### PR TITLE
drivers:adc:ad7768-1: include spi

### DIFF
--- a/drivers/adc/ad7768-1/ad77681.h
+++ b/drivers/adc/ad7768-1/ad77681.h
@@ -40,7 +40,7 @@
 #ifndef SRC_AD77681_H_
 #define SRC_AD77681_H_
 
-#include "spi_engine.h"
+#include "spi.h"
 
 /******************************************************************************/
 /********************** Macros and Constants Definitions **********************/


### PR DESCRIPTION
The driver does not contain any particular spi_engine specific
functions/parameters, therefore it should be independent on the
framework.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>