### PR TITLE
iio_types: Add channel type information to "struct iio_channel".

### DIFF
--- a/iio/iio_types.h
+++ b/iio/iio_types.h
@@ -65,6 +65,7 @@ struct iio_attribute {
 struct iio_channel {
 	char *name;
 	struct iio_attribute **attributes;
+	bool ch_out;
 };
 
 struct iio_device {


### PR DESCRIPTION
This is necessary to differentiate, between input and output channels, with
the same name, but have different lists of attributes. This is useful when
reading or writing all the attributes of a channel.

Signed-off-by: Cristian Pop <cristian.pop@analog.com>