### PR TITLE
projects:altera: fix chip select value in function

### DIFF
--- a/projects/adrv9009/src/devices/adi_hal/parameters.h
+++ b/projects/adrv9009/src/devices/adi_hal/parameters.h
@@ -54,8 +54,6 @@
 /******************************************************************************/
 #ifdef ALTERA_PLATFORM
 #define GPIO_OFFSET		0
-#define CLK_CS			1
-#define ADRV_CS			2
 
 #define ADRV_RESETB		GPIO_OFFSET + 52
 #define ADRV_SYSREF_REQ	GPIO_OFFSET + 58
@@ -103,9 +101,6 @@
 #define GPIO_OFFSET		54
 #endif
 
-#define CLK_CS			0
-#define ADRV_CS			1
-
 #define ADRV_RESETB		GPIO_OFFSET + 52
 #define ADRV_SYSREF_REQ	GPIO_OFFSET + 58
 #define CLK_RESETB		GPIO_OFFSET + 59
@@ -138,4 +133,8 @@
 
 #define DDR_MEM_BASEADDR		XPAR_DDR_MEM_BASEADDR
 #endif
+
+#define CLK_CS			0
+#define ADRV_CS			1
+
 #endif

--- a/projects/drivers/altera_platform/spi.c
+++ b/projects/drivers/altera_platform/spi.c
@@ -108,7 +108,7 @@ int32_t spi_write_and_read(struct spi_desc *desc,
 		      ALTERA_AVALON_SPI_CONTROL_SSO_MSK);
 	IOWR_32DIRECT(SPI_BASEADDR,
 		      (ALTERA_AVALON_SPI_SLAVE_SEL_REG * 4),
-		      desc->chip_select);
+		      (0x1 << (desc->chip_select)));
 	for (i = 0; i < bytes_number; i++) {
 		while ((IORD_32DIRECT(SPI_BASEADDR,
 				      (ALTERA_AVALON_SPI_STATUS_REG * 4)) &


### PR DESCRIPTION
Fixes: 0d2fe781d389cae5d160c38db796f98eb9885cf1

The updates for chip select values supported by Microblaze/ARM
plafrorms affect the behavior of Altera platform based projects.

The spi impementation for altera platforms is updated to handle the
correct chip select values.

This patch fixes the AD9371 project for altera platform.

CS values for ADRV9009 are updated to match the current altera spi
implementation.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>