### PR TITLE
AD7193 driver extended to support 0/2/4/5 chips

### DIFF
--- a/drivers/adc/ad7193/ad7193.c
+++ b/drivers/adc/ad7193/ad7193.c
@@ -139,9 +139,11 @@ int ad7193_init(struct ad7193_dev **device,
 	if (ret != SUCCESS)
 		goto error_miso;
 
-	ret = ad7193_config_input_mode(dev, init_param.input_mode);
-	if (ret != SUCCESS)
-		goto error_miso;
+	if(dev->chip_id == AD7193 || dev->chip_id == AD7194) {
+		ret = ad7193_config_input_mode(dev, init_param.input_mode);
+		if (ret != SUCCESS)
+			goto error_miso;
+	}
 
 	ret = ad7193_clock_select(dev, init_param.clock_source);
 	if (ret != SUCCESS)
@@ -445,16 +447,17 @@ int ad7193_config_input_mode(struct ad7193_dev *dev, uint8_t mode)
 {
 	int ret;
 
-	ret = ad7193_set_masked_register_value(dev, AD7193_REG_CONF,
-					       AD7193_CONF_PSEUDO, (AD7193_CONF_PSEUDO * mode),
-					       3);
-
-	if (ret == SUCCESS) {
-		/* Store the last settings regarding input mode. */
-		dev->input_mode = mode;
-	}
-
-	return ret;
+	if(dev->chip_id == AD7193 || dev->chip_id == AD7194) {
+		ret = ad7193_set_masked_register_value(dev, AD7193_REG_CONF,
+						       AD7193_CONF_PSEUDO, (AD7193_CONF_PSEUDO * mode),
+						       3);
+		if (ret == SUCCESS) {
+			/* Store the last settings regarding input mode. */
+			dev->input_mode = mode;
+		}
+		return ret;
+	} else
+		return -ENOTSUP;
 }
 
 /***************************************************************************//**
@@ -550,6 +553,10 @@ int ad7193_clock_select(struct ad7193_dev *dev,
 int ad7193_set_bridge_switch(struct ad7193_dev *dev, uint8_t bpdsw_select)
 {
 	int ret;
+
+	if(dev->chip_id == AD7194) {
+		return -ENOTSUP;
+	}
 
 	ret = ad7193_set_masked_register_value(dev, AD7193_REG_GPOCON,
 					       AD7193_GPOCON_BPDSW, (AD7193_GPOCON_BPDSW * bpdsw_select),

--- a/drivers/adc/ad7193/ad7193.c
+++ b/drivers/adc/ad7193/ad7193.c
@@ -557,25 +557,25 @@ int ad7193_set_bridge_switch(struct ad7193_dev *dev, uint8_t bpdsw_select)
  * @param polarity - Polarity select bit.
  *                   Example: 0 - bipolar operation is selected.
  *                            1 - unipolar operation is selected.
- *@param range     - Gain select bits. These bits are written by the user to select
+ *@param gain      - Gain select bits. These bits are written by the user to select
  *                   the ADC input range.
  *
  * @return SUCCESS in case of success or negative error code.
 *******************************************************************************/
 int ad7193_range_setup(struct ad7193_dev *dev,
-		       uint8_t polarity, enum ad7193_adc_range range)
+		       uint8_t polarity, enum ad719x_adc_gain gain)
 {
 	int ret;
 
 	ret = ad7193_set_masked_register_value(dev, AD7193_REG_CONF,
 					       (AD7193_CONF_UNIPOLAR | AD7193_CONF_GAIN(0x7)),
-					       (polarity * AD7193_CONF_UNIPOLAR) | AD7193_CONF_GAIN(range),
+					       (polarity * AD7193_CONF_UNIPOLAR) | AD7193_CONF_GAIN(gain),
 					       3);
 
 	if (ret == SUCCESS) {
 		/* Store the last settings regarding polarity and gain. */
 		dev->current_polarity = polarity;
-		dev->current_gain     = 1 << range;
+		dev->current_gain     = 1 << gain;
 	}
 
 	return ret;
@@ -666,8 +666,8 @@ int ad7193_temperature_read(struct ad7193_dev *dev, float *temp)
 	uint32_t data_reg = 0;
 	int ret;
 
-	// Bipolar operation, 0 Gain.
-	ret = ad7193_range_setup(dev, 0, AD7193_ADC_2_5V);
+	// Bipolar operation, 1 Gain.
+	ret = ad7193_range_setup(dev, 0, AD719X_ADC_GAIN_1);
 	if (ret != SUCCESS)
 		return ret;
 

--- a/drivers/adc/ad7193/ad7193.c
+++ b/drivers/adc/ad7193/ad7193.c
@@ -70,6 +70,8 @@ int ad7193_init(struct ad7193_dev **device,
 	if (!dev)
 		return -ENOMEM;
 
+	dev->chip_id = init_param.chip_id;
+
 	/* SPI */
 	ret = spi_init(&dev->spi_desc, &init_param.spi_init);
 	if (ret != SUCCESS)
@@ -93,10 +95,35 @@ int ad7193_init(struct ad7193_dev **device,
 	if (ret != SUCCESS)
 		goto error_miso;
 
-	if((reg_val & AD7193_ID_MASK) != ID_AD7193) {
-		goto error_miso;
+	switch (dev->chip_id) {
+	case AD7190:
+		if((reg_val & AD719X_ID_MASK) != AD7190) {
+			goto error_miso;
+		}
+		break;
+	case AD7192:
+		if((reg_val & AD719X_ID_MASK) != AD7192) {
+			goto error_miso;
+		}
+		break;
+	case AD7193:
+		if((reg_val & AD719X_ID_MASK) != AD7193) {
+			goto error_miso;
+		}
+		break;
+	case AD7194:
+		if((reg_val & AD719X_ID_MASK) != AD7194) {
+			goto error_miso;
+		}
+		break;
+	case AD7195:
+		if((reg_val & AD719X_ID_MASK) != AD7195) {
+			goto error_miso;
+		}
+		break;
+	default:
+		return FAILURE;
 	}
-
 
 	/* Initialization */
 	ret = ad7193_range_setup(dev, init_param.current_polarity,

--- a/drivers/adc/ad7193/ad7193.c
+++ b/drivers/adc/ad7193/ad7193.c
@@ -372,18 +372,31 @@ int ad7193_wait_rdy_go_low(struct ad7193_dev *dev)
  *
  * @param dev      - The device structure.
  * @param chn_mask - Channel mask.
- *                  Example: AD7193_CH_0 - AIN1(+) - AIN2(-);  (Pseudo = 0)
- *                           AD7193_CH_1 - AIN3(+) - AIN4(-);  (Pseudo = 0)
- *                           AD7193_TEMP - Temperature sensor
- *                           AD7193_SHORT - AIN2(+) - AIN2(-); (Pseudo = 0)
+ *                  Example: AD719X_CH_0 - AIN1(+) - AIN2(-);  (Pseudo = 0)
+ *                           AD719X_CH_1 - AIN3(+) - AIN4(-);  (Pseudo = 0)
+ *                           AD719X_TEMP - Temperature sensor
+ *                           AD719X_SHORT - AIN2(+) - AIN2(-); (Pseudo = 0)
  *
  * @return SUCCESS in case of success or negative error code.
 *******************************************************************************/
 int ad7193_channels_select(struct ad7193_dev *dev,
 			   uint16_t chn_mask)
 {
-	if (chn_mask > 0x3FF) {
-		return -EINVAL;
+	switch (dev->chip_id) {
+	case AD7193:
+		if (chn_mask > 0x3FF) {
+			return -EINVAL;
+		}
+		break;
+	case AD7194:
+		if (chn_mask > 0x1FF) {
+			return -EINVAL;
+		}
+		break;
+	default:
+		if (chn_mask > 0xFF) {
+			return -EINVAL;
+		}
 	}
 
 	return ad7193_set_masked_register_value(dev, AD7193_REG_CONF,
@@ -671,7 +684,7 @@ int ad7193_temperature_read(struct ad7193_dev *dev, float *temp)
 	if (ret != SUCCESS)
 		return ret;
 
-	ret = ad7193_channels_select(dev, AD7193_CH_MASK(AD7193_CH_TEMP));
+	ret = ad7193_channels_select(dev, AD719X_CH_MASK(AD719X_CH_TEMP));
 	if (ret != SUCCESS)
 		return ret;
 

--- a/drivers/adc/ad7193/ad7193.c
+++ b/drivers/adc/ad7193/ad7193.c
@@ -684,9 +684,15 @@ int ad7193_temperature_read(struct ad7193_dev *dev, float *temp)
 	if (ret != SUCCESS)
 		return ret;
 
-	ret = ad7193_channels_select(dev, AD719X_CH_MASK(AD719X_CH_TEMP));
-	if (ret != SUCCESS)
-		return ret;
+	if(dev->chip_id == AD7190 || dev->chip_id == AD7192 || dev->chip_id == AD7195) {
+		ret = ad7193_channels_select(dev, AD719X_CH_MASK(AD719X_CH_2));
+		if (ret != SUCCESS)
+			return ret;
+	} else {
+		ret = ad7193_channels_select(dev, AD719X_CH_MASK(AD719X_CH_TEMP));
+		if (ret != SUCCESS)
+			return ret;
+	}
 
 	ret = ad7193_single_conversion(dev, &data_reg);
 	if (ret != SUCCESS)

--- a/drivers/adc/ad7193/ad7193.c
+++ b/drivers/adc/ad7193/ad7193.c
@@ -319,18 +319,18 @@ int ad7193_reset(struct ad7193_dev *dev)
  *
  * @param dev        - The device structure.
  * @param opt_mode	 - Operating mode to be set.
- *		     Accepted values: AD7193_MODE_CONT
- *				      AD7193_MODE_SINGLE
- *				      AD7193_MODE_IDLE
- *				      AD7193_MODE_PWRDN
- *				      AD7193_MODE_CAL_INT_ZERO
- *				      AD7193_MODE_CAL_INT_FULL
- *				      AD7193_MODE_CAL_SYS_ZERO
- *				      AD7193_MODE_CAL_SYS_FULL
+ *		     Accepted values: AD719X_MODE_CONT
+ *				      AD719X_MODE_SINGLE
+ *				      AD719X_MODE_IDLE
+ *				      AD719X_MODE_PWRDN
+ *				      AD719X_MODE_CAL_INT_ZERO
+ *				      AD719X_MODE_CAL_INT_FULL
+ *				      AD719X_MODE_CAL_SYS_ZERO
+ *				      AD719X_MODE_CAL_SYS_FULL
  * @return SUCCESS in case of success or negative error code.
 *******************************************************************************/
 int ad7193_set_operating_mode(struct ad7193_dev *dev,
-			      enum ad7193_adc_modes opt_mode)
+			      enum ad719x_adc_modes opt_mode)
 {
 	int ret;
 
@@ -500,15 +500,15 @@ int ad7193_output_rate_select(struct ad7193_dev *dev,
  *
  * @param dev         - The device structure.
  * @param clk_select  - Clock source to be selected.
- * 		     Accepted values: AD7193_EXT_CRYSTAL_MCLK1_MCLK2
- *				      AD7193_EXT_CRYSTAL_MCLK2
- *				      AD7193_INT_CLK_4_92_MHZ_TRIST
- *				      AD7193_INT_CLK_4_92_MHZ
+ * 		     Accepted values: AD719X_EXT_CRYSTAL_MCLK1_MCLK2
+ *				      AD719X_EXT_CRYSTAL_MCLK2
+ *				      AD719X_INT_CLK_4_92_MHZ_TRIST
+ *				      AD719X_INT_CLK_4_92_MHZ
  *
  * @return SUCCESS in case of success or negative error code.
 *******************************************************************************/
 int ad7193_clock_select(struct ad7193_dev *dev,
-			enum ad7193_adc_clock clk_select)
+			enum ad719x_adc_clock clk_select)
 {
 	int ret;
 
@@ -597,8 +597,8 @@ int ad7193_single_conversion(struct ad7193_dev *dev, uint32_t *reg_data)
 	if (!reg_data)
 		return FAILURE;
 
-	command = AD7193_MODE_SEL(AD7193_MODE_SINGLE) | AD7193_MODE_CLKSRC(
-			  AD7193_INT_CLK_4_92_MHZ_TRIST) | AD7193_MODE_RATE(dev->data_rate_code);
+	command = AD7193_MODE_SEL(AD719X_MODE_SINGLE) | AD7193_MODE_CLKSRC(
+			  AD719X_INT_CLK_4_92_MHZ_TRIST) | AD7193_MODE_RATE(dev->data_rate_code);
 
 	ret = ad7193_set_register_value(dev, AD7193_REG_MODE, command, 3);
 	if (ret != SUCCESS)
@@ -628,8 +628,8 @@ int ad7193_continuous_read_avg(struct ad7193_dev *dev,
 	uint8_t count = 0;
 	int ret;
 
-	command = AD7193_MODE_SEL(AD7193_MODE_CONT) |
-		  AD7193_MODE_CLKSRC(AD7193_INT_CLK_4_92_MHZ_TRIST) |
+	command = AD7193_MODE_SEL(AD719X_MODE_CONT) |
+		  AD7193_MODE_CLKSRC(AD719X_INT_CLK_4_92_MHZ_TRIST) |
 		  AD7193_MODE_RATE(dev->data_rate_code);
 
 	ret = ad7193_set_register_value(dev, AD7193_REG_MODE, command, 3);

--- a/drivers/adc/ad7193/ad7193.h
+++ b/drivers/adc/ad7193/ad7193.h
@@ -126,8 +126,7 @@
 #define AD7193_CH_SHORT  9 // AIN2(+) - AIN2(-);       AINCOM(+) - AINCOM(-)
 
 /* ID Register Bit Designations (AD7193_REG_ID) */
-#define ID_AD7193               0x2
-#define AD7193_ID_MASK          0x0F
+#define AD719X_ID_MASK          0x0F
 
 /* GPOCON Register Bit Designations (AD7193_REG_GPOCON) */
 #define AD7193_GPOCON_BPDSW     (1 << 6) // Bridge power-down switch enable
@@ -185,6 +184,14 @@ enum ad7193_adc_modes {
 	AD7193_MODE_CAL_SYS_FULL,
 };
 
+enum ad719x_chip_id {
+	AD7190 = 0x4,
+	AD7192 = 0x0,
+	AD7193 = 0x2,
+	AD7194 = 0x3,
+	AD7195 = 0xA6
+};
+
 struct ad7193_dev {
 	/* SPI */
 	spi_desc		*spi_desc;
@@ -199,6 +206,7 @@ struct ad7193_dev {
 	uint8_t			input_mode;
 	uint8_t			buffer;
 	uint8_t     		bpdsw_mode;
+	enum ad719x_chip_id chip_id;
 };
 
 struct ad7193_init_param {
@@ -215,6 +223,7 @@ struct ad7193_init_param {
 	uint8_t			input_mode;
 	uint8_t			buffer;
 	uint8_t     		bpdsw_mode;
+	enum ad719x_chip_id chip_id;
 };
 
 /******************************************************************************/

--- a/drivers/adc/ad7193/ad7193.h
+++ b/drivers/adc/ad7193/ad7193.h
@@ -144,14 +144,14 @@
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
-enum ad7193_adc_range {
-//                              ADC Input Range (5 V Reference)
-	AD7193_ADC_2_5V = 0, 		// Gain 1    +-2.5 V
-	AD7193_ADC_312_5_mV = 3, 	// Gain 8    +-312.5 mV
-	AD7193_ADC_156_2_mV = 4,	// Gain 16   +-156.2 mV
-	AD7193_ADC_78_125mV = 5,	// Gain 32   +-78.125 mV
-	AD7193_ADC_39_06mV = 6,		// Gain 64   +-39.06 mV
-	AD7193_ADC_19_53mV = 7		// Gain 128  +-19.53 mV
+enum ad719x_adc_gain {
+//                           ADC Gain (CONF Reg)
+	AD719X_ADC_GAIN_1 = 0, 		// Gain 1
+	AD719X_ADC_GAIN_8 = 3, 		// Gain 8
+	AD719X_ADC_GAIN_16 = 4,		// Gain 16
+	AD719X_ADC_GAIN_32 = 5,		// Gain 32
+	AD719X_ADC_GAIN_64 = 6,		// Gain 64
+	AD719X_ADC_GAIN_128 = 7		// Gain 128
 };
 
 enum ad7193_adc_clock {
@@ -199,7 +199,7 @@ struct ad7193_dev {
 	struct gpio_desc	*gpio_miso;
 	/* Device Settings */
 	uint8_t			current_polarity;
-	enum ad7193_adc_range	current_gain;
+	enum ad719x_adc_gain	current_gain;
 	enum ad7193_adc_modes	operating_mode;
 	uint16_t    		data_rate_code;
 	enum ad7193_adc_clock	clock_source;
@@ -216,7 +216,7 @@ struct ad7193_init_param {
 	struct gpio_init_param	gpio_miso;
 	/* Device Settings */
 	uint8_t			current_polarity;
-	enum ad7193_adc_range	current_gain;
+	enum ad719x_adc_gain	current_gain;
 	enum ad7193_adc_modes	operating_mode;
 	uint16_t    		data_rate_code;
 	enum ad7193_adc_clock	clock_source;
@@ -286,7 +286,7 @@ int ad7193_set_bridge_switch(struct ad7193_dev *dev, uint8_t bpdsw_select);
 
 /*! Selects the polarity of the conversion and the ADC input range. */
 int ad7193_range_setup(struct ad7193_dev *dev,
-		       uint8_t polarity, enum ad7193_adc_range range);
+		       uint8_t polarity, enum ad719x_adc_gain gain);
 
 /*! Returns the result of a single conversion. */
 int ad7193_single_conversion(struct ad7193_dev *dev, uint32_t *reg_data);

--- a/drivers/adc/ad7193/ad7193.h
+++ b/drivers/adc/ad7193/ad7193.h
@@ -154,34 +154,34 @@ enum ad719x_adc_gain {
 	AD719X_ADC_GAIN_128 = 7		// Gain 128
 };
 
-enum ad7193_adc_clock {
+enum ad719x_adc_clock {
 	// External crystal. The external crystal is connected from MCLK1 to MCLK2.
-	AD7193_EXT_CRYSTAL_MCLK1_MCLK2,
+	AD719X_EXT_CRYSTAL_MCLK1_MCLK2,
 	// External Clock applied to MCLK2
-	AD7193_EXT_CRYSTAL_MCLK2,
+	AD719X_EXT_CRYSTAL_MCLK2,
 	// Internal 4.92 MHz clock. Pin MCLK2 is tristated.
-	AD7193_INT_CLK_4_92_MHZ_TRIST,
+	AD719X_INT_CLK_4_92_MHZ_TRIST,
 	// Internal 4.92 MHz clock. The internal clock is available on MCLK2.
-	AD7193_INT_CLK_4_92_MHZ
+	AD719X_INT_CLK_4_92_MHZ
 };
 
-enum ad7193_adc_modes {
+enum ad719x_adc_modes {
 	// Continuous Conversion Mode
-	AD7193_MODE_CONT,
+	AD719X_MODE_CONT,
 	// Single Conversion Mode
-	AD7193_MODE_SINGLE,
+	AD719X_MODE_SINGLE,
 	// Idle Mode
-	AD7193_MODE_IDLE,
+	AD719X_MODE_IDLE,
 	// Power-Down Mode
-	AD7193_MODE_PWRDN,
+	AD719X_MODE_PWRDN,
 	// Internal Zero-Scale Calibration
-	AD7193_MODE_CAL_INT_ZERO,
+	AD719X_MODE_CAL_INT_ZERO,
 	// Internal Full-Scale Calibration4
-	AD7193_MODE_CAL_INT_FULL,
+	AD719X_MODE_CAL_INT_FULL,
 	// System Zero-Scale Calibration5
-	AD7193_MODE_CAL_SYS_ZERO,
+	AD719X_MODE_CAL_SYS_ZERO,
 	// System Full-Scale Calibration
-	AD7193_MODE_CAL_SYS_FULL,
+	AD719X_MODE_CAL_SYS_FULL,
 };
 
 enum ad719x_chip_id {
@@ -200,9 +200,9 @@ struct ad7193_dev {
 	/* Device Settings */
 	uint8_t			current_polarity;
 	enum ad719x_adc_gain	current_gain;
-	enum ad7193_adc_modes	operating_mode;
+	enum ad719x_adc_modes	operating_mode;
 	uint16_t    		data_rate_code;
-	enum ad7193_adc_clock	clock_source;
+	enum ad719x_adc_clock	clock_source;
 	uint8_t			input_mode;
 	uint8_t			buffer;
 	uint8_t     		bpdsw_mode;
@@ -217,9 +217,9 @@ struct ad7193_init_param {
 	/* Device Settings */
 	uint8_t			current_polarity;
 	enum ad719x_adc_gain	current_gain;
-	enum ad7193_adc_modes	operating_mode;
+	enum ad719x_adc_modes	operating_mode;
 	uint16_t    		data_rate_code;
-	enum ad7193_adc_clock	clock_source;
+	enum ad719x_adc_clock	clock_source;
 	uint8_t			input_mode;
 	uint8_t			buffer;
 	uint8_t     		bpdsw_mode;
@@ -255,7 +255,7 @@ int ad7193_reset(struct ad7193_dev *dev);
 
 /*! Set the device into specified operating mode. */
 int ad7193_set_operating_mode(struct ad7193_dev *dev,
-			      enum ad7193_adc_modes opt_mode);
+			      enum ad719x_adc_modes opt_mode);
 
 /*! Waits for RDY pin to go low. */
 int ad7193_wait_rdy_go_low(struct ad7193_dev *dev);
@@ -279,7 +279,7 @@ int ad7193_output_rate_select(struct ad7193_dev *dev,
 
 /*! Selects the clock source of the ADC */
 int ad7193_clock_select(struct ad7193_dev *dev,
-			enum ad7193_adc_clock clk_select);
+			enum ad719x_adc_clock clk_select);
 
 /*! Opens or closes the bridge power-down switch of the ADC */
 int ad7193_set_bridge_switch(struct ad7193_dev *dev, uint8_t bpdsw_select);

--- a/drivers/adc/ad7193/ad7193.h
+++ b/drivers/adc/ad7193/ad7193.h
@@ -112,18 +112,20 @@
 #define AD7193_CONF_UNIPOLAR    (1 << 3)                            // Unipolar/Bipolar Enable.
 #define AD7193_CONF_GAIN(x)     ((x) & 0x7)                         // Gain Select.
 
+/* Channel Mask */
+#define AD719X_CH_MASK(channel)		BIT(channel)
+
 /* Configuration Register: AD7193_CONF_CHAN(x) options */
-//                            Pseudo Bit = 0           Pseudo Bit = 1
-#define AD7193_CH_0      0 // AIN1(+) - AIN2(-);       AIN1 - AINCOM
-#define AD7193_CH_1      1 // AIN3(+) - AIN4(-);       AIN2 - AINCOM
-#define AD7193_CH_2      2 // AIN5(+) - AIN6(-);       AIN3 - AINCOM
-#define AD7193_CH_3      3 // AIN7(+) - AIN8(-);       AIN4 - AINCOM
-#define AD7193_CH_4      4 // AIN1(+) - AIN2(-);       AIN5 - AINCOM
-#define AD7193_CH_5      5 // AIN3(+) - AIN4(-);       AIN6 - AINCOM
-#define AD7193_CH_6      6 // AIN5(+) - AIN6(-);       AIN7 - AINCOM
-#define AD7193_CH_7      7 // AIN7(+) - AIN8(-);       AIN8 - AINCOM
-#define AD7193_CH_TEMP   8 //           Temperature sensor
-#define AD7193_CH_SHORT  9 // AIN2(+) - AIN2(-);       AINCOM(+) - AINCOM(-)
+#define AD719X_CH_0      0
+#define AD719X_CH_1      1
+#define AD719X_CH_2      2
+#define AD719X_CH_3      3
+#define AD719X_CH_4      4
+#define AD719X_CH_5      5
+#define AD719X_CH_6      6
+#define AD719X_CH_7      7
+#define AD719X_CH_TEMP   8
+#define AD719X_CH_SHORT  9
 
 /* ID Register Bit Designations (AD7193_REG_ID) */
 #define AD719X_ID_MASK          0x0F
@@ -136,9 +138,6 @@
 #define AD7193_GPOCON_P2DAT     (1 << 2) // P2 state
 #define AD7193_GPOCON_P1DAT     (1 << 1) // P1 state
 #define AD7193_GPOCON_P0DAT     (1 << 0) // P0 state
-
-/* Channel Mask */
-#define AD7193_CH_MASK(x)		BIT(x)
 
 /******************************************************************************/
 /*************************** Types Declarations *******************************/

--- a/drivers/adc/ad719x/ad719x.c
+++ b/drivers/adc/ad719x/ad719x.c
@@ -1,6 +1,6 @@
 /***************************************************************************//**
- *   @file   AD7193.c
- *   @brief  Implementation of AD7193 Driver.
+ *   @file   AD719X.c
+ *   @brief  Implementation of AD7190/2/3/4/5 Driver.
  *   @author DNechita (Dan.Nechita@analog.com)
 ********************************************************************************
  * Copyright 2012(c) Analog Devices, Inc.
@@ -41,7 +41,7 @@
 /***************************** Include Files **********************************/
 /******************************************************************************/
 #include <stdlib.h>
-#include "ad7193.h"    // AD7193 definitions.
+#include "ad719x.h"    // AD719X definitions.
 #include "no-os/error.h"
 #include "no-os/delay.h"
 
@@ -51,7 +51,7 @@
 
 /***************************************************************************//**
  * @brief Initializes the communication peripheral and the initial Values for
- *        AD7193 Board and resets the device.
+ *        AD719X Board and resets the device.
  *
  * @param device     - The device structure.
  * @param init_param - The structure that contains the device initial
@@ -59,14 +59,14 @@
  *
  * @return SUCCESS in case of success or negative error code.
 *******************************************************************************/
-int ad7193_init(struct ad7193_dev **device,
-		struct ad7193_init_param init_param)
+int ad719x_init(struct ad719x_dev **device,
+		struct ad719x_init_param init_param)
 {
-	struct ad7193_dev *dev;
+	struct ad719x_dev *dev;
 	uint32_t reg_val;
 	int ret;
 
-	dev = (struct ad7193_dev *)malloc(sizeof(*dev));
+	dev = (struct ad719x_dev *)malloc(sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -87,11 +87,11 @@ int ad7193_init(struct ad7193_dev **device,
 		goto error_miso;
 
 	/* Reset */
-	ret = ad7193_reset(dev);
+	ret = ad719x_reset(dev);
 	if (ret != SUCCESS)
 		goto error_miso;
 
-	ret = ad7193_get_register_value(dev, AD7193_REG_ID, 1, &reg_val);
+	ret = ad719x_get_register_value(dev, AD719X_REG_ID, 1, &reg_val);
 	if (ret != SUCCESS)
 		goto error_miso;
 
@@ -126,34 +126,34 @@ int ad7193_init(struct ad7193_dev **device,
 	}
 
 	/* Initialization */
-	ret = ad7193_range_setup(dev, init_param.current_polarity,
+	ret = ad719x_range_setup(dev, init_param.current_polarity,
 				 init_param.current_gain);
 	if (ret != SUCCESS)
 		goto error_miso;
 
-	ret = ad7193_output_rate_select(dev, init_param.data_rate_code);
+	ret = ad719x_output_rate_select(dev, init_param.data_rate_code);
 	if (ret != SUCCESS)
 		goto error_miso;
 
-	ret = ad7193_buffer_select(dev, init_param.buffer);
+	ret = ad719x_buffer_select(dev, init_param.buffer);
 	if (ret != SUCCESS)
 		goto error_miso;
 
 	if(dev->chip_id == AD7193 || dev->chip_id == AD7194) {
-		ret = ad7193_config_input_mode(dev, init_param.input_mode);
+		ret = ad719x_config_input_mode(dev, init_param.input_mode);
 		if (ret != SUCCESS)
 			goto error_miso;
 	}
 
-	ret = ad7193_clock_select(dev, init_param.clock_source);
+	ret = ad719x_clock_select(dev, init_param.clock_source);
 	if (ret != SUCCESS)
 		goto error_miso;
 
-	ret = ad7193_set_bridge_switch(dev, init_param.bpdsw_mode);
+	ret = ad719x_set_bridge_switch(dev, init_param.bpdsw_mode);
 	if (ret != SUCCESS)
 		goto error_miso;
 
-	ret = ad7193_set_operating_mode(dev, init_param.operating_mode);
+	ret = ad719x_set_operating_mode(dev, init_param.operating_mode);
 	if (ret != SUCCESS)
 		goto error_miso;
 
@@ -172,13 +172,13 @@ error_dev:
 }
 
 /***************************************************************************//**
- * @brief Free the resources allocated by ad7193_init().
+ * @brief Free the resources allocated by ad719x_init().
  *
  * @param dev - The device structure.
  *
  * @return SUCCESS in case of success or negative error code.
 *******************************************************************************/
-int ad7193_remove(struct ad7193_dev *dev)
+int ad719x_remove(struct ad719x_dev *dev)
 {
 	int ret;
 
@@ -205,7 +205,7 @@ int ad7193_remove(struct ad7193_dev *dev)
  *
  * @return SUCCESS in case of success or negative error code.
 *******************************************************************************/
-int ad7193_set_register_value(struct ad7193_dev *dev,
+int ad719x_set_register_value(struct ad719x_dev *dev,
 			      uint8_t reg_addr,
 			      uint32_t reg_val,
 			      uint8_t bytes_number)
@@ -215,7 +215,7 @@ int ad7193_set_register_value(struct ad7193_dev *dev,
 	uint8_t bytes_nr         = bytes_number;
 	int ret;
 
-	write_command[0] = AD7193_COMM_WRITE | AD7193_COMM_ADDR(reg_addr);
+	write_command[0] = AD719X_COMM_WRITE | AD719X_COMM_ADDR(reg_addr);
 	while (bytes_nr > 0) {
 		write_command[bytes_nr] = *data_pointer;
 		data_pointer++;
@@ -239,7 +239,7 @@ int ad7193_set_register_value(struct ad7193_dev *dev,
  *
  * @return SUCCESS in case of success or negative error code.
 *******************************************************************************/
-int ad7193_get_register_value(struct ad7193_dev *dev, uint8_t reg_addr,
+int ad719x_get_register_value(struct ad719x_dev *dev, uint8_t reg_addr,
 			      uint8_t bytes_number, uint32_t *reg_data)
 {
 	uint8_t reg_word[5] = {0, 0, 0, 0, 0};
@@ -249,7 +249,7 @@ int ad7193_get_register_value(struct ad7193_dev *dev, uint8_t reg_addr,
 	if (!reg_data)
 		return FAILURE;
 
-	reg_word[0] = AD7193_COMM_READ | AD7193_COMM_ADDR(reg_addr);
+	reg_word[0] = AD719X_COMM_READ | AD719X_COMM_ADDR(reg_addr);
 
 	ret = spi_write_and_read(dev->spi_desc, reg_word, bytes_number + 1);
 	if (ret != SUCCESS)
@@ -274,7 +274,7 @@ int ad7193_get_register_value(struct ad7193_dev *dev, uint8_t reg_addr,
  *
  * @return SUCCESS in case of success or negative error code.
 *******************************************************************************/
-int ad7193_set_masked_register_value(struct ad7193_dev *dev,
+int ad719x_set_masked_register_value(struct ad719x_dev *dev,
 				     uint8_t reg_addr, uint32_t mask, uint32_t reg_data,
 				     uint8_t bytes)
 {
@@ -282,14 +282,14 @@ int ad7193_set_masked_register_value(struct ad7193_dev *dev,
 	uint32_t new_reg_data = 0x00;
 	int ret;
 
-	ret = ad7193_get_register_value(dev, reg_addr, bytes, &old_reg_data);
+	ret = ad719x_get_register_value(dev, reg_addr, bytes, &old_reg_data);
 	if (ret != SUCCESS)
 		return ret;
 
 	old_reg_data &= ~mask;
 	new_reg_data = old_reg_data | reg_data;
 
-	return ad7193_set_register_value(dev, reg_addr, new_reg_data, bytes);
+	return ad719x_set_register_value(dev, reg_addr, new_reg_data, bytes);
 }
 
 /***************************************************************************//**
@@ -299,7 +299,7 @@ int ad7193_set_masked_register_value(struct ad7193_dev *dev,
  *
  * @return SUCCESS in case of success or negative error code.
 *******************************************************************************/
-int ad7193_reset(struct ad7193_dev *dev)
+int ad719x_reset(struct ad719x_dev *dev)
 {
 	int ret;
 	uint8_t register_word[5];
@@ -331,13 +331,13 @@ int ad7193_reset(struct ad7193_dev *dev)
  *				      AD719X_MODE_CAL_SYS_FULL
  * @return SUCCESS in case of success or negative error code.
 *******************************************************************************/
-int ad7193_set_operating_mode(struct ad7193_dev *dev,
+int ad719x_set_operating_mode(struct ad719x_dev *dev,
 			      enum ad719x_adc_modes opt_mode)
 {
 	int ret;
 
-	ret = ad7193_set_masked_register_value(dev, AD7193_REG_MODE,
-					       AD7193_MODE_SEL(0x7), AD7193_MODE_SEL(opt_mode),
+	ret = ad719x_set_masked_register_value(dev, AD719X_REG_MODE,
+					       AD719X_MODE_SEL(0x7), AD719X_MODE_SEL(opt_mode),
 					       3);
 
 	if (ret == SUCCESS) {
@@ -353,7 +353,7 @@ int ad7193_set_operating_mode(struct ad7193_dev *dev,
  *
  * @return SUCCESS in case of success or negative error code.
 *******************************************************************************/
-int ad7193_wait_rdy_go_low(struct ad7193_dev *dev)
+int ad719x_wait_rdy_go_low(struct ad719x_dev *dev)
 {
 	uint8_t wait = 1;
 	uint16_t timeout = 0xFFFF;
@@ -381,7 +381,7 @@ int ad7193_wait_rdy_go_low(struct ad7193_dev *dev)
  *
  * @return SUCCESS in case of success or negative error code.
 *******************************************************************************/
-int ad7193_channels_select(struct ad7193_dev *dev,
+int ad719x_channels_select(struct ad719x_dev *dev,
 			   uint16_t chn_mask)
 {
 	switch (dev->chip_id) {
@@ -401,8 +401,8 @@ int ad7193_channels_select(struct ad7193_dev *dev,
 		}
 	}
 
-	return ad7193_set_masked_register_value(dev, AD7193_REG_CONF,
-						AD7193_CONF_CHAN(0x3FF), AD7193_CONF_CHAN(chn_mask),
+	return ad719x_set_masked_register_value(dev, AD719X_REG_CONF,
+						AD719X_CONF_CHAN(0x3FF), AD719X_CONF_CHAN(chn_mask),
 						3);
 }
 
@@ -415,22 +415,22 @@ int ad7193_channels_select(struct ad7193_dev *dev,
  *
  * @return SUCCESS in case of success or negative error code.
 *******************************************************************************/
-int ad7193_calibrate(struct ad7193_dev *dev,
+int ad719x_calibrate(struct ad719x_dev *dev,
 		     uint8_t mode, uint8_t channel)
 {
 	int ret;
 
-	ret = ad7193_channels_select(dev, channel);
+	ret = ad719x_channels_select(dev, channel);
 	if (ret != SUCCESS)
 		return ret;
 
-	ret = ad7193_set_masked_register_value(dev, AD7193_REG_MODE,
-					       AD7193_MODE_SEL(0x7), AD7193_MODE_SEL(mode),
+	ret = ad719x_set_masked_register_value(dev, AD719X_REG_MODE,
+					       AD719X_MODE_SEL(0x7), AD719X_MODE_SEL(mode),
 					       3);
 	if (ret != SUCCESS)
 		return ret;
 
-	return ad7193_wait_rdy_go_low(dev);
+	return ad719x_wait_rdy_go_low(dev);
 }
 
 /***************************************************************************//**
@@ -443,13 +443,13 @@ int ad7193_calibrate(struct ad7193_dev *dev,
  *
  * @return SUCCESS in case of success or negative error code.
 *******************************************************************************/
-int ad7193_config_input_mode(struct ad7193_dev *dev, uint8_t mode)
+int ad719x_config_input_mode(struct ad719x_dev *dev, uint8_t mode)
 {
 	int ret;
 
 	if(dev->chip_id == AD7193 || dev->chip_id == AD7194) {
-		ret = ad7193_set_masked_register_value(dev, AD7193_REG_CONF,
-						       AD7193_CONF_PSEUDO, (AD7193_CONF_PSEUDO * mode),
+		ret = ad719x_set_masked_register_value(dev, AD719X_REG_CONF,
+						       AD719X_CONF_PSEUDO, (AD719X_CONF_PSEUDO * mode),
 						       3);
 		if (ret == SUCCESS) {
 			/* Store the last settings regarding input mode. */
@@ -470,12 +470,12 @@ int ad7193_config_input_mode(struct ad7193_dev *dev, uint8_t mode)
  *
  * @return SUCCESS in case of success or negative error code.
 *******************************************************************************/
-int ad7193_buffer_select(struct ad7193_dev *dev, uint8_t buff_en)
+int ad719x_buffer_select(struct ad719x_dev *dev, uint8_t buff_en)
 {
 	int ret;
 
-	ret = ad7193_set_masked_register_value(dev, AD7193_REG_CONF,
-					       AD7193_CONF_BUF, (AD7193_CONF_BUF * buff_en),
+	ret = ad719x_set_masked_register_value(dev, AD719X_REG_CONF,
+					       AD719X_CONF_BUF, (AD719X_CONF_BUF * buff_en),
 					       3);
 
 	if (ret == SUCCESS) {
@@ -494,13 +494,13 @@ int ad7193_buffer_select(struct ad7193_dev *dev, uint8_t buff_en)
  *
  * @return SUCCESS in case of success or negative error code.
 *******************************************************************************/
-int ad7193_output_rate_select(struct ad7193_dev *dev,
+int ad719x_output_rate_select(struct ad719x_dev *dev,
 			      uint16_t out_rate_code)
 {
 	int ret;
 
-	ret = ad7193_set_masked_register_value(dev, AD7193_REG_MODE,
-					       AD7193_MODE_RATE(0x3FF), AD7193_MODE_RATE(out_rate_code),
+	ret = ad719x_set_masked_register_value(dev, AD719X_REG_MODE,
+					       AD719X_MODE_RATE(0x3FF), AD719X_MODE_RATE(out_rate_code),
 					       3);
 
 	if (ret == SUCCESS) {
@@ -523,13 +523,13 @@ int ad7193_output_rate_select(struct ad7193_dev *dev,
  *
  * @return SUCCESS in case of success or negative error code.
 *******************************************************************************/
-int ad7193_clock_select(struct ad7193_dev *dev,
+int ad719x_clock_select(struct ad719x_dev *dev,
 			enum ad719x_adc_clock clk_select)
 {
 	int ret;
 
-	ret = ad7193_set_masked_register_value(dev, AD7193_REG_MODE,
-					       AD7193_MODE_CLKSRC(0x3), AD7193_MODE_CLKSRC(clk_select),
+	ret = ad719x_set_masked_register_value(dev, AD719X_REG_MODE,
+					       AD719X_MODE_CLKSRC(0x3), AD719X_MODE_CLKSRC(clk_select),
 					       3);
 
 	if (ret == SUCCESS) {
@@ -550,7 +550,7 @@ int ad7193_clock_select(struct ad7193_dev *dev,
  *
  * @return SUCCESS in case of success or negative error code.
 *******************************************************************************/
-int ad7193_set_bridge_switch(struct ad7193_dev *dev, uint8_t bpdsw_select)
+int ad719x_set_bridge_switch(struct ad719x_dev *dev, uint8_t bpdsw_select)
 {
 	int ret;
 
@@ -558,8 +558,8 @@ int ad7193_set_bridge_switch(struct ad7193_dev *dev, uint8_t bpdsw_select)
 		return -ENOTSUP;
 	}
 
-	ret = ad7193_set_masked_register_value(dev, AD7193_REG_GPOCON,
-					       AD7193_GPOCON_BPDSW, (AD7193_GPOCON_BPDSW * bpdsw_select),
+	ret = ad719x_set_masked_register_value(dev, AD719X_REG_GPOCON,
+					       AD719X_GPOCON_BPDSW, (AD719X_GPOCON_BPDSW * bpdsw_select),
 					       1);
 
 	if (ret == SUCCESS) {
@@ -582,14 +582,14 @@ int ad7193_set_bridge_switch(struct ad7193_dev *dev, uint8_t bpdsw_select)
  *
  * @return SUCCESS in case of success or negative error code.
 *******************************************************************************/
-int ad7193_range_setup(struct ad7193_dev *dev,
+int ad719x_range_setup(struct ad719x_dev *dev,
 		       uint8_t polarity, enum ad719x_adc_gain gain)
 {
 	int ret;
 
-	ret = ad7193_set_masked_register_value(dev, AD7193_REG_CONF,
-					       (AD7193_CONF_UNIPOLAR | AD7193_CONF_GAIN(0x7)),
-					       (polarity * AD7193_CONF_UNIPOLAR) | AD7193_CONF_GAIN(gain),
+	ret = ad719x_set_masked_register_value(dev, AD719X_REG_CONF,
+					       (AD719X_CONF_UNIPOLAR | AD719X_CONF_GAIN(0x7)),
+					       (polarity * AD719X_CONF_UNIPOLAR) | AD719X_CONF_GAIN(gain),
 					       3);
 
 	if (ret == SUCCESS) {
@@ -609,7 +609,7 @@ int ad7193_range_setup(struct ad7193_dev *dev,
  *
  * @return SUCCESS in case of success or negative error code.
 *******************************************************************************/
-int ad7193_single_conversion(struct ad7193_dev *dev, uint32_t *reg_data)
+int ad719x_single_conversion(struct ad719x_dev *dev, uint32_t *reg_data)
 {
 	uint32_t command = 0x0;
 	int ret;
@@ -617,18 +617,18 @@ int ad7193_single_conversion(struct ad7193_dev *dev, uint32_t *reg_data)
 	if (!reg_data)
 		return FAILURE;
 
-	command = AD7193_MODE_SEL(AD719X_MODE_SINGLE) | AD7193_MODE_CLKSRC(
-			  AD719X_INT_CLK_4_92_MHZ_TRIST) | AD7193_MODE_RATE(dev->data_rate_code);
+	command = AD719X_MODE_SEL(AD719X_MODE_SINGLE) | AD719X_MODE_CLKSRC(
+			  AD719X_INT_CLK_4_92_MHZ_TRIST) | AD719X_MODE_RATE(dev->data_rate_code);
 
-	ret = ad7193_set_register_value(dev, AD7193_REG_MODE, command, 3);
+	ret = ad719x_set_register_value(dev, AD719X_REG_MODE, command, 3);
 	if (ret != SUCCESS)
 		return ret;
 
-	ret = ad7193_wait_rdy_go_low(dev);
+	ret = ad719x_wait_rdy_go_low(dev);
 	if (ret != SUCCESS)
 		return ret;
 
-	return ad7193_get_register_value(dev, AD7193_REG_DATA, 3, reg_data);
+	return ad719x_get_register_value(dev, AD719X_REG_DATA, 3, reg_data);
 }
 
 /***************************************************************************//**
@@ -640,7 +640,7 @@ int ad7193_single_conversion(struct ad7193_dev *dev, uint32_t *reg_data)
  *
  * @return SUCCESS in case of success or negative error code.
 *******************************************************************************/
-int ad7193_continuous_read_avg(struct ad7193_dev *dev,
+int ad719x_continuous_read_avg(struct ad719x_dev *dev,
 			       uint8_t sample_number, uint32_t *samples_avg)
 {
 	uint32_t samples = 0;
@@ -648,20 +648,20 @@ int ad7193_continuous_read_avg(struct ad7193_dev *dev,
 	uint8_t count = 0;
 	int ret;
 
-	command = AD7193_MODE_SEL(AD719X_MODE_CONT) |
-		  AD7193_MODE_CLKSRC(AD719X_INT_CLK_4_92_MHZ_TRIST) |
-		  AD7193_MODE_RATE(dev->data_rate_code);
+	command = AD719X_MODE_SEL(AD719X_MODE_CONT) |
+		  AD719X_MODE_CLKSRC(AD719X_INT_CLK_4_92_MHZ_TRIST) |
+		  AD719X_MODE_RATE(dev->data_rate_code);
 
-	ret = ad7193_set_register_value(dev, AD7193_REG_MODE, command, 3);
+	ret = ad719x_set_register_value(dev, AD719X_REG_MODE, command, 3);
 	if (ret != SUCCESS)
 		return ret;
 
 	for (count = 0; count < sample_number; count++) {
-		ret = ad7193_wait_rdy_go_low(dev);
+		ret = ad719x_wait_rdy_go_low(dev);
 		if (ret != SUCCESS)
 			return ret;
 
-		ret = ad7193_get_register_value(dev, AD7193_REG_DATA, 3, &samples);
+		ret = ad719x_get_register_value(dev, AD719X_REG_DATA, 3, &samples);
 		if(ret != SUCCESS)
 			return ret;
 
@@ -681,27 +681,27 @@ int ad7193_continuous_read_avg(struct ad7193_dev *dev,
  *
  * @return SUCCESS in case of success or negative error code.
 *******************************************************************************/
-int ad7193_temperature_read(struct ad7193_dev *dev, float *temp)
+int ad719x_temperature_read(struct ad719x_dev *dev, float *temp)
 {
 	uint32_t data_reg = 0;
 	int ret;
 
 	// Bipolar operation, 1 Gain.
-	ret = ad7193_range_setup(dev, 0, AD719X_ADC_GAIN_1);
+	ret = ad719x_range_setup(dev, 0, AD719X_ADC_GAIN_1);
 	if (ret != SUCCESS)
 		return ret;
 
 	if(dev->chip_id == AD7190 || dev->chip_id == AD7192 || dev->chip_id == AD7195) {
-		ret = ad7193_channels_select(dev, AD719X_CH_MASK(AD719X_CH_2));
+		ret = ad719x_channels_select(dev, AD719X_CH_MASK(AD719X_CH_2));
 		if (ret != SUCCESS)
 			return ret;
 	} else {
-		ret = ad7193_channels_select(dev, AD719X_CH_MASK(AD719X_CH_TEMP));
+		ret = ad719x_channels_select(dev, AD719X_CH_MASK(AD719X_CH_TEMP));
 		if (ret != SUCCESS)
 			return ret;
 	}
 
-	ret = ad7193_single_conversion(dev, &data_reg);
+	ret = ad719x_single_conversion(dev, &data_reg);
 	if (ret != SUCCESS)
 		return ret;
 
@@ -721,7 +721,7 @@ int ad7193_temperature_read(struct ad7193_dev *dev, float *temp)
  *
  * @return voltage - The result of the conversion expressed as volts.
 *******************************************************************************/
-float ad7193_convert_to_volts(struct ad7193_dev *dev,
+float ad719x_convert_to_volts(struct ad719x_dev *dev,
 			      uint32_t raw_data,
 			      float v_ref)
 {

--- a/drivers/adc/ad719x/ad719x.h
+++ b/drivers/adc/ad719x/ad719x.h
@@ -1,6 +1,6 @@
 /***************************************************************************//**
- *   @file   AD7193.h
- *   @brief  Header file of AD7193 Driver.
+ *   @file   AD719X.h
+ *   @brief  Header file of AD7190/2/3/4/5 Driver.
  *   @author DNechita (Dan.Nechita@analog.com)
 ********************************************************************************
  * Copyright 2012(c) Analog Devices, Inc.
@@ -37,8 +37,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 
-#ifndef __AD7193_H__
-#define __AD7193_H__
+#ifndef __AD719X_H__
+#define __AD719X_H__
 
 /******************************************************************************/
 /***************************** Include Files **********************************/
@@ -49,73 +49,73 @@
 #include "no-os/util.h"
 
 /******************************************************************************/
-/******************************** AD7193 **************************************/
+/******************************** AD719X **************************************/
 /******************************************************************************/
 
 /* SPI slave device ID */
-#define AD7193_SLAVE_ID         1
+#define AD719X_SLAVE_ID         1
 
-/* AD7193 Register Map */
-#define AD7193_REG_COMM         0 // Communications Register (WO, 8-bit)
-#define AD7193_REG_STAT         0 // Status Register         (RO, 8-bit)
-#define AD7193_REG_MODE         1 // Mode Register           (RW, 24-bit
-#define AD7193_REG_CONF         2 // Configuration Register  (RW, 24-bit)
-#define AD7193_REG_DATA         3 // Data Register           (RO, 24/32-bit)
-#define AD7193_REG_ID           4 // ID Register             (RO, 8-bit)
-#define AD7193_REG_GPOCON       5 // GPOCON Register         (RW, 8-bit)
-#define AD7193_REG_OFFSET       6 // Offset Register         (RW, 24-bit
-#define AD7193_REG_FULLSCALE    7 // Full-Scale Register     (RW, 24-bit)
+/* AD719X Register Map */
+#define AD719X_REG_COMM         0 // Communications Register (WO, 8-bit)
+#define AD719X_REG_STAT         0 // Status Register         (RO, 8-bit)
+#define AD719X_REG_MODE         1 // Mode Register           (RW, 24-bit
+#define AD719X_REG_CONF         2 // Configuration Register  (RW, 24-bit)
+#define AD719X_REG_DATA         3 // Data Register           (RO, 24/32-bit)
+#define AD719X_REG_ID           4 // ID Register             (RO, 8-bit)
+#define AD719X_REG_GPOCON       5 // GPOCON Register         (RW, 8-bit)
+#define AD719X_REG_OFFSET       6 // Offset Register         (RW, 24-bit
+#define AD719X_REG_FULLSCALE    7 // Full-Scale Register     (RW, 24-bit)
 
-/* Communications Register Bit Designations (AD7193_REG_COMM) */
-#define AD7193_COMM_WEN         (1 << 7)           // Write Enable.
-#define AD7193_COMM_WRITE       (0 << 6)           // Write Operation.
-#define AD7193_COMM_READ        (1 << 6)           // Read Operation.
-#define AD7193_COMM_ADDR(x)     (((x) & 0x7) << 3) // Register Address.
-#define AD7193_COMM_CREAD       (1 << 2)           // Continuous Read of Data Register.
+/* Communications Register Bit Designations (AD719X_REG_COMM) */
+#define AD719X_COMM_WEN         (1 << 7)           // Write Enable.
+#define AD719X_COMM_WRITE       (0 << 6)           // Write Operation.
+#define AD719X_COMM_READ        (1 << 6)           // Read Operation.
+#define AD719X_COMM_ADDR(x)     (((x) & 0x7) << 3) // Register Address.
+#define AD719X_COMM_CREAD       (1 << 2)           // Continuous Read of Data Register.
 
-/* Status Register Bit Designations (AD7193_REG_STAT) */
-#define AD7193_STAT_RDY         (1 << 7) // Ready.
-#define AD7193_STAT_ERR         (1 << 6) // ADC error bit.
-#define AD7193_STAT_NOREF       (1 << 5) // Error no external reference.
-#define AD7193_STAT_PARITY      (1 << 4) // Parity check of the data register.
-#define AD7193_STAT_CH3         (1 << 3) // Channel 3.
-#define AD7193_STAT_CH2         (1 << 2) // Channel 2.
-#define AD7193_STAT_CH1         (1 << 1) // Channel 1.
-#define AD7193_STAT_CH0         (1 << 0) // Channel 0.
+/* Status Register Bit Designations (AD719X_REG_STAT) */
+#define AD719X_STAT_RDY         (1 << 7) // Ready.
+#define AD719X_STAT_ERR         (1 << 6) // ADC error bit.
+#define AD719X_STAT_NOREF       (1 << 5) // Error no external reference.
+#define AD719X_STAT_PARITY      (1 << 4) // Parity check of the data register.
+#define AD719X_STAT_CH3         (1 << 3) // Channel 3.
+#define AD719X_STAT_CH2         (1 << 2) // Channel 2.
+#define AD719X_STAT_CH1         (1 << 1) // Channel 1.
+#define AD719X_STAT_CH0         (1 << 0) // Channel 0.
 
-/* Mode Register Bit Designations (AD7193_REG_MODE) */
-#define AD7193_MODE_SEL(x)      (((uint32_t)(x) & 0x7) << 21) // Operation Mode Select.
-#define AD7193_MODE_DAT_STA     ((uint32_t)1 << 20)           // Status Register transmission.
-#define AD7193_MODE_CLKSRC(x)   (((uint32_t)(x) & 0x3) << 18) // Clock Source Select.
-#define AD7193_MODE_AVG(x)      (((uint32_t)(x) & 0x3) << 16) // Fast settling filter.
-#define AD7193_MODE_SINC3       (1 << 15)                          // SINC3 Filter Select.
-#define AD7193_MODE_ENPAR       (1 << 13)                          // Parity Enable.
-#define AD7193_MODE_CLKDIV      (1 << 12)                          // Clock divide by 2 (AD7190/2 only).
-#define AD7193_MODE_SCYCLE      (1 << 11)                          // Single cycle conversion.
-#define AD7193_MODE_REJ60       (1 << 10)                          // 50/60Hz notch filter.
-#define AD7193_MODE_RATE(x)     ((x) & 0x3FF)                      // Filter Update Rate Select.
+/* Mode Register Bit Designations (AD719X_REG_MODE) */
+#define AD719X_MODE_SEL(x)      (((uint32_t)(x) & 0x7) << 21) // Operation Mode Select.
+#define AD719X_MODE_DAT_STA     ((uint32_t)1 << 20)           // Status Register transmission.
+#define AD719X_MODE_CLKSRC(x)   (((uint32_t)(x) & 0x3) << 18) // Clock Source Select.
+#define AD719X_MODE_AVG(x)      (((uint32_t)(x) & 0x3) << 16) // Fast settling filter.
+#define AD719X_MODE_SINC3       (1 << 15)                          // SINC3 Filter Select.
+#define AD719X_MODE_ENPAR       (1 << 13)                          // Parity Enable.
+#define AD719X_MODE_CLKDIV      (1 << 12)                          // Clock divide by 2 (AD7190/2 only).
+#define AD719X_MODE_SCYCLE      (1 << 11)                          // Single cycle conversion.
+#define AD719X_MODE_REJ60       (1 << 10)                          // 50/60Hz notch filter.
+#define AD719X_MODE_RATE(x)     ((x) & 0x3FF)                      // Filter Update Rate Select.
 
-/* Mode Register: AD7193_MODE_AVG(x) options */
-#define AD7193_AVG_NONE                 0 // No averaging (fast settling mode disabled).
-#define AD7193_AVG_BY_2                 1 // Average by 2.
-#define AD7193_AVG_BY_8                 2 // Average by 8.
-#define AD7193_AVG_BY_16                3 // Average by 16.
+/* Mode Register: AD719X_MODE_AVG(x) options */
+#define AD719X_AVG_NONE                 0 // No averaging (fast settling mode disabled).
+#define AD719X_AVG_BY_2                 1 // Average by 2.
+#define AD719X_AVG_BY_8                 2 // Average by 8.
+#define AD719X_AVG_BY_16                3 // Average by 16.
 
-/* Configuration Register Bit Designations (AD7193_REG_CONF) */
-#define AD7193_CONF_CHOP        ((uint32_t)1 << 23)            // CHOP enable.
-#define AD7193_CONF_REFSEL      ((uint32_t)1 << 20)            // REFIN1/REFIN2 Reference Select.
-#define AD7193_CONF_PSEUDO      ((uint32_t)1 << 18)            // Pseudo differential analog inputs.
-#define AD7193_CONF_CHAN(x)     ((uint32_t)((x) & 0x3FF) << 8) // Channel select.
-#define AD7193_CONF_BURN        (1 << 7)                            // Burnout current enable.
-#define AD7193_CONF_REFDET      (1 << 6)                            // Reference detect enable.
-#define AD7193_CONF_BUF         (1 << 4)                            // Buffered Mode Enable.
-#define AD7193_CONF_UNIPOLAR    (1 << 3)                            // Unipolar/Bipolar Enable.
-#define AD7193_CONF_GAIN(x)     ((x) & 0x7)                         // Gain Select.
+/* Configuration Register Bit Designations (AD719X_REG_CONF) */
+#define AD719X_CONF_CHOP        ((uint32_t)1 << 23)            // CHOP enable.
+#define AD719X_CONF_REFSEL      ((uint32_t)1 << 20)            // REFIN1/REFIN2 Reference Select.
+#define AD719X_CONF_PSEUDO      ((uint32_t)1 << 18)            // Pseudo differential analog inputs.
+#define AD719X_CONF_CHAN(x)     ((uint32_t)((x) & 0x3FF) << 8) // Channel select.
+#define AD719X_CONF_BURN        (1 << 7)                            // Burnout current enable.
+#define AD719X_CONF_REFDET      (1 << 6)                            // Reference detect enable.
+#define AD719X_CONF_BUF         (1 << 4)                            // Buffered Mode Enable.
+#define AD719X_CONF_UNIPOLAR    (1 << 3)                            // Unipolar/Bipolar Enable.
+#define AD719X_CONF_GAIN(x)     ((x) & 0x7)                         // Gain Select.
 
 /* Channel Mask */
 #define AD719X_CH_MASK(channel)		BIT(channel)
 
-/* Configuration Register: AD7193_CONF_CHAN(x) options */
+/* Configuration Register: AD719X_CONF_CHAN(x) options */
 #define AD719X_CH_0      0
 #define AD719X_CH_1      1
 #define AD719X_CH_2      2
@@ -130,14 +130,14 @@
 /* ID Register Bit Designations (AD7193_REG_ID) */
 #define AD719X_ID_MASK          0x0F
 
-/* GPOCON Register Bit Designations (AD7193_REG_GPOCON) */
-#define AD7193_GPOCON_BPDSW     (1 << 6) // Bridge power-down switch enable
-#define AD7193_GPOCON_GP32EN    (1 << 5) // Digital Output P3 and P2 enable
-#define AD7193_GPOCON_GP10EN    (1 << 4) // Digital Output P1 and P0 enable
-#define AD7193_GPOCON_P3DAT     (1 << 3) // P3 state
-#define AD7193_GPOCON_P2DAT     (1 << 2) // P2 state
-#define AD7193_GPOCON_P1DAT     (1 << 1) // P1 state
-#define AD7193_GPOCON_P0DAT     (1 << 0) // P0 state
+/* GPOCON Register Bit Designations (AD719X_REG_GPOCON) */
+#define AD719X_GPOCON_BPDSW     (1 << 6) // Bridge power-down switch enable
+#define AD719X_GPOCON_GP32EN    (1 << 5) // Digital Output P3 and P2 enable
+#define AD719X_GPOCON_GP10EN    (1 << 4) // Digital Output P1 and P0 enable
+#define AD719X_GPOCON_P3DAT     (1 << 3) // P3 state
+#define AD719X_GPOCON_P2DAT     (1 << 2) // P2 state
+#define AD719X_GPOCON_P1DAT     (1 << 1) // P1 state
+#define AD719X_GPOCON_P0DAT     (1 << 0) // P0 state
 
 /******************************************************************************/
 /*************************** Types Declarations *******************************/
@@ -191,7 +191,7 @@ enum ad719x_chip_id {
 	AD7195 = 0xA6
 };
 
-struct ad7193_dev {
+struct ad719x_dev {
 	/* SPI */
 	spi_desc		*spi_desc;
 	/* GPIO */
@@ -208,7 +208,7 @@ struct ad7193_dev {
 	enum ad719x_chip_id chip_id;
 };
 
-struct ad7193_init_param {
+struct ad719x_init_param {
 	/* SPI */
 	spi_init_param		spi_init;
 	/* GPIO */
@@ -230,75 +230,75 @@ struct ad7193_init_param {
 /******************************************************************************/
 
 /*! Checks if the AD7139 part is present. */
-int ad7193_init(struct ad7193_dev **device,
-		struct ad7193_init_param init_param);
+int ad719x_init(struct ad719x_dev **device,
+		struct ad719x_init_param init_param);
 
-/*! Free the resources allocated by ad7193_init(). */
-int ad7193_remove(struct ad7193_dev *dev);
+/*! Free the resources allocated by ad719x_init(). */
+int ad719x_remove(struct ad719x_dev *dev);
 
 /*! Writes data into a register. */
-int ad7193_set_register_value(struct ad7193_dev *dev, uint8_t reg_addr,
+int ad719x_set_register_value(struct ad719x_dev *dev, uint8_t reg_addr,
 			      uint32_t reg_value, uint8_t bytes_number);
 
 /*! Reads the value of a register. */
-int ad7193_get_register_value(struct ad7193_dev *dev, uint8_t reg_addr,
+int ad719x_get_register_value(struct ad719x_dev *dev, uint8_t reg_addr,
 			      uint8_t bytes_number, uint32_t *reg_data);
 
 /* Write masked data into device register. */
-int ad7193_set_masked_register_value(struct ad7193_dev *dev,
+int ad719x_set_masked_register_value(struct ad719x_dev *dev,
 				     uint8_t reg_addr, uint32_t mask, uint32_t data,
 				     uint8_t bytes);
 
 /*! Resets the device. */
-int ad7193_reset(struct ad7193_dev *dev);
+int ad719x_reset(struct ad719x_dev *dev);
 
 /*! Set the device into specified operating mode. */
-int ad7193_set_operating_mode(struct ad7193_dev *dev,
+int ad719x_set_operating_mode(struct ad719x_dev *dev,
 			      enum ad719x_adc_modes opt_mode);
 
 /*! Waits for RDY pin to go low. */
-int ad7193_wait_rdy_go_low(struct ad7193_dev *dev);
+int ad719x_wait_rdy_go_low(struct ad719x_dev *dev);
 
 /*! Selects the channels to be enabled. */
-int ad7193_channels_select(struct ad7193_dev *dev, uint16_t chn_mask);
+int ad719x_channels_select(struct ad719x_dev *dev, uint16_t chn_mask);
 
 /*! Performs the given calibration to the specified channel. */
-int ad7193_calibrate(struct ad7193_dev *dev,
+int ad719x_calibrate(struct ad719x_dev *dev,
 		     uint8_t mode, uint8_t channel);
 
 /*! Configures the input mode of the ADC */
-int ad7193_config_input_mode(struct ad7193_dev *dev, uint8_t mode);
+int ad719x_config_input_mode(struct ad719x_dev *dev, uint8_t mode);
 
 /*! Enables or disables the buffer on the ADC input channels */
-int ad7193_buffer_select(struct ad7193_dev *dev, uint8_t buff_en);
+int ad719x_buffer_select(struct ad719x_dev *dev, uint8_t buff_en);
 
 /*! Selects the filter output data rate of the ADC */
-int ad7193_output_rate_select(struct ad7193_dev *dev,
+int ad719x_output_rate_select(struct ad719x_dev *dev,
 			      uint16_t out_rate_code);
 
 /*! Selects the clock source of the ADC */
-int ad7193_clock_select(struct ad7193_dev *dev,
+int ad719x_clock_select(struct ad719x_dev *dev,
 			enum ad719x_adc_clock clk_select);
 
 /*! Opens or closes the bridge power-down switch of the ADC */
-int ad7193_set_bridge_switch(struct ad7193_dev *dev, uint8_t bpdsw_select);
+int ad719x_set_bridge_switch(struct ad719x_dev *dev, uint8_t bpdsw_select);
 
 /*! Selects the polarity of the conversion and the ADC input range. */
-int ad7193_range_setup(struct ad7193_dev *dev,
-		       uint8_t polarity, enum ad719x_adc_gain gain);
+int ad719x_range_setup(struct ad719x_dev *dev,
+		       uint8_t polarity, enum ad719x_adc_gain range);
 
 /*! Returns the result of a single conversion. */
-int ad7193_single_conversion(struct ad7193_dev *dev, uint32_t *reg_data);
+int ad719x_single_conversion(struct ad719x_dev *dev, uint32_t *reg_data);
 
 /*! Returns the average of several conversion results. */
-int ad7193_continuous_read_avg(struct ad7193_dev *dev,
+int ad719x_continuous_read_avg(struct ad719x_dev *dev,
 			       uint8_t sample_number, uint32_t *samples_avg);
 
 /*! Read data from temperature sensor and converts it to Celsius degrees. */
-int ad7193_temperature_read(struct ad7193_dev *dev, float *temp);
+int ad719x_temperature_read(struct ad719x_dev *dev, float *temp);
 
 /*! Converts 24-bit raw data to volts. */
-float ad7193_convert_to_volts(struct ad7193_dev *dev,
+float ad719x_convert_to_volts(struct ad719x_dev *dev,
 			      uint32_t raw_data, float v_ref);
 
-#endif /* __AD7193_H__ */
+#endif /* __AD719X_H__ */

--- a/drivers/adc/ad719x/ad719x.h
+++ b/drivers/adc/ad719x/ad719x.h
@@ -196,6 +196,7 @@ struct ad719x_dev {
 	spi_desc		*spi_desc;
 	/* GPIO */
 	struct gpio_desc	*gpio_miso;
+	struct gpio_desc	*sync_pin;
 	/* Device Settings */
 	uint8_t			current_polarity;
 	enum ad719x_adc_gain	current_gain;
@@ -210,9 +211,11 @@ struct ad719x_dev {
 
 struct ad719x_init_param {
 	/* SPI */
-	spi_init_param		spi_init;
+	spi_init_param		*spi_init;
 	/* GPIO */
-	struct gpio_init_param	gpio_miso;
+	struct gpio_init_param	*gpio_miso;
+	/* Optional GPIO pin - only for multiple devices */
+	struct gpio_desc	*sync_pin;
 	/* Device Settings */
 	uint8_t			current_polarity;
 	enum ad719x_adc_gain	current_gain;


### PR DESCRIPTION
-reworked AD7193 driver to support AD719X family (AD7190/2/3/4/5)

Signed-off-by: Andrei Porumb <andrei.porumb@analog.com>