### PR TITLE
platform: i2c: update

### DIFF
--- a/drivers/platform/altera/i2c.c
+++ b/drivers/platform/altera/i2c.c
@@ -89,7 +89,7 @@ int32_t i2c_remove(struct i2c_desc *desc)
  * @param desc - The I2C descriptor.
  * @param data - Buffer that stores the transmission data.
  * @param bytes_number - Number of bytes to write.
- * @param stop_bit - Stop condition control.
+ * @param option - Stop condition control.
  *                   Example: 0 - A stop condition will not be generated;
  *                            1 - A stop condition will be generated.
  * @return SUCCESS in case of success, FAILURE otherwise.
@@ -97,7 +97,7 @@ int32_t i2c_remove(struct i2c_desc *desc)
 int32_t i2c_write(struct i2c_desc *desc,
 		  uint8_t *data,
 		  uint8_t bytes_number,
-		  uint8_t stop_bit)
+		  uint8_t option)
 {
 	if (desc) {
 		// Unused variable - fix compiler warning
@@ -111,7 +111,7 @@ int32_t i2c_write(struct i2c_desc *desc,
 		// Unused variable - fix compiler warning
 	}
 
-	if (stop_bit) {
+	if (option) {
 		// Unused variable - fix compiler warning
 	}
 
@@ -123,7 +123,7 @@ int32_t i2c_write(struct i2c_desc *desc,
  * @param desc - The I2C descriptor.
  * @param data - Buffer that will store the received data.
  * @param bytes_number - Number of bytes to read.
- * @param stop_bit - Stop condition control.
+ * @param option - Stop condition control.
  *                   Example: 0 - A stop condition will not be generated;
  *                            1 - A stop condition will be generated.
  * @return SUCCESS in case of success, FAILURE otherwise.
@@ -131,7 +131,7 @@ int32_t i2c_write(struct i2c_desc *desc,
 int32_t i2c_read(struct i2c_desc *desc,
 		 uint8_t *data,
 		 uint8_t bytes_number,
-		 uint8_t stop_bit)
+		 uint8_t option)
 {
 	if (desc) {
 		// Unused variable - fix compiler warning
@@ -145,7 +145,7 @@ int32_t i2c_read(struct i2c_desc *desc,
 		// Unused variable - fix compiler warning
 	}
 
-	if (stop_bit) {
+	if (option) {
 		// Unused variable - fix compiler warning
 	}
 

--- a/drivers/platform/generic/i2c.c
+++ b/drivers/platform/generic/i2c.c
@@ -86,7 +86,7 @@ int32_t i2c_remove(struct i2c_desc *desc)
  * @param desc - The I2C descriptor.
  * @param data - Buffer that stores the transmission data.
  * @param bytes_number - Number of bytes to write.
- * @param stop_bit - Stop condition control.
+ * @param option - Stop condition control.
  *                   Example: 0 - A stop condition will not be generated;
  *                            1 - A stop condition will be generated.
  * @return SUCCESS in case of success, FAILURE otherwise.
@@ -94,7 +94,7 @@ int32_t i2c_remove(struct i2c_desc *desc)
 int32_t i2c_write(struct i2c_desc *desc,
 		  uint8_t *data,
 		  uint8_t bytes_number,
-		  uint8_t stop_bit)
+		  uint8_t option)
 {
 	if (desc) {
 		// Unused variable - fix compiler warning
@@ -108,7 +108,7 @@ int32_t i2c_write(struct i2c_desc *desc,
 		// Unused variable - fix compiler warning
 	}
 
-	if (stop_bit) {
+	if (option) {
 		// Unused variable - fix compiler warning
 	}
 
@@ -120,7 +120,7 @@ int32_t i2c_write(struct i2c_desc *desc,
  * @param desc - The I2C descriptor.
  * @param data - Buffer that will store the received data.
  * @param bytes_number - Number of bytes to read.
- * @param stop_bit - Stop condition control.
+ * @param option - Stop condition control.
  *                   Example: 0 - A stop condition will not be generated;
  *                            1 - A stop condition will be generated.
  * @return SUCCESS in case of success, FAILURE otherwise.
@@ -128,7 +128,7 @@ int32_t i2c_write(struct i2c_desc *desc,
 int32_t i2c_read(struct i2c_desc *desc,
 		 uint8_t *data,
 		 uint8_t bytes_number,
-		 uint8_t stop_bit)
+		 uint8_t option)
 {
 	if (desc) {
 		// Unused variable - fix compiler warning
@@ -142,7 +142,7 @@ int32_t i2c_read(struct i2c_desc *desc,
 		// Unused variable - fix compiler warning
 	}
 
-	if (stop_bit) {
+	if (option) {
 		// Unused variable - fix compiler warning
 	}
 

--- a/drivers/platform/linux/platform_drivers.c
+++ b/drivers/platform/linux/platform_drivers.c
@@ -108,7 +108,7 @@ int32_t i2c_remove(i2c_desc *desc)
  * @param desc - The I2C descriptor.
  * @param data - Buffer that stores the transmission data.
  * @param bytes_number - Number of bytes to write.
- * @param stop_bit - Stop condition control.
+ * @param option - Stop condition control.
  *                   Example: 0 - A stop condition will not be generated;
  *                            1 - A stop condition will be generated.
  * @return SUCCESS in case of success, FAILURE otherwise.
@@ -116,7 +116,7 @@ int32_t i2c_remove(i2c_desc *desc)
 int32_t i2c_write(i2c_desc *desc,
 		  uint8_t *data,
 		  uint8_t bytes_number,
-		  uint8_t stop_bit)
+		  uint8_t option)
 {
 	int ret;
 
@@ -132,7 +132,7 @@ int32_t i2c_write(i2c_desc *desc,
 		return FAILURE;
 	}
 
-	if (stop_bit) {
+	if (option) {
 		// Unused variable - fix compiler warning
 	}
 
@@ -144,7 +144,7 @@ int32_t i2c_write(i2c_desc *desc,
  * @param desc - The I2C descriptor.
  * @param data - Buffer that will store the received data.
  * @param bytes_number - Number of bytes to read.
- * @param stop_bit - Stop condition control.
+ * @param option - Stop condition control.
  *                   Example: 0 - A stop condition will not be generated;
  *                            1 - A stop condition will be generated.
  * @return SUCCESS in case of success, FAILURE otherwise.
@@ -152,7 +152,7 @@ int32_t i2c_write(i2c_desc *desc,
 int32_t i2c_read(i2c_desc *desc,
 		 uint8_t *data,
 		 uint8_t bytes_number,
-		 uint8_t stop_bit)
+		 uint8_t option)
 {
 	int ret;
 
@@ -168,7 +168,7 @@ int32_t i2c_read(i2c_desc *desc,
 		return FAILURE;
 	}
 
-	if (stop_bit) {
+	if (option) {
 		// Unused variable - fix compiler warning
 	}
 

--- a/drivers/platform/linux/platform_drivers.h
+++ b/drivers/platform/linux/platform_drivers.h
@@ -134,13 +134,13 @@ int32_t i2c_remove(i2c_desc *desc);
 int32_t i2c_write(i2c_desc *desc,
 		  uint8_t *data,
 		  uint8_t bytes_number,
-		  uint8_t stop_bit);
+		  uint8_t option);
 
 /* Read data from a slave device. */
 int32_t i2c_read(i2c_desc *desc,
 		 uint8_t *data,
 		 uint8_t bytes_number,
-		 uint8_t stop_bit);
+		 uint8_t option);
 
 /* Initialize the SPI communication peripheral. */
 int32_t spi_init(spi_desc **desc,


### PR DESCRIPTION
With #285, i2c R/W function headers changed.

This patch replaces `stop_bit` parameter with the `option` parameter
for all i2c source files.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>