### PR TITLE
doxy: adrv9009: fix warnings

### DIFF
--- a/projects/adrv9009/profiles/tx_bw100_ir122p88_rx_bw100_or122p88_orx_bw100_or122p88_dc122p88/talise_config.c
+++ b/projects/adrv9009/profiles/tx_bw100_ir122p88_rx_bw100_or122p88_orx_bw100_or122p88_dc122p88/talise_config.c
@@ -72,7 +72,7 @@ taliseDevice_t talDevice = {
 	 * Talise API does not use the devHalInfo member */
 	.devHalInfo = &talDevHalInfo,
 #else
-	.devHalInfo = NULL,     /*/** < Insert Customer Platform HAL State Container here>*/
+	.devHalInfo = NULL,     /* < Insert Customer Platform HAL State Container here>*/
 #endif
 	/* devStateInfo is maintained internal to the Talise API, just create the memory */
 	.devStateInfo = {0}

--- a/projects/adrv9009/profiles/tx_bw200_ir245p76_rx_bw200_or245p76_orx_bw200_or245p76_dc245p76/talise_config.c
+++ b/projects/adrv9009/profiles/tx_bw200_ir245p76_rx_bw200_or245p76_orx_bw200_or245p76_dc245p76/talise_config.c
@@ -72,7 +72,7 @@ taliseDevice_t talDevice = {
 	 * Talise API does not use the devHalInfo member */
 	.devHalInfo = &talDevHalInfo,
 #else
-	.devHalInfo = NULL,     /*/** < Insert Customer Platform HAL State Container here>*/
+	.devHalInfo = NULL,     /* < Insert Customer Platform HAL State Container here>*/
 #endif
 	/* devStateInfo is maintained internal to the Talise API, just create the memory */
 	.devStateInfo = {0}

--- a/projects/adrv9009/profiles/tx_bw400_ir491p52_rx_bw200_or245p76_orx_bw400_or491p52_dc245p76/talise_config.c
+++ b/projects/adrv9009/profiles/tx_bw400_ir491p52_rx_bw200_or245p76_orx_bw400_or491p52_dc245p76/talise_config.c
@@ -72,7 +72,7 @@ taliseDevice_t talDevice = {
 	 * Talise API does not use the devHalInfo member */
 	.devHalInfo = &talDevHalInfo,
 #else
-	.devHalInfo = NULL,     /*/** < Insert Customer Platform HAL State Container here>*/
+	.devHalInfo = NULL,     /* < Insert Customer Platform HAL State Container here>*/
 #endif
 	/* devStateInfo is maintained internal to the Talise API, just create the memory */
 	.devStateInfo = {0}


### PR DESCRIPTION
Fix Doxygen warnings: "Reached end of file while still inside a
(nested) comment."

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>