### PR TITLE
tools:scripts:src_model: fix IGNORED_FILES variable

### DIFF
--- a/tools/scripts/src_model.mk
+++ b/tools/scripts/src_model.mk
@@ -20,7 +20,7 @@ INCS += $(PROJECT)/src/main.h
 SRC_DIRS += $(PLATFORM_DRIVERS)
 
 # Add to IGNORE_FILES files to be ignored from build
-IGNORE_FILES += $(PLATFORM_DRIVERS)/irq.c
+IGNORED_FILES += $(PLATFORM_DRIVERS)/irq.c
 
 # Add to LIBRARIES the libraries that need to be linked in the build
 # LIBRARIES += mqtt


### PR DESCRIPTION
The generic.mk file actually looks for the variable IGNORED_FILES instead
of IGNORE_FILES. https://github.com/analogdevicesinc/no-OS/blob/master/tools/scripts/generic.mk#L47
Change example accordingly.

Signed-off-by: Andrei Drimbarean <Andrei.Drimbarean@analog.com>