### PR TITLE
includes: i2c: Modify name and type of options

### DIFF
--- a/drivers/platform/altera/i2c.c
+++ b/drivers/platform/altera/i2c.c
@@ -89,15 +89,13 @@ int32_t i2c_remove(struct i2c_desc *desc)
  * @param desc - The I2C descriptor.
  * @param data - Buffer that stores the transmission data.
  * @param bytes_number - Number of bytes to write.
- * @param option - Stop condition control.
- *                   Example: 0 - A stop condition will not be generated;
- *                            1 - A stop condition will be generated.
+ * @param transfer_mode - Transfer mode type
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t i2c_write(struct i2c_desc *desc,
 		  uint8_t *data,
 		  uint8_t bytes_number,
-		  uint8_t option)
+		  enum i2c_transfer_mode transfer_mode)
 {
 	if (desc) {
 		// Unused variable - fix compiler warning
@@ -111,7 +109,7 @@ int32_t i2c_write(struct i2c_desc *desc,
 		// Unused variable - fix compiler warning
 	}
 
-	if (option) {
+	if (transfer_mode) {
 		// Unused variable - fix compiler warning
 	}
 
@@ -123,15 +121,13 @@ int32_t i2c_write(struct i2c_desc *desc,
  * @param desc - The I2C descriptor.
  * @param data - Buffer that will store the received data.
  * @param bytes_number - Number of bytes to read.
- * @param option - Stop condition control.
- *                   Example: 0 - A stop condition will not be generated;
- *                            1 - A stop condition will be generated.
+ * @param transfer_mode - Transfer mode type
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t i2c_read(struct i2c_desc *desc,
 		 uint8_t *data,
 		 uint8_t bytes_number,
-		 uint8_t option)
+		 enum i2c_transfer_mode transfer_mode)
 {
 	if (desc) {
 		// Unused variable - fix compiler warning
@@ -145,7 +141,7 @@ int32_t i2c_read(struct i2c_desc *desc,
 		// Unused variable - fix compiler warning
 	}
 
-	if (option) {
+	if (transfer_mode) {
 		// Unused variable - fix compiler warning
 	}
 

--- a/drivers/platform/generic/i2c.c
+++ b/drivers/platform/generic/i2c.c
@@ -86,15 +86,13 @@ int32_t i2c_remove(struct i2c_desc *desc)
  * @param desc - The I2C descriptor.
  * @param data - Buffer that stores the transmission data.
  * @param bytes_number - Number of bytes to write.
- * @param option - Stop condition control.
- *                   Example: 0 - A stop condition will not be generated;
- *                            1 - A stop condition will be generated.
+ * @param transfer_mode - Transfer mode type
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t i2c_write(struct i2c_desc *desc,
 		  uint8_t *data,
 		  uint8_t bytes_number,
-		  uint8_t option)
+		  enum i2c_transfer_mode transfer_mode)
 {
 	if (desc) {
 		// Unused variable - fix compiler warning
@@ -108,7 +106,7 @@ int32_t i2c_write(struct i2c_desc *desc,
 		// Unused variable - fix compiler warning
 	}
 
-	if (option) {
+	if (transfer_mode) {
 		// Unused variable - fix compiler warning
 	}
 
@@ -120,15 +118,13 @@ int32_t i2c_write(struct i2c_desc *desc,
  * @param desc - The I2C descriptor.
  * @param data - Buffer that will store the received data.
  * @param bytes_number - Number of bytes to read.
- * @param option - Stop condition control.
- *                   Example: 0 - A stop condition will not be generated;
- *                            1 - A stop condition will be generated.
+ * @param transfer_mode - Transfer mode type
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t i2c_read(struct i2c_desc *desc,
 		 uint8_t *data,
 		 uint8_t bytes_number,
-		 uint8_t option)
+		 enum i2c_transfer_mode transfer_mode)
 {
 	if (desc) {
 		// Unused variable - fix compiler warning
@@ -142,7 +138,7 @@ int32_t i2c_read(struct i2c_desc *desc,
 		// Unused variable - fix compiler warning
 	}
 
-	if (option) {
+	if (transfer_mode) {
 		// Unused variable - fix compiler warning
 	}
 

--- a/drivers/platform/linux/platform_drivers.c
+++ b/drivers/platform/linux/platform_drivers.c
@@ -108,15 +108,13 @@ int32_t i2c_remove(i2c_desc *desc)
  * @param desc - The I2C descriptor.
  * @param data - Buffer that stores the transmission data.
  * @param bytes_number - Number of bytes to write.
- * @param option - Stop condition control.
- *                   Example: 0 - A stop condition will not be generated;
- *                            1 - A stop condition will be generated.
+ * @param transfer_mode - Transfer mode type
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t i2c_write(i2c_desc *desc,
 		  uint8_t *data,
 		  uint8_t bytes_number,
-		  uint8_t option)
+		  enum i2c_transfer_mode transfer_mode)
 {
 	int ret;
 
@@ -132,7 +130,7 @@ int32_t i2c_write(i2c_desc *desc,
 		return FAILURE;
 	}
 
-	if (option) {
+	if (transfer_mode) {
 		// Unused variable - fix compiler warning
 	}
 
@@ -144,15 +142,13 @@ int32_t i2c_write(i2c_desc *desc,
  * @param desc - The I2C descriptor.
  * @param data - Buffer that will store the received data.
  * @param bytes_number - Number of bytes to read.
- * @param option - Stop condition control.
- *                   Example: 0 - A stop condition will not be generated;
- *                            1 - A stop condition will be generated.
+ * @param transfer_mode - Transfer mode type
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t i2c_read(i2c_desc *desc,
 		 uint8_t *data,
 		 uint8_t bytes_number,
-		 uint8_t option)
+		 enum i2c_transfer_mode transfer_mode)
 {
 	int ret;
 
@@ -168,7 +164,7 @@ int32_t i2c_read(i2c_desc *desc,
 		return FAILURE;
 	}
 
-	if (option) {
+	if (transfer_mode) {
 		// Unused variable - fix compiler warning
 	}
 

--- a/drivers/platform/xilinx/i2c.c
+++ b/drivers/platform/xilinx/i2c.c
@@ -213,15 +213,13 @@ error:
  * @param desc - The I2C descriptor.
  * @param data - Buffer that stores the transmission data.
  * @param bytes_number - Number of bytes to write.
- * @param option - Stop condition control.
- *                   Example: 0 - A stop condition will not be generated;
- *                            1 - A stop condition will be generated.
+ * @param transfer_mode - Transfer mode type
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t i2c_write(struct i2c_desc *desc,
 		  uint8_t *data,
 		  uint8_t bytes_number,
-		  uint8_t option)
+		  enum i2c_transfer_mode transfer_mode)
 {
 	xil_i2c_desc	*xdesc;
 	int32_t		ret;
@@ -235,15 +233,21 @@ int32_t i2c_write(struct i2c_desc *desc,
 			  desc->slave_address,
 			  data,
 			  bytes_number,
-			  option ? XIIC_REPEATED_START : XIIC_STOP);
+			  (transfer_mode & I2C_REPEATED_START) ?
+			  XIIC_REPEATED_START :	XIIC_STOP);
 		break;
 #endif
 		goto error;
 	case IIC_PS:
 #ifdef XIICPS_H
-
-		ret = XIicPs_SetOptions(xdesc->instance,
-					option);
+		uint8_t options =
+			((transfer_mode & I2C_10_BIT_TRANSFER) ?
+			 XIICPS_10_BIT_ADDR_OPTION : XIICPS_7_BIT_ADDR_OPTION) |
+			((transfer_mode & I2C_REPEATED_START) ?
+			 XIICPS_REP_START_OPTION : 0) |
+			((transfer_mode & I2C_SLAVE_MONITOR) ?
+			 XIICPS_SLAVE_MON_OPTION : 0);
+		ret = XIicPs_SetOptions(xdesc->instance, options);
 		if(ret != SUCCESS)
 			goto error;
 
@@ -272,15 +276,13 @@ error:
  * @param desc - The I2C descriptor.
  * @param data - Buffer that will store the received data.
  * @param bytes_number - Number of bytes to read.
- * @param option - Stop condition control.
- *                   Example: 0 - A stop condition will not be generated;
- *                            1 - A stop condition will be generated.
+ * @param transfer_mode - Transfer mode type
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t i2c_read(struct i2c_desc *desc,
 		 uint8_t *data,
 		 uint8_t bytes_number,
-		 uint8_t option)
+		 enum i2c_transfer_mode transfer_mode)
 {
 	xil_i2c_desc	*xdesc;
 	int32_t		ret;
@@ -294,7 +296,8 @@ int32_t i2c_read(struct i2c_desc *desc,
 				desc->slave_address,
 				data,
 				bytes_number,
-				option ? XIIC_REPEATED_START : XIIC_STOP);
+				(transfer_mode & I2C_REPEATED_START) ?
+				XIIC_REPEATED_START : XIIC_STOP);
 		if(ret != SUCCESS)
 			goto error;
 
@@ -303,9 +306,14 @@ int32_t i2c_read(struct i2c_desc *desc,
 		goto error;
 	case IIC_PS:
 #ifdef XIICPS_H
-
-		ret = XIicPs_SetOptions(xdesc->instance,
-					option);
+		uint8_t options =
+			((transfer_mode & I2C_10_BIT_TRANSFER) ?
+			 XIICPS_10_BIT_ADDR_OPTION : XIICPS_7_BIT_ADDR_OPTION) |
+			((transfer_mode & I2C_REPEATED_START) ?
+			 XIICPS_REP_START_OPTION : 0) |
+			((transfer_mode & I2C_SLAVE_MONITOR) ?
+			 XIICPS_SLAVE_MON_OPTION : 0);
+		ret = XIicPs_SetOptions(xdesc->instance, options);
 		if(ret != SUCCESS)
 			goto error;
 

--- a/include/i2c.h
+++ b/include/i2c.h
@@ -55,12 +55,16 @@
  * @brief I2C transfer mode configuration
  */
 typedef enum i2c_transfer_mode {
+	/** Transfer with STOP condition and with 7-bit address scheme */
+	I2C_NORMAL_TRANSFER = 0x00,
 	/** Address every device connected */
-	i2c_general_call =	0x01,
+	I2C_GENERAL_CALL = 0x01,
 	/** Send multiple start conditions */
-	i2c_repeated_start =	0x02,
+	I2C_REPEATED_START = 0x02,
 	/** Use 10-bit address scheme */
-	i2c_10_bit_transfer =	0x04
+	I2C_10_BIT_TRANSFER = 0x04,
+	/** Use Slave monitor mode */
+	I2C_SLAVE_MONITOR = 0x08
 } i2c_transfer_mode;
 
 /**
@@ -104,12 +108,12 @@ int32_t i2c_remove(struct i2c_desc *desc);
 int32_t i2c_write(struct i2c_desc *desc,
 		  uint8_t *data,
 		  uint8_t bytes_number,
-		  uint8_t option);
+		  enum i2c_transfer_mode transfer_mode);
 
 /* Read data from a slave device. */
 int32_t i2c_read(struct i2c_desc *desc,
 		 uint8_t *data,
 		 uint8_t bytes_number,
-		 uint8_t option);
+		 enum i2c_transfer_mode transfer_mode);
 
 #endif // I2C_H_


### PR DESCRIPTION
Modify options name to transfer_mode.
Modify transfer_mode type to enum i2c_transfer_mode.
Add filed i2c_slave_monitor to transfer_mode necesary on xilinx.
implementation.
Make necesary modifications in platform driveres implementtions.
This changes make easy to use and understand the functionality of
transfer_mode parameter

Signed-off-by: Mihail Chindris <mihail.chindris@analog.com>