### PR TITLE
ADRV9009 update: make drivers platform agnostic

### DIFF
--- a/projects/adrv9009/src/devices/ad9528/ad9528.c
+++ b/projects/adrv9009/src/devices/ad9528/ad9528.c
@@ -12,9 +12,6 @@
 
 #include "parameters.h"
 #include "ad9528.h"
-#ifndef ALTERA_PLATFORM
-#include "xilinx_platform_drivers.h"
-#endif
 
 static uint32_t _desired_time_to_elapse_ms = 0;
 
@@ -232,10 +229,8 @@ adiHalErr_t AD9528_initDeviceDataStruct(ad9528Device_t *device,
 	spi_param.mode = SPI_MODE_0;
 	spi_param.chip_select = CLK_CS;
 
-#ifndef ALTERA_PLATFORM
-	xil_spi_init_param xil_spi_param = {.id = 0};
-	spi_param.extra = &xil_spi_param;
-#endif
+	if(device->extra)
+		(device->extra)(&spi_param);
 
 	status |= spi_init(&device->spi_desc, &spi_param);
 

--- a/projects/adrv9009/src/devices/ad9528/t_ad9528.h
+++ b/projects/adrv9009/src/devices/ad9528/t_ad9528.h
@@ -184,6 +184,7 @@ typedef struct {
 	ad9528pll2Settings_t *pll2Settings;
 	ad9528outputSettings_t *outputSettings;
 	ad9528sysrefSettings_t *sysrefSettings;
+	void (*extra)(spi_init_param*);
 } ad9528Device_t;
 
 typedef enum {

--- a/projects/adrv9009/src/devices/adi_hal/adi_hal.h
+++ b/projects/adrv9009/src/devices/adi_hal/adi_hal.h
@@ -24,6 +24,7 @@ struct adi_hal {
 	struct gpio_desc	*gpio_adrv_sysref_req;
 	struct spi_desc		*spi_adrv_desc;
 	uint32_t			log_level;
+	void 				(*extra)(spi_init_param*);
 };
 
 /**

--- a/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
+++ b/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
@@ -43,9 +43,6 @@
 #include <stdio.h>
 #include "adi_hal.h"
 #include "parameters.h"
-#ifndef ALTERA_PLATFORM
-#include "xilinx_platform_drivers.h"
-#endif
 
 /******************************************************************************/
 /************************** Functions Implementation **************************/
@@ -66,10 +63,9 @@ adiHalErr_t ADIHAL_openHw(void *devHalInfo, uint32_t halTimeout_ms)
 
 	spi_param.mode = SPI_MODE_0;
 	spi_param.chip_select = ADRV_CS;
-#ifndef ALTERA_PLATFORM
-	xil_spi_init_param xil_spi_param = {.id = 0, .flags = SPI_CS_DECODE};
-	spi_param.extra = &xil_spi_param;
-#endif
+	if ((((struct adi_hal*)devHalInfo)->extra))
+		(((struct adi_hal*)devHalInfo)->extra)(&spi_param);
+
 	status |= spi_init(&dev_hal_data->spi_adrv_desc, &spi_param);
 
 	status |= gpio_get(&dev_hal_data->gpio_adrv_sysref_req, ADRV_SYSREF_REQ);

--- a/projects/drivers/axi_adc_core/axi_adc_core.c
+++ b/projects/drivers/axi_adc_core/axi_adc_core.c
@@ -44,11 +44,6 @@
 #include <stdio.h>
 #include <inttypes.h>
 #include "platform_drivers.h"
-#ifdef ALTERA_PLATFORM
-#include "io.h"
-#else
-#include "xil_io.h"
-#endif
 #include "util.h"
 #include "axi_adc_core.h"
 
@@ -110,11 +105,7 @@ int32_t axi_adc_read(struct axi_adc *adc,
 		     uint32_t reg_addr,
 		     uint32_t *reg_data)
 {
-#ifdef ALTERA_PLATFORM
-	*reg_data = IORD_32DIRECT(adc->base, reg_addr);
-#else
-	*reg_data = Xil_In32((adc->base + reg_addr));
-#endif
+	*reg_data = adc->adc_read(adc->base, reg_addr);
 
 	return SUCCESS;
 }
@@ -126,11 +117,7 @@ int32_t axi_adc_write(struct axi_adc *adc,
 		      uint32_t reg_addr,
 		      uint32_t reg_data)
 {
-#ifdef ALTERA_PLATFORM
-	IOWR_32DIRECT(adc->base, reg_addr, reg_data);
-#else
-	Xil_Out32((adc->base + reg_addr), reg_data);
-#endif
+	adc->adc_write(adc->base, reg_addr, reg_data);
 
 	return SUCCESS;
 }
@@ -354,6 +341,8 @@ int32_t axi_adc_init(struct axi_adc **adc_core,
 	adc->name = init->name;
 	adc->base = init->base;
 	adc->num_channels = init->num_channels;
+	adc->adc_read = init->adc_read;
+	adc->adc_write = init->adc_write;
 
 	axi_adc_write(adc, AXI_ADC_REG_RSTN, 0);
 	axi_adc_write(adc, AXI_ADC_REG_RSTN,

--- a/projects/drivers/axi_adc_core/axi_adc_core.h
+++ b/projects/drivers/axi_adc_core/axi_adc_core.h
@@ -52,12 +52,16 @@ struct axi_adc {
 	uint32_t base;
 	uint8_t	num_channels;
 	uint64_t clock_hz;
+	uint32_t (*adc_read)(uint32_t, uint32_t);
+	void (*adc_write)(uint32_t, uint32_t, uint32_t);
 };
 
 struct axi_adc_init {
 	const char *name;
 	uint32_t base;
 	uint8_t	num_channels;
+	uint32_t (*adc_read)(uint32_t, uint32_t);
+	void (*adc_write)(uint32_t, uint32_t, uint32_t);
 };
 
 enum axi_adc_pn_sel {

--- a/projects/drivers/axi_dmac/axi_dmac.c
+++ b/projects/drivers/axi_dmac/axi_dmac.c
@@ -43,11 +43,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "platform_drivers.h"
-#ifdef ALTERA_PLATFORM
-#include "io.h"
-#else
-#include "xil_io.h"
-#endif
 #include "util.h"
 #include "axi_dmac.h"
 
@@ -81,11 +76,7 @@ int32_t axi_dmac_read(struct axi_dmac *dmac,
 		      uint32_t reg_addr,
 		      uint32_t *reg_data)
 {
-#ifdef ALTERA_PLATFORM
-	*reg_data = IORD_32DIRECT(dmac->base, reg_addr);
-#else
-	*reg_data = Xil_In32((dmac->base + reg_addr));
-#endif
+	*reg_data = dmac->dmac_read(dmac->base, reg_addr);
 
 	return SUCCESS;
 }
@@ -97,11 +88,8 @@ int32_t axi_dmac_write(struct axi_dmac *dmac,
 		       uint32_t reg_addr,
 		       uint32_t reg_data)
 {
-#ifdef ALTERA_PLATFORM
-	IOWR_32DIRECT(dmac->base, reg_addr, reg_data);
-#else
-	Xil_Out32((dmac->base + reg_addr), reg_data);
-#endif
+
+	dmac->dmac_write(dmac->base, reg_addr, reg_data);
 
 	return SUCCESS;
 }
@@ -181,6 +169,8 @@ int32_t axi_dmac_init(struct axi_dmac **dmac_core,
 	dmac->base = init->base;
 	dmac->direction = init->direction;
 	dmac->flags = init->flags;
+	dmac->dmac_read = init->dmac_read;
+	dmac->dmac_write = init->dmac_write;
 
 	*dmac_core = dmac;
 

--- a/projects/drivers/axi_dmac/axi_dmac.h
+++ b/projects/drivers/axi_dmac/axi_dmac.h
@@ -62,6 +62,8 @@ struct axi_dmac {
 	uint32_t base;
 	enum dma_direction direction;
 	enum dma_flags flags;
+	uint32_t (*dmac_read)(uint32_t, uint32_t);
+	void (*dmac_write)(uint32_t, uint32_t, uint32_t);
 };
 
 struct axi_dmac_init {
@@ -69,6 +71,8 @@ struct axi_dmac_init {
 	uint32_t base;
 	enum dma_direction direction;
 	enum dma_flags flags;
+	uint32_t (*dmac_read)(uint32_t, uint32_t);
+	void (*dmac_write)(uint32_t, uint32_t, uint32_t);
 };
 
 /******************************************************************************/

--- a/projects/drivers/jesd204/axi_jesd204_rx.h
+++ b/projects/drivers/jesd204/axi_jesd204_rx.h
@@ -63,6 +63,8 @@ struct axi_jesd204_rx {
 	struct jesd204_rx_config config;
 	uint32_t device_clk_khz;
 	uint32_t lane_clk_khz;
+	uint32_t (*jesd_read)(uint32_t, uint32_t);
+	void (*jesd_write)(uint32_t, uint32_t, uint32_t);
 };
 
 struct jesd204_rx_init {
@@ -73,6 +75,8 @@ struct jesd204_rx_init {
 	uint8_t subclass;
 	uint32_t device_clk_khz;
 	uint32_t lane_clk_khz;
+	uint32_t (*jesd_read)(uint32_t, uint32_t);
+	void (*jesd_write)(uint32_t, uint32_t, uint32_t);
 };
 
 /******************************************************************************/

--- a/projects/drivers/jesd204/axi_jesd204_tx.c
+++ b/projects/drivers/jesd204/axi_jesd204_tx.c
@@ -44,11 +44,6 @@
 #include <stdio.h>
 #include <inttypes.h>
 #include "platform_drivers.h"
-#ifdef ALTERA_PLATFORM
-#include "io.h"
-#else
-#include "xil_io.h"
-#endif
 #include "util.h"
 #include "axi_jesd204_tx.h"
 
@@ -101,13 +96,9 @@ const char *axi_jesd204_tx_link_status_label[] = {
 int32_t axi_jesd204_tx_write(struct axi_jesd204_tx *jesd,
 			     uint32_t reg_addr, uint32_t reg_val)
 {
-#ifdef ALTERA_PLATFORM
-	IOWR_32DIRECT(jesd->base, reg_addr, reg_val);
-#else
-	Xil_Out32((jesd->base + reg_addr), reg_val);
-#endif
+	jesd->jesd_write(jesd->base, reg_addr, reg_val);
 
-	return SUCCESS;
+		return SUCCESS;
 }
 
 /**
@@ -116,11 +107,7 @@ int32_t axi_jesd204_tx_write(struct axi_jesd204_tx *jesd,
 int32_t axi_jesd204_tx_read(struct axi_jesd204_tx *jesd,
 			    uint32_t reg_addr, uint32_t *reg_val)
 {
-#ifdef ALTERA_PLATFORM
-	*reg_val = IORD_32DIRECT(jesd->base, reg_addr);
-#else
-	*reg_val = Xil_In32(jesd->base + reg_addr);
-#endif
+	*reg_val = jesd->jesd_read(jesd->base, reg_addr);
 
 	return SUCCESS;
 }
@@ -331,6 +318,8 @@ int32_t axi_jesd204_tx_init(struct axi_jesd204_tx **jesd204,
 	jesd->name = init->name;
 	jesd->device_clk_khz = init->device_clk_khz;
 	jesd->lane_clk_khz = init->lane_clk_khz;
+	jesd->jesd_read = init->jesd_read;
+	jesd->jesd_write = init->jesd_write;
 
 	axi_jesd204_tx_read(jesd, JESD204_TX_REG_MAGIC, &magic);
 	if (magic != JESD204_TX_MAGIC) {

--- a/projects/drivers/jesd204/axi_jesd204_tx.h
+++ b/projects/drivers/jesd204/axi_jesd204_tx.h
@@ -74,6 +74,8 @@ struct axi_jesd204_tx {
 	struct jesd204_tx_config config;
 	uint32_t device_clk_khz;
 	uint32_t lane_clk_khz;
+	uint32_t (*jesd_read)(uint32_t, uint32_t);
+	void (*jesd_write)(uint32_t, uint32_t, uint32_t);
 };
 
 struct jesd204_tx_init {
@@ -89,6 +91,8 @@ struct jesd204_tx_init {
 	uint8_t subclass;
 	uint32_t device_clk_khz;
 	uint32_t lane_clk_khz;
+	uint32_t (*jesd_read)(uint32_t, uint32_t);
+	void (*jesd_write)(uint32_t, uint32_t, uint32_t);
 };
 
 /******************************************************************************/


### PR DESCRIPTION
Use wrappers to make project specific drivers platform agnostic.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>