### PR TITLE
IIO attributes update

### DIFF
--- a/iio/iio_ad9361/iio_ad9361.c
+++ b/iio/iio_ad9361/iio_ad9361.c
@@ -99,7 +99,8 @@ extern const char *ad9361_ensm_states[12];
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_rf_port_select(void *device, char *buf, size_t len,
-				  const struct iio_ch_info *channel)
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
 {
 	ssize_t ret = 0;
 	uint32_t mode;
@@ -123,7 +124,8 @@ static ssize_t get_rf_port_select(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_hardwaregain(void *device, char *buf, size_t len,
-				const struct iio_ch_info *channel)
+				const struct iio_ch_info *channel,
+				intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	struct rf_rx_gain rx_gain = {0};
@@ -168,7 +170,8 @@ static ssize_t get_hardwaregain(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_rssi(void *device, char *buf, size_t len,
-			const struct iio_ch_info *channel)
+			const struct iio_ch_info *channel,
+			intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	ssize_t ret = 0;
@@ -197,7 +200,8 @@ static ssize_t get_rssi(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_hardwaregain_available(void *device, char *buf, size_t len,
-		const struct iio_ch_info *channel)
+		const struct iio_ch_info *channel,
+		intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 
@@ -223,7 +227,8 @@ static ssize_t get_hardwaregain_available(void *device, char *buf, size_t len,
  */
 static ssize_t get_sampling_frequency_available(void *device, char *buf,
 		size_t len,
-		const struct iio_ch_info *channel)
+		const struct iio_ch_info *channel,
+		intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	int32_t int_dec;
@@ -259,7 +264,8 @@ static ssize_t get_sampling_frequency_available(void *device, char *buf,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_rf_port_select_available(void *device, char *buf, size_t len,
-		const struct iio_ch_info *channel)
+		const struct iio_ch_info *channel,
+		intptr_t priv)
 {
 	ssize_t bytes_no, ret;
 	uint16_t i;
@@ -293,7 +299,8 @@ static ssize_t get_rf_port_select_available(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_filter_fir_en(void *device, char *buf, size_t len,
-				 const struct iio_ch_info *channel)
+				 const struct iio_ch_info *channel,
+				 intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	uint8_t en_dis;
@@ -318,7 +325,8 @@ static ssize_t get_filter_fir_en(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_sampling_frequency(void *device, char *buf, size_t len,
-				      const struct iio_ch_info *channel)
+				      const struct iio_ch_info *channel,
+				      intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	uint32_t sampling_freq_hz;
@@ -339,7 +347,8 @@ static ssize_t get_sampling_frequency(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_rf_bandwidth_available(void *device, char *buf, size_t len,
-		const struct iio_ch_info *channel)
+		const struct iio_ch_info *channel,
+		intptr_t priv)
 {
 	if (channel->ch_out)
 		return snprintf(buf, len, "[200000 1 40000000]");
@@ -356,7 +365,8 @@ static ssize_t get_rf_bandwidth_available(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_rf_bandwidth(void *device, char *buf, size_t len,
-				const struct iio_ch_info *channel)
+				const struct iio_ch_info *channel,
+				intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	if (channel->ch_out)
@@ -374,7 +384,8 @@ static ssize_t get_rf_bandwidth(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_gain_control_mode(void *device, char *buf, size_t len,
-				     const struct iio_ch_info *channel)
+				     const struct iio_ch_info *channel,
+				     intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	return (ssize_t) snprintf(buf, len, "%s",
@@ -390,7 +401,8 @@ static ssize_t get_gain_control_mode(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_rf_dc_offset_tracking_en(void *device, char *buf, size_t len,
-		const struct iio_ch_info *channel)
+		const struct iio_ch_info *channel,
+		intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 
@@ -409,7 +421,8 @@ static ssize_t get_rf_dc_offset_tracking_en(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_quadrature_tracking_en(void *device, char *buf, size_t len,
-		const struct iio_ch_info *channel)
+		const struct iio_ch_info *channel,
+		intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 
@@ -429,7 +442,8 @@ static ssize_t get_quadrature_tracking_en(void *device, char *buf, size_t len,
  */
 static ssize_t get_gain_control_mode_available(void *device, char *buf,
 		size_t len,
-		const struct iio_ch_info *channel)
+		const struct iio_ch_info *channel,
+		intptr_t priv)
 {
 	return (ssize_t) snprintf(buf, len, "%s %s %s %s",
 				  ad9361_agc_modes[0],
@@ -447,7 +461,8 @@ static ssize_t get_gain_control_mode_available(void *device, char *buf,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_bb_dc_offset_tracking_en(void *device, char *buf, size_t len,
-		const struct iio_ch_info *channel)
+		const struct iio_ch_info *channel,
+		intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 
@@ -466,7 +481,8 @@ static ssize_t get_bb_dc_offset_tracking_en(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_frequency_available(void *device, char *buf, size_t len,
-				       const struct iio_ch_info *channel)
+				       const struct iio_ch_info *channel,
+				       intptr_t priv)
 {
 	return snprintf(buf, len, "[%"PRIu64" 1 %"PRIu64"]",
 			AD9363A_MIN_CARRIER_FREQ_HZ,
@@ -482,7 +498,8 @@ static ssize_t get_frequency_available(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_fastlock_save(void *device, char *buf, size_t len,
-				 const struct iio_ch_info *channel)
+				 const struct iio_ch_info *channel,
+				 intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	uint8_t faslock_vals[16];
@@ -512,7 +529,8 @@ static ssize_t get_fastlock_save(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_powerdown(void *device, char *buf, size_t len,
-			     const struct iio_ch_info *channel)
+			     const struct iio_ch_info *channel,
+			     intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	uint64_t val = 0;
@@ -532,7 +550,8 @@ static ssize_t get_powerdown(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_fastlock_load(void *device, char *buf, size_t len,
-				 const struct iio_ch_info *channel)
+				 const struct iio_ch_info *channel,
+				 intptr_t priv)
 {
 	/* This function doesn't have an equivalent function in ad9361,
 	 * and it should be implemented there first */
@@ -549,7 +568,8 @@ static ssize_t get_fastlock_load(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_fastlock_store(void *device, char *buf, size_t len,
-				  const struct iio_ch_info *channel)
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
 {
 	/* This function doesn't have an equivalent function in ad9361,
 	 * and it should be implemented there first */
@@ -566,7 +586,8 @@ static ssize_t get_fastlock_store(void *device, char *buf, size_t len,
  * @return: Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_frequency(void *device, char *buf, size_t len,
-			     const struct iio_ch_info *channel)
+			     const struct iio_ch_info *channel,
+			     intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	uint64_t val = 0;
@@ -586,7 +607,8 @@ static ssize_t get_frequency(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_external(void *device, char *buf, size_t len,
-			    const struct iio_ch_info *channel)
+			    const struct iio_ch_info *channel,
+			    intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 
@@ -607,7 +629,8 @@ static ssize_t get_external(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_fastlock_recall(void *device, char *buf, size_t len,
-				   const struct iio_ch_info *channel)
+				   const struct iio_ch_info *channel,
+				   intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 
@@ -624,7 +647,8 @@ static ssize_t get_fastlock_recall(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_temp0_input(void *device, char *buf, size_t len,
-			       const struct iio_ch_info *channel)
+			       const struct iio_ch_info *channel,
+			       intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	int32_t temp;
@@ -644,7 +668,8 @@ static ssize_t get_temp0_input(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_voltage_filter_fir_en(void *device, char *buf, size_t len,
-		const struct iio_ch_info *channel)
+		const struct iio_ch_info *channel,
+		intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	uint8_t en_dis_tx, en_dis_rx;
@@ -669,7 +694,8 @@ static ssize_t get_voltage_filter_fir_en(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_hardwaregain_available(void *device, char *buf, size_t len,
-		const struct iio_ch_info *channel)
+		const struct iio_ch_info *channel,
+		intptr_t priv)
 {
 	/* This function doesn't have an equivalent function in ad9361,
 	 * and it should be implemented there first */
@@ -686,7 +712,8 @@ static ssize_t set_hardwaregain_available(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_hardwaregain(void *device, char *buf, size_t len,
-				const struct iio_ch_info *channel)
+				const struct iio_ch_info *channel,
+				intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	ssize_t ret = 0;
@@ -728,7 +755,8 @@ static ssize_t set_hardwaregain(void *device, char *buf, size_t len,
  * @return  Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_rssi(void *device, char *buf, size_t len,
-			const struct iio_ch_info *channel)
+			const struct iio_ch_info *channel,
+			intptr_t priv)
 {
 	/* This function doesn't have an equivalent function in ad9361,
 	 * and it should be implemented there first */
@@ -745,7 +773,8 @@ static ssize_t set_rssi(void *device, char *buf, size_t len,
  * @return: Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_rf_port_select(void *device, char *buf, size_t len,
-				  const struct iio_ch_info *channel)
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	ssize_t ret = 0;
@@ -785,7 +814,8 @@ static ssize_t set_rf_port_select(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_gain_control_mode(void *device, char *buf, size_t len,
-				     const struct iio_ch_info *channel)
+				     const struct iio_ch_info *channel,
+				     intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	struct rf_gain_ctrl gc = {0};
@@ -822,7 +852,8 @@ static ssize_t set_gain_control_mode(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_rf_port_select_available(void *device, char *buf, size_t len,
-		const struct iio_ch_info *channel)
+		const struct iio_ch_info *channel,
+		intptr_t priv)
 {
 	/* This function doesn't have an equivalent function in ad9361,
 	 * and it should be implemented there first */
@@ -839,7 +870,8 @@ static ssize_t set_rf_port_select_available(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_rf_bandwidth(void *device, char *buf, size_t len,
-				const struct iio_ch_info *channel)
+				const struct iio_ch_info *channel,
+				intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	ssize_t ret = -ENOENT;
@@ -870,7 +902,8 @@ static ssize_t set_rf_bandwidth(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_rf_dc_offset_tracking_en(void *device, char *buf, size_t len,
-		const struct iio_ch_info *channel)
+		const struct iio_ch_info *channel,
+		intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	int8_t en_dis = str_to_int32(buf);
@@ -900,7 +933,8 @@ static ssize_t set_rf_dc_offset_tracking_en(void *device, char *buf, size_t len,
  */
 static ssize_t set_sampling_frequency_available(void *device, char *buf,
 		size_t len,
-		const struct iio_ch_info *channel)
+		const struct iio_ch_info *channel,
+		intptr_t priv)
 {
 	/* This function doesn't have an equivalent function in ad9361,
 	 * and it should be implemented there first */
@@ -917,7 +951,8 @@ static ssize_t set_sampling_frequency_available(void *device, char *buf,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_quadrature_tracking_en(void *device, char *buf, size_t len,
-		const struct iio_ch_info *channel)
+		const struct iio_ch_info *channel,
+		intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	int8_t en_dis = str_to_int32(buf);
@@ -946,7 +981,8 @@ static ssize_t set_quadrature_tracking_en(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_sampling_frequency(void *device, char *buf, size_t len,
-				      const struct iio_ch_info *channel)
+				      const struct iio_ch_info *channel,
+				      intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	uint32_t sampling_freq_hz = srt_to_uint32(buf);
@@ -968,7 +1004,8 @@ static ssize_t set_sampling_frequency(void *device, char *buf, size_t len,
  */
 static ssize_t set_gain_control_mode_available(void *device, char *buf,
 		size_t len,
-		const struct iio_ch_info *channel)
+		const struct iio_ch_info *channel,
+		intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	struct rf_gain_ctrl gc = {0};
@@ -1005,7 +1042,8 @@ static ssize_t set_gain_control_mode_available(void *device, char *buf,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_filter_fir_en(void *device, char *buf, size_t len,
-				 const struct iio_ch_info *channel)
+				 const struct iio_ch_info *channel,
+				 intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	int8_t en_dis = str_to_int32(buf);
@@ -1034,7 +1072,8 @@ static ssize_t set_filter_fir_en(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_rf_bandwidth_available(void *device, char *buf, size_t len,
-		const struct iio_ch_info *channel)
+		const struct iio_ch_info *channel,
+		intptr_t priv)
 {
 	/* This function doesn't have an equivalent function in ad9361,
 	 * and it should be implemented there first */
@@ -1051,7 +1090,8 @@ static ssize_t set_rf_bandwidth_available(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_bb_dc_offset_tracking_en(void *device, char *buf, size_t len,
-		const struct iio_ch_info *channel)
+		const struct iio_ch_info *channel,
+		intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	int8_t en_dis = str_to_int32(buf);
@@ -1080,7 +1120,8 @@ static ssize_t set_bb_dc_offset_tracking_en(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_frequency_available(void *device, char *buf, size_t len,
-				       const struct iio_ch_info *channel)
+				       const struct iio_ch_info *channel,
+				       intptr_t priv)
 {
 	/* This function doesn't have an equivalent function in ad9361,
 	 * and it should be implemented there first */
@@ -1097,7 +1138,8 @@ static ssize_t set_frequency_available(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_fastlock_save(void *device, char *buf, size_t len,
-				 const struct iio_ch_info *channel)
+				 const struct iio_ch_info *channel,
+				 intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	uint32_t readin = srt_to_uint32(buf);
@@ -1116,7 +1158,8 @@ static ssize_t set_fastlock_save(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_powerdown(void *device, char *buf, size_t len,
-			     const struct iio_ch_info *channel)
+			     const struct iio_ch_info *channel,
+			     intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	ssize_t ret = -ENOENT;
@@ -1141,7 +1184,8 @@ static ssize_t set_powerdown(void *device, char *buf, size_t len,
  * @return: Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_fastlock_load(void *device, char *buf, size_t len,
-				 const struct iio_ch_info *channel)
+				 const struct iio_ch_info *channel,
+				 intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	ssize_t ret = 0;
@@ -1183,7 +1227,8 @@ static ssize_t set_fastlock_load(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_fastlock_store(void *device, char *buf, size_t len,
-				  const struct iio_ch_info *channel)
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	uint32_t profile = srt_to_uint32(buf);
@@ -1205,7 +1250,8 @@ static ssize_t set_fastlock_store(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_frequency(void *device, char *buf, size_t len,
-			     const struct iio_ch_info *channel)
+			     const struct iio_ch_info *channel,
+			     intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	uint64_t lo_freq_hz = srt_to_uint32(buf);
@@ -1238,7 +1284,8 @@ static ssize_t set_frequency(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_external(void *device, char *buf, size_t len,
-			    const struct iio_ch_info *channel)
+			    const struct iio_ch_info *channel,
+			    intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	bool select = str_to_int32(buf) ? 1 : 0;
@@ -1263,7 +1310,8 @@ static ssize_t set_external(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_fastlock_recall(void *device, char *buf, size_t len,
-				   const struct iio_ch_info *channel)
+				   const struct iio_ch_info *channel,
+				   intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	ssize_t ret = 0;
@@ -1285,7 +1333,8 @@ static ssize_t set_fastlock_recall(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_voltage_filter_fir_en(void *device, char *buf, size_t len,
-		const struct iio_ch_info *channel)
+		const struct iio_ch_info *channel,
+		intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	int8_t en_dis = str_to_int32(buf) ? 1 : 0;
@@ -1310,7 +1359,8 @@ static ssize_t set_voltage_filter_fir_en(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_dcxo_tune_coarse(void *device, char *buf, size_t len,
-				    const struct iio_ch_info *channel)
+				    const struct iio_ch_info *channel,
+				    intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 
@@ -1329,7 +1379,8 @@ static ssize_t get_dcxo_tune_coarse(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_rx_path_rates(void *device, char *buf, size_t len,
-				 const struct iio_ch_info *channel)
+				 const struct iio_ch_info *channel,
+				 intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	unsigned long clk[6];
@@ -1352,7 +1403,8 @@ static ssize_t get_rx_path_rates(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_trx_rate_governor(void *device, char *buf, size_t len,
-				     const struct iio_ch_info *channel)
+				     const struct iio_ch_info *channel,
+				     intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	uint32_t rate_governor;
@@ -1373,7 +1425,8 @@ static ssize_t get_trx_rate_governor(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_calib_mode_available(void *device, char *buf, size_t len,
-					const struct iio_ch_info *channel)
+					const struct iio_ch_info *channel,
+					intptr_t priv)
 {
 	return (ssize_t) snprintf(buf, len, "%s %s %s %s %s", ad9361_calib_mode[0],
 				  ad9361_calib_mode[1], ad9361_calib_mode[2],
@@ -1389,7 +1442,8 @@ static ssize_t get_calib_mode_available(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_xo_correction_available(void *device, char *buf, size_t len,
-		const struct iio_ch_info *channel)
+		const struct iio_ch_info *channel,
+		intptr_t priv)
 {
 	return (ssize_t) snprintf(buf, len, "%"PRIi16"", 0); /* dummy */
 }
@@ -1403,7 +1457,8 @@ static ssize_t get_xo_correction_available(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_gain_table_config(void *device, char *buf, size_t len,
-				     const struct iio_ch_info *channel)
+				     const struct iio_ch_info *channel,
+				     intptr_t priv)
 {
 	return (ssize_t) snprintf(buf, len, "%"PRIi16"", 0); /* dummy */
 }
@@ -1417,7 +1472,8 @@ static ssize_t get_gain_table_config(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_dcxo_tune_fine(void *device, char *buf, size_t len,
-				  const struct iio_ch_info *channel)
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 
@@ -1436,7 +1492,8 @@ static ssize_t get_dcxo_tune_fine(void *device, char *buf, size_t len,
  * @return: Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_dcxo_tune_fine_available(void *device, char *buf, size_t len,
-		const struct iio_ch_info *channel)
+		const struct iio_ch_info *channel,
+		intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 
@@ -1453,7 +1510,8 @@ static ssize_t get_dcxo_tune_fine_available(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_ensm_mode_available(void *device, char *buf, size_t len,
-				       const struct iio_ch_info *channel)
+				       const struct iio_ch_info *channel,
+				       intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 
@@ -1471,7 +1529,8 @@ static ssize_t get_ensm_mode_available(void *device, char *buf, size_t len,
  * @return: Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_multichip_sync(void *device, char *buf, size_t len,
-				  const struct iio_ch_info *channel)
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
 {
 	return (ssize_t) snprintf(buf, len, "%"PRIi16"", 0);  /* dummy */
 }
@@ -1485,7 +1544,8 @@ static ssize_t get_multichip_sync(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_rssi_gain_step_error(void *device, char *buf, size_t len,
-					const struct iio_ch_info *channel)
+					const struct iio_ch_info *channel,
+					intptr_t priv)
 {
 	return (ssize_t) snprintf(buf, len, "%"PRIi16"", 0);  /* dummy */
 }
@@ -1500,7 +1560,8 @@ static ssize_t get_rssi_gain_step_error(void *device, char *buf, size_t len,
  */
 static ssize_t get_dcxo_tune_coarse_available(void *device, char *buf,
 		size_t len,
-		const struct iio_ch_info *channel)
+		const struct iio_ch_info *channel,
+		intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 
@@ -1517,7 +1578,8 @@ static ssize_t get_dcxo_tune_coarse_available(void *device, char *buf,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_tx_path_rates(void *device, char *buf, size_t len,
-				 const struct iio_ch_info *channel)
+				 const struct iio_ch_info *channel,
+				 intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	unsigned long clk[6];
@@ -1541,7 +1603,8 @@ static ssize_t get_tx_path_rates(void *device, char *buf, size_t len,
  */
 static ssize_t get_trx_rate_governor_available(void *device, char *buf,
 		size_t len,
-		const struct iio_ch_info *channel)
+		const struct iio_ch_info *channel,
+		intptr_t priv)
 {
 	return snprintf(buf, len, "%s", "nominal highest_osr");
 }
@@ -1555,7 +1618,8 @@ static ssize_t get_trx_rate_governor_available(void *device, char *buf,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_xo_correction(void *device, char *buf, size_t len,
-				 const struct iio_ch_info *channel)
+				 const struct iio_ch_info *channel,
+				 intptr_t priv)
 {
 	return (ssize_t) snprintf(buf, len, "%"PRIi16"", 0); /* dummy */
 }
@@ -1569,7 +1633,8 @@ static ssize_t get_xo_correction(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_ensm_mode(void *device, char *buf, size_t len,
-			     const struct iio_ch_info *channel)
+			     const struct iio_ch_info *channel,
+			     intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	ssize_t ret = ad9361_ensm_get_state(ad9361_phy);
@@ -1592,7 +1657,8 @@ static ssize_t get_ensm_mode(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_filter_fir_config(void *device, char *buf, size_t len,
-				     const struct iio_ch_info *channel)
+				     const struct iio_ch_info *channel,
+				     intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 
@@ -1610,7 +1676,8 @@ static ssize_t get_filter_fir_config(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_calib_mode(void *device, char *buf, size_t len,
-			      const struct iio_ch_info *channel)
+			      const struct iio_ch_info *channel,
+			      intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	uint8_t en_dis;
@@ -1631,7 +1698,8 @@ static ssize_t get_calib_mode(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_trx_rate_governor(void *device, char *buf, size_t len,
-				     const struct iio_ch_info *channel)
+				     const struct iio_ch_info *channel,
+				     intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	ssize_t ret = 0;
@@ -1655,7 +1723,8 @@ static ssize_t set_trx_rate_governor(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_dcxo_tune_coarse(void *device, char *buf, size_t len,
-				    const struct iio_ch_info *channel)
+				    const struct iio_ch_info *channel,
+				    intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	uint32_t dcxo_coarse = srt_to_uint32(buf);
@@ -1681,7 +1750,8 @@ static ssize_t set_dcxo_tune_coarse(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_dcxo_tune_fine(void *device, char *buf, size_t len,
-				  const struct iio_ch_info *channel)
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	uint32_t dcxo_fine = srt_to_uint32(buf);
@@ -1707,7 +1777,8 @@ static ssize_t set_dcxo_tune_fine(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_calib_mode(void *device, char *buf, size_t len,
-			      const struct iio_ch_info *channel)
+			      const struct iio_ch_info *channel,
+			      intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	int32_t arg = -1;
@@ -1750,7 +1821,8 @@ static ssize_t set_calib_mode(void *device, char *buf, size_t len,
  * @return: Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_ensm_mode(void *device, char *buf, size_t len,
-			     const struct iio_ch_info *channel)
+			     const struct iio_ch_info *channel,
+			     intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	uint32_t val = 0;
@@ -1801,7 +1873,8 @@ static ssize_t set_ensm_mode(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_multichip_sync(void *device, char *buf, size_t len,
-				  const struct iio_ch_info *channel)
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	uint32_t readin = srt_to_uint32(buf);
@@ -1826,7 +1899,8 @@ extern int32_t ad9361_parse_fir(struct ad9361_rf_phy *phy,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_filter_fir_config(void *device, char *buf, size_t len,
-				     const struct iio_ch_info *channel)
+				     const struct iio_ch_info *channel,
+				     intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	int32_t ret;

--- a/iio/iio_ad9361/iio_ad9361.c
+++ b/iio/iio_ad9361/iio_ad9361.c
@@ -1838,339 +1838,293 @@ static ssize_t set_filter_fir_config(void *device, char *buf, size_t len,
 	return len;
 }
 
-static struct iio_attribute iio_attr_rf_port_select = {
-	.name = "rf_port_select",
-	.show = get_rf_port_select,
-	.store = set_rf_port_select,
+struct iio_attribute voltage_output_attributes[] = {
+	{
+		.name = "rf_port_select",
+		.show = get_rf_port_select,
+		.store = set_rf_port_select,
+	},
+	{
+		.name = "hardwaregain",
+		.show = get_hardwaregain,
+		.store = set_hardwaregain,
+	},
+	{
+		.name = "rssi",
+		.show = get_rssi,
+		.store = set_rssi,
+	},
+	{
+		.name = "hardwaregain_available",
+		.show = get_hardwaregain_available,
+		.store = set_hardwaregain_available,
+	},
+	{
+		.name = "sampling_frequency_available",
+		.show = get_sampling_frequency_available,
+		.store = set_sampling_frequency_available,
+	},
+	{
+		.name = "rf_port_select_available",
+		.show = get_rf_port_select_available,
+		.store = set_rf_port_select_available,
+	},
+	{
+		.name = "filter_fir_en",
+		.show = get_filter_fir_en,
+		.store = set_filter_fir_en,
+	},
+	{
+		.name = "sampling_frequency",
+		.show = get_sampling_frequency,
+		.store = set_sampling_frequency,
+	},
+	{
+		.name = "rf_bandwidth_available",
+		.show = get_rf_bandwidth_available,
+		.store = set_rf_bandwidth_available,
+	},
+	{
+		.name = "rf_bandwidth",
+		.show = get_rf_bandwidth,
+		.store = set_rf_bandwidth,
+	},
+	END_ATTRIBUTES_ARRAY
 };
 
-static struct iio_attribute iio_attr_hardwaregain = {
-	.name = "hardwaregain",
-	.show = get_hardwaregain,
-	.store = set_hardwaregain,
+struct iio_attribute voltage_input_attributes[] = {
+	{
+		.name = "hardwaregain_available",
+		.show = get_hardwaregain_available,
+		.store = set_hardwaregain_available,
+	},
+	{
+		.name = "hardwaregain",
+		.show = get_hardwaregain,
+		.store = set_hardwaregain,
+	},
+	{
+		.name = "rssi",
+		.show = get_rssi,
+		.store = set_rssi,
+	},
+	{
+		.name = "rf_port_select",
+		.show = get_rf_port_select,
+		.store = set_rf_port_select,
+	},
+	{
+		.name = "gain_control_mode",
+		.show = get_gain_control_mode,
+		.store = set_gain_control_mode,
+	},
+	{
+		.name = "rf_port_select_available",
+		.show = get_rf_port_select_available,
+		.store = set_rf_port_select_available,
+	},
+	{
+		.name = "rf_bandwidth",
+		.show = get_rf_bandwidth,
+		.store = set_rf_bandwidth,
+	},
+	{
+		.name = "rf_dc_offset_tracking_en",
+		.show = get_rf_dc_offset_tracking_en,
+		.store = set_rf_dc_offset_tracking_en,
+	},
+	{
+		.name = "sampling_frequency_available",
+		.show = get_sampling_frequency_available,
+		.store = set_sampling_frequency_available,
+	},
+	{
+		.name = "quadrature_tracking_en",
+		.show = get_quadrature_tracking_en,
+		.store = set_quadrature_tracking_en,
+	},
+	{
+		.name = "sampling_frequency",
+		.show = get_sampling_frequency,
+		.store = set_sampling_frequency,
+	},
+	{
+		.name = "gain_control_mode_available",
+		.show = get_gain_control_mode_available,
+		.store = set_gain_control_mode_available,
+	},
+	{
+		.name = "filter_fir_en",
+		.show = get_filter_fir_en,
+		.store = set_filter_fir_en,
+	},
+	{
+		.name = "rf_bandwidth_available",
+		.show = get_rf_bandwidth_available,
+		.store = set_rf_bandwidth_available,
+	},
+	{
+		.name = "bb_dc_offset_tracking_en",
+		.show = get_bb_dc_offset_tracking_en,
+		.store = set_bb_dc_offset_tracking_en,
+	},
+	END_ATTRIBUTES_ARRAY
 };
 
-static struct iio_attribute iio_attr_rssi = {
-	.name = "rssi",
-	.show = get_rssi,
-	.store = set_rssi,
+struct iio_attribute altvoltage_attributes[] = {
+	{
+		.name = "frequency_available",
+		.show = get_frequency_available,
+		.store = set_frequency_available,
+	},
+	{
+		.name = "fastlock_save",
+		.show = get_fastlock_save,
+		.store = set_fastlock_save,
+	},
+	{
+		.name = "powerdown",
+		.show = get_powerdown,
+		.store = set_powerdown,
+	},
+	{
+		.name = "fastlock_load",
+		.show = get_fastlock_load,
+		.store = set_fastlock_load,
+	},
+	{
+		.name = "fastlock_store",
+		.show = get_fastlock_store,
+		.store = set_fastlock_store,
+	},
+	{
+		.name = "frequency",
+		.show = get_frequency,
+		.store = set_frequency,
+	},
+	{
+		.name = "external",
+		.show = get_external,
+		.store = set_external,
+	},
+	{
+		.name = "fastlock_recall",
+		.show = get_fastlock_recall,
+		.store = set_fastlock_recall,
+	},
+	END_ATTRIBUTES_ARRAY
 };
 
-static struct iio_attribute iio_attr_hardwaregain_available = {
-	.name = "hardwaregain_available",
-	.show = get_hardwaregain_available,
-	.store = set_hardwaregain_available,
+struct iio_attribute out_attributes[] = {
+	{
+		.name = "voltage_filter_fir_en",
+		.show = get_voltage_filter_fir_en,
+		.store = set_voltage_filter_fir_en,
+	},
+	END_ATTRIBUTES_ARRAY,
 };
 
-static struct iio_attribute iio_attr_sampling_frequency_available = {
-	.name = "sampling_frequency_available",
-	.show = get_sampling_frequency_available,
-	.store = set_sampling_frequency_available,
+struct iio_attribute temp0_attributes[] = {
+	{
+		.name = "input",
+		.show = get_temp0_input,
+		.store = NULL,
+	},
+	END_ATTRIBUTES_ARRAY,
 };
 
-static struct iio_attribute iio_attr_rf_port_select_available = {
-	.name = "rf_port_select_available",
-	.show = get_rf_port_select_available,
-	.store = set_rf_port_select_available,
-};
-
-static struct iio_attribute iio_attr_filter_fir_en = {
-	.name = "filter_fir_en",
-	.show = get_filter_fir_en,
-	.store = set_filter_fir_en,
-};
-
-static struct iio_attribute iio_attr_sampling_frequency = {
-	.name = "sampling_frequency",
-	.show = get_sampling_frequency,
-	.store = set_sampling_frequency,
-};
-
-static struct iio_attribute iio_attr_rf_bandwidth_available = {
-	.name = "rf_bandwidth_available",
-	.show = get_rf_bandwidth_available,
-	.store = set_rf_bandwidth_available,
-};
-
-static struct iio_attribute iio_attr_rf_bandwidth = {
-	.name = "rf_bandwidth",
-	.show = get_rf_bandwidth,
-	.store = set_rf_bandwidth,
-};
-
-static struct iio_attribute iio_attr_gain_control_mode = {
-	.name = "gain_control_mode",
-	.show = get_gain_control_mode,
-	.store = set_gain_control_mode,
-};
-
-static struct iio_attribute iio_attr_rf_dc_offset_tracking_en = {
-	.name = "rf_dc_offset_tracking_en",
-	.show = get_rf_dc_offset_tracking_en,
-	.store = set_rf_dc_offset_tracking_en,
-};
-
-static struct iio_attribute iio_attr_quadrature_tracking_en = {
-	.name = "quadrature_tracking_en",
-	.show = get_quadrature_tracking_en,
-	.store = set_quadrature_tracking_en,
-};
-
-static struct iio_attribute iio_attr_gain_control_mode_available = {
-	.name = "gain_control_mode_available",
-	.show = get_gain_control_mode_available,
-	.store = set_gain_control_mode_available,
-};
-
-static struct iio_attribute iio_attr_bb_dc_offset_tracking_en = {
-	.name = "bb_dc_offset_tracking_en",
-	.show = get_bb_dc_offset_tracking_en,
-	.store = set_bb_dc_offset_tracking_en,
-};
-
-struct iio_attribute *voltage_output_attributes[] = {
-	&iio_attr_rf_port_select,
-	&iio_attr_hardwaregain,
-	&iio_attr_rssi,
-	&iio_attr_hardwaregain_available,
-	&iio_attr_sampling_frequency_available,
-	&iio_attr_rf_port_select_available,
-	&iio_attr_filter_fir_en,
-	&iio_attr_sampling_frequency,
-	&iio_attr_rf_bandwidth_available,
-	&iio_attr_rf_bandwidth,
-	NULL,
-};
-
-struct iio_attribute *voltage_input_attributes[] = {
-	&iio_attr_hardwaregain_available,
-	&iio_attr_hardwaregain,
-	&iio_attr_rssi,
-	&iio_attr_rf_port_select,
-	&iio_attr_gain_control_mode,
-	&iio_attr_rf_port_select_available,
-	&iio_attr_rf_bandwidth,
-	&iio_attr_rf_dc_offset_tracking_en,
-	&iio_attr_sampling_frequency_available,
-	&iio_attr_quadrature_tracking_en,
-	&iio_attr_sampling_frequency,
-	&iio_attr_gain_control_mode_available,
-	&iio_attr_filter_fir_en,
-	&iio_attr_rf_bandwidth_available,
-	&iio_attr_bb_dc_offset_tracking_en,
-	NULL,
-};
-
-static struct iio_attribute iio_attr_frequency_available = {
-	.name = "frequency_available",
-	.show = get_frequency_available,
-	.store = set_frequency_available,
-};
-
-static struct iio_attribute iio_attr_fastlock_save = {
-	.name = "fastlock_save",
-	.show = get_fastlock_save,
-	.store = set_fastlock_save,
-};
-
-static struct iio_attribute iio_attr_powerdown = {
-	.name = "powerdown",
-	.show = get_powerdown,
-	.store = set_powerdown,
-};
-
-static struct iio_attribute iio_attr_fastlock_load = {
-	.name = "fastlock_load",
-	.show = get_fastlock_load,
-	.store = set_fastlock_load,
-};
-
-static struct iio_attribute iio_attr_fastlock_store = {
-	.name = "fastlock_store",
-	.show = get_fastlock_store,
-	.store = set_fastlock_store,
-};
-
-static struct iio_attribute iio_attr_frequency = {
-	.name = "frequency",
-	.show = get_frequency,
-	.store = set_frequency,
-};
-
-static struct iio_attribute iio_attr_external = {
-	.name = "external",
-	.show = get_external,
-	.store = set_external,
-};
-
-static struct iio_attribute iio_attr_fastlock_recall = {
-	.name = "fastlock_recall",
-	.show = get_fastlock_recall,
-	.store = set_fastlock_recall,
-};
-
-struct iio_attribute *altvoltage_attributes[] = {
-	&iio_attr_frequency_available,
-	&iio_attr_fastlock_save,
-	&iio_attr_powerdown,
-	&iio_attr_fastlock_load,
-	&iio_attr_fastlock_store,
-	&iio_attr_frequency,
-	&iio_attr_external,
-	&iio_attr_fastlock_recall,
-	NULL,
-};
-
-static struct iio_attribute iio_attr_voltage_filter_fir_en = {
-	.name = "voltage_filter_fir_en",
-	.show = get_voltage_filter_fir_en,
-	.store = set_voltage_filter_fir_en,
-};
-
-struct iio_attribute *out_attributes[] = {
-	&iio_attr_voltage_filter_fir_en,
-	NULL,
-};
-
-static struct iio_attribute iio_attr_temp0_input = {
-	.name = "input",
-	.show = get_temp0_input,
-	.store = NULL,
-};
-
-struct iio_attribute *temp0_attributes[] = {
-	&iio_attr_temp0_input,
-	NULL,
-};
-
-static struct iio_attribute iio_attr_dcxo_tune_coarse = {
-	.name = "dcxo_tune_coarse",
-	.show = get_dcxo_tune_coarse,
-	.store = set_dcxo_tune_coarse,
-};
-
-static struct iio_attribute iio_attr_rx_path_rates = {
-	.name = "rx_path_rates",
-	.show = get_rx_path_rates,
-	.store = NULL,
-};
-
-static struct iio_attribute iio_attr_trx_rate_governor = {
-	.name = "trx_rate_governor",
-	.show = get_trx_rate_governor,
-	.store = set_trx_rate_governor,
-};
-
-static struct iio_attribute iio_attr_calib_mode_available = {
-	.name = "calib_mode_available",
-	.show = get_calib_mode_available,
-	.store = NULL,
-};
-
-static struct iio_attribute iio_attr_xo_correction_available = {
-	.name = "xo_correction_available",
-	.show = get_xo_correction_available,
-	.store = NULL,
-};
-
-static struct iio_attribute iio_attr_gain_table_config = {
-	.name = "gain_table_config",
-	.show = get_gain_table_config,
-	.store = NULL,
-};
-
-static struct iio_attribute iio_attr_dcxo_tune_fine = {
-	.name = "dcxo_tune_fine",
-	.show = get_dcxo_tune_fine,
-	.store = set_dcxo_tune_fine,
-};
-
-static struct iio_attribute iio_attr_dcxo_tune_fine_available = {
-	.name = "dcxo_tune_fine_available",
-	.show = get_dcxo_tune_fine_available,
-	.store = NULL,
-};
-
-static struct iio_attribute iio_attr_ensm_mode_available = {
-	.name = "ensm_mode_available",
-	.show = get_ensm_mode_available,
-	.store = NULL,
-};
-
-static struct iio_attribute iio_attr_multichip_sync = {
-	.name = "multichip_sync",
-	.show = get_multichip_sync,
-	.store = set_multichip_sync,
-};
-
-static struct iio_attribute iio_attr_rssi_gain_step_error = {
-	.name = "rssi_gain_step_error",
-	.show = get_rssi_gain_step_error,
-	.store = NULL,
-};
-
-static struct iio_attribute iio_attr_dcxo_tune_coarse_available = {
-	.name = "dcxo_tune_coarse_available",
-	.show = get_dcxo_tune_coarse_available,
-	.store = NULL,
-};
-
-static struct iio_attribute iio_attr_tx_path_rates = {
-	.name = "tx_path_rates",
-	.show = get_tx_path_rates,
-	.store = NULL,
-};
-
-static struct iio_attribute iio_attr_trx_rate_governor_available = {
-	.name = "trx_rate_governor_available",
-	.show = get_trx_rate_governor_available,
-	.store = NULL,
-};
-
-static struct iio_attribute iio_attr_xo_correction = {
-	.name = "xo_correction",
-	.show = get_xo_correction,
-	.store = NULL,
-};
-
-static struct iio_attribute iio_attr_ensm_mode = {
-	.name = "ensm_mode",
-	.show = get_ensm_mode,
-	.store = set_ensm_mode,
-};
-
-static struct iio_attribute iio_attr_filter_fir_config = {
-	.name = "filter_fir_config",
-	.show = get_filter_fir_config,
-	.store = set_filter_fir_config,
-};
-
-static struct iio_attribute iio_attr_calib_mode = {
-	.name = "calib_mode",
-	.show = get_calib_mode,
-	.store = set_calib_mode,
-};
-
-static struct iio_attribute *global_attributes[] = {
-	&iio_attr_dcxo_tune_coarse,
-	&iio_attr_rx_path_rates,
-	&iio_attr_trx_rate_governor,
-	&iio_attr_calib_mode_available,
-	&iio_attr_xo_correction_available,
-	&iio_attr_gain_table_config,
-	&iio_attr_dcxo_tune_fine,
-	&iio_attr_dcxo_tune_fine_available,
-	&iio_attr_ensm_mode_available,
-	&iio_attr_multichip_sync,
-	&iio_attr_rssi_gain_step_error,
-	&iio_attr_dcxo_tune_coarse_available,
-	&iio_attr_tx_path_rates,
-	&iio_attr_trx_rate_governor_available,
-	&iio_attr_xo_correction,
-	&iio_attr_ensm_mode,
-	&iio_attr_filter_fir_config,
-	&iio_attr_calib_mode,
-	NULL,
+static struct iio_attribute global_attributes[] = {
+	{
+		.name = "dcxo_tune_coarse",
+		.show = get_dcxo_tune_coarse,
+		.store = set_dcxo_tune_coarse,
+	},
+	{
+		.name = "rx_path_rates",
+		.show = get_rx_path_rates,
+		.store = NULL,
+	},
+	{
+		.name = "trx_rate_governor",
+		.show = get_trx_rate_governor,
+		.store = set_trx_rate_governor,
+	},
+	{
+		.name = "calib_mode_available",
+		.show = get_calib_mode_available,
+		.store = NULL,
+	},
+	{
+		.name = "xo_correction_available",
+		.show = get_xo_correction_available,
+		.store = NULL,
+	},
+	{
+		.name = "gain_table_config",
+		.show = get_gain_table_config,
+		.store = NULL,
+	},
+	{
+		.name = "dcxo_tune_fine",
+		.show = get_dcxo_tune_fine,
+		.store = set_dcxo_tune_fine,
+	},
+	{
+		.name = "dcxo_tune_fine_available",
+		.show = get_dcxo_tune_fine_available,
+		.store = NULL,
+	},
+	{
+		.name = "ensm_mode_available",
+		.show = get_ensm_mode_available,
+		.store = NULL,
+	},
+	{
+		.name = "multichip_sync",
+		.show = get_multichip_sync,
+		.store = set_multichip_sync,
+	},
+	{
+		.name = "rssi_gain_step_error",
+		.show = get_rssi_gain_step_error,
+		.store = NULL,
+	},
+	{
+		.name = "dcxo_tune_coarse_available",
+		.show = get_dcxo_tune_coarse_available,
+		.store = NULL,
+	},
+	{
+		.name = "tx_path_rates",
+		.show = get_tx_path_rates,
+		.store = NULL,
+	},
+	{
+		.name = "trx_rate_governor_available",
+		.show = get_trx_rate_governor_available,
+		.store = NULL,
+	},
+	{
+		.name = "xo_correction",
+		.show = get_xo_correction,
+		.store = NULL,
+	},
+	{
+		.name = "ensm_mode",
+		.show = get_ensm_mode,
+		.store = set_ensm_mode,
+	},
+	{
+		.name = "filter_fir_config",
+		.show = get_filter_fir_config,
+		.store = set_filter_fir_config,
+	},
+	{
+		.name = "calib_mode",
+		.show = get_calib_mode,
+		.store = set_calib_mode,
+	},
+	END_ATTRIBUTES_ARRAY,
 };
 
 static struct iio_channel iio_channel_voltage0_in = {

--- a/iio/iio_adxrs290/iio_adxrs290.c
+++ b/iio/iio_adxrs290/iio_adxrs290.c
@@ -84,7 +84,8 @@ static const int adxrs290_hpf_3db_freq_hz_table[][2] = {
 };
 
 ssize_t get_adxrs290_iio_ch_raw(void *device, char *buf, size_t len,
-				const struct iio_ch_info *channel)
+				const struct iio_ch_info *channel,
+				intptr_t priv)
 {
 	int16_t data;
 
@@ -98,7 +99,8 @@ ssize_t get_adxrs290_iio_ch_raw(void *device, char *buf, size_t len,
 
 
 ssize_t get_adxrs290_iio_ch_scale(void *device, char *buf, size_t len,
-				  const struct iio_ch_info *channel)
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
 {
 	if (channel->ch_num == ADXRS290_CHANNEL_TEMP)
 		// Temperature scale 1 LSB = 0.1 degree Celsius
@@ -109,7 +111,8 @@ ssize_t get_adxrs290_iio_ch_scale(void *device, char *buf, size_t len,
 }
 
 ssize_t get_adxrs290_iio_ch_hpf(void *device, char *buf, size_t len,
-				const struct iio_ch_info *channel)
+				const struct iio_ch_info *channel,
+				intptr_t priv)
 {
 	uint8_t index;
 	adxrs290_get_hpf((struct adxrs290_dev *)device, &index);
@@ -122,7 +125,8 @@ ssize_t get_adxrs290_iio_ch_hpf(void *device, char *buf, size_t len,
 }
 
 ssize_t set_adxrs290_iio_ch_hpf(void *device, char *buf, size_t len,
-				const struct iio_ch_info *channel)
+				const struct iio_ch_info *channel,
+				intptr_t priv)
 {
 	float hpf = strtof(buf, NULL);
 	int32_t val = (int32_t)hpf;
@@ -142,7 +146,8 @@ ssize_t set_adxrs290_iio_ch_hpf(void *device, char *buf, size_t len,
 }
 
 ssize_t get_adxrs290_iio_ch_lpf(void *device, char *buf, size_t len,
-				const struct iio_ch_info *channel)
+				const struct iio_ch_info *channel,
+				intptr_t priv)
 {
 	uint8_t index;
 
@@ -155,7 +160,8 @@ ssize_t get_adxrs290_iio_ch_lpf(void *device, char *buf, size_t len,
 }
 
 ssize_t set_adxrs290_iio_ch_lpf(void *device, char *buf, size_t len,
-				const struct iio_ch_info *channel)
+				const struct iio_ch_info *channel,
+				intptr_t priv)
 {
 	float lpf = strtof(buf, NULL);
 	int32_t val = (int32_t)lpf;

--- a/iio/iio_adxrs290/iio_adxrs290.h
+++ b/iio/iio_adxrs290/iio_adxrs290.h
@@ -43,21 +43,21 @@
 #include "iio_types.h"
 
 ssize_t get_adxrs290_iio_reg(void *device, char *buf, size_t len,
-			     const struct iio_ch_info *channel);
+			     const struct iio_ch_info *channel, intptr_t priv);
 ssize_t set_adxrs290_iio_reg(void *device, char *buf, size_t len,
-			     const struct iio_ch_info *channel);
+			     const struct iio_ch_info *channel, intptr_t priv);
 ssize_t get_adxrs290_iio_ch_raw(void *device, char *buf, size_t len,
-				const struct iio_ch_info *channel);
+				const struct iio_ch_info *channel, intptr_t priv);
 ssize_t get_adxrs290_iio_ch_scale(void *device, char *buf, size_t len,
-				  const struct iio_ch_info *channel);
+				  const struct iio_ch_info *channel, intptr_t priv);
 ssize_t set_adxrs290_iio_ch_hpf(void *device, char *buf, size_t len,
-				const struct iio_ch_info *channel);
+				const struct iio_ch_info *channel, intptr_t priv);
 ssize_t get_adxrs290_iio_ch_hpf(void *device, char *buf, size_t len,
-				const struct iio_ch_info *channel);
+				const struct iio_ch_info *channel, intptr_t priv);
 ssize_t set_adxrs290_iio_ch_lpf(void *device, char *buf, size_t len,
-				const struct iio_ch_info *channel);
+				const struct iio_ch_info *channel, intptr_t priv);
 ssize_t get_adxrs290_iio_ch_lpf(void *device, char *buf, size_t len,
-				const struct iio_ch_info *channel);
+				const struct iio_ch_info *channel, intptr_t priv);
 
 
 static struct iio_attribute adxrs290_iio_vel_attrs[] = {

--- a/iio/iio_adxrs290/iio_adxrs290.h
+++ b/iio/iio_adxrs290/iio_adxrs290.h
@@ -59,42 +59,43 @@ ssize_t set_adxrs290_iio_ch_lpf(void *device, char *buf, size_t len,
 ssize_t get_adxrs290_iio_ch_lpf(void *device, char *buf, size_t len,
 				const struct iio_ch_info *channel);
 
-static struct iio_attribute adxrs290_iio_ch_attr_3db_hpf_freq_val = {
-	.name = "filter_high_pass_3db_frequency",
-	.show = get_adxrs290_iio_ch_hpf,
-	.store = set_adxrs290_iio_ch_hpf
+
+static struct iio_attribute adxrs290_iio_vel_attrs[] = {
+	{
+		.name = "filter_high_pass_3db_frequency",
+		.show = get_adxrs290_iio_ch_hpf,
+		.store = set_adxrs290_iio_ch_hpf
+	},
+	{
+		.name = "filter_low_pass_3db_frequency",
+		.show = get_adxrs290_iio_ch_lpf,
+		.store = set_adxrs290_iio_ch_lpf
+	},
+	{
+		.name = "raw",
+		.show = get_adxrs290_iio_ch_raw,
+		.store = NULL
+	},
+	{
+		.name = "scale",
+		.show = get_adxrs290_iio_ch_scale,
+		.store = NULL
+	},
+	END_ATTRIBUTES_ARRAY
 };
 
-static struct iio_attribute adxrs290_iio_ch_attr_3db_lpf_freq_val = {
-	.name = "filter_low_pass_3db_frequency",
-	.show = get_adxrs290_iio_ch_lpf,
-	.store = set_adxrs290_iio_ch_lpf
-};
-
-static struct iio_attribute adxrs290_iio_ch_attr_raw = {
-	.name = "raw",
-	.show = get_adxrs290_iio_ch_raw,
-	.store = NULL
-};
-
-static struct iio_attribute adxrs290_iio_ch_attr_scale = {
-	.name = "scale",
-	.show = get_adxrs290_iio_ch_scale,
-	.store = NULL
-};
-
-static struct iio_attribute *adxrs290_iio_vel_attrs[] = {
-	&adxrs290_iio_ch_attr_3db_hpf_freq_val,
-	&adxrs290_iio_ch_attr_3db_lpf_freq_val,
-	&adxrs290_iio_ch_attr_raw,
-	&adxrs290_iio_ch_attr_scale,
-	NULL,
-};
-
-static struct iio_attribute *adxrs290_iio_temp_attrs[] = {
-	&adxrs290_iio_ch_attr_raw,
-	&adxrs290_iio_ch_attr_scale,
-	NULL,
+static struct iio_attribute adxrs290_iio_temp_attrs[] = {
+	{
+		.name = "raw",
+		.show = get_adxrs290_iio_ch_raw,
+		.store = NULL
+	},
+	{
+		.name = "scale",
+		.show = get_adxrs290_iio_ch_scale,
+		.store = NULL
+	},
+	END_ATTRIBUTES_ARRAY,
 };
 
 static struct iio_channel adxrs290_iio_channel_x = {

--- a/iio/iio_axi_adc/iio_axi_adc.c
+++ b/iio/iio_axi_adc/iio_axi_adc.c
@@ -65,7 +65,8 @@
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_calibphase(void *device, char *buf, size_t len,
-			      const struct iio_ch_info *channel)
+			      const struct iio_ch_info *channel,
+			      intptr_t priv)
 {
 	int32_t val, val2;
 	int32_t i = 0;
@@ -92,7 +93,8 @@ static ssize_t get_calibphase(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_calibbias(void *device, char *buf, size_t len,
-			     const struct iio_ch_info *channel)
+			     const struct iio_ch_info *channel,
+			     intptr_t priv)
 {
 	int32_t val;
 	ssize_t ret;
@@ -117,7 +119,8 @@ static ssize_t get_calibbias(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_calibscale(void *device, char *buf, size_t len,
-			      const struct iio_ch_info *channel)
+			      const struct iio_ch_info *channel,
+			      intptr_t priv)
 {
 	int32_t val, val2;
 	int32_t i = 0;
@@ -148,7 +151,8 @@ static ssize_t get_calibscale(void *device, char *buf, size_t len,
  * @return: Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_samples_pps(void *device, char *buf, size_t len,
-			       const struct iio_ch_info *channel)
+			       const struct iio_ch_info *channel,
+			       intptr_t priv)
 {
 	/* This function doesn't have an equivalent function in axi_adc_core,
 	 * and it should be implemented there first */
@@ -165,7 +169,8 @@ static ssize_t get_samples_pps(void *device, char *buf, size_t len,
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_sampling_frequency(void *device, char *buf, size_t len,
-				      const struct iio_ch_info *channel)
+				      const struct iio_ch_info *channel,
+				      intptr_t priv)
 {
 	uint64_t sampling_freq_hz;
 	ssize_t ret;
@@ -192,7 +197,8 @@ static ssize_t get_sampling_frequency(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_calibphase(void *device, char *buf, size_t len,
-			      const struct iio_ch_info *channel)
+			      const struct iio_ch_info *channel,
+			      intptr_t priv)
 {
 	ssize_t ret;
 	float calib = strtof(buf, NULL);
@@ -216,7 +222,8 @@ static ssize_t set_calibphase(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_calibbias(void *device, char *buf, size_t len,
-			     const struct iio_ch_info *channel)
+			     const struct iio_ch_info *channel,
+			     intptr_t priv)
 {
 	int32_t val = str_to_int32(buf);
 	struct iio_axi_adc_desc *iio_adc = (struct iio_axi_adc_desc *)device;
@@ -241,7 +248,8 @@ static ssize_t set_calibbias(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_calibscale(void *device, char *buf, size_t len,
-			      const struct iio_ch_info *channel)
+			      const struct iio_ch_info *channel,
+			      intptr_t priv)
 {
 	float calib= strtof(buf, NULL);
 	int32_t val = (int32_t)calib;
@@ -264,7 +272,8 @@ static ssize_t set_calibscale(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_samples_pps(void *device, char *buf, size_t len,
-			       const struct iio_ch_info *channel)
+			       const struct iio_ch_info *channel,
+			       intptr_t priv)
 {
 	/* This function doesn't have an equivalent function in axi_adc_core,
 	 * and it should be implemented there first */
@@ -281,7 +290,8 @@ static ssize_t set_samples_pps(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_sampling_frequency(void *device, char *buf, size_t len,
-				      const struct iio_ch_info *channel)
+				      const struct iio_ch_info *channel,
+				      intptr_t priv)
 {
 	/* This function doesn't have an equivalent function in axi_adc_core,
 	 * and it should be implemented there first */

--- a/iio/iio_axi_adc/iio_axi_adc.c
+++ b/iio/iio_axi_adc/iio_axi_adc.c
@@ -289,81 +289,37 @@ static ssize_t set_sampling_frequency(void *device, char *buf, size_t len,
 	return -ENOENT;
 }
 
-/**
- * @struct iio_attr_calibphase
- * @brief Structure for "calibphase" attribute.
- */
-static struct iio_attribute iio_attr_calibphase = {
-	/** Attribute name */
-	.name = "calibphase",
-	/** Read attribute from device */
-	.show = get_calibphase,
-	/** Write attribute to device */
-	.store = set_calibphase,
-};
-
-/**
- * @struct iio_attr_calibbias
- * @brief Structure for "calibbias" attribute.
- */
-static struct iio_attribute iio_attr_calibbias = {
-	/** Attribute name */
-	.name = "calibbias",
-	/** Read attribute from device */
-	.show = get_calibbias,
-	/** Write attribute to device */
-	.store = set_calibbias,
-};
-
-/**
- * @struct iio_attr_calibscale
- * @brief Structure for "calibscale" attribute.
- */
-static struct iio_attribute iio_attr_calibscale = {
-	/** Attribute name */
-	.name = "calibscale",
-	/** Read attribute from device */
-	.show = get_calibscale,
-	/** Write attribute to device */
-	.store = set_calibscale,
-};
-
-/**
- * @struct iio_attr_samples_pps
- * @brief Structure for "samples_pps" attribute.
- */
-static struct iio_attribute iio_attr_samples_pps = {
-	/** Attribute name */
-	.name = "samples_pps",
-	/** Read attribute from device */
-	.show = get_samples_pps,
-	/** Write attribute to device */
-	.store = set_samples_pps,
-};
-
-/**
- * @struct iio_attr_sampling_frequency
- * @brief Structure for "sampling_frequency" attribute.
- */
-static struct iio_attribute iio_attr_sampling_frequency = {
-	/** Attribute name */
-	.name = "sampling_frequency",
-	/** Read attribute from device */
-	.show = get_sampling_frequency,
-	/** Write attribute to device */
-	.store = set_sampling_frequency,
-};
 
 /**
  * List containing attributes, corresponding to "voltage" channels.
  */
-static struct iio_attribute *iio_voltage_attributes[] = {
-	&iio_attr_calibphase,
-	&iio_attr_calibbias,
-	&iio_attr_calibscale,
-	&iio_attr_samples_pps,
-	&iio_attr_sampling_frequency,
-	NULL,
+static struct iio_attribute iio_voltage_attributes[] = {
+	{
+		.name = "calibphase",
+		.show = get_calibphase,
+		.store = set_calibphase,
+	},
+	{
+		.name = "calibbias",
+		.show = get_calibbias,
+		.store = set_calibbias,
+	},
+	{
+		.name = "calibscale",
+		.show = get_calibscale,
+		.store = set_calibscale,
+	},
+	{
+		.name = "samples_pps",
+		.show = get_samples_pps,
+		.store = set_samples_pps,
+	},
+	{
+		.name = "sampling_frequency",
+		.show = get_sampling_frequency,
+		.store = set_sampling_frequency,
+	},
+	END_ATTRIBUTES_ARRAY
 };
 
 /**

--- a/iio/iio_axi_dac/iio_axi_dac.c
+++ b/iio/iio_axi_dac/iio_axi_dac.c
@@ -65,7 +65,8 @@
  * @return Length of chars written in buf, or negative value on failure.
  */
 static ssize_t get_voltage_calibscale(void *device, char *buf, size_t len,
-				      const struct iio_ch_info *channel)
+				      const struct iio_ch_info *channel,
+				      intptr_t priv)
 {
 	int32_t val, val2;
 	struct iio_axi_dac_desc *iio_dac = (struct iio_axi_dac_desc*)device;
@@ -95,7 +96,8 @@ static ssize_t get_voltage_calibscale(void *device, char *buf, size_t len,
  * @return Number of bytes written in buf, or negative value on failure.
  */
 static ssize_t get_voltage_calibphase(void *device, char *buf, size_t len,
-				      const struct iio_ch_info *channel)
+				      const struct iio_ch_info *channel,
+				      intptr_t priv)
 {
 	int32_t val, val2;
 	int32_t i = 0;
@@ -120,7 +122,8 @@ static ssize_t get_voltage_calibphase(void *device, char *buf, size_t len,
  */
 static ssize_t get_voltage_sampling_frequency(void *device, char *buf,
 		size_t len,
-		const struct iio_ch_info *channel)
+		const struct iio_ch_info *channel,
+		intptr_t priv)
 {
 	/* This function doesn't have an equivalent function in axi_dac_core,
 	 * and it should be implemented there first */
@@ -137,7 +140,8 @@ static ssize_t get_voltage_sampling_frequency(void *device, char *buf,
  * @return Number of bytes written in buf, or negative value on failure.
  */
 static ssize_t get_altvoltage_phase(void *device, char *buf, size_t len,
-				    const struct iio_ch_info *channel)
+				    const struct iio_ch_info *channel,
+				    intptr_t priv)
 {
 	uint32_t phase;
 	struct iio_axi_dac_desc* iio_dac = (struct iio_axi_dac_desc*)device;
@@ -157,7 +161,8 @@ static ssize_t get_altvoltage_phase(void *device, char *buf, size_t len,
  * @return Number of bytes written in buf, or negative value on failure.
  */
 static ssize_t get_altvoltage_scale(void *device, char *buf, size_t len,
-				    const struct iio_ch_info *channel)
+				    const struct iio_ch_info *channel,
+				    intptr_t priv)
 {
 	int32_t scale;
 	struct iio_axi_dac_desc* iio_dac = (struct iio_axi_dac_desc*)device;
@@ -178,7 +183,8 @@ static ssize_t get_altvoltage_scale(void *device, char *buf, size_t len,
  * @return Number of bytes written in buf, or negative value on failure.
  */
 static ssize_t get_altvoltage_frequency(void *device, char *buf, size_t len,
-					const struct iio_ch_info *channel)
+					const struct iio_ch_info *channel,
+					intptr_t priv)
 {
 	uint32_t freq;
 	struct iio_axi_dac_desc* iio_dac = (struct iio_axi_dac_desc*)device;
@@ -198,7 +204,8 @@ static ssize_t get_altvoltage_frequency(void *device, char *buf, size_t len,
  * @return Number of bytes written in buf, or negative value on failure.
  */
 static ssize_t get_altvoltage_raw(void *device, char *buf, size_t len,
-				  const struct iio_ch_info *channel)
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
 {
 	/* This function doesn't have an equivalent function in axi_dac_core,
 	 * and it should be implemented there first */
@@ -216,7 +223,8 @@ static ssize_t get_altvoltage_raw(void *device, char *buf, size_t len,
  */
 static ssize_t get_altvoltage_sampling_frequency(void *device, char *buf,
 		size_t len,
-		const struct iio_ch_info *channel)
+		const struct iio_ch_info *channel,
+		intptr_t priv)
 {
 	/* This function doesn't have an equivalent function in axi_dac_core,
 	 * and it should be implemented there first */
@@ -233,7 +241,8 @@ static ssize_t get_altvoltage_sampling_frequency(void *device, char *buf,
  * @return Number of bytes written in buf, or negative value on failure.
  */
 static ssize_t set_voltage_calibscale(void *device, char *buf, size_t len,
-				      const struct iio_ch_info *channel)
+				      const struct iio_ch_info *channel,
+				      intptr_t priv)
 {
 	float calib= strtof(buf, NULL);
 	int32_t val = (int32_t)calib;
@@ -256,7 +265,8 @@ static ssize_t set_voltage_calibscale(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_voltage_calibphase(void *device, char *buf, size_t len,
-				      const struct iio_ch_info *channel)
+				      const struct iio_ch_info *channel,
+				      intptr_t priv)
 {
 	float calib = strtof(buf, NULL);
 	int32_t val = (int32_t)calib;
@@ -280,7 +290,8 @@ static ssize_t set_voltage_calibphase(void *device, char *buf, size_t len,
  */
 static ssize_t set_voltage_sampling_frequency(void *device, char *buf,
 		size_t len,
-		const struct iio_ch_info *channel)
+		const struct iio_ch_info *channel,
+		intptr_t priv)
 {
 	/* This function doesn't have an equivalent function in axi_dac_core,
 	 * and it should be implemented there first */
@@ -297,7 +308,8 @@ static ssize_t set_voltage_sampling_frequency(void *device, char *buf,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_altvoltage_phase(void *device, char *buf, size_t len,
-				    const struct iio_ch_info *channel)
+				    const struct iio_ch_info *channel,
+				    intptr_t priv)
 {
 	uint32_t phase = srt_to_uint32(buf);
 	struct iio_axi_dac_desc * iio_dac = (struct iio_axi_dac_desc *)device;
@@ -317,7 +329,8 @@ static ssize_t set_altvoltage_phase(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_altvoltage_scale(void *device, char *buf, size_t len,
-				    const struct iio_ch_info *channel)
+				    const struct iio_ch_info *channel,
+				    intptr_t priv)
 {
 	float fscale = strtof(buf, NULL);
 	int32_t scale = fscale * 1000000;
@@ -338,7 +351,8 @@ static ssize_t set_altvoltage_scale(void *device, char *buf, size_t len,
  * @return Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_altvoltage_frequency(void *device, char *buf, size_t len,
-					const struct iio_ch_info *channel)
+					const struct iio_ch_info *channel,
+					intptr_t priv)
 {
 	uint32_t freq = srt_to_uint32(buf);
 	struct iio_axi_dac_desc* iio_dac = (struct iio_axi_dac_desc*)device;
@@ -358,7 +372,8 @@ static ssize_t set_altvoltage_frequency(void *device, char *buf, size_t len,
  * @return: Number of bytes written to device, or negative value on failure.
  */
 static ssize_t set_altvoltage_raw(void *device, char *buf, size_t len,
-				  const struct iio_ch_info *channel)
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
 {
 	uint32_t dds_mode = srt_to_uint32(buf);
 	struct iio_axi_dac_desc* iio_dac = (struct iio_axi_dac_desc*)device;
@@ -381,7 +396,8 @@ static ssize_t set_altvoltage_raw(void *device, char *buf, size_t len,
  */
 static ssize_t set_altvoltage_sampling_frequency(void *device, char *buf,
 		size_t len,
-		const struct iio_ch_info *channel)
+		const struct iio_ch_info *channel,
+		intptr_t priv)
 {
 	/* This function doesn't have an equivalent function in axi_dac_core,
 	 * and it should be implemented there first */

--- a/iio/iio_axi_dac/iio_axi_dac.c
+++ b/iio/iio_axi_dac/iio_axi_dac.c
@@ -390,130 +390,57 @@ static ssize_t set_altvoltage_sampling_frequency(void *device, char *buf,
 }
 
 /**
- * @struct iio_attr_voltage_calibphase
- * @brief Structure for "calibphase" attribute.
- */
-static struct iio_attribute iio_attr_voltage_calibphase = {
-	/** Attribute name */
-	.name = "calibphase",
-	/** Read attribute from device */
-	.show = get_voltage_calibphase,
-	/** Write attribute to device */
-	.store = set_voltage_calibphase,
-};
-
-/**
- * @struct iio_attr_voltage_calibscale
- * @brief Structure for "calibscale" attribute.
- */
-static struct iio_attribute iio_attr_voltage_calibscale = {
-	/** Attribute name */
-	.name = "calibscale",
-	/** Read attribute from device */
-	.show = get_voltage_calibscale,
-	/** Write attribute to device */
-	.store = set_voltage_calibscale,
-
-};
-
-/**
- * @struct iio_attr_voltage_sampling_frequency
- * @brief Structure for "sampling_frequency" attribute.
- */
-static struct iio_attribute iio_attr_voltage_sampling_frequency = {
-	/** Attribute name */
-	.name = "sampling_frequency",
-	/** Read attribute from device */
-	.show = get_voltage_sampling_frequency,
-	/** Write attribute to device */
-	.store = set_voltage_sampling_frequency,
-};
-
-/**
- * @struct iio_attr_altvoltage_raw
- * @brief Structure for "raw" attribute.
- */
-static struct iio_attribute iio_attr_altvoltage_raw = {
-	/** Attribute name */
-	.name = "raw",
-	/** Read attribute from device */
-	.show = get_altvoltage_raw,
-	/** Write attribute to device */
-	.store = set_altvoltage_raw,
-};
-
-/**
- * @struct iio_attr_altvoltage_phase
- * @brief Structure for "phase" attribute.
- */
-static struct iio_attribute iio_attr_altvoltage_phase = {
-	/** Attribute name */
-	.name = "phase",
-	/** Read attribute from device */
-	.show = get_altvoltage_phase,
-	/** Write attribute to device */
-	.store = set_altvoltage_phase,
-};
-
-/**
- * @struct iio_attr_altvoltage_frequency
- * @brief Structure for "frequency" attribute.
- */
-static struct iio_attribute iio_attr_altvoltage_frequency = {
-	/** Attribute name */
-	.name = "frequency",
-	/** Read attribute from device */
-	.show = get_altvoltage_frequency,
-	/** Write attribute to device */
-	.store = set_altvoltage_frequency,
-};
-
-/**
- * @struct iio_attr_altvoltage_scale
- * @brief Structure for "scale" attribute.
- */
-static struct iio_attribute iio_attr_altvoltage_scale = {
-	/** Attribute name */
-	.name = "scale",
-	/** Read attribute from device */
-	.show = get_altvoltage_scale,
-	/** Write attribute to device */
-	.store = set_altvoltage_scale,
-};
-
-/**
- * @struct iio_attr_altvoltage_sampling_frequency
- * @brief Structure for "sampling_frequency" attribute.
- */
-static struct iio_attribute iio_attr_altvoltage_sampling_frequency = {
-	/** Attribute name */
-	.name = "sampling_frequency",
-	/** Read attribute from device */
-	.show = get_altvoltage_sampling_frequency,
-	/** Write attribute to device */
-	.store = set_altvoltage_sampling_frequency,
-};
-
-/**
  * List containing attributes, corresponding to "voltage" channels.
  */
-static struct iio_attribute *iio_voltage_attributes[] = {
-	&iio_attr_voltage_calibscale,
-	&iio_attr_voltage_calibphase,
-	&iio_attr_voltage_sampling_frequency,
-	NULL,
+static struct iio_attribute iio_voltage_attributes[] = {
+	{
+		.name = "calibscale",
+		.show = get_voltage_calibscale,
+		.store = set_voltage_calibscale,
+	},
+	{
+		.name = "calibphase",
+		.show = get_voltage_calibphase,
+		.store = set_voltage_calibphase,
+	},
+	{
+		.name = "sampling_frequency",
+		.show = get_voltage_sampling_frequency,
+		.store = set_voltage_sampling_frequency,
+	},
+	END_ATTRIBUTES_ARRAY
 };
 
 /**
  * List containing attributes, corresponding to "altvoltage" channels.
  */
-static struct iio_attribute *iio_altvoltage_attributes[] = {
-	&iio_attr_altvoltage_raw,
-	&iio_attr_altvoltage_phase,
-	&iio_attr_altvoltage_scale,
-	&iio_attr_altvoltage_frequency,
-	&iio_attr_altvoltage_sampling_frequency,
-	NULL,
+static struct iio_attribute iio_altvoltage_attributes[] = {
+	{
+		.name = "raw",
+		.show = get_altvoltage_raw,
+		.store = set_altvoltage_raw,
+	},
+	{
+		.name = "phase",
+		.show = get_altvoltage_phase,
+		.store = set_altvoltage_phase,
+	},
+	{
+		.name = "scale",
+		.show = get_altvoltage_scale,
+		.store = set_altvoltage_scale,
+	},
+	{
+		.name = "frequency",
+		.show = get_altvoltage_frequency,
+		.store = set_altvoltage_frequency,
+	},
+	{
+		.name = "sampling_frequency",
+		.show = get_altvoltage_sampling_frequency,
+		.store = set_altvoltage_sampling_frequency,
+	},
+	END_ATTRIBUTES_ARRAY,
 };
 
 /**

--- a/iio/iio_demo/demo_dev.c
+++ b/iio/iio_demo/demo_dev.c
@@ -46,6 +46,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "demo_dev.h"
+#include "iio_demo_dev.h"
 #include "error.h"
 #include "util.h"
 
@@ -76,68 +77,61 @@ int32_t iio_demo_reg_read(struct iio_demo_desc *desc, uint32_t reg,
 }
 
 /**
- * @brief get_demo_channel_attr().
+ * @brief get_demo_attr().
  * @param device- Physical instance of a iio_demo_device.
  * @param buf - Where value is stored.
  * @param len - Maximum length of value to be stored in buf.
  * @param channel - Channel properties.
+ * @param priv - Attribute ID
  * @return Length of chars written in buf, or negative value on failure.
  */
-ssize_t get_demo_channel_attr(void *device, char *buf, size_t len,
-			      const struct iio_ch_info *channel)
+ssize_t get_demo_attr(void *device, char *buf, size_t len,
+		      const struct iio_ch_info *channel, intptr_t priv)
 {
 	struct iio_demo_desc *desc = device;
 
-	return snprintf(buf, len, "%"PRIu32"", desc->dev_ch_attr);
+	if (channel) {
+		if (priv == DEMO_CHANNEL_ATTR)
+			return snprintf(buf, len, "%"PRIu32"",
+					desc->dev_ch_attr);
+	} else {
+		if (priv == DEMO_GLOBAL_ATTR)
+			return snprintf(buf, len, "%"PRIu32"",
+					desc->dev_global_attr);
+	}
+
+	return -EINVAL;
 }
 
 /**
- * @brief set_demo_channel_attr().
+ * @brief set_demo_attr().
  * @param device - Physical instance of a iio_demo_device.
  * @param buf - Value to be written to attribute.
  * @param len -	Length of the data in "buf".
  * @param channel - Channel properties.
+ * @param priv - Attribute ID
  * @return: Number of bytes written to device, or negative value on failure.
  */
-ssize_t set_demo_channel_attr(void *device, char *buf, size_t len,
-			      const struct iio_ch_info *channel)
+ssize_t set_demo_attr(void *device, char *buf, size_t len,
+		      const struct iio_ch_info *channel, intptr_t priv)
 {
 	struct iio_demo_desc *desc = device;
-	desc->dev_ch_attr = srt_to_uint32(buf);
+	uint32_t val = srt_to_uint32(buf);
 
-	return len;
-}
+	if (channel) {
+		if (priv == DEMO_CHANNEL_ATTR) {
+			desc->dev_ch_attr = val;
+			return len;
+		}
+	} else {
+		if (priv == DEMO_GLOBAL_ATTR) {
+			desc->dev_global_attr = val;
+			return len;
+		}
+	}
 
-/**
- * @brief get_demo_global_attr().
- * @param device- Physical instance of a iio_demo_device.
- * @param buf - Where value is stored.
- * @param len - Maximum length of value to be stored in buf.
- * @param channel - Channel properties.
- * @return Length of chars written in buf, or negative value on failure.
- */
-ssize_t get_demo_global_attr(void *device, char *buf, size_t len,
-			     const struct iio_ch_info *channel)
-{
-	struct iio_demo_desc *desc = device;
-	return snprintf(buf, len, "%"PRIu32"", desc->dev_global_attr);
-}
+	return -EINVAL;
 
-/**
- * @brief set_demo_global_attr().
- * @param device - Physical instance of a iio_demo_device.
- * @param buf - Value to be written to attribute.
- * @param len -	Length of the data in "buf".
- * @param channel - Channel properties.
- * @return: Number of bytes written to device, or negative value on failure.
- */
-ssize_t set_demo_global_attr(void *device, char *buf, size_t len,
-			     const struct iio_ch_info *channel)
-{
-	struct iio_demo_desc *desc = device;
-	desc->dev_global_attr = srt_to_uint32(buf);
-
-	return len;
 }
 
 int32_t iio_demo_update_active_channels(void *dev, uint32_t mask)

--- a/iio/iio_demo/demo_dev.h
+++ b/iio/iio_demo/demo_dev.h
@@ -91,14 +91,10 @@ struct iio_demo_init_param {
 /************************ Functions Declarations ******************************/
 /******************************************************************************/
 
-ssize_t get_demo_channel_attr(void *device, char *buf, size_t len,
-			      const struct iio_ch_info *channel);
-ssize_t set_demo_channel_attr(void *device, char *buf, size_t len,
-			      const struct iio_ch_info *channel);
-ssize_t get_demo_global_attr(void *device, char *buf, size_t len,
-			     const struct iio_ch_info *channel);
-ssize_t set_demo_global_attr(void *device, char *buf, size_t len,
-			     const struct iio_ch_info *channel);
+ssize_t get_demo_attr(void *device, char *buf, size_t len,
+		      const struct iio_ch_info *channel, intptr_t priv);
+ssize_t set_demo_attr(void *device, char *buf, size_t len,
+		      const struct iio_ch_info *channel, intptr_t priv);
 
 int32_t iio_demo_reg_read(struct iio_demo_desc *desc, uint32_t reg,
 			  uint32_t *readval);

--- a/iio/iio_demo/iio_demo_dev.h
+++ b/iio/iio_demo/iio_demo_dev.h
@@ -43,21 +43,26 @@
 #include <stdlib.h>
 #include "demo_dev.h"
 
-static struct iio_attribute iio_attr_demo_channel = {
-	.name = "demo_channel_attr",
-	.show = get_demo_channel_attr,
-	.store = set_demo_channel_attr,
+enum iio_demo_attributes {
+	DEMO_CHANNEL_ATTR,
+	DEMO_GLOBAL_ATTR,
 };
 
-static struct iio_attribute iio_attr_demo_global = {
-	.name = "demo_global_attr",
-	.show = get_demo_global_attr,
-	.store = set_demo_global_attr,
+#define IIO_DEMO_ATTR(_name, _priv) {\
+	.name = _name,\
+	.priv = _priv,\
+	.show = get_demo_attr,\
+	.store = set_demo_attr\
+}
+
+static struct iio_attribute demo_channel_attributes[] = {
+	IIO_DEMO_ATTR("demo_channel_attr", DEMO_CHANNEL_ATTR),
+	END_ATTRIBUTES_ARRAY,
 };
 
-static struct iio_attribute *demo_channel_attributes[] = {
-	&iio_attr_demo_channel,
-	NULL,
+static struct iio_attribute iio_demo_global_attributes[] = {
+	IIO_DEMO_ATTR("demo_global_attr", DEMO_GLOBAL_ATTR),
+	END_ATTRIBUTES_ARRAY,
 };
 
 static struct scan_type scan_type = {
@@ -121,11 +126,6 @@ static struct iio_channel *iio_demo_channels_in[] = {
 static struct iio_channel *iio_demo_channels_out[] = {
 	&iio_demo_channel_voltage0_out,
 	&iio_demo_channel_voltage1_out,
-	NULL,
-};
-
-static struct iio_attribute *iio_demo_global_attributes[] = {
-	&iio_attr_demo_global,
 	NULL,
 };
 

--- a/libraries/iio/iio.c
+++ b/libraries/iio/iio.c
@@ -389,7 +389,9 @@ static ssize_t iio_read_all_attr(struct attr_fun_params *params,
 
 	while (attributes[i].name) {
 		attr_length = attributes[i].show(params->dev_instance,
-						 local_buf, params->len, params->ch_info);
+						 local_buf, params->len,
+						 params->ch_info,
+						 attributes[i].priv);
 		pattr_length = (uint32_t *)(params->buf + j);
 		*pattr_length = bswap_constant_32(attr_length);
 		j += 4;
@@ -424,7 +426,8 @@ static ssize_t iio_write_all_attr(struct attr_fun_params *params,
 		attr_length = bswap_constant_32((uint32_t)(params->buf + j));
 		j += 4;
 		attributes[i].store(params->dev_instance, (params->buf + j),
-				    attr_length, params->ch_info);
+				    attr_length, params->ch_info,
+				    attributes[i].priv);
 		j += attr_length;
 		if (j & 0x3)
 			j = ((j >> 2) + 1) << 2;
@@ -465,12 +468,14 @@ static ssize_t iio_rd_wr_attribute(struct attr_fun_params *params,
 			return -ENOENT;
 
 		return attributes[i].store(params->dev_instance, params->buf,
-					   params->len, params->ch_info);
+					   params->len, params->ch_info,
+					   attributes[i].priv);
 	} else {
 		if (!attributes[i].show)
 			return -ENOENT;
 		return attributes[i].show(params->dev_instance, params->buf,
-					  params->len, params->ch_info);
+					  params->len, params->ch_info,
+					  attributes[i].priv);
 	}
 }
 

--- a/libraries/iio/iio_types.h
+++ b/libraries/iio/iio_types.h
@@ -96,12 +96,14 @@ struct iio_ch_info {
 struct iio_attribute {
 	/** Attribute name */
 	const char *name;
+	/** Attribute id */
+	intptr_t priv;
 	/** Show function pointer */
 	ssize_t (*show)(void *device, char *buf, size_t len,
-			const struct iio_ch_info *channel);
+			const struct iio_ch_info *channel, intptr_t priv);
 	/** Store function pointer */
 	ssize_t (*store)(void *device, char *buf, size_t len,
-			 const struct iio_ch_info *channel);
+			 const struct iio_ch_info *channel, intptr_t priv);
 };
 
 /**

--- a/libraries/iio/iio_types.h
+++ b/libraries/iio/iio_types.h
@@ -87,6 +87,8 @@ struct iio_ch_info {
 	bool ch_out;
 };
 
+#define END_ATTRIBUTES_ARRAY {.name = NULL}
+
 /**
  * @struct iio_attribute
  * @brief Structure holding pointers to show and store functions.
@@ -138,8 +140,8 @@ struct iio_channel {
 	int			scan_index;
 	/** */
 	struct scan_type	*scan_type;
-	/** list of attributes */
-	struct iio_attribute	**attributes;
+	/** Array of attributes. Last one should have its name set to NULL */
+	struct iio_attribute	*attributes;
 	/** if true, the channel is an output channel */
 	bool			ch_out;
 	/** Set if channel has a modifier. Use channel2 property to
@@ -166,12 +168,12 @@ struct iio_device {
 	uint16_t num_ch;
 	/** List of channels */
 	struct iio_channel **channels;
-	/** List of device attributes */
-	struct iio_attribute **attributes;
-	/** List of debug attributes */
-	struct iio_attribute **debug_attributes;
-	/** List of buffer attributes */
-	struct iio_attribute **buffer_attributes;
+	/** Array of attributes. Last one should have its name set to NULL */
+	struct iio_attribute *attributes;
+	/** Array of attributes. Last one should have its name set to NULL */
+	struct iio_attribute *debug_attributes;
+	/** Array of attributes. Last one should have its name set to NULL */
+	struct iio_attribute *buffer_attributes;
 	/** Transfer data from device into RAM */
 	ssize_t (*transfer_dev_to_mem)(void *dev_instance, size_t bytes_count,
 				       uint32_t ch_mask);


### PR DESCRIPTION
- priv field was added to be able to set the same function for multiple attributes
- attributes are now set as array of structures not array of pointers. This will avoid to create structures just to pass a reference
- minimal attributes test on ad9361 was done using iio-osciloscope