### PR TITLE
drivers: platform: xilinx: Updated i2c driver

### DIFF
--- a/drivers/platform/xilinx/i2c.c
+++ b/drivers/platform/xilinx/i2c.c
@@ -42,9 +42,18 @@
 /******************************************************************************/
 
 #include <stdlib.h>
+
+#include <xparameters.h>
+#ifdef XPAR_XIIC_NUM_INSTANCES
+#include <xiic.h>
+#endif
+#ifdef XPAR_XIICPS_NUM_INSTANCES
+#include <xiicps.h>
+#endif
+
 #include "error.h"
 #include "i2c.h"
-#include "xilinx_platform_drivers.h"
+#include "i2c_extra.h"
 
 /******************************************************************************/
 /************************ Functions Definitions *******************************/
@@ -57,65 +66,105 @@
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t i2c_init(struct i2c_desc **desc,
-		 const struct i2c_init_param *param)
+		 const struct i2c_init_param *init_param)
 {
+	int32_t		ret;
+	i2c_desc	*idesc;
+	xil_i2c_desc	*xdesc;
+	xil_i2c_init	*xinit;
+
+	idesc = (struct i2c_desc *)malloc(sizeof(*idesc));
+	xdesc = (struct xil_i2c_desc *)malloc(sizeof(*xdesc));
+
+	if(!idesc || !xdesc)
+		goto error;
+
+	idesc->max_speed_hz = init_param->max_speed_hz;
+	idesc->slave_address = init_param->slave_address;
+	xinit = init_param->extra;
+
+	idesc->extra = xdesc;
+	xdesc->type = xinit->type;
+	switch (xinit->type) {
+	case IIC_PL:
 #ifdef XIIC_H
-	i2c_desc *dev;
-	xil_i2c_desc *xil_dev;
-	xil_i2c_init_param *xil_param;
-	int32_t ret;
+		xdesc->instance = (XIic *)malloc(sizeof(XIic));
+		if(!xdesc->instance)
+			goto pl_error;
 
-	dev = calloc(1, sizeof *dev);
-	if(!dev)
-		return FAILURE;
+		xdesc->config = XIic_LookupConfig(xinit->device_id);
+		if(xdesc->config == NULL)
+			goto pl_error;
 
-	dev->extra = calloc(1, sizeof *xil_dev);
-	if(!(dev->extra)) {
-		free(dev);
-		return FAILURE;
+		ret = XIic_CfgInitialize(xdesc->instance,
+					 xdesc->config,
+					 ((XIic_Config*)xdesc->config)
+					 ->BaseAddress);
+		if(ret != SUCCESS)
+			goto pl_error;
+
+		ret = XIic_Start(xdesc->instance);
+		if(ret != SUCCESS)
+			goto pl_error;
+
+		ret = XIic_SetAddress(xdesc->instance,
+				      XII_ADDR_TO_SEND_TYPE,
+				      init_param->slave_address);
+		if(ret != SUCCESS)
+			goto pl_error;
+
+		ret = XIic_SelfTest(xdesc->instance);
+		if(ret < 0)
+			goto pl_error;
+
+		ret = XIic_SetGpOutput(xdesc->instance, 1);
+		if(ret < 0)
+			goto pl_error;
+
+		break;
+pl_error:
+		free(xdesc->instance);
+#endif
+		goto error;
+	case IIC_PS:
+#ifdef XIICPS_H
+		xdesc->instance = (XIicPs *)malloc(sizeof(XIicPs));
+		if(!xdesc->instance)
+			goto ps_error;
+
+		xdesc->config = XIicPs_LookupConfig(xinit->device_id);
+		if(xdesc->config == NULL)
+			goto ps_error;
+
+		ret = XIicPs_CfgInitialize(xdesc->instance,
+					   xdesc->config,
+					   ((XIicPs_Config*)xdesc->config)
+					   ->BaseAddress);
+		if(ret != SUCCESS)
+			goto ps_error;
+
+		XIicPs_SetSClk(xdesc->instance, init_param->max_speed_hz);
+
+		break;
+ps_error:
+		free(xdesc->instance);
+#endif
+		goto error;
+
+	default:
+		goto error;
+		break;
 	}
 
-	xil_dev = dev->extra;
-	xil_param = param->extra;
+	*desc = idesc;
 
-	xil_dev->type = xil_param->type;
-	xil_dev->id = xil_param->id;
-	dev->max_speed_hz = param->max_speed_hz;
-	dev->slave_address = param->slave_address;
-
-	xil_dev->config = XIic_LookupConfig(xil_dev->id);
-	if (xil_dev->config == NULL)
-		goto error;
-
-	ret = XIic_CfgInitialize(&xil_dev->instance, xil_dev->config,
-				 xil_dev->config->BaseAddress);
-	if(ret != 0)
-		goto error;
-
-	Xil_ExceptionInit();
-
-	Xil_ExceptionRegisterHandler(XIL_EXCEPTION_ID_IRQ_INT,
-				     XIic_InterruptHandler, &xil_dev->instance);
-
-	ret = XIic_Start(&xil_dev->instance);
-	if(ret != 0)
-		goto error;
-
-	ret = XIic_SetAddress(&xil_dev->instance, XII_ADDR_TO_SEND_TYPE,
-			      dev->slave_address);
-	if(ret != 0)
-		goto error;
-
-	*desc = dev;
-
-#endif
 	return SUCCESS;
-#ifdef XIIC_H
+
 error:
-	free(dev);
+	free(idesc);
+	free(xdesc);
 
 	return FAILURE;
-#endif
 }
 
 /**
@@ -125,17 +174,37 @@ error:
  */
 int32_t i2c_remove(struct i2c_desc *desc)
 {
+	xil_i2c_desc	*xdesc;
+	int32_t		ret;
+
+	xdesc = desc->extra;
+
+	switch (xdesc->type) {
+	case IIC_PL:
 #ifdef XIIC_H
-	int32_t ret;
-	xil_i2c_desc *xil_desc;
-	xil_desc = desc->extra;
+		ret = XIic_Stop(((XIic *)xdesc->instance));
 
-	ret = XIic_Stop(&xil_desc->instance);
-	if(ret != 0)
-		return FAILURE;
-
-	free(desc);
+		if(ret != SUCCESS)
+			goto error;
+		break;
 #endif
+		goto error;
+	case IIC_PS:
+#ifdef XIICPS_H
+		break;
+#endif
+		/* Intended fallthrough */
+error:
+	default:
+
+		return FAILURE;
+		break;
+	}
+
+	free(xdesc->instance);
+	free(desc->extra);
+	free(desc);
+
 	return SUCCESS;
 }
 
@@ -152,16 +221,50 @@ int32_t i2c_remove(struct i2c_desc *desc)
 int32_t i2c_write(struct i2c_desc *desc,
 		  uint8_t *data,
 		  uint8_t bytes_number,
-		  uint8_t stop_bit)
+		  uint8_t option)
 {
+	xil_i2c_desc	*xdesc;
+	int32_t		ret;
+
+	xdesc = desc->extra;
+
+	switch (xdesc->type) {
+	case IIC_PL:
 #ifdef XIIC_H
-	xil_i2c_desc *xil_desc;
-	xil_desc = desc->extra;
-	return XIic_Send(xil_desc->instance.BaseAddress, desc->slave_address, data,
-			 bytes_number, stop_bit ? XIIC_STOP : XIIC_REPEATED_START);
-#else
-	return SUCCESS;
+		XIic_Send(((XIic*)xdesc->instance)->BaseAddress,
+			  desc->slave_address,
+			  data,
+			  bytes_number,
+			  option ? XIIC_STOP : XIIC_REPEATED_START);
+		break;
 #endif
+		goto error;
+	case IIC_PS:
+#ifdef XIICPS_H
+
+		ret = XIicPs_SetOptions(xdesc->instance,
+					option);
+		if(ret != SUCCESS)
+			goto error;
+
+		XIicPs_MasterSend(xdesc->instance,
+				  data,
+				  bytes_number,
+				  desc->slave_address);
+		if(ret != SUCCESS)
+			goto error;
+
+		break;
+#endif
+		/* Intended fallthrough */
+error:
+	default:
+
+		return FAILURE;
+		break;
+	}
+
+	return SUCCESS;
 }
 
 /**
@@ -177,16 +280,51 @@ int32_t i2c_write(struct i2c_desc *desc,
 int32_t i2c_read(struct i2c_desc *desc,
 		 uint8_t *data,
 		 uint8_t bytes_number,
-		 uint8_t stop_bit)
+		 uint8_t option)
 {
+	xil_i2c_desc	*xdesc;
+	int32_t		ret;
+
+	xdesc = desc->extra;
+
+	switch (xdesc->type) {
+	case IIC_PL:
 #ifdef XIIC_H
-	xil_i2c_desc *xil_desc;
-	xil_desc = desc->extra;
+		ret = XIic_Recv(((XIic*)xdesc->instance)->BaseAddress,
+				desc->slave_address,
+				data,
+				bytes_number,
+				option ? XIIC_STOP : XIIC_REPEATED_START);
+		if(ret != SUCCESS)
+			goto error;
 
-	return XIic_Recv(xil_desc->instance.BaseAddress, desc->slave_address, data,
-			 bytes_number, stop_bit ? XIIC_STOP : XIIC_REPEATED_START);
-#else
-	return SUCCESS;
+		break;
 #endif
-}
+		goto error;
+	case IIC_PS:
+#ifdef XIICPS_H
 
+		ret = XIicPs_SetOptions(xdesc->instance,
+					option);
+		if(ret != SUCCESS)
+			goto error;
+
+		XIicPs_MasterRecv(xdesc->instance,
+				  data,
+				  bytes_number,
+				  desc->slave_address);
+		if(ret != SUCCESS)
+			goto error;
+
+		break;
+#endif
+		/* Intended fallthrough */
+error:
+	default:
+		return FAILURE;
+
+		break;
+	}
+
+	return SUCCESS;
+}

--- a/drivers/platform/xilinx/i2c_extra.h
+++ b/drivers/platform/xilinx/i2c_extra.h
@@ -1,6 +1,7 @@
-/***************************************************************************//**
- *   @file   i2c.h
- *   @author DBogdan (dragos.bogdan@analog.com)
+/*******************************************************************************
+ *   @file   i2c_extra.h
+ *   @brief  Header containing types used in the i2c driver.
+ *   @author scuciurean (sergiu.cuciurean@analog.com)
 ********************************************************************************
  * Copyright 2019(c) Analog Devices, Inc.
  *
@@ -36,8 +37,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 
-#ifndef I2C_H_
-#define I2C_H_
+#ifndef I2C_EXTRA_H_
+#define I2C_EXTRA_H_
 
 /******************************************************************************/
 /***************************** Include Files **********************************/
@@ -49,45 +50,20 @@
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
-typedef enum i2c_transfer_mode {
-	i2c_general_call =	0x01,
-	i2c_repeated_start =	0x02,
-	i2c_10_bit_transfer =	0x04
-} i2c_transfer_mode;
+enum xil_i2c_type {
+	IIC_PL,
+	IIC_PS
+} xil_i2c_type;
 
-typedef struct i2c_init_param {
-	uint32_t	max_speed_hz;
-	uint8_t		slave_address;
-	void		*extra;
-} i2c_init_param;
+typedef struct xil_i2c_init {
+	enum xil_i2c_type	type;
+	uint32_t		device_id;
+} xil_i2c_init;
 
-typedef struct i2c_desc {
-	uint32_t	max_speed_hz;
-	uint8_t		slave_address;
-	void		*extra;
-} i2c_desc;
+typedef struct xil_i2c_desc {
+	enum xil_i2c_type	type;
+	void			*config;
+	void			*instance;
+} xil_i2c_desc;
 
-/******************************************************************************/
-/************************ Functions Declarations ******************************/
-/******************************************************************************/
-
-/* Initialize the I2C communication peripheral. */
-int32_t i2c_init(struct i2c_desc **desc,
-		 const struct i2c_init_param *param);
-
-/* Free the resources allocated by i2c_init(). */
-int32_t i2c_remove(struct i2c_desc *desc);
-
-/* Write data to a slave device. */
-int32_t i2c_write(struct i2c_desc *desc,
-		  uint8_t *data,
-		  uint8_t bytes_number,
-		  uint8_t option);
-
-/* Read data from a slave device. */
-int32_t i2c_read(struct i2c_desc *desc,
-		 uint8_t *data,
-		 uint8_t bytes_number,
-		 uint8_t option);
-
-#endif // I2C_H_
+#endif // I2C_EXTRA_H_

--- a/drivers/platform/xilinx/platform_drivers.h
+++ b/drivers/platform/xilinx/platform_drivers.h
@@ -46,7 +46,6 @@
 #include "delay.h"
 #include "error.h"
 #include "gpio.h"
-#include "i2c.h"
 #include "spi.h"
 
 #endif // PLATFORM_DRIVERS_H_

--- a/projects/ad9172/src/README
+++ b/projects/ad9172/src/README
@@ -4,14 +4,12 @@
 	cp ../../../include/axi_io.h ./
 	cp ../../../include/error.h ./
 	cp ../../../include/spi.h ./
-	cp ../../../include/i2c.h ./
 	cp ../../../include/gpio.h ./
 	cp ../../../include/delay.h ./
 	cp ../../../drivers/platform/xilinx/axi_io.c ./
 	cp ../../../drivers/platform/xilinx/platform_drivers.h ./
 	cp ../../../drivers/platform/xilinx/xilinx_platform_drivers.h ./
 	cp ../../../drivers/platform/xilinx/spi.c ./
-	cp ../../../drivers/platform/xilinx/i2c.c ./
 	cp ../../../drivers/platform/xilinx/gpio.c ./
 	cp ../../../drivers/platform/xilinx/delay.c ./
 	cp ../../drivers/util/util.c ./

--- a/projects/ad9208/README
+++ b/projects/ad9208/README
@@ -3,14 +3,12 @@
 	cp ../../../include/axi_io.h ./
 	cp ../../../include/error.h ./
 	cp ../../../include/spi.h ./
-	cp ../../../include/i2c.h ./
 	cp ../../../include/gpio.h ./
 	cp ../../../include/delay.h ./
 	cp ../../../drivers/platform/xilinx/axi_io.c ./
 	cp ../../../drivers/platform/xilinx/platform_drivers.h ./
 	cp ../../../drivers/platform/xilinx/xilinx_platform_drivers.h ./
 	cp ../../../drivers/platform/xilinx/spi.c ./
-	cp ../../../drivers/platform/xilinx/i2c.c ./
 	cp ../../../drivers/platform/xilinx/gpio.c ./
 	cp ../../../drivers/platform/xilinx/delay.c ./
 	cp ../../drivers/util/util.c ./

--- a/projects/ad9371/src/README
+++ b/projects/ad9371/src/README
@@ -7,12 +7,10 @@
 	cp ../../../include/axi_io.h devices/adi_hal/
 	cp ../../../include/error.h devices/adi_hal/
 	cp ../../../include/spi.h devices/adi_hal/
-	cp ../../../include/i2c.h devices/adi_hal/
 	cp ../../../include/gpio.h devices/adi_hal/
 	cp ../../../include/delay.h devices/adi_hal/
 	cp ../../../drivers/platform/altera/axi_io.c devices/adi_hal/
 	cp ../../drivers/altera_platform/spi.c devices/adi_hal/
-	cp ../../drivers/altera_platform/i2c.c devices/adi_hal/
 	cp ../../drivers/altera_platform/gpio.c devices/adi_hal/
 	cp ../../drivers/altera_platform/delay.c devices/adi_hal/
 	cp ../../drivers/axi_adc_core/axi_adc_core.c devices/adi_hal/
@@ -39,14 +37,12 @@
 	cp ../../../include/axi_io.h devices/adi_hal/
 	cp ../../../include/error.h devices/adi_hal/
 	cp ../../../include/spi.h devices/adi_hal/
-	cp ../../../include/i2c.h devices/adi_hal/
 	cp ../../../include/gpio.h devices/adi_hal/
 	cp ../../../include/delay.h devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/axi_io.c devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/platform_drivers.h devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/xilinx_platform_drivers.h devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/spi.c devices/adi_hal/
-	cp ../../../drivers/platform/xilinx/i2c.c devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/gpio.c devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/delay.c devices/adi_hal/
 	cp ../../drivers/axi_adc_core/axi_adc_core.c devices/adi_hal/

--- a/projects/adrv9009/src/README
+++ b/projects/adrv9009/src/README
@@ -7,12 +7,10 @@ Additional required source files:
 	cp ../../../include/axi_io.h devices/adi_hal/
 	cp ../../../include/error.h devices/adi_hal/
 	cp ../../../include/spi.h devices/adi_hal/
-	cp ../../../include/i2c.h devices/adi_hal/
 	cp ../../../include/gpio.h devices/adi_hal/
 	cp ../../../include/delay.h devices/adi_hal/
 	cp ../../../drivers/platform/altera/axi_io.c devices/adi_hal/
 	cp ../../drivers/altera_platform/spi.c devices/adi_hal/
-	cp ../../drivers/altera_platform/i2c.c devices/adi_hal/
 	cp ../../drivers/altera_platform/gpio.c devices/adi_hal/
 	cp ../../drivers/altera_platform/delay.c devices/adi_hal/
 	cp ../../drivers/axi_adc_core/axi_adc_core.c devices/adi_hal/
@@ -39,14 +37,12 @@ Additional required source files:
 	cp ../../../include/axi_io.h devices/adi_hal/
 	cp ../../../include/error.h devices/adi_hal/
 	cp ../../../include/spi.h devices/adi_hal/
-	cp ../../../include/i2c.h devices/adi_hal/
 	cp ../../../include/gpio.h devices/adi_hal/
 	cp ../../../include/delay.h devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/axi_io.c devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/platform_drivers.h devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/xilinx_platform_drivers.h devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/spi.c devices/adi_hal/
-	cp ../../../drivers/platform/xilinx/i2c.c devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/gpio.c devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/delay.c devices/adi_hal/
 	cp ../../drivers/axi_adc_core/axi_adc_core.c devices/adi_hal/


### PR DESCRIPTION
Removed platform_drivers.h dependency and updated compiler
switches to support both PS and PL implementation of a i2c
controller.
The driver is now updated to use the platform agnostic extra
features passed in the i2c descriptor.
Changed 'stop_bit' param to 'options'.

Signed-off-by: Sergiu Cuciurean sergiu.cuciurean@analog.com