### PR TITLE
driver:platform:aducm:i2c add #include "error.h"

### DIFF
--- a/drivers/platform/aducm3029/i2c.c
+++ b/drivers/platform/aducm3029/i2c.c
@@ -42,6 +42,7 @@
 /******************************************************************************/
 
 #include "i2c.h"
+#include "error.h"
 #include <stdlib.h>
 #include <drivers/i2c/adi_i2c.h>
 #include <drivers/gpio/adi_gpio.h>


### PR DESCRIPTION
This is needed beacause the driver return SUCCESS and FAILURE
but the include is missing.

Signed-off-by: Mihail Chindris <mihail.chindris@analog.com>