### PR TITLE
include:uart Add nonblocking functions + support for aducm3029

### DIFF
--- a/drivers/platform/aducm3029/uart_extra.h
+++ b/drivers/platform/aducm3029/uart_extra.h
@@ -45,39 +45,13 @@
 /******************************************************************************/
 
 #include <drivers/uart/adi_uart.h>
-#include <drivers/pwr/adi_pwr.h>
 #include <stdint.h>
 #include "error.h"
+#include "irq.h"
 
 /******************************************************************************/
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
-
-/**
- * @enum UART_EVENT
- * @brief Possible events for \ref UART_CALLBACK
- */
-enum UART_EVENT {
-	/** Write operation finalized */
-	WRITE_DONE,
-	/** Read operation finalized */
-	READ_DONE,
-	/** An error occurred */
-	ERROR
-};
-
-/**
- * @typedef UART_CALLBACK
- * @brief Signature of the function for
- * callback parameter from \ref aducm_uart_init_param
- */
-typedef void (*UART_CALLBACK) (
-	/** Parameter set by the user */
-	void		*app_param,
-	/** Event given by the driver */
-	enum UART_EVENT	event,
-	/** Processed buffer or error code */
-	uint8_t		*data);
 
 /**
  * @enum UART_ERROR
@@ -203,10 +177,19 @@ struct aducm_uart_init_param {
 	enum UART_STOPBITS	stop_bits;
 	/** Set the word length */
 	enum UART_WORDLEN	word_length;
-	/** Set a callback to be called when an operation is done (optional)*/
-	UART_CALLBACK		callback;
-	/** Set a parameter to be passed to the callback as app_param */
-	void			*param;
+};
+
+/**
+ * @struct op_desc
+ * @brief It stores the state of a operation
+ */
+struct op_desc {
+	/** Is set when an write nonblocking operation is executing */
+	bool		is_nonblocking;
+	/** Current buffer*/
+	uint8_t		*buff;
+	/** Number of bytes pending to process */
+	uint32_t	pending;
 };
 
 /**
@@ -219,10 +202,6 @@ struct aducm_uart_desc {
 	ADI_UART_HANDLE	uart_handler;
 	/** Stores the error occurred */
 	enum UART_ERROR	errors;
-	/** Set a callback to be called when an operation is done (optional) */
-	UART_CALLBACK	callback;
-	/** Set a parameter to be passed to the callback as app_param */
-	void		*param;
 	/**
 	 * Buffer needed by the ADI UART driver to operate.
 	 * This buffer allocated and aligned at runtime to 32 bits
@@ -233,16 +212,15 @@ struct aducm_uart_desc {
 	 * Needed to deallocate \ref adi_uart_buffer
 	 */
 	uint32_t	adi_uart_buffer_offset;
-	/**
-	 * Boolean value used in CALLBACK_MODE. Is set when \ref uart_read is
-	 * called and reset when the buffer is processed
-	 */
-	uint32_t	waiting_read_callback;
-	/**
-	 * Boolean value used in CALLBACK_MODE. Is set when \ref uart_write
-	 * is called and reset when the buffer is processed
-	 */
-	uint32_t	waiting_write_callback;
+	/** Status of a write operation */
+	struct op_desc	write_desc;
+	/** Status of a read operation */
+	struct op_desc	read_desc;
 };
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
 
 #endif /* UART_H_ */

--- a/drivers/platform/generic/uart.c
+++ b/drivers/platform/generic/uart.c
@@ -98,6 +98,60 @@ int32_t uart_write(struct uart_desc *desc, const uint8_t *data,
 }
 
 /**
+ * @brief Submit reading buffer to the UART driver.
+ *
+ * Buffer is used until bytes_number bytes are read.
+ * @param desc:	Descriptor of the UART device
+ * @param data:	Buffer where data will be read
+ * @param bytes_number:	Number of bytes to be read.
+ * @return \ref SUCCESS in case of success, \ref FAILURE otherwise.
+ */
+int32_t uart_read_nonblocking(struct uart_desc *desc, uint8_t *data,
+			      uint32_t bytes_number)
+{
+	if (desc) {
+		// Unused variable - fix compiler warning
+	}
+
+	if (data) {
+		// Unused variable - fix compiler warning
+	}
+
+	if (bytes_number) {
+		// Unused variable - fix compiler warning
+	}
+
+	return SUCCESS;
+}
+
+/**
+ * @brief Submit writting buffer to the UART driver.
+ *
+ * Data from the buffer is sent over the UART, the function returns imediatly.
+ * @param desc:	Descriptor of the UART device
+ * @param data:	Buffer where data will be written
+ * @param bytes_number:	Number of bytes to be written.
+ * @return \ref SUCCESS in case of success, \ref FAILURE otherwise.
+ */
+int32_t uart_write_nonblocking(struct uart_desc *desc, const uint8_t *data,
+			       uint32_t bytes_number)
+{
+	if (desc) {
+		// Unused variable - fix compiler warning
+	}
+
+	if (data) {
+		// Unused variable - fix compiler warning
+	}
+
+	if (bytes_number) {
+		// Unused variable - fix compiler warning
+	}
+
+	return SUCCESS;
+}
+
+/**
  * @brief Initialize the UART communication peripheral.
  * @param desc - The UART descriptor.
  * @param param - The structure that contains the UART parameters.

--- a/include/uart.h
+++ b/include/uart.h
@@ -79,12 +79,20 @@ struct uart_desc {
 /************************ Functions Declarations ******************************/
 /******************************************************************************/
 
-/* Read data to UART. */
+/* Read data from UART. Blocking function */
 int32_t uart_read(struct uart_desc *desc, uint8_t *data, uint32_t bytes_number);
 
-/* Write data to UART. */
+/* Write data to UART. Blocking function */
 int32_t uart_write(struct uart_desc *desc, const uint8_t *data,
 		   uint32_t bytes_number);
+
+/* Read data from UART. Non blocking function */
+int32_t uart_read_nonblocking(struct uart_desc *desc, uint8_t *data,
+			      uint32_t bytes_number);
+
+/* Write data to UART. Non blocking function*/
+int32_t uart_write_nonblocking(struct uart_desc *desc, const uint8_t *data,
+			       uint32_t bytes_number);
 
 /* Initialize the UART communication peripheral. */
 int32_t uart_init(struct uart_desc **desc, struct uart_init_param *param);


### PR DESCRIPTION
This changes where requested during the meeting about the irq_register_callback.
Only when using this function a callback will be generated for the uart.
A pull request for the irq will come soon.