### PR TITLE
Platform drivers spi

### DIFF
--- a/projects/ad9361/src/ad9361_parameters.h
+++ b/projects/ad9361/src/ad9361_parameters.h
@@ -123,7 +123,7 @@
 #endif
 #endif
 
-#define CLK_CS			0x0f
+#define CLK_CS			0x00
 
 #define RX_CORE_BASEADDR	AD9361_RX_0_BASEADDR
 #define TX_CORE_BASEADDR	AD9361_TX_0_BASEADDR

--- a/projects/ad9371/src/devices/adi_hal/common.c
+++ b/projects/ad9371/src/devices/adi_hal/common.c
@@ -111,7 +111,7 @@ commonErr_t CMB_SPIWriteByte(spiSettings_t *spiSettings, uint16_t addr,
 {
 	uint8_t buf[3];
 
-	spi_ad_desc->chip_select = spiSettings->chipSelectIndex;
+	spi_ad_desc->chip_select = spiSettings->chipSelectIndex - 1;
 
 	buf[0] = (uint8_t) ((addr >> 8) & 0x7f);
 	buf[1] = (uint8_t) (addr & 0xff);

--- a/projects/adrv9009/src/devices/adi_hal/parameters.h
+++ b/projects/adrv9009/src/devices/adi_hal/parameters.h
@@ -103,8 +103,8 @@
 #define GPIO_OFFSET		54
 #endif
 
-#define CLK_CS			1
-#define ADRV_CS			2
+#define CLK_CS			0
+#define ADRV_CS			1
 
 #define ADRV_RESETB		GPIO_OFFSET + 52
 #define ADRV_SYSREF_REQ	GPIO_OFFSET + 58

--- a/projects/drivers/xilinx_platform/platform_drivers.c
+++ b/projects/drivers/xilinx_platform/platform_drivers.c
@@ -259,7 +259,7 @@ int32_t spi_write_and_read(struct spi_desc *desc,
 			   XSPIPS_CLK_PHASE_1_OPTION : 0));
 
 	XSpiPs_SetSlaveSelect(&desc->instance,
-			      0xf & ~desc->chip_select);
+			      desc->chip_select);
 	XSpiPs_PolledTransfer(&desc->instance,
 			      data, data, bytes_number);
 #else
@@ -271,7 +271,7 @@ int32_t spi_write_and_read(struct spi_desc *desc,
 			 XSP_CLK_PHASE_1_OPTION : 0));
 
 	XSpi_SetSlaveSelect(&desc->instance,
-			    desc->chip_select);
+			    0x01 << desc->chip_select);
 
 	XSpi_Transfer(&desc->instance,
 		      data, data, bytes_number);


### PR DESCRIPTION

When writing to SPI, some mask is applied to chip_select value. This seems
to be wrong.

Signed-off-by: Cristian Pop <cristian.pop@analog.com>