### PR TITLE
drivers:adc:ad7124: display decimal raw value instead of hexa

### DIFF
--- a/drivers/adc/ad7124/iio_ad7124.c
+++ b/drivers/adc/ad7124/iio_ad7124.c
@@ -259,7 +259,7 @@ static ssize_t ad7124_iio_read_raw_chan(void *device, char *buf, size_t len,
 	if (ret != SUCCESS)
 		return ret;
 
-	return snprintf(buf, len, "%"PRIX32"", (uint32_t)value);
+	return snprintf(buf, len, "%"PRId32"", (uint32_t)value);
 }
 
 /**


### PR DESCRIPTION
The pyadi-iio framework assumes values from raw come in decimal format
and will lose all values that do not start with a number.

Signed-off-by: Andrei Drimbarean <Andrei.Drimbarean@analog.com>