### PR TITLE
.gitignore: Add more files to be excluded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,10 @@ build
 dfp_drivers
 aducm_project
 aducm_build
+.vscode
 
+*.a
+*.o
+*.d
+*.hex
+*.hdf


### PR DESCRIPTION
These files are binary file and there is no need to be tracked by git.

Signed-off-by: Mihail Chindris <mihail.chindris@analog.com>