### PR TITLE
Added No-OS driver support for AD5674, AD5679, AD5687, AD5687R, AD568…

### DIFF
--- a/drivers/dac/ad5686/ad5686.c
+++ b/drivers/dac/ad5686/ad5686.c
@@ -3,7 +3,7 @@
 *   @brief  Implementation of AD5686 Driver.
 *   @author Istvan Csomortani (istvan.csomortani@analog.com)
 *******************************************************************************
-* Copyright 2013(c) Analog Devices, Inc.
+* Copyright 2013, 2020(c) Analog Devices, Inc.
 *
 * All rights reserved.
 *
@@ -51,6 +51,11 @@
 /*****************************************************************************/
 static const uint32_t ad5683_channel_addr [] = {
 	[AD5686_CH_0] = 0,
+};
+
+static const uint32_t ad5689_channel_addr[] = {
+	[AD5686_CH_0] = 1,
+	[AD5686_CH_1] = 8,
 };
 
 static const uint32_t ad5686_channel_addr[] = {
@@ -109,6 +114,12 @@ static const struct ad5686_chip_info chip_info[] = {
 		.communication = I2C,
 		.channel_addr = ad5679_channel_addr,
 	},
+	[ID_AD5674] = {
+		.resolution = 12,
+		.register_map = AD5686_REG_MAP,
+		.communication = SPI,
+		.channel_addr = ad5679_channel_addr,
+	},
 	[ID_AD5674R] = {
 		.resolution = 12,
 		.register_map = AD5686_REG_MAP,
@@ -137,6 +148,12 @@ static const struct ad5686_chip_info chip_info[] = {
 		.resolution = 16,
 		.register_map = AD5686_REG_MAP,
 		.communication = I2C,
+		.channel_addr = ad5679_channel_addr,
+	},
+	[ID_AD5679] = {
+		.resolution = 16,
+		.register_map = AD5686_REG_MAP,
+		.communication = SPI,
 		.channel_addr = ad5679_channel_addr,
 	},
 	[ID_AD5679R] = {
@@ -168,6 +185,36 @@ static const struct ad5686_chip_info chip_info[] = {
 		.register_map = AD5686_REG_MAP,
 		.communication = SPI,
 		.channel_addr = ad5686_channel_addr,
+	},
+	[ID_AD5687] = {
+		.resolution = 12,
+		.register_map = AD5686_REG_MAP,
+		.communication = SPI,
+		.channel_addr = ad5689_channel_addr,
+	},
+	[ID_AD5687R] = {
+		.resolution = 12,
+		.register_map = AD5686_REG_MAP,
+		.communication = SPI,
+		.channel_addr = ad5689_channel_addr,
+	},
+	[ID_AD5689] = {
+		.resolution = 16,
+		.register_map = AD5686_REG_MAP,
+		.communication = SPI,
+		.channel_addr = ad5689_channel_addr,
+	},
+	[ID_AD5689R] = {
+		.resolution = 16,
+		.register_map = AD5686_REG_MAP,
+		.communication = SPI,
+		.channel_addr = ad5689_channel_addr,
+	},
+	[ID_AD5697R] = {
+		.resolution = 12,
+		.register_map = AD5686_REG_MAP,
+		.communication = I2C,
+		.channel_addr = ad5689_channel_addr,
 	},
 	[ID_AD5694] = {
 		.resolution = 12,

--- a/drivers/dac/ad5686/ad5686.h
+++ b/drivers/dac/ad5686/ad5686.h
@@ -5,7 +5,7 @@
 *
 *   @author Istvan Csomortani (istvan.csomortani@analog.com)
 ********************************************************************************
-* Copyright 2013(c) Analog Devices, Inc.
+* Copyright 2013, 2020(c) Analog Devices, Inc.
 *
 * All rights reserved.
 *
@@ -122,16 +122,23 @@ enum ad5686_type {
 	ID_AD5671R,
 	ID_AD5672R,
 	ID_AD5673R,
+	ID_AD5674,
 	ID_AD5674R,
 	ID_AD5675R,
 	ID_AD5676,
 	ID_AD5676R,
 	ID_AD5677R,
+	ID_AD5679,
 	ID_AD5679R,
 	ID_AD5686,
 	ID_AD5684R,
 	ID_AD5685R,
 	ID_AD5686R,
+	ID_AD5687,
+	ID_AD5687R,
+	ID_AD5689,
+	ID_AD5689R,
+	ID_AD5697R,
 	ID_AD5694,
 	ID_AD5694R,
 	ID_AD5695R,


### PR DESCRIPTION
Added No-OS driver support for AD5674, AD5679, AD5687, AD5687R, AD5689, AD5689R and AD5697R nanodac+ devices