### PR TITLE
iio_app: remove irq for platfrom_mb

### DIFF
--- a/iio/iio_app/iio_app.c
+++ b/iio/iio_app/iio_app.c
@@ -117,16 +117,14 @@ int32_t iio_app_run(struct iio_app_device *devices, int32_t len)
 #endif
 
 #ifdef XILINX_PLATFORM
+#ifndef PLATFORM_MB
 	/* Xilinx platform dependent initialization for IRQ. */
 	struct xil_irq_init_param platform_irq_init_par;
 
 	platform_irq_init_par = (struct xil_irq_init_param ) {
-#ifdef XPAR_INTC_SINGLE_DEVICE_ID
-		.type = IRQ_PL,
-#else
 		.type = IRQ_PS,
-#endif
 	};
+#endif
 #endif // XILINX_PLATFORM
 
 #ifdef ADUCM_PLATFORM
@@ -135,6 +133,7 @@ int32_t iio_app_run(struct iio_app_device *devices, int32_t len)
 #endif //ADUCM_PLATFORM
 
 #if defined(ADUCM_PLATFORM) || defined(XILINX_PLATFORM)
+#ifndef PLATFORM_MB
 	irq_init_param = (struct irq_init_param ) {
 		.irq_ctrl_id = INTC_DEVICE_ID,
 		.extra = &platform_irq_init_par
@@ -143,6 +142,7 @@ int32_t iio_app_run(struct iio_app_device *devices, int32_t len)
 	status = irq_ctrl_init(&irq_desc, &irq_init_param);
 	if(status < 0)
 		return status;
+#endif
 #endif
 
 #ifdef XILINX_PLATFORM
@@ -154,9 +154,9 @@ int32_t iio_app_run(struct iio_app_device *devices, int32_t len)
 		.type = UART_PL,
 #else
 		.type = UART_PS,
-#endif
 		.irq_id = UART_IRQ_ID,
 		.irq_desc = irq_desc,
+#endif
 	};
 #endif // XILINX_PLATFORM
 
@@ -191,9 +191,11 @@ int32_t iio_app_run(struct iio_app_device *devices, int32_t len)
 #endif
 
 #if defined(ADUCM_PLATFORM) || defined(XILINX_PLATFORM)
+#ifndef PLATFORM_MB
 	status = irq_global_enable(irq_desc);
 	if (status < 0)
 		return status;
+#endif
 #endif
 #ifndef LINUX_PLATFORM
 	status = uart_init(&uart_desc, &uart_init_par);


### PR DESCRIPTION
For microblaze platforms, the IIO support does not use
the irq interface.

This patch makes sure that projects that use the IIO generic app and
have support for Microblaze platforms will build successfully.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>