### PR TITLE
[DRAFT] Add iio trigger support

### DIFF
--- a/iio/iio.c
+++ b/iio/iio.c
@@ -1077,7 +1077,7 @@ ssize_t iio_step(struct iio_desc *desc)
  * If buff_size is 0, no data will be written to buff, but size will be returned
  */
 static uint32_t iio_generate_device_xml(struct iio_device *device, char *name,
-					int32_t id, char *buff,
+					char * id, char *buff,
 					uint32_t buff_size)
 {
 	struct iio_channel	*ch;
@@ -1099,7 +1099,7 @@ static uint32_t iio_generate_device_xml(struct iio_device *device, char *name,
 
 	i = 0;
 	i += snprintf(buff, max(n - i, 0),
-		      "<device id=\"device%"PRIi32"\" name=\"%s\">", id, name);
+		      "<device id=\"%s\" name=\"%s\">", id, name);
 
 	/* Write channels */
 	if (device->channels)
@@ -1272,10 +1272,12 @@ ssize_t iio_register(struct iio_desc *desc, struct iio_device *dev_descriptor,
 	iio_interface->read_buffer = read_buff;
 	iio_interface->write_buffer = write_buff;
 
+	sprintf((char *)iio_interface->dev_id, "iio:device%d",
+		(int)desc->dev_count);
 	/* Get number of bytes needed for the xml of the new device */
 	n = iio_generate_device_xml(iio_interface->dev_descriptor,
 				    (char *)iio_interface->name,
-				    desc->dev_count, NULL, -1);
+				    iio_interface->dev_id, NULL, -1);
 
 	new_size = desc->xml_size + n;
 	aux = realloc(desc->xml_desc, new_size);
@@ -1295,10 +1297,9 @@ ssize_t iio_register(struct iio_desc *desc, struct iio_device *dev_descriptor,
 	/* Print the new device xml at the end of the xml */
 	iio_generate_device_xml(iio_interface->dev_descriptor,
 				(char *)iio_interface->name,
-				desc->dev_count,
+				iio_interface->dev_id,
 				desc->xml_desc + desc->xml_size_to_last_dev,
 				new_size - desc->xml_size_to_last_dev);
-	sprintf((char *)iio_interface->dev_id, "device%d", (int)desc->dev_count);
 	desc->xml_size_to_last_dev += n;
 	desc->xml_size += n;
 	/* Copy end header at the end */
@@ -1329,12 +1330,14 @@ ssize_t iio_unregister(struct iio_desc *desc, char *name)
 			    (void **)&to_remove_interface, &search_interface);
 	if (IS_ERR_VALUE(ret))
 		return ret;
-	free(to_remove_interface);
 
 	/* Get number of bytes needed for the xml of the device */
 	n = iio_generate_device_xml(to_remove_interface->dev_descriptor,
 				    (char *)to_remove_interface->name,
-				    desc->dev_count, NULL, -1);
+				    to_remove_interface->dev_id, NULL, -1);
+
+	free(to_remove_interface);
+
 
 	/* Overwritte the deleted device */
 	aux = desc->xml_desc + desc->xml_size_to_last_dev - n;

--- a/iio/iio_app/iio_app.h
+++ b/iio/iio_app/iio_app.h
@@ -50,6 +50,18 @@
 	.write_buff = _write_buff\
 }
 
+#define IIO_APP_INPUT_DEVICE(_name, _dev, _dev_descriptor, _read_buff) \
+	IIO_APP_DEVICE(_name, _dev, _dev_descriptor, _read_buff, NULL)
+
+#define IIO_APP_OUTPUT_DEVICE(_name, _dev, _dev_descriptor, _write_buff) \
+	IIO_APP_DEVICE(_name, _dev, _dev_descriptor, NULL, _write_buff)
+
+#define IIO_APP_NO_BUFFER_DEVICE(_name, _dev, _dev_descriptor) \
+	IIO_APP_DEVICE(_name, _dev, _dev_descriptor, NULL, NULL)
+
+#define IIO_APP_TRIGGER(_name, _dev, _dev_descriptor) \
+	IIO_APP_DEVICE(_name, _dev, _dev_descriptor, NULL, NULL)
+
 struct iio_app_device {
 	char *name;
 	void *dev;

--- a/iio/iio_trigger/iio_timer_trigger.c
+++ b/iio/iio_trigger/iio_timer_trigger.c
@@ -1,0 +1,255 @@
+/**************************************************************************//**
+*   @file   iio_ad3552r.c
+*   @brief  IIO implementation for ad3552r Driver
+*   @author Mihail Chindris (Mihail.Chindris@analog.com)
+*
+*******************************************************************************
+* Copyright 2021(c) Analog Devices, Inc.
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification,
+* are permitted provided that the following conditions are met:
+*  - Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*  - Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in
+*    the documentation and/or other materials provided with the
+*    distribution.
+*  - Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*  - The use of this software may or may not infringe the patent rights
+*    of one or more patent holders.  This license does not release you
+*    from the requirement that you obtain separate licenses from these
+*    patent holders to use this software.
+*  - Use of the software either in source or binary form, must be run
+*    on or directly connected to an Analog Devices Inc. component.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL,SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+* OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+* DAMAGE.
+******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <stdio.h>
+#include "iio_types.h"
+#include "iio_timer_trigger.h"
+#include "error.h"
+#include "util.h"
+#include "list.h"
+#include <pthread.h>
+#include <unistd.h>
+
+/*****************************************************************************/
+/******************** Macros and Constants Definitions ***********************/
+/*****************************************************************************/
+
+#define IIO_SAMPLING_FREQUENCY 0
+
+#define STR(x) #x
+#define XSTR(x) STR(x)
+
+#define IIO_TRIGGER_ATTR(_name, _priv) {\
+	.name = _name,\
+	.priv = _priv,\
+	.show = iio_attr_get,\
+	.store = iio_attr_set\
+}
+
+struct iio_timer_trigger_desc {
+	struct timer_desc	*timer;
+	struct list_desc	*callbacks;
+	struct iterator		*calls_iter;
+};
+
+/*****************************************************************************/
+/************************* Functions Definitions *****************************/
+/*****************************************************************************/
+
+struct timer_trigger_callback {
+	void (*callback)(void * dev);
+	void *dev;
+};
+
+static int32_t iio_cmp_interfaces(struct timer_trigger_callback *a,
+				  struct timer_trigger_callback *b)
+{
+	if (a->callback == b->callback && a->dev == b->dev)
+		return 0;
+
+	return -1;
+}
+
+void thread_function(struct iio_timer_trigger_desc *desc)
+{
+	struct timer_trigger_callback *call;
+	int32_t err;
+
+	while(true)
+	{
+		err = iterator_move_to_idx(desc->calls_iter, 0);
+		while (!IS_ERR_VALUE(err)) {
+			err = iterator_read(desc->calls_iter, (void **)&call);
+			call->callback(call->dev);
+			err = iterator_move(desc->calls_iter, 1);
+		}
+		usleep(1000000);
+	}
+}
+/* Init iio. */
+int32_t iio_timer_trigger_init(struct iio_timer_trigger_desc **desc,
+			       struct iio_timer_trigger_init_param *param)
+{
+	struct iio_timer_trigger_desc *ldesc;
+	int32_t ret;
+
+	if (!param || !desc)
+		return FAILURE;
+
+	ldesc = (struct iio_timer_trigger_desc *)calloc(1,
+			sizeof(struct iio_timer_trigger_desc));
+	if (!ldesc)
+		return -ENOMEM;
+
+	
+	ret = list_init(&ldesc->callbacks, LIST_DEFAULT,
+			(f_cmp)iio_cmp_interfaces);
+	if (IS_ERR_VALUE(ret))
+		goto err_desc;
+	
+	*desc = ldesc;
+		
+	ret = iterator_init(&ldesc->calls_iter, ldesc->callbacks, 1);
+	if (IS_ERR_VALUE(ret))
+		goto err_list;
+
+	pthread_t pid;
+	pthread_create(&pid, NULL, thread_function, ldesc);
+
+	return 0;
+err_desc:
+	free(ldesc);
+err_list:
+	list_remove(ldesc->callbacks);
+	return ret;
+}
+
+/* Free the resources allocated by iio_timer_trigger_init(). */
+int32_t iio_timer_trigger_remove(struct iio_timer_trigger_desc *desc)
+{
+	struct timer_trigger_callback	*call;
+	int32_t				err;
+
+	if (!desc)
+		return -EINVAL;
+
+	while (true) {
+		err = desc->callbacks->pop(desc->callbacks, (void **)&call);
+		if (IS_ERR_VALUE(err))
+			break;
+		free(call);
+	}
+
+	iterator_remove(desc->calls_iter);
+	list_remove(desc->callbacks);
+	free(desc);
+
+	return 0;
+}
+
+static ssize_t iio_attr_get(void *device, char *buf, size_t len,
+			    const struct iio_ch_info *channel,
+			    intptr_t priv)
+{
+	int ok = 0;
+        if (priv == IIO_SAMPLING_FREQUENCY)
+                ok++;
+
+        return -EINVAL;
+}
+
+static ssize_t iio_attr_set(void *device, char *buf, size_t len,
+			    const struct iio_ch_info *channel, intptr_t priv)
+{
+	int ok = 0;
+        if (priv == IIO_SAMPLING_FREQUENCY)
+                ok++;
+
+        return -EINVAL;
+}
+
+int32_t iio_timer_trigger_add_callback(struct iio_timer_trigger_desc *desc,
+				       void (*callback)(void * dev),
+				       void *dev)
+{
+	struct timer_trigger_callback	*call;
+	int32_t				err;
+
+	if (!desc)
+		return -EINVAL;
+
+	call = (struct timer_trigger_callback *)calloc(1, sizeof(call));
+	if (!call)
+		return -ENOMEM;
+
+	call->callback = callback;
+	call->dev = dev;
+	err = desc->callbacks->push(desc->callbacks, call);
+	if (IS_ERR_VALUE(err)) {
+		free(call);
+		return err;
+	}
+
+	return 0;
+}
+
+int32_t iio_timer_trigger_remove_callback(struct iio_timer_trigger_desc *desc,
+					  void (*callback)(void * dev),
+					  void *dev)
+{
+	struct timer_trigger_callback	*call;
+	struct timer_trigger_callback	cmp_call;
+	int32_t				err;
+
+	if (!desc)
+		return -EINVAL;
+
+	cmp_call.callback = callback;
+	cmp_call.dev = dev;
+	err = list_get_find(desc->callbacks, (void **)&call, &cmp_call);
+	if (IS_ERR_VALUE(err))
+		return err;
+
+	free(call);
+
+	return 0;
+}
+
+/******************************************************************************/
+/************************** IIO Types Declarations *****************************/
+/******************************************************************************/
+
+struct iio_attribute iio_timer_trigger_attributes[] = {
+	IIO_TRIGGER_ATTR("sampling_frequency", IIO_SAMPLING_FREQUENCY),
+	END_ATTRIBUTES_ARRAY,
+};
+
+struct iio_device iio_timer_trigger_device_desc = {
+	.is_trigger = true,
+	.attributes = iio_timer_trigger_attributes,
+	.add_callback = iio_timer_trigger_add_callback,
+	.remove_callback = iio_timer_trigger_remove_callback,
+};

--- a/iio/iio_trigger/iio_timer_trigger.h
+++ b/iio/iio_trigger/iio_timer_trigger.h
@@ -1,0 +1,66 @@
+/**************************************************************************//**
+*   @file   ad3552r.h
+*   @brief  IIO Header file of ad3552r Driver
+*   @author Mihail Chindris (Mihail.Chindris@analog.com)
+*
+*******************************************************************************
+* Copyright 2021(c) Analog Devices, Inc.
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification,
+* are permitted provided that the following conditions are met:
+*  - Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*  - Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in
+*    the documentation and/or other materials provided with the
+*    distribution.
+*  - Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*  - The use of this software may or may not infringe the patent rights
+*    of one or more patent holders.  This license does not release you
+*    from the requirement that you obtain separate licenses from these
+*    patent holders to use this software.
+*  - Use of the software either in source or binary form, must be run
+*    on or directly connected to an Analog Devices Inc. component.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL,SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+* LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+* OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+* DAMAGE.
+******************************************************************************/
+
+#ifndef IIO_TIMER_TRIGGER_H
+#define IIO_TIMER_TRIGGER_H
+
+#include "timer.h"
+#include "irq.h"
+#include "iio_types.h"
+
+struct iio_timer_trigger_desc;
+
+struct iio_timer_trigger_init_param {
+	struct timer_init_param timer_param;
+};
+
+extern struct iio_device iio_timer_trigger_device_desc;
+
+/* Init iio. */
+int32_t iio_timer_trigger_init(struct iio_timer_trigger_desc **desc,
+			       struct iio_timer_trigger_init_param *param);
+
+/* Free the resources allocated by iio_timer_trigger_init(). */
+int32_t iio_timer_trigger_remove(struct iio_timer_trigger_desc *desc);
+
+
+#endif /* IIO_TIMER_TRIGGER_H */

--- a/iio/iio_types.h
+++ b/iio/iio_types.h
@@ -224,7 +224,24 @@ struct iio_device {
 	int32_t (*debug_reg_read)(void *dev, uint32_t reg, uint32_t *readval);
 	/* Write device register */
 	int32_t (*debug_reg_write)(void *dev, uint32_t reg, uint32_t writeval);
+	/* Called when a trigger is triggered */
+	void (*trigger_callback)(void *dev);
 
+	/* Trigger fields */
+	/*
+	 * Set if the device represents a trigger.
+	 * It should have only attributes field set
+	 */
+	bool is_trigger;
+	/*
+	 * Called when a new device is using the trigger. Dev must be passed
+	 * to the callback
+	 */
+	int32_t (*add_callback)(void *trig_instance, void (*callback)(void * dev),
+				void *dev);
+	/* Called when a device stops using the trigger */
+	int32_t (*remove_callback)(void *trig_instance, void (*callback)(void * dev),
+				   void *dev);
 };
 
 #endif /* IIO_TYPES_H_ */


### PR DESCRIPTION
First step will review and merge the support from libtinyiiod: https://github.com/analogdevicesinc/libtinyiiod/pull/43 
Then, to choose an approach for how to implement the trigger, I suggested one but is not the better one, it is just a fast one.
 - How the trigger works:
   - An iio trigger is similar to a iio device, it has attributes and an id like "triggerX" instead of "iio:deviceX" for devices.
   - When a trigger is triggered (irq, manually ...) it should call the callback of the devices that are using that trigger.
   - To set a trigger for a device the "SETTRIG iio:deviceX <triggerId>" command is used. 
 -  The proposed implementation:
    - Extend the `struct iio_device`  with is_trigger field to select if it should act as a trigger.
    - Add add_callback, remove_callback fields which needs to be implemented by the trigger. They will be called when a new devices needs to be notified by the trigger.
    - Add a trigger_callback for a device which will be the one that will be called by the trigger.
    - Implement the logic of add/remove_callback notification in iio.c
    - Add an example of trigger implementation. (It is an implementation for linux platform not a generic one)
 - Improvements to the implementation:
   - Create a `struct iio_triggers` but this will need some refactor of the iio_app API which means update all the project that are using it. 
   - How should we implement a trigger with the current generic files?