### PR TITLE
readme: replace codacy badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # no-OS
 
-[![Build Status](https://travis-ci.org/analogdevicesinc/no-OS.svg?branch=master)](https://travis-ci.org/analogdevicesinc/no-OS) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/8b54ad19266248f786280925a5967965)](https://www.codacy.com/manual/antoniumiclaus/no-OS?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=analogdevicesinc/no-OS&amp;utm_campaign=Badge_Grade)
+[![Build Status](https://travis-ci.org/analogdevicesinc/no-OS.svg?branch=master)](https://travis-ci.org/analogdevicesinc/no-OS) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/9f57b0bbc3f6465ea211aa6c96afcb23)](https://www.codacy.com/gh/analogdevicesinc/no-OS?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=analogdevicesinc/no-OS&amp;utm_campaign=Badge_Grade)
 
 [Analog Devices Inc.](http://www.analog.com/en/index.html) Software drivers for systems without OS.
 


### PR DESCRIPTION
Use codacy badge linked to the analogdevices organization instead of
personal account.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>