### PR TITLE
projects: fix typos

### DIFF
--- a/projects/ad9172/src/main.c
+++ b/projects/ad9172/src/main.c
@@ -200,7 +200,7 @@ int main(void)
 
 	status = axi_jesd204_tx_init(&tx_jesd, &tx_jesd_init);
 	if (status != SUCCESS) {
-		printf("error: %s: axi_jesd204_rx_init() failed\n", tx_jesd_init.name);
+		printf("error: %s: axi_jesd204_tx_init() failed\n", tx_jesd_init.name);
 		goto error_2;
 	}
 

--- a/projects/ad9371/src/app/headless.c
+++ b/projects/ad9371/src/app/headless.c
@@ -464,7 +464,7 @@ int main(void)
 	}
 	status = axi_jesd204_tx_init(&tx_jesd, &tx_jesd_init);
 	if (status != SUCCESS) {
-		printf("error: %s: axi_jesd204_rx_init() failed\n", rx_jesd_init.name);
+		printf("error: %s: axi_jesd204_tx_init() failed\n", tx_jesd_init.name);
 		goto error_5;
 	}
 	status = axi_jesd204_rx_init(&rx_os_jesd, &rx_os_jesd_init);


### PR DESCRIPTION
Minor typos found in main functions of ad9172 and ad9371 projects.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>