### PR TITLE
travis: build fixes

### DIFF
--- a/.cppcheckignore
+++ b/.cppcheckignore
@@ -11,3 +11,5 @@
 //
 // Another alternative is using inline suppressions. Please see Cppcheck manual
 // for further information: https://cppcheck.sourceforge.net/manual.pdf 
+
+*:drivers/adc/ad9081/api/*

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -25,6 +25,7 @@ set(DOCUMENTED_FILES
 
 set(EXCLUDE_FILES
     "${SOURCES_DIR}/drivers/rf-transceiver/talise \\
+    ${SOURCES_DIR}/drivers/adc/ad9081/api \\
 ")
 
 configure_file(

--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -8,6 +8,7 @@ INCLUDES = -I../include/ \
 	 -I./dac/ad917x/ad917x_api/ \
 	 -I../projects/ad9361/src/ \
 	 -I./adc/ad9208/ad9208_api \
+	 -I./adc/ad9081/api \
 	 -I./axi_core/axi_adc_core \
 	 -I../projects/adrv9009/src/devices/adi_hal
 

--- a/drivers/adc/ad9081/ad9081.c
+++ b/drivers/adc/ad9081/ad9081.c
@@ -1017,7 +1017,7 @@ error_1:
 
 /**
  * Remove the device - release resources.
- * @param device - The device structure.
+ * @param dev - The device structure.
  * @return SUCCESS in case of success, negative error code otherwise.
  */
 int32_t ad9081_remove(struct ad9081_phy *dev)


### PR DESCRIPTION
Fix latest introduced TravisCI build issues:

1. cppcheck: ignore ad9081 api.
2. drivers build: include ad9081 required paths.
3. Doxygen: fix doc for `ad9081_remove` function; exclude ad9801
api from documentation check.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>