### PR TITLE
drivers:platform:aducm3029: Add support for printf over uart

### DIFF
--- a/drivers/platform/aducm3029/uart_stdio.c
+++ b/drivers/platform/aducm3029/uart_stdio.c
@@ -1,0 +1,131 @@
+/***************************************************************************//**
+ *   @file   uart_stdio.c
+ *   @brief  Source file to use printf over uart
+ *   @author Mihail Chindris (mihail.chindris@analog.com)
+********************************************************************************
+ * Copyright 2021(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <stdio.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include "uart.h"
+
+static struct uart_desc *g_uart;
+
+#define STDIN_FILENO  0
+#define STDOUT_FILENO 1
+#define STDERR_FILENO 2
+
+void init_uart_stdio(struct uart_desc *desc)
+{
+	g_uart = desc;
+}
+
+int _isatty(int fd)
+{
+	if (fd >= STDIN_FILENO && fd <= STDERR_FILENO)
+		return 1;
+
+	errno = EBADF;
+	return 0;
+}
+
+int _write(int fd, char* ptr, int len)
+{
+	int32_t ret;
+
+	if (!g_uart)
+		return EIO;
+
+	if (fd == STDOUT_FILENO || fd == STDERR_FILENO) {
+		ret = uart_write(g_uart, (uint8_t *) ptr, len);
+		if (ret < 0) {
+			errno = ret;
+			return EIO;
+		}
+		return len;
+	}
+	errno = EBADF;
+
+	return -1;
+}
+
+int _close(int fd)
+{
+	if (fd >= STDIN_FILENO && fd <= STDERR_FILENO)
+		return 0;
+
+	errno = EBADF;
+	return -1;
+}
+
+int _lseek(int fd, int ptr, int dir)
+{
+	(void) fd;
+	(void) ptr;
+	(void) dir;
+
+	errno = EBADF;
+	return -1;
+}
+
+int _read(int fd, char* ptr, int len)
+{
+	int32_t ret;
+
+	if (!g_uart)
+		return EIO;
+
+	if (fd == STDIN_FILENO) {
+		ret = uart_read(g_uart, (uint8_t *) ptr, len);
+		if (ret < 0)
+			return EIO;
+
+		return len;
+	}
+	errno = EBADF;
+	return -1;
+}
+
+int _fstat(int fd, struct stat* st)
+{
+	if (fd >= STDIN_FILENO && fd <= STDERR_FILENO) {
+		st->st_mode = S_IFCHR;
+		return 0;
+	}
+
+	errno = EBADF;
+	return -1;
+}

--- a/drivers/platform/aducm3029/uart_stdio.h
+++ b/drivers/platform/aducm3029/uart_stdio.h
@@ -1,0 +1,46 @@
+/***************************************************************************//**
+ *   @file   uart_stdio.h
+ *   @brief  Header file for UART driver stdout/stdin redirection.
+ *   @author Mihail Chindris (mihail.chindris@analog.com)
+********************************************************************************
+ * Copyright 2021(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef _UART_STDIO_H_
+#define _UART_STDIO_H_
+
+#include "uart.h"
+
+void init_uart_stdio(struct uart_desc *desc);
+
+#endif //_UART_STDIO_H_


### PR DESCRIPTION
Similar to 30a8f246001e but it uses general uart_desc and it didn't
disable buffering because otherwise the first few printed bytes
will be dummy data instead of the actual data.

Signed-off-by: Mihail Chindris <mihail.chindris@analog.com>