### PR TITLE
Ad fmcjesdadc1 ebz fix

### DIFF
--- a/ad-fmcjesdadc1-ebz/ad9250.c
+++ b/ad-fmcjesdadc1-ebz/ad9250.c
@@ -105,6 +105,10 @@ int32_t ad9250_setup(struct ad9250_dev **device,
 
 	/* Setup SPI descriptor */
 	ret = spi_init(&dev->spi_dev, &init_param.spi_init);
+	if(ret < 0) {
+		ad_printf("Error spi_init()\n");
+		return ret;
+	}
 
 	dev->id_no = init_param.id_no;
 

--- a/ad-fmcjesdadc1-ebz/ad9250.c
+++ b/ad-fmcjesdadc1-ebz/ad9250.c
@@ -50,8 +50,8 @@
 * @brief ad9250_spi_read
 *******************************************************************************/
 int32_t ad9250_spi_read(struct ad9250_dev *dev,
-						uint16_t reg_addr,
-						uint8_t *reg_data)
+			uint16_t reg_addr,
+			uint8_t *reg_data)
 {
 	uint8_t buf[4];
 	int32_t ret;
@@ -71,8 +71,8 @@ int32_t ad9250_spi_read(struct ad9250_dev *dev,
 * @brief ad9250_spi_write
 *******************************************************************************/
 int32_t ad9250_spi_write(struct ad9250_dev *dev,
-						 uint16_t reg_addr,
-						 uint8_t reg_data)
+			 uint16_t reg_addr,
+			 uint8_t reg_data)
 {
 	uint8_t buf[4];
 	int32_t ret;
@@ -91,7 +91,7 @@ int32_t ad9250_spi_write(struct ad9250_dev *dev,
 * @brief ad9250_setup
 *******************************************************************************/
 int32_t ad9250_setup(struct ad9250_dev **device,
-					 struct ad9250_init_param init_param)
+		     struct ad9250_init_param init_param)
 {
 	uint8_t chip_id;
 	uint8_t stat;
@@ -110,7 +110,7 @@ int32_t ad9250_setup(struct ad9250_dev **device,
 
 	ad9250_spi_read(dev, AD9250_REG_CHIP_ID, &chip_id);
 	printf("AD9250 CHIP ID %s (0x%x).\n",
-			(chip_id == AD9250_CHIP_ID) ? "ok" : "errors", chip_id);
+	       (chip_id == AD9250_CHIP_ID) ? "ok" : "errors", chip_id);
 
 	ad9250_spi_write(dev, AD9250_REG_JESD204B_LINK_CNTRL_1, (0x16 | 0x1));
 	ad9250_spi_write(dev, AD9250_REG_JESD204B_QUICK_CONFIG, 0x22);
@@ -126,7 +126,7 @@ int32_t ad9250_setup(struct ad9250_dev **device,
 	mdelay(10);
 	ad9250_spi_read(dev, AD9250_REG_PLL_STATUS, &stat);
 	printf("AD9250 PLL/link %s (0x%x).\n",
-			(stat == 0x81) ? "ok" : "errors", stat);
+	       (stat == 0x81) ? "ok" : "errors", stat);
 
 	*device = dev;
 
@@ -151,10 +151,10 @@ int32_t ad9250_remove(struct ad9250_dev *dev)
  * @brief ad9250_test
  *******************************************************************************/
 int32_t ad9250_test(struct ad9250_dev *dev,
-					uint32_t test_mode)
+		    uint32_t test_mode)
 {
-        ad9250_spi_write(dev, AD9250_REG_TEST_CNTRL, test_mode);
-        ad9250_spi_write(dev, AD9250_REG_TRANSFER, 0x01);
+	ad9250_spi_write(dev, AD9250_REG_TEST_CNTRL, test_mode);
+	ad9250_spi_write(dev, AD9250_REG_TRANSFER, 0x01);
 
 	return 0;
 }

--- a/ad-fmcjesdadc1-ebz/ad9517.c
+++ b/ad-fmcjesdadc1-ebz/ad9517.c
@@ -55,8 +55,8 @@ uint8_t ad9517_slave_select;
 * @brief ad9517_spi_read
 *******************************************************************************/
 int32_t ad9517_spi_read(struct ad9517_dev *dev,
-						uint16_t reg_addr,
-						uint8_t *reg_data)
+			uint16_t reg_addr,
+			uint8_t *reg_data)
 {
 	uint8_t buf[4];
 	int32_t ret;
@@ -76,8 +76,8 @@ int32_t ad9517_spi_read(struct ad9517_dev *dev,
 * @brief ad9517_spi_write
 *******************************************************************************/
 int32_t ad9517_spi_write(struct ad9517_dev *dev,
-						 uint16_t reg_addr,
-						 uint8_t reg_data)
+			 uint16_t reg_addr,
+			 uint8_t reg_data)
 {
 	uint8_t buf[4];
 	int32_t ret;
@@ -96,7 +96,7 @@ int32_t ad9517_spi_write(struct ad9517_dev *dev,
 * @brief ad9517_setup
 *******************************************************************************/
 int32_t ad9517_setup(struct ad9517_dev **device,
-					 struct ad9517_init_param init_param)
+		     struct ad9517_init_param init_param)
 {
 	uint8_t stat;
 	int32_t ret;

--- a/ad-fmcjesdadc1-ebz/ad9517.c
+++ b/ad-fmcjesdadc1-ebz/ad9517.c
@@ -109,6 +109,10 @@ int32_t ad9517_setup(struct ad9517_dev **device,
 
 	/* Setup SPI descriptor */
 	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
+	if(ret < 0) {
+		ad_printf("Error spi_init()\n");
+		return ret;
+	}
 
 	ad9517_spi_write(dev, 0x0010, 0x7c);
 	ad9517_spi_write(dev, 0x0014, 0x05);

--- a/ad-fmcjesdadc1-ebz/ad_fmcjesdadc1_ebz.c
+++ b/ad-fmcjesdadc1-ebz/ad_fmcjesdadc1_ebz.c
@@ -72,6 +72,7 @@ int main(void)
 	dmac_core		ad9250_1_dma;
 	dmac_xfer		rx_xfer_0;
 	dmac_xfer		rx_xfer_1;
+	int32_t ret;
 
 #ifdef XILINX
 	ad9250_xcvr.base_address = XPAR_AXI_AD9250_XCVR_BASEADDR;
@@ -180,11 +181,16 @@ int main(void)
 	rx_xfer_1.no_of_samples = 32768;
 
 	// set up clock generator
-	ad9517_setup(&ad9517_device, ad9517_param);
-
+	ret = ad9517_setup(&ad9517_device, ad9517_param);
+	if(ret < 0)
+		ad_printf("Error ad9517_setup()\n");
 	// set up the devices
-	ad9250_setup(&ad9250_0_device, ad9250_0_param);
-	ad9250_setup(&ad9250_1_device, ad9250_1_param);
+	ret = ad9250_setup(&ad9250_0_device, ad9250_0_param);
+	if(ret < 0)
+		ad_printf("Error ad9250_setup()\n");
+	ret = ad9250_setup(&ad9250_1_device, ad9250_1_param);
+	if(ret < 0)
+		ad_printf("Error ad9250_setup()\n");
 
 	// generate SYSREF
 	jesd_sysref_control(&ad9250_jesd204, 1);

--- a/ad-fmcjesdadc1-ebz/ad_fmcjesdadc1_ebz.c
+++ b/ad-fmcjesdadc1-ebz/ad_fmcjesdadc1_ebz.c
@@ -88,9 +88,25 @@ int main(void)
 	rx_xfer_1.start_address = XPAR_DDR_MEM_BASEADDR + 0x900000;
 #endif
 
+#ifdef ZYNQ_PS7
+	ad9517_param.spi_init.type = ZYNQ_PS7_SPI;
+	ad9250_0_param.spi_init.type = ZYNQ_PS7_SPI;
+	ad9250_1_param.spi_init.type = ZYNQ_PS7_SPI;
+#endif
+
+#ifdef ZYNQ_PSU
+	ad9517_param.spi_init.type = ZYNQ_PSU_SPI;
+	ad9250_0_param.spi_init.type = ZYNQ_PSU_SPI;
+	ad9250_1_param.spi_init.type = ZYNQ_PSU_SPI;
+#endif
+
 #ifdef MICROBLAZE
 	rx_xfer_0.start_address = XPAR_AXI_DDR_CNTRL_BASEADDR + 0x800000;
 	rx_xfer_1.start_address = XPAR_AXI_DDR_CNTRL_BASEADDR + 0x900000;
+
+	ad9517_param.spi_init.type = MICROBLAZE_SPI;
+	ad9250_0_param.spi_init.type = MICROBLAZE_SPI;
+	ad9250_1_param.spi_init.type = MICROBLAZE_SPI;
 #endif
 
 #ifdef ALTERA
@@ -107,6 +123,10 @@ int main(void)
 	ad9250_1_dma.base_address = AXI_AD9250_DMA_1_BASE;
 	rx_xfer_0.start_address =  0x800000;
 	rx_xfer_1.start_address =  0x900000;
+
+	ad9517_param.spi_init.type = NIOS_II_SPI;
+	ad9250_0_param.spi_init.type = NIOS_II_SPI;
+	ad9250_1_param.spi_init.type = NIOS_II_SPI;
 #endif
 
 	// SPI configuration
@@ -114,15 +134,15 @@ int main(void)
 	ad9517_param.spi_init.chip_select = SPI_CHIP_SELECT(0);
 	ad9517_param.spi_init.cpha = 0;
 	ad9517_param.spi_init.cpol = 0;
-	ad9517_param.spi_init.type = ZYNQ_PS7_SPI;
+
 	ad9250_0_param.spi_init.chip_select = SPI_CHIP_SELECT(0);
 	ad9250_0_param.spi_init.cpha = 0;
 	ad9250_0_param.spi_init.cpol = 0;
-	ad9250_0_param.spi_init.type = ZYNQ_PS7_SPI;
+
 	ad9250_1_param.spi_init.chip_select = SPI_CHIP_SELECT(0);
 	ad9250_1_param.spi_init.cpha = 0;
 	ad9250_1_param.spi_init.cpol = 0;
-	ad9250_1_param.spi_init.type = ZYNQ_PS7_SPI;
+
 	ad9250_0_param.id_no = 0x0;
 	ad9250_1_param.id_no = 0x1;
 


### PR DESCRIPTION
Fix SPI init value for spi_init.type
This parameter is platform dependent and some compiler switch has been
added.