### PR TITLE
drivers: ad5592r: Fix read value reference

### DIFF
--- a/drivers/ad5592r/ad5592r-base.c
+++ b/drivers/ad5592r/ad5592r-base.c
@@ -63,7 +63,7 @@ int32_t ad5592r_base_reg_write(struct ad5592r_dev *dev, uint8_t reg,
  * @return 0 in case of success, negative error code otherwise
  */
 int32_t ad5592r_base_reg_read(struct ad5592r_dev *dev, uint8_t reg,
-			      uint16_t value)
+			      uint16_t *value)
 {
 	return dev->ops->reg_read(dev, reg, value);
 }

--- a/drivers/ad5592r/ad5592r-base.h
+++ b/drivers/ad5592r/ad5592r-base.h
@@ -110,7 +110,7 @@ struct ad5592r_dev {
 int32_t ad5592r_base_reg_write(struct ad5592r_dev *dev, uint8_t reg,
 			       uint16_t value);
 int32_t ad5592r_base_reg_read(struct ad5592r_dev *dev, uint8_t reg,
-			      uint16_t value);
+			      uint16_t *value);
 int32_t ad5592r_gpio_get(struct ad5592r_dev *dev, uint8_t offset);
 int32_t ad5592r_gpio_set(struct ad5592r_dev *dev, uint8_t offset,
 			 int32_t value);


### PR DESCRIPTION
Variable in which to read the register value should be passed by reference.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>