### PR TITLE
remove src.mk whitespace

### DIFF
--- a/projects/ad400x-fmcz/src.mk
+++ b/projects/ad400x-fmcz/src.mk
@@ -10,27 +10,27 @@
 ################################################################################
 
 SRCS += $(PROJECT)/src/ad400x_fmcz.c
-SRCS += $(DRIVERS)/spi/spi.c						\
-	$(DRIVERS)/adc/ad400x/ad400x.c					\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
-	$(DRIVERS)/axi_core/spi_engine/spi_engine.c			\
+SRCS += $(DRIVERS)/spi/spi.c \
+	$(DRIVERS)/adc/ad400x/ad400x.c \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+	$(DRIVERS)/axi_core/spi_engine/spi_engine.c \
 	$(NO-OS)/util/util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/delay.c
-INCS += $(DRIVERS)/adc/ad400x/ad400x.h					\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h				\
-	$(DRIVERS)/axi_core/spi_engine/spi_engine.h			\
+INCS += $(DRIVERS)/adc/ad400x/ad400x.h \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
+	$(DRIVERS)/axi_core/spi_engine/spi_engine.h \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine_private.h
-INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
-	$(PLATFORM_DRIVERS)/uart_extra.h				\
+INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
-INCS +=	$(INCLUDE)/axi_io.h						\
-	$(INCLUDE)/spi.h						\
-	$(INCLUDE)/gpio.h						\
-	$(INCLUDE)/error.h						\
-	$(INCLUDE)/delay.h						\
-	$(INCLUDE)/irq.h						\
-	$(INCLUDE)/uart.h						\
+INCS +=	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/spi.h \
+	$(INCLUDE)/gpio.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
+	$(INCLUDE)/irq.h \
+	$(INCLUDE)/uart.h \
 	$(INCLUDE)/util.h

--- a/projects/ad4110/src.mk
+++ b/projects/ad4110/src.mk
@@ -10,30 +10,30 @@
 ################################################################################
 
 SRC_DIRS += $(PROJECT)/src
-SRCS += $(DRIVERS)/spi/spi.c						\
-	$(DRIVERS)/irq/irq.c						\
-	$(DRIVERS)/gpio/gpio.c						\
+SRCS += $(DRIVERS)/spi/spi.c \
+	$(DRIVERS)/irq/irq.c \
+	$(DRIVERS)/gpio/gpio.c \
 	$(DRIVERS)/afe/ad4110/ad4110.c
 				
-SRCS += $(PLATFORM_DRIVERS)/xilinx_spi.c				\
-	$(PLATFORM_DRIVERS)/xilinx_irq.c				\
-	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
-	$(PLATFORM_DRIVERS)/xilinx_gpio_irq.c				\
-	$(PLATFORM_DRIVERS)/delay.c					\
+SRCS += $(PLATFORM_DRIVERS)/xilinx_spi.c \
+	$(PLATFORM_DRIVERS)/xilinx_irq.c \
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
+	$(PLATFORM_DRIVERS)/xilinx_gpio_irq.c \
+	$(PLATFORM_DRIVERS)/delay.c \
 	$(NO-OS)/util/list.c
 
 INCS += $(DRIVERS)/afe/ad4110/ad4110.h
 
-INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
-	$(PLATFORM_DRIVERS)/gpio_extra.h				\
+INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/gpio_extra.h \
 	$(PLATFORM_DRIVERS)/gpio_irq_extra.h
 
-INCS += $(INCLUDE)/spi.h						\
-	$(INCLUDE)/gpio.h						\
-	$(INCLUDE)/error.h						\
-	$(INCLUDE)/delay.h						\
-	$(INCLUDE)/irq.h						\
-	$(INCLUDE)/util.h						\
-	$(INCLUDE)/print_log.h						\
+INCS += $(INCLUDE)/spi.h \
+	$(INCLUDE)/gpio.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
+	$(INCLUDE)/irq.h \
+	$(INCLUDE)/util.h \
+	$(INCLUDE)/print_log.h \
 	$(INCLUDE)/list.h

--- a/projects/ad463x_fmcz/src.mk
+++ b/projects/ad463x_fmcz/src.mk
@@ -10,51 +10,51 @@
 ################################################################################
 
 SRCS := $(PROJECT)/src/ad463x_fmc.c
-SRCS += $(DRIVERS)/spi/spi.c						\
-	$(DRIVERS)/gpio/gpio.c						\
-	$(DRIVERS)/adc/ad463x/ad463x.c					\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c		\
-	$(DRIVERS)/axi_core/axi_pwmgen/axi_pwm.c			\
-	$(DRIVERS)/axi_core/spi_engine/spi_engine.c			\
+SRCS += $(DRIVERS)/spi/spi.c \
+	$(DRIVERS)/gpio/gpio.c \
+	$(DRIVERS)/adc/ad463x/ad463x.c \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
+	$(DRIVERS)/axi_core/axi_pwmgen/axi_pwm.c \
+	$(DRIVERS)/axi_core/spi_engine/spi_engine.c \
 	$(NO-OS)/util/util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
 SRC_DIRS += $(NO-OS)/iio/iio_app
-SRCS += $(PLATFORM_DRIVERS)/uart.c					\
-	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c				\
-	$(DRIVERS)/irq/irq.c						\
-	$(DRIVERS)/adc/ad463x/iio_ad463x.c				\
-	$(NO-OS)/util/fifo.c						\
+SRCS += $(PLATFORM_DRIVERS)/uart.c \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c \
+	$(DRIVERS)/irq/irq.c \
+	$(DRIVERS)/adc/ad463x/iio_ad463x.c \
+	$(NO-OS)/util/fifo.c \
 	$(NO-OS)/util/list.c
 endif
 INCS += $(PROJECT)/src/parameters.h
-INCS += $(DRIVERS)/adc/ad463x/ad463x.h					\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h				\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h		\
-	$(DRIVERS)/axi_core/axi_pwmgen/axi_pwm_extra.h			\
-	$(DRIVERS)/axi_core/spi_engine/spi_engine.h			\
+INCS += $(DRIVERS)/adc/ad463x/ad463x.h \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h \
+	$(DRIVERS)/axi_core/axi_pwmgen/axi_pwm_extra.h \
+	$(DRIVERS)/axi_core/spi_engine/spi_engine.h \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine_private.h
-INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
-	$(PLATFORM_DRIVERS)/uart_extra.h				\
+INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
-INCS +=	$(INCLUDE)/axi_io.h						\
-	$(INCLUDE)/spi.h						\
-	$(INCLUDE)/pwm.h						\
-	$(INCLUDE)/gpio.h						\
-	$(INCLUDE)/error.h						\
-	$(INCLUDE)/delay.h						\
-	$(INCLUDE)/irq.h						\
-	$(INCLUDE)/uart.h						\
-	$(INCLUDE)/util.h						\
+INCS +=	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/spi.h \
+	$(INCLUDE)/pwm.h \
+	$(INCLUDE)/gpio.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
+	$(INCLUDE)/irq.h \
+	$(INCLUDE)/uart.h \
+	$(INCLUDE)/util.h \
 	$(INCLUDE)/print_log.h
 ifeq (y,$(strip $(TINYIIOD)))
-INCS += $(DRIVERS)/adc/ad463x/iio_ad463x.h				\
-	$(INCLUDE)/fifo.h						\
+INCS += $(DRIVERS)/adc/ad463x/iio_ad463x.h \
+	$(INCLUDE)/fifo.h \
 	$(INCLUDE)/list.h
 endif

--- a/projects/ad469x_fmcz/src.mk
+++ b/projects/ad469x_fmcz/src.mk
@@ -10,51 +10,51 @@
 ################################################################################
 
 SRCS += $(PROJECT)/src/ad469x_fmcz.c
-SRCS += $(DRIVERS)/spi/spi.c						\
-	$(DRIVERS)/gpio/gpio.c						\
-	$(DRIVERS)/adc/ad469x/ad469x.c					\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c		\
-	$(DRIVERS)/axi_core/axi_pwmgen/axi_pwm.c			\
-	$(DRIVERS)/axi_core/spi_engine/spi_engine.c			\
+SRCS += $(DRIVERS)/spi/spi.c \
+	$(DRIVERS)/gpio/gpio.c \
+	$(DRIVERS)/adc/ad469x/ad469x.c \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
+	$(DRIVERS)/axi_core/axi_pwmgen/axi_pwm.c \
+	$(DRIVERS)/axi_core/spi_engine/spi_engine.c \
 	$(NO-OS)/util/util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
-SRCS += $(PLATFORM_DRIVERS)/uart.c					\
-	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c				\
-	$(DRIVERS)/irq/irq.c						\
-	$(NO-OS)/util/fifo.c						\
+SRCS += $(PLATFORM_DRIVERS)/uart.c \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c \
+	$(DRIVERS)/irq/irq.c \
+	$(NO-OS)/util/fifo.c \
 	$(NO-OS)/util/list.c						
 endif
 INCS += $(PROJECT)/src/parameters.h
-INCS += $(DRIVERS)/adc/ad469x/ad469x.h					\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h				\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h		\
-	$(DRIVERS)/axi_core/axi_pwmgen/axi_pwm_extra.h			\
-	$(DRIVERS)/axi_core/spi_engine/spi_engine.h			\
+INCS += $(DRIVERS)/adc/ad469x/ad469x.h \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h \
+	$(DRIVERS)/axi_core/axi_pwmgen/axi_pwm_extra.h \
+	$(DRIVERS)/axi_core/spi_engine/spi_engine.h \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine_private.h
-INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
-	$(PLATFORM_DRIVERS)/uart_extra.h				\
+INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
-INCS +=	$(INCLUDE)/axi_io.h						\
-	$(INCLUDE)/spi.h						\
-	$(INCLUDE)/pwm.h						\
-	$(INCLUDE)/gpio.h						\
-	$(INCLUDE)/error.h						\
-	$(INCLUDE)/delay.h						\
-	$(INCLUDE)/irq.h						\
-	$(INCLUDE)/uart.h						\
+INCS +=	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/spi.h \
+	$(INCLUDE)/pwm.h \
+	$(INCLUDE)/gpio.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
+	$(INCLUDE)/irq.h \
+	$(INCLUDE)/uart.h \
 	$(INCLUDE)/util.h
 ifeq (y,$(strip $(TINYIIOD)))
-INCS += $(INCLUDE)/fifo.h						\
-	$(INCLUDE)/irq.h						\
-	$(INCLUDE)/uart.h						\
-	$(INCLUDE)/list.h						\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
+INCS += $(INCLUDE)/fifo.h \
+	$(INCLUDE)/irq.h \
+	$(INCLUDE)/uart.h \
+	$(INCLUDE)/list.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
 	$(PLATFORM_DRIVERS)/uart_extra.h				
 endif

--- a/projects/ad5766-sdz/src.mk
+++ b/projects/ad5766-sdz/src.mk
@@ -10,29 +10,29 @@
 ################################################################################
 
 SRCS += $(PROJECT)/src/ad5766_sdz.c
-SRCS += $(PROJECT)/src/ad5766_core.c					\
-	$(DRIVERS)/dac/ad5766/ad5766.c					\
-	$(DRIVERS)/spi/spi.c						\
-	$(DRIVERS)/gpio/gpio.c						\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
-	$(DRIVERS)/axi_core/spi_engine/spi_engine.c			\
+SRCS += $(PROJECT)/src/ad5766_core.c \
+	$(DRIVERS)/dac/ad5766/ad5766.c \
+	$(DRIVERS)/spi/spi.c \
+	$(DRIVERS)/gpio/gpio.c \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+	$(DRIVERS)/axi_core/spi_engine/spi_engine.c \
 	$(NO-OS)/util/util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/delay.c
-INCS += $(PROJECT)/src/parameters.h					\
-	$(PROJECT)/src/ad5766_core.h					\
-	$(DRIVERS)/dac/ad5766/ad5766.h					\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h				\
-	$(DRIVERS)/axi_core/spi_engine/spi_engine.h			\
+INCS += $(PROJECT)/src/parameters.h \
+	$(PROJECT)/src/ad5766_core.h \
+	$(DRIVERS)/dac/ad5766/ad5766.h \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
+	$(DRIVERS)/axi_core/spi_engine/spi_engine.h \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine_private.h
-INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\
+INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
-INCS +=	$(INCLUDE)/axi_io.h						\
-	$(INCLUDE)/spi.h						\
-	$(INCLUDE)/gpio.h						\
-	$(INCLUDE)/error.h						\
-	$(INCLUDE)/delay.h						\
-	$(INCLUDE)/print_log.h						\
+INCS +=	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/spi.h \
+	$(INCLUDE)/gpio.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
+	$(INCLUDE)/print_log.h \
 	$(INCLUDE)/util.h

--- a/projects/ad6676-ebz/src.mk
+++ b/projects/ad6676-ebz/src.mk
@@ -15,57 +15,57 @@ SRCS += $(PROJECT)/src/ad6676_ebz.c
 ifeq (y,$(strip $(TINYIIOD)))
 SRCS += $(PROJECT)/src/app_iio.c
 endif
-SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c		\
-	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c			\
-	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
-	$(DRIVERS)/spi/spi.c						\
-	$(DRIVERS)/gpio/gpio.c						\
-	$(DRIVERS)/adc/ad6676/ad6676.c					\
+SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
+	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c \
+	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
+	$(DRIVERS)/spi/spi.c \
+	$(DRIVERS)/gpio/gpio.c \
+	$(DRIVERS)/adc/ad6676/ad6676.c \
 	$(NO-OS)/util/util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
-	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
-SRCS += $(NO-OS)/util/fifo.c						\
-	$(NO-OS)/util/list.c						\
-	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c				\
-	$(PLATFORM_DRIVERS)/uart.c					\
-	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c                           \
+SRCS += $(NO-OS)/util/fifo.c \
+	$(NO-OS)/util/list.c \
+	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \
+	$(PLATFORM_DRIVERS)/uart.c \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c \
 	$(DRIVERS)/irq/irq.c
 endif
-INCS +=	$(PROJECT)/src/app_config.h					\
+INCS +=	$(PROJECT)/src/app_config.h \
 	$(PROJECT)/src/parameters.h
 ifeq (y,$(strip $(TINYIIOD)))
 INCS +=	$(PROJECT)/src/app_iio.h
 endif
-INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h			\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h				\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h		\
-	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h			\
-	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h		\
-	$(DRIVERS)/io-expander/demux_spi/demux_spi.h			\
+INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h \
+	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h \
+	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h \
+	$(DRIVERS)/io-expander/demux_spi/demux_spi.h \
 	$(DRIVERS)/adc/ad6676/ad6676.h
-INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\
+INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
-INCS +=	$(INCLUDE)/axi_io.h						\
-	$(INCLUDE)/spi.h						\
-	$(INCLUDE)/gpio.h						\
-	$(INCLUDE)/error.h						\
-	$(INCLUDE)/delay.h						\
-	$(INCLUDE)/util.h						\
+INCS +=	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/spi.h \
+	$(INCLUDE)/gpio.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
+	$(INCLUDE)/util.h \
 	$(INCLUDE)/print_log.h
 ifeq (y,$(strip $(TINYIIOD)))
-INCS += $(INCLUDE)/fifo.h						\
-	$(INCLUDE)/irq.h						\
-	$(INCLUDE)/uart.h						\
-	$(INCLUDE)/list.h						\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
-	$(PLATFORM_DRIVERS)/uart_extra.h                                \
+INCS += $(INCLUDE)/fifo.h \
+	$(INCLUDE)/irq.h \
+	$(INCLUDE)/uart.h \
+	$(INCLUDE)/list.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h
 endif

--- a/projects/ad7124-4sdz/src.mk
+++ b/projects/ad7124-4sdz/src.mk
@@ -10,24 +10,24 @@
 ################################################################################
 
 SRCS += $(PROJECT)/src/ad7124-4sdz.c
-SRCS += $(DRIVERS)/spi/spi.c						\
-	$(DRIVERS)/adc/ad7124/ad7124.c					\
+SRCS += $(DRIVERS)/spi/spi.c \
+	$(DRIVERS)/adc/ad7124/ad7124.c \
 	$(DRIVERS)/adc/ad7124/ad7124_regs.c				
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/delay.c
-INCS += $(DRIVERS)/adc/ad7124/ad7124.h					\
+INCS += $(DRIVERS)/adc/ad7124/ad7124.h \
 	$(DRIVERS)/adc/ad7124/ad7124_regs.h
 
-INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
-	$(PLATFORM_DRIVERS)/uart_extra.h				\
+INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
-INCS +=	$(INCLUDE)/axi_io.h						\
-	$(INCLUDE)/spi.h						\
-	$(INCLUDE)/gpio.h						\
-	$(INCLUDE)/error.h						\
-	$(INCLUDE)/delay.h						\
-	$(INCLUDE)/irq.h						\
-	$(INCLUDE)/uart.h						\
+INCS +=	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/spi.h \
+	$(INCLUDE)/gpio.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
+	$(INCLUDE)/irq.h \
+	$(INCLUDE)/uart.h \
 	$(INCLUDE)/util.h

--- a/projects/ad713x_fmcz/src.mk
+++ b/projects/ad713x_fmcz/src.mk
@@ -12,40 +12,40 @@
 SRC_DIRS += $(PROJECT)/src
 SRC_DIRS += $(DRIVERS)/adc/ad713x
 
-SRCS += $(DRIVERS)/spi/spi.c						\
-	$(DRIVERS)/gpio/gpio.c						\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
-	$(DRIVERS)/axi_core/spi_engine/spi_engine.c			\
+SRCS += $(DRIVERS)/spi/spi.c \
+	$(DRIVERS)/gpio/gpio.c \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+	$(DRIVERS)/axi_core/spi_engine/spi_engine.c \
 	$(NO-OS)/util/util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
 SRC_DIRS += $(NO-OS)/iio/iio_app
-SRCS += $(PLATFORM_DRIVERS)/uart.c					\
-	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c				\
-	$(DRIVERS)/irq/irq.c						\
-	$(NO-OS)/util/fifo.c						\
+SRCS += $(PLATFORM_DRIVERS)/uart.c \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c \
+	$(DRIVERS)/irq/irq.c \
+	$(NO-OS)/util/fifo.c \
 	$(NO-OS)/util/list.c	
 endif
-INCS += $(DRIVERS)/axi_core/axi_dmac/axi_dmac.h				\
-	$(DRIVERS)/axi_core/spi_engine/spi_engine.h			\
+INCS += $(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
+	$(DRIVERS)/axi_core/spi_engine/spi_engine.h \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine_private.h
-INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
-	$(PLATFORM_DRIVERS)/uart_extra.h				\
+INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
-INCS +=	$(INCLUDE)/axi_io.h						\
-	$(INCLUDE)/spi.h						\
-	$(INCLUDE)/gpio.h						\
-	$(INCLUDE)/error.h						\
-	$(INCLUDE)/delay.h						\
-	$(INCLUDE)/irq.h						\
-	$(INCLUDE)/uart.h						\
+INCS +=	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/spi.h \
+	$(INCLUDE)/gpio.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
+	$(INCLUDE)/irq.h \
+	$(INCLUDE)/uart.h \
 	$(INCLUDE)/util.h
 ifeq (y,$(strip $(TINYIIOD)))
-INCS += $(INCLUDE)/fifo.h						\
+INCS += $(INCLUDE)/fifo.h \
 	$(INCLUDE)/list.h
 endif

--- a/projects/ad738x_fmcz/src.mk
+++ b/projects/ad738x_fmcz/src.mk
@@ -10,24 +10,24 @@
 ################################################################################
 
 SRCS += $(PROJECT)/src/ad738x_fmc.c
-SRCS += $(DRIVERS)/adc/ad738x/ad738x.c					\
-	$(DRIVERS)/spi/spi.c						\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
-	$(DRIVERS)/axi_core/spi_engine/spi_engine.c			\
+SRCS += $(DRIVERS)/adc/ad738x/ad738x.c \
+	$(DRIVERS)/spi/spi.c \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+	$(DRIVERS)/axi_core/spi_engine/spi_engine.c \
 	$(NO-OS)/util/util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/delay.c
-INCS += $(PROJECT)/src/app_config.h					\
-	$(PROJECT)/src/parameters.h					\
-	$(DRIVERS)/adc/ad738x/ad738x.h					\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h				\
-	$(DRIVERS)/axi_core/spi_engine/spi_engine.h			\
+INCS += $(PROJECT)/src/app_config.h \
+	$(PROJECT)/src/parameters.h \
+	$(DRIVERS)/adc/ad738x/ad738x.h \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
+	$(DRIVERS)/axi_core/spi_engine/spi_engine.h \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine_private.h
 INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					
-INCS +=	$(INCLUDE)/axi_io.h						\
-	$(INCLUDE)/spi.h						\
-	$(INCLUDE)/error.h						\
-	$(INCLUDE)/delay.h						\
-	$(INCLUDE)/print_log.h						\
+INCS +=	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/spi.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
+	$(INCLUDE)/print_log.h \
 	$(INCLUDE)/util.h

--- a/projects/ad7616-sdz/src.mk
+++ b/projects/ad7616-sdz/src.mk
@@ -10,27 +10,27 @@
 ################################################################################
 
 SRCS := $(PROJECT)/src/ad7616_sdz.c
-SRCS += $(DRIVERS)/adc/ad7616/ad7616.c					\
-	$(DRIVERS)/spi/spi.c						\
-	$(DRIVERS)/gpio/gpio.c						\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
-	$(DRIVERS)/axi_core/spi_engine/spi_engine.c			\
+SRCS += $(DRIVERS)/adc/ad7616/ad7616.c \
+	$(DRIVERS)/spi/spi.c \
+	$(DRIVERS)/gpio/gpio.c \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+	$(DRIVERS)/axi_core/spi_engine/spi_engine.c \
 	$(NO-OS)/util/util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
-	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/delay.c
-INCS += $(PROJECT)/src/parameters.h					\
-	$(DRIVERS)/adc/ad7616/ad7616.h					\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h				\
-	$(DRIVERS)/axi_core/spi_engine/spi_engine.h			\
+INCS += $(PROJECT)/src/parameters.h \
+	$(DRIVERS)/adc/ad7616/ad7616.h \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
+	$(DRIVERS)/axi_core/spi_engine/spi_engine.h \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine_private.h
-INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\
+INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
-INCS +=	$(INCLUDE)/axi_io.h						\
-	$(INCLUDE)/spi.h						\
-	$(INCLUDE)/gpio.h						\
-	$(INCLUDE)/error.h						\
-	$(INCLUDE)/delay.h						\
-	$(INCLUDE)/print_log.h						\
+INCS +=	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/spi.h \
+	$(INCLUDE)/gpio.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
+	$(INCLUDE)/print_log.h \
 	$(INCLUDE)/util.h

--- a/projects/ad7768-1fmcz/src.mk
+++ b/projects/ad7768-1fmcz/src.mk
@@ -13,29 +13,29 @@
 SRC_DIRS += $(DRIVERS)/axi_core/clk_axi_clkgen
 
 SRCS += $(PROJECT)/src/ad77681evb.c
-SRCS += $(DRIVERS)/spi/spi.c						\
-	$(DRIVERS)/adc/ad7768-1/ad77681.c				\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
-	$(DRIVERS)/axi_core/spi_engine/spi_engine.c			\
+SRCS += $(DRIVERS)/spi/spi.c \
+	$(DRIVERS)/adc/ad7768-1/ad77681.c \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+	$(DRIVERS)/axi_core/spi_engine/spi_engine.c \
 	$(NO-OS)/util/util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/delay.c
 INCS += $(PROJECT)/src/parameters.h
-INCS += $(DRIVERS)/adc/ad7768-1/ad77681.h				\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h				\
-	$(DRIVERS)/axi_core/spi_engine/spi_engine.h			\
+INCS += $(DRIVERS)/adc/ad7768-1/ad77681.h \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
+	$(DRIVERS)/axi_core/spi_engine/spi_engine.h \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine_private.h
-INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
-	$(PLATFORM_DRIVERS)/uart_extra.h				\
+INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
-INCS +=	$(INCLUDE)/axi_io.h						\
-	$(INCLUDE)/spi.h						\
-	$(INCLUDE)/gpio.h						\
-	$(INCLUDE)/error.h						\
-	$(INCLUDE)/delay.h						\
-	$(INCLUDE)/irq.h						\
-	$(INCLUDE)/uart.h						\
+INCS +=	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/spi.h \
+	$(INCLUDE)/gpio.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
+	$(INCLUDE)/irq.h \
+	$(INCLUDE)/uart.h \
 	$(INCLUDE)/util.h

--- a/projects/ad7768-evb/src.mk
+++ b/projects/ad7768-evb/src.mk
@@ -51,15 +51,15 @@ ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
 SRC_DIRS += $(NO-OS)/iio/iio_app
 
-INCS +=	$(INCLUDE)/fifo.h						\
-	$(INCLUDE)/uart.h						\
-	$(INCLUDE)/list.h						\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
-	$(PLATFORM_DRIVERS)/uart_extra.h                                \
+INCS +=	$(INCLUDE)/fifo.h \
+	$(INCLUDE)/uart.h \
+	$(INCLUDE)/list.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h
-SRCS += $(NO-OS)/util/fifo.c						\
-	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c			\
-	$(NO-OS)/util/list.c						\
-	$(PLATFORM_DRIVERS)/uart.c					\
+SRCS += $(NO-OS)/util/fifo.c \
+	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \
+	$(NO-OS)/util/list.c \
+	$(PLATFORM_DRIVERS)/uart.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c
 endif

--- a/projects/ad9081/src.mk
+++ b/projects/ad9081/src.mk
@@ -9,98 +9,98 @@
 #									       #
 ################################################################################
 
-SRCS += $(PROJECT)/src/app.c						\
-	$(PROJECT)/src/app_clock.c					\
-	$(PROJECT)/src/app_jesd.c					\
-	$(DRIVERS)/adc/ad9081/ad9081.c					\
-	$(DRIVERS)/adc/ad9081/api/adi_ad9081_adc.c			\
-	$(DRIVERS)/adc/ad9081/api/adi_ad9081_dac.c			\
-	$(DRIVERS)/adc/ad9081/api/adi_ad9081_device.c			\
-	$(DRIVERS)/adc/ad9081/api/adi_ad9081_hal.c			\
-	$(DRIVERS)/adc/ad9081/api/adi_ad9081_jesd.c			\
-	$(DRIVERS)/frequency/hmc7044/hmc7044.c				\
-	$(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
-	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c			\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
-	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c			\
-	$(DRIVERS)/axi_core/jesd204/jesd204_clk.c			\
-	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
-	$(DRIVERS)/spi/spi.c						\
-	$(DRIVERS)/gpio/gpio.c						\
-	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/delay.c					\
-	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
-	$(NO-OS)/util/clk.c						\
+SRCS += $(PROJECT)/src/app.c \
+	$(PROJECT)/src/app_clock.c \
+	$(PROJECT)/src/app_jesd.c \
+	$(DRIVERS)/adc/ad9081/ad9081.c \
+	$(DRIVERS)/adc/ad9081/api/adi_ad9081_adc.c \
+	$(DRIVERS)/adc/ad9081/api/adi_ad9081_dac.c \
+	$(DRIVERS)/adc/ad9081/api/adi_ad9081_device.c \
+	$(DRIVERS)/adc/ad9081/api/adi_ad9081_hal.c \
+	$(DRIVERS)/adc/ad9081/api/adi_ad9081_jesd.c \
+	$(DRIVERS)/frequency/hmc7044/hmc7044.c \
+	$(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
+	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c \
+	$(DRIVERS)/axi_core/jesd204/jesd204_clk.c \
+	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
+	$(DRIVERS)/spi/spi.c \
+	$(DRIVERS)/gpio/gpio.c \
+	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/delay.c \
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
+	$(NO-OS)/util/clk.c \
 	$(NO-OS)/util/util.c
 ifeq (y,$(strip $(QUAD_MXFE)))
 SRCS += $(DRIVERS)/frequency/adf4371/adf4371.c
 endif
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
-SRCS += $(NO-OS)/iio/iio_app/iio_app.c					\
-	$(PLATFORM_DRIVERS)/uart.c					\
-	$(PLATFORM_DRIVERS)/xilinx_irq.c				\
-	$(NO-OS)/util/list.c						\
-	$(NO-OS)/util/fifo.c						\
-	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c			\
-	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.c			\
+SRCS += $(NO-OS)/iio/iio_app/iio_app.c \
+	$(PLATFORM_DRIVERS)/uart.c \
+	$(PLATFORM_DRIVERS)/xilinx_irq.c \
+	$(NO-OS)/util/list.c \
+	$(NO-OS)/util/fifo.c \
+	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \
+	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.c \
 	$(DRIVERS)/irq/irq.c
 endif
-INCS +=	$(PROJECT)/src/app_clock.h					\
-	$(PROJECT)/src/app_jesd.h					\
-	$(PROJECT)/src/app_config.h					\
-	$(PROJECT)/src/parameters.h					\
-	$(DRIVERS)/adc/ad9081/ad9081.h					\
-	$(DRIVERS)/adc/ad9081/api/adi_ad9081_bf_ad9081.h		\
-	$(DRIVERS)/adc/ad9081/api/adi_ad9081_bf_impala_tc.h		\
-	$(DRIVERS)/adc/ad9081/api/adi_ad9081_bf_jrxa_des.h		\
-	$(DRIVERS)/adc/ad9081/api/adi_ad9081_bf_jtx_dual_link.h		\
-	$(DRIVERS)/adc/ad9081/api/adi_ad9081_bf_jtx_qbf_ad9081.h	\
-	$(DRIVERS)/adc/ad9081/api/adi_ad9081_bf_lcpll_28nm.h		\
-	$(DRIVERS)/adc/ad9081/api/adi_ad9081_bf_main.h			\
-	$(DRIVERS)/adc/ad9081/api/adi_ad9081_bf_nb_coarse_nco.h		\
-	$(DRIVERS)/adc/ad9081/api/adi_ad9081_bf_nb_ddc_dformat.h	\
-	$(DRIVERS)/adc/ad9081/api/adi_ad9081_bf_nb_fine_nco.h		\
-	$(DRIVERS)/adc/ad9081/api/adi_ad9081_bf_rx_paging.h		\
-	$(DRIVERS)/adc/ad9081/api/adi_ad9081_bf_ser_phy.h		\
-	$(DRIVERS)/adc/ad9081/api/adi_ad9081_bf_spi_only_up.h		\
-	$(DRIVERS)/adc/ad9081/api/adi_ad9081_config.h			\
-	$(DRIVERS)/adc/ad9081/api/adi_ad9081.h				\
-	$(DRIVERS)/adc/ad9081/api/adi_ad9081_hal.h			\
-	$(DRIVERS)/adc/ad9081/api/adi_cms_api_common.h			\
-	$(DRIVERS)/adc/ad9081/api/adi_cms_api_config.h			\
-	$(DRIVERS)/frequency/hmc7044/hmc7044.h				\
-	$(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h			\
-	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.h			\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h				\
-	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h			\
-	$(DRIVERS)/axi_core/jesd204/jesd204_clk.h			\
-	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h		\
-	$(PLATFORM_DRIVERS)/gpio_extra.h				\
-	$(PLATFORM_DRIVERS)/spi_extra.h					\
-	$(INCLUDE)/axi_io.h						\
-	$(INCLUDE)/clk.h						\
-	$(INCLUDE)/delay.h						\
-	$(INCLUDE)/error.h						\
-	$(INCLUDE)/gpio.h						\
-	$(INCLUDE)/spi.h						\
+INCS +=	$(PROJECT)/src/app_clock.h \
+	$(PROJECT)/src/app_jesd.h \
+	$(PROJECT)/src/app_config.h \
+	$(PROJECT)/src/parameters.h \
+	$(DRIVERS)/adc/ad9081/ad9081.h \
+	$(DRIVERS)/adc/ad9081/api/adi_ad9081_bf_ad9081.h \
+	$(DRIVERS)/adc/ad9081/api/adi_ad9081_bf_impala_tc.h \
+	$(DRIVERS)/adc/ad9081/api/adi_ad9081_bf_jrxa_des.h \
+	$(DRIVERS)/adc/ad9081/api/adi_ad9081_bf_jtx_dual_link.h \
+	$(DRIVERS)/adc/ad9081/api/adi_ad9081_bf_jtx_qbf_ad9081.h \
+	$(DRIVERS)/adc/ad9081/api/adi_ad9081_bf_lcpll_28nm.h \
+	$(DRIVERS)/adc/ad9081/api/adi_ad9081_bf_main.h \
+	$(DRIVERS)/adc/ad9081/api/adi_ad9081_bf_nb_coarse_nco.h \
+	$(DRIVERS)/adc/ad9081/api/adi_ad9081_bf_nb_ddc_dformat.h \
+	$(DRIVERS)/adc/ad9081/api/adi_ad9081_bf_nb_fine_nco.h \
+	$(DRIVERS)/adc/ad9081/api/adi_ad9081_bf_rx_paging.h \
+	$(DRIVERS)/adc/ad9081/api/adi_ad9081_bf_ser_phy.h \
+	$(DRIVERS)/adc/ad9081/api/adi_ad9081_bf_spi_only_up.h \
+	$(DRIVERS)/adc/ad9081/api/adi_ad9081_config.h \
+	$(DRIVERS)/adc/ad9081/api/adi_ad9081.h \
+	$(DRIVERS)/adc/ad9081/api/adi_ad9081_hal.h \
+	$(DRIVERS)/adc/ad9081/api/adi_cms_api_common.h \
+	$(DRIVERS)/adc/ad9081/api/adi_cms_api_config.h \
+	$(DRIVERS)/frequency/hmc7044/hmc7044.h \
+	$(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \
+	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.h \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
+	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h \
+	$(DRIVERS)/axi_core/jesd204/jesd204_clk.h \
+	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h \
+	$(PLATFORM_DRIVERS)/gpio_extra.h \
+	$(PLATFORM_DRIVERS)/spi_extra.h \
+	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/clk.h \
+	$(INCLUDE)/delay.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/gpio.h \
+	$(INCLUDE)/spi.h \
 	$(INCLUDE)/util.h
 ifeq (y,$(strip $(QUAD_MXFE)))
 INCS += $(DRIVERS)/frequency/adf4371/adf4371.h
 endif
 ifeq (y,$(strip $(TINYIIOD)))
-INCS += $(NO-OS)/iio/iio_app/iio_app.h					\
-	$(INCLUDE)/uart.h						\
-	$(INCLUDE)/irq.h						\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
-	$(PLATFORM_DRIVERS)/uart_extra.h				\
-	$(INCLUDE)/fifo.h						\
-	$(INCLUDE)/list.h						\
-	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h			\
+INCS += $(NO-OS)/iio/iio_app/iio_app.h \
+	$(INCLUDE)/uart.h \
+	$(INCLUDE)/irq.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(INCLUDE)/fifo.h \
+	$(INCLUDE)/list.h \
+	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h \
 	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.h
 endif

--- a/projects/ad9083/src.mk
+++ b/projects/ad9083/src.mk
@@ -15,70 +15,70 @@ endif
 
 SRC_DIRS += $(DRIVERS)/adc/ad9083
 
-SRCS += $(PROJECT)/src/app.c						\
-	$(PROJECT)/src/app_ad9083.c					\
-	$(PROJECT)/src/app_clocking.c					\
-	$(PROJECT)/src/app_jesd.c					\
-	$(PROJECT)/src/uc/uc_settings.c					\
-	$(DRIVERS)/spi/spi.c						\
-	$(DRIVERS)/gpio/gpio.c						\
+SRCS += $(PROJECT)/src/app.c \
+	$(PROJECT)/src/app_ad9083.c \
+	$(PROJECT)/src/app_clocking.c \
+	$(PROJECT)/src/app_jesd.c \
+	$(PROJECT)/src/uc/uc_settings.c \
+	$(DRIVERS)/spi/spi.c \
+	$(DRIVERS)/gpio/gpio.c \
 	$(DRIVERS)/frequency/ad9528/ad9528.c
 
-SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c		\
-	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c			\
-	$(DRIVERS)/axi_core/jesd204/jesd204_clk.c			\
-	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
-	$(NO-OS)/util/clk.c						\
+SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
+	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c \
+	$(DRIVERS)/axi_core/jesd204/jesd204_clk.c \
+	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
+	$(NO-OS)/util/clk.c \
 	$(NO-OS)/util/util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
-	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/delay.c
-INCS += $(PROJECT)/src/app_ad9083.h					\
-	$(PROJECT)/src/app_clocking.h					\
-	$(PROJECT)/src/app_config.h					\
-	$(PROJECT)/src/app_jesd.h					\
-	$(PROJECT)/src/parameters.h					\
-	$(PROJECT)/src/uc/uc_settings.h					\
+INCS += $(PROJECT)/src/app_ad9083.h \
+	$(PROJECT)/src/app_clocking.h \
+	$(PROJECT)/src/app_config.h \
+	$(PROJECT)/src/app_jesd.h \
+	$(PROJECT)/src/parameters.h \
+	$(PROJECT)/src/uc/uc_settings.h \
 	$(DRIVERS)/frequency/ad9528/ad9528.h
 
-INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h			\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h				\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h		\
-	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h			\
-	$(DRIVERS)/axi_core/jesd204/jesd204_clk.h			\
+INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h \
+	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h \
+	$(DRIVERS)/axi_core/jesd204/jesd204_clk.h \
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h
-INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\
+INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
-INCS +=	$(INCLUDE)/axi_io.h						\
-	$(INCLUDE)/spi.h						\
-	$(INCLUDE)/gpio.h						\
-	$(INCLUDE)/error.h						\
-	$(INCLUDE)/delay.h						\
-	$(INCLUDE)/clk.h						\
-	$(INCLUDE)/print_log.h						\
+INCS +=	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/spi.h \
+	$(INCLUDE)/gpio.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
+	$(INCLUDE)/clk.h \
+	$(INCLUDE)/print_log.h \
 	$(INCLUDE)/util.h
 ifeq (y,$(strip $(TINYIIOD)))
-SRCS += $(NO-OS)/util/fifo.c						\
-	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c			\
-	$(NO-OS)/iio/iio_app/iio_app.c					\
-	$(NO-OS)/util/list.c						\
-	$(PLATFORM_DRIVERS)/uart.c					\
-	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c				\
-	$(DRIVERS)/irq/irq.c                        			\
+SRCS += $(NO-OS)/util/fifo.c \
+	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \
+	$(NO-OS)/iio/iio_app/iio_app.c \
+	$(NO-OS)/util/list.c \
+	$(PLATFORM_DRIVERS)/uart.c \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c \
+	$(DRIVERS)/irq/irq.c \
 
-INCS += $(INCLUDE)/fifo.h						\
-	$(INCLUDE)/irq.h						\
-	$(INCLUDE)/uart.h						\
-	$(INCLUDE)/list.h						\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
-	$(PLATFORM_DRIVERS)/uart_extra.h                                \
-	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h			\
+INCS += $(INCLUDE)/fifo.h \
+	$(INCLUDE)/irq.h \
+	$(INCLUDE)/uart.h \
+	$(INCLUDE)/list.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h \
 	$(NO-OS)/iio/iio_app/iio_app.h
 endif

--- a/projects/ad9172/src.mk
+++ b/projects/ad9172/src.mk
@@ -14,65 +14,65 @@ ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
 SRCS += $(PROJECT)/src/app_iio.c
 endif
-SRCS += $(DRIVERS)/spi/spi.c						\
-	$(DRIVERS)/gpio/gpio.c						\
-	$(DRIVERS)/frequency/hmc7044/hmc7044.c				\
-	$(DRIVERS)/dac/ad917x/ad9172.c					\
-	$(DRIVERS)/dac/ad917x/ad917x_api/ad917x_api.c			\
-	$(DRIVERS)/dac/ad917x/ad917x_api/ad917x_jesd_api.c		\
-	$(DRIVERS)/dac/ad917x/ad917x_api/ad917x_nco_api.c		\
+SRCS += $(DRIVERS)/spi/spi.c \
+	$(DRIVERS)/gpio/gpio.c \
+	$(DRIVERS)/frequency/hmc7044/hmc7044.c \
+	$(DRIVERS)/dac/ad917x/ad9172.c \
+	$(DRIVERS)/dac/ad917x/ad917x_api/ad917x_api.c \
+	$(DRIVERS)/dac/ad917x/ad917x_api/ad917x_jesd_api.c \
+	$(DRIVERS)/dac/ad917x/ad917x_api/ad917x_nco_api.c \
 	$(DRIVERS)/dac/ad917x/ad917x_api/ad917x_reg.c
-SRCS += $(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c			\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c		\
-	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c			\
-	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
+SRCS += $(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
+	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c \
+	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
 	$(NO-OS)/util/util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
-	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/delay.c
 ifeq (y,$(strip $(TINYIIOD)))
-SRCS += $(NO-OS)/util/fifo.c						\
-	$(NO-OS)/util/list.c						\
-	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.c				\
-	$(PLATFORM_DRIVERS)/uart.c					\
+SRCS += $(NO-OS)/util/fifo.c \
+	$(NO-OS)/util/list.c \
+	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.c \
+	$(PLATFORM_DRIVERS)/uart.c \
 	$(PLATFORM_DRIVERS)/irq.c
 endif
-INCS += $(PROJECT)/src/parameters.h					\
+INCS += $(PROJECT)/src/parameters.h \
 	$(PROJECT)/src/app_config.h
 ifeq (y,$(strip $(TINYIIOD)))
 INCS +=	$(PROJECT)/src/app_iio.h
 endif
-INCS += $(DRIVERS)/frequency/hmc7044/hmc7044.h				\
-	$(DRIVERS)/dac/ad917x/ad9172.h					\
-	$(DRIVERS)/dac/ad917x/ad917x_api/ad917x_reg.h			\
-	$(DRIVERS)/dac/ad917x/ad917x_api/AD917x.h			\
-	$(DRIVERS)/dac/ad917x/ad917x_api/api_def.h			\
+INCS += $(DRIVERS)/frequency/hmc7044/hmc7044.h \
+	$(DRIVERS)/dac/ad917x/ad9172.h \
+	$(DRIVERS)/dac/ad917x/ad917x_api/ad917x_reg.h \
+	$(DRIVERS)/dac/ad917x/ad917x_api/AD917x.h \
+	$(DRIVERS)/dac/ad917x/ad917x_api/api_def.h \
 	$(DRIVERS)/dac/ad917x/ad917x_api/api_errors.h		
-INCS += $(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.h			\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h				\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h		\
-	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h			\
+INCS += $(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.h \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h \
+	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h \
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h
-INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\
+INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
-INCS +=	$(INCLUDE)/axi_io.h						\
-	$(INCLUDE)/spi.h						\
-	$(INCLUDE)/gpio.h						\
-	$(INCLUDE)/error.h						\
-	$(INCLUDE)/delay.h						\
+INCS +=	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/spi.h \
+	$(INCLUDE)/gpio.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
 	$(INCLUDE)/util.h
 ifeq (y,$(strip $(TINYIIOD)))
-INCS += $(INCLUDE)/fifo.h						\
-	$(INCLUDE)/irq.h						\
-	$(INCLUDE)/uart.h						\
-	$(INCLUDE)/list.h						\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
-	$(PLATFORM_DRIVERS)/uart_extra.h                                \
+INCS += $(INCLUDE)/fifo.h \
+	$(INCLUDE)/irq.h \
+	$(INCLUDE)/uart.h \
+	$(INCLUDE)/list.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
 	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.h
 endif

--- a/projects/ad9208/src.mk
+++ b/projects/ad9208/src.mk
@@ -16,44 +16,44 @@ SRC_DIRS += $(PROJECT)/src \
 		$(DRIVERS)/axi_core/clk_axi_clkgen
 
 ifeq (y,$(strip $(TINYIIOD)))
-SRC_DIRS += $(DRIVERS)/axi_core/iio_axi_adc			\
-	    $(DRIVERS)/irq/irq.c				\
+SRC_DIRS += $(DRIVERS)/axi_core/iio_axi_adc \
+	    $(DRIVERS)/irq/irq.c \
 		$(NO-OS)/iio/iio_app
 
-SRCS	+= $(PLATFORM_DRIVERS)/uart.c			\
-		$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c	\
+SRCS	+= $(PLATFORM_DRIVERS)/uart.c \
+		$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c \
 		$(NO-OS)/util/list.c 
-INCS	+= $(INCLUDE)/uart.h				\
-		$(INCLUDE)/list.h			\
-		$(INCLUDE)/irq.h			\
-		$(PLATFORM_DRIVERS)/irq_extra.h		\
+INCS	+= $(INCLUDE)/uart.h \
+		$(INCLUDE)/list.h \
+		$(INCLUDE)/irq.h \
+		$(PLATFORM_DRIVERS)/irq_extra.h \
 		$(PLATFORM_DRIVERS)/uart_extra.h
 		
 endif
 
-SRCS += $(DRIVERS)/spi/spi.c						\
-	$(DRIVERS)/gpio/gpio.c						\
+SRCS += $(DRIVERS)/spi/spi.c \
+	$(DRIVERS)/gpio/gpio.c \
 	$(DRIVERS)/frequency/hmc7044/hmc7044.c
-SRCS += $(DRIVERS)/axi_core/jesd204/axi_adxcvr.c			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c			\
-	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
+SRCS += $(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c \
+	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
 	$(NO-OS)/util/util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
-	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/delay.c
 
-INCS += $(DRIVERS)/frequency/hmc7044/hmc7044.h				\
-	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h			\
+INCS += $(DRIVERS)/frequency/hmc7044/hmc7044.h \
+	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h \
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h
-INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\
+INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
-INCS +=	$(INCLUDE)/axi_io.h						\
-	$(INCLUDE)/spi.h						\
-	$(INCLUDE)/gpio.h						\
-	$(INCLUDE)/error.h						\
-	$(INCLUDE)/delay.h						\
+INCS +=	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/spi.h \
+	$(INCLUDE)/gpio.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
 	$(INCLUDE)/util.h

--- a/projects/ad9265-fmc-125ebz/src.mk
+++ b/projects/ad9265-fmc-125ebz/src.mk
@@ -14,42 +14,42 @@ ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
 SRCS += $(PROJECT)/src/app_iio.c
 endif
-SRCS += $(DRIVERS)/adc/ad9265/ad9265.c					\
-	$(DRIVERS)/spi/spi.c						\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
-	$(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
+SRCS += $(DRIVERS)/adc/ad9265/ad9265.c \
+	$(DRIVERS)/spi/spi.c \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+	$(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(NO-OS)/util/util.c
 ifeq (y,$(strip $(TINYIIOD)))
-SRCS += $(NO-OS)/util/fifo.c						\
-	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c			\
-	$(DRIVERS)/irq/irq.c						\
-	$(NO-OS)/util/list.c						\
-	$(PLATFORM_DRIVERS)/uart.c					\
+SRCS += $(NO-OS)/util/fifo.c \
+	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \
+	$(DRIVERS)/irq/irq.c \
+	$(NO-OS)/util/list.c \
+	$(PLATFORM_DRIVERS)/uart.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c
 endif
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/delay.c
-INCS += $(PROJECT)/src/parameters.h					\
-	$(DRIVERS)/adc/ad9265/ad9265.h					\
-	$(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h			\
+INCS += $(PROJECT)/src/parameters.h \
+	$(DRIVERS)/adc/ad9265/ad9265.h \
+	$(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h
 ifeq (y,$(strip $(TINYIIOD)))
 INCS +=	$(PROJECT)/src/app_iio.h
 endif
 INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h
-INCS +=	$(INCLUDE)/axi_io.h						\
-	$(INCLUDE)/spi.h						\
-	$(INCLUDE)/error.h						\
-	$(INCLUDE)/delay.h						\
-	$(INCLUDE)/print_log.h						\
+INCS +=	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/spi.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
+	$(INCLUDE)/print_log.h \
 	$(INCLUDE)/util.h
 ifeq (y,$(strip $(TINYIIOD)))
-INCS +=	$(INCLUDE)/fifo.h						\
-	$(INCLUDE)/irq.h						\
-	$(INCLUDE)/uart.h						\
-	$(INCLUDE)/list.h						\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
-	$(PLATFORM_DRIVERS)/uart_extra.h                                \
+INCS +=	$(INCLUDE)/fifo.h \
+	$(INCLUDE)/irq.h \
+	$(INCLUDE)/uart.h \
+	$(INCLUDE)/list.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h
 endif

--- a/projects/ad9361/src.mk
+++ b/projects/ad9361/src.mk
@@ -10,18 +10,18 @@
 ################################################################################
 
 SRCS += $(PROJECT)/src/main.c
-SRCS += $(DRIVERS)/rf-transceiver/ad9361/ad9361_api.c			\
-	$(DRIVERS)/rf-transceiver/ad9361/ad9361.c			\
-	$(DRIVERS)/rf-transceiver/ad9361/ad9361_conv.c			\
+SRCS += $(DRIVERS)/rf-transceiver/ad9361/ad9361_api.c \
+	$(DRIVERS)/rf-transceiver/ad9361/ad9361.c \
+	$(DRIVERS)/rf-transceiver/ad9361/ad9361_conv.c \
 	$(DRIVERS)/rf-transceiver/ad9361/ad9361_util.c
-SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
-	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c			\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
-	$(DRIVERS)/spi/spi.c						\
-	$(DRIVERS)/gpio/gpio.c						\
+SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
+	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+	$(DRIVERS)/spi/spi.c \
+	$(DRIVERS)/gpio/gpio.c \
 	$(NO-OS)/util/util.c
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c
-SRCS +=	$(PLATFORM_DRIVERS)/$(PLATFORM)_spi.c				\
+SRCS +=	$(PLATFORM_DRIVERS)/$(PLATFORM)_spi.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_gpio.c
 ifeq (linux,$(strip $(PLATFORM)))
 SRCS +=	$(PLATFORM_DRIVERS)/linux_delay.c
@@ -32,69 +32,69 @@ ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
 
 ifeq (linux,$(strip $(PLATFORM)))
-CFLAGS += -DENABLE_IIO_NETWORK 	\
+CFLAGS += -DENABLE_IIO_NETWORK \
 		-DDISABLE_SECURE_SOCKET
-SRCS += $(NO-OS)/network/linux_socket/linux_socket.c	\
-		$(NO-OS)/network/tcp_socket.c	\
+SRCS += $(NO-OS)/network/linux_socket/linux_socket.c \
+		$(NO-OS)/network/tcp_socket.c \
 	$(PLATFORM_DRIVERS)/linux_uart.c
 else
 SRCS += $(PLATFORM_DRIVERS)/uart.c
 endif
 
-SRCS += $(NO-OS)/util/fifo.c						\
-	$(NO-OS)/util/list.c						\
-	$(DRIVERS)/rf-transceiver/ad9361/iio_ad9361.c				\
-	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c				\
-	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.c		\
-	$(NO-OS)/iio/iio_app/iio_app.c		\
+SRCS += $(NO-OS)/util/fifo.c \
+	$(NO-OS)/util/list.c \
+	$(DRIVERS)/rf-transceiver/ad9361/iio_ad9361.c \
+	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \
+	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.c \
+	$(NO-OS)/iio/iio_app/iio_app.c \
 	$(NO-OS)/util/circular_buffer.c
 endif
-INCS += $(DRIVERS)/rf-transceiver/ad9361/common.h			\
+INCS += $(DRIVERS)/rf-transceiver/ad9361/common.h \
 	$(PROJECT)/src/app_config.h
-INCS += $(DRIVERS)/rf-transceiver/ad9361/ad9361.h			\
-	$(PROJECT)/src/parameters.h					\
-	$(DRIVERS)/rf-transceiver/ad9361/ad9361_util.h			\
+INCS += $(DRIVERS)/rf-transceiver/ad9361/ad9361.h \
+	$(PROJECT)/src/parameters.h \
+	$(DRIVERS)/rf-transceiver/ad9361/ad9361_util.h \
 	$(DRIVERS)/rf-transceiver/ad9361/ad9361_api.h
-INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h			\
-	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.h			\
-	$(INCLUDE)/irq.h						\
+INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \
+	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.h \
+	$(INCLUDE)/irq.h \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h
 ifeq (linux,$(strip $(PLATFORM)))
 CFLAGS += -DPLATFORM_MB
-INCS +=	$(PLATFORM_DRIVERS)/linux_spi.h					\
-	$(PLATFORM_DRIVERS)/linux_gpio.h	\
+INCS +=	$(PLATFORM_DRIVERS)/linux_spi.h \
+	$(PLATFORM_DRIVERS)/linux_gpio.h \
 	$(PLATFORM_DRIVERS)/linux_uart.h
 endif
-INCS +=	$(INCLUDE)/axi_io.h						\
-	$(INCLUDE)/spi.h						\
-	$(INCLUDE)/gpio.h						\
-	$(INCLUDE)/error.h						\
-	$(INCLUDE)/delay.h						\
+INCS +=	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/spi.h \
+	$(INCLUDE)/gpio.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
 	$(INCLUDE)/util.h
 ifeq (y,$(strip $(TINYIIOD)))
 
 ifeq (linux,$(strip $(PLATFORM)))
-INCS += $(NO-OS)/network/tcp_socket.h	\
-	$(NO-OS)/network/linux_socket/linux_socket.h	\
-	$(NO-OS)/network/network_interface.h	\
+INCS += $(NO-OS)/network/tcp_socket.h \
+	$(NO-OS)/network/linux_socket/linux_socket.h \
+	$(NO-OS)/network/network_interface.h \
 	$(NO-OS)/network/noos_mbedtls_config.h
 endif
 
-INCS += $(INCLUDE)/fifo.h						\
-	$(INCLUDE)/uart.h						\
-	$(INCLUDE)/list.h										\
-	$(DRIVERS)/rf-transceiver/ad9361/iio_ad9361.h				\
-	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h				\
-	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.h	\
-	$(NO-OS)/iio/iio_app/iio_app.h	\
+INCS += $(INCLUDE)/fifo.h \
+	$(INCLUDE)/uart.h \
+	$(INCLUDE)/list.h \
+	$(DRIVERS)/rf-transceiver/ad9361/iio_ad9361.h \
+	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h \
+	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.h \
+	$(NO-OS)/iio/iio_app/iio_app.h \
 	$(INCLUDE)/circular_buffer.h
 endif
 ifeq (xilinx,$(strip $(PLATFORM)))
 SRCS += $(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c \
 	$(DRIVERS)/irq/irq.c
 	
-INCS += $(PLATFORM_DRIVERS)/irq_extra.h				\
-	$(PLATFORM_DRIVERS)/spi_extra.h					\
-	$(PLATFORM_DRIVERS)/gpio_extra.h	\
+INCS += $(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/spi_extra.h \
+	$(PLATFORM_DRIVERS)/gpio_extra.h \
 	$(PLATFORM_DRIVERS)/uart_extra.h	
 endif

--- a/projects/ad9371/src.mk
+++ b/projects/ad9371/src.mk
@@ -14,98 +14,98 @@
 #PROFILE =  tx_bw100_orx_bw100_rx_bw100
 #PROFILE = tx_bw100_orx_bw100_rx_bw40
 PROFILE = tx_bw200_orx_bw200_rx_bw100
-SRCS += $(PROJECT)/src/app/headless.c					\
-	$(PROJECT)/profiles/$(PROFILE)/myk_ad9528init.c			\
-	$(PROJECT)/profiles/$(PROFILE)/myk.c				\
-	$(PROJECT)/src/devices/ad9528/ad9528.c				\
-	$(PROJECT)/src/devices/adi_hal/common.c				\
-	$(PROJECT)/src/devices/mykonos/mykonos.c			\
-	$(PROJECT)/src/devices/mykonos/mykonos_debug/mykonos_dbgjesd.c	\
-	$(PROJECT)/src/devices/mykonos/mykonos_gpio.c			\
-	$(PROJECT)/src/devices/mykonos/mykonosMmap.c			\
+SRCS += $(PROJECT)/src/app/headless.c \
+	$(PROJECT)/profiles/$(PROFILE)/myk_ad9528init.c \
+	$(PROJECT)/profiles/$(PROFILE)/myk.c \
+	$(PROJECT)/src/devices/ad9528/ad9528.c \
+	$(PROJECT)/src/devices/adi_hal/common.c \
+	$(PROJECT)/src/devices/mykonos/mykonos.c \
+	$(PROJECT)/src/devices/mykonos/mykonos_debug/mykonos_dbgjesd.c \
+	$(PROJECT)/src/devices/mykonos/mykonos_gpio.c \
+	$(PROJECT)/src/devices/mykonos/mykonosMmap.c \
 	$(PROJECT)/src/devices/mykonos/mykonos_user.c
-SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
-	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c			\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c			\
-	$(NO-OS)/util/util.c						\
-	$(DRIVERS)/spi/spi.c						\
+SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
+	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c \
+	$(NO-OS)/util/util.c \
+	$(DRIVERS)/spi/spi.c \
 	$(DRIVERS)/gpio/gpio.c
 ifeq (xilinx,$(strip $(PLATFORM)))
-SRCS += $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
-	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c			\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c		\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
+SRCS += $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
+	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c
 else
-SRCS += $(DRIVERS)/axi_core/clk_altera_a10_fpll/clk_altera_a10_fpll.c	\
-	$(DRIVERS)/axi_core/jesd204/altera_a10_atx_pll.c		\
-	$(DRIVERS)/axi_core/jesd204/altera_a10_cdr_pll.c		\
-	$(DRIVERS)/axi_core/jesd204/altera_adxcvr.c			\
-	$(PLATFORM_DRIVERS)/altera_spi.c				\
+SRCS += $(DRIVERS)/axi_core/clk_altera_a10_fpll/clk_altera_a10_fpll.c \
+	$(DRIVERS)/axi_core/jesd204/altera_a10_atx_pll.c \
+	$(DRIVERS)/axi_core/jesd204/altera_a10_cdr_pll.c \
+	$(DRIVERS)/axi_core/jesd204/altera_adxcvr.c \
+	$(PLATFORM_DRIVERS)/altera_spi.c \
 	$(PLATFORM_DRIVERS)/altera_gpio.c
 endif
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
 	$(PLATFORM_DRIVERS)/delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
-SRCS += $(PLATFORM_DRIVERS)/uart.c					\
-	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c				\
-	$(NO-OS)/util/fifo.c						\
-	$(NO-OS)/util/list.c						\
-	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c			\
-	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.c			\
-	$(NO-OS)/iio/iio_app/iio_app.c		\
+SRCS += $(PLATFORM_DRIVERS)/uart.c \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c \
+	$(NO-OS)/util/fifo.c \
+	$(NO-OS)/util/list.c \
+	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \
+	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.c \
+	$(NO-OS)/iio/iio_app/iio_app.c \
 	$(DRIVERS)/irq/irq.c
 endif
-INCS +=	$(PROJECT)/src/app/app_config.h					\
-	$(PROJECT)/src/devices/ad9528/ad9528.h				\
-	$(PROJECT)/src/devices/ad9528/t_ad9528.h			\
-	$(PROJECT)/src/devices/adi_hal/common.h				\
-	$(PROJECT)/src/devices/adi_hal/parameters.h			\
-	$(PROJECT)/profiles/$(PROFILE)/myk.h				\
-	$(PROJECT)/src/devices/mykonos/mykonos_debug/mykonos_dbgjesd.h	\
-	$(PROJECT)/src/devices/mykonos/mykonos_debug/t_mykonos_dbgjesd.h\
-	$(PROJECT)/src/devices/mykonos/mykonos_gpio.h			\
-	$(PROJECT)/src/devices/mykonos/mykonos.h			\
-	$(PROJECT)/src/devices/mykonos/mykonos_macros.h			\
-	$(PROJECT)/src/devices/mykonos/mykonos_user.h			\
-	$(PROJECT)/src/devices/mykonos/mykonos_version.h		\
-	$(PROJECT)/src/devices/mykonos/t_mykonos_gpio.h			\
-	$(PROJECT)/src/devices/mykonos/t_mykonos.h			\
+INCS +=	$(PROJECT)/src/app/app_config.h \
+	$(PROJECT)/src/devices/ad9528/ad9528.h \
+	$(PROJECT)/src/devices/ad9528/t_ad9528.h \
+	$(PROJECT)/src/devices/adi_hal/common.h \
+	$(PROJECT)/src/devices/adi_hal/parameters.h \
+	$(PROJECT)/profiles/$(PROFILE)/myk.h \
+	$(PROJECT)/src/devices/mykonos/mykonos_debug/mykonos_dbgjesd.h \
+	$(PROJECT)/src/devices/mykonos/mykonos_debug/t_mykonos_dbgjesd.h \
+	$(PROJECT)/src/devices/mykonos/mykonos_gpio.h \
+	$(PROJECT)/src/devices/mykonos/mykonos.h \
+	$(PROJECT)/src/devices/mykonos/mykonos_macros.h \
+	$(PROJECT)/src/devices/mykonos/mykonos_user.h \
+	$(PROJECT)/src/devices/mykonos/mykonos_version.h \
+	$(PROJECT)/src/devices/mykonos/t_mykonos_gpio.h \
+	$(PROJECT)/src/devices/mykonos/t_mykonos.h \
 	$(PROJECT)/src/firmware/Mykonos_M3.h
-INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h			\
-	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.h			\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h				\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h			\
+INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \
+	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.h \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h
 ifeq (xilinx,$(strip $(PLATFORM)))
-INCS += $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h		\
-	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h			\
+INCS += $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h \
+	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h \
 	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h
 else
-INCS += $(DRIVERS)/axi_core/clk_altera_a10_fpll/clk_altera_a10_fpll.h	\
-	$(DRIVERS)/axi_core/jesd204/altera_a10_atx_pll.h		\
-	$(DRIVERS)/axi_core/jesd204/altera_a10_cdr_pll.h		\
+INCS += $(DRIVERS)/axi_core/clk_altera_a10_fpll/clk_altera_a10_fpll.h \
+	$(DRIVERS)/axi_core/jesd204/altera_a10_atx_pll.h \
+	$(DRIVERS)/axi_core/jesd204/altera_a10_cdr_pll.h \
 	$(DRIVERS)/axi_core/jesd204/altera_adxcvr.h
 endif
-INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\
+INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
-INCS +=	$(INCLUDE)/axi_io.h						\
-	$(INCLUDE)/spi.h						\
-	$(INCLUDE)/gpio.h						\
-	$(INCLUDE)/error.h						\
-	$(INCLUDE)/delay.h						\
+INCS +=	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/spi.h \
+	$(INCLUDE)/gpio.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
 	$(INCLUDE)/util.h
 ifeq (y,$(strip $(TINYIIOD)))
-INCS += $(INCLUDE)/fifo.h						\
-	$(INCLUDE)/irq.h						\
-	$(INCLUDE)/uart.h						\
-	$(INCLUDE)/list.h						\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
-	$(PLATFORM_DRIVERS)/uart_extra.h				\
-	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h				\
-	$(NO-OS)/iio/iio_app/iio_app.h	\
+INCS += $(INCLUDE)/fifo.h \
+	$(INCLUDE)/irq.h \
+	$(INCLUDE)/uart.h \
+	$(INCLUDE)/list.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h \
+	$(NO-OS)/iio/iio_app/iio_app.h \
 	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.h
 endif

--- a/projects/ad9434-fmc-500ebz/src.mk
+++ b/projects/ad9434-fmc-500ebz/src.mk
@@ -14,42 +14,42 @@ ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
 SRCS += $(PROJECT)/src/app_iio.c
 endif
-SRCS += $(DRIVERS)/adc/ad9434/ad9434.c					\
-	$(DRIVERS)/spi/spi.c						\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
-	$(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
+SRCS += $(DRIVERS)/adc/ad9434/ad9434.c \
+	$(DRIVERS)/spi/spi.c \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+	$(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(NO-OS)/util/util.c
 ifeq (y,$(strip $(TINYIIOD)))
-SRCS += $(NO-OS)/util/fifo.c						\
-	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c				\
-	$(NO-OS)/util/list.c						\
-	$(PLATFORM_DRIVERS)/uart.c					\
-	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c                           \
+SRCS += $(NO-OS)/util/fifo.c \
+	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \
+	$(NO-OS)/util/list.c \
+	$(PLATFORM_DRIVERS)/uart.c \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c \
 	$(DRIVERS)/irq/irq.c
 endif
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/delay.c
-INCS += $(PROJECT)/src/parameters.h					\
-	$(DRIVERS)/adc/ad9434/ad9434.h					\
-	$(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h			\
+INCS += $(PROJECT)/src/parameters.h \
+	$(DRIVERS)/adc/ad9434/ad9434.h \
+	$(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h
 ifeq (y,$(strip $(TINYIIOD)))
 INCS +=	$(PROJECT)/src/app_iio.h
 endif
 INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h
-INCS +=	$(INCLUDE)/axi_io.h						\
-	$(INCLUDE)/spi.h						\
-	$(INCLUDE)/error.h						\
-	$(INCLUDE)/delay.h						\
-	$(INCLUDE)/print_log.h						\
+INCS +=	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/spi.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
+	$(INCLUDE)/print_log.h \
 	$(INCLUDE)/util.h
 ifeq (y,$(strip $(TINYIIOD)))
-INCS +=	$(INCLUDE)/fifo.h						\
-	$(INCLUDE)/irq.h						\
-	$(INCLUDE)/uart.h						\
-	$(INCLUDE)/list.h						\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
-	$(PLATFORM_DRIVERS)/uart_extra.h                                \
+INCS +=	$(INCLUDE)/fifo.h \
+	$(INCLUDE)/irq.h \
+	$(INCLUDE)/uart.h \
+	$(INCLUDE)/list.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h
 endif

--- a/projects/ad9467/src.mk
+++ b/projects/ad9467/src.mk
@@ -16,44 +16,44 @@ ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
 SRCS += $(PROJECT)/src/app/app_iio.c
 endif
-SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
-	$(DRIVERS)/adc/ad9467/ad9467.c					\
-	$(DRIVERS)/frequency/ad9517/ad9517.c				\
-	$(DRIVERS)/spi/spi.c						\
+SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+	$(DRIVERS)/adc/ad9467/ad9467.c \
+	$(DRIVERS)/frequency/ad9517/ad9517.c \
+	$(DRIVERS)/spi/spi.c \
 	$(NO-OS)/util/util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/delay.c
 ifeq (y,$(strip $(TINYIIOD)))
-SRCS += $(NO-OS)/util/fifo.c						\
-	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c			\
-	$(DRIVERS)/irq/irq.c						\
-	$(NO-OS)/util/list.c						\
-	$(PLATFORM_DRIVERS)/uart.c					\
+SRCS += $(NO-OS)/util/fifo.c \
+	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \
+	$(DRIVERS)/irq/irq.c \
+	$(NO-OS)/util/list.c \
+	$(PLATFORM_DRIVERS)/uart.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c
 endif
-INCS +=	$(PROJECT)/src/app/app_config.h					\
+INCS +=	$(PROJECT)/src/app/app_config.h \
 	$(PROJECT)/src/devices/adi_hal/parameters.h
 ifeq (y,$(strip $(TINYIIOD)))
 INCS +=	$(PROJECT)/src/app/app_iio.h
 endif
-INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h			\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h				\
-	$(DRIVERS)/adc/ad9467/ad9467.h					\
+INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
+	$(DRIVERS)/adc/ad9467/ad9467.h \
 	$(DRIVERS)/frequency/ad9517/ad9517.h
 INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h
-INCS +=	$(INCLUDE)/axi_io.h						\
-	$(INCLUDE)/spi.h						\
-	$(INCLUDE)/error.h						\
-	$(INCLUDE)/delay.h						\
+INCS +=	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/spi.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
 	$(INCLUDE)/util.h
 ifeq (y,$(strip $(TINYIIOD)))
-INCS +=	$(INCLUDE)/fifo.h						\
-	$(INCLUDE)/irq.h						\
-	$(INCLUDE)/uart.h						\
-	$(INCLUDE)/list.h						\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
-	$(PLATFORM_DRIVERS)/uart_extra.h                                \
+INCS +=	$(INCLUDE)/fifo.h \
+	$(INCLUDE)/irq.h \
+	$(INCLUDE)/uart.h \
+	$(INCLUDE)/list.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h
 endif

--- a/projects/ad9656_fmc/src.mk
+++ b/projects/ad9656_fmc/src.mk
@@ -11,59 +11,59 @@
 
 # Uncomment to select the profile
 
-SRCS += $(PROJECT)/src/app/ad9656_fmc.c                                 \
-	$(PROJECT)/src/app/ad9508.c   					\
+SRCS += $(PROJECT)/src/app/ad9656_fmc.c \
+	$(PROJECT)/src/app/ad9508.c \
 	$(PROJECT)/src/app/ad9553.c
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
 SRCS += $(PROJECT)/src/app/app_iio.c
 endif
-SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
-        $(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
-        $(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c		\
-        $(DRIVERS)/axi_core/jesd204/axi_adxcvr.c			\
-        $(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c			\
-        $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
-        $(DRIVERS)/adc/ad9656/ad9656.c					\
-        $(DRIVERS)/spi/spi.c						\
+SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
+        $(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+        $(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
+        $(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
+        $(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c \
+        $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
+        $(DRIVERS)/adc/ad9656/ad9656.c \
+        $(DRIVERS)/spi/spi.c \
         $(NO-OS)/util/util.c
 ifeq (y,$(strip $(TINYIIOD)))
-SRCS += $(NO-OS)/util/fifo.c					\
-	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c		\
-	$(DRIVERS)/irq/irq.c					\
-	$(NO-OS)/util/list.c						\
-	$(PLATFORM_DRIVERS)/uart.c					\
+SRCS += $(NO-OS)/util/fifo.c \
+	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \
+	$(DRIVERS)/irq/irq.c \
+	$(NO-OS)/util/list.c \
+	$(PLATFORM_DRIVERS)/uart.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c
 endif
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-        $(PLATFORM_DRIVERS)/xilinx_spi.c				\
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+        $(PLATFORM_DRIVERS)/xilinx_spi.c \
         $(PLATFORM_DRIVERS)/delay.c
-INCS +=	$(PROJECT)/src/app/app_config.h					\
-        $(PROJECT)/src/devices/adi_hal/parameters.h                     \
-        $(PROJECT)/src/app/ad9508.h					\
+INCS +=	$(PROJECT)/src/app/app_config.h \
+        $(PROJECT)/src/devices/adi_hal/parameters.h \
+        $(PROJECT)/src/app/ad9508.h \
         $(PROJECT)/src/app/ad9553.h
-INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h			\
-        $(DRIVERS)/axi_core/axi_dmac/axi_dmac.h				\
-        $(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h		\
-        $(DRIVERS)/axi_core/jesd204/axi_adxcvr.h			\
-        $(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h			\
-        $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h		\
+INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \
+        $(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
+        $(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h \
+        $(DRIVERS)/axi_core/jesd204/axi_adxcvr.h \
+        $(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h \
+        $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h \
         $(DRIVERS)/adc/ad9656/ad9656.h
 ifeq (y,$(strip $(TINYIIOD)))
 INCS +=	$(PROJECT)/src/app/app_iio.h
 endif
 INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h
-INCS +=	$(INCLUDE)/axi_io.h						\
-        $(INCLUDE)/spi.h						\
-        $(INCLUDE)/error.h						\
-        $(INCLUDE)/delay.h						\
+INCS +=	$(INCLUDE)/axi_io.h \
+        $(INCLUDE)/spi.h \
+        $(INCLUDE)/error.h \
+        $(INCLUDE)/delay.h \
         $(INCLUDE)/util.h
 ifeq (y,$(strip $(TINYIIOD)))
-INCS +=	$(INCLUDE)/fifo.h					\
-	$(INCLUDE)/irq.h						\
-	$(INCLUDE)/uart.h						\
-	$(INCLUDE)/list.h						\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
-	$(PLATFORM_DRIVERS)/uart_extra.h                                \
+INCS +=	$(INCLUDE)/fifo.h \
+	$(INCLUDE)/irq.h \
+	$(INCLUDE)/uart.h \
+	$(INCLUDE)/list.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h
 endif

--- a/projects/ad9739a-fmc-ebz/src.mk
+++ b/projects/ad9739a-fmc-ebz/src.mk
@@ -14,44 +14,44 @@ ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
 SRCS += $(PROJECT)/src/app_iio.c
 endif
-SRCS += $(DRIVERS)/dac/ad9739a/ad9739a.c				\
-	$(DRIVERS)/frequency/adf4350/adf4350.c				\
-	$(DRIVERS)/spi/spi.c						\
-	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c			\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
+SRCS += $(DRIVERS)/dac/ad9739a/ad9739a.c \
+	$(DRIVERS)/frequency/adf4350/adf4350.c \
+	$(DRIVERS)/spi/spi.c \
+	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
 	$(NO-OS)/util/util.c
 ifeq (y,$(strip $(TINYIIOD)))
-SRCS += $(NO-OS)/util/fifo.c						\
-	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.c			\
-	$(DRIVERS)/irq/irq.c                                            \
-	$(NO-OS)/util/list.c						\
-	$(PLATFORM_DRIVERS)/uart.c					\
+SRCS += $(NO-OS)/util/fifo.c \
+	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.c \
+	$(DRIVERS)/irq/irq.c \
+	$(NO-OS)/util/list.c \
+	$(PLATFORM_DRIVERS)/uart.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c
 endif
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 INCS +=	$(PROJECT)/src/app_iio.h
 endif
-INCS += $(PROJECT)/src/parameters.h					\
-	$(DRIVERS)/frequency/adf4350/adf4350.h				\
-	$(DRIVERS)/dac/ad9739a/ad9739a.h				\
-	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.h			\
+INCS += $(PROJECT)/src/parameters.h \
+	$(DRIVERS)/frequency/adf4350/adf4350.h \
+	$(DRIVERS)/dac/ad9739a/ad9739a.h \
+	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.h \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h
 INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					
-INCS +=	$(INCLUDE)/axi_io.h						\
-	$(INCLUDE)/spi.h						\
-	$(INCLUDE)/error.h						\
-	$(INCLUDE)/delay.h						\
-	$(INCLUDE)/print_log.h						\
+INCS +=	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/spi.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
+	$(INCLUDE)/print_log.h \
 	$(INCLUDE)/util.h
 ifeq (y,$(strip $(TINYIIOD)))
-INCS +=	$(INCLUDE)/fifo.h						\
-	$(INCLUDE)/irq.h						\
-	$(INCLUDE)/uart.h						\
-	$(INCLUDE)/list.h						\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
-	$(PLATFORM_DRIVERS)/uart_extra.h                                \
+INCS +=	$(INCLUDE)/fifo.h \
+	$(INCLUDE)/irq.h \
+	$(INCLUDE)/uart.h \
+	$(INCLUDE)/list.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
 	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.h
 endif

--- a/projects/ada4250_ardz/src.mk
+++ b/projects/ada4250_ardz/src.mk
@@ -9,12 +9,12 @@ SRC_DIRS += $(NO-OS)/drivers/gpio
 SRC_DIRS += $(PLATFORM_DRIVERS)
 SRC_DIRS += $(INCLUDE)
 
-SRCS += $(NO-OS)/util/util.c					\
-	$(NO-OS)/util/list.c					\
-	$(DRIVERS)/spi/spi.c					\
-	$(DRIVERS)/platform/$(PLATFORM)/$(PLATFORM)_spi.c 	\
+SRCS += $(NO-OS)/util/util.c \
+	$(NO-OS)/util/list.c \
+	$(DRIVERS)/spi/spi.c \
+	$(DRIVERS)/platform/$(PLATFORM)/$(PLATFORM)_spi.c \
 
-INCS += $(INCLUDE)/spi.h					\
+INCS += $(INCLUDE)/spi.h \
 	$(DRIVERS)/platform/$(PLATFORM)/spi_extra.h
 
 IGNORED_FILES += $(PLATFORM_DRIVERS)/uart_stdio.c

--- a/projects/adaq7980_sdz/src.mk
+++ b/projects/adaq7980_sdz/src.mk
@@ -10,35 +10,35 @@
 ################################################################################
 
 SRCS += $(PROJECT)/src/adaq7980_sdz.c
-SRCS += $(DRIVERS)/spi/spi.c						\
-	$(DRIVERS)/gpio/gpio.c						\
-	$(DRIVERS)/adc/adaq7980/adaq7980.c				\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c		\
-	$(DRIVERS)/axi_core/axi_pwmgen/axi_pwm.c			\
-	$(DRIVERS)/axi_core/spi_engine/spi_engine.c			\
+SRCS += $(DRIVERS)/spi/spi.c \
+	$(DRIVERS)/gpio/gpio.c \
+	$(DRIVERS)/adc/adaq7980/adaq7980.c \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
+	$(DRIVERS)/axi_core/axi_pwmgen/axi_pwm.c \
+	$(DRIVERS)/axi_core/spi_engine/spi_engine.c \
 	$(NO-OS)/util/util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/delay.c
 INCS += $(PROJECT)/src/parameters.h
-INCS += $(DRIVERS)/adc/adaq7980/adaq7980.h				\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h				\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h		\
-	$(DRIVERS)/axi_core/axi_pwmgen/axi_pwm_extra.h			\
-	$(DRIVERS)/axi_core/spi_engine/spi_engine.h			\
+INCS += $(DRIVERS)/adc/adaq7980/adaq7980.h \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h \
+	$(DRIVERS)/axi_core/axi_pwmgen/axi_pwm_extra.h \
+	$(DRIVERS)/axi_core/spi_engine/spi_engine.h \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine_private.h
-INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
-	$(PLATFORM_DRIVERS)/uart_extra.h				\
+INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
-INCS +=	$(INCLUDE)/axi_io.h						\
-	$(INCLUDE)/spi.h						\
-	$(INCLUDE)/pwm.h						\
-	$(INCLUDE)/gpio.h						\
-	$(INCLUDE)/error.h						\
-	$(INCLUDE)/delay.h						\
-	$(INCLUDE)/irq.h						\
-	$(INCLUDE)/uart.h						\
+INCS +=	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/spi.h \
+	$(INCLUDE)/pwm.h \
+	$(INCLUDE)/gpio.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
+	$(INCLUDE)/irq.h \
+	$(INCLUDE)/uart.h \
 	$(INCLUDE)/util.h

--- a/projects/adf4377_sdz/src.mk
+++ b/projects/adf4377_sdz/src.mk
@@ -10,44 +10,44 @@
 ################################################################################
 
 SRCS += $(PROJECT)/src/app/adf4377_sdz.c
-SRCS += $(DRIVERS)/spi/spi.c						\
-	$(DRIVERS)/gpio/gpio.c							\
+SRCS += $(DRIVERS)/spi/spi.c \
+	$(DRIVERS)/gpio/gpio.c \
 	$(DRIVERS)/frequency/adf4377/adf4377.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c				\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
-	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
-	$(PLATFORM_DRIVERS)/delay.c						\
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
+	$(PLATFORM_DRIVERS)/delay.c \
 	$(NO-OS)/util/util.c
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
-SRCS += $(NO-OS)/util/fifo.c						\
-	$(NO-OS)/util/list.c						\
-	$(PLATFORM_DRIVERS)/uart.c					\
-	$(PLATFORM_DRIVERS)/irq.c					\
-	$(NO-OS)/iio/iio_app/iio_app.c				\
+SRCS += $(NO-OS)/util/fifo.c \
+	$(NO-OS)/util/list.c \
+	$(PLATFORM_DRIVERS)/uart.c \
+	$(PLATFORM_DRIVERS)/irq.c \
+	$(NO-OS)/iio/iio_app/iio_app.c \
 	$(DRIVERS)/frequency/adf4377/iio_adf4377.c
 endif
-INCS +=	$(PROJECT)/src/app/app_config.h					\
+INCS +=	$(PROJECT)/src/app/app_config.h \
 	$(PROJECT)/src/app/parameters.h
 ifeq (y,$(strip $(TINYIIOD)))
 INCS +=	$(DRIVERS)/frequency/adf4377/iio_adf4377.h
 endif
 INCS += $(DRIVERS)/frequency/adf4377/adf4377.h
-INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h				\
+INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
-INCS +=	$(INCLUDE)/axi_io.h							\
-	$(INCLUDE)/spi.h								\
-	$(INCLUDE)/gpio.h								\
-	$(INCLUDE)/error.h								\
-	$(INCLUDE)/delay.h								\
-	$(INCLUDE)/util.h								\
+INCS +=	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/spi.h \
+	$(INCLUDE)/gpio.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
+	$(INCLUDE)/util.h \
 	$(INCLUDE)/print_log.h
 ifeq (y,$(strip $(TINYIIOD)))
-INCS += $(INCLUDE)/fifo.h						\
-	$(INCLUDE)/irq.h						\
-	$(INCLUDE)/uart.h						\
-	$(INCLUDE)/list.h						\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
-	$(PLATFORM_DRIVERS)/uart_extra.h				\
+INCS += $(INCLUDE)/fifo.h \
+	$(INCLUDE)/irq.h \
+	$(INCLUDE)/uart.h \
+	$(INCLUDE)/list.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
 	$(NO-OS)/iio/iio_app/iio_app.h
 endif

--- a/projects/adf5902_sdz/src.mk
+++ b/projects/adf5902_sdz/src.mk
@@ -10,43 +10,43 @@
 ################################################################################
 
 SRCS += $(PROJECT)/src/adf5902_sdz.c
-SRCS += $(DRIVERS)/spi/spi.c						\
-	$(DRIVERS)/gpio/gpio.c							\
+SRCS += $(DRIVERS)/spi/spi.c \
+	$(DRIVERS)/gpio/gpio.c \
 	$(DRIVERS)/frequency/adf5902/adf5902.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c				\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
-	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
-SRCS += $(NO-OS)/util/fifo.c						\
-	$(NO-OS)/util/list.c						\
-	$(PLATFORM_DRIVERS)/uart.c					\
-	$(PLATFORM_DRIVERS)/irq.c					\
-	$(NO-OS)/iio/iio_app/iio_app.c				\
+SRCS += $(NO-OS)/util/fifo.c \
+	$(NO-OS)/util/list.c \
+	$(PLATFORM_DRIVERS)/uart.c \
+	$(PLATFORM_DRIVERS)/irq.c \
+	$(NO-OS)/iio/iio_app/iio_app.c \
 	$(DRIVERS)/frequency/adf5902/iio_adf5902.c
 endif
-INCS +=	$(PROJECT)/src/app_config.h					\
+INCS +=	$(PROJECT)/src/app_config.h \
 	$(PROJECT)/src/parameters.h
 ifeq (y,$(strip $(TINYIIOD)))
 INCS +=	$(DRIVERS)/frequency/adf5902/iio_adf5902.h
 endif
 INCS += $(DRIVERS)/frequency/adf5902/adf5902.h
-INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h				\
+INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
-INCS +=	$(INCLUDE)/axi_io.h							\
-	$(INCLUDE)/spi.h								\
-	$(INCLUDE)/gpio.h								\
-	$(INCLUDE)/error.h								\
-	$(INCLUDE)/delay.h								\
-	$(INCLUDE)/util.h								\
+INCS +=	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/spi.h \
+	$(INCLUDE)/gpio.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
+	$(INCLUDE)/util.h \
 	$(INCLUDE)/print_log.h
 ifeq (y,$(strip $(TINYIIOD)))
-INCS += $(INCLUDE)/fifo.h						\
-	$(INCLUDE)/irq.h						\
-	$(INCLUDE)/uart.h						\
-	$(INCLUDE)/list.h						\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
-	$(PLATFORM_DRIVERS)/uart_extra.h				\
+INCS += $(INCLUDE)/fifo.h \
+	$(INCLUDE)/irq.h \
+	$(INCLUDE)/uart.h \
+	$(INCLUDE)/list.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
 	$(NO-OS)/iio/iio_app/iio_app.h
 endif

--- a/projects/adrv9009/src.mk
+++ b/projects/adrv9009/src.mk
@@ -22,130 +22,130 @@
 PROFILE = tx_bw100_ir122p88_rx_bw100_or122p88_orx_bw100_or122p88_dc122p88
 #PROFILE = tx_bw200_ir245p76_rx_bw200_or245p76_orx_bw200_or245p76_dc245p76
 #PROFILE = tx_bw400_ir491p52_rx_bw200_or245p76_orx_bw400_or491p52_dc245p76
-SRCS += $(PROJECT)/src/app/headless.c					\
-	$(PROJECT)/src/app/app_clocking.c					\
-	$(PROJECT)/src/app/app_jesd.c						\
-	$(PROJECT)/src/app/app_transceiver.c				\
-	$(PROJECT)/src/app/app_talise.c						\
-	$(DRIVERS)/frequency/ad9528/ad9528.c				\
-	$(PROJECT)/src/devices/adi_hal/no_os_hal.c			\
-	$(DRIVERS)/frequency/hmc7044/hmc7044.c					\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_agc.c			\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_arm.c			\
-	$(DRIVERS)/rf-transceiver/talise/api/talise.c				\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_cals.c			\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_error.c			\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_gpio.c			\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_hal.c			\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_jesd204.c			\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_radioctrl.c		\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_rx.c			\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_tx.c			\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_user.c			\
+SRCS += $(PROJECT)/src/app/headless.c \
+	$(PROJECT)/src/app/app_clocking.c \
+	$(PROJECT)/src/app/app_jesd.c \
+	$(PROJECT)/src/app/app_transceiver.c \
+	$(PROJECT)/src/app/app_talise.c \
+	$(DRIVERS)/frequency/ad9528/ad9528.c \
+	$(PROJECT)/src/devices/adi_hal/no_os_hal.c \
+	$(DRIVERS)/frequency/hmc7044/hmc7044.c \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_agc.c \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_arm.c \
+	$(DRIVERS)/rf-transceiver/talise/api/talise.c \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_cals.c \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_error.c \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_gpio.c \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_hal.c \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_jesd204.c \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_radioctrl.c \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_rx.c \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_tx.c \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_user.c \
 	$(PROJECT)/profiles/$(PROFILE)/talise_config.c
-SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
-	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c			\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c			\
-	$(DRIVERS)/spi/spi.c						\
+SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
+	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c \
+	$(DRIVERS)/spi/spi.c \
 	$(DRIVERS)/gpio/gpio.c
 ifeq (y,$(strip $(TINYIIOD)))
 SRC_DIRS += $(NO-OS)/iio/iio_app
 LIBRARIES += iio
-SRCS += $(NO-OS)/util/fifo.c						\
-	$(NO-OS)/util/list.c						\
-	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c				\
-	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.c                          \
-	$(DRIVERS)/irq/irq.c						\
-	$(PLATFORM_DRIVERS)/uart.c					\
+SRCS += $(NO-OS)/util/fifo.c \
+	$(NO-OS)/util/list.c \
+	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \
+	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.c \
+	$(DRIVERS)/irq/irq.c \
+	$(PLATFORM_DRIVERS)/uart.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c
 endif
 SRCS +=	$(NO-OS)/util/util.c
 ifeq (xilinx,$(strip $(PLATFORM)))
-SRCS += $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
-	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c			\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c		\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
+SRCS += $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
+	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c
 else
-SRCS += $(DRIVERS)/axi_core/clk_altera_a10_fpll/clk_altera_a10_fpll.c	\
-	$(DRIVERS)/axi_core/jesd204/altera_a10_atx_pll.c		\
-	$(DRIVERS)/axi_core/jesd204/altera_a10_cdr_pll.c		\
-	$(DRIVERS)/axi_core/jesd204/altera_adxcvr.c			\
-	$(PLATFORM_DRIVERS)/altera_spi.c				\
+SRCS += $(DRIVERS)/axi_core/clk_altera_a10_fpll/clk_altera_a10_fpll.c \
+	$(DRIVERS)/axi_core/jesd204/altera_a10_atx_pll.c \
+	$(DRIVERS)/axi_core/jesd204/altera_a10_cdr_pll.c \
+	$(DRIVERS)/axi_core/jesd204/altera_adxcvr.c \
+	$(PLATFORM_DRIVERS)/altera_spi.c \
 	$(PLATFORM_DRIVERS)/altera_gpio.c
 endif
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
 	$(PLATFORM_DRIVERS)/delay.c
-INCS +=	$(PROJECT)/src/app/app_config.h					\
-	$(PROJECT)/src/app/app_clocking.h						\
-	$(PROJECT)/src/app/app_jesd.h						\
-	$(PROJECT)/src/app/app_transceiver.h				\
-	$(PROJECT)/src/app/app_talise.h						\
-	$(DRIVERS)/frequency/ad9528/ad9528.h				\
-	$(PROJECT)/src/devices/adi_hal/adi_hal.h			\
-	$(PROJECT)/src/devices/adi_hal/common.h				\
-	$(PROJECT)/src/devices/adi_hal/parameters.h			\
-	$(DRIVERS)/frequency/hmc7044/hmc7044.h					\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_agc.h			\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_agc_types.h		\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_arm.h			\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_arm_macros.h		\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_arm_types.h		\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_cals.h			\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_cals_types.h		\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_error.h			\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_error_types.h		\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_gpio.h			\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_gpio_types.h		\
-	$(DRIVERS)/rf-transceiver/talise/api/talise.h				\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_hal.h			\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_jesd204.h			\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_jesd204_types.h		\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_radioctrl.h		\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_radioctrl_types.h		\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_reg_addr_macros.h		\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_rx.h			\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_rx_types.h			\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_tx.h			\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_tx_types.h			\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_types.h			\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_user.h			\
-	$(DRIVERS)/rf-transceiver/talise/api/talise_version.h			\
-	$(DRIVERS)/rf-transceiver/talise/firmware/talise_arm_binary.h			\
-	$(DRIVERS)/rf-transceiver/talise/firmware/talise_stream_binary.h			\
+INCS +=	$(PROJECT)/src/app/app_config.h \
+	$(PROJECT)/src/app/app_clocking.h \
+	$(PROJECT)/src/app/app_jesd.h \
+	$(PROJECT)/src/app/app_transceiver.h \
+	$(PROJECT)/src/app/app_talise.h \
+	$(DRIVERS)/frequency/ad9528/ad9528.h \
+	$(PROJECT)/src/devices/adi_hal/adi_hal.h \
+	$(PROJECT)/src/devices/adi_hal/common.h \
+	$(PROJECT)/src/devices/adi_hal/parameters.h \
+	$(DRIVERS)/frequency/hmc7044/hmc7044.h \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_agc.h \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_agc_types.h \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_arm.h \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_arm_macros.h \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_arm_types.h \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_cals.h \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_cals_types.h \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_error.h \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_error_types.h \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_gpio.h \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_gpio_types.h \
+	$(DRIVERS)/rf-transceiver/talise/api/talise.h \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_hal.h \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_jesd204.h \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_jesd204_types.h \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_radioctrl.h \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_radioctrl_types.h \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_reg_addr_macros.h \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_rx.h \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_rx_types.h \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_tx.h \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_tx_types.h \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_types.h \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_user.h \
+	$(DRIVERS)/rf-transceiver/talise/api/talise_version.h \
+	$(DRIVERS)/rf-transceiver/talise/firmware/talise_arm_binary.h \
+	$(DRIVERS)/rf-transceiver/talise/firmware/talise_stream_binary.h \
 	$(PROJECT)/profiles/$(PROFILE)/talise_config.h
-INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h			\
-	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.h			\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h				\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h			\
+INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \
+	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.h \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h
 ifeq (xilinx,$(strip $(PLATFORM)))
-INCS += $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h		\
-	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h			\
+INCS += $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h \
+	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h \
 	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h
 else
-INCS += $(DRIVERS)/axi_core/clk_altera_a10_fpll/clk_altera_a10_fpll.h	\
-	$(DRIVERS)/axi_core/jesd204/altera_a10_atx_pll.h		\
-	$(DRIVERS)/axi_core/jesd204/altera_a10_cdr_pll.h		\
+INCS += $(DRIVERS)/axi_core/clk_altera_a10_fpll/clk_altera_a10_fpll.h \
+	$(DRIVERS)/axi_core/jesd204/altera_a10_atx_pll.h \
+	$(DRIVERS)/axi_core/jesd204/altera_a10_cdr_pll.h \
 	$(DRIVERS)/axi_core/jesd204/altera_adxcvr.h
 endif
-INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\
+INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
-INCS +=	$(INCLUDE)/axi_io.h						\
-	$(INCLUDE)/spi.h						\
-	$(INCLUDE)/gpio.h						\
-	$(INCLUDE)/error.h						\
-	$(INCLUDE)/delay.h						\
+INCS +=	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/spi.h \
+	$(INCLUDE)/gpio.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
 	$(INCLUDE)/util.h
 ifeq (y,$(strip $(TINYIIOD)))
-INCS +=	$(INCLUDE)/fifo.h						\
-	$(INCLUDE)/irq.h						\
-	$(INCLUDE)/uart.h						\
-	$(INCLUDE)/list.h						\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
-	$(PLATFORM_DRIVERS)/uart_extra.h                                \
-	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h				\
+INCS +=	$(INCLUDE)/fifo.h \
+	$(INCLUDE)/irq.h \
+	$(INCLUDE)/uart.h \
+	$(INCLUDE)/list.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h \
 	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.h
 endif

--- a/projects/aducm_blinky_example/src.mk
+++ b/projects/aducm_blinky_example/src.mk
@@ -12,11 +12,11 @@
 #In aducm projects the name of the source dir should be different from src
 #Direcory where app srcs are stored
 
-SRC_DIRS +=	$(PROJECT)/app_src		\
-		$(PLATFORM_DRIVERS)		\
-		$(INCLUDE)			\
-		$(NO-OS)/util			\
-		$(DRIVERS)/gpio                 \
+SRC_DIRS +=	$(PROJECT)/app_src \
+		$(PLATFORM_DRIVERS) \
+		$(INCLUDE) \
+		$(NO-OS)/util \
+		$(DRIVERS)/gpio \
 
 #Include makefiles from each source directory if they exist
 SUB_MAKES= $(wildcard $(addsuffix /src.mk, $(SRC_DIRS)))

--- a/projects/adv7511/src.mk
+++ b/projects/adv7511/src.mk
@@ -11,74 +11,74 @@
 
 # Uncomment to select the profile
 
-SRCS += $(PROJECT)/src/main.c	\
-	$(PROJECT)/src/cf_hdmi.c	\
-	$(PROJECT)/src/edid.c	\
-	$(PROJECT)/src/transmitter.c	\
+SRCS += $(PROJECT)/src/main.c \
+	$(PROJECT)/src/cf_hdmi.c \
+	$(PROJECT)/src/edid.c \
+	$(PROJECT)/src/transmitter.c \
 	$(PROJECT)/src/wrapper.c
-SRCS += $(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c	\
-	$(DRIVERS)/i2c/i2c.c	\
-	$(DRIVERS)/gpio/gpio.c	\
-	$(DRIVERS)/spi/spi.c	\
-	$(NO-OS)/util/util.c	\
+SRCS += $(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
+	$(DRIVERS)/i2c/i2c.c \
+	$(DRIVERS)/gpio/gpio.c \
+	$(DRIVERS)/spi/spi.c \
+	$(NO-OS)/util/util.c \
 	$(NO-OS)/util/list.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
-	$(PLATFORM_DRIVERS)/xilinx_gpio.c					\
-	$(PLATFORM_DRIVERS)/delay.c		\
-	$(PLATFORM_DRIVERS)/xilinx_i2c.c	\
-	$(PLATFORM_DRIVERS)/irq.c	\
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
+	$(PLATFORM_DRIVERS)/delay.c \
+	$(PLATFORM_DRIVERS)/xilinx_i2c.c \
+	$(PLATFORM_DRIVERS)/irq.c \
 	$(PLATFORM_DRIVERS)/timer.c
-SRCS +=$(PROJECT)/TX/HAL/COMMON/tx_hal.c	\
-	$(PROJECT)/TX/HAL/WIRED/wrd_hal.c	\
-	$(PROJECT)/TX/HAL/WIRED/ADV7511/7511_hal.c	\
-	$(PROJECT)/TX/LIB/tx_cec.c	\
-	$(PROJECT)/TX/LIB/tx_isr.c	\
-	$(PROJECT)/TX/LIB/tx_lib.c	\
+SRCS +=$(PROJECT)/TX/HAL/COMMON/tx_hal.c \
+	$(PROJECT)/TX/HAL/WIRED/wrd_hal.c \
+	$(PROJECT)/TX/HAL/WIRED/ADV7511/7511_hal.c \
+	$(PROJECT)/TX/LIB/tx_cec.c \
+	$(PROJECT)/TX/LIB/tx_isr.c \
+	$(PROJECT)/TX/LIB/tx_lib.c \
 	$(PROJECT)/TX/LIB/tx_multi.c
-INCS +=	$(PROJECT)/src/app_config.h					\
-	$(PROJECT)/src/cf_hdmi.h			\
-	$(PROJECT)/src/cf_hdmi_demo.h	\
-	$(PROJECT)/src/edid.h	\
-	$(PROJECT)/src/transmitter.h	\
-	$(PROJECT)/src/transmitter_defs.h	\
+INCS +=	$(PROJECT)/src/app_config.h \
+	$(PROJECT)/src/cf_hdmi.h \
+	$(PROJECT)/src/cf_hdmi_demo.h \
+	$(PROJECT)/src/edid.h \
+	$(PROJECT)/src/transmitter.h \
+	$(PROJECT)/src/transmitter_defs.h \
 	$(PROJECT)/src/wrapper.h
-INCS += $(DRIVERS)/axi_core/axi_dmac/axi_dmac.h	\
+INCS += $(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
 	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h
-INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\
-	$(PLATFORM_DRIVERS)/gpio_extra.h	\
-	$(PLATFORM_DRIVERS)/i2c_extra.h	\
-	$(PLATFORM_DRIVERS)/irq_extra.h	\
+INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
+	$(PLATFORM_DRIVERS)/gpio_extra.h \
+	$(PLATFORM_DRIVERS)/i2c_extra.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
 	$(PLATFORM_DRIVERS)/timer_extra.h
-INCS +=	$(INCLUDE)/axi_io.h						\
-	$(INCLUDE)/spi.h						\
-	$(INCLUDE)/gpio.h						\
-	$(INCLUDE)/error.h						\
-	$(INCLUDE)/delay.h						\
-	$(INCLUDE)/util.h	\
-	$(INCLUDE)/list.h	\
-	$(INCLUDE)/i2c.h	\
-	$(INCLUDE)/irq.h	\
+INCS +=	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/spi.h \
+	$(INCLUDE)/gpio.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
+	$(INCLUDE)/util.h \
+	$(INCLUDE)/list.h \
+	$(INCLUDE)/i2c.h \
+	$(INCLUDE)/irq.h \
 	$(INCLUDE)/timer.h
-INCS +=	$(PROJECT)/TX/tx_lib.h	\
-	$(PROJECT)/TX/HAL/COMMON/tx_cfg.h	\
-	$(PROJECT)/TX/HAL/COMMON/tx_hal.h	\
-	$(PROJECT)/TX/HAL/WIRED/ADV7511/7511_cfg.h	\
-	$(PROJECT)/TX/HAL/WIRED/ADV7511/7511_hal.h	\
-	$(PROJECT)/TX/HAL/WIRED/ADV7511/MACROS/ADV7511_cec_map_adr.h	\
-	$(PROJECT)/TX/HAL/WIRED/ADV7511/MACROS/ADV7511_cec_map_def.h	\
-	$(PROJECT)/TX/HAL/WIRED/ADV7511/MACROS/ADV7511_cec_map_fct.h	\
-	$(PROJECT)/TX/HAL/WIRED/ADV7511/MACROS/ADV7511_cfg.h	\
-	$(PROJECT)/TX/HAL/WIRED/ADV7511/MACROS/ADV7511_edid_map_adr.h	\
-	$(PROJECT)/TX/HAL/WIRED/ADV7511/MACROS/ADV7511_edid_map_def.h	\
-	$(PROJECT)/TX/HAL/WIRED/ADV7511/MACROS/ADV7511_edid_map_fct.h	\
-	$(PROJECT)/TX/HAL/WIRED/ADV7511/MACROS/ADV7511_lib.h	\
-	$(PROJECT)/TX/HAL/WIRED/ADV7511/MACROS/ADV7511_main_map_adr.h	\
-	$(PROJECT)/TX/HAL/WIRED/ADV7511/MACROS/ADV7511_main_map_def.h	\
-	$(PROJECT)/TX/HAL/WIRED/ADV7511/MACROS/ADV7511_main_map_fct.h	\
-	$(PROJECT)/TX/HAL/WIRED/ADV7511/MACROS/ADV7511_packet_map_adr.h	\
-	$(PROJECT)/TX/HAL/WIRED/ADV7511/MACROS/ADV7511_packet_map_def.h	\
-	$(PROJECT)/TX/HAL/WIRED/ADV7511/MACROS/ADV7511_packet_map_fct.h	\
-	$(PROJECT)/TX/LIB/tx_isr.h	\
+INCS +=	$(PROJECT)/TX/tx_lib.h \
+	$(PROJECT)/TX/HAL/COMMON/tx_cfg.h \
+	$(PROJECT)/TX/HAL/COMMON/tx_hal.h \
+	$(PROJECT)/TX/HAL/WIRED/ADV7511/7511_cfg.h \
+	$(PROJECT)/TX/HAL/WIRED/ADV7511/7511_hal.h \
+	$(PROJECT)/TX/HAL/WIRED/ADV7511/MACROS/ADV7511_cec_map_adr.h \
+	$(PROJECT)/TX/HAL/WIRED/ADV7511/MACROS/ADV7511_cec_map_def.h \
+	$(PROJECT)/TX/HAL/WIRED/ADV7511/MACROS/ADV7511_cec_map_fct.h \
+	$(PROJECT)/TX/HAL/WIRED/ADV7511/MACROS/ADV7511_cfg.h \
+	$(PROJECT)/TX/HAL/WIRED/ADV7511/MACROS/ADV7511_edid_map_adr.h \
+	$(PROJECT)/TX/HAL/WIRED/ADV7511/MACROS/ADV7511_edid_map_def.h \
+	$(PROJECT)/TX/HAL/WIRED/ADV7511/MACROS/ADV7511_edid_map_fct.h \
+	$(PROJECT)/TX/HAL/WIRED/ADV7511/MACROS/ADV7511_lib.h \
+	$(PROJECT)/TX/HAL/WIRED/ADV7511/MACROS/ADV7511_main_map_adr.h \
+	$(PROJECT)/TX/HAL/WIRED/ADV7511/MACROS/ADV7511_main_map_def.h \
+	$(PROJECT)/TX/HAL/WIRED/ADV7511/MACROS/ADV7511_main_map_fct.h \
+	$(PROJECT)/TX/HAL/WIRED/ADV7511/MACROS/ADV7511_packet_map_adr.h \
+	$(PROJECT)/TX/HAL/WIRED/ADV7511/MACROS/ADV7511_packet_map_def.h \
+	$(PROJECT)/TX/HAL/WIRED/ADV7511/MACROS/ADV7511_packet_map_fct.h \
+	$(PROJECT)/TX/LIB/tx_isr.h \
 	$(PROJECT)/TX/LIB/tx_multi.h

--- a/projects/adxrs290-pmdz/src.mk
+++ b/projects/adxrs290-pmdz/src.mk
@@ -24,9 +24,9 @@ SRC_DIRS += $(PLATFORM_DRIVERS)
 SRC_DIRS += $(NO-OS)/iio/iio_app
 SRC_DIRS += $(INCLUDE)
 
-SRCS +=	$(DRIVERS)/irq/irq.c						\
-	$(DRIVERS)/gpio/gpio.c						\
-	$(NO-OS)/util/list.c						\
-	$(NO-OS)/util/fifo.c						\
-	$(NO-OS)/util/util.c						\
+SRCS +=	$(DRIVERS)/irq/irq.c \
+	$(DRIVERS)/gpio/gpio.c \
+	$(NO-OS)/util/list.c \
+	$(NO-OS)/util/fifo.c \
+	$(NO-OS)/util/util.c \
 	$(DRIVERS)/spi/spi.c

--- a/projects/cn0552/src.mk
+++ b/projects/cn0552/src.mk
@@ -10,7 +10,7 @@ SRCS += $(NO-OS)/util/util.c \
 	$(DRIVERS)/cdc/ad7746/ad7746.c \
 	$(DRIVERS)/cdc/ad7746/iio_ad7746.c \
 	$(DRIVERS)/irq/irq.c \
-	$(DRIVERS)/i2c/i2c.c	\
+	$(DRIVERS)/i2c/i2c.c \
 	$(PROJECT)/src/app/headless.c
 
 INCS +=	$(INCLUDE)/uart.h \

--- a/projects/display_demo/src.mk
+++ b/projects/display_demo/src.mk
@@ -1,19 +1,19 @@
 # See No-OS/tool/scripts/src_model.mk for variable description
-SRCS += $(PROJECT)/src/app/main.c                                       \
-        $(DRIVERS)/display/ssd_1306/ssd_1306.c                          \
-        $(DRIVERS)/display/display.c                                    \
-	$(DRIVERS)/gpio/gpio.c                                          \
-        $(DRIVERS)/spi/spi.c                                            \
-        $(DRIVERS)/platform/xilinx/xilinx_spi.c                         \
-        $(DRIVERS)/platform/xilinx/xilinx_gpio.c                        \
+SRCS += $(PROJECT)/src/app/main.c \
+        $(DRIVERS)/display/ssd_1306/ssd_1306.c \
+        $(DRIVERS)/display/display.c \
+	$(DRIVERS)/gpio/gpio.c \
+        $(DRIVERS)/spi/spi.c \
+        $(DRIVERS)/platform/xilinx/xilinx_spi.c \
+        $(DRIVERS)/platform/xilinx/xilinx_gpio.c \
 	$(NO-OS)/util/font_8x8.c
 
-INCS += $(INCLUDE)/gpio.h						\
-	$(INCLUDE)/spi.h                                                \
-        $(DRIVERS)/display/ssd_1306/ssd_1306.h                          \
-        $(DRIVERS)/display/display.h                                    \
-        $(PROJECT)/src/app/parameters.h                                 \
-        $(INCLUDE)/error.h                                              \
-        $(INCLUDE)/delay.h                                              \
-        $(DRIVERS)/platform/xilinx/gpio_extra.h                         \
+INCS += $(INCLUDE)/gpio.h \
+	$(INCLUDE)/spi.h \
+        $(DRIVERS)/display/ssd_1306/ssd_1306.h \
+        $(DRIVERS)/display/display.h \
+        $(PROJECT)/src/app/parameters.h \
+        $(INCLUDE)/error.h \
+        $(INCLUDE)/delay.h \
+        $(DRIVERS)/platform/xilinx/gpio_extra.h \
 	$(DRIVERS)/platform/xilinx/spi_extra.h

--- a/projects/fmcadc2/src.mk
+++ b/projects/fmcadc2/src.mk
@@ -15,55 +15,55 @@ SRCS += $(PROJECT)/src/app/fmcadc2.c
 ifeq (y,$(strip $(TINYIIOD)))
 SRCS += $(PROJECT)/src/app/app_iio.c
 endif
-SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c		\
-	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c			\
-	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
-	$(DRIVERS)/adc/ad9625/ad9625.c					\
-	$(DRIVERS)/spi/spi.c						\
-	$(DRIVERS)/gpio/gpio.c						\
+SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
+	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c \
+	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
+	$(DRIVERS)/adc/ad9625/ad9625.c \
+	$(DRIVERS)/spi/spi.c \
+	$(DRIVERS)/gpio/gpio.c \
 	$(NO-OS)/util/util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
-	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
-SRCS += $(NO-OS)/util/fifo.c						\
-	$(NO-OS)/util/list.c						\
-	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c				\
-	$(DRIVERS)/irq/irq.c						\
-	$(PLATFORM_DRIVERS)/uart.c					\
+SRCS += $(NO-OS)/util/fifo.c \
+	$(NO-OS)/util/list.c \
+	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \
+	$(DRIVERS)/irq/irq.c \
+	$(PLATFORM_DRIVERS)/uart.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c
 endif
-INCS +=	$(PROJECT)/src/app/app_config.h					\
+INCS +=	$(PROJECT)/src/app/app_config.h \
 	$(PROJECT)/src/devices/adi_hal/parameters.h
 ifeq (y,$(strip $(TINYIIOD)))
 INCS +=	$(PROJECT)/src/app/app_iio.h
 endif
-INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h			\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h				\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h		\
-	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h			\
-	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h		\
+INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h \
+	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h \
+	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h \
 	$(DRIVERS)/adc/ad9625/ad9625.h					
-INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\
+INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
-INCS +=	$(INCLUDE)/axi_io.h						\
-	$(INCLUDE)/spi.h						\
-	$(INCLUDE)/gpio.h						\
-	$(INCLUDE)/error.h						\
-	$(INCLUDE)/delay.h						\
+INCS +=	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/spi.h \
+	$(INCLUDE)/gpio.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
 	$(INCLUDE)/util.h
 ifeq (y,$(strip $(TINYIIOD)))
-INCS += $(INCLUDE)/fifo.h						\
-	$(INCLUDE)/irq.h						\
-	$(INCLUDE)/uart.h						\
-	$(INCLUDE)/list.h						\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
-	$(PLATFORM_DRIVERS)/uart_extra.h                                \
+INCS += $(INCLUDE)/fifo.h \
+	$(INCLUDE)/irq.h \
+	$(INCLUDE)/uart.h \
+	$(INCLUDE)/list.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h
 endif

--- a/projects/fmcadc5/src.mk
+++ b/projects/fmcadc5/src.mk
@@ -11,61 +11,61 @@
 
 # Uncomment to select the profile
 
-SRCS += $(PROJECT)/src/app/fmcadc5.c					\
+SRCS += $(PROJECT)/src/app/fmcadc5.c \
 	$(PROJECT)/src/devices/i5g/i5g.c
 ifeq (y,$(strip $(TINYIIOD)))
 SRCS += $(PROJECT)/src/app/app_iio.c
 endif
-SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c		\
-	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c			\
-	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
-	$(DRIVERS)/adc/ad9625/ad9625.c					\
-	$(DRIVERS)/spi/spi.c						\
-	$(DRIVERS)/gpio/gpio.c						\
+SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
+	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c \
+	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
+	$(DRIVERS)/adc/ad9625/ad9625.c \
+	$(DRIVERS)/spi/spi.c \
+	$(DRIVERS)/gpio/gpio.c \
 	$(NO-OS)/util/util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
-	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
-SRCS += $(NO-OS)/util/fifo.c					\
-	$(NO-OS)/util/list.c						\
-	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c		\
-	$(DRIVERS)/irq/irq.c						\
-	$(PLATFORM_DRIVERS)/uart.c					\
+SRCS += $(NO-OS)/util/fifo.c \
+	$(NO-OS)/util/list.c \
+	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \
+	$(DRIVERS)/irq/irq.c \
+	$(PLATFORM_DRIVERS)/uart.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c
 endif
-INCS +=	$(PROJECT)/src/app/app_config.h					\
-	$(PROJECT)/src/devices/adi_hal/parameters.h			\
+INCS +=	$(PROJECT)/src/app/app_config.h \
+	$(PROJECT)/src/devices/adi_hal/parameters.h \
 	$(PROJECT)/src/devices/i5g/i5g.h
 ifeq (y,$(strip $(TINYIIOD)))
 INCS +=	$(PROJECT)/src/app/app_iio.h
 endif
-INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h			\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h				\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h		\
-	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h			\
-	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h		\
+INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h \
+	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h \
+	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h \
 	$(DRIVERS)/adc/ad9625/ad9625.h					
-INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\
+INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
-INCS +=	$(INCLUDE)/axi_io.h						\
-	$(INCLUDE)/spi.h						\
-	$(INCLUDE)/gpio.h						\
-	$(INCLUDE)/error.h						\
-	$(INCLUDE)/delay.h						\
+INCS +=	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/spi.h \
+	$(INCLUDE)/gpio.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
 	$(INCLUDE)/util.h
 ifeq (y,$(strip $(TINYIIOD)))
-INCS += $(INCLUDE)/fifo.h					\
-	$(INCLUDE)/irq.h						\
-	$(INCLUDE)/uart.h						\
-	$(INCLUDE)/list.h						\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
-	$(PLATFORM_DRIVERS)/uart_extra.h                                \
+INCS += $(INCLUDE)/fifo.h \
+	$(INCLUDE)/irq.h \
+	$(INCLUDE)/uart.h \
+	$(INCLUDE)/list.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h
 endif

--- a/projects/fmcdaq2/src.mk
+++ b/projects/fmcdaq2/src.mk
@@ -15,69 +15,69 @@ SRCS += $(PROJECT)/src/app/fmcdaq2.c
 ifeq (y,$(strip $(TINYIIOD)))
 SRCS += $(PROJECT)/src/app/app_iio.c
 endif
-SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
-	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c			\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c		\
-	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c			\
-	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
-	$(DRIVERS)/frequency/ad9523/ad9523.c				\
-	$(DRIVERS)/adc/ad9680/ad9680.c					\
-	$(DRIVERS)/dac/ad9144/ad9144.c					\
-	$(DRIVERS)/spi/spi.c						\
-	$(DRIVERS)/gpio/gpio.c						\
+SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
+	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
+	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c \
+	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
+	$(DRIVERS)/frequency/ad9523/ad9523.c \
+	$(DRIVERS)/adc/ad9680/ad9680.c \
+	$(DRIVERS)/dac/ad9144/ad9144.c \
+	$(DRIVERS)/spi/spi.c \
+	$(DRIVERS)/gpio/gpio.c \
 	$(NO-OS)/util/util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
-	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
-SRCS += $(NO-OS)/util/fifo.c						\
-	$(NO-OS)/util/list.c						\
-	$(DRIVERS)/adc/ad9680/iio_ad9680.c				\
-	$(DRIVERS)/dac/ad9144/iio_ad9144.c				\
-	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c				\
-	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.c				\
-	$(DRIVERS)/irq/irq.c                                            \
-	$(PLATFORM_DRIVERS)/uart.c					\
+SRCS += $(NO-OS)/util/fifo.c \
+	$(NO-OS)/util/list.c \
+	$(DRIVERS)/adc/ad9680/iio_ad9680.c \
+	$(DRIVERS)/dac/ad9144/iio_ad9144.c \
+	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \
+	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.c \
+	$(DRIVERS)/irq/irq.c \
+	$(PLATFORM_DRIVERS)/uart.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c
 endif
-INCS +=	$(PROJECT)/src/app/app_config.h					\
+INCS +=	$(PROJECT)/src/app/app_config.h \
 	$(PROJECT)/src/devices/adi_hal/parameters.h
 ifeq (y,$(strip $(TINYIIOD)))
-INCS +=	$(PROJECT)/src/app/app_iio.h					\
-	$(DRIVERS)/adc/ad9680/iio_ad9680.h				\
+INCS +=	$(PROJECT)/src/app/app_iio.h \
+	$(DRIVERS)/adc/ad9680/iio_ad9680.h \
 	$(DRIVERS)/dac/ad9144/iio_ad9144.h
 endif
-INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h			\
-	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.h			\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h				\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h		\
-	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h			\
-	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h		\
-	$(DRIVERS)/frequency/ad9523/ad9523.h				\
-	$(DRIVERS)/adc/ad9680/ad9680.h					\
+INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \
+	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.h \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h \
+	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h \
+	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h \
+	$(DRIVERS)/frequency/ad9523/ad9523.h \
+	$(DRIVERS)/adc/ad9680/ad9680.h \
 	$(DRIVERS)/dac/ad9144/ad9144.h					
-INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\
+INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
-INCS +=	$(INCLUDE)/axi_io.h						\
-	$(INCLUDE)/spi.h						\
-	$(INCLUDE)/gpio.h						\
-	$(INCLUDE)/error.h						\
-	$(INCLUDE)/delay.h						\
+INCS +=	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/spi.h \
+	$(INCLUDE)/gpio.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
 	$(INCLUDE)/util.h
 ifeq (y,$(strip $(TINYIIOD)))
-INCS += $(INCLUDE)/fifo.h						\
-	$(INCLUDE)/irq.h						\
-	$(INCLUDE)/uart.h						\
-	$(INCLUDE)/list.h						\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
-	$(PLATFORM_DRIVERS)/uart_extra.h                                \
-	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h				\
+INCS += $(INCLUDE)/fifo.h \
+	$(INCLUDE)/irq.h \
+	$(INCLUDE)/uart.h \
+	$(INCLUDE)/list.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h \
 	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.h
 endif

--- a/projects/fmcdaq3/src.mk
+++ b/projects/fmcdaq3/src.mk
@@ -15,69 +15,69 @@ SRCS += $(PROJECT)/src/app/fmcdaq3.c
 ifeq (y,$(strip $(TINYIIOD)))
 SRCS += $(PROJECT)/src/app/app_iio.c
 endif
-SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
-	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c			\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c		\
-	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c			\
-	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
-	$(DRIVERS)/frequency/ad9528/ad9528.c				\
-	$(DRIVERS)/adc/ad9680/ad9680.c					\
-	$(DRIVERS)/dac/ad9152/ad9152.c					\
-	$(DRIVERS)/spi/spi.c						\
-	$(DRIVERS)/gpio/gpio.c						\
+SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
+	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
+	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c \
+	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
+	$(DRIVERS)/frequency/ad9528/ad9528.c \
+	$(DRIVERS)/adc/ad9680/ad9680.c \
+	$(DRIVERS)/dac/ad9152/ad9152.c \
+	$(DRIVERS)/spi/spi.c \
+	$(DRIVERS)/gpio/gpio.c \
 	$(NO-OS)/util/util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
-	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
-SRCS += $(NO-OS)/util/fifo.c					\
-	$(NO-OS)/util/list.c						\
-	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c		\
-	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.c		\
-	$(DRIVERS)/adc/ad9680/iio_ad9680.c				\
-	$(DRIVERS)/dac/ad9152/iio_ad9152.c				\
-	$(DRIVERS)/irq/irq.c						\
-	$(PLATFORM_DRIVERS)/uart.c					\
+SRCS += $(NO-OS)/util/fifo.c \
+	$(NO-OS)/util/list.c \
+	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \
+	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.c \
+	$(DRIVERS)/adc/ad9680/iio_ad9680.c \
+	$(DRIVERS)/dac/ad9152/iio_ad9152.c \
+	$(DRIVERS)/irq/irq.c \
+	$(PLATFORM_DRIVERS)/uart.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c
 endif
-INCS +=	$(PROJECT)/src/app/app_config.h					\
+INCS +=	$(PROJECT)/src/app/app_config.h \
 	$(PROJECT)/src/devices/adi_hal/parameters.h
 ifeq (y,$(strip $(TINYIIOD)))
-INCS +=	$(PROJECT)/src/app/app_iio.h					\
-	$(DRIVERS)/adc/ad9680/iio_ad9680.h				\
+INCS +=	$(PROJECT)/src/app/app_iio.h \
+	$(DRIVERS)/adc/ad9680/iio_ad9680.h \
 	$(DRIVERS)/dac/ad9152/iio_ad9152.h
 endif
-INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h			\
-	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.h			\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h				\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h		\
-	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h			\
-	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h		\
-	$(DRIVERS)/frequency/ad9528/ad9528.h				\
-	$(DRIVERS)/adc/ad9680/ad9680.h					\
+INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \
+	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.h \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h \
+	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h \
+	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h \
+	$(DRIVERS)/frequency/ad9528/ad9528.h \
+	$(DRIVERS)/adc/ad9680/ad9680.h \
 	$(DRIVERS)/dac/ad9152/ad9152.h					
-INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\
+INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
-INCS +=	$(INCLUDE)/axi_io.h						\
-	$(INCLUDE)/spi.h						\
-	$(INCLUDE)/gpio.h						\
-	$(INCLUDE)/error.h						\
-	$(INCLUDE)/delay.h						\
+INCS +=	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/spi.h \
+	$(INCLUDE)/gpio.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
 	$(INCLUDE)/util.h
 ifeq (y,$(strip $(TINYIIOD)))
-INCS += $(INCLUDE)/fifo.h				    \
-	$(INCLUDE)/irq.h						\
-	$(INCLUDE)/uart.h						\
-	$(INCLUDE)/list.h						\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
-	$(PLATFORM_DRIVERS)/uart_extra.h                                \
-	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h				\
+INCS += $(INCLUDE)/fifo.h \
+	$(INCLUDE)/irq.h \
+	$(INCLUDE)/uart.h \
+	$(INCLUDE)/list.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h \
 	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.h
 endif

--- a/projects/fmcjesdadc1/src.mk
+++ b/projects/fmcjesdadc1/src.mk
@@ -12,58 +12,58 @@
 # Uncomment to select the profile
 
 SRCS += $(PROJECT)/src/app/fmcjesdadc1.c
-SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c			\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c				\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c		\
-	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c			\
-	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c		\
-	$(DRIVERS)/io-expander/demux_spi/demux_spi.c			\
-	$(DRIVERS)/spi/spi.c						\
-	$(DRIVERS)/gpio/gpio.c						\
-	$(DRIVERS)/adc/ad9250/ad9250.c					\
-	$(DRIVERS)/frequency/ad9517/ad9517.c				\
+SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
+	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c \
+	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
+	$(DRIVERS)/io-expander/demux_spi/demux_spi.c \
+	$(DRIVERS)/spi/spi.c \
+	$(DRIVERS)/gpio/gpio.c \
+	$(DRIVERS)/adc/ad9250/ad9250.c \
+	$(DRIVERS)/frequency/ad9517/ad9517.c \
 	$(NO-OS)/util/util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c					\
-	$(PLATFORM_DRIVERS)/xilinx_spi.c				\
-	$(PLATFORM_DRIVERS)/xilinx_gpio.c				\
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
-SRCS += $(NO-OS)/util/fifo.c				    \
-	$(NO-OS)/util/list.c						\
-	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c	    \
-	$(DRIVERS)/irq/irq.c						\
-	$(NO-OS)/iio/iio_app/iio_app.c					\
-	$(PLATFORM_DRIVERS)/uart.c					\
+SRCS += $(NO-OS)/util/fifo.c \
+	$(NO-OS)/util/list.c \
+	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \
+	$(DRIVERS)/irq/irq.c \
+	$(NO-OS)/iio/iio_app/iio_app.c \
+	$(PLATFORM_DRIVERS)/uart.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c
 endif
-INCS +=	$(PROJECT)/src/app/app_config.h					\
+INCS +=	$(PROJECT)/src/app/app_config.h \
 	$(PROJECT)/src/devices/adi_hal/parameters.h			
-INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h			\
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h				\
-	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h		\
-	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h			\
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h			\
-	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h		\
-	$(DRIVERS)/io-expander/demux_spi/demux_spi.h			\
-	$(DRIVERS)/adc/ad9250/ad9250.h					\
+INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h \
+	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h \
+	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h \
+	$(DRIVERS)/io-expander/demux_spi/demux_spi.h \
+	$(DRIVERS)/adc/ad9250/ad9250.h \
 	$(DRIVERS)/frequency/ad9517/ad9517.h
-INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h					\
+INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
-INCS +=	$(INCLUDE)/axi_io.h						\
-	$(INCLUDE)/spi.h						\
-	$(INCLUDE)/gpio.h						\
-	$(INCLUDE)/error.h						\
-	$(INCLUDE)/delay.h						\
+INCS +=	$(INCLUDE)/axi_io.h \
+	$(INCLUDE)/spi.h \
+	$(INCLUDE)/gpio.h \
+	$(INCLUDE)/error.h \
+	$(INCLUDE)/delay.h \
 	$(INCLUDE)/util.h
 ifeq (y,$(strip $(TINYIIOD)))
-INCS += $(INCLUDE)/fifo.h					\
-	$(INCLUDE)/irq.h						\
-	$(INCLUDE)/uart.h						\
-	$(INCLUDE)/list.h						\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
-	$(PLATFORM_DRIVERS)/uart_extra.h                                \
-	$(NO-OS)/iio/iio_app/iio_app.h					\
+INCS += $(INCLUDE)/fifo.h \
+	$(INCLUDE)/irq.h \
+	$(INCLUDE)/uart.h \
+	$(INCLUDE)/list.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(NO-OS)/iio/iio_app/iio_app.h \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h
 endif

--- a/projects/iio_aducm3029/src.mk
+++ b/projects/iio_aducm3029/src.mk
@@ -4,8 +4,8 @@ PLATFORM = aducm3029
 # TINYIIOD=y
 
 SRC_DIRS += $(PROJECT)/src \
-		$(PLATFORM_DRIVERS)\
-		$(NO-OS)/util\
+		$(PLATFORM_DRIVERS) \
+		$(NO-OS)/util \
 		$(NO-OS)/include \
 
 ifeq '$(TINYIIOD)' 'y'

--- a/projects/iio_demo/src.mk
+++ b/projects/iio_demo/src.mk
@@ -2,27 +2,27 @@
 SRC_DIRS += $(PROJECT)/src/app
 SRC_DIRS += $(NO-OS)/iio/iio_app
 
-SRCS +=	$(NO-OS)/util/list.c					\
-	$(NO-OS)/util/fifo.c						\
+SRCS +=	$(NO-OS)/util/list.c \
+	$(NO-OS)/util/fifo.c \
 	$(NO-OS)/util/util.c
 
 #drivers
-SRCS += $(DRIVERS)/adc/adc_demo/adc_demo.c				\
-	$(DRIVERS)/adc/adc_demo/iio_adc_demo.c				\
-	$(DRIVERS)/dac/dac_demo/iio_dac_demo.c				\
-	$(DRIVERS)/dac/dac_demo/dac_demo.c                              \
+SRCS += $(DRIVERS)/adc/adc_demo/adc_demo.c \
+	$(DRIVERS)/adc/adc_demo/iio_adc_demo.c \
+	$(DRIVERS)/dac/dac_demo/iio_dac_demo.c \
+	$(DRIVERS)/dac/dac_demo/dac_demo.c \
 	$(DRIVERS)/irq/irq.c
 
-INCS += $(INCLUDE)/fifo.h					\
-	$(INCLUDE)/uart.h						\
-	$(INCLUDE)/list.h						\
-	$(INCLUDE)/util.h						\
+INCS += $(INCLUDE)/fifo.h \
+	$(INCLUDE)/uart.h \
+	$(INCLUDE)/list.h \
+	$(INCLUDE)/util.h \
 	$(INCLUDE)/error.h
 
-INCS += $(DRIVERS)/adc/adc_demo/iio_adc_demo.h			\
-		$(DRIVERS)/dac/dac_demo/dac_demo.h		\
-		$(DRIVERS)/dac/dac_demo/iio_dac_demo.h			\
-		$(DRIVERS)/adc/adc_demo/adc_demo.h		\
+INCS += $(DRIVERS)/adc/adc_demo/iio_adc_demo.h \
+		$(DRIVERS)/dac/dac_demo/dac_demo.h \
+		$(DRIVERS)/dac/dac_demo/iio_dac_demo.h \
+		$(DRIVERS)/adc/adc_demo/adc_demo.h \
 
 ifeq ($(PLATFORM),$(filter $(PLATFORM),xilinx aducm3029))
 SRCS += $(PLATFORM_DRIVERS)/delay.c
@@ -43,19 +43,19 @@ DISABLE_SECURE_SOCKET ?= y
 SRC_DIRS += $(NO-OS)/network
 SRCS	 += $(NO-OS)/util/circular_buffer.c
 SRCS	 += $(PLATFORM_DRIVERS)/timer.c
-INCS	 += $(INCLUDE)/timer.h		\
-		$(INCLUDE)/circular_buffer.h	\
-		$(PLATFORM_DRIVERS)/timer_extra.h\
+INCS	 += $(INCLUDE)/timer.h \
+		$(INCLUDE)/circular_buffer.h \
+		$(PLATFORM_DRIVERS)/timer_extra.h \
 		$(PLATFORM_DRIVERS)/rtc_extra.h
 endif
 
 SRCS += $(PLATFORM_DRIVERS)/uart.c \
 		$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c
 
-INCS += $(INCLUDE)/irq.h						\
-	$(INCLUDE)/rtc.h						\
-	$(INCLUDE)/gpio.h						\
-	$(PLATFORM_DRIVERS)/irq_extra.h					\
+INCS += $(INCLUDE)/irq.h \
+	$(INCLUDE)/rtc.h \
+	$(INCLUDE)/gpio.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
 	$(PLATFORM_DRIVERS)/uart_extra.h
 endif
 
@@ -108,7 +108,7 @@ INCS += $(NO-OS)/network/tcp_socket.h \
 		$(NO-OS)/network/linux_socket/linux_socket.h
 
 INCS	 += $(INCLUDE)/circular_buffer.h
-INCS += $(PROJECT)/src/app/app_config.h  \
+INCS += $(PROJECT)/src/app/app_config.h \
 		$(PROJECT)/src/app/parameters.h	
 
 INCS += $(NO-OS)/iio/iio_app/iio_app.h 

--- a/projects/iio_demo/src.mk
+++ b/projects/iio_demo/src.mk
@@ -10,8 +10,7 @@ SRCS +=	$(NO-OS)/util/list.c \
 SRCS += $(DRIVERS)/adc/adc_demo/adc_demo.c \
 	$(DRIVERS)/adc/adc_demo/iio_adc_demo.c \
 	$(DRIVERS)/dac/dac_demo/iio_dac_demo.c \
-	$(DRIVERS)/dac/dac_demo/dac_demo.c \
-	$(DRIVERS)/irq/irq.c
+	$(DRIVERS)/dac/dac_demo/dac_demo.c
 
 INCS += $(INCLUDE)/fifo.h \
 	$(INCLUDE)/uart.h \
@@ -25,7 +24,8 @@ INCS += $(DRIVERS)/adc/adc_demo/iio_adc_demo.h \
 		$(DRIVERS)/adc/adc_demo/adc_demo.h \
 
 ifeq ($(PLATFORM),$(filter $(PLATFORM),xilinx aducm3029))
-SRCS += $(PLATFORM_DRIVERS)/delay.c
+SRCS += $(PLATFORM_DRIVERS)/delay.c \
+	$(DRIVERS)/irq/irq.c
 endif
 INCS += $(INCLUDE)/delay.h
 


### PR DESCRIPTION
Some src.mk files use whitespace to align the line break \ character
in the Makefile. Whitespace used is either tab or space or a mixture
of both. This leads to awkward looking Makefiles that have either
missaligned backslashes and are harder to maintain because typing
tab tab tab tab ... backslash is always longer than typing space
backslash.

Signed-off-by: Darius Berghe <darius.berghe@analog.com>

Command used to to this:
```
cd projects
find . -name "src.mk" -print0 | xargs -0 sed -i 's/\s*\\/ \\/'
```