### PR TITLE
drivers:platform:xilinx: fix gpio_get_optional bug

### DIFF
--- a/drivers/platform/xilinx/xilinx_gpio.c
+++ b/drivers/platform/xilinx/xilinx_gpio.c
@@ -195,7 +195,7 @@ int32_t xil_gpio_get_optional(struct gpio_desc **desc,
 		return SUCCESS;
 	}
 
-	return gpio_get(desc, param);
+	return xil_gpio_get(desc, param);
 }
 
 /**


### PR DESCRIPTION
The 'xil_gpio_get_optional' method should use 'xil_gpio_get' instead of the
outdated 'gpio_get'.

Signed-off-by: Andrei Drimbarean <Andrei.Drimbarean@analog.com>