### PR TITLE
tools:script:xilinx.mk: Fix heap replacement

### DIFF
--- a/tools/scripts/xilinx.mk
+++ b/tools/scripts/xilinx.mk
@@ -180,11 +180,8 @@ $(BUILD_DIR)/.bsp.target: $(LIB_TARGETS) $(TEMP_DIR)/arch.txt
 	$(MUTE) echo $(UDPATE_TCL_CONTENT) > $(TEMP_DIR)/update_sdk.tcl
 	$(call print,Configuring project)
 	$(MUTE) xsct $(TEMP_DIR)/update_sdk.tcl $(HIDE)
-ifeq ($(strip $(ARCH)),sys_mb)
 	$(MUTE)$(call replace_heap,0x800,0x100000,$(BUILD_DIR)/app/src/lscript.ld)
-else
 	$(MUTE)$(call replace_heap,0x2000,0x100000,$(BUILD_DIR)/app/src/lscript.ld)
-endif
 	$(MUTE) $(MAKE) --no-print-directory update_srcs
 	$(MUTE) $(call set_one_time_rule,$@) $(HIDE)
 


### PR DESCRIPTION
It seems that only the first branch of the if is executed when
running make. This seems to be beacause the if is evaluated before
ARCH is available.
Anyway, both replacements can be executed because only one will take
have effect, the one that matches the HEAP value.

Signed-off-by: Mihail Chindris <mihail.chindris@analog.com>