### PR TITLE
drivers: ada4250: Minor Updates

### DIFF
--- a/drivers/amplifiers/ada4250/ada4250.c
+++ b/drivers/amplifiers/ada4250/ada4250.c
@@ -338,10 +338,10 @@ int32_t ada4250_set_bandwidth(struct ada4250_dev *dev,
 
 	switch (bw) {
 	case ADA4250_BANDWIDTH_LOW:
-		val = GPIO_LOW;
+		val = GPIO_HIGH;
 		break;
 	case ADA4250_BANDWIDTH_HIGH:
-		val = GPIO_HIGH;
+		val = GPIO_LOW;
 		break;
 	default:
 		return -EINVAL;

--- a/drivers/amplifiers/ada4250/ada4250.h
+++ b/drivers/amplifiers/ada4250/ada4250.h
@@ -254,6 +254,9 @@ int32_t ada4250_read(struct ada4250_dev *dev, uint8_t reg_addr,
 int32_t ada4250_update(struct ada4250_dev *dev, uint8_t reg_addr,
 		       uint8_t mask, uint8_t data);
 
+/* ADA4250 Device Descriptor Update */
+int32_t ada4250_update_desc(struct ada4250_dev *dev);
+
 /* Software Reset */
 int32_t ada4250_soft_reset(struct ada4250_dev *dev);
 


### PR DESCRIPTION
Apparently the logic is reversed for this one. When in low BW mode, the BW pin should tied to AVDD and when in high BW mode, the BW pin should be tied to AVSS.
The low BW mode is actually the standard response while the high BW mode is more of a BW boost feature.