### PR TITLE
axi_dac_core: implement axi_dac_datasel() function

### DIFF
--- a/projects/drivers/axi_dac_core/axi_dac_core.c
+++ b/projects/drivers/axi_dac_core/axi_dac_core.c
@@ -553,6 +553,24 @@ uint32_t axi_dac_set_sine_lut(struct axi_dac *dac,
 }
 
 /***************************************************************************//**
+ * @brief dac_datasel
+*******************************************************************************/
+int32_t axi_dac_datasel(struct axi_dac *dac, int32_t chan,
+			enum axi_dac_data_sel sel)
+{
+	int32_t i;
+	if (chan < 0) { /* ALL */
+		for (i = 0; i < dac->num_channels; i++) {
+			axi_dac_write(dac, AXI_DAC_REG_CHAN_CNTRL_8(i), sel);
+		}
+	} else {
+		axi_dac_write(dac, AXI_DAC_REG_CHAN_CNTRL_8(chan), sel);
+	}
+	axi_dac_write(dac, AXI_DAC_REG_SYNC_CONTROL, AXI_DAC_SYNC);
+	return 0;
+}
+
+/***************************************************************************//**
  * @brief axi_dac_set_buff
 *******************************************************************************/
 int32_t axi_dac_set_buff(struct axi_dac *dac,

--- a/projects/drivers/axi_dac_core/axi_dac_core.h
+++ b/projects/drivers/axi_dac_core/axi_dac_core.h
@@ -102,6 +102,8 @@ int32_t axi_dac_set_buff(struct axi_dac *dac,
 			 uint32_t buff_size);
 uint32_t axi_dac_set_sine_lut(struct axi_dac *dac,
 			      uint32_t address);
+int32_t axi_dac_datasel(struct axi_dac *dac, int32_t chan,
+			enum axi_dac_data_sel sel);
 int32_t axi_dac_dds_get_calib_scale(struct axi_dac *dac,
 				    uint32_t chan,
 				    int32_t *val,


### PR DESCRIPTION
Implement axi_dac_datasel() function.
This function selects between DDS and DMA

Signed-off-by: Cristian Pop <cristian.pop@analog.com>