### PR TITLE
app_iio: fix missing platform_ops init for irq

### DIFF
--- a/projects/adrv9001/src/app/app_iio.c
+++ b/projects/adrv9001/src/app/app_iio.c
@@ -81,6 +81,7 @@ int32_t iio_server_init(struct iio_axi_adc_init_param *adc1_init,
 	};
 	struct irq_init_param irq_init_par = {
 		.irq_ctrl_id = INTC_DEVICE_ID,
+		.platform_ops = &xil_irq_ops,
 		.extra = &xil_irq_init_par
 	};
 	struct xil_uart_init_param xil_uart_init_par = {


### PR DESCRIPTION
Recent changes to irq subsystem have probably introduced this
error, this commit fixes it.

Signed-off-by: Darius Berghe <darius.berghe@analog.com>