### PR TITLE
include:irq Modification decided on no-os meeting

### DIFF
--- a/drivers/platform/aducm3029/irq.c
+++ b/drivers/platform/aducm3029/irq.c
@@ -194,7 +194,7 @@ int32_t irq_unregister(struct irq_ctrl_desc *desc, uint32_t irq_id)
 }
 
 /**
- * @brief Enable all previously enabled interrupts by \ref irq_source_enable().
+ * @brief Enable all previously enabled interrupts by \ref irq_enable().
  * @param desc - Interrupt controller descriptor.
  * @return \ref SUCCESS
  */
@@ -246,7 +246,7 @@ int32_t irq_global_disable(struct irq_ctrl_desc *desc)
  * @param irq_id - Id of the interrupt
  * @return \ref SUCCESS in case of success, \ref FAILURE otherwise.
  */
-int32_t irq_source_enable(struct irq_ctrl_desc *desc, uint32_t irq_id)
+int32_t irq_enable(struct irq_ctrl_desc *desc, uint32_t irq_id)
 {
 	struct aducm_irq_desc *aducm_desc;
 
@@ -270,7 +270,7 @@ int32_t irq_source_enable(struct irq_ctrl_desc *desc, uint32_t irq_id)
  * @param irq_id - Id of the interrupt
  * @return \ref SUCCESS in case of success, \ref FAILURE otherwise.
  */
-int32_t irq_source_disable(struct irq_ctrl_desc *desc, uint32_t irq_id)
+int32_t irq_disable(struct irq_ctrl_desc *desc, uint32_t irq_id)
 {
 	struct aducm_irq_desc *aducm_desc;
 

--- a/drivers/platform/aducm3029/irq_extra.h
+++ b/drivers/platform/aducm3029/irq_extra.h
@@ -79,10 +79,8 @@ enum irq_mode {
  * @brief Stores specific platform parameters
  */
 struct aducm_irq_desc {
-	/** Callback that will be called when the interrupt occurs*/
-	void 			(*irq_handler[NB_EXT_INTERRUPTS])(void *irq_id);
-	/** Trigger condition for the external interrupt */
-	enum irq_mode		mode[NB_EXT_INTERRUPTS];
+	/** Structure where user callback are stored */
+	struct callback_desc	callbacks[NB_EXT_INTERRUPTS];
 	/** Memory needed by the ADI IRQ driver */
 	uint8_t			irq_memory[ADI_XINT_MEMORY_SIZE];
 	/** Stores the enabled interrupts */

--- a/drivers/platform/xilinx/irq.c
+++ b/drivers/platform/xilinx/irq.c
@@ -177,7 +177,7 @@ int32_t irq_global_disable(struct irq_ctrl_desc *desc)
  * @param irq_id - Interrupt identifier.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t irq_source_enable(struct irq_ctrl_desc *desc, uint32_t irq_id)
+int32_t irq_enable(struct irq_ctrl_desc *desc, uint32_t irq_id)
 {
 	struct xil_irq_desc *xil_dev = desc->extra;
 
@@ -206,7 +206,7 @@ int32_t irq_source_enable(struct irq_ctrl_desc *desc, uint32_t irq_id)
  * @param irq_id - Interrupt identifier.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t irq_source_disable(struct irq_ctrl_desc *desc, uint32_t irq_id)
+int32_t irq_disable(struct irq_ctrl_desc *desc, uint32_t irq_id)
 {
 	struct xil_irq_desc *xil_dev = desc->extra;
 

--- a/drivers/platform/xilinx/irq.c
+++ b/drivers/platform/xilinx/irq.c
@@ -230,29 +230,30 @@ int32_t irq_disable(struct irq_ctrl_desc *desc, uint32_t irq_id)
 }
 
 /**
- * @brief Registers a generic IRQ handling function.
+ * @brief Register a callback to handle the irq events.
  * @param desc - The IRQ controller descriptor.
  * @param irq_id - Interrupt identifier.
- * @param irq_handler - The IRQ handler.
- * @param dev_instance - device instance.
+ * @param callback_desc - Callback descriptor
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t irq_register(struct irq_ctrl_desc *desc, uint32_t irq_id,
-		     void (*irq_handler)(void *data), void *dev_instance)
+int32_t irq_register_callback(struct irq_ctrl_desc *desc, uint32_t irq_id,
+			      struct callback_desc *callback_desc);
 {
 	struct xil_irq_desc *xil_dev = desc->extra;
 
 	switch(xil_dev->type) {
 	case IRQ_PS:
 #ifdef XSCUGIC_H
-		return XScuGic_Connect(xil_dev->instance, irq_id, irq_handler,
-				       dev_instance);
+		return XScuGic_Connect(xil_dev->instance, irq_id,
+				       callback_desc->callback,
+				       callback_desc->ctx);
 #endif
 		break;
 	case IRQ_PL:
 #ifdef XINTC_H
-		return XIntc_Connect(xil_dev->instance, irq_id, irq_handler,
-				     dev_instance);
+		return XIntc_Connect(xil_dev->instance, irq_id,
+				     callback_desc->callback,
+				     callback_desc->ctx);
 #endif
 		break;
 	default:

--- a/drivers/platform/xilinx/uart.c
+++ b/drivers/platform/xilinx/uart.c
@@ -67,7 +67,7 @@ static int32_t uart_fifo_insert(struct uart_desc *desc)
 	struct irq_ctrl_desc *irq_desc = xil_uart_desc->irq_desc;
 
 	if (xil_uart_desc->bytes_received > 0) {
-		ret = irq_source_disable(irq_desc, xil_uart_desc->irq_id);
+		ret = irq_disable(irq_desc, xil_uart_desc->irq_id);
 		if (ret < 0)
 			return ret;
 		ret = fifo_insert(&xil_uart_desc->fifo, xil_uart_desc->buff,
@@ -89,7 +89,7 @@ static int32_t uart_fifo_insert(struct uart_desc *desc)
 			return FAILURE;
 			break;
 		}
-		ret = irq_source_enable(irq_desc, xil_uart_desc->irq_id);
+		ret = irq_enable(irq_desc, xil_uart_desc->irq_id);
 		if (ret < 0)
 			return ret;
 	}
@@ -276,7 +276,7 @@ static int32_t uart_irq_init(struct uart_desc *descriptor)
 		break;
 	}
 
-	status = irq_source_enable(xil_uart_desc->irq_desc, xil_uart_desc->irq_id);
+	status = irq_enable(xil_uart_desc->irq_desc, xil_uart_desc->irq_id);
 	if (status < 0)
 		return status;
 

--- a/drivers/platform/xilinx/uart.c
+++ b/drivers/platform/xilinx/uart.c
@@ -247,12 +247,16 @@ static int32_t uart_irq_init(struct uart_desc *descriptor)
 	int32_t status;
 	uint32_t uart_irq_mask;
 	struct xil_uart_desc *xil_uart_desc = descriptor->extra;
+	struct callback_desc callback_desc;
 
 	switch(xil_uart_desc->type) {
 	case UART_PS:
 #ifdef XUARTPS_H
-		status = irq_register(xil_uart_desc->irq_desc, xil_uart_desc->irq_id,
-				      (Xil_ExceptionHandler) XUartPs_InterruptHandler, xil_uart_desc->instance);
+		callback_desc.callback = XUartPs_InterruptHandler;
+		callback_desc.ctx = xil_uart_desc->instance;
+		status = irq_register_callback(xil_uart_desc->irq_desc,
+					       xil_uart_desc->irq_id,
+					       &callback_desc);
 		if (status < 0)
 			return status;
 		XUartPs_SetHandler(xil_uart_desc->instance, uart_irq_handler, xil_uart_desc);

--- a/include/irq.h
+++ b/include/irq.h
@@ -104,9 +104,9 @@ int32_t irq_global_enable(struct irq_ctrl_desc *desc);
 int32_t irq_global_disable(struct irq_ctrl_desc *desc);
 
 /* Enable specific interrupt */
-int32_t irq_source_enable(struct irq_ctrl_desc *desc, uint32_t irq_id);
+int32_t irq_enable(struct irq_ctrl_desc *desc, uint32_t irq_id);
 
 /* Disable specific interrupt */
-int32_t irq_source_disable(struct irq_ctrl_desc *desc, uint32_t irq_id);
+int32_t irq_disable(struct irq_ctrl_desc *desc, uint32_t irq_id);
 
 #endif // IRQ_H_

--- a/include/irq.h
+++ b/include/irq.h
@@ -72,6 +72,24 @@ struct irq_ctrl_desc {
 	void		*extra;
 };
 
+/**
+ * @struct callback_desc
+ * @brief Structure describing a callback to be registered
+ */
+struct callback_desc {
+	/**
+	 * Callback to be called when the event an event occurs
+	 *  @param ctx - Same as \ref callback_desc.ctx
+	 *  @param event - Event that generated the callback
+	 *  @param extra - Platform specific data
+	 */
+	void (*callback)(void *ctx, uint32_t event, void *extra);
+	/** Parameter to be passed when the callback is called */
+	void *ctx;
+	/** Platform specific configuration for a callback */
+	void *config;
+};
+
 /******************************************************************************/
 /************************ Functions Declarations ******************************/
 /******************************************************************************/
@@ -83,16 +101,9 @@ int32_t irq_ctrl_init(struct irq_ctrl_desc **desc,
 /* Free the resources allocated by irq_ctrl_init(). */
 int32_t irq_ctrl_remove(struct irq_ctrl_desc *desc);
 
-/**
- * @brief Registers a IRQ handling function to irq controller.
- * @param desc - The IRQ controller descriptor.
- * @param irq_id - Interrupt identifier.
- * @param irq_handler - The IRQ handler.
- * @param dev_instance - device instance.
- * @return SUCCESS in case of success, FAILURE otherwise.
- */
-int32_t irq_register(struct irq_ctrl_desc *desc, uint32_t irq_id,
-		     void (*irq_handler)(void *data), void *dev_instance);
+/* Register a callback to handle the irq events */
+int32_t irq_register_callback(struct irq_ctrl_desc *desc, uint32_t irq_id,
+			      struct callback_desc *callback_desc);
 
 /* Unregisters a generic IRQ handling function */
 int32_t irq_unregister(struct irq_ctrl_desc *desc, uint32_t irq_id);


### PR DESCRIPTION
I didn't test modifications on xilinx.
Integration of the uart irq will be done in an other pull request.

Later Edit:
The last commit didn't looks good because of how git works. The changes I have done in xilinx/irq.c are:
 - Make static irq_unregister
 - Move irq_unregister before irq_register_callback (will be used inside it)
 - Add this in irq_register_callback:
```
if (!callback_desc)
		return irq_unregister(desc, irq_id);
```