### PR TITLE
AXI DMAC IRQ

### DIFF
--- a/drivers/axi_core/axi_dmac/axi_dmac.c
+++ b/drivers/axi_core/axi_dmac/axi_dmac.c
@@ -42,10 +42,62 @@
 /******************************************************************************/
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include "axi_io.h"
 #include "error.h"
 #include "delay.h"
 #include "axi_dmac.h"
+
+/***************************************************************************//**
+ * @brief dma_isr
+*******************************************************************************/
+void axi_dmac_default_isr(void *instance)
+{
+	struct axi_dmac *dmac = (struct axi_dmac *)instance;
+	uint32_t remaining_size, burst_size;
+	uint32_t reg_val;
+
+	/* Get interrupt sources and clear interrupts. */
+	axi_dmac_read(dmac, AXI_DMAC_REG_IRQ_PENDING, &reg_val);
+	axi_dmac_write(dmac, AXI_DMAC_REG_IRQ_PENDING, reg_val);
+
+	if ((reg_val & AXI_DMAC_IRQ_SOT) && (dmac->big_transfer.size != 0)) {
+		remaining_size = dmac->big_transfer.size -
+				 dmac->big_transfer.size_done;
+		burst_size = (remaining_size <= dmac->transfer_max_size) ?
+			     remaining_size : dmac->transfer_max_size;
+
+		dmac->big_transfer.size_done += burst_size;
+		dmac->big_transfer.address += burst_size;
+		switch (dmac->direction) {
+		case DMA_DEV_TO_MEM:
+			axi_dmac_write(dmac, AXI_DMAC_REG_DEST_ADDRESS,
+				       dmac->big_transfer.address);
+			axi_dmac_write(dmac, AXI_DMAC_REG_DEST_STRIDE, 0x0);
+			break;
+		case DMA_MEM_TO_DEV:
+			axi_dmac_write(dmac, AXI_DMAC_REG_SRC_ADDRESS,
+				       dmac->big_transfer.address);
+			axi_dmac_write(dmac, AXI_DMAC_REG_SRC_STRIDE, 0x0);
+			break;
+		default:
+			return; // Other directions are not supported yet
+		}
+		/* The current transfer was started and a new one is queued. */
+		axi_dmac_write(dmac, AXI_DMAC_REG_X_LENGTH,
+			       burst_size);
+		axi_dmac_write(dmac, AXI_DMAC_REG_Y_LENGTH, 0x0);
+
+		axi_dmac_write(dmac, AXI_DMAC_REG_START_TRANSFER, 0x1);
+	}
+	if (reg_val & AXI_DMAC_IRQ_EOT) {
+		dmac->big_transfer.transfer_done = true;
+		dmac->big_transfer.address = 0;
+		dmac->big_transfer.size = 0;
+		dmac->big_transfer.size_done = 0;
+	}
+}
 
 /***************************************************************************//**
  * @brief axi_dmac_read
@@ -72,6 +124,76 @@ int32_t axi_dmac_write(struct axi_dmac *dmac,
 }
 
 /***************************************************************************//**
+ * @brief axi_dmac_transfer_nonblock
+ *******************************************************************************/
+int32_t axi_dmac_transfer_nonblocking(struct axi_dmac *dmac,
+				      uint32_t address, uint32_t size)
+{
+	uint32_t reg_val;
+
+	if (size == 0)
+		return SUCCESS; /* nothing to do */
+
+	axi_dmac_read(dmac, AXI_DMAC_REG_CTRL, &reg_val);
+	if (!(reg_val & AXI_DMAC_CTRL_ENABLE)) {
+		axi_dmac_write(dmac, AXI_DMAC_REG_CTRL, 0x0);
+		axi_dmac_write(dmac, AXI_DMAC_REG_CTRL, AXI_DMAC_CTRL_ENABLE);
+		axi_dmac_write(dmac, AXI_DMAC_REG_IRQ_MASK, 0x0);
+	}
+
+	axi_dmac_read(dmac, AXI_DMAC_REG_START_TRANSFER, &reg_val);
+	if (!(reg_val & 1)) {
+		switch (dmac->direction) {
+		case DMA_DEV_TO_MEM:
+			axi_dmac_write(dmac, AXI_DMAC_REG_DEST_ADDRESS, address);
+			axi_dmac_write(dmac, AXI_DMAC_REG_DEST_STRIDE, 0x0);
+			break;
+		case DMA_MEM_TO_DEV:
+			axi_dmac_write(dmac, AXI_DMAC_REG_SRC_ADDRESS, address);
+			axi_dmac_write(dmac, AXI_DMAC_REG_SRC_STRIDE, 0x0);
+			break;
+		default:
+			return FAILURE; // Other directions are not supported yet
+		}
+		if ((size - 1) > dmac->transfer_max_size) {
+			dmac->big_transfer.address = address;
+			dmac->big_transfer.size = size - 1;
+			dmac->big_transfer.size_done = dmac->transfer_max_size;
+
+			axi_dmac_write(dmac, AXI_DMAC_REG_X_LENGTH,
+				       dmac->transfer_max_size);
+			axi_dmac_write(dmac, AXI_DMAC_REG_Y_LENGTH, 0x0);
+
+			axi_dmac_write(dmac, AXI_DMAC_REG_FLAGS, dmac->flags);
+
+			axi_dmac_write(dmac, AXI_DMAC_REG_START_TRANSFER, 0x1);
+		} else {
+			axi_dmac_write(dmac, AXI_DMAC_REG_X_LENGTH,
+				       size - 1);
+			axi_dmac_write(dmac, AXI_DMAC_REG_Y_LENGTH, 0x0);
+
+			axi_dmac_write(dmac, AXI_DMAC_REG_FLAGS, dmac->flags);
+
+			axi_dmac_write(dmac, AXI_DMAC_REG_START_TRANSFER, 0x1);
+		}
+	} else {
+		return FAILURE;
+	}
+
+	return SUCCESS;
+}
+
+/***************************************************************************//**
+ * @brief axi_dmac_is_transfer_ready
+ *******************************************************************************/
+int32_t axi_dmac_is_transfer_ready(struct axi_dmac *dmac, bool *rdy)
+{
+	*rdy = dmac->big_transfer.transfer_done;
+
+	return SUCCESS;
+}
+
+/***************************************************************************//**
  * @brief axi_dmac_transfer
  *******************************************************************************/
 int32_t axi_dmac_transfer(struct axi_dmac *dmac,
@@ -79,6 +201,7 @@ int32_t axi_dmac_transfer(struct axi_dmac *dmac,
 {
 	uint32_t transfer_id;
 	uint32_t reg_val;
+	uint32_t timeout = 0;
 
 	if (size == 0)
 		return SUCCESS; /* nothing to do */
@@ -104,6 +227,33 @@ int32_t axi_dmac_transfer(struct axi_dmac *dmac,
 	default:
 		return FAILURE; // Other directions are not supported yet
 	}
+
+	if ((size - 1) > dmac->transfer_max_size) {
+		dmac->big_transfer.address = address;
+		dmac->big_transfer.size = size - 1;
+		dmac->big_transfer.size_done = dmac->transfer_max_size;
+
+		axi_dmac_write(dmac, AXI_DMAC_REG_X_LENGTH,
+			       dmac->transfer_max_size);
+		axi_dmac_write(dmac, AXI_DMAC_REG_Y_LENGTH, 0x0);
+
+		axi_dmac_write(dmac, AXI_DMAC_REG_FLAGS, dmac->flags);
+
+		axi_dmac_write(dmac, AXI_DMAC_REG_START_TRANSFER, 0x1);
+
+		while(!dmac->big_transfer.transfer_done) {
+			timeout++;
+			if (timeout == UINT32_MAX)
+				return FAILURE;
+		}
+
+		dmac->big_transfer.address = 0;
+		dmac->big_transfer.size = 0;
+		dmac->big_transfer.size_done = 0;
+
+		return SUCCESS;
+	}
+
 	axi_dmac_write(dmac, AXI_DMAC_REG_X_LENGTH, size - 1);
 	axi_dmac_write(dmac, AXI_DMAC_REG_Y_LENGTH, 0x0);
 
@@ -122,8 +272,11 @@ int32_t axi_dmac_transfer(struct axi_dmac *dmac,
 	/* Wait until the current transfer is completed. */
 	do {
 		axi_dmac_read(dmac, AXI_DMAC_REG_IRQ_PENDING, &reg_val);
-	} while(reg_val != (AXI_DMAC_IRQ_SOT | AXI_DMAC_IRQ_EOT));
-	axi_dmac_write(dmac, AXI_DMAC_REG_IRQ_PENDING, reg_val);
+		if (reg_val == (AXI_DMAC_IRQ_SOT | AXI_DMAC_IRQ_EOT))
+			break;
+	} while(!dmac->big_transfer.transfer_done);
+	if (reg_val != (AXI_DMAC_IRQ_SOT | AXI_DMAC_IRQ_EOT))
+		axi_dmac_write(dmac, AXI_DMAC_REG_IRQ_PENDING, reg_val);
 
 	/* Wait until the transfer with the ID transfer_id is completed. */
 	do {
@@ -149,6 +302,13 @@ int32_t axi_dmac_init(struct axi_dmac **dmac_core,
 	dmac->base = init->base;
 	dmac->direction = init->direction;
 	dmac->flags = init->flags;
+	dmac->transfer_max_size = -1;
+	dmac->big_transfer.address = 0;
+	dmac->big_transfer.size = 0;
+	dmac->big_transfer.size_done = 0;
+
+	axi_dmac_write(dmac, AXI_DMAC_REG_X_LENGTH, dmac->transfer_max_size);
+	axi_dmac_read(dmac, AXI_DMAC_REG_X_LENGTH, &dmac->transfer_max_size);
 
 	*dmac_core = dmac;
 

--- a/drivers/axi_core/axi_dmac/axi_dmac.h
+++ b/drivers/axi_core/axi_dmac/axi_dmac.h
@@ -81,11 +81,20 @@ enum dma_flags {
 	DMA_LAST = 2
 };
 
+struct axi_dma_transfer {
+	uint32_t size;
+	uint32_t address;
+	uint32_t size_done;
+	volatile bool transfer_done;
+};
+
 struct axi_dmac {
 	const char *name;
 	uint32_t base;
 	enum dma_direction direction;
 	uint32_t flags;
+	uint32_t transfer_max_size;
+	volatile struct axi_dma_transfer big_transfer;
 };
 
 struct axi_dmac_init {
@@ -98,10 +107,14 @@ struct axi_dmac_init {
 /******************************************************************************/
 /************************ Functions Declarations ******************************/
 /******************************************************************************/
+void axi_dmac_default_isr(void *instance);
 int32_t axi_dmac_read(struct axi_dmac *dmac, uint32_t reg_addr,
 		      uint32_t *reg_data);
 int32_t axi_dmac_write(struct axi_dmac *dmac, uint32_t reg_addr,
 		       uint32_t reg_data);
+int32_t axi_dmac_transfer_nonblocking(struct axi_dmac *dmac,
+				      uint32_t address, uint32_t size);
+int32_t axi_dmac_is_transfer_ready(struct axi_dmac *dmac, bool *rdy);
 int32_t axi_dmac_transfer(struct axi_dmac *dmac,
 			  uint32_t address, uint32_t size);
 int32_t axi_dmac_init(struct axi_dmac **adc_core,

--- a/drivers/platform/xilinx/irq.c
+++ b/drivers/platform/xilinx/irq.c
@@ -280,6 +280,46 @@ int32_t irq_register_callback(struct irq_ctrl_desc *desc, uint32_t irq_id,
 }
 
 /**
+ * @brief Set interrupt trigger level.
+ * @param desc - The IRQ controller descriptor.
+ * @param irq_id - Interrupt identifier.
+ * @param trig - New trigger level for the interrupt.
+ * @return SUCCESS in case of success, FAILURE otherwise.
+ */
+int32_t irq_trigger_level_set(struct irq_ctrl_desc *desc, uint32_t irq_id,
+			      enum irq_trig_level trig)
+{
+	struct xil_irq_desc *xil_dev = desc->extra;
+
+	switch(xil_dev->type) {
+	case IRQ_PS:
+#ifdef XSCUGIC_H
+		;
+		uint8_t priority, trigger;
+
+		XScuGic_GetPriorityTriggerType(xil_dev->instance, irq_id, &priority,
+					       &trigger);
+		trigger = trig;
+		XScuGic_SetPriorityTriggerType(xil_dev->instance, irq_id, priority,
+					       trigger);
+
+		return SUCCESS;
+#endif
+		break;
+	case IRQ_PL:
+#ifdef XINTC_H
+		/* Interrupt trigger determined in hardware. TODO: verify */
+		return SUCCESS;
+#endif
+		break;
+	default:
+		break;
+	}
+
+	return FAILURE;
+}
+
+/**
  * @brief Unregisters a generic IRQ handling function.
  * @param desc - The IRQ controller descriptor.
  * @param irq_id - Interrupt identifier.

--- a/include/irq.h
+++ b/include/irq.h
@@ -63,6 +63,13 @@ enum irq_uart_event_e {
 	ERROR
 };
 
+enum irq_trig_level {
+	IRQ_LEVEL_LOW,
+	IRQ_LEVEL_HIGH,
+	IRQ_EDGE_LOW,
+	IRQ_EDGE_HIGH
+};
+
 /**
  * @struct irq_init_param
  * @brief Structure holding the initial parameters for Interrupt Request.
@@ -126,6 +133,10 @@ int32_t irq_global_enable(struct irq_ctrl_desc *desc);
 
 /* Global interrupt disable */
 int32_t irq_global_disable(struct irq_ctrl_desc *desc);
+
+/* Set interrupt trigger level. */
+int32_t irq_trigger_level_set(struct irq_ctrl_desc *desc, uint32_t irq_id,
+			      enum irq_trig_level trig);
 
 /* Enable specific interrupt */
 int32_t irq_enable(struct irq_ctrl_desc *desc, uint32_t irq_id);

--- a/projects/ad9361/src.mk
+++ b/projects/ad9361/src.mk
@@ -22,6 +22,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
 	$(NO-OS)/util/util.c
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c
 SRCS +=	$(PLATFORM_DRIVERS)/$(PLATFORM)_spi.c				\
+	$(PLATFORM_DRIVERS)/irq.c					\
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_gpio.c
 ifeq (linux,$(strip $(PLATFORM)))
 SRCS +=	$(PLATFORM_DRIVERS)/linux_delay.c
@@ -31,7 +32,6 @@ endif
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
 SRCS += $(PLATFORM_DRIVERS)/uart.c					\
-	$(PLATFORM_DRIVERS)/irq.c					\
 	$(NO-OS)/util/xml.c						\
 	$(NO-OS)/util/fifo.c						\
 	$(NO-OS)/util/list.c						\
@@ -47,6 +47,8 @@ INCS += $(DRIVERS)/rf-transceiver/ad9361/ad9361.h			\
 	$(DRIVERS)/rf-transceiver/ad9361/ad9361_api.h
 INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h			\
 	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.h			\
+	$(PLATFORM_DRIVERS)/irq_extra.h					\
+	$(INCLUDE)/irq.h						\
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h
 ifeq (linux,$(strip $(PLATFORM)))
 INCS +=	$(PLATFORM_DRIVERS)/linux_spi.h					\
@@ -64,10 +66,8 @@ INCS +=	$(INCLUDE)/axi_io.h						\
 ifeq (y,$(strip $(TINYIIOD)))
 INCS += $(INCLUDE)/xml.h						\
 	$(INCLUDE)/fifo.h						\
-	$(INCLUDE)/irq.h						\
 	$(INCLUDE)/uart.h						\
 	$(INCLUDE)/list.h						\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
 	$(PLATFORM_DRIVERS)/uart_extra.h				\
 	$(NO-OS)/iio/iio_ad9361/iio_ad9361.h				\
 	$(NO-OS)/iio/iio_axi_adc/iio_axi_adc.h				\


### PR DESCRIPTION
This is a first draft on using interrupts with DMA.

The AXI DMA driver will now get the maximum transfer size by reading the transfer size register and use interrupts to split up the transfer if it is bigger than that.

The example project with AD9361 has a maximum transfer size of 16kb and a 32kb transfer is successfully done.

 - investigate working with cyclic mode
    - cyclic mode is a transfer that runs endlessly until stopped; interrupt does not seem necessary here
 - investigate working with DAC
    - The DMA interrupt seems to work well with the DAC as well as ADC