### PR TITLE
SPI Generic Layer

### DIFF
--- a/drivers/io-expander/demux_spi/demux_spi.c
+++ b/drivers/io-expander/demux_spi/demux_spi.c
@@ -1,0 +1,148 @@
+/***************************************************************************//**
+ *   @file   demux_spi.c
+ *   @brief  Implementation of the SPI Demux Interface
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include "demux_spi.h"
+#include "error.h"
+#include <stdlib.h>
+#include <string.h>
+
+/******************************************************************************/
+/**************************** Types Definitions *******************************/
+/******************************************************************************/
+
+/**
+ * @brief Demux specific SPI platform ops structure
+ */
+const struct spi_platform_ops demux_spi_platform_ops = {
+	.spi_ops_init = demux_spi_init,
+	.spi_ops_remove = demux_spi_remove,
+	.spi_ops_write_and_read = demux_spi_write_and_read
+};
+
+/**
+ * @brief Initialize the SPI demux layer.
+ * @param desc - The SPI descriptor.
+ * @param param - The structure that contains the SPI parameters.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t demux_spi_init(struct spi_desc **desc,
+		       const struct spi_init_param *param)
+{
+	int32_t ret;
+
+	struct spi_desc *descriptor;
+	struct spi_desc *spi_dev_desc;
+	struct spi_init_param *spi_dev_param;
+
+	if (!param)
+		return FAILURE;
+
+	descriptor = (struct spi_desc *)calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return FAILURE;
+
+	descriptor->chip_select = param->chip_select;
+	descriptor->max_speed_hz = param->max_speed_hz;
+	descriptor->mode = param->mode;
+
+	spi_dev_param = param->extra;
+
+	ret = spi_init(&spi_dev_desc, spi_dev_param);
+
+	(descriptor->extra) = spi_dev_desc;
+
+	*desc = descriptor;
+
+	return ret;
+}
+
+/**
+ * @brief Free the resources allocated by demux_spi_init().
+ * @param desc - The SPI descriptor.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t demux_spi_remove(struct spi_desc *desc)
+{
+	if (spi_remove(desc->extra))
+		return FAILURE;
+
+	free(desc);
+
+	return SUCCESS;
+}
+
+/**
+ * @brief Write and read data to/from SPI demux layer.
+ * @param desc - The SPI descriptor.
+ * @param data - The buffer with the transmitted/received data.
+ * @param bytes_number - Number of bytes to write/read.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t demux_spi_write_and_read(struct spi_desc *desc, uint8_t *data,
+				 uint16_t bytes_number)
+{
+	int32_t ret;
+	uint8_t cs;
+	uint8_t *buff;
+
+	struct spi_desc *spi_dev;
+
+	buff = malloc(sizeof(*buff) * (bytes_number+1));
+	if (!buff)
+		return FAILURE;
+
+	spi_dev = desc->extra;
+	cs = CS_OFFSET | desc->chip_select;
+
+	buff[0] = cs;
+	memcpy((buff+1), data, bytes_number);
+
+	ret = spi_write_and_read(spi_dev, buff, bytes_number+1);
+
+	memcpy(data, buff+1, bytes_number);
+
+	free(buff);
+
+	return ret;
+}
+

--- a/drivers/io-expander/demux_spi/demux_spi.h
+++ b/drivers/io-expander/demux_spi/demux_spi.h
@@ -1,0 +1,80 @@
+/***************************************************************************//**
+ *   @file   demux_spi.h
+ *   @brief  Header file of SPI Demux Interface
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef SRC_DEMUX_SPI_H_
+#define SRC_DEMUX_SPI_H_
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include "spi.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+#define CS_OFFSET 0x80
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+
+/**
+ * @struct spi_desc
+ * @brief Structure initialization with the platform specific SPI functions
+ */
+extern const struct spi_platform_ops demux_spi_platform_ops;
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+/* Initialize the SPI communication peripheral. */
+int32_t demux_spi_init(struct spi_desc **desc,
+		       const struct spi_init_param *param);
+
+/* Free the resources allocated by spi_init(). */
+int32_t demux_spi_remove(struct spi_desc *desc);
+
+/* Write and read data to/from SPI. */
+int32_t demux_spi_write_and_read(struct spi_desc *desc, uint8_t *data,
+				 uint16_t bytes_number);
+
+#endif /* SRC_DEMUX_SPI_H_ */

--- a/drivers/platform/altera/altera_spi.c
+++ b/drivers/platform/altera/altera_spi.c
@@ -1,5 +1,5 @@
 /***************************************************************************//**
- *   @file   altera/spi.c
+ *   @file   altera/altera_spi.c
  *   @brief  Implementation of Altera SPI Generic Driver.
  *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
 ********************************************************************************
@@ -53,13 +53,22 @@
 /******************************************************************************/
 
 /**
+ * @brief Altera platform specific SPI platform ops structure
+ */
+const struct spi_platform_ops altera_platform_ops = {
+	.spi_ops_init = &altera_spi_init,
+	.spi_ops_write_and_read = &altera_spi_write_and_read,
+	.spi_ops_remove = &altera_spi_remove
+};
+
+/**
  * @brief Initialize the SPI communication peripheral.
  * @param desc - The SPI descriptor.
  * @param param - The structure that contains the SPI parameters.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t spi_init(struct spi_desc **desc,
-		 const struct spi_init_param *param)
+int32_t altera_spi_init(struct spi_desc **desc,
+			const struct spi_init_param *param)
 {
 	spi_desc *descriptor;
 	struct altera_spi_desc *altera_descriptor;
@@ -95,7 +104,7 @@ int32_t spi_init(struct spi_desc **desc,
  * @param desc - The SPI descriptor.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t spi_remove(struct spi_desc *desc)
+int32_t altera_spi_remove(struct spi_desc *desc)
 {
 	if (desc) {
 		// Unused variable - fix compiler warning
@@ -112,9 +121,9 @@ int32_t spi_remove(struct spi_desc *desc)
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
 
-int32_t spi_write_and_read(struct spi_desc *desc,
-			   uint8_t *data,
-			   uint16_t bytes_number)
+int32_t altera_spi_write_and_read(struct spi_desc *desc,
+				  uint8_t *data,
+				  uint16_t bytes_number)
 {
 	uint32_t i;
 	struct altera_spi_desc *altera_desc;

--- a/drivers/platform/altera/spi_extra.h
+++ b/drivers/platform/altera/spi_extra.h
@@ -79,4 +79,18 @@ struct altera_spi_desc {
 	uint32_t	base_address;
 } altera_spi_desc;
 
+/**
+ * @brief Altera specific SPI platform ops structure
+ */
+extern const struct spi_platform_ops altera_platform_ops;
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+int32_t altera_spi_init(struct spi_desc **desc,
+			const struct spi_init_param *param);
+int32_t altera_spi_remove(struct spi_desc *desc);
+int32_t altera_spi_write_and_read(struct spi_desc *desc, uint8_t *data,
+				  uint16_t bytes_number);
+
 #endif /* SPI_EXTRA_H_ */

--- a/drivers/platform/xilinx/spi_extra.h
+++ b/drivers/platform/xilinx/spi_extra.h
@@ -98,4 +98,24 @@ typedef struct xil_spi_desc {
 	void			*instance;
 } xil_spi_desc;
 
+/**
+ * @brief Xilinx platform specific SPI platform ops structure
+ */
+extern const struct spi_platform_ops xil_platform_ops;
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+/* Initialize the SPI communication peripheral. */
+int32_t xil_spi_init(struct spi_desc **desc,
+		     const struct spi_init_param *param);
+
+/* Free the resources allocated by spi_init(). */
+int32_t xil_spi_remove(struct spi_desc *desc);
+
+/* Write and read data to/from SPI. */
+int32_t xil_spi_write_and_read(struct spi_desc *desc, uint8_t *data,
+			       uint16_t bytes_number);
+
 #endif // SPI_EXTRA_H_

--- a/drivers/platform/xilinx/xilinx_spi.c
+++ b/drivers/platform/xilinx/xilinx_spi.c
@@ -1,5 +1,5 @@
 /***************************************************************************//**
- *   @file   xilinx/spi.c
+ *   @file   xilinx/xilinx_spi.c
  *   @brief  Implementation of Xilinx SPI Generic Driver.
  *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
 ********************************************************************************
@@ -71,6 +71,16 @@
 /******************************************************************************/
 /************************ Functions Definitions *******************************/
 /******************************************************************************/
+
+
+/**
+ * @brief Xilinx platform specific SPI platform ops structure
+ */
+const struct spi_platform_ops xil_platform_ops = {
+	.spi_ops_init = &xil_spi_init,
+	.spi_ops_write_and_read = &xil_spi_write_and_read,
+	.spi_ops_remove = &xil_spi_remove
+};
 
 /**
  * @brief Initialize the hardware SPI peripherial
@@ -252,8 +262,8 @@ ps_error:
  * @param param - The structure that contains the SPI parameters.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t spi_init(struct spi_desc **desc,
-		 const struct spi_init_param *param)
+int32_t xil_spi_init(struct spi_desc **desc,
+		     const struct spi_init_param *param)
 {
 	int32_t				ret;
 	enum xil_spi_type		*spi_type;
@@ -316,7 +326,7 @@ init_error:
  * @param desc - The SPI descriptor.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t spi_remove(struct spi_desc *desc)
+int32_t xil_spi_remove(struct spi_desc *desc)
 {
 #ifdef XSPI_H
 	int32_t				ret;
@@ -384,10 +394,9 @@ error:
  * @param bytes_number - Number of bytes to write/read.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-
-int32_t spi_write_and_read(struct spi_desc *desc,
-			   uint8_t *data,
-			   uint16_t bytes_number)
+int32_t xil_spi_write_and_read(struct spi_desc *desc,
+			       uint8_t *data,
+			       uint16_t bytes_number)
 {
 	int32_t			ret;
 	struct xil_spi_desc	*xdesc;

--- a/drivers/spi/spi.c
+++ b/drivers/spi/spi.c
@@ -1,0 +1,88 @@
+/***************************************************************************//**
+ *   @file   spi.c
+ *   @brief  Implementation of the SPI Interface
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <inttypes.h>
+#include "spi.h"
+#include <stdlib.h>
+#include "error.h"
+
+/**
+ * @brief Initialize the SPI communication peripheral.
+ * @param desc - The SPI descriptor.
+ * @param param - The structure that contains the SPI parameters.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t spi_init(struct spi_desc **desc,
+		 const struct spi_init_param *param)
+{
+
+	if (!param)
+		return FAILURE;
+
+	if ((param->platform_ops->spi_ops_init(desc, param)))
+		return FAILURE;
+
+	(*desc)->platform_ops = param->platform_ops;
+
+	return SUCCESS;
+}
+
+/**
+ * @brief Free the resources allocated by spi_init().
+ * @param desc - The SPI descriptor.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t spi_remove(struct spi_desc *desc)
+{
+	return desc->platform_ops->spi_ops_remove(desc);
+}
+
+/**
+ * @brief Write and read data to/from SPI.
+ * @param desc - The SPI descriptor.
+ * @param data - The buffer with the transmitted/received data.
+ * @param bytes_number - Number of bytes to write/read.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t spi_write_and_read(struct spi_desc *desc,
+			   uint8_t *data,
+			   uint16_t bytes_number)
+{
+	return (desc->platform_ops->spi_ops_write_and_read(desc, data, bytes_number));
+}

--- a/include/spi.h
+++ b/include/spi.h
@@ -73,6 +73,13 @@ typedef enum spi_mode {
 } spi_mode;
 
 /**
+ * @struct spi_platform_ops
+ * @brief Structure holding SPI function pointers that point to the platform
+ * specific function
+ */
+struct spi_platform_ops ;
+
+/**
  * @struct spi_init_param
  * @brief Structure holding the parameters for SPI initialization
  */
@@ -83,6 +90,7 @@ typedef struct spi_init_param {
 	uint8_t		chip_select;
 	/** SPI mode */
 	enum spi_mode	mode;
+	const struct spi_platform_ops *platform_ops;
 	/**  SPI extra parameters (device specific) */
 	void		*extra;
 } spi_init_param;
@@ -98,9 +106,24 @@ typedef struct spi_desc {
 	uint8_t		chip_select;
 	/** SPI mode */
 	enum spi_mode	mode;
+	const struct spi_platform_ops *platform_ops;
 	/**  SPI extra parameters (device specific) */
 	void		*extra;
 } spi_desc;
+
+/**
+ * @struct spi_platform_ops
+ * @brief Structure holding SPI function pointers that point to the platform
+ * specific function
+ */
+struct spi_platform_ops {
+	/** SPI initialization function pointer */
+	int32_t (*spi_ops_init)(struct spi_desc **, const struct spi_init_param *);
+	/** SPI write/read function pointer */
+	int32_t (*spi_ops_write_and_read)(struct spi_desc *, uint8_t *, uint16_t);
+	/** SPI remove function pointer */
+	int32_t (*spi_ops_remove)(struct spi_desc *);
+};
 
 /******************************************************************************/
 /************************ Functions Declarations ******************************/

--- a/projects/ad9081/src.mk
+++ b/projects/ad9081/src.mk
@@ -27,10 +27,11 @@ SRCS := $(PROJECT)/src/app.c						\
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c			\
 	$(DRIVERS)/axi_core/jesd204/jesd204_clk.c			\
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
+	$(DRIVERS)/spi/spi.c						\
 	$(PLATFORM_DRIVERS)/axi_io.c					\
 	$(PLATFORM_DRIVERS)/delay.c					\
 	$(PLATFORM_DRIVERS)/gpio.c					\
-	$(PLATFORM_DRIVERS)/spi.c					\
+	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
 	$(NO-OS)/util/clk.c						\
 	$(NO-OS)/util/util.c
 ifeq (y,$(strip $(TINYIIOD)))

--- a/projects/ad9081/src/app.c
+++ b/projects/ad9081/src/app.c
@@ -84,6 +84,7 @@ int main(void)
 		.max_speed_hz = 1000000,
 		.mode = SPI_MODE_0,
 		.chip_select = PHY_CS,
+		.platform_ops = &xil_platform_ops,
 		.extra = &xil_spi_param
 	};
 	struct link_init_param jesd_tx_link = {

--- a/projects/ad9081/src/app_clock.c
+++ b/projects/ad9081/src/app_clock.c
@@ -87,6 +87,7 @@ int32_t app_clock_init(struct clk clk[NUM_APP_CLKS])
 		.max_speed_hz = 10000000,
 		.mode = SPI_MODE_0,
 		.chip_select = CLK_CS,
+		.platform_ops = &xil_platform_ops,
 		.extra = &xil_spi_param
 	};
 

--- a/projects/ad9172/src.mk
+++ b/projects/ad9172/src.mk
@@ -10,7 +10,8 @@
 ################################################################################
 
 SRCS := $(PROJECT)/src/main.c
-SRCS += $(DRIVERS)/frequency/hmc7044/hmc7044.c				\
+SRCS += $(DRIVERS)/spi/spi.c						\
+	$(DRIVERS)/frequency/hmc7044/hmc7044.c				\
 	$(DRIVERS)/dac/ad917x/ad9172.c					\
 	$(DRIVERS)/dac/ad917x/ad917x_api/ad917x_api.c			\
 	$(DRIVERS)/dac/ad917x/ad917x_api/ad917x_jesd_api.c		\
@@ -25,7 +26,7 @@ SRCS += $(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c			\
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
 	$(NO-OS)/util/util.c
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/spi.c					\
+	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
 	$(PLATFORM_DRIVERS)/gpio.c					\
 	$(PLATFORM_DRIVERS)/delay.c
 INCS := $(PROJECT)/src/parameters.h					\

--- a/projects/ad9172/src/README
+++ b/projects/ad9172/src/README
@@ -6,9 +6,10 @@
 	cp ../../../include/spi.h ./
 	cp ../../../include/gpio.h ./
 	cp ../../../include/delay.h ./
+	cp ../../../drivers/spi/spi.c ./
 	cp ../../../drivers/platform/xilinx/axi_io.c ./
 	cp ../../../drivers/platform/xilinx/spi_extra.h ./
-	cp ../../../drivers/platform/xilinx/spi.c ./
+	cp ../../../drivers/platform/xilinx/xilinx_spi.c ./
 	cp ../../../drivers/platform/xilinx/gpio_extra.h ./
 	cp ../../../drivers/platform/xilinx/gpio.c ./
 	cp ../../../drivers/platform/xilinx/delay.c ./

--- a/projects/ad9172/src/main.c
+++ b/projects/ad9172/src/main.c
@@ -77,6 +77,7 @@ int main(void)
 		.max_speed_hz = 10000000,
 		.mode = SPI_MODE_0,
 		.chip_select = SPI_HMC7044_CS,
+		.platform_ops = &xil_platform_ops,
 		.extra = &xil_spi_param
 	};
 
@@ -132,6 +133,7 @@ int main(void)
 		.max_speed_hz = 1000000,
 		.mode = SPI_MODE_0,
 		.chip_select = SPI_AD9172_CS,
+		.platform_ops = &xil_platform_ops,
 		.extra = &xil_spi_param
 	};
 

--- a/projects/ad9208/src.mk
+++ b/projects/ad9208/src.mk
@@ -10,7 +10,8 @@
 ################################################################################
 
 SRCS := $(PROJECT)/src/main.c
-SRCS += $(DRIVERS)/frequency/hmc7044/hmc7044.c				\
+SRCS += $(DRIVERS)/spi/spi.c						\
+	$(DRIVERS)/frequency/hmc7044/hmc7044.c				\
 	$(DRIVERS)/adc/ad9208/ad9208.c 					\
 	$(DRIVERS)/adc/ad9208/ad9208_api/ad9208_adc_api.c 		\
 	$(DRIVERS)/adc/ad9208/ad9208_api/ad9208_api.c 			\
@@ -26,7 +27,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
 	$(NO-OS)/util/util.c
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/spi.c					\
+	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
 	$(PLATFORM_DRIVERS)/gpio.c					\
 	$(PLATFORM_DRIVERS)/delay.c
 INCS := $(PROJECT)/src/parameters.h

--- a/projects/ad9208/src/README
+++ b/projects/ad9208/src/README
@@ -5,9 +5,10 @@
 	cp ../../../include/spi.h ./
 	cp ../../../include/gpio.h ./
 	cp ../../../include/delay.h ./
+	cp ../../../drivers/spi/spi.c ./
 	cp ../../../drivers/platform/xilinx/axi_io.c ./
 	cp ../../../drivers/platform/xilinx/spi_extra.h ./
-	cp ../../../drivers/platform/xilinx/spi.c ./
+	cp ../../../drivers/platform/xilinx/xilinx_spi.c ./
 	cp ../../../drivers/platform/xilinx/gpio_extra.h ./
 	cp ../../../drivers/platform/xilinx/gpio.c ./
 	cp ../../../drivers/platform/xilinx/delay.c ./

--- a/projects/ad9208/src/main.c
+++ b/projects/ad9208/src/main.c
@@ -77,6 +77,7 @@ int main(void)
 		.max_speed_hz = 10000000,
 		.mode = SPI_MODE_0,
 		.chip_select = SPI_HMC7044_CS,
+		.platform_ops = &xil_platform_ops,
 		.extra = &xil_spi_param
 	};
 
@@ -150,6 +151,7 @@ int main(void)
 		.max_speed_hz = 10000000,
 		.mode = SPI_MODE_3,
 		.chip_select = SPI_AD9208_0_CS,
+		.platform_ops = &xil_platform_ops,
 		.extra = &xil_spi_param
 	};
 
@@ -157,6 +159,7 @@ int main(void)
 		.max_speed_hz = 10000000,
 		.mode = SPI_MODE_3,
 		.chip_select = SPI_AD9208_CS,
+		.platform_ops = &xil_platform_ops,
 		.extra = &xil_spi_param
 	};
 

--- a/projects/ad9361/src.mk
+++ b/projects/ad9361/src.mk
@@ -25,11 +25,12 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
 	$(DRIVERS)/spi/spi.c						\
 	$(NO-OS)/util/util.c
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/spi.c					\
 	$(PLATFORM_DRIVERS)/gpio.c					\
 	$(PLATFORM_DRIVERS)/delay.c
 ifeq (xilinx,$(strip $(PLATFORM)))
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_spi.c
+else
+SRCS +=	$(PLATFORM_DRIVERS)/altera_spi.c
 endif
 ifeq (y,$(strip $(TINYIIOD)))
 SRCS += $(PLATFORM_DRIVERS)/uart.c					\

--- a/projects/ad9361/src.mk
+++ b/projects/ad9361/src.mk
@@ -22,11 +22,15 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c			\
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c			\
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
+	$(DRIVERS)/spi/spi.c						\
 	$(NO-OS)/util/util.c
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
 	$(PLATFORM_DRIVERS)/spi.c					\
 	$(PLATFORM_DRIVERS)/gpio.c					\
 	$(PLATFORM_DRIVERS)/delay.c
+ifeq (xilinx,$(strip $(PLATFORM)))
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_spi.c
+endif
 ifeq (y,$(strip $(TINYIIOD)))
 SRCS += $(PLATFORM_DRIVERS)/uart.c					\
 	$(PLATFORM_DRIVERS)/irq.c					\

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -478,6 +478,7 @@ int main(void)
 	Xil_ICacheEnable();
 	Xil_DCacheEnable();
 	spi_param.extra = &xil_spi_param;
+	spi_param.platform_ops = &xil_platform_ops;
 #endif
 	struct gpio_init_param 	gpio_init;
 	gpio_init.extra = &xil_gpio_param;

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -479,6 +479,8 @@ int main(void)
 	Xil_DCacheEnable();
 	spi_param.extra = &xil_spi_param;
 	spi_param.platform_ops = &xil_platform_ops;
+#else
+	spi_param.platform_ops = &altera_platform_ops;
 #endif
 	struct gpio_init_param 	gpio_init;
 	gpio_init.extra = &xil_gpio_param;

--- a/projects/ad9371/src.mk
+++ b/projects/ad9371/src.mk
@@ -30,11 +30,13 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c			\
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c			\
-	$(NO-OS)/util/util.c
+	$(NO-OS)/util/util.c						\
+	$(DRIVERS)/spi/spi.c
 ifeq (xilinx,$(strip $(PLATFORM)))
 SRCS += $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c			\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c		\
+	$(PLATFORM_DRIVERS)/xilinx_spi.c
 else
 SRCS += $(DRIVERS)/axi_core/clk_altera_a10_fpll/clk_altera_a10_fpll.c	\
 	$(DRIVERS)/axi_core/jesd204/altera_a10_atx_pll.c		\

--- a/projects/ad9371/src.mk
+++ b/projects/ad9371/src.mk
@@ -41,10 +41,10 @@ else
 SRCS += $(DRIVERS)/axi_core/clk_altera_a10_fpll/clk_altera_a10_fpll.c	\
 	$(DRIVERS)/axi_core/jesd204/altera_a10_atx_pll.c		\
 	$(DRIVERS)/axi_core/jesd204/altera_a10_cdr_pll.c		\
-	$(DRIVERS)/axi_core/jesd204/altera_adxcvr.c
+	$(DRIVERS)/axi_core/jesd204/altera_adxcvr.c			\
+	$(PLATFORM_DRIVERS)/altera_spi.c
 endif
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/spi.c					\
 	$(PLATFORM_DRIVERS)/gpio.c					\
 	$(PLATFORM_DRIVERS)/delay.c
 ifeq (y,$(strip $(TINYIIOD)))

--- a/projects/ad9371/src/README
+++ b/projects/ad9371/src/README
@@ -39,8 +39,9 @@
 	cp ../../../include/spi.h devices/adi_hal/
 	cp ../../../include/gpio.h devices/adi_hal/
 	cp ../../../include/delay.h devices/adi_hal/
+	cp ../../../spi/spi.c devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/axi_io.c devices/adi_hal/
-	cp ../../../drivers/platform/xilinx/spi.c devices/adi_hal/
+	cp ../../../drivers/platform/xilinx/xilinx_spi.c devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/spi_extra.h devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/gpio.c devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/gpio_extra.h devices/adi_hal/

--- a/projects/ad9371/src/README
+++ b/projects/ad9371/src/README
@@ -7,8 +7,9 @@
 	cp ../../../include/spi.h devices/adi_hal/
 	cp ../../../include/gpio.h devices/adi_hal/
 	cp ../../../include/delay.h devices/adi_hal/
+	cp ../../../spi/spi.c devices/adi_hal/
 	cp ../../../drivers/platform/altera/axi_io.c devices/adi_hal/
-	cp ../../../drivers/platform/altera/spi.c devices/adi_hal/
+	cp ../../../drivers/platform/altera/altera_spi.c devices/adi_hal/
 	cp ../../../drivers/platform/altera/spi_extra.h devices/adi_hal/
 	cp ../../../drivers/platform/altera/gpio.c devices/adi_hal/
 	cp ../../../drivers/platform/altera/gpio_extra.h devices/adi_hal/

--- a/projects/ad9371/src/devices/adi_hal/common.c
+++ b/projects/ad9371/src/devices/adi_hal/common.c
@@ -85,6 +85,7 @@ int32_t platform_init(void)
 		.type = NIOS_II_GPIO,
 		.base_address = GPIO_BASEADDR
 	};
+	spi_param.platform_ops = &altera_platform_ops;
 	spi_param.extra = &altera_spi_param;
 	gpio_ad9371_resetb_param.extra = &altera_gpio_param;
 	gpio_ad9528_resetb_param.extra = &altera_gpio_param;

--- a/projects/ad9371/src/devices/adi_hal/common.c
+++ b/projects/ad9371/src/devices/adi_hal/common.c
@@ -69,6 +69,7 @@ int32_t platform_init(void)
 		.device_id = GPIO_DEVICE_ID
 	};
 	spi_param.extra = &xilinx_spi_param;
+	spi_param.platform_ops = &xil_platform_ops;
 	gpio_ad9371_resetb_param.extra = &xilinx_gpio_param;
 	gpio_ad9528_resetb_param.extra = &xilinx_gpio_param;
 	gpio_ad9528_sysref_param.extra = &xilinx_gpio_param;

--- a/projects/adrv9009/src.mk
+++ b/projects/adrv9009/src.mk
@@ -39,7 +39,8 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
 	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c			\
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c			\
+	$(DRIVERS)/spi/spi.c
 ifeq (y,$(strip $(TINYIIOD)))
 SRCS += $(NO-OS)/util/xml.c						\
 	$(NO-OS)/util/fifo.c						\
@@ -54,7 +55,8 @@ SRCS +=	$(NO-OS)/util/util.c
 ifeq (xilinx,$(strip $(PLATFORM)))
 SRCS += $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c			\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c		\
+	$(PLATFORM_DRIVERS)/xilinx_spi.c
 else
 SRCS += $(DRIVERS)/axi_core/clk_altera_a10_fpll/clk_altera_a10_fpll.c	\
 	$(DRIVERS)/axi_core/jesd204/altera_a10_atx_pll.c		\

--- a/projects/adrv9009/src.mk
+++ b/projects/adrv9009/src.mk
@@ -61,10 +61,10 @@ else
 SRCS += $(DRIVERS)/axi_core/clk_altera_a10_fpll/clk_altera_a10_fpll.c	\
 	$(DRIVERS)/axi_core/jesd204/altera_a10_atx_pll.c		\
 	$(DRIVERS)/axi_core/jesd204/altera_a10_cdr_pll.c		\
-	$(DRIVERS)/axi_core/jesd204/altera_adxcvr.c
+	$(DRIVERS)/axi_core/jesd204/altera_adxcvr.c			\
+	$(PLATFORM_DRIVERS)/altera_spi.c
 endif
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/spi.c					\
 	$(PLATFORM_DRIVERS)/gpio.c					\
 	$(PLATFORM_DRIVERS)/delay.c
 INCS :=	$(PROJECT)/src/app/app_config.h					\

--- a/projects/adrv9009/src/README
+++ b/projects/adrv9009/src/README
@@ -80,8 +80,9 @@
 	cp ../../../include/spi.h devices/adi_hal/
 	cp ../../../include/gpio.h devices/adi_hal/
 	cp ../../../include/delay.h devices/adi_hal/
+	cp ../../../drivers/spi.c devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/axi_io.c devices/adi_hal/
-	cp ../../../drivers/platform/xilinx/spi.c devices/adi_hal/
+	cp ../../../drivers/platform/xilinx/xilinx_spi.c devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/spi_extra.h devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/gpio.c devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/gpio_extra.h devices/adi_hal/

--- a/projects/adrv9009/src/README
+++ b/projects/adrv9009/src/README
@@ -7,8 +7,9 @@
 	cp ../../../include/spi.h devices/adi_hal/
 	cp ../../../include/gpio.h devices/adi_hal/
 	cp ../../../include/delay.h devices/adi_hal/
+	cp ../../../drivers/spi.c devices/adi_hal/
 	cp ../../../drivers/platform/altera/axi_io.c devices/adi_hal/
-	cp ../../../drivers/platform/altera/spi.c devices/adi_hal/
+	cp ../../../drivers/platform/altera/altera_spi.c devices/adi_hal/
 	cp ../../../drivers/platform/altera/spi_extra.h devices/adi_hal/
 	cp ../../../drivers/platform/altera/gpio.c devices/adi_hal/
 	cp ../../../drivers/platform/altera/gpio_extra.h devices/adi_hal/

--- a/projects/adrv9009/src/app/app_clocking.c
+++ b/projects/adrv9009/src/app/app_clocking.c
@@ -402,6 +402,9 @@ adiHalErr_t clocking_init(uint32_t rx_div40_rate_hz,
 		.max_speed_hz = 10000000,
 		.mode = SPI_MODE_0,
 		.chip_select = CLK_CS,
+#ifndef ALTERA_PLATFORM
+		.platform_ops = &xil_platform_ops,
+#endif
 		.extra = &xil_spi_param
 	};
 
@@ -411,6 +414,7 @@ adiHalErr_t clocking_init(uint32_t rx_div40_rate_hz,
 		.max_speed_hz = 10000000,
 		.mode = SPI_MODE_0,
 		.chip_select = CAR_CLK_CS,
+		.platform_ops = &xil_platform_ops,
 		.extra = &xil_spi_param
 	};
 	hmc7044_car_param.spi_init = &car_clkchip_spi_init_param;

--- a/projects/adrv9009/src/app/app_clocking.c
+++ b/projects/adrv9009/src/app/app_clocking.c
@@ -404,6 +404,8 @@ adiHalErr_t clocking_init(uint32_t rx_div40_rate_hz,
 		.chip_select = CLK_CS,
 #ifndef ALTERA_PLATFORM
 		.platform_ops = &xil_platform_ops,
+#else
+		.platform_ops = &altera_platform_ops,
 #endif
 		.extra = &xil_spi_param
 	};

--- a/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
+++ b/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
@@ -78,6 +78,9 @@ adiHalErr_t ADIHAL_openHw(void *devHalInfo, uint32_t halTimeout_ms)
 	spi_param.max_speed_hz = 25000000;
 	spi_param.mode = SPI_MODE_0;
 	spi_param.chip_select = dev_hal_data->spi_adrv_csn;
+#ifndef ALTERA_PLATFORM
+	spi_param.platform_ops = &xil_platform_ops;
+#endif
 	if (dev_hal_data->extra_spi)
 		spi_param.extra = dev_hal_data->extra_spi;
 

--- a/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
+++ b/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
@@ -80,6 +80,8 @@ adiHalErr_t ADIHAL_openHw(void *devHalInfo, uint32_t halTimeout_ms)
 	spi_param.chip_select = dev_hal_data->spi_adrv_csn;
 #ifndef ALTERA_PLATFORM
 	spi_param.platform_ops = &xil_platform_ops;
+#else
+	spi_param.platform_ops = &altera_platform_ops;
 #endif
 	if (dev_hal_data->extra_spi)
 		spi_param.extra = dev_hal_data->extra_spi;

--- a/projects/fmcadc2/src.mk
+++ b/projects/fmcadc2/src.mk
@@ -20,9 +20,10 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c			\
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
 	$(DRIVERS)/adc/ad9625/ad9625.c					\
+	$(DRIVERS)/spi/spi.c						\
 	$(NO-OS)/util/util.c
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/spi.c					\
+	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
 	$(PLATFORM_DRIVERS)/gpio.c					\
 	$(PLATFORM_DRIVERS)/delay.c
 INCS :=	$(PROJECT)/src/app/app_config.h					\

--- a/projects/fmcadc2/src/README
+++ b/projects/fmcadc2/src/README
@@ -6,10 +6,11 @@ cp ../../../include/error.h devices/adi_hal/
 cp ../../../include/spi.h devices/adi_hal/
 cp ../../../include/gpio.h devices/adi_hal/
 cp ../../../include/delay.h devices/adi_hal/
+cp ../../../drivers/spi/spi.c devices/adi_hal/
 cp ../../../drivers/adc/ad9625/ad9625.h devices/adi_hal/
 cp ../../../drivers/adc/ad9625/ad9625.c devices/adi_hal/		
 cp ../../../drivers/platform/xilinx/axi_io.c devices/adi_hal/
-cp ../../../drivers/platform/xilinx/spi.c devices/adi_hal/
+cp ../../../drivers/platform/xilinx/xilinx_spi.c devices/adi_hal/
 cp ../../../drivers/platform/xilinx/spi_extra.h devices/adi_hal/
 cp ../../../drivers/platform/xilinx/gpio.c devices/adi_hal/
 cp ../../../drivers/platform/xilinx/gpio_extra.h devices/adi_hal/

--- a/projects/fmcadc2/src/app/fmcadc2.c
+++ b/projects/fmcadc2/src/app/fmcadc2.c
@@ -68,6 +68,7 @@ int main(void)
 	struct spi_init_param ad9625_spi_param = {
 		.max_speed_hz = 2000000u,
 		.chip_select = 0,
+		.platform_ops = &xil_platform_ops,
 		.mode = SPI_MODE_0
 	};
 

--- a/projects/fmcadc5/src.mk
+++ b/projects/fmcadc5/src.mk
@@ -21,9 +21,10 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c			\
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
 	$(DRIVERS)/adc/ad9625/ad9625.c					\
+	$(DRIVERS)/spi/spi.c						\
 	$(NO-OS)/util/util.c
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/spi.c					\
+	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
 	$(PLATFORM_DRIVERS)/gpio.c					\
 	$(PLATFORM_DRIVERS)/delay.c
 INCS :=	$(PROJECT)/src/app/app_config.h					\

--- a/projects/fmcadc5/src/app/fmcadc5.c
+++ b/projects/fmcadc5/src/app/fmcadc5.c
@@ -70,13 +70,15 @@ int main(void)
 	struct spi_init_param ad9625_0_spi_param = {
 		.max_speed_hz = 2000000u,
 		.chip_select = 0,
-		.mode = SPI_MODE_0
+		.mode = SPI_MODE_0,
+		.platform_ops = &xil_platform_ops
 	};
 
 	struct spi_init_param ad9625_1_spi_param = {
 		.max_speed_hz = 2000000u,
 		.chip_select = 1,
-		.mode = SPI_MODE_0
+		.mode = SPI_MODE_0,
+		.platform_ops = &xil_platform_ops,
 	};
 
 	struct xil_spi_init_param xil_spi_param = {

--- a/projects/fmcdaq2/src.mk
+++ b/projects/fmcdaq2/src.mk
@@ -23,9 +23,10 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
 	$(DRIVERS)/frequency/ad9523/ad9523.c				\
 	$(DRIVERS)/adc/ad9680/ad9680.c					\
 	$(DRIVERS)/dac/ad9144/ad9144.c					\
+	$(DRIVERS)/spi/spi.c						\
 	$(NO-OS)/util/util.c
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/spi.c					\
+	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
 	$(PLATFORM_DRIVERS)/gpio.c					\
 	$(PLATFORM_DRIVERS)/delay.c
 INCS :=	$(PROJECT)/src/app/app_config.h					\

--- a/projects/fmcdaq2/src/README
+++ b/projects/fmcdaq2/src/README
@@ -7,6 +7,7 @@
 	cp ../../../include/spi.h devices/adi_hal/
 	cp ../../../include/gpio.h devices/adi_hal/
 	cp ../../../include/delay.h devices/adi_hal/
+	cp ../../../drivers/spi/spi.c devices/adi_hal/
 	cp ../../../drivers/frequency/ad9523/ad9523.h devices/adi_hal/
 	cp ../../../drivers/frequency/ad9523/ad9523.c devices/adi_hal/
 	cp ../../../drivers/adc/ad9680/ad9680.h devices/adi_hal/
@@ -14,7 +15,7 @@
 	cp ../../../drivers/dac/ad9144/ad9144.h devices/adi_hal/
 	cp ../../../drivers/dac/ad9144/ad9144.c devices/adi_hal/
 	cp ../../../drivers/platform/altera/axi_io.c devices/adi_hal/
-	cp ../../../drivers/platform/altera/spi.c devices/adi_hal/
+	cp ../../../drivers/platform/altera/altera_spi.c devices/adi_hal/
 	cp ../../../drivers/platform/altera/spi_extra.h devices/adi_hal/
 	cp ../../../drivers/platform/altera/gpio.c devices/adi_hal/
 	cp ../../../drivers/platform/altera/gpio_extra.h devices/adi_hal/

--- a/projects/fmcdaq2/src/README
+++ b/projects/fmcdaq2/src/README
@@ -45,6 +45,7 @@
 	cp ../../../include/spi.h devices/adi_hal/
 	cp ../../../include/gpio.h devices/adi_hal/
 	cp ../../../include/delay.h devices/adi_hal/
+	cp ../../../drivers/spi/spi.c devices/adi_hal/
 	cp ../../../drivers/frequency/ad9523/ad9523.h devices/adi_hal/
 	cp ../../../drivers/frequency/ad9523/ad9523.c devices/adi_hal/
 	cp ../../../drivers/adc/ad9680/ad9680.h devices/adi_hal/
@@ -52,7 +53,7 @@
 	cp ../../../drivers/dac/ad9144/ad9144.h devices/adi_hal/
 	cp ../../../drivers/dac/ad9144/ad9144.c devices/adi_hal/		
 	cp ../../../drivers/platform/xilinx/axi_io.c devices/adi_hal/
-	cp ../../../drivers/platform/xilinx/spi.c devices/adi_hal/
+	cp ../../../drivers/platform/xilinx/xilinx_spi.c devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/spi_extra.h devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/gpio.c devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/gpio_extra.h devices/adi_hal/

--- a/projects/fmcdaq2/src/app/fmcdaq2.c
+++ b/projects/fmcdaq2/src/app/fmcdaq2.c
@@ -287,8 +287,11 @@ int main(void)
 		.type = NIOS_II_SPI,
 		.base_address = SYS_SPI_BASE
 	};
+	ad9523.platform_ops = &altera_platform_ops;
 	ad9523_spi_param.extra = &altera_spi_param;
+	ad9144.platform_ops = &altera_platform_ops;
 	ad9144_spi_param.extra = &altera_spi_param;
+	ad9680.platform_ops = &altera_platform_ops;
 	ad9680_spi_param.extra = &altera_spi_param;
 #endif
 

--- a/projects/fmcdaq2/src/app/fmcdaq2.c
+++ b/projects/fmcdaq2/src/app/fmcdaq2.c
@@ -275,8 +275,11 @@ int main(void)
 #endif
 		.device_id = SPI_DEVICE_ID
 	};
+	ad9523.platform_ops = &xil_platform_ops;
 	ad9523_spi_param.extra = &xil_spi_param;
+	ad9144.platform_ops = &xil_platform_ops;
 	ad9144_spi_param.extra = &xil_spi_param;
+	ad9680.platform_ops = &xil_platform_ops;
 	ad9680_spi_param.extra = &xil_spi_param;
 #else
 	struct altera_spi_init_param altera_spi_param = {

--- a/projects/fmcdaq3/src.mk
+++ b/projects/fmcdaq3/src.mk
@@ -23,9 +23,10 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
 	$(DRIVERS)/frequency/ad9528/ad9528.c				\
 	$(DRIVERS)/adc/ad9680/ad9680.c					\
 	$(DRIVERS)/dac/ad9152/ad9152.c					\
+	$(DRIVERS)/spi/spi.c						\
 	$(NO-OS)/util/util.c
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/spi.c					\
+	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
 	$(PLATFORM_DRIVERS)/gpio.c					\
 	$(PLATFORM_DRIVERS)/delay.c
 INCS :=	$(PROJECT)/src/app/app_config.h					\

--- a/projects/fmcdaq3/src/README
+++ b/projects/fmcdaq3/src/README
@@ -45,6 +45,7 @@
 	cp ../../../include/spi.h devices/adi_hal/
 	cp ../../../include/gpio.h devices/adi_hal/
 	cp ../../../include/delay.h devices/adi_hal/
+	cp ../../../drivers/spi/spi.c devices/adi_hal/
 	cp ../../../drivers/frequency/ad9528/ad9528.h devices/adi_hal/
 	cp ../../../drivers/frequency/ad9528/ad9528.c devices/adi_hal/
 	cp ../../../drivers/adc/ad9680/ad9680.h devices/adi_hal/
@@ -52,7 +53,7 @@
 	cp ../../../drivers/dac/ad9152/ad9152.h devices/adi_hal/
 	cp ../../../drivers/dac/ad9152/ad9152.c devices/adi_hal/		
 	cp ../../../drivers/platform/xilinx/axi_io.c devices/adi_hal/
-	cp ../../../drivers/platform/xilinx/spi.c devices/adi_hal/
+	cp ../../../drivers/platform/xilinx/xilinx_spi.c devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/spi_extra.h devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/gpio.c devices/adi_hal/
 	cp ../../../drivers/platform/xilinx/gpio_extra.h devices/adi_hal/

--- a/projects/fmcdaq3/src/README
+++ b/projects/fmcdaq3/src/README
@@ -7,6 +7,7 @@
 	cp ../../../include/spi.h devices/adi_hal/
 	cp ../../../include/gpio.h devices/adi_hal/
 	cp ../../../include/delay.h devices/adi_hal/
+	cp ../../../drivers/spi/spi.c devices/adi_hal/
 	cp ../../../drivers/frequency/ad9528/ad9528.h devices/adi_hal/
 	cp ../../../drivers/frequency/ad9528/ad9528.c devices/adi_hal/
 	cp ../../../drivers/adc/ad9680/ad9680.h devices/adi_hal/
@@ -14,7 +15,7 @@
 	cp ../../../drivers/dac/ad9152/ad9152.h devices/adi_hal/
 	cp ../../../drivers/dac/ad9152/ad9152.c devices/adi_hal/
 	cp ../../../drivers/platform/altera/axi_io.c devices/adi_hal/
-	cp ../../../drivers/platform/altera/spi.c devices/adi_hal/
+	cp ../../../drivers/platform/altera/altera_spi.c devices/adi_hal/
 	cp ../../../drivers/platform/altera/spi_extra.h devices/adi_hal/
 	cp ../../../drivers/platform/altera/gpio.c devices/adi_hal/
 	cp ../../../drivers/platform/altera/gpio_extra.h devices/adi_hal/

--- a/projects/fmcdaq3/src/app/fmcdaq3.c
+++ b/projects/fmcdaq3/src/app/fmcdaq3.c
@@ -106,8 +106,11 @@ int main(void)
 #endif
 		.device_id = SPI_DEVICE_ID
 	};
+	ad9528_spi_param.platform_ops = &xil_platform_ops;
 	ad9528_spi_param.extra = &xil_spi_param;
+	ad9152_spi_param.platform_ops = &xil_platform_ops;
 	ad9152_spi_param.extra = &xil_spi_param;
+	ad9680_spi_param.platform_ops = &xil_platform_ops;
 	ad9680_spi_param.extra = &xil_spi_param;
 #else
 	struct altera_spi_init_param altera_spi_param = {

--- a/projects/fmcdaq3/src/app/fmcdaq3.c
+++ b/projects/fmcdaq3/src/app/fmcdaq3.c
@@ -118,8 +118,11 @@ int main(void)
 		.type = NIOS_II_SPI,
 		.base_address = SYS_SPI_BASE
 	};
+	ad9528_spi_param.platform_ops = &altera_platform_ops;
 	ad9528_spi_param.extra = &altera_spi_param;
+	ad9152_spi_param.platform_ops = &altera_platform_ops;
 	ad9152_spi_param.extra = &altera_spi_param;
+	ad9680_spi_param.platform_ops = &altera_platform_ops;
 	ad9680_spi_param.extra = &altera_spi_param;
 #endif
 

--- a/projects/fmcjesdadc1/src.mk
+++ b/projects/fmcjesdadc1/src.mk
@@ -19,6 +19,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c			\
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c			\
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
+	$(DRIVERS)/io-expander/demux_spi/demux_spi.c			\
 	$(DRIVERS)/spi/spi.c						\
 	$(PROJECT)/src/devices/ad9250/ad9250.c				\
 	$(PROJECT)/src/devices/ad9517/ad9517.c
@@ -35,6 +36,7 @@ INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h			\
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h			\
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h			\
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h		\
+	$(DRIVERS)/io-expander/demux_spi/demux_spi.h			\
 	$(PROJECT)/src/devices/ad9250/ad9250.h				\
 	$(PROJECT)/src/devices/ad9517/ad9517.h				
 INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\

--- a/projects/fmcjesdadc1/src.mk
+++ b/projects/fmcjesdadc1/src.mk
@@ -19,11 +19,12 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c			\
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c			\
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
+	$(DRIVERS)/spi/spi.c						\
 	$(PROJECT)/src/devices/ad9250/ad9250.c				\
 	$(PROJECT)/src/devices/ad9517/ad9517.c
 	$(NO-OS)/util/util.c
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/spi.c					\
+	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
 	$(PLATFORM_DRIVERS)/gpio.c					\
 	$(PLATFORM_DRIVERS)/delay.c
 INCS :=	$(PROJECT)/src/app/app_config.h					\

--- a/projects/fmcjesdadc1/src/README
+++ b/projects/fmcjesdadc1/src/README
@@ -7,7 +7,8 @@ cp ../../../include/spi.h devices/adi_hal/
 cp ../../../include/gpio.h devices/adi_hal/
 cp ../../../include/delay.h devices/adi_hal/		
 cp ../../../drivers/platform/xilinx/axi_io.c devices/adi_hal/
-cp ../../../drivers/platform/xilinx/spi.c devices/adi_hal/
+cp ../../../drivers/spi/spi.c devices/adi_hal/
+cp ../../../drivers/platform/xilinx/xilinx_spi.c devices/adi_hal/
 cp ../../../drivers/platform/xilinx/spi_extra.h devices/adi_hal/
 cp ../../../drivers/platform/xilinx/gpio.c devices/adi_hal/
 cp ../../../drivers/platform/xilinx/gpio_extra.h devices/adi_hal/

--- a/projects/fmcjesdadc1/src/README
+++ b/projects/fmcjesdadc1/src/README
@@ -8,6 +8,8 @@ cp ../../../include/gpio.h devices/adi_hal/
 cp ../../../include/delay.h devices/adi_hal/		
 cp ../../../drivers/platform/xilinx/axi_io.c devices/adi_hal/
 cp ../../../drivers/spi/spi.c devices/adi_hal/
+cp ../../../drivers/io-expander/demux_spi.h devices/adi_hal/
+cp ../../../drivers/io-expander/demux_spi.c devices/adi_hal/
 cp ../../../drivers/platform/xilinx/xilinx_spi.c devices/adi_hal/
 cp ../../../drivers/platform/xilinx/spi_extra.h devices/adi_hal/
 cp ../../../drivers/platform/xilinx/gpio.c devices/adi_hal/

--- a/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
+++ b/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
@@ -59,6 +59,7 @@
 #include "axi_adc_core.h"
 #include "axi_dmac.h"
 #include "axi_jesd204_rx.h"
+#include "demux_spi.h"
 
 /***************************************************************************//**
 * @brief main
@@ -67,20 +68,33 @@ int main(void)
 {
 
 	int32_t status;
-
 	// SPI configuration
-	struct spi_init_param ad9250_spi_param = {
+	struct spi_init_param demux_spi_param = {
 		.max_speed_hz = 2000000u,
 		.chip_select = 0,
 		.mode = SPI_MODE_0,
 		.platform_ops = &xil_platform_ops
 	};
 
-	struct spi_init_param ad9517_spi_param = {
+	struct spi_init_param ad9250_0_spi_param = {
 		.max_speed_hz = 2000000u,
 		.chip_select = 0,
 		.mode = SPI_MODE_0,
-		.platform_ops = &xil_platform_ops
+		.platform_ops = &demux_spi_platform_ops
+	};
+
+	struct spi_init_param ad9250_1_spi_param = {
+		.max_speed_hz = 2000000u,
+		.chip_select = 1,
+		.mode = SPI_MODE_0,
+		.platform_ops = &demux_spi_platform_ops
+	};
+
+	struct spi_init_param ad9517_spi_param = {
+		.max_speed_hz = 2000000u,
+		.chip_select = 4,
+		.mode = SPI_MODE_0,
+		.platform_ops = &demux_spi_platform_ops
 	};
 
 	struct xil_spi_init_param xil_spi_param = {
@@ -91,8 +105,11 @@ int main(void)
 #endif
 		.device_id = SPI_DEVICE_ID
 	};
-	ad9250_spi_param.extra = &xil_spi_param;
-	ad9517_spi_param.extra = &xil_spi_param;
+
+	demux_spi_param.extra = &xil_spi_param;
+	ad9250_0_spi_param.extra = &demux_spi_param;
+	ad9250_1_spi_param.extra = &demux_spi_param;
+	ad9517_spi_param.extra = &demux_spi_param;
 
 	struct gpio_init_param gpio_sysref_param = {
 		.number = GPIO_JESD204_SYSREF
@@ -172,8 +189,8 @@ int main(void)
 
 	// SPI configuration
 	ad9517_param.spi_init = ad9517_spi_param;
-	ad9250_0_param.spi_init = ad9250_spi_param;
-	ad9250_1_param.spi_init = ad9250_spi_param;
+	ad9250_0_param.spi_init = ad9250_0_spi_param;
+	ad9250_1_param.spi_init = ad9250_1_spi_param;
 
 	ad9250_0_param.id_no = 0x0;
 	ad9250_1_param.id_no = 0x1;

--- a/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
+++ b/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
@@ -72,13 +72,15 @@ int main(void)
 	struct spi_init_param ad9250_spi_param = {
 		.max_speed_hz = 2000000u,
 		.chip_select = 0,
-		.mode = SPI_MODE_0
+		.mode = SPI_MODE_0,
+		.platform_ops = &xil_platform_ops
 	};
 
 	struct spi_init_param ad9517_spi_param = {
 		.max_speed_hz = 2000000u,
 		.chip_select = 0,
-		.mode = SPI_MODE_0
+		.mode = SPI_MODE_0,
+		.platform_ops = &xil_platform_ops
 	};
 
 	struct xil_spi_init_param xil_spi_param = {

--- a/projects/fmcjesdadc1/src/devices/ad9250/ad9250.c
+++ b/projects/fmcjesdadc1/src/devices/ad9250/ad9250.c
@@ -53,16 +53,15 @@ int32_t ad9250_spi_read(struct ad9250_dev *dev,
 			uint16_t reg_addr,
 			uint8_t *reg_data)
 {
-	uint8_t buf[4];
+	uint8_t buf[3];
 	int32_t ret;
 
-	buf[0] = 0x80 | dev->id_no;
-	buf[1] = 0x80 | (reg_addr >> 8);
-	buf[2] = reg_addr & 0xFF;
-	buf[3] = 0x00;
+	buf[0] = 0x80 | (reg_addr >> 8);
+	buf[1] = reg_addr & 0xFF;
+	buf[2] = 0x00;
 
-	ret = spi_write_and_read(dev->spi_dev, buf, 4);
-	*reg_data = buf[3];
+	ret = spi_write_and_read(dev->spi_dev, buf, 3);
+	*reg_data = buf[2];
 
 	return ret;
 }
@@ -74,15 +73,14 @@ int32_t ad9250_spi_write(struct ad9250_dev *dev,
 			 uint16_t reg_addr,
 			 uint8_t reg_data)
 {
-	uint8_t buf[4];
+	uint8_t buf[3];
 	int32_t ret;
 
-	buf[0] = 0x80 | dev->id_no;
-	buf[1] = reg_addr >> 8;
-	buf[2] = reg_addr & 0xFF;
-	buf[3] = reg_data;
+	buf[0] = reg_addr >> 8;
+	buf[1] = reg_addr & 0xFF;
+	buf[2] = reg_data;
 
-	ret = spi_write_and_read(dev->spi_dev, buf, 4);
+	ret = spi_write_and_read(dev->spi_dev, buf, 3);
 
 	return ret;
 }

--- a/projects/fmcjesdadc1/src/devices/ad9517/ad9517.c
+++ b/projects/fmcjesdadc1/src/devices/ad9517/ad9517.c
@@ -58,16 +58,15 @@ int32_t ad9517_spi_read(struct ad9517_dev *dev,
 			uint16_t reg_addr,
 			uint8_t *reg_data)
 {
-	uint8_t buf[4];
+	uint8_t buf[3];
 	int32_t ret;
 
-	buf[0] = 0x84;
-	buf[1] = 0x80 | (reg_addr >> 8);
-	buf[2] = reg_addr & 0xFF;
-	buf[3] = 0x00;
+	buf[0] = 0x80 | (reg_addr >> 8);
+	buf[1] = reg_addr & 0xFF;
+	buf[2] = 0x00;
 
-	ret = spi_write_and_read(dev->spi_desc, buf, 4);
-	*reg_data = buf[3];
+	ret = spi_write_and_read(dev->spi_desc, buf, 3);
+	*reg_data = buf[2];
 
 	return ret;
 }
@@ -79,15 +78,14 @@ int32_t ad9517_spi_write(struct ad9517_dev *dev,
 			 uint16_t reg_addr,
 			 uint8_t reg_data)
 {
-	uint8_t buf[4];
+	uint8_t buf[3];
 	int32_t ret;
 
-	buf[0] = 0x84;
-	buf[1] = reg_addr >> 8;
-	buf[2] = reg_addr & 0xFF;
-	buf[3] = reg_data;
+	buf[0] = reg_addr >> 8;
+	buf[1] = reg_addr & 0xFF;
+	buf[2] = reg_data;
 
-	ret = spi_write_and_read(dev->spi_desc, buf, 4);
+	ret = spi_write_and_read(dev->spi_desc, buf, 3);
 
 	return ret;
 }


### PR DESCRIPTION
This patch contains the following updates regarding the SPI structure and implementation:

1. Add generic SPI interface
2. Update Xilinx and Altera platform drivers to support the new generic layer.
3. Update the related projects from the projects folder.

Signed-off-by: Antoniu Miclaus antoniu.miclaus@analog.com