### PR TITLE
Projects Makefile: Update projects makefile to use generic_variables.mk

### DIFF
--- a/projects/ad400x-fmcz/Makefile
+++ b/projects/ad400x-fmcz/Makefile
@@ -1,7 +1,6 @@
-TARGET := ad400x-fmcz
-ifeq ($(OS), Windows_NT)
-include ../../tools/scripts/windows.mk
-else
-include ../../tools/scripts/linux.mk
-endif
+TINYIIOD ?= n
+include ../../tools/scripts/generic_variables.mk
 
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/ad7124-4sdz/Makefile
+++ b/projects/ad7124-4sdz/Makefile
@@ -1,7 +1,6 @@
-TARGET := ad7124-4sdz
-ifeq ($(OS), Windows_NT)
-include ../../tools/scripts/windows.mk
-else
-include ../../tools/scripts/linux.mk
-endif
+TINYIIOD ?= n
+include ../../tools/scripts/generic_variables.mk
 
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/ad7768-1fmcz/Makefile
+++ b/projects/ad7768-1fmcz/Makefile
@@ -1,7 +1,6 @@
-TARGET := ad7768-1fmcz
-ifeq ($(OS), Windows_NT)
-include ../../tools/scripts/windows.mk
-else
-include ../../tools/scripts/linux.mk
-endif
+TINYIIOD ?= n
+include ../../tools/scripts/generic_variables.mk
 
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/ad9656_fmc/Makefile
+++ b/projects/ad9656_fmc/Makefile
@@ -1,6 +1,6 @@
-TARGET := ad9656_fmc
-ifeq ($(OS), Windows_NT)
-include ../../tools/scripts/windows.mk
-else
-include ../../tools/scripts/linux.mk
-endif
+TINYIIOD ?= n
+include ../../tools/scripts/generic_variables.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk


### PR DESCRIPTION
and generic.mk. This solves build issues of the project:
make[2]: *** No rule to make target 'libs'.  Stop.

Signed-off-by: Cristian Pop <cristian.pop@analog.com>