### PR TITLE
drivers: dac: ad5755: Remove delay when changing range

### DIFF
--- a/drivers/dac/ad5755/ad5755.c
+++ b/drivers/dac/ad5755/ad5755.c
@@ -523,7 +523,6 @@ void ad5755_set_channel_range(struct ad5755_dev *dev,
 				  AD5755_DREG_WR_DAC,
 				  channel,
 				  output_code);
-	mdelay(200);
 	/* Enable the output of the channel. */
 	new_dac_ctrl_reg |= AD5755_DAC_OUTEN;
 	ad5755_set_control_registers(dev,


### PR DESCRIPTION
The 200 msec delay is not required when changing the channel range. This
commit removes it from the code.

This change has been tested on EVAL-AD575xSDZ board with AD5755-1.

Signed-off-by: Mircea Caprioru <mircea.caprioru@analog.com>