### PR TITLE
sync talise calibration flags with linux

### DIFF
--- a/projects/adrv9009/src/app/app_talise.c
+++ b/projects/adrv9009/src/app/app_talise.c
@@ -87,11 +87,12 @@ adiHalErr_t talise_setup(taliseDevice_t * const pd, taliseInit_t * const pi)
 	uint8_t framerStatus = 0;
 	uint32_t count = sizeof(armBinary);
 	taliseArmVersionInfo_t talArmVersionInfo;
-	uint32_t initCalMask =  TAL_TX_BB_FILTER | TAL_ADC_TUNER | TAL_TIA_3DB_CORNER
-				| TAL_DC_OFFSET | TAL_TX_ATTENUATION_DELAY | TAL_RX_GAIN_DELAY | TAL_FLASH_CAL |
-				TAL_PATH_DELAY | TAL_TX_LO_LEAKAGE_INTERNAL | TAL_TX_QEC_INIT |
-				TAL_LOOPBACK_RX_LO_DELAY | TAL_LOOPBACK_RX_RX_QEC_INIT |
-				TAL_RX_LO_DELAY | TAL_RX_QEC_INIT;
+	uint32_t initCalMask =  TAL_TX_BB_FILTER | TAL_ADC_TUNER |  TAL_TIA_3DB_CORNER |
+				TAL_DC_OFFSET | TAL_RX_GAIN_DELAY | TAL_FLASH_CAL |
+				TAL_PATH_DELAY | TAL_TX_LO_LEAKAGE_INTERNAL |
+				TAL_TX_QEC_INIT | TAL_LOOPBACK_RX_LO_DELAY |
+				TAL_LOOPBACK_RX_RX_QEC_INIT | TAL_RX_QEC_INIT |
+				TAL_ORX_QEC_INIT | TAL_TX_DAC  | TAL_ADC_STITCHING;
 	uint32_t trackingCalMask =  TAL_TRACK_RX1_QEC |
 				    TAL_TRACK_RX2_QEC |
 				    TAL_TRACK_TX1_QEC |


### PR DESCRIPTION
This seems to cut about 100ms off the calibration time.

Signed-off-by: Darius Berghe <darius.berghe@analog.com>