### PR TITLE
fmcdaq2: ADC/DAC IIO direct reg access.

### DIFF
--- a/drivers/adc/ad9680/iio_ad9680.h
+++ b/drivers/adc/ad9680/iio_ad9680.h
@@ -1,0 +1,52 @@
+/***************************************************************************//**
+ *   @file   iio_ad9680.h
+ *   @brief  Header file of AD9680 iio.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2021(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef IIO_AD9680_H
+#define IIO_AD9680_H
+
+#include "iio_types.h"
+#include "ad9680.h"
+
+/** IIO Descriptor */
+struct iio_device ad9680_iio_descriptor = {
+	.debug_reg_read = (int32_t (*)())ad9680_spi_read,
+	.debug_reg_write = (int32_t (*)())ad9680_spi_write,
+};
+
+#endif //IIO_AD9680_H

--- a/drivers/dac/ad9144/iio_ad9144.h
+++ b/drivers/dac/ad9144/iio_ad9144.h
@@ -1,0 +1,52 @@
+/***************************************************************************//**
+ *   @file   iio_ad9144.h
+ *   @brief  Header file of AD9144 iio.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2021(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef IIO_AD9144_H
+#define IIO_AD9144_H
+
+#include "iio_types.h"
+#include "ad9144.h"
+
+/** IIO Descriptor */
+struct iio_device ad9144_iio_descriptor = {
+	.debug_reg_read = (int32_t (*)())ad9144_spi_read,
+	.debug_reg_write = (int32_t (*)())ad9144_spi_write,
+};
+
+#endif //IIO_AD9144_H

--- a/projects/fmcdaq2/src.mk
+++ b/projects/fmcdaq2/src.mk
@@ -46,7 +46,9 @@ endif
 INCS +=	$(PROJECT)/src/app/app_config.h					\
 	$(PROJECT)/src/devices/adi_hal/parameters.h
 ifeq (y,$(strip $(TINYIIOD)))
-INCS +=	$(PROJECT)/src/app/app_iio.h
+INCS +=	$(PROJECT)/src/app/app_iio.h					\
+	$(DRIVERS)/adc/ad9680/iio_ad9680.h				\
+	$(DRIVERS)/dac/ad9144/iio_ad9144.h
 endif
 INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h			\
 	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.h			\

--- a/projects/fmcdaq2/src/app/app_iio.c
+++ b/projects/fmcdaq2/src/app/app_iio.c
@@ -47,6 +47,10 @@
 #include "iio.h"
 #include "parameters.h"
 #include "app_iio.h"
+#include "iio_ad9680.h"
+#include "ad9680.h"
+#include "iio_ad9144.h"
+#include "ad9144.h"
 #ifndef PLATFORM_MB
 #include "irq.h"
 #include "irq_extra.h"
@@ -78,7 +82,9 @@ static struct iio_data_buffer g_write_buff = {
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t iio_server_init(struct iio_axi_adc_init_param *adc_init,
-			struct iio_axi_dac_init_param *dac_init)
+			struct iio_axi_dac_init_param *dac_init,
+			struct ad9680_dev *ad9680_device,
+			struct ad9144_dev *ad9144_device)
 {
 	struct xil_uart_init_param xil_uart_init_par = {
 #ifdef PLATFORM_MB
@@ -145,6 +151,16 @@ int32_t iio_server_init(struct iio_axi_adc_init_param *adc_init,
 	iio_axi_dac_get_dev_descriptor(iio_axi_dac_desc, &dac_dev_desc);
 	status = iio_register(iio_desc, dac_dev_desc, "axi_dac",
 			      iio_axi_dac_desc, NULL, &g_write_buff);
+	if (status < 0)
+		return status;
+
+	status = iio_register(iio_desc, &ad9680_iio_descriptor, "ad9680_dev",
+			      ad9680_device, NULL, NULL);
+	if (status < 0)
+		return status;
+
+	status = iio_register(iio_desc, &ad9144_iio_descriptor, "ad9144_dev",
+			      ad9144_device, NULL, NULL);
 	if (status < 0)
 		return status;
 

--- a/projects/fmcdaq2/src/app/app_iio.h
+++ b/projects/fmcdaq2/src/app/app_iio.h
@@ -45,6 +45,8 @@
 #include <stdint.h>
 #include "iio_axi_adc.h"
 #include "iio_axi_dac.h"
+#include "ad9680.h"
+#include "ad9144.h"
 
 /******************************************************************************/
 /************************ Functions Declarations ******************************/
@@ -52,6 +54,8 @@
 
 /* @brief Application IIO setup. */
 int32_t iio_server_init(struct iio_axi_adc_init_param *adc_init,
-			struct iio_axi_dac_init_param *dac_init);
+			struct iio_axi_dac_init_param *dac_init,
+			struct ad9680_dev *ad9680_device,
+			struct ad9144_dev *ad9144_device);
 
 #endif

--- a/projects/fmcdaq2/src/app/fmcdaq2.c
+++ b/projects/fmcdaq2/src/app/fmcdaq2.c
@@ -650,7 +650,8 @@ static int fmcdaq2_iio_init(struct fmcdaq2_dev *dev,
 #endif
 	};
 
-	return iio_server_init(&iio_axi_adc_init_par, &iio_axi_dac_init_par);
+	return iio_server_init(&iio_axi_adc_init_par, &iio_axi_dac_init_par,
+			       dev->ad9680_device, dev->ad9144_device);
 #endif
 
 	return SUCCESS;


### PR DESCRIPTION
- ad9680: add IIO driver
- ad9144: add IIO driver
- fmcdaq2: add IIO support for ADC/DAC reg access

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>