### PR TITLE
drivers: freq: hmc7044: Remove option for High performance PLLs/VCO

### DIFF
--- a/drivers/frequency/hmc7044/hmc7044.c
+++ b/drivers/frequency/hmc7044/hmc7044.c
@@ -637,9 +637,7 @@ static int32_t hmc7044_setup(struct hmc7044_dev *dev)
 	mdelay(1);
 	hmc7044_write(dev, HMC7044_REG_REQ_MODE_0,
 		      (dev->high_performance_mode_clock_dist_en ?
-		       HMC7044_HIGH_PERF_DISTRIB_PATH : 0) |
-		      (dev->high_performance_mode_pll_vco_en ?
-		       HMC7044_HIGH_PERF_PLL_VCO : 0));
+		       HMC7044_HIGH_PERF_DISTRIB_PATH : 0));
 	mdelay(1);
 
 	return SUCCESS;
@@ -806,8 +804,6 @@ int32_t hmc7044_init(struct hmc7044_dev **device,
 	dev->clkin1_vcoin_en = init_param->clkin1_vcoin_en;
 	dev->high_performance_mode_clock_dist_en =
 		init_param->high_performance_mode_clock_dist_en;
-	dev->high_performance_mode_pll_vco_en =
-		init_param->high_performance_mode_pll_vco_en;
 	dev->rf_reseeder_en = !init_param->rf_reseeder_disable;
 	dev->sync_pin_mode = init_param->sync_pin_mode;
 	dev->pulse_gen_mode = init_param->pulse_gen_mode;

--- a/drivers/frequency/hmc7044/hmc7044.h
+++ b/drivers/frequency/hmc7044/hmc7044.h
@@ -80,7 +80,6 @@ struct hmc7044_dev {
 	bool		clkin0_rfsync_en;
 	bool		clkin1_vcoin_en;
 	bool		high_performance_mode_clock_dist_en;
-	bool		high_performance_mode_pll_vco_en;
 	bool		rf_reseeder_en;
 	unsigned int	sync_pin_mode;
 	uint32_t	pulse_gen_mode;
@@ -105,7 +104,6 @@ struct hmc7044_init_param {
 	bool		clkin0_rfsync_en;
 	bool		clkin1_vcoin_en;
 	bool		high_performance_mode_clock_dist_en;
-	bool		high_performance_mode_pll_vco_en;
 	bool		rf_reseeder_disable;
 	unsigned int	sync_pin_mode;
 	uint32_t	pulse_gen_mode;

--- a/projects/ad9081/src/app_clock.c
+++ b/projects/ad9081/src/app_clock.c
@@ -296,7 +296,6 @@ int32_t app_clock_init(struct clk dev_refclk[MULTIDEVICE_INSTANCE_COUNT])
 		.pll1_ref_prio_ctrl = 0xe4,
 		.sync_pin_mode = 0x1,
 		.high_performance_mode_clock_dist_en = false,
-		.high_performance_mode_pll_vco_en = false,
 		.pulse_gen_mode = 0x0,
 		.channels = chan_spec
 	};

--- a/projects/adrv9009/src/app/app_clocking.c
+++ b/projects/adrv9009/src/app/app_clocking.c
@@ -124,7 +124,6 @@ adiHalErr_t clocking_init(uint32_t rx_div40_rate_hz,
 		.pll1_ref_prio_ctrl = 0xE5,
 		.sync_pin_mode = 0x1,
 		.high_performance_mode_clock_dist_en = true,
-		.high_performance_mode_pll_vco_en = true,
 		.pulse_gen_mode = 0x0,
 	};
 


### PR DESCRIPTION
Draws extra current and doesn't improve much.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>