### PR TITLE
includes:error.h: Include <errno.h>

### DIFF
--- a/include/error.h
+++ b/include/error.h
@@ -40,6 +40,8 @@
 #ifndef ERROR_H_
 #define ERROR_H_
 
+#include <errno.h>
+
 /******************************************************************************/
 /********************** Macros and Constants Definitions **********************/
 /******************************************************************************/
@@ -52,8 +54,5 @@
 #endif
 
 #define IS_ERR_VALUE(x)	((x) < 0)
-
-#define	EAGAIN		11
-#define EINVAL          22
 
 #endif // ERROR_H_


### PR DESCRIPTION
EAGAIN and EINVAlL are inside errno.h and other error codes that can be used.
This way we don't need to redefine each error code.

Signed-off-by: Mihail Chindris <mihail.chindris@analog.com>