### PR TITLE
tools: scripts: xilinx: Remove Vivado dependency

### DIFF
--- a/tools/scripts/platform/xilinx/environment.sh
+++ b/tools/scripts/platform/xilinx/environment.sh
@@ -3,7 +3,7 @@
 if [ "$#" -eq 2 ]
 then
 export PATH="$PATH\
-:$1/Vivado/$2/bin\
+:$1/SDK/$2/bin\
 :$1/SDK/$2/gnu/microblaze/lin/bin\
 :$1/SDK/$2/gnu/aarch32/lin/gcc-arm-none-eabi/bin\
 :$1/SDK/$2/gnu/aarch64/lin/aarch64-none/bin"


### PR DESCRIPTION
Since Xilinx SDK can be installed standalone too, the Vivado dependency
should be removed.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>