### PR TITLE
ad9081: Fix 4x4 Crossbar Mux0 Mappings for AD9081

### DIFF
--- a/drivers/adc/ad9081/ad9081.c
+++ b/drivers/adc/ad9081/ad9081.c
@@ -595,6 +595,17 @@ static int32_t ad9081_setup(struct ad9081_phy *phy)
 	if (ret != 0)
 		return ret;
 
+	/* Fix: 4x4 Crossbar Mux0 Mappings for AD9081 */
+	ret  = adi_ad9081_adc_pfir_din_select_set(&phy->ad9081,
+		AD9081_ADC_PFIR_ADC_PAIR0, 0, 1);
+	if (ret != 0)
+		return ret;
+
+	ret  = adi_ad9081_adc_pfir_din_select_set(&phy->ad9081,
+		AD9081_ADC_PFIR_ADC_PAIR1, 3, 0);
+	if (ret != 0)
+		return ret;
+
 	/* setup txfe dac channel gain */
 	ret = adi_ad9081_dac_duc_nco_gains_set(&phy->ad9081,
 					       phy->dac_cache.chan_gain);


### PR DESCRIPTION
Corresponds to linux commit:
18fa16da2d3cf5c78f6c13ec651a667313102813

Signed-off-by: Darius Berghe <darius.berghe@analog.com>