### PR TITLE
tools:scripts: fix aducm 'make run' command

### DIFF
--- a/tools/scripts/aducm.mk
+++ b/tools/scripts/aducm.mk
@@ -156,7 +156,11 @@ $(PIN_MUX): $(PROJECT_PIN_MUX)
 
 # Upload binary to target
 PHONY += aducm3029_run
+ifeq ($(wildcard $(BUILD_DIR)),)
 aducm3029_run: all
+else
+aducm3029_run: $(BINARY)
+endif
 	$(MUTE) openocd -s "$(OPENOCD_SCRIPTS)" -f interface/cmsis-dap.cfg \
 		-s "$(ADUCM_DFP)/openocd/scripts" -f target/aducm3029.cfg \
 		-c "program  $(BINARY) verify reset exit" $(HIDE)


### PR DESCRIPTION
Aducm 'make run' command would fail if run after the project is build once
because it would try to make a new project with the same name where one
already exists. 'make ca' was needed in between each 'make run' commands.

Signed-off-by: Andrei Drimbarean <Andrei.Drimbarean@analog.com>