### PR TITLE
doxy: add exclude paths

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -19,26 +19,13 @@ set(DOCUMENTED_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/mainpage.dox \\
     ${SOURCES_DIR}/include \\
     ${SOURCES_DIR}/iio \\
-    ${SOURCES_DIR}/drivers/accel \\
-    ${SOURCES_DIR}/drivers/adc \\
-    ${SOURCES_DIR}/drivers/adc-dac  \\
-    ${SOURCES_DIR}/drivers/afe \\
-    ${SOURCES_DIR}/drivers/axi_core \\
-    ${SOURCES_DIR}/drivers/cdc \\
-    ${SOURCES_DIR}/drivers/dac \\
-    ${SOURCES_DIR}/drivers/frequency \\
-    ${SOURCES_DIR}/drivers/gyro \\
-    ${SOURCES_DIR}/drivers/impedance-analyzer \\
-    ${SOURCES_DIR}/drivers/io-expander \\
-    ${SOURCES_DIR}/drivers/mux \\
-    ${SOURCES_DIR}/drivers/platform \\
-    ${SOURCES_DIR}/drivers/photo-electronic \\
-    ${SOURCES_DIR}/drivers/potentiometer \\
-    ${SOURCES_DIR}/drivers/rf-transceiver/adf7023 \\
-    ${SOURCES_DIR}/drivers/sd-card \\
-    ${SOURCES_DIR}/drivers/temperature \\
+    ${SOURCES_DIR}/drivers \\
     ${SOURCES_DIR}/projects \\
  ")
+
+set(EXCLUDE_FILES
+    "${SOURCES_DIR}/drivers/rf-transceiver/talise \\
+")
 
 configure_file(
     DoxygenLayoutIn.xml

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -832,7 +832,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                =
+EXCLUDE                = @EXCLUDE_FILES@
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded


### PR DESCRIPTION
Use `EXCLUDE` tag from Doxygen configuration file to exclude
undocumented/unwanted paths.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>