### PR TITLE
"Small" refactor in iio.c

### DIFF
--- a/iio/iio.c
+++ b/iio/iio.c
@@ -342,7 +342,7 @@ static inline struct iio_channel *iio_get_channel(const char *channel,
  * @param iio_dev_privs - List of interfaces.
  * @return Interface pointer if interface is found, NULL otherwise.
  */
-static struct iio_dev_priv *iio_get_interface(const char *device_name)
+static struct iio_dev_priv *get_iio_device(const char *device_name)
 {
 	uint32_t i;
 
@@ -656,7 +656,7 @@ static ssize_t iio_read_attr(const char *device_id, const char *attr, char *buf,
 	struct attr_fun_params	params;
 	struct iio_attribute	*attributes;
 
-	dev = iio_get_interface(device_id);
+	dev = get_iio_device(device_id);
 	if (!dev)
 		return FAILURE;
 
@@ -706,7 +706,7 @@ static ssize_t iio_write_attr(const char *device_id, const char *attr,
 	struct attr_fun_params	params;
 	struct iio_attribute	*attributes;
 
-	dev = iio_get_interface(device_id);
+	dev = get_iio_device(device_id);
 	if (!dev)
 		return -ENODEV;
 
@@ -757,7 +757,7 @@ static ssize_t iio_ch_read_attr(const char *device_id, const char *channel,
 	struct iio_channel	*ch;
 	struct attr_fun_params	params;
 
-	dev = iio_get_interface(device_id);
+	dev = get_iio_device(device_id);
 	if (!dev)
 		return FAILURE;
 
@@ -798,7 +798,7 @@ static ssize_t iio_ch_write_attr(const char *device_id, const char *channel,
 	struct iio_channel	*ch;
 	struct attr_fun_params	params;
 
-	dev = iio_get_interface(device_id);
+	dev = get_iio_device(device_id);
 	if (!dev)
 		return -ENOENT;
 
@@ -834,7 +834,7 @@ static int32_t iio_open_dev(const char *device, size_t sample_size,
 	struct iio_dev_priv *iface;
 	uint32_t ch_mask;
 
-	iface = iio_get_interface(device);
+	iface = get_iio_device(device);
 	if (!iface)
 		return -ENODEV;
 
@@ -861,7 +861,7 @@ static int32_t iio_close_dev(const char *device)
 {
 	struct iio_dev_priv *iface;
 
-	iface = iio_get_interface(device);
+	iface = get_iio_device(device);
 	if (!iface)
 		return FAILURE;
 
@@ -882,7 +882,7 @@ static int32_t iio_get_mask(const char *device, uint32_t *mask)
 {
 	struct iio_dev_priv *iface;
 
-	iface = iio_get_interface(device);
+	iface = get_iio_device(device);
 	if (!iface)
 		return -ENODEV;
 
@@ -927,7 +927,7 @@ static uint32_t bytes_to_samples(struct iio_dev_priv *intf, uint32_t bytes)
  */
 static ssize_t iio_transfer_dev_to_mem(const char *device, size_t bytes_count)
 {
-	struct iio_dev_priv *iio_interface = iio_get_interface(device);
+	struct iio_dev_priv *iio_interface = get_iio_device(device);
 	struct iio_data_buffer	*r_buff;
 	uint32_t		samples;
 	ssize_t			ret;
@@ -960,7 +960,7 @@ static ssize_t iio_transfer_dev_to_mem(const char *device, size_t bytes_count)
 static ssize_t iio_read_dev(const char *device, char *pbuf, size_t offset,
 			    size_t bytes_count)
 {
-	struct iio_dev_priv *iio_interface = iio_get_interface(device);
+	struct iio_dev_priv *iio_interface = get_iio_device(device);
 	struct iio_data_buffer *r_buff;
 
 	r_buff = iio_interface->read_buffer;
@@ -984,7 +984,7 @@ static ssize_t iio_read_dev(const char *device, char *pbuf, size_t offset,
  */
 static ssize_t iio_transfer_mem_to_dev(const char *device, size_t bytes_count)
 {
-	struct iio_dev_priv *iio_interface = iio_get_interface(device);
+	struct iio_dev_priv *iio_interface = get_iio_device(device);
 	struct iio_data_buffer	*w_buff;
 	ssize_t			ret;
 	uint32_t		samples;
@@ -1017,7 +1017,7 @@ static ssize_t iio_transfer_mem_to_dev(const char *device, size_t bytes_count)
 static ssize_t iio_write_dev(const char *device, const char *buf,
 			     size_t offset, size_t bytes_count)
 {
-	struct iio_dev_priv *iio_interface = iio_get_interface(device);
+	struct iio_dev_priv *iio_interface = get_iio_device(device);
 	struct iio_data_buffer	*w_buff;
 
 	w_buff = iio_interface->write_buffer;

--- a/iio/iio.c
+++ b/iio/iio.c
@@ -1356,6 +1356,22 @@ static int32_t iio_cmp_interfaces(struct iio_interface *a,
 	return strcmp(a->dev_id, b->dev_id);
 }
 
+static int32_t iio_init_devs(struct iio_desc *desc,
+			     struct iio_device_init *devs, int32_t n)
+{
+	int32_t i, ret;
+
+	for (i = 0; i < n; i++) {
+		ret = iio_register(desc, devs[i].dev_descriptor, devs[i].name,
+				   devs[i].dev, devs[i].read_buff,
+				   devs[i].write_buff);
+		if (ret < 0)
+			return ret;
+	}
+
+	return SUCCESS;
+}
+
 /**
  * @brief Set communication ops and read/write ops that will be called
  * from "libtinyiiod".
@@ -1442,6 +1458,10 @@ ssize_t iio_init(struct iio_desc **desc, struct iio_init_param *init_param)
 			(f_cmp)iio_cmp_interfaces);
 	if (IS_ERR_VALUE(ret))
 		goto free_pylink;
+
+	ret = iio_init_devs(ldesc, init_param->devs, init_param->nb_devs);
+	if (IS_ERR_VALUE(ret))
+		goto free_list;
 
 	ldesc->iiod = tinyiiod_create(ops);
 	if (!(ldesc->iiod))

--- a/iio/iio.c
+++ b/iio/iio.c
@@ -124,8 +124,8 @@ struct attr_fun_params {
  * with a "iio_device *iio" that describes capabilities of the device.
  */
 struct iio_interface {
-	/** Will be: device[0...n] n beeing the count of registerd devices */
-	char			dev_id[10];
+	/** Will be: iio:device[0...n] n beeing the count of registerd devices*/
+	char			dev_id[21];
 	/** Device name */
 	const char		*name;
 	/** Opened channels */
@@ -1301,7 +1301,7 @@ ssize_t iio_register(struct iio_desc *desc, struct iio_device *dev_descriptor,
 				desc->dev_count,
 				desc->xml_desc + desc->xml_size_to_last_dev,
 				new_size - desc->xml_size_to_last_dev);
-	sprintf((char *)iio_interface->dev_id, "device%d", (int)desc->dev_count);
+	sprintf((char *)iio_interface->dev_id, "iio:device%d", (int)desc->dev_count);
 	desc->xml_size_to_last_dev += n;
 	desc->xml_size += n;
 	/* Copy end header at the end */

--- a/iio/iio.c
+++ b/iio/iio.c
@@ -1322,11 +1322,13 @@ ssize_t iio_init(struct iio_desc **desc, struct iio_init_param *init_param)
 
 	ops = (struct tinyiiod_ops *)calloc(1, sizeof(struct tinyiiod_ops));
 	if (!ops)
-		return FAILURE;
+		return -ENOMEM;
 
 	ldesc = (struct iio_desc *)calloc(1, sizeof(*ldesc));
-	if (!ldesc)
+	if (!ldesc) {
+		ret = -ENOMEM;
 		goto free_ops;
+	}
 	ldesc->iiod_ops = ops;
 
 	/* device operations */
@@ -1406,7 +1408,7 @@ free_desc:
 free_ops:
 	free(ops);
 
-	return FAILURE;
+	return ret;
 }
 
 /**

--- a/iio/iio.c
+++ b/iio/iio.c
@@ -119,11 +119,11 @@ struct attr_fun_params {
 };
 
 /**
- * @struct iio_interface
+ * @struct iio_dev_priv
  * @brief Links a physical device instance "void *dev_instance"
  * with a "iio_device *iio" that describes capabilities of the device.
  */
-struct iio_interface {
+struct iio_dev_priv {
 	/** Will be: iio:device[0...n] n beeing the count of registerd devices*/
 	char			dev_id[21];
 	/** Device name */
@@ -147,7 +147,7 @@ struct iio_desc {
 	void			*phy_desc;
 	char			*xml_desc;
 	uint32_t		xml_size;
-	struct iio_interface	*devs;
+	struct iio_dev_priv	*devs;
 	uint32_t		nb_devs;
 	struct uart_desc	*uart_desc;
 #ifdef ENABLE_IIO_NETWORK
@@ -339,10 +339,10 @@ static inline struct iio_channel *iio_get_channel(const char *channel,
 /**
  * @brief Find interface with "device_name".
  * @param device_name - Device name.
- * @param iio_interfaces - List of interfaces.
+ * @param iio_dev_privs - List of interfaces.
  * @return Interface pointer if interface is found, NULL otherwise.
  */
-static struct iio_interface *iio_get_interface(const char *device_name)
+static struct iio_dev_priv *iio_get_interface(const char *device_name)
 {
 	uint32_t i;
 
@@ -466,7 +466,7 @@ static ssize_t iio_rd_wr_attribute(struct attr_fun_params *params,
 /* Read a device register. The register address to read is set on
  * in desc->active_reg_addr in the function set_demo_reg_attr
  */
-static int32_t debug_reg_read(struct iio_interface *dev, char *buf, size_t len)
+static int32_t debug_reg_read(struct iio_dev_priv *dev, char *buf, size_t len)
 {
 	uint32_t		value;
 	int32_t			ret;
@@ -492,7 +492,7 @@ static int32_t debug_reg_read(struct iio_interface *dev, char *buf, size_t len)
  * 	   sprintf(write_buf, "0x%x 0x%x", reg_addr, value);
  * 	1. debug_reg_write(dev, write_buf,len);
  */
-static int32_t debug_reg_write(struct iio_interface *dev, const char *buf,
+static int32_t debug_reg_write(struct iio_dev_priv *dev, const char *buf,
 			       size_t len)
 {
 	uint32_t		nb_filled;
@@ -652,7 +652,7 @@ ssize_t iio_format_value(char *buf, size_t len, enum iio_val fmt,
 static ssize_t iio_read_attr(const char *device_id, const char *attr, char *buf,
 			     size_t len, enum iio_attr_type type)
 {
-	struct iio_interface	*dev;
+	struct iio_dev_priv	*dev;
 	struct attr_fun_params	params;
 	struct iio_attribute	*attributes;
 
@@ -702,7 +702,7 @@ static ssize_t iio_write_attr(const char *device_id, const char *attr,
 			      const char *buf,
 			      size_t len, enum iio_attr_type type)
 {
-	struct iio_interface	*dev;
+	struct iio_dev_priv	*dev;
 	struct attr_fun_params	params;
 	struct iio_attribute	*attributes;
 
@@ -752,7 +752,7 @@ static ssize_t iio_write_attr(const char *device_id, const char *attr,
 static ssize_t iio_ch_read_attr(const char *device_id, const char *channel,
 				bool ch_out, const char *attr, char *buf, size_t len)
 {
-	struct iio_interface	*dev;
+	struct iio_dev_priv	*dev;
 	struct iio_ch_info	ch_info;
 	struct iio_channel	*ch;
 	struct attr_fun_params	params;
@@ -793,7 +793,7 @@ static ssize_t iio_ch_read_attr(const char *device_id, const char *channel,
 static ssize_t iio_ch_write_attr(const char *device_id, const char *channel,
 				 bool ch_out, const char *attr, const char *buf, size_t len)
 {
-	struct iio_interface	*dev;
+	struct iio_dev_priv	*dev;
 	struct iio_ch_info	ch_info;
 	struct iio_channel	*ch;
 	struct attr_fun_params	params;
@@ -831,7 +831,7 @@ static ssize_t iio_ch_write_attr(const char *device_id, const char *channel,
 static int32_t iio_open_dev(const char *device, size_t sample_size,
 			    uint32_t mask, bool cyclic)
 {
-	struct iio_interface *iface;
+	struct iio_dev_priv *iface;
 	uint32_t ch_mask;
 
 	iface = iio_get_interface(device);
@@ -859,7 +859,7 @@ static int32_t iio_open_dev(const char *device, size_t sample_size,
  */
 static int32_t iio_close_dev(const char *device)
 {
-	struct iio_interface *iface;
+	struct iio_dev_priv *iface;
 
 	iface = iio_get_interface(device);
 	if (!iface)
@@ -880,7 +880,7 @@ static int32_t iio_close_dev(const char *device)
  */
 static int32_t iio_get_mask(const char *device, uint32_t *mask)
 {
-	struct iio_interface *iface;
+	struct iio_dev_priv *iface;
 
 	iface = iio_get_interface(device);
 	if (!iface)
@@ -891,7 +891,7 @@ static int32_t iio_get_mask(const char *device, uint32_t *mask)
 	return SUCCESS;
 }
 
-static uint32_t bytes_to_samples(struct iio_interface *intf, uint32_t bytes)
+static uint32_t bytes_to_samples(struct iio_dev_priv *intf, uint32_t bytes)
 {
 	uint32_t bytes_per_sample;
 	uint32_t first_ch;
@@ -927,7 +927,7 @@ static uint32_t bytes_to_samples(struct iio_interface *intf, uint32_t bytes)
  */
 static ssize_t iio_transfer_dev_to_mem(const char *device, size_t bytes_count)
 {
-	struct iio_interface *iio_interface = iio_get_interface(device);
+	struct iio_dev_priv *iio_interface = iio_get_interface(device);
 	struct iio_data_buffer	*r_buff;
 	uint32_t		samples;
 	ssize_t			ret;
@@ -960,7 +960,7 @@ static ssize_t iio_transfer_dev_to_mem(const char *device, size_t bytes_count)
 static ssize_t iio_read_dev(const char *device, char *pbuf, size_t offset,
 			    size_t bytes_count)
 {
-	struct iio_interface *iio_interface = iio_get_interface(device);
+	struct iio_dev_priv *iio_interface = iio_get_interface(device);
 	struct iio_data_buffer *r_buff;
 
 	r_buff = iio_interface->read_buffer;
@@ -984,7 +984,7 @@ static ssize_t iio_read_dev(const char *device, char *pbuf, size_t offset,
  */
 static ssize_t iio_transfer_mem_to_dev(const char *device, size_t bytes_count)
 {
-	struct iio_interface *iio_interface = iio_get_interface(device);
+	struct iio_dev_priv *iio_interface = iio_get_interface(device);
 	struct iio_data_buffer	*w_buff;
 	ssize_t			ret;
 	uint32_t		samples;
@@ -1017,7 +1017,7 @@ static ssize_t iio_transfer_mem_to_dev(const char *device, size_t bytes_count)
 static ssize_t iio_write_dev(const char *device, const char *buf,
 			     size_t offset, size_t bytes_count)
 {
-	struct iio_interface *iio_interface = iio_get_interface(device);
+	struct iio_dev_priv *iio_interface = iio_get_interface(device);
 	struct iio_data_buffer	*w_buff;
 
 	w_buff = iio_interface->write_buffer;
@@ -1241,7 +1241,7 @@ static uint32_t iio_generate_device_xml(struct iio_device *device, char *name,
 
 static int32_t iio_init_xml(struct iio_desc *desc)
 {
-	struct iio_interface *dev;
+	struct iio_dev_priv *dev;
 	uint32_t size, of;
 	int32_t i;
 
@@ -1277,11 +1277,11 @@ static int32_t iio_init_devs(struct iio_desc *desc,
 {
 	uint32_t i;
 	int32_t ret;
-	struct iio_interface *ldev;
+	struct iio_dev_priv *ldev;
 	struct iio_device_init *ndev;
 
 	desc->nb_devs = n;
-	desc->devs = (struct iio_interface *)calloc(desc->nb_devs,
+	desc->devs = (struct iio_dev_priv *)calloc(desc->nb_devs,
 			sizeof(*desc->devs));
 	if (!desc->devs)
 		return -ENOMEM;

--- a/iio/iio.c
+++ b/iio/iio.c
@@ -1080,7 +1080,7 @@ ssize_t iio_step(struct iio_desc *desc)
  * If buff_size is 0, no data will be written to buff, but size will be returned
  */
 static uint32_t iio_generate_device_xml(struct iio_device *device, char *name,
-					int32_t id, char *buff,
+					char *id, char *buff,
 					uint32_t buff_size)
 {
 	struct iio_channel	*ch;
@@ -1102,7 +1102,7 @@ static uint32_t iio_generate_device_xml(struct iio_device *device, char *name,
 
 	i = 0;
 	i += snprintf(buff, max(n - i, 0),
-		      "<device id=\"device%"PRIi32"\" name=\"%s\">", id, name);
+		      "<device id=\"%s\" name=\"%s\">", id, name);
 
 	/* Write channels */
 	if (device->channels)
@@ -1275,10 +1275,11 @@ ssize_t iio_register(struct iio_desc *desc, struct iio_device *dev_descriptor,
 	iio_interface->read_buffer = read_buff;
 	iio_interface->write_buffer = write_buff;
 
+	sprintf((char *)iio_interface->dev_id, "iio:device%d", (int)desc->dev_count);
 	/* Get number of bytes needed for the xml of the new device */
 	n = iio_generate_device_xml(iio_interface->dev_descriptor,
 				    (char *)iio_interface->name,
-				    desc->dev_count, NULL, -1);
+				    (char *)iio_interface->dev_id, NULL, -1);
 
 	new_size = desc->xml_size + n;
 	aux = realloc(desc->xml_desc, new_size);
@@ -1298,10 +1299,9 @@ ssize_t iio_register(struct iio_desc *desc, struct iio_device *dev_descriptor,
 	/* Print the new device xml at the end of the xml */
 	iio_generate_device_xml(iio_interface->dev_descriptor,
 				(char *)iio_interface->name,
-				desc->dev_count,
+				(char *)iio_interface->dev_id,
 				desc->xml_desc + desc->xml_size_to_last_dev,
 				new_size - desc->xml_size_to_last_dev);
-	sprintf((char *)iio_interface->dev_id, "iio:device%d", (int)desc->dev_count);
 	desc->xml_size_to_last_dev += n;
 	desc->xml_size += n;
 	/* Copy end header at the end */
@@ -1337,7 +1337,7 @@ ssize_t iio_unregister(struct iio_desc *desc, char *name)
 	/* Get number of bytes needed for the xml of the device */
 	n = iio_generate_device_xml(to_remove_interface->dev_descriptor,
 				    (char *)to_remove_interface->name,
-				    desc->dev_count, NULL, -1);
+				    (char *)to_remove_interface->dev_id,, NULL, -1);
 
 	/* Overwritte the deleted device */
 	aux = desc->xml_desc + desc->xml_size_to_last_dev - n;

--- a/iio/iio.h
+++ b/iio/iio.h
@@ -64,6 +64,14 @@ enum pysical_link_type {
 
 struct iio_desc;
 
+struct iio_device_init {
+	char *name;
+	void *dev;
+	struct iio_device *dev_descriptor;
+	struct iio_data_buffer *read_buff;
+	struct iio_data_buffer *write_buff;
+};
+
 struct iio_init_param {
 	enum pysical_link_type	phy_type;
 	union {
@@ -72,6 +80,8 @@ struct iio_init_param {
 		struct tcp_socket_init_param *tcp_socket_init_param;
 #endif
 	};
+	struct iio_device_init *devs;
+	int32_t nb_devs;
 };
 
 /******************************************************************************/
@@ -85,13 +95,7 @@ ssize_t iio_init(struct iio_desc **desc, struct iio_init_param *init_param);
 ssize_t iio_remove(struct iio_desc *desc);
 /* Execut an iio step. */
 ssize_t iio_step(struct iio_desc *desc);
-/* Register interface. */
-ssize_t iio_register(struct iio_desc *desc, struct iio_device *dev_descriptor,
-		     char *name, void *dev_instance,
-		     struct iio_data_buffer *read_buff,
-		     struct iio_data_buffer *write_buff);
-/* Unregister interface. */
-ssize_t iio_unregister(struct iio_desc *desc, char *name);
+
 int32_t iio_parse_value(char *buf, enum iio_val fmt,
 			int32_t *val, int32_t *val2);
 ssize_t iio_format_value(char *buf, size_t len, enum iio_val fmt,


### PR DESCRIPTION
 - Remove iio_register and use init param. No project use register during runtime. This simplify a lot structures in desc and xml is generated only once.
 - Some naming changes.