### PR TITLE
Talise MCS sync

### DIFF
--- a/projects/adrv9009/src/app/app_config.h
+++ b/projects/adrv9009/src/app/app_config.h
@@ -40,17 +40,18 @@
 #ifndef APP_CONFIG_H_
 #define APP_CONFIG_H_
 
-// Uncomment if using adrv2crr-fmc + adrv9009-zu11eg:
-//#define ZU11EG
+/* Uncomment if using adrv2crr-fmc + adrv9009-zu11eg: */
+// #define ZU11EG
 
-// Uncomment if using zcu102 + fmcomms8:
-//#define FMCOMMS8_ZCU102
+/* Uncomment if using zcu102 + fmcomms8: */
+// #define FMCOMMS8_ZCU102
 
-// Provided ZU11EG or FMCOMMS8_ZCU102 were not defined, this project builds
-// by default for zc706 + adrv9009-w/pcbz.
+/* Provided ZU11EG or FMCOMMS8_ZCU102 were not defined, this project builds
+ * by default for zc706 + adrv9009-w/pcbz.
+ */
 
-//#define DAC_DMA_EXAMPLE
-
-//#define IIO_EXAMPLE
+/* To build a specific example, uncomment one (only one) of the lines below: */
+// #define DAC_DMA_EXAMPLE
+// #define IIO_EXAMPLE
 
 #endif /* APP_CONFIG_H_ */

--- a/projects/adrv9009/src/app/app_jesd.c
+++ b/projects/adrv9009/src/app/app_jesd.c
@@ -58,9 +58,9 @@
 // header
 #include "app_jesd.h"
 
-static struct axi_jesd204_rx *rx_jesd = NULL;
-static struct axi_jesd204_tx *tx_jesd = NULL;
-static struct axi_jesd204_rx *rx_os_jesd = NULL;
+struct axi_jesd204_rx *rx_jesd = NULL;
+struct axi_jesd204_tx *tx_jesd = NULL;
+struct axi_jesd204_rx *rx_os_jesd = NULL;
 
 adiHalErr_t jesd_init(uint32_t rx_div40_rate_hz,
 		      uint32_t tx_div40_rate_hz,

--- a/projects/adrv9009/src/app/app_jesd.c
+++ b/projects/adrv9009/src/app/app_jesd.c
@@ -120,10 +120,6 @@ adiHalErr_t jesd_init(uint32_t rx_div40_rate_hz,
 		goto error_7;
 	}
 
-	axi_jesd204_tx_lane_clk_enable(tx_jesd);
-	axi_jesd204_rx_lane_clk_enable(rx_jesd);
-	axi_jesd204_rx_lane_clk_enable(rx_os_jesd);
-
 	return ADIHAL_OK;
 
 error_7:

--- a/projects/adrv9009/src/app/app_jesd.h
+++ b/projects/adrv9009/src/app/app_jesd.h
@@ -42,6 +42,10 @@
 #include <stdint.h>
 #include "adi_hal.h"
 
+extern struct axi_jesd204_rx *rx_jesd;
+extern struct axi_jesd204_tx *tx_jesd;
+extern struct axi_jesd204_rx *rx_os_jesd;
+
 adiHalErr_t jesd_init(uint32_t rx_div40_rate_hz,
 		      uint32_t tx_div40_rate_hz,
 		      uint32_t rx_os_div40_rate_hz);

--- a/projects/adrv9009/src/app/app_talise.c
+++ b/projects/adrv9009/src/app/app_talise.c
@@ -127,8 +127,6 @@ adiHalErr_t talise_setup(taliseDevice_t * const pd, taliseInit_t * const pi)
 		goto error_11;
 	}
 
-	mdelay(100);
-
 	/* TALISE_initialize() loads the Talise device data structure
 	 * settings for the Rx/Tx/ORx profiles, FIR filters, digital
 	 * filter enables, calibrates the CLKPLL, loads the user provided Rx
@@ -247,6 +245,7 @@ adiHalErr_t talise_setup(taliseDevice_t * const pd, taliseInit_t * const pi)
 	}
 
 	/*** < wait 200ms for PLLs to lock - user code here > ***/
+	mdelay(200);
 
 	talAction = TALISE_getPllsLockStatus(pd, &pllLockStatus);
 	if ((pllLockStatus & 0x07) != 0x07) {
@@ -284,65 +283,106 @@ adiHalErr_t talise_setup(taliseDevice_t * const pd, taliseInit_t * const pi)
 	/***************************************************/
 	/**** Enable  Talise JESD204B Framer ***/
 	/***************************************************/
+	if (pi->jesd204Settings.framerA.M) {
+		talAction = TALISE_enableFramerLink(pd, TAL_FRAMER_A, 0);
+		if (talAction != TALACT_NO_ACTION) {
+			printf("error: TALISE_enableFramerLink() failed\n");
+			goto error_11;
+		}
 
-	talAction = TALISE_enableFramerLink(pd, TAL_FRAMER_A, 0);
-	if (talAction != TALACT_NO_ACTION) {
-		/*** < User: decide what to do based on Talise recovery action returned > ***/
-		printf("error: TALISE_enableFramerLink() failed\n");
-		goto error_11;
+		talAction |= TALISE_enableFramerLink(pd, TAL_FRAMER_A, 1);
+		if (talAction != TALACT_NO_ACTION) {
+			printf("error: TALISE_enableFramerLink() failed\n");
+			goto error_11;
+		}
+
+		/*************************************************/
+		/**** Enable SYSREF to Talise JESD204B Framer ***/
+		/*************************************************/
+		/*** < User: Make sure SYSREF is stopped/disabled > ***/
+
+		talAction = TALISE_enableSysrefToFramer(pd, TAL_FRAMER_A, 1);
+		if (talAction != TALACT_NO_ACTION) {
+			printf("error: TALISE_enableSysrefToFramer() failed\n");
+			goto error_11;
+		}
 	}
 
-	talAction |= TALISE_enableFramerLink(pd, TAL_FRAMER_A, 1);
-	if (talAction != TALACT_NO_ACTION) {
-		/*** < User: decide what to do based on Talise recovery action returned > ***/
-		printf("error: TALISE_enableFramerLink() failed\n");
-		goto error_11;
-	}
+	/***************************************************/
+	/**** Enable  Talise JESD204B Framer ***/
+	/***************************************************/
+	if (pi->jesd204Settings.framerB.M) {
+		talAction = TALISE_enableFramerLink(pd, TAL_FRAMER_B, 0);
+		if (talAction != TALACT_NO_ACTION) {
+			printf("error: TALISE_enableFramerLink() failed\n");
+			goto error_11;
+		}
 
-	/*************************************************/
-	/**** Enable SYSREF to Talise JESD204B Framer ***/
-	/*************************************************/
-	/*** < User: Make sure SYSREF is stopped/disabled > ***/
+		talAction |= TALISE_enableFramerLink(pd, TAL_FRAMER_B, 1);
+		if (talAction != TALACT_NO_ACTION) {
+			printf("error: TALISE_enableFramerLink() failed\n");
+			goto error_11;
+		}
 
-	talAction = TALISE_enableSysrefToFramer(pd, TAL_FRAMER_A, 1);
-	if (talAction != TALACT_NO_ACTION) {
-		/*** < User: decide what to do based on Talise recovery action returned > ***/
-		printf("error: TALISE_enableSysrefToFramer() failed\n");
-		goto error_11;
+		/*************************************************/
+		/**** Enable SYSREF to Talise JESD204B Framer ***/
+		/*************************************************/
+		/*** < User: Make sure SYSREF is stopped/disabled > ***/
+
+		talAction = TALISE_enableSysrefToFramer(pd, TAL_FRAMER_B, 1);
+		if (talAction != TALACT_NO_ACTION) {
+			printf("error: TALISE_enableSysrefToFramer() failed\n");
+			goto error_11;
+		}
 	}
 
 	/***************************************************/
 	/**** Enable  Talise JESD204B Deframer ***/
 	/***************************************************/
+	if (pi->jesd204Settings.deframerA.M) {
+		talAction = TALISE_enableDeframerLink(pd, TAL_DEFRAMER_A, 0);
+		if (talAction != TALACT_NO_ACTION) {
+			/*** < User: decide what to do based on Talise recovery action returned > ***/
+			printf("error: TALISE_enableDeframerLink() failed\n");
+			goto error_11;
+		}
 
-	talAction = TALISE_enableDeframerLink(pd, TAL_DEFRAMER_A, 0);
-	if (talAction != TALACT_NO_ACTION) {
-		/*** < User: decide what to do based on Talise recovery action returned > ***/
-		printf("error: TALISE_enableDeframerLink() failed\n");
-		goto error_11;
-	}
-
-	talAction |= TALISE_enableDeframerLink(pd, TAL_DEFRAMER_A, 1);
-	if (talAction != TALACT_NO_ACTION) {
-		/*** < User: decide what to do based on Talise recovery action returned > ***/
-		printf("error: TALISE_enableDeframerLink() failed\n");
-		goto error_11;
-	}
-	/***************************************************/
-	/**** Enable SYSREF to Talise JESD204B Deframer ***/
-	/***************************************************/
-	talAction = TALISE_enableSysrefToDeframer(pd, TAL_DEFRAMER_A, 1);
-	if (talAction != TALACT_NO_ACTION) {
-		/*** < User: decide what to do based on Talise recovery action returned > ***/
-		printf("error: TALISE_enableDeframerLink() failed\n");
-		goto error_11;
+		talAction |= TALISE_enableDeframerLink(pd, TAL_DEFRAMER_A, 1);
+		if (talAction != TALACT_NO_ACTION) {
+			/*** < User: decide what to do based on Talise recovery action returned > ***/
+			printf("error: TALISE_enableDeframerLink() failed\n");
+			goto error_11;
+		}
+		/***************************************************/
+		/**** Enable SYSREF to Talise JESD204B Deframer ***/
+		/***************************************************/
+		talAction = TALISE_enableSysrefToDeframer(pd, TAL_DEFRAMER_A, 1);
+		if (talAction != TALACT_NO_ACTION) {
+			/*** < User: decide what to do based on Talise recovery action returned > ***/
+			printf("error: TALISE_enableDeframerLink() failed\n");
+			goto error_11;
+		}
 	}
 
 	/*** < User Sends SYSREF Here > ***/
 
 	ADIHAL_sysrefReq(pd->devHalInfo, SYSREF_CONT_ON);
 
-	mdelay(100);
+	if(talInit.rx.rxChannels != TAL_RXOFF)
+		axi_jesd204_rx_lane_clk_enable(rx_jesd);
+
+	if(talInit.obsRx.obsRxChannelsEnable != TAL_RXOFF)
+		axi_jesd204_rx_lane_clk_enable(rx_os_jesd);
+
+	if(talInit.tx.txChannels != TAL_RXOFF) {
+		axi_jesd204_tx_lane_clk_enable(tx_jesd);
+
+		/* RESET CDR */
+		uint8_t phy_ctrl;
+		ADIHAL_spiReadByte(pd->devHalInfo, TALISE_ADDR_DES_PHY_GENERAL_CTL_1, &phy_ctrl);
+		ADIHAL_spiWriteByte(pd->devHalInfo, TALISE_ADDR_DES_PHY_GENERAL_CTL_1, phy_ctrl & ~BIT(7));
+		ADIHAL_spiWriteByte(pd->devHalInfo, TALISE_ADDR_DES_PHY_GENERAL_CTL_1, phy_ctrl);
+	}
 
 	ADIHAL_sysrefReq(pd->devHalInfo, SYSREF_CONT_OFF);
 
@@ -353,28 +393,48 @@ adiHalErr_t talise_setup(taliseDevice_t * const pd, taliseInit_t * const pi)
 	/**************************************/
 	/**** Check Talise Deframer Status ***/
 	/**************************************/
-	talAction = TALISE_readDeframerStatus(pd, TAL_DEFRAMER_A, &deframerStatus);
-	if (talAction != TALACT_NO_ACTION) {
-		/*** < User: decide what to do based on Talise recovery action returned > ***/
-		printf("error: TALISE_readDeframerStatus() failed\n");
-		goto error_11;
-	}
+	if (pi->jesd204Settings.deframerA.M) {
+		talAction = TALISE_readDeframerStatus(pd, TAL_DEFRAMER_A, &deframerStatus);
+		if (talAction != TALACT_NO_ACTION) {
+			/*** < User: decide what to do based on Talise recovery action returned > ***/
+			printf("error: TALISE_readDeframerStatus() failed\n");
+			goto error_11;
+		}
 
-	if ((deframerStatus & 0xF7) != 0x86)
-		printf("warning: TAL_DEFRAMER_A status 0x%X\n", deframerStatus);
+		if ((deframerStatus & 0xF7) != 0x86)
+			printf("warning: TAL_DEFRAMER_A status 0x%X\n", deframerStatus);
+	}
 
 	/************************************/
 	/**** Check Talise Framer Status ***/
 	/************************************/
-	talAction = TALISE_readFramerStatus(pd, TAL_FRAMER_A, &framerStatus);
-	if (talAction != TALACT_NO_ACTION) {
-		/*** < User: decide what to do based on Talise recovery action returned > ***/
-		printf("error: TALISE_readFramerStatus() failed\n");
-		goto error_11;
+	if (pi->jesd204Settings.framerA.M) {
+		talAction = TALISE_readFramerStatus(pd, TAL_FRAMER_A, &framerStatus);
+		if (talAction != TALACT_NO_ACTION) {
+			/*** < User: decide what to do based on Talise recovery action returned > ***/
+			printf("error: TALISE_readFramerStatus() failed\n");
+			goto error_11;
+		}
+
+		if ((framerStatus & 0x07) != 0x05) {
+			printf("warning: TAL_FRAMER_A status 0x%X\n", framerStatus);
+		}
 	}
 
-	if ((framerStatus & 0x07) != 0x05) {
-		printf("warning: TAL_FRAMER_A status 0x%X\n", framerStatus);
+	/************************************/
+	/**** Check Talise Framer Status ***/
+	/************************************/
+	if (pi->jesd204Settings.framerB.M) {
+		talAction = TALISE_readFramerStatus(pd, TAL_FRAMER_B, &framerStatus);
+		if (talAction != TALACT_NO_ACTION) {
+			/*** < User: decide what to do based on Talise recovery action returned > ***/
+			printf("error: TALISE_readFramerStatus() failed\n");
+			goto error_11;
+		}
+
+		if ((framerStatus & 0x07) != 0x05) {
+			printf("warning: TAL_FRAMER_B status 0x%X\n", framerStatus);
+		}
 	}
 
 	/*** < User: When links have been verified, proceed > ***/
@@ -479,17 +539,21 @@ int talise_multi_chip_sync(taliseDevice_t * pd, int step)
 			if (ret != TALACT_NO_ACTION) {
 				printf("%s:%d (ret %d)\n", __func__, __LINE__, ret);
 				ret = FAILURE;
+				break;
 			}
+
 			ret = TALISE_enableFramerLink(pd, TAL_FRAMER_A, 0);
 			if (ret != TALACT_NO_ACTION) {
 				printf("%s:%d (ret %d)\n", __func__, __LINE__, ret);
 				ret = FAILURE;
+				break;
 			}
 
 			ret = TALISE_enableFramerLink(pd, TAL_FRAMER_A, 1);
 			if (ret != TALACT_NO_ACTION) {
 				printf("%s:%d (ret %d)\n", __func__, __LINE__, ret);
 				ret = FAILURE;
+				break;
 			}
 
 			/*************************************************/
@@ -501,6 +565,7 @@ int talise_multi_chip_sync(taliseDevice_t * pd, int step)
 			if (ret != TALACT_NO_ACTION) {
 				printf("%s:%d (ret %d)\n", __func__, __LINE__, ret);
 				ret = FAILURE;
+				break;
 			}
 		}
 
@@ -513,18 +578,21 @@ int talise_multi_chip_sync(taliseDevice_t * pd, int step)
 			if (ret != TALACT_NO_ACTION) {
 				printf("%s:%d (ret %d)\n", __func__, __LINE__, ret);
 				ret = FAILURE;
+				break;
 			}
 
 			ret = TALISE_enableFramerLink(pd, TAL_FRAMER_B, 0);
 			if (ret != TALACT_NO_ACTION) {
 				printf("%s:%d (ret %d)\n", __func__, __LINE__, ret);
 				ret = FAILURE;
+				break;
 			}
 
 			ret = TALISE_enableFramerLink(pd, TAL_FRAMER_B, 1);
 			if (ret != TALACT_NO_ACTION) {
 				printf("%s:%d (ret %d)\n", __func__, __LINE__, ret);
 				ret = FAILURE;
+				break;
 			}
 
 			/*************************************************/
@@ -536,6 +604,7 @@ int talise_multi_chip_sync(taliseDevice_t * pd, int step)
 			if (ret != TALACT_NO_ACTION) {
 				printf("%s:%d (ret %d)\n", __func__, __LINE__, ret);
 				ret = FAILURE;
+				break;
 			}
 		}
 		/***************************************************/
@@ -546,18 +615,21 @@ int talise_multi_chip_sync(taliseDevice_t * pd, int step)
 			if (ret != TALACT_NO_ACTION) {
 				printf("%s:%d (ret %d)\n", __func__, __LINE__, ret);
 				ret = FAILURE;
+				break;
 			}
 
 			ret = TALISE_enableDeframerLink(pd, TAL_DEFRAMER_A, 0);
 			if (ret != TALACT_NO_ACTION) {
 				printf("%s:%d (ret %d)\n", __func__, __LINE__, ret);
 				ret = FAILURE;
+				break;
 			}
 
 			ret |= TALISE_enableDeframerLink(pd, TAL_DEFRAMER_A, 1);
 			if (ret != TALACT_NO_ACTION) {
 				printf("%s:%d (ret %d)\n", __func__, __LINE__, ret);
 				ret = FAILURE;
+				break;
 			}
 
 			/***************************************************/
@@ -567,6 +639,7 @@ int talise_multi_chip_sync(taliseDevice_t * pd, int step)
 			if (ret != TALACT_NO_ACTION) {
 				printf("%s:%d (ret %d)\n", __func__, __LINE__, ret);
 				ret = FAILURE;
+				break;
 			}
 
 		}
@@ -577,13 +650,13 @@ int talise_multi_chip_sync(taliseDevice_t * pd, int step)
 		/* RESET CDR */
 		uint8_t phy_ctrl;
 		ret = ADIHAL_spiReadByte(pd->devHalInfo, TALISE_ADDR_DES_PHY_GENERAL_CTL_1, &phy_ctrl);
-		if(ret)
+		if (ret)
 			break;
 		ret = ADIHAL_spiWriteByte(pd->devHalInfo, TALISE_ADDR_DES_PHY_GENERAL_CTL_1, phy_ctrl & ~BIT(7));
-		if(ret)
+		if (ret)
 			break;
 		ret = ADIHAL_spiWriteByte(pd->devHalInfo, TALISE_ADDR_DES_PHY_GENERAL_CTL_1, phy_ctrl);
-		if(ret)
+		if (ret)
 			break;
 
 		axi_jesd204_rx_lane_clk_enable(rx_os_jesd);
@@ -604,6 +677,7 @@ int talise_multi_chip_sync(taliseDevice_t * pd, int step)
 			if (ret != TALACT_NO_ACTION) {
 				printf("%s:%d (ret %d)\n", __func__, __LINE__, ret);
 				ret = FAILURE;
+				break;
 			}
 
 			if ((deframerStatus & 0xF7) != 0x86)
@@ -618,6 +692,7 @@ int talise_multi_chip_sync(taliseDevice_t * pd, int step)
 			if (ret != TALACT_NO_ACTION) {
 				printf("%s:%d (ret %d)\n", __func__, __LINE__, ret);
 				ret = FAILURE;
+				break;
 			}
 
 			if ((framerStatus & 0x07) != 0x05)
@@ -631,6 +706,7 @@ int talise_multi_chip_sync(taliseDevice_t * pd, int step)
 			if (ret != TALACT_NO_ACTION) {
 				printf("%s:%d (ret %d)\n", __func__, __LINE__, ret);
 				ret = FAILURE;
+				break;
 			}
 
 			if ((framerStatus & 0x07) != 0x05)

--- a/projects/adrv9009/src/app/app_talise.c
+++ b/projects/adrv9009/src/app/app_talise.c
@@ -379,9 +379,12 @@ adiHalErr_t talise_setup(taliseDevice_t * const pd, taliseInit_t * const pi)
 
 		/* RESET CDR */
 		uint8_t phy_ctrl;
-		ADIHAL_spiReadByte(pd->devHalInfo, TALISE_ADDR_DES_PHY_GENERAL_CTL_1, &phy_ctrl);
-		ADIHAL_spiWriteByte(pd->devHalInfo, TALISE_ADDR_DES_PHY_GENERAL_CTL_1, phy_ctrl & ~BIT(7));
-		ADIHAL_spiWriteByte(pd->devHalInfo, TALISE_ADDR_DES_PHY_GENERAL_CTL_1, phy_ctrl);
+		ADIHAL_spiReadByte(pd->devHalInfo, TALISE_ADDR_DES_PHY_GENERAL_CTL_1,
+				   &phy_ctrl);
+		ADIHAL_spiWriteByte(pd->devHalInfo, TALISE_ADDR_DES_PHY_GENERAL_CTL_1,
+				    phy_ctrl & ~BIT(7));
+		ADIHAL_spiWriteByte(pd->devHalInfo, TALISE_ADDR_DES_PHY_GENERAL_CTL_1,
+				    phy_ctrl);
 	}
 
 	ADIHAL_sysrefReq(pd->devHalInfo, SYSREF_CONT_OFF);
@@ -511,7 +514,7 @@ int talise_multi_chip_sync(taliseDevice_t * pd, int step)
 		ret = TALISE_enableMultichipSync(pd, 0, &mcsStatus);
 		if ((mcsStatus & 0x0B) != 0x0B) {
 			printf("%s:%d Unexpected MCS sync status (0x%X)\n",
-				__func__, __LINE__, mcsStatus);
+			       __func__, __LINE__, mcsStatus);
 			ret = FAILURE;
 		}
 		break;
@@ -649,13 +652,16 @@ int talise_multi_chip_sync(taliseDevice_t * pd, int step)
 
 		/* RESET CDR */
 		uint8_t phy_ctrl;
-		ret = ADIHAL_spiReadByte(pd->devHalInfo, TALISE_ADDR_DES_PHY_GENERAL_CTL_1, &phy_ctrl);
+		ret = ADIHAL_spiReadByte(pd->devHalInfo, TALISE_ADDR_DES_PHY_GENERAL_CTL_1,
+					 &phy_ctrl);
 		if (ret)
 			break;
-		ret = ADIHAL_spiWriteByte(pd->devHalInfo, TALISE_ADDR_DES_PHY_GENERAL_CTL_1, phy_ctrl & ~BIT(7));
+		ret = ADIHAL_spiWriteByte(pd->devHalInfo, TALISE_ADDR_DES_PHY_GENERAL_CTL_1,
+					  phy_ctrl & ~BIT(7));
 		if (ret)
 			break;
-		ret = ADIHAL_spiWriteByte(pd->devHalInfo, TALISE_ADDR_DES_PHY_GENERAL_CTL_1, phy_ctrl);
+		ret = ADIHAL_spiWriteByte(pd->devHalInfo, TALISE_ADDR_DES_PHY_GENERAL_CTL_1,
+					  phy_ctrl);
 		if (ret)
 			break;
 

--- a/projects/adrv9009/src/app/app_talise.h
+++ b/projects/adrv9009/src/app/app_talise.h
@@ -58,7 +58,7 @@ enum taliseDeviceId {
 
 adiHalErr_t talise_setup(taliseDevice_t * const talDev,
 			 taliseInit_t * const talInit);
-
+int talise_multi_chip_sync(taliseDevice_t * pd, int step);
 void talise_shutdown(taliseDevice_t * const pd);
 bool adrv9009_check_sysref_rate(uint32_t lmfc, uint32_t sysref);
 

--- a/projects/adrv9009/src/app/headless.c
+++ b/projects/adrv9009/src/app/headless.c
@@ -225,7 +225,7 @@ int main(void)
 			goto error_3;
 	}
 #if defined(ZU11EG) || defined(FMCOMMS8_ZCU102)
-	
+	printf("Performing multi-chip synchronization...\n");
 	for(int i=0; i < 12; i++) {
 		for (t = TALISE_A; t < TALISE_DEVICE_ID_MAX; t++) {
 			err = talise_multi_chip_sync(&tal[t], i);

--- a/projects/adrv9009/src/app/headless.c
+++ b/projects/adrv9009/src/app/headless.c
@@ -224,7 +224,16 @@ int main(void)
 		if (err != ADIHAL_OK)
 			goto error_3;
 	}
-
+#if defined(ZU11EG) || defined(FMCOMMS8_ZCU102)
+	
+	for(int i=0; i < 12; i++) {
+		for (t = TALISE_A; t < TALISE_DEVICE_ID_MAX; t++) {
+			err = talise_multi_chip_sync(&tal[t], i);
+			if (err != ADIHAL_OK)
+				goto error_3;
+		}
+	}
+#endif
 	ADIHAL_sysrefReq(tal[TALISE_A].devHalInfo, SYSREF_CONT_ON);
 
 	jesd_rx_watchdog();

--- a/projects/adrv9009/src/app/headless.c
+++ b/projects/adrv9009/src/app/headless.c
@@ -136,7 +136,7 @@ int main(void)
 		"tx_dmac",
 		TX_DMA_BASEADDR,
 		DMA_MEM_TO_DEV,
-		DMA_CYCLIC,
+		0,
 	};
 	struct axi_dmac *tx_dmac;
 	struct gpio_desc *gpio_plddrbypass;
@@ -255,7 +255,7 @@ int main(void)
 		printf("gpio_get() failed with status %d", s);
 		return s;
 	}
-	gpio_direction_output(gpio_plddrbypass, 1);
+	gpio_direction_output(gpio_plddrbypass, 0);
 	axi_dac_load_custom_data(tx_dac, sine_lut_iq,
 				 ARRAY_SIZE(sine_lut_iq),
 				 DDR_MEM_BASEADDR + 0xA000000);


### PR DESCRIPTION
Various adrv9009 related improvements:
- add some scripts to visualize the DAC_DMA_EXAMPLE data
- get the talise_setup procedure in sync with linux (FRAMER_B was uninitialized in the old procedure!)
- fix DAC_DMA_EXAMPLE (cyclic tx DMA and pl-fifo were overwriting each other)
- MCS sync seems to be working, i see constant near zero offsets across reboots