### PR TITLE
axi_core: altera_a10_atx_pll: fix round rate

### DIFF
--- a/drivers/axi_core/jesd204/altera_a10_atx_pll.c
+++ b/drivers/axi_core/jesd204/altera_a10_atx_pll.c
@@ -199,8 +199,8 @@ int32_t altera_a10_atx_pll_round_rate(struct adxcvr *xcvr,
 	if (n == 0 || m == 0 || l == 0)
 		return -1;
 
-	tmp = xcvr->parent_rate_khz * m;
-	tmp = DIV_ROUND_CLOSEST_ULL(tmp, l * n / 4);
+	tmp = xcvr->parent_rate_khz * m * 4;
+	tmp = DIV_ROUND_CLOSEST_ULL(tmp, l * n);
 
 	return min_t(uint64_t, tmp, LONG_MAX);
 }


### PR DESCRIPTION
Fix `altera_a10_atx_pll_round_rate` function by applying the correct
formulas.

The reference for this fix can be found in
/common_drivers/xcvr_core/xcvr_modules/altera_a10_atx_pll.c

Fixes: e1b717fb576ab9e3776271f8aa49a0c5689a1e03

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>