### PR TITLE
RFC: For AD9144, honour the JESD204 crossbar settings.

### DIFF
--- a/drivers/ad9144/ad9144.c
+++ b/drivers/ad9144/ad9144.c
@@ -492,6 +492,18 @@ int32_t ad9144_setup(struct ad9144_dev **device,
 	ad9144_spi_write(dev, REG_SYNC_CTRL, 0x01);	// sync-oneshot mode
 	ad9144_spi_write(dev, REG_SYNC_CTRL, 0x81);	// sync-enable
 	ad9144_spi_write(dev, REG_SYNC_CTRL, 0xc1);	// sysref-armed
+	ad9144_spi_write(dev, REG_XBAR_LN_0_1,
+			 SRC_LANE0(init_param->jesd204_lane_xbar[0]) |
+			 SRC_LANE1(init_param->jesd204_lane_xbar[1]));
+	ad9144_spi_write(dev, REG_XBAR_LN_2_3,
+			 SRC_LANE2(init_param->jesd204_lane_xbar[2]) |
+			 SRC_LANE3(init_param->jesd204_lane_xbar[3]));
+	ad9144_spi_write(dev, REG_XBAR_LN_4_5,
+			 SRC_LANE4(init_param->jesd204_lane_xbar[4]) |
+			 SRC_LANE5(init_param->jesd204_lane_xbar[5]));
+	ad9144_spi_write(dev, REG_XBAR_LN_6_7,
+			 SRC_LANE6(init_param->jesd204_lane_xbar[6]) |
+			 SRC_LANE7(init_param->jesd204_lane_xbar[7]));
 	ad9144_spi_write(dev, REG_GENERAL_JRX_CTRL_0, 0x01);	// enable link
 
 	// dac calibration

--- a/fmcdaq2/fmcdaq2.c
+++ b/fmcdaq2/fmcdaq2.c
@@ -239,6 +239,8 @@ int fmcdaq2_reconfig(struct ad9144_init_param *p_ad9144_param,
  ******************************************************************************/
 int main(void)
 {
+	int n;
+
 	spi_init_param	ad9523_spi_param;
 	spi_init_param	ad9144_spi_param;
 	spi_init_param	ad9680_spi_param;
@@ -444,10 +446,8 @@ int main(void)
 	ad9144_param.jesd204_subclass = 1;
 	ad9144_param.jesd204_scrambling = 1;
 	ad9144_param.jesd204_mode = 4;
-	ad9144_param.jesd204_lane_xbar[0] = 0;
-	ad9144_param.jesd204_lane_xbar[1] = 1;
-	ad9144_param.jesd204_lane_xbar[2] = 2;
-	ad9144_param.jesd204_lane_xbar[3] = 3;
+	for(n=0; n<ARRAY_SIZE(ad9144_param.jesd204_lane_xbar); n++)
+		ad9144_param.jesd204_lane_xbar[n] = n;
 
 	ad9144_core.no_of_channels = 2;
 	ad9144_core.resolution = 16;


### PR DESCRIPTION
Current AD9144 code provides a place in the ad9144_init_param struct for
this field, but setup code ignores it. I recommend either honouring the
field, or removing the placeholder. I have tested this code lightly on a
FMCDAQ2 setup.