### PR TITLE
uart: Rename structure to "uart_ini_param" and parameter to "param".

### DIFF
--- a/drivers/platform/generic/uart.c
+++ b/drivers/platform/generic/uart.c
@@ -100,16 +100,16 @@ int32_t uart_write(struct uart_desc *desc, const uint8_t *data,
 /**
  * @brief Initialize the UART communication peripheral.
  * @param desc - The UART descriptor.
- * @param init_param - The structure that contains the UART parameters.
+ * @param param - The structure that contains the UART parameters.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t uart_init(struct uart_desc **desc, struct uart_init_par *par)
+int32_t uart_init(struct uart_desc **desc, struct uart_init_param *param)
 {
 	if (desc) {
 		// Unused variable - fix compiler warning
 	}
 
-	if (par) {
+	if (param) {
 		// Unused variable - fix compiler warning
 	}
 

--- a/drivers/platform/xilinx/uart.c
+++ b/drivers/platform/xilinx/uart.c
@@ -276,10 +276,10 @@ static int32_t uart_irq_init(struct uart_desc *descriptor)
 /**
  * @brief Initialize the UART communication peripheral.
  * @param desc - The UART descriptor.
- * @param init_param - The structure that contains the UART parameters.
+ * @param param - The structure that contains the UART parameters.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t uart_init(struct uart_desc **desc, struct uart_init_par *par)
+int32_t uart_init(struct uart_desc **desc, struct uart_init_param *param)
 {
 	int32_t status;
 	struct uart_desc *descriptor;
@@ -295,9 +295,9 @@ int32_t uart_init(struct uart_desc **desc, struct uart_init_par *par)
 		goto error_free_descriptor;
 
 	descriptor->extra = xil_uart_desc;
-	descriptor->baud_rate = par->baud_rate;
-	descriptor->device_id = par->device_id;
-	xil_uart_init_param = par->extra;
+	descriptor->baud_rate = param->baud_rate;
+	descriptor->device_id = param->device_id;
+	xil_uart_init_param = param->extra;
 	xil_uart_desc = descriptor->extra;
 	xil_uart_desc->irq_id = xil_uart_init_param->irq_id;
 	xil_uart_desc->irq_desc = xil_uart_init_param->irq_desc;

--- a/include/uart.h
+++ b/include/uart.h
@@ -43,7 +43,7 @@
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
-struct uart_init_par {
+struct uart_init_param {
 	uint8_t	device_id;
 	uint32_t 	baud_rate;
 	void 		*extra;
@@ -67,7 +67,7 @@ int32_t uart_write(struct uart_desc *desc, const uint8_t *data,
 		   uint32_t bytes_number);
 
 /* Initialize the UART communication peripheral. */
-int32_t uart_init(struct uart_desc **desc, struct uart_init_par *par);
+int32_t uart_init(struct uart_desc **desc, struct uart_init_param *param);
 
 /* Free the resources allocated by uart_init(). */
 int32_t uart_remove(struct uart_desc *desc);


### PR DESCRIPTION
This is necessary, for consistency with other modules: spi, irq, i2c.

Signed-off-by: Cristian Pop <cristian.pop@analog.com>