### PR TITLE
drivers: apply standard code style

### DIFF
--- a/drivers/adc/ad717x/ad7172_2_regs.h
+++ b/drivers/adc/ad717x/ad7172_2_regs.h
@@ -45,12 +45,11 @@
 
 #ifdef AD7172_2_INIT
 /*! Array holding the info for the AD7172_2 registers - address, initial value, size */
-ad717x_st_reg ad7172_2_regs[] =
-{
+ad717x_st_reg ad7172_2_regs[] = {
 	{ AD717X_STATUS_REG, 0x00, 1 },
 	{ AD717X_ADCMODE_REG, 0x0000, 2	},
 	{
-		AD717X_IFMODE_REG, 
+		AD717X_IFMODE_REG,
 		AD717X_IFMODE_REG_DOUT_RESET | AD717X_IFMODE_REG_CRC_EN,
 		2
 	},
@@ -59,7 +58,7 @@ ad717x_st_reg ad7172_2_regs[] =
 	{ AD717X_GPIOCON_REG, 0x0000, 2 },
 	{ AD717X_ID_REG, 0x0000, 2 },
 	{
-		AD717X_CHMAP0_REG, 
+		AD717X_CHMAP0_REG,
 		AD717X_CHMAP_REG_CH_EN | AD717X_CHMAP_REG_AINNEG(2),
 		2
 	},

--- a/drivers/adc/ad717x/ad7172_4_regs.h
+++ b/drivers/adc/ad717x/ad7172_4_regs.h
@@ -45,12 +45,11 @@
 
 #ifdef AD7172_4_INIT
 /*! Array holding the info for the AD7172_4 registers - address, initial value, size */
-ad717x_st_reg ad7172_4_regs[] =
-{
+ad717x_st_reg ad7172_4_regs[] = {
 	{ AD717X_STATUS_REG, 0x00, 1 },
 	{ AD717X_ADCMODE_REG, 0x0000, 2 },
 	{
-		AD717X_IFMODE_REG, 
+		AD717X_IFMODE_REG,
 		AD717X_IFMODE_REG_DOUT_RESET | AD717X_IFMODE_REG_CRC_EN,
 		2
 	},
@@ -59,7 +58,7 @@ ad717x_st_reg ad7172_4_regs[] =
 	{ AD717X_GPIOCON_REG, 0x0000, 2 },
 	{ AD717X_ID_REG, 0x0000, 2 },
 	{
-		AD717X_CHMAP0_REG, 
+		AD717X_CHMAP0_REG,
 		AD717X_CHMAP_REG_CH_EN | AD717X_CHMAP_REG_AINNEG(2),
 		2
 	},

--- a/drivers/adc/ad717x/ad7173_8_regs.h
+++ b/drivers/adc/ad717x/ad7173_8_regs.h
@@ -45,12 +45,11 @@
 
 #ifdef AD7173_8_INIT
 /*! Array holding the info for the AD7173_8 registers - address, initial value, size */
-ad717x_st_reg ad7173_8_regs[] =
-{
+ad717x_st_reg ad7173_8_regs[] = {
 	{ AD717X_STATUS_REG, 0x00, 1 },
 	{ AD717X_ADCMODE_REG, 0x0000, 2 },
 	{
-		AD717X_IFMODE_REG, 
+		AD717X_IFMODE_REG,
 		AD717X_IFMODE_REG_DOUT_RESET | AD717X_IFMODE_REG_CRC_EN,
 		2
 	},
@@ -59,7 +58,7 @@ ad717x_st_reg ad7173_8_regs[] =
 	{ AD717X_GPIOCON_REG, 0x0000, 2 },
 	{ AD717X_ID_REG, 0x0000, 2 },
 	{
-		AD717X_CHMAP0_REG, 
+		AD717X_CHMAP0_REG,
 		AD717X_CHMAP_REG_CH_EN | AD717X_CHMAP_REG_AINNEG(2),
 		2
 	},

--- a/drivers/adc/ad717x/ad7175_2_regs.h
+++ b/drivers/adc/ad717x/ad7175_2_regs.h
@@ -45,12 +45,11 @@
 
 #ifdef AD7175_2_INIT
 /*! Array holding the info for the AD7175_2 registers - address, initial value, size */
-ad717x_st_reg ad7175_2_regs[] =
-{
+ad717x_st_reg ad7175_2_regs[] = {
 	{ AD717X_STATUS_REG, 0x00, 1 },
 	{ AD717X_ADCMODE_REG, 0x0000, 2	},
 	{
-		AD717X_IFMODE_REG, 
+		AD717X_IFMODE_REG,
 		AD717X_IFMODE_REG_DOUT_RESET | AD717X_IFMODE_REG_CRC_EN,
 		2
 	},
@@ -59,7 +58,7 @@ ad717x_st_reg ad7175_2_regs[] =
 	{ AD717X_GPIOCON_REG, 0x0000, 2 },
 	{ AD717X_ID_REG, 0x0000, 2 },
 	{
-		AD717X_CHMAP0_REG, 
+		AD717X_CHMAP0_REG,
 		AD717X_CHMAP_REG_CH_EN | AD717X_CHMAP_REG_AINNEG(2),
 		2
 	},

--- a/drivers/adc/ad717x/ad7175_8_regs.h
+++ b/drivers/adc/ad717x/ad7175_8_regs.h
@@ -45,12 +45,11 @@
 
 #ifdef AD7175_8_INIT
 /*! Array holding the info for the AD7175_8 registers - address, initial value, size */
-ad717x_st_reg ad7175_8_regs[] =
-{
+ad717x_st_reg ad7175_8_regs[] = {
 	{ AD717X_STATUS_REG, 0x00, 1 },
 	{ AD717X_ADCMODE_REG, 0x0000, 2 },
 	{
-		AD717X_IFMODE_REG, 
+		AD717X_IFMODE_REG,
 		AD717X_IFMODE_REG_DOUT_RESET | AD717X_IFMODE_REG_CRC_EN,
 		2
 	},
@@ -59,7 +58,7 @@ ad717x_st_reg ad7175_8_regs[] =
 	{ AD717X_GPIOCON_REG, 0x0000, 2 },
 	{ AD717X_ID_REG, 0x0000, 2 },
 	{
-		AD717X_CHMAP0_REG, 
+		AD717X_CHMAP0_REG,
 		AD717X_CHMAP_REG_CH_EN | AD717X_CHMAP_REG_AINNEG(2),
 		2
 	},

--- a/drivers/adc/ad717x/ad7176_2_regs.h
+++ b/drivers/adc/ad717x/ad7176_2_regs.h
@@ -46,12 +46,11 @@
 
 #ifdef AD7176_2_INIT
 /*! Array holding the info for the AD7176_2 registers - address, initial value, size */
-ad717x_st_reg ad7176_2_regs[] =
-{
+ad717x_st_reg ad7176_2_regs[] = {
 	{ AD717X_STATUS_REG, 0x00, 1 },
 	{ AD717X_ADCMODE_REG, 0x0000, 2 },
 	{
-		AD717X_IFMODE_REG, 
+		AD717X_IFMODE_REG,
 		AD717X_IFMODE_REG_DOUT_RESET | AD717X_IFMODE_REG_CRC_EN,
 		2
 	},
@@ -60,7 +59,7 @@ ad717x_st_reg ad7176_2_regs[] =
 	{ AD717X_GPIOCON_REG, 0x0000, 2 },
 	{ AD717X_ID_REG, 0x0000, 2 },
 	{
-		AD717X_CHMAP0_REG, 
+		AD717X_CHMAP0_REG,
 		AD717X_CHMAP_REG_CH_EN | AD717X_CHMAP_REG_AINNEG(2),
 		2
 	},

--- a/drivers/adc/ad717x/ad7177_2_regs.h
+++ b/drivers/adc/ad717x/ad7177_2_regs.h
@@ -45,12 +45,11 @@
 
 #ifdef AD7172_2_INIT
 /*! Array holding the info for the AD7172_2 registers - address, initial value, size */
-ad717x_st_reg ad7172_2_regs[] =
-{
+ad717x_st_reg ad7172_2_regs[] = {
 	{ AD717X_STATUS_REG, 0x00, 1 },
 	{ AD717X_ADCMODE_REG, 0x0000, 2	},
 	{
-		AD717X_IFMODE_REG, 
+		AD717X_IFMODE_REG,
 		AD717X_IFMODE_REG_DOUT_RESET | AD717X_IFMODE_REG_CRC_EN,
 		2
 	},
@@ -59,7 +58,7 @@ ad717x_st_reg ad7172_2_regs[] =
 	{ AD717X_GPIOCON_REG, 0x0000, 2 },
 	{ AD717X_ID_REG, 0x0000, 2 },
 	{
-		AD717X_CHMAP0_REG, 
+		AD717X_CHMAP0_REG,
 		AD717X_CHMAP_REG_CH_EN | AD717X_CHMAP_REG_AINNEG(2),
 		2
 	},

--- a/drivers/adc/ad7768/ad7768.c
+++ b/drivers/adc/ad7768/ad7768.c
@@ -46,16 +46,16 @@
 
 const uint8_t standard_pin_ctrl_mode_sel[3][4] = {
 //		MCLK/1,	MCLK/2,	MCLK/4,	MCLK/8
-		{0x0,	0x1,	0x2,	0x3},	// Eco
-		{0x4,	0x5,	0x6,	0x7},	// Median
-		{0x8,	0x9,	0xA,	0xB},	// Fast
+	{0x0,	0x1,	0x2,	0x3},	// Eco
+	{0x4,	0x5,	0x6,	0x7},	// Median
+	{0x8,	0x9,	0xA,	0xB},	// Fast
 };
 
 const uint8_t one_shot_pin_ctrl_mode_sel[3][4] = {
 //		MCLK/1,	MCLK/2,	MCLK/4,	MCLK/8
-		{0xC,	0xFF,	0xFF,	0xFF},	// Eco
-		{0xD,	0xFF,	0xFF,	0xFF},	// Median
-		{0xF,	0xE,	0xFF,	0xFF},	// Fast
+	{0xC,	0xFF,	0xFF,	0xFF},	// Eco
+	{0xD,	0xFF,	0xFF,	0xFF},	// Median
+	{0xF,	0xE,	0xFF,	0xFF},	// Fast
 };
 
 /**
@@ -66,8 +66,8 @@ const uint8_t one_shot_pin_ctrl_mode_sel[3][4] = {
  * @return 0 in case of success, negative error code otherwise.
  */
 int32_t ad7768_spi_read(ad7768_dev *dev,
-						uint8_t reg_addr,
-						uint8_t *reg_data)
+			uint8_t reg_addr,
+			uint8_t *reg_data)
 {
 	uint8_t buf[2];
 	int32_t ret;
@@ -92,8 +92,8 @@ int32_t ad7768_spi_read(ad7768_dev *dev,
  * @return 0 in case of success, negative error code otherwise.
  */
 int32_t ad7768_spi_write(ad7768_dev *dev,
-						 uint8_t reg_addr,
-						 uint8_t reg_data)
+			 uint8_t reg_addr,
+			 uint8_t reg_data)
 {
 	uint8_t buf[2];
 	int32_t ret;
@@ -114,9 +114,9 @@ int32_t ad7768_spi_write(ad7768_dev *dev,
  * @return 0 in case of success, negative error code otherwise.
  */
 int32_t ad7768_spi_read_mask(ad7768_dev *dev,
-							 uint8_t reg_addr,
-							 uint8_t mask,
-							 uint8_t *data)
+			     uint8_t reg_addr,
+			     uint8_t mask,
+			     uint8_t *data)
 {
 	uint8_t reg_data;
 	int32_t ret;
@@ -136,9 +136,9 @@ int32_t ad7768_spi_read_mask(ad7768_dev *dev,
  * @return 0 in case of success, negative error code otherwise.
  */
 int32_t ad7768_spi_write_mask(ad7768_dev *dev,
-							  uint8_t reg_addr,
-							  uint8_t mask,
-							  uint8_t data)
+			      uint8_t reg_addr,
+			      uint8_t mask,
+			      uint8_t data)
 {
 	uint8_t reg_data;
 	int32_t ret;
@@ -160,12 +160,12 @@ int32_t ad7768_spi_write_mask(ad7768_dev *dev,
  * @return 0 in case of success, negative error code otherwise.
  */
 int32_t ad7768_set_sleep_mode(ad7768_dev *dev,
-							  ad7768_sleep_mode mode)
+			      ad7768_sleep_mode mode)
 {
 	ad7768_spi_write_mask(dev,
-						  AD7768_REG_PWR_MODE,
-						  AD7768_PWR_MODE_SLEEP_MODE,
-						  (mode ? AD7768_PWR_MODE_SLEEP_MODE : 0));
+			      AD7768_REG_PWR_MODE,
+			      AD7768_PWR_MODE_SLEEP_MODE,
+			      (mode ? AD7768_PWR_MODE_SLEEP_MODE : 0));
 	dev->sleep_mode = mode;
 
 	return 0;
@@ -178,7 +178,7 @@ int32_t ad7768_set_sleep_mode(ad7768_dev *dev,
  * @return 0 in case of success, negative error code otherwise.
  */
 int32_t ad7768_get_sleep_mode(ad7768_dev *dev,
-							  ad7768_sleep_mode *mode)
+			      ad7768_sleep_mode *mode)
 {
 	*mode = dev->sleep_mode;
 
@@ -192,20 +192,20 @@ int32_t ad7768_get_sleep_mode(ad7768_dev *dev,
  * @return 0 in case of success, negative error code otherwise.
  */
 int32_t ad7768_set_mode_pins(ad7768_dev *dev,
-							 uint8_t state)
+			     uint8_t state)
 {
 	int32_t ret;
 
 	if (dev->gpio_mode0 && dev->gpio_mode1 &&
-			dev->gpio_mode2 && dev->gpio_mode3) {
+	    dev->gpio_mode2 && dev->gpio_mode3) {
 		ret = gpio_set_value(dev->gpio_mode0,
-						((state & 0x01) >> 0));
+				     ((state & 0x01) >> 0));
 		ret |= gpio_set_value(dev->gpio_mode1,
-						((state & 0x02) >> 1));
+				      ((state & 0x02) >> 1));
 		ret |= gpio_set_value(dev->gpio_mode2,
-						((state & 0x04) >> 2));
+				      ((state & 0x04) >> 2));
 		ret |= gpio_set_value(dev->gpio_mode3,
-						((state & 0x08) >> 3));
+				      ((state & 0x08) >> 3));
 	} else {
 		printf ("MODE GPIOs are not defined.");
 		ret = -1;
@@ -224,28 +224,27 @@ int32_t ad7768_set_mode_pins(ad7768_dev *dev,
  * @return 0 in case of success, negative error code otherwise.
  */
 int32_t ad7768_set_power_mode(ad7768_dev *dev,
-							  ad7768_power_mode mode)
+			      ad7768_power_mode mode)
 {
 	uint8_t mode_pins_state;
 
 	if (dev->pin_spi_ctrl == AD7768_SPI_CTRL) {
 		ad7768_spi_write_mask(dev,
-							  AD7768_REG_PWR_MODE,
-							  AD7768_PWR_MODE_POWER_MODE(0x3),
-							  AD7768_PWR_MODE_POWER_MODE(mode));
+				      AD7768_REG_PWR_MODE,
+				      AD7768_PWR_MODE_POWER_MODE(0x3),
+				      AD7768_PWR_MODE_POWER_MODE(mode));
 		dev->power_mode = mode;
 	} else {
 		if (dev->conv_op == AD7768_STANDARD_CONV)
 			mode_pins_state =
-					standard_pin_ctrl_mode_sel[mode][dev->dclk_div];
+				standard_pin_ctrl_mode_sel[mode][dev->dclk_div];
 		else
 			mode_pins_state =
-					one_shot_pin_ctrl_mode_sel[mode][dev->dclk_div];
+				one_shot_pin_ctrl_mode_sel[mode][dev->dclk_div];
 		if (mode_pins_state != 0xFF) {
 			dev->power_mode = mode;
 			ad7768_set_mode_pins(dev, mode_pins_state);
-		}
-		else {
+		} else {
 			printf("Invalid Power Mode for the current configuration.");
 
 			return -1;
@@ -262,7 +261,7 @@ int32_t ad7768_set_power_mode(ad7768_dev *dev,
  * @return 0 in case of success, negative error code otherwise.
  */
 int32_t ad7768_get_power_mode(ad7768_dev *dev,
-							  ad7768_power_mode *mode)
+			      ad7768_power_mode *mode)
 {
 	*mode = dev->power_mode;
 
@@ -279,12 +278,12 @@ int32_t ad7768_get_power_mode(ad7768_dev *dev,
  * @return 0 in case of success, negative error code otherwise.
  */
 int32_t ad7768_set_mclk_div(ad7768_dev *dev,
-							ad7768_mclk_div clk_div)
+			    ad7768_mclk_div clk_div)
 {
 	ad7768_spi_write_mask(dev,
-						  AD7768_REG_PWR_MODE,
-						  AD7768_PWR_MODE_MCLK_DIV(0x3),
-						  AD7768_PWR_MODE_MCLK_DIV(clk_div));
+			      AD7768_REG_PWR_MODE,
+			      AD7768_PWR_MODE_MCLK_DIV(0x3),
+			      AD7768_PWR_MODE_MCLK_DIV(clk_div));
 	dev->mclk_div = clk_div;
 
 	return 0;
@@ -297,7 +296,7 @@ int32_t ad7768_set_mclk_div(ad7768_dev *dev,
  * @return 0 in case of success, negative error code otherwise.
  */
 int32_t ad7768_get_mclk_div(ad7768_dev *dev,
-							ad7768_mclk_div *clk_div)
+			    ad7768_mclk_div *clk_div)
 {
 	*clk_div = dev->mclk_div;
 
@@ -315,28 +314,27 @@ int32_t ad7768_get_mclk_div(ad7768_dev *dev,
  * @return 0 in case of success, negative error code otherwise.
  */
 int32_t ad7768_set_dclk_div(ad7768_dev *dev,
-							ad7768_dclk_div clk_div)
+			    ad7768_dclk_div clk_div)
 {
 	uint8_t mode_pins_state;
 
 	if (dev->pin_spi_ctrl == AD7768_SPI_CTRL) {
 		ad7768_spi_write_mask(dev,
-							  AD7768_REG_INTERFACE_CFG,
-							  AD7768_INTERFACE_CFG_DCLK_DIV(0x3),
-							  AD7768_INTERFACE_CFG_DCLK_DIV(clk_div));
+				      AD7768_REG_INTERFACE_CFG,
+				      AD7768_INTERFACE_CFG_DCLK_DIV(0x3),
+				      AD7768_INTERFACE_CFG_DCLK_DIV(clk_div));
 		dev->dclk_div = clk_div;
 	} else {
 		if (dev->conv_op == AD7768_STANDARD_CONV)
 			mode_pins_state =
-					standard_pin_ctrl_mode_sel[dev->power_mode][clk_div];
+				standard_pin_ctrl_mode_sel[dev->power_mode][clk_div];
 		else
 			mode_pins_state =
-					one_shot_pin_ctrl_mode_sel[dev->power_mode][clk_div];
+				one_shot_pin_ctrl_mode_sel[dev->power_mode][clk_div];
 		if (mode_pins_state != 0xFF) {
 			dev->dclk_div = clk_div;
 			ad7768_set_mode_pins(dev, mode_pins_state);
-		}
-		else {
+		} else {
 			printf("Invalid DCLK_DIV for the current configuration.");
 
 			return -1;
@@ -353,7 +351,7 @@ int32_t ad7768_set_dclk_div(ad7768_dev *dev,
  * @return 0 in case of success, negative error code otherwise.
  */
 int32_t ad7768_get_dclk_div(ad7768_dev *dev,
-							ad7768_dclk_div *clk_div)
+			    ad7768_dclk_div *clk_div)
 {
 	*clk_div = dev->dclk_div;
 
@@ -370,28 +368,27 @@ int32_t ad7768_get_dclk_div(ad7768_dev *dev,
  * @return 0 in case of success, negative error code otherwise.
  */
 int32_t ad7768_set_conv_op(ad7768_dev *dev,
-						   ad7768_conv_op conv_op)
+			   ad7768_conv_op conv_op)
 {
 	uint8_t mode_pins_state;
 
 	if (dev->pin_spi_ctrl == AD7768_SPI_CTRL) {
 		ad7768_spi_write_mask(dev,
-							  AD7768_REG_DATA_CTRL,
-							  AD7768_DATA_CTRL_SINGLE_SHOT_EN,
-							  conv_op ? AD7768_DATA_CTRL_SINGLE_SHOT_EN : 0);
+				      AD7768_REG_DATA_CTRL,
+				      AD7768_DATA_CTRL_SINGLE_SHOT_EN,
+				      conv_op ? AD7768_DATA_CTRL_SINGLE_SHOT_EN : 0);
 		dev->conv_op = conv_op;
 	} else {
 		if (conv_op == AD7768_STANDARD_CONV)
 			mode_pins_state =
-					standard_pin_ctrl_mode_sel[dev->power_mode][dev->dclk_div];
+				standard_pin_ctrl_mode_sel[dev->power_mode][dev->dclk_div];
 		else
 			mode_pins_state =
-					one_shot_pin_ctrl_mode_sel[dev->power_mode][dev->dclk_div];
+				one_shot_pin_ctrl_mode_sel[dev->power_mode][dev->dclk_div];
 		if (mode_pins_state != 0xFF) {
 			dev->conv_op = conv_op;
 			ad7768_set_mode_pins(dev, mode_pins_state);
-		}
-		else {
+		} else {
 			printf("Invalid Conversion Operation for the current configuration.");
 
 			return -1;
@@ -408,7 +405,7 @@ int32_t ad7768_set_conv_op(ad7768_dev *dev,
  * @return 0 in case of success, negative error code otherwise.
  */
 int32_t ad7768_get_conv_op(ad7768_dev *dev,
-						   ad7768_conv_op *conv_op)
+			   ad7768_conv_op *conv_op)
 {
 	*conv_op = dev->conv_op;
 
@@ -425,12 +422,12 @@ int32_t ad7768_get_conv_op(ad7768_dev *dev,
  * @return 0 in case of success, negative error code otherwise.
  */
 int32_t ad7768_set_crc_sel(ad7768_dev *dev,
-						   ad7768_crc_sel crc_sel)
+			   ad7768_crc_sel crc_sel)
 {
 	ad7768_spi_write_mask(dev,
-						  AD7768_REG_INTERFACE_CFG,
-						  AD7768_INTERFACE_CFG_CRC_SEL(0x3),
-						  AD7768_INTERFACE_CFG_CRC_SEL(crc_sel));
+			      AD7768_REG_INTERFACE_CFG,
+			      AD7768_INTERFACE_CFG_CRC_SEL(0x3),
+			      AD7768_INTERFACE_CFG_CRC_SEL(crc_sel));
 	dev->crc_sel = crc_sel;
 
 	return 0;
@@ -443,7 +440,7 @@ int32_t ad7768_set_crc_sel(ad7768_dev *dev,
  * @return 0 in case of success, negative error code otherwise.
  */
 int32_t ad7768_get_crc_sel(ad7768_dev *dev,
-						   ad7768_crc_sel *crc_sel)
+			   ad7768_crc_sel *crc_sel)
 {
 	*crc_sel = dev->crc_sel;
 
@@ -468,13 +465,13 @@ int32_t ad7768_get_crc_sel(ad7768_dev *dev,
  * @return 0 in case of success, negative error code otherwise.
  */
 int32_t ad7768_set_ch_state(ad7768_dev *dev,
-							ad7768_ch ch,
-							ad7768_ch_state state)
+			    ad7768_ch ch,
+			    ad7768_ch_state state)
 {
 	ad7768_spi_write_mask(dev,
-						  AD7768_REG_CH_STANDBY,
-						  AD7768_CH_STANDBY(ch),
-						  state ? AD7768_CH_STANDBY(ch) : 0);
+			      AD7768_REG_CH_STANDBY,
+			      AD7768_CH_STANDBY(ch),
+			      state ? AD7768_CH_STANDBY(ch) : 0);
 	dev->ch_state[ch] = state;
 
 	return 0;
@@ -496,8 +493,8 @@ int32_t ad7768_set_ch_state(ad7768_dev *dev,
  * @return 0 in case of success, negative error code otherwise.
  */
 int32_t ad7768_get_ch_state(ad7768_dev *dev,
-							ad7768_ch ch,
-							ad7768_ch_state *state)
+			    ad7768_ch ch,
+			    ad7768_ch_state *state)
 {
 	*state = dev->ch_state[ch];
 
@@ -523,14 +520,14 @@ int32_t ad7768_get_ch_state(ad7768_dev *dev,
  * @return 0 in case of success, negative error code otherwise.
  */
 int32_t ad7768_set_mode_config(ad7768_dev *dev,
-							   ad7768_ch_mode mode,
-							   ad7768_filt_type filt_type,
-							   ad7768_dec_rate dec_rate)
+			       ad7768_ch_mode mode,
+			       ad7768_filt_type filt_type,
+			       ad7768_dec_rate dec_rate)
 {
 	uint8_t reg_val;
 
 	reg_val = ((filt_type == AD7768_FILTER_SINC) ? AD7768_CH_MODE_FILTER_TYPE : 0) |
-			AD7768_CH_MODE_DEC_RATE(dec_rate);
+		  AD7768_CH_MODE_DEC_RATE(dec_rate);
 	if (mode == AD7768_MODE_A) {
 		ad7768_spi_write(dev, AD7768_REG_CH_MODE_A, reg_val);
 	} else {
@@ -551,9 +548,9 @@ int32_t ad7768_set_mode_config(ad7768_dev *dev,
  * @return 0 in case of success, negative error code otherwise.
  */
 int32_t ad7768_get_mode_config(ad7768_dev *dev,
-							   ad7768_ch_mode mode,
-							   ad7768_filt_type *filt_type,
-							   ad7768_dec_rate *dec_rate)
+			       ad7768_ch_mode mode,
+			       ad7768_filt_type *filt_type,
+			       ad7768_dec_rate *dec_rate)
 {
 	*filt_type = dev->filt_type[mode];
 	*dec_rate = dev->dec_rate[mode];
@@ -579,13 +576,13 @@ int32_t ad7768_get_mode_config(ad7768_dev *dev,
  * @return 0 in case of success, negative error code otherwise.
  */
 int32_t ad7768_set_ch_mode(ad7768_dev *dev,
-						   ad7768_ch ch,
-						   ad7768_ch_mode mode)
+			   ad7768_ch ch,
+			   ad7768_ch_mode mode)
 {
 	ad7768_spi_write_mask(dev,
-						  AD7768_REG_CH_MODE_SEL,
-						  AD7768_CH_MODE(ch),
-						  mode ? AD7768_CH_MODE(ch) : 0);
+			      AD7768_REG_CH_MODE_SEL,
+			      AD7768_CH_MODE(ch),
+			      mode ? AD7768_CH_MODE(ch) : 0);
 	dev->ch_mode[ch] = mode;
 
 	return 0;
@@ -607,8 +604,8 @@ int32_t ad7768_set_ch_mode(ad7768_dev *dev,
  * @return 0 in case of success, negative error code otherwise.
  */
 int32_t ad7768_get_ch_mode(ad7768_dev *dev,
-						   ad7768_ch ch,
-						   ad7768_ch_mode *mode)
+			   ad7768_ch ch,
+			   ad7768_ch_mode *mode)
 {
 	*mode = dev->ch_mode[ch];
 
@@ -623,7 +620,7 @@ int32_t ad7768_get_ch_mode(ad7768_dev *dev,
  * @return 0 in case of success, negative error code otherwise.
  */
 int32_t ad7768_setup(ad7768_dev **device,
-					 ad7768_init_param init_param)
+		     ad7768_init_param init_param)
 {
 	ad7768_dev *dev;
 	int32_t ret;
@@ -638,7 +635,7 @@ int32_t ad7768_setup(ad7768_dev **device,
 	dev->pin_spi_input_value = init_param.pin_spi_input_value;
 
 	dev->pin_spi_ctrl = dev->pin_spi_input_value ?
-									AD7768_SPI_CTRL : AD7768_PIN_CTRL;
+			    AD7768_SPI_CTRL : AD7768_PIN_CTRL;
 
 	ret |= gpio_get(&dev->gpio_reset, init_param.gpio_reset);
 	dev->gpio_reset_value = init_param.gpio_reset_value;

--- a/drivers/adc/ad9208/ad9208.c
+++ b/drivers/adc/ad9208/ad9208.c
@@ -171,7 +171,7 @@ static int32_t ad9208_setup(struct ad9208_state *st)
 	}
 
 	ret = ad9208_set_input_clk_duty_cycle_stabilizer(ad9208_h,
-							 st->duty_cycle_stabilizer_en);
+			st->duty_cycle_stabilizer_en);
 	if (ret < 0) {
 		printf("Failed to set clk duty cycle stabilizer (%d)\n", ret);
 		goto error;

--- a/drivers/platform/linux/platform_drivers.c
+++ b/drivers/platform/linux/platform_drivers.c
@@ -198,7 +198,7 @@ int32_t spi_init(spi_desc **desc, const spi_init_param *param)
 	}
 
 	ret = ioctl(descriptor->fd, SPI_IOC_WR_MODE,
-			&param->mode);
+		    &param->mode);
 	if (ret == -1) {
 		printf("%s: Can't set mode\n\r", __func__);
 		close(descriptor->fd);
@@ -207,7 +207,7 @@ int32_t spi_init(spi_desc **desc, const spi_init_param *param)
 	}
 
 	ret = ioctl(descriptor->fd, SPI_IOC_WR_MAX_SPEED_HZ,
-			&param->max_speed_hz);
+		    &param->max_speed_hz);
 	if (ret == -1) {
 		printf("%s: Can't set speed\n\r", __func__);
 		close(descriptor->fd);
@@ -458,9 +458,9 @@ int32_t gpio_get_direction(gpio_desc *desc,
 	}
 
 	if(data == 'o')
-		 *direction = GPIO_OUT;
+		*direction = GPIO_OUT;
 	else
-		 *direction = GPIO_IN;
+		*direction = GPIO_IN;
 
 	ret = close(fd);
 	if (ret < 0) {
@@ -541,9 +541,9 @@ int32_t gpio_get_value(gpio_desc *desc,
 	}
 
 	if(data == '0')
-		 *value = GPIO_LOW;
+		*value = GPIO_LOW;
 	else
-		 *value = GPIO_HIGH;
+		*value = GPIO_HIGH;
 
 	ret = close(fd);
 	if (ret < 0) {


### PR DESCRIPTION
This patch applies astyle on remaning drivers.

The aim is to help in avoiding large code modifications due to code
style issues when only a few code lines are changed for
funcionality/fix purposes.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>