### PR TITLE
platform: xilinx: gpio: fix error handling

### DIFF
--- a/drivers/platform/xilinx/gpio.c
+++ b/drivers/platform/xilinx/gpio.c
@@ -101,8 +101,6 @@ int32_t _gpio_init(struct gpio_desc *desc,
 		break;
 pl_error:
 		free(xdesc->instance);
-
-		break;
 #endif
 		goto error;
 	case GPIO_PS:


### PR DESCRIPTION
For the PL GPIO scenario, if an error occurs at initialization, the
memory is freed but the return code will be SUCCESS, since the switch
case statement will break.

This patch makes sure that if an error occurs, the code will jump to
the default case and return the FAILURE error code.

Fixes #659.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>