### PR TITLE
Update ad9361.c for ad9361_rfpll_vco_init rx table init

### DIFF
--- a/drivers/rf-transceiver/ad9361/ad9361.c
+++ b/drivers/rf-transceiver/ad9361/ad9361.c
@@ -1746,6 +1746,12 @@ static int32_t ad9361_rfpll_vco_init(struct ad9361_rf_phy *phy,
 				phy->current_tx_use_tdd_table = true;
 			else
 				phy->current_rx_use_tdd_table = true;
+		} else {
+			tab = &SynthLUT_FDD[range][0];
+			if (tx)
+				phy->current_tx_use_tdd_table = false;
+			else
+				phy->current_rx_use_tdd_table = false;
 		}
 	}
 


### PR DESCRIPTION
if `phy->current_tx_lo_freq == phy->current_rx_lo_freq` on the `ad9361_init()`, the `ad9361_rfpll_vco_init()`'s **rx lo tab** is not initialized.