### PR TITLE
projects:iio_demo: add new source files in src.mk

### DIFF
--- a/projects/iio_demo/src.mk
+++ b/projects/iio_demo/src.mk
@@ -10,7 +10,9 @@ SRCS +=	$(NO-OS)/util/xml.c						\
 
 #drivers
 SRCS += $(DRIVERS)/adc/adc_demo/adc_demo.c				\
-		$(DRIVERS)/dac/dac_demo/dac_demo.c
+	$(DRIVERS)/adc/adc_demo/iio_adc_demo.c				\
+	$(DRIVERS)/dac/dac_demo/iio_dac_demo.c				\
+	$(DRIVERS)/dac/dac_demo/dac_demo.c
 
 INCS += $(INCLUDE)/xml.h						\
 	$(INCLUDE)/fifo.h						\

--- a/projects/iio_demo/src/app/main.c
+++ b/projects/iio_demo/src/app/main.c
@@ -78,8 +78,6 @@ static uint8_t out_buff[MAX_SIZE_BASE_ADDR];
 
 #define DAC_DDR_BASEADDR	((uint32_t)out_buff)
 #define ADC_DDR_BASEADDR	((uint32_t)in_buff)
-#define MAX_SAMPLES_PER_CHANNEL	800
-#define DEFAULT_CHANNEL_NO	16
 
 #endif
 
@@ -150,8 +148,6 @@ int32_t platform_init()
 #endif
 	return 0;
 }
-
-uint16_t buf[DEFAULT_CHANNEL_NO][MAX_SAMPLES_PER_CHANNEL];
 
 /***************************************************************************//**
  * @brief main


### PR DESCRIPTION
Add the iio_adc_demo.c and iio_dac_demo.c in the src.mk to explicitly
specify them in the build and link process.

Signed-off-by: Andrei Drimbarean <Andrei.Drimbarean@analog.com>