### PR TITLE
Remove unneeded i2c_transfer_mode enum from i2c.h

### DIFF
--- a/drivers/platform/aducm3029/i2c.c
+++ b/drivers/platform/aducm3029/i2c.c
@@ -172,7 +172,7 @@ int32_t i2c_remove(struct i2c_desc *desc)
  * @param desc - Descriptor of the I2C device
  * @param data - Buffer that stores the transmission data.
  * @param bytes_number - Number of bytes to write.
- * @param option - Stop condition control.
+ * @param stop_bit - Stop condition control.
  *                   Example: 0 - A stop condition will not be generated;
  *                            1 - A stop condition will be generated.
  * @return \ref SUCCESS in case of success, \ref FAILURE otherwise.
@@ -180,7 +180,7 @@ int32_t i2c_remove(struct i2c_desc *desc)
 int32_t i2c_write(struct i2c_desc *desc,
 		  uint8_t *data,
 		  uint8_t bytes_number,
-		  uint8_t option)
+		  uint8_t stop_bit)
 {
 	if (!desc)
 		return FAILURE;
@@ -198,7 +198,7 @@ int32_t i2c_write(struct i2c_desc *desc,
 		return SUCCESS;
 	}
 
-	trans->bRepeatStart = (option == 1) ? 0 : 1;
+	trans->bRepeatStart = (stop_bit == 1) ? 0 : 1;
 	trans->pPrologue = 0;
 	trans->nPrologueSize = 0;
 	trans->pData = data;
@@ -215,7 +215,7 @@ int32_t i2c_write(struct i2c_desc *desc,
  * @param desc - Descriptor of the I2C device
  * @param data - Buffer that stores the transmission data.
  * @param bytes_number - Number of bytes to write.
- * @param option - Stop condition control.
+ * @param stop_bit - Stop condition control.
  *                   Example: 0 - A stop condition will not be generated.
  *                            1 - A stop condition will be generated
  * @return \ref SUCCESS in case of success, \ref FAILURE otherwise.
@@ -223,7 +223,7 @@ int32_t i2c_write(struct i2c_desc *desc,
 int32_t i2c_read(struct i2c_desc *desc,
 		 uint8_t *data,
 		 uint8_t bytes_number,
-		 uint8_t option)
+		 uint8_t stop_bit)
 {
 	if (!desc)
 		return FAILURE;
@@ -234,7 +234,7 @@ int32_t i2c_read(struct i2c_desc *desc,
 	if (SUCCESS != set_transmission_configuration(desc))
 		return FAILURE;
 
-	trans->bRepeatStart = (option == 1) ? 0 : 1;
+	trans->bRepeatStart = (stop_bit == 1) ? 0 : 1;
 	trans->pPrologue = 0;
 	trans->nPrologueSize = 0;
 	trans->pData = data;

--- a/drivers/platform/altera/i2c.c
+++ b/drivers/platform/altera/i2c.c
@@ -89,7 +89,7 @@ int32_t i2c_remove(struct i2c_desc *desc)
  * @param desc - The I2C descriptor.
  * @param data - Buffer that stores the transmission data.
  * @param bytes_number - Number of bytes to write.
- * @param option - Stop condition control.
+ * @param stop_bit - Stop condition control.
  *                   Example: 0 - A stop condition will not be generated;
  *                            1 - A stop condition will be generated.
  * @return SUCCESS in case of success, FAILURE otherwise.
@@ -97,7 +97,7 @@ int32_t i2c_remove(struct i2c_desc *desc)
 int32_t i2c_write(struct i2c_desc *desc,
 		  uint8_t *data,
 		  uint8_t bytes_number,
-		  uint8_t option)
+		  uint8_t stop_bit)
 {
 	if (desc) {
 		// Unused variable - fix compiler warning
@@ -111,7 +111,7 @@ int32_t i2c_write(struct i2c_desc *desc,
 		// Unused variable - fix compiler warning
 	}
 
-	if (option) {
+	if (stop_bit) {
 		// Unused variable - fix compiler warning
 	}
 
@@ -123,7 +123,7 @@ int32_t i2c_write(struct i2c_desc *desc,
  * @param desc - The I2C descriptor.
  * @param data - Buffer that will store the received data.
  * @param bytes_number - Number of bytes to read.
- * @param option - Stop condition control.
+ * @param stop_bit - Stop condition control.
  *                   Example: 0 - A stop condition will not be generated;
  *                            1 - A stop condition will be generated.
  * @return SUCCESS in case of success, FAILURE otherwise.
@@ -131,7 +131,7 @@ int32_t i2c_write(struct i2c_desc *desc,
 int32_t i2c_read(struct i2c_desc *desc,
 		 uint8_t *data,
 		 uint8_t bytes_number,
-		 uint8_t option)
+		 uint8_t stop_bit)
 {
 	if (desc) {
 		// Unused variable - fix compiler warning
@@ -145,7 +145,7 @@ int32_t i2c_read(struct i2c_desc *desc,
 		// Unused variable - fix compiler warning
 	}
 
-	if (option) {
+	if (stop_bit) {
 		// Unused variable - fix compiler warning
 	}
 

--- a/drivers/platform/generic/i2c.c
+++ b/drivers/platform/generic/i2c.c
@@ -86,7 +86,7 @@ int32_t i2c_remove(struct i2c_desc *desc)
  * @param desc - The I2C descriptor.
  * @param data - Buffer that stores the transmission data.
  * @param bytes_number - Number of bytes to write.
- * @param option - Stop condition control.
+ * @param stop_bit - Stop condition control.
  *                   Example: 0 - A stop condition will not be generated;
  *                            1 - A stop condition will be generated.
  * @return SUCCESS in case of success, FAILURE otherwise.
@@ -94,7 +94,7 @@ int32_t i2c_remove(struct i2c_desc *desc)
 int32_t i2c_write(struct i2c_desc *desc,
 		  uint8_t *data,
 		  uint8_t bytes_number,
-		  uint8_t option)
+		  uint8_t stop_bit)
 {
 	if (desc) {
 		// Unused variable - fix compiler warning
@@ -108,7 +108,7 @@ int32_t i2c_write(struct i2c_desc *desc,
 		// Unused variable - fix compiler warning
 	}
 
-	if (option) {
+	if (stop_bit) {
 		// Unused variable - fix compiler warning
 	}
 
@@ -120,7 +120,7 @@ int32_t i2c_write(struct i2c_desc *desc,
  * @param desc - The I2C descriptor.
  * @param data - Buffer that will store the received data.
  * @param bytes_number - Number of bytes to read.
- * @param option - Stop condition control.
+ * @param stop_bit - Stop condition control.
  *                   Example: 0 - A stop condition will not be generated;
  *                            1 - A stop condition will be generated.
  * @return SUCCESS in case of success, FAILURE otherwise.
@@ -128,7 +128,7 @@ int32_t i2c_write(struct i2c_desc *desc,
 int32_t i2c_read(struct i2c_desc *desc,
 		 uint8_t *data,
 		 uint8_t bytes_number,
-		 uint8_t option)
+		 uint8_t stop_bit)
 {
 	if (desc) {
 		// Unused variable - fix compiler warning
@@ -142,7 +142,7 @@ int32_t i2c_read(struct i2c_desc *desc,
 		// Unused variable - fix compiler warning
 	}
 
-	if (option) {
+	if (stop_bit) {
 		// Unused variable - fix compiler warning
 	}
 

--- a/drivers/platform/linux/platform_drivers.c
+++ b/drivers/platform/linux/platform_drivers.c
@@ -108,7 +108,7 @@ int32_t i2c_remove(i2c_desc *desc)
  * @param desc - The I2C descriptor.
  * @param data - Buffer that stores the transmission data.
  * @param bytes_number - Number of bytes to write.
- * @param option - Stop condition control.
+ * @param stop_bit - Stop condition control.
  *                   Example: 0 - A stop condition will not be generated;
  *                            1 - A stop condition will be generated.
  * @return SUCCESS in case of success, FAILURE otherwise.
@@ -116,7 +116,7 @@ int32_t i2c_remove(i2c_desc *desc)
 int32_t i2c_write(i2c_desc *desc,
 		  uint8_t *data,
 		  uint8_t bytes_number,
-		  uint8_t option)
+		  uint8_t stop_bit)
 {
 	int ret;
 
@@ -132,7 +132,7 @@ int32_t i2c_write(i2c_desc *desc,
 		return FAILURE;
 	}
 
-	if (option) {
+	if (stop_bit) {
 		// Unused variable - fix compiler warning
 	}
 
@@ -144,7 +144,7 @@ int32_t i2c_write(i2c_desc *desc,
  * @param desc - The I2C descriptor.
  * @param data - Buffer that will store the received data.
  * @param bytes_number - Number of bytes to read.
- * @param option - Stop condition control.
+ * @param stop_bit - Stop condition control.
  *                   Example: 0 - A stop condition will not be generated;
  *                            1 - A stop condition will be generated.
  * @return SUCCESS in case of success, FAILURE otherwise.
@@ -152,7 +152,7 @@ int32_t i2c_write(i2c_desc *desc,
 int32_t i2c_read(i2c_desc *desc,
 		 uint8_t *data,
 		 uint8_t bytes_number,
-		 uint8_t option)
+		 uint8_t stop_bit)
 {
 	int ret;
 
@@ -168,7 +168,7 @@ int32_t i2c_read(i2c_desc *desc,
 		return FAILURE;
 	}
 
-	if (option) {
+	if (stop_bit) {
 		// Unused variable - fix compiler warning
 	}
 

--- a/drivers/platform/xilinx/i2c.c
+++ b/drivers/platform/xilinx/i2c.c
@@ -213,7 +213,7 @@ error:
  * @param desc - The I2C descriptor.
  * @param data - Buffer that stores the transmission data.
  * @param bytes_number - Number of bytes to write.
- * @param option - Stop condition control.
+ * @param stop_bit - Stop condition control.
  *                   Example: 0 - A stop condition will not be generated;
  *                            1 - A stop condition will be generated.
  * @return SUCCESS in case of success, FAILURE otherwise.
@@ -221,7 +221,7 @@ error:
 int32_t i2c_write(struct i2c_desc *desc,
 		  uint8_t *data,
 		  uint8_t bytes_number,
-		  uint8_t option)
+		  uint8_t stop_bit)
 {
 	xil_i2c_desc	*xdesc;
 	int32_t		ret;
@@ -235,7 +235,7 @@ int32_t i2c_write(struct i2c_desc *desc,
 			  desc->slave_address,
 			  data,
 			  bytes_number,
-			  option ? XIIC_REPEATED_START : XIIC_STOP);
+			  stop_bit ? XIIC_STOP : XIIC_REPEATED_START);
 		break;
 #endif
 		goto error;
@@ -243,7 +243,7 @@ int32_t i2c_write(struct i2c_desc *desc,
 #ifdef XIICPS_H
 
 		ret = XIicPs_SetOptions(xdesc->instance,
-					option);
+					stop_bit ? 0 : XIIC_REPEATED_START);
 		if(ret != SUCCESS)
 			goto error;
 
@@ -272,7 +272,7 @@ error:
  * @param desc - The I2C descriptor.
  * @param data - Buffer that will store the received data.
  * @param bytes_number - Number of bytes to read.
- * @param option - Stop condition control.
+ * @param stop_bit - Stop condition control.
  *                   Example: 0 - A stop condition will not be generated;
  *                            1 - A stop condition will be generated.
  * @return SUCCESS in case of success, FAILURE otherwise.
@@ -280,7 +280,7 @@ error:
 int32_t i2c_read(struct i2c_desc *desc,
 		 uint8_t *data,
 		 uint8_t bytes_number,
-		 uint8_t option)
+		 uint8_t stop_bit)
 {
 	xil_i2c_desc	*xdesc;
 	int32_t		ret;
@@ -294,7 +294,7 @@ int32_t i2c_read(struct i2c_desc *desc,
 				desc->slave_address,
 				data,
 				bytes_number,
-				option ? XIIC_REPEATED_START : XIIC_STOP);
+				stop_bit ? XIIC_STOP : XIIC_REPEATED_START);
 		if(ret != SUCCESS)
 			goto error;
 
@@ -305,7 +305,7 @@ int32_t i2c_read(struct i2c_desc *desc,
 #ifdef XIICPS_H
 
 		ret = XIicPs_SetOptions(xdesc->instance,
-					option);
+					stop_bit ? 0 : XIIC_REPEATED_START);
 		if(ret != SUCCESS)
 			goto error;
 

--- a/include/i2c.h
+++ b/include/i2c.h
@@ -51,19 +51,6 @@
 /******************************************************************************/
 
 /**
- * @enum i2c_transfer_mode
- * @brief I2C transfer mode configuration
- */
-typedef enum i2c_transfer_mode {
-	/** Address every device connected */
-	i2c_general_call =	0x01,
-	/** Send multiple start conditions */
-	i2c_repeated_start =	0x02,
-	/** Use 10-bit address scheme */
-	i2c_10_bit_transfer =	0x04
-} i2c_transfer_mode;
-
-/**
  * @struct i2c_init_param
  * @brief Structure holding the parameters for I2C initialization.
  */
@@ -104,12 +91,12 @@ int32_t i2c_remove(struct i2c_desc *desc);
 int32_t i2c_write(struct i2c_desc *desc,
 		  uint8_t *data,
 		  uint8_t bytes_number,
-		  uint8_t option);
+		  uint8_t stop_bit);
 
 /* Read data from a slave device. */
 int32_t i2c_read(struct i2c_desc *desc,
 		 uint8_t *data,
 		 uint8_t bytes_number,
-		 uint8_t option);
+		 uint8_t stop_bit);
 
 #endif // I2C_H_


### PR DESCRIPTION
There is no need for i2c_transfer_mode enum. To fix that:
 - Rename option to stop_bit from function header
 - Make needed modification in i2c xilinx implementation

Signed-off-by: Mihail Chindris <mihail.chindris@analog.com>