### PR TITLE
drivers:platform:xilinx: fix spi type enum

### DIFF
--- a/drivers/platform/xilinx/spi_extra.h
+++ b/drivers/platform/xilinx/spi_extra.h
@@ -68,7 +68,7 @@ enum xil_spi_type {
 	SPI_PS,
 	/** SPI Engine */
 	SPI_ENGINE
-} xil_spi_type;
+};
 
 /**
  * @struct xil_spi_init_param


### PR DESCRIPTION
After the removal of `typedef` the alias is redundant.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>