### PR TITLE
drivers:platform:aducm3029: Remove #include <drivers/uart/adi_uart.h>

### DIFF
--- a/drivers/platform/aducm3029/irq.c
+++ b/drivers/platform/aducm3029/irq.c
@@ -330,7 +330,6 @@ int32_t irq_global_disable(struct irq_ctrl_desc *desc)
 int32_t irq_enable(struct irq_ctrl_desc *desc, uint32_t irq_id)
 {
 	struct aducm_irq_ctrl_desc	*aducm_desc;
-	struct aducm_uart_desc		*uart_desc;
 	struct aducm_rtc_desc		*rtc_desc;
 
 	if (!desc || !desc->extra || !initialized ||
@@ -344,10 +343,8 @@ int32_t irq_enable(struct irq_ctrl_desc *desc, uint32_t irq_id)
 	if (irq_id < NB_EXT_INTERRUPTS) {
 		adi_xint_EnableIRQ(id_map_event[irq_id],
 				   aducm_desc->conf[irq_id].xint_conf);
-	} else if ((irq_id == ADUCM_UART_INT_ID) &&
-		   aducm_desc->conf[irq_id].uart_conf) {
-		uart_desc = aducm_desc->conf[irq_id].uart_conf->extra;
-		uart_desc->callback_enabled = true;
+	} else if (irq_id == ADUCM_UART_INT_ID) {
+		NVIC_EnableIRQ(UART_EVT_IRQn);
 	} else if ((irq_id == ADUCM_RTC_INT_ID) &&
 		   aducm_desc->conf[irq_id].rtc_conf) {
 		rtc_desc = aducm_desc->conf[irq_id].rtc_conf->rtc_handler->extra;
@@ -369,7 +366,6 @@ int32_t irq_enable(struct irq_ctrl_desc *desc, uint32_t irq_id)
 int32_t irq_disable(struct irq_ctrl_desc *desc, uint32_t irq_id)
 {
 	struct aducm_irq_ctrl_desc	*aducm_desc;
-	struct aducm_uart_desc		*uart_desc;
 	struct aducm_rtc_desc		*rtc_desc;
 
 	if (!desc || !desc->extra || !initialized ||
@@ -379,10 +375,8 @@ int32_t irq_disable(struct irq_ctrl_desc *desc, uint32_t irq_id)
 	aducm_desc = desc->extra;
 	if (irq_id < NB_EXT_INTERRUPTS) {
 		adi_xint_DisableIRQ(id_map_event[irq_id]);
-	} else if ((irq_id == ADUCM_UART_INT_ID) &&
-		   aducm_desc->conf[irq_id].uart_conf) {
-		uart_desc = aducm_desc->conf[irq_id].uart_conf->extra;
-		uart_desc->callback_enabled = false;
+	} else if (irq_id == ADUCM_UART_INT_ID) {
+		NVIC_DisableIRQ(UART_EVT_IRQn);
 	} else if ((irq_id == ADUCM_RTC_INT_ID) &&
 		   aducm_desc->conf[irq_id].rtc_conf) {
 		rtc_desc = aducm_desc->conf[irq_id].rtc_conf->rtc_handler->extra;

--- a/drivers/platform/aducm3029/uart_extra.h
+++ b/drivers/platform/aducm3029/uart_extra.h
@@ -44,7 +44,7 @@
 /***************************** Include Files **********************************/
 /******************************************************************************/
 
-#include <drivers/uart/adi_uart.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include "error.h"
 
@@ -176,47 +176,6 @@ struct aducm_uart_init_param {
 	enum UART_STOPBITS	stop_bits;
 	/** Set the word length */
 	enum UART_WORDLEN	word_length;
-};
-
-/**
- * @struct op_desc
- * @brief It stores the state of a operation
- */
-struct op_desc {
-	/** Is set when an write nonblocking operation is executing */
-	bool		is_nonblocking;
-	/** Current buffer*/
-	uint8_t		*buff;
-	/** Number of bytes pending to process */
-	uint32_t	pending;
-};
-
-/**
- * @struct aducm_uart_desc
- * @brief Stores specific parameter needed by the UART driver for internal
- * operations
- */
-struct aducm_uart_desc {
-	/** Handle needed by low level functions */
-	ADI_UART_HANDLE	uart_handler;
-	/** Stores the error occurred */
-	enum UART_ERROR	errors;
-	/** Set if callback is enabled */
-	bool		callback_enabled;
-	/**
-	 * Buffer needed by the ADI UART driver to operate.
-	 * This buffer allocated and aligned at runtime to 32 bits
-	 */
-	uint8_t		*adi_uart_buffer;
-	/**
-	 * Stores the offset used to align adi_uart_buffer.
-	 * Needed to deallocate \ref adi_uart_buffer
-	 */
-	uint32_t	adi_uart_buffer_offset;
-	/** Status of a write operation */
-	struct op_desc	write_desc;
-	/** Status of a read operation */
-	struct op_desc	read_desc;
 };
 
 #endif /* UART_H_ */


### PR DESCRIPTION
This change is related to
https://github.com/analogdevicesinc/EVAL-ADICUP3029/pull/49

In the PR is an adicup project that builds noos as a static library and a new project
that uses the library doesn't have this include in the include directory.

The irq_enable and disable implementation was changed to support this change.

Signed-off-by: Mihail Chindris <mihail.chindris@analog.com>