### PR TITLE
projects:ad7768_evb: fix AXI ADC base address

### DIFF
--- a/projects/ad7768-evb/src/ad7768_evb.c
+++ b/projects/ad7768-evb/src/ad7768_evb.c
@@ -215,7 +215,7 @@ int main(void)
 	};
 	struct axi_adc *axi_adc_core_desc;
 	struct axi_adc_init axi_adc_initial = {
-		.base = ADC_DDR_BASEADDR,
+		.base = AD7768_ADC_BASEADDR,
 		.name = "ad7768_axi_adc",
 		.num_channels = chan_no
 	};


### PR DESCRIPTION
Apply correct base AXI ADC base address to the driver. Before the address
was to the memory area dedicated to the DMA transfer.

Signed-off-by: Andrei Drimbarean <Andrei.Drimbarean@analog.com>