### PR TITLE
drivers:adc:ad719x: Fix gpio init param

### DIFF
--- a/drivers/adc/ad719x/ad719x.h
+++ b/drivers/adc/ad719x/ad719x.h
@@ -215,7 +215,7 @@ struct ad719x_init_param {
 	/* GPIO */
 	struct gpio_init_param	*gpio_miso;
 	/* Optional GPIO pin - only for multiple devices */
-	struct gpio_desc	*sync_pin;
+	struct gpio_init_param	*sync_pin;
 	/* Device Settings */
 	uint8_t			current_polarity;
 	enum ad719x_adc_gain	current_gain;


### PR DESCRIPTION
Switched from gpio_desc to gpio_init_param.

Signed-off-by:Andrei Porumb <andrei.porumb@analog.com>