### PR TITLE
ad5592r: Initial driver for ad5592r/ad5593r

### DIFF
--- a/drivers/ad5592r/ad5592r-base.c
+++ b/drivers/ad5592r/ad5592r-base.c
@@ -1,0 +1,323 @@
+/***************************************************************************//**
+ *   @file   ad5592r-base.c
+ *   @brief  Implementation of AD5592R Base Driver.
+ *   @author Mircea Caprioru (mircea.caprioru@analog.com)
+********************************************************************************
+ * Copyright 2018(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "ad5592r-base.h"
+#include "platform_drivers.h"
+
+/**
+ * Write register.
+ *
+ * @param dev - The device structure.
+ * @param reg - The register address.
+ * @param value - register value
+ * @return 0 in case of success, negative error code otherwise
+ */
+int32_t ad5592r_base_reg_write(struct ad5592r_dev *dev, uint8_t reg,
+			       uint16_t value)
+{
+	return dev->ops->reg_write(dev, reg, value);
+}
+
+/**
+ * Read register.
+ *
+ * @param dev - The device structure.
+ * @param reg - The register address.
+ * @param value - register value
+ * @return 0 in case of success, negative error code otherwise
+ */
+int32_t ad5592r_base_reg_read(struct ad5592r_dev *dev, uint8_t reg,
+			      uint16_t value)
+{
+	return dev->ops->reg_read(dev, reg, value);
+}
+
+/**
+ * Get GPIO value
+ *
+ * @param dev - The device structure.
+ * @param offset - The channel number.
+ * @return 0 or 1 depending on the GPIO value.
+ */
+int32_t ad5592r_gpio_get(struct ad5592r_dev *dev, uint8_t offset)
+{
+	int32_t ret = 0;
+	uint8_t val;
+
+	if (!dev)
+		return FAILURE;
+
+	if (dev->gpio_out & BIT(offset))
+		val = dev->gpio_val;
+	else
+		ret = dev->ops->gpio_read(dev, &val);
+
+	if (ret < 0)
+		return ret;
+
+	return !!(val & BIT(offset));
+}
+
+/**
+ * Set GPIO value
+ *
+ * @param dev - The device structure.
+ * @param offset - The channel number.
+ * @param value - the GPIO value (0 or 1)
+ */
+int32_t ad5592r_gpio_set(struct ad5592r_dev *dev, uint8_t offset, int32_t value)
+{
+	if (!dev)
+		return FAILURE;
+
+	if (value)
+		dev->gpio_val |= BIT(offset);
+	else
+		dev->gpio_val &= ~BIT(offset);
+
+	return ad5592r_base_reg_write(dev, AD5592R_REG_GPIO_SET,
+				      dev->gpio_val);
+}
+
+/**
+ * Set GPIO as input
+ *
+ * @param dev - The device structure.
+ * @param offset - The channel number.
+ * @return 0 in case of success, negative error code otherwise
+ */
+int32_t ad5592r_gpio_direction_input(struct ad5592r_dev *dev, uint8_t offset)
+{
+	int32_t ret;
+
+	if (!dev)
+		return FAILURE;
+
+	dev->gpio_out &= ~BIT(offset);
+	dev->gpio_in |= BIT(offset);
+
+	ret = ad5592r_base_reg_write(dev, AD5592R_REG_GPIO_OUT_EN,
+				     dev->gpio_out);
+	if (ret < 0)
+		return ret;
+
+	return ad5592r_base_reg_write(dev, AD5592R_REG_GPIO_IN_EN,
+				      dev->gpio_in);
+}
+
+/**
+ * Set GPIO as output
+ *
+ * @param dev - The device structure.
+ * @param offset - The channel number.
+ * @param value - GPIO value to set.
+ * @return 0 in case of success, negative error code otherwise
+ */
+int32_t ad5592r_gpio_direction_output(struct ad5592r_dev *dev,
+				      uint8_t offset, int32_t value)
+{
+	int32_t ret;
+
+	if (!dev)
+		return FAILURE;
+
+	if (value)
+		dev->gpio_val |= BIT(offset);
+	else
+		dev->gpio_val &= ~BIT(offset);
+
+	dev->gpio_in &= ~BIT(offset);
+	dev->gpio_out |= BIT(offset);
+
+	ret = ad5592r_base_reg_write(dev, AD5592R_REG_GPIO_SET, dev->gpio_val);
+	if (ret < 0)
+		return ret;
+
+	ret = ad5592r_base_reg_write(dev, AD5592R_REG_GPIO_OUT_EN,
+				     dev->gpio_out);
+	if (ret < 0)
+		return ret;
+
+	ret = ad5592r_base_reg_write(dev, AD5592R_REG_GPIO_IN_EN,
+				     dev->gpio_in);
+
+	return ret;
+}
+
+/**
+ * Software reset device.
+ *
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise
+ */
+int32_t ad5592r_software_reset(struct ad5592r_dev *dev)
+{
+	int32_t ret;
+
+	if (!dev)
+		return FAILURE;
+
+	/* Writing this magic value resets the device */
+	ret = ad5592r_base_reg_write(dev, AD5592R_REG_RESET, 0xdac);
+
+	mdelay(10);
+
+	return ret;
+}
+
+/**
+ * Set channels modes.
+ *
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise
+ */
+int32_t ad5592r_set_channel_modes(struct ad5592r_dev *dev)
+{
+	int32_t ret;
+	uint8_t i;
+	uint8_t pulldown = 0, tristate = 0, dac = 0, adc = 0;
+	uint16_t read_back;
+
+	if (!dev)
+		return FAILURE;
+
+	for (i = 0; i < dev->num_channels; i++) {
+		switch (dev->channel_modes[i]) {
+		case CH_MODE_DAC:
+			dac |= BIT(i);
+			break;
+
+		case CH_MODE_ADC:
+			adc |= BIT(i);
+			break;
+
+		case CH_MODE_DAC_AND_ADC:
+			dac |= BIT(i);
+			adc |= BIT(i);
+			break;
+
+		case CH_MODE_GPIO:
+			dev->gpio_map |= BIT(i);
+			dev->gpio_in |= BIT(i); /* Default to input */
+			break;
+
+		case CH_MODE_UNUSED:
+		/* fall-through */
+		default:
+			switch (dev->channel_offstate[i]) {
+			case CH_OFFSTATE_OUT_TRISTATE:
+				tristate |= BIT(i);
+				break;
+
+			case CH_OFFSTATE_OUT_LOW:
+				dev->gpio_out |= BIT(i);
+				break;
+
+			case CH_OFFSTATE_OUT_HIGH:
+				dev->gpio_out |= BIT(i);
+				dev->gpio_val |= BIT(i);
+				break;
+
+			case CH_OFFSTATE_PULLDOWN:
+			/* fall-through */
+			default:
+				pulldown |= BIT(i);
+				break;
+			}
+		}
+	}
+
+	/* Pull down unused pins to GND */
+	ret = ad5592r_base_reg_write(dev, AD5592R_REG_PULLDOWN, pulldown);
+	if (ret < 0)
+		return ret;
+
+	ret = ad5592r_base_reg_write(dev, AD5592R_REG_TRISTATE, tristate);
+	if (ret < 0)
+		return ret;
+
+	/* Configure pins that we use */
+	ret = ad5592r_base_reg_write(dev, AD5592R_REG_DAC_EN, dac);
+	if (ret < 0)
+		return ret;
+
+	ret = ad5592r_base_reg_write(dev, AD5592R_REG_ADC_EN, adc);
+	if (ret < 0)
+		return ret;
+
+	ret = ad5592r_base_reg_write(dev, AD5592R_REG_GPIO_SET, dev->gpio_val);
+	if (ret < 0)
+		return ret;
+
+	ret = ad5592r_base_reg_write(dev, AD5592R_REG_GPIO_OUT_EN,
+				     dev->gpio_out);
+	if (ret < 0)
+		return ret;
+
+	ret = ad5592r_base_reg_write(dev, AD5592R_REG_GPIO_IN_EN,
+				     dev->gpio_in);
+	if (ret < 0)
+		return ret;
+
+	/* Verify that we can read back at least one register */
+	ret = ad5592r_base_reg_read(dev, AD5592R_REG_ADC_EN, &read_back);
+	if (!ret && (read_back & 0xff) != adc)
+		return FAILURE;
+
+	return ret;
+}
+
+/**
+ * Reset channels and set GPIO to unused.
+ *
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise
+ */
+int32_t ad5592r_reset_channel_modes(struct ad5592r_dev *dev)
+{
+	int32_t i;
+
+	if (!dev)
+		return FAILURE;
+
+	for (i = 0; i < sizeof(dev->channel_modes); i++)
+		dev->channel_modes[i] = CH_MODE_UNUSED;
+
+	return ad5592r_set_channel_modes(dev);
+}

--- a/drivers/ad5592r/ad5592r-base.h
+++ b/drivers/ad5592r/ad5592r-base.h
@@ -1,0 +1,124 @@
+/***************************************************************************//**
+ *   @file   ad5592r-base.h
+ *   @brief  Header file of AD5592R Base Driver.
+ *   @author Mircea Caprioru (mircea.caprioru@analog.com)
+********************************************************************************
+ * Copyright 2018(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef AD5592R_BASE_H_
+#define AD5592R_BASE_H_
+
+#include "stdint.h"
+#include "platform_drivers.h"
+
+#define BIT(n) (1<<(n))
+
+#define CH_MODE_UNUSED			0
+#define CH_MODE_ADC			1
+#define CH_MODE_DAC			2
+#define CH_MODE_DAC_AND_ADC		3
+#define CH_MODE_GPIO			8
+
+#define CH_OFFSTATE_PULLDOWN		0
+#define CH_OFFSTATE_OUT_LOW		1
+#define CH_OFFSTATE_OUT_HIGH		2
+#define CH_OFFSTATE_OUT_TRISTATE	3
+
+enum ad5592r_registers {
+	AD5592R_REG_NOOP		= 0x0,
+	AD5592R_REG_DAC_READBACK	= 0x1,
+	AD5592R_REG_ADC_SEQ		= 0x2,
+	AD5592R_REG_CTRL		= 0x3,
+	AD5592R_REG_ADC_EN		= 0x4,
+	AD5592R_REG_DAC_EN		= 0x5,
+	AD5592R_REG_PULLDOWN		= 0x6,
+	AD5592R_REG_LDAC		= 0x7,
+	AD5592R_REG_GPIO_OUT_EN		= 0x8,
+	AD5592R_REG_GPIO_SET		= 0x9,
+	AD5592R_REG_GPIO_IN_EN		= 0xA,
+	AD5592R_REG_PD			= 0xB,
+	AD5592R_REG_OPEN_DRAIN		= 0xC,
+	AD5592R_REG_TRISTATE		= 0xD,
+	AD5592R_REG_RESET		= 0xF,
+};
+
+#define AD5592R_REG_PD_EN_REF		BIT(9)
+#define AD5592R_REG_CTRL_ADC_RANGE	BIT(5)
+#define AD5592R_REG_CTRL_DAC_RANGE	BIT(4)
+
+struct ad5592r_dev;
+
+struct ad5592r_rw_ops {
+	int32_t (*write_dac)(struct ad5592r_dev *dev, uint8_t chan,
+			     uint16_t value);
+	int32_t (*read_adc)(struct ad5592r_dev *dev, uint8_t chan,
+			    uint16_t *value);
+	int32_t (*reg_write)(struct ad5592r_dev *dev, uint8_t reg,
+			     uint16_t value);
+	int32_t (*reg_read)(struct ad5592r_dev *dev, uint8_t reg,
+			    uint16_t *value);
+	int32_t (*gpio_read)(struct ad5592r_dev *dev, uint8_t *value);
+};
+
+struct ad5592r_dev {
+	const struct ad5592r_rw_ops *ops;
+	i2c_desc *i2c;
+	spi_desc *spi;
+	uint16_t spi_msg;
+	uint8_t num_channels;
+	uint16_t cached_dac[8];
+	uint16_t cached_gp_ctrl;
+	uint8_t channel_modes[8];
+	uint8_t channel_offstate[8];
+	uint8_t gpio_map;
+	uint8_t gpio_out;
+	uint8_t gpio_in;
+	uint8_t gpio_val;
+};
+
+int32_t ad5592r_base_reg_write(struct ad5592r_dev *dev, uint8_t reg,
+			       uint16_t value);
+int32_t ad5592r_base_reg_read(struct ad5592r_dev *dev, uint8_t reg,
+			      uint16_t value);
+int32_t ad5592r_gpio_get(struct ad5592r_dev *dev, uint8_t offset);
+int32_t ad5592r_gpio_set(struct ad5592r_dev *dev, uint8_t offset,
+			 int32_t value);
+int32_t ad5592r_gpio_direction_input(struct ad5592r_dev *dev, uint8_t offset);
+int32_t ad5592r_gpio_direction_output(struct ad5592r_dev *dev,
+				      uint8_t offset, int32_t value);
+int32_t ad5592r_software_reset(struct ad5592r_dev *dev);
+int32_t ad5592r_set_channel_modes(struct ad5592r_dev *dev);
+int32_t ad5592r_reset_channel_modes(struct ad5592r_dev *dev);
+
+#endif /* AD5592R_BASE_H_ */

--- a/drivers/ad5592r/ad5592r.c
+++ b/drivers/ad5592r/ad5592r.c
@@ -1,0 +1,231 @@
+/***************************************************************************//**
+ *   @file   ad5592r.c
+ *   @brief  Implementation of AD5592R driver.
+ *   @author Mircea Caprioru (mircea.caprioru@analog.com)
+********************************************************************************
+ * Copyright 2018(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "ad5592r-base.h"
+#include "ad5592r.h"
+#include "platform_drivers.h"
+
+const struct ad5592r_rw_ops ad5592r_rw_ops = {
+	.write_dac = ad5592r_write_dac,
+	.read_adc = ad5592r_read_adc,
+	.reg_write = ad5592r_reg_write,
+	.reg_read = ad5592r_reg_read,
+	.gpio_read = ad5592r_gpio_read,
+};
+
+/**
+ * Write NOP and read value.
+ *
+ * @param dev - The device structure.
+ * @param buf - buffer where to read
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int32_t ad5592r_spi_wnop_r16(struct ad5592r_dev *dev, uint16_t *buf)
+{
+	int32_t ret;
+	uint16_t spi_msg_nop = 0; /* NOP */
+
+	ret = spi_write_and_read(dev->spi, (uint8_t *)&spi_msg_nop,
+				 sizeof(spi_msg_nop));
+	if (ret < 0)
+		return ret;
+
+	*buf = swab16(spi_msg_nop);
+
+	return ret;
+}
+
+/**
+ * Write DAC channel.
+ *
+ * @param dev - The device structure.
+ * @param chan - The channel number.
+ * @param value - DAC value
+ * @return 0 in case of success, negative error code otherwise
+ */
+int32_t ad5592r_write_dac(struct ad5592r_dev *dev, uint8_t chan,
+			  uint16_t value)
+{
+	if (!dev)
+		return FAILURE;
+
+	dev->spi_msg = swab16( BIT(15) | (uint16_t)(chan << 12) | value);
+
+	return spi_write_and_read(dev->spi, (uint8_t *)&dev->spi_msg,
+				  sizeof(dev->spi_msg));
+}
+
+/**
+ * Read ADC channel.
+ *
+ * @param dev - The device structure.
+ * @param chan - The channel number.
+ * @param value - ADC value
+ * @return 0 in case of success, negative error code otherwise
+ */
+int32_t ad5592r_read_adc(struct ad5592r_dev *dev, uint8_t chan,
+			 uint16_t *value)
+{
+	int32_t ret;
+
+	if (!dev)
+		return FAILURE;
+
+	dev->spi_msg = swab16((uint16_t)(AD5592R_REG_ADC_SEQ << 11) |
+			      BIT(chan));
+
+	ret = spi_write_and_read(dev->spi, (uint8_t *)&dev->spi_msg,
+				 sizeof(dev->spi_msg));
+	if (ret < 0)
+		return ret;
+
+	/*
+	 * Invalid data:
+	 * See Figure 40. Single-Channel ADC Conversion Sequence
+	 */
+	ret = ad5592r_spi_wnop_r16(dev, &dev->spi_msg);
+	if (ret < 0)
+		return ret;
+
+	ret = ad5592r_spi_wnop_r16(dev, &dev->spi_msg);
+	if (ret < 0)
+		return ret;
+
+	*value = dev->spi_msg;
+
+	return 0;
+}
+
+/**
+ * Write register.
+ *
+ * @param dev - The device structure.
+ * @param reg - The register address.
+ * @param value - register value
+ * @return 0 in case of success, negative error code otherwise
+ */
+int32_t ad5592r_reg_write(struct ad5592r_dev *dev, uint8_t reg, uint16_t value)
+{
+	if (!dev)
+		return FAILURE;
+
+	dev->spi_msg = swab16((reg << 11) | value);
+
+	return spi_write_and_read(dev->spi, (uint8_t *)&dev->spi_msg,
+				  sizeof(dev->spi_msg));
+}
+
+/**
+ * Read register.
+ *
+ * @param dev - The device structure.
+ * @param reg - The register address.
+ * @param value - register value
+ * @return 0 in case of success, negative error code otherwise
+ */
+int32_t ad5592r_reg_read(struct ad5592r_dev *dev, uint8_t reg, uint16_t *value)
+{
+	int32_t ret;
+
+	if (!dev)
+		return FAILURE;
+
+	dev->spi_msg = swab16((AD5592R_REG_LDAC << 11) |
+			      AD5592R_LDAC_READBACK_EN | (reg << 2));
+
+	ret = spi_write_and_read(dev->spi, (uint8_t *)&dev->spi_msg,
+				 sizeof(dev->spi_msg));
+	if (ret < 0)
+		return ret;
+
+	ret = ad5592r_spi_wnop_r16(dev, &dev->spi_msg);
+	if (ret < 0)
+		return ret;
+
+	*value = swab16(dev->spi_msg);
+
+	return 0;
+}
+
+/**
+ * Read GPIOs.
+ *
+ * @param dev - The device structure.
+ * @param value - GPIOs value.
+ * @return 0 in case of success, negative error code otherwise
+ */
+int32_t ad5592r_gpio_read(struct ad5592r_dev *dev, uint8_t *value)
+{
+	int32_t ret;
+
+	if (!dev)
+		return FAILURE;
+
+	ret = ad5592r_reg_write(dev, AD5592R_REG_GPIO_IN_EN,
+				AD5592R_GPIO_READBACK_EN | dev->gpio_in);
+	if (ret < 0)
+		return ret;
+
+	ret = ad5592r_spi_wnop_r16(dev, &dev->spi_msg);
+	if (ret < 0)
+		return ret;
+
+	*value = (uint8_t) swab16(dev->spi_msg);
+
+	return 0;
+}
+
+/**
+ * Initialize AD5593r device.
+ *
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise
+ */
+int32_t ad5592r_init(struct ad5592r_dev *dev)
+{
+	int32_t ret;
+
+	if (!dev)
+		return FAILURE;
+
+	ret = ad5592r_software_reset(dev);
+	if (ret < 0)
+		return ret;
+
+	return ad5592r_set_channel_modes(dev);
+}

--- a/drivers/ad5592r/ad5592r.h
+++ b/drivers/ad5592r/ad5592r.h
@@ -1,0 +1,64 @@
+/***************************************************************************//**
+ *   @file   ad5592r.h
+ *   @brief  Header file of AD5592R driver.
+ *   @author Mircea Caprioru (mircea.caprioru@analog.com)
+********************************************************************************
+ * Copyright 2018(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef AD5592R_H_
+#define AD5592R_H_
+
+#include "stdint.h"
+#include "ad5592r-base.h"
+
+#define AD5592R_GPIO_READBACK_EN	BIT(10)
+#define AD5592R_LDAC_READBACK_EN	BIT(6)
+
+#define swab16(x) \
+	((((x) & 0x00ff) << 8) | \
+	 (((x) & 0xff00) >> 8))
+
+int32_t ad5592r_spi_wnop_r16(struct ad5592r_dev *dev, uint16_t *buf);
+int32_t ad5592r_write_dac(struct ad5592r_dev *dev, uint8_t chan,
+			  uint16_t value);
+int32_t ad5592r_read_adc(struct ad5592r_dev *dev, uint8_t chan,
+			 uint16_t *value);
+int32_t ad5592r_reg_write(struct ad5592r_dev *dev, uint8_t reg,
+			  uint16_t value);
+int32_t ad5592r_reg_read(struct ad5592r_dev *dev, uint8_t reg,
+			 uint16_t *value);
+int32_t ad5592r_gpio_read(struct ad5592r_dev *dev, uint8_t *value);
+int32_t ad5592r_init(struct ad5592r_dev *dev);
+
+#endif /* AD5592R_H_ */

--- a/drivers/ad5592r/ad5593r.c
+++ b/drivers/ad5592r/ad5593r.c
@@ -1,0 +1,226 @@
+/***************************************************************************//**
+ *   @file   ad5593r.c
+ *   @brief  Implementation of AD5593R driver.
+ *   @author Mircea Caprioru (mircea.caprioru@analog.com)
+********************************************************************************
+ * Copyright 2018(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "ad5592r-base.h"
+#include "ad5593r.h"
+#include "platform_drivers.h"
+
+#define AD5593R_MODE_CONF		(0 << 4)
+#define AD5593R_MODE_DAC_WRITE		(1 << 4)
+#define AD5593R_MODE_ADC_READBACK	(4 << 4)
+#define AD5593R_MODE_DAC_READBACK	(5 << 4)
+#define AD5593R_MODE_GPIO_READBACK	(6 << 4)
+#define AD5593R_MODE_REG_READBACK	(7 << 4)
+
+const struct ad5592r_rw_ops ad5593r_rw_ops = {
+	.write_dac = ad5593r_write_dac,
+	.read_adc = ad5593r_read_adc,
+	.reg_write = ad5593r_reg_write,
+	.reg_read = ad5593r_reg_read,
+	.gpio_read = ad5593r_gpio_read,
+};
+
+/**
+ * Write DAC channel.
+ *
+ * @param dev - The device structure.
+ * @param chan - The channel number.
+ * @param value - DAC value
+ * @return 0 in case of success, negative error code otherwise
+ */
+int32_t ad5593r_write_dac(struct ad5592r_dev *dev, uint8_t chan,
+			  uint16_t value)
+{
+	uint8_t data[3];
+
+	if (!dev)
+		return FAILURE;
+
+	data[0] = AD5593R_MODE_DAC_WRITE | chan;
+	data[1] = (value >> 8) & 0xF ;
+	data[2] = value & 0xFF;
+
+	return i2c_write(dev->i2c, data, sizeof(data), 0);
+}
+
+/**
+ * Read ADC channel.
+ *
+ * @param dev - The device structure.
+ * @param chan - The channel number.
+ * @param value - ADC value
+ * @return 0 in case of success, negative error code otherwise
+ */
+int32_t ad5593r_read_adc(struct ad5592r_dev *dev, uint8_t chan,
+			 uint16_t *value)
+{
+	int32_t ret;
+	uint8_t data[3];
+	uint16_t temp;
+
+	if (!dev)
+		return FAILURE;
+
+	temp = BIT(chan);
+
+	data[0] = AD5593R_MODE_CONF | AD5592R_REG_ADC_SEQ;
+	data[1] = temp >> 8;
+	data[2] = temp & 0xFF;
+
+	ret = i2c_write(dev->i2c, data, sizeof(data), 0);
+	if (ret < 0)
+		return ret;
+
+	data[0] = AD5593R_MODE_ADC_READBACK;
+	ret = i2c_write(dev->i2c, data, 1, 0);
+	if (ret < 0)
+		return ret;
+
+	ret = i2c_read(dev->i2c, data, 2, 0);
+	if (ret < 0)
+		return ret;
+
+	*value = (uint16_t)((data[0] & 0x0F) << 8) + data[1];
+
+	return 0;
+}
+
+/**
+ * Write register.
+ *
+ * @param dev - The device structure.
+ * @param reg - The register address.
+ * @param value - register value
+ * @return 0 in case of success, negative error code otherwise
+ */
+int32_t ad5593r_reg_write(struct ad5592r_dev *dev, uint8_t reg,
+			  uint16_t value)
+{
+	uint8_t data[3];
+
+	if (!dev)
+		return FAILURE;
+
+	data[0] = AD5593R_MODE_CONF | reg;
+	data[1] = value >> 8;
+	data[2] = value;
+
+	return i2c_write(dev->i2c, data,sizeof(data), 0);
+}
+
+/**
+ * Read register.
+ *
+ * @param dev - The device structure.
+ * @param reg - The register address.
+ * @param value - register value
+ * @return 0 in case of success, negative error code otherwise
+ */
+int32_t ad5593r_reg_read(struct ad5592r_dev *dev, uint8_t reg,
+			 uint16_t *value)
+{
+	int32_t ret;
+	uint8_t data[2];
+
+	if (!dev)
+		return FAILURE;
+
+	data[0] = AD5593R_MODE_REG_READBACK | reg;
+
+	ret = i2c_write(dev->i2c, data, 1, 0);
+	if (ret < 0)
+		return ret;
+
+	ret = i2c_read(dev->i2c, data, sizeof(data), 0);
+	if (ret < 0)
+		return ret;
+
+	*value = (uint16_t) (data[0] << 8) + data[1];
+
+	return 0;
+}
+
+/**
+ * Read GPIOs.
+ *
+ * @param dev - The device structure.
+ * @param value - GPIOs value.
+ * @return 0 in case of success, negative error code otherwise
+ */
+int32_t ad5593r_gpio_read(struct ad5592r_dev *dev, uint8_t *value)
+{
+	int32_t ret;
+	uint8_t data[2];
+
+	if (!dev)
+		return FAILURE;
+
+	data[0] = AD5593R_MODE_GPIO_READBACK;
+	ret = i2c_write(dev->i2c, data, 1, 0);
+	if (ret < 0)
+		return ret;
+
+	ret = i2c_read(dev->i2c, data, sizeof(data), 0);
+	if (ret < 0)
+		return ret;
+
+	*value = data[1];
+
+	return 0;
+}
+
+/**
+ * Initialize AD5593r device.
+ *
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise
+ */
+int32_t ad5593r_init(struct ad5592r_dev *dev)
+{
+	int32_t ret;
+
+	if (!dev)
+		return FAILURE;
+
+	ret = ad5592r_software_reset(dev);
+	if (ret < 0)
+		return ret;
+
+	return ad5592r_set_channel_modes(dev);
+}

--- a/drivers/ad5592r/ad5593r.h
+++ b/drivers/ad5592r/ad5593r.h
@@ -1,0 +1,56 @@
+/***************************************************************************//**
+ *   @file   ad5593r.h
+ *   @brief  Header file of AD5593R driver.
+ *   @author Mircea Caprioru (mircea.caprioru@analog.com)
+********************************************************************************
+ * Copyright 2018(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef AD5593R_H_
+#define AD5593R_H_
+
+#include "stdint.h"
+#include "ad5592r-base.h"
+
+int32_t ad5593r_write_dac(struct ad5592r_dev *dev, uint8_t chan,
+			  uint16_t value);
+int32_t ad5593r_read_adc(struct ad5592r_dev *dev, uint8_t chan,
+			 uint16_t *value);
+int32_t ad5593r_reg_write(struct ad5592r_dev *dev, uint8_t reg,
+			  uint16_t value);
+int32_t ad5593r_reg_read(struct ad5592r_dev *dev, uint8_t reg,
+			 uint16_t *value);
+int32_t ad5593r_gpio_read(struct ad5592r_dev *dev, uint8_t *value);
+int32_t ad5593r_init(struct ad5592r_dev *dev);
+
+#endif /* AD5593R_H_ */


### PR DESCRIPTION
The ad5592r/ad5593r has 8 I/Ox pins that can be independently configured as
digital-to-analog converter outputs (DAC), analog-to-digital converter
inputs (ADC) or digital inputs.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>