### PR TITLE
projects: ad9801: change IIO define naming

### DIFF
--- a/projects/ad9081/Makefile
+++ b/projects/ad9081/Makefile
@@ -7,7 +7,7 @@ else
 include ../../tools/scripts/linux.mk
 endif
 ifeq (y,$(strip $(TINYIIOD)))
-	CFLAGS += -D IIO_SUPPORT
+	CFLAGS += -D IIO_EXAMPLE
 endif
 ifeq (y,$(strip $(QUAD_MXFE)))
 	CFLAGS += -D QUAD_MXFE

--- a/projects/ad9081/src/app.c
+++ b/projects/ad9081/src/app.c
@@ -58,7 +58,7 @@
 #include "app_parameters.h"
 #include "app_config.h"
 
-#ifdef IIO_SUPPORT
+#ifdef IIO_EXAMPLE
 #include "app_iio.h"
 #endif
 
@@ -257,7 +257,7 @@ int main(void)
 	axi_dmac_init(&tx_dmac, &tx_dmac_init);
 	axi_dmac_init(&rx_dmac, &rx_dmac_init);
 
-#ifdef IIO_SUPPORT
+#ifdef IIO_EXAMPLE
 	printf("The board accepts libiio clients connections through the serial backend.\n");
 
 	struct iio_axi_adc_init_param iio_axi_adc_init_par;


### PR DESCRIPTION
Use `IIO_EXAMPLE` naming for the iio application option of the ad9081
project.

This will allign the naming with the rest of the projects that support
IIO integration.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>