### PR TITLE
drivers: adc: add AD7798/AD7799 driver

### DIFF
--- a/drivers/adc/ad7799/ad7799.c
+++ b/drivers/adc/ad7799/ad7799.c
@@ -1,0 +1,444 @@
+/***************************************************************************//**
+ *   @file   ad7799.c
+ *   @brief  Implementation of AD7798/AD7799 Driver.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include "error.h"
+#include "ad7799.h"
+
+/*****************************************************************************/
+/***************************** Constant definition ***************************/
+/*****************************************************************************/
+static const uint8_t ad7798_reg_size[] = {
+	[AD7799_REG_COMM] = AD7799_REG_SIZE_1B,
+	[AD7799_REG_MODE] = AD7799_REG_SIZE_2B,
+	[AD7799_REG_CONF] = AD7799_REG_SIZE_2B,
+	[AD7799_REG_DATA] = AD7799_REG_SIZE_2B,
+	[AD7799_REG_ID] = AD7799_REG_SIZE_1B,
+	[AD7799_REG_IO] = AD7799_REG_SIZE_1B,
+	[AD7799_REG_OFFSET] = AD7799_REG_SIZE_2B,
+	[AD7799_REG_FULLSCALE] = AD7799_REG_SIZE_2B
+};
+
+static const uint8_t ad7799_reg_size[] = {
+	[AD7799_REG_COMM] = AD7799_REG_SIZE_1B,
+	[AD7799_REG_MODE] = AD7799_REG_SIZE_2B,
+	[AD7799_REG_CONF] = AD7799_REG_SIZE_2B,
+	[AD7799_REG_DATA] = AD7799_REG_SIZE_3B,
+	[AD7799_REG_ID] = AD7799_REG_SIZE_1B,
+	[AD7799_REG_IO] = AD7799_REG_SIZE_1B,
+	[AD7799_REG_OFFSET] = AD7799_REG_SIZE_3B,
+	[AD7799_REG_FULLSCALE] = AD7799_REG_SIZE_3B
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+/**
+ * @brief Read device register.
+ * @param device - The device structure.
+ * @param reg_addr - The register address.
+ * @param reg_data - The data read from the register.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad7799_read(struct ad7799_dev *device, uint8_t reg_addr,
+		    uint32_t *reg_data)
+{
+	int32_t ret;
+	uint8_t i;
+	uint8_t buff[4];
+	uint8_t buff_size;
+
+	*reg_data = 0;
+
+	buff_size = device->reg_size[reg_addr];
+
+	buff[0] = AD7799_COMM_READ | AD7799_COMM_ADDR(reg_addr);
+
+	memset((buff + 1), 0, buff_size + 1);
+
+	ret = spi_write_and_read(device->spi_desc, buff, buff_size + 1);
+	if(ret)
+		return FAILURE;
+
+	for(i = 1; i < buff_size + 1 ; i++)
+		*reg_data = (*reg_data << 8) | buff[i];
+
+	return ret;
+}
+
+/**
+ * @brief Write device register.
+ * @param device - The device structure.
+ * @param reg_addr - The register address.
+ * @param reg_data - The data to be written.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad7799_write(struct ad7799_dev *device, uint8_t reg_addr,
+		     uint32_t reg_data)
+{
+	int32_t ret;
+	uint8_t i;
+	uint8_t buff[4];
+	uint8_t buff_size;
+
+	buff_size = device->reg_size[reg_addr];
+	buff[0] = AD7799_COMM_WRITE | AD7799_COMM_ADDR(reg_addr);
+
+	for (i = 1; i < buff_size + 1 ; i++)
+		buff[i] = reg_data >> ((buff_size - i) * 8);
+
+	ret = spi_write_and_read(device->spi_desc, buff, buff_size + 1);
+	if(ret)
+		return FAILURE;
+
+	return ret;
+}
+
+/**
+ * @brief Software reset of the device.
+ * @param device - The device structure.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad7799_reset(struct ad7799_dev *device)
+{
+	uint8_t reset_data[4] = {
+		AD7799_RESET_DATA,
+		AD7799_RESET_DATA,
+		AD7799_RESET_DATA,
+		AD7799_RESET_DATA
+	};
+
+	return spi_write_and_read(device->spi_desc, reset_data, 4);
+}
+
+/**
+ * @brief Set the device mode.
+ * @param device - The device structure.
+ * @param mode - The device mode.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad7799_set_mode(struct ad7799_dev *device, uint8_t mode)
+{
+	int32_t ret;
+	uint32_t reg_data = 0;
+
+	ret = ad7799_read(device, AD7799_REG_MODE, &reg_data);
+	if (ret)
+		return FAILURE;
+
+	reg_data &= ~AD7799_MODE_SEL(AD7799_REG_MASK);
+	reg_data |= AD7799_MODE_SEL(mode);
+
+	ret = ad7799_write(device, AD7799_REG_MODE, reg_data);
+	if (ret)
+		return FAILURE;
+
+	ret = ad7799_dev_ready(device);
+	if (ret)
+		return FAILURE;
+
+	return SUCCESS;
+}
+
+/**
+ * @brief Select the ADC channel.
+ * @param device - The device structure.
+ * @param  ch - The channel number.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad7799_set_channel(struct ad7799_dev *device, uint8_t ch)
+{
+	int32_t ret;
+	uint32_t reg_data = 0;
+
+	ret = ad7799_read(device, AD7799_REG_CONF, &reg_data);
+	if (ret)
+		return FAILURE;
+
+	reg_data &= ~AD7799_CONF_CHAN(AD7799_REG_MASK);
+	reg_data |= AD7799_CONF_CHAN(ch);
+
+	return ad7799_write(device, AD7799_REG_CONF, reg_data);
+}
+
+/**
+ * @brief Read specific ADC channel.
+ * @param device - The device structure.
+ * @param ch - The ADC channel.
+ * @param reg_data - The content of the data register.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad7799_get_channel(struct ad7799_dev *device, uint8_t ch,
+			   uint32_t *reg_data)
+{
+	int32_t ret;
+
+	ret = ad7799_set_channel(device, ch);
+	if (ret)
+		return FAILURE;
+
+	ret = ad7799_set_mode(device, AD7799_MODE_SINGLE);
+	if (ret)
+		return FAILURE;
+
+	ret = ad7799_dev_ready(device);
+	if (ret)
+		return FAILURE;
+
+	ret = ad7799_read(device, AD7799_REG_DATA, reg_data);
+	if (ret)
+		return FAILURE;
+
+	return SUCCESS;
+}
+
+/**
+ * @brief Set the ADC gain.
+ * @param device - The device structure.
+ * @param  gain - the channel number.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad7799_set_gain(struct ad7799_dev *device, uint8_t gain)
+{
+	int32_t ret;
+	uint32_t reg_data = 0;
+
+	ret = ad7799_read(device, AD7799_REG_CONF, &reg_data);
+	if (ret)
+		return FAILURE;
+
+	reg_data &= ~AD7799_CONF_GAIN(AD7799_REG_MASK);
+	reg_data |= AD7799_CONF_GAIN(gain);
+
+	return ad7799_write(device, AD7799_REG_CONF, reg_data);
+}
+
+/**
+ * @brief Get the ADC gain
+ * @param device - The device structure.
+ * @param  gain - the gain value from the register.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad7799_get_gain(struct ad7799_dev *device, uint8_t *gain)
+{
+	int32_t ret;
+	uint32_t reg_data = 0;
+
+	ret = ad7799_read(device, AD7799_REG_CONF, &reg_data);
+	if (ret)
+		return FAILURE;
+
+	reg_data &= AD7799_CONF_GAIN(AD7799_REG_MASK);
+	*gain = reg_data >> 8;
+
+	return SUCCESS;
+}
+
+/**
+ * @brief Enable or disable the reference detect function.
+ * @param device - The device structure.
+ * @param  ref_en - 1 reference detect enable.
+ * 				  - 0 reference detect disable.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad7799_set_refdet(struct ad7799_dev *device, uint8_t ref_en)
+{
+	int32_t ret;
+	uint32_t reg_data = 0;
+
+	ret = ad7799_read(device, AD7799_REG_CONF, &reg_data);
+	if (ret)
+		return FAILURE;
+
+	reg_data &= ~AD7799_CONF_REFDET(AD7799_REG_MASK);
+	reg_data |= AD7799_CONF_REFDET(ref_en);
+
+	return ad7799_write(device, AD7799_REG_CONF, reg_data);
+}
+
+/**
+ * @brief Set ADC polarity.
+ * @param device - The device structure.
+ * @param polarity - set the device polarity:
+ * 					0 - Bipolar coding
+ * 					1 - Unipolar coding
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad7799_set_polarity(struct ad7799_dev *device, uint8_t polarity)
+{
+	int32_t ret;
+	uint32_t reg_data = 0;
+
+	ret = ad7799_read(device, AD7799_REG_CONF, &reg_data);
+	if (ret)
+		return FAILURE;
+
+	reg_data &= ~AD7799_CONF_POLARITY(AD7799_REG_MASK);
+	reg_data |= AD7799_CONF_POLARITY(polarity);
+
+	return ad7799_write(device, AD7799_REG_CONF, reg_data);
+}
+
+/**
+ * @brief Read the /RDY bit of status register and check the status
+ * of the device
+ * @param device - The device structure.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad7799_dev_ready(struct ad7799_dev *device)
+{
+	int32_t ret;
+	uint32_t data;
+	uint32_t timeout = AD7799_TIMEOUT;
+
+	while (timeout > 0) {
+		ret = ad7799_read(device, AD7799_REG_STAT, &data);
+		if (ret)
+			return FAILURE;
+
+		if (!(data & AD7799_STAT_RDY))
+			return SUCCESS;
+
+		timeout--;
+	}
+
+	return FAILURE;
+}
+
+/**
+ * @brief Initialize the device.
+ * @param device - The device structure.
+ * @param init_param - The structure that contains the device initial
+ * 		       parameters.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad7799_init(struct ad7799_dev **device,
+		    const struct ad7799_init_param *init_param)
+{
+	struct ad7799_dev *dev;
+	int32_t ret;
+	uint32_t chip_id = 0;
+
+
+	dev = (struct ad7799_dev *)calloc(1, sizeof(*dev));
+	if (!dev)
+		return FAILURE;
+
+	dev->chip_type = init_param->chip_type;
+
+	switch(dev->chip_type) {
+	case ID_AD7798:
+		dev->reg_size = ad7798_reg_size;
+		break;
+	case ID_AD7799:
+		dev->reg_size = ad7799_reg_size;
+		break;
+	default:
+		free(dev);
+		return FAILURE;
+	}
+
+	ret = spi_init(&dev->spi_desc, &init_param->spi_init);
+	if (ret) {
+		free(dev);
+		return FAILURE;
+	}
+
+	ret = ad7799_reset(dev);
+	if (ret)
+		return FAILURE;
+
+	/* Check Chip ID */
+	ret = ad7799_read(dev, AD7799_REG_ID, &chip_id);
+	if (ret)
+		return FAILURE;
+
+	switch(dev->chip_type) {
+	case ID_AD7798:
+		if ((chip_id & AD7799_ID_MASK) != ID_AD7798) {
+			printf("Invalid AD7798 Chip ID");
+			return FAILURE;
+		}
+		break;
+	case ID_AD7799:
+		if ((chip_id & AD7799_ID_MASK) != ID_AD7799) {
+			printf("Invalid AD7799 Chip ID");
+			return FAILURE;
+		}
+		break;
+	default:
+		printf("Invalid AD7798 Chip ID");
+		return FAILURE;
+	}
+
+	/* Initially set gain to 1 */
+	ret = ad7799_set_gain(dev, AD7799_GAIN_1);
+	if (ret)
+		return FAILURE;
+
+	/* Enable unipolar coding */
+	ret = ad7799_set_polarity(dev, AD7799_UNIPOLAR);
+	if (ret)
+		return FAILURE;
+
+	*device = dev;
+
+	return ret;
+}
+
+/**
+ * @brief Remove the device and release resources.
+ * @param device - The device structure.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t ad7799_remove(struct ad7799_dev *device)
+{
+	int32_t ret;
+
+	ret = spi_remove(device->spi_desc);
+	free(device);
+
+	return ret;
+}

--- a/drivers/adc/ad7799/ad7799.h
+++ b/drivers/adc/ad7799/ad7799.h
@@ -1,0 +1,229 @@
+/***************************************************************************//**
+ *   @file   ad7799.h
+ *   @brief  Header file of AD7798/AD7799 Driver.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef AD7799_H_
+#define AD7799_H_
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdint.h>
+#include "spi.h"
+
+/******************************************************************************/
+/********************** Macros and Types Declarations *************************/
+/******************************************************************************/
+
+/*AD7799 Registers*/
+#define AD7799_REG_COMM		0x0 /* Communications Register(WO, 8-bit) */
+#define AD7799_REG_STAT	    	0x0 /* Status Register (RO, 8-bit) */
+#define AD7799_REG_MODE	    	0x1 /* Mode Register (RW, 16-bit) */
+#define AD7799_REG_CONF	    	0x2 /* Configuration Register (RW, 16-bit)*/
+#define AD7799_REG_DATA	    	0x3 /* Data Register (RO, 16-/24-bit) */
+#define AD7799_REG_ID	    	0x4 /* ID Register (RO, 8-bit) */
+#define AD7799_REG_IO	    	0x5 /* IO Register (RO, 8-bit) */
+#define AD7799_REG_OFFSET   	0x6 /* Offset Register (RW, 24-bit) */
+#define AD7799_REG_FULLSCALE	0x7 /* Full-Scale Register (RW, 24-bit) */
+
+/* AD7799 Polarity */
+#define AD7799_BIPOLAR 		0x0 /* Bipolar bit */
+#define AD7799_UNIPOLAR		0x1 /* Unipolar bit */
+
+/* Communications Register Bit Designations (AD7799_REG_COMM) */
+#define AD7799_COMM_WEN		0x80 /* Write Enable */
+#define AD7799_COMM_WRITE	0x00 /* Write Operation */
+#define AD7799_COMM_READ    	0x40 /* Read Operation */
+#define AD7799_COMM_ADDR(x)	(((x) & 0x7) << 3) /* Register Address */
+#define AD7799_COMM_CREAD	0x04 /* Continuous Read */
+
+/* Status Register Bit Designations (AD7799_REG_STAT) */
+#define AD7799_STAT_RDY		0x80 /* Ready */
+#define AD7799_STAT_ERR		0x40 /* Error (Overrange, Underrange) */
+#define AD7799_STAT_CH3		0x04 /* Channel 3 */
+#define AD7799_STAT_CH2		(1 << 1) /* Channel 2 */
+#define AD7799_STAT_CH1		(1 << 0) /* Channel 1 */
+
+/* Mode Register Bit Designations (AD7799_REG_MODE) */
+#define AD7799_MODE_SEL(x)	(((x) & 0x7) << 13) /* Operation Mode Select */
+#define AD7799_MODE_PSW(x)	0x1000 /* Power Switch Control Bit */
+#define AD7799_MODE_RATE(x)	((x) & 0xF) /* Filter Update Rate */
+
+/* AD7799_MODE_SEL(x) options */
+#define AD7799_MODE_CONT	 0x0 /* Continuous Conversion Mode */
+#define AD7799_MODE_SINGLE	 0x1 /* Single Conversion Mode */
+#define AD7799_MODE_IDLE	 0x2 /* Idle Mode */
+#define AD7799_MODE_PWRDN	 0x3 /* Power-Down Mode */
+#define AD7799_MODE_CAL_INT_ZERO 0x4 /* Internal Zero-Scale Calibration */
+#define AD7799_MODE_CAL_INT_FULL 0x5 /* Internal Full-Scale Calibration */
+#define AD7799_MODE_CAL_SYS_ZERO 0x6 /* System Zero-Scale Calibration */
+#define AD7799_MODE_CAL_SYS_FULL 0x7 /* System Full-Scale Calibration */
+
+/* Configuration Register Bit Designations (AD7799_REG_CONF) */
+#define AD7799_CONF_BO_EN	 0x2000 /* Burnout Current */
+#define AD7799_CONF_POLARITY(x)  (((x) & 0x1) << 12) /* Unipolar/Bipolar */
+#define AD7799_CONF_GAIN(x)	 (((x) & 0x7) << 8) /* Gain Select */
+#define AD7799_CONF_REFDET(x)    (((x) & 0x1) << 5) /* Reference detect */
+#define AD7799_CONF_BUF		 0x10 /* Buffered Mode Enable */
+#define AD7799_CONF_CHAN(x)	 ((x) & 0x7) /* Channel select */
+
+/* AD7799_CONF_GAIN(x) options */
+#define AD7799_GAIN_1       	 0x0
+#define AD7799_GAIN_2       	 0x1
+#define AD7799_GAIN_4       	 0x2
+#define AD7799_GAIN_8       	 0x3
+#define AD7799_GAIN_16      	 0x4
+#define AD7799_GAIN_32      	 0x5
+#define AD7799_GAIN_64      	 0x6
+#define AD7799_GAIN_128     	 0x7
+
+/* AD7799 Register size */
+#define AD7799_REG_SIZE_1B	 0x1
+#define AD7799_REG_SIZE_2B	 0x2
+#define AD7799_REG_SIZE_3B	 0x3
+
+/* AD7799_CONF_REFDET(x) options */
+#define AD7799_REFDET_ENA   	 0x1
+#define AD7799_REFDET_DIS   	 0x0
+
+/* AD7799_CONF_CHAN(x) options */
+#define AD7799_CH_AIN1P_AIN1M	 0x0 /* AIN1(+) - AIN1(-) */
+#define AD7799_CH_AIN2P_AIN2M	 0x1 /* AIN2(+) - AIN2(-) */
+#define AD7799_CH_AIN3P_AIN3M	 0x2 /* AIN3(+) - AIN3(-) */
+#define AD7799_CH_AIN1M_AIN1M	 0x3 /* AIN1(-) - AIN1(-) */
+#define AD7799_CH_AVDD_MONITOR	 0x7 /* AVDD Monitor */
+
+/* ID Register Bit Designations (AD7799_REG_ID) */
+#define AD7799_ID_MASK		 0xF
+
+/* AD7799 Configuration Mask */
+#define AD7799_REG_MASK		 0xF
+
+/* IO (Excitation Current Sources) Register Bit Designations (AD7799_REG_IO) */
+#define AD7799_IOEN		 0x40
+#define AD7799_IO1(x)		 (((x) & 0x1) << 4)
+#define AD7799_IO2(x)		 (((x) & 0x1) << 5)
+
+/* AD7799 Timeout */
+#define AD7799_TIMEOUT		 0xFFFF
+
+/* AD7799 Reset Sequence */
+#define AD7799_RESET_DATA	 0xFF
+
+/**
+ * @enum ad7799_type
+ * @brief Device type (AD7798/AD7799)
+ */
+enum ad7799_type {
+	/** AD7798 device*/
+	ID_AD7798 = 0x8,
+	/** AD7799 device */
+	ID_AD7799 = 0x9
+};
+
+/**
+ * @struct ad7799_dev
+ * @brief AD7798/AD7799 Device description
+ */
+struct ad7799_dev {
+	/** SPI Descriptor */
+	struct spi_desc *spi_desc;
+	/** Chip type (AD7798/AD7799) */
+	uint8_t chip_type;
+	/** Register size */
+	const uint8_t *reg_size;
+};
+
+/**
+ * @struct ad7799_init_param
+ * @brief AD7798/AD7799 Device initialization parameters
+ */
+struct ad7799_init_param {
+	/** SPI Initialization parameters */
+	struct spi_init_param spi_init;
+	/** Chip type (AD7798/AD7799) */
+	enum ad7799_type chip_type;
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+/* Read device register. */
+int32_t ad7799_read(struct ad7799_dev *device, uint8_t reg_addr,
+		    uint32_t *reg_data);
+
+/* Write device register */
+int32_t ad7799_write(struct ad7799_dev *device, uint8_t reg_addr,
+		     uint32_t reg_data);
+
+/* Software reset of the device. */
+int32_t ad7799_reset(struct ad7799_dev *device);
+
+/* Set the device mode. */
+int32_t ad7799_set_mode(struct ad7799_dev *device, uint8_t mode);
+
+/* Select the ADC channel. */
+int32_t ad7799_set_channel(struct ad7799_dev *device, uint8_t ch);
+
+/* Read specific ADC channel. */
+int32_t ad7799_get_channel(struct ad7799_dev *device, uint8_t ch,
+			   uint32_t *reg_data);
+
+/* Set the ADC gain. */
+int32_t ad7799_set_gain(struct ad7799_dev *device, uint8_t gain);
+
+/* Get the ADC gain. */
+int32_t ad7799_get_gain(struct ad7799_dev *device, uint8_t *gain);
+
+/* Enable or disable the reference detect function. */
+int32_t ad7799_set_refdet(struct ad7799_dev *device, uint8_t ref_en);
+
+/* Set ADC polarity. */
+int32_t ad7799_set_polarity(struct ad7799_dev *device, uint8_t polarity);
+
+/* Check the status of the device. */
+int32_t ad7799_dev_ready(struct ad7799_dev *device);
+
+/* Initialize the device. */
+int32_t ad7799_init(struct ad7799_dev **device,
+		    const struct ad7799_init_param *init_param);
+
+/* Remove the device and release resources. */
+int32_t ad7799_remove(struct ad7799_dev *device);
+
+#endif /* AD7799_H_ */


### PR DESCRIPTION
Add driver implementation for the AD7798/AD7799 ADC.

More information:
https://www.analog.com/media/en/technical-documentation/data-sheets/AD7798_7799.pdf

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>