### PR TITLE
add stm32f4 submodule directory too

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,6 @@
 [submodule "libraries/iio/libtinyiiod"]
 	path = libraries/iio/libtinyiiod
 	url = https://github.com/analogdevicesinc/libtinyiiod
-[submodule "libraries/STM32CubeF4"]
+[submodule "libraries/stm32/STM32CubeF4"]
 	path = libraries/stm32/STM32CubeF4
 	url = https://github.com/STMicroelectronics/STM32CubeF4.git


### PR DESCRIPTION
When adding the submodule, the new file mode change was not included
by mistake and the submodule was not checking out out on repo cloning.