### PR TITLE
ad9361: Fix missing breaks in switch statements

### DIFF
--- a/ad9361/sw/ad9361.c
+++ b/ad9361/sw/ad9361.c
@@ -6972,6 +6972,7 @@ int32_t ad9361_rfpll_round_rate(struct refclk_scale *clk_priv, uint32_t rate)
 			round_rate = ad9361_rfpll_int_round_rate(phy->ref_clk_scale[RX_RFPLL_INT], rate,
 					&phy->clks[phy->ref_clk_scale[RX_RFPLL_INT]->parent_source]->rate);
 		}
+		break;
 	case TX_RFPLL:
 		if (phy->pdata->use_ext_tx_lo) {
 			if (phy->ad9361_rfpll_ext_round_rate)

--- a/ad9361/sw/util.c
+++ b/ad9361/sw/util.c
@@ -83,6 +83,7 @@ uint32_t clk_get_rate(struct ad9361_rf_phy *phy,
 		case RX_RFPLL_INT:
 			rate = ad9361_rfpll_int_recalc_rate(clk_priv,
 						phy->clks[clk_priv->parent_source]->rate);
+			break;
 		case RX_RFPLL_DUMMY:
 		case TX_RFPLL_DUMMY:
 			rate = ad9361_rfpll_dummy_recalc_rate(clk_priv);
@@ -152,6 +153,7 @@ int32_t clk_set_rate(struct ad9361_rf_phy *phy,
 			case RX_RFPLL_DUMMY:
 			case TX_RFPLL_DUMMY:
 				ad9361_rfpll_dummy_set_rate(clk_priv, rate);
+				break;
 			case TX_RFPLL:
 			case RX_RFPLL:
 				round_rate = ad9361_rfpll_round_rate(clk_priv, rate);

--- a/projects/ad9361/src/ad9361.c
+++ b/projects/ad9361/src/ad9361.c
@@ -6836,6 +6836,7 @@ int32_t ad9361_rfpll_round_rate(struct refclk_scale *clk_priv, uint32_t rate)
 			round_rate = ad9361_rfpll_int_round_rate(phy->ref_clk_scale[RX_RFPLL_INT], rate,
 					&phy->clks[phy->ref_clk_scale[RX_RFPLL_INT]->parent_source]->rate);
 		}
+		break;
 	case TX_RFPLL:
 		if (phy->pdata->use_ext_tx_lo) {
 			if (phy->ad9361_rfpll_ext_round_rate)

--- a/projects/ad9361/src/ad9361_util.c
+++ b/projects/ad9361/src/ad9361_util.c
@@ -83,6 +83,7 @@ uint32_t clk_get_rate(struct ad9361_rf_phy *phy,
 	case RX_RFPLL_INT:
 		rate = ad9361_rfpll_int_recalc_rate(clk_priv,
 						    phy->clks[clk_priv->parent_source]->rate);
+		break;
 	case RX_RFPLL_DUMMY:
 	case TX_RFPLL_DUMMY:
 		rate = ad9361_rfpll_dummy_recalc_rate(clk_priv);
@@ -151,6 +152,7 @@ int32_t clk_set_rate(struct ad9361_rf_phy *phy,
 		case RX_RFPLL_DUMMY:
 		case TX_RFPLL_DUMMY:
 			ad9361_rfpll_dummy_set_rate(clk_priv, rate);
+			break;
 		case TX_RFPLL:
 		case RX_RFPLL:
 			round_rate = ad9361_rfpll_round_rate(clk_priv, rate);


### PR DESCRIPTION
Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>