### PR TITLE
include: add type comments in header

### DIFF
--- a/include/fifo.h
+++ b/include/fifo.h
@@ -49,6 +49,16 @@
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
+/**
+ * @struct fifo_element
+ * @brief Structure holding the fifo element parameters.
+ * @var fifo_element::next
+ * next FIFO element
+ * @var fifo_element::data
+ * FIFO data pointer
+ * @var fifo_element::len
+ * FIFO length
+ */
 struct fifo_element {
 	struct fifo_element *next;
 	char *data;

--- a/include/gpio.h
+++ b/include/gpio.h
@@ -59,11 +59,27 @@
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
+/**
+ * @struct gpio_init_param
+ * @brief Structure holding the parameters for GPIO initialization.
+ * @var gpio_init_param::number
+ * GPIO number
+ * @var gpio_init_param::extra
+ * GPIO extra parameters (device specific)
+ */
 typedef struct gpio_init_param {
 	uint8_t		number;
 	void		*extra;
 } gpio_init_param;
 
+/**
+ * @struct gpio_desc
+ * @brief Structure holding the GPIO descriptor.
+ * @var gpio_desc::number
+ * GPIO number
+ * @var gpio_desc::extra
+ * GPIO extra parameters (device specific)
+ */
 typedef struct gpio_desc {
 	uint8_t		number;
 	void		*extra;

--- a/include/i2c.h
+++ b/include/i2c.h
@@ -49,18 +49,48 @@
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
+/**
+ * @enum i2c_transfer_mode
+ * @brief I2C transfer mode configuration
+ * @var i2c_transfer_mode::i2c_general_call
+ * Address every device connected
+ * @var i2c_transfer_mode::i2c_repeated_start
+ * Send multiple start conditions
+ * @var i2c_transfer_mode::i2c_10_bit_transfer
+ * Use 10-bit address scheme
+ */
 typedef enum i2c_transfer_mode {
 	i2c_general_call =	0x01,
 	i2c_repeated_start =	0x02,
 	i2c_10_bit_transfer =	0x04
 } i2c_transfer_mode;
 
+/**
+ * @struct i2c_init_param
+ * @brief Structure holding the parameters for I2C initialization.
+ * @var i2c_init_param::max_speed_hz
+ * I2C maximum transfer speed supported
+ * @var i2c_init_param::slave_address
+ * Slave address
+ * @var i2c_init_param::extra
+ * I2C extra parameters (device specific parameters)
+ */
 typedef struct i2c_init_param {
 	uint32_t	max_speed_hz;
 	uint8_t		slave_address;
 	void		*extra;
 } i2c_init_param;
 
+/**
+ * @struct i2c_desc
+ * @brief Structure holding I2C descriptor
+ * @var i2c_desc::max_speed_hz
+ * I2C maximum transfer speed supported
+ * @var i2c_desc::slave_address
+ * Slave address
+ * @var i2c_desc::extra
+ * I2C extra parameters (device specific parameters)
+ */
 typedef struct i2c_desc {
 	uint32_t	max_speed_hz;
 	uint8_t		slave_address;

--- a/include/irq.h
+++ b/include/irq.h
@@ -45,11 +45,27 @@
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
+/**
+ * @struct irq_init_param
+ * @brief Structure holding the initial parameters for Interrupt Request.
+ * @var irq_init_param::irq_id
+ * Interrupt Request ID.
+ * @var irq_init_param::extra
+ * IRQ extra parameters (device specific)
+ */
 struct irq_init_param {
 	uint32_t	irq_id;
 	void		*extra;
 };
 
+/**
+ * @struct irq_desc
+ * @brief Structure for Interrupt Request descriptor.
+ * @var irq_desc::irq_id
+ * Interrupt Request ID.
+ * @var irq_desc::extra
+ * IRQ extra parameters (device specific)
+ */
 struct irq_desc {
 	uint32_t	irq_id;
 	void		*extra;

--- a/include/spi.h
+++ b/include/spi.h
@@ -56,6 +56,18 @@
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
+/**
+ * @enum spi_mode
+ * @brief SPI configuration for clock phase and polarity
+ * @var spimode::SPI_MODE_0
+ * Data on rising, shift out on falling
+ * @var spimode::SPI_MODE_1
+ * Data on falling, shift out on rising
+ * @var spimode::SPI_MODE_2
+ * Data on falling, shift out on rising
+ * @var spimode::SPI_MODE_3
+ * Data on rising, shift out on falling
+ */
 typedef enum spi_mode {
 	SPI_MODE_0 = (0 | 0),
 	SPI_MODE_1 = (0 | SPI_CPHA),
@@ -63,6 +75,18 @@ typedef enum spi_mode {
 	SPI_MODE_3 = (SPI_CPOL | SPI_CPHA)
 } spi_mode;
 
+/**
+ * @struct spi_init_param
+ * @brief Structure holding the parameters for SPI initialization
+ * @var spi_init_param::max_speed_hz
+ * maximum transfer speed
+ * @var spi_init_param::chip_select
+ * SPI chip select
+ * @var spi_init_param::mode
+ * SPI mode
+ * @var spi_init_param::extra
+ * SPI extra parameters (device specific)
+ */
 typedef struct spi_init_param {
 	uint32_t	max_speed_hz;
 	uint8_t		chip_select;
@@ -70,6 +94,18 @@ typedef struct spi_init_param {
 	void		*extra;
 } spi_init_param;
 
+/**
+ * @struct spi_desc
+ * @brief Structure holding SPI descriptor
+ * @var spi_desc::max_speed_hz
+ * maximum transfer speed
+ * @var spi_desc::chip_select
+ * SPI chip select
+ * @var spi_desc::mode
+ * SPI mode
+ * @var spi_desc::extra
+ * SPI extra parameters (device specific)
+ */
 typedef struct spi_desc {
 	uint32_t	max_speed_hz;
 	uint8_t		chip_select;

--- a/include/timer.h
+++ b/include/timer.h
@@ -50,12 +50,32 @@
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
+/**
+ * @struct timer_desc
+ * @brief Structure holding timer descriptor
+ * @var timer_desc::freq_hz
+ * timer count frequency (Hz)
+ * @var timer_desc::load_value
+ * counter start value
+ * @var timer_desc::extra
+ * timer extra parameters (device specific)
+ */
 struct timer_desc {
 	uint32_t freq_hz;
 	uint32_t load_value;
 	void *extra;
 };
 
+/**
+ * @struct timer_init_param
+ * @brief  Structure holding the parameters for timer initialization
+ * @var timer_init_param::freq_hz
+ * timer count frequency (Hz)
+ * @var timer_init_param::load_value
+ * counter start value
+ * @var timer_init_param::extra
+ * timer extra parameters (device specific)
+ */
 struct timer_init_param {
 	uint32_t freq_hz;
 	uint32_t load_value;

--- a/include/uart.h
+++ b/include/uart.h
@@ -43,12 +43,32 @@
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
+/**
+ * @struct uart_init_param
+ * @brief Structure holding the parameters for UART initialization
+ * @var uart_init_param::device_id
+ * UART Device ID
+ * @var uart_init_param::baud_rate
+ * UART Baud Rate
+ * @var uart_init_param::extra
+ * UART extra parameters (device specific)
+ */
 struct uart_init_param {
 	uint8_t	device_id;
 	uint32_t 	baud_rate;
 	void 		*extra;
 };
 
+/**
+ * @struct uart_desc
+ * @brief Stucture holding the UART descriptor.
+ * @var uart_desc::device_id
+ * UART Device ID
+ * @var uart_desc::baud_rate
+ * UART Baud Rate
+ * @var uart_desc::extra
+ * UART extra parameters (device specific)
+ */
 struct uart_desc {
 	uint8_t 	device_id;
 	uint32_t 	baud_rate;

--- a/include/xml.h
+++ b/include/xml.h
@@ -50,11 +50,33 @@
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
+/**
+ * @struct xml_attribute
+ * @brief Structure holding the parameters for XML attribute
+ * @var xml_attribute::name
+ * XML attribute name
+ * @var xml_attribute::value
+ * XML attribute value
+ */
 struct xml_attribute {
 	char *name;
 	char *value;
 };
 
+/**
+ * @struct xml_node
+ * @brief Structure holding the parameters for XML node
+ * @var xml_node::name
+ * XML node name
+ * @var xml_node::attributes
+ * Node's attributes
+ * @var xml_node::attr_cnt
+ * Number of attributes
+ * @var xml_node::children
+ * XML children nodes
+ * @var xml_node::children_cnt
+ * Number of children
+ */
 struct xml_node {
 	char *name;
 	struct xml_attribute **attributes;
@@ -63,6 +85,14 @@ struct xml_node {
 	uint16_t children_cnt;
 };
 
+/**
+ * @struct xml_document
+ * @brief Structure holding the parameters for XML document
+ * @var xml_document::buff
+ * XML Document buffer
+ * @var xml_document::index
+ * Buffer length
+ */
 struct xml_document {
 	char *buff;
 	uint32_t index;


### PR DESCRIPTION
Add type comments for sturct/enum members in the header comment.

This patch is an alernative to #386 

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>