### PR TITLE
ad9371: README: fix condition

### DIFF
--- a/projects/ad9371/src/README
+++ b/projects/ad9371/src/README
@@ -1,7 +1,7 @@
 
 # Additional required source files:
 
-#ifndef ALTERA_PLATFORM
+#ifdef ALTERA_PLATFORM
 	cp ../../drivers/altera_platform/platform_drivers.c devices/adi_hal/
 	cp ../../drivers/altera_platform/platform_drivers.h devices/adi_hal/
 	cp ../../drivers/axi_adc_core/axi_adc_core.c devices/adi_hal/


### PR DESCRIPTION
Replace `ifndef` with correct condition for Altera platforms.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>