### PR TITLE
drivers:adc:ad713x: fix naming typo

### DIFF
--- a/drivers/adc/ad713x/iio_dual_ad713x.c
+++ b/drivers/adc/ad713x/iio_dual_ad713x.c
@@ -157,7 +157,7 @@ void iio_dual_ad713x_get_dev_descriptor(struct iio_ad713x *desc,
 
 /**
  * @brief Init for reading/writing and parameterization of a
- * ad9361 device.
+ * iio_ad713x device.
  * @param desc - Descriptor.
  * @param param - Configuration structure.
  * @return SUCCESS in case of success, FAILURE otherwise.


### PR DESCRIPTION
Fix naming in the header comment for the iio_dual_ad713x_init function.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>