### PR TITLE
Refactoring xil_i2c_ops refactoring

### DIFF
--- a/drivers/platform/xilinx/i2c_extra.h
+++ b/drivers/platform/xilinx/i2c_extra.h
@@ -91,7 +91,7 @@ typedef struct xil_i2c_desc {
 /**
  * @brief Xilinx platform specific i2c platform ops structure
  */
-extern const struct i2c_platform_ops xil_i2c_platform_ops;
+extern const struct i2c_platform_ops xil_i2c_ops;
 
 /******************************************************************************/
 /************************ Functions Declarations ******************************/

--- a/drivers/platform/xilinx/xilinx_i2c.c
+++ b/drivers/platform/xilinx/xilinx_i2c.c
@@ -89,7 +89,7 @@ static uint32_t ps_last_bitrate = 0;
 /**
  * @brief Xilinx platform specific I2C platform ops structure
  */
-const struct i2c_platform_ops xil_i2c_platform_ops = {
+const struct i2c_platform_ops xil_i2c_ops = {
 	.i2c_ops_init = &xil_i2c_init,
 	.i2c_ops_write = &xil_i2c_write,
 	.i2c_ops_read = &xil_i2c_read,

--- a/projects/adv7511/src/main.c
+++ b/projects/adv7511/src/main.c
@@ -208,7 +208,7 @@ static int32_t app_set_i2c_mux(struct i2c_desc *adv7511_i2c)
 	i2c_mux_init_extra.type = IIC_PL;
 	i2c_mux_init.max_speed_hz = 400000;
 	i2c_mux_init.slave_address = mux_addr;
-	i2c_mux_init.platform_ops = &xil_i2c_platform_ops;
+	i2c_mux_init.platform_ops = &xil_i2c_ops;
 	i2c_mux_init.extra = &i2c_mux_init_extra;
 
 	mem_val = pca9548_setup;
@@ -352,7 +352,7 @@ int main()
 	adv7511_extra_i2c_init.type = IIC_PL;
 	adv7511_i2c_init.max_speed_hz = 400000;
 	adv7511_i2c_init.slave_address = 0x39;
-	adv7511_i2c_init.platform_ops = &xil_i2c_platform_ops;
+	adv7511_i2c_init.platform_ops = &xil_i2c_ops;
 	adv7511_i2c_init.extra = &adv7511_extra_i2c_init;
 #if defined(_XPARAMETERS_PS_H_)
 	xil_timer_init.active_tmr = 0;


### PR DESCRIPTION
Refactoring xil_i2c_platform_ops to xil_i2c_ops.

Signed-off-by: Andrei Porumb <andrei.porumb@analog.com> 