### PR TITLE
tools: scripts: Makefile

### DIFF
--- a/projects/ad9371/src.mk
+++ b/projects/ad9371/src.mk
@@ -28,12 +28,19 @@ SRCS := $(PROJECT)/src/app/headless.c					\
 SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
 	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c			\
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c		\
-	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c			\
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c			\
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c			\
-	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
-	$(NO-OS)/util/util.c	
+	$(NO-OS)/util/util.c
+ifeq (xilinx,$(strip $(PLATFORM)))
+SRCS += $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
+	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c			\
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c
+else
+SRCS += $(DRIVERS)/axi_core/clk_altera_a10_fpll/clk_altera_a10_fpll.c	\
+	$(DRIVERS)/axi_core/jesd204/altera_a10_atx_pll.c		\
+	$(DRIVERS)/axi_core/jesd204/altera_a10_cdr_pll.c		\
+	$(DRIVERS)/axi_core/jesd204/altera_adxcvr.c
+endif
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
 	$(PLATFORM_DRIVERS)/spi.c					\
 	$(PLATFORM_DRIVERS)/gpio.c					\
@@ -56,11 +63,18 @@ INCS :=	$(PROJECT)/src/app/app_config.h					\
 INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h			\
 	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.h			\
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h				\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h		\
-	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h			\
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h			\
-	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h
+ifeq (xilinx,$(strip $(PLATFORM)))
+INCS += $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h		\
+	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h			\
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h
+else
+INCS += $(DRIVERS)/axi_core/clk_altera_a10_fpll/clk_altera_a10_fpll.h	\
+	$(DRIVERS)/axi_core/jesd204/altera_a10_atx_pll.h		\
+	$(DRIVERS)/axi_core/jesd204/altera_a10_cdr_pll.h		\
+	$(DRIVERS)/axi_core/jesd204/altera_adxcvr.h
+endif
 INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\
 	$(PLATFORM_DRIVERS)/gpio_extra.h
 INCS +=	$(INCLUDE)/axi_io.h						\

--- a/projects/adrv9009/src.mk
+++ b/projects/adrv9009/src.mk
@@ -33,12 +33,19 @@ SRCS := $(PROJECT)/src/app/headless.c					\
 SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
 	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c			\
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c		\
-	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c			\
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c			\
-	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
-	$(NO-OS)/util/util.c
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c
+SRCS +=	$(NO-OS)/util/util.c
+ifeq (xilinx,$(strip $(PLATFORM)))
+SRCS += $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
+	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c			\
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c
+else
+SRCS += $(DRIVERS)/axi_core/clk_altera_a10_fpll/clk_altera_a10_fpll.c	\
+	$(DRIVERS)/axi_core/jesd204/altera_a10_atx_pll.c		\
+	$(DRIVERS)/axi_core/jesd204/altera_a10_cdr_pll.c		\
+	$(DRIVERS)/axi_core/jesd204/altera_adxcvr.c
+endif
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
 	$(PLATFORM_DRIVERS)/spi.c					\
 	$(PLATFORM_DRIVERS)/gpio.c					\
@@ -81,11 +88,18 @@ INCS :=	$(PROJECT)/src/app/app_config.h					\
 INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h			\
 	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.h			\
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h				\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h		\
-	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h			\
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h			\
-	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h
+ifeq (xilinx,$(strip $(PLATFORM)))
+INCS += $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h		\
+	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h			\
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h
+else
+INCS += $(DRIVERS)/axi_core/clk_altera_a10_fpll/clk_altera_a10_fpll.h	\
+	$(DRIVERS)/axi_core/jesd204/altera_a10_atx_pll.h		\
+	$(DRIVERS)/axi_core/jesd204/altera_a10_cdr_pll.h		\
+	$(DRIVERS)/axi_core/jesd204/altera_adxcvr.h
+endif
 INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\
 	$(PLATFORM_DRIVERS)/gpio_extra.h
 INCS +=	$(INCLUDE)/axi_io.h						\

--- a/tools/scripts/Makefile
+++ b/tools/scripts/Makefile
@@ -81,10 +81,6 @@ CFLAGS = -Wall 								\
 	 -Wuninitialized						\
 	 -Wunused-but-set-parameter					\
 	 -Wno-unused-parameter						\
-	 -fdata-sections						\
-	 -ffunction-sections 						\
-	 -O2 								\
-	 -g3								\
 	 -MMD 								\
 	 -MP								\
 	 -lm						
@@ -106,7 +102,11 @@ LDFLAGS = -T $(LSCRIPT)							\
 ifeq (xilinx,$(strip $(PLATFORM)))
 
 # Define the platform compiler switch
-CFLAGS += -D XILINX_PLATFORM
+CFLAGS += -D XILINX_PLATFORM						\
+	 -fdata-sections						\
+	 -ffunction-sections 						\
+	 -O2								\
+	 -g3
 # Xilinx's generated linker script path
 LSCRIPT := $(BUILD_DIR)/app/src/lscript.ld
 # Xilinx's generate bsp library path
@@ -195,6 +195,8 @@ LD := nios2-elf-g++
 
 CFLAGS += -xc								\
 	  -pipe								\
+	  -O3								\
+	  -g								\
 	  -mno-hw-div							\
 	  -mhw-mul							\
 	  -mno-hw-mulx							\
@@ -217,8 +219,10 @@ LDFLAGS += -msys-crt0='$(BUILD_DIR)/bsp//obj/HAL/src/crt0.o'		\
 	   -mhw-mul							\
 	   -mno-hw-mulx							\
 	   -mgpopt=global						\
+	   -lm								\
+	   -msys-lib=m							\
 	   -Wl,-Map=sw.map
-	   
+
 STAMP +=   --thread_model hal						\
 	   --cpu_name sys_cpu						\
 	   --qsys true							\
@@ -266,6 +270,7 @@ all: pre-build eval-hardware bsp
 
 .SILENT:bsp
 bsp: 
+	$(call print,Platform : \e[33m$(PLATFORM)\e[39m\n)
 	@ if [ "$(PLATFORM)" = "xilinx" ];then				\
 		$(eval export ARCH:= $(shell cat $(TEMP_DIR)/arch.txt))	\
 		$(MAKE) -s xilinx-bsp;					\
@@ -289,6 +294,7 @@ compile:
 	fi;))
 	$(MAKE) -s $(EXEC)
 
+.SILENT:create-build-dirs
 create-build-dirs:
 	mkdir -p $(BUILD_DIR)/app
 	mkdir -p $(BUILD_DIR)/app/src
@@ -310,7 +316,7 @@ clean:
 	rm -rf $(BUILD_DIR)
 
 # If the hardware file is not specified, start searching for one
-# Check for .hdf files inside the project directory	
+# Check for .hdf files inside the project directory
 .SILENT:eval-hardware
 eval-hardware:	
 ifndef HARDWARE
@@ -339,7 +345,6 @@ endif
 	else								\
 		echo none;						\
 	fi;))
-	$(call print,Platform : \e[33m$(PLATFORM)\e[39m\n)
 	@ if [ "$(PLATFORM)" = "xilinx" ];then				\
 		$(MAKE) -s xilinx-read-hdf;				\
 	elif [ "$(PLATFORM)" = "altera" ];then				\
@@ -358,7 +363,7 @@ altera-bsp:
 altera-elf:
 	nios2-elf-insert $(BUILD_DIR)/$(EXEC).elf $(STAMP)
 
-.SILENT:pre-build		
+.SILENT:pre-build
 pre-build:
 	@$(MAKE) -s create-build-dirs
 
@@ -372,10 +377,24 @@ post-build:
 		mv -f sw.map $(TEMP_DIR);				\
 	fi;
 
-xilinx:	xil-pre-cleanup eval-hardware pre-build xilinx-bsp
-	$(call copy_srcs,xilinx)
-	@$(MAKE) -s compile
-	rm -rf $(BUILD_DIR)/SDK.log
+# Upload the bitstream and elf file to the board
+.SILENT:run
+run: eval-hardware
+	@ if [ "$(PLATFORM)" = "xilinx" ];then				\
+		xsdb $(SCRIPTS_DIR)/upload.tcl				\
+			$(shell cat $(TEMP_DIR)/arch.txt) 		\
+			$(BUILD_DIR)/hw/system_top.bit			\
+			$(BUILD_DIR)/$(EXEC).elf			\
+			$(BUILD_DIR)/hw	;				\
+	elif [ "$(PLATFORM)" = "altera" ];then				\
+		nios2-configure-sof *.sof;				\
+		nios2-download -r -g $(BUILD_DIR)/$(EXEC).elf;		\
+		nios2-terminal;						\
+	elif [ "$(PLATFORM)" = "none" ]; then				\
+		$(call print_err,Platform not found\n)			\
+		exit 1;							\
+	fi;
+
 
 # Extract the architecture from the hdf file
 .SILENT:xilinx-read-hdf
@@ -390,7 +409,6 @@ xilinx-bsp:
 	$(call print,Building hardware specification and bsp \n);	\
 	xsdk -batch -source $(SCRIPTS_PATH)/create_project.tcl		\
 		$(SDK_WORKSPACE) $(HARDWARE) $(ARCH) $(NULL);		\
-	mv $(TEMP_DIR)/system_top.bit $(BUILD_DIR);			\
 	fi;
 # Update the linker script the heap size for microlbaze from 0x800 to 
 # 0x100000 

--- a/tools/scripts/Makefile
+++ b/tools/scripts/Makefile
@@ -1,7 +1,14 @@
-export PROCESSOR_CORE 
+#------------------------------------------------------------------------------
+#                             EXPORTED VARIABLES                               
+#------------------------------------------------------------------------------
+# Exported variables used by subshells
 export HARDWARE
 export PLATFORM
+export ARCH
 
+#------------------------------------------------------------------------------
+#                           ENVIRONMENT VARIABLES                              
+#------------------------------------------------------------------------------
 NO-OS 		  = $(CURDIR)/../..
 DRIVERS 	  = $(NO-OS)/drivers
 INCLUDE 	  = $(NO-OS)/include
@@ -10,15 +17,21 @@ PROJECTS_DIR 	  = $(NO-OS)/projects
 SDK_WORKSPACE	  = $(PROJECT)/build
 BUILD_DIR	  = $(PROJECT)/build
 OBJECTS_DIR	  = $(BUILD_DIR)/obj
+TEMP_DIR	  = $(BUILD_DIR)/tmp
 SCRIPTS_PATH 	  = $(SCRIPTS_DIR)/platform/$(PLATFORM)
-LIBRARY_DIR 	  = $(BUILD_DIR)/bsp/$(PROCESSOR_CORE)/lib
 PLATFORM_DRIVERS  = $(DRIVERS)/platform/LOCAL_PLATFORM
 PROJECT 	  = $(PROJECTS_DIR)/$(TARGET)
 
-# uncomment this line to include a custom config
+#------------------------------------------------------------------------------
+#                             MAKEFILE INCLUDES                                
+#------------------------------------------------------------------------------
+# Uncomment this line to include a custom config
 #include $(SCRIPTS_DIR)/config.mk
 include $(PROJECTS_DIR)/$(TARGET)/src.mk
 
+#------------------------------------------------------------------------------
+#                               VERBOSE LEVEL                                  
+#------------------------------------------------------------------------------
 # Default verbosity level is 0
 VERBOSE ?=0
 ifeq ($(VERBOSE),1)
@@ -29,25 +42,38 @@ MUTE = @
 NULL = >/dev/null
 endif
 
+#------------------------------------------------------------------------------
+#                                ECHO HELPER                                   
+#------------------------------------------------------------------------------
 EXEC = release
 TIMESTAMP = $(shell date +"%T")
 define print
-	@printf "\\e[32m[$(TIMESTAMP)]\\e[39m $(1)"
+	printf "\\e[32m[$(TIMESTAMP)]\\e[39m $(1)"
 endef
 define print_err
-	@printf "\\e[32m[$(TIMESTAMP)]\\e[31m $(1)"
+	printf "\\e[32m[$(TIMESTAMP)]\\e[31m $(1)"
 endef
+
+#------------------------------------------------------------------------------
+#                              DEFAULT COMPILER                                
+#------------------------------------------------------------------------------
 CC ?= gcc
 
-# Xilinx platform handling
-ifeq (xilinx,$(strip $(PLATFORM)))
+#------------------------------------------------------------------------------
+#                              DEFAULT LINKER                                  
+#------------------------------------------------------------------------------
+LD ?= $(CC)
 
+#------------------------------------------------------------------------------
+#                            COMMON COMPILER FLAGS                             
+#------------------------------------------------------------------------------
 CFLAGS = -Wall 								\
 	 -Wmissing-field-initializers					\
 	 -Wclobbered 							\
 	 -Wempty-body 							\
 	 -Wignored-qualifiers 						\
 	 -Wmissing-parameter-type					\
+	 -Wno-format  							\
 	 -Wold-style-declaration					\
 	 -Woverride-init 						\
 	 -Wsign-compare							\
@@ -64,13 +90,37 @@ CFLAGS = -Wall 								\
 	 -lm						
 	#-Werror
 
-LDFLAGS = -Wl,-T							\
-	  -Wl,$(BUILD_DIR)/app/src/lscript.ld -L $(LIBRARY_DIR)
+#------------------------------------------------------------------------------
+#                            COMMON LINKER FLAGS                               
+#------------------------------------------------------------------------------
+LDFLAGS = -T $(LSCRIPT)							\
+	  -L $(LIBRARY_DIRS)
 
-# Zynq
-ifeq (ps7_cortexa9_0,$(strip $(PROCESSOR_CORE)))
+#------------------------------------------------------------------------------
+#                             PLATFORM HANDLING                                
+#------------------------------------------------------------------------------
+
+########|----------------------------------------------------------------------
+########|                           XILINX                                     
+########|----------------------------------------------------------------------
+ifeq (xilinx,$(strip $(PLATFORM)))
+
+# Define the platform compiler switch
+CFLAGS += -D XILINX_PLATFORM
+# Xilinx's generated linker script path
+LSCRIPT := $(BUILD_DIR)/app/src/lscript.ld
+# Xilinx's generate bsp library path
+LIBRARY_DIRS := $(BUILD_DIR)/bsp/$(ARCH)/lib
+# Xilinx's bsp include path
+EXTRA_INCS := -I $(BUILD_DIR)/bsp/$(ARCH)/include
+################|--------------------------------------------------------------
+################|                   Zynq                                       
+################|--------------------------------------------------------------
+ifeq (ps7_cortexa9_0,$(strip $(ARCH)))
 
 CC := arm-none-eabi-gcc
+
+LD := $(CC)
 
 CFLAGS += -mcpu=cortex-a9 						\
 	  -mfpu=vfpv3 							\
@@ -82,16 +132,24 @@ LDFLAGS += -specs=$(BUILD_DIR)/app/src/Xilinx.spec 			\
 	   -mcpu=cortex-a9						\
 	   -Wl,-build-id=none
 endif
-# Zynqmp 
-ifeq (psu_cortexa53_0,$(strip $(PROCESSOR_CORE)))
+################|--------------------------------------------------------------
+################|                   ZynqMP                                     
+################|--------------------------------------------------------------
+ifeq (psu_cortexa53_0,$(strip $(ARCH)))
 
 CC := aarch64-none-elf-gcc
 
+LD := $(CC)
+
 endif
-# Microblaze
-ifeq (sys_mb,$(strip $(PROCESSOR_CORE)))
+################|--------------------------------------------------------------
+################|                  Microblaze                                  
+################|--------------------------------------------------------------
+ifeq (sys_mb,$(strip $(ARCH)))
 
 CC := microblaze-xilinx-elf-gcc
+
+LD := $(CC)
 
 CFLAGS += -mcpu=cortex-a9 						\
 	  -DXILINX -DMICROBLAZE						\
@@ -121,81 +179,153 @@ endif
 # Common xilinx libs
 LIBS =	-Wl,--start-group,-lxil,-lgcc,-lc,--end-group
 
+else
+ifeq (altera,$(strip $(PLATFORM)))
+
+# Define the platform compiler switch
+CFLAGS += -D ALTERA_PLATFORM
+
+LSCRIPT := $(BUILD_DIR)/bsp/linker.x
+
+LIBRARY_DIRS := $(BUILD_DIR)/bsp
+
+CC := nios2-elf-gcc 
+
+LD := nios2-elf-g++
+
+CFLAGS += -xc								\
+	  -pipe								\
+	  -mno-hw-div							\
+	  -mhw-mul							\
+	  -mno-hw-mulx							\
+	  -mgpopt=global						\
+	  -D__hal__							\
+	  -DALT_NO_INSTRUCTION_EMULATION 				\
+	  -DALTERA_TRIPLE_SPEED_MAC 					\
+	  -DALT_SINGLE_THREADED 					\
+	  -DALTERA_AUTONEG_TIMEOUT_THRESHOLD=2500 			\
+	  -DALTERA_CHECKLINK_TIMEOUT_THRESHOLD=10000 			\
+	  -DALTERA_NOMDIO_TIMEOUT_THRESHOLD=1000000  			\
+	  -DALTERA							\
+	  -DNIOS_II
+
+LDFLAGS += -msys-crt0='$(BUILD_DIR)/bsp//obj/HAL/src/crt0.o'		\
+	   -msys-lib=hal_bsp 						\
+	   -DALTERA							\
+	   -DNIOS_II							\
+	   -mno-hw-div							\
+	   -mhw-mul							\
+	   -mno-hw-mulx							\
+	   -mgpopt=global						\
+	   -Wl,-Map=sw.map
+	   
+STAMP +=   --thread_model hal						\
+	   --cpu_name sys_cpu						\
+	   --qsys true							\
+	   --simulation_enabled false					\
+	   --id 182193580						\
+	   --sidp 0x101814e8						\
+	   --timestamp 1520874786					\
+	   --stderr_dev sys_uart					\
+	   --stdin_dev sys_uart						\
+	   --stdout_dev sys_uart					\
+	   --sopc_system_name system_bd					\
+	   --sopcinfo $(HARDWARE)
+endif
 endif
 
 # Add the common include paths
-INC_PATHS = $(foreach x, $(INCS), $(addprefix -I ,$(dir $(x))))
-LIB_PATHS = $(foreach x, $(LIBRARY_DIR), $(addprefix -L ,$(x)))
-EXTRA_INCS =
+INC_PATHS :=-I $(BUILD_DIR)/app/src
+LIB_PATHS = $(foreach x, $(LIBRARY_DIRS), $(addprefix -L ,$(x)))
 
 OBJS = $(SRCS:.c=.o)
 
 # Compile all the source files
 %.o : %.c
-	$(call print, [CC] $(notdir $<) \n)
-	$(MUTE)$(CC) $(CFLAGS) $(INC_PATHS) $(EXTRA_INCS)		\
+	@$(call print,[CC] $(notdir $<) \n)
+	$(CC) $(CFLAGS)	$(INC_PATHS) $(EXTRA_INCS)			\
 	-c $(addprefix $(BUILD_DIR)/app/src/,$(notdir $<))		\
 	-o $(addprefix $(OBJECTS_DIR)/,$(notdir $@))
 
 # Link the resulted object files
-$(EXEC): check-srcs $(subst LOCAL_PLATFORM,xilinx,$(OBJS))		\
-		$(BUILD_DIR)/app/src/lscript.ld
-	$(call print, [LD] $(shell ls $(OBJECTS_DIR)) \n)
-	$(MUTE)$(CC) $(LDFLAGS) $(LIB_PATHS) 				\
+$(EXEC): $(subst LOCAL_PLATFORM,xilinx,$(OBJS))				\
+		$(LSCRIPT)
+	$(call print,[LD] $(shell ls $(OBJECTS_DIR)) \n)
+	$(MUTE)$(LD) $(LDFLAGS) $(LIB_PATHS) 				\
 	$(OBJECTS_DIR)/*.o						\
 	$(LIBS) -o $(BUILD_DIR)/$(EXEC).elf
 
-# Copy the source files from the no-Os repo to the local project
-define copy_srcs
-	$(MUTE)cp -r $(subst LOCAL_PLATFORM,$(1),$(SRCS))		\
-		$(BUILD_DIR)/app/src/
-	$(MUTE)cp -r $(subst LOCAL_PLATFORM,$(1),$(INCS))		\
-		$(BUILD_DIR)/app/src/
-endef
-
 .DEFAULT_GOAL := all
-all: xilinx
 
-compile: $(EXEC)
+.SILENT:all
+all: pre-build eval-hardware bsp 
+	$(MAKE) -s copy-srcs
+	$(MAKE) -s compile
+	$(MAKE) -s post-build
+	$(call print,Done \n)
 
-create-obj-dir:
-	$(MUTE)mkdir -p $(OBJECTS_DIR)
+.SILENT:bsp
+bsp: 
+	@ if [ "$(PLATFORM)" = "xilinx" ];then				\
+		$(eval export ARCH:= $(shell cat $(TEMP_DIR)/arch.txt))	\
+		$(MAKE) -s xilinx-bsp;					\
+	elif [ "$(PLATFORM)" = "altera" ];then				\
+		$(MAKE) -s altera-bsp;					\
+	else								\
+		$(call print_err,Can't generate the bsp\n);		\
+		exit 1;							\
+	fi;
+
+.SILENT:compile	
+compile: 
+	$(eval export EXTRA_INCS:= $(shell \
+	if [ "$(PLATFORM)" = "xilinx" ]; then	\
+		echo "-I $(BUILD_DIR)/bsp/$(ARCH)/include";\
+	elif [ "$(PLATFORM)" = "altera" ];then				\
+		echo "-I $(BUILD_DIR)/bsp/HAL/inc/sys			\
+		      -I $(BUILD_DIR)/bsp/drivers/inc			\
+		      -I $(BUILD_DIR)/bsp/HAL/inc			\
+		      -I $(BUILD_DIR)/bsp";				\
+	fi;))
+	$(MAKE) -s $(EXEC)
+
+create-build-dirs:
+	mkdir -p $(BUILD_DIR)/app
+	mkdir -p $(BUILD_DIR)/app/src
+	mkdir -p $(OBJECTS_DIR)
+	mkdir -p $(TEMP_DIR)
 	
-create-build-dir:
-	$(MUTE)mkdir -p $(BUILD_DIR)
 
+# Copy the source files from the no-Os repo to the local project
+.SILENT:copy-srcs
 copy-srcs:
-	$(call copy_srcs,$(PLATFORM))
+	cp -r $(subst LOCAL_PLATFORM,$(PLATFORM),$(SRCS))	\
+		$(BUILD_DIR)/app/src/
+	cp -r $(subst LOCAL_PLATFORM,$(PLATFORM),$(INCS))	\
+		$(BUILD_DIR)/app/src/
 
-check-srcs:
-ifeq (xilinx,$(strip $(PLATFORM)))
-# Replace the target sources (the default ones are the repository files) with
-# the local project sources
-	$(eval SRCS :=$(shell find $(BUILD_DIR)/app/src/ -name '*.c'))
-	$(eval EXTRA_INCS :=-I $(BUILD_DIR)/bsp/$(PROCESSOR_CORE)/include)
-	$(eval INC_PATHS :=-I $(BUILD_DIR)/app/src)
-endif
-
+.SILENT:clean
 clean:
-
 	$(call print,Cleaning build workspace \n)
-	$(MUTE)rm -rf temp
-	$(MUTE)rm -rf $(BUILD_DIR)
-	@$(MAKE) -s xil-pre-cleanup
+	rm -rf $(BUILD_DIR)
 
-eval-hardware:
 # If the hardware file is not specified, start searching for one
-# Check for .hdf files inside the project directory		
+# Check for .hdf files inside the project directory	
+.SILENT:eval-hardware
+eval-hardware:	
 ifndef HARDWARE
 	$(eval HARDWARE = $(shell					\
 	if [ -z $(HARDWARE) ]; then					\
-		echo $(shell find $(PROJECT) -name "*.hdf") ;	\
+		echo $(shell find $(PROJECT) -maxdepth 1		\
+			-name "*.hdf") ;				\
 	fi;))
 	$(eval HARDWARE = $(shell					\
 	if [ -z $(HARDWARE) ]; then					\
-		echo $(shell find $(PROJECT) -name "*.sopcinfo") ;	\
+		echo $(shell find $(PROJECT) -maxdepth 1		\
+			-name "*.sopcinfo") ;				\
 	else								\
-		echo $(shell find $(PROJECT) -name "*.hdf") ;	\
+		echo $(shell find $(PROJECT) -maxdepth 1		\
+			-name "*.hdf") ;				\
 	fi;))
 endif
 # Assign the platform based on the hardware file extension
@@ -203,59 +333,68 @@ endif
 	$(eval PLATFORM:= $(shell \
 	if [ "$(findstring hdf,$(notdir $(HARDWARE)))" = "hdf" ]; then	\
 		echo xilinx;						\
-	elif [ "$(findstring sopcinfo,$(notdir $(HARDWARE)))" = "sopcinfo" ]; then\
+	elif [ "$(findstring sopcinfo,$(notdir $(HARDWARE)))" 		\
+		= "sopcinfo" ]; then					\
 		echo altera;						\
 	else								\
 		echo none;						\
 	fi;))
-	@ if [ "$(PLATFORM)" = "none" ]; then				\
-		echo \\e[32m[$(TIMESTAMP)]\\e[31m Platform not found\\e[39m;\
+	$(call print,Platform : \e[33m$(PLATFORM)\e[39m\n)
+	@ if [ "$(PLATFORM)" = "xilinx" ];then				\
+		$(MAKE) -s xilinx-read-hdf;				\
+	elif [ "$(PLATFORM)" = "altera" ];then				\
+		echo nios2 > $(TEMP_DIR)/arch.txt;			\
+	elif [ "$(PLATFORM)" = "none" ]; then				\
+		$(call print_err,Platform not found\n)			\
 		exit 1;							\
 	fi;
-	$(call print,Found platform : \e[33m$(PLATFORM)\e[39m\n)
 
+.SILENT:altera-bsp
+altera-bsp:
+	nios2-bsp hal $(BUILD_DIR)/bsp $(HARDWARE) --cpu-name sys_cpu $(NULL)
+	$(MAKE) -C $(BUILD_DIR)/bsp $(NULL)
+
+.SILENT:altera-elf
+altera-elf:
+	nios2-elf-insert $(BUILD_DIR)/$(EXEC).elf $(STAMP)
+
+.SILENT:pre-build		
 pre-build:
-	@$(MAKE) -s xil-pre-cleanup
-	@$(MAKE) -s create-build-dir
-	@$(MAKE) -s create-obj-dir
+	@$(MAKE) -s create-build-dirs
 
-prepare-project:
+.SILENT:post-build
+post-build:
 	@ if [ "$(PLATFORM)" = "xilinx" ];then				\
-		$(MAKE) -s xil-prepare-project	;			\
-		$(MAKE) -s copy-srcs ;					\
+		rm -rf \.Xil;						\
+		rm -rf \.metadata;					\
+	else								\
+		$(MAKE) -s altera-elf;					\
+		mv -f sw.map $(TEMP_DIR);				\
 	fi;
+
+xilinx:	xil-pre-cleanup eval-hardware pre-build xilinx-bsp
+	$(call copy_srcs,xilinx)
 	@$(MAKE) -s compile
+	rm -rf $(BUILD_DIR)/SDK.log
 
-xilinx: eval-hardware pre-build xil-prepare-project copy-srcs
-	@$(MAKE) -s compile
-	$(call print,Done \n)
+# Extract the architecture from the hdf file
+.SILENT:xilinx-read-hdf
+xilinx-read-hdf:
+	cp $(HARDWARE) $(TEMP_DIR)
+	xsct $(SCRIPTS_PATH)/read_hdf.tcl $(NULL)			\
+		$(TEMP_DIR) $(TEMP_DIR)/$(notdir $(HARDWARE))
 
-xil-extract-hdf-info:
-	$(MUTE)mkdir -p temp
-	$(MUTE)cp $(HARDWARE) temp
-	$(MUTE)rm -rf arch.txt
-# Extract the processor name from the hdf file
-	$(MUTE)xsct $(SCRIPTS_PATH)/read_hdf.tcl $(NULL)		\
-		temp/$(notdir $(HARDWARE))
-
-xil-update-hdf-info:
-	$(eval PROCESSOR_CORE:= $(shell cat arch.txt))
-	$(MUTE)rm -rf arch.txt
-
-xil-pre-cleanup:
-	$(MUTE)rm -rf \.Xil
-	$(MUTE)rm -rf \.metadata
-
-xil-prepare-project: xil-extract-hdf-info xil-update-hdf-info
-	$(call print,Building hardware specification and bsp \n)
-# Create the local sdk project
-	$(MUTE)xsdk -batch -source $(SCRIPTS_PATH)/create_project.tcl	\
-	$(SDK_WORKSPACE) $(HARDWARE) $(PROCESSOR_CORE) $(NULL)
-	$(MUTE)mv $(PROJECT)/temp/system_top.bit $(BUILD_DIR)
-	$(MUTE)rm -rf temp
-	# Update in the linker script the heap size for microlbaze from 0x800 to 
-	# 0x100000 
-	@ if [ "$(PROCESSOR_CORE)" = "sys_mb" ]; then			\
+.SILENT:xilinx-bsp
+xilinx-bsp:
+	@ if [ ! -d "$(BUILD_DIR)/bsp" ];then				\
+	$(call print,Building hardware specification and bsp \n);	\
+	xsdk -batch -source $(SCRIPTS_PATH)/create_project.tcl		\
+		$(SDK_WORKSPACE) $(HARDWARE) $(ARCH) $(NULL);		\
+	mv $(TEMP_DIR)/system_top.bit $(BUILD_DIR);			\
+	fi;
+# Update the linker script the heap size for microlbaze from 0x800 to 
+# 0x100000 
+	@ if [ "$(ARCH)" = "sys_mb" ]; then				\
 		sed -i "s/_HEAP_SIZE : 0x800/_HEAP_SIZE : 0x100000/g"	\
 		$(BUILD_DIR)/app/src/lscript.ld;			\
 	fi;

--- a/tools/scripts/platform/intel/environment.sh
+++ b/tools/scripts/platform/intel/environment.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+if [ "$#" -eq 2 ]
+then
+export PATH="$PATH							\
+:$$(1)/$$(2)/quartus/bin						\
+:$$(1)/$$(2)/quartus/sop_builder/bin					\
+:$$(1)/$$(2)/nios2eds							\
+:$$(1)/$$(2)/nios2edsbin						\
+:$$(1)/$$(2)/nios2eds/sdk/bin						\
+:$$(1)/$$(2)/embedded							\
+:$$(1)/$$(2)/nios2edsbin/gnu/H-x86_64-pc-linux-gnu/bin			\
+:$$(1)/$$(2)/modelsim_ase/linuxaloem					\
+:$$(1)/$$(2)/embedded/host_tools/menor/gnu/arm/baremetal/bin		\
+:$$(1)/$$(2)/embedded/host_tools/altera/preloadergen			\
+:$$(1)/$$(2)/embedded/host_tools/altera/mkimage				\
+:$$(1)/$$(2)/embedded/host_tools/altera/mkpimag				\
+:$$(1)/$$(2)/embedded/host_tools/altera/device_tee			\
+:$$(1)/$$(2)/embedded/host_tools/altera/diskutils			\
+:$$(1)/$$(2)/embedded/host_tools/altera/imagecat			\
+:$$(1)/$$(2)/embedded/host_tools/altera/securebot			\
+:$$(1)/$$(2)/embedded/host_tools/gnu/dtc				\
+:$$(1)/$$(2)/embedded/ds-5/sw/gcc/bin					\
+:$$(1)/$$(2)/embedded/ds-5/sw/ARMCompler5.06u1/bin			\
+:$$(1)/$$(2)/embedded/ds-5/bi"
+else
+echo "Usage : source intel_env.sh [/path/to/intel/directory] [version]"
+fi

--- a/tools/scripts/platform/xilinx/create_project.tcl
+++ b/tools/scripts/platform/xilinx/create_project.tcl
@@ -1,5 +1,5 @@
 if { $argc != 3 } {
-	puts "Invalid arguments"
+	puts "create_project: Invalid arguments"
 	exit
 }
 # Set the workspace

--- a/tools/scripts/platform/xilinx/environment.sh
+++ b/tools/scripts/platform/xilinx/environment.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if [ "$#" -eq 2 ]
+then
+export PATH="$PATH							\
+:$$(1)/Vivado/$$(2)/bin							\
+:$$(1)/SDK/$$(2)/bin							\
+:$$(1)/SDK/$$(2)/gnu/microblaze/lin/bin					\
+:$$(1)/SDK/$$(2)/gnu/arm/lin/bin					\
+:$$(1)/SDK/$$(2)/gnu/microblaze/linux_toolchain/lin64_le/bin		\
+:$$(1)/SDK/$$(2)/gnu/aarch32/lin/gcc-arm-linux-gnueabi/bin		\
+:$$(1)/SDK/$$(2)/gnu/aarch32/lin/gcc-arm-none-eabi/bin			\
+:$$(1)/SDK/$$(2)/gnu/aarch64/lin/aarch64-linux/bin			\
+:$$(1)/SDK/$$(2)/gnu/aarch64/lin/aarch64-none/bin			\
+:$$(1)/SDK/$$(2)/gnu/armr5/lin/gcc-arm-none-eabi/bin			\
+:$$(1)/SDK/$$(2)/tps/lnx64/cmake-3.3.2/bin:$PATH"
+else
+echo "Usage : source xilinx_env.sh [/path/to/xilinx/directory] [version]"
+fi

--- a/tools/scripts/platform/xilinx/read_hdf.tcl
+++ b/tools/scripts/platform/xilinx/read_hdf.tcl
@@ -1,9 +1,10 @@
-if { $argc != 1 } {
-	puts "Invalid arguments"
+if { $argc != 2 } {
+	puts "read_hdf: Invalid arguments"
 	exit
 }
+cd [lindex $argv 0]
 # Open the design
-hsi open_hw_design [lindex $argv 0]
+hsi open_hw_design [lindex $argv 1]
 # Save the cpu name in a variable
 set cpu_name [lindex [hsi get_cells -filter {IP_TYPE==PROCESSOR}] 0]
 # Open a file

--- a/tools/scripts/upload.tcl
+++ b/tools/scripts/upload.tcl
@@ -1,0 +1,58 @@
+set arch [lindex $argv 0]
+set bitstream [lindex $argv 1]
+set elf [lindex $argv 2]
+set hw_path [lindex $argv 3]
+
+# Connect to the fpga
+connect
+
+# Reset and stop the ARM CPU before we re-program the FPGA if we are on a ZYNQ.
+# Otherwise undefined behavior can occur.
+if {$arch == "ps7_cortexa9_0"} {
+	targets -set -filter {name =~ "APU*"}
+	stop
+	rst
+}
+
+# Write the bitstream
+if {$arch == "ps7_cortexa9_0"} {
+	targets -set -filter {name =~ "xc7z*"}
+} elseif {$arch == "psu_cortexa53_0"} {
+	targets -set -filter {name =~ "PSU"}
+} elseif {$arch == "sys_mb"} {
+	targets -set -filter {name =~ "xc7*" || name =~ "xck*" }
+}
+fpga -file "[file normalize $bitstream]"
+
+# Initialize the board
+if {$arch == "ps7_cortexa9_0"} {
+	targets -set -filter {name =~ "APU*"}
+	source "[file normalize $hw_path/ps7_init.tcl]"
+	ps7_init
+	ps7_post_config
+} elseif {$arch == "psu_cortexa53_0"} {
+	targets -set -filter {name =~ "APU*"}
+	source "[file normalize $hw_path/psu_init.tcl]"
+	psu_init
+	psu_post_config
+	psu_ps_pl_isolation_removal
+	psu_ps_pl_reset_config
+	mwr 0xffff0000 0x14000000
+	mwr 0xFD1A0104 0x380E
+} elseif {$arch == "sys_mb"} {
+	targets -set -filter {name =~ "xc7*" || name =~ "xck*" }
+}
+
+# Upload the elf file
+if {$arch == "ps7_cortexa9_0"} {
+	targets -set -filter {name =~ "*Cortex-A9 MPCore #0*"}
+} elseif {$arch == "psu_cortexa53_0"} {
+	targets -set -filter {name =~ "*Cortex-A53 #0*"}
+} elseif {$arch == "sys_mb"} {
+	after 1000
+	targets -set -filter {name =~ "*MicroBlaze #*"}
+}
+dow "[file normalize $elf]"
+con
+disconnect
+exit


### PR DESCRIPTION
The makefile now has the possibility to build and upload the no-Os software, supporting Intel and Xilinx carriers.
Added environment scripts that are used when building with an SDK and updated the project's source makefile.