### PR TITLE
fix abs() function

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -75,7 +75,7 @@
 	(type)clamp((type)(val), (type)(min_val), (type)(max_val))
 
 #define abs(x) \
-	((x) < 0 ? (-x) : (x))
+	((x) < 0 ? (-(x)) : (x))
 
 #define swap(x, y) \
 	{typeof(x) _tmp_ = (x); (x) = (y); (y) = _tmp_;}


### PR DESCRIPTION
For abs(40 - 52) the previous version would expand to:
((40 - 52) < 0 ? (-40 - 52) : (40 - 52))
((-12) < 0 ? (-92) : (-12))
Giving the result of -92 instead of 12.

C macros are tricky, this is why one should always enclose usages of the
macro parameters with parantheses.

Signed-off-by: Darius Berghe <darius.berghe@analog.com>