### PR TITLE
travis: build drivers

### DIFF
--- a/ci/travis/before_install_linux
+++ b/ci/travis/before_install_linux
@@ -2,5 +2,5 @@
 set -e
 
 sudo apt-get update
-sudo apt-get install libmatio-dev cppcheck 
+sudo apt-get install libmatio-dev cppcheck gcc-arm-none-eabi libnewlib-arm-none-eabi
 

--- a/ci/travis/build_projects.sh
+++ b/ci/travis/build_projects.sh
@@ -4,7 +4,12 @@ set -e
 
 if [ "$TRAVIS_OS_NAME" == "linux" ] 
 then 
+	echo "Building AD9361-Linux"
 	make -C ./ad9361/sw -f Makefile.linux
+	echo "Building Drivers"
+	make -C ./drivers -f Makefile
 fi
 
+echo "Building AD9361-Generic"
 make -C ./ad9361/sw -f Makefile.generic
+

--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -1,12 +1,14 @@
 CC = arm-none-eabi-gcc
-CFLAGS = -c -Wall -I../include/ \
+CFLAGS = -c -Wall -std=gnu11 -Wformat=0 \
+	 -I../include/ \
 	 -I../projects/drivers/util/ \
 	 -I./dac/ad917x/ad917x_api/ \
 	 -I../projects/ad9361/src/ \
-	 -I./adc/ad9208/ad9208_api \
-	 -I../projects/drivers/axi_adc_core
+	 -I./adc/ad9208/ad9208_api/ \
+	 -I./axi_core/axi_adc_core/
 
-SUBDIRS = $(shell find . -path ./platform -prune -o -name '*.c')
+SUBDIRS = $(shell find . -path ./platform -prune -o \
+	  -path ./axi_core -prune -o -name '*.c')
 
 all:
 	$(CC) $(CFLAGS) $(SUBDIRS)


### PR DESCRIPTION
This patch integrates the drivers builds into TravisCI.

Builds are available on Linux OS.

Platform drivers and AXI Core drivers are skipped.

Build errors are fixed with #331 and #332.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>