### PR TITLE
projects:  update README

### DIFF
--- a/projects/ad9172/src/README
+++ b/projects/ad9172/src/README
@@ -1,8 +1,19 @@
 
 # Additional required source files:
 
-	cp ../../drivers/xilinx_platform/platform_drivers.h	./
-	cp ../../drivers/xilinx_platform/platform_drivers.c	./
+	cp ../../drivers/xilinx_platform/platform_drivers.h ./
+	cp ../../drivers/xilinx_platform/xilinx_platform_drivers.h ./
+	cp ../../../include/axi_io.h ./
+	cp ../../../include/error.h ./
+	cp ../../../include/spi.h ./
+	cp ../../../include/i2c.h ./
+	cp ../../../include/gpio.h ./
+	cp ../../../include/delay.h ./
+	cp ../../../drivers/platform/xilinx/axi_io.c ./
+	cp ../../drivers/xilinx_platform/spi.c ./
+	cp ../../drivers/xilinx_platform/i2c.c ./
+	cp ../../drivers/xilinx_platform/gpio.c ./
+	cp ../../drivers/xilinx_platform/delay.c ./
 	cp ../../drivers/util/util.c ./
 	cp ../../drivers/util/util.h ./						
 	cp ../../drivers/jesd204/xilinx_transceiver.h ./

--- a/projects/ad9208/README
+++ b/projects/ad9208/README
@@ -1,7 +1,18 @@
 # Additional required source files:
 
-	cp ../../drivers/xilinx_platform/platform_drivers.h	./
-	cp ../../drivers/xilinx_platform/platform_drivers.c	./
+	cp ../../drivers/xilinx_platform/platform_drivers.h ./
+	cp ../../drivers/xilinx_platform/xilinx_platform_drivers.h ./
+	cp ../../../include/axi_io.h ./
+	cp ../../../include/error.h ./
+	cp ../../../include/spi.h ./
+	cp ../../../include/i2c.h ./
+	cp ../../../include/gpio.h ./
+	cp ../../../include/delay.h ./
+	cp ../../../drivers/platform/xilinx/axi_io.c ./
+	cp ../../drivers/xilinx_platform/spi.c ./
+	cp ../../drivers/xilinx_platform/i2c.c ./
+	cp ../../drivers/xilinx_platform/gpio.c ./
+	cp ../../drivers/xilinx_platform/delay.c ./
 	cp ../../drivers/util/util.c ./
 	cp ../../drivers/util/util.h ./
 	cp ../../drivers/jesd204/xilinx_transceiver.h ./

--- a/projects/adrv9009/src/README
+++ b/projects/adrv9009/src/README
@@ -2,8 +2,19 @@
 Additional required source files:
 
 #ifdef ALTERA_PLATFORM
-	cp ../../drivers/altera_platform/platform_drivers.c devices/adi_hal/
 	cp ../../drivers/altera_platform/platform_drivers.h devices/adi_hal/
+	cp ../../drivers/altera_platform/altera_platform_drivers.h devices/adi_hal/
+	cp ../../../include/axi_io.h devices/adi_hal/
+	cp ../../../include/error.h devices/adi_hal/
+	cp ../../../include/spi.h devices/adi_hal/
+	cp ../../../include/i2c.h devices/adi_hal/
+	cp ../../../include/gpio.h devices/adi_hal/
+	cp ../../../include/delay.h devices/adi_hal/
+	cp ../../../drivers/platform/altera/axi_io.c devices/adi_hal/
+	cp ../../drivers/altera_platform/spi.c devices/adi_hal/
+	cp ../../drivers/altera_platform/i2c.c devices/adi_hal/
+	cp ../../drivers/altera_platform/gpio.c devices/adi_hal/
+	cp ../../drivers/altera_platform/delay.c devices/adi_hal/
 	cp ../../drivers/axi_adc_core/axi_adc_core.c devices/adi_hal/
 	cp ../../drivers/axi_adc_core/axi_adc_core.h devices/adi_hal/
 	cp ../../drivers/axi_dac_core/axi_dac_core.c devices/adi_hal/
@@ -25,6 +36,19 @@ Additional required source files:
 	cp ../../drivers/util/util.c devices/adi_hal/
 	cp ../../drivers/util/util.h devices/adi_hal/
 #else
+	cp ../../drivers/xilinx_platform/platform_drivers.h devices/adi_hal/
+	cp ../../drivers/xilinx_platform/xilinx_platform_drivers.h devices/adi_hal/
+	cp ../../../include/axi_io.h devices/adi_hal/
+	cp ../../../include/error.h devices/adi_hal/
+	cp ../../../include/spi.h devices/adi_hal/
+	cp ../../../include/i2c.h devices/adi_hal/
+	cp ../../../include/gpio.h devices/adi_hal/
+	cp ../../../include/delay.h devices/adi_hal/
+	cp ../../../drivers/platform/xilinx/axi_io.c devices/adi_hal/
+	cp ../../drivers/xilinx_platform/spi.c devices/adi_hal/
+	cp ../../drivers/xilinx_platform/i2c.c devices/adi_hal/
+	cp ../../drivers/xilinx_platform/gpio.c devices/adi_hal/
+	cp ../../drivers/xilinx_platform/delay.c devices/adi_hal/
 	cp ../../drivers/axi_adc_core/axi_adc_core.c devices/adi_hal/
 	cp ../../drivers/axi_adc_core/axi_adc_core.h devices/adi_hal/
 	cp ../../drivers/axi_dac_core/axi_dac_core.c devices/adi_hal/
@@ -43,7 +67,5 @@ Additional required source files:
 	cp ../../drivers/jesd204/xilinx_transceiver.h devices/adi_hal/
 	cp ../../drivers/util/util.c devices/adi_hal/
 	cp ../../drivers/util/util.h devices/adi_hal/
-	cp ../../drivers/xilinx_platform/platform_drivers.c devices/adi_hal/
-	cp ../../drivers/xilinx_platform/platform_drivers.h devices/adi_hal/
 #endif
 


### PR DESCRIPTION
This patch adds the new source file paths required by some no-OS projects
after spliting platform drivers into separate modules and making drivers
platform agnostic.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>