### PR TITLE
drivers: Makefile rework

### DIFF
--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -1,5 +1,7 @@
 CC = arm-none-eabi-gcc
 
+SKIPDIR = -path ./platform -prune -o
+
 INCLUDES = -I../include/ \
 	 -I../projects/drivers/util/ \
 	 -I./dac/ad917x/ad917x_api/ \
@@ -9,7 +11,7 @@ INCLUDES = -I../include/ \
 
 CFLAGS = -c -Wall -Wformat=0 $(INCLUDES)
 
-SUBDIRS = $(shell find . -path ./platform -prune -o -name '*.c')
+SUBDIRS = $(shell find . $(SKIPDIR) -name '*.c')
 
 all:
 	$(CC) $(CFLAGS) $(SUBDIRS)

--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -1,6 +1,7 @@
 CC = arm-none-eabi-gcc
 
-SKIPDIR = -path ./platform -prune -o
+SKIPDIR = -path ./platform -prune -o \
+	-path ./axi_core -prune -o
 
 INCLUDES = -I../include/ \
 	 -I../projects/drivers/util/ \

--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -4,7 +4,7 @@ CFLAGS = -c -Wall -I../include/ \
 	 -I./dac/ad917x/ad917x_api/ \
 	 -I../projects/ad9361/src/ \
 	 -I./adc/ad9208/ad9208_api \
-	 -I../projects/drivers/axi_adc_core
+	 -I./axi_core/axi_adc_core
 
 SUBDIRS = $(shell find . -path ./platform -prune -o -name '*.c')
 

--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -7,7 +7,7 @@ INCLUDES = -I../include/ \
 	 -I./adc/ad9208/ad9208_api \
 	 -I./axi_core/axi_adc_core
 
-CFLAGS = -c -Wall $(INCLUDES)
+CFLAGS = -c -Wall -Wformat=0 $(INCLUDES)
 
 SUBDIRS = $(shell find . -path ./platform -prune -o -name '*.c')
 

--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -1,10 +1,13 @@
 CC = arm-none-eabi-gcc
-CFLAGS = -c -Wall -I../include/ \
+
+INCLUDES = -I../include/ \
 	 -I../projects/drivers/util/ \
 	 -I./dac/ad917x/ad917x_api/ \
 	 -I../projects/ad9361/src/ \
 	 -I./adc/ad9208/ad9208_api \
 	 -I./axi_core/axi_adc_core
+
+CFLAGS = -c -Wall $(INCLUDES)
 
 SUBDIRS = $(shell find . -path ./platform -prune -o -name '*.c')
 


### PR DESCRIPTION
Add variables for includes and for folders to be skipped.

Skip `axi_core` drivers. (require BSP generated header files).

Disable Wformat flag (for now). There are multiple warnings regarding
printf format which are in conflict with Codacy.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>