### PR TITLE
Ad469x fixes

### DIFF
--- a/drivers/adc/ad469x/ad469x.c
+++ b/drivers/adc/ad469x/ad469x.c
@@ -639,7 +639,7 @@ error_gpio:
 error_clkgen:
 	axi_clkgen_remove(dev->clkgen);
 error_dev:
-	ad469x_remove(dev);
+	free(dev);
 
 	return FAILURE;
 }

--- a/drivers/adc/ad469x/ad469x.c
+++ b/drivers/adc/ad469x/ad469x.c
@@ -149,7 +149,7 @@ int32_t ad469x_spi_read_mask(struct ad469x_dev *dev,
 	if (ret != SUCCESS)
 		return ret;
 
-	*data = (reg_data[1] & mask);
+	*data = (reg_data[0] & mask);
 
 	return ret;
 }


### PR DESCRIPTION
Fix memory deallocation inside `ad469x_init` function.
Fix `ad469x_spi_read_mask` function.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>