### PR TITLE
Make ad9361_dig_tune report failure to tune.

### DIFF
--- a/ad9361/sw/ad9361_conv.c
+++ b/ad9361/sw/ad9361_conv.c
@@ -544,8 +544,6 @@ int32_t ad9361_dig_tune(struct ad9361_rf_phy *phy, uint32_t max_freq,
 
 		if (ret == -EIO)
 			restore = true;
-		if (!max_freq)
-			ret = 0;
 	}
 
 	if (restore) {


### PR DESCRIPTION
ad9361_dig_tune didn't return an error code when max_freq == 0, making
it impossible to know whether tuning the digital interface to a specific
frequency succeeded. Now a caller of ad9361_dig_tune can determine
whether tuning to the frequency was successful or not.