### PR TITLE
Master ad9371 dac dma example

### DIFF
--- a/projects/ad9371/src/app/headless.c
+++ b/projects/ad9371/src/app/headless.c
@@ -53,6 +53,7 @@
 #include "clk_altera_a10_fpll.h"
 #include "altera_adxcvr.h"
 #else
+#include "xil_cache.h"
 #include "clk_axi_clkgen.h"
 #include "axi_adxcvr.h"
 #endif
@@ -264,6 +265,16 @@ int main(void)
 		0,
 	};
 	struct axi_dmac *rx_dmac;
+#ifdef DAC_DMA_EXAMPLE
+	struct axi_dmac_init tx_dmac_init = {
+		"tx_dmac",
+		TX_DMA_BASEADDR,
+		DMA_MEM_TO_DEV,
+		DMA_LAST,
+	};
+	struct axi_dmac *tx_dmac;
+	extern const uint32_t sine_lut_iq[1024];
+#endif
 	uint32_t i;
 
 	/* Allocating memory for the errorString */
@@ -863,6 +874,14 @@ int main(void)
 	/* Initialize the ADC core */
 	axi_adc_init(&rx_adc, &rx_adc_init);
 
+#ifdef DAC_DMA_EXAMPLE
+	axi_dac_load_custom_data(tx_dac, sine_lut_iq,
+				 ARRAY_SIZE(sine_lut_iq),
+				 DDR_MEM_BASEADDR + 0xA000000);
+	axi_dmac_init(&tx_dmac, &tx_dmac_init);
+	axi_dmac_transfer(tx_dmac, DDR_MEM_BASEADDR + 0xA000000,
+			  sizeof(sine_lut_iq) * 2);
+#endif
 	mdelay(1000);
 
 	/* Initialize the DMAC and transfer 16384 samples from ADC to MEM */
@@ -870,6 +889,9 @@ int main(void)
 	axi_dmac_transfer(rx_dmac,
 			  DDR_MEM_BASEADDR + 0x800000,
 			  16384 * 8);
+#ifndef ALTERA_PLATFORM
+	Xil_DCacheInvalidateRange(XPAR_DDR_MEM_BASEADDR + 0x800000, 16384 * 8);
+#endif
 
 	printf("Done\n");
 

--- a/projects/ad9371/src/app/headless.c
+++ b/projects/ad9371/src/app/headless.c
@@ -632,12 +632,14 @@ int main(void)
 	/*****                Mykonos Initialize attenuations                *****/
 	/*************************************************************************/
 
-	if ((mykError = MYKONOS_setTx1Attenuation(&mykDevice, 0)) != MYKONOS_ERR_OK) {
+	mykError = MYKONOS_setTx1Attenuation(&mykDevice, 10000);
+	if (mykError != MYKONOS_ERR_OK) {
 		errorString = getMykonosErrorMessage(mykError);
 		goto error_11;
 	}
 
-	if ((mykError = MYKONOS_setTx2Attenuation(&mykDevice, 0)) != MYKONOS_ERR_OK) {
+	mykError = MYKONOS_setTx2Attenuation(&mykDevice, 10000);
+	if (mykError != MYKONOS_ERR_OK) {
 		errorString = getMykonosErrorMessage(mykError);
 		goto error_11;
 	}


### PR DESCRIPTION
Commit f9992d9 offers an example of how to send custom data using the
DMA and adrv9009.
This patch updates the headless file in the same manner in order to work
with the ad9371 project. The main difference is that the configuration
for ad9371 uses the FIFO, while adrv9009 bypasses it. At the moment, the
DMA cyclic mode is not supported in the hdl.