### PR TITLE
drivers: ad5770r: remove ch_enable register

### DIFF
--- a/drivers/dac/ad5770r/ad5770r.c
+++ b/drivers/dac/ad5770r/ad5770r.c
@@ -552,37 +552,6 @@ int32_t ad5770r_set_sw_ldac(struct ad5770r_dev *dev,
 }
 
 /**
- * Set the enabled channels.
- * @param dev - The device structure.
- * @param channel_enable - The array contains channels enabled.
- * @return SUCCESS in case of success, negative error code otherwise.
- */
-int32_t ad5770r_set_channel_en(struct ad5770r_dev *dev,
-			       const struct ad5770r_channel_switches *channel_enable)
-{
-	int32_t ret;
-
-	if (!dev || !channel_enable)
-		return FAILURE;
-
-	ret = ad5770r_spi_reg_write(dev,
-				    AD5770R_CH_ENABLE,
-				    AD5770R_CH_ENABLE_SET(channel_enable->en0, AD5770R_CH0) |
-				    AD5770R_CH_ENABLE_SET(channel_enable->en1, AD5770R_CH1) |
-				    AD5770R_CH_ENABLE_SET(channel_enable->en2, AD5770R_CH2) |
-				    AD5770R_CH_ENABLE_SET(channel_enable->en3, AD5770R_CH3) |
-				    AD5770R_CH_ENABLE_SET(channel_enable->en4, AD5770R_CH4) |
-				    AD5770R_CH_ENABLE_SET(channel_enable->en5, AD5770R_CH5));
-
-	if (ret)
-		return ret;
-
-	dev->channel_enable = *channel_enable;
-
-	return ret;
-}
-
-/**
  * Get status value.
  * @param dev - The device structure.
  * @param status - The status of the device.
@@ -667,8 +636,6 @@ int32_t ad5770r_init(struct ad5770r_dev **device,
 
 	ret |= ad5770r_channel_config(dev,
 				      &init_param->channel_config);
-	ret |= ad5770r_set_channel_en(dev,
-				      &init_param->channel_enable);
 
 	ret |= ad5770r_set_reference(dev,
 				     init_param->external_reference,

--- a/drivers/dac/ad5770r/ad5770r.h
+++ b/drivers/dac/ad5770r/ad5770r.h
@@ -125,7 +125,6 @@
 #define AD5770R_CH4_INPUT_MSB		0x41
 #define AD5770R_CH5_INPUT_LSB		0x42
 #define AD5770R_CH5_INPUT_MSB		0x43
-#define AD5770R_CH_ENABLE		0x44
 
 /* AD5770R_INTERFACE_CONFIG_A */
 #define AD5770R_INTERFACE_CONFIG_A_SW_RESET_MSK			BIT(7) | BIT(0)
@@ -220,8 +219,6 @@
 /* AD5770R_SW_LDAC */
 #define AD5770R_SW_LDAC_CH(x, channel)				(((x) & 0x1) << (channel))
 
-/* AD5770R_CH_ENABLE */
-#define AD5770R_CH_ENABLE_SET(x, channel)			(((x) & 0x1) << (channel))
 
 #define AD5770R_REG_READ(x)					(((x) & 0x7F) | 0x80)
 #define AD5770R_REG_WRITE(x)					((x) & 0x7F)
@@ -316,7 +313,6 @@ struct ad5770r_dev {
 	struct ad5770r_channel_switches		mask_channel_sel;
 	struct ad5770r_channel_switches		sw_ldac;
 	uint16_t				input_value[6];
-	struct ad5770r_channel_switches		channel_enable;
 };
 
 struct ad5770r_init_param {
@@ -339,7 +335,6 @@ struct ad5770r_init_param {
 	struct ad5770r_channel_switches		mask_channel_sel;
 	struct ad5770r_channel_switches		sw_ldac;
 	uint16_t				input_value[6];
-	struct ad5770r_channel_switches		channel_enable;
 };
 
 /******************************************************************************/
@@ -390,8 +385,6 @@ int32_t ad5770r_set_mask_channel(struct ad5770r_dev *dev,
 				 const struct ad5770r_channel_switches *mask_channel_sel);
 int32_t ad5770r_set_sw_ldac(struct ad5770r_dev *dev,
 			    const struct ad5770r_channel_switches *sw_ldac);
-int32_t ad5770r_set_channel_en(struct ad5770r_dev *dev,
-			       const struct ad5770r_channel_switches *channel_enable);
 int32_t ad5770r_get_status(struct ad5770r_dev *dev,
 			   uint8_t *status);
 int32_t ad5770r_set_monitor_setup(struct ad5770r_dev *dev,


### PR DESCRIPTION
The CH_ENABLE register is not implemented and is not documented in the
data sheet. This removes the #defines and associated functions.

Signed-off-by: Michael Bradley <Michael.Bradley@analog.com>