### PR TITLE
stm32 gpio: remove MODER access

### DIFF
--- a/drivers/platform/stm32/stm32_gpio.c
+++ b/drivers/platform/stm32/stm32_gpio.c
@@ -97,6 +97,14 @@ static int32_t _gpio_init(struct gpio_desc *desc,
 	else
 		return -EINVAL;
 
+	switch (pextra->mode & GPIO_MODE) {
+	case MODE_INPUT:
+	case MODE_OUTPUT:
+		break;
+	default:
+		return -EINVAL;
+	}
+
 	/* copy the settings to gpio descriptor */
 	desc->number = param->number;
 	extra->port = pextra->port;
@@ -272,12 +280,7 @@ int32_t stm32_gpio_get_direction(struct gpio_desc *desc,
 		return -EINVAL;
 
 	struct stm32_gpio_desc *extra = desc->extra;
-	uint8_t pin = desc->number;
-
-	/* MODER = 0x00 - input */
-	/* MODER = 0x01 - general purpose output mode */
-	*direction = (extra->port->MODER >> (2 * pin)) & 0x3;
-
+	*direction = (extra->mode & GPIO_MODE) ? GPIO_OUT : GPIO_IN;
 	return 0;
 }
 


### PR DESCRIPTION
MODER register seems to not be present on all stm32 mcu's so
avoid accessing it directly.

This commit changes the gpio_get_direction implementation on stm32
by reading the direction configuration set using the initialization
functions. So it doesn't perform a register access.

Closes #1228

Signed-off-by: Darius Berghe <darius.berghe@analog.com>