### PR TITLE
drivers: platform: change init_param variable

### DIFF
--- a/drivers/platform/xilinx/gpio.c
+++ b/drivers/platform/xilinx/gpio.c
@@ -62,11 +62,11 @@
 /**
  * @brief Prepare the GPIO decriptor.
  * @param desc - The GPIO descriptor.
- * @param init_param - The structure that contains the GPIO parameters.
+ * @param param - The structure that contains the GPIO parameters.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t _gpio_init(struct gpio_desc *desc,
-		   const struct gpio_init_param *init_param)
+		   const struct gpio_init_param *param)
 {
 	int32_t				ret;
 	struct xil_gpio_desc		*xdesc;
@@ -75,10 +75,10 @@ int32_t _gpio_init(struct gpio_desc *desc,
 	ret = FAILURE;
 
 	xdesc = desc->extra;
-	xinit = init_param->extra;
+	xinit = param->extra;
 
 	xdesc->type = xinit->type;
-	desc->number = init_param->number;
+	desc->number = param->number;
 
 	switch (xinit->type) {
 	case GPIO_PL:
@@ -137,11 +137,11 @@ error:
 /**
  * @brief Obtain the GPIO decriptor.
  * @param desc - The GPIO descriptor.
- * @param init_param - GPIO initialization parameters
+ * @param param - GPIO initialization parameters
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t gpio_get(struct gpio_desc **desc,
-		 const struct gpio_init_param *init_param)
+		 const struct gpio_init_param *param)
 {
 	struct gpio_desc	*descriptor;
 	struct xil_gpio_desc	*extra;
@@ -154,7 +154,7 @@ int32_t gpio_get(struct gpio_desc **desc,
 		return FAILURE;
 
 	descriptor->extra = extra;
-	ret = _gpio_init(descriptor, init_param);
+	ret = _gpio_init(descriptor, param);
 
 	if(ret != SUCCESS)
 		goto error;

--- a/drivers/platform/xilinx/i2c.c
+++ b/drivers/platform/xilinx/i2c.c
@@ -62,11 +62,11 @@
 /**
  * @brief Initialize the I2C communication peripheral.
  * @param desc - The I2C descriptor.
- * @param init_param - The structure that contains the I2C parameters.
+ * @param param - The structure that contains the I2C parameters.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t i2c_init(struct i2c_desc **desc,
-		 const struct i2c_init_param *init_param)
+		 const struct i2c_init_param *param)
 {
 	int32_t		ret;
 	i2c_desc	*idesc;
@@ -79,9 +79,9 @@ int32_t i2c_init(struct i2c_desc **desc,
 	if(!idesc || !xdesc)
 		goto error;
 
-	idesc->max_speed_hz = init_param->max_speed_hz;
-	idesc->slave_address = init_param->slave_address;
-	xinit = init_param->extra;
+	idesc->max_speed_hz = param->max_speed_hz;
+	idesc->slave_address = param->slave_address;
+	xinit = param->extra;
 
 	idesc->extra = xdesc;
 	xdesc->type = xinit->type;
@@ -109,7 +109,7 @@ int32_t i2c_init(struct i2c_desc **desc,
 
 		ret = XIic_SetAddress(xdesc->instance,
 				      XII_ADDR_TO_SEND_TYPE,
-				      init_param->slave_address);
+				      param->slave_address);
 		if(ret != SUCCESS)
 			goto pl_error;
 
@@ -143,7 +143,7 @@ pl_error:
 		if(ret != SUCCESS)
 			goto ps_error;
 
-		XIicPs_SetSClk(xdesc->instance, init_param->max_speed_hz);
+		XIicPs_SetSClk(xdesc->instance, param->max_speed_hz);
 
 		break;
 ps_error:


### PR DESCRIPTION
Change `init_param` to `param` matching all init function headers from `/include` folder and other platform drivers implementations.

Fixes unmatching parameter name warnings generated by Doxygen integration.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>