### PR TITLE
fix xil_platform_ops not defined in adrv9009

### DIFF
--- a/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
+++ b/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
@@ -44,6 +44,7 @@
 #include "adi_hal.h"
 #include "parameters.h"
 #include "spi.h"
+#include "spi_extra.h"
 #include "gpio.h"
 #include "error.h"
 #include "delay.h"


### PR DESCRIPTION
Recent changes in SPI broke the adrv9009 build. This fixes the project.

I checked all the projects modified by 463a16fb8, they all include "spi_extra.h" so they should build correctly.