### PR TITLE
Adrv9009 Altera update

### DIFF
--- a/projects/adrv9009/src/devices/ad9528/ad9528.c
+++ b/projects/adrv9009/src/devices/ad9528/ad9528.c
@@ -12,6 +12,9 @@
 
 #include "parameters.h"
 #include "ad9528.h"
+#ifndef ALTERA_PLATFORM
+#include "xilinx_platform_drivers.h"
+#endif
 
 static uint32_t _desired_time_to_elapse_ms = 0;
 
@@ -226,9 +229,14 @@ adiHalErr_t AD9528_initDeviceDataStruct(ad9528Device_t *device,
 	status = gpio_get(&device->gpio_resetb, CLK_RESETB);
 	status |= gpio_get(&device->gpio_sysref_req, ADRV_SYSREF_REQ);
 
-	spi_param.id = 0;
 	spi_param.mode = SPI_MODE_0;
 	spi_param.chip_select = CLK_CS;
+
+#ifndef ALTERA_PLATFORM
+	xil_spi_init_param xil_spi_param = {.id = 0};
+	spi_param.extra = &xil_spi_param;
+#endif
+
 	status |= spi_init(&device->spi_desc, &spi_param);
 
 	if (status != SUCCESS)

--- a/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
+++ b/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
@@ -43,6 +43,9 @@
 #include <stdio.h>
 #include "adi_hal.h"
 #include "parameters.h"
+#ifndef ALTERA_PLATFORM
+#include "xilinx_platform_drivers.h"
+#endif
 
 /******************************************************************************/
 /************************** Functions Implementation **************************/
@@ -61,11 +64,11 @@ adiHalErr_t ADIHAL_openHw(void *devHalInfo, uint32_t halTimeout_ms)
 
 	status = gpio_get(&dev_hal_data->gpio_adrv_resetb, ADRV_RESETB);
 
-	spi_param.id = 0;
 	spi_param.mode = SPI_MODE_0;
 	spi_param.chip_select = ADRV_CS;
 #ifndef ALTERA_PLATFORM
-	spi_param.flags = SPI_CS_DECODE;
+	xil_spi_init_param xil_spi_param = {.id = 0, .flags = SPI_CS_DECODE};
+	spi_param.extra = &xil_spi_param;
 #endif
 	status |= spi_init(&dev_hal_data->spi_adrv_desc, &spi_param);
 

--- a/projects/drivers/altera_platform/altera_platform_drivers.h
+++ b/projects/drivers/altera_platform/altera_platform_drivers.h
@@ -1,5 +1,5 @@
 /***************************************************************************//**
- *   @file   platform_drivers.h
+ *   @file   altera_platform_drivers.h
  *   @brief  Header file of Altera Platform Drivers.
  *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
 ********************************************************************************
@@ -37,22 +37,48 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 
-#ifndef PLATFORM_DRIVERS_H_
-#define PLATFORM_DRIVERS_H_
+#ifndef ALTERA_PLATFORM_DRIVERS_H_
+#define ALTERA_PLATFORM_DRIVERS_H_
 
 /******************************************************************************/
-/***************************** Include Files **********************************/
-/******************************************************************************/
-#include "delay.h"
-#include "error.h"
-#include "gpio.h"
-#include "i2c.h"
-#include "spi.h"
-
-/******************************************************************************/
-/********************** Macros and Constants Definitions **********************/
+/*************************** Types Declarations *******************************/
 /******************************************************************************/
 
-#define ALTERA_PLATFORM
+typedef enum i2c_type {
+	ALTERA_I2C
+} i2c_type;
 
-#endif // PLATFORM_DRIVERS_H_
+typedef struct altera_i2c_init_param {
+	enum i2c_type	type;
+	uint32_t	id;
+} altera_i2c_init_param;
+
+typedef struct altera_i2c_desc {
+	enum i2c_type	type;
+	uint32_t	id;
+} altera_i2c_desc;
+
+typedef enum spi_type {
+	ALTERA_SPI
+} spi_type;
+
+typedef struct altera_spi_init_param {
+	enum spi_type	type;
+	uint32_t	id;
+} altera_spi_init_param;
+
+typedef struct altera_spi_desc {
+	enum spi_type	type;
+	uint32_t		id;
+} altera_spi_desc;
+
+typedef enum gpio_type {
+	ALTERA_GPIO
+} gpio_type;
+
+typedef struct altera_gpio_desc {
+	enum gpio_type	type;
+	uint32_t		id;
+} altera_gpio_desc;
+
+#endif /* ALTERA_PLATFORM_DRIVERS_H_ */

--- a/projects/drivers/altera_platform/delay.c
+++ b/projects/drivers/altera_platform/delay.c
@@ -1,6 +1,6 @@
 /***************************************************************************//**
- *   @file   platform_drivers.h
- *   @brief  Header file of Altera Platform Drivers.
+ *   @file   delay.c
+ *   @brief  Implementation of Altera Delay Functions.
  *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
 ********************************************************************************
  * Copyright 2019(c) Analog Devices, Inc.
@@ -37,22 +37,32 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 
-#ifndef PLATFORM_DRIVERS_H_
-#define PLATFORM_DRIVERS_H_
-
 /******************************************************************************/
 /***************************** Include Files **********************************/
 /******************************************************************************/
+
 #include "delay.h"
-#include "error.h"
-#include "gpio.h"
-#include "i2c.h"
-#include "spi.h"
 
 /******************************************************************************/
-/********************** Macros and Constants Definitions **********************/
+/************************ Functions Definitions *******************************/
 /******************************************************************************/
 
-#define ALTERA_PLATFORM
+/**
+ * @brief Generate microseconds delay.
+ * @param usecs - Delay in microseconds.
+ * @return None.
+ */
+void udelay(uint32_t usecs)
+{
+	usleep(usecs);
+}
 
-#endif // PLATFORM_DRIVERS_H_
+/**
+ * @brief Generate miliseconds delay.
+ * @param msecs - Delay in miliseconds.
+ * @return None.
+ */
+void mdelay(uint32_t msecs)
+{
+	usleep(msecs * 1000);
+}

--- a/projects/drivers/altera_platform/gpio.c
+++ b/projects/drivers/altera_platform/gpio.c
@@ -1,9 +1,9 @@
 /***************************************************************************//**
- *   @file   platform_drivers.c
- *   @brief  Implementation of Altera Platform Drivers.
- *   @author DBogdan (dragos.bogdan@analog.com)
+ *   @file   gpio.c
+ *   @brief  Implementation of Altera GPIO Generic Driver.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
 ********************************************************************************
- * Copyright 2018(c) Analog Devices, Inc.
+ * Copyright 2019(c) Analog Devices, Inc.
  *
  * All rights reserved.
  *
@@ -40,195 +40,16 @@
 /******************************************************************************/
 /***************************** Include Files **********************************/
 /******************************************************************************/
+
 #include <stdlib.h>
 #include <altera_avalon_spi_regs.h>
+#include "gpio.h"
+#include "error.h"
 #include "parameters.h"
-#include "platform_drivers.h"
 
 /******************************************************************************/
 /************************ Functions Definitions *******************************/
 /******************************************************************************/
-
-/**
- * @brief Initialize the I2C communication peripheral.
- * @param desc - The I2C descriptor.
- * @param init_param - The structure that contains the I2C parameters.
- * @return SUCCESS in case of success, FAILURE otherwise.
- */
-int32_t i2c_init(struct i2c_desc **desc,
-		 const struct i2c_init_param *param)
-{
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (param->type) {
-		// Unused variable - fix compiler warning
-	}
-
-	return SUCCESS;
-}
-
-/**
- * @brief Free the resources allocated by i2c_init().
- * @param desc - The I2C descriptor.
- * @return SUCCESS in case of success, FAILURE otherwise.
- */
-int32_t i2c_remove(struct i2c_desc *desc)
-{
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
-
-	return SUCCESS;
-}
-
-/**
- * @brief Write data to a slave device.
- * @param desc - The I2C descriptor.
- * @param data - Buffer that stores the transmission data.
- * @param bytes_number - Number of bytes to write.
- * @param stop_bit - Stop condition control.
- *                   Example: 0 - A stop condition will not be generated;
- *                            1 - A stop condition will be generated.
- * @return SUCCESS in case of success, FAILURE otherwise.
- */
-int32_t i2c_write(struct i2c_desc *desc,
-		  uint8_t *data,
-		  uint8_t bytes_number,
-		  uint8_t stop_bit)
-{
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (data) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (bytes_number) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (stop_bit) {
-		// Unused variable - fix compiler warning
-	}
-
-	return SUCCESS;
-}
-
-/**
- * @brief Read data from a slave device.
- * @param desc - The I2C descriptor.
- * @param data - Buffer that will store the received data.
- * @param bytes_number - Number of bytes to read.
- * @param stop_bit - Stop condition control.
- *                   Example: 0 - A stop condition will not be generated;
- *                            1 - A stop condition will be generated.
- * @return SUCCESS in case of success, FAILURE otherwise.
- */
-int32_t i2c_read(struct i2c_desc *desc,
-		 uint8_t *data,
-		 uint8_t bytes_number,
-		 uint8_t stop_bit)
-{
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (data) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (bytes_number) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (stop_bit) {
-		// Unused variable - fix compiler warning
-	}
-
-	return SUCCESS;
-}
-
-/**
- * @brief Initialize the SPI communication peripheral.
- * @param desc - The SPI descriptor.
- * @param init_param - The structure that contains the SPI parameters.
- * @return SUCCESS in case of success, FAILURE otherwise.
- */
-int32_t spi_init(struct spi_desc **desc,
-		 const struct spi_init_param *param)
-{
-	spi_desc *descriptor;
-
-	descriptor = (struct spi_desc *) malloc(sizeof(*descriptor));
-	if (!descriptor)
-		return FAILURE;
-
-	descriptor->chip_select = param->chip_select;
-
-	descriptor->mode = param->mode;
-
-	*desc = descriptor;
-
-	return SUCCESS;
-}
-
-/**
- * @brief Free the resources allocated by spi_init().
- * @param desc - The SPI descriptor.
- * @return SUCCESS in case of success, FAILURE otherwise.
- */
-int32_t spi_remove(struct spi_desc *desc)
-{
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
-
-	return SUCCESS;
-}
-
-/**
- * @brief Write and read data to/from SPI.
- * @param desc - The SPI descriptor.
- * @param data - The buffer with the transmitted/received data.
- * @param bytes_number - Number of bytes to write/read.
- * @return SUCCESS in case of success, FAILURE otherwise.
- */
-
-int32_t spi_write_and_read(struct spi_desc *desc,
-			   uint8_t *data,
-			   uint8_t bytes_number)
-{
-	uint32_t i;
-
-	IOWR_32DIRECT(SPI_BASEADDR,
-		      (ALTERA_AVALON_SPI_CONTROL_REG * 4),
-		      ALTERA_AVALON_SPI_CONTROL_SSO_MSK);
-	IOWR_32DIRECT(SPI_BASEADDR,
-		      (ALTERA_AVALON_SPI_SLAVE_SEL_REG * 4),
-		      desc->chip_select);
-	for (i = 0; i < bytes_number; i++) {
-		while ((IORD_32DIRECT(SPI_BASEADDR,
-				      (ALTERA_AVALON_SPI_STATUS_REG * 4)) &
-			ALTERA_AVALON_SPI_STATUS_TRDY_MSK) == 0x00) {}
-		IOWR_32DIRECT(SPI_BASEADDR,
-			      (ALTERA_AVALON_SPI_TXDATA_REG * 4),
-			      *(data + i));
-		while ((IORD_32DIRECT(SPI_BASEADDR,
-				      (ALTERA_AVALON_SPI_STATUS_REG * 4)) &
-			ALTERA_AVALON_SPI_STATUS_RRDY_MSK) == 0x00) {}
-		*(data + i) = IORD_32DIRECT(SPI_BASEADDR,
-					    (ALTERA_AVALON_SPI_RXDATA_REG * 4));
-	}
-	IOWR_32DIRECT(SPI_BASEADDR,
-		      (ALTERA_AVALON_SPI_SLAVE_SEL_REG * 4), 0x000);
-	IOWR_32DIRECT(SPI_BASEADDR,
-		      (ALTERA_AVALON_SPI_CONTROL_REG * 4), 0x000);
-
-	return SUCCESS;
-}
 
 /**
  * @brief Obtain the GPIO decriptor.
@@ -373,24 +194,4 @@ int32_t gpio_get_value(struct gpio_desc *desc,
 	}
 
 	return 0;
-}
-
-/**
- * @brief Generate microseconds delay.
- * @param usecs - Delay in microseconds.
- * @return None.
- */
-void udelay(uint32_t usecs)
-{
-	usleep(usecs);
-}
-
-/**
- * @brief Generate miliseconds delay.
- * @param msecs - Delay in miliseconds.
- * @return None.
- */
-void mdelay(uint32_t msecs)
-{
-	usleep(msecs * 1000);
 }

--- a/projects/drivers/altera_platform/i2c.c
+++ b/projects/drivers/altera_platform/i2c.c
@@ -1,6 +1,6 @@
 /***************************************************************************//**
- *   @file   platform_drivers.h
- *   @brief  Header file of Altera Platform Drivers.
+ *   @file   i2c.c
+ *   @brief  Implementation of Altera I2C Generic Driver.
  *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
 ********************************************************************************
  * Copyright 2019(c) Analog Devices, Inc.
@@ -37,22 +37,117 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 
-#ifndef PLATFORM_DRIVERS_H_
-#define PLATFORM_DRIVERS_H_
-
 /******************************************************************************/
 /***************************** Include Files **********************************/
 /******************************************************************************/
-#include "delay.h"
+
+#include <stdlib.h>
 #include "error.h"
-#include "gpio.h"
 #include "i2c.h"
-#include "spi.h"
+#include "altera_platform_drivers.h"
 
 /******************************************************************************/
-/********************** Macros and Constants Definitions **********************/
+/************************ Functions Definitions *******************************/
 /******************************************************************************/
 
-#define ALTERA_PLATFORM
+/**
+ * @brief Initialize the I2C communication peripheral.
+ * @param desc - The I2C descriptor.
+ * @param init_param - The structure that contains the I2C parameters.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t i2c_init(struct i2c_desc **desc,
+		 const struct i2c_init_param *param)
+{
+	if (desc) {
+		// Unused variable - fix compiler warning
+	}
 
-#endif // PLATFORM_DRIVERS_H_
+	if (((altera_i2c_init_param *)param->extra)->type) {
+		// Unused variable - fix compiler warning
+	}
+
+	return SUCCESS;
+}
+
+/**
+ * @brief Free the resources allocated by i2c_init().
+ * @param desc - The I2C descriptor.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t i2c_remove(struct i2c_desc *desc)
+{
+	if (desc) {
+		// Unused variable - fix compiler warning
+	}
+
+	return SUCCESS;
+}
+
+/**
+ * @brief Write data to a slave device.
+ * @param desc - The I2C descriptor.
+ * @param data - Buffer that stores the transmission data.
+ * @param bytes_number - Number of bytes to write.
+ * @param stop_bit - Stop condition control.
+ *                   Example: 0 - A stop condition will not be generated;
+ *                            1 - A stop condition will be generated.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t i2c_write(struct i2c_desc *desc,
+		  uint8_t *data,
+		  uint8_t bytes_number,
+		  uint8_t stop_bit)
+{
+	if (desc) {
+		// Unused variable - fix compiler warning
+	}
+
+	if (data) {
+		// Unused variable - fix compiler warning
+	}
+
+	if (bytes_number) {
+		// Unused variable - fix compiler warning
+	}
+
+	if (stop_bit) {
+		// Unused variable - fix compiler warning
+	}
+
+	return SUCCESS;
+}
+
+/**
+ * @brief Read data from a slave device.
+ * @param desc - The I2C descriptor.
+ * @param data - Buffer that will store the received data.
+ * @param bytes_number - Number of bytes to read.
+ * @param stop_bit - Stop condition control.
+ *                   Example: 0 - A stop condition will not be generated;
+ *                            1 - A stop condition will be generated.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t i2c_read(struct i2c_desc *desc,
+		 uint8_t *data,
+		 uint8_t bytes_number,
+		 uint8_t stop_bit)
+{
+	if (desc) {
+		// Unused variable - fix compiler warning
+	}
+
+	if (data) {
+		// Unused variable - fix compiler warning
+	}
+
+	if (bytes_number) {
+		// Unused variable - fix compiler warning
+	}
+
+	if (stop_bit) {
+		// Unused variable - fix compiler warning
+	}
+
+	return SUCCESS;
+}

--- a/projects/drivers/axi_adc_core/axi_adc_core.c
+++ b/projects/drivers/axi_adc_core/axi_adc_core.c
@@ -43,8 +43,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <inttypes.h>
-#include "error.h"
-#include "delay.h"
+#include "platform_drivers.h"
 #ifdef ALTERA_PLATFORM
 #include "io.h"
 #else

--- a/projects/drivers/axi_dac_core/axi_dac_core.c
+++ b/projects/drivers/axi_dac_core/axi_dac_core.c
@@ -43,8 +43,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <inttypes.h>
-#include "error.h"
-#include "delay.h"
+#include "platform_drivers.h"
 #ifdef ALTERA_PLATFORM
 #include "io.h"
 #else

--- a/projects/drivers/axi_dac_core/axi_dac_core.c
+++ b/projects/drivers/axi_dac_core/axi_dac_core.c
@@ -827,7 +827,7 @@ int32_t axi_dac_load_custom_data(struct axi_dac *dac,
 		/* Send the same data on all the channels */
 		for (chan = 0; chan < num_tx_channels; chan++) {
 #ifdef ALTERA_PLATFORM
-			IOWR_32DIRECT(address + index_mem * sizeof(uint32_t),
+			IOWR_32DIRECT(address, index_mem * sizeof(uint32_t),
 				      custom_data_iq[index]);
 #else
 			Xil_Out32(address + index_mem * sizeof(uint32_t),

--- a/projects/drivers/axi_dmac/axi_dmac.c
+++ b/projects/drivers/axi_dmac/axi_dmac.c
@@ -42,7 +42,7 @@
 /******************************************************************************/
 #include <stdlib.h>
 #include <stdio.h>
-#include "error.h"
+#include "platform_drivers.h"
 #ifdef ALTERA_PLATFORM
 #include "io.h"
 #else


### PR DESCRIPTION
Update platform drivers to current structure (spi, i2c, gpio, delay).

DAC Core: Fix write function for Altera .

Update "platform_drivers.h".

Add platform specific header file `altera_platform_drivers.h`.

Update project drivers to work both with Altera and Xilinx Platform.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>