### PR TITLE
altera: update drivers and projects

### DIFF
--- a/drivers/platform/altera/gpio_extra.h
+++ b/drivers/platform/altera/gpio_extra.h
@@ -1,6 +1,6 @@
 /***************************************************************************//**
- *   @file   gpio.h
- *   @author DBogdan (dragos.bogdan@analog.com)
+ *   @file   gpio_extra.h
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
 ********************************************************************************
  * Copyright 2019(c) Analog Devices, Inc.
  *
@@ -36,66 +36,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 
-#ifndef GPIO_H_
-#define GPIO_H_
+#ifndef GPIO_EXTRA_H_
+#define GPIO_EXTRA_H_
 
-/******************************************************************************/
-/***************************** Include Files **********************************/
-/******************************************************************************/
+enum gpio_type {
+	NIOS_II_GPIO
+} gpio_type;
 
-#include <stdint.h>
+typedef struct altera_gpio_desc {
+	enum gpio_type	type;
+	uint32_t		device_id;
+	uint32_t base_address;
+} altera_gpio_desc;
 
-/******************************************************************************/
-/********************** Macros and Constants Definitions **********************/
-/******************************************************************************/
-
-#define GPIO_OUT	0x01
-#define GPIO_IN		0x00
-
-#define GPIO_HIGH	0x01
-#define GPIO_LOW	0x00
-
-/******************************************************************************/
-/*************************** Types Declarations *******************************/
-/******************************************************************************/
-
-typedef struct gpio_desc {
-	uint8_t		number;
-	void		*extra;
-} gpio_desc;
-
-/******************************************************************************/
-/************************ Functions Declarations ******************************/
-/******************************************************************************/
-
-/* Obtain the GPIO decriptor. */
-int32_t gpio_get(struct gpio_desc **desc,
-		 uint8_t gpio_number);
-
-/* Free the resources allocated by gpio_get() */
-int32_t gpio_remove(struct gpio_desc *desc);
-
-/* Enable the input direction of the specified GPIO. */
-int32_t gpio_direction_input(struct gpio_desc *desc);
-
-/* Enable the output direction of the specified GPIO. */
-int32_t gpio_direction_output(struct gpio_desc *desc,
-			      uint8_t value);
-
-/* Get the direction of the specified GPIO. */
-int32_t gpio_get_direction(struct gpio_desc *desc,
-			   uint8_t *direction);
-
-/* Set the value of the specified GPIO. */
-int32_t gpio_set_value(struct gpio_desc *desc,
-		       uint8_t value);
-
-/* Get the value of the specified GPIO. */
-int32_t gpio_get_value(struct gpio_desc *desc,
-		       uint8_t *value);
-
-/* Initialize GPIO. */
-int32_t gpio_init(struct gpio_desc **desc,
-		  uint32_t type, uint32_t base_address);
-
-#endif // GPIO_H_
+#endif /* GPIO_EXTRA_H_ */

--- a/drivers/platform/altera/i2c.c
+++ b/drivers/platform/altera/i2c.c
@@ -44,7 +44,7 @@
 #include <stdlib.h>
 #include "error.h"
 #include "i2c.h"
-#include "altera_platform_drivers.h"
+#include "i2c_extra.h"
 
 /******************************************************************************/
 /************************ Functions Definitions *******************************/

--- a/drivers/platform/altera/i2c_extra.h
+++ b/drivers/platform/altera/i2c_extra.h
@@ -1,6 +1,5 @@
 /***************************************************************************//**
- *   @file   altera_platform_drivers.h
- *   @brief  Header file of Altera Platform Drivers.
+ *   @file   i2c_extra.h
  *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
 ********************************************************************************
  * Copyright 2019(c) Analog Devices, Inc.
@@ -37,15 +36,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 
-#ifndef ALTERA_PLATFORM_DRIVERS_H_
-#define ALTERA_PLATFORM_DRIVERS_H_
-
-/******************************************************************************/
-/*************************** Types Declarations *******************************/
-/******************************************************************************/
+#ifndef I2C_EXTRA_H_
+#define I2C_EXTRA_H_
 
 typedef enum i2c_type {
-	ALTERA_I2C
+	NIOS_II_I2C
 } i2c_type;
 
 typedef struct altera_i2c_init_param {
@@ -58,27 +53,4 @@ typedef struct altera_i2c_desc {
 	uint32_t	id;
 } altera_i2c_desc;
 
-typedef enum spi_type {
-	ALTERA_SPI
-} spi_type;
-
-typedef struct altera_spi_init_param {
-	enum spi_type	type;
-	uint32_t	id;
-} altera_spi_init_param;
-
-typedef struct altera_spi_desc {
-	enum spi_type	type;
-	uint32_t		id;
-} altera_spi_desc;
-
-typedef enum gpio_type {
-	ALTERA_GPIO
-} gpio_type;
-
-typedef struct altera_gpio_desc {
-	enum gpio_type	type;
-	uint32_t		id;
-} altera_gpio_desc;
-
-#endif /* ALTERA_PLATFORM_DRIVERS_H_ */
+#endif /* I2C_EXTRA_H_ */

--- a/drivers/platform/altera/spi.c
+++ b/drivers/platform/altera/spi.c
@@ -46,6 +46,7 @@
 #include "parameters.h"
 #include "error.h"
 #include "spi.h"
+#include "spi_extra.h"
 
 /******************************************************************************/
 /************************ Functions Definitions *******************************/
@@ -61,14 +62,28 @@ int32_t spi_init(struct spi_desc **desc,
 		 const struct spi_init_param *param)
 {
 	spi_desc *descriptor;
+	altera_spi_desc *altera_descriptor;
+	altera_spi_init_param *altera_param;
 
 	descriptor = malloc(sizeof(*descriptor));
 	if (!descriptor)
 		return FAILURE;
 
-	descriptor->chip_select = param->chip_select;
+	descriptor->extra = calloc(1, sizeof *altera_descriptor);
+	if (!(descriptor->extra)) {
+		free(descriptor);
+		return FAILURE;
+	}
 
+	altera_descriptor = descriptor->extra;
+	altera_param = param->extra;
+
+	descriptor->chip_select = param->chip_select;
 	descriptor->mode = param->mode;
+
+	altera_descriptor->type = altera_param->type;
+	altera_descriptor->device_id = altera_param->device_id;
+	altera_descriptor->base_address = altera_param->base_address;
 
 	*desc = descriptor;
 
@@ -102,30 +117,40 @@ int32_t spi_write_and_read(struct spi_desc *desc,
 			   uint8_t bytes_number)
 {
 	uint32_t i;
+	altera_spi_desc *altera_desc;
 
-	IOWR_32DIRECT(SPI_BASEADDR,
-		      (ALTERA_AVALON_SPI_CONTROL_REG * 4),
-		      ALTERA_AVALON_SPI_CONTROL_SSO_MSK);
-	IOWR_32DIRECT(SPI_BASEADDR,
-		      (ALTERA_AVALON_SPI_SLAVE_SEL_REG * 4),
-		      (0x1 << (desc->chip_select)));
-	for (i = 0; i < bytes_number; i++) {
-		while ((IORD_32DIRECT(SPI_BASEADDR,
-				      (ALTERA_AVALON_SPI_STATUS_REG * 4)) &
-			ALTERA_AVALON_SPI_STATUS_TRDY_MSK) == 0x00) {}
-		IOWR_32DIRECT(SPI_BASEADDR,
-			      (ALTERA_AVALON_SPI_TXDATA_REG * 4),
-			      *(data + i));
-		while ((IORD_32DIRECT(SPI_BASEADDR,
-				      (ALTERA_AVALON_SPI_STATUS_REG * 4)) &
-			ALTERA_AVALON_SPI_STATUS_RRDY_MSK) == 0x00) {}
-		*(data + i) = IORD_32DIRECT(SPI_BASEADDR,
-					    (ALTERA_AVALON_SPI_RXDATA_REG * 4));
+	altera_desc = desc->extra;
+
+	switch(altera_desc->type) {
+	case NIOS_II_SPI:
+		IOWR_32DIRECT(altera_desc->base_address,
+			      (ALTERA_AVALON_SPI_CONTROL_REG * 4),
+			      ALTERA_AVALON_SPI_CONTROL_SSO_MSK);
+		IOWR_32DIRECT(altera_desc->base_address,
+			      (ALTERA_AVALON_SPI_SLAVE_SEL_REG * 4),
+			      (0x1 << (desc->chip_select)));
+		for (i = 0; i < bytes_number; i++) {
+			while ((IORD_32DIRECT(altera_desc->base_address,
+					      (ALTERA_AVALON_SPI_STATUS_REG * 4)) &
+				ALTERA_AVALON_SPI_STATUS_TRDY_MSK) == 0x00) {}
+			IOWR_32DIRECT(altera_desc->base_address,
+				      (ALTERA_AVALON_SPI_TXDATA_REG * 4),
+				      *(data + i));
+			while ((IORD_32DIRECT(altera_desc->base_address,
+					      (ALTERA_AVALON_SPI_STATUS_REG * 4)) &
+				ALTERA_AVALON_SPI_STATUS_RRDY_MSK) == 0x00) {}
+			*(data + i) = IORD_32DIRECT(altera_desc->base_address,
+						    (ALTERA_AVALON_SPI_RXDATA_REG * 4));
+		}
+		IOWR_32DIRECT(altera_desc->base_address,
+			      (ALTERA_AVALON_SPI_SLAVE_SEL_REG * 4), 0x000);
+		IOWR_32DIRECT(altera_desc->base_address,
+			      (ALTERA_AVALON_SPI_CONTROL_REG * 4), 0x000);
+
+		break;
+	default:
+		return FAILURE;
 	}
-	IOWR_32DIRECT(SPI_BASEADDR,
-		      (ALTERA_AVALON_SPI_SLAVE_SEL_REG * 4), 0x000);
-	IOWR_32DIRECT(SPI_BASEADDR,
-		      (ALTERA_AVALON_SPI_CONTROL_REG * 4), 0x000);
 
 	return SUCCESS;
 }

--- a/drivers/platform/altera/spi_extra.h
+++ b/drivers/platform/altera/spi_extra.h
@@ -1,6 +1,6 @@
 /***************************************************************************//**
- *   @file   gpio.h
- *   @author DBogdan (dragos.bogdan@analog.com)
+ *   @file   spi_extra.h
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
 ********************************************************************************
  * Copyright 2019(c) Analog Devices, Inc.
  *
@@ -36,66 +36,23 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 
-#ifndef GPIO_H_
-#define GPIO_H_
+#ifndef SPI_EXTRA_H_
+#define SPI_EXTRA_H_
 
-/******************************************************************************/
-/***************************** Include Files **********************************/
-/******************************************************************************/
+typedef enum spi_type {
+	NIOS_II_SPI
+} spi_type;
 
-#include <stdint.h>
+typedef struct altera_spi_init_param {
+	enum spi_type	type;
+	uint32_t	device_id;
+	uint32_t	base_address;
+} altera_spi_init_param;
 
-/******************************************************************************/
-/********************** Macros and Constants Definitions **********************/
-/******************************************************************************/
+typedef struct altera_spi_desc {
+	enum spi_type	type;
+	uint32_t		device_id;
+	uint32_t	base_address;
+} altera_spi_desc;
 
-#define GPIO_OUT	0x01
-#define GPIO_IN		0x00
-
-#define GPIO_HIGH	0x01
-#define GPIO_LOW	0x00
-
-/******************************************************************************/
-/*************************** Types Declarations *******************************/
-/******************************************************************************/
-
-typedef struct gpio_desc {
-	uint8_t		number;
-	void		*extra;
-} gpio_desc;
-
-/******************************************************************************/
-/************************ Functions Declarations ******************************/
-/******************************************************************************/
-
-/* Obtain the GPIO decriptor. */
-int32_t gpio_get(struct gpio_desc **desc,
-		 uint8_t gpio_number);
-
-/* Free the resources allocated by gpio_get() */
-int32_t gpio_remove(struct gpio_desc *desc);
-
-/* Enable the input direction of the specified GPIO. */
-int32_t gpio_direction_input(struct gpio_desc *desc);
-
-/* Enable the output direction of the specified GPIO. */
-int32_t gpio_direction_output(struct gpio_desc *desc,
-			      uint8_t value);
-
-/* Get the direction of the specified GPIO. */
-int32_t gpio_get_direction(struct gpio_desc *desc,
-			   uint8_t *direction);
-
-/* Set the value of the specified GPIO. */
-int32_t gpio_set_value(struct gpio_desc *desc,
-		       uint8_t value);
-
-/* Get the value of the specified GPIO. */
-int32_t gpio_get_value(struct gpio_desc *desc,
-		       uint8_t *value);
-
-/* Initialize GPIO. */
-int32_t gpio_init(struct gpio_desc **desc,
-		  uint32_t type, uint32_t base_address);
-
-#endif // GPIO_H_
+#endif /* SPI_EXTRA_H_ */

--- a/projects/ad9371/src/README
+++ b/projects/ad9371/src/README
@@ -2,7 +2,8 @@
 # Additional required source files:
 
 #ifdef ALTERA_PLATFORM
-	cp ../../../drivers/platform/altera/altera_platform_drivers.h devices/adi_hal/
+	cp ../../../drivers/platform/altera/spi_extra.h devices/adi_hal/
+	cp ../../../drivers/platform/altera/gpio_extra.h devices/adi_hal/
 	cp ../../../include/axi_io.h devices/adi_hal/
 	cp ../../../include/error.h devices/adi_hal/
 	cp ../../../include/spi.h devices/adi_hal/

--- a/projects/ad9371/src/devices/adi_hal/common.c
+++ b/projects/ad9371/src/devices/adi_hal/common.c
@@ -25,7 +25,8 @@
 #ifndef ALTERA_PLATFORM
 #include "xilinx_platform_drivers.h"
 #else
-#include "altera_platform_drivers.h"
+#include "spi_extra.h"
+#include "gpio_extra.h"
 #endif
 
 ADI_LOGLEVEL CMB_LOGLEVEL = ADIHAL_LOG_NONE;
@@ -41,19 +42,26 @@ int32_t platform_init(void)
 	struct spi_init_param spi_param;
 	int32_t status = 0;
 
-	status = gpio_get(&gpio_ad9371_resetb, AD9371_RESET_B);
-	status = gpio_get(&gpio_ad9528_resetb, AD9528_RESET_B);
-	status = gpio_get(&gpio_ad9528_sysref_req, AD9528_SYSREF_REQ);
-
 	spi_param.mode = SPI_MODE_0;
 	spi_param.chip_select = AD9371_CS;
 #ifndef ALTERA_PLATFORM
 	struct xil_spi_init_param xil_param = {.id = SPI_DEVICE_ID, .flags = SPI_CS_DECODE};
 	spi_param.extra = &xil_param;
 #else
-	struct altera_spi_init_param altera_param = {.id = SPI_DEVICE_ID};
+	struct altera_spi_init_param altera_param = {.device_id = SPI_DEVICE_ID, .type = NIOS_II_GPIO,
+		       .base_address = SPI_BASEADDR
+	};
 	spi_param.extra = &altera_param;
+
+	status |= gpio_init(&gpio_ad9371_resetb, NIOS_II_GPIO, GPIO_BASEADDR);
+	status |= gpio_init(&gpio_ad9528_resetb, NIOS_II_GPIO, GPIO_BASEADDR);
+	status |= gpio_init(&gpio_ad9528_sysref_req, NIOS_II_GPIO, GPIO_BASEADDR);
 #endif
+
+	status |= gpio_get(&gpio_ad9371_resetb, AD9371_RESET_B);
+	status |= gpio_get(&gpio_ad9528_resetb, AD9528_RESET_B);
+	status |= gpio_get(&gpio_ad9528_sysref_req, AD9528_SYSREF_REQ);
+
 	status |= spi_init(&spi_ad_desc, &spi_param);
 
 	return status;

--- a/projects/adrv9009/src/README
+++ b/projects/adrv9009/src/README
@@ -2,7 +2,8 @@
 # Additional required source files:
 
 #ifdef ALTERA_PLATFORM
-	cp ../../../drivers/platform/altera/altera_platform_drivers.h devices/adi_hal/
+	cp ../../../drivers/platform/altera/spi_extra.h devices/adi_hal/
+	cp ../../../drivers/platform/altera/gpio_extra.h devices/adi_hal/
 	cp ../../../include/axi_io.h devices/adi_hal/
 	cp ../../../include/error.h devices/adi_hal/
 	cp ../../../include/spi.h devices/adi_hal/

--- a/projects/adrv9009/src/devices/ad9528/ad9528.c
+++ b/projects/adrv9009/src/devices/ad9528/ad9528.c
@@ -13,6 +13,7 @@
 #include "parameters.h"
 #include "ad9528.h"
 #include "spi.h"
+#include "gpio.h"
 #include "error.h"
 #include "delay.h"
 


### PR DESCRIPTION
This patch contains the following modifications for Altera platform
drivers:

1. Split `altera_platform_drivers.h` into `spi_extra.h`, `i2c_extra.h`
and `gpio_extra.h`

2. Add extra parameters `type` and `base address` to spi/i2c/gpio
descriptors. which will be used for read/write operations. (replaces
hardcoded values).

3. Add `gpio_init` function that helps initialization for gpio
descriptors with type/address attributes. (NOTE: this implementation
will change the `gpio.h` header file from `/include` but won't affect
the functionality of other projects/drivers.)

4. Update drivers using the latest added parameters (type, base address)

5. Update projects which are Altera platform dependent from `projects`
folder.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>