### PR TITLE
Add EAGAIN error to error.h

### DIFF
--- a/include/error.h
+++ b/include/error.h
@@ -53,4 +53,6 @@
 
 #define IS_ERR_VALUE(x)	((x) < 0)
 
+#define	EAGAIN		11
+
 #endif // ERROR_H_

--- a/network/data_link/at_parser.c
+++ b/network/data_link/at_parser.c
@@ -53,6 +53,7 @@
 #include "uart.h"
 #include "irq.h"
 #include "util.h"
+#include "error.h"
 
 /******************************************************************************/
 /********************** Macros and Constants Definitions **********************/
@@ -988,6 +989,9 @@ end:
 		desc->errors = 0;
 		return -ret;
 	}
+
+	if (to_read == 0)
+		return -EAGAIN;
 
 	return to_read;
 }


### PR DESCRIPTION
- This is needed in order to implement secure tcp socket with mbedtls.
- EAGAIN will be returned when socket_recv is called but there is no data available. If 0 is returned doesn't work with mbedtls.
- An other other error name can be used, depending what noos team decides.
- Changes have been made in mqtt_noos_read and in at_read_buffer to adapt them to the new change.
