### PR TITLE
ad9172: remove PLATFORM_MB from project

### DIFF
--- a/projects/ad9172/src/main.c
+++ b/projects/ad9172/src/main.c
@@ -64,11 +64,7 @@
 int main(void)
 {
 	struct xil_spi_init_param xil_spi_param = {
-#ifdef PLATFORM_MB
-		.type = SPI_PL,
-#else
 		.type = SPI_PS,
-#endif
 		.device_id = SPI_DEVICE_ID,
 		.flags = 0
 	};
@@ -138,11 +134,7 @@ int main(void)
 	};
 
 	struct xil_gpio_init_param xilinx_gpio_init_param = {
-#ifdef PLATFORM_MB
-		.type = GPIO_PL,
-#else
 		.type = GPIO_PS,
-#endif
 		.device_id = GPIO_DEVICE_ID
 	};
 	struct ad9172_init_param ad9172_param = {


### PR DESCRIPTION
The Microblaze platforms are not supported by the HDL for this specific
project.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>