### PR TITLE
stm32 uart

### DIFF
--- a/drivers/platform/stm32/stm32_uart.c
+++ b/drivers/platform/stm32/stm32_uart.c
@@ -1,0 +1,244 @@
+/***************************************************************************//**
+ *   @file   stm32/stm32_uart.c
+ *   @brief  Source file of UART driver for STM32
+ *   @author Darius Berghe (darius.berghe@analog.com)
+********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include <errno.h>
+#include <stdlib.h>
+#include "uart.h"
+#include "stm32_uart.h"
+#include "stm32_hal.h"
+
+/**
+ * @brief Initialize the UART communication peripheral.
+ * @param desc - The UART descriptor.
+ * @param param - The structure that contains the UART parameters.
+ * @return SUCCESS in case of success, error code otherwise.
+ */
+int32_t uart_init(struct uart_desc **desc, struct uart_init_param *param)
+{
+	struct stm32_uart_init_param *suip;
+	struct stm32_uart_desc *sud;
+	struct uart_desc *descriptor;
+	USART_TypeDef *base = NULL;
+	int ret;
+
+	if (!desc || !param)
+		return -EINVAL;
+
+	descriptor = (struct uart_desc *) calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	sud = (struct stm32_uart_desc *) calloc(1, sizeof(struct stm32_uart_desc));
+	if (!sud) {
+		ret = -ENOMEM;
+		goto error;
+	}
+
+	descriptor->extra = sud;
+	suip = param->extra;
+
+	switch (param->device_id) {
+#ifdef USART1
+	case 1:
+		base = USART1;
+		break;
+#endif
+#ifdef USART2
+	case 2:
+		base = USART2;
+		break;
+#endif
+#ifdef USART3
+	case 3:
+		base = USART3;
+		break;
+#endif
+#ifdef USART4
+	case 4:
+		base = USART4;
+		break;
+#endif
+#ifdef USART5
+	case 5:
+		base = USART5;
+		break;
+#endif
+#ifdef USART6
+	case 6:
+		base = USART6;
+		break;
+#endif
+#ifdef USART7
+	case 7:
+		base = USART7;
+		break;
+#endif
+#ifdef USART8
+	case 8:
+		base = USART8;
+		break;
+#endif
+	default:
+		ret = -EINVAL;
+		goto error;
+	};
+
+	sud->huart.Instance = base;
+	sud->huart.Init.BaudRate = param->baud_rate;
+	switch (param->size) {
+	case UART_CS_8:
+		sud->huart.Init.WordLength = UART_WORDLENGTH_8B;
+		break;
+	case UART_CS_9:
+		sud->huart.Init.WordLength = UART_WORDLENGTH_9B;
+		break;
+	default:
+		ret = -EINVAL;
+		goto error;
+	};
+	switch (param->parity) {
+	case UART_PAR_NO:
+		sud->huart.Init.Parity = UART_PARITY_NONE;
+		break;
+	case UART_PAR_ODD:
+		sud->huart.Init.Parity = UART_PARITY_ODD;
+		break;
+	case UART_PAR_EVEN:
+		sud->huart.Init.Parity = UART_PARITY_EVEN;
+		break;
+	default:
+		ret = -EINVAL;
+		goto error;
+	};
+	sud->huart.Init.StopBits = param->stop == UART_STOP_1 ? UART_STOPBITS_1 :
+				   UART_STOPBITS_2;
+	sud->huart.Init.Mode = suip->mode;
+	sud->huart.Init.HwFlowCtl = suip->hw_flow_ctl;
+	sud->huart.Init.OverSampling = suip->over_sampling;
+	ret = HAL_UART_Init(&sud->huart);
+	if (ret != HAL_OK) {
+		ret = -EIO;
+		goto error;
+	}
+
+	*desc = descriptor;
+
+	return 0;
+error:
+	free(descriptor);
+	free(sud);
+
+	return ret;
+}
+
+/**
+ * @brief Free the resources allocated by uart_init().
+ * @param desc - The UART descriptor.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t uart_remove(struct uart_desc *desc)
+{
+	struct stm32_uart_desc *sud;
+
+	if (!desc)
+		return -EINVAL;
+
+	sud = desc->extra;
+	HAL_UART_DeInit(&sud->huart);
+	free(desc->extra);
+	free(desc);
+
+	return 0;
+};
+
+/**
+ * @brief Write data to UART device.
+ * @param desc - Instance of UART.
+ * @param data - Pointer to buffer containing data.
+ * @param bytes_number - Number of bytes to read.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t uart_write(struct uart_desc *desc, const uint8_t *data,
+		   uint32_t bytes_number)
+{
+	struct stm32_uart_desc *sud;
+	int32_t ret;
+
+	if (!desc || !desc->extra || !data)
+		return -EINVAL;
+
+	if (!bytes_number)
+		return 0;
+
+	sud = desc->extra;
+	ret = HAL_UART_Transmit(&sud->huart, (uint8_t *)data, bytes_number,
+				HAL_MAX_DELAY);
+	if (ret != HAL_OK)
+		return -EIO;
+
+	return 0;
+}
+
+/**
+ * @brief Read data from UART device.
+ * @param desc - Instance of UART.
+ * @param data - Pointer to buffer containing data.
+ * @param bytes_number - Number of bytes to read.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t uart_read(struct uart_desc *desc, uint8_t *data,
+		  uint32_t bytes_number)
+{
+	struct stm32_uart_desc *sud;
+	int32_t ret;
+
+	if (!desc || !desc->extra || !data)
+		return -EINVAL;
+
+	if (!bytes_number)
+		return 0;
+
+	sud = desc->extra;
+
+	ret = HAL_UART_Receive(&sud->huart, (uint8_t *)data, bytes_number,
+			       HAL_MAX_DELAY);
+	if (ret != HAL_OK)
+		return -EIO;
+
+	return 0;
+}

--- a/drivers/platform/stm32/stm32_uart.h
+++ b/drivers/platform/stm32/stm32_uart.h
@@ -1,0 +1,69 @@
+/***************************************************************************//**
+ *   @file   stm32/stm32_uart.h
+ *   @brief  Header file of UART driver for STM32
+ *   @author Darius Berghe (darius.berghe@analog.com)
+********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef _STM32_UART_H_
+#define _STM32_UART_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "uart.h"
+#include "stm32_hal.h"
+
+/**
+ * @struct stm32_uart_init_param
+ * @brief Specific initialization parameters for stm32 UART.
+ */
+struct stm32_uart_init_param {
+	/** Specifies the Receive or Transmit mode. */
+	uint32_t mode;
+	/** Specifies the hardware flow control mode. */
+	uint32_t hw_flow_ctl;
+	/** Specifies oversampling mode. */
+	uint32_t over_sampling;
+};
+
+/**
+ * @struct stm32_uart_desc
+ * @brief stm32 platform specific UART descriptor
+ */
+struct stm32_uart_desc {
+	/** SPI instance */
+	UART_HandleTypeDef huart;
+};
+
+#endif

--- a/drivers/platform/stm32/stm32_uart_stdio.c
+++ b/drivers/platform/stm32/stm32_uart_stdio.c
@@ -1,0 +1,146 @@
+/***************************************************************************//**
+ *   @file   stm32/stm32_uart_stdio.c
+ *   @brief  Implementation file of stm32 UART driver stdout/stdin redirection.
+ *   @author Darius Berghe (darius.berghe@analog.com)
+ *           Credit to Carmine Noviello for stdio redirection in this file
+ * 	     that was inspired from his "Mastering STM32" book.
+********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include <_ansi.h>
+#include <_syslist.h>
+#include <errno.h>
+#include <sys/time.h>
+#include <sys/times.h>
+#include <limits.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "stm32_uart_stdio.h"
+#include "stm32_hal.h"
+
+#if !defined(OS_USE_SEMIHOSTING)
+
+#define STDIN_FILENO  0
+#define STDOUT_FILENO 1
+#define STDERR_FILENO 2
+
+UART_HandleTypeDef *gHuart = NULL;
+
+void stm32_uart_stdio(struct uart_desc *desc)
+{
+	struct stm32_uart_desc *sud;
+
+	if(!desc || !desc->extra)
+		return;
+
+	sud = desc->extra;
+
+	gHuart = &sud->huart;
+
+	/* Disable I/O buffering for STDOUT stream, so that
+	* chars are sent out as soon as they are printed. */
+	setvbuf(stdout, NULL, _IONBF, 0);
+}
+
+int _isatty(int fd)
+{
+	if (fd >= STDIN_FILENO && fd <= STDERR_FILENO)
+		return 1;
+
+	errno = EBADF;
+	return 0;
+}
+
+int _write(int fd, char* ptr, int len)
+{
+	HAL_StatusTypeDef hstatus;
+
+	if (fd == STDOUT_FILENO || fd == STDERR_FILENO) {
+		hstatus = HAL_UART_Transmit(gHuart, (uint8_t *) ptr, len, HAL_MAX_DELAY);
+		if (hstatus == HAL_OK)
+			return len;
+		else
+			return EIO;
+	}
+	errno = EBADF;
+	return -1;
+}
+
+int _close(int fd)
+{
+	if (fd >= STDIN_FILENO && fd <= STDERR_FILENO)
+		return 0;
+
+	errno = EBADF;
+	return -1;
+}
+
+int _lseek(int fd, int ptr, int dir)
+{
+	(void) fd;
+	(void) ptr;
+	(void) dir;
+
+	errno = EBADF;
+	return -1;
+}
+
+int _read(int fd, char* ptr, int len)
+{
+	HAL_StatusTypeDef hstatus;
+
+	if (fd == STDIN_FILENO) {
+		hstatus = HAL_UART_Receive(gHuart, (uint8_t *) ptr, 1, HAL_MAX_DELAY);
+		if (hstatus == HAL_OK)
+			return 1;
+		else
+			return EIO;
+	}
+	errno = EBADF;
+	return -1;
+}
+
+int _fstat(int fd, struct stat* st)
+{
+	if (fd >= STDIN_FILENO && fd <= STDERR_FILENO) {
+		st->st_mode = S_IFCHR;
+		return 0;
+	}
+
+	errno = EBADF;
+	return 0;
+}
+
+#endif //#if !defined(OS_USE_SEMIHOSTING)

--- a/drivers/platform/stm32/stm32_uart_stdio.h
+++ b/drivers/platform/stm32/stm32_uart_stdio.h
@@ -1,0 +1,54 @@
+/***************************************************************************//**
+ *   @file   stm32/stm32_uart_stdio.h
+ *   @brief  Header file of stm32 UART driver stdout/stdin redirection.
+ *   @author Darius Berghe (darius.berghe@analog.com)
+********************************************************************************
+ * Copyright 2020(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef _STM32_UART_STDIO_H_
+#define _STM32_UART_STDIO_H_
+
+#include <sys/stat.h>
+#include "uart.h"
+#include "stm32_uart.h"
+
+void stm32_uart_stdio(struct uart_desc *desc);
+int _isatty(int fd);
+int _write(int fd, char* ptr, int len);
+int _close(int fd);
+int _lseek(int fd, int ptr, int dir);
+int _read(int fd, char* ptr, int len);
+int _fstat(int fd, struct stat* st);
+
+#endif

--- a/include/uart.h
+++ b/include/uart.h
@@ -62,7 +62,7 @@ enum uart_size {
 	UART_CS_7,
 	/** 8 data bits */
 	UART_CS_8
-} uart_size;
+};
 
 /**
  * @enum uart_parity
@@ -79,7 +79,7 @@ enum uart_parity {
 	UART_PAR_ODD,
 	/** even parity */
 	UART_PAR_EVEN
-} uart_parity;
+};
 
 /**
  * @enum uart_stop
@@ -90,7 +90,7 @@ enum uart_stop {
 	UART_STOP_1,
 	/** two stop bits */
 	UART_STOP_2
-} uart_stop;
+};
 
 /**
  * @struct uart_init_param

--- a/include/uart.h
+++ b/include/uart.h
@@ -61,7 +61,9 @@ enum uart_size {
 	/** 7 data bits */
 	UART_CS_7,
 	/** 8 data bits */
-	UART_CS_8
+	UART_CS_8,
+	/** 9 data bits */
+	UART_CS_9,
 };
 
 /**


### PR DESCRIPTION
Add the UART layer and stdio redirection for stm32 platform.

Example usage:
```
	struct uart_desc *uart;

        // stm32 specific stuff
	struct stm32_uart_init_param uip_extra = {
		.Mode = UART_MODE_TX_RX,
		.HwFlowCtl = UART_HWCONTROL_NONE,
		.OverSampling = UART_OVERSAMPLING_16,
	};

        // generic stuff
	struct uart_init_param uip = {
		.device_id = 2,
		.baud_rate = 115200,
		.size = UART_CS_8,
		.parity = UART_PAR_NO,
		.stop = UART_STOP_1,
		.extra = &uip_extra,
	};

	ret = uart_init(&uart, &uip);
	if (ret < 0)
		return ret;

        // bind stdout and stdin to the uart instance and have printf/scanf use uart as their operating medium
	stm32_uart_stdio(uart); 
```