### PR TITLE
drivers: axi_dac_core: add channel customization

### DIFF
--- a/drivers/axi_core/axi_dac_core/axi_dac_core.h
+++ b/drivers/axi_core/axi_dac_core/axi_dac_core.h
@@ -52,12 +52,14 @@ struct axi_dac {
 	uint32_t base;
 	uint8_t	num_channels;
 	uint64_t clock_hz;
+	struct axi_dac_channel *channels; //dac channels manual configuration
 };
 
 struct axi_dac_init {
 	const char *name;
 	uint32_t base;
 	uint8_t	num_channels;
+	struct axi_dac_channel *channels; //dac channels manual configuration
 };
 
 enum axi_dac_data_sel {
@@ -71,6 +73,18 @@ enum axi_dac_data_sel {
 	AXI_DAC_DATA_SEL_PN31,
 	AXI_DAC_DATA_SEL_LB,
 	AXI_DAC_DATA_SEL_PNXX,
+};
+
+struct axi_dac_channel {
+	uint32_t dds_frequency_0;       // in hz (1000*1000 for MHz)
+	uint32_t dds_phase_0;           // in milli(?) angles (90*1000 for 90 degrees = pi/2)
+	int32_t dds_scale_0;            // in micro units (1.0*1000*1000 is 1.0)
+	uint32_t dds_frequency_1;       // in hz (1000*1000 for MHz)
+	uint32_t dds_phase_1;           // in milli(?) angles (90*1000 for 90 degrees = pi/2)
+	int32_t dds_scale_1;            // in micro units (1.0*1000*1000 is 1.0)
+	uint32_t dds_dual_tone;         // if using single tone for this channel, set to 0x0
+	uint32_t pat_data;              // if using SED/debug that sort of thing
+	enum axi_dac_data_sel sel;      // set to one of the enumerated type above.
 };
 
 /******************************************************************************/
@@ -124,4 +138,6 @@ int32_t axi_dac_load_custom_data(struct axi_dac *dac,
 				 const uint32_t *custom_data_iq,
 				 uint32_t custom_tx_count,
 				 uint32_t address);
+int32_t axi_dac_data_setup(struct axi_dac *dac);
+
 #endif

--- a/projects/ad9172/src/main.c
+++ b/projects/ad9172/src/main.c
@@ -171,7 +171,8 @@ int main(void)
 	struct axi_dac_init tx_dac_init = {
 		"tx_dac",
 		TX_CORE_BASEADDR,
-		4
+		4,
+		NULL
 	};
 
 #ifdef DAC_DMA_EXAMPLE

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -106,7 +106,8 @@ struct axi_adc_init rx_adc_init = {
 struct axi_dac_init tx_dac_init = {
 	"cf-ad9361-dds-core-lpc",
 	TX_CORE_BASEADDR,
-	4
+	4,
+	NULL
 };
 struct axi_dmac_init rx_dmac_init = {
 	"rx_dmac",

--- a/projects/ad9371/src/app/headless.c
+++ b/projects/ad9371/src/app/headless.c
@@ -286,7 +286,8 @@ int main(void)
 	struct axi_dac_init tx_dac_init = {
 		"tx_dac",
 		TX_CORE_BASEADDR,
-		4
+		4,
+		NULL
 	};
 	struct axi_dac *tx_dac;
 	struct axi_adc_init rx_adc_init = {

--- a/projects/adrv9009/src/app/headless.c
+++ b/projects/adrv9009/src/app/headless.c
@@ -118,7 +118,8 @@ int main(void)
 	struct axi_dac_init tx_dac_init = {
 		"tx_dac",
 		TX_CORE_BASEADDR,
-		4
+		4,
+		NULL
 	};
 	struct axi_dac *tx_dac;
 	struct axi_dmac_init rx_dmac_init = {


### PR DESCRIPTION
Previous implementation did not permit customization of the dac channels
by the user.

This patch allows the user setup the dac channels using the
`axi_dac_channel` structure.

The default configuration is used if the channel is not defined.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>