### PR TITLE
AD5770R: adds new functions, updates device struct, fixes function name type

### DIFF
--- a/drivers/dac/ad5770r/ad5770r.c
+++ b/drivers/dac/ad5770r/ad5770r.c
@@ -693,3 +693,22 @@ int32_t ad5770r_init(struct ad5770r_dev **device,
 
 	return ret;
 }
+
+/**
+ * Delete and remove the device.
+ * @param device - The device structure.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad5770r_remove(struct ad5770r_dev *dev)
+{
+	int32_t ret;
+
+	if (!dev)
+		return FAILURE;
+
+	ret = spi_remove(dev->spi_desc);
+
+	free(dev);
+
+	return ret;
+}

--- a/drivers/dac/ad5770r/ad5770r.c
+++ b/drivers/dac/ad5770r/ad5770r.c
@@ -3,7 +3,7 @@
  *   @brief  Implementation of ad5770r Driver.
  *   @author Mircea Caprioru (mircea.caprioru@analog.com)
 ********************************************************************************
- * Copyright 2018(c) Analog Devices, Inc.
+ * Copyright 2018, 2020(c) Analog Devices, Inc.
  *
  * All rights reserved.
  *
@@ -384,7 +384,7 @@ int32_t ad5770r_set_output_filter(struct ad5770r_dev *dev,
  * @param mask_hw_ldac - The array contains HW LDAC channel masks.
  * @return SUCCESS in case of success, negative error code otherwise.
  */
-int32_t ad5770r_set_hw_ladc(struct ad5770r_dev *dev,
+int32_t ad5770r_set_hw_ldac(struct ad5770r_dev *dev,
 			    const struct ad5770r_channel_switches *mask_hw_ldac)
 {
 	int32_t ret;
@@ -642,7 +642,7 @@ int32_t ad5770r_init(struct ad5770r_dev **device,
 				     init_param->reference_selector);
 	ret |= ad5770r_set_alarm(dev, &init_param->alarm_config);
 
-	ret |= ad5770r_set_hw_ladc(dev,
+	ret |= ad5770r_set_hw_ldac(dev,
 				   &init_param->mask_hw_ldac);
 
 	for( i = AD5770R_CH0; i <=  AD5770R_CH5; i++) {

--- a/drivers/dac/ad5770r/ad5770r.c
+++ b/drivers/dac/ad5770r/ad5770r.c
@@ -566,6 +566,20 @@ int32_t ad5770r_get_status(struct ad5770r_dev *dev,
 };
 
 /**
+ * Get interface status value.
+ * @param dev - The device structure.
+ * @param status - The INTERFACE STATUS A register value.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad5770r_get_interface_status(struct ad5770r_dev *dev,
+				     uint8_t *status)
+{
+	return ad5770r_spi_reg_read(dev,
+				    AD5770R_INTERFACE_STATUS_A,
+				    status);
+};
+
+/**
  * Set the channel monitor configuration.
  * @param dev - The device structure.
  * @param mon_setup - The structure that contains the monitor setup

--- a/drivers/dac/ad5770r/ad5770r.h
+++ b/drivers/dac/ad5770r/ad5770r.h
@@ -393,5 +393,6 @@ int32_t ad5770r_set_monitor_setup(struct ad5770r_dev *dev,
 				  const struct ad5770r_monitor_setup *mon_setup);
 int32_t ad5770r_init(struct ad5770r_dev **device,
 		     const struct ad5770r_init_param *init_param);
+int32_t ad5770r_remove(struct ad5770r_dev *dev);
 
 #endif /* AD5770R_H_ */

--- a/drivers/dac/ad5770r/ad5770r.h
+++ b/drivers/dac/ad5770r/ad5770r.h
@@ -3,7 +3,7 @@
  *   @brief  Header file for AD5770R Driver.
  *   @author Mircea Caprioru (mircea.caprioru@analog.com)
 ********************************************************************************
- * Copyright 2018(c) Analog Devices, Inc.
+ * Copyright 2018, 2020(c) Analog Devices, Inc.
  *
  * All rights reserved.
  *
@@ -373,7 +373,7 @@ int32_t ad5770r_set_alarm(struct ad5770r_dev *dev,
 int32_t ad5770r_set_output_filter(struct ad5770r_dev *dev,
 				  enum ad5770r_output_filter_resistor output_filter,
 				  enum ad5770r_channels channel);
-int32_t ad5770r_set_hw_ladc(struct ad5770r_dev *dev,
+int32_t ad5770r_set_hw_ldac(struct ad5770r_dev *dev,
 			    const struct ad5770r_channel_switches *mask_hw_ldac);
 int32_t ad5770r_set_dac_value(struct ad5770r_dev *dev,
 			      uint16_t dac_value, enum ad5770r_channels channel);

--- a/drivers/dac/ad5770r/ad5770r.h
+++ b/drivers/dac/ad5770r/ad5770r.h
@@ -387,6 +387,8 @@ int32_t ad5770r_set_sw_ldac(struct ad5770r_dev *dev,
 			    const struct ad5770r_channel_switches *sw_ldac);
 int32_t ad5770r_get_status(struct ad5770r_dev *dev,
 			   uint8_t *status);
+int32_t ad5770r_get_interface_status(struct ad5770r_dev *dev,
+				     uint8_t *status);
 int32_t ad5770r_set_monitor_setup(struct ad5770r_dev *dev,
 				  const struct ad5770r_monitor_setup *mon_setup);
 int32_t ad5770r_init(struct ad5770r_dev **device,


### PR DESCRIPTION
Adds two new driver functions: to get interface status of device and remove device, freeing spi and device memory.
Updates the device struct after writing input, dac values and issuing a SW LDAC command
Fixes typo in function name for set_hw_ladc to ...ldac to match device pin naming.