### PR TITLE
stm32 (stm32f4) support in makefiles

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "libraries/iio/libtinyiiod"]
 	path = libraries/iio/libtinyiiod
 	url = https://github.com/analogdevicesinc/libtinyiiod
+[submodule "libraries/STM32CubeF4"]
+	path = libraries/stm32/STM32CubeF4
+	url = https://github.com/STMicroelectronics/STM32CubeF4.git

--- a/tools/scripts/generic_variables.mk
+++ b/tools/scripts/generic_variables.mk
@@ -3,10 +3,13 @@
 # This variables will be set to their default value if not set by the user
 # It assumes that the makefile is invoked from No-OS/project/some_project
 
-# User must set PLATFORM variable between:
+# For these platforms, the user may optionally pass the PLATFORM variable:
 # PLATFORM = xilinx
 # PLATFORM = altera
 # PLATFORM = aducm3029
+
+# For these platforms, the user must set the PLATFORM variable:
+# PLATFORM = stm32
 
 ifeq '$(LOCAL_BUILD)' 'y'
 

--- a/tools/scripts/stm32.mk
+++ b/tools/scripts/stm32.mk
@@ -1,0 +1,95 @@
+CFLAGS += -std=gnu11 \
+	-g3 \
+	-DUSE_HAL_DRIVER \
+	-DDEBUG \
+	-O0 \
+	-ffunction-sections \
+	-fdata-sections \
+	--specs=nano.specs \
+	-mfpu=fpv4-sp-d16 \
+	-mfloat-abi=hard \
+	-mthumb \
+	-mcpu=cortex-m4
+
+LDFLAGS	= -mcpu=cortex-m4 \
+	--specs=nosys.specs \
+	-Wl,--gc-sections \
+	-static \
+	--specs=nano.specs \
+	-mfpu=fpv4-sp-d16 \
+	-mfloat-abi=hard \
+	-mthumb \
+	-Wl,--start-group \
+	-lc \
+	-lm \
+	-Wl,--end-group
+
+CC = arm-none-eabi-gcc
+AS = arm-none-eabi-gcc
+AR = arm-none-eabi-ar
+
+rwildcard=$(foreach d,$(wildcard $(1:=/*)),$(call rwildcard,$d,$2) $(filter $(subst *,%,$2),$d))
+ifneq '' '$(call rwildcard,src,stm32f4*)'
+SUBPLATFORM = stm32f4
+CFLAGS += -I$(NO-OS)/libraries/stm32/STM32CubeF4/Drivers/STM32F4xx_HAL_Driver/Inc \
+	-I$(NO-OS)/libraries/stm32/STM32CubeF4/Drivers/STM32F4xx_HAL_Driver/Inc/Legacy \
+	-I$(NO-OS)/libraries/stm32/STM32CubeF4/Drivers/CMSIS/Device/ST/STM32F4xx/Include \
+	-I$(NO-OS)/libraries/stm32/STM32CubeF4/Drivers/CMSIS/Include
+TARGETCFG = target/stm32f4x.cfg
+else
+$(error Couldn't detect stm32 family.$(ENDL))
+endif
+
+openocd_paths:
+ifndef OPENOCD_SCRIPTS
+	$(error OPENOCD_SCRIPTS not found in shell environment.$(ENDL))
+endif
+
+ifndef OPENOCD_BIN
+	$(error OPENOCD_BIN not found in shell environment.$(ENDL))
+endif
+
+.PHONY: $(BINARY).openocd
+$(BINARY).openocd:
+	@echo source [find interface/stlink-dap.cfg] > $(BINARY).openocd
+	@echo set WORKAREASIZE 0x8000 >> $(BINARY).openocd
+	@echo transport select "dapdirect_swd" >> $(BINARY).openocd
+	@echo set CHIPNAME $(CHIPNAME) >> $(BINARY).openocd
+	@echo set ENABLE_LOW_POWER 1 >> $(BINARY).openocd
+	@echo set STOP_WATCHDOG 1 >> $(BINARY).openocd
+	@echo set CLOCK_FREQ 8000 >> $(BINARY).openocd
+	@echo reset_config srst_only srst_nogate connect_assert_srst >> $(BINARY).openocd
+	@echo set CONNECT_UNDER_RESET 1 >> $(BINARY).openocd
+	@echo set CORE_RESET 0 >> $(BINARY).openocd
+	@echo set AP_NUM 0 >> $(BINARY).openocd
+	@echo set GDB_PORT 3333 >> $(BINARY).openocd
+	@echo source [find $(TARGETCFG)] >> $(BINARY).openocd
+	@echo tpiu config disable >> $(BINARY).openocd
+
+.PHONY: $(BINARY).gdb
+$(BINARY).gdb:
+	@echo target remote localhost:3333 > $(BINARY).gdb
+	@echo load $(BINARY) >> $(BINARY).gdb
+	@echo file $(BINARY) >> $(BINARY).gdb
+	@echo monitor reset init >> $(BINARY).gdb
+	@echo monitor halt >> $(BINARY).gdb
+	@echo tb main >> $(BINARY).gdb
+	@echo tb HardFault_Handler >> $(BINARY).gdb
+	# These may be helpful but are disabled due to
+	# limited number of breakpoints:
+	# @echo tb UsageFault_Handler >> $(BINARY).gdb
+	# @echo tb MemManage_Handler >> $(BINARY).gdb
+	# @echo tb BusFault_Handler >> $(BINARY).gdb
+
+.PHONY: stm32_run
+stm32_run: all openocd_paths $(BINARY).openocd 
+	$(OPENOCD_BIN)/openocd -s "$(OPENOCD_SCRIPTS)" -f $(BINARY).openocd \
+		-c "program $(BINARY) verify reset exit"
+
+.PHONY: debug
+debug: all openocd_paths $(BINARY).openocd $(BINARY).gdb
+	($(OPENOCD_BIN)/openocd -s "$(OPENOCD_SCRIPTS)" -f $(BINARY).openocd \
+		-c "init" &);
+	arm-none-eabi-gdb --command=$(BINARY).gdb
+
+stm32_project: ;


### PR DESCRIPTION
This adds the possibility to build a project for the STM32
microcontrollers using:

make PLATFORM=stm32

The family is detected automatically from file names.

The build/ directory is used only to store the .o, .elf
and other build artifacts and, unlike for xilinx and intel
projects, it is not used to store an SDK project. The reason
behind this is that STM32CubeIDE does not support project
creation from command line. Therefore the build is entirely
maintained by us using our build system.

A new rule was added specifically for this platform, which is:

make PLATORM=stm32 debug

This rule has as prerequisite that the shell PATH contains

OPENOCD_BIN
OPENOCD_SCRIPTS

environment variables. If they are properly configured, the
rule creates an .openocd and a .gdb config script, starts
an openocd server and starts a gdb debug session with the .elf.

Additionaly, like for other platforms, one can flash the chip
and run execution by

make PLATFORM=stm32 run



![Screenshot from 2020-12-16 22-16-26](https://user-images.githubusercontent.com/8933663/102401763-7accb580-3fec-11eb-83eb-47e4b9a1215b.png)
