### PR TITLE
Fix DAQ2/DAQ3 DAC JESD204 link startup

### DIFF
--- a/drivers/ad9152/ad9152.c
+++ b/drivers/ad9152/ad9152.c
@@ -140,7 +140,7 @@ int32_t ad9152_setup(struct ad9152_dev **device,
 	ad9152_spi_write(dev, 0x201, 0x00);	// phy - power up
 	ad9152_spi_write(dev, 0x230, 0x28);	// half-rate CDR
 	ad9152_spi_write(dev, 0x312, 0x20);	// half-rate CDR
-	ad9152_spi_write(dev, 0x300, 0x01);	// single link - link 0
+	ad9152_spi_write(dev, 0x300, 0x00);	// single link - link 0
 	ad9152_spi_write(dev, 0x450, 0x00);	// device id (0x400)
 	ad9152_spi_write(dev, 0x451, 0x00);	// bank id (0x401)
 	ad9152_spi_write(dev, 0x452, 0x04);	// lane-id (0x402)

--- a/fmcdaq3/config.h
+++ b/fmcdaq3/config.h
@@ -41,7 +41,7 @@
 #define CONFIG_H_
 
 // #define HAVE_VERBOSE_MESSAGES /* Recommended during development prints errors and warnings */
- #define DEBUG		 /* For Debug purposes only */
+// #define DEBUG		 /* For Debug purposes only */
 
 /******************************************************************************/
 /****************************** Carrier Vendors *******************************/

--- a/fmcdaq3/fmcdaq3.c
+++ b/fmcdaq3/fmcdaq3.c
@@ -298,10 +298,15 @@ int main(void)
 
 	ad9528_setup(&ad9528_device, ad9528_param);
 
-	ad9152_setup(&ad9152_device, ad9152_param);
+	// Recommended DAC JESD204 link startup sequence
+	//   1. FPGA JESD204 Link Layer
+	//   2. FPGA JESD204 PHY Layer
+	//   3. DAC
 
 	jesd_setup(&ad9152_jesd);
 	xcvr_setup(&ad9152_xcvr);
+	ad9152_setup(&ad9152_device, ad9152_param);
+
 	axi_jesd204_tx_status_read(&ad9152_jesd);
 	dac_setup(&ad9152_core);
 	ad9152_status(ad9152_device);


### PR DESCRIPTION
Currently on both DAQ2 and DAQ3 the DAC JESD204 startup fails every now and then (maybe 1 in 10 to 20 times).

This series fixes the remaining issues to ensure that the link starts up reliably. No issues have been observed while continuously restarting the application every 10 seconds for a few hours.

(At least in the default configuration, more things to come to fix dynamic reconfiguration.)