### PR TITLE
Use the Euclidean algorithm in gcd() function across all drivers

### DIFF
--- a/device_drivers/ADF4156/ADF4156.c
+++ b/device_drivers/ADF4156/ADF4156.c
@@ -174,17 +174,16 @@ long adf4156_tune_r_cnt(adf4156_state *st, long r_cnt)
 *******************************************************************************/
 unsigned long gcd(unsigned long x, unsigned long y)
 {
-        long tmp;
+	unsigned long tmp;
 
-        tmp = y > x ? x : y;
+	while (y != 0)
+	{
+		tmp = x % y;
+		x = y;
+		y = tmp;
+	}
 
-
-        while((x % tmp) || (y % tmp))
-        {
-                tmp--;
-        }
-
-        return tmp;
+	return x;
 }
 
 /***************************************************************************//**

--- a/device_drivers/ADF4157/ADF4157.c
+++ b/device_drivers/ADF4157/ADF4157.c
@@ -173,17 +173,16 @@ long ADF4157_tune_r_cnt(ADF4157_state *st, long r_cnt)
 *******************************************************************************/
 unsigned long gcd(unsigned long x, unsigned long y)
 {
-        long tmp;
+	unsigned long tmp;
 
-        tmp = y > x ? x : y;
+	while (y != 0)
+	{
+		tmp = x % y;
+		x = y;
+		y = tmp;
+	}
 
-
-        while((x % tmp) || (y % tmp))
-        {
-                tmp--;
-        }
-
-        return tmp;
+	return x;
 }
 
 /***************************************************************************//**

--- a/drivers/adf4350/adf4350.c
+++ b/drivers/adf4350/adf4350.c
@@ -151,17 +151,16 @@ int32_t adf4350_tune_r_cnt(struct adf4350_state *st, uint16_t r_cnt)
 *******************************************************************************/
 uint32_t gcd(uint32_t x, uint32_t y)
 {
-	int32_t tmp;
+	uint32_t tmp;
 
-	tmp = y > x ? x : y;
-
-
-	while((x % tmp) || (y % tmp))
+	while (y != 0)
 	{
-		tmp--;
+		tmp = x % y;
+		x = y;
+		y = tmp;
 	}
 
-	return tmp;
+	return x;
 }
 
 /***************************************************************************//**

--- a/fmcomms1/ADF4351/ADF4351.c
+++ b/fmcomms1/ADF4351/ADF4351.c
@@ -143,17 +143,16 @@ int32_t adf4351_tune_r_cnt(struct adf4351_state *st, uint16_t r_cnt)
 *******************************************************************************/
 uint32_t gcd(uint32_t x, uint32_t y)
 {
-	int32_t tmp;
+	uint32_t tmp;
 
-	tmp = y > x ? x : y;
-
-
-	while((x % tmp) || (y % tmp))
+	while (y != 0)
 	{
-		tmp--;
+		tmp = x % y;
+		x = y;
+		y = tmp;
 	}
 
-	return tmp;
+	return x;
 }
 
 /***************************************************************************//**


### PR DESCRIPTION
This improves the efficiency of the gcd() function which returns the
greatest common divisor of two numbers.

Signed-off-by: Dan Nechita <Dan.Nechita@analog.com>