### PR TITLE
ADRV9009 update: make drivers platform agnostic - Part 2 

### DIFF
--- a/include/adrv9009_wrappers.h
+++ b/include/adrv9009_wrappers.h
@@ -1,0 +1,66 @@
+/***************************************************************************//**
+ *   @file   adrv9009_wrappers.h
+ *   @brief  Header file of ADRV9009 Wrappers.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2019(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef ADRV9009_WRAPPERS_H_
+#define ADRV9009_WRAPPERS_H_
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <stdint.h>
+#include "spi.h"
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+/* Initialize the platform specific spi parameters. */
+void spi_wrapper(spi_init_param *param);
+
+/* Read data */
+int32_t read_wrapper(uint32_t base, uint32_t offset);
+
+/* Write data */
+void write_wrapper(uint32_t base, uint32_t offset, uint32_t data);
+
+/* Perform cache flush. */
+void cache_flush_wrapper();
+
+#endif // ADRV9009_WRAPPERS_H_

--- a/projects/drivers/altera_platform/adrv9009_wrappers.c
+++ b/projects/drivers/altera_platform/adrv9009_wrappers.c
@@ -54,7 +54,8 @@
  * @param offset - Address offset of the register.
  * @return data
  */
-int32_t read_wrapper(uint32_t base, uint32_t offset){
+int32_t read_wrapper(uint32_t base, uint32_t offset)
+{
 	return IORD_32DIRECT(base, offset);
 }
 
@@ -65,7 +66,8 @@ int32_t read_wrapper(uint32_t base, uint32_t offset){
  * @param data - data to be written.
  * @return none
  */
-void write_wrapper(uint32_t base, uint32_t offset, uint32_t data){
+void write_wrapper(uint32_t base, uint32_t offset, uint32_t data)
+{
 	IOWR_32DIRECT(base, offset, data);
 }
 

--- a/projects/drivers/altera_platform/adrv9009_wrappers.c
+++ b/projects/drivers/altera_platform/adrv9009_wrappers.c
@@ -1,0 +1,71 @@
+/***************************************************************************//**
+ *   @file   adrv9009_wrappers.c
+ *   @brief  Implementation of ADRV9009 Altera Wrappers.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2019(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include "adrv9009_wrappers.h"
+#include <io.h>
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+/**
+ * @brief Wrapper Altera read function.
+ * @param base - Base address of the register.
+ * @param offset - Address offset of the register.
+ * @return data
+ */
+int32_t read_wrapper(uint32_t base, uint32_t offset){
+	return IORD_32DIRECT(base, offset);
+}
+
+/**
+ * @brief Wrapper Altera write function.
+ * @param base - Base address of the register.
+ * @param offset - Address offset of the register.
+ * @param data - data to be written.
+ * @return none
+ */
+void write_wrapper(uint32_t base, uint32_t offset, uint32_t data){
+	IOWR_32DIRECT(base, offset, data);
+}
+

--- a/projects/drivers/axi_dac_core/axi_dac_core.c
+++ b/projects/drivers/axi_dac_core/axi_dac_core.c
@@ -800,7 +800,7 @@ int32_t axi_dac_load_custom_data(struct axi_dac *dac,
 		for (chan = 0; chan < num_tx_channels; chan++) {
 
 			dac->dac_write(address, index_mem * sizeof(uint32_t),
-				      custom_data_iq[index]);
+				       custom_data_iq[index]);
 
 			index_mem++;
 		}

--- a/projects/drivers/axi_dac_core/axi_dac_core.h
+++ b/projects/drivers/axi_dac_core/axi_dac_core.h
@@ -52,12 +52,18 @@ struct axi_dac {
 	uint32_t base;
 	uint8_t	num_channels;
 	uint64_t clock_hz;
+	uint32_t (*dac_read)(uint32_t, uint32_t);
+	void (*dac_write)(uint32_t, uint32_t, uint32_t);
+	void (*extra)();
 };
 
 struct axi_dac_init {
 	const char *name;
 	uint32_t base;
 	uint8_t	num_channels;
+	uint32_t (*dac_read)(uint32_t, uint32_t);
+	void (*dac_write)(uint32_t, uint32_t, uint32_t);
+	void (*extra)();
 };
 
 enum axi_dac_data_sel {

--- a/projects/drivers/xilinx_platform/adrv9009_wrappers.c
+++ b/projects/drivers/xilinx_platform/adrv9009_wrappers.c
@@ -1,0 +1,92 @@
+/***************************************************************************//**
+ *   @file   adrv9009_wrappers.c
+ *   @brief  Implementation of ADRV9009 Xilinx Wrappers.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2019(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <stdlib.h>
+#include "adrv9009_wrappers.h"
+#include "xilinx_platform_drivers.h"
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+/**
+ * @brief Initialize the Xilinx specific SPI parameters.
+ * @param param - The structure that contains the SPI parameters.
+ * @return none
+ */
+void spi_wrapper(spi_init_param *param){
+	xil_spi_init_param *xil_spi_param = calloc(1, sizeof(xil_spi_init_param));
+	xil_spi_param->id = 0;
+	xil_spi_param->flags = SPI_CS_DECODE;
+	param->extra = xil_spi_param;
+}
+
+/**
+ * @brief Wrap Xilinx specific read function.
+ * @param base - Base address of the register.
+ * @param offset - Address offset of the register.
+ * @return data
+ */
+int32_t read_wrapper(uint32_t base, uint32_t offset){
+	return Xil_In32(base + offset);
+}
+
+/**
+ * @brief Wrap Xilinx specific write function.
+ * @param base - Base address of the register.
+ * @param offset - Address offset of the register.
+ * @param data - data to be written.
+ * @return none
+ */
+void write_wrapper(uint32_t base, uint32_t offset, uint32_t data){
+	Xil_Out32(base + offset, data);
+}
+
+/**
+ * @brief Wrap Xilinx cache flush function.
+ * @return none
+ */
+void cache_flush_wrapper(){
+	Xil_DCacheFlush();
+}

--- a/projects/drivers/xilinx_platform/adrv9009_wrappers.c
+++ b/projects/drivers/xilinx_platform/adrv9009_wrappers.c
@@ -55,7 +55,8 @@
  * @param param - The structure that contains the SPI parameters.
  * @return none
  */
-void spi_wrapper(spi_init_param *param){
+void spi_wrapper(spi_init_param *param)
+{
 	xil_spi_init_param *xil_spi_param = calloc(1, sizeof(xil_spi_init_param));
 	xil_spi_param->id = 0;
 	xil_spi_param->flags = SPI_CS_DECODE;
@@ -68,7 +69,8 @@ void spi_wrapper(spi_init_param *param){
  * @param offset - Address offset of the register.
  * @return data
  */
-int32_t read_wrapper(uint32_t base, uint32_t offset){
+int32_t read_wrapper(uint32_t base, uint32_t offset)
+{
 	return Xil_In32(base + offset);
 }
 
@@ -79,7 +81,8 @@ int32_t read_wrapper(uint32_t base, uint32_t offset){
  * @param data - data to be written.
  * @return none
  */
-void write_wrapper(uint32_t base, uint32_t offset, uint32_t data){
+void write_wrapper(uint32_t base, uint32_t offset, uint32_t data)
+{
 	Xil_Out32(base + offset, data);
 }
 
@@ -87,6 +90,7 @@ void write_wrapper(uint32_t base, uint32_t offset, uint32_t data){
  * @brief Wrap Xilinx cache flush function.
  * @return none
  */
-void cache_flush_wrapper(){
+void cache_flush_wrapper()
+{
 	Xil_DCacheFlush();
 }


### PR DESCRIPTION
Use wrappers to make drivers platform agnostic.

Signed-off-by: Antoniu Miclaus antoniu.miclaus@analog.com