### PR TITLE
travis: remove build jobs for ad9361 project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ env:
   matrix:
     - BUILD_TYPE=astyle
     - BUILD_TYPE=cppcheck
-    - BUILD_TYPE=ad9361_generic
-    - BUILD_TYPE=ad9361_linux
     - BUILD_TYPE=drivers
     - BUILD_TYPE=doxygen
 

--- a/ci/travis/run_build.sh
+++ b/ci/travis/run_build.sh
@@ -14,16 +14,6 @@ build_cppcheck() {
     . ./ci/travis/cppcheck.sh
 }
 
-build_ad9361_generic() {
-    sudo apt-get install libmatio-dev
-    make -C ./ad9361/sw -f Makefile.generic
-}
-
-build_ad9361_linux() {
-    sudo apt-get install libmatio-dev
-    make -C ./ad9361/sw -f Makefile.linux
-}
-
 build_drivers() {
     sudo apt-get install gcc-arm-none-eabi libnewlib-arm-none-eabi
     make -C ./drivers -f Makefile


### PR DESCRIPTION
With #810 the old makefiles for ad9361 project were removed.

The build jobs ad9361_generic and ad9361_linux are no longer valid.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>