### PR TITLE
Add iio trigger support

### DIFF
--- a/drivers/gyro/adxrs290/iio_adxrs290.h
+++ b/drivers/gyro/adxrs290/iio_adxrs290.h
@@ -41,8 +41,36 @@
 #define IIO_ADXRS290_H
 
 #include "iio_types.h"
+#include "gpio.h"
+#include "irq.h"
+#include "circular_buffer.h"
 
+struct iio_adxrs290_desc {
+	struct adxrs290_dev *dev;
+	struct circular_buffer buf[1];
+	struct gpio_desc *sync;
+	struct irq_ctrl_desc *irq_ctrl;
+	uint32_t irq_nb;
+	uint32_t mask;
+	char trigger_name[20];
+};
+
+struct iio_adxrs290_init_param {
+	struct irq_ctrl_desc *irq_ctrl;
+	uint32_t irq_nb;
+	void *irq_config;
+	struct gpio_init_param *gpio_sync;
+	struct adxrs290_dev *dev;
+	int8_t *buf;
+	uint32_t buffer_size;
+	char *trigger_name;
+};
+
+int32_t iio_adxrs290_cfg(struct iio_adxrs290_desc *desc,
+			  struct iio_adxrs290_init_param *param);
+int32_t iio_adxrs290_remove(struct iio_adxrs290_desc *desc);
 
 extern struct iio_device adxrs290_iio_descriptor;
+extern struct iio_trigger adxrs290_iio_trigger_descriptor;
 
 #endif

--- a/iio/iio.c
+++ b/iio/iio.c
@@ -1321,11 +1321,13 @@ ssize_t iio_init(struct iio_desc **desc, struct iio_init_param *init_param)
 
 	ops = (struct tinyiiod_ops *)calloc(1, sizeof(struct tinyiiod_ops));
 	if (!ops)
-		return FAILURE;
+		return -ENOMEM;
 
 	ldesc = (struct iio_desc *)calloc(1, sizeof(*ldesc));
-	if (!ldesc)
+	if (!ldesc) {
+		ret = -ENOMEM;
 		goto free_ops;
+	}
 	ldesc->iiod_ops = ops;
 
 	/* device operations */
@@ -1405,7 +1407,7 @@ free_desc:
 free_ops:
 	free(ops);
 
-	return FAILURE;
+	return ret;
 }
 
 /**

--- a/iio/iio.h
+++ b/iio/iio.h
@@ -87,6 +87,9 @@ ssize_t iio_init(struct iio_desc **desc, struct iio_init_param *init_param);
 ssize_t iio_remove(struct iio_desc *desc);
 /* Execut an iio step. */
 ssize_t iio_step(struct iio_desc *desc);
+/* To call when need to notify a trigger. */
+/* TODO use name or trig_dev ? */
+void iio_trigger_notify(char *trigger_name);
 
 int32_t iio_parse_value(char *buf, enum iio_val fmt,
 			int32_t *val, int32_t *val2);

--- a/iio/iio.h
+++ b/iio/iio.h
@@ -72,6 +72,8 @@ struct iio_init_param {
 		struct tcp_socket_init_param *tcp_socket_init_param;
 #endif
 	};
+	struct iio_app_device *devs;
+	int32_t nb_devs;
 };
 
 /******************************************************************************/
@@ -85,13 +87,7 @@ ssize_t iio_init(struct iio_desc **desc, struct iio_init_param *init_param);
 ssize_t iio_remove(struct iio_desc *desc);
 /* Execut an iio step. */
 ssize_t iio_step(struct iio_desc *desc);
-/* Register interface. */
-ssize_t iio_register(struct iio_desc *desc, struct iio_device *dev_descriptor,
-		     char *name, void *dev_instance,
-		     struct iio_data_buffer *read_buff,
-		     struct iio_data_buffer *write_buff);
-/* Unregister interface. */
-ssize_t iio_unregister(struct iio_desc *desc, char *name);
+
 int32_t iio_parse_value(char *buf, enum iio_val fmt,
 			int32_t *val, int32_t *val2);
 ssize_t iio_format_value(char *buf, size_t len, enum iio_val fmt,

--- a/iio/iio_app/iio_app.c
+++ b/iio/iio_app/iio_app.c
@@ -305,21 +305,11 @@ int32_t iio_app_run(struct iio_app_device *devices, int32_t len)
 	iio_init_param.uart_desc = uart_desc;
 #endif
 
+	iio_init_param.devs = devices;
+	iio_init_param.nb_devs = len;
 	status = iio_init(&iio_desc, &iio_init_param);
 	if(status < 0)
 		goto error;
-
-	int32_t i;
-	for (i = 0; i < len; i++) {
-		status = iio_register(iio_desc,
-				      devices[i].dev_descriptor,
-				      devices[i].name,
-				      devices[i].dev,
-				      devices[i].read_buff,
-				      devices[i].write_buff);
-		if (status < 0)
-			goto error;
-	}
 
 	do {
 		status = iio_step(iio_desc);

--- a/iio/iio_app/iio_app.h
+++ b/iio/iio_app/iio_app.h
@@ -50,6 +50,21 @@
 	.write_buff = _write_buff\
 }
 
+#define IIO_APP_DEVICE_WITH_TRIGGER(_name, _dev, _dev_descriptor, _read_buff,\
+				    _write_buff, _trig_name) {\
+	.name = _name,\
+	.dev = _dev,\
+	.dev_descriptor = _dev_descriptor,\
+	.read_buff = _read_buff,\
+	.write_buff = _write_buff,\
+	.trigger_name = _trig_name\
+}
+
+#define IIO_APP_TRIGGER(_name, _dev, _trig_desc) {\
+	.name = _name,\
+	.dev = _dev,\
+	.trig_descriptor = _trig_desc \
+}
 
 /**
  * @brief Register devices and start an iio application

--- a/iio/iio_app/iio_app.h
+++ b/iio/iio_app/iio_app.h
@@ -42,6 +42,10 @@
 
 #include "iio.h"
 
+#if defined(ADUCM_PLATFORM) || defined(XILINX_PLATFORM)
+#include "irq.h"
+#endif
+
 #define IIO_APP_DEVICE(_name, _dev, _dev_descriptor, _read_buff, _write_buff) {\
 	.name = _name,\
 	.dev = _dev,\
@@ -75,5 +79,10 @@
  * @return 0 on success, negative value otherwise
  */
 int32_t iio_app_run(struct iio_app_device *devices, int32_t len);
+
+#if defined(ADUCM_PLATFORM) || defined(XILINX_PLATFORM)
+int32_t iio_app_run_irq_param(struct iio_app_device *devices, int32_t len,
+			      struct irq_ctrl_desc *irq_ctrl);
+#endif
 
 #endif

--- a/iio/iio_app/iio_app.h
+++ b/iio/iio_app/iio_app.h
@@ -50,13 +50,6 @@
 	.write_buff = _write_buff\
 }
 
-struct iio_app_device {
-	char *name;
-	void *dev;
-	struct iio_device *dev_descriptor;
-	struct iio_data_buffer *read_buff;
-	struct iio_data_buffer *write_buff;
-};
 
 /**
  * @brief Register devices and start an iio application

--- a/iio/iio_types.h
+++ b/iio/iio_types.h
@@ -227,4 +227,12 @@ struct iio_device {
 
 };
 
+struct iio_app_device {
+	char *name;
+	void *dev;
+	struct iio_device *dev_descriptor;
+	struct iio_data_buffer *read_buff;
+	struct iio_data_buffer *write_buff;
+};
+
 #endif /* IIO_TYPES_H_ */

--- a/iio/iio_types.h
+++ b/iio/iio_types.h
@@ -192,6 +192,11 @@ struct iio_data_buffer {
 	void		*buff;
 };
 
+struct iio_trigger {
+	struct iio_attribute *attributes;
+	void (*trigger_handler)(void *dev);
+};
+
 /**
  * @struct iio_device
  * @brief Structure holding channels and attributes of a device.
@@ -227,12 +232,24 @@ struct iio_device {
 
 };
 
+/* Strucure to initialize a iio device or iio trigger */
 struct iio_app_device {
 	char *name;
 	void *dev;
 	struct iio_device *dev_descriptor;
 	struct iio_data_buffer *read_buff;
 	struct iio_data_buffer *write_buff;
+	union {
+		/* 
+		 * If dev_descriptor is set, a trigger name for the device can
+		 * be specified
+		 */
+		char *trigger_name;
+		
+		/* If dev_descriptor is NULL, a trig descriptor should be
+		 * specifed */
+		struct iio_trigger *trig_descriptor;
+	};
 };
 
 #endif /* IIO_TYPES_H_ */

--- a/include/circular_buffer.h
+++ b/include/circular_buffer.h
@@ -52,17 +52,42 @@
 /******************************************************************************/
 
 /**
- * @brief Reference type for circular buffer
- *
- * Abstract type of the circular buffer, used as reference for the functions.
+ * @struct cb_ptr
+ * @brief Circular buffer pointer
  */
-struct circular_buffer;
+struct cb_ptr {
+	/** Index of data in the buffer */
+	uint32_t	idx;
+	/** Counts the number of times idx exceeds the liniar buffer */
+	uint32_t	spin_count;
+	/** Set if async transaction is active */
+	bool		async_started;
+	/** Number of bytes to update after an async transaction is finished */
+	uint32_t	async_size;
+};
+
+/**
+ * @struct circular_buffer
+ * @brief Circular buffer descriptor
+ */
+struct circular_buffer {
+	/** Size of the buffer in bytes */
+	uint32_t	size;
+	/** Address of the buffer */
+	int8_t		*buff;
+	/** Write pointer */
+	struct cb_ptr	write;
+	/** Read pointer */
+	struct cb_ptr	read;
+};
 
 /******************************************************************************/
 /************************ Functions Declarations ******************************/
 /******************************************************************************/
 
 int32_t cb_init(struct circular_buffer **desc, uint32_t size);
+/* Configure cb structure with given parameters without memory allocation */
+int32_t cb_cfg(struct circular_buffer *desc, int8_t *buf, uint32_t size);
 int32_t cb_remove(struct circular_buffer *desc);
 int32_t cb_size(struct circular_buffer *desc, uint32_t *size);
 

--- a/util/circular_buffer.c
+++ b/util/circular_buffer.c
@@ -50,42 +50,20 @@
 #include "util.h"
 
 /******************************************************************************/
-/*************************** Types Declarations *******************************/
-/******************************************************************************/
-
-/**
- * @struct cb_ptr
- * @brief Circular buffer pointer
- */
-struct cb_ptr {
-	/** Index of data in the buffer */
-	uint32_t	idx;
-	/** Counts the number of times idx exceeds the liniar buffer */
-	uint32_t	spin_count;
-	/** Set if async transaction is active */
-	bool		async_started;
-	/** Number of bytes to update after an async transaction is finished */
-	uint32_t	async_size;
-};
-
-/**
- * @struct circular_buffer
- * @brief Circular buffer descriptor
- */
-struct circular_buffer {
-	/** Size of the buffer in bytes */
-	uint32_t	size;
-	/** Address of the buffer */
-	int8_t		*buff;
-	/** Write pointer */
-	struct cb_ptr	write;
-	/** Read pointer */
-	struct cb_ptr	read;
-};
-
-/******************************************************************************/
 /************************ Functions Definitions *******************************/
 /******************************************************************************/
+
+int32_t cb_cfg(struct circular_buffer *desc, int8_t *buff, uint32_t size)
+{
+	if (!desc)
+		return -EINVAL;
+
+	memset(desc, 0, sizeof(*desc));
+	desc->size = size;
+	desc->buff = buff;
+
+	return 0;
+}
 
 /**
  * @brief Create circular buffer structure


### PR DESCRIPTION
1. There is some rework on iio.c which in order to succed on the checks #1140 needs to be merged first (#1141 and #1143  )
2. Trigger over UART seems not to be supported yet in libiio (it is on master, but no binaries yet). Will try to fix this. It worked only using WI-FI
2. Current example is not working but the trigger should work this way. 
      - The trigger is generated by an GPIO IRQ and when trying to do a SPI read in the irq handler won't work because the SPI driver is also using an IRQ which seems to be of a lower priority.
      - The solution will be to rethink the spi driver for aducm3029 or to some busy waiting in the main loop and call the trigger function from there.
