### PR TITLE
include:error.h Create define to check function result

### DIFF
--- a/include/error.h
+++ b/include/error.h
@@ -51,4 +51,6 @@
 #define FAILURE		-1
 #endif
 
+#define IS_ERR_VALUE(x)	((x) < 0)
+
 #endif // ERROR_H_


### PR DESCRIPTION
With this macros, checking the result of no-os functions will be more readable:
Old:
    if (SUCCESS != spi_init())
         goto handle_fail;
New:
   if (RET_FAIL(spi_init())
        goto handle_fail;

Signed-off-by: Mihail Chindris <mihail.chindris@analog.com>