### PR TITLE
drivers: freq: ad9528: check if hw reset enabled

### DIFF
--- a/drivers/frequency/ad9528/ad9528.c
+++ b/drivers/frequency/ad9528/ad9528.c
@@ -374,18 +374,18 @@ int32_t ad9528_setup(struct ad9528_dev **device,
 
 	dev->pdata = init_param.pdata;
 
-	/* GPIO */
-	ret = gpio_get(&dev->gpio_resetb, &init_param.gpio_resetb);
-	if (ret < 0)
-		return ret;
-
 	/* SPI */
 	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 	if (ret < 0)
 		return ret;
 
-	ad9528_reset(dev);
-
+	/* GPIO */
+	if(init_param.hw_reset_en) {
+		ret = gpio_get(&dev->gpio_resetb, &init_param.gpio_resetb);
+		if (ret < 0)
+			return ret;
+		ad9528_reset(dev);
+	}
 	ret = ad9528_spi_write_n(dev,
 				 AD9528_SERIAL_PORT_CONFIG,
 				 AD9528_SER_CONF_SOFT_RESET |

--- a/drivers/frequency/ad9528/ad9528.h
+++ b/drivers/frequency/ad9528/ad9528.h
@@ -491,6 +491,7 @@ struct ad9528_init_param {
 	/* SPI */
 	spi_init_param spi_init;
 	/* GPIO */
+	bool hw_reset_en;
 	gpio_init_param gpio_resetb;
 	/* Device Settings */
 	struct ad9528_platform_data *pdata;

--- a/projects/adrv9009/src/app/app_clocking.c
+++ b/projects/adrv9009/src/app/app_clocking.c
@@ -428,6 +428,7 @@ adiHalErr_t clocking_init(uint32_t rx_div40_rate_hz,
 		.extra = &xil_gpio_param
 	};
 	ad9528_param.gpio_resetb = clkchip_gpio_init_param;
+	ad9528_param.hw_reset_en = true;
 #endif
 
 	/** < Insert User System Clock(s) Initialization Code Here >


### PR DESCRIPTION
Not all projects that use ad9528 driver have a gpio connected to the
reset pin of the device.

This patch adds a `hw_reset_en` parameter to the device initialization
structure that is used to verify if hardware reset can be performed.

Update adrv9009 project to use the latest feature of the driver.

Fixes: a223f817f40aed7a33ade8b472855f0632171f73

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>