### PR TITLE
iio_types: Update read/write and transfer functions.

### DIFF
--- a/iio/iio_types.h
+++ b/iio/iio_types.h
@@ -91,12 +91,14 @@ struct iio_interface_init_par {
 	void *dev_instance;
 	struct iio_device *iio_device;
 	ssize_t (*get_xml)(char** xml, struct iio_device *iio_dev);
-	ssize_t (*transfer_dev_to_mem)(void *dev_instance, size_t bytes_count);
+	ssize_t (*transfer_dev_to_mem)(void *dev_instance, size_t bytes_count,
+				       uint32_t ch_mask);
 	ssize_t (*read_data)(void *dev_instance, char *pbuf, size_t offset,
-			     size_t bytes_count);
-	ssize_t (*transfer_mem_to_dev)(void *dev_instance, size_t bytes_count);
+			     size_t bytes_count, uint32_t ch_mask);
+	ssize_t (*transfer_mem_to_dev)(void *dev_instance, size_t bytes_count,
+				       uint32_t ch_mask);
 	ssize_t (*write_data)(void *dev_instance, char *pbuf, size_t offset,
-			      size_t bytes_count);
+			      size_t bytes_count, uint32_t ch_mask);
 };
 
 struct iio_server_ops {


### PR DESCRIPTION
Add "mask" parameter to function prototypes, that specifies opened
channels. This is necessary for data multiplexing/demultiplexing, in case
that not all channels of a device are opened.

Signed-off-by: Cristian Pop <cristian.pop@analog.com>