### PR TITLE
drivers:afe:ad4110: Fix author name

### DIFF
--- a/drivers/afe/ad4110/ad4110.c
+++ b/drivers/afe/ad4110/ad4110.c
@@ -2,7 +2,7 @@
  *   @file   ad4110.c
  *   @brief  Implementation of AD4110 Driver.
  *   @author Stefan Popa (stefan.popa@analog.com)
- * 	     Andrei Porump (andrei.porumb@analog.com)
+ * 	     Andrei Porumb (andrei.porumb@analog.com)
  * 	     Mihail Chindris (mihail.chindris@analog.com)
 ********************************************************************************
  * Copyright 2021(c) Analog Devices, Inc.

--- a/drivers/afe/ad4110/ad4110.h
+++ b/drivers/afe/ad4110/ad4110.h
@@ -2,7 +2,7 @@
  *   @file   ad4110.h
  *   @brief  Header file of AD4110 Driver.
  *   @author Stefan Popa (stefan.popa@analog.com)
- * 	     Andrei Porump (andrei.porumb@analog.com)
+ * 	     Andrei Porumb (andrei.porumb@analog.com)
  * 	     Mihail Chindris (mihail.chindris@analog.com)
 ********************************************************************************
  * Copyright 2021(c) Analog Devices, Inc.


### PR DESCRIPTION
Seems like a copy-paste issue. Fixed with this commit.