### PR TITLE
drivers:platform:xilinx: fix options for AXI IIC

### DIFF
--- a/drivers/platform/xilinx/i2c.c
+++ b/drivers/platform/xilinx/i2c.c
@@ -235,7 +235,7 @@ int32_t i2c_write(struct i2c_desc *desc,
 			  desc->slave_address,
 			  data,
 			  bytes_number,
-			  option ? XIIC_STOP : XIIC_REPEATED_START);
+			  option ? XIIC_REPEATED_START : XIIC_STOP);
 		break;
 #endif
 		goto error;
@@ -294,7 +294,7 @@ int32_t i2c_read(struct i2c_desc *desc,
 				desc->slave_address,
 				data,
 				bytes_number,
-				option ? XIIC_STOP : XIIC_REPEATED_START);
+				option ? XIIC_REPEATED_START : XIIC_STOP);
 		if(ret != SUCCESS)
 			goto error;
 


### PR DESCRIPTION
The AXI IIC driver functions XIic_Send and XIic_Recv use the options
argument to control if the transmission ends with a STOP bit or a REPEATED
START. To use the repeated start enum the platform driver must send a 1
value for repeated start and 0 for a stop bit. Fix the implementation to do
that.

Signed-off-by: Andrei Drimbarean <Andrei.Drimbarean@analog.com>