### PR TITLE
projects: remove axi_io function pointers

### DIFF
--- a/projects/ad9172/src/main.c
+++ b/projects/ad9172/src/main.c
@@ -51,7 +51,6 @@
 #include "inttypes.h"
 #include "error.h"
 #include "xilinx_platform_drivers.h"
-#include "axi_io.h"
 
 #ifdef DAC_DMA_EXAMPLE
 #include "axi_dmac.h"
@@ -103,8 +102,6 @@ int main(void)
 		.subclass = 1,
 		.device_clk_khz = 184320,	/* (lane_clk_khz / 40) */
 		.lane_clk_khz = 7372800,	/* LaneRate = ( M/L)*NP*(10/8)*DataRate */
-		.axi_io_read = axi_io_read,
-		.axi_io_write = axi_io_write
 	};
 
 	struct adxcvr_init tx_adxcvr_init = {
@@ -143,9 +140,7 @@ int main(void)
 	struct axi_dac_init tx_dac_init = {
 		"tx_dac",
 		TX_CORE_BASEADDR,
-		4,
-		axi_io_read,
-		axi_io_write
+		4
 	};
 
 #ifdef DAC_DMA_EXAMPLE

--- a/projects/ad9208/main.c
+++ b/projects/ad9208/main.c
@@ -55,7 +55,6 @@
 #include "xil_printf.h"
 #include "platform.h"
 #include "xilinx_platform_drivers.h"
-#include "axi_io.h"
 
 int main(void)
 {
@@ -217,8 +216,6 @@ int main(void)
 		.device_clk_khz = 375000,
 		/* LaneRate = (M/L)*NP*(10/8)*DataRate */
 		.lane_clk_khz = 15000000,
-		.axi_io_read = axi_io_read,
-		.axi_io_write = axi_io_write,
 	};
 
 	struct jesd204_rx_init rx_1_jesd_init = {
@@ -231,24 +228,18 @@ int main(void)
 		.device_clk_khz = 375000,
 		/* LaneRate = (M/L)*NP*(10/8)*DataRate */
 		.lane_clk_khz = 15000000,
-		.axi_io_read = axi_io_read,
-		.axi_io_write = axi_io_write,
 	};
 
 	struct axi_adc_init rx_0_adc_init = {
 		.name = "rx_0_adc",
 		.base = RX_0_CORE_BASEADDR,
 		.num_channels = 2,
-		.axi_io_read = axi_io_read,
-		.axi_io_write = axi_io_write,
 	};
 
 	struct axi_adc_init rx_1_adc_init = {
 		.name = "rx_1_adc",
 		.base = RX_1_CORE_BASEADDR,
 		.num_channels = 2,
-		.axi_io_read = axi_io_read,
-		.axi_io_write = axi_io_write,
 	};
 
 	struct axi_dmac_init rx_dmac_init = {
@@ -256,8 +247,6 @@ int main(void)
 		.base = RX_DMA_BASEADDR,
 		.direction = DMA_DEV_TO_MEM,
 		.flags = 0,
-		.axi_io_read = axi_io_read,
-		.axi_io_write = axi_io_write,
 	};
 
 	struct ad9208_init_param ad9208_0_param = {

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -46,7 +46,6 @@
 #include "ad9361_parameters.h"
 #include "spi.h"
 #include "gpio.h"
-#include "axi_io.h"
 #ifdef XILINX_PLATFORM
 #include "xilinx_platform_drivers.h"
 #include <xil_cache.h>
@@ -61,32 +60,24 @@
 struct axi_adc_init rx_adc_init = {
 	"rx_adc",
 	RX_CORE_BASEADDR,
-	4,
-	axi_io_read,
-	axi_io_write
+	4
 };
 struct axi_dac_init tx_dac_init = {
 	"tx_dac",
 	TX_CORE_BASEADDR,
-	4,
-	axi_io_read,
-	axi_io_write
+	4
 };
 struct axi_dmac_init rx_dmac_init = {
 	"rx_dmac",
 	CF_AD9361_RX_DMA_BASEADDR,
 	DMA_DEV_TO_MEM,
-	0,
-	axi_io_read,
-	axi_io_write
+	0
 };
 struct axi_dmac_init tx_dmac_init = {
 	"tx_dmac",
 	CF_AD9361_TX_DMA_BASEADDR,
 	DMA_MEM_TO_DEV,
-	0,
-	axi_io_read,
-	axi_io_write
+	0
 };
 
 AD9361_InitParam default_init_param = {

--- a/projects/ad9371/src/app/headless.c
+++ b/projects/ad9371/src/app/headless.c
@@ -62,7 +62,6 @@
 #include "axi_dac_core.h"
 #include "axi_adc_core.h"
 #include "axi_dmac.h"
-#include "axi_io.h"
 
 /******************************************************************************/
 /************************ Variables Definitions *******************************/
@@ -158,9 +157,7 @@ int main(void)
 		32,
 		1,
 		rx_div40_rate_hz / 1000,
-		rx_lane_rate_khz,
-		axi_io_read,
-		axi_io_write
+		rx_lane_rate_khz
 	};
 	struct jesd204_tx_init tx_jesd_init = {
 		"tx_jesd",
@@ -174,9 +171,7 @@ int main(void)
 		2,
 		1,
 		tx_div40_rate_hz / 1000,
-		tx_lane_rate_khz,
-		axi_io_read,
-		axi_io_write
+		tx_lane_rate_khz
 	};
 
 	struct jesd204_rx_init rx_os_jesd_init = {
@@ -186,9 +181,7 @@ int main(void)
 		32,
 		1,
 		rx_os_div40_rate_hz / 1000,
-		rx_os_lane_rate_khz,
-		axi_io_read,
-		axi_io_write
+		rx_os_lane_rate_khz
 	};
 	struct axi_jesd204_rx *rx_jesd;
 	struct axi_jesd204_tx *tx_jesd;
@@ -256,26 +249,20 @@ int main(void)
 	struct axi_dac_init tx_dac_init = {
 		"tx_dac",
 		TX_CORE_BASEADDR,
-		4,
-		axi_io_read,
-		axi_io_write
+		4
 	};
 	struct axi_dac *tx_dac;
 	struct axi_adc_init rx_adc_init = {
 		"rx_adc",
 		RX_CORE_BASEADDR,
-		4,
-		axi_io_read,
-		axi_io_write
+		4
 	};
 	struct axi_adc *rx_adc;
 	struct axi_dmac_init rx_dmac_init = {
 		"rx_dmac",
 		RX_DMA_BASEADDR,
 		DMA_DEV_TO_MEM,
-		0,
-		axi_io_read,
-		axi_io_write
+		0
 	};
 	struct axi_dmac *rx_dmac;
 #ifdef DAC_DMA_EXAMPLE

--- a/projects/adrv9009/src/app/headless.c
+++ b/projects/adrv9009/src/app/headless.c
@@ -44,8 +44,6 @@
 #include "talise_arm_binary.h"
 #include "talise_stream_binary.h"
 
-#include "axi_io.h"
-
 /**********************************************************/
 /**********************************************************/
 /********** Talise Data Structure Initializations ********/
@@ -127,9 +125,7 @@ int main(void)
 		32,
 		1,
 		rx_div40_rate_hz / 1000,
-		rx_lane_rate_khz,
-		axi_io_read,
-		axi_io_write
+		rx_lane_rate_khz
 	};
 	struct jesd204_tx_init tx_jesd_init = {
 		"tx_jesd",
@@ -143,9 +139,7 @@ int main(void)
 		2,
 		1,
 		tx_div40_rate_hz / 1000,
-		tx_lane_rate_khz,
-		axi_io_read,
-		axi_io_write
+		tx_lane_rate_khz
 	};
 
 	struct jesd204_rx_init rx_os_jesd_init = {
@@ -156,8 +150,6 @@ int main(void)
 		1,
 		rx_os_div40_rate_hz / 1000,
 		rx_os_lane_rate_khz,
-		axi_io_read,
-		axi_io_write
 	};
 	struct axi_jesd204_rx *rx_jesd;
 	struct axi_jesd204_tx *tx_jesd;
@@ -225,26 +217,20 @@ int main(void)
 	struct axi_adc_init rx_adc_init = {
 		"rx_adc",
 		RX_CORE_BASEADDR,
-		4,
-		axi_io_read,
-		axi_io_write
+		4
 	};
 	struct axi_adc *rx_adc;
 	struct axi_dac_init tx_dac_init = {
 		"tx_dac",
 		TX_CORE_BASEADDR,
-		4,
-		axi_io_read,
-		axi_io_write
+		4
 	};
 	struct axi_dac *tx_dac;
 	struct axi_dmac_init rx_dmac_init = {
 		"rx_dmac",
 		RX_DMA_BASEADDR,
 		DMA_DEV_TO_MEM,
-		0,
-		axi_io_read,
-		axi_io_write
+		0
 	};
 	struct axi_dmac *rx_dmac;
 #ifdef DAC_DMA_EXAMPLE

--- a/projects/drivers/axi_adc_core/axi_adc_core.c
+++ b/projects/drivers/axi_adc_core/axi_adc_core.c
@@ -54,7 +54,7 @@ int32_t axi_adc_read(struct axi_adc *adc,
 		     uint32_t reg_addr,
 		     uint32_t *reg_data)
 {
-	adc->axi_io_read(adc->base, reg_addr, reg_data);
+	axi_io_read(adc->base, reg_addr, reg_data);
 
 	return SUCCESS;
 }
@@ -66,7 +66,7 @@ int32_t axi_adc_write(struct axi_adc *adc,
 		      uint32_t reg_addr,
 		      uint32_t reg_data)
 {
-	adc->axi_io_write(adc->base, reg_addr, reg_data);
+	axi_io_write(adc->base, reg_addr, reg_data);
 
 	return SUCCESS;
 }
@@ -308,8 +308,6 @@ int32_t axi_adc_init(struct axi_adc **adc_core,
 	adc->name = init->name;
 	adc->base = init->base;
 	adc->num_channels = init->num_channels;
-	adc->axi_io_read = init->axi_io_read;
-	adc->axi_io_write = init->axi_io_write;
 
 	axi_adc_write(adc, AXI_ADC_REG_RSTN, 0);
 	axi_adc_write(adc, AXI_ADC_REG_RSTN,

--- a/projects/drivers/axi_adc_core/axi_adc_core.h
+++ b/projects/drivers/axi_adc_core/axi_adc_core.h
@@ -114,16 +114,12 @@ struct axi_adc {
 	uint32_t base;
 	uint8_t	num_channels;
 	uint64_t clock_hz;
-	int32_t (*axi_io_read)(uint32_t, uint32_t, uint32_t*);
-	int32_t (*axi_io_write)(uint32_t, uint32_t, uint32_t);
 };
 
 struct axi_adc_init {
 	const char *name;
 	uint32_t base;
 	uint8_t	num_channels;
-	int32_t (*axi_io_read)(uint32_t, uint32_t, uint32_t*);
-	int32_t (*axi_io_write)(uint32_t, uint32_t, uint32_t);
 };
 
 enum axi_adc_pn_sel {

--- a/projects/drivers/axi_dac_core/axi_dac_core.c
+++ b/projects/drivers/axi_dac_core/axi_dac_core.c
@@ -339,7 +339,7 @@ int32_t axi_dac_read(struct axi_dac *dac,
 		     uint32_t reg_addr,
 		     uint32_t *reg_data)
 {
-	dac->axi_io_read(dac->base, reg_addr, reg_data);
+	axi_io_read(dac->base, reg_addr, reg_data);
 
 	return SUCCESS;
 }
@@ -351,7 +351,7 @@ int32_t axi_dac_write(struct axi_dac *dac,
 		      uint32_t reg_addr,
 		      uint32_t reg_data)
 {
-	dac->axi_io_write(dac->base, reg_addr, reg_data);
+	axi_io_write(dac->base, reg_addr, reg_data);
 
 	return SUCCESS;
 }
@@ -708,7 +708,7 @@ uint32_t axi_dac_set_sine_lut(struct axi_dac *dac,
 			data_i1 = (sine_lut[index_i1 / 2] << 20);
 			data_q1 = (sine_lut[index_q1 / 2] << 4);
 
-			dac->axi_io_write(address, index_mem * 4, data_i1 | data_q1);
+			axi_io_write(address, index_mem * 4, data_i1 | data_q1);
 
 			index_i2 = index_i1;
 			index_q2 = index_q1;
@@ -719,7 +719,7 @@ uint32_t axi_dac_set_sine_lut(struct axi_dac *dac,
 			data_i2 = (sine_lut[index_i2 / 2] << 20);
 			data_q2 = (sine_lut[index_q2 / 2] << 4);
 
-			dac->axi_io_write(address, (index_mem + 1) * 4, data_i2 | data_q2);
+			axi_io_write(address, (index_mem + 1) * 4, data_i2 | data_q2);
 
 		}
 	} else {
@@ -731,7 +731,7 @@ uint32_t axi_dac_set_sine_lut(struct axi_dac *dac,
 			data_i1 = (sine_lut[index_i1] << 20);
 			data_q1 = (sine_lut[index_q1] << 4);
 
-			dac->axi_io_write(address, index * 4, data_i1 | data_q1);
+			axi_io_write(address, index * 4, data_i1 | data_q1);
 		}
 	}
 
@@ -773,7 +773,7 @@ int32_t axi_dac_set_buff(struct axi_dac *dac,
 		data_i = (buff[index]);
 		data_q = (buff[index + 1] << 16);
 
-		dac->axi_io_write(address, index * 2, data_i | data_q);
+		axi_io_write(address, index * 2, data_i | data_q);
 	}
 
 	return SUCCESS;
@@ -795,7 +795,7 @@ int32_t axi_dac_load_custom_data(struct axi_dac *dac,
 		/* Send the same data on all the channels */
 		for (chan = 0; chan < num_tx_channels; chan++) {
 
-			dac->axi_io_write(address, index_mem * sizeof(uint32_t),
+			axi_io_write(address, index_mem * sizeof(uint32_t),
 					  custom_data_iq[index]);
 
 			index_mem++;
@@ -831,8 +831,6 @@ int32_t axi_dac_init(struct axi_dac **dac_core,
 	dac->name = init->name;
 	dac->base = init->base;
 	dac->num_channels = init->num_channels;
-	dac->axi_io_read = init->axi_io_read;
-	dac->axi_io_write = init->axi_io_write;
 
 	axi_dac_write(dac, AXI_DAC_REG_RSTN, 0);
 	axi_dac_write(dac, AXI_DAC_REG_RSTN,

--- a/projects/drivers/axi_dac_core/axi_dac_core.h
+++ b/projects/drivers/axi_dac_core/axi_dac_core.h
@@ -52,16 +52,12 @@ struct axi_dac {
 	uint32_t base;
 	uint8_t	num_channels;
 	uint64_t clock_hz;
-	int32_t (*axi_io_read)(uint32_t, uint32_t, uint32_t*);
-	int32_t (*axi_io_write)(uint32_t, uint32_t, uint32_t);
 };
 
 struct axi_dac_init {
 	const char *name;
 	uint32_t base;
 	uint8_t	num_channels;
-	int32_t (*axi_io_read)(uint32_t, uint32_t, uint32_t*);
-	int32_t (*axi_io_write)(uint32_t, uint32_t, uint32_t);
 };
 
 enum axi_dac_data_sel {

--- a/projects/drivers/axi_dmac/axi_dmac.c
+++ b/projects/drivers/axi_dmac/axi_dmac.c
@@ -42,6 +42,7 @@
 /******************************************************************************/
 #include <stdlib.h>
 #include <stdio.h>
+#include "axi_io.h"
 #include "error.h"
 #include "axi_dmac.h"
 
@@ -52,7 +53,7 @@ int32_t axi_dmac_read(struct axi_dmac *dmac,
 		      uint32_t reg_addr,
 		      uint32_t *reg_data)
 {
-	dmac->axi_io_read(dmac->base, reg_addr, reg_data);
+	axi_io_read(dmac->base, reg_addr, reg_data);
 
 	return SUCCESS;
 }
@@ -64,7 +65,7 @@ int32_t axi_dmac_write(struct axi_dmac *dmac,
 		       uint32_t reg_addr,
 		       uint32_t reg_data)
 {
-	dmac->axi_io_write(dmac->base, reg_addr, reg_data);
+	axi_io_write(dmac->base, reg_addr, reg_data);
 
 	return SUCCESS;
 }
@@ -144,8 +145,6 @@ int32_t axi_dmac_init(struct axi_dmac **dmac_core,
 	dmac->base = init->base;
 	dmac->direction = init->direction;
 	dmac->flags = init->flags;
-	dmac->axi_io_read = init->axi_io_read;
-	dmac->axi_io_write = init->axi_io_write;
 
 	*dmac_core = dmac;
 

--- a/projects/drivers/axi_dmac/axi_dmac.h
+++ b/projects/drivers/axi_dmac/axi_dmac.h
@@ -86,8 +86,6 @@ struct axi_dmac {
 	uint32_t base;
 	enum dma_direction direction;
 	uint32_t flags;
-	int32_t (*axi_io_read)(uint32_t, uint32_t, uint32_t*);
-	int32_t (*axi_io_write)(uint32_t, uint32_t, uint32_t);
 };
 
 struct axi_dmac_init {
@@ -95,8 +93,6 @@ struct axi_dmac_init {
 	uint32_t base;
 	enum dma_direction direction;
 	uint32_t flags;
-	int32_t (*axi_io_read)(uint32_t, uint32_t, uint32_t*);
-	int32_t (*axi_io_write)(uint32_t, uint32_t, uint32_t);
 };
 
 /******************************************************************************/

--- a/projects/drivers/jesd204/axi_jesd204_rx.c
+++ b/projects/drivers/jesd204/axi_jesd204_rx.c
@@ -111,7 +111,7 @@ const char *axi_jesd204_rx_lane_status_label[] = {
 int32_t axi_jesd204_rx_write(struct axi_jesd204_rx *jesd,
 			     uint32_t reg_addr, uint32_t reg_val)
 {
-	jesd->axi_io_write(jesd->base, reg_addr, reg_val);
+	axi_io_write(jesd->base, reg_addr, reg_val);
 
 	return SUCCESS;
 }
@@ -122,7 +122,7 @@ int32_t axi_jesd204_rx_write(struct axi_jesd204_rx *jesd,
 int32_t axi_jesd204_rx_read(struct axi_jesd204_rx *jesd,
 			    uint32_t reg_addr, uint32_t *reg_val)
 {
-	jesd->axi_io_read(jesd->base, reg_addr, reg_val);
+	axi_io_read(jesd->base, reg_addr, reg_val);
 
 	return SUCCESS;
 }
@@ -410,8 +410,6 @@ int32_t axi_jesd204_rx_init(struct axi_jesd204_rx **jesd204,
 	jesd->base = init->base;
 	jesd->device_clk_khz = init->device_clk_khz;
 	jesd->lane_clk_khz = init->lane_clk_khz;
-	jesd->axi_io_read = init->axi_io_read;
-	jesd->axi_io_write = init->axi_io_write;
 
 	axi_jesd204_rx_read(jesd, JESD204_RX_REG_MAGIC, &magic);
 	if (magic != JESD204_RX_MAGIC) {

--- a/projects/drivers/jesd204/axi_jesd204_rx.h
+++ b/projects/drivers/jesd204/axi_jesd204_rx.h
@@ -63,8 +63,6 @@ struct axi_jesd204_rx {
 	struct jesd204_rx_config config;
 	uint32_t device_clk_khz;
 	uint32_t lane_clk_khz;
-	int32_t (*axi_io_read)(uint32_t, uint32_t, uint32_t*);
-	int32_t (*axi_io_write)(uint32_t, uint32_t, uint32_t);
 };
 
 struct jesd204_rx_init {
@@ -75,8 +73,6 @@ struct jesd204_rx_init {
 	uint8_t subclass;
 	uint32_t device_clk_khz;
 	uint32_t lane_clk_khz;
-	int32_t (*axi_io_read)(uint32_t, uint32_t, uint32_t*);
-	int32_t (*axi_io_write)(uint32_t, uint32_t, uint32_t);
 };
 
 /******************************************************************************/

--- a/projects/drivers/jesd204/axi_jesd204_tx.c
+++ b/projects/drivers/jesd204/axi_jesd204_tx.c
@@ -96,7 +96,7 @@ const char *axi_jesd204_tx_link_status_label[] = {
 int32_t axi_jesd204_tx_write(struct axi_jesd204_tx *jesd,
 			     uint32_t reg_addr, uint32_t reg_val)
 {
-	jesd->axi_io_write(jesd->base, reg_addr, reg_val);
+	axi_io_write(jesd->base, reg_addr, reg_val);
 
 	return SUCCESS;
 }
@@ -107,7 +107,7 @@ int32_t axi_jesd204_tx_write(struct axi_jesd204_tx *jesd,
 int32_t axi_jesd204_tx_read(struct axi_jesd204_tx *jesd,
 			    uint32_t reg_addr, uint32_t *reg_val)
 {
-	jesd->axi_io_read(jesd->base, reg_addr, reg_val);
+	axi_io_read(jesd->base, reg_addr, reg_val);
 
 	return SUCCESS;
 }
@@ -318,8 +318,6 @@ int32_t axi_jesd204_tx_init(struct axi_jesd204_tx **jesd204,
 	jesd->name = init->name;
 	jesd->device_clk_khz = init->device_clk_khz;
 	jesd->lane_clk_khz = init->lane_clk_khz;
-	jesd->axi_io_read = init->axi_io_read;
-	jesd->axi_io_write = init->axi_io_write;
 
 	axi_jesd204_tx_read(jesd, JESD204_TX_REG_MAGIC, &magic);
 	if (magic != JESD204_TX_MAGIC) {

--- a/projects/drivers/jesd204/axi_jesd204_tx.h
+++ b/projects/drivers/jesd204/axi_jesd204_tx.h
@@ -74,8 +74,6 @@ struct axi_jesd204_tx {
 	struct jesd204_tx_config config;
 	uint32_t device_clk_khz;
 	uint32_t lane_clk_khz;
-	int32_t (*axi_io_read)(uint32_t, uint32_t, uint32_t*);
-	int32_t (*axi_io_write)(uint32_t, uint32_t, uint32_t);
 };
 
 struct jesd204_tx_init {
@@ -91,8 +89,6 @@ struct jesd204_tx_init {
 	uint8_t subclass;
 	uint32_t device_clk_khz;
 	uint32_t lane_clk_khz;
-	int32_t (*axi_io_read)(uint32_t, uint32_t, uint32_t*);
-	int32_t (*axi_io_write)(uint32_t, uint32_t, uint32_t);
 };
 
 /******************************************************************************/


### PR DESCRIPTION
Remove function pointers from device structures.
Use `axi_io` read/write functions directly inside drivers.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>