### PR TITLE
xilinx_qpll: Fix using a feedback divider of 40

### DIFF
--- a/common_drivers/xcvr_core/xcvr_modules/xilinx_qpll.c
+++ b/common_drivers/xcvr_core/xcvr_modules/xilinx_qpll.c
@@ -217,7 +217,7 @@ int32_t xilinx_xcvr_qpll_write_config(xcvr_core *core,
 	case 32:
 		fbdiv = 96;
 		break;
-	case 44:
+	case 40:
 		fbdiv = 128;
 		break;
 	case 64:


### PR DESCRIPTION
Fix typo, 44 should be 40 here.

This fixes using a feedback divider of 40, which e.g. happens when the
reference clock is 1/40 of the lane rate.

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>