### PR TITLE
SPI Demux

### DIFF
--- a/drivers/io-expander/demux_spi/demux_spi.c
+++ b/drivers/io-expander/demux_spi/demux_spi.c
@@ -1,0 +1,158 @@
+/***************************************************************************//**
+ *   @file   demux_spi.c
+ *   @brief  Implementation of the SPI Demux Interface
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include "demux_spi.h"
+#include "error.h"
+#include <stdlib.h>
+#include <string.h>
+
+/******************************************************************************/
+/**************************** Types Definitions *******************************/
+/******************************************************************************/
+
+/**
+ * @brief Demux specific SPI platform ops structure
+ */
+const struct spi_platform_ops demux_spi_platform_ops = {
+	.spi_ops_init = demux_spi_init,
+	.spi_ops_remove = demux_spi_remove,
+	.spi_ops_write_and_read = demux_spi_write_and_read
+};
+
+/**
+ * @brief Initialize the SPI demux layer.
+ * @param desc - The SPI descriptor.
+ * @param param - The structure that contains the SPI parameters.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t demux_spi_init(struct spi_desc **desc,
+		       const struct spi_init_param *param)
+{
+	int32_t ret;
+
+	struct spi_desc *descriptor;
+	struct spi_desc *spi_dev_desc;
+	struct spi_init_param *spi_dev_param;
+
+	if (!param)
+		return FAILURE;
+
+	descriptor = (struct spi_desc *)calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return FAILURE;
+
+	descriptor->chip_select = param->chip_select;
+	descriptor->max_speed_hz = param->max_speed_hz;
+	descriptor->mode = param->mode;
+
+	spi_dev_param = param->extra;
+
+	ret = spi_init(&spi_dev_desc, spi_dev_param);
+	if (ret != SUCCESS) {
+		free(descriptor);
+		return FAILURE;
+	}
+
+	(descriptor->extra) = spi_dev_desc;
+
+	*desc = descriptor;
+
+	return ret;
+}
+
+/**
+ * @brief Free the resources allocated by demux_spi_init().
+ * @param desc - The SPI descriptor.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t demux_spi_remove(struct spi_desc *desc)
+{
+	if (!desc)
+		return FAILURE;
+
+	if (spi_remove(desc->extra))
+		return FAILURE;
+
+	free(desc);
+
+	return SUCCESS;
+}
+
+/**
+ * @brief Write and read data to/from SPI demux layer.
+ * @param desc - The SPI descriptor.
+ * @param data - The buffer with the transmitted/received data.
+ * @param bytes_number - Number of bytes to write/read.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t demux_spi_write_and_read(struct spi_desc *desc, uint8_t *data,
+				 uint16_t bytes_number)
+{
+	int32_t ret;
+	uint8_t cs;
+	uint8_t *buff;
+
+	struct spi_desc *spi_dev;
+
+	if (!desc)
+		return FAILURE;
+
+	buff = malloc(sizeof(*buff) * (bytes_number+1));
+	if (!buff)
+		return FAILURE;
+
+	spi_dev = desc->extra;
+	cs = CS_OFFSET | desc->chip_select;
+
+	buff[0] = cs;
+	memcpy((buff+1), data, bytes_number);
+
+	ret = spi_write_and_read(spi_dev, buff, bytes_number+1);
+
+	memcpy(data, buff+1, bytes_number);
+
+	free(buff);
+
+	return ret;
+}
+

--- a/drivers/io-expander/demux_spi/demux_spi.h
+++ b/drivers/io-expander/demux_spi/demux_spi.h
@@ -1,0 +1,80 @@
+/***************************************************************************//**
+ *   @file   demux_spi.h
+ *   @brief  Header file of SPI Demux Interface
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef SRC_DEMUX_SPI_H_
+#define SRC_DEMUX_SPI_H_
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include "spi.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+#define CS_OFFSET 0x80
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+
+/**
+ * @struct spi_desc
+ * @brief Structure initialization with the platform specific SPI functions
+ */
+extern const struct spi_platform_ops demux_spi_platform_ops;
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+/* Initialize the SPI communication peripheral. */
+int32_t demux_spi_init(struct spi_desc **desc,
+		       const struct spi_init_param *param);
+
+/* Free the resources allocated by spi_init(). */
+int32_t demux_spi_remove(struct spi_desc *desc);
+
+/* Write and read data to/from SPI. */
+int32_t demux_spi_write_and_read(struct spi_desc *desc, uint8_t *data,
+				 uint16_t bytes_number);
+
+#endif /* SRC_DEMUX_SPI_H_ */

--- a/projects/fmcjesdadc1/src.mk
+++ b/projects/fmcjesdadc1/src.mk
@@ -19,6 +19,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c			\
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c			\
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
+	$(DRIVERS)/io-expander/demux_spi/demux_spi.c			\
 	$(DRIVERS)/spi/spi.c						\
 	$(PROJECT)/src/devices/ad9250/ad9250.c				\
 	$(PROJECT)/src/devices/ad9517/ad9517.c
@@ -35,6 +36,7 @@ INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h			\
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h			\
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h			\
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h		\
+	$(DRIVERS)/io-expander/demux_spi/demux_spi.h			\
 	$(PROJECT)/src/devices/ad9250/ad9250.h				\
 	$(PROJECT)/src/devices/ad9517/ad9517.h				
 INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\

--- a/projects/fmcjesdadc1/src/README
+++ b/projects/fmcjesdadc1/src/README
@@ -8,6 +8,8 @@ cp ../../../include/gpio.h devices/adi_hal/
 cp ../../../include/delay.h devices/adi_hal/		
 cp ../../../drivers/platform/xilinx/axi_io.c devices/adi_hal/
 cp ../../../drivers/spi/spi.c devices/adi_hal/
+cp ../../../drivers/io-expander/demux_spi.h devices/adi_hal/
+cp ../../../drivers/io-expander/demux_spi.c devices/adi_hal/
 cp ../../../drivers/platform/xilinx/xilinx_spi.c devices/adi_hal/
 cp ../../../drivers/platform/xilinx/spi_extra.h devices/adi_hal/
 cp ../../../drivers/platform/xilinx/gpio.c devices/adi_hal/

--- a/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
+++ b/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
@@ -59,6 +59,7 @@
 #include "axi_adc_core.h"
 #include "axi_dmac.h"
 #include "axi_jesd204_rx.h"
+#include "demux_spi.h"
 
 /***************************************************************************//**
 * @brief main
@@ -67,20 +68,33 @@ int main(void)
 {
 
 	int32_t status;
-
 	// SPI configuration
-	struct spi_init_param ad9250_spi_param = {
+	struct spi_init_param demux_spi_param = {
 		.max_speed_hz = 2000000u,
 		.chip_select = 0,
 		.mode = SPI_MODE_0,
 		.platform_ops = &xil_platform_ops
 	};
 
-	struct spi_init_param ad9517_spi_param = {
-		.max_speed_hz = 2000000u,
+	struct spi_init_param ad9250_0_spi_param = {
+		.max_speed_hz = demux_spi_param.max_speed_hz,
 		.chip_select = 0,
-		.mode = SPI_MODE_0,
-		.platform_ops = &xil_platform_ops
+		.mode = demux_spi_param.mode,
+		.platform_ops = &demux_spi_platform_ops
+	};
+
+	struct spi_init_param ad9250_1_spi_param = {
+		.max_speed_hz = demux_spi_param.max_speed_hz,
+		.chip_select = 1,
+		.mode = demux_spi_param.mode,
+		.platform_ops = &demux_spi_platform_ops
+	};
+
+	struct spi_init_param ad9517_spi_param = {
+		.max_speed_hz = demux_spi_param.max_speed_hz,
+		.chip_select = 4,
+		.mode = demux_spi_param.mode,
+		.platform_ops = &demux_spi_platform_ops
 	};
 
 	struct xil_spi_init_param xil_spi_param = {
@@ -91,8 +105,11 @@ int main(void)
 #endif
 		.device_id = SPI_DEVICE_ID
 	};
-	ad9250_spi_param.extra = &xil_spi_param;
-	ad9517_spi_param.extra = &xil_spi_param;
+
+	demux_spi_param.extra = &xil_spi_param;
+	ad9250_0_spi_param.extra = &demux_spi_param;
+	ad9250_1_spi_param.extra = &demux_spi_param;
+	ad9517_spi_param.extra = &demux_spi_param;
 
 	struct gpio_init_param gpio_sysref_param = {
 		.number = GPIO_JESD204_SYSREF
@@ -172,8 +189,8 @@ int main(void)
 
 	// SPI configuration
 	ad9517_param.spi_init = ad9517_spi_param;
-	ad9250_0_param.spi_init = ad9250_spi_param;
-	ad9250_1_param.spi_init = ad9250_spi_param;
+	ad9250_0_param.spi_init = ad9250_0_spi_param;
+	ad9250_1_param.spi_init = ad9250_1_spi_param;
 
 	ad9250_0_param.id_no = 0x0;
 	ad9250_1_param.id_no = 0x1;

--- a/projects/fmcjesdadc1/src/devices/ad9250/ad9250.c
+++ b/projects/fmcjesdadc1/src/devices/ad9250/ad9250.c
@@ -53,16 +53,15 @@ int32_t ad9250_spi_read(struct ad9250_dev *dev,
 			uint16_t reg_addr,
 			uint8_t *reg_data)
 {
-	uint8_t buf[4];
+	uint8_t buf[3];
 	int32_t ret;
 
-	buf[0] = 0x80 | dev->id_no;
-	buf[1] = 0x80 | (reg_addr >> 8);
-	buf[2] = reg_addr & 0xFF;
-	buf[3] = 0x00;
+	buf[0] = 0x80 | (reg_addr >> 8);
+	buf[1] = reg_addr & 0xFF;
+	buf[2] = 0x00;
 
-	ret = spi_write_and_read(dev->spi_dev, buf, 4);
-	*reg_data = buf[3];
+	ret = spi_write_and_read(dev->spi_dev, buf, 3);
+	*reg_data = buf[2];
 
 	return ret;
 }
@@ -74,15 +73,14 @@ int32_t ad9250_spi_write(struct ad9250_dev *dev,
 			 uint16_t reg_addr,
 			 uint8_t reg_data)
 {
-	uint8_t buf[4];
+	uint8_t buf[3];
 	int32_t ret;
 
-	buf[0] = 0x80 | dev->id_no;
-	buf[1] = reg_addr >> 8;
-	buf[2] = reg_addr & 0xFF;
-	buf[3] = reg_data;
+	buf[0] = reg_addr >> 8;
+	buf[1] = reg_addr & 0xFF;
+	buf[2] = reg_data;
 
-	ret = spi_write_and_read(dev->spi_dev, buf, 4);
+	ret = spi_write_and_read(dev->spi_dev, buf, 3);
 
 	return ret;
 }

--- a/projects/fmcjesdadc1/src/devices/ad9517/ad9517.c
+++ b/projects/fmcjesdadc1/src/devices/ad9517/ad9517.c
@@ -58,16 +58,15 @@ int32_t ad9517_spi_read(struct ad9517_dev *dev,
 			uint16_t reg_addr,
 			uint8_t *reg_data)
 {
-	uint8_t buf[4];
+	uint8_t buf[3];
 	int32_t ret;
 
-	buf[0] = 0x84;
-	buf[1] = 0x80 | (reg_addr >> 8);
-	buf[2] = reg_addr & 0xFF;
-	buf[3] = 0x00;
+	buf[0] = 0x80 | (reg_addr >> 8);
+	buf[1] = reg_addr & 0xFF;
+	buf[2] = 0x00;
 
-	ret = spi_write_and_read(dev->spi_desc, buf, 4);
-	*reg_data = buf[3];
+	ret = spi_write_and_read(dev->spi_desc, buf, 3);
+	*reg_data = buf[2];
 
 	return ret;
 }
@@ -79,15 +78,14 @@ int32_t ad9517_spi_write(struct ad9517_dev *dev,
 			 uint16_t reg_addr,
 			 uint8_t reg_data)
 {
-	uint8_t buf[4];
+	uint8_t buf[3];
 	int32_t ret;
 
-	buf[0] = 0x84;
-	buf[1] = reg_addr >> 8;
-	buf[2] = reg_addr & 0xFF;
-	buf[3] = reg_data;
+	buf[0] = reg_addr >> 8;
+	buf[1] = reg_addr & 0xFF;
+	buf[2] = reg_data;
 
-	ret = spi_write_and_read(dev->spi_desc, buf, 4);
+	ret = spi_write_and_read(dev->spi_desc, buf, 3);
 
 	return ret;
 }


### PR DESCRIPTION
1. Add an intermediary Demux SPI layer to configure device selection via SPI data transfer.
2. fmcjesdadc1: add support for the demux SPI layer.

Signed-off-by: Antoniu Miclaus antoniu.miclaus@analog.com

