### PR TITLE
ad9172: Add DAC_DMA_EXAMPLE

### DIFF
--- a/projects/ad9172/src/README
+++ b/projects/ad9172/src/README
@@ -15,6 +15,8 @@
 	cp ../../drivers/jesd204/axi_adxcvr.c ./
 	cp ../../drivers/axi_dac_core/axi_dac_core.h ./
 	cp ../../drivers/axi_dac_core/axi_dac_core.c ./
+	cp ../../drivers/axi_dmac/axi_dmac.h ./
+	cp ../../drivers/axi_dmac/axi_dmac.c ./
 	cp ../../../drivers/frequency/hmc7044/hmc7044.h ./
 	cp ../../../drivers/frequency/hmc7044/hmc7044.c ./
 	cp ../../../drivers/ad917x/ad9172.h ./

--- a/projects/ad9172/src/README
+++ b/projects/ad9172/src/README
@@ -1,9 +1,9 @@
 
-Additional required source files:
+# Additional required source files:
 
 	cp ../../drivers/xilinx_platform/platform_drivers.h	./
 	cp ../../drivers/xilinx_platform/platform_drivers.c	./
-	cp ../../drivers/util/util.h ./
+	cp ../../drivers/util/util.c ./
 	cp ../../drivers/util/util.h ./						
 	cp ../../drivers/jesd204/xilinx_transceiver.h ./
 	cp ../../drivers/jesd204/xilinx_transceiver.c ./
@@ -15,8 +15,8 @@ Additional required source files:
 	cp ../../drivers/jesd204/axi_adxcvr.c ./
 	cp ../../drivers/axi_dac_core/axi_dac_core.h ./
 	cp ../../drivers/axi_dac_core/axi_dac_core.c ./
-	cp ../../../drivers/hmc7044/hmc7044.h ./
-	cp ../../../drivers/hmc7044/hmc7044.c ./
+	cp ../../../drivers/frequency/hmc7044/hmc7044.h ./
+	cp ../../../drivers/frequency/hmc7044/hmc7044.c ./
 	cp ../../../drivers/ad917x/ad9172.h ./
 	cp ../../../drivers/ad917x/ad9172.c ./
 	cp ../../../drivers/ad917x/ad917x_api/ad917x_api.c ./
@@ -24,6 +24,6 @@ Additional required source files:
 	cp ../../../drivers/ad917x/ad917x_api/ad917x_nco_api.c ./
 	cp ../../../drivers/ad917x/ad917x_api/ad917x_reg.c ./
 	cp ../../../drivers/ad917x/ad917x_api/ad917x_reg.h ./
-	cp ../../../drivers/ad917x/ad917x_api/ad917x.h ./
+	cp ../../../drivers/ad917x/ad917x_api/AD917x.h ./
 	cp ../../../drivers/ad917x/ad917x_api/api_def.h ./
 	cp ../../../drivers/ad917x/ad917x_api/api_errors.h ./


### PR DESCRIPTION
Select AXI_DAC_DATA_SEL_DMA as source for DAC. In this way custom data can
be sent at the output of AD9172.

Signed-off-by: Cristian Pop <cristian.pop@analog.com>