### PR TITLE
daq2 & daq3 iio: perform irq_ctrl_init first

### DIFF
--- a/projects/fmcdaq2/src/app/app_iio.c
+++ b/projects/fmcdaq2/src/app/app_iio.c
@@ -99,7 +99,6 @@ int32_t iio_server_init(struct iio_axi_adc_init_param *adc_init,
 #else
 		.type = UART_PS,
 		.irq_id = UART_IRQ_ID,
-		.irq_desc = irq_desc,
 #endif
 	};
 	struct uart_init_param uart_init_par = {
@@ -132,6 +131,8 @@ int32_t iio_server_init(struct iio_axi_adc_init_param *adc_init,
 	status = irq_ctrl_init(&irq_desc, &irq_init_param);
 	if (IS_ERR_VALUE(status))
 		return FAILURE;
+
+	xil_uart_init_par.irq_desc = irq_desc;
 #endif
 
 	status = uart_init(&uart_desc, &uart_init_par);

--- a/projects/fmcdaq3/src/app/app_iio.c
+++ b/projects/fmcdaq3/src/app/app_iio.c
@@ -99,7 +99,6 @@ int32_t iio_server_init(struct iio_axi_adc_init_param *adc_init,
 #else
 		.type = UART_PS,
 		.irq_id = UART_IRQ_ID,
-		.irq_desc = irq_desc,
 #endif
 	};
 	struct uart_init_param uart_init_par = {
@@ -132,6 +131,8 @@ int32_t iio_server_init(struct iio_axi_adc_init_param *adc_init,
 	status = irq_ctrl_init(&irq_desc, &irq_init_param);
 	if (IS_ERR_VALUE(status))
 		return FAILURE;
+
+	xil_uart_init_par.irq_desc = irq_desc;
 #endif
 
 	status = uart_init(&uart_desc, &uart_init_par);


### PR DESCRIPTION
Initialize the IRQ interrupts before any other iio related operation.

This patch fixes the IIO osc occasional hanging for PS platforms.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>