### PR TITLE
gpio: generic interface

### DIFF
--- a/drivers/platform/altera/altera_gpio.c
+++ b/drivers/platform/altera/altera_gpio.c
@@ -1,0 +1,267 @@
+/***************************************************************************//**
+ *   @file   altera/altera_gpio.c
+ *   @brief  Implementation of Altera GPIO Generic Driver.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2019(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <stdlib.h>
+#include <altera_avalon_spi_regs.h>
+#include "gpio.h"
+#include "gpio_extra.h"
+#include "error.h"
+#include "parameters.h"
+
+/**
+ * @brief Altera platform specific GPIO platform ops structure
+ */
+const struct gpio_platform_ops altera_gpio_platform_ops = {
+	.gpio_ops_get = &altera_gpio_get,
+	.gpio_ops_get_optional = &altera_gpio_get_optional,
+	.gpio_ops_remove = &altera_gpio_remove,
+	.gpio_ops_direction_input = &altera_gpio_direction_input,
+	.gpio_ops_direction_output = &altera_gpio_direction_output,
+	.gpio_ops_get_direction = &altera_gpio_get_direction,
+	.gpio_ops_set_value = &altera_gpio_set_value,
+	.gpio_ops_get_value = &altera_gpio_get_value,
+};
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+/**
+ * @brief Obtain the GPIO decriptor.
+ * @param desc - The GPIO descriptor.
+ * @param param - GPIO Initialization parameters.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t altera_gpio_get(struct gpio_desc **desc,
+			const struct gpio_init_param *param)
+{
+
+	struct gpio_desc *descriptor;
+	struct altera_gpio_desc *altera_descriptor;
+	struct altera_gpio_init_param *altera_param;
+
+	descriptor = calloc(1, sizeof(*descriptor));
+
+	if (!descriptor)
+		return FAILURE;
+
+	descriptor->extra = calloc(1, sizeof *altera_descriptor);
+	if (!(descriptor->extra)) {
+		free(descriptor);
+		return FAILURE;
+	}
+
+	altera_descriptor = descriptor->extra;
+	altera_param = param->extra;
+
+	descriptor->number = param->number;
+
+	altera_descriptor->type = altera_param->type;
+	altera_descriptor->device_id = altera_param->device_id;
+	altera_descriptor->base_address = altera_param->base_address;
+
+	*desc = descriptor;
+
+	return SUCCESS;
+}
+
+/**
+ * @brief Get the value of an optional GPIO.
+ * @param desc - The GPIO descriptor.
+ * @param param - GPIO Initialization parameters.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t altera_gpio_get_optional(struct gpio_desc **desc,
+				 const struct gpio_init_param *param)
+{
+	if(param == NULL) {
+		*desc = NULL;
+		return SUCCESS;
+	}
+
+	return gpio_get(desc, param);
+}
+
+/**
+ * @brief Free the resources allocated by gpio_get().
+ * @param desc - The GPIO descriptor.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t altera_gpio_remove(struct gpio_desc *desc)
+{
+	if (desc) {
+		free(desc->extra);
+		free(desc);
+	}
+
+	return SUCCESS;
+}
+
+/**
+ * @brief Enable the input direction of the specified GPIO.
+ * @param desc - The GPIO descriptor.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t altera_gpio_direction_input(struct gpio_desc *desc)
+{
+	if (desc) {
+		// Unused variable - fix compiler warning
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Enable the output direction of the specified GPIO.
+ * @param desc - The GPIO descriptor.
+ * @param value - The value.
+ *                Example: GPIO_HIGH
+ *                         GPIO_LOW
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t altera_gpio_direction_output(struct gpio_desc *desc,
+				     uint8_t value)
+{
+	return gpio_set_value(desc, value);
+}
+
+/**
+ * @brief Get the direction of the specified GPIO.
+ * @param desc - The GPIO descriptor.
+ * @param direction - The direction.
+ *                    Example: GPIO_OUT
+ *                             GPIO_IN
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t altera_gpio_get_direction(struct gpio_desc *desc,
+				  uint8_t *direction)
+{
+	if (desc) {
+		// Unused variable - fix compiler warning
+	}
+
+	if (direction) {
+		// Unused variable - fix compiler warning
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Set the value of the specified GPIO.
+ * @param desc - The GPIO descriptor.
+ * @param value - The value.
+ *                Example: GPIO_HIGH
+ *                         GPIO_LOW
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t altera_gpio_set_value(struct gpio_desc *desc,
+			      uint8_t value)
+{
+	if(!desc)
+		return FAILURE;
+
+	uint32_t ppos;
+	uint32_t pdata;
+	uint32_t pmask;
+
+	struct altera_gpio_desc *altera_desc;
+	altera_desc = desc->extra;
+
+	if (desc->number < 32)
+		return FAILURE;
+
+	switch(altera_desc->type) {
+	case NIOS_II_GPIO:
+		ppos = desc->number - 32;
+		pmask = 0x1 << ppos;
+
+		pdata = IORD_32DIRECT(altera_desc->base_address, 0x0);
+		IOWR_32DIRECT(altera_desc->base_address,
+			      0x0, ((pdata & ~pmask) | (value << ppos)));
+
+		break;
+	default:
+		return FAILURE;
+	}
+
+	return SUCCESS;
+}
+
+/**
+ * @brief Get the value of the specified GPIO.
+ * @param desc - The GPIO descriptor.
+ * @param value - The value.
+ *                Example: GPIO_HIGH
+ *                         GPIO_LOW
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t altera_gpio_get_value(struct gpio_desc *desc,
+			      uint8_t *value)
+{
+	if(!desc)
+		return FAILURE;
+
+	uint32_t ppos;
+	uint32_t pdata;
+
+	struct altera_gpio_desc *altera_desc;
+	altera_desc = desc->extra;
+
+	if (desc->number < 32)
+		return FAILURE;
+
+	switch(altera_desc->type) {
+	case NIOS_II_GPIO:
+		ppos = desc->number - 32;
+
+		pdata = IORD_32DIRECT(altera_desc->base_address, 0x0);
+		*value = (pdata >> ppos) & 0x01;
+
+		break;
+	default:
+		return FAILURE;
+	}
+
+	return SUCCESS;
+}

--- a/drivers/platform/altera/gpio_extra.h
+++ b/drivers/platform/altera/gpio_extra.h
@@ -44,6 +44,11 @@
 /******************************************************************************/
 
 /**
+ * @brief Altera platform specific gpio platform ops structure
+ */
+extern const struct gpio_platform_ops altera_gpio_platform_ops;
+
+/**
  * @enum gpio_type
  * @brief Altera platform architecture types
  */
@@ -78,5 +83,39 @@ struct altera_gpio_desc {
 	/** GPIO base address */
 	uint32_t base_address;
 } altera_gpio_desc;
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+/* Obtain the GPIO decriptor. */
+int32_t altera_gpio_get(struct gpio_desc **desc,
+			const struct gpio_init_param *param);
+
+/* Obtain optional GPIO descriptor. */
+int32_t altera_gpio_get_optional(struct gpio_desc **desc,
+				 const struct gpio_init_param *param);
+
+/* Free the resources allocated by gpio_get() */
+int32_t altera_gpio_remove(struct gpio_desc *desc);
+
+/* Enable the input direction of the specified GPIO. */
+int32_t altera_gpio_direction_input(struct gpio_desc *desc);
+
+/* Enable the output direction of the specified GPIO. */
+int32_t altera_gpio_direction_output(struct gpio_desc *desc,
+				     uint8_t value);
+
+/* Get the direction of the specified GPIO. */
+int32_t altera_gpio_get_direction(struct gpio_desc *desc,
+				  uint8_t *direction);
+
+/* Set the value of the specified GPIO. */
+int32_t altera_gpio_set_value(struct gpio_desc *desc,
+			      uint8_t value);
+
+/* Get the value of the specified GPIO. */
+int32_t altera_gpio_get_value(struct gpio_desc *desc,
+			      uint8_t *value);
 
 #endif /* GPIO_EXTRA_H_ */

--- a/drivers/platform/xilinx/gpio_extra.h
+++ b/drivers/platform/xilinx/gpio_extra.h
@@ -87,4 +87,43 @@ typedef struct xil_gpio_desc {
 	void			*instance;
 } xil_gpio_desc;
 
+/**
+ * @brief Xilinx platform specific gpio platform ops structure
+ */
+extern const struct gpio_platform_ops xil_gpio_platform_ops;
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+/* Obtain the GPIO decriptor. */
+int32_t xil_gpio_get(struct gpio_desc **desc,
+		     const struct gpio_init_param *param);
+
+/* Obtain optional GPIO descriptor. */
+int32_t xil_gpio_get_optional(struct gpio_desc **desc,
+			      const struct gpio_init_param *param);
+
+/* Free the resources allocated by gpio_get() */
+int32_t xil_gpio_remove(struct gpio_desc *desc);
+
+/* Enable the input direction of the specified GPIO. */
+int32_t xil_gpio_direction_input(struct gpio_desc *desc);
+
+/* Enable the output direction of the specified GPIO. */
+int32_t xil_gpio_direction_output(struct gpio_desc *desc,
+				  uint8_t value);
+
+/* Get the direction of the specified GPIO. */
+int32_t xil_gpio_get_direction(struct gpio_desc *desc,
+			       uint8_t *direction);
+
+/* Set the value of the specified GPIO. */
+int32_t xil_gpio_set_value(struct gpio_desc *desc,
+			   uint8_t value);
+
+/* Get the value of the specified GPIO. */
+int32_t xil_gpio_get_value(struct gpio_desc *desc,
+			   uint8_t *value);
+
 #endif

--- a/drivers/platform/xilinx/xilinx_gpio.c
+++ b/drivers/platform/xilinx/xilinx_gpio.c
@@ -1,5 +1,5 @@
 /***************************************************************************//**
- *   @file   xilinx/gpio.c
+ *   @file   xilinx/xilinx_gpio.c
  *   @brief  Implementation of Xilinx GPIO Generic Driver.
  *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
 ********************************************************************************
@@ -54,6 +54,20 @@
 #include "error.h"
 #include "gpio.h"
 #include "gpio_extra.h"
+
+/**
+ * @brief Xilinx platform specific GPIO platform ops structure
+ */
+const struct gpio_platform_ops xil_gpio_platform_ops = {
+	.gpio_ops_get = &xil_gpio_get,
+	.gpio_ops_get_optional = &xil_gpio_get_optional,
+	.gpio_ops_remove = &xil_gpio_remove,
+	.gpio_ops_direction_input = &xil_gpio_direction_input,
+	.gpio_ops_direction_output = &xil_gpio_direction_output,
+	.gpio_ops_get_direction = &xil_gpio_get_direction,
+	.gpio_ops_set_value = &xil_gpio_set_value,
+	.gpio_ops_get_value = &xil_gpio_get_value,
+};
 
 /******************************************************************************/
 /************************ Functions Definitions *******************************/
@@ -138,8 +152,8 @@ error:
  * @param param - GPIO initialization parameters
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t gpio_get(struct gpio_desc **desc,
-		 const struct gpio_init_param *param)
+int32_t xil_gpio_get(struct gpio_desc **desc,
+		     const struct gpio_init_param *param)
 {
 	struct gpio_desc	*descriptor;
 	struct xil_gpio_desc	*extra;
@@ -173,8 +187,8 @@ error:
  * @param param - GPIO Initialization parameters.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t gpio_get_optional(struct gpio_desc **desc,
-			  const struct gpio_init_param *param)
+int32_t xil_gpio_get_optional(struct gpio_desc **desc,
+			      const struct gpio_init_param *param)
 {
 	if(param == NULL) {
 		*desc = NULL;
@@ -186,10 +200,10 @@ int32_t gpio_get_optional(struct gpio_desc **desc,
 
 /**
  * @brief Free the resources allocated by gpio_get().
- * @param desc - The SPI descriptor.
+ * @param desc - The GPIO descriptor.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t gpio_remove(struct gpio_desc *desc)
+int32_t xil_gpio_remove(struct gpio_desc *desc)
 {
 	if (desc != NULL) {
 		free(((xil_gpio_desc *)(desc->extra))->instance);
@@ -205,7 +219,7 @@ int32_t gpio_remove(struct gpio_desc *desc)
  * @param desc - The GPIO descriptor.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t gpio_direction_input(struct gpio_desc *desc)
+int32_t xil_gpio_direction_input(struct gpio_desc *desc)
 {
 	struct xil_gpio_desc	*extra;
 #ifdef XGPIO_H
@@ -254,8 +268,8 @@ int32_t gpio_direction_input(struct gpio_desc *desc)
  *                         GPIO_LOW
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t gpio_direction_output(struct gpio_desc *desc,
-			      uint8_t value)
+int32_t xil_gpio_direction_output(struct gpio_desc *desc,
+				  uint8_t value)
 {
 	struct xil_gpio_desc	*extra;
 #ifdef XGPIO_H
@@ -320,8 +334,8 @@ int32_t gpio_direction_output(struct gpio_desc *desc,
  *                             GPIO_IN
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t gpio_get_direction(struct gpio_desc *desc,
-			   uint8_t *direction)
+int32_t xil_gpio_get_direction(struct gpio_desc *desc,
+			       uint8_t *direction)
 {
 	if (!desc)
 		return FAILURE;
@@ -367,8 +381,8 @@ int32_t gpio_get_direction(struct gpio_desc *desc,
  *                         GPIO_LOW
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t gpio_set_value(struct gpio_desc *desc,
-		       uint8_t value)
+int32_t xil_gpio_set_value(struct gpio_desc *desc,
+			   uint8_t value)
 {
 	struct xil_gpio_desc	*extra;
 #ifdef XGPIO_H
@@ -416,8 +430,8 @@ int32_t gpio_set_value(struct gpio_desc *desc,
  *                         GPIO_LOW
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t gpio_get_value(struct gpio_desc *desc,
-		       uint8_t *value)
+int32_t xil_gpio_get_value(struct gpio_desc *desc,
+			   uint8_t *value)
 {
 	if (!desc)
 		return FAILURE;

--- a/include/gpio.h
+++ b/include/gpio.h
@@ -58,12 +58,21 @@
 /******************************************************************************/
 
 /**
+ * @struct gpio_platform_ops
+ * @brief Structure holding gpio function pointers that point to the platform
+ * specific function
+ */
+struct gpio_platform_ops ;
+
+/**
  * @struct gpio_init_param
  * @brief Structure holding the parameters for GPIO initialization.
  */
 typedef struct gpio_init_param {
 	/** GPIO number */
 	uint32_t	number;
+	/** GPIO platform specific functions */
+	const struct gpio_platform_ops *platform_ops;
 	/** GPIO extra parameters (device specific) */
 	void		*extra;
 } gpio_init_param;
@@ -75,6 +84,8 @@ typedef struct gpio_init_param {
 typedef struct gpio_desc {
 	/** GPIO number */
 	uint32_t	number;
+	/** GPIO platform specific functions */
+	const struct gpio_platform_ops *platform_ops;
 	/** GPIO extra parameters (device specific) */
 	void		*extra;
 } gpio_desc;
@@ -90,6 +101,31 @@ enum gpio_values {
 	GPIO_HIGH,
 	/** GPIO high impedance */
 	GPIO_HIGH_Z
+};
+
+/**
+ * @struct gpio_platform_ops
+ * @brief Structure holding gpio function pointers that point to the platform
+ * specific function
+ */
+struct gpio_platform_ops {
+	/** gpio initialization function pointer */
+	int32_t (*gpio_ops_get)(struct gpio_desc **, const struct gpio_init_param *);
+	/** gpio optional descriptor function pointer */
+	int32_t (*gpio_ops_get_optional)(struct gpio_desc **,
+					 const struct gpio_init_param *);
+	/** gpio remove function pointer */
+	int32_t (*gpio_ops_remove)(struct gpio_desc *);
+	/** gpio direction input function pointer */
+	int32_t (*gpio_ops_direction_input)(struct gpio_desc *);
+	/** gpio direction output function pointer */
+	int32_t (*gpio_ops_direction_output)(struct gpio_desc *, uint8_t);
+	/** gpio get direction function pointer */
+	int32_t (*gpio_ops_get_direction)(struct gpio_desc *, uint8_t *);
+	/** gpio set value function pointer */
+	int32_t (*gpio_ops_set_value)(struct gpio_desc *, uint8_t);
+	/** gpio get value function pointer */
+	int32_t (*gpio_ops_get_value)(struct gpio_desc *, uint8_t *);
 };
 
 /******************************************************************************/

--- a/projects/ad713x_fmcz/src.mk
+++ b/projects/ad713x_fmcz/src.mk
@@ -11,12 +11,13 @@
 
 SRCS := $(PROJECT)/src/ad713x_fmc.c
 SRCS += $(DRIVERS)/spi/spi.c						\
+	$(DRIVERS)/gpio/gpio.c						\
 	$(DRIVERS)/adc/ad713x/ad713x.c					\
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
 	$(DRIVERS)/axi_core/spi_engine/spi_engine.c			\
 	$(NO-OS)/util/util.c
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/gpio.c					\
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
 	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
 	$(PLATFORM_DRIVERS)/delay.c
 ifeq (y,$(strip $(TINYIIOD)))

--- a/projects/ad713x_fmcz/src/ad713x_fmc.c
+++ b/projects/ad713x_fmcz/src/ad713x_fmc.c
@@ -139,42 +139,52 @@ int main()
 	struct xil_gpio_init_param gpio_extra_param;
 	struct gpio_init_param ad7134_1_dclkio = {
 		.number = GPIO_DCLKIO_1,
+		.platform_ops = &xil_gpio_platform_ops,
 		.extra = &gpio_extra_param
 	};
 	struct gpio_init_param ad7134_2_dclkio = {
 		.number = GPIO_DCLKIO_2,
+		.platform_ops = &xil_gpio_platform_ops,
 		.extra = &gpio_extra_param
 	};
 	struct gpio_init_param ad7134_1_dclkmode = {
 		.number = GPIO_DCLKMODE,
+		.platform_ops = &xil_gpio_platform_ops,
 		.extra = &gpio_extra_param
 	};
 	struct gpio_init_param ad7134_2_dclkmode = {
 		.number = GPIO_DCLKMODE,
+		.platform_ops = &xil_gpio_platform_ops,
 		.extra = &gpio_extra_param
 	};
 	struct gpio_init_param ad7134_1_mode = {
 		.number = GPIO_MODE_1,
+		.platform_ops = &xil_gpio_platform_ops,
 		.extra = &gpio_extra_param
 	};
 	struct gpio_init_param ad7134_2_mode = {
 		.number = GPIO_MODE_2,
+		.platform_ops = &xil_gpio_platform_ops,
 		.extra = &gpio_extra_param
 	};
 	struct gpio_init_param ad7134_1_pnd = {
 		.number = GPIO_PDN_1,
+		.platform_ops = &xil_gpio_platform_ops,
 		.extra = &gpio_extra_param
 	};
 	struct gpio_init_param ad7134_2_pnd = {
 		.number = GPIO_PDN_2,
+		.platform_ops = &xil_gpio_platform_ops,
 		.extra = &gpio_extra_param
 	};
 	struct gpio_init_param ad7134_1_resetn = {
 		.number = GPIO_RESETN_1,
+		.platform_ops = &xil_gpio_platform_ops,
 		.extra = &gpio_extra_param
 	};
 	struct gpio_init_param ad7134_2_resetn = {
 		.number = GPIO_RESETN_2,
+		.platform_ops = &xil_gpio_platform_ops,
 		.extra = &gpio_extra_param
 	};
 	struct spi_desc *spi_eng_desc;

--- a/projects/ad9081/src.mk
+++ b/projects/ad9081/src.mk
@@ -28,9 +28,10 @@ SRCS := $(PROJECT)/src/app.c						\
 	$(DRIVERS)/axi_core/jesd204/jesd204_clk.c			\
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
 	$(DRIVERS)/spi/spi.c						\
+	$(DRIVERS)/gpio/gpio.c						\
 	$(PLATFORM_DRIVERS)/axi_io.c					\
 	$(PLATFORM_DRIVERS)/delay.c					\
-	$(PLATFORM_DRIVERS)/gpio.c					\
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
 	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
 	$(NO-OS)/util/clk.c						\
 	$(NO-OS)/util/util.c

--- a/projects/ad9081/src/app.c
+++ b/projects/ad9081/src/app.c
@@ -79,6 +79,7 @@ int main(void)
 	};
 	struct gpio_init_param	gpio_phy_resetb = {
 		.number = PHY_RESET,
+		.platform_ops = &xil_gpio_platform_ops,
 		.extra = &xil_gpio_param
 	};
 	struct xil_spi_init_param xil_spi_param = {
@@ -216,6 +217,7 @@ int main(void)
 	};
 	struct gpio_init_param	ad9081_gpio0_mux_init = {
 		.number = AD9081_GPIO_0_MUX,
+		.platform_ops = &xil_gpio_platform_ops,
 		.extra = &xil_gpio_param_2
 	};
 	gpio_desc *ad9081_gpio0_mux;

--- a/projects/ad9081/src/app_clock.c
+++ b/projects/ad9081/src/app_clock.c
@@ -184,6 +184,7 @@ int32_t app_clock_init(struct clk dev_refclk[MULTIDEVICE_INSTANCE_COUNT])
 	};
 	struct gpio_init_param gpio_adrf5020_ctrl = {
 		.number = ADRF5020_CTRL_GPIO,
+		.platform_ops = &xil_gpio_platform_ops,
 		.extra = &xil_gpio_param
 	};
 	gpio_desc *adrf5020_ctrl;

--- a/projects/ad9172/src.mk
+++ b/projects/ad9172/src.mk
@@ -14,6 +14,7 @@ ifeq (y,$(strip $(TINYIIOD)))
 SRCS += $(PROJECT)/src/app_iio.c
 endif
 SRCS += $(DRIVERS)/spi/spi.c						\
+	$(DRIVERS)/gpio/gpio.c						\
 	$(DRIVERS)/frequency/hmc7044/hmc7044.c				\
 	$(DRIVERS)/dac/ad917x/ad9172.c					\
 	$(DRIVERS)/dac/ad917x/ad917x_api/ad917x_api.c			\
@@ -30,7 +31,7 @@ SRCS += $(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c			\
 	$(NO-OS)/util/util.c
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
 	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
-	$(PLATFORM_DRIVERS)/gpio.c					\
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
 	$(PLATFORM_DRIVERS)/delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 SRCS += $(NO-OS)/util/xml.c						\

--- a/projects/ad9172/src/main.c
+++ b/projects/ad9172/src/main.c
@@ -146,14 +146,17 @@ int main(void)
 		.spi_init = &ad9172_spi_param,	/* spi_init_param */
 		.gpio_reset = {
 			.number = 54 + 0,
+			.platform_ops = &xil_gpio_platform_ops,
 			.extra = &xilinx_gpio_init_param
 		},
 		.gpio_txen0 = {
 			.number = 54 + 22,
+			.platform_ops = &xil_gpio_platform_ops,
 			.extra = &xilinx_gpio_init_param
 		},
 		.gpio_txen1 = {
 			.number = 54 + 23,
+			.platform_ops = &xil_gpio_platform_ops,
 			.extra = &xilinx_gpio_init_param
 		},
 		.dac_rate_khz = 11796480,		/* or sample rate */

--- a/projects/ad9208/src.mk
+++ b/projects/ad9208/src.mk
@@ -14,6 +14,7 @@ ifeq (y,$(strip $(TINYIIOD)))
 SRCS += $(PROJECT)/src/app_iio.c
 endif
 SRCS += $(DRIVERS)/spi/spi.c						\
+	$(DRIVERS)/gpio/gpio.c						\
 	$(DRIVERS)/frequency/hmc7044/hmc7044.c				\
 	$(DRIVERS)/adc/ad9208/ad9208.c 					\
 	$(DRIVERS)/adc/ad9208/ad9208_api/ad9208_adc_api.c 		\
@@ -31,7 +32,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
 	$(NO-OS)/util/util.c
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
 	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
-	$(PLATFORM_DRIVERS)/gpio.c					\
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
 	$(PLATFORM_DRIVERS)/delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 SRCS += $(NO-OS)/util/xml.c						\

--- a/projects/ad9208/src/main.c
+++ b/projects/ad9208/src/main.c
@@ -272,6 +272,7 @@ int main(void)
 		.spi_init = &ad9208_0_spi_param,
 		.gpio_powerdown = {
 			.number = 54 + 34, /* adc0_pwdn */
+			.platform_ops = &xil_gpio_platform_ops,
 			.extra = &xilinx_gpio_init_param
 		},
 		.sampling_frequency_hz = 3000000000,
@@ -315,6 +316,7 @@ int main(void)
 		.spi_init = &ad9208_1_spi_param,
 		.gpio_powerdown = {
 			.number = 54 + 33, /* adc1_pwdn */
+			.platform_ops = &xil_gpio_platform_ops,
 			.extra = &xilinx_gpio_init_param
 		},
 		.sampling_frequency_hz = 3000000000,

--- a/projects/ad9361/src.mk
+++ b/projects/ad9361/src.mk
@@ -23,14 +23,16 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c			\
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
 	$(DRIVERS)/spi/spi.c						\
+	$(DRIVERS)/gpio/gpio.c						\
 	$(NO-OS)/util/util.c
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/gpio.c					\
 	$(PLATFORM_DRIVERS)/delay.c
 ifeq (xilinx,$(strip $(PLATFORM)))
-SRCS +=	$(PLATFORM_DRIVERS)/xilinx_spi.c
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c
 else
-SRCS +=	$(PLATFORM_DRIVERS)/altera_spi.c
+SRCS +=	$(PLATFORM_DRIVERS)/altera_spi.c				\
+	$(PLATFORM_DRIVERS)/altera_gpio.c
 endif
 ifeq (y,$(strip $(TINYIIOD)))
 SRCS += $(PLATFORM_DRIVERS)/uart.c					\

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -364,21 +364,25 @@ AD9361_InitParam default_init_param = {
 	/* GPIO definitions */
 	{
 		.number = -1,
+		.platform_ops = &xil_gpio_platform_ops,
 		.extra = &xil_gpio_param
 	},		//gpio_resetb *** reset-gpios
 	/* MCS Sync */
 	{
 		.number = -1,
+		.platform_ops = &xil_gpio_platform_ops,
 		.extra = &xil_gpio_param
 	},		//gpio_sync *** sync-gpios
 
 	{
 		.number = -1,
+		.platform_ops = &xil_gpio_platform_ops,
 		.extra = &xil_gpio_param
 	},		//gpio_cal_sw1 *** cal-sw1-gpios
 
 	{
 		.number = -1,
+		.platform_ops = &xil_gpio_platform_ops,
 		.extra = &xil_gpio_param
 	},		//gpio_cal_sw2 *** cal-sw2-gpios
 	/* External LO clocks */
@@ -483,6 +487,7 @@ int main(void)
 	spi_param.platform_ops = &altera_platform_ops;
 #endif
 	struct gpio_init_param 	gpio_init;
+	gpio_init.platform_ops = &xil_gpio_platform_ops;
 	gpio_init.extra = &xil_gpio_param;
 
 #ifdef ALTERA_PLATFORM

--- a/projects/ad9371/src.mk
+++ b/projects/ad9371/src.mk
@@ -31,21 +31,23 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c			\
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c			\
 	$(NO-OS)/util/util.c						\
-	$(DRIVERS)/spi/spi.c
+	$(DRIVERS)/spi/spi.c						\
+	$(DRIVERS)/gpio/gpio.c
 ifeq (xilinx,$(strip $(PLATFORM)))
 SRCS += $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c			\
 	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c		\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c
+	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c
 else
 SRCS += $(DRIVERS)/axi_core/clk_altera_a10_fpll/clk_altera_a10_fpll.c	\
 	$(DRIVERS)/axi_core/jesd204/altera_a10_atx_pll.c		\
 	$(DRIVERS)/axi_core/jesd204/altera_a10_cdr_pll.c		\
 	$(DRIVERS)/axi_core/jesd204/altera_adxcvr.c			\
-	$(PLATFORM_DRIVERS)/altera_spi.c
+	$(PLATFORM_DRIVERS)/altera_spi.c				\
+	$(PLATFORM_DRIVERS)/altera_gpio.c
 endif
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/gpio.c					\
 	$(PLATFORM_DRIVERS)/delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 SRCS += $(PLATFORM_DRIVERS)/uart.c					\

--- a/projects/ad9371/src/devices/adi_hal/common.c
+++ b/projects/ad9371/src/devices/adi_hal/common.c
@@ -70,8 +70,11 @@ int32_t platform_init(void)
 	};
 	spi_param.extra = &xilinx_spi_param;
 	spi_param.platform_ops = &xil_platform_ops;
+	gpio_ad9371_resetb_param.platform_ops = &xil_gpio_platform_ops;
 	gpio_ad9371_resetb_param.extra = &xilinx_gpio_param;
+	gpio_ad9528_resetb_param.platform_ops = &xil_gpio_platform_ops;
 	gpio_ad9528_resetb_param.extra = &xilinx_gpio_param;
+	gpio_ad9528_sysref_param.platform_ops = &xil_gpio_platform_ops;
 	gpio_ad9528_sysref_param.extra = &xilinx_gpio_param;
 #else
 	struct altera_spi_init_param altera_spi_param = {
@@ -87,8 +90,11 @@ int32_t platform_init(void)
 	};
 	spi_param.platform_ops = &altera_platform_ops;
 	spi_param.extra = &altera_spi_param;
+	gpio_ad9371_resetb_param.platform_ops = &altera_gpio_platform_ops;
 	gpio_ad9371_resetb_param.extra = &altera_gpio_param;
+	gpio_ad9528_resetb_param.platform_ops = &altera_gpio_platform_ops;
 	gpio_ad9528_resetb_param.extra = &altera_gpio_param;
+	gpio_ad9528_sysref_param.platform_ops = &altera_gpio_platform_ops;
 	gpio_ad9528_sysref_param.extra = &altera_gpio_param;
 #endif
 	status = gpio_get(&gpio_ad9371_resetb, &gpio_ad9371_resetb_param);

--- a/projects/adrv9009/src.mk
+++ b/projects/adrv9009/src.mk
@@ -48,7 +48,8 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c			\
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c			\
-	$(DRIVERS)/spi/spi.c
+	$(DRIVERS)/spi/spi.c						\
+	$(DRIVERS)/gpio/gpio.c
 ifeq (y,$(strip $(TINYIIOD)))
 SRCS += $(NO-OS)/util/xml.c						\
 	$(NO-OS)/util/fifo.c						\
@@ -64,16 +65,17 @@ ifeq (xilinx,$(strip $(PLATFORM)))
 SRCS += $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c			\
 	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c		\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c
+	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c
 else
 SRCS += $(DRIVERS)/axi_core/clk_altera_a10_fpll/clk_altera_a10_fpll.c	\
 	$(DRIVERS)/axi_core/jesd204/altera_a10_atx_pll.c		\
 	$(DRIVERS)/axi_core/jesd204/altera_a10_cdr_pll.c		\
 	$(DRIVERS)/axi_core/jesd204/altera_adxcvr.c			\
-	$(PLATFORM_DRIVERS)/altera_spi.c
+	$(PLATFORM_DRIVERS)/altera_spi.c				\
+	$(PLATFORM_DRIVERS)/altera_gpio.c
 endif
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/gpio.c					\
 	$(PLATFORM_DRIVERS)/delay.c
 INCS :=	$(PROJECT)/src/app/app_config.h					\
 	$(PROJECT)/src/app/app_clocking.h						\

--- a/projects/adrv9009/src/app/app_clocking.c
+++ b/projects/adrv9009/src/app/app_clocking.c
@@ -435,6 +435,7 @@ adiHalErr_t clocking_init(uint32_t rx_div40_rate_hz,
 #else
 	struct gpio_init_param clkchip_gpio_init_param = {
 		.number = CLK_RESETB_GPIO,
+		.platform_ops = &xil_gpio_platform_ops,
 		.extra = &xil_gpio_param
 	};
 	ad9528_param.gpio_resetb = &clkchip_gpio_init_param;

--- a/projects/adrv9009/src/app/headless.c
+++ b/projects/adrv9009/src/app/headless.c
@@ -266,6 +266,11 @@ int main(void)
 
 #ifdef DAC_DMA_EXAMPLE
 	gpio_init_plddrbypass.extra = &hal_gpio_param;
+#ifndef ALTERA_PLATFORM
+	gpio_init_plddrbypass.platform_ops = &xil_gpio_platform_ops;
+#else
+	gpio_init_plddrbypass.platform_ops = &altera_gpio_platform_ops;
+#endif
 	gpio_init_plddrbypass.number = DAC_FIFO_BYPASS_GPIO;
 	status = gpio_get(&gpio_plddrbypass, &gpio_init_plddrbypass);
 	if (status) {

--- a/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
+++ b/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
@@ -67,7 +67,17 @@ adiHalErr_t ADIHAL_openHw(void *devHalInfo, uint32_t halTimeout_ms)
 	int32_t status = 0;
 
 	gpio_adrv_resetb_param.number = dev_hal_data->gpio_adrv_resetb_num;
+#ifndef ALTERA_PLATFORM
+	gpio_adrv_resetb_param.platform_ops = &xil_gpio_platform_ops;
+#else
+	gpio_adrv_resetb_param.platform_ops = &altera_gpio_platform_ops;
+#endif
 	gpio_adrv_sysref_req_param.number = SYSREF_REQ_GPIO;
+#ifndef ALTERA_PLATFORM
+	gpio_adrv_sysref_req_param.platform_ops = &xil_gpio_platform_ops;
+#else
+	gpio_adrv_sysref_req_param.platform_ops = &altera_gpio_platform_ops;
+#endif
 
 	if (dev_hal_data->extra_gpio) {
 		gpio_adrv_resetb_param.extra = dev_hal_data->extra_gpio;

--- a/projects/fmcadc2/src.mk
+++ b/projects/fmcadc2/src.mk
@@ -23,10 +23,11 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
 	$(DRIVERS)/adc/ad9625/ad9625.c					\
 	$(DRIVERS)/spi/spi.c						\
+	$(DRIVERS)/gpio/gpio.c						\
 	$(NO-OS)/util/util.c
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
 	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
-	$(PLATFORM_DRIVERS)/gpio.c					\
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
 	$(PLATFORM_DRIVERS)/delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 SRCS += $(NO-OS)/util/xml.c						\

--- a/projects/fmcadc2/src/app/fmcadc2.c
+++ b/projects/fmcadc2/src/app/fmcadc2.c
@@ -97,6 +97,7 @@ int main(void)
 #endif
 		.device_id = GPIO_DEVICE_ID
 	};
+	gpio_sysref_param.platform_ops = &xil_gpio_platform_ops;
 	gpio_sysref_param.extra = &xil_gpio_param;
 
 	gpio_desc *gpio_sysref;

--- a/projects/fmcadc5/src.mk
+++ b/projects/fmcadc5/src.mk
@@ -24,10 +24,11 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
 	$(DRIVERS)/adc/ad9625/ad9625.c					\
 	$(DRIVERS)/spi/spi.c						\
+	$(DRIVERS)/gpio/gpio.c						\
 	$(NO-OS)/util/util.c
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
 	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
-	$(PLATFORM_DRIVERS)/gpio.c					\
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
 	$(PLATFORM_DRIVERS)/delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 SRCS += $(NO-OS)/util/xml.c						\

--- a/projects/fmcadc5/src/app/fmcadc5.c
+++ b/projects/fmcadc5/src/app/fmcadc5.c
@@ -94,22 +94,28 @@ int main(void)
 
 	// GPIO configuration
 	struct gpio_init_param gpio_sysref_param = {
-		.number = GPIO_JESD204_SYSREF
+		.number = GPIO_JESD204_SYSREF,
+		.platform_ops = &xil_gpio_platform_ops
 	};
 	struct gpio_init_param gpio_rst_0_param = {
-		.number = GPIO_RST_0
+		.number = GPIO_RST_0,
+		.platform_ops = &xil_gpio_platform_ops
 	};
 	struct gpio_init_param gpio_rst_1_param = {
-		.number = GPIO_RST_1
+		.number = GPIO_RST_1,
+		.platform_ops = &xil_gpio_platform_ops
 	};
 	struct gpio_init_param gpio_pwdn_0_param = {
-		.number = GPIO_PWDN_0
+		.number = GPIO_PWDN_0,
+		.platform_ops = &xil_gpio_platform_ops
 	};
 	struct gpio_init_param gpio_pwdn_1_param = {
-		.number = GPIO_PWDN_1
+		.number = GPIO_PWDN_1,
+		.platform_ops = &xil_gpio_platform_ops
 	};
 	struct gpio_init_param gpio_pwr_good_param = {
-		.number = GPIO_PWR_GOOD
+		.number = GPIO_PWR_GOOD,
+		.platform_ops = &xil_gpio_platform_ops
 	};
 
 	struct xil_gpio_init_param xil_gpio_param = {

--- a/projects/fmcdaq2/src.mk
+++ b/projects/fmcdaq2/src.mk
@@ -27,10 +27,11 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
 	$(DRIVERS)/adc/ad9680/ad9680.c					\
 	$(DRIVERS)/dac/ad9144/ad9144.c					\
 	$(DRIVERS)/spi/spi.c						\
+	$(DRIVERS)/gpio/gpio.c						\
 	$(NO-OS)/util/util.c
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
 	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
-	$(PLATFORM_DRIVERS)/gpio.c					\
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
 	$(PLATFORM_DRIVERS)/delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 SRCS += $(NO-OS)/util/xml.c						\

--- a/projects/fmcdaq2/src/app/fmcdaq2.c
+++ b/projects/fmcdaq2/src/app/fmcdaq2.c
@@ -301,16 +301,20 @@ int main(void)
 
 	/* Initialize GPIO structures */
 	struct gpio_init_param clkd_sync_param = {
-		.number = GPIO_CLKD_SYNC
+		.number = GPIO_CLKD_SYNC,
+		.platform_ops = &xil_gpio_platform_ops
 	};
 	struct gpio_init_param dac_reset_param = {
-		.number = GPIO_DAC_RESET
+		.number = GPIO_DAC_RESET,
+		.platform_ops = &xil_gpio_platform_ops
 	};
 	struct gpio_init_param dac_txen_param = {
-		.number = GPIO_DAC_TXEN
+		.number = GPIO_DAC_TXEN,
+		.platform_ops = &xil_gpio_platform_ops
 	};
 	struct gpio_init_param adc_pd_param = {
-		.number = GPIO_ADC_PD
+		.number = GPIO_ADC_PD,
+		.platform_ops = &xil_gpio_platform_ops
 	};
 
 #ifndef ALTERA_PLATFORM

--- a/projects/fmcdaq3/src.mk
+++ b/projects/fmcdaq3/src.mk
@@ -27,10 +27,11 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
 	$(DRIVERS)/adc/ad9680/ad9680.c					\
 	$(DRIVERS)/dac/ad9152/ad9152.c					\
 	$(DRIVERS)/spi/spi.c						\
+	$(DRIVERS)/gpio/gpio.c						\
 	$(NO-OS)/util/util.c
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
 	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
-	$(PLATFORM_DRIVERS)/gpio.c					\
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
 	$(PLATFORM_DRIVERS)/delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 SRCS += $(NO-OS)/util/xml.c						\

--- a/projects/fmcdaq3/src/app/fmcdaq3.c
+++ b/projects/fmcdaq3/src/app/fmcdaq3.c
@@ -132,7 +132,7 @@ int main(void)
 
 	/* Initialize GPIO structures */
 	struct gpio_init_param dac_txen_param = {
-		.number = GPIO_DAC_TXEN
+		.number = GPIO_DAC_TXEN,
 	};
 
 	struct gpio_init_param adc_pd_param = {
@@ -149,7 +149,9 @@ int main(void)
 		.device_id = GPIO_DEVICE_ID
 	};
 	dac_txen_param.extra = &xil_gpio_param;
+	dac_txen_param.platform_ops = &xil_gpio_platform_ops;
 	adc_pd_param.extra = &xil_gpio_param;
+	adc_pd_param.platform_ops = &xil_gpio_platform_ops;
 #else
 	struct altera_gpio_init_param altera_gpio_param = {
 		.base_address = GPIO_BASEADDR,
@@ -157,7 +159,9 @@ int main(void)
 		.device_id = GPIO_DEVICE_ID
 	};
 	dac_txen_param.extra = &altera_gpio_param;
+	dac_txen_param.platform_ops = &altera_gpio_platform_ops;
 	adc_pd_param.extra = &altera_gpio_param;
+	adc_pd_param.platform_ops = &altera_gpio_platform_ops;
 #endif
 
 	gpio_desc *dac_txen;

--- a/projects/fmcjesdadc1/src.mk
+++ b/projects/fmcjesdadc1/src.mk
@@ -23,12 +23,13 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
 	$(DRIVERS)/io-expander/demux_spi/demux_spi.c			\
 	$(DRIVERS)/spi/spi.c						\
+	$(DRIVERS)/gpio/gpio.c						\
 	$(DRIVERS)/adc/ad9250/ad9250.c					\
 	$(DRIVERS)/frequency/ad9517/ad9517.c				\
 	$(NO-OS)/util/util.c
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
 	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
-	$(PLATFORM_DRIVERS)/gpio.c					\
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
 	$(PLATFORM_DRIVERS)/delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 SRCS += $(NO-OS)/util/xml.c						\

--- a/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
+++ b/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
@@ -118,7 +118,8 @@ int main(void)
 	ad9517_spi_param.extra = &demux_spi_param;
 
 	struct gpio_init_param gpio_sysref_param = {
-		.number = GPIO_JESD204_SYSREF
+		.number = GPIO_JESD204_SYSREF,
+		.platform_ops = &xil_gpio_platform_ops
 	};
 
 	struct xil_gpio_init_param xil_gpio_param = {


### PR DESCRIPTION
Add generic gpio structure that aims to point to the gpio platform
specific functions.

Implement generic GPIO functions based on the new interface.

Update gpio dependent projects accordingly.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>