### PR TITLE
Pass init param and state structures by reference

### DIFF
--- a/ad-fmcjesdadc1-ebz/ad9250.c
+++ b/ad-fmcjesdadc1-ebz/ad9250.c
@@ -104,7 +104,7 @@ int32_t ad9250_setup(struct ad9250_dev **device,
 		return -1;
 
 	/* Setup SPI descriptor */
-	ret = spi_init(&dev->spi_dev, init_param.spi_init);
+	ret = spi_init(&dev->spi_dev, &init_param.spi_init);
 
 	dev->id_no = init_param.id_no;
 

--- a/ad-fmcjesdadc1-ebz/ad9517.c
+++ b/ad-fmcjesdadc1-ebz/ad9517.c
@@ -108,7 +108,7 @@ int32_t ad9517_setup(struct ad9517_dev **device,
 		return -1;
 
 	/* Setup SPI descriptor */
-	ret = spi_init(&dev->spi_desc, init_param.spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	ad9517_spi_write(dev, 0x0010, 0x7c);
 	ad9517_spi_write(dev, 0x0014, 0x05);

--- a/ad-fmcjesdadc1-ebz/ad_fmcjesdadc1_ebz.c
+++ b/ad-fmcjesdadc1-ebz/ad_fmcjesdadc1_ebz.c
@@ -167,16 +167,16 @@ int main(void)
 	ad9250_setup(&ad9250_1_device, ad9250_1_param);
 
 	// generate SYSREF
-	jesd_sysref_control(ad9250_jesd204,1);
+	jesd_sysref_control(&ad9250_jesd204, 1);
 
 	// set up the XCVR core
 	xcvr_setup(&ad9250_xcvr);
 
 	// set up the JESD core
-	jesd_setup(ad9250_jesd204);
+	jesd_setup(&ad9250_jesd204);
 
 	// JESD core status
-	axi_jesd204_rx_status_read(ad9250_jesd204);
+	axi_jesd204_rx_status_read(&ad9250_jesd204);
 
 	// set up interface core
 	adc_setup(ad9250_0_core);

--- a/ad5758-sdz/ad5758.c
+++ b/ad5758-sdz/ad5758.c
@@ -796,7 +796,7 @@ int32_t ad5758_init(struct ad5758_dev **device,
 	ret |= gpio_set_value(dev->ldac_n, GPIO_LOW);
 
 	/* Initialize the SPI communication */
-	ret |= spi_init(&dev->spi_desc, init_param.spi_init);
+	ret |= spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* Perform a software reset */
 	ret |= ad5758_soft_reset(dev);

--- a/ad6676-ebz/ad6676_ebz.c
+++ b/ad6676-ebz/ad6676_ebz.c
@@ -231,16 +231,16 @@ int main(void)
 	ad6676_setup(&ad6676_device, ad6676_param);
 
 	// set up the JESD core
-	jesd_setup(ad6676_jesd);
+	jesd_setup(&ad6676_jesd);
 
 	// set up the XCVRs
 	xcvr_setup(&ad6676_xcvr);
 
 	// generate SYSREF
-	jesd_sysref_control(ad6676_jesd, 1);
+	jesd_sysref_control(&ad6676_jesd, 1);
 
 	// JESD core status
-	axi_jesd204_rx_status_read(ad6676_jesd);
+	axi_jesd204_rx_status_read(&ad6676_jesd);
 
 	// interface core setup
 	adc_setup(ad6676_core);

--- a/ad713x-fmcz/ad713x.c
+++ b/ad713x-fmcz/ad713x.c
@@ -293,7 +293,7 @@ int32_t ad713x_init(ad713x_dev **device,
 		return -1;
 
 	/* SPI */
-	ret = spi_init(&dev->spi_desc, init_param.spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 	/* GPIO */
 	ret |= gpio_get(&dev->gpio_mode1, init_param.gpio_mode1);
 	ret |= gpio_get(&dev->gpio_mode2, init_param.gpio_mode2);

--- a/ad738x-fmcz/ad738x.c
+++ b/ad738x-fmcz/ad738x.c
@@ -301,7 +301,7 @@ int32_t ad738x_init(ad738x_dev **device,
 	if (!dev)
 		return -1;
 
-	ret = spi_init(&dev->spi_desc, init_param.spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	ret |= ad738x_reset(dev, HARD_RESET);
 	mdelay(1000);

--- a/common_drivers/jesd_core/jesd_core.c
+++ b/common_drivers/jesd_core/jesd_core.c
@@ -67,11 +67,11 @@ const char *axi_jesd204_rx_lane_status_label[4] = {
 /***************************************************************************//**
 * @brief jesd_read
 *******************************************************************************/
-int32_t jesd_read(jesd_core core,
+int32_t jesd_read(jesd_core *jesd,
 					uint32_t reg_addr,
 					uint32_t *reg_data)
 {
-	*reg_data = ad_reg_read((core.base_address + reg_addr));
+	*reg_data = ad_reg_read((jesd->base_address + reg_addr));
 
 	return 0;
 }
@@ -79,11 +79,11 @@ int32_t jesd_read(jesd_core core,
 /***************************************************************************//**
 * @brief jesd_write
 *******************************************************************************/
-int32_t jesd_write(jesd_core core,
+int32_t jesd_write(jesd_core *jesd,
 					uint32_t reg_addr,
 					uint32_t reg_data)
 {
-	ad_reg_write((core.base_address + reg_addr), reg_data);
+	ad_reg_write((jesd->base_address + reg_addr), reg_data);
 
 	return 0;
 }
@@ -92,12 +92,12 @@ int32_t jesd_write(jesd_core core,
 /***************************************************************************//**
 * @brief jesd_init
 *******************************************************************************/
-int32_t jesd_setup(jesd_core core)
+int32_t jesd_setup(jesd_core *jesd)
 {
-	jesd_write(core, JESD204_REG_LINK_DISABLE, 1);
-	jesd_write(core, JESD204_REG_LINK_CONF0, (((core.octets_per_frame-1) << 16) |
-		((core.frames_per_multiframe*core.octets_per_frame)-1)));
-	jesd_write(core, JESD204_REG_LINK_DISABLE, 0);
+	jesd_write(jesd, JESD204_REG_LINK_DISABLE, 1);
+	jesd_write(jesd, JESD204_REG_LINK_CONF0, (((jesd->octets_per_frame-1) << 16) |
+		((jesd->frames_per_multiframe*jesd->octets_per_frame)-1)));
+	jesd_write(jesd, JESD204_REG_LINK_DISABLE, 0);
 	mdelay(100);
 	return(0);
 }
@@ -105,14 +105,14 @@ int32_t jesd_setup(jesd_core core)
 /***************************************************************************//**
 * @brief jesd generate SYSREF if necessar
 *******************************************************************************/
-int32_t jesd_sysref_control(jesd_core core, uint32_t enable)
+int32_t jesd_sysref_control(jesd_core *jesd, uint32_t enable)
 {
 	gpio_desc *sysref_pin;
-	if ((core.sysref_type == INTERN) && (core.subclass_mode >= 1)) {
+	if ((jesd->sysref_type == INTERN) && (jesd->subclass_mode >= 1)) {
 
 		// generate SYS_REF
 
-		gpio_get(&sysref_pin, core.sysref_gpio_pin);
+		gpio_get(&sysref_pin, jesd->sysref_gpio_pin);
 
 		gpio_set_value(sysref_pin, enable);
 
@@ -126,7 +126,7 @@ int32_t jesd_sysref_control(jesd_core core, uint32_t enable)
 /***************************************************************************//**
 * @brief jesd_read_status generic
 *******************************************************************************/
-int32_t jesd_status(jesd_core core)
+int32_t jesd_status(jesd_core *jesd)
 {
 	uint32_t status;
 	int32_t timeout;
@@ -136,7 +136,7 @@ int32_t jesd_status(jesd_core core)
 	timeout = 100;
 	while (timeout > 0) {
 		mdelay(1);
-		jesd_read(core, 0x280, &status);
+		jesd_read(jesd, 0x280, &status);
 		if ((status & 0x13) == 0x13) break;
 		timeout = timeout - 1;
 	}
@@ -156,7 +156,7 @@ int32_t jesd_status(jesd_core core)
 /***************************************************************************//**
 * @brief axi_jesd204_rx_status_read
 *******************************************************************************/
-int32_t axi_jesd204_rx_status_read(jesd_core jesd)
+int32_t axi_jesd204_rx_status_read(jesd_core *jesd)
 {
 	uint32_t sysref_status;
 	uint32_t link_disabled;
@@ -200,7 +200,7 @@ int32_t axi_jesd204_rx_status_read(jesd_core jesd)
 /***************************************************************************//**
 * @brief axi_jesd204_tx_status_read
 *******************************************************************************/
-int32_t axi_jesd204_tx_status_read(jesd_core jesd)
+int32_t axi_jesd204_tx_status_read(jesd_core *jesd)
 {
 	uint32_t sysref_status;
 	uint32_t link_disabled;
@@ -244,7 +244,7 @@ int32_t axi_jesd204_tx_status_read(jesd_core jesd)
 * @brief axi_jesd204_rx_laneinfo_read
 *******************************************************************************/
 /* FIXME: This violates every single sysfs ABI recommendation */
-int32_t axi_jesd204_rx_laneinfo_read(jesd_core jesd, uint32_t lane)
+int32_t axi_jesd204_rx_laneinfo_read(jesd_core *jesd, uint32_t lane)
 {
 	uint32_t lane_status;
 	uint32_t lane_latency;

--- a/common_drivers/jesd_core/jesd_core.h
+++ b/common_drivers/jesd_core/jesd_core.h
@@ -159,14 +159,14 @@ typedef struct {
 /************************ Functions Declarations ******************************/
 /******************************************************************************/
 
-int32_t jesd_read(jesd_core core, uint32_t reg_addr, uint32_t *reg_data);
-int32_t jesd_write(jesd_core core, uint32_t reg_addr, uint32_t reg_data);
+int32_t jesd_read(jesd_core *jesd, uint32_t reg_addr, uint32_t *reg_data);
+int32_t jesd_write(jesd_core *jesd, uint32_t reg_addr, uint32_t reg_data);
 
-int32_t jesd_setup(jesd_core core);
-int32_t jesd_status(jesd_core core);
-int32_t axi_jesd204_rx_status_read(jesd_core jesd);
-int32_t axi_jesd204_tx_status_read(jesd_core jesd);
-int32_t axi_jesd204_rx_laneinfo_read(jesd_core jesd, uint32_t lane);
-int32_t jesd_sysref_control(jesd_core core, uint32_t enable);
+int32_t jesd_setup(jesd_core *jesd);
+int32_t jesd_status(jesd_core *jesd);
+int32_t axi_jesd204_rx_status_read(jesd_core *jesd);
+int32_t axi_jesd204_tx_status_read(jesd_core *jesd);
+int32_t axi_jesd204_rx_laneinfo_read(jesd_core *jesd, uint32_t lane);
+int32_t jesd_sysref_control(jesd_core *jesd, uint32_t enable);
 
 #endif

--- a/common_drivers/platform_drivers/platform_drivers.c
+++ b/common_drivers/platform_drivers/platform_drivers.c
@@ -163,7 +163,7 @@ int32_t i2c_read(i2c_desc *desc,
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t spi_init(spi_desc **desc,
-		 spi_init_param param)
+		 const spi_init_param *param)
 {
 	spi_desc *dev;
 
@@ -171,7 +171,7 @@ int32_t spi_init(spi_desc **desc,
 	if (!dev)
 		return FAILURE;
 
-	dev->type = param.type;
+	dev->type = param->type;
 	dev->id = 0;
 
 	switch(dev->type) {
@@ -199,9 +199,9 @@ int32_t spi_init(spi_desc **desc,
 		return FAILURE;
 	}
 
-	dev->chip_select = param.chip_select;
-	dev->cpha = param.cpha;
-	dev->cpol = param.cpol;
+	dev->chip_select = param->chip_select;
+	dev->cpha = param->cpha;
+	dev->cpol = param->cpol;
 
 	#ifdef ZYNQ
 	m_spi_config = XSpiPs_LookupConfig(dev->device_id);

--- a/common_drivers/platform_drivers/platform_drivers.c
+++ b/common_drivers/platform_drivers/platform_drivers.c
@@ -61,13 +61,13 @@ XSpiPs_Config  *m_spi_config;
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t i2c_init(i2c_desc **desc,
-		 i2c_init_param param)
+		 const i2c_init_param *param)
 {
 	if (desc) {
 		// Unused variable - fix compiler warning
 	}
 
-	if (param.type) {
+	if (param->type) {
 		// Unused variable - fix compiler warning
 	}
 

--- a/common_drivers/platform_drivers/platform_drivers.h
+++ b/common_drivers/platform_drivers/platform_drivers.h
@@ -258,7 +258,7 @@ typedef struct {
 
 /* Initialize the I2C communication peripheral. */
 int32_t i2c_init(i2c_desc **desc,
-		 i2c_init_param param);
+		 const i2c_init_param *param);
 
 /* Free the resources allocated by i2c_init(). */
 int32_t i2c_remove(i2c_desc *desc);

--- a/common_drivers/platform_drivers/platform_drivers.h
+++ b/common_drivers/platform_drivers/platform_drivers.h
@@ -277,7 +277,7 @@ int32_t i2c_read(i2c_desc *desc,
 
 /* Initialize the SPI communication peripheral. */
 int32_t spi_init(spi_desc **desc,
-		 spi_init_param param);
+		 const spi_init_param *param);
 
 /* Free the resources allocated by spi_init() */
 int32_t spi_remove(spi_desc *desc);

--- a/drivers/ad4110/ad4110.c
+++ b/drivers/ad4110/ad4110.c
@@ -531,7 +531,7 @@ int32_t ad4110_setup(struct ad4110_dev **device,
 		return -1;
 
 	/* SPI */
-	ret = spi_init(&dev->spi_dev, init_param.spi_init);
+	ret = spi_init(&dev->spi_dev, &init_param.spi_init);
 
 	/* GPIO */
 	ret |= gpio_get(&dev->gpio_reset, init_param.gpio_reset);

--- a/drivers/ad5110/ad5110.c
+++ b/drivers/ad5110/ad5110.c
@@ -68,7 +68,7 @@ int8_t ad5110_init(struct ad5110_dev **device,
 		return -1;
 
 	dev->ad5110_dev_addr = init_param.ad5110_dev_addr;
-	status = i2c_init(&dev->i2c_desc, init_param.i2c_init);
+	status = i2c_init(&dev->i2c_desc, &init_param.i2c_init);
 
 	*device = dev;
 

--- a/drivers/ad525x/ad525x.c
+++ b/drivers/ad525x/ad525x.c
@@ -120,7 +120,7 @@ int8_t ad525x_init(struct ad525x_dev **device,
 		/* CPHA = 0; CPOL = 0; */
 		status = spi_init(&dev->spi_desc, &init_param.spi_init);
 	} else {
-		status = i2c_init(&dev->i2c_desc, init_param.i2c_init);
+		status = i2c_init(&dev->i2c_desc, &init_param.i2c_init);
 	}
 
 	status |= gpio_get(&dev->gpio_reset, init_param.gpio_reset);

--- a/drivers/ad525x/ad525x.c
+++ b/drivers/ad525x/ad525x.c
@@ -118,7 +118,7 @@ int8_t ad525x_init(struct ad525x_dev **device,
 
 	if(chip_info[dev->this_device].comm_type == SPI) {
 		/* CPHA = 0; CPOL = 0; */
-		status = spi_init(&dev->spi_desc, init_param.spi_init);
+		status = spi_init(&dev->spi_desc, &init_param.spi_init);
 	} else {
 		status = i2c_init(&dev->i2c_desc, init_param.i2c_init);
 	}

--- a/drivers/ad5421/ad5421.c
+++ b/drivers/ad5421/ad5421.c
@@ -83,7 +83,7 @@ int32_t ad5421_init(struct ad5421_dev **device,
 	gpio_get(&dev->gpio_faultin, init_param.gpio_faultin);
 
 	/* Setup the SPI interface. */
-	spi_init(&dev->spi_desc, init_param.spi_init);
+	spi_init(&dev->spi_desc, &init_param.spi_init);
 	/* Setup AD5421 control register. */
 	/* Write to the control register. */
 	spi_data = AD5421_CMD(AD5421_CMDWRCTRL);

--- a/drivers/ad5446/ad5446.c
+++ b/drivers/ad5446/ad5446.c
@@ -146,7 +146,7 @@ int8_t ad5446_init(struct ad5446_dev **device,
 
 	dev->act_device = init_param.act_device;
 
-	status = spi_init(&dev->spi_desc, init_param.spi_init);
+	status = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* GPIO */
 	status |= gpio_get(&dev->gpio_ladc, init_param.gpio_ladc);

--- a/drivers/ad5449/ad5449.c
+++ b/drivers/ad5449/ad5449.c
@@ -124,7 +124,7 @@ int8_t ad5449_init(struct ad5449_dev **device,
 	dev->act_device = init_param.act_device;
 
 	/* Initialize SPI communication. */
-	status = spi_init(&dev->spi_desc, init_param.spi_init);
+	status = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* GPIO */
 	status |= gpio_get(&dev->gpio_ldac, init_param.gpio_ldac);

--- a/drivers/ad5628/ad5628.c
+++ b/drivers/ad5628/ad5628.c
@@ -70,7 +70,7 @@ int32_t ad5628_init(struct ad5628_dev **device,
 		return -1;
 
 	/* Initializes communication. */
-	status = spi_init(&dev->spi_desc, init_param.spi_init);
+	status = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* Behaves as a power-on reset. */
 	ad5628_reset(dev);

--- a/drivers/ad5629r/ad5629r.c
+++ b/drivers/ad5629r/ad5629r.c
@@ -105,7 +105,7 @@ int8_t ad5629r_init(struct ad5629r_dev **device,
 	dev->act_device = init_param.act_device;
 
 	if (chip_info[dev->act_device].communication == com_spi) {
-		status = spi_init(&dev->spi_desc, init_param.spi_init);
+		status = spi_init(&dev->spi_desc, &init_param.spi_init);
 	} else {
 		status = i2c_init(&dev->i2c_desc, init_param.i2c_init);
 	}

--- a/drivers/ad5629r/ad5629r.c
+++ b/drivers/ad5629r/ad5629r.c
@@ -107,7 +107,7 @@ int8_t ad5629r_init(struct ad5629r_dev **device,
 	if (chip_info[dev->act_device].communication == com_spi) {
 		status = spi_init(&dev->spi_desc, &init_param.spi_init);
 	} else {
-		status = i2c_init(&dev->i2c_desc, init_param.i2c_init);
+		status = i2c_init(&dev->i2c_desc, &init_param.i2c_init);
 	}
 
 	status |= gpio_get(&dev->gpio_ldac, init_param.gpio_ldac);

--- a/drivers/ad5686/ad5686.c
+++ b/drivers/ad5686/ad5686.c
@@ -105,7 +105,7 @@ int32_t ad5686_init(struct ad5686_dev **device,
 	dev->act_device = init_param.act_device;
 
 	if (chip_info[dev->act_device].communication == SPI)
-		ret = spi_init(&dev->spi_desc, init_param.spi_init);
+		ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 	else
 		ret = i2c_init(&dev->i2c_desc, init_param.i2c_init);
 

--- a/drivers/ad5686/ad5686.c
+++ b/drivers/ad5686/ad5686.c
@@ -107,7 +107,7 @@ int32_t ad5686_init(struct ad5686_dev **device,
 	if (chip_info[dev->act_device].communication == SPI)
 		ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 	else
-		ret = i2c_init(&dev->i2c_desc, init_param.i2c_init);
+		ret = i2c_init(&dev->i2c_desc, &init_param.i2c_init);
 
 
 	/* GPIO */

--- a/drivers/ad5755/ad5755.c
+++ b/drivers/ad5755/ad5755.c
@@ -93,7 +93,7 @@ int8_t ad5755_init(struct ad5755_dev **device,
 	AD5755_POC_OUT;
 	AD5755_POC_LOW;
 
-	status |= spi_init(&dev->spi_desc, init_param.spi_init);
+	status |= spi_init(&dev->spi_desc, &init_param.spi_init);
 	/* Device Setup. */
 	/* Configure the POC bit, STATREAD bit and ShtCcLim bit. */
 	ad5755_set_control_registers(dev,

--- a/drivers/ad5761r/ad5761r.c
+++ b/drivers/ad5761r/ad5761r.c
@@ -669,7 +669,7 @@ int32_t ad5761r_init(struct ad5761r_dev **device,
 	}
 
 	/* SPI */
-	ret = spi_init(&dev->spi_desc, init_param.spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* GPIO */
 	ret |= gpio_get(&dev->gpio_reset, init_param.gpio_reset);

--- a/drivers/ad5766/ad5766.c
+++ b/drivers/ad5766/ad5766.c
@@ -301,7 +301,7 @@ int32_t ad5766_init(struct ad5766_dev **device,
 	}
 
 	/* SPI */
-	ret = spi_init(&dev->spi_desc, init_param.spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* GPIO */
 	ret |= gpio_get(&dev->gpio_reset, init_param.gpio_reset);

--- a/drivers/ad5770r/ad5770r.c
+++ b/drivers/ad5770r/ad5770r.c
@@ -650,7 +650,7 @@ int32_t ad5770r_init(struct ad5770r_dev **device,
 		return FAILURE;
 
 	/* SPI */
-	ret = spi_init(&dev->spi_desc, init_param->spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param->spi_init);
 
 	/* Query device presence */
 	ad5770r_spi_reg_read(dev, AD5770R_PRODUCT_ID_L, &product_id_l);

--- a/drivers/ad5791/ad5791.c
+++ b/drivers/ad5791/ad5791.c
@@ -102,7 +102,7 @@ int32_t ad5791_init(struct ad5791_dev **device,
 	AD5791_CLR_OUT;
 	AD5791_CLR_HIGH;
 
-	status |= spi_init(&dev->spi_desc, init_param.spi_init);
+	status |= spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	*device = dev;
 

--- a/drivers/ad5933/ad5933.c
+++ b/drivers/ad5933/ad5933.c
@@ -84,7 +84,7 @@ int32_t ad5933_init(struct ad5933_dev **device,
 	dev->current_gain = init_param.current_gain;
 	dev->current_range = init_param.current_range;
 
-	status = i2c_init(&dev->i2c_desc, init_param.i2c_init);
+	status = i2c_init(&dev->i2c_desc, &init_param.i2c_init);
 
 	*device = dev;
 

--- a/drivers/ad6673/ad6673.c
+++ b/drivers/ad6673/ad6673.c
@@ -104,7 +104,7 @@ int32_t ad6673_setup(struct ad6673_dev **device,
 		return -1;
 
 	/* Initializes the SPI peripheral */
-	ret = spi_init(&dev->spi_desc, init_param.spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 	if(ret != SUCCESS) {
 		return ret;
 	}

--- a/drivers/ad6676/ad6676.c
+++ b/drivers/ad6676/ad6676.c
@@ -638,7 +638,7 @@ int32_t ad6676_setup(struct ad6676_dev **device,
 		return -1;
 
 	/* SPI */
-	ret = spi_init(&dev->spi_desc, init_param.spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 	if (ret < 0)
 		return ret;
 

--- a/drivers/ad7091r/ad7091r.c
+++ b/drivers/ad7091r/ad7091r.c
@@ -74,7 +74,7 @@ int8_t ad7091r_init(struct ad7091r_dev **device,
 	if (!dev)
 		return -1;
 
-	status = spi_init(&dev->spi_desc, init_param.spi_init);
+	status = spi_init(&dev->spi_desc, &init_param.spi_init);
 	/* Ensures that last state of SDO is high. */
 	spi_write_and_read(dev->spi_desc, &tmp_val, 1);
 	ad7091r_software_reset(dev);

--- a/drivers/ad7124/ad7124.c
+++ b/drivers/ad7124/ad7124.c
@@ -472,7 +472,7 @@ int32_t ad7124_setup(struct ad7124_dev **device,
 	dev->spi_rdy_poll_cnt = init_param.spi_rdy_poll_cnt;
 
 	/* Initialize the SPI communication. */
-	ret = spi_init(&dev->spi_desc, init_param.spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 	if (ret < 0)
 		return ret;
 

--- a/drivers/ad7156/ad7156.c
+++ b/drivers/ad7156/ad7156.c
@@ -119,7 +119,7 @@ int8_t ad7156_init(struct ad7156_dev **device,
 	dev->ad7156_channel1_range = init_param.ad7156_channel1_range;
 	dev->ad7156_channel2_range = init_param.ad7156_channel2_range;
 
-	status = i2c_init(&dev->i2c_desc, init_param.i2c_init);
+	status = i2c_init(&dev->i2c_desc, &init_param.i2c_init);
 	ad7156_get_register_value(dev,
 				  &test,
 				  AD7156_REG_CHIP_ID,

--- a/drivers/ad717x/ad717x.c
+++ b/drivers/ad717x/ad717x.c
@@ -398,7 +398,7 @@ int32_t AD717X_Init(ad717x_dev **device,
         dev->num_regs = init_param.num_regs;
 
         /* Initialize the SPI communication. */
-        ret = spi_init(&dev->spi_desc, init_param.spi_init);
+        ret = spi_init(&dev->spi_desc, &init_param.spi_init);
         if (ret < 0)
                 return ret;
 

--- a/drivers/ad7193/ad7193.c
+++ b/drivers/ad7193/ad7193.c
@@ -78,7 +78,7 @@ int8_t ad7193_init(struct ad7193_dev **device,
 	dev->current_gain = init_param.current_gain;
 
 	/* SPI */
-	status = spi_init(&dev->spi_desc, init_param.spi_init);
+	status = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* GPIO */
 	status |= gpio_get(&dev->gpio_cs, init_param.gpio_cs);

--- a/drivers/ad7280a/ad7280a.c
+++ b/drivers/ad7280a/ad7280a.c
@@ -87,7 +87,7 @@ int8_t ad7280a_init(struct ad7280a_dev **device,
 	/* Wait 250us */
 	mdelay(250);
 
-	status |= spi_init(&dev->spi_desc, init_param.spi_init);
+	status |= spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* Example 1 from the datasheet */
 	/* Configure the Control LB register for all devices */

--- a/drivers/ad7303/ad7303.c
+++ b/drivers/ad7303/ad7303.c
@@ -66,7 +66,7 @@ int8_t ad7303_init(struct ad7303_dev **device,
 	if (!dev)
 		return -1;
 
-	status = spi_init(&dev->spi_desc, init_param.spi_init);
+	status = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	*device = dev;
 

--- a/drivers/ad74xx/ad74xx.c
+++ b/drivers/ad74xx/ad74xx.c
@@ -74,7 +74,7 @@ int8_t ad74xx_init(struct ad74xx_dev **device,
 		return -1;
 
 	/* SPI */
-	status = spi_init(&dev->spi_desc, init_param.spi_init);
+	status = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* GPIO */
 	status |= gpio_get(&dev->gpio_cs, init_param.gpio_cs);

--- a/drivers/ad7779/ad7779.c
+++ b/drivers/ad7779/ad7779.c
@@ -1256,7 +1256,7 @@ int32_t ad7779_init(ad7779_dev **device,
 		return -1;
 
 	/* SPI */
-	ret = spi_init(&dev->spi_desc, init_param.spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* GPIO */
 	ret |= gpio_get(&dev->gpio_reset,

--- a/drivers/ad7780/ad7780.c
+++ b/drivers/ad7780/ad7780.c
@@ -92,7 +92,7 @@ int8_t ad7780_init(struct ad7780_dev **device,
 	AD7780_FILTER_LOW;   // The update rate is set to 16.7 Hz.
 	AD7780_GAIN_HIGH;    // Gain is set to 1.
 	/* SPI */
-	init_status = spi_init(&dev->spi_desc, init_param.spi_init);
+	init_status = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	if(init_status != 0) {
 		return -1;

--- a/drivers/ad7980/ad7980.c
+++ b/drivers/ad7980/ad7980.c
@@ -71,7 +71,7 @@ int8_t ad7980_init(struct ad7980_dev **device,
 		return -1;
 
 	/* SPI */
-	status = spi_init(&dev->spi_desc, init_param.spi_init);
+	status = spi_init(&dev->spi_desc, &init_param.spi_init);
 	/* GPIO */
 	status |= gpio_get(&dev->gpio_cs, init_param.gpio_cs);
 

--- a/drivers/ad799x/ad799x.c
+++ b/drivers/ad799x/ad799x.c
@@ -71,7 +71,7 @@ int8_t ad799x_init(struct ad799x_dev **device,
 		return -1;
 
 	/* Initialize I2C peripheral. */
-	status = i2c_init(&dev->i2c_desc, init_param.i2c_init);
+	status = i2c_init(&dev->i2c_desc, &init_param.i2c_init);
 
 	/* Determine the number of bits available for a conversion. */
 	switch(init_param.part_number) {

--- a/drivers/ad9144/ad9144.c
+++ b/drivers/ad9144/ad9144.c
@@ -120,7 +120,7 @@ int32_t ad9144_spi_check_status(struct ad9144_dev *dev,
  * @brief ad9144_setup
 ********************************************************************************/
 int32_t ad9144_setup(struct ad9144_dev **device,
-		     struct ad9144_init_param init_param)
+		     const struct ad9144_init_param *init_param)
 {
 	uint8_t chip_id;
 	uint8_t scratchpad;
@@ -132,7 +132,7 @@ int32_t ad9144_setup(struct ad9144_dev **device,
 		return -1;
 
 	/* SPI */
-	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param->spi_init);
 	if (ret == -1)
 		printf("%s : Device descriptor failed!\n", __func__);
 
@@ -207,9 +207,9 @@ int32_t ad9144_setup(struct ad9144_dev **device,
 	ad9144_spi_write(dev, REG_TERM_BLK1_CTRLREG0, 0x01);	// input termination calibration
 	ad9144_spi_write(dev, REG_TERM_BLK2_CTRLREG0, 0x01);	// input termination calibration
 	ad9144_spi_write(dev, REG_SERDES_SPI_REG, 0x01);	// pclk == qbd master clock
-	if (init_param.lane_rate_kbps < 2880000)
+	if (init_param->lane_rate_kbps < 2880000)
 		ad9144_spi_write(dev, REG_CDR_OPERATING_MODE_REG_0, 0x0A);		// CDR_OVERSAMP
-	else if (init_param.lane_rate_kbps > 5520000)
+	else if (init_param->lane_rate_kbps > 5520000)
 		ad9144_spi_write(dev, REG_CDR_OPERATING_MODE_REG_0,
 				 0x28);	// ENHALFRATE
 	else
@@ -217,9 +217,9 @@ int32_t ad9144_setup(struct ad9144_dev **device,
 				 0x08);
 	ad9144_spi_write(dev, REG_CDR_RESET, 0x00);	// cdr reset
 	ad9144_spi_write(dev, REG_CDR_RESET, 0x01);	// cdr reset
-	if (init_param.lane_rate_kbps < 2880000)
+	if (init_param->lane_rate_kbps < 2880000)
 		ad9144_spi_write(dev, REG_REF_CLK_DIVIDER_LDO, 0x06);		// data-rate < 2.88 Gbps
-	else if (init_param.lane_rate_kbps > 5520000)
+	else if (init_param->lane_rate_kbps > 5520000)
 		ad9144_spi_write(dev, REG_REF_CLK_DIVIDER_LDO, 0x04);	// data-rate > 5.52 Gbps
 	else
 		ad9144_spi_write(dev, REG_REF_CLK_DIVIDER_LDO, 0x05);
@@ -331,7 +331,7 @@ int32_t ad9144_status(struct ad9144_dev *dev)
  * @brief ad9144_short_pattern_test
  *******************************************************************************/
 int32_t ad9144_short_pattern_test(struct ad9144_dev *dev,
-				  struct ad9144_init_param init_param)
+				  const struct ad9144_init_param *init_param)
 {
 
 	uint32_t dac = 0;
@@ -339,14 +339,14 @@ int32_t ad9144_short_pattern_test(struct ad9144_dev *dev,
 	uint8_t status = 0;
 	int32_t ret = 0;
 
-	for (dac = 0; dac < init_param.active_converters; dac++) {
+	for (dac = 0; dac < init_param->active_converters; dac++) {
 		for (sample = 0; sample < 4; sample++) {
 			ad9144_spi_write(dev, REG_SHORT_TPL_TEST_0,
 					 ((sample << 4) | (dac << 2) | 0x00));
 			ad9144_spi_write(dev, REG_SHORT_TPL_TEST_2,
-					 (init_param.stpl_samples[dac][sample]>>8));
+					 (init_param->stpl_samples[dac][sample]>>8));
 			ad9144_spi_write(dev, REG_SHORT_TPL_TEST_1,
-					 (init_param.stpl_samples[dac][sample]>>0));
+					 (init_param->stpl_samples[dac][sample]>>0));
 			ad9144_spi_write(dev, REG_SHORT_TPL_TEST_0,
 					 ((sample << 4) | (dac << 2) | 0x01));
 			ad9144_spi_write(dev, REG_SHORT_TPL_TEST_0,
@@ -360,7 +360,7 @@ int32_t ad9144_short_pattern_test(struct ad9144_dev *dev,
 			if (ret == -1)
 				printf("%s : short-pattern-test mismatch (0x%x, 0x%x 0x%x, 0x%x)!.\n",
 				       __func__, dac, sample,
-				       init_param.stpl_samples[dac][sample],
+				       init_param->stpl_samples[dac][sample],
 				       status);
 		}
 	}
@@ -371,15 +371,15 @@ int32_t ad9144_short_pattern_test(struct ad9144_dev *dev,
  * @brief ad9144_datapath_prbs_test
  *******************************************************************************/
 int32_t ad9144_datapath_prbs_test(struct ad9144_dev *dev,
-				  struct ad9144_init_param init_param)
+				  const struct ad9144_init_param *init_param)
 {
 
 	uint8_t status = 0;
 	int32_t ret = 0;
 
 
-	ad9144_spi_write(dev, REG_PRBS, ((init_param.prbs_type << 2) | 0x03));
-	ad9144_spi_write(dev, REG_PRBS, ((init_param.prbs_type << 2) | 0x01));
+	ad9144_spi_write(dev, REG_PRBS, ((init_param->prbs_type << 2) | 0x03));
+	ad9144_spi_write(dev, REG_PRBS, ((init_param->prbs_type << 2) | 0x01));
 	mdelay(500);
 
 	ad9144_spi_write(dev, REG_SPI_PAGEINDX, 0x01);

--- a/drivers/ad9144/ad9144.c
+++ b/drivers/ad9144/ad9144.c
@@ -132,7 +132,7 @@ int32_t ad9144_setup(struct ad9144_dev **device,
 		return -1;
 
 	/* SPI */
-	ret = spi_init(&dev->spi_desc, init_param.spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 	if (ret == -1)
 		printf("%s : Device descriptor failed!\n", __func__);
 

--- a/drivers/ad9144/ad9144.h
+++ b/drivers/ad9144/ad9144.h
@@ -1373,7 +1373,7 @@ struct ad9144_init_param {
 /************************ Functions Declarations ******************************/
 /******************************************************************************/
 int32_t ad9144_setup(struct ad9144_dev **device,
-		     struct ad9144_init_param init_param);
+		     const struct ad9144_init_param *init_param);
 
 int32_t ad9144_remove(struct ad9144_dev *dev);
 
@@ -1393,9 +1393,9 @@ int32_t ad9144_spi_check_status(struct ad9144_dev *dev,
 int32_t ad9144_status(struct ad9144_dev *dev);
 
 int32_t ad9144_short_pattern_test(struct ad9144_dev *dev,
-				  struct ad9144_init_param init_param);
+				  const struct ad9144_init_param *init_param);
 
 int32_t ad9144_datapath_prbs_test(struct ad9144_dev *dev,
-				  struct ad9144_init_param init_param);
+				  const struct ad9144_init_param *init_param);
 
 #endif

--- a/drivers/ad9152/ad9152.c
+++ b/drivers/ad9152/ad9152.c
@@ -107,7 +107,7 @@ int32_t ad9152_setup(struct ad9152_dev **device,
 		return -1;
 
 	/* SPI */
-	ret = spi_init(&dev->spi_desc, init_param.spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	ret = 0;
 

--- a/drivers/ad9250/ad9250.c
+++ b/drivers/ad9250/ad9250.c
@@ -105,7 +105,7 @@ int32_t ad9250_setup(struct ad9250_dev **device,
 		dev->shadow_regs[i] = shadow_regs[i];
 
 	/* Initializes the SPI peripheral */
-	ret = spi_init(&dev->spi_desc, init_param.spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 	if(ret != SUCCESS) {
 		return ret;
 	}

--- a/drivers/ad9265/ad9265.c
+++ b/drivers/ad9265/ad9265.c
@@ -308,7 +308,7 @@ int32_t ad9265_setup(struct ad9265_dev **device,
 		return -1;
 
 	/* SPI */
-	ret = spi_init(&dev->spi_desc, init_param.spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	ad9265_spi_read(dev, AD9265_REG_CHIP_ID, &chip_id);
 	if(chip_id != AD9265_CHIP_ID) {

--- a/drivers/ad9434/ad9434.c
+++ b/drivers/ad9434/ad9434.c
@@ -154,7 +154,7 @@ int32_t ad9434_setup(struct ad9434_dev **device,
 		return -1;
 
 	/* SPI */
-	ret = spi_init(&dev->spi_desc, init_param.spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	ret |= ad9434_spi_read(dev, AD9434_REG_CHIP_ID, &chip_id);
 	if(chip_id != AD9434_CHIP_ID) {

--- a/drivers/ad9467/ad9467.c
+++ b/drivers/ad9467/ad9467.c
@@ -65,7 +65,7 @@ int32_t ad9467_setup(struct ad9467_dev **device,
 		return -1;
 
 	/* SPI */
-	ret = spi_init(&dev->spi_desc, init_param.spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* Disable test mode. */
 	ret = ad9467_write(dev, AD9467_REG_TEST_IO, 0x00);

--- a/drivers/ad9517/ad9517.c
+++ b/drivers/ad9517/ad9517.c
@@ -75,7 +75,7 @@ int32_t ad9517_setup(struct ad9517_dev **device,
 	dev->ad9517_st.lvds_cmos_channels = &ad9517_lvds_cmos_channels[0];
 
 	/* Initializes the SPI peripheral */
-	ret = spi_init(&dev->spi_desc, init_param.spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* Configure serial port for long instructions and reset the serial
 	 * interface. */

--- a/drivers/ad9523/ad9523.c
+++ b/drivers/ad9523/ad9523.c
@@ -409,7 +409,7 @@ int32_t ad9523_init(struct ad9523_init_param *init_param)
  * @return Returns 0 in case of success or negative error code.
  *******************************************************************************/
 int32_t ad9523_setup(struct ad9523_dev **device,
-		     struct ad9523_init_param init_param)
+		     const struct ad9523_init_param *init_param)
 
 {
 	struct ad9523_channel_spec *chan;
@@ -424,11 +424,11 @@ int32_t ad9523_setup(struct ad9523_dev **device,
 		return -1;
 
 	/* SPI */
-	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param->spi_init);
 	if (ret < 0)
 		return ret;
 
-	dev->pdata = init_param.pdata;
+	dev->pdata = init_param->pdata;
 
 	ret = ad9523_spi_write(dev,
 			       AD9523_SERIAL_PORT_CONFIG,

--- a/drivers/ad9523/ad9523.c
+++ b/drivers/ad9523/ad9523.c
@@ -424,7 +424,7 @@ int32_t ad9523_setup(struct ad9523_dev **device,
 		return -1;
 
 	/* SPI */
-	ret = spi_init(&dev->spi_desc, init_param.spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 	if (ret < 0)
 		return ret;
 

--- a/drivers/ad9523/ad9523.h
+++ b/drivers/ad9523/ad9523.h
@@ -512,7 +512,7 @@ int32_t ad9523_init(struct ad9523_init_param *init_param);
 
 /* Configure the AD9523. */
 int32_t ad9523_setup(struct ad9523_dev **device,
-		     struct ad9523_init_param init_param);
+		     const struct ad9523_init_param *init_param);
 
 /* Free the resources allocated by ad9523_setup(). */
 int32_t ad9523_remove(struct ad9523_dev *dev);

--- a/drivers/ad9528/ad9528.c
+++ b/drivers/ad9528/ad9528.c
@@ -344,7 +344,7 @@ int32_t ad9528_setup(struct ad9528_dev **device,
 	dev->pdata = init_param.pdata;
 
 	/* SPI */
-	ret = spi_init(&dev->spi_desc, init_param.spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 	if (ret < 0)
 		return ret;
 

--- a/drivers/ad9625/ad9625.c
+++ b/drivers/ad9625/ad9625.c
@@ -105,7 +105,7 @@ int32_t ad9625_setup(struct ad9625_dev **device,
 		return -1;
 
 	/* SPI */
-	ret = spi_init(&dev->spi_desc, init_param.spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	ad9625_spi_write(dev, AD9625_REG_CHIP_PORT_CONF, 0x18);
 	ad9625_spi_write(dev, AD9625_REG_TRANSFER, 0x01);

--- a/drivers/ad9680/ad9680.c
+++ b/drivers/ad9680/ad9680.c
@@ -129,7 +129,7 @@ int32_t ad9680_setup(struct ad9680_dev **device,
 		return -1;
 
 	/* SPI */
-	ret = spi_init(&dev->spi_desc, init_param.spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	ad9680_spi_read(dev,
 			AD9680_REG_CHIP_ID_LOW,

--- a/drivers/ad9680/ad9680.c
+++ b/drivers/ad9680/ad9680.c
@@ -115,7 +115,7 @@ int32_t ad9680_test(struct ad9680_dev *dev,
  * @brief ad9680_setup
  *******************************************************************************/
 int32_t ad9680_setup(struct ad9680_dev **device,
-		     struct ad9680_init_param init_param)
+		     const struct ad9680_init_param *init_param)
 {
 	uint8_t chip_id;
 	uint8_t pll_stat;
@@ -129,7 +129,7 @@ int32_t ad9680_setup(struct ad9680_dev **device,
 		return -1;
 
 	/* SPI */
-	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param->spi_init);
 
 	ad9680_spi_read(dev,
 			AD9680_REG_CHIP_ID_LOW,
@@ -159,7 +159,7 @@ int32_t ad9680_setup(struct ad9680_dev **device,
 	ad9680_spi_write(dev,
 			 AD9680_REG_JESD204B_QUICK_CONFIG,
 			 0x88);	// m=2, l=4, f= 1
-	if (init_param.lane_rate_kbps < 6250000)
+	if (init_param->lane_rate_kbps < 6250000)
 		ad9680_spi_write(dev,
 				 AD9680_REG_JESD204B_LANE_RATE_CTRL,
 				 0x10);	// low line rate mode must be enabled

--- a/drivers/ad9680/ad9680.h
+++ b/drivers/ad9680/ad9680.h
@@ -98,7 +98,7 @@ int32_t ad9680_spi_write(struct ad9680_dev *dev,
 			 uint8_t reg_data);
 
 int32_t ad9680_setup(struct ad9680_dev **device,
-		     struct ad9680_init_param init_param);
+		     const struct ad9680_init_param *init_param);
 
 int32_t ad9680_remove(struct ad9680_dev *dev);
 

--- a/drivers/ad9739a/ad9739a.c
+++ b/drivers/ad9739a/ad9739a.c
@@ -290,7 +290,7 @@ int32_t ad9739a_setup(struct ad9739a_dev **device,
 		return -1;
 
 	/* SPI */
-	ret = spi_init(&dev->spi_desc, init_param.spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* Device ID */
 	ad9739a_read(dev, AD9739A_REG_PART_ID, &chip_id);

--- a/drivers/ad9833/ad9833.c
+++ b/drivers/ad9833/ad9833.c
@@ -122,7 +122,7 @@ int8_t ad9833_init(struct ad9833_dev **device,
 
 	/* Setup SPI interface. */
 	status = spi_init(&dev->spi_desc,
-			  init_param.spi_init);
+			  &init_param.spi_init);
 	/* Initialize board. */
 	spi_data |= AD9833_CTRLRESET;
 	ad9833_tx_spi(dev,

--- a/drivers/adf4106/adf4106.c
+++ b/drivers/adf4106/adf4106.c
@@ -117,7 +117,7 @@ int8_t adf4106_init(struct adf4106_dev **device,
 	dev->i_latch = 0;
 
 	/* CPHA = 1; CPOL = 0; */
-	status = spi_init(&dev->spi_desc, init_param.spi_init);
+	status = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* GPIO */
 	status |= gpio_get(&dev->gpio_le, init_param.gpio_le);

--- a/drivers/adf4153/adf4153.c
+++ b/drivers/adf4153/adf4153.c
@@ -96,7 +96,7 @@ int8_t adf4153_init(struct adf4153_dev **device,
 	dev->r3 = 0;
 
 	/* CPHA = 1; CPOL = 0; */
-	status = spi_init(&dev->spi_desc, init_param.spi_init);
+	status = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* GPIO */
 	status |= gpio_get(&dev->gpio_le, init_param.gpio_le);

--- a/drivers/adf4156/adf4156.c
+++ b/drivers/adf4156/adf4156.c
@@ -82,7 +82,7 @@ int8_t adf4156_init(struct adf4156_dev **device,
 	//ADF4156_CE2_OUT;
 
 	/* Setup SPI Interface */
-	status |= spi_init(&dev->spi_desc, init_param.spi_init);
+	status |= spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* R4 */
 	cfg_value = adf4156_pdata_lpc.r4_user_settings |

--- a/drivers/adf4157/adf4157.c
+++ b/drivers/adf4157/adf4157.c
@@ -81,7 +81,7 @@ int8_t adf4157_init(struct adf4157_dev **device,
 	//ADF4157_CE2_OUT;
 
 	/* Setup SPI Interface */
-	status |= spi_init(&dev->spi_desc, init_param.spi_init);
+	status |= spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* R4 */
 	cfg_value = adf4157_pdata_lpc.r4_user_settings |

--- a/drivers/adf4350/adf4350.c
+++ b/drivers/adf4350/adf4350.c
@@ -302,7 +302,7 @@ int32_t adf4350_setup(adf4350_dev **device,
 	}
 
 	/* SPI */
-	ret = spi_init(&dev->spi_desc, init_param.spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	dev->pdata = (struct adf4350_platform_data *)malloc(sizeof(*dev->pdata));
 	if (!dev->pdata)

--- a/drivers/adf7023/adf7023.c
+++ b/drivers/adf7023/adf7023.c
@@ -107,7 +107,7 @@ int32_t adf7023_init(struct adf7023_dev **device,
 		return -1;
 
 	/* SPI */
-	ret = spi_init(&dev->spi_desc, init_param.spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* GPIO */
 	ret |= gpio_get(&dev->gpio_cs, init_param.gpio_cs);

--- a/drivers/adgs1408/adgs1408.c
+++ b/drivers/adgs1408/adgs1408.c
@@ -400,7 +400,7 @@ int32_t adgs1408_init(struct adgs1408_dev **device,
 		return -1;
 
 	/* SPI */
-	ret = spi_init(&dev->spi_desc, init_param.spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 	ret |= adgs1408_do_soft_reset(dev);
 
 	/* Device Settings */

--- a/drivers/adgs5412/adgs5412.c
+++ b/drivers/adgs5412/adgs5412.c
@@ -333,7 +333,7 @@ int32_t adgs5412_init(adgs5412_dev **device,
 		return -1;
 
 	/* SPI */
-	ret = spi_init(&dev->spi_desc, init_param.spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* Device Settings */
 	dev->crc_en = ADGS5412_DISABLE;

--- a/drivers/adp5589/adp5589.c
+++ b/drivers/adp5589/adp5589.c
@@ -115,7 +115,7 @@ int8_t adp5589_init(struct adp5589_dev **device,
 	if (!dev)
 		return -1;
 
-	status = i2c_init(&dev->i2c_desc, init_param.i2c_init);
+	status = i2c_init(&dev->i2c_desc, &init_param.i2c_init);
 	if((adp5589_get_register_value(dev,ADP5589_ADR_ID) & ADP5589_ID_MAN_ID) !=
 	    ADP5589_ID) {
 		status = -1;

--- a/drivers/adt7420/adt7420.c
+++ b/drivers/adt7420/adt7420.c
@@ -119,7 +119,7 @@ int32_t adt7420_init(struct adt7420_dev **device,
 		return -1;
 
 	/* I2C */
-	status = i2c_init(&dev->i2c_desc, init_param.i2c_init);
+	status = i2c_init(&dev->i2c_desc, &init_param.i2c_init);
 
 	/* Device Settings */
 	dev->resolution_setting = init_param.resolution_setting;

--- a/drivers/adxl345/adxl345.c
+++ b/drivers/adxl345/adxl345.c
@@ -142,7 +142,7 @@ int32_t adxl345_init(struct adxl345_dev **device,
 	dev->communication_type = init_param.communication_type;
 
 	if (dev->communication_type == ADXL345_SPI_COMM)
-		status = spi_init(&dev->spi_desc, init_param.spi_init);
+		status = spi_init(&dev->spi_desc, &init_param.spi_init);
 	else
 		status = i2c_init(&dev->i2c_desc, init_param.i2c_init);
 

--- a/drivers/adxl345/adxl345.c
+++ b/drivers/adxl345/adxl345.c
@@ -144,7 +144,7 @@ int32_t adxl345_init(struct adxl345_dev **device,
 	if (dev->communication_type == ADXL345_SPI_COMM)
 		status = spi_init(&dev->spi_desc, &init_param.spi_init);
 	else
-		status = i2c_init(&dev->i2c_desc, init_param.i2c_init);
+		status = i2c_init(&dev->i2c_desc, &init_param.i2c_init);
 
 	if (adxl345_get_register_value(dev, ADXL345_DEVID) != ADXL345_ID)
 		status = -1;

--- a/drivers/adxl362/adxl362.c
+++ b/drivers/adxl362/adxl362.c
@@ -72,7 +72,7 @@ int32_t adxl362_init(struct adxl362_dev **device,
 		return -1;
 
 	/* SPI */
-	status = spi_init(&dev->spi_desc, init_param.spi_init);
+	status = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	adxl362_get_register_value(dev, &reg_value, ADXL362_REG_PARTID, 1);
 	if((reg_value != ADXL362_PART_ID))

--- a/drivers/adxl372/adxl372.c
+++ b/drivers/adxl372/adxl372.c
@@ -715,7 +715,7 @@ int32_t adxl372_init(adxl372_dev **device,
 		return -1;
 
 	/* SPI */
-	ret = spi_init(&dev->spi_desc, init_param.spi_init);
+	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* GPIO */
 	ret |= gpio_get(&dev->gpio_int1,

--- a/drivers/adxrs453/adxrs453.c
+++ b/drivers/adxrs453/adxrs453.c
@@ -68,7 +68,7 @@ int32_t adxrs453_init(struct adxrs453_dev **device,
 	if (!dev)
 		return -1;
 
-	status = spi_init(&dev->spi_desc, init_param.spi_init);
+	status = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* Read the value of the ADXRS453 ID register. */
 	adxrs453_id = adxrs453_get_register_value(dev, ADXRS453_REG_PID);

--- a/drivers/generic_platform/platform_drivers.c
+++ b/drivers/generic_platform/platform_drivers.c
@@ -156,13 +156,13 @@ int32_t i2c_read(struct i2c_desc *desc,
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t spi_init(struct spi_desc **desc,
-		 struct spi_init_param param)
+		 const struct spi_init_param *param)
 {
 	if (desc) {
 		// Unused variable - fix compiler warning
 	}
 
-	if (param.type) {
+	if (param->type) {
 		// Unused variable - fix compiler warning
 	}
 

--- a/drivers/generic_platform/platform_drivers.c
+++ b/drivers/generic_platform/platform_drivers.c
@@ -54,13 +54,13 @@
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t i2c_init(struct i2c_desc **desc,
-		 struct i2c_init_param param)
+		 const struct i2c_init_param *param)
 {
 	if (desc) {
 		// Unused variable - fix compiler warning
 	}
 
-	if (param.type) {
+	if (param->type) {
 		// Unused variable - fix compiler warning
 	}
 

--- a/drivers/generic_platform/platform_drivers.h
+++ b/drivers/generic_platform/platform_drivers.h
@@ -140,7 +140,7 @@ int32_t i2c_read(struct i2c_desc *desc,
 
 /* Initialize the SPI communication peripheral. */
 int32_t spi_init(struct spi_desc **desc,
-		 struct spi_init_param param);
+		 const struct spi_init_param *param);
 
 /* Free the resources allocated by spi_init() */
 int32_t spi_remove(struct spi_desc *desc);

--- a/drivers/generic_platform/platform_drivers.h
+++ b/drivers/generic_platform/platform_drivers.h
@@ -121,7 +121,7 @@ typedef struct gpio_desc {
 
 /* Initialize the I2C communication peripheral. */
 int32_t i2c_init(struct i2c_desc **desc,
-		 struct i2c_init_param param);
+		 const struct i2c_init_param *param);
 
 /* Free the resources allocated by i2c_init(). */
 int32_t i2c_remove(struct i2c_desc *desc);

--- a/drivers/linux_platform/platform_drivers.c
+++ b/drivers/linux_platform/platform_drivers.c
@@ -180,8 +180,7 @@ int32_t i2c_read(i2c_desc *desc,
  * @param init_param - The structure that contains the SPI parameters.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t spi_init(spi_desc **desc,
-		 spi_init_param param)
+int32_t spi_init(spi_desc **desc, const spi_init_param *param)
 {
 	spi_desc *descriptor;
 	int ret;
@@ -190,21 +189,21 @@ int32_t spi_init(spi_desc **desc,
 	if (!descriptor)
 		return FAILURE;
 
-	descriptor->fd = open(param.pathname, O_RDWR);
+	descriptor->fd = open(param->pathname, O_RDWR);
 	if (descriptor->fd < 0) {
 		printf("%s: Can't open device\n\r", __func__);
 		return FAILURE;
 	}
 
 	ret = ioctl(descriptor->fd, SPI_IOC_WR_MODE,
-			&param.mode);
+			&param->mode);
 	if (ret == -1) {
 		printf("%s: Can't set mode\n\r", __func__);
 		return FAILURE;
 	}
 
 	ret = ioctl(descriptor->fd, SPI_IOC_WR_MAX_SPEED_HZ,
-			&param.max_speed_hz);
+			&param->max_speed_hz);
 	if (ret == -1) {
 		printf("%s: Can't set speed\n\r", __func__);
 		return FAILURE;

--- a/drivers/linux_platform/platform_drivers.c
+++ b/drivers/linux_platform/platform_drivers.c
@@ -61,7 +61,7 @@
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t i2c_init(i2c_desc **desc,
-		 i2c_init_param param)
+		 const i2c_init_param *param)
 {
 	i2c_desc *descriptor;
 
@@ -69,13 +69,13 @@ int32_t i2c_init(i2c_desc **desc,
 	if (!descriptor)
 		return FAILURE;
 
-	descriptor->fd = open(param.pathname, O_RDWR);
+	descriptor->fd = open(param->pathname, O_RDWR);
 	if (descriptor->fd < 0) {
 		printf("%s: Can't open device\n\r", __func__);
 		return FAILURE;
 	}
 
-	descriptor->slave_address = param.slave_address;
+	descriptor->slave_address = param->slave_address;
 
 	*desc = descriptor;
 

--- a/drivers/linux_platform/platform_drivers.h
+++ b/drivers/linux_platform/platform_drivers.h
@@ -125,7 +125,7 @@ typedef struct {
 
 /* Initialize the I2C communication peripheral. */
 int32_t i2c_init(i2c_desc **desc,
-		 i2c_init_param param);
+		 const i2c_init_param *param);
 
 /* Free the resources allocated by i2c_init(). */
 int32_t i2c_remove(i2c_desc *desc);

--- a/drivers/linux_platform/platform_drivers.h
+++ b/drivers/linux_platform/platform_drivers.h
@@ -144,7 +144,7 @@ int32_t i2c_read(i2c_desc *desc,
 
 /* Initialize the SPI communication peripheral. */
 int32_t spi_init(spi_desc **desc,
-		 spi_init_param param);
+		 const spi_init_param *param);
 
 /* Free the resources allocated by spi_init() */
 int32_t spi_remove(spi_desc *desc);

--- a/fmcadc2/fmcadc2.c
+++ b/fmcadc2/fmcadc2.c
@@ -115,13 +115,13 @@ int main(void)
 	// set up the device
 	ad9625_setup(&ad9625_device, ad9625_param);
 	// set up the JESD core
-	jesd_setup(ad9625_jesd);
+	jesd_setup(&ad9625_jesd);
 	// set up the XCVRs
 	xcvr_setup(&ad9625_xcvr);
 	// generate SYSREF
-	jesd_sysref_control(ad9625_jesd, 1);
+	jesd_sysref_control(&ad9625_jesd, 1);
 	// JESD core status
-	axi_jesd204_rx_status_read(ad9625_jesd);
+	axi_jesd204_rx_status_read(&ad9625_jesd);
 
 	// interface core setup
 	adc_setup(ad9625_core);

--- a/fmcadc4/fmcadc4.c
+++ b/fmcadc4/fmcadc4.c
@@ -256,9 +256,9 @@ int main(void)
 
 	ad9680_setup(&ad9680_0_device, &ad9680_0_param);
 	ad9680_setup(&ad9680_1_device, &ad9680_1_param);
-	jesd_setup(ad9680_jesd);
+	jesd_setup(&ad9680_jesd);
 	xcvr_setup(&ad9680_xcvr);
-	axi_jesd204_rx_status_read(ad9680_jesd);
+	axi_jesd204_rx_status_read(&ad9680_jesd);
 
 	adc_setup(ad9680_0_core);
 	ad9680_test(ad9680_0_device, AD9680_TEST_PN9);

--- a/fmcadc4/fmcadc4.c
+++ b/fmcadc4/fmcadc4.c
@@ -254,8 +254,8 @@ int main(void)
 
 	ad9528_setup(&ad9528_device, ad9528_param);
 
-	ad9680_setup(&ad9680_0_device, ad9680_0_param);
-	ad9680_setup(&ad9680_1_device, ad9680_1_param);
+	ad9680_setup(&ad9680_0_device, &ad9680_0_param);
+	ad9680_setup(&ad9680_1_device, &ad9680_1_param);
 	jesd_setup(ad9680_jesd);
 	xcvr_setup(&ad9680_xcvr);
 	axi_jesd204_rx_status_read(ad9680_jesd);

--- a/fmcadc5/fmcadc5.c
+++ b/fmcadc5/fmcadc5.c
@@ -200,8 +200,8 @@ int main(void)
 	i5g_init_param.regs = XPAR_AXI_FMCADC5_SYNC_BASEADDR;
 
 	/* Set up the JESD core */
-	jesd_setup(ad9625_0_jesd);
-	jesd_setup(ad9625_1_jesd);
+	jesd_setup(&ad9625_0_jesd);
+	jesd_setup(&ad9625_1_jesd);
 
 	/* Set up the XCVRs */
 	xcvr_setup(&ad9625_0_xcvr);
@@ -212,14 +212,14 @@ int main(void)
 	adc_setup(ad9625_1_core);
 
 	/* JESD core status */
-	axi_jesd204_rx_status_read(ad9625_0_jesd);
-	axi_jesd204_rx_status_read(ad9625_1_jesd);
+	axi_jesd204_rx_status_read(&ad9625_0_jesd);
+	axi_jesd204_rx_status_read(&ad9625_1_jesd);
 
 	i5g_setup(&i5g_core, i5g_init_param);
 
 	/* JESD core status */
-	axi_jesd204_rx_status_read(ad9625_0_jesd);
-	axi_jesd204_rx_status_read(ad9625_1_jesd);
+	axi_jesd204_rx_status_read(&ad9625_0_jesd);
+	axi_jesd204_rx_status_read(&ad9625_1_jesd);
 
 	/* PRBS test */
 	ad9625_test(ad9625_0_device, AD9625_TEST_PNLONG);

--- a/fmcdaq2/fmcdaq2.c
+++ b/fmcdaq2/fmcdaq2.c
@@ -507,7 +507,7 @@ int main(void)
 
 	// setup clocks
 
-	ad9523_setup(&ad9523_device, ad9523_param);
+	ad9523_setup(&ad9523_device, &ad9523_param);
 
 	// set up the devices
 	ad9680_setup(&ad9680_device, ad9680_param);

--- a/fmcdaq2/fmcdaq2.c
+++ b/fmcdaq2/fmcdaq2.c
@@ -514,8 +514,8 @@ int main(void)
 	ad9144_setup(&ad9144_device, &ad9144_param);
 
 	// set up the JESD core
-	jesd_setup(ad9680_jesd);
-	jesd_setup(ad9144_jesd);
+	jesd_setup(&ad9680_jesd);
+	jesd_setup(&ad9144_jesd);
 
 	// set up the XCVRs
 #ifdef ALTERA
@@ -534,8 +534,8 @@ int main(void)
 #endif
 
 	// JESD core status
-	axi_jesd204_tx_status_read(ad9144_jesd);
-	axi_jesd204_rx_status_read(ad9680_jesd);
+	axi_jesd204_tx_status_read(&ad9144_jesd);
+	axi_jesd204_rx_status_read(&ad9680_jesd);
 
 	// interface core set up
 	adc_setup(ad9680_core);

--- a/fmcdaq2/fmcdaq2.c
+++ b/fmcdaq2/fmcdaq2.c
@@ -511,7 +511,7 @@ int main(void)
 
 	// set up the devices
 	ad9680_setup(&ad9680_device, ad9680_param);
-	ad9144_setup(&ad9144_device, ad9144_param);
+	ad9144_setup(&ad9144_device, &ad9144_param);
 
 	// set up the JESD core
 	jesd_setup(ad9680_jesd);
@@ -550,7 +550,7 @@ int main(void)
 	ad9144_channels[0].sel = DAC_SRC_SED;
 	ad9144_channels[1].sel = DAC_SRC_SED;
 	dac_data_setup(&ad9144_core);
-	ad9144_short_pattern_test(ad9144_device, ad9144_param);
+	ad9144_short_pattern_test(ad9144_device, &ad9144_param);
 
 	// PN7 data path test
 
@@ -558,7 +558,7 @@ int main(void)
 	ad9144_channels[1].sel = DAC_SRC_PN23;
 	dac_data_setup(&ad9144_core);
 	ad9144_param.prbs_type = AD9144_PRBS7;
-	ad9144_datapath_prbs_test(ad9144_device, ad9144_param);
+	ad9144_datapath_prbs_test(ad9144_device, &ad9144_param);
 
 	// PN15 data path test
 
@@ -566,7 +566,7 @@ int main(void)
 	ad9144_channels[1].sel = DAC_SRC_PN31;
 	dac_data_setup(&ad9144_core);
 	ad9144_param.prbs_type = AD9144_PRBS15;
-	ad9144_datapath_prbs_test(ad9144_device, ad9144_param);
+	ad9144_datapath_prbs_test(ad9144_device, &ad9144_param);
 
 //******************************************************************************
 // receive path testing

--- a/fmcdaq2/fmcdaq2.c
+++ b/fmcdaq2/fmcdaq2.c
@@ -510,7 +510,7 @@ int main(void)
 	ad9523_setup(&ad9523_device, &ad9523_param);
 
 	// set up the devices
-	ad9680_setup(&ad9680_device, ad9680_param);
+	ad9680_setup(&ad9680_device, &ad9680_param);
 	ad9144_setup(&ad9144_device, &ad9144_param);
 
 	// set up the JESD core

--- a/fmcdaq3/fmcdaq3.c
+++ b/fmcdaq3/fmcdaq3.c
@@ -300,9 +300,9 @@ int main(void)
 
 	ad9152_setup(&ad9152_device, ad9152_param);
 
-	jesd_setup(ad9152_jesd);
+	jesd_setup(&ad9152_jesd);
 	xcvr_setup(&ad9152_xcvr);
-	axi_jesd204_tx_status_read(ad9152_jesd);
+	axi_jesd204_tx_status_read(&ad9152_jesd);
 	dac_setup(&ad9152_core);
 	ad9152_status(ad9152_device);
 
@@ -328,9 +328,9 @@ int main(void)
 	ad9152_datapath_prbs_test(ad9152_device, ad9152_param);
 
 	ad9680_setup(&ad9680_device, &ad9680_param);
-	jesd_setup(ad9680_jesd);
+	jesd_setup(&ad9680_jesd);
 	xcvr_setup(&ad9680_xcvr);
-	axi_jesd204_tx_status_read(ad9680_jesd);
+	axi_jesd204_tx_status_read(&ad9680_jesd);
 	adc_setup(ad9680_core);
 	ad9680_test(ad9680_device, AD9680_TEST_PN9);
 	if(adc_pn_mon(ad9680_core, ADC_PN9) == -1) {

--- a/fmcdaq3/fmcdaq3.c
+++ b/fmcdaq3/fmcdaq3.c
@@ -327,7 +327,7 @@ int main(void)
 	ad9152_param.prbs_type = AD9152_TEST_PN15;
 	ad9152_datapath_prbs_test(ad9152_device, ad9152_param);
 
-	ad9680_setup(&ad9680_device, ad9680_param);
+	ad9680_setup(&ad9680_device, &ad9680_param);
 	jesd_setup(ad9680_jesd);
 	xcvr_setup(&ad9680_xcvr);
 	axi_jesd204_tx_status_read(ad9680_jesd);


### PR DESCRIPTION
Update a few drivers to pass the init structure by reference instead of by value.

This generally results in smaller generated code size and less runtime stack usage.