### PR TITLE
Added -e switch to echo for backslash escapes

### DIFF
--- a/tools/scripts/Makefile
+++ b/tools/scripts/Makefile
@@ -31,8 +31,8 @@ endif
 
 EXEC = release
 TIMESTAMP = $(shell date +"%T")
-ECHO = @echo -n "\\e[32m[$(TIMESTAMP)]\\e[39m"
-ERROR = @echo -n "\\e[32m[$(TIMESTAMP)]\\e[31m"
+ECHO = @echo -n -e "\\e[32m[$(TIMESTAMP)]\\e[39m"
+ERROR = @echo -n -e "\\e[32m[$(TIMESTAMP)]\\e[31m"
 CC ?= gcc
 
 # Xilinx platform handling


### PR DESCRIPTION
Previously, on a Linux gnome-terminal, the output of the make
command was uncoloured and contained the explicit color codes like

$ make clean
\e[32m[17:09:49]\e[39m Cleaning build workspace \n