### PR TITLE
I2C: add generic interface

### DIFF
--- a/drivers/i2c/i2c.c
+++ b/drivers/i2c/i2c.c
@@ -1,9 +1,9 @@
 /***************************************************************************//**
- *   @file   altera/i2c.c
- *   @brief  Implementation of Altera I2C Generic Driver.
+ *   @file   i2c.c
+ *   @brief  Implementation of the I2C Interface
  *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
 ********************************************************************************
- * Copyright 2019(c) Analog Devices, Inc.
+ * Copyright 2020(c) Analog Devices, Inc.
  *
  * All rights reserved.
  *
@@ -37,18 +37,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 
-/******************************************************************************/
-/***************************** Include Files **********************************/
-/******************************************************************************/
-
+#include <inttypes.h>
+#include "i2c.h"
 #include <stdlib.h>
 #include "error.h"
-#include "i2c.h"
-#include "i2c_extra.h"
-
-/******************************************************************************/
-/************************ Functions Definitions *******************************/
-/******************************************************************************/
 
 /**
  * @brief Initialize the I2C communication peripheral.
@@ -59,13 +51,13 @@
 int32_t i2c_init(struct i2c_desc **desc,
 		 const struct i2c_init_param *param)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
+	if (!param)
+		return FAILURE;
 
-	if (((struct altera_i2c_init_param *)param->extra)->type) {
-		// Unused variable - fix compiler warning
-	}
+	if ((param->platform_ops->i2c_ops_init(desc, param)))
+		return FAILURE;
+
+	(*desc)->platform_ops = param->platform_ops;
 
 	return SUCCESS;
 }
@@ -77,20 +69,16 @@ int32_t i2c_init(struct i2c_desc **desc,
  */
 int32_t i2c_remove(struct i2c_desc *desc)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
-
-	return SUCCESS;
+	return desc->platform_ops->i2c_ops_remove(desc);
 }
 
 /**
- * @brief Write data to a slave device.
+ * @brief I2C Write data to slave device.
  * @param desc - The I2C descriptor.
- * @param data - Buffer that stores the transmission data.
+ * @param data - The buffer with the transmitted/received data.
  * @param bytes_number - Number of bytes to write.
- * @param stop_bit - Stop condition control.
- *                   Example: 0 - A stop condition will not be generated;
+ * @param stop_bit - Stop conditional control.
+ *                   Example: 0 - A stop condition will not be generated.
  *                            1 - A stop condition will be generated.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
@@ -99,32 +87,17 @@ int32_t i2c_write(struct i2c_desc *desc,
 		  uint8_t bytes_number,
 		  uint8_t stop_bit)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (data) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (bytes_number) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (stop_bit) {
-		// Unused variable - fix compiler warning
-	}
-
-	return SUCCESS;
+	return desc->platform_ops->i2c_ops_write(desc, data, bytes_number,
+			stop_bit);
 }
 
 /**
- * @brief Read data from a slave device.
- * @param desc - The I2C descriptor.
- * @param data - Buffer that will store the received data.
+ * @brief I2C Read data from slave device.
+ * @param desc - The i2c descriptor.
+ * @param data - The buffer with the transmitted/received data.
  * @param bytes_number - Number of bytes to read.
- * @param stop_bit - Stop condition control.
- *                   Example: 0 - A stop condition will not be generated;
+ * @param stop_bit - Stop conditional control.
+ *                   Example: 0 - A stop condition will not be generated.
  *                            1 - A stop condition will be generated.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
@@ -133,21 +106,6 @@ int32_t i2c_read(struct i2c_desc *desc,
 		 uint8_t bytes_number,
 		 uint8_t stop_bit)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (data) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (bytes_number) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (stop_bit) {
-		// Unused variable - fix compiler warning
-	}
-
-	return SUCCESS;
+	return desc->platform_ops->i2c_ops_read(desc, data, bytes_number,
+						stop_bit);
 }

--- a/drivers/platform/altera/altera_i2c.c
+++ b/drivers/platform/altera/altera_i2c.c
@@ -1,0 +1,167 @@
+/***************************************************************************//**
+ *   @file   altera/altera_i2c.c
+ *   @brief  Implementation of Altera I2C Generic Driver.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2019(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <stdlib.h>
+#include "error.h"
+#include "i2c.h"
+#include "i2c_extra.h"
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+
+/**
+ * @brief Altera platform specific I2C platform ops structure
+ */
+const struct i2c_platform_ops xil_i2c_platform_ops = {
+	.i2c_ops_init = &altera_i2c_init,
+	.i2c_ops_write = &altera_i2c_write,
+	.i2c_ops_read = &altera_i2c_read,
+	.i2c_ops_remove = &altera_i2c_remove
+};
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+/**
+ * @brief Initialize the I2C communication peripheral.
+ * @param desc - The I2C descriptor.
+ * @param param - The structure that contains the I2C parameters.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t altera_i2c_init(struct i2c_desc **desc,
+			const struct i2c_init_param *param)
+{
+	if (desc) {
+		// Unused variable - fix compiler warning
+	}
+
+	if (((struct altera_i2c_init_param *)param->extra)->type) {
+		// Unused variable - fix compiler warning
+	}
+
+	return SUCCESS;
+}
+
+/**
+ * @brief Free the resources allocated by i2c_init().
+ * @param desc - The I2C descriptor.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t altera_i2c_remove(struct i2c_desc *desc)
+{
+	if (desc) {
+		// Unused variable - fix compiler warning
+	}
+
+	return SUCCESS;
+}
+
+/**
+ * @brief Write data to a slave device.
+ * @param desc - The I2C descriptor.
+ * @param data - Buffer that stores the transmission data.
+ * @param bytes_number - Number of bytes to write.
+ * @param stop_bit - Stop condition control.
+ *                   Example: 0 - A stop condition will not be generated;
+ *                            1 - A stop condition will be generated.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t altera_i2c_write(struct i2c_desc *desc,
+			 uint8_t *data,
+			 uint8_t bytes_number,
+			 uint8_t stop_bit)
+{
+	if (desc) {
+		// Unused variable - fix compiler warning
+	}
+
+	if (data) {
+		// Unused variable - fix compiler warning
+	}
+
+	if (bytes_number) {
+		// Unused variable - fix compiler warning
+	}
+
+	if (stop_bit) {
+		// Unused variable - fix compiler warning
+	}
+
+	return SUCCESS;
+}
+
+/**
+ * @brief Read data from a slave device.
+ * @param desc - The I2C descriptor.
+ * @param data - Buffer that will store the received data.
+ * @param bytes_number - Number of bytes to read.
+ * @param stop_bit - Stop condition control.
+ *                   Example: 0 - A stop condition will not be generated;
+ *                            1 - A stop condition will be generated.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t altera_i2c_read(struct i2c_desc *desc,
+			uint8_t *data,
+			uint8_t bytes_number,
+			uint8_t stop_bit)
+{
+	if (desc) {
+		// Unused variable - fix compiler warning
+	}
+
+	if (data) {
+		// Unused variable - fix compiler warning
+	}
+
+	if (bytes_number) {
+		// Unused variable - fix compiler warning
+	}
+
+	if (stop_bit) {
+		// Unused variable - fix compiler warning
+	}
+
+	return SUCCESS;
+}

--- a/drivers/platform/altera/i2c_extra.h
+++ b/drivers/platform/altera/i2c_extra.h
@@ -75,4 +75,28 @@ struct altera_i2c_desc {
 	uint32_t	id;
 } altera_i2c_desc;
 
+/**
+ * @brief Altera platform specific i2c platform ops structure
+ */
+extern const struct i2c_platform_ops altera_i2c_platform_ops;
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+/* Initialize the I2C communication peripheral. */
+int32_t altera_i2c_init(struct i2c_desc **desc,
+			const struct i2c_init_param *param);
+
+/* Free the resources allocated by i2c_init(). */
+int32_t altera_i2c_remove(struct i2c_desc *desc);
+
+/* I2C Write data */
+int32_t altera_i2c_write(struct i2c_desc *desc, uint8_t *data,
+			 uint8_t bytes_number, uint8_t stop_bit);
+
+/* I2C Read data. */
+int32_t altera_i2c_read(struct i2c_desc *desc, uint8_t *data,
+			uint8_t bytes_number, uint8_t stop_bit);
+
 #endif /* I2C_EXTRA_H_ */

--- a/drivers/platform/xilinx/i2c_extra.h
+++ b/drivers/platform/xilinx/i2c_extra.h
@@ -66,12 +66,12 @@ enum xil_i2c_type {
  * @brief Structure holding the initialization parameters for Xilinx platform
  * specific I2C parameters.
  */
-typedef struct xil_i2c_init {
+typedef struct xil_i2c_init_param {
 	/** Xilinx architecture */
 	enum xil_i2c_type	type;
 	/** Device ID */
 	uint32_t		device_id;
-} xil_i2c_init;
+} xil_i2c_init_param;
 
 /**
  * @struct xil_i2c_desc

--- a/drivers/platform/xilinx/i2c_extra.h
+++ b/drivers/platform/xilinx/i2c_extra.h
@@ -88,4 +88,28 @@ typedef struct xil_i2c_desc {
 	void			*instance;
 } xil_i2c_desc;
 
+/**
+ * @brief Xilinx platform specific i2c platform ops structure
+ */
+extern const struct i2c_platform_ops xil_i2c_platform_ops;
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+/* Initialize the I2C communication peripheral. */
+int32_t xil_i2c_init(struct i2c_desc **desc,
+		     const struct i2c_init_param *param);
+
+/* Free the resources allocated by i2c_init(). */
+int32_t xil_i2c_remove(struct i2c_desc *desc);
+
+/* I2C Write data */
+int32_t xil_i2c_write(struct i2c_desc *desc, uint8_t *data,
+		      uint8_t bytes_number, uint8_t stop_bit);
+
+/* I2C Read data. */
+int32_t xil_i2c_read(struct i2c_desc *desc, uint8_t *data,
+		     uint8_t bytes_number, uint8_t stop_bit);
+
 #endif // I2C_EXTRA_H_

--- a/include/i2c.h
+++ b/include/i2c.h
@@ -51,6 +51,13 @@
 /******************************************************************************/
 
 /**
+ * @struct i2c_platform_ops
+ * @brief Structure holding I2C function pointers that point to the platform
+ * specific function
+ */
+struct i2c_platform_ops ;
+
+/**
  * @struct i2c_init_param
  * @brief Structure holding the parameters for I2C initialization.
  */
@@ -59,6 +66,8 @@ typedef struct i2c_init_param {
 	uint32_t	max_speed_hz;
 	/** Slave address */
 	uint8_t		slave_address;
+	/** I2C platform specific functions */
+	const struct i2c_platform_ops *platform_ops;
 	/** I2C extra parameters (device specific parameters) */
 	void		*extra;
 } i2c_init_param;
@@ -72,9 +81,27 @@ typedef struct i2c_desc {
 	uint32_t	max_speed_hz;
 	/** Slave address */
 	uint8_t		slave_address;
+	/** I2C platform specific functions */
+	const struct i2c_platform_ops *platform_ops;
 	/** I2C extra parameters (device specific parameters) */
 	void		*extra;
 } i2c_desc;
+
+/**
+ * @struct i2c_platform_ops
+ * @brief Structure holding i2c function pointers that point to the platform
+ * specific function
+ */
+struct i2c_platform_ops {
+	/** i2c initialization function pointer */
+	int32_t (*i2c_ops_init)(struct i2c_desc **, const struct i2c_init_param *);
+	/** i2c write function pointer */
+	int32_t (*i2c_ops_write)(struct i2c_desc *, uint8_t *, uint8_t, uint8_t);
+	/** i2c write function pointer */
+	int32_t (*i2c_ops_read)(struct i2c_desc *, uint8_t *, uint8_t, uint8_t);
+	/** i2c remove function pointer */
+	int32_t (*i2c_ops_remove)(struct i2c_desc *);
+};
 
 /******************************************************************************/
 /************************ Functions Declarations ******************************/

--- a/projects/adv7511/src.mk
+++ b/projects/adv7511/src.mk
@@ -18,13 +18,14 @@ SRCS := $(PROJECT)/src/main.c	\
 	$(PROJECT)/src/wrapper.c
 SRCS += $(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
 	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c	\
+	$(DRIVERS)/i2c/i2c.c	\
 	$(NO-OS)/util/util.c	\
 	$(NO-OS)/util/list.c
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
 	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
 	$(PLATFORM_DRIVERS)/gpio.c					\
 	$(PLATFORM_DRIVERS)/delay.c		\
-	$(PLATFORM_DRIVERS)/i2c.c	\
+	$(PLATFORM_DRIVERS)/xilinx_i2c.c	\
 	$(PLATFORM_DRIVERS)/irq.c	\
 	$(PLATFORM_DRIVERS)/timer.c
 SRCS +=$(PROJECT)/TX/HAL/COMMON/tx_hal.c	\

--- a/projects/adv7511/src/main.c
+++ b/projects/adv7511/src/main.c
@@ -208,6 +208,7 @@ static int32_t app_set_i2c_mux(struct i2c_desc *adv7511_i2c)
 	i2c_mux_init_extra.type = IIC_PL;
 	i2c_mux_init.max_speed_hz = 400000;
 	i2c_mux_init.slave_address = mux_addr;
+	i2c_mux_init.platform_ops = &xil_i2c_platform_ops;
 	i2c_mux_init.extra = &i2c_mux_init_extra;
 
 	mem_val = pca9548_setup;
@@ -351,6 +352,7 @@ int main()
 	adv7511_extra_i2c_init.type = IIC_PL;
 	adv7511_i2c_init.max_speed_hz = 400000;
 	adv7511_i2c_init.slave_address = 0x39;
+	adv7511_i2c_init.platform_ops = &xil_i2c_platform_ops;
 	adv7511_i2c_init.extra = &adv7511_extra_i2c_init;
 #if defined(_XPARAMETERS_PS_H_)
 	xil_timer_init.active_tmr = 0;

--- a/projects/adv7511/src/main.c
+++ b/projects/adv7511/src/main.c
@@ -202,7 +202,7 @@ static int32_t app_set_i2c_mux(struct i2c_desc *adv7511_i2c)
 	const uint8_t byte_transfer_no = 1, stop_bit = 1;
 	struct i2c_desc *i2c_mux;
 	struct i2c_init_param i2c_mux_init;
-	struct xil_i2c_init i2c_mux_init_extra;
+	struct xil_i2c_init_param i2c_mux_init_extra;
 
 	i2c_mux_init_extra.device_id = XPAR_AXI_IIC_MAIN_DEVICE_ID;
 	i2c_mux_init_extra.type = IIC_PL;
@@ -328,7 +328,7 @@ int main()
 	uint32_t start_count;
 	struct i2c_desc *adv7511_i2c;
 	struct i2c_init_param adv7511_i2c_init;
-	struct xil_i2c_init adv7511_extra_i2c_init;
+	struct xil_i2c_init_param adv7511_extra_i2c_init;
 	struct timer_desc *timer_inst_ptr;
 	struct timer_init_param timer_init;
 	struct xil_timer_init_param xil_timer_init;


### PR DESCRIPTION
Add generic i2c_platform_ops structure that aims to point to the i2c
platform specific functions.

Implement the generic I2C functions based on the new interface.

Update the I2C dependent projects from the `/projects` folder.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>