### PR TITLE
ad9361 project: fix spi extra init params

### DIFF
--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -399,7 +399,7 @@ int main(void)
 #ifdef XILINX_PLATFORM
 	Xil_ICacheEnable();
 	Xil_DCacheEnable();
-	(xil_spi_init_param) spi_param.extra = xil_spi_param;
+	spi_param.extra = &xil_spi_param;
 #endif
 
 #ifdef ALTERA_PLATFORM


### PR DESCRIPTION
Fix initialization for xilinx specific spi extra parameters.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>