### PR TITLE
Create aducm3029_adc and iio project

### DIFF
--- a/drivers/platform/aducm3029/adc.c
+++ b/drivers/platform/aducm3029/adc.c
@@ -1,0 +1,200 @@
+/***************************************************************************//**
+ *   @file   adc.c
+ *   @brief  Implementation of adc.c
+ *   @author Mihail Chindris (mihail.chindris@analog.com)
+********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <drivers/adc/adi_adc.h>
+#include "adc.h"
+#include "error.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include "util.h"
+
+#define ADUCM3029_DEV_ID 0
+
+/**
+ * @struct adc_desc
+ * @brief Adc descriptor
+ */
+struct adc_desc {
+	/** Memory needed by bsp */
+	uint8_t		dev_mem[ADI_ADC_MEMORY_SIZE];
+	/** BSP handler */
+	ADI_ADC_HANDLE	dev;
+	/** Active channels. Each bit represents a channel */
+	uint32_t	ch_mask;
+};
+
+/**
+ * @brief Activate adc channels
+ * @param desc - Adc descriptor
+ * @param mask - Channels to activates. Use ADUCM3029_CH define
+ * @return \ref SUCCESS in case of success, negative value otherwise.
+ */
+int32_t aducm3029_adc_update_active_channels(struct adc_desc *desc,
+		uint32_t mask)
+{
+	if (!desc)
+		return -EINVAL;
+
+	desc->ch_mask = mask;
+
+	return SUCCESS;
+}
+
+/**
+ * @brief Read adc data. aducm3029_adc_update_active_channels should be called
+ * in order to enable channeles.
+ * @param desc - Adc descriptor
+ * @param buff - Buffer where to store data. The available size should be
+ * number of activated channels * nb_samples.
+ * @param nb_samples - Number of samples to read for each channel.
+ * @return \ref SUCCESS in case of success, negative value otherwise.
+ */
+int32_t aducm3029_adc_read(struct adc_desc *desc, uint16_t *buff,
+			   uint32_t nb_samples)
+{
+	ADI_ADC_BUFFER	adi_buff, *pbuff;
+	int32_t		ret;
+	uint32_t	i;
+
+	if (!desc)
+		return -EINVAL;
+
+	for (i = 0; i < nb_samples; i++) {
+		adi_buff.nChannels = desc->ch_mask;
+		adi_buff.pDataBuffer = buff + i * hweight8(desc->ch_mask);
+		adi_buff.nNumConversionPasses = 1;
+		adi_buff.nBuffSize = hweight8(desc->ch_mask) * sizeof(uint16_t);
+		ret = adi_adc_SubmitBuffer(desc->dev, &adi_buff);
+		if (ret != ADI_ADC_SUCCESS)
+			return -ret;
+		ret = adi_adc_Enable(desc->dev, true);
+		if (ret != ADI_ADC_SUCCESS)
+			return -ret;
+		ret = adi_adc_GetBuffer(desc->dev, &pbuff);
+		if (ret != ADI_ADC_SUCCESS)
+			return -ret;
+		ret = adi_adc_Enable(desc->dev, false);
+		if (ret != ADI_ADC_SUCCESS)
+			return -ret;
+	}
+
+	return SUCCESS;
+}
+
+/**
+ * @brief Allocate adc_desc and initialize adc
+ * @param desc - Adc descriptor
+ * @param param - Initialization parameter
+ * @return \ref SUCCESS in case of success, negative value otherwise.
+ */
+int32_t aducm3029_adc_init(struct adc_desc **desc, struct adc_init_param *param)
+{
+	UNUSED_PARAM(param);
+
+	ADI_ADC_RESULT	ret;
+	struct adc_desc	*ldesc;
+	bool		ready;
+
+	if (!desc)
+		return -EINVAL;
+
+	ldesc = (struct adc_desc *)calloc(1, sizeof(*ldesc));
+	if (!ldesc)
+		return -ENOMEM;
+
+	ret = adi_adc_Open(ADUCM3029_DEV_ID, ldesc->dev_mem,
+			   ADI_ADC_MEMORY_SIZE, &ldesc->dev);
+	if (ret != ADI_ADC_SUCCESS)
+		goto free_desc;
+
+	ret = adi_adc_PowerUp(ldesc->dev, true);
+	if (ret != ADI_ADC_SUCCESS)
+		goto close_adc;
+
+	ret = adi_adc_SetVrefSource(ldesc->dev, ADI_ADC_VREF_SRC_INT_2_50_V);
+	if (ret != ADI_ADC_SUCCESS)
+		goto close_adc;
+
+	ret = adi_adc_EnableADCSubSystem(ldesc->dev, true);
+	if (ret != ADI_ADC_SUCCESS)
+		goto close_adc;
+
+	do {
+		ret = adi_adc_IsReady(ldesc->dev, &ready);
+		if (ret != ADI_ADC_SUCCESS)
+			goto close_adc;
+	} while (!ready);
+
+	ret = adi_adc_StartCalibration(ldesc->dev);
+	if (ret != ADI_ADC_SUCCESS)
+		goto close_adc;
+	do {
+		ret = adi_adc_IsCalibrationDone(ldesc->dev, &ready);
+		if (ret != ADI_ADC_SUCCESS)
+			goto close_adc;
+	} while (!ready);
+
+	*desc = ldesc;
+
+	return SUCCESS;
+close_adc:
+	adi_adc_PowerUp(ldesc->dev, false);
+	adi_adc_Close(ldesc->dev);
+free_desc:
+	free(ldesc);
+	*desc = NULL;
+	return -ret;
+}
+
+
+/**
+ * @brief Dealocate resources allocated by aducm3029_adc_init
+ * @param desc - Adc descriptor
+ * @return \ref SUCCESS
+ */
+int32_t aducm3029_adc_remove(struct adc_desc *desc)
+{
+	adi_adc_EnableADCSubSystem(desc->dev, false);
+	adi_adc_PowerUp(desc->dev, false);
+	adi_adc_Close(desc->dev);
+
+	free(desc);
+
+	return SUCCESS;
+}

--- a/drivers/platform/aducm3029/adc.h
+++ b/drivers/platform/aducm3029/adc.h
@@ -1,0 +1,73 @@
+/***************************************************************************//**
+ *   @file   adc.h
+ *   @brief  Interface of adc.c
+ *   @author Mihail Chindris (mihail.chindris@analog.com)
+********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef ADUCM3029_ADC_H
+#define ADUCM3029_ADC_H
+
+#include <stdint.h>
+
+#define ADUCM3029_CH(x) (1 << x)
+
+struct adc_desc;
+
+/**
+ * @struct adc_init_param
+ * @brief This can be extended in the future, no utility for the moment.
+ */
+struct adc_init_param {
+	/* To add options in the future */
+	uint32_t reserved;
+};
+
+/* Activate channels for reading */
+int32_t aducm3029_adc_update_active_channels(struct adc_desc *desc,
+		uint32_t mask);
+
+/* Read adc channels */
+int32_t aducm3029_adc_read(struct adc_desc *desc, uint16_t *buff,
+			   uint32_t nb_samples);
+
+/* Initialize the ADC */
+int32_t aducm3029_adc_init(struct adc_desc **desc,
+			   struct adc_init_param *param);
+
+/* Free the resources allocated by adc_init(). */
+int32_t aducm3029_adc_remove(struct adc_desc *desc);
+
+#endif

--- a/drivers/platform/aducm3029/iio_aducm3029.c
+++ b/drivers/platform/aducm3029/iio_aducm3029.c
@@ -1,0 +1,371 @@
+/***************************************************************************//**
+ *   @file   iio_aducm3029.c
+ *   @brief  Implementation of aducm3029 iio device
+ *   @author Mihail Chindris (mihail.chindris@analog.com)
+********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "pwm.h"
+#include "util.h"
+#include "gpio.h"
+#include "iio_aducm3029.h"
+#include "adc.h"
+#include "error.h"
+#include <stdio.h>
+#include <inttypes.h>
+#include <sys/platform.h>
+
+#define GPIO_PIN(nb)	(1u << ((nb) & 0x0F))
+#define GPIO_PORT(nb)	(((nb) & 0xF0) >> 4)
+
+volatile uint32_t *pinmux_addrs[] = {
+	((volatile uint32_t *)REG_GPIO0_CFG),
+	((volatile uint32_t *)REG_GPIO1_CFG),
+	((volatile uint32_t *)REG_GPIO2_CFG)
+};
+
+static struct adc_init_param default_adc_init_param = {0};
+static struct pwm_init_param default_pwm_init_par = {
+	.id = 0,
+	.duty_cycle_ns = 5000000,
+	.period_ns = 10000000,
+	.polarity = PWM_POLARITY_HIGH,
+	.extra = NULL
+};
+static struct gpio_init_param default_gpio_init_par = {
+	.number = 0,
+	.extra = NULL
+};
+
+/*
+ * adc_mux[0][0] -> ADC0 port,
+ * adc_mux[0][1] -> ADC0 pin,
+ * adc_mux[0][2] -> mux_val
+ */
+static uint32_t adc_muxs[ADUCM3029_ADC_NUM_CH][3] = {
+	{2, 3, 1},
+	{2, 4, 1},
+	{2, 5, 1},
+	{2, 6, 1},
+	{2, 7, 1},
+	{2, 8, 1}
+};
+
+static uint32_t timers_muxs[ADUCM3029_TIMERS_NUMS][3] = {
+	{0, 14, 1},
+	{1, 11, 2},
+	{2, 1, 2}
+};
+
+enum pin_type {
+	PIN_TYPE_GPIO,
+	PIN_TYPE_ADC,
+	PIN_TYPE_TIMER
+};
+
+/* Enable in pin mux the needed type */
+static void set_pin(uint32_t id, enum pin_type type)
+{
+	volatile uint32_t *port_addr;
+	uint32_t pin;
+	uint32_t val;
+
+	switch (type) {
+	case PIN_TYPE_GPIO:
+		port_addr = pinmux_addrs[GPIO_PORT(id)];
+		pin = GPIO_PORT(id);
+		/* All gpios are enabled on 0 besied 6, 7 and 17 */
+		if (id == 6 || id == 7 || id == 17)
+			val = 1;
+		else
+			val = 0;
+		break;
+	case PIN_TYPE_ADC:
+		port_addr = pinmux_addrs[adc_muxs[id][0]];
+		pin = adc_muxs[id][1];
+		val = adc_muxs[id][2];
+		break;
+	case PIN_TYPE_TIMER:
+		port_addr = pinmux_addrs[timers_muxs[id][0]];
+		pin = timers_muxs[id][1];
+		val = timers_muxs[id][2];
+		break;
+	}
+	*port_addr &= ~(0b11 << (pin * 2));
+	*port_addr |= val << (pin * 2);
+}
+
+
+/* Get global iio attributes */
+ssize_t get_global_attr(void *device, char *buf, size_t len,
+			const struct iio_ch_info *channel, intptr_t priv)
+{
+	uint32_t val;
+	struct iio_aducm3029_desc *desc = device;
+
+	switch (priv) {
+	case PINMUX_PORT_0:
+	case PINMUX_PORT_1:
+	case PINMUX_PORT_2:
+		val = *pinmux_addrs[priv];
+		return snprintf(buf, len, "%"PRIx32"", val);
+	case ADC_ENABLE:
+		val = !!desc->adc;
+		return snprintf(buf, len, "%"PRIu32"", val);
+	}
+
+	return -EINVAL;
+}
+
+/* Set global iio attributes */
+ssize_t set_global_attr(void *device, char *buf, size_t len,
+			const struct iio_ch_info *channel, intptr_t priv)
+{
+	int32_t ret;
+	uint32_t i;
+	uint32_t val = srt_to_uint32(buf);
+	struct iio_aducm3029_desc *desc = device;
+
+	switch (priv) {
+	case PINMUX_PORT_0:
+	case PINMUX_PORT_1:
+	case PINMUX_PORT_2:
+		*pinmux_addrs[priv] = val;
+		break;
+	case ADC_ENABLE:
+		if (val) {
+			if (desc->adc) {
+				ret = SUCCESS;
+			} else {
+				for (i = 0; i < ADUCM3029_ADC_NUM_CH; i++)
+					set_pin(i, PIN_TYPE_ADC);
+				ret = aducm3029_adc_init(&desc->adc,
+							 &default_adc_init_param);
+			}
+		} else {
+			ret = aducm3029_adc_remove(desc->adc);
+			desc->adc = NULL;
+		}
+	}
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	return len;
+}
+
+/* Set get iio attributes */
+ssize_t get_pwm_attr(void *device, char *buf, size_t len,
+		     const struct iio_ch_info *channel, intptr_t priv)
+{
+	int32_t ret;
+	uint32_t val;
+	uint32_t idx;
+	enum pwm_polarity pol;
+	struct iio_aducm3029_desc *desc = device;
+
+	idx = channel->ch_num - ADUCM3029_ADC_NUM_CH;
+	switch (priv) {
+	case PWM_ENABLE:
+		ret = SUCCESS;
+		val = !!desc->pwm[idx];
+		break;
+	case PWM_PERIOD:
+		ret = pwm_get_period(desc->pwm[idx], &val);
+		break;
+	case PWM_DUTY_CYCLE:
+		ret = pwm_get_duty_cycle(desc->pwm[idx], &val);
+		break;
+	case PWM_POLARITY_IS_HIGH:
+		ret = pwm_get_polarity(desc->pwm[idx], &pol);
+		val = !!pol;
+		break;
+	}
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	return snprintf(buf, len, "%"PRIu32"", val);
+}
+
+/* Set gpio pwm attributes */
+ssize_t set_pwm_attr(void *device, char *buf, size_t len,
+		     const struct iio_ch_info *channel, intptr_t priv)
+{
+	int32_t ret;
+	uint32_t val = srt_to_uint32(buf);
+	uint32_t idx;
+	struct iio_aducm3029_desc *desc = device;
+
+	idx = channel->ch_num - ADUCM3029_ADC_NUM_CH;
+	if (desc->pwm[idx]) {
+		ret = pwm_disable(desc->pwm[idx]);
+		if (IS_ERR_VALUE(ret))
+			return ret;
+	}
+	switch (priv) {
+	case PWM_ENABLE:
+		if (val) {
+			if (desc->pwm[idx]) {
+				ret = SUCCESS;
+			} else {
+				set_pin(idx, PIN_TYPE_TIMER);
+				default_pwm_init_par.id = idx;
+				ret = pwm_init(&desc->pwm[idx],
+					       &default_pwm_init_par);
+			}
+		} else {
+			ret = pwm_remove(desc->pwm[idx]);
+			desc->pwm[idx] = NULL;
+		}
+		break;
+	case PWM_PERIOD:
+		ret = pwm_set_period(desc->pwm[idx], val);
+		break;
+	case PWM_DUTY_CYCLE:
+		ret = pwm_set_duty_cycle(desc->pwm[idx], val);
+		break;
+	case PWM_POLARITY_IS_HIGH:
+		ret = pwm_set_polarity(desc->pwm[idx], !!val);
+		break;
+	}
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	if (desc->pwm[idx]) {
+		ret = pwm_enable(desc->pwm[idx]);
+		if (IS_ERR_VALUE(ret))
+			return ret;
+	}
+
+	return len;
+}
+
+/* Get gpio iio attributes */
+ssize_t get_gpio_attr(void *device, char *buf, size_t len,
+		      const struct iio_ch_info *channel, intptr_t priv)
+{
+	int32_t ret;
+	uint8_t val;
+	uint32_t idx;
+	struct iio_aducm3029_desc *desc = device;
+
+	idx = desc->current_gpio;
+	switch (priv) {
+	case GPIO_ENABLE:
+		ret = SUCCESS;
+		val = !!desc->gpio[idx];
+		break;
+	case GPIO_VALUE:
+		ret = gpio_get_value(desc->gpio[idx], &val);
+		break;
+	case GPIO_DIRECTION_OUTPUT:
+		ret = gpio_get_direction(desc->gpio[idx], &val);
+		break;
+	case GPIO_NUMBER:
+		ret = SUCCESS;
+		val = idx;
+		break;
+	}
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	return snprintf(buf, len, "%"PRIu8"", val);
+}
+
+/* Set gpio iio attributes */
+ssize_t set_gpio_attr(void *device, char *buf, size_t len,
+		      const struct iio_ch_info *channel, intptr_t priv)
+{
+	int32_t ret;
+	uint32_t val = srt_to_uint32(buf);
+	uint32_t idx;
+	struct iio_aducm3029_desc *desc = device;
+
+	idx = desc->current_gpio;
+	switch (priv) {
+	case GPIO_ENABLE:
+		if (val) {
+			if (desc->pwm[idx]) {
+				ret = SUCCESS;
+			} else {
+				set_pin(idx, PIN_TYPE_GPIO);
+				default_gpio_init_par.number = idx;
+				ret = gpio_get(&desc->gpio[idx],
+					       &default_gpio_init_par);
+			}
+		} else {
+			ret = gpio_remove(desc->gpio[idx]);
+			desc->gpio[idx] = NULL;
+		}
+		break;
+	case GPIO_VALUE:
+		ret = gpio_set_value(desc->gpio[idx], val);
+		break;
+	case GPIO_DIRECTION_OUTPUT:
+		if (val)
+			ret = gpio_direction_output(desc->gpio[idx], 0);
+		else
+			ret = gpio_direction_input(desc->gpio[idx]);
+
+		break;
+	case GPIO_NUMBER:
+		ret = SUCCESS;
+		desc->current_gpio = val;
+		break;
+	}
+	if (IS_ERR_VALUE(ret))
+		return ret;
+
+	return len;
+}
+
+/* iio wrapper for aducm3029_adc_update_active_channels */
+int32_t iio_aducm3029_adc_set_mask(struct iio_aducm3029_desc *desc,
+				   uint32_t mask)
+{
+	if (!desc)
+		return FAILURE;
+
+	return aducm3029_adc_update_active_channels(desc->adc, mask);
+}
+
+/* iio wrapper for aducm3029_adc_read */
+int32_t iio_aducm3029_adc_read(struct iio_aducm3029_desc *desc, uint16_t *buff,
+			       uint32_t nb_samples)
+{
+	if (!desc)
+		return FAILURE;
+
+	return aducm3029_adc_read(desc->adc, buff, nb_samples);
+}

--- a/drivers/platform/aducm3029/iio_aducm3029.h
+++ b/drivers/platform/aducm3029/iio_aducm3029.h
@@ -1,0 +1,198 @@
+/***************************************************************************//**
+ *   @file   iio_aducm3029.h
+ *   @brief  iio description of aducm3029 uc
+ *   @author Mihail Chindris (mihail.chindris@analog.com)
+********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef IIO_ADCUM3029
+#define IIO_ADCUM3029
+
+#include "iio_types.h"
+#include "adc.h"
+
+#define ADUCM3029_ADC_NUM_CH	6
+#define ADUCM3029_TIMERS_NUMS	3
+#define ADUCM3029_GPIOS_NUMS	44
+
+struct iio_aducm3029_desc {
+	struct adc_desc		*adc;
+	struct timer_desc	*timer[ADUCM3029_TIMERS_NUMS];
+	struct pwm_desc		*pwm[ADUCM3029_TIMERS_NUMS];
+	struct gpio_desc	*gpio[ADUCM3029_GPIOS_NUMS];
+	uint32_t		current_gpio;
+};
+
+static struct iio_aducm3029_desc g_aducm3029_desc;
+
+ssize_t get_pwm_attr(void *device, char *buf, size_t len,
+		     const struct iio_ch_info *channel, intptr_t priv);
+ssize_t set_pwm_attr(void *device, char *buf, size_t len,
+		     const struct iio_ch_info *channel, intptr_t priv);
+
+ssize_t get_global_attr(void *device, char *buf, size_t len,
+			const struct iio_ch_info *channel, intptr_t priv);
+ssize_t set_global_attr(void *device, char *buf, size_t len,
+			const struct iio_ch_info *channel, intptr_t priv);
+
+ssize_t get_gpio_attr(void *device, char *buf, size_t len,
+		      const struct iio_ch_info *channel, intptr_t priv);
+ssize_t set_gpio_attr(void *device, char *buf, size_t len,
+		      const struct iio_ch_info *channel, intptr_t priv);
+
+int32_t iio_aducm3029_adc_set_mask(struct iio_aducm3029_desc *desc,
+				   uint32_t mask);
+int32_t iio_aducm3029_adc_read(struct iio_aducm3029_desc *desc, uint16_t *buff,
+			       uint32_t nb_samples);
+
+enum iio_pwm_attributes {
+	PWM_ENABLE,
+	PWM_PERIOD,
+	PWM_DUTY_CYCLE,
+	PWM_POLARITY_IS_HIGH
+};
+
+#define IIO_PWM_ATTR(_name, _priv) {\
+	.name = _name,\
+	.priv = _priv,\
+	.show = get_pwm_attr,\
+	.store = set_pwm_attr\
+}
+
+static struct iio_attribute pwm_attributes[] = {
+	IIO_PWM_ATTR("en", PWM_ENABLE),
+	IIO_PWM_ATTR("period", PWM_PERIOD),
+	IIO_PWM_ATTR("duty_cycle", PWM_DUTY_CYCLE),
+	IIO_PWM_ATTR("polarity_is_high", PWM_POLARITY_IS_HIGH),
+	END_ATTRIBUTES_ARRAY,
+};
+
+enum iio_gpio_attributes {
+	GPIO_ENABLE,
+	GPIO_VALUE,
+	GPIO_DIRECTION_OUTPUT,
+	GPIO_NUMBER,
+};
+
+#define IIO_GPIO_ATTR(_name, _priv) {\
+	.name = _name,\
+	.priv = _priv,\
+	.show = get_gpio_attr,\
+	.store = set_gpio_attr\
+}
+static struct iio_attribute gpio_attributes[] = {
+	IIO_GPIO_ATTR("en", GPIO_ENABLE),
+	IIO_GPIO_ATTR("value", GPIO_VALUE),
+	IIO_GPIO_ATTR("is_output", GPIO_DIRECTION_OUTPUT),
+	IIO_GPIO_ATTR("number", GPIO_NUMBER),
+	END_ATTRIBUTES_ARRAY,
+};
+
+#define ADCUM3029_ADC_CH(idx)  {\
+	.name = "adc" # idx, \
+	.ch_type = IIO_VOLTAGE,\
+	.channel = idx,\
+	.scan_index = idx,\
+	.scan_type = &adc_scan_type,\
+	.indexed = true}
+
+#define ADCUM3029_PWM_CH(idx)  {\
+	.name = "pwm" # idx, \
+	.ch_type = IIO_VOLTAGE,\
+	.channel = idx + ADUCM3029_ADC_NUM_CH,\
+	.indexed = true,\
+	.attributes = pwm_attributes,\
+	.ch_out = true}
+
+#define ADUCM3029_GPIO_CONTROLLER(idx)  {\
+	.name = "gpio_controller", \
+	.ch_type = IIO_VOLTAGE,\
+	.channel = idx + ADUCM3029_ADC_NUM_CH + ADUCM3029_TIMERS_NUMS,\
+	.indexed = true,\
+	.attributes = gpio_attributes,\
+	.ch_out = true}
+
+static struct scan_type adc_scan_type = {
+	.realbits = 12,
+	.storagebits = 16,
+	.shift = 0,
+	.sign = 'u',
+	.is_big_endian = false
+};
+
+static struct iio_channel aducm3029_channels[] = {
+	ADCUM3029_ADC_CH(0),
+	ADCUM3029_ADC_CH(1),
+	ADCUM3029_ADC_CH(2),
+	ADCUM3029_ADC_CH(3),
+	ADCUM3029_ADC_CH(4),
+	ADCUM3029_ADC_CH(5),
+	ADCUM3029_PWM_CH(0),
+	ADCUM3029_PWM_CH(1),
+	ADCUM3029_PWM_CH(2),
+	ADUCM3029_GPIO_CONTROLLER(0),
+};
+
+enum global_attributes {
+	PINMUX_PORT_0,
+	PINMUX_PORT_1,
+	PINMUX_PORT_2,
+	ADC_ENABLE
+};
+
+#define GLOBAL_ATTR(_name, _priv) {\
+	.name = _name,\
+	.priv = _priv,\
+	.show = get_global_attr,\
+	.store = set_global_attr\
+}
+
+static struct iio_attribute aducm3029_attributes[] = {
+	GLOBAL_ATTR("pinmux_port0_cfg", PINMUX_PORT_0),
+	GLOBAL_ATTR("pinmux_port1_cfg", PINMUX_PORT_1),
+	GLOBAL_ATTR("pinmux_port2_cfg", PINMUX_PORT_2),
+	GLOBAL_ATTR("adc_enable", ADC_ENABLE),
+	END_ATTRIBUTES_ARRAY,
+};
+
+static struct iio_device iio_aducm3029_desc = {
+	.num_ch = sizeof(aducm3029_channels) / sizeof(aducm3029_channels[0]),
+	.channels = aducm3029_channels,
+	.attributes = aducm3029_attributes,
+	.prepare_transfer = (int32_t (*)())iio_aducm3029_adc_set_mask,
+	.read_dev = (int32_t (*)())iio_aducm3029_adc_read,
+};
+
+#endif

--- a/drivers/platform/aducm3029/platform_init.c
+++ b/drivers/platform/aducm3029/platform_init.c
@@ -37,6 +37,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 
+#include <sys/platform.h>
+#include "adi_initialize.h"
 #include <drivers/pwr/adi_pwr.h>
 #include "error.h"
 
@@ -45,7 +47,7 @@
  *        divider.
  * @return 0 in case of success or error code otherwise.
  */
-int32_t pwr_setup(void)
+int32_t platform_init(void)
 {
 	int32_t ret;
 
@@ -55,5 +57,11 @@ int32_t pwr_setup(void)
 	ret = adi_pwr_SetClockDivider(ADI_CLOCK_HCLK,1);
 	if(ret != SUCCESS)
 		return FAILURE;
-	return adi_pwr_SetClockDivider(ADI_CLOCK_PCLK,1);
+	ret = adi_pwr_SetClockDivider(ADI_CLOCK_PCLK,1);
+	if(ret != SUCCESS)
+		return ret;
+
+	adi_initComponents();
+
+	return SUCCESS;
 }

--- a/drivers/platform/aducm3029/platform_init.h
+++ b/drivers/platform/aducm3029/platform_init.h
@@ -42,6 +42,6 @@
 
 /* Initialize the power controller and set the core and peripherals clock
  * divider. */
-int32_t pwr_setup();
+int32_t platform_init();
 
 #endif /* PLATFORM_INIT_H_ */

--- a/drivers/platform/aducm3029/pwm.c
+++ b/drivers/platform/aducm3029/pwm.c
@@ -1,0 +1,302 @@
+/***************************************************************************//**
+ *   @file   aducm3029/pwm.c
+ *   @brief  Implementation of pwm.c
+ *   @author Mihail Chindris (mihail.chindris@analog.com)
+********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "pwm.h"
+#include "stdlib.h"
+#include "error.h"
+#include <drivers/tmr/adi_tmr.h>
+#include <drivers/pwr/adi_pwr.h>
+
+#define NS_PER_SEC 1000000000
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+static int32_t config_clock_init(ADI_TMR_CONFIG *cfg, uint32_t period,
+				 uint32_t duty, uint32_t *match)
+{
+	float		base_time;
+	float		aux;
+	uint32_t	clk_freq;
+	int32_t		ret;
+	/*
+	 * ADI_TMR_CLOCK_HFOSC (26MHz) &&  ADI_TMR_PRESCALER_1
+	 * -> base_period = 38nS -> max_period = 2,490330 ms
+	 * ADI_TMR_CLOCK_HFOSC (26MHz) &&  ADI_TMR_PRESCALER_16
+	 * -> base_period = 615nS -> max_period = 40,304025 ms
+	 * ADI_TMR_CLOCK_HFOSC (26MHz) &&  ADI_TMR_PRESCALER_64
+	 * -> base_period = 2461nS -> max_period = 161,281635 ms
+	 * ADI_TMR_CLOCK_HFOSC (26MHz) &&  ADI_TMR_PRESCALER_256
+	 * -> base_period = 9846nS -> max_period = 645,257610 ms
+	 *
+	 * ADI_TMR_CLOCK_LFOSC (32KHz) &&  ADI_TMR_PRESCALER_1
+	 * -> base_period = 31,25uS -> max_period = 2,04796875 s
+	 * ADI_TMR_CLOCK_LFOSC (32KHz) &&  ADI_TMR_PRESCALER_16
+	 * -> base_period = 500uS -> max_period = 32,767500 s
+	 * ADI_TMR_CLOCK_LFOSC (32KHz) &&  ADI_TMR_PRESCALER_64
+	 * -> base_period = 2mS -> max_period = 131,070 s
+	 * ADI_TMR_CLOCK_LFOSC (32KHz) &&  ADI_TMR_PRESCALER_256
+	 * -> base_period = 8mS -> max_period = 524,280 s
+	 */
+
+	/* Use HFOSC because in general periods for pwms are lower than 645 ms*/
+	cfg->eClockSource = ADI_TMR_CLOCK_HFOSC;
+	ret = adi_pwr_GetClockFrequency(ADI_CLOCK_HCLK, &clk_freq);
+	if (ret != ADI_PWR_SUCCESS)
+		return -ret;
+
+	/* Select prescaler */
+	aux = (float)UINT16_MAX / clk_freq * NS_PER_SEC;
+	if (period > 256 * aux)
+		return -EINVAL;
+	if (period > 64 * aux) {
+		cfg->ePrescaler = ADI_TMR_PRESCALER_256;
+		base_time = 256;
+	} else if (period > 16 * aux) {
+		cfg->ePrescaler = ADI_TMR_PRESCALER_64;
+		base_time = 64;
+	} else if (period > 1 * aux) {
+		cfg->ePrescaler = ADI_TMR_PRESCALER_16;
+		base_time = 16;
+	} else {
+		cfg->ePrescaler = ADI_TMR_PRESCALER_1;
+		if (cfg->bSyncBypass)
+			base_time = 1;
+		else
+			base_time = 0;
+	}
+	base_time = base_time * NS_PER_SEC / clk_freq;
+	cfg->nLoad = period / base_time;
+	cfg->nAsyncLoad = cfg->nLoad;
+	*match = cfg->nLoad - duty / base_time;
+
+	return SUCCESS;
+}
+
+static int32_t update_pwm_config(struct pwm_desc *desc)
+{
+	ADI_TMR_CONFIG		cfg;
+	ADI_TMR_PWM_CONFIG	pwm_cfg;
+	ADI_TMR_RESULT		ret;
+	uint32_t 		match_val;
+
+	if (!desc)
+		return -EINVAL;
+
+	cfg = (ADI_TMR_CONFIG) {
+		.bCountingUp = false,
+		.bPeriodic = true,
+		.bReloading = true,
+		.bSyncBypass = true
+	};
+	ret = config_clock_init(&cfg, desc->period_ns, desc->duty_cycle_ns,
+				&match_val);
+	if (IS_ERR_VALUE(ret))
+		return ret;
+	do {
+		ret = adi_tmr_ConfigTimer(desc->id, &cfg);
+	} while (ret == ADI_TMR_DEVICE_BUSY);
+	if (ret != ADI_TMR_SUCCESS)
+		return -ret;
+
+	pwm_cfg.eOutput = ADI_TMR_PWM_OUTPUT_0;
+	pwm_cfg.bMatch = true;
+	pwm_cfg.bIdleHigh = (desc->polarity == PWM_POLARITY_HIGH);
+	pwm_cfg.nMatchValue = match_val;
+	ret = adi_tmr_ConfigPwm(desc->id, &pwm_cfg);
+	if (ret != ADI_TMR_SUCCESS)
+		return -ret;
+
+	return SUCCESS;
+}
+
+/* Initialize the PWM generator device */
+int32_t pwm_init(struct pwm_desc **desc,
+		 const struct pwm_init_param *param)
+{
+	ADI_TMR_RESULT	ret;
+	struct pwm_desc	*ldesc;
+
+	if (!desc || !param)
+		return -EINVAL;
+
+	if (param->id < ADI_TMR_DEVICE_GP0  || param->id > ADI_TMR_DEVICE_GP2)
+		return -EINVAL;
+
+	ldesc = (struct pwm_desc *)calloc(1, sizeof(*ldesc));
+	if (!ldesc)
+		return -ENOMEM;
+
+	ldesc->id = param->id;
+	ldesc->duty_cycle_ns = param->duty_cycle_ns;
+	ldesc->period_ns = param->period_ns;
+	ldesc->polarity = param->polarity;
+
+	ret = adi_tmr_Init(ldesc->id,  NULL, NULL, false);
+	if (ret != ADI_TMR_SUCCESS)
+		goto error;
+
+	ret = update_pwm_config(ldesc);
+	if (IS_ERR_VALUE(ret))
+		goto error;
+
+	*desc = ldesc;
+
+	return SUCCESS;
+error:
+	*desc = NULL;
+	free(ldesc);
+
+	return ret;
+}
+
+/* Free the resources used by the PWM generator device */
+int32_t pwm_remove(struct pwm_desc *desc)
+{
+	if (!desc || !desc->extra)
+		return -EINVAL;
+
+	free(desc->extra);
+	free(desc);
+
+	return SUCCESS;
+}
+
+/* Enable PWM generator device */
+int32_t pwm_enable(struct pwm_desc *desc)
+{
+	ADI_TMR_RESULT		ret;
+
+	if (!desc)
+		return -EINVAL;
+
+	ret = adi_tmr_Enable(desc->id, true);
+	if (ret != ADI_TMR_SUCCESS)
+		return -ret;
+
+	return SUCCESS;
+}
+
+/* Disable PWM generator device */
+int32_t pwm_disable(struct pwm_desc *desc)
+{
+	ADI_TMR_RESULT		ret;
+
+	if (!desc)
+		return -EINVAL;
+
+	ret = adi_tmr_Enable(desc->id, false);
+	if (ret != ADI_TMR_SUCCESS)
+		return -ret;
+
+	return SUCCESS;
+}
+
+/* Set period of PWM generator device */
+int32_t pwm_set_period(struct pwm_desc *desc,
+		       uint32_t period_ns)
+{
+	if (!desc)
+		return -EINVAL;
+
+	desc->period_ns = period_ns;
+
+	return update_pwm_config(desc);
+}
+
+/* Get period of PWM generator device */
+int32_t pwm_get_period(struct pwm_desc *desc,
+		       uint32_t *period_ns)
+{
+	if (!desc || !period_ns)
+		return -EINVAL;
+
+	*period_ns = desc->period_ns;
+
+	return SUCCESS;
+}
+
+/* Set duty cycle of PWM generator device */
+int32_t pwm_set_duty_cycle(struct pwm_desc *desc,
+			   uint32_t duty_cycle_ns)
+{
+	if (!desc)
+		return -EINVAL;
+
+	desc->duty_cycle_ns = duty_cycle_ns;
+
+	return update_pwm_config(desc);
+}
+
+/* Get period of PWM generator device */
+int32_t pwm_get_duty_cycle(struct pwm_desc *desc,
+			   uint32_t *duty_cycle_ns)
+{
+	if (!desc || !duty_cycle_ns)
+		return -EINVAL;
+
+	*duty_cycle_ns = desc->duty_cycle_ns;
+
+	return SUCCESS;
+}
+
+/* Set polarity of PWM generator device */
+int32_t pwm_set_polarity(struct pwm_desc *desc,
+			 enum pwm_polarity polarity)
+{
+	if (!desc)
+		return -EINVAL;
+
+	desc->polarity = polarity;
+
+	return update_pwm_config(desc);
+}
+
+/* Set polarity of PWM generator device */
+int32_t pwm_get_polarity(struct pwm_desc *desc,
+			 enum pwm_polarity *polarity)
+{
+	if (!desc || !polarity)
+		return -EINVAL;
+
+	*polarity = desc->polarity;
+
+	return SUCCESS;
+}

--- a/include/pwm.h
+++ b/include/pwm.h
@@ -64,6 +64,8 @@ enum pwm_polarity {
  * @brief  Structure containing the init parameters needed by the PWM generator
  */
 struct pwm_init_param {
+	/** Pwm id (Ex. Pin number, timer_id) */
+	uint32_t id;
 	/** PWM generator period */
 	uint32_t period_ns;
 	/** PWM generator duty cycle */
@@ -79,6 +81,8 @@ struct pwm_init_param {
  * @brief  Structure representing an PWM generator device
  */
 struct pwm_desc {
+	/** Pwm id */
+	uint32_t id;
 	/** PWM generator period */
 	uint32_t period_ns;
 	/** PWM generator duty cycle */
@@ -113,7 +117,7 @@ int32_t pwm_set_period(struct pwm_desc *desc,
 
 /* Get period of PWM generator device */
 int32_t pwm_get_period(struct pwm_desc *desc,
-			uint32_t *period_ns);
+		       uint32_t *period_ns);
 
 /* Set duty cycle of PWM generator device */
 int32_t pwm_set_duty_cycle(struct pwm_desc *desc,

--- a/libraries/iio/iio.c
+++ b/libraries/iio/iio.c
@@ -665,7 +665,7 @@ static ssize_t iio_ch_read_attr(const char *device_id, const char *channel,
 		return -ENOENT;
 
 	ch_info.ch_out = ch_out;
-	ch_info.ch_num = ch->scan_index;
+	ch_info.ch_num = ch->channel;
 	params.buf = buf;
 	params.len = len;
 	params.dev_instance = dev->dev_instance;
@@ -703,7 +703,7 @@ static ssize_t iio_ch_write_attr(const char *device_id, const char *channel,
 		return -ENOENT;
 
 	ch_info.ch_out = ch_out;
-	ch_info.ch_num = ch->scan_index;
+	ch_info.ch_num = ch->channel;
 	params.buf = (char *)buf;
 	params.len = len;
 	params.dev_instance = dev->dev_instance;

--- a/projects/iio_aducm3029/Makefile
+++ b/projects/iio_aducm3029/Makefile
@@ -1,0 +1,5 @@
+include ../../tools/scripts/generic_variables.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/iio_aducm3029/pinmux_config.c
+++ b/projects/iio_aducm3029/pinmux_config.c
@@ -1,0 +1,68 @@
+/*
+ **
+ ** Source file generated on December 18, 2020 at 17:18:55.
+ **
+ ** Copyright (C) 2011-2020 Analog Devices Inc., All Rights Reserved.
+ **
+ ** This file is generated automatically based upon the options selected in
+ ** the Pin Multiplexing configuration editor. Changes to the Pin Multiplexing
+ ** configuration should be made by changing the appropriate options rather
+ ** than editing this file.
+ **
+ ** Selected Peripherals
+ ** --------------------
+ ** UART0 (Tx, Rx, UART_SOUT_EN)
+ ** TIMER0 (TIMER0_OUT)
+ ** TIMER1 (TIMER1_OUT)
+ ** TIMER2 (TIMER2_OUT)
+ ** ADC0_IN (ADC_CONVERT, ADC0_IN0, ADC0_IN1, ADC0_IN2, ADC0_IN3, ADC0_IN4, ADC0_IN5, ADC0_IN6, ADC0_IN7)
+ **
+ ** GPIO (unavailable)
+ ** ------------------
+ ** P0_10, P0_11, P0_12, P0_14, P1_11, P1_13, P2_01, P2_03, P2_04, P2_05, P2_06, P2_07,
+ ** P2_08, P2_09, P2_10
+ */
+
+#include <sys/platform.h>
+#include <stdint.h>
+
+#define UART0_TX_PORTP0_MUX  ((uint32_t) ((uint32_t) 1<<20))
+#define UART0_RX_PORTP0_MUX  ((uint32_t) ((uint32_t) 1<<22))
+#define UART0_UART_SOUT_EN_PORTP0_MUX  ((uint32_t) ((uint32_t) 3<<24))
+#define TIMER0_TIMER0_OUT_PORTP0_MUX  ((uint32_t) ((uint32_t) 1<<28))
+#define TIMER1_TIMER1_OUT_PORTP1_MUX  ((uint32_t) ((uint32_t) 2<<22))
+#define TIMER2_TIMER2_OUT_PORTP2_MUX  ((uint16_t) ((uint16_t) 2<<2))
+#define ADC0_IN_ADC_CONVERT_PORTP1_MUX  ((uint32_t) ((uint32_t) 1<<26))
+#define ADC0_IN_ADC0_IN0_PORTP2_MUX  ((uint16_t) ((uint16_t) 1<<6))
+#define ADC0_IN_ADC0_IN1_PORTP2_MUX  ((uint16_t) ((uint16_t) 1<<8))
+#define ADC0_IN_ADC0_IN2_PORTP2_MUX  ((uint16_t) ((uint16_t) 1<<10))
+#define ADC0_IN_ADC0_IN3_PORTP2_MUX  ((uint16_t) ((uint16_t) 1<<12))
+#define ADC0_IN_ADC0_IN4_PORTP2_MUX  ((uint16_t) ((uint16_t) 1<<14))
+#define ADC0_IN_ADC0_IN5_PORTP2_MUX  ((uint32_t) ((uint32_t) 1<<16))
+#define ADC0_IN_ADC0_IN6_PORTP2_MUX  ((uint32_t) ((uint32_t) 1<<18))
+#define ADC0_IN_ADC0_IN7_PORTP2_MUX  ((uint32_t) ((uint32_t) 1<<20))
+
+int32_t adi_initpinmux(void);
+
+/*
+ * Initialize the Port Control MUX Registers
+ */
+int32_t adi_initpinmux(void)
+{
+	/* PORTx_MUX registers */
+	*((volatile uint32_t *)REG_GPIO0_CFG) = UART0_TX_PORTP0_MUX |
+						UART0_RX_PORTP0_MUX
+						| UART0_UART_SOUT_EN_PORTP0_MUX | TIMER0_TIMER0_OUT_PORTP0_MUX;
+	*((volatile uint32_t *)REG_GPIO1_CFG) = TIMER1_TIMER1_OUT_PORTP1_MUX |
+						ADC0_IN_ADC_CONVERT_PORTP1_MUX;
+	*((volatile uint32_t *)REG_GPIO2_CFG) = TIMER2_TIMER2_OUT_PORTP2_MUX |
+						ADC0_IN_ADC0_IN0_PORTP2_MUX
+						| ADC0_IN_ADC0_IN1_PORTP2_MUX | ADC0_IN_ADC0_IN2_PORTP2_MUX |
+						ADC0_IN_ADC0_IN3_PORTP2_MUX
+						| ADC0_IN_ADC0_IN4_PORTP2_MUX | ADC0_IN_ADC0_IN5_PORTP2_MUX |
+						ADC0_IN_ADC0_IN6_PORTP2_MUX
+						| ADC0_IN_ADC0_IN7_PORTP2_MUX;
+
+	return 0;
+}
+

--- a/projects/iio_aducm3029/src.mk
+++ b/projects/iio_aducm3029/src.mk
@@ -1,0 +1,10 @@
+#See No-OS/tool/scripts/src_model.mk for variable description
+PLATFORM = aducm3029
+
+# TINYIIOD=y
+
+SRC_DIRS += $(PROJECT)/src \
+		$(PLATFORM_DRIVERS)\
+		$(NO-OS)/util\
+		$(NO-OS)/include \
+		$(NO-OS)/iio/iio_app

--- a/projects/iio_aducm3029/src/main.c
+++ b/projects/iio_aducm3029/src/main.c
@@ -1,0 +1,194 @@
+/***************************************************************************//**
+ *   @file   iio_aducm3029/src/main.c
+ *   @brief  Implementation of Main Function.
+ *   @author Mihail Chindris (mihail.chindris@analog.com)
+********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include "parameters.h"
+#include "platform_init.h"
+#include "error.h"
+#include "adc.h"
+#include "uart.h"
+#include "uart_extra.h"
+#include "pwm.h"
+#include "util.h"
+#include <stdio.h>
+#include <string.h>
+
+static uint16_t	adc_buffer[ADC_BUFF_SIZE];
+
+#ifdef IIO_SUPPORT
+#include "iio_aducm3029.h"
+#include "iio_app.h"
+
+static struct iio_data_buffer adc_read_buff = {
+	.buff = adc_buffer,
+	.size = ADC_BUFF_SIZE * sizeof(uint16_t)
+};
+#endif
+
+static int32_t initialize_uart(struct uart_desc **uart)
+{
+	struct aducm_uart_init_param platform_uart_init_par = {
+		.parity = UART_NO_PARITY,
+		.stop_bits = UART_ONE_STOPBIT,
+		.word_length = UART_WORDLEN_8BITS
+	};
+	struct uart_init_param uart_init_par = {
+		.device_id = UART_DEVICE_ID,
+		.baud_rate = UART_BAUDRATE,
+		.extra = &platform_uart_init_par
+	};
+
+	return uart_init(uart, &uart_init_par);
+}
+
+static int32_t init_pwms(struct pwm_desc **pwms)
+{
+	uint32_t i;
+	int32_t ret;
+	uint32_t duty = 100000000;
+	struct pwm_init_param		pwm_init_par = {
+		.period_ns = 400000000,
+		.polarity = PWM_POLARITY_HIGH,
+		.extra = NULL
+	};
+	struct pwm_desc *pwm;
+	for (i = 0; i < 3; i++) {
+		pwm_init_par.id = i;
+		pwm_init_par.duty_cycle_ns = (i + 1) * duty;
+		ret = pwm_init(&pwm, &pwm_init_par);
+		if (IS_ERR_VALUE(ret))
+			return -ret;
+		pwms[i] = pwm;
+		ret = pwm_enable(pwms[i]);
+		if (IS_ERR_VALUE(ret))
+			return -ret;
+	}
+
+	return SUCCESS;
+}
+
+int main(void)
+{
+	int32_t status;
+
+	status = platform_init();
+	if (IS_ERR_VALUE(status))
+		return status;
+
+#ifdef IIO_SUPPORT
+	struct iio_app_device devices[] = {
+		IIO_APP_DEVICE("adcum3029", &g_aducm3029_desc,
+			       &iio_aducm3029_desc,
+			       &adc_read_buff, NULL)
+	};
+
+	/**
+	 * In order to read data adc_enable must be set to 1
+	 * In order to start pwms en from each pwm must be set to 1
+	 * This can be done from an iio client (Ex. IIO Oscilloscope)
+	 * but, to just start reading demo data they will be enabled here.
+	 */
+	set_global_attr(&g_aducm3029_desc, "1", 1, NULL, ADC_ENABLE);
+	struct iio_ch_info ch = {.ch_num = 6, .ch_out = 1};
+	set_pwm_attr(&g_aducm3029_desc, "1", 1, &ch, PWM_ENABLE);
+	ch.ch_num = 7;
+	set_pwm_attr(&g_aducm3029_desc, "1", 1, &ch, PWM_ENABLE);
+	ch.ch_num = 8;
+	set_pwm_attr(&g_aducm3029_desc, "1", 1, &ch, PWM_ENABLE);
+
+	return iio_app_run(devices, ARRAY_SIZE(devices));
+#endif
+
+	struct adc_init_param	adc_init_param = {0};
+	struct adc_desc		*adc;
+	struct uart_desc	*uart;
+	struct pwm_desc		*pwms[3];
+
+	status = aducm3029_adc_init(&adc, &adc_init_param);
+	if (IS_ERR_VALUE(status))
+		return status;
+
+	status = init_pwms(pwms);
+	if (IS_ERR_VALUE(status))
+		return status;
+
+	status = initialize_uart(&uart);
+	if (IS_ERR_VALUE(status))
+		return status;
+
+	/* Enabled ADC channels */
+	uint32_t ch_mask =
+		ADUCM3029_CH(0) |
+		ADUCM3029_CH(1) |
+		ADUCM3029_CH(2) |
+		ADUCM3029_CH(3) |
+		ADUCM3029_CH(4) |
+		ADUCM3029_CH(5) |
+		0;
+	char buff[100];
+	uint32_t active_ch = hweight8(ch_mask);
+	uint32_t nb_samples = 10;
+	uint32_t i,j,k;
+
+	status = aducm3029_adc_update_active_channels(adc, ch_mask);
+	if (IS_ERR_VALUE(status))
+		return status;
+	while (true) {
+		status = aducm3029_adc_read(adc, adc_buffer, nb_samples);
+		if (IS_ERR_VALUE(status))
+			return status;
+		k = 0;
+		for (i = 0; i < nb_samples; i++) {
+			uint32_t n = 0;
+			for (j = 0; j < active_ch; j++) {
+				n += sprintf(buff + n, "ch%d:%d",j,adc_buffer[k++]);
+				if (j == active_ch - 1)
+					n += sprintf(buff + n, "\n");
+				else
+					n += sprintf(buff + n, ",");
+			}
+			status = uart_write(uart, buff, strlen(buff));
+			if (IS_ERR_VALUE(status))
+				return status;
+		}
+	}
+}

--- a/projects/iio_aducm3029/src/parameters.h
+++ b/projects/iio_aducm3029/src/parameters.h
@@ -1,0 +1,53 @@
+/***************************************************************************//**
+ *   @file   iio_aducm3029/src/parameters.h
+ *   @brief  Parameters Definitions.
+ *   @author Mihail Chindris (mihail.chindris@analog.com)
+********************************************************************************
+ * Copyright 2013(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef PARAMETERS_H
+#define PARAMETERS_H
+
+#include "iio_aducm3029.h"
+#include "irq_extra.h"
+
+#define MAX_SIZE_BASE_ADDR		3000
+#define UART_DEVICE_ID			0
+#define INTC_DEVICE_ID			0
+#define UART_IRQ_ID			ADUCM_UART_INT_ID
+#define UART_BAUDRATE			115200
+#define DEFAULT_SAMPLES			400
+#define ADC_BUFF_SIZE			(ADUCM3029_ADC_NUM_CH * DEFAULT_SAMPLES)
+
+#endif


### PR DESCRIPTION
A minimal driver for the built-in adc in the aducm uc was developed and in order to don't die locally a sample project was created too.  Maybe the project can be added to the adicup repository but that is just the last commit.
In order to capture some data on the adc a pwm driver was also created.
The project support also iio and a simple gpio controller was added to the iio device to be able to control gpios from iio clients.
The firsts 3 commits are small fixes that can be moved to a separate commit if needed.
Some screen shots:
osc:
![image](https://user-images.githubusercontent.com/16192750/102637491-c4d5a880-415e-11eb-8e46-4ae19f2d946d.png)

uart:
![image](https://user-images.githubusercontent.com/16192750/102637668-036b6300-415f-11eb-87e5-241a3af378e4.png)
![image](https://user-images.githubusercontent.com/16192750/102637729-1da54100-415f-11eb-9fce-06037eaaccb4.png)

