### PR TITLE
projects & drivers: Add delay header file

### DIFF
--- a/drivers/axi_core/axi_adc_core/axi_adc_core.c
+++ b/drivers/axi_core/axi_adc_core/axi_adc_core.c
@@ -44,6 +44,7 @@
 #include <stdio.h>
 #include <inttypes.h>
 #include "error.h"
+#include "delay.h"
 #include "util.h"
 #include "axi_adc_core.h"
 #include "axi_io.h"

--- a/drivers/axi_core/axi_dac_core/axi_dac_core.c
+++ b/drivers/axi_core/axi_dac_core/axi_dac_core.c
@@ -44,6 +44,7 @@
 #include <stdio.h>
 #include <inttypes.h>
 #include "error.h"
+#include "delay.h"
 #include "util.h"
 #include "axi_dac_core.h"
 #include "axi_io.h"

--- a/drivers/axi_core/axi_dmac/axi_dmac.c
+++ b/drivers/axi_core/axi_dmac/axi_dmac.c
@@ -44,6 +44,7 @@
 #include <stdio.h>
 #include "axi_io.h"
 #include "error.h"
+#include "delay.h"
 #include "axi_dmac.h"
 
 /***************************************************************************//**

--- a/drivers/axi_core/clk_axi_clkgen/clk_axi_clkgen.c
+++ b/drivers/axi_core/clk_axi_clkgen/clk_axi_clkgen.c
@@ -46,6 +46,7 @@
 #include <inttypes.h>
 #include "util.h"
 #include "error.h"
+#include "delay.h"
 #include "clk_axi_clkgen.h"
 #include "xil_io.h"
 

--- a/drivers/axi_core/jesd204/axi_adxcvr.c
+++ b/drivers/axi_core/jesd204/axi_adxcvr.c
@@ -46,6 +46,7 @@
 #include <xil_io.h>
 #include "util.h"
 #include "error.h"
+#include "delay.h"
 #include "xilinx_transceiver.h"
 #include "axi_adxcvr.h"
 

--- a/drivers/axi_core/jesd204/axi_jesd204_rx.c
+++ b/drivers/axi_core/jesd204/axi_jesd204_rx.c
@@ -44,6 +44,7 @@
 #include <stdio.h>
 #include <inttypes.h>
 #include "error.h"
+#include "delay.h"
 #include "util.h"
 #include "axi_jesd204_rx.h"
 #include "axi_io.h"

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -46,6 +46,7 @@
 #include "ad9361_parameters.h"
 #include "spi.h"
 #include "gpio.h"
+#include "delay.h"
 #ifdef XILINX_PLATFORM
 #include "xilinx_platform_drivers.h"
 #include <xil_cache.h>

--- a/projects/ad9371/src/app/headless.c
+++ b/projects/ad9371/src/app/headless.c
@@ -49,6 +49,7 @@
 #include "parameters.h"
 #include "util.h"
 #include "error.h"
+#include "delay.h"
 #ifdef ALTERA_PLATFORM
 #include "clk_altera_a10_fpll.h"
 #include "altera_adxcvr.h"

--- a/projects/ad9371/src/devices/adi_hal/common.c
+++ b/projects/ad9371/src/devices/adi_hal/common.c
@@ -18,6 +18,7 @@
 #include "common.h"
 #include "spi.h"
 #include "gpio.h"
+#include "delay.h"
 
 #include "parameters.h"
 

--- a/projects/adrv9009/src/app/headless.c
+++ b/projects/adrv9009/src/app/headless.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include "adi_hal.h"
 #include "error.h"
+#include "delay.h"
 #include "parameters.h"
 #include "util.h"
 #include "ad9528.h"

--- a/projects/adrv9009/src/devices/ad9528/ad9528.c
+++ b/projects/adrv9009/src/devices/ad9528/ad9528.c
@@ -14,6 +14,7 @@
 #include "ad9528.h"
 #include "spi.h"
 #include "error.h"
+#include "delay.h"
 
 static uint32_t _desired_time_to_elapse_ms = 0;
 

--- a/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
+++ b/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
@@ -46,6 +46,7 @@
 #include "spi.h"
 #include "gpio.h"
 #include "error.h"
+#include "delay.h"
 
 /******************************************************************************/
 /************************** Functions Implementation **************************/


### PR DESCRIPTION
Add delay header file for `mdelay/udelay` function recognition.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>