### PR TITLE
drivers: platform: xilinx: Fix SPI_PL initialization

### DIFF
--- a/drivers/platform/xilinx/spi.c
+++ b/drivers/platform/xilinx/spi.c
@@ -98,7 +98,7 @@ static int32_t spi_init_pl(struct spi_desc *desc,
 	xdesc->type = xinit->type;
 	xdesc->flags = xinit->flags;
 
-	xdesc->instance = (XSpi*)malloc(sizeof(XSpi));
+	xdesc->instance = (XSpi*)calloc(1, sizeof(XSpi));
 	if(!xdesc->instance)
 		goto pl_error;
 


### PR DESCRIPTION
xdesc->instance should be initialized to zero, otherwise
XSpi_Initialize can fail reporting that the device is
started (return XST_DEVICE_IS_STARTED). calloc() was used
instead of malloc() for preventing this.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>