### PR TITLE
Adxrs290 support

### DIFF
--- a/drivers/gyro/adxrs290/adxrs290.c
+++ b/drivers/gyro/adxrs290/adxrs290.c
@@ -1,0 +1,321 @@
+/***************************************************************************//**
+ *   @file   adxrs290.c
+ *   @brief  Implementation of ADXRS290 Driver.
+ *   @author Kister Genesis Jimenez (kister.jimenez@analog.com)
+********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include "error.h"
+#include "adxrs290.h"
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+/**
+ * @brief Read device register.
+ * @param dev - Device handler.
+ * @param address - Register address.
+ * @param data - Pointer to the register value container.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t adxrs290_reg_read(struct adxrs290_dev *dev, uint8_t address,
+			  uint8_t *data)
+{
+	int32_t ret = SUCCESS;
+	uint8_t buff[] = {address | 0x80, 0};
+
+	ret = spi_write_and_read(dev->spi_desc, buff, 2);
+	if (IS_ERR_VALUE(ret))
+		return FAILURE;
+
+	*data = buff[1];
+
+	return SUCCESS;
+}
+
+/**
+ * @brief Write device register.
+ * @param dev - Device handler.
+ * @param address - Register address.
+ * @param data - New register value.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t adxrs290_reg_write(struct adxrs290_dev *dev, uint8_t address,
+			   uint8_t data)
+{
+	uint8_t buff[] = {address & 0x7F, data};
+
+	return spi_write_and_read(dev->spi_desc, buff, 2);
+}
+
+/**
+ * @brief Set device operation mode.
+ * @param dev - Device handler.
+ * @param mode - mode of operation.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t adxrs290_set_op_mode(struct adxrs290_dev *dev, enum adxrs290_mode mode)
+{
+	int32_t ret = SUCCESS;
+	uint8_t val = 0;
+
+	ret = adxrs290_reg_read(dev, ADXRS290_REG_POWER_CTL, &val);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	switch(mode) {
+	case ADXRS290_MODE_STANDBY:
+		val &= ~ADXRS290_MEASUREMENT;
+		break;
+	case ADXRS290_MODE_MEASUREMENT:
+		val |= ADXRS290_MEASUREMENT;
+		break;
+	default:
+		return FAILURE;
+	}
+
+	return adxrs290_reg_write(dev, ADXRS290_REG_POWER_CTL, val);
+}
+
+/**
+ * @brief Get the low-pass filter pole location.
+ * @param dev - Device handler.
+ * @param lpf - Pointer to Low-pass pole location container.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t adxrs290_get_lpf(struct adxrs290_dev *dev, enum adxrs290_lpf *lpf)
+{
+	int32_t ret = SUCCESS;
+	uint8_t data;
+
+	ret = adxrs290_reg_read(dev, ADXRS290_REG_FILTER, &data);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	*lpf = ADXRS290_LPF(data);
+
+	return ret;
+}
+
+/**
+ * @brief Set the low-pass filter pole location.
+ * @param dev - Device handler.
+ * @param lpf - Low-pass pole location.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t adxrs290_set_lpf(struct adxrs290_dev *dev, enum adxrs290_lpf lpf)
+{
+	int32_t ret = SUCCESS;
+	uint8_t reg_val;
+
+	ret = adxrs290_reg_read(dev, ADXRS290_REG_FILTER, &reg_val);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	reg_val &= ~ADXRS290_LPF_MASK;
+	reg_val |= lpf & ADXRS290_LPF_MASK;
+
+	return adxrs290_reg_write(dev, ADXRS290_REG_FILTER, reg_val);
+}
+
+/**
+ * @brief Get the high-pass filter pole location.
+ * @param dev - Device handler.
+ * @param hpf - Pointer to high-pass pole location container.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t adxrs290_get_hpf(struct adxrs290_dev *dev, enum adxrs290_hpf *hpf)
+{
+	int32_t ret = SUCCESS;
+	uint8_t data;
+
+	ret = adxrs290_reg_read(dev, ADXRS290_REG_FILTER, &data);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	*hpf = ADXRS290_HPF(data);
+
+	return ret;
+}
+
+/**
+ * @brief Set the low-pass filter pole location.
+ * @param dev - Device handler.
+ * @param hpf - High-pass pole location.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t adxrs290_set_hpf(struct adxrs290_dev *dev, enum adxrs290_hpf hpf)
+{
+	int32_t ret = SUCCESS;
+	uint8_t reg_val;
+
+	ret = adxrs290_reg_read(dev, ADXRS290_REG_FILTER, &reg_val);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	reg_val &= ~ADXRS290_HPF_MASK;
+	reg_val |= (hpf << 4) & ADXRS290_HPF_MASK;
+
+	return adxrs290_reg_write(dev, ADXRS290_REG_FILTER, reg_val);
+}
+
+/**
+ * @brief Get the Gyro data channels.
+ * @param dev - Device handler.
+ * @param ch - Channel to read.
+ * @param rate - Pointer to rate value.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t adxrs290_get_rate_data(struct adxrs290_dev *dev,
+			       enum adxrs290_channel ch, int16_t *rate)
+{
+	int32_t ret = SUCCESS;
+	uint8_t data[3];
+
+	data[0] = 0x80 | (ADXRS290_REG_DATAX0+ch*2);
+	data[1] = 0x80 | (ADXRS290_REG_DATAX1+ch*2);
+	data[2] = 0;
+	ret = spi_write_and_read(dev->spi_desc, data, 3);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	*rate = (((int16_t)data[2]) << 8) | data[1];
+
+	return SUCCESS;
+}
+
+/**
+ * @brief Get the temperature data.
+ * @param dev - Device handler.
+ * @param temp - Pointer to temperature value.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t adxrs290_get_temp_data(struct adxrs290_dev *dev, int16_t *temp)
+{
+	int32_t ret = SUCCESS;
+	uint8_t data[3];
+
+	data[0] = 0x80 | ADXRS290_REG_TEMP0;
+	data[1] = 0x80 | ADXRS290_REG_TEMP1;
+	data[2] = 0;
+
+	ret = spi_write_and_read(dev->spi_desc, data, 3);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	*temp = ((((int16_t)data[2]) << 8) | data[1]) & 0x0FFF;
+	*temp = (*temp << 4) >> 4;
+
+	return ret;
+}
+
+/**
+ * Initialize the device.
+ * @param device - The device structure.
+ * @param init_param - The structure that contains the device initial
+ *		       parameters.
+ * @return SUCCESS in case of success, negative error code otherwise.
+ */
+int32_t adxrs290_init(struct adxrs290_dev **device,
+		      const struct adxrs290_init_param *init_param)
+{
+	struct adxrs290_dev *dev;
+	int32_t ret = 0;
+	uint8_t val = 0;
+
+	dev = (struct adxrs290_dev *)malloc(sizeof(*dev));
+	if (!dev)
+		return -ENOMEM;
+
+	ret = spi_init(&dev->spi_desc, &init_param->spi_init);
+	if (IS_ERR_VALUE(ret))
+		goto error_dev;
+
+	ret = adxrs290_reg_read(dev, ADXRS290_REG_DEV_ID, &val);
+	if (IS_ERR_VALUE(ret) || (val != ADXRS290_DEV_ID))
+		goto error_spi;
+
+	// Enable measurement mode.
+	if (init_param->mode == ADXRS290_MODE_MEASUREMENT) {
+		ret |= adxrs290_reg_write(dev, ADXRS290_REG_POWER_CTL,
+					  ADXRS290_MEASUREMENT | ADXRS290_TSM);
+		if (IS_ERR_VALUE(ret))
+			goto error_spi;
+
+	}
+	// Set initial Band pass filter poles.
+	ret |= adxrs290_set_lpf(dev, init_param->lpf);
+	if (IS_ERR_VALUE(ret))
+		goto error_spi;
+
+	ret |= adxrs290_set_hpf(dev, init_param->hpf);
+	if (IS_ERR_VALUE(ret))
+		goto error_spi;
+
+	*device = dev;
+
+	return ret;
+
+error_spi:
+	spi_remove(dev->spi_desc);
+
+error_dev:
+	free(dev);
+
+	return ret;
+}
+
+/**
+ * @brief Free memory allocated by adxrs290_setup().
+ * @param dev - Device handler.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t adxrs290_remove(struct adxrs290_dev *dev)
+{
+	spi_remove(dev->spi_desc);
+	free(dev);
+
+	return SUCCESS;
+}
+
+

--- a/drivers/gyro/adxrs290/adxrs290.h
+++ b/drivers/gyro/adxrs290/adxrs290.h
@@ -1,0 +1,222 @@
+/***************************************************************************//**
+ *   @file   adxrs290.h
+ *   @brief  Implementation of ADXRS290 Driver.
+ *   @author Kister Genesis Jimenez (kister.jimenez@analog.com)
+********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef ADXRS290_H_
+#define ADXRS290_H_
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <stdbool.h>
+#include "spi.h"
+#include "util.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+/* ADXRS290 ID */
+#define ADXRS290_ADI_ID				0xAD
+#define ADXRS290_MEMS_ID			0x1D
+#define ADXRS290_DEV_ID				0x92
+
+/* ADXRS290 Registers */
+#define ADXRS290_REG_ADI_ID			0x00
+#define ADXRS290_REG_MEMS_ID			0x01
+#define ADXRS290_REG_DEV_ID			0x02
+#define ADXRS290_REG_REV_ID			0x03
+#define ADXRS290_REG_SN0			0x04
+#define ADXRS290_REG_SN1			0x05
+#define ADXRS290_REG_SN2			0x06
+#define ADXRS290_REG_SN3			0x07
+#define ADXRS290_REG_DATAX0			0x08
+#define ADXRS290_REG_DATAX1			0x09
+#define ADXRS290_REG_DATAY0			0x0A
+#define ADXRS290_REG_DATAY1			0x0B
+#define ADXRS290_REG_TEMP0			0x0C
+#define ADXRS290_REG_TEMP1			0x0D
+
+#define ADXRS290_REG_POWER_CTL			0x10
+#define ADXRS290_REG_FILTER			0x11
+#define ADXRS290_REG_DATA_READY			0x12
+
+#define ADXRS290_READ				BIT(7)
+#define ADXRS290_TSM				BIT(0)
+#define ADXRS290_MEASUREMENT			BIT(1)
+#define ADXRS290_DATA_RDY_OUT			BIT(0)
+#define ADXRS290_SYNC_MASK			0x03
+#define ADXRS290_SYNC(x)			(x) & ADXRS290_SYNC_MASK
+#define ADXRS290_LPF_MASK			0x07
+#define ADXRS290_LPF(x)				(x) & ADXRS290_LPF_MASK
+#define ADXRS290_HPF_MASK			0xF0
+#define ADXRS290_HPF(x)				((x) & ADXRS290_HPF_MASK ) >> 4
+
+#define ADXRS290_READ_REG(reg)	(ADXRS290_READ | (reg))
+
+#define ADXRS290_MAX_TRANSITION_TIME_MS 100
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+
+/**
+ * @enum adxrs290_mode
+ * @brief Mode of the adxrs290
+ */
+enum adxrs290_mode {
+	/** Standby mode */
+	ADXRS290_MODE_STANDBY,
+	/** Measurement mode */
+	ADXRS290_MODE_MEASUREMENT,
+};
+
+/**
+ * @enum adxrs290_channel
+ * @brief Channel of teh adxrs290 data rate
+ */
+enum adxrs290_channel {
+	/** X-Axis */
+	ADXRS290_CHANNEL_X,
+	/** Y-Axis */
+	ADXRS290_CHANNEL_Y,
+	/** Temp */
+	ADXRS290_CHANNEL_TEMP,
+};
+
+/**
+ * @enum adxrs290_lpf
+ * @brief Low-Pass filter pole location
+ */
+enum adxrs290_lpf {
+	ADXRS290_LPF_480HZ,
+	ADXRS290_LPF_320HZ,
+	ADXRS290_LPF_160HZ,
+	ADXRS290_LPF_80HZ,
+	ADXRS290_LPF_56HZ6,
+	ADXRS290_LPF_40HZ,
+	ADXRS290_LPF_28HZ3,
+	ADXRS290_LPF_20HZ
+};
+
+/**
+ * @enum adxrs290_hpf
+ * @brief High-Pass filter pole location
+ */
+enum adxrs290_hpf {
+	ADXRS290_HPF_ALL_PASS,
+	ADXRS290_HPF_0HZ011,
+	ADXRS290_HPF_0HZ022,
+	ADXRS290_HPF_0HZ044,
+	ADXRS290_HPF_0HZ087,
+	ADXRS290_HPF_0HZ175,
+	ADXRS290_HPF_0HZ350,
+	ADXRS290_HPF_0HZ700,
+	ADXRS290_HPF_1HZ400,
+	ADXRS290_HPF_2HZ800,
+	ADXRS290_HPF_11HZ30
+};
+
+/**
+ * @struct adxrs290_init_param
+ * @brief Device driver initialization structure
+ */
+struct adxrs290_init_param {
+	/** SPI Initialization structure. */
+	struct spi_init_param	spi_init;
+	/** Initial Mode */
+	enum adxrs290_mode mode;
+	/** Initial lpf settings */
+	enum adxrs290_lpf lpf;
+	/** Initial hpf settings */
+	enum adxrs290_hpf hpf;
+
+};
+
+/**
+ * @struct adxrs290_dev
+ * @brief Device driver handler
+ */
+struct adxrs290_dev {
+	/** SPI handler */
+	struct spi_desc *spi_desc;
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+/* Read device register. */
+int32_t adxrs290_reg_read(struct adxrs290_dev *dev, uint8_t address,
+			  uint8_t *data);
+
+/* Write device register. */
+int32_t adxrs290_reg_write(struct adxrs290_dev *dev, uint8_t address,
+			   uint8_t data);
+
+/* Set mode */
+int32_t adxrs290_set_op_mode(struct adxrs290_dev *dev, enum adxrs290_mode mode);
+
+/* Get the low-pass filter pole location. */
+int32_t adxrs290_get_lpf(struct adxrs290_dev *dev, enum adxrs290_lpf *lpf);
+
+/* Set the low-pass filter pole location. */
+int32_t adxrs290_set_lpf(struct adxrs290_dev *dev, enum adxrs290_lpf lpf);
+
+/* Get the high-pass filter pole location. */
+int32_t adxrs290_get_hpf(struct adxrs290_dev *dev, enum adxrs290_hpf *hpf);
+
+/* Set the high-pass filter pole location. */
+int32_t adxrs290_set_hpf(struct adxrs290_dev *dev, enum adxrs290_hpf hpf);
+
+/* Read X or Y angular velocity data */
+int32_t adxrs290_get_rate_data(struct adxrs290_dev *dev,
+			       enum adxrs290_channel ch, int16_t *rate);
+
+/* Read Temperature data */
+int32_t adxrs290_get_temp_data(struct adxrs290_dev *dev, int16_t *temp);
+
+/* Init. the comm. peripheral and checks if the ADXRS290 part is present. */
+int32_t adxrs290_init(struct adxrs290_dev **device,
+		      const struct adxrs290_init_param *init_param);
+
+/* Free the resources allocated by adxrs290_init(). */
+int32_t adxrs290_remove(struct adxrs290_dev *dev);
+
+
+#endif /* ADXRS290_H_ */

--- a/iio/iio_adxrs290/iio_adxrs290.c
+++ b/iio/iio_adxrs290/iio_adxrs290.c
@@ -1,0 +1,212 @@
+/***************************************************************************//**
+ *   @file   iio_adxrs290.c
+ *   @brief  Implementation of ADXRS290 iio.
+ *   @author Kister Genesis Jimenez (kister.jimenez@analog.com)
+********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "iio_types.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include "adxrs290.h"
+#include "util.h"
+#include "error.h"
+
+#define NUM_CHANNELS		3
+#define MAX_REG_ADDR		0x12
+
+volatile uint8_t current_direct_reg = 0;
+
+/*
+ * Available cut-off frequencies of the low pass filter in Hz.
+ * The integer part and fractional part are represented separately.
+ */
+static const int adxrs290_lpf_3db_freq_hz_table[][2] = {
+	[0] = {480, 0},
+	[1] = {320, 0},
+	[2] = {160, 0},
+	[3] = {80, 0},
+	[4] = {56, 600000},
+	[5] = {40, 0},
+	[6] = {28, 300000},
+	[7] = {20, 0},
+};
+
+/*
+ * Available cut-off frequencies of the high pass filter in Hz.
+ * The integer part and fractional part are represented separately.
+ */
+static const int adxrs290_hpf_3db_freq_hz_table[][2] = {
+	[0] = {0, 0},
+	[1] = {0, 11000},
+	[2] = {0, 22000},
+	[3] = {0, 44000},
+	[4] = {0, 87000},
+	[5] = {0, 175000},
+	[6] = {0, 350000},
+	[7] = {0, 700000},
+	[8] = {1, 400000},
+	[9] = {2, 800000},
+	[10] = {11, 300000},
+};
+
+ssize_t get_adxrs290_iio_reg(void *device, char *buf, size_t len,
+			     const struct iio_ch_info *channel)
+{
+	uint8_t val;
+
+	adxrs290_reg_read((struct adxrs290_dev *)device, current_direct_reg, &val);
+
+	return snprintf(buf, len,  "%d", val);
+
+}
+
+ssize_t set_adxrs290_iio_reg(void *device, char *buf, size_t len,
+			     const struct iio_ch_info *channel)
+{
+	unsigned int reg;
+	unsigned int val;
+	uint8_t param_size = sscanf(buf, "0x%x 0x%x", &reg, &val);
+
+	if (param_size == 2) {
+		if (reg > MAX_REG_ADDR)
+			return -EINVAL;
+		else
+			adxrs290_reg_write((struct adxrs290_dev *)device,
+					   reg & 0xFF, val & 0xFF);
+	} else {
+		param_size = sscanf(buf, "%u", &reg);
+		if (param_size == 1) {
+			if (reg > MAX_REG_ADDR)
+				return -EINVAL;
+
+			current_direct_reg = reg & 0xFF;
+		} else
+			return -EINVAL;
+	}
+
+	return len;
+}
+
+ssize_t get_adxrs290_iio_ch_raw(void *device, char *buf, size_t len,
+				const struct iio_ch_info *channel)
+{
+	int16_t data;
+
+	adxrs290_get_rate_data((struct adxrs290_dev *)device,
+			       channel->ch_num, &data);
+	if (channel->ch_num == ADXRS290_CHANNEL_TEMP)
+		data = (data << 4) >> 4;
+
+	return snprintf(buf, len, "%d", data);
+}
+
+
+ssize_t get_adxrs290_iio_ch_scale(void *device, char *buf, size_t len,
+				  const struct iio_ch_info *channel)
+{
+	if (channel->ch_num == ADXRS290_CHANNEL_TEMP)
+		// Temperature scale 1 LSB = 0.1 degree Celsius
+		return snprintf(buf, len, "100");
+
+	// Angular velocity scale 1 LSB = 0.005 degrees/sec = 0.000087266 rad/sec
+	return snprintf(buf, len, "0.000087266");
+}
+
+ssize_t get_adxrs290_iio_ch_hpf(void *device, char *buf, size_t len,
+				const struct iio_ch_info *channel)
+{
+	uint8_t index;
+	adxrs290_get_hpf((struct adxrs290_dev *)device, &index);
+	if (index > 0x0A)
+		index = 0x0A;
+
+	return snprintf(buf, len, "%d.%d",
+			adxrs290_hpf_3db_freq_hz_table[index][0],
+			adxrs290_hpf_3db_freq_hz_table[index][1]);
+}
+
+ssize_t set_adxrs290_iio_ch_hpf(void *device, char *buf, size_t len,
+				const struct iio_ch_info *channel)
+{
+	float hpf = strtof(buf, NULL);
+	int32_t val = (int32_t)hpf;
+	int32_t val2 = (int32_t)(hpf * 1000000) % 1000000;
+	uint8_t i;
+	uint8_t n = ARRAY_SIZE(adxrs290_hpf_3db_freq_hz_table);
+
+	for (i = 0; i < n; i++)
+		if (adxrs290_hpf_3db_freq_hz_table[i][0] == val
+		    && adxrs290_hpf_3db_freq_hz_table[i][1] == val2) {
+			adxrs290_set_hpf(device, (enum adxrs290_hpf) i);
+
+			return len;
+		}
+
+	return FAILURE;
+}
+
+ssize_t get_adxrs290_iio_ch_lpf(void *device, char *buf, size_t len,
+				const struct iio_ch_info *channel)
+{
+	uint8_t index;
+
+	adxrs290_get_lpf((struct adxrs290_dev *)device, &index);
+	if (index > 0x07)
+		index = 0x07;
+
+	return snprintf(buf, len, "%d.%d", adxrs290_lpf_3db_freq_hz_table[index][0],
+			adxrs290_lpf_3db_freq_hz_table[index][1]);
+}
+
+ssize_t set_adxrs290_iio_ch_lpf(void *device, char *buf, size_t len,
+				const struct iio_ch_info *channel)
+{
+	float lpf = strtof(buf, NULL);
+	int32_t val = (int32_t)lpf;
+	int32_t val2 = (int32_t)(lpf * 1000000) % 1000000;
+	uint8_t i;
+	uint8_t n = ARRAY_SIZE(adxrs290_lpf_3db_freq_hz_table);
+
+	for (i = 0; i < n; i++)
+		if (adxrs290_lpf_3db_freq_hz_table[i][0] == val
+		    && adxrs290_lpf_3db_freq_hz_table[i][1] == val2) {
+			adxrs290_set_lpf(device, (enum adxrs290_lpf) i);
+			return len;
+		}
+
+	return FAILURE;
+}

--- a/iio/iio_adxrs290/iio_adxrs290.h
+++ b/iio/iio_adxrs290/iio_adxrs290.h
@@ -1,0 +1,159 @@
+/***************************************************************************//**
+ *   @file   iio_adxrs290.h
+ *   @brief  Implementation of ADXRS290 iio.
+ *   @author Kister Genesis Jimenez (kister.jimenez@analog.com)
+********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef IIO_ADXRS290_H
+#define IIO_ADXRS290_H
+
+#include "iio_types.h"
+
+ssize_t get_adxrs290_iio_reg(void *device, char *buf, size_t len,
+			     const struct iio_ch_info *channel);
+ssize_t set_adxrs290_iio_reg(void *device, char *buf, size_t len,
+			     const struct iio_ch_info *channel);
+ssize_t get_adxrs290_iio_ch_raw(void *device, char *buf, size_t len,
+				const struct iio_ch_info *channel);
+ssize_t get_adxrs290_iio_ch_scale(void *device, char *buf, size_t len,
+				  const struct iio_ch_info *channel);
+ssize_t set_adxrs290_iio_ch_hpf(void *device, char *buf, size_t len,
+				const struct iio_ch_info *channel);
+ssize_t get_adxrs290_iio_ch_hpf(void *device, char *buf, size_t len,
+				const struct iio_ch_info *channel);
+ssize_t set_adxrs290_iio_ch_lpf(void *device, char *buf, size_t len,
+				const struct iio_ch_info *channel);
+ssize_t get_adxrs290_iio_ch_lpf(void *device, char *buf, size_t len,
+				const struct iio_ch_info *channel);
+
+static struct iio_attribute adxrs290_iio_ch_attr_3db_hpf_freq_val = {
+	.name = "filter_high_pass_3db_frequency",
+	.show = get_adxrs290_iio_ch_hpf,
+	.store = set_adxrs290_iio_ch_hpf
+};
+
+static struct iio_attribute adxrs290_iio_ch_attr_3db_lpf_freq_val = {
+	.name = "filter_low_pass_3db_frequency",
+	.show = get_adxrs290_iio_ch_lpf,
+	.store = set_adxrs290_iio_ch_lpf
+};
+
+static struct iio_attribute adxrs290_iio_ch_attr_raw = {
+	.name = "raw",
+	.show = get_adxrs290_iio_ch_raw,
+	.store = NULL
+};
+
+static struct iio_attribute adxrs290_iio_ch_attr_scale = {
+	.name = "scale",
+	.show = get_adxrs290_iio_ch_scale,
+	.store = NULL
+};
+
+static struct iio_attribute *adxrs290_iio_vel_attrs[] = {
+	&adxrs290_iio_ch_attr_3db_hpf_freq_val,
+	&adxrs290_iio_ch_attr_3db_lpf_freq_val,
+	&adxrs290_iio_ch_attr_raw,
+	&adxrs290_iio_ch_attr_scale,
+	NULL,
+};
+
+static struct iio_attribute *adxrs290_iio_temp_attrs[] = {
+	&adxrs290_iio_ch_attr_raw,
+	&adxrs290_iio_ch_attr_scale,
+	NULL,
+};
+
+static struct iio_channel adxrs290_iio_channel_x = {
+	.ch_type = IIO_ANGL_VEL,
+	.modified=1,
+	.channel2=IIO_MOD_X,
+	.scan_index = 0,
+	.scan_type = NULL,
+	.attributes = adxrs290_iio_vel_attrs,
+	.ch_out = false,
+};
+
+static struct iio_channel adxrs290_iio_channel_y = {
+	.ch_type = IIO_ANGL_VEL,
+	.modified=1,
+	.channel2=IIO_MOD_Y,
+	.scan_index = 1,
+	.scan_type = NULL,
+	.attributes = adxrs290_iio_vel_attrs,
+	.ch_out = false,
+};
+
+static struct iio_channel adxrs290_iio_channel_temp = {
+	.ch_type = IIO_TEMP,
+	.scan_index = 2,
+	.scan_type = NULL,
+	.attributes = adxrs290_iio_temp_attrs,
+	.ch_out = false,
+};
+
+static struct iio_channel *adxrs290_iio_channels[] = {
+	&adxrs290_iio_channel_x,
+	&adxrs290_iio_channel_y,
+	&adxrs290_iio_channel_temp,
+	NULL,
+};
+
+static struct iio_attribute adxrs290_iio_reg_attr = {
+	.name = "direct_reg_access",
+	.show = get_adxrs290_iio_reg,
+	.store = set_adxrs290_iio_reg,
+};
+
+static struct iio_attribute *adxrs290_iio_debug_attrs[] = {
+	&adxrs290_iio_reg_attr,
+	NULL,
+};
+
+//extern struct iio_device adxrs290_iio_descriptor ;
+struct iio_device adxrs290_iio_descriptor = {
+	.num_ch = 3,
+	.channels = adxrs290_iio_channels,
+	.attributes = NULL,
+	.debug_attributes = adxrs290_iio_debug_attrs,
+	.buffer_attributes = NULL,
+	.transfer_dev_to_mem = NULL,
+	.transfer_mem_to_dev = NULL,
+	.read_data = NULL,
+	.write_data = NULL
+};
+
+#endif

--- a/projects/adxrs290-pmdz/Makefile
+++ b/projects/adxrs290-pmdz/Makefile
@@ -1,0 +1,10 @@
+# Uncomment to use the desired platform
+# PLATFORM = xilinx
+# PLATFORM = altera
+# PLATFORM = aducm3029
+
+include ../../tools/scripts/generic_variables.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/adxrs290-pmdz/pinmux_config.c
+++ b/projects/adxrs290-pmdz/pinmux_config.c
@@ -1,0 +1,49 @@
+/*
+ **
+ ** Source file generated on October 6, 2020 at 18:23:01.
+ **
+ ** Copyright (C) 2011-2020 Analog Devices Inc., All Rights Reserved.
+ **
+ ** This file is generated automatically based upon the options selected in
+ ** the Pin Multiplexing configuration editor. Changes to the Pin Multiplexing
+ ** configuration should be made by changing the appropriate options rather
+ ** than editing this file.
+ **
+ ** Selected Peripherals
+ ** --------------------
+ ** SPI1 (SCLK, MISO, MOSI, CS_0)
+ ** UART0 (Tx, Rx)
+ **
+ ** GPIO (unavailable)
+ ** ------------------
+ ** P0_10, P0_11, P1_06, P1_07, P1_08, P1_09
+ */
+
+#include <sys/platform.h>
+#include <stdint.h>
+
+#define SPI1_SCLK_PORTP1_MUX  ((uint16_t) ((uint16_t) 1 << 12))
+#define SPI1_MISO_PORTP1_MUX  ((uint16_t) ((uint16_t) 1 << 14))
+#define SPI1_MOSI_PORTP1_MUX  ((uint32_t) ((uint32_t) 1 << 16))
+#define SPI1_CS_0_PORTP1_MUX  ((uint32_t) ((uint32_t) 1 << 18))
+#define UART0_TX_PORTP0_MUX  ((uint32_t) ((uint32_t) 1 << 20))
+#define UART0_RX_PORTP0_MUX  ((uint32_t) ((uint32_t) 1 << 22))
+
+int32_t adi_initpinmux(void);
+
+/*
+ * Initialize the Port Control MUX Registers
+ */
+int32_t adi_initpinmux(void)
+{
+	/* PORTx_MUX registers */
+	*((volatile uint32_t *)REG_GPIO0_CFG) = UART0_TX_PORTP0_MUX
+						| UART0_RX_PORTP0_MUX;
+	*((volatile uint32_t *)REG_GPIO1_CFG) = SPI1_SCLK_PORTP1_MUX
+						| SPI1_MISO_PORTP1_MUX
+						| SPI1_MOSI_PORTP1_MUX
+						| SPI1_CS_0_PORTP1_MUX;
+
+	return 0;
+}
+

--- a/projects/adxrs290-pmdz/src.mk
+++ b/projects/adxrs290-pmdz/src.mk
@@ -1,0 +1,41 @@
+#See No-OS/tool/scripts/src_model.mk for variable description
+
+SRC_DIRS += $(PROJECT)/src
+SRC_DIRS += $(DRIVERS)/gyro/adxrs290 
+SRC_DIRS += $(NO-OS)/iio/iio_adxrs290 
+
+# For the moment there is support only for aducm for iio with network backend
+ifeq (aducm3029,$(strip $(PLATFORM)))
+ENABLE_IIO_NETWORK = n
+endif
+
+ifeq (y,$(strip $(ENABLE_IIO_NETWORK)))
+DISABLE_SECURE_SOCKET ?= y
+SRC_DIRS += $(NO-OS)/network
+SRCS	 += $(NO-OS)/util/circular_buffer.c
+SRCS	 += $(PLATFORM_DRIVERS)/delay.c
+SRCS	 += $(PLATFORM_DRIVERS)/timer.c
+endif
+
+
+LIBRARIES += iio
+
+SRCS += $(PLATFORM_DRIVERS)/uart.c					\
+	$(PLATFORM_DRIVERS)/irq.c					\
+	$(PLATFORM_DRIVERS)/spi.c					\
+	$(NO-OS)/util/xml.c						\
+	$(NO-OS)/util/list.c						\
+	$(NO-OS)/util/fifo.c						\
+	$(NO-OS)/util/util.c						\
+
+INCS += $(INCLUDE)/xml.h						\
+	$(INCLUDE)/fifo.h						\
+	$(INCLUDE)/irq.h						\
+	$(INCLUDE)/uart.h						\
+	$(INCLUDE)/list.h						\
+	$(INCLUDE)/util.h						\
+	$(INCLUDE)/error.h						\
+	$(INCLUDE)/spi.h						\
+	$(PLATFORM_DRIVERS)/spi_extra.h					\
+	$(PLATFORM_DRIVERS)/irq_extra.h					\
+	$(PLATFORM_DRIVERS)/uart_extra.h				

--- a/projects/adxrs290-pmdz/src/app_config.h
+++ b/projects/adxrs290-pmdz/src/app_config.h
@@ -1,0 +1,50 @@
+/***************************************************************************//**
+ *   @file   adxrs290-pmdz/src/app_config.h
+ *   @brief  Config file of ADXRS290/API Driver.
+ *   @author DBogdan (dragos.bogdan@analog.com)
+********************************************************************************
+ * Copyright 2015(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef CONFIG_H_
+#define CONFIG_H_
+
+//#define XILINX_PLATFORM
+//#define ALTERA_PLATFORM
+//#define ADUCM_PLATFORM
+
+#ifdef ENABLE_IIO_NETWORK
+#define USE_TCP_SOCKET
+#endif
+
+#endif

--- a/projects/adxrs290-pmdz/src/main.c
+++ b/projects/adxrs290-pmdz/src/main.c
@@ -1,0 +1,234 @@
+/***************************************************************************//**
+ *   @file   adxrs290-pmdz/src/main.c
+ *   @brief  Implementation of Main Function.
+ *   @author Kister Genesis Jimenez  (kister.jimenez@analog.com)
+********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include "spi.h"
+#include "spi_extra.h"
+#include "adxrs290.h"
+#include "iio_adxrs290.h"
+#include "app_config.h"
+#include "parameters.h"
+#include "error.h"
+#include "iio.h"
+#include "irq.h"
+#include "irq_extra.h"
+#include "uart.h"
+#include "uart_extra.h"
+
+#ifdef USE_TCP_SOCKET
+#include "wifi.h"
+#include "tcp_socket.h"
+#endif
+
+#ifdef ADUCM_PLATFORM
+
+#include <sys/platform.h>
+#include "adi_initialize.h"
+#include <drivers/pwr/adi_pwr.h>
+
+#define MAX_SIZE_BASE_ADDR		3000
+
+#endif
+
+int32_t platform_init()
+{
+#ifdef ADUCM_PLATFORM
+	if (ADI_PWR_SUCCESS != adi_pwr_Init())
+		return FAILURE;
+
+	if (ADI_PWR_SUCCESS != adi_pwr_SetClockDivider(ADI_CLOCK_HCLK, 1u))
+		return FAILURE;
+
+	if (ADI_PWR_SUCCESS != adi_pwr_SetClockDivider(ADI_CLOCK_PCLK, 1u))
+		return FAILURE;
+	adi_initComponents();
+#endif
+	return SUCCESS;
+}
+
+/***************************************************************************//**
+ * @brief main
+*******************************************************************************/
+int main(void)
+{
+	int32_t status;
+
+	struct adxrs290_dev *adxrs290_device;
+
+	/* iio descriptor. */
+	struct iio_desc  *iio_desc;
+
+	/* iio init param */
+	struct iio_init_param iio_init_param;
+
+	/* Initialization for UART. */
+	struct uart_init_param uart_init_par;
+
+	/* IRQ initial configuration. */
+	struct irq_init_param irq_init_param;
+
+	/* IRQ instance. */
+	struct irq_ctrl_desc *irq_desc;
+
+#ifdef USE_TCP_SOCKET
+	struct tcp_socket_init_param	socket_param;
+	struct wifi_init_param		wifi_param;
+	struct wifi_desc		*wifi;
+	struct uart_desc		*uart_desc;
+#endif
+
+	status = platform_init();
+	if (IS_ERR_VALUE(status))
+		return status;
+
+#ifdef ADUCM_PLATFORM
+	/* Dummy value for Aducm platform dependent initialization for IRQ. */
+	int32_t platform_irq_init_par = 0;
+#endif //ADUCM_PLATFORM
+
+	irq_init_param = (struct irq_init_param ) {
+		.irq_ctrl_id = INTC_DEVICE_ID,
+		.extra = &platform_irq_init_par
+	};
+
+	status = irq_ctrl_init(&irq_desc, &irq_init_param);
+	if(status < 0)
+		return status;
+
+#ifdef ADUCM_PLATFORM
+
+	/* Aducm platform dependent initialization for UART. */
+	struct aducm_uart_init_param platform_uart_init_par = {
+		.parity = UART_NO_PARITY,
+		.stop_bits = UART_ONE_STOPBIT,
+		.word_length = UART_WORDLEN_8BITS
+	};
+
+	/* Aducm platform dependent initialization for SPI. */
+	struct aducm_spi_init_param spi_param = {
+		.continuous_mode = true,
+		.dma = false,
+		.half_duplex = false,
+		.master_mode = MASTER,
+		.spi_channel = SPI1
+	};
+
+#endif // ADUCM_PLATFORM
+	uart_init_par = (struct uart_init_param) {
+		.device_id = UART_DEVICE_ID,
+		.baud_rate = UART_BAUDRATE,
+		.extra = &platform_uart_init_par
+	};
+
+	status = irq_global_enable(irq_desc);
+	if (status < 0)
+		return status;
+
+#ifdef USE_TCP_SOCKET
+	status = uart_init(&uart_desc, &uart_init_par);
+	if (status < 0)
+		return status;
+
+	wifi_param.irq_desc = irq_desc;
+	wifi_param.uart_desc = uart_desc;
+#ifdef ADUCM_PLATFORM
+	wifi_param.uart_irq_conf = uart_desc;
+#endif //ADUCM_PLATFORM
+	wifi_param.uart_irq_id = UART_IRQ_ID;
+
+	status = wifi_init(&wifi, &wifi_param);
+	if (status < 0)
+		return status;
+
+	status = wifi_connect(wifi, WIFI_SSID, WIFI_PWD);
+	if (status < 0)
+		return status;
+
+	char buff[100];
+	wifi_get_ip(wifi, buff, 100);
+	printf("Tinyiiod ip is: %s\n", buff);
+
+	wifi_get_network_interface(wifi, &socket_param.net);
+	socket_param.max_buff_size = 0;
+
+	iio_init_param.phy_type = USE_NETWORK;
+	iio_init_param.tcp_socket_init_param = &socket_param;
+
+#else //USE_TCP_SOCKET
+	iio_init_param.phy_type = USE_UART;
+	iio_init_param.uart_init_param = &uart_init_par;
+#endif //USE_TCP_SOCKET
+
+	struct spi_init_param init_param = {
+		.chip_select = 0,
+		.extra = &spi_param,
+		.max_speed_hz = 900000,
+		.mode = SPI_MODE_3,
+		.platform_ops = NULL
+	};
+
+	struct adxrs290_init_param adxrs290_param = {
+		.spi_init = init_param,
+		.mode = ADXRS290_MODE_MEASUREMENT,
+		.lpf = ADXRS290_LPF_480HZ,
+		.hpf = ADXRS290_HPF_ALL_PASS
+	};
+
+	status = adxrs290_init(&adxrs290_device, &adxrs290_param);
+	if (status < 0)
+		return status;
+
+	status = iio_init(&iio_desc, &iio_init_param);
+	if(status < 0)
+		return status;
+
+	status = iio_register(iio_desc, &adxrs290_iio_descriptor,
+			      "adxrs290", adxrs290_device);
+	if (status < 0)
+		return status;
+
+	do {
+		status = iio_step(iio_desc);
+	} while (true);
+
+	return status;
+}

--- a/projects/adxrs290-pmdz/src/parameters.h
+++ b/projects/adxrs290-pmdz/src/parameters.h
@@ -1,0 +1,68 @@
+/***************************************************************************//**
+ *   @file   adxrs290-pmdz/src/parameters.h
+ *   @brief  Parameters Definitions.
+ *   @author DBogdan (dragos.bogdan@analog.com)
+********************************************************************************
+ * Copyright 2013(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#ifdef ADUCM_PLATFORM
+#include "irq_extra.h"
+#endif
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+#ifdef ADUCM_PLATFORM
+
+#define UART_DEVICE_ID	0
+#define INTC_DEVICE_ID	0
+#define UART_IRQ_ID		ADUCM_UART_INT_ID
+#define UART_BAUDRATE	115200
+
+#endif //ADUCM_PLATFORM
+
+#ifdef USE_TCP_SOCKET
+#define WIFI_SSID	"RouterSSID"
+#define WIFI_PWD	"******"
+#endif /* USE_TCP_SOCKET */
+
+#endif // __PARAMETERS_H__


### PR DESCRIPTION
- Adding driver for ADXRS290.
- Adding tinyiio project for ADXRS290.
- Buffer-enabled channel is not yet used since there is no trigger feature yet.
- Tested with iio_reg, iio_attr, iio_info, and iio-oscilloscope.
