### PR TITLE
drivers: platform: linux: gpio: Use already exported GPIOs

### DIFF
--- a/drivers/platform/linux/linux_gpio.c
+++ b/drivers/platform/linux/linux_gpio.c
@@ -45,6 +45,7 @@
 #include "no-os/gpio.h"
 #include "no-os/delay.h"
 
+#include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -108,7 +109,7 @@ int32_t linux_gpio_get(struct gpio_desc **desc,
 
 	len = sprintf(path, "%d", descriptor->number);
 	ret = write(fd, path, len);
-	if (ret < 0) {
+	if ((ret < 0) && (errno != EBUSY)) {
 		printf("%s: Can't write to file\n\r", __func__);
 		close(fd);
 		goto free_linux_desc;


### PR DESCRIPTION
...instead of returning an error.

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>