### PR TITLE
libraries:iio: Make channels as array

### DIFF
--- a/iio/iio_ad9361/iio_ad9361.c
+++ b/iio/iio_ad9361/iio_ad9361.c
@@ -2201,126 +2201,65 @@ static struct iio_attribute global_attributes[] = {
 	END_ATTRIBUTES_ARRAY,
 };
 
-static struct iio_channel iio_channel_voltage0_in = {
-	.name = "voltage0",
-	.attributes = voltage_input_attributes,
-	.ch_out = false,
-	.scan_type = NULL,
-	.indexed = true,
-	.channel = 0,
-	.ch_type = IIO_VOLTAGE,
-};
+#define AD9361_VOLTAGE_IN(_idx) {\
+	.name = "voltage" # _idx,\
+	.attributes = voltage_input_attributes,\
+	.ch_out = false,\
+	.scan_type = NULL,\
+	.indexed = true,\
+	.channel = _idx,\
+	.ch_type = IIO_VOLTAGE,\
+}
 
-static struct iio_channel iio_channel_voltage1_in = {
-	.name = "voltage1",
-	.attributes = voltage_input_attributes,
-	.ch_out = false,
-	.scan_type = NULL,
-	.indexed = true,
-	.channel = 1,
-	.ch_type = IIO_VOLTAGE,
-};
+#define AD9361_VOLTAGE_OUT(_idx) {\
+	.name = "voltage" # _idx,\
+	.attributes = voltage_output_attributes,\
+	.ch_out = true,\
+	.scan_type = NULL,\
+	.indexed = true,\
+	.channel = _idx,\
+	.ch_type = IIO_VOLTAGE,\
+}
 
-static struct iio_channel iio_channel_voltage2_in = {
-	.name = "voltage2",
-	.attributes = voltage_input_attributes,
-	.ch_out = false,
-	.scan_type = NULL,
-	.indexed = true,
-	.channel = 2,
-	.ch_type = IIO_VOLTAGE,
-};
+#define AD9361_ALTVOLTAGE_OUT(_idx) {\
+	.name = "altvoltage" # _idx,\
+	.attributes = altvoltage_attributes,\
+	.ch_out = true,\
+	.scan_type = NULL,\
+	.indexed = true,\
+	.channel = _idx,\
+	.ch_type = IIO_ALTVOLTAGE,\
+}
 
-static struct iio_channel iio_channel_voltage0_out = {
-	.name = "voltage0",
-	.attributes = voltage_output_attributes,
-	.ch_out = true,
-	.scan_type = NULL,
-	.indexed = true,
-	.channel = 0,
-	.ch_type = IIO_VOLTAGE,
-};
+#define AD9361_TEMP(_idx) {\
+	.name = "temp" # _idx,\
+	.attributes = temp0_attributes,\
+	.ch_out = false,\
+	.scan_type = NULL,\
+	.indexed = true,\
+	.channel = _idx,\
+	.ch_type = IIO_TEMP,\
+}
 
-static struct iio_channel iio_channel_voltage1_out = {
-	.name = "voltage1",
-	.attributes = voltage_output_attributes,
-	.ch_out = true,
-	.scan_type = NULL,
-	.indexed = true,
-	.channel = 1,
-	.ch_type = IIO_VOLTAGE,
-};
+#define AD9361_OUT() {\
+	.name = "out",\
+	.attributes = out_attributes,\
+	.ch_out = false,\
+	.scan_type = NULL,\
+}
 
-static struct iio_channel iio_channel_voltage2_out = {
-	.name = "voltage2",
-	.attributes = voltage_output_attributes,
-	.ch_out = true,
-	.scan_type = NULL,
-	.indexed = true,
-	.channel = 2,
-	.ch_type = IIO_VOLTAGE,
-};
-
-static struct iio_channel iio_channel_voltage3_out = {
-	.name = "voltage3",
-	.attributes = voltage_output_attributes,
-	.ch_out = true,
-	.scan_type = NULL,
-	.indexed = true,
-	.channel = 3,
-	.ch_type = IIO_VOLTAGE,
-};
-
-static struct iio_channel iio_channel_altvoltage0 = {
-	.name = "altvoltage0",
-	.attributes = altvoltage_attributes,
-	.ch_out = true,
-	.scan_type = NULL,
-	.indexed = true,
-	.channel = 0,
-	.ch_type = IIO_ALTVOLTAGE,
-};
-
-static struct iio_channel iio_channel_altvoltage1 = {
-	.name = "altvoltage1",
-	.attributes = altvoltage_attributes,
-	.ch_out = true,
-	.scan_type = NULL,
-	.indexed = true,
-	.channel = 1,
-	.ch_type = IIO_ALTVOLTAGE,
-};
-
-static struct iio_channel iio_channel_temp0 = {
-	.name = "temp0",
-	.attributes = temp0_attributes,
-	.ch_out = false,
-	.scan_type = NULL,
-	.indexed = true,
-	.channel = 0,
-	.ch_type = IIO_TEMP,
-};
-
-static struct iio_channel iio_channel_out = {
-	.name = "out",
-	.attributes = out_attributes,
-	.ch_out = false,
-	.scan_type = NULL,
-};
-
-static struct iio_channel *iio_ad9361_channels[] = {
-	&iio_channel_voltage0_in,
-	&iio_channel_voltage1_in,
-	&iio_channel_voltage2_in,
-	&iio_channel_voltage0_out,
-	&iio_channel_voltage1_out,
-	&iio_channel_voltage2_out,
-	&iio_channel_voltage3_out,
-	&iio_channel_altvoltage0,
-	&iio_channel_altvoltage1,
-	&iio_channel_temp0,
-	&iio_channel_out,
-	NULL,
+static struct iio_channel iio_ad9361_channels[] = {
+	AD9361_VOLTAGE_IN(0),
+	AD9361_VOLTAGE_IN(1),
+	AD9361_VOLTAGE_IN(2),
+	AD9361_VOLTAGE_OUT(0),
+	AD9361_VOLTAGE_OUT(1),
+	AD9361_VOLTAGE_OUT(2),
+	AD9361_VOLTAGE_OUT(3),
+	AD9361_ALTVOLTAGE_OUT(0),
+	AD9361_ALTVOLTAGE_OUT(1),
+	AD9361_TEMP(0),
+	AD9361_OUT(),
 };
 
 /**

--- a/iio/iio_adxrs290/iio_adxrs290.h
+++ b/iio/iio_adxrs290/iio_adxrs290.h
@@ -98,39 +98,32 @@ static struct iio_attribute adxrs290_iio_temp_attrs[] = {
 	END_ATTRIBUTES_ARRAY,
 };
 
-static struct iio_channel adxrs290_iio_channel_x = {
-	.ch_type = IIO_ANGL_VEL,
-	.modified=1,
-	.channel2=IIO_MOD_X,
-	.scan_index = 0,
-	.scan_type = NULL,
-	.attributes = adxrs290_iio_vel_attrs,
-	.ch_out = false,
-};
-
-static struct iio_channel adxrs290_iio_channel_y = {
-	.ch_type = IIO_ANGL_VEL,
-	.modified=1,
-	.channel2=IIO_MOD_Y,
-	.scan_index = 1,
-	.scan_type = NULL,
-	.attributes = adxrs290_iio_vel_attrs,
-	.ch_out = false,
-};
-
-static struct iio_channel adxrs290_iio_channel_temp = {
-	.ch_type = IIO_TEMP,
-	.scan_index = 2,
-	.scan_type = NULL,
-	.attributes = adxrs290_iio_temp_attrs,
-	.ch_out = false,
-};
-
-static struct iio_channel *adxrs290_iio_channels[] = {
-	&adxrs290_iio_channel_x,
-	&adxrs290_iio_channel_y,
-	&adxrs290_iio_channel_temp,
-	NULL,
+static struct iio_channel adxrs290_iio_channels[] = {
+	{
+		.ch_type = IIO_ANGL_VEL,
+		.modified=1,
+		.channel2=IIO_MOD_X,
+		.scan_index = 0,
+		.scan_type = NULL,
+		.attributes = adxrs290_iio_vel_attrs,
+		.ch_out = false,
+	},
+	{
+		.ch_type = IIO_ANGL_VEL,
+		.modified=1,
+		.channel2=IIO_MOD_Y,
+		.scan_index = 1,
+		.scan_type = NULL,
+		.attributes = adxrs290_iio_vel_attrs,
+		.ch_out = false,
+	},
+	{
+		.ch_type = IIO_TEMP,
+		.scan_index = 2,
+		.scan_type = NULL,
+		.attributes = adxrs290_iio_temp_attrs,
+		.ch_out = false,
+	}
 };
 
 //extern struct iio_device adxrs290_iio_descriptor ;

--- a/iio/iio_axi_adc/iio_axi_adc.h
+++ b/iio/iio_axi_adc/iio_axi_adc.h
@@ -70,6 +70,8 @@ struct iio_axi_adc_desc {
 				      uint64_t *sampling_freq_hz);
 	/** iio device descriptor */
 	struct iio_device dev_descriptor;
+	/** Channel names */
+	char (*ch_names)[20];
 };
 
 /**

--- a/iio/iio_axi_dac/iio_axi_dac.h
+++ b/iio/iio_axi_dac/iio_axi_dac.h
@@ -66,6 +66,8 @@ struct iio_axi_dac_desc {
 	void (*dcache_flush_range)(uint32_t address, uint32_t bytes_count);
 	/** iio device descriptor */
 	struct iio_device dev_descriptor;
+	/** Channel names */
+	char (*ch_names)[20];
 };
 
 /**

--- a/iio/iio_demo/iio_demo_dev.h
+++ b/iio/iio_demo/iio_demo_dev.h
@@ -73,60 +73,50 @@ static struct scan_type scan_type = {
 	.is_big_endian = false
 };
 
-static struct iio_channel iio_demo_channel_voltage0_in = {
-	.name = "input_channel_0",
-	.ch_type = IIO_VOLTAGE,
-	.channel = 0,
-	.scan_index = 0,
-	.indexed = true,
-	.scan_type = &scan_type,
-	.attributes = demo_channel_attributes,
-	.ch_out = false,
+static struct iio_channel iio_demo_channels_in[] = {
+	{
+		.name = "input_channel_0",
+		.ch_type = IIO_VOLTAGE,
+		.channel = 0,
+		.scan_index = 0,
+		.indexed = true,
+		.scan_type = &scan_type,
+		.attributes = demo_channel_attributes,
+		.ch_out = false,
+	},
+	{
+		.name = "input_channel_1",
+		.ch_type = IIO_VOLTAGE,
+		.channel = 1,
+		.scan_index = 1,
+		.indexed = true,
+		.scan_type = &scan_type,
+		.attributes = demo_channel_attributes,
+		.ch_out = false,
+	},
 };
 
-static struct iio_channel iio_demo_channel_voltage1_in = {
-	.name = "input_channel_1",
-	.ch_type = IIO_VOLTAGE,
-	.channel = 1,
-	.scan_index = 1,
-	.indexed = true,
-	.scan_type = &scan_type,
-	.attributes = demo_channel_attributes,
-	.ch_out = false,
-};
-
-static struct iio_channel iio_demo_channel_voltage0_out = {
-	.name = "output_channel0",
-	.ch_type = IIO_VOLTAGE,
-	.channel = 0,
-	.scan_index = 0,
-	.indexed = true,
-	.scan_type = &scan_type,
-	.attributes = demo_channel_attributes,
-	.ch_out = true,
-};
-
-static struct iio_channel iio_demo_channel_voltage1_out = {
-	.name = "output_channel1",
-	.ch_type = IIO_VOLTAGE,
-	.channel = 1,
-	.scan_index = 1,
-	.indexed = true,
-	.scan_type = &scan_type,
-	.attributes = demo_channel_attributes,
-	.ch_out = true,
-};
-
-static struct iio_channel *iio_demo_channels_in[] = {
-	&iio_demo_channel_voltage0_in,
-	&iio_demo_channel_voltage1_in,
-	NULL,
-};
-
-static struct iio_channel *iio_demo_channels_out[] = {
-	&iio_demo_channel_voltage0_out,
-	&iio_demo_channel_voltage1_out,
-	NULL,
+static struct iio_channel iio_demo_channels_out[] = {
+	{
+		.name = "output_channel0",
+		.ch_type = IIO_VOLTAGE,
+		.channel = 0,
+		.scan_index = 0,
+		.indexed = true,
+		.scan_type = &scan_type,
+		.attributes = demo_channel_attributes,
+		.ch_out = true,
+	},
+	{
+		.name = "output_channel1",
+		.ch_type = IIO_VOLTAGE,
+		.channel = 1,
+		.scan_index = 1,
+		.indexed = true,
+		.scan_type = &scan_type,
+		.attributes = demo_channel_attributes,
+		.ch_out = true,
+	},
 };
 
 static struct iio_device iio_demo_dev_in_descriptor = {

--- a/libraries/iio/iio_types.h
+++ b/libraries/iio/iio_types.h
@@ -169,7 +169,7 @@ struct iio_device {
 	/** Device number of channels */
 	uint16_t num_ch;
 	/** List of channels */
-	struct iio_channel **channels;
+	struct iio_channel *channels;
 	/** Array of attributes. Last one should have its name set to NULL */
 	struct iio_attribute *attributes;
 	/** Array of attributes. Last one should have its name set to NULL */


### PR DESCRIPTION
This approach is similar to linux and channels can be added using
defines

Signed-off-by: Mihail Chindris <mihail.chindris@analog.com>

It was tested on ad9361 and it generates the same output of iio_info as the current master