### PR TITLE
AD9144 PLL support

### DIFF
--- a/drivers/ad9144/ad9144.h
+++ b/drivers/ad9144/ad9144.h
@@ -182,7 +182,8 @@
 #define REG_DACPLLT5				0x1B5 /* ALC/Varactor control */
 #define REG_DACPLLTB				0x1BB /* VCO Bias Control */
 #define REG_DACPLLTD				0x1BD /* VCO Cal control */
-#define REG_DACPLLT17				0x1C4 /* Varactor ControlV */
+#define REG_DACPLLT17				0x1C4 /* Varactor Control 1 */
+#define REG_DACPLLT18				0x1C5 /* Varactor Control 2 */
 #define REG_ASPI_SPARE0				0x1C6 /* Spare Register 0 */
 #define REG_ASPI_SPARE1				0x1C7 /* Spare Register 1 */
 #define REG_SPISTRENGTH				0x1DF /* Reg 70 Description */
@@ -1372,6 +1373,13 @@ struct ad9144_init_param {
 	uint8_t		jesd204_subclass;
 	uint8_t		jesd204_scrambling;
 	uint8_t		jesd204_lane_xbar[8];
+
+	/* Whether to enable the internal DAC PLL (0=disable, 1=enable) */
+	uint8_t		pll_enable;
+	/* When using the DAC PLL this specifies the external reference clock frequency in kHz. */
+	uint32_t	pll_ref_frequency_khz;
+	/* When using the DAC PLL this specifies the target PLL output frequency in kHz. */
+	uint32_t	pll_dac_frequency_khz;
 };
 
 /******************************************************************************/

--- a/fmcdaq2/fmcdaq2.c
+++ b/fmcdaq2/fmcdaq2.c
@@ -428,6 +428,7 @@ int main(void)
 
 	ad9144_param.lane_rate_kbps = 10000000;
 	ad9144_param.spi3wire = 1;
+	ad9144_param.interpolation = 1;
 	ad9144_param.jesd204_subclass = 1;
 	ad9144_param.jesd204_scrambling = 1;
 	ad9144_param.jesd204_mode = 4;

--- a/fmcdaq2/fmcdaq2.c
+++ b/fmcdaq2/fmcdaq2.c
@@ -97,11 +97,22 @@ int fmcdaq2_reconfig(struct ad9144_init_param *p_ad9144_param,
 	printf ("\t2 - ADC  500 MSPS; DAC 1000 MSPS\n");
 	printf ("\t3 - ADC  500 MSPS; DAC  500 MSPS\n");
 	printf ("\t4 - ADC  600 MSPS; DAC  600 MSPS\n");
+	printf ("\t5 - ADC 1000 MSPS; DAC 2000 MSPS (2x interpolation)\n");
 	printf ("choose an option [default 1]:\n");
 
 	mode = ad_uart_read();
 
 	switch (mode) {
+		case '5':
+			/* REF clock = 100 MHz */
+			p_ad9523_param->channels[DAC_DEVICE_CLK].channel_divider = 10;
+			p_ad9144_param->pll_ref_frequency_khz = 100000;
+
+			/* DAC at 2 GHz using the internal PLL and 2 times interpolation */
+			p_ad9144_param->interpolation = 2;
+			p_ad9144_param->pll_enable = 1;
+			p_ad9144_param->pll_dac_frequency_khz = 2000000;
+			break;
 		case '4':
 			printf ("4 - ADC  600 MSPS; DAC  600 MSPS\n");
 			p_ad9523_param->pll2_vco_diff_m1 = 5;

--- a/fmcdaq2/fmcdaq2.c
+++ b/fmcdaq2/fmcdaq2.c
@@ -429,6 +429,7 @@ int main(void)
 	ad9144_param.lane_rate_kbps = 10000000;
 	ad9144_param.spi3wire = 1;
 	ad9144_param.interpolation = 1;
+	ad9144_param.pll_enable = 0;
 	ad9144_param.jesd204_subclass = 1;
 	ad9144_param.jesd204_scrambling = 1;
 	ad9144_param.jesd204_mode = 4;


### PR DESCRIPTION
Add support for the internal PLL in the AD9144. It can be used to synthesize a DAC clock from a slower external reference clock.

Also add an example to the DAQ2 project that shows how to use the PLL mode.