### PR TITLE
drivers:platform:xilinx: update I2C driver for multiple instances

### DIFF
--- a/drivers/platform/xilinx/i2c_extra.h
+++ b/drivers/platform/xilinx/i2c_extra.h
@@ -80,6 +80,8 @@ typedef struct xil_i2c_init {
 typedef struct xil_i2c_desc {
 	/** Xilinx architecture */
 	enum xil_i2c_type	type;
+	/** Device ID */
+	uint32_t		device_id;
 	/** Xilinx I2C configuration */
 	void			*config;
 	/** Xilinx I2C Instance */


### PR DESCRIPTION
The I2C driver needs to accustom devices on the same I2C bus. Add support
to init and remove multiple instances of the driver on the same bus without
re-initializing the core or BSP driver. Add support to change transmission
parameters like bit rate and slave address at every transmission, if
necessary.

Signed-off-by: Andrei Drimbarean <Andrei.Drimbarean@analog.com>