### PR TITLE
projects: ad9361: fix fmcomms5 cs

### DIFF
--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -558,6 +558,7 @@ int main(void)
 	gpio_init(default_init_param.gpio_sync);
 #endif
 	default_init_param.id_no = SPI_CS_2;
+	default_init_param.spi_param.chip_select = SPI_CS_2;
 	default_init_param.gpio_resetb.number = GPIO_RESET_PIN_2;
 #ifdef LINUX_PLATFORM
 	gpio_init(default_init_param.gpio_resetb);


### PR DESCRIPTION
Make sure that SPI_CS2 is used for the second ad9361 device from the
fmcomms5 board.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>