### PR TITLE
Add .gitattributes to no-OS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto
+
+*.c text
+*.cpp text
+*.h text
+*.txt text
+*.xml text
+Makefile text


### PR DESCRIPTION
This attributes enables and controls the EOL normalization. This is set to
auto and the line endings are converted to LF on checkin.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>