### PR TITLE
util: add crc24 implementation

### DIFF
--- a/include/crc24.h
+++ b/include/crc24.h
@@ -1,9 +1,9 @@
 /***************************************************************************//**
- *   @file   crc.h
- *   @brief  Generic header file for all CRC computation algorithms.
- *   @author Darius Berghe (darius.berghe@analog.com)
+ *   @file   crc24.h
+ *   @brief  Header file of CRC-24 computation.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
 ********************************************************************************
- * Copyright 2020(c) Analog Devices, Inc.
+ * Copyright 2021(c) Analog Devices, Inc.
  *
  * All rights reserved.
  *
@@ -36,11 +36,19 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
-#ifndef __CRC_H
-#define __CRC_H
+#ifndef __CRC24_H
+#define __CRC24_H
 
-#include "crc8.h"
-#include "crc16.h"
-#include "crc24.h"
+#include <stdint.h>
+#include <stddef.h>
 
-#endif // __CRC_H
+#define CRC24_TABLE_SIZE 256
+
+#define DECLARE_CRC24_TABLE(_table) \
+	static uint32_t _table[CRC24_TABLE_SIZE]
+
+void crc24_populate_msb(uint32_t * table, const uint32_t polynomial);
+uint32_t crc24(const uint32_t * table, const uint8_t *pdata, size_t nbytes,
+	       uint32_t crc);
+
+#endif // __CRC24_H

--- a/util/crc24.c
+++ b/util/crc24.c
@@ -1,0 +1,103 @@
+/***************************************************************************//**
+ *   @file   crc24.c
+ *   @brief  Source file of CRC-24 computation.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2021(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "crc24.h"
+
+/***************************************************************************//**
+ * @brief Creates the CRC-24 lookup table for a given polynomial.
+ *
+ * @param table      - Pointer to a CRC-24 lookup table to write to.
+ * @param polynomial - msb-first representation of desired polynomial.
+ *
+ * Polynomials in CRC algorithms are typically represented as shown below.
+ *
+ *    poly = x^24 + x^22 + x^20 + x^19 + x^18 + x^16 + x^14 + x^13 + x^11 +
+ *           x^10 + x^8 + x^7 + x^6 + x^3 + x^1 + 1
+ *
+ * Using msb-first direction, x^24 maps to the msb.
+ *
+ *    msb first: poly = (1)010111010110110111001011 = 5D6DCB
+ *                         ^
+ *
+ * @return None.
+*******************************************************************************/
+void crc24_populate_msb(uint32_t * table, const uint32_t polynomial)
+{
+	if (!table)
+		return;
+
+	for (int16_t n = 0; n < CRC24_TABLE_SIZE; n++) {
+		uint32_t currByte = (uint32_t)(n << 16);
+		for (uint8_t bit = 0; bit < 8; bit++) {
+			if ((currByte & 0x800000) != 0) {
+				currByte &= 0x7FFFFF;
+				currByte <<= 1;
+				currByte ^= polynomial;
+			} else {
+				currByte <<= 1;
+			}
+		}
+		table[n] = currByte;
+	}
+}
+
+/***************************************************************************//**
+ * @brief Computes the CRC-24 over a buffer of data.
+ *
+ * @param table     - Pointer to a CRC-24 lookup table for the desired polynomial.
+ * @param pdata     - Pointer to data buffer.
+ * @param nbytes    - Number of bytes to compute the CRC-24 over.
+ * @param crc       - Initial value for the CRC-24 computation. Can be used to
+ *                    cascade calls to this function by providing a previous
+ *                    output of this function as the crc parameter.
+ *
+ * @return crc      - Computed CRC-24 value.
+*******************************************************************************/
+uint32_t crc24(const uint32_t * table, const uint8_t *pdata, size_t nbytes,
+	       uint32_t crc)
+{
+	unsigned int idx;
+
+	while (nbytes--) {
+		idx = ((crc >> 16) ^ *pdata) & 0xff;
+		crc = (table[idx] ^ (crc << 8)) & 0xffffff;
+		pdata++;
+	}
+
+	return (crc & 0xffffff);
+}


### PR DESCRIPTION
Add crc24 lookup table generation and crc24 function that computes the
actual crc based on the generated table.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>