### PR TITLE
Update xstc.tcl script to increase heap size for MICROBLAZE

### DIFF
--- a/scripts/microblaze.mk
+++ b/scripts/microblaze.mk
@@ -71,7 +71,7 @@ $(P_SRC_FILES): hw/system_top.bit
 hw/system_top.bit: $(HDF-FILE)
 	rm -fr .metadata .Xil hw bsp xilsw sw xsct.log
 	$(XSCT_CMD) $(XSCT_SCRIPT) init $(HDF-FILE) > $(XSCT_LOG) 2>&1
-	$(XSCT_CMD) $(XSCT_SCRIPT) defines $(COMPILER_DEFINES) >> $(XSCT_LOG) 2>&1
+	$(XSCT_CMD) $(XSCT_SCRIPT) defines $(HDF-FILE) $(COMPILER_DEFINES) >> $(XSCT_LOG) 2>&1
 	$(XSCT_CMD) $(XSCT_SCRIPT) make-bsp-xilsw >> $(XSCT_LOG) 2>&1
 
 

--- a/scripts/xsct.tcl
+++ b/scripts/xsct.tcl
@@ -33,7 +33,7 @@ if {$m_mode == "library"} {
 if {$m_mode == "defines"} {
 
   sdk configapp -app sw build-config debug
-  for {set i 1} {$i < $argc} {incr i} {
+  for {set i 2} {$i < $argc} {incr i} {
     set compiler_define [lindex $argv $i]
     if { [regexp [ 0-9] $compiler_define ] } {
 	regsub -all { } $compiler_define {=} compiler_define
@@ -41,12 +41,19 @@ if {$m_mode == "defines"} {
     sdk configapp -app sw define-compiler-symbols $compiler_define
   }
   sdk configapp -app sw build-config release
-  for {set i 1} {$i < $argc} {incr i} {
+  for {set i 2} {$i < $argc} {incr i} {
     set compiler_define [lindex $argv $i]
     if { [regexp [ 0-9] $compiler_define ] } {
 	regsub -all { } $compiler_define {=} compiler_define
     }
     sdk configapp -app sw define-compiler-symbols $compiler_define
+  }
+
+  set hdf_file [lindex $argv 1]
+  hsi open_hw_design $hdf_file
+  set cpu_name [lindex [hsi get_cells -filter {IP_TYPE==PROCESSOR}] 0]
+  if { $cpu_name == "sys_mb" } {	  
+	  sdk configapp -app sw -set linker-misc {-Xlinker --defsym=_HEAP_SIZE=0x2000 -Xlinker --defsym=_STACK_SIZE=0x2000}
   }
   exit
 }

--- a/scripts/zynq.mk
+++ b/scripts/zynq.mk
@@ -75,7 +75,7 @@ $(P_SRC_FILES): hw/system_top.bit
 hw/system_top.bit: $(HDF-FILE)
 	rm -fr .metadata .Xil hw bsp xilsw sw xsct.log
 	$(XSCT_CMD) $(XSCT_SCRIPT) init $(HDF-FILE) > $(XSCT_LOG) 2>&1
-	$(XSCT_CMD) $(XSCT_SCRIPT) defines $(COMPILER_DEFINES) >> $(XSCT_LOG) 2>&1
+	$(XSCT_CMD) $(XSCT_SCRIPT) defines $(HDF-FILE) $(COMPILER_DEFINES) >> $(XSCT_LOG) 2>&1
 	$(XSCT_CMD) $(XSCT_SCRIPT) make-bsp-xilsw >> $(XSCT_LOG) 2>&1
 
 


### PR DESCRIPTION
For MICROBLAZE platforms most projects require an increase in HEAP size
for the application to function properly. Increase the size of the heap and
the stack on the MICROBLAZE platforms to match the default sizes of the
ZYNQ platforms.

Signed-off-by: Andrei Drimbarean <Andrei.Drimbarean@analog.com>