### PR TITLE
axi_dac_core: use correct implementation for internal data source selection

### DIFF
--- a/drivers/axi_core/axi_dac_core/axi_dac_core.c
+++ b/drivers/axi_core/axi_dac_core/axi_dac_core.c
@@ -744,24 +744,6 @@ uint32_t axi_dac_set_sine_lut(struct axi_dac *dac,
 }
 
 /***************************************************************************//**
- * @brief dac_datasel
-*******************************************************************************/
-int32_t axi_dac_datasel(struct axi_dac *dac, int32_t chan,
-			enum axi_dac_data_sel sel)
-{
-	int32_t i;
-	if (chan < 0) { /* ALL */
-		for (i = 0; i < dac->num_channels; i++) {
-			axi_dac_write(dac, AXI_DAC_REG_CHAN_CNTRL_8(i), sel);
-		}
-	} else {
-		axi_dac_write(dac, AXI_DAC_REG_CHAN_CNTRL_8(chan), sel);
-	}
-	axi_dac_write(dac, AXI_DAC_REG_SYNC_CONTROL, AXI_DAC_SYNC);
-	return 0;
-}
-
-/***************************************************************************//**
  * @brief axi_dac_set_buff
 *******************************************************************************/
 int32_t axi_dac_set_buff(struct axi_dac *dac,

--- a/drivers/axi_core/axi_dac_core/axi_dac_core.h
+++ b/drivers/axi_core/axi_dac_core/axi_dac_core.h
@@ -116,8 +116,6 @@ int32_t axi_dac_set_buff(struct axi_dac *dac,
 			 uint32_t buff_size);
 uint32_t axi_dac_set_sine_lut(struct axi_dac *dac,
 			      uint32_t address);
-int32_t axi_dac_datasel(struct axi_dac *dac, int32_t chan,
-			enum axi_dac_data_sel sel);
 int32_t axi_dac_dds_get_calib_scale(struct axi_dac *dac,
 				    uint32_t chan,
 				    int32_t *val,

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -617,18 +617,18 @@ int main(void)
 #ifdef DAC_DMA_EXAMPLE
 #ifdef FMCOMMS5
 	axi_dac_init(&ad9361_phy_b->tx_dac, ad9361_phy_b->tx_dac_init);
-	axi_dac_datasel(ad9361_phy_b->tx_dac, -1, AXI_DAC_DATA_SEL_DMA);
+	axi_dac_set_datasel(ad9361_phy_b->tx_dac, -1, AXI_DAC_DATA_SEL_DMA);
 #endif
 	axi_dac_init(&ad9361_phy->tx_dac, ad9361_phy->tx_dac_init);
-	axi_dac_datasel(ad9361_phy->tx_dac, -1, AXI_DAC_DATA_SEL_DMA);
+	axi_dac_set_datasel(ad9361_phy->tx_dac, -1, AXI_DAC_DATA_SEL_DMA);
 	axi_dac_set_sine_lut(ad9361_phy->tx_dac, DAC_DDR_BASEADDR);
 #else
 #ifdef FMCOMMS5
 	axi_dac_init(&ad9361_phy_b->tx_dac, ad9361_phy_b->tx_dac_init);
-	axi_dac_datasel(ad9361_phy_b->tx_dac, -1, AXI_DAC_DATA_SEL_DDS);
+	axi_dac_set_datasel(ad9361_phy_b->tx_dac, -1, AXI_DAC_DATA_SEL_DDS);
 #endif
 	axi_dac_init(&ad9361_phy->tx_dac, ad9361_phy->tx_dac_init);
-	axi_dac_datasel(ad9361_phy->tx_dac, -1, AXI_DAC_DATA_SEL_DDS);
+	axi_dac_set_datasel(ad9361_phy->tx_dac, -1, AXI_DAC_DATA_SEL_DDS);
 #endif
 #endif
 #endif


### PR DESCRIPTION
This patch provides the following modifications:
1. Replace `axi_dac_datasel` function with `axi_dac_set_datasel` which is properly selecting the internal data sources.
2. Remove incorrect function implementation (`axi_dac_datasel`).

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>