### PR TITLE
ad9371: Add iio support in build process.

### DIFF
--- a/projects/ad9371/Makefile
+++ b/projects/ad9371/Makefile
@@ -1,4 +1,5 @@
 TARGET := ad9371
+TINYIIOD = n
 ifeq ($(OS), Windows_NT)
 include ../../tools/scripts/windows.mk
 else

--- a/projects/ad9371/src.mk
+++ b/projects/ad9371/src.mk
@@ -45,6 +45,18 @@ SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
 	$(PLATFORM_DRIVERS)/spi.c					\
 	$(PLATFORM_DRIVERS)/gpio.c					\
 	$(PLATFORM_DRIVERS)/delay.c
+ifeq (y,$(strip $(TINYIIOD)))
+SRCS += $(PLATFORM_DRIVERS)/uart.c					\
+	$(PLATFORM_DRIVERS)/irq.c					\
+	$(NO-OS)/util/xml.c						\
+	$(NO-OS)/util/fifo.c						\
+	$(NO-OS)/iio/iio.c						\
+	$(NO-OS)/iio/iio_axi_adc/iio_axi_adc.c				\
+	$(NO-OS)/iio/iio_axi_dac/iio_axi_dac.c				\
+	$(NO-OS)/iio/iio_app/iio_app.c					\
+	$(NO-OS)/iio/iio_app/iio_axi_adc_app.c				\
+	$(NO-OS)/iio/iio_app/iio_axi_dac_app.c
+endif
 INCS :=	$(PROJECT)/src/app/app_config.h					\
 	$(PROJECT)/src/devices/ad9528/ad9528.h				\
 	$(PROJECT)/src/devices/ad9528/t_ad9528.h			\
@@ -83,3 +95,20 @@ INCS +=	$(INCLUDE)/axi_io.h						\
 	$(INCLUDE)/error.h						\
 	$(INCLUDE)/delay.h						\
 	$(INCLUDE)/util.h
+ifeq (y,$(strip $(TINYIIOD)))
+INCS += $(INCLUDE)/xml.h						\
+	$(INCLUDE)/fifo.h						\
+	$(INCLUDE)/irq.h						\
+	$(INCLUDE)/uart.h						\
+	$(PLATFORM_DRIVERS)/irq_extra.h					\
+	$(PLATFORM_DRIVERS)/uart_extra.h				\
+	$(NO-OS)/iio/iio.h						\
+	$(NO-OS)/iio/iio_types.h					\
+	$(NO-OS)/iio/iio_axi_adc/iio_axi_adc.h				\
+	$(NO-OS)/iio/iio_axi_dac/iio_axi_dac.h				\
+	$(NO-OS)/iio/iio_app/iio_app.h					\
+	$(NO-OS)/iio/iio_app/iio_axi_adc_app.h				\
+	$(NO-OS)/iio/iio_app/iio_axi_dac_app.h				\
+	$(NO-OS)/libraries/libtinyiiod/tinyiiod.h			\
+	$(NO-OS)/libraries/libtinyiiod/compat.h
+endif


### PR DESCRIPTION
This will allow to build IIO_EXAMPLE from application.

Signed-off-by: Cristian Pop <cristian.pop@analog.com>