### PR TITLE
ad9361: move the location where axiadc_init() is called

### DIFF
--- a/projects/ad9361/src/ad9361_api.c
+++ b/projects/ad9361/src/ad9361_api.c
@@ -531,11 +531,6 @@ int32_t ad9361_init (struct ad9361_rf_phy **ad9361_phy,
 	if (ret < 0)
 		goto out;
 
-#ifndef AXI_ADC_NOT_PRESENT
-	axiadc_init(phy);
-	phy->adc_state->pcore_version = axiadc_read(phy->adc_state, ADI_REG_VERSION);
-#endif
-
 	ad9361_init_gain_tables(phy);
 
 	ret = ad9361_setup(phy);
@@ -543,6 +538,8 @@ int32_t ad9361_init (struct ad9361_rf_phy **ad9361_phy,
 		goto out;
 
 #ifndef AXI_ADC_NOT_PRESENT
+	axiadc_init(phy);
+	phy->adc_state->pcore_version = axiadc_read(phy->adc_state, ADI_REG_VERSION);
 	/* platform specific wrapper to call ad9361_post_setup() */
 	ret = axiadc_post_setup(phy);
 	if (ret < 0)


### PR DESCRIPTION
The location is wrong since clocks are not enabled yet. This is done in
ad9361_setup(),  with the following call:

ad9361_spi_write(spi, REG_CLOCK_ENABLE,
		DIGITAL_POWER_UP | CLOCK_ENABLE_DFLT | BBPLL_ENABLE |
		 (pd->use_extclk ? XO_BYPASS : 0)); /* Enable Clocks */

Signed-off-by: Cristian Pop <cristian.pop@analog.com>