### PR TITLE
projects: ad9361: fix EXT_LO comparison

### DIFF
--- a/projects/ad9361/src/ad9361_api.c
+++ b/projects/ad9361/src/ad9361_api.c
@@ -870,7 +870,7 @@ int32_t ad9361_get_rx_lo_freq (struct ad9361_rf_phy *phy,
  */
 int32_t ad9361_set_rx_lo_int_ext(struct ad9361_rf_phy *phy, uint8_t int_ext)
 {
-	if ((phy->dev_sel == ID_AD9363A) && (int_ext = EXT_LO)) {
+	if ((phy->dev_sel == ID_AD9363A) && (int_ext == EXT_LO)) {
 		printf("%s : EXT_LO is not supported by AD9363!\n", __func__);
 		return -1;
 	}
@@ -1510,7 +1510,7 @@ int32_t ad9361_get_tx_lo_freq (struct ad9361_rf_phy *phy,
  */
 int32_t ad9361_set_tx_lo_int_ext(struct ad9361_rf_phy *phy, uint8_t int_ext)
 {
-	if ((phy->dev_sel == ID_AD9363A) && (int_ext = EXT_LO)) {
+	if ((phy->dev_sel == ID_AD9363A) && (int_ext == EXT_LO)) {
 		printf("%s : EXT_LO is not supported by AD9363!\n", __func__);
 		return -1;
 	}


### PR DESCRIPTION
Use comparison operator instead of assignment operator when checking the
selected LO.

Fixes: #680

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>