### PR TITLE
ci: ignore legacy folder

### DIFF
--- a/.astyleignore
+++ b/.astyleignore
@@ -9,3 +9,4 @@ network/application/MQTT_eclipse_paho/
 drivers/rf-transceiver/navassa/common/
 drivers/rf-transceiver/navassa/devices/
 drivers/rf-transceiver/navassa/third_party/
+legacy/

--- a/.cppcheckignore
+++ b/.cppcheckignore
@@ -18,3 +18,4 @@
 *:drivers/rf-transceiver/navassa/third_party/*
 *:libraries/fatfs/*
 *:libraries/mbedtls/*
+*:legacy/*


### PR DESCRIPTION
The `legacy` folder is skipped for static analysis and code style check
within the build jobs.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>