### PR TITLE
ad9361: fix DAC debug ouput

### DIFF
--- a/ad9361/sw/ad9361.c
+++ b/ad9361/sw/ad9361.c
@@ -6071,9 +6071,9 @@ int32_t ad9361_validate_enable_fir(struct ad9361_rf_phy *phy)
 		max = (tx[DAC_FREQ] / tx[TX_SAMPL_FREQ]) * 16;
 		if (phy->tx_fir_ntaps > max) {
 			dev_err(dev,
-				"%s: Invalid: ratio ADC/2 / TX_SAMPL * 16 > TAPS"
+				"%s: Invalid: ratio DAC / TX_SAMPL * 16 > TAPS"
 				"(max %"PRIu32", adc %"PRIu32", tx %"PRIu32")",
-				__func__, max, rx[ADC_FREQ], tx[TX_SAMPL_FREQ]);
+				__func__, max, tx[DAC_FREQ], tx[TX_SAMPL_FREQ]);
 			return -EINVAL;
 		}
 	}


### PR DESCRIPTION
Supersedes PR #32 
The comment of the commit is a bit more descriptive.

--------------------------------------------------------

When an invalid value/ratio would occur for the DAC frequency, the
displayed value on the error path would be erroneous.

This patch updates the printed-out values to the correct ones.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>