### PR TITLE
generic.mk: remove double LDFLAGS

### DIFF
--- a/tools/scripts/generic.mk
+++ b/tools/scripts/generic.mk
@@ -314,7 +314,7 @@ $(OBJECTS_DIR)/%.o: $$(call get_full_path, %).S | $$(@D)/.
 	$(MUTE) $(AS) -c $(ASFLAGS) $< -o $@
 
 ifneq ($(strip $(LSCRIPT)),)
-LSCRIPT_FLAG = -T$(LSCRIPT) $(LDFLAGS)
+LSCRIPT_FLAG = -T$(LSCRIPT)
 endif
 
 $(BINARY): $(LIB_TARGETS) $(OBJS) $(ASM_OBJS) $(LSCRIPT)


### PR DESCRIPTION
For some reason $(LDFLAGS) was added twice to the linker command.
This creates troubles with newer compilers, something like:

arm-none-eabi-gcc: fatal error:
/usr/lib/gcc/arm-none-eabi/11.1.0/../../../../arm-none-eabi/lib/nosys.specs:
attempt to rename spec 'link_gcc_c_sequence' to already defined
spec 'nosys_link_gcc_c_sequence'

Signed-off-by: Darius Berghe <darius.berghe@analog.com>