### PR TITLE
Remove stm32 submodule, use environment variable instead

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "libraries/iio/libtinyiiod"]
 	path = libraries/iio/libtinyiiod
 	url = https://github.com/analogdevicesinc/libtinyiiod
-[submodule "libraries/stm32/STM32CubeF4"]
-	path = libraries/stm32/STM32CubeF4
-	url = https://github.com/STMicroelectronics/STM32CubeF4.git

--- a/tools/scripts/aducm.mk
+++ b/tools/scripts/aducm.mk
@@ -37,6 +37,9 @@ CCES_EXE = $(CCES_HOME)/Eclipse
 
 export PATH := $(CCES_EXE):$(OPENOCD_SCRIPTS):$(OPENOCD_BIN):$(COMPILER_BIN):$(PATH)
 
+PLATFORM_RELATIVE_PATH = $1
+PLATFORM_FULL_PATH = $1
+
 #------------------------------------------------------------------------------
 #                          FIX SPACES PROBLEM                              
 #------------------------------------------------------------------------------

--- a/tools/scripts/generic.mk
+++ b/tools/scripts/generic.mk
@@ -124,11 +124,11 @@ set_one_time_rule = echo Target file. Do not delete > $1
 # $(PROJECT)/something -> srcs/something
 # $(NO-OS)/something -> noos/something
 # $(PLATFORM_TOOLS)/something -> aducm3029/something TODO test without these
-RELATIVE_PATH = $(patsubst $(NO-OS)%,noos%,$(patsubst $(PROJECT)%,$(TARGET)%,$1))
+RELATIVE_PATH = $(patsubst $(NO-OS)%,noos%,$(patsubst $(PROJECT)%,$(TARGET)%,$(PLATFORM_RELATIVE_PATH)))
 
 # Transforme relative path to full path in order to find the needed .c files
 # Reverse of get_relative_path
-FULL_PATH = $(patsubst noos%,$(NO-OS)%,$(patsubst $(TARGET)%,$(PROJECT)%,$1))
+FULL_PATH = $(patsubst noos%,$(NO-OS)%,$(patsubst $(TARGET)%,$(PROJECT)%,$(PLATFORM_FULL_PATH)))
 
 ifeq ($(OS), Windows_NT)
 get_relative_path = $(patsubst $(ROOT_DRIVE)%,root%,$(RELATIVE_PATH))

--- a/tools/scripts/stm32.mk
+++ b/tools/scripts/stm32.mk
@@ -1,3 +1,10 @@
+ifndef STM32CUBE
+$(error STM32CUBE not found in shell environment.$(ENDL))
+endif
+
+PLATFORM_RELATIVE_PATH = $(patsubst $(STM32CUBE)%,stm32%,$1)
+PLATFORM_FULL_PATH = $(patsubst stm32%,$(STM32CUBE)%,$1)
+
 CFLAGS += -std=gnu11 \
 	-g3 \
 	-DUSE_HAL_DRIVER \
@@ -30,11 +37,10 @@ AR = arm-none-eabi-ar
 
 rwildcard=$(foreach d,$(wildcard $(1:=/*)),$(call rwildcard,$d,$2) $(filter $(subst *,%,$2),$d))
 ifneq '' '$(call rwildcard,src,stm32f4*)'
-SUBPLATFORM = stm32f4
-CFLAGS += -I$(NO-OS)/libraries/stm32/STM32CubeF4/Drivers/STM32F4xx_HAL_Driver/Inc \
-	-I$(NO-OS)/libraries/stm32/STM32CubeF4/Drivers/STM32F4xx_HAL_Driver/Inc/Legacy \
-	-I$(NO-OS)/libraries/stm32/STM32CubeF4/Drivers/CMSIS/Device/ST/STM32F4xx/Include \
-	-I$(NO-OS)/libraries/stm32/STM32CubeF4/Drivers/CMSIS/Include
+CFLAGS += -I$(STM32CUBE)/STM32CubeF4/Drivers/STM32F4xx_HAL_Driver/Inc \
+	-I$(STM32CUBE)/STM32CubeF4/Drivers/STM32F4xx_HAL_Driver/Inc/Legacy \
+	-I$(STM32CUBE)/STM32CubeF4/Drivers/CMSIS/Device/ST/STM32F4xx/Include \
+	-I$(STM32CUBE)/STM32CubeF4/Drivers/CMSIS/Include
 TARGETCFG = target/stm32f4x.cfg
 else
 $(error Couldn't detect stm32 family.$(ENDL))

--- a/tools/scripts/xilinx.mk
+++ b/tools/scripts/xilinx.mk
@@ -33,6 +33,10 @@ LSCRIPT		:= $(BUILD_DIR)/app/src/lscript.ld
 LIB_PATHS	+= -L$(BUILD_DIR)/bsp/$(ARCH)/lib
 # Xilinx's bsp include path
 CFLAGS		+= -I$(BUILD_DIR)/bsp/$(ARCH)/include
+
+PLATFORM_RELATIVE_PATH = $1
+PLATFORM_FULL_PATH = $1
+
 ################|--------------------------------------------------------------
 ################|                   Zynq                                       
 ################|--------------------------------------------------------------


### PR DESCRIPTION
See commit descriptions for more info.

Tested on Linux (xilinx + stm32) and Windows (xilinx) since this PR modifies generic.mk, xilinx.mk and aducm.mk. Didn't explicitly test aducm because the change is identical to xilinx so it was "implicitly" tested.
