### PR TITLE
fix adrv9002 on zc706 gpio offset

### DIFF
--- a/projects/adrv9001/src/hal/parameters.h
+++ b/projects/adrv9001/src/hal/parameters.h
@@ -56,10 +56,10 @@
 #define ADC1_CHANNELS 4
 #define ADC2_CHANNELS 2
 
-#if defined(PLATFORM_MB)
-#define GPIO_OFFSET			54
-#else
+#ifdef XPS_BOARD_ZCU102
 #define GPIO_OFFSET			78
+#else
+#define GPIO_OFFSET			54
 #endif
 
 /* GPIO */


### PR DESCRIPTION
A wrong #ifdef condition was causing this project to not work on
zc706 carrier, this commit fixes it.

If I'm not mistaken, this wasn't yet tested on zc706 in no-OS.