### PR TITLE
d9361: Clear ad9361 state, when channels mode is selected

### DIFF
--- a/ad9361/sw/ad9361.h
+++ b/ad9361/sw/ad9361.h
@@ -3541,4 +3541,5 @@ int32_t ad9361_get_temp(struct ad9361_rf_phy *phy);
 int ad9361_synth_lo_powerdown(struct ad9361_rf_phy *phy,
 			      enum synth_pd_ctrl rx,
 			      enum synth_pd_ctrl tx);
+void ad9361_clear_state(struct ad9361_rf_phy *phy);
 #endif

--- a/ad9361/sw/ad9361_api.c
+++ b/ad9361/sw/ad9361_api.c
@@ -1880,6 +1880,8 @@ int32_t ad9361_get_trx_path_clks(struct ad9361_rf_phy *phy,
 /**
  * Set the number of channels mode.
  * @param phy The AD9361 state structure.
+ * Note: This function also resets the device, some additional
+ *       configurations might be necessary
  * @param ch_mode Number of channels mode (MODE_1x1, MODE_2x2).
  * 				  Accepted values:
  * 				   MODE_1x1 (1)
@@ -1906,6 +1908,8 @@ int32_t ad9361_set_no_ch_mode(struct ad9361_rf_phy *phy, uint8_t no_ch_mode)
 	ad9361_reset(phy);
 	ad9361_spi_write(phy->spi, REG_SPI_CONF, SOFT_RESET | _SOFT_RESET);
 	ad9361_spi_write(phy->spi, REG_SPI_CONF, 0x0);
+
+	ad9361_clear_state(phy);
 
 	phy->clks[TX_REFCLK]->rate = ad9361_clk_factor_recalc_rate(
 					     phy->ref_clk_scale[TX_REFCLK], phy->clk_refin->rate);


### PR DESCRIPTION
In this way, ad9361 gain table will be reconfigured, as before calling
"ad9361_set_no_ch_mode()" function.

Signed-off-by: Cristian Pop <cristian.pop@analog.com>