### PR TITLE
drivers:iio_adpd410x: add channel scan_index

### DIFF
--- a/drivers/photo-electronic/adpd410x/iio_adpd410x.c
+++ b/drivers/photo-electronic/adpd410x/iio_adpd410x.c
@@ -307,6 +307,7 @@ static struct scan_type channel_scan_type = {
 		.ch_type = IIO_VOLTAGE, \
 		.channel = ch, \
 		.scan_type = &channel_scan_type, \
+		.scan_index = ch, \
 		.attributes = adpd410x_iio_channel_attributes, \
 		.ch_out = false, \
 		.indexed = 1, \


### PR DESCRIPTION
Make channel `scan_index` explicit so the samples are properly
displayed when used with IIO Oscilloscope.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>