### PR TITLE
drivers:platform:aducm3029: Small uart fix

### DIFF
--- a/drivers/platform/aducm3029/uart.c
+++ b/drivers/platform/aducm3029/uart.c
@@ -499,11 +499,12 @@ int32_t uart_remove(struct uart_desc *desc)
 
 	if (desc == NULL || desc->extra == NULL)
 		return FAILURE;
-	aducm_desc = desc->extra;
 
+	initialized[desc->device_id] = 0;
+
+	aducm_desc = desc->extra;
 	adi_uart_Close(aducm_desc->uart_handler);
 	free_desc_mem(desc);
-	initialized[desc->device_id] = 0;
 
 	return SUCCESS;
 }


### PR DESCRIPTION
desc->device_id was accesed after desc was deallocated resulting in unconsistent data.

Signed-off-by: Mihail Chindris <mihail.chindris@analog.com>