### PR TITLE
iio_demo: add direct_reg_access attribute

### DIFF
--- a/iio/iio_demo/demo_dev.c
+++ b/iio/iio_demo/demo_dev.c
@@ -53,6 +53,60 @@
 /************************ Functions Definitions *******************************/
 /******************************************************************************/
 
+/* Read a device register. The register address to read is set on
+ * in desc->active_reg_addr in the function set_demo_reg_attr
+ */
+ssize_t get_demo_reg_attr(void *device, char *buf, size_t len,
+			  const struct iio_ch_info *channel)
+{
+	struct iio_demo_desc	*desc = device;
+	uint32_t		value;
+
+	value = desc->dummy_regs[desc->active_reg_addr];
+
+	return snprintf(buf, len, "%"PRIu32"", value);
+}
+
+/* Flow of reading and writing registers. This is how iio works for
+ * direct_reg_access attribute:
+ * Read register:
+ * 	   //Reg_addr in decimal
+ * 	   reg_addr = "10";
+ * 	1. set_demo_reg_attr(dev, reg_addr, len, channel);
+ * 	2. get_demo_reg_attr(dev, out_buf, out_len, channel);
+ * Write register:
+ * 	   sprintf(write_buf, "0x%x 0x%x", reg_addr, value);
+ * 	1. set_demo_reg_attr(dev, write_buf, len, channel);
+ */
+ssize_t set_demo_reg_attr(void *device, char *buf, size_t len,
+			  const struct iio_ch_info *channel)
+{
+	struct iio_demo_desc	*desc = device;
+	uint32_t		nb_filled;
+	uint32_t		addr;
+	uint32_t		value;
+
+	nb_filled = sscanf(buf, "0x%x 0x%x", &addr, &value);
+	if (nb_filled == 2) {
+		/* Write register */
+		if (addr >= MAX_REG_ADDR)
+			return -EINVAL;
+		desc->dummy_regs[addr] = value;
+	} else {
+		nb_filled = sscanf(buf, "%u", &addr);
+		if (nb_filled == 1) {
+			if (addr >= MAX_REG_ADDR)
+				return -EINVAL;
+			desc->active_reg_addr = addr;
+			return len;
+		} else {
+			return -EINVAL;
+		}
+	}
+
+	return len;
+}
+
 /**
  * @brief get_demo_channel_attr().
  * @param device- Physical instance of a iio_demo_device.

--- a/iio/iio_demo/demo_dev.h
+++ b/iio/iio_demo/demo_dev.h
@@ -53,12 +53,17 @@
 /******************************************************************************/
 
 #define DEMO_NUM_CHANNELS	4
+#define MAX_REG_ADDR		10
 
 /**
  * @struct iio_demo_desc
  * @brief Desciptor.
  */
 struct iio_demo_desc {
+	/** Dummy registers of device for testing direct_reg_access attribute */
+	uint32_t dummy_regs[MAX_REG_ADDR];
+	/** Active reg	 */
+	uint32_t active_reg_addr;
 	/** Demo global device attribute */
 	uint32_t dev_global_attr;
 	/** Demo device channel attribute */
@@ -96,6 +101,12 @@ ssize_t get_demo_global_attr(void *device, char *buf, size_t len,
 			     const struct iio_ch_info *channel);
 ssize_t set_demo_global_attr(void *device, char *buf, size_t len,
 			     const struct iio_ch_info *channel);
+
+ssize_t get_demo_reg_attr(void *device, char *buf, size_t len,
+			  const struct iio_ch_info *channel);
+ssize_t set_demo_reg_attr(void *device, char *buf, size_t len,
+			  const struct iio_ch_info *channel);
+
 ssize_t iio_demo_transfer_mem_to_dev(void *iio_inst,
 				     size_t bytes_count,
 				     uint32_t ch_mask);

--- a/iio/iio_demo/iio_demo_dev.h
+++ b/iio/iio_demo/iio_demo_dev.h
@@ -103,11 +103,22 @@ static struct iio_attribute *iio_demo_global_attributes[] = {
 	NULL,
 };
 
+static struct iio_attribute iio_attr_debug = {
+	.name = "direct_reg_access",
+	.show = get_demo_reg_attr,
+	.store = set_demo_reg_attr,
+};
+
+static struct iio_attribute *iio_demo_debug_attributes[] = {
+	&iio_attr_debug,
+	NULL,
+};
+
 static struct iio_device iio_demo_dev_in_descriptor = {
 	.num_ch = DEMO_NUM_CHANNELS,
 	.channels = iio_demo_channels_in,
 	.attributes = iio_demo_global_attributes,
-	.debug_attributes = NULL,
+	.debug_attributes = iio_demo_debug_attributes,
 	.buffer_attributes = NULL,
 	.transfer_dev_to_mem = iio_demo_transfer_dev_to_mem,
 	.transfer_mem_to_dev = iio_demo_transfer_mem_to_dev,
@@ -115,12 +126,11 @@ static struct iio_device iio_demo_dev_in_descriptor = {
 	.write_data = iio_demo_write_dev
 };
 
-
 static struct iio_device iio_demo_dev_out_descriptor = {
 	.num_ch = DEMO_NUM_CHANNELS,
 	.channels = iio_demo_channels_out,
 	.attributes = iio_demo_global_attributes,
-	.debug_attributes = NULL,
+	.debug_attributes = iio_demo_debug_attributes,
 	.buffer_attributes = NULL,
 	.transfer_dev_to_mem = iio_demo_transfer_dev_to_mem,
 	.transfer_mem_to_dev = iio_demo_transfer_mem_to_dev,

--- a/libraries/iio/iio.c
+++ b/libraries/iio/iio.c
@@ -339,6 +339,7 @@ static ssize_t iio_read_attr(const char *device_id, const char *attr, char *buf,
 {
 	struct iio_interface	*dev;
 	struct attr_fun_params	params;
+	struct iio_attribute	**attributes;
 
 	dev = iio_get_interface(device_id);
 	if (!dev)
@@ -348,13 +349,15 @@ static ssize_t iio_read_attr(const char *device_id, const char *attr, char *buf,
 	params.len = len;
 	params.dev_instance = dev->dev_instance;
 	params.ch_info = NULL;
-	if (!strcmp(attr, ""))
-		return iio_read_all_attr(&params,
-					 dev->dev_descriptor->attributes);
+	if (debug)
+		attributes = dev->dev_descriptor->debug_attributes;
 	else
-		return iio_rd_wr_attribute(&params,
-					   dev->dev_descriptor->attributes,
-					   attr, 0);
+		attributes = dev->dev_descriptor->attributes;
+
+	if (!strcmp(attr, ""))
+		return iio_read_all_attr(&params, attributes);
+	else
+		return iio_rd_wr_attribute(&params,attributes, attr, 0);
 }
 
 /**
@@ -372,6 +375,7 @@ static ssize_t iio_write_attr(const char *device_id, const char *attr,
 {
 	struct iio_interface	*dev;
 	struct attr_fun_params	params;
+	struct iio_attribute	**attributes;
 
 	dev = iio_get_interface(device_id);
 	if (!dev)
@@ -381,13 +385,15 @@ static ssize_t iio_write_attr(const char *device_id, const char *attr,
 	params.len = len;
 	params.dev_instance = dev->dev_instance;
 	params.ch_info = NULL;
-	if (!strcmp(attr, ""))
-		return iio_write_all_attr(&params,
-					  dev->dev_descriptor->attributes);
+	if (debug)
+		attributes = dev->dev_descriptor->debug_attributes;
 	else
-		return iio_rd_wr_attribute(&params,
-					   dev->dev_descriptor->attributes,
-					   attr, 1);
+		attributes = dev->dev_descriptor->attributes;
+
+	if (!strcmp(attr, ""))
+		return iio_write_all_attr(&params, attributes);
+	else
+		return iio_rd_wr_attribute(&params, attributes, attr, 1);
 }
 
 /**


### PR DESCRIPTION
By implementing this attribute, register can be read or written from iio_oscilloscope