### PR TITLE
tools: scripts: generic.mk: Do not remove inexistent folders

### DIFF
--- a/tools/scripts/generic.mk
+++ b/tools/scripts/generic.mk
@@ -348,7 +348,9 @@ post_build:
 PHONY += update_srcs
 update_srcs: $(PROJECT_TARGET)
 	@$(call print, $(ACTION) srcs to created project)
-	-$(MUTE)$(call remove_dir,$(DIRS_TO_REMOVE)) $(HIDE)
+ifneq ($(wildcard $(DIRS_TO_REMOVE)),)
+	$(MUTE) $(call remove_dir,$(wildcard $(DIRS_TO_REMOVE))) $(HIDE)
+endif
 	$(MUTE) -$(call mk_dir,$(DIRS_TO_CREATE)) $(HIDE)
 	$(MUTE) $(foreach dir,$(sort $(SRC_DIRS)),\
 		$(call folder_fun,$(dir),$(call relative_to_project,$(dir))) $(HIDE)\


### PR DESCRIPTION
Otherwise the following messages are displayed at build time:
The system cannot find the file specified.
make[1]: [../../tools/scripts/generic.mk:351: update_srcs] Error 2 (ignored)

Signed-off-by: George Mois <george.mois@analog.com>