### PR TITLE
drivers:platform:maxim Maxim platform drivers

### DIFF
--- a/drivers/platform/maxim/gpio_extra.h
+++ b/drivers/platform/maxim/gpio_extra.h
@@ -1,0 +1,81 @@
+/***************************************************************************//**
+ *   @file   maxim/gpio_extra.h
+ *   @brief  Header file for maxim gpio specifics.
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef GPIO_EXTRA_H_
+#define GPIO_EXTRA_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "no-os/irq.h"
+#include "no-os/gpio.h"
+#include "max32660.h"
+
+#define N_PINS	MXC_CFG_GPIO_PINS_PORT
+#define N_PORTS	MXC_CFG_GPIO_INSTANCES
+
+/**
+ * @brief maxim platform specific gpio platform ops structure
+ */
+extern const struct gpio_platform_ops max_gpio_ops;
+/**
+ * @brief maxim platform specific gpio irq platform ops structure
+ */
+extern const struct irq_platform_ops max_gpio_irq_ops;
+
+/**
+ * @struct gpio_irq_config
+ * @brief maxim configuration descriptor for irq operations
+ */
+struct gpio_irq_config {
+	enum irq_trig_level mode;
+};
+
+struct max_gpio_init_param {
+	/** Input/Output */
+	uint32_t mode;
+	/** Pull_up/Pull_down  */
+	uint32_t pull;
+	uint32_t port;
+};
+
+struct max_gpio_irq_param {
+	struct irq_ctrl_desc *parent;
+	struct gpio_desc *desc
+	};
+
+#endif

--- a/drivers/platform/maxim/irq_extra.h
+++ b/drivers/platform/maxim/irq_extra.h
@@ -1,0 +1,64 @@
+/***************************************************************************//**
+ *   @file   maxim/irq_extra.h
+ *   @brief  Header file for maxim irq specifics.
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef IRQ_MAXIM_EXTRA_H
+#define IRQ_MAXIM_EXTRA_H
+
+#include "max32660.h"
+#include "gpio.h"
+#include "gpio_extra.h"
+#include "no-os/irq.h"
+
+/**
+ * @enum irq_id
+ * @brief maxim specific interrupt ids
+ */
+enum irq_id {
+	MAX_GPIO_INT_ID = GPIO0_IRQn,
+	MAX_UART0_INT_ID = UART0_IRQn,
+	MAX_UART1_INT_ID = UART1_IRQn,
+	MAX_RTC_INT_ID = RTC_IRQn,
+	MAX_IRQ_DESC_COUNT
+};
+
+/**
+ * @brief maxim platform specific irq platform ops structure
+ */
+extern const struct irq_platform_ops irq_ops;
+
+#endif

--- a/drivers/platform/maxim/maxim_delay.c
+++ b/drivers/platform/maxim/maxim_delay.c
@@ -1,0 +1,60 @@
+/***************************************************************************//**
+ *   @file   maxim/maxim_delay.c
+ *   @brief  Implementation of maxim delay functions.
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "no-os/delay.h"
+#include "mxc_delay.h"
+
+/**
+ * @brief Generate microseconds delay.
+ * @param usecs - Delay in microseconds.
+ * @return None.
+ */
+void udelay(uint32_t usecs)
+{
+	mxc_delay(MXC_DELAY_USEC(usecs));
+}
+
+/**
+ * @brief Generate miliseconds delay.
+ * @param msecs - Delay in miliseconds.
+ * @return None.
+ */
+void mdelay(uint32_t msecs)
+{
+	mxc_delay(MXC_DELAY_MSEC(msecs));
+}

--- a/drivers/platform/maxim/maxim_gpio.c
+++ b/drivers/platform/maxim/maxim_gpio.c
@@ -1,0 +1,594 @@
+/***************************************************************************//**
+ *   @file   maxim/maxim_gpio.c
+ *   @brief  Implementation of gpio driver.
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <stdio.h>
+#include <errno.h>
+#include <stdlib.h>
+#include "no-os/gpio.h"
+#include "no-os/irq.h"
+#include "no-os/util.h"
+#include "gpio.h"
+#include "gpio_regs.h"
+#include "gpio_extra.h"
+#include "irq_extra.h"
+#include "max32660.h"
+#include "mxc_errors.h"
+
+static struct callback_desc *gpio_callback[N_PORTS][N_PINS];
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+static void _gpio_irq(uint8_t port)
+{
+	uint32_t pin;
+	mxc_gpio_regs_t *gpio_regs = MXC_GPIO_GET_GPIO(port);
+	uint32_t stat_reg = gpio_regs->int_stat;
+	/** Clear interrupt flags for the current port*/
+	gpio_regs->int_clr = stat_reg;
+	while(stat_reg) {
+		pin = find_first_set_bit(stat_reg);
+		if (!gpio_callback[port][pin]) {
+			stat_reg >>= pin + 1;
+			continue;
+		}
+		void *ctx = gpio_callback[port][pin]->ctx;
+		gpio_callback[port][pin]->callback(ctx, pin, NULL);
+
+		stat_reg >>= pin + 1;
+	}
+}
+
+void GPIO0_IRQHandler()
+{
+	_gpio_irq(0);
+}
+
+/**
+ * @brief Obtain the GPIO decriptor.
+ * @param desc - The GPIO descriptor.
+ * @param param - GPIO initialization parameters
+ * @return 0 in case of success, errno error codes otherwise.
+ */
+int32_t max_gpio_get(struct gpio_desc **desc,
+		     const struct gpio_init_param *param)
+{
+	int32_t ret;
+	gpio_cfg_t *g_cfg;
+	struct max_gpio_init_param *pextra;
+	uint32_t m_pad, m_func;
+	struct gpio_desc *descriptor;
+
+	if (!param || !param->extra || param->number >= N_PINS)
+		return -EINVAL;
+
+	descriptor = calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	g_cfg = calloc(1, sizeof(*g_cfg));
+	if (!g_cfg) {
+		ret = -ENOMEM;
+		goto free_descriptor;
+	}
+
+	pextra = param->extra;
+	m_pad = (pextra->pull == 0) ? GPIO_PAD_PULL_UP :  GPIO_PAD_PULL_DOWN;
+	m_func = (pextra->mode == 0) ? GPIO_FUNC_IN : GPIO_FUNC_OUT;
+
+	if (pextra->port >= N_PORTS) {
+		ret = -EINVAL;
+		goto free_g_cfg;
+	}
+
+	g_cfg->port = pextra->port;
+	g_cfg->mask = BIT(param->number);
+	g_cfg->pad = m_pad;
+	g_cfg->func = m_func;
+
+	descriptor->number = param->number;
+	descriptor->platform_ops = param->platform_ops;
+	descriptor->extra = g_cfg;
+
+	GPIO_Config(descriptor->extra);
+
+	*desc = descriptor;
+
+	return 0;
+
+free_g_cfg:
+	free(g_cfg);
+free_descriptor:
+	free(descriptor);
+
+	return ret;
+}
+
+/**
+ * @brief Get the value of an optional GPIO.
+ * @param desc - The GPIO descriptor.
+ * @param param - GPIO initialization parameters
+ * @return 0 in case of success, errno error codes otherwise.
+ */
+int32_t max_gpio_get_optional(struct gpio_desc **desc,
+			      const struct gpio_init_param *param)
+{
+	if (param == NULL) {
+		*desc = NULL;
+		return 0;
+	}
+
+	return max_gpio_get(desc, param);
+}
+
+/**
+ * @brief Free the resources allocated by gpio_get().
+ * @param desc - The GPIO descriptor.
+ * @return 0 in case of success, errno error codes otherwise.
+ */
+int32_t max_gpio_remove(struct gpio_desc *desc)
+{
+	if (!desc)
+		return -EINVAL;
+
+	free(desc->extra);
+	free(desc);
+
+	return 0;
+}
+
+/**
+ * @brief Enable the input direction of the specified GPIO.
+ * @param desc - The GPIO descriptor.
+ * @return 0 in case of success, errno error codes otherwise.
+ */
+int32_t max_gpio_direction_input(struct gpio_desc *desc)
+{
+	int32_t ret;
+	gpio_cfg_t *maxim_extra;
+
+	if (!desc || desc->number >= N_PINS)
+		return -EINVAL;
+
+	maxim_extra = desc->extra;
+
+	if (maxim_extra->port >= N_PORTS)
+		return -EINVAL;
+
+	maxim_extra->func = GPIO_FUNC_IN;
+	GPIO_Config(maxim_extra);
+
+	return 0;
+}
+
+/**
+ * @brief Enable the output direction of the specified GPIO.
+ * @param desc - The GPIO descriptor.
+ * @param value - The value.
+ *                Example: GPIO_HIGH
+ *                         GPIO_LOW
+ * @return 0 in case of success, errno error codes otherwise.
+ */
+int32_t max_gpio_direction_output(struct gpio_desc *desc, uint8_t value)
+{
+	mxc_gpio_regs_t *gpio_regs;
+	gpio_cfg_t *maxim_extra;
+
+	if (!desc || desc->number >= N_PINS || value > GPIO_HIGH_Z)
+		return -EINVAL;
+
+	gpio_regs = MXC_GPIO_GET_GPIO(desc->number);
+	maxim_extra = desc->extra;
+	maxim_extra->func = GPIO_FUNC_OUT;
+	GPIO_Config(maxim_extra);
+
+	switch(value) {
+	case GPIO_LOW:
+		GPIO_OutClr(maxim_extra);
+		/** Enable gpio if it was previously set to HIGH_Z */
+		if ((gpio_regs->en & BIT(desc->number)) == 0)
+			gpio_regs->en |= BIT(desc->number);
+		break;
+	case GPIO_HIGH:
+		GPIO_OutSet(maxim_extra);
+		if ((gpio_regs->en & BIT(desc->number)) == 0)
+			gpio_regs->en |= BIT(desc->number);
+		break;
+	case GPIO_HIGH_Z:
+		gpio_regs->en &= ~BIT(desc->number);
+		break;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Get the direction of the specified GPIO.
+ * @param desc - The GPIO descriptor.
+ * @param direction - The direction.
+ *                    Example: GPIO_OUT
+ *                             GPIO_IN
+ * @return 0 in case of success, errno error codes otherwise.
+ */
+int32_t max_gpio_get_direction(struct gpio_desc *desc, uint8_t *direction)
+{
+	gpio_cfg_t *maxim_extra;
+
+	if (!desc || desc->number >= N_PINS)
+		return -EINVAL;
+
+	maxim_extra = desc->extra;
+
+	if (maxim_extra->func == GPIO_FUNC_OUT)
+		*direction = GPIO_OUT;
+	else
+		*direction = GPIO_IN;
+
+	return 0;
+}
+
+/**
+ * @brief Set the value of the specified GPIO.
+ * @param desc - The GPIO descriptor.
+ * @param value - The value.
+ *                Example: GPIO_HIGH
+ *                         GPIO_LOW
+ * @return 0 in case of success, errno error codes otherwise.
+ */
+int32_t max_gpio_set_value(struct gpio_desc *desc, uint8_t value)
+{
+	gpio_cfg_t *max_gpio_cfg;
+	mxc_gpio_regs_t *gpio_regs;
+
+	if (!desc || desc->number >= N_PINS)
+		return -EINVAL;
+
+	max_gpio_cfg = desc->extra;
+	gpio_regs = MXC_GPIO_GET_GPIO(max_gpio_cfg->port);
+
+	switch(value) {
+	case GPIO_LOW:
+		GPIO_OutClr(max_gpio_cfg);
+		if (gpio_regs->en & BIT(desc->number) == 0)
+			gpio_regs->en |= BIT(desc->number);
+		break;
+	case GPIO_HIGH:
+		GPIO_OutSet(max_gpio_cfg);
+		if (gpio_regs->en & BIT(desc->number) == 0)
+			gpio_regs->en |= BIT(desc->number);
+		break;
+	case GPIO_HIGH_Z:
+		gpio_regs->en &= ~BIT(desc->number);
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Get the value of the specified GPIO.
+ * @param desc - The GPIO descriptor.
+ * @param value - The value.
+ *                Example: GPIO_HIGH
+ *                         GPIO_LOW
+ * 			   GPIO_HIGH_Z
+ * @return 0 in case of success, errno error codes otherwise.
+ */
+int32_t max_gpio_get_value(struct gpio_desc *desc, uint8_t *value)
+{
+	gpio_cfg_t *max_gpio_cfg;
+	mxc_gpio_regs_t *gpio_regs;
+
+	if (!desc || desc->number >= N_PINS)
+		return -EINVAL;
+
+	max_gpio_cfg = desc->extra;
+	gpio_regs = MXC_GPIO_GET_GPIO(max_gpio_cfg->port);
+
+	if (!max_gpio_cfg)
+		return -EINVAL;
+
+	if (!(gpio_regs->en & BIT(desc->number)))
+		*value = GPIO_HIGH_Z;
+	else if (max_gpio_cfg->func == GPIO_FUNC_IN)
+		*value = GPIO_InGet(max_gpio_cfg);
+	else
+		*value = GPIO_OutGet(max_gpio_cfg);
+
+	return 0;
+}
+
+/**
+ * @brief Init the gpio irq descriptor.
+ * @param desc - The gpio irq descriptor.
+ * @param param - The init param for the gpio irq descriptor.
+ * @return 0 in case of success, -EINVAL otherwise.
+ */
+static int32_t max_gpio_irq_ctrl_init(struct irq_ctrl_desc **desc,
+				      const struct irq_init_param *param)
+{
+	struct irq_ctrl_desc *descriptor;
+
+	if (!param)
+		return -EINVAL;
+
+	descriptor = calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	descriptor->irq_ctrl_id = param->irq_ctrl_id;
+	descriptor->platform_ops = param->platform_ops;
+	descriptor->extra = param->extra;
+
+	*desc = descriptor;
+
+	return 0;
+}
+
+/**
+ * @brief Remove gpio interrupt descriptor.
+ * @param desc - The GPIO descriptor.
+ * @return 0 in case of success, -EINVAL otherwise.
+ */
+static int32_t max_gpio_irq_ctrl_remove(struct irq_ctrl_desc *desc)
+{
+	if (!desc)
+		return -EINVAL;
+
+	free(desc);
+
+	return 0;
+}
+
+/**
+ * @brief Set the trigger condition for an interrupt.
+ * @param desc - gpio irq descriptor.
+ * @param irq_id - the pin number
+ * @param trig_l - the trigger condition.
+ * @return 0 in case of success, -EINVAL otherwise.
+ */
+static int32_t max_gpio_irq_set_trigger_level(struct irq_ctrl_desc *desc,
+		uint32_t irq_id,
+		enum irq_trig_level trig_l)
+{
+	struct gpio_desc *g_desc;
+	gpio_cfg_t *max_gpio_cfg;
+	mxc_gpio_regs_t *gpio_regs;
+	uint32_t is_enabled;
+
+	if (!desc || !desc->extra || irq_id > N_PINS)
+		return -EINVAL;
+
+	g_desc = desc->extra;
+	max_gpio_cfg = g_desc->extra;
+	gpio_regs = MXC_GPIO_GET_GPIO(max_gpio_cfg->port);
+	is_enabled = gpio_regs->int_en & BIT(irq_id);
+
+	/** Disable interrupts for pin desc->number */
+	gpio_regs->int_en &= ~(BIT(irq_id));
+	/** Clear pending interrupts for pin desc->number */
+	gpio_regs->int_clr |= BIT(irq_id);
+	/** Disable dual edge interrupts for pin desc->number */
+	gpio_regs->int_dual_edge &= ~BIT(irq_id);
+
+	switch (trig_l) {
+	case IRQ_EDGE_RISING:
+		/** Select edge triggered interrupt mode */
+		gpio_regs->int_mod |= BIT(irq_id);
+		/** Select rising edge trigger condition */
+		gpio_regs->int_pol |= BIT(irq_id);
+		break;
+	case IRQ_EDGE_FALLING:
+		/** Select edge triggered interrupt mode */
+		gpio_regs->int_mod |= BIT(irq_id);
+		/** Select falling edge trigger condition */
+		gpio_regs->int_pol &= ~(BIT(irq_id));
+		break;
+	case IRQ_LEVEL_HIGH:
+		/** Select level triggered interrupt mode */
+		gpio_regs->int_mod &= ~(BIT(irq_id));
+		/** Select level high trigger condition */
+		//gpio_regs->int_pol |= BIT(irq_id);
+		break;
+	case IRQ_LEVEL_LOW:
+		/** Select level triggered interrupt mode */
+		gpio_regs->int_mod &= ~(BIT(irq_id));
+		/** Select level low trigger condition */
+		gpio_regs->int_pol &= ~(BIT(irq_id));
+		break;
+	case IRQ_EDGE_BOTH:
+		/** Edge triggered on both rising and falling */
+		gpio_regs->int_dual_edge |= BIT(irq_id);
+		break;
+	default:
+		if (is_enabled)
+			gpio_regs->int_en |= BIT(irq_id);
+		return -EINVAL;
+	}
+	/** Enable interupts for pin desc->number if they were already enabled*/
+	if (is_enabled)
+		gpio_regs->int_en |= BIT(irq_id);
+
+	return 0;
+}
+
+/**
+ * @brief Register a function to be called when an interrupt occurs.
+ * @param desc - The gpio irq descriptor
+ * @param irq_id - The pin number.
+ * @param callback_desc - The callback descriptor
+ * @return 0 in case of success, errno error codes otherwise.
+ */
+static int32_t max_gpio_register_callback(struct irq_ctrl_desc *desc,
+		uint32_t irq_id, struct callback_desc *callback_desc)
+{
+	int32_t ret;
+	struct callback_desc *descriptor;
+	struct gpio_irq_config *g_irq;
+	struct gpio_desc *g_desc;
+	gpio_cfg_t *max_gpio_cfg;
+	enum irq_trig_level trig_level;
+
+	if (!desc || !desc->extra || !callback_desc || !callback_desc->config
+	    || irq_id >= N_PINS)
+		return -EINVAL;
+
+	g_irq = callback_desc->config;
+	g_desc = desc->extra;
+	max_gpio_cfg = g_desc->extra;
+	trig_level = g_irq->mode;
+
+	descriptor = calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	ret = max_gpio_direction_input(g_desc);
+	if (ret) {
+		free(descriptor);
+		return ret;
+	}
+
+	ret = irq_trigger_level_set(desc, irq_id, trig_level);
+	if (ret) {
+		free(descriptor);
+		return ret;
+	}
+
+	descriptor->ctx = callback_desc->ctx;
+	descriptor->callback = callback_desc->callback;
+	descriptor->config = callback_desc->config;
+
+	gpio_callback[max_gpio_cfg->port][irq_id] = descriptor;
+
+	return 0;
+}
+
+/**
+ * @brief Unregister a callback function.
+ * @param desc - The IRQ descriptor
+ * @param irq_id - The pin number
+ * @return 0 in case of success, errno error codes otherwise.
+ */
+static int32_t max_gpio_unregister_callback(struct irq_ctrl_desc *desc,
+		uint32_t irq_id)
+{
+	struct gpio_desc *g_desc;
+	gpio_cfg_t *max_gpio_cfg;
+
+	if (!desc || !desc->extra)
+		return -EINVAL;
+
+	g_desc = desc->extra;
+	max_gpio_cfg = g_desc->extra;
+
+	free(gpio_callback[max_gpio_cfg->port][irq_id]);
+	gpio_callback[max_gpio_cfg->port][irq_id] = NULL;
+
+	return 0;
+}
+
+/**
+ * @brief Enable interrupts on a GPIO pin.
+ * @param desc - The IRQ descriptor
+ * @param irq_id - The pin number
+ * @return 0 in case of success, errno error codes otherwise.
+ */
+static int32_t max_gpio_enable_irq(struct irq_ctrl_desc *desc, uint32_t irq_id)
+{
+	gpio_cfg_t *max_gpio_cfg;
+
+	if (!desc || !desc->extra)
+		return -EINVAL;
+
+	struct gpio_desc *g_desc = desc->extra;
+	max_gpio_cfg = g_desc->extra;
+	GPIO_IntEnable(max_gpio_cfg);
+
+	return 0;
+}
+
+/**
+ * @brief Disable interrupts on a GPIO pin.
+ * @param desc - The IRQ descriptor
+ * @param irq_id - The pin on which the interrupt will be disabled
+ * @return 0 in case of success, errno error codes otherwise.
+ */
+static int32_t max_gpio_disable_irq(struct irq_ctrl_desc *desc, uint32_t irq_id)
+{
+	gpio_cfg_t *max_gpio_cfg;
+
+	if (!desc || !desc->extra)
+		return -EINVAL;
+
+	struct gpio_desc *g_desc = desc->extra;
+	max_gpio_cfg = g_desc->extra;
+	GPIO_IntDisable(max_gpio_cfg);
+
+	return 0;
+}
+
+/**
+ * @brief maxim platform specific GPIO platform ops structure
+ */
+const struct gpio_platform_ops max_gpio_ops = {
+	.gpio_ops_get = &max_gpio_get,
+	.gpio_ops_get_optional = &max_gpio_get_optional,
+	.gpio_ops_remove = &max_gpio_remove,
+	.gpio_ops_direction_input = &max_gpio_direction_input,
+	.gpio_ops_direction_output = &max_gpio_direction_output,
+	.gpio_ops_get_direction = &max_gpio_get_direction,
+	.gpio_ops_set_value = &max_gpio_set_value,
+	.gpio_ops_get_value = &max_gpio_get_value
+};
+
+/**
+ * @brief maxim platform specific GPIO IRQ platform ops structure
+ */
+const struct irq_platform_ops max_gpio_irq_ops = {
+	.init = &max_gpio_irq_ctrl_init,
+	.register_callback = &max_gpio_register_callback,
+	.unregister = &max_gpio_unregister_callback,
+	.trigger_level_set = &max_gpio_irq_set_trigger_level,
+	.enable = &max_gpio_enable_irq,
+	.disable = &max_gpio_disable_irq,
+	.remove = &max_gpio_irq_ctrl_remove,
+};

--- a/drivers/platform/maxim/maxim_irq.c
+++ b/drivers/platform/maxim/maxim_irq.c
@@ -1,0 +1,197 @@
+/***************************************************************************//**
+ *   @file   maxim/maxim_irq.c
+ *   @brief  Implementation of external irq driver.
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/************************* Include Files **************************************/
+/******************************************************************************/
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <errno.h>
+#include "no-os/irq.h"
+#include "irq_extra.h"
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+/**
+ * @brief Initialized the controller for the MAX32660 external interrupts
+ * @param desc - Pointer where the configured instance is stored
+ * @param param - Configuration information for the instance
+ * @return 0 in case of success, errno error codes otherwise.
+ */
+int32_t max_irq_ctrl_init(struct irq_ctrl_desc **desc,
+			  const struct irq_init_param *param)
+{
+	struct irq_ctrl_desc *descriptor;
+
+	if (!param)
+		return -EINVAL;
+
+	descriptor = calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	descriptor->irq_ctrl_id = param->irq_ctrl_id;
+	descriptor->platform_ops = param->platform_ops;
+	descriptor->extra = param->extra;
+
+	*desc = descriptor;
+
+	return 0;
+}
+
+/**
+ * @brief Free the resources allocated by irq_ctrl_init()
+ * @param desc - Interrupt controller descriptor.
+ * @return 0 in case of success, errno error codes otherwise.
+ */
+int32_t max_irq_ctrl_remove(struct irq_ctrl_desc *desc)
+{
+	if (!desc)
+		return -EINVAL;
+
+	for(uint32_t i = 0; i < MXC_IRQ_COUNT; i++) {
+		NVIC_DisableIRQ(i);
+	}
+
+	free(desc);
+
+	return 0;
+}
+
+/**
+ * @brief Not implemented.
+ * @param desc - The IRQ controller descriptor.
+ * @param irq_id - Interrupt identifier.
+ * @param callback_desc - Descriptor of the callback.
+ * @return -ENOSYS
+ */
+int32_t max_irq_register_callback(struct irq_ctrl_desc *desc, uint32_t irq_id,
+				  struct callback_desc *callback_desc)
+{
+	return -ENOSYS;
+}
+
+/**
+ * @brief Not implemented
+ * @param desc - Interrupt controller descriptor.
+ * @param irq_id - Id of the interrupt
+ * @return -ENOSYS
+ */
+int32_t max_irq_unregister(struct irq_ctrl_desc *desc, uint32_t irq_id)
+{
+	return -ENOSYS;
+}
+
+/**
+ * @brief Enable all interrupts
+ * @param desc - Interrupt controller descriptor.
+ * @return 0
+ */
+int32_t max_irq_global_enable(struct irq_ctrl_desc *desc)
+{
+	for(uint32_t i = 0; i < MXC_IRQ_COUNT; i++) {
+		NVIC_EnableIRQ(i);
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Disable all interrupts
+ * @param desc - Interrupt controller descriptor.
+ * @return 0
+ */
+int32_t max_irq_global_disable(struct irq_ctrl_desc *desc)
+{
+	for(uint32_t i = 0; i < MXC_IRQ_COUNT; i++) {
+		NVIC_ClearPendingIRQ(i);
+		NVIC_DisableIRQ(i);
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Enable a specific interrupt
+ * @param desc - Interrupt controller descriptor.
+ * @param irq_id - Interrupt identifier
+ * @return 0 in case of success, errno error codes otherwise.
+ */
+int32_t max_irq_enable(struct irq_ctrl_desc *desc, uint32_t irq_id)
+{
+	if (irq_id >= MXC_IRQ_EXT_COUNT)
+		return -EINVAL;
+
+	NVIC_EnableIRQ(irq_id);
+
+	return 0;
+}
+
+/**
+ * @brief Disable a specific interrupt
+ * @param desc - Interrupt controller descriptor.
+ * @param irq_id - Interrupt identifier
+ * @return 0 in case of success, -EINVAL otherwise.
+ */
+int32_t max_irq_disable(struct irq_ctrl_desc *desc, uint32_t irq_id)
+{
+	if (irq_id >= MXC_IRQ_EXT_COUNT)
+		return -EINVAL;
+
+	NVIC_DisableIRQ(irq_id);
+
+	return 0;
+}
+
+/**
+ * @brief maxim specific IRQ platform ops structure
+ */
+const struct irq_platform_ops irq_ops = {
+	.init = &max_irq_ctrl_init,
+	.register_callback = &max_irq_register_callback,
+	.unregister = &max_irq_unregister,
+	.global_enable = &max_irq_global_enable,
+	.global_disable = &max_irq_global_disable,
+	.enable = &max_irq_enable,
+	.disable = &max_irq_disable,
+	.remove = &max_irq_ctrl_remove
+};

--- a/drivers/platform/maxim/maxim_rtc.c
+++ b/drivers/platform/maxim/maxim_rtc.c
@@ -1,0 +1,354 @@
+/***************************************************************************//**
+ *   @file   maxim/maxim_rtc.c
+ *   @brief  Implementation of RTC driver.
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/************************* Include Files **************************************/
+/******************************************************************************/
+
+#include <stdlib.h>
+#include <errno.h>
+#include "no-os/irq.h"
+#include "no-os/rtc.h"
+#include "no-os/util.h"
+#include "rtc.h"
+#include "rtc_extra.h"
+#include "rtc_regs.h"
+
+#define MS_TO_RSSA(x) (0 - ((x * 256) / 1000))
+
+/**
+* @brief Callback descriptor that contains a function to be called when an
+* interrupt occurs.
+*/
+static struct callback_desc *cb;
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+void RTC_IRQHandler()
+{
+	mxc_rtc_regs_t *rtc_regs;
+	volatile uint32_t rtc_ctrl;
+	uint8_t n_int;
+
+	rtc_regs = MXC_RTC;
+	rtc_ctrl = rtc_regs->ctrl;
+	/** Sub-second alarm flag clear */
+	rtc_regs->ctrl &= ~BIT(7);
+	/** Time-of-day alarm flag clear */
+	rtc_regs->ctrl &= ~BIT(6);
+	/** RTC (read) ready flag */
+	rtc_regs->ctrl &= ~BIT(5);
+
+	if(!cb)
+		return;
+
+	/** Shift right so the interrupt flags will be the first 3 bits */
+	rtc_ctrl >>= 5UL;
+	/** Clear the remaining bits */
+	rtc_ctrl &= 0x7UL;
+	while(rtc_ctrl) {
+		n_int = find_first_set_bit(rtc_ctrl);
+		if (rtc_ctrl & (rtc_regs->ctrl & BIT(n_int))) {
+			cb->callback(cb->ctx, n_int, cb->config);
+		}
+		rtc_ctrl >>= n_int + 1;
+	}
+}
+
+/**
+ * @brief Initialize the RTC peripheral.
+ * @param device - The RTC descriptor.
+ * @param init_param - The structure that contains the RTC initialization.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+int32_t rtc_init(struct rtc_desc **device, struct rtc_init_param *init_param)
+{
+	int32_t ret;
+	struct rtc_desc *dev;
+	sys_cfg_rtc_t sys_cfg;
+
+	if(!init_param)
+		return -EINVAL;
+
+	dev = calloc(1, sizeof(*dev));
+	if (!dev)
+		return -ENOMEM;
+
+	dev->id = init_param->id;
+	dev->freq = init_param->freq;
+	dev->load = init_param->load;
+	dev->extra = init_param->extra;
+
+	if (RTC_Init(MXC_RTC, dev->load, 0, &sys_cfg) != E_NO_ERROR) {
+		ret = -EINVAL;
+		goto error;
+	}
+
+	*device = dev;
+
+	return 0;
+
+error:
+	free(dev);
+
+	return ret;
+}
+
+/**
+ * @brief Free the resources allocated by rtc_init().
+ * @param dev - The RTC descriptor.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+int32_t rtc_remove(struct rtc_desc *dev)
+{
+	if (!dev)
+		return -EINVAL;
+
+	free(dev);
+
+	return 0;
+}
+
+/**
+ * @brief Start the real time clock.
+ * @param dev - The RTC descriptor.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+int32_t rtc_start(struct rtc_desc *dev)
+{
+	RTC_EnableRTCE(MXC_RTC);
+
+	/** Wait for synchronization */
+	if (RTC_CheckBusy())
+		return -EBUSY;
+
+	return 0;
+}
+
+/**
+ * @brief Stop the real time clock.
+ * @param dev - The RTC descriptor.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+int32_t rtc_stop(struct rtc_desc *dev)
+{
+	RTC_DisableRTCE(MXC_RTC);
+
+	return 0;
+}
+
+/**
+ * @brief Get the current count for the real time clock.
+ * @param dev - The RTC descriptor.
+ * @param tmr_cnt - Pointer where the read counter will be stored.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+int32_t rtc_get_cnt(struct rtc_desc *dev, uint32_t *tmr_cnt)
+{
+	if (RTC_CheckBusy())
+		return -EBUSY;
+
+	*tmr_cnt = RTC_GetSecond();
+
+	return 0;
+}
+
+/**
+ * @brief Set the current count for the real time clock.
+ * @param dev - The RTC descriptor.
+ * @param tmr_cnt - New value of the timer counter.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+int32_t rtc_set_cnt(struct rtc_desc *dev, uint32_t tmr_cnt)
+{
+	mxc_rtc_regs_t *rtc_regs;
+
+	if (!dev)
+		return-EINVAL;
+
+	rtc_regs = MXC_RTC;
+
+	if (RTC_CheckBusy())
+		return -EBUSY;
+
+	rtc_regs->ctrl |= MXC_F_RTC_CTRL_WE;
+	rtc_stop(dev);
+
+	if (RTC_CheckBusy())
+		return -EBUSY;
+
+	rtc_regs->sec = tmr_cnt;
+	rtc_start(dev);
+
+	if (RTC_CheckBusy())
+		return -EBUSY;
+
+	rtc_regs->ctrl &= ~MXC_F_RTC_CTRL_WE;
+
+	return 0;
+}
+
+static int32_t max_rtc_irq_ctrl_init(struct irq_ctrl_desc **desc,
+				     const struct irq_init_param *param)
+{
+	struct irq_ctrl_desc *descriptor;
+
+	if (!param)
+		return -EINVAL;
+
+	descriptor = calloc(1, sizeof(*descriptor));
+
+	if (!descriptor)
+		return -ENOMEM;
+
+	descriptor->irq_ctrl_id = param->irq_ctrl_id;
+	descriptor->platform_ops = param->platform_ops;
+	descriptor->extra = param->extra;
+
+	*desc = descriptor;
+
+	return 0;
+}
+
+static int32_t max_rtc_irq_ctrl_remove(struct irq_ctrl_desc *desc)
+{
+	if (!desc)
+		return -EINVAL;
+
+	free(desc);
+}
+
+/**
+ * @brief Register a function to be called when an interrupt occurs.
+ * @param dev - the callback descriptor.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+static int32_t max_rtc_register_callback(struct irq_ctrl_desc *desc,
+		uint32_t irq_id, struct callback_desc *callback_desc)
+{
+	struct max_rtc_alarm_desc *alarm_desc;
+
+	if (!desc || !callback_desc || !callback_desc->config)
+		return -EINVAL;
+
+	if (!cb) {
+		cb = calloc(1, sizeof(*cb));
+		if (!cb)
+			return -ENOMEM;
+	}
+
+	alarm_desc = callback_desc->config;
+
+	if (irq_id == RTC_TIMEOFDAY_INT)
+		RTC_SetTimeofdayAlarm(MXC_RTC, alarm_desc->irq_time);
+	else if (irq_id == RTC_SUBSEC_INT)
+		RTC_SetSubsecondAlarm(MXC_RTC, alarm_desc->irq_time);
+	else {
+		free(cb);
+		return -EINVAL;
+	}
+
+	cb->ctx = callback_desc->ctx;
+	cb->callback = callback_desc->callback;
+	cb->config = callback_desc->config;
+
+	return 0;
+}
+
+/**
+ * @brief Unregister a callback function.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+static int32_t max_rtc_unregister_callback(struct irq_ctrl_desc *desc,
+		uint32_t irq_id)
+{
+	if (!cb)
+		return -EINVAL;
+
+	free(cb);
+	cb = NULL;
+
+	return 0;
+}
+
+/**
+ * @brief Enable a specific interrupt.
+ * @param int_id - the interrupt identifier.
+ * @param irq_time - the time at which the interrupt must occur (one-shot).
+ * @return 0 in case of success, errno codes otherwise.
+ */
+static int32_t max_rtc_enable_irq(struct irq_ctrl_desc *desc, uint32_t irq_id)
+{
+	if (irq_id == RTC_TIMEOFDAY_INT) {
+		RTC_EnableTimeofdayInterrupt(MXC_RTC);
+	} else if (irq_id == RTC_SUBSEC_INT) {
+		RTC_EnableSubsecondInterrupt(MXC_RTC);
+	} else
+		return -EINVAL;
+
+	return 0;
+}
+
+/**
+ * @brief Disable a specific interrupt.
+ * @param int_id - the interrupt identifier.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+static int32_t max_rtc_disable_irq(struct irq_ctrl_desc *desc, uint32_t irq_id)
+{
+	if (irq_id == RTC_TIMEOFDAY_INT)
+		RTC_DisableTimeofdayInterrupt(MXC_RTC);
+	else if (irq_id == RTC_SUBSEC_INT)
+		RTC_DisableSubsecondInterrupt(MXC_RTC);
+	else
+		return -EINVAL;
+
+	return 0;
+}
+
+const struct irq_platform_ops max_rtc_irq_ops = {
+	.init = &max_rtc_irq_ctrl_init,
+	.remove = &max_rtc_irq_ctrl_remove,
+	.register_callback = &max_rtc_register_callback,
+	.unregister = &max_rtc_unregister_callback,
+	.enable = &max_rtc_enable_irq,
+	.disable = &max_rtc_disable_irq
+};

--- a/drivers/platform/maxim/maxim_spi.c
+++ b/drivers/platform/maxim/maxim_spi.c
@@ -1,0 +1,229 @@
+/***************************************************************************//**
+ *   @file   maxim/maxim_spi.c
+ *   @brief  Implementation of SPI driver.
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/************************* Include Files **************************************/
+/******************************************************************************/
+
+#include <stdlib.h>
+#include <errno.h>
+#include "spi.h"
+#include "spi_extra.h"
+#include "no-os/spi.h"
+#include "no-os/util.h"
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+/**
+ * @brief Initialize the SPI communication peripheral.
+ * @param desc - The SPI descriptor.
+ * @param param - The structure that contains the SPI parameters.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+int32_t max_spi_init(struct spi_desc **desc, const struct spi_init_param *param)
+{
+	int32_t ret;
+	struct spi_desc *descriptor;
+
+	if (!param)
+		return -EINVAL;
+
+	descriptor = calloc(1, sizeof(*descriptor));
+
+	if (!descriptor)
+		return -ENOMEM;
+
+	descriptor->device_id = param->device_id;
+	descriptor->max_speed_hz = param->max_speed_hz;
+	descriptor->chip_select = param->chip_select;
+	descriptor->mode = param->mode;
+	descriptor->bit_order = param->bit_order;
+	descriptor->platform_ops = &max_spi_ops;
+
+	if (descriptor->device_id == 0)
+		ret = SPI_Init(SPI0A, descriptor->mode, param->max_speed_hz);
+#ifdef MXC_SPI1A
+	else if (descriptor->device_id == 1)
+		ret = SPI_Init(SPI1A, descriptor->mode, param->max_speed_hz);
+#endif
+	else {
+		ret = -EINVAL;
+		goto err;
+	}
+
+	if (ret == E_BAD_PARAM) {
+		ret = -EINVAL;
+		goto err;
+	}
+	if (ret == E_NO_DEVICE) {
+		ret = -ENODEV;
+		goto err;
+	}
+
+	*desc = descriptor;
+
+	return 0;
+err:
+	free(descriptor);
+
+	return ret;
+}
+
+/**
+ * @brief Free the resources allocated by spi_init().
+ * @param desc - The SPI descriptor.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+int32_t max_spi_remove(struct spi_desc *desc)
+{
+	if (!desc)
+		return -EINVAL;
+
+	free(desc);
+
+	return 0;
+}
+
+/**
+ * @brief Write and read data to/from SPI.
+ * @param desc - The SPI descriptor.
+ * @param data - The buffer with the transmitted/received data.
+ * @param bytes_number - Number of bytes to write/read.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+int32_t max_spi_write_and_read(struct spi_desc *desc,
+			       uint8_t *data,
+			       uint16_t bytes_number)
+{
+	int32_t ret;
+	uint8_t *tx_buffer;
+	uint8_t *rx_buffer;
+	spi_req_t req;
+
+	if (!desc || !data)
+		return -EINVAL;
+
+	rx_buffer = data;
+	tx_buffer = data;
+
+	req.bits = 8;
+	req.ssel = desc->chip_select;
+	req.tx_data = tx_buffer;
+	req.tx_num = 0;
+	req.rx_data = rx_buffer;
+	req.rx_num = 0;
+	req.deass = 1;
+	req.width = SPI17Y_WIDTH_1;
+	req.ssel_pol = SPI17Y_POL_LOW;
+	req.len = bytes_number;
+
+	if (desc->device_id == 0)
+		ret = SPI_MasterTrans(SPI0A, &req);
+#ifdef MXC_SPI1
+	else if (desc->device_id == 1)
+		ret = SPI_MasterTrans(SPI1A, &req);
+#endif
+	else
+		return -EINVAL;
+
+	if (ret == E_BAD_PARAM)
+		return -EINVAL;
+	if (ret == E_BAD_STATE)
+		return -EBUSY;
+
+	return 0;
+}
+
+/**
+ * @brief Write/read multiple messages to/from SPI.
+ * @param desc - The SPI descriptor.
+ * @param msgs - The messages array.
+ * @param len - Number of messages.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+int32_t max_spi_transfer(struct spi_desc *desc, struct spi_msg *msgs,
+			 uint32_t len)
+{
+	spi_req_t req;
+	int32_t ret;
+
+	if (!desc || !desc->extra || !msgs)
+		return -EINVAL;
+
+	req.bits = 8;
+	req.ssel = desc->chip_select;
+	req.ssel_pol = SPI17Y_POL_LOW;
+
+	for (uint32_t i = 0; i < len; i++) {
+		req.tx_data = msgs[i].tx_buff;
+		req.rx_data = msgs[i].rx_buff;
+		req.tx_num = 0;
+		req.rx_num = 0;
+		req.deass = msgs[i].cs_change;
+		req.len = msgs[i].bytes_number;
+
+		if (desc->device_id == 0)
+			ret = SPI_MasterTrans(SPI0A, &req);
+#ifdef MXC_SPI1
+		else if (desc->device_id == 1)
+			ret = SPI_MasterTrans(SPI1A, &req);
+#endif
+		else
+			return -EINVAL;
+
+		if (ret == E_BAD_PARAM)
+			return -EINVAL;
+		if (ret == E_BAD_STATE)
+			return -EBUSY;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief maxim platform specific SPI platform ops structure
+ */
+const struct spi_platform_ops max_spi_ops = {
+	.init = &max_spi_init,
+	.write_and_read = &max_spi_write_and_read,
+	.transfer = &max_spi_transfer,
+	.remove = &max_spi_remove
+};

--- a/drivers/platform/maxim/maxim_stdio.c
+++ b/drivers/platform/maxim/maxim_stdio.c
@@ -1,0 +1,133 @@
+/***************************************************************************//**
+ *   @file   maxim/maxim_stdio.c
+ *   @brief  Implementation file of MAX32660 UART driver stdout/stdin redirection.
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+ *
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "maxim_stdio.h"
+
+#include "mxc_config.h"
+#include "mxc_sys.h"
+#include "board.h"
+#include "no-os/uart.h"
+#include "uart.h"
+
+#define CONSOLE_UART	(1)
+#define MXC_UARTn   MXC_UART_GET_UART(CONSOLE_UART)
+#define UART_FIFO   MXC_UART_GET_FIFO(CONSOLE_UART)
+
+#include <unistd.h>
+#include <sys/stat.h>
+
+#define STDIN_FILENO	0   /**> Definition of stdin */
+#define STDOUT_FILENO   1   /**> Definition of stdout */
+#define STDERR_FILENO   2   /**> Definition of stderr */
+
+static struct uart_desc *mdesc;
+
+void maxim_uart_stdio(struct uart_desc *desc)
+{
+	if (!desc)
+		return;
+	mdesc = desc;
+}
+
+int _open(const char *name, int flags, int mode)
+{
+	return -1;
+}
+int _close(int file)
+{
+	return -1;
+}
+int _isatty(int file)
+{
+	return -1;
+}
+int _lseek(int file, off_t offset, int whence)
+{
+	return -1;
+}
+int _fstat(int file, struct stat *st)
+{
+	return -1;
+}
+
+int _read(int file, char *ptr, int len)
+{
+	int ret = 0;
+
+	switch (file) {
+	case STDIN_FILENO:
+		ret = uart_read(mdesc, (uint8_t *)ptr, len);
+		if (ret < 0) {
+			errno = ret;
+			return -1;
+		}
+		break;
+	default:
+		errno = EBADF;
+		return -1;
+	}
+	return ret;
+}
+
+int _write(int file, char *ptr, int len)
+{
+	int32_t ret = 0;
+	switch (file) {
+	case STDOUT_FILENO:
+	case STDERR_FILENO:
+		ret = uart_write(mdesc, (const uint8_t *)ptr, len);
+		if (ret < 0) {
+			errno = ret;
+			return -1;
+		}
+
+		break;
+	default:
+		errno = EBADF;
+		return -1;
+	}
+
+	return len;
+}

--- a/drivers/platform/maxim/maxim_stdio.h
+++ b/drivers/platform/maxim/maxim_stdio.h
@@ -1,0 +1,54 @@
+/***************************************************************************//**
+ *   @file   maxim/maxim_stdio.h
+ *   @brief  Header file for UART driver stdout/stdin redirection.
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef _MAXIM_UART_STDIO_H_
+#define _MAXIM_UART_STDIO_H_
+
+#include <sys/stat.h>
+#include "no-os/uart.h"
+
+void maxim_uart_stdio(struct uart_desc *);
+int _open(const char *, int, int);
+int _isatty(int);
+int _write(int, char *, int);
+int _close(int);
+int _lseek(int, off_t, int);
+int _read(int, char *, int);
+int _fstat(int, struct stat *);
+
+#endif

--- a/drivers/platform/maxim/maxim_uart.c
+++ b/drivers/platform/maxim/maxim_uart.c
@@ -1,0 +1,448 @@
+/***************************************************************************//**
+ *   @file   maxim/maxim_uart.c
+ *   @brief  Source file of UART driver for STM32
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/************************* Include Files **************************************/
+/******************************************************************************/
+
+#include <errno.h>
+#include <stdlib.h>
+#include "maxim_stdio.h"
+#include "mxc_sys.h"
+#include "uart.h"
+#include "maxim_uart.h"
+#include "no-os/uart.h"
+#include "no-os/irq.h"
+#include "no-os/util.h"
+
+/**
+* @brief Callback descriptor that contains a function to be called when an
+* interrupt occurs.
+*/
+static struct callback_desc *cb[2];
+
+/**
+* @brief Descriptors to hold the state of nonblocking read and writes
+* on each port
+*/
+static uart_req_t rx_state[2];
+static uart_req_t tx_state[2];
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+static void _uart_irq(uint8_t port)
+{
+	mxc_uart_regs_t *uart_regs;
+	uint8_t	n_int;
+	uint32_t reg_int_fl;
+	uint32_t reg_int_en;
+
+	uart_regs = (port == 0) ? MXC_UART0 : MXC_UART1;
+	reg_int_fl = uart_regs->int_fl;
+	reg_int_en = uart_regs->int_en;
+
+	/** Handle nonblocking write and read, also clears the interrupt flags */
+	UART_Handler(uart_regs);
+
+	/** Disable all interrupts */
+	uart_regs->int_en = 0x0;
+
+	if (!cb[port])	{
+		/** Enable the interrupts back */
+		uart_regs->int_en = reg_int_en;
+
+		return;
+	}
+
+	while(reg_int_fl) {
+		n_int = find_first_set_bit(reg_int_fl);
+		if (reg_int_fl & (reg_int_en & BIT(n_int))) {
+			void *ctx = cb[port]->ctx;
+			void *config = cb[port]->config;
+			cb[port]->callback(ctx, n_int, config);
+		}
+		reg_int_fl >>= n_int + 1;
+	}
+
+	/** Enable the interrupts back */
+	uart_regs->int_en = reg_int_en;
+}
+
+void UART0_IRQHandler()
+{
+	_uart_irq(0);
+}
+
+void UART1_IRQHandler()
+{
+	_uart_irq(1);
+}
+
+/**
+ * @brief Read data from UART device. Blocking function.
+ * @param desc - Instance of UART.
+ * @param data - Pointer to buffer containing data.
+ * @param bytes_number - Number of bytes to read.
+ * @return positive number of received bytes in case of success, negative error code otherwise.
+ */
+int32_t uart_read(struct uart_desc *desc, uint8_t *data, uint32_t bytes_number)
+{
+	int32_t ret;
+	uint32_t bytes_read;
+
+	if (!desc || !data || !bytes_number)
+		return -EINVAL;
+
+	ret = UART_Read(MXC_UART_GET_UART(desc->device_id), data, bytes_number,
+			&bytes_read);
+
+	if (ret == E_BUSY)
+		return -EBUSY;
+
+	return bytes_read;
+}
+
+/**
+ * @brief Write data to UART device. Blocking function.
+ * @param desc - Instance of UART.
+ * @param data - Pointer to buffer containing data.
+ * @param bytes_number - Number of bytes to read.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+int32_t uart_write(struct uart_desc *desc, const uint8_t *data,
+		   uint32_t bytes_number)
+{
+	uint32_t ret;
+
+	if(!desc || !data || !bytes_number)
+		return -EINVAL;
+
+	ret = UART_Write(MXC_UART_GET_UART(desc->device_id), data, bytes_number);
+
+	if (ret == E_BUSY)
+		return -EBUSY;
+
+	return 0;
+}
+
+/**
+ * @brief Read data from UART device. Non blocking function.
+ * @param desc - Instance of UART.
+ * @param data - Pointer to buffer containing data.
+ * @param bytes_number - Number of bytes to read.
+ * @return positive number of received bytes in case of success, negative error code otherwise.
+ */
+int32_t uart_read_nonblocking(struct uart_desc *desc, uint8_t *data,
+			      uint32_t bytes_number)
+{
+	int32_t ret;
+
+	if (!desc || !data || !bytes_number)
+		return -EINVAL;
+
+	rx_state[desc->device_id].data = data;
+	rx_state[desc->device_id].len = bytes_number;
+	rx_state[desc->device_id].callback = NULL;
+
+	ret = UART_ReadAsync(MXC_UART_GET_UART(desc->device_id),
+			     &rx_state[desc->device_id]);
+
+	if (ret == E_BUSY)
+		return -EBUSY;
+
+	return 0;
+}
+
+/**
+ * @brief Write data to UART device. Non blocking function.
+ * @param desc - Instance of UART.
+ * @param data - Pointer to buffer containing data.
+ * @param bytes_number - Number of bytes to read.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+
+int32_t uart_write_nonblocking(struct uart_desc *desc, const uint8_t *data,
+			       uint32_t bytes_number)
+{
+	int32_t ret;
+
+	if (!desc || !data || !bytes_number)
+		return -EINVAL;
+
+	tx_state[desc->device_id].data = data;
+	tx_state[desc->device_id].len = bytes_number;
+	tx_state[desc->device_id].callback = NULL;
+
+	ret = UART_WriteAsync(MXC_UART_GET_UART(desc->device_id),
+			      &tx_state[desc->device_id]);
+
+	if (ret == E_BUSY)
+		return -EBUSY;
+
+	return 0;
+}
+
+/**
+ * @brief Initialize the UART communication peripheral.
+ * @param desc - The UART descriptor.
+ * @param param - The structure that contains the UART parameters.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+int32_t uart_init(struct uart_desc **desc, struct uart_init_param *param)
+{
+	int32_t ret;
+	struct max_uart_init_param *eparam;
+	struct uart_desc *descriptor;
+	uart_cfg_t maxim_desc;
+	sys_cfg_uart_t maxim_desc_sys;
+
+	if (!param || !param->extra)
+		return -EINVAL;
+
+	descriptor = calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	eparam = param->extra;
+	maxim_desc_sys.map = MAP_A;
+	maxim_desc_sys.flow_flag = UART_FLOW_DISABLE;
+
+	descriptor->device_id = param->device_id;
+	descriptor->baud_rate = param->baud_rate;
+
+	switch(param->parity) {
+	case UART_PAR_NO:
+		maxim_desc.parity = UART_PARITY_DISABLE;
+		break;
+	case UART_PARITY_MARK:
+		maxim_desc.parity = UART_PARITY_MARK;
+		break;
+	case UART_PAR_SPACE:
+		maxim_desc.parity = UART_PARITY_SPACE;
+		break;
+	case UART_PAR_ODD:
+		maxim_desc.parity = UART_PARITY_ODD;
+		break;
+	case UART_PAR_EVEN:
+		maxim_desc.parity = UART_PARITY_EVEN;
+		break;
+	default:
+		ret = -EINVAL;
+		goto error;
+	}
+
+	switch(param->size) {
+	case UART_CS_5:
+		maxim_desc.size = UART_DATA_SIZE_5_BITS;
+		break;
+	case UART_CS_6:
+		maxim_desc.size = UART_DATA_SIZE_6_BITS;
+		break;
+	case UART_CS_7:
+		maxim_desc.size = UART_DATA_SIZE_7_BITS;
+		break;
+	case UART_CS_8:
+		maxim_desc.size = UART_DATA_SIZE_8_BITS;
+		break;
+	default:
+		ret = -EINVAL;
+		goto error;
+	}
+
+	switch(param->stop) {
+	case UART_STOP_1_BIT:
+		maxim_desc.stop = UART_STOP_1;
+		break;
+	case UART_STOP_2_BIT:
+		maxim_desc.stop = UART_STOP_2;
+		break;
+	default:
+		ret = -EINVAL;
+		goto error;
+	}
+
+	maxim_desc.baud = param->baud_rate;
+
+	if (eparam->flow == UART_FLOW_DIS)
+		maxim_desc.flow = UART_FLOW_CTRL_DIS;
+	else
+		maxim_desc.flow = UART_FLOW_CTRL_EN;
+
+	if (eparam->pol == UART_FPOL_DIS)
+		maxim_desc.pol = UART_FLOW_POL_DIS;
+	else
+		maxim_desc.pol = UART_FLOW_POL_EN;
+
+	ret = UART_Init(MXC_UART_GET_UART(descriptor->device_id), &maxim_desc,
+			&maxim_desc_sys);
+	if (ret != E_NO_ERROR) {
+		ret = -EINVAL;
+		goto error;
+	}
+
+	*desc = descriptor;
+
+	return 0;
+error:
+	free(descriptor);
+
+	return ret;
+}
+
+/**
+ * @brief Free the resources allocated by uart_init().
+ * @param desc - The UART descriptor.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+int32_t uart_remove(struct uart_desc *desc)
+{
+	if (!desc)
+		return -EINVAL;
+
+	free(desc);
+
+	return 0;
+}
+
+/**
+ * @brief Not implemented.
+ * @param desc - The UART descriptor.
+ * @return -ENOSYS
+ */
+uint32_t uart_get_errors(struct uart_desc *desc)
+{
+	return -ENOSYS;
+}
+
+/**
+ * @brief Initialize the UART irq descriptor
+ * @param desc - The UART irq descriptor.
+ * @param desc - The init parameter.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+static int32_t max_uart_irq_ctrl_init(struct irq_ctrl_desc **desc,
+				      const struct irq_init_param *param)
+{
+	struct irq_ctrl_desc *descriptor;
+
+	if (!param)
+		return -EINVAL;
+
+	descriptor = calloc(1, sizeof(*descriptor));
+
+	if (!descriptor)
+		return -EINVAL;
+
+	descriptor->irq_ctrl_id = param->irq_ctrl_id;
+	descriptor->platform_ops = param->platform_ops;
+	descriptor->extra = param->extra;
+
+	*desc = descriptor;
+
+	return 0;
+}
+
+/**
+ * @brief Free the UART irq descriptor
+ * @param desc - The UART descriptor.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+static int32_t max_uart_irq_ctrl_remove(struct irq_ctrl_desc *desc)
+{
+	if (!desc)
+		return -EINVAL;
+
+	free(desc);
+
+	return 0;
+}
+
+/**
+ * @brief Register a function to be called when an interrupt occurs.
+ * @param desc - The UART irq descriptor.
+ * @param irq_id - The port on which the callback is registered.
+ * @param callback_desc - The callback_descriptor.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+static int32_t max_uart_register_callback(struct irq_ctrl_desc *desc,
+		uint32_t irq_id,
+		struct callback_desc *callback_desc)
+{
+	if (!desc || !callback_desc || irq_id >= N_PORTS)
+		return -EINVAL;
+
+	if (!cb[irq_id]) {
+		cb[irq_id] = calloc(1, sizeof(*cb[irq_id]));
+		if (!cb[irq_id])
+			return -ENOMEM;
+	}
+
+	cb[irq_id]->ctx = callback_desc->ctx;
+	cb[irq_id]->callback = callback_desc->callback;
+	cb[irq_id]->config = callback_desc->config;
+
+	return 0;
+}
+
+/**
+ * @brief Unregister a callback function.
+ * @param desc - The UART irq descriptor.
+ * @param irq_id - The UART port.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+static int32_t max_uart_unregister_callback(struct irq_ctrl_desc *desc,
+		uint32_t irq_id)
+{
+	if (irq_id >= N_PORTS || !cb[irq_id])
+		return -EINVAL;
+
+	free(cb[irq_id]);
+	cb[irq_id] = NULL;
+
+	return 0;
+}
+
+const struct irq_platform_ops max_uart_irq_ops = {
+	.init = &max_uart_irq_ctrl_init,
+	.remove = &max_uart_irq_ctrl_remove,
+	.register_callback = &max_uart_register_callback,
+	.unregister = &max_uart_unregister_callback
+};

--- a/drivers/platform/maxim/maxim_uart.h
+++ b/drivers/platform/maxim/maxim_uart.h
@@ -1,0 +1,78 @@
+/***************************************************************************//**
+ *   @file   maxim/maxim_uart.h
+ *   @brief  Header file of UART driver.
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef _MAXIM_UART_H_
+#define _MAXIM_UART_H_
+
+#include "uart.h"
+#include "no-os/irq.h"
+#include "max32660.h"
+
+#define N_PORTS	MXC_UART_INSTANCES
+
+/**
+ * @brief UART flow control
+ */
+enum max_uart_flow_ctrl {
+	UART_FLOW_DIS,
+	UART_FLOW_EN
+};
+
+/**
+ * @brief UART flow control polarity
+ */
+enum max_uart_pol {
+	UART_FPOL_DIS,
+	UART_FPOL_EN
+};
+
+/**
+ * @brief Aditional UART config parameters
+ */
+struct max_uart_init_param {
+	enum max_uart_flow_ctrl flow;
+	enum max_uart_pol pol;
+};
+
+/**
+ * @brief maxim specific UART IRQ platform ops structure
+ */
+extern const struct irq_platform_ops max_uart_irq_ops;
+
+#endif

--- a/drivers/platform/maxim/rtc_extra.h
+++ b/drivers/platform/maxim/rtc_extra.h
@@ -1,0 +1,70 @@
+/***************************************************************************//**
+ *   @file   maxim/rtc_extra.h
+ *   @brief  Header file of RTC driver.
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef RTC_EXTRA_H_
+#define RTC_EXTRA_H_
+
+#include <stdint.h>
+#include "no-os/rtc.h"
+
+#define MAX_RTC_MAX_VALUE	(0xFFFFF)
+
+/**
+ * @enum rtc_interrupt_id
+ * @brief maxim specific interrupts
+ */
+enum rtc_interrupt_id {
+	RTC_TIMEOFDAY_INT,
+	RTC_SUBSEC_INT
+};
+
+/**
+ * @struct maxim_rtc_alarm_desc
+ * @brief maxim specific interrupt descriptor
+ */
+struct max_rtc_alarm_desc {
+	uint32_t irq_time;
+};
+
+/**
+ * @brief maxim specific RTC IRQ platform ops structure
+ */
+extern const struct irq_platform_ops max_rtc_irq_ops;
+
+#endif

--- a/drivers/platform/maxim/spi_extra.h
+++ b/drivers/platform/maxim/spi_extra.h
@@ -1,0 +1,48 @@
+/***************************************************************************//**
+ *   @file   maxim/spi_extra.h
+ *   @brief  maxim specific header for SPI driver
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef SPI_EXTRA_H_
+#define SPI_EXTRA_H_
+
+/**
+ * @brief maxim specific SPI platform ops structure
+ */
+extern const struct spi_platform_ops max_spi_ops;
+
+#endif


### PR DESCRIPTION
Initial implementation of peripheral drivers for MAX32660 (UART, RTC,
SPI, GPIO and IRQ).

Signed-off-by: Ciprian Regus <ciprian.regus@analog.com>