### PR TITLE
drivers:platform:maxim: I2C driver initial commit

### DIFF
--- a/drivers/platform/maxim/i2c_extra.h
+++ b/drivers/platform/maxim/i2c_extra.h
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ *   @file   maxim/i2c_extra.h
+ *   @brief  Header containing types used in the i2c driver.
+ *   @author Andrei Drimbarean (andrei.drimbarean@analog.com)
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef I2C_EXTRA_H_
+#define I2C_EXTRA_H_
+
+#include "i2c_regs.h"
+
+/**
+ * @struct max332660_i2c_extra
+ * @brief MAX32660 specific I2C handler structure
+ */
+struct max32660_i2c_extra {
+	/** Pointer to the abstracted register structure */
+	mxc_i2c_regs_t *handler;
+	/** Pointer to the write data in case of
+	 *  write-repeated start-read operation */
+	uint8_t *prologue_data;
+	/** Size of the write data in case of
+	 *  write-repeated start-read operation */
+	uint8_t prologue_size;
+};
+
+/**
+ * @enum max32660_i2c_speed
+ * @brief MAX32660 I2C SCL frequency options
+ */
+enum max32660_i2c_speed {
+	MAX_I2C_STD_MODE = 100000,
+	MAX_I2C_FAST_MODE = 400000,
+	MAX_I2C_FAST_PLUS_MODE = 1000000,
+	MAX_I2C_HS_MODE = 3400000
+};
+
+/**
+ * @brief MAX32660 specific I2C platform ops structure
+ */
+extern const struct i2c_platform_ops max32660_i2c_ops;
+
+#endif /* I2C_EXTRA_H_ */

--- a/drivers/platform/maxim/maxim_i2c.c
+++ b/drivers/platform/maxim/maxim_i2c.c
@@ -1,0 +1,291 @@
+/***************************************************************************//**
+ *   @file   maxim/maxim_i2c.c
+ *   @brief  Implementation of max32660 I2C driver.
+ *   @author Andrei Drimbarean (andrei.drimbarean@analog.com)
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "i2c.h"
+#include "no-os/error.h"
+#include "no-os/i2c.h"
+#include "no-os/util.h"
+#include "i2c_extra.h"
+
+#define I2C_MASTER_MODE	1
+
+/** Used to know how many instances are created */
+static uint32_t nb_created_desc[MXC_I2C_INSTANCES];
+
+/**
+ * @brief I2C0 interrupt handler.
+ * @return void
+ */
+void I2C0_IRQHandler(void)
+{
+	MXC_I2C_AsyncHandler(MXC_I2C0);
+}
+
+/**
+ * @brief I2C1 interrupt handler.
+ * @return void
+ */
+void I2C1_IRQHandler(void)
+{
+	MXC_I2C_AsyncHandler(MXC_I2C1);
+}
+
+/**
+ * @brief Initialize the I2C communication peripheral.
+ * Supported bitrates are between 100kHz and 400 kHz.
+ * Is slave address is 0, then this instance will be used for general call.
+ * 10 bits addressing is not supported.
+ * @param desc - Descriptor of the I2C device used in the call of the driver
+ * functions.
+ * @param param - Parameter used to configure the I2C device. The extra field
+ * it is not used and must be set to NULL.
+ * @return \ref SUCCESS in case of success, \ref FAILURE otherwise.
+ */
+static int32_t max32660_i2c_init(struct i2c_desc **desc,
+				 const struct i2c_init_param *param)
+{
+	int32_t ret;
+	struct max32660_i2c_extra *max32660_i2c;
+	mxc_i2c_regs_t *i2c_regs;
+	uint32_t current_freq = 0;
+	uint32_t freq;
+
+	if (!desc || !param)
+		return -EINVAL;
+	if (param->device_id >= MXC_I2C_INSTANCES)
+		return -EINVAL;
+
+	*desc = calloc(1, sizeof(**desc));
+	if (!(*desc))
+		return -ENOMEM;
+
+	max32660_i2c = calloc(1, sizeof(*max32660_i2c));
+	if (!max32660_i2c) {
+		ret = -ENOMEM;
+		goto error_desc;
+	}
+
+	i2c_regs = MXC_I2C_GET_I2C(param->device_id);
+	max32660_i2c->handler = i2c_regs;
+	(*desc)->device_id = param->device_id;
+	if (param->max_speed_hz <= MAX_I2C_STD_MODE) {
+		(*desc)->max_speed_hz = MAX_I2C_STD_MODE;
+	} else if (param->max_speed_hz <= MAX_I2C_FAST_MODE) {
+		(*desc)->max_speed_hz = MAX_I2C_FAST_MODE;
+	} else if (param->max_speed_hz <= MAX_I2C_FAST_PLUS_MODE) {
+		(*desc)->max_speed_hz = MAX_I2C_FAST_PLUS_MODE;
+	} else if (param->max_speed_hz <= MAX_I2C_HS_MODE) {
+		(*desc)->max_speed_hz = MAX_I2C_HS_MODE;
+	} else {
+		ret = -EINVAL;
+		goto error_extra;
+	}
+	(*desc)->slave_address = param->slave_address;
+	(*desc)->extra = max32660_i2c;
+
+	if (nb_created_desc[param->device_id] == 0) {
+		MXC_I2C_Shutdown(max32660_i2c->handler);
+		/** The last parameter (slave address) is ignored in master mode */
+		if((MXC_I2C_Init(i2c_regs, I2C_MASTER_MODE, 0)) != E_NO_ERROR) {
+			ret = -1;
+			goto error_extra;
+		}
+	}
+	freq = MXC_I2C_GetFrequency(i2c_regs);
+	freq = min(freq, (*desc)->max_speed_hz);
+	ret = MXC_I2C_SetFrequency(i2c_regs, freq);
+	if (ret < 0)
+		return -EINVAL;
+
+	nb_created_desc[param->device_id]++;
+
+	return 0;
+error_extra:
+	free(max32660_i2c);
+error_desc:
+	free(*desc);
+
+	return ret;
+}
+
+/**
+ * @brief Free the resources allocated by \ref i2c_init
+ * @param desc - Descriptor of the I2C device
+ * @return \ref SUCCESS in case of success, \ref FAILURE otherwise.
+ */
+static int32_t max32660_i2c_remove(struct i2c_desc *desc)
+{
+	struct max32660_i2c_extra *max32660_i2c = desc->extra;
+	int32_t ret;
+
+	if (!desc)
+		return -EINVAL;
+	nb_created_desc[desc->device_id]--;
+
+	if(nb_created_desc[desc->device_id] == 0) {
+		ret = MXC_I2C_Shutdown(max32660_i2c->handler);
+		if (ret != E_NO_ERROR)
+			return ret;
+		NVIC_DisableIRQ(desc->device_id == 0 ? I2C0_IRQn : I2C1_IRQn);
+	}
+
+	free(max32660_i2c);
+	free(desc);
+
+	return 0;
+}
+
+/**
+ * @brief Write data to a slave device
+ * @param desc - Descriptor of the I2C device
+ * @param data - Buffer that stores the transmission data.
+ * @param bytes_number - Number of bytes to write.
+ * @param stop_bit - Stop condition control.
+ *                   Example: 0 - A stop condition will not be generated;
+ *                            1 - A stop condition will be generated.
+ * @return \ref SUCCESS in case of success, \ref FAILURE otherwise.
+ */
+static int32_t max32660_i2c_write(struct i2c_desc *desc,
+				  uint8_t *data,
+				  uint8_t bytes_number,
+				  uint8_t stop_bit)
+{
+	mxc_i2c_regs_t *i2c_regs;
+	mxc_i2c_req_t req;
+	struct max32660_i2c_extra *max_i2c_desc;
+	void *ptr;
+	int32_t ret;
+
+	if (!desc || !desc->extra)
+		return -EINVAL;
+
+	i2c_regs = MXC_I2C_GET_I2C(desc->device_id);
+	max_i2c_desc = desc->extra;
+
+	if (stop_bit == 0) {
+		max_i2c_desc->prologue_size = bytes_number;
+		if (max_i2c_desc->prologue_data) {
+			ptr = realloc(max_i2c_desc->prologue_data, bytes_number);
+			max_i2c_desc->prologue_data = ptr;
+		} else {
+			max_i2c_desc->prologue_data = malloc(bytes_number);
+			if (!max_i2c_desc->prologue_data)
+				return -ENOMEM;
+		}
+		memcpy(max_i2c_desc->prologue_data, data, bytes_number);
+
+		return 0;
+	}
+
+	req.i2c = i2c_regs;
+	req.addr = desc->slave_address;
+	req.tx_buf = data;
+	req.tx_len = bytes_number;
+	/** Write transaction */
+	req.rx_len = 0;
+	req.rx_buf = data;
+	req.restart = 0;
+
+	return MXC_I2C_MasterTransaction(&req);
+}
+
+/**
+ * @brief Read data from a slave device
+ * @param desc - Descriptor of the I2C device
+ * @param data - Buffer that stores the transmission data.
+ * @param bytes_number - Number of bytes to write.
+ * @param stop_bit - Stop condition control. NOTE: not applicable in this case
+ *                   Example: 0 - A stop condition will not be generated.
+ *                            1 - A stop condition will be generated
+ * @return \ref SUCCESS in case of success, \ref FAILURE otherwise.
+ */
+static int32_t max32660_i2c_read(struct i2c_desc *desc,
+				 uint8_t *data,
+				 uint8_t bytes_number,
+				 uint8_t stop_bit)
+{
+	mxc_i2c_regs_t *i2c_regs;
+	mxc_i2c_req_t req;
+	int32_t ret;
+	struct max32660_i2c_extra *max_i2c_desc;
+
+	if (!desc || !desc->extra)
+		return -EINVAL;
+
+	max_i2c_desc = desc->extra;
+	i2c_regs = MXC_I2C_GET_I2C(desc->device_id);
+	req.i2c = i2c_regs;
+	req.addr = desc->slave_address;
+	/** Read transaction */
+	req.tx_len = 0;
+	req.tx_buf = NULL;
+	req.rx_buf = data;
+	req.rx_len = bytes_number;
+	req.restart = stop_bit ? 0 : 1;
+
+	if (max_i2c_desc->prologue_size != 0) {
+		req.restart = 0;
+		req.tx_len = max_i2c_desc->prologue_size;
+		req.tx_buf = max_i2c_desc->prologue_data;
+	}
+
+	ret = MXC_I2C_MasterTransaction(&req);
+
+	if (max_i2c_desc->prologue_size != 0) {
+		free(max_i2c_desc->prologue_data);
+		max_i2c_desc->prologue_size = 0;
+		max_i2c_desc->prologue_data = NULL;
+	}
+
+	return ret;
+}
+
+/**
+ * @brief MAX32660 platform specific I2C platform ops structure
+ */
+const struct i2c_platform_ops max32660_i2c_ops = {
+	.i2c_ops_init = &max32660_i2c_init,
+	.i2c_ops_write = &max32660_i2c_write,
+	.i2c_ops_read = &max32660_i2c_read,
+	.i2c_ops_remove = &max32660_i2c_remove
+};


### PR DESCRIPTION
Add MAX32660 I2C driver allowing for master mode write and read
transactions.

Signed-off-by: Andrei Drimbarean <Andrei.Drimbarean@analog.com>
Signed-off-by: Ciprian Regus <ciprian.regus@analog.com>

This PR should be merged after https://github.com/analogdevicesinc/no-OS/pull/1207