### PR TITLE
projects: ad400x: remove gpio from makefile

### DIFF
--- a/projects/ad400x-fmcz/src.mk
+++ b/projects/ad400x-fmcz/src.mk
@@ -11,13 +11,11 @@
 
 SRCS := $(PROJECT)/src/ad400x_fmcz.c
 SRCS += $(DRIVERS)/spi/spi.c						\
-	$(DRIVERS)/gpio/gpio.c						\
 	$(DRIVERS)/adc/ad400x/ad400x.c					\
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
 	$(DRIVERS)/axi_core/spi_engine/spi_engine.c			\
 	$(NO-OS)/util/util.c
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
 	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
 	$(PLATFORM_DRIVERS)/delay.c
 INCS += $(DRIVERS)/adc/ad400x/ad400x.h					\


### PR DESCRIPTION
The gpio driver is not used by the project, nor the driver.

Fixes: 95e03af

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>