### PR TITLE
redefine SUCCESS and FAILURE if necessary

### DIFF
--- a/include/error.h
+++ b/include/error.h
@@ -46,12 +46,14 @@
 /********************** Macros and Constants Definitions **********************/
 /******************************************************************************/
 
-#ifndef SUCCESS
+#ifdef SUCCESS
+#undef SUCCESS
+#endif
 #define SUCCESS		0
+#ifdef FAILURE
+#undef FAILURE
 #endif
-#ifndef FAILURE
 #define FAILURE		-1
-#endif
 
 #ifndef __ELASTERROR
 #define __ELASTERROR 2000


### PR DESCRIPTION
It makes sense for SUCCESS/FAILURE to be redefined using our own
(no-OS) convention rather than mix things up.

One currently known scenario is the aducm3029 platform which
defines FAILURE as 1, contrary to our -1 expectation. This leads
to bad behaviour.

Signed-off-by: Darius Berghe <darius.berghe@analog.com>