### PR TITLE
projects:ad9361: fix comment

### DIFF
--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -658,7 +658,7 @@ int main(void)
 	samples = 2097150;
 #endif
 	// NOTE: To prevent unwanted data loss, it's recommended to invalidate
-	// cache after each adc_capture() call, keeping in mind that the
+	// cache after each axi_dmac_transfer() call, keeping in mind that the
 	// size of the capture and the start address must be alinged to the size
 	// of the cache line.
 	mdelay(1000);


### PR DESCRIPTION
The `adc_capture` function is no longer supported.

Reference: https://ez.analog.com/microcontroller-no-os-drivers/f/q-a/550449/adc_capture-for-ad9361

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>