### PR TITLE
projects: ad9434: add IIO support

### DIFF
--- a/projects/ad9434-fmc-500ebz/src.mk
+++ b/projects/ad9434-fmc-500ebz/src.mk
@@ -10,11 +10,23 @@
 ################################################################################
 
 SRCS := $(PROJECT)/src/ad9434_fmc_500ebz.c
+ifeq (y,$(strip $(TINYIIOD)))
+LIBRARIES += iio
+SRCS += $(PROJECT)/src/app_iio.c
+endif
 SRCS += $(DRIVERS)/adc/ad9434/ad9434.c					\
 	$(DRIVERS)/spi/spi.c						\
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
 	$(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
 	$(NO-OS)/util/util.c
+ifeq (y,$(strip $(TINYIIOD)))
+SRCS += $(NO-OS)/util/xml.c						\
+	$(NO-OS)/util/fifo.c						\
+	$(NO-OS)/iio/iio_axi_adc/iio_axi_adc.c				\
+	$(NO-OS)/util/list.c						\
+	$(PLATFORM_DRIVERS)/uart.c					\
+	$(PLATFORM_DRIVERS)/irq.c
+endif
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
 	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
 	$(PLATFORM_DRIVERS)/delay.c
@@ -22,6 +34,9 @@ INCS += $(PROJECT)/src/parameters.h					\
 	$(DRIVERS)/adc/ad9434/ad9434.h					\
 	$(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h			\
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h
+ifeq (y,$(strip $(TINYIIOD)))
+INCS +=	$(PROJECT)/src/app_iio.h
+endif
 INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h
 INCS +=	$(INCLUDE)/axi_io.h						\
 	$(INCLUDE)/spi.h						\
@@ -29,3 +44,13 @@ INCS +=	$(INCLUDE)/axi_io.h						\
 	$(INCLUDE)/delay.h						\
 	$(INCLUDE)/print_log.h						\
 	$(INCLUDE)/util.h
+ifeq (y,$(strip $(TINYIIOD)))
+INCS +=	$(INCLUDE)/xml.h						\
+	$(INCLUDE)/fifo.h						\
+	$(INCLUDE)/irq.h						\
+	$(INCLUDE)/uart.h						\
+	$(INCLUDE)/list.h						\
+	$(PLATFORM_DRIVERS)/irq_extra.h					\
+	$(PLATFORM_DRIVERS)/uart_extra.h                                \
+	$(NO-OS)/iio/iio_axi_adc/iio_axi_adc.h
+endif

--- a/projects/ad9434-fmc-500ebz/src/ad9434_fmc_500ebz.c
+++ b/projects/ad9434-fmc-500ebz/src/ad9434_fmc_500ebz.c
@@ -41,6 +41,8 @@
 /******************************************************************************/
 /***************************** Include Files **********************************/
 /******************************************************************************/
+#include "xil_cache.h"
+#include "xparameters.h"
 #include "axi_adc_core.h"
 #include "axi_dmac.h"
 #include "ad9434.h"
@@ -48,6 +50,10 @@
 #include "spi_extra.h"
 #include "parameters.h"
 #include "error.h"
+
+#ifdef IIO_SUPPORT
+#include "app_iio.h"
+#endif
 
 #define LOG_LEVEL 6
 #include "print_log.h"
@@ -146,6 +152,20 @@ int main(void)
 		pr_info("axi_dmac_transfer() failed!");
 		return FAILURE;
 	}
+
+#ifdef IIO_SUPPORT
+	pr_info("The board accepts libiio clients connections through the serial backend.\n");
+
+	struct iio_axi_adc_init_param iio_axi_adc_init_par;
+	iio_axi_adc_init_par = (struct iio_axi_adc_init_param) {
+		.rx_adc = ad9434_core,
+		.rx_dmac = ad9434_dmac,
+		.dcache_invalidate_range = (void (*)(uint32_t,
+						     uint32_t))Xil_DCacheInvalidateRange
+	};
+
+	return iio_app_start(&iio_axi_adc_init_par);
+#endif
 
 	pr_info("Capture done.\n");
 

--- a/projects/ad9434-fmc-500ebz/src/app_config.h
+++ b/projects/ad9434-fmc-500ebz/src/app_config.h
@@ -1,6 +1,6 @@
 /***************************************************************************//**
- *   @file   parameters.h
- *   @brief  Platform dependent parameters.
+ *   @file   ad9434-fmc-500ebz/src/app_config.h
+ *   @brief  Config file for AD9434 project.
  *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
 ********************************************************************************
  * Copyright 2020(c) Analog Devices, Inc.
@@ -37,17 +37,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 
-#ifndef _PARAMETERS_H_
-#define _PARAMETERS_H_
+#ifndef APP_CONFIG_H_
+#define APP_CONFIG_H_
 
-#include <xparameters.h>
+//#define IIO_SUPPORT
 
-#define SPI_DEVICE_ID				XPAR_PS7_SPI_0_DEVICE_ID
-#define RX_CORE_BASEADDR			XPAR_AXI_AD9434_BASEADDR
-#define RX_DMA_BASEADDR				XPAR_AXI_AD9434_DMA_BASEADDR
-#define ADC_DDR_BASEADDR			XPAR_DDR_MEM_BASEADDR + 0x800000
-#define UART_DEVICE_ID				XPAR_XUARTPS_0_DEVICE_ID
-#define UART_IRQ_ID				XPAR_XUARTPS_1_INTR
-#define INTC_DEVICE_ID				XPAR_SCUGIC_SINGLE_DEVICE_ID
-
-#endif /* _PARAMETERS_H_ */
+#endif /* APP_CONFIG_H_ */

--- a/projects/ad9434-fmc-500ebz/src/app_iio.c
+++ b/projects/ad9434-fmc-500ebz/src/app_iio.c
@@ -1,6 +1,6 @@
 /***************************************************************************//**
- *   @file   parameters.h
- *   @brief  Platform dependent parameters.
+ *   @file   app_iio.c
+ *   @brief  Application IIO setup.
  *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
 ********************************************************************************
  * Copyright 2020(c) Analog Devices, Inc.
@@ -37,17 +37,88 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 
-#ifndef _PARAMETERS_H_
-#define _PARAMETERS_H_
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
 
-#include <xparameters.h>
+#include "error.h"
+#include "uart.h"
+#include "uart_extra.h"
+#include "parameters.h"
+#include "app_iio.h"
+#include "iio.h"
+#include "irq.h"
+#include "irq_extra.h"
 
-#define SPI_DEVICE_ID				XPAR_PS7_SPI_0_DEVICE_ID
-#define RX_CORE_BASEADDR			XPAR_AXI_AD9434_BASEADDR
-#define RX_DMA_BASEADDR				XPAR_AXI_AD9434_DMA_BASEADDR
-#define ADC_DDR_BASEADDR			XPAR_DDR_MEM_BASEADDR + 0x800000
-#define UART_DEVICE_ID				XPAR_XUARTPS_0_DEVICE_ID
-#define UART_IRQ_ID				XPAR_XUARTPS_1_INTR
-#define INTC_DEVICE_ID				XPAR_SCUGIC_SINGLE_DEVICE_ID
+/******************************************************************************/
+/************************ Variables Definitions *******************************/
+/******************************************************************************/
+static struct irq_ctrl_desc *irq_desc;
 
-#endif /* _PARAMETERS_H_ */
+struct iio_data_buffer g_read_buff = {
+	.buff = (void *)ADC_DDR_BASEADDR,
+	.size = 0xFFFFFFFF,
+};
+
+/**
+ * @brief Application IIO setup.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t iio_app_start(struct iio_axi_adc_init_param *adc_init)
+{
+	int32_t status;
+
+	struct xil_irq_init_param xil_irq_init_param = {
+		.type = IRQ_PS,
+	};
+
+	struct irq_init_param irq_init_param = {
+		.irq_ctrl_id = INTC_DEVICE_ID,
+		.extra = &xil_irq_init_param,
+	};
+
+	status = irq_ctrl_init(&irq_desc, &irq_init_param);
+	if(status < 0)
+		return status;
+
+	struct xil_uart_init_param xil_uart_init_par = {
+		.type = UART_PS,
+		.irq_id = UART_IRQ_ID,
+		.irq_desc = irq_desc,
+	};
+
+	struct uart_init_param uart_init_par = {
+		.baud_rate = 115200,
+		.device_id = UART_DEVICE_ID,
+		.extra = &xil_uart_init_par,
+	};
+	struct iio_axi_adc_desc *iio_axi_adc_desc;
+	struct iio_device *dev_desc;
+	struct iio_desc *iio;
+	struct iio_init_param iio_init_par = {
+		.phy_type = USE_UART,
+		.uart_init_param = &uart_init_par
+	};
+
+	status = irq_global_enable(irq_desc);
+	if (status < 0)
+		return status;
+
+	status = iio_axi_adc_init(&iio_axi_adc_desc, adc_init);
+	if (status < 0)
+		return status;
+
+	iio_axi_adc_get_dev_descriptor(iio_axi_adc_desc, &dev_desc);
+
+	status = iio_init(&iio, &iio_init_par);
+	if (status < 0)
+		return status;
+
+	status = iio_register(iio, dev_desc, "ad9434_dev", iio_axi_adc_desc,
+			      &g_read_buff, NULL);
+	if (status < 0)
+		return status;
+
+	while (true)
+		iio_step(iio);
+}

--- a/projects/ad9434-fmc-500ebz/src/app_iio.h
+++ b/projects/ad9434-fmc-500ebz/src/app_iio.h
@@ -1,6 +1,6 @@
 /***************************************************************************//**
- *   @file   parameters.h
- *   @brief  Platform dependent parameters.
+ *   @file   app_iio.h
+ *   @brief  Application IIO setup.
  *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
 ********************************************************************************
  * Copyright 2020(c) Analog Devices, Inc.
@@ -36,18 +36,20 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
+#ifndef APP_IIO_H_
+#define APP_IIO_H_
 
-#ifndef _PARAMETERS_H_
-#define _PARAMETERS_H_
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdint.h>
+#include "iio_axi_adc.h"
 
-#include <xparameters.h>
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
 
-#define SPI_DEVICE_ID				XPAR_PS7_SPI_0_DEVICE_ID
-#define RX_CORE_BASEADDR			XPAR_AXI_AD9434_BASEADDR
-#define RX_DMA_BASEADDR				XPAR_AXI_AD9434_DMA_BASEADDR
-#define ADC_DDR_BASEADDR			XPAR_DDR_MEM_BASEADDR + 0x800000
-#define UART_DEVICE_ID				XPAR_XUARTPS_0_DEVICE_ID
-#define UART_IRQ_ID				XPAR_XUARTPS_1_INTR
-#define INTC_DEVICE_ID				XPAR_SCUGIC_SINGLE_DEVICE_ID
+/* @brief Application IIO setup. */
+int32_t iio_app_start(struct iio_axi_adc_init_param *adc_init);
 
-#endif /* _PARAMETERS_H_ */
+#endif


### PR DESCRIPTION
Allow the user to read/write via UART using IIO oscilloscope.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>