### PR TITLE
projects: ad9371: Fix MicroBlaze compilation error

### DIFF
--- a/projects/ad9371/src/app/headless.c
+++ b/projects/ad9371/src/app/headless.c
@@ -890,7 +890,7 @@ int main(void)
 			  DDR_MEM_BASEADDR + 0x800000,
 			  16384 * 8);
 #ifndef ALTERA_PLATFORM
-	Xil_DCacheInvalidateRange(XPAR_DDR_MEM_BASEADDR + 0x800000, 16384 * 8);
+	Xil_DCacheInvalidateRange(DDR_MEM_BASEADDR + 0x800000, 16384 * 8);
 #endif
 
 	printf("Done\n");


### PR DESCRIPTION
Use the generic DDR_MEM_BASEADDR macro.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>