### PR TITLE
spi generic layer + adc1 example

### DIFF
--- a/drivers/platform/xilinx/spi_extra.h
+++ b/drivers/platform/xilinx/spi_extra.h
@@ -98,4 +98,11 @@ typedef struct xil_spi_desc {
 	void			*instance;
 } xil_spi_desc;
 
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+int32_t xil_spi_init(struct spi_desc **desc, const struct spi_init_param *param);
+int32_t xil_spi_remove(struct spi_desc *desc);
+int32_t xil_spi_write_and_read(struct spi_desc *desc, uint8_t *data, uint16_t bytes_number);
+
 #endif // SPI_EXTRA_H_

--- a/drivers/platform/xilinx/xilinx_spi.c
+++ b/drivers/platform/xilinx/xilinx_spi.c
@@ -252,7 +252,7 @@ ps_error:
  * @param param - The structure that contains the SPI parameters.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t spi_init(struct spi_desc **desc,
+int32_t xil_spi_init(struct spi_desc **desc,
 		 const struct spi_init_param *param)
 {
 	int32_t				ret;
@@ -316,7 +316,7 @@ init_error:
  * @param desc - The SPI descriptor.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t spi_remove(struct spi_desc *desc)
+int32_t xil_spi_remove(struct spi_desc *desc)
 {
 #ifdef XSPI_H
 	int32_t				ret;
@@ -385,7 +385,7 @@ error:
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
 
-int32_t spi_write_and_read(struct spi_desc *desc,
+int32_t xil_spi_write_and_read(struct spi_desc *desc,
 			   uint8_t *data,
 			   uint16_t bytes_number)
 {

--- a/drivers/spi/spi.c
+++ b/drivers/spi/spi.c
@@ -1,0 +1,41 @@
+/*
+ * spi.c
+ *
+ *  Created on: Apr 10, 2020
+ *      Author: amiclaus
+ */
+#include <inttypes.h>
+#include "spi.h"
+#include <stdlib.h>
+#include "error.h"
+
+int32_t spi_init(struct spi_desc **desc,
+		 const struct spi_init_param *param){
+	(*desc)->dev = calloc(1, sizeof(struct spi_dev));
+	if(!((*desc)->dev))
+		return FAILURE;
+
+	(*desc)->dev->spi_dev_init = param->dev.spi_dev_init;
+	(*desc)->dev->spi_dev_remove = param->dev.spi_dev_remove;
+	(*desc)->dev->spi_dev_write_and_read = param->dev.spi_dev_write_and_read;
+
+	return ((*desc)->dev->spi_dev_init(desc, param));
+}
+
+
+/* Free the resources allocated by spi_init(). */
+int32_t spi_remove(struct spi_desc *desc){
+	if(desc->dev->spi_dev_remove(desc))
+		return FAILURE;
+
+	free(desc->dev);
+
+	return SUCCESS;
+}
+
+/* Write and read data to/from SPI. */
+int32_t spi_write_and_read(struct spi_desc *desc,
+			   uint8_t *data,
+			   uint16_t bytes_number){
+	return (desc->dev->spi_dev_write_and_read(desc, data, bytes_number));
+}

--- a/include/spi.h
+++ b/include/spi.h
@@ -72,6 +72,11 @@ typedef enum spi_mode {
 	SPI_MODE_3 = (SPI_CPOL | SPI_CPHA)
 } spi_mode;
 
+struct spi_dev {
+	int32_t (*spi_dev_init)();
+	int32_t (*spi_dev_write_and_read)();
+	int32_t (*spi_dev_remove)();
+};
 /**
  * @struct spi_init_param
  * @brief Structure holding the parameters for SPI initialization
@@ -83,6 +88,7 @@ typedef struct spi_init_param {
 	uint8_t		chip_select;
 	/** SPI mode */
 	enum spi_mode	mode;
+	struct spi_dev dev;
 	/**  SPI extra parameters (device specific) */
 	void		*extra;
 } spi_init_param;
@@ -98,9 +104,11 @@ typedef struct spi_desc {
 	uint8_t		chip_select;
 	/** SPI mode */
 	enum spi_mode	mode;
+	struct spi_dev *dev;
 	/**  SPI extra parameters (device specific) */
 	void		*extra;
 } spi_desc;
+
 
 /******************************************************************************/
 /************************ Functions Declarations ******************************/

--- a/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
+++ b/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
@@ -68,17 +68,24 @@ int main(void)
 
 	int32_t status;
 
+	struct spi_dev spi_dev = {
+		.spi_dev_init = &xil_spi_init,
+		.spi_dev_remove = &xil_spi_remove,
+		.spi_dev_write_and_read = &xil_spi_write_and_read
+	};
 	// SPI configuration
 	struct spi_init_param ad9250_spi_param = {
 		.max_speed_hz = 2000000u,
 		.chip_select = 0,
-		.mode = SPI_MODE_0
+		.mode = SPI_MODE_0,
+		.dev = spi_dev
 	};
 
 	struct spi_init_param ad9517_spi_param = {
 		.max_speed_hz = 2000000u,
 		.chip_select = 0,
-		.mode = SPI_MODE_0
+		.mode = SPI_MODE_0,
+		.dev = spi_dev
 	};
 
 	struct xil_spi_init_param xil_spi_param = {


### PR DESCRIPTION
This a proposal for the spi generic layer implementation.

And example of usage is provided using the fmcjesdadc1 project with the
Xilinx platform specific driver.

An additional layer will be added afterwards between spi generic layer
and xilinx spi layer for the CPLD demux spi driver.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>