### PR TITLE
doxygen: add EXCLUDE_PATTERNS

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -29,6 +29,10 @@ set(EXCLUDE_FILES
     ${SOURCES_DIR}/drivers/adc/ad9081/api \\
 ")
 
+set(EXCLUDE_PATT
+    "*/hal/stm32/* \\
+")
+
 configure_file(
     DoxygenLayoutIn.xml
     ${DOXY_WORKING_DIR}/DoxygenLayout.xml

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -848,7 +848,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       =
+EXCLUDE_PATTERNS       = @EXCLUDE_PATT@
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the


### PR DESCRIPTION
The user can now exclude files/folders using specific patterns.

For now, all `/hal/stm32/` folders will be excluded for doxygen build.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>