### PR TITLE
Ad7746 driver and demo with ad7746-ebz

### DIFF
--- a/drivers/adc/ad7746/ad7746.c
+++ b/drivers/adc/ad7746/ad7746.c
@@ -1,0 +1,508 @@
+/***************************************************************************//**
+ *   @file   ad7746.c
+ *   @brief  Implementation of AD7746 Driver.
+ *   @author Dragos Bogdan (dragos.bogdan@analog.com)
+ *   @author Darius Berghe (darius.berghe@analog.com)
+********************************************************************************
+ * Copyright 2021(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <stdlib.h>
+#include <string.h>
+#include "error.h"
+#include "delay.h"
+#include "ad7746.h"
+
+/***************************************************************************//**
+ * @brief Initialize the ad7606 device structure.
+ *
+ * Performs memory allocation of the device structure.
+ *
+ * @param device     - Pointer to location of device structure to write.
+ * @param init_param - Pointer to the configuration of the driver.
+ * @return ret - return code.
+ *         Example: -ENOMEM - Memory allocation error.
+ *                  -EIO - I2C communication error.
+ *                  SUCCESS - No errors encountered.
+*******************************************************************************/
+int32_t ad7746_init(struct ad7746_dev **device,
+		    struct ad7746_init_param *init_param)
+{
+	int32_t ret;
+	struct ad7746_dev *dev;
+
+	dev = (struct ad7746_dev *)calloc(1, sizeof(struct ad7746_dev));
+	if (!dev)
+		return -ENOMEM;
+
+	ret = i2c_init(&dev->i2c_dev, &init_param->i2c_init);
+	if (ret < 0)
+		goto error_1;
+
+	ret = ad7746_reset(dev);
+	if (ret < 0)
+		goto error_2;
+
+	// the device does not acknowledge for max: 200us after a reset
+	udelay(200);
+
+	ret = ad7746_set_cap(dev, init_param->setup.cap);
+	if (ret < 0)
+		goto error_2;
+
+	ret = ad7746_set_vt(dev, init_param->setup.vt);
+	if (ret < 0)
+		goto error_2;
+
+	ret = ad7746_set_exc(dev, init_param->setup.exc);
+	if (ret < 0)
+		goto error_2;
+
+	ret = ad7746_set_config(dev, init_param->setup.config);
+	if (ret < 0)
+		goto error_2;
+
+	*device = dev;
+
+	return SUCCESS;
+error_2:
+	i2c_remove(dev->i2c_dev);
+error_1:
+	free(dev);
+	return ret;
+}
+
+/***************************************************************************//**
+ * @brief Writes data into AD7746 registers, starting from the selected
+ *        register address pointer.
+ *
+ * @param dev - Device descriptor pointer.
+ * @param reg - The selected register address.
+ * @param data - Pointer to data to transmit.
+ * @param bytes_number - Number of bytes to send (typically 1, other values when using the address auto-increment).
+ *
+ * @return return code.
+ *         Example: -EINVAL - Wrong input values.
+ *                  SUCCESS - No errors encountered.
+*******************************************************************************/
+int32_t ad7746_reg_write(struct ad7746_dev *dev, uint8_t reg,
+			 uint8_t* data, uint16_t bytes_number)
+{
+	if (!data || bytes_number > AD7746_NUM_REGISTERS || reg >= AD7746_NUM_REGISTERS)
+		return -EINVAL;
+
+	dev->buf[0] = reg;
+	memcpy(&dev->buf[1], data, bytes_number);
+
+	return i2c_write(dev->i2c_dev, dev->buf, bytes_number + 1, 1);
+}
+
+/***************************************************************************//**
+ * @brief Reads data from AD7746 registers, starting from the selected
+ *        register address pointer.
+ *
+ * @param dev - Device descriptor pointer.
+ * @param reg - The selected register address pointer.
+ * @param data - Pointer to a buffer that will store the received data.
+ * @param bytes_number - Number of bytes to read (typically 1, other values when using the address auto-increment).
+ *
+ * @return return code.
+ *         Example: -EINVAL - Wrong input values.
+ *                  SUCCESS - No errors encountered.
+*******************************************************************************/
+int32_t ad7746_reg_read(struct ad7746_dev *dev,
+			uint8_t reg,
+			uint8_t* data,
+			uint16_t bytes_number)
+{
+	int32_t ret;
+
+	if (!data || bytes_number > AD7746_NUM_REGISTERS || reg >= AD7746_NUM_REGISTERS)
+		return -EINVAL;
+
+	ret = i2c_write(dev->i2c_dev, &reg, 1, 0);
+	if (ret < 0)
+		return ret;
+
+	return i2c_read(dev->i2c_dev, data, bytes_number, 1);
+}
+
+/***************************************************************************//**
+ * @brief Resets the AD7746.
+ *
+ * @param dev - Device descriptor pointer.
+ * @return return code.
+ *         Example: -EINVAL - Wrong input values.
+ *                  SUCCESS - No errors encountered.
+*******************************************************************************/
+int32_t ad7746_reset(struct ad7746_dev *dev)
+{
+	uint8_t cmd = AD7746_RESET_CMD;
+
+	if (!dev)
+		return -EINVAL;
+
+	return i2c_write(dev->i2c_dev, &cmd, 1, 1);
+}
+
+/***************************************************************************//**
+ * @brief Deinitialize the ad7746 driver and free all allocated resources.
+ *
+ * @param dev - Device descriptor pointer.
+ * @return SUCCESS
+*******************************************************************************/
+int32_t ad7746_remove(struct ad7746_dev *dev)
+{
+	if (!dev)
+		return SUCCESS;
+
+	i2c_remove(dev->i2c_dev);
+	dev->i2c_dev = NULL;
+	free(dev);
+
+	return SUCCESS;
+}
+
+/***************************************************************************//**
+ * @brief Configure the capacitive setup register.
+ *
+ * @param dev - Device descriptor pointer.
+ * @param cap - Capacitive setup settings.
+ *
+ * @return return code.
+ *         Example: -EINVAL - Wrong input values.
+ *                  SUCCESS - No errors encountered.
+*******************************************************************************/
+int32_t ad7746_set_cap(struct ad7746_dev *dev, struct ad7746_cap cap)
+{
+	int32_t ret;
+	uint8_t reg;
+
+	if (!dev)
+		return -EINVAL;
+
+	reg = field_prep(AD7746_CAPSETUP_CAPEN_MSK, cap.capen) |
+	      field_prep(AD7746_CAPSETUP_CIN2_MSK, cap.cin2) |
+	      field_prep(AD7746_CAPSETUP_CAPDIFF_MSK, cap.capdiff) |
+	      field_prep(AD7746_CAPSETUP_CAPCHOP_MSK, cap.capchop);
+
+	ret = ad7746_reg_write(dev, AD7746_REG_CAP_SETUP, &reg, 1);
+	if (ret < 0)
+		return ret;
+
+	dev->setup.cap = cap;
+
+	return SUCCESS;
+}
+
+/***************************************************************************//**
+ * @brief Configure the voltage/temperature setup register.
+ *
+ * @param dev - Device descriptor pointer.
+ * @param vt - Voltage/Temperature setup settings.
+ *
+ * @return return code.
+ *         Example: -EINVAL - Wrong input values.
+ *                  SUCCESS - No errors encountered.
+*******************************************************************************/
+int32_t ad7746_set_vt(struct ad7746_dev *dev, struct ad7746_vt vt)
+{
+	int32_t ret;
+	uint8_t reg;
+
+	if (!dev)
+		return -EINVAL;
+
+	reg = field_prep(AD7746_VTSETUP_VTEN_MSK, vt.vten) |
+	      field_prep(AD7746_VTSETUP_VTMD_MSK, vt.vtmd) |
+	      field_prep(AD7746_VTSETUP_EXTREF_MSK, vt.extref) |
+	      field_prep(AD7746_VTSETUP_VTSHORT_MSK, vt.vtshort) |
+	      field_prep(AD7746_VTSETUP_VTCHOP_MSK, vt.vtchop);
+
+	ret = ad7746_reg_write(dev, AD7746_REG_VT_SETUP, &reg, 1);
+	if (ret < 0)
+		return ret;
+
+	dev->setup.vt = vt;
+
+	return SUCCESS;
+}
+
+/***************************************************************************//**
+ * @brief Configure the excitation setup register.
+ *
+ * @param dev - Device descriptor pointer.
+ * @param exc - Excitation setup settings.
+ *
+ * @return return code.
+ *         Example: -EINVAL - Wrong input values.
+ *                  SUCCESS - No errors encountered.
+*******************************************************************************/
+int32_t ad7746_set_exc(struct ad7746_dev *dev, struct ad7746_exc exc)
+{
+	int32_t ret;
+	uint8_t reg;
+
+	if (!dev)
+		return -EINVAL;
+
+	reg = field_prep(AD7746_EXCSETUP_CLKCTRL_MSK, exc.clkctrl) |
+	      field_prep(AD7746_EXCSETUP_EXCON_MSK, exc.excon) |
+	      field_prep(AD7746_EXCSETUP_EXCB_MSK, exc.excb) |
+	      field_prep(AD7746_EXCSETUP_EXCA_MSK, exc.exca) |
+	      field_prep(AD7746_EXCSETUP_EXCLVL_MSK, exc.exclvl);
+
+	ret = ad7746_reg_write(dev, AD7746_REG_EXC_SETUP, &reg, 1);
+	if (ret < 0)
+		return ret;
+
+	dev->setup.exc = exc;
+
+	return SUCCESS;
+}
+
+/***************************************************************************//**
+ * @brief Set the configuration register.
+ *
+ * @param dev - Device descriptor pointer.
+ * @param config - Configuration register settings.
+ *
+ * @return return code.
+ *         Example: -EINVAL - Wrong input values.
+ *                  SUCCESS - No errors encountered.
+*******************************************************************************/
+int32_t ad7746_set_config(struct ad7746_dev *dev, struct ad7746_config config)
+{
+	int32_t ret;
+	uint8_t reg;
+
+	if (!dev)
+		return -EINVAL;
+
+	reg = field_prep(AD7746_CONF_VTF_MSK, config.vtf) |
+	      field_prep(AD7746_CONF_CAPF_MSK, config.capf) |
+	      field_prep(AD7746_CONF_MD_MSK, config.md);
+
+	ret = ad7746_reg_write(dev, AD7746_REG_CFG, &reg, 1);
+	if (ret < 0)
+		return ret;
+
+	dev->setup.config = config;
+
+	return SUCCESS;
+}
+
+/***************************************************************************//**
+ * @brief Set the DAC code and enable state for EXCA.
+ *
+ * @param dev - Device descriptor pointer.
+ * @param enable - DAC_A Enable.
+ * @param code - DAC_A register code.
+ *
+ * @return return code.
+ *         Example: -EINVAL - Wrong input values.
+ *                  SUCCESS - No errors encountered.
+*******************************************************************************/
+int32_t ad7746_set_cap_dac_a(struct ad7746_dev *dev, bool enable, uint8_t code)
+{
+	uint8_t reg;
+
+	if (!dev)
+		return -EINVAL;
+
+	reg = field_prep(AD7746_CAPDAC_DACEN_MSK, enable) |
+	      field_prep(AD7746_CAPDAC_DACP_MSK, code);
+
+	return ad7746_reg_write(dev, AD7746_REG_CAPDACA, &reg, 1);
+}
+
+/***************************************************************************//**
+ * @brief Set the DAC code and enable state for EXCB.
+ *
+ * @param dev - Device descriptor pointer.
+ * @param enable - DAC_B Enable.
+ * @param code - DAC_B register code.
+ *
+ * @return return code.
+ *         Example: -EINVAL - Wrong input values.
+ *                  SUCCESS - No errors encountered.
+*******************************************************************************/
+int32_t ad7746_set_cap_dac_b(struct ad7746_dev *dev, bool enable, uint8_t code)
+{
+	uint8_t reg;
+
+	if (!dev)
+		return -EINVAL;
+
+	reg = field_prep(AD7746_CAPDAC_DACEN_MSK, enable) |
+	      field_prep(AD7746_CAPDAC_DACP_MSK, code);
+
+	return ad7746_reg_write(dev, AD7746_REG_CAPDACB, &reg, 1);
+}
+
+static inline int32_t _ad7746_write_2byte(struct ad7746_dev *dev, uint8_t reg,
+		uint16_t val)
+{
+	uint8_t buf[2];
+
+	if (!dev)
+		return -EINVAL;
+
+	buf[0] = (uint8_t)(val >> 16);
+	buf[1] = (uint8_t)val;
+
+	return ad7746_reg_write(dev, reg, buf, 2);
+}
+
+/***************************************************************************//**
+ * @brief Set the capacitive offset.
+ *
+ * @param dev - Device descriptor pointer.
+ * @param offset - Offset as raw code.
+ *
+ * @return return code.
+ *         Example: -EINVAL - Wrong input values.
+ *                  SUCCESS - No errors encountered.
+*******************************************************************************/
+int32_t ad7746_set_cap_offset(struct ad7746_dev *dev, uint16_t offset)
+{
+	return _ad7746_write_2byte(dev, AD7746_REG_CAP_OFFH, offset);
+}
+
+/***************************************************************************//**
+ * @brief Set the capacitive gain.
+ *
+ * @param dev - Device descriptor pointer.
+ * @param gain - Gain as raw code.
+ *
+ * @return return code.
+ *         Example: -EINVAL - Wrong input values.
+ *                  SUCCESS - No errors encountered.
+*******************************************************************************/
+int32_t ad7746_set_cap_gain(struct ad7746_dev *dev, uint16_t gain)
+{
+	return _ad7746_write_2byte(dev, AD7746_REG_CAP_GAINH, gain);
+}
+
+/***************************************************************************//**
+ * @brief Set the voltage gain.
+ *
+ * @param dev - Device descriptor pointer.
+ * @param gain - Gain as raw code.
+ *
+ * @return return code.
+ *         Example: -EINVAL - Wrong input values.
+ *                  SUCCESS - No errors encountered.
+*******************************************************************************/
+int32_t ad7746_set_volt_gain(struct ad7746_dev *dev, uint16_t gain)
+{
+	return _ad7746_write_2byte(dev, AD7746_REG_VOLT_GAINH, gain);
+}
+
+/***************************************************************************//**
+ * @brief Waits until a conversion on a voltage/temperature channel has been
+ *        finished and returns the output data.
+ *
+ * @param dev - Device descriptor pointer.
+ * @param vt_data - The content of the VT Data register.
+ *
+ * @return return code.
+ *         Example: -EINVAL - Wrong input values.
+ *                  -EIO - I2C Communication error.
+ *                  SUCCESS - No errors encountered.
+*******************************************************************************/
+int32_t ad7746_get_vt_data(struct ad7746_dev *dev, uint32_t *vt_data)
+{
+	int32_t ret;
+
+	if (!dev || !vt_data)
+		return -EINVAL;
+
+	memset(dev->buf, 0, 3);
+
+	dev->buf[0] = AD7746_STATUS_RDYVT_MSK;
+	while(dev->buf[0] & AD7746_STATUS_RDYVT_MSK) {
+		ret = ad7746_reg_read(dev, AD7746_REG_STATUS, dev->buf, 1);
+		if (ret < 0)
+			return ret;
+	}
+
+	ret = ad7746_reg_read(dev, AD7746_REG_VT_DATA_HIGH, dev->buf, 3);
+	if (ret < 0)
+		return ret;
+
+	*vt_data = ((uint32_t)dev->buf[0] << 16) |
+		   ((uint32_t)dev->buf[1] << 8) |
+		   dev->buf[0];
+
+	return SUCCESS;
+}
+
+/***************************************************************************//**
+ * @brief Waits until a conversion on the capacitive channel has been
+ *        finished and returns the output data.
+ *
+ * @param dev - Device descriptor pointer.
+ * @param cap_data - The content of the Capacitive Data register.
+ *
+ * @return return code.
+ *         Example: -EINVAL - Wrong input values.
+ *                  -EIO - I2C Communication error.
+ *                  SUCCESS - No errors encountered.
+*******************************************************************************/
+int32_t ad7746_get_cap_data(struct ad7746_dev *dev, uint32_t *cap_data)
+{
+	int32_t ret;
+
+	if (!dev || !cap_data)
+		return -EINVAL;
+
+	memset(dev->buf, 0, 3);
+
+	dev->buf[0] = AD7746_STATUS_RDYCAP_MSK;
+	while(dev->buf[0] & AD7746_STATUS_RDYCAP_MSK) {
+		ret = ad7746_reg_read(dev, AD7746_REG_STATUS,	dev->buf, 1);
+		if (ret < 0)
+			return ret;
+	}
+
+	ret = ad7746_reg_read(dev, AD7746_REG_CAP_DATA_HIGH, dev->buf, 3);
+	if (ret < 0)
+		return ret;
+
+	*cap_data = ((uint32_t)dev->buf[0] << 16) |
+		    ((uint32_t)dev->buf[1] << 8) |
+		    dev->buf[0];
+
+	return SUCCESS;
+}

--- a/drivers/adc/ad7746/ad7746.h
+++ b/drivers/adc/ad7746/ad7746.h
@@ -1,0 +1,208 @@
+/***************************************************************************//**
+ *   @file   ad7746.h
+ *   @brief  Header file of AD7746 Driver.
+ *   @author Dragos Bogdan (dragos.bogdan@analog.com)
+ *   @author Darius Berghe (darius.berghe@analog.com)
+********************************************************************************
+ * Copyright 2021(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef _AD7746_H_
+#define _AD7746_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "util.h"
+#include "i2c.h"
+
+/* AD7746 Slave Address */
+#define AD7746_ADDRESS			0x48
+
+/* AD7746 Reset command */
+#define AD7746_RESET_CMD		0xBF
+
+/* AD7746 Register Definition */
+#define AD7746_REG_STATUS		0u
+#define AD7746_REG_CAP_DATA_HIGH	1u
+#define AD7746_REG_CAP_DATA_MID		2u
+#define AD7746_REG_CAP_DATA_LOW		3u
+#define AD7746_REG_VT_DATA_HIGH		4u
+#define AD7746_REG_VT_DATA_MID		5u
+#define AD7746_REG_VT_DATA_LOW		6u
+#define AD7746_REG_CAP_SETUP		7u
+#define AD7746_REG_VT_SETUP		8u
+#define AD7746_REG_EXC_SETUP		9u
+#define AD7746_REG_CFG			10u
+#define AD7746_REG_CAPDACA		11u
+#define AD7746_REG_CAPDACB		12u
+#define AD7746_REG_CAP_OFFH		13u
+#define AD7746_REG_CAP_OFFL		14u
+#define AD7746_REG_CAP_GAINH		15u
+#define AD7746_REG_CAP_GAINL		16u
+#define AD7746_REG_VOLT_GAINH		17u
+#define AD7746_REG_VOLT_GAINL		18u
+
+#define AD7746_NUM_REGISTERS		(AD7746_REG_VOLT_GAINL + 1u)
+
+/* AD7746_REG_STATUS bits */
+#define AD7746_STATUS_EXCERR_MSK	BIT(3)
+#define AD7746_STATUS_RDY_MSK		BIT(2)
+#define AD7746_STATUS_RDYVT_MSK		BIT(1)
+#define AD7746_STATUS_RDYCAP_MSK	BIT(0)
+
+/* AD7746_REG_CAP_SETUP bits */
+#define AD7746_CAPSETUP_CAPEN_MSK	BIT(7)
+#define AD7746_CAPSETUP_CIN2_MSK	BIT(6)
+#define AD7746_CAPSETUP_CAPDIFF_MSK	BIT(5)
+#define AD7746_CAPSETUP_CAPCHOP_MSK	BIT(0)
+
+/* AD7746_REG_VT_SETUP bits */
+#define AD7746_VTSETUP_VTEN_MSK		BIT(7)
+#define AD7746_VTSETUP_VTMD_MSK		GENMASK(6,5)
+#define AD7746_VTSETUP_EXTREF_MSK	BIT(4)
+#define AD7746_VTSETUP_VTSHORT_MSK	BIT(1)
+#define AD7746_VTSETUP_VTCHOP_MSK	BIT(0)
+
+/* AD7746_REG_EXC_SETUP bits */
+#define AD7746_EXCSETUP_CLKCTRL_MSK	BIT(7)
+#define AD7746_EXCSETUP_EXCON_MSK	BIT(6)
+#define AD7746_EXCSETUP_EXCB_MSK	GENMASK(5,4)
+#define AD7746_EXCSETUP_EXCA_MSK	GENMASK(3,2)
+#define AD7746_EXCSETUP_EXCLVL_MSK	GENMASK(1,0)
+
+/* AD7746_REG_CFG bits */
+#define AD7746_CONF_VTF_MSK		GENMASK(7,6)
+#define AD7746_CONF_CAPF_MSK		GENMASK(5,3)
+#define AD7746_CONF_MD_MSK		GENMASK(2,0)
+
+/* AD7746_REG_CAPDACx bits */
+#define AD7746_CAPDAC_DACEN_MSK		BIT(7)
+#define AD7746_CAPDAC_DACP_MSK		GENMASK(6,0)
+
+struct ad7746_cap {
+	bool capen;
+	bool cin2;
+	bool capdiff;
+	bool capchop;
+};
+
+enum ad7746_vtmd {
+	AD7746_VTMD_INT_TEMP,
+	AD7746_VTMD_EXT_TEMP,
+	AD7746_VTMD_VDD_MON,
+	AD7746_VIN_EXT_VIN
+};
+
+struct ad7746_vt {
+	bool vten;
+	enum ad7746_vtmd vtmd;
+	bool extref;
+	bool vtshort;
+	bool vtchop;
+};
+
+enum ad7746_exc_pin {
+	AD7746_EXC_PIN_DISABLED,
+	AD7746_EXC_PIN_INVERTED,
+	AD7746_EXC_PIN_NORMAL
+};
+
+enum ad7746_exclvl {
+	AD7746_EXCLVL_1_DIV_8,
+	AD7746_EXCLVL_2_DIV_8,
+	AD7746_EXCLVL_3_DIV_8,
+	AD7746_EXCLVL_4_DIV_8
+};
+
+struct ad7746_exc {
+	bool clkctrl;
+	bool excon;
+	enum ad7746_exc_pin excb;
+	enum ad7746_exc_pin exca;
+	enum ad7746_exclvl exclvl;
+};
+
+enum ad7746_md {
+	AD7746_MODE_IDLE,
+	AD7746_MODE_CONT,
+	AD7746_MODE_SINGLE,
+	AD7746_MODE_POWERDOWN,
+	AD7746_MODE_OFFSET_CALIB = 5,
+	AD7746_MODE_GAIN_CALIB
+};
+
+struct ad7746_config {
+	uint8_t vtf;
+	uint8_t capf;
+	enum ad7746_md md;
+};
+
+struct ad7746_setup {
+	struct ad7746_cap cap;
+	struct ad7746_vt vt;
+	struct ad7746_exc exc;
+	struct ad7746_config config;
+};
+
+struct ad7746_init_param {
+	struct i2c_init_param i2c_init;
+	struct ad7746_setup setup;
+};
+
+struct ad7746_dev {
+	i2c_desc *i2c_dev;
+	uint8_t buf[AD7746_NUM_REGISTERS + 1u];
+	struct ad7746_setup setup;
+};
+
+int32_t ad7746_init(struct ad7746_dev **device,
+		    struct ad7746_init_param *init_param);
+int32_t ad7746_reg_write(struct ad7746_dev *dev, uint8_t reg,
+			 uint8_t* data, uint16_t bytes_number);
+int32_t ad7746_reg_read(struct ad7746_dev *dev, uint8_t reg,
+			uint8_t* data, uint16_t bytes_number);
+int32_t ad7746_reset(struct ad7746_dev *dev);
+int32_t ad7746_remove(struct ad7746_dev *dev);
+int32_t ad7746_set_cap(struct ad7746_dev *dev, struct ad7746_cap cap);
+int32_t ad7746_set_vt(struct ad7746_dev *dev, struct ad7746_vt vt);
+int32_t ad7746_set_exc(struct ad7746_dev *dev, struct ad7746_exc exc);
+int32_t ad7746_set_config(struct ad7746_dev *dev, struct ad7746_config config);
+int32_t ad7746_set_cap_dac_a(struct ad7746_dev *dev, bool enable, uint8_t code);
+int32_t ad7746_set_cap_dac_b(struct ad7746_dev *dev, bool enable, uint8_t code);
+int32_t ad7746_set_cap_offset(struct ad7746_dev *dev, uint16_t offset);
+int32_t ad7746_set_cap_gain(struct ad7746_dev *dev, uint16_t gain);
+int32_t ad7746_set_volt_gain(struct ad7746_dev *dev, uint16_t gain);
+int32_t ad7746_get_vt_data(struct ad7746_dev *dev, uint32_t *vt_data);
+int32_t ad7746_get_cap_data(struct ad7746_dev *dev, uint32_t *cap_data);
+
+#endif // _AD7746_H

--- a/projects/ad7746-ebz/Makefile
+++ b/projects/ad7746-ebz/Makefile
@@ -1,0 +1,5 @@
+include ../../tools/scripts/generic_variables.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/ad7746-ebz/builds.json
+++ b/projects/ad7746-ebz/builds.json
@@ -1,0 +1,7 @@
+{
+  "aducm3029": {
+    "ruler_demo": {
+      "flags" : ""
+    }
+  }
+}

--- a/projects/ad7746-ebz/pinmux_config.c
+++ b/projects/ad7746-ebz/pinmux_config.c
@@ -1,0 +1,45 @@
+/*
+ **
+ ** Source file generated on April 5, 2021 at 10:17:10.
+ **
+ ** Copyright (C) 2011-2021 Analog Devices Inc., All Rights Reserved.
+ **
+ ** This file is generated automatically based upon the options selected in
+ ** the Pin Multiplexing configuration editor. Changes to the Pin Multiplexing
+ ** configuration should be made by changing the appropriate options rather
+ ** than editing this file.
+ **
+ ** Selected Peripherals
+ ** --------------------
+ ** I2C0 (SCL0, SDA0)
+ ** UART0 (Tx, Rx, UART_SOUT_EN)
+ **
+ ** GPIO (unavailable)
+ ** ------------------
+ ** P0_04, P0_05, P0_10, P0_11, P0_12
+ */
+
+#include <sys/platform.h>
+#include <stdint.h>
+
+#define I2C0_SCL0_PORTP0_MUX  ((uint16_t) ((uint16_t) 1<<8))
+#define I2C0_SDA0_PORTP0_MUX  ((uint16_t) ((uint16_t) 1<<10))
+#define UART0_TX_PORTP0_MUX  ((uint32_t) ((uint32_t) 1<<20))
+#define UART0_RX_PORTP0_MUX  ((uint32_t) ((uint32_t) 1<<22))
+#define UART0_UART_SOUT_EN_PORTP0_MUX  ((uint32_t) ((uint32_t) 3<<24))
+
+int32_t adi_initpinmux(void);
+
+/*
+ * Initialize the Port Control MUX Registers
+ */
+int32_t adi_initpinmux(void)
+{
+	/* PORTx_MUX registers */
+	*((volatile uint32_t *)REG_GPIO0_CFG) = I2C0_SCL0_PORTP0_MUX |
+						I2C0_SDA0_PORTP0_MUX
+						| UART0_TX_PORTP0_MUX | UART0_RX_PORTP0_MUX | UART0_UART_SOUT_EN_PORTP0_MUX;
+
+	return 0;
+}
+

--- a/projects/ad7746-ebz/src.mk
+++ b/projects/ad7746-ebz/src.mk
@@ -1,0 +1,31 @@
+SRCS += $(NO-OS)/util/util.c \
+	$(PLATFORM_DRIVERS)/delay.c \
+	$(PLATFORM_DRIVERS)/timer.c \
+	$(PLATFORM_DRIVERS)/i2c.c \
+	$(PLATFORM_DRIVERS)/irq.c \
+	$(PLATFORM_DRIVERS)/uart.c \
+	$(PLATFORM_DRIVERS)/uart_stdio.c \
+	$(PLATFORM_DRIVERS)/rtc.c \
+	$(PLATFORM_DRIVERS)/platform_init.c \
+	$(DRIVERS)/adc/ad7746/ad7746.c \
+	$(PROJECT)/src/app/headless.c
+
+INCS +=	$(INCLUDE)/uart.h \
+	$(INCLUDE)/util.h \
+	$(INCLUDE)/delay.h \
+	$(INCLUDE)/timer.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/irq.h \
+	$(INCLUDE)/gpio.h \
+	$(INCLUDE)/rtc.h \
+	$(INCLUDE)/i2c.h \
+	$(INCLUDE)/print_log.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/timer_extra.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/uart_stdio.h \
+	$(PLATFORM_DRIVERS)/rtc_extra.h \
+	$(PLATFORM_DRIVERS)/platform_init.h \
+	$(DRIVERS)/adc/ad7746/ad7746.h \
+	$(PROJECT)/src/app/parameters.h
+

--- a/projects/ad7746-ebz/src/app/headless.c
+++ b/projects/ad7746-ebz/src/app/headless.c
@@ -1,0 +1,187 @@
+/***************************************************************************//**
+* @file headless.c
+* @brief AD7746-EBZ demo project main file.
+* @author Darius Berghe (darius.berghe@analog.com)
+********************************************************************************
+* Copyright 2021(c) Analog Devices, Inc.
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+* - Redistributions of source code must retain the above copyright
+* notice, this list of conditions and the following disclaimer.
+* - Redistributions in binary form must reproduce the above copyright
+* notice, this list of conditions and the following disclaimer in
+* the documentation and/or other materials provided with the
+* distribution.
+* - Neither the name of Analog Devices, Inc. nor the names of its
+* contributors may be used to endorse or promote products derived
+* from this software without specific prior written permission.
+* - The use of this software may or may not infringe the patent rights
+* of one or more patent holders. This license does not release you
+* from the requirement that you obtain separate licenses from these
+* patent holders to use this software.
+* - Use of the software either in source or binary form, must be run
+* on or directly connected to an Analog Devices Inc. component.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <sys/platform.h>
+#include "adi_initialize.h"
+#include <drivers/pwr/adi_pwr.h>
+
+#include "ad7746.h"
+#include "i2c.h"
+#include "delay.h"
+#include "print_log.h"
+#include "uart.h"
+#include "uart_extra.h"
+#include "uart_stdio.h"
+#include "platform_init.h"
+#include "parameters.h"
+
+int main(void)
+{
+	int32_t ret;
+	char input[10];
+	uint32_t capData = 0;
+	uint32_t min = 0;
+	uint32_t max = 0;
+	uint32_t mm = 0;
+	uint32_t temperature = 0;
+	struct ad7746_init_param adcip;
+	struct ad7746_dev *adc = NULL;
+
+	struct uart_desc *uart;
+	struct aducm_uart_init_param xuip = {
+		.parity = UART_NO_PARITY,
+		.stop_bits = UART_ONE_STOPBIT,
+		.word_length = UART_WORDLEN_8BITS
+	};
+	struct uart_init_param uip = {
+		.device_id = UART_DEVICE,
+		.baud_rate = UART_BAUDRATE,
+		.size = UART_CS_8,
+		.parity = UART_PAR_NO,
+		.stop = UART_STOP_1,
+		.extra = &xuip,
+	};
+
+	ret = platform_init();
+	if (ret < 0)
+		goto error;
+	ret = uart_init(&uart, &uip);
+	if (ret < 0)
+		goto error;
+
+	init_uart_stdio(uart);
+
+	adcip.i2c_init = (struct i2c_init_param) {
+		.max_speed_hz = I2C_SPEED,
+		.slave_address = AD7746_ADDRESS,
+	};
+	adcip.setup = (struct ad7746_setup) {
+		.cap = {
+			.capen = true,
+			.cin2 = true,
+			.capdiff = false,
+			.capchop = true
+		},
+		.vt = {
+			.vten = true,
+			.vtmd = AD7746_VTMD_INT_TEMP,
+			.extref = false,
+			.vtshort = false,
+			.vtchop = true
+		},
+		.exc = {
+			.clkctrl = false,
+			.excon = false,
+			.excb = AD7746_EXC_PIN_DISABLED,
+			.exca = AD7746_EXC_PIN_NORMAL,
+			.exclvl = AD7746_EXCLVL_4_DIV_8
+		},
+		.config = {
+			.vtf = 0,
+			.capf = 0,
+			.md = AD7746_MODE_CONT
+		}
+	};
+
+	pr_info("Hello!\n");
+
+	ret = ad7746_init(&adc, &adcip);
+	if (ret < 0) {
+		pr_err("AD7746 initialization failed with: %d\n", ret);
+		goto error;
+	}
+	pr_info("[INIT] AD7746 initialization ok.\n");
+
+	ret = ad7746_set_cap_dac_a(adc, true, 0x42);
+	if (ret < 0) {
+		pr_err("DACA setting failed with: %d\n", ret);
+		goto error;
+	}
+
+	pr_info("[CALIB] 1. Remove the ruler and press ENTER. ");
+	fflush(stdout);
+	scanf("%s", input);
+	ret = ad7746_get_cap_data(adc, &min);
+	if (ret < 0) {
+		pr_err("CAP reading failed with: %d\n", ret);
+		goto error;
+	}
+
+	pr_info("[CALIB] 2. Place ruler to 51mm (2inch) and press ENTER.");
+	fflush(stdout);
+	scanf("%s", input);
+	ret = ad7746_get_cap_data(adc, &max);
+	if (ret < 0) {
+		pr_err("CAP reading failed with: %d\n", ret);
+		goto error;
+	}
+
+	mm = (max - min) / 51;
+
+	pr_info("[DEMO] Move the ruler around, its position will is read and displayed every 2 seconds.\n");
+	while(true) {
+		ret = ad7746_get_cap_data(adc, &capData);
+		if (ret < 0) {
+			pr_err("CAP reading failed with: %d\n", ret);
+			goto error;
+		}
+
+		capData -= min;
+		capData /= mm;
+
+		ret = ad7746_get_vt_data(adc, &temperature);
+		if (ret < 0) {
+			pr_err("CAP reading failed with: %d\n", ret);
+			goto error;
+		}
+		temperature /= 2048;
+		temperature -= 4096;
+
+		pr_info("Position: %d mm, Temperature: %d *C\n", capData, temperature);
+
+		mdelay(2000);
+	}
+
+error:
+	pr_info("Bye!\n");
+	return 0;
+}

--- a/projects/ad7746-ebz/src/app/parameters.h
+++ b/projects/ad7746-ebz/src/app/parameters.h
@@ -1,0 +1,46 @@
+/***************************************************************************//**
+* @file parameters.h
+* @brief Configuration parameters for AD7746-EBZ demo project.
+* @author Darius Berghe (darius.berghe@analog.com)
+********************************************************************************
+* Copyright 2021(c) Analog Devices, Inc.
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+* - Redistributions of source code must retain the above copyright
+* notice, this list of conditions and the following disclaimer.
+* - Redistributions in binary form must reproduce the above copyright
+* notice, this list of conditions and the following disclaimer in
+* the documentation and/or other materials provided with the
+* distribution.
+* - Neither the name of Analog Devices, Inc. nor the names of its
+* contributors may be used to endorse or promote products derived
+* from this software without specific prior written permission.
+* - The use of this software may or may not infringe the patent rights
+* of one or more patent holders. This license does not release you
+* from the requirement that you obtain separate licenses from these
+* patent holders to use this software.
+* - Use of the software either in source or binary form, must be run
+* on or directly connected to an Analog Devices Inc. component.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PARAMETERS_H
+#define __PARAMETERS_H
+
+#define UART_DEVICE	0
+#define UART_BAUDRATE	115200
+#define I2C_SPEED	100000
+
+#endif


### PR DESCRIPTION
Based on the work of @dbogdan  here:
https://wiki.analog.com/resources/tools-software/uc-drivers/renesas/ad7746?s[]=ad7746

Basically, the driver had a facelift and is now compatible with no-OS.
The demo project was translated to work over simple UART.

The demo is not functional on ADUCM now because scanf is broken on ADUCM. Once that gets fixed, demo will work out of the box.

This PR also depends on #1006 to work properly due to a bug in aducm/i2c implementation.

Here's what the demo prints over UART:
```
[INIT] AD7746 initialization ok.
[CALIB] 1. Remove the ruler and press ENTER. 
[CALIB] 2. Place ruler to 51mm (2inch) and press ENTER.
[DEMO] Move the ruler around, its position will is read and displayed every 2 seconds.
Position: 51 mm, Temperature: 23 *C
Position: 50 mm, Temperature: 23 *C
Position: 67 mm, Temperature: 23 *C
Position: 67 mm, Temperature: 23 *C
Position: 67 mm, Temperature: 23 *C
Position: 67 mm, Temperature: 23 *C
Position: 67 mm, Temperature: 23 *C
Position: 47 mm, Temperature: 23 *C
Position: 37 mm, Temperature: 23 *C
Position: 34 mm, Temperature: 23 *C
Position: 34 mm, Temperature: 23 *C
Position: 27 mm, Temperature: 23 *C
Position: 27 mm, Temperature: 23 *C
```

And a pic of the ruler slider and hardware:
![signal-2021-04-08-134541](https://user-images.githubusercontent.com/8933663/114014084-e58e4f00-9870-11eb-8f40-e08829606d1e.jpeg)

