### PR TITLE
Iio app message

### DIFF
--- a/libraries/iio/iio.c
+++ b/libraries/iio/iio.c
@@ -1225,10 +1225,7 @@ ssize_t iio_init(struct iio_desc **desc, struct iio_init_param *init_param)
 
 	ldesc->phy_type = init_param->phy_type;
 	if (init_param->phy_type == USE_UART) {
-		ret = uart_init((struct uart_desc **)&ldesc->uart_desc,
-				init_param->uart_init_param);
-		if (IS_ERR_VALUE(ret))
-			goto free_desc;
+		ldesc->uart_desc = init_param->uart_desc;
 	}
 #ifdef ENABLE_IIO_NETWORK
 	else if (init_param->phy_type == USE_NETWORK) {
@@ -1274,10 +1271,8 @@ ssize_t iio_init(struct iio_desc **desc, struct iio_init_param *init_param)
 free_list:
 	list_remove(ldesc->interfaces_list);
 free_pylink:
-	if (ldesc->phy_type == USE_UART)
-		uart_remove(ldesc->uart_desc);
 #ifdef ENABLE_IIO_NETWORK
-	else {
+	if (ldesc->phy_type == USE_NETWORK) {
 		socket_remove(ldesc->server);
 		if (ldesc->sockets)
 			cb_remove(ldesc->sockets);

--- a/libraries/iio/iio.h
+++ b/libraries/iio/iio.h
@@ -67,9 +67,9 @@ struct iio_desc;
 struct iio_init_param {
 	enum pysical_link_type	phy_type;
 	union {
-		struct uart_init_param		*uart_init_param;
+		struct uart_desc *uart_desc;
 #ifdef ENABLE_IIO_NETWORK
-		struct tcp_socket_init_param	*tcp_socket_init_param;
+		struct tcp_socket_init_param *tcp_socket_init_param;
 #endif
 	};
 };

--- a/projects/ad469x_fmcz/src/ad469x_fmcz.c
+++ b/projects/ad469x_fmcz/src/ad469x_fmcz.c
@@ -220,6 +220,7 @@ int main()
 		return ret;
 
 #ifdef IIO_SUPPORT
+	struct uart_desc *uart_desc;
 	struct iio_desc *iio_app_desc;
 	struct xil_irq_init_param xil_irq_init_par = {
 		.type = IRQ_PS,
@@ -242,9 +243,14 @@ int main()
 		.device_id = UART_DEVICE_ID,
 		.extra = &xil_uart_init_par,
 	};
+
+	ret = uart_init(&uart_desc, &uart_init_par);
+	if (ret < 0)
+		return ret;
+
 	struct iio_init_param iio_init_par = {
 		.phy_type = USE_UART,
-		.uart_init_param = &uart_init_par,
+		.uart_desc = uart_desc,
 	};
 
 	ret = irq_global_enable(irq_desc);

--- a/projects/ad6676-ebz/src/app_iio.c
+++ b/projects/ad6676-ebz/src/app_iio.c
@@ -76,6 +76,7 @@ struct iio_data_buffer g_read_buff = {
 int32_t iio_app_start(struct iio_axi_adc_init_param *adc_init)
 {
 	int32_t status;
+	struct uart_desc *uart_desc;
 
 #ifndef PLATFORM_MB
 	struct xil_irq_init_param xil_irq_init_param = {
@@ -105,9 +106,14 @@ int32_t iio_app_start(struct iio_axi_adc_init_param *adc_init)
 		.device_id = UART_DEVICE_ID,
 		.extra = &xil_uart_init_par,
 	};
+
+	status = uart_init(&uart_desc, &uart_init_par);
+	if (status < 0)
+		return status;
+
 	struct iio_init_param iio_init_par = {
 		.phy_type = USE_UART,
-		.uart_init_param = &uart_init_par,
+		.uart_desc = uart_desc,
 	};
 	struct iio_device *adc_dev_desc;
 	struct iio_desc *iio_desc;

--- a/projects/ad7768-evb/src/app_iio.c
+++ b/projects/ad7768-evb/src/app_iio.c
@@ -68,6 +68,7 @@ struct iio_data_buffer g_read_buff = {
 int32_t iio_app_start(struct iio_axi_adc_init_param *adc_init)
 {
 	int32_t status;
+	struct uart_desc *uart_desc;
 
 	struct xil_irq_init_param xil_irq_init_param = {
 		.type = IRQ_PS,
@@ -96,9 +97,14 @@ int32_t iio_app_start(struct iio_axi_adc_init_param *adc_init)
 	struct iio_axi_adc_desc *iio_axi_adc_desc;
 	struct iio_device *dev_desc;
 	struct iio_desc *iio;
+
+	status = uart_init(&uart_desc, &uart_init_par);
+	if (status < 0)
+		return status;
+
 	struct iio_init_param iio_init_par = {
 		.phy_type = USE_UART,
-		.uart_init_param = &uart_init_par
+		.uart_desc = uart_desc
 	};
 
 	status = irq_global_enable(irq_desc);

--- a/projects/ad9081/src/app_iio.c
+++ b/projects/ad9081/src/app_iio.c
@@ -73,6 +73,7 @@ static struct iio_data_buffer g_write_buff = {
 int32_t iio_server_init(struct iio_axi_adc_init_param *adc_init,
 			struct iio_axi_dac_init_param *dac_init)
 {
+	struct uart_desc *uart_desc;
 	struct xil_uart_init_param xil_uart_init_par = {
 #ifdef PLATFORM_MB
 		.type = UART_PL,
@@ -94,8 +95,12 @@ int32_t iio_server_init(struct iio_axi_adc_init_param *adc_init,
 	struct iio_device *adc_dev_desc, *dac_dev_desc;
 	int32_t status;
 
+	status = uart_init(&uart_desc, &uart_init_par);
+	if (status < 0)
+		return status;
+
 	iio_init_par.phy_type = USE_UART;
-	iio_init_par.uart_init_param = &uart_init_par;
+	iio_init_par.uart_desc = uart_desc;
 	status = iio_init(&iio_app_desc, &iio_init_par);
 	if (status < 0)
 		return status;

--- a/projects/ad9265-fmc-125ebz/src/app_iio.c
+++ b/projects/ad9265-fmc-125ebz/src/app_iio.c
@@ -68,6 +68,7 @@ struct iio_data_buffer g_read_buff = {
 int32_t iio_app_start(struct iio_axi_adc_init_param *adc_init)
 {
 	int32_t status;
+	struct uart_desc *uart_desc;
 
 	struct xil_irq_init_param xil_irq_init_param = {
 		.type = IRQ_PS,
@@ -96,9 +97,14 @@ int32_t iio_app_start(struct iio_axi_adc_init_param *adc_init)
 	struct iio_axi_adc_desc *iio_axi_adc_desc;
 	struct iio_device *dev_desc;
 	struct iio_desc *iio;
+
+	status = uart_init(&uart_desc, &uart_init_par);
+	if (status < 0)
+		return status;
+
 	struct iio_init_param iio_init_par = {
 		.phy_type = USE_UART,
-		.uart_init_param = &uart_init_par
+		.uart_desc = uart_desc
 	};
 
 	status = irq_global_enable(irq_desc);

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -789,6 +789,7 @@ int main(void)
 	 * Initialization for UART.
 	 */
 	struct uart_init_param uart_init_par;
+	struct uart_desc *uart_desc;
 
 	status = irq_ctrl_init(&irq_desc, &irq_init_param);
 	if(status < 0)
@@ -814,8 +815,12 @@ int main(void)
 	if(status < 0)
 		return status;
 
+	status = uart_init(&uart_desc, &uart_init_par);
+	if (status < 0)
+		return status;
+
 	iio_init_par.phy_type = USE_UART;
-	iio_init_par.uart_init_param = &uart_init_par;
+	iio_init_par.uart_desc = uart_desc;
 	status = iio_init(&iio_app_desc, &iio_init_par);
 	if(status < 0)
 		return status;

--- a/projects/ad9371/src/app/headless.c
+++ b/projects/ad9371/src/app/headless.c
@@ -1016,6 +1016,7 @@ int main(void)
 	 * Initialization for UART.
 	 */
 	struct uart_init_param uart_init_par;
+	struct uart_desc *uart_desc;
 
 	struct iio_device *adc_dev_desc, *dac_dev_desc;
 
@@ -1043,8 +1044,12 @@ int main(void)
 	if(status < 0)
 		return status;
 
+	status = uart_init(&uart_desc, &uart_init_par);
+	if (status < 0)
+		return status;
+
 	iio_init_par.phy_type = USE_UART;
-	iio_init_par.uart_init_param = &uart_init_par;
+	iio_init_par.uart_desc = uart_desc;
 	status = iio_init(&iio_app_desc, &iio_init_par);
 	if(status < 0)
 		return status;

--- a/projects/ad9434-fmc-500ebz/src/app_iio.c
+++ b/projects/ad9434-fmc-500ebz/src/app_iio.c
@@ -67,6 +67,7 @@ struct iio_data_buffer g_read_buff = {
 int32_t iio_app_start(struct iio_axi_adc_init_param *adc_init)
 {
 	int32_t status;
+	struct uart_desc *uart_desc;
 
 	struct xil_irq_init_param xil_irq_init_param = {
 		.type = IRQ_PS,
@@ -95,9 +96,14 @@ int32_t iio_app_start(struct iio_axi_adc_init_param *adc_init)
 	struct iio_axi_adc_desc *iio_axi_adc_desc;
 	struct iio_device *dev_desc;
 	struct iio_desc *iio;
+
+	status = uart_init(&uart_desc, &uart_init_par);
+	if (status < 0)
+		return status;
+
 	struct iio_init_param iio_init_par = {
 		.phy_type = USE_UART,
-		.uart_init_param = &uart_init_par
+		.uart_desc = uart_desc
 	};
 
 	status = irq_global_enable(irq_desc);

--- a/projects/ad9467/src/app/app_iio.c
+++ b/projects/ad9467/src/app/app_iio.c
@@ -71,7 +71,7 @@ struct iio_data_buffer g_read_buff = {
 int32_t iio_app_start(struct iio_axi_adc_init_param *adc_init)
 {
 	int32_t status;
-
+	struct uart_desc *uart_desc;
 #ifndef PLATFORM_MB
 	struct xil_irq_init_param xil_irq_init_param = {
 		.type = IRQ_PS,
@@ -105,9 +105,14 @@ int32_t iio_app_start(struct iio_axi_adc_init_param *adc_init)
 	struct iio_axi_adc_desc *iio_axi_adc_desc;
 	struct iio_device *dev_desc;
 	struct iio_desc *iio;
+
+	status = uart_init(&uart_desc, &uart_init_par);
+	if (status < 0)
+		return status;
+
 	struct iio_init_param iio_init_par = {
 		.phy_type = USE_UART,
-		.uart_init_param = &uart_init_par
+		.uart_desc = uart_desc
 	};
 
 #ifndef PLATFORM_MB

--- a/projects/ad9656_fmc/src/app/app_iio.c
+++ b/projects/ad9656_fmc/src/app/app_iio.c
@@ -68,6 +68,7 @@ struct iio_data_buffer g_read_buff = {
 int32_t iio_app_start(struct iio_axi_adc_init_param *adc_init)
 {
 	int32_t status;
+	struct uart_desc *uart_desc;
 
 	struct xil_irq_init_param xil_irq_init_param = {
 		.type = IRQ_PS,
@@ -96,9 +97,14 @@ int32_t iio_app_start(struct iio_axi_adc_init_param *adc_init)
 	struct iio_axi_adc_desc *iio_axi_adc_desc;
 	struct iio_device *dev_desc;
 	struct iio_desc *iio;
+
+	status = uart_init(&uart_desc, &uart_init_par);
+	if (status < 0)
+		return status;
+
 	struct iio_init_param iio_init_par = {
 		.phy_type = USE_UART,
-		.uart_init_param = &uart_init_par
+		.uart_desc = uart_desc
 	};
 
 	status = irq_global_enable(irq_desc);

--- a/projects/ad9739a-fmc-ebz/src/app_iio.c
+++ b/projects/ad9739a-fmc-ebz/src/app_iio.c
@@ -67,6 +67,7 @@ struct iio_data_buffer g_read_buff = {
 int32_t iio_app_start(struct iio_axi_dac_init_param *dac_init)
 {
 	int32_t status;
+	struct uart_desc *uart_desc;
 
 	struct xil_irq_init_param xil_irq_init_param = {
 		.type = IRQ_PS,
@@ -95,9 +96,14 @@ int32_t iio_app_start(struct iio_axi_dac_init_param *dac_init)
 	struct iio_axi_dac_desc *iio_axi_dac_desc;
 	struct iio_device *dev_desc;
 	struct iio_desc *iio;
+
+	status = uart_init(&uart_desc, &uart_init_par);
+	if (status < 0)
+		return status;
+
 	struct iio_init_param iio_init_par = {
 		.phy_type = USE_UART,
-		.uart_init_param = &uart_init_par
+		.uart_desc = uart_desc
 	};
 
 	status = irq_global_enable(irq_desc);

--- a/projects/adrv9001/src/app/app_iio.c
+++ b/projects/adrv9001/src/app/app_iio.c
@@ -74,6 +74,7 @@ int32_t iio_server_init(struct iio_axi_adc_init_param *adc1_init,
 			struct iio_axi_dac_init_param *dac1_init,
 			struct iio_axi_dac_init_param *dac2_init)
 {
+	struct uart_desc *uart_desc;
 	struct irq_ctrl_desc *irq_desc;
 	struct xil_irq_init_param xil_irq_init_par = {
 		.type = IRQ_PS,
@@ -108,8 +109,12 @@ int32_t iio_server_init(struct iio_axi_adc_init_param *adc1_init,
 	if (status < 0)
 		return status;
 
+	status = uart_init(&uart_desc, &uart_init_par);
+	if (status < 0)
+		return status;
+
 	iio_init_par.phy_type = USE_UART;
-	iio_init_par.uart_init_param = &uart_init_par;
+	iio_init_par.uart_desc = uart_desc;
 	status = iio_init(&iio_desc, &iio_init_par);
 	if (status < 0)
 		return status;

--- a/projects/adxrs290-pmdz/src.mk
+++ b/projects/adxrs290-pmdz/src.mk
@@ -18,12 +18,7 @@ ifeq (y,$(strip $(ENABLE_IIO_NETWORK)))
 DISABLE_SECURE_SOCKET ?= y
 SRC_DIRS += $(NO-OS)/network
 SRCS	 += $(NO-OS)/util/circular_buffer.c
-SRCS	 += $(PLATFORM_DRIVERS)/delay.c
-SRCS	 += $(PLATFORM_DRIVERS)/timer.c
-INCS	 += $(INCLUDE)/delay.h
-INCS	 += $(INCLUDE)/timer.h
 INCS	 += $(INCLUDE)/circular_buffer.h
-INCS	 += $(PLATFORM_DRIVERS)/timer_extra.h
 endif
 
 
@@ -33,15 +28,19 @@ SRCS += $(PLATFORM_DRIVERS)/uart.c					\
 	$(PLATFORM_DRIVERS)/irq.c					\
 	$(PLATFORM_DRIVERS)/gpio.c					\
 	$(PLATFORM_DRIVERS)/spi.c					\
+	$(PLATFORM_DRIVERS)/delay.c					\
+	$(PLATFORM_DRIVERS)/timer.c					\
 	$(NO-OS)/util/list.c						\
 	$(NO-OS)/util/fifo.c						\
 	$(NO-OS)/util/util.c						\
 
-INCS += $(INCLUDE)/fifo.h					\
+INCS += $(INCLUDE)/fifo.h						\
 	$(INCLUDE)/irq.h						\
 	$(INCLUDE)/uart.h						\
 	$(INCLUDE)/list.h						\
 	$(INCLUDE)/util.h						\
+	$(INCLUDE)/delay.h						\
+	$(INCLUDE)/timer.h						\
 	$(INCLUDE)/error.h						\
 	$(INCLUDE)/gpio.h						\
 	$(INCLUDE)/rtc.h						\
@@ -49,4 +48,5 @@ INCS += $(INCLUDE)/fifo.h					\
 	$(PLATFORM_DRIVERS)/spi_extra.h					\
 	$(PLATFORM_DRIVERS)/irq_extra.h					\
 	$(PLATFORM_DRIVERS)/rtc_extra.h					\
+	$(PLATFORM_DRIVERS)/timer_extra.h				\
 	$(PLATFORM_DRIVERS)/uart_extra.h				

--- a/projects/adxrs290-pmdz/src/main.c
+++ b/projects/adxrs290-pmdz/src/main.c
@@ -121,8 +121,8 @@ int main(void)
 	struct tcp_socket_init_param	socket_param;
 	struct wifi_init_param		wifi_param;
 	struct wifi_desc		*wifi;
-	struct uart_desc		*uart_desc;
 #endif
+	struct uart_desc		*uart_desc;
 
 	status = platform_init();
 	if (IS_ERR_VALUE(status))
@@ -170,11 +170,10 @@ int main(void)
 	if (status < 0)
 		return status;
 
-#ifdef USE_TCP_SOCKET
 	status = uart_init(&uart_desc, &uart_init_par);
 	if (status < 0)
 		return status;
-
+#ifdef USE_TCP_SOCKET
 	wifi_param.irq_desc = irq_desc;
 	wifi_param.uart_desc = uart_desc;
 #ifdef ADUCM_PLATFORM
@@ -202,7 +201,7 @@ int main(void)
 
 #else //USE_TCP_SOCKET
 	iio_init_param.phy_type = USE_UART;
-	iio_init_param.uart_init_param = &uart_init_par;
+	iio_init_param.uart_desc = uart_desc;
 #endif //USE_TCP_SOCKET
 
 	struct spi_init_param init_param = {

--- a/projects/fmcadc2/src/app/app_iio.c
+++ b/projects/fmcadc2/src/app/app_iio.c
@@ -75,6 +75,7 @@ struct iio_data_buffer g_read_buff = {
 int32_t iio_server_init(struct iio_axi_adc_init_param *adc_init)
 {
 	int32_t status;
+	struct uart_desc *uart_desc;
 
 #ifndef PLATFORM_MB
 	struct xil_irq_init_param xil_irq_init_param = {
@@ -106,9 +107,14 @@ int32_t iio_server_init(struct iio_axi_adc_init_param *adc_init)
 		.device_id = UART_DEVICE_ID,
 		.extra = &xil_uart_init_par,
 	};
+
+	status = uart_init(&uart_desc, &uart_init_par);
+	if (status < 0)
+		return status;
+
 	struct iio_init_param iio_init_par = {
 		.phy_type = USE_UART,
-		.uart_init_param = &uart_init_par,
+		.uart_desc = uart_desc,
 	};
 
 	struct iio_device *adc_dev_desc;

--- a/projects/fmcadc5/src/app/app_iio.c
+++ b/projects/fmcadc5/src/app/app_iio.c
@@ -71,23 +71,29 @@ struct iio_data_buffer g_read_buff1 = {
 int32_t iio_server_init(struct iio_axi_adc_init_param *adc_0_init,
 			struct iio_axi_adc_init_param *adc_1_init)
 {
+	int32_t status;
+	struct uart_desc *uart_desc;
 	struct xil_uart_init_param xil_uart_init_par = {
 		.type = UART_PL,
-	};
-	struct uart_init_param uart_init_par = {
-		.baud_rate = 115200,
-		.device_id = UART_DEVICE_ID,
-		.extra = &xil_uart_init_par,
-	};
-	struct iio_init_param iio_init_par = {
-		.phy_type = USE_UART,
-		.uart_init_param = &uart_init_par,
 	};
 	struct iio_device *adc_dev_desc;
 	struct iio_desc *iio_desc;
 	struct iio_axi_adc_desc *iio_axi_adc_0_desc;
 	struct iio_axi_adc_desc *iio_axi_adc_1_desc;
-	int32_t status;
+	struct uart_init_param uart_init_par = {
+		.baud_rate = 115200,
+		.device_id = UART_DEVICE_ID,
+		.extra = &xil_uart_init_par,
+	};
+
+	status = uart_init(&uart_desc, &uart_init_par);
+	if (status < 0)
+		return status;
+
+	struct iio_init_param iio_init_par = {
+		.phy_type = USE_UART,
+		.uart_desc = uart_desc,
+	};
 
 	status = iio_init(&iio_desc, &iio_init_par);
 	if (IS_ERR_VALUE(status))

--- a/projects/fmcdaq2/src/app/app_iio.c
+++ b/projects/fmcdaq2/src/app/app_iio.c
@@ -86,6 +86,8 @@ int32_t iio_server_init(struct iio_axi_adc_init_param *adc_init,
 			struct ad9680_dev *ad9680_device,
 			struct ad9144_dev *ad9144_device)
 {
+	int32_t status;
+	struct uart_desc *uart_desc;
 	struct xil_uart_init_param xil_uart_init_par = {
 #ifdef PLATFORM_MB
 		.type = UART_PL,
@@ -99,15 +101,19 @@ int32_t iio_server_init(struct iio_axi_adc_init_param *adc_init,
 		.device_id = UART_DEVICE_ID,
 		.extra = &xil_uart_init_par,
 	};
+
+	status = uart_init(&uart_desc, &uart_init_par);
+	if (status < 0)
+		return status;
+
 	struct iio_init_param iio_init_par = {
 		.phy_type = USE_UART,
-		.uart_init_param = &uart_init_par,
+		.uart_desc = uart_desc,
 	};
 	struct iio_desc *iio_desc;
 	struct iio_axi_adc_desc *iio_axi_adc_desc;
 	struct iio_axi_dac_desc *iio_axi_dac_desc;
 	struct iio_device *adc_dev_desc, *dac_dev_desc;
-	int32_t status;
 
 #ifndef PLATFORM_MB
 	struct xil_irq_init_param xil_irq_init_param = {

--- a/projects/fmcdaq3/src/app/app_iio.c
+++ b/projects/fmcdaq3/src/app/app_iio.c
@@ -84,6 +84,8 @@ int32_t iio_server_init(struct iio_axi_adc_init_param *adc_init,
 			struct ad9680_dev *ad9680_device,
 			struct ad9152_dev *ad9152_device)
 {
+	int32_t status;
+	struct uart_desc *uart_desc;
 	struct xil_uart_init_param xil_uart_init_par = {
 #ifdef PLATFORM_MB
 		.type = UART_PL,
@@ -92,20 +94,24 @@ int32_t iio_server_init(struct iio_axi_adc_init_param *adc_init,
 		.irq_id = UART_IRQ_ID,
 #endif
 	};
+	struct iio_desc *iio_desc;
+	struct iio_axi_adc_desc *iio_axi_adc_desc;
+	struct iio_axi_dac_desc *iio_axi_dac_desc;
+	struct iio_device *adc_dev_desc, *dac_dev_desc;
 	struct uart_init_param uart_init_par = {
 		.baud_rate = 921600,
 		.device_id = UART_DEVICE_ID,
 		.extra = &xil_uart_init_par,
 	};
+
+	status = uart_init(&uart_desc, &uart_init_par);
+	if (status < 0)
+		return status;
+
 	struct iio_init_param iio_init_par = {
 		.phy_type = USE_UART,
-		.uart_init_param = &uart_init_par,
+		.uart_desc = uart_desc,
 	};
-	struct iio_desc *iio_desc;
-	struct iio_axi_adc_desc *iio_axi_adc_desc;
-	struct iio_axi_dac_desc *iio_axi_dac_desc;
-	struct iio_device *adc_dev_desc, *dac_dev_desc;
-	int32_t status;
 
 #ifndef PLATFORM_MB
 	struct xil_irq_init_param xil_irq_init_param = {

--- a/projects/fmcjesdadc1/src/app/app_iio.c
+++ b/projects/fmcjesdadc1/src/app/app_iio.c
@@ -82,6 +82,8 @@ struct iio_data_buffer g_read_buff1 = {
 int32_t iio_server_init(struct iio_axi_adc_init_param *adc_0_init,
 			struct iio_axi_adc_init_param *adc_1_init)
 {
+	int32_t status;
+	struct uart_desc *uart_desc;
 	struct xil_uart_init_param xil_uart_init_par = {
 #ifdef PLATFORM_MB
 		.type = UART_PL,
@@ -96,15 +98,19 @@ int32_t iio_server_init(struct iio_axi_adc_init_param *adc_0_init,
 		.device_id = UART_DEVICE_ID,
 		.extra = &xil_uart_init_par,
 	};
+
+	status = uart_init(&uart_desc, &uart_init_par);
+	if (status < 0)
+		return status;
+
 	struct iio_init_param iio_init_par = {
 		.phy_type = USE_UART,
-		.uart_init_param = &uart_init_par,
+		.uart_desc = uart_desc,
 	};
 	struct iio_device *adc_dev_desc;
 	struct iio_desc *iio_desc;
 	struct iio_axi_adc_desc *iio_axi_adc_0_desc;
 	struct iio_axi_adc_desc *iio_axi_adc_1_desc;
-	int32_t status;
 
 #ifndef PLATFORM_MB
 	struct xil_irq_init_param xil_irq_init_param = {

--- a/projects/iio_demo/src.mk
+++ b/projects/iio_demo/src.mk
@@ -23,6 +23,9 @@ INCS += $(DRIVERS)/adc/adc_demo/iio_adc_demo.h			\
 		$(DRIVERS)/dac/dac_demo/iio_dac_demo.h			\
 		$(DRIVERS)/adc/adc_demo/adc_demo.h		\
 
+SRCS += $(PLATFORM_DRIVERS)/delay.c
+INCS += $(INCLUDE)/delay.h
+
 ifeq ($(PLATFORM),$(filter $(PLATFORM),xilinx aducm3029))
 # For the moment there is support only for aducm for iio with network backend
 ifeq (aducm3029,$(strip $(PLATFORM)))
@@ -36,10 +39,8 @@ ifeq (y,$(strip $(ENABLE_IIO_NETWORK)))
 DISABLE_SECURE_SOCKET ?= y
 SRC_DIRS += $(NO-OS)/network
 SRCS	 += $(NO-OS)/util/circular_buffer.c
-SRCS	 += $(PLATFORM_DRIVERS)/delay.c
 SRCS	 += $(PLATFORM_DRIVERS)/timer.c
-INCS	 += $(INCLUDE)/delay.h			\
-		$(INCLUDE)/timer.h		\
+INCS	 += $(INCLUDE)/timer.h		\
 		$(INCLUDE)/circular_buffer.h	\
 		$(PLATFORM_DRIVERS)/timer_extra.h\
 		$(PLATFORM_DRIVERS)/rtc_extra.h


### PR DESCRIPTION
iio_app will print this message upon startup, this way we solve the problem of having to document the baudrate setting in the wiki - we document it run-time, at the serial terminal.
```
Running TinyIIOD server...
If successful, you may connect an IIO client application by:
1. Disconnecting the serial terminal you use to view this message.
2. Connecting the IIO client application using the serial backend configured as shown:
	Baudrate: 921600
	Data size: 8 bits
	Parity: none
	Stop bits: 1
	Flow control: none

```