### PR TITLE
Support for direct register access

### DIFF
--- a/iio/iio_adxrs290/iio_adxrs290.c
+++ b/iio/iio_adxrs290/iio_adxrs290.c
@@ -83,44 +83,6 @@ static const int adxrs290_hpf_3db_freq_hz_table[][2] = {
 	[10] = {11, 300000},
 };
 
-ssize_t get_adxrs290_iio_reg(void *device, char *buf, size_t len,
-			     const struct iio_ch_info *channel)
-{
-	uint8_t val;
-
-	adxrs290_reg_read((struct adxrs290_dev *)device, current_direct_reg, &val);
-
-	return snprintf(buf, len,  "%d", val);
-
-}
-
-ssize_t set_adxrs290_iio_reg(void *device, char *buf, size_t len,
-			     const struct iio_ch_info *channel)
-{
-	unsigned int reg;
-	unsigned int val;
-	uint8_t param_size = sscanf(buf, "0x%x 0x%x", &reg, &val);
-
-	if (param_size == 2) {
-		if (reg > MAX_REG_ADDR)
-			return -EINVAL;
-		else
-			adxrs290_reg_write((struct adxrs290_dev *)device,
-					   reg & 0xFF, val & 0xFF);
-	} else {
-		param_size = sscanf(buf, "%u", &reg);
-		if (param_size == 1) {
-			if (reg > MAX_REG_ADDR)
-				return -EINVAL;
-
-			current_direct_reg = reg & 0xFF;
-		} else
-			return -EINVAL;
-	}
-
-	return len;
-}
-
 ssize_t get_adxrs290_iio_ch_raw(void *device, char *buf, size_t len,
 				const struct iio_ch_info *channel)
 {

--- a/iio/iio_adxrs290/iio_adxrs290.h
+++ b/iio/iio_adxrs290/iio_adxrs290.h
@@ -132,28 +132,19 @@ static struct iio_channel *adxrs290_iio_channels[] = {
 	NULL,
 };
 
-static struct iio_attribute adxrs290_iio_reg_attr = {
-	.name = "direct_reg_access",
-	.show = get_adxrs290_iio_reg,
-	.store = set_adxrs290_iio_reg,
-};
-
-static struct iio_attribute *adxrs290_iio_debug_attrs[] = {
-	&adxrs290_iio_reg_attr,
-	NULL,
-};
-
 //extern struct iio_device adxrs290_iio_descriptor ;
 struct iio_device adxrs290_iio_descriptor = {
 	.num_ch = 3,
 	.channels = adxrs290_iio_channels,
 	.attributes = NULL,
-	.debug_attributes = adxrs290_iio_debug_attrs,
+	.debug_attributes = NULL,
 	.buffer_attributes = NULL,
 	.transfer_dev_to_mem = NULL,
 	.transfer_mem_to_dev = NULL,
 	.read_data = NULL,
-	.write_data = NULL
+	.write_data = NULL,
+	.debug_reg_read = (int32_t (*)())adxrs290_reg_read,
+	.debug_reg_write = (int32_t (*)())adxrs290_reg_write,
 };
 
 #endif

--- a/iio/iio_demo/demo_dev.h
+++ b/iio/iio_demo/demo_dev.h
@@ -100,11 +100,10 @@ ssize_t get_demo_global_attr(void *device, char *buf, size_t len,
 ssize_t set_demo_global_attr(void *device, char *buf, size_t len,
 			     const struct iio_ch_info *channel);
 
-ssize_t get_demo_reg_attr(void *device, char *buf, size_t len,
-			  const struct iio_ch_info *channel);
-ssize_t set_demo_reg_attr(void *device, char *buf, size_t len,
-			  const struct iio_ch_info *channel);
-
+int32_t iio_demo_reg_read(struct iio_demo_desc *desc, uint32_t reg,
+			  uint32_t *readval);
+int32_t iio_demo_reg_write(struct iio_demo_desc *desc, uint32_t reg,
+			   uint32_t writeval);
 int32_t iio_demo_update_active_channels(void *dev, uint32_t mask);
 int32_t iio_demo_close_channels(void *dev);
 int32_t	iio_demo_read_local_samples(void *dev, uint16_t *buff,

--- a/iio/iio_demo/iio_demo_dev.h
+++ b/iio/iio_demo/iio_demo_dev.h
@@ -129,37 +129,30 @@ static struct iio_attribute *iio_demo_global_attributes[] = {
 	NULL,
 };
 
-static struct iio_attribute iio_attr_debug = {
-	.name = "direct_reg_access",
-	.show = get_demo_reg_attr,
-	.store = set_demo_reg_attr,
-};
-
-static struct iio_attribute *iio_demo_debug_attributes[] = {
-	&iio_attr_debug,
-	NULL,
-};
-
 static struct iio_device iio_demo_dev_in_descriptor = {
 	.num_ch = DEMO_NUM_CHANNELS,
 	.channels = iio_demo_channels_in,
 	.attributes = iio_demo_global_attributes,
-	.debug_attributes = iio_demo_debug_attributes,
+	.debug_attributes = NULL,
 	.buffer_attributes = NULL,
 	.prepare_transfer = iio_demo_update_active_channels,
 	.end_transfer = iio_demo_close_channels,
-	.read_dev = iio_demo_read_local_samples,
+	.read_dev =  (int32_t (*)())iio_demo_read_local_samples,
+	.debug_reg_read = (int32_t (*)())iio_demo_reg_read,
+	.debug_reg_write = (int32_t (*)())iio_demo_reg_write,
 };
 
 static struct iio_device iio_demo_dev_out_descriptor = {
 	.num_ch = DEMO_NUM_CHANNELS,
 	.channels = iio_demo_channels_out,
 	.attributes = iio_demo_global_attributes,
-	.debug_attributes = iio_demo_debug_attributes,
+	.debug_attributes = NULL,
 	.buffer_attributes = NULL,
 	.prepare_transfer = iio_demo_update_active_channels,
 	.end_transfer = iio_demo_close_channels,
-	.write_dev = iio_demo_write_local_samples
+	.write_dev = (int32_t (*)())iio_demo_write_local_samples,
+	.debug_reg_read = (int32_t (*)())iio_demo_reg_read,
+	.debug_reg_write = (int32_t (*)())iio_demo_reg_write,
 };
 
 #endif /* IIO_DEMO_DEV */

--- a/libraries/iio/iio_types.h
+++ b/libraries/iio/iio_types.h
@@ -195,6 +195,11 @@ struct iio_device {
 	 * samples * (storage_size_of_first_active_ch / 8) * nb_active_channels
 	 */
 	int32_t	(*write_dev)(void *dev, void *buff, uint32_t nb_samples);
+	/* Read device register */
+	int32_t (*debug_reg_read)(void *dev, uint32_t reg, uint32_t *readval);
+	/* Write device register */
+	int32_t (*debug_reg_write)(void *dev, uint32_t reg, uint32_t writeval);
+
 };
 
 #endif /* IIO_TYPES_H_ */


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16192750/100451576-52722b00-30c0-11eb-803f-dda83cea54f7.png)

This PR makes posible to enable Register Map Settings from iio Oscilloscope by just setting the deriver register access functions
to iio_device descriptor.
