### PR TITLE
fmcjesdadc1: add iio application

### DIFF
--- a/projects/fmcjesdadc1/src/app/app_config.h
+++ b/projects/fmcjesdadc1/src/app/app_config.h
@@ -43,4 +43,6 @@
 
 //#define XILINX_PLATFORM
 
+//#define IIO_EXAMPLE
+
 #endif /* APP_CONFIG_H_ */

--- a/projects/fmcjesdadc1/src/app/app_iio.c
+++ b/projects/fmcjesdadc1/src/app/app_iio.c
@@ -1,0 +1,126 @@
+/***************************************************************************//**
+ *   @file   app_iio.c
+ *   @brief  Application IIO setup.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include "error.h"
+#include "uart.h"
+#include "uart_extra.h"
+#include "iio_app.h"
+#include "parameters.h"
+#include "app_iio.h"
+
+/******************************************************************************/
+/************************ Variables Definitions *******************************/
+/******************************************************************************/
+static struct uart_desc *uart_desc;
+
+/******************************************************************************/
+/************************** Functions Implementation **************************/
+/******************************************************************************/
+
+/**
+ * iio_server_write() - Write data to UART.
+ * @buf - Data to be written.
+ * @len - Number of bytes to be written.
+ * @Return: SUCCESS in case of success, FAILURE otherwise.
+ */
+static ssize_t iio_server_write(const char *buf, size_t len)
+{
+	return uart_write(uart_desc, (const uint8_t *)buf, len);
+}
+
+/**
+ * iio_server_read() - Read data from UART.
+ * @buf - Storing data location.
+ * @len - Number of bytes to be read.
+ * @Return: SUCCESS in case of success, FAILURE otherwise.
+ */
+static ssize_t iio_server_read(char *buf, size_t len)
+{
+	return uart_read(uart_desc, (uint8_t *)buf, len);
+}
+
+/**
+ * @brief Application IIO setup.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t iio_server_init(struct iio_axi_adc_init_param *adc_0_init,
+			struct iio_axi_adc_init_param *adc_1_init)
+{
+	struct xil_uart_init_param xil_uart_init_par = {
+		.type = UART_PL,
+	};
+	struct uart_init_param uart_init_par = {
+		.baud_rate = 115200,
+		.device_id = UART_DEVICE_ID,
+		.extra = &xil_uart_init_par,
+	};
+	struct iio_server_ops uart_iio_server_ops = {
+		.read = iio_server_read,
+		.write = iio_server_write,
+	};
+	struct iio_app_init_param iio_app_init_par = {
+		.iio_server_ops = &uart_iio_server_ops,
+	};
+	struct iio_app_desc *iio_app_desc;
+	struct iio_axi_adc_desc *iio_axi_adc_0_desc;
+	struct iio_axi_adc_desc *iio_axi_adc_1_desc;
+	int32_t status;
+
+	status = uart_init(&uart_desc, &uart_init_par);
+	if (status < 0)
+		return status;
+
+	status = iio_app_init(&iio_app_desc, &iio_app_init_par);
+	if (status < 0)
+		return status;
+
+	status = iio_axi_adc_init(&iio_axi_adc_0_desc, adc_0_init);
+	if (status < 0)
+		return status;
+
+	status = iio_axi_adc_init(&iio_axi_adc_1_desc, adc_1_init);
+	if (status < 0)
+		return status;
+
+	return iio_app(iio_app_desc);
+}

--- a/projects/fmcjesdadc1/src/app/app_iio.h
+++ b/projects/fmcjesdadc1/src/app/app_iio.h
@@ -1,6 +1,6 @@
 /***************************************************************************//**
- *   @file   parameters.h
- *   @brief  Platform dependent parameters.
+ *   @file   app_iio.h
+ *   @brief  Application IIO setup.
  *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
 ********************************************************************************
  * Copyright 2020(c) Analog Devices, Inc.
@@ -36,44 +36,21 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
+#ifndef APP_IIO_H_
+#define APP_IIO_H_
 
-#ifndef _PARAMETERS_H_
-#define _PARAMETERS_H_
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdint.h>
+#include "iio_axi_adc.h"
 
-#include "app_config.h"
-#include "xparameters.h"
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
 
-#ifdef PLATFORM_MB
-#define SPI_DEVICE_ID				XPAR_SPI_0_DEVICE_ID
-#define GPIO_DEVICE_ID				XPAR_GPIO_0_DEVICE_ID
-#define UART_DEVICE_ID				XPAR_AXI_UART_DEVICE_ID
+/* @brief Application IIO setup. */
+int32_t iio_server_init(struct iio_axi_adc_init_param *adc_0_init,
+			struct iio_axi_adc_init_param *adc_1_init);
 
-#define GPIO_OFFSET				0
-
-#define ADC_0_DDR_BASEADDR			(XPAR_AXI_DDR_CNTRL_BASEADDR + 0x800000)
-#define ADC_1_DDR_BASEADDR			(XPAR_AXI_DDR_CNTRL_BASEADDR + 0x900000)
-#else
-#define SPI_DEVICE_ID				XPAR_XSPIPS_0_DEVICE_ID
-#define GPIO_DEVICE_ID				XPAR_XGPIOPS_0_DEVICE_ID
-
-#ifdef PLATFORM_ZYNQ
-#define GPIO_OFFSET				54
 #endif
-
-#define ADC_0_DDR_BASEADDR			(XPAR_DDR_MEM_BASEADDR + 0x800000)
-#define ADC_1_DDR_BASEADDR			(XPAR_DDR_MEM_BASEADDR + 0x900000)
-#endif
-
-#define RX_0_CORE_BASEADDR			XPAR_AXI_AD9250_0_CORE_BASEADDR
-#define RX_1_CORE_BASEADDR			XPAR_AXI_AD9250_1_CORE_BASEADDR
-
-#define RX_DMA_0_BASEADDR			XPAR_AXI_AD9250_0_DMA_BASEADDR
-#define RX_DMA_1_BASEADDR			XPAR_AXI_AD9250_1_DMA_BASEADDR
-
-#define RX_JESD_BASEADDR			XPAR_AXI_AD9250_JESD_RX_AXI_BASEADDR
-
-#define RX_XCVR_BASEADDR			XPAR_AXI_AD9250_XCVR_BASEADDR
-
-#define GPIO_JESD204_SYSREF			(GPIO_OFFSET + 32)
-
-#endif /* _PARAMETERS_H_ */

--- a/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
+++ b/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
@@ -61,6 +61,10 @@
 #include "axi_jesd204_rx.h"
 #include "demux_spi.h"
 
+#ifdef IIO_EXAMPLE
+#include "app_iio.h"
+#endif
+
 /***************************************************************************//**
 * @brief main
 *******************************************************************************/
@@ -368,6 +372,26 @@ int main(void)
 	// capture data with DMA
 	axi_dmac_transfer(ad9250_0_dmac, ADC_0_DDR_BASEADDR, 16384 * 2);
 	axi_dmac_transfer(ad9250_1_dmac, ADC_1_DDR_BASEADDR, 16384 * 2);
+
+#ifdef IIO_EXAMPLE
+	printf("The board accepts libiio clients connections through the serial backend.\n");
+
+	struct iio_axi_adc_init_param iio_axi_adc_0_init_par;
+	iio_axi_adc_0_init_par = (struct iio_axi_adc_init_param) {
+		.rx_adc = ad9250_0_core,
+		.rx_dmac = ad9250_0_dmac,
+		.adc_ddr_base = ADC_0_DDR_BASEADDR,
+	};
+	struct iio_axi_adc_init_param iio_axi_adc_1_init_par;
+	iio_axi_adc_1_init_par = (struct iio_axi_adc_init_param) {
+		.rx_adc = ad9250_1_core,
+		.rx_dmac = ad9250_1_dmac,
+		.adc_ddr_base = ADC_1_DDR_BASEADDR,
+	};
+
+	return iio_server_init(&iio_axi_adc_0_init_par, &iio_axi_adc_1_init_par);
+
+#endif
 
 	printf("adc1: setup and configuration is done\n");
 


### PR DESCRIPTION
Allow the used to read, write and edit axi_adc parameters via UART.

IIO-Oscilloscope application is now compatible with the fmcjesdadc1
project.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>