### PR TITLE
ada4250: improve readability & minor fixes

### DIFF
--- a/drivers/instr-amplif/ada4250/ada4250.c
+++ b/drivers/instr-amplif/ada4250/ada4250.c
@@ -150,7 +150,7 @@ int32_t ada4250_soft_reset(struct ada4250_dev *dev)
  * @param refbuf - REFBUF enable/disable.
  * @return Returns SUCCESS in case of success or negative error code.
  */
-int32_t ada4250_set_refbuf(struct ada4250_dev *dev, uint8_t refbuf)
+int32_t ada4250_en_refbuf(struct ada4250_dev *dev, bool refbuf)
 {
 	return ada4250_update(dev, ADA4250_REG_REFBUF_EN, ADA4250_REFBUF_MSK,
 			      ADA4250_REFBUF(refbuf));
@@ -258,7 +258,7 @@ int32_t ada4250_init(struct ada4250_dev **device,
 	if(ret != SUCCESS)
 		return FAILURE;
 
-	ret = ada4250_set_refbuf(dev, dev->refbuf_en);
+	ret = ada4250_en_refbuf(dev, dev->refbuf_en);
 	if(ret != SUCCESS)
 		return FAILURE;
 

--- a/drivers/instr-amplif/ada4250/ada4250.c
+++ b/drivers/instr-amplif/ada4250/ada4250.c
@@ -162,7 +162,7 @@ int32_t ada4250_en_refbuf(struct ada4250_dev *dev, bool refbuf)
  * @param bias - Current bias option.
  * @return Returns SUCCESS in case of success or negative error code.
  */
-int32_t ada4250_set_bias(struct ada4250_dev *dev, uint8_t bias)
+int32_t ada4250_set_bias(struct ada4250_dev *dev, enum ada4250_bias bias)
 {
 	return ada4250_update(dev, ADA4250_REG_SNSR_CAL_CNFG, ADA4250_BIAS_SET_MSK,
 			      ADA4250_BIAS_SET(bias));

--- a/drivers/instr-amplif/ada4250/ada4250.c
+++ b/drivers/instr-amplif/ada4250/ada4250.c
@@ -187,7 +187,7 @@ int32_t ada4250_set_range(struct ada4250_dev *dev,
  * @param gain - Gain Value.
  * @return Returns SUCCESS in case of success or negative error code.
  */
-int32_t ada4250_set_gain(struct ada4250_dev *dev, uint8_t gain)
+int32_t ada4250_set_gain(struct ada4250_dev *dev, enum ada4250_gain gain)
 {
 	return ada4250_update(dev, ADA4250_REG_GAIN_MUX, ADA4250_GAIN_MUX_MSK,
 			      ADA4250_GAIN_MUX(ADA4250_GAIN(gain)));

--- a/drivers/instr-amplif/ada4250/ada4250.c
+++ b/drivers/instr-amplif/ada4250/ada4250.c
@@ -174,7 +174,8 @@ int32_t ada4250_set_bias(struct ada4250_dev *dev, enum ada4250_bias bias)
  * @param range - Offset range option.
  * @return Returns SUCCESS in case of success or negative error code.
  */
-int32_t ada4250_set_range(struct ada4250_dev *dev, uint8_t range)
+int32_t ada4250_set_range(struct ada4250_dev *dev,
+			  enum ada4250_offset_range range)
 {
 	return ada4250_update(dev, ADA4250_REG_SNSR_CAL_CNFG, ADA4250_RANGE_SET_MSK,
 			      ADA4250_RANGE_SET(ADA4250_RANGE(range)));

--- a/drivers/instr-amplif/ada4250/ada4250.h
+++ b/drivers/instr-amplif/ada4250/ada4250.h
@@ -123,6 +123,17 @@ enum ada4250_bias {
 };
 
 /**
+  * @enum ada4250_offset_range
+  * @brief Sensor offset trim range.
+  */
+enum ada4250_offset_range {
+	ADA4250_RANGE1_1UA_MAX,
+	ADA4250_RANGE2_3UA_MAX,
+	ADA4250_RANGE3_7UA_MAX,
+	ADA4250_RANGE4_15UA_MAX,
+};
+
+/**
  * @struct ada4250_init_param
  * @brief ADA4250 Initialization Parameters structure.
  */
@@ -136,7 +147,7 @@ struct ada4250_init_param {
 	/* Bias Set */
 	enum ada4250_bias bias;
 	/* Offset Range */
-	uint8_t offset_range;
+	enum ada4250_offset_range offset_range;
 	/* Offset Calibration Value */
 	int8_t offset_val;
 };
@@ -155,7 +166,7 @@ struct ada4250_dev {
 	/* Bias Set */
 	enum ada4250_bias bias;
 	/* Offset Range */
-	uint8_t offset_range;
+	enum ada4250_offset_range offset_range;
 	/* Offset Calibration Value */
 	int8_t offset_val;
 };
@@ -186,7 +197,8 @@ int32_t ada4250_en_refbuf(struct ada4250_dev *dev, bool refbuf);
 int32_t ada4250_set_bias(struct ada4250_dev *dev, enum ada4250_bias bias);
 
 /* Set offset trim range */
-int32_t ada4250_set_range(struct ada4250_dev *dev, uint8_t range);
+int32_t ada4250_set_range(struct ada4250_dev *dev,
+			  enum ada4250_offset_range range);
 
 /* Set gain */
 int32_t ada4250_set_gain(struct ada4250_dev *dev, uint8_t gain);

--- a/drivers/instr-amplif/ada4250/ada4250.h
+++ b/drivers/instr-amplif/ada4250/ada4250.h
@@ -134,6 +134,21 @@ enum ada4250_offset_range {
 };
 
 /**
+  * @enum ada4250_gain
+  * @brief Gain value.
+  */
+enum ada4250_gain {
+	ADA4250_GAIN_1 = 1,
+	ADA4250_GAIN_2 = 2,
+	ADA4250_GAIN_4 = 4,
+	ADA4250_GAIN_8 = 8,
+	ADA4250_GAIN_16 = 16,
+	ADA4250_GAIN_32 = 32,
+	ADA4250_GAIN_64 = 64,
+	ADA4250_GAIN_128 = 128,
+};
+
+/**
  * @struct ada4250_init_param
  * @brief ADA4250 Initialization Parameters structure.
  */
@@ -143,7 +158,7 @@ struct ada4250_init_param {
 	/* Reference Buffer Enable */
 	bool refbuf_en;
 	/* Gain Value */
-	uint8_t gain;
+	enum ada4250_gain gain;
 	/* Bias Set */
 	enum ada4250_bias bias;
 	/* Offset Range */
@@ -162,7 +177,7 @@ struct ada4250_dev {
 	/* Reference Buffer Enable */
 	bool refbuf_en;
 	/* Gain Value */
-	uint8_t gain;
+	enum ada4250_gain gain;
 	/* Bias Set */
 	enum ada4250_bias bias;
 	/* Offset Range */
@@ -201,7 +216,7 @@ int32_t ada4250_set_range(struct ada4250_dev *dev,
 			  enum ada4250_offset_range range);
 
 /* Set gain */
-int32_t ada4250_set_gain(struct ada4250_dev *dev, uint8_t gain);
+int32_t ada4250_set_gain(struct ada4250_dev *dev, enum ada4250_gain gain);
 
 /* Set offset value */
 int32_t ada4250_set_offset(struct ada4250_dev *dev, int8_t offset);

--- a/drivers/instr-amplif/ada4250/ada4250.h
+++ b/drivers/instr-amplif/ada4250/ada4250.h
@@ -183,7 +183,7 @@ int32_t ada4250_soft_reset(struct ada4250_dev *dev);
 int32_t ada4250_en_refbuf(struct ada4250_dev *dev, bool refbuf);
 
 /* Set Current Bias */
-int32_t ada4250_set_bias(struct ada4250_dev *dev, uint8_t bias);
+int32_t ada4250_set_bias(struct ada4250_dev *dev, enum ada4250_bias bias);
 
 /* Set offset trim range */
 int32_t ada4250_set_range(struct ada4250_dev *dev, uint8_t range);

--- a/drivers/instr-amplif/ada4250/ada4250.h
+++ b/drivers/instr-amplif/ada4250/ada4250.h
@@ -180,7 +180,7 @@ int32_t ada4250_update(struct ada4250_dev *dev, uint8_t reg_addr,
 int32_t ada4250_soft_reset(struct ada4250_dev *dev);
 
 /* Set Reference Buffer */
-int32_t ada4250_set_refbuf(struct ada4250_dev *dev, uint8_t refbuf);
+int32_t ada4250_en_refbuf(struct ada4250_dev *dev, bool refbuf);
 
 /* Set Current Bias */
 int32_t ada4250_set_bias(struct ada4250_dev *dev, uint8_t bias);

--- a/projects/ada4250_ardz/src/ada4250_ardz.c
+++ b/projects/ada4250_ardz/src/ada4250_ardz.c
@@ -78,7 +78,7 @@ int main()
 		.spi_init = &init_param,
 		.refbuf_en = ADA4250_BUF_DISABLE,
 		.bias = ADA4250_BIAS_DISABLE,
-		.gain = 8,
+		.gain = ADA4250_GAIN_8,
 		.offset_range = ADA4250_RANGE1_1UA_MAX,
 		.offset_val = 0,
 	};

--- a/projects/ada4250_ardz/src/ada4250_ardz.c
+++ b/projects/ada4250_ardz/src/ada4250_ardz.c
@@ -79,7 +79,7 @@ int main()
 		.refbuf_en = ADA4250_BUF_DISABLE,
 		.bias = ADA4250_BIAS_DISABLE,
 		.gain = 8,
-		.offset_range = 1,
+		.offset_range = ADA4250_RANGE1_1UA_MAX,
 		.offset_val = 0,
 	};
 


### PR DESCRIPTION
Use enums instead of defines where needed.

Allign data types between device attributes and function parameters.

Signed-off-by: Antoniu Miclaus antoniu.miclaus@analog.com