### PR TITLE
projects: remove platform drivers header 

### DIFF
--- a/projects/ad9172/src/README
+++ b/projects/ad9172/src/README
@@ -7,7 +7,6 @@
 	cp ../../../include/gpio.h ./
 	cp ../../../include/delay.h ./
 	cp ../../../drivers/platform/xilinx/axi_io.c ./
-	cp ../../../drivers/platform/xilinx/platform_drivers.h ./
 	cp ../../../drivers/platform/xilinx/xilinx_platform_drivers.h ./
 	cp ../../../drivers/platform/xilinx/spi.c ./
 	cp ../../../drivers/platform/xilinx/gpio.c ./

--- a/projects/ad9208/README
+++ b/projects/ad9208/README
@@ -7,7 +7,6 @@
 	cp ../../include/gpio.h ./
 	cp ../../include/delay.h ./
 	cp ../../drivers/platform/xilinx/axi_io.c ./
-	cp ../../drivers/platform/xilinx/platform_drivers.h ./
 	cp ../../drivers/platform/xilinx/xilinx_platform_drivers.h ./
 	cp ../../drivers/platform/xilinx/spi.c ./
 	cp ../../drivers/platform/xilinx/i2c.c ./

--- a/projects/ad9371/src/README
+++ b/projects/ad9371/src/README
@@ -2,7 +2,6 @@
 # Additional required source files:
 
 #ifdef ALTERA_PLATFORM
-	cp ../../drivers/altera_platform/platform_drivers.h devices/adi_hal/
 	cp ../../drivers/altera_platform/altera_platform_drivers.h devices/adi_hal/
 	cp ../../../include/axi_io.h devices/adi_hal/
 	cp ../../../include/error.h devices/adi_hal/
@@ -40,7 +39,6 @@
 	cp ../../../include/gpio.h devices/adi_hal/
 	cp ../../../include/delay.h devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/axi_io.c devices/adi_hal/
-	cp ../../../drivers/platform/xilinx/platform_drivers.h devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/xilinx_platform_drivers.h devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/spi.c devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/gpio.c devices/adi_hal/

--- a/projects/ad9371/src/app/headless.c
+++ b/projects/ad9371/src/app/headless.c
@@ -46,9 +46,9 @@
 #include "mykonos.h"
 #include "Mykonos_M3.h"
 #include "mykonos_gpio.h"
-#include "platform_drivers.h"
 #include "parameters.h"
 #include "util.h"
+#include "error.h"
 #ifdef ALTERA_PLATFORM
 #include "clk_altera_a10_fpll.h"
 #include "altera_adxcvr.h"

--- a/projects/ad9371/src/devices/adi_hal/common.c
+++ b/projects/ad9371/src/devices/adi_hal/common.c
@@ -16,8 +16,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include "common.h"
+#include "spi.h"
 
-#include "platform_drivers.h"
 #include "parameters.h"
 
 #ifndef ALTERA_PLATFORM

--- a/projects/ad9371/src/devices/adi_hal/parameters.h
+++ b/projects/ad9371/src/devices/adi_hal/parameters.h
@@ -43,7 +43,6 @@
 /***************************** Include Files **********************************/
 /******************************************************************************/
 #include "app_config.h"
-#include "platform_drivers.h"
 #ifdef ALTERA_PLATFORM
 #include "system.h"
 #else

--- a/projects/adrv9009/src/README
+++ b/projects/adrv9009/src/README
@@ -2,7 +2,6 @@
 Additional required source files:
 
 #ifdef ALTERA_PLATFORM
-	cp ../../drivers/altera_platform/platform_drivers.h devices/adi_hal/
 	cp ../../drivers/altera_platform/altera_platform_drivers.h devices/adi_hal/
 	cp ../../../include/axi_io.h devices/adi_hal/
 	cp ../../../include/error.h devices/adi_hal/
@@ -40,7 +39,6 @@ Additional required source files:
 	cp ../../../include/gpio.h devices/adi_hal/
 	cp ../../../include/delay.h devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/axi_io.c devices/adi_hal/
-	cp ../../../drivers/platform/xilinx/platform_drivers.h devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/xilinx_platform_drivers.h devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/spi.c devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/gpio.c devices/adi_hal/

--- a/projects/adrv9009/src/app/headless.c
+++ b/projects/adrv9009/src/app/headless.c
@@ -20,7 +20,7 @@
 
 #include <stdio.h>
 #include "adi_hal.h"
-#include "platform_drivers.h"
+#include "error.h"
 #include "parameters.h"
 #include "util.h"
 #include "ad9528.h"

--- a/projects/adrv9009/src/devices/ad9528/ad9528.c
+++ b/projects/adrv9009/src/devices/ad9528/ad9528.c
@@ -12,6 +12,8 @@
 
 #include "parameters.h"
 #include "ad9528.h"
+#include "spi.h"
+#include "error.h"
 
 static uint32_t _desired_time_to_elapse_ms = 0;
 

--- a/projects/adrv9009/src/devices/ad9528/t_ad9528.h
+++ b/projects/adrv9009/src/devices/ad9528/t_ad9528.h
@@ -13,7 +13,7 @@
 #ifndef _AD9528_TYPES_H_
 #define _AD9528_TYPES_H_
 
-#include "platform_drivers.h"
+#include <stdint.h>
 
 /* AD9528 SPI Address defines */
 #define AD9528_ADDR_ADI_SPI_CONFIG_A	0x000

--- a/projects/adrv9009/src/devices/adi_hal/adi_hal.h
+++ b/projects/adrv9009/src/devices/adi_hal/adi_hal.h
@@ -13,8 +13,6 @@
 #include <stdint.h>
 #include <stddef.h>
 
-#include "platform_drivers.h"
-
 /*========================================
  * Enums and structures
  *=======================================*/

--- a/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
+++ b/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
@@ -43,6 +43,9 @@
 #include <stdio.h>
 #include "adi_hal.h"
 #include "parameters.h"
+#include "spi.h"
+#include "gpio.h"
+#include "error.h"
 
 /******************************************************************************/
 /************************** Functions Implementation **************************/

--- a/projects/adrv9009/src/devices/adi_hal/parameters.h
+++ b/projects/adrv9009/src/devices/adi_hal/parameters.h
@@ -43,7 +43,6 @@
 /***************************** Include Files **********************************/
 /******************************************************************************/
 #include "app_config.h"
-#include "platform_drivers.h"
 #ifdef ALTERA_PLATFORM
 #include "system.h"
 #else

--- a/projects/drivers/axi_adc_core/axi_adc_core.c
+++ b/projects/drivers/axi_adc_core/axi_adc_core.c
@@ -43,7 +43,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <inttypes.h>
-#include "platform_drivers.h"
+#include "error.h"
 #include "util.h"
 #include "axi_adc_core.h"
 #include "axi_io.h"

--- a/projects/drivers/axi_dac_core/axi_dac_core.c
+++ b/projects/drivers/axi_dac_core/axi_dac_core.c
@@ -797,7 +797,7 @@ int32_t axi_dac_load_custom_data(struct axi_dac *dac,
 		for (chan = 0; chan < num_tx_channels; chan++) {
 
 			axi_io_write(address, index_mem * sizeof(uint32_t),
-					  custom_data_iq[index]);
+				     custom_data_iq[index]);
 
 			index_mem++;
 		}

--- a/projects/drivers/axi_dac_core/axi_dac_core.c
+++ b/projects/drivers/axi_dac_core/axi_dac_core.c
@@ -43,7 +43,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <inttypes.h>
-#include "platform_drivers.h"
+#include "error.h"
 #include "util.h"
 #include "axi_dac_core.h"
 #include "axi_io.h"

--- a/projects/drivers/clk_altera_a10_fpll/clk_altera_a10_fpll.c
+++ b/projects/drivers/clk_altera_a10_fpll/clk_altera_a10_fpll.c
@@ -46,9 +46,9 @@
 #include <stdbool.h>
 #include <inttypes.h>
 #include <limits.h>
-#include "platform_drivers.h"
 #include "io.h"
 #include "util.h"
+#include "error.h"
 #include "clk_altera_a10_fpll.h"
 
 /******************************************************************************/

--- a/projects/drivers/clk_axi_clkgen/clk_axi_clkgen.c
+++ b/projects/drivers/clk_axi_clkgen/clk_axi_clkgen.c
@@ -45,7 +45,7 @@
 #include <stdlib.h>
 #include <inttypes.h>
 #include "util.h"
-#include "platform_drivers.h"
+#include "error.h"
 #include "clk_axi_clkgen.h"
 #include "xil_io.h"
 

--- a/projects/drivers/jesd204/altera_adxcvr.c
+++ b/projects/drivers/jesd204/altera_adxcvr.c
@@ -43,8 +43,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <inttypes.h>
-#include "platform_drivers.h"
 #include "io.h"
+#include "error.h"
 #include "util.h"
 #include "altera_a10_atx_pll.h"
 #include "altera_a10_cdr_pll.h"

--- a/projects/drivers/jesd204/axi_adxcvr.c
+++ b/projects/drivers/jesd204/axi_adxcvr.c
@@ -45,7 +45,7 @@
 #include <inttypes.h>
 #include <xil_io.h>
 #include "util.h"
-#include "platform_drivers.h"
+#include "error.h"
 #include "xilinx_transceiver.h"
 #include "axi_adxcvr.h"
 

--- a/projects/drivers/jesd204/axi_jesd204_rx.c
+++ b/projects/drivers/jesd204/axi_jesd204_rx.c
@@ -43,7 +43,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <inttypes.h>
-#include "platform_drivers.h"
+#include "error.h"
 #include "util.h"
 #include "axi_jesd204_rx.h"
 #include "axi_io.h"

--- a/projects/drivers/jesd204/axi_jesd204_tx.c
+++ b/projects/drivers/jesd204/axi_jesd204_tx.c
@@ -43,7 +43,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <inttypes.h>
-#include "platform_drivers.h"
+#include "error.h"
 #include "util.h"
 #include "axi_jesd204_tx.h"
 #include "axi_io.h"

--- a/projects/drivers/jesd204/xilinx_transceiver.c
+++ b/projects/drivers/jesd204/xilinx_transceiver.c
@@ -46,7 +46,7 @@
 #include <inttypes.h>
 #include <xil_io.h>
 #include "util.h"
-#include "platform_drivers.h"
+#include "error.h"
 #include "axi_adxcvr.h"
 #include "xilinx_transceiver.h"
 

--- a/projects/drivers/jesd204/xilinx_transceiver.c
+++ b/projects/drivers/jesd204/xilinx_transceiver.c
@@ -348,7 +348,7 @@ int32_t xilinx_xcvr_configure_lpm_dfe_mode(struct xilinx_xcvr *xcvr,
 }
 
 static void xilinx_xcvr_setup_cpll_vco_range(struct xilinx_xcvr *xcvr,
-					     uint32_t *vco_max)
+		uint32_t *vco_max)
 {
 	if  ((xcvr->type == XILINX_XCVR_TYPE_US_GTH3) |
 	     (xcvr->type == XILINX_XCVR_TYPE_US_GTH4) |
@@ -361,10 +361,10 @@ static void xilinx_xcvr_setup_cpll_vco_range(struct xilinx_xcvr *xcvr,
 }
 
 static void xilinx_xcvr_setup_qpll_vco_range(struct xilinx_xcvr *xcvr,
-					     uint32_t *vco0_min,
-					     uint32_t *vco0_max,
-					     uint32_t *vco1_min,
-					     uint32_t *vco1_max)
+		uint32_t *vco0_min,
+		uint32_t *vco0_max,
+		uint32_t *vco1_min,
+		uint32_t *vco1_max)
 {
 	switch (xcvr->type) {
 	case XILINX_XCVR_TYPE_S7_GTX2:


### PR DESCRIPTION
Remove `platform_drivers.h` header file from projects.

Use header files available in `/include` folder instead.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>