### PR TITLE
drivers: amplifiers: ada4230 support

### DIFF
--- a/drivers/amplifiers/ada4250/ada4250.h
+++ b/drivers/amplifiers/ada4250/ada4250.h
@@ -47,6 +47,7 @@
 #include <math.h>
 #include <stdbool.h>
 #include "spi.h"
+#include "gpio.h"
 #include "util.h"
 
 /******************************************************************************/
@@ -110,6 +111,15 @@
 /******************************************************************************/
 
 /**
+  * @enum ada4250_id
+  * @brief Current bias settings
+  */
+enum ada4250_id {
+	ADA4230,
+	ADA4250,
+};
+
+/**
   * @enum ada4250_bias
   * @brief Current bias settings
   */
@@ -150,8 +160,15 @@ enum ada4250_gain {
  * @brief ADA4250 Initialization Parameters structure.
  */
 struct ada4250_init_param {
+	/* Device ID */
+	enum ada4250_id device_id;
 	/* SPI Initialization parameters */
 	struct spi_init_param	*spi_init;
+	/* GPIO Initialization parameters */
+	struct gpio_init_param	*gpio_g2_param;
+	struct gpio_init_param	*gpio_g1_param;
+	struct gpio_init_param	*gpio_g0_param;
+	struct gpio_init_param	*gpio_bufen_param;
 	/* AVDD value in Volts */
 	int32_t avdd_v;
 	/* Reference Buffer Enable */
@@ -169,8 +186,15 @@ struct ada4250_init_param {
  * @brief ADA4250 Device Descriptor.
  */
 struct ada4250_dev {
+	/* Device ID */
+	enum ada4250_id device_id;
 	/* SPI Initialization parameters */
 	struct spi_desc	*spi_desc;
+	/* GPIO Descriptors */
+	struct gpio_desc	*gpio_g2;
+	struct gpio_desc	*gpio_g1;
+	struct gpio_desc	*gpio_g0;
+	struct gpio_desc	*gpio_bufen;
 	/* AVDD value in Volts */
 	int32_t avdd_v;
 	/* Reference Buffer Enable */

--- a/projects/ada4250_ardz/src.mk
+++ b/projects/ada4250_ardz/src.mk
@@ -4,9 +4,11 @@ SRC_DIRS += $(PROJECT)/src
 SRC_DIRS += $(DRIVERS)/amplifiers/ada4250
 
 SRCS += $(PLATFORM_DRIVERS)/spi.c					\
+	$(PLATFORM_DRIVERS)/gpio.c					\
 	$(NO-OS)/util/util.c						\
 
 INCS += $(INCLUDE)/util.h						\
 	$(INCLUDE)/error.h						\
 	$(INCLUDE)/spi.h						\
+	$(INCLUDE)/gpio.h						\
 	$(PLATFORM_DRIVERS)/spi_extra.h

--- a/projects/ada4250_ardz/src/ada4250_ardz.c
+++ b/projects/ada4250_ardz/src/ada4250_ardz.c
@@ -75,6 +75,7 @@ int main()
 	};
 
 	struct ada4250_init_param ada4250_param = {
+		.device_id = ADA4250,
 		.spi_init = &init_param,
 		.refbuf_en = ADA4250_BUF_DISABLE,
 		.bias = ADA4250_BIAS_DISABLE,


### PR DESCRIPTION
Pin strap version of ADA4250.

Gain and Reference buffer are controlled via GPIOs.

Calibration features not available.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>