### PR TITLE
Updates for the AD9144 driver

### DIFF
--- a/drivers/ad9144/ad9144.c
+++ b/drivers/ad9144/ad9144.c
@@ -293,6 +293,16 @@ int32_t ad9144_setup(struct ad9144_dev **device,
 	ad9144_spi_write(dev, REG_GENERAL_JRX_CTRL_0, 0x01);	// enable link
 
 	// dac calibration
+	ad9144_dac_calibrate(dev);
+
+	*device = dev;
+
+	return ret;
+}
+
+int32_t ad9144_dac_calibrate(struct ad9144_dev *dev)
+{
+	int ret;
 
 	ad9144_spi_write(dev, REG_CAL_CLKDIV, 0x38);	// set calibration clock to 1m
 	ad9144_spi_write(dev, REG_CAL_INIT, 0xa6);	// use isb reference of 38 to set cal
@@ -315,9 +325,7 @@ int32_t ad9144_setup(struct ad9144_dev **device,
 
 	ad9144_spi_write(dev, REG_CAL_CLKDIV, 0x30);	// turn off cal clock
 
-	*device = dev;
-
-	return ret;
+	return 0;
 }
 
 /***************************************************************************//**

--- a/drivers/ad9144/ad9144.c
+++ b/drivers/ad9144/ad9144.c
@@ -178,6 +178,7 @@ int32_t ad9144_setup(struct ad9144_dev **device,
 	uint32_t serdes_cdr;
 	uint8_t chip_id;
 	uint8_t scratchpad;
+	uint32_t val;
 	int32_t ret;
 	struct ad9144_dev *dev;
 
@@ -222,7 +223,22 @@ int32_t ad9144_setup(struct ad9144_dev **device,
 
 	// digital data path
 
-	ad9144_spi_write(dev, REG_INTERP_MODE, 0x00);	// interpolation (bypass)
+	switch (init_param->interpolation) {
+	case 2:
+		val = 0x01;
+		break;
+	case 4:
+		val = 0x03;
+		break;
+	case 8:
+		val = 0x04;
+		break;
+	default:
+		val = 0x00;
+		break;
+	}
+
+	ad9144_spi_write(dev, REG_INTERP_MODE, val);
 	ad9144_spi_write(dev, REG_DATA_FORMAT, 0x00);	// 2's complement
 
 	// transport layer

--- a/drivers/ad9144/ad9144.c
+++ b/drivers/ad9144/ad9144.c
@@ -138,7 +138,7 @@ int32_t ad9144_setup(struct ad9144_dev **device,
 
 	// reset
 	ad9144_spi_write(dev, REG_SPI_INTFCONFA, SOFTRESET_M | SOFTRESET);
-	ad9144_spi_write(dev, REG_SPI_INTFCONFA, 0x00);
+	ad9144_spi_write(dev, REG_SPI_INTFCONFA, init_param->spi3wire ? 0x00 : 0x18);
 	mdelay(1);
 
 	ad9144_spi_read(dev, REG_SPI_PRODIDL, &chip_id);

--- a/drivers/ad9144/ad9144.c
+++ b/drivers/ad9144/ad9144.c
@@ -136,6 +136,11 @@ int32_t ad9144_setup(struct ad9144_dev **device,
 	if (ret == -1)
 		printf("%s : Device descriptor failed!\n", __func__);
 
+	// reset
+	ad9144_spi_write(dev, REG_SPI_INTFCONFA, SOFTRESET_M | SOFTRESET);
+	ad9144_spi_write(dev, REG_SPI_INTFCONFA, 0x00);
+	mdelay(1);
+
 	ad9144_spi_read(dev, REG_SPI_PRODIDL, &chip_id);
 	if(chip_id != AD9144_CHIP_ID) {
 		printf("%s : Invalid CHIP ID (0x%x).\n", __func__, chip_id);
@@ -151,11 +156,6 @@ int32_t ad9144_setup(struct ad9144_dev **device,
 	}
 
 	// power-up and dac initialization
-
-	ad9144_spi_write(dev, REG_SPI_INTFCONFA, SOFTRESET_M | SOFTRESET);	// reset
-	ad9144_spi_write(dev, REG_SPI_INTFCONFA, 0x00);	// reset
-	mdelay(1);
-
 	ad9144_spi_write(dev, REG_PWRCNTRL0, 0x00);	// dacs - power up everything
 	ad9144_spi_write(dev, REG_CLKCFG0, 0x00);	// clocks - power up everything
 	ad9144_spi_write(dev, REG_SYSREF_ACTRL0, 0x00);	// sysref - power up/falling edge

--- a/drivers/ad9144/ad9144.h
+++ b/drivers/ad9144/ad9144.h
@@ -1365,6 +1365,7 @@ struct ad9144_init_param {
 	uint8_t		jesd_xbar_lane3_sel;
 	uint8_t		active_converters;
 	uint8_t		spi3wire; // set device spi intereface 3/4 wires
+	uint8_t		interpolation; // interpolation factor
 	uint32_t	stpl_samples[4][4];
 	uint32_t	lane_rate_kbps;
 	uint32_t	prbs_type;

--- a/drivers/ad9144/ad9144.h
+++ b/drivers/ad9144/ad9144.h
@@ -1353,22 +1353,25 @@
 struct ad9144_dev {
 	/* SPI */
 	spi_desc *spi_desc;
+
+	uint8_t num_converters;
+	uint8_t num_lanes;
 };
 
 struct ad9144_init_param {
 	/* SPI */
 	spi_init_param	spi_init;
 	/* Device Settings */
-	uint8_t		jesd_xbar_lane0_sel;
-	uint8_t		jesd_xbar_lane1_sel;
-	uint8_t		jesd_xbar_lane2_sel;
-	uint8_t		jesd_xbar_lane3_sel;
-	uint8_t		active_converters;
 	uint8_t		spi3wire; // set device spi intereface 3/4 wires
 	uint8_t		interpolation; // interpolation factor
 	uint32_t	stpl_samples[4][4];
 	uint32_t	lane_rate_kbps;
 	uint32_t	prbs_type;
+
+	uint8_t		jesd204_mode;
+	uint8_t		jesd204_subclass;
+	uint8_t		jesd204_scrambling;
+	uint8_t		jesd204_lane_xbar[8];
 };
 
 /******************************************************************************/

--- a/drivers/ad9144/ad9144.h
+++ b/drivers/ad9144/ad9144.h
@@ -1364,6 +1364,7 @@ struct ad9144_init_param {
 	uint8_t		jesd_xbar_lane2_sel;
 	uint8_t		jesd_xbar_lane3_sel;
 	uint8_t		active_converters;
+	uint8_t		spi3wire; // set device spi intereface 3/4 wires
 	uint32_t	stpl_samples[4][4];
 	uint32_t	lane_rate_kbps;
 	uint32_t	prbs_type;

--- a/drivers/ad9144/ad9144.h
+++ b/drivers/ad9144/ad9144.h
@@ -1399,4 +1399,6 @@ int32_t ad9144_short_pattern_test(struct ad9144_dev *dev,
 int32_t ad9144_datapath_prbs_test(struct ad9144_dev *dev,
 				  const struct ad9144_init_param *init_param);
 
+int32_t ad9144_dac_calibrate(struct ad9144_dev *dev);
+
 #endif

--- a/fmcdaq2/fmcdaq2.c
+++ b/fmcdaq2/fmcdaq2.c
@@ -410,10 +410,16 @@ int main(void)
 	ad9144_channels[1].sel = DAC_SRC_DDS;
 
 	ad9144_param.lane_rate_kbps = 10000000;
-	ad9144_param.active_converters = 2;
 	ad9144_param.spi3wire = 1;
+	ad9144_param.jesd204_subclass = 1;
+	ad9144_param.jesd204_scrambling = 1;
+	ad9144_param.jesd204_mode = 4;
+	ad9144_param.jesd204_lane_xbar[0] = 0;
+	ad9144_param.jesd204_lane_xbar[1] = 1;
+	ad9144_param.jesd204_lane_xbar[2] = 2;
+	ad9144_param.jesd204_lane_xbar[3] = 3;
 
-	ad9144_core.no_of_channels = ad9144_param.active_converters;
+	ad9144_core.no_of_channels = 2;
 	ad9144_core.resolution = 16;
 	ad9144_core.channels = &ad9144_channels[0];
 

--- a/fmcdaq2/fmcdaq2.c
+++ b/fmcdaq2/fmcdaq2.c
@@ -411,6 +411,7 @@ int main(void)
 
 	ad9144_param.lane_rate_kbps = 10000000;
 	ad9144_param.active_converters = 2;
+	ad9144_param.spi3wire = 1;
 
 	ad9144_core.no_of_channels = ad9144_param.active_converters;
 	ad9144_core.resolution = 16;


### PR DESCRIPTION
Updates for the AD9144 driver that bring it closer in sync with the Linux version.

* Add 4-wire support
* Add support for all link modes
* Update recommended write sequences according to latest datasheet

Tested on the FMCDAQ2.