### PR TITLE
projects: remove axi_io from dac dma example

### DIFF
--- a/projects/ad9172/src/main.c
+++ b/projects/ad9172/src/main.c
@@ -149,8 +149,6 @@ int main(void)
 		TX_DMA_BASEADDR,
 		DMA_MEM_TO_DEV,
 		DMA_LAST,
-		axi_io_read,
-		axi_io_write
 	};
 	struct axi_dmac *tx_dmac;
 #endif /* DAC_DMA_EXAMPLE */

--- a/projects/ad9371/src/app/headless.c
+++ b/projects/ad9371/src/app/headless.c
@@ -271,8 +271,6 @@ int main(void)
 		TX_DMA_BASEADDR,
 		DMA_MEM_TO_DEV,
 		DMA_LAST,
-		axi_io_read,
-		axi_io_write
 	};
 	struct axi_dmac *tx_dmac;
 	extern const uint32_t sine_lut_iq[1024];


### PR DESCRIPTION
Remove `axi_io` function pointers from DAC DMA examples.

Related to:  #296

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>