### PR TITLE
drivers: gpio: pass value by reference

### DIFF
--- a/drivers/accel/adxl372/adxl372.c
+++ b/drivers/accel/adxl372/adxl372.c
@@ -737,12 +737,12 @@ int32_t adxl372_init(struct adxl372_dev **device,
 	}
 	/* GPIO */
 	ret = gpio_get(&dev->gpio_int1,
-		       init_param.gpio_int1);
+		       &init_param.gpio_int1);
 	if (ret < 0)
 		goto error;
 
 	ret |= gpio_get(&dev->gpio_int2,
-			init_param.gpio_int2);
+			&init_param.gpio_int2);
 	if (ret < 0)
 		goto error;
 

--- a/drivers/adc/ad7193/ad7193.c
+++ b/drivers/adc/ad7193/ad7193.c
@@ -79,8 +79,8 @@ int8_t ad7193_init(struct ad7193_dev **device,
 	status = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* GPIO */
-	status |= gpio_get(&dev->gpio_cs, init_param.gpio_cs);
-	status |= gpio_get(&dev->gpio_miso, init_param.gpio_miso);
+	status |= gpio_get(&dev->gpio_cs, &init_param.gpio_cs);
+	status |= gpio_get(&dev->gpio_miso, &init_param.gpio_miso);
 
 	if (dev->gpio_cs)
 		status |= gpio_direction_output(dev->gpio_cs,

--- a/drivers/adc/ad7280a/ad7280a.c
+++ b/drivers/adc/ad7280a/ad7280a.c
@@ -72,9 +72,9 @@ int8_t ad7280a_init(struct ad7280a_dev **device,
 		return -1;
 
 	/* GPIO */
-	status = gpio_get(&dev->gpio_pd, init_param.gpio_pd);
-	status |= gpio_get(&dev->gpio_cnvst, init_param.gpio_cnvst);
-	status |= gpio_get(&dev->gpio_alert, init_param.gpio_alert);
+	status = gpio_get(&dev->gpio_pd, &init_param.gpio_pd);
+	status |= gpio_get(&dev->gpio_cnvst, &init_param.gpio_cnvst);
+	status |= gpio_get(&dev->gpio_alert, &init_param.gpio_alert);
 
 	AD7280A_PD_OUT;
 	AD7280A_PD_HIGH;

--- a/drivers/adc/ad74xx/ad74xx.c
+++ b/drivers/adc/ad74xx/ad74xx.c
@@ -75,7 +75,7 @@ int8_t ad74xx_init(struct ad74xx_dev **device,
 	status = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* GPIO */
-	status |= gpio_get(&dev->gpio_cs, init_param.gpio_cs);
+	status |= gpio_get(&dev->gpio_cs, &init_param.gpio_cs);
 
 	if (dev->gpio_cs)
 		status |= gpio_direction_output(dev->gpio_cs,

--- a/drivers/adc/ad7606/ad7606.c
+++ b/drivers/adc/ad7606/ad7606.c
@@ -173,34 +173,34 @@ int32_t ad7606_request_gpios(struct ad7606_dev *dev,
 {
 	int32_t ret;
 
-	ret = gpio_get(&dev->gpio_reset, init_param->gpio_reset);
+	ret = gpio_get(&dev->gpio_reset, &init_param->gpio_reset);
 	if (ret < 0)
 		return ret;
 
-	ret = gpio_get(&dev->gpio_convst, init_param->gpio_convst);
+	ret = gpio_get(&dev->gpio_convst, &init_param->gpio_convst);
 	if (ret < 0)
 		return ret;
 
-	ret = gpio_get(&dev->gpio_busy, init_param->gpio_busy);
+	ret = gpio_get(&dev->gpio_busy, &init_param->gpio_busy);
 	if (ret < 0)
 		return ret;
 
-	ret = gpio_get(&dev->gpio_range, init_param->gpio_range);
+	ret = gpio_get(&dev->gpio_range, &init_param->gpio_range);
 	if (ret < 0)
 		return ret;
 
 	if (!ad7606_chip_info_tbl[dev->device_id].has_oversampling)
 		return 0;
 
-	ret = gpio_get(&dev->gpio_range, init_param->gpio_os0);
+	ret = gpio_get(&dev->gpio_range, &init_param->gpio_os0);
 	if (ret < 0)
 		return ret;
 
-	ret = gpio_get(&dev->gpio_range, init_param->gpio_os1);
+	ret = gpio_get(&dev->gpio_range, &init_param->gpio_os1);
 	if (ret < 0)
 		return ret;
 
-	return gpio_get(&dev->gpio_range, init_param->gpio_os2);
+	return gpio_get(&dev->gpio_range, &init_param->gpio_os2);
 }
 
 int32_t ad7606_set_os_ratio(struct ad7606_dev *dev,

--- a/drivers/adc/ad7768/ad7768.c
+++ b/drivers/adc/ad7768/ad7768.c
@@ -1,5 +1,5 @@
 /***************************************************************************//**
- *   @file   ad7768.c
+ *   @file
  *   @brief  Implementation of AD7768 Driver.
  *   @author DBogdan (dragos.bogdan@analog.com)
 ********************************************************************************
@@ -637,13 +637,13 @@ int32_t ad7768_setup(ad7768_dev **device,
 	dev->pin_spi_ctrl = dev->pin_spi_input_value ?
 			    AD7768_SPI_CTRL : AD7768_PIN_CTRL;
 
-	ret |= gpio_get(&dev->gpio_reset, init_param.gpio_reset);
+	ret |= gpio_get(&dev->gpio_reset, &init_param.gpio_reset);
 	dev->gpio_reset_value = init_param.gpio_reset_value;
 
-	ret |= gpio_get(&dev->gpio_mode0, init_param.gpio_mode0);
-	ret |= gpio_get(&dev->gpio_mode1, init_param.gpio_mode1);
-	ret |= gpio_get(&dev->gpio_mode2, init_param.gpio_mode2);
-	ret |= gpio_get(&dev->gpio_mode3, init_param.gpio_mode3);
+	ret |= gpio_get(&dev->gpio_mode0, &init_param.gpio_mode0);
+	ret |= gpio_get(&dev->gpio_mode1, &init_param.gpio_mode1);
+	ret |= gpio_get(&dev->gpio_mode2, &init_param.gpio_mode2);
+	ret |= gpio_get(&dev->gpio_mode3, &init_param.gpio_mode3);
 
 	if (dev->gpio_reset)
 		ret |= gpio_direction_output(dev->gpio_reset, dev->gpio_reset_value);

--- a/drivers/adc/ad7779/ad7779.c
+++ b/drivers/adc/ad7779/ad7779.c
@@ -1259,25 +1259,25 @@ int32_t ad7779_init(ad7779_dev **device,
 
 	/* GPIO */
 	ret |= gpio_get(&dev->gpio_reset,
-			init_param.gpio_reset);
+			&init_param.gpio_reset);
 	ret |= gpio_get(&dev->gpio_mode0,
-			init_param.gpio_mode0);
+			&init_param.gpio_mode0);
 	ret |= gpio_get(&dev->gpio_mode1,
-			init_param.gpio_mode1);
+			&init_param.gpio_mode1);
 	ret |= gpio_get(&dev->gpio_mode2,
-			init_param.gpio_mode2);
+			&init_param.gpio_mode2);
 	ret |= gpio_get(&dev->gpio_mode3,
-			init_param.gpio_mode3);
+			&init_param.gpio_mode3);
 	ret |= gpio_get(&dev->gpio_dclk0,
-			init_param.gpio_dclk0);
+			&init_param.gpio_dclk0);
 	ret |= gpio_get(&dev->gpio_dclk1,
-			init_param.gpio_dclk1);
+			&init_param.gpio_dclk1);
 	ret |= gpio_get(&dev->gpio_dclk2,
-			init_param.gpio_dclk2);
+			&init_param.gpio_dclk2);
 	ret |= gpio_get(&dev->gpio_sync_in,
-			init_param.gpio_sync_in);
+			&init_param.gpio_sync_in);
 	ret |= gpio_get(&dev->gpio_convst_sar,
-			init_param.gpio_convst_sar);
+			&init_param.gpio_convst_sar);
 
 	ret |= gpio_direction_output(dev->gpio_reset,
 				     GPIO_LOW);

--- a/drivers/adc/ad7780/ad7780.c
+++ b/drivers/adc/ad7780/ad7780.c
@@ -72,10 +72,10 @@ int8_t ad7780_init(struct ad7780_dev **device,
 	if (!dev)
 		return -1;
 
-	init_status = gpio_get(&dev->gpio_pdrst, init_param.gpio_pdrst);
-	init_status = gpio_get(&dev->gpio_miso, init_param.gpio_miso);
-	init_status = gpio_get(&dev->gpio_filter, init_param.gpio_filter);
-	init_status = gpio_get(&dev->gpio_gain, init_param.gpio_gain);
+	init_status = gpio_get(&dev->gpio_pdrst, &init_param.gpio_pdrst);
+	init_status = gpio_get(&dev->gpio_miso, &init_param.gpio_miso);
+	init_status = gpio_get(&dev->gpio_filter, &init_param.gpio_filter);
+	init_status = gpio_get(&dev->gpio_gain, &init_param.gpio_gain);
 
 	if (dev->gpio_miso)
 		init_status = gpio_direction_input(dev->gpio_miso);

--- a/drivers/adc/ad7980/ad7980.c
+++ b/drivers/adc/ad7980/ad7980.c
@@ -71,7 +71,7 @@ int8_t ad7980_init(struct ad7980_dev **device,
 	/* SPI */
 	status = spi_init(&dev->spi_desc, &init_param.spi_init);
 	/* GPIO */
-	status |= gpio_get(&dev->gpio_cs, init_param.gpio_cs);
+	status |= gpio_get(&dev->gpio_cs, &init_param.gpio_cs);
 
 	if (dev->gpio_cs)
 		status |= gpio_direction_output(dev->gpio_cs,

--- a/drivers/afe/ad4110/ad4110.c
+++ b/drivers/afe/ad4110/ad4110.c
@@ -533,7 +533,7 @@ int32_t ad4110_setup(struct ad4110_dev **device,
 	ret = spi_init(&dev->spi_dev, &init_param.spi_init);
 
 	/* GPIO */
-	ret |= gpio_get(&dev->gpio_reset, init_param.gpio_reset);
+	ret |= gpio_get(&dev->gpio_reset, &init_param.gpio_reset);
 
 	ret |= gpio_direction_output(dev->gpio_reset, GPIO_LOW);
 	mdelay(10);

--- a/drivers/afe/ad4110/ad4110.h
+++ b/drivers/afe/ad4110/ad4110.h
@@ -205,7 +205,7 @@ struct ad4110_dev {
 	/* SPI */
 	struct spi_desc			*spi_dev;
 	/* GPIO */
-	struct struct gpio_desc		*gpio_reset;
+	struct gpio_desc		*gpio_reset;
 	/* Device Settings */
 	enum ad4110_state		data_stat;
 	enum ad4110_data_word_length 	data_length;

--- a/drivers/dac/ad5421/ad5421.c
+++ b/drivers/dac/ad5421/ad5421.c
@@ -77,8 +77,8 @@ int32_t ad5421_init(struct ad5421_dev **device,
 	if (!dev)
 		return -1;
 
-	gpio_get(&dev->gpio_ldac, init_param.gpio_ldac);
-	gpio_get(&dev->gpio_faultin, init_param.gpio_faultin);
+	gpio_get(&dev->gpio_ldac, &init_param.gpio_ldac);
+	gpio_get(&dev->gpio_faultin, &init_param.gpio_faultin);
 
 	/* Setup the SPI interface. */
 	spi_init(&dev->spi_desc, &init_param.spi_init);

--- a/drivers/dac/ad5446/ad5446.c
+++ b/drivers/dac/ad5446/ad5446.c
@@ -152,8 +152,8 @@ int8_t ad5446_init(struct ad5446_dev **device,
 	status = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* GPIO */
-	status |= gpio_get(&dev->gpio_ladc, init_param.gpio_ladc);
-	status |= gpio_get(&dev->gpio_clrout, init_param.gpio_clrout);
+	status |= gpio_get(&dev->gpio_ladc, &init_param.gpio_ladc);
+	status |= gpio_get(&dev->gpio_clrout, &init_param.gpio_clrout);
 
 	/* Initialize configuration pins, if exist. */
 	if(dev->act_device == ID_AD5542A) {

--- a/drivers/dac/ad5449/ad5449.c
+++ b/drivers/dac/ad5449/ad5449.c
@@ -125,8 +125,8 @@ int8_t ad5449_init(struct ad5449_dev **device,
 	status = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* GPIO */
-	status |= gpio_get(&dev->gpio_ldac, init_param.gpio_ldac);
-	status |= gpio_get(&dev->gpio_clr, init_param.gpio_clr);
+	status |= gpio_get(&dev->gpio_ldac, &init_param.gpio_ldac);
+	status |= gpio_get(&dev->gpio_clr, &init_param.gpio_clr);
 
 	/* Set GPIO pins. */
 	AD5449_LDAC_OUT;

--- a/drivers/dac/ad5629r/ad5629r.c
+++ b/drivers/dac/ad5629r/ad5629r.c
@@ -108,8 +108,8 @@ int8_t ad5629r_init(struct ad5629r_dev **device,
 		status = i2c_init(&dev->i2c_desc, &init_param.i2c_init);
 	}
 
-	status |= gpio_get(&dev->gpio_ldac, init_param.gpio_ldac);
-	status |= gpio_get(&dev->gpio_clr, init_param.gpio_clr);
+	status |= gpio_get(&dev->gpio_ldac, &init_param.gpio_ldac);
+	status |= gpio_get(&dev->gpio_clr, &init_param.gpio_clr);
 
 	AD5629R_LDAC_OUT;
 	AD5629R_LDAC_LOW;

--- a/drivers/dac/ad5686/ad5686.c
+++ b/drivers/dac/ad5686/ad5686.c
@@ -272,9 +272,9 @@ int32_t ad5686_init(struct ad5686_dev **device,
 
 
 	/* GPIO */
-	ret |= gpio_get(&dev->gpio_reset, init_param.gpio_reset);
-	ret |= gpio_get(&dev->gpio_ldac, init_param.gpio_ldac);
-	ret |= gpio_get(&dev->gpio_gain, init_param.gpio_gain);
+	ret |= gpio_get(&dev->gpio_reset, &init_param.gpio_reset);
+	ret |= gpio_get(&dev->gpio_ldac, &init_param.gpio_ldac);
+	ret |= gpio_get(&dev->gpio_gain, &init_param.gpio_gain);
 
 	if (dev->gpio_ldac)
 		ret |= gpio_direction_output(dev->gpio_ldac, GPIO_LOW);

--- a/drivers/dac/ad5755/ad5755.c
+++ b/drivers/dac/ad5755/ad5755.c
@@ -76,10 +76,10 @@ int8_t ad5755_init(struct ad5755_dev **device,
 	dev->this_device = init_param.this_device;
 
 	/* GPIO */
-	status = gpio_get(&dev->gpio_ldac, init_param.gpio_ldac);
-	status |= gpio_get(&dev->gpio_rst, init_param.gpio_rst);
-	status |= gpio_get(&dev->gpio_clr, init_param.gpio_clr);
-	status |= gpio_get(&dev->gpio_poc, init_param.gpio_poc);
+	status = gpio_get(&dev->gpio_ldac, &init_param.gpio_ldac);
+	status |= gpio_get(&dev->gpio_rst, &init_param.gpio_rst);
+	status |= gpio_get(&dev->gpio_clr, &init_param.gpio_clr);
+	status |= gpio_get(&dev->gpio_poc, &init_param.gpio_poc);
 
 	/* GPIO configuration. */
 	AD5755_LDAC_OUT;

--- a/drivers/dac/ad5761r/ad5761r.c
+++ b/drivers/dac/ad5761r/ad5761r.c
@@ -670,11 +670,11 @@ int32_t ad5761r_init(struct ad5761r_dev **device,
 	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* GPIO */
-	ret |= gpio_get(&dev->gpio_reset, init_param.gpio_reset);
+	ret |= gpio_get(&dev->gpio_reset, &init_param.gpio_reset);
 	dev->gpio_reset_value = init_param.gpio_reset_value;
-	ret |= gpio_get(&dev->gpio_clr, init_param.gpio_clr);
+	ret |= gpio_get(&dev->gpio_clr, &init_param.gpio_clr);
 	dev->gpio_clr_value = init_param.gpio_clr_value;
-	ret |= gpio_get(&dev->gpio_ldac, init_param.gpio_ldac);
+	ret |= gpio_get(&dev->gpio_ldac, &init_param.gpio_ldac);
 	dev->gpio_ldac_value = init_param.gpio_ldac_value;
 
 	if (dev->gpio_reset)

--- a/drivers/dac/ad5766/ad5766.c
+++ b/drivers/dac/ad5766/ad5766.c
@@ -303,7 +303,7 @@ int32_t ad5766_init(struct ad5766_dev **device,
 	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* GPIO */
-	ret |= gpio_get(&dev->gpio_reset, init_param.gpio_reset);
+	ret |= gpio_get(&dev->gpio_reset, &init_param.gpio_reset);
 	ret |= gpio_direction_output(dev->gpio_reset, GPIO_LOW);
 	mdelay(10);
 	ret |= gpio_set_value(dev->gpio_reset, GPIO_HIGH);

--- a/drivers/dac/ad5791/ad5791.c
+++ b/drivers/dac/ad5791/ad5791.c
@@ -89,9 +89,9 @@ int32_t ad5791_init(struct ad5791_dev **device,
 	dev->act_device = init_param.act_device;
 
 	/* GPIO */
-	status = gpio_get(&dev->gpio_reset, init_param.gpio_reset);
-	status |= gpio_get(&dev->gpio_clr, init_param.gpio_clr);
-	status |= gpio_get(&dev->gpio_ldac, init_param.gpio_ldac);
+	status = gpio_get(&dev->gpio_reset, &init_param.gpio_reset);
+	status |= gpio_get(&dev->gpio_clr, &init_param.gpio_clr);
+	status |= gpio_get(&dev->gpio_ldac, &init_param.gpio_ldac);
 
 	AD5791_RESET_OUT;
 	AD5791_RESET_HIGH;

--- a/drivers/frequency/ad9833/ad9833.c
+++ b/drivers/frequency/ad9833/ad9833.c
@@ -97,13 +97,13 @@ int8_t ad9833_init(struct ad9833_dev **device,
 
 	/* Setup GPIO pads. */
 	status |= gpio_get(&dev->gpio_psel,
-			   init_param.gpio_psel);
+			   &init_param.gpio_psel);
 	status |= gpio_get(&dev->gpio_fsel,
-			   init_param.gpio_fsel);
+			   &init_param.gpio_fsel);
 	status |= gpio_get(&dev->gpio_reset,
-			   init_param.gpio_reset);
+			   &init_param.gpio_reset);
 	status |= gpio_get(&dev->gpio_sleep,
-			   init_param.gpio_sleep);
+			   &init_param.gpio_sleep);
 
 	AD9834_PSEL_OUT;
 	AD9834_PSEL_LOW;

--- a/drivers/frequency/adf4106/adf4106.c
+++ b/drivers/frequency/adf4106/adf4106.c
@@ -118,10 +118,10 @@ int8_t adf4106_init(struct adf4106_dev **device,
 	status = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* GPIO */
-	status |= gpio_get(&dev->gpio_le, init_param.gpio_le);
-	status |= gpio_get(&dev->gpio_ce, init_param.gpio_ce);
-	status |= gpio_get(&dev->gpio_le2, init_param.gpio_le2);
-	status |= gpio_get(&dev->gpio_ce2, init_param.gpio_ce2);
+	status |= gpio_get(&dev->gpio_le, &init_param.gpio_le);
+	status |= gpio_get(&dev->gpio_ce, &init_param.gpio_ce);
+	status |= gpio_get(&dev->gpio_le2, &init_param.gpio_le2);
+	status |= gpio_get(&dev->gpio_ce2, &init_param.gpio_ce2);
 
 	/* Bring CE high to put device to power up */
 	ADF4106_CE_OUT;

--- a/drivers/frequency/adf4153/adf4153.c
+++ b/drivers/frequency/adf4153/adf4153.c
@@ -97,10 +97,10 @@ int8_t adf4153_init(struct adf4153_dev **device,
 	status = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* GPIO */
-	status |= gpio_get(&dev->gpio_le, init_param.gpio_le);
-	status |= gpio_get(&dev->gpio_ce, init_param.gpio_ce);
-	status |= gpio_get(&dev->gpio_le2, init_param.gpio_le2);
-	status |= gpio_get(&dev->gpio_ce2, init_param.gpio_ce2);
+	status |= gpio_get(&dev->gpio_le, &init_param.gpio_le);
+	status |= gpio_get(&dev->gpio_ce, &init_param.gpio_ce);
+	status |= gpio_get(&dev->gpio_le2, &init_param.gpio_le2);
+	status |= gpio_get(&dev->gpio_ce2, &init_param.gpio_ce2);
 
 	/* Bring CE high to put device to power up */
 	ADF4153_CE_OUT;

--- a/drivers/frequency/adf4156/adf4156.c
+++ b/drivers/frequency/adf4156/adf4156.c
@@ -68,8 +68,8 @@ int8_t adf4156_init(struct adf4156_dev **device,
 		return -1;
 
 	/* Setup GPIO pads */
-	status = gpio_get(&dev->gpio_le, init_param.gpio_le);
-	status |= gpio_get(&dev->gpio_ce, init_param.gpio_ce);
+	status = gpio_get(&dev->gpio_le, &init_param.gpio_le);
+	status |= gpio_get(&dev->gpio_ce, &init_param.gpio_ce);
 
 	/* Setup Control GPIO Pins */
 	ADF4156_LE_OUT;

--- a/drivers/frequency/adf4157/adf4157.c
+++ b/drivers/frequency/adf4157/adf4157.c
@@ -67,8 +67,8 @@ int8_t adf4157_init(struct adf4157_dev **device,
 		return -1;
 
 	/* Setup GPIO pads */
-	status = gpio_get(&dev->gpio_le, init_param.gpio_le);
-	status |= gpio_get(&dev->gpio_ce, init_param.gpio_ce);
+	status = gpio_get(&dev->gpio_le, &init_param.gpio_le);
+	status |= gpio_get(&dev->gpio_ce, &init_param.gpio_ce);
 
 	/* Setup Control GPIO Pins */
 	ADF4157_LE_OUT;

--- a/drivers/potentiometer/ad525x/ad525x.c
+++ b/drivers/potentiometer/ad525x/ad525x.c
@@ -121,10 +121,10 @@ int8_t ad525x_init(struct ad525x_dev **device,
 		status = i2c_init(&dev->i2c_desc, &init_param.i2c_init);
 	}
 
-	status |= gpio_get(&dev->gpio_reset, init_param.gpio_reset);
-	status |= gpio_get(&dev->gpio_shutdown, init_param.gpio_shutdown);
-	status |= gpio_get(&dev->gpio_ready, init_param.gpio_ready);
-	status |= gpio_get(&dev->gpio_wpbf, init_param.gpio_wpbf);
+	status |= gpio_get(&dev->gpio_reset, &init_param.gpio_reset);
+	status |= gpio_get(&dev->gpio_shutdown, &init_param.gpio_shutdown);
+	status |= gpio_get(&dev->gpio_ready, &init_param.gpio_ready);
+	status |= gpio_get(&dev->gpio_wpbf, &init_param.gpio_wpbf);
 
 	/* Deactivate Hardware Reset */
 	AD525X_RESET_OUT;

--- a/drivers/rf-transceiver/adf7023/adf7023.c
+++ b/drivers/rf-transceiver/adf7023/adf7023.c
@@ -108,8 +108,8 @@ int32_t adf7023_init(struct adf7023_dev **device,
 	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 
 	/* GPIO */
-	ret |= gpio_get(&dev->gpio_cs, init_param.gpio_cs);
-	ret |= gpio_get(&dev->gpio_miso, init_param.gpio_miso);
+	ret |= gpio_get(&dev->gpio_cs, &init_param.gpio_cs);
+	ret |= gpio_get(&dev->gpio_miso, &init_param.gpio_miso);
 
 	dev->adf7023_bbram_current = adf7023_bbram_default;
 


### PR DESCRIPTION
With the new structure of gpio driver, init param values should be
passed by reference.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>