### PR TITLE
libraries: libtinyiiod: Add makefile support

### DIFF
--- a/projects/adrv9009/Makefile
+++ b/projects/adrv9009/Makefile
@@ -1,4 +1,5 @@
 TARGET := adrv9009
+TINYIIOD = y
 ifeq ($(OS), Windows_NT)
 include ../../tools/scripts/windows.mk
 else

--- a/projects/adrv9009/src.mk
+++ b/projects/adrv9009/src.mk
@@ -39,6 +39,16 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c			\
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c
+ifdef TINYIIOD
+SRCS += $(NO-OS)/util/xml.c						\
+	$(NO-OS)/util/fifo.c						\
+	$(NO-OS)/iio/iio.c						\
+	$(NO-OS)/iio/iio_axi_adc/iio_axi_adc.c				\
+	$(NO-OS)/iio/iio_axi_dac/iio_axi_dac.c				\
+	$(NO-OS)/iio/iio_app/iio_app.c					\
+	$(NO-OS)/iio/iio_app/iio_axi_adc_app.c				\
+	$(NO-OS)/iio/iio_app/iio_axi_dac_app.c
+endif
 SRCS +=	$(NO-OS)/util/util.c
 ifeq (xilinx,$(strip $(PLATFORM)))
 SRCS += $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
@@ -53,7 +63,9 @@ endif
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
 	$(PLATFORM_DRIVERS)/spi.c					\
 	$(PLATFORM_DRIVERS)/gpio.c					\
-	$(PLATFORM_DRIVERS)/delay.c
+	$(PLATFORM_DRIVERS)/delay.c					\
+	$(PLATFORM_DRIVERS)/uart.c					\
+	$(PLATFORM_DRIVERS)/irq.c
 INCS :=	$(PROJECT)/src/app/app_config.h					\
 	$(PROJECT)/src/app/app_clocking.h						\
 	$(PROJECT)/src/app/app_jesd.h						\
@@ -107,10 +119,27 @@ INCS += $(DRIVERS)/axi_core/clk_altera_a10_fpll/clk_altera_a10_fpll.h	\
 	$(DRIVERS)/axi_core/jesd204/altera_adxcvr.h
 endif
 INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\
-	$(PLATFORM_DRIVERS)/gpio_extra.h
+	$(PLATFORM_DRIVERS)/gpio_extra.h				\
+	$(PLATFORM_DRIVERS)/irq_extra.h					\
+	$(PLATFORM_DRIVERS)/uart_extra.h
 INCS +=	$(INCLUDE)/axi_io.h						\
 	$(INCLUDE)/spi.h						\
 	$(INCLUDE)/gpio.h						\
 	$(INCLUDE)/error.h						\
 	$(INCLUDE)/delay.h						\
-	$(INCLUDE)/util.h
+	$(INCLUDE)/fifo.h						\
+	$(INCLUDE)/irq.h						\
+	$(INCLUDE)/uart.h
+ifdef TINYIIOD
+INCS +=	$(INCLUDE)/xml.h						\
+	$(INCLUDE)/util.h						\
+	$(NO-OS)/iio/iio.h						\
+	$(NO-OS)/iio/iio_types.h					\
+	$(NO-OS)/iio/iio_axi_adc/iio_axi_adc.h				\
+	$(NO-OS)/iio/iio_axi_dac/iio_axi_dac.h				\
+	$(NO-OS)/iio/iio_app/iio_app.h					\
+	$(NO-OS)/iio/iio_app/iio_axi_adc_app.h				\
+	$(NO-OS)/iio/iio_app/iio_axi_dac_app.h				\
+	$(NO-OS)/libraries/libtinyiiod/tinyiiod.h			\
+	$(NO-OS)/libraries/libtinyiiod/compat.h
+endif

--- a/tools/scripts/linux.mk
+++ b/tools/scripts/linux.mk
@@ -432,6 +432,9 @@ xilinx-bsp:
 	@ if [ "$(ARCH)" = "sys_mb" ]; then				\
 		sed -i "s/_HEAP_SIZE : 0x800/_HEAP_SIZE : 0x100000/g"	\
 		$(BUILD_DIR)/app/src/lscript.ld;			\
+	else								\
+		sed -i "s/_HEAP_SIZE : 0x2000/_HEAP_SIZE : 0x100000/g"	\
+		$(BUILD_DIR)/app/src/lscript.ld;			\
 	fi;
 	$(MUTE)rm -rf $(BUILD_DIR)/SDK.log
 


### PR DESCRIPTION
This PR adds makefile support for tinyiiod and sets the functionality as default in adrv9009 .