### PR TITLE
spi_engine: update write/read function

### DIFF
--- a/drivers/adc/ad400x/ad400x.c
+++ b/drivers/adc/ad400x/ad400x.c
@@ -80,7 +80,7 @@ int32_t ad400x_spi_reg_read(struct ad400x_dev *dev,
 	spi_engine_set_speed(dev->spi_desc, dev->reg_access_speed);
 
 	ret = spi_write_and_read(dev->spi_desc, buf, 2);
-	*reg_data = buf[0];
+	*reg_data = buf[1];
 
 	spi_engine_set_speed(dev->spi_desc, dev->spi_desc->max_speed_hz);
 

--- a/drivers/adc/ad469x/ad469x.c
+++ b/drivers/adc/ad469x/ad469x.c
@@ -92,7 +92,7 @@ int32_t ad469x_spi_reg_read(struct ad469x_dev *dev,
 	buf[2] = 0xFF;
 
 	ret = spi_write_and_read(dev->spi_desc, buf, 3);
-	*reg_data = buf[1];
+	*reg_data = buf[2];
 
 	ret = spi_engine_set_transfer_width(dev->spi_desc,
 					    dev->capture_data_width);

--- a/drivers/adc/ad7768-1/ad77681.c
+++ b/drivers/adc/ad7768-1/ad77681.c
@@ -143,7 +143,7 @@ int32_t ad77681_spi_reg_read(struct ad77681_dev *dev,
 	}
 
 	reg_data[0] = AD77681_REG_READ(reg_addr);
-	memcpy(reg_data + 1, buf, ARRAY_SIZE(buf) - 1);
+	memcpy(reg_data + 1, buf + 1, ARRAY_SIZE(buf) - 1);
 
 	return ret;
 }

--- a/drivers/axi_core/spi_engine/spi_engine.c
+++ b/drivers/axi_core/spi_engine/spi_engine.c
@@ -736,11 +736,10 @@ int32_t spi_engine_write_and_read(struct spi_desc *desc,
 
 	ret = spi_engine_transfer_message(desc, &msg);
 
-	/* Skip the first byte ( dummy read byte ) */
-	for (i = 1; i < bytes_number; i++)
-		data[i - 1] = msg.rx_buf[(i) / word_len] >>
-			      (desc_extra->data_width -
-			       ((i) % word_len + 1) * 8);
+	for (i = 0; i < bytes_number; i++)
+		data[i] = msg.rx_buf[(i) / word_len] >>
+			  (desc_extra->data_width -
+			   ((i) % word_len + 1) * 8);
 
 	spi_engine_queue_free(&msg.cmds);
 	free(msg.tx_buf);


### PR DESCRIPTION
Do not skip the first byte. This implies shifting the data byte in each
driver that uses SPI Engine when performing a read operation.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>