### PR TITLE
projects:drivers:xilinx_platform: add AXI I2C implementation

### DIFF
--- a/projects/drivers/xilinx_platform/platform_drivers.h
+++ b/projects/drivers/xilinx_platform/platform_drivers.h
@@ -48,6 +48,8 @@
 #ifdef _XPARAMETERS_PS_H_
 #include <xspips.h>
 #include <xgpiops.h>
+#include <xiic.h>
+#include <xil_exception.h>
 #else
 #include <xspi.h>
 #include <xgpio.h>
@@ -91,6 +93,11 @@ typedef struct i2c_desc {
 	uint32_t	id;
 	uint32_t	max_speed_hz;
 	uint8_t		slave_address;
+#ifdef _XPARAMETERS_PS_H_
+	XIic_Config *config;
+	XIic instance;
+#else
+#endif
 } i2c_desc;
 
 typedef enum spi_type {


### PR DESCRIPTION
Add AXI I2C implementation to the xilinx platform drivers. The
implementation is for the ZYNQ PS7 family.

Signed-off-by: Andrei Drimbarean <Andrei.Drimbarean@analog.com>