### PR TITLE
projects/ad9361: Clear ad9361 state, when channels mode is configured

### DIFF
--- a/projects/ad9361/src/ad9361.h
+++ b/projects/ad9361/src/ad9361.h
@@ -3540,4 +3540,5 @@ int32_t ad9361_get_temp(struct ad9361_rf_phy *phy);
 int32_t ad9361_synth_lo_powerdown(struct ad9361_rf_phy *phy,
 				  enum synth_pd_ctrl rx,
 				  enum synth_pd_ctrl tx);
+void ad9361_clear_state(struct ad9361_rf_phy *phy);
 #endif

--- a/projects/ad9361/src/ad9361_api.c
+++ b/projects/ad9361/src/ad9361_api.c
@@ -1885,6 +1885,8 @@ int32_t ad9361_get_trx_path_clks(struct ad9361_rf_phy *phy,
 /**
  * Set the number of channels mode.
  * @param phy The AD9361 state structure.
+ * Note: This function also resets the device, some additional
+ *       configurations might be necessary
  * @param ch_mode Number of channels mode (MODE_1x1, MODE_2x2).
  * 				  Accepted values:
  * 				   MODE_1x1 (1)
@@ -1911,6 +1913,8 @@ int32_t ad9361_set_no_ch_mode(struct ad9361_rf_phy *phy, uint8_t no_ch_mode)
 	ad9361_reset(phy);
 	ad9361_spi_write(phy->spi, REG_SPI_CONF, SOFT_RESET | _SOFT_RESET);
 	ad9361_spi_write(phy->spi, REG_SPI_CONF, 0x0);
+
+	ad9361_clear_state(phy);
 
 	phy->clks[TX_REFCLK]->rate = ad9361_clk_factor_recalc_rate(
 					     phy->ref_clk_scale[TX_REFCLK], phy->clk_refin->rate);


### PR DESCRIPTION
By calling "ad9361_set_no_ch_mode()" function, to reconfigure the number of
channels, ad9361 device, receives a reset command. It's state should be
also cleared by calling "ad9361_clear_state()" function (this sets
"phy->current_table" value to "NO_GAIN_TABLE").
In this way, ad9361 gain table will be reconfigured when "ad9361_load_gt()"
is called, since "phy->current_table" has "NO_GAIN_TABLE" value

Signed-off-by: Cristian Pop <cristian.pop@analog.com>