### PR TITLE
Aducm make debug

### DIFF
--- a/tools/scripts/stm32.mk
+++ b/tools/scripts/stm32.mk
@@ -86,6 +86,7 @@ $(BINARY).gdb:
 	# @echo tb UsageFault_Handler >> $(BINARY).gdb
 	# @echo tb MemManage_Handler >> $(BINARY).gdb
 	# @echo tb BusFault_Handler >> $(BINARY).gdb
+	@echo tui enable >> $(BINARY).gdb
 	@echo c >> $(BINARY).gdb
 
 .PHONY: stm32_run


### PR DESCRIPTION
As a side effect, this PR enables debugger flags for all aducm builds, this should be fine, we do it anyway on all platforms and we don't have debug/release separation.