### PR TITLE
drivers: ad9208: fixes

### DIFF
--- a/drivers/adc/ad9208/ad9208.h
+++ b/drivers/adc/ad9208/ad9208.h
@@ -78,10 +78,10 @@
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 struct ad9208_ddc {
-	u32 decimation;
-	u32 nco_mode;
-	u64 carrier_freq_hz;
-	u64 po;
+	uint32_t decimation;
+	uint32_t nco_mode;
+	uint64_t carrier_freq_hz;
+	uint64_t po;
 	bool gain_db;
 };
 

--- a/drivers/adc/ad9208/ad9208_api/ad9208_adc_api.c
+++ b/drivers/adc/ad9208/ad9208_api/ad9208_adc_api.c
@@ -297,7 +297,7 @@ int ad9208_adc_set_input_cfg(ad9208_handle_t *h,
 	}
 	/*Set Analog Input Mode Optimization */
 	tmp_reg = analog_input_mode ? AD9208_DC_COUPLE_EN(1) :
-		AD9208_DC_COUPLE_EN(0);
+		  AD9208_DC_COUPLE_EN(0);
 	err = ad9208_register_write(h, AD9208_ANALOG_CFG_REG, tmp_reg);
 	if (err != API_ERROR_OK)
 		return err;
@@ -468,7 +468,7 @@ int ad9208_adc_set_data_format(ad9208_handle_t *h,
 		return err;
 	tmp_reg &= ~AD9208_ADC_Q_IGNORE;
 	tmp_reg |= (op_data_frmt == AD9208_DATA_FRMT_COMPLEX) ? 0 :
-		AD9208_ADC_Q_IGNORE;
+		   AD9208_ADC_Q_IGNORE;
 	err = ad9208_register_write(h, AD9208_ADC_MODE_REG, tmp_reg);
 	if (err != API_ERROR_OK)
 		return err;
@@ -483,9 +483,9 @@ int ad9208_adc_set_data_format(ad9208_handle_t *h,
 		tmp_reg &= ~(AD9208_DDCX_MIXER_SEL |
 			     AD9208_DDCX_COMPLEX_TO_REAL);
 		tmp_reg |= (ip_data_frmt == AD9208_DATA_FRMT_COMPLEX) ?
-			    AD9208_DDCX_MIXER_SEL : 0;
+			   AD9208_DDCX_MIXER_SEL : 0;
 		tmp_reg |= (op_data_frmt == AD9208_DATA_FRMT_COMPLEX) ?
-			    0 : AD9208_DDCX_COMPLEX_TO_REAL;
+			   0 : AD9208_DDCX_COMPLEX_TO_REAL;
 		err = ad9208_register_write(h, AD9208_DDCX_CTRL0_REG + offset,
 					    tmp_reg);
 		if (err != API_ERROR_OK)

--- a/drivers/adc/ad9208/ad9208_api/ad9208_adc_api.c
+++ b/drivers/adc/ad9208/ad9208_api/ad9208_adc_api.c
@@ -12,7 +12,7 @@
  * Analog Devices Software License Agreement.
  */
 
-#include <ad9208_api.h>
+#include "ad9208_api.h"
 #include "ad9208_reg.h"
 #include "api_errors.h"
 #include <stddef.h>

--- a/drivers/adc/ad9208/ad9208_api/ad9208_api.c
+++ b/drivers/adc/ad9208/ad9208_api/ad9208_api.c
@@ -12,7 +12,7 @@
  * Analog Devices Software License Agreement.
  */
 
-#include <ad9208_api.h>
+#include "ad9208_api.h"
 #include "ad9208_reg.h"
 #include "api_errors.h"
 

--- a/drivers/adc/ad9208/ad9208_api/ad9208_jesd_api.c
+++ b/drivers/adc/ad9208/ad9208_api/ad9208_jesd_api.c
@@ -12,7 +12,7 @@
  * Analog Devices Software License Agreement.
  */
 
-#include <ad9208_api.h>
+#include "ad9208_api.h"
 #include "ad9208_reg.h"
 #include "api_errors.h"
 

--- a/drivers/adc/ad9208/ad9208_api/ad9208_reg.c
+++ b/drivers/adc/ad9208/ad9208_api/ad9208_reg.c
@@ -12,7 +12,7 @@
  * Analog Devices Software License Agreement.
  */
 
-#include <ad9208_api.h>
+#include "ad9208_api.h"
 #include "ad9208_reg.h"
 #include "api_errors.h"
 

--- a/drivers/adc/ad9208/ad9208_api/ad9208_signal_monitor_api.c
+++ b/drivers/adc/ad9208/ad9208_api/ad9208_signal_monitor_api.c
@@ -12,7 +12,7 @@
  * Analog Devices Software License Agreement.
  */
 
-#include <ad9208_api.h>
+#include "ad9208_api.h"
 #include "ad9208_reg.h"
 #include "api_errors.h"
 


### PR DESCRIPTION
Replace <> with "" for local header files to avoid build errors.

Use integer types provided by <stdint.h> lib.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>