### PR TITLE
Implemented Support to ADT7xxx Family

### DIFF
--- a/drivers/temperature/adt7420/adt7420.c
+++ b/drivers/temperature/adt7420/adt7420.c
@@ -3,7 +3,7 @@
  *   @brief  Implementation of ADT7420 Driver.
  *   @author DBogdan (dragos.bogdan@analog.com)
 ********************************************************************************
- * Copyright 2012(c) Analog Devices, Inc.
+ * Copyright 2012, 2019, 2021(c) Analog Devices, Inc.
  *
  * All rights reserved.
  *
@@ -40,8 +40,35 @@
 /******************************************************************************/
 /***************************** Include Files **********************************/
 /******************************************************************************/
+#include <stdint.h>
 #include <stdlib.h>
+#include "spi.h"
+#include "i2c.h"
+#include "error.h"
 #include "adt7420.h"
+
+const struct adt7420_chip_info chip_info[] = {
+	[ID_ADT7410] = {
+		.resolution = 16,
+		.communication = I2C,
+	},
+	[ID_ADT7420] = {
+		.resolution = 16,
+		.communication = I2C,
+	},
+	[ID_ADT7422] = {
+		.resolution = 16,
+		.communication = I2C,
+	},
+	[ID_ADT7310] = {
+		.resolution = 16,
+		.communication = SPI,
+	},
+	[ID_ADT7320] = {
+		.resolution = 16,
+		.communication = SPI,
+	}
+};
 
 /***************************************************************************//**
  * @brief Reads the value of a register.
@@ -51,44 +78,57 @@
  *
  * @return register_value  - Value of the register.
 *******************************************************************************/
-uint8_t adt7420_get_register_value(struct adt7420_dev *dev,
-				   uint8_t register_address)
+uint16_t adt7420_get_register_value(struct adt7420_dev *dev,
+				    uint8_t register_address)
 {
-	uint8_t register_value = 0;
-
-	i2c_write(dev->i2c_desc,
-		  &register_address,
-		  1,
-		  0);
-	i2c_read(dev->i2c_desc,
-		 &register_value,
-		 1,
-		 1);
-
-	return register_value;
+	if (adt7420_is_spi(dev))
+		return adt7420_spi_get_register_value(dev, register_address);
+	else
+		return adt7420_i2c_get_register_value(dev, register_address);
 }
 
 /***************************************************************************//**
- * @brief Sets the value of a register.
+ * @brief Sets the value of a register SPI/I2C.
  *
  * @param dev              - The device structure.
  * @param register_address - Address of the register.
- * @param register_value   - Value of the register.
+ * @param num_data_bytes   - Number of bytes.
+ * @param data             - Data to be written in input register.
+ * @param mask		   - Bit Mask of the bit to be written
+ * @param value		   - Value of the bit
  *
- * @return None.
+ * @return SUCCESS in case of success, FAILURE otherwise.
 *******************************************************************************/
-void adt7420_set_register_value(struct adt7420_dev *dev,
-				uint8_t register_address,
-				uint8_t register_value)
+int32_t set_register_value(struct adt7420_dev *dev,
+			   uint8_t register_address,
+			   uint8_t num_data_bytes,
+			   uint8_t *data, uint8_t mask, uint8_t value)
 {
-	uint8_t data_buffer[2] = {0, 0};
 
-	data_buffer[0] = register_address;
-	data_buffer[1] = register_value;
-	i2c_write(dev->i2c_desc,
-		  data_buffer,
-		  2,
-		  1);
+	uint8_t data_buffer[3] = {0, 0, 0};
+
+	data[0] &= ~mask;
+	data[0] |= value;
+	data_buffer[1] = data[0];
+	data_buffer[2] = data[1];
+
+	if (adt7420_is_spi(dev)) {
+		/*Form the SPI register read command byte. Bits [5:3] of command byte
+		 holds the register address.*/
+		data_buffer[0] = (register_address << 3) & ADT7320_WRITE_MASK_CMD;
+		if (spi_write_and_read(dev->spi_desc, data_buffer, num_data_bytes) != SUCCESS)
+			return FAILURE;
+	} else {
+		data_buffer[0] = register_address;
+
+		if (i2c_write(dev->i2c_desc,
+			      data_buffer,
+			      num_data_bytes,
+			      1) != SUCCESS)
+			//no repeat start
+			return FAILURE;
+	}
+	return SUCCESS;
 }
 
 /***************************************************************************//**
@@ -110,24 +150,51 @@ int32_t adt7420_init(struct adt7420_dev **device,
 {
 	struct adt7420_dev *dev;
 	int32_t status;
-	uint8_t test = 0;
+	uint8_t device_connected_check = 0;
 
 	dev = (struct adt7420_dev *)malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
-	/* I2C */
-	status = i2c_init(&dev->i2c_desc, &init_param.i2c_init);
+	dev->active_device = init_param.active_device;
 
-	/* Device Settings */
-	dev->resolution_setting = init_param.resolution_setting;
+	if (adt7420_is_spi(dev))
+		status = spi_init(&dev->spi_desc, &init_param.interface_init.spi_init);
+	else
+		status = i2c_init(&dev->i2c_desc, &init_param.interface_init.i2c_init);
 
-	test   = adt7420_get_register_value(dev, ADT7420_REG_ID);
-	if(test != ADT7420_DEFAULT_ID)
-		status = -1;
+	if (status != FAILURE) {
+		/* Device Settings */
+		dev->resolution_setting = init_param.resolution_setting;
 
-	*device = dev;
+		/* Reset device to default values to ensure all internal circuitry is properly initialised*/
+		status = adt7420_reset(dev);
+		if (status < 0)
+			goto adt7420_init_error;
 
+		/*Register read to ensure that next read will be valid - acts as 200us delay while
+		  device resets*/
+		if (adt7420_is_spi(dev))
+			device_connected_check = adt7420_get_register_value(dev, ADT7320_REG_ID);
+		else
+			device_connected_check = adt7420_get_register_value(dev, ADT7420_REG_ID);
+
+		device_connected_check >>= 4; // Manufacturer ID
+
+		if(device_connected_check != ADT7xxx_ID) // AD7xxx ID Check
+			status = FAILURE;
+		else
+			status = SUCCESS;
+
+		*device = dev;
+
+		return status;
+	}
+
+	return status;
+
+adt7420_init_error:
+	adt7420_remove(dev);
 	return status;
 }
 
@@ -142,35 +209,17 @@ int32_t adt7420_remove(struct adt7420_dev *dev)
 {
 	int32_t ret;
 
-	ret = i2c_remove(dev->i2c_desc);
-
+	if (!(adt7420_is_spi(dev)))
+		ret = i2c_remove(dev->i2c_desc);
+	else
+		ret = spi_remove(dev->spi_desc);
 	free(dev);
 
 	return ret;
 }
 
 /***************************************************************************//**
- * @brief Resets the ADT7420.
- *        The ADT7420 does not respond to I2C bus commands while the default
- *        values upload (approximately 200 us).
- *
- * @param dev - The device structure.
- *
- * @return None.
-*******************************************************************************/
-void adt7420_reset(struct adt7420_dev *dev)
-{
-	uint8_t register_address = ADT7420_REG_RESET;
-
-	i2c_write(dev->i2c_desc,
-		  &register_address,
-		  1,
-		  1);
-	dev->resolution_setting = 0;
-}
-
-/***************************************************************************//**
- * @brief Sets the operational mode for ADT7420.
+ * @brief Sets the operational mode for ADT7420/ADT7320.
  *
  * @param dev  - The device structure.
  * @param mode - Operation mode.
@@ -184,16 +233,23 @@ void adt7420_reset(struct adt7420_dev *dev)
 void adt7420_set_operation_mode(struct adt7420_dev *dev,
 				uint8_t mode)
 {
-	uint8_t register_value = 0;
+	uint8_t register_value [2] = { 0, 0 };
+	uint8_t device_reg_address;
 
-	register_value  = adt7420_get_register_value(dev, ADT7420_REG_CONFIG);
-	register_value &= ~ADT7420_CONFIG_OP_MODE(ADT7420_OP_MODE_SHUTDOWN);
-	register_value |= ADT7420_CONFIG_OP_MODE(mode);
-	adt7420_set_register_value(dev, ADT7420_REG_CONFIG, register_value);
+	if (adt7420_is_spi(dev)) {
+		device_reg_address = ADT7320_REG_CONFIG;
+		register_value[0]  = adt7420_get_register_value(dev, device_reg_address);
+	} else {
+		device_reg_address = ADT7420_REG_CONFIG;
+		register_value[0]  = adt7420_get_register_value(dev, device_reg_address);
+	}
+
+	set_register_value(dev, device_reg_address, 2, register_value,
+			   ADT7420_CONFIG_OP_MODE(ADT7420_OP_MODE_SHUTDOWN), ADT7420_CONFIG_OP_MODE(mode));
 }
 
 /***************************************************************************//**
- * @brief Sets the resolution for ADT7420.
+ * @brief Sets the resolution for ADT7420/ADT7320.
  *
  * @param dev        - The device structure.
  * @param resolution - Resolution.
@@ -205,13 +261,50 @@ void adt7420_set_operation_mode(struct adt7420_dev *dev,
 void adt7420_set_resolution(struct adt7420_dev *dev,
 			    uint8_t resolution)
 {
-	uint8_t register_value = 0;
+	uint8_t register_value[1] = { 0 };
+	uint8_t device_reg_address;
 
-	register_value  = adt7420_get_register_value(dev, ADT7420_REG_CONFIG);
-	register_value &= ~ADT7420_CONFIG_RESOLUTION;
-	register_value |= (resolution * ADT7420_CONFIG_RESOLUTION);
-	adt7420_set_register_value(dev, ADT7420_REG_CONFIG, register_value);
+	if (adt7420_is_spi(dev)) {
+		device_reg_address = ADT7320_REG_CONFIG;
+		register_value[0]  = adt7420_get_register_value(dev, device_reg_address);
+	} else {
+		device_reg_address = ADT7420_REG_CONFIG;
+		register_value[0]  = adt7420_get_register_value(dev, device_reg_address);
+	}
+
+	set_register_value(dev, device_reg_address, 2, register_value,
+			   ADT7420_CONFIG_RESOLUTION, (resolution * ADT7420_CONFIG_RESOLUTION));
 	dev->resolution_setting = resolution;
+}
+
+/***************************************************************************//**
+ * @brief Resets the SPI or I2C inteface for the ADT7420/ADT7320
+ *
+ * @param dev        - The device structure.
+ *
+ * @return SUCCESS in case of Success, FAILURE otherwise.
+*******************************************************************************/
+int32_t adt7420_reset(struct adt7420_dev *dev)
+{
+	uint8_t data_buffer[] = { 0xFF, 0xFF, 0xFF, 0xFF };
+
+	if (adt7420_is_spi(dev)) {
+		if (spi_write_and_read(dev->spi_desc,
+				       data_buffer,
+				       sizeof(data_buffer)) != SUCCESS)
+			return FAILURE;
+	} else {
+		uint8_t register_address = ADT7420_REG_RESET;
+		if (i2c_write(dev->i2c_desc,
+			      &register_address,
+			      1,
+			      1) != SUCCESS) {
+			//no repeat start
+			return FAILURE;
+		}
+	}
+	dev->resolution_setting = 0;
+	return SUCCESS;
 }
 
 /***************************************************************************//**
@@ -223,14 +316,16 @@ void adt7420_set_resolution(struct adt7420_dev *dev,
 *******************************************************************************/
 float adt7420_get_temperature(struct adt7420_dev *dev)
 {
-	uint8_t msb_temp = 0;
-	uint8_t lsb_temp = 0;
 	uint16_t temp = 0;
 	float temp_c = 0;
 
-	msb_temp = adt7420_get_register_value(dev, ADT7420_REG_TEMP_MSB);
-	lsb_temp = adt7420_get_register_value(dev, ADT7420_REG_TEMP_LSB);
-	temp    = ((uint16_t)msb_temp << 8) + lsb_temp;
+	if (adt7420_is_spi(dev))
+		temp = adt7420_get_register_value(dev, ADT7320_REG_TEMP);
+	else {
+		temp  = adt7420_get_register_value(dev, ADT7420_REG_TEMP_MSB) << 8;
+		temp |= adt7420_get_register_value(dev, ADT7420_REG_TEMP_LSB);
+	}
+
 	if(dev->resolution_setting) {
 		if(temp & 0x8000)
 			/*! Negative temperature */
@@ -249,4 +344,104 @@ float adt7420_get_temperature(struct adt7420_dev *dev)
 	}
 
 	return temp_c;
+}
+
+
+/**************************************************************************//**
+ * @brief Write to input shift register SPI interface.
+ *
+ * @param dev               - The device structure.
+ * @param register_address  - Command control bits.
+ * @param data              - Data to be written in input register.
+ *
+ * @return  read_back_data  - value read from register.
+******************************************************************************/
+uint16_t set_shift_reg(struct adt7420_dev *dev,
+		       uint8_t register_address,
+		       uint8_t *data)
+{
+	uint8_t data_buffer[3] = { 0, 0, 0 };
+	uint16_t read_back_data = 0;
+	uint8_t num_bytes;
+
+	switch (register_address) {
+	case ADT7320_REG_STATUS:
+	case ADT7320_REG_CONFIG:
+	case ADT7320_REG_ID:
+	case ADT7320_REG_HIST:
+		num_bytes = 2;
+		break;
+	default:
+		num_bytes = 3;
+		break;
+	}
+
+	data_buffer[0] = data[0];
+	data_buffer[1] = data[1];
+	spi_write_and_read(dev->spi_desc, data_buffer, num_bytes);
+
+	if (num_bytes == 2)
+		read_back_data = data_buffer[1];
+	else
+		read_back_data = data_buffer[1] << 8 | data_buffer[2];
+
+	return read_back_data;
+}
+
+/***************************************************************************//**
+ * @brief Reads the value of a register SPI interface device.
+ *
+ * @param dev              - The device structure.
+ * @param register_address - Address of the register.
+ *
+ * @return register_value  - Value of the register.
+*******************************************************************************/
+uint16_t adt7420_spi_get_register_value(struct adt7420_dev *dev,
+					uint8_t register_address)
+{
+	uint8_t data[2] = { 0, 0xFF };
+	/* Form the SPI register read command byte. Bits [5:3] of command byte
+		 holds the register address.*/
+	data[0] = ADT7320_READ_CMD  | (register_address << 3);
+
+	return set_shift_reg(dev, register_address, data);
+}
+
+/***************************************************************************//**
+ * @brief Reads the value of a register I2C interface device.
+ *
+ * @param dev              - The device structure.
+ * @param register_address - Address of the register.
+ *
+ * @return register_value  - Value of the register.
+*******************************************************************************/
+uint16_t adt7420_i2c_get_register_value(struct adt7420_dev *dev,
+					uint8_t register_address)
+{
+	uint8_t register_value = 0;
+	uint8_t data[2] = { 0, 0xFF };
+	data[0] = register_address;
+
+	i2c_write(dev->i2c_desc,
+		  &register_address,
+		  1,
+		  0); //add a repeat start
+	i2c_read(dev->i2c_desc,
+		 &register_value,
+		 1,
+		 1);
+
+	return register_value;
+}
+
+/***************************************************************************//**
+ * @brief Check if the interface of the selected device is SPI
+ *
+ * @param dev              - The device structure.
+ *
+ * @return True in case of an SPI interface, False Otherwise
+*******************************************************************************/
+bool adt7420_is_spi(struct adt7420_dev *dev)
+{
+	return (chip_info[dev->active_device].communication == SPI);
 }

--- a/drivers/temperature/adt7420/adt7420.h
+++ b/drivers/temperature/adt7420/adt7420.h
@@ -3,7 +3,7 @@
  *   @brief  Header file of ADT7420 Driver.
  *   @author DBogdan (dragos.bogdan@analog.com)
 ********************************************************************************
- * Copyright 2012(c) Analog Devices, Inc.
+ * Copyright 2012, 2019, 2021(c) Analog Devices, Inc.
  *
  * All rights reserved.
  *
@@ -42,19 +42,36 @@
 /******************************************************************************/
 /***************************** Include Files **********************************/
 /******************************************************************************/
-#include <stdint.h>
+
+#include "spi.h"
 #include "i2c.h"
+#include "util.h"
+#include <stdbool.h>
 
 /******************************************************************************/
 /************************** ADT7420 Definitions *******************************/
 /******************************************************************************/
 
 /* ADT7420 address */
-#define ADT7420_A0_PIN(x)	(((x) & 0x1) << 0) // I2C Serial Bus Address Selection Pin
-#define ADT7420_A1_PIN(x)	(((x) & 0x1) << 1) // I2C Serial Bus Address Selection Pin
-#define ADT7420_ADDRESS(x,y)	(0x48 + ADT7420_A1_PIN(x) + ADT7420_A0_PIN(y))
+#define ADT7420_A0_PIN(x)		(((x) & 0x1) << 0) // I2C Serial Bus Address Selection Pin
+#define ADT7420_A1_PIN(x)		(((x) & 0x1) << 1) // I2C Serial Bus Address Selection Pin
+#define ADT7420_ADDRESS(x,y)		(0x48 + ADT7420_A1_PIN(x) + ADT7420_A0_PIN(y))
 
-/* ADT7420 registers */
+/* ADT7320  (SPI) registers */
+#define ADT7320_REG_STATUS		0x00 // Status
+#define ADT7320_REG_CONFIG		0x01 // Configuration
+#define ADT7320_REG_TEMP    		0x02 // Temperature value
+#define ADT7320_REG_ID			0x03 // ID
+#define ADT7320_REG_T_CRIT		0x04 // Temperature CRIT setpoint (147'C)
+#define ADT7320_REG_HIST		0x05 // Temperature HYST setpoint (5'C)
+#define ADT7320_REG_T_HIGH    		0x06 // Temperature HIGH setpoint (64'C)
+#define ADT7320_REG_T_LOW    		0x07 // Temperature LOW setpoint (10'C)
+
+/* ADT7320 SPI command byte */
+#define ADT7320_WRITE_MASK_CMD		0b00111000 // SPI write command
+#define ADT7320_READ_CMD		0b01000000 // SPI read command
+
+/* ADT7420 (I2C) registers */
 #define ADT7420_REG_TEMP_MSB		0x00 // Temperature value MSB
 #define ADT7420_REG_TEMP_LSB		0x01 // Temperature value LSB
 #define ADT7420_REG_STATUS		0x02 // Status
@@ -70,24 +87,14 @@
 #define ADT7420_REG_RESET		0x2F // Software reset
 
 /* ADT7420_REG_STATUS definition */
-#define ADT7420_STATUS_T_LOW		(1 << 4)
-#define ADT7420_STATUS_T_HIGH		(1 << 5)
-#define ADT7420_STATUS_T_CRIT		(1 << 6)
-#define ADT7420_STATUS_RDY		(1 << 7)
+#define ADT7420_STATUS_T_LOW		BIT(4)
+#define ADT7420_STATUS_T_HIGH		BIT(5)
+#define ADT7420_STATUS_T_CRIT		BIT(6)
+#define ADT7420_STATUS_RDY		BIT(7)
 
 /* ADT7420_REG_CONFIG definition */
-#define ADT7420_CONFIG_FAULT_QUEUE(x)	(x & 0x3)
-#define ADT7420_CONFIG_CT_POL		(1 << 2)
-#define ADT7420_CONFIG_INT_POL		(1 << 3)
-#define ADT7420_CONFIG_INT_CT_MODE	(1 << 4)
-#define ADT7420_CONFIG_OP_MODE(x)	((x & 0x3) << 5)
-#define ADT7420_CONFIG_RESOLUTION	(1 << 7)
-
-/* ADT7420_CONFIG_FAULT_QUEUE(x) options */
-#define ADT7420_FAULT_QUEUE_1_FAULT	0
-#define ADT7420_FAULT_QUEUE_2_FAULTS	1
-#define ADT7420_FAULT_QUEUE_3_FAULTS	2
-#define ADT7420_FAULT_QUEUE_4_FAULTS	3
+#define ADT7420_CONFIG_OP_MODE(x)	((x) << 5) & (GENMASK(6,5))
+#define ADT7420_CONFIG_RESOLUTION	BIT(7)
 
 /* ADT7420_CONFIG_OP_MODE(x) options */
 #define ADT7420_OP_MODE_CONT_CONV	0
@@ -96,38 +103,77 @@
 #define ADT7420_OP_MODE_SHUTDOWN	3
 
 /* ADT7420 default ID */
-#define ADT7420_DEFAULT_ID		0xCB
+#define ADT7xxx_ID			0xC
+
 
 /******************************************************************************/
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
+enum dev_interface {
+	SPI,
+	I2C,
+};
+
+struct adt7420_chip_info {
+	uint8_t			resolution;
+	enum dev_interface  communication;
+};
+
+enum adt7420_type {
+	ID_ADT7410,
+	ID_ADT7420,
+	ID_ADT7422,
+	ID_ADT7310,
+	ID_ADT7311,
+	ID_ADT7312,
+	ID_ADT7320
+};
+
 struct adt7420_dev {
 	/* I2C */
 	i2c_desc	*i2c_desc;
+	/* SPI */
+	spi_desc	*spi_desc;
+	/* Device Settings */
+	enum adt7420_type active_device;
 	/* Device Settings */
 	uint8_t		resolution_setting;
+
 };
 
 struct adt7420_init_param {
-	/* I2C */
-	i2c_init_param	i2c_init;
+	union interface_type {
+		/* I2C */
+		i2c_init_param	i2c_init;
+		/* SPI */
+		spi_init_param	spi_init;
+	} interface_init;
 	/* Device Settings */
 	uint8_t		resolution_setting;
+	/* Device Settings */
+	enum adt7420_type	active_device;
 };
+
+extern const struct adt7420_chip_info chip_info[];
 
 /******************************************************************************/
 /************************ Functions Declarations ******************************/
 /******************************************************************************/
 
-/*! Reads the value of a register. */
-uint8_t adt7420_get_register_value(struct adt7420_dev *dev,
-				   uint8_t register_address);
+/*! Reads the value of a register */
+uint16_t adt7420_get_register_value(struct adt7420_dev *dev,
+				    uint8_t register_address);
+/*! Write to input shift register SPI interface. */
+uint16_t set_shift_reg(struct adt7420_dev *dev,
+		       uint8_t register_address,
+		       uint8_t *data) ;
 
-/*! Sets the value of a register. */
-void adt7420_set_register_value(struct adt7420_dev *dev,
-				uint8_t register_address,
-				uint8_t register_value);
+/*! Sets the value of a register.*/
+int32_t set_register_value(struct adt7420_dev *dev,
+			   uint8_t register_address,
+			   uint8_t num_data_bytes,
+			   uint8_t *data, uint8_t mask, uint8_t value);
 
 /*! Initializes the comm. peripheral and checks if the device is present. */
 int32_t adt7420_init(struct adt7420_dev **device,
@@ -135,9 +181,6 @@ int32_t adt7420_init(struct adt7420_dev **device,
 
 /* Free the resources allocated by adt7420_init(). */
 int32_t adt7420_remove(struct adt7420_dev *dev);
-
-/*! Resets the ADT7420. */
-void adt7420_reset(struct adt7420_dev *dev);
 
 /*! Sets the operational mode for ADT7420. */
 void adt7420_set_operation_mode(struct adt7420_dev *dev,
@@ -147,7 +190,21 @@ void adt7420_set_operation_mode(struct adt7420_dev *dev,
 void adt7420_set_resolution(struct adt7420_dev *dev,
 			    uint8_t resolution);
 
+/*! Resets the SPI or I2C inteface for the ADT7420/ADT7320*/
+int32_t adt7420_reset(struct adt7420_dev *dev);
+
 /*! Reads the temperature data and converts it to Celsius degrees. */
 float adt7420_get_temperature(struct adt7420_dev *dev);
+
+/*! Read the register value for I2C interface devices */
+uint16_t adt7420_i2c_get_register_value(struct adt7420_dev *dev,
+					uint8_t register_address);
+
+/*! Read the register value for SPI interface devices */
+uint16_t adt7420_spi_get_register_value(struct adt7420_dev *dev,
+					uint8_t register_address);
+
+/*! Check if the interface of the selected device is SPI */
+bool adt7420_is_spi(struct adt7420_dev *dev);
 
 #endif	/* __ADT7420_H__ */


### PR DESCRIPTION
1.) Added support to devices from the ADT7xxx family.
2.)The code flow has accommodated selection of devices based on SPI or I2C interfacing, corresponding to the target device selected-  Example: ADT7420 /ADT7320.To achieve this, macros corresponding to the register map information for ADT7320 has also been added.
3.) The individual functions would thus include a communication interface check, depending on which, the  register definitions are passed as arguments to the function calls serving the purpose.

Signed-off-by: Janani Sunil <janani.sunil@analog.com>