### PR TITLE
drivers:platform:aducm: uart: unset non_blockin flags on error

### DIFF
--- a/drivers/platform/aducm3029/uart.c
+++ b/drivers/platform/aducm3029/uart.c
@@ -211,6 +211,8 @@ static void uart_callback(void *ctx, uint32_t event, void *buff)
 		break;
 	default:
 		extra->errors |= (uint32_t)buff;
+		extra->read_desc.is_nonblocking = false;
+		extra->write_desc.is_nonblocking = false;
 		if (extra->callback_enabled)
 			desc->callback(desc->callback_ctx, ERROR, buff);
 		break;


### PR DESCRIPTION
When an error ocurrs, the is_non_blocking flag should be set to 0 in order to let the application submit an other buffer.

Signed-off-by: Mihail Chindris <mihail.chindris@analog.com>