### PR TITLE
ad9361: fix fmcomms5 implemetation

### DIFF
--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -503,6 +503,9 @@ int main(void)
 	}
 	gpio_direction_output(default_init_param.gpio_desc_resetb, 1);
 
+	rx_adc_init.base = AD9361_RX_1_BASEADDR;
+	tx_dac_init.base = AD9361_TX_1_BASEADDR;
+
 	spi_param.chip_select = default_init_param.id_no;
 
 	status = spi_init(&default_init_param.spi, &spi_param);


### PR DESCRIPTION
In the latest version of AD9361 project found in the root of the no-OS
repository, the axi read/write function contained a switch which used
either RX0TX0/RX1TX1 base addresses by checking the`id_no`parameter. Since the current
implementation of ADC/DAC core is platform agnostic, the base addresses
for RX1/TX1 are now initialized in the FMCOMMS5 configuration of AD9361 project main function.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>