### PR TITLE
Stm32 tpiu

### DIFF
--- a/tools/scripts/stm32.mk
+++ b/tools/scripts/stm32.mk
@@ -147,11 +147,6 @@ $(BINARY).gdb:
 	@echo monitor reset halt >> $(BINARY).gdb
 	@echo tb main >> $(BINARY).gdb
 	@echo tb HardFault_Handler >> $(BINARY).gdb
-	# These may be helpful but are disabled due to
-	# limited number of breakpoints:
-	# @echo tb UsageFault_Handler >> $(BINARY).gdb
-	# @echo tb MemManage_Handler >> $(BINARY).gdb
-	# @echo tb BusFault_Handler >> $(BINARY).gdb
 	@echo tui enable >> $(BINARY).gdb
 	@echo c >> $(BINARY).gdb
 

--- a/tools/scripts/stm32.mk
+++ b/tools/scripts/stm32.mk
@@ -138,7 +138,6 @@ $(BINARY).openocd:
 	@echo set AP_NUM 0 >> $(BINARY).openocd
 	@echo set GDB_PORT 3333 >> $(BINARY).openocd
 	@echo source [find $(TARGETCFG)] >> $(BINARY).openocd
-	@echo tpiu config disable >> $(BINARY).openocd
 
 .PHONY: $(BINARY).gdb
 $(BINARY).gdb:


### PR DESCRIPTION
- remove openocd obsolete `tpiu config` command
- remove some makefile comments that were polluting