### PR TITLE
ad9361: fix fmcomms5 build issue

### DIFF
--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -595,7 +595,7 @@ int main(void)
 	axi_dac_set_sine_lut(ad9361_phy->tx_dac, DAC_DDR_BASEADDR);
 #else
 #ifdef FMCOMMS5
-	axi_dac_init(&ad9361_phy_b->tx_dac, ad9361_phy_b->tx_dac_init);
+	axi_dac_init(&ad9361_phy_b->tx_dac, &tx_dac_init);
 	axi_dac_set_datasel(ad9361_phy_b->tx_dac, -1, AXI_DAC_DATA_SEL_DDS);
 #endif
 	axi_dac_init(&ad9361_phy->tx_dac, &tx_dac_init);


### PR DESCRIPTION
Fix error: `ad9351_rf_phy` has no member named `tx_dac_init`.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>