### PR TITLE
adrv9009: fix IIO app issue

### DIFF
--- a/projects/adrv9009/src/app/headless.c
+++ b/projects/adrv9009/src/app/headless.c
@@ -375,7 +375,7 @@ int main(void)
 #endif
 
 #ifdef IIO_SUPPORT
-	status = start_iiod(tx_dmac, rx_dmac, rx_adc, tx_dac);
+	status = start_iiod(rx_dmac, tx_dmac, rx_adc, tx_dac);
 	if (status)
 		printf("Tinyiiod error: %d\n", status);
 #endif // IIO_SUPPORT


### PR DESCRIPTION
The order of the parameters passed to the `start_iiod` function was
incorrect.

This patch fixes the addressed issue.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>