### PR TITLE
Remove old transfer_dev_to_mem and update ad7134 to use iio_app

### DIFF
--- a/drivers/adc/ad713x/iio_ad713x.c
+++ b/drivers/adc/ad713x/iio_ad713x.c
@@ -1,0 +1,58 @@
+/***************************************************************************//**
+ *   @file   iio_ad713x.c
+ *   @brief  Implementation of iio_ad713x.c.
+ *   @author Mihail Chindris (mihail.chindris@analog.com)
+********************************************************************************
+ * Copyright 2021(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifdef IIO_SUPPORT
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include "iio_types.h"
+#include "ad713x.h"
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+
+struct iio_device ad713x_iio_desc = {
+	.debug_reg_read = (int32_t (*)()) ad713x_spi_reg_read,
+	.debug_reg_write = (int32_t (*)()) ad713x_spi_reg_write
+};
+
+#endif /* IIO_SUPPORT */

--- a/drivers/adc/ad713x/iio_ad713x.h
+++ b/drivers/adc/ad713x/iio_ad713x.h
@@ -1,0 +1,58 @@
+/***************************************************************************//**
+*   @file   iio_ad713x.h
+*   @brief  Header file of iio_axi_adc
+*   @author Cristian Pop (cristian.pop@analog.com)
+********************************************************************************
+* Copyright 2019(c) Analog Devices, Inc.
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*  - Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*  - Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in
+*    the documentation and/or other materials provided with the
+*    distribution.
+*  - Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*  - The use of this software may or may not infringe the patent rights
+*    of one or more patent holders.  This license does not release you
+*    from the requirement that you obtain separate licenses from these
+*    patent holders to use this software.
+*  - Use of the software either in source or binary form, must be run
+*    on or directly connected to an Analog Devices Inc. component.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef IIO_AD713X
+#define IIO_AD713X
+
+#ifdef IIO_SUPPORT
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include "iio_types.h"
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+
+extern struct iio_device ad713x_iio_desc;
+
+#endif /* IIO_SUPPORT */
+
+#endif /* IIO_AD713X */

--- a/drivers/adc/ad713x/iio_dual_ad713x.h
+++ b/drivers/adc/ad713x/iio_dual_ad713x.h
@@ -1,6 +1,6 @@
 /***************************************************************************//**
 *   @file   iio_ad713x.h
-*   @brief  Header file of iio_axi_adc
+*   @brief  Header file of iio_dual_ad713x
 *   @author Cristian Pop (cristian.pop@analog.com)
 ********************************************************************************
 * Copyright 2019(c) Analog Devices, Inc.
@@ -36,14 +36,17 @@
 * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
-#ifndef IIO_AXI_ADC_H_
-#define IIO_AXI_ADC_H_
+#ifndef IIO_DUAL_AD713X
+#define IIO_DUAL_AD713X
+
+#ifdef IIO_SUPPORT
 
 /******************************************************************************/
 /***************************** Include Files **********************************/
 /******************************************************************************/
 
 #include <stdio.h>
+#include "ad713x.h"
 #include "iio_types.h"
 #include "spi.h"
 
@@ -58,6 +61,8 @@
 struct iio_ad713x_init_par {
 	/** Number of channels */
 	uint8_t	num_channels;
+	/* Device instance */
+	struct ad713x_dev *dev;
 	/** Spi engine descriptor */
 	struct spi_desc *spi_eng_desc;
 	/** Spi engine message descriptor */
@@ -67,8 +72,10 @@ struct iio_ad713x_init_par {
 };
 
 struct iio_ad713x {
+	/* Mask of active ch */
+	uint32_t mask;
 	/** iio device descriptor */
-	struct iio_device dev_descriptor;
+	struct iio_device iio_dev_desc;
 	/** Spi engine descriptor */
 	struct spi_desc *spi_eng_desc;
 	/** Spi engine message descriptor */
@@ -82,12 +89,14 @@ struct iio_ad713x {
 /******************************************************************************/
 
 /* Init function. */
-int32_t iio_ad713x_init(struct iio_ad713x **desc,
-			struct iio_ad713x_init_par *param);
+int32_t iio_dual_ad713x_init(struct iio_ad713x **desc,
+			     struct iio_ad713x_init_par *param);
 /* Get desciptor. */
-void iio_ad713x_get_dev_descriptor(struct iio_ad713x *desc,
-				   struct iio_device **dev_descriptor);
-/* Free the resources allocated by iio_demo_init(). */
-int32_t iio_ad713x_remove(struct iio_ad713x *desc);
+void iio_dual_ad713x_get_dev_descriptor(struct iio_ad713x *desc,
+					struct iio_device **dev_descriptor);
+/* Free the resources allocated by iio_ad713x_init(). */
+int32_t iio_dual_ad713x_remove(struct iio_ad713x *desc);
 
-#endif /* IIO_AXI_ADC_H_ */
+#endif /* IIO_SUPPORT */
+
+#endif /* IIO_AD713X */

--- a/drivers/adc/ad7799/iio_ad7799.c
+++ b/drivers/adc/ad7799/iio_ad7799.c
@@ -168,10 +168,6 @@ struct iio_device const ad7799_iio_descriptor = {
 	.attributes = ad7799_iio_attributes,
 	.debug_attributes = NULL,
 	.buffer_attributes = NULL,
-	.transfer_dev_to_mem = NULL,
-	.transfer_mem_to_dev = NULL,
-	.read_data = NULL,
-	.write_data = NULL,
 	.debug_reg_read = (int32_t (*)())ad7799_read,
 	.debug_reg_write = (int32_t (*)())ad7799_write,
 };

--- a/iio/iio_ad9361/iio_ad9361.c
+++ b/iio/iio_ad9361/iio_ad9361.c
@@ -2296,10 +2296,6 @@ int32_t iio_ad9361_init(struct iio_ad9361_desc **desc,
 	iio_ad9361_inst->dev_descriptor.attributes = global_attributes;
 	iio_ad9361_inst->dev_descriptor.debug_attributes = NULL;
 	iio_ad9361_inst->dev_descriptor.buffer_attributes = NULL;
-	iio_ad9361_inst->dev_descriptor.transfer_dev_to_mem = NULL;
-	iio_ad9361_inst->dev_descriptor.transfer_mem_to_dev = NULL;
-	iio_ad9361_inst->dev_descriptor.read_data = NULL;
-	iio_ad9361_inst->dev_descriptor.write_data = NULL;
 	*desc = iio_ad9361_inst;
 
 	return SUCCESS;

--- a/iio/iio_app/iio_app.c
+++ b/iio/iio_app/iio_app.c
@@ -36,6 +36,9 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
+
+#ifdef IIO_SUPPORT
+
 #include <stdlib.h>
 #include "iio.h"
 #include "iio_app.h"
@@ -222,3 +225,5 @@ int32_t iio_app_run(struct iio_app_device *devices, int32_t len)
 		status = iio_step(iio_desc);
 	} while (true);
 }
+
+#endif

--- a/libraries/iio/iio.c
+++ b/libraries/iio/iio.c
@@ -819,12 +819,6 @@ static uint32_t bytes_to_samples(struct iio_interface *intf, uint32_t bytes)
 static ssize_t iio_transfer_dev_to_mem(const char *device, size_t bytes_count)
 {
 	struct iio_interface *iio_interface = iio_get_interface(device);
-
-	if (iio_interface->dev_descriptor->transfer_dev_to_mem)
-		return iio_interface->dev_descriptor->transfer_dev_to_mem(
-			       iio_interface->dev_instance,
-			       bytes_count, iio_interface->ch_mask);
-	//else
 	struct iio_data_buffer	*r_buff;
 	uint32_t		samples;
 	ssize_t			ret;
@@ -858,14 +852,6 @@ static ssize_t iio_read_dev(const char *device, char *pbuf, size_t offset,
 			    size_t bytes_count)
 {
 	struct iio_interface *iio_interface = iio_get_interface(device);
-
-	if (iio_interface->dev_descriptor->read_data)
-		return iio_interface->dev_descriptor->read_data(
-			       iio_interface->dev_instance,
-			       pbuf, offset,
-			       bytes_count, iio_interface->ch_mask);
-
-	//else
 	struct iio_data_buffer *r_buff;
 
 	r_buff = iio_interface->read_buffer;
@@ -890,13 +876,6 @@ static ssize_t iio_read_dev(const char *device, char *pbuf, size_t offset,
 static ssize_t iio_transfer_mem_to_dev(const char *device, size_t bytes_count)
 {
 	struct iio_interface *iio_interface = iio_get_interface(device);
-
-	if (iio_interface->dev_descriptor->transfer_mem_to_dev)
-		return iio_interface->dev_descriptor->transfer_mem_to_dev(
-			       iio_interface->dev_instance,
-			       bytes_count, iio_interface->ch_mask);
-
-	//else
 	struct iio_data_buffer	*w_buff;
 	ssize_t			ret;
 	uint32_t		samples;
@@ -930,13 +909,6 @@ static ssize_t iio_write_dev(const char *device, const char *buf,
 			     size_t offset, size_t bytes_count)
 {
 	struct iio_interface *iio_interface = iio_get_interface(device);
-	if(iio_interface->dev_descriptor->write_data)
-		return iio_interface->dev_descriptor->write_data(
-			       iio_interface->dev_instance,
-			       (char*)buf, offset, bytes_count,
-			       iio_interface->ch_mask);
-
-	//else
 	struct iio_data_buffer	*w_buff;
 
 	w_buff = iio_interface->write_buffer;

--- a/libraries/iio/iio_types.h
+++ b/libraries/iio/iio_types.h
@@ -176,18 +176,6 @@ struct iio_device {
 	struct iio_attribute *debug_attributes;
 	/** Array of attributes. Last one should have its name set to NULL */
 	struct iio_attribute *buffer_attributes;
-	/** Transfer data from device into RAM */
-	ssize_t (*transfer_dev_to_mem)(void *dev_instance, size_t bytes_count,
-				       uint32_t ch_mask);
-	/** Read data from RAM to pbuf. It should be called after "transfer_dev_to_mem" */
-	ssize_t (*read_data)(void *dev_instance, char *pbuf, size_t offset,
-			     size_t bytes_count, uint32_t ch_mask);
-	/** Transfer data from RAM to device */
-	ssize_t (*transfer_mem_to_dev)(void *dev_instance, size_t bytes_count,
-				       uint32_t ch_mask);
-	/** Write data to RAM. It should be called before "transfer_mem_to_dev" */
-	ssize_t (*write_data)(void *dev_instance, char *pbuf, size_t offset,
-			      size_t bytes_count, uint32_t ch_mask);
 	/** Called before a transfer starts. The device should activate the
 	 * channels from the mask */
 	int32_t (*prepare_transfer)(void *dev, uint32_t mask);

--- a/projects/ad713x_fmcz/src.mk
+++ b/projects/ad713x_fmcz/src.mk
@@ -9,10 +9,11 @@
 #									       #
 ################################################################################
 
-SRCS += $(PROJECT)/src/ad713x_fmc.c
+SRC_DIRS += $(PROJECT)/src
+SRC_DIRS += $(DRIVERS)/adc/ad713x
+
 SRCS += $(DRIVERS)/spi/spi.c						\
 	$(DRIVERS)/gpio/gpio.c						\
-	$(DRIVERS)/adc/ad713x/ad713x.c					\
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
 	$(DRIVERS)/axi_core/spi_engine/spi_engine.c			\
 	$(NO-OS)/util/util.c
@@ -22,14 +23,13 @@ SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
 	$(PLATFORM_DRIVERS)/delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
+SRC_DIRS += $(NO-OS)/iio/iio_app
 SRCS += $(PLATFORM_DRIVERS)/uart.c					\
 	$(PLATFORM_DRIVERS)/irq.c					\
 	$(NO-OS)/util/fifo.c						\
-	$(NO-OS)/util/list.c						\
-	$(NO-OS)/iio/iio_ad713x/iio_ad713x.c
+	$(NO-OS)/util/list.c	
 endif
-INCS += $(DRIVERS)/adc/ad713x/ad713x.h					\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h				\
+INCS += $(DRIVERS)/axi_core/axi_dmac/axi_dmac.h				\
 	$(DRIVERS)/axi_core/spi_engine/spi_engine.h			\
 	$(DRIVERS)/axi_core/spi_engine/spi_engine_private.h
 INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\
@@ -46,6 +46,5 @@ INCS +=	$(INCLUDE)/axi_io.h						\
 	$(INCLUDE)/util.h
 ifeq (y,$(strip $(TINYIIOD)))
 INCS += $(INCLUDE)/fifo.h						\
-	$(INCLUDE)/list.h						\
-	$(NO-OS)/iio/iio_ad713x/iio_ad713x.h
+	$(INCLUDE)/list.h
 endif

--- a/projects/ad713x_fmcz/src/parameters.h
+++ b/projects/ad713x_fmcz/src/parameters.h
@@ -1,0 +1,92 @@
+/***************************************************************************//**
+ *   @file   parameters.h
+ *   @brief  Parameters Definitions.
+ *   @author Mihail Chindris (mihail.chindris@analog.com)
+********************************************************************************
+ * Copyright 2021(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <xparameters.h>
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+#define SPI_DEVICE_ID			XPAR_PS7_SPI_0_DEVICE_ID
+#define GPIO_DEVICE_ID			XPAR_PS7_GPIO_0_DEVICE_ID
+#define AD7134_DMA_BASEADDR		XPAR_AXI_AD7134_DMA_BASEADDR
+#define AD7134_SPI_ENGINE_BASEADDR	XPAR_DUAL_AD7134_AXI_BASEADDR
+#define AD713x_SPI_ENG_REF_CLK_FREQ_HZ	XPAR_PS7_SPI_0_SPI_CLK_FREQ_HZ
+#define AD7134_1_SPI_CS			0
+#define AD7134_2_SPI_CS			1
+#define GPIO_DEVICE_ID			XPAR_PS7_GPIO_0_DEVICE_ID
+#define GPIO_OFFSET			54
+#define GPIO_RESETN_1			GPIO_OFFSET + 32
+#define GPIO_RESETN_2			GPIO_OFFSET + 33
+#define GPIO_PDN_1			GPIO_OFFSET + 34
+#define GPIO_PDN_2			GPIO_OFFSET + 35
+#define GPIO_MODE_1			GPIO_OFFSET + 36
+#define GPIO_MODE_2			GPIO_OFFSET + 37
+#define GPIO_0				GPIO_OFFSET + 38
+#define GPIO_1				GPIO_OFFSET + 39
+#define GPIO_2				GPIO_OFFSET + 40
+#define GPIO_3				GPIO_OFFSET + 41
+#define GPIO_4				GPIO_OFFSET + 42
+#define GPIO_5				GPIO_OFFSET + 43
+#define GPIO_6				GPIO_OFFSET + 44
+#define GPIO_7				GPIO_OFFSET + 45
+#define GPIO_DCLKIO_1			GPIO_OFFSET + 46
+#define GPIO_DCLKIO_2			GPIO_OFFSET + 47
+#define GPIO_PINBSPI			GPIO_OFFSET + 48
+#define GPIO_DCLKMODE			GPIO_OFFSET + 49
+#define AD7134_FMC_CH_NO		8
+#define AD7134_FMC_SAMPLE_NO		1024
+
+#define SPI_ENGINE_RX_ADDR		0x800000
+#define SPI_ENGINE_TX_ADDR		0xA000000
+#define RX_BUFF_ADDR			0x840000
+
+#ifdef IIO_SUPPORT
+#define UART_BAUDRATE			115200
+#define UART_DEVICE_ID			XPAR_XUARTPS_0_DEVICE_ID
+#define UART_IRQ_ID			XPAR_XUARTPS_1_INTR
+#define INTC_DEVICE_ID			XPAR_SCUGIC_SINGLE_DEVICE_ID
+#endif // IIO_SUPPORT
+
+#endif /* __PARAMETERS_H__ */


### PR DESCRIPTION
Remove old transfer_dev_to_mem function and use new one. Then remove it from iio.
Add support for register access.
Use iio_app