### PR TITLE
Ad5933 feature update

### DIFF
--- a/drivers/impedance-analyzer/ad5933/ad5933.c
+++ b/drivers/impedance-analyzer/ad5933/ad5933.c
@@ -44,10 +44,15 @@
 #include "ad5933.h"
 #include <math.h>
 
+#ifndef M_PI
+#define M_PI 3.14159265359
+#endif
+
 /******************************************************************************/
 /************************** Constants Definitions *****************************/
 /******************************************************************************/
 const int32_t pow_2_27 = 134217728ul;      // 2 to the power of 27
+const double radToDeg180ovPi = 180 / M_PI;
 
 /******************************************************************************/
 /************************ Functions Definitions *******************************/
@@ -217,6 +222,7 @@ void ad5933_set_system_clk(struct ad5933_dev *dev,
  *                Example: AD5933_RANGE_2000mVpp
  *                         AD5933_RANGE_200mVpp
  *                         AD5933_RANGE_400mVpp
+
  *                         AD5933_RANGE_1000mVpp
  * @param gain  - Gain option.
  *                Example: AD5933_GAIN_X5
@@ -421,17 +427,17 @@ double ad5933_calculate_gain_factor(struct ad5933_dev *dev,
  *                       Example: AD5933_FUNCTION_INC_FREQ - Increment freq.;
  *                                AD5933_FUNCTION_REPEAT_FREQ - Repeat freq..
  *
- * @return impedance   - Calculated impedance.
+ * @return ad5933_impedance - Struct of calculated values.
 *******************************************************************************/
-double ad5933_calculate_impedance(struct ad5933_dev *dev,
-				  double gain_factor,
-				  uint8_t freq_function)
+ad5933_impedance ad5933_calculate_impedance(struct ad5933_dev *dev,
+		double gain_factor,
+		uint8_t freq_function)
 {
 	signed short real_data = 0;
 	signed short imag_data = 0;
 	double magnitude = 0;
-	double impedance = 0;
 	uint8_t status = 0;
+	ad5933_impedance result;
 
 	ad5933_set_register_value(dev,
 				  AD5933_REG_CONTROL_HB,
@@ -453,9 +459,10 @@ double ad5933_calculate_impedance(struct ad5933_dev *dev,
 					      2);
 	magnitude = sqrt((real_data * real_data) + (imag_data * imag_data));
 
-	impedance =  1 / (magnitude * gain_factor);
+	result.magnitude = magnitude;
+	result.phase	 = atan2(imag_data,real_data) * radToDeg180ovPi;
 
-	return impedance;
+	return result;
 }
 
 /***************************************************************************//**

--- a/drivers/impedance-analyzer/ad5933/ad5933.c
+++ b/drivers/impedance-analyzer/ad5933/ad5933.c
@@ -81,6 +81,7 @@ int32_t ad5933_init(struct ad5933_dev **device,
 	dev->current_clock_source = init_param.current_clock_source;
 	dev->current_gain = init_param.current_gain;
 	dev->current_range = init_param.current_range;
+	dev->current_settling = init_param.current_settling;
 
 	status = i2c_init(&dev->i2c_desc, &init_param.i2c_init);
 
@@ -216,7 +217,6 @@ void ad5933_set_system_clk(struct ad5933_dev *dev,
  *                Example: AD5933_RANGE_2000mVpp
  *                         AD5933_RANGE_200mVpp
  *                         AD5933_RANGE_400mVpp
-
  *                         AD5933_RANGE_1000mVpp
  * @param gain  - Gain option.
  *                Example: AD5933_GAIN_X5
@@ -456,4 +456,34 @@ double ad5933_calculate_impedance(struct ad5933_dev *dev,
 	impedance =  1 / (magnitude * gain_factor);
 
 	return impedance;
+}
+
+/***************************************************************************//**
+ * @brief Selects the number of settling cycles of the device.
+ *
+ * @param dev		 - The device structure.
+ * @param cycles	 - 9-bit number of cycles to wait before triggering ADC
+ *
+ * @param multiplier - Multiply number of cycles by X1, X2 or X4
+ *                Example: AD5933_SETTLING_X1
+ *                         AD5933_SETTLING_X2
+ *                         AD5933_SETTLING_X4
+ *
+ * @return None.
+*******************************************************************************/
+void ad5933_set_settling_time(struct ad5933_dev *dev,
+			      uint8_t		multiplier,
+			      uint16_t		number_cycles)
+{
+
+
+	if ((multiplier != AD5933_SETTLING_X2) && (multiplier != AD5933_SETTLING_X4))
+		multiplier = AD5933_SETTLING_X1;
+
+	ad5933_set_register_value(dev,
+				  AD5933_REG_SETTLING_CYCLES,
+				  number_cycles | (multiplier << 9),
+				  2);
+	/* Store the last settings made. */
+	dev->current_settling = number_cycles;
 }

--- a/drivers/impedance-analyzer/ad5933/ad5933.h
+++ b/drivers/impedance-analyzer/ad5933/ad5933.h
@@ -143,6 +143,11 @@ struct ad5933_init_param {
 	uint16_t current_settling;
 };
 
+typedef struct ad5933_impedance {
+	double  		magnitude;
+	double 			phase;
+} ad5933_impedance;
+
 /******************************************************************************/
 /************************ Functions Declarations ******************************/
 /******************************************************************************/
@@ -196,9 +201,9 @@ double ad5933_calculate_gain_factor(struct ad5933_dev *dev,
 				    uint8_t freq_function);
 
 /*! Reads the real and the imaginary data and calculates the Impedance. */
-double ad5933_calculate_impedance(struct ad5933_dev *dev,
-				  double gain_factor,
-				  uint8_t freq_function);
+ad5933_impedance ad5933_calculate_impedance(struct ad5933_dev *dev,
+		double gain_factor,
+		uint8_t freq_function);
 
 void ad5933_set_settling_time(struct ad5933_dev *dev,
 			      uint8_t		mulitplier,

--- a/drivers/impedance-analyzer/ad5933/ad5933.h
+++ b/drivers/impedance-analyzer/ad5933/ad5933.h
@@ -91,6 +91,14 @@
 #define AD5933_GAIN_X5              0
 #define AD5933_GAIN_X1              1
 
+/* AD5933 Default number of settling cycles */
+#define AD5933_15_CYCLES			15
+
+/* AD5933 settling cycles mulitiplier */
+#define AD5933_SETTLING_X1			0
+#define AD5933_SETTLING_X2			1
+#define AD5933_SETTLING_X4			3
+
 /* AD5933_REG_STATUS Bits */
 #define AD5933_STAT_TEMP_VALID      (0x1 << 0)
 #define AD5933_STAT_DATA_VALID      (0x1 << 1)
@@ -107,6 +115,7 @@
 /* AD5933 Specifications */
 #define AD5933_INTERNAL_SYS_CLK     16000000ul      // 16MHz
 #define AD5933_MAX_INC_NUM          511             // Maximum increment number
+#define AD5933_MAX_SETTLING_CYCLES  511
 
 /******************************************************************************/
 /*************************** Types Declarations *******************************/
@@ -120,6 +129,7 @@ struct ad5933_dev {
 	uint8_t current_clock_source;
 	uint8_t current_gain;
 	uint8_t current_range;
+	uint16_t current_settling;
 };
 
 struct ad5933_init_param {
@@ -130,6 +140,7 @@ struct ad5933_init_param {
 	uint8_t current_clock_source;
 	uint8_t current_gain;
 	uint8_t current_range;
+	uint16_t current_settling;
 };
 
 /******************************************************************************/
@@ -188,5 +199,9 @@ double ad5933_calculate_gain_factor(struct ad5933_dev *dev,
 double ad5933_calculate_impedance(struct ad5933_dev *dev,
 				  double gain_factor,
 				  uint8_t freq_function);
+
+void ad5933_set_settling_time(struct ad5933_dev *dev,
+			      uint8_t		mulitplier,
+			      uint16_t	number_cycles);
 
 #endif /* __AD5933_H__ */


### PR DESCRIPTION
Added settling time function

Changed return-type for ad5933_calculate_impedance to a structure

Function now returns magnitude and phase with the intent to calculate the impedance in the application code

Added M_PI definition for calculation of radToDeg180ovPi
