### PR TITLE
ad469x: Update makefile according to gpio changes

### DIFF
--- a/projects/ad469x_fmcz/src.mk
+++ b/projects/ad469x_fmcz/src.mk
@@ -11,6 +11,7 @@
 
 SRCS := $(PROJECT)/src/ad469x_fmcz.c
 SRCS += $(DRIVERS)/spi/spi.c						\
+	$(DRIVERS)/gpio/gpio.c						\
 	$(DRIVERS)/adc/ad469x/ad469x.c					\
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
 	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c		\
@@ -18,7 +19,7 @@ SRCS += $(DRIVERS)/spi/spi.c						\
 	$(DRIVERS)/axi_core/spi_engine/spi_engine.c			\
 	$(NO-OS)/util/util.c
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/gpio.c					\
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
 	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
 	$(PLATFORM_DRIVERS)/delay.c
 INCS += $(PROJECT)/src/parameters.h

--- a/projects/ad469x_fmcz/src/ad469x_fmcz.c
+++ b/projects/ad469x_fmcz/src/ad469x_fmcz.c
@@ -103,6 +103,7 @@ int main()
 
 	struct gpio_init_param ad469x_resetn = {
 		.number = GPIO_RESETN_1,
+		.platform_ops = &xil_gpio_platform_ops,
 		.extra = &gpio_extra_param
 	};
 


### PR DESCRIPTION
Add files for gpio generic interface.
Fixes: 4e38848

Signed-off-by: Cristian Pop <cristian.pop@analog.com>