### PR TITLE
Ultrascale xcvr projects update

### DIFF
--- a/ad-fmcjesdadc1-ebz/ad_fmcjesdadc1_ebz.c
+++ b/ad-fmcjesdadc1-ebz/ad_fmcjesdadc1_ebz.c
@@ -134,7 +134,7 @@ int main(void)
 
 	ad9250_xcvr.reconfig_bypass = 0;
 	ad9250_xcvr.lane_rate_kbps = ad9250_0_param.lane_rate_kbps;
-	ad9250_xcvr.ref_clock_khz = 245760;
+	ad9250_xcvr.ref_rate_khz = 245760;
 
 	ad9250_jesd204.scramble_enable = 1;
 	ad9250_jesd204.octets_per_frame = 1;

--- a/ad6676-ebz/ad6676_ebz.c
+++ b/ad6676-ebz/ad6676_ebz.c
@@ -208,7 +208,7 @@ int main(void)
 	ad6676_xcvr.dev.sys_clk_sel = 0;
 	ad6676_xcvr.reconfig_bypass = 0;
 	ad6676_xcvr.lane_rate_kbps = 4000000;
-	ad6676_xcvr.ref_clock_khz = 200000;
+	ad6676_xcvr.ref_rate_khz = 200000;
 
 	// adc settings
 

--- a/common_drivers/platform_drivers/platform_drivers.c
+++ b/common_drivers/platform_drivers/platform_drivers.c
@@ -204,7 +204,7 @@ int32_t spi_init(spi_desc **desc,
 	dev->cpha = param->cpha;
 	dev->cpol = param->cpol;
 
-	#ifdef ZYNQ
+#ifdef ZYNQ
 	m_spi_config = XSpiPs_LookupConfig(dev->device_id);
 
 	if (m_spi_config == NULL) {
@@ -212,11 +212,12 @@ int32_t spi_init(spi_desc **desc,
 		return FAILURE;
 	}
 
-	if (XSpiPs_CfgInitialize(&m_spi, m_spi_config, m_spi_config->BaseAddress) != 0) {
+	if (XSpiPs_CfgInitialize(&m_spi, m_spi_config,
+				 m_spi_config->BaseAddress) != 0) {
 		free(dev);
 		return FAILURE;
 	}
-	#endif
+#endif
 
 	*desc = dev;
 
@@ -255,9 +256,9 @@ int32_t spi_write_and_read(spi_desc *desc,
 	initss = initss | (0x7 << XSPIPS_CR_SSCTRL_SHIFT);
 	XSpiPs_WriteReg(desc->base_address, XSPIPS_CR_OFFSET, initss);
 	XSpiPs_SetOptions(&m_spi, XSPIPS_MASTER_OPTION |
-			XSPIPS_DECODE_SSELECT_OPTION | XSPIPS_FORCE_SSELECT_OPTION |
-			((desc->cpol == 1) ? XSPIPS_CLK_ACTIVE_LOW_OPTION : 0) |
-			((desc->cpha == 1) ? XSPIPS_CLK_PHASE_1_OPTION : 0));
+			  XSPIPS_DECODE_SSELECT_OPTION | XSPIPS_FORCE_SSELECT_OPTION |
+			  ((desc->cpol == 1) ? XSPIPS_CLK_ACTIVE_LOW_OPTION : 0) |
+			  ((desc->cpha == 1) ? XSPIPS_CLK_PHASE_1_OPTION : 0));
 	XSpiPs_SetSlaveSelect(&m_spi,  (uint8_t) 0x7);
 	XSpiPs_SetClkPrescaler(&m_spi, XSPIPS_CLK_PRESCALE_64);
 	XSpiPs_SetSlaveSelect(&m_spi,  (uint8_t) (desc->chip_select & 0x7));
@@ -288,14 +289,16 @@ int32_t spi_write_and_read(spi_desc *desc,
 	uint32_t i;
 
 	Xil_Out32((XPAR_SPI_0_BASEADDR + 0x70), desc->chip_select);
-	Xil_Out32((XPAR_SPI_0_BASEADDR + 0x60), (0x086 | (desc->cpol<<3) | (desc->cpha<<4)));
+	Xil_Out32((XPAR_SPI_0_BASEADDR + 0x60),
+		  (0x086 | (desc->cpol<<3) | (desc->cpha<<4)));
 	for (i = 0; i < bytes_number; i++) {
 		Xil_Out32((XPAR_SPI_0_BASEADDR + 0x68), *(data + i));
 		while ((Xil_In32(XPAR_SPI_0_BASEADDR + 0x64) & 0x1) == 0x1) {}
 		*(data + i) = Xil_In32(XPAR_SPI_0_BASEADDR + 0x6c) & 0xff;
 	}
 	Xil_Out32((XPAR_SPI_0_BASEADDR + 0x70), 0xff);
-	Xil_Out32((XPAR_SPI_0_BASEADDR + 0x60), (0x186 | (desc->cpol<<3) | (desc->cpha<<4)));
+	Xil_Out32((XPAR_SPI_0_BASEADDR + 0x60),
+		  (0x186 | (desc->cpol<<3) | (desc->cpha<<4)));
 
 #endif
 
@@ -439,7 +442,8 @@ int32_t gpio_set_value(gpio_desc *desc,
 		pdata = Xil_In32(XPAR_PS7_GPIO_0_BASEADDR + 0x02c8);
 		Xil_Out32((XPAR_PS7_GPIO_0_BASEADDR + 0x02c8), (pdata | pmask));
 		pdata = Xil_In32(XPAR_PS7_GPIO_0_BASEADDR + 0x004c);
-		Xil_Out32((XPAR_PS7_GPIO_0_BASEADDR + 0x004c), ((pdata & ~pmask) | (value << ppos)));
+		Xil_Out32((XPAR_PS7_GPIO_0_BASEADDR + 0x004c),
+			  ((pdata & ~pmask) | (value << ppos)));
 		pstatus = 0;
 		break;
 #endif
@@ -450,14 +454,16 @@ int32_t gpio_set_value(gpio_desc *desc,
 		pdata = Xil_In32(XPAR_PSU_GPIO_0_BASEADDR + 0x0308);
 		Xil_Out32((XPAR_PSU_GPIO_0_BASEADDR + 0x0308), (pdata | pmask));
 		pdata = Xil_In32(XPAR_PSU_GPIO_0_BASEADDR + 0x0050);
-		Xil_Out32((XPAR_PSU_GPIO_0_BASEADDR + 0x0050), ((pdata & ~pmask) | (value << ppos)));
+		Xil_Out32((XPAR_PSU_GPIO_0_BASEADDR + 0x0050),
+			  ((pdata & ~pmask) | (value << ppos)));
 		pstatus = 0;
 		break;
 #endif
 #ifdef NIOS_II
 	case NIOS_II_GPIO:
 		pdata = IORD_32DIRECT(SYS_GPIO_OUT_BASE, 0x0);
-		IOWR_32DIRECT(SYS_GPIO_OUT_BASE, 0x0, ((pdata & ~pmask) | (value << ppos)));
+		IOWR_32DIRECT(SYS_GPIO_OUT_BASE, 0x0,
+			      ((pdata & ~pmask) | (value << ppos)));
 		pstatus = 0;
 		break;
 #endif
@@ -466,7 +472,8 @@ int32_t gpio_set_value(gpio_desc *desc,
 		pdata = Xil_In32(XPAR_AXI_GPIO_BASEADDR + 0xc);
 		Xil_Out32((XPAR_AXI_GPIO_BASEADDR + 0xc), (pdata & ~pmask));
 		pdata = Xil_In32(XPAR_AXI_GPIO_BASEADDR + 0x8);
-		Xil_Out32((XPAR_AXI_GPIO_BASEADDR + 0x8), ((pdata & ~pmask) | (value << ppos)));
+		Xil_Out32((XPAR_AXI_GPIO_BASEADDR + 0x8),
+			  ((pdata & ~pmask) | (value << ppos)));
 		pstatus = 0;
 		break;
 #endif
@@ -491,15 +498,15 @@ int32_t gpio_get_value(gpio_desc *desc,
 	int32_t pstatus;
 	uint32_t ppos;
 	uint32_t pdata;
-	#ifdef ZYNQ
+#ifdef ZYNQ
 	uint32_t pmask;
-	#endif
+#endif
 
 	pstatus = -1;
 	ppos = desc->number - 32;
-	#ifdef ZYNQ
+#ifdef ZYNQ
 	pmask = 0x1 << ppos;
-	#endif
+#endif
 
 	switch(desc->type) {
 #ifdef ZYNQ_PS7
@@ -543,7 +550,7 @@ int32_t gpio_get_value(gpio_desc *desc,
 
 /***************************************************************************//**
  * @brief ad_gpio_set_range
- *******************************************************************************/
+ ******************************************************************************/
 
 int32_t ad_gpio_set_range(uint8_t start_pin, uint8_t num_pins, uint8_t data)
 {
@@ -568,7 +575,8 @@ int32_t ad_gpio_set_range(uint8_t start_pin, uint8_t num_pins, uint8_t data)
 	pdata = Xil_In32(XPAR_PS7_GPIO_0_BASEADDR + 0x02c8);
 	Xil_Out32((XPAR_PS7_GPIO_0_BASEADDR + 0x02c8), (pdata | pmask));
 	pdata = Xil_In32(XPAR_PS7_GPIO_0_BASEADDR + 0x004c);
-	Xil_Out32((XPAR_PS7_GPIO_0_BASEADDR + 0x004c), ((pdata & ~pmask) | (data << ppos)));
+	Xil_Out32((XPAR_PS7_GPIO_0_BASEADDR + 0x004c),
+		  ((pdata & ~pmask) | (data << ppos)));
 	pstatus = 0;
 
 #endif
@@ -580,7 +588,8 @@ int32_t ad_gpio_set_range(uint8_t start_pin, uint8_t num_pins, uint8_t data)
 	pdata = Xil_In32(XPAR_PSU_GPIO_0_BASEADDR + 0x0308);
 	Xil_Out32((XPAR_PSU_GPIO_0_BASEADDR + 0x0308), (pdata | pmask));
 	pdata = Xil_In32(XPAR_PSU_GPIO_0_BASEADDR + 0x0050);
-	Xil_Out32((XPAR_PSU_GPIO_0_BASEADDR + 0x0050), ((pdata & ~pmask) | (data << ppos)));
+	Xil_Out32((XPAR_PSU_GPIO_0_BASEADDR + 0x0050),
+		  ((pdata & ~pmask) | (data << ppos)));
 	pstatus = 0;
 
 #endif
@@ -598,7 +607,8 @@ int32_t ad_gpio_set_range(uint8_t start_pin, uint8_t num_pins, uint8_t data)
 	pdata = Xil_In32(XPAR_AXI_GPIO_BASEADDR + 0xc);
 	Xil_Out32((XPAR_AXI_GPIO_BASEADDR + 0xc), (pdata & ~pmask));
 	pdata = Xil_In32(XPAR_AXI_GPIO_BASEADDR + 0x8);
-	Xil_Out32((XPAR_AXI_GPIO_BASEADDR + 0x8), ((pdata & ~pmask) | (data << ppos)));
+	Xil_Out32((XPAR_AXI_GPIO_BASEADDR + 0x8),
+		  ((pdata & ~pmask) | (data << ppos)));
 	pstatus = 0;
 
 #endif
@@ -608,7 +618,7 @@ int32_t ad_gpio_set_range(uint8_t start_pin, uint8_t num_pins, uint8_t data)
 
 /***************************************************************************//**
  * @brief ad_gpio_get_range
- *******************************************************************************/
+ ******************************************************************************/
 
 int32_t ad_gpio_get_range(uint8_t start_pin, uint8_t num_pins, uint32_t *data)
 {
@@ -667,7 +677,7 @@ int32_t ad_gpio_get_range(uint8_t start_pin, uint8_t num_pins, uint32_t *data)
 
 /***************************************************************************//**
  * @brief do_div
- *******************************************************************************/
+ ******************************************************************************/
 uint64_t do_div(uint64_t* n, uint64_t base)
 {
 	uint64_t mod = 0;
@@ -680,7 +690,7 @@ uint64_t do_div(uint64_t* n, uint64_t base)
 
 /***************************************************************************//**
  * @brief ad_reg_write_16
- *******************************************************************************/
+ ******************************************************************************/
 void ad_reg_write_16(uint32_t addr, uint32_t data)
 {
 	uint32_t m_data;
@@ -723,7 +733,7 @@ void usleep(uint32_t us_count)
 
 /***************************************************************************//**
  * @brief ad_uart_read
- *******************************************************************************/
+ ******************************************************************************/
 uint8_t ad_uart_read()
 {
 #ifdef ZYNQ_PS7
@@ -748,8 +758,9 @@ uint8_t ad_uart_read()
 
 /***************************************************************************//**
  * @brief ad_pow2 Create a mask for a given number of bit
- *******************************************************************************/
-uint32_t ad_pow2(uint32_t number) {
+ ******************************************************************************/
+uint32_t ad_pow2(uint32_t number)
+{
 
 	uint32_t index;
 	uint32_t mask = 1;

--- a/common_drivers/platform_drivers/platform_drivers.c
+++ b/common_drivers/platform_drivers/platform_drivers.c
@@ -213,7 +213,7 @@ int32_t spi_init(spi_desc **desc,
 	}
 
 	if (XSpiPs_CfgInitialize(&m_spi, m_spi_config, m_spi_config->BaseAddress) != 0) {
-		free(dev)
+		free(dev);
 		return FAILURE;
 	}
 	#endif

--- a/common_drivers/xcvr_core/xcvr_core.c
+++ b/common_drivers/xcvr_core/xcvr_core.c
@@ -238,11 +238,11 @@ int32_t xcvr_setup(xcvr_core *core)
 	xcvr_write(core, XCVR_REG_RESETN, 0);  // enter reset state
 
 	if (core->reconfig_bypass == 0) {
-		if (core->lane_rate_khz > 12500000) {
+		if (core->lane_rate_kbps > 12500000) {
 			printf("ERROR: Max qpll lane_rate: %d", 12500000);
 			return -1;
 		}
-		if (core->lane_rate_khz < 1250000) {
+		if (core->lane_rate_kbps < 1250000) {
 			printf("ERROR: Min cpll lane_rate: %d", 1250000);
 			return -1;
 		}
@@ -250,7 +250,8 @@ int32_t xcvr_setup(xcvr_core *core)
 		if (core->dev.cpll_enable == 0) {
 			printf("\nQPLL ENABLE\n");
 			ret |= xilinx_xcvr_calc_qpll_config(core, core->ref_rate_khz,
-							    core->lane_rate_khz, &qpll_config, &core->dev.out_div);
+							    core->lane_rate_kbps, &qpll_config,
+							    &core->dev.out_div);
 			out_div = core->dev.out_div;
 
 			ln_rate_kbps = xilinx_xcvr_qpll_calc_lane_rate(core,
@@ -263,7 +264,8 @@ int32_t xcvr_setup(xcvr_core *core)
 		} else {
 			printf("\nCPLL ENABLE\n");
 			ret |= xilinx_xcvr_calc_cpll_config(core, core->ref_rate_khz,
-							    core->lane_rate_khz, &cpll_config, &core->dev.out_div);
+							    core->lane_rate_kbps, &cpll_config,
+							    &core->dev.out_div);
 			out_div = core->dev.out_div;
 
 			ln_rate_kbps = xilinx_xcvr_cpll_calc_lane_rate(core,
@@ -276,10 +278,10 @@ int32_t xcvr_setup(xcvr_core *core)
 		}
 
 
-		if ((ln_rate_kbps == 0) || (ln_rate_kbps != core->lane_rate_khz)) {
+		if ((ln_rate_kbps == 0) || (ln_rate_kbps != core->lane_rate_kbps)) {
 			printf("%s: Faild to set line rate!",__func__);
 			printf("Desired rate: %lu, obtained rate: %lu\n",
-			       core->lane_rate_khz, ln_rate_kbps);
+			       core->lane_rate_kbps, ln_rate_kbps);
 			return -1;
 		}
 
@@ -296,7 +298,7 @@ int32_t xcvr_setup(xcvr_core *core)
 							   core->dev.lpm_enable);
 			xilinx_xcvr_configure_cdr(core,
 						  XCVR_DRP_PORT_COMMON,
-						  core->lane_rate_khz,
+						  core->lane_rate_kbps,
 						  out_div,
 						  core->dev.lpm_enable);
 			rx_out_div = out_div;

--- a/common_drivers/xcvr_core/xcvr_core.h
+++ b/common_drivers/xcvr_core/xcvr_core.h
@@ -104,7 +104,7 @@ typedef struct {
 	uint32_t			   base_address;
 	xilinx_xcvr_refclk_ppm ppm;
 	uint16_t			   encoding;
-	uint32_t			   lane_rate_khz;
+	uint32_t			   lane_rate_kbps;
 	uint32_t			   ref_rate_khz;
 	uint8_t				   reconfig_bypass;
 	struct fpga_dev		   dev;

--- a/common_drivers/xcvr_core/xcvr_modules/xilinx_xcvr_channel.c
+++ b/common_drivers/xcvr_core/xcvr_modules/xilinx_xcvr_channel.c
@@ -367,7 +367,7 @@ uint32_t xilinx_xcvr_cpll_calc_lane_rate(xcvr_core *core,
 		return 0;
 
 	return (refclk_hz * conf->fb_div_N1 * conf->fb_div_N2 * 2) /
-	       (conf->refclk_div * out_div * 1000);
+	       (conf->refclk_div * out_div);
 }
 
 /***************************************************************************//**

--- a/fmcadc2/fmcadc2.c
+++ b/fmcadc2/fmcadc2.c
@@ -137,9 +137,9 @@ int main(void)
 	// test the captured data
 	if(!dmac_start_transaction(ad9625_dma)) {
 		adc_ramp_test(ad9625_core,
-					  1,
-					  rx_xfer.no_of_samples / ad9625_core.no_of_channels,
-					  rx_xfer.start_address);
+			      1,
+			      rx_xfer.no_of_samples / ad9625_core.no_of_channels,
+			      rx_xfer.start_address);
 	};
 
 	// capture data with DMA

--- a/fmcadc2/fmcadc2.c
+++ b/fmcadc2/fmcadc2.c
@@ -95,7 +95,7 @@ int main(void)
 	xcvr_getconfig(&ad9625_xcvr);
 	ad9625_xcvr.reconfig_bypass = 0;
 	ad9625_xcvr.lane_rate_kbps = ad9625_param.lane_rate_kbps;
-	ad9625_xcvr.ref_clock_khz = 625000;
+	ad9625_xcvr.ref_rate_khz = 625000;
 
 	ad9625_jesd.scramble_enable = 1;
 	ad9625_jesd.octets_per_frame = 1;

--- a/fmcadc4/fmcadc4.c
+++ b/fmcadc4/fmcadc4.c
@@ -213,7 +213,7 @@ int main(void)
 	ad9680_1_core.no_of_channels = 2;
 	ad9680_1_core.resolution = 14;
 
-    // receiver DMA configuration
+	// receiver DMA configuration
 
 #ifdef ZYNQ
 	rx_xfer.start_address = XPAR_DDR_MEM_BASEADDR + 0x800000;
@@ -285,15 +285,15 @@ int main(void)
 	ad9680_test(ad9680_0_device, AD9680_TEST_RAMP);
 	ad9680_test(ad9680_1_device, AD9680_TEST_RAMP);
 
-	if(!dmac_start_transaction(ad9680_dma)){
+	if(!dmac_start_transaction(ad9680_dma)) {
 		adc_ramp_test(ad9680_0_core, 2,
-					  rx_xfer.no_of_samples / (2*ad9680_0_core.no_of_channels),
-					  rx_xfer.start_address);
+			      rx_xfer.no_of_samples / (2*ad9680_0_core.no_of_channels),
+			      rx_xfer.start_address);
 	};
 
 	ad9680_test(ad9680_0_device, AD9680_TEST_OFF);
 	ad9680_test(ad9680_1_device, AD9680_TEST_OFF);
-	if(!dmac_start_transaction(ad9680_dma)){
+	if(!dmac_start_transaction(ad9680_dma)) {
 		ad_printf("RX capture done.\n");
 	};
 

--- a/fmcadc4/fmcadc4.c
+++ b/fmcadc4/fmcadc4.c
@@ -238,9 +238,9 @@ int main(void)
 
 	xcvr_getconfig(&ad9680_xcvr);
 	ad9680_xcvr.reconfig_bypass = 0;
-	ad9680_xcvr.ref_clock_khz = 500000;
+	ad9680_xcvr.ref_rate_khz = 500000;
 	ad9680_xcvr.lane_rate_kbps = ad9680_0_param.lane_rate_kbps;
-	ad9680_xcvr.dev.qpll_enable = 1;
+	ad9680_xcvr.dev.cpll_enable = 0;
 
 	gpio_get(&gpio_ad9528_status, GPIO_AD9528_STATUS);
 	gpio_get(&gpio_ad9528_rstn, GPIO_AD9528_RSTN);

--- a/fmcadc5/fmcadc5.c
+++ b/fmcadc5/fmcadc5.c
@@ -187,8 +187,6 @@ int main(void)
 	rx_xfer.id = 0;
 	rx_xfer.no_of_samples = 32768;
 
-	ad_platform_init();
-
 	/* Set up the device */
 	ad9625_setup(&ad9625_0_device, ad9625_0_param);
 	ad9625_setup(&ad9625_1_device, ad9625_1_param);
@@ -261,8 +259,6 @@ int main(void)
 	gpio_remove(gpio_pwr_good);
 
 	i5g_remove(i5g_core);
-
-	ad_platform_close();
 
 	printf("Done\n");
 

--- a/fmcadc5/fmcadc5.c
+++ b/fmcadc5/fmcadc5.c
@@ -155,12 +155,12 @@ int main(void)
 	xcvr_getconfig(&ad9625_0_xcvr);
 	ad9625_0_xcvr.reconfig_bypass = 1;
 	ad9625_0_xcvr.lane_rate_kbps = ad9625_0_param.lane_rate_kbps;
-	ad9625_0_xcvr.ref_clock_khz = 625000;
+	ad9625_0_xcvr.ref_rate_khz = 625000;
 
 	xcvr_getconfig(&ad9625_1_xcvr);
 	ad9625_1_xcvr.reconfig_bypass = 1;
 	ad9625_1_xcvr.lane_rate_kbps = ad9625_1_param.lane_rate_kbps;
-	ad9625_1_xcvr.ref_clock_khz = 625000;
+	ad9625_1_xcvr.ref_rate_khz = 625000;
 
 	ad9625_0_jesd.scramble_enable = 1;
 	ad9625_0_jesd.octets_per_frame = 1;

--- a/fmcadc5/fmcadc5.c
+++ b/fmcadc5/fmcadc5.c
@@ -134,10 +134,10 @@ int main(void)
 	if (!pwr_good) {
 		xil_printf("Error: GPIO Power Good NOT set.\n\r");
 		return -1;
-    }
+	}
 	gpio_set_value(gpio_rst_0, 1);
 	gpio_set_value(gpio_rst_1, 1);
-        	mdelay(100);
+	mdelay(100);
 
 	/* ADC and receive path configuration */
 	ad9625_0_param.lane_rate_kbps = 6250000;

--- a/fmcdaq2/fmcdaq2.c
+++ b/fmcdaq2/fmcdaq2.c
@@ -572,7 +572,7 @@ int main(void)
 	xcvr_setup(&ad9680_xcvr);
 #endif
 #ifdef XILINX
-	if (ad9144_xcvr.dev.qpll_enable) {	// DAC_XCVR controls the QPLL reset
+	if (!ad9144_xcvr.dev.cpll_enable) {	// DAC_XCVR controls the QPLL reset
 		xcvr_setup(&ad9144_xcvr);
 		xcvr_setup(&ad9680_xcvr);
 	} else {				// ADC_XCVR controls the CPLL reset

--- a/fmcdaq2/fmcdaq2.c
+++ b/fmcdaq2/fmcdaq2.c
@@ -84,10 +84,10 @@ enum ad9523_channels {
  * @brief main
  ******************************************************************************/
 int fmcdaq2_reconfig(struct ad9144_init_param *p_ad9144_param,
-					 xcvr_core *p_ad9144_xcvr,
-					 struct ad9680_init_param *p_ad9680_param,
-			 	 	 xcvr_core *p_ad9680_xcvr,
-					 struct ad9523_platform_data *p_ad9523_param)
+		     xcvr_core *p_ad9144_xcvr,
+		     struct ad9680_init_param *p_ad9680_param,
+		     xcvr_core *p_ad9680_xcvr,
+		     struct ad9523_platform_data *p_ad9523_param)
 {
 
 	uint8_t mode = 0;
@@ -103,132 +103,132 @@ int fmcdaq2_reconfig(struct ad9144_init_param *p_ad9144_param,
 	mode = ad_uart_read();
 
 	switch (mode) {
-		case '5':
-			/* REF clock = 100 MHz */
-			p_ad9523_param->channels[DAC_DEVICE_CLK].channel_divider = 10;
-			p_ad9144_param->pll_ref_frequency_khz = 100000;
+	case '5':
+		/* REF clock = 100 MHz */
+		p_ad9523_param->channels[DAC_DEVICE_CLK].channel_divider = 10;
+		p_ad9144_param->pll_ref_frequency_khz = 100000;
 
-			/* DAC at 2 GHz using the internal PLL and 2 times interpolation */
-			p_ad9144_param->interpolation = 2;
-			p_ad9144_param->pll_enable = 1;
-			p_ad9144_param->pll_dac_frequency_khz = 2000000;
-			break;
-		case '4':
-			printf ("4 - ADC  600 MSPS; DAC  600 MSPS\n");
-			p_ad9523_param->pll2_vco_diff_m1 = 5;
-			(&p_ad9523_param->channels[DAC_FPGA_CLK])->
-					channel_divider = 2;
-			(&p_ad9523_param->channels[DAC_DEVICE_CLK])->
-					channel_divider = 1;
-			(&p_ad9523_param->channels[DAC_DEVICE_SYSREF])->
-					channel_divider = 128;
-			(&p_ad9523_param->channels[DAC_FPGA_SYSREF])->
-					channel_divider = 128;
-			(&p_ad9523_param->channels[ADC_FPGA_CLK])->
-					channel_divider = 2;
-			(&p_ad9523_param->channels[ADC_DEVICE_CLK])->
-					channel_divider = 1;
-			(&p_ad9523_param->channels[ADC_DEVICE_SYSREF])->
-					channel_divider = 128;
-			(&p_ad9523_param->channels[ADC_FPGA_SYSREF])->
-					channel_divider = 128;
-			p_ad9144_xcvr->reconfig_bypass = 0;
-			p_ad9144_param->lane_rate_kbps = 6000000;
-			p_ad9144_xcvr->lane_rate_kbps = 6000000;
-			p_ad9144_xcvr->ref_clock_khz = 300000;
-			p_ad9680_xcvr->reconfig_bypass = 0;
-			p_ad9680_param->lane_rate_kbps = 6000000;
-			p_ad9680_xcvr->lane_rate_kbps = 6000000;
-			p_ad9680_xcvr->ref_clock_khz = 300000;
+		/* DAC at 2 GHz using the internal PLL and 2 times interpolation */
+		p_ad9144_param->interpolation = 2;
+		p_ad9144_param->pll_enable = 1;
+		p_ad9144_param->pll_dac_frequency_khz = 2000000;
+		break;
+	case '4':
+		printf ("4 - ADC  600 MSPS; DAC  600 MSPS\n");
+		p_ad9523_param->pll2_vco_diff_m1 = 5;
+		(&p_ad9523_param->channels[DAC_FPGA_CLK])->
+		channel_divider = 2;
+		(&p_ad9523_param->channels[DAC_DEVICE_CLK])->
+		channel_divider = 1;
+		(&p_ad9523_param->channels[DAC_DEVICE_SYSREF])->
+		channel_divider = 128;
+		(&p_ad9523_param->channels[DAC_FPGA_SYSREF])->
+		channel_divider = 128;
+		(&p_ad9523_param->channels[ADC_FPGA_CLK])->
+		channel_divider = 2;
+		(&p_ad9523_param->channels[ADC_DEVICE_CLK])->
+		channel_divider = 1;
+		(&p_ad9523_param->channels[ADC_DEVICE_SYSREF])->
+		channel_divider = 128;
+		(&p_ad9523_param->channels[ADC_FPGA_SYSREF])->
+		channel_divider = 128;
+		p_ad9144_xcvr->reconfig_bypass = 0;
+		p_ad9144_param->lane_rate_kbps = 6000000;
+		p_ad9144_xcvr->lane_rate_kbps = 6000000;
+		p_ad9144_xcvr->ref_clock_khz = 300000;
+		p_ad9680_xcvr->reconfig_bypass = 0;
+		p_ad9680_param->lane_rate_kbps = 6000000;
+		p_ad9680_xcvr->lane_rate_kbps = 6000000;
+		p_ad9680_xcvr->ref_clock_khz = 300000;
 #ifdef XILINX
-			p_ad9144_xcvr->dev.lpm_enable = 0;
-			p_ad9144_xcvr->dev.qpll_enable = 0;
-			p_ad9144_xcvr->dev.out_clk_sel = 4;
+		p_ad9144_xcvr->dev.lpm_enable = 0;
+		p_ad9144_xcvr->dev.qpll_enable = 0;
+		p_ad9144_xcvr->dev.out_clk_sel = 4;
 
-			p_ad9680_xcvr->dev.lpm_enable = 1;
-			p_ad9680_xcvr->dev.qpll_enable = 0;
-			p_ad9680_xcvr->dev.out_clk_sel = 4;
+		p_ad9680_xcvr->dev.lpm_enable = 1;
+		p_ad9680_xcvr->dev.qpll_enable = 0;
+		p_ad9680_xcvr->dev.out_clk_sel = 4;
 #endif
-			break;
-		case '3':
-			printf ("3 - ADC  500 MSPS; DAC  500 MSPS\n");
-			p_ad9523_param->pll2_vco_diff_m1 = 3;
-			(&p_ad9523_param->channels[DAC_FPGA_CLK])->
-					channel_divider = 4;
-			(&p_ad9523_param->channels[DAC_DEVICE_CLK])->
-					channel_divider = 2;
-			(&p_ad9523_param->channels[DAC_DEVICE_SYSREF])->
-					channel_divider = 256;
-			(&p_ad9523_param->channels[DAC_FPGA_SYSREF])->
-					channel_divider = 256;
-			(&p_ad9523_param->channels[ADC_FPGA_CLK])->
-					channel_divider = 4;
-			(&p_ad9523_param->channels[ADC_DEVICE_CLK])->
-					channel_divider = 2;
-			(&p_ad9523_param->channels[ADC_DEVICE_SYSREF])->
-					channel_divider = 256;
-			(&p_ad9523_param->channels[ADC_FPGA_SYSREF])->
-					channel_divider = 256;
-			p_ad9144_xcvr->reconfig_bypass = 0;
-			p_ad9144_param->lane_rate_kbps = 5000000;
-			p_ad9144_xcvr->lane_rate_kbps = 5000000;
-			p_ad9144_xcvr->ref_clock_khz = 250000;
-			p_ad9680_xcvr->reconfig_bypass = 0;
-			p_ad9680_param->lane_rate_kbps = 5000000;
-			p_ad9680_xcvr->lane_rate_kbps = 5000000;
-			p_ad9680_xcvr->ref_clock_khz = 250000;
+		break;
+	case '3':
+		printf ("3 - ADC  500 MSPS; DAC  500 MSPS\n");
+		p_ad9523_param->pll2_vco_diff_m1 = 3;
+		(&p_ad9523_param->channels[DAC_FPGA_CLK])->
+		channel_divider = 4;
+		(&p_ad9523_param->channels[DAC_DEVICE_CLK])->
+		channel_divider = 2;
+		(&p_ad9523_param->channels[DAC_DEVICE_SYSREF])->
+		channel_divider = 256;
+		(&p_ad9523_param->channels[DAC_FPGA_SYSREF])->
+		channel_divider = 256;
+		(&p_ad9523_param->channels[ADC_FPGA_CLK])->
+		channel_divider = 4;
+		(&p_ad9523_param->channels[ADC_DEVICE_CLK])->
+		channel_divider = 2;
+		(&p_ad9523_param->channels[ADC_DEVICE_SYSREF])->
+		channel_divider = 256;
+		(&p_ad9523_param->channels[ADC_FPGA_SYSREF])->
+		channel_divider = 256;
+		p_ad9144_xcvr->reconfig_bypass = 0;
+		p_ad9144_param->lane_rate_kbps = 5000000;
+		p_ad9144_xcvr->lane_rate_kbps = 5000000;
+		p_ad9144_xcvr->ref_clock_khz = 250000;
+		p_ad9680_xcvr->reconfig_bypass = 0;
+		p_ad9680_param->lane_rate_kbps = 5000000;
+		p_ad9680_xcvr->lane_rate_kbps = 5000000;
+		p_ad9680_xcvr->ref_clock_khz = 250000;
 #ifdef XILINX
-			p_ad9144_xcvr->dev.lpm_enable = 1;
-			p_ad9144_xcvr->dev.qpll_enable = 0;
-			p_ad9144_xcvr->dev.out_clk_sel = 4;
+		p_ad9144_xcvr->dev.lpm_enable = 1;
+		p_ad9144_xcvr->dev.qpll_enable = 0;
+		p_ad9144_xcvr->dev.out_clk_sel = 4;
 
-			p_ad9680_xcvr->dev.lpm_enable = 1;
-			p_ad9680_xcvr->dev.qpll_enable = 0;
-			p_ad9680_xcvr->dev.out_clk_sel = 4;
+		p_ad9680_xcvr->dev.lpm_enable = 1;
+		p_ad9680_xcvr->dev.qpll_enable = 0;
+		p_ad9680_xcvr->dev.out_clk_sel = 4;
 #endif
-			break;
-		case '2':
-			printf ("2 - ADC  500 MSPS; DAC 1000 MSPS\n");
-			p_ad9523_param->pll2_vco_diff_m1 = 3;
-			(&p_ad9523_param->channels[DAC_FPGA_CLK])->
-					channel_divider = 2;
-			(&p_ad9523_param->channels[DAC_DEVICE_CLK])->
-					channel_divider = 1;
-			(&p_ad9523_param->channels[DAC_DEVICE_SYSREF])->
-					channel_divider = 128;
-			(&p_ad9523_param->channels[DAC_FPGA_SYSREF])->
-					channel_divider = 128;
-			(&p_ad9523_param->channels[ADC_FPGA_CLK])->
-					channel_divider = 4;
-			(&p_ad9523_param->channels[ADC_DEVICE_CLK])->
-					channel_divider = 2;
-			(&p_ad9523_param->channels[ADC_DEVICE_SYSREF])->
-					channel_divider = 256;
-			(&p_ad9523_param->channels[ADC_FPGA_SYSREF])->
-					channel_divider = 256;
-			p_ad9144_xcvr->reconfig_bypass = 0;
-			p_ad9144_param->lane_rate_kbps = 10000000;
-			p_ad9144_xcvr->lane_rate_kbps = 10000000;
-			p_ad9144_xcvr->ref_clock_khz = 500000;
-			p_ad9680_xcvr->reconfig_bypass = 0;
-			p_ad9680_param->lane_rate_kbps = 5000000;
-			p_ad9680_xcvr->lane_rate_kbps = 5000000;
-			p_ad9680_xcvr->ref_clock_khz = 250000;
+		break;
+	case '2':
+		printf ("2 - ADC  500 MSPS; DAC 1000 MSPS\n");
+		p_ad9523_param->pll2_vco_diff_m1 = 3;
+		(&p_ad9523_param->channels[DAC_FPGA_CLK])->
+		channel_divider = 2;
+		(&p_ad9523_param->channels[DAC_DEVICE_CLK])->
+		channel_divider = 1;
+		(&p_ad9523_param->channels[DAC_DEVICE_SYSREF])->
+		channel_divider = 128;
+		(&p_ad9523_param->channels[DAC_FPGA_SYSREF])->
+		channel_divider = 128;
+		(&p_ad9523_param->channels[ADC_FPGA_CLK])->
+		channel_divider = 4;
+		(&p_ad9523_param->channels[ADC_DEVICE_CLK])->
+		channel_divider = 2;
+		(&p_ad9523_param->channels[ADC_DEVICE_SYSREF])->
+		channel_divider = 256;
+		(&p_ad9523_param->channels[ADC_FPGA_SYSREF])->
+		channel_divider = 256;
+		p_ad9144_xcvr->reconfig_bypass = 0;
+		p_ad9144_param->lane_rate_kbps = 10000000;
+		p_ad9144_xcvr->lane_rate_kbps = 10000000;
+		p_ad9144_xcvr->ref_clock_khz = 500000;
+		p_ad9680_xcvr->reconfig_bypass = 0;
+		p_ad9680_param->lane_rate_kbps = 5000000;
+		p_ad9680_xcvr->lane_rate_kbps = 5000000;
+		p_ad9680_xcvr->ref_clock_khz = 250000;
 #ifdef XILINX
-			p_ad9144_xcvr->dev.lpm_enable = 0;
-			p_ad9144_xcvr->dev.qpll_enable = 1;
-			p_ad9144_xcvr->dev.out_clk_sel = 4;
+		p_ad9144_xcvr->dev.lpm_enable = 0;
+		p_ad9144_xcvr->dev.qpll_enable = 1;
+		p_ad9144_xcvr->dev.out_clk_sel = 4;
 
-			p_ad9680_xcvr->dev.lpm_enable = 1;
-			p_ad9680_xcvr->dev.qpll_enable = 0;
-			p_ad9680_xcvr->dev.out_clk_sel = 4;
+		p_ad9680_xcvr->dev.lpm_enable = 1;
+		p_ad9680_xcvr->dev.qpll_enable = 0;
+		p_ad9680_xcvr->dev.out_clk_sel = 4;
 #endif
-			break;
-		default:
-			printf ("1 - ADC 1000 MSPS; DAC 1000 MSPS\n");
-			p_ad9144_xcvr->ref_clock_khz = 500000;
-			p_ad9680_xcvr->ref_clock_khz = 500000;
-			break;
+		break;
+	default:
+		printf ("1 - ADC 1000 MSPS; DAC 1000 MSPS\n");
+		p_ad9144_xcvr->ref_clock_khz = 500000;
+		p_ad9680_xcvr->ref_clock_khz = 500000;
+		break;
 	}
 
 	return(0);
@@ -326,23 +326,23 @@ int main(void)
 
 #ifdef ALTERA
 	ad9144_xcvr.base_address =
-			AD9144_JESD204_LINK_MANAGEMENT_BASE;
+		AD9144_JESD204_LINK_MANAGEMENT_BASE;
 	ad9144_xcvr.dev.link_pll.base_address =
-			AD9144_JESD204_LINK_PLL_RECONFIG_BASE;
+		AD9144_JESD204_LINK_PLL_RECONFIG_BASE;
 	ad9144_xcvr.dev.atx_pll.base_address =
-			AD9144_JESD204_LANE_PLL_RECONFIG_BASE;
+		AD9144_JESD204_LANE_PLL_RECONFIG_BASE;
 	ad9144_core.base_address =
-			AXI_AD9144_CORE_BASE;
+		AXI_AD9144_CORE_BASE;
 	ad9680_xcvr.base_address =
-			AD9680_JESD204_LINK_MANAGEMENT_BASE;
+		AD9680_JESD204_LINK_MANAGEMENT_BASE;
 	ad9680_xcvr.dev.link_pll.base_address =
-			AD9680_JESD204_LINK_PLL_RECONFIG_BASE;
+		AD9680_JESD204_LINK_PLL_RECONFIG_BASE;
 	ad9680_core.base_address =
-			AXI_AD9680_CORE_BASE;
+		AXI_AD9680_CORE_BASE;
 	ad9144_jesd.base_address =
-			AD9144_JESD204_LINK_RECONFIG_BASE;
+		AD9144_JESD204_LINK_RECONFIG_BASE;
 	ad9680_jesd.base_address =
-			AD9680_JESD204_LINK_RECONFIG_BASE;
+		AD9680_JESD204_LINK_RECONFIG_BASE;
 
 	ad9144_xcvr.dev.channel_pll[0].type = cmu_tx_type;
 	ad9680_xcvr.dev.channel_pll[0].type = cmu_cdr_type;
@@ -454,21 +454,21 @@ int main(void)
 	ad9144_core.channels = &ad9144_channels[0];
 
 	ad9144_param.stpl_samples[0][0] =
-			(ad9144_channels[0].pat_data >> 0)  & 0xffff;
+		(ad9144_channels[0].pat_data >> 0)  & 0xffff;
 	ad9144_param.stpl_samples[0][1] =
-			(ad9144_channels[0].pat_data >> 16) & 0xffff;
+		(ad9144_channels[0].pat_data >> 16) & 0xffff;
 	ad9144_param.stpl_samples[0][2] =
-			(ad9144_channels[0].pat_data >> 0)  & 0xffff;
+		(ad9144_channels[0].pat_data >> 0)  & 0xffff;
 	ad9144_param.stpl_samples[0][3] =
-			(ad9144_channels[0].pat_data >> 16) & 0xffff;
+		(ad9144_channels[0].pat_data >> 16) & 0xffff;
 	ad9144_param.stpl_samples[1][0] =
-			(ad9144_channels[1].pat_data >> 0)  & 0xffff;
+		(ad9144_channels[1].pat_data >> 0)  & 0xffff;
 	ad9144_param.stpl_samples[1][1] =
-			(ad9144_channels[1].pat_data >> 16) & 0xffff;
+		(ad9144_channels[1].pat_data >> 16) & 0xffff;
 	ad9144_param.stpl_samples[1][2] =
-			(ad9144_channels[1].pat_data >> 0)  & 0xffff;
+		(ad9144_channels[1].pat_data >> 0)  & 0xffff;
 	ad9144_param.stpl_samples[1][3] =
-			(ad9144_channels[1].pat_data >> 16) & 0xffff;
+		(ad9144_channels[1].pat_data >> 16) & 0xffff;
 
 //******************************************************************************
 // ADC (AD9680) and the receive path ( AXI_ADXCVR,
@@ -510,10 +510,10 @@ int main(void)
 
 	// change the default JESD configurations, if required
 	fmcdaq2_reconfig(&ad9144_param,
-					 &ad9144_xcvr,
-					 &ad9680_param,
-					 &ad9680_xcvr,
-					 ad9523_param.pdata);
+			 &ad9144_xcvr,
+			 &ad9680_param,
+			 &ad9680_xcvr,
+			 ad9523_param.pdata);
 
 //******************************************************************************
 // bring up the system
@@ -642,7 +642,7 @@ int main(void)
 	ad9144_channels[1].sel = DAC_SRC_DMA;
 	dac_data_setup(&ad9144_core);
 
-	if(!dmac_start_transaction(ad9144_dma)){
+	if(!dmac_start_transaction(ad9144_dma)) {
 		printf("daq2: transmit data from memory\n");
 	};
 #else
@@ -657,7 +657,7 @@ int main(void)
 //******************************************************************************
 
 	ad9680_test(ad9680_device, AD9680_TEST_OFF);
-	if(!dmac_start_transaction(ad9680_dma)){
+	if(!dmac_start_transaction(ad9680_dma)) {
 		printf("daq2: RX capture done.\n");
 	};
 

--- a/fmcdaq2/fmcdaq2.c
+++ b/fmcdaq2/fmcdaq2.c
@@ -135,18 +135,18 @@ int fmcdaq2_reconfig(struct ad9144_init_param *p_ad9144_param,
 		p_ad9144_xcvr->reconfig_bypass = 0;
 		p_ad9144_param->lane_rate_kbps = 6000000;
 		p_ad9144_xcvr->lane_rate_kbps = 6000000;
-		p_ad9144_xcvr->ref_clock_khz = 300000;
+		p_ad9144_xcvr->ref_rate_khz = 300000;
 		p_ad9680_xcvr->reconfig_bypass = 0;
 		p_ad9680_param->lane_rate_kbps = 6000000;
 		p_ad9680_xcvr->lane_rate_kbps = 6000000;
-		p_ad9680_xcvr->ref_clock_khz = 300000;
+		p_ad9680_xcvr->ref_rate_khz = 300000;
 #ifdef XILINX
 		p_ad9144_xcvr->dev.lpm_enable = 0;
-		p_ad9144_xcvr->dev.qpll_enable = 0;
+		p_ad9144_xcvr->dev.cpll_enable = 1;
 		p_ad9144_xcvr->dev.out_clk_sel = 4;
 
 		p_ad9680_xcvr->dev.lpm_enable = 1;
-		p_ad9680_xcvr->dev.qpll_enable = 0;
+		p_ad9680_xcvr->dev.cpll_enable = 1;
 		p_ad9680_xcvr->dev.out_clk_sel = 4;
 #endif
 		break;
@@ -172,18 +172,18 @@ int fmcdaq2_reconfig(struct ad9144_init_param *p_ad9144_param,
 		p_ad9144_xcvr->reconfig_bypass = 0;
 		p_ad9144_param->lane_rate_kbps = 5000000;
 		p_ad9144_xcvr->lane_rate_kbps = 5000000;
-		p_ad9144_xcvr->ref_clock_khz = 250000;
+		p_ad9144_xcvr->ref_rate_khz = 250000;
 		p_ad9680_xcvr->reconfig_bypass = 0;
 		p_ad9680_param->lane_rate_kbps = 5000000;
 		p_ad9680_xcvr->lane_rate_kbps = 5000000;
-		p_ad9680_xcvr->ref_clock_khz = 250000;
+		p_ad9680_xcvr->ref_rate_khz = 250000;
 #ifdef XILINX
 		p_ad9144_xcvr->dev.lpm_enable = 1;
-		p_ad9144_xcvr->dev.qpll_enable = 0;
+		p_ad9144_xcvr->dev.cpll_enable = 1;
 		p_ad9144_xcvr->dev.out_clk_sel = 4;
 
 		p_ad9680_xcvr->dev.lpm_enable = 1;
-		p_ad9680_xcvr->dev.qpll_enable = 0;
+		p_ad9680_xcvr->dev.cpll_enable = 1;
 		p_ad9680_xcvr->dev.out_clk_sel = 4;
 #endif
 		break;
@@ -209,25 +209,25 @@ int fmcdaq2_reconfig(struct ad9144_init_param *p_ad9144_param,
 		p_ad9144_xcvr->reconfig_bypass = 0;
 		p_ad9144_param->lane_rate_kbps = 10000000;
 		p_ad9144_xcvr->lane_rate_kbps = 10000000;
-		p_ad9144_xcvr->ref_clock_khz = 500000;
+		p_ad9144_xcvr->ref_rate_khz = 500000;
 		p_ad9680_xcvr->reconfig_bypass = 0;
 		p_ad9680_param->lane_rate_kbps = 5000000;
 		p_ad9680_xcvr->lane_rate_kbps = 5000000;
-		p_ad9680_xcvr->ref_clock_khz = 250000;
+		p_ad9680_xcvr->ref_rate_khz = 250000;
 #ifdef XILINX
 		p_ad9144_xcvr->dev.lpm_enable = 0;
-		p_ad9144_xcvr->dev.qpll_enable = 1;
+		p_ad9144_xcvr->dev.cpll_enable = 0;
 		p_ad9144_xcvr->dev.out_clk_sel = 4;
 
 		p_ad9680_xcvr->dev.lpm_enable = 1;
-		p_ad9680_xcvr->dev.qpll_enable = 0;
+		p_ad9680_xcvr->dev.cpll_enable = 1;
 		p_ad9680_xcvr->dev.out_clk_sel = 4;
 #endif
 		break;
 	default:
 		printf ("1 - ADC 1000 MSPS; DAC 1000 MSPS\n");
-		p_ad9144_xcvr->ref_clock_khz = 500000;
-		p_ad9680_xcvr->ref_clock_khz = 500000;
+		p_ad9144_xcvr->ref_rate_khz = 500000;
+		p_ad9680_xcvr->ref_rate_khz = 500000;
 		break;
 	}
 
@@ -403,8 +403,8 @@ int main(void)
 	ad9523_pdata.rzero = 7;
 	ad9523_pdata.cpole1 = 2;
 
-	ad9144_xcvr.ref_clock_khz = 500000;
-	ad9680_xcvr.ref_clock_khz = 500000;
+	ad9144_xcvr.ref_rate_khz = 500000;
+	ad9680_xcvr.ref_rate_khz = 500000;
 
 //******************************************************************************
 // DAC (AD9144) and the transmit path (AXI_ADXCVR,
@@ -414,7 +414,7 @@ int main(void)
 	xcvr_getconfig(&ad9144_xcvr);
 	ad9144_xcvr.reconfig_bypass = 1;
 #ifdef XILINX
-	ad9144_xcvr.dev.qpll_enable = 1;
+	ad9144_xcvr.dev.cpll_enable = 0;
 #endif
 	ad9144_xcvr.lane_rate_kbps = 10000000;
 
@@ -480,7 +480,7 @@ int main(void)
 	xcvr_getconfig(&ad9680_xcvr);
 	ad9680_xcvr.reconfig_bypass = 1;
 #ifdef XILINX
-	ad9680_xcvr.dev.qpll_enable = 1;
+	ad9680_xcvr.dev.cpll_enable = 0;
 #endif
 	ad9680_xcvr.rx_tx_n = 1;
 	ad9680_xcvr.lane_rate_kbps = ad9680_param.lane_rate_kbps;

--- a/fmcdaq3/fmcdaq3.c
+++ b/fmcdaq3/fmcdaq3.c
@@ -218,7 +218,7 @@ int main(void)
 	xcvr_getconfig(&ad9152_xcvr);
 	ad9152_xcvr.reconfig_bypass = 0;
 	ad9152_xcvr.ref_rate_khz = 616500;
-	ad9152_xcvr.lane_rate_khz = 12330000;
+	ad9152_xcvr.lane_rate_kbps = 12330000;
 #ifdef XILINX
 	ad9152_xcvr.dev.cpll_enable = 0;
 #endif
@@ -272,7 +272,7 @@ int main(void)
 	xcvr_getconfig(&ad9680_xcvr);
 	ad9680_xcvr.reconfig_bypass = 0;
 	ad9680_xcvr.ref_rate_khz = 616500;
-	ad9680_xcvr.lane_rate_khz = 12330000;
+	ad9680_xcvr.lane_rate_kbps = 12330000;
 #ifdef XILINX
 	ad9680_xcvr.dev.cpll_enable = 0;
 #endif


### PR DESCRIPTION
After the xcvr_core updates some structure members changed names making projects using xcvr_core incorrect. Adjust new names, apply AStyle on the sources and tow minor bugs: one introduced with the xcvr_core update and one missing semicolon.