### PR TITLE
jesd204

### DIFF
--- a/drivers/axi_core/jesd204/axi_jesd204_rx.c
+++ b/drivers/axi_core/jesd204/axi_jesd204_rx.c
@@ -160,12 +160,15 @@ uint32_t axi_jesd204_rx_status_read(struct axi_jesd204_rx *jesd)
 	uint32_t clock_rate;
 	uint32_t link_rate;
 	uint32_t sysref_config;
+	uint32_t link_config0;
+	uint32_t lmfc_rate;
 
 	axi_jesd204_rx_read(jesd, JESD204_RX_REG_LINK_STATE, &link_disabled);
 	axi_jesd204_rx_read(jesd, JESD204_RX_REG_LINK_STATUS, &link_status);
 	axi_jesd204_rx_read(jesd, JESD204_RX_REG_SYSREF_STATUS, &sysref_status);
 	axi_jesd204_rx_read(jesd, JESD204_RX_REG_LINK_CLK_RATIO, &clock_ratio);
 	axi_jesd204_rx_read(jesd, JESD204_RX_REG_SYSREF_CONF, &sysref_config);
+	axi_jesd204_rx_read(jesd, JESD204_RX_REG_LINK_CONF0, &link_config0);
 
 	printf("%s status:\n", jesd->name);
 
@@ -187,10 +190,13 @@ uint32_t axi_jesd204_rx_status_read(struct axi_jesd204_rx *jesd)
 	if (!link_disabled) {
 		clock_rate = jesd->lane_clk_khz;
 		link_rate = DIV_ROUND_CLOSEST(clock_rate, 40);
+		lmfc_rate = clock_rate / (10 * ((link_config0 & 0xFF) + 1));
 		printf("\tLane rate: %"PRIu32".%.3"PRIu32" MHz\n"
-		       "\tLane rate / 40: %"PRIu32".%.3"PRIu32" MHz\n",
+		       "\tLane rate / 40: %"PRIu32".%.3"PRIu32" MHz\n"
+		       "\tLMFC rate: %"PRIu32".%.3"PRIu32" MHz\n",
 		       clock_rate / 1000, clock_rate % 1000,
-		       link_rate / 1000, link_rate % 1000);
+		       link_rate / 1000, link_rate % 1000,
+		       lmfc_rate / 1000, lmfc_rate % 1000);
 
 		printf("\tLink status: %s\n"
 		       "\tSYSREF captured: %s\n"

--- a/drivers/axi_core/jesd204/axi_jesd204_rx.h
+++ b/drivers/axi_core/jesd204/axi_jesd204_rx.h
@@ -54,6 +54,14 @@ struct jesd204_rx_config {
 	uint8_t subclass_version;
 };
 
+/* JESD204 Supported encoding scheme */
+enum jesd204_rx_encoder {
+	JESD204_RX_ENCODER_UNKNOWN,
+	JESD204_RX_ENCODER_8B10B,
+	JESD204_RX_ENCODER_64B66B,
+	JESD204_RX_ENCODER_MAX,
+};
+
 struct axi_jesd204_rx {
 	const char *name;
 	uint32_t base;
@@ -63,6 +71,7 @@ struct axi_jesd204_rx {
 	struct jesd204_rx_config config;
 	uint32_t device_clk_khz;
 	uint32_t lane_clk_khz;
+	enum jesd204_rx_encoder encoder;
 };
 
 struct jesd204_rx_init {

--- a/drivers/axi_core/jesd204/axi_jesd204_tx.c
+++ b/drivers/axi_core/jesd204/axi_jesd204_tx.c
@@ -57,6 +57,10 @@
 #define JESD204_TX_REG_CONF_NUM_LANES		0x10
 #define JESD204_TX_REG_CONF_DATA_PATH_WIDTH	0x14
 
+#define JESD204_TX_REG_SYNTH_REG_1		0x18
+#define JESD204_TX_ENCODER_MASK			GENMASK(9, 8)
+#define JESD204_TX_ENCODER_GET(x)	field_get(JESD204_TX_ENCODER_MASK, x)
+
 #define JESD204_TX_REG_LINK_DISABLE		0xc0
 #define JESD204_TX_REG_LINK_STATE		0xc4
 #define JESD204_TX_REG_LINK_CLK_RATIO	0xc8
@@ -146,6 +150,7 @@ uint32_t axi_jesd204_tx_status_read(struct axi_jesd204_tx *jesd)
 	uint32_t sysref_config;
 	uint32_t link_config0;
 	uint32_t lmfc_rate;
+	const char *status;
 
 	axi_jesd204_tx_read(jesd, JESD204_TX_REG_LINK_STATE, &link_disabled);
 	axi_jesd204_tx_read(jesd, JESD204_TX_REG_LINK_STATUS, &link_status);
@@ -172,21 +177,35 @@ uint32_t axi_jesd204_tx_status_read(struct axi_jesd204_tx *jesd)
 	       clock_rate / 1000, clock_rate % 1000);
 
 	if (!link_disabled) {
+		status = (link_status & 0x10) ?
+			 "\tSYNC~: deasserted\n" : "\tSYNC~: asserted\n";
+
 		clock_rate = jesd->lane_clk_khz;
-		link_rate = DIV_ROUND_CLOSEST(clock_rate, 40);
-		lmfc_rate = clock_rate / (10 * ((link_config0 & 0xFF) + 1));
+		if (jesd->encoder == JESD204_TX_ENCODER_64B66B) {
+			link_rate = DIV_ROUND_CLOSEST(clock_rate, 66);
+			lmfc_rate = (clock_rate * 8) /
+				    (66 * ((link_config0 & 0xFF) + 1));
+		} else {
+			link_rate = DIV_ROUND_CLOSEST(clock_rate, 40);
+			lmfc_rate = clock_rate /
+				    (10 * ((link_config0 & 0xFF) + 1));
+		}
 		printf("\tLane rate: %"PRIu32".%.3"PRIu32" MHz\n"
-		       "\tLane rate / 40: %"PRIu32".%.3"PRIu32" MHz\n"
-		       "LMFC rate: %"PRIu32".%.3"PRIu32" MHz\n",
+		       "\tLane rate / %d: %"PRIu32".%.3"PRIu32" MHz\n"
+		       "\t%s rate: %"PRIu32".%.3"PRIu32" MHz\n",
 		       clock_rate / 1000, clock_rate % 1000,
+		       (jesd->encoder == JESD204_TX_ENCODER_8B10B) ? 40 : 66,
 		       link_rate / 1000, link_rate % 1000,
+		       (jesd->encoder == JESD204_TX_ENCODER_8B10B) ? "LMFC" :
+		       "LEMC",
 		       lmfc_rate / 1000, lmfc_rate % 1000);
 
-		printf("\tSYNC~: %s\n"
+		printf("%s"
 		       "\tLink status: %s\n"
 		       "\tSYSREF captured: %s\n"
 		       "\tSYSREF alignment error: %s\n",
-		       (link_status & 0x10) ? "deasserted" : "asserted",
+		       jesd->encoder == JESD204_TX_ENCODER_64B66B ? "" :
+		       status,
 		       axi_jesd204_tx_link_status_label[link_status & 0x3],
 		       (sysref_config & JESD204_TX_REG_SYSREF_CONF_SYSREF_DISABLE) ?
 		       "disabled" : (sysref_status & 1) ? "Yes" : "No",
@@ -285,6 +304,13 @@ int32_t axi_jesd204_tx_apply_config(struct axi_jesd204_tx *jesd,
 
 	multiframe_align = 1 << jesd->data_path_width;
 
+	if (jesd->encoder == JESD204_TX_ENCODER_64B66B &&
+	    (octets_per_multiframe % 256) != 0) {
+		printf("%s: octets_per_frame * frames_per_multiframe must be a multiple of 256",
+		       jesd->name);
+		return FAILURE;
+	}
+
 	if (octets_per_multiframe % multiframe_align != 0) {
 		printf("%s: octets_per_frame * frames_per_multiframe must be a "
 		       "multiple of %"PRIu32"\n", jesd->name, multiframe_align);
@@ -301,7 +327,8 @@ int32_t axi_jesd204_tx_apply_config(struct axi_jesd204_tx *jesd,
 	axi_jesd204_tx_write(jesd, JESD204_TX_REG_CONF0, val);
 
 	for (lane = 0; lane < jesd->num_lanes; lane++)
-		axi_jesd204_tx_set_lane_ilas(jesd, config, lane);
+		if (jesd->encoder == JESD204_TX_ENCODER_8B10B)
+			axi_jesd204_tx_set_lane_ilas(jesd, config, lane);
 
 	return SUCCESS;
 }
@@ -313,6 +340,7 @@ int32_t axi_jesd204_tx_init(struct axi_jesd204_tx **jesd204,
 			    const struct jesd204_tx_init *init)
 {
 	struct axi_jesd204_tx *jesd;
+	uint32_t synth_1;
 	uint32_t magic;
 	uint32_t version;
 	uint32_t status;
@@ -348,6 +376,13 @@ int32_t axi_jesd204_tx_init(struct axi_jesd204_tx **jesd204,
 			    &jesd->num_lanes);
 	axi_jesd204_tx_read(jesd, JESD204_TX_REG_CONF_DATA_PATH_WIDTH,
 			    &jesd->data_path_width);
+	axi_jesd204_tx_read(jesd, JESD204_TX_REG_SYNTH_REG_1,
+			    &synth_1);
+	jesd->encoder = JESD204_TX_ENCODER_GET(synth_1);
+	if (jesd->encoder == JESD204_TX_ENCODER_UNKNOWN)
+		jesd->encoder = JESD204_TX_ENCODER_8B10B;
+	else if (jesd->encoder >= JESD204_TX_ENCODER_MAX)
+		goto err;
 
 	jesd->config.device_id = 0;
 	jesd->config.bank_id = 0;

--- a/drivers/axi_core/jesd204/axi_jesd204_tx.c
+++ b/drivers/axi_core/jesd204/axi_jesd204_tx.c
@@ -144,12 +144,15 @@ uint32_t axi_jesd204_tx_status_read(struct axi_jesd204_tx *jesd)
 	uint32_t clock_rate;
 	uint32_t link_rate;
 	uint32_t sysref_config;
+	uint32_t link_config0;
+	uint32_t lmfc_rate;
 
 	axi_jesd204_tx_read(jesd, JESD204_TX_REG_LINK_STATE, &link_disabled);
 	axi_jesd204_tx_read(jesd, JESD204_TX_REG_LINK_STATUS, &link_status);
 	axi_jesd204_tx_read(jesd, JESD204_TX_REG_SYSREF_STATUS, &sysref_status);
 	axi_jesd204_tx_read(jesd, JESD204_TX_REG_LINK_CLK_RATIO, &clock_ratio);
 	axi_jesd204_tx_read(jesd, JESD204_TX_REG_SYSREF_CONF, &sysref_config);
+	axi_jesd204_tx_read(jesd, JESD204_TX_REG_CONF0, &link_config0);
 
 	printf("%s status:\n", jesd->name);
 
@@ -171,10 +174,13 @@ uint32_t axi_jesd204_tx_status_read(struct axi_jesd204_tx *jesd)
 	if (!link_disabled) {
 		clock_rate = jesd->lane_clk_khz;
 		link_rate = DIV_ROUND_CLOSEST(clock_rate, 40);
+		lmfc_rate = clock_rate / (10 * ((link_config0 & 0xFF) + 1));
 		printf("\tLane rate: %"PRIu32".%.3"PRIu32" MHz\n"
-		       "\tLane rate / 40: %"PRIu32".%.3"PRIu32" MHz\n",
+		       "\tLane rate / 40: %"PRIu32".%.3"PRIu32" MHz\n"
+		       "LMFC rate: %"PRIu32".%.3"PRIu32" MHz\n",
 		       clock_rate / 1000, clock_rate % 1000,
-		       link_rate / 1000, link_rate % 1000);
+		       link_rate / 1000, link_rate % 1000,
+		       lmfc_rate / 1000, lmfc_rate % 1000);
 
 		printf("\tSYNC~: %s\n"
 		       "\tLink status: %s\n"

--- a/drivers/axi_core/jesd204/axi_jesd204_tx.h
+++ b/drivers/axi_core/jesd204/axi_jesd204_tx.h
@@ -66,6 +66,14 @@ struct jesd204_tx_config {
 	bool high_density;
 };
 
+/* JESD204 Supported encoding scheme */
+enum jesd204_tx_encoder {
+	JESD204_TX_ENCODER_UNKNOWN,
+	JESD204_TX_ENCODER_8B10B,
+	JESD204_TX_ENCODER_64B66B,
+	JESD204_TX_ENCODER_MAX,
+};
+
 struct axi_jesd204_tx {
 	const char *name;
 	uint32_t base;
@@ -74,6 +82,7 @@ struct axi_jesd204_tx {
 	struct jesd204_tx_config config;
 	uint32_t device_clk_khz;
 	uint32_t lane_clk_khz;
+	enum jesd204_tx_encoder encoder;
 };
 
 struct jesd204_tx_init {

--- a/include/util.h
+++ b/include/util.h
@@ -107,6 +107,8 @@
 uint32_t find_first_set_bit(uint32_t word);
 /* Find last set bit in word. */
 uint32_t find_last_set_bit(uint32_t word);
+/* Get a field specified by a mask from a word. */
+uint32_t field_get(uint32_t mask, uint32_t word);
 /* Log base 2 of the given number. */
 int32_t log_base_2(uint32_t x);
 /* Find greatest common divisor of the given two numbers. */

--- a/util/util.c
+++ b/util/util.c
@@ -84,6 +84,14 @@ uint32_t find_last_set_bit(uint32_t word)
 }
 
 /**
+ * Get a field specified by a mask from a word.
+ */
+uint32_t field_get(uint32_t mask, uint32_t word)
+{
+	return (word & mask) >> find_first_set_bit(mask);
+}
+
+/**
  * Log base 2 of the given number.
  */
 int32_t log_base_2(uint32_t x)


### PR DESCRIPTION
Bring the axi_jesd204_[rx|tx] no-OS drivers in sync with the Linux versions:
https://github.com/analogdevicesinc/linux/blob/master/drivers/iio/jesd204/axi_jesd204_rx.c
https://github.com/analogdevicesinc/linux/blob/master/drivers/iio/jesd204/axi_jesd204_tx.c