### PR TITLE
Staging/spi platform ops

### DIFF
--- a/drivers/axi_core/spi_engine/spi_engine.h
+++ b/drivers/axi_core/spi_engine/spi_engine.h
@@ -177,7 +177,7 @@ struct spi_engine_offload_message {
 /**
  * @brief Spi engine platform specific SPI platform ops structure
  */
-extern const struct spi_platform_ops xil_platform_ops;
+extern const struct spi_platform_ops xil_spi_ops;
 
 /* Write SPI Engine's axi registers */
 int32_t spi_engine_write(struct spi_engine_desc *desc,

--- a/drivers/platform/aducm3029/aducm3029_spi.c
+++ b/drivers/platform/aducm3029/aducm3029_spi.c
@@ -1,5 +1,5 @@
 /***************************************************************************//**
- *   @file   aducm3029/spi.c
+ *   @file   aducm3029/aducm3029_spi.c
  *   @brief  Implementation of SPI driver for ADuCM302x
  *   @author Mihail Chindris (mihail.chindris@analog.com)
 ********************************************************************************
@@ -121,8 +121,8 @@ static int32_t config_device(struct aducm_device_desc *dev,
  * @param param - The structure that contains the SPI parameters.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t spi_init(struct spi_desc **desc,
-		 const struct spi_init_param *param)
+int32_t aducm3029_spi_init(struct spi_desc **desc,
+			   const struct spi_init_param *param)
 {
 	struct spi_desc			*spi_desc;
 	struct aducm_spi_desc		*aducm_desc;
@@ -191,7 +191,7 @@ failure:
  * @param desc - The SPI descriptor.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t spi_remove(struct spi_desc *desc)
+int32_t aducm3029_spi_remove(struct spi_desc *desc)
 {
 	struct aducm_spi_desc *aducm_desc;
 
@@ -222,9 +222,9 @@ int32_t spi_remove(struct spi_desc *desc)
  * @param bytes_number - Number of bytes to write/read.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t spi_write_and_read(struct spi_desc *desc,
-			   uint8_t *data,
-			   uint16_t bytes_number)
+int32_t aducm3029_spi_write_and_read(struct spi_desc *desc,
+				     uint8_t *data,
+				     uint16_t bytes_number)
 {
 	struct aducm_spi_desc		*aducm_desc;
 	ADI_SPI_TRANSCEIVER		spi_trans;
@@ -279,3 +279,11 @@ int32_t spi_write_and_read(struct spi_desc *desc,
 	return SUCCESS;
 }
 
+/**
+ * @brief ADuCM3029 platform specific SPI platform ops structure
+ */
+const struct spi_platform_ops aducm_spi_ops = {
+	.init = &aducm3029_spi_init,
+	.write_and_read = &aducm3029_spi_write_and_read,
+	.remove = &aducm3029_spi_remove
+};

--- a/drivers/platform/aducm3029/spi_extra.h
+++ b/drivers/platform/aducm3029/spi_extra.h
@@ -105,6 +105,11 @@ struct aducm_spi_init_param {
 };
 
 /**
+ * @brief ADuCM3029 specific SPI platform ops structure
+ */
+extern const struct spi_platform_ops aducm_spi_ops;
+
+/**
  * @struct aducm_spi_desc
  * @brief SPI specific descriptor for the ADuCM3029. The structure is available
  * in the extra parameter from spi_desc.

--- a/drivers/platform/altera/altera_spi.c
+++ b/drivers/platform/altera/altera_spi.c
@@ -53,15 +53,6 @@
 /******************************************************************************/
 
 /**
- * @brief Altera platform specific SPI platform ops structure
- */
-const struct spi_platform_ops altera_platform_ops = {
-	.init = &altera_spi_init,
-	.write_and_read = &altera_spi_write_and_read,
-	.remove = &altera_spi_remove
-};
-
-/**
  * @brief Initialize the SPI communication peripheral.
  * @param desc - The SPI descriptor.
  * @param param - The structure that contains the SPI parameters.
@@ -164,4 +155,11 @@ int32_t altera_spi_write_and_read(struct spi_desc *desc,
 	return SUCCESS;
 }
 
-
+/**
+ * @brief Altera platform specific SPI platform ops structure
+ */
+const struct spi_platform_ops altera_spi_ops  = {
+	.init = &altera_spi_init,
+	.write_and_read = &altera_spi_write_and_read,
+	.remove = &altera_spi_remove
+};

--- a/drivers/platform/altera/spi_extra.h
+++ b/drivers/platform/altera/spi_extra.h
@@ -80,15 +80,6 @@ struct altera_spi_desc {
 /**
  * @brief Altera specific SPI platform ops structure
  */
-extern const struct spi_platform_ops altera_platform_ops;
-
-/******************************************************************************/
-/************************ Functions Declarations ******************************/
-/******************************************************************************/
-int32_t altera_spi_init(struct spi_desc **desc,
-			const struct spi_init_param *param);
-int32_t altera_spi_remove(struct spi_desc *desc);
-int32_t altera_spi_write_and_read(struct spi_desc *desc, uint8_t *data,
-				  uint16_t bytes_number);
+extern const struct spi_platform_ops altera_spi_ops;
 
 #endif /* SPI_EXTRA_H_ */

--- a/drivers/platform/generic/generic_spi.c
+++ b/drivers/platform/generic/generic_spi.c
@@ -110,7 +110,7 @@ int32_t generic_spi_write_and_read(struct spi_desc *desc,
 /**
  * @brief Generic platform SPI ops
  */
-const struct spi_platform_ops generic_spi_platform_ops = {
+const struct spi_platform_ops generic_spi_ops = {
 	.init = &generic_spi_init,
 	.write_and_read = &generic_spi_write_and_read,
 	.remove = &generic_spi_remove

--- a/drivers/platform/linux/linux_spi.c
+++ b/drivers/platform/linux/linux_spi.c
@@ -223,7 +223,7 @@ static int32_t linux_spi_transfer(struct spi_desc *desc,
 /**
  * @brief Linux platform specific SPI platform ops structure
  */
-const struct spi_platform_ops linux_spi_platform_ops = {
+const struct spi_platform_ops linux_spi_ops = {
 	.init = &linux_spi_init,
 	.write_and_read = &linux_spi_write_and_read,
 	.remove = &linux_spi_remove,

--- a/drivers/platform/linux/linux_spi.h
+++ b/drivers/platform/linux/linux_spi.h
@@ -43,6 +43,6 @@
 /**
  * @brief Linux specific SPI platform ops structure
  */
-extern const struct spi_platform_ops linux_spi_platform_ops;
+extern const struct spi_platform_ops linux_spi_ops;
 
 #endif // LINUX_SPI_H_

--- a/drivers/platform/stm32/stm32_spi.c
+++ b/drivers/platform/stm32/stm32_spi.c
@@ -45,15 +45,6 @@
 #include "stm32_spi.h"
 
 /**
- * @brief stm32 platform specific SPI platform ops structure
- */
-const struct spi_platform_ops stm32_platform_ops = {
-	.init = &stm32_spi_init,
-	.write_and_read = &stm32_spi_write_and_read,
-	.remove = &stm32_spi_remove
-};
-
-/**
  * @brief Initialize the SPI communication peripheral.
  * @param desc - The SPI descriptor.
  * @param param - The structure that contains the SPI parameters.
@@ -236,3 +227,12 @@ int32_t stm32_spi_write_and_read(struct spi_desc *desc,
 
 	return SUCCESS;
 }
+
+/**
+ * @brief stm32 platform specific SPI platform ops structure
+ */
+const struct spi_platform_ops stm32_spi_ops = {
+	.init = &stm32_spi_init,
+	.write_and_read = &stm32_spi_write_and_read,
+	.remove = &stm32_spi_remove
+};

--- a/drivers/platform/stm32/stm32_spi.h
+++ b/drivers/platform/stm32/stm32_spi.h
@@ -71,18 +71,6 @@ typedef struct stm32_spi_desc {
 /**
  * @brief stm32 specific SPI platform ops structure
  */
-extern const struct spi_platform_ops stm32_platform_ops;
-
-
-/* Initialize the SPI communication peripheral. */
-int32_t stm32_spi_init(struct spi_desc **desc,
-		       const struct spi_init_param *param);
-
-/* Free the resources allocated by spi_init(). */
-int32_t stm32_spi_remove(struct spi_desc *desc);
-
-/* Write and read data to/from SPI. */
-int32_t stm32_spi_write_and_read(struct spi_desc *desc, uint8_t *data,
-				 uint16_t bytes_number);
+extern const struct spi_platform_ops stm32_spi_ops;
 
 #endif // STM32_SPI_H_

--- a/drivers/platform/xilinx/spi_extra.h
+++ b/drivers/platform/xilinx/spi_extra.h
@@ -73,7 +73,7 @@ enum xil_spi_type {
 /**
  * @struct xil_spi_init_param
  * @brief Structure holding the initialization parameters for Xilinx platform
- * specific SPI parameters when using xil_platform_ops.
+ * specific SPI parameters when using xil_spi_ops.
  */
 typedef struct xil_spi_init_param {
 	/** Xilinx architecture */
@@ -105,26 +105,11 @@ extern const struct spi_platform_ops spi_eng_platform_ops;
 /**
  * @brief Xilinx specific SPI platform ops structure
  */
-extern const struct spi_platform_ops xil_platform_ops;
+extern const struct spi_platform_ops xil_spi_ops;
 
 /**
  * @brief Xilinx SPI PS register functions. No extra param needed
  */
 extern const struct spi_platform_ops xil_spi_reg_ops_pl;
-
-/******************************************************************************/
-/************************ Functions Declarations ******************************/
-/******************************************************************************/
-
-/* Initialize the SPI communication peripheral. */
-int32_t xil_spi_init(struct spi_desc **desc,
-		     const struct spi_init_param *param);
-
-/* Free the resources allocated by spi_init(). */
-int32_t xil_spi_remove(struct spi_desc *desc);
-
-/* Write and read data to/from SPI. */
-int32_t xil_spi_write_and_read(struct spi_desc *desc, uint8_t *data,
-			       uint16_t bytes_number);
 
 #endif // SPI_EXTRA_H_

--- a/drivers/platform/xilinx/xilinx_spi.c
+++ b/drivers/platform/xilinx/xilinx_spi.c
@@ -69,16 +69,6 @@
 /************************ Functions Definitions *******************************/
 /******************************************************************************/
 
-
-/**
- * @brief Xilinx platform specific SPI platform ops structure
- */
-const struct spi_platform_ops xil_platform_ops = {
-	.init = &xil_spi_init,
-	.write_and_read = &xil_spi_write_and_read,
-	.remove = &xil_spi_remove
-};
-
 /**
  * @brief Initialize the hardware SPI peripherial
  *
@@ -461,3 +451,12 @@ error:
 
 	return ret;
 }
+
+/**
+ * @brief Xilinx platform specific SPI platform ops structure
+ */
+const struct spi_platform_ops xil_spi_ops = {
+	.init = &xil_spi_init,
+	.write_and_read = &xil_spi_write_and_read,
+	.remove = &xil_spi_remove
+};

--- a/projects/ad6676-ebz/src/ad6676_ebz.c
+++ b/projects/ad6676-ebz/src/ad6676_ebz.c
@@ -285,7 +285,7 @@ int main(void)
 		.max_speed_hz = 2000000u,
 		.chip_select = 0,
 		.mode = SPI_MODE_0,
-		.platform_ops = &xil_platform_ops,
+		.platform_ops = &xil_spi_ops,
 		.extra = &xil_spi_param
 	};
 

--- a/projects/ad7124-4sdz/src/ad7124-4sdz.c
+++ b/projects/ad7124-4sdz/src/ad7124-4sdz.c
@@ -57,7 +57,7 @@ int main(void)
 	};
 
 	struct spi_init_param spi_init = {
-		.platform_ops = &xil_platform_ops,
+		.platform_ops = &xil_spi_ops,
 		.chip_select = 0,
 		.max_speed_hz = 1000000,
 		.mode = SPI_MODE_3,

--- a/projects/ad7124-8pmdz/src.mk
+++ b/projects/ad7124-8pmdz/src.mk
@@ -5,7 +5,8 @@ SRC_DIRS += $(NO-OS)/iio/iio_app
 
 # Add to SRCS source files to be build in the project
 SRCS += $(NO-OS)/drivers/adc/ad7124/ad7124.c \
-	$(NO-OS)/drivers/adc/ad7124/iio_ad7124.c
+	$(NO-OS)/drivers/adc/ad7124/iio_ad7124.c \
+	$(NO-OS)/drivers/spi/spi.c
 
 # Add to INCS inlcude files to be build in the porject
 INCS += $(NO-OS)/drivers/adc/ad7124/ad7124.h \

--- a/projects/ad7124-8pmdz/src/main.c
+++ b/projects/ad7124-8pmdz/src/main.c
@@ -102,6 +102,7 @@ int main(void)
 		.max_speed_hz = 10000000,
 		.mode = SPI_MODE_3,
 		.device_id = 1,
+		.platform_ops = &aducm_spi_ops,
 		.extra = &aducm_spi_ini
 	};
 	struct ad7124_init_param ad7124_initial = {

--- a/projects/ad713x_fmcz/src/ad713x_fmc.c
+++ b/projects/ad713x_fmcz/src/ad713x_fmc.c
@@ -176,7 +176,7 @@ int main()
 	ad713x_init_param_1.spi_init_prm.device_id = SPI_DEVICE_ID;
 	ad713x_init_param_1.spi_init_prm.max_speed_hz = 10000000;
 	ad713x_init_param_1.spi_init_prm.mode = SPI_MODE_3;
-	ad713x_init_param_1.spi_init_prm.platform_ops = &xil_platform_ops;
+	ad713x_init_param_1.spi_init_prm.platform_ops = &xil_spi_ops;
 	ad713x_init_param_1.spi_init_prm.extra = (void *)&spi_engine_init_params;
 	ad713x_init_param_1.spi_common_dev = 0;
 
@@ -198,7 +198,7 @@ int main()
 	ad713x_init_param_2.spi_init_prm.chip_select = AD7134_2_SPI_CS;
 	ad713x_init_param_2.spi_init_prm.max_speed_hz = 10000000;
 	ad713x_init_param_2.spi_init_prm.mode = SPI_MODE_3;
-	ad713x_init_param_2.spi_init_prm.platform_ops = &xil_platform_ops;
+	ad713x_init_param_2.spi_init_prm.platform_ops = &xil_spi_ops;
 	ad713x_init_param_2.spi_init_prm.extra = (void *)&spi_engine_init_params;
 	ad713x_init_param_2.spi_common_dev = 0;
 

--- a/projects/ad7768-evb/src/ad7768_evb.c
+++ b/projects/ad7768-evb/src/ad7768_evb.c
@@ -173,7 +173,7 @@ int main(void)
 			.max_speed_hz = 1000000,
 			.chip_select = SPI_AD7768_CS,
 			.mode = SPI_MODE_0,
-			.platform_ops = &xil_platform_ops,
+			.platform_ops = &xil_spi_ops,
 			.extra = &xil_spi_initial
 		},
 		/* GPIO */

--- a/projects/ad9081/src/app.c
+++ b/projects/ad9081/src/app.c
@@ -94,7 +94,7 @@ int main(void)
 		.max_speed_hz = 1000000,
 		.mode = SPI_MODE_0,
 		.chip_select = PHY_CS,
-		.platform_ops = &xil_platform_ops,
+		.platform_ops = &xil_spi_ops,
 		.extra = &xil_spi_param
 	};
 	struct link_init_param jesd_tx_link = {

--- a/projects/ad9081/src/app_clock.c
+++ b/projects/ad9081/src/app_clock.c
@@ -97,7 +97,7 @@ int32_t app_clock_init(struct clk dev_refclk[MULTIDEVICE_INSTANCE_COUNT])
 #else
 		.chip_select = CLK_CS,
 #endif
-		.platform_ops = &xil_platform_ops,
+		.platform_ops = &xil_spi_ops,
 		.extra = &xil_spi_param
 	};
 

--- a/projects/ad9083/src/app_ad9083.c
+++ b/projects/ad9083/src/app_ad9083.c
@@ -160,7 +160,7 @@ int32_t app_ad9083_init(struct app_ad9083 **app,
 		.mode = SPI_MODE_0,
 		.chip_select = SPI_AD9083_CS,
 
-		.platform_ops = &xil_platform_ops,
+		.platform_ops = &xil_spi_ops,
 		.extra = &xil_spi_param
 	};
 	struct xil_gpio_init_param  xil_gpio_param = {

--- a/projects/ad9083/src/app_clocking.c
+++ b/projects/ad9083/src/app_clocking.c
@@ -181,7 +181,7 @@ int32_t app_clocking_init(struct app_clocking **app,
 		.max_speed_hz = 10000000,
 		.mode = SPI_MODE_0,
 		.chip_select = CLK_AD9258_CS,
-		.platform_ops = &xil_platform_ops,
+		.platform_ops = &xil_spi_ops,
 		.extra = &xil_spi_param
 	};
 

--- a/projects/ad9172/src/main.c
+++ b/projects/ad9172/src/main.c
@@ -78,7 +78,7 @@ int main(void)
 		.max_speed_hz = 10000000,
 		.mode = SPI_MODE_0,
 		.chip_select = SPI_HMC7044_CS,
-		.platform_ops = &xil_platform_ops,
+		.platform_ops = &xil_spi_ops,
 		.extra = &xil_spi_param
 	};
 
@@ -134,7 +134,7 @@ int main(void)
 		.max_speed_hz = 1000000,
 		.mode = SPI_MODE_0,
 		.chip_select = SPI_AD9172_CS,
-		.platform_ops = &xil_platform_ops,
+		.platform_ops = &xil_spi_ops,
 		.extra = &xil_spi_param
 	};
 

--- a/projects/ad9208/src/main.c
+++ b/projects/ad9208/src/main.c
@@ -137,7 +137,7 @@ int main(void)
 		.max_speed_hz = 10000000,
 		.mode = SPI_MODE_0,
 		.chip_select = SPI_HMC7044_CS,
-		.platform_ops = &xil_platform_ops,
+		.platform_ops = &xil_spi_ops,
 		.extra = &xil_spi_param
 	};
 
@@ -211,7 +211,7 @@ int main(void)
 		.max_speed_hz = 10000000,
 		.mode = SPI_MODE_3,
 		.chip_select = SPI_AD9208_0_CS,
-		.platform_ops = &xil_platform_ops,
+		.platform_ops = &xil_spi_ops,
 		.extra = &xil_spi_param
 	};
 
@@ -219,7 +219,7 @@ int main(void)
 		.max_speed_hz = 10000000,
 		.mode = SPI_MODE_3,
 		.chip_select = SPI_AD9208_CS,
-		.platform_ops = &xil_platform_ops,
+		.platform_ops = &xil_spi_ops,
 		.extra = &xil_spi_param
 	};
 

--- a/projects/ad9265-fmc-125ebz/src/ad9265_fmc_125ebz.c
+++ b/projects/ad9265-fmc-125ebz/src/ad9265_fmc_125ebz.c
@@ -75,7 +75,7 @@ int main(void)
 		.chip_select = 0,
 		.mode = SPI_MODE_0,
 		.extra = &xil_spi_param,
-		.platform_ops = &xil_platform_ops,
+		.platform_ops = &xil_spi_ops,
 	};
 
 	/* ADC Core */

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -118,7 +118,7 @@ struct xil_gpio_init_param xil_gpio_param = {
 #endif
 #ifdef LINUX_PLATFORM
 #define GPIO_OPS	&linux_gpio_platform_ops
-#define SPI_OPS		&linux_spi_platform_ops
+#define SPI_OPS		&linux_spi_ops
 #define GPIO_PARAM	NULL
 #define SPI_PARAM	NULL
 #endif

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -498,7 +498,7 @@ int main(void)
 #endif
 
 #ifdef ALTERA_PLATFORM
-	default_init_param.spi_param.platform_ops = &altera_platform_ops;
+	default_init_param.spi_param.platform_ops = &altera_spi_ops;
 
 	if (altera_bridge_init()) {
 		printf("Altera Bridge Init Error!\n");

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -103,7 +103,7 @@ struct xil_gpio_init_param xil_gpio_param = {
 	.device_id = GPIO_DEVICE_ID
 };
 #define GPIO_OPS	&xil_gpio_platform_ops
-#define SPI_OPS		&xil_platform_ops
+#define SPI_OPS		&xil_spi_ops
 #define GPIO_PARAM	&xil_gpio_param
 #define SPI_PARAM	&xil_spi_param
 #endif
@@ -494,7 +494,7 @@ int main(void)
 	Xil_ICacheEnable();
 	Xil_DCacheEnable();
 	default_init_param.spi_param.extra = &xil_spi_param;
-	default_init_param.spi_param.platform_ops = &xil_platform_ops;
+	default_init_param.spi_param.platform_ops = &xil_spi_ops;
 #endif
 
 #ifdef ALTERA_PLATFORM

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -110,7 +110,7 @@ struct xil_gpio_init_param xil_gpio_param = {
 
 #ifdef GENERIC_PLATFORM
 #define GPIO_OPS	&generic_gpio_platform_ops
-#define SPI_OPS		&generic_spi_platform_ops
+#define SPI_OPS		&generic_spi_ops
 #define GPIO_PARAM	NULL
 #define SPI_PARAM	NULL
 #endif

--- a/projects/ad9371/src/devices/adi_hal/common.c
+++ b/projects/ad9371/src/devices/adi_hal/common.c
@@ -88,7 +88,7 @@ int32_t platform_init(void)
 		.base_address = GPIO_BASEADDR
 	};
 	spi_param.device_id = SPI_DEVICE_ID;
-	spi_param.platform_ops = &altera_platform_ops;
+	spi_param.platform_ops = &altera_spi_ops;
 	spi_param.extra = &altera_spi_param;
 	gpio_ad9371_resetb_param.platform_ops = &altera_gpio_platform_ops;
 	gpio_ad9371_resetb_param.extra = &altera_gpio_param;

--- a/projects/ad9371/src/devices/adi_hal/common.c
+++ b/projects/ad9371/src/devices/adi_hal/common.c
@@ -69,7 +69,7 @@ int32_t platform_init(void)
 	};
 	spi_param.device_id = SPI_DEVICE_ID;
 	spi_param.extra = &xilinx_spi_param;
-	spi_param.platform_ops = &xil_platform_ops;
+	spi_param.platform_ops = &xil_spi_ops;
 	gpio_ad9371_resetb_param.platform_ops = &xil_gpio_platform_ops;
 	gpio_ad9371_resetb_param.extra = &xilinx_gpio_param;
 	gpio_ad9528_resetb_param.platform_ops = &xil_gpio_platform_ops;

--- a/projects/ad9434-fmc-500ebz/src/ad9434_fmc_500ebz.c
+++ b/projects/ad9434-fmc-500ebz/src/ad9434_fmc_500ebz.c
@@ -77,7 +77,7 @@ int main(void)
 		.chip_select = 0,
 		.mode = SPI_MODE_0,
 		.extra = &xil_spi_param,
-		.platform_ops = &xil_platform_ops,
+		.platform_ops = &xil_spi_ops,
 	};
 
 	/* ADC Core */

--- a/projects/ad9467/src/app/ad9467_fmc.c
+++ b/projects/ad9467/src/app/ad9467_fmc.c
@@ -124,7 +124,7 @@ int main()
 	struct spi_init_param ad9467_spi_param = {
 		.max_speed_hz = 2000000u,
 		.chip_select = 0,
-		.platform_ops = &xil_platform_ops,
+		.platform_ops = &xil_spi_ops,
 		.mode = SPI_MODE_0
 	};
 
@@ -142,7 +142,7 @@ int main()
 		.device_id = SPI_DEVICE_ID,
 		.max_speed_hz = 2000000u,
 		.chip_select = 1,
-		.platform_ops = &xil_platform_ops,
+		.platform_ops = &xil_spi_ops,
 		.mode = SPI_MODE_0
 	};
 	ad9517_spi_param.extra = &xil_spi_param;

--- a/projects/ad9656_fmc/src/app/ad9656_fmc.c
+++ b/projects/ad9656_fmc/src/app/ad9656_fmc.c
@@ -103,13 +103,13 @@ int main(void)
 	};
 
 	ad9508_spi_param.device_id = SPI_DEVICE_ID;
-	ad9508_spi_param.platform_ops = &xil_platform_ops;
+	ad9508_spi_param.platform_ops = &xil_spi_ops;
 	ad9508_spi_param.extra = &xil_spi_param;
 	ad9553_spi_param.device_id = SPI_DEVICE_ID;
-	ad9553_spi_param.platform_ops = &xil_platform_ops;
+	ad9553_spi_param.platform_ops = &xil_spi_ops;
 	ad9553_spi_param.extra = &xil_spi_param;
 	ad9656_spi_param.device_id = SPI_DEVICE_ID;
-	ad9656_spi_param.platform_ops = &xil_platform_ops;
+	ad9656_spi_param.platform_ops = &xil_spi_ops;
 	ad9656_spi_param.extra = &xil_spi_param;
 
 	struct ad9508_init_param	ad9508_param;

--- a/projects/ad9739a-fmc-ebz/src/ad9739a_fmc_ebz.c
+++ b/projects/ad9739a-fmc-ebz/src/ad9739a_fmc_ebz.c
@@ -79,7 +79,7 @@ int main(void)
 		.chip_select = 0,
 		.mode = SPI_MODE_0,
 		.extra = &xil_spi_param,
-		.platform_ops = &xil_platform_ops,
+		.platform_ops = &xil_spi_ops,
 	};
 
 	struct spi_init_param ad9739_spi_param = {
@@ -88,7 +88,7 @@ int main(void)
 		.chip_select = 1,
 		.mode = SPI_MODE_0,
 		.extra = &xil_spi_param,
-		.platform_ops = &xil_platform_ops,
+		.platform_ops = &xil_spi_ops,
 	};
 
 	adf4350_init_param default_adf4350_init_param = {

--- a/projects/ada4250_ardz/src.mk
+++ b/projects/ada4250_ardz/src.mk
@@ -8,8 +8,13 @@ SRC_DIRS += $(NO-OS)/drivers/irq
 SRC_DIRS += $(PLATFORM_DRIVERS)
 SRC_DIRS += $(INCLUDE)
 
-SRCS += $(NO-OS)/util/util.c				\
-	$(NO-OS)/util/list.c
+SRCS += $(NO-OS)/util/util.c					\
+	$(NO-OS)/util/list.c					\
+	$(DRIVERS)/spi/spi.c					\
+	$(DRIVERS)/platform/$(PLATFORM)/$(PLATFORM)_spi.c 	\
+
+INCS += $(INCLUDE)/spi.h					\
+	$(DRIVERS)/platform/$(PLATFORM)/spi_extra.h
 
 IGNORED_FILES += $(PLATFORM_DRIVERS)/uart_stdio.c
 IGNORED_FILES += $(PLATFORM_DRIVERS)/uart_stdio.h

--- a/projects/ada4250_ardz/src/ada4250_ardz.c
+++ b/projects/ada4250_ardz/src/ada4250_ardz.c
@@ -76,7 +76,7 @@ int main()
 		.extra = &spi_param,
 		.max_speed_hz = 1000000,
 		.mode = SPI_MODE_3,
-		.platform_ops = NULL
+		.platform_ops = &aducm_spi_ops
 	};
 
 	struct ada4250_init_param ada4250_param = {

--- a/projects/adf4377_sdz/src/app/adf4377_sdz.c
+++ b/projects/adf4377_sdz/src/app/adf4377_sdz.c
@@ -96,7 +96,7 @@ int main(void)
 		.chip_select = SPI_ADF4377_CS,
 		.mode = SPI_MODE_0,
 		.bit_order = SPI_BIT_ORDER_MSB_FIRST,
-		.platform_ops = &xil_platform_ops,
+		.platform_ops = &xil_spi_ops,
 		.extra = &xil_spi_init
 	};
 

--- a/projects/adf5902_sdz/src/adf5902_sdz.c
+++ b/projects/adf5902_sdz/src/adf5902_sdz.c
@@ -86,7 +86,7 @@ int main(void)
 		.max_speed_hz = 2000000,
 		.chip_select = SPI_ADF5902_CS,
 		.mode = SPI_MODE_0,
-		.platform_ops = &xil_platform_ops,
+		.platform_ops = &xil_spi_ops,
 		.extra = &xil_spi_init
 	};
 

--- a/projects/adrv9001/src/hal/no_os_platform.c
+++ b/projects/adrv9001/src/hal/no_os_platform.c
@@ -122,7 +122,7 @@ int32_t no_os_hw_open(void *devHalCfg)
 		.max_speed_hz = 20000000,
 		.mode = SPI_MODE_0,
 		.chip_select = SPI_CS,
-		.platform_ops = &xil_platform_ops,
+		.platform_ops = &xil_spi_ops,
 		.extra = &sip_extra
 	};
 	ret = spi_init(&phal->spi, &sip);

--- a/projects/adrv9009/src/app/app_clocking.c
+++ b/projects/adrv9009/src/app/app_clocking.c
@@ -406,7 +406,7 @@ adiHalErr_t clocking_init(uint32_t rx_div40_rate_hz,
 		.mode = SPI_MODE_0,
 		.chip_select = CLK_CS,
 #ifndef ALTERA_PLATFORM
-		.platform_ops = &xil_platform_ops,
+		.platform_ops = &xil_spi_ops,
 #else
 		.platform_ops = &altera_platform_ops,
 #endif
@@ -420,7 +420,7 @@ adiHalErr_t clocking_init(uint32_t rx_div40_rate_hz,
 		.max_speed_hz = 10000000,
 		.mode = SPI_MODE_0,
 		.chip_select = CAR_CLK_CS,
-		.platform_ops = &xil_platform_ops,
+		.platform_ops = &xil_spi_ops,
 		.extra = &xil_spi_param
 	};
 	hmc7044_car_param.spi_init = &car_clkchip_spi_init_param;

--- a/projects/adrv9009/src/app/app_clocking.c
+++ b/projects/adrv9009/src/app/app_clocking.c
@@ -408,7 +408,7 @@ adiHalErr_t clocking_init(uint32_t rx_div40_rate_hz,
 #ifndef ALTERA_PLATFORM
 		.platform_ops = &xil_spi_ops,
 #else
-		.platform_ops = &altera_platform_ops,
+		.platform_ops = &altera_spi_ops,
 #endif
 		.extra = &xil_spi_param
 	};

--- a/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
+++ b/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
@@ -92,7 +92,7 @@ adiHalErr_t ADIHAL_openHw(void *devHalInfo, uint32_t halTimeout_ms)
 	spi_param.mode = SPI_MODE_0;
 	spi_param.chip_select = dev_hal_data->spi_adrv_csn;
 #ifndef ALTERA_PLATFORM
-	spi_param.platform_ops = &xil_platform_ops;
+	spi_param.platform_ops = &xil_spi_ops;
 #else
 	spi_param.platform_ops = &altera_platform_ops;
 #endif

--- a/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
+++ b/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
@@ -94,7 +94,7 @@ adiHalErr_t ADIHAL_openHw(void *devHalInfo, uint32_t halTimeout_ms)
 #ifndef ALTERA_PLATFORM
 	spi_param.platform_ops = &xil_spi_ops;
 #else
-	spi_param.platform_ops = &altera_platform_ops;
+	spi_param.platform_ops = &altera_spi_ops;
 #endif
 	if (dev_hal_data->extra_spi)
 		spi_param.extra = dev_hal_data->extra_spi;

--- a/projects/adxrs290-pmdz/src.mk
+++ b/projects/adxrs290-pmdz/src.mk
@@ -26,13 +26,14 @@ LIBRARIES += iio
 SRCS += $(PLATFORM_DRIVERS)/uart.c					\
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c				\
 	$(PLATFORM_DRIVERS)/gpio.c					\
-	$(PLATFORM_DRIVERS)/spi.c					\
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_spi.c				\
 	$(PLATFORM_DRIVERS)/delay.c					\
 	$(PLATFORM_DRIVERS)/timer.c					\
 	$(DRIVERS)/irq/irq.c						\
 	$(NO-OS)/util/list.c						\
 	$(NO-OS)/util/fifo.c						\
 	$(NO-OS)/util/util.c						\
+	$(DRIVERS)/spi/spi.c
 
 INCS += $(INCLUDE)/fifo.h						\
 	$(INCLUDE)/irq.h						\

--- a/projects/adxrs290-pmdz/src/main.c
+++ b/projects/adxrs290-pmdz/src/main.c
@@ -210,7 +210,7 @@ int main(void)
 		.extra = &spi_param,
 		.max_speed_hz = 900000,
 		.mode = SPI_MODE_3,
-		.platform_ops = NULL
+		.platform_ops = &aducm_spi_ops
 	};
 
 	/* Initialization for Sync pin GPIO. */

--- a/projects/cn0531/src.mk
+++ b/projects/cn0531/src.mk
@@ -10,6 +10,9 @@ SRC_DIRS += $(PLATFORM_DRIVERS)
 SRC_DIRS += $(NO-OS)/util
 SRC_DIRS += $(INCLUDE)
 SRC_DIRS += $(DRIVERS)/irq
-
+SRCS += $(DRIVERS)/spi/spi.c \
+	$(DRIVERS)/platform/$(PLATFORM)/$(PLATFORM)_spi.c
+INCS += $(INCLUDE)/spi.h \
+	$(DRIVERS)/platform/$(PLATFORM)/spi_extra.h
 TINYIIOD=y
 

--- a/projects/display_demo/src/app/main.c
+++ b/projects/display_demo/src/app/main.c
@@ -72,7 +72,7 @@ int main(void)
 		.mode = SPI_MODE_0,
 		.chip_select = 10U,
 		.bit_order = SPI_BIT_ORDER_MSB_FIRST,
-		.platform_ops = &xil_platform_ops,
+		.platform_ops = &xil_spi_ops,
 		.extra = &spi_extra
 	};
 

--- a/projects/fmcadc2/src/app/fmcadc2.c
+++ b/projects/fmcadc2/src/app/fmcadc2.c
@@ -71,7 +71,7 @@ int main(void)
 	struct spi_init_param ad9625_spi_param = {
 		.max_speed_hz = 2000000u,
 		.chip_select = 0,
-		.platform_ops = &xil_platform_ops,
+		.platform_ops = &xil_spi_ops,
 		.mode = SPI_MODE_0
 	};
 

--- a/projects/fmcadc5/src/app/fmcadc5.c
+++ b/projects/fmcadc5/src/app/fmcadc5.c
@@ -76,7 +76,7 @@ int main(void)
 		.max_speed_hz = 2000000u,
 		.chip_select = 0,
 		.mode = SPI_MODE_0,
-		.platform_ops = &xil_platform_ops
+		.platform_ops = &xil_spi_ops
 	};
 
 	struct spi_init_param ad9625_1_spi_param = {
@@ -84,7 +84,7 @@ int main(void)
 		.max_speed_hz = 2000000u,
 		.chip_select = 1,
 		.mode = SPI_MODE_0,
-		.platform_ops = &xil_platform_ops,
+		.platform_ops = &xil_spi_ops,
 	};
 
 	struct xil_spi_init_param xil_spi_param = {

--- a/projects/fmcdaq2/src/app/fmcdaq2.c
+++ b/projects/fmcdaq2/src/app/fmcdaq2.c
@@ -246,13 +246,13 @@ static int fmcdaq2_spi_init(struct fmcdaq2_init_param *dev_init)
 		.type = SPI_PS,
 #endif
 	};
-	ad9523_spi_param.platform_ops = &xil_platform_ops;
+	ad9523_spi_param.platform_ops = &xil_spi_ops;
 	ad9523_spi_param.extra = &xil_spi_param;
 
-	ad9144_spi_param.platform_ops = &xil_platform_ops;
+	ad9144_spi_param.platform_ops = &xil_spi_ops;
 	ad9144_spi_param.extra = &xil_spi_param;
 
-	ad9680_spi_param.platform_ops = &xil_platform_ops;
+	ad9680_spi_param.platform_ops = &xil_spi_ops;
 	ad9680_spi_param.extra = &xil_spi_param;
 #else
 	struct altera_spi_init_param altera_spi_param = {

--- a/projects/fmcdaq2/src/app/fmcdaq2.c
+++ b/projects/fmcdaq2/src/app/fmcdaq2.c
@@ -259,13 +259,13 @@ static int fmcdaq2_spi_init(struct fmcdaq2_init_param *dev_init)
 		.type = NIOS_II_SPI,
 		.base_address = SYS_SPI_BASE
 	};
-	ad9523_spi_param.platform_ops = &altera_platform_ops;
+	ad9523_spi_param.platform_ops = &altera_spi_ops;
 	ad9523_spi_param.extra = &altera_spi_param;
 
-	ad9144_spi_param.platform_ops = &altera_platform_ops;
+	ad9144_spi_param.platform_ops = &altera_spi_ops;
 	ad9144_spi_param.extra = &altera_spi_param;
 
-	ad9680_spi_param.platform_ops = &altera_platform_ops;
+	ad9680_spi_param.platform_ops = &altera_spi_ops;
 	ad9680_spi_param.extra = &altera_spi_param;
 #endif
 

--- a/projects/fmcdaq3/src/app/fmcdaq3.c
+++ b/projects/fmcdaq3/src/app/fmcdaq3.c
@@ -167,11 +167,11 @@ int main(void)
 		.type = NIOS_II_SPI,
 		.base_address = SYS_SPI_BASE
 	};
-	ad9528_spi_param.platform_ops = &altera_platform_ops;
+	ad9528_spi_param.platform_ops = &altera_spi_ops;
 	ad9528_spi_param.extra = &altera_spi_param;
-	ad9152_spi_param.platform_ops = &altera_platform_ops;
+	ad9152_spi_param.platform_ops = &altera_spi_ops;
 	ad9152_spi_param.extra = &altera_spi_param;
-	ad9680_spi_param.platform_ops = &altera_platform_ops;
+	ad9680_spi_param.platform_ops = &altera_spi_ops;
 	ad9680_spi_param.extra = &altera_spi_param;
 #endif
 

--- a/projects/fmcdaq3/src/app/fmcdaq3.c
+++ b/projects/fmcdaq3/src/app/fmcdaq3.c
@@ -156,11 +156,11 @@ int main(void)
 		.type = SPI_PS,
 #endif
 	};
-	ad9528_spi_param.platform_ops = &xil_platform_ops;
+	ad9528_spi_param.platform_ops = &xil_spi_ops;
 	ad9528_spi_param.extra = &xil_spi_param;
-	ad9152_spi_param.platform_ops = &xil_platform_ops;
+	ad9152_spi_param.platform_ops = &xil_spi_ops;
 	ad9152_spi_param.extra = &xil_spi_param;
-	ad9680_spi_param.platform_ops = &xil_platform_ops;
+	ad9680_spi_param.platform_ops = &xil_spi_ops;
 	ad9680_spi_param.extra = &xil_spi_param;
 #else
 	struct altera_spi_init_param altera_spi_param = {

--- a/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
+++ b/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
@@ -80,7 +80,7 @@ int main(void)
 		.max_speed_hz = 2000000u,
 		.chip_select = 0,
 		.mode = SPI_MODE_0,
-		.platform_ops = &xil_platform_ops
+		.platform_ops = &xil_spi_ops
 	};
 
 	struct spi_init_param ad9250_0_spi_param = {

--- a/projects/iio_adpd1080/src.mk
+++ b/projects/iio_adpd1080/src.mk
@@ -12,5 +12,7 @@ SRCS +=	$(DRIVERS)/platform/$(PLATFORM)/$(PLATFORM)_irq.c
 INCS += $(INCLUDE)/irq.h
 INCS += $(DRIVERS)/platform/$(PLATFORM)/irq_extra.h
 
+SRCS += $(DRIVERS)/spi/spi.c
+
 TINYIIOD=y
 


### PR DESCRIPTION
Refactored PLATFORM_platform_ops to PLATFORM_spi_ops.

Removed functions from spi_extra.h files so that they can be used only from spi.c.

Added aducm_spi_ops to drivers/platform/aducm3029.

Resolved other conflicts.