### PR TITLE
Ad4111 driver dev

### DIFF
--- a/drivers/ad717x/ad4111_regs.h
+++ b/drivers/ad717x/ad4111_regs.h
@@ -1,0 +1,128 @@
+/***************************************************************************//**
+*   @file   ad4111_regs.h
+*   @brief  ad4111 Registers Definitions.
+*   @author Andrei Drimbarean (andrei.drimbarean@analog.com)
+********************************************************************************
+* Copyright 2018(c) Analog Devices, Inc.
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*  - Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*  - Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in
+*    the documentation and/or other materials provided with the
+*    distribution.
+*  - Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*  - The use of this software may or may not infringe the patent rights
+*    of one or more patent holders.  This license does not release you
+*    from the requirement that you obtain separate licenses from these
+*    patent holders to use this software.
+*  - Use of the software either in source or binary form, must be run
+*    on or directly connected to an Analog Devices Inc. component.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR IMPLIED
+* WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT, MERCHANTABILITY
+* AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************************************************************/
+
+#ifndef AD4111_CFG_H_
+#define AD4111_CFG_H_
+
+#include "ad717x.h"
+
+ad717x_st_reg ad4111_regs[] =
+{
+	{ AD717X_STATUS_REG, 0x00, 1 },
+	{
+			AD717X_ADCMODE_REG,
+			AD717X_ADCMODE_REG_MODE(0),
+			2
+	},
+	{ AD717X_IFMODE_REG, 0x0000, 2 },
+	{ AD717X_REGCHECK_REG, 0x0000, 3 },
+	{ AD717X_DATA_REG, 0x0000, 3 },
+	{
+			AD717X_GPIOCON_REG,
+			AD717X_GPIOCON_REG_SYNC_EN,
+			2
+	},
+	{ AD717X_ID_REG, 0x0000, 2 },
+	{ AD717X_CHMAP0_REG, 0x0000, 2 },
+	{ AD717X_CHMAP1_REG, 0x0000, 2 },
+	{ AD717X_CHMAP2_REG, 0x0000, 2 },
+	{ AD717X_CHMAP3_REG, 0x0000, 2 },
+	{ AD717X_CHMAP4_REG, 0x0000, 2 },
+	{ AD717X_CHMAP5_REG, 0x0000, 2 },
+	{ AD717X_CHMAP6_REG, 0x0000, 2 },
+	{ AD717X_CHMAP7_REG, 0x0000, 2 },
+	{ AD717X_CHMAP8_REG, 0x0000, 2 },
+	{ AD717X_CHMAP9_REG, 0x0000, 2 },
+	{ AD717X_CHMAP10_REG, 0x0000, 2 },
+	{ AD717X_CHMAP11_REG, 0x0000, 2 },
+	{ AD717X_CHMAP12_REG, 0x0000, 2 },
+	{ AD717X_CHMAP13_REG, 0x0000, 2 },
+	{ AD717X_CHMAP14_REG, 0x0000, 2 },
+	{ AD717X_CHMAP15_REG, 0x0000, 2 },
+	{ AD717X_SETUPCON0_REG, 0x0000 | AD717X_SETUP_CONF_REG_REF_SEL(2), 2 },
+	{ AD717X_SETUPCON1_REG, 0x0000 | AD717X_SETUP_CONF_REG_REF_SEL(2), 2 },
+	{ AD717X_SETUPCON2_REG, 0x0000 | AD717X_SETUP_CONF_REG_REF_SEL(2), 2 },
+	{ AD717X_SETUPCON3_REG, 0x0000 | AD717X_SETUP_CONF_REG_REF_SEL(2), 2 },
+	{ AD717X_SETUPCON4_REG, 0x0000 | AD717X_SETUP_CONF_REG_REF_SEL(2), 2 },
+	{ AD717X_SETUPCON5_REG, 0x0000 | AD717X_SETUP_CONF_REG_REF_SEL(2), 2 },
+	{ AD717X_SETUPCON6_REG, 0x0000 | AD717X_SETUP_CONF_REG_REF_SEL(2), 2 },
+	{ AD717X_SETUPCON7_REG, 0x0000 | AD717X_SETUP_CONF_REG_REF_SEL(2), 2 },
+	{
+			AD717X_FILTCON0_REG, AD717X_FILT_CONF_REG_ENHFILT(2), 2
+	},
+	{
+			AD717X_FILTCON1_REG, AD717X_FILT_CONF_REG_ENHFILT(2), 2
+	},
+	{
+			AD717X_FILTCON2_REG, AD717X_FILT_CONF_REG_ENHFILT(2), 2
+	},
+	{
+			AD717X_FILTCON3_REG, AD717X_FILT_CONF_REG_ENHFILT(2), 2
+	},
+	{
+			AD717X_FILTCON4_REG, AD717X_FILT_CONF_REG_ENHFILT(2), 2
+	},
+	{
+			AD717X_FILTCON5_REG, AD717X_FILT_CONF_REG_ENHFILT(2), 2
+	},
+	{
+			AD717X_FILTCON6_REG, AD717X_FILT_CONF_REG_ENHFILT(2), 2
+	},
+	{
+			AD717X_FILTCON7_REG, AD717X_FILT_CONF_REG_ENHFILT(2), 2
+	},
+	{AD717X_OFFSET0_REG, 0, 3 },
+	{AD717X_OFFSET1_REG, 0, 3 },
+	{AD717X_OFFSET2_REG, 0, 3 },
+	{AD717X_OFFSET3_REG, 0, 3 },
+	{AD717X_OFFSET4_REG, 0, 3 },
+	{AD717X_OFFSET5_REG, 0, 3 },
+	{AD717X_OFFSET6_REG, 0, 3 },
+	{AD717X_OFFSET7_REG, 0, 3 },
+	{AD717X_GAIN0_REG, 0, 3 },
+	{AD717X_GAIN1_REG, 0, 3 },
+	{AD717X_GAIN2_REG, 0, 3 },
+	{AD717X_GAIN3_REG, 0, 3 },
+	{AD717X_GAIN4_REG, 0, 3 },
+	{AD717X_GAIN5_REG, 0, 3 },
+	{AD717X_GAIN6_REG, 0, 3 },
+	{AD717X_GAIN7_REG, 0, 3 },
+};
+
+#endif /* AD4111_CFG_H_ */

--- a/drivers/ad717x/ad717x.c
+++ b/drivers/ad717x/ad717x.c
@@ -439,6 +439,11 @@ int32_t AD717X_Init(ad717x_dev **device,
                 preg ++;
         }
 
+        /* Read ID register to identify the part */
+        ret = AD717X_ReadRegister(dev, AD717X_ID_REG);
+        if(ret < 0)
+                return ret;
+
         *device = dev;
 
         return ret;

--- a/drivers/ad717x/ad717x.c
+++ b/drivers/ad717x/ad717x.c
@@ -285,13 +285,54 @@ int32_t AD717X_ReadData(ad717x_dev *device,
         if (!dataReg)
                 return INVALID_VAL;
 
+        /* Update the data register length with respect to device and options */
+        ret = AD717X_ComputeDataregSize(device);
+
         /* Read the value of the Status Register */
-        ret = AD717X_ReadRegister(device, AD717X_DATA_REG);
+        ret |= AD717X_ReadRegister(device, AD717X_DATA_REG);
 
         /* Get the read result */
         *pData = dataReg->value;
 
         return ret;
+}
+
+/***************************************************************************//**
+* @brief Computes data register read size to account for bit number and status
+* 		 read.
+*
+* @param device - The handler of the instance of the driver.
+*
+* @return 0in case of success or negative code in case of failure.
+*******************************************************************************/
+int32_t AD717X_ComputeDataregSize(ad717x_dev *device)
+{
+	ad717x_st_reg *reg_ptr;
+	ad717x_st_reg *datareg_ptr;
+	uint16_t case_var;
+
+	/* Get interface mode register pointer */
+	reg_ptr = AD717X_GetReg(device, AD717X_IFMODE_REG);
+	/* Get data register pointer */
+	datareg_ptr = AD717X_GetReg(device, AD717X_DATA_REG);
+	case_var = reg_ptr->value & (AD717X_IFMODE_REG_DATA_STAT |
+			AD717X_IFMODE_REG_DATA_WL16);
+
+	/* Compute data register size */
+	datareg_ptr->size = 3;
+	if ((case_var & AD717X_IFMODE_REG_DATA_WL16) == AD717X_IFMODE_REG_DATA_WL16)
+		datareg_ptr->size--;
+	if ((case_var & AD717X_IFMODE_REG_DATA_STAT) == AD717X_IFMODE_REG_DATA_STAT)
+		datareg_ptr->size++;
+
+	/* Get ID register pointer */
+	reg_ptr = AD717X_GetReg(device, AD717X_ID_REG);
+
+	/* If the part is 32/24 bit wide add a byte to the read */
+	if((reg_ptr->value & AD717X_ID_REG_MASK) == AD7177_2_ID_REG_VALUE)
+		datareg_ptr->size++;
+
+	return 0;
 }
 
 /***************************************************************************//**

--- a/drivers/ad717x/ad717x.h
+++ b/drivers/ad717x/ad717x.h
@@ -301,6 +301,10 @@ int32_t AD717X_WaitForReady(ad717x_dev *device,
 int32_t AD717X_ReadData(ad717x_dev *device,
 			int32_t* pData);
 
+/*! Computes data register read size to account for bit number and status
+ *  read. */
+int32_t AD717X_ComputeDataregSize(ad717x_dev *device);
+
 /*! Computes the CRC checksum for a data buffer. */
 uint8_t AD717X_ComputeCRC8(uint8_t* pBuf,
 			   uint8_t bufSize);

--- a/drivers/ad717x/ad717x.h
+++ b/drivers/ad717x/ad717x.h
@@ -2,7 +2,7 @@
 *   @file    AD717X.h
 *   @brief   AD717X header file.
 *   @devices AD7172-2, AD7172-4, AD7173-8, AD7175-2, AD7175-8, AD7176-2,
-*            AD7177-2
+*            AD7177-2, AD4111
 *   @author  acozma (andrei.cozma@analog.com)
 *            dnechita (dan.nechita@analog.com)
 *******************************************************************************
@@ -167,7 +167,7 @@ typedef struct {
 #define AD717X_ADCMODE_REG_MODE(x)    (((x) & 0x7) << 4)
 #define AD717X_ADCMODE_REG_CLKSEL(x)) (((x) & 0x3) << 2)
 
-/* ADC Mode Register additional bits for AD7172-2 and AD7172-4 */
+/* ADC Mode Register additional bits for AD7172-2, AD7172-4 and AD4111 */
 #define AD717X_ADCMODE_REG_HIDE_DELAY   (1 << 14)
 
 /* Interface Mode Register bits */
@@ -206,11 +206,20 @@ typedef struct {
 #define AD717X_GPIOCON_REG_PDSW        (1 << 14)
 #define AD717X_GPIOCON_REG_OP_EN2_3    (1 << 13)
 
+/* GPIO Configuration Register additional bits for AD4111 */
+#define AD4111_GPIOCON_REG_OP_EN0_1    (1 << 13)
+#define AD4111_GPIOCON_REG_OW_EN       (1 << 12)
+#define AD4111_GPIOCON_REG_DATA1       (1 << 7)
+#define AD4111_GPIOCON_REG_DATA0       (1 << 6)
+
 /* Channel Map Register 0-3 bits */
 #define AD717X_CHMAP_REG_CH_EN         (1 << 15)
 #define AD717X_CHMAP_REG_SETUP_SEL(x)  (((x) & 0x7) << 12)
 #define AD717X_CHMAP_REG_AINPOS(x)     (((x) & 0x1F) << 5)
 #define AD717X_CHMAP_REG_AINNEG(x)     (((x) & 0x1F) << 0)
+
+/* Channel Map Register additional bits for AD4111 */
+#define AD4111_CHMAP_REG_INPUT(x)      (((x) & 0x3FF) << 0)
 
 /* Setup Configuration Register 0-3 bits */
 #define AD717X_SETUP_CONF_REG_BI_UNIPOLAR  (1 << 12)
@@ -228,12 +237,37 @@ typedef struct {
 #define AD717X_SETUP_CONF_REG_AINBUF_P    (1 << 9)
 #define AD717X_SETUP_CONF_REG_AINBUF_N    (1 << 8)
 
+/* Setup Configuration Register additional bits for AD4111 */
+#define AD4111_SETUP_CONF_REG_REFPOS_BUF   (1 << 11)
+#define AD4111_SETUP_CONF_REG_REFNEG_BUF   (1 << 10)
+#define AD4111_SETUP_CONF_REG_AIN_BUF(x)   (((x) & 0x3) << 8)
+#define AD4111_SETUP_CONF_REG_BUFCHOPMAX   (1 << 6)
+
 /* Filter Configuration Register 0-3 bits */
 #define AD717X_FILT_CONF_REG_SINC3_MAP    (1 << 15)
 #define AD717X_FILT_CONF_REG_ENHFILTEN    (1 << 11)
 #define AD717X_FILT_CONF_REG_ENHFILT(x)   (((x) & 0x7) << 8)
 #define AD717X_FILT_CONF_REG_ORDER(x)     (((x) & 0x3) << 5)
 #define AD717X_FILT_CONF_REG_ODR(x)       (((x) & 0x1F) << 0)
+
+/* ID register mask for relevant bits */
+#define AD717X_ID_REG_MASK	  0xFFF0
+/* AD7172-2 ID */
+#define AD7172_2_ID_REG_VALUE 0x00D0
+/* AD7172-4 ID */
+#define AD7172_4_ID_REG_VALUE 0x2050
+/* AD7173-8 ID */
+#define AD7173_8_ID_REG_VALUE 0x30D0
+/* AD7175-2 ID */
+#define AD7175_2_ID_REG_VALUE 0x0CD0
+/* AD7175-8 ID */
+#define AD7175_8_ID_REG_VALUE 0x3CD0
+/* AD7176-2 ID */
+#define AD7176_2_ID_REG_VALUE 0x0C90
+/* AD7177-2 ID */
+#define AD7177_2_ID_REG_VALUE 0x4FD0
+/* AD4111 ID */
+#define AD4111_ID_REG_VALUE   0x30D0
 
 /*****************************************************************************/
 /******************* AD717X Constants ****************************************/

--- a/drivers/ad717x/ad717x.h
+++ b/drivers/ad717x/ad717x.h
@@ -158,7 +158,7 @@ typedef struct {
 #define AD717X_STATUS_REG_ADC_ERR  (1 << 6)
 #define AD717X_STATUS_REG_CRC_ERR  (1 << 5)
 #define AD717X_STATUS_REG_REG_ERR  (1 << 4)
-#define AD717X_STATUS_REG_CH(x)    ((x) & 0x03)
+#define AD717X_STATUS_REG_CH(x)    ((x) & 0x0F)
 
 /* ADC Mode Register bits */
 #define AD717X_ADCMODE_REG_REF_EN     (1 << 15)
@@ -208,7 +208,7 @@ typedef struct {
 
 /* Channel Map Register 0-3 bits */
 #define AD717X_CHMAP_REG_CH_EN         (1 << 15)
-#define AD717X_CHMAP_REG_SETUP_SEL(x)  (((x) & 0x3) << 12)
+#define AD717X_CHMAP_REG_SETUP_SEL(x)  (((x) & 0x7) << 12)
 #define AD717X_CHMAP_REG_AINPOS(x)     (((x) & 0x1F) << 5)
 #define AD717X_CHMAP_REG_AINNEG(x)     (((x) & 0x1F) << 0)
 


### PR DESCRIPTION
Make small fixes to the AD717X driver and add AD4111 support to the AD717X driver.

The AD4111 is a low power, low noise, 24-bit, sigma delta (Σ-Δ) analog-to-digital converter (ADC) that integrates an analog front end (AFE) for fully differential or single-ended rail-to-rail, buffered bipolar, ±10 V voltage inputs, and 0 mA to 20 mA current inputs.

The AD4111 is very similar to the AD717X family so support for it is added to that family driver instead of creating new driver with duplicate code.