### PR TITLE
pwm.h: Change interface for "pwm_get_polarity".

### DIFF
--- a/include/pwm.h
+++ b/include/pwm.h
@@ -129,6 +129,6 @@ int32_t pwm_set_polarity(struct pwm_desc *desc,
 
 /* Set polarity of PWM generator device */
 int32_t pwm_get_polarity(struct pwm_desc *desc,
-			 enum pwm_polarity polarity);
+			 enum pwm_polarity *polarity);
 
 #endif

--- a/include/pwm.h
+++ b/include/pwm.h
@@ -112,7 +112,7 @@ int32_t pwm_set_period(struct pwm_desc *desc,
 		       uint32_t period_ns);
 
 /* Get period of PWM generator device */
-int32_t pwmg_get_period(struct pwm_desc *desc,
+int32_t pwm_get_period(struct pwm_desc *desc,
 			uint32_t *period_ns);
 
 /* Set duty cycle of PWM generator device */


### PR DESCRIPTION
Send pointer to "polarity" parameter, so we get the value in the exterior
of the function.

Signed-off-by: Cristian Pop <cristian.pop@analog.com>