### PR TITLE
tools: scripts: xilinx: Update Vitis template name

### DIFF
--- a/tools/scripts/platform/xilinx/util.tcl
+++ b/tools/scripts/platform/xilinx/util.tcl
@@ -90,7 +90,7 @@ proc _vitis_project {} {
 		-hw $::hw						\
 		-proc $cpu						\
 		-os standalone						\
-		-template  {Empty Application}
+		-template  {Empty Application(C)}
 
 	closehw $::hw
 


### PR DESCRIPTION
This is valid for newever versions - tested on Vitis 2021.1.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>