### PR TITLE
ad5770r: Initial commit of AD5770R driver

### DIFF
--- a/drivers/ad5770r/ad5770r.c
+++ b/drivers/ad5770r/ad5770r.c
@@ -1,0 +1,650 @@
+/***************************************************************************//**
+ *   @file   ad5770r.c
+ *   @brief  Implementation of ad5770r Driver.
+ *   @author Mircea Caprioru (mircea.caprioru@analog.com)
+********************************************************************************
+ * Copyright 2018(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include "platform_drivers.h"
+#include "ad5770r.h"
+
+/******************************************************************************/
+/************************** Functions Implementation **************************/
+/******************************************************************************/
+/**
+ * Read from device.
+ * @param dev - The device structure.
+ * @param reg_addr - The register address.
+ * @param reg_data - The register data.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int32_t ad5770r_spi_reg_read(struct ad5770r_dev *dev,
+			     uint8_t reg_addr,
+			     uint8_t *reg_data)
+{
+	uint8_t buf[3];
+	int32_t ret;
+
+	buf[0] = AD5770R_REG_READ(reg_addr);
+	buf[1] = 0x00;
+
+	ret = spi_write_and_read(dev->spi_desc, buf, 2);
+	*reg_data = buf[1];
+
+	return ret;
+}
+
+/**
+ * Multibyte read from device. A register read begins with the address
+ * and autoincrements for each aditional byte in the transfer.
+ * @param dev - The device structure.
+ * @param reg_addr - The register address.
+ * @param reg_data - The register data.
+ * @param count - Number of bytes to read.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int32_t ad5770r_spi_reg_read_multiple(struct ad5770r_dev *dev,
+				      uint8_t reg_addr,
+				      uint8_t *reg_data,
+				      uint16_t count)
+{
+	uint8_t buf[1024];
+	uint16_t i;
+	int32_t ret;
+
+	/* Check if multibyte enabled */
+
+	buf[0] = AD5770R_REG_READ(reg_addr);
+	memset(&buf[1], 0x00, count);
+
+	ret = spi_write_and_read(dev->spi_desc, buf, count + 1);
+
+	for (i = 0; i < count; i++)
+		reg_data[i] = buf[i+1];
+
+	return ret;
+}
+/**
+ * Write to device.
+ * @param dev - The device structure.
+ * @param reg_addr - The register address.
+ * @param reg_data - The register data.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int32_t ad5770r_spi_reg_write(struct ad5770r_dev *dev,
+			      uint8_t reg_addr,
+			      uint8_t reg_data)
+{
+	int32_t ret;
+	uint8_t buf[2];
+
+	buf[0] = AD5770R_REG_WRITE(reg_addr);
+	buf[1] = reg_data & 0xFF;
+
+	ret = spi_write_and_read(dev->spi_desc, buf, 2);
+
+	return ret;
+}
+
+/**
+ * Multibyte write from device. A register write begins with the address
+ * and autoincrements for each additional byte in the transfer.
+ * @param dev - The device structure.
+ * @param reg_addr - The register address.
+ * @param reg_data - The register data.
+ * @param count - Number of bytes to read.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int32_t ad5770r_spi_reg_write_multiple(struct ad5770r_dev *dev,
+				       uint8_t reg_addr,
+				       uint8_t *reg_data,
+				       uint16_t count)
+{
+	int32_t ret;
+	uint8_t data[1024];
+
+	data[0] = AD5770R_REG_WRITE(reg_addr);
+	memcpy(&data[1], reg_data, count);
+
+	ret = spi_write_and_read(dev->spi_desc, data, count + 1);
+
+	return ret;
+}
+
+/**
+ * SPI write to device using a mask.
+ * @param dev - The device structure.
+ * @param reg_addr - The register address.
+ * @param mask - The mask.
+ * @param data - The register data.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int32_t ad5770r_spi_write_mask(struct ad5770r_dev *dev,
+			       uint8_t reg_addr,
+			       uint32_t mask,
+			       uint8_t data)
+{
+	uint8_t reg_data;
+	int32_t ret;
+
+	ret = ad5770r_spi_reg_read(dev, reg_addr, &reg_data);
+	reg_data &= ~mask;
+	reg_data |= data;
+	ret |= ad5770r_spi_reg_write(dev, reg_addr, reg_data);
+
+	return ret;
+}
+
+/**
+ * Set device spi settings.
+ * @param dev - The device structure.
+ * @param spi_settings - The structure that contains the device spi
+ *		       parameters.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad5770r_set_device_spi(struct ad5770r_dev *dev,
+			       struct device_spi_settings spi_settings)
+{
+	int32_t ret;
+
+	ret = ad5770r_spi_write_mask(dev,
+				     AD5770R_INTERFACE_CONFIG_A,
+				     AD5770R_INTERFACE_CONFIG_A_ADDR_ASCENSION_MSB_MSK,
+				     AD5770R_INTERFACE_CONFIG_A_ADDR_ASCENSION_MSB(spi_settings.addr_ascension));
+
+	ret |= ad5770r_spi_write_mask(dev,
+				      AD5770R_INTERFACE_CONFIG_B,
+				      AD5770R_INTERFACE_CONFIG_B_SINGLE_INST_MSK,
+				      AD5770R_INTERFACE_CONFIG_B_SINGLE_INST(spi_settings.single_instruction));
+
+	ret |= ad5770r_spi_reg_write(dev,
+				     AD5770R_STREAM_MODE,
+				     spi_settings.stream_mode_length);
+
+	if (ret)
+		return -1;
+
+	dev->dev_spi_settings.addr_ascension =
+		spi_settings.addr_ascension;
+	dev->dev_spi_settings.single_instruction =
+		spi_settings.single_instruction;
+	dev->dev_spi_settings.stream_mode_length =
+		spi_settings.stream_mode_length;
+
+	return ret;
+}
+
+/**
+ * Set the channel configuration.
+ * @param dev - The device structure.
+ * @param channel_config - The structure that contains the channel
+ *			configuration.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad5770r_channel_config(struct ad5770r_dev *dev,
+			       bool *channel_config)
+{
+	int32_t ret;
+
+	ret = ad5770r_spi_reg_write(dev,
+				    AD5770R_CHANNEL_CONFIG,
+				    AD5770R_CHANNEL_CONFIG_CH0_SHUTDOWN_B(channel_config[0]) |
+				    AD5770R_CHANNEL_CONFIG_CH1_SHUTDOWN_B(channel_config[1]) |
+				    AD5770R_CHANNEL_CONFIG_CH2_SHUTDOWN_B(channel_config[2]) |
+				    AD5770R_CHANNEL_CONFIG_CH3_SHUTDOWN_B(channel_config[3]) |
+				    AD5770R_CHANNEL_CONFIG_CH4_SHUTDOWN_B(channel_config[4]) |
+				    AD5770R_CHANNEL_CONFIG_CH5_SHUTDOWN_B(channel_config[5]) |
+				    AD5770R_CHANNEL_CONFIG_CH0_SINK_EN(channel_config[6]));
+
+	if (ret)
+		return -1;
+
+	dev->channel_config = channel_config;
+
+	return ret;
+}
+
+/**
+ * Set the channel configuration.
+ * @param dev - The device structure.
+ * @param output_mode - The structure that contains the channel output
+ *			parameters.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad5770r_set_output_mode(struct ad5770r_dev *dev,
+				struct output_range output_mode,
+				enum ad5770r_channels channel)
+{
+	return ad5770r_spi_reg_write(dev,
+				     AD5770R_OUTPUT_RANGE_CH0 + channel,
+				     AD5770R_OUTPUT_RANGE_OUTPUT_SCALING(output_mode.output_scale) |
+				     AD5770R_OUTPUT_RANGE_MODE(output_mode.output_range_mode));
+};
+
+/**
+ * Set reference configuration.
+ * @param dev - The device structure.
+ * @param output_mode - The structure that contains the channel output
+ *			parameters.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad5770r_set_reference(struct ad5770r_dev *dev,
+			      bool external_reference,
+			      enum ad5770r_reference_voltage reference_selector)
+{
+	int32_t ret;
+
+	ret = ad5770r_spi_reg_write(dev,
+				    AD5770R_REFERENCE,
+				    AD5770R_REFERENCE_RESISTOR_SEL(external_reference) |
+				    AD5770R_REFERENCE_VOLTATE_SEL(reference_selector));
+
+	if (ret)
+		return -1;
+
+	dev->reference_selector = reference_selector;
+	dev->external_reference = external_reference;
+
+	return ret;
+};
+
+/**
+ * Set reference configuration.
+ * @param dev - The device structure.
+ * @param alarm_config - Pointer to the array that contains the alarms
+ *			that will be enabled.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad5770r_set_alarm(struct ad5770r_dev *dev,
+			  bool * const alarm_config)
+{
+	int32_t ret;
+
+	ret = ad5770r_spi_reg_write(dev,
+				    AD5770R_ALARM_CONFIG,
+				    AD5770R_ALARM_CONFIG_OPEN_DRAIN_EN(alarm_config[0]) |
+				    AD5770R_ALARM_CONFIG_THERMAL_SHUTDOWN_EN(alarm_config[1]) |
+				    AD5770R_ALARM_CONFIG_BACKGROUND_CRC_EN(alarm_config[2]) |
+				    AD5770R_ALARM_CONFIG_TEMP_WARNING_ALARM_MASK(alarm_config[3]) |
+				    AD5770R_ALARM_CONFIG_OVER_TEMP_ALARM_MASK(alarm_config[4]) |
+				    AD5770R_ALARM_CONFIG_NEGATIVE_CHANNEL0_ALARM_MASK(alarm_config[5]) |
+				    AD5770R_ALARM_CONFIG_IREF_FAULT_ALARM_MASK(alarm_config[6]) |
+				    AD5770R_ALARM_CONFIG_BACKGROUND_CRC_ALARM_MASK(alarm_config[7]));
+
+	if (ret)
+		return -1;
+
+	dev->alarm_config = alarm_config;
+
+	return ret;
+};
+
+/**
+ * Set the channel output filter resistor.
+ * @param dev - The device structure.
+ * @param output_filter - The structure that contains the channel output
+ *			filter resistor values.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad5770r_set_output_filter(struct ad5770r_dev *dev,
+				  enum ad5770r_output_filter_resistor output_filter,
+				  enum ad5770r_channels channel)
+{
+	return ad5770r_spi_reg_write(dev,
+				     AD5770R_OUTPUT_FILTER_CH0 + channel,
+				     AD5770R_OUTPUT_FILTER_CH(output_filter));
+};
+
+/**
+ * Set the hardware ldac configuration.
+ * @param dev - The device structure.
+ * @param mask_hw_ldac - The array contains HW LDAC channel masks.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad5770r_set_hw_ladc(struct ad5770r_dev *dev,
+			    bool * const mask_hw_ldac)
+{
+	int32_t ret;
+
+	ret = ad5770r_spi_reg_write(dev,
+				    AD5770R_HW_LDAC,
+				    AD5770R_HW_LDAC_MASK_CH(mask_hw_ldac[0], AD5770R_CH0) |
+				    AD5770R_HW_LDAC_MASK_CH(mask_hw_ldac[1], AD5770R_CH1) |
+				    AD5770R_HW_LDAC_MASK_CH(mask_hw_ldac[2], AD5770R_CH2) |
+				    AD5770R_HW_LDAC_MASK_CH(mask_hw_ldac[3], AD5770R_CH3) |
+				    AD5770R_HW_LDAC_MASK_CH(mask_hw_ldac[4], AD5770R_CH4) |
+				    AD5770R_HW_LDAC_MASK_CH(mask_hw_ldac[5], AD5770R_CH5));
+
+	if (ret)
+		return -1;
+
+	dev->mask_hw_ldac = mask_hw_ldac;
+
+	return ret;
+};
+
+/**
+ * Set dac value.
+ * @param dev - The device structure.
+ * @param dac_value - value that will be set in the register.
+ * @param channel - the selected channel.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad5770r_set_dac_value(struct ad5770r_dev *dev,
+			      uint16_t dac_value, enum ad5770r_channels channel)
+{
+	uint8_t data[2];
+	int32_t ret;
+
+	data[1] = (uint8_t)AD5770R_CH_DAC_DATA_LSB(dac_value);
+	data[0] = (uint8_t)((dac_value & 0x3FC0) >> 6);
+
+	ret = ad5770r_spi_reg_write_multiple(dev,
+					     AD5770R_CH0_DAC_MSB + 2 * channel,
+					     data, 2);
+
+	return ret;
+};
+
+/**
+ * Set dac value.
+ * @param dev - The device structure.
+ * @param dac_input - value that will be set in the register.
+ * @param channel - the selected channel.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad5770r_set_dac_input(struct ad5770r_dev *dev,
+			      uint16_t dac_input, enum ad5770r_channels channel)
+{
+	uint8_t data[2];
+	int32_t ret;
+
+	data[1] = (uint8_t)AD5770R_CH_DAC_DATA_LSB(dac_input);
+	data[0] = (uint8_t)((dac_input & 0x3FC0) >> 6);
+
+	ret = ad5770r_spi_reg_write_multiple(dev,
+					     AD5770R_CH0_INPUT_MSB + 2 * channel,
+					     data, 2);
+
+	return ret;
+};
+
+/**
+ * Set page mask for dac value and input.
+ * @param dev - The device structure.
+ * @param page_mask - The structure contains the page mask values.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad5770r_set_page_mask(struct ad5770r_dev *dev,
+			      struct dac_page_mask page_mask)
+{
+	int32_t ret;
+	uint8_t data[2];
+
+	data[1] = (uint8_t)AD5770R_CH_DAC_DATA_LSB(page_mask.dac_data_page_mask);
+	data[0] = (uint8_t)((page_mask.dac_data_page_mask & 0x3FC0) >> 6);
+
+	ret = ad5770r_spi_reg_write_multiple(dev,
+					     AD5770R_DAC_PAGE_MASK_MSB,
+					     data, 2);
+
+	data[1] = (uint8_t)AD5770R_CH_DAC_DATA_LSB(page_mask.input_page_mask);
+	data[0] = (uint8_t)((page_mask.input_page_mask & 0x3FC0) >> 6);
+
+	ret = ad5770r_spi_reg_write_multiple(dev,
+					     AD5770R_INPUT_PAGE_MASK_MSB,
+					     data, 2);
+
+	return ret;
+}
+
+/**
+ * Set channel select.
+ * @param dev - The device structure.
+ * @param mask_channel_sel - The array contains channel selection options.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad5770r_set_mask_channel(struct ad5770r_dev *dev,
+				 bool *mask_channel_sel)
+{
+	int32_t ret;
+
+	ret = ad5770r_spi_reg_write(dev,
+				    AD5770R_CH_SELECT,
+				    AD5770R_CH_SELECT_SEL_CH(mask_channel_sel[0], AD5770R_CH0) |
+				    AD5770R_CH_SELECT_SEL_CH(mask_channel_sel[1], AD5770R_CH1) |
+				    AD5770R_CH_SELECT_SEL_CH(mask_channel_sel[2], AD5770R_CH2) |
+				    AD5770R_CH_SELECT_SEL_CH(mask_channel_sel[3], AD5770R_CH3) |
+				    AD5770R_CH_SELECT_SEL_CH(mask_channel_sel[4], AD5770R_CH4) |
+				    AD5770R_CH_SELECT_SEL_CH(mask_channel_sel[5], AD5770R_CH5));
+
+	if (ret)
+		return -1;
+
+	dev->mask_channel_sel = mask_channel_sel;
+
+	return ret;
+}
+
+/**
+ * Set software LDAC.
+ * @param dev - The device structure.
+ * @param sw_ldac - The array contains channel selection options.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad5770r_set_sw_ldac(struct ad5770r_dev *dev,
+			    bool *sw_ldac)
+{
+	int32_t ret;
+
+	ret = ad5770r_spi_reg_write(dev,
+				    AD5770R_SW_LDAC,
+				    AD5770R_SW_LDAC_CH(sw_ldac[0], AD5770R_CH0) |
+				    AD5770R_SW_LDAC_CH(sw_ldac[1], AD5770R_CH1) |
+				    AD5770R_SW_LDAC_CH(sw_ldac[2], AD5770R_CH2) |
+				    AD5770R_SW_LDAC_CH(sw_ldac[3], AD5770R_CH3) |
+				    AD5770R_SW_LDAC_CH(sw_ldac[4], AD5770R_CH4) |
+				    AD5770R_SW_LDAC_CH(sw_ldac[5], AD5770R_CH5));
+
+	if (ret)
+		return -1;
+
+	dev->sw_ldac = sw_ldac;
+
+	return ret;
+}
+
+/**
+ * Set the enabled channels.
+ * @param dev - The device structure.
+ * @param channel_enable - The array contains channels enabled.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad5770r_set_channel_en(struct ad5770r_dev *dev,
+			       bool *channel_enable)
+{
+	int32_t ret;
+
+	ret = ad5770r_spi_reg_write(dev,
+				    AD5770R_CH_ENABLE,
+				    AD5770R_CH_ENABLE_SET(channel_enable[0], AD5770R_CH0) |
+				    AD5770R_CH_ENABLE_SET(channel_enable[1], AD5770R_CH1) |
+				    AD5770R_CH_ENABLE_SET(channel_enable[2], AD5770R_CH2) |
+				    AD5770R_CH_ENABLE_SET(channel_enable[3], AD5770R_CH3) |
+				    AD5770R_CH_ENABLE_SET(channel_enable[4], AD5770R_CH4) |
+				    AD5770R_CH_ENABLE_SET(channel_enable[5], AD5770R_CH5));
+
+	if (ret)
+		return -1;
+
+	dev->channel_enable = channel_enable;
+
+	return ret;
+}
+
+/**
+ * Get status value.
+ * @param dev - The device structure.
+ * @param mon_setup - The structure that contains the monitor setup
+ *		values.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad5770r_get_status(struct ad5770r_dev *dev,
+			   uint8_t *status)
+{
+	return ad5770r_spi_reg_read(dev,
+				    AD5770R_STATUS,
+				    status);
+};
+
+/**
+ * Set the channel monitor configuration.
+ * @param dev - The device structure.
+ * @param mon_setup - The structure that contains the monitor setup
+ *		values.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad5770r_set_monitor_setup(struct ad5770r_dev *dev,
+				  struct monitor_setup mon_setup)
+{
+	int32_t ret;
+	ret = ad5770r_spi_reg_write(dev,
+				    AD5770R_MONITOR_SETUP,
+				    AD5770R_MONITOR_SETUP_MON_CH(mon_setup.monitor_channel) |
+				    AD5770R_MONITOR_SETUP_IB_EXT_EN(mon_setup.ib_ext_en) |
+				    AD5770R_MONITOR_SETUP_MUX_BUFFER(mon_setup.mux_buffer) |
+				    AD5770R_MONITOR_SETUP_MON_FUNCTION(mon_setup.monitor_function));
+
+	if (ret)
+		return -1;
+
+	dev->mon_setup = mon_setup;
+
+	return ret;
+};
+
+/**
+ * Initialize the device.
+ * @param device - The device structure.
+ * @param init_param - The structure that contains the device initial
+ *		       parameters.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad5770r_init(struct ad5770r_dev **device,
+		     struct ad5770r_init_param init_param)
+{
+	struct ad5770r_dev	*dev;
+	uint8_t product_id_l, product_id_h;
+	int32_t ret;
+	enum ad5770r_channels i;
+
+	dev = (struct ad5770r_dev *)malloc(sizeof(*dev));
+	if (!dev)
+		return -1;
+
+	/* SPI */
+	ret = spi_init(&dev->spi_desc, init_param.spi_init);
+
+	/* Query device presence */
+	ad5770r_spi_reg_read(dev, AD5770R_PRODUCT_ID_L, &product_id_l);
+	ad5770r_spi_reg_read(dev, AD5770R_PRODUCT_ID_H, &product_id_h);
+
+	if (product_id_l != 0x04 || product_id_h != 0x40) {
+		printf("failed to read id (0x%X : 0x%X)\n", product_id_l,
+		       product_id_h);
+		return -1;
+	}
+
+	/* Device settings */
+	ret = ad5770r_set_device_spi(dev,
+				     init_param.dev_spi_settings);
+
+	ret |= ad5770r_channel_config(dev,
+				      init_param.channel_config);
+	ret |= ad5770r_set_channel_en(dev,
+				      init_param.channel_enable);
+
+	ret |= ad5770r_set_reference(dev,
+				     init_param.external_reference,
+				     init_param.reference_selector);
+	ret |= ad5770r_set_alarm(dev, init_param.alarm_config);
+
+	ret |= ad5770r_set_hw_ladc(dev,
+				   init_param.mask_hw_ldac);
+
+	for( i = AD5770R_CH0; i <=  AD5770R_CH5; i++) {
+		ret |= ad5770r_set_output_mode(dev,
+					       init_param.output_mode[i], i);
+		ret |= ad5770r_set_output_filter(dev,
+						 init_param.output_filter[i], i);
+		ret |= ad5770r_set_dac_value(dev,
+					     init_param.dac_value[i], i);
+		ret |= ad5770r_set_dac_input(dev,
+					     init_param.input_value[i], i);
+	}
+
+	dev->output_mode = init_param.output_mode;
+	dev->output_filter = init_param.output_filter;
+	dev->dac_value = init_param.dac_value;
+	dev->input_value = init_param.input_value;
+
+	ret |= ad5770r_set_page_mask(dev,
+				     init_param.page_mask);
+	ret |= ad5770r_set_mask_channel(dev,
+					init_param.mask_channel_sel);
+	ret |= ad5770r_set_sw_ldac(dev,
+				   init_param.sw_ldac);
+	ret |= ad5770r_set_monitor_setup(dev,
+					 init_param.mon_setup);
+
+	*device = dev;
+
+	if (!ret)
+		printf("ad5770r successfully initialized\n");
+	else
+		printf("ad5770r initialization error (%d)\n", ret);
+
+	mdelay(1000);
+
+	return ret;
+}

--- a/drivers/ad5770r/ad5770r.h
+++ b/drivers/ad5770r/ad5770r.h
@@ -1,0 +1,377 @@
+/***************************************************************************//**
+ *   @file   ad5770r.h
+ *   @brief  Header file for AD5770R Driver.
+ *   @author Mircea Caprioru (mircea.caprioru@analog.com)
+********************************************************************************
+ * Copyright 2018(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef AD5770R_H_
+#define AD5770R_H_
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+#define BIT(x)					(1UL << (x))
+/*
+ * Create a contiguous bitmask starting at bit position @l and ending at
+ * position @h.
+ */
+#define GENMASK(h, l) \
+		(((~0UL) - (1UL << (l)) + 1) & (~0UL >> (31 - (h))))
+
+/*SPI configuration registers*/
+#define AD5770R_INTERFACE_CONFIG_A 	0x00
+#define AD5770R_INTERFACE_CONFIG_B 	0x01
+#define AD5770R_CHIP_TYPE		0x03
+#define AD5770R_PRODUCT_ID_L		0x04
+#define AD5770R_PRODUCT_ID_H		0x05
+#define AD5770R_CHIP_GRADE		0x06
+#define AD5770R_SCRATCH_PAD		0x0A
+#define AD5770R_SPI_REVISION		0x0B
+#define AD5770R_VENDOR_L		0x0C
+#define AD5770R_VENDOR_H		0x0D
+#define AD5770R_STREAM_MODE		0x0E
+#define AD5770R_INTERFACE_CONFIG_C	0x10
+#define AD5770R_INTERFACE_STATUS_A	0x11
+
+/*AD5770R configuration registers*/
+#define AD5770R_CHANNEL_CONFIG		0x14
+#define AD5770R_OUTPUT_RANGE_CH0	0x15
+#define AD5770R_OUTPUT_RANGE_CH1	0x16
+#define AD5770R_OUTPUT_RANGE_CH2	0x17
+#define AD5770R_OUTPUT_RANGE_CH3	0x18
+#define AD5770R_OUTPUT_RANGE_CH4	0x19
+#define AD5770R_OUTPUT_RANGE_CH5	0x1A
+#define AD5770R_REFERENCE		0x1B
+#define AD5770R_ALARM_CONFIG		0x1C
+#define AD5770R_OUTPUT_FILTER_CH0	0x1D
+#define AD5770R_OUTPUT_FILTER_CH1	0x1E
+#define AD5770R_OUTPUT_FILTER_CH2	0x1F
+#define AD5770R_OUTPUT_FILTER_CH3	0x20
+#define AD5770R_OUTPUT_FILTER_CH4	0x21
+#define AD5770R_OUTPUT_FILTER_CH5	0x22
+#define AD5770R_MONITOR_SETUP		0x23
+#define AD5770R_STATUS			0x24
+#define AD5770R_HW_LDAC			0x25
+#define AD5770R_CH0_DAC_LSB		0x26
+#define AD5770R_CH0_DAC_MSB		0x27
+#define AD5770R_CH1_DAC_LSB		0x28
+#define AD5770R_CH1_DAC_MSB		0x29
+#define AD5770R_CH2_DAC_LSB		0x2A
+#define AD5770R_CH2_DAC_MSB		0x2B
+#define AD5770R_CH3_DAC_LSB		0x2C
+#define AD5770R_CH3_DAC_MSB		0x2D
+#define AD5770R_CH4_DAC_LSB		0x2E
+#define AD5770R_CH4_DAC_MSB		0x2F
+#define AD5770R_CH5_DAC_LSB		0x30
+#define AD5770R_CH5_DAC_MSB		0x31
+#define AD5770R_DAC_PAGE_MASK_LSB	0x32
+#define AD5770R_DAC_PAGE_MASK_MSB	0x33
+#define AD5770R_CH_SELECT		0x34
+#define AD5770R_INPUT_PAGE_MASK_LSB	0x35
+#define AD5770R_INPUT_PAGE_MASK_MSB	0x36
+#define AD5770R_SW_LDAC			0x37
+#define AD5770R_CH0_INPUT_LSB		0x38
+#define AD5770R_CH0_INPUT_MSB		0x39
+#define AD5770R_CH1_INPUT_LSB		0x3A
+#define AD5770R_CH1_INPUT_MSB		0x3B
+#define AD5770R_CH2_INPUT_LSB		0x3C
+#define AD5770R_CH2_INPUT_MSB		0x3D
+#define AD5770R_CH3_INPUT_LSB		0x3E
+#define AD5770R_CH3_INPUT_MSB		0x3F
+#define AD5770R_CH4_INPUT_LSB		0x40
+#define AD5770R_CH4_INPUT_MSB		0x41
+#define AD5770R_CH5_INPUT_LSB		0x42
+#define AD5770R_CH5_INPUT_MSB		0x43
+#define AD5770R_CH_ENABLE		0x44
+
+/* AD5770R_INTERFACE_CONFIG_A */
+#define AD5770R_INTERFACE_CONFIG_A_SW_RESET_MSK			BIT(7) | BIT(0)
+#define AD5770R_INTERFACE_CONFIG_A_SW_RESET(x)			(((x) & 0x1) | 0x80)
+#define AD5770R_INTERFACE_CONFIG_A_ADDR_ASCENSION_MSB_MSK	BIT(5)
+#define AD5770R_INTERFACE_CONFIG_A_ADDR_ASCENSION_MSB(x)	(((x) & 0x1) << 5)
+#define AD5770R_INTERFACE_CONFIG_A_SDO_ACTIVE_MSK		BIT(4) | BIT(3)
+
+/* AD5770R_INTERFACE_CONFIG_B */
+#define AD5770R_INTERFACE_CONFIG_B_SINGLE_INST_MSK		BIT(7)
+#define AD5770R_INTERFACE_CONFIG_B_SINGLE_INST(x)		(((x) & 0x1) << 7)
+#define AD5770R_INTERFACE_CONFIG_B_SHORT_INST_MSK		BIT(3)
+#define AD5770R_INTERFACE_CONFIG_B_SHORT_INST(x)		(((x) & 0x1) << 3)
+
+/* AD5770R_INTERFACE_CONFIG_C */
+#define AD5770R_INTERFACE_CONFIG_C_STRUCT_REGISTER_ACCESS_MSK	BIT(5)
+#define AD5770R_INTERFACE_CONFIG_C_STRUCT_REGISTER_ACCESS(x)	(((x) & 0x1) << 5)
+
+/* AD5770R_CHANNEL_CONFIG */
+#define AD5770R_CHANNEL_CONFIG_CH0_SINK_EN_MSK			BIT(7)
+#define AD5770R_CHANNEL_CONFIG_CH0_SINK_EN(x)			(((x) & 0x1) << 7)
+#define AD5770R_CHANNEL_CONFIG_CH5_SHUTDOWN_B_MSK		BIT(5)
+#define AD5770R_CHANNEL_CONFIG_CH5_SHUTDOWN_B(x)		(((x) & 0x1) << 5)
+#define AD5770R_CHANNEL_CONFIG_CH4_SHUTDOWN_B_MSK		BIT(4)
+#define AD5770R_CHANNEL_CONFIG_CH4_SHUTDOWN_B(x)		(((x) & 0x1) << 4)
+#define AD5770R_CHANNEL_CONFIG_CH3_SHUTDOWN_B_MSK		BIT(3)
+#define AD5770R_CHANNEL_CONFIG_CH3_SHUTDOWN_B(x)		(((x) & 0x1) << 3)
+#define AD5770R_CHANNEL_CONFIG_CH2_SHUTDOWN_B_MSK		BIT(2)
+#define AD5770R_CHANNEL_CONFIG_CH2_SHUTDOWN_B(x)		(((x) & 0x1) << 2)
+#define AD5770R_CHANNEL_CONFIG_CH1_SHUTDOWN_B_MSK		BIT(1)
+#define AD5770R_CHANNEL_CONFIG_CH1_SHUTDOWN_B(x)		(((x) & 0x1) << 1)
+#define AD5770R_CHANNEL_CONFIG_CH0_SHUTDOWN_B_MSK		BIT(0)
+#define AD5770R_CHANNEL_CONFIG_CH0_SHUTDOWN_B(x)		(((x) & 0x1) << 0)
+
+/* AD5770R_OUTPUT_RANGE */
+#define AD5770R_OUTPUT_RANGE_OUTPUT_SCALING_MSK			GENMASK(7, 2)
+#define AD5770R_OUTPUT_RANGE_OUTPUT_SCALING(x)			(((x) & 0x3F) << 2)
+#define AD5770R_OUTPUT_RANGE_MODE_MSK				GENMASK(1, 0)
+#define AD5770R_OUTPUT_RANGE_MODE(x)				((x) & 0x03)
+
+/* AD5770R_REFERENCE */
+#define AD5770R_REFERENCE_RESISTOR_SEL_MSK			BIT(2)
+#define AD5770R_REFERENCE_RESISTOR_SEL(x)			(((x) & 0x1) << 2)
+#define AD5770R_REFERENCE_VOLTATE_SEL_MSK			GENMASK(1, 0)
+#define AD5770R_REFERENCE_VOLTATE_SEL(x)			(((x) & 0x3) << 0)
+
+/* AD5770R_ALARM_CONFIG */
+#define AD5770R_ALARM_CONFIG_BACKGROUND_CRC_ALARM_MASK(x)	(((x) & 0x1) << 7)
+#define AD5770R_ALARM_CONFIG_IREF_FAULT_ALARM_MASK(x)		(((x) & 0x1) << 6)
+#define AD5770R_ALARM_CONFIG_NEGATIVE_CHANNEL0_ALARM_MASK(x)	(((x) & 0x1) << 5)
+#define AD5770R_ALARM_CONFIG_OVER_TEMP_ALARM_MASK(x)		(((x) & 0x1) << 4)
+#define AD5770R_ALARM_CONFIG_TEMP_WARNING_ALARM_MASK(x)		(((x) & 0x1) << 3)
+#define AD5770R_ALARM_CONFIG_BACKGROUND_CRC_EN(x)		(((x) & 0x1) << 2)
+#define AD5770R_ALARM_CONFIG_THERMAL_SHUTDOWN_EN(x)		(((x) & 0x1) << 1)
+#define AD5770R_ALARM_CONFIG_OPEN_DRAIN_EN(x)			(((x) & 0x1) << 0)
+
+/* AD5770R_OUTPUT_FILTER_CH */
+#define AD5770R_OUTPUT_FILTER_CH_MSK				GENMASK(3, 0)
+#define AD5770R_OUTPUT_FILTER_CH(x)				(((x) & 0xF) << 0)
+
+/* AD5770R_MONITOR_SETUP */
+#define AD5770R_MONITOR_SETUP_MON_FUNCTION_MSK			GENMASK(7, 6)
+#define AD5770R_MONITOR_SETUP_MON_FUNCTION(x)			(((x) & 0x3) << 6)
+#define AD5770R_MONITOR_SETUP_MUX_BUFFER_MSK			BIT(5)
+#define AD5770R_MONITOR_SETUP_MUX_BUFFER(x)			(((x) & 0x1) << 5)
+#define AD5770R_MONITOR_SETUP_IB_EXT_EN_MSK			BIT(4)
+#define AD5770R_MONITOR_SETUP_IB_EXT_EN(x)			(((x) & 0x1) << 4)
+#define AD5770R_MONITOR_SETUP_MON_CH_MSK			GENMASK(3, 0)
+#define AD5770R_MONITOR_SETUP_MON_CH(x)				(((x) & 0x7) << 0)
+
+/* AD5770R_STATUS */
+#define AD5770R_STATUS_BACKGROUND_CRC_STATUS_MSK		BIT(7)
+#define AD5770R_STATUS_IREF_FAULT_MSK				BIT(3)
+#define AD5770R_STATUS_NEGATIVE_CHANNEL0_MSK			BIT(2)
+#define AD5770R_STATUS_OVER_TEMP_MSK				BIT(1)
+#define AD5770R_STATUS_TEMP_WARNING_MSK				BIT(0)
+
+/* AD5770R_HW_LDAC */
+#define AD5770R_HW_LDAC_MASK_CH(x, channel)			(((x) & 0x1) << (channel))
+
+/* AD5770R_CH_DAC */
+#define AD5770R_CH_DAC_DATA_LSB(x)				(((x) & 0x3F) << 2)
+#define AD5770R_CH_DAC_DATA_MSB(x)				(((x) & 0xFF) << 0)
+
+/* AD5770R_CH_SELECT */
+#define AD5770R_CH_SELECT_SEL_CH(x, channel)			(((x) & 0x1) << (channel))
+
+/* AD5770R_CH_INPUT */
+#define AD5770R_CH_DAC_INPUT_DATA_LSB(x)			(((x) & 0x3F) << 2)
+#define AD5770R_CH_DAC_INPUT_DATA_MSB(x)			(((x) & 0xFF) << 0)
+
+/* AD5770R_SW_LDAC */
+#define AD5770R_SW_LDAC_CH(x, channel)				(((x) & 0x1) << (channel))
+
+/* AD5770R_CH_ENABLE */
+#define AD5770R_CH_ENABLE_SET(x, channel)			(((x) & 0x1) << (channel))
+
+#define AD5770R_REG_READ(x)					(((x) & 0x7F) | 0x80)
+#define AD5770R_REG_WRITE(x)					((x) & 0x7F)
+
+enum ad5770r_output_filter_resistor {
+	AD5770R_OUTPUT_FILTER_RESISTOR_60_OHM = 0x0,
+	AD5770R_OUTPUT_FILTER_RESISTOR_5_6_KOHM = 0x5,
+	AD5770R_OUTPUT_FILTER_RESISTOR_11_2_KOHM,
+	AD5770R_OUTPUT_FILTER_RESISTOR_22_2_KOHM,
+	AD5770R_OUTPUT_FILTER_RESISTOR_44_4_KOHM,
+	AD5770R_OUTPUT_FILTER_RESISTOR_104_KOHM,
+};
+
+enum ad5770r_monitor_function {
+	AD5770R_DISABLE = 0,
+	AD5770R_VOLTAGE_MONITORING,
+	AD5770R_CURRENT_MONITORING,
+	AD5770R_TEMPERATURE_MONITORING
+};
+
+enum ad5770r_channels {
+	AD5770R_CH0 = 0,
+	AD5770R_CH1,
+	AD5770R_CH2,
+	AD5770R_CH3,
+	AD5770R_CH4,
+	AD5770R_CH5
+};
+
+enum ad5770r_reference_voltage {
+	AD5770R_EXT_REF_2_5_V = 0,
+	AD5770R_INT_REF_1_25_V_OUT_ON,
+	AD5770R_EXT_REF_1_25_V,
+	AD5770R_INT_REF_1_25_V_OUT_OFF
+};
+
+struct monitor_setup {
+	enum ad5770r_monitor_function		monitor_function;
+	bool 					mux_buffer;
+	bool					ib_ext_en;
+	enum ad5770r_channels			monitor_channel;
+};
+
+struct dac_page_mask {
+	uint16_t 		dac_data_page_mask;
+	uint16_t		input_page_mask;
+};
+
+struct output_range {
+	uint8_t		output_scale;
+	uint8_t		output_range_mode;
+};
+
+struct device_spi_settings {
+	bool			addr_ascension;
+	bool			single_instruction; // for multibyte read/write
+	uint8_t		stream_mode_length;
+};
+
+struct ad5770r_dev {
+	/* SPI */
+	spi_desc				*spi_desc;
+
+	/* Device SPI Settings */
+	struct device_spi_settings		dev_spi_settings;
+	/* Device Settings */
+	bool					*channel_config;
+	struct output_range			*output_mode;
+	bool					external_reference;
+	enum ad5770r_reference_voltage		reference_selector;
+	bool					*alarm_config;
+	enum ad5770r_output_filter_resistor	*output_filter;
+	struct monitor_setup			mon_setup;
+	bool					*mask_hw_ldac;
+	uint16_t				*dac_value;
+	struct dac_page_mask			page_mask;
+	bool					*mask_channel_sel;
+	bool 					*sw_ldac;
+	uint16_t				*input_value;
+	bool					*channel_enable;
+};
+
+struct ad5770r_init_param {
+	/* SPI */
+	spi_init_param				spi_init;
+
+	/* Device SPI Settings */
+	struct device_spi_settings		dev_spi_settings;
+	/* Device Settings */
+	bool					channel_config[7];
+	struct output_range			output_mode[6];
+	bool					external_reference;
+	enum ad5770r_reference_voltage		reference_selector;
+	bool					alarm_config[8];
+	enum ad5770r_output_filter_resistor	output_filter[6];
+	struct monitor_setup			mon_setup;
+	bool					mask_hw_ldac[6];
+	uint16_t				dac_value[6];
+	struct dac_page_mask			page_mask;
+	bool					mask_channel_sel[6];
+	bool 					sw_ldac[6];
+	uint16_t				input_value[6];
+	bool					channel_enable[6];
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+int32_t ad5770r_spi_reg_read(struct ad5770r_dev *dev,
+			     uint8_t reg_addr,
+			     uint8_t *reg_data);
+int32_t ad5770r_spi_reg_read_multiple(struct ad5770r_dev *dev,
+				      uint8_t reg_addr,
+				      uint8_t *reg_data,
+				      uint16_t count);
+int32_t ad5770r_spi_reg_write(struct ad5770r_dev *dev,
+			      uint8_t reg_addr,
+			      uint8_t reg_data);
+int32_t ad5770r_spi_reg_write_multiple(struct ad5770r_dev *dev,
+				       uint8_t reg_addr,
+				       uint8_t *reg_data,
+				       uint16_t count);
+int32_t ad5770r_spi_write_mask(struct ad5770r_dev *dev,
+			       uint8_t reg_addr,
+			       uint32_t mask,
+			       uint8_t data);
+int32_t ad5770r_set_device_spi(struct ad5770r_dev *dev,
+			       struct device_spi_settings spi_settings);
+int32_t ad5770r_channel_config(struct ad5770r_dev *dev,
+			       bool *channel_config);
+int32_t ad5770r_set_output_mode(struct ad5770r_dev *dev,
+				struct output_range output_mode,
+				enum ad5770r_channels channel);
+int32_t ad5770r_set_reference(struct ad5770r_dev *dev,
+			      bool external_reference,
+			      enum ad5770r_reference_voltage reference_selector);
+int32_t ad5770r_set_alarm(struct ad5770r_dev *dev,
+			  bool * const alarm_config);
+int32_t ad5770r_set_output_filter(struct ad5770r_dev *dev,
+				  enum ad5770r_output_filter_resistor output_filter,
+				  enum ad5770r_channels channel);
+int32_t ad5770r_set_hw_ladc(struct ad5770r_dev *dev,
+			    bool * const mask_hw_ldac);
+int32_t ad5770r_set_dac_value(struct ad5770r_dev *dev,
+			      uint16_t dac_value, enum ad5770r_channels channel);
+int32_t ad5770r_set_dac_input(struct ad5770r_dev *dev,
+			      uint16_t dac_input, enum ad5770r_channels channel);
+int32_t ad5770r_set_page_mask(struct ad5770r_dev *dev,
+			      struct dac_page_mask page_mask);
+int32_t ad5770r_set_mask_channel(struct ad5770r_dev *dev,
+				 bool *mask_channel_sel);
+int32_t ad5770r_set_sw_ldac(struct ad5770r_dev *dev,
+			    bool *sw_ldac);
+int32_t ad5770r_set_channel_en(struct ad5770r_dev *dev,
+			       bool *channel_enable);
+int32_t ad5770r_get_status(struct ad5770r_dev *dev,
+			   uint8_t *status);
+int32_t ad5770r_set_monitor_setup(struct ad5770r_dev *dev,
+				  struct monitor_setup mon_setup);
+int32_t ad5770r_init(struct ad5770r_dev **device,
+		     struct ad5770r_init_param init_param);
+
+#endif // AD5770R_H_0


### PR DESCRIPTION
The AD5770R is a 6-channel, 14-bit resolution, low noise, programmable
current output digital-to-analog converter (DAC) for photonics control
applications. The chip contains five 14-bit resolution sourcing DAC
channels and one 14-bit resolution current sourcing/sinking DAC channel.

The driver enables the user to set the output of any of the five DAC
channels with hardware LDAC control or software LDAC.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>