### PR TITLE
iio: add support for doxygen integration

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -18,6 +18,7 @@ set(DOCUMENTED_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/license_page.dox \\
     ${CMAKE_CURRENT_SOURCE_DIR}/mainpage.dox \\
     ${SOURCES_DIR}/include \\
+    ${SOURCES_DIR}/iio \\
     ${SOURCES_DIR}/drivers/accel \\
     ${SOURCES_DIR}/drivers/adc \\
     ${SOURCES_DIR}/drivers/adc-dac  \\

--- a/doc/mainpage.dox
+++ b/doc/mainpage.dox
@@ -37,6 +37,10 @@ which can't run Linux or aren't running a specific operating system, to help cus
 
 Generic header files from no-OS repository: \link_to_subdir{/include "Include"}
 
+\section iio IIO
+
+IIO interfaces and application documentation available at : \link_to_subdir{/iio "IIO"}
+
 \section drivers Drivers
 
 A list of available drivers can be found here: \ref drivers_page "Drivers"

--- a/iio/iio.c
+++ b/iio/iio.c
@@ -55,58 +55,58 @@
 /******************************************************************************/
 
 /**
- * struct iio_interface - Links a physical device instance "void *dev_instance"
+ * @struct iio_interface
+ * @brief Links a physical device instance "void *dev_instance"
  * with a "iio_device *iio" that describes capabilities of the device.
- * @name:			Device name.
- * @ch_mask:			Opened channels.
- * @dev_instance:		Physical instance of a device.
- * @iio:			Device descriptor(describes channels and
- *				attributes).
- * @get_xml:			Generate device xml.
- * @transfer_dev_to_mem:	Transfer data from device into RAM.
- * @read_data:			Read data from RAM to pbuf. It should be called
- *				after "transfer_dev_to_mem".
- * @transfer_mem_to_dev:	Transfer data from RAM to device.
- * @write_data:			Write data to RAM. It should be called before
- *				"transfer_mem_to_dev".
  */
 struct iio_interface {
+	/** Device name */
 	const char *name;
+	/** Opened channels */
 	uint32_t ch_mask;
+	/** Physical instance of a device */
 	void *dev_instance;
+	/** Device descriptor(describes channels and attributes) */
 	struct iio_device *iio;
+	/** Generate device xml */
 	ssize_t (*get_xml)(char **xml, struct iio_device *iio);
+	/** Transfer data from device into RAM */
 	ssize_t (*transfer_dev_to_mem)(void *dev_instance, size_t bytes_count,
 				       uint32_t ch_mask);
+	/** Read data from RAM to pbuf. It should be called after "transfer_dev_to_mem" */
 	ssize_t (*read_data)(void *dev_instance, char *pbuf, size_t offset,
 			     size_t bytes_count, uint32_t ch_mask);
+	/** Transfer data from RAM to device */
 	ssize_t (*transfer_mem_to_dev)(void *dev_instance, size_t bytes_count,
 				       uint32_t ch_mask);
+	/** Write data to RAM. It should be called before "transfer_mem_to_dev" */
 	ssize_t (*write_data)(void *dev_instance, char *pbuf, size_t offset,
 			      size_t bytes_count, uint32_t ch_mask);
 };
 
 /**
- * struct iio_interfaces - Structure containing all interfaces.
- * @interfaces:		List containing all interfaces.
- * @num_interfaces:	Number of Interfaces.
+ * @struct iio_interfaces
+ * @brief Structure containing all interfaces.
  */
 struct iio_interfaces {
+	/** List containing all interfaces */
 	struct iio_interface **interfaces;
+	/** Number of Interfaces */
 	uint8_t num_interfaces;
 };
 
 /**
- * struct element_info - Structure informations about a specific parameter.
- * @device_name:	Device name.
- * @channel_name:	Channel name.
- * @attribute_name:	Attribute name.
- * @ch_out:		If set, is an output channel.
+ * @struct element_info
+ * @brief Structure informations about a specific parameter.
  */
 struct element_info {
+	/** Device name */
 	const char *device_name;
+	/** Channel name */
 	const char *channel_name;
+	/** Attribute name */
 	const char *attribute_name;
+	/** If set, is an output channel */
 	bool ch_out;
 };
 
@@ -120,9 +120,9 @@ static struct iio_interfaces *iio_interfaces = NULL;
 /******************************************************************************/
 
 /**
- * iio_get_channel_number() - Get channel number.
- * @ch: String containing channel name + channel number.
- * Return: Channel number. Ex: for "altvoltage0" return 0, for "voltage2"
+ * @brief Get channel number.
+ * @param ch - String containing channel name + channel number.
+ * @return - Channel number. Ex: for "altvoltage0" return 0, for "voltage2"
  * return 2.
  */
 static int32_t iio_get_channel_number(const char *ch)
@@ -141,11 +141,11 @@ static int32_t iio_get_channel_number(const char *ch)
 }
 
 /**
- * iio_get_channel_id() - Get channel ID from a list of channels.
- * @channel:	Channel name.
- * @channels:	List of channels.
- * @ch_out:	If "true" is output channel, if "false" is input channel.
- * Return: Channel ID, or negative value if attribute is not found.
+ * @brief Get channel ID from a list of channels.
+ * @param channel - Channel name.
+ * @param channels - List of channels.
+ * @param ch_out - If "true" is output channel, if "false" is input channel.
+ * @return Channel ID, or negative value if attribute is not found.
  */
 static int16_t iio_get_channel_id(const char *channel,
 				  struct iio_channel **channels, bool ch_out)
@@ -165,10 +165,10 @@ static int16_t iio_get_channel_id(const char *channel,
 }
 
 /**
- * iio_get_attribute_id() - Get attribute ID from a list of attributes.
- * @attr:	Attribute name.
- * @attributes:	List of attributes.
- * Return: Attribute ID, or negative value if attribute is not found.
+ * @brief Get attribute ID from a list of attributes.
+ * @param attr - Attribute name.
+ * @param attributes - List of attributes.
+ * @return - Attribute ID, or negative value if attribute is not found.
  */
 static int16_t iio_get_attribute_id(const char *attr,
 				    struct iio_attribute **attributes)
@@ -188,10 +188,10 @@ static int16_t iio_get_attribute_id(const char *attr,
 }
 
 /**
- * iio_get_interface() - Find interface with "device_name".
- * @device_name:	Device name.
- * @iio_interfaces:	List of interfaces.
- * Return: Interface pointer if interface is found, NULL otherwise.
+ * @brief Find interface with "device_name".
+ * @param device_name - Device name.
+ * @param iio_interfaces - List of interfaces.
+ * @return Interface pointer if interface is found, NULL otherwise.
  */
 static struct iio_interface *iio_get_interface(const char *device_name,
 		struct iio_interfaces *iio_interfaces)
@@ -210,13 +210,13 @@ static struct iio_interface *iio_get_interface(const char *device_name,
 }
 
 /**
- * iio_read_all_attr() - Read all attributes from an attribute list.
- * @device:		Physical instance of a device.
- * @buf:		Buffer where values are read.
- * @len:		Maximum length of value to be stored in buf.
- * @channel:		Channel properties.
- * @attributes:		List of attributes to be read.
- * Return: Number of bytes read or negative value in case of error.
+ * @brief Read all attributes from an attribute list.
+ * @param device - Physical instance of a device.
+ * @param buf - Buffer where values are read.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @param attributes - List of attributes to be read.
+ * @return Number of bytes read or negative value in case of error.
  */
 static ssize_t iio_read_all_attr(void *device, char *buf, size_t len,
 				 const struct iio_ch_info *channel, struct iio_attribute **attributes)
@@ -250,13 +250,13 @@ static ssize_t iio_read_all_attr(void *device, char *buf, size_t len,
 }
 
 /**
- * iio_write_all_attr() - Write all attributes from an attribute list.
- * @device:	Physical instance of a device.
- * @buf:	Values to be written.
- * @len:	Length of buf.
- * @channel:	Channel properties.
- * @attributes:	List of attributes to be written.
- * Return: Number of written bytes or negative value in case of error.
+ * @brief Write all attributes from an attribute list.
+ * @param device - Physical instance of a device.
+ * @param buf - Values to be written.
+ * @param len - Length of buf.
+ * @param channel - Channel properties.
+ * @param attributes - List of attributes to be written.
+ * @return Number of written bytes or negative value in case of error.
  */
 static ssize_t iio_write_all_attr(void *device, char *buf, size_t len,
 				  const struct iio_ch_info *channel, struct iio_attribute **attributes)
@@ -284,14 +284,14 @@ static ssize_t iio_write_all_attr(void *device, char *buf, size_t len,
 }
 
 /**
- * iio_rd_wr_channel_attribute() - Read/write channel attribute.
- * @el_info:	Structure describing element to be written.
- * @buf:	Read/write value.
- * @len:	Length of data in "buf" parameter.
- * @channel: 	Structure describing channel attributes.
- * @is_write:	If it has value "1", writes attribute, otherwise reads
+ * @brief Read/write channel attribute.
+ * @param el_info - Structure describing element to be written.
+ * @param buf - Read/write value.
+ * @param len - Length of data in "buf" parameter.
+ * @param channel - Structure describing channel attributes.
+ * @param is_write -If it has value "1", writes attribute, otherwise reads
  * 		attribute.
- * Return: Length of chars written/read or negative value in case of error.
+ * @return Length of chars written/read or negative value in case of error.
  */
 static ssize_t iio_rd_wr_channel_attribute(struct element_info *el_info,
 		char *buf, size_t len,
@@ -331,14 +331,14 @@ static ssize_t iio_rd_wr_channel_attribute(struct element_info *el_info,
 }
 
 /**
- * iio_rd_wr_attribute() - Read/write attribute.
- * @el_info:	Structure describing element to be written.
- * @buf:	Read/write value.
- * @len:	Length of data in "buf" parameter.
- * @iio_device:	Physical instance of a device.
- * @is_write:	If it has value "1", writes attribute, otherwise reads
+ * @brief Read/write attribute.
+ * @param el_info - Structure describing element to be written.
+ * @param buf - Read/write value.
+ * @param len - Length of data in "buf" parameter.
+ * @param iio_device - Physical instance of a device.
+ * @param is_write -If it has value "1", writes attribute, otherwise reads
  * 		attribute.
- * Return: Length of chars written/read or negative value in case of error.
+ * @return Length of chars written/read or negative value in case of error.
  */
 static ssize_t iio_rd_wr_attribute(struct element_info *el_info, char *buf,
 				   size_t len,
@@ -388,9 +388,9 @@ static ssize_t iio_rd_wr_attribute(struct element_info *el_info, char *buf,
 }
 
 /**
- * iio_supported_dev() - Check if device is supported.
- * @device:	Device name.
- * Return: TRUE if device is supported, FALSE otherwise.
+ * @brief Check if device is supported.
+ * @param device - Device name.
+ * @return TRUE if device is supported, FALSE otherwise.
  */
 static bool iio_supported_dev(const char *device)
 {
@@ -398,13 +398,13 @@ static bool iio_supported_dev(const char *device)
 }
 
 /**
- * iio_read_attr() - Read global attribute of a device.
- * @device:	String containing device name.
- * @attr:	String containing attribute name.
- * @buf:	Buffer where value is read.
- * @len:	Maximum length of value to be stored in buf.
- * @debug:	Read raw value if set.
- * Return: Number of bytes read.
+ * @brief Read global attribute of a device.
+ * @param device - String containing device name.
+ * @param attr - String containing attribute name.
+ * @param buf - Buffer where value is read.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param debug - Read raw value if set.
+ * @return Number of bytes read.
  */
 static ssize_t iio_read_attr(const char *device, const char *attr, char *buf,
 			     size_t len, bool debug)
@@ -427,13 +427,13 @@ static ssize_t iio_read_attr(const char *device, const char *attr, char *buf,
 }
 
 /**
- * iio_write_attr() - Write global attribute of a device.
- * @device:	String containing device name.
- * @attr:	String containing attribute name.
- * @buf:	Value to be written.
- * @len:	Length of data.
- * @debug:	Write raw value if set.
- * Return: Number of written bytes.
+ * @brief Write global attribute of a device.
+ * @param device - String containing device name.
+ * @param attr - String containing attribute name.
+ * @param buf - Value to be written.
+ * @param len - Length of data.
+ * @param debug - Write raw value if set.
+ * @return Number of written bytes.
  */
 static ssize_t iio_write_attr(const char *device, const char *attr,
 			      const char *buf,
@@ -457,14 +457,14 @@ static ssize_t iio_write_attr(const char *device, const char *attr,
 }
 
 /**
- * iio_ch_read_attr() - Read channel attribute.
- * @device:	String containing device name.
- * @channel:	String containing channel name.
- * @ch_out:	Channel type input/output.
- * @attr:	String containing attribute name.
- * @buf:	Buffer where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * Return: Number of bytes read.
+ * @brief Read channel attribute.
+ * @param device - String containing device name.
+ * @param channel - String containing channel name.
+ * @param ch_out -Channel type input/output.
+ * @param attr - String containing attribute name.
+ * @param buf - Buffer where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @return - Number of bytes read.
  */
 static ssize_t iio_ch_read_attr(const char *device, const char *channel,
 				bool ch_out, const char *attr, char *buf, size_t len)
@@ -488,14 +488,14 @@ static ssize_t iio_ch_read_attr(const char *device, const char *channel,
 }
 
 /**
- * iio_ch_write_attr() - Write channel attribute.
- * @device:	String containing device name.
- * @channel:	String containing channel name.
- * @ch_out:	Channel type input/output.
- * @attr:	String containing attribute name.
- * @buf:	Value to be written.
- * @len:	Length of data in "buf" parameter.
- * Return: Number of written bytes.
+ * @brief Write channel attribute.
+ * @param device - String containing device name.
+ * @param channel - String containing channel name.
+ * @param ch_out - Channel type input/output.
+ * @param attr - String containing attribute name.
+ * @param buf - Value to be written.
+ * @param len - Length of data in "buf" parameter.
+ * @return Number of written bytes.
  */
 static ssize_t iio_ch_write_attr(const char *device, const char *channel,
 				 bool ch_out, const char *attr, const char *buf, size_t len)
@@ -519,11 +519,11 @@ static ssize_t iio_ch_write_attr(const char *device, const char *channel,
 }
 
 /**
- * iio_open_dev() - Open device.
- * @device:		String containing device name.
- * @sample_size:	Sample size.
- * @mask:		Channels to be opened.
- * Return: SUCCESS, negative value in case of failure.
+ * @brief  Open device.
+ * @param device - String containing device name.
+ * @param sample_size - Sample size.
+ * @param mask - Channels to be opened.
+ * @return SUCCESS, negative value in case of failure.
  */
 static int32_t iio_open_dev(const char *device, size_t sample_size,
 			    uint32_t mask)
@@ -546,9 +546,9 @@ static int32_t iio_open_dev(const char *device, size_t sample_size,
 }
 
 /**
- * iio_close_dev() - Close device.
- * @device:	String containing device name.
- * Return: SUCCESS, negative value in case of failure.
+ * @brief Close device.
+ * @param device - String containing device name.
+ * @return SUCCESS, negative value in case of failure.
  */
 static int32_t iio_close_dev(const char *device)
 {
@@ -563,10 +563,10 @@ static int32_t iio_close_dev(const char *device)
 }
 
 /**
- * iio_get_mask() - Get device mask, this specifies the channels that are used.
- * @device:	String containing device name.
- * @mask:	Channels that are opened.
- * Return: SUCCESS, negative value in case of failure.
+ * @brief Get device mask, this specifies the channels that are used.
+ * @param device - String containing device name.
+ * @param mask - Channels that are opened.
+ * @return SUCCESS, negative value in case of failure.
  */
 static int32_t iio_get_mask(const char *device, uint32_t *mask)
 {
@@ -582,10 +582,10 @@ static int32_t iio_get_mask(const char *device, uint32_t *mask)
 }
 
 /**
- * iio_transfer_dev_to_mem() - Transfer data from device into RAM.
- * @device:		String containing device name.
- * @bytes_count:	Number of bytes.
- * Return: Bytes_count or negative value in case of error.
+ * @brief Transfer data from device into RAM.
+ * @param device - String containing device name.
+ * @param bytes_count - Number of bytes.
+ * @return Bytes_count or negative value in case of error.
  */
 static ssize_t iio_transfer_dev_to_mem(const char *device, size_t bytes_count)
 {
@@ -599,15 +599,15 @@ static ssize_t iio_transfer_dev_to_mem(const char *device, size_t bytes_count)
 }
 
 /**
- * iio_read_dev() - Read chunk of data from RAM to pbuf. Call
+ * @brief Read chunk of data from RAM to pbuf. Call
  * "iio_transfer_dev_to_mem()" first.
  * This function is probably called multiple times by libtinyiiod after a
  * "iio_transfer_dev_to_mem" call, since we can only read "bytes_count" bytes.
- * @device:		String containing device name.
- * @pbuf:		Buffer where value is stored.
- * @offset:		Offset to the remaining data after reading n chunks.
- * @bytes_count:	Number of bytes to read.
- * Return: Bytes_count or negative value in case of error.
+ * @param device - String containing device name.
+ * @param pbuf - Buffer where value is stored.
+ * @param offset - Offset to the remaining data after reading n chunks.
+ * @param bytes_count - Number of bytes to read.
+ * @return: Bytes_count or negative value in case of error.
  */
 static ssize_t iio_read_dev(const char *device, char *pbuf, size_t offset,
 			    size_t bytes_count)
@@ -622,10 +622,10 @@ static ssize_t iio_read_dev(const char *device, char *pbuf, size_t offset,
 }
 
 /**
- * iio_transfer_mem_to_dev() - Transfer memory to device.
- * @device:		String containing device name.
- * @bytes_count:	Number of bytes to transfer.
- * Return: Bytes_count or negative value in case of error.
+ * @brief Transfer memory to device.
+ * @param device - String containing device name.
+ * @param bytes_count - Number of bytes to transfer.
+ * @return Bytes_count or negative value in case of error.
  */
 static ssize_t iio_transfer_mem_to_dev(const char *device, size_t bytes_count)
 {
@@ -639,15 +639,15 @@ static ssize_t iio_transfer_mem_to_dev(const char *device, size_t bytes_count)
 }
 
 /**
- * iio_write_dev() - Write chunk of data into RAM.
+ * @brief Write chunk of data into RAM.
  * This function is probably called multiple times by libtinyiiod before a
  * "iio_transfer_mem_to_dev" call, since we can only write "bytes_count" bytes
  * at a time.
- * @device:		String containing device name.
- * @buf:		Values to write.
- * @offset:		Offset in memory after the nth chunk of data.
- * @bytes_count:	Number of bytes to write.
- * Return: Bytes_count or negative value in case of error.
+ * @param device - String containing device name.
+ * @param buf - Values to write.
+ * @param offset - Offset in memory after the nth chunk of data.
+ * @param bytes_count - Number of bytes to write.
+ * @return Bytes_count or negative value in case of error.
  */
 static ssize_t iio_write_dev(const char *device, const char *buf,
 			     size_t offset, size_t bytes_count)
@@ -661,9 +661,9 @@ static ssize_t iio_write_dev(const char *device, const char *buf,
 }
 
 /**
- * iio_get_xml() - Get a merged xml containing all devices.
- * @outxml:	Generated xml.
- * Return: SUCCESS in case of success or negative value otherwise.
+ * @brief Get a merged xml containing all devices.
+ * @param outxml - Generated xml.
+ * @return SUCCESS in case of success or negative value otherwise.
  */
 static ssize_t iio_get_xml(char **outxml)
 {
@@ -736,10 +736,10 @@ error:
 }
 
 /**
- * iio_register() - Register interface.
- * @init_par:	Structure containing physical device instance and device
+ * @brief Register interface.
+ * @param init_par - Structure containing physical device instance and device
  * 		descriptor.
- * Return: SUCCESS in case of success or negative value otherwise.
+ * @return SUCCESS in case of success or negative value otherwise.
  */
 ssize_t iio_register(struct iio_interface_init_par *init_par)
 {
@@ -786,9 +786,9 @@ ssize_t iio_register(struct iio_interface_init_par *init_par)
 }
 
 /**
- * iio_unregister() - Unregister interface.
- * @device_name: String containing device name.
- * Return: SUCCESS in case of success or negative value otherwise.
+ * @brief Unregister interface.
+ * @param device_name String containing device name.
+ * @return SUCCESS in case of success or negative value otherwise.
  */
 ssize_t iio_unregister(const char *device_name)
 {
@@ -829,12 +829,12 @@ ssize_t iio_unregister(const char *device_name)
 }
 
 /**
- * iio_init() - Set communication ops and read/write ops that will be called
+ * @brief Set communication ops and read/write ops that will be called
  * from "libtinyiiod".
- * @*iiod:		Structure containing new tinyiiod instance.
- * @iio_server_ops:	Structure containing read/write ops (Ex: read/write to
+ * @param iiod - Structure containing new tinyiiod instance.
+ * @param iio_server_ops - Structure containing read/write ops (Ex: read/write to
  * 			UART).
- * Return: SUCCESS in case of success or negative value otherwise.
+ * @return SUCCESS in case of success or negative value otherwise.
  */
 ssize_t iio_init(struct tinyiiod **iiod, struct iio_server_ops *iio_server_ops)
 {
@@ -872,9 +872,9 @@ ssize_t iio_init(struct tinyiiod **iiod, struct iio_server_ops *iio_server_ops)
 }
 
 /**
- * iio_remove() - Free the resources allocated by "iio_init()".
- * @iiod: Structure containing tinyiiod instance.
- * Return: SUCCESS in case of success or negative value otherwise.
+ * @brief Free the resources allocated by "iio_init()".
+ * @param iiod: Structure containing tinyiiod instance.
+ * @return SUCCESS in case of success or negative value otherwise.
  */
 ssize_t iio_remove(struct tinyiiod *iiod)
 {

--- a/iio/iio_ad9361/iio_ad9361.c
+++ b/iio/iio_ad9361/iio_ad9361.c
@@ -412,12 +412,12 @@ static const char * const  ad9361_phy_xml =
 /******************************************************************************/
 
 /**
- * get_cf_calibphase().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_rf_port_select().
+ * @param device- Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_rf_port_select(void *device, char *buf, size_t len,
 				  const struct iio_ch_info *channel)
@@ -436,12 +436,12 @@ static ssize_t get_rf_port_select(void *device, char *buf, size_t len,
 }
 
 /**
- * get_hardwaregain().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_hardwaregain().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_hardwaregain(void *device, char *buf, size_t len,
 				const struct iio_ch_info *channel)
@@ -481,12 +481,12 @@ static ssize_t get_hardwaregain(void *device, char *buf, size_t len,
 }
 
 /**
- * get_rssi().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_rssi().
+ * @param device- Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_rssi(void *device, char *buf, size_t len,
 			const struct iio_ch_info *channel)
@@ -510,12 +510,12 @@ static ssize_t get_rssi(void *device, char *buf, size_t len,
 }
 
 /**
- * get_hardwaregain_available().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_hardwaregain_available().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_hardwaregain_available(void *device, char *buf, size_t len,
 		const struct iio_ch_info *channel)
@@ -533,12 +533,12 @@ static ssize_t get_hardwaregain_available(void *device, char *buf, size_t len,
 }
 
 /**
- * get_sampling_frequency_available().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_sampling_frequency_available().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_sampling_frequency_available(void *device, char *buf,
 		size_t len,
@@ -570,12 +570,12 @@ static ssize_t get_sampling_frequency_available(void *device, char *buf,
 }
 
 /**
- * get_rf_port_select_available().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_rf_port_select_available().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_rf_port_select_available(void *device, char *buf, size_t len,
 		const struct iio_ch_info *channel)
@@ -604,12 +604,12 @@ static ssize_t get_rf_port_select_available(void *device, char *buf, size_t len,
 }
 
 /**
- * get_filter_fir_en().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_filter_fir_en().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_filter_fir_en(void *device, char *buf, size_t len,
 				 const struct iio_ch_info *channel)
@@ -629,12 +629,12 @@ static ssize_t get_filter_fir_en(void *device, char *buf, size_t len,
 }
 
 /**
- * get_sampling_frequency().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_sampling_frequency().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_sampling_frequency(void *device, char *buf, size_t len,
 				      const struct iio_ch_info *channel)
@@ -650,12 +650,12 @@ static ssize_t get_sampling_frequency(void *device, char *buf, size_t len,
 }
 
 /**
- * get_rf_bandwidth_available().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_rf_bandwidth_available().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_rf_bandwidth_available(void *device, char *buf, size_t len,
 		const struct iio_ch_info *channel)
@@ -667,12 +667,12 @@ static ssize_t get_rf_bandwidth_available(void *device, char *buf, size_t len,
 }
 
 /**
- * get_rf_bandwidth().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_rf_bandwidth().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_rf_bandwidth(void *device, char *buf, size_t len,
 				const struct iio_ch_info *channel)
@@ -685,12 +685,12 @@ static ssize_t get_rf_bandwidth(void *device, char *buf, size_t len,
 }
 
 /**
- * get_gain_control_mode().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_gain_control_mode().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_gain_control_mode(void *device, char *buf, size_t len,
 				     const struct iio_ch_info *channel)
@@ -701,12 +701,12 @@ static ssize_t get_gain_control_mode(void *device, char *buf, size_t len,
 }
 
 /**
- * get_rf_dc_offset_tracking_en().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_rf_dc_offset_tracking_en().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_rf_dc_offset_tracking_en(void *device, char *buf, size_t len,
 		const struct iio_ch_info *channel)
@@ -720,12 +720,12 @@ static ssize_t get_rf_dc_offset_tracking_en(void *device, char *buf, size_t len,
 }
 
 /**
- * get_quadrature_tracking_en().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_quadrature_tracking_en().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_quadrature_tracking_en(void *device, char *buf, size_t len,
 		const struct iio_ch_info *channel)
@@ -739,12 +739,12 @@ static ssize_t get_quadrature_tracking_en(void *device, char *buf, size_t len,
 }
 
 /**
- * get_gain_control_mode_available().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_gain_control_mode_available().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_gain_control_mode_available(void *device, char *buf,
 		size_t len,
@@ -758,12 +758,12 @@ static ssize_t get_gain_control_mode_available(void *device, char *buf,
 }
 
 /**
- * get_bb_dc_offset_tracking_en().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_bb_dc_offset_tracking_en().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len -	Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_bb_dc_offset_tracking_en(void *device, char *buf, size_t len,
 		const struct iio_ch_info *channel)
@@ -777,12 +777,12 @@ static ssize_t get_bb_dc_offset_tracking_en(void *device, char *buf, size_t len,
 }
 
 /**
- * get_frequency_available().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_frequency_available().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_frequency_available(void *device, char *buf, size_t len,
 				       const struct iio_ch_info *channel)
@@ -793,12 +793,12 @@ static ssize_t get_frequency_available(void *device, char *buf, size_t len,
 }
 
 /**
- * get_fastlock_save().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_fastlock_save().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_fastlock_save(void *device, char *buf, size_t len,
 				 const struct iio_ch_info *channel)
@@ -823,12 +823,12 @@ static ssize_t get_fastlock_save(void *device, char *buf, size_t len,
 }
 
 /**
- * get_powerdown().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_powerdown().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_powerdown(void *device, char *buf, size_t len,
 			     const struct iio_ch_info *channel)
@@ -843,12 +843,12 @@ static ssize_t get_powerdown(void *device, char *buf, size_t len,
 }
 
 /**
- * get_fastlock_load().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_fastlock_load().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_fastlock_load(void *device, char *buf, size_t len,
 				 const struct iio_ch_info *channel)
@@ -860,12 +860,12 @@ static ssize_t get_fastlock_load(void *device, char *buf, size_t len,
 }
 
 /**
- * get_fastlock_store().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_fastlock_store().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_fastlock_store(void *device, char *buf, size_t len,
 				  const struct iio_ch_info *channel)
@@ -877,12 +877,12 @@ static ssize_t get_fastlock_store(void *device, char *buf, size_t len,
 }
 
 /**
- * get_frequency().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_frequency().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf -	Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return: Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_frequency(void *device, char *buf, size_t len,
 			     const struct iio_ch_info *channel)
@@ -897,12 +897,12 @@ static ssize_t get_frequency(void *device, char *buf, size_t len,
 }
 
 /**
- * get_external().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_external().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_external(void *device, char *buf, size_t len,
 			    const struct iio_ch_info *channel)
@@ -918,12 +918,12 @@ static ssize_t get_external(void *device, char *buf, size_t len,
 }
 
 /**
- * get_fastlock_recall().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_fastlock_recall().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len -	Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_fastlock_recall(void *device, char *buf, size_t len,
 				   const struct iio_ch_info *channel)
@@ -935,12 +935,12 @@ static ssize_t get_fastlock_recall(void *device, char *buf, size_t len,
 }
 
 /**
- * get_temp0_input().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_temp0_input().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_temp0_input(void *device, char *buf, size_t len,
 			       const struct iio_ch_info *channel)
@@ -955,12 +955,12 @@ static ssize_t get_temp0_input(void *device, char *buf, size_t len,
 }
 
 /**
- * get_voltage_filter_fir_en().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_voltage_filter_fir_en().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_voltage_filter_fir_en(void *device, char *buf, size_t len,
 		const struct iio_ch_info *channel)
@@ -980,12 +980,12 @@ static ssize_t get_voltage_filter_fir_en(void *device, char *buf, size_t len,
 }
 
 /**
- * set_hardwaregain_available().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_hardwaregain_available().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_hardwaregain_available(void *device, char *buf, size_t len,
 		const struct iio_ch_info *channel)
@@ -997,12 +997,12 @@ static ssize_t set_hardwaregain_available(void *device, char *buf, size_t len,
 }
 
 /**
- * set_hardwaregain().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_hardwaregain().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_hardwaregain(void *device, char *buf, size_t len,
 				const struct iio_ch_info *channel)
@@ -1039,12 +1039,12 @@ static ssize_t set_hardwaregain(void *device, char *buf, size_t len,
 }
 
 /**
- * set_rssi().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_rssi().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return  Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_rssi(void *device, char *buf, size_t len,
 			const struct iio_ch_info *channel)
@@ -1056,12 +1056,12 @@ static ssize_t set_rssi(void *device, char *buf, size_t len,
 }
 
 /**
- * set_rf_port_select().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_rf_port_select().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len -	Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return: Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_rf_port_select(void *device, char *buf, size_t len,
 				  const struct iio_ch_info *channel)
@@ -1096,12 +1096,12 @@ static ssize_t set_rf_port_select(void *device, char *buf, size_t len,
 }
 
 /**
- * set_gain_control_mode().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_gain_control_mode().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_gain_control_mode(void *device, char *buf, size_t len,
 				     const struct iio_ch_info *channel)
@@ -1133,12 +1133,12 @@ static ssize_t set_gain_control_mode(void *device, char *buf, size_t len,
 }
 
 /**
- * set_rf_port_select_available().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_rf_port_select_available().
+ * @param device Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_rf_port_select_available(void *device, char *buf, size_t len,
 		const struct iio_ch_info *channel)
@@ -1150,12 +1150,12 @@ static ssize_t set_rf_port_select_available(void *device, char *buf, size_t len,
 }
 
 /**
- * set_rf_bandwidth().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_rf_bandwidth().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_rf_bandwidth(void *device, char *buf, size_t len,
 				const struct iio_ch_info *channel)
@@ -1181,12 +1181,12 @@ static ssize_t set_rf_bandwidth(void *device, char *buf, size_t len,
 }
 
 /**
- * set_rf_dc_offset_tracking_en().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_rf_dc_offset_tracking_en().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_rf_dc_offset_tracking_en(void *device, char *buf, size_t len,
 		const struct iio_ch_info *channel)
@@ -1210,12 +1210,12 @@ static ssize_t set_rf_dc_offset_tracking_en(void *device, char *buf, size_t len,
 }
 
 /**
- * set_sampling_frequency_available().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_sampling_frequency_available().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_sampling_frequency_available(void *device, char *buf,
 		size_t len,
@@ -1228,12 +1228,12 @@ static ssize_t set_sampling_frequency_available(void *device, char *buf,
 }
 
 /**
- * set_quadrature_tracking_en().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_quadrature_tracking_en().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_quadrature_tracking_en(void *device, char *buf, size_t len,
 		const struct iio_ch_info *channel)
@@ -1257,12 +1257,12 @@ static ssize_t set_quadrature_tracking_en(void *device, char *buf, size_t len,
 }
 
 /**
- * set_sampling_frequency().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_sampling_frequency().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_sampling_frequency(void *device, char *buf, size_t len,
 				      const struct iio_ch_info *channel)
@@ -1278,12 +1278,12 @@ static ssize_t set_sampling_frequency(void *device, char *buf, size_t len,
 }
 
 /**
- * set_gain_control_mode_available().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_gain_control_mode_available().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_gain_control_mode_available(void *device, char *buf,
 		size_t len,
@@ -1316,12 +1316,12 @@ static ssize_t set_gain_control_mode_available(void *device, char *buf,
 }
 
 /**
- * set_filter_fir_en().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_filter_fir_en().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_filter_fir_en(void *device, char *buf, size_t len,
 				 const struct iio_ch_info *channel)
@@ -1345,12 +1345,12 @@ static ssize_t set_filter_fir_en(void *device, char *buf, size_t len,
 }
 
 /**
- * set_rf_bandwidth_available().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_rf_bandwidth_available().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_rf_bandwidth_available(void *device, char *buf, size_t len,
 		const struct iio_ch_info *channel)
@@ -1362,12 +1362,12 @@ static ssize_t set_rf_bandwidth_available(void *device, char *buf, size_t len,
 }
 
 /**
- * set_bb_dc_offset_tracking_en().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_bb_dc_offset_tracking_en().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_bb_dc_offset_tracking_en(void *device, char *buf, size_t len,
 		const struct iio_ch_info *channel)
@@ -1391,12 +1391,12 @@ static ssize_t set_bb_dc_offset_tracking_en(void *device, char *buf, size_t len,
 }
 
 /**
- * set_frequency_available().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_frequency_available().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_frequency_available(void *device, char *buf, size_t len,
 				       const struct iio_ch_info *channel)
@@ -1408,12 +1408,12 @@ static ssize_t set_frequency_available(void *device, char *buf, size_t len,
 }
 
 /**
- * set_fastlock_save().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_fastlock_save().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_fastlock_save(void *device, char *buf, size_t len,
 				 const struct iio_ch_info *channel)
@@ -1427,12 +1427,12 @@ static ssize_t set_fastlock_save(void *device, char *buf, size_t len,
 }
 
 /**
- * set_powerdown().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_powerdown().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_powerdown(void *device, char *buf, size_t len,
 			     const struct iio_ch_info *channel)
@@ -1452,12 +1452,12 @@ static ssize_t set_powerdown(void *device, char *buf, size_t len,
 }
 
 /**
- * set_fastlock_load().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_fastlock_load().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return: Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_fastlock_load(void *device, char *buf, size_t len,
 				 const struct iio_ch_info *channel)
@@ -1494,12 +1494,12 @@ static ssize_t set_fastlock_load(void *device, char *buf, size_t len,
 }
 
 /**
- * set_fastlock_store().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_fastlock_store().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_fastlock_store(void *device, char *buf, size_t len,
 				  const struct iio_ch_info *channel)
@@ -1516,12 +1516,12 @@ static ssize_t set_fastlock_store(void *device, char *buf, size_t len,
 }
 
 /**
- * set_frequency().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_frequency().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_frequency(void *device, char *buf, size_t len,
 			     const struct iio_ch_info *channel)
@@ -1549,12 +1549,12 @@ static ssize_t set_frequency(void *device, char *buf, size_t len,
 }
 
 /**
- * set_external().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_external().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_external(void *device, char *buf, size_t len,
 			    const struct iio_ch_info *channel)
@@ -1574,12 +1574,12 @@ static ssize_t set_external(void *device, char *buf, size_t len,
 }
 
 /**
- * set_fastlock_recall().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_fastlock_recall().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_fastlock_recall(void *device, char *buf, size_t len,
 				   const struct iio_ch_info *channel)
@@ -1596,12 +1596,12 @@ static ssize_t set_fastlock_recall(void *device, char *buf, size_t len,
 }
 
 /**
- * set_voltage_filter_fir_en().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_voltage_filter_fir_en().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_voltage_filter_fir_en(void *device, char *buf, size_t len,
 		const struct iio_ch_info *channel)
@@ -1621,12 +1621,12 @@ static ssize_t set_voltage_filter_fir_en(void *device, char *buf, size_t len,
 }
 
 /**
- * get_dcxo_tune_coarse().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_dcxo_tune_coarse().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_dcxo_tune_coarse(void *device, char *buf, size_t len,
 				    const struct iio_ch_info *channel)
@@ -1640,12 +1640,12 @@ static ssize_t get_dcxo_tune_coarse(void *device, char *buf, size_t len,
 }
 
 /**
- * get_rx_path_rates().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_rx_path_rates().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_rx_path_rates(void *device, char *buf, size_t len,
 				 const struct iio_ch_info *channel)
@@ -1663,12 +1663,12 @@ static ssize_t get_rx_path_rates(void *device, char *buf, size_t len,
 }
 
 /**
- * get_trx_rate_governor().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_trx_rate_governor().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_trx_rate_governor(void *device, char *buf, size_t len,
 				     const struct iio_ch_info *channel)
@@ -1684,12 +1684,12 @@ static ssize_t get_trx_rate_governor(void *device, char *buf, size_t len,
 }
 
 /**
- * get_calib_mode_available().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_calib_mode_available().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_calib_mode_available(void *device, char *buf, size_t len,
 					const struct iio_ch_info *channel)
@@ -1700,12 +1700,12 @@ static ssize_t get_calib_mode_available(void *device, char *buf, size_t len,
 }
 
 /**
- * get_xo_correction_available().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_xo_correction_available().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_xo_correction_available(void *device, char *buf, size_t len,
 		const struct iio_ch_info *channel)
@@ -1714,12 +1714,12 @@ static ssize_t get_xo_correction_available(void *device, char *buf, size_t len,
 }
 
 /**
- * get_gain_table_config().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_gain_table_config().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_gain_table_config(void *device, char *buf, size_t len,
 				     const struct iio_ch_info *channel)
@@ -1728,12 +1728,12 @@ static ssize_t get_gain_table_config(void *device, char *buf, size_t len,
 }
 
 /**
- * get_dcxo_tune_fine().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_dcxo_tune_fine().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_dcxo_tune_fine(void *device, char *buf, size_t len,
 				  const struct iio_ch_info *channel)
@@ -1747,12 +1747,12 @@ static ssize_t get_dcxo_tune_fine(void *device, char *buf, size_t len,
 }
 
 /**
- * get_dcxo_tune_fine_available().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_dcxo_tune_fine_available().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len -Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return: Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_dcxo_tune_fine_available(void *device, char *buf, size_t len,
 		const struct iio_ch_info *channel)
@@ -1764,12 +1764,12 @@ static ssize_t get_dcxo_tune_fine_available(void *device, char *buf, size_t len,
 }
 
 /**
- * get_ensm_mode_available().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_ensm_mode_available().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_ensm_mode_available(void *device, char *buf, size_t len,
 				       const struct iio_ch_info *channel)
@@ -1782,12 +1782,12 @@ static ssize_t get_ensm_mode_available(void *device, char *buf, size_t len,
 }
 
 /**
- * get_multichip_sync().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_multichip_sync().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - sChannel properties.
+ * @return: Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_multichip_sync(void *device, char *buf, size_t len,
 				  const struct iio_ch_info *channel)
@@ -1796,12 +1796,12 @@ static ssize_t get_multichip_sync(void *device, char *buf, size_t len,
 }
 
 /**
- * get_rssi_gain_step_error().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_rssi_gain_step_error().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_rssi_gain_step_error(void *device, char *buf, size_t len,
 					const struct iio_ch_info *channel)
@@ -1810,12 +1810,12 @@ static ssize_t get_rssi_gain_step_error(void *device, char *buf, size_t len,
 }
 
 /**
- * get_dcxo_tune_coarse_available().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_dcxo_tune_coarse_available().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_dcxo_tune_coarse_available(void *device, char *buf,
 		size_t len,
@@ -1828,12 +1828,12 @@ static ssize_t get_dcxo_tune_coarse_available(void *device, char *buf,
 }
 
 /**
- * get_tx_path_rates().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_tx_path_rates().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_tx_path_rates(void *device, char *buf, size_t len,
 				 const struct iio_ch_info *channel)
@@ -1851,12 +1851,12 @@ static ssize_t get_tx_path_rates(void *device, char *buf, size_t len,
 }
 
 /**
- * get_trx_rate_governor_available().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_trx_rate_governor_available().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_trx_rate_governor_available(void *device, char *buf,
 		size_t len,
@@ -1866,12 +1866,12 @@ static ssize_t get_trx_rate_governor_available(void *device, char *buf,
 }
 
 /**
- * get_xo_correction().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_xo_correction().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_xo_correction(void *device, char *buf, size_t len,
 				 const struct iio_ch_info *channel)
@@ -1880,12 +1880,12 @@ static ssize_t get_xo_correction(void *device, char *buf, size_t len,
 }
 
 /**
- * get_ensm_mode().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_ensm_mode().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_ensm_mode(void *device, char *buf, size_t len,
 			     const struct iio_ch_info *channel)
@@ -1903,12 +1903,12 @@ static ssize_t get_ensm_mode(void *device, char *buf, size_t len,
 }
 
 /**
- * get_filter_fir_config().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_filter_fir_config().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_filter_fir_config(void *device, char *buf, size_t len,
 				     const struct iio_ch_info *channel)
@@ -1921,12 +1921,12 @@ static ssize_t get_filter_fir_config(void *device, char *buf, size_t len,
 }
 
 /**
- * get_calib_mode().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_calib_mode().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_calib_mode(void *device, char *buf, size_t len,
 			      const struct iio_ch_info *channel)
@@ -1942,12 +1942,12 @@ static ssize_t get_calib_mode(void *device, char *buf, size_t len,
 }
 
 /**
- * set_trx_rate_governor().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_trx_rate_governor().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_trx_rate_governor(void *device, char *buf, size_t len,
 				     const struct iio_ch_info *channel)
@@ -1966,12 +1966,12 @@ static ssize_t set_trx_rate_governor(void *device, char *buf, size_t len,
 }
 
 /**
- * set_dcxo_tune_coarse().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_dcxo_tune_coarse().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_dcxo_tune_coarse(void *device, char *buf, size_t len,
 				    const struct iio_ch_info *channel)
@@ -1992,12 +1992,12 @@ static ssize_t set_dcxo_tune_coarse(void *device, char *buf, size_t len,
 }
 
 /**
- * set_dcxo_tune_fine().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_dcxo_tune_fine().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_dcxo_tune_fine(void *device, char *buf, size_t len,
 				  const struct iio_ch_info *channel)
@@ -2018,12 +2018,12 @@ static ssize_t set_dcxo_tune_fine(void *device, char *buf, size_t len,
 }
 
 /**
- * set_calib_mode().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_calib_mode().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_calib_mode(void *device, char *buf, size_t len,
 			      const struct iio_ch_info *channel)
@@ -2061,12 +2061,12 @@ static ssize_t set_calib_mode(void *device, char *buf, size_t len,
 }
 
 /**
- * set_ensm_mode().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_ensm_mode().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return: Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_ensm_mode(void *device, char *buf, size_t len,
 			     const struct iio_ch_info *channel)
@@ -2112,12 +2112,12 @@ static ssize_t set_ensm_mode(void *device, char *buf, size_t len,
 }
 
 /**
- * set_multichip_sync().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_multichip_sync().
+ * @param device Physical instance of a iio_axi_dac device.
+ * @param buf Value to be written to attribute.
+ * @param len Length of the data in "buf".
+ * @param channel Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_multichip_sync(void *device, char *buf, size_t len,
 				  const struct iio_ch_info *channel)
@@ -2137,12 +2137,12 @@ extern int32_t ad9361_parse_fir(struct ad9361_rf_phy *phy,
 				char *data, uint32_t size);
 
 /**
- * set_filter_fir_config().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_filter_fir_config().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_filter_fir_config(void *device, char *buf, size_t len,
 				     const struct iio_ch_info *channel)
@@ -2574,10 +2574,10 @@ static struct iio_channel *iio_ad9361_channels[] = {
 };
 
 /**
- * iio_ad9361_get_xml() - Get xml corresponding to an "ad9361" device.
- * @xml:	Xml containing description of a device.
- * @iio_dev:	Structure describing a device, channels and attributes.
- * Return: SUCCESS in case of success or negative value otherwise.
+ * @brief Get xml corresponding to an "ad9361" device.
+ * @param xml - Xml containing description of a device.
+ * @param iio_dev - Structure describing a device, channels and attributes.
+ * @return SUCCESS in case of success or negative value otherwise.
  */
 ssize_t iio_ad9361_get_xml(char **xml, struct iio_device *iio_dev)
 {
@@ -2591,10 +2591,9 @@ ssize_t iio_ad9361_get_xml(char **xml, struct iio_device *iio_dev)
 }
 
 /**
- * iio_ad9361_create_device() - Create structure describing a device, channels
- * and attributes.
- * @device:	Device name.
- * Return: iio_device or NULL, in case of failure.
+ * @brief Create structure describing a device, channels and attributes.
+ * @param device_name - Device name.
+ * @return iio_device or NULL, in case of failure
  */
 struct iio_device *iio_ad9361_create_device(const char *device_name)
 {

--- a/iio/iio_app/iio_app.c
+++ b/iio/iio_app/iio_app.c
@@ -48,10 +48,10 @@
 #include "iio_app.h"
 
 /**
- * iio_app_init() - Application parameterization.
- * @desc - Application descriptor.
- * @param - Application initial configuration structure.
- * @Return: SUCCESS in case of success, FAILURE otherwise.
+ * @brief Application parameterization.
+ * @param desc - Application descriptor.
+ * @param param - Application initial configuration structure.
+ * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t iio_app_init(struct iio_app_desc **desc,
 		     struct iio_app_init_param *param)
@@ -76,9 +76,9 @@ int32_t iio_app_init(struct iio_app_desc **desc,
 }
 
 /**
- * iio_app_remove() - Release resources.
- * @desc - Application descriptor.
- * @Return: SUCCESS in case of success, FAILURE otherwise.
+ * @brief Release resources.
+ * @param desc - Application descriptor.
+ * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t iio_app_remove(struct iio_app_desc *desc)
 {
@@ -97,9 +97,9 @@ int32_t iio_app_remove(struct iio_app_desc *desc)
 }
 
 /**
- * iio_app() - iio application, reads commands and executes them.
- * @desc - Application descriptor.
- * @Return: SUCCESS in case of success, FAILURE otherwise.
+ * @brief iio application, reads commands and executes them.
+ * @param desc - Application descriptor.
+ * @return: SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t iio_app(struct iio_app_desc *desc)
 {

--- a/iio/iio_app/iio_app.h
+++ b/iio/iio_app/iio_app.h
@@ -51,20 +51,22 @@
 /******************************************************************************/
 
 /**
- * struct iio_app_desc - Application desciptor.
- * @iio_server_ops - read./write function callbacks.
- * @iiod - iiod handle.
+ * @struct iio_app_desc
+ * @brief Application desciptor.
  */
 struct iio_app_desc {
+	/** read./write function callbacks */
 	struct iio_server_ops *iio_server_ops;
+	/** iiod handle */
 	struct tinyiiod *iiod;
 };
 
 /**
- * struct iio_app_init_param - Application initial configuration.
- * @iio_server_ops - read./write function callbacks.
+ * @struct iio_app_init_param
+ * @brief Application initial configuration.
  */
 struct iio_app_init_param {
+	/** read./write function callbacks */
 	struct iio_server_ops *iio_server_ops;
 };
 

--- a/iio/iio_app/iio_axi_adc_app.c
+++ b/iio/iio_app/iio_axi_adc_app.c
@@ -54,11 +54,11 @@
 /******************************************************************************/
 
 /**
- * iio_axi_adc_app_init() - Application for reading/writing and parameterization of
+ * @brief Application for reading/writing and parameterization of
  * axi_adc device.
- * @desc - Application descriptor.
- * @init - Application configuration structure.
- * @Return: SUCCESS in case of success, FAILURE otherwise.
+ * @param  desc - Application descriptor.
+ * @param init - Application configuration structure.
+ * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t iio_axi_adc_app_init(struct iio_axi_adc_app_desc **desc,
 			     struct iio_axi_adc_app_init_param *init)
@@ -118,9 +118,9 @@ int32_t iio_axi_adc_app_init(struct iio_axi_adc_app_desc **desc,
 }
 
 /**
- * iio_axi_adc_app_remove() - Release resources.
- * @desc - Application descriptor.
- * @Return: SUCCESS in case of success, FAILURE otherwise.
+ * @brief Release resources.
+ * @param desc - Application descriptor.
+ * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t iio_axi_adc_app_remove(struct iio_axi_adc_app_desc *desc)
 {

--- a/iio/iio_app/iio_axi_adc_app.h
+++ b/iio/iio_app/iio_axi_adc_app.h
@@ -53,20 +53,22 @@
 /******************************************************************************/
 
 /**
- * struct iio_axi_adc_desc - Application desciptor.
- * @iio_axi_dac_inst - iio DAC device handle.
+ * @struct iio_axi_adc_desc
+ * @brief Application desciptor.
  */
 struct iio_axi_adc_app_desc {
+	/** iio DAC device handle */
 	struct iio_axi_adc *iio_axi_adc_inst;
 };
 
 /**
- * struct iio_axi_adc_init_param - Application configuration.
- * @rx_adc - ADC device.
- * @rx_dmac - Receive DMA device.
+ * @struct iio_axi_adc_init_param
+ * @brief Application configuration.
  */
 struct iio_axi_adc_app_init_param {
+	/** ADC device */
 	struct axi_adc *rx_adc;
+	/** Receive DMA device */
 	struct axi_dmac *rx_dmac;
 };
 

--- a/iio/iio_app/iio_axi_dac_app.c
+++ b/iio/iio_app/iio_axi_dac_app.c
@@ -54,11 +54,11 @@
 /******************************************************************************/
 
 /**
- * iio_axi_dac_init() - Application for reading/writing and parameterization of
+ * @brief Application for reading/writing and parameterization of
  * axi_dac device.
- * @desc - Application descriptor.
- * @param - Application configuration structure.
- * @Return: SUCCESS in case of success, FAILURE otherwise.
+ * @param desc - Application descriptor.
+ * @param param - Application configuration structure.
+ * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t iio_axi_dac_app_init(struct iio_axi_dac_app_desc **desc,
 			     struct iio_axi_dac_app_init_param *param)
@@ -116,9 +116,9 @@ int32_t iio_axi_dac_app_init(struct iio_axi_dac_app_desc **desc,
 }
 
 /**
- * iio_axi_dac_app_remove() - Release resources.
- * @desc - Application descriptor.
- * @Return: SUCCESS in case of success, FAILURE otherwise.
+ * @brief Release resources.
+ * @param desc - Application descriptor.
+ * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t iio_axi_dac_app_remove(struct iio_axi_dac_app_desc *desc)
 {

--- a/iio/iio_app/iio_axi_dac_app.h
+++ b/iio/iio_app/iio_axi_dac_app.h
@@ -1,6 +1,6 @@
 /***************************************************************************//**
- *   @file   iio_basic_app.h
- *   @brief  Header file of iio_basic_app.
+ *   @file   iio_axi_dac_app.h
+ *   @brief  Header file of iio_axi_dac_app.
  *   @author Cristian Pop (cristian.pop@analog.com)
 ********************************************************************************
  * Copyright 2019(c) Analog Devices, Inc.
@@ -53,20 +53,22 @@
 /******************************************************************************/
 
 /**
- * struct iio_basic_app_desc - Application desciptor.
- * @iio_axi_dac_inst - iio DAC device handle.
+ * @struct iio_basic_app_desc
+ * @brief Application desciptor.
  */
 struct iio_axi_dac_app_desc {
+	/** iio DAC device handle */
 	struct iio_axi_dac *iio_axi_dac_inst;
 };
 
 /**
- * struct iio_basic_app_init_param - Application configuration.
- * @tx_dac - DAC device.
- * @tx_dmac - Transmit DMA device.
+ * @struct iio_basic_app_init_param
+ * @brief Application configuration.
  */
 struct iio_axi_dac_app_init_param {
+	/** DAC device */
 	struct axi_dac *tx_dac;
+	/** Transmit DMA device */
 	struct axi_dmac *tx_dmac;
 };
 

--- a/iio/iio_app/iio_generic_app.c
+++ b/iio/iio_app/iio_generic_app.c
@@ -75,7 +75,7 @@ int32_t iio_generic_app_init(struct iio_generic_app_desc **desc,
 }
 
 /**
- * @biref Release resources.
+ * @brief Release resources.
  * @param desc - Application descriptor.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */

--- a/iio/iio_axi_adc/iio_axi_adc.c
+++ b/iio/iio_axi_adc/iio_axi_adc.c
@@ -58,10 +58,10 @@
 /******************************************************************************/
 
 /**
- * iio_axi_adc_init() - Init and create iio_axi_adc.
- * @iio_axi_adc:	Pointer to iio_axi_adc.
- * @init:		Init parameters.
- * Return: SUCCESS in case of success or negative value otherwise.
+ * @brief Init and create iio_axi_adc.
+ * @param iio_axi_adc - Pointer to iio_axi_adc.
+ * @param init - Init parameters.
+ * @return SUCCESS in case of success or negative value otherwise.
  */
 ssize_t iio_axi_adc_init(struct iio_axi_adc **iio_axi_adc,
 			 struct iio_axi_adc_init_par *init)
@@ -83,9 +83,9 @@ ssize_t iio_axi_adc_init(struct iio_axi_adc **iio_axi_adc,
 }
 
 /**
- * iio_axi_adc_remove() - Free the resources allocated by iio_axi_adc_init().
- * @iio_axi_adc:	Pointer to iio_axi_adc.
- * Return: SUCCESS in case of success or negative value otherwise.
+ * @brief Free the resources allocated by iio_axi_adc_init().
+ * @param iio_axi_adc - Pointer to iio_axi_adc.
+ * @return SUCCESS in case of success or negative value otherwise.
  */
 ssize_t iio_axi_adc_remove(struct iio_axi_adc *iio_axi_adc)
 {
@@ -95,12 +95,12 @@ ssize_t iio_axi_adc_remove(struct iio_axi_adc *iio_axi_adc)
 }
 
 /**
- * get_cf_calibphase().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_cf_calibphase().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_calibphase(void *device, char *buf, size_t len,
 			      const struct iio_ch_info *channel)
@@ -122,12 +122,12 @@ static ssize_t get_calibphase(void *device, char *buf, size_t len,
 }
 
 /**
- * get_cf_calibbias().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_cf_calibbias().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_calibbias(void *device, char *buf, size_t len,
 			     const struct iio_ch_info *channel)
@@ -147,12 +147,12 @@ static ssize_t get_calibbias(void *device, char *buf, size_t len,
 }
 
 /**
- * get_cf_calibscale().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_cf_calibscale().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_calibscale(void *device, char *buf, size_t len,
 			      const struct iio_ch_info *channel)
@@ -178,12 +178,12 @@ static ssize_t get_calibscale(void *device, char *buf, size_t len,
 }
 
 /**
- * get_cf_samples_pps().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_cf_samples_pps().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return: Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_samples_pps(void *device, char *buf, size_t len,
 			       const struct iio_ch_info *channel)
@@ -195,12 +195,12 @@ static ssize_t get_samples_pps(void *device, char *buf, size_t len,
 }
 
 /**
- * get_cf_sampling_frequency().
- * @device:	Physical instance of a iio_axi_adc device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_cf_sampling_frequency().
+ * @param device - Physical instance of a iio_axi_adc device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_sampling_frequency(void *device, char *buf, size_t len,
 				      const struct iio_ch_info *channel)
@@ -216,12 +216,12 @@ static ssize_t get_sampling_frequency(void *device, char *buf, size_t len,
 }
 
 /**
- * set_cf_calibphase().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_cf_calibphase().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_calibphase(void *device, char *buf, size_t len,
 			      const struct iio_ch_info *channel)
@@ -240,12 +240,12 @@ static ssize_t set_calibphase(void *device, char *buf, size_t len,
 }
 
 /**
- * set_cf_calibbias().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_cf_calibbias().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_calibbias(void *device, char *buf, size_t len,
 			     const struct iio_ch_info *channel)
@@ -265,12 +265,12 @@ static ssize_t set_calibbias(void *device, char *buf, size_t len,
 }
 
 /**
- * set_cf_calibscale().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_cf_calibscale().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_calibscale(void *device, char *buf, size_t len,
 			      const struct iio_ch_info *channel)
@@ -288,12 +288,12 @@ static ssize_t set_calibscale(void *device, char *buf, size_t len,
 }
 
 /**
- * set_cf_samples_pps().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_cf_samples_pps().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_samples_pps(void *device, char *buf, size_t len,
 			       const struct iio_ch_info *channel)
@@ -305,12 +305,12 @@ static ssize_t set_samples_pps(void *device, char *buf, size_t len,
 }
 
 /**
- * set_cf_sampling_frequency().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_cf_sampling_frequency().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_sampling_frequency(void *device, char *buf, size_t len,
 				      const struct iio_ch_info *channel)
@@ -322,62 +322,67 @@ static ssize_t set_sampling_frequency(void *device, char *buf, size_t len,
 }
 
 /**
- * struct iio_attr_calibphase - Structure for "calibphase" attribute.
- * @name:	Attribute name.
- * @show:	Read attribute from device.
- * @store:	Write attribute to device.
+ * @struct iio_attr_calibphase
+ * @brief Structure for "calibphase" attribute.
  */
 static struct iio_attribute iio_attr_calibphase = {
+	/** Attribute name */
 	.name = "calibphase",
+	/** Read attribute from device */
 	.show = get_calibphase,
+	/** Write attribute to device */
 	.store = set_calibphase,
 };
 
 /**
- * struct iio_attr_calibbias - Structure for "calibbias" attribute.
- * @name:	Attribute name.
- * @show:	Read attribute from device.
- * @store:	Write attribute to device.
+ * @struct iio_attr_calibbias
+ * @brief Structure for "calibbias" attribute.
  */
 static struct iio_attribute iio_attr_calibbias = {
+	/** Attribute name */
 	.name = "calibbias",
+	/** Read attribute from device */
 	.show = get_calibbias,
+	/** Write attribute to device */
 	.store = set_calibbias,
 };
 
 /**
- * struct iio_attr_calibscale - Structure for "calibscale" attribute.
- * @name:	Attribute name.
- * @show:	Read attribute from device.
- * @store:	Write attribute to device.
+ * @struct iio_attr_calibscale
+ * @brief Structure for "calibscale" attribute.
  */
 static struct iio_attribute iio_attr_calibscale = {
+	/** Attribute name */
 	.name = "calibscale",
+	/** Read attribute from device */
 	.show = get_calibscale,
+	/** Write attribute to device */
 	.store = set_calibscale,
 };
 
 /**
- * struct iio_attr_samples_pps - Structure for "samples_pps" attribute.
- * @name:	Attribute name.
- * @show:	Read attribute from device.
- * @store:	Write attribute to device.
+ * @struct iio_attr_samples_pps
+ * @brief Structure for "samples_pps" attribute.
  */
 static struct iio_attribute iio_attr_samples_pps = {
+	/** Attribute name */
 	.name = "samples_pps",
+	/** Read attribute from device */
 	.show = get_samples_pps,
+	/** Write attribute to device */
 	.store = set_samples_pps,
 };
 
 /**
- * struct iio_attr_sampling_frequency - Structure for "sampling_frequency" attribute.
- * @name:	Attribute name.
- * @show:	Read attribute from device.
- * @store:	Write attribute to device.
+ * @struct iio_attr_sampling_frequency
+ * @brief Structure for "sampling_frequency" attribute.
  */
 static struct iio_attribute iio_attr_sampling_frequency = {
+	/** Attribute name */
 	.name = "sampling_frequency",
+	/** Read attribute from device */
 	.show = get_sampling_frequency,
+	/** Write attribute to device */
 	.store = set_sampling_frequency,
 };
 
@@ -394,10 +399,10 @@ static struct iio_attribute *iio_voltage_attributes[] = {
 };
 
 /**
- * iio_axi_adc_get_xml() - Get xml corresponding to an "axi_adc" device.
- * @xml:	Xml containing description of a device.
- * @iio_dev:	Structure describing a device, channels and attributes.
- * Return: SUCCESS in case of success or negative value otherwise.
+ * @brief Get xml corresponding to an "axi_adc" device.
+ * @param xml - Xml containing description of a device.
+ * @param iio_dev - Structure describing a device, channels and attributes.
+ * @return SUCCESS in case of success or negative value otherwise.
  */
 ssize_t iio_axi_adc_get_xml(char** xml, struct iio_device *iio_dev)
 {
@@ -511,9 +516,9 @@ error:
 }
 
 /**
- * iio_axi_adc_delete_device() - Delete iio_device.
- * @iio_device:	Structure describing a device, channels and attributes.
- * Return: SUCCESS in case of success or negative value otherwise.
+ * @brief Delete iio_device.
+ * @param iio_device - Structure describing a device, channels and attributes.
+ * @return SUCCESS in case of success or negative value otherwise.
  */
 ssize_t iio_axi_adc_delete_device(struct iio_device *iio_device)
 {
@@ -539,11 +544,11 @@ ssize_t iio_axi_adc_delete_device(struct iio_device *iio_device)
 }
 
 /**
- * iio_axi_adc_create_device() - Create structure describing a device, channels
+ * @brief Create structure describing a device, channels
  * and attributes.
- * @device:	Device name.
- * @num_ch:	Number of channels that the device has.
- * Return: iio_device or NULL, in case of failure.
+ * @param device_name - Device name.
+ * @param num_ch - Number of channels that the device has.
+ * @return iio_device or NULL, in case of failure.
  */
 struct iio_device *iio_axi_adc_create_device(const char *device_name,
 		uint16_t num_ch)
@@ -594,11 +599,11 @@ error:
 }
 
 /**
- * iio_axi_adc_transfer_dev_to_mem() - Transfer data from device into RAM.
- * @iio_inst:		Physical instance of a iio_axi_adc device.
- * @bytes_count:	Number of bytes to transfer.
- * @ch_mask:		Opened channels mask.
- * Return: bytes_count or negative value in case of error.
+ * @brief Transfer data from device into RAM.
+ * @param iio_inst - Physical instance of a iio_axi_adc device.
+ * @param bytes_count - Number of bytes to transfer.
+ * @param ch_mask - Opened channels mask.
+ * @return bytes_count or negative value in case of error.
  */
 ssize_t iio_axi_adc_transfer_dev_to_mem(void *iio_inst, size_t bytes_count,
 					uint32_t ch_mask)
@@ -625,17 +630,17 @@ ssize_t iio_axi_adc_transfer_dev_to_mem(void *iio_inst, size_t bytes_count,
 }
 
 /**
- * iio_axi_adc_read_dev() - Read chunk of data from RAM to pbuf.
+ * @brief Read chunk of data from RAM to pbuf.
  * Call "iio_axi_adc_transfer_dev_to_mem" first.
  * This function is probably called multiple times by libtinyiiod after a
  * "iio_axi_adc_transfer_dev_to_mem" call, since we can only read "bytes_count"
  * bytes at a time.
- * @iio_inst:		Physical instance of a iio_axi_adc device.
- * @pbuf:		Buffer where value is stored.
- * @offset:		Offset to the remaining data after reading n chunks.
- * @bytes_count: 	Number of bytes to read.
- * @ch_mask: 		Opened channels mask.
- * Return: bytes_count or negative value in case of error.
+ * @param iio_inst - Physical instance of a iio_axi_adc device.
+ * @param pbuf - Buffer where value is stored.
+ * @param offset - Offset to the remaining data after reading n chunks.
+ * @param bytes_count - Number of bytes to read.
+ * @param ch_mask - Opened channels mask.
+ * @return bytes_count or negative value in case of error.
  */
 ssize_t iio_axi_adc_read_dev(void *iio_inst, char *pbuf, size_t offset,
 			     size_t bytes_count, uint32_t ch_mask)

--- a/iio/iio_axi_dac/iio_axi_dac.c
+++ b/iio/iio_axi_dac/iio_axi_dac.c
@@ -58,10 +58,10 @@
 /******************************************************************************/
 
 /**
- * iio_axi_dac_init() - Init and create iio_axi_dac.
- * @iio_axi_adc:	Pointer to iio_axi_dac.
- * @init:	Init parameters.
- * Return: SUCCESS in case of success or negative value otherwise.
+ * @brief Init and create iio_axi_dac.
+ * @param iio_axi_dac - Pointer to iio_axi_dac.
+ * @param init - Init parameters.
+ * @return SUCCESS in case of success or negative value otherwise.
  */
 ssize_t iio_axi_dac_init(struct iio_axi_dac **iio_axi_dac,
 			 struct iio_axi_dac_init_par *init)
@@ -78,9 +78,9 @@ ssize_t iio_axi_dac_init(struct iio_axi_dac **iio_axi_dac,
 }
 
 /**
- * iio_axi_dac_remove() - Free the resources allocated by iio_axi_dac_init().
- * @iio_axi_dac:	Pointer to iio_axi_adc.
- * Return: SUCCESS in case of success or negative value otherwise.
+ * @brief Free the resources allocated by iio_axi_dac_init().
+ * @param iio_axi_dac - Pointer to iio_axi_adc.
+ * @return SUCCESS in case of success or negative value otherwise.
  */
 ssize_t iio_axi_dac_remove(struct iio_axi_dac *iio_axi_dac)
 {
@@ -90,12 +90,12 @@ ssize_t iio_axi_dac_remove(struct iio_axi_dac *iio_axi_dac)
 }
 
 /**
- * get_dds_calibscale().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Length of chars written in buf, or negative value on failure.
+ * @brief get_dds_calibscale().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_voltage_calibscale(void *device, char *buf, size_t len,
 				      const struct iio_ch_info *channel)
@@ -120,12 +120,12 @@ static ssize_t get_voltage_calibscale(void *device, char *buf, size_t len,
 }
 
 /**
- * get_dds_calibphase().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Number of bytes written in buf, or negative value on failure.
+ * @brief get_dds_calibphase().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Number of bytes written in buf, or negative value on failure.
  */
 static ssize_t get_voltage_calibphase(void *device, char *buf, size_t len,
 				      const struct iio_ch_info *channel)
@@ -144,12 +144,12 @@ static ssize_t get_voltage_calibphase(void *device, char *buf, size_t len,
 }
 
 /**
- * get_dds_sampling_frequency().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Number of bytes written in buf, or negative value on failure.
+ * @brief get_dds_sampling_frequency().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Number of bytes written in buf, or negative value on failure.
  */
 static ssize_t get_voltage_sampling_frequency(void *device, char *buf,
 		size_t len,
@@ -163,11 +163,11 @@ static ssize_t get_voltage_sampling_frequency(void *device, char *buf,
 
 /**
  * get_dds_altvoltage_phase().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Number of bytes written in buf, or negative value on failure.
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Number of bytes written in buf, or negative value on failure.
  */
 static ssize_t get_altvoltage_phase(void *device, char *buf, size_t len,
 				    const struct iio_ch_info *channel)
@@ -182,12 +182,12 @@ static ssize_t get_altvoltage_phase(void *device, char *buf, size_t len,
 }
 
 /**
- * get_dds_altvoltage_scale().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Number of bytes written in buf, or negative value on failure.
+ * @brief get_dds_altvoltage_scale().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Number of bytes written in buf, or negative value on failure.
  */
 static ssize_t get_altvoltage_scale(void *device, char *buf, size_t len,
 				    const struct iio_ch_info *channel)
@@ -203,12 +203,12 @@ static ssize_t get_altvoltage_scale(void *device, char *buf, size_t len,
 }
 
 /**
- * get_dds_altvoltage_frequency().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Number of bytes written in buf, or negative value on failure.
+ * @brief get_dds_altvoltage_frequency().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Number of bytes written in buf, or negative value on failure.
  */
 static ssize_t get_altvoltage_frequency(void *device, char *buf, size_t len,
 					const struct iio_ch_info *channel)
@@ -223,12 +223,12 @@ static ssize_t get_altvoltage_frequency(void *device, char *buf, size_t len,
 }
 
 /**
- * get_dds_altvoltage_raw().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Number of bytes written in buf, or negative value on failure.
+ * @brief get_dds_altvoltage_raw().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Number of bytes written in buf, or negative value on failure.
  */
 static ssize_t get_altvoltage_raw(void *device, char *buf, size_t len,
 				  const struct iio_ch_info *channel)
@@ -240,12 +240,12 @@ static ssize_t get_altvoltage_raw(void *device, char *buf, size_t len,
 }
 
 /**
- * get_dds_altvoltage_sampling_frequency().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Where value is stored.
- * @len:	Maximum length of value to be stored in buf.
- * @channel:	Channel properties.
- * Return: Number of bytes written in buf, or negative value on failure.
+ * @brief get_dds_altvoltage_sampling_frequency().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Where value is stored.
+ * @param len - Maximum length of value to be stored in buf.
+ * @param channel - Channel properties.
+ * @return Number of bytes written in buf, or negative value on failure.
  */
 static ssize_t get_altvoltage_sampling_frequency(void *device, char *buf,
 		size_t len,
@@ -258,12 +258,12 @@ static ssize_t get_altvoltage_sampling_frequency(void *device, char *buf,
 }
 
 /**
- * set_dds_calibscale().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written in buf, or negative value on failure.
+ * @brief set_dds_calibscale().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written in buf, or negative value on failure.
  */
 static ssize_t set_voltage_calibscale(void *device, char *buf, size_t len,
 				      const struct iio_ch_info *channel)
@@ -281,12 +281,12 @@ static ssize_t set_voltage_calibscale(void *device, char *buf, size_t len,
 }
 
 /**
- * set_dds_calibphase().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_dds_calibphase().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_voltage_calibphase(void *device, char *buf, size_t len,
 				      const struct iio_ch_info *channel)
@@ -304,12 +304,12 @@ static ssize_t set_voltage_calibphase(void *device, char *buf, size_t len,
 }
 
 /**
- * set_dds_sampling_frequency().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_dds_sampling_frequency().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return: Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_voltage_sampling_frequency(void *device, char *buf,
 		size_t len,
@@ -322,12 +322,12 @@ static ssize_t set_voltage_sampling_frequency(void *device, char *buf,
 }
 
 /**
- * set_dds_altvoltage_phase().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_dds_altvoltage_phase().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_altvoltage_phase(void *device, char *buf, size_t len,
 				    const struct iio_ch_info *channel)
@@ -342,12 +342,12 @@ static ssize_t set_altvoltage_phase(void *device, char *buf, size_t len,
 }
 
 /**
- * set_dds_altvoltage_scale().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_dds_altvoltage_scale().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_altvoltage_scale(void *device, char *buf, size_t len,
 				    const struct iio_ch_info *channel)
@@ -363,12 +363,12 @@ static ssize_t set_altvoltage_scale(void *device, char *buf, size_t len,
 }
 
 /**
- * set_dds_altvoltage_frequency().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_dds_altvoltage_frequency().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_altvoltage_frequency(void *device, char *buf, size_t len,
 					const struct iio_ch_info *channel)
@@ -383,12 +383,12 @@ static ssize_t set_altvoltage_frequency(void *device, char *buf, size_t len,
 }
 
 /**
- * set_dds_altvoltage_raw().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_dds_altvoltage_raw().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return: Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_altvoltage_raw(void *device, char *buf, size_t len,
 				  const struct iio_ch_info *channel)
@@ -405,12 +405,12 @@ static ssize_t set_altvoltage_raw(void *device, char *buf, size_t len,
 }
 
 /**
- * set_dds_altvoltage_sampling_frequency().
- * @device:	Physical instance of a iio_axi_dac device.
- * @buf:	Value to be written to attribute.
- * @len:	Length of the data in "buf".
- * @channel:	Channel properties.
- * Return: Number of bytes written to device, or negative value on failure.
+ * @brief set_dds_altvoltage_sampling_frequency().
+ * @param device - Physical instance of a iio_axi_dac device.
+ * @param buf - Value to be written to attribute.
+ * @param len - Length of the data in "buf".
+ * @param channel - Channel properties.
+ * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_altvoltage_sampling_frequency(void *device, char *buf,
 		size_t len,
@@ -423,101 +423,107 @@ static ssize_t set_altvoltage_sampling_frequency(void *device, char *buf,
 }
 
 /**
- * struct iio_attr_voltage_calibphase - Structure for "calibphase" attribute.
- * @name:	Attribute name.
- * @show:	Read attribute from device.
- * @store:	Write attribute to device.
+ * @struct iio_attr_voltage_calibphase
+ * @brief Structure for "calibphase" attribute.
  */
 static struct iio_attribute iio_attr_voltage_calibphase = {
+	/** Attribute name */
 	.name = "calibphase",
+	/** Read attribute from device */
 	.show = get_voltage_calibphase,
+	/** Write attribute to device */
 	.store = set_voltage_calibphase,
 };
 
 /**
- * struct iio_attr_voltage_calibscale - Structure for "calibscale" attribute.
- * @name:	Attribute name.
- * @show:	Read attribute from device.
- * @store:	Write attribute to device.
+ * @struct iio_attr_voltage_calibscale
+ * @brief Structure for "calibscale" attribute.
  */
 static struct iio_attribute iio_attr_voltage_calibscale = {
+	/** Attribute name */
 	.name = "calibscale",
+	/** Read attribute from device */
 	.show = get_voltage_calibscale,
+	/** Write attribute to device */
 	.store = set_voltage_calibscale,
+
 };
 
 /**
- * struct iio_attr_voltage_sampling_frequency - Structure for
- * "sampling_frequency".
- * attribute.
- * @name:	Attribute name.
- * @show:	Read attribute from device.
- * @store:	Write attribute to device.
+ * @struct iio_attr_voltage_sampling_frequency
+ * @brief Structure for "sampling_frequency" attribute.
  */
 static struct iio_attribute iio_attr_voltage_sampling_frequency = {
+	/** Attribute name */
 	.name = "sampling_frequency",
+	/** Read attribute from device */
 	.show = get_voltage_sampling_frequency,
+	/** Write attribute to device */
 	.store = set_voltage_sampling_frequency,
 };
 
 /**
- * struct iio_attr_altvoltage_raw - Structure for "raw" attribute.
- * @name:	Attribute name.
- * @show:	Read attribute from device.
- * @store:	Write attribute to device.
+ * @struct iio_attr_altvoltage_raw
+ * @brief Structure for "raw" attribute.
  */
 static struct iio_attribute iio_attr_altvoltage_raw = {
+	/** Attribute name */
 	.name = "raw",
+	/** Read attribute from device */
 	.show = get_altvoltage_raw,
+	/** Write attribute to device */
 	.store = set_altvoltage_raw,
 };
 
 /**
- * struct iio_attr_altvoltage_phase - Structure for "phase" attribute.
- * @name:	Attribute name.
- * @show:	Read attribute from device.
- * @store:	Write attribute to device.
+ * @struct iio_attr_altvoltage_phase
+ * @brief Structure for "phase" attribute.
  */
 static struct iio_attribute iio_attr_altvoltage_phase = {
+	/** Attribute name */
 	.name = "phase",
+	/** Read attribute from device */
 	.show = get_altvoltage_phase,
+	/** Write attribute to device */
 	.store = set_altvoltage_phase,
 };
 
 /**
- * struct iio_attr_altvoltage_frequency - Structure for "frequency" attribute.
- * @name:	Attribute name.
- * @show:	Read attribute from device.
- * @store:	Write attribute to device.
+ * @struct iio_attr_altvoltage_frequency
+ * @brief Structure for "frequency" attribute.
  */
 static struct iio_attribute iio_attr_altvoltage_frequency = {
+	/** Attribute name */
 	.name = "frequency",
+	/** Read attribute from device */
 	.show = get_altvoltage_frequency,
+	/** Write attribute to device */
 	.store = set_altvoltage_frequency,
 };
 
 /**
- * struct iio_attr_altvoltage_scale - Structure for "scale" attribute.
- * @name:	Attribute name.
- * @show:	Read attribute from device.
- * @store:	Write attribute to device.
+ * @struct iio_attr_altvoltage_scale
+ * @brief Structure for "scale" attribute.
  */
 static struct iio_attribute iio_attr_altvoltage_scale = {
+	/** Attribute name */
 	.name = "scale",
+	/** Read attribute from device */
 	.show = get_altvoltage_scale,
+	/** Write attribute to device */
 	.store = set_altvoltage_scale,
 };
 
 /**
- * struct iio_attr_altvoltage_sampling_frequency - Structure for
- * "sampling_frequency" attribute.
- * @name:	Attribute name.
- * @show:	Read attribute from device.
- * @store:	Write attribute to device.
+ * @struct iio_attr_altvoltage_sampling_frequency
+ * @brief Structure for "sampling_frequency" attribute.
  */
 static struct iio_attribute iio_attr_altvoltage_sampling_frequency = {
+	/** Attribute name */
 	.name = "sampling_frequency",
+	/** Read attribute from device */
 	.show = get_altvoltage_sampling_frequency,
+	/** Write attribute to device */
 	.store = set_altvoltage_sampling_frequency,
 };
 
@@ -544,11 +550,11 @@ static struct iio_attribute *iio_altvoltage_attributes[] = {
 };
 
 /**
- * iio_axi_dac_transfer_mem_to_dev() - Transfer data from RAM to device.
- * @iio_inst:		Physical instance of a iio_axi_dac device.
- * @bytes_count:	Number of bytes to transfer.
- * @ch_mask:		Opened channels mask.
- * Return: Number of bytes transfered, or negative value in case of failure.
+ * @brief Transfer data from RAM to device.
+ * @param iio_inst - Physical instance of a iio_axi_dac device.
+ * @param bytes_count - Number of bytes to transfer.
+ * @param ch_mask - Opened channels mask.
+ * @return Number of bytes transfered, or negative value in case of failure.
  */
 ssize_t iio_axi_dac_transfer_mem_to_dev(void *iio_inst, size_t bytes_count,
 					uint32_t ch_mask)
@@ -569,16 +575,16 @@ ssize_t iio_axi_dac_transfer_mem_to_dev(void *iio_inst, size_t bytes_count,
 }
 
 /**
- * iio_axi_dac_write_dev() - Write chunk of data into RAM.
+ * @brief Write chunk of data into RAM.
  * This function is probably called multiple times by libtinyiiod before a
  * "iio_transfer_mem_to_dev" call, since we can only write "bytes_count" bytes
  * at a time.
- * @iio_inst:	Physical instance of a iio_axi_dac device.
- * @buf:	Values to write.
- * @offset:	Offset in memory after the nth chunk of data.
- * @bytes_count:	Number of bytes to write.
- * @ch_mask:	Opened channels mask.
- * Return: bytes_count or negative value in case of error.
+ * @param iio_inst - Physical instance of a iio_axi_dac device.
+ * @param buf - Values to write.
+ * @param offset - Offset in memory after the nth chunk of data.
+ * @param bytes_count - Number of bytes to write.
+ * @param ch_mask - Opened channels mask.
+ * @return bytes_count or negative value in case of error.
  */
 ssize_t iio_axi_dac_write_dev(void *iio_inst, char *buf,
 			      size_t offset,  size_t bytes_count, uint32_t ch_mask)
@@ -608,11 +614,11 @@ enum ch_type {
 };
 
 /**
- * iio_axi_dac_channel_xml() - Fill device with channels.
- * @device:	Node to populate with channels.
- * @ch_no:	Number of channels to be added to "device" element.
- * @ch_t:	Channel type.
- * Return: SUCCESS in case of success or negative value otherwise.
+ * @brief Fill device with channels.
+ * @param device - Node to populate with channels.
+ * @param ch_no - Number of channels to be added to "device" element.
+ * @param ch_t - Channel type.
+ * @return SUCCESS in case of success or negative value otherwise.
  */
 static ssize_t iio_axi_dac_channel_xml(struct xml_node *device, uint8_t ch_no,
 				       enum ch_type ch_t)
@@ -716,10 +722,10 @@ static ssize_t iio_axi_dac_channel_xml(struct xml_node *device, uint8_t ch_no,
 }
 
 /**
- * iio_axi_dac_get_xml() - Get an axi_dac xml.
- * @xml:	Xml containing description of a device.
- * @iio_dev:	Structure describing a device, channels and attributes.
- * Return: SUCCESS in case of success or negative value otherwise.
+ * @brief Get an axi_dac xml.
+ * @param xml - Xml containing description of a device.
+ * @param iio_dev - Structure describing a device, channels and attributes.
+ * @return SUCCESS in case of success or negative value otherwise.
  */
 ssize_t iio_axi_dac_get_xml(char** xml, struct iio_device *iio_dev)
 {
@@ -765,9 +771,9 @@ error:
 }
 
 /**
- * iio_axi_dac_delete_device() - Delete iio_device.
- * @iio_device:	Structure describing a device, channels and attributes.
- * Return: SUCCESS in case of success or negative value otherwise.
+ * @brief Delete iio_device.
+ * @param iio_device - Structure describing a device, channels and attributes.
+ * @return SUCCESS in case of success or negative value otherwise.
  */
 ssize_t iio_axi_dac_delete_device(struct iio_device *iio_device)
 {
@@ -793,10 +799,10 @@ ssize_t iio_axi_dac_delete_device(struct iio_device *iio_device)
 }
 
 /**
- * iio_axi_dac_create_device() - Create structure describing a device, channels and attributes.
- * @device:	Device name.
- * @num_ch:	Number of channels that the device has.
- * Return: iio_device or NULL, in case of failure.
+ * @brief Create structure describing a device, channels and attributes.
+ * @param device_name - Device name.
+ * @param num_ch - Number of channels that the device has.
+ * @return iio_device or NULL, in case of failure.
  */
 struct iio_device *iio_axi_dac_create_device(const char *device_name,
 		uint16_t num_ch)

--- a/iio/iio_axi_dac/iio_axi_dac.h
+++ b/iio/iio_axi_dac/iio_axi_dac.h
@@ -52,32 +52,32 @@
 /******************************************************************************/
 
 /**
- * struct iio_axi_dac_init_par - Initialization parameters for "iio_axi_dac".
- * @dac:		Pointer to "axi_dac" instance.
- * @dac:		Pointer to "axi_dmac" instance.
- * @dac_ddr_base:	Address used by DMA, for sending data to device.
- * @dcache_flush_range:	Function pointer to flush the data cache for the given
- * 			address range.
+ * @struct iio_axi_dac_init_par
+ * @brief Initialization parameters for "iio_axi_dac".
  */
 struct iio_axi_dac_init_par {
+	/** Pointer to "axi_dac" instance */
 	struct axi_dac *dac;
+	/** Pointer to "axi_dmac" instance */
 	struct axi_dmac *dmac;
+	/** Address used by DMA, for sending data to device */
 	uint32_t dac_ddr_base;
+	/** Function pointer to flush the data cache for the given address range */
 	void (*dcache_flush_range)(uint32_t address, uint32_t bytes_count);
 };
 
 /**
- * struct iio_axi_dac - Structure with references to DAC and DMA cores.
- * @dac:		Pointer to "axi_dac" instance.
- * @dac:		Pointer to "axi_dmac" instance.
- * @dac_ddr_base:	Address used by DMA, for sending data to device.
- * @dcache_flush_range:	Function pointer to flush the data cache for the given
- * 			address range.
+ * @struct iio_axi_dac
+ * @brief Structure with references to DAC and DMA cores.
  */
 struct iio_axi_dac {
+	/** Pointer to "axi_dac" instance */
 	struct axi_dac *dac;
+	/** Pointer to "axi_dmac" instance. */
 	struct axi_dmac *dmac;
+	/** Address used by DMA, for sending data to device */
 	uint32_t dac_ddr_base;
+	/** Function pointer to flush the data cache for the given address range */
 	void (*dcache_flush_range)(uint32_t address, uint32_t bytes_count);
 };
 

--- a/iio/iio_types.h
+++ b/iio/iio_types.h
@@ -77,36 +77,40 @@ struct iio_device {
 };
 
 /**
- * struct iio_interface_init_par - iio interface init par.
- * @dev_name: device name.
- * @num_ch: number of channels.
- * @dev_instance: physical instance of a device.
- * @iio_device: device descriptor(describes channels and attributes)
- * @get_xml: Generate device xml.
- * @transfer_dev_to_mem: transfer data from ADC into RAM.
- * @read_data: Read data from RAM to pbuf. It should be called after "transfer_dev_to_mem".
- * @transfer_mem_to_dev: Transfer data from RAM to DAC.
- * @write_data: Write data to RAM. It should be called before "transfer_mem_to_dev".
+ * @struct iio_interface_init_par
+ * @brief iio interface init parameters
  */
 struct iio_interface_init_par {
+	/** device name */
 	const char *dev_name;
+	/**  physical instance of a device */
 	void *dev_instance;
+	/** device descriptor(describes channels and attributes) */
 	struct iio_device *iio_device;
+	/** Generate device xml */
 	ssize_t (*get_xml)(char** xml, struct iio_device *iio_dev);
+	/** transfer data from ADC into RAM */
 	ssize_t (*transfer_dev_to_mem)(void *dev_instance, size_t bytes_count,
 				       uint32_t ch_mask);
+	/** Read data from RAM to pbuf. It should be called after "transfer_dev_to_mem" */
 	ssize_t (*read_data)(void *dev_instance, char *pbuf, size_t offset,
 			     size_t bytes_count, uint32_t ch_mask);
+	/** Transfer data from RAM to DAC */
 	ssize_t (*transfer_mem_to_dev)(void *dev_instance, size_t bytes_count,
 				       uint32_t ch_mask);
+	/** Write data to RAM. It should be called before "transfer_mem_to_dev" */
 	ssize_t (*write_data)(void *dev_instance, char *pbuf, size_t offset,
 			      size_t bytes_count, uint32_t ch_mask);
 };
 
+/**
+ * @struct iio_server_ops
+ * @brief iio interface for server read/write operations
+ */
 struct iio_server_ops {
-	/* Read from from a peripheral device (UART, USB, NETWORK) */
+	/** Read from from a peripheral device (UART, USB, NETWORK) */
 	ssize_t (*read)(char *buf, size_t len);
-	/* Write to a peripheral device (UART, USB, NETWORK) */
+	/** Write to a peripheral device (UART, USB, NETWORK) */
 	ssize_t (*write)(const char *buf, size_t len);
 };
 


### PR DESCRIPTION
Include iio application and interfaces to the Doxygen build.
Adapt current code documentation to the required format.

**NOTE**: This patch is required due to future IIO implementations that should comply the current doc format. 

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>