### PR TITLE
Remove unused function and add ch name checking in xml.

### DIFF
--- a/libraries/iio/iio.c
+++ b/libraries/iio/iio.c
@@ -278,27 +278,6 @@ static ssize_t iio_phy_write(const char *buf, size_t len)
 	return -EINVAL;
 }
 
-/**
- * @brief Get channel number.
- * @param ch - String containing channel name + channel number.
- * @return - Channel number. Ex: for "altvoltage0" return 0, for "voltage2"
- * return 2.
- */
-static int32_t iio_get_channel_number(const char *ch)
-{
-	char *p = (char*)ch;
-	int32_t ch_num = FAILURE;
-
-	while (*p) {
-		if (isdigit(*p))
-			ch_num = strtol(p, &p, 10);
-		else
-			p++;
-	}
-
-	return ch_num;
-}
-
 /* Get string for channel id from channel type */
 static char *get_channel_id(enum iio_chan_type type)
 {

--- a/libraries/iio/iio.c
+++ b/libraries/iio/iio.c
@@ -845,9 +845,14 @@ static uint32_t iio_generate_device_xml(struct iio_device *device, char *name,
 			ch = device->channels[j];
 			_print_ch_id(ch_id, ch);
 			i += snprintf(buff + i, max(n - i, 0),
-				      "<channel id=\"%s\" name=\"%s\""
+				      "<channel id=\"%s\"",
+				      ch_id);
+			if(ch->name)
+				i += snprintf(buff + i, max(n - i, 0),
+					      " name=\"%s\"",
+					      ch->name);
+			i += snprintf(buff + i, max(n - i, 0),
 				      " type=\"%s\" >",
-				      ch_id, ch->name,
 				      ch->ch_out ? "output" : "input");
 
 			if (ch->scan_type)


### PR DESCRIPTION
Some iio library changes:
- removed unused function: int32_t iio_get_channel_number(const char *ch)
- added channel name checking before printing name field in xml. This makes the name field optional so tools like iio-osc and iio_info will use the channel id as names if not provided.