### PR TITLE
ad9361: update project to latest platform drivers

### DIFF
--- a/projects/ad9361/src/ad9361_api.c
+++ b/projects/ad9361/src/ad9361_api.c
@@ -43,6 +43,7 @@
 #include "ad9361.h"
 #include "ad9361_api.h"
 #include "platform_drivers.h"
+#include "xil_drivers.h"
 #include "axi_adc_core.h"
 #include "axi_dac_core.h"
 #include "util.h"
@@ -125,7 +126,7 @@ int32_t ad9361_init (struct ad9361_rf_phy **ad9361_phy,
 	phy->dev_sel = init_param->dev_sel;
 
 	/* Identification number */
-	phy->spi->id = init_param->id_no;
+	((xil_spi_desc*)phy->spi->extra)->id = init_param->id_no;
 	phy->id_no = init_param->id_no;
 
 	/* Reference Clock */

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -45,6 +45,7 @@
 #include "ad9361_api.h"
 #include "ad9361_parameters.h"
 #include "platform_drivers.h"
+#include "xil_drivers.h"
 #ifdef XILINX_PLATFORM
 #include <xil_cache.h>
 #endif
@@ -385,7 +386,8 @@ struct ad9361_rf_phy *ad9361_phy;
 struct ad9361_rf_phy *ad9361_phy_b;
 #endif
 
-struct spi_init_param spi_param = {.id = SPI_DEVICE_ID, .mode = SPI_MODE_1, .chip_select = CLK_CS, .flags = 0};
+struct spi_init_param spi_param = {.mode = SPI_MODE_1, .chip_select = CLK_CS};
+struct xil_spi_init_param xil_spi_param = {.id = SPI_DEVICE_ID, .flags = 0};
 
 /***************************************************************************//**
  * @brief main


### PR DESCRIPTION
Use the reorganized Xilinx platform drivers for the AD9361 project.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>