### PR TITLE
projects:ad469x: use iio buffers + minor naming fix

### DIFF
--- a/projects/ad469x_fmcz/src/ad469x_fmcz.c
+++ b/projects/ad469x_fmcz/src/ad469x_fmcz.c
@@ -212,8 +212,8 @@ int main()
 #ifdef IIO_SUPPORT
 
 	struct iio_data_buffer read_buff = {
-		.buff = (void *)ADC_DDR_BASEADDR,
-		.size = MAX_SIZE_BASE_ADDR
+		.buff = (void *)buf,
+		.size = sizeof(buf)
 	};
 
 	struct iio_app_device devices[] = {

--- a/projects/ad469x_fmcz/src/ad469x_fmcz.c
+++ b/projects/ad469x_fmcz/src/ad469x_fmcz.c
@@ -217,7 +217,7 @@ int main()
 	};
 
 	struct iio_app_device devices[] = {
-		IIO_APP_DEVICE("adc", dev, &ad469x_iio_descriptor,
+		IIO_APP_DEVICE("ad463x", dev, &ad469x_iio_descriptor,
 			       &read_buff, NULL),
 	};
 


### PR DESCRIPTION
- use buffers for the IIO support of the project
- use less generic naming for the device

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>