### PR TITLE
ad9361_api: remove redundant spi mem alloc

### DIFF
--- a/projects/ad9361/src/ad9361_api.c
+++ b/projects/ad9361/src/ad9361_api.c
@@ -90,10 +90,6 @@ int32_t ad9361_init (struct ad9361_rf_phy **ad9361_phy,
 		return -ENOMEM;
 	}
 
-	phy->spi = zmalloc(sizeof(*phy->spi));
-	if (!phy->spi) {
-		return -ENOMEM;
-	}
 	phy->spi = init_param->spi;
 	phy->gpio_desc_device_id = init_param->gpio_desc_device_id;
 	phy->gpio_desc_resetb = init_param->gpio_desc_resetb;
@@ -563,7 +559,6 @@ int32_t ad9361_init (struct ad9361_rf_phy **ad9361_phy,
 	return 0;
 
 out:
-	free(phy->spi);
 #ifndef AXI_ADC_NOT_PRESENT
 	free(phy->adc_conv);
 	free(phy->adc_state);


### PR DESCRIPTION
Memory allocation for spi descriptor is already done in the main function
when `spi_init(default_init_param.spi, &spi_param)` function is called.

Solves #665.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>