### PR TITLE
drivers:Makefile: Fix make clean

### DIFF
--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -41,4 +41,4 @@ OBJS = $(SRCS:.c=.o)
 all: $(OBJS)
 
 clean:
-	rm -f $(OBJS)
+	rm -f *.o


### PR DESCRIPTION
With find, ignored directories where also added to SRCS and they
can't and shoulden't be removed.

Signed-off-by: Mihail Chindris <mihail.chindris@analog.com>