### PR TITLE
drivers:afe:ad4110: Driver fix

### DIFF
--- a/drivers/afe/ad4110/ad4110.c
+++ b/drivers/afe/ad4110/ad4110.c
@@ -603,7 +603,13 @@ int32_t ad4110_setup(struct ad4110_dev **device,
 	if (ret)
 		goto err_init;
 
+	dev->afe_crc_en = AD4110_AFE_CRC_DISABLE;
+	dev->adc_crc_en = AD4110_ADC_CRC_DISABLE;
 	dev->addr = init_param.addr;
+	dev->data_stat = init_param.data_stat;
+	dev->data_length = init_param.data_length;
+	dev->op_mode = init_param.op_mode;
+	dev->gain = init_param.gain;
 
 	/* Device Settings */
 	ret = ad4110_spi_do_soft_reset(dev);
@@ -620,7 +626,6 @@ int32_t ad4110_setup(struct ad4110_dev **device,
 		if (ret)
 			goto err_init;
 	}
-	dev->data_stat = init_param.data_stat;
 
 	if(init_param.data_length == AD4110_DATA_WL16) {
 		ret = ad4110_spi_int_reg_write_msk(dev,
@@ -631,7 +636,6 @@ int32_t ad4110_setup(struct ad4110_dev **device,
 		if (ret)
 			goto err_init;
 	}
-	dev->data_length = init_param.data_length;
 
 	if(init_param.afe_crc_en != AD4110_AFE_CRC_DISABLE) {
 		ret = ad4110_spi_int_reg_write(dev,
@@ -641,7 +645,6 @@ int32_t ad4110_setup(struct ad4110_dev **device,
 		if (ret)
 			goto err_init;
 	}
-	dev->afe_crc_en = init_param.afe_crc_en;
 
 	if(init_param.adc_crc_en != AD4110_ADC_CRC_DISABLE) {
 		ret = ad4110_spi_int_reg_write_msk(dev,
@@ -652,18 +655,14 @@ int32_t ad4110_setup(struct ad4110_dev **device,
 		if (ret)
 			goto err_init;
 	}
-	dev->adc_crc_en = init_param.adc_crc_en;
 
-	ret = ad4110_set_op_mode(dev, init_param.op_mode);
+	ret = ad4110_set_op_mode(dev, dev->op_mode);
 	if (ret)
 		goto err_init;
-	dev->op_mode = init_param.op_mode;
 
-	ret = ad4110_set_gain(dev, init_param.gain);
+	ret = ad4110_set_gain(dev, dev->gain);
 	if (ret)
 		goto err_init;
-	dev->gain = init_param.gain;
-
 	*device = dev;
 
 	printf("AD4110 successfully initialized\n");

--- a/drivers/afe/ad4110/ad4110.c
+++ b/drivers/afe/ad4110/ad4110.c
@@ -687,6 +687,7 @@ int32_t ad4110_setup(struct ad4110_dev **device,
 	dev->addr = init_param.addr;
 	dev->data_stat = init_param.data_stat;
 	dev->data_length = init_param.data_length;
+	dev->sync = init_param.sync;
 	dev->op_mode = init_param.op_mode;
 	dev->gain = init_param.gain;
 	dev->volt_ref = init_param.volt_ref;
@@ -739,6 +740,17 @@ int32_t ad4110_setup(struct ad4110_dev **device,
 		if (ret)
 			goto err_init;
 	}
+
+	if(dev->sync != AD4110_SYNC_EN) {
+		ret = ad4110_spi_int_reg_write_msk(dev,
+						   A4110_ADC,
+						   AD4110_REG_ADC_GPIO_CONFIG,
+						   AD4110_REG_GPIO_CONFIG_SYNC_EN(AD4110_SYNC_DIS),
+						   AD4110_REG_GPIO_CONFIG_SYNC_EN(0xF));
+		if (ret)
+			goto err_init;
+	}
+
 
 	ret = ad4110_set_op_mode(dev, dev->op_mode);
 	if (ret)

--- a/drivers/afe/ad4110/ad4110.c
+++ b/drivers/afe/ad4110/ad4110.c
@@ -529,13 +529,6 @@ int32_t ad4110_setup(struct ad4110_dev **device,
 	/* SPI */
 	ret = spi_init(&dev->spi_dev, &init_param.spi_init);
 
-	/* GPIO */
-	ret |= gpio_get(&dev->gpio_reset, &init_param.gpio_reset);
-
-	ret |= gpio_direction_output(dev->gpio_reset, GPIO_LOW);
-	mdelay(10);
-	ret |= gpio_set_value(dev->gpio_reset, GPIO_HIGH);
-	mdelay(10);
 	dev->addr = init_param.addr;
 
 	/* Device Settings */
@@ -605,8 +598,6 @@ int32_t ad4110_remove(struct ad4110_dev *dev)
 	int32_t ret;
 
 	ret = spi_remove(dev->spi_dev);
-
-	ret |= gpio_remove(dev->gpio_reset);
 
 	free(dev);
 

--- a/drivers/afe/ad4110/ad4110.c
+++ b/drivers/afe/ad4110/ad4110.c
@@ -86,11 +86,11 @@ int32_t ad4110_spi_int_reg_write_msk(struct ad4110_dev *dev,
 	uint32_t reg_data;
 
 	ret = ad4110_spi_int_reg_read(dev, reg_map, reg_addr, &reg_data);
+	if (ret)
+		return ret;
 	reg_data &= ~mask;
 	reg_data |= data;
-	ret |= ad4110_spi_int_reg_write(dev, reg_map, reg_addr, reg_data);
-
-	return ret;
+	return ad4110_spi_int_reg_write(dev, reg_map, reg_addr, reg_data);
 }
 
 /***************************************************************************//**
@@ -109,20 +109,16 @@ int32_t ad4110_spi_int_reg_write_msk(struct ad4110_dev *dev,
 *******************************************************************************/
 int32_t ad4110_set_adc_mode(struct ad4110_dev *dev, enum ad4110_adc_mode mode)
 {
-	int32_t ret;
-
 	if(mode == AD4110_SYS_OFFSET_CAL)
 		printf("Assuming that the applied analog input is the zero scale point. \n");
 	else if(mode == AD4110_SYS_GAIN_CAL)
 		printf("Assuming that the applied analog input is the full scale point. \n");
 
-	ret = ad4110_spi_int_reg_write_msk(dev,
-					   A4110_ADC,
-					   AD4110_REG_ADC_MODE,
-					   AD4110_ADC_MODE(mode),
-					   AD4110_REG_ADC_MODE_MSK);
-
-	return ret;
+	return ad4110_spi_int_reg_write_msk(dev,
+					    A4110_ADC,
+					    AD4110_REG_ADC_MODE,
+					    AD4110_ADC_MODE(mode),
+					    AD4110_REG_ADC_MODE_MSK);
 }
 
 /***************************************************************************//**
@@ -151,15 +147,11 @@ int32_t ad4110_set_adc_mode(struct ad4110_dev *dev, enum ad4110_adc_mode mode)
 *******************************************************************************/
 int32_t ad4110_set_gain(struct ad4110_dev *dev, enum ad4110_gain gain)
 {
-	int32_t ret;
-
-	ret = ad4110_spi_int_reg_write_msk(dev,
-					   A4110_AFE,
-					   AD4110_REG_PGA_RTD_CTRL,
-					   AD4110_REG_PGA_RTD_CTRL_GAIN_CH(gain),
-					   AD4110_REG_PGA_RTD_CTRL_GAIN_CH(0xF));
-
-	return ret;
+	return ad4110_spi_int_reg_write_msk(dev,
+					    A4110_AFE,
+					    AD4110_REG_PGA_RTD_CTRL,
+					    AD4110_REG_PGA_RTD_CTRL_GAIN_CH(gain),
+					    AD4110_REG_PGA_RTD_CTRL_GAIN_CH(0xF));
 }
 
 /***************************************************************************//**
@@ -264,22 +256,18 @@ int32_t ad4110_set_op_mode(struct ad4110_dev *dev, enum ad4110_op_mode mode)
 	switch(mode) {
 	case AD4110_VOLTAGE_MODE:
 		// clear IMODE bit
-		ret = ad4110_spi_int_reg_write_msk(dev,
-						   A4110_AFE,
-						   AD4110_REG_AFE_CNTRL2,
-						   AD4110_DISABLE,
-						   AD4110_REG_AFE_CNTRL2_IMODE_MSK);
-		break;
+		return ad4110_spi_int_reg_write_msk(dev,
+						    A4110_AFE,
+						    AD4110_REG_AFE_CNTRL2,
+						    AD4110_DISABLE,
+						    AD4110_REG_AFE_CNTRL2_IMODE_MSK);
 	case AD4110_CURRENT_MODE:
 		// set IMODE bit
-		ret = ad4110_spi_int_reg_write_msk(dev,
-						   A4110_AFE,
-						   AD4110_REG_AFE_CNTRL2,
-						   AD4110_ENABLE,
-						   AD4110_REG_AFE_CNTRL2_IMODE_MSK);
-
-		break;
-
+		return ad4110_spi_int_reg_write_msk(dev,
+						    A4110_AFE,
+						    AD4110_REG_AFE_CNTRL2,
+						    AD4110_ENABLE,
+						    AD4110_REG_AFE_CNTRL2_IMODE_MSK);
 	case AD4110_CURRENT_MODE_EXT_R_SEL:
 		// set IMODE bit
 		ret = ad4110_spi_int_reg_write_msk(dev,
@@ -287,15 +275,15 @@ int32_t ad4110_set_op_mode(struct ad4110_dev *dev, enum ad4110_op_mode mode)
 						   AD4110_REG_AFE_CNTRL2,
 						   AD4110_ENABLE,
 						   AD4110_REG_AFE_CNTRL2_IMODE_MSK);
+		if (ret)
+			return ret;
 
 		// set EXT_R_SEL
-		ret |= ad4110_spi_int_reg_write_msk(dev,
+		return ad4110_spi_int_reg_write_msk(dev,
 						    A4110_AFE,
 						    AD4110_REG_AFE_CNTRL2,
 						    AD4110_ENABLE,
 						    AD4110_REG_AFE_CNTRL2_EXT_R_SEL_MSK);
-		break;
-
 	case AD4110_THERMOCOUPLE:
 		// clear IMODE bit
 		ret = ad4110_spi_int_reg_write_msk(dev,
@@ -303,15 +291,15 @@ int32_t ad4110_set_op_mode(struct ad4110_dev *dev, enum ad4110_op_mode mode)
 						   AD4110_REG_AFE_CNTRL2,
 						   AD4110_DISABLE,
 						   AD4110_REG_AFE_CNTRL2_IMODE_MSK);
+		if (ret)
+			return ret;
 
 		// enable VBIAS
-		ret |= ad4110_spi_int_reg_write_msk(dev,
+		return ad4110_spi_int_reg_write_msk(dev,
 						    A4110_AFE,
 						    AD4110_REG_AFE_CNTRL2,
 						    AD4110_AFE_VBIAS(AD4110_AFE_VBIAS_ON),
 						    AD4110_AFE_VBIAS(AD4110_AFE_VBIAS_OFF));
-		break;
-
 	case AD4110_FLD_POWER_MODE:
 		// set IMODE bit
 		ret = ad4110_spi_int_reg_write_msk(dev,
@@ -319,15 +307,15 @@ int32_t ad4110_set_op_mode(struct ad4110_dev *dev, enum ad4110_op_mode mode)
 						   AD4110_REG_AFE_CNTRL2,
 						   AD4110_ENABLE,
 						   AD4110_REG_AFE_CNTRL2_IMODE_MSK);
+		if (ret)
+			return ret;
 
 		// set EN_FLD_PWR
-		ret |= ad4110_spi_int_reg_write_msk(dev,
+		return ad4110_spi_int_reg_write_msk(dev,
 						    A4110_AFE,
 						    AD4110_REG_AFE_CNTRL2,
 						    AD4110_ENABLE,
 						    AD4110_REG_AFE_CNTRL2_EN_FLD_PWR_MSK);
-
-		break;
 
 	case AD4110_RTD_4W_MODE:
 		// clear IMODE bit
@@ -336,14 +324,15 @@ int32_t ad4110_set_op_mode(struct ad4110_dev *dev, enum ad4110_op_mode mode)
 						   AD4110_REG_AFE_CNTRL2,
 						   AD4110_DISABLE,
 						   AD4110_REG_AFE_CNTRL2_IMODE_MSK);
-		// clear RTD_3W4W bit
-		ret |= ad4110_spi_int_reg_write_msk(dev,
-						    A4110_AFE,
-						    AD4110_REG_PGA_RTD_CTRL,
-						    AD4110_DISABLE,
-						    AD4110_REG_PGA_RTD_CTRL_23W_EN_MSK);
-		break;
+		if (ret)
+			return ret;
 
+		// clear RTD_3W4W bit
+		return  ad4110_spi_int_reg_write_msk(dev,
+						     A4110_AFE,
+						     AD4110_REG_PGA_RTD_CTRL,
+						     AD4110_DISABLE,
+						     AD4110_REG_PGA_RTD_CTRL_23W_EN_MSK);
 	case AD4110_RTD_3W_MODE:
 		// clear IMODE bit
 		ret = ad4110_spi_int_reg_write_msk(dev,
@@ -351,14 +340,15 @@ int32_t ad4110_set_op_mode(struct ad4110_dev *dev, enum ad4110_op_mode mode)
 						   AD4110_REG_AFE_CNTRL2,
 						   AD4110_DISABLE,
 						   AD4110_REG_AFE_CNTRL2_IMODE_MSK);
+		if (ret)
+			return ret;
+
 		// set RTD_3W4W bit
-		ret |= ad4110_spi_int_reg_write_msk(dev,
+		return ad4110_spi_int_reg_write_msk(dev,
 						    A4110_AFE,
 						    AD4110_REG_PGA_RTD_CTRL,
 						    AD4110_ENABLE,
 						    AD4110_REG_PGA_RTD_CTRL_23W_EN_MSK);
-		break;
-
 	case AD4110_RTD_2W_MODE:
 		// clear IMODE bit
 		ret = ad4110_spi_int_reg_write_msk(dev,
@@ -366,33 +356,36 @@ int32_t ad4110_set_op_mode(struct ad4110_dev *dev, enum ad4110_op_mode mode)
 						   AD4110_REG_AFE_CNTRL2,
 						   AD4110_DISABLE,
 						   AD4110_REG_AFE_CNTRL2_IMODE_MSK);
+		if (ret)
+			return ret;
+
 		// set RTD_3W4W bit
-		ret |= ad4110_spi_int_reg_write_msk(dev,
-						    A4110_AFE,
-						    AD4110_REG_PGA_RTD_CTRL,
-						    AD4110_ENABLE,
-						    AD4110_REG_PGA_RTD_CTRL_23W_EN_MSK);
+		ret = ad4110_spi_int_reg_write_msk(dev,
+						   A4110_AFE,
+						   AD4110_REG_PGA_RTD_CTRL,
+						   AD4110_ENABLE,
+						   AD4110_REG_PGA_RTD_CTRL_23W_EN_MSK);
+		if (ret)
+			return ret;
+
 		// enable VBIAS
-		ret |=
-			ad4110_spi_int_reg_write_msk(dev,
-						     A4110_AFE,
-						     AD4110_REG_AFE_CNTRL2,
-						     AD4110_AFE_VBIAS(AD4110_AFE_VBIAS_ON),
-						     AD4110_AFE_VBIAS(AD4110_AFE_VBIAS_OFF));
+		ret = ad4110_spi_int_reg_write_msk(dev,
+						   A4110_AFE,
+						   AD4110_REG_AFE_CNTRL2,
+						   AD4110_AFE_VBIAS(AD4110_AFE_VBIAS_ON),
+						   AD4110_AFE_VBIAS(AD4110_AFE_VBIAS_OFF));
+		if (ret)
+			return ret;
 
 		// enable the 100 �A pull-down current source on AIN(-)
-		ret |= ad4110_spi_int_reg_write_msk(dev,
+		return ad4110_spi_int_reg_write_msk(dev,
 						    A4110_AFE,
 						    AD4110_REG_AFE_CNTRL2,
 						    AD4110_REG_AFE_CNTRL2_AINN_DN100,
 						    AD4110_REG_AFE_CNTRL2_AINN_DN100);
-		break;
-
 	default:
-		break;
+		return FAILURE;
 	}
-
-	return ret;
 }
 
 /***************************************************************************//**
@@ -404,14 +397,11 @@ int32_t ad4110_set_op_mode(struct ad4110_dev *dev, enum ad4110_op_mode mode)
 *******************************************************************************/
 int32_t ad4110_spi_do_soft_reset(struct ad4110_dev *dev)
 {
-	int32_t ret;
 	uint8_t buf [ 8 ] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
 	/* The AD4110 can be reset by writing a series of 64 1�s to the DIN
 	 * input */
-	ret = spi_write_and_read(dev->spi_dev, buf, 8);
-
-	return ret;
+	return spi_write_and_read(dev->spi_dev, buf, 8);
 }
 
 
@@ -470,7 +460,6 @@ int32_t ad4110_spi_int_reg_write(struct ad4110_dev *dev,
 
 	uint8_t buf_size;
 	uint8_t data_size = 3;
-	int32_t ret;
 
 	if(reg_addr >= AD4110_ADC_OFFSET0)
 		data_size = 4;
@@ -490,7 +479,7 @@ int32_t ad4110_spi_int_reg_write(struct ad4110_dev *dev,
 		break;
 
 	default:
-		break;
+		return -EINVAL;
 	}
 
 	if(((dev->afe_crc_en != AD4110_AFE_CRC_DISABLE) &&
@@ -501,9 +490,7 @@ int32_t ad4110_spi_int_reg_write(struct ad4110_dev *dev,
 		buf[data_size] = ad4110_compute_crc8(&buf[0], data_size);
 	} else
 		buf_size = data_size;
-	ret = spi_write_and_read(dev->spi_dev, buf, buf_size);
-
-	return ret;
+	return spi_write_and_read(dev->spi_dev, buf, buf_size);
 }
 
 /***************************************************************************//**
@@ -622,6 +609,9 @@ int32_t ad4110_spi_int_reg_read(struct ad4110_dev *dev,
 		buf_size = data_size;
 
 	ret = spi_write_and_read(dev->spi_dev, buf, buf_size);
+	if (ret)
+		return ret;
+
 	switch (data_size) {
 	case 3:
 		data = (buf[1] << 8) | buf[2];
@@ -644,20 +634,20 @@ int32_t ad4110_spi_int_reg_read(struct ad4110_dev *dev,
 		buf[0] = (reg_map << 7) | AD4110_CMD_READ_COM_REG(reg_addr);
 		crc = ad4110_compute_crc8(&buf[0], data_size);
 		if (crc != buf[buf_size - 1]) {
-			printf("%s: CRC Error.\n", __func__);
-			ret = FAILURE;
+			pr_err("%s: CRC Error.\n", __func__);
+			return FAILURE;
 		}
 	} else if ((dev->adc_crc_en == AD4110_ADC_XOR_CRC) &&
 		   (reg_map == A4110_ADC)) {
 		buf[0] = (reg_map << 7) | AD4110_CMD_READ_COM_REG(reg_addr);
 		crc = ad4110_compute_xor(&buf[0], data_size);
 		if (crc != buf[buf_size - 1]) {
-			printf("%s: CRC Error.\n", __func__);
-			ret = FAILURE;
+			pr_err("%s: CRC Error.\n", __func__);
+			return FAILURE;
 		}
 	}
 
-	return ret;
+	return SUCCESS;
 }
 
 /***************************************************************************//**
@@ -698,7 +688,7 @@ int32_t ad4110_setup(struct ad4110_dev **device,
 	/* SPI */
 	ret = spi_init(&dev->spi_dev, &init_param.spi_init);
 	if (ret)
-		goto err_init;
+		goto err_dev;
 
 	dev->afe_crc_en = AD4110_AFE_CRC_DISABLE;
 	dev->adc_crc_en = AD4110_ADC_CRC_DISABLE;
@@ -717,7 +707,7 @@ int32_t ad4110_setup(struct ad4110_dev **device,
 	/* Device Settings */
 	ret = ad4110_spi_do_soft_reset(dev);
 	if (ret)
-		goto err_init;
+		goto err_spi;
 	mdelay(10);
 
 	if(init_param.afe_crc_en != AD4110_AFE_CRC_DISABLE) {
@@ -726,7 +716,7 @@ int32_t ad4110_setup(struct ad4110_dev **device,
 					       AD4110_REG_AFE_CNTRL1,
 					       AD4110_REG_AFE_CNTRL1_CRC_EN);
 		if (ret)
-			goto err_init;
+			goto err_spi;
 	}
 	dev->afe_crc_en = init_param.afe_crc_en;
 
@@ -737,7 +727,7 @@ int32_t ad4110_setup(struct ad4110_dev **device,
 						   AD4110_ADC_CRC_EN(init_param.adc_crc_en),
 						   AD4110_REG_ADC_INTERFACE_CRC_EN_MSK);
 		if (ret)
-			goto err_init;
+			goto err_spi;
 	}
 	dev->adc_crc_en = init_param.adc_crc_en;
 
@@ -748,7 +738,7 @@ int32_t ad4110_setup(struct ad4110_dev **device,
 						   AD4110_DATA_STAT_EN,
 						   AD4110_REG_ADC_INTERFACE_DS_MSK);
 		if (ret)
-			goto err_init;
+			goto err_spi;
 	}
 
 	if(dev->data_length == AD4110_DATA_WL16) {
@@ -758,7 +748,7 @@ int32_t ad4110_setup(struct ad4110_dev **device,
 						   AD4110_DATA_WL16,
 						   AD4110_REG_ADC_INTERFACE_WL16_MSK);
 		if (ret)
-			goto err_init;
+			goto err_spi;
 	}
 
 	if(dev->sync != AD4110_SYNC_EN) {
@@ -768,42 +758,44 @@ int32_t ad4110_setup(struct ad4110_dev **device,
 						   AD4110_REG_GPIO_CONFIG_SYNC_EN(AD4110_SYNC_DIS),
 						   AD4110_REG_GPIO_CONFIG_SYNC_EN(0xF));
 		if (ret)
-			goto err_init;
+			goto err_spi;
 	}
 
 
 	ret = ad4110_set_op_mode(dev, dev->op_mode);
 	if (ret)
-		goto err_init;
+		goto err_spi;
 
 	ret = ad4110_set_gain(dev, dev->gain);
 	if (ret)
-		goto err_init;
+		goto err_spi;
 
 	ret = ad4110_set_reference(dev, dev->volt_ref);
 	if (ret)
-		goto err_init;
+		goto err_spi;
 
 	/* When AD4110_AFE_ADC_CLOCKED selected, adc_clk must be AD4110_ADC_INT_CLK_CLKIO */
 	if((dev->afe_clk == AD4110_AFE_ADC_CLOCKED)
 	    && (dev->adc_clk != AD4110_ADC_INT_CLK_CLKIO))
-		goto err_init;
+		goto err_spi;
 	else {
 		ret = ad4110_set_adc_clk(dev, dev->adc_clk);
 		if (ret)
-			goto err_init;
+			goto err_spi;
 	}
 
 	ret = ad4110_set_afe_clk(dev, dev->afe_clk);
 	if (ret)
-		goto err_init;
+		goto err_spi;
 
 	*device = dev;
 
 	printf("AD4110 successfully initialized\n");
 	return SUCCESS;
 
-err_init:
+err_spi:
+	spi_remove(dev->spi_dev);
+err_dev:
 	free(dev);
 	pr_err("AD4110 initialization error (%d)\n", ret);
 	return ret;

--- a/drivers/afe/ad4110/ad4110.c
+++ b/drivers/afe/ad4110/ad4110.c
@@ -617,7 +617,28 @@ int32_t ad4110_setup(struct ad4110_dev **device,
 		goto err_init;
 	mdelay(10);
 
-	if(init_param.data_stat == AD4110_ENABLE) {
+	if(init_param.afe_crc_en != AD4110_AFE_CRC_DISABLE) {
+		ret = ad4110_spi_int_reg_write(dev,
+					       A4110_AFE,
+					       AD4110_REG_AFE_CNTRL1,
+					       AD4110_REG_AFE_CNTRL1_CRC_EN);
+		if (ret)
+			goto err_init;
+	}
+	dev->afe_crc_en = init_param.afe_crc_en;
+
+	if(init_param.adc_crc_en != AD4110_ADC_CRC_DISABLE) {
+		ret = ad4110_spi_int_reg_write_msk(dev,
+						   A4110_ADC,
+						   AD4110_REG_ADC_INTERFACE,
+						   AD4110_ADC_CRC_EN(init_param.adc_crc_en),
+						   AD4110_REG_ADC_INTERFACE_CRC_EN_MSK);
+		if (ret)
+			goto err_init;
+	}
+	dev->adc_crc_en = init_param.adc_crc_en;
+
+	if(dev->data_stat == AD4110_ENABLE) {
 		ret = ad4110_spi_int_reg_write_msk(dev,
 						   A4110_ADC,
 						   AD4110_REG_ADC_INTERFACE,
@@ -627,31 +648,12 @@ int32_t ad4110_setup(struct ad4110_dev **device,
 			goto err_init;
 	}
 
-	if(init_param.data_length == AD4110_DATA_WL16) {
+	if(dev->data_length == AD4110_DATA_WL16) {
 		ret = ad4110_spi_int_reg_write_msk(dev,
 						   A4110_ADC,
 						   AD4110_REG_ADC_INTERFACE,
 						   AD4110_DATA_WL16,
 						   AD4110_REG_ADC_INTERFACE_WL16_MSK);
-		if (ret)
-			goto err_init;
-	}
-
-	if(init_param.afe_crc_en != AD4110_AFE_CRC_DISABLE) {
-		ret = ad4110_spi_int_reg_write(dev,
-					       A4110_AFE,
-					       AD4110_REG_AFE_CNTRL1,
-					       AD4110_REG_AFE_CNTRL1_CRC_EN);
-		if (ret)
-			goto err_init;
-	}
-
-	if(init_param.adc_crc_en != AD4110_ADC_CRC_DISABLE) {
-		ret = ad4110_spi_int_reg_write_msk(dev,
-						   A4110_ADC,
-						   AD4110_REG_ADC_INTERFACE,
-						   AD4110_ADC_CRC_EN(init_param.adc_crc_en),
-						   AD4110_REG_ADC_INTERFACE_CRC_EN_MSK);
 		if (ret)
 			goto err_init;
 	}

--- a/drivers/afe/ad4110/ad4110.h
+++ b/drivers/afe/ad4110/ad4110.h
@@ -142,6 +142,12 @@
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
+enum ad4110_voltage_reference {
+	AD4110_EXT_REF = 0,
+	AD4110_INT_2_5V_REF = 2,
+	AD4110_AVDD5_REF = 3
+};
+
 enum ad4110_state {
 	AD4110_DISABLE,
 	AD4110_ENABLE
@@ -206,6 +212,7 @@ struct ad4110_dev {
 	/* SPI */
 	struct spi_desc			*spi_dev;
 	/* Device Settings */
+	enum ad4110_voltage_reference volt_ref;
 	enum ad4110_state		data_stat;
 	enum ad4110_data_word_length 	data_length;
 	enum ad4110_adc_crc_mode 	adc_crc_en;
@@ -219,6 +226,7 @@ struct ad4110_init_param {
 	/* SPI */
 	struct spi_init_param		spi_init;
 	/* Device Settings */
+	enum ad4110_voltage_reference volt_ref;
 	enum ad4110_state		data_stat;
 	enum ad4110_data_word_length 	data_length;
 	enum ad4110_afe_crc_mode	afe_crc_en;
@@ -249,6 +257,10 @@ int32_t ad4110_set_adc_mode(struct ad4110_dev *dev, enum ad4110_adc_mode mode);
 
 /* Set the gain. */
 int32_t ad4110_set_gain(struct ad4110_dev *dev, enum ad4110_gain gain);
+
+/* Set voltage reference. */
+int32_t ad4110_set_reference(struct ad4110_dev *dev,
+			     enum ad4110_voltage_reference ref);
 
 /* Set the operation mode. */
 int32_t ad4110_set_op_mode(struct ad4110_dev *dev, enum ad4110_op_mode mode);

--- a/drivers/afe/ad4110/ad4110.h
+++ b/drivers/afe/ad4110/ad4110.h
@@ -8,6 +8,7 @@
 #include "delay.h"
 #include "gpio.h"
 #include "spi.h"
+#include "irq.h"
 
 /******************************************************************************/
 /********************** Macros and Constants Definitions **********************/
@@ -240,6 +241,9 @@ struct ad4110_dev {
 	enum ad4110_afe_clk_cfg		afe_clk;
 	enum ad4110_adc_clk_sel		adc_clk;
 	uint8_t				addr;
+	/* GPIO - used only for continuous mode */
+	struct irq_ctrl_desc *irq_desc;
+	uint32_t nready_pin;
 };
 
 struct ad4110_init_param {
@@ -257,6 +261,15 @@ struct ad4110_init_param {
 	enum ad4110_afe_clk_cfg		afe_clk;
 	enum ad4110_adc_clk_sel		adc_clk;
 	uint8_t				addr;
+	/* GPIO - used only for continuous mode */
+	struct irq_ctrl_desc *irq_desc;
+	uint32_t nready_pin;
+};
+
+struct ad4110_callback_ctx {
+	struct ad4110_dev *dev;
+	int32_t *buffer;
+	int32_t buffer_size;
 };
 
 /******************************************************************************/
@@ -313,6 +326,10 @@ int32_t ad4110_spi_int_reg_read(struct ad4110_dev *dev,
 				uint8_t reg_map,
 				uint8_t reg_addr,
 				uint32_t *reg_data);
+
+/* Fills buffer with buffer_size number of samples using irq */
+int32_t ad4110_continuous_read(struct ad4110_dev *dev, int32_t *buffer,
+			       int32_t buffer_size);
 
 /* SPI internal DATA register read from device. */
 int32_t ad4110_spi_int_data_reg_read(struct ad4110_dev *dev,

--- a/drivers/afe/ad4110/ad4110.h
+++ b/drivers/afe/ad4110/ad4110.h
@@ -153,6 +153,12 @@ enum ad4110_afe_clk_cfg {
 	AD4110_AFE_INT_CLOCK = 0,
 	AD4110_AFE_ADC_CLOCKED = 2
 };
+
+enum ad4110_sync_en {
+	AD4110_SYNC_DIS,
+	AD4110_SYNC_EN
+};
+
 enum ad4110_voltage_reference {
 	AD4110_EXT_REF = 0,
 	AD4110_INT_2_5V_REF = 2,
@@ -230,6 +236,7 @@ struct ad4110_dev {
 	enum ad4110_afe_crc_mode	afe_crc_en;
 	enum ad4110_op_mode 		op_mode;
 	enum ad4110_gain 		gain;
+	enum ad4110_sync_en 		sync;
 	enum ad4110_afe_clk_cfg		afe_clk;
 	enum ad4110_adc_clk_sel		adc_clk;
 	uint8_t				addr;
@@ -246,6 +253,7 @@ struct ad4110_init_param {
 	enum ad4110_adc_crc_mode	adc_crc_en;
 	enum ad4110_op_mode 		op_mode;
 	enum ad4110_gain 		gain;
+	enum ad4110_sync_en 		sync;
 	enum ad4110_afe_clk_cfg		afe_clk;
 	enum ad4110_adc_clk_sel		adc_clk;
 	uint8_t				addr;

--- a/drivers/afe/ad4110/ad4110.h
+++ b/drivers/afe/ad4110/ad4110.h
@@ -205,8 +205,6 @@ enum ad4110_gain {
 struct ad4110_dev {
 	/* SPI */
 	struct spi_desc			*spi_dev;
-	/* GPIO */
-	struct gpio_desc		*gpio_reset;
 	/* Device Settings */
 	enum ad4110_state		data_stat;
 	enum ad4110_data_word_length 	data_length;
@@ -220,8 +218,6 @@ struct ad4110_dev {
 struct ad4110_init_param {
 	/* SPI */
 	struct spi_init_param		spi_init;
-	/* GPIO */
-	struct gpio_init_param		gpio_reset;
 	/* Device Settings */
 	enum ad4110_state		data_stat;
 	enum ad4110_data_word_length 	data_length;

--- a/drivers/afe/ad4110/ad4110.h
+++ b/drivers/afe/ad4110/ad4110.h
@@ -15,6 +15,7 @@
 
 #define AD4110_CMD_WR_COM_REG(x)   (0x00 | ((x) & 0xF)) // Write to Register x
 #define AD4110_CMD_READ_COM_REG(x) (0x40 | ((x) & 0xF)) // Read from Register x
+#define AD4110_DEV_ADDR_MASK	   (0x30) // Device address mask
 
 /* Register map */
 #define A4110_ADC 0x00
@@ -213,6 +214,7 @@ struct ad4110_dev {
 	enum ad4110_afe_crc_mode	afe_crc_en;
 	enum ad4110_op_mode 		op_mode;
 	enum ad4110_gain 		gain;
+	uint8_t				addr;
 };
 
 struct ad4110_init_param {
@@ -227,6 +229,7 @@ struct ad4110_init_param {
 	enum ad4110_adc_crc_mode	adc_crc_en;
 	enum ad4110_op_mode 		op_mode;
 	enum ad4110_gain 		gain;
+	uint8_t				addr;
 };
 
 /******************************************************************************/

--- a/drivers/afe/ad4110/ad4110.h
+++ b/drivers/afe/ad4110/ad4110.h
@@ -273,6 +273,10 @@ int32_t ad4110_spi_int_reg_read(struct ad4110_dev *dev,
 				uint8_t reg_addr,
 				uint32_t *reg_data);
 
+/* SPI internal DATA register read from device. */
+int32_t ad4110_spi_int_data_reg_read(struct ad4110_dev *dev,
+				     uint32_t *reg_data);
+
 /* Initialize the device. */
 int32_t ad4110_setup(struct ad4110_dev **device,
 		     struct ad4110_init_param init_param);

--- a/drivers/afe/ad4110/ad4110.h
+++ b/drivers/afe/ad4110/ad4110.h
@@ -104,8 +104,8 @@
 #define AD4110_REG_ADC_MODE_MSK			0x70
 #define AD4110_ADC_MODE(x)			(((x) & 0x7) << 4)
 #define AD4110_REG_ADC_MODE_REF_EN		(1 << 15)
-#define AD4110_REG_ADC_DELAY			(((x) & 0x7) << 8)
-#define AD4110_REG_ADC_CLK_SEL			(((x) & 0x3) << 3)
+#define AD4110_REG_ADC_DELAY(x)			(((x) & 0x7) << 8)
+#define AD4110_REG_ADC_CLK_SEL(x)		(((x) & 0x3) << 2)
 
 /* ADC_INTERFACE Register */
 #define AD4110_REG_ADC_INTERFACE_CRC_EN_MSK	0x0C
@@ -120,7 +120,7 @@
 #define AD4110_REG_ADC_CONFIG_CHAN_EN_1		(1 << 1)
 #define AD4110_REG_ADC_CONFIG_CHAN_EN_2		(1 << 2)
 #define AD4110_REG_ADC_CONFIG_CHAN_EN_3		(1 << 3)
-#define AD4110_REG_ADC_CONFIG_REF_SEL(x)	((((x) & 0x3) << 4)
+#define AD4110_REG_ADC_CONFIG_REF_SEL(x)	(((x) & 0x3) << 4)
 #define AD4110_REG_ADC_CONFIG_BIT_6		(1 << 6)
 #define AD4110_REG_ADC_CONFIG_AIN_BUFF(x)	((((x) & 0x3) << 10)
 #define AD4110_REG_ADC_CONFIG_BI_UNIPOLAR	(1 << 12)
@@ -132,8 +132,8 @@
 #define AD4110_REG_ADC_FILTER_EN_ENH		(1 << 11)
 
 /* ADC_GPIO_CONFIG Register */
-#define AD4110_REG_GPIO_CONFIG_ERR_EN(x)	((((x) & 0x3) << 9)
-#define AD4110_REG_GPIO_CONFIG_SYNC_EN		(1 << 11)
+#define AD4110_REG_GPIO_CONFIG_ERR_EN(x)	(((x) & 0x3) << 9)
+#define AD4110_REG_GPIO_CONFIG_SYNC_EN(x)	(((x) & 0x1) << 11)
 
 /* 8-bits wide checksum generated using the polynomial */
 #define AD4110_CRC8_POLY	0x07 // x^8 + x^2 + x^1 + x^0
@@ -153,12 +153,12 @@ enum ad4110_data_word_length {
 };
 
 enum ad4110_adc_mode {
-	AD4110_CONTINOUS_CONV_MODE,
-	AD4110_SINGLE_CONV_MODE,
-	AD4110_STANDBY_MODE,
-	AD4110_PW_DOWN_MODE,
+	AD4110_CONTINOUS_CONV_MODE = 0,
+	AD4110_SINGLE_CONV_MODE = 1,
+	AD4110_STANDBY_MODE = 2,
+	AD4110_PW_DOWN_MODE = 3,
 	AD4110_SYS_OFFSET_CAL = 6,
-	AD4110_SYS_GAIN_CAL
+	AD4110_SYS_GAIN_CAL = 7
 };
 
 enum ad4110_op_mode {

--- a/drivers/afe/ad4110/ad4110.h
+++ b/drivers/afe/ad4110/ad4110.h
@@ -142,6 +142,17 @@
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
+/* If AD4110_AFE_ADC_CLOCKED selected, select AD4110_ADC_INT_CLK_CLKIO */
+enum ad4110_adc_clk_sel {
+	AD4110_ADC_INT_CLK,
+	AD4110_ADC_INT_CLK_CLKIO,
+	AD4110_ADC_EXT_CLK,
+};
+
+enum ad4110_afe_clk_cfg {
+	AD4110_AFE_INT_CLOCK = 0,
+	AD4110_AFE_ADC_CLOCKED = 2
+};
 enum ad4110_voltage_reference {
 	AD4110_EXT_REF = 0,
 	AD4110_INT_2_5V_REF = 2,
@@ -219,6 +230,8 @@ struct ad4110_dev {
 	enum ad4110_afe_crc_mode	afe_crc_en;
 	enum ad4110_op_mode 		op_mode;
 	enum ad4110_gain 		gain;
+	enum ad4110_afe_clk_cfg		afe_clk;
+	enum ad4110_adc_clk_sel		adc_clk;
 	uint8_t				addr;
 };
 
@@ -233,6 +246,8 @@ struct ad4110_init_param {
 	enum ad4110_adc_crc_mode	adc_crc_en;
 	enum ad4110_op_mode 		op_mode;
 	enum ad4110_gain 		gain;
+	enum ad4110_afe_clk_cfg		afe_clk;
+	enum ad4110_adc_clk_sel		adc_clk;
 	uint8_t				addr;
 };
 
@@ -257,6 +272,12 @@ int32_t ad4110_set_adc_mode(struct ad4110_dev *dev, enum ad4110_adc_mode mode);
 
 /* Set the gain. */
 int32_t ad4110_set_gain(struct ad4110_dev *dev, enum ad4110_gain gain);
+
+/* Set ADC clock mode. */
+int32_t ad4110_set_adc_clk(struct ad4110_dev *dev, enum ad4110_adc_clk_sel clk);
+
+/* Set AFE clock mode. */
+int32_t ad4110_set_afe_clk(struct ad4110_dev *dev, enum ad4110_afe_clk_cfg clk);
 
 /* Set voltage reference. */
 int32_t ad4110_set_reference(struct ad4110_dev *dev,


### PR DESCRIPTION
This PR tries to solve: https://ez.analog.com/microcontroller-no-os-drivers/f/q-a/545992/ad4110-1-no-os-driver-issue-in-spi-library-linux-while-multiple-adc-communication-on-same-chip-select-line

Will be keept as draft after clients confirms that it solves the issue because I didn't test it on hardware. 