### PR TITLE
iio: Add iio_types.h

### DIFF
--- a/iio/iio_types.h
+++ b/iio/iio_types.h
@@ -1,0 +1,83 @@
+/***************************************************************************//**
+ *   @file   iio_types.h
+ *   @brief  Header file for iio_types
+ *   @author Cristian Pop (cristian.pop@analog.com)
+********************************************************************************
+ * Copyright 2013(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef IIO_TYPES_H_
+#define IIO_TYPES_H_
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <stdbool.h>
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+
+struct iio_ch_info {
+	int16_t ch_num;
+	bool ch_out;
+};
+
+struct iio_attribute {
+	const char *name;
+	ssize_t (*show)(void *device, char *buf, size_t len,
+			const struct iio_ch_info *channel);
+	ssize_t (*store)(void *device, char *buf, size_t len,
+			 const struct iio_ch_info *channel);
+};
+
+struct iio_channel {
+	char *name;
+	struct iio_attribute **attributes;
+};
+
+struct iio_device {
+	const char *name;
+	struct iio_channel **channels;
+	struct iio_attribute **attributes;
+};
+
+struct iio_server_ops {
+	/* Read from the input stream */
+	ssize_t (*read)(char *buf, size_t len);
+	/* Write to the output stream */
+	ssize_t (*write)(const char *buf, size_t len);
+};
+
+#endif /* IIO_TYPES_H_ */


### PR DESCRIPTION
This is will be used in "iio" core and iio devices: "iio_axi_adc.c",
"iio_axi_dac.c", "iio_ad9361.c"...

Signed-off-by: Cristian Pop <cristian.pop@analog.com>