### PR TITLE
adrv9009 warnings fix

### DIFF
--- a/drivers/axi_core/axi_dmac/axi_dmac.c
+++ b/drivers/axi_core/axi_dmac/axi_dmac.c
@@ -125,7 +125,7 @@ int32_t axi_dmac_transfer(struct axi_dmac *dmac,
 	/* Wait until the transfer with the ID transfer_id is completed. */
 	do {
 		axi_dmac_read(dmac, AXI_DMAC_REG_TRANSFER_DONE, &reg_val);
-	} while((reg_val & (1 << transfer_id)) != (1 << transfer_id));
+	} while((reg_val & (1u << transfer_id)) != (1u << transfer_id));
 
 	return SUCCESS;
 }

--- a/drivers/axi_core/clk_axi_clkgen/clk_axi_clkgen.c
+++ b/drivers/axi_core/clk_axi_clkgen/clk_axi_clkgen.c
@@ -368,12 +368,12 @@ void axi_clkgen_calc_params(struct axi_clkgen *axi_clkgen,
 			dout = DIV_ROUND_CLOSEST(fvco, fout);
 			dout = clamp(dout, 1, 128);
 			f = fvco / dout;
-			if (abs(f - fout) < abs(best_f - fout)) {
+			if (abs(f - (int32_t)fout) < abs(best_f - (int32_t)fout)) {
 				best_f = f;
 				*best_d = d;
 				*best_m = m;
 				*best_dout = dout;
-				if (best_f == fout)
+				if (best_f == (int32_t)fout)
 					return;
 			}
 		}

--- a/drivers/axi_core/jesd204/axi_adxcvr.c
+++ b/drivers/axi_core/jesd204/axi_adxcvr.c
@@ -230,8 +230,8 @@ int32_t adxcvr_clk_set_rate(struct adxcvr *xcvr,
 
 		ret = xilinx_xcvr_write_out_div(&xcvr->xlx_xcvr,
 						ADXCVR_DRP_PORT_CHANNEL(i),
-						xcvr->tx_enable ? -1 : out_div,
-						xcvr->tx_enable ? out_div : -1);
+						xcvr->tx_enable ? -1 : (int32_t)out_div,
+						xcvr->tx_enable ? (int32_t)out_div : -1);
 		if (ret < 0)
 			return ret;
 
@@ -329,7 +329,7 @@ int32_t adxcvr_init(struct adxcvr **ad_xcvr,
 {
 	struct adxcvr *xcvr;
 	uint32_t synth_conf, xcvr_type;
-	int32_t i;
+	uint32_t i;
 
 	xcvr = (struct adxcvr *)malloc(sizeof(*xcvr));
 	if (!xcvr)

--- a/drivers/platform/xilinx/gpio.c
+++ b/drivers/platform/xilinx/gpio.c
@@ -66,7 +66,7 @@
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t _gpio_init(struct gpio_desc *desc,
-		   struct gpio_init_param *init_param)
+		   const struct gpio_init_param *init_param)
 {
 	int32_t				ret;
 	struct xil_gpio_desc		*xdesc;
@@ -193,9 +193,10 @@ int32_t gpio_remove(struct gpio_desc *desc)
 int32_t gpio_direction_input(struct gpio_desc *desc)
 {
 	struct xil_gpio_desc	*extra;
+#ifdef XGPIO_H
 	uint32_t channel = 1;
 	uint32_t config	 = 0;
-
+#endif
 	extra = desc->extra;
 
 	switch (extra->type) {
@@ -245,10 +246,11 @@ int32_t gpio_direction_output(struct gpio_desc *desc,
 			      uint8_t value)
 {
 	struct xil_gpio_desc	*extra;
+#ifdef XGPIO_H
 	uint8_t pin = desc->number;
 	uint8_t channel;
 	uint32_t reg_val;
-
+#endif
 	extra = desc->extra;
 
 	switch (extra->type) {
@@ -332,10 +334,11 @@ int32_t gpio_set_value(struct gpio_desc *desc,
 		       uint8_t value)
 {
 	struct xil_gpio_desc	*extra;
+#ifdef XGPIO_H
 	uint8_t pin = desc->number;
 	uint8_t channel;
 	uint32_t reg_val;
-
+#endif
 	extra = desc->extra;
 
 	switch (extra->type) {

--- a/drivers/platform/xilinx/spi.c
+++ b/drivers/platform/xilinx/spi.c
@@ -189,7 +189,9 @@ error:
  */
 int32_t spi_remove(struct spi_desc *desc)
 {
-	int32_t			ret;
+#ifdef XSPI_H
+	int32_t				ret;
+#endif
 	struct xil_spi_desc	*xdesc;
 
 	xdesc = desc->extra;
@@ -212,7 +214,9 @@ int32_t spi_remove(struct spi_desc *desc)
 
 #endif
 		/* Intended fallthrough */
+#ifdef XSPI_H
 error:
+#endif
 	default:
 		return FAILURE;
 		break;

--- a/util/util.c
+++ b/util/util.c
@@ -98,7 +98,7 @@ uint32_t greatest_common_divisor(uint32_t a,
 				 uint32_t b)
 {
 	uint32_t div;
-	uint32_t common_div;
+	uint32_t common_div = 1;
 
 	for (div = 1; (div <= a) && (div <= b); div++)
 		if (!(a % div) && !(b % div))


### PR DESCRIPTION
Fixed adrv9009 xilinx compilation warnings coming from our own code.
Some warnings (related to talise and the autogenerated talise_config) could not be fixed at this point, they need to be fixed upstream.