### PR TITLE
ad9361: Fix ad9361_get_split_table_gain.

### DIFF
--- a/ad9361/sw/ad9361.c
+++ b/ad9361/sw/ad9361.c
@@ -659,16 +659,6 @@ static const uint8_t gm_st_ctrl[16] = { 0x0, 0xD, 0x15, 0x1B, 0x21, 0x25, 0x29,
 					0x2C, 0x2F, 0x31, 0x33, 0x34, 0x35, 0x3A, 0x3D, 0x3E
 				      };
 
-static const int8_t lna_table[RXGAIN_TBLS_END][4] = {
-	{5, 17, 19, 24}, {3, 14, 17, 21}, {-4, 10, 13, 14}
-};
-static const int8_t tia_table[] = { -6, 0 };
-static const int8_t mixer_table[RXGAIN_TBLS_END][16] = {
-	{0, 3, 9, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25},
-	{0, 3, 9, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26},
-	{0, 3, 8, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24}
-};
-
 static const uint32_t gain_step_calib_reg_val[4][5] = {
 	{0xC0, 0x2E, 0x10, 0x06, 0x00},	// LO Frequency Range: 600 to 1300 MHz
 	{0xC0, 0x2C, 0x10, 0x06, 0x00},	// LO Frequency Range: 1300 to 3300 MHz
@@ -1815,9 +1805,8 @@ static int32_t ad9361_get_split_table_gain(struct ad9361_rf_phy *phy,
 
 	rx_gain->tia_index = ad9361_spi_readf(spi, REG_GAIN_TABLE_READ_DATA2, TIA_GAIN);
 
-	rx_gain->lmt_gain = lna_table[ad9361_gt(phy)][rx_gain->lna_index] +
-			    mixer_table[ad9361_gt(phy)][rx_gain->mixer_index] +
-			    tia_table[rx_gain->tia_index];
+	rx_gain->lmt_gain = phy->gt_info[ad9361_gt(
+			phy)].abs_gain_tbl[rx_gain->fgt_lmt_index];
 
 	ad9361_spi_write(spi, REG_GAIN_TABLE_ADDRESS, tbl_addr);
 


### PR DESCRIPTION
Fixes #394.

The implementation was based on ad9361_get_full_table_gain.  This PR also removes the now unused static tables.

I believe ad9361_get_split_table_gain could be simplified further if we didn't need to fill out the lna_index, mixer_index, or tia_index of the `lpf_gain` index of the `rx_gain` struct.  

Alternatively, `ad9361_get_rx_gain` could be implemented to do what `ad9361_get_split_table_gain` was trying to do: see which table index is active, read the gains for that table index, and calculate the gain based on that.  Then there wouldn't need to be two different methods for split table/full table calculations, just a conditional to add the LPF gain in split gain table mode.  I could submit a PR implementing that if that would be preferable.