### PR TITLE
altera: update drivers and projects

### DIFF
--- a/drivers/platform/altera/gpio_extra.h
+++ b/drivers/platform/altera/gpio_extra.h
@@ -1,0 +1,56 @@
+/***************************************************************************//**
+ *   @file   gpio_extra.h
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2019(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef GPIO_EXTRA_H_
+#define GPIO_EXTRA_H_
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+
+enum gpio_type {
+	NIOS_II_GPIO
+} gpio_type;
+
+struct altera_gpio_desc {
+	enum gpio_type	type;
+	uint32_t		device_id;
+	uint32_t base_address;
+} altera_gpio_desc;
+
+#endif /* GPIO_EXTRA_H_ */

--- a/drivers/platform/altera/i2c.c
+++ b/drivers/platform/altera/i2c.c
@@ -44,7 +44,7 @@
 #include <stdlib.h>
 #include "error.h"
 #include "i2c.h"
-#include "altera_platform_drivers.h"
+#include "i2c_extra.h"
 
 /******************************************************************************/
 /************************ Functions Definitions *******************************/
@@ -63,7 +63,7 @@ int32_t i2c_init(struct i2c_desc **desc,
 		// Unused variable - fix compiler warning
 	}
 
-	if (((altera_i2c_init_param *)param->extra)->type) {
+	if (((struct altera_i2c_init_param *)param->extra)->type) {
 		// Unused variable - fix compiler warning
 	}
 

--- a/drivers/platform/altera/i2c_extra.h
+++ b/drivers/platform/altera/i2c_extra.h
@@ -1,0 +1,60 @@
+/***************************************************************************//**
+ *   @file   i2c_extra.h
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2019(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef I2C_EXTRA_H_
+#define I2C_EXTRA_H_
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+
+enum i2c_type {
+	NIOS_II_I2C
+} i2c_type;
+
+struct altera_i2c_init_param {
+	enum i2c_type	type;
+	uint32_t	id;
+} altera_i2c_init_param;
+
+struct altera_i2c_desc {
+	enum i2c_type	type;
+	uint32_t	id;
+} altera_i2c_desc;
+
+#endif /* I2C_EXTRA_H_ */

--- a/drivers/platform/altera/spi.c
+++ b/drivers/platform/altera/spi.c
@@ -46,6 +46,7 @@
 #include "parameters.h"
 #include "error.h"
 #include "spi.h"
+#include "spi_extra.h"
 
 /******************************************************************************/
 /************************ Functions Definitions *******************************/
@@ -61,14 +62,28 @@ int32_t spi_init(struct spi_desc **desc,
 		 const struct spi_init_param *param)
 {
 	spi_desc *descriptor;
+	struct altera_spi_desc *altera_descriptor;
+	struct altera_spi_init_param *altera_param;
 
 	descriptor = malloc(sizeof(*descriptor));
 	if (!descriptor)
 		return FAILURE;
 
-	descriptor->chip_select = param->chip_select;
+	descriptor->extra = calloc(1, sizeof *altera_descriptor);
+	if (!(descriptor->extra)) {
+		free(descriptor);
+		return FAILURE;
+	}
 
+	altera_descriptor = descriptor->extra;
+	altera_param = param->extra;
+
+	descriptor->chip_select = param->chip_select;
 	descriptor->mode = param->mode;
+
+	altera_descriptor->type = altera_param->type;
+	altera_descriptor->device_id = altera_param->device_id;
+	altera_descriptor->base_address = altera_param->base_address;
 
 	*desc = descriptor;
 
@@ -102,30 +117,40 @@ int32_t spi_write_and_read(struct spi_desc *desc,
 			   uint8_t bytes_number)
 {
 	uint32_t i;
+	struct altera_spi_desc *altera_desc;
 
-	IOWR_32DIRECT(SPI_BASEADDR,
-		      (ALTERA_AVALON_SPI_CONTROL_REG * 4),
-		      ALTERA_AVALON_SPI_CONTROL_SSO_MSK);
-	IOWR_32DIRECT(SPI_BASEADDR,
-		      (ALTERA_AVALON_SPI_SLAVE_SEL_REG * 4),
-		      (0x1 << (desc->chip_select)));
-	for (i = 0; i < bytes_number; i++) {
-		while ((IORD_32DIRECT(SPI_BASEADDR,
-				      (ALTERA_AVALON_SPI_STATUS_REG * 4)) &
-			ALTERA_AVALON_SPI_STATUS_TRDY_MSK) == 0x00) {}
-		IOWR_32DIRECT(SPI_BASEADDR,
-			      (ALTERA_AVALON_SPI_TXDATA_REG * 4),
-			      *(data + i));
-		while ((IORD_32DIRECT(SPI_BASEADDR,
-				      (ALTERA_AVALON_SPI_STATUS_REG * 4)) &
-			ALTERA_AVALON_SPI_STATUS_RRDY_MSK) == 0x00) {}
-		*(data + i) = IORD_32DIRECT(SPI_BASEADDR,
-					    (ALTERA_AVALON_SPI_RXDATA_REG * 4));
+	altera_desc = desc->extra;
+
+	switch(altera_desc->type) {
+	case NIOS_II_SPI:
+		IOWR_32DIRECT(altera_desc->base_address,
+			      (ALTERA_AVALON_SPI_CONTROL_REG * 4),
+			      ALTERA_AVALON_SPI_CONTROL_SSO_MSK);
+		IOWR_32DIRECT(altera_desc->base_address,
+			      (ALTERA_AVALON_SPI_SLAVE_SEL_REG * 4),
+			      (0x1 << (desc->chip_select)));
+		for (i = 0; i < bytes_number; i++) {
+			while ((IORD_32DIRECT(altera_desc->base_address,
+					      (ALTERA_AVALON_SPI_STATUS_REG * 4)) &
+				ALTERA_AVALON_SPI_STATUS_TRDY_MSK) == 0x00) {}
+			IOWR_32DIRECT(altera_desc->base_address,
+				      (ALTERA_AVALON_SPI_TXDATA_REG * 4),
+				      *(data + i));
+			while ((IORD_32DIRECT(altera_desc->base_address,
+					      (ALTERA_AVALON_SPI_STATUS_REG * 4)) &
+				ALTERA_AVALON_SPI_STATUS_RRDY_MSK) == 0x00) {}
+			*(data + i) = IORD_32DIRECT(altera_desc->base_address,
+						    (ALTERA_AVALON_SPI_RXDATA_REG * 4));
+		}
+		IOWR_32DIRECT(altera_desc->base_address,
+			      (ALTERA_AVALON_SPI_SLAVE_SEL_REG * 4), 0x000);
+		IOWR_32DIRECT(altera_desc->base_address,
+			      (ALTERA_AVALON_SPI_CONTROL_REG * 4), 0x000);
+
+		break;
+	default:
+		return FAILURE;
 	}
-	IOWR_32DIRECT(SPI_BASEADDR,
-		      (ALTERA_AVALON_SPI_SLAVE_SEL_REG * 4), 0x000);
-	IOWR_32DIRECT(SPI_BASEADDR,
-		      (ALTERA_AVALON_SPI_CONTROL_REG * 4), 0x000);
 
 	return SUCCESS;
 }

--- a/drivers/platform/altera/spi_extra.h
+++ b/drivers/platform/altera/spi_extra.h
@@ -1,6 +1,5 @@
 /***************************************************************************//**
- *   @file   altera_platform_drivers.h
- *   @brief  Header file of Altera Platform Drivers.
+ *   @file   spi_extra.h
  *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
 ********************************************************************************
  * Copyright 2019(c) Analog Devices, Inc.
@@ -37,48 +36,27 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 
-#ifndef ALTERA_PLATFORM_DRIVERS_H_
-#define ALTERA_PLATFORM_DRIVERS_H_
+#ifndef SPI_EXTRA_H_
+#define SPI_EXTRA_H_
 
 /******************************************************************************/
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
-typedef enum i2c_type {
-	ALTERA_I2C
-} i2c_type;
-
-typedef struct altera_i2c_init_param {
-	enum i2c_type	type;
-	uint32_t	id;
-} altera_i2c_init_param;
-
-typedef struct altera_i2c_desc {
-	enum i2c_type	type;
-	uint32_t	id;
-} altera_i2c_desc;
-
-typedef enum spi_type {
-	ALTERA_SPI
+enum spi_type {
+	NIOS_II_SPI
 } spi_type;
 
-typedef struct altera_spi_init_param {
+struct altera_spi_init_param {
 	enum spi_type	type;
-	uint32_t	id;
+	uint32_t	device_id;
+	uint32_t	base_address;
 } altera_spi_init_param;
 
-typedef struct altera_spi_desc {
+struct altera_spi_desc {
 	enum spi_type	type;
-	uint32_t		id;
+	uint32_t		device_id;
+	uint32_t	base_address;
 } altera_spi_desc;
 
-typedef enum gpio_type {
-	ALTERA_GPIO
-} gpio_type;
-
-typedef struct altera_gpio_desc {
-	enum gpio_type	type;
-	uint32_t		id;
-} altera_gpio_desc;
-
-#endif /* ALTERA_PLATFORM_DRIVERS_H_ */
+#endif /* SPI_EXTRA_H_ */

--- a/projects/ad9371/src/README
+++ b/projects/ad9371/src/README
@@ -2,7 +2,8 @@
 # Additional required source files:
 
 #ifdef ALTERA_PLATFORM
-	cp ../../../drivers/platform/altera/altera_platform_drivers.h devices/adi_hal/
+	cp ../../../drivers/platform/altera/spi_extra.h devices/adi_hal/
+	cp ../../../drivers/platform/altera/gpio_extra.h devices/adi_hal/
 	cp ../../../include/axi_io.h devices/adi_hal/
 	cp ../../../include/error.h devices/adi_hal/
 	cp ../../../include/spi.h devices/adi_hal/

--- a/projects/ad9371/src/devices/adi_hal/common.c
+++ b/projects/ad9371/src/devices/adi_hal/common.c
@@ -25,7 +25,8 @@
 #ifndef ALTERA_PLATFORM
 #include "xilinx_platform_drivers.h"
 #else
-#include "altera_platform_drivers.h"
+#include "spi_extra.h"
+#include "gpio_extra.h"
 #endif
 
 ADI_LOGLEVEL CMB_LOGLEVEL = ADIHAL_LOG_NONE;
@@ -51,7 +52,11 @@ int32_t platform_init(void)
 	struct xil_spi_init_param xil_param = {.id = SPI_DEVICE_ID, .flags = SPI_CS_DECODE};
 	spi_param.extra = &xil_param;
 #else
-	struct altera_spi_init_param altera_param = {.id = SPI_DEVICE_ID};
+	struct altera_spi_init_param altera_param = {
+		.device_id = SPI_DEVICE_ID,
+		.type = NIOS_II_GPIO,
+		.base_address = SPI_BASEADDR
+	};
 	spi_param.extra = &altera_param;
 #endif
 	status |= spi_init(&spi_ad_desc, &spi_param);

--- a/projects/adrv9009/src/README
+++ b/projects/adrv9009/src/README
@@ -2,7 +2,8 @@
 # Additional required source files:
 
 #ifdef ALTERA_PLATFORM
-	cp ../../../drivers/platform/altera/altera_platform_drivers.h devices/adi_hal/
+	cp ../../../drivers/platform/altera/spi_extra.h devices/adi_hal/
+	cp ../../../drivers/platform/altera/gpio_extra.h devices/adi_hal/
 	cp ../../../include/axi_io.h devices/adi_hal/
 	cp ../../../include/error.h devices/adi_hal/
 	cp ../../../include/spi.h devices/adi_hal/

--- a/projects/adrv9009/src/app/headless.c
+++ b/projects/adrv9009/src/app/headless.c
@@ -20,6 +20,8 @@
 
 #include <stdio.h>
 #include "adi_hal.h"
+#include "gpio.h"
+#include "spi.h"
 #include "error.h"
 #include "delay.h"
 #include "parameters.h"
@@ -28,7 +30,8 @@
 #ifdef ALTERA_PLATFORM
 #include "clk_altera_a10_fpll.h"
 #include "altera_adxcvr.h"
-#include "altera_platform_drivers.h"
+#include "spi_extra.h"
+#include "gpio_extra.h"
 #else
 #include "xil_cache.h"
 #include "clk_axi_clkgen.h"
@@ -68,6 +71,11 @@ int main(void)
 	};
 	ad9528Device_t *clockAD9528_device = &clockAD9528_;
 #ifdef ALTERA_PLATFORM
+	struct altera_spi_init_param ad9528_spi_param = {
+		.device_id = 0, 
+		.base_address = SPI_BASEADDR
+		};
+	clockAD9528_.extra = &ad9528_spi_param;
 	struct altera_a10_fpll_init rx_device_clk_pll_init = {
 		"rx_device_clk_pll",
 		RX_A10_FPLL_BASEADDR,
@@ -249,8 +257,13 @@ int main(void)
 	struct adi_hal hal;
 #ifndef ALTERA_PLATFORM
 	xil_spi_init_param hal_spi_param = {.id = 0, .flags = SPI_CS_DECODE};
-	hal.extra = &hal_spi_param;
+#else
+	struct altera_spi_init_param hal_spi_param = {
+		.type = NIOS_II_SPI, 
+		.base_address = SPI_BASEADDR
+		};
 #endif
+	hal.extra = &hal_spi_param;
 	taliseDevice_t talDev = {
 		.devHalInfo = &hal,
 		.devStateInfo = {0}

--- a/projects/adrv9009/src/app/headless.c
+++ b/projects/adrv9009/src/app/headless.c
@@ -72,9 +72,9 @@ int main(void)
 	ad9528Device_t *clockAD9528_device = &clockAD9528_;
 #ifdef ALTERA_PLATFORM
 	struct altera_spi_init_param ad9528_spi_param = {
-		.device_id = 0, 
+		.device_id = 0,
 		.base_address = SPI_BASEADDR
-		};
+	};
 	clockAD9528_.extra = &ad9528_spi_param;
 	struct altera_a10_fpll_init rx_device_clk_pll_init = {
 		"rx_device_clk_pll",
@@ -259,9 +259,9 @@ int main(void)
 	xil_spi_init_param hal_spi_param = {.id = 0, .flags = SPI_CS_DECODE};
 #else
 	struct altera_spi_init_param hal_spi_param = {
-		.type = NIOS_II_SPI, 
+		.type = NIOS_II_SPI,
 		.base_address = SPI_BASEADDR
-		};
+	};
 #endif
 	hal.extra = &hal_spi_param;
 	taliseDevice_t talDev = {

--- a/projects/adrv9009/src/devices/ad9528/ad9528.c
+++ b/projects/adrv9009/src/devices/ad9528/ad9528.c
@@ -13,6 +13,7 @@
 #include "parameters.h"
 #include "ad9528.h"
 #include "spi.h"
+#include "gpio.h"
 #include "error.h"
 #include "delay.h"
 


### PR DESCRIPTION
This patch contains the following modifications for Altera platform
drivers:

1. Split `altera_platform_drivers.h` into `spi_extra.h`, `i2c_extra.h`
and `gpio_extra.h`

2. Add extra parameters `type` and `base address` to spi/i2c/gpio
descriptors. which will be used for read/write operations. (replaces
hardcoded values).

3. Update drivers using the latest added parameters (type, base address)

4. Update projects which are Altera platform dependent from `projects`
folder.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>