### PR TITLE
projects: ad9208: update main function

### DIFF
--- a/projects/ad9208/README
+++ b/projects/ad9208/README
@@ -3,13 +3,11 @@
 	cp ../../include/axi_io.h ./
 	cp ../../include/error.h ./
 	cp ../../include/spi.h ./
-	cp ../../include/i2c.h ./
 	cp ../../include/gpio.h ./
 	cp ../../include/delay.h ./
 	cp ../../drivers/platform/xilinx/axi_io.c ./
 	cp ../../drivers/platform/xilinx/xilinx_platform_drivers.h ./
 	cp ../../drivers/platform/xilinx/spi.c ./
-	cp ../../drivers/platform/xilinx/i2c.c ./
 	cp ../../drivers/platform/xilinx/gpio.c ./
 	cp ../../drivers/platform/xilinx/delay.c ./
 	cp ../drivers/util/util.c ./

--- a/projects/ad9208/main.c
+++ b/projects/ad9208/main.c
@@ -53,14 +53,11 @@
 #include "axi_dmac.h"
 #include "parameters.h"
 #include "xil_printf.h"
-#include "platform.h"
 #include "xilinx_platform_drivers.h"
 #include "error.h"
 
 int main(void)
 {
-	init_platform();
-
 	struct xil_spi_init_param xil_spi_param = {.id = SPI_DEVICE_ID, .flags = 0};
 
 	struct spi_init_param hmc7044_spi_param = {
@@ -492,8 +489,6 @@ error_1:
 	hmc7044_remove(hmc7044_device);
 
 	xil_printf("Bye\n");
-
-	cleanup_platform();
 
 	return 0;
 }

--- a/projects/ad9208/main.c
+++ b/projects/ad9208/main.c
@@ -55,6 +55,7 @@
 #include "xil_printf.h"
 #include "xilinx_platform_drivers.h"
 #include "error.h"
+#include "delay.h"
 
 int main(void)
 {


### PR DESCRIPTION
Remove SDK generated `platform.h` header file. Remove associated function calls. The project should be SDK independent.

Remove i2c driver from README file.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>