### PR TITLE
tools: scripts: libraries.mk remove git command

### DIFF
--- a/tools/scripts/libraries.mk
+++ b/tools/scripts/libraries.mk
@@ -11,8 +11,7 @@ include $(NO-OS)/tools/scripts/iio_srcs.mk
 
 CFLAGS += -DTINYIIOD_VERSION_MAJOR=0	 \
 	   -DTINYIIOD_VERSION_MINOR=1		 \
-	   -DTINYIIOD_VERSION_GIT=0x$(shell git -C $(NO-OS)/libraries/iio/libtinyiiod/ \
-	   				rev-parse --short HEAD) \
+	   -DTINYIIOD_VERSION_GIT=0x440e425	 \
 	   -DIIOD_BUFFER_SIZE=0x1000		 \
 	   -D_USE_STD_INT_TYPES
 CFLAGS += -DIIO_SUPPORT


### PR DESCRIPTION
In order to use git on windows it needs to be installed making harder
the build process. If the version is hardcoded, posible issues related
with the git command are avoided.

Signed-off-by: Mihail Chindris <mihail.chindris@analog.com>