### PR TITLE
fix gpio_get_direction output when using PL

### DIFF
--- a/drivers/platform/xilinx/gpio.c
+++ b/drivers/platform/xilinx/gpio.c
@@ -344,7 +344,8 @@ int32_t gpio_get_direction(struct gpio_desc *desc,
 			pin -= 32;
 		} else
 			channel = 1;
-		*direction = (XGpio_GetDataDirection(extra->instance,channel) >> pin) & 0x01;
+		*direction = ((XGpio_GetDataDirection(extra->instance,
+						      channel) >> pin) & 0x1) ^ 0x1;
 #endif
 		break;
 	case GPIO_PS:


### PR DESCRIPTION
From XGpio_GetDataDirection documentation:
	Bits set to 0 are output and bits set to 1 are input.

no-OS (and also xilinx PS) convention is:
GPIO_IN = 0
GPIO_OUT = 1

Fixes #608

Signed-off-by: Darius Berghe <darius.berghe@analog.com>