### PR TITLE
projects: ad9371: fix namings

### DIFF
--- a/projects/ad9371/src/app/headless.c
+++ b/projects/ad9371/src/app/headless.c
@@ -1081,7 +1081,7 @@ int main(void)
 		.size = 0xFFFFFFFF,
 	};
 	iio_axi_adc_get_dev_descriptor(iio_axi_adc_desc, &adc_dev_desc);
-	status = iio_register(iio_app_desc, adc_dev_desc, "cf-ad9361-lpc",
+	status = iio_register(iio_app_desc, adc_dev_desc, "cf-ad9371-lpc",
 			      iio_axi_adc_desc, &read_buff, NULL);
 	if (status < 0)
 		return status;
@@ -1102,7 +1102,7 @@ int main(void)
 		.size = 0xFFFFFFFF,
 	};
 	iio_axi_dac_get_dev_descriptor(iio_axi_dac_desc, &dac_dev_desc);
-	status = iio_register(iio_app_desc, dac_dev_desc, "cf-ad9361-dds-core-lpc",
+	status = iio_register(iio_app_desc, dac_dev_desc, "cf-ad9371-dds-core-lpc",
 			      iio_axi_dac_desc, NULL, &write_buff);
 	if (status < 0)
 		return status;


### PR DESCRIPTION
Change IIO namings `ad9361` -> `ad9371`.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>