### PR TITLE
xilinx_capture script: regular expression fix for target setting in m_type=ZYNQ_PSU context

### DIFF
--- a/scripts/xilinx_capture.tcl
+++ b/scripts/xilinx_capture.tcl
@@ -15,7 +15,7 @@ set storage_bits  [lindex $argv 4]   ;# for 8-16bit rezolution data is stored on
 connect
 
 if {$m_type == "ZYNQ_PSU"} {
-  targets -set -filter {name =~ "ARM*#0*"}
+  targets -set -filter {name =~ "*A53*#0*"}
 }
 
 if {$m_type == "ZYNQ_PS7"} {


### PR DESCRIPTION
Changed the filter's regular experssion for the target setting instruction in the m_type=ZYNQ_PSU context. Changed from "ARM*#0*" to "*A53*#0*".