### PR TITLE
Add parameterized JTAG filtering to PS init

### DIFF
--- a/tools/scripts/generic.mk
+++ b/tools/scripts/generic.mk
@@ -10,6 +10,7 @@ export AR
 export EXTRA_INC_PATHS
 export FLAGS_WITHOUT_D
 export PROJECT_BUILD
+export JTAG_CABLE_ID
 #------------------------------------------------------------------------------
 #                              UTIL FUNCTIONS
 #------------------------------------------------------------------------------

--- a/tools/scripts/xilinx.mk
+++ b/tools/scripts/xilinx.mk
@@ -27,6 +27,7 @@ LIB_PATHS	+= -L$(BUILD_DIR)/bsp/$(ARCH)/lib
 
 PLATFORM_RELATIVE_PATH = $1
 PLATFORM_FULL_PATH = $1
+JTAG_CABLE_ID = $2
 
 ################|--------------------------------------------------------------
 ################|                   Zynq                                       
@@ -138,7 +139,7 @@ $(BINARY): $(TEMP_DIR)/arch.txt
 
 PHONY += xilinx_run
 xilinx_run: all
-	$(MUTE) $(call tcl_util, upload) $(HIDE)
+	$(MUTE) $(call tcl_util, upload) $(HIDE) $(JTAG_CABLE_ID)
 
 $(TEMP_DIR)/arch.txt: $(HARDWARE)
 	$(MUTE) $(call mk_dir,$(BUILD_DIR)/app $(BUILD_DIR)/app/src $(OBJECTS_DIR) $(TEMP_DIR)) $(HIDE)


### PR DESCRIPTION
This change allows more advanced filtering of the JTAG targets using the
jtag_cable_name filter. This is required when you have multiple JTAG
cables connected to the same machine. Not providing the argument
JTAG_CABLE_ID will fall back to the standard behavior.

This is required for the hardware testing hardness.

Example usage:
```
make run JTAG_CABLE_ID=210299A567FE
```

This has been tested with and without this new argument with ADRV9361-Z7035 boards and the Xilinx SDK 2019.1.

Signed-off-by: Travis F. Collins <travis.collins@analog.com>