### PR TITLE
ADRV9009 update: make drivers platform agnostic - Part 2

### DIFF
--- a/projects/adrv9009/src/app/headless.c
+++ b/projects/adrv9009/src/app/headless.c
@@ -27,10 +27,12 @@
 #ifdef ALTERA_PLATFORM
 #include "clk_altera_a10_fpll.h"
 #include "altera_adxcvr.h"
+#include "adrv9009_altera_wrappers.h"
 #else
 #include "xil_cache.h"
 #include "clk_axi_clkgen.h"
 #include "axi_adxcvr.h"
+#include "adrv9009_xilinx_wrappers.h"
 #endif
 #include "axi_jesd204_rx.h"
 #include "axi_jesd204_tx.h"
@@ -41,6 +43,8 @@
 #include "talise_config_ad9528.h"
 #include "talise_arm_binary.h"
 #include "talise_stream_binary.h"
+
+
 
 /**********************************************************/
 /**********************************************************/
@@ -59,7 +63,8 @@ int main(void)
 		&clockPll1Settings,
 		&clockPll2Settings,
 		&clockOutputSettings,
-		&clockSysrefSettings
+		&clockSysrefSettings,
+		NULL
 	};
 	ad9528Device_t *clockAD9528_device = &clockAD9528_;
 #ifdef ALTERA_PLATFORM
@@ -82,6 +87,7 @@ int main(void)
 	struct altera_a10_fpll *tx_device_clk_pll;
 	struct altera_a10_fpll *rx_os_device_clk_pll;
 #else
+	clockAD9528_.extra = xilinx_spi_wrapper;
 	struct axi_clkgen_init rx_clkgen_init = {
 		"rx_clkgen",
 		RX_CLKGEN_BASEADDR,
@@ -121,6 +127,13 @@ int main(void)
 		1,
 		rx_div40_rate_hz / 1000,
 		rx_lane_rate_khz,
+#ifndef ALTERA_PLATFORM
+		xilinx_read_wrapper,
+		xilinx_write_wrapper
+#else
+		altera_read_wrapper,
+		altera_write_wrapper,
+#endif
 	};
 	struct jesd204_tx_init tx_jesd_init = {
 		"tx_jesd",
@@ -135,6 +148,13 @@ int main(void)
 		1,
 		tx_div40_rate_hz / 1000,
 		tx_lane_rate_khz,
+#ifndef ALTERA_PLATFORM
+		xilinx_read_wrapper,
+		xilinx_write_wrapper
+#else
+		altera_read_wrapper,
+		altera_write_wrapper,
+#endif
 	};
 
 	struct jesd204_rx_init rx_os_jesd_init = {
@@ -145,6 +165,13 @@ int main(void)
 		1,
 		rx_os_div40_rate_hz / 1000,
 		rx_os_lane_rate_khz,
+#ifndef ALTERA_PLATFORM
+		xilinx_read_wrapper,
+		xilinx_write_wrapper
+#else
+		altera_read_wrapper,
+		altera_write_wrapper,
+#endif
 	};
 	struct axi_jesd204_rx *rx_jesd;
 	struct axi_jesd204_tx *tx_jesd;
@@ -213,12 +240,27 @@ int main(void)
 		"rx_adc",
 		RX_CORE_BASEADDR,
 		4,
+#ifndef ALTERA_PLATFORM
+		xilinx_read_wrapper,
+		xilinx_write_wrapper
+#else
+		altera_read_wrapper,
+		altera_write_wrapper,
+#endif
 	};
 	struct axi_adc *rx_adc;
 	struct axi_dac_init tx_dac_init = {
 		"tx_dac",
 		TX_CORE_BASEADDR,
 		4,
+#ifndef ALTERA_PLATFORM
+		xilinx_read_wrapper,
+		xilinx_write_wrapper,
+		xilinx_cache_flush_wrapper
+#else
+		altera_read_wrapper,
+		altera_write_wrapper,
+#endif
 	};
 	struct axi_dac *tx_dac;
 	struct axi_dmac_init rx_dmac_init = {
@@ -226,6 +268,13 @@ int main(void)
 		RX_DMA_BASEADDR,
 		DMA_DEV_TO_MEM,
 		0,
+#ifndef ALTERA_PLATFORM
+		xilinx_read_wrapper,
+		xilinx_write_wrapper
+#else
+		altera_read_wrapper,
+		altera_write_wrapper
+#endif
 	};
 	struct axi_dmac *rx_dmac;
 #ifdef DAC_DMA_EXAMPLE
@@ -234,12 +283,22 @@ int main(void)
 		TX_DMA_BASEADDR,
 		DMA_MEM_TO_DEV,
 		DMA_CYCLIC,
+#ifndef ALTERA_PLATFORM
+		xilinx_read_wrapper,
+		xilinx_write_wrapper
+#else
+		altera_read_wrapper,
+		altera_write_wrapper
+#endif
 	};
 	struct axi_dmac *tx_dmac;
 	struct gpio_desc *gpio_plddrbypass;
 	extern const uint32_t sine_lut_iq[1024];
 #endif
 	struct adi_hal hal;
+#ifndef ALTERA_PLATFORM
+	hal.extra = xilinx_spi_wrapper;
+#endif
 	taliseDevice_t talDev = {
 		.devHalInfo = &hal,
 		.devStateInfo = {0}

--- a/projects/drivers/altera_platform/adrv9009_altera_wrappers.c
+++ b/projects/drivers/altera_platform/adrv9009_altera_wrappers.c
@@ -1,0 +1,71 @@
+/***************************************************************************//**
+ *   @file   adrv9009_altera_wrappers.c
+ *   @brief  Source file of ADRV9009 Altera Wrapper.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2019(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include "altera_platform_drivers.h"
+#include "adrv9009_altera_wrappers.h"
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+/**
+ * @brief Wrap Altera specific read function.
+ * @param base - Base address of the register.
+ * @param offset - Address offset of the register.
+ * @return data
+ */
+int32_t altera_read_wrapper(uint32_t base, uint32_t offset){
+	return IORD_32DIRECT(base, offset);
+}
+
+/**
+ * @brief Wrap Xilinx specific write function.
+ * @param base - Base address of the register.
+ * @param offset - Address offset of the register.
+ * @param data - data to be written.
+ * @return none
+ */
+void altera_write_wrapper(uint32_t base, uint32_t offset, uint32_t data){
+	IOWR_32DIRECT(base, offset, data);
+}
+

--- a/projects/drivers/altera_platform/adrv9009_altera_wrappers.h
+++ b/projects/drivers/altera_platform/adrv9009_altera_wrappers.h
@@ -1,0 +1,59 @@
+/***************************************************************************//**
+ *   @file   adrv9009_altera_wrappers.h
+ *   @brief  Header file of ADRV9009 Altera Wrapper.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2019(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef ADRV9009_ALTERA_WRAPPERS_H_
+#define ADRV9009_ALTERA_WRAPPERS_H_
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <stdint.h>
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+/* Read data for Altera platforms. */
+int32_t altera_read_wrapper(uint32_t base, uint32_t offset);
+
+/* Write data for Altera platforms. */
+void altera_write_wrapper(uint32_t base, uint32_t offset, uint32_t data);
+
+#endif // ADRV9009_ALTERA_WRAPPERS_H_

--- a/projects/drivers/axi_dac_core/axi_dac_core.h
+++ b/projects/drivers/axi_dac_core/axi_dac_core.h
@@ -52,12 +52,18 @@ struct axi_dac {
 	uint32_t base;
 	uint8_t	num_channels;
 	uint64_t clock_hz;
+	uint32_t (*dac_read)(uint32_t, uint32_t);
+	void (*dac_write)(uint32_t, uint32_t, uint32_t);
+	void (*extra)();
 };
 
 struct axi_dac_init {
 	const char *name;
 	uint32_t base;
 	uint8_t	num_channels;
+	uint32_t (*dac_read)(uint32_t, uint32_t);
+	void (*dac_write)(uint32_t, uint32_t, uint32_t);
+	void (*extra)();
 };
 
 enum axi_dac_data_sel {

--- a/projects/drivers/xilinx_platform/adrv9009_xilinx_wrappers.c
+++ b/projects/drivers/xilinx_platform/adrv9009_xilinx_wrappers.c
@@ -1,0 +1,91 @@
+/***************************************************************************//**
+ *   @file   adrv9009_xilinx_wrappers.c
+ *   @brief  Source file of ADRV9009 Xilinx Wrapper.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2019(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <stdlib.h>
+#include "adrv9009_xilinx_wrappers.h"
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+/**
+ * @brief Initialize the Xilinx specific SPI parameters.
+ * @param param - The structure that contains the SPI parameters.
+ * @return none
+ */
+void xilinx_spi_wrapper(spi_init_param *param){
+	xil_spi_init_param *xil_spi_param = calloc(1, sizeof(xil_spi_init_param));
+	xil_spi_param->id = 0;
+	xil_spi_param->flags = SPI_CS_DECODE;
+	param->extra = xil_spi_param;
+}
+
+/**
+ * @brief Wrap Xilinx specific read function.
+ * @param base - Base address of the register.
+ * @param offset - Address offset of the register.
+ * @return data
+ */
+int32_t xilinx_read_wrapper(uint32_t base, uint32_t offset){
+	return Xil_In32(base + offset);
+}
+
+/**
+ * @brief Wrap Xilinx specific write function.
+ * @param base - Base address of the register.
+ * @param offset - Address offset of the register.
+ * @param data - data to be written.
+ * @return none
+ */
+void xilinx_write_wrapper(uint32_t base, uint32_t offset, uint32_t data){
+	Xil_Out32(base + offset, data);
+}
+
+/**
+ * @brief Wrap Xilinx cache flush function.
+ * @return none
+ */
+void xilinx_cache_flush_wrapper(){
+	Xil_DCacheFlush();
+}

--- a/projects/drivers/xilinx_platform/adrv9009_xilinx_wrappers.h
+++ b/projects/drivers/xilinx_platform/adrv9009_xilinx_wrappers.h
@@ -1,0 +1,68 @@
+/***************************************************************************//**
+ *   @file   adrv9009_xilinx_wrappers.h
+ *   @brief  Header file of ADRV9009 Xilinx Wrapper.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2019(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef ADRV9009_XILINX_WRAPPERS_H_
+#define ADRV9009_XILINX_WRAPPERS_H_
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <stdint.h>
+#include "spi.h"
+#include "xilinx_platform_drivers.h"
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+/* Initialize the Xilinx specific Spi parameters. */
+void xilinx_spi_wrapper(spi_init_param *param);
+
+/* Read data for Xilinx platforms. */
+int32_t xilinx_read_wrapper(uint32_t base, uint32_t offset);
+
+/* Write data for Xilinx platforms. */
+void xilinx_write_wrapper(uint32_t base, uint32_t offset, uint32_t data);
+
+/* Perform Xilinx cache flush. */
+void xilinx_cache_flush_wrapper();
+
+#endif // ADRV9009_XILINX_WRAPPERS_H_
+


### PR DESCRIPTION
Use wrappers to make project specific drivers platform agnostic.

Signed-off-by: Antoniu Miclaus antoniu.miclaus@analog.com