### PR TITLE
drivers:adc:ad713x make GPIOs optional

### DIFF
--- a/drivers/adc/ad713x/ad713x.c
+++ b/drivers/adc/ad713x/ad713x.c
@@ -372,58 +372,70 @@ static int32_t ad713x_init_gpio(struct ad713x_dev *dev,
 
 	int32_t ret;
 
-	ret = gpio_get(&dev->gpio_mode, &init_param->gpio_mode);
+	ret = gpio_get_optional(&dev->gpio_mode, init_param->gpio_mode);
 	if (IS_ERR_VALUE(ret))
 		return FAILURE;
 
-	ret = gpio_get(&dev->gpio_dclkmode, &init_param->gpio_dclkmode);
+	ret = gpio_get_optional(&dev->gpio_dclkmode, init_param->gpio_dclkmode);
 	if (IS_ERR_VALUE(ret))
 		return FAILURE;
 
-	ret = gpio_get(&dev->gpio_dclkio, &init_param->gpio_dclkio);
+	ret = gpio_get_optional(&dev->gpio_dclkio, init_param->gpio_dclkio);
 	if (IS_ERR_VALUE(ret))
 		return FAILURE;
 
-	ret = gpio_get(&dev->gpio_resetn, &init_param->gpio_resetn);
+	ret = gpio_get_optional(&dev->gpio_resetn, init_param->gpio_resetn);
 	if (IS_ERR_VALUE(ret))
 		return FAILURE;
 
-	ret = gpio_get(&dev->gpio_pnd, &init_param->gpio_pnd);
+	ret = gpio_get_optional(&dev->gpio_pnd, init_param->gpio_pnd);
 	if (IS_ERR_VALUE(ret))
 		return FAILURE;
 
-	/** Tie this pin to IOVDD for master mode operation, tie this pin to IOGND
-	 *  for slave mode operation. */
-	ret = gpio_direction_output(dev->gpio_mode, init_param->mode_master_nslave);
-	if (IS_ERR_VALUE(ret))
-		return FAILURE;
+	/** Tie this pin to IOVDD for master mode operation, tie this pin to
+	 *  IOGND for slave mode operation. */
+	if (init_param->gpio_mode) {
+		ret = gpio_direction_output(dev->gpio_mode,
+					    init_param->mode_master_nslave);
+		if (IS_ERR_VALUE(ret))
+			return FAILURE;
+	}
 
 	/* Tie this pin low to ground to make DLCK operating in gated mode */
-	ret = gpio_direction_output(dev->gpio_dclkmode,
-				    init_param->dclkmode_free_ngated);
-	if (IS_ERR_VALUE(ret))
-		return FAILURE;
+	if (init_param->gpio_dclkmode) {
+		ret = gpio_direction_output(dev->gpio_dclkmode,
+					    init_param->dclkmode_free_ngated);
+		if (IS_ERR_VALUE(ret))
+			return FAILURE;
+	}
 
-	/** Tie this pin high to make DCLK an output, tie this pin low to make DLCK
-	 *  an input. */
-	ret = gpio_direction_output(dev->gpio_dclkio, init_param->dclkio_out_nin);
-	if (IS_ERR_VALUE(ret))
-		return FAILURE;
+	/** Tie this pin high to make DCLK an output, tie this pin low to make
+	 *  DLCK an input. */
+	if (init_param->gpio_dclkio) {
+		ret = gpio_direction_output(dev->gpio_dclkio,
+					    init_param->dclkio_out_nin);
+		if (IS_ERR_VALUE(ret))
+			return FAILURE;
+	}
 
 	/** Get the ADCs out of power down state */
-	ret = gpio_direction_output(dev->gpio_pnd, init_param->pnd);
-	if (IS_ERR_VALUE(ret))
-		return FAILURE;
+	if (init_param->gpio_pnd) {
+		ret = gpio_direction_output(dev->gpio_pnd, init_param->pnd);
+		if (IS_ERR_VALUE(ret))
+			return FAILURE;
+	}
 
 	/** Reset to configure pins */
-	ret = gpio_direction_output(dev->gpio_resetn, false);
-	if (IS_ERR_VALUE(ret))
-		return FAILURE;
-	mdelay(100);
-	ret = gpio_set_value(dev->gpio_resetn, true);
-	if (IS_ERR_VALUE(ret))
-		return FAILURE;
-	mdelay(100);
+	if (init_param->gpio_resetn) {
+		ret = gpio_direction_output(dev->gpio_resetn, false);
+		if (IS_ERR_VALUE(ret))
+			return FAILURE;
+		mdelay(100);
+		ret = gpio_set_value(dev->gpio_resetn, true);
+		if (IS_ERR_VALUE(ret))
+			return FAILURE;
+		mdelay(100);
+	}
 
 	return SUCCESS;
 }

--- a/drivers/adc/ad713x/ad713x.h
+++ b/drivers/adc/ad713x/ad713x.h
@@ -702,15 +702,15 @@ struct ad713x_init_param {
 	/** SPI layer initialization structure. */
 	struct spi_init_param spi_init_prm;
 	/** MODE GPIO initialization structure. */
-	struct gpio_init_param gpio_mode;
+	struct gpio_init_param *gpio_mode;
 	/** DCLKMODE GPIO initialization structure. */
-	struct gpio_init_param gpio_dclkmode;
+	struct gpio_init_param *gpio_dclkmode;
 	/** DCLKIO GPIO initialization structure. */
-	struct gpio_init_param gpio_dclkio;
+	struct gpio_init_param *gpio_dclkio;
 	/** RESET GPIO initialization structure. */
-	struct gpio_init_param gpio_resetn;
+	struct gpio_init_param *gpio_resetn;
 	/** PDN GPIO initialization structure. */
-	struct gpio_init_param gpio_pnd;
+	struct gpio_init_param *gpio_pnd;
 	/** MODE GPIO starting value */
 	bool mode_master_nslave;
 	/** DCLKMODE GPIO starting value */


### PR DESCRIPTION
In certain applications the GPIOs are not going to be software controlled.
Make the GPIO usage optional for this use case.

Signed-off-by: Andrei Drimbarean <Andrei.Drimbarean@analog.com>