### PR TITLE
scripts/xsct.tcl: Return error when build was not successful

### DIFF
--- a/scripts/xsct.tcl
+++ b/scripts/xsct.tcl
@@ -59,5 +59,8 @@ if {$m_mode == "make-bsp-xilsw"} {
 }
 
 sdk projects -build -type app -name sw
+if {![file exists sw/Release/sw.elf]} {
+  exit 1
+}
 exit
 


### PR DESCRIPTION
When building the sw.elf file the xsct.tcl script currently always returns
success. Regardless of whether it was able to build the project or not. The
`sdk projects -build` command unfortunately neither returns an error code
nor throws and exception.

Add a manually check to see if the sw.elf file was generated successfully
and if not return an error code.

This for example allows `make` to abort if something goes wrong and it will
not try to run targets that depend on the sw.elf having been build
successfully.

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>