### PR TITLE
tools: scripts: linux.mk: Fixed wrong scripts path

### DIFF
--- a/tools/scripts/linux.mk
+++ b/tools/scripts/linux.mk
@@ -381,7 +381,7 @@ post-build:
 .SILENT:run
 run: eval-hardware
 	@ if [ "$(PLATFORM)" = "xilinx" ];then				\
-		xsdb $(SCRIPTS_DIR)/upload.tcl				\
+		xsdb $(SCRIPTS_PATH)/upload.tcl				\
 			$(shell cat $(TEMP_DIR)/arch.txt) 		\
 			$(BUILD_DIR)/hw/system_top.bit			\
 			$(BUILD_DIR)/$(EXEC).elf			\


### PR DESCRIPTION
The upload script was moved in the xilinx platform folder but the path
wasn't updated. This commit fixes this path.

Signed-off-by: Sergiu Cuciurean <sergiu.cuciurean@analog.com>