### PR TITLE
drivers:amplifiers:ada4250: fix polarity meaning

### DIFF
--- a/drivers/amplifiers/ada4250/ada4250.c
+++ b/drivers/amplifiers/ada4250/ada4250.c
@@ -283,10 +283,10 @@ int32_t ada4250_set_offset(struct ada4250_dev *dev, int32_t offset)
 
 	if (offset < 0) {
 		dev->offset_uv = (-1) * offset_raw * vlsb;
-		return ada4250_write(dev, ADA4250_REG_SNSR_CAL_VAL, (1 << 8 | abs(offset_raw)));
+		return ada4250_write(dev, ADA4250_REG_SNSR_CAL_VAL, offset_raw);
 	} else {
 		dev->offset_uv = offset_raw * vlsb;
-		return ada4250_write(dev, ADA4250_REG_SNSR_CAL_VAL, offset_raw);
+		return ada4250_write(dev, ADA4250_REG_SNSR_CAL_VAL, (1 << 8 | offset_raw));
 	}
 }
 


### PR DESCRIPTION
According to the datasheet, 0 corresponds to negative offset values and
1 corresponds to positive offset values. 

![image](https://user-images.githubusercontent.com/26061529/114206428-02f01580-9964-11eb-8d22-331dec45a688.png)

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>