### PR TITLE
Add mbedtls library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "libraries/libtinyiiod"]
 	path = libraries/libtinyiiod
 	url = https://github.com/analogdevicesinc/libtinyiiod
+[submodule "libraries/mbedtls"]
+	path = libraries/mbedtls
+	url = https://github.com/ARMmbed/mbedtls

--- a/network/transport/noos_mbedtls_config.h
+++ b/network/transport/noos_mbedtls_config.h
@@ -1,0 +1,89 @@
+/***************************************************************************//**
+ *   @file   noos_mbedtls_config.h
+ *   @brief  Config to build mbedtls library
+ *   @author Mihail Chindris (mihail.chindris@analog.com)
+********************************************************************************
+ *   @copyright
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef MBEDTLS_CONFIG_H
+#define MBEDTLS_CONFIG_H
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+#define MBEDTLS_NO_PLATFORM_ENTROPY
+#define MBEDTLS_DEBUG_C
+#define MBEDTLS_ERROR_C
+#define MBEDTLS_SSL_MAX_CONTENT_LEN             3500
+
+/* mbed TLS feature support */
+#define MBEDTLS_CIPHER_MODE_CBC
+#define MBEDTLS_PKCS1_V15
+#define MBEDTLS_KEY_EXCHANGE_RSA_ENABLED
+#define MBEDTLS_SSL_PROTO_TLS1_1
+
+/* mbed TLS modules */
+#define MBEDTLS_AES_C
+#define MBEDTLS_ASN1_PARSE_C
+#define MBEDTLS_ASN1_WRITE_C
+#define MBEDTLS_BIGNUM_C
+#define MBEDTLS_CIPHER_C
+#define MBEDTLS_CTR_DRBG_C
+#define MBEDTLS_DES_C
+#define MBEDTLS_ENTROPY_C
+#define MBEDTLS_MD_C
+#define MBEDTLS_MD5_C
+#define MBEDTLS_OID_C
+#define MBEDTLS_PK_C
+#define MBEDTLS_PK_PARSE_C
+#define MBEDTLS_RSA_C
+#define MBEDTLS_SHA1_C
+#define MBEDTLS_SHA256_C
+#define MBEDTLS_SSL_CLI_C
+#define MBEDTLS_SSL_TLS_C
+#define MBEDTLS_X509_CRT_PARSE_C
+#define MBEDTLS_X509_CRL_PARSE_C
+#define MBEDTLS_X509_CSR_PARSE_C
+#define MBEDTLS_X509_USE_C
+
+/* For test certificates */
+#define MBEDTLS_BASE64_C
+#define MBEDTLS_PEM_PARSE_C
+
+#include "mbedtls/check_config.h"
+
+#endif /* MBEDTLS_CONFIG_H */

--- a/tools/scripts/linux.mk
+++ b/tools/scripts/linux.mk
@@ -96,6 +96,13 @@ CFLAGS += -D IIO_EXAMPLE
 CFLAGS += -D _USE_STD_INT_TYPES
 endif
 
+ifeq (y,$(strip $(MBEDTLS)))
+#Specify configuration file to build mbedtls
+CFLAGS += -I $(NO-OS)/network/transport -D MBEDTLS_CONFIG_FILE='"noos_mbedtls_config.h"'
+#Add mbedtls include directory to inlcude path
+INCLUDE += $(NO-OS)/libraries/mbedtls/include
+endif
+
 #------------------------------------------------------------------------------
 #                            COMMON LINKER FLAGS                               
 #------------------------------------------------------------------------------
@@ -324,6 +331,9 @@ copy-srcs:
 clean:
 	$(call print,Cleaning build workspace \n)
 	rm -rf $(BUILD_DIR)
+	# Clean mbedtls only if submodule exists
+	( ! test -f $(LIBRARIES)/mbedtls/Makefile ) || \
+	$(MAKE) -C $(LIBRARIES)/mbedtls clean
 
 # If the hardware file is not specified, start searching for one
 # Check for .hdf files inside the project directory
@@ -377,7 +387,15 @@ altera-elf:
 libs:
 ifeq (y,$(strip $(TINYIIOD)))
 	@$(MAKE) -C $(LIBRARIES)/libtinyiiod re
+endif
+ifeq (y,$(strip $(MBEDTLS)))
+	@$(MAKE) -C $(LIBRARIES)/mbedtls lib
+endif
+ifeq (y,$(strip $(TINYIIOD)))
 LIBS += -L $(LIBRARIES)/libtinyiiod/build -ltinyiiod
+endif
+ifeq (y,$(strip $(MBEDTLS)))
+LIBS += -L $(LIBRARIES)/mbedtls/library -lmbedtls -lmbedx509 -lmbedcrypto
 endif
 
 .SILENT:pre-build


### PR DESCRIPTION
- Add mbedtls library that will be used for tls sockets.
- Add config file to build mbedtls library
- Add dummy makefile of how mbedtls should be integrated