### PR TITLE
Update Chip Select data member in the SPI headers

### DIFF
--- a/include/no-os/spi.h
+++ b/include/no-os/spi.h
@@ -115,7 +115,7 @@ typedef struct spi_init_param {
 	/** maximum transfer speed */
 	uint32_t	max_speed_hz;
 	/** SPI chip select */
-	uint8_t		chip_select;
+	uint16_t		chip_select;
 	/** SPI mode */
 	enum spi_mode	mode;
 	/** SPI bit order */
@@ -135,7 +135,7 @@ typedef struct spi_desc {
 	/** maximum transfer speed */
 	uint32_t	max_speed_hz;
 	/** SPI chip select */
-	uint8_t		chip_select;
+	uint16_t		chip_select;
 	/** SPI mode */
 	enum spi_mode	mode;
 	/** SPI bit order */


### PR DESCRIPTION
include: no-os: Changed the chip select data member type to 16 bit wide

Certain mbed supported MCUs require a 16 Bit wide data member to store
the pin name. Since the SPI chip select data member utilizes a GPIO name
to be stored as its value, it has been updated to uint16_t in the SPI
init param and in the SPI descriptor.

Signed-off-by: Janani Sunil <Janani.Sunil@analog.com>