### PR TITLE
Drivers: platform: modify type of parameter bytes_number from uint8_t to uint16

### DIFF
--- a/drivers/platform/altera/spi.c
+++ b/drivers/platform/altera/spi.c
@@ -114,7 +114,7 @@ int32_t spi_remove(struct spi_desc *desc)
 
 int32_t spi_write_and_read(struct spi_desc *desc,
 			   uint8_t *data,
-			   uint8_t bytes_number)
+			   uint16_t bytes_number)
 {
 	uint32_t i;
 	struct altera_spi_desc *altera_desc;

--- a/drivers/platform/generic/spi.c
+++ b/drivers/platform/generic/spi.c
@@ -90,7 +90,7 @@ int32_t spi_remove(struct spi_desc *desc)
  */
 int32_t spi_write_and_read(struct spi_desc *desc,
 			   uint8_t *data,
-			   uint8_t bytes_number)
+			   uint16_t bytes_number)
 {
 	if (desc) {
 		// Unused variable - fix compiler warning

--- a/drivers/platform/linux/platform_drivers.c
+++ b/drivers/platform/linux/platform_drivers.c
@@ -249,7 +249,7 @@ int32_t spi_remove(spi_desc *desc)
  */
 int32_t spi_write_and_read(spi_desc *desc,
 			   uint8_t *data,
-			   uint8_t bytes_number)
+			   uint16_t bytes_number)
 {
 	struct spi_ioc_transfer transfer = {
 		.tx_buf = (unsigned long)data,

--- a/drivers/platform/xilinx/spi.c
+++ b/drivers/platform/xilinx/spi.c
@@ -235,7 +235,7 @@ error:
 
 int32_t spi_write_and_read(struct spi_desc *desc,
 			   uint8_t *data,
-			   uint8_t bytes_number)
+			   uint16_t bytes_number)
 {
 	int32_t			ret;
 	struct xil_spi_desc	*xdesc;

--- a/include/spi.h
+++ b/include/spi.h
@@ -91,6 +91,6 @@ int32_t spi_remove(struct spi_desc *desc);
 /* Write and read data to/from SPI. */
 int32_t spi_write_and_read(struct spi_desc *desc,
 			   uint8_t *data,
-			   uint8_t bytes_number);
+			   uint16_t bytes_number);
 
 #endif // SPI_H_


### PR DESCRIPTION
Modify parameter type of _bytes_number_ from _uint8_t_ to _uint16_t_ in
function _spi_write_and_read_. Modify file in includes and in all platform
files.
_Uint8_t_ data type is not enough to represent the size of a data block
(512 bytes) for reading and writing data in a SD card over SPI.
This modification doesn't affect the existing spi drivers because in the
implementation there are no constrains for this parameter to be _uint8_t_

Signed-off-by: Chindris <Mihail.Chindris@analog.com>