### PR TITLE
drivers:ad5592/3r: initialize internal reference

### DIFF
--- a/drivers/adc-dac/ad5592r/ad5592r-base.h
+++ b/drivers/adc-dac/ad5592r/ad5592r-base.h
@@ -91,6 +91,10 @@ struct ad5592r_rw_ops {
 	int32_t (*gpio_read)(struct ad5592r_dev *dev, uint8_t *value);
 };
 
+struct ad5592r_init_param {
+	bool int_ref;
+};
+
 struct ad5592r_dev {
 	const struct ad5592r_rw_ops *ops;
 	i2c_desc *i2c;

--- a/drivers/adc-dac/ad5592r/ad5592r.c
+++ b/drivers/adc-dac/ad5592r/ad5592r.c
@@ -216,9 +216,11 @@ int32_t ad5592r_gpio_read(struct ad5592r_dev *dev, uint8_t *value)
  * @param dev - The device structure.
  * @return 0 in case of success, negative error code otherwise
  */
-int32_t ad5592r_init(struct ad5592r_dev *dev)
+int32_t ad5592r_init(struct ad5592r_dev *dev,
+		     struct ad5592r_init_param *init_param)
 {
 	int32_t ret;
+	uint16_t temp_reg_val;
 
 	if (!dev)
 		return FAILURE;
@@ -227,5 +229,18 @@ int32_t ad5592r_init(struct ad5592r_dev *dev)
 	if (ret < 0)
 		return ret;
 
-	return ad5592r_set_channel_modes(dev);
+	ret = ad5592r_set_channel_modes(dev);
+	if (ret < 0)
+		return ret;
+
+	if(init_param->int_ref) {
+		ret = ad5592r_reg_read(dev, AD5592R_REG_PD, &temp_reg_val);
+		if (ret < 0)
+			return ret;
+		temp_reg_val |= AD5592R_REG_PD_EN_REF;
+
+		return ad5592r_reg_write(dev, AD5592R_REG_PD, temp_reg_val);
+	}
+
+	return ret;
 }

--- a/drivers/adc-dac/ad5592r/ad5592r.h
+++ b/drivers/adc-dac/ad5592r/ad5592r.h
@@ -58,6 +58,7 @@ int32_t ad5592r_reg_write(struct ad5592r_dev *dev, uint8_t reg,
 int32_t ad5592r_reg_read(struct ad5592r_dev *dev, uint8_t reg,
 			 uint16_t *value);
 int32_t ad5592r_gpio_read(struct ad5592r_dev *dev, uint8_t *value);
-int32_t ad5592r_init(struct ad5592r_dev *dev);
+int32_t ad5592r_init(struct ad5592r_dev *dev,
+		     struct ad5592r_init_param *init_param);
 
 #endif /* AD5592R_H_ */

--- a/drivers/adc-dac/ad5592r/ad5593r.c
+++ b/drivers/adc-dac/ad5592r/ad5593r.c
@@ -211,9 +211,11 @@ int32_t ad5593r_gpio_read(struct ad5592r_dev *dev, uint8_t *value)
  * @param dev - The device structure.
  * @return 0 in case of success, negative error code otherwise
  */
-int32_t ad5593r_init(struct ad5592r_dev *dev)
+int32_t ad5593r_init(struct ad5592r_dev *dev,
+		     struct ad5592r_init_param *init_param)
 {
 	int32_t ret;
+	uint16_t temp_reg_val;
 
 	if (!dev)
 		return FAILURE;
@@ -222,5 +224,18 @@ int32_t ad5593r_init(struct ad5592r_dev *dev)
 	if (ret < 0)
 		return ret;
 
-	return ad5592r_set_channel_modes(dev);
+	ret = ad5592r_set_channel_modes(dev);
+	if (ret < 0)
+		return ret;
+
+	if(init_param->int_ref) {
+		ret = ad5593r_reg_read(dev, AD5592R_REG_PD, &temp_reg_val);
+		if (ret < 0)
+			return ret;
+		temp_reg_val |= AD5592R_REG_PD_EN_REF;
+
+		return ad5593r_reg_write(dev, AD5592R_REG_PD, temp_reg_val);
+	}
+
+	return ret;
 }

--- a/drivers/adc-dac/ad5592r/ad5593r.h
+++ b/drivers/adc-dac/ad5592r/ad5593r.h
@@ -51,6 +51,7 @@ int32_t ad5593r_reg_write(struct ad5592r_dev *dev, uint8_t reg,
 int32_t ad5593r_reg_read(struct ad5592r_dev *dev, uint8_t reg,
 			 uint16_t *value);
 int32_t ad5593r_gpio_read(struct ad5592r_dev *dev, uint8_t *value);
-int32_t ad5593r_init(struct ad5592r_dev *dev);
+int32_t ad5593r_init(struct ad5592r_dev *dev,
+		     struct ad5592r_init_param *init_param);
 
 #endif /* AD5593R_H_ */


### PR DESCRIPTION
The internal reference is a core feature for the AD5592R and AD5593R
devices. The driver must have the posibility to initialize the internal
reference so that applications can activate it or leaving it deactivated in
a transparent manner. This helps applications to deliver a more complete
out-of-the-box experience.

Signed-off-by: Andrei Drimbarean <Andrei.Drimbarean@analog.com>