### PR TITLE
Adxrs290 Buffered channel support.

### DIFF
--- a/drivers/gyro/adxrs290/adxrs290.h
+++ b/drivers/gyro/adxrs290/adxrs290.h
@@ -91,6 +91,8 @@
 #define ADXRS290_READ_REG(reg)	(ADXRS290_READ | (reg))
 
 #define ADXRS290_MAX_TRANSITION_TIME_MS 100
+#define ADXRS290_CHANNEL_COUNT			3
+#define ADXRS290_CHANNEL_MASK			0x07
 /******************************************************************************/
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
@@ -174,7 +176,9 @@ struct adxrs290_init_param {
  */
 struct adxrs290_dev {
 	/** SPI handler */
-	struct spi_desc *spi_desc;
+	struct spi_desc		*spi_desc;
+	/** Active Channels */
+	uint8_t			ch_mask;
 };
 
 /******************************************************************************/
@@ -210,6 +214,13 @@ int32_t adxrs290_get_rate_data(struct adxrs290_dev *dev,
 
 /* Read Temperature data */
 int32_t adxrs290_get_temp_data(struct adxrs290_dev *dev, int16_t *temp);
+
+/* Get the burst data */
+int32_t adxrs290_get_burst_data(struct adxrs290_dev *dev, int16_t *burst_data,
+				uint8_t *ch_cnt);
+
+/* Set the ADXRS290 active channels */
+int32_t adxrs290_set_active_channels(struct adxrs290_dev *dev, uint32_t mask);
 
 /* Init. the comm. peripheral and checks if the ADXRS290 part is present. */
 int32_t adxrs290_init(struct adxrs290_dev **device,

--- a/drivers/gyro/adxrs290/adxrs290.h
+++ b/drivers/gyro/adxrs290/adxrs290.h
@@ -45,6 +45,7 @@
 /******************************************************************************/
 
 #include <stdbool.h>
+#include "gpio.h"
 #include "spi.h"
 #include "util.h"
 
@@ -161,13 +162,14 @@ enum adxrs290_hpf {
 struct adxrs290_init_param {
 	/** SPI Initialization structure. */
 	struct spi_init_param	spi_init;
+	/** GPIO */
+	struct gpio_init_param	gpio_sync;
 	/** Initial Mode */
-	enum adxrs290_mode mode;
+	enum adxrs290_mode	mode;
 	/** Initial lpf settings */
-	enum adxrs290_lpf lpf;
+	enum adxrs290_lpf	lpf;
 	/** Initial hpf settings */
-	enum adxrs290_hpf hpf;
-
+	enum adxrs290_hpf	hpf;
 };
 
 /**
@@ -177,6 +179,8 @@ struct adxrs290_init_param {
 struct adxrs290_dev {
 	/** SPI handler */
 	struct spi_desc		*spi_desc;
+	/** GPIO */
+	struct gpio_desc	*gpio_sync;
 	/** Active Channels */
 	uint8_t			ch_mask;
 };
@@ -221,6 +225,9 @@ int32_t adxrs290_get_burst_data(struct adxrs290_dev *dev, int16_t *burst_data,
 
 /* Set the ADXRS290 active channels */
 int32_t adxrs290_set_active_channels(struct adxrs290_dev *dev, uint32_t mask);
+
+/* Get the data ready state */
+int32_t adxrs290_get_data_ready(struct adxrs290_dev *dev, bool *rdy);
 
 /* Init. the comm. peripheral and checks if the ADXRS290 part is present. */
 int32_t adxrs290_init(struct adxrs290_dev **device,

--- a/iio/iio_adxrs290/iio_adxrs290.c
+++ b/iio/iio_adxrs290/iio_adxrs290.c
@@ -173,3 +173,30 @@ ssize_t set_adxrs290_iio_ch_lpf(void *device, char *buf, size_t len,
 
 	return FAILURE;
 }
+
+int32_t adxrs290_update_active_channels(void *device, uint32_t mask)
+{
+	struct adxrs290_dev *dev = device;
+
+	adxrs290_set_active_channels(dev, mask);
+
+	return SUCCESS;
+}
+
+int32_t adxrs290_read_samples(void *device, uint16_t *buff, uint32_t nb_samples)
+{
+	struct adxrs290_dev	*dev = device;
+	uint32_t		i;
+	uint32_t		offset;
+	int16_t			data[ADXRS290_CHANNEL_COUNT];
+	uint8_t			ch_cnt;
+
+	offset = 0;
+	for (i = 0; i < nb_samples; i++) {
+		adxrs290_get_burst_data(dev, data, &ch_cnt);
+		memcpy(&buff[offset], data, ch_cnt*sizeof(int16_t));
+		offset += ch_cnt;
+	}
+
+	return nb_samples;
+}

--- a/iio/iio_adxrs290/iio_adxrs290.c
+++ b/iio/iio_adxrs290/iio_adxrs290.c
@@ -45,11 +45,6 @@
 #include "util.h"
 #include "error.h"
 
-#define NUM_CHANNELS		3
-#define MAX_REG_ADDR		0x12
-
-volatile uint8_t current_direct_reg = 0;
-
 /*
  * Available cut-off frequencies of the low pass filter in Hz.
  * The integer part and fractional part are represented separately.

--- a/iio/iio_adxrs290/iio_adxrs290.c
+++ b/iio/iio_adxrs290/iio_adxrs290.c
@@ -190,9 +190,18 @@ int32_t adxrs290_read_samples(void *device, uint16_t *buff, uint32_t nb_samples)
 	uint32_t		offset;
 	int16_t			data[ADXRS290_CHANNEL_COUNT];
 	uint8_t			ch_cnt;
+	bool			rdy;
 
 	offset = 0;
 	for (i = 0; i < nb_samples; i++) {
+		/* Stop until data is available.
+		 * This will not block at first data since sync pin will
+		 * will always be high until read. */
+		while(true) {
+			adxrs290_get_data_ready(dev, &rdy);
+			if (rdy == true)
+				break;
+		}
 		adxrs290_get_burst_data(dev, data, &ch_cnt);
 		memcpy(&buff[offset], data, ch_cnt*sizeof(int16_t));
 		offset += ch_cnt;

--- a/iio/iio_adxrs290/iio_adxrs290.h
+++ b/iio/iio_adxrs290/iio_adxrs290.h
@@ -42,10 +42,6 @@
 
 #include "iio_types.h"
 
-ssize_t get_adxrs290_iio_reg(void *device, char *buf, size_t len,
-			     const struct iio_ch_info *channel, intptr_t priv);
-ssize_t set_adxrs290_iio_reg(void *device, char *buf, size_t len,
-			     const struct iio_ch_info *channel, intptr_t priv);
 ssize_t get_adxrs290_iio_ch_raw(void *device, char *buf, size_t len,
 				const struct iio_ch_info *channel, intptr_t priv);
 ssize_t get_adxrs290_iio_ch_scale(void *device, char *buf, size_t len,

--- a/projects/adxrs290-pmdz/src.mk
+++ b/projects/adxrs290-pmdz/src.mk
@@ -22,6 +22,7 @@ LIBRARIES += iio
 
 SRCS += $(PLATFORM_DRIVERS)/uart.c					\
 	$(PLATFORM_DRIVERS)/irq.c					\
+	$(PLATFORM_DRIVERS)/gpio.c					\
 	$(PLATFORM_DRIVERS)/spi.c					\
 	$(NO-OS)/util/xml.c						\
 	$(NO-OS)/util/list.c						\
@@ -35,6 +36,7 @@ INCS += $(INCLUDE)/xml.h						\
 	$(INCLUDE)/list.h						\
 	$(INCLUDE)/util.h						\
 	$(INCLUDE)/error.h						\
+	$(INCLUDE)/gpio.h						\
 	$(INCLUDE)/spi.h						\
 	$(PLATFORM_DRIVERS)/spi_extra.h					\
 	$(PLATFORM_DRIVERS)/irq_extra.h					\

--- a/projects/adxrs290-pmdz/src/main.c
+++ b/projects/adxrs290-pmdz/src/main.c
@@ -67,6 +67,10 @@
 
 #define MAX_SIZE_BASE_ADDR		3000
 
+static uint8_t in_buff[MAX_SIZE_BASE_ADDR];
+
+#define GYRO_DDR_BASEADDR		((uint32_t)in_buff)
+
 #endif
 
 int32_t platform_init()
@@ -217,12 +221,17 @@ int main(void)
 	if (status < 0)
 		return status;
 
+	struct iio_data_buffer rd_buf = {
+		.buff = (void *)GYRO_DDR_BASEADDR,
+		.size = MAX_SIZE_BASE_ADDR
+	};
+
 	status = iio_init(&iio_desc, &iio_init_param);
 	if(status < 0)
 		return status;
 
 	status = iio_register(iio_desc, &adxrs290_iio_descriptor,
-			      "adxrs290", adxrs290_device, NULL, NULL);
+			      "adxrs290", adxrs290_device, &rd_buf, NULL);
 	if (status < 0)
 		return status;
 

--- a/projects/adxrs290-pmdz/src/main.c
+++ b/projects/adxrs290-pmdz/src/main.c
@@ -70,6 +70,7 @@
 static uint8_t in_buff[MAX_SIZE_BASE_ADDR];
 
 #define GYRO_DDR_BASEADDR		((uint32_t)in_buff)
+#define GPIO_SYNC_PIN_NUM		0x10
 
 #endif
 
@@ -106,6 +107,9 @@ int main(void)
 
 	/* Initialization for UART. */
 	struct uart_init_param uart_init_par;
+
+	/* GPIO initial configuration. */
+	struct gpio_init_param	gpio_sync_init_param;
 
 	/* IRQ initial configuration. */
 	struct irq_init_param irq_init_param;
@@ -210,9 +214,16 @@ int main(void)
 		.platform_ops = NULL
 	};
 
+	/* Initialization for Sync pin GPIO. */
+	gpio_sync_init_param = (struct gpio_init_param) {
+		.number = GPIO_SYNC_PIN_NUM,
+		.extra = NULL
+	};
+
 	struct adxrs290_init_param adxrs290_param = {
 		.spi_init = init_param,
 		.mode = ADXRS290_MODE_MEASUREMENT,
+		.gpio_sync = gpio_sync_init_param,
 		.lpf = ADXRS290_LPF_480HZ,
 		.hpf = ADXRS290_HPF_ALL_PASS
 	};


### PR DESCRIPTION
To make this tinyiio demo as close as possible to the linux version, buffered channels has been added. The following are added:
1. Added buffered channel reading in the iio\iio_adxrs290 and the project.
2. Added the sync pin support to the driver to be able to check if the device has data available. 
3. Added a data_ready function from the driver and use this when getting data for the read_dev. This enables the read_dev to get the data only if it is available. Since TRIGGER is not yet supported by tinyiio, this acts as the throttling mechanism to ensure a minimum data reading interval.

This is how it will look like in IIO-OSC capture window (Auto scale disabled: Ymax: 30000, Ymin:-30000):
![image](https://user-images.githubusercontent.com/60493211/104317361-d3726e00-5518-11eb-89cc-ffaf44f003b2.png)
