### PR TITLE
drivers: remove redundant breaks

### DIFF
--- a/drivers/adc/ad469x/ad469x.c
+++ b/drivers/adc/ad469x/ad469x.c
@@ -414,7 +414,6 @@ int32_t ad469x_set_channel_sequence(struct ad469x_dev *dev,
 
 	default:
 		return FAILURE;
-		break;
 	}
 
 	dev->ch_sequence = seq;

--- a/drivers/adc/ad7768-1/ad77681.c
+++ b/drivers/adc/ad7768-1/ad77681.c
@@ -451,7 +451,6 @@ int32_t ad77681_update_sample_rate(struct ad77681_dev *dev)
 		break;
 	default:
 		return FAILURE;
-		break;
 	}
 
 	/* Finding out decimation ratio */
@@ -496,7 +495,6 @@ int32_t ad77681_update_sample_rate(struct ad77681_dev *dev)
 		break;
 	default:
 		return FAILURE;
-		break;
 	}
 
 	/* Sample rate to Hz */
@@ -538,7 +536,6 @@ int32_t ad77681_SINC3_ODR(struct ad77681_dev *dev,
 		break;
 	default:
 		return FAILURE;
-		break;
 	}
 
 	odr = ((float)(dev->mclk * 1000.0) / (sinc3_odr * (float)(32 * mclk_div))) - 1;
@@ -1355,7 +1352,6 @@ int32_t ad77681_gpio_read(struct ad77681_dev *dev,
 		break;
 	default:
 		return FAILURE;
-		break;
 	}
 
 	return ret;
@@ -1415,7 +1411,6 @@ int32_t ad77681_gpio_write(struct ad77681_dev *dev,
 		break;
 	default:
 		return FAILURE;
-		break;
 	}
 
 	return ret;
@@ -1475,7 +1470,6 @@ int32_t ad77681_gpio_inout(struct ad77681_dev *dev,
 		break;
 	default:
 		return FAILURE;
-		break;
 	}
 
 	return ret;
@@ -1578,7 +1572,6 @@ int32_t ad77681_gpio_open_drain(struct ad77681_dev *dev,
 		break;
 	default:
 		return FAILURE;
-		break;
 	}
 
 	return ret;

--- a/drivers/axi_core/spi_engine/spi_engine.c
+++ b/drivers/axi_core/spi_engine/spi_engine.c
@@ -499,7 +499,6 @@ static int32_t spi_engine_write_cmd(struct spi_desc *desc,
 	default:
 
 		return FAILURE;
-		break;
 	}
 
 	return SUCCESS;

--- a/drivers/platform/xilinx/uart.c
+++ b/drivers/platform/xilinx/uart.c
@@ -214,7 +214,6 @@ int32_t uart_write(struct uart_desc *desc, const uint8_t *data,
 		break;
 	default:
 		return FAILURE;
-		break;
 	}
 
 	return SUCCESS;
@@ -314,7 +313,6 @@ static int32_t uart_irq_init(struct uart_desc *descriptor)
 		break;
 	default:
 		return FAILURE;
-		break;
 	}
 
 	status = irq_enable(xil_uart_desc->irq_desc, xil_uart_desc->irq_id);

--- a/drivers/platform/xilinx/xilinx_gpio.c
+++ b/drivers/platform/xilinx/xilinx_gpio.c
@@ -126,7 +126,6 @@ ps_error:
 error:
 	default:
 		return FAILURE;
-		break;
 	}
 
 	return SUCCESS;
@@ -240,7 +239,6 @@ int32_t xil_gpio_direction_input(struct gpio_desc *desc)
 		break;
 	default:
 		return FAILURE;
-		break;
 	}
 
 	return SUCCESS;
@@ -306,7 +304,6 @@ int32_t xil_gpio_direction_output(struct gpio_desc *desc,
 		break;
 	default:
 		return FAILURE;
-		break;
 	}
 
 	return SUCCESS;
@@ -353,7 +350,6 @@ int32_t xil_gpio_get_direction(struct gpio_desc *desc,
 		break;
 	default:
 		return FAILURE;
-		break;
 	}
 
 	return SUCCESS;
@@ -402,7 +398,6 @@ int32_t xil_gpio_set_value(struct gpio_desc *desc,
 		break;
 	default:
 		return FAILURE;
-		break;
 	}
 
 	return SUCCESS;
@@ -448,7 +443,6 @@ int32_t xil_gpio_get_value(struct gpio_desc *desc,
 		break;
 	default:
 		return FAILURE;
-		break;
 	}
 
 	return SUCCESS;

--- a/drivers/platform/xilinx/xilinx_i2c.c
+++ b/drivers/platform/xilinx/xilinx_i2c.c
@@ -370,7 +370,6 @@ error:
 	default:
 
 		return FAILURE;
-		break;
 	}
 
 	free(desc->extra);
@@ -439,7 +438,6 @@ error:
 	default:
 
 		return FAILURE;
-		break;
 	}
 
 	return SUCCESS;

--- a/drivers/platform/xilinx/xilinx_spi.c
+++ b/drivers/platform/xilinx/xilinx_spi.c
@@ -344,7 +344,6 @@ error:
 #endif
 	default:
 		return FAILURE;
-		break;
 	}
 
 	if(xdesc)
@@ -446,7 +445,6 @@ int32_t xil_spi_write_and_read(struct spi_desc *desc,
 error:
 	default:
 		return FAILURE;
-		break;
 	}
 
 	return ret;


### PR DESCRIPTION
If a return statement is followed by a break statement, then the second
one is not reached.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>