### PR TITLE
Added util.h into include search path in ad7606.h file as GENMASK macro

### DIFF
--- a/drivers/adc/ad7606/ad7606.h
+++ b/drivers/adc/ad7606/ad7606.h
@@ -4,7 +4,7 @@
  *   @author Stefan Popa (stefan.popa@analog.com)
  *   @author Darius Berghe (darius.berghe@analog.com)
 ********************************************************************************
- * Copyright 2019(c) Analog Devices, Inc.
+ * Copyright 2019, 2021(c) Analog Devices, Inc.
  *
  * All rights reserved.
  *
@@ -48,6 +48,7 @@
 #include "delay.h"
 #include "gpio.h"
 #include "spi.h"
+#include "util.h"
 
 /******************************************************************************/
 /********************** Macros and Constants Definitions **********************/


### PR DESCRIPTION
Added util.h into include search path in ad7606.h file as GENMASK macro is defined in util.h file

Signed-off-by: mahphalke <Mahesh.Phalke@analog.com>