### PR TITLE
ad7124: Ensuring CRC is disabled after reset

### DIFF
--- a/drivers/adc/ad7124/ad7124.c
+++ b/drivers/adc/ad7124/ad7124.c
@@ -231,6 +231,9 @@ int32_t ad7124_reset(struct ad7124_dev *dev)
 				 wr_buf,
 				 8);
 
+	/* CRC is disabled after reset */
+	dev->use_crc = AD7124_DISABLE_CRC;
+
 	/* Wait for the reset to complete */
 	ret = ad7124_wait_to_power_on(dev,
 				      dev->spi_rdy_poll_cnt);


### PR DESCRIPTION
need to make sure CRC is disabled after a reset, otherwise there may be communication issues.

Signed-off-by: Michael Bradley <michael.bradley@analog.com>