### PR TITLE
spi: remove max_speed_init from root projects

### DIFF
--- a/ad9739a-fmc-ebz/ad9739a_fmc_ebz.c
+++ b/ad9739a-fmc-ebz/ad9739a_fmc_ebz.c
@@ -108,7 +108,6 @@ int main(void)
 	spi_param.chip_select = SPI_CHIP_SELECT(1);
 	spi_param.cpha = 0;
 	spi_param.cpol = 0;
-	spi_param.max_speed_hz = 2000000u;
 
 	/* SPI */
 	init_param.spi_init = spi_param;

--- a/fmcadc2/fmcadc2.c
+++ b/fmcadc2/fmcadc2.c
@@ -78,7 +78,6 @@ int main(void)
 	// SPI configuration
 
 	ad9526_spi_param.chip_select = SPI_CHIP_SELECT(0);
-	ad9526_spi_param.max_speed_hz = 2000000u;
 	ad9526_spi_param.cpha = 0;
 	ad9526_spi_param.cpol = 0;
 	ad9526_spi_param.type = ZYNQ_PS7_SPI;

--- a/fmcdaq2/fmcdaq2.c
+++ b/fmcdaq2/fmcdaq2.c
@@ -274,9 +274,6 @@ int main(void)
 	ad9523_spi_param.cpol = 0;
 	ad9144_spi_param.cpol = 0;
 	ad9680_spi_param.cpol = 0;
-	ad9523_spi_param.max_speed_hz = 2000000u;
-	ad9144_spi_param.max_speed_hz = 2000000u;
-	ad9680_spi_param.max_speed_hz = 2000000u;
 
 	struct ad9523_channel_spec	ad9523_channels[8];
 	struct ad9523_platform_data	ad9523_pdata;

--- a/fmcdaq3/fmcdaq3.c
+++ b/fmcdaq3/fmcdaq3.c
@@ -154,9 +154,6 @@ int main(void)
 	ad9528_spi_param.cpol = 0;
 	ad9152_spi_param.cpol = 0;
 	ad9680_spi_param.cpol = 0;
-	ad9528_spi_param.max_speed_hz = 2000000u;
-	ad9152_spi_param.max_speed_hz = 2000000u;
-	ad9680_spi_param.max_speed_hz = 2000000u;
 
 	ad9528_param.spi_init = ad9528_spi_param;
 	ad9152_param.spi_init = ad9152_spi_param;


### PR DESCRIPTION
This patches fixes 635c6b9eda56a9eff95e9c025757c8eb4fd28a96

Remove `max_speed_hz` initialization from projects that use old platform
drivers where the attribute is not available and avoid compiling errors.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>