### PR TITLE
include: add type comments

### DIFF
--- a/include/fifo.h
+++ b/include/fifo.h
@@ -49,10 +49,14 @@
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
+/**
+ * @struct fifo_element
+ * @brief Structure holding the fifo element parameters.
+ */
 struct fifo_element {
-	struct fifo_element *next;
-	char *data;
-	uint32_t len;
+	struct fifo_element *next; ///< next FIFO element
+	char *data; ///< FIFO data pointer
+	uint32_t len; ///< FIFO length
 };
 
 /******************************************************************************/

--- a/include/gpio.h
+++ b/include/gpio.h
@@ -59,14 +59,22 @@
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
+/**
+ * @struct gpio_init_param
+ * @brief Structure holding the parameters for GPIO initialization.
+ */
 typedef struct gpio_init_param {
-	uint8_t		number;
-	void		*extra;
+	uint8_t		number; ///< GPIO number
+	void		*extra; ///< GPIO extra parameters (device specific)
 } gpio_init_param;
 
+/**
+ * @struct gpio_desc
+ * @brief Structure holding the GPIO descriptor.
+ */
 typedef struct gpio_desc {
-	uint8_t		number;
-	void		*extra;
+	uint8_t		number; ///< GPIO number
+	void		*extra; ///< GPIO extra parameters (device specific)
 } gpio_desc;
 
 /******************************************************************************/

--- a/include/i2c.h
+++ b/include/i2c.h
@@ -49,22 +49,34 @@
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
+/**
+ * @enum i2c_transfer_mode
+ * @brief I2C transfer mode configuration
+ */
 typedef enum i2c_transfer_mode {
-	i2c_general_call =	0x01,
-	i2c_repeated_start =	0x02,
-	i2c_10_bit_transfer =	0x04
+	i2c_general_call =	0x01, ///< address every device connected
+	i2c_repeated_start =	0x02, ///< send multiple start conditions
+	i2c_10_bit_transfer =	0x04 ///< use 10-bit address scheme
 } i2c_transfer_mode;
 
+/**
+ * @struct i2c_init_param
+ * @brief Structure holding the parameters for I2C initialization.
+ */
 typedef struct i2c_init_param {
-	uint32_t	max_speed_hz;
-	uint8_t		slave_address;
-	void		*extra;
+	uint32_t	max_speed_hz; ///< I2C maximum transfer speed supported
+	uint8_t		slave_address; ///< Slave address
+	void		*extra; ///< I2C extra parameters (device specific parameters)
 } i2c_init_param;
 
+/**
+ * @struct i2c_desc
+ * @brief Structure holding I2C descriptor
+ */
 typedef struct i2c_desc {
-	uint32_t	max_speed_hz;
-	uint8_t		slave_address;
-	void		*extra;
+	uint32_t	max_speed_hz; ///< I2C maximum transfer speed supported
+	uint8_t		slave_address; ///< Slave address
+	void		*extra; ///< I2C extra parameters (device specific parameters)
 } i2c_desc;
 
 /******************************************************************************/

--- a/include/irq.h
+++ b/include/irq.h
@@ -45,11 +45,19 @@
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
+/**
+ * @struct irq_init_param
+ * @brief Structure holding the parameters for Interrupt Request.
+ */
 struct irq_init_param {
-	uint32_t	irq_id;
-	void		*extra;
+	uint32_t	irq_id; ///< Interrupt Request ID.
+	void		*extra; ///< IRQ extra parameters (device specific)
 };
 
+/**
+ * @struct irq_desc
+ * @brief Structure for Interrupt Request descriptor.
+ */
 struct irq_desc {
 	uint32_t	irq_id;
 	void		*extra;

--- a/include/spi.h
+++ b/include/spi.h
@@ -56,25 +56,37 @@
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
+/**
+ * @enum spi_mode
+ * @brief SPI configuration for clock phase and polarity
+ */
 typedef enum spi_mode {
-	SPI_MODE_0 = (0 | 0),
-	SPI_MODE_1 = (0 | SPI_CPHA),
-	SPI_MODE_2 = (SPI_CPOL | 0),
-	SPI_MODE_3 = (SPI_CPOL | SPI_CPHA)
+	SPI_MODE_0 = (0 | 0), ///< Data on rising, shift out on falling
+	SPI_MODE_1 = (0 | SPI_CPHA), ///< Data on falling, shift out on rising
+	SPI_MODE_2 = (SPI_CPOL | 0), ///< Data on falling, shift out on rising
+	SPI_MODE_3 = (SPI_CPOL | SPI_CPHA) ///< Data on rising, shift out on falling
 } spi_mode;
 
+/**
+ * @struct spi_init_param
+ * @brief Structure holding the parameters for SPI initialization
+ */
 typedef struct spi_init_param {
-	uint32_t	max_speed_hz;
-	uint8_t		chip_select;
-	enum spi_mode	mode;
-	void		*extra;
+	uint32_t	max_speed_hz; ///< SPI maximum transfer speed
+	uint8_t		chip_select; ///< SPI chip select
+	enum spi_mode	mode; ///< SPI mode
+	void		*extra; ///< SPI extra parameters (device specific)
 } spi_init_param;
 
+/**
+ * @struct spi_desc
+ * @brief Structure holding SPI descriptor
+ */
 typedef struct spi_desc {
-	uint32_t	max_speed_hz;
-	uint8_t		chip_select;
-	enum spi_mode	mode;
-	void		*extra;
+	uint32_t	max_speed_hz; ///< SPI maximum transfer speed
+	uint8_t		chip_select; ///< SPI chip select
+	enum spi_mode	mode; ///< SPI mode
+	void		*extra; ///< SPI extra parameters (device specific)
 } spi_desc;
 
 /******************************************************************************/

--- a/include/timer.h
+++ b/include/timer.h
@@ -50,16 +50,24 @@
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
+/**
+ * @enum timer_desc
+ * @brief Structure holding timer descriptor
+ */
 struct timer_desc {
-	uint32_t freq_hz;
-	uint32_t load_value;
-	void *extra;
+	uint32_t freq_hz; ///< timer count frequency (Hz)
+	uint32_t load_value; ///< counter start value
+	void *extra; ///< timer extra parameters (device specific)
 };
 
+/**
+ * @enum timer_init_param
+ * @brief  Structure holding the parameters for timer initialization
+ */
 struct timer_init_param {
-	uint32_t freq_hz;
-	uint32_t load_value;
-	void *extra;
+	uint32_t freq_hz; ///< timer count frequency (Hz)
+	uint32_t load_value; ///< counter start value
+	void *extra; ///< timer extra parameters (device specific)
 };
 
 /******************************************************************************/

--- a/include/uart.h
+++ b/include/uart.h
@@ -43,16 +43,20 @@
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
+/**
+ * @struct uart_init_param
+ * @brief Structure holding the parameters for UART initialization
+ */
 struct uart_init_param {
-	uint8_t	device_id;
-	uint32_t 	baud_rate;
-	void 		*extra;
+	uint8_t	device_id; ///< UART Device ID
+	uint32_t 	baud_rate; ///< UART Baud Rate
+	void 		*extra; ///< UART extra parameters (device specific)
 };
 
 struct uart_desc {
-	uint8_t 	device_id;
-	uint32_t 	baud_rate;
-	void 		*extra;
+	uint8_t 	device_id; ///< UART Device ID
+	uint32_t 	baud_rate; ///< UART Baud Rate
+	void 		*extra; ///< UART extra parameters (device specific)
 };
 
 /******************************************************************************/

--- a/include/xml.h
+++ b/include/xml.h
@@ -50,22 +50,34 @@
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
+/**
+ * @struct xml_attribute
+ * @brief Structure holding the parameters for XML attribute
+ */
 struct xml_attribute {
-	char *name;
-	char *value;
+	char *name; ///< XML attribute name
+	char *value; ///< XML attribute value
 };
 
+/**
+ * @struct xml_node
+ * @brief Structure holding the parameters for XML node
+ */
 struct xml_node {
-	char *name;
-	struct xml_attribute **attributes;
-	uint16_t attr_cnt;
-	struct xml_node **children;
-	uint16_t children_cnt;
+	char *name; ///< XML node name
+	struct xml_attribute **attributes; ///< Node's attributes
+	uint16_t attr_cnt; ///< Number of attributes
+	struct xml_node **children; ///< XML children nodes
+	uint16_t children_cnt; ///< Number of children
 };
 
+/**
+ * @struct xml_document
+ * @brief Structure holding the parameters for XML document
+ */
 struct xml_document {
-	char *buff;
-	uint32_t index;
+	char *buff; ///< XML Document buffer
+	uint32_t index; ///< Buffer length
 };
 
 /******************************************************************************/


### PR DESCRIPTION
Add comments for types to easily integrate with Doxygen.

The `///<` sequence is used to document struct members and enums.

Outlook:
Struct members:
![Screenshot from 2019-12-13 14-36-08](https://user-images.githubusercontent.com/26061529/70801055-799ff180-1db6-11ea-823c-c177fb7b24c0.png)

Enums:
![Screenshot from 2019-12-13 14-43-18](https://user-images.githubusercontent.com/26061529/70801219-fdf27480-1db6-11ea-90f2-74e9c635d929.png)

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>