### PR TITLE
util: Fix greatest_common_divisor() when one given number is 0

### DIFF
--- a/util/util.c
+++ b/util/util.c
@@ -137,6 +137,9 @@ uint32_t greatest_common_divisor(uint32_t a,
 	uint32_t div;
 	uint32_t common_div = 1;
 
+	if ((a == 0) || (b == 0))
+		return max(a, b);
+
 	for (div = 1; (div <= a) && (div <= b); div++)
 		if (!(a % div) && !(b % div))
 			common_div = div;


### PR DESCRIPTION
When one of the given numbers is 0, the greatest common divisor is the
maximum between the two numbers.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>