### PR TITLE
iio: adc: Add support for ADuM7701 sigma-delta modulator

### DIFF
--- a/adum7701_fmc/adc_core.c
+++ b/adum7701_fmc/adc_core.c
@@ -1,0 +1,270 @@
+/***************************************************************************//**
+ * @file adc_core.c
+ * @brief Implementation of ADC Core Driver.
+ * @author DBogdan (dragos.bogdan@analog.com)
+ ********************************************************************************
+ * Copyright 2014-2015(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in
+ * the documentation and/or other materials provided with the
+ * distribution.
+ * - Neither the name of Analog Devices, Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ * - The use of this software may or may not infringe the patent rights
+ * of one or more patent holders. This license does not release you
+ * from the requirement that you obtain separate licenses from these
+ * patent holders to use this software.
+ * - Use of the software either in source or binary form, must be run
+ * on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <inttypes.h>
+#include <stdio.h>
+#include "adc_core.h"
+
+/***************************************************************************//**
+ * @brief adc_read
+ *******************************************************************************/
+int32_t adc_read(adc_core *core,
+				 uint32_t reg_addr,
+				 uint32_t *reg_data)
+{
+	*reg_data = Xil_In32((core->base_address + reg_addr));
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * @brief adc_write
+ *******************************************************************************/
+int32_t adc_write(adc_core *core,
+				  uint32_t reg_addr,
+				  uint32_t reg_data)
+{
+	Xil_Out32((core->base_address + reg_addr), reg_data);
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * @brief adc_dma_read
+*******************************************************************************/
+void adc_dma_read(uint32_t regAddr,
+				  uint32_t *data)
+{
+	*data = Xil_In32(XPAR_AXI_AD7405_DMA_BASEADDR + regAddr);
+}
+
+/***************************************************************************//**
+ * @brief adc_dma_write
+*******************************************************************************/
+void adc_dma_write(uint32_t regAddr,
+				   uint32_t data)
+{
+	Xil_Out32(XPAR_AXI_AD7405_DMA_BASEADDR + regAddr, data);
+}
+
+/***************************************************************************//**
+ * @brief adc_setup
+ *******************************************************************************/
+int32_t adc_setup(adc_core *core)
+{
+	uint8_t	 index;
+	uint32_t reg_data;
+	uint32_t adc_clock;
+
+	adc_read(core, ADC_REG_ID, &reg_data);
+	if (reg_data)
+		core->master = 1;
+	else
+		core->master = 0;
+
+	adc_write(core, ADC_REG_RSTN, 0);
+	adc_write(core, ADC_REG_RSTN, ADC_MMCM_RSTN | ADC_RSTN);
+
+	for(index = 0; index < core->no_of_channels; index++) {
+		adc_write(core, ADC_REG_CHAN_CNTRL(index), ADC_FORMAT_SIGNEXT |
+							   ADC_FORMAT_ENABLE |
+							   ADC_ENABLE);
+	}
+
+	mdelay(100);
+
+	adc_read(core, ADC_REG_STATUS, &reg_data);
+	if(reg_data == 0x0) {
+		printf("%s adc core Status errors.\n", __func__);
+		return -1;
+	}
+
+	adc_read(core, ADC_REG_CLK_FREQ, &adc_clock);
+	adc_read(core, ADC_REG_CLK_RATIO, &reg_data);
+	adc_clock = (adc_clock * reg_data * 100) + 0x7fff;
+	adc_clock = adc_clock >> 16;
+
+	printf("%s adc core initialized (%"PRIu32" MHz).\n", __func__, adc_clock);
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * @brief adc_set_pnsel
+ *******************************************************************************/
+int32_t adc_set_pnsel(adc_core *core,
+					  uint8_t channel,
+					  enum adc_pn_sel sel)
+{
+	uint32_t reg;
+
+	adc_read(core, ADC_REG_CHAN_CNTRL_3(channel), &reg);
+	reg &= ~ADC_ADC_PN_SEL(~0);
+	reg |= ADC_ADC_PN_SEL(sel);
+	adc_write(core, ADC_REG_CHAN_CNTRL_3(channel), reg);
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * @brief adc_pn_mon
+ *	  Note: The device must be in PRBS test mode, when calling this function
+ *******************************************************************************/
+int32_t adc_pn_mon(adc_core *core,
+				   enum adc_pn_sel sel)
+{
+	uint8_t	index;
+	uint32_t reg_data;
+	int32_t pn_errors = 0;
+
+	for (index = 0; index < core->no_of_channels; index++) {
+ 		adc_read(core, ADC_REG_CHAN_CNTRL(index), &reg_data);
+ 		reg_data |= ADC_ENABLE;
+ 		adc_write(core, ADC_REG_CHAN_CNTRL(index), reg_data);
+		adc_set_pnsel(core, index, sel);
+	}
+	mdelay(1);
+
+	for (index = 0; index < core->no_of_channels; index++) {
+		adc_write(core, ADC_REG_CHAN_STATUS(index), 0xff);
+	}
+	mdelay(100);
+
+	for (index = 0; index < core->no_of_channels; index++) {
+		adc_read(core, ADC_REG_CHAN_STATUS(index), &reg_data);
+		if (reg_data != 0) {
+			pn_errors = -1;
+			printf("%s ERROR: adc pn OUT OF SYNC: %d, %d, 0x%02"PRIx32"!\n", __func__, index, sel, reg_data);
+		}
+	}
+
+	return pn_errors;
+}
+
+/***************************************************************************//**
+ * @brief adc_ramp_test
+ *	  This functions supports channel number multiple of 2 (e.g 1/2/4/6/8...)
+ *******************************************************************************/
+int32_t adc_ramp_test(adc_core *core,
+					  uint8_t no_of_cores,
+					  uint32_t no_of_samples,
+					  uint32_t start_address)
+{
+	uint8_t	 err_cnt = 0;
+	uint16_t exp_data[32];
+	uint16_t rcv_data[32];
+	uint8_t index;
+	uint32_t mask = ad_pow2(core->resolution);
+	uint8_t no_of_channels = core->no_of_channels*no_of_cores;
+	uint32_t current_address = start_address;
+	uint32_t last_address = start_address + (no_of_channels*no_of_samples)*2;
+	uint32_t sample_count = 0;
+
+	while (current_address < last_address) {
+
+		// read data back from memory, one samples from each channel, min a word
+		for (index=0; index<no_of_channels; index+=2) {
+			rcv_data[index] = Xil_In32(current_address + index) & mask;
+			rcv_data[index+1] = (Xil_In32(current_address + index) >> 16) & mask;
+		}
+
+		// generate expected data
+		for (index=0; index<no_of_channels; index+=2) {
+			if (current_address == start_address) {
+				exp_data[index] = rcv_data[index];
+				exp_data[index+1] = rcv_data[index+1];
+			} else {
+				if(no_of_channels < 2) {
+					exp_data[index] = ((exp_data[index]+2) > mask) ? 0 : (exp_data[index] + 2);
+					exp_data[index+1] = ((exp_data[index+1]+2) > mask) ? 1 : (exp_data[index+1] + 2);
+				} else {
+					exp_data[index] = (exp_data[index] == mask) ? 0 : exp_data[index] + 1;
+					exp_data[index+1] = (exp_data[index+1] == mask) ? 0 : exp_data[index+1] + 1;
+				}
+			}
+		}
+
+		// compare received and expected
+		for (index=0; index<no_of_channels; index+=2) {
+			if ((rcv_data[index] != exp_data[index]) || (rcv_data[index+1] != exp_data[index+1])) {
+				printf("%s Capture Error[%"PRIu32"]: rcv(%08x) exp(%08x).\n",
+						__func__, sample_count+index, rcv_data[index], exp_data[index]);
+				printf("%s Capture Error[%"PRIu32"]: rcv(%08x) exp(%08x).\n",
+						__func__, sample_count+index+1, rcv_data[index+1], exp_data[index+1]);
+				err_cnt++;
+				if (err_cnt == 50) break;
+			}
+		}
+		sample_count+=index;
+
+		// increment address pointer
+		current_address = (no_of_channels == 1) ? (current_address+4) :
+							(current_address+(no_of_channels*2));
+	}
+
+	if (err_cnt)
+		return -1;
+	else
+		return 0;
+}
+
+/***************************************************************************//**
+ * @brief adc_capture
+*******************************************************************************/
+int32_t adc_capture(adc_core *core,
+		uint32_t size)
+{
+	uint32_t length;
+
+	length = (size * sizeof(uint32_t));
+
+	adc_dma_write(AXI_DMAC_REG_CTRL, 0x0);
+	adc_dma_write(AXI_DMAC_REG_CTRL, AXI_DMAC_CTRL_ENABLE);
+	adc_dma_write(AXI_DMAC_REG_DEST_ADDRESS, core->start_address);
+	adc_dma_write(AXI_DMAC_REG_DEST_STRIDE, 0x0);
+	adc_dma_write(AXI_DMAC_REG_X_LENGTH, length - 1);
+	adc_dma_write(AXI_DMAC_REG_Y_LENGTH, 0x0);
+	adc_dma_write(AXI_DMAC_REG_FLAGS, 0x01);
+	adc_dma_write(AXI_DMAC_REG_START_TRANSFER, 0x1);
+
+	return 0;
+}

--- a/adum7701_fmc/adc_core.h
+++ b/adum7701_fmc/adc_core.h
@@ -1,0 +1,174 @@
+/***************************************************************************//**
+ * @file adc_core.h
+ * @brief Header file of ADC Core Driver.
+ * @author DBogdan (dragos.bogdan@analog.com)
+ ********************************************************************************
+ * Copyright 2014-2015(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in
+ * the documentation and/or other materials provided with the
+ * distribution.
+ * - Neither the name of Analog Devices, Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ * - The use of this software may or may not infringe the patent rights
+ * of one or more patent holders. This license does not release you
+ * from the requirement that you obtain separate licenses from these
+ * patent holders to use this software.
+ * - Use of the software either in source or binary form, must be run
+ * on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#ifndef ADC_CORE_H_
+#define ADC_CORE_H_
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "platform_drivers.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+#define ADC_REG_ID			0x0004
+#define ADC_ID(x)			(((x) & 0xffffffff) << 0)
+
+#define ADC_REG_RSTN			0x0040
+#define ADC_MMCM_RSTN			(1 << 1)
+#define ADC_RSTN			(1 << 0)
+
+#define ADC_REG_CNTRL			0x0044
+#define ADC_R1_MODE			(1 << 2)
+#define ADC_DDR_EDGESEL			(1 << 1)
+#define ADC_PIN_MODE			(1 << 0)
+
+#define ADC_REG_CLK_FREQ		0x0054
+#define ADC_CLK_FREQ(x)			(((x) & 0xFFFFFFFF) << 0)
+#define ADC_TO_CLK_FREQ(x)		(((x) >> 0) & 0xFFFFFFFF)
+
+#define ADC_REG_CLK_RATIO		0x0058
+#define ADC_CLK_RATIO(x)		(((x) & 0xFFFFFFFF) << 0)
+#define ADC_TO_CLK_RATIO(x)		(((x) >> 0) & 0xFFFFFFFF)
+
+#define ADC_REG_STATUS			0x005C
+#define ADC_MUX_PN_ERR			(1 << 3)
+#define ADC_MUX_PN_OOS			(1 << 2)
+#define ADC_MUX_OVER_RANGE		(1 << 1)
+#define ADC_STATUS			(1 << 0)
+
+#define ADC_REG_DELAY_CNTRL		0x0060
+#define ADC_DELAY_SEL			(1 << 17)
+#define ADC_DELAY_RWN			(1 << 16)
+#define ADC_DELAY_ADDRESS(x) 		(((x) & 0xFF) << 8)
+#define ADC_TO_DELAY_ADDRESS(x) 	(((x) >> 8) & 0xFF)
+#define ADC_DELAY_WDATA(x)		(((x) & 0x1F) << 0)
+#define ADC_TO_DELAY_WDATA(x)		(((x) >> 0) & 0x1F)
+
+#define ADC_REG_CHAN_CNTRL(c)		(0x0400 + (c) * 0x40)
+#define ADC_PN_SEL			(1 << 10)
+#define ADC_IQCOR_ENB			(1 << 9)
+#define ADC_DCFILT_ENB			(1 << 8)
+#define ADC_FORMAT_SIGNEXT		(1 << 6)
+#define ADC_FORMAT_TYPE			(1 << 5)
+#define ADC_FORMAT_ENABLE		(1 << 4)
+#define ADC_PN23_TYPE			(1 << 1)
+#define ADC_ENABLE			(1 << 0)
+
+#define ADC_REG_CHAN_STATUS(c)		(0x0404 + (c) * 0x40)
+#define ADC_PN_ERR			(1 << 2)
+#define ADC_PN_OOS			(1 << 1)
+#define ADC_OVER_RANGE			(1 << 0)
+
+#define ADC_REG_CHAN_CNTRL_3(c)		(0x0418 + (c) * 0x40)
+#define ADC_ADC_PN_SEL(x)		(((x) & 0xF) << 16)
+#define ADC_TO_ADC_PN_SEL(x)		(((x) >> 16) & 0xF)
+#define ADC_ADC_DATA_SEL(x)		(((x) & 0xF) << 0)
+#define ADC_TO_ADC_DATA_SEL(x)		(((x) >> 0) & 0xF)
+
+#define AXI_DMAC_REG_IRQ_MASK			0x80
+#define AXI_DMAC_REG_IRQ_PENDING		0x84
+#define AXI_DMAC_REG_IRQ_SOURCE			0x88
+
+#define AXI_DMAC_REG_CTRL				0x400
+#define AXI_DMAC_REG_TRANSFER_ID		0x404
+#define AXI_DMAC_REG_START_TRANSFER		0x408
+#define AXI_DMAC_REG_FLAGS				0x40c
+#define AXI_DMAC_REG_DEST_ADDRESS		0x410
+#define AXI_DMAC_REG_SRC_ADDRESS		0x414
+#define AXI_DMAC_REG_X_LENGTH			0x418
+#define AXI_DMAC_REG_Y_LENGTH			0x41c
+#define AXI_DMAC_REG_DEST_STRIDE		0x420
+#define AXI_DMAC_REG_SRC_STRIDE			0x424
+#define AXI_DMAC_REG_TRANSFER_DONE		0x428
+#define AXI_DMAC_REG_ACTIVE_TRANSFER_ID 0x42c
+#define AXI_DMAC_REG_STATUS				0x430
+#define AXI_DMAC_REG_CURRENT_DEST_ADDR	0x434
+#define AXI_DMAC_REG_CURRENT_SRC_ADDR	0x438
+#define AXI_DMAC_REG_DBG0				0x43c
+#define AXI_DMAC_REG_DBG1				0x440
+
+#define AXI_DMAC_CTRL_ENABLE			(1 << 0)
+#define AXI_DMAC_CTRL_PAUSE				(1 << 1)
+
+#define AXI_DMAC_IRQ_SOT				(1 << 0)
+#define AXI_DMAC_IRQ_EOT				(1 << 1)
+
+enum adc_pn_sel {
+	ADC_PN9 = 0,
+	ADC_PN23A = 1,
+	ADC_PN7 = 4,
+	ADC_PN15 = 5,
+	ADC_PN23 = 6,
+	ADC_PN31 = 7,
+	ADC_PN_CUSTOM = 9,
+	ADC_PN_END = 10,
+};
+
+typedef struct {
+	uint32_t base_address;
+	uint8_t	 master;
+	uint8_t	 no_of_channels;
+	uint8_t	 resolution;
+	uint32_t start_address;
+} adc_core;
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+int32_t adc_read(adc_core *core,
+				 uint32_t reg_addr,
+				 uint32_t *reg_data);
+int32_t adc_write(adc_core *core,
+				  uint32_t reg_addr,
+				  uint32_t reg_data);
+int32_t adc_setup(adc_core *core);
+int32_t adc_set_pnsel(adc_core *core,
+					  uint8_t channel,
+					  enum adc_pn_sel sel);
+int32_t adc_pn_mon(adc_core *core,
+				   enum adc_pn_sel sel);
+int32_t adc_ramp_test(adc_core *core,
+					  uint8_t no_of_cores,
+					  uint32_t no_of_samples,
+					  uint32_t start_address);
+int32_t adc_capture(adc_core *core,
+					uint32_t size);
+#endif

--- a/adum7701_fmc/adum7701.c
+++ b/adum7701_fmc/adum7701.c
@@ -1,0 +1,104 @@
+/***************************************************************************//**
+ *   @file   adum7701.c
+ *   @brief  Implementation of adum7701 Driver.
+ *   @author SPopa (stefan.popa@analog.com)
+********************************************************************************
+ * Copyright 2018(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "stdio.h"
+#include "stdlib.h"
+#include "platform_drivers.h"
+#include "adum7701.h"
+
+/******************************************************************************/
+/************************** Functions Implementation **************************/
+/******************************************************************************/
+
+/**
+ * Initialize the device.
+ * @param device - The device structure.
+ * @param init_param - The structure that contains the device initial
+ *                     parameters.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int32_t adum7701_init(struct adum7701_dev **device,
+		      struct adum7701_init_param init_param)
+{
+	struct adum7701_dev *dev;
+	int32_t ret;
+
+	dev = (struct adum7701_dev *)malloc(sizeof(*dev));
+	if (!dev)
+		return -1;
+
+	/* GPIO */
+	ret = gpio_get(&dev->dec_ratio, init_param.dec_ratio);
+	ret |= gpio_get(&dev->filter_reset, init_param.filter_reset);
+
+	/* Set the decimation ratio */
+	ret |= gpio_set_value(dev->dec_ratio, GPIO_HIGH);
+
+	/* Perform a reset */
+	ret |= gpio_set_value(dev->filter_reset, GPIO_HIGH);
+	ret |= gpio_set_value(dev->filter_reset, GPIO_LOW);
+
+	*device = dev;
+
+	if (!ret)
+		printf("adum7701 successfully initialized\n");
+	mdelay(1000);
+
+	return ret;
+}
+
+/***************************************************************************//**
+ * @brief Free the resources allocated by adum7701_init().
+ * @param dev - The device structure.
+ * @return SUCCESS in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t adum7701_remove(struct adum7701_dev *dev)
+{
+	int32_t ret;
+
+	ret = gpio_remove(dev->dec_ratio);
+	ret |= gpio_remove(dev->filter_reset);
+
+	free(dev);
+
+	return ret;
+}

--- a/adum7701_fmc/adum7701.h
+++ b/adum7701_fmc/adum7701.h
@@ -1,0 +1,67 @@
+/***************************************************************************//**
+ *   @file   adum7701.h
+ *   @brief  Header file for adum7701 Driver.
+ *   @author SPopa (stefan.popa@analog.com)
+********************************************************************************
+ * Copyright 2018(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef SRC_ADUM7701_H_
+#define SRC_ADUM7701_H_
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+
+struct adum7701_dev {
+	/* GPIO */
+	gpio_desc *dec_ratio;
+	gpio_desc *filter_reset;
+};
+
+struct adum7701_init_param {
+	/* GPIO */
+	gpio_init_param dec_ratio;
+	gpio_init_param filter_reset;
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+int32_t adum7701_init(struct adum7701_dev **device,
+		      struct adum7701_init_param init_param);
+int32_t adum7701_remove(struct adum7701_dev *dev);
+
+#endif /* SRC_ADUM7701_H_ */

--- a/adum7701_fmc/adum7701_fmc.c
+++ b/adum7701_fmc/adum7701_fmc.c
@@ -1,0 +1,117 @@
+/***************************************************************************//**
+* @file adum7701_fmc.c
+* @brief Implementation of Main Function.
+* @author SPopa (stefan.popa@analog.com)
+********************************************************************************
+* Copyright 2018(c) Analog Devices, Inc.
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+* - Redistributions of source code must retain the above copyright
+* notice, this list of conditions and the following disclaimer.
+* - Redistributions in binary form must reproduce the above copyright
+* notice, this list of conditions and the following disclaimer in
+* the documentation and/or other materials provided with the
+* distribution.
+* - Neither the name of Analog Devices, Inc. nor the names of its
+* contributors may be used to endorse or promote products derived
+* from this software without specific prior written permission.
+* - The use of this software may or may not infringe the patent rights
+* of one or more patent holders. This license does not release you
+* from the requirement that you obtain separate licenses from these
+* patent holders to use this software.
+* - Use of the software either in source or binary form, must be run
+* on or directly connected to an Analog Devices Inc. component.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdio.h>
+#include <sleep.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include <xil_cache.h>
+#include <xparameters.h>
+#include "xil_printf.h"
+
+#include "clkgen_core.h"
+#include "adc_core.h"
+
+#include "platform_drivers.h"
+#include "adum7701.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+#define GPIO_DEVICE_ID		XPAR_PS7_GPIO_0_DEVICE_ID
+#define GPIO_OFFSET		54
+#define GPIO_DEC_RATIO_32	GPIO_OFFSET + 35
+#define GPIO_DEC_RATIO_64	GPIO_OFFSET + 36
+#define GPIO_DEC_RATIO_128	GPIO_OFFSET + 37
+#define GPIO_DEC_RATIO_256	GPIO_OFFSET + 38
+#define GPIO_DEC_RATIO_512	GPIO_OFFSET + 39
+#define GPIO_DEC_RATIO_1024	GPIO_OFFSET + 40
+#define GPIO_DEC_RATIO_2048	GPIO_OFFSET + 41
+#define GPIO_DEC_RATIO_4096	GPIO_OFFSET + 42
+#define GPIO_RESET		GPIO_OFFSET + 48
+
+struct adum7701_init_param adum7701_default_init_param = {
+	/* GPIO */
+	/* dec_ratio */
+	{ PS7_GPIO, GPIO_DEVICE_ID, GPIO_DEC_RATIO_256 },
+	/* filter_reset */
+	{ PS7_GPIO, GPIO_DEVICE_ID, GPIO_RESET },
+};
+
+clkgen_init_params clkgen_default_init_params = {
+	XPAR_AXI_ADC_CLKGEN_BASEADDR, // base_addr
+	10000000, // 10Mhz rate
+	100000000, // 100Mhz parent_rate
+};
+
+int main()
+{
+	struct adum7701_dev *dev;
+	clkgen_device *clkgen_dev;
+	adc_core  adum7701_adc_core;
+	uint32_t *adc_data, i;
+
+	/* Initialize the device */
+	adum7701_init(&dev, adum7701_default_init_param);
+
+	/* Initialize CLKGENs */
+	clkgen_setup(&clkgen_dev, clkgen_default_init_params);
+
+	/* ADC capture */
+	adum7701_adc_core.start_address = 0x800000;
+	adc_capture(&adum7701_adc_core, 1024);
+
+	mdelay(10000);
+
+	adc_data = (uint32_t*)adum7701_adc_core.start_address;
+	for(i = 0; i < 1024; i++) {
+		printf("%lu\r\n", *adc_data);
+		adc_data += 1; // go to the next address in memory
+	}
+
+	adum7701_remove(dev);
+
+	printf("Done\n");
+
+	return 0;
+}

--- a/adum7701_fmc/clkgen_core.c
+++ b/adum7701_fmc/clkgen_core.c
@@ -1,0 +1,429 @@
+/***************************************************************************//**
+ * @file clkgen_core.c
+ * @brief Implementation of CLKGEN Core Driver.
+ * @author DBogdan (dragos.bogdan@analog.com)
+ ********************************************************************************
+ * Copyright 2017(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in
+ * the documentation and/or other materials provided with the
+ * distribution.
+ * - Neither the name of Analog Devices, Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ * - The use of this software may or may not infringe the patent rights
+ * of one or more patent holders. This license does not release you
+ * from the requirement that you obtain separate licenses from these
+ * patent holders to use this software.
+ * - Use of the software either in source or binary form, must be run
+ * on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdio.h>
+#include <stdlib.h>
+#include "clkgen_core.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+#define CLKGEN_REG_RESETN			0x40
+#define CLKGEN_MMCM_RESETN			(1 << 1)
+#define CLKGEN_RESETN				(1 << 0)
+
+#define CLKGEN_REG_STATUS			0x5c
+#define CLKGEN_STATUS				(1 << 0)
+
+#define CLKGEN_REG_DRP_CNTRL		0x70
+#define CLKGEN_DRP_CNTRL_SEL		(1 << 29)
+#define CLKGEN_DRP_CNTRL_READ		(1 << 28)
+
+#define CLKGEN_REG_DRP_STATUS		0x74
+#define CLKGEN_DRP_STATUS_BUSY		(1 << 16)
+
+#define MMCM_REG_CLKOUT0_1			0x08
+#define MMCM_REG_CLKOUT0_2			0x09
+#define MMCM_REG_CLKOUT1_1			0x0A
+#define MMCM_REG_CLKOUT1_2			0x0B
+#define MMCM_REG_CLK_FB1			0x14
+#define MMCM_REG_CLK_FB2			0x15
+#define MMCM_REG_CLK_DIV			0x16
+#define MMCM_REG_LOCK1				0x18
+#define MMCM_REG_LOCK2				0x19
+#define MMCM_REG_LOCK3				0x1a
+#define MMCM_REG_FILTER1			0x4e
+#define MMCM_REG_FILTER2			0x4f
+
+#define MIN(x, y)				(x < y ? x : y)
+#define MAX(x, y) 				(x > y ? x : y)
+#define DIV_ROUND_UP(x,y)		(((x) + (y) - 1) / (y))
+#define DIV_ROUND_CLOSEST(x, y)	(uint32_t)(((double)x / y) + 0.5)
+#define CLAMP(val, min, max)	(val < min ? min : (val > max ? max :val))
+#define ABS(x)					(x < 0 ? -x : x)
+
+static const uint32_t clkgen_filter_table[] =
+{
+	0x01001990, 0x01001190, 0x01009890, 0x01001890,
+	0x01008890, 0x01009090, 0x01009090, 0x01009090,
+	0x01009090, 0x01000890, 0x01000890, 0x01000890,
+	0x08009090, 0x01001090, 0x01001090, 0x01001090,
+	0x01001090, 0x01001090, 0x01001090, 0x01001090,
+	0x01001090, 0x01001090, 0x01001090, 0x01008090,
+	0x01008090, 0x01008090, 0x01008090, 0x01008090,
+	0x01008090, 0x01008090, 0x01008090, 0x01008090,
+	0x01008090, 0x01008090, 0x01008090, 0x01008090,
+	0x01008090, 0x08001090, 0x08001090, 0x08001090,
+	0x08001090, 0x08001090, 0x08001090, 0x08001090,
+	0x08001090, 0x08001090, 0x08001090
+};
+
+static const uint32_t clkgen_lock_table[] =
+{
+	0x060603e8, 0x060603e8, 0x080803e8, 0x0b0b03e8,
+	0x0e0e03e8, 0x111103e8, 0x131303e8, 0x161603e8,
+	0x191903e8, 0x1c1c03e8, 0x1f1f0384, 0x1f1f0339,
+	0x1f1f02ee, 0x1f1f02bc, 0x1f1f028a, 0x1f1f0271,
+	0x1f1f023f, 0x1f1f0226, 0x1f1f020d, 0x1f1f01f4,
+	0x1f1f01db, 0x1f1f01c2, 0x1f1f01a9, 0x1f1f0190,
+	0x1f1f0190, 0x1f1f0177, 0x1f1f015e, 0x1f1f015e,
+	0x1f1f0145, 0x1f1f0145, 0x1f1f012c, 0x1f1f012c,
+	0x1f1f012c, 0x1f1f0113, 0x1f1f0113, 0x1f1f0113
+};
+
+/***************************************************************************//**
+ * @brief clkgen_write
+ *******************************************************************************/
+int32_t clkgen_write(clkgen_device *dev,
+					 uint32_t reg_addr,
+					 uint32_t reg_val)
+{
+	Xil_Out32((dev->base_addr + reg_addr), reg_val);
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * @brief clkgen_read
+ *******************************************************************************/
+int32_t clkgen_read(clkgen_device *dev,
+					uint32_t reg_addr,
+					uint32_t *reg_val)
+{
+	*reg_val = Xil_In32(dev->base_addr + reg_addr);
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * @brief clkgen_mmcm_read
+*******************************************************************************/
+static void clkgen_mmcm_read(clkgen_device *dev,
+							 uint32_t reg,
+							 uint32_t *val)
+{
+	uint32_t timeout = 1000000;
+	uint32_t reg_val;
+
+	do {
+		clkgen_read(dev, CLKGEN_REG_DRP_STATUS, &reg_val);
+	} while ((reg_val & CLKGEN_DRP_STATUS_BUSY) && --timeout);
+
+	if (timeout == 0) {
+		return;
+	}
+
+	reg_val = CLKGEN_DRP_CNTRL_SEL | CLKGEN_DRP_CNTRL_READ | (reg << 16);
+
+	clkgen_write(dev, CLKGEN_REG_DRP_CNTRL, reg_val);
+	do {
+		clkgen_read(dev, CLKGEN_REG_DRP_STATUS, val);
+	} while ((*val & CLKGEN_DRP_STATUS_BUSY) && --timeout);
+
+	if (timeout == 0) {
+		return;
+	}
+
+	*val &= 0xffff;
+}
+
+/***************************************************************************//**
+ * @brief clkgen_mmcm_write
+*******************************************************************************/
+void clkgen_mmcm_write(clkgen_device *dev,
+					   uint32_t reg,
+					   uint32_t val,
+					   uint32_t mask)
+{
+	uint32_t timeout = 1000000;
+	uint32_t reg_val;
+
+	do {
+		clkgen_read(dev, CLKGEN_REG_DRP_STATUS, &reg_val);
+	} while ((reg_val & CLKGEN_DRP_STATUS_BUSY) && --timeout);
+
+	if (timeout == 0) {
+		return;
+	}
+
+	if (mask != 0xffff) {
+		clkgen_mmcm_read(dev, reg, &reg_val);
+		reg_val &= ~mask;
+	} else {
+		reg_val = 0;
+	}
+
+	reg_val |= CLKGEN_DRP_CNTRL_SEL | (reg << 16) | (val & mask);
+
+	clkgen_write(dev, CLKGEN_REG_DRP_CNTRL, reg_val);
+}
+
+/***************************************************************************//**
+ * @brief clkgen_lookup_filter
+*******************************************************************************/
+static uint32_t clkgen_lookup_filter(uint32_t m)
+{
+	if (m < 47)
+		return clkgen_filter_table[m];
+
+	return 0x08008090;
+}
+
+/***************************************************************************//**
+ * @brief clkgen_lookup_lock
+*******************************************************************************/
+static uint32_t clkgen_lookup_lock(uint32_t m)
+{
+	if (m < 36)
+		return clkgen_lock_table[m];
+
+	return 0x1f1f00fa;
+}
+
+/***************************************************************************//**
+ * @brief clkgen_calc_params
+*******************************************************************************/
+void clkgen_calc_params(uint32_t fin,
+						uint32_t fout,
+						uint32_t *best_d,
+						uint32_t *best_m,
+						uint32_t *best_dout)
+{
+	const uint32_t fpfd_min	= 10000;
+	const uint32_t fpfd_max	= 300000;
+	const uint32_t fvco_min	= 600000;
+	const uint32_t fvco_max	= 1200000;
+	uint32_t	   d		= 0;
+	uint32_t	   d_min	= 0;
+	uint32_t	   d_max	= 0;
+	uint32_t	   _d_min	= 0;
+	uint32_t	   _d_max	= 0;
+	uint32_t	   m		= 0;
+	uint32_t	   m_min	= 0;
+	uint32_t	   m_max	= 0;
+	uint32_t	   dout		= 0;
+	uint32_t	   fvco		= 0;
+	int32_t		   f		= 0;
+	int32_t		   best_f	= 0;
+
+	fin /= 1000;
+	fout /= 1000;
+
+	best_f = 0x7fffffff;
+	*best_d = 0;
+	*best_m = 0;
+	*best_dout = 0;
+
+	d_min = MAX(DIV_ROUND_UP(fin, fpfd_max), 1);
+	d_max = MIN(fin / fpfd_min, 80);
+
+	m_min = MAX(DIV_ROUND_UP(fvco_min, fin) * d_min, 1);
+	m_max = MIN(fvco_max * d_max / fin, 64);
+
+	for(m = m_min; m <= m_max; m++) {
+		_d_min = MAX(d_min, DIV_ROUND_UP(fin * m, fvco_max));
+		_d_max = MIN(d_max, fin * m / fvco_min);
+
+		for (d = _d_min; d <= _d_max; d++) {
+			fvco = fin * m / d;
+			dout = DIV_ROUND_CLOSEST(fvco, fout);
+			dout = CLAMP(dout, 1, 128);
+			f = fvco / dout;
+			if (ABS(f - fout) < ABS(best_f - fout)) {
+				best_f = f;
+				*best_d = d;
+				*best_m = m;
+				*best_dout = dout;
+				if (best_f == fout)
+					return;
+			}
+		}
+	}
+}
+
+/***************************************************************************//**
+ * @brief clkgen_calc_clk_params
+*******************************************************************************/
+void clkgen_calc_clk_params(uint32_t divider,
+							uint32_t *low,
+							uint32_t *high,
+							uint32_t *edge,
+							uint32_t *nocount)
+{
+	if (divider == 1)
+		*nocount = 1;
+	else
+		*nocount = 0;
+	*high = divider / 2;
+	*edge = divider % 2;
+	*low = divider - *high;
+}
+
+/***************************************************************************//**
+ * @brief clkgen_mmcm_enable
+*******************************************************************************/
+static void clkgen_mmcm_enable(clkgen_device *dev,
+							   char enable)
+{
+	uint32_t val = CLKGEN_RESETN;
+
+	if (enable)
+			val |= CLKGEN_MMCM_RESETN;
+
+	clkgen_write(dev, CLKGEN_REG_RESETN, val);
+}
+
+/***************************************************************************//**
+ * @brief clkgen_set_rate
+*******************************************************************************/
+int32_t clkgen_set_rate(clkgen_device *dev,
+						uint32_t rate,
+						uint32_t parent_rate)
+{
+	uint32_t d		 = 0;
+	uint32_t m		 = 0;
+	uint32_t dout	 = 0;
+	uint32_t nocount = 0;
+	uint32_t high	 = 0;
+	uint32_t edge	 = 0;
+	uint32_t low	 = 0;
+	uint32_t filter  = 0;
+	uint32_t lock	 = 0;
+
+	if (parent_rate == 0 || rate == 0)
+		return 0;
+
+	clkgen_calc_params(parent_rate, rate, &d, &m, &dout);
+
+	if (d == 0 || dout == 0 || m == 0)
+		return 0;
+
+	filter = clkgen_lookup_filter(m - 1);
+	lock = clkgen_lookup_lock(m - 1);
+
+	clkgen_mmcm_enable(dev, 0);
+
+	clkgen_calc_clk_params(dout, &low, &high, &edge, &nocount);
+	clkgen_mmcm_write(dev, MMCM_REG_CLKOUT0_1, (high << 6) | low, 0xefff);
+	clkgen_mmcm_write(dev, MMCM_REG_CLKOUT0_2, (edge << 7) | (nocount << 6), 0x03ff);
+
+	dout *= 4;
+	clkgen_calc_clk_params(dout, &low, &high, &edge, &nocount);
+	clkgen_mmcm_write(dev, MMCM_REG_CLKOUT1_1, (high << 6) | low, 0xefff);
+	clkgen_mmcm_write(dev, MMCM_REG_CLKOUT1_2, (edge << 7) | (nocount << 6), 0x03ff);
+
+	clkgen_calc_clk_params(d, &low, &high, &edge, &nocount);
+	clkgen_mmcm_write(dev, MMCM_REG_CLK_DIV, (edge << 13) | (nocount << 12) | (high << 6) | low, 0x3fff);
+
+	clkgen_calc_clk_params(m, &low, &high, &edge, &nocount);
+	clkgen_mmcm_write(dev, MMCM_REG_CLK_FB1, (high << 6) | low, 0xefff);
+	clkgen_mmcm_write(dev, MMCM_REG_CLK_FB2, (edge << 7) | (nocount << 6), 0x03ff);
+
+	clkgen_mmcm_write(dev, MMCM_REG_LOCK1, lock & 0x3ff, 0x3ff);
+	clkgen_mmcm_write(dev, MMCM_REG_LOCK2, (((lock >> 16) & 0x1f) << 10) | 0x1, 0x7fff);
+	clkgen_mmcm_write(dev, MMCM_REG_LOCK3, (((lock >> 24) & 0x1f) << 10) | 0x3e9, 0x7fff);
+	clkgen_mmcm_write(dev, MMCM_REG_FILTER1, filter >> 16, 0x9900);
+	clkgen_mmcm_write(dev, MMCM_REG_FILTER2, filter, 0x9900);
+
+	clkgen_mmcm_enable(dev, 1);
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * @brief clkgen_get_rate
+*******************************************************************************/
+uint32_t clkgen_get_rate(clkgen_device *dev,
+						 uint32_t parent_rate)
+{
+	uint32_t d, m, dout;
+	uint32_t reg;
+	uint64_t tmp;
+
+	clkgen_mmcm_read(dev, MMCM_REG_CLKOUT0_1, &reg);
+	dout = (reg & 0x3f) + ((reg >> 6) & 0x3f);
+	clkgen_mmcm_read(dev, MMCM_REG_CLK_DIV, &reg);
+	d = (reg & 0x3f) + ((reg >> 6) & 0x3f);
+	clkgen_mmcm_read(dev, MMCM_REG_CLK_FB1, &reg);
+	m = (reg & 0x3f) + ((reg >> 6) & 0x3f);
+
+	if (d == 0 || dout == 0)
+		return 0;
+
+	tmp = (uint64_t)(parent_rate / d) * m;
+	tmp = tmp / dout;
+
+	if (tmp > 0xffffffff)
+		return 0xffffffff;
+
+	return (uint32_t)tmp;
+}
+
+/***************************************************************************//**
+ * @brief clkgen_setup
+ *******************************************************************************/
+int32_t clkgen_setup(clkgen_device **clkgen_dev,
+		clkgen_init_params init_params)
+{
+	clkgen_device	*adc_clkgen;
+	uint32_t	reg_val;
+	int32_t		status = 0;
+
+	adc_clkgen = (clkgen_device *)malloc(sizeof(*adc_clkgen));
+        if (!adc_clkgen)
+                return -1;
+
+	adc_clkgen->base_addr = init_params.base_addr;
+	clkgen_set_rate(adc_clkgen,
+			init_params.rate,
+			init_params.parent_rate);
+
+	mdelay(1);
+
+	clkgen_read(adc_clkgen, CLKGEN_REG_STATUS, &reg_val);
+	if ((reg_val & CLKGEN_STATUS) == 0x0) {
+		printf("clkgen_setup failed");
+		status--;
+	}
+
+	return status;
+}

--- a/adum7701_fmc/clkgen_core.h
+++ b/adum7701_fmc/clkgen_core.h
@@ -1,0 +1,67 @@
+/***************************************************************************//**
+ * @file clkgen_core.h
+ * @brief Header file of CLKGEN Core Driver.
+ * @author DBogdan (dragos.bogdan@analog.com)
+ ********************************************************************************
+ * Copyright 2017(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in
+ * the documentation and/or other materials provided with the
+ * distribution.
+ * - Neither the name of Analog Devices, Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ * - The use of this software may or may not infringe the patent rights
+ * of one or more patent holders. This license does not release you
+ * from the requirement that you obtain separate licenses from these
+ * patent holders to use this software.
+ * - Use of the software either in source or binary form, must be run
+ * on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#ifndef CLKGEN_CORE_H_
+#define CLKGEN_CORE_H_
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "platform_drivers.h"
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+typedef struct {
+	uint32_t	base_addr;
+} clkgen_device;
+
+typedef struct {
+	uint32_t	base_addr;
+	uint32_t 	rate;
+	uint32_t 	parent_rate;
+} clkgen_init_params;
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+int32_t clkgen_setup(clkgen_device **clkgen_dev,
+		clkgen_init_params init_params);
+
+#endif

--- a/adum7701_fmc/platform_drivers.c
+++ b/adum7701_fmc/platform_drivers.c
@@ -1,0 +1,119 @@
+/***************************************************************************//**
+ * @file platform_drivers.c
+ * @brief Implementation of Platform Drivers.
+ ********************************************************************************
+ * Copyright 2017(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in
+ * the documentation and/or other materials provided with the
+ * distribution.
+ * - Neither the name of Analog Devices, Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ * - The use of this software may or may not infringe the patent rights
+ * of one or more patent holders. This license does not release you
+ * from the requirement that you obtain separate licenses from these
+ * patent holders to use this software.
+ * - Use of the software either in source or binary form, must be run
+ * on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "platform_drivers.h"
+/***************************************************************************//**
+ * @brief ad_pow2 Create a mask for a given number of bit
+ *******************************************************************************/
+uint32_t ad_pow2(uint32_t number)
+{
+
+	uint32_t index;
+	uint32_t mask = 1;
+
+	for (index=1; index < number; index++) {
+		mask = (mask << 1) ^ 1;
+	}
+
+	return mask;
+}
+
+/**
+ * @brief Obtain the GPIO decriptor.
+ * @param desc - The GPIO descriptor.
+ * @param gpio_number - The number of the GPIO.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t gpio_get(gpio_desc **desc,
+		 gpio_init_param param)
+{
+	gpio_desc        *d;
+	d = (gpio_desc *)malloc(sizeof(*d));
+	if (!d)
+		return -1;
+
+	d->number = param.number;
+	d->id = param.id;
+
+	d->ps7_config = XGpioPs_LookupConfig(d->id);
+	XGpioPs_CfgInitialize(&d->ps7_instance,
+			      d->ps7_config,
+			      d->ps7_config->BaseAddr);
+	*desc = d;
+
+	return 0;
+}
+
+/**
+ * @brief Free the resources allocated by gpio_get().
+ * @param desc - The SPI descriptor.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t gpio_remove(gpio_desc *desc)
+{
+	free(desc);
+
+	return 0;
+}
+
+/**
+ * @brief Set the value of the specified GPIO.
+ * @param desc - The GPIO descriptor.
+ * @param value - The value.
+ *                Example: GPIO_HIGH
+ *                         GPIO_LOW
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t gpio_set_value(gpio_desc *desc,
+		       uint8_t value)
+{
+	XGpioPs_SetDirectionPin(&desc->ps7_instance,
+				desc->number, 1);
+	XGpioPs_SetOutputEnablePin(&desc->ps7_instance,
+				   desc->number, 1);
+	XGpioPs_WritePin(&desc->ps7_instance,
+			 desc->number, value);
+
+	return 0;
+}

--- a/adum7701_fmc/platform_drivers.h
+++ b/adum7701_fmc/platform_drivers.h
@@ -1,0 +1,96 @@
+/***************************************************************************//**
+ *   @file   platform_drivers.h
+ *   @brief  Header file of Generic Platform Drivers.
+ *   @author DBogdan (dragos.bogdan@analog.com)
+********************************************************************************
+ * Copyright 2017(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef PLATFORM_DRIVERS_H_
+#define PLATFORM_DRIVERS_H_
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <sleep.h>
+#include <xil_io.h>
+#include <xgpiops.h>
+#include <xspips.h>
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+#define mdelay(msecs)	usleep(1000 * msecs)
+#define GPIO_HIGH	0x01
+#define GPIO_LOW	0x00
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+
+typedef enum {
+	GENERIC_GPIO,
+	PS7_GPIO
+} gpio_type;
+
+typedef struct {
+	gpio_type	type;
+	uint32_t	id;
+	uint8_t		number;
+} gpio_init_param;
+
+typedef struct {
+	gpio_type	type;
+	uint32_t	id;
+	uint8_t		number;
+	XGpioPs_Config *ps7_config;
+	XGpioPs		ps7_instance;
+} gpio_desc;
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+/* Obtain the GPIO decriptor. */
+int32_t gpio_get(gpio_desc **desc,
+		 gpio_init_param param);
+
+/* Free the resources allocated by gpio_get() */
+int32_t gpio_remove(gpio_desc *desc);
+
+/* Set the value of the specified GPIO. */
+int32_t gpio_set_value(gpio_desc *desc,
+		       uint8_t value);
+uint32_t ad_pow2(uint32_t number);
+#endif /* PLATFORM_DRIVERS_H_ */


### PR DESCRIPTION
This patch adds support for ADuM7701/ADuM7702 and AD7405 16-bit sigma-delta
modulators.

Datasheet:
http://www.analog.com/media/en/technical-documentation/data-sheets/AD7405.pdf

Signed-off-by: Stefan Popa <stefan.popa@analog.com>