### PR TITLE
Fix lvds_bias_ctrl

### DIFF
--- a/ad9361/sw/ad9361_api.c
+++ b/ad9361/sw/ad9361_api.c
@@ -323,7 +323,7 @@ int32_t ad9361_init (struct ad9361_rf_phy **ad9361_phy, AD9361_InitParam *init_p
 	phy->pdata->port_ctrl.rx_clk_data_delay |= RX_DATA_DELAY(init_param->rx_data_delay);
 	phy->pdata->port_ctrl.tx_clk_data_delay = FB_CLK_DELAY(init_param->tx_fb_clock_delay);
 	phy->pdata->port_ctrl.tx_clk_data_delay |= TX_DATA_DELAY(init_param->tx_data_delay);
-	phy->pdata->port_ctrl.lvds_bias_ctrl = (init_param->lvds_bias_mV / 75) & 0x7;
+	phy->pdata->port_ctrl.lvds_bias_ctrl = ((init_param->lvds_bias_mV - 75) / 75) & 0x7;
 	phy->pdata->port_ctrl.lvds_bias_ctrl |= (init_param->lvds_rx_onchip_termination_enable << 5);
 	phy->pdata->rx1rx2_phase_inversion_en = init_param->rx1rx2_phase_inversion_en;
 


### PR DESCRIPTION
Must subtract 75 from init_params->lvds_bias_mV before dividing by 75 in order to agree with the register definition which states: LVDS driver amplitude control. |VOD| = 75 mV to 450 mV; 75 mV/LSB.