### PR TITLE
drivers/platform/xilinx:gpio_irq Added retriggerable option

### DIFF
--- a/drivers/platform/xilinx/gpio_irq_extra.h
+++ b/drivers/platform/xilinx/gpio_irq_extra.h
@@ -70,6 +70,8 @@ struct xil_callback_desc {
 struct xil_gpio_irq_init_param {
 	struct irq_ctrl_desc *parent_desc;
 	int32_t gpio_device_id;
+	/* If retriggerable = false, irq pin remains disabled after irq execution */
+	bool retriggerable;
 };
 
 /**
@@ -81,6 +83,7 @@ struct xil_gpio_irq_desc {
 	XGpioPs my_Gpio;
 	struct list_desc *callback_list;
 	struct iterator *it;
+	bool retriggerable;
 };
 
 /**

--- a/drivers/platform/xilinx/xilinx_gpio_irq.c
+++ b/drivers/platform/xilinx/xilinx_gpio_irq.c
@@ -93,7 +93,8 @@ static void xil_gpio_irq_handler(struct xil_gpio_irq_desc *param)
 			XGpioPs_IntrDisablePin(&param->my_Gpio, callback_desc->pin_nb);
 			XGpioPs_IntrClearPin(&param->my_Gpio, callback_desc->pin_nb);
 			callback_desc->callback.callback(callback_desc->callback.ctx, 0U, NULL);
-			XGpioPs_IntrEnablePin(&param->my_Gpio, callback_desc->pin_nb);
+			if(param->retriggerable)
+				XGpioPs_IntrEnablePin(&param->my_Gpio, callback_desc->pin_nb);
 		}
 	}
 }
@@ -151,6 +152,7 @@ int32_t xil_gpio_irq_ctrl_init(struct irq_ctrl_desc **desc,
 
 	ldesc->extra = xil_desc;
 	xil_desc->parent_desc = xil_ip->parent_desc;
+	xil_desc->retriggerable = xil_ip->retriggerable;
 
 	status = list_init(&xil_desc->callback_list, LIST_DEFAULT, call_cmp);
 	if(status)


### PR DESCRIPTION
This option allows the user to disable the nested interrupt.
Previously, if the user wanted to disable the irq pin inside the irq handler,
the nested interrupt would reactivate the pin.

Signed-off-by: Andrei Porumb <andrei.porumb@analog.com>