### PR TITLE
stm32 delay DWT enable in DEMCR

### DIFF
--- a/drivers/platform/stm32/stm32_delay.c
+++ b/drivers/platform/stm32/stm32_delay.c
@@ -52,6 +52,7 @@ void udelay(uint32_t usecs)
 	static bool firstrun = true;
 	volatile uint32_t cycles = (SystemCoreClock / 1000000L) * usecs;
 	if (firstrun) {
+		CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
 		DWT->CTRL |= 1;
 		firstrun = false;
 	}


### PR DESCRIPTION
The stm32 delay implementation is based on the DWT timer in order
not to make use of normal timers that may be useful for the user.

There was an error in the prior implementation however - this DWT
was being enabled in its own registers but the
Debug Exception and Monitor Control Register (DEMCR) register did
not enable debugging facilities.

Therefore, when loading a .hex via DAPLink, the program would
hang in delay functions because the DWT wasn't counting. When
debugging via SDK, this wasn't visible, likely because the SDK
debugger enables TRCENA in DEMCR.

This commit fixes this hang.

Signed-off-by: Darius Berghe <darius.berghe@analog.com>