### PR TITLE
libraries:iio: Add modifier to channel type.

### DIFF
--- a/libraries/iio/iio.c
+++ b/libraries/iio/iio.c
@@ -94,6 +94,11 @@ static char header[] =
 	"<context-attribute name=\"no-OS\" value=\"1.1.0-g0000000\" />";
 static char header_end[] = "</context>";
 
+static const char * const iio_modifier_names[] = {
+	[IIO_MOD_X] = "x",
+	[IIO_MOD_Y] = "y",
+};
+
 /* Parameters used in show and store functions */
 struct attr_fun_params {
 	void			*dev_instance;
@@ -315,10 +320,16 @@ static char *get_channel_id(enum iio_chan_type type)
 
 static inline void _print_ch_id(char *buff, struct iio_channel *ch)
 {
-	if(ch->indexed) {
-		sprintf(buff, "%s%d", get_channel_id(ch->ch_type), (int)ch->channel);
+	if(ch->modified) {
+		sprintf(buff, "%s_%s", get_channel_id(ch->ch_type),
+			iio_modifier_names[ch->channel2]);
 	} else {
-		sprintf(buff, "%s", get_channel_id(ch->ch_type));
+		if(ch->indexed) {
+			sprintf(buff, "%s%d", get_channel_id(ch->ch_type),
+				(int)ch->channel);
+		} else {
+			sprintf(buff, "%s", get_channel_id(ch->ch_type));
+		}
 	}
 }
 

--- a/libraries/iio/iio.c
+++ b/libraries/iio/iio.c
@@ -305,6 +305,10 @@ static char *get_channel_id(enum iio_chan_type type)
 		return "current";
 	case IIO_ALTVOLTAGE:
 		return "altvoltage";
+	case IIO_ANGL_VEL:
+		return "anglvel";
+	case IIO_TEMP:
+		return "temp";
 	}
 
 	return "";

--- a/libraries/iio/iio_types.h
+++ b/libraries/iio/iio_types.h
@@ -66,6 +66,17 @@ enum iio_chan_type {
 };
 
 /**
+ * @struct iio_modifier
+ * @brief IIO channel modifier
+ */
+enum iio_modifier {
+	IIO_NO_MOD,
+	IIO_MOD_X,
+	IIO_MOD_Y,
+	IIO_MOD_Z,
+};
+
+/**
  * @struct iio_ch_info
  * @brief Structure holding channel attributess.
  */

--- a/libraries/iio/iio_types.h
+++ b/libraries/iio/iio_types.h
@@ -59,6 +59,8 @@ enum iio_chan_type {
 	IIO_VOLTAGE,
 	IIO_CURRENT,
 	IIO_ALTVOLTAGE,
+	IIO_ANGL_VEL,
+	IIO_TEMP,
 	/* All new types must be added before this field */
 	IIO_LAST_TYPE
 };

--- a/libraries/iio/iio_types.h
+++ b/libraries/iio/iio_types.h
@@ -117,6 +117,12 @@ struct iio_channel {
 	char			*name;
 	/** Chanel type */
 	enum iio_chan_type	ch_type;
+	/** Channel number when the same channel type */
+	int 			channel;
+	/** If modified is set, this provides the modifier. E.g. IIO_MOD_X
+	 *  for angular rate when applied to channel2 will make make the
+	 *  IIO_ANGL_VEL have anglvel_x which corresponds to the x-axis. */
+	int 			channel2;
 	/** Index to give ordering in scans when read  from a buffer. */
 	int			scan_index;
 	/** */
@@ -127,6 +133,12 @@ struct iio_channel {
 	bool ch_out;
 	/** Reserved. Id offset */
 	int32_t reserved;
+	/** Set if channel has a modifier. Use channel2 property to
+	 *  select the modifier to use.*/
+	bool			modified;
+	/** Specify if channel has a numerical index. If not set, channel
+	 *  number will be suppressed. */
+	bool			indexed;
 };
 
 /**

--- a/libraries/iio/iio_types.h
+++ b/libraries/iio/iio_types.h
@@ -128,11 +128,9 @@ struct iio_channel {
 	/** */
 	struct scan_type	*scan_type;
 	/** list of attributes */
-	struct iio_attribute **attributes;
+	struct iio_attribute	**attributes;
 	/** if true, the channel is an output channel */
-	bool ch_out;
-	/** Reserved. Id offset */
-	int32_t reserved;
+	bool			ch_out;
 	/** Set if channel has a modifier. Use channel2 property to
 	 *  select the modifier to use.*/
 	bool			modified;


### PR DESCRIPTION
Added channel properties to make it as close as possible to linux iio:
- .channel
- .channel2
- .modified
- .indexed

The modified is a property used in linux iio on the channel spec that 
when set to true, the channel2 property is used as the selector for the
modifier. For example, if the type is IIO_ANGL_VEL this will use 
"anglvel" as the channel type. If modified is true and channel2 is set 
to IIO_MOD_X, the type becomes "anglvel_x".

This also affects the indexing which uses the channel and indexed 
property were added. if channel indexed is true, the value set in the 
channel property is attached to the channel. For example, "altvoltage1"
is channel type altvoltage, channel=1 and indexed=true.

Signed-off-by: Kister Jimenez <kister.jimenez@analog.com>