### PR TITLE
projects:drivers: include axi_io header file

### DIFF
--- a/projects/drivers/axi_adc_core/axi_adc_core.c
+++ b/projects/drivers/axi_adc_core/axi_adc_core.c
@@ -46,6 +46,7 @@
 #include "platform_drivers.h"
 #include "util.h"
 #include "axi_adc_core.h"
+#include "axi_io.h"
 
 /***************************************************************************//**
  * @brief axi_adc_read

--- a/projects/drivers/axi_dac_core/axi_dac_core.c
+++ b/projects/drivers/axi_dac_core/axi_dac_core.c
@@ -46,6 +46,7 @@
 #include "platform_drivers.h"
 #include "util.h"
 #include "axi_dac_core.h"
+#include "axi_io.h"
 
 /******************************************************************************/
 /********************** Macros and Constants Definitions **********************/

--- a/projects/drivers/jesd204/axi_jesd204_rx.c
+++ b/projects/drivers/jesd204/axi_jesd204_rx.c
@@ -46,6 +46,7 @@
 #include "platform_drivers.h"
 #include "util.h"
 #include "axi_jesd204_rx.h"
+#include "axi_io.h"
 
 /******************************************************************************/
 /********************** Macros and Constants Definitions **********************/

--- a/projects/drivers/jesd204/axi_jesd204_tx.c
+++ b/projects/drivers/jesd204/axi_jesd204_tx.c
@@ -46,6 +46,7 @@
 #include "platform_drivers.h"
 #include "util.h"
 #include "axi_jesd204_tx.h"
+#include "axi_io.h"
 
 /******************************************************************************/
 /********************** Macros and Constants Definitions **********************/


### PR DESCRIPTION
Make sure the header file is included in all dependent drivers.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>