### PR TITLE
jesd frames_per_multiframe uint8_t -> uint16_t

### DIFF
--- a/drivers/axi_core/jesd204/axi_jesd204_rx.h
+++ b/drivers/axi_core/jesd204/axi_jesd204_rx.h
@@ -50,7 +50,7 @@
 /******************************************************************************/
 struct jesd204_rx_config {
 	uint8_t octets_per_frame;
-	uint8_t frames_per_multiframe;
+	uint16_t frames_per_multiframe;
 	uint8_t subclass_version;
 };
 
@@ -79,7 +79,7 @@ struct jesd204_rx_init {
 	const char *name;
 	uint32_t base;
 	uint8_t octets_per_frame;
-	uint8_t frames_per_multiframe;
+	uint16_t frames_per_multiframe;
 	uint8_t subclass;
 	uint32_t device_clk_khz;
 	uint32_t lane_clk_khz;

--- a/drivers/axi_core/jesd204/axi_jesd204_tx.h
+++ b/drivers/axi_core/jesd204/axi_jesd204_tx.h
@@ -54,7 +54,7 @@ struct jesd204_tx_config {
 	uint8_t lane_id;
 	uint8_t lanes_per_device;
 	uint8_t octets_per_frame;
-	uint8_t frames_per_multiframe;
+	uint16_t frames_per_multiframe;
 	uint8_t converters_per_device;
 	uint8_t resolution;
 	uint8_t bits_per_sample;
@@ -91,7 +91,7 @@ struct jesd204_tx_init {
 	const char *name;
 	uint32_t base;
 	uint8_t octets_per_frame;
-	uint8_t frames_per_multiframe;
+	uint16_t frames_per_multiframe;
 	uint8_t converters_per_device;
 	uint8_t converter_resolution;
 	uint8_t bits_per_sample;


### PR DESCRIPTION
uint8_t cannot accomodate values like 256 which is a valud value
for the JESD K parameter, so increase the storage size to uint16_t.

Related to this EZ thread:
https://ez.analog.com/microcontroller-no-os-drivers/f/q-a/554890/ad9081_fmca_ebz-noos-driver-problem-when-k-is-set-to-256-uint8_t

Signed-off-by: Darius Berghe <darius.berghe@analog.com>