### PR TITLE
tools:scripst:generic.mk: Refer to mk files relative to noos path

### DIFF
--- a/tools/scripts/generic.mk
+++ b/tools/scripts/generic.mk
@@ -50,14 +50,14 @@ INCS     := $(filter-out $(ALL_IGNORED_FILES),$(INCS))
 
 ifeq (aducm3029,$(strip $(PLATFORM)))
 #Aducm3029 makefile
-include ../../tools/scripts/aducm.mk
+include $(NO-OS)/tools/scripts/aducm.mk
 
 else
 #Xilnx and altera makefiles
 ifeq ($(OS), Windows_NT)
-include ../../tools/scripts/windows.mk
+include $(NO-OS)/tools/scripts/windows.mk
 else
-include ../../tools/scripts/linux.mk
+include $(NO-OS)/tools/scripts/linux.mk
 endif #($(OS), Windows_NT)
 
 endif #(aducm3029,$(strip $(PLATFORM)))


### PR DESCRIPTION
This will enable set NO-OS variable anywhere and don't brake
the build. The first usecase for the change is the adicup repository
which uses noos as submodule

Signed-off-by: Mihail Chindris <Mihail.Chindris@analog.com>