### PR TITLE
projects: remove project specific page

### DIFF
--- a/projects/ad9371/src/devices/ad9528/ad9528.c
+++ b/projects/ad9371/src/devices/ad9528/ad9528.c
@@ -4,7 +4,7 @@
  */
 
 /**
-* \page Disclaimer Legal Disclaimer
+* Legal Disclaimer
 * Copyright 2015-2017 Analog Devices Inc.
 * Released under the AD9371 API license, for more information see the "LICENSE.txt" file in this zip file.
 *

--- a/projects/ad9371/src/devices/ad9528/ad9528.h
+++ b/projects/ad9371/src/devices/ad9528/ad9528.h
@@ -4,7 +4,7 @@
  */
 
 /**
-* \page Disclaimer Legal Disclaimer
+* Legal Disclaimer
 * Copyright 2015-2017 Analog Devices Inc.
 * Released under the AD9371 API license, for more information see the "LICENSE.txt" file in this zip file.
 *

--- a/projects/ad9371/src/devices/ad9528/t_ad9528.h
+++ b/projects/ad9371/src/devices/ad9528/t_ad9528.h
@@ -4,7 +4,7 @@
  */
 
 /**
-* \page Disclaimer Legal Disclaimer
+* Legal Disclaimer
 * Copyright 2015-2017 Analog Devices Inc.
 * Released under the AD9371 API license, for more information see the "LICENSE.txt" file in this zip file.
 *

--- a/projects/ad9371/src/devices/adi_hal/common.c
+++ b/projects/ad9371/src/devices/adi_hal/common.c
@@ -4,7 +4,7 @@
  */
 
 /**
-* \page Disclaimer Legal Disclaimer
+* Legal Disclaimer
 * Copyright 2015-2017 Analog Devices Inc.
 * Released under the AD9371 API license, for more information see the "LICENSE.txt" file in this zip file.
 *

--- a/projects/ad9371/src/devices/adi_hal/common.h
+++ b/projects/ad9371/src/devices/adi_hal/common.h
@@ -4,7 +4,7 @@
  */
 
 /**
-* \page Disclaimer Legal Disclaimer
+* Legal Disclaimer
 * Copyright 2015-2017 Analog Devices Inc.
 * Released under the AD9371 API license, for more information see the "LICENSE.txt" file in this zip file.
 *

--- a/projects/ad9371/src/devices/mykonos/mykonos.c
+++ b/projects/ad9371/src/devices/mykonos/mykonos.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * \mainpage Overview
+ * Overview
  *
  * This document is intended for use by software engineering professionals and
  * includes detailed information regarding the data types and function calls
@@ -17,7 +17,7 @@
  */
 
 /**
- * \page Use Suggested Use
+ *   Use Suggested Use
  * The purpose of this API library is to add abstraction for the low level
  * SPI control and calculations necessary to control the Mykonos family of transceiver devices
  *
@@ -26,7 +26,7 @@
  */
 
 /**
-* \page Disclaimer Legal Disclaimer
+* Legal Disclaimer
 * Copyright 2015-2017 Analog Devices Inc.
 * Released under the AD9371 API license, for more information see the "LICENSE.txt" file in this zip file.
 *

--- a/projects/ad9371/src/devices/mykonos/mykonos.h
+++ b/projects/ad9371/src/devices/mykonos/mykonos.h
@@ -6,7 +6,7 @@
  */
 
 /**
-* \page Disclaimer Legal Disclaimer
+* Legal Disclaimer
 * Copyright 2015-2017 Analog Devices Inc.
 * Released under the AD9371 API license, for more information see the "LICENSE.txt" file in this zip file.
 *

--- a/projects/ad9371/src/devices/mykonos/mykonosMmap.c
+++ b/projects/ad9371/src/devices/mykonos/mykonosMmap.c
@@ -6,7 +6,7 @@
  */
 
 /**
-* \page Disclaimer Legal Disclaimer
+* Legal Disclaimer
 * Copyright 2015-2017 Analog Devices Inc.
 * Released under the AD9371 API license, for more information see the "LICENSE.txt" file in this zip file.
 *

--- a/projects/ad9371/src/devices/mykonos/mykonos_debug/mykonos_dbgjesd.c
+++ b/projects/ad9371/src/devices/mykonos/mykonos_debug/mykonos_dbgjesd.c
@@ -7,7 +7,7 @@
  */
 
 /**
-* \page Disclaimer Legal Disclaimer
+* Legal Disclaimer
 * Copyright 2015-2017 Analog Devices Inc.
 * Released under the AD9371 API license, for more information see the "LICENSE.txt" file in this zip file.
 *

--- a/projects/ad9371/src/devices/mykonos/mykonos_debug/mykonos_dbgjesd.h
+++ b/projects/ad9371/src/devices/mykonos/mykonos_debug/mykonos_dbgjesd.h
@@ -7,7 +7,7 @@
  */
 
 /**
-* \page Disclaimer Legal Disclaimer
+* Legal Disclaimer
 * Copyright 2015-2017 Analog Devices Inc.
 * Released under the AD9371 API license, for more information see the "LICENSE.txt" file in this zip file.
 *

--- a/projects/ad9371/src/devices/mykonos/mykonos_debug/t_mykonos_dbgjesd.h
+++ b/projects/ad9371/src/devices/mykonos/mykonos_debug/t_mykonos_dbgjesd.h
@@ -7,7 +7,7 @@
  */
 
 /**
-* \page Disclaimer Legal Disclaimer
+* Legal Disclaimer
 * Copyright 2015-2017 Analog Devices Inc.
 * Released under the AD9371 API license, for more information see the "LICENSE.txt" file in this zip file.
 *

--- a/projects/ad9371/src/devices/mykonos/mykonos_gpio.c
+++ b/projects/ad9371/src/devices/mykonos/mykonos_gpio.c
@@ -7,7 +7,7 @@
  */
 
 /**
-* \page Disclaimer Legal Disclaimer
+* Legal Disclaimer
 * Copyright 2015-2017 Analog Devices Inc.
 * Released under the AD9371 API license, for more information see the "LICENSE.txt" file in this zip file.
 *

--- a/projects/ad9371/src/devices/mykonos/mykonos_gpio.h
+++ b/projects/ad9371/src/devices/mykonos/mykonos_gpio.h
@@ -6,7 +6,7 @@
  */
 
 /**
-* \page Disclaimer Legal Disclaimer
+* Legal Disclaimer
 * Copyright 2015-2017 Analog Devices Inc.
 * Released under the AD9371 API license, for more information see the "LICENSE.txt" file in this zip file.
 *

--- a/projects/ad9371/src/devices/mykonos/mykonos_macros.h
+++ b/projects/ad9371/src/devices/mykonos/mykonos_macros.h
@@ -6,7 +6,7 @@
  */
 
 /**
-* \page Disclaimer Legal Disclaimer
+* Legal Disclaimer
 * Copyright 2015-2017 Analog Devices Inc.
 * Released under the AD9371 API license, for more information see the "LICENSE.txt" file in this zip file.
 *

--- a/projects/ad9371/src/devices/mykonos/mykonos_user.c
+++ b/projects/ad9371/src/devices/mykonos/mykonos_user.c
@@ -6,7 +6,7 @@
  */
 
 /**
-* \page Disclaimer Legal Disclaimer
+* Legal Disclaimer
 * Copyright 2015-2017 Analog Devices Inc.
 * Released under the AD9371 API license, for more information see the "LICENSE.txt" file in this zip file.
 *

--- a/projects/ad9371/src/devices/mykonos/mykonos_user.h
+++ b/projects/ad9371/src/devices/mykonos/mykonos_user.h
@@ -7,7 +7,7 @@
  */
 
 /**
-* \page Disclaimer Legal Disclaimer
+* Legal Disclaimer
 * Copyright 2015-2017 Analog Devices Inc.
 * Released under the AD9371 API license, for more information see the "LICENSE.txt" file in this zip file.
 *

--- a/projects/ad9371/src/devices/mykonos/mykonos_version.h
+++ b/projects/ad9371/src/devices/mykonos/mykonos_version.h
@@ -6,7 +6,7 @@
  */
 
 /**
-* \page Disclaimer Legal Disclaimer
+* Legal Disclaimer
 * Copyright 2015-2017 Analog Devices Inc.
 * Released under the AD9371 API license, for more information see the "LICENSE.txt" file in * this zip file.
 *

--- a/projects/ad9371/src/devices/mykonos/t_mykonos.h
+++ b/projects/ad9371/src/devices/mykonos/t_mykonos.h
@@ -6,7 +6,7 @@
  */
 
 /**
-* \page Disclaimer Legal Disclaimer
+* Legal Disclaimer
 * Copyright 2015-2017 Analog Devices Inc.
 * Released under the AD9371 API license, for more information see the "LICENSE.txt" file in this zip file.
 *
@@ -1029,7 +1029,7 @@ typedef struct{
 
 /**
  *  \brief Structure to configure DPD (Only valid for a DPD-enabled transceiver)
- *  \deprecated robustModeling member of this structure is no longer in use.
+ *  deprecated robustModeling member of this structure is no longer in use.
  *  This information is loaded into the ARM memory using the
  *  MYKONOS_configDpd() function before running the DPD init or tracking
  *  calibrations.  These values can only be changed when the ARM is in the

--- a/projects/ad9371/src/devices/mykonos/t_mykonos_gpio.h
+++ b/projects/ad9371/src/devices/mykonos/t_mykonos_gpio.h
@@ -6,7 +6,7 @@
  */
 
 /**
-* \page Disclaimer Legal Disclaimer
+* Legal Disclaimer
 * Copyright 2015-2017 Analog Devices Inc.
 * Released under the AD9371 API license, for more information see the "LICENSE.txt" file in this zip file.
 *

--- a/projects/adrv9009/src/devices/ad9528/ad9528.c
+++ b/projects/adrv9009/src/devices/ad9528/ad9528.c
@@ -4,7 +4,7 @@
  */
 
 /**
-* \page Disclaimer Legal Disclaimer
+* Legal Disclaimer
 * Copyright 2015-2017 Analog Devices Inc.
 * Released under the AD9371 API license.
 *

--- a/projects/adrv9009/src/devices/ad9528/ad9528.h
+++ b/projects/adrv9009/src/devices/ad9528/ad9528.h
@@ -4,7 +4,7 @@
  */
 
 /**
-* \page Disclaimer Legal Disclaimer
+* Legal Disclaimer
 * Copyright 2015-2017 Analog Devices Inc.
 * Released under the AD9371 API license.
 *

--- a/projects/adrv9009/src/devices/ad9528/t_ad9528.h
+++ b/projects/adrv9009/src/devices/ad9528/t_ad9528.h
@@ -4,7 +4,7 @@
  */
 
 /**
-* \page Disclaimer Legal Disclaimer
+* Legal Disclaimer
 * Copyright 2015-2017 Analog Devices Inc.
 * Released under the AD9371 API license.
 *


### PR DESCRIPTION
Remove page/mainpage Doxygen commands for specific projects.

Doxygen mainpage will contain general information about the entire no-OS
repository.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>