### PR TITLE
tools:scripts: Fix rwildcard

### DIFF
--- a/tools/scripts/generic.mk
+++ b/tools/scripts/generic.mk
@@ -58,7 +58,7 @@ MUTE = @
 endif
 
 # recursive wildcard
-rwildcard = $(wildcard $1$2) $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2))
+rwildcard=$(foreach d,$(wildcard $(1:=/*)),$(call rwildcard,$d,$2) $(filter $(subst *,%,$2),$d))
 
 #Creates file with the specified name
 set_one_time_rule = echo Target file. Do not delete > $1

--- a/tools/scripts/stm32.mk
+++ b/tools/scripts/stm32.mk
@@ -37,7 +37,6 @@ CC = arm-none-eabi-gcc
 AS = arm-none-eabi-gcc
 AR = arm-none-eabi-ar
 
-rwildcard=$(foreach d,$(wildcard $(1:=/*)),$(call rwildcard,$d,$2) $(filter $(subst *,%,$2),$d))
 ifneq '' '$(call rwildcard,src,stm32f4*)'
 CFLAGS += -I$(STM32CUBE)/STM32CubeF4/Drivers/STM32F4xx_HAL_Driver/Inc \
 	-I$(STM32CUBE)/STM32CubeF4/Drivers/STM32F4xx_HAL_Driver/Inc/Legacy \


### PR DESCRIPTION
rwildcard from generic have some issues. For example, for SRC_DIRS with
drivers/adc/ad7768 will find also ad7768-1

It seems that rwildcard from stm32.mk fix the issue so it is moved to
generic.mk

Signed-off-by: Mihail Chindris <mihail.chindris@analog.com>