### PR TITLE
doxyfile: disable CREATE_SUBDIRS tag

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -68,7 +68,7 @@ OUTPUT_DIRECTORY       =
 # performance problems for the file system.
 # The default value is: NO.
 
-CREATE_SUBDIRS         = YES
+CREATE_SUBDIRS         = NO
 
 # If the ALLOW_UNICODE_NAMES tag is set to YES, doxygen will allow non-ASCII
 # characters to appear in the names of generated files. If set to NO, non-ASCII


### PR DESCRIPTION
Disable creating subdirectories in the output directory where the
generated files are stored.

Ease the usage of doxygen links when integrated on external pages.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>