### PR TITLE
travis: add .cppcheckignore option

### DIFF
--- a/.cppcheckignore
+++ b/.cppcheckignore
@@ -1,0 +1,13 @@
+# This file contains the list of suppressions used by the cppcheck tool
+# 
+# The surpression format:
+# [error id]:[filename]
+# 
+# Example where all the warnings under the "drivers" folder are suppressed:
+# *:drivers/*
+# 
+# Please use ".cppcheckignore" only for files/folders that are included
+# as libraries/modules and are outside of the scope of this repository. 
+#
+# Another alternative is using inline suppressions. Please see Cppcheck manual
+# for further information: https://cppcheck.sourceforge.net/manual.pdf 

--- a/ci/travis/cppcheck.sh
+++ b/ci/travis/cppcheck.sh
@@ -2,4 +2,6 @@
 
 set -e
 
+[[ ! -f .cppcheckignore ]] || CPPCHECK_OPTIONS="${CPPCHECK_OPTIONS} --suppressions-list=.cppcheckignore"
+	
 cppcheck --quiet --force --error-exitcode=1 $CPPCHECK_OPTIONS .


### PR DESCRIPTION
The user can now define in the root directory of the repo a file called
".cppcheckignore" containing all the paths that will be ignored by the
static analysis tool.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>