### PR TITLE
projects: typos fixes

### DIFF
--- a/projects/ad7124-8pmdz/src/app_config.h
+++ b/projects/ad7124-8pmdz/src/app_config.h
@@ -1,6 +1,6 @@
 /***************************************************************************//**
  *   @file   app_config.h
- *   @brief  Config file of AD9361/API Driver.
+ *   @brief  Config file of AD7124-8 project.
  *   @author DBogdan (dragos.bogdan@analog.com)
 ********************************************************************************
  * Copyright 2015(c) Analog Devices, Inc.

--- a/projects/ad7124-8pmdz/src/parameters.h
+++ b/projects/ad7124-8pmdz/src/parameters.h
@@ -1,5 +1,5 @@
 /***************************************************************************//**
- *   @file   ad9361/src/parameters.h
+ *   @file   ad7124-8pmdz/src/parameters.h
  *   @brief  Parameters Definitions.
  *   @author DBogdan (dragos.bogdan@analog.com)
 ********************************************************************************

--- a/projects/ad9083/src/uc/uc_settings.h
+++ b/projects/ad9083/src/uc/uc_settings.h
@@ -1,6 +1,6 @@
 /***************************************************************************//**
  *   @file   uc_settings.h
- *   @brief  Config file of AD9361/API Driver.
+ *   @brief  Use Case Settings of AD9083 project.
  *   @author Cristian Pop (cristian.pop@analog.com)
 ********************************************************************************
  * Copyright 2021(c) Analog Devices, Inc.

--- a/projects/cn0531/src/app_config.h
+++ b/projects/cn0531/src/app_config.h
@@ -1,6 +1,6 @@
 /***************************************************************************//**
  *   @file   app_config.h
- *   @brief  Config file of AD9361/API Driver.
+ *   @brief  Config file of CN0531 project.
  *   @author DBogdan (dragos.bogdan@analog.com)
 ********************************************************************************
  * Copyright 2015(c) Analog Devices, Inc.

--- a/projects/iio_adpd1080/src/app_config.h
+++ b/projects/iio_adpd1080/src/app_config.h
@@ -1,6 +1,6 @@
 /***************************************************************************//**
  *   @file   app_config.h
- *   @brief  Config file of AD9361/API Driver.
+ *   @brief  Config file of ADPD1080 project.
  *   @author DBogdan (dragos.bogdan@analog.com)
 ********************************************************************************
  * Copyright 2015(c) Analog Devices, Inc.

--- a/projects/iio_demo/src/app/app_config.h
+++ b/projects/iio_demo/src/app/app_config.h
@@ -1,6 +1,6 @@
 /***************************************************************************//**
  *   @file   app_config.h
- *   @brief  Config file of AD9361/API Driver.
+ *   @brief  Config file of IIO Demo project.
  *   @author DBogdan (dragos.bogdan@analog.com)
 ********************************************************************************
  * Copyright 2015(c) Analog Devices, Inc.

--- a/projects/iio_demo/src/app/parameters.h
+++ b/projects/iio_demo/src/app/parameters.h
@@ -1,5 +1,5 @@
 /***************************************************************************//**
- *   @file   ad9361/src/parameters.h
+ *   @file   iio_demo/src/app/parameters.h
  *   @brief  Parameters Definitions.
  *   @author DBogdan (dragos.bogdan@analog.com)
 ********************************************************************************


### PR DESCRIPTION
Fix multiple typos in several no-OS projects.

No functional changes.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>