### PR TITLE
doxy: drivers: sd-card update doc & ad9528 minor fix

### DIFF
--- a/drivers/frequency/ad9528/ad9528.c
+++ b/drivers/frequency/ad9528/ad9528.c
@@ -754,6 +754,7 @@ uint32_t ad9528_calc_out_div(uint32_t rate,
 /***************************************************************************//**
  * @brief Calculate closest possible rate.
  *
+ * @param dev - is a pointer to the ad9528_dev data structure.
  * @param chan - The output channel.
  * @param rate - The desired rate.
  *

--- a/drivers/sd-card/sd.c
+++ b/drivers/sd-card/sd.c
@@ -399,7 +399,7 @@ static int32_t read_multiple_blocks(struct sd_desc *sd_desc,
  * This operation returns only when the read is complete
  * @param sd_desc	- Instance of the SD card
  * @param data		- Where data will be read
- * @param addr		- Address in memory from where data will be read
+ * @param address	- Address in memory from where data will be read
  * @param len		- Length in bytes of data to be read
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
@@ -450,7 +450,7 @@ int32_t sd_read(struct sd_desc *sd_desc,
  * This operation returns only when the write is complete
  * @param sd_desc	- Instance of the SD card
  * @param data		- Data to write
- * @param addr		- Address in memory where data will be written
+ * @param address	- Address in memory where data will be written
  * @param len		- Length of data in bytes
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
@@ -616,7 +616,7 @@ int32_t sd_init(struct sd_desc **sd_desc, const struct sd_init_param *param)
 
 /**
  * Remove the initialize instance of SD card.
- * @param sd_desc	- Instance of the SD card
+ * @param desc	- Instance of the SD card
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t sd_remove(struct sd_desc *desc)

--- a/drivers/sd-card/sd.h
+++ b/drivers/sd-card/sd.h
@@ -73,38 +73,41 @@
 /******************************************************************************/
 
 /**
- * struct sd_init_param - Configuration structure sent in the function sd_init
- * @spi_desc		- Descriptor of an initialized SPI channel
+ * @struct sd_init_param
+ * @brief Configuration structure sent in the function sd_init
  */
 struct sd_init_param {
+	/** Descriptor of an initialized SPI channel */
 	struct spi_desc *spi_desc;
 };
 
 /**
- * struct sd_desc - Structure that stores data about the SD card configurations
- * @spi_desc		- Descriptor of an initialized SPI channel
- * @memory_size		- Memory size of the SD card in bytes
- * @high_capacity	- 1 if SD card is HC or XC, 0 otherwise
- * @buff		- Buffer used for the driver implementation
+ * @struct sd_desc
+ * @brief Structure that stores data about the SD card configurations
  */
 struct sd_desc {
+	/** Descriptor of an initialized SPI channel */
 	struct spi_desc *spi_desc;
+	/** Memory size of the SD card in bytes */
 	uint64_t	memory_size;
+	/** 1 if SD card is HC or XC, 0 otherwise */
 	uint8_t		high_capacity;
+	/** Buffer used for the driver implementation */
 	uint8_t		buff[18];
 };
 
 /**
- * struct cmd_desc - Contains the elements needed to build a command
- * @cmd			- Command code
- * @arg			- Argument for the command
- * @response 		- Response with the size response_len will be written here
- * @response_len	- Expected length for the response
+ * @struct cmd_desc
+ * @brief Contains the elements needed to build a command
  */
 struct cmd_desc {
+	/** Command code */
 	uint8_t		cmd;
+	/** Argument for the command */
 	uint32_t	arg;
+	/** Response with the size response_len will be written here */
 	uint8_t		response[MAX_RESPONSE_LEN];
+	/** Expected length for the response */
 	uint32_t	response_len;
 };
 


### PR DESCRIPTION
- AD9528: Add missing parameter `dev` for doxygen integration.
- SD Card: Update code documentation to comply with Doxygen format.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>