### PR TITLE
adc: ad7768-1: remove `spi_read_interrupt_data`

### DIFF
--- a/drivers/adc/ad7768-1/ad77681.h
+++ b/drivers/adc/ad7768-1/ad77681.h
@@ -634,8 +634,6 @@ int32_t ad77681_clear_error_flags(struct ad77681_dev *dev);
 int32_t ad77681_data_to_voltage(struct ad77681_dev *dev,
 				int32_t *raw_code,
 				double *voltage);
-int32_t ad77681_spi_read_interrupt_adc_data(struct ad77681_dev *dev,
-		struct adc_data *measured_data);
 int32_t ad77681_CRC_status_handling(struct ad77681_dev *dev,
 				    uint16_t *data_buffer);
 int32_t ad77681_set_AINn_buffer(struct ad77681_dev *dev,


### PR DESCRIPTION
Remove the function since it uses `spi_read_cont_data` function that is
not implemented in the no-OS spi drivers.

An example of using the driver in continous mode with SPI Engine offload
transfer is available at:
https://github.com/analogdevicesinc/no-OS/blob/master/projects/ad7768-1fmcz/src/ad77681evb.c

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>