### PR TITLE
Increase Xilinx SPI clock speed

### DIFF
--- a/drivers/platform/xilinx/spi.c
+++ b/drivers/platform/xilinx/spi.c
@@ -150,7 +150,7 @@ pl_error:
 			goto ps_error;
 
 		ret = XSpiPs_SetClkPrescaler(xdesc->instance,
-					     XSPIPS_CLK_PRESCALE_64);
+					     XSPIPS_CLK_PRESCALE_4);
 		if(ret != SUCCESS)
 			goto ps_error;
 


### PR DESCRIPTION
SPI source PCLK is 100 MHz, and with the new prescaler of 4 this gives an
SPI clock of 25 MHz.

Linux also uses 25 MHz as max frequency.

Signed-off-by: Darius Berghe <darius.berghe@analog.com>