### PR TITLE
GPIO tristate API

### DIFF
--- a/drivers/platform/generic/gpio.c
+++ b/drivers/platform/generic/gpio.c
@@ -159,9 +159,10 @@ int32_t gpio_get_direction(struct gpio_desc *desc,
 /**
  * @brief Set the value of the specified GPIO.
  * @param desc - The GPIO descriptor.
- * @param value - The value.
+ * @param value - The value taken from the enum gpio_values members.
  *                Example: GPIO_HIGH
  *                         GPIO_LOW
+ *                         GPIO_HIGH_Z
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t gpio_set_value(struct gpio_desc *desc,

--- a/include/gpio.h
+++ b/include/gpio.h
@@ -53,9 +53,6 @@
 #define GPIO_OUT	0x01
 #define GPIO_IN		0x00
 
-#define GPIO_HIGH	0x01
-#define GPIO_LOW	0x00
-
 /******************************************************************************/
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
@@ -81,6 +78,19 @@ typedef struct gpio_desc {
 	/** GPIO extra parameters (device specific) */
 	void		*extra;
 } gpio_desc;
+
+/**
+ * @enum gpio_values
+ * @brief Enum that holds the possible output states of a GPIO.
+ */
+enum gpio_values {
+	/** GPIO logic low */
+	GPIO_LOW,
+	/** GPIO logic high */
+	GPIO_HIGH,
+	/** GPIO high impedance */
+	GPIO_HIGH_Z
+};
 
 /******************************************************************************/
 /************************ Functions Declarations ******************************/


### PR DESCRIPTION
Suggestion on how to implement a method to disable output and input buffers for GPIOs after they have been enabled.

This approach makes a new API, which seems logical to me considering there are two different APIs to enable input and output direction.

Any thoughts or suggestions?