### PR TITLE
make: Add defines into the xsdk iio project

### DIFF
--- a/projects/iio_demo/src.mk
+++ b/projects/iio_demo/src.mk
@@ -18,9 +18,7 @@ SRCS += $(PLATFORM_DRIVERS)/uart.c					\
 	$(NO-OS)/util/util.c						\
 	$(NO-OS)/iio/iio.c						\
 	$(NO-OS)/iio/iio_app/iio_app.c					\
-	$(NO-OS)/iio/iio_demo/iio_demo.c				\
-	$(NO-OS)/libraries/libtinyiiod/parser.c				\
-	$(NO-OS)/libraries/libtinyiiod/tinyiiod.c
+	$(NO-OS)/iio/iio_demo/iio_demo.c
 
 INCS += $(PROJECT)/src/app_config.h					\
 	$(PROJECT)/src/parameters.h
@@ -38,5 +36,4 @@ INCS += $(INCLUDE)/xml.h						\
 	$(NO-OS)/iio/iio_app/iio_app.h					\
 	$(NO-OS)/iio/iio_demo/iio_demo.h				\
 	$(NO-OS)/libraries/libtinyiiod/compat.h				\
-	$(NO-OS)/libraries/libtinyiiod/tinyiiod.h			\
-	$(NO-OS)/libraries/libtinyiiod/tinyiiod-private.h
+	$(NO-OS)/libraries/libtinyiiod/tinyiiod.h

--- a/tools/scripts/linux.mk
+++ b/tools/scripts/linux.mk
@@ -91,9 +91,15 @@ CFLAGS = -Wall 								\
 	 -lm						
 	#-Werror
 
+LIB_TINYIIOD_PATH = ""
+LIB_TINYIIOD = ""
+TINYIIOD_STD_TYPES = ""
 ifeq (y,$(strip $(TINYIIOD)))
 CFLAGS += -D IIO_SUPPORT
-CFLAGS += -D _USE_STD_INT_TYPES
+LIB_TINYIIOD_PATH = $(LIBRARIES)/libtinyiiod/build
+LIB_TINYIIOD = tinyiiod
+TINYIIOD_STD_TYPES = _USE_STD_INT_TYPES
+CFLAGS += -D $(TINYIIOD_STD_TYPES)
 endif
 
 ifeq (y,$(strip $(MBEDTLS)))
@@ -392,7 +398,7 @@ ifeq (y,$(strip $(MBEDTLS)))
 	@$(MAKE) -C $(LIBRARIES)/mbedtls lib
 endif
 ifeq (y,$(strip $(TINYIIOD)))
-LIBS += -L $(LIBRARIES)/libtinyiiod/build -ltinyiiod
+LIBS += -L $(LIB_TINYIIOD_PATH) -l$(LIB_TINYIIOD)
 endif
 ifeq (y,$(strip $(MBEDTLS)))
 LIBS += -L $(LIBRARIES)/mbedtls/library -lmbedtls -lmbedx509 -lmbedcrypto
@@ -443,7 +449,9 @@ xilinx-bsp:
 	@ if [ ! -d "$(BUILD_DIR)/bsp" ];then				\
 	$(call print,Building hardware specification and bsp \n);	\
 	xsdk -batch -source $(SCRIPTS_PATH)/create_project.tcl		\
-		$(SDK_WORKSPACE) $(HARDWARE) $(ARCH) $(NULL);		\
+		$(SDK_WORKSPACE) $(HARDWARE) $(ARCH) 			\
+		$(LIB_TINYIIOD_PATH) $(LIB_TINYIIOD)			\
+		$(TINYIIOD_STD_TYPES) $(NULL);				\
 	fi;
 # Update the linker script the heap size for microlbaze from 0x800 to 
 # 0x100000 

--- a/tools/scripts/platform/xilinx/create_project.tcl
+++ b/tools/scripts/platform/xilinx/create_project.tcl
@@ -1,4 +1,4 @@
-if { $argc != 3 } {
+if { $argc != 6 } {
 	puts "create_project: Invalid arguments"
 	exit
 }
@@ -11,6 +11,11 @@ sdk createbsp -name bsp -hwproject hw -proc [lindex $argv 2] -os standalone
 # Create app
 sdk createapp -name app -hwproject hw -proc [lindex $argv 2] -os standalone \
 	-lang C -app {Empty Application} -bsp bsp
+
+sdk configapp -app app library-search-path [lindex $argv 3]
+sdk configapp -app app libraries [lindex $argv 4]
+sdk configapp -app app define-compiler-symbols [lindex $argv 5]
+
 # Build the project via SDK
 clean -type all
 build -type all


### PR DESCRIPTION
This will be used to extract variable values and define them into the sdk
project, allowing us to create a functional iio sdk project.

This commit has to be approved first: 
https://github.com/analogdevicesinc/libtinyiiod/pull/27
