### PR TITLE
ad9528: update gpio reset handling

### DIFF
--- a/drivers/frequency/ad9528/ad9528.c
+++ b/drivers/frequency/ad9528/ad9528.c
@@ -380,8 +380,8 @@ int32_t ad9528_setup(struct ad9528_dev **device,
 		return ret;
 
 	/* GPIO */
-	if(init_param.hw_reset_en) {
-		ret = gpio_get(&dev->gpio_resetb, &init_param.gpio_resetb);
+	if(init_param.gpio_resetb) {
+		ret = gpio_get(&dev->gpio_resetb, init_param.gpio_resetb);
 		if (ret < 0)
 			return ret;
 		ad9528_reset(dev);

--- a/drivers/frequency/ad9528/ad9528.h
+++ b/drivers/frequency/ad9528/ad9528.h
@@ -491,8 +491,7 @@ struct ad9528_init_param {
 	/* SPI */
 	spi_init_param spi_init;
 	/* GPIO */
-	bool hw_reset_en;
-	gpio_init_param gpio_resetb;
+	gpio_init_param *gpio_resetb;
 	/* Device Settings */
 	struct ad9528_platform_data *pdata;
 };

--- a/projects/adrv9009/src/app/app_clocking.c
+++ b/projects/adrv9009/src/app/app_clocking.c
@@ -427,8 +427,7 @@ adiHalErr_t clocking_init(uint32_t rx_div40_rate_hz,
 		.number = CLK_RESETB_GPIO,
 		.extra = &xil_gpio_param
 	};
-	ad9528_param.gpio_resetb = clkchip_gpio_init_param;
-	ad9528_param.hw_reset_en = true;
+	ad9528_param.gpio_resetb = &clkchip_gpio_init_param;
 #endif
 
 	/** < Insert User System Clock(s) Initialization Code Here >

--- a/projects/fmcdaq3/src/app/fmcdaq3.c
+++ b/projects/fmcdaq3/src/app/fmcdaq3.c
@@ -297,7 +297,7 @@ int main(void)
 	struct axi_dmac *ad9680_dmac;
 
 	// ad9528 defaults
-	ad9528_param.hw_reset_en = false;
+	ad9528_param.gpio_resetb = NULL;
 	ad9528_param.pdata = &ad9528_pdata;
 	ad9528_param.pdata->num_channels = 8;
 	ad9528_param.pdata->channels = &ad9528_channels[0];


### PR DESCRIPTION
Remove `hw_reset_en` attribute.

Make `gpio_resetb` pointer in the device initialization structure.

Update dependent projects.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>