### PR TITLE
ad9144: Keep link disabled during configuration

### DIFF
--- a/drivers/ad9144/ad9144.c
+++ b/drivers/ad9144/ad9144.c
@@ -441,7 +441,7 @@ int32_t ad9144_setup(struct ad9144_dev **device,
 
 	ad9144_spi_write(dev, REG_MASTER_PD, 0x00);	// phy - power up
 	ad9144_spi_write(dev, REG_PHY_PD, 0x00);	// phy - power up
-	ad9144_spi_write(dev, REG_GENERAL_JRX_CTRL_0, 0x01);	// single link - link 0
+	ad9144_spi_write(dev, REG_GENERAL_JRX_CTRL_0, 0x00);	// single link - link 0
 	ad9144_setup_jesd204_link(dev, init_param);
 
 	// physical layer


### PR DESCRIPTION
Currently when calling the ad9144_setup() function there is a certain
chance that the AD9144 will not be correctly initialized. The symptoms can
range from the AD9144 not reporting any errors, but also not generating any
signal at the DAC output, to recording a lot of JESD204 character errors
and constantly restarting the link.

This appears to be caused by the link being enabled while the link is being
configured. Make sure that the link is kept disabled during link
configuration.

After this patch has been applied erratic behavior after converter
initialization can no longer be observed and the AD9144 properly
initializes every time.

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>