### PR TITLE
drivers:platform:aducm3029: i2c read fix

### DIFF
--- a/drivers/platform/aducm3029/i2c.c
+++ b/drivers/platform/aducm3029/i2c.c
@@ -255,3 +255,43 @@ int32_t i2c_read(struct i2c_desc *desc,
 
 	return SUCCESS;
 }
+
+/**
+ * @brief Read data after writing with repeated start (useful for
+ *        reading registers).
+ * @param desc - Descriptor of the I2C device
+ * @param write_data - Buffer that stores the data to be written.
+ * @param wr_bytes_number - Number of bytes to write.
+ * @param read_data - Buffer that stores the data that will be read.
+ * @param rd_bytes_number - Number of bytes to read.
+ * @return \ref SUCCESS in case of success, \ref FAILURE otherwise.
+ */
+int32_t i2c_writeread(struct i2c_desc *desc,
+		      uint8_t *write_data,
+		      uint8_t wr_bytes_number,
+		      uint8_t *read_data,
+		      uint8_t rd_bytes_number)
+{
+	if (!desc)
+		return -EINVAL;
+
+	ADI_I2C_TRANSACTION trans[1];
+	uint32_t errors;
+	int32_t ret;
+
+	ret = set_transmission_configuration(desc);
+	if (ret < 0)
+		return ret;
+
+	trans->bRepeatStart = true;
+	trans->pPrologue = write_data;
+	trans->nPrologueSize = wr_bytes_number;
+	trans->pData = read_data;
+	trans->nDataSize = rd_bytes_number;
+	trans->bReadNotWrite = 1;
+	if (ADI_I2C_SUCCESS != adi_i2c_ReadWrite(i2c_handler, trans, &errors))
+		return -EIO;
+
+	return SUCCESS;
+}
+

--- a/include/i2c.h
+++ b/include/i2c.h
@@ -126,4 +126,10 @@ int32_t i2c_read(struct i2c_desc *desc,
 		 uint8_t bytes_number,
 		 uint8_t stop_bit);
 
+int32_t i2c_writeread(struct i2c_desc *desc,
+		      uint8_t *write_data,
+		      uint8_t wr_bytes_number,
+		      uint8_t *read_data,
+		      uint8_t rd_bytes_number);
+
 #endif // I2C_H_


### PR DESCRIPTION
Setting bRepeatedStart=true for a transaction does not only ommit the stop
bit of the current transaction, but actually sends the repeated start as
well as a prologue data sequence.
This means that calling a read without a
stop bit and thn a write for aducm3029 actually sends the reapeated start,
then the I2C address and then a Stop bit directly, meaning the write
operation is not atomic anymore.
At best this is a benign bug and might still work, with hardware errors and
reading wrong registers at worst.

This is a variant solution to the #1006 

Signed-off-by: Andrei Drimbarean <Andrei.Drimbarean@analog.com>