### PR TITLE
tools:scripts: Fix makefile

### DIFF
--- a/tools/scripts/linux.mk
+++ b/tools/scripts/linux.mk
@@ -9,13 +9,17 @@ export CFLAGS
 export LDFLAGS
 export CC
 export LD
-#Needed by iio library
-export NO-OS
 
 #------------------------------------------------------------------------------
 #                           ENVIRONMENT VARIABLES                              
 #------------------------------------------------------------------------------
+
 NO-OS 		  ?= $(CURDIR)/../..
+#Needed by iio library
+#Should be exported after attribution. Otherwise, is set as null and the
+#the attribution will not work
+export NO-OS
+
 DRIVERS 	  ?= $(NO-OS)/drivers
 INCLUDE 	  ?= $(NO-OS)/include
 LIBRARIES	  ?= $(NO-OS)/libraries

--- a/tools/scripts/windows.mk
+++ b/tools/scripts/windows.mk
@@ -6,13 +6,15 @@ export HARDWARE
 export PLATFORM
 export ARCH
 export CC
-#Needed by iio library
-export NO-OS
 
 #------------------------------------------------------------------------------
 #                           ENVIRONMENT VARIABLES                              
 #------------------------------------------------------------------------------
 NO-OS 		  = $(subst /c/,C:/,$(CURDIR)/../..)
+#Needed by iio library
+#Should be exported after attribution. Otherwise, is set as null and the
+#the attribution will not work
+export NO-OS
 DRIVERS 	  = $(NO-OS)/drivers
 INCLUDE 	  = $(NO-OS)/include
 SCRIPTS_DIR	  = $(NO-OS)/tools/scripts


### PR DESCRIPTION
When exporting NO-OS it is set as empty variable and the ?= attribution doesn't work as intended.
So the export was moved before the attribution