### PR TITLE
drivers: Makefile: include libraries/iio

### DIFF
--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -16,7 +16,8 @@ INCLUDES = -I../include/ \
 	 -I./axi_core/axi_dmac \
 	 -I./axi_core/clk_axi_clkgen \
 	 -I./platform/xilinx \
-	 -I../projects/adrv9009/src/devices/adi_hal
+	 -I../projects/adrv9009/src/devices/adi_hal \
+	 -I../libraries/iio
 
 CFLAGS = -c -Wall -Wformat=0 $(INCLUDES)
 


### PR DESCRIPTION
Required for future IIO drivers that will be placed inside the `drivers`
folder.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>