### PR TITLE
projects: ad9739a: add DMA support

### DIFF
--- a/projects/ad9739a-fmc-ebz/src/ad9739a_fmc_ebz.c
+++ b/projects/ad9739a-fmc-ebz/src/ad9739a_fmc_ebz.c
@@ -137,11 +137,6 @@ int main(void)
 
 	/* AXI DAC Core */
 	struct axi_dac_channel ad9739a_channels[1];
-	ad9739a_channels[0].dds_dual_tone = 0;
-	ad9739a_channels[0].dds_frequency_0 = 33*1000*1000;
-	ad9739a_channels[0].dds_phase_0 = 0;
-	ad9739a_channels[0].dds_scale_0 = 250000;
-	ad9739a_channels[0].sel = AXI_DAC_DATA_SEL_DDS;
 
 	struct axi_dac_init ad9739a_core_param = {
 		.name = "ad9739a_dac",
@@ -168,6 +163,33 @@ int main(void)
 		pr_info("ad9739a_setup() error: %s\n", ad9739a_core->name);
 		return FAILURE;
 	}
+
+#ifdef DAC_DMA_EXAMPLE
+	extern const uint16_t sine_lut[128];
+	struct axi_dmac_init ad9739a_dmac_init_param = {
+		.name = "ad9739a_dmac",
+		.base = TX_DMA_BASEADDR,
+		.direction = DMA_MEM_TO_DEV,
+		.flags = DMA_CYCLIC
+	};
+	struct axi_dmac *ad9739a_dmac_desc;
+
+	ad9739a_channels[0].sel = AXI_DAC_DATA_SEL_DMA;
+	axi_dac_data_setup(ad9739a_core);
+	axi_dmac_init(&ad9739a_dmac_desc, &ad9739a_dmac_init_param);
+	axi_dac_set_buff(ad9739a_core, DAC_DDR_BASEADDR, sine_lut,
+			 ARRAY_SIZE(sine_lut));
+	Xil_DCacheFlush();
+	axi_dmac_transfer(ad9739a_dmac_desc, DAC_DDR_BASEADDR,
+			  ARRAY_SIZE(sine_lut) * sizeof(uint16_t));
+#else
+	ad9739a_channels[0].dds_dual_tone = 0;
+	ad9739a_channels[0].dds_frequency_0 = 33*1000*1000;
+	ad9739a_channels[0].dds_phase_0 = 0;
+	ad9739a_channels[0].dds_scale_0 = 250000;
+	ad9739a_channels[0].sel = AXI_DAC_DATA_SEL_DDS;
+	axi_dac_data_setup(ad9739a_core);
+#endif
 
 #ifdef IIO_SUPPORT
 	pr_info("The board accepts libiio clients connections through the serial backend.\n");

--- a/projects/ad9739a-fmc-ebz/src/app_config.h
+++ b/projects/ad9739a-fmc-ebz/src/app_config.h
@@ -41,5 +41,6 @@
 #define APP_CONFIG_H_
 
 //#define IIO_SUPPORT
+//#define DAC_DMA_EXAMPLE
 
 #endif /* APP_CONFIG_H_ */


### PR DESCRIPTION
Add DAC DMA example for the ad9739a project.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>