### PR TITLE
libraries:iio: add differential channel identifier

### DIFF
--- a/libraries/iio/iio.c
+++ b/libraries/iio/iio.c
@@ -312,8 +312,13 @@ static inline void _print_ch_id(char *buff, struct iio_channel *ch)
 			iio_modifier_names[ch->channel2]);
 	} else {
 		if(ch->indexed) {
-			sprintf(buff, "%s%d", get_channel_id(ch->ch_type),
-				(int)ch->channel);
+			if (ch->diferential)
+				sprintf(buff, "%s%d-%s%d", get_channel_id(ch->ch_type),
+					(int)ch->channel, get_channel_id(ch->ch_type),
+					(int)ch->channel2);
+			else
+				sprintf(buff, "%s%d", get_channel_id(ch->ch_type),
+					(int)ch->channel);
 		} else {
 			sprintf(buff, "%s", get_channel_id(ch->ch_type));
 		}

--- a/libraries/iio/iio_types.h
+++ b/libraries/iio/iio_types.h
@@ -148,6 +148,8 @@ struct iio_channel {
 	/** Specify if channel has a numerical index. If not set, channel
 	 *  number will be suppressed. */
 	bool			indexed;
+	/* Set if the channel is differential. */
+	bool			diferential;
 };
 
 struct iio_data_buffer {


### PR DESCRIPTION
Add differential channel identifier as it is in the Linux
implementation. This is done to help integrate no-OS IIO with pyadi-iio.

Signed-off-by: Andrei Drimbarean <Andrei.Drimbarean@analog.com>