### PR TITLE
drivers: fix printf format warnings

### DIFF
--- a/drivers/accel/adxl372/adxl372.c
+++ b/drivers/accel/adxl372/adxl372.c
@@ -811,7 +811,7 @@ int32_t adxl372_init(struct adxl372_dev **device,
 		return ret;
 	}
 error:
-	printf("adxl372 initialization error (%d)\n", ret);
+	printf("adxl372 initialization error (%ld)\n", ret);
 	free(dev);
 	mdelay(1000);
 	return ret;

--- a/drivers/adc/ad6676/ad6676.c
+++ b/drivers/adc/ad6676/ad6676.c
@@ -403,7 +403,7 @@ static int32_t ad6676_set_clk_synth(struct ad6676_dev *dev,
 	} while (--tout && (reg_val & SYN_STAT_VCO_CAL_BUSY));
 
 	if (!tout)
-		printf("VCO CAL failed (0x%X)\n", reg_val);
+		printf("VCO CAL failed (0x%lx)\n", reg_val);
 
 
 	/* Start CP calibration */
@@ -421,7 +421,7 @@ static int32_t ad6676_set_clk_synth(struct ad6676_dev *dev,
 					SYN_STAT_CP_CAL_DONE)));
 
 	if (!tout) {
-		printf("AD6676 Synthesizer PLL unlocked (0x%X)\n", reg_val);
+		printf("AD6676 Synthesizer PLL unlocked (0x%lx)\n", reg_val);
 		return -1;
 	}
 
@@ -441,7 +441,7 @@ static int32_t ad6676_set_extclk_cntl(struct ad6676_dev *dev,
 {
 	int ret;
 
-	printf("%s: frequency %u\n", __func__, freq);
+	printf("%s: frequency %lu\n", __func__, freq);
 
 	ret = ad6676_spi_write(dev, AD6676_CLKSYN_LOGEN, 0x5);
 	if (ret < 0)
@@ -544,7 +544,7 @@ static int32_t ad6676_calibrate(struct ad6676_dev *dev,
 		} while (tout_i-- && !done);
 
 		if (!done) {
-			printf("AD6676 CAL timeout (0x%X)\n", cal);
+			printf("AD6676 CAL timeout (0x%lx)\n", cal);
 			ad6676_spi_write(dev,
 					 AD6676_FORCE_END_CAL,
 					 FORCE_END_CAL);
@@ -555,7 +555,7 @@ static int32_t ad6676_calibrate(struct ad6676_dev *dev,
 
 	} while (tout_o--);
 
-	printf("AD6676 CAL failed (0x%X)\n", cal);
+	printf("AD6676 CAL failed (0x%lx)\n", cal);
 
 	return -1;
 }
@@ -702,7 +702,7 @@ int32_t ad6676_setup(struct ad6676_dev **device,
 	reg_val &= SYN_STAT_PLL_LCK;
 
 	if (reg_val != SYN_STAT_PLL_LCK) {
-		printf("AD6676 JESD PLL unlocked (0x%X)\n", reg_val);
+		printf("AD6676 JESD PLL unlocked (0x%lx)\n", reg_val);
 		return -1;
 	}
 

--- a/drivers/adc/ad7779/ad7779.c
+++ b/drivers/adc/ad7779/ad7779.c
@@ -1376,7 +1376,7 @@ int32_t ad7779_init(ad7779_dev **device,
 	if (!ret)
 		printf("AD7779 successfully initialized\n");
 	else
-		printf("AD7779 initialization error (%d)\n", ret);
+		printf("AD7779 initialization error (%ld)\n", ret);
 
 	return ret;
 }

--- a/drivers/adc/ad9208/ad9208.c
+++ b/drivers/adc/ad9208/ad9208.c
@@ -127,20 +127,20 @@ static int32_t ad9208_setup(struct ad9208_state *st)
 
 	ret = ad9208_init(ad9208_h);
 	if (ret < 0) {
-		printf("ad9208 init failed (%d)\n", ret);
+		printf("ad9208 init failed (%ld)\n", ret);
 		return -ENODEV;
 	}
 
 	ret = ad9208_reset(ad9208_h, 0);
 	if (ret < 0) {
-		printf("ad9298 reset failed (%d)\n", ret);
+		printf("ad9298 reset failed (%ld)\n", ret);
 		ret = -ENODEV;
 		goto error;
 	}
 
 	ret = ad9208_get_chip_id(ad9208_h, &chip_id);
 	if (ret < 0) {
-		printf("ad9208_get_chip_id failed (%d)\n", ret);
+		printf("ad9208_get_chip_id failed (%ld)\n", ret);
 		ret = -ENODEV;
 		goto error;
 	}
@@ -159,21 +159,21 @@ static int32_t ad9208_setup(struct ad9208_state *st)
 
 	ret = ad9208_adc_set_channel_select(ad9208_h, AD9208_ADC_CH_ALL);
 	if (ret < 0) {
-		printf( "Failed to select channels (%d)\n", ret);
+		printf( "Failed to select channels (%ld)\n", ret);
 		goto error;
 	}
 
 	ret = ad9208_set_pdn_pin_mode(ad9208_h, st->powerdown_pin_en,
 				      st->powerdown_mode);
 	if (ret < 0) {
-		printf("Failed to set PWDN pin mode (%d)\n", ret);
+		printf("Failed to set PWDN pin mode (%ld)\n", ret);
 		goto error;
 	}
 
 	ret = ad9208_set_input_clk_duty_cycle_stabilizer(ad9208_h,
 			st->duty_cycle_stabilizer_en);
 	if (ret < 0) {
-		printf("Failed to set clk duty cycle stabilizer (%d)\n", ret);
+		printf("Failed to set clk duty cycle stabilizer (%ld)\n", ret);
 		goto error;
 	}
 
@@ -182,7 +182,7 @@ static int32_t ad9208_setup(struct ad9208_state *st)
 	ret = ad9208_set_input_clk_cfg(ad9208_h, sample_rate,
 				       st->input_div);
 	if (ret < 0) {
-		printf("Failed to set input clk config (%d)\n", ret);
+		printf("Failed to set input clk config (%ld)\n", ret);
 		goto error;
 	}
 
@@ -190,20 +190,20 @@ static int32_t ad9208_setup(struct ad9208_state *st)
 				       st->analog_input_mode ? COUPLING_DC : COUPLING_AC,
 				       st->ext_vref_en, st->current_scale);
 	if (ret < 0) {
-		printf("Failed to set adc input config: %d\n", ret);
+		printf("Failed to set adc input config: %ld\n", ret);
 		goto error;
 	}
 
 	ret = ad9208_adc_set_input_buffer_cfg(ad9208_h, st->buff_curr_n,
 					      st->buff_curr_p, AD9208_BUFF_CURR_600_UA);
 	if (ret < 0) {
-		printf("Failed to set input buffer config: %d\n", ret);
+		printf("Failed to set input buffer config: %ld\n", ret);
 		goto error;
 	}
 
 	ret = ad9208_adc_set_fc_ch_mode(ad9208_h, st->fc_ch);
 	if (ret < 0) {
-		printf("Failed to set channel mode: %d\n", ret);
+		printf("Failed to set channel mode: %ld\n", ret);
 		goto error;
 	}
 
@@ -217,7 +217,7 @@ static int32_t ad9208_setup(struct ad9208_state *st)
 
 	ret = ad9208_adc_set_dcm_mode(ad9208_h, dcm);
 	if (ret < 0) {
-		printf("Failed to set decimation mode: %d\n", ret);
+		printf("Failed to set decimation mode: %ld\n", ret);
 		goto error;
 	}
 
@@ -234,7 +234,7 @@ static int32_t ad9208_setup(struct ad9208_state *st)
 
 	ret = ad9208_adc_set_data_format(ad9208_h, input_fmt, output_fmt);
 	if (ret < 0) {
-		printf("Failed to set data format: %d\n", ret);
+		printf("Failed to set data format: %ld\n", ret);
 		goto error;
 	}
 
@@ -242,54 +242,54 @@ static int32_t ad9208_setup(struct ad9208_state *st)
 		ret = ad9208_adc_set_ddc_gain(ad9208_h, i,
 					      st->ddc[i].gain_db ? 6 : 0);
 		if (ret < 0) {
-			printf("Failed to set ddc gain: %d\n", ret);
+			printf("Failed to set ddc gain: %ld\n", ret);
 			goto error;
 		}
 
 		ret = ad9208_adc_set_ddc_dcm(ad9208_h, i,
 					     st->ddc[i].decimation);
 		if (ret < 0) {
-			printf("Failed to set ddc decimation mode: %d\n", ret);
+			printf("Failed to set ddc decimation mode: %ld\n", ret);
 			goto error;
 		}
 
 		ret = ad9208_adc_set_ddc_nco_mode(ad9208_h, i,
 						  st->ddc[i].nco_mode);
 		if (ret < 0) {
-			printf("Failed to set ddc nco mode: %d\n", ret);
+			printf("Failed to set ddc nco mode: %ld\n", ret);
 			goto error;
 		}
 
 		ret = ad9208_adc_set_ddc_nco(ad9208_h, i,
 					     st->ddc[i].carrier_freq_hz);
 		if (ret < 0) {
-			printf("Failed to set ddc nco frequency: %d\n", ret);
+			printf("Failed to set ddc nco frequency: %ld\n", ret);
 			goto error;
 		}
 
 		ret = ad9208_adc_set_ddc_nco_phase(ad9208_h, i, st->ddc[i].po);
 		if (ret < 0) {
-			printf("Failed to set ddc nco phase: %d\n", ret);
+			printf("Failed to set ddc nco phase: %ld\n", ret);
 			goto error;
 		}
 	}
 
 	ret = ad9208_testmode_set(st, 0, st->test_mode_ch0);
 	if (ret < 0) {
-		printf("Failed to set test mode for ch 0: %d\n", ret);
+		printf("Failed to set test mode for ch 0: %ld\n", ret);
 		goto error;
 	}
 
 	ret = ad9208_testmode_set(st, 1, st->test_mode_ch1);
 	if (ret < 0) {
-		printf("Failed to set test mode for ch 1: %d\n", ret);
+		printf("Failed to set test mode for ch 1: %ld\n", ret);
 		goto error;
 	}
 
 	ret = ad9208_jesd_syref_lmfc_offset_set(ad9208_h,
 						st->sysref_lmfc_offset);
 	if (ret < 0) {
-		printf("Failed to set SYSREF lmfc offset: %d\n", ret);
+		printf("Failed to set SYSREF lmfc offset: %ld\n", ret);
 		goto error;
 	}
 
@@ -298,39 +298,39 @@ static int32_t ad9208_setup(struct ad9208_state *st)
 					   st->sysref_neg_window_skew,
 					   st->sysref_pos_window_skew);
 	if (ret < 0) {
-		printf("Failed to set SYSREF sig capture settings: %d\n", ret);
+		printf("Failed to set SYSREF sig capture settings: %ld\n", ret);
 		goto error;
 	}
 
 	ret = ad9208_jesd_syref_mode_set(ad9208_h, st->sysref_mode,
 					 st->sysref_count);
 	if (ret < 0) {
-		printf("Failed to Set JESD SYNCHRONIZATION Mode: %d\n", ret);
+		printf("Failed to Set JESD SYNCHRONIZATION Mode: %ld\n", ret);
 		goto error;
 	}
 
 	ret = ad9208_jesd_set_if_config(ad9208_h, (jesd_param_t )*st->jesd_param,
 					&lane_rate_kbps);
 	if (ret < 0) {
-		printf("Failed to set JESD204 interface config (%d)\n", ret);
+		printf("Failed to set JESD204 interface config (%ld)\n", ret);
 		goto error;
 	}
 
 	ret = ad9208_jesd_subclass_set(ad9208_h, st->jesd_subclass);
 	if (ret < 0) {
-		printf("Failed to set subclass (%d)\n", ret);
+		printf("Failed to set subclass (%ld)\n", ret);
 		goto error;
 	}
 
 	ret = ad9208_jesd_enable_scrambler(ad9208_h, 1);
 	if (ret < 0) {
-		printf("Failed to enable scrambler (%d)\n", ret);
+		printf("Failed to enable scrambler (%ld)\n", ret);
 		goto error;
 	}
 
 	ret = ad9208_jesd_enable_link(ad9208_h, 1);
 	if (ret < 0) {
-		printf("Failed to enabled JESD204 link (%d)\n", ret);
+		printf("Failed to enabled JESD204 link (%ld)\n", ret);
 		goto error;
 	}
 
@@ -340,7 +340,7 @@ static int32_t ad9208_setup(struct ad9208_state *st)
 		mdelay(10);
 		ret = ad9208_jesd_get_pll_status(ad9208_h, &pll_stat);
 		if (ret < 0) {
-			printf("Failed to get pll status (%d)\n", ret);
+			printf("Failed to get pll status (%ld)\n", ret);
 			goto error;
 		}
 	} while (!(pll_stat & AD9208_JESD_PLL_LOCK_STAT) && timeout--);

--- a/drivers/afe/ad4110/ad4110.c
+++ b/drivers/afe/ad4110/ad4110.c
@@ -590,7 +590,7 @@ int32_t ad4110_setup(struct ad4110_dev **device,
 	if (!ret)
 		printf("AD4110 successfully initialized\n");
 	else
-		printf("AD4110 initialization error (%d)\n", ret);
+		printf("AD4110 initialization error (%ld)\n", ret);
 
 	return ret;
 }

--- a/drivers/dac/ad5766/ad5766.c
+++ b/drivers/dac/ad5766/ad5766.c
@@ -326,7 +326,7 @@ int32_t ad5766_init(struct ad5766_dev **device,
 	if (!ret)
 		printf("AD5766 successfully initialized\n");
 	else
-		printf("AD5766 initialization error (%d)\n", ret);
+		printf("AD5766 initialization error (%ld)\n", ret);
 
 	return ret;
 }

--- a/drivers/dac/ad5770r/ad5770r.c
+++ b/drivers/dac/ad5770r/ad5770r.c
@@ -707,7 +707,7 @@ int32_t ad5770r_init(struct ad5770r_dev **device,
 	if (!ret)
 		printf("ad5770r successfully initialized\n");
 	else
-		printf("ad5770r initialization error (%d)\n", ret);
+		printf("ad5770r initialization error (%ld)\n", ret);
 
 	return ret;
 }

--- a/drivers/dac/ad9144/ad9144.c
+++ b/drivers/dac/ad9144/ad9144.c
@@ -635,7 +635,7 @@ int32_t ad9144_short_pattern_test(struct ad9144_dev *dev,
 						      REG_SHORT_TPL_TEST_3,
 						      0x01, 0x00);
 			if (ret == -1)
-				printf("%s : short-pattern-test mismatch (0x%x, 0x%x 0x%x, 0x%x)!.\n",
+				printf("%s : short-pattern-test mismatch (0x%lx, 0x%lx 0x%lx, 0x%x)!.\n",
 				       __func__, dac, sample,
 				       init_param->stpl_samples[dac][sample],
 				       status);

--- a/drivers/dac/ad9152/ad9152.c
+++ b/drivers/dac/ad9152/ad9152.c
@@ -245,7 +245,7 @@ int32_t ad9152_short_pattern_test(struct ad9152_dev *dev,
 
 			ad9152_spi_read(dev, 0x32f, &status);
 			if ((status & 0x1) == 0x1)
-				printf("AD9152: short-pattern-test mismatch (%x, %d, %d, %x)!.\n",
+				printf("AD9152: short-pattern-test mismatch (%lu, %ld, %ld, %d)!.\n",
 				       dac, sample,
 				       init_param.stpl_samples[dac][sample],
 				       status);

--- a/drivers/frequency/ad9523/ad9523.c
+++ b/drivers/frequency/ad9523/ad9523.c
@@ -229,7 +229,7 @@ int32_t ad9523_calibrate(struct ad9523_dev *dev)
 			AD9523_READBACK_1,
 			&reg_data);
 	if ((reg_data & 0x1) != 0x0) {
-		printf("AD9523: VCO calibration failed (%x)!\n", reg_data);
+		printf("AD9523: VCO calibration failed (%lx)!\n", reg_data);
 		return(-1);
 	}
 
@@ -281,12 +281,12 @@ int32_t ad9523_status(struct ad9523_dev *dev)
 
 	ret = 0;
 	if ((reg_data & AD9523_READBACK_0_STAT_VCXO) != AD9523_READBACK_0_STAT_VCXO) {
-		printf("AD9523: VCXO status errors (%x)!\n", reg_data);
+		printf("AD9523: VCXO status errors (%lx)!\n", reg_data);
 		ret = -1;
 	}
 	if ((reg_data & AD9523_READBACK_0_STAT_PLL2_LD) !=
 	    AD9523_READBACK_0_STAT_PLL2_LD) {
-		printf("AD9523: PLL2 NOT locked (%x)!\n", reg_data);
+		printf("AD9523: PLL2 NOT locked (%lx)!\n", reg_data);
 		ret = -1;
 	}
 	return(ret);
@@ -467,7 +467,7 @@ int32_t ad9523_setup(struct ad9523_dev **device,
 		return ret;
 
 	if (reg_data != 0xAD95) {
-		printf("AD9523: SPI write-verify failed (0x%X)!\n\r",
+		printf("AD9523: SPI write-verify failed (0x%lx)!\n\r",
 		       reg_data);
 		return -1;
 	}

--- a/drivers/frequency/ad9528/ad9528.c
+++ b/drivers/frequency/ad9528/ad9528.c
@@ -371,7 +371,7 @@ int32_t ad9528_setup(struct ad9528_dev **device,
 		return ret;
 
 	if ((reg_data & 0xFFFFFF) != AD9528_SPI_MAGIC) {
-		printf("AD9528 SPI Read Verify failed (0x%X).\n", reg_data);
+		printf("AD9528 SPI Read Verify failed (0x%lx).\n", reg_data);
 		return -1;
 	}
 

--- a/drivers/mux/adgs1408/adgs1408.c
+++ b/drivers/mux/adgs1408/adgs1408.c
@@ -440,7 +440,7 @@ int32_t adgs1408_init(struct adgs1408_dev **device,
 	if (!ret)
 		printf("ADGS1408 successfully initialized\n");
 	else
-		printf("ADGS1408 initialization error (%d)\n", ret);
+		printf("ADGS1408 initialization error (%ld)\n", ret);
 
 	return ret;
 }

--- a/drivers/mux/adgs5412/adgs5412.c
+++ b/drivers/mux/adgs5412/adgs5412.c
@@ -364,7 +364,7 @@ int32_t adgs5412_init(adgs5412_dev **device,
 	if (!ret)
 		printf("ADGS5412 successfully initialized\n");
 	else
-		printf("ADGS5412 initialization error (%d)\n", ret);
+		printf("ADGS5412 initialization error (%ld)\n", ret);
 
 	return ret;
 }


### PR DESCRIPTION
Fix formats when using `printf` function.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>