### PR TITLE
driver/ad7746: iio driver debug interface fix

### DIFF
--- a/drivers/cdc/ad7746/iio_ad7746.c
+++ b/drivers/cdc/ad7746/iio_ad7746.c
@@ -9,16 +9,16 @@
 #include "util.h"
 #include "ad7746.h"
 
-static int32_t _ad7746_read_register2(struct ad7746_dev *dev, uint32_t reg,
+static int32_t _ad7746_read_register2(struct ad7746_iio_dev *dev, uint32_t reg,
 				      uint32_t *readval)
 {
-	return ad7746_reg_read(dev, reg, (uint8_t *)readval, 1);
+	return ad7746_reg_read(dev->ad7746_dev, reg, (uint8_t *)readval, 1);
 }
 
-static int32_t _ad7746_write_register2(struct ad7746_dev *dev, uint32_t reg,
+static int32_t _ad7746_write_register2(struct ad7746_iio_dev *dev, uint32_t reg,
 				       uint32_t writeval)
 {
-	return ad7746_reg_write(dev, reg, (uint8_t *)writeval, 1);
+	return ad7746_reg_write(dev->ad7746_dev, reg, (uint8_t *)writeval, 1);
 }
 
 static inline bool _capdiff(struct ad7746_cap *cap1, struct ad7746_cap *cap2)


### PR DESCRIPTION
Due to a last minute codereview comment I have introduced an incorrect
dereferencing in the original driver. This commit fixes it and now
the debugging interface works with this device.
