### PR TITLE
fmcomms2:kcu105: add project folder

### DIFF
--- a/fmcomms2/kcu105/Makefile
+++ b/fmcomms2/kcu105/Makefile
@@ -1,0 +1,9 @@
+## Makefile
+
+include ../../scripts/noos.mk
+
+M_HDF_FILE := $(HDL-DIR)/projects/fmcomms2/kcu105/fmcomms2_kcu105.sdk/system_top.hdf
+
+include $(NOOS-DIR)/fmcomms2/fmcomms2.mk
+include $(NOOS-DIR)/scripts/microblaze.mk
+


### PR DESCRIPTION
Add project folder for KCU105 plaform for FMCOMMS2 to match the HDL
version.

Signed-off-by: Andrei Drimbarean <Andrei.Drimbarean@analog.com>