### PR TITLE
propagate CFLAGS from project Makefile or src.mk

### DIFF
--- a/tools/scripts/linux.mk
+++ b/tools/scripts/linux.mk
@@ -72,7 +72,7 @@ LD ?= $(CC)
 #------------------------------------------------------------------------------
 #                            COMMON COMPILER FLAGS                             
 #------------------------------------------------------------------------------
-CFLAGS = -Wall 								\
+CFLAGS += -Wall								\
 	 -Wmissing-field-initializers					\
 	 -Wclobbered 							\
 	 -Wempty-body 							\

--- a/tools/scripts/windows.mk
+++ b/tools/scripts/windows.mk
@@ -88,7 +88,7 @@ LD ?= $(CC)
 #------------------------------------------------------------------------------
 #                            COMMON COMPILER FLAGS                             
 #------------------------------------------------------------------------------
-CFLAGS = -Wall 								\
+CFLAGS += -Wall								\
 	 -Wmissing-field-initializers					\
 	 -Wclobbered 							\
 	 -Wempty-body 							\


### PR DESCRIPTION
CFLAGS was being overwritten in linux and windows makefiles.
This commit adds the possibility to use CFLAGS defined in
projects/xyz/Makefile or projects/xyz/src.mk in the build
process.

Signed-off-by: Darius Berghe <darius.berghe@analog.com>