### PR TITLE
tools:scripts:linux.mk: Add support for debugging

### DIFF
--- a/tools/scripts/linux.mk
+++ b/tools/scripts/linux.mk
@@ -12,5 +12,11 @@ $(PROJECT_TARGET):
 	$(MUTE) $(call mk_dir, $(BUILD_DIR)) $(HIDE)
 	$(MUTE) $(call set_one_time_rule,$@)
 
+develop:
+	$(MUTE) $(call mk_dir, $(PROJECT_BUILD)) $(HIDE)
+	$(MUTE) $(call copy_folder, $(PLATFORM_TOOLS)/.vscode, $(PROJECT_BUILD)/.vscode) $(HIDE)
+	$(MUTE) python $(PLATFORM_TOOLS)/config_build.py $(NO-OS) $(PROJECT) $(BINARY) $(HIDE)
+	$(call print, Workspace ready. Open $(PROJECT_BUILD) directory in VSCode for debug)
+
 linux_run: $(BINARY)
 	$(BINARY)

--- a/tools/scripts/platform/linux/.vscode/c_cpp_properties.json
+++ b/tools/scripts/platform/linux/.vscode/c_cpp_properties.json
@@ -1,0 +1,19 @@
+{
+    "version": 4, 
+    "configurations": [
+        {
+            "intelliSenseMode": "linux-gcc-arm", 
+            "name": "App", 
+            "cppStandard": "gnu++14", 
+            "compilerArgs": [], 
+            "cStandard": "gnu17", 
+            "compilerPath": "/usr/bin/gcc", 
+            "browse": {
+                "databaseFilename": "", 
+                "limitSymbolsToIncludedHeaders": true
+            }, 
+            "includePath": [], 
+            "defines": []
+        }
+    ]
+}

--- a/tools/scripts/platform/linux/.vscode/launch.json
+++ b/tools/scripts/platform/linux/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    "version": "0.2.0", 
+    "configurations": [
+        {
+            "name": "(gdb) Launch", 
+            "targetArchitecture": "arm", 
+            "externalConsole": false, 
+            "request": "launch", 
+            "preLaunchTask": "build", 
+            "program": "program.out", 
+            "miDebuggerPath": "/usr/bin/gdb", 
+            "type": "cppdbg", 
+            "cwd": "project_dir"
+        }
+    ]
+}

--- a/tools/scripts/platform/linux/.vscode/tasks.json
+++ b/tools/scripts/platform/linux/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+    "tasks": [
+        {
+            "command": "make_command", 
+            "problemMatcher": [
+                "$gcc"
+            ], 
+            "type": "shell", 
+            "label": "build", 
+            "group": {
+                "kind": "build", 
+                "isDefault": true
+            }
+        }
+    ], 
+    "version": "2.0.0"
+}

--- a/tools/scripts/platform/linux/config_build.py
+++ b/tools/scripts/platform/linux/config_build.py
@@ -1,0 +1,60 @@
+#!/bin/python
+
+import json
+import os
+import argparse
+
+description_help='''Build noos projects
+Examples:\n
+    	>python config_build.py ..\..
+'''
+
+def parse_input():
+	parser = argparse.ArgumentParser(description=description_help,\
+				formatter_class=argparse.RawTextHelpFormatter)
+	parser.add_argument('noos', help="Path to noos location")
+	parser.add_argument('project', help="Project to build")
+	parser.add_argument('binary', help="File to debug")
+	args = parser.parse_args()
+
+	return (args.noos, args.project, args.binary)
+
+(noos, project, binary) = parse_input()
+
+dir = os.environ['PROJECT_BUILD']
+code_dir = os.path.join(dir, '.vscode')
+
+fn = 'launch.json'
+file = os.path.join(code_dir, fn)
+with open(file, 'r') as fp:
+	data = json.loads(fp.read())
+data['configurations'][0]['program'] = binary
+data['configurations'][0]['cwd'] = dir
+with open(file, 'w') as fp:
+	json.dump(data, fp, indent=4)
+
+fn = 'tasks.json'
+file = os.path.join(code_dir, fn)
+with open(file, 'r') as fp:
+	data = json.loads(fp.read())
+data['tasks'][0]['command'] = 'make -C %s' % project
+with open(file, 'w') as fp:
+	json.dump(data, fp, indent=4)
+
+flags = os.environ['FLAGS_WITHOUT_D']
+incs = os.environ['EXTRA_INC_PATHS']
+
+fn = 'c_cpp_properties.json'
+file = os.path.join(code_dir, fn)
+with open(file, 'r') as fp:
+	data = json.loads(fp.read())
+
+data['configurations'][0]['defines'] = flags.split(' ')
+#remove lasta / from incs
+incs = incs.split(' ')
+for i in range(0, len(incs)):
+	incs[i] = incs[i].rstrip('/')
+
+data['configurations'][0]['includePath'] = incs
+with open(file, 'w') as fp:
+	json.dump(data, fp, indent=4)


### PR DESCRIPTION
After running make, the folder build/app can be selected
from vscode in order to start developing and debugging the
project.
Includes path and flags are set by the config_build.py
script in order to have correct linting.
Files from tools/scripts/platform/linux/.vscode are copied to
the build/app folder and the updated with config_build.py
with the project specific parameters
tools:scripts:linux.mk: Add support for debugging

After running make, the folder build/app can be selected
from vscode in order to start developing and debugging the
project.
Includes path and flags are set by the config_build.py
script in order to have correct linting.
Files from tools/scripts/platform/linux/.vscode are copied to
the build/app folder and the updated with config_build.py
with the project specific parameters

Signed-off-by: Mihail Chindris <mihail.chindris@analog.com>