### PR TITLE
tools:scripts: Add development feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ aducm_build
 *.hdf
 *.sof
 *.sopcinfo
+
+local_variables.mk

--- a/tools/scripts/generic_variables.mk
+++ b/tools/scripts/generic_variables.mk
@@ -8,6 +8,12 @@
 # PLATFORM = altera
 # PLATFORM = aducm3029
 
+ifeq '$(LOCAL_BUILD)' 'y'
+
+include local_variables.mk
+
+else
+
 PROJECT			?= $(realpath .)
 TARGET 			?= $(notdir $(realpath .))
 NO-OS			?= $(realpath ../..)
@@ -16,6 +22,8 @@ WORKSPACE		?= $(PROJECT)/build
 INCLUDE			?= $(NO-OS)/include
 DRIVERS 		?= $(NO-OS)/drivers
 PLATFORM_DRIVERS	?= $(NO-OS)/drivers/platform/$(PLATFORM)
+
+endif
 
 #------------------------------------------------------------------------------
 #                          EVALUATE PLATFORM


### PR DESCRIPTION
When LOCAL_BUILD is set to y, variables from an ignored local file
local_variables.mk will be used. So, LOCAL_BUILD can be set in
system path and in local_variables.mk add options like LINK_SRCS=y
or change BUILD_DIR to $(PLATFORM)_build in order to have projects
for diferent platforms at the same time

Signed-off-by: Mihail Chindris <mihail.chindris@analog.com>