### PR TITLE
projects:ad469x: naming typo

### DIFF
--- a/projects/ad469x_fmcz/src/ad469x_fmcz.c
+++ b/projects/ad469x_fmcz/src/ad469x_fmcz.c
@@ -217,7 +217,7 @@ int main()
 	};
 
 	struct iio_app_device devices[] = {
-		IIO_APP_DEVICE("ad463x", dev, &ad469x_iio_descriptor,
+		IIO_APP_DEVICE("ad469x", dev, &ad469x_iio_descriptor,
 			       &read_buff, NULL),
 	};
 


### PR DESCRIPTION
Fix typo for the IIO device name.

No functional changes.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>