### PR TITLE
drivers:freq:hmc7044: make function non-static

### DIFF
--- a/drivers/frequency/hmc7044/hmc7044.c
+++ b/drivers/frequency/hmc7044/hmc7044.c
@@ -244,9 +244,8 @@ static int hmc7044_write(struct hmc7044_dev *dev,
  * @param val - The register data.
  * @return SUCCESS in case of success, negative error code otherwise.
  */
-static int hmc7044_read(struct hmc7044_dev *dev,
-			uint16_t reg,
-			uint8_t *val)
+
+int32_t hmc7044_read(struct hmc7044_dev *dev, uint16_t reg, uint8_t *val)
 {
 	uint8_t buf[3];
 	uint16_t cmd;

--- a/drivers/frequency/hmc7044/hmc7044.h
+++ b/drivers/frequency/hmc7044/hmc7044.h
@@ -98,6 +98,7 @@ int32_t hmc7044_init(struct hmc7044_dev **device,
 		     const struct hmc7044_init_param *init_param);
 /* Remove the device. */
 int32_t hmc7044_remove(struct hmc7044_dev *device);
+int32_t hmc7044_read(struct hmc7044_dev *dev, uint16_t reg, uint8_t *val);
 uint32_t hmc7044_clk_recalc_rate(struct hmc7044_dev *dev, uint32_t chan,
 				 uint32_t *rate);
 uint32_t hmc7044_clk_round_rate(struct hmc7044_dev *dev, uint32_t rate,


### PR DESCRIPTION
The `hmc7044_read` function is not used within the driver.

It can be useful to access it in the upper layers of the
applications/for debug.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>