### PR TITLE
tools:scripts:platform:xilinx: update windows script

### DIFF
--- a/tools/scripts/platform/xilinx/environment.bat
+++ b/tools/scripts/platform/xilinx/environment.bat
@@ -1,9 +1,0 @@
-setx /m PATH ^"^
-%1\Vivado\%2\bin;^
-%1\Vivado\%2\msys64\usr\bin;^
-%1\SDK\%2\bin;^
-%1\SDK\%2\gnuwin\bin;^
-%1\SDK\%2\gnu\microblaze\nt\bin;^
-%1\SDK\%2\gnu\aarch32\nt\gcc-arm-none-eabi\bin;^
-%1\SDK\%2\gnu\aarch64\nt\aarch64-none\bin;^
-%PATH%"

--- a/tools/scripts/platform/xilinx/environment.ps1
+++ b/tools/scripts/platform/xilinx/environment.ps1
@@ -1,0 +1,20 @@
+﻿$env_pth = $env:Path.Split(";")
+$arg1 = $args[0]
+$arg2 = $args[1]
+$new_pth = "$arg1\Vivado\$arg2\bin","$arg1\Vivado\$arg2\msys64\usr\bin","$arg1\SDK\$arg2\bin","$arg1\SDK\$arg2\gnuwin\bin","$arg1\SDK\$arg2\gnu\microblaze\nt\bin","$arg1\SDK\$arg2\gnu\aarch32\nt\gcc-arm-none-eabi\bin","$arg1\SDK\$arg2\gnu\aarch64\nt\aarch64-none\bin"
+$acc = $env:Path
+
+foreach ($a in $new_pth){
+  foreach ($b in $env_pth){
+  if ($a -eq $b) {
+    $exist = 1
+    break
+  }
+  $exist = 0
+  }
+  if ($exist -eq 0) {
+    $acc = $a + ";" + $acc
+  }
+}
+
+setx PATH $acc


### PR DESCRIPTION
Update windows script to not create duplicates PATH environment variables
and only affect the variable locally to avoid permanently corrupting it.
The way to use it is the same, only the extension has been changed.

Signed-off-by: Andrei Drimbarean <Andrei.Drimbarean@analog.com>