### PR TITLE
ad9361: Fix warnings.

### DIFF
--- a/projects/ad9361/src/ad9361_conv.c
+++ b/projects/ad9361/src/ad9361_conv.c
@@ -688,8 +688,8 @@ int32_t ad9361_post_setup(struct ad9361_rf_phy *phy)
 	struct axiadc_converter *conv = phy->adc_conv;
 	struct axi_adc *rx_adc = phy->rx_adc;
 	int32_t rx2tx2 = phy->pdata->rx2tx2;
-	uint32_t tmp, num_chan, flags;
-	int32_t i, ret;
+	uint32_t tmp, num_chan, flags, i;
+	int32_t ret;
 
 	num_chan = ad9361_num_phy_chan(conv);
 

--- a/projects/ad9361/src/ad9361_util.h
+++ b/projects/ad9361/src/ad9361_util.h
@@ -97,7 +97,7 @@ struct axiadc_state {
 
 struct axiadc_chip_info {
 	char		*name;
-	int32_t		num_channels;
+	uint32_t	num_channels;
 };
 
 struct axiadc_converter {


### PR DESCRIPTION
Fix comparisons between signed and unsigned variables.

Signed-off-by: Cristian Pop <cristian.pop@analog.com>