### PR TITLE
iio: adc: ad9361: Fix external LO mode in TDD mode

### DIFF
--- a/ad9361/sw/ad9361.c
+++ b/ad9361/sw/ad9361.c
@@ -3349,6 +3349,9 @@ static int32_t ad9361_trx_ext_lo_control(struct ad9361_rf_phy *phy,
 		ret = ad9361_spi_writef(phy->spi, REG_ENSM_CONFIG_2,
 					POWER_DOWN_TX_SYNTH, mcs_rf_enable ? 0 : enable);
 
+		ret = ad9361_spi_writef(phy->spi, REG_ENSM_CONFIG_2,
+					TX_SYNTH_READY_MASK, enable);
+
 		ret |= ad9361_spi_writef(phy->spi, REG_RFPLL_DIVIDERS,
 					 TX_VCO_DIVIDER(~0), enable ? 7 :
 					 phy->cached_tx_rfpll_div);
@@ -3374,6 +3377,9 @@ static int32_t ad9361_trx_ext_lo_control(struct ad9361_rf_phy *phy,
 	} else {
 		ret = ad9361_spi_writef(phy->spi, REG_ENSM_CONFIG_2,
 					POWER_DOWN_RX_SYNTH, mcs_rf_enable ? 0 : enable);
+
+		ret = ad9361_spi_writef(phy->spi, REG_ENSM_CONFIG_2,
+					RX_SYNTH_READY_MASK, enable);
 
 		ret |= ad9361_spi_writef(phy->spi, REG_RFPLL_DIVIDERS,
 					 RX_VCO_DIVIDER(~0), enable ? 7 :
@@ -4814,7 +4820,8 @@ int32_t ad9361_set_ensm_mode(struct ad9361_rf_phy *phy, bool fdd, bool pinctrl)
 	ad9361_spi_write(phy->spi, REG_ENSM_MODE, fdd ? FDD_MODE : 0);
 
 	val = ad9361_spi_read(phy->spi, REG_ENSM_CONFIG_2);
-	val &= POWER_DOWN_RX_SYNTH | POWER_DOWN_TX_SYNTH;
+	val &= POWER_DOWN_RX_SYNTH | POWER_DOWN_TX_SYNTH |
+		RX_SYNTH_READY_MASK | TX_SYNTH_READY_MASK;
 
 	if (fdd)
 		ret = ad9361_spi_write(phy->spi, REG_ENSM_CONFIG_2,


### PR DESCRIPTION
When using external LO, the ENSM should ignore the RF tuner ready signal.
This can be accomplished by setting the Rx/Tx Synth Ready Mask,
otherwise the ENSM would not leave ALERT state, even when instructed
by pin control or SPI writes.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>