### PR TITLE
drivers: fix issues for ISO C89 standard

### DIFF
--- a/drivers/frequency/adf4106/adf4106.c
+++ b/drivers/frequency/adf4106/adf4106.c
@@ -52,8 +52,8 @@
 #define DATA_OFFSET_LSB8    0
 #define ADDRESS_MASK        3
 
-#define FREQ_2_4_GHZ        2400000000
-#define FREQ_5_2_GHZ        5200000000
+#define FREQ_2_4_GHZ        2400000000u
+#define FREQ_5_2_GHZ        5200000000u
 
 /******************************************************************************/
 /************************** Constants Definitions *****************************/

--- a/drivers/frequency/adf4153/adf4153.c
+++ b/drivers/frequency/adf4153/adf4153.c
@@ -86,7 +86,7 @@ int8_t adf4153_init(struct adf4153_dev **device,
 	dev->adf4153_rfin_max_frq = 250000000;  // 250 Mhz
 	dev->adf4153_pfd_max_frq  = 32000000;   // 32 Mhz
 	dev->adf4153_vco_min_frq  = 500000000;  // 500 Mhz
-	dev->adf4153_vco_max_frq  = 4000000000; // 4 Ghz
+	dev->adf4153_vco_max_frq  = 4000000000u; // 4 Ghz
 	dev->adf4153_mod_max      = 4095;       // the MOD is stored in 12 bits
 	dev->r0 = 0;
 	dev->r1 = 0;


### PR DESCRIPTION
Fix warnings detected by travis when building drivers according to the
C89 standard.

Force unsigned values.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>