### PR TITLE
Staging/refactoring irq ops

### DIFF
--- a/drivers/platform/aducm3029/aducm3029_irq.c
+++ b/drivers/platform/aducm3029/aducm3029_irq.c
@@ -87,20 +87,6 @@ static const uint32_t id_map_event[NB_INTERRUPTS] = {
  */
 static uint32_t		initialized;
 
-/**
- * @brief Aducm3029 platform specific IRQ platform ops structure
- */
-const struct irq_platform_ops aducm3029_irq_platform_ops = {
-	.init = &aducm3029_irq_ctrl_init,
-	.register_callback = &aducm3029_irq_register_callback,
-	.unregister = &aducm3029_irq_unregister,
-	.global_enable = &aducm3029_irq_global_enable,
-	.global_disable = &aducm3029_irq_global_disable,
-	.enable = &aducm3029_irq_enable,
-	.disable = &aducm3029_irq_disable,
-	.remove = &aducm3029_irq_ctrl_remove
-};
-
 /******************************************************************************/
 /************************ Functions Definitions *******************************/
 /******************************************************************************/
@@ -475,3 +461,17 @@ int32_t aducm3029_irq_disable(struct irq_ctrl_desc *desc, uint32_t irq_id)
 
 	return SUCCESS;
 }
+
+/**
+ * @brief Aducm3029 platform specific IRQ platform ops structure
+ */
+const struct irq_platform_ops aducm_irq_ops = {
+	.init = &aducm3029_irq_ctrl_init,
+	.register_callback = &aducm3029_irq_register_callback,
+	.unregister = &aducm3029_irq_unregister,
+	.global_enable = &aducm3029_irq_global_enable,
+	.global_disable = &aducm3029_irq_global_disable,
+	.enable = &aducm3029_irq_enable,
+	.disable = &aducm3029_irq_disable,
+	.remove = &aducm3029_irq_ctrl_remove
+};

--- a/drivers/platform/aducm3029/irq_extra.h
+++ b/drivers/platform/aducm3029/irq_extra.h
@@ -170,42 +170,6 @@ struct aducm_irq_ctrl_desc {
 /**
  * @brief ADuCM3029 specific IRQ platform ops structure
  */
-extern const struct irq_platform_ops aducm3029_irq_platform_ops;
-
-/******************************************************************************/
-/************************ Functions Declarations ******************************/
-/******************************************************************************/
-
-/* Initialize a interrupt controller peripheral. */
-int32_t aducm3029_irq_ctrl_init(struct irq_ctrl_desc **desc,
-				const struct irq_init_param *param);
-
-/* Free the resources allocated by irq_ctrl_init(). */
-int32_t aducm3029_irq_ctrl_remove(struct irq_ctrl_desc *desc);
-
-/* Register a callback to handle the irq events */
-int32_t aducm3029_irq_register_callback(struct irq_ctrl_desc *desc,
-					uint32_t irq_id,
-					struct callback_desc *callback_desc);
-
-/* Unregisters a generic IRQ handling function */
-int32_t aducm3029_irq_unregister(struct irq_ctrl_desc *desc, uint32_t irq_id);
-
-/* Global interrupt enable */
-int32_t aducm3029_irq_global_enable(struct irq_ctrl_desc *desc);
-
-/* Global interrupt disable */
-int32_t aducm3029_irq_global_disable(struct irq_ctrl_desc *desc);
-
-/* Set interrupt trigger level. */
-int32_t aducm3029_irq_trigger_level_set(struct irq_ctrl_desc *desc,
-					uint32_t irq_id,
-					enum irq_trig_level trig);
-
-/* Enable specific interrupt */
-int32_t aducm3029_irq_enable(struct irq_ctrl_desc *desc, uint32_t irq_id);
-
-/* Disable specific interrupt */
-int32_t aducm3029_irq_disable(struct irq_ctrl_desc *desc, uint32_t irq_id);
+extern const struct irq_platform_ops aducm_irq_ops;
 
 #endif // IRQ_EXTRA_H_

--- a/drivers/platform/xilinx/irq_extra.h
+++ b/drivers/platform/xilinx/irq_extra.h
@@ -86,40 +86,6 @@ struct xil_irq_desc {
 /**
  * @brief Xilinx specific IRQ platform ops structure
  */
-extern const struct irq_platform_ops xil_irq_platform_ops;
-
-/******************************************************************************/
-/************************ Functions Declarations ******************************/
-/******************************************************************************/
-
-/* Initialize a interrupt controller peripheral. */
-int32_t xil_irq_ctrl_init(struct irq_ctrl_desc **desc,
-			  const struct irq_init_param *param);
-
-/* Free the resources allocated by irq_ctrl_init(). */
-int32_t xil_irq_ctrl_remove(struct irq_ctrl_desc *desc);
-
-/* Register a callback to handle the irq events */
-int32_t xil_irq_register_callback(struct irq_ctrl_desc *desc, uint32_t irq_id,
-				  struct callback_desc *callback_desc);
-
-/* Unregisters a generic IRQ handling function */
-int32_t xil_irq_unregister(struct irq_ctrl_desc *desc, uint32_t irq_id);
-
-/* Global interrupt enable */
-int32_t xil_irq_global_enable(struct irq_ctrl_desc *desc);
-
-/* Global interrupt disable */
-int32_t xil_irq_global_disable(struct irq_ctrl_desc *desc);
-
-/* Set interrupt trigger level. */
-int32_t xil_irq_trigger_level_set(struct irq_ctrl_desc *desc, uint32_t irq_id,
-				  enum irq_trig_level trig);
-
-/* Enable specific interrupt */
-int32_t xil_irq_enable(struct irq_ctrl_desc *desc, uint32_t irq_id);
-
-/* Disable specific interrupt */
-int32_t xil_irq_disable(struct irq_ctrl_desc *desc, uint32_t irq_id);
+extern const struct irq_platform_ops xil_irq_ops;
 
 #endif

--- a/drivers/platform/xilinx/xilinx_irq.c
+++ b/drivers/platform/xilinx/xilinx_irq.c
@@ -61,21 +61,6 @@
 /******************************************************************************/
 
 /**
- * @brief Xilinx platform specific IRQ platform ops structure
- */
-const struct irq_platform_ops xil_irq_platform_ops = {
-	.init = &xil_irq_ctrl_init,
-	.register_callback = &xil_irq_register_callback,
-	.unregister = &xil_irq_unregister,
-	.global_enable = &xil_irq_global_enable,
-	.global_disable = &xil_irq_global_disable,
-	.trigger_level_set = &xil_irq_trigger_level_set,
-	.enable = &xil_irq_enable,
-	.disable = &xil_irq_disable,
-	.remove = &xil_irq_ctrl_remove
-};
-
-/**
  * @brief Initialize the IRQ interrupts.
  * @param desc - The IRQ controller descriptor.
  * @param param - The structure that contains the IRQ parameters.
@@ -379,3 +364,18 @@ int32_t xil_irq_ctrl_remove(struct irq_ctrl_desc *desc)
 
 	return SUCCESS;
 }
+
+/**
+ * @brief Xilinx platform specific IRQ platform ops structure
+ */
+const struct irq_platform_ops xil_irq_ops = {
+	.init = &xil_irq_ctrl_init,
+	.register_callback = &xil_irq_register_callback,
+	.unregister = &xil_irq_unregister,
+	.global_enable = &xil_irq_global_enable,
+	.global_disable = &xil_irq_global_disable,
+	.trigger_level_set = &xil_irq_trigger_level_set,
+	.enable = &xil_irq_enable,
+	.disable = &xil_irq_disable,
+	.remove = &xil_irq_ctrl_remove
+};

--- a/iio/iio_app/iio_app.c
+++ b/iio/iio_app/iio_app.c
@@ -144,7 +144,7 @@ int32_t iio_app_run(struct iio_app_device *devices, int32_t len)
 #ifndef PLATFORM_MB
 	irq_init_param = (struct irq_init_param ) {
 		.irq_ctrl_id = INTC_DEVICE_ID,
-		.platform_ops = &xil_irq_platform_ops,
+		.platform_ops = &xil_irq_ops,
 		.extra = &platform_irq_init_par
 	};
 #endif

--- a/iio/iio_app/iio_app.c
+++ b/iio/iio_app/iio_app.c
@@ -135,7 +135,7 @@ int32_t iio_app_run(struct iio_app_device *devices, int32_t len)
 #if defined(ADUCM_PLATFORM)
 	irq_init_param = (struct irq_init_param ) {
 		.irq_ctrl_id = INTC_DEVICE_ID,
-		.platform_ops = &aducm3029_irq_platform_ops,
+		.platform_ops = &aducm_irq_ops,
 		.extra = &platform_irq_init_par
 	};
 #endif


### PR DESCRIPTION
Refactored PLATFORM_irq_platform_ops to PLATFORM_irq_ops.

Removed functions declarations from irq_extra.h files so that they can be used only from irq.c.

Resolved other conflicts.