### PR TITLE
tools: scripts: *.mk: Naming & typo corrections

### DIFF
--- a/tools/scripts/aducm.mk
+++ b/tools/scripts/aducm.mk
@@ -260,7 +260,7 @@ $(PROJECT_TARGET):
 		-append-switch linker additionaloption="$(LIB_PATHS) $(LIB_FLAGS)" \
 		$(HIDE)
 #The default startup_ADuCM3029.c has compiling errors
-#TODO Replace with patch if team think is a better aproch to install a windows
+#TODO Replace with patch if team thinks it is a better approach to install a windows
 #program for patching	
 	$(MUTE) $(call copy_fun\
 	,$(PLATFORM_TOOLS)/startup_ADuCM3029_patch.c,$(PROJECT_BUILD)/RTE/Device/ADuCM3029/startup_ADuCM3029.c) $(HIDE)

--- a/tools/scripts/aducm.mk
+++ b/tools/scripts/aducm.mk
@@ -138,7 +138,7 @@ clean: clean_hex
 
 clean_hex:
 	@$(call print,[Delete] $(HEX))
-	$(MUTE) $(call remove_fun,$(HEX)) $(HIDE)
+	$(MUTE) $(call remove_file,$(HEX)) $(HIDE)
 
 ifneq ($(wildcard $(BUILD_DIR)),)
 all: $(PIN_MUX)
@@ -147,7 +147,7 @@ endif
 #Used to update pinmux if updated on project
 $(PIN_MUX): $(PROJECT_PIN_MUX)
 	$(call print,Updating pinmux)
-	$(MUTE) $(call copy_fun,$(PROJECT_PIN_MUX),$(PIN_MUX)) $(HIDE)
+	$(MUTE) $(call copy_file,$(PROJECT_PIN_MUX),$(PIN_MUX)) $(HIDE)
 
 # Upload binary to target
 PHONY += aducm3029_run
@@ -246,7 +246,7 @@ $(PROJECT_TARGET):
 		-remove-switch linker -specs=rdimon.specs $(HIDE)
 	$(call print,Configuring project)
 #Overwrite system.rteconfig file with one that enables all DFP feautres neede by noos
-	$(MUTE) $(call copy_fun,$(PLATFORM_TOOLS)/system.rteconfig,$(PROJECT_BUILD)/system.rteconfig) $(HIDE)
+	$(MUTE) $(call copy_file,$(PLATFORM_TOOLS)/system.rteconfig,$(PROJECT_BUILD)/system.rteconfig) $(HIDE)
 #Adding pinmux plugin (Did not work to add it in the first command) and update project
 	$(MUTE) $(CCES) -nosplash -application com.analog.crosscore.headlesstools \
  		-command addaddin \
@@ -262,14 +262,14 @@ $(PROJECT_TARGET):
 #The default startup_ADuCM3029.c has compiling errors
 #TODO Replace with patch if team thinks it is a better approach to install a windows
 #program for patching	
-	$(MUTE) $(call copy_fun\
+	$(MUTE) $(call copy_file\
 	,$(PLATFORM_TOOLS)/startup_ADuCM3029_patch.c,$(PROJECT_BUILD)/RTE/Device/ADuCM3029/startup_ADuCM3029.c) $(HIDE)
 #Remove default files from projectsrc
 	$(MUTE) $(call remove_dir,$(PROJECT_BUILD)/src) $(HIDE)
 	$(MUTE) $(call set_one_time_rule,$@)
 
 copy_pinmux:
-	$(MUTE) $(call copy_fun,$(PIN_MUX),$(PROJECT_PIN_MUX)) $(HIDE)
+	$(MUTE) $(call copy_file,$(PIN_MUX),$(PROJECT_PIN_MUX)) $(HIDE)
 
 update_srcs: copy_pinmux
 

--- a/tools/scripts/aducm.mk
+++ b/tools/scripts/aducm.mk
@@ -138,7 +138,7 @@ clean: clean_hex
 
 clean_hex:
 	@$(call print,[Delete] $(HEX))
-	-$(MUTE) $(call remove_fun,$(HEX)) $(HIDE)
+	$(MUTE) $(call remove_fun,$(HEX)) $(HIDE)
 
 ifneq ($(wildcard $(BUILD_DIR)),)
 all: $(PIN_MUX)
@@ -275,7 +275,7 @@ update_srcs: copy_pinmux
 
 PHONY += clean_project
 clean_project:
-	-$(MUTE) $(call remove_dir,$(PROJECT_BUILD)/Release) $(HIDE)
+	$(MUTE) $(call remove_dir,$(PROJECT_BUILD)/Release) $(HIDE)
 #OR	
 #	$(CCES) -nosplash -application com.analog.crosscore.headlesstools \
  		-data $(WORKSPACE) \

--- a/tools/scripts/altera.mk
+++ b/tools/scripts/altera.mk
@@ -111,5 +111,5 @@ $(PROJECT_TARGET):
 
 post_build:
 	$(WSL) nios2-elf-insert $(BINARY) $(STAMP)
-	-$(call copy_fun,sw.map,$(TEMP_DIR))
-	$(call remove_fun, sw.map)
+	-$(call copy_file,sw.map,$(TEMP_DIR))
+	$(call remove_file, sw.map)

--- a/tools/scripts/altera.mk
+++ b/tools/scripts/altera.mk
@@ -112,4 +112,4 @@ $(PROJECT_TARGET):
 post_build:
 	$(WSL) nios2-elf-insert $(BINARY) $(STAMP)
 	-$(call copy_fun,sw.map,$(TEMP_DIR))
-	-$(call remove_fun, sw.map)
+	$(call remove_fun, sw.map)

--- a/tools/scripts/generic.mk
+++ b/tools/scripts/generic.mk
@@ -23,7 +23,7 @@ ROOT_DRIVE = C:
 #TIMESTAMP = $(shell powershell Get-Date -Format "HH:mm.ss")
 TIMESTAMP = 00:00:00
 copy_file = xcopy /F /Y /B "$(subst /,\,$1)" "$(subst /,\,$2)"
-copy_folder = xcopy /F /S /Y /C /I "$(subst /,\,$1)" "$(subst /,\,$2)"
+copy_dir = xcopy /F /S /Y /C /I "$(subst /,\,$1)" "$(subst /,\,$2)"
 remove_file_action = del /S /Q $(subst /,\,$1)
 remove_file = $(if $(wildcard $1),$(call remove_file_action,$(wildcard $1)),\
 			@echo rd /S /Q $(addsuffix ",$(addprefix ",$(subst /,\,$1))))
@@ -44,7 +44,7 @@ HIDE_OUTPUT = > nul
 else
 TIMESTAMP = $(shell date +"%T")
 copy_file = cp $1 $2
-copy_folder = cp -r $1 $2
+copy_dir = cp -r $1 $2
 remove_file = rm -rf $1
 remove_dir = rm -rf $1
 mk_dir = mkdir -p $1
@@ -95,12 +95,12 @@ get_full_path = $(FULL_PATH)
 endif
 
 ifeq 'y' '$(strip $(LINK_SRCS))'
-file_fun = $(make_link)
-folder_fun = $(make_dir_link)
+update_file = $(make_link)
+update_dir = $(make_dir_link)
 ACTION = Linking
 else
-file_fun = $(call copy_file,$1,$(dir $2))
-folder_fun = $(copy_folder)
+update_file = $(call copy_file,$1,$(dir $2))
+update_dir = $(copy_dir)
 ACTION = Copying
 endif
 
@@ -355,10 +355,10 @@ update_srcs: $(PROJECT_TARGET)
 	$(MUTE) $(call remove_dir,$(DIRS_TO_REMOVE)) $(HIDE)
 	$(MUTE) -$(call mk_dir,$(DIRS_TO_CREATE)) $(HIDE)
 	$(MUTE) $(foreach dir,$(sort $(SRC_DIRS)),\
-		$(call folder_fun,$(dir),$(call relative_to_project,$(dir))) $(HIDE)\
+		$(call update_dir,$(dir),$(call relative_to_project,$(dir))) $(HIDE)\
 		$(cmd_separator)) echo . $(HIDE)
 	$(MUTE) $(foreach file,$(sort $(FILES_OUT_OF_DIRS)),\
-		$(call file_fun,$(file),$(call relative_to_project,$(file))) $(HIDE)\
+		$(call update_file,$(file),$(call relative_to_project,$(file))) $(HIDE)\
 		$(cmd_separator)) echo . $(HIDE)
 
 standalone:

--- a/tools/scripts/generic.mk
+++ b/tools/scripts/generic.mk
@@ -24,8 +24,12 @@ ROOT_DRIVE = C:
 TIMESTAMP = 00:00:00
 copy_fun = xcopy /F /Y /B "$(subst /,\,$1)" "$(subst /,\,$2)"
 copy_folder = xcopy /F /S /Y /C /I "$(subst /,\,$1)" "$(subst /,\,$2)"
-remove_fun = del /S /Q $(subst /,\,$1)
-remove_dir = rd /S /Q $(addsuffix ",$(addprefix ",$(subst /,\,$1)))
+remove_fun_action = del /S /Q $(subst /,\,$1)
+remove_fun = $(if $(wildcard $1),$(call remove_fun_action,$(wildcard $1)),\
+			@echo rd /S /Q $(addsuffix ",$(addprefix ",$(subst /,\,$1))))
+remove_dir_action = rd /S /Q $(addsuffix ",$(addprefix ",$(subst /,\,$1)))
+remove_dir = $(if $(wildcard $1),$(call remove_dir_action,$(wildcard $1)),\
+			@echo rd /S /Q $(addsuffix ",$(addprefix ",$(subst /,\,$1))))
 mk_dir = md $(subst /,\,$1)
 read_file = type $(subst /,\,$1) 2> NUL
 make_dir_link = mklink /D "$(strip $(subst /,\,$2))" "$(strip $(subst /,\,$1))"
@@ -348,9 +352,7 @@ post_build:
 PHONY += update_srcs
 update_srcs: $(PROJECT_TARGET)
 	@$(call print, $(ACTION) srcs to created project)
-ifneq ($(wildcard $(DIRS_TO_REMOVE)),)
-	$(MUTE) $(call remove_dir,$(wildcard $(DIRS_TO_REMOVE))) $(HIDE)
-endif
+	$(MUTE) $(call remove_dir,$(DIRS_TO_REMOVE)) $(HIDE)
 	$(MUTE) -$(call mk_dir,$(DIRS_TO_CREATE)) $(HIDE)
 	$(MUTE) $(foreach dir,$(sort $(SRC_DIRS)),\
 		$(call folder_fun,$(dir),$(call relative_to_project,$(dir))) $(HIDE)\

--- a/tools/scripts/generic.mk
+++ b/tools/scripts/generic.mk
@@ -371,13 +371,13 @@ project_build: $(PLATFORM)_project_build
 PHONY += clean
 clean:
 	$(call print,[Delete] $(notdir $(OBJS) $(BINARY) $(ASM_OBJS)))
-	-$(MUTE)$(call remove_fun,$(BINARY) $(OBJS) $(ASM_OBJS)) $(HIDE)
+	$(MUTE) $(call remove_fun,$(BINARY) $(OBJS) $(ASM_OBJS)) $(HIDE)
 
 # Remove the whole build directory
 PHONY += clean_all
 clean_all: clean_libs
 	@$(call print,[Delete] $(BUILD_DIR))
-	-$(MUTE)$(call remove_dir,$(BUILD_DIR)) $(HIDE)
+	$(MUTE) $(call remove_dir,$(BUILD_DIR)) $(HIDE)
 
 PHONY += ca
 ca: clean_all

--- a/tools/scripts/generic.mk
+++ b/tools/scripts/generic.mk
@@ -19,13 +19,13 @@ export JTAG_CABLE_ID
 ifeq ($(OS), Windows_NT)
 SHELL=cmd
 ROOT_DRIVE = C:
-#Is slow to print timestamp in windows
+# It is slow to print timestamp in windows
 #TIMESTAMP = $(shell powershell Get-Date -Format "HH:mm.ss")
 TIMESTAMP = 00:00:00
-copy_fun = xcopy /F /Y /B "$(subst /,\,$1)" "$(subst /,\,$2)"
+copy_file = xcopy /F /Y /B "$(subst /,\,$1)" "$(subst /,\,$2)"
 copy_folder = xcopy /F /S /Y /C /I "$(subst /,\,$1)" "$(subst /,\,$2)"
-remove_fun_action = del /S /Q $(subst /,\,$1)
-remove_fun = $(if $(wildcard $1),$(call remove_fun_action,$(wildcard $1)),\
+remove_file_action = del /S /Q $(subst /,\,$1)
+remove_file = $(if $(wildcard $1),$(call remove_file_action,$(wildcard $1)),\
 			@echo rd /S /Q $(addsuffix ",$(addprefix ",$(subst /,\,$1))))
 remove_dir_action = rd /S /Q $(addsuffix ",$(addprefix ",$(subst /,\,$1)))
 remove_dir = $(if $(wildcard $1),$(call remove_dir_action,$(wildcard $1)),\
@@ -43,9 +43,9 @@ HIDE_OUTPUT = > nul
 #	LINUX
 else
 TIMESTAMP = $(shell date +"%T")
-copy_fun = cp $1 $2
+copy_file = cp $1 $2
 copy_folder = cp -r $1 $2
-remove_fun = rm -rf $1
+remove_file = rm -rf $1
 remove_dir = rm -rf $1
 mk_dir = mkdir -p $1
 read_file = cat $1 2> /dev/null
@@ -70,19 +70,19 @@ ifeq ($(strip $(VERBOSE)),2)
 HIDE = $(HIDE_OUTPUT)
 endif
 
-# recursive wildcard
+# Recursive wildcard
 rwildcard=$(foreach d,$(wildcard $(1:=/*)),$(call rwildcard,$d,$2) $(filter $(subst *,%,$2),$d))
 
-#Creates file with the specified name
+# Creates file with the specified name
 set_one_time_rule = echo Target file. Do not delete > $1
 
-# Transforme full path to relative path to be used in build
+# Transform full path to relative path to be used in build
 # $(PROJECT)/something -> srcs/something
 # $(NO-OS)/something -> noos/something
 # $(PLATFORM_TOOLS)/something -> aducm3029/something TODO test without these
 RELATIVE_PATH = $(patsubst $(NO-OS)%,noos%,$(patsubst $(PROJECT)%,$(PROJECT_NAME)%,$(PLATFORM_RELATIVE_PATH)))
 
-# Transforme relative path to full path in order to find the needed .c files
+# Transform relative path to full path in order to find the needed .c files
 # Reverse of get_relative_path
 FULL_PATH = $(patsubst noos%,$(NO-OS)%,$(patsubst $(PROJECT_NAME)%,$(PROJECT)%,$(PLATFORM_FULL_PATH)))
 
@@ -99,7 +99,7 @@ file_fun = $(make_link)
 folder_fun = $(make_dir_link)
 ACTION = Linking
 else
-file_fun = $(call copy_fun,$1,$(dir $2))
+file_fun = $(call copy_file,$1,$(dir $2))
 folder_fun = $(copy_folder)
 ACTION = Copying
 endif
@@ -112,7 +112,7 @@ ifndef NO-OS
 $(error "NO-OS variable needs to be set")
 endif
 
-#Need in libraries
+# Need in libraries
 export NO-OS
 
 ifndef PROJECT
@@ -125,7 +125,7 @@ ifndef WORKSPACE
 $(error "WORKSPACE variable needs to be set")
 endif
 
-#USED IN MAKEFILE
+# USED IN MAKEFILE
 PROJECT_NAME	= $(notdir $(PROJECT))
 OBJECTS_DIR		= $(BUILD_DIR)/objs
 PLATFORM_TOOLS	= $(NO-OS)/tools/scripts/platform/$(PLATFORM)
@@ -241,7 +241,7 @@ ALL_IGNORED_FILES = $(foreach dir, $(IGNORED_FILES), $(call rwildcard, $(dir),*)
 SRCS     := $(filter-out $(ALL_IGNORED_FILES),$(SRCS))
 INCS     := $(filter-out $(ALL_IGNORED_FILES),$(INCS))
 
-#Get all src files that are not in SRC_DRIS
+# Get all src files that are not in SRC_DRIS
 FILES_OUT_OF_DIRS := $(filter-out $(call rwildcard, $(SRC_DIRS),*), $(SRCS) $(INCS)) 
 
 REL_SRCS = $(addprefix $(OBJECTS_DIR)/,$(call get_relative_path,$(SRCS_IN_BUILD) $(PLATFORM_SRCS)))
@@ -257,10 +257,10 @@ ifneq ($(REL_ASM_SRCS),$(ASM_OBJS_S))
 	ASM_OBJS += $(ASM_OBJS_S)
 endif
 
-#Will be used to add this flags to sdk project
+# Will be used to add these flags to sdk project
 FLAGS_WITHOUT_D = $(sort $(subst -D,,$(filter -D%, $(CFLAGS))))
 
-#Remove duplicates
+# Remove duplicates
 SRCS := $(sort $(SRCS))
 INCS := $(sort $(INCS))
 
@@ -268,10 +268,10 @@ CREATED_DIRECTORIES += noos root $(PROJECT_NAME)
 SRCS_IN_BUILD = $(call relative_to_project, $(SRCS))
 INCS_IN_BUILD = $(call relative_to_project, $(INCS))
 DIRS_TO_CREATE = $(sort $(dir $(call relative_to_project, $(FILES_OUT_OF_DIRS) $(SRC_DIRS))))
-#Prefixes from get_relative_path 
+# Prefixes from get_relative_path
 DIRS_TO_REMOVE = $(addprefix $(PROJECT_BUILD)/,$(CREATED_DIRECTORIES))
 
-#Add to include all directories containing a .h file
+# Add to include all directories containing a .h file
 EXTRA_INC_PATHS := $(sort $(foreach dir, $(INCS_IN_BUILD),$(dir $(dir))))
 EXTRA_INC_PATHS := $(filter-out $(call relative_to_project,$(NO-OS)/include/no-os/),$(EXTRA_INC_PATHS))
 EXTRA_INC_PATHS += $(call relative_to_project, $(INCLUDE))
@@ -291,7 +291,7 @@ all: print_build_type $(BINARY)
 	$(call print,Done ($(notdir $(BUILD_DIR))/$(notdir $(BINARY))))
 else
 all: print_build_type
-#Remove -j flag for running project target. (It doesn't work on xilinx on this target)
+# Remove -j flag for running project target. (It doesn't work on xilinx on this target)
 	$(MUTE) $(MAKE) --no-print-directory update_srcs MAKEFLAGS=$(MAKEOVERRIDES)
 	$(MUTE) $(MAKE) --no-print-directory $(BINARY)
 	$(call print,Done ($(notdir $(BUILD_DIR))/$(notdir $(BINARY))))
@@ -301,12 +301,12 @@ PHONY += print_build_type
 print_build_type:
 	$(call print,Building for $(call green,$(PLATFORM)))
 
-#This is used to keep directory targets between makefile executions
-#More details: http://ismail.badawi.io/blog/2017/03/28/automatic-directory-creation-in-make/
-#Also the last . is explained
+# This is used to keep directory targets between makefile executions
+# More details: http://ismail.badawi.io/blog/2017/03/28/automatic-directory-creation-in-make/
+# Also the last . is explained
 .PRECIOUS: $(OBJECTS_DIR)/. $(OBJECTS_DIR)%/.
 
-#Create directories for binary files. This is needed in order to know from which
+# Create directories for binary files. This is needed in order to know from which
 # .c it was build
 $(OBJECTS_DIR)/.:
 	-@$(call mk_dir,$@) $(HIDE)
@@ -346,7 +346,7 @@ project: $(PROJECT_TARGET)
 
 $(PROJECT_TARGET): $(LIB_TARGETS)
 
-#Platform specific post build dependencies can be added to this rule.
+# Platform specific post build dependencies can be added to this rule.
 post_build:
 
 PHONY += update_srcs
@@ -371,7 +371,7 @@ project_build: $(PLATFORM)_project_build
 PHONY += clean
 clean:
 	$(call print,[Delete] $(notdir $(OBJS) $(BINARY) $(ASM_OBJS)))
-	$(MUTE) $(call remove_fun,$(BINARY) $(OBJS) $(ASM_OBJS)) $(HIDE)
+	$(MUTE) $(call remove_file,$(BINARY) $(OBJS) $(ASM_OBJS)) $(HIDE)
 
 # Remove the whole build directory
 PHONY += clean_all

--- a/tools/scripts/libraries.mk
+++ b/tools/scripts/libraries.mk
@@ -31,7 +31,7 @@ EXTRA_INC_PATHS		+= $(MBEDTLS_DIR)/include
 
 #Rules
 MBED_TLS_CONFIG_FILE = $(NO-OS)/network/noos_mbedtls_config.h
-CLEAN_MBEDTLS	= $(call remove_fun,$(MBEDTLS_LIB_DIR)/*.o $(MBEDTLS_LIBS))
+CLEAN_MBEDTLS	= $(call remove_file,$(MBEDTLS_LIB_DIR)/*.o $(MBEDTLS_LIBS))
 $(MBEDTLS_LIB_DIR)/libmbedcrypto.a: $(MBED_TLS_CONFIG_FILE)
 	-$(CLEAN_MBEDTLS)
 	$(MAKE) -C $(MBEDTLS_LIB_DIR)

--- a/tools/scripts/linux.mk
+++ b/tools/scripts/linux.mk
@@ -15,7 +15,7 @@ $(PROJECT_TARGET):
 
 develop:
 	$(MUTE) $(call mk_dir, $(PROJECT_BUILD)) $(HIDE)
-	$(MUTE) $(call copy_folder, $(PLATFORM_TOOLS)/.vscode, $(PROJECT_BUILD)/.vscode) $(HIDE)
+	$(MUTE) $(call copy_dir, $(PLATFORM_TOOLS)/.vscode, $(PROJECT_BUILD)/.vscode) $(HIDE)
 	$(MUTE) python $(PLATFORM_TOOLS)/config_build.py $(NO-OS) $(PROJECT) $(BINARY) $(HIDE)
 	$(call print, Workspace ready. Open $(PROJECT_BUILD) directory in VSCode for debug)
 

--- a/tools/scripts/stm32.mk
+++ b/tools/scripts/stm32.mk
@@ -71,7 +71,7 @@ $(PROJECT_TARGET):
 	@echo project generate >> $(BINARY).cubemx
 	@echo exit >> $(BINARY).cubemx
 	$(MUTE) java -jar $(STM32CUBEMX)/$(MX) -q $(BINARY).cubemx $(HIDE)
-	-$(MUTE)$(call remove_fun,$(BINARY).cubemx) $(HIDE)
+	$(MUTE) $(call remove_fun,$(BINARY).cubemx) $(HIDE)
 
 	$(MUTE) sed -i 's/ main(/ generated_main(/' $(PROJECT_BUILD)/Src/main.c $(HIDE)
 	$(MUTE) $(call copy_fun, $(PROJECT_BUILD)/Src/main.c, $(PROJECT_BUILD)/Src/generated_main.c) $(HIDE)
@@ -170,7 +170,7 @@ $(PLATFORM)_project_build: $(PROJECT_TARGET) $(LIB_TARGETS)
 
 clean_hex:
 	@$(call print,[Delete] $(HEX))
-	-$(MUTE) $(call remove_fun,$(HEX)) $(HIDE)
+	$(MUTE) $(call remove_fun,$(HEX)) $(HIDE)
 
 clean: clean_hex
 

--- a/tools/scripts/stm32.mk
+++ b/tools/scripts/stm32.mk
@@ -1,3 +1,4 @@
+copy_fileifeq ($(OS),Windows_NT)
 ifeq ($(OS),Windows_NT)
 $(error STM32 builds on Windows are not currently supported.)
 else
@@ -71,13 +72,13 @@ $(PROJECT_TARGET):
 	@echo project generate >> $(BINARY).cubemx
 	@echo exit >> $(BINARY).cubemx
 	$(MUTE) java -jar $(STM32CUBEMX)/$(MX) -q $(BINARY).cubemx $(HIDE)
-	$(MUTE) $(call remove_fun,$(BINARY).cubemx) $(HIDE)
+	$(MUTE) $(call remove_file,$(BINARY).cubemx) $(HIDE)
 
 	$(MUTE) sed -i 's/ main(/ generated_main(/' $(PROJECT_BUILD)/Src/main.c $(HIDE)
-	$(MUTE) $(call copy_fun, $(PROJECT_BUILD)/Src/main.c, $(PROJECT_BUILD)/Src/generated_main.c) $(HIDE)
-	$(MUTE) $(call remove_fun, $(PROJECT_BUILD)/Src/main.c) $(HIDE)
+	$(MUTE) $(call copy_file, $(PROJECT_BUILD)/Src/main.c, $(PROJECT_BUILD)/Src/generated_main.c) $(HIDE)
+	$(MUTE) $(call remove_file, $(PROJECT_BUILD)/Src/main.c) $(HIDE)
 
-	$(MUTE) $(call remove_fun, $(PROJECT_BUILD)/Src/syscalls.c) $(HIDE)
+	$(MUTE) $(call remove_file, $(PROJECT_BUILD)/Src/syscalls.c) $(HIDE)
 
 	$(call print,Configuring project)
 	$(MUTE) $(STM32CUBEIDE)/$(IDE) -nosplash -application org.eclipse.cdt.managedbuilder.core.headlessbuild \
@@ -170,7 +171,7 @@ $(PLATFORM)_project_build: $(PROJECT_TARGET) $(LIB_TARGETS)
 
 clean_hex:
 	@$(call print,[Delete] $(HEX))
-	$(MUTE) $(call remove_fun,$(HEX)) $(HIDE)
+	$(MUTE) $(call remove_file,$(HEX)) $(HIDE)
 
 clean: clean_hex
 

--- a/tools/scripts/xilinx.mk
+++ b/tools/scripts/xilinx.mk
@@ -144,7 +144,7 @@ xilinx_run: all
 
 $(TEMP_DIR)/arch.txt: $(HARDWARE)
 	$(MUTE) $(call mk_dir,$(BUILD_DIR)/app $(BUILD_DIR)/app/src $(OBJECTS_DIR) $(TEMP_DIR)) $(HIDE)
-	$(MUTE) $(call copy_fun,$(HARDWARE),$(TEMP_DIR)) $(HIDE)
+	$(MUTE) $(call copy_file,$(HARDWARE),$(TEMP_DIR)) $(HIDE)
 	$(call print,Evaluating hardware: $(HARDWARE))
 	$(MUTE)	$(call tcl_util, get_arch) $(HIDE)
 

--- a/tools/scripts/xilinx.mk
+++ b/tools/scripts/xilinx.mk
@@ -161,4 +161,4 @@ $(PROJECT_TARGET): $(TEMP_DIR)/arch.txt
 clean_all: xilinx_clean_all
 
 xilinx_clean_all:
-	-$(MUTE) $(call remove_dir,.Xil) $(HIDE)
+	$(MUTE) $(call remove_dir,.Xil) $(HIDE)


### PR DESCRIPTION
General solution to ignored error when attempting to delete non-existent file/directory in make. 

Modifications for consistency in names used in *.mk files. 