### PR TITLE
network: wifi move CONNECTION_BUFFER_SIZE to init_param

### DIFF
--- a/network/network_interface.h
+++ b/network/network_interface.h
@@ -91,7 +91,7 @@ struct network_interface {
 	 *  - \ref FAILURE : Otherwise
 	 */
 	int32_t (*socket_open)(void *net, uint32_t *sock_id,
-			       enum socket_protocol proto);
+			       enum socket_protocol proto, uint32_t buff_size);
 	/**
 	 * @brief Close the socket.
 	 * @param net - Network interface

--- a/network/tcp_socket.c
+++ b/network/tcp_socket.c
@@ -51,6 +51,23 @@
 #ifndef DISABLE_SECURE_SOCKET
 #include "mbedtls/ssl.h"
 #include "noos_mbedtls_config.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+#ifdef DISABLE_SECURE_SOCKET
+
+#define DEFAULT_CONNECTION_BUFFER_SIZE 500
+
+#else
+
+#ifdef MAX_CONTENT_LEN
+#define DEFAULT_CONNECTION_BUFFER_SIZE MAX_CONTENT_LEN
+#else
+#define DEFAULT_CONNECTION_BUFFER_SIZE 16384
+#endif /* MAX_CONTENT_LEN */
+
 #endif /* DISABLE_SECURE_SOCKET */
 
 /******************************************************************************/
@@ -251,6 +268,7 @@ int32_t socket_init(struct tcp_socket_desc **desc,
 {
 	struct tcp_socket_desc	*ldesc;
 	int32_t			ret;
+	uint32_t		buff_size;
 
 	if (!desc || !param)
 		return FAILURE;
@@ -261,8 +279,13 @@ int32_t socket_init(struct tcp_socket_desc **desc,
 
 	ldesc->net = param->net;
 
-	ret = ldesc->net->socket_open(ldesc->net->net, &ldesc->id,
-				      PROTOCOL_TCP);
+	if (param->max_buff_size != 0)
+		buff_size = param->max_buff_size;
+	else
+		buff_size = DEFAULT_CONNECTION_BUFFER_SIZE;
+
+	ret = ldesc->net->socket_open(ldesc->net->net, &ldesc->id, PROTOCOL_TCP,
+				      buff_size);
 	if (IS_ERR_VALUE(ret)) {
 		free(ldesc);
 		return ret;

--- a/network/tcp_socket.h
+++ b/network/tcp_socket.h
@@ -107,6 +107,12 @@ struct tcp_socket_init_param {
 	struct network_interface	*net;
 #ifndef DISABLE_SECURE_SOCKET
 	/**
+	 *  Max buffer size for incoming data.
+	 *  If set to 0, default value will be used (CONNECTION_BUFFER_SIZE)
+	 *  from tcp_socket.c
+	 */
+	uint32_t			max_buff_size;
+	/**
 	 * Reference to \ref secure_init_param if a TCP socket over TLS should
 	 * be used. NULL if just raw connection is needed.
 	 */

--- a/network/wifi/wifi.c
+++ b/network/wifi/wifi.c
@@ -49,12 +49,6 @@
 #include "util.h"
 
 /******************************************************************************/
-/********************** Macros and Constants Definitions **********************/
-/******************************************************************************/
-
-#define CONNECTION_BUFFER_SIZE 2500
-
-/******************************************************************************/
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
@@ -84,7 +78,7 @@ struct wifi_desc {
 
 
 static int32_t wifi_socket_open(struct wifi_desc *desc, uint32_t *sock_id,
-				enum socket_protocol proto);
+				enum socket_protocol proto, uint32_t buff_size);
 static int32_t wifi_socket_close(struct wifi_desc *desc, uint32_t sock_id);
 static int32_t wifi_socket_connect(struct wifi_desc *desc, uint32_t sock_id,
 				   struct socket_address *addr);
@@ -268,7 +262,7 @@ int32_t wifi_get_network_interface(struct wifi_desc *desc,
 
 /** @brief See \ref network_interface.socket_open */
 static int32_t wifi_socket_open(struct wifi_desc *desc, uint32_t *sock_id,
-				enum socket_protocol proto)
+				enum socket_protocol proto, uint32_t buff_size)
 {
 	uint32_t		i;
 	struct socket_desc	*sock;
@@ -286,12 +280,12 @@ static int32_t wifi_socket_open(struct wifi_desc *desc, uint32_t *sock_id,
 		return FAILURE; //All the available connections are used
 
 	sock->type = proto;
-	sock->buff = (uint8_t *)malloc(CONNECTION_BUFFER_SIZE);
+	sock->buff = (uint8_t *)malloc(buff_size);
 	if (!sock->buff)
 		return FAILURE;
 
 	*sock_id = i;
-	at_submit_buffer(desc->at, i, sock->buff, CONNECTION_BUFFER_SIZE);
+	at_submit_buffer(desc->at, i, sock->buff, buff_size);
 
 	return SUCCESS;
 }


### PR DESCRIPTION
This will allow the user to choos the buffer size for each socket.

Signed-off-by: Mihail Chindris <mihail.chindris@analog.com>