### PR TITLE
drivers:adc:ad7124: add register methods wrappers

### DIFF
--- a/drivers/adc/ad7124/ad7124.c
+++ b/drivers/adc/ad7124/ad7124.c
@@ -187,6 +187,7 @@ int32_t ad7124_no_check_write_register(struct ad7124_dev *dev,
  * @brief Reads the value of the specified register only when the device is ready
  *        to accept user requests. If the device ready flag is deactivated the
  *        read operation will be executed without checking the device state.
+ *        DEPRECATED, use ad7124_read_register2.
  *
  * @param dev   - The handler of the instance of the driver.
  * @param p_reg - Pointer to the register structure holding info about the
@@ -212,10 +213,32 @@ int32_t ad7124_read_register(struct ad7124_dev *dev,
 	return ret;
 }
 
+/**
+ * @brief Wrap the read register function to give it a modern signature.
+ * @param [in] dev - Driver handler pointer.
+ * @param [in] reg - Address of the register to be read.
+ * @param [out] readval - Pointer to the register value.
+ * @return SUCCESS in case of success, error code otherwise.
+ */
+int32_t ad7124_read_register2(struct ad7124_dev *dev, uint32_t reg,
+			      uint32_t *readval)
+{
+	int32_t ret;
+
+	ret = ad7124_read_register(dev, &dev->regs[reg]);
+	if (ret != 0)
+		return ret;
+
+	*readval = dev->regs[reg].value;
+
+	return ret;
+}
+
 /***************************************************************************//**
  * @brief Writes the value of the specified register only when the device is
  *        ready to accept user requests. If the device ready flag is deactivated
  *        the write operation will be executed without checking the device state.
+ *        DEPRECATED, use ad7124_write_register2.
  *
  * @param dev - The handler of the instance of the driver.
  * @param p_reg - Register structure holding info about the register to be written
@@ -237,6 +260,21 @@ int32_t ad7124_write_register(struct ad7124_dev *dev,
 					     p_reg);
 
 	return ret;
+}
+
+/**
+ * @brief Wrap the write register function to give it a modern signature.
+ * @param [in] dev - Driver handler pointer.
+ * @param [in] reg - Address of the register to be read.
+ * @param [in] writeval - New value for the register.
+ * @return SUCCESS in case of success, error code otherwise.
+ */
+int32_t ad7124_write_register2(struct ad7124_dev *dev, uint32_t reg,
+			       uint32_t writeval)
+{
+	dev->regs[reg].value = writeval;
+
+	return ad7124_write_register(dev, dev->regs[reg]);
 }
 
 /***************************************************************************//**

--- a/drivers/adc/ad7124/ad7124.h
+++ b/drivers/adc/ad7124/ad7124.h
@@ -376,9 +376,17 @@ struct ad7124_init_param {
 int32_t ad7124_read_register(struct ad7124_dev *dev,
 			     struct ad7124_st_reg* p_reg);
 
+/*! Wrap the read register function to give it a modern signature. */
+int32_t ad7124_read_register2(struct ad7124_dev *dev, uint32_t reg,
+			      uint32_t *readval);
+
 /*! Writes the value of the specified register. */
 int32_t ad7124_write_register(struct ad7124_dev *dev,
 			      struct ad7124_st_reg reg);
+
+/*! Wrap the write register function to give it a modern signature. */
+int32_t ad7124_write_register2(struct ad7124_dev *dev, uint32_t reg,
+			       uint32_t writeval);
 
 /*! Reads the value of the specified register without a device state check. */
 int32_t ad7124_no_check_read_register(struct ad7124_dev *dev,

--- a/drivers/adc/ad7124/ad7124.h
+++ b/drivers/adc/ad7124/ad7124.h
@@ -415,6 +415,9 @@ int32_t ad7124_wait_for_conv_ready(struct ad7124_dev *dev,
 int32_t ad7124_read_data(struct ad7124_dev *dev,
 			 int32_t* p_data);
 
+/*! Get the ID of the channel of the latest conversion. */
+int32_t ad7124_get_read_chan_id(struct ad7124_dev *dev, uint32_t *status);
+
 /*! Computes the CRC checksum for a data buffer. */
 uint8_t ad7124_compute_crc8(uint8_t* p_buf,
 			    uint8_t buf_size);
@@ -424,6 +427,20 @@ void ad7124_update_crcsetting(struct ad7124_dev *dev);
 
 /*! Updates the device SPI interface settings. */
 void ad7124_update_dev_spi_settings(struct ad7124_dev *dev);
+
+/*! Get the AD7124 reference clock. */
+int32_t ad7124_fclk_get(struct ad7124_dev *dev, float *f_clk);
+
+/*! Get the filter coefficient for the sample rate. */
+int32_t ad7124_fltcoff_get(struct ad7124_dev *dev, int16_t ch_no,
+			   uint16_t *flt_coff);
+
+/*! Calculate ODR of the device. */
+float ad7124_get_odr(struct ad7124_dev *dev, int16_t ch_no);
+
+/*! Set ODR of the device. */
+int32_t ad7124_set_odr(struct ad7124_dev *dev, float odr,
+		       int16_t ch_no);
 
 /*! Initializes the AD7124. */
 int32_t ad7124_setup(struct ad7124_dev **device,


### PR DESCRIPTION
Add register get and set functions wrappers to give them an appropriate
modern signature and call scheme.

Using the old get/set register functions means accessing the driver
handlers inner workings which is usually not desirable. Those wrappers
avoid this issue and maintain backwards compatibility.

Add convenient functions to the driver to use with IIO driver.

Signed-off-by: Andrei Drimbarean <Andrei.Drimbarean@analog.com>