### PR TITLE
projects: ad9371: add gpio

### DIFF
--- a/projects/ad9371/src/devices/adi_hal/common.c
+++ b/projects/ad9371/src/devices/adi_hal/common.c
@@ -17,6 +17,7 @@
 #include <stdlib.h>
 #include "common.h"
 #include "spi.h"
+#include "gpio.h"
 
 #include "parameters.h"
 


### PR DESCRIPTION
Add gpio header file in `common.c` source file.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>