### PR TITLE
drivers: adc: ad7779: fix power mode

### DIFF
--- a/drivers/adc/ad7779/ad7779.c
+++ b/drivers/adc/ad7779/ad7779.c
@@ -1348,7 +1348,7 @@ int32_t ad7779_init(ad7779_dev **device,
 
 	dev->pwr_mode = init_param.pwr_mode;
 	if (dev->ctrl_mode == AD7779_SPI_CTRL)
-		ret |= ad7779_set_reference_type(dev, dev->ref_type);
+		ret |= ad7779_set_power_mode(dev, dev->pwr_mode);
 
 	if (dev->ctrl_mode == AD7779_PIN_CTRL) {
 		ret |= ad7779_do_update_mode_pins(dev);

--- a/drivers/adc/ad7779/ad7779.h
+++ b/drivers/adc/ad7779/ad7779.h
@@ -194,8 +194,8 @@ typedef enum {
 } ad7768_dclk_div;
 
 typedef enum {
-	AD7779_HIGH_RES,
 	AD7779_LOW_PWR,
+	AD7779_HIGH_RES,
 } ad7779_pwr_mode;
 
 typedef enum {


### PR DESCRIPTION
Call `ad7779_set_power_mode` when performing device initialization.

Fix `ad7779_pwr_mode` enum.

Fixes: #552

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>