### PR TITLE
drivers: jesd204: axi_adxcvr: Fix adxcvr_init return

### DIFF
--- a/drivers/axi_core/jesd204/axi_adxcvr.c
+++ b/drivers/axi_core/jesd204/axi_adxcvr.c
@@ -411,7 +411,7 @@ int32_t adxcvr_init(struct adxcvr **ad_xcvr,
 	if (xcvr->lane_rate_khz && xcvr->ref_rate_khz) {
 		ret = adxcvr_clk_set_rate(xcvr, xcvr->lane_rate_khz, xcvr->ref_rate_khz);
 		if (ret)
-			return ret;
+			goto err;
 	}
 
 	*ad_xcvr = xcvr;


### PR DESCRIPTION
In a case where the adxcvr_clk_set_rate() will fail to find a satyisfying
lane rate, the function will return an error code, without saving the xcvr
descriptor to the given address.
This change first assigns the descriptor and returns the error code after.

Signed-off-by: Sergiu Cuciurean <sergiu.cuciurean@analog.com>