### PR TITLE
AD7798/AD7799 updates

### DIFF
--- a/drivers/adc/ad7799/ad7799.c
+++ b/drivers/adc/ad7799/ad7799.c
@@ -367,6 +367,9 @@ int32_t ad7799_init(struct ad7799_dev **device,
 		return FAILURE;
 
 	dev->chip_type = init_param->chip_type;
+	dev->polarity = init_param->polarity;
+	dev->gain = init_param->gain;
+	dev->vref_mv = init_param->vref_mv;
 
 	switch(dev->chip_type) {
 	case ID_AD7798:
@@ -414,12 +417,12 @@ int32_t ad7799_init(struct ad7799_dev **device,
 	}
 
 	/* Initially set gain to 1 */
-	ret = ad7799_set_gain(dev, AD7799_GAIN_1);
+	ret = ad7799_set_gain(dev, dev->gain);
 	if (ret)
 		return FAILURE;
 
 	/* Enable unipolar coding */
-	ret = ad7799_set_polarity(dev, AD7799_UNIPOLAR);
+	ret = ad7799_set_polarity(dev, dev->polarity);
 	if (ret)
 		return FAILURE;
 

--- a/drivers/adc/ad7799/ad7799.h
+++ b/drivers/adc/ad7799/ad7799.h
@@ -43,6 +43,7 @@
 /***************************** Include Files **********************************/
 /******************************************************************************/
 #include <stdint.h>
+#include <stdbool.h>
 #include "spi.h"
 
 /******************************************************************************/
@@ -166,6 +167,12 @@ struct ad7799_dev {
 	uint8_t chip_type;
 	/** Register size */
 	const uint8_t *reg_size;
+	/** Gain */
+	uint8_t gain;
+	/** Unipolar/Bipolar Coding */
+	bool polarity;
+	/** Reference Voltage in mV */
+	uint32_t vref_mv;
 };
 
 /**
@@ -177,6 +184,12 @@ struct ad7799_init_param {
 	struct spi_init_param spi_init;
 	/** Chip type (AD7798/AD7799) */
 	enum ad7799_type chip_type;
+	/** Gain */
+	uint8_t gain;
+	/** Unipolar/Bipolar Coding */
+	bool polarity;
+	/** Reference Voltage in mV */
+	uint32_t vref_mv;
 };
 
 /******************************************************************************/

--- a/drivers/adc/ad7799/ad7799.h
+++ b/drivers/adc/ad7799/ad7799.h
@@ -217,6 +217,10 @@ int32_t ad7799_set_channel(struct ad7799_dev *device, uint8_t ch);
 int32_t ad7799_get_channel(struct ad7799_dev *device, uint8_t ch,
 			   uint32_t *reg_data);
 
+/* Read specific ADC channel in mV. */
+int32_t ad7799_read_channel_mv(struct ad7799_dev *device, uint8_t ch,
+			       int32_t *data_mv);
+
 /* Set the ADC gain. */
 int32_t ad7799_set_gain(struct ad7799_dev *device, uint8_t gain);
 

--- a/drivers/adc/ad7799/iio_ad7799.c
+++ b/drivers/adc/ad7799/iio_ad7799.c
@@ -57,10 +57,9 @@ static ssize_t ad7799_iio_channel_read(void *device, char *buf, size_t len,
 				       const struct iio_ch_info *channel)
 {
 	struct ad7799_dev *dev = (struct ad7799_dev *)device;
-	uint32_t data;
-	int32_t ret;
+	int32_t ret, data;
 
-	ret = ad7799_get_channel(dev, channel->ch_num, &data);
+	ret = ad7799_read_channel_mv(dev, channel->ch_num, &data);
 	if (ret != SUCCESS)
 		return ret;
 

--- a/drivers/adc/ad7799/iio_ad7799.c
+++ b/drivers/adc/ad7799/iio_ad7799.c
@@ -145,9 +145,9 @@ static struct scan_type channel_scan_type = {
 
 /** IIO ADC Channels */
 static struct iio_channel ad7799_iio_channels[] = {
-	AD7799_IIO_CHANN_DEF("ch0", 0),
-	AD7799_IIO_CHANN_DEF("ch1", 1),
-	AD7799_IIO_CHANN_DEF("ch2", 2),
+	AD7799_IIO_CHANN_DEF("channel0", 0),
+	AD7799_IIO_CHANN_DEF("channel1", 1),
+	AD7799_IIO_CHANN_DEF("channel2", 2),
 	END_ATTRIBUTES_ARRAY
 };
 


### PR DESCRIPTION
- expose device attributes
- add function to read adc channel in mV
- update IIO driver

**NOTE:** these updates are required for the CN0548 project using ADUCUP3029, therefore a no-OS submodule sync will be required at: https://github.com/analogdevicesinc/EVAL-ADICUP3029 

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>