### PR TITLE
axi_adc_core: Add "axi_adc_get_sampling_freq()" function.

### DIFF
--- a/projects/drivers/axi_adc_core/axi_adc_core.c
+++ b/projects/drivers/axi_adc_core/axi_adc_core.c
@@ -89,6 +89,24 @@ int32_t axi_adc_set_pnsel(struct axi_adc *adc,
 }
 
 /***************************************************************************//**
+ * @brief axi_adc_get_sampling_freq
+*******************************************************************************/
+int32_t axi_adc_get_sampling_freq(struct axi_adc *adc,
+				  uint32_t chan,
+				  uint64_t *sampling_freq)
+{
+	uint32_t freq;
+	uint32_t ratio;
+
+	axi_adc_read(adc, AXI_ADC_REG_CLK_FREQ, &freq);
+	axi_adc_read(adc, AXI_ADC_REG_CLK_RATIO, &ratio);
+	*sampling_freq = freq * ratio;
+	*sampling_freq = ((*sampling_freq) * 390625) >> 8;
+
+	return SUCCESS;
+}
+
+/***************************************************************************//**
  * @brief axi_adc_idelay_set
 *******************************************************************************/
 void axi_adc_idelay_set(struct axi_adc *adc,

--- a/projects/drivers/axi_adc_core/axi_adc_core.h
+++ b/projects/drivers/axi_adc_core/axi_adc_core.h
@@ -152,6 +152,9 @@ int32_t axi_adc_write(struct axi_adc *adc,
 int32_t axi_adc_set_pnsel(struct axi_adc *adc,
 			  uint32_t chan,
 			  enum axi_adc_pn_sel sel);
+int32_t axi_adc_get_sampling_freq(struct axi_adc *adc,
+				  uint32_t chan,
+				  uint64_t *sampling_freq);
 void axi_adc_idelay_set(struct axi_adc *adc,
 			uint32_t lane,
 			uint32_t val);


### PR DESCRIPTION
This is needed in tinyiiod project.

Signed-off-by: Cristian Pop <cristian.pop@analog.com>