### PR TITLE
AD9517: Activate PLL and calibrate when using VCO

### DIFF
--- a/drivers/frequency/ad9517/ad9517.c
+++ b/drivers/frequency/ad9517/ad9517.c
@@ -153,10 +153,25 @@ int32_t ad9517_setup(struct ad9517_dev **device,
 			return ret;
 	}
 	/* Check if VCO is selected as input. */
-	if(dev->ad9517_st.pdata->vco_clk_sel)
+	if(dev->ad9517_st.pdata->vco_clk_sel) {
 		/* Sets the VCO frequency. */
 		ad9517_vco_frequency(dev,
 				     dev->ad9517_st.pdata->int_vco_freq);
+
+		/* Activate PLL */
+		reg_value = AD9517_PLL_POWER_DOWN(0x0) |
+			    AD9517_CP_MODE (0x3) |
+			    AD9517_CP_CURRENT (0x7) |
+			    0 * AD9517_PFD_POLARITY;
+		ret = ad9517_write(dev, AD9517_REG_PFD_CHARGE_PUMP, reg_value);
+		if(ret < 0)
+			return ret;
+
+		/* Start VCO Calibration */
+		ret = ad9517_write(dev, AD9517_REG_PLL_CTRL_3, AD9517_VCO_CAL_NOW);
+		if(ret < 0)
+			return ret;
+	}
 
 	*device = dev;
 


### PR DESCRIPTION
I am currently working with the AD9467 eval board and wanted to use an external 10 MHz reference to generate the ADC sampling clock using the on-board AD9517-4. It didn't work out of the box by just setting the correct values in ad9517_cfg.h, and after a lot of digging in the datasheet, I found that the PLL is not enabled by default or in the driver. This makes no sense in my opinion, as using the VCO without the PLL enabled is not possible as far as I can tell. So it should be enabled by the driver when vco_clk_sel is enabled I think.

Also, the VCO must be calibrated in order for the PLL to lock. That should definitely also be kicked off by the driver.