### PR TITLE
libraries: updated include paths to no-os/

### DIFF
--- a/libraries/fatfs/adi_diskio.c
+++ b/libraries/fatfs/adi_diskio.c
@@ -45,7 +45,7 @@
 #include "diskio.h"		/* Declarations of disk functions */
 
 #include "sd.h"
-#include "error.h"
+#include "no-os/error.h"
 #include <stdio.h>
 
 /******************************************************************************/

--- a/libraries/mqtt/mqtt_client.c
+++ b/libraries/mqtt/mqtt_client.c
@@ -45,7 +45,7 @@
 #include <string.h>
 #include "mqtt_client.h"
 #include "MQTTClient.h"
-#include "error.h"
+#include "no-os/error.h"
 
 /******************************************************************************/
 /*************************** Types Declarations *******************************/

--- a/libraries/mqtt/mqtt_noos_support.c
+++ b/libraries/mqtt/mqtt_noos_support.c
@@ -158,16 +158,16 @@ int mqtt_noos_read(Network* net, unsigned char* buff, int len, int timeout)
 
 	sent = 0;
 	do {
- 		rc = socket_recv(net->sock, (void *)(buff + sent),
-				(uint32_t)(len - sent));
- 		if (rc != -EAGAIN) { //If data available or error
- 			if (IS_ERR_VALUE(rc))
- 				return rc;
-				 
- 			sent += rc;
- 			if (sent >= len)
- 				return sent;
- 		}
+		rc = socket_recv(net->sock, (void *)(buff + sent),
+				 (uint32_t)(len - sent));
+		if (rc != -EAGAIN) { //If data available or error
+			if (IS_ERR_VALUE(rc))
+				return rc;
+
+			sent += rc;
+			if (sent >= len)
+				return sent;
+		}
 
 		mdelay(1);
 	} while (--timeout);

--- a/libraries/mqtt/mqtt_noos_support.c
+++ b/libraries/mqtt/mqtt_noos_support.c
@@ -43,11 +43,11 @@
 
 #include "mqtt_noos_support.h"
 #include <stdlib.h>
-#include "timer.h"
-#include "error.h"
-#include "util.h"
-#include "delay.h"
-#include "error.h"
+#include "no-os/timer.h"
+#include "no-os/error.h"
+#include "no-os/util.h"
+#include "no-os/delay.h"
+#include "no-os/error.h"
 
 /******************************************************************************/
 /**************************** Global Variables ********************************/


### PR DESCRIPTION
Modified some #include directives from mqtt and fatfs libraries with
the correct paths. This change should have been made in #1178.

Signed-off-by: Ciprian Regus <ciprian.regus@analog.com>