### PR TITLE
ad7768-evb: ad7768_evb.mk: Typo fix

### DIFF
--- a/ad7768-evb/ad7768_evb.mk
+++ b/ad7768-evb/ad7768_evb.mk
@@ -11,7 +11,7 @@
 ## M_SRC_FILES:
 ##		if you want to hand pick files, use this variable to list source files.
 
-M_INC_DIRS +=  $(NOOS-DIR)/ad7768-evb/
+M_INC_DIRS +=  $(NOOS-DIR)/ad7768-evb
 M_INC_DIRS +=  $(NOOS-DIR)/drivers/ad7768
 
 M_HDR_FILES :=


### PR DESCRIPTION
The issue was discovered by:
https://github.com/analogdevicesinc/no-OS/issues/132

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>