### PR TITLE
AD7124 driver - minor fixes

### DIFF
--- a/ci/scripts/astyle.sh
+++ b/ci/scripts/astyle.sh
@@ -27,7 +27,7 @@ is_source_file() {
 for file in $FILES; do
 	if is_source_file $file
 	then 
-		astyle --options=./astyle_config $file
+		astyle --options=./ci/scripts/astyle_config $file
 	fi
 done;
 

--- a/drivers/ad7124/ad7124.h
+++ b/drivers/ad7124/ad7124.h
@@ -330,7 +330,7 @@ enum ad7124_registers {
 
 /*
  * The structure describes the device and is used with the ad7124 driver.
- * @slave_select_id: The ID of the Slave Select to be passed to the SPI calls.
+ * @spi_desc: A reference to the SPI configuration of the device.
  * @regs: A reference to the register list of the device that the user must
  *       provide when calling the Setup() function.
  * @userCRC: Whether to do or not a cyclic redundancy check on SPI transfers.

--- a/drivers/ad7124/ad7124.h
+++ b/drivers/ad7124/ad7124.h
@@ -272,7 +272,7 @@ enum ad7124_registers {
 	AD7124_ADC_Control,
 	AD7124_Data,
 	AD7124_IOCon1,
-	AD7124_IOCon2_,
+	AD7124_IOCon2,
 	AD7124_ID,
 	AD7124_Error,
 	AD7124_Error_En,

--- a/drivers/ad7124/ad7124.h
+++ b/drivers/ad7124/ad7124.h
@@ -134,7 +134,7 @@
 #define AD7124_ADC_CTRL_REG_REF_EN         (1 << 8)
 #define AD7124_ADC_CTRL_REG_POWER_MODE(x)  (((x) & 0x3) << 6)
 #define AD7124_ADC_CTRL_REG_MODE(x)        (((x) & 0xF) << 2)
-#define AD7124_ADC_CTRL_REG_CLK_SEL(x))    (((x) & 0x3) << 0)
+#define AD7124_ADC_CTRL_REG_CLK_SEL(x)     (((x) & 0x3) << 0)
 
 /* IO_Control_1 Register bits */
 #define AD7124_IO_CTRL1_REG_GPIO_DAT2     (1 << 23)


### PR DESCRIPTION
Set of minor fixes in the header file of the AD7124 driver and fix astyle_config file path for travis.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>