### PR TITLE
Add xilinx network support

### DIFF
--- a/network/xil_eth/i2c_access.c
+++ b/network/xil_eth/i2c_access.c
@@ -1,0 +1,420 @@
+/*
+ * Copyright (C) 2013 - 2019 Xilinx, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+/*****************************************************************************/
+/**
+ * @file i2c_lib.c
+ *
+ * This file contains library functions to initialize, control and access
+ * IIC devices.
+ *
+ * <pre>
+ * MODIFICATION HISTORY:
+ *
+ * Ver   Who  Date	 Changes
+ * ----- ---- -------- ---------------------------------------------------------
+ * 1.0   srt  10/19/13 Initial Version
+ *
+ * </pre>
+ *
+ ******************************************************************************/
+
+/***************************** Include Files *********************************/
+#include "xparameters.h"
+#if defined (__arm__) && !defined (ARMR5)
+#if XPAR_GIGE_PCS_PMA_SGMII_CORE_PRESENT == 1 || \
+	XPAR_GIGE_PCS_PMA_1000BASEX_CORE_PRESENT == 1
+#include "xil_exception.h"
+#include "xil_printf.h"
+#include "xiicps.h"
+#include "sleep.h"
+#include "xscugic.h"
+
+/************************** Constant Definitions *****************************/
+#define IIC_DEVICE_ID   XPAR_XIICPS_0_DEVICE_ID
+#define XIIC	XIicPs
+#define XIICCFG	XIicPs_Config
+#define I2cSetStatusHandler	XIicPs_SetStatusHandler
+#define	I2cLookupConfig		XIicPs_LookupConfig
+#define	I2cCfgInitialize	XIicPs_CfgInitialize
+#define INTC_DEVICE_ID	XPAR_SCUGIC_SINGLE_DEVICE_ID
+#define IIC_INTR_ID	XPAR_XIICPS_0_INTR
+#define INTC_HANDLER	XScuGic_InterruptHandler
+#define IIC_HANDLER	XIicPs_IntrHandler
+#define INTC	XScuGic
+#define IIC_SCLK_RATE           100000
+/**************************** Type Definitions *******************************/
+typedef struct {
+	XIIC I2cInstance;
+	INTC IntcInstance;
+	volatile u8 TransmitComplete;   /* Flag to check completion of Transmission */
+	volatile u8 ReceiveComplete;    /* Flag to check completion of Reception */
+	volatile u32 TotalErrorCount;
+} XIIC_LIB;
+/***************** Macros (Inline Functions) Definitions *********************/
+
+/************************** Function Prototypes ******************************/
+int I2cPhyWrite(XIIC_LIB *I2cLibPtr, u8 PhyAddr, u8 Reg, u16 Data, u16 SlaveAddr);
+int I2cPhyRead(XIIC_LIB *I2cLibPtr, u8 PhyAddr, u8 Reg, u16 *Data, u16 SlaveAddr);
+int I2cSetupHardware(XIIC_LIB *I2cLibPtr);
+int I2cWriteData(XIIC_LIB *I2cLibPtr, u8 *WrBuffer, u16 ByteCount, u16 SlaveAddr);
+int I2cReadData(XIIC_LIB *I2cLibPtr, u8 *RdBuffer, u16 ByteCount, u16 SlaveAddr);
+static int SetupInterruptSystem(XIIC_LIB *I2cLibPtr);
+static void StatusHandler(XIIC_LIB *I2cLibPtr, int Event);
+
+/************************* Global Definitions *****************************/
+
+/************************** Function Definitions *****************************/
+
+/*****************************************************************************/
+/**
+ * This function configures the IIC hardware.
+ *
+ * @param	I2cLibPtr contains a pointer to the instance of the IIC library
+ *
+ * @return	XST_SUCCESS if successful else XST_FAILURE.
+ *
+ ******************************************************************************/
+int I2cSetupHardware(XIIC_LIB *I2cLibPtr)
+{
+	int Status;
+	XIICCFG *ConfigPtr;
+	XIIC *I2cInstancePtr;
+
+	I2cInstancePtr = &I2cLibPtr->I2cInstance;
+
+	/*
+	 * Initialize the IIC driver so that it is ready to use.
+	 */
+	ConfigPtr = I2cLookupConfig(IIC_DEVICE_ID);
+	if (ConfigPtr == NULL) {
+		return XST_FAILURE;
+	}
+
+	Status = I2cCfgInitialize(I2cInstancePtr, ConfigPtr,
+			ConfigPtr->BaseAddress);
+	if (Status != XST_SUCCESS) {
+		return XST_FAILURE;
+	}
+
+	/*
+	 * GPIO Code to pull MUX out of reset.
+	 */
+	Xil_Out32(0xe000a204, 0x2000);
+	Xil_Out32(0xe000a208, 0x2000);
+	Xil_Out32(0xe000a040, 0x2000);
+
+	/*
+	 * Setup the Interrupt System.
+	 */
+	Status = SetupInterruptSystem(I2cLibPtr);
+	if (Status != XST_SUCCESS) {
+		return XST_FAILURE;
+	}
+
+	I2cSetStatusHandler(I2cInstancePtr, I2cLibPtr, (IIC_HANDLER) StatusHandler);
+
+	/*
+	 * Set the IIC serial clock rate.
+	 */
+	XIicPs_SetSClk(I2cInstancePtr, IIC_SCLK_RATE);
+
+	I2cLibPtr->TotalErrorCount = 0;
+	I2cLibPtr->TransmitComplete = FALSE;
+	I2cLibPtr->ReceiveComplete = FALSE;
+
+	return XST_SUCCESS;
+}
+
+/*****************************************************************************/
+/**
+ * This function writes data to the PHY.
+ *
+ * @param	I2cLibPtr contains a pointer to the instance of the IIC library
+ * @param 	PhyAddr is the address of PHY to be written
+ * @param	Reg is the register address to be written to
+ * @param 	Data is the pointer which contains the data to be written
+ * @param	SlaveAddr is the address of the slave we are sending to.
+ *
+ * @return	XST_SUCCESS if successful else XST_FAILURE.
+ *
+ ******************************************************************************/
+int I2cPhyWrite(XIIC_LIB *I2cLibPtr, u8 PhyAddr, u8 Reg, u16 Data, u16 SlaveAddr)
+{
+	int Status;
+	u8 WrBuffer[3];
+
+	WrBuffer[0] = Reg;
+	WrBuffer[1] = Data >> 8;
+	WrBuffer[2] = Data;
+
+	Status = I2cWriteData(I2cLibPtr, WrBuffer, 3, SlaveAddr);
+	if (Status != XST_SUCCESS) {
+		xil_printf("PhyWrite: Writing data failed\n\r");
+		return Status;
+	}
+
+	return Status;
+}
+
+/*****************************************************************************/
+/**
+ * This function reads data from the PHY.
+ *
+ * @param	I2cLibPtr contains a pointer to the instance of the IIC library
+ * @param 	PhyAddr is the address of PHY to be read from
+ * @param	Reg is the register address to be read from
+ * @param 	Data is the pointer which stores the data read
+ * @param	SlaveAddr is the address of the slave we are sending to.
+ *
+ * @return	XST_SUCCESS if successful else XST_FAILURE.
+ *
+ ******************************************************************************/
+int I2cPhyRead(XIIC_LIB *I2cLibPtr, u8 PhyAddr, u8 Reg, u16 *Data, u16 SlaveAddr)
+{
+	int Status;
+	u8 WrBuffer[2];
+	u8 RdBuffer[2];
+
+	WrBuffer[0] = Reg;
+
+	Status = I2cWriteData(I2cLibPtr, WrBuffer, 1, SlaveAddr);
+	if (Status != XST_SUCCESS) {
+		xil_printf("PhyWrite: Writing data failed\n\r");
+		return Status;
+	}
+
+	Status = I2cReadData(I2cLibPtr, RdBuffer, 2, SlaveAddr);
+	if (Status != XST_SUCCESS) {
+		xil_printf("PhyRead: Reading data failed\n\r");
+		return Status;
+	}
+
+	*Data = RdBuffer[0] << 8 | RdBuffer[1];
+
+	return Status;
+}
+
+/*****************************************************************************/
+/**
+ * This function writes a buffer of data to the IIC Device.
+ *
+ * @param	I2cLibPtr contains a pointer to the instance of the IIC library
+ * @param 	WrBuffer is the buffer which contains data to be written
+ * @param	ByteCount contains the number of bytes in the buffer to be
+ *			written.
+ * @param	SlaveAddr is the address of the slave we are sending to.
+ *
+ * @return	XST_SUCCESS if successful else XST_FAILURE.
+ *
+ ******************************************************************************/
+int I2cWriteData(XIIC_LIB *I2cLibPtr, u8 *WrBuffer, u16 ByteCount,
+		u16 SlaveAddr)
+{
+	XIIC *I2cInstancePtr;
+
+	I2cInstancePtr = &I2cLibPtr->I2cInstance;
+
+	I2cLibPtr->TransmitComplete = FALSE;
+
+	/*
+	 * Send the Data.
+	 */
+	XIicPs_MasterSend(I2cInstancePtr, WrBuffer, ByteCount, SlaveAddr);
+
+	/*
+	 * Wait for the entire buffer to be sent, letting the interrupt
+	 * processing work in the background, this function may get
+	 * locked up in this loop if the interrupts are not working
+	 * correctly.
+	 */
+	while (I2cLibPtr->TransmitComplete == FALSE) {
+		if (0 != I2cLibPtr->TotalErrorCount) {
+			xil_printf("I2cWriteData: Failed due to errors\n\r");
+			return XST_FAILURE;
+		}
+	}
+
+	/*
+	 * Wait until bus is idle to start another transfer.
+	 */
+	while (XIicPs_BusIsBusy(I2cInstancePtr));
+
+	return XST_SUCCESS;
+}
+
+/*****************************************************************************/
+/**
+ * This function read data from the IIC Device.
+ *
+ * @param	I2cLibPtr contains a pointer to the instance of the IIC library
+ * @param 	RdBuffer is the buffer into which data read
+ * @param	ByteCount contains the number of bytes in the buffer to be
+ *			written.
+ * @param	SlaveAddr is the address of the slave we are sending to.
+ *
+ * @return	XST_SUCCESS if successful else XST_FAILURE.
+ *
+ ******************************************************************************/
+int I2cReadData(XIIC_LIB *I2cLibPtr, u8 *RdBuffer, u16 ByteCount, u16 SlaveAddr)
+{
+	XIIC *I2cInstancePtr;
+
+	I2cInstancePtr = &I2cLibPtr->I2cInstance;
+
+	I2cLibPtr->ReceiveComplete = FALSE;
+
+	/*
+	 * Receive the Data.
+	 */
+	XIicPs_MasterRecv(I2cInstancePtr, RdBuffer, ByteCount, SlaveAddr);
+
+	while (I2cLibPtr->ReceiveComplete == FALSE) {
+		if (0 != I2cLibPtr->TotalErrorCount) {
+			xil_printf("I2cReadData: Failed due to errors %d\n\r",
+					I2cLibPtr->TotalErrorCount);
+			return XST_FAILURE;
+		}
+	}
+
+	/*
+	 * Wait until bus is idle to start another transfer.
+	 */
+	while (XIicPs_BusIsBusy(I2cInstancePtr))
+		;
+
+	return XST_SUCCESS;
+}
+
+/*****************************************************************************/
+/**
+ * This function setups the interrupt system so interrupts can occur for the
+ * IIC device. The function is application-specific since the actual system may
+ * or may not have an interrupt controller. The IIC device could be directly
+ * connected to a processor without an interrupt controller. The user should
+ * modify this function to fit the application.
+ *
+ * @param	IicInstPtr contains a pointer to the instance of the IIC device
+ *		which is going to be connected to the interrupt controller.
+ *
+ * @return	XST_SUCCESS if successful else XST_FAILURE.
+ *
+ * @note		None.
+ *
+ ******************************************************************************/
+static int SetupInterruptSystem(XIIC_LIB *I2cLibPtr)
+{
+	int Status;
+	XIIC *I2cInstancePtr;
+	INTC *IntcPtr;
+
+	I2cInstancePtr = &I2cLibPtr->I2cInstance;
+	IntcPtr = &I2cLibPtr->IntcInstance;
+
+	XScuGic_Config *IntcConfig;
+
+	/*
+	 * Initialize the interrupt controller driver so that it is ready to
+	 * use.
+	 */
+	IntcConfig = XScuGic_LookupConfig(INTC_DEVICE_ID);
+	if (NULL == IntcConfig) {
+		return XST_FAILURE;
+	}
+
+	Status = XScuGic_CfgInitialize(IntcPtr, IntcConfig,
+			IntcConfig->CpuBaseAddress);
+	if (Status != XST_SUCCESS) {
+		return XST_FAILURE;
+	}
+
+	XScuGic_SetPriorityTriggerType(IntcPtr, IIC_INTR_ID, 0xA0, 0x3);
+
+	/*
+	 * Connect the interrupt handler that will be called when an
+	 * interrupt occurs for the device.
+	 */
+	Status = XScuGic_Connect(IntcPtr, IIC_INTR_ID,
+			(Xil_InterruptHandler) XIicPs_MasterInterruptHandler,
+			I2cInstancePtr);
+	if (Status != XST_SUCCESS) {
+		return Status;
+	}
+
+	/*
+	 * Enable the interrupt for the IIC device.
+	 */
+	XScuGic_Enable(IntcPtr, IIC_INTR_ID);
+
+	/*
+	 * Initialize the exception table and register the interrupt
+	 * controller handler with the exception table
+	 */
+	Xil_ExceptionInit();
+
+	Xil_ExceptionRegisterHandler(XIL_EXCEPTION_ID_INT,
+			(Xil_ExceptionHandler) INTC_HANDLER, IntcPtr);
+
+	/* Enable non-critical exceptions */Xil_ExceptionEnable();
+
+	return XST_SUCCESS;
+}
+
+/*****************************************************************************/
+/**
+ * This Status handler is called asynchronously from an interrupt
+ * context and indicates the events that have occurred.
+ *
+ * @param	InstancePtr is a pointer to the IIC driver instance for which
+ *		the handler is being called for.
+ * @param	Event indicates the condition that has occurred.
+ *
+ * @return	None.
+ *
+ * @note		None.
+ *
+ ******************************************************************************/
+static void StatusHandler(XIIC_LIB *I2cLibPtr, int Event)
+{
+	/*
+	 * All of the data transfer has been finished.
+	 */
+	if (0 != (Event & XIICPS_EVENT_COMPLETE_RECV)) {
+		I2cLibPtr->ReceiveComplete = TRUE;
+	} else if (0 != (Event & XIICPS_EVENT_COMPLETE_SEND)) {
+		I2cLibPtr->TransmitComplete = TRUE;
+	} else if (0 == (Event & XIICPS_EVENT_SLAVE_RDY)) {
+		/*
+		 * If it is other interrupt but not slave ready interrupt, it is
+		 * an error.
+		 * Data was received with an error.
+		 */
+		I2cLibPtr->TotalErrorCount++;
+	}
+}
+#endif
+#endif

--- a/network/xil_eth/iic_phyreset.c
+++ b/network/xil_eth/iic_phyreset.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2016 - 2019 Xilinx, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+
+#include <stdio.h>
+
+#include "xparameters.h"
+#if defined (__arm__) || defined(__aarch64__)
+#include "xil_printf.h"
+#endif
+
+#ifdef XPS_BOARD_ZCU102
+#ifdef XPAR_XIICPS_0_DEVICE_ID
+#include "xiicps.h"
+
+#define BUF_LEN		10U
+
+#define IOEXPANDER1_ADDR		0x20U
+
+#define IIC_SCLK_RATE_IOEXP		400000
+
+#define CMD_CFG_0_REG		0x06U
+#define CMD_OUTPUT_0_REG	0x02U
+#define DATA_OUTPUT			0x0U
+
+#define DATA_COMMON_CFG		0xE0U
+#define DATA_GT_0000_CFG	0x00U
+
+XIicPs I2c0InstancePtr;
+
+int IicPhyReset(void)
+{
+
+	u8 WriteBuffer[BUF_LEN] = {0};
+	XIicPs_Config *I2c0CfgPtr;
+	int Status = XST_SUCCESS;
+
+	/* Initialize the IIC0 driver so that it is ready to use */
+	I2c0CfgPtr = XIicPs_LookupConfig(XPAR_XIICPS_0_DEVICE_ID);
+	if (I2c0CfgPtr == NULL) {
+		Status = XST_FAILURE;
+		return Status;
+	}
+
+	Status = XIicPs_CfgInitialize(&I2c0InstancePtr, I2c0CfgPtr,
+			I2c0CfgPtr->BaseAddress);
+	if (Status != XST_SUCCESS) {
+		Status = XST_FAILURE;
+		return Status;
+	}
+
+	/* Set the IIC serial clock rate */
+	XIicPs_SetSClk(&I2c0InstancePtr, IIC_SCLK_RATE_IOEXP);
+
+	/* Configure I/O pins as Output */
+	WriteBuffer[0] = CMD_CFG_0_REG;
+	WriteBuffer[1] = DATA_OUTPUT;
+	Status = XIicPs_MasterSendPolled(&I2c0InstancePtr,
+			WriteBuffer, 2, IOEXPANDER1_ADDR);
+	if (Status != XST_SUCCESS) {
+		Status = XST_FAILURE;
+		return Status;
+	}
+
+	/* Wait until bus is idle to start another transfer */
+	while (XIicPs_BusIsBusy(&I2c0InstancePtr));
+
+	/*
+	 * Deasserting I2C_MUX_RESETB
+	 * And GEM3 Resetb
+	 * Selecting lanes based on configuration
+	 */
+	WriteBuffer[0] = CMD_OUTPUT_0_REG;
+	/* gt0000 or no GT configuration */
+	WriteBuffer[1] = DATA_COMMON_CFG | DATA_GT_0000_CFG;
+
+	/* Send the Data */
+	Status = XIicPs_MasterSendPolled(&I2c0InstancePtr,
+			WriteBuffer, 2, IOEXPANDER1_ADDR);
+	if (Status != XST_SUCCESS) {
+		Status = XST_FAILURE;
+		return Status;
+	}
+
+	/* Wait until bus is idle */
+	while (XIicPs_BusIsBusy(&I2c0InstancePtr));
+
+	xil_printf("IIC PHY reset on ZCU102 successful \n\r");
+
+	return XST_SUCCESS;
+}
+#endif
+#endif

--- a/network/xil_eth/platform.c
+++ b/network/xil_eth/platform.c
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2009 - 2019 Xilinx, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+#if __MICROBLAZE__ || __PPC__
+#include "arch/cc.h"
+#include "platform.h"
+#include "platform_config.h"
+#include "xil_cache.h"
+#include "xparameters.h"
+#include "xintc.h"
+#include "xil_exception.h"
+#include "lwip/tcp.h"
+#include "netif/xadapter.h"
+#ifdef STDOUT_IS_16550
+#include "xuartns550_l.h"
+#endif
+
+#include "lwip/tcp.h"
+
+#if LWIP_DHCP==1
+volatile int dhcp_timoutcntr = 24;
+void dhcp_fine_tmr();
+void dhcp_coarse_tmr();
+#endif
+
+volatile int TcpFastTmrFlag = 0;
+volatile int TcpSlowTmrFlag = 0;
+
+extern struct netif *echo_netif;
+
+void
+timer_callback()
+{
+	static int DetectEthLinkStatus = 0;
+	/* we need to call tcp_fasttmr & tcp_slowtmr at intervals specified by lwIP.
+	 * It is not important that the timing is absoluetly accurate.
+	 */
+	static int odd = 1;
+#if LWIP_DHCP==1
+    static int dhcp_timer = 0;
+#endif
+	DetectEthLinkStatus++;
+	 TcpFastTmrFlag = 1;
+
+	odd = !odd;
+	if (odd) {
+
+#if LWIP_DHCP==1
+		dhcp_timer++;
+		dhcp_timoutcntr--;
+#endif
+		TcpSlowTmrFlag = 1;
+#if LWIP_DHCP==1
+		dhcp_fine_tmr();
+		if (dhcp_timer >= 120) {
+			dhcp_coarse_tmr();
+			dhcp_timer = 0;
+		}
+#endif
+	}
+
+	/* For detecting Ethernet phy link status periodically */
+	if (DetectEthLinkStatus == ETH_LINK_DETECT_INTERVAL) {
+		eth_link_detect(echo_netif);
+		DetectEthLinkStatus = 0;
+	}
+}
+
+static XIntc intc;
+
+void platform_setup_interrupts()
+{
+	XIntc *intcp;
+	intcp = &intc;
+
+	XIntc_Initialize(intcp, XPAR_INTC_0_DEVICE_ID);
+	XIntc_Start(intcp, XIN_REAL_MODE);
+
+	/* Start the interrupt controller */
+	XIntc_MasterEnable(XPAR_INTC_0_BASEADDR);
+
+#ifdef __PPC__
+	Xil_ExceptionInit();
+	Xil_ExceptionRegisterHandler(XIL_EXCEPTION_ID_INT,
+			(XExceptionHandler)XIntc_DeviceInterruptHandler,
+			(void*) XPAR_INTC_0_DEVICE_ID);
+#elif __MICROBLAZE__
+	microblaze_register_handler((XInterruptHandler)XIntc_InterruptHandler, intcp);
+#endif
+
+	platform_setup_timer();
+
+#ifdef XPAR_ETHERNET_MAC_IP2INTC_IRPT_MASK
+	/* Enable timer and EMAC interrupts in the interrupt controller */
+	XIntc_EnableIntr(XPAR_INTC_0_BASEADDR,
+#ifdef __MICROBLAZE__
+			PLATFORM_TIMER_INTERRUPT_MASK |
+#endif
+			XPAR_ETHERNET_MAC_IP2INTC_IRPT_MASK);
+#endif
+
+
+#ifdef XPAR_INTC_0_LLTEMAC_0_VEC_ID
+#ifdef __MICROBLAZE__
+	XIntc_Enable(intcp, PLATFORM_TIMER_INTERRUPT_INTR);
+#endif
+	XIntc_Enable(intcp, XPAR_INTC_0_LLTEMAC_0_VEC_ID);
+#endif
+
+
+#ifdef XPAR_INTC_0_AXIETHERNET_0_VEC_ID
+	XIntc_Enable(intcp, PLATFORM_TIMER_INTERRUPT_INTR);
+	XIntc_Enable(intcp, XPAR_INTC_0_AXIETHERNET_0_VEC_ID);
+#endif
+
+
+#ifdef XPAR_INTC_0_EMACLITE_0_VEC_ID
+#ifdef __MICROBLAZE__
+	XIntc_Enable(intcp, PLATFORM_TIMER_INTERRUPT_INTR);
+#endif
+	XIntc_Enable(intcp, XPAR_INTC_0_EMACLITE_0_VEC_ID);
+#endif
+
+
+}
+
+void
+enable_caches()
+{
+#ifdef __PPC__
+	Xil_ICacheEnableRegion(CACHEABLE_REGION_MASK);
+	Xil_DCacheEnableRegion(CACHEABLE_REGION_MASK);
+#elif __MICROBLAZE__
+#ifdef XPAR_MICROBLAZE_USE_ICACHE
+	Xil_ICacheEnable();
+#endif
+#ifdef XPAR_MICROBLAZE_USE_DCACHE
+	Xil_DCacheEnable();
+#endif
+#endif
+}
+
+void
+disable_caches()
+{
+	Xil_DCacheDisable();
+	Xil_ICacheDisable();
+}
+
+void init_platform()
+{
+	enable_caches();
+
+#ifdef STDOUT_IS_16550
+	XUartNs550_SetBaud(STDOUT_BASEADDR, XPAR_XUARTNS550_CLOCK_HZ, 9600);
+	XUartNs550_SetLineControlReg(STDOUT_BASEADDR, XUN_LCR_8_DATA_BITS);
+#endif
+
+	platform_setup_interrupts();
+}
+
+void cleanup_platform()
+{
+	disable_caches();
+}
+#endif

--- a/network/xil_eth/platform.h
+++ b/network/xil_eth/platform.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2009 - 2019 Xilinx, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef __PLATFORM_H_
+#define __PLATFORM_H_
+
+/* Platform timer is calibrated for 250 ms, so kept interval value 4 to call
+ * eth_link_detect() at every one second
+ */
+#define ETH_LINK_DETECT_INTERVAL 4
+
+void init_platform();
+void cleanup_platform();
+#ifdef __MICROBLAZE__
+void timer_callback();
+#endif
+#ifdef __PPC__
+void timer_callback();
+#endif
+void platform_setup_timer();
+void platform_enable_interrupts();
+#endif
+

--- a/network/xil_eth/platform_config.h
+++ b/network/xil_eth/platform_config.h
@@ -1,0 +1,6 @@
+#ifndef __PLATFORM_CONFIG_H_
+#define __PLATFORM_CONFIG_H_
+
+#include "app_config.h"
+
+#endif

--- a/network/xil_eth/platform_mb.c
+++ b/network/xil_eth/platform_mb.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2010 - 2019 Xilinx, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+/*
+ * platform_mb.c
+ *
+ * MicroBlaze platform specific functions.
+ */
+
+#ifdef __MICROBLAZE__
+
+#include "platform.h"
+#include "platform_config.h"
+
+#include "mb_interface.h"
+
+#include "xparameters.h"
+#include "xintc.h"
+#include "xtmrctr_l.h"
+
+void
+xadapter_timer_handler(void *p)
+{
+	timer_callback();
+
+	/* Load timer, clear interrupt bit */
+	XTmrCtr_SetControlStatusReg(PLATFORM_TIMER_BASEADDR, 0,
+			XTC_CSR_INT_OCCURED_MASK
+			| XTC_CSR_LOAD_MASK);
+
+	XTmrCtr_SetControlStatusReg(PLATFORM_TIMER_BASEADDR, 0,
+			XTC_CSR_ENABLE_TMR_MASK
+			| XTC_CSR_ENABLE_INT_MASK
+			| XTC_CSR_AUTO_RELOAD_MASK
+			| XTC_CSR_DOWN_COUNT_MASK);
+
+	XIntc_AckIntr(XPAR_INTC_0_BASEADDR, PLATFORM_TIMER_INTERRUPT_MASK);
+}
+
+#define MHZ (66)
+#define TIMER_TLR (25000000*((float)MHZ/100))
+
+void
+platform_setup_timer()
+{
+	/* set the number of cycles the timer counts before interrupting */
+	/* 100 Mhz clock => .01us for 1 clk tick. For 100ms, 10000000 clk ticks need to elapse  */
+	XTmrCtr_SetLoadReg(PLATFORM_TIMER_BASEADDR, 0, TIMER_TLR);
+
+	/* reset the timers, and clear interrupts */
+	XTmrCtr_SetControlStatusReg(PLATFORM_TIMER_BASEADDR, 0, XTC_CSR_INT_OCCURED_MASK | XTC_CSR_LOAD_MASK );
+
+	/* start the timers */
+	XTmrCtr_SetControlStatusReg(PLATFORM_TIMER_BASEADDR, 0,
+			XTC_CSR_ENABLE_TMR_MASK | XTC_CSR_ENABLE_INT_MASK
+			| XTC_CSR_AUTO_RELOAD_MASK | XTC_CSR_DOWN_COUNT_MASK);
+
+	/* Register Timer handler */
+	XIntc_RegisterHandler(XPAR_INTC_0_BASEADDR,
+			PLATFORM_TIMER_INTERRUPT_INTR,
+			(XInterruptHandler)xadapter_timer_handler,
+			0);
+}
+
+void platform_enable_interrupts()
+{
+	microblaze_enable_interrupts();
+}
+#endif

--- a/network/xil_eth/platform_ppc.c
+++ b/network/xil_eth/platform_ppc.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2010 - 2019 Xilinx, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+/*
+ * platform_ppc.c
+ *
+ * PPC specific functions to setup timer
+ */
+
+#ifdef __PPC__
+
+#include "platform.h"
+#include "platform_config.h"
+
+#include "xexception_l.h"
+#include "xil_exception.h"
+#include "xtime_l.h"
+#include "xparameters.h"
+
+#define MHZ 400
+#define PIT_INTERVAL (250*MHZ*1000)
+
+void
+xadapter_timer_handler(void *p)
+{
+	timer_callback();
+
+	XTime_TSRClearStatusBits(XREG_TSR_CLEAR_ALL);
+}
+
+void
+platform_setup_timer()
+{
+#ifdef XPAR_CPU_PPC440_CORE_CLOCK_FREQ_HZ
+	Xil_ExceptionRegisterHandler(XIL_EXCEPTION_ID_DEC_INT,
+			(XExceptionHandler)xadapter_timer_handler, NULL);
+
+	/* Set DEC to interrupt every 250 mseconds */
+	XTime_DECSetInterval(PIT_INTERVAL);
+	XTime_TSRClearStatusBits(XREG_TSR_CLEAR_ALL);
+	XTime_DECEnableAutoReload();
+	XTime_DECEnableInterrupt();
+#else
+	Xil_ExceptionRegisterHandler(XIL_EXCEPTION_ID_PIT_INT,
+			(XExceptionHandler)xadapter_timer_handler, NULL);
+
+	/* Set PIT to interrupt every 250 mseconds */
+	XTime_PITSetInterval(PIT_INTERVAL);
+	XTime_TSRClearStatusBits(XREG_TSR_CLEAR_ALL);
+	XTime_PITEnableAutoReload();
+	XTime_PITEnableInterrupt();
+#endif
+}
+
+void
+platform_enable_interrupts()
+{
+	Xil_ExceptionEnable();
+}
+#endif

--- a/network/xil_eth/platform_zynq.c
+++ b/network/xil_eth/platform_zynq.c
@@ -1,0 +1,236 @@
+/*
+ * Copyright (C) 2010 - 2019 Xilinx, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+/*
+* platform_zynq.c
+*
+* Zynq platform specific functions.
+*
+* 02/29/2012: UART initialization is removed. Timer initializations are
+* removed. All unnecessary include files and hash defines are removed.
+* 03/01/2013: Timer initialization is added back. Support for SI #692601 is
+* added in the timer callback. The SI #692601 refers to the following issue.
+*
+* The EmacPs has a HW bug on the Rx path for heavy Rx traffic.
+* Under heavy Rx traffic because of the HW bug there are times when the Rx path
+* becomes unresponsive. The workaround for it is to check for the Rx path for
+* traffic (by reading the stats registers regularly). If the stats register
+* does not increment for sometime (proving no Rx traffic), the function resets
+* the Rx data path.
+*
+* </pre>
+ */
+
+#ifdef __arm__
+
+#include "xparameters.h"
+#include "xparameters_ps.h"	/* defines XPAR values */
+#include "xil_cache.h"
+#include "xscugic.h"
+#include "lwip/tcp.h"
+#include "xil_printf.h"
+#include "platform.h"
+#include "platform_config.h"
+#include "netif/xadapter.h"
+#ifdef PLATFORM_ZYNQ
+#include "xscutimer.h"
+
+#define INTC_DEVICE_ID		XPAR_SCUGIC_SINGLE_DEVICE_ID
+#define TIMER_DEVICE_ID		XPAR_SCUTIMER_DEVICE_ID
+#define INTC_BASE_ADDR		XPAR_SCUGIC_0_CPU_BASEADDR
+#define INTC_DIST_BASE_ADDR	XPAR_SCUGIC_0_DIST_BASEADDR
+#define TIMER_IRPT_INTR		XPAR_SCUTIMER_INTR
+
+#define RESET_RX_CNTR_LIMIT	400
+
+void tcp_fasttmr(void);
+void tcp_slowtmr(void);
+
+static XScuTimer TimerInstance;
+
+#ifndef USE_SOFTETH_ON_ZYNQ
+static int ResetRxCntr = 0;
+#endif
+
+extern struct netif *echo_netif;
+
+volatile int TcpFastTmrFlag = 0;
+volatile int TcpSlowTmrFlag = 0;
+
+#if LWIP_DHCP==1
+volatile int dhcp_timoutcntr = 24;
+void dhcp_fine_tmr();
+void dhcp_coarse_tmr();
+#endif
+
+void
+timer_callback(XScuTimer * TimerInstance)
+{
+	static int DetectEthLinkStatus = 0;
+	/* we need to call tcp_fasttmr & tcp_slowtmr at intervals specified
+	 * by lwIP. It is not important that the timing is absoluetly accurate.
+	 */
+	static int odd = 1;
+#if LWIP_DHCP==1
+    static int dhcp_timer = 0;
+#endif
+	DetectEthLinkStatus++;
+	 TcpFastTmrFlag = 1;
+
+	odd = !odd;
+#ifndef USE_SOFTETH_ON_ZYNQ
+	ResetRxCntr++;
+#endif
+	if (odd) {
+#if LWIP_DHCP==1
+		dhcp_timer++;
+		dhcp_timoutcntr--;
+#endif
+		TcpSlowTmrFlag = 1;
+#if LWIP_DHCP==1
+		dhcp_fine_tmr();
+		if (dhcp_timer >= 120) {
+			dhcp_coarse_tmr();
+			dhcp_timer = 0;
+		}
+#endif
+	}
+
+	/* For providing an SW alternative for the SI #692601. Under heavy
+	 * Rx traffic if at some point the Rx path becomes unresponsive, the
+	 * following API call will ensures a SW reset of the Rx path. The
+	 * API xemacpsif_resetrx_on_no_rxdata is called every 100 milliseconds.
+	 * This ensures that if the above HW bug is hit, in the worst case,
+	 * the Rx path cannot become unresponsive for more than 100
+	 * milliseconds.
+	 */
+#ifndef USE_SOFTETH_ON_ZYNQ
+	if (ResetRxCntr >= RESET_RX_CNTR_LIMIT) {
+		xemacpsif_resetrx_on_no_rxdata(echo_netif);
+		ResetRxCntr = 0;
+	}
+#endif
+	/* For detecting Ethernet phy link status periodically */
+	if (DetectEthLinkStatus == ETH_LINK_DETECT_INTERVAL) {
+		eth_link_detect(echo_netif);
+		DetectEthLinkStatus = 0;
+	}
+
+	XScuTimer_ClearInterruptStatus(TimerInstance);
+}
+
+void platform_setup_timer(void)
+{
+	int Status = XST_SUCCESS;
+	XScuTimer_Config *ConfigPtr;
+	int TimerLoadValue = 0;
+
+	ConfigPtr = XScuTimer_LookupConfig(TIMER_DEVICE_ID);
+	Status = XScuTimer_CfgInitialize(&TimerInstance, ConfigPtr,
+			ConfigPtr->BaseAddr);
+	if (Status != XST_SUCCESS) {
+
+		xil_printf("In %s: Scutimer Cfg initialization failed...\r\n",
+		__func__);
+		return;
+	}
+
+	Status = XScuTimer_SelfTest(&TimerInstance);
+	if (Status != XST_SUCCESS) {
+		xil_printf("In %s: Scutimer Self test failed...\r\n",
+		__func__);
+		return;
+
+	}
+
+	XScuTimer_EnableAutoReload(&TimerInstance);
+	/*
+	 * Set for 250 milli seconds timeout.
+	 */
+	TimerLoadValue = XPAR_CPU_CORTEXA9_0_CPU_CLK_FREQ_HZ / 8;
+
+	XScuTimer_LoadTimer(&TimerInstance, TimerLoadValue);
+	return;
+}
+
+void platform_setup_interrupts(void)
+{
+	Xil_ExceptionInit();
+
+	XScuGic_DeviceInitialize(INTC_DEVICE_ID);
+
+	/*
+	 * Connect the interrupt controller interrupt handler to the hardware
+	 * interrupt handling logic in the processor.
+	 */
+	Xil_ExceptionRegisterHandler(XIL_EXCEPTION_ID_IRQ_INT,
+			(Xil_ExceptionHandler)XScuGic_DeviceInterruptHandler,
+			(void *)INTC_DEVICE_ID);
+	/*
+	 * Connect the device driver handler that will be called when an
+	 * interrupt for the device occurs, the handler defined above performs
+	 * the specific interrupt processing for the device.
+	 */
+	XScuGic_RegisterHandler(INTC_BASE_ADDR, TIMER_IRPT_INTR,
+					(Xil_ExceptionHandler)timer_callback,
+					(void *)&TimerInstance);
+	/*
+	 * Enable the interrupt for scu timer.
+	 */
+	XScuGic_EnableIntr(INTC_DIST_BASE_ADDR, TIMER_IRPT_INTR);
+
+	return;
+}
+
+void platform_enable_interrupts()
+{
+	/*
+	 * Enable non-critical exceptions.
+	 */
+	Xil_ExceptionEnableMask(XIL_EXCEPTION_IRQ);
+	XScuTimer_EnableInterrupt(&TimerInstance);
+	XScuTimer_Start(&TimerInstance);
+	return;
+}
+
+void init_platform()
+{
+	platform_setup_timer();
+	platform_setup_interrupts();
+
+	return;
+}
+
+void cleanup_platform()
+{
+	Xil_ICacheDisable();
+	Xil_DCacheDisable();
+	return;
+}
+#endif
+#endif
+

--- a/network/xil_eth/platform_zynqmp.c
+++ b/network/xil_eth/platform_zynqmp.c
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2015 - 2019 Xilinx, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+/*
+* platform_zynqmp.c
+*
+* ZynqMP platform specific functions.
+*
+*
+* </pre>
+ */
+
+#if defined (__arm__) || defined (__aarch64__)
+
+#include "xparameters.h"
+#include "xparameters_ps.h"	/* defines XPAR values */
+#include "xil_cache.h"
+#include "xscugic.h"
+#include "lwip/tcp.h"
+#include "xil_printf.h"
+#include "platform.h"
+#include "platform_config.h"
+#include "netif/xadapter.h"
+#ifdef PLATFORM_ZYNQMP
+#include "xttcps.h"
+
+#define INTC_DEVICE_ID		XPAR_SCUGIC_SINGLE_DEVICE_ID
+#define TIMER_DEVICE_ID		XPAR_XTTCPS_0_DEVICE_ID
+#define TIMER_IRPT_INTR		XPAR_XTTCPS_0_INTR
+#define INTC_BASE_ADDR		XPAR_SCUGIC_0_CPU_BASEADDR
+#define INTC_DIST_BASE_ADDR	XPAR_SCUGIC_0_DIST_BASEADDR
+
+#define PLATFORM_TIMER_INTR_RATE_HZ (4)
+
+static XTtcPs TimerInstance;
+static XInterval Interval;
+static u8 Prescaler;
+
+volatile int TcpFastTmrFlag = 0;
+volatile int TcpSlowTmrFlag = 0;
+
+#if LWIP_DHCP==1
+volatile int dhcp_timoutcntr = 24;
+void dhcp_fine_tmr();
+void dhcp_coarse_tmr();
+#endif
+
+extern struct netif *echo_netif;
+
+void platform_clear_interrupt( XTtcPs * TimerInstance );
+
+void
+timer_callback(XTtcPs * TimerInstance)
+{
+	static int DetectEthLinkStatus = 0;
+	/* we need to call tcp_fasttmr & tcp_slowtmr at intervals specified
+	 * by lwIP. It is not important that the timing is absoluetly accurate.
+	 */
+	static int odd = 1;
+#if LWIP_DHCP==1
+    static int dhcp_timer = 0;
+#endif
+	DetectEthLinkStatus++;
+    TcpFastTmrFlag = 1;
+	odd = !odd;
+	if (odd) {
+#if LWIP_DHCP==1
+		dhcp_timer++;
+		dhcp_timoutcntr--;
+#endif
+		TcpSlowTmrFlag = 1;
+#if LWIP_DHCP==1
+		dhcp_fine_tmr();
+		if (dhcp_timer >= 120) {
+			dhcp_coarse_tmr();
+			dhcp_timer = 0;
+		}
+#endif
+	}
+
+	/* For detecting Ethernet phy link status periodically */
+	if (DetectEthLinkStatus == ETH_LINK_DETECT_INTERVAL) {
+		eth_link_detect(echo_netif);
+		DetectEthLinkStatus = 0;
+	}
+
+	platform_clear_interrupt(TimerInstance);
+}
+
+void platform_setup_timer(void)
+{
+	int Status;
+	XTtcPs * Timer = &TimerInstance;
+	XTtcPs_Config *Config;
+
+
+	Config = XTtcPs_LookupConfig(TIMER_DEVICE_ID);
+
+	Status = XTtcPs_CfgInitialize(Timer, Config, Config->BaseAddress);
+	if (Status != XST_SUCCESS) {
+		xil_printf("In %s: Timer Cfg initialization failed...\r\n",
+				__func__);
+				return;
+	}
+	XTtcPs_SetOptions(Timer, XTTCPS_OPTION_INTERVAL_MODE | XTTCPS_OPTION_WAVE_DISABLE);
+	XTtcPs_CalcIntervalFromFreq(Timer, PLATFORM_TIMER_INTR_RATE_HZ, &Interval, &Prescaler);
+	XTtcPs_SetInterval(Timer, Interval);
+	XTtcPs_SetPrescaler(Timer, Prescaler);
+}
+
+void platform_clear_interrupt( XTtcPs * TimerInstance )
+{
+	u32 StatusEvent;
+
+	StatusEvent = XTtcPs_GetInterruptStatus(TimerInstance);
+	XTtcPs_ClearInterruptStatus(TimerInstance, StatusEvent);
+}
+
+void platform_setup_interrupts(void)
+{
+	Xil_ExceptionInit();
+
+	XScuGic_DeviceInitialize(INTC_DEVICE_ID);
+
+	/*
+	 * Connect the interrupt controller interrupt handler to the hardware
+	 * interrupt handling logic in the processor.
+	 */
+	Xil_ExceptionRegisterHandler(XIL_EXCEPTION_ID_IRQ_INT,
+			(Xil_ExceptionHandler)XScuGic_DeviceInterruptHandler,
+			(void *)INTC_DEVICE_ID);
+	/*
+	 * Connect the device driver handler that will be called when an
+	 * interrupt for the device occurs, the handler defined above performs
+	 * the specific interrupt processing for the device.
+	 */
+	XScuGic_RegisterHandler(INTC_BASE_ADDR, TIMER_IRPT_INTR,
+					(Xil_ExceptionHandler)timer_callback,
+					(void *)&TimerInstance);
+	/*
+	 * Enable the interrupt for scu timer.
+	 */
+	XScuGic_EnableIntr(INTC_DIST_BASE_ADDR, TIMER_IRPT_INTR);
+
+	return;
+}
+
+void platform_enable_interrupts()
+{
+	/*
+	 * Enable non-critical exceptions.
+	 */
+	Xil_ExceptionEnableMask(XIL_EXCEPTION_IRQ);
+	XScuGic_EnableIntr(INTC_DIST_BASE_ADDR, TIMER_IRPT_INTR);
+	XTtcPs_EnableInterrupts(&TimerInstance, XTTCPS_IXR_INTERVAL_MASK);
+	XTtcPs_Start(&TimerInstance);
+	return;
+}
+
+void init_platform()
+{
+	platform_setup_timer();
+	platform_setup_interrupts();
+
+	return;
+}
+
+void cleanup_platform()
+{
+	Xil_ICacheDisable();
+	Xil_DCacheDisable();
+	return;
+}
+#endif
+#endif

--- a/network/xil_eth/sfp.c
+++ b/network/xil_eth/sfp.c
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2013 - 2019 Xilinx, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+/*****************************************************************************/
+/**
+* @file sfp.c
+*
+* This file programs sfp phy chip.
+*
+* <pre>
+* MODIFICATION HISTORY:
+*
+* Ver   Who  Date	 Changes
+* ----- ---- -------- ---------------------------------------------------------
+* 1.0   srt  10/19/13 Initial Version
+*
+* </pre>
+*
+******************************************************************************/
+
+/***************************** Include Files *********************************/
+#include "xparameters.h"
+#if defined (__arm__) && !defined (ARMR5)
+#if XPAR_GIGE_PCS_PMA_SGMII_CORE_PRESENT == 1 || \
+	XPAR_GIGE_PCS_PMA_1000BASEX_CORE_PRESENT == 1
+#include "xil_printf.h"
+#include "xiicps.h"
+#include "sleep.h"
+#include "xscugic.h"
+
+/************************** Constant Definitions *****************************/
+#define IIC_SLAVE_ADDR		0x56
+#define IIC_MUX_ADDRESS		0x74
+#define IIC_CHANNEL_ADDRESS	0x01
+
+#define XIIC	XIicPs
+#define INTC	XScuGic
+/**************************** Type Definitions *******************************/
+typedef struct {
+	XIIC I2cInstance;
+	INTC IntcInstance;
+	volatile u8 TransmitComplete;   /* Flag to check completion of Transmission */
+	volatile u8 ReceiveComplete;    /* Flag to check completion of Reception */
+	volatile u32 TotalErrorCount;
+} XIIC_LIB;
+/***************** Macros (Inline Functions) Definitions *********************/
+
+/************************** Function Prototypes ******************************/
+int I2cWriteData(XIIC_LIB *I2cLibPtr, u8 *WrBuffer, u16 ByteCount, u16 SlaveAddr);
+int I2cReadData(XIIC_LIB *I2cLibPtr, u8 *RdBuffer, u16 ByteCount, u16 SlaveAddr);
+int I2cPhyWrite(XIIC_LIB *I2cLibPtr, u8 PhyAddr, u8 Reg, u16 Data, u16 SlaveAddr);
+int I2cPhyRead(XIIC_LIB *I2cLibPtr, u8 PhyAddr, u8 Reg, u16 *Data, u16 SlaveAddr);
+int I2cSetupHardware(XIIC_LIB *I2cLibPtr);
+/************************** Function Definitions *****************************/
+
+/*****************************************************************************/
+/**
+ * This function initializes ZC706 MUX.
+ *
+ * @param	I2cLibPtr contains a pointer to the instance of the IIC library
+ *
+ * @return	XST_SUCCESS if successful else XST_FAILURE.
+ *
+ ******************************************************************************/
+int ZC706MuxInit(XIIC_LIB *I2cLibInstancePtr)
+{
+	u8 WrBuffer;
+	int Status;
+
+	WrBuffer = IIC_CHANNEL_ADDRESS;
+
+	Status = I2cWriteData(I2cLibInstancePtr, &WrBuffer, 1, IIC_MUX_ADDRESS);
+	if (Status != XST_SUCCESS) {
+		xil_printf("SFP_PHY: Writing failed\n\r");
+		return XST_FAILURE;
+ 	}
+	return XST_SUCCESS;
+}
+
+/*****************************************************************************/
+/**
+ * This function program SFP PHY.
+ *
+ * @return	XST_SUCCESS if successful else XST_FAILURE.
+ *
+ ******************************************************************************/
+int ProgramSfpPhy(void)
+{
+	XIIC_LIB I2cLibInstance;
+	int Status;
+	u8 WrBuffer[2];
+	u16 phy_read_val;
+
+	Status = I2cSetupHardware(&I2cLibInstance);
+	if (Status != XST_SUCCESS) {
+		xil_printf("Fail!!!\n\r");
+		xil_printf("SFP_PHY: Configuring HW failed\n\r");
+		return XST_FAILURE;
+	}
+	Status = ZC706MuxInit(&I2cLibInstance);
+	if (Status != XST_SUCCESS) {
+		xil_printf("SFP_PHY: Mux Init failed\n\r");
+		return XST_FAILURE;
+	}
+
+	WrBuffer[0] = 0;
+	Status = I2cWriteData(&I2cLibInstance, WrBuffer, 1, IIC_SLAVE_ADDR);
+	if (Status != XST_SUCCESS) {
+		xil_printf("SFP_PHY: Writing failed\n\r");
+		return XST_FAILURE;
+	}
+
+#if XPAR_GIGE_PCS_PMA_1000BASEX_CORE_PRESENT == 1
+	/* Enabling 1000BASEX */
+	I2cPhyWrite(&I2cLibInstance, IIC_SLAVE_ADDR, 0x1B, 0x9088, IIC_SLAVE_ADDR);
+#else
+	/* Enabling SGMII */
+	I2cPhyWrite(&I2cLibInstance, IIC_SLAVE_ADDR, 0x1B, 0x9084, IIC_SLAVE_ADDR);
+#endif
+
+	/* Apply Soft Reset */
+	I2cPhyWrite(&I2cLibInstance, IIC_SLAVE_ADDR, 0x00, 0x9140, IIC_SLAVE_ADDR);
+
+	/* Enable 1000BaseT Full Duplex capabilities */
+	I2cPhyWrite(&I2cLibInstance, IIC_SLAVE_ADDR, 0x09, 0x0E00, IIC_SLAVE_ADDR);
+
+	/* Apply Soft Reset */
+	I2cPhyWrite(&I2cLibInstance, IIC_SLAVE_ADDR, 0x00, 0x9140, IIC_SLAVE_ADDR);
+
+	/* Advertise 10/100 Capabilities else change the capabilities */
+	I2cPhyWrite(&I2cLibInstance, IIC_SLAVE_ADDR, 0x04, 0x0141, IIC_SLAVE_ADDR);
+
+	/* Apply Soft Reset */
+	I2cPhyWrite(&I2cLibInstance, IIC_SLAVE_ADDR, 0x00, 0x9140, IIC_SLAVE_ADDR);
+
+	/* Apply Soft Reset */
+	I2cPhyWrite(&I2cLibInstance, IIC_SLAVE_ADDR, 0x00, 0x9140, IIC_SLAVE_ADDR);
+
+	I2cPhyWrite(&I2cLibInstance, IIC_SLAVE_ADDR, 0x10, 0xF079, IIC_SLAVE_ADDR);
+	/* Apply Soft Reset */
+	I2cPhyWrite(&I2cLibInstance, IIC_SLAVE_ADDR, 0x00, 0x9140, IIC_SLAVE_ADDR);
+
+	I2cPhyWrite(&I2cLibInstance, IIC_SLAVE_ADDR, 0x16, 0x0001, IIC_SLAVE_ADDR);
+	I2cPhyWrite(&I2cLibInstance, IIC_SLAVE_ADDR, 0x00, 0x9140, IIC_SLAVE_ADDR);
+	I2cPhyWrite(&I2cLibInstance, IIC_SLAVE_ADDR, 0x00, 0x9340, IIC_SLAVE_ADDR);
+	usleep(1);
+
+	I2cPhyWrite(&I2cLibInstance, IIC_SLAVE_ADDR, 0x16, 0x0, IIC_SLAVE_ADDR);
+	phy_read_val = 0x0;
+
+	while((phy_read_val & 0x0C00) != 0x0C00) {
+		I2cPhyRead(&I2cLibInstance, IIC_SLAVE_ADDR, 0x11, &phy_read_val, IIC_SLAVE_ADDR);
+	}
+	usleep(1);
+
+	I2cPhyWrite(&I2cLibInstance, IIC_SLAVE_ADDR, 0x16, 0x0, IIC_SLAVE_ADDR);
+	I2cPhyRead(&I2cLibInstance, IIC_SLAVE_ADDR, 0x11, &phy_read_val, IIC_SLAVE_ADDR);
+	I2cPhyWrite(&I2cLibInstance, IIC_SLAVE_ADDR, 0x16, 0x0001, IIC_SLAVE_ADDR);
+
+	/* configure speed */
+	I2cPhyWrite(&I2cLibInstance, IIC_SLAVE_ADDR, 0x14, 0x0c61, IIC_SLAVE_ADDR);
+	I2cPhyWrite(&I2cLibInstance, IIC_SLAVE_ADDR, 0x00, 0x9340, IIC_SLAVE_ADDR);
+	I2cPhyWrite(&I2cLibInstance, IIC_SLAVE_ADDR, 0x16, 0x0, IIC_SLAVE_ADDR);
+
+	return XST_SUCCESS;
+}
+#endif
+#endif

--- a/network/xil_eth/si5324.c
+++ b/network/xil_eth/si5324.c
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2013 - 2019 Xilinx, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ */
+/*****************************************************************************/
+/**
+* @file si5324.c
+*
+* This file programs si5324 chip which generates clock for the peripherals.
+*
+* Please refer to Si5324 Datasheet for more information
+* http://www.silabs.com/Support%20Documents/TechnicalDocs/Si5324.pdf
+*
+* Tested on Zynq ZC706 platform
+*
+* <pre>
+* MODIFICATION HISTORY:
+*
+* Ver   Who  Date	 Changes
+* ----- ---- -------- ---------------------------------------------------------
+* 1.0   srt  10/19/13 Initial Version
+*
+* </pre>
+*
+******************************************************************************/
+
+/***************************** Include Files *********************************/
+#include "xparameters.h"
+#if defined (__arm__) && !defined (ARMR5)
+#if XPAR_GIGE_PCS_PMA_SGMII_CORE_PRESENT == 1 || \
+	XPAR_GIGE_PCS_PMA_1000BASEX_CORE_PRESENT == 1
+#include "xil_printf.h"
+#include "xiicps.h"
+#include "sleep.h"
+#include "xscugic.h"
+/************************** Constant Definitions *****************************/
+#define IIC_SLAVE_ADDR		0x68
+#define IIC_MUX_ADDRESS		0x74
+#define IIC_CHANNEL_ADDRESS	0x10
+
+#define XIIC	XIicPs
+#define INTC	XScuGic
+/**************************** Type Definitions *******************************/
+typedef struct SI324Info
+{
+	u32 RegIndex;	/* Register Number */
+	u32 Value;		/* Value to be Written */
+} SI324Info;
+
+typedef struct {
+	XIIC I2cInstance;
+	INTC IntcInstance;
+	volatile u8 TransmitComplete;   /* Flag to check completion of Transmission */
+	volatile u8 ReceiveComplete;    /* Flag to check completion of Reception */
+	volatile u32 TotalErrorCount;
+} XIIC_LIB;
+/************************** Function Prototypes *****************************/
+int I2cWriteData(XIIC_LIB *I2cLibPtr, u8 *WrBuffer, u16 ByteCount, u16 SlaveAddr);
+int I2cReadData(XIIC_LIB *I2cLibPtr, u8 *RdBuffer, u16 ByteCount, u16 SlaveAddr);
+int I2cPhyWrite(XIIC_LIB *I2cLibPtr, u8 PhyAddr, u8 Reg, u16 Data, u16 SlaveAddr);
+int I2cPhyRead(XIIC_LIB *I2cLibPtr, u8 PhyAddr, u8 Reg, u16 *Data, u16 SlaveAddr);
+int I2cSetupHardware(XIIC_LIB *I2cLibPtr);
+/************************* Global Definitions *****************************/
+/*
+ * These configuration values generates 125MHz clock
+ * For more information please refer to Si5324 Datasheet.
+ */
+SI324Info InitTable[] = {
+		{  0, 0x54},	/* Register 0 */
+		{  1, 0xE4},	/* Register 1 */
+		{  2, 0x12},	/* Register 2 */
+		{  3, 0x15},	/* Register 3 */
+		{  4, 0x92},	/* Register 4 */
+		{  5, 0xed},	/* Register 5 */
+		{  6, 0x2d},	/* Register 6 */
+		{  7, 0x2a},	/* Register 7 */
+		{  8, 0x00},	/* Register 8 */
+		{  9, 0xc0},	/* Register 9 */
+		{ 10, 0x08},	/* Register 10 */
+		{ 11, 0x40},	/* Register 11 */
+		{ 19, 0x29},	/* Register 19 */
+		{ 20, 0x3e},	/* Register 20 */
+		{ 21, 0xff},	/* Register 21 */
+		{ 22, 0xdf},	/* Register 22 */
+		{ 23, 0x1f},	/* Register 23 */
+		{ 24, 0x3f},	/* Register 24 */
+		{ 25, 0x60},	/* Register 25 */
+		{ 31, 0x00},	/* Register 31 */
+		{ 32, 0x00},	/* Register 32 */
+		{ 33, 0x05},	/* Register 33 */
+		{ 34, 0x00},	/* Register 34 */
+		{ 35, 0x00},	/* Register 35 */
+		{ 36, 0x05},	/* Register 36 */
+		{ 40, 0xc2},	/* Register 40 */
+		{ 41, 0x22},	/* Register 41 */
+		{ 42, 0xdf},	/* Register 42 */
+		{ 43, 0x00},	/* Register 43 */
+		{ 44, 0x77},	/* Register 44 */
+		{ 45, 0x0b},	/* Register 45 */
+		{ 46, 0x00},	/* Register 46 */
+		{ 47, 0x77},	/* Register 47 */
+		{ 48, 0x0b},	/* Register 48 */
+		{ 55, 0x00},	/* Register 55 */
+		{131, 0x1f},	/* Register 131 */
+		{132, 0x02},	/* Register 132 */
+		{137, 0x01},	/* Register 137 */
+		{138, 0x0f},	/* Register 138 */
+		{139, 0xff},	/* Register 139 */
+		{142, 0x00},	/* Register 142 */
+		{143, 0x00},	/* Register 143 */
+		{136, 0x40}		/* Register 136 */
+};
+
+/************************** Function Definitions *****************************/
+int MuxInit(XIIC_LIB *I2cLibInstancePtr)
+{
+	u8 WrBuffer[0];
+	int Status;
+
+	WrBuffer[0] = IIC_CHANNEL_ADDRESS;
+
+	Status = I2cWriteData(I2cLibInstancePtr,
+				WrBuffer, 1, IIC_MUX_ADDRESS);
+	if (Status != XST_SUCCESS) {
+		xil_printf("Si5324: Writing failed\n\r");
+		return XST_FAILURE;
+	}
+
+	return XST_SUCCESS;
+}
+
+int ProgramSi5324(void)
+{
+	XIIC_LIB I2cLibInstance;
+	int Index;
+	int Status;
+	u8 WrBuffer[2];
+
+	Status = I2cSetupHardware(&I2cLibInstance);
+	if (Status != XST_SUCCESS) {
+		xil_printf("Si5324: Configuring HW failed\n\r");
+		return XST_FAILURE;
+	}
+
+	Status = MuxInit(&I2cLibInstance);
+	if (Status != XST_SUCCESS) {
+		xil_printf("Si5324: Mux Init failed\n\r");
+		return XST_FAILURE;
+	}
+
+	for (Index = 0; Index < sizeof(InitTable)/8; Index++) {
+		WrBuffer[0] = InitTable[Index].RegIndex;
+		WrBuffer[1] = InitTable[Index].Value;
+
+		Status = I2cWriteData(&I2cLibInstance, WrBuffer, 2, IIC_SLAVE_ADDR);
+		if (Status != XST_SUCCESS) {
+			xil_printf("Si5324: Writing failed\n\r");
+			return XST_FAILURE;
+		}
+	}
+	return XST_SUCCESS;
+}
+#endif
+#endif

--- a/network/xil_eth/xil_eth.c
+++ b/network/xil_eth/xil_eth.c
@@ -1,0 +1,654 @@
+/***************************************************************************//**
+ * @file xil_eth.c
+ * @brief Implementation of ethernet functions for network.
+ * @author Mihail Chindris (mihail.chindris@analog.com)
+ ********************************************************************************
+ * Copyright 2021(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in
+ * the documentation and/or other materials provided with the
+ * distribution.
+ * - Neither the name of Analog Devices, Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ * - The use of this software may or may not infringe the patent rights
+ * of one or more patent holders. This license does not release you
+ * from the requirement that you obtain separate licenses from these
+ * patent holders to use this software.
+ * - Use of the software either in source or binary form, must be run
+ * on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#ifdef XILINX_PLATFORM
+
+#include <string.h>
+
+#include "lwip/dhcp.h"
+#include "lwip/init.h"
+#include "lwip/tcp.h"
+#include "netif/xadapter.h"
+#include "platform.h"
+#include "platform_config.h"
+#include "xil_cache.h"
+#include "xil_eth.h"
+
+#include "no-os/error.h"
+#include "no-os/print_log.h"
+#include "no-os/util.h"
+
+/*
+ * TODO: I would move this to xil_eth_desc but this implies modify the default
+ * eth files. I think this would be a better way. But for faster development
+ * are kept as globals.
+ */
+extern volatile int TcpFastTmrFlag;
+extern volatile int TcpSlowTmrFlag;
+extern volatile int dhcp_timoutcntr;
+struct netif *echo_netif;
+
+static void xil_eth_config_noos_if(struct xil_eth_desc *desc);
+
+/* Internal structure describing a connection */
+struct socket_desc {
+	enum {
+		/* Available to be used */
+		SOCKET_UNUSED,
+		/* Connection set as server bound to a port */
+		SOCKET_LISTENING,
+		/* Connection set as server and accepting incomming conns  */
+		SOCKET_ACCEPTING,
+		/* Accept callback received, waiting call to accept function */
+		SOCKET_WAITING_ACCEPT,
+		/* Socket is connected to remote */
+		SOCKET_CONNECTED,
+		/* Socked has been disconnected. */
+		SOCKET_DISCONNECTED,
+	} state;
+	/* Xilinx structure of connection state and data */
+	struct tcp_pcb *pcb;
+	/* List of buffers to be read */
+	struct pbuf *p;
+	/* Inedex for p->payload. To keep track of read bytes */
+	uint32_t p_idx;
+	/* Reference to ethernet structure */
+	struct xil_eth_desc *desc;
+	/* Current socket ID. Same as index in sockets */
+	uint32_t id;
+};
+
+struct xil_eth_desc {
+	/* Structure with network operations */
+	struct network_interface noos_net;
+	/* Internal xilinx network structure */
+	struct netif netif;
+	/* Array of all connections. Used or not used */
+	struct socket_desc sockets[MAX_SOCKETS];
+};
+
+/* Get socket pointer from socket id */
+static struct socket_desc *_get_sock(struct xil_eth_desc *desc, uint32_t id)
+{
+	if (id >= MAX_SOCKETS)
+		return NULL;
+
+	return &desc->sockets[id];
+}
+
+/* Get first socket with state SOCKET_UNUSED. Then, set id with index */
+static int32_t _get_unused_socket(struct xil_eth_desc *desc, uint32_t *id)
+{
+	uint32_t i;
+
+	for (i = 0; i < MAX_SOCKETS; i++)
+		if (desc->sockets[i].state == SOCKET_UNUSED) {
+			*id = i;
+			desc->sockets[i].state = SOCKET_DISCONNECTED;
+
+			return SUCCESS;
+		}
+
+	/* All the available connections are used */
+	return -ENOMEM;
+}
+
+/* Mark socket as SOCKET_UNUSED. */
+static void _release_socket(struct xil_eth_desc *desc, uint32_t id)
+{
+	struct socket_desc *sock = _get_sock(desc, id);
+
+	sock->state = SOCKET_UNUSED;
+}
+
+/*
+ * Implement with IPV4 and DHCP enabled by default.
+ * For more configs see lwip echo example
+ */
+int32_t xil_eth_init(struct xil_eth_desc **desc,
+		     struct xil_eth_init_param *param)
+{
+	struct xil_eth_desc *ldesc;
+	struct netif *netif;
+	ip_addr_t ipaddr, netmask, gw;
+	int32_t ret, i;
+
+	ldesc = calloc(1, sizeof(*ldesc));
+	if (!ldesc)
+		return -ENOMEM;
+
+#if defined (__arm__) && !defined (ARMR5)
+#if XPAR_GIGE_PCS_PMA_SGMII_CORE_PRESENT == 1 || \
+    XPAR_GIGE_PCS_PMA_1000BASEX_CORE_PRESENT == 1
+	ProgramSi5324();
+	ProgramSfpPhy();
+#endif
+#endif
+
+	/* Define this board specific macro in order perform PHY reset on ZCU102 */
+#ifdef XPS_BOARD_ZCU102
+	if(IicPhyReset()) {
+		pr_err("Error performing PHY reset \n\r");
+		return -1;
+	}
+#endif
+
+	init_platform();
+
+	if (param->use_static_ip) {
+		ipaddr = param->ip_addr;
+		gw = param->gw;
+		netmask = param->netmask;
+	} else {
+		ipaddr.addr = 0;
+		gw.addr = 0;
+		netmask.addr = 0;
+	}
+
+	lwip_init();
+
+	netif = &ldesc->netif;
+	/* Needed by platform files */
+	echo_netif = netif;
+
+	/* Add network interface to the netif_list, and set it as default */
+	if (!xemac_add(netif, &ipaddr, &netmask, &gw,
+		       param->mac_ethernet_address, param->emac_baseaddr)) {
+		pr_err("Error adding N/W interface\n\r");
+		ret = FAILURE;
+		goto cleanup;
+	}
+
+	netif_set_default(netif);
+
+	/* now enable interrupts */
+	platform_enable_interrupts();
+
+	if (!param->use_static_ip) {
+		/* specify that the network if is up */
+		netif_set_up(netif);
+
+		/* DHCP Config */
+
+		/* Create a new DHCP client for this interface.
+		* Note: you must call dhcp_fine_tmr() and dhcp_coarse_tmr() at
+		* the predefined regular intervals after starting the client.
+		*/
+		dhcp_start(netif);
+		dhcp_timoutcntr = 24;
+
+		while(((netif->ip_addr.addr) == 0) && (dhcp_timoutcntr > 0))
+			xemacif_input(netif);
+
+		if (dhcp_timoutcntr <= 0) {
+			if ((netif->ip_addr.addr) == 0) {
+				pr_err("DHCP Timeout\r\n");
+				ret = FAILURE;
+				goto cleanup;
+			}
+		}
+	}
+
+	xil_eth_config_noos_if(ldesc);
+
+	*desc = ldesc;
+	for (i = 0; i < MAX_SOCKETS; ++i) {
+		ldesc->sockets[i].id = i;
+		ldesc->sockets[i].desc = ldesc;
+	}
+
+	return SUCCESS;
+cleanup:
+	free(ldesc);
+	return ret;
+}
+
+int32_t xil_eth_remove(struct xil_eth_desc *desc)
+{
+	free(desc);
+
+	return SUCCESS;
+}
+
+/* They seem to be non static in tcp.c but they aren't in any .h file */
+void tcp_fasttmr(void);
+void tcp_slowtmr(void);
+
+/* It is simpler to call tcp_tmr every 250 seconds than using xil_eth_step */
+int32_t xil_eth_step(struct xil_eth_desc *desc)
+{
+	if (TcpFastTmrFlag) {
+		tcp_fasttmr();
+		TcpFastTmrFlag = 0;
+	}
+	if (TcpSlowTmrFlag) {
+		tcp_slowtmr();
+		TcpSlowTmrFlag = 0;
+	}
+	xemacif_input(&desc->netif);
+
+	return SUCCESS;
+}
+
+int32_t xil_eth_get_network_interface(struct xil_eth_desc *desc,
+				      struct network_interface **net)
+{
+	*net = &desc->noos_net;
+
+	return SUCCESS;
+}
+
+int32_t xil_eth_get_ip(struct xil_eth_desc *desc, char *ip_buff,
+		       uint32_t buff_size)
+{
+	ip_addr_t *ip;
+
+	ip = &desc->netif.ip_addr;
+
+	return snprintf(ip_buff, buff_size, "%d.%d.%d.%d", ip4_addr1(ip),
+			ip4_addr2(ip), ip4_addr3(ip), ip4_addr4(ip));
+}
+
+
+/******************************************************************************/
+/*************************** Functions Declarations *******************************/
+/******************************************************************************/
+
+/* Called when new data arrives */
+static err_t xil_eth_recv_callback(void *arg, struct tcp_pcb *tpcb,
+				   struct pbuf *p, err_t err)
+{
+	struct socket_desc *sock = arg;
+
+	if (!p) {
+		/* Remote has closed connection */
+		tcp_recv(sock->pcb, NULL);
+		sock->state = SOCKET_DISCONNECTED;
+
+		return ERR_OK;
+	} else if (err != ERR_OK) {
+		/* Cleanup for unknown reasons */
+		pbuf_free(p);
+		return err;
+	}
+
+	if (!sock->p) {
+		/* First buffer. Save it in p */
+		sock->p = p;
+		sock->p_idx = 0;
+	} else {
+		/*
+		 * TODO: Can this cause error while reading?
+		 * Should some locking be use here?
+		 */
+		/* Concatenate new buffer to p */
+		pbuf_cat(sock->p, p);
+	}
+
+	return ERR_OK;
+}
+
+static void xil_eth_err_callback(void *arg, err_t err)
+{
+	struct socket_desc *sock = arg;
+
+	sock->state = SOCKET_DISCONNECTED;
+}
+
+/* Set default callbacks for a new socket */
+static void xil_eth_config_sock(struct socket_desc *sock)
+{
+	/* Set function argument for callback */
+	tcp_arg(sock->pcb, sock);
+	tcp_recv(sock->pcb, xil_eth_recv_callback);
+	tcp_err(sock->pcb, xil_eth_err_callback);
+}
+
+/** @brief See \ref network_interface.socket_open */
+static int32_t xil_socket_open(struct xil_eth_desc *desc, uint32_t *sock_id,
+			       enum socket_protocol prot, uint32_t buff_size)
+{
+	int32_t err;
+	struct tcp_pcb *pcb;
+
+	err = _get_unused_socket(desc, sock_id);
+	if (IS_ERR_VALUE(err))
+		return err;
+
+	pcb = tcp_new_ip_type(IPADDR_TYPE_ANY);
+	if (!pcb) {
+		_release_socket(desc, *sock_id);
+		return -ENOMEM;
+	}
+	desc->sockets[*sock_id].pcb = pcb;
+
+	xil_eth_config_sock(&desc->sockets[*sock_id]);
+
+	return SUCCESS;
+}
+
+/** @brief See \ref network_interface.socket_close */
+static int32_t xil_socket_close(struct xil_eth_desc *desc, uint32_t sock_id)
+{
+	struct socket_desc *sock;
+
+	sock = _get_sock(desc, sock_id);
+	if (!sock)
+		return -EINVAL;
+
+	if (sock->state == SOCKET_UNUSED)
+		return -ENOENT;
+
+	tcp_recv(sock->pcb, NULL);
+	tcp_err(sock->pcb, NULL);
+	if (sock->p) {
+		tcp_recved(sock->pcb, sock->p->tot_len);
+		pbuf_free(sock->p);
+	}
+
+	tcp_close(sock->pcb);
+	sock->p_idx = 0;
+	_release_socket(desc, sock_id);
+
+	return SUCCESS;
+}
+
+/** @brief See \ref network_interface.socket_send */
+static int32_t xil_socket_send(struct xil_eth_desc *desc, uint32_t sock_id,
+			       const void *data, uint32_t size)
+{
+	struct socket_desc *sock;
+	err_t err;
+	uint32_t aval;
+	uint32_t flags;
+	int8_t _err;
+
+	sock = _get_sock(desc, sock_id);
+	if (!sock)
+		return -EINVAL;
+
+	if (sock->state != SOCKET_CONNECTED)
+		return -ENOTCONN;
+
+	aval = tcp_sndbuf(sock->pcb);
+	flags = TCP_WRITE_FLAG_COPY;
+	if (aval < size)
+		/* Partial write */
+		flags |= TCP_WRITE_FLAG_MORE;
+	size = min(aval, size);
+	err = tcp_write(sock->pcb, data, size, flags);
+	if (err != ERR_OK) {
+		_err = err;
+		pr_err("TCP write err: %"PRIi8"\n", _err);
+		return _err;
+	}
+
+	if (!(flags & TCP_WRITE_FLAG_MORE)) {
+		/* Mark data as ready to be sent */
+		err = tcp_output(sock->pcb);
+		if (err != ERR_OK) {
+			_err = err;
+			pr_err("TCP output err: %"PRIi8"\n", _err);
+			return _err;
+		}
+	}
+
+	return size;
+}
+
+/** @brief See \ref network_interface.socket_recv */
+static int32_t xil_socket_recv(struct xil_eth_desc *desc, uint32_t sock_id,
+			       void *data, uint32_t size)
+{
+	struct socket_desc *sock;
+	struct pbuf *p, *old_p;
+	uint8_t *buf, *pdata;
+	uint32_t i, len;
+
+	sock = _get_sock(desc, sock_id);
+	if (!sock)
+		return -EINVAL;
+
+	if (sock->state != SOCKET_CONNECTED)
+		return -ENOTCONN;
+
+	i = 0;
+	p = sock->p;
+	pdata = data;
+	/* Iterate over payloads until requested data has been read */
+	while (p && i < size) {
+		len = min(size - i, p->len - sock->p_idx);
+		buf = p->payload;
+		buf += sock->p_idx;
+		memcpy(pdata + i, buf, len);
+		i += len;
+		sock->p_idx += len;
+		if (sock->p_idx == p->len) {
+			/* Done with current p. Cleanup and mark as read */
+			old_p = p;
+			p = p->next;
+			if (p)
+				pbuf_ref(p);
+			pbuf_free(old_p);
+			tcp_recved(sock->pcb, sock->p_idx);
+			sock->p_idx = 0;
+		}
+	}
+	sock->p = p;
+
+	return i;
+}
+
+/** @brief See \ref network_interface.socket_bind */
+static int32_t xil_socket_bind(struct xil_eth_desc *desc, uint32_t sock_id,
+			       uint16_t port)
+{
+	err_t err;
+	struct socket_desc *sock;
+
+	sock = _get_sock(desc, sock_id);
+	if (!sock)
+		return -EINVAL;
+
+	err = tcp_bind(sock->pcb, IP_ANY_TYPE, port);
+	if (err != ERR_OK) {
+		pr_err("Unable to bind port %"PRIu16"\n", port);
+		return -EINVAL;
+	}
+
+	return SUCCESS;
+}
+
+/** @brief See \ref network_interface.socket_listen */
+static int32_t xil_socket_listen(struct xil_eth_desc *desc, uint32_t sock_id,
+				 uint32_t back_log)
+{
+	struct socket_desc *sock;
+	struct tcp_pcb *pcb;
+
+	sock = _get_sock(desc, sock_id);
+	if (!sock)
+		return -EINVAL;
+
+	pcb = tcp_listen_with_backlog(sock->pcb, back_log);
+	if (!pcb) {
+		pr_err("Unable to listen on socket\n");
+		return -ENOMEM;
+	}
+	sock->pcb = pcb;
+	sock->state = SOCKET_LISTENING;
+
+	xil_eth_config_sock(sock);
+
+	return SUCCESS;
+}
+
+/* Called when at a new connection request. Prepare structure for new socket */
+static err_t xil_eth_accept_callback(void *arg, struct tcp_pcb *new_pcb,
+				     err_t err)
+{
+	int32_t noos_err;
+	int8_t _err;
+	uint32_t id;
+	struct socket_desc *sock;
+	struct socket_desc *serv_sock = arg;
+	struct xil_eth_desc *desc = serv_sock->desc;
+
+	if (err != ERR_OK) {
+		_err = err;
+		pr_err("Accept callback err %"PRIi8"\n", _err);
+		return ERR_OK;
+	}
+
+	noos_err = _get_unused_socket(desc, &id);
+	if (IS_ERR_VALUE(noos_err))
+		return ERR_MEM;
+
+	sock = _get_sock(desc, id);
+	sock->pcb = new_pcb;
+	sock->state = SOCKET_WAITING_ACCEPT;
+
+	xil_eth_config_sock(sock);
+
+	return ERR_OK;
+}
+
+/** @brief See \ref network_interface.socket_accept */
+static int32_t xil_socket_accept(struct xil_eth_desc *desc, uint32_t sock_id,
+				 uint32_t *client_socket_id)
+{
+	struct socket_desc *serv_sock, *cli_sock;
+	uint32_t i;
+
+	serv_sock = _get_sock(desc, sock_id);
+	if (!serv_sock)
+		return -EINVAL;
+
+	if (serv_sock->state != SOCKET_ACCEPTING) {
+		if (serv_sock->state != SOCKET_LISTENING)
+			return -EINVAL;
+		tcp_accept(serv_sock->pcb, xil_eth_accept_callback);
+		serv_sock->state = SOCKET_ACCEPTING;
+	}
+
+	for (i = 0; i < MAX_SOCKETS; ++i) {
+		cli_sock = &desc->sockets[i];
+		if (cli_sock->state == SOCKET_WAITING_ACCEPT) {
+			if (cli_sock->pcb->local_port ==
+			    serv_sock->pcb->local_port) {
+				/* New client connection for server */
+				*client_socket_id = i;
+				cli_sock->state = SOCKET_CONNECTED;
+				return SUCCESS;
+			}
+		}
+	}
+
+	return -EAGAIN;
+}
+
+/** @brief See \ref network_interface.socket_sendto */
+static int32_t xil_socket_sendto(struct xil_eth_desc *desc, uint32_t sock_id,
+				 const void *data, uint32_t size,
+				 const struct socket_address* to)
+{
+	return -ENOENT;
+}
+
+/** @brief See \ref network_interface.socket_recvfrom */
+static int32_t xil_socket_recvfrom(struct xil_eth_desc *desc, uint32_t sock_id,
+				   void *data, uint32_t size,
+				   struct socket_address *from)
+{
+	return -ENOENT;
+}
+
+/** @brief See \ref network_interface.socket_connect */
+static int32_t xil_socket_connect(struct xil_eth_desc *desc, uint32_t sock_id,
+				  struct socket_address *addr)
+{
+	return -ENOENT;
+
+}
+
+/** @brief See \ref network_interface.socket_disconnect */
+static int32_t xil_socket_disconnect(struct xil_eth_desc *desc,
+				     uint32_t sock_id)
+{
+	return -ENOENT;
+}
+
+static void xil_eth_config_noos_if(struct xil_eth_desc *desc)
+{
+	struct network_interface *net = &desc->noos_net;
+
+	net->socket_open = (int32_t (*)(void *, uint32_t *,
+					enum socket_protocol, uint32_t))
+			   xil_socket_open;
+	net->socket_close = (int32_t (*)(void *, uint32_t)) xil_socket_close;
+	net->socket_connect = (int32_t (*)(void *, uint32_t,
+					   struct socket_address *))
+			      xil_socket_connect;
+	net->socket_disconnect = (int32_t (*)(void *, uint32_t))
+				 xil_socket_disconnect;
+	net->socket_send = (int32_t (*)(void *, uint32_t, const void *,
+					uint32_t))xil_socket_send;
+	net->socket_recv = (int32_t (*)(void *, uint32_t, void *, uint32_t))
+			   xil_socket_recv;
+	net->socket_sendto = (int32_t (*)(void *, uint32_t, const void *,
+					  uint32_t,
+					  const struct socket_address* to))
+			     xil_socket_sendto;
+	net->socket_recvfrom = (int32_t (*)(void *, uint32_t, void *, uint32_t,
+					    struct socket_address* from))
+			       xil_socket_recvfrom;
+	net->socket_bind = (int32_t (*)(void *, uint32_t, uint16_t))
+			   xil_socket_bind;
+	net->socket_listen = (int32_t (*)(void *, uint32_t, uint32_t))
+			     xil_socket_listen;
+	net->socket_accept = (int32_t (*)(void *, uint32_t, uint32_t*))
+			     xil_socket_accept;
+
+	net->net = desc;
+}
+#endif

--- a/network/xil_eth/xil_eth.h
+++ b/network/xil_eth/xil_eth.h
@@ -1,0 +1,84 @@
+/***************************************************************************//**
+ * @file xil_eth.h
+ * @brief Function to initialize xilinx ethernet.
+ * @author Mihail Chindris (mihail.chindris@analog.com)
+ ********************************************************************************
+ * Copyright 2021(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * - Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * - Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in
+ * the documentation and/or other materials provided with the
+ * distribution.
+ * - Neither the name of Analog Devices, Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ * - The use of this software may or may not infringe the patent rights
+ * of one or more patent holders. This license does not release you
+ * from the requirement that you obtain separate licenses from these
+ * patent holders to use this software.
+ * - Use of the software either in source or binary form, must be run
+ * on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+#ifndef XIL_SOCKET_H_
+#define XIL_SOCKET_H_
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include "lwip/ip4_addr.h"
+#include "network_interface.h"
+
+
+/* Xilnx ethernet parameters */
+#define MAX_SOCKETS		10
+#define SOCKET_BUFFER_SIZE	100000
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+struct xil_eth_desc;
+
+struct xil_eth_init_param {
+	/* Initialize with MAC address bytes */
+	unsigned char mac_ethernet_address[6];
+	unsigned emac_baseaddr;
+	/* If set to 1, static IP must be set for ip_addr, netmask and gw */
+	uint8_t use_static_ip;
+	struct ip4_addr ip_addr;
+	struct ip4_addr netmask;
+	struct ip4_addr gw;
+};
+
+int32_t xil_eth_init(struct xil_eth_desc **desc,
+		     struct xil_eth_init_param *param);
+int32_t xil_eth_remove(struct xil_eth_desc *desc);
+/* Proccessing unit. Must be called in order for packets to be procesed. */
+int32_t xil_eth_step(struct xil_eth_desc *desc);
+
+int32_t xil_eth_get_ip(struct xil_eth_desc *desc, char *ip_buff,
+		       uint32_t buff_size);
+
+int32_t xil_eth_get_network_interface(struct xil_eth_desc *desc,
+				      struct network_interface **net);
+
+#endif /* XIL_SOCKET_H_ */

--- a/tools/scripts/linux.mk
+++ b/tools/scripts/linux.mk
@@ -9,6 +9,11 @@ PROJECT_BUILD = $(BUILD_DIR)/app
 CFLAGS +=  -g3 \
 		-DLINUX_PLATFORM \
 
+ifeq (y,$(strip $(TINYIIOD)))
+CFLAGS += -DUSE_TCP_SOCKET \
+		-DENABLE_IIO_NETWORK
+endif
+
 $(PROJECT_TARGET):
 	$(MUTE) $(call mk_dir, $(BUILD_DIR)) $(HIDE)
 	$(MUTE) $(call set_one_time_rule,$@)


### PR DESCRIPTION
Created to debug a new tinyiiod version.
 - For tinyiiod seems to work, but it doesn't has the same performance as in linux.
 - Some file are token from here: https://github.com/Xilinx/embeddedsw/tree/master/lib/sw_apps/lwip_echo_server/src
   because it seems that there is support for multiple xilinx boards.
 - Tested on zc706 and zedboard
 - At the moment lwip must be enabled manually from BSP with LWIP_DHCP set to true. (I failed to add them from makefile but there should be a way. I didn't spend too much time on that )