### PR TITLE
fmcdaq3: ADC/DAC IIO direct reg access

### DIFF
--- a/drivers/dac/ad9152/iio_ad9152.h
+++ b/drivers/dac/ad9152/iio_ad9152.h
@@ -1,0 +1,52 @@
+/***************************************************************************//**
+ *   @file   iio_ad9152.h
+ *   @brief  Header file of AD9152 iio.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2021(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef IIO_AD9152_H
+#define IIO_AD9152_H
+
+#include "iio_types.h"
+#include "ad9152.h"
+
+/** IIO Descriptor */
+struct iio_device ad9152_iio_descriptor = {
+	.debug_reg_read = (int32_t (*)())ad9152_spi_read,
+	.debug_reg_write = (int32_t (*)())ad9152_spi_write,
+};
+
+#endif //IIO_AD9152_H

--- a/projects/fmcdaq3/src.mk
+++ b/projects/fmcdaq3/src.mk
@@ -46,7 +46,9 @@ endif
 INCS +=	$(PROJECT)/src/app/app_config.h					\
 	$(PROJECT)/src/devices/adi_hal/parameters.h
 ifeq (y,$(strip $(TINYIIOD)))
-INCS +=	$(PROJECT)/src/app/app_iio.h
+INCS +=	$(PROJECT)/src/app/app_iio.h					\
+	$(DRIVERS)/adc/ad9680/iio_ad9680.h				\
+	$(DRIVERS)/dac/ad9152/iio_ad9152.h
 endif
 INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h			\
 	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.h			\

--- a/projects/fmcdaq3/src/app/app_iio.c
+++ b/projects/fmcdaq3/src/app/app_iio.c
@@ -47,6 +47,8 @@
 #include "iio.h"
 #include "parameters.h"
 #include "app_iio.h"
+#include "iio_ad9680.h"
+#include "iio_ad9152.h"
 #ifndef PLATFORM_MB
 #include "irq.h"
 #include "irq_extra.h"
@@ -78,7 +80,9 @@ static struct iio_data_buffer g_write_buff = {
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t iio_server_init(struct iio_axi_adc_init_param *adc_init,
-			struct iio_axi_dac_init_param *dac_init)
+			struct iio_axi_dac_init_param *dac_init,
+			struct ad9680_dev *ad9680_device,
+			struct ad9152_dev *ad9152_device)
 {
 	struct xil_uart_init_param xil_uart_init_par = {
 #ifdef PLATFORM_MB
@@ -145,6 +149,16 @@ int32_t iio_server_init(struct iio_axi_adc_init_param *adc_init,
 	iio_axi_dac_get_dev_descriptor(iio_axi_dac_desc, &dac_dev_desc);
 	status = iio_register(iio_desc, dac_dev_desc, "axi_dac",
 			      iio_axi_dac_desc, NULL, &g_write_buff);
+	if (status < 0)
+		return status;
+
+	status = iio_register(iio_desc, &ad9680_iio_descriptor, "ad9680_dev",
+			      ad9680_device, NULL, NULL);
+	if (status < 0)
+		return status;
+
+	status = iio_register(iio_desc, &ad9152_iio_descriptor, "ad9152_dev",
+			      ad9152_device, NULL, NULL);
 	if (status < 0)
 		return status;
 

--- a/projects/fmcdaq3/src/app/app_iio.h
+++ b/projects/fmcdaq3/src/app/app_iio.h
@@ -45,6 +45,8 @@
 #include <stdint.h>
 #include "iio_axi_adc.h"
 #include "iio_axi_dac.h"
+#include "ad9680.h"
+#include "ad9152.h"
 
 /******************************************************************************/
 /************************ Functions Declarations ******************************/
@@ -52,6 +54,8 @@
 
 /* @brief Application IIO setup. */
 int32_t iio_server_init(struct iio_axi_adc_init_param *adc_init,
-			struct iio_axi_dac_init_param *dac_init);
+			struct iio_axi_dac_init_param *dac_init,
+			struct ad9680_dev *ad9680_device,
+			struct ad9152_dev *ad9152_device);
 
 #endif

--- a/projects/fmcdaq3/src/app/fmcdaq3.c
+++ b/projects/fmcdaq3/src/app/fmcdaq3.c
@@ -578,7 +578,8 @@ int main(void)
 #endif
 	};
 
-	return iio_server_init(&iio_axi_adc_init_par, &iio_axi_dac_init_par);
+	return iio_server_init(&iio_axi_adc_init_par, &iio_axi_dac_init_par,
+			       ad9680_device, ad9152_device);
 
 #endif
 


### PR DESCRIPTION
- ad9152: add IIO driver
- fmcdaq3: add IIO support for ADC/DAC reg access

Signed-off-by: Antoniu Miclaus antoniu.miclaus@analog.com