### PR TITLE
travis: cppcheck: exclude mbedtls

### DIFF
--- a/ci/travis/cppcheck.sh
+++ b/ci/travis/cppcheck.sh
@@ -6,4 +6,4 @@ sudo apt-get install cppcheck
 
 [[ ! -f .cppcheckignore ]] || CPPCHECK_OPTIONS="${CPPCHECK_OPTIONS} --suppressions-list=.cppcheckignore"
 	
-cppcheck --quiet --force --error-exitcode=1 $CPPCHECK_OPTIONS .
+cppcheck -ilibraries/mbedtls --quiet --force --error-exitcode=1 $CPPCHECK_OPTIONS .


### PR DESCRIPTION
Exclude mbedtls library from static analysis check.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>