### PR TITLE
gitignore: add .Xil folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dfp_drivers
 aducm_project
 aducm_build
 .vscode
+.Xil
 
 *.a
 *.o


### PR DESCRIPTION
Add the `.Xil` folder to the gitignore, so it won't be included
accidentally in no-OS repository commits when building projects.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>