### PR TITLE
sync hmc7044 no-os driver with the linux driver

### DIFF
--- a/drivers/frequency/hmc7044/hmc7044.h
+++ b/drivers/frequency/hmc7044/hmc7044.h
@@ -53,20 +53,34 @@
 struct hmc7044_chan_spec {
 	unsigned int	num;
 	bool		disable;
-	bool			high_performance_mode_dis;
-	bool			start_up_mode_dynamic_enable;
-	bool			output_control0_rb4_enable;
+	bool		high_performance_mode_dis;
+	bool		start_up_mode_dynamic_enable;
+	bool		dynamic_driver_enable;
+	bool		output_control0_rb4_enable;
+	bool		force_mute_enable;
 	unsigned int	divider;
 	unsigned int	driver_mode;
+	unsigned int	driver_impedance;
+	unsigned int	coarse_delay;
+	unsigned int	fine_delay;
+	unsigned int	out_mux_mode;
 };
 
 struct hmc7044_dev {
 	spi_desc	*spi_desc;
 	uint32_t	clkin_freq[4];
+	uint32_t	clkin_freq_ccf[4];
 	uint32_t	vcxo_freq;
+	uint32_t	pll1_pfd;
 	uint32_t	pll2_freq;
 	uint32_t	pll1_loop_bw;
 	uint32_t	sysref_timer_div;
+	unsigned int	pll1_ref_prio_ctrl;
+	bool		clkin0_rfsync_en;
+	bool		clkin1_vcoin_en;
+	bool		high_performance_mode_clock_dist_en;
+	bool		high_performance_mode_pll_vco_en;
+	unsigned int	sync_pin_mode;
 	uint32_t	pulse_gen_mode;
 	uint32_t	in_buf_mode[5];
 	uint32_t	gpi_ctrl[4];
@@ -78,10 +92,18 @@ struct hmc7044_dev {
 struct hmc7044_init_param {
 	spi_init_param	*spi_init;
 	uint32_t	clkin_freq[4];
+	uint32_t	clkin_freq_ccf[4];
 	uint32_t	vcxo_freq;
+	uint32_t	pll1_pfd;
 	uint32_t	pll2_freq;
 	uint32_t	pll1_loop_bw;
 	uint32_t	sysref_timer_div;
+	unsigned int	pll1_ref_prio_ctrl;
+	bool		clkin0_rfsync_en;
+	bool		clkin1_vcoin_en;
+	bool		high_performance_mode_clock_dist_en;
+	bool		high_performance_mode_pll_vco_en;
+	unsigned int	sync_pin_mode;
 	uint32_t	pulse_gen_mode;
 	uint32_t	in_buf_mode[5];
 	uint32_t	gpi_ctrl[4];


### PR DESCRIPTION
The following linux kernel commits implement changes that are needed for the
hmc7044 to work on the adrv9009-zu11eg.

f316710d44554
51bdb91c6a767
d540768ae9fed
178195fff0f3b
74f76eb464fcc
7648a18bebb74
4ad15b25e6e5d
8053df102f877
f73b7874486d0
55e449589c1de
9d6a091391599
7ae263475cf15
618128a3c0976
ddb8a1978b4e6
b4b05318100da
e10ad36e2f7b1
c7c6e9053e4fd
ea0e697da6988
bb13250bbb211

Signed-off-by: Darius Berghe <darius.berghe@analog.com>