### PR TITLE
projects: change buffer address to DDR

### DIFF
--- a/projects/ad738x_fmcz/src/ad738x_fmc.c
+++ b/projects/ad738x_fmcz/src/ad738x_fmc.c
@@ -99,7 +99,7 @@ int main()
 	};
 
 #ifdef SPI_ENGINE_OFFLOAD_EXAMPLE
-	uint32_t* buf = XPAR_PS7_RAM_0_S_AXI_BASEADDR;
+	uint32_t* buf = XPAR_PS7_DDR_0_S_AXI_BASEADDR;
 	uint32_t i;
 #endif
 

--- a/projects/ad7616-sdz/src/ad7616_sdz.c
+++ b/projects/ad7616-sdz/src/ad7616_sdz.c
@@ -129,7 +129,7 @@ struct ad7616_init_param init_param = {
 int main(void)
 {
 	struct ad7616_dev	*dev;
-	uint32_t* buf = XPAR_PS7_RAM_0_S_AXI_BASEADDR;
+	uint32_t* buf = XPAR_PS7_DDR_0_S_AXI_BASEADDR;
 
 	Xil_ICacheEnable();
 	Xil_DCacheEnable();


### PR DESCRIPTION
The address of the buffers is set now to the DDR base address
instead of RAM.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>