### PR TITLE
drivers: axi_adxcvr: Typo fix

### DIFF
--- a/drivers/axi_core/jesd204/axi_adxcvr.c
+++ b/drivers/axi_core/jesd204/axi_adxcvr.c
@@ -366,7 +366,7 @@ int32_t adxcvr_init(struct adxcvr **ad_xcvr,
 			xcvr->xlx_xcvr.type = XILINX_XCVR_TYPE_US_GTH3;
 			break;
 		case XILINX_XCVR_LEGACY_TYPE_US_GTH4:
-			xcvr->xlx_xcvr.type = XILINX_XCVR_TYPE_US_GTH3;
+			xcvr->xlx_xcvr.type = XILINX_XCVR_TYPE_US_GTH4;
 			break;
 		case XILINX_XCVR_LEGACY_TYPE_US_GTY4:
 			xcvr->xlx_xcvr.type = XILINX_XCVR_TYPE_US_GTY4;


### PR DESCRIPTION
Reported here: https://github.com/analogdevicesinc/no-OS/pull/772

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>