### PR TITLE
AD9517 update & fmcjesdadc1 driver integration

### DIFF
--- a/drivers/frequency/ad9517/ad9517.c
+++ b/drivers/frequency/ad9517/ad9517.c
@@ -73,6 +73,7 @@ int32_t ad9517_setup(struct ad9517_dev **device,
 		return -1;
 
 	dev->ad9517_st = init_param.ad9517_st;
+	dev->ad9517_type = init_param.ad9517_type;
 
 	/* Initializes the SPI peripheral */
 	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
@@ -332,9 +333,30 @@ int64_t ad9517_vco_frequency(struct ad9517_dev *dev,
 	uint8_t prescaler = 0;
 	uint32_t reg_value = 0;
 
-	if((frequency < AD9517_MIN_VCO_FREQ) ||
-	    (frequency > AD9517_MAX_VCO_FREQ))
+	switch(dev->ad9517_type) {
+	case AD9517_1:
+		if((frequency < AD9517_1_MIN_VCO_FREQ) ||
+		    (frequency > AD9517_1_MAX_VCO_FREQ))
+			return -1;
+		break;
+	case AD9517_2:
+		if((frequency < AD9517_2_MIN_VCO_FREQ) ||
+		    (frequency > AD9517_2_MAX_VCO_FREQ))
+			return -1;
+		break;
+	case AD9517_3:
+		if((frequency < AD9517_3_MIN_VCO_FREQ) ||
+		    (frequency > AD9517_3_MAX_VCO_FREQ))
+			return -1;
+		break;
+	case AD9517_4:
+		if((frequency < AD9517_4_MIN_VCO_FREQ) ||
+		    (frequency > AD9517_4_MAX_VCO_FREQ))
+			return -1;
+		break;
+	default:
 		return -1;
+	}
 	if(dev->ad9517_st.pdata->ref_sel_pin_en)
 		/* Reference selection is made using REF_SEL pin. */
 		ref_freq = dev->ad9517_st.pdata->ref_sel_pin ?

--- a/drivers/frequency/ad9517/ad9517.h
+++ b/drivers/frequency/ad9517/ad9517.h
@@ -295,8 +295,14 @@
 /* AD9517_REG_UPDATE_ALL_REGS Definition */
 #define AD9517_UPDATE_ALL_REGS			(1 << 0)
 
-#define AD9517_MIN_VCO_FREQ			1450000000
-#define AD9517_MAX_VCO_FREQ			3000000000
+#define AD9517_1_MIN_VCO_FREQ			2300000000
+#define AD9517_1_MAX_VCO_FREQ			2650000000
+#define AD9517_2_MIN_VCO_FREQ			2050000000
+#define AD9517_2_MAX_VCO_FREQ			2330000000
+#define AD9517_3_MIN_VCO_FREQ			1750000000
+#define AD9517_3_MAX_VCO_FREQ			2250000000
+#define AD9517_4_MIN_VCO_FREQ			1450000000
+#define AD9517_4_MAX_VCO_FREQ			1800000000
 #define AD9517_MAX_PFD_FREQ			100000000
 #define AD9517_MAX_PRESCLAER_OUT_FREQ		300000000
 
@@ -335,6 +341,13 @@ struct ad9517_lvpecl_channel_spec {
 	uint8_t out_invert_en;	  // Invert the polarity of the output clock.
 	uint8_t out_diff_voltage; // LVPECL output differential voltage.
 	uint8_t name[16];	  // Optional descriptive channel name.
+};
+
+enum ad9517_type {
+	AD9517_1,
+	AD9517_2,
+	AD9517_3,
+	AD9517_4
 };
 
 enum out_diff_voltage_options {
@@ -383,6 +396,7 @@ struct ad9517_dev {
 	spi_desc	    *spi_desc;
 	/* Device Settings */
 	struct ad9517_state ad9517_st;
+	enum ad9517_type	ad9517_type;
 };
 
 struct ad9517_init_param {
@@ -390,6 +404,7 @@ struct ad9517_init_param {
 	spi_init_param	    spi_init;
 	/* Device Settings */
 	struct ad9517_state ad9517_st;
+	enum ad9517_type	ad9517_type;
 };
 
 /******************************************************************************/

--- a/projects/fmcjesdadc1/src.mk
+++ b/projects/fmcjesdadc1/src.mk
@@ -22,7 +22,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
 	$(DRIVERS)/io-expander/demux_spi/demux_spi.c			\
 	$(DRIVERS)/spi/spi.c						\
 	$(DRIVERS)/adc/ad9250/ad9250.c					\
-	$(PROJECT)/src/devices/ad9517/ad9517.c
+	$(DRIVERS)/frequency/ad9517/ad9517.c
 	$(NO-OS)/util/util.c
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
 	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
@@ -38,7 +38,7 @@ INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h			\
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h		\
 	$(DRIVERS)/io-expander/demux_spi/demux_spi.h			\
 	$(DRIVERS)/adc/ad9250/ad9250.h					\
-	$(PROJECT)/src/devices/ad9517/ad9517.h				
+	$(DRIVERS)/frequency/ad9517/ad9517.h
 INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\
 	$(PLATFORM_DRIVERS)/gpio_extra.h
 INCS +=	$(INCLUDE)/axi_io.h						\

--- a/projects/fmcjesdadc1/src/README
+++ b/projects/fmcjesdadc1/src/README
@@ -8,6 +8,8 @@ cp ../../../include/gpio.h devices/adi_hal/
 cp ../../../include/delay.h devices/adi_hal/
 cp ../../../drivers/adc/ad9250/ad9250.h devices/adi_hal/
 cp ../../../drivers/adc/ad9250/ad9250.c devices/adi_hal/
+cp ../../../drivers/frequency/ad9517/ad9517.h devices/adi_hal/
+cp ../../../drivers/frequency/ad9517/ad9517.c devices/adi_hal/
 cp ../../../drivers/platform/xilinx/axi_io.c devices/adi_hal/
 cp ../../../drivers/spi/spi.c devices/adi_hal/
 cp ../../../drivers/io-expander/demux_spi.h devices/adi_hal/

--- a/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
+++ b/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
@@ -68,6 +68,8 @@ int main(void)
 {
 
 	int32_t status;
+	uint32_t reg_value;
+
 	// SPI configuration
 	struct spi_init_param demux_spi_param = {
 		.max_speed_hz = 2000000u,
@@ -180,6 +182,85 @@ int main(void)
 	};
 	struct axi_dmac *ad9250_1_dmac;
 
+	struct ad9517_platform_data ad9517_pdata_lpc = {
+		/* PLL Reference */
+		.ref_1_freq = 30720000,
+		.ref_2_freq = 0,
+		.diff_ref_en = 0,
+		.ref_1_power_on = 1,
+		.ref_2_power_on = 0,
+		.ref_sel_pin_en = 0,
+		.ref_sel_pin = 1,
+		.ref_2_en = 0,
+		.ext_clk_freq = 0,
+		.int_vco_freq = 2500000000,
+		.vco_clk_sel = 1,
+		.power_down_vco_clk = 0,
+		.name = "ad9517-lpc"
+	};
+
+	struct ad9517_lvpecl_channel_spec ad9517_lvpecl_channels[] = {
+		{
+			.channel_num = 0,
+			.out_invert_en = 0,
+			.out_diff_voltage = LVPECL_780mV,
+			.name = "CH0"
+		},
+		{
+			.channel_num = 1,
+			.out_invert_en = 0,
+			.out_diff_voltage = LVPECL_780mV,
+			.name = "CH1"
+		},
+		{
+			.channel_num = 2,
+			.out_invert_en = 0,
+			.out_diff_voltage = LVPECL_780mV,
+			.name = "CH2"
+		},
+		{
+			.channel_num = 3,
+			.out_invert_en = 0,
+			.out_diff_voltage = LVPECL_780mV,
+			.name = "CH3"
+		}
+	};
+
+	struct ad9517_lvds_cmos_channel_spec ad9517_lvds_cmos_channels[] = {
+		{
+			.channel_num = 4,
+			.out_invert = 0,
+			.logic_level = LVDS,
+			.cmos_b_en = 0,
+			.out_lvds_current = LVDS_3_5mA,
+			.name = "CH4"
+		},
+		{
+			.channel_num = 5,
+			.out_invert = 0,
+			.logic_level = LVDS,
+			.cmos_b_en = 0,
+			.out_lvds_current = LVDS_3_5mA,
+			.name = "CH5"
+		},
+		{
+			.channel_num = 6,
+			.out_invert = 0,
+			.logic_level = LVDS,
+			.cmos_b_en = 0,
+			.out_lvds_current = LVDS_3_5mA,
+			.name = "CH6"
+		},
+		{
+			.channel_num = 7,
+			.out_invert = 0,
+			.logic_level = LVDS,
+			.cmos_b_en = 0,
+			.out_lvds_current = LVDS_3_5mA,
+			.name = "CH7"
+		}
+	};
+
 	struct ad9250_platform_data ad9250_pdata_lpc = {
 		.extrn_pdwnmode = 0,
 		.en_clk_dcs = 1,
@@ -260,6 +341,11 @@ int main(void)
 	struct ad9250_init_param	ad9250_1_param;
 	struct ad9517_init_param	ad9517_param;
 
+	ad9517_param.ad9517_type = AD9517_1;
+	ad9517_param.ad9517_st.pdata = &ad9517_pdata_lpc;
+	ad9517_param.ad9517_st.lvpecl_channels = &ad9517_lvpecl_channels[0];
+	ad9517_param.ad9517_st.lvds_cmos_channels = &ad9517_lvds_cmos_channels[0];
+
 	ad9250_0_param.ad9250_st_init.pdata = &ad9250_pdata_lpc;
 	ad9250_0_param.ad9250_st_init.p_jesd204b = &ad9250_0_jesd204b_interface;
 	ad9250_0_param.ad9250_st_init.p_fd = &ad9250_fast_detect;
@@ -280,8 +366,109 @@ int main(void)
 
 	// set up clock generator
 	status = ad9517_setup(&ad9517_device, ad9517_param);
-	if(status < 0)
+	if(status < 0) {
 		printf("Error ad9517_setup()\n");
+		return FAILURE;
+	}
+
+	/* Set the channel 0 power mode on */
+	status = ad9517_power_mode(ad9517_device, 0, 0);
+	if(status < 0) {
+		printf("Error channel 0 ad9517_power_mode()\n");
+		return FAILURE;
+	}
+	/* Set the channel 0 frequency to 250Mhz */
+	status = ad9517_frequency(ad9517_device, 0, 250000000);
+	if(status < 0) {
+		printf("Error channel 0 ad9517_frequency()\n");
+		return FAILURE;
+	}
+
+	/* Set the channel 1 power mode on */
+	status = ad9517_power_mode(ad9517_device, 1, 0);
+	if(status < 0) {
+		printf("Error channel 1 ad9517_power_mode()\n");
+		return FAILURE;
+	}
+
+	/* Set the channel 1 frequency to 250Mhz */
+	status = ad9517_frequency(ad9517_device, 1, 250000000);
+	if(status < 0) {
+		printf("Error channel 1 ad9517_frequency()\n");
+		return FAILURE;
+	}
+
+	/* Set the channel 4 power mode on */
+	status = ad9517_power_mode(ad9517_device, 4, 0);
+	if(status < 0) {
+		printf("Error channel 4 ad9517_power_mode()\n");
+		return FAILURE;
+	}
+
+	/* Set the channel 4 frequency to 250Mhz */
+	status = ad9517_frequency(ad9517_device, 4, 250000000);
+	if(status < 0) {
+		printf("Error channel 4 ad9517_frequency()\n");
+		return FAILURE;
+	}
+
+	/* Set the channel 5 power mode on */
+	status = ad9517_power_mode(ad9517_device, 5, 0);
+	if(status < 0) {
+		printf("Error channel 5 ad9517_power_mode()\n");
+		return FAILURE;
+	}
+
+	/* Set the channel 5 frequency to 250Mhz */
+	status = ad9517_frequency(ad9517_device, 5, 250000000);
+	if(status < 0) {
+		printf("Error channel 5 ad9517_frequency()\n");
+		return FAILURE;
+	}
+
+	/* Set the channel 6 power mode on */
+	status = ad9517_power_mode(ad9517_device, 6, 0);
+	if(status < 0) {
+		printf("Error channel 6 ad9517_power_mode()\n");
+		return FAILURE;
+	}
+
+	/* Set the channel 6 frequency to 250Mhz */
+	status = ad9517_frequency(ad9517_device, 6, 250000000);
+	if(status < 0) {
+		printf("Error channel 6 ad9517_frequency()\n");
+		return FAILURE;
+	}
+
+	/* Set the channel 7 power mode on */
+	status = ad9517_power_mode(ad9517_device, 7, 0);
+	if(status < 0) {
+		printf("Error channel 7 ad9517_power_mode()\n");
+		return FAILURE;
+	}
+
+	/* Set the channel 7 frequency to 250Mhz */
+	status = ad9517_frequency(ad9517_device, 7, 250000000);
+	if(status < 0) {
+		printf("Error channel 7 ad9517_frequency()\n");
+		return FAILURE;
+	}
+
+	status = ad9517_update(ad9517_device);
+	if(status < 0) {
+		printf("Error ad9517_update()\n");
+		return FAILURE;
+	}
+
+	status = ad9517_read(ad9517_device, AD9517_REG_PLL_READBACK, &reg_value);
+	if (status < 0) {
+		printf("Error ad9517_read()!\n");
+		return FAILURE;
+	} else if (!(reg_value & AD9517_DIGITAL_LOCK_DETECT)) {
+		printf("AD9517 PLL not locked!\n");
+		return FAILURE;
+	}
+	printf("AD9517 PLL locked.\n");
 
 	// set up the devices
 	status= ad9250_setup(&ad9250_0_device, ad9250_0_param);


### PR DESCRIPTION
1. Add part type check for ad9517.
2. Integrate ad9517 driver from `drivers/frequency` folder.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>