### PR TITLE
ad9144: Fix PLL setup corner case

### DIFF
--- a/drivers/ad9144/ad9144.c
+++ b/drivers/ad9144/ad9144.c
@@ -326,6 +326,10 @@ static int32_t ad9144_pll_setup(struct ad9144_dev *dev,
 
 	fvco = fdac << (lo_div_mode + 1);
 	bcount = fdac / (2 * fref);
+	if (bcount < 6) {
+		bcount *= 2;
+		ref_div_mode++;
+	}
 
 	if (fvco < 6300000) {
 		vco_param[0] = 0x08;


### PR DESCRIPTION
The bcount setting of the PLL needs to be 6 or larger for the PLL to lock.

The current logic might pick for certain PLL output frequency and reference
frequency combinations a value for bcount that is less than 6.

In this case double the bcount value as well as the reference divider
value to mitigate the issue.

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>