### PR TITLE
Adrv9009 iio make

### DIFF
--- a/projects/adrv9009/Makefile
+++ b/projects/adrv9009/Makefile
@@ -1,5 +1,5 @@
 TARGET := adrv9009
-TINYIIOD = y
+TINYIIOD = n
 ifeq ($(OS), Windows_NT)
 include ../../tools/scripts/windows.mk
 else

--- a/projects/adrv9009/src.mk
+++ b/projects/adrv9009/src.mk
@@ -39,7 +39,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c			\
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c
-ifdef TINYIIOD
+ifeq (y,$(strip $(TINYIIOD)))
 SRCS += $(NO-OS)/util/xml.c						\
 	$(NO-OS)/util/fifo.c						\
 	$(NO-OS)/iio/iio.c						\
@@ -47,7 +47,9 @@ SRCS += $(NO-OS)/util/xml.c						\
 	$(NO-OS)/iio/iio_axi_dac/iio_axi_dac.c				\
 	$(NO-OS)/iio/iio_app/iio_app.c					\
 	$(NO-OS)/iio/iio_app/iio_axi_adc_app.c				\
-	$(NO-OS)/iio/iio_app/iio_axi_dac_app.c
+	$(NO-OS)/iio/iio_app/iio_axi_dac_app.c                          \
+	$(PLATFORM_DRIVERS)/uart.c					\
+	$(PLATFORM_DRIVERS)/irq.c
 endif
 SRCS +=	$(NO-OS)/util/util.c
 ifeq (xilinx,$(strip $(PLATFORM)))
@@ -63,9 +65,7 @@ endif
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
 	$(PLATFORM_DRIVERS)/spi.c					\
 	$(PLATFORM_DRIVERS)/gpio.c					\
-	$(PLATFORM_DRIVERS)/delay.c					\
-	$(PLATFORM_DRIVERS)/uart.c					\
-	$(PLATFORM_DRIVERS)/irq.c
+	$(PLATFORM_DRIVERS)/delay.c
 INCS :=	$(PROJECT)/src/app/app_config.h					\
 	$(PROJECT)/src/app/app_clocking.h						\
 	$(PROJECT)/src/app/app_jesd.h						\
@@ -119,20 +119,20 @@ INCS += $(DRIVERS)/axi_core/clk_altera_a10_fpll/clk_altera_a10_fpll.h	\
 	$(DRIVERS)/axi_core/jesd204/altera_adxcvr.h
 endif
 INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\
-	$(PLATFORM_DRIVERS)/gpio_extra.h				\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
-	$(PLATFORM_DRIVERS)/uart_extra.h
+	$(PLATFORM_DRIVERS)/gpio_extra.h
 INCS +=	$(INCLUDE)/axi_io.h						\
 	$(INCLUDE)/spi.h						\
 	$(INCLUDE)/gpio.h						\
 	$(INCLUDE)/error.h						\
 	$(INCLUDE)/delay.h						\
+	$(INCLUDE)/util.h
+ifeq (y,$(strip $(TINYIIOD)))
+INCS +=	$(INCLUDE)/xml.h						\
 	$(INCLUDE)/fifo.h						\
 	$(INCLUDE)/irq.h						\
-	$(INCLUDE)/uart.h
-ifdef TINYIIOD
-INCS +=	$(INCLUDE)/xml.h						\
-	$(INCLUDE)/util.h						\
+	$(INCLUDE)/uart.h						\
+	$(PLATFORM_DRIVERS)/irq_extra.h					\
+	$(PLATFORM_DRIVERS)/uart_extra.h                                \
 	$(NO-OS)/iio/iio.h						\
 	$(NO-OS)/iio/iio_types.h					\
 	$(NO-OS)/iio/iio_axi_adc/iio_axi_adc.h				\


### PR DESCRIPTION
adrv9009 src.mk: Fix TINYIIOD build option.

Build was failing with: "TINYIIOD = n".

Signed-off-by: Cristian Pop <cristian.pop@analog.com>