### PR TITLE
Aducm small makefile fixes

### DIFF
--- a/libraries/mqtt/Makefile
+++ b/libraries/mqtt/Makefile
@@ -31,7 +31,13 @@ LIBRARY = libmqtt_client.a
 
 .PHONEY = all clean
 
+ifeq ($(wildcard $(PAHO_DIR)/README.md),)
+all:
+	git submodule update --init --remote -- $(PAHO_DIR)
+	$(MAKE) $(LIBRARY)
+else
 all: $(LIBRARY)
+endif
 
 $(LIBRARY): $(OBJS)
 	$(AR) $(ARFLAGS) $@ $(OBJS)

--- a/tools/scripts/aducm.mk
+++ b/tools/scripts/aducm.mk
@@ -286,19 +286,19 @@ OBJS = $(REL_SRCS:.c=.o)
 
 INCS_FLAGS += $(addprefix -I,$(INCLUDE_DIRS))
 
-CFLAGS	+=	-O2				\
-		-ffunction-sections		\
-		-fdata-sections			\
-		-DCORE0				\
-		-DNDEBUG			\
-		-D_RTE_				\
-		-D__ADUCM3029__			\
-		-D__SILICON_REVISION__=0xffff	\
-		-Wall				\
-		-c -mcpu=cortex-m3		\
-		-mthumb				\
-		$(INCS_FLAGS)		
-#		-Werror
+GENERIC_FLAGS = -c -DCORE0 -D_RTE_ -D__ADUCM3029__ -D__SILICON_REVISION__=0xffff -mcpu=cortex-m3 -mthumb \
+		$(INCS_FLAGS)
+
+GENERIC_DEBUG_FLAGS = -g -gdwarf-2 -D_DEBUG
+
+GENERIC_RELEASE_FLAGS = -DNDEBUG 
+C_RELEASE_FLAGS = -O2
+
+CFLAGS	+= $(GENERIC_FLAGS) -Wall -ffunction-sections -fdata-sections
+
+CFLAGS	+= $(GENERIC_RELEASE_FLAGS) $(C_RELEASE_FLAGS)
+
+#CFLAGS	+= $(GENERIC_DEBUG_FLAGS)
 
 LINKER_FILE	=$(PROJECT_BUILD)/RTE/Device/ADuCM3029/ADuCM3029.ld
 
@@ -348,7 +348,7 @@ $(BUILD_DIR)%/.:
 .SECONDEXPANSION:
 $(BUILD_DIR)/%.o: $$(call get_full_path, %).c | $$(@D)/.
 	@echo CC -c $(notdir $<) -o $(notdir $@)
-	@$(CC) -c $(CFLAGS) $< -o $@
+	@$(CC) $(CFLAGS) $< -o $@
 
 $(BINARY): $(LIB_TARGETS) $(OBJS)
 	@echo CC LDFLAGS OBJS INCS_FLAGS -o $(BINARY)

--- a/tools/scripts/aducm.mk
+++ b/tools/scripts/aducm.mk
@@ -23,7 +23,7 @@ ifeq ($(OS), Windows_NT)
 SHELL=cmd
 copy_fun = copy /Y /B "$(subst /,\,$1)" "$(subst /,\,$2)"
 copy_folder = xcopy /S /Y /C /I "$(subst /,\,$1)" "$(subst /,\,$2)"
-remove_fun = del /S /Q "$(subst /,\,$1)"
+remove_fun = del /S /Q $(subst /,\,$1)
 remove_dir = rd /S /Q "$(subst /,\,$1)"
 mk_dir = md "$(subst /,\,$1)"
 #cces works to but has no console output
@@ -169,13 +169,14 @@ endif
 #Executed only once if one of the libs needs update
 
 $(MBEDTLS_LIB_DIR)/libmbedcrypto.a:
+#Workaround for cleaning because mbedtls clean don't work on windows enviroment
+CLEAN_MBEDTLS	= $(call remove_fun,$(MBEDTLS_LIB_DIR)/*.o $(MBEDTLS_TARGETS))
 	$(MAKE) -C $(MBEDTLS_LIB_DIR)
 
 $(MBEDTLS_LIB_DIR)/libmbedx509.a: $(MBEDTLS_LIB_DIR)/libmbedcrypto.a
 
 $(MBEDTLS_LIB_DIR)/libmbedtls.a: $(MBEDTLS_LIB_DIR)/libmbedx509.a
 
-CLEAN_MBEDTLS	= $(MAKE) -C $(NO-OS)/libraries/mbedtls clean
 
 endif
 

--- a/tools/scripts/aducm.mk
+++ b/tools/scripts/aducm.mk
@@ -166,11 +166,13 @@ MBEDTLS_TARGETS	= $(addprefix $(MBEDTLS_LIB_DIR)/,$(MBEDTLS_LIB_NAMES))
 ifeq ($(wildcard $(MBEDTLS_PATH)/LICENSE),)
 MBED_TLS_INIT = git submodule update --init --remote -- $(MBEDTLS_PATH)
 endif
-#Executed only once if one of the libs needs update
 
-$(MBEDTLS_LIB_DIR)/libmbedcrypto.a:
 #Workaround for cleaning because mbedtls clean don't work on windows enviroment
 CLEAN_MBEDTLS	= $(call remove_fun,$(MBEDTLS_LIB_DIR)/*.o $(MBEDTLS_TARGETS))
+
+#Executed only once if one of the libs needs update
+$(MBEDTLS_LIB_DIR)/libmbedcrypto.a: $(MBED_TLS_CONFIG_FILE)
+	-$(CLEAN_MBEDTLS)
 	$(MAKE) -C $(MBEDTLS_LIB_DIR)
 
 $(MBEDTLS_LIB_DIR)/libmbedx509.a: $(MBEDTLS_LIB_DIR)/libmbedcrypto.a

--- a/tools/scripts/aducm.mk
+++ b/tools/scripts/aducm.mk
@@ -357,6 +357,9 @@ run: all
 		-s "$(ADUCM_DFP)/openocd/scripts" -f target/aducm3029.cfg \
 		-c "program  $(BINARY) verify reset exit"
 
+PHONY += libs
+libs: $(LIB_TARGETS)
+
 # Remove project binaries
 PHONY += clean
 clean:

--- a/tools/scripts/aducm.mk
+++ b/tools/scripts/aducm.mk
@@ -147,25 +147,29 @@ include src.mk
 #If network dir is included, mbedtls will be used
 ifneq ($(if $(findstring $(NO-OS)/network, $(SRC_DIRS)), 1),)
 
-MBEDTLS_LIB_NAMES = libmbedcrypto.a libmbedtls.a libmbedx509.a
-MBEDTLS_LIB_DIR = $(NO-OS)/libraries/mbedtls/library
+MBEDTLS_PATH		= $(NO-OS)/libraries/mbedtls
+MBEDTLS_LIB_DIR		= $(MBEDTLS_PATH)/library
+MBEDTLS_LIB_NAMES	= libmbedtls.a libmbedx509.a  libmbedcrypto.a
 
 LIBS_DIRS	+= "$(MBEDTLS_LIB_DIR)"
 LIBS		+= $(MBEDTLS_LIB_NAMES)
-INCLUDE_DIRS 	+= $(NO-OS)/libraries/mbedtls/include
+INCLUDE_DIRS 	+= $(MBEDTLS_PATH)/include
 
-CFLAGS 		+= -I $(NO-OS)/network/transport \
-			-DMBEDTLS_CONFIG_FILE=\"noos_mbedtls_config.h\"
+MBED_TLS_CONFIG_FILE = $(NO-OS)/network/noos_mbedtls_config.h
+
+#Add to CFAGS the config file name and the directory where it is located
+CFLAGS 		+= -I$(dir $(MBED_TLS_CONFIG_FILE)) \
+			-DMBEDTLS_CONFIG_FILE=\"$(notdir $(MBED_TLS_CONFIG_FILE))\"
 
 MBEDTLS_TARGETS	= $(addprefix $(MBEDTLS_LIB_DIR)/,$(MBEDTLS_LIB_NAMES))
 
-ifeq ($(wildcard $(NO-OS)/libraries/mbedtls/LICENSE),)
-MBED_TLS_INIT = git submodule update --init --remote -- $(NO-OS)/libraries/mbedtls
+ifeq ($(wildcard $(MBEDTLS_PATH)/LICENSE),)
+MBED_TLS_INIT = git submodule update --init --remote -- $(MBEDTLS_PATH)
 endif
 #Executed only once if one of the libs needs update
 
 $(MBEDTLS_LIB_DIR)/libmbedcrypto.a:
-	$(MAKE) -C $(NO-OS)/libraries/mbedtls lib
+	$(MAKE) -C $(MBEDTLS_LIB_DIR)
 
 $(MBEDTLS_LIB_DIR)/libmbedx509.a: $(MBEDTLS_LIB_DIR)/libmbedcrypto.a
 


### PR DESCRIPTION
- Initialize mqtt repository if not initialized
- Add libs rule
- use variables instead of duplicated paths
- fix CLEAN_MBEDTLS for windows
- Add noos_mbedtls_config.h as dependency for mbedtls
- Refactor CFLAGS
- Add reset_ADuCM3029.s in build