### PR TITLE
Update drivers to be platform agnostic

### DIFF
--- a/projects/adrv9009/src/devices/ad9528/ad9528.c
+++ b/projects/adrv9009/src/devices/ad9528/ad9528.c
@@ -12,9 +12,6 @@
 
 #include "parameters.h"
 #include "ad9528.h"
-#ifndef ALTERA_PLATFORM
-#include "xilinx_platform_drivers.h"
-#endif
 
 static uint32_t _desired_time_to_elapse_ms = 0;
 
@@ -232,10 +229,8 @@ adiHalErr_t AD9528_initDeviceDataStruct(ad9528Device_t *device,
 	spi_param.mode = SPI_MODE_0;
 	spi_param.chip_select = CLK_CS;
 
-#ifndef ALTERA_PLATFORM
-	xil_spi_init_param xil_spi_param = {.id = 0};
-	spi_param.extra = &xil_spi_param;
-#endif
+	if(device->extra)
+		spi_param.extra=device->extra;
 
 	status |= spi_init(&device->spi_desc, &spi_param);
 

--- a/projects/adrv9009/src/devices/ad9528/t_ad9528.h
+++ b/projects/adrv9009/src/devices/ad9528/t_ad9528.h
@@ -184,6 +184,7 @@ typedef struct {
 	ad9528pll2Settings_t *pll2Settings;
 	ad9528outputSettings_t *outputSettings;
 	ad9528sysrefSettings_t *sysrefSettings;
+	void *extra;
 } ad9528Device_t;
 
 typedef enum {

--- a/projects/adrv9009/src/devices/adi_hal/adi_hal.h
+++ b/projects/adrv9009/src/devices/adi_hal/adi_hal.h
@@ -24,6 +24,7 @@ struct adi_hal {
 	struct gpio_desc	*gpio_adrv_sysref_req;
 	struct spi_desc		*spi_adrv_desc;
 	uint32_t			log_level;
+	void 				*extra;
 };
 
 /**

--- a/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
+++ b/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
@@ -43,9 +43,6 @@
 #include <stdio.h>
 #include "adi_hal.h"
 #include "parameters.h"
-#ifndef ALTERA_PLATFORM
-#include "xilinx_platform_drivers.h"
-#endif
 
 /******************************************************************************/
 /************************** Functions Implementation **************************/
@@ -66,10 +63,9 @@ adiHalErr_t ADIHAL_openHw(void *devHalInfo, uint32_t halTimeout_ms)
 
 	spi_param.mode = SPI_MODE_0;
 	spi_param.chip_select = ADRV_CS;
-#ifndef ALTERA_PLATFORM
-	xil_spi_init_param xil_spi_param = {.id = 0, .flags = SPI_CS_DECODE};
-	spi_param.extra = &xil_spi_param;
-#endif
+	if (dev_hal_data->extra)
+		spi_param.extra = dev_hal_data->extra;
+
 	status |= spi_init(&dev_hal_data->spi_adrv_desc, &spi_param);
 
 	status |= gpio_get(&dev_hal_data->gpio_adrv_sysref_req, ADRV_SYSREF_REQ);

--- a/projects/drivers/axi_adc_core/axi_adc_core.c
+++ b/projects/drivers/axi_adc_core/axi_adc_core.c
@@ -44,11 +44,6 @@
 #include <stdio.h>
 #include <inttypes.h>
 #include "platform_drivers.h"
-#ifdef ALTERA_PLATFORM
-#include "io.h"
-#else
-#include "xil_io.h"
-#endif
 #include "util.h"
 #include "axi_adc_core.h"
 
@@ -110,11 +105,7 @@ int32_t axi_adc_read(struct axi_adc *adc,
 		     uint32_t reg_addr,
 		     uint32_t *reg_data)
 {
-#ifdef ALTERA_PLATFORM
-	*reg_data = IORD_32DIRECT(adc->base, reg_addr);
-#else
-	*reg_data = Xil_In32((adc->base + reg_addr));
-#endif
+	adc->axi_io_read(adc->base, reg_addr, reg_data);
 
 	return SUCCESS;
 }
@@ -126,11 +117,7 @@ int32_t axi_adc_write(struct axi_adc *adc,
 		      uint32_t reg_addr,
 		      uint32_t reg_data)
 {
-#ifdef ALTERA_PLATFORM
-	IOWR_32DIRECT(adc->base, reg_addr, reg_data);
-#else
-	Xil_Out32((adc->base + reg_addr), reg_data);
-#endif
+	adc->axi_io_write(adc->base, reg_addr, reg_data);
 
 	return SUCCESS;
 }
@@ -354,6 +341,8 @@ int32_t axi_adc_init(struct axi_adc **adc_core,
 	adc->name = init->name;
 	adc->base = init->base;
 	adc->num_channels = init->num_channels;
+	adc->axi_io_read = init->axi_io_read;
+	adc->axi_io_write = init->axi_io_write;
 
 	axi_adc_write(adc, AXI_ADC_REG_RSTN, 0);
 	axi_adc_write(adc, AXI_ADC_REG_RSTN,

--- a/projects/drivers/axi_adc_core/axi_adc_core.h
+++ b/projects/drivers/axi_adc_core/axi_adc_core.h
@@ -52,12 +52,16 @@ struct axi_adc {
 	uint32_t base;
 	uint8_t	num_channels;
 	uint64_t clock_hz;
+	int32_t (*axi_io_read)(uint32_t, uint32_t, uint32_t*);
+	int32_t (*axi_io_write)(uint32_t, uint32_t, uint32_t);
 };
 
 struct axi_adc_init {
 	const char *name;
 	uint32_t base;
 	uint8_t	num_channels;
+	int32_t (*axi_io_read)(uint32_t, uint32_t, uint32_t*);
+	int32_t (*axi_io_write)(uint32_t, uint32_t, uint32_t);
 };
 
 enum axi_adc_pn_sel {

--- a/projects/drivers/axi_dac_core/axi_dac_core.c
+++ b/projects/drivers/axi_dac_core/axi_dac_core.c
@@ -44,12 +44,6 @@
 #include <stdio.h>
 #include <inttypes.h>
 #include "platform_drivers.h"
-#ifdef ALTERA_PLATFORM
-#include "io.h"
-#else
-#include "xil_io.h"
-#include "xil_cache.h"
-#endif
 #include "util.h"
 #include "axi_dac_core.h"
 
@@ -345,11 +339,7 @@ int32_t axi_dac_read(struct axi_dac *dac,
 		     uint32_t reg_addr,
 		     uint32_t *reg_data)
 {
-#ifdef ALTERA_PLATFORM
-	*reg_data = IORD_32DIRECT(dac->base, reg_addr);
-#else
-	*reg_data = Xil_In32((dac->base + reg_addr));
-#endif
+	dac->axi_io_read(dac->base, reg_addr, reg_data);
 
 	return SUCCESS;
 }
@@ -361,11 +351,7 @@ int32_t axi_dac_write(struct axi_dac *dac,
 		      uint32_t reg_addr,
 		      uint32_t reg_data)
 {
-#ifdef ALTERA_PLATFORM
-	IOWR_32DIRECT(dac->base, reg_addr, reg_data);
-#else
-	Xil_Out32((dac->base + reg_addr), reg_data);
-#endif
+	dac->axi_io_write(dac->base, reg_addr, reg_data);
 
 	return SUCCESS;
 }
@@ -721,11 +707,8 @@ uint32_t axi_dac_set_sine_lut(struct axi_dac *dac,
 				index_q1 -= (tx_count * 2);
 			data_i1 = (sine_lut[index_i1 / 2] << 20);
 			data_q1 = (sine_lut[index_q1 / 2] << 4);
-#ifdef ALTERA_PLATFORM
-			IOWR_32DIRECT(address, index_mem * 4, data_i1 | data_q1);
-#else
-			Xil_Out32(address + index_mem * 4, data_i1 | data_q1);
-#endif
+
+			dac->axi_io_write(address, index_mem * 4, data_i1 | data_q1);
 
 			index_i2 = index_i1;
 			index_q2 = index_q1;
@@ -735,11 +718,9 @@ uint32_t axi_dac_set_sine_lut(struct axi_dac *dac,
 				index_q2 -= (tx_count * 2);
 			data_i2 = (sine_lut[index_i2 / 2] << 20);
 			data_q2 = (sine_lut[index_q2 / 2] << 4);
-#ifdef ALTERA_PLATFORM
-			IOWR_32DIRECT(address, (index_mem + 1) * 4, data_i2 | data_q2);
-#else
-			Xil_Out32(address + (index_mem + 1) * 4, data_i2 | data_q2);
-#endif
+
+			dac->axi_io_write(address, (index_mem + 1) * 4, data_i2 | data_q2);
+
 		}
 	} else {
 		for(index = 0; index < tx_count; index += 1) {
@@ -749,16 +730,11 @@ uint32_t axi_dac_set_sine_lut(struct axi_dac *dac,
 				index_q1 -= tx_count;
 			data_i1 = (sine_lut[index_i1] << 20);
 			data_q1 = (sine_lut[index_q1] << 4);
-#ifdef ALTERA_PLATFORM
-			IOWR_32DIRECT(address, index * 4, data_i1 | data_q1);
-#else
-			Xil_Out32(address + index * 4, data_i1 | data_q1);
-#endif
+
+			dac->axi_io_write(address, index * 4, data_i1 | data_q1);
 		}
 	}
-#ifndef ALTERA_PLATFORM
-	Xil_DCacheFlush();
-#endif
+
 	length = tx_count * dac->num_channels * 2;
 	return length;
 }
@@ -796,16 +772,9 @@ int32_t axi_dac_set_buff(struct axi_dac *dac,
 	for(index = 0; index < buff_size; index += 2) {
 		data_i = (buff[index]);
 		data_q = (buff[index + 1] << 16);
-#ifdef ALTERA_PLATFORM
-		IOWR_32DIRECT(address, index * 2, data_i | data_q);
-#else
-		Xil_Out32(address + index * 2, data_i | data_q);
-#endif
-	}
 
-#ifndef ALTERA_PLATFORM
-	Xil_DCacheFlush();
-#endif
+		dac->axi_io_write(address, index * 2, data_i | data_q);
+	}
 
 	return SUCCESS;
 }
@@ -825,19 +794,13 @@ int32_t axi_dac_load_custom_data(struct axi_dac *dac,
 	for(index = 0; index < custom_tx_count; index++) {
 		/* Send the same data on all the channels */
 		for (chan = 0; chan < num_tx_channels; chan++) {
-#ifdef ALTERA_PLATFORM
-			IOWR_32DIRECT(address, index_mem * sizeof(uint32_t),
+
+			dac->axi_io_write(address, index_mem * sizeof(uint32_t),
 				      custom_data_iq[index]);
-#else
-			Xil_Out32(address + index_mem * sizeof(uint32_t),
-				  custom_data_iq[index]);
-#endif
+
 			index_mem++;
 		}
 	}
-#ifndef ALTERA_PLATFORM
-	Xil_DCacheFlush();
-#endif
 
 	for (chan = 0; chan < dac->num_channels; chan++) {
 		axi_dac_write(dac, AXI_DAC_REG_DATA_SELECT((chan*2)+0), 0x2);
@@ -868,6 +831,8 @@ int32_t axi_dac_init(struct axi_dac **dac_core,
 	dac->name = init->name;
 	dac->base = init->base;
 	dac->num_channels = init->num_channels;
+	dac->axi_io_read = init->axi_io_read;
+	dac->axi_io_write = init->axi_io_write;
 
 	axi_dac_write(dac, AXI_DAC_REG_RSTN, 0);
 	axi_dac_write(dac, AXI_DAC_REG_RSTN,

--- a/projects/drivers/axi_dac_core/axi_dac_core.h
+++ b/projects/drivers/axi_dac_core/axi_dac_core.h
@@ -52,12 +52,16 @@ struct axi_dac {
 	uint32_t base;
 	uint8_t	num_channels;
 	uint64_t clock_hz;
+	int32_t (*axi_io_read)(uint32_t, uint32_t, uint32_t*);
+	int32_t (*axi_io_write)(uint32_t, uint32_t, uint32_t);
 };
 
 struct axi_dac_init {
 	const char *name;
 	uint32_t base;
 	uint8_t	num_channels;
+	int32_t (*axi_io_read)(uint32_t, uint32_t, uint32_t*);
+	int32_t (*axi_io_write)(uint32_t, uint32_t, uint32_t);
 };
 
 enum axi_dac_data_sel {

--- a/projects/drivers/axi_dmac/axi_dmac.c
+++ b/projects/drivers/axi_dmac/axi_dmac.c
@@ -43,11 +43,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "platform_drivers.h"
-#ifdef ALTERA_PLATFORM
-#include "io.h"
-#else
-#include "xil_io.h"
-#endif
 #include "util.h"
 #include "axi_dmac.h"
 
@@ -81,11 +76,7 @@ int32_t axi_dmac_read(struct axi_dmac *dmac,
 		      uint32_t reg_addr,
 		      uint32_t *reg_data)
 {
-#ifdef ALTERA_PLATFORM
-	*reg_data = IORD_32DIRECT(dmac->base, reg_addr);
-#else
-	*reg_data = Xil_In32((dmac->base + reg_addr));
-#endif
+	dmac->axi_io_read(dmac->base, reg_addr, reg_data);
 
 	return SUCCESS;
 }
@@ -97,11 +88,7 @@ int32_t axi_dmac_write(struct axi_dmac *dmac,
 		       uint32_t reg_addr,
 		       uint32_t reg_data)
 {
-#ifdef ALTERA_PLATFORM
-	IOWR_32DIRECT(dmac->base, reg_addr, reg_data);
-#else
-	Xil_Out32((dmac->base + reg_addr), reg_data);
-#endif
+	dmac->axi_io_write(dmac->base, reg_addr, reg_data);
 
 	return SUCCESS;
 }
@@ -181,6 +168,8 @@ int32_t axi_dmac_init(struct axi_dmac **dmac_core,
 	dmac->base = init->base;
 	dmac->direction = init->direction;
 	dmac->flags = init->flags;
+	dmac->axi_io_read = init->axi_io_read;
+	dmac->axi_io_write = init->axi_io_write;
 
 	*dmac_core = dmac;
 

--- a/projects/drivers/axi_dmac/axi_dmac.h
+++ b/projects/drivers/axi_dmac/axi_dmac.h
@@ -62,6 +62,8 @@ struct axi_dmac {
 	uint32_t base;
 	enum dma_direction direction;
 	enum dma_flags flags;
+	int32_t (*axi_io_read)(uint32_t, uint32_t, uint32_t*);
+	int32_t (*axi_io_write)(uint32_t, uint32_t, uint32_t);
 };
 
 struct axi_dmac_init {
@@ -69,6 +71,8 @@ struct axi_dmac_init {
 	uint32_t base;
 	enum dma_direction direction;
 	enum dma_flags flags;
+	int32_t (*axi_io_read)(uint32_t, uint32_t, uint32_t*);
+	int32_t (*axi_io_write)(uint32_t, uint32_t, uint32_t);
 };
 
 /******************************************************************************/

--- a/projects/drivers/jesd204/axi_jesd204_rx.c
+++ b/projects/drivers/jesd204/axi_jesd204_rx.c
@@ -44,11 +44,6 @@
 #include <stdio.h>
 #include <inttypes.h>
 #include "platform_drivers.h"
-#ifdef ALTERA_PLATFORM
-#include "io.h"
-#else
-#include "xil_io.h"
-#endif
 #include "util.h"
 #include "axi_jesd204_rx.h"
 
@@ -116,11 +111,7 @@ const char *axi_jesd204_rx_lane_status_label[] = {
 int32_t axi_jesd204_rx_write(struct axi_jesd204_rx *jesd,
 			     uint32_t reg_addr, uint32_t reg_val)
 {
-#ifdef ALTERA_PLATFORM
-	IOWR_32DIRECT(jesd->base, reg_addr, reg_val);
-#else
-	Xil_Out32((jesd->base + reg_addr), reg_val);
-#endif
+	jesd->axi_io_write(jesd->base, reg_addr, reg_val);
 
 	return SUCCESS;
 }
@@ -131,11 +122,7 @@ int32_t axi_jesd204_rx_write(struct axi_jesd204_rx *jesd,
 int32_t axi_jesd204_rx_read(struct axi_jesd204_rx *jesd,
 			    uint32_t reg_addr, uint32_t *reg_val)
 {
-#ifdef ALTERA_PLATFORM
-	*reg_val = IORD_32DIRECT(jesd->base, reg_addr);
-#else
-	*reg_val = Xil_In32(jesd->base + reg_addr);
-#endif
+	jesd->axi_io_read(jesd->base, reg_addr, reg_val);
 
 	return SUCCESS;
 }
@@ -423,6 +410,8 @@ int32_t axi_jesd204_rx_init(struct axi_jesd204_rx **jesd204,
 	jesd->base = init->base;
 	jesd->device_clk_khz = init->device_clk_khz;
 	jesd->lane_clk_khz = init->lane_clk_khz;
+	jesd->axi_io_read = init->axi_io_read;
+	jesd->axi_io_write = init->axi_io_write;
 
 	axi_jesd204_rx_read(jesd, JESD204_RX_REG_MAGIC, &magic);
 	if (magic != JESD204_RX_MAGIC) {

--- a/projects/drivers/jesd204/axi_jesd204_rx.h
+++ b/projects/drivers/jesd204/axi_jesd204_rx.h
@@ -63,6 +63,8 @@ struct axi_jesd204_rx {
 	struct jesd204_rx_config config;
 	uint32_t device_clk_khz;
 	uint32_t lane_clk_khz;
+	int32_t (*axi_io_read)(uint32_t, uint32_t, uint32_t*);
+	int32_t (*axi_io_write)(uint32_t, uint32_t, uint32_t);
 };
 
 struct jesd204_rx_init {
@@ -73,6 +75,8 @@ struct jesd204_rx_init {
 	uint8_t subclass;
 	uint32_t device_clk_khz;
 	uint32_t lane_clk_khz;
+	int32_t (*axi_io_read)(uint32_t, uint32_t, uint32_t*);
+	int32_t(*axi_io_write)(uint32_t, uint32_t, uint32_t);
 };
 
 /******************************************************************************/

--- a/projects/drivers/jesd204/axi_jesd204_tx.c
+++ b/projects/drivers/jesd204/axi_jesd204_tx.c
@@ -44,11 +44,6 @@
 #include <stdio.h>
 #include <inttypes.h>
 #include "platform_drivers.h"
-#ifdef ALTERA_PLATFORM
-#include "io.h"
-#else
-#include "xil_io.h"
-#endif
 #include "util.h"
 #include "axi_jesd204_tx.h"
 
@@ -101,11 +96,7 @@ const char *axi_jesd204_tx_link_status_label[] = {
 int32_t axi_jesd204_tx_write(struct axi_jesd204_tx *jesd,
 			     uint32_t reg_addr, uint32_t reg_val)
 {
-#ifdef ALTERA_PLATFORM
-	IOWR_32DIRECT(jesd->base, reg_addr, reg_val);
-#else
-	Xil_Out32((jesd->base + reg_addr), reg_val);
-#endif
+	jesd->axi_io_write(jesd->base, reg_addr, reg_val);
 
 	return SUCCESS;
 }
@@ -116,11 +107,7 @@ int32_t axi_jesd204_tx_write(struct axi_jesd204_tx *jesd,
 int32_t axi_jesd204_tx_read(struct axi_jesd204_tx *jesd,
 			    uint32_t reg_addr, uint32_t *reg_val)
 {
-#ifdef ALTERA_PLATFORM
-	*reg_val = IORD_32DIRECT(jesd->base, reg_addr);
-#else
-	*reg_val = Xil_In32(jesd->base + reg_addr);
-#endif
+	jesd->axi_io_read(jesd->base, reg_addr, reg_val);
 
 	return SUCCESS;
 }
@@ -331,6 +318,8 @@ int32_t axi_jesd204_tx_init(struct axi_jesd204_tx **jesd204,
 	jesd->name = init->name;
 	jesd->device_clk_khz = init->device_clk_khz;
 	jesd->lane_clk_khz = init->lane_clk_khz;
+	jesd->axi_io_read = init->axi_io_read;
+	jesd->axi_io_write = init->axi_io_write;
 
 	axi_jesd204_tx_read(jesd, JESD204_TX_REG_MAGIC, &magic);
 	if (magic != JESD204_TX_MAGIC) {

--- a/projects/drivers/jesd204/axi_jesd204_tx.h
+++ b/projects/drivers/jesd204/axi_jesd204_tx.h
@@ -74,6 +74,8 @@ struct axi_jesd204_tx {
 	struct jesd204_tx_config config;
 	uint32_t device_clk_khz;
 	uint32_t lane_clk_khz;
+	int32_t (*axi_io_read)(uint32_t, uint32_t, uint32_t*);
+	int32_t (*axi_io_write)(uint32_t, uint32_t, uint32_t);
 };
 
 struct jesd204_tx_init {
@@ -89,6 +91,8 @@ struct jesd204_tx_init {
 	uint8_t subclass;
 	uint32_t device_clk_khz;
 	uint32_t lane_clk_khz;
+	int32_t (*axi_io_read)(uint32_t, uint32_t, uint32_t*);
+	int32_t (*axi_io_write)(uint32_t, uint32_t, uint32_t);
 };
 
 /******************************************************************************/


### PR DESCRIPTION
Update the following drivers using `axi_io` wrapper functions:
- AD9528
- ADI_HAL
- ADC_CORE
- DAC_CORE
- DMAC
- JESD204

**NOTE**: This pull request depends on #253 

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>