### PR TITLE
ad9656: add reference project for the ad9656 eval board

### DIFF
--- a/projects/ad9656_fmc/Makefile
+++ b/projects/ad9656_fmc/Makefile
@@ -1,0 +1,6 @@
+TARGET := ad9656_fmc
+ifeq ($(OS), Windows_NT)
+include ../../tools/scripts/windows.mk
+else
+include ../../tools/scripts/linux.mk
+endif

--- a/projects/ad9656_fmc/src.mk
+++ b/projects/ad9656_fmc/src.mk
@@ -1,0 +1,45 @@
+################################################################################
+#									       #
+#     Shared variables:							       #
+#	- PROJECT							       #
+#	- DRIVERS							       #
+#	- INCLUDE							       #
+#	- PLATFORM_DRIVERS						       #
+#	- NO-OS								       #
+#									       #
+################################################################################
+
+# Uncomment to select the profile
+
+SRCS := $(PROJECT)/src/app/ad9656_fmc.c                                 \
+	$(PROJECT)/src/app/ad9508.c   					\
+	$(PROJECT)/src/app/ad9508.h					\
+	$(PROJECT)/src/app/ad9553.c					\
+	$(PROJECT)/src/app/ad9553.h
+SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
+        $(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
+        $(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c		\
+        $(DRIVERS)/axi_core/jesd204/axi_adxcvr.c			\
+        $(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c			\
+        $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
+        $(DRIVERS)/adc/ad9656/ad9656.c					\
+        $(DRIVERS)/spi/spi.c						\
+        $(NO-OS)/util/util.c
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
+        $(PLATFORM_DRIVERS)/xilinx_spi.c				\
+        $(PLATFORM_DRIVERS)/delay.c
+INCS :=	$(PROJECT)/src/app/app_config.h					\
+        $(PROJECT)/src/devices/adi_hal/parameters.h
+INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h			\
+        $(DRIVERS)/axi_core/axi_dmac/axi_dmac.h				\
+        $(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h		\
+        $(DRIVERS)/axi_core/jesd204/axi_adxcvr.h			\
+        $(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h			\
+        $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h		\
+        $(DRIVERS)/adc/ad9656/ad9656.h
+INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h
+INCS +=	$(INCLUDE)/axi_io.h						\
+        $(INCLUDE)/spi.h						\
+        $(INCLUDE)/error.h						\
+        $(INCLUDE)/delay.h						\
+        $(INCLUDE)/util.h

--- a/projects/ad9656_fmc/src/README
+++ b/projects/ad9656_fmc/src/README
@@ -1,0 +1,29 @@
+
+# Additional required source files:
+
+cp ../../../include/axi_io.h devices/adi_hal/
+cp ../../../include/error.h devices/adi_hal/
+cp ../../../include/spi.h devices/adi_hal/
+cp ../../../include/delay.h devices/adi_hal/
+cp ../../../drivers/spi/spi.c devices/adi_hal/
+cp ../../../drivers/adc/ad9656/ad9656.h devices/adi_hal/
+cp ../../../drivers/adc/ad9656/ad9656.c devices/adi_hal/
+cp ../../../drivers/platform/xilinx/axi_io.c devices/adi_hal/
+cp ../../../drivers/platform/xilinx/xilinx_spi.c devices/adi_hal/
+cp ../../../drivers/platform/xilinx/spi_extra.h devices/adi_hal/
+cp ../../../drivers/platform/xilinx/delay.c devices/adi_hal/
+cp ../../../drivers/axi_core/axi_adc_core/axi_adc_core.c devices/adi_hal/
+cp ../../../drivers/axi_core/axi_adc_core/axi_adc_core.h devices/adi_hal/
+cp ../../../drivers/axi_core/axi_dmac/axi_dmac.c devices/adi_hal/
+cp ../../../drivers/axi_core/axi_dmac/axi_dmac.h devices/adi_hal/
+cp ../../../drivers/axi_core/clk_axi_clkgen/clk_axi_clkgen.c devices/adi_hal/
+cp ../../../drivers/axi_core/clk_axi_clkgen/clk_axi_clkgen.h devices/adi_hal/
+cp ../../../drivers/axi_core/jesd204/axi_adxcvr.c devices/adi_hal/
+cp ../../../drivers/axi_core/jesd204/axi_adxcvr.h devices/adi_hal/
+cp ../../../drivers/axi_core/jesd204/axi_jesd204_rx.c devices/adi_hal/
+cp ../../../drivers/axi_core/jesd204/axi_jesd204_rx.h devices/adi_hal/
+cp ../../../drivers/axi_core/jesd204/xilinx_transceiver.c devices/adi_hal/
+cp ../../../drivers/axi_core/jesd204/xilinx_transceiver.h devices/adi_hal/
+cp ../../../util/util.c devices/adi_hal/
+cp ../../../include/util.h devices/adi_hal/
+

--- a/projects/ad9656_fmc/src/app/ad9508.c
+++ b/projects/ad9656_fmc/src/app/ad9508.c
@@ -1,0 +1,198 @@
+/***************************************************************************//**
+ * @file ad9508.c
+ * @brief Implementation of AD9508 Driver.
+ * @author DHotolea (dan.hotoleanu@analog.com)
+ ********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in
+ * the documentation and/or other materials provided with the
+ * distribution.
+ * - Neither the name of Analog Devices, Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ * - The use of this software may or may not infringe the patent rights
+ * of one or more patent holders. This license does not release you
+ * from the requirement that you obtain separate licenses from these
+ * patent holders to use this software.
+ * - Use of the software either in source or binary form, must be run
+ * on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "error.h"
+#include "ad9508.h"
+#include "delay.h"
+
+/**
+ * @brief Reads from the ad9508 that is contected to the SPI
+ * @param dev - The ad9508 device handler
+ * @param reg_addr - The address of the internal register of the ad9508 chip
+ * @param reg_data - The value read from the internal register
+ * @return SUCCESS if the value was successfully read, FAILURE otherwise
+ */
+int32_t ad9508_reg_read(struct ad9508_dev *dev,
+			uint16_t reg_addr,
+			uint8_t *reg_data)
+{
+	uint8_t buf[3];
+	int32_t ret;
+
+	/*
+	* the MSB of byte 0 indicates a r/w operation, following 7 bits are the
+	* bits 14-8 of the address of the register that is accessed. Byte 1
+	* contains the bits 7-0 of the address of the register.
+	*/
+	buf[0] = 0x80 | (reg_addr >> 8);
+	buf[1] = reg_addr & 0xFF;
+	buf[2] = 0x00;
+
+	ret = spi_write_and_read(dev->spi_desc, buf, 3);
+	if (ret < 0)
+		return ret;
+
+	*reg_data = buf[2];
+
+	return ret;
+}
+
+/**
+ * @brief Write to the ad9508 that is conected to the SPI
+ * @param dev - The device handler for the ad9508 chip
+ * @param reg_addr - Address of the internal register of the ad9508 chip
+ * @param reg_data - Value to be written to the register
+ * @return SUCCESS if the value was written successfully, FAILURE otherwise
+ */
+int32_t ad9508_reg_write(struct ad9508_dev *dev,
+			 uint16_t reg_addr,
+			 uint8_t reg_data)
+{
+	uint8_t buf[3];
+
+	/*
+	 * the MSB of byte 0 indicates a r/w operation, following 7 bits are the
+	 * bits 14-8 of the address of the register that is accessed. Byte 1
+	 * contains the bits 7-0 of the address of the register. Byte 2 contains
+	 * the data to be written.
+	 */
+	buf[0] = reg_addr >> 8;
+	buf[1] = reg_addr & 0xFF;
+	buf[2] = reg_data;
+
+	return spi_write_and_read(dev->spi_desc, buf, 3);
+}
+
+/**
+ * @brief Setup the working parameters of the ad9508 chip
+ * @param device - The device handler of the ad9508 chip
+ * @param init_param - Values for the working parameters of ad9508
+ * @return SUCCESS if device is ready for use, FAILURE otherwise
+ */
+int32_t ad9508_setup(struct ad9508_dev **device,
+		     const struct ad9508_init_param *init_param)
+{
+	int32_t ret;
+
+	struct ad9508_dev *dev;
+	uint8_t reg_data;
+
+	dev = (struct ad9508_dev *)malloc(sizeof(*dev));
+	if (!dev)
+		return FAILURE;
+
+	/* SPI */
+	ret = spi_init(&dev->spi_desc, &init_param->spi_init);
+	if (ret != SUCCESS)
+		return ret;
+
+	/* reset */
+	ret = ad9508_reg_write(dev, AD9508_SPI_CONFIG, 0x24);
+	if (ret != SUCCESS)
+		return ret;
+
+	mdelay(250);
+
+	/*
+	 * read family part id: 0x0C contains the least significant byte,
+	 *                      0x0D contains the most significant byte
+	 */
+	ret = ad9508_reg_read(dev, AD9508_PART_ID_LOW, &reg_data);
+	if (ret != SUCCESS)
+		return ret;
+
+	if (reg_data != (AD9508_PART_ID_VALUE & 0xFF))
+		return FAILURE;
+	ret = ad9508_reg_read(dev, AD9508_PART_ID_HIGH, &reg_data);
+	if (ret != SUCCESS)
+		return ret;
+
+	if (reg_data != (AD9508_PART_ID_VALUE >> 8))
+		return FAILURE;
+
+	/*
+	 * configure 9508 to pass the 125MHz input clock unmodified, so divider = 1
+	 * no phase offset
+	 */
+	ret = ad9508_reg_write(dev, AD9508_OUT1_DIV_RATIO_LOW,
+			       AD9508_DIVIDE_RATIO_ONE); /* divide ratio[7:0] */
+	if (ret != SUCCESS)
+		return ret;
+
+	ret = ad9508_reg_write(dev, AD9508_OUT1_DIV_RATIO_HIGH,
+			       AD9508_DIVIDE_RATIO_ONE); /* divide ratio[9:8] */
+	if (ret != SUCCESS)
+		return ret;
+
+	ret = ad9508_reg_write(dev, AD9508_OUT1_PHASE_LOW,
+			       AD9508_DIVIDE_RATIO_ONE); /* phase offset[7:0] */
+	if (ret != SUCCESS)
+		return ret;
+
+	ret = ad9508_reg_write(dev, AD9508_OUT1_PHASE_HIGH,
+			       AD9508_DIVIDE_RATIO_ONE); /* phase offset[10:8] */
+	if (ret != SUCCESS)
+		return ret;
+
+	return SUCCESS;
+}
+
+/**
+ * @brief Free the resources allocated by ad9508_setup().
+ * @param dev - The device structure.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad9508_remove(struct ad9508_dev *dev)
+{
+	int32_t ret;
+
+	ret = spi_remove(dev->spi_desc);
+	if (ret != SUCCESS)
+		return ret;
+
+	free(dev);
+
+	return ret;
+}

--- a/projects/ad9656_fmc/src/app/ad9508.h
+++ b/projects/ad9656_fmc/src/app/ad9508.h
@@ -1,0 +1,90 @@
+/***************************************************************************//**
+ * @file ad9508.h
+ * @brief Header file of AD9508 Driver.
+ * @author DHotolea (dan.hotoleanu@analog.com)
+ ********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in
+ * the documentation and/or other materials provided with the
+ * distribution.
+ * - Neither the name of Analog Devices, Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ * - The use of this software may or may not infringe the patent rights
+ * of one or more patent holders. This license does not release you
+ * from the requirement that you obtain separate licenses from these
+ * patent holders to use this software.
+ * - Use of the software either in source or binary form, must be run
+ * on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#ifndef AD9508_H_
+#define AD9508_H_
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "spi.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+#define AD9508_SPI_CONFIG				    0x000
+#define AD9508_PART_ID_LOW				    0x00C
+#define AD9508_PART_ID_HIGH				    0x00D
+#define AD9508_OUT1_DIV_RATIO_LOW			    0x01B
+#define AD9508_OUT1_DIV_RATIO_HIGH			    0x01C
+#define AD9508_OUT1_PHASE_LOW			   	    0x01D
+#define AD9508_OUT1_PHASE_HIGH			   	    0x01E
+#define AD9508_PART_ID_VALUE			   	    0x005
+#define AD9508_DIVIDE_RATIO_ONE			   	    0x000
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+
+struct ad9508_init_param {
+	/* SPI */
+	struct spi_init_param	spi_init;
+};
+
+struct ad9508_dev {
+	/* SPI */
+	struct spi_desc	*spi_desc;
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+int32_t ad9508_reg_read(struct ad9508_dev *dev, uint16_t reg_addr,
+			uint8_t *reg_data);
+
+int32_t ad9508_reg_write(struct ad9508_dev *dev, uint16_t reg_addr,
+			 uint8_t reg_data);
+
+int32_t ad9508_setup(struct ad9508_dev **device,
+		     const struct ad9508_init_param *init_param);
+
+int32_t ad9508_remove(struct ad9508_dev *dev);
+
+#endif

--- a/projects/ad9656_fmc/src/app/ad9553.c
+++ b/projects/ad9656_fmc/src/app/ad9553.c
@@ -1,0 +1,244 @@
+/***************************************************************************//**
+ * @file ad9553.c
+ * @brief Implementation of AD9553 Driver.
+ * @author DHotolea (dan.hotoleanu@analog.com)
+ ********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in
+ * the documentation and/or other materials provided with the
+ * distribution.
+ * - Neither the name of Analog Devices, Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ * - The use of this software may or may not infringe the patent rights
+ * of one or more patent holders. This license does not release you
+ * from the requirement that you obtain separate licenses from these
+ * patent holders to use this software.
+ * - Use of the software either in source or binary form, must be run
+ * on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "error.h"
+#include "ad9553.h"
+#include "delay.h"
+
+/**
+ * @brief Reads from the ad9553 that is contected to the SPI
+ * @param dev - The ad9553 device handler
+ * @param reg_addr - The address of the internal register of the ad9553 chip
+ * @param reg_data - The value read from the internal register
+ * @return SUCCESS if the value was successfully read, FAILURE otherwise
+ */
+int32_t ad9553_reg_read(struct ad9553_dev *dev,
+			uint16_t reg_addr,
+			uint8_t *reg_data)
+{
+	uint8_t buf[3];
+
+	int32_t ret;
+
+	// the MSB of byte 0 indicates a r/w operation, following 7 bits are the
+	// bits 14-8 of the address of the register that is accessed. Byte 1
+	// contains the bits 7-0 of the address of the register.
+	buf[0] = 0x80 | (reg_addr >> 8);
+	buf[1] = reg_addr & 0xFF;
+	buf[2] = 0x00;
+
+	ret = spi_write_and_read(dev->spi_desc, buf, 3);
+	if (ret < 0)
+		return ret;
+
+	*reg_data = buf[2];
+
+	return ret;
+}
+
+/**
+ * @brief Write to the ad9553 that is conected to the SPI
+ * @param dev - The device handler for the ad9553 chip
+ * @param reg_addr - Address of the internal register of the ad9553 chip
+ * @param reg_data - Value to be written to the register
+ * @return SUCCESS if the value was written successfully, FAILURE otherwise
+ */
+int32_t ad9553_reg_write(struct ad9553_dev *dev,
+			 uint16_t reg_addr,
+			 uint8_t reg_data)
+{
+	uint8_t buf[3];
+
+	// the MSB of byte 0 indicates a r/w operation, following 7 bits are the
+	// bits 14-8 of the address of the register that is accessed. Byte 1
+	// contains the bits 7-0 of the address of the register. Byte 2 contains
+	// the data to be written.
+	buf[0] = reg_addr >> 8;
+	buf[1] = reg_addr & 0xFF;
+	buf[2] = reg_data;
+
+	return spi_write_and_read(dev->spi_desc, buf, 3);
+}
+
+/**
+ * @brief Setup the working parameters of the ad9553 chip
+ * @param device - The device handler of the ad9553 chip
+ * @param init_param - Values for the working parameters of ad9553
+ * @return SUCCESS if device is ready for use, FAILURE otherwise
+ */
+int32_t ad9553_setup(struct ad9553_dev **device,
+		     const struct ad9553_init_param *init_param)
+{
+	int32_t ret;
+
+	struct ad9553_dev *dev;
+
+	dev = (struct ad9553_dev *)malloc(sizeof(*dev));
+	if (!dev)
+		return FAILURE;
+
+	/* SPI */
+	ret = spi_init(&dev->spi_desc, &init_param->spi_init);
+	if (ret != SUCCESS)
+		return ret;
+
+	// reset
+	ret = ad9553_reg_write(dev, AD9553_SPI_CONFIG, 0x3C);
+	if (ret != SUCCESS)
+		return ret;
+
+	mdelay(250);
+
+	// enable SPI control of charge pump
+	ret = ad9553_reg_write(dev, AD9553_PLL_CHARGE_PUMP_PFD_CTRL, 0xB0);
+	if (ret != SUCCESS)
+		return ret;
+
+	// lock detector activated
+	ret = ad9553_reg_write(dev, AD9553_PLL_CTRL, 0x00);
+	if (ret != SUCCESS)
+		return ret;
+
+	// P1 = 4
+	// P1[9:2]
+	ret = ad9553_reg_write(dev, AD9553_P1_DIV_HIGH, 0x01);
+	if (ret != SUCCESS)
+		return ret;
+
+	// P1[1:0], P2[9:4]
+	ret = ad9553_reg_write(dev, AD9553_P1_DIV_LOW_P2_DIV_HIGH, 0x00);
+	if (ret != SUCCESS)
+		return ret;
+
+	// P2[3:0]
+	ret = ad9553_reg_write(dev, AD9553_P2_DIV_LOW, 0x00);
+	if (ret != SUCCESS)
+		return ret;
+
+	// P0 = 7
+	ret = ad9553_reg_write(dev, AD9553_P0_DIV, 0x60);
+	if (ret != SUCCESS)
+		return ret;
+
+	// N = 700
+	// N[19:12]
+	ret = ad9553_reg_write(dev, AD9553_N_DIV_HIGH, 0x00);
+	if (ret != SUCCESS)
+		return ret;
+
+	// N[11:4]
+	ret = ad9553_reg_write(dev, AD9553_N_DIV_MEDIUM, 0x2B);
+	if (ret != SUCCESS)
+		return ret;
+
+	// N[3:0], take the N value from the feedback divide register,
+	// take the output divider values from the registers, reset
+	// counters and logic of the PLL
+	ret = ad9553_reg_write(dev, AD9553_N_DIV_LOW, 0xCC);
+	if (ret != SUCCESS)
+		return ret;
+
+	mdelay(250);
+
+	// RefA = 10
+	// RefA[13:6] divider
+	ret = ad9553_reg_write(dev, AD9553_REFA_DIV_HIGH, 0x00);
+	if (ret != SUCCESS)
+		return ret;
+
+	// RefA[5:0], use the value stored in RefA register for RefA divider value
+	ret = ad9553_reg_write(dev, AD9553_REFA_DIV_LOW, 0x2A);
+	if (ret != SUCCESS)
+		return ret;
+
+	// k = 2/5
+	// enable SPI control for x2 for RefA, select x2 for RefA,
+	// enable SPI control for :5 for RefA, select :5 for RefA
+	ret = ad9553_reg_write(dev, AD9553_K_VALUE, 0xF0);
+	if (ret != SUCCESS)
+		return ret;
+
+	// RefA is configured as a differential input so RefDiff = 1
+	ret = ad9553_reg_write(dev, AD9553_REFA_DIFF, 0xA0);
+	if (ret != SUCCESS)
+		return ret;
+
+	// Out1 drive strength diven by SPI configuration, Out1 driver mode
+	// selection LVDS , the rest of the settings for this register
+	// remain default
+	ret = ad9553_reg_write(dev, AD9553_OUT1_DRIVER_CTRL, 0xA1);
+	if (ret != SUCCESS)
+		return ret;
+
+	// Out2 powered down
+	ret = ad9553_reg_write(dev, AD9553_OUT2_DRIVER_CTRL, 0xE8);
+	if (ret != SUCCESS)
+		return ret;
+
+	// update contents of the registers with the new values
+	ret = ad9553_reg_write(dev, AD9553_IO_UPDATE, 0x01);
+	if (ret != SUCCESS)
+		return ret;
+
+	return SUCCESS;
+}
+
+/**
+ * @brief Free the resources allocated by ad9553_setup().
+ * @param dev - The device structure.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad9553_remove(struct ad9553_dev *dev)
+{
+	int32_t ret;
+
+	ret = spi_remove(dev->spi_desc);
+	if (ret != SUCCESS)
+		return ret;
+
+	free(dev);
+
+	return ret;
+}

--- a/projects/ad9656_fmc/src/app/ad9553.h
+++ b/projects/ad9656_fmc/src/app/ad9553.h
@@ -1,0 +1,98 @@
+/***************************************************************************//**
+ * @file ad9553.h
+ * @brief Header file of AD9553 Driver.
+ * @author DHotolea (dan.hotoleanu@analog.com)
+ ********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in
+ * the documentation and/or other materials provided with the
+ * distribution.
+ * - Neither the name of Analog Devices, Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ * - The use of this software may or may not infringe the patent rights
+ * of one or more patent holders. This license does not release you
+ * from the requirement that you obtain separate licenses from these
+ * patent holders to use this software.
+ * - Use of the software either in source or binary form, must be run
+ * on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#ifndef AD9553_H_
+#define AD9553_H_
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "spi.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+#define AD9553_SPI_CONFIG				        0x000
+#define AD9553_PLL_CHARGE_PUMP_PFD_CTRL	        		0x00B
+#define AD9553_PLL_CTRL	        				0x00D
+#define AD9553_P1_DIV_HIGH     					0x015
+#define AD9553_P1_DIV_LOW_P2_DIV_HIGH   			0x016
+#define AD9553_P2_DIV_LOW				   	0x017
+#define AD9553_P0_DIV					   	0x018
+#define AD9553_N_DIV_HIGH				   	0x012
+#define AD9553_N_DIV_MEDIUM				   	0x013
+#define AD9553_N_DIV_LOW				   	0x014
+#define AD9553_REFA_DIV_HIGH				   	0x01F
+#define AD9553_REFA_DIV_LOW					0x020
+#define AD9553_K_VALUE					   	0x021
+#define AD9553_REFA_DIFF				   	0x029
+#define AD9553_OUT1_DRIVER_CTRL			   		0x032
+#define AD9553_OUT2_DRIVER_CTRL			   		0x034
+#define AD9553_IO_UPDATE				   	0x005
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+
+struct ad9553_init_param {
+	/* SPI */
+	struct spi_init_param	spi_init;
+};
+
+struct ad9553_dev {
+	/* SPI */
+	struct spi_desc	*spi_desc;
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+int32_t ad9553_reg_read(struct ad9553_dev *dev, uint16_t reg_addr,
+			uint8_t *reg_data);
+
+int32_t ad9553_reg_write(struct ad9553_dev *dev, uint16_t reg_addr,
+			 uint8_t reg_data);
+
+int32_t ad9553_setup(struct ad9553_dev **device,
+		     const struct ad9553_init_param *init_param);
+
+int32_t ad9553_remove(struct ad9553_dev *dev);
+
+#endif

--- a/projects/ad9656_fmc/src/app/ad9656_fmc.c
+++ b/projects/ad9656_fmc/src/app/ad9656_fmc.c
@@ -1,0 +1,268 @@
+/***************************************************************************//**
+ *   @file   ad9656_fmc.c
+ *   @brief  Implementation of Main Function.
+ *   @author DHotolea (dan.hotoleanu@analog.com)
+ *******************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "ad9656.h"
+#include "ad9508.h"
+#include "ad9553.h"
+#include "axi_adc_core.h"
+#include "axi_dmac.h"
+#include "axi_adxcvr.h"
+#include "axi_jesd204_rx.h"
+#include "spi_extra.h"
+#include "parameters.h"
+#include "error.h"
+#include "delay.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+#define DMA_BUFFER		 0
+
+/***************************************************************************//**
+ * @brief main
+ ******************************************************************************/
+int main(void)
+{
+	int32_t status;
+
+	/* Initialize SPI structures */
+	struct spi_init_param ad9508_spi_param = {
+		.max_speed_hz = 2000000u,
+		.chip_select = 1,
+		.mode = SPI_MODE_0
+	};
+
+	struct spi_init_param ad9553_spi_param = {
+		.max_speed_hz = 2000000u,
+		.chip_select = 2,
+		.mode = SPI_MODE_0
+	};
+	struct spi_init_param ad9656_spi_param = {
+		.max_speed_hz = 2000000u,
+		.chip_select = 0,
+		.mode = SPI_MODE_0
+	};
+
+	struct xil_spi_init_param xil_spi_param = {
+		.type = SPI_PS,
+		.device_id = SPI_DEVICE_ID
+	};
+
+	/* this pattern is outputed by the ad9656 chip after the JESD204 test is finished */
+	struct ad9656_user_input_test_pattern user_input_test_pattern = {
+		.user_test_pattern1 = 0xA1B2,
+		.user_test_pattern2 = 0xC3D4
+	};
+
+	ad9508_spi_param.platform_ops = &xil_platform_ops;
+	ad9508_spi_param.extra = &xil_spi_param;
+	ad9553_spi_param.platform_ops = &xil_platform_ops;
+	ad9553_spi_param.extra = &xil_spi_param;
+	ad9656_spi_param.platform_ops = &xil_platform_ops;
+	ad9656_spi_param.extra = &xil_spi_param;
+
+	struct ad9508_init_param	ad9508_param;
+	struct ad9553_init_param	ad9553_param;
+	struct ad9656_init_param	ad9656_param;
+
+	ad9508_param.spi_init = ad9508_spi_param;
+	ad9553_param.spi_init = ad9553_spi_param;
+	ad9656_param.spi_init = ad9656_spi_param;
+
+	struct ad9508_dev *ad9508_device;
+	struct ad9553_dev *ad9553_device;
+	struct ad9656_dev *ad9656_device;
+
+//******************************************************************************
+// setup the base addresses
+//******************************************************************************
+
+	struct adxcvr_init ad9656_xcvr_param = {
+		.name = "ad9656_xcvr",
+		.base = XPAR_AXI_AD9656_RX_XCVR_BASEADDR,
+		.sys_clk_sel = 0,
+		.out_clk_sel = 4,
+		.lpm_enable = 1,
+		.cpll_enable = 1,
+		.ref_rate_khz = 125000,
+		.lane_rate_khz = 2500000
+	};
+
+//******************************************************************************
+// ADC (AD9656) and the receive path ( AXI_ADXCVR,
+//	JESD204, AXI_AD9656, RX DMAC) configuration
+//******************************************************************************
+
+	/* JESD initialization */
+	struct jesd204_rx_init  ad9656_jesd_param = {
+		.name = "ad9656_jesd",
+		.base = RX_JESD_BASEADDR,
+		.octets_per_frame = 2,
+		.frames_per_multiframe = 32,
+		.subclass = 1,
+		.device_clk_khz = 2500000/40,
+		.lane_clk_khz = 2500000
+	};
+
+	struct axi_jesd204_rx *ad9656_jesd;
+
+	/* ADC Core */
+	struct axi_adc_init ad9656_core_param = {
+		.name = "ad9656_adc",
+		.base = RX_CORE_BASEADDR,
+		.num_channels = 4
+	};
+	struct axi_adc	*ad9656_core;
+	struct adxcvr	*ad9656_xcvr;
+
+//******************************************************************************
+// configure the receiver DMA
+//******************************************************************************
+
+	struct axi_dmac_init ad9656_dmac_param = {
+		.name = "ad9656_dmac",
+		.base = RX_DMA_BASEADDR,
+		.direction = DMA_DEV_TO_MEM,
+		.flags = 0
+	};
+	struct axi_dmac *ad9656_dmac;
+
+//******************************************************************************
+// bring up the system
+//******************************************************************************
+
+	ad9656_param.lane_rate_kbps = 2500000;
+
+	// setup clocks
+	if (ad9508_setup(&ad9508_device, &ad9508_param) != SUCCESS)
+		printf("The ad9508 chip could not be setup correctly!\n");
+	else
+		printf("The ad9508 chip successfully configured\n");
+
+	if (ad9553_setup(&ad9553_device, &ad9553_param) != SUCCESS)
+		printf("The ad9553 chip could not be setup!\n");
+	else
+		printf("The ad9553 chip successfully configured\n");
+
+	// ADC
+	if (ad9656_setup(&ad9656_device, &ad9656_param) != SUCCESS)
+		printf("The ad9656 chip could not be setup correctly!\n");
+	else
+		printf("The ad9656 chip successfully configured\n");
+
+	if (adxcvr_init(&ad9656_xcvr, &ad9656_xcvr_param) != SUCCESS) {
+		printf("error: %s: adxcvr_init() failed\n", ad9656_xcvr->name);
+	}
+
+	if (adxcvr_clk_enable(ad9656_xcvr) != SUCCESS) {
+		printf("error: %s: adxcvr_clk_enable() failed\n", ad9656_xcvr->name);
+	}
+
+	if (axi_jesd204_rx_init(&ad9656_jesd, &ad9656_jesd_param) != SUCCESS) {
+		printf("error: %s: axi_jesd204_rx_init() failed\n", ad9656_jesd->name);
+	}
+
+	if (axi_jesd204_rx_lane_clk_enable(ad9656_jesd) != SUCCESS) {
+		printf("error: %s: axi_jesd204_tx_lane_clk_enable() failed\n",
+		       ad9656_jesd->name);
+	}
+
+	status = axi_jesd204_rx_status_read(ad9656_jesd);
+	if (status != SUCCESS) {
+		printf("axi_jesd204_rx_status_read() error: %d\n", status);
+	}
+
+	if (axi_adc_init(&ad9656_core,  &ad9656_core_param) != SUCCESS) {
+		printf("axi_adc_init() error: %s\n", ad9656_core->name);
+	}
+
+//******************************************************************************
+// receive path testing
+//******************************************************************************
+
+	/* receive path testing */
+	ad9656_JESD204_test(ad9656_device, AD9656_TEST_PN9);
+	if(axi_adc_pn_mon(ad9656_core, AXI_ADC_PN9, 10) == -1) {
+		printf("%s ad9656 - PN9 sequence mismatch!\n", __func__);
+	} else {
+		printf("%s ad9656 - PN9 sequence checked!\n", __func__);
+	}
+	ad9656_JESD204_test(ad9656_device, AD9656_TEST_PN23);
+	if(axi_adc_pn_mon(ad9656_core, AXI_ADC_PN23A, 10) == -1) {
+		printf("%s ad9656 - PN23 sequence mismatch!\n", __func__);
+	} else {
+		printf("%s ad9656 - PN23 sequence checked!\n", __func__);
+	}
+
+	ad9656_JESD204_test(ad9656_device, AD9656_TEST_OFF);
+
+//******************************************************************************
+// generate user input in place of real ADC data and capture data with DMA
+//******************************************************************************
+
+	/* start sending user input test pattern */
+	if (ad9656_user_input_test(ad9656_device, AD9656_TEST_USER_INPUT,
+				   user_input_test_pattern) == -1) {
+		printf("Could not start the user input test sequence!\n");
+	} else {
+		printf("User input test sequence started!\n");
+	}
+
+	/* Initialize the DMAC and transfer 16384 samples from ADC to MEM */
+	axi_dmac_init(&ad9656_dmac, &ad9656_dmac_param);
+	axi_dmac_transfer(ad9656_dmac, ADC_DDR_BASEADDR, 16384 * 4);
+
+	ad9656_user_input_test(ad9656_device, AD9656_TEST_OFF, user_input_test_pattern);
+
+	printf("ad9656: setup, configuration and test program is done\n");
+
+	/* Memory deallocation for devices and spi */
+	ad9508_remove(ad9508_device);
+	ad9553_remove(ad9553_device);
+	ad9656_remove(ad9656_device);
+
+	return(0);
+}

--- a/projects/ad9656_fmc/src/app/app_config.h
+++ b/projects/ad9656_fmc/src/app/app_config.h
@@ -1,0 +1,43 @@
+/***************************************************************************//**
+ *   @file   projects/ad9656_fmc/src/app/app_config.h
+ *   @brief  Config file for AD9656 project.
+ *   @author DHotolea (dan.hotoleanu@analog.com)
+********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef APP_CONFIG_H_
+#define APP_CONFIG_H_
+
+#endif /* APP_CONFIG_H_ */

--- a/projects/ad9656_fmc/src/devices/adi_hal/parameters.h
+++ b/projects/ad9656_fmc/src/devices/adi_hal/parameters.h
@@ -1,0 +1,54 @@
+/***************************************************************************//**
+ *   @file   parameters.h
+ *   @brief  Platform dependent parameters.
+ *   @author DHotolea (dan.hotoleanu@analog.com)
+********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef _PARAMETERS_H_
+#define _PARAMETERS_H_
+
+#include "xparameters.h"
+
+#define SPI_DEVICE_ID				XPAR_XSPIPS_0_DEVICE_ID
+
+#define ADC_DDR_BASEADDR			(XPAR_DDR_MEM_BASEADDR + 0x800000)
+
+#define RX_CORE_BASEADDR			XPAR_RX_AD9656_TPL_CORE_TPL_CORE_BASEADDR
+#define RX_DMA_BASEADDR				XPAR_AXI_AD9656_RX_DMA_BASEADDR
+#define RX_JESD_BASEADDR			XPAR_AXI_AD9656_RX_JESD_RX_AXI_BASEADDR
+#define RX_XCVR_BASEADDR			XPAR_AXI_AD9656_XCVR_BASEADDR
+
+#endif /* _PARAMETERS_H_ */


### PR DESCRIPTION
Added new reference project for ad9656 eval board coupled with the zcu102 carrier.

Signed-off-by: Dan Hotoleanu <dan.hotoleanu@analog.com>