### PR TITLE
general: fix astyle path

### DIFF
--- a/ci/scripts/astyle.sh
+++ b/ci/scripts/astyle.sh
@@ -40,12 +40,10 @@ then
 	popd
 fi
 
-export PATH="build/astyle/build/gcc;$PATH"
-
 for file in $FILES; do
 	if is_source_file $file
 	then 
-		astyle --options=./ci/scripts/astyle_config $file
+		./build/astyle/build/gcc/bin/astyle --options=./ci/scripts/astyle_config $file
 	fi
 done;
 


### PR DESCRIPTION
Remove astyle path from PATH env var and access it directly from folder.
This solves the issue of finding the "astyle" command which fails the
Travis build.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>