### PR TITLE
tools:scripts: use mqtt source instead of library

### DIFF
--- a/tools/scripts/libraries.mk
+++ b/tools/scripts/libraries.mk
@@ -3,7 +3,7 @@
 #	IIO
 ifeq (y,$(strip $(TINYIIOD)))
 
-include ../../tools/scripts/iio_srcs.mk
+include $(NO-OS)/tools/scripts/iio_srcs.mk
 
 CFLAGS += -DTINYIIOD_VERSION_MAJOR=0	 \
 	   -DTINYIIOD_VERSION_MINOR=1		 \
@@ -62,16 +62,8 @@ endif
 
 #	MQTT
 ifneq ($(if $(findstring mqtt, $(LIBRARIES)), 1),)
-# Generic part
-MQTT_DIR					= $(NO-OS)/libraries/mqtt
-MQTT_LIB					= $(MQTT_DIR)/libmqtt.a
-EXTRA_LIBS					+= $(MQTT_LIB)
-EXTRA_LIBS_PATHS			+= $(MQTT_DIR)
-EXTRA_INC_PATHS		+= $(MQTT_DIR)
 
-CLEAN_MQTT	= $(MAKE) -C $(MQTT_DIR) clean
-$(MQTT_LIB):
-	$(MAKE) -C $(MQTT_DIR)
+include $(NO-OS)/tools/scripts/mqtt_srcs.mk
 
 endif
 

--- a/tools/scripts/mqtt_srcs.mk
+++ b/tools/scripts/mqtt_srcs.mk
@@ -1,0 +1,14 @@
+CFLAGS += -DMQTTCLIENT_PLATFORM_HEADER="mqtt_noos_support.h"
+
+MQTT_DIR	= $(NO-OS)/libraries/mqtt
+PAHO_DIR	= $(MQTT_DIR)/paho.mqtt.embedded-c
+
+SRC_DIRS += $(PAHO_DIR)/MQTTPacket/src
+
+SRCS += $(MQTT_DIR)/mqtt_client.c \
+	$(MQTT_DIR)/mqtt_noos_support.c \
+	$(PAHO_DIR)/MQTTClient-C/src/MQTTClient.c
+
+INCS += $(MQTT_DIR)/mqtt_client.h \
+	$(MQTT_DIR)/mqtt_noos_support.h \
+	$(PAHO_DIR)/MQTTClient-C/src/MQTTClient.h


### PR DESCRIPTION
There is a bug in CCES and libraries can't be added
to the project and it has to be done manually.
So using the source will solve that issue.
Make standalone will work for projects using mqtt now.
For debug purposes it will be useful to have mqtt sources.

Signed-off-by: Mihail Chindris <mihail.chindris@analog.com>