### PR TITLE
network:wifi:at_parser: Remove return check

### DIFF
--- a/network/wifi/at_parser.c
+++ b/network/wifi/at_parser.c
@@ -809,9 +809,8 @@ static int32_t handle_special(struct at_desc *desc, enum at_cmd cmd)
 		desc->result.len = 0;
 		if (SUCCESS != stop_echo(desc))
 			return FAILURE;
-		if (SUCCESS != at_run_cmd(desc, AT_DISCONNECT_NETWORK,
-					  AT_EXECUTE_OP, NULL))
-			return FAILURE;
+		at_run_cmd(desc, AT_DISCONNECT_NETWORK, AT_EXECUTE_OP, NULL);
+
 		break;
 	case AT_DEEP_SLEEP:
 		/* TODO : Implement when needed if possible */


### PR DESCRIPTION
The command AT_DISONNECT_NETWORK may return an error if the
module is not connected to a network. This will make the reset command
to fail event it isn't really an error.

Signed-off-by: Mihail Chindris <mihail.chindris@analog.com>