### PR TITLE
drivers:frequency: fix naming typos

### DIFF
--- a/drivers/frequency/adf4156/adf4156.c
+++ b/drivers/frequency/adf4156/adf4156.c
@@ -1,6 +1,6 @@
 /**************************************************************************//**
 *   @file   adf4156.c
-*   @brief  Implementation of ad9833 Driver for Microblaze processor.
+*   @brief  Implementation of ADF4156 Driver for Microblaze processor.
 *   @author Lucian Sin (Lucian.Sin@analog.com)
 *******************************************************************************
 * Copyright 2013(c) Analog Devices, Inc.

--- a/drivers/frequency/adf4156/adf4156.h
+++ b/drivers/frequency/adf4156/adf4156.h
@@ -1,6 +1,6 @@
 /***************************************************************************//**
 *   @file   adf4156.h
-*   @brief  Header file of AD9833 Driver for Microblaze processor.
+*   @brief  Header file of ADF4156 Driver for Microblaze processor.
 *   @author Lucian Sin (Lucian.Sin@analog.com)
 *
 ********************************************************************************

--- a/drivers/frequency/adf4157/adf4157.c
+++ b/drivers/frequency/adf4157/adf4157.c
@@ -1,6 +1,6 @@
 /**************************************************************************//**
 *   @file   ADF4157.c
-*   @brief  Implementation of ad9833 Driver for Microblaze processor.
+*   @brief  Implementation of ADF4157 Driver for Microblaze processor.
 *   @author Lucian Sin (Lucian.Sin@analog.com)
 *******************************************************************************
 * Copyright 2013(c) Analog Devices, Inc.

--- a/drivers/frequency/adf4157/adf4157.h
+++ b/drivers/frequency/adf4157/adf4157.h
@@ -1,6 +1,6 @@
 /***************************************************************************//**
 *   @file   ADF4157.h
-*   @brief  Header file of AD9833 Driver for Microblaze processor.
+*   @brief  Header file of ADF4157 Driver for Microblaze processor.
 *   @author Lucian Sin (Lucian.Sin@analog.com)
 *
 ********************************************************************************


### PR DESCRIPTION
Replace `ad9833` with `adf4156/adf4157`.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>