### PR TITLE
irq: Rename to a more significant name: "struct irq_ctrl_desc"

### DIFF
--- a/drivers/platform/xilinx/irq.c
+++ b/drivers/platform/xilinx/irq.c
@@ -59,19 +59,19 @@
 
 /**
  * @brief Initialize the IRQ interrupts.
- * @param desc - The IRQ descriptor.
+ * @param desc - The IRQ controller descriptor.
  * @param param - The structure that contains the IRQ parameters.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t irq_ctrl_init(struct irq_desc **desc,
+int32_t irq_ctrl_init(struct irq_ctrl_desc **desc,
 		      const struct irq_init_param *param)
 {
 	int32_t status;
-	struct irq_desc *descriptor;
+	struct irq_ctrl_desc *descriptor;
 	struct xil_irq_desc *xil_dev;
 	void *config;
 
-	descriptor = (struct irq_desc *)calloc(1, sizeof *descriptor);
+	descriptor = (struct irq_ctrl_desc *)calloc(1, sizeof *descriptor);
 	if(!descriptor)
 		return FAILURE;
 	xil_dev = (struct xil_irq_desc *)calloc(1, sizeof *xil_dev);
@@ -82,7 +82,7 @@ int32_t irq_ctrl_init(struct irq_desc **desc,
 
 	Xil_ExceptionInit();
 
-	descriptor->irq_id = param->irq_id;
+	descriptor->irq_ctrl_id = param->irq_ctrl_id;
 	descriptor->extra = xil_dev;
 	xil_dev->type = ((struct xil_irq_init_param *)param->extra)->type;
 
@@ -93,7 +93,7 @@ int32_t irq_ctrl_init(struct irq_desc **desc,
 		if(!xil_dev->instance)
 			goto error;
 
-		config = XScuGic_LookupConfig(descriptor->irq_id);
+		config = XScuGic_LookupConfig(descriptor->irq_ctrl_id);
 		if(!config)
 			goto ps_error;
 
@@ -151,7 +151,7 @@ error:
  * @brief Enable global interrupts.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t irq_global_enable(struct irq_desc *desc)
+int32_t irq_global_enable(struct irq_ctrl_desc *desc)
 {
 	/* Enable interrupts */
 	Xil_ExceptionEnable();
@@ -163,7 +163,7 @@ int32_t irq_global_enable(struct irq_desc *desc)
  * @brief Disable global interrupts.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t irq_global_disable(struct irq_desc *desc)
+int32_t irq_global_disable(struct irq_ctrl_desc *desc)
 {
 	/* Disable interrupts */
 	Xil_ExceptionDisable();
@@ -173,11 +173,11 @@ int32_t irq_global_disable(struct irq_desc *desc)
 
 /**
  * @brief Enable specific interrupt.
- * @param desc - The IRQ descriptor.
+ * @param desc - The IRQ controller descriptor.
  * @param irq_id - Interrupt identifier.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t irq_source_enable(struct irq_desc *desc, uint32_t irq_id)
+int32_t irq_source_enable(struct irq_ctrl_desc *desc, uint32_t irq_id)
 {
 	struct xil_irq_desc *xil_dev = desc->extra;
 
@@ -202,11 +202,11 @@ int32_t irq_source_enable(struct irq_desc *desc, uint32_t irq_id)
 
 /**
  * @brief Disable specific interrupt.
- * @param desc - The IRQ descriptor.
+ * @param desc - The IRQ controller descriptor.
  * @param irq_id - Interrupt identifier.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t irq_source_disable(struct irq_desc *desc, uint32_t irq_id)
+int32_t irq_source_disable(struct irq_ctrl_desc *desc, uint32_t irq_id)
 {
 	struct xil_irq_desc *xil_dev = desc->extra;
 
@@ -231,13 +231,13 @@ int32_t irq_source_disable(struct irq_desc *desc, uint32_t irq_id)
 
 /**
  * @brief Registers a generic IRQ handling function.
- * @param desc - The IRQ descriptor.
+ * @param desc - The IRQ controller descriptor.
  * @param irq_id - Interrupt identifier.
  * @param irq_handler - The IRQ handler.
  * @param dev_instance - device instance.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t irq_register(struct irq_desc *desc, uint32_t irq_id,
+int32_t irq_register(struct irq_ctrl_desc *desc, uint32_t irq_id,
 		     void (*irq_handler)(void *data), void *dev_instance)
 {
 	struct xil_irq_desc *xil_dev = desc->extra;
@@ -264,11 +264,11 @@ int32_t irq_register(struct irq_desc *desc, uint32_t irq_id,
 
 /**
  * @brief Unregisters a generic IRQ handling function.
- * @param desc - The IRQ descriptor.
+ * @param desc - The IRQ controller descriptor.
  * @param irq_id - Interrupt identifier.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t irq_unregister(struct irq_desc *desc, uint32_t irq_id)
+int32_t irq_unregister(struct irq_ctrl_desc *desc, uint32_t irq_id)
 {
 	struct xil_irq_desc *xil_dev = desc->extra;
 
@@ -293,10 +293,10 @@ int32_t irq_unregister(struct irq_desc *desc, uint32_t irq_id)
 
 /**
  * @brief Free the resources allocated by irq_ctrl_init().
- * @param desc - The IRQ descriptor.
+ * @param desc - The IRQ control descriptor.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t irq_ctrl_remove(struct irq_desc *desc)
+int32_t irq_ctrl_remove(struct irq_ctrl_desc *desc)
 {
 	struct xil_irq_desc *xil_dev = desc->extra;
 	free(xil_dev->instance);

--- a/drivers/platform/xilinx/uart.c
+++ b/drivers/platform/xilinx/uart.c
@@ -64,7 +64,7 @@ static int32_t uart_fifo_insert(struct uart_desc *desc)
 {
 	int32_t ret;
 	struct xil_uart_desc *xil_uart_desc = desc->extra;
-	struct irq_desc	*irq_desc = xil_uart_desc->irq_desc;
+	struct irq_ctrl_desc *irq_desc = xil_uart_desc->irq_desc;
 
 	if (xil_uart_desc->bytes_received > 0) {
 		ret = irq_source_disable(irq_desc, xil_uart_desc->irq_id);

--- a/drivers/platform/xilinx/uart_extra.h
+++ b/drivers/platform/xilinx/uart_extra.h
@@ -76,7 +76,7 @@ struct xil_uart_init_param {
 	/** Interrupt Request ID */
 	uint32_t			irq_id;
 	/** Interrupt Request Descriptor */
-	struct irq_desc		*irq_desc;
+	struct irq_ctrl_desc *irq_desc;
 };
 
 /**
@@ -89,7 +89,7 @@ struct xil_uart_desc {
 	/** Interrupt Request ID */
 	uint32_t			irq_id;
 	/** Interrupt Request Descriptor */
-	struct irq_desc		*irq_desc;
+	struct irq_ctrl_desc *irq_desc;
 	/** FIFO */
 	struct fifo_element	*fifo;
 	/** FIFO read offset */

--- a/include/irq.h
+++ b/include/irq.h
@@ -55,8 +55,8 @@
  * @brief Structure holding the initial parameters for Interrupt Request.
  */
 struct irq_init_param {
-	/** Interrupt Request ID. */
-	uint32_t	irq_id;
+	/** Interrupt request controller ID. */
+	uint32_t	irq_ctrl_id;
 	/** IRQ extra parameters (device specific) */
 	void		*extra;
 };
@@ -65,9 +65,9 @@ struct irq_init_param {
  * @struct irq_desc
  * @brief Structure for Interrupt Request descriptor.
  */
-struct irq_desc {
-	/** Interrupt Request ID. */
-	uint32_t	irq_id;
+struct irq_ctrl_desc {
+	/** Interrupt request controller ID. */
+	uint32_t	irq_ctrl_id;
 	/** IRQ extra parameters (device specific) */
 	void		*extra;
 };
@@ -77,29 +77,36 @@ struct irq_desc {
 /******************************************************************************/
 
 /* Initialize a interrupt controller peripheral. */
-int32_t irq_ctrl_init(struct irq_desc **desc,
+int32_t irq_ctrl_init(struct irq_ctrl_desc **desc,
 		      const struct irq_init_param *param);
 
 /* Free the resources allocated by irq_ctrl_init(). */
-int32_t irq_ctrl_remove(struct irq_desc *desc);
+int32_t irq_ctrl_remove(struct irq_ctrl_desc *desc);
 
-/* Registers a generic IRQ handling function */
-int32_t irq_register(struct irq_desc *desc, uint32_t irq_id,
+/**
+ * @brief Registers a IRQ handling function to irq controller.
+ * @param desc - The IRQ controller descriptor.
+ * @param irq_id - Interrupt identifier.
+ * @param irq_handler - The IRQ handler.
+ * @param dev_instance - device instance.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t irq_register(struct irq_ctrl_desc *desc, uint32_t irq_id,
 		     void (*irq_handler)(void *data), void *dev_instance);
 
 /* Unregisters a generic IRQ handling function */
-int32_t irq_unregister(struct irq_desc *desc, uint32_t irq_id);
+int32_t irq_unregister(struct irq_ctrl_desc *desc, uint32_t irq_id);
 
 /* Global interrupt enable */
-int32_t irq_global_enable(struct irq_desc *desc);
+int32_t irq_global_enable(struct irq_ctrl_desc *desc);
 
 /* Global interrupt disable */
-int32_t irq_global_disable(struct irq_desc *desc);
+int32_t irq_global_disable(struct irq_ctrl_desc *desc);
 
 /* Enable specific interrupt */
-int32_t irq_source_enable(struct irq_desc *desc, uint32_t irq_id);
+int32_t irq_source_enable(struct irq_ctrl_desc *desc, uint32_t irq_id);
 
 /* Disable specific interrupt */
-int32_t irq_source_disable(struct irq_desc *desc, uint32_t irq_id);
+int32_t irq_source_disable(struct irq_ctrl_desc *desc, uint32_t irq_id);
 
 #endif // IRQ_H_

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -719,14 +719,14 @@ int main(void)
 	 * IRQ initial configuration.
 	 */
 	struct irq_init_param irq_init_param = {
-		.irq_id = INTC_DEVICE_ID,
+		.irq_ctrl_id = INTC_DEVICE_ID,
 		.extra = &xil_irq_init_par,
 	};
 
 	/**
 	 * IRQ instance.
 	 */
-	struct irq_desc *irq_desc;
+	struct irq_ctrl_desc *irq_desc;
 
 	/**
 	 * Xilinx platform dependent initialization for UART.

--- a/projects/ad9371/src/app/headless.c
+++ b/projects/ad9371/src/app/headless.c
@@ -1027,14 +1027,14 @@ int main(void)
 	 * IRQ initial configuration.
 	 */
 	struct irq_init_param irq_init_param = {
-		.irq_id = INTC_DEVICE_ID,
+		.irq_ctrl_id = INTC_DEVICE_ID,
 		.extra = &xil_irq_init_par,
 	};
 
 	/**
 	 * IRQ instance.
 	 */
-	struct irq_desc *irq_desc;
+	struct irq_ctrl_desc *irq_desc;
 
 	/**
 	 * Xilinx platform dependent initialization for UART.

--- a/projects/adrv9009/src/app/headless.c
+++ b/projects/adrv9009/src/app/headless.c
@@ -335,14 +335,14 @@ int main(void)
 	 * IRQ initial configuration.
 	 */
 	struct irq_init_param irq_init_param = {
-		.irq_id = INTC_DEVICE_ID,
+		.irq_ctrl_id = INTC_DEVICE_ID,
 		.extra = &xil_irq_init_par,
 	};
 
 	/**
 	 * IRQ instance.
 	 */
-	struct irq_desc *irq_desc;
+	struct irq_ctrl_desc *irq_desc;
 
 	/**
 	 * Xilinx platform dependent initialization for UART.


### PR DESCRIPTION
This is necessary to eliminate confusion between interrupt controller ID
and interrupt ID.

Signed-off-by: Cristian Pop <cristian.pop@analog.com>