### PR TITLE
fix stm32 uart_write return value

### DIFF
--- a/drivers/platform/stm32/stm32_uart.c
+++ b/drivers/platform/stm32/stm32_uart.c
@@ -238,7 +238,7 @@ int32_t uart_write(struct uart_desc *desc, const uint8_t *data,
 		return -EIO;
 	};
 
-	return 0;
+	return bytes_number;
 }
 
 /**

--- a/drivers/platform/stm32/stm32_uart_stdio.c
+++ b/drivers/platform/stm32/stm32_uart_stdio.c
@@ -91,7 +91,7 @@ int _write(int fd, char* ptr, int len)
 			return -1;
 		}
 
-		return len;
+		return ret;
 	}
 	errno = EBADF;
 	return -1;


### PR DESCRIPTION
uart_write() apparently needs to return the number of characters
transmitted for the iio_demo to work.

Signed-off-by: Darius Berghe <darius.berghe@analog.com>