### PR TITLE
Iio unregister

### DIFF
--- a/iio/iio.h
+++ b/iio/iio.h
@@ -51,6 +51,36 @@
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
+/**
+ * @struct iio_interface
+ * @brief Links a physical device instance "void *dev_instance"
+ * with a "iio_device *iio" that describes capabilities of the device.
+ */
+struct iio_interface {
+	/** Device name */
+	const char *name;
+	/** Opened channels */
+	uint32_t ch_mask;
+	/** Physical instance of a device */
+	void *dev_instance;
+	/** Device descriptor(describes channels and attributes) */
+	struct iio_device *iio;
+	/** Generate device xml */
+	ssize_t (*get_xml)(char **xml, struct iio_device *iio);
+	/** Transfer data from device into RAM */
+	ssize_t (*transfer_dev_to_mem)(void *dev_instance, size_t bytes_count,
+				       uint32_t ch_mask);
+	/** Read data from RAM to pbuf. It should be called after "transfer_dev_to_mem" */
+	ssize_t (*read_data)(void *dev_instance, char *pbuf, size_t offset,
+			     size_t bytes_count, uint32_t ch_mask);
+	/** Transfer data from RAM to device */
+	ssize_t (*transfer_mem_to_dev)(void *dev_instance, size_t bytes_count,
+				       uint32_t ch_mask);
+	/** Write data to RAM. It should be called before "transfer_mem_to_dev" */
+	ssize_t (*write_data)(void *dev_instance, char *pbuf, size_t offset,
+			      size_t bytes_count, uint32_t ch_mask);
+};
+
 /******************************************************************************/
 /************************ Functions Declarations ******************************/
 /******************************************************************************/
@@ -61,8 +91,8 @@ ssize_t iio_init(struct tinyiiod **iiod, struct iio_server_ops *comm_ops);
 /* Free the resources allocated by iio_init(). */
 ssize_t iio_remove(struct tinyiiod *iiod);
 /* Register interface. */
-ssize_t iio_register(struct iio_interface_init_par *init_par);
+ssize_t iio_register(struct iio_interface *iio_interface);
 /* Unregister interface. */
-ssize_t iio_unregister(const char *device_name);
+ssize_t iio_unregister(struct iio_interface *iio_interface);
 
 #endif /* IIO_H_ */

--- a/iio/iio_app/iio_ad9361_app.h
+++ b/iio/iio_app/iio_ad9361_app.h
@@ -67,7 +67,7 @@ struct iio_ad9361_app_init_param {
  */
 struct iio_ad9361_app_desc {
 	/** device name */
-	const char *dev_name;
+	struct iio_interface *iio_interface;
 };
 
 /******************************************************************************/

--- a/iio/iio_app/iio_axi_adc_app.c
+++ b/iio/iio_app/iio_axi_adc_app.c
@@ -660,7 +660,7 @@ static ssize_t iio_axi_adc_read_dev(void *iio_inst, char *pbuf, size_t offset,
 int32_t iio_axi_adc_app_init(struct iio_axi_adc_app_desc **desc,
 			     struct iio_axi_adc_app_init_param *init)
 {
-	struct iio_interface_init_par iio_axi_adc_intf_par;
+	struct iio_interface *iio_interface;
 	struct iio_device *iio_axi_adc_device;
 	struct iio_axi_adc *iio_axi_adc_inst;
 
@@ -686,10 +686,14 @@ int32_t iio_axi_adc_app_init(struct iio_axi_adc_app_desc **desc,
 	if (!iio_axi_adc_device)
 		goto error_free_iio_axi_adc_inst;
 
-	iio_axi_adc_intf_par = (struct iio_interface_init_par) {
-		.dev_name = iio_axi_adc_inst->adc->name,
+	iio_interface = (struct iio_interface *)calloc(1, sizeof(struct iio_interface));
+	if (!iio_interface)
+		goto error_free_iio_axi_adc_delete_dev;
+
+	*iio_interface = (struct iio_interface) {
+		.name = iio_axi_adc_inst->adc->name,
 		.dev_instance = iio_axi_adc_inst,
-		.iio_device = iio_axi_adc_device,
+		.iio = iio_axi_adc_device,
 		.get_xml = iio_axi_adc_get_xml,
 		.transfer_dev_to_mem = iio_axi_adc_transfer_dev_to_mem,
 		.transfer_mem_to_dev = NULL,
@@ -697,20 +701,22 @@ int32_t iio_axi_adc_app_init(struct iio_axi_adc_app_desc **desc,
 		.write_data = NULL,
 	};
 
-	status = iio_register(&iio_axi_adc_intf_par);
-	if(status < 0)
-		goto error_free_iio_axi_adc_inst;
+	status = iio_register(iio_interface);
+	if (status < 0)
+		goto error_free_iio_axi_adc_delete_dev;
 
 	*desc = calloc(1, sizeof(struct iio_axi_adc_app_desc));
 	if (!(*desc))
-		goto error_free_unregister;
+		goto error_iio_unregister;
 
-	(*desc)->iio_axi_adc_inst = iio_axi_adc_inst;
+	(*desc)->iio_interface = iio_interface;
 
 	return SUCCESS;
 
-error_free_unregister:
-	iio_unregister(iio_axi_adc_inst->adc->name);
+error_iio_unregister:
+	iio_unregister(iio_interface);
+error_free_iio_axi_adc_delete_dev:
+	iio_axi_adc_delete_device(iio_axi_adc_device);
 error_free_iio_axi_adc_inst:
 	free(iio_axi_adc_inst);
 
@@ -729,10 +735,16 @@ int32_t iio_axi_adc_app_remove(struct iio_axi_adc_app_desc *desc)
 	if (!desc)
 		return FAILURE;
 
-	status = iio_unregister(desc->iio_axi_adc_inst->adc->name);
-	if(status < 0)
-		return status;
+	status = iio_unregister(desc->iio_interface);
+	if (status < 0)
+		return FAILURE;
 
+	status = iio_axi_adc_delete_device(desc->iio_interface->iio);
+	if (status < 0)
+		return FAILURE;
+
+	free(desc->iio_interface->dev_instance);
+	free(desc->iio_interface);
 	free(desc);
 
 	return SUCCESS;

--- a/iio/iio_app/iio_axi_adc_app.h
+++ b/iio/iio_app/iio_axi_adc_app.h
@@ -56,8 +56,8 @@
  * @brief Application desciptor.
  */
 struct iio_axi_adc_app_desc {
-	/** iio DAC device handle */
-	struct iio_axi_adc *iio_axi_adc_inst;
+	/** Structure containing physical device instance and device descriptor */
+	struct iio_interface *iio_interface;
 };
 
 /**

--- a/iio/iio_app/iio_axi_dac_app.h
+++ b/iio/iio_app/iio_axi_dac_app.h
@@ -57,7 +57,7 @@
  */
 struct iio_axi_dac_app_desc {
 	/** iio DAC device handle */
-	struct iio_axi_dac *iio_axi_dac_inst;
+	struct iio_interface *iio_interface;
 };
 
 /**

--- a/iio/iio_types.h
+++ b/iio/iio_types.h
@@ -105,33 +105,6 @@ struct iio_device {
 };
 
 /**
- * @struct iio_interface_init_par
- * @brief iio interface init parameters
- */
-struct iio_interface_init_par {
-	/** device name */
-	const char *dev_name;
-	/**  physical instance of a device */
-	void *dev_instance;
-	/** device descriptor(describes channels and attributes) */
-	struct iio_device *iio_device;
-	/** Generate device xml */
-	ssize_t (*get_xml)(char** xml, struct iio_device *iio_dev);
-	/** transfer data from ADC into RAM */
-	ssize_t (*transfer_dev_to_mem)(void *dev_instance, size_t bytes_count,
-				       uint32_t ch_mask);
-	/** Read data from RAM to pbuf. It should be called after "transfer_dev_to_mem" */
-	ssize_t (*read_data)(void *dev_instance, char *pbuf, size_t offset,
-			     size_t bytes_count, uint32_t ch_mask);
-	/** Transfer data from RAM to DAC */
-	ssize_t (*transfer_mem_to_dev)(void *dev_instance, size_t bytes_count,
-				       uint32_t ch_mask);
-	/** Write data to RAM. It should be called before "transfer_mem_to_dev" */
-	ssize_t (*write_data)(void *dev_instance, char *pbuf, size_t offset,
-			      size_t bytes_count, uint32_t ch_mask);
-};
-
-/**
  * @struct iio_server_ops
  * @brief iio interface for server read/write operations
  */


### PR DESCRIPTION
iio: Release resources properly. 
"iio_unregister" function should return the interface and further more, the
resources allocated should be released in "iio_*_app_remove" functions.

Signed-off-by: Cristian Pop <cristian.pop@analog.com>