### PR TITLE
ad7193 driver rework

### DIFF
--- a/drivers/adc/ad7193/ad7193.c
+++ b/drivers/adc/ad7193/ad7193.c
@@ -286,10 +286,18 @@ int ad7193_reset(struct ad7193_dev *dev)
  *
  * @param dev        - The device structure.
  * @param opt_mode	 - Operating mode to be set.
+ *		     Accepted values: AD7193_MODE_CONT
+ *				      AD7193_MODE_SINGLE
+ *				      AD7193_MODE_IDLE
+ *				      AD7193_MODE_PWRDN
+ *				      AD7193_MODE_CAL_INT_ZERO
+ *				      AD7193_MODE_CAL_INT_FULL
+ *				      AD7193_MODE_CAL_SYS_ZERO
+ *				      AD7193_MODE_CAL_SYS_FULL
  * @return SUCCESS in case of success or negative error code.
 *******************************************************************************/
 int ad7193_set_operating_mode(struct ad7193_dev *dev,
-			      uint8_t opt_mode)
+			      enum ad7193_adc_modes opt_mode)
 {
 	int ret;
 

--- a/drivers/adc/ad7193/ad7193.c
+++ b/drivers/adc/ad7193/ad7193.c
@@ -467,10 +467,15 @@ int ad7193_output_rate_select(struct ad7193_dev *dev,
  *
  * @param dev         - The device structure.
  * @param clk_select  - Clock source to be selected.
+ * 		     Accepted values: AD7193_EXT_CRYSTAL_MCLK1_MCLK2
+ *				      AD7193_EXT_CRYSTAL_MCLK2
+ *				      AD7193_INT_CLK_4_92_MHZ_TRIST
+ *				      AD7193_INT_CLK_4_92_MHZ
  *
  * @return SUCCESS in case of success or negative error code.
 *******************************************************************************/
-int ad7193_clock_select(struct ad7193_dev *dev, uint16_t clk_select)
+int ad7193_clock_select(struct ad7193_dev *dev,
+			enum ad7193_adc_clock clk_select)
 {
 	int ret;
 
@@ -560,7 +565,7 @@ int ad7193_single_conversion(struct ad7193_dev *dev, uint32_t *reg_data)
 		return FAILURE;
 
 	command = AD7193_MODE_SEL(AD7193_MODE_SINGLE) | AD7193_MODE_CLKSRC(
-			  AD7193_CLK_INT) | AD7193_MODE_RATE(dev->data_rate_code);
+			  AD7193_INT_CLK_4_92_MHZ_TRIST) | AD7193_MODE_RATE(dev->data_rate_code);
 
 	ret = ad7193_set_register_value(dev, AD7193_REG_MODE, command, 3);
 	if (ret != SUCCESS)
@@ -591,7 +596,7 @@ int ad7193_continuous_read_avg(struct ad7193_dev *dev,
 	int ret;
 
 	command = AD7193_MODE_SEL(AD7193_MODE_CONT) |
-		  AD7193_MODE_CLKSRC(AD7193_CLK_INT) |
+		  AD7193_MODE_CLKSRC(AD7193_INT_CLK_4_92_MHZ_TRIST) |
 		  AD7193_MODE_RATE(dev->data_rate_code);
 
 	ret = ad7193_set_register_value(dev, AD7193_REG_MODE, command, 3);

--- a/drivers/adc/ad7193/ad7193.c
+++ b/drivers/adc/ad7193/ad7193.c
@@ -98,7 +98,7 @@ int ad7193_init(struct ad7193_dev **device,
 
 	/* Initialization */
 	ret = ad7193_range_setup(dev, init_param.current_polarity,
-				 init_param.current_gain_code);
+				 init_param.current_gain);
 	if (ret != SUCCESS)
 		goto error_miso;
 
@@ -517,7 +517,7 @@ int ad7193_set_bridge_switch(struct ad7193_dev *dev, uint8_t bpdsw_select)
  * @return SUCCESS in case of success or negative error code.
 *******************************************************************************/
 int ad7193_range_setup(struct ad7193_dev *dev,
-		       uint8_t polarity, uint8_t range)
+		       uint8_t polarity, enum ad7193_adc_range range)
 {
 	int ret;
 
@@ -621,7 +621,7 @@ int ad7193_temperature_read(struct ad7193_dev *dev, float *temp)
 	int ret;
 
 	// Bipolar operation, 0 Gain.
-	ret = ad7193_range_setup(dev, 0, AD7193_CONF_GAIN_1);
+	ret = ad7193_range_setup(dev, 0, AD7193_ADC_2_5V);
 	if (ret != SUCCESS)
 		return ret;
 

--- a/drivers/adc/ad7193/ad7193.h
+++ b/drivers/adc/ad7193/ad7193.h
@@ -144,15 +144,6 @@
 #define AD7193_CH_TEMP   8 //           Temperature sensor
 #define AD7193_CH_SHORT  9 // AIN2(+) - AIN2(-);       AINCOM(+) - AINCOM(-)
 
-/* Configuration Register: AD7193_CONF_GAIN(x) options */
-//                              ADC Input Range (5 V Reference)
-#define AD7193_CONF_GAIN_1	0 // Gain 1    +-2.5 V
-#define AD7193_CONF_GAIN_8	3 // Gain 8    +-312.5 mV
-#define AD7193_CONF_GAIN_16	4 // Gain 16   +-156.2 mV
-#define AD7193_CONF_GAIN_32	5 // Gain 32   +-78.125 mV
-#define AD7193_CONF_GAIN_64	6 // Gain 64   +-39.06 mV
-#define AD7193_CONF_GAIN_128	7 // Gain 128  +-19.53 mV
-
 /* ID Register Bit Designations (AD7193_REG_ID) */
 #define ID_AD7193               0x2
 #define AD7193_ID_MASK          0x0F
@@ -173,6 +164,15 @@
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
+enum ad7193_adc_range {
+//                              ADC Input Range (5 V Reference)
+	AD7193_ADC_2_5V = 0, 		// Gain 1    +-2.5 V
+	AD7193_ADC_312_5_mV = 3, 	// Gain 8    +-312.5 mV
+	AD7193_ADC_156_2_mV = 4,	// Gain 16   +-156.2 mV
+	AD7193_ADC_78_125mV = 5,	// Gain 32   +-78.125 mV
+	AD7193_ADC_39_06mV = 6,		// Gain 64   +-39.06 mV
+	AD7193_ADC_19_53mV = 7		// Gain 128  +-19.53 mV
+};
 struct ad7193_dev {
 	/* SPI */
 	spi_desc	*spi_desc;
@@ -180,13 +180,13 @@ struct ad7193_dev {
 	struct gpio_desc	*gpio_miso;
 	/* Device Settings */
 	uint8_t		current_polarity;
-	uint8_t		current_gain;
 	uint8_t     operating_mode;
 	uint16_t    data_rate_code;
 	uint8_t     clock_source;
 	uint8_t		input_mode;
 	uint8_t		buffer;
 	uint8_t     bpdsw_mode;
+	enum ad7193_adc_range	current_gain;
 };
 
 struct ad7193_init_param {
@@ -196,13 +196,13 @@ struct ad7193_init_param {
 	struct gpio_init_param	gpio_miso;
 	/* Device Settings */
 	uint8_t		current_polarity;
-	uint8_t		current_gain_code;
 	uint8_t     operating_mode;
 	uint16_t    data_rate_code;
 	uint8_t     clock_source;
 	uint8_t		input_mode;
 	uint8_t		buffer;
 	uint8_t     bpdsw_mode;
+	enum ad7193_adc_range	current_gain;
 };
 
 /******************************************************************************/
@@ -264,7 +264,7 @@ int ad7193_set_bridge_switch(struct ad7193_dev *dev, uint8_t bpdsw_select);
 
 /*! Selects the polarity of the conversion and the ADC input range. */
 int ad7193_range_setup(struct ad7193_dev *dev,
-		       uint8_t polarity, uint8_t range);
+		       uint8_t polarity, enum ad7193_adc_range range);
 
 /*! Returns the result of a single conversion. */
 int ad7193_single_conversion(struct ad7193_dev *dev, uint32_t *reg_data);

--- a/drivers/adc/ad7193/ad7193.h
+++ b/drivers/adc/ad7193/ad7193.h
@@ -187,34 +187,34 @@ enum ad7193_adc_modes {
 
 struct ad7193_dev {
 	/* SPI */
-	spi_desc	*spi_desc;
+	spi_desc		*spi_desc;
 	/* GPIO */
 	struct gpio_desc	*gpio_miso;
 	/* Device Settings */
-	uint8_t		current_polarity;
-	uint16_t    data_rate_code;
-	uint8_t		input_mode;
-	uint8_t		buffer;
-	uint8_t     bpdsw_mode;
+	uint8_t			current_polarity;
 	enum ad7193_adc_range	current_gain;
 	enum ad7193_adc_modes	operating_mode;
+	uint16_t    		data_rate_code;
 	enum ad7193_adc_clock	clock_source;
+	uint8_t			input_mode;
+	uint8_t			buffer;
+	uint8_t     		bpdsw_mode;
 };
 
 struct ad7193_init_param {
 	/* SPI */
-	spi_init_param	spi_init;
+	spi_init_param		spi_init;
 	/* GPIO */
 	struct gpio_init_param	gpio_miso;
 	/* Device Settings */
-	uint8_t		current_polarity;
-	uint16_t    data_rate_code;
-	uint8_t		input_mode;
-	uint8_t		buffer;
-	uint8_t     bpdsw_mode;
+	uint8_t			current_polarity;
 	enum ad7193_adc_range	current_gain;
 	enum ad7193_adc_modes	operating_mode;
+	uint16_t    		data_rate_code;
 	enum ad7193_adc_clock	clock_source;
+	uint8_t			input_mode;
+	uint8_t			buffer;
+	uint8_t     		bpdsw_mode;
 };
 
 /******************************************************************************/

--- a/drivers/adc/ad7193/ad7193.h
+++ b/drivers/adc/ad7193/ad7193.h
@@ -177,7 +177,6 @@ struct ad7193_dev {
 	/* SPI */
 	spi_desc	*spi_desc;
 	/* GPIO */
-	struct gpio_desc	*gpio_cs;
 	struct gpio_desc	*gpio_miso;
 	/* Device Settings */
 	uint8_t		current_polarity;
@@ -194,7 +193,6 @@ struct ad7193_init_param {
 	/* SPI */
 	spi_init_param	spi_init;
 	/* GPIO */
-	struct gpio_init_param	gpio_cs;
 	struct gpio_init_param	gpio_miso;
 	/* Device Settings */
 	uint8_t		current_polarity;
@@ -220,23 +218,23 @@ int ad7193_remove(struct ad7193_dev *dev);
 
 /*! Writes data into a register. */
 int ad7193_set_register_value(struct ad7193_dev *dev, uint8_t reg_addr,
-			      uint32_t reg_value, uint8_t bytes_number, uint8_t modify_cs);
+			      uint32_t reg_value, uint8_t bytes_number);
 
 /*! Reads the value of a register. */
 int ad7193_get_register_value(struct ad7193_dev *dev, uint8_t reg_addr,
-			      uint8_t bytes_number, uint32_t *reg_data, uint8_t modify_cs);
+			      uint8_t bytes_number, uint32_t *reg_data);
 
 /* Write masked data into device register. */
 int ad7193_set_masked_register_value(struct ad7193_dev *dev,
 				     uint8_t reg_addr, uint32_t mask, uint32_t data,
-				     uint8_t bytes, uint8_t modify_cs);
+				     uint8_t bytes);
 
 /*! Resets the device. */
 int ad7193_reset(struct ad7193_dev *dev);
 
 /*! Set the device into specified operating mode. */
 int ad7193_set_operating_mode(struct ad7193_dev *dev,
-			      uint8_t opt_mode, uint8_t modify_cs);
+			      uint8_t opt_mode);
 
 /*! Waits for RDY pin to go low. */
 int ad7193_wait_rdy_go_low(struct ad7193_dev *dev);

--- a/drivers/adc/ad7193/ad7193.h
+++ b/drivers/adc/ad7193/ad7193.h
@@ -95,16 +95,6 @@
 #define AD7193_MODE_REJ60       (1 << 10)                          // 50/60Hz notch filter.
 #define AD7193_MODE_RATE(x)     ((x) & 0x3FF)                      // Filter Update Rate Select.
 
-/* Mode Register: AD7193_MODE_SEL(x) options */
-#define AD7193_MODE_CONT                0 // Continuous Conversion Mode.
-#define AD7193_MODE_SINGLE              1 // Single Conversion Mode.
-#define AD7193_MODE_IDLE                2 // Idle Mode.
-#define AD7193_MODE_PWRDN               3 // Power-Down Mode.
-#define AD7193_MODE_CAL_INT_ZERO        4 // Internal Zero-Scale Calibration.
-#define AD7193_MODE_CAL_INT_FULL        5 // Internal Full-Scale Calibration.
-#define AD7193_MODE_CAL_SYS_ZERO        6 // System Zero-Scale Calibration.
-#define AD7193_MODE_CAL_SYS_FULL        7 // System Full-Scale Calibration.
-
 /* Mode Register: AD7193_MODE_CLKSRC(x) options */
 #define AD7193_CLK_EXT_MCLK1_2          0 // External crystal. The external crystal
 // is connected from MCLK1 to MCLK2.
@@ -173,6 +163,25 @@ enum ad7193_adc_range {
 	AD7193_ADC_39_06mV = 6,		// Gain 64   +-39.06 mV
 	AD7193_ADC_19_53mV = 7		// Gain 128  +-19.53 mV
 };
+enum ad7193_adc_modes {
+	// Continuous Conversion Mode
+	AD7193_MODE_CONT,
+	// Single Conversion Mode
+	AD7193_MODE_SINGLE,
+	// Idle Mode
+	AD7193_MODE_IDLE,
+	// Power-Down Mode
+	AD7193_MODE_PWRDN,
+	// Internal Zero-Scale Calibration
+	AD7193_MODE_CAL_INT_ZERO,
+	// Internal Full-Scale Calibration4
+	AD7193_MODE_CAL_INT_FULL,
+	// System Zero-Scale Calibration5
+	AD7193_MODE_CAL_SYS_ZERO,
+	// System Full-Scale Calibration
+	AD7193_MODE_CAL_SYS_FULL,
+};
+
 struct ad7193_dev {
 	/* SPI */
 	spi_desc	*spi_desc;
@@ -180,13 +189,13 @@ struct ad7193_dev {
 	struct gpio_desc	*gpio_miso;
 	/* Device Settings */
 	uint8_t		current_polarity;
-	uint8_t     operating_mode;
 	uint16_t    data_rate_code;
 	uint8_t     clock_source;
 	uint8_t		input_mode;
 	uint8_t		buffer;
 	uint8_t     bpdsw_mode;
 	enum ad7193_adc_range	current_gain;
+	enum ad7193_adc_modes	operating_mode;
 };
 
 struct ad7193_init_param {
@@ -196,13 +205,13 @@ struct ad7193_init_param {
 	struct gpio_init_param	gpio_miso;
 	/* Device Settings */
 	uint8_t		current_polarity;
-	uint8_t     operating_mode;
 	uint16_t    data_rate_code;
 	uint8_t     clock_source;
 	uint8_t		input_mode;
 	uint8_t		buffer;
 	uint8_t     bpdsw_mode;
 	enum ad7193_adc_range	current_gain;
+	enum ad7193_adc_modes	operating_mode;
 };
 
 /******************************************************************************/
@@ -234,7 +243,7 @@ int ad7193_reset(struct ad7193_dev *dev);
 
 /*! Set the device into specified operating mode. */
 int ad7193_set_operating_mode(struct ad7193_dev *dev,
-			      uint8_t opt_mode);
+			      enum ad7193_adc_modes opt_mode);
 
 /*! Waits for RDY pin to go low. */
 int ad7193_wait_rdy_go_low(struct ad7193_dev *dev);

--- a/drivers/adc/ad7193/ad7193.h
+++ b/drivers/adc/ad7193/ad7193.h
@@ -95,15 +95,6 @@
 #define AD7193_MODE_REJ60       (1 << 10)                          // 50/60Hz notch filter.
 #define AD7193_MODE_RATE(x)     ((x) & 0x3FF)                      // Filter Update Rate Select.
 
-/* Mode Register: AD7193_MODE_CLKSRC(x) options */
-#define AD7193_CLK_EXT_MCLK1_2          0 // External crystal. The external crystal
-// is connected from MCLK1 to MCLK2.
-#define AD7193_CLK_EXT_MCLK2            1 // External Clock applied to MCLK2
-#define AD7193_CLK_INT                  2 // Internal 4.92 MHz clock.
-// Pin MCLK2 is tristated.
-#define AD7193_CLK_INT_CO               3 // Internal 4.92 MHz clock. The internal
-// clock is available on MCLK2.
-
 /* Mode Register: AD7193_MODE_AVG(x) options */
 #define AD7193_AVG_NONE                 0 // No averaging (fast settling mode disabled).
 #define AD7193_AVG_BY_2                 1 // Average by 2.
@@ -163,6 +154,18 @@ enum ad7193_adc_range {
 	AD7193_ADC_39_06mV = 6,		// Gain 64   +-39.06 mV
 	AD7193_ADC_19_53mV = 7		// Gain 128  +-19.53 mV
 };
+
+enum ad7193_adc_clock {
+	// External crystal. The external crystal is connected from MCLK1 to MCLK2.
+	AD7193_EXT_CRYSTAL_MCLK1_MCLK2,
+	// External Clock applied to MCLK2
+	AD7193_EXT_CRYSTAL_MCLK2,
+	// Internal 4.92 MHz clock. Pin MCLK2 is tristated.
+	AD7193_INT_CLK_4_92_MHZ_TRIST,
+	// Internal 4.92 MHz clock. The internal clock is available on MCLK2.
+	AD7193_INT_CLK_4_92_MHZ
+};
+
 enum ad7193_adc_modes {
 	// Continuous Conversion Mode
 	AD7193_MODE_CONT,
@@ -190,12 +193,12 @@ struct ad7193_dev {
 	/* Device Settings */
 	uint8_t		current_polarity;
 	uint16_t    data_rate_code;
-	uint8_t     clock_source;
 	uint8_t		input_mode;
 	uint8_t		buffer;
 	uint8_t     bpdsw_mode;
 	enum ad7193_adc_range	current_gain;
 	enum ad7193_adc_modes	operating_mode;
+	enum ad7193_adc_clock	clock_source;
 };
 
 struct ad7193_init_param {
@@ -206,12 +209,12 @@ struct ad7193_init_param {
 	/* Device Settings */
 	uint8_t		current_polarity;
 	uint16_t    data_rate_code;
-	uint8_t     clock_source;
 	uint8_t		input_mode;
 	uint8_t		buffer;
 	uint8_t     bpdsw_mode;
 	enum ad7193_adc_range	current_gain;
 	enum ad7193_adc_modes	operating_mode;
+	enum ad7193_adc_clock	clock_source;
 };
 
 /******************************************************************************/
@@ -266,7 +269,8 @@ int ad7193_output_rate_select(struct ad7193_dev *dev,
 			      uint16_t out_rate_code);
 
 /*! Selects the clock source of the ADC */
-int ad7193_clock_select(struct ad7193_dev *dev, uint16_t clk_select);
+int ad7193_clock_select(struct ad7193_dev *dev,
+			enum ad7193_adc_clock clk_select);
 
 /*! Opens or closes the bridge power-down switch of the ADC */
 int ad7193_set_bridge_switch(struct ad7193_dev *dev, uint8_t bpdsw_select);


### PR DESCRIPTION
AD7193 driver rework including:

-removed CS as gpio (the new SPI driver toggles automatically CS pin)
-range enum added
-op mode enum added
-clock enum added
-restyled

