### PR TITLE
iio: Generate "scan-element" only for streaming channels

### DIFF
--- a/iio/iio_demo/iio_demo_dev.h
+++ b/iio/iio_demo/iio_demo_dev.h
@@ -60,16 +60,18 @@ static struct iio_attribute *demo_channel_attributes[] = {
 	NULL,
 };
 
+static struct scan_type scan_type = {
+	.sign = 's',
+	.realbits = 12,
+	.storagebits = 16,
+	.shift = 0,
+	.is_big_endian = false
+};
+
 static struct iio_channel iio_demo_channel_voltage0_in = {
 	.name = "input_channel",
 	.scan_index = 0,
-	.scan_type = {
-		.sign = 's',
-		.realbits = 12,
-		.storagebits = 16,
-		.shift = 0,
-		.is_big_endian = false
-	},
+	.scan_type = &scan_type,
 	.attributes = demo_channel_attributes,
 	.ch_out = false,
 };
@@ -77,13 +79,7 @@ static struct iio_channel iio_demo_channel_voltage0_in = {
 static struct iio_channel iio_demo_channel_voltage0_out = {
 	.name = "output_channel",
 	.scan_index = 0,
-	.scan_type = {
-		.sign = 's',
-		.realbits = 12,
-		.storagebits = 16,
-		.shift = 0,
-		.is_big_endian = false
-	},
+	.scan_type = &scan_type,
 	.attributes = demo_channel_attributes,
 	.ch_out = true,
 };

--- a/libraries/iio/iio.c
+++ b/libraries/iio/iio.c
@@ -842,15 +842,16 @@ static uint32_t iio_generate_device_xml(struct iio_device *device, char *name,
 				      ch_id, ch->name,
 				      ch->ch_out ? "output" : "input");
 
-			i += snprintf(buff + i, max(n - i, 0),
-				      "<scan-element index=\"%d\""
-				      " format=\"%s:%c%d/%d&gt;&gt;%d\" />",
-				      ch->scan_index,
-				      ch->scan_type.is_big_endian ? "be" : "le",
-				      ch->scan_type.sign,
-				      ch->scan_type.realbits,
-				      ch->scan_type.storagebits,
-				      ch->scan_type.shift);
+			if (ch->scan_type)
+				i += snprintf(buff + i, max(n - i, 0),
+					      "<scan-element index=\"%d\""
+					      " format=\"%s:%c%d/%d&gt;&gt;%d\" />",
+					      ch->scan_index,
+					      ch->scan_type->is_big_endian ? "be" : "le",
+					      ch->scan_type->sign,
+					      ch->scan_type->realbits,
+					      ch->scan_type->storagebits,
+					      ch->scan_type->shift);
 
 			/* Write channel attributes */
 			if (ch->attributes)

--- a/libraries/iio/iio_types.h
+++ b/libraries/iio/iio_types.h
@@ -118,7 +118,7 @@ struct iio_channel {
 	/** Index to give ordering in scans when read  from a buffer. */
 	int			scan_index;
 	/** */
-	struct scan_type	scan_type;
+	struct scan_type	*scan_type;
 	/** list of attributes */
 	struct iio_attribute **attributes;
 	/** if true, the channel is an output channel */


### PR DESCRIPTION
This attribute is necessary only for channels that allows reading or
writing data streams. It specifies the way data is packed, endianness,util
bits, sign, shift ...

Signed-off-by: Cristian Pop <cristian.pop@analog.com>