### PR TITLE
[3] Naming fixes.

### DIFF
--- a/drivers/axi_core/spi_engine/spi_engine.c
+++ b/drivers/axi_core/spi_engine/spi_engine.c
@@ -61,9 +61,9 @@ significant delays */
  * @brief Spi engine platform specific SPI platform ops structure
  */
 const struct spi_platform_ops spi_eng_platform_ops = {
-	.spi_ops_init = &spi_engine_init,
-	.spi_ops_write_and_read = &spi_engine_write_and_read,
-	.spi_ops_remove = &spi_engine_remove
+	.init = &spi_engine_init,
+	.write_and_read = &spi_engine_write_and_read,
+	.remove = &spi_engine_remove
 };
 
 /******************************************************************************/

--- a/drivers/io-expander/demux_spi/demux_spi.c
+++ b/drivers/io-expander/demux_spi/demux_spi.c
@@ -54,9 +54,9 @@
  * @brief Demux specific SPI platform ops structure
  */
 const struct spi_platform_ops demux_spi_platform_ops = {
-	.spi_ops_init = demux_spi_init,
-	.spi_ops_remove = demux_spi_remove,
-	.spi_ops_write_and_read = demux_spi_write_and_read
+	.init = demux_spi_init,
+	.remove = demux_spi_remove,
+	.write_and_read = demux_spi_write_and_read
 };
 
 /**

--- a/drivers/platform/aducm3029/spi.c
+++ b/drivers/platform/aducm3029/spi.c
@@ -134,7 +134,7 @@ int32_t spi_init(struct spi_desc **desc,
 		return FAILURE;
 
 	config = param->extra;
-	if (config->spi_channel >= NB_SPI_DEVICES ||
+	if (param->device_id >= NB_SPI_DEVICES ||
 	    param->chip_select > MAX_CS_NUMBER)
 		return FAILURE;
 
@@ -154,8 +154,9 @@ int32_t spi_init(struct spi_desc **desc,
 	spi_desc->chip_select = (1 << param->chip_select);
 	spi_desc->max_speed_hz = param->max_speed_hz;
 	spi_desc->mode = param->mode;
+	spi_desc->device_id = param->device_id;
 
-	dev = devices[config->spi_channel];
+	dev = devices[param->device_id];
 	/* If device not initialized initialize it */
 	if (!dev) {
 		dev = (struct aducm_device_desc *)calloc(1, sizeof(*dev));
@@ -164,14 +165,14 @@ int32_t spi_init(struct spi_desc **desc,
 			free(aducm_desc);
 			return FAILURE;
 		}
-		if (ADI_SPI_SUCCESS != adi_spi_Open(config->spi_channel,
+		if (ADI_SPI_SUCCESS != adi_spi_Open(param->device_id,
 						    dev->buffer,
 						    ADI_SPI_MEMORY_SIZE,
 						    &dev->spi_handle))
 			goto failure;
 		if (SUCCESS != config_device(dev, spi_desc, true))
 			goto failure;
-		devices[config->spi_channel] = dev;
+		devices[param->device_id] = dev;
 	}
 	dev->ref_instances++;
 	aducm_desc->dev = dev;
@@ -206,7 +207,7 @@ int32_t spi_remove(struct spi_desc *desc)
 			    aducm_desc->dev->spi_handle))
 			return FAILURE;
 		free(aducm_desc->dev);
-		devices[aducm_desc->aducm_conf.spi_channel] = NULL;
+		devices[desc->device_id] = NULL;
 	}
 	free(aducm_desc);
 	free(desc);

--- a/drivers/platform/aducm3029/spi_extra.h
+++ b/drivers/platform/aducm3029/spi_extra.h
@@ -52,19 +52,6 @@
 /******************************************************************************/
 
 /**
- * @enum spi_channel
- * @brief Available SPI channels on the ADuCM3029
- */
-enum spi_channel {
-	/** SPI0 channel. */
-	SPI0,
-	/** SPI1 channel. */
-	SPI1,
-	/** SPI2 channel. */
-	SPI2
-};
-
-/**
  * @enum master_mode
  * @brief Available operations mode for a SPI channel
  */
@@ -104,8 +91,6 @@ struct aducm_device_desc {
  * spi_init_param.
  */
 struct aducm_spi_init_param {
-	/** Select the SPI channel */
-	enum spi_channel	spi_channel;
 	/** Select the operation mode */
 	enum master_mode	master_mode;
 	/** Enable or disable continuous mode */

--- a/drivers/platform/altera/altera_spi.c
+++ b/drivers/platform/altera/altera_spi.c
@@ -56,9 +56,9 @@
  * @brief Altera platform specific SPI platform ops structure
  */
 const struct spi_platform_ops altera_platform_ops = {
-	.spi_ops_init = &altera_spi_init,
-	.spi_ops_write_and_read = &altera_spi_write_and_read,
-	.spi_ops_remove = &altera_spi_remove
+	.init = &altera_spi_init,
+	.write_and_read = &altera_spi_write_and_read,
+	.remove = &altera_spi_remove
 };
 
 /**

--- a/drivers/platform/altera/altera_spi.c
+++ b/drivers/platform/altera/altera_spi.c
@@ -89,9 +89,9 @@ int32_t altera_spi_init(struct spi_desc **desc,
 
 	descriptor->chip_select = param->chip_select;
 	descriptor->mode = param->mode;
+	descriptor->device_id = param->device_id;
 
 	altera_descriptor->type = altera_param->type;
-	altera_descriptor->device_id = altera_param->device_id;
 	altera_descriptor->base_address = altera_param->base_address;
 
 	*desc = descriptor;

--- a/drivers/platform/altera/spi_extra.h
+++ b/drivers/platform/altera/spi_extra.h
@@ -62,8 +62,6 @@ enum spi_type {
 struct altera_spi_init_param {
 	/** Altera architecture type */
 	enum spi_type	type;
-	/** Device ID */
-	uint32_t	device_id;
 	/** SPI base address */
 	uint32_t	base_address;
 };
@@ -75,8 +73,6 @@ struct altera_spi_init_param {
 struct altera_spi_desc {
 	/** Altera architecture type */
 	enum spi_type	type;
-	/** Device ID */
-	uint32_t		device_id;
 	/** SPI base address */
 	uint32_t	base_address;
 };

--- a/drivers/platform/linux/linux_spi.c
+++ b/drivers/platform/linux/linux_spi.c
@@ -56,15 +56,6 @@
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
-/**
- * @struct linux_spi_desc
- * @brief Linux platform specific SPI descriptor
- */
-struct linux_spi_desc {
-	/** /dev/spidev"device_id"."chip_select" file descriptor */
-	int spidev_fd;
-};
-
 /******************************************************************************/
 /************************ Functions Definitions *******************************/
 /******************************************************************************/
@@ -97,7 +88,7 @@ int32_t linux_spi_init(struct spi_desc **desc,
 	linux_init = param->extra;
 
 	snprintf(path, sizeof(path), "/dev/spidev%d.%d",
-		 linux_init->device_id, param->chip_select);
+		 param->device_id, param->chip_select);
 
 	linux_desc->spidev_fd = open(path, O_RDWR);
 	if (linux_desc->spidev_fd < 0) {

--- a/drivers/platform/linux/linux_spi.c
+++ b/drivers/platform/linux/linux_spi.c
@@ -186,7 +186,7 @@ int32_t linux_spi_remove(struct spi_desc *desc)
  * @brief Linux platform specific SPI platform ops structure
  */
 const struct spi_platform_ops linux_spi_platform_ops = {
-	.spi_ops_init = &linux_spi_init,
-	.spi_ops_write_and_read = &linux_spi_write_and_read,
-	.spi_ops_remove = &linux_spi_remove
+	.init = &linux_spi_init,
+	.write_and_read = &linux_spi_write_and_read,
+	.remove = &linux_spi_remove
 };

--- a/drivers/platform/linux/linux_spi.h
+++ b/drivers/platform/linux/linux_spi.h
@@ -41,16 +41,6 @@
 #define LINUX_SPI_H_
 
 /**
- * @struct linux_spi_init_param
- * @brief Structure holding the initialization parameters for Linux platform
- * specific SPI parameters.
- */
-struct linux_spi_init_param {
-	/** SPI bus ID (/dev/spidev"device_id"."chip_select") */
-	uint32_t device_id;
-};
-
-/**
  * @brief Linux specific SPI platform ops structure
  */
 extern const struct spi_platform_ops linux_spi_platform_ops;

--- a/drivers/platform/stm32/stm32_spi.c
+++ b/drivers/platform/stm32/stm32_spi.c
@@ -48,9 +48,9 @@
  * @brief stm32 platform specific SPI platform ops structure
  */
 const struct spi_platform_ops stm32_platform_ops = {
-	.spi_ops_init = &stm32_spi_init,
-	.spi_ops_write_and_read = &stm32_spi_write_and_read,
-	.spi_ops_remove = &stm32_spi_remove
+	.init = &stm32_spi_init,
+	.write_and_read = &stm32_spi_write_and_read,
+	.remove = &stm32_spi_remove
 };
 
 /**

--- a/drivers/platform/xilinx/spi_extra.h
+++ b/drivers/platform/xilinx/spi_extra.h
@@ -80,8 +80,6 @@ typedef struct xil_spi_init_param {
 	enum xil_spi_type	type;
 	/** SPI flags */
 	uint32_t		flags;
-	/** Device ID */
-	uint32_t		device_id;
 } xil_spi_init_param;
 
 /**

--- a/drivers/platform/xilinx/xilinx_spi.c
+++ b/drivers/platform/xilinx/xilinx_spi.c
@@ -109,7 +109,7 @@ static int32_t spi_init_pl(struct spi_desc *desc,
 	if(!xdesc->instance)
 		goto pl_error;
 
-	xdesc->config = XSpi_LookupConfig(xinit->device_id);
+	xdesc->config = XSpi_LookupConfig(param->device_id);
 	if(xdesc->config == NULL)
 		goto pl_error;
 
@@ -120,7 +120,7 @@ static int32_t spi_init_pl(struct spi_desc *desc,
 	if(ret != SUCCESS)
 		goto pl_error;
 
-	ret = XSpi_Initialize(xdesc->instance, xinit->device_id);
+	ret = XSpi_Initialize(xdesc->instance, param->device_id);
 	if (ret != SUCCESS)
 		goto pl_error;
 
@@ -183,7 +183,7 @@ static int32_t spi_init_ps(struct spi_desc *desc,
 	if(!xdesc->instance)
 		goto ps_error;
 
-	xdesc->config = XSpiPs_LookupConfig(xinit->device_id);
+	xdesc->config = XSpiPs_LookupConfig(param->device_id);
 	if(xdesc->config == NULL)
 		goto ps_error;
 
@@ -194,7 +194,7 @@ static int32_t spi_init_ps(struct spi_desc *desc,
 	if(ret != SUCCESS)
 		goto ps_error;
 
-	switch (xinit->device_id) {
+	switch (param->device_id) {
 #if (SPI_NUM_INSTANCES >= 1)
 	case 0:
 		input_clock = SPI_CLK_FREQ_HZ(0);

--- a/drivers/platform/xilinx/xilinx_spi.c
+++ b/drivers/platform/xilinx/xilinx_spi.c
@@ -74,9 +74,9 @@
  * @brief Xilinx platform specific SPI platform ops structure
  */
 const struct spi_platform_ops xil_platform_ops = {
-	.spi_ops_init = &xil_spi_init,
-	.spi_ops_write_and_read = &xil_spi_write_and_read,
-	.spi_ops_remove = &xil_spi_remove
+	.init = &xil_spi_init,
+	.write_and_read = &xil_spi_write_and_read,
+	.remove = &xil_spi_remove
 };
 
 /**

--- a/drivers/spi/spi.c
+++ b/drivers/spi/spi.c
@@ -54,7 +54,7 @@ int32_t spi_init(struct spi_desc **desc,
 	if (!param)
 		return FAILURE;
 
-	if ((param->platform_ops->spi_ops_init(desc, param)))
+	if ((param->platform_ops->init(desc, param)))
 		return FAILURE;
 
 	(*desc)->platform_ops = param->platform_ops;
@@ -69,7 +69,7 @@ int32_t spi_init(struct spi_desc **desc,
  */
 int32_t spi_remove(struct spi_desc *desc)
 {
-	return desc->platform_ops->spi_ops_remove(desc);
+	return desc->platform_ops->remove(desc);
 }
 
 /**
@@ -83,5 +83,5 @@ int32_t spi_write_and_read(struct spi_desc *desc,
 			   uint8_t *data,
 			   uint16_t bytes_number)
 {
-	return desc->platform_ops->spi_ops_write_and_read(desc, data, bytes_number);
+	return desc->platform_ops->write_and_read(desc, data, bytes_number);
 }

--- a/include/spi.h
+++ b/include/spi.h
@@ -95,6 +95,8 @@ struct spi_platform_ops ;
  * @brief Structure holding the parameters for SPI initialization
  */
 typedef struct spi_init_param {
+	/** Device ID */
+	uint32_t	device_id;
 	/** maximum transfer speed */
 	uint32_t	max_speed_hz;
 	/** SPI chip select */
@@ -113,6 +115,8 @@ typedef struct spi_init_param {
  * @brief Structure holding SPI descriptor.
  */
 typedef struct spi_desc {
+	/** Device ID */
+	uint32_t	device_id;
 	/** maximum transfer speed */
 	uint32_t	max_speed_hz;
 	/** SPI chip select */

--- a/include/spi.h
+++ b/include/spi.h
@@ -137,11 +137,11 @@ typedef struct spi_desc {
  */
 struct spi_platform_ops {
 	/** SPI initialization function pointer */
-	int32_t (*spi_ops_init)(struct spi_desc **, const struct spi_init_param *);
+	int32_t (*init)(struct spi_desc **, const struct spi_init_param *);
 	/** SPI write/read function pointer */
-	int32_t (*spi_ops_write_and_read)(struct spi_desc *, uint8_t *, uint16_t);
+	int32_t (*write_and_read)(struct spi_desc *, uint8_t *, uint16_t);
 	/** SPI remove function pointer */
-	int32_t (*spi_ops_remove)(struct spi_desc *);
+	int32_t (*remove)(struct spi_desc *);
 };
 
 /******************************************************************************/

--- a/projects/ad6676-ebz/src/ad6676_ebz.c
+++ b/projects/ad6676-ebz/src/ad6676_ebz.c
@@ -278,10 +278,10 @@ int main(void)
 #else
 		.type = SPI_PS,
 #endif
-		.device_id = SPI_DEVICE_ID
 	};
 
 	struct spi_init_param ad6676_spi_param = {
+		.device_id = SPI_DEVICE_ID,
 		.max_speed_hz = 2000000u,
 		.chip_select = 0,
 		.mode = SPI_MODE_0,

--- a/projects/ad7124-8pmdz/src/main.c
+++ b/projects/ad7124-8pmdz/src/main.c
@@ -95,13 +95,13 @@ int main(void)
 		.continuous_mode = true,
 		.dma = false,
 		.half_duplex = false,
-		.master_mode = MASTER,
-		.spi_channel = SPI1
+		.master_mode = MASTER
 	};
 	struct spi_init_param spi_initial = {
 		.chip_select = 0x00,
 		.max_speed_hz = 10000000,
 		.mode = SPI_MODE_3,
+		.device_id = 1,
 		.extra = &aducm_spi_ini
 	};
 	struct ad7124_init_param ad7124_initial = {

--- a/projects/ad7768-evb/src/ad7768_evb.c
+++ b/projects/ad7768-evb/src/ad7768_evb.c
@@ -157,7 +157,6 @@ int main(void)
 	const uint32_t chan_no = AD7768_CH_NO, resolution = AD7768_RESOLUTION,
 		       sample_no = 1024;
 	struct xil_spi_init_param xil_spi_initial = {
-		.device_id = SPI_DEVICE_ID,
 		.flags = 0,
 		.type = SPI_PS
 	};
@@ -170,6 +169,7 @@ int main(void)
 	ad7768_init_param default_init_param = {
 		/* SPI */
 		.spi_init = {
+			.device_id = SPI_DEVICE_ID,
 			.max_speed_hz = 1000000,
 			.chip_select = SPI_AD7768_CS,
 			.mode = SPI_MODE_0,

--- a/projects/ad9081/src/app.c
+++ b/projects/ad9081/src/app.c
@@ -88,9 +88,9 @@ int main(void)
 #else
 		.type = SPI_PS,
 #endif
-		.device_id = PHY_SPI_DEVICE_ID,
 	};
 	struct spi_init_param phy_spi_init_param = {
+		.device_id = PHY_SPI_DEVICE_ID,
 		.max_speed_hz = 1000000,
 		.mode = SPI_MODE_0,
 		.chip_select = PHY_CS,

--- a/projects/ad9081/src/app_clock.c
+++ b/projects/ad9081/src/app_clock.c
@@ -82,14 +82,14 @@ int32_t app_clock_init(struct clk dev_refclk[MULTIDEVICE_INSTANCE_COUNT])
 #else
 		.type = SPI_PS,
 #endif
+	};
+
+	struct spi_init_param clkchip_spi_init_param = {
 #ifdef QUAD_MXFE
 		.device_id = SPI_2_DEVICE_ID,
 #else
 		.device_id = CLK_SPI_DEVICE_ID,
 #endif
-	};
-
-	struct spi_init_param clkchip_spi_init_param = {
 		.max_speed_hz = 10000000,
 		.mode = SPI_MODE_0,
 #ifdef QUAD_MXFE

--- a/projects/ad9083/src/app_ad9083.c
+++ b/projects/ad9083/src/app_ad9083.c
@@ -125,11 +125,11 @@ int32_t app_ad9083_init(struct app_ad9083 **app,
 	struct app_ad9083 *app_ad9083;
 	struct xil_spi_init_param xil_spi_param = {
 		.type = SPI_PS,
-		.device_id = 0,
 	};
 
 	// clock chip spi settings
 	struct spi_init_param ad9083_spi_init_param = {
+		.device_id = 0,
 		.max_speed_hz = 10000000,
 		.mode = SPI_MODE_0,
 		.chip_select = SPI_AD9083_CS,

--- a/projects/ad9083/src/app_clocking.c
+++ b/projects/ad9083/src/app_clocking.c
@@ -174,11 +174,11 @@ int32_t app_clocking_init(struct app_clocking **app,
 
 	struct xil_spi_init_param xil_spi_param = {
 		.type = SPI_PS,
-		.device_id = 0,
 	};
 
 	/* clock chip spi settings */
 	struct spi_init_param clkchip_spi_init_param = {
+		.device_id = 0,
 		.max_speed_hz = 10000000,
 		.mode = SPI_MODE_0,
 		.chip_select = CLK_AD9258_CS,

--- a/projects/ad9172/src/main.c
+++ b/projects/ad9172/src/main.c
@@ -70,11 +70,11 @@ int main(void)
 {
 	struct xil_spi_init_param xil_spi_param = {
 		.type = SPI_PS,
-		.device_id = SPI_DEVICE_ID,
 		.flags = 0
 	};
 
 	struct spi_init_param hmc7044_spi_param = {
+		.device_id = SPI_DEVICE_ID,
 		.max_speed_hz = 10000000,
 		.mode = SPI_MODE_0,
 		.chip_select = SPI_HMC7044_CS,

--- a/projects/ad9208/src/main.c
+++ b/projects/ad9208/src/main.c
@@ -129,11 +129,11 @@ int main(void)
 {
 	struct xil_spi_init_param xil_spi_param = {
 		.type = SPI_PL,
-		.device_id = SPI_DEVICE_ID,
 		.flags = 0
 	};
 
 	struct spi_init_param hmc7044_spi_param = {
+		.device_id = SPI_DEVICE_ID,
 		.max_speed_hz = 10000000,
 		.mode = SPI_MODE_0,
 		.chip_select = SPI_HMC7044_CS,

--- a/projects/ad9265-fmc-125ebz/src/ad9265_fmc_125ebz.c
+++ b/projects/ad9265-fmc-125ebz/src/ad9265_fmc_125ebz.c
@@ -66,11 +66,11 @@ int main(void)
 
 	/* Initialize SPI structures */
 	struct xil_spi_init_param xil_spi_param = {
-		.device_id = SPI_DEVICE_ID,
 		.type = SPI_PS,
 	};
 
 	struct spi_init_param ad9265_spi_param = {
+		.device_id = SPI_DEVICE_ID,
 		.max_speed_hz = 10000000u,
 		.chip_select = 0,
 		.mode = SPI_MODE_0,

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -85,7 +85,6 @@ struct xil_spi_init_param xil_spi_param = {
 #else
 	.type = SPI_PS,
 #endif
-	.device_id = SPI_DEVICE_ID,
 	.flags = 0
 };
 
@@ -96,12 +95,6 @@ struct xil_gpio_init_param xil_gpio_param = {
 	.type = GPIO_PS,
 #endif
 	.device_id = GPIO_DEVICE_ID
-};
-#endif
-
-#ifdef LINUX_PLATFORM
-struct linux_spi_init_param linux_spi_param = {
-	.device_id = 0
 };
 #endif
 
@@ -410,6 +403,7 @@ AD9361_InitParam default_init_param = {
 	},		//gpio_cal_sw2 *** cal-sw2-gpios
 
 	{
+		.device_id = SPI_DEVICE_ID,
 		.mode = SPI_MODE_1,
 		.chip_select = SPI_CS,
 #ifdef XILINX_PLATFORM
@@ -417,7 +411,6 @@ AD9361_InitParam default_init_param = {
 		.platform_ops = &xil_platform_ops
 #endif
 #ifdef LINUX_PLATFORM
-		.extra = &linux_spi_param,
 		.platform_ops = &linux_spi_platform_ops
 #endif
 	},

--- a/projects/ad9361/src/parameters.h
+++ b/projects/ad9361/src/parameters.h
@@ -147,6 +147,7 @@
 #define CF_AD9361_RX_DMA_BASEADDR	2
 #define CF_AD9361_TX_DMA_BASEADDR	3
 
+#define SPI_DEVICE_ID		0
 #define SPI_CS			0
 
 #define GPIO_RESET_PIN	1006

--- a/projects/ad9371/src/devices/adi_hal/common.c
+++ b/projects/ad9371/src/devices/adi_hal/common.c
@@ -56,7 +56,6 @@ int32_t platform_init(void)
 #else
 		.type = SPI_PS,
 #endif
-		.device_id = SPI_DEVICE_ID,
 		.flags = SPI_CS_DECODE
 	};
 
@@ -68,6 +67,7 @@ int32_t platform_init(void)
 #endif
 		.device_id = GPIO_DEVICE_ID
 	};
+	spi_param.device_id = SPI_DEVICE_ID;
 	spi_param.extra = &xilinx_spi_param;
 	spi_param.platform_ops = &xil_platform_ops;
 	gpio_ad9371_resetb_param.platform_ops = &xil_gpio_platform_ops;
@@ -78,7 +78,6 @@ int32_t platform_init(void)
 	gpio_ad9528_sysref_param.extra = &xilinx_gpio_param;
 #else
 	struct altera_spi_init_param altera_spi_param = {
-		.device_id = SPI_DEVICE_ID,
 		.type = NIOS_II_SPI,
 		.base_address = SPI_BASEADDR
 	};
@@ -88,6 +87,7 @@ int32_t platform_init(void)
 		.type = NIOS_II_GPIO,
 		.base_address = GPIO_BASEADDR
 	};
+	spi_param.device_id = SPI_DEVICE_ID;
 	spi_param.platform_ops = &altera_platform_ops;
 	spi_param.extra = &altera_spi_param;
 	gpio_ad9371_resetb_param.platform_ops = &altera_gpio_platform_ops;

--- a/projects/ad9434-fmc-500ebz/src/ad9434_fmc_500ebz.c
+++ b/projects/ad9434-fmc-500ebz/src/ad9434_fmc_500ebz.c
@@ -68,11 +68,11 @@ int main(void)
 
 	/* Initialize SPI structures */
 	struct xil_spi_init_param xil_spi_param = {
-		.device_id = SPI_DEVICE_ID,
 		.type = SPI_PS,
 	};
 
 	struct spi_init_param ad9434_spi_param = {
+		.device_id = SPI_DEVICE_ID,
 		.max_speed_hz = 10000000u,
 		.chip_select = 0,
 		.mode = SPI_MODE_0,

--- a/projects/ad9467/src/app/ad9467_fmc.c
+++ b/projects/ad9467/src/app/ad9467_fmc.c
@@ -134,11 +134,12 @@ int main()
 #else
 		.type = SPI_PS,
 #endif
-		.device_id = SPI_DEVICE_ID
 	};
+	ad9467_spi_param.device_id = SPI_DEVICE_ID;
 	ad9467_spi_param.extra = &xil_spi_param;
 
 	struct spi_init_param ad9517_spi_param = {
+		.device_id = SPI_DEVICE_ID,
 		.max_speed_hz = 2000000u,
 		.chip_select = 1,
 		.platform_ops = &xil_platform_ops,

--- a/projects/ad9656_fmc/src/app/ad9656_fmc.c
+++ b/projects/ad9656_fmc/src/app/ad9656_fmc.c
@@ -93,8 +93,7 @@ int main(void)
 	};
 
 	struct xil_spi_init_param xil_spi_param = {
-		.type = SPI_PS,
-		.device_id = SPI_DEVICE_ID
+		.type = SPI_PS
 	};
 
 	/* this pattern is outputed by the ad9656 chip after the JESD204 test is finished */
@@ -103,10 +102,13 @@ int main(void)
 		.user_test_pattern2 = 0xC3D4
 	};
 
+	ad9508_spi_param.device_id = SPI_DEVICE_ID;
 	ad9508_spi_param.platform_ops = &xil_platform_ops;
 	ad9508_spi_param.extra = &xil_spi_param;
+	ad9553_spi_param.device_id = SPI_DEVICE_ID;
 	ad9553_spi_param.platform_ops = &xil_platform_ops;
 	ad9553_spi_param.extra = &xil_spi_param;
+	ad9656_spi_param.device_id = SPI_DEVICE_ID;
 	ad9656_spi_param.platform_ops = &xil_platform_ops;
 	ad9656_spi_param.extra = &xil_spi_param;
 

--- a/projects/ad9739a-fmc-ebz/src/ad9739a_fmc_ebz.c
+++ b/projects/ad9739a-fmc-ebz/src/ad9739a_fmc_ebz.c
@@ -70,11 +70,11 @@ int main(void)
 	/* Initialize SPI structures */
 
 	struct xil_spi_init_param xil_spi_param = {
-		.device_id = SPI_DEVICE_ID,
 		.type = SPI_PS,
 	};
 
 	struct spi_init_param adf4350_spi_param = {
+		.device_id = SPI_DEVICE_ID,
 		.max_speed_hz = 5000000u,
 		.chip_select = 0,
 		.mode = SPI_MODE_0,
@@ -83,6 +83,7 @@ int main(void)
 	};
 
 	struct spi_init_param ad9739_spi_param = {
+		.device_id = SPI_DEVICE_ID,
 		.max_speed_hz = 20000000u,
 		.chip_select = 1,
 		.mode = SPI_MODE_0,

--- a/projects/ada4250_ardz/src/ada4250_ardz.c
+++ b/projects/ada4250_ardz/src/ada4250_ardz.c
@@ -62,11 +62,11 @@ int main()
 		.continuous_mode = true,
 		.dma = false,
 		.half_duplex = false,
-		.master_mode = MASTER,
-		.spi_channel = SPI0
+		.master_mode = MASTER
 	};
 
 	struct spi_init_param init_param = {
+		.device_id = 0,
 		.chip_select = 1,
 		.extra = &spi_param,
 		.max_speed_hz = 1000000,

--- a/projects/adf5902_sdz/src/adf5902_sdz.c
+++ b/projects/adf5902_sdz/src/adf5902_sdz.c
@@ -66,7 +66,6 @@ int main(void)
 	uint64_t freq = 0;
 
 	struct xil_spi_init_param xil_spi_init = {
-		.device_id = SPI_DEVICE_ID,
 		.flags = 0,
 		.type = SPI_PS
 	};
@@ -83,6 +82,7 @@ int main(void)
 	};
 
 	struct spi_init_param spi_init = {
+		.device_id = SPI_DEVICE_ID,
 		.max_speed_hz = 2000000,
 		.chip_select = SPI_ADF5902_CS,
 		.mode = SPI_MODE_0,

--- a/projects/adrv9001/src/hal/no_os_platform.c
+++ b/projects/adrv9001/src/hal/no_os_platform.c
@@ -89,7 +89,6 @@ int32_t no_os_hw_open(void *devHalCfg)
 #else
 		.type = SPI_PS,
 #endif
-		.device_id = SPI_DEVICE_ID,
 		.flags = 0
 	};
 
@@ -119,6 +118,7 @@ int32_t no_os_hw_open(void *devHalCfg)
 		return ret;
 #endif
 	struct spi_init_param sip = {
+		.device_id = SPI_DEVICE_ID,
 		.max_speed_hz = 20000000,
 		.mode = SPI_MODE_0,
 		.chip_select = SPI_CS,

--- a/projects/adrv9009/src/app/app_clocking.c
+++ b/projects/adrv9009/src/app/app_clocking.c
@@ -369,7 +369,6 @@ adiHalErr_t clocking_init(uint32_t rx_div40_rate_hz,
 #else
 		.type = SPI_PS,
 #endif
-		.device_id = 0,
 #if defined(ZU11EG) || defined(FMCOMMS8_ZCU102)
 		.flags = SPI_CS_DECODE
 #endif
@@ -403,6 +402,7 @@ adiHalErr_t clocking_init(uint32_t rx_div40_rate_hz,
 
 	// clock chip spi settings
 	struct spi_init_param clkchip_spi_init_param = {
+		.device_id = 0,
 		.max_speed_hz = 10000000,
 		.mode = SPI_MODE_0,
 		.chip_select = CLK_CS,
@@ -417,6 +417,7 @@ adiHalErr_t clocking_init(uint32_t rx_div40_rate_hz,
 #if defined(ZU11EG) || defined(FMCOMMS8_ZCU102)
 	// clock chip spi settings
 	struct spi_init_param car_clkchip_spi_init_param = {
+		.device_id = 0,
 		.max_speed_hz = 10000000,
 		.mode = SPI_MODE_0,
 		.chip_select = CAR_CLK_CS,

--- a/projects/adrv9009/src/app/headless.c
+++ b/projects/adrv9009/src/app/headless.c
@@ -189,7 +189,6 @@ int main(void)
 #else
 		.type = SPI_PS,
 #endif
-		.device_id = 0,
 		.flags = SPI_CS_DECODE
 	};
 	struct xil_gpio_init_param hal_gpio_param = {
@@ -203,7 +202,6 @@ int main(void)
 #else
 	struct altera_spi_init_param hal_spi_param = {
 		.type = NIOS_II_SPI,
-		.device_id = 0,
 		.base_address = SPI_BASEADDR
 	};
 	struct altera_gpio_init_param hal_gpio_param = {

--- a/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
+++ b/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
@@ -87,6 +87,7 @@ adiHalErr_t ADIHAL_openHw(void *devHalInfo, uint32_t halTimeout_ms)
 
 	status = gpio_get(&dev_hal_data->gpio_adrv_resetb, &gpio_adrv_resetb_param);
 
+	spi_param.device_id = 0;
 	spi_param.max_speed_hz = 25000000;
 	spi_param.mode = SPI_MODE_0;
 	spi_param.chip_select = dev_hal_data->spi_adrv_csn;

--- a/projects/adxrs290-pmdz/src/main.c
+++ b/projects/adxrs290-pmdz/src/main.c
@@ -156,8 +156,7 @@ int main(void)
 		.continuous_mode = true,
 		.dma = false,
 		.half_duplex = false,
-		.master_mode = MASTER,
-		.spi_channel = SPI1
+		.master_mode = MASTER
 	};
 
 #endif // ADUCM_PLATFORM
@@ -207,6 +206,7 @@ int main(void)
 #endif //USE_TCP_SOCKET
 
 	struct spi_init_param init_param = {
+		.device_id = 1,
 		.chip_select = 0,
 		.extra = &spi_param,
 		.max_speed_hz = 900000,

--- a/projects/cn0531/src/main.c
+++ b/projects/cn0531/src/main.c
@@ -76,8 +76,7 @@ int main(void)
 		.continuous_mode = true,
 		.dma = false,
 		.half_duplex = false,
-		.master_mode = MASTER,
-		.spi_channel = SPI1
+		.master_mode = MASTER
 	};
 	struct ad5791_init_param ad5791_initial = {
 		.act_device = ID_AD5791,
@@ -87,6 +86,7 @@ int main(void)
 		.gpio_ldac.extra = NULL,
 		.gpio_reset.number = 0x0C,
 		.gpio_reset.extra = NULL,
+		.spi_init.device_id = 1,
 		.spi_init.chip_select = 0x00,
 		.spi_init.extra = &aducm_spi_ini,
 		.spi_init.max_speed_hz = 5000000,

--- a/projects/fmcadc2/src/app/fmcadc2.c
+++ b/projects/fmcadc2/src/app/fmcadc2.c
@@ -81,8 +81,8 @@ int main(void)
 #else
 		.type = SPI_PS,
 #endif
-		.device_id = SPI_DEVICE_ID
 	};
+	ad9625_spi_param.device_id = SPI_DEVICE_ID;
 	ad9625_spi_param.extra = &xil_spi_param;
 
 	struct gpio_init_param gpio_sysref_param = {

--- a/projects/fmcadc5/src/app/fmcadc5.c
+++ b/projects/fmcadc5/src/app/fmcadc5.c
@@ -72,6 +72,7 @@ int main(void)
 
 	// SPI configuration
 	struct spi_init_param ad9625_0_spi_param = {
+		.device_id = SPI_DEVICE_ID,
 		.max_speed_hz = 2000000u,
 		.chip_select = 0,
 		.mode = SPI_MODE_0,
@@ -79,6 +80,7 @@ int main(void)
 	};
 
 	struct spi_init_param ad9625_1_spi_param = {
+		.device_id = SPI_DEVICE_ID,
 		.max_speed_hz = 2000000u,
 		.chip_select = 1,
 		.mode = SPI_MODE_0,
@@ -87,7 +89,6 @@ int main(void)
 
 	struct xil_spi_init_param xil_spi_param = {
 		.type = SPI_PL,
-		.device_id = SPI_DEVICE_ID
 	};
 	ad9625_0_spi_param.extra = &xil_spi_param;
 	ad9625_1_spi_param.extra = &xil_spi_param;

--- a/projects/fmcdaq2/src/app/fmcdaq2.c
+++ b/projects/fmcdaq2/src/app/fmcdaq2.c
@@ -220,16 +220,19 @@ static int fmcdaq2_spi_init(struct fmcdaq2_init_param *dev_init)
 {
 	/* Initialize SPI structures */
 	struct spi_init_param ad9523_spi_param = {
+		.device_id = SPI_DEVICE_ID,
 		.max_speed_hz = 2000000u,
 		.chip_select = 0,
 		.mode = SPI_MODE_0
 	};
 	struct spi_init_param ad9144_spi_param = {
+		.device_id = SPI_DEVICE_ID,
 		.max_speed_hz = 2000000u,
 		.chip_select = 1,
 		.mode = SPI_MODE_0
 	};
 	struct spi_init_param ad9680_spi_param = {
+		.device_id = SPI_DEVICE_ID,
 		.max_speed_hz = 2000000u,
 		.chip_select = 2,
 		.mode = SPI_MODE_0
@@ -242,7 +245,6 @@ static int fmcdaq2_spi_init(struct fmcdaq2_init_param *dev_init)
 #else
 		.type = SPI_PS,
 #endif
-		.device_id = SPI_DEVICE_ID
 	};
 	ad9523_spi_param.platform_ops = &xil_platform_ops;
 	ad9523_spi_param.extra = &xil_spi_param;
@@ -254,7 +256,6 @@ static int fmcdaq2_spi_init(struct fmcdaq2_init_param *dev_init)
 	ad9680_spi_param.extra = &xil_spi_param;
 #else
 	struct altera_spi_init_param altera_spi_param = {
-		.device_id = SPI_DEVICE_ID,
 		.type = NIOS_II_SPI,
 		.base_address = SYS_SPI_BASE
 	};

--- a/projects/fmcdaq3/src/app/fmcdaq3.c
+++ b/projects/fmcdaq3/src/app/fmcdaq3.c
@@ -128,18 +128,21 @@ int main(void)
 
 	/* Initialize SPI structures */
 	struct spi_init_param ad9528_spi_param = {
+		.device_id = SPI_DEVICE_ID,
 		.max_speed_hz = 2000000u,
 		.chip_select = 0,
 		.mode = SPI_MODE_0
 	};
 
 	struct spi_init_param ad9152_spi_param = {
+		.device_id = SPI_DEVICE_ID,
 		.max_speed_hz = 2000000u,
 		.chip_select = 1,
 		.mode = SPI_MODE_0
 	};
 
 	struct spi_init_param ad9680_spi_param = {
+		.device_id = SPI_DEVICE_ID,
 		.max_speed_hz = 2000000u,
 		.chip_select = 2,
 		.mode = SPI_MODE_0
@@ -152,7 +155,6 @@ int main(void)
 #else
 		.type = SPI_PS,
 #endif
-		.device_id = SPI_DEVICE_ID
 	};
 	ad9528_spi_param.platform_ops = &xil_platform_ops;
 	ad9528_spi_param.extra = &xil_spi_param;
@@ -162,7 +164,6 @@ int main(void)
 	ad9680_spi_param.extra = &xil_spi_param;
 #else
 	struct altera_spi_init_param altera_spi_param = {
-		.device_id = SPI_DEVICE_ID,
 		.type = NIOS_II_SPI,
 		.base_address = SYS_SPI_BASE
 	};

--- a/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
+++ b/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
@@ -83,6 +83,7 @@ int main(void)
 	};
 
 	struct spi_init_param ad9250_0_spi_param = {
+		.device_id = SPI_DEVICE_ID,
 		.max_speed_hz = demux_spi_param.max_speed_hz,
 		.chip_select = 0,
 		.mode = demux_spi_param.mode,
@@ -90,6 +91,7 @@ int main(void)
 	};
 
 	struct spi_init_param ad9250_1_spi_param = {
+		.device_id = SPI_DEVICE_ID,
 		.max_speed_hz = demux_spi_param.max_speed_hz,
 		.chip_select = 1,
 		.mode = demux_spi_param.mode,
@@ -97,6 +99,7 @@ int main(void)
 	};
 
 	struct spi_init_param ad9517_spi_param = {
+		.device_id = SPI_DEVICE_ID,
 		.max_speed_hz = demux_spi_param.max_speed_hz,
 		.chip_select = 4,
 		.mode = demux_spi_param.mode,
@@ -109,7 +112,6 @@ int main(void)
 #else
 		.type = SPI_PS,
 #endif
-		.device_id = SPI_DEVICE_ID
 	};
 
 	demux_spi_param.extra = &xil_spi_param;


### PR DESCRIPTION
Se last 2 commits. Will rebase onto #995 

This PR will:
 - Remove platform_ops form platform ops fields
 - Move device id from extra to spi.h init param.