### PR TITLE
drivers:adc:ad717x: remove wrong configuration

### DIFF
--- a/drivers/adc/ad717x/ad7172_4_regs.h
+++ b/drivers/adc/ad717x/ad7172_4_regs.h
@@ -132,7 +132,6 @@ ad717x_st_reg ad7172_4_regs[] = {
 	{AD717X_GAIN5_REG, 0, 3 },
 	{AD717X_GAIN6_REG, 0, 3 },
 	{AD717X_GAIN7_REG, 0, 3 },
-	{AD717X_GAIN8_REG, 0, 3 },
 };
 #endif
 


### PR DESCRIPTION
Configuration tried to set a register that doesn't exist.

Signed-off-by: Andrei Drimbarean <Andrei.Drimbarean@analog.com>