### PR TITLE
dac: ad5770r: minor doxygen fix

### DIFF
--- a/drivers/dac/ad5770r/ad5770r.c
+++ b/drivers/dac/ad5770r/ad5770r.c
@@ -719,7 +719,7 @@ int32_t ad5770r_init(struct ad5770r_dev **device,
 
 /**
  * Delete and remove the device.
- * @param device - The device structure.
+ * @param dev - The device structure.
  * @return SUCCESS in case of success, negative error code otherwise.
  */
 int32_t ad5770r_remove(struct ad5770r_dev *dev)


### PR DESCRIPTION
User proper parameter name in the header comment of function
`ad5770r_remove`.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>