### PR TITLE
GPIO updates

### DIFF
--- a/drivers/frequency/ad9528/ad9528.c
+++ b/drivers/frequency/ad9528/ad9528.c
@@ -380,12 +380,12 @@ int32_t ad9528_setup(struct ad9528_dev **device,
 		return ret;
 
 	/* GPIO */
-	if(init_param.hw_reset_en) {
-		ret = gpio_get(&dev->gpio_resetb, &init_param.gpio_resetb);
-		if (ret < 0)
-			return ret;
-		ad9528_reset(dev);
-	}
+	ret = gpio_get_optional(&dev->gpio_resetb, init_param.gpio_resetb);
+	if (ret < 0)
+		return ret;
+
+	ad9528_reset(dev);
+
 	ret = ad9528_spi_write_n(dev,
 				 AD9528_SERIAL_PORT_CONFIG,
 				 AD9528_SER_CONF_SOFT_RESET |
@@ -891,17 +891,18 @@ int32_t ad9528_reset(struct ad9528_dev *dev)
 	if(!dev)
 		return -1;
 
-	s = gpio_direction_output(dev->gpio_resetb, 0);
-	if(s < 0)
-		return s;
+	if(dev->gpio_resetb) {
+		s = gpio_direction_output(dev->gpio_resetb, 0);
+		if(s < 0)
+			return s;
 
-	mdelay(100);
+		mdelay(100);
 
-	s = gpio_direction_output(dev->gpio_resetb, 1);
-	if(s < 0)
-		return s;
-
-	mdelay(100);
+		s = gpio_direction_output(dev->gpio_resetb, 1);
+		if(s < 0)
+			return s;
+		mdelay(100);
+	}
 
 	s = ad9528_spi_write_n(dev, AD9528_SERIAL_PORT_CONFIG, 0x81);
 	if(s < 0)

--- a/drivers/frequency/ad9528/ad9528.c
+++ b/drivers/frequency/ad9528/ad9528.c
@@ -387,14 +387,6 @@ int32_t ad9528_setup(struct ad9528_dev **device,
 	ad9528_reset(dev);
 
 	ret = ad9528_spi_write_n(dev,
-				 AD9528_SERIAL_PORT_CONFIG,
-				 AD9528_SER_CONF_SOFT_RESET |
-				 (dev->pdata->spi3wire ? 0 :
-				  AD9528_SER_CONF_SDO_ACTIVE));
-	if (ret < 0)
-		return ret;
-
-	ret = ad9528_spi_write_n(dev,
 				 AD9528_SERIAL_PORT_CONFIG_B,
 				 AD9528_SER_CONF_READ_BUFFERED);
 	if (ret < 0)
@@ -904,8 +896,12 @@ int32_t ad9528_reset(struct ad9528_dev *dev)
 		mdelay(100);
 	}
 
-	s = ad9528_spi_write_n(dev, AD9528_SERIAL_PORT_CONFIG, 0x81);
-	if(s < 0)
+	s = ad9528_spi_write_n(dev,
+			       AD9528_SERIAL_PORT_CONFIG,
+			       AD9528_SER_CONF_SOFT_RESET |
+			       (dev->pdata->spi3wire ? 0 :
+				AD9528_SER_CONF_SDO_ACTIVE));
+	if (s < 0)
 		return s;
 
 	mdelay(100);

--- a/drivers/frequency/ad9528/ad9528.h
+++ b/drivers/frequency/ad9528/ad9528.h
@@ -491,8 +491,7 @@ struct ad9528_init_param {
 	/* SPI */
 	spi_init_param spi_init;
 	/* GPIO */
-	bool hw_reset_en;
-	gpio_init_param gpio_resetb;
+	gpio_init_param *gpio_resetb;
 	/* Device Settings */
 	struct ad9528_platform_data *pdata;
 };

--- a/drivers/platform/aducm3029/gpio.c
+++ b/drivers/platform/aducm3029/gpio.c
@@ -96,6 +96,23 @@ int32_t gpio_get(struct gpio_desc **desc, const struct gpio_init_param *param)
 }
 
 /**
+ * @brief Get the value of an optional GPIO.
+ * @param desc - The GPIO descriptor.
+ * @param param - GPIO Initialization parameters.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t gpio_get_optional(struct gpio_desc **desc,
+			  const struct gpio_init_param *param)
+{
+	if(param == NULL) {
+		*desc = NULL;
+		return SUCCESS;
+	}
+
+	return gpio_get(desc, param);
+}
+
+/**
  * @brief Free the resources allocated by gpio_get().
  * @param desc - The GPIO descriptor.
  * @return \ref SUCCESS in case of success, \ref FAILURE otherwise.

--- a/drivers/platform/altera/gpio.c
+++ b/drivers/platform/altera/gpio.c
@@ -92,6 +92,23 @@ int32_t gpio_get(struct gpio_desc **desc,
 }
 
 /**
+ * @brief Get the value of an optional GPIO.
+ * @param desc - The GPIO descriptor.
+ * @param param - GPIO Initialization parameters.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t gpio_get_optional(struct gpio_desc **desc,
+			  const struct gpio_init_param *param)
+{
+	if(param == NULL) {
+		*desc = NULL;
+		return SUCCESS;
+	}
+
+	return gpio_get(desc, param);
+}
+
+/**
  * @brief Free the resources allocated by gpio_get().
  * @param desc - The GPIO descriptor.
  * @return SUCCESS in case of success, FAILURE otherwise.

--- a/drivers/platform/generic/gpio.c
+++ b/drivers/platform/generic/gpio.c
@@ -68,6 +68,23 @@ int32_t gpio_get(struct gpio_desc **desc,
 }
 
 /**
+ * @brief Get the value of an optional GPIO.
+ * @param desc - The GPIO descriptor.
+ * @param param - GPIO Initialization parameters.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t gpio_get_optional(struct gpio_desc **desc,
+			  const struct gpio_init_param *param)
+{
+	if(param == NULL) {
+		*desc = NULL;
+		return SUCCESS;
+	}
+
+	return gpio_get(desc, param);
+}
+
+/**
  * @brief Free the resources allocated by gpio_get().
  * @param desc - The SPI descriptor.
  * @return SUCCESS in case of success, FAILURE otherwise.

--- a/drivers/platform/xilinx/gpio.c
+++ b/drivers/platform/xilinx/gpio.c
@@ -170,6 +170,23 @@ error:
 }
 
 /**
+ * @brief Get the value of an optional GPIO.
+ * @param desc - The GPIO descriptor.
+ * @param param - GPIO Initialization parameters.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t gpio_get_optional(struct gpio_desc **desc,
+			  const struct gpio_init_param *param)
+{
+	if(param == NULL) {
+		*desc = NULL;
+		return SUCCESS;
+	}
+
+	return gpio_get(desc, param);
+}
+
+/**
  * @brief Free the resources allocated by gpio_get().
  * @param desc - The SPI descriptor.
  * @return SUCCESS in case of success, FAILURE otherwise.

--- a/include/gpio.h
+++ b/include/gpio.h
@@ -90,6 +90,10 @@ typedef struct gpio_desc {
 int32_t gpio_get(struct gpio_desc **desc,
 		 const struct gpio_init_param *param);
 
+/* Obtain optional GPIO descriptor. */
+int32_t gpio_get_optional(struct gpio_desc **desc,
+			  const struct gpio_init_param *param);
+
 /* Free the resources allocated by gpio_get() */
 int32_t gpio_remove(struct gpio_desc *desc);
 

--- a/projects/adrv9009/src/app/app_clocking.c
+++ b/projects/adrv9009/src/app/app_clocking.c
@@ -427,8 +427,7 @@ adiHalErr_t clocking_init(uint32_t rx_div40_rate_hz,
 		.number = CLK_RESETB_GPIO,
 		.extra = &xil_gpio_param
 	};
-	ad9528_param.gpio_resetb = clkchip_gpio_init_param;
-	ad9528_param.hw_reset_en = true;
+	ad9528_param.gpio_resetb = &clkchip_gpio_init_param;
 #endif
 
 	/** < Insert User System Clock(s) Initialization Code Here >

--- a/projects/fmcdaq3/src/app/fmcdaq3.c
+++ b/projects/fmcdaq3/src/app/fmcdaq3.c
@@ -297,7 +297,7 @@ int main(void)
 	struct axi_dmac *ad9680_dmac;
 
 	// ad9528 defaults
-	ad9528_param.hw_reset_en = false;
+	ad9528_param.gpio_resetb = NULL;
 	ad9528_param.pdata = &ad9528_pdata;
 	ad9528_param.pdata->num_channels = 8;
 	ad9528_param.pdata->channels = &ad9528_channels[0];


### PR DESCRIPTION
- add `gpio_get_optional` function
- ad9528: update gpio reset handling


Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>