### PR TITLE
travis: astyle_config: do not retain original file

### DIFF
--- a/ci/travis/astyle_config
+++ b/ci/travis/astyle_config
@@ -1,3 +1,4 @@
 --style=linux 
 --indent=force-tab=8 
 --max-code-length=80
+--suffix=none


### PR DESCRIPTION
Avoid generating additional files when running astyle locally.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>