### PR TITLE
drivers: makefile: include axi_dac_core.h

### DIFF
--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -11,6 +11,7 @@ INCLUDES = -I../include/ \
 	 -I./adc/ad9208/ad9208_api \
 	 -I./adc/ad9081/api \
 	 -I./axi_core/axi_adc_core \
+	 -I./axi_core/axi_dac_core \
 	 -I./axi_core/spi_engine \
 	 -I./axi_core/clk_axi_clkgen \
 	 -I./platform/xilinx \


### PR DESCRIPTION
The file is required by the rf-transciver/ad9361 driver.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>