### PR TITLE
projects: ad9208: add iio support

### DIFF
--- a/projects/ad9208/Makefile
+++ b/projects/ad9208/Makefile
@@ -1,4 +1,5 @@
 TARGET := ad9208
+TINYIIOD ?= n
 ifeq ($(OS), Windows_NT)
 include ../../tools/scripts/windows.mk
 else

--- a/projects/ad9208/src.mk
+++ b/projects/ad9208/src.mk
@@ -10,6 +10,9 @@
 ################################################################################
 
 SRCS := $(PROJECT)/src/main.c
+ifeq (y,$(strip $(TINYIIOD)))
+SRCS += $(PROJECT)/src/app_iio.c
+endif
 SRCS += $(DRIVERS)/spi/spi.c						\
 	$(DRIVERS)/frequency/hmc7044/hmc7044.c				\
 	$(DRIVERS)/adc/ad9208/ad9208.c 					\
@@ -30,7 +33,19 @@ SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
 	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
 	$(PLATFORM_DRIVERS)/gpio.c					\
 	$(PLATFORM_DRIVERS)/delay.c
+ifeq (y,$(strip $(TINYIIOD)))
+SRCS += $(NO-OS)/util/xml.c						\
+	$(NO-OS)/util/fifo.c						\
+	$(NO-OS)/iio/iio.c						\
+	$(NO-OS)/iio/iio_app/iio_app.c					\
+	$(NO-OS)/iio/iio_axi_adc/iio_axi_adc.c				\
+	$(PLATFORM_DRIVERS)/uart.c					\
+	$(PLATFORM_DRIVERS)/irq.c
+endif
 INCS := $(PROJECT)/src/parameters.h
+ifeq (y,$(strip $(TINYIIOD)))
+INCS +=	$(PROJECT)/src/app_iio.h
+endif
 INCS += $(DRIVERS)/frequency/hmc7044/hmc7044.h				\
 	$(DRIVERS)/adc/ad9208/ad9208.h					\
 	$(DRIVERS)/adc/ad9208/ad9208_api/ad9208_api.h			\
@@ -52,3 +67,17 @@ INCS +=	$(INCLUDE)/axi_io.h						\
 	$(INCLUDE)/error.h						\
 	$(INCLUDE)/delay.h						\
 	$(INCLUDE)/util.h
+ifeq (y,$(strip $(TINYIIOD)))
+INCS += $(INCLUDE)/xml.h						\
+	$(INCLUDE)/fifo.h						\
+	$(INCLUDE)/irq.h						\
+	$(INCLUDE)/uart.h						\
+	$(PLATFORM_DRIVERS)/irq_extra.h					\
+	$(PLATFORM_DRIVERS)/uart_extra.h                                \
+	$(NO-OS)/iio/iio.h						\
+	$(NO-OS)/iio/iio_types.h					\
+	$(NO-OS)/iio/iio_app/iio_app.h					\
+	$(NO-OS)/iio/iio_axi_adc/iio_axi_adc.h				\
+	$(NO-OS)/libraries/libtinyiiod/tinyiiod.h			\
+	$(NO-OS)/libraries/libtinyiiod/compat.h
+endif

--- a/projects/ad9208/src/app_iio.c
+++ b/projects/ad9208/src/app_iio.c
@@ -1,0 +1,126 @@
+/***************************************************************************//**
+ *   @file   app_iio.c
+ *   @brief  Application IIO setup.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include "error.h"
+#include "uart.h"
+#include "uart_extra.h"
+#include "iio_app.h"
+#include "parameters.h"
+#include "app_iio.h"
+
+/******************************************************************************/
+/************************ Variables Definitions *******************************/
+/******************************************************************************/
+static struct uart_desc *uart_desc;
+
+/******************************************************************************/
+/************************** Functions Implementation **************************/
+/******************************************************************************/
+
+/**
+ * iio_server_write() - Write data to UART.
+ * @buf - Data to be written.
+ * @len - Number of bytes to be written.
+ * @Return: SUCCESS in case of success, FAILURE otherwise.
+ */
+static ssize_t iio_server_write(const char *buf, size_t len)
+{
+	return uart_write(uart_desc, (const uint8_t *)buf, len);
+}
+
+/**
+ * iio_server_read() - Read data from UART.
+ * @buf - Storing data location.
+ * @len - Number of bytes to be read.
+ * @Return: SUCCESS in case of success, FAILURE otherwise.
+ */
+static ssize_t iio_server_read(char *buf, size_t len)
+{
+	return uart_read(uart_desc, (uint8_t *)buf, len);
+}
+
+/**
+ * @brief Application IIO setup.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t iio_server_init(struct iio_axi_adc_init_param *adc_0_init,
+			struct iio_axi_adc_init_param *adc_1_init)
+{
+	struct xil_uart_init_param xil_uart_init_par = {
+		.type = UART_PL,
+	};
+	struct uart_init_param uart_init_par = {
+		.baud_rate = 115200,
+		.device_id = UART_DEVICE_ID,
+		.extra = &xil_uart_init_par,
+	};
+	struct iio_server_ops uart_iio_server_ops = {
+		.read = iio_server_read,
+		.write = iio_server_write,
+	};
+	struct iio_app_init_param iio_app_init_par = {
+		.iio_server_ops = &uart_iio_server_ops,
+	};
+	struct iio_app_desc *iio_app_desc;
+	struct iio_axi_adc_desc *iio_axi_adc_0_desc;
+	struct iio_axi_adc_desc *iio_axi_adc_1_desc;
+	int32_t status;
+
+	status = uart_init(&uart_desc, &uart_init_par);
+	if (IS_ERR_VALUE(status))
+		return FAILURE;
+
+	status = iio_app_init(&iio_app_desc, &iio_app_init_par);
+	if (IS_ERR_VALUE(status))
+		return FAILURE;
+
+	status = iio_axi_adc_init(&iio_axi_adc_0_desc, adc_0_init);
+	if (IS_ERR_VALUE(status))
+		return FAILURE;
+
+	status = iio_axi_adc_init(&iio_axi_adc_1_desc, adc_1_init);
+	if (IS_ERR_VALUE(status))
+		return FAILURE;
+
+	return iio_app(iio_app_desc);
+}

--- a/projects/ad9208/src/app_iio.h
+++ b/projects/ad9208/src/app_iio.h
@@ -1,9 +1,9 @@
 /***************************************************************************//**
- *   @file   ad9208/src/parameters.h
- *   @brief  Parameters Definitions.
- *   @author Stefan Popa (stefan.popa@analog.com)
+ *   @file   app_iio.h
+ *   @brief  Application IIO setup.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
 ********************************************************************************
- * Copyright 2019(c) Analog Devices, Inc.
+ * Copyright 2020(c) Analog Devices, Inc.
  *
  * All rights reserved.
  *
@@ -36,34 +36,21 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
-#ifndef __PARAMETERS_H__
-#define __PARAMETERS_H__
+#ifndef APP_IIO_H_
+#define APP_IIO_H_
 
 /******************************************************************************/
 /***************************** Include Files **********************************/
 /******************************************************************************/
-#include <xparameters.h>
+#include <stdint.h>
+#include "iio_axi_adc.h"
 
-#define SPI_HMC7044_CS		0x00
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
 
-#define SPI_0_DEVICE_ID		XPAR_SPI_0_DEVICE_ID
-#define SPI_AD9208_0_CS		0x01
-#define RX_0_JESD_BASEADDR 	XPAR_AXI_AD9208_0_JESD_RX_AXI_BASEADDR
-#define RX_0_XCVR_BASEADDR 	XPAR_AXI_AD9208_0_XCVR_BASEADDR
-#define RX_0_CORE_BASEADDR	XPAR_RX_AD9208_0_TPL_CORE_TPL_CORE_BASEADDR
+/* @brief Application IIO setup. */
+int32_t iio_server_init(struct iio_axi_adc_init_param *adc_0_init,
+			struct iio_axi_adc_init_param *adc_1_init);
 
-#define SPI_DEVICE_ID		XPAR_AXI_SPI_DEVICE_ID
-#define SPI_AD9208_CS		0x02
-
-#define GPIO_DEVICE_ID		XPAR_GPIO_0_DEVICE_ID
-
-#define UART_DEVICE_ID          XPAR_AXI_UART_DEVICE_ID
-
-#define RX_1_JESD_BASEADDR 	XPAR_AXI_AD9208_1_JESD_RX_AXI_BASEADDR
-#define RX_1_XCVR_BASEADDR 	XPAR_AXI_AD9208_1_XCVR_BASEADDR
-#define RX_1_CORE_BASEADDR	XPAR_RX_AD9208_1_TPL_CORE_TPL_CORE_BASEADDR
-
-#define RX_DMA_BASEADDR		XPAR_AXI_AD9208_DMA_BASEADDR
-#define DDR_MEM_BASEADDR	XPAR_AXI_DDR_CNTRL_BASEADDR
-
-#endif /* __PARAMETERS_H__ */
+#endif

--- a/projects/ad9208/src/main.c
+++ b/projects/ad9208/src/main.c
@@ -61,6 +61,10 @@
 #include "gpio.h"
 #include "gpio_extra.h"
 
+#ifdef IIO_SUPPORT
+#include "app_iio.h"
+#endif
+
 int main(void)
 {
 	struct xil_spi_init_param xil_spi_param = {
@@ -487,6 +491,26 @@ int main(void)
 				   DDR_MEM_BASEADDR + 0x800000, 16384 * size);
 	if (status != SUCCESS)
 		xil_printf("axi_dmac_transfer() error: %"PRIi32"\n", status);
+
+#ifdef IIO_SUPPORT
+	printf("The board accepts libiio clients connections through the serial backend.\n");
+
+	struct iio_axi_adc_init_param iio_axi_adc_0_init_par;
+	iio_axi_adc_0_init_par = (struct iio_axi_adc_init_param) {
+		.rx_adc = rx_0_adc,
+		.rx_dmac = rx_dmac,
+		.adc_ddr_base = DDR_MEM_BASEADDR + 0x800000,
+	};
+	struct iio_axi_adc_init_param iio_axi_adc_1_init_par;
+	iio_axi_adc_1_init_par = (struct iio_axi_adc_init_param) {
+		.rx_adc = rx_1_adc,
+		.rx_dmac = rx_dmac,
+		.adc_ddr_base = DDR_MEM_BASEADDR + 0x800000,
+	};
+
+	return iio_server_init(&iio_axi_adc_0_init_par, &iio_axi_adc_1_init_par);
+
+#endif
 
 error_11:
 	axi_adc_remove(rx_1_adc);


### PR DESCRIPTION
Add IIO support for ad9208 project.

Allow the user to read/write via UART using IIO oscilloscope app.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>