### PR TITLE
drivers:platform:xilinx: Xilinx GPIO IRQ driver rework

### DIFF
--- a/drivers/platform/xilinx/gpio_irq_extra.h
+++ b/drivers/platform/xilinx/gpio_irq_extra.h
@@ -60,6 +60,7 @@ struct xil_callback_desc {
 	int32_t pin_nb;
 	struct callback_desc callback;
 	bool triggered;
+	bool enabled;
 };
 
 /**
@@ -70,8 +71,6 @@ struct xil_callback_desc {
 struct xil_gpio_irq_init_param {
 	struct irq_ctrl_desc *parent_desc;
 	int32_t gpio_device_id;
-	/* If retriggerable = false, irq pin remains disabled after irq execution */
-	bool retriggerable;
 };
 
 /**
@@ -83,7 +82,6 @@ struct xil_gpio_irq_desc {
 	XGpioPs my_Gpio;
 	struct list_desc *callback_list;
 	struct iterator *it;
-	bool retriggerable;
 };
 
 /**


### PR DESCRIPTION
-now GPIO IRQ can be enabled/disabled on each pin individually

Signed-off-by: Andrei Porumb <andrei.porumb@analog.com>