### PR TITLE
add device tree like functionality to no-os

### DIFF
--- a/include/dt.h
+++ b/include/dt.h
@@ -1,0 +1,62 @@
+/***************************************************************************//**
+ *   @file   dt.h
+ *   @brief  Linux device tree like functionality.
+ *   @author Darius Berghe (darius.berghe@analog.com)
+********************************************************************************
+ * Copyright 2021(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef _DT_H_
+#define _DT_H_
+#include <stdint.h>
+
+struct dt_property {
+	const char *name;
+	const int value; // contains the number of elements in array when array is given
+	void *array;
+};
+
+struct dt_properties {
+	struct dt_property *table;
+	unsigned int size;
+	int dflt; // default value, returned by dt_value() when property not found
+};
+
+void dt_init(struct dt_properties *ps, struct dt_property *table,
+	     unsigned int size, int dflt);
+void dt_default(struct dt_properties *ps, int dflt);
+int dt_value(struct dt_properties ps, const char *name);
+int dt_array(struct dt_properties ps, const char *name, void *array,
+	     size_t item_sz);
+
+#endif

--- a/util/dt.c
+++ b/util/dt.c
@@ -1,0 +1,77 @@
+/***************************************************************************//**
+ *   @file   dt.c
+ *   @brief  Linux device tree like functionality.
+ *   @author Darius Berghe (darius.berghe@analog.com)
+********************************************************************************
+ * Copyright 2021(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include <stdlib.h>
+#include <string.h>
+#include "dt.h"
+
+static int _cmp(const void *va, const void *vb)
+{
+	const struct dt_property *a = va, *b = vb;
+	return strcmp(a->name, b->name);
+}
+
+void dt_init(struct dt_properties *ps, struct dt_property *table,
+	     unsigned int size, int dflt)
+{
+	ps->table = table;
+	ps->size = size;
+	ps->dflt = dflt;
+	qsort (table, size, sizeof (struct dt_property), _cmp);
+}
+
+int dt_value(struct dt_properties ps, const char *name)
+{
+	struct dt_property name_dt_property[1] = {{name}};
+	struct dt_property *dt_property = bsearch(name_dt_property, ps.table,
+					  ps.size, sizeof(struct dt_property), _cmp);
+	return dt_property ? dt_property->value : ps.dflt;
+}
+
+int dt_array(struct dt_properties ps, const char *name, void *array,
+	     size_t item_sz)
+{
+	struct dt_property name_dt_property[1] = {{name}};
+	struct dt_property *dt_property = bsearch(name_dt_property, ps.table,
+					  ps.size, sizeof(struct dt_property), _cmp);
+	if(dt_property && dt_property->array) {
+		memcpy(array, dt_property->array, dt_property->value * item_sz);
+		return dt_property->value;
+	}
+	return ps.dflt;
+}


### PR DESCRIPTION
Many of our drivers are written first on linux and then ported on
no-OS. In order to ease the transition of a driver from linux
towards no-OS, a device tree like functionality is added with this
change.

The way it works is as follows. A linux device tree source may look
something like this:

ad9081_rx_jesd_l0: link@0 {
	...
	adi,logical-lane-mapping = /bits/ 8 <2 0 7 6 5 4 3 1>;
	adi,link-mode = <10>;
	adi,subclass = <1>;
	adi,version = <1>;
	adi,dual-link = <0>;
	...
}

This is then read during probe with macros like this which populate
a certain variable with the value read from device tree:

JESD204_LNK_READ_DEVICE_ID(dev, np, &link->jesd204_link,
			   &link->jesd_param.jesd_did, 0);

Here, the variable is "link->jesd_param.jesd_did" and the value was
read from device property "device-id" (this info is available in the
macro definition).

To do the same thing on no-OS, one may first define the equivalent
of a device tree in a header file. Note the similarity with the
linux device tree (identical names, easy correspondence, easy syntax
adaptation).

struct dt_property link_tx_ps_init[] = {
	{"logical-lane-mapping", 8, (unsigned int []){0, 2, 7, 6, 1, 5, 4, 3}},
	{"link-mode", 9},
	{"subclass", 1},
	{"version", 1},
	{"dual-link", 0},
	...
};

This may then be used in application code by first initializing a
dt_properties structure:

struct dt_properties link_tx_ps;
dt_init(&link_tx_ps, link_tx_ps_init, ARRAY_SIZE(link_tx_ps_init), 0);

Once initialized, the user may search for device tree keywords that
table, get their values, and assign them to variables. Here, the
correspondence between variable and device tree property is even
more clear than on linux.

jp->jesd_mode_id = dt_value(link_tx_ps, "link-mode");
jp->jesd_subclass = dt_value(link_tx_ps, "subclass");
jp->jesd_jesdv = dt_value(link_tx_ps, "version");
jp->jesd_duallink = dt_value(link_tx_ps, "dual-link");

Even arrays may be initialized from such a device tree like interface.

uint8_t llmp[8];
dt_array(link_tx_ps, "logical-lane-mapping", llmp, sizeof(llmp[0]));

Performance-wise, even though the search is fast (binary search on
the sorted array), it's obviously slower than a direct approach
using arbitrary names for properties that the programmer knows what
it corresponds in the linux device tree.

My arguments against that are:
- performance doesn't matter, this code is only executed at the
  initialization phase
- the benefit of seeing clearly the correspondance between variable
  and property and the fact that the configuration is copy-pastable
  with minor adaptations make this a better choice than plain init
  param approach.

Signed-off-by: Darius Berghe <darius.berghe@analog.com>