### PR TITLE
projects:adv7511: update makefile

### DIFF
--- a/projects/adv7511/Makefile
+++ b/projects/adv7511/Makefile
@@ -1,6 +1,6 @@
-TARGET := adv7511
-ifeq ($(strip $(OS)),Windows_NT)
-include ../../tools/scripts/windows.mk
-else
-include ../../tools/scripts/linux.mk
-endif
+TINYIIOD ?= n
+include ../../tools/scripts/generic_variables.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk


### PR DESCRIPTION
Update makefile to work with new freamwork. Replace windows.mk and linux.mk
with generic.mk and standardise the makefile.

Signed-off-by: Andrei Drimbarean <Andrei.Drimbarean@analog.com>