### PR TITLE
projects: change macro naming for IIO apps

### DIFF
--- a/projects/ad713x_fmcz/src/ad713x_fmc.c
+++ b/projects/ad713x_fmcz/src/ad713x_fmc.c
@@ -60,7 +60,7 @@
 #include "util.h"
 #include "error.h"
 
-#ifdef IIO_EXAMPLE
+#ifdef IIO_SUPPORT
 #include "irq.h"
 #include "irq_extra.h"
 #include "uart.h"
@@ -69,7 +69,7 @@
 #include "iio_ad713x.h"
 #include "iio.h"
 #include "iio_app.h"
-#endif // IIO_EXAMPLE
+#endif // IIO_SUPPORT
 
 /******************************************************************************/
 /********************** Macros and Constants Definitions **********************/
@@ -103,7 +103,7 @@
 #define AD7134_FMC_CH_NO		8
 #define AD7134_FMC_SAMPLE_NO		1024
 
-#ifdef IIO_EXAMPLE
+#ifdef IIO_SUPPORT
 #define UART_DEVICE_ID			XPAR_XUARTPS_0_DEVICE_ID
 #define UART_IRQ_ID			XPAR_XUARTPS_1_INTR
 #define INTC_DEVICE_ID			XPAR_SCUGIC_SINGLE_DEVICE_ID
@@ -118,7 +118,7 @@ ssize_t iio_uart_read(char *buf, size_t len)
 {
 	return uart_read(uart_device, (uint8_t *)buf, len);
 }
-#endif // IIO_EXAMPLE
+#endif // IIO_SUPPORT
 
 int main()
 {
@@ -270,7 +270,7 @@ int main()
 	spi_engine_offload_message.rx_addr = 0x800000;
 	spi_engine_offload_message.tx_addr = 0xA000000;
 
-#ifdef IIO_EXAMPLE
+#ifdef IIO_SUPPORT
 	struct iio_ad713x *iio_ad713x;
 	struct iio_server_ops uart_iio_server_ops;
 	struct iio_app_init_param iio_app_init_par;
@@ -341,7 +341,7 @@ int main()
 
 	return iio_app(iio_app_desc);
 
-#endif /* IIO_EXAMPLE */
+#endif /* IIO_SUPPORT */
 
 	ret = spi_engine_offload_transfer(spi_eng_desc, spi_engine_offload_message,
 					  (AD7134_FMC_CH_NO * AD7134_FMC_SAMPLE_NO));

--- a/projects/ad9361/src/app_config.h
+++ b/projects/ad9361/src/app_config.h
@@ -57,9 +57,9 @@
 //#define AXI_ADC_NOT_PRESENT
 //#define TDD_SWITCH_STATE_EXAMPLE
 
-//#define IIO_EXAMPLE
+//#define IIO_SUPPORT
 
-#ifndef IIO_EXAMPLE
+#ifndef IIO_SUPPORT
 #define HAVE_VERBOSE_MESSAGES /* Recommended during development prints errors and warnings */
 //#define HAVE_DEBUG_MESSAGES /* For Debug purposes only */
 #endif // USE_LIBIIO

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -58,7 +58,7 @@
 #include "axi_dmac.h"
 #include "error.h"
 
-#ifdef IIO_EXAMPLE
+#ifdef IIO_SUPPORT
 
 #include "iio_app.h"
 #include "iio_axi_adc.h"
@@ -94,7 +94,7 @@ static ssize_t iio_uart_read(char *buf, size_t len)
 	return uart_read(uart_desc, (uint8_t *)buf, len);
 }
 
-#endif // IIO_EXAMPLE
+#endif // IIO_SUPPORT
 
 /******************************************************************************/
 /************************ Variables Definitions *******************************/
@@ -660,7 +660,7 @@ int main(void)
 #endif
 #endif
 
-#ifdef IIO_EXAMPLE
+#ifdef IIO_SUPPORT
 
 	/**
 	 * Transmit DMA initial configuration.
@@ -826,7 +826,7 @@ int main(void)
 
 	return iio_app(iio_app_desc);
 
-#endif // IIO_EXAMPLE
+#endif // IIO_SUPPORT
 
 	printf("Done.\n");
 

--- a/projects/ad9371/src/app/app_config.h
+++ b/projects/ad9371/src/app/app_config.h
@@ -45,6 +45,6 @@
 
 //#define DAC_DMA_EXAMPLE
 
-//#define IIO_EXAMPLE
+//#define IIO_SUPPORT
 
 #endif /* APP_CONFIG_H_ */

--- a/projects/ad9371/src/app/headless.c
+++ b/projects/ad9371/src/app/headless.c
@@ -65,7 +65,7 @@
 #include "axi_dmac.h"
 #include "app_config.h"
 
-#ifdef IIO_EXAMPLE
+#ifdef IIO_SUPPORT
 
 #include "iio_app.h"
 #include "iio_axi_adc.h"
@@ -99,7 +99,7 @@ static ssize_t iio_uart_read(char *buf, size_t len)
 	return uart_read(uart_desc, (uint8_t *)buf, len);
 }
 
-#endif // IIO_EXAMPLE
+#endif // IIO_SUPPORT
 /******************************************************************************/
 /************************ Variables Definitions *******************************/
 /******************************************************************************/
@@ -954,7 +954,7 @@ int main(void)
 	axi_dmac_init(&rx_dmac, &rx_dmac_init);
 	axi_dmac_init(&rx_obs_dmac, &rx_obs_dmac_init);
 
-#ifdef IIO_EXAMPLE
+#ifdef IIO_SUPPORT
 
 	/**
 	 * Transmit DMA initial configuration.
@@ -1125,7 +1125,7 @@ int main(void)
 
 	return iio_app(iio_app_desc);
 
-#endif // IIO_EXAMPLE
+#endif // IIO_SUPPORT
 
 	axi_dmac_transfer(rx_dmac,
 			  DDR_MEM_BASEADDR + 0x800000,

--- a/projects/adrv9009/src/app/app_config.h
+++ b/projects/adrv9009/src/app/app_config.h
@@ -52,6 +52,6 @@
 
 /* To build a specific example, uncomment one (only one) of the lines below: */
 // #define DAC_DMA_EXAMPLE
-// #define IIO_EXAMPLE
+// #define IIO_SUPPORT
 
 #endif /* APP_CONFIG_H_ */

--- a/projects/adrv9009/src/app/headless.c
+++ b/projects/adrv9009/src/app/headless.c
@@ -34,7 +34,7 @@
 #include "app_talise.h"
 #include "ad9528.h"
 
-#ifdef IIO_EXAMPLE
+#ifdef IIO_SUPPORT
 
 #include "iio_app.h"
 #include "iio_axi_adc.h"
@@ -68,7 +68,7 @@ static ssize_t iio_uart_read(char *buf, size_t len)
 	return uart_read(uart_desc, (uint8_t *)buf, len);
 }
 
-#endif // IIO_EXAMPLE
+#endif // IIO_SUPPORT
 
 /**********************************************************/
 /**********************************************************/
@@ -139,7 +139,7 @@ int main(void)
 		"tx_dmac",
 		TX_DMA_BASEADDR,
 		DMA_MEM_TO_DEV,
-#ifdef IIO_EXAMPLE
+#ifdef IIO_SUPPORT
 		DMA_CYCLIC,
 #else
 		0,
@@ -309,7 +309,7 @@ int main(void)
 #endif
 #endif
 
-#ifdef IIO_EXAMPLE
+#ifdef IIO_SUPPORT
 	/**
 	 * iio application configurations.
 	 */
@@ -445,7 +445,7 @@ int main(void)
 
 	return iio_app(iio_app_desc);
 
-#endif // IIO_EXAMPLE
+#endif // IIO_SUPPORT
 
 	for (t = TALISE_A; t < TALISE_DEVICE_ID_MAX; t++) {
 		talise_shutdown(&tal[t]);

--- a/projects/fmcjesdadc1/src/app/app_config.h
+++ b/projects/fmcjesdadc1/src/app/app_config.h
@@ -43,6 +43,6 @@
 
 //#define XILINX_PLATFORM
 
-//#define IIO_EXAMPLE
+//#define IIO_SUPPORT
 
 #endif /* APP_CONFIG_H_ */

--- a/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
+++ b/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
@@ -61,7 +61,7 @@
 #include "axi_jesd204_rx.h"
 #include "demux_spi.h"
 
-#ifdef IIO_EXAMPLE
+#ifdef IIO_SUPPORT
 #include "app_iio.h"
 #endif
 
@@ -560,7 +560,7 @@ int main(void)
 	axi_dmac_transfer(ad9250_0_dmac, ADC_0_DDR_BASEADDR, 16384 * 2);
 	axi_dmac_transfer(ad9250_1_dmac, ADC_1_DDR_BASEADDR, 16384 * 2);
 
-#ifdef IIO_EXAMPLE
+#ifdef IIO_SUPPORT
 	printf("The board accepts libiio clients connections through the serial backend.\n");
 
 	struct iio_axi_adc_init_param iio_axi_adc_0_init_par;

--- a/tools/scripts/linux.mk
+++ b/tools/scripts/linux.mk
@@ -92,7 +92,7 @@ CFLAGS = -Wall 								\
 	#-Werror
 
 ifeq (y,$(strip $(TINYIIOD)))
-CFLAGS += -D IIO_EXAMPLE
+CFLAGS += -D IIO_SUPPORT
 CFLAGS += -D _USE_STD_INT_TYPES
 endif
 


### PR DESCRIPTION
Replace 'IIO_EXAMPLE' macro naming from no-OS projects with 'IIO_SUPPORT'.

This name is more suggestive since the implementations represent more
than an IIO example. They help the users interface with the boards via
IIO Oscilloscope app.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>