### PR TITLE
Dual talise

### DIFF
--- a/projects/adrv9009/src.mk
+++ b/projects/adrv9009/src.mk
@@ -12,8 +12,8 @@
 # Uncomment to select the profile
 
 #PROFILE = tx_bw100_ir122p88_rx_bw100_or122p88_orx_bw100_or122p88_dc122p88
-#PROFILE = tx_bw200_ir245p76_rx_bw200_or245p76_orx_bw200_or245p76_dc245p76
-PROFILE = tx_bw400_ir491p52_rx_bw200_or245p76_orx_bw400_or491p52_dc245p76
+PROFILE = tx_bw200_ir245p76_rx_bw200_or245p76_orx_bw200_or245p76_dc245p76
+#PROFILE = tx_bw400_ir491p52_rx_bw200_or245p76_orx_bw400_or491p52_dc245p76
 SRCS := $(PROJECT)/src/app/headless.c					\
 	$(PROJECT)/src/app/app_clocking.c					\
 	$(PROJECT)/src/app/app_jesd.c						\

--- a/projects/adrv9009/src/app/app_clocking.c
+++ b/projects/adrv9009/src/app/app_clocking.c
@@ -337,7 +337,9 @@ adiHalErr_t clocking_init(uint32_t rx_div40_rate_hz,
 		.type = SPI_PS,
 #endif
 		.device_id = 0,
+#if defined(ZU11EG)
 		.flags = SPI_CS_DECODE
+#endif
 	};
 #if !defined(ZU11EG)
 	struct xil_gpio_init_param xil_gpio_param = {

--- a/projects/adrv9009/src/app/app_talise.h
+++ b/projects/adrv9009/src/app/app_talise.h
@@ -52,6 +52,10 @@ enum taliseDeviceId {
 	TALISE_DEVICE_ID_MAX
 };
 
+#define TALISE_NUM_SUBCHANNELS		2 /* I - in-phase and Q - quadrature channels */
+#define TALISE_NUM_CHAIN_CHANNELS	2 /* channels per RX/TX chain */
+#define TALISE_NUM_CHANNELS		(TALISE_DEVICE_ID_MAX * TALISE_NUM_CHAIN_CHANNELS * TALISE_NUM_SUBCHANNELS)
+
 adiHalErr_t talise_setup(taliseDevice_t * const talDev,
 			 taliseInit_t * const talInit);
 

--- a/projects/adrv9009/src/app/app_talise.h
+++ b/projects/adrv9009/src/app/app_talise.h
@@ -43,6 +43,15 @@
 #include "talise_types.h"
 #include "adi_hal.h"
 
+enum taliseDeviceId {
+	TALISE_A = 0u,
+#if defined(ZU11EG)
+	TALISE_B,
+#endif
+
+	TALISE_DEVICE_ID_MAX
+};
+
 adiHalErr_t talise_setup(taliseDevice_t * const talDev,
 			 taliseInit_t * const talInit);
 

--- a/projects/adrv9009/src/app/headless.c
+++ b/projects/adrv9009/src/app/headless.c
@@ -231,7 +231,7 @@ int main(void)
 
 #ifdef DAC_DMA_EXAMPLE
 	gpio_init_plddrbypass.extra = &hal_gpio_param;
-	gpio_init_plddrbypass.number = DAC_FIFO_BYPASS;
+	gpio_init_plddrbypass.number = DAC_FIFO_BYPASS_GPIO;
 	int32_t s = gpio_get(&gpio_plddrbypass, &gpio_init_plddrbypass);
 	if (s) {
 		printf("gpio_get() failed with status %d", s);

--- a/projects/adrv9009/src/app/headless.c
+++ b/projects/adrv9009/src/app/headless.c
@@ -114,13 +114,13 @@ int main(void)
 	struct axi_adc_init rx_adc_init = {
 		"rx_adc",
 		RX_CORE_BASEADDR,
-		4
+		TALISE_NUM_CHANNELS
 	};
 	struct axi_adc *rx_adc;
 	struct axi_dac_init tx_dac_init = {
 		"tx_dac",
 		TX_CORE_BASEADDR,
-		4,
+		TALISE_NUM_CHANNELS,
 		NULL
 	};
 	struct axi_dac *tx_dac;
@@ -264,9 +264,10 @@ int main(void)
 	axi_dmac_init(&rx_dmac, &rx_dmac_init);
 	axi_dmac_transfer(rx_dmac,
 			  DDR_MEM_BASEADDR + 0x800000,
-			  16384 * 8);
+			  16384 * TALISE_NUM_CHANNELS * (talInit.jesd204Settings.framerA.Np / 8));
 #ifndef ALTERA_PLATFORM
-	Xil_DCacheInvalidateRange(XPAR_DDR_MEM_BASEADDR + 0x800000, 16384 * 8);
+	Xil_DCacheInvalidateRange(XPAR_DDR_MEM_BASEADDR + 0x800000,
+				  16384 * TALISE_NUM_CHANNELS * (talInit.jesd204Settings.framerA.Np / 8));
 #endif
 
 #ifdef IIO_EXAMPLE

--- a/projects/adrv9009/src/devices/adi_hal/adi_hal.h
+++ b/projects/adrv9009/src/devices/adi_hal/adi_hal.h
@@ -21,9 +21,11 @@ struct adi_hal {
 	struct gpio_desc	*gpio_adrv_resetb;
 	struct gpio_desc	*gpio_adrv_sysref_req;
 	struct spi_desc		*spi_adrv_desc;
-	uint32_t			log_level;
-	void 				*extra_spi;
-	void 				*extra_gpio;
+	uint32_t		log_level;
+	void 			*extra_spi;
+	uint8_t			spi_adrv_csn;
+	void 			*extra_gpio;
+	uint8_t			gpio_adrv_resetb_num;
 };
 
 /**

--- a/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
+++ b/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
@@ -65,7 +65,7 @@ adiHalErr_t ADIHAL_openHw(void *devHalInfo, uint32_t halTimeout_ms)
 	struct gpio_init_param gpio_adrv_sysref_req_param;
 	int32_t status = 0;
 
-	gpio_adrv_resetb_param.number = TRX_A_RESETB_GPIO;
+	gpio_adrv_resetb_param.number = dev_hal_data->gpio_adrv_resetb_num;
 	gpio_adrv_sysref_req_param.number = SYSREF_REQ_GPIO;
 
 	if (dev_hal_data->extra_gpio) {
@@ -76,7 +76,7 @@ adiHalErr_t ADIHAL_openHw(void *devHalInfo, uint32_t halTimeout_ms)
 	status = gpio_get(&dev_hal_data->gpio_adrv_resetb, &gpio_adrv_resetb_param);
 
 	spi_param.mode = SPI_MODE_0;
-	spi_param.chip_select = ADRV_CS;
+	spi_param.chip_select = dev_hal_data->spi_adrv_csn;
 	if (dev_hal_data->extra_spi)
 		spi_param.extra = dev_hal_data->extra_spi;
 


### PR DESCRIPTION
Add no-OS support for adrv9009-zu11eg which features two adrv9009 devices.

To test this code, one needs to:
- insert some loopback wires between TX/RX connectors
- compile the code with ZU11EG define
- read with a .tcl script from address 0x800000 size 16384 * 16 bytes or 16384 * 8 samples and observe the sinewave on all channels.
