### PR TITLE
projects: ad9172: fix README

### DIFF
--- a/projects/ad9172/src/README
+++ b/projects/ad9172/src/README
@@ -30,13 +30,13 @@
 	cp ../../drivers/axi_dmac/axi_dmac.c ./
 	cp ../../../drivers/frequency/hmc7044/hmc7044.h ./
 	cp ../../../drivers/frequency/hmc7044/hmc7044.c ./
-	cp ../../../drivers/ad917x/ad9172.h ./
-	cp ../../../drivers/ad917x/ad9172.c ./
-	cp ../../../drivers/ad917x/ad917x_api/ad917x_api.c ./
-	cp ../../../drivers/ad917x/ad917x_api/ad917x_jesd_api.c ./
-	cp ../../../drivers/ad917x/ad917x_api/ad917x_nco_api.c ./
-	cp ../../../drivers/ad917x/ad917x_api/ad917x_reg.c ./
-	cp ../../../drivers/ad917x/ad917x_api/ad917x_reg.h ./
-	cp ../../../drivers/ad917x/ad917x_api/AD917x.h ./
-	cp ../../../drivers/ad917x/ad917x_api/api_def.h ./
-	cp ../../../drivers/ad917x/ad917x_api/api_errors.h ./
+	cp ../../../drivers/dac/ad917x/ad9172.h ./
+	cp ../../../drivers/dac/ad917x/ad9172.c ./
+	cp ../../../drivers/dac/ad917x/ad917x_api/ad917x_api.c ./
+	cp ../../../drivers/dac/ad917x/ad917x_api/ad917x_jesd_api.c ./
+	cp ../../../drivers/dac/ad917x/ad917x_api/ad917x_nco_api.c ./
+	cp ../../../drivers/dac/ad917x/ad917x_api/ad917x_reg.c ./
+	cp ../../../drivers/dac/ad917x/ad917x_api/ad917x_reg.h ./
+	cp ../../../drivers/dac/ad917x/ad917x_api/AD917x.h ./
+	cp ../../../drivers/dac/ad917x/ad917x_api/api_def.h ./
+	cp ../../../drivers/dac/ad917x/ad917x_api/api_errors.h ./


### PR DESCRIPTION
Use correct path for ad917x driver.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>