### PR TITLE
xilinx spi prescaler based on max_speed_hz

### DIFF
--- a/ad9739a-fmc-ebz/ad9739a_fmc_ebz.c
+++ b/ad9739a-fmc-ebz/ad9739a_fmc_ebz.c
@@ -108,6 +108,7 @@ int main(void)
 	spi_param.chip_select = SPI_CHIP_SELECT(1);
 	spi_param.cpha = 0;
 	spi_param.cpol = 0;
+	spi_param.max_speed_hz = 2000000u;
 
 	/* SPI */
 	init_param.spi_init = spi_param;

--- a/fmcadc2/fmcadc2.c
+++ b/fmcadc2/fmcadc2.c
@@ -78,6 +78,7 @@ int main(void)
 	// SPI configuration
 
 	ad9526_spi_param.chip_select = SPI_CHIP_SELECT(0);
+	ad9526_spi_param.max_speed_hz = 2000000u;
 	ad9526_spi_param.cpha = 0;
 	ad9526_spi_param.cpol = 0;
 	ad9526_spi_param.type = ZYNQ_PS7_SPI;

--- a/fmcdaq2/fmcdaq2.c
+++ b/fmcdaq2/fmcdaq2.c
@@ -274,6 +274,9 @@ int main(void)
 	ad9523_spi_param.cpol = 0;
 	ad9144_spi_param.cpol = 0;
 	ad9680_spi_param.cpol = 0;
+	ad9523_spi_param.max_speed_hz = 2000000u;
+	ad9144_spi_param.max_speed_hz = 2000000u;
+	ad9680_spi_param.max_speed_hz = 2000000u;
 
 	struct ad9523_channel_spec	ad9523_channels[8];
 	struct ad9523_platform_data	ad9523_pdata;

--- a/fmcdaq3/fmcdaq3.c
+++ b/fmcdaq3/fmcdaq3.c
@@ -154,6 +154,9 @@ int main(void)
 	ad9528_spi_param.cpol = 0;
 	ad9152_spi_param.cpol = 0;
 	ad9680_spi_param.cpol = 0;
+	ad9528_spi_param.max_speed_hz = 2000000u;
+	ad9152_spi_param.max_speed_hz = 2000000u;
+	ad9680_spi_param.max_speed_hz = 2000000u;
 
 	ad9528_param.spi_init = ad9528_spi_param;
 	ad9152_param.spi_init = ad9152_spi_param;

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -588,6 +588,7 @@ int main(void)
 	tx_dac_init.base = AD9361_TX_1_BASEADDR;
 
 	spi_param.chip_select = default_init_param.id_no;
+	spi_param.max_speed_hz = 2000000u;
 
 	status = spi_init(&default_init_param.spi, &spi_param);
 	if (status != SUCCESS) {

--- a/projects/ad9371/src/devices/adi_hal/common.c
+++ b/projects/ad9371/src/devices/adi_hal/common.c
@@ -95,6 +95,7 @@ int32_t platform_init(void)
 
 	spi_param.mode = SPI_MODE_0;
 	spi_param.chip_select = AD9371_CS;
+	spi_param.max_speed_hz = 2000000u;
 
 	status |= spi_init(&spi_ad_desc, &spi_param);
 

--- a/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
+++ b/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
@@ -75,6 +75,7 @@ adiHalErr_t ADIHAL_openHw(void *devHalInfo, uint32_t halTimeout_ms)
 
 	status = gpio_get(&dev_hal_data->gpio_adrv_resetb, &gpio_adrv_resetb_param);
 
+	spi_param.max_speed_hz = 25000000;
 	spi_param.mode = SPI_MODE_0;
 	spi_param.chip_select = dev_hal_data->spi_adrv_csn;
 	if (dev_hal_data->extra_spi)


### PR DESCRIPTION
max_speed_hz field of spi_desc was not taken into account and the SPI prescaler value was hardcoded to 64.
This pull request handles the max_speed_hz field and computes the closest possible prescaler that yields a clock speed as close as posible to max_speed_hz.