### PR TITLE
ad3552r:iio: fix prepare transfer function

### DIFF
--- a/drivers/dac/ad3552r/iio_ad3552r.c
+++ b/drivers/dac/ad3552r/iio_ad3552r.c
@@ -258,7 +258,7 @@ int32_t iio_ad3552r_init(struct iio_ad3552r_desc **iio_dac,
 	liio_dac->iio_desc.num_ch = j;
 	liio_dac->iio_desc.channels = liio_dac->channels;
 	liio_dac->iio_desc.write_dev = (int32_t (*)())iio_ad3552r_wr_dev;
-	liio_dac->iio_desc.prepare_transfer = (int32_t (*)())iio_ad3552r_prep_wr;
+	liio_dac->iio_desc.pre_enable = (int32_t (*)())iio_ad3552r_prep_wr;
 	liio_dac->iio_desc.debug_reg_read = (int32_t (*)())iio_ad3552r_read_reg;
 	liio_dac->iio_desc.debug_reg_write = (int32_t (*)())iio_ad3552r_write_reg;
 


### PR DESCRIPTION
Replace `prepare_transfer` with `pre_enable` function pointer.

There is no `prepare_transfer` attribute inside iio_device structure.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>

Example:

https://github.com/analogdevicesinc/no-OS/blob/d6b3591b5af2969818a55795681332f39ac29e1f/drivers/adc/ad713x/iio_dual_ad713x.c#L181

https://github.com/analogdevicesinc/no-OS/blob/d6b3591b5af2969818a55795681332f39ac29e1f/drivers/adc/ad713x/iio_dual_ad713x.c#L97-L106