### PR TITLE
hmc7044: fix clk_set_rate if channel numbers aren't continuous

### DIFF
--- a/drivers/frequency/hmc7044/hmc7044.c
+++ b/drivers/frequency/hmc7044/hmc7044.c
@@ -322,17 +322,27 @@ uint32_t hmc7044_calc_out_div(uint32_t rate,
 /**
  * Recalculate rate corresponding to a channel.
  * @param dev - The device structure.
- * @param chan - Channel number.
+ * @param chan_num - Channel number.
  * @param rate - Channel rate.
  * @return SUCCESS in case of success, negative error code otherwise.
  */
-int32_t hmc7044_clk_recalc_rate(struct hmc7044_dev *dev, uint32_t chan,
+int32_t hmc7044_clk_recalc_rate(struct hmc7044_dev *dev, uint32_t chan_num,
 				uint64_t *rate)
 {
-	if (chan > dev->num_channels)
+	int i;
+	struct hmc7044_chan_spec *chan = NULL;
+
+	/* Find the reqested channel number */
+	for (i = 0; i < dev->num_channels; i++) {
+		if (dev->channels[i].num == chan_num) {
+			chan = &dev->channels[i];
+			break;
+		}
+	}
+	if (chan == NULL )
 		return FAILURE;
 
-	*rate = dev->pll2_freq / dev->channels[chan].divider;
+	*rate = dev->pll2_freq / chan->divider;
 
 	return SUCCESS;
 }
@@ -357,28 +367,37 @@ int32_t hmc7044_clk_round_rate(struct hmc7044_dev *dev, uint32_t rate,
 /**
  * Set channel rate.
  * @param dev - The device structure.
- * @param chan - Channel number.
+ * @param chan_num - Channel number.
  * @param rate - Channel rate.
  * @return SUCCESS in case of success, negative error code otherwise.
  */
-int32_t hmc7044_clk_set_rate(struct hmc7044_dev *dev, uint32_t chan,
+int32_t hmc7044_clk_set_rate(struct hmc7044_dev *dev, uint32_t chan_num,
 			     uint64_t rate)
 {
 	uint32_t div;
 	int32_t ret;
+	int i;
+	struct hmc7044_chan_spec *chan = NULL;
 
-	if (chan >= dev->num_channels)
+	/* Find the reqested channel number */
+	for (i = 0; i < dev->num_channels; i++) {
+		if (dev->channels[i].num == chan_num) {
+			chan = &dev->channels[i];
+			break;
+		}
+	}
+	if (chan == NULL )
 		return FAILURE;
 
 	div = hmc7044_calc_out_div(rate, dev->pll2_freq);
-	dev->channels[chan].divider = div;
+	chan->divider = div;
 
-	ret = hmc7044_write(dev, HMC7044_REG_CH_OUT_CRTL_1(chan),
+	ret = hmc7044_write(dev, HMC7044_REG_CH_OUT_CRTL_1(chan->num),
 			    HMC7044_DIV_LSB(div));
 	if(ret < 0)
 		return ret;
 
-	return hmc7044_write(dev, HMC7044_REG_CH_OUT_CRTL_2(chan),
+	return hmc7044_write(dev, HMC7044_REG_CH_OUT_CRTL_2(chan->num),
 			     HMC7044_DIV_MSB(div));
 }
 

--- a/drivers/frequency/hmc7044/hmc7044.h
+++ b/drivers/frequency/hmc7044/hmc7044.h
@@ -123,11 +123,11 @@ int32_t hmc7044_init(struct hmc7044_dev **device,
 /* Remove the device. */
 int32_t hmc7044_remove(struct hmc7044_dev *device);
 int32_t hmc7044_read(struct hmc7044_dev *dev, uint16_t reg, uint8_t *val);
-int32_t hmc7044_clk_recalc_rate(struct hmc7044_dev *dev, uint32_t chan,
+int32_t hmc7044_clk_recalc_rate(struct hmc7044_dev *dev, uint32_t chan_num,
 				uint64_t *rate);
 int32_t hmc7044_clk_round_rate(struct hmc7044_dev *dev, uint32_t rate,
 			       uint64_t *rounded_rate);
-int32_t hmc7044_clk_set_rate(struct hmc7044_dev *dev, uint32_t chan,
+int32_t hmc7044_clk_set_rate(struct hmc7044_dev *dev, uint32_t chan_num,
 			     uint64_t rate);
 
 #endif // HMC7044_H_


### PR DESCRIPTION
Previously this function treated the channel number as an index into the channel list, which worked as long as the channel list contained continuous channel numbers starting at zero. This fix looks the channel number up in the list and returns an error if not found.