### PR TITLE
include:irq: Add support for uart callback

### DIFF
--- a/drivers/platform/aducm3029/irq.c
+++ b/drivers/platform/aducm3029/irq.c
@@ -41,10 +41,11 @@
 /************************* Include Files **************************************/
 /******************************************************************************/
 
-#include "irq.h"
-#include "irq_extra.h"
 #include "error.h"
 #include <stdlib.h>
+#include "irq_extra.h"
+#include "irq.h"
+#include "uart_extra.h"
 
 /******************************************************************************/
 /********************** Macros and Constants Definitions **********************/
@@ -53,15 +54,20 @@
 /** The number of the first external interrupt, used by NVIC */
 #define BASE_XINT_NB			(XINT_EVT0_IRQn)
 
+/** Number of available external interrupts */
+#define NB_EXT_INTERRUPTS		4u
+
 /** Number of interrupts controllers available */
 #define NB_INTERRUPT_CONTROLLERS	1u
 
 /** Map the interrupt ID to the ADI_XINT_EVENT associated event */
-static const uint32_t id_map_event[NB_EXT_INTERRUPTS] = {
-	ADI_XINT_EVENT_INT0, // ID 0
-	ADI_XINT_EVENT_INT1, // ID 1
-	ADI_XINT_EVENT_INT2, // ID 2
-	ADI_XINT_EVENT_INT3  // ID 3
+static const uint32_t id_map_event[NB_INTERRUPTS] = {
+	ADI_XINT_EVENT_INT0,	//ID ADUCM_EXTERNAL_INT0
+	ADI_XINT_EVENT_INT1,	//ID ADUCM_EXTERNAL_INT1
+	ADI_XINT_EVENT_INT2,	//ID ADUCM_EXTERNAL_INT2
+	ADI_XINT_EVENT_INT3,	//ID ADUCM_EXTERNAL_INT3
+	UART_EVT_IRQn		//UART IRQ
+
 };
 
 /******************************************************************************/
@@ -79,22 +85,6 @@ static uint32_t		initialized;
 /******************************************************************************/
 
 /**
- * @brief Call the user callback
- * @param aducm_desc - Descriptor where the user callback is stared
- * @param event - Event that generated the callback
- * @param arg - Unused
- */
-static void internal_callback(void *aducm_desc, uint32_t event, void *arg)
-{
-	struct aducm_irq_desc *desc = aducm_desc;
-
-	(void)arg;
-
-	if (event < NB_EXT_INTERRUPTS && desc->irq_handler[event])
-		desc->irq_handler[event]((void *)event);
-}
-
-/**
  * @brief Initialized the controller for the ADuCM3029 external interrupts
  *
  * @param desc - Pointer where the configured instance is stored
@@ -104,7 +94,7 @@ static void internal_callback(void *aducm_desc, uint32_t event, void *arg)
 int32_t irq_ctrl_init(struct irq_ctrl_desc **desc,
 		      const struct irq_init_param *param)
 {
-	struct aducm_irq_desc		*aducm_desc;
+	struct aducm_irq_ctrl_desc		*aducm_desc;
 
 	if (!desc || !param || initialized)
 		return FAILURE;
@@ -112,7 +102,8 @@ int32_t irq_ctrl_init(struct irq_ctrl_desc **desc,
 	*desc = (struct irq_ctrl_desc *)calloc(1, sizeof(**desc));
 	if (!*desc)
 		return FAILURE;
-	aducm_desc = (struct aducm_irq_desc *)calloc(1, sizeof(*aducm_desc));
+	aducm_desc = (struct aducm_irq_ctrl_desc *)calloc(1,
+			sizeof(*aducm_desc));
 	if (!aducm_desc) {
 		free(*desc);
 		*desc = NULL;
@@ -124,55 +115,7 @@ int32_t irq_ctrl_init(struct irq_ctrl_desc **desc,
 
 	adi_xint_Init(aducm_desc->irq_memory, ADI_XINT_MEMORY_SIZE);
 
-	for (uint32_t i = 0; i < NB_EXT_INTERRUPTS; i++)
-		adi_xint_RegisterCallback(id_map_event[i], internal_callback,
-					  aducm_desc);
-
 	initialized = 1;
-	return SUCCESS;
-}
-
-/**
- * @brief Free the resources allocated by \ref irq_ctrl_init()
- * @param desc - Interrupt controller descriptor.
- * @return \ref SUCCESS in case of success, \ref FAILURE otherwise.
- */
-int32_t irq_ctrl_remove(struct irq_ctrl_desc *desc)
-{
-	if (!desc || !desc->extra || !initialized)
-		return FAILURE;
-
-	initialized = 0;
-	adi_xint_UnInit();
-	free(desc->extra);
-	free(desc);
-
-	return SUCCESS;
-}
-
-/**
- * @brief Register IRQ handling function for the specified <em>irq_id</em>.
- * @param desc - Interrupt controller descriptor.
- * @param irq_id - Id of the interrupt
- * @param irq_handler - Generic function to be registered. Will be called using
- * as parameter the interrupt ID.
- * @param dev_instance - Specify the trigger condition for the interrupt. To be
- * one of the values from \ref irq_mode.
- * @return \ref SUCCESS in case of success, \ref FAILURE otherwise.
- */
-int32_t irq_register(struct irq_ctrl_desc *desc, uint32_t irq_id,
-		     void (*irq_handler)(void *data), void *dev_instance)
-{
-	struct aducm_irq_desc *aducm_desc;
-
-	if (!desc || !desc->extra || !initialized || !irq_handler ||
-	    irq_id >= NB_EXT_INTERRUPTS)
-		return FAILURE;
-
-	aducm_desc = desc->extra;
-	aducm_desc->irq_handler[irq_id] = irq_handler;
-	aducm_desc->mode[irq_id] = (enum irq_mode)dev_instance;
-
 	return SUCCESS;
 }
 
@@ -182,25 +125,108 @@ int32_t irq_register(struct irq_ctrl_desc *desc, uint32_t irq_id,
  * @param irq_id - Id of the interrupt
  * @return \ref SUCCESS in case of success, \ref FAILURE otherwise.
  */
-int32_t irq_unregister(struct irq_ctrl_desc *desc, uint32_t irq_id)
+static int32_t irq_unregister(struct irq_ctrl_desc *desc, uint32_t irq_id)
 {
+	struct aducm_irq_ctrl_desc	*aducm_desc;
+
 	if (!desc || !desc->extra || !initialized ||
-	    irq_id >= NB_EXT_INTERRUPTS)
+	    irq_id >= NB_INTERRUPTS)
 		return FAILURE;
 
-	((struct aducm_irq_desc *)desc->extra)->irq_handler[irq_id] = NULL;
+	aducm_desc = desc->extra;
+
+	if (irq_id < NB_EXT_INTERRUPTS)
+		adi_xint_RegisterCallback(id_map_event[irq_id], 0, 0);
+	else if (aducm_desc->conf[irq_id].uart_conf) //irq_id = UART_ID
+		if (SUCCESS != uart_register_callback(
+			    aducm_desc->conf[irq_id].uart_conf, NULL,
+			    NULL))
+			return FAILURE;
+
+	aducm_desc->conf[irq_id].uart_conf = 0;
+	aducm_desc->conf[irq_id].xint_conf = 0;
+	aducm_desc->callback_configured[irq_id] = false;
+
+	return irq_disable(desc, irq_id);
+}
+
+/**
+ * @brief Free the resources allocated by \ref irq_ctrl_init()
+ * @param desc - Interrupt controller descriptor.
+ * @return \ref SUCCESS in case of success, \ref FAILURE otherwise.
+ */
+int32_t irq_ctrl_remove(struct irq_ctrl_desc *desc)
+{
+	uint32_t i;
+
+	if (!desc || !desc->extra || !initialized)
+		return FAILURE;
+
+	/* Free external interrupts */
+	for (i = 0; i < NB_EXT_INTERRUPTS; i++)
+		adi_xint_DisableIRQ(id_map_event[i]);
+	adi_xint_UnInit();
+
+	/* Free UART */
+	irq_unregister(desc, ADUCM_UART_INT_ID);
+	free(desc->extra);
+	free(desc);
+	initialized = 0;
 
 	return SUCCESS;
 }
 
 /**
- * @brief Enable all previously enabled interrupts by \ref irq_source_enable().
+ * @brief Registers a IRQ callback function to irq controller.
+ * @param desc - The IRQ controller descriptor.
+ * @param irq_id - Interrupt identifier.
+ * @param callback_desc - Descriptor of the callback. If it is NULL, the
+ * callback will be unregistered
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t irq_register_callback(struct irq_ctrl_desc *desc, uint32_t irq_id,
+			      struct callback_desc *callback_desc)
+{
+	struct aducm_irq_ctrl_desc	*aducm_desc;
+	struct uart_desc		*uart_desc;
+
+	if (!desc || !desc->extra || !initialized ||  irq_id >= NB_INTERRUPTS)
+		return FAILURE;
+
+	if (!callback_desc)
+		return irq_unregister(desc, irq_id);
+
+	aducm_desc = desc->extra;
+
+	if (irq_id < NB_EXT_INTERRUPTS) {
+		aducm_desc->conf[irq_id].xint_conf =
+			(enum irq_mode)callback_desc->callback_config;
+		adi_xint_RegisterCallback(id_map_event[irq_id],
+					  callback_desc->callback,
+					  callback_desc->callback_ctx);
+	} else { //if (irq_id == ADUCM_UART_INT_ID) {
+		uart_desc = (struct uart_desc *)callback_desc->callback_config;
+		aducm_desc->conf[irq_id].uart_conf = uart_desc;
+		if (!uart_desc)
+			return FAILURE;
+		if (SUCCESS != uart_register_callback(uart_desc,
+						      callback_desc->callback,
+						      callback_desc->callback_ctx))
+			return FAILURE;
+	}
+
+	aducm_desc->callback_configured[irq_id] = true;
+	return SUCCESS;
+}
+
+/**
+ * @brief Enable all previously enabled interrupts by \ref irq_enable().
  * @param desc - Interrupt controller descriptor.
  * @return \ref SUCCESS
  */
 int32_t irq_global_enable(struct irq_ctrl_desc *desc)
 {
-	struct aducm_irq_desc *aducm_desc;
+	struct aducm_irq_ctrl_desc *aducm_desc;
 	if (!desc || !desc->extra || !initialized)
 		return FAILURE;
 
@@ -208,6 +234,8 @@ int32_t irq_global_enable(struct irq_ctrl_desc *desc)
 	for (uint32_t i = 0; i < NB_EXT_INTERRUPTS; i++)
 		if (aducm_desc->enabled & (1u << i))
 			NVIC_EnableIRQ(BASE_XINT_NB + i);
+	if (aducm_desc->enabled & (1u << ADUCM_UART_INT_ID))
+		NVIC_EnableIRQ(id_map_event[ADUCM_UART_INT_ID]);
 
 	return SUCCESS;
 }
@@ -219,7 +247,7 @@ int32_t irq_global_enable(struct irq_ctrl_desc *desc)
  */
 int32_t irq_global_disable(struct irq_ctrl_desc *desc)
 {
-	struct aducm_irq_desc *aducm_desc;
+	struct aducm_irq_ctrl_desc *aducm_desc;
 	if (!desc || !desc->extra || !initialized)
 		return FAILURE;
 
@@ -227,6 +255,8 @@ int32_t irq_global_disable(struct irq_ctrl_desc *desc)
 	for (uint32_t i = 0; i < NB_EXT_INTERRUPTS; i++)
 		if (aducm_desc->enabled & (1u << i))
 			NVIC_DisableIRQ(BASE_XINT_NB + i);
+	if (aducm_desc->enabled & (1u << ADUCM_UART_INT_ID))
+		NVIC_DisableIRQ(id_map_event[ADUCM_UART_INT_ID]);
 
 	return SUCCESS;
 }
@@ -246,19 +276,23 @@ int32_t irq_global_disable(struct irq_ctrl_desc *desc)
  * @param irq_id - Id of the interrupt
  * @return \ref SUCCESS in case of success, \ref FAILURE otherwise.
  */
-int32_t irq_source_enable(struct irq_ctrl_desc *desc, uint32_t irq_id)
+int32_t irq_enable(struct irq_ctrl_desc *desc, uint32_t irq_id)
 {
-	struct aducm_irq_desc *aducm_desc;
+	struct aducm_irq_ctrl_desc *aducm_desc;
 
 	if (!desc || !desc->extra || !initialized ||
-	    irq_id >= NB_EXT_INTERRUPTS)
+	    irq_id >= NB_INTERRUPTS)
 		return FAILURE;
 	aducm_desc = desc->extra;
-	if (aducm_desc->irq_handler[irq_id] == NULL)
+
+	if (!aducm_desc->callback_configured[irq_id])
 		return FAILURE;
 
-	adi_xint_EnableIRQ(id_map_event[irq_id],
-			   (ADI_XINT_IRQ_MODE)aducm_desc->mode[irq_id]);
+	if (irq_id < NB_EXT_INTERRUPTS)
+		adi_xint_EnableIRQ(id_map_event[irq_id],
+				   aducm_desc->conf[irq_id].xint_conf);
+	else //if (irq_id == ADUCM_UART_INT_ID)
+		NVIC_EnableIRQ(id_map_event[irq_id]);
 	aducm_desc->enabled |= (1u << irq_id);
 
 	return SUCCESS;
@@ -270,16 +304,19 @@ int32_t irq_source_enable(struct irq_ctrl_desc *desc, uint32_t irq_id)
  * @param irq_id - Id of the interrupt
  * @return \ref SUCCESS in case of success, \ref FAILURE otherwise.
  */
-int32_t irq_source_disable(struct irq_ctrl_desc *desc, uint32_t irq_id)
+int32_t irq_disable(struct irq_ctrl_desc *desc, uint32_t irq_id)
 {
-	struct aducm_irq_desc *aducm_desc;
+	struct aducm_irq_ctrl_desc *aducm_desc;
 
 	if (!desc || !desc->extra || !initialized ||
-	    irq_id >= NB_EXT_INTERRUPTS)
+	    irq_id >= NB_INTERRUPTS)
 		return FAILURE;
 
 	aducm_desc = desc->extra;
-	adi_xint_DisableIRQ(id_map_event[irq_id]);
+	if (irq_id < NB_EXT_INTERRUPTS)
+		adi_xint_DisableIRQ(id_map_event[irq_id]);
+	else //if (irq_id == ADUCM_UART_INT_ID)
+		NVIC_DisableIRQ(id_map_event[irq_id]);
 	aducm_desc->enabled &= ~(1u << irq_id);
 
 	return SUCCESS;

--- a/drivers/platform/aducm3029/irq_extra.h
+++ b/drivers/platform/aducm3029/irq_extra.h
@@ -62,7 +62,7 @@
 /******************************************************************************/
 
 /**
- * @enum uart_irq_id
+ * @enum irq_id
  * @brief Interrupts IDs supported by the irq driver
  */
 enum irq_id {

--- a/drivers/platform/aducm3029/irq_extra.h
+++ b/drivers/platform/aducm3029/irq_extra.h
@@ -45,17 +45,38 @@
 /******************************************************************************/
 
 #include <drivers/xint/adi_xint.h>
+#include <stdbool.h>
+#include "irq.h"
 
 /******************************************************************************/
 /********************** Macros and Constants Definitions **********************/
 /******************************************************************************/
 
-/** Number of available external interrupts */
-#define NB_EXT_INTERRUPTS	4u
+
+
+/** Number of available interrupts */
+#define NB_INTERRUPTS		5u
 
 /******************************************************************************/
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
+
+/**
+ * @enum uart_irq_id
+ * @brief Interrupts IDs supported by the irq driver
+ */
+enum irq_id {
+	/** External interrupt 0, on GPIO 15 */
+	ADUCM_EXTERNAL_INT0_ID,
+	/** External interrupt 0, on GPIO 16 */
+	ADUCM_EXTERNAL_INT1_ID,
+	/** External interrupt 0, on GPIO 13 */
+	ADUCM_EXTERNAL_INT2_ID,
+	/** External interrupt 0, on GPIO 33 */
+	ADUCM_EXTERNAL_INT3_ID,
+	/** UART interrupt ID*/
+	ADUCM_UART_INT_ID
+};
 
 /**
  * @enum irq_mode
@@ -75,14 +96,25 @@ enum irq_mode {
 };
 
 /**
- * @struct aducm_irq_desc
+ * @union irq_config
+ * @brief Configuration for the callback
+ */
+union irq_config {
+	/** UART descriptor */
+	struct uart_desc	*uart_conf;
+	/** Trigger condition for the external interrupt */
+	enum irq_mode		xint_conf;
+};
+
+/**
+ * @struct aducm_irq_ctrl_desc
  * @brief Stores specific platform parameters
  */
-struct aducm_irq_desc {
-	/** Callback that will be called when the interrupt occurs*/
-	void 			(*irq_handler[NB_EXT_INTERRUPTS])(void *irq_id);
-	/** Trigger condition for the external interrupt */
-	enum irq_mode		mode[NB_EXT_INTERRUPTS];
+struct aducm_irq_ctrl_desc {
+	/** Configuration for each interrupt */
+	union irq_config	conf[NB_INTERRUPTS];
+	/** Store if a callback has been configured */
+	bool			callback_configured[NB_INTERRUPTS];
 	/** Memory needed by the ADI IRQ driver */
 	uint8_t			irq_memory[ADI_XINT_MEMORY_SIZE];
 	/** Stores the enabled interrupts */

--- a/drivers/platform/aducm3029/uart_extra.h
+++ b/drivers/platform/aducm3029/uart_extra.h
@@ -45,39 +45,13 @@
 /******************************************************************************/
 
 #include <drivers/uart/adi_uart.h>
-#include <drivers/pwr/adi_pwr.h>
 #include <stdint.h>
 #include "error.h"
+#include "irq.h"
 
 /******************************************************************************/
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
-
-/**
- * @enum UART_EVENT
- * @brief Possible events for \ref UART_CALLBACK
- */
-enum UART_EVENT {
-	/** Write operation finalized */
-	WRITE_DONE,
-	/** Read operation finalized */
-	READ_DONE,
-	/** An error occurred */
-	ERROR
-};
-
-/**
- * @typedef UART_CALLBACK
- * @brief Signature of the function for
- * callback parameter from \ref aducm_uart_init_param
- */
-typedef void (*UART_CALLBACK) (
-	/** Parameter set by the user */
-	void		*app_param,
-	/** Event given by the driver */
-	enum UART_EVENT	event,
-	/** Processed buffer or error code */
-	uint8_t		*data);
 
 /**
  * @enum UART_ERROR
@@ -203,10 +177,6 @@ struct aducm_uart_init_param {
 	enum UART_STOPBITS	stop_bits;
 	/** Set the word length */
 	enum UART_WORDLEN	word_length;
-	/** Set a callback to be called when an operation is done (optional)*/
-	UART_CALLBACK		callback;
-	/** Set a parameter to be passed to the callback as app_param */
-	void			*param;
 };
 
 /**
@@ -220,9 +190,10 @@ struct aducm_uart_desc {
 	/** Stores the error occurred */
 	enum UART_ERROR	errors;
 	/** Set a callback to be called when an operation is done (optional) */
-	UART_CALLBACK	callback;
+	void		(*callback)(void *callback_ctx, uint32_t event,
+				    void *extra);
 	/** Set a parameter to be passed to the callback as app_param */
-	void		*param;
+	void		*callback_ctx;
 	/**
 	 * Buffer needed by the ADI UART driver to operate.
 	 * This buffer allocated and aligned at runtime to 32 bits
@@ -244,5 +215,14 @@ struct aducm_uart_desc {
 	 */
 	uint32_t	waiting_write_callback;
 };
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+int32_t uart_register_callback(struct uart_desc *desc,
+			       void (*callback)(void *callback_ctx,
+					       uint32_t event, void *extra),
+			       void *callback_ctx);
 
 #endif /* UART_H_ */

--- a/drivers/wifi/wifi.c
+++ b/drivers/wifi/wifi.c
@@ -1,0 +1,119 @@
+#include "wifi.h"
+#include "uart.h"
+#include "uart_extra.h"
+#include "error.h"
+#include "irq.h"
+#include "irq_extra.h"
+#include <stdlib.h>
+
+void uart_callback(void *ctx, uint32_t event, void *extra)
+{
+	struct wifi_desc *wifi = ctx;
+
+	switch (event) {
+	case READ_DONE:
+		if (wifi->wait_full_read) {
+			wifi->read_done = true;
+			wifi->wait_full_read = false;
+		} else if (*wifi->buff == ':') {
+			wifi->wait_full_read = true;
+			uart_read(wifi->uart, wifi->buff, 100);
+			break;
+		}
+		uart_read(wifi->uart, wifi->buff, 1);
+		break;
+	case WRITE_DONE:
+		wifi->write_done = true;
+		break;
+	case ERROR:
+		break;
+	}
+}
+
+uint32_t wifi_init(struct wifi_desc **desc,
+		   const struct wifi_init_param *param)
+{
+	struct wifi_desc *wifi;
+	struct callback_desc call;
+	wifi = calloc(1, sizeof(*wifi));
+
+	wifi->irq = param->irq;
+	wifi->uart = param->uart;
+	wifi->uart_irq_id = param->uart_irq_id;
+
+	call.callback = uart_callback;
+	call.callback_ctx = wifi;
+	call.callback_config = wifi->uart;
+
+	irq_register_callback(wifi->irq, wifi->uart_irq_id, &call);
+	irq_enable(wifi->irq, wifi->uart_irq_id);
+
+	wifi->read_done = false;
+	uart_read(wifi->uart, wifi->buff, 1);
+
+	*desc = wifi;
+	return SUCCESS;
+}
+
+uint32_t wifi_write(struct wifi_desc *desc, uint8_t *buff, uint32_t len)
+{
+	desc->write_done = false;
+	uart_write(desc->uart, buff, len);
+	while (!desc->write_done)
+		;
+	return SUCCESS;
+}
+
+uint32_t wifi_read(struct wifi_desc *desc, uint8_t *buff, uint32_t len)
+{
+	while (!desc->read_done)
+		;
+
+	memcpy(buff, desc->buff, len);
+
+	return SUCCESS;
+}
+
+#include <stdio.h>
+
+void dummy_wifi_driver_test()
+{
+
+	struct uart_desc	*uart_desc;
+	struct irq_ctrl_desc	*desc;
+
+	struct aducm_uart_init_param aducm_param = {
+		.parity = UART_NO_PARITY,
+		.stop_bits = UART_ONE_STOPBIT,
+		.word_length = UART_WORDLEN_8BITS
+	};
+	struct uart_init_param uart_param = {
+		.device_id = 0,
+		.baud_rate = BD_115200,
+		.extra = &aducm_param
+	};
+
+	struct irq_init_param param = {
+		.irq_ctrl_id = 0,
+		.extra = 0
+	};
+
+	uart_init(&uart_desc, &uart_param);
+	irq_ctrl_init(&desc, &param);
+
+	struct wifi_desc *wifi;
+	struct wifi_init_param wifi_param = {
+		.irq = desc,
+		.uart = uart_desc,
+		.uart_irq_id = ADUCM_UART_INT_ID
+	};
+
+	wifi_init(&wifi, &wifi_param);
+
+	wifi_write(wifi,"AT\r\n", 4);
+
+	uint8_t buff[1000];
+	wifi_read(wifi, buff, 100);
+	buff[100] = 0;
+	printf("%s\n", buff);
+}

--- a/drivers/wifi/wifi.h
+++ b/drivers/wifi/wifi.h
@@ -1,0 +1,29 @@
+#ifndef WIFI_H
+# define WIFI_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+struct wifi_desc {
+	uint8_t			buff[1000];
+	struct uart_desc	*uart;
+	struct irq_ctrl_desc	*irq;
+	uint32_t		uart_irq_id;
+	bool			read_done;
+	bool			write_done;
+	bool			wait_full_read;
+};
+struct wifi_init_param {
+	struct uart_desc	*uart;
+	struct irq_ctrl_desc	*irq;
+	uint32_t		uart_irq_id;
+};
+
+uint32_t wifi_init(struct wifi_desc **desc,
+		   const struct wifi_init_param *param);
+
+uint32_t wifi_write(struct wifi_desc *desc, uint8_t *buff, uint32_t len);
+
+uint32_t wifi_read(struct wifi_desc *desc, uint8_t *buff, uint32_t len);
+
+#endif

--- a/include/irq.h
+++ b/include/irq.h
@@ -51,6 +51,19 @@
 /******************************************************************************/
 
 /**
+ * @enum irq_uart_event_e
+ * @brief Possible events for uart interrupt
+ */
+enum irq_uart_event_e {
+	/** Write operation finalized */
+	WRITE_DONE,
+	/** Read operation finalized */
+	READ_DONE,
+	/** An error occurred */
+	ERROR
+};
+
+/**
  * @struct irq_init_param
  * @brief Structure holding the initial parameters for Interrupt Request.
  */
@@ -72,6 +85,24 @@ struct irq_ctrl_desc {
 	void		*extra;
 };
 
+/**
+ * @struct callback_desc
+ * @brief Structure describing a callback to be registered
+ */
+struct callback_desc {
+	/**
+	 * Callback to be called when the event an event occurs
+	 *  @param callback_ctx - Same as \ref callback_desc.callback_ctx
+	 *  @param event - Event that generated the callback
+	 *  @param extra - Platform specific data
+	 */
+	void (*callback)(void *callback_ctx, uint32_t event, void *extra);
+	/** Parameter to be passed when the callback is called */
+	void *callback_ctx;
+	/** Platform specific configuration for a callback */
+	void *callback_config;
+};
+
 /******************************************************************************/
 /************************ Functions Declarations ******************************/
 /******************************************************************************/
@@ -83,30 +114,19 @@ int32_t irq_ctrl_init(struct irq_ctrl_desc **desc,
 /* Free the resources allocated by irq_ctrl_init(). */
 int32_t irq_ctrl_remove(struct irq_ctrl_desc *desc);
 
-/**
- * @brief Registers a IRQ handling function to irq controller.
- * @param desc - The IRQ controller descriptor.
- * @param irq_id - Interrupt identifier.
- * @param irq_handler - The IRQ handler.
- * @param dev_instance - device instance.
- * @return SUCCESS in case of success, FAILURE otherwise.
- */
-int32_t irq_register(struct irq_ctrl_desc *desc, uint32_t irq_id,
-		     void (*irq_handler)(void *data), void *dev_instance);
+/* Register a callback to handle the irq events */
+int32_t irq_register_callback(struct irq_ctrl_desc *desc, uint32_t irq_id,
+			      struct callback_desc *callback_desc);
+/* Enable specific interrupt */
+int32_t irq_enable(struct irq_ctrl_desc *desc, uint32_t irq_id);
 
-/* Unregisters a generic IRQ handling function */
-int32_t irq_unregister(struct irq_ctrl_desc *desc, uint32_t irq_id);
+/* Disable specific interrupt */
+int32_t irq_disable(struct irq_ctrl_desc *desc, uint32_t irq_id);
 
 /* Global interrupt enable */
 int32_t irq_global_enable(struct irq_ctrl_desc *desc);
 
 /* Global interrupt disable */
 int32_t irq_global_disable(struct irq_ctrl_desc *desc);
-
-/* Enable specific interrupt */
-int32_t irq_source_enable(struct irq_ctrl_desc *desc, uint32_t irq_id);
-
-/* Disable specific interrupt */
-int32_t irq_source_disable(struct irq_ctrl_desc *desc, uint32_t irq_id);
 
 #endif // IRQ_H_


### PR DESCRIPTION
- Change irq_register_interrupt -> irq_register_callback
- Add uart interrupt support in aducm/uart.c and adumc/irq.c

These change are needed to support ashynchrnous operations over uart

\+

Dummy wifi example