### PR TITLE
drivers:dac:ad5686: fix driver

### DIFF
--- a/drivers/dac/ad5686/ad5686.c
+++ b/drivers/dac/ad5686/ad5686.c
@@ -509,8 +509,8 @@ uint16_t ad5686_read_back_register(struct ad5686_dev *dev,
 						      0);
 		read_back_data >>= offset;
 	} else {
-		i2c_write(dev->i2c_desc, &address, 1, NO_STOP_BIT);
-		i2c_read(dev->i2c_desc, rb_data_i2c, 2, STOP_BIT);
+		i2c_write(dev->i2c_desc, &address, 1, 0);
+		i2c_read(dev->i2c_desc, rb_data_i2c, 2, 1);
 		read_back_data = (rb_data_i2c[1] << 8) | rb_data_i2c[0];
 	}
 

--- a/drivers/dac/ad5686/ad5686.h
+++ b/drivers/dac/ad5686/ad5686.h
@@ -197,9 +197,9 @@ struct ad5686_init_param {
 	/* SPI */
 	spi_init_param	spi_init;
 	/* GPIO */
-	gpio_desc	gpio_reset;
-	gpio_desc	gpio_ldac;
-	gpio_desc	gpio_gain;
+	uint8_t		gpio_reset;
+	uint8_t		gpio_ldac;
+	uint8_t		gpio_gain;
 	/* Device Settings */
 	enum ad5686_type	act_device;
 };


### PR DESCRIPTION
1. Replace undefined macros for i2c stop bit.

2. Fix gpio init param types.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>