### PR TITLE
projects makefile: Send 'TINYIIOD" option from command line.

### DIFF
--- a/projects/ad9361/Makefile
+++ b/projects/ad9361/Makefile
@@ -1,5 +1,5 @@
 TARGET := ad9361
-TINYIIOD = n
+TINYIIOD ?= n
 ifeq ($(OS), Windows_NT)
 include ../../tools/scripts/windows.mk
 else

--- a/projects/ad9371/Makefile
+++ b/projects/ad9371/Makefile
@@ -1,5 +1,5 @@
 TARGET := ad9371
-TINYIIOD = n
+TINYIIOD ?= n
 ifeq ($(OS), Windows_NT)
 include ../../tools/scripts/windows.mk
 else

--- a/projects/adrv9009/Makefile
+++ b/projects/adrv9009/Makefile
@@ -1,5 +1,5 @@
 TARGET := adrv9009
-TINYIIOD = n
+TINYIIOD ?= n
 ifeq ($(OS), Windows_NT)
 include ../../tools/scripts/windows.mk
 else


### PR DESCRIPTION
In this way we don't need to modify the Makefile corresponding to project,
if we want to build with TINYIIOD.

Signed-off-by: Cristian Pop <cristian.pop@analog.com>