### PR TITLE
azure-pipelines: add custom branch build support

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,6 +2,7 @@ trigger:
 - main
 - master
 - staging/*
+- dev/*
 - 20*
 
 pr:


### PR DESCRIPTION
Branches that have `dev/` prefix will be build before creating PRs.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>