### PR TITLE
util: Add find_closest() and field_prep()

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -110,6 +110,12 @@
 uint32_t find_first_set_bit(uint32_t word);
 /* Find last set bit in word. */
 uint32_t find_last_set_bit(uint32_t word);
+/* Locate the closest element in an array. */
+uint32_t find_closest(int32_t val,
+		      const int32_t *array,
+		      uint32_t size);
+/* Shift the value and apply the specified mask. */
+uint32_t field_prep(uint32_t mask, uint32_t val);
 /* Get a field specified by a mask from a word. */
 uint32_t field_get(uint32_t mask, uint32_t word);
 /* Log base 2 of the given number. */

--- a/util/util.c
+++ b/util/util.c
@@ -84,6 +84,35 @@ uint32_t find_last_set_bit(uint32_t word)
 }
 
 /**
+ * Locate the closest element in an array.
+ */
+uint32_t find_closest(int32_t val,
+		      const int32_t *array,
+		      uint32_t size)
+{
+	int32_t diff = abs(array[0] - val);
+	uint32_t ret = 0;
+	uint32_t i;
+
+	for (i = 1; i < size; i++) {
+		if (abs(array[i] - val) < diff) {
+			diff = abs(array[i] - val);
+			ret = i;
+		}
+	}
+
+	return ret;
+}
+
+/**
+ * Shift the value and apply the specified mask.
+ */
+uint32_t field_prep(uint32_t mask, uint32_t val)
+{
+	return (val << find_first_set_bit(mask)) & mask;
+}
+
+/**
  * Get a field specified by a mask from a word.
  */
 uint32_t field_get(uint32_t mask, uint32_t word)


### PR DESCRIPTION
find_closest() - Locate the closest element in an array.
field_prep() - Shift the value and apply the specified mask.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>