### PR TITLE
spi_engine: driver updates

### DIFF
--- a/drivers/axi_core/spi_engine/spi_engine.c
+++ b/drivers/axi_core/spi_engine/spi_engine.c
@@ -835,6 +835,9 @@ int32_t spi_engine_offload_transfer(struct spi_desc *desc,
 
 	spi_engine_transfer_message(desc, &transfer);
 
+	/* Start transfer */
+	spi_engine_write(eng_desc, SPI_ENGINE_REG_OFFLOAD_CTRL(0), 0x0001);
+
 	word_length = spi_get_word_lenght(eng_desc);
 	if(eng_desc->offload_config & OFFLOAD_TX_EN) {
 		axi_dmac_transfer(eng_desc->offload_tx_dma,
@@ -851,9 +854,6 @@ int32_t spi_engine_offload_transfer(struct spi_desc *desc,
 	}
 
 	usleep(1000);
-
-	/* Start transfer */
-	spi_engine_write(eng_desc, SPI_ENGINE_REG_OFFLOAD_CTRL(0), 0x0001);
 
 	spi_engine_queue_free(&transfer.cmds);
 

--- a/drivers/axi_core/spi_engine/spi_engine.c
+++ b/drivers/axi_core/spi_engine/spi_engine.c
@@ -519,6 +519,12 @@ static int32_t spi_engine_compile_message(struct spi_desc *desc,
 
 	desc_extra = desc->extra;
 
+	/* Configure the prescaler */
+	spi_engine_queue_append_cmd(&msg->cmds,
+				    SPI_ENGINE_CMD_CONFIG(
+					    SPI_ENGINE_CMD_REG_CLK_DIV,
+					    desc_extra->clk_div));
+
 	/* Set the data transfer length */
 	spi_engine_queue_append_cmd(&msg->cmds,
 				    SPI_ENGINE_CMD_CONFIG(
@@ -534,12 +540,6 @@ static int32_t spi_engine_compile_message(struct spi_desc *desc,
 				    SPI_ENGINE_CMD_CONFIG(
 					    SPI_ENGINE_CMD_REG_CONFIG,
 					    desc->mode));
-
-	/* Configure the prescaler */
-	spi_engine_queue_append_cmd(&msg->cmds,
-				    SPI_ENGINE_CMD_CONFIG(
-					    SPI_ENGINE_CMD_REG_CLK_DIV,
-					    desc_extra->clk_div));
 
 	/* Add a sync command to signal that the transfer has finished */
 	spi_engine_queue_add_cmd(&msg->cmds, SPI_ENGINE_CMD_SYNC(_sync_id));


### PR DESCRIPTION
- rearrange SPI commands order 
- start SPI transfer before the DMA 

Changes required for ad7616-sdz project update.

**NOTE:** changes tested on https://github.com/analogdevicesinc/no-OS/tree/master/projects/ad738x_fmcz

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>