### PR TITLE
network:linux_sockets: Fix return

### DIFF
--- a/network/linux_socket/linux_socket.c
+++ b/network/linux_socket/linux_socket.c
@@ -149,11 +149,18 @@ static int32_t linux_socket_recv(struct linux_desc *desc, uint32_t sock_id,
 {
 	int32_t ret;
 
+	if (!size)
+		return size;
+
 	ret = recv(sock_id, data, size, MSG_DONTWAIT);
 	if(ret < 0)
 		return -errno;
 
-	return size;
+	/* A stream socket peer has performed an orderly shutdown */
+	if(ret == 0)
+		return -ENOTCONN;
+
+	return ret;
 }
 
 /** @brief See \ref network_interface.socket_sendto */


### PR DESCRIPTION
As per recv documentation, 0 is returned when requested
size is 0 or if a socket was disconnected by a peer.
Therfore, return error message when necesary.

With this PR (https://github.com/analogdevicesinc/libtinyiiod/pull/41), DAC buffers will work over sockets: 
When merged will add a commit updating the submodule too