### PR TITLE
include: gpio: switch `number` param to integer

### DIFF
--- a/include/gpio.h
+++ b/include/gpio.h
@@ -70,7 +70,7 @@ struct gpio_platform_ops ;
  */
 typedef struct gpio_init_param {
 	/** GPIO number */
-	uint32_t	number;
+	int32_t		number;
 	/** GPIO platform specific functions */
 	const struct gpio_platform_ops *platform_ops;
 	/** GPIO extra parameters (device specific) */
@@ -83,7 +83,7 @@ typedef struct gpio_init_param {
  */
 typedef struct gpio_desc {
 	/** GPIO number */
-	uint32_t	number;
+	int32_t		number;
 	/** GPIO platform specific functions */
 	const struct gpio_platform_ops *platform_ops;
 	/** GPIO extra parameters (device specific) */


### PR DESCRIPTION
With e610bcd the gpio `number` can take also negative values.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>