### PR TITLE
projects:adv7511: update source paths on make

### DIFF
--- a/projects/adv7511/src.mk
+++ b/projects/adv7511/src.mk
@@ -19,11 +19,13 @@ SRCS := $(PROJECT)/src/main.c	\
 SRCS += $(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
 	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c	\
 	$(DRIVERS)/i2c/i2c.c	\
+	$(DRIVERS)/gpio/gpio.c	\
+	$(DRIVERS)/spi/spi.c	\
 	$(NO-OS)/util/util.c	\
 	$(NO-OS)/util/list.c
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
 	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
-	$(PLATFORM_DRIVERS)/gpio.c					\
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c					\
 	$(PLATFORM_DRIVERS)/delay.c		\
 	$(PLATFORM_DRIVERS)/xilinx_i2c.c	\
 	$(PLATFORM_DRIVERS)/irq.c	\


### PR DESCRIPTION
The SPI and GPIO drivers have changed format to pointer implementation
and the platform specific implementation. Update the paths to the
sources.

Signed-off-by: Andrei Drimbarean <Andrei.Drimbarean@analog.com>