### PR TITLE
projects: update Xilinx README file paths

### DIFF
--- a/projects/ad9172/src/README
+++ b/projects/ad9172/src/README
@@ -7,8 +7,9 @@
 	cp ../../../include/gpio.h ./
 	cp ../../../include/delay.h ./
 	cp ../../../drivers/platform/xilinx/axi_io.c ./
-	cp ../../../drivers/platform/xilinx/xilinx_platform_drivers.h ./
+	cp ../../../drivers/platform/xilinx/spi_extra.h ./
 	cp ../../../drivers/platform/xilinx/spi.c ./
+	cp ../../../drivers/platform/xilinx/gpio_extra.h ./
 	cp ../../../drivers/platform/xilinx/gpio.c ./
 	cp ../../../drivers/platform/xilinx/delay.c ./
 	cp ../../../util/util.c ./

--- a/projects/ad9208/README
+++ b/projects/ad9208/README
@@ -6,8 +6,9 @@
 	cp ../../include/gpio.h ./
 	cp ../../include/delay.h ./
 	cp ../../drivers/platform/xilinx/axi_io.c ./
-	cp ../../drivers/platform/xilinx/xilinx_platform_drivers.h ./
+	cp ../../drivers/platform/xilinx/spi_extra.h ./
 	cp ../../drivers/platform/xilinx/spi.c ./
+	cp ../../drivers/platform/xilinx/gpio_extra.h ./
 	cp ../../drivers/platform/xilinx/gpio.c ./
 	cp ../../drivers/platform/xilinx/delay.c ./
 	cp ../../util/util.c ./

--- a/projects/ad9371/src/README
+++ b/projects/ad9371/src/README
@@ -43,7 +43,7 @@
 	cp ../../../drivers/platform/xilinx/spi.c devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/spi_extra.h devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/gpio.c devices/adi_hal/
-	cp ../../../drivers/platform/altera/gpio_extra.h devices/adi_hal/
+	cp ../../../drivers/platform/xilinx/gpio_extra.h devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/delay.c devices/adi_hal/
 	cp ../../../drivers/axi_core/axi_adc_core/axi_adc_core.c devices/adi_hal/
 	cp ../../../drivers/axi_core/axi_adc_core/axi_adc_core.h devices/adi_hal/

--- a/projects/adrv9009/src/README
+++ b/projects/adrv9009/src/README
@@ -41,9 +41,9 @@
 	cp ../../../include/delay.h devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/axi_io.c devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/spi.c devices/adi_hal/
-	cp ../../../drivers/platform/altera/spi_extra.h devices/adi_hal/
+	cp ../../../drivers/platform/xilinx/spi_extra.h devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/gpio.c devices/adi_hal/
-	cp ../../../drivers/platform/altera/gpio_extra.h devices/adi_hal/
+	cp ../../../drivers/platform/xilinx/gpio_extra.h devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/delay.c devices/adi_hal/
 	cp ../../../drivers/axi_core/axi_adc_core/axi_adc_core.c devices/adi_hal/
 	cp ../../../drivers/axi_core/axi_adc_core/axi_adc_core.h devices/adi_hal/


### PR DESCRIPTION
After the restructure of the platform specific drivers, README files for
Xilinx platform were not properly updated.

This patch fixes the Xilinx platform drivers file paths.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>