### PR TITLE
drivers: makefile: include clk_axi_clkgen

### DIFF
--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -11,6 +11,7 @@ INCLUDES = -I../include/ \
 	 -I./adc/ad9081/api \
 	 -I./axi_core/axi_adc_core \
 	 -I./axi_core/spi_engine \
+	 -I./axi_core/clk_axi_clkgen \
 	 -I./platform/xilinx \
 	 -I../projects/adrv9009/src/devices/adi_hal
 


### PR DESCRIPTION
Required by new driver implementations.

For example: #746 

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>