### PR TITLE
xilinx scripts: fix typo in util.tcl

### DIFF
--- a/tools/scripts/platform/xilinx/util.tcl
+++ b/tools/scripts/platform/xilinx/util.tcl
@@ -169,7 +169,7 @@ proc _cpu_reset {cpu} {
 	stop
 	if {$cpu == "ps7_cortexa9_0"} {
 		rst 
-	} elseif {$arch == "psu_cortexa53_0"} {
+	} elseif {$cpu == "psu_cortexa53_0"} {
 		rst -system
 	}
 }


### PR DESCRIPTION
make run was broken on xilinx in de1396b8f.

Signed-off-by: buha <darius@berghe.ro>