### PR TITLE
projects: iio: enable .dcache only for PS

### DIFF
--- a/projects/fmcadc2/src/app/fmcadc2.c
+++ b/projects/fmcadc2/src/app/fmcadc2.c
@@ -215,8 +215,10 @@ int main(void)
 		.rx_adc = ad9625_core,
 		.rx_dmac = ad9625_dmac,
 		.adc_ddr_base = ADC_DDR_BASEADDR,
+#ifndef PLATFORM_MB
 		.dcache_invalidate_range = (void (*)(uint32_t,
 						     uint32_t))Xil_DCacheInvalidateRange
+#endif
 	};
 
 	return iio_server_init(&iio_axi_adc_init_par);

--- a/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
+++ b/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
@@ -568,16 +568,20 @@ int main(void)
 		.rx_adc = ad9250_0_core,
 		.rx_dmac = ad9250_0_dmac,
 		.adc_ddr_base = ADC_0_DDR_BASEADDR,
+#ifndef PLATFORM_MB
 		.dcache_invalidate_range = (void (*)(uint32_t,
 						     uint32_t))Xil_DCacheInvalidateRange
+#endif
 	};
 	struct iio_axi_adc_init_param iio_axi_adc_1_init_par;
 	iio_axi_adc_1_init_par = (struct iio_axi_adc_init_param) {
 		.rx_adc = ad9250_1_core,
 		.rx_dmac = ad9250_1_dmac,
 		.adc_ddr_base = ADC_1_DDR_BASEADDR,
+#ifndef PLATFORM_MB
 		.dcache_invalidate_range = (void (*)(uint32_t,
 						     uint32_t))Xil_DCacheInvalidateRange
+#endif
 	};
 
 	return iio_server_init(&iio_axi_adc_0_init_par, &iio_axi_adc_1_init_par);


### PR DESCRIPTION
The `Xil_DCacheInvalidateRange` function is not valid for PL based
platforms.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>