### PR TITLE
Print Log update

### DIFF
--- a/include/print_log.h
+++ b/include/print_log.h
@@ -80,29 +80,25 @@ fmt, __FILE__, __func__, __LINE__, ##args)
 #endif
 
 #if defined(LOG_LEVEL) && LOG_LEVEL >= LOG_WARNING && LOG_LEVEL <= LOG_DEBUG
-#define pr_warning(fmt, args...) printf("WARNING: %s:%s:%d(): " \
-fmt, __FILE__, __func__, __LINE__, ##args)
+#define pr_warning(fmt, args...) printf("WARNING: " fmt, ##args)
 #else
 #define pr_warning(fmt, args...)
 #endif
 
 #if defined(LOG_LEVEL) && LOG_LEVEL >= LOG_NOTICE && LOG_LEVEL <= LOG_DEBUG
-#define pr_notice(fmt, args...) printf("NOTICE: %s:%s:%d(): " \
-fmt, __FILE__, __func__, __LINE__, ##args)
+#define pr_notice(fmt, args...) printf("NOTICE: " fmt, ##args)
 #else
 #define pr_notice(fmt, args...)
 #endif
 
 #if defined(LOG_LEVEL) && LOG_LEVEL >= LOG_INFO && LOG_LEVEL <= LOG_DEBUG
-#define pr_info(fmt, args...) printf("%s:%s:%d(): " \
-fmt, __FILE__, __func__, __LINE__, ##args)
+#define pr_info(fmt, args...) printf(fmt, ##args)
 #else
 #define pr_info(fmt, args...)
 #endif
 
 #if defined(LOG_LEVEL) && LOG_LEVEL == LOG_DEBUG
-#define pr_debug(fmt, args...) printf("DEBUG: %s:%s:%d(): " \
-fmt, __FILE__, __func__, __LINE__, ##args)
+#define pr_debug(fmt, args...) printf("DEBUG: " fmt, ##args)
 #else
 #define pr_debug(fmt, args...)
 #endif

--- a/include/print_log.h
+++ b/include/print_log.h
@@ -51,6 +51,10 @@
 #define LOG_INFO	0x6
 #define LOG_DEBUG	0x7
 
+#ifndef LOG_LEVEL
+#define LOG_LEVEL LOG_INFO
+#endif
+
 #if defined(LOG_LEVEL) && LOG_LEVEL >= LOG_EMERG && LOG_LEVEL <= LOG_DEBUG
 #define pr_emerg(fmt, args...) printf("EMERG: %s:%d:%s(): " \
 fmt, __FILE__, __LINE__, __func__, ##args)

--- a/include/print_log.h
+++ b/include/print_log.h
@@ -52,29 +52,29 @@
 #define LOG_DEBUG	0x7
 
 #if defined(LOG_LEVEL) && LOG_LEVEL >= LOG_EMERG && LOG_LEVEL <= LOG_DEBUG
-#define pr_emerg(fmt, args...) printf("EMERG: %s:%s:%d(): " \
-fmt, __FILE__, __func__, __LINE__, ##args)
+#define pr_emerg(fmt, args...) printf("EMERG: %s:%d:%s(): " \
+fmt, __FILE__, __LINE__, __func__, ##args)
 #else
 #define pr_emerg(fmt, args...)
 #endif
 
 #if defined(LOG_LEVEL) && LOG_LEVEL >= LOG_ALERT && LOG_LEVEL <= LOG_DEBUG
-#define pr_alert(fmt, args...) printf("ALERT: %s:%s:%d(): " \
-fmt, __FILE__, __func__, __LINE__, ##args)
+#define pr_alert(fmt, args...) printf("ALERT: %s:%d:%s(): " \
+fmt, __FILE__, __LINE__, __func__, ##args)
 #else
 #define pr_alert(fmt, args...)
 #endif
 
 #if defined(LOG_LEVEL) && LOG_LEVEL >= LOG_CRIT && LOG_LEVEL <= LOG_DEBUG
-#define pr_crit(fmt, args...) printf("CRIT: %s:%s:%d(): " \
-fmt, __FILE__, __func__, __LINE__, ##args)
+#define pr_crit(fmt, args...) printf("CRIT: %s:%d:%s(): " \
+fmt, __FILE__, __LINE__, __func__, ##args)
 #else
 #define pr_crit(fmt, args...)
 #endif
 
 #if defined(LOG_LEVEL) && LOG_LEVEL >= LOG_ERR && LOG_LEVEL <= LOG_DEBUG
-#define pr_err(fmt, args...) printf("ERR: %s:%s:%d(): " \
-fmt, __FILE__, __func__, __LINE__, ##args)
+#define pr_err(fmt, args...) printf("ERR: %s:%d:%s(): " \
+fmt, __FILE__, __LINE__, __func__, ##args)
 #else
 #define pr_err(fmt, args...)
 #endif

--- a/projects/ad5766-sdz/src/ad5766_sdz.c
+++ b/projects/ad5766-sdz/src/ad5766_sdz.c
@@ -53,7 +53,6 @@
 #include "spi.h"
 #include "spi_extra.h"
 
-#define LOG_LEVEL 6
 #include "print_log.h"
 
 /***************************************************************************//**

--- a/projects/ad6676-ebz/src/ad6676_ebz.c
+++ b/projects/ad6676-ebz/src/ad6676_ebz.c
@@ -59,7 +59,6 @@
 #include "axi_jesd204_rx.h"
 #include "axi_adxcvr.h"
 
-#define LOG_LEVEL 6
 #include "print_log.h"
 
 #ifdef IIO_SUPPORT

--- a/projects/ad738x_fmcz/src/ad738x_fmc.c
+++ b/projects/ad738x_fmcz/src/ad738x_fmc.c
@@ -54,7 +54,6 @@
 #include "error.h"
 #include "app_config.h"
 
-#define LOG_LEVEL 6
 #include "print_log.h"
 
 #define AD738x_EVB_SAMPLE_NO		1000

--- a/projects/ad7616-sdz/src/ad7616_sdz.c
+++ b/projects/ad7616-sdz/src/ad7616_sdz.c
@@ -55,7 +55,6 @@
 #include "ad7616.h"
 #include "parameters.h"
 
-#define LOG_LEVEL 6
 #include "print_log.h"
 
 /******************************************************************************/

--- a/projects/ad9265-fmc-125ebz/src/ad9265_fmc_125ebz.c
+++ b/projects/ad9265-fmc-125ebz/src/ad9265_fmc_125ebz.c
@@ -55,7 +55,6 @@
 #include "app_iio.h"
 #endif
 
-#define LOG_LEVEL 6
 #include "print_log.h"
 
 /***************************************************************************//**

--- a/projects/ad9434-fmc-500ebz/src/ad9434_fmc_500ebz.c
+++ b/projects/ad9434-fmc-500ebz/src/ad9434_fmc_500ebz.c
@@ -55,7 +55,6 @@
 #include "app_iio.h"
 #endif
 
-#define LOG_LEVEL 6
 #include "print_log.h"
 
 /***************************************************************************//**

--- a/projects/ad9739a-fmc-ebz/src/ad9739a_fmc_ebz.c
+++ b/projects/ad9739a-fmc-ebz/src/ad9739a_fmc_ebz.c
@@ -58,7 +58,6 @@
 #include "app_iio.h"
 #endif
 
-#define LOG_LEVEL 6
 #include "print_log.h"
 
 /***************************************************************************//**


### PR DESCRIPTION
- Remove FILE, LINE and FUNCTION information from the low priority log
levels.
- Print code line before function name.
- Set default log level to 6 inside `print_log.h`.
- Remove the log level defines from projects where the default one is
used.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>