### PR TITLE
include: print_log: fix typo

### DIFF
--- a/include/print_log.h
+++ b/include/print_log.h
@@ -104,7 +104,7 @@ fmt, __FILE__, __func__, __LINE__, ##args)
 #define pr_debug(fmt, args...) printf("DEBUG: %s:%s:%d(): " \
 fmt, __FILE__, __func__, __LINE__, ##args)
 #else
-#define pr_info(fmt, args...)
+#define pr_debug(fmt, args...)
 #endif
 
 #endif /* PRINT_LOG_H_ */


### PR DESCRIPTION
Replace pr_info with pr_debug for the debug log level.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>