### PR TITLE
AD5592/3r byte swap fix

### DIFF
--- a/drivers/ad5592r/ad5592r.c
+++ b/drivers/ad5592r/ad5592r.c
@@ -177,7 +177,7 @@ int32_t ad5592r_reg_read(struct ad5592r_dev *dev, uint8_t reg, uint16_t *value)
 	if (ret < 0)
 		return ret;
 
-	*value = swab16(dev->spi_msg);
+	*value = dev->spi_msg;
 
 	return 0;
 }
@@ -205,7 +205,7 @@ int32_t ad5592r_gpio_read(struct ad5592r_dev *dev, uint8_t *value)
 	if (ret < 0)
 		return ret;
 
-	*value = (uint8_t) swab16(dev->spi_msg);
+	*value = (uint8_t)dev->spi_msg;
 
 	return 0;
 }

--- a/drivers/ad5592r/ad5592r.h
+++ b/drivers/ad5592r/ad5592r.h
@@ -49,7 +49,6 @@
 	((((x) & 0x00ff) << 8) | \
 	 (((x) & 0xff00) >> 8))
 
-int32_t ad5592r_spi_wnop_r16(struct ad5592r_dev *dev, uint16_t *buf);
 int32_t ad5592r_write_dac(struct ad5592r_dev *dev, uint8_t chan,
 			  uint16_t value);
 int32_t ad5592r_read_adc(struct ad5592r_dev *dev, uint8_t chan,


### PR DESCRIPTION
Changes in this patch:
 - fix SPI byte swap error when reading registers;
 - fix compiler error about a static function treated as non-static.