### PR TITLE
README: update build guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,8 @@ Code documentation is automatically generated using Doxygen tool, available at [
 
 ## Build
 
-Build guides for no-OS projects:
-  * [Linux](https://github.com/analogdevicesinc/no-OS/wiki/Building-no-OS-on-Linux)
-  * [Windows](https://github.com/analogdevicesinc/no-OS/wiki/Building-no-OS-on-Windows)
+Build guide for no-OS projects:
+  * [NO-OS Build Guide](https://wiki.analog.com/resources/no-os/build)
 
 ## Code Style
 When writing code, please follow the [style guidelines](https://github.com/analogdevicesinc/no-OS/wiki/Code-Style-guidelines).


### PR DESCRIPTION
Build guide is from now on available only on wiki.analog.com.