### PR TITLE
Ad9371 update project

### DIFF
--- a/projects/ad9371/src/README
+++ b/projects/ad9371/src/README
@@ -2,8 +2,19 @@
 # Additional required source files:
 
 #ifdef ALTERA_PLATFORM
-	cp ../../drivers/altera_platform/platform_drivers.c devices/adi_hal/
 	cp ../../drivers/altera_platform/platform_drivers.h devices/adi_hal/
+	cp ../../drivers/altera_platform/altera_platform_drivers.h devices/adi_hal/
+	cp ../../../include/axi_io.h devices/adi_hal/
+	cp ../../../include/error.h devices/adi_hal/
+	cp ../../../include/spi.h devices/adi_hal/
+	cp ../../../include/i2c.h devices/adi_hal/
+	cp ../../../include/gpio.h devices/adi_hal/
+	cp ../../../include/delay.h devices/adi_hal/
+	cp ../../../drivers/platform/altera/axi_io.c devices/adi_hal/
+	cp ../../drivers/altera_platform/spi.c devices/adi_hal/
+	cp ../../drivers/altera_platform/i2c.c devices/adi_hal/
+	cp ../../drivers/altera_platform/gpio.c devices/adi_hal/
+	cp ../../drivers/altera_platform/delay.c devices/adi_hal/
 	cp ../../drivers/axi_adc_core/axi_adc_core.c devices/adi_hal/
 	cp ../../drivers/axi_adc_core/axi_adc_core.h devices/adi_hal/
 	cp ../../drivers/axi_dac_core/axi_dac_core.c devices/adi_hal/
@@ -25,6 +36,19 @@
 	cp ../../drivers/util/util.c devices/adi_hal/
 	cp ../../drivers/util/util.h devices/adi_hal/
 #else
+	cp ../../drivers/xilinx_platform/platform_drivers.h devices/adi_hal/
+	cp ../../drivers/xilinx_platform/xilinx_platform_drivers.h devices/adi_hal/
+	cp ../../../include/axi_io.h devices/adi_hal/
+	cp ../../../include/error.h devices/adi_hal/
+	cp ../../../include/spi.h devices/adi_hal/
+	cp ../../../include/i2c.h devices/adi_hal/
+	cp ../../../include/gpio.h devices/adi_hal/
+	cp ../../../include/delay.h devices/adi_hal/
+	cp ../../../drivers/platform/xilinx/axi_io.c devices/adi_hal/
+	cp ../../drivers/xilinx_platform/spi.c devices/adi_hal/
+	cp ../../drivers/xilinx_platform/i2c.c devices/adi_hal/
+	cp ../../drivers/xilinx_platform/gpio.c devices/adi_hal/
+	cp ../../drivers/xilinx_platform/delay.c devices/adi_hal/
 	cp ../../drivers/axi_adc_core/axi_adc_core.c devices/adi_hal/
 	cp ../../drivers/axi_adc_core/axi_adc_core.h devices/adi_hal/
 	cp ../../drivers/axi_dac_core/axi_dac_core.c devices/adi_hal/
@@ -43,6 +67,4 @@
 	cp ../../drivers/jesd204/xilinx_transceiver.h devices/adi_hal/
 	cp ../../drivers/util/util.c devices/adi_hal/
 	cp ../../drivers/util/util.h devices/adi_hal/
-	cp ../../drivers/xilinx_platform/platform_drivers.c devices/adi_hal/
-	cp ../../drivers/xilinx_platform/platform_drivers.h devices/adi_hal/
 #endif

--- a/projects/ad9371/src/app/headless.c
+++ b/projects/ad9371/src/app/headless.c
@@ -62,6 +62,7 @@
 #include "axi_dac_core.h"
 #include "axi_adc_core.h"
 #include "axi_dmac.h"
+#include "axi_io.h"
 
 /******************************************************************************/
 /************************ Variables Definitions *******************************/
@@ -158,6 +159,8 @@ int main(void)
 		1,
 		rx_div40_rate_hz / 1000,
 		rx_lane_rate_khz,
+		axi_io_read,
+		axi_io_write
 	};
 	struct jesd204_tx_init tx_jesd_init = {
 		"tx_jesd",
@@ -172,6 +175,8 @@ int main(void)
 		1,
 		tx_div40_rate_hz / 1000,
 		tx_lane_rate_khz,
+		axi_io_read,
+		axi_io_write
 	};
 
 	struct jesd204_rx_init rx_os_jesd_init = {
@@ -182,6 +187,8 @@ int main(void)
 		1,
 		rx_os_div40_rate_hz / 1000,
 		rx_os_lane_rate_khz,
+		axi_io_read,
+		axi_io_write
 	};
 	struct axi_jesd204_rx *rx_jesd;
 	struct axi_jesd204_tx *tx_jesd;
@@ -250,12 +257,16 @@ int main(void)
 		"tx_dac",
 		TX_CORE_BASEADDR,
 		4,
+		axi_io_read,
+		axi_io_write
 	};
 	struct axi_dac *tx_dac;
 	struct axi_adc_init rx_adc_init = {
 		"rx_adc",
 		RX_CORE_BASEADDR,
 		4,
+		axi_io_read,
+		axi_io_write
 	};
 	struct axi_adc *rx_adc;
 	struct axi_dmac_init rx_dmac_init = {
@@ -263,6 +274,8 @@ int main(void)
 		RX_DMA_BASEADDR,
 		DMA_DEV_TO_MEM,
 		0,
+		axi_io_read,
+		axi_io_write
 	};
 	struct axi_dmac *rx_dmac;
 #ifdef DAC_DMA_EXAMPLE
@@ -271,6 +284,8 @@ int main(void)
 		TX_DMA_BASEADDR,
 		DMA_MEM_TO_DEV,
 		DMA_LAST,
+		axi_io_read,
+		axi_io_write
 	};
 	struct axi_dmac *tx_dmac;
 	extern const uint32_t sine_lut_iq[1024];

--- a/projects/ad9371/src/devices/adi_hal/common.c
+++ b/projects/ad9371/src/devices/adi_hal/common.c
@@ -20,6 +20,12 @@
 #include "platform_drivers.h"
 #include "parameters.h"
 
+#ifndef ALTERA_PLATFORM
+#include "xilinx_platform_drivers.h"
+#else
+#include "altera_platform_drivers.h"
+#endif
+
 ADI_LOGLEVEL CMB_LOGLEVEL = ADIHAL_LOG_NONE;
 
 static uint32_t _desired_time_to_elapse_us = 0;
@@ -37,11 +43,14 @@ int32_t platform_init(void)
 	status = gpio_get(&gpio_ad9528_resetb, AD9528_RESET_B);
 	status = gpio_get(&gpio_ad9528_sysref_req, AD9528_SYSREF_REQ);
 
-	spi_param.id = SPI_DEVICE_ID;
 	spi_param.mode = SPI_MODE_0;
 	spi_param.chip_select = AD9371_CS;
 #ifndef ALTERA_PLATFORM
-	spi_param.flags = SPI_CS_DECODE;
+	struct xil_spi_init_param xil_param = {.id = SPI_DEVICE_ID, .flags = SPI_CS_DECODE};
+	spi_param.extra = &xil_param;
+#else
+	struct altera_spi_init_param altera_param = {.id = SPI_DEVICE_ID};
+	spi_param.extra = &altera_param;
 #endif
 	status |= spi_init(&spi_ad_desc, &spi_param);
 

--- a/projects/drivers/clk_axi_clkgen/clk_axi_clkgen.c
+++ b/projects/drivers/clk_axi_clkgen/clk_axi_clkgen.c
@@ -47,6 +47,7 @@
 #include "util.h"
 #include "platform_drivers.h"
 #include "clk_axi_clkgen.h"
+#include "xil_io.h"
 
 /******************************************************************************/
 /********************** Macros and Constants Definitions **********************/


### PR DESCRIPTION
Add initialization for device structures using `axi_io` wrappers.
Initialize devices with Xilinx platform specific parameters.
Update README.
Include required Xilinx header file.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>