### PR TITLE
drivers: xilinx_platform: Fix XIIC presence check

### DIFF
--- a/projects/drivers/xilinx_platform/xilinx_platform_drivers.h
+++ b/projects/drivers/xilinx_platform/xilinx_platform_drivers.h
@@ -48,11 +48,14 @@
 #ifdef _XPARAMETERS_PS_H_
 #include <xspips.h>
 #include <xgpiops.h>
-#include <xiic.h>
 #include <xil_exception.h>
 #else
 #include <xspi.h>
 #include <xgpio.h>
+#endif
+
+#ifdef XIIC_H
+#include <xiic.h>
 #endif
 
 /******************************************************************************/
@@ -77,7 +80,7 @@ typedef struct xil_i2c_init_param {
 typedef struct xil_i2c_desc {
 	enum i2c_type	type;
 	uint32_t	id;
-#ifdef _XPARAMETERS_PS_H_
+#ifdef XIIC_H
 	XIic_Config *config;
 	XIic instance;
 #else


### PR DESCRIPTION
XIIC is the AXI IIC Bus Interface LogiCORE IP. Its presence is not
dependent of _XPARAMETERS_PS_H_.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>