### PR TITLE
ad9081: add zcu102 support

### DIFF
--- a/projects/ad9081/src.mk
+++ b/projects/ad9081/src.mk
@@ -40,6 +40,8 @@ endif
 ifeq (y,$(strip $(TINYIIOD)))
 SRCS += $(PROJECT)/src/app_iio.c					\
 	$(PLATFORM_DRIVERS)/uart.c					\
+	$(PLATFORM_DRIVERS)/irq.c					\
+	$(NO-OS)/util/fifo.c						\
 	$(NO-OS)/util/xml.c						\
 	$(NO-OS)/iio/iio.c						\
 	$(NO-OS)/iio/iio_app/iio_app.c					\
@@ -93,7 +95,10 @@ endif
 ifeq (y,$(strip $(TINYIIOD)))
 INCS += $(PROJECT)/src/app_iio.h					\
 	$(INCLUDE)/uart.h						\
+	$(INCLUDE)/irq.h						\
+	$(PLATFORM_DRIVERS)/irq_extra.h					\
 	$(PLATFORM_DRIVERS)/uart_extra.h				\
+	$(INCLUDE)/fifo.h						\
 	$(INCLUDE)/xml.h						\
 	$(NO-OS)/iio/iio.h						\
 	$(NO-OS)/iio/iio_types.h					\

--- a/projects/ad9081/src/app.c
+++ b/projects/ad9081/src/app.c
@@ -70,7 +70,11 @@ int main(void)
 	struct clk app_clk[MULTIDEVICE_INSTANCE_COUNT];
 	struct clk jesd_clk[2];
 	struct xil_gpio_init_param  xil_gpio_param = {
+#ifdef PLATFORM_MB
 		.type = GPIO_PL,
+#else
+		.type = GPIO_PS,
+#endif
 		.device_id = GPIO_DEVICE_ID
 	};
 	struct gpio_init_param	gpio_phy_resetb = {
@@ -78,8 +82,12 @@ int main(void)
 		.extra = &xil_gpio_param
 	};
 	struct xil_spi_init_param xil_spi_param = {
+#ifdef PLATFORM_MB
 		.type = SPI_PL,
-		.device_id = SPI_DEVICE_ID,
+#else
+		.type = SPI_PS,
+#endif
+		.device_id = PHY_SPI_DEVICE_ID,
 	};
 	struct spi_init_param phy_spi_init_param = {
 		.max_speed_hz = 1000000,
@@ -199,7 +207,11 @@ int main(void)
 
 #ifdef QUAD_MXFE
 	struct xil_gpio_init_param  xil_gpio_param_2 = {
+#ifdef PLATFORM_MB
 		.type = GPIO_PL,
+#else
+		.type = GPIO_PS,
+#endif
 		.device_id = GPIO_2_DEVICE_ID
 	};
 	struct gpio_init_param	ad9081_gpio0_mux_init = {

--- a/projects/ad9081/src/app_clock.c
+++ b/projects/ad9081/src/app_clock.c
@@ -77,11 +77,15 @@ int32_t app_clock_init(struct clk dev_refclk[MULTIDEVICE_INSTANCE_COUNT])
 	int32_t ret;
 
 	struct xil_spi_init_param xil_spi_param = {
+#ifdef PLATFORM_MB
 		.type = SPI_PL,
+#else
+		.type = SPI_PS,
+#endif
 #ifdef QUAD_MXFE
 		.device_id = SPI_2_DEVICE_ID,
 #else
-		.device_id = SPI_DEVICE_ID,
+		.device_id = CLK_SPI_DEVICE_ID,
 #endif
 	};
 
@@ -171,7 +175,11 @@ int32_t app_clock_init(struct clk dev_refclk[MULTIDEVICE_INSTANCE_COUNT])
 	};
 
 	struct xil_gpio_init_param xil_gpio_param = {
+#ifdef PLATFORM_MB
 		.type = GPIO_PL,
+#else
+		.type = GPIO_PS,
+#endif
 		.device_id = GPIO_DEVICE_ID
 	};
 	struct gpio_init_param gpio_adrf5020_ctrl = {
@@ -190,8 +198,13 @@ int32_t app_clock_init(struct clk dev_refclk[MULTIDEVICE_INSTANCE_COUNT])
 		return ret;
 
 #else
+#if defined(PLATFORM_ZYNQMP)
 	struct hmc7044_chan_spec chan_spec[] = {
 		{
+			.num = 0,		// CORE_CLK_RX
+			.divider = 12,		// 250 MHz
+			.driver_mode = 2,	// LVDS
+		}, {
 			.num = 2,		// DEV_REFCLK
 			.divider = 12,		// 250 MHz
 			.driver_mode = 2,	// LVDS
@@ -205,6 +218,10 @@ int32_t app_clock_init(struct clk dev_refclk[MULTIDEVICE_INSTANCE_COUNT])
 			.driver_mode = 2,	// LVDS
 		}, {
 			.num = 8,		// CORE_CLK_RX
+			.divider = 6,		// 500 MHz
+			.driver_mode = 2,	// LVDS
+		}, {
+			.num = 10,		// CORE_CLK_RX_ALT
 			.divider = 12,		// 250 MHz
 			.driver_mode = 2,	// LVDS
 		}, {
@@ -217,6 +234,43 @@ int32_t app_clock_init(struct clk dev_refclk[MULTIDEVICE_INSTANCE_COUNT])
 			.driver_mode = 2,	// LVDS
 		}
 	};
+#elif defined(PLATFORM_MB)
+	struct hmc7044_chan_spec chan_spec[] = {
+		{
+			.num = 0,		// CORE_CLK_RX
+			.divider = 12,		// 250 MHz
+			.driver_mode = 2,	// LVDS
+		}, {
+			.num = 2,		// DEV_REFCLK
+			.divider = 12,		// 250 MHz
+			.driver_mode = 2,	// LVDS
+		}, {
+			.num = 3,		// DEV_SYSREF
+			.divider = 1536,	// 1.953125 MHz
+			.driver_mode = 2,	// LVDS
+		}, {
+			.num = 6,		// CORE_CLK_TX
+			.divider = 12,		// 250 MHz
+			.driver_mode = 2,	// LVDS
+		}, {
+			.num = 8,		// CORE_CLK_RX_ALT2
+			.divider = 12,		// 250 MHz
+			.driver_mode = 2,	// LVDS
+		}, {
+			.num = 10,		// CORE_CLK_RX_ALT
+			.divider = 12,		// 250 MHz
+			.driver_mode = 2,	// LVDS
+		}, {
+			.num = 12,		// FPGA_REFCLK2
+			.divider = 6,		// 500 MHz
+			.driver_mode = 2,	// LVDS
+		}, {
+			.num = 13,		// FPGA_SYSREF
+			.divider = 1536,	// 1.953125 MHz
+			.driver_mode = 2,	// LVDS
+		}
+	};
+#endif
 
 	struct hmc7044_init_param hmc7044_param = {
 		.spi_init = &clkchip_spi_init_param,

--- a/projects/ad9081/src/app_iio.c
+++ b/projects/ad9081/src/app_iio.c
@@ -47,6 +47,10 @@
 #include "iio_app.h"
 #include "app_parameters.h"
 #include "app_iio.h"
+#ifndef PLATFORM_MB
+#include "irq.h"
+#include "irq_extra.h"
+#endif
 
 /******************************************************************************/
 /************************ Variables Definitions *******************************/
@@ -87,7 +91,12 @@ int32_t iio_server_init(struct iio_axi_adc_init_param *adc_init,
 			struct iio_axi_dac_init_param *dac_init)
 {
 	struct xil_uart_init_param xil_uart_init_par = {
+#ifdef PLATFORM_MB
 		.type = UART_PL,
+#else
+		.type = UART_PS,
+		.irq_id = UART_IRQ_ID,
+#endif
 	};
 	struct uart_init_param uart_init_par = {
 		.baud_rate = 115200,

--- a/projects/ad9081/src/app_parameters.h
+++ b/projects/ad9081/src/app_parameters.h
@@ -44,28 +44,48 @@
 /******************************************************************************/
 /********************** Macros and Constants Definitions **********************/
 /******************************************************************************/
-#define PHY_CS	0
+#ifdef XPS_BOARD_ZCU102
+#define GPIO_OFFSET		78
+#else
+#define GPIO_OFFSET		0
+#endif
+
+#define PHY_CS			0
 
 #ifdef QUAD_MXFE
-#define ADF4371_CS	0
-#define HMC7043_CS	4
+#define ADF4371_CS		0
+#define HMC7043_CS		4
 
-#define PHY_RESET		41
+#define PHY_RESET		(GPIO_OFFSET + 41)
 
-#define ADRF5020_CTRL_GPIO	34
-#define AD9081_GPIO_0_MUX	44
+#define ADRF5020_CTRL_GPIO	(GPIO_OFFSET + 34)
+#define AD9081_GPIO_0_MUX	(GPIO_OFFSET + 44)
 
 #define GPIO_2_DEVICE_ID	XPAR_AXI_GPIO_2_DEVICE_ID
 #define SPI_2_DEVICE_ID		XPAR_AXI_SPI_2_DEVICE_ID
 
 #else
-#define CLK_CS	1
-#define PHY_RESET	55
+#define PHY_RESET		(GPIO_OFFSET + 55)
 #endif
 
+#if defined(PLATFORM_MB)
 #define GPIO_DEVICE_ID		XPAR_AXI_GPIO_DEVICE_ID
-#define SPI_DEVICE_ID		XPAR_AXI_SPI_DEVICE_ID
+#define PHY_SPI_DEVICE_ID	XPAR_AXI_SPI_DEVICE_ID
+#define CLK_SPI_DEVICE_ID	XPAR_AXI_SPI_DEVICE_ID
 #define UART_DEVICE_ID		XPAR_AXI_UART_DEVICE_ID
+#define DDR_CNTRL_BASEADDR	XPAR_AXI_DDR_CNTRL_BASEADDR
+#define CLK_CS			1
+#elif defined(PLATFORM_ZYNQMP)
+#define GPIO_DEVICE_ID		XPAR_PSU_GPIO_0_DEVICE_ID
+#define PHY_SPI_DEVICE_ID	XPAR_PSU_SPI_0_DEVICE_ID
+#define CLK_SPI_DEVICE_ID	XPAR_PSU_SPI_1_DEVICE_ID
+#define UART_DEVICE_ID		XPAR_XUARTPS_0_DEVICE_ID
+#define UART_IRQ_ID		XPAR_XUARTPS_0_INTR
+#define DDR_CNTRL_BASEADDR	XPAR_PSU_DDRC_0_BASEADDR
+#define CLK_CS			0
+#else
+#error Unsupported platform.
+#endif
 
 #define RX_JESD_BASEADDR	XPAR_AXI_MXFE_RX_JESD_RX_AXI_BASEADDR
 #define TX_JESD_BASEADDR	XPAR_AXI_MXFE_TX_JESD_TX_AXI_BASEADDR
@@ -91,7 +111,7 @@
 #define RX_DMA_BASEADDR		XPAR_AXI_MXFE_RX_DMA_BASEADDR
 #define TX_DMA_BASEADDR		XPAR_AXI_MXFE_TX_DMA_BASEADDR
 
-#define ADC_DDR_BASEADDR	XPAR_AXI_DDR_CNTRL_BASEADDR + 0x800000
-#define DAC_DDR_BASEADDR	XPAR_AXI_DDR_CNTRL_BASEADDR + 0xA000000
+#define ADC_DDR_BASEADDR	(DDR_CNTRL_BASEADDR + 0x800000)
+#define DAC_DDR_BASEADDR	(DDR_CNTRL_BASEADDR + 0xA000000)
 
 #endif


### PR DESCRIPTION
HDL design for zcu102 exists, this commit performs necessary
modifications to make no-OS/projects/ad9081 work on zcu102.

Signed-off-by: Darius Berghe <darius.berghe@analog.com>

Tested, works well on vcu118 + ad9081-fmca-ebz and zcu102 + ad9081-fmca-ebz.
