### PR TITLE
iio:iio_app: Revert changes to fix build

### DIFF
--- a/iio/iio_app/iio_app.c
+++ b/iio/iio_app/iio_app.c
@@ -56,13 +56,13 @@
 int32_t iio_app_init(struct iio_app_desc **desc,
 		     struct iio_app_init_param *param)
 {
-	struct iio_desc *iio;
+	struct tinyiiod *iiod;
 	int32_t status;
 
 	if (!param)
 		return FAILURE;
 
-	status = iio_init(&iio, param->iio_server_ops);
+	status = iio_init(&iiod, param->iio_server_ops);
 	if(status < 0)
 		return status;
 
@@ -70,7 +70,7 @@ int32_t iio_app_init(struct iio_app_desc **desc,
 	if (!(*desc))
 		return FAILURE;
 
-	(*desc)->iio = iio;
+	(*desc)->iiod = iiod;
 
 	return SUCCESS;
 }
@@ -87,7 +87,7 @@ int32_t iio_app_remove(struct iio_app_desc *desc)
 	if (!desc)
 		return FAILURE;
 
-	status = iio_remove(desc->iio);
+	status = iio_remove(desc->iiod);
 	if(status < 0)
 		return status;
 
@@ -106,7 +106,7 @@ int32_t iio_app(struct iio_app_desc *desc)
 	int32_t status;
 
 	while(1) {
-		status = iio_step(desc->iio);
+		status = tinyiiod_read_command(desc->iiod);
 		if(status < 0)
 			return status;
 	}

--- a/iio/iio_app/iio_app.h
+++ b/iio/iio_app/iio_app.h
@@ -58,7 +58,7 @@ struct iio_app_desc {
 	/** read./write function callbacks */
 	struct iio_server_ops *iio_server_ops;
 	/** iiod handle */
-	struct iio_desc		*iio;
+	struct tinyiiod *iiod;
 };
 
 /**


### PR DESCRIPTION
During new libraries/iio modification iio_app shouldn't have been modified
in order to keep functional current iio_projects. These file were changed in
https://github.com/analogdevicesinc/no-OS/commit/64c0b509a70e093961e8cdd95dcfb81a38db2b03
and these changes are now reverted back to fix projects build.

Signed-off-by: Mihail Chindris <mihail.chindris@analog.com>