### PR TITLE
drivers: ada4250: Added support for sleep and shutdown pins

### DIFF
--- a/drivers/amplifiers/ada4250/ada4250.h
+++ b/drivers/amplifiers/ada4250/ada4250.h
@@ -167,10 +167,14 @@ struct ada4250_init_param {
 	struct gpio_init_param	*gpio_g1_param;
 	struct gpio_init_param	*gpio_g0_param;
 	struct gpio_init_param	*gpio_bufen_param;
+	struct gpio_init_param	*gpio_slp;
+	struct gpio_init_param	*gpio_shtdwn;
 	/* AVDD value in Volts */
 	int32_t avdd_v;
 	/* Reference Buffer Enable */
 	bool refbuf_en;
+	/* Sleep/Shutdown Pins Enable */
+	bool slp_shtdwn_en;
 	/* Gain Value */
 	enum ada4250_gain gain;
 	/* Bias Set */
@@ -193,6 +197,8 @@ struct ada4250_dev {
 	struct gpio_desc	*gpio_g1;
 	struct gpio_desc	*gpio_g0;
 	struct gpio_desc	*gpio_bufen;
+	struct gpio_desc	*gpio_slp;
+	struct gpio_desc	*gpio_shtdwn;
 	/* AVDD value in Volts */
 	int32_t avdd_v;
 	/* Reference Buffer Enable */


### PR DESCRIPTION
The sleep and shutdown gpios are common to both ADA4250 and ADA4230.
I believe these GPIOs should be a part of the device structure, as this would provide flexibility for the customer, to control current consumption of the device through the MCU. 

Also if these GPIOs are not driven high during initialization, the MCU might not be able to communicate through SPI (ADA4250) or configure the chip ( ADA4230). 

Signed-off-by: Pratyush Mallick <Pratyush.Mallick@analog.com>