### PR TITLE
Fix RFPLL frequency calculation

### DIFF
--- a/ad9361/sw/ad9361.c
+++ b/ad9361/sw/ad9361.c
@@ -5690,8 +5690,8 @@ uint32_t ad9361_rfpll_recalc_rate(struct refclk_scale *clk_priv,
 		vco_div = ad9361_spi_readf(clk_priv->spi, REG_RFPLL_DIVIDERS, div_mask);
 	}
 
-	fract = (buf[0] << 16) | (buf[1] << 8) | buf[2];
-	integer = buf[3] << 8 | buf[4];
+	fract = ((buf[0] & 0x7F) << 16) | (buf[1] << 8) | buf[2];
+	integer = (buf[3] & 0x7) << 8 | buf[4];
 
 	return ad9361_to_clk(ad9361_calc_rfpll_freq(parent_rate, integer,
 		fract, vco_div));
@@ -5770,11 +5770,12 @@ int32_t ad9361_rfpll_set_rate(struct refclk_scale *clk_priv, uint32_t rate,
 
 	ad9361_rfpll_vco_init(phy, div_mask == TX_VCO_DIVIDER(~0),
 		vco, parent_rate);
+    ad9361_spi_readm(clk_priv->spi, reg, buf, 5);
 
-	buf[0] = fract >> 16;
-	buf[1] = fract >> 8;
+	buf[0] = (fract >> 16) & 0xFF | (buf[0] & 0x80);
+	buf[1] = (fract >> 8) & 0xFF;
 	buf[2] = fract & 0xFF;
-	buf[3] = integer >> 8;
+	buf[3] = ((integer >> 8) & 0xFF) | (buf[3] & 0xF8);
 	buf[4] = integer & 0xFF;
 
 	ad9361_spi_writem(clk_priv->spi, reg, buf, 5);


### PR DESCRIPTION
Fix ad9361_rfpll_recalc_rate and ad9361_rfpll_set_rate.
After this fix, these methods return or set correct value even when user use SDM Bypass or SDM PD (0x232[7:6] or 0x272[7:6]).