### PR TITLE
drivers:adc:ad7779: add user commit with review changes

### DIFF
--- a/drivers/adc/ad7779/ad7779.c
+++ b/drivers/adc/ad7779/ad7779.c
@@ -425,8 +425,8 @@ int32_t ad7779_set_state(ad7779_dev *dev,
 
 	ret = ad7779_spi_int_reg_write_mask(dev,
 					    AD7779_REG_CH_DISABLE,
-					    AD7779_CH_DISABLE(0x1),
-					    AD7779_CH_DISABLE(state));
+					    AD7779_CH_DISABLE(ch),
+					    state ? AD7779_CH_DISABLE(ch) : 0);
 	dev->state[ch] = state;
 
 	return ret;
@@ -704,7 +704,7 @@ int32_t ad7779_set_dclk_div(ad7779_dev *dev,
 				      ((div & 0x04) >> 2));
 	} else {
 		ret = ad7779_spi_int_reg_write_mask(dev,
-						    AD7779_REG_CH_DISABLE,
+						    AD7779_REG_DOUT_FORMAT,
 						    AD7779_DCLK_CLK_DIV(0x3),
 						    AD7779_DCLK_CLK_DIV(div));
 	}


### PR DESCRIPTION
Implement user fixes, address the pull request comments and avoid merge
commit. User pull request:
https://github.com/analogdevicesinc/no-OS/pull/250
Add one commit with the message:
"
 Update ad7779.c

 Spurious deactivation of channels
 Correction  register address in ad7779_set_dclk_div.
 Correction of bit manipulation in ad7779_set_state
"

Co-Developed-by: F.HÉRÉSON <franck.hereson@secad.fr>
Signed-off-by: Andrei Drimbarean <Andrei.Drimbarean@analog.com>