### PR TITLE
ad7689, ad7682, ad7949, ad7699 driver

### DIFF
--- a/drivers/adc/ad7689/ad7689.c
+++ b/drivers/adc/ad7689/ad7689.c
@@ -1,0 +1,293 @@
+/***************************************************************************//**
+ *   @file   ad7689.c
+ *   @brief  Source file for the ad7689 driver
+ *   @author Darius Berghe (darius.berghe@analog.com)
+********************************************************************************
+ * Copyright 2021(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include <stdlib.h>
+#include "ad7689.h"
+#include "util.h"
+#include "error.h"
+#include "print_log.h"
+#include "delay.h"
+
+const char *ad7689_device_name[] = {
+	"AD7689",
+	"AD7682",
+	"AD7949",
+	"AD7699",
+};
+
+static void _ad7689_config_put(struct ad7689_dev *dev,
+			       struct ad7689_config *config)
+{
+	dev->configs[1] = dev->configs[0];
+	if (config)
+		dev->configs[0] = *config;
+	else
+		dev->configs[0] = dev->configs[1];
+}
+
+static struct ad7689_config *_ad7689_config_get(struct ad7689_dev *dev)
+{
+	// dev->configs[1] is the config currently in use. If the current
+	// SPI transaction is numbered N, this config was written at N-2
+	// and applied at the EOC of N-1.
+	return &dev->configs[1];
+}
+
+static int32_t _ad7689_rac(struct ad7689_dev *dev,
+			   struct ad7689_config *config_in, struct ad7689_config *config_out,
+			   uint16_t *data)
+{
+	int32_t ret;
+	uint16_t cfg = 0;
+	uint8_t buf[4] = {0, 0, 0, 0};
+	uint16_t sz;
+	struct ad7689_config *c;
+
+	if (!dev)
+		return -EINVAL;
+
+	c = _ad7689_config_get(dev);
+
+	if (config_in) {
+		cfg |= field_prep(AD7689_CFG_CFG_MSK, 1);
+		cfg |= field_prep(AD7689_CFG_INCC_MSK, config_in->incc);
+		cfg |= field_prep(AD7689_CFG_INX_MSK, config_in->inx);
+		cfg |= field_prep(AD7689_CFG_BW_MSK, config_in->bw);
+		cfg |= field_prep(AD7689_CFG_REF_MSK, config_in->ref);
+		cfg |= field_prep(AD7689_CFG_SEQ_MSK, config_in->seq);
+		cfg |= field_prep(AD7689_CFG_RB_MSK, !config_in->rb);
+		cfg <<= 2;
+		buf[0] = cfg >> 8;
+		buf[1] = cfg;
+	}
+	sz = c->rb && config_out ? 4 : 2;
+	ret = spi_write_and_read(dev->spi_desc, buf, sz);
+	if (ret < 0)
+		return ret;
+
+	_ad7689_config_put(dev, config_in);
+
+	if (data) {
+		// by default, data width is 16-bits
+		*data = ((uint16_t)buf[0] << 8) | buf[1];
+
+		// handle 14-bit data width:
+		if (dev->id == ID_AD7949) {
+			// Bipolar samples are in two's complement, scale down to 14-bit
+			// by keeping the sign bit using division instead of implementation
+			// specific right shift. This works for unipolar samples too.
+			*data = (int16_t)*data / 4;
+		}
+	}
+
+	if (c->rb && config_out) {
+		if (dev->id == ID_AD7949)
+			cfg = (((uint32_t)buf[1] << 16) | ((uint32_t)buf[2] << 8) | buf[3]) >> 2;
+		else
+			cfg = ((uint16_t)buf[2] << 8) | buf[3];
+		cfg >>= 2;
+		config_out->incc = field_get(AD7689_CFG_INCC_MSK, cfg);
+		config_out->inx = field_get(AD7689_CFG_INX_MSK, cfg);
+		config_out->bw = field_get(AD7689_CFG_BW_MSK, cfg);
+		config_out->ref = field_get(AD7689_CFG_REF_MSK, cfg);
+		config_out->seq = field_get(AD7689_CFG_SEQ_MSK, cfg);
+		config_out->rb = !(bool)field_get(AD7689_CFG_RB_MSK, cfg);
+	}
+
+	return SUCCESS;
+}
+
+/***************************************************************************//**
+ * @brief Initialize the ad7689 driver and create a descriptor.
+ *
+ * @param dev - Device descriptor to create.
+ * @param init_param - Initialization parameters.
+ *
+ * @return Returns negative error code or SUCCESS in case of success.
+ *         Example: -EINVAL - Bad input parameters.
+ *                  -ENOMEM - Failed to allocate memory.
+ *                  SUCCESS - No errors encountered.
+*******************************************************************************/
+int32_t ad7689_init(struct ad7689_dev **dev,
+		    struct ad7689_init_param *init_param)
+{
+	struct ad7689_dev *d;
+	int32_t ret;
+
+	if (init_param->id > ID_AD7699)
+		return -EINVAL;
+
+	d = (struct ad7689_dev *)calloc(1, sizeof(*d));
+	if (!d)
+		return -ENOMEM;
+
+	d->id = init_param->id;
+	d->name = ad7689_device_name[d->id];
+
+	ret = spi_init(&d->spi_desc, &init_param->spi_init);
+	if (ret < 0)
+		goto error_spi;
+
+	// write config twice to also perform two dummy conversions
+	ret = ad7689_write_config(d, &init_param->config);
+	if (ret < 0)
+		goto error_init;
+
+	ret = ad7689_write_config(d, &init_param->config);
+	if (ret < 0)
+		goto error_init;
+
+	*dev = d;
+
+	return SUCCESS;
+error_init:
+	spi_remove(d->spi_desc);
+error_spi:
+	free(d);
+	pr_err("%s initialization failed with status %d\n", d->name,
+	       ret);
+
+	return ret;
+}
+
+/***************************************************************************//**
+ * @brief Write the device's CFG register.
+ *
+ * @param dev - Device descriptor.
+ * @param config - Configuration to write.
+ *
+ * @return Returns negative error code or SUCCESS in case of success.
+ *         Example: -EINVAL - Bad input parameters.
+ *                  SUCCESS - No errors encountered.
+*******************************************************************************/
+int32_t ad7689_write_config(struct ad7689_dev *dev,
+			    struct ad7689_config *config)
+{
+	return _ad7689_rac(dev, config, NULL, NULL);
+}
+
+/***************************************************************************//**
+ * @brief Read the device's CFG register.
+ *
+ * If the readback is enabled when making this call, one SPI transaction
+ * is enough to retrieve the CFG register.
+ *
+ * If the readback is disabled when making this call, it is temporarily
+ * enabled, then disabled back. 3 SPI transactions are needed to retrieve
+ * the CFG register.
+ *
+ * @param dev - Device descriptor.
+ * @param config - pointer to location where the read configuration gets stored.
+ *
+ * @return Returns negative error code or SUCCESS in case of success.
+ *         Example: -EINVAL - Bad input parameters.
+ *                  SUCCESS - No errors encountered.
+*******************************************************************************/
+int32_t ad7689_read_config(struct ad7689_dev *dev, struct ad7689_config *config)
+{
+	int32_t ret = 0;
+	struct ad7689_config *c = _ad7689_config_get(dev);
+	if (c->rb == true)
+		return _ad7689_rac(dev, NULL, config, NULL);
+
+	struct ad7689_config c_in = *c;
+	c_in.rb = true;
+	ret = _ad7689_rac(dev, &c_in, NULL, NULL);
+	if (ret < 0)
+		return ret;
+
+	c_in.rb = false;
+	ret = _ad7689_rac(dev, &c_in, NULL, NULL);
+	if (ret < 0)
+		return ret;
+
+	return _ad7689_rac(dev, NULL, config, NULL);
+}
+
+/***************************************************************************//**
+ * @brief Read ADC samples.
+ *
+ * This function uses the RAC mode to perform the SPI transactions.
+ *
+ * @param dev - Device descriptor.
+ * @param data - pointer to a large enough buffer where the data gets stored.
+ * @param nb_samples - Number of samples to read.
+ *
+ * @return Returns negative error code or SUCCESS in case of success.
+ *         Example: -EINVAL - Bad input parameters.
+ *                  SUCCESS - No errors encountered.
+*******************************************************************************/
+int32_t ad7689_read(struct ad7689_dev *dev, uint16_t *data, uint32_t nb_samples)
+{
+	int32_t ret;
+	uint32_t i = 0;
+
+	if (!data)
+		return -EINVAL;
+	if (!nb_samples)
+		return SUCCESS;
+
+	do {
+		ret = _ad7689_rac(dev, NULL, NULL, &data[i]);
+		if (ret < 0)
+			return ret;
+		i++;
+	} while (i < nb_samples);
+
+	return SUCCESS;
+}
+
+/***************************************************************************//**
+ * @brief Remove the driver's descriptor by freeing the associated resources.
+ *
+ * @param dev - Device descriptor.
+ *
+ * @return Returns negative error code or SUCCESS in case of success.
+ *         Example: -EINVAL - Bad input parameters.
+ *                  SUCCESS - No errors encountered.
+*******************************************************************************/
+int32_t ad7689_remove(struct ad7689_dev *dev)
+{
+	if (!dev)
+		return -EINVAL;
+
+	spi_remove(dev->spi_desc);
+	free(dev);
+
+	return SUCCESS;
+}

--- a/drivers/adc/ad7689/ad7689.h
+++ b/drivers/adc/ad7689/ad7689.h
@@ -1,0 +1,182 @@
+/***************************************************************************//**
+ *   @file   ad7689.h
+ *   @brief  Header file for the ad7689 driver
+ *   @author Darius Berghe (darius.berghe@analog.com)
+********************************************************************************
+ * Copyright 2021(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef AD7689_H_
+#define AD7689_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "spi.h"
+
+#define AD7689_CFG_CFG_MSK      BIT(13)
+#define AD7689_CFG_INCC_MSK     GENMASK(12,10)
+#define AD7689_CFG_INX_MSK      GENMASK(9,7)
+#define AD7689_CFG_BW_MSK       BIT(6)
+#define AD7689_CFG_REF_MSK      GENMASK(5,3)
+#define AD7689_CFG_SEQ_MSK      GENMASK(2,1)
+#define AD7689_CFG_RB_MSK       BIT(0)
+
+/**
+ * @enum ad7689_device_id
+ * @brief Device ID definitions
+ */
+enum ad7689_device_id {
+	/** 16-Bit, 8-Channel, 250 kSPS PulSAR ADC */
+	ID_AD7689,
+	/** 16-Bit, 4-Channel, 250 kSPS PulSAR ADC */
+	ID_AD7682,
+	/** 14-Bit, 8-Channel, 250 kSPS PulSAR ADC */
+	ID_AD7949,
+	/** 16-Bit, 8-Channel, 500 kSPS PulSAR ADC */
+	ID_AD7699,
+};
+
+/**
+ * @enum ad7689_incc
+ * @brief Input channel configuration
+ */
+enum ad7689_incc {
+	/** Bipolar differential pairs; INx− referenced to VREF/2 ± 0.1 V. */
+	AD7689_BIPOLAR_DIFFERENTIAL_PAIRS = 0x1,
+	/** Bipolar; INx referenced to COM = V REF /2 ± 0.1 V. */
+	AD7689_BIPOLAR_COM,
+	/** Temperature sensor. */
+	AD7689_TEMPERATURE_SENSOR,
+	/** Unipolar differential pairs; INx− referenced to GND ± 0.1 V. */
+	AD7689_UNIPOLAR_DIFFERENTIAL_PAIRS = 0x5,
+	/** Unipolar, INx referenced to COM = GND ± 0.1 V. */
+	AD7689_UNIPOLAR_COM,
+	/** Unipolar, INx referenced to GND. */
+	AD7689_UNIPOLAR_GND
+};
+
+/**
+ * @enum ad7689_bw
+ * @brief Low-pass filter bandwidth selection
+ */
+enum ad7689_bw {
+	/** 1⁄4 of BW, uses an additional series resistor to further bandwidth limit the noise. Maximum throughput must be reduced to 1⁄4. */
+	AD7689_BW_QUARTER,
+	/** Full bandwidth. */
+	AD7689_BW_FULL
+};
+
+/**
+ * @enum ad7689_ref
+ * @brief Reference/buffer selection
+ */
+enum ad7689_ref {
+	/** Internal reference and temperature sensor enabled. REF = 2.5 V buffered output. */
+	AD7689_REF_INTERNAL_2p5V,
+	/** Internal reference and temperature sensor enabled. REF = 4.096 V buffered output. */
+	AD7689_REF_INTERNAL_4p096V,
+	/** Use external reference. Temperature sensor enabled. Internal buffer disabled. */
+	AD7689_REF_EXTERNAL_TEMP,
+	/** Use external reference. Internal buffer and temperature sensor enabled. */
+	AD7689_REF_EXTERNAL_TEMP_IBUF,
+	/** Use external reference. Internal reference, internal buffer, and temperature sensor disabled. */
+	AD7689_REF_EXTERNAL = 0x6,
+	/** Use external reference. Internal buffer enabled. Internal reference and temperature sensor disabled. */
+	AD7689_REF_IBUF
+};
+
+/**
+ * @enum ad7689_seq
+ * @brief Channel sequencer configuration
+ */
+enum ad7689_seq {
+	/** Disable sequencer. */
+	AD7689_SEQ_DISABLE,
+	/** Update configuration during sequence. */
+	AD7689_SEQ_UPDATE_CFG,
+	/** Scan IN0 to INX, then temperature. */
+	AD7689_SEQ_SCAN_ALL_THEN_TEMP,
+	/** Scan IN0 to INX. */
+	AD7689_SEQ_SCAN_ALL
+};
+
+/**
+ * @struct ad7689_config
+ * @brief AD7689 configuration
+ */
+struct ad7689_config {
+	/** Input channel configuration */
+	enum ad7689_incc incc;
+	/** INX channel selection (sequencer iterates from IN0 to INX) */
+	uint8_t inx;
+	/** Low-pass filter bandwidth selection */
+	enum ad7689_bw bw;
+	/**  Reference/buffer selection */
+	enum ad7689_ref ref;
+	/** Channel sequencer configuration */
+	enum ad7689_seq seq;
+	/** Read back the CFG register */
+	bool rb;
+};
+
+struct ad7689_init_param {
+	/** Device ID */
+	enum ad7689_device_id id;
+	/** ADC specific parameters */
+	struct ad7689_config config;
+	/** SPI initialization parameters */
+	spi_init_param spi_init;
+};
+
+struct ad7689_dev {
+	/** Device name string */
+	const char *name;
+	/** Device ID */
+	enum ad7689_device_id id;
+	/** AD7689 configs (configs[1] - in use, configs[0] - will be in use during next transaction) */
+	struct ad7689_config configs[2];
+	/** SPI descriptor*/
+	spi_desc *spi_desc;
+};
+
+int32_t ad7689_init(struct ad7689_dev **dev,
+		    struct ad7689_init_param *init_param);
+int32_t ad7689_write_config(struct ad7689_dev *dev,
+			    struct ad7689_config *config);
+int32_t ad7689_read_config(struct ad7689_dev *dev,
+			   struct ad7689_config *config);
+int32_t ad7689_read(struct ad7689_dev *dev, uint16_t *data,
+		    uint32_t nb_samples);
+int32_t ad7689_remove(struct ad7689_dev *dev);
+
+#endif


### PR DESCRIPTION
Initial version of the driver for these four PulSAR ADC's.
The driver uses the Read After Conversion (RAC) mode for
communication with the device.
This could be improved by using the Read Spanning Conversion
(RSC) mode to allow even slower hosts to be able to retrieve
data at maximum sample rate.
However, RAC was chosen due to it being standard and easy to
implement on any platform (bare-metal microcontrollers, SoC's
running linux etc.) that no-OS can run on.

Signed-off-by: Darius Berghe <darius.berghe@analog.com>