### PR TITLE
travis: remove build_default

### DIFF
--- a/ci/travis/run_build.sh
+++ b/ci/travis/run_build.sh
@@ -6,10 +6,6 @@ sudo apt-get update
 
 . ./ci/travis/lib.sh
 
-build_default() {
-    . ./ci/travis/build_projects.sh
-}
-
 build_astyle() {
     . ./ci/travis/astyle.sh
 }
@@ -33,4 +29,4 @@ build_drivers() {
     make -C ./drivers -f Makefile
 }
 
-build_${BUILD_TYPE:-default}
+build_${BUILD_TYPE}


### PR DESCRIPTION
With the new restructure of Travis integration, the function is no
longer used.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>