### PR TITLE
drivers: gpio_get_optional fix

### DIFF
--- a/drivers/gpio/gpio.c
+++ b/drivers/gpio/gpio.c
@@ -75,8 +75,10 @@ int32_t gpio_get(struct gpio_desc **desc,
 int32_t gpio_get_optional(struct gpio_desc **desc,
 			  const struct gpio_init_param *param)
 {
-	if (!param)
-		return FAILURE;
+	if (!param) {
+		*desc = NULL;
+		return SUCCESS;
+	}
 
 	if ((param->platform_ops->gpio_ops_get_optional(desc, param)))
 		return FAILURE;


### PR DESCRIPTION
The check of the initialization parameters should be
performed properly before accessing the platform specific function.

The check is kept also inside each platform specific function to make
sure that the drivers still work if used independently on the generic
gpio interface.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>