### PR TITLE
projects: ad9371: update ad9371 project to use iio_app

### DIFF
--- a/projects/ad9371/src.mk
+++ b/projects/ad9371/src.mk
@@ -56,6 +56,7 @@ SRCS += $(PLATFORM_DRIVERS)/uart.c					\
 	$(NO-OS)/util/list.c						\
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c			\
 	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.c			\
+	$(NO-OS)/iio/iio_app/iio_app.c		\
 	$(DRIVERS)/irq/irq.c
 endif
 INCS +=	$(PROJECT)/src/app/app_config.h					\
@@ -105,5 +106,6 @@ INCS += $(INCLUDE)/fifo.h						\
 	$(PLATFORM_DRIVERS)/irq_extra.h					\
 	$(PLATFORM_DRIVERS)/uart_extra.h				\
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h				\
+	$(NO-OS)/iio/iio_app/iio_app.h	\
 	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.h
 endif

--- a/projects/ad9371/src/app/app_config.h
+++ b/projects/ad9371/src/app/app_config.h
@@ -47,4 +47,6 @@
 
 //#define IIO_SUPPORT
 
+#define UART_BAUDRATE 115200
+
 #endif /* APP_CONFIG_H_ */


### PR DESCRIPTION
Use iio_app_run when built with IIO_SUPPORT.

Signed-off-by: Ramona Alexandra Nechita <ramona.nechita@analog.com>