### PR TITLE
tools:scripts: fix bug in the windows.mk makefile

### DIFF
--- a/tools/scripts/windows.mk
+++ b/tools/scripts/windows.mk
@@ -472,7 +472,7 @@ xilinx-replace-heap:
 
 .SILENT:xilinx-bsp
 xilinx-bsp:
-	xsdk -batch -source $(SCRIPTS_PATH)/create_project.tcl \
+	xsdk.bat -batch -source $(SCRIPTS_PATH)/create_project.tcl \
 		$(SDK_WORKSPACE) $(HARDWARE) $(ARCH) 		\
 		$(LIB_TINYIIOD_PATH) $(LIB_TINYIIOD)		\
 		$(TINYIIOD_STD_TYPES) $(NULL);


### PR DESCRIPTION
The windows makefile has to call the "xsdk.bat" batch script instead of the
"xsdk" on which is a shell script.

Signed-off-by: Andrei Drimbarean <Andrei.Drimbarean@analog.com>