### PR TITLE
Minor fixes w.r.t. void pointer typecasting

### DIFF
--- a/iio/iio.c
+++ b/iio/iio.c
@@ -970,7 +970,7 @@ static ssize_t iio_read_dev(const char *device, char *pbuf, size_t offset,
 		if (offset + bytes_count > r_buff->size)
 			return -ENOMEM;
 
-		memcpy(pbuf, r_buff->buff + offset, bytes_count);
+		memcpy(pbuf, (char *)r_buff->buff + offset, bytes_count);
 
 		return bytes_count;
 	}
@@ -1026,7 +1026,7 @@ static ssize_t iio_write_dev(const char *device, const char *buf,
 	if (w_buff) {
 		if (offset + bytes_count > w_buff->size)
 			return -ENOMEM;
-		memcpy(w_buff->buff + offset, buf, bytes_count);
+		memcpy((char *)w_buff->buff + offset, buf, bytes_count);
 		return bytes_count;
 	}
 

--- a/util/list.c
+++ b/util/list.c
@@ -95,7 +95,7 @@ struct _list_desc {
 /** @brief Default function used to compare element in the list ( \ref f_cmp) */
 static int32_t default_comparator(void *data1, void *data2)
 {
-	return (int32_t)(data1 - data2);
+	return (int32_t)((int32_t *)data1 - (int32_t *)data2);
 }
 
 /**


### PR DESCRIPTION
1. Direct operations done on void pointers which causes build failure on IAR compiler. The build works well with GCC and ARMC compiler but not on IAR. Added typecasting to pointers before performing any operations.

Signed-off-by: mahphalke <Mahesh.Phalke@analog.com>