### PR TITLE
IIOD attribute write and debug register read/write issue fix

### DIFF
--- a/iio/iiod.c
+++ b/iio/iiod.c
@@ -634,6 +634,7 @@ static int32_t iiod_run_cmd(struct iiod_desc *desc,
 		ret = desc->ops.write_attr(&ctx, data->device, &attr,
 					   conn->payload_buf,
 					   data->bytes_count);
+		conn->nb_buf.len = 0;
 		conn->res.val = ret;
 		conn->res.write_val = 1;
 		break;
@@ -728,6 +729,9 @@ static int32_t iiod_run_state(struct iiod_desc *desc,
 			conn->state = IIOD_WRITING_CMD_RESULT;
 		} else if (conn->cmd_data.cmd == IIOD_CMD_WRITE) {
 			/* Special case. Attribute needs to be read */
+			conn->nb_buf.buf = conn->payload_buf;
+			conn->nb_buf.len = conn->cmd_data.bytes_count;
+			conn->nb_buf.idx = 0;
 			conn->state = IIOD_READING_WRITE_DATA;
 		} else {
 			conn->state = IIOD_RUNNING_CMD;


### PR DESCRIPTION
The non-blocking version of IIOD doesn't work well with IIO client (e.g. IIO oscilloscope) to write the IIO attribute value and perform debug register read/write operations. The IIO attribute write is a special case where two consecutive commands are sent from IIO client over serial link: 1) Attribute write command with size of data byte  2) Attribute write value
Existing code had bug in reading the attribute write value (i.e. 2nd command was not handled correctly). So updated code to handle this command by initializing payload buffer and length in IIOD command run state.
Verified other operation (attr read/write, data capture, debug register read/write) after this change and nothing is broken.

Signed-off-by: mahphalke <Mahesh.Phalke@analog.com>