### PR TITLE
[2018_R1] ad9371: platform_xilinx: fix GPIO_OFFSET for Microblaze

### DIFF
--- a/ad9371/sw/platform_xilinx/platform_drivers.h
+++ b/ad9371/sw/platform_xilinx/platform_drivers.h
@@ -53,7 +53,12 @@
 /******************************************************************************/
 /********************** Macros and Constants Definitions **********************/
 /******************************************************************************/
-#define GPIO_OFFSET			54
+#ifdef _XPARAMETERS_PS_H_
+#define GPIO_OFFSET	54
+#else
+#define GPIO_OFFSET	0
+#endif
+
 #define DAC_GPIO_PLDDR_BYPASS	GPIO_OFFSET + 60
 #define AD9528_RESET_B      GPIO_OFFSET + 59
 #define AD9528_SYSREF_REQ   GPIO_OFFSET + 58


### PR DESCRIPTION
Reported via EZ:
  https://ez.analog.com/thread/109040-ad9375-platformdriversh-modification-using-microblaze

The GPIOs for Microblaze are part of 2 x 32 bit registers, so there cannot
be a GPIO number higher than 63.

The GPIO_OFFSET is a left-over from the implementation of the driver for
the Zynq platform.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>