### PR TITLE
ad719x: Fix ID mask

### DIFF
--- a/drivers/adc/ad719x/ad719x.c
+++ b/drivers/adc/ad719x/ad719x.c
@@ -105,27 +105,27 @@ int ad719x_init(struct ad719x_dev **device,
 
 	switch (dev->chip_id) {
 	case AD7190:
-		if((reg_val & AD719X_ID_MASK) != AD7190) {
+		if((reg_val & AD7190_4_ID_MASK) != AD7190) {
 			goto error_sync;
 		}
 		break;
 	case AD7192:
-		if((reg_val & AD719X_ID_MASK) != AD7192) {
+		if((reg_val & AD7190_4_ID_MASK) != AD7192) {
 			goto error_sync;
 		}
 		break;
 	case AD7193:
-		if((reg_val & AD719X_ID_MASK) != AD7193) {
+		if((reg_val & AD7190_4_ID_MASK) != AD7193) {
 			goto error_sync;
 		}
 		break;
 	case AD7194:
-		if((reg_val & AD719X_ID_MASK) != AD7194) {
+		if((reg_val & AD7190_4_ID_MASK) != AD7194) {
 			goto error_sync;
 		}
 		break;
 	case AD7195:
-		if((reg_val & AD719X_ID_MASK) != AD7195) {
+		if((reg_val & AD7195_ID_MASK) != AD7195) {
 			goto error_sync;
 		}
 		break;

--- a/drivers/adc/ad719x/ad719x.h
+++ b/drivers/adc/ad719x/ad719x.h
@@ -127,8 +127,10 @@
 #define AD719X_CH_TEMP   8
 #define AD719X_CH_SHORT  9
 
+
 /* ID Register Bit Designations (AD7193_REG_ID) */
-#define AD719X_ID_MASK          0x0F
+#define AD7190_4_ID_MASK			0x0F
+#define AD7195_ID_MASK				0xFF
 
 /* GPOCON Register Bit Designations (AD719X_REG_GPOCON) */
 #define AD719X_GPOCON_BPDSW     (1 << 6) // Bridge power-down switch enable


### PR DESCRIPTION
Previously, the ID mask was set only for the last nibble. AD7195 has a full byte
ID so we need to consider the whole byte. Mask changed to 0xFF for AD7195 case.

Signed-off-by: Andrei Porumb <andrei.porumb@analog.com>