### PR TITLE
xilinx_transceiver: allow higher QPLL frequencies

### DIFF
--- a/drivers/axi_core/jesd204/axi_adxcvr.c
+++ b/drivers/axi_core/jesd204/axi_adxcvr.c
@@ -204,6 +204,10 @@ int32_t adxcvr_clk_set_rate(struct adxcvr *xcvr,
 	uint32_t i;
 	int32_t ret;
 
+	ret = xilinx_xcvr_check_lane_rate(&xcvr->xlx_xcvr, rate);
+	if (ret < 0)
+		return ret;
+
 	clk25_div = DIV_ROUND_CLOSEST(parent_rate, 25000);
 
 	if (xcvr->cpll_enable)

--- a/drivers/axi_core/jesd204/xilinx_transceiver.h
+++ b/drivers/axi_core/jesd204/xilinx_transceiver.h
@@ -167,6 +167,8 @@ struct xilinx_xcvr_qpll_config {
 /******************************************************************************/
 /************************ Functions Declarations ******************************/
 /******************************************************************************/
+int32_t xilinx_xcvr_check_lane_rate(struct xilinx_xcvr *xcvr,
+				    uint32_t lane_rate_khz);
 int32_t xilinx_xcvr_configure_cdr(struct xilinx_xcvr *xcvr,
 				  uint32_t drp_port, uint32_t lane_rate, uint32_t out_div,
 				  bool lpm_enable);


### PR DESCRIPTION
Currently the QPLL output frequency is limited to the maximum
transceiver line rate assuming the QPLL divider is set to 1. This limits
the achievable output frequencies because some valid combinations of
QPLL frequency and divider are not allowed.

This change removes this restriction by replacing the voltage/speed
grade limit on the QPLL frequency with a check on the lane rate before
the PLLs are configured. Then the QPLLs can use their full range
specified by F_QPLL[01]RANGE in the datasheets. An invalid QPLL
configuration with the divider set to 1 is not possible because of the
previous check on the lane rate.