### PR TITLE
ad9361: remove id_no param

### DIFF
--- a/drivers/rf-transceiver/ad9361/ad9361.h
+++ b/drivers/rf-transceiver/ad9361/ad9361.h
@@ -3339,7 +3339,6 @@ enum dev_id {
 
 struct ad9361_rf_phy {
 	enum dev_id		dev_sel;
-	uint8_t 		id_no;
 	struct spi_desc 	*spi;
 	struct gpio_desc 	*gpio_desc_resetb;
 	struct gpio_desc 	*gpio_desc_sync;

--- a/drivers/rf-transceiver/ad9361/ad9361_api.c
+++ b/drivers/rf-transceiver/ad9361/ad9361_api.c
@@ -116,9 +116,6 @@ int32_t ad9361_init (struct ad9361_rf_phy **ad9361_phy,
 	/* Device selection */
 	phy->dev_sel = init_param->dev_sel;
 
-	/* Identification number */
-	phy->id_no = init_param->id_no;
-
 	/* Reference Clock */
 	phy->clk_refin->rate = init_param->reference_clk_rate;
 

--- a/drivers/rf-transceiver/ad9361/ad9361_api.h
+++ b/drivers/rf-transceiver/ad9361/ad9361_api.h
@@ -52,8 +52,6 @@
 typedef struct {
 	/* Device selection */
 	enum dev_id	dev_sel;
-	/* Identification number */
-	uint8_t		id_no;
 	/* Reference Clock */
 	uint32_t	reference_clk_rate;
 	/* Base Configuration */

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -162,8 +162,6 @@ struct axi_dmac *tx_dmac;
 AD9361_InitParam default_init_param = {
 	/* Device selection */
 	ID_AD9361,	// dev_sel
-	/* Identification number */
-	0,		//id_no
 	/* Reference Clock */
 	40000000UL,	//reference_clk_rate
 	/* Base Configuration */
@@ -557,7 +555,6 @@ int main(void)
 #ifdef LINUX_PLATFORM
 	gpio_init(default_init_param.gpio_sync);
 #endif
-	default_init_param.id_no = SPI_CS_2;
 	default_init_param.spi_param.chip_select = SPI_CS_2;
 	default_init_param.gpio_resetb.number = GPIO_RESET_PIN_2;
 #ifdef LINUX_PLATFORM


### PR DESCRIPTION
The `id_no` parameter is redundant in the latest version
of the driver/project.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>