### PR TITLE
Ad9172 update

### DIFF
--- a/drivers/dac/ad917x/ad9172.c
+++ b/drivers/dac/ad917x/ad9172.c
@@ -106,7 +106,7 @@ static int32_t ad9172_setup(struct ad9172_state *st)
 
 	pll_mult = DIV_ROUND_CLOSEST(st->dac_rate_khz, dac_clkin_Hz / 1000);
 
-	ret = ad917x_set_dac_clk(ad917x_h, (u64)dac_clkin_Hz * pll_mult,
+	ret = ad917x_set_dac_clk(ad917x_h, (uint64_t)dac_clkin_Hz * pll_mult,
 				 1, dac_clkin_Hz);
 	if (ret != 0) {
 		printf("ad917x_set_dac_clk failed (%"PRIi32")\n", ret);


### PR DESCRIPTION
Use Xilinx platform specific spi parameters.
Add `axi_io` support for read/write function wrappers.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>