### PR TITLE
ad7606: Add support for AD7606B ADC

### DIFF
--- a/drivers/ad7606/ad7606.h
+++ b/drivers/ad7606/ad7606.h
@@ -39,14 +39,39 @@
 #ifndef AD7606_H_
 #define AD7606_H_
 
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+/*
+ * Create a contiguous bitmask starting at bit position @l and ending at
+ * position @h.
+ */
+#define GENMASK(h, l) \
+		(((~0UL) - (1UL << (l)) + 1) & (~0UL >> (31 - (h))))
+#define BIT(x)	(1UL << (x))
+#define ARRAY_SIZE(x)			(sizeof(x) / sizeof((x)[0]))
+
+#define AD7606_RANGE_CH_ADDR(ch)	(0x03 + ((ch) >> 1))
+#define AD7606_OS_MODE			0x08
+
+/* AD7606_RANGE_CH_X_Y */
+#define AD7606_RANGE_CH_MSK(ch)		(GENMASK(3, 0) << (4 * ((ch) % 2)))
+#define AD7606_RANGE_CH_MODE(ch, mode)	\
+	((GENMASK(3, 0) & mode) << (4 * ((ch) % 2)))
+
+#define AD7606_RD_FLAG_MSK(x)		(BIT(6) | ((x) & 0x3F))
+#define AD7606_WR_FLAG_MSK(x)		((x) & 0x3F)
+
 enum ad7606_supported_device_ids {
 	ID_AD7605_4,
 	ID_AD7606_4,
 	ID_AD7606_6,
-	ID_AD7606_8
+	ID_AD7606_8,
+	ID_AD7606B
 };
 
 enum ad7606_range {
+	AD7606_RANGE_2_5V,
 	AD7606_RANGE_5V,
 	AD7606_RANGE_10V
 };
@@ -58,12 +83,16 @@ enum ad7606_osr {
 	AD7606_OSR_8,
 	AD7606_OSR_16,
 	AD7606_OSR_32,
-	AD7606_OSR_64
+	AD7606_OSR_64,
+	/* Available for AD7606B, sw mode only */
+	AD7606_OSR_128,
+	AD7606_OSR_256
 };
 
 struct ad7606_chip_info {
 	uint8_t num_channels;
 	bool has_oversampling;
+	bool has_registers;
 };
 
 struct ad7606_dev {
@@ -81,6 +110,7 @@ struct ad7606_dev {
 	uint8_t device_id;
 	/* Buffer to store the conv result */
 	uint8_t	data[16];
+	bool sw_mode_en;
 };
 
 struct ad7606_init_param {
@@ -98,8 +128,15 @@ struct ad7606_init_param {
 	uint8_t device_id;
 	enum ad7606_range range;
 	enum ad7606_osr osr;
+	bool sw_mode_en;
 };
 
+int32_t ad7606_spi_reg_read(struct ad7606_dev *dev,
+			    uint8_t reg_addr,
+			    uint8_t *reg_data);
+int32_t ad7606_spi_reg_write(struct ad7606_dev *dev,
+			     uint8_t reg_addr,
+			     uint8_t reg_data);
 int32_t ad7606_spi_read_bulk(struct ad7606_dev *dev);
 int32_t ad7606_spi_read_samples(struct ad7606_dev *dev,
 				uint8_t channel,
@@ -109,6 +146,8 @@ int32_t ad7606_request_gpios(struct ad7606_dev *dev,
 			     struct ad7606_init_param *init_param);
 int32_t ad7606_set_os_ratio(struct ad7606_dev *dev,
 			    enum ad7606_osr osr);
+int32_t ad7606_set_ch_range(struct ad7606_dev *dev, uint8_t ch,
+			    enum ad7606_range range);
 int32_t ad7606_init(struct ad7606_dev **device,
 		    struct ad7606_init_param *init_param);
 int32_t ad7606_remove(struct ad7606_dev *dev);


### PR DESCRIPTION
The AD7606B is a 16-bit ADC that supports simultaneous sampling of 8
channels. It is pin compatible to AD7606, but adds extra modes by
writing to the register map.

The AD7606B can be configured to work in software mode by setting all
oversampling pins to high. The oversampling ratio is configured from the
OS_MODE register (address 0x08) with the addition of OS=128 and OS=256
that were not available in hardware mode.

Moreover, in software mode, the range gpio has no longer its function.
Instead, the scale can be configured individually for each channel from
the RANGE_CH registers (address 0x03 to 0x06). Besides the already
supported ±10 V and ±5 V ranges, software mode can also accommodate the
±2.5 V range.

Signed-off-by: Stefan Popa <stefan.popa@analog.com>