### PR TITLE
Refactoring linux_i2c_platform_ops

### DIFF
--- a/drivers/platform/linux/linux_i2c.c
+++ b/drivers/platform/linux/linux_i2c.c
@@ -221,7 +221,7 @@ int32_t linux_i2c_read(struct i2c_desc *desc,
 /**
  * @brief Linux platform specific I2C platform ops structure
  */
-const struct i2c_platform_ops linux_i2c_platform_ops = {
+const struct i2c_platform_ops linux_i2c_ops = {
 	.i2c_ops_init = &linux_i2c_init,
 	.i2c_ops_write = &linux_i2c_write,
 	.i2c_ops_read = &linux_i2c_read,

--- a/drivers/platform/linux/linux_i2c.h
+++ b/drivers/platform/linux/linux_i2c.h
@@ -52,6 +52,6 @@ struct linux_i2c_init_param {
 /**
  * @brief Linux specific I2C platform ops structure
  */
-extern const struct i2c_platform_ops linux_i2c_platform_ops;
+extern const struct i2c_platform_ops linux_i2c_ops;
 
 #endif // LINUX_I2C_H_


### PR DESCRIPTION
Refactored linux_i2c_platform_ops to linux_i2c_ops.

Signed-off-by: Andrei Porumb <andrei.porumb@analog.com>