### PR TITLE
drivers: xilinx_platform: use xilinx descriptor

### DIFF
--- a/projects/drivers/xilinx_platform/spi.c
+++ b/projects/drivers/xilinx_platform/spi.c
@@ -187,7 +187,7 @@ int32_t spi_write_and_read(struct spi_desc *desc,
 	XSpi_SetSlaveSelect(&xil_desc->instance,
 			    0x01 << desc->chip_select);
 
-	XSpi_Transfer(&desc->instance,
+	XSpi_Transfer(&xil_desc->instance,
 		      data, data, bytes_number);
 #endif
 	return SUCCESS;


### PR DESCRIPTION
Use xilinx descriptor when passing the `instance` attribute.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>