### PR TITLE
hmc7044: Extend interface

### DIFF
--- a/drivers/frequency/hmc7044/hmc7044.h
+++ b/drivers/frequency/hmc7044/hmc7044.h
@@ -95,4 +95,11 @@ int32_t hmc7044_init(struct hmc7044_dev **device,
 		     const struct hmc7044_init_param *init_param);
 /* Remove the device. */
 int32_t hmc7044_remove(struct hmc7044_dev *device);
+uint32_t hmc7044_clk_recalc_rate(struct hmc7044_dev *dev, uint32_t chan,
+				 uint32_t *rate);
+uint32_t hmc7044_clk_round_rate(struct hmc7044_dev *dev, uint32_t rate,
+				uint32_t parent_rate);
+uint32_t hmc7044_clk_set_rate(struct hmc7044_dev *dev, uint32_t chan,
+			      uint32_t rate);
+
 #endif // HMC7044_H_


### PR DESCRIPTION
Extend interface, with equivalent functions, found in linux driver.
They will be needed in the JESD autoconfiguration project.

Signed-off-by: Cristian Pop <cristian.pop@analog.com>