### PR TITLE
add crc16

### DIFF
--- a/include/crc16.h
+++ b/include/crc16.h
@@ -1,6 +1,6 @@
 /***************************************************************************//**
- *   @file   crc.h
- *   @brief  Generic header file for all CRC computation algorithms.
+ *   @file   crc16.h
+ *   @brief  Header file of CRC-16 computation.
  *   @author Darius Berghe (darius.berghe@analog.com)
 ********************************************************************************
  * Copyright 2020(c) Analog Devices, Inc.
@@ -36,10 +36,19 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
-#ifndef __CRC_H
-#define __CRC_H
+#ifndef __CRC16_H
+#define __CRC16_H
 
-#include "crc8.h"
-#include "crc16.h"
+#include <stdint.h>
+#include <stddef.h>
 
-#endif // __CRC_H
+#define CRC16_TABLE_SIZE 256
+
+#define DECLARE_CRC16_TABLE(_table) \
+	static uint16_t _table[CRC16_TABLE_SIZE]
+
+void crc16_populate_msb(uint16_t * table, const uint16_t polynomial);
+uint16_t crc16(const uint16_t * table, const uint8_t *pdata, size_t nbytes,
+	       uint16_t crc);
+
+#endif // __CRC16_H

--- a/util/crc16.c
+++ b/util/crc16.c
@@ -1,6 +1,6 @@
 /***************************************************************************//**
- *   @file   crc.h
- *   @brief  Generic header file for all CRC computation algorithms.
+ *   @file   crc16.c
+ *   @brief  Source file of CRC-16 computation.
  *   @author Darius Berghe (darius.berghe@analog.com)
 ********************************************************************************
  * Copyright 2020(c) Analog Devices, Inc.
@@ -36,10 +36,67 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
-#ifndef __CRC_H
-#define __CRC_H
-
-#include "crc8.h"
 #include "crc16.h"
 
-#endif // __CRC_H
+/***************************************************************************//**
+ * @brief Creates the CRC-16 lookup table for a given polynomial.
+ *
+ * @param table      - Pointer to a CRC-16 lookup table to write to.
+ * @param polynomial - msb-first representation of desired polynomial.
+ *
+ * Polynomials in CRC algorithms are typically represented as shown below.
+ *
+ *    poly = x^16 + x^14 + x^13 + x^12 + x^10 + x^8 + x^6 + x^4 + x^3 +
+ *           x^1 + 1
+ *
+ * Using msb-first direction, x^15 maps to the msb.
+ *
+ *    msb first: poly = (1)0111010101011011 = 0x755B
+ *                         ^
+ *
+ * @return None.
+*******************************************************************************/
+void crc16_populate_msb(uint16_t * table, const uint16_t polynomial)
+{
+	if (!table)
+		return;
+
+	for (int16_t n = 0; n < CRC16_TABLE_SIZE; n++) {
+		uint16_t currByte = (uint16_t)(n << 8);
+		for (uint8_t bit = 0; bit < 8; bit++) {
+			if ((currByte & 0x8000) != 0) {
+				currByte <<= 1;
+				currByte ^= polynomial;
+			} else {
+				currByte <<= 1;
+			}
+		}
+		table[n] = currByte;
+	}
+}
+
+/***************************************************************************//**
+ * @brief Computes the CRC-16 over a buffer of data.
+ *
+ * @param table     - Pointer to a CRC-16 lookup table for the desired polynomial.
+ * @param pdata     - Pointer to data buffer.
+ * @param nbytes    - Number of bytes to compute the CRC-16 over.
+ * @param crc       - Initial value for the CRC-16 computation. Can be used to
+ *                    cascade calls to this function by providing a previous
+ *                    output of this function as the crc parameter.
+ *
+ * @return crc      - Computed CRC-16 value.
+*******************************************************************************/
+uint16_t crc16(const uint16_t * table, const uint8_t *pdata, size_t nbytes,
+	       uint16_t crc)
+{
+	unsigned int idx;
+
+	while (nbytes--) {
+		idx = ((crc >> 8) ^ *pdata) & 0xff;
+		crc = (table[idx] ^ (crc << 8)) & 0xffff;
+		pdata++;
+	}
+
+	return crc;
+}


### PR DESCRIPTION
This adds a lookup table based crc16 to no-OS. Table is generated at runtime
via crc16_populate_msb based on desired polynomial. Then, the table is used as
input to the crc16() function that computes the actual CRC. CRC computation can
be conveniently broken into multiple crc16() calls by providing results from
previous calls to the crc parameter of the function.

Signed-off-by: Darius Berghe <darius.berghe@analog.com>

Tested and compared against: http://www.sunshine2k.de/coding/javascript/crc/crc_js.html