### PR TITLE
cppcheckignore: minor fix

### DIFF
--- a/.cppcheckignore
+++ b/.cppcheckignore
@@ -1,13 +1,13 @@
-# This file contains the list of suppressions used by the cppcheck tool
-# 
-# The surpression format:
-# [error id]:[filename]
-# 
-# Example where all the warnings under the "drivers" folder are suppressed:
-# *:drivers/*
-# 
-# Please use ".cppcheckignore" only for files/folders that are included
-# as libraries/modules and are outside of the scope of this repository. 
-#
-# Another alternative is using inline suppressions. Please see Cppcheck manual
-# for further information: https://cppcheck.sourceforge.net/manual.pdf 
+// This file contains the list of suppressions used by the cppcheck tool
+//
+// The surpression format:
+// [error id]:[filename]
+// 
+// Example where all the warnings under the "drivers" folder are suppressed:
+// *:drivers/*
+// 
+// Please use ".cppcheckignore" only for files/folders that are included
+// as libraries/modules and are outside of the scope of this repository. 
+//
+// Another alternative is using inline suppressions. Please see Cppcheck manual
+// for further information: https://cppcheck.sourceforge.net/manual.pdf 


### PR DESCRIPTION
Use "//" instead of "#" for comments.
This change supports all versions of cppcheck.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>