### PR TITLE
drivers: ad7124: Fix ad7124_wait_for_conv_ready()

### DIFF
--- a/drivers/ad7124/ad7124.c
+++ b/drivers/ad7124/ad7124.c
@@ -337,7 +337,7 @@ int32_t ad7124_wait_for_conv_ready(struct ad7124_dev *dev,
 
 		/* Check the RDY bit in the Status Register */
 		ready = (regs[AD7124_Status].value &
-			 AD7124_STATUS_REG_RDY) != 0;
+			 AD7124_STATUS_REG_RDY) == 0;
 	}
 
 	return timeout ? 0 : TIMEOUT;


### PR DESCRIPTION
Hi!
The RDY bit of the status register is cleared when data is ready to be read and the code does the opposite.

It seems that this is the same issue but in another part https://github.com/analogdevicesinc/no-OS/issues/31 and this was the fix https://github.com/analogdevicesinc/no-OS/commit/8251dfc96b85e1b1f3875dcd8a35633cea075e42

Tested with hardware.