### PR TITLE
AD413x driver

### DIFF
--- a/drivers/afe/ad413x/ad413x.c
+++ b/drivers/afe/ad413x/ad413x.c
@@ -1,0 +1,816 @@
+/***************************************************************************//**
+ *   @file   ad413x.c
+ *   @brief  Implementation of AD413X Driver.
+ *   @author Andrei Porumb (andrei.porumb@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdio.h>
+#include <stdlib.h>
+#include "ad413x.h"
+#include "no-os/error.h"
+#include "no-os/irq.h"
+#include "no-os/print_log.h"
+#include "no-os/delay.h"
+
+/******************************************************************************/
+/************************** Functions Implementation **************************/
+/******************************************************************************/
+/***************************************************************************//**
+ * Compute CRC8 checksum.
+ *
+ * @param data      - The data buffer.
+ * @param data_size - The size of the data buffer.
+ *
+ * @return CRC8 checksum.
+*******************************************************************************/
+static uint8_t ad413x_compute_crc8(uint8_t *data, uint8_t data_size)
+{
+	uint8_t i;
+	uint8_t crc = 0;
+
+	while (data_size) {
+		for (i = 0x80; i != 0; i >>= 1) {
+			if (((crc & 0x80) != 0) != ((*data & i) != 0)) {
+				crc <<= 1;
+				crc ^= AD413X_CRC8_POLY;
+			} else
+				crc <<= 1;
+		}
+		data++;
+		data_size--;
+	}
+	return crc;
+}
+
+/***************************************************************************//**
+ * SPI DATA register continuous read from device.
+ *
+ * @param dev      - The device structure.
+ * @param reg_data - The register data.
+ *
+ * @return SUCCESS in case of success, negative error code otherwise.
+*******************************************************************************/
+static int32_t ad413x_spi_data_cont_read(struct ad413x_dev *dev,
+		uint32_t *reg_data)
+{
+	uint8_t ret;
+	uint8_t buf[3];
+	uint32_t data;
+
+	memset(buf, 0xAA, 3); // dummy data bytes
+
+	ret = spi_write_and_read(dev->spi_dev, buf, 3);
+	if (ret)
+		return ret;
+
+	data = (buf[0] << 16) | (buf[1] << 8) | buf[2];
+
+	*reg_data = data;
+
+	return SUCCESS;
+}
+
+/***************************************************************************//**
+ * IRQ handler for single ADC read.
+*******************************************************************************/
+static void irq_adc_single_read(struct ad413x_callback_ctx *ctx)
+{
+	struct ad413x_dev *dev = ctx->dev;
+	if(ctx->buffer_size > 0) {
+		if(ad413x_spi_int_reg_read(ctx->dev, AD413X_REG_DATA, ctx->buffer))
+			pr_err("DATA reg could not be read \n");
+		ctx->buffer_size--;
+		ctx->buffer++;
+		if(irq_enable(dev->irq_desc, dev->rdy_pin))
+			pr_err("IRQ_enable error \n");
+	} else if(irq_disable(dev->irq_desc, dev->rdy_pin)) {
+		pr_err("IRQ_disable error \n");
+	}
+}
+
+/***************************************************************************//**
+ * IRQ handler for continuously ADC read.
+*******************************************************************************/
+static void irq_adc_cont_read(struct ad413x_callback_ctx *ctx)
+{
+	struct ad413x_dev *dev = ctx->dev;
+	if(ctx->buffer_size > 0) {
+		if(ad413x_spi_data_cont_read(ctx->dev, ctx->buffer))
+			pr_err("DATA reg could not be read \n");
+		ctx->buffer_size--;
+		ctx->buffer++;
+		if(irq_enable(dev->irq_desc, dev->rdy_pin))
+			pr_err("IRQ_enable error \n");
+	} else if(irq_disable(dev->irq_desc, dev->rdy_pin)) {
+		pr_err("IRQ_disable error \n");
+	}
+}
+
+/***************************************************************************//**
+ * SPI internal register write to device using a mask.
+ *
+ * @param dev      - The device structure.
+ * @param reg_addr - The register address.
+ * @param data     - The register data.
+ * @param mask     - The mask.
+ *
+ * @return SUCCESS in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_spi_int_reg_write_msk(struct ad413x_dev *dev,
+				     uint32_t reg_addr,
+				     uint32_t data,
+				     uint32_t mask)
+{
+	int32_t ret;
+	uint32_t reg_data;
+
+	ret = ad413x_spi_int_reg_read(dev, reg_addr, &reg_data);
+	if (ret)
+		return ret;
+	reg_data &= ~mask;
+	reg_data |= data;
+	return ad413x_spi_int_reg_write(dev, reg_addr, reg_data);
+}
+
+/***************************************************************************//**
+ * Set the mode of the ADC.
+ *
+ * @param dev       - The device structure.
+ * @param mode      - The ADC mode
+ *		      Accepted values: AD4110_CONTINOUS_CONV_MODE
+ *				       AD4110_SINGLE_CONV_MODE
+ *				       AD4110_STANDBY_MODE
+ *				       AD4110_PW_DOWN_MODE
+ *				       AD4110_SYS_OFFSET_CAL
+ *				       AD4110_SYS_GAIN_CAL
+ *
+ * @return SUCCESS in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_set_adc_mode(struct ad413x_dev *dev, enum ad413x_adc_mode mode)
+{
+	int32_t ret;
+	ret = ad413x_spi_int_reg_write_msk(dev,
+					   AD413X_REG_ADC_CTRL,
+					   AD413X_ADC_MODE(mode),
+					   AD413X_ADC_MODE(0xF));
+	if (ret)
+		return ret;
+
+	dev->op_mode = mode;
+
+	return ret;
+}
+
+/***************************************************************************//**
+ * Set the gain from configuration register.
+ *
+ * @param dev  - The device structure.
+ * @param gain - The gain value.
+ * 		 Accepted values: AD413X_GAIN_1
+ * 				  AD413X_GAIN_2
+ * 				  AD413X_GAIN_4
+ * 				  AD413X_GAIN_8
+ * 				  AD413X_GAIN_16
+ * 				  AD413X_GAIN_32
+ * 				  AD413X_GAIN_64
+ *				  AD413X_GAIN_128
+ * @param reg_nb - Number of Configuration Register
+ *
+ * @return SUCCESS in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_set_gain(struct ad413x_dev *dev, enum ad413x_gain gain,
+			uint8_t reg_nb)
+{
+	int32_t ret;
+
+	ret = ad413x_spi_int_reg_write_msk(dev,
+					   AD413X_REG_CONFIG(reg_nb),
+					   AD413X_PGA_N(gain),
+					   AD413X_PGA_N(0xF));
+	if (ret)
+		return ret;
+
+	dev->preset[reg_nb].gain = gain;
+
+	return SUCCESS;
+}
+
+/***************************************************************************//**
+ * Select reference from configuration register.
+ *
+ * @param dev  - The device structure.
+ * @param ref - The gain value.
+ * 		 Accepted values: AD413X_REFIN1
+ *					AD413X_REFIN2
+ *					AD413X_REFOUT_AVSS
+ *					AD413X_AVDD_AVSS
+ * @param reg_nb - Number of Configuration Register
+ *
+ * @return SUCCESS in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_set_ref(struct ad413x_dev *dev, enum ad413x_ref_sel ref,
+		       uint8_t reg_nb)
+{
+	int32_t ret;
+
+	ret = ad413x_spi_int_reg_write_msk(dev,
+					   AD413X_REG_CONFIG(reg_nb),
+					   AD413X_REF_SEL_N(ref),
+					   AD413X_REF_SEL_N(0xF));
+	if (ret)
+		return ret;
+
+	dev->preset[reg_nb].ref_sel = ref;
+
+	return SUCCESS;
+}
+
+/***************************************************************************//**
+ * Select filter from filter register.
+ *
+ * @param dev  	 - The device structure.
+ * @param filter - The gain value.
+ * 		 Accepted values: AD413X_SYNC4_STANDALONE
+ *					AD413X_SYNC4_SYNC1
+ *					AD413X_SYNC3_STANDALONE
+ *					AD413X_SYNC3_REJ60
+ *					AD413X_SYNC3_SYNC1
+ *					AD413X_SYNC3_PF1
+ *					AD413X_SYNC3_PF2
+ *					AD413X_SYNC3_PF3
+ *					AD413X_SYNC3_PF4
+ * @param reg_nb - Number of Configuration Register
+ *
+ * @return SUCCESS in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_set_filter(struct ad413x_dev *dev, enum ad413x_filter filter,
+			  uint8_t reg_nb)
+{
+	int32_t ret;
+
+	ret = ad413x_spi_int_reg_write_msk(dev,
+					   AD413X_REG_FILTER(reg_nb),
+					   AD413X_FILTER_MODE_N(filter),
+					   AD413X_FILTER_MODE_N(0xF));
+	if (ret)
+		return ret;
+
+	dev->preset[reg_nb].filter = filter;
+
+	return SUCCESS;
+}
+
+/***************************************************************************//**
+ * Select preset for adc channel.
+ *
+ * @param dev  		- The device structure.
+ * @param ch_nb  	- The channel number.
+ * @param preset_nb - The preset number.
+ *
+ * @return SUCCESS in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_set_ch_preset(struct ad413x_dev *dev, uint8_t ch_nb,
+			     uint8_t preset_nb)
+{
+	int32_t ret;
+
+	ret = ad413x_spi_int_reg_write_msk(dev,
+					   AD413X_REG_CHN(ch_nb),
+					   AD413X_SETUP_M(preset_nb),
+					   AD413X_SETUP_M(0xF));
+	if (ret)
+		return ret;
+
+	dev->ch[ch_nb].preset = preset_nb;
+
+	return SUCCESS;
+}
+
+/***************************************************************************//**
+ * Enable/disable channel.
+ *
+ * @param dev  		- The device structure.
+ * @param ch_nb  	- The channel number.
+ * @param enable 	- Channel status.
+ *
+ * @return SUCCESS in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_ch_en(struct ad413x_dev *dev, uint8_t ch_nb, uint8_t enable)
+{
+	int32_t ret;
+
+	if (enable) {
+		ret = ad413x_spi_int_reg_write_msk(dev,
+						   AD413X_REG_CHN(ch_nb),
+						   AD413X_ENABLE_M,
+						   AD413X_ENABLE_M);
+		if (ret)
+			return ret;
+	} else {
+		ret = ad413x_spi_int_reg_write_msk(dev,
+						   AD413X_REG_CHN(ch_nb),
+						   0x0U,
+						   AD413X_ENABLE_M);
+		if (ret)
+			return ret;
+	}
+
+	dev->ch[ch_nb].enable = enable;
+
+	return SUCCESS;
+}
+
+/***************************************************************************//**
+ * Enable/disable bipolar data coding.
+ *
+ * @param dev  		- The device structure.
+ * @param enable 	- 1 - Bipolar
+ * 					  0 - Unipolar
+ *
+ * @return SUCCESS in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_adc_bipolar(struct ad413x_dev *dev, uint8_t enable)
+{
+	int32_t ret;
+
+	if (enable) {
+		ret = ad413x_spi_int_reg_write_msk(dev,
+						   AD413X_REG_ADC_CTRL,
+						   AD413X_ADC_BIPOLAR,
+						   AD413X_ADC_BIPOLAR);
+		if (ret)
+			return ret;
+	} else {
+		ret = ad413x_spi_int_reg_write_msk(dev,
+						   AD413X_REG_ADC_CTRL,
+						   0x0U,
+						   AD413X_ADC_BIPOLAR);
+		if (ret)
+			return ret;
+	}
+
+	dev->bipolar = enable;
+
+	return SUCCESS;
+}
+
+/***************************************************************************//**
+ * Set ADC master clock mode.
+ *
+ * @param dev  - The device structure.
+ * @param clk - The clock mode.
+ * 		 Accepted values: AD413X_INT_76_8_KHZ_OUT_OFF
+ * 				  AD413X_INT_76_8_KHZ_OUT_ON
+ * 				  AD413X_EXT_76_8KHZ
+ * 				  AD413X_EXT_153_6_KHZ_DIV_2
+ *
+ * @return SUCCESS in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_set_mclk(struct ad413x_dev *dev, enum ad413x_mclk_sel clk)
+{
+	int32_t ret;
+	ret = ad413x_spi_int_reg_write_msk(dev,
+					   AD413X_REG_ADC_CTRL,
+					   AD413X_ADC_CNTRL_MCLK(clk),
+					   AD413X_ADC_CNTRL_MCLK(0xF));
+	if(ret)
+		return ret;
+
+	dev->mclk = clk;
+
+	return ret;
+}
+
+/***************************************************************************//**
+ * Do a SPI software reset.
+ *
+ * @param dev - The device structure.
+ *
+ * @return SUCCESS in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_spi_do_soft_reset(struct ad413x_dev *dev)
+{
+	int32_t ret;
+	uint8_t buf [ 8 ] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+
+	/* The AD413X can be reset by writing a series of 64 1�s to the DIN
+	 * input */
+	ret = spi_write_and_read(dev->spi_dev, buf, 8);
+	if(ret)
+		return ret;
+
+	mdelay(1); // TBD
+
+	return SUCCESS;
+}
+
+/***************************************************************************//**
+ * SPI internal register write to device.
+ *
+ * @param dev      - The device structure.
+ * @param reg_addr - The register address.
+ * @param reg_data - The register data.
+ *
+ * @return SUCCESS in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_spi_int_reg_write(struct ad413x_dev *dev,
+				 uint32_t reg_addr,
+				 uint32_t reg_data)
+{
+	uint8_t buf[5];
+
+	uint8_t data_size = AD413X_TRANSF_LEN(reg_addr);
+
+	buf[0] = AD413X_CMD_WR_COM_REG(reg_addr);
+
+	switch(data_size) {
+	case 1:
+		buf[1] = (reg_data & 0xFF);
+		break;
+
+	case 2:
+		buf[1] = (reg_data & 0xFF00) >> 8;
+		buf[2] = (reg_data & 0xFF);
+		break;
+
+	case 3:
+		buf[1] = (reg_data & 0xFF0000) >> 16;
+		buf[2] = (reg_data & 0xFF00) >> 8;
+		buf[3] = (reg_data & 0xFF);
+		break;
+
+	default:
+		return -EINVAL;
+	}
+
+	return spi_write_and_read(dev->spi_dev, buf, data_size + 1);
+}
+
+/***************************************************************************//**
+ * SPI internal register read from device.
+ *
+ * @param dev      - The device structure.
+ * @param reg_addr - The register address.
+ * @param reg_data - The register data.
+ *
+ * @return SUCCESS in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_spi_int_reg_read(struct ad413x_dev *dev,
+				uint32_t reg_addr,
+				uint32_t *reg_data)
+{
+	uint8_t ret;
+	uint8_t buf[5];
+	uint32_t data;
+
+	uint8_t data_size = AD413X_TRANSF_LEN(reg_addr);
+
+	buf[0] = AD413X_CMD_RD_COM_REG(reg_addr);
+
+	memset(buf + 1, 0xAA, 4); // dummy data bytes
+
+	ret = spi_write_and_read(dev->spi_dev, buf, data_size + 1);
+	if (ret)
+		return ret;
+
+	switch (data_size) {
+	case 1:
+		data = buf[1];
+		break;
+
+	case 2:
+		data = (buf[1] << 8) | buf[2];
+		break;
+
+	case 3:
+		data = (buf[1] << 16) | (buf[2] << 8) | buf[3];
+		break;
+
+	default:
+		return -EINVAL;
+	}
+
+	*reg_data = data;
+
+	return SUCCESS;
+}
+
+/***************************************************************************//**
+ * Single read of each adc active channel's data.
+ *
+ * @param device     - The device structure.
+ * @param buffer	 - Buffer to store read data.
+ * @param ch_nb		 - Number of active channels.
+ *
+ * @return SUCCESS in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_single_read(struct ad413x_dev *dev, int32_t *buffer,
+			   int32_t ch_nb)
+{
+	int32_t ret;
+
+	struct ad413x_callback_ctx ctx = {
+		.dev = dev,
+		.buffer = buffer,
+		.buffer_size = ch_nb,
+	};
+
+	struct callback_desc irq_callback = {
+		.callback = &irq_adc_single_read,
+		.ctx = &ctx
+	};
+
+	ret = irq_trigger_level_set(dev->irq_desc, dev->rdy_pin, IRQ_LEVEL_LOW);
+	if (ret)
+		return ret;
+	ret = irq_register_callback(dev->irq_desc, dev->rdy_pin, &irq_callback);
+	if (ret)
+		return ret;
+
+	ret = ad413x_set_adc_mode(dev, AD413X_SINGLE_CONV_MODE);
+	if (ret)
+		return ret;
+
+	// make sure adc is fully initialized before irq enabling
+	mdelay(1U);
+
+	ret = irq_enable(dev->irq_desc, dev->rdy_pin);
+	if (ret)
+		return ret;
+
+	while(ctx.buffer_size != 0U) ;
+
+	return SUCCESS;
+}
+
+/***************************************************************************//**
+ * Continuous read of each adc active channel's data.
+ *
+ * @param dev        - The device structure.
+ * @param buffer	 - Buffer to store read data.
+ * @param ch_nb		 - Number of active channels.
+ * @param sample_nb  - Samples number.
+ *
+ * @return SUCCESS in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_continuous_read(struct ad413x_dev *dev, int32_t *buffer,
+			       int32_t ch_nb, int32_t sample_nb)
+{
+	int32_t ret;
+
+	struct ad413x_callback_ctx ctx = {
+		.dev = dev,
+		.buffer = buffer,
+		.buffer_size = ch_nb * sample_nb,
+	};
+
+	struct callback_desc irq_callback = {
+		.callback = &irq_adc_cont_read,
+		.ctx = &ctx
+	};
+
+	ret = irq_trigger_level_set(dev->irq_desc, dev->rdy_pin, IRQ_LEVEL_LOW);
+	if (ret)
+		return ret;
+	ret = irq_register_callback(dev->irq_desc, dev->rdy_pin, &irq_callback);
+	if (ret)
+		return ret;
+
+	ret = ad413x_spi_int_reg_write_msk(dev,
+					   AD413X_REG_ADC_CTRL,
+					   AD413X_ADC_CONT_READ,
+					   AD413X_ADC_CONT_READ);
+	if (ret)
+		return ret;
+
+	ret = ad413x_set_adc_mode(dev, AD413X_CONTINOUS_CONV_MODE);
+	if (ret)
+		return ret;
+
+	// make sure adc is fully initialized before irq enabling
+	mdelay(1U);
+
+	ret = irq_enable(dev->irq_desc, dev->rdy_pin);
+	if (ret)
+		return ret;
+
+	while(ctx.buffer_size != 0U) ;
+
+	return ad413x_spi_int_reg_write_msk(dev,
+					    AD413X_REG_ADC_CTRL,
+					    0x00,
+					    AD413X_ADC_CONT_READ);
+}
+
+/***************************************************************************//**
+ * Store adc channel presets.
+ *
+ * @param dev        - The device structure.
+ * @param preset 	 - The structure to be saved as preset.
+ * @param preset_nb	 - Preset's number.
+ *
+ * @return SUCCESS in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_preset_store(struct ad413x_dev *dev, struct ad413x_preset preset,
+			    uint8_t preset_nb)
+{
+	int32_t ret;
+
+	ret = ad413x_set_gain(dev, preset.gain, preset_nb);
+	if (ret)
+		return ret;
+
+	ret = ad413x_set_ref(dev, preset.ref_sel, preset_nb);
+	if (ret)
+		return ret;
+
+	return ad413x_set_filter(dev, preset.filter, preset_nb);
+}
+
+/***************************************************************************//**
+ * Initialize the device.
+ *
+ * @param device     - The device structure.
+ * @param init_param - The structure that contains the device initial
+ * 		       parameters.
+ *
+ * @return SUCCESS in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_init(struct ad413x_dev **device,
+		    struct ad413x_init_param init_param)
+{
+	struct ad413x_dev *dev;
+	uint32_t reg_data;
+	int32_t ret;
+	int32_t i;
+
+	dev = (struct ad413x_dev *)malloc(sizeof(*dev));
+	if (!dev)
+		return FAILURE;
+
+	dev->chip_id = init_param.chip_id;
+	dev->int_ref = init_param.int_ref;
+
+	/* SPI */
+	ret = spi_init(&dev->spi_dev, init_param.spi_init);
+	if (ret)
+		goto err_dev;
+
+	/* Device Settings */
+	ret = ad413x_spi_do_soft_reset(dev);
+	if (ret)
+		goto err_spi;
+
+	/* Change SPI to 4 wire*/
+	ret = ad413x_spi_int_reg_write_msk(dev,
+					   AD413X_REG_ADC_CTRL,
+					   AD413X_ADC_CSB_EN,
+					   AD413X_ADC_CSB_EN);
+	if (ret)
+		goto err_spi;
+
+	/* TBD - chip ID is 0x00 for now */
+	ret = ad413x_spi_int_reg_read(dev, AD413X_REG_ID, &reg_data);
+	if (ret)
+		goto err_spi;
+
+	switch(dev->chip_id) {
+	case AD4130_8:
+		if(reg_data != AD4130_8) {
+			goto err_spi;
+		}
+		break;
+	default:
+		goto err_spi;
+	}
+
+	ret = ad413x_set_adc_mode(dev, AD413X_STANDBY_MODE);
+	if (ret)
+		goto err_spi;
+
+	/* TDB */
+	mdelay(1);
+
+	/* Preset configured and saved in dev */
+	for (i = 0; i < 8; i++) {
+		ret = ad413x_set_gain(dev, init_param.preset[i].gain, i);
+		if (ret)
+			goto err_spi;
+		ret = ad413x_set_ref(dev, init_param.preset[i].ref_sel, i);
+		if (ret)
+			goto err_spi;
+		ret = ad413x_set_filter(dev, init_param.preset[i].filter, i);
+		if (ret)
+			goto err_spi;
+	}
+
+	/* Channel setup */
+	for (i = 0; i < 16; i++) {
+		ret = ad413x_set_ch_preset(dev, i, init_param.ch[i].preset);
+		if (ret)
+			goto err_spi;
+		ret = ad413x_ch_en(dev, i, init_param.ch[i].enable);
+		if (ret)
+			goto err_spi;
+
+		ret = ad413x_spi_int_reg_write_msk(dev,
+						   AD413X_REG_CHN(i),
+						   AD413X_AINP_M(init_param.ch[i].ain_p),
+						   AD413X_AINP_M(0xFF));
+		if (ret)
+			goto err_spi;
+		dev->ch[i].ain_p = init_param.ch[i].ain_p;
+
+		ret = ad413x_spi_int_reg_write_msk(dev,
+						   AD413X_REG_CHN(i),
+						   AD413X_AINM_M(init_param.ch[i].ain_m),
+						   AD413X_AINM_M(0xFF));
+		if (ret)
+			goto err_spi;
+		dev->ch[i].ain_m = init_param.ch[i].ain_m;
+	}
+
+	/* EN/DIS internal reference */
+	if (dev->int_ref) {
+		ret = ad413x_spi_int_reg_write_msk(dev,
+						   AD413X_REG_ADC_CTRL,
+						   AD413X_ADC_REF_EN,
+						   AD413X_ADC_REF_EN);
+	}
+
+	ret = ad413x_adc_bipolar(dev, init_param.bipolar);
+	if (ret)
+		goto err_spi;
+
+	ret = ad413x_set_mclk(dev, init_param.mclk);
+	if (ret)
+		goto err_spi;
+
+	*device = dev;
+
+	pr_info("AD413X successfully initialized\n");
+	return SUCCESS;
+
+err_spi:
+	spi_remove(dev->spi_dev);
+err_dev:
+	free(dev);
+	pr_err("AD413X initialization error (%d)\n", ret);
+	return ret;
+}
+
+/***************************************************************************//**
+ * @brief Free the resources allocated by ad413x_init().
+ *
+ * @param dev - The device structure.
+ *
+ * @return SUCCESS in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_remove(struct ad413x_dev *dev)
+{
+	int32_t ret;
+
+	ret = spi_remove(dev->spi_dev);
+	if (ret)
+		return ret;
+
+	free(dev);
+
+	return SUCCESS;
+}

--- a/drivers/afe/ad413x/ad413x.h
+++ b/drivers/afe/ad413x/ad413x.h
@@ -1,0 +1,417 @@
+/***************************************************************************//**
+ *   @file   ad413x.h
+ *   @brief  Header file of AD411X Driver.
+ *   @author Andrei Porumb (andrei.porumb@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef AD413X_H_
+#define AD413X_H_
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdint.h>
+#include "no-os/delay.h"
+#include "no-os/gpio.h"
+#include "no-os/spi.h"
+#include "no-os/irq.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+#define AD413X_CMD_WR_COM_REG(x)	(0x00 | ((x) & 0x3F)) // Write to Register x
+#define AD413X_CMD_RD_COM_REG(x) 	(0x40 | ((x) & 0x3F)) // Read from Register x
+
+/*************************** ADC Register Lengths *****************************/
+#define AD413X_R1B					(1 << 8)
+#define AD413X_R2B					(2 << 8)
+#define AD413X_R3B					(3 << 8)
+#define AD413X_TRANSF_LEN(x)		(((x) >> 8) & 0xFF)
+
+/***************************** ADC Register Map *******************************/
+#define AD413X_REG_STATUS 			(AD413X_R1B | 0x0)
+#define AD413X_REG_ADC_CTRL			(AD413X_R2B | 0x1)
+#define AD413X_REG_DATA				(AD413X_R3B | 0x2)
+#define AD413X_REG_IO_CTRL			(AD413X_R2B | 0x3)
+#define AD413X_REG_VBIAS_CTRL		(AD413X_R2B | 0x4)
+#define AD413X_REG_ID				(AD413X_R1B | 0x5)
+#define AD413X_REG_ERROR			(AD413X_R2B | 0x6)
+#define AD413X_REG_ERROR_EN			(AD413X_R2B | 0x7)
+#define AD413X_REG_MCLK_CNT			(AD413X_R1B | 0x8)
+#define AD413X_REG_CHN(x)			(AD413X_R3B | (0x09U + (x)))
+#define AD413X_REG_CONFIG(x)		(AD413X_R2B | (0x19U + (x)))
+#define AD413X_REG_FILTER(x)		(AD413X_R3B | (0x21U + (x)))
+#define AD413X_REG_OFFSET(x)		(AD413X_R3B | (0x29U + (x)))
+#define AD413X_REG_GAIN(x)			(AD413X_R3B | (0x31U + (x)))
+#define AD413X_REG_MISC				(AD413X_R2B | 0x39)
+#define AD413X_REG_FIFO_CTRL		(AD413X_R3B | 0x3A)
+#define AD413X_REG_FIFO_STS			(AD413X_R1B | 0x3B)
+#define AD413X_REG_FIFO_THRSHLD		(AD413X_R3B | 0x3C)
+#define AD413X_REG_FIFO_DATA		(AD413X_R3B | 0x3D)
+
+
+/* ADC_CNTROL Register */
+#define AD413X_ADC_BIPOLAR				(1 << 14)
+#define AD413X_ADC_REF_VAL				(1 << 13)
+#define AD413X_ADC_DOUT_DIS_DEL			(1 << 12)
+#define AD413X_ADC_CONT_READ			(1 << 11)
+#define AD413X_ADC_DATA_STATUS			(1 << 10)
+#define AD413X_ADC_CSB_EN				(1 <<  9)
+#define AD413X_ADC_REF_EN				(1 <<  8)
+#define AD413X_ADC_DUTY_CYC_RATIO		(1 <<  6)
+#define AD413X_ADC_MODE(x)				(((x) & 0xF) << 2)
+#define AD413X_ADC_CNTRL_MCLK(x)		((x) & 0x3)
+
+/* IO_CONTROL Register */
+#define AD413X_SYNCB_CLEAR 				(1 << 10)
+#define AD413X_INT_PIN_SEL(x) 			(((x) & 0x3) << 8)
+#define AD413X_GPO_DATA_P4 				(1 << 7)
+#define AD413X_GPO_DATA_P3 				(1 << 6)
+#define AD413X_GPO_DATA_P2 				(1 << 5)
+#define AD413X_GPO_DATA_P1 				(1 << 4)
+#define AD413X_GPO_CTRL_P4		 		(1 << 3)
+#define AD413X_GPO_CTRL_P3		 		(1 << 2)
+#define AD413X_GPO_CTRL_P2		 		(1 << 1)
+#define AD413X_GPO_CTRL_P1		 		0x01
+
+/* VBIAS_CTRL Register */
+#define AD413X_VBIAS_15					(1 << 15)
+#define AD413X_VBIAS_14					(1 << 14)
+#define AD413X_VBIAS_13					(1 << 13)
+#define AD413X_VBIAS_12					(1 << 12)
+#define AD413X_VBIAS_11					(1 << 11)
+#define AD413X_VBIAS_10					(1 << 10)
+#define AD413X_VBIAS_9					(1 <<  9)
+#define AD413X_VBIAS_8					(1 <<  8)
+#define AD413X_VBIAS_7					(1 <<  7)
+#define AD413X_VBIAS_6					(1 <<  6)
+#define AD413X_VBIAS_5					(1 <<  5)
+#define AD413X_VBIAS_4					(1 <<  4)
+#define AD413X_VBIAS_3					(1 <<  3)
+#define AD413X_VBIAS_2					(1 <<  2)
+#define AD413X_VBIAS_1					(1 <<  1)
+#define AD413X_VBIAS_0					0x01
+
+/* ERROR Register */
+#define AD413X_AINP_OV_UV_ERR			(1 << 11)
+#define AD413X_AINM_OV_UV_ERR			(1 << 10)
+#define AD413X_REF_OV_UV_ERR			(1 <<  9)
+#define AD413X_REF_DETECT_ERR			(1 <<  8)
+#define AD413X_ADC_ERR					(1 <<  7)
+#define AD413X_SPI_IGNORE_ERR			(1 <<  6)
+#define AD413X_SPI_SCLK_CNT_ERR			(1 <<  5)
+#define AD413X_SPI_READ_ERR				(1 <<  4)
+#define AD413X_SPI_WRITE_ERR			(1 <<  3)
+#define AD413X_SPI_CRC_ERR				(1 <<  2)
+#define AD413X_MM_CRC_ERR				(1 <<  1)
+#define AD413X_ROM_CRC_ERR				0x01
+
+/* ERROR_EN Register */
+#define AD413X_MCLK_CNT_EN				(1 << 12)
+#define AD413X_AINP_OV_UV_ERR_EN		(1 << 11)
+#define AD413X_AINM_OV_UV_ERR_EN		(1 << 10)
+#define AD413X_REF_OV_UV_ERR_EN			(1 <<  9)
+#define AD413X_REF_DETECT_ERR_EN		(1 <<  8)
+#define AD413X_ADC_ERR_EN				(1 <<  7)
+#define AD413X_SPI_IGNORE_ERR_EN		(1 <<  6)
+#define AD413X_SPI_SCLK_CNT_ERR_EN		(1 <<  5)
+#define AD413X_SPI_READ_ERR_EN			(1 <<  4)
+#define AD413X_SPI_WRITE_ERR_EN			(1 <<  3)
+#define AD413X_SPI_CRC_ERR_EN			(1 <<  2)
+#define AD413X_MM_CRC_ERR_EN			(1 <<  1)
+#define AD413X_ROM_CRC_ERR_EN			0x01
+
+/* CHANNEL_M Register */
+#define AD413X_ENABLE_M					(1 << 23)
+#define AD413X_SETUP_M(x)				(((x) & 0x7) << 20)
+#define AD413X_PDSW_M					(1 << 19)
+#define AD413X_THRES_EN_M				(1 << 18)
+#define AD413X_AINP_M(x)				(((x) & 0x1F) << 13)
+#define AD413X_AINM_M(x)				(((x) & 0x1F) <<  8)
+#define AD413X_I_OUT1_CH_M(x)			(((x) & 0xF) <<   4)
+#define AD413X_I_OUT0_CH_M(x)			((x) & 0xF)
+
+/* CONFIG_N Register */
+#define AD413X_I_OUT1_N(x)				(((x) & 0x7) << 13)
+#define AD413X_I_OUT0_N(x)				(((x) & 0x7) << 10)
+#define AD413X_BURNOUT_N(x)				(((x) & 0x3) <<  8)
+#define AD413X_REF_BUFP_N(x)			(1 <<  7)
+#define AD413X_EF_BUFM_N				(1 <<  6)
+#define AD413X_REF_SEL_N(x)				(((x) & 0x3) <<  4)
+#define AD413X_PGA_N(x)					(((x) & 0x7) <<  1)
+#define AD413X_PGA_BYP_N				0x01
+
+/* FILTER_N Register */
+#define AD413X_SETTLE_N(x)				(((x) & 0x7) <<  21)
+#define AD413X_REPEAT_N(x)				(((x) & 0x1F) << 16)
+#define AD413X_FILTER_MODE_N(x)			(((x) & 0xF) <<  12)
+#define AD413X_FS_N(x)					((x) & 0x7FF)
+
+/* OFFSET_N Register */
+#define AD413X_OFFSET_N(x)				((x) & 0xFFFFFF)
+
+/* GAIN_N Register */
+#define AD413X_GAIN_N(x)				((x) & 0xFFFFFF)
+
+/* MISC Register */
+#define AD413X_BYPASS_OSC				(1 << 15)
+#define AD413X_PD_ALDO					(1 << 14)
+#define AD413X_CAL_RANGE_X2				(1 << 13)
+#define AD413X_RESERVED(x)				(((x) & 0xF) << 9)
+#define AD413X_STBY_OUT_EN				(1 << 8)
+#define AD413X_STBY_DIAGNOSTICS_EN		(1 << 7)
+#define AD413X_STBY_GPO_EN				(1 << 6)
+#define AD413X_STBY_PDSW_EN				(1 << 5)
+#define AD413X_STBY_BURNOUT_EN			(1 << 4)
+#define AD413X_STBY_VBIAS_EN			(1 << 3)
+#define AD413X_STBY_IEXC_EN				(1 << 2)
+#define AD413X_STBY_REFHOL_EN			(1 << 1)
+#define AD413X_STBY_INTREF_EN			0x01
+
+/* FIFO_CONTROL Register */
+#define AD413X_ADD_FIFO_STATUS			(1 << 19)
+#define AD413X_ADD_FIFO_HEADER			(1 << 18)
+#define AD413X_FIFO_MODE(x) 			(((x) & 0x3) << 16)
+#define AD413X_FIFO_WRITE_ERR_INT_EN 	(1 << 14)
+#define AD413X_FIFO_READ_ERR_INT_EN 	(1 << 13)
+#define AD413X_THRES_HIGH_INT_EN 		(1 << 12)
+#define AD413X_THRES_LOW_INT_EN  		(1 << 11)
+#define AD413X_OVERRUN_INT_EN 			(1 << 10)
+#define AD413X_WATERMARK_INT_EN 		(1 <<  9)
+#define AD413X_EMPTY_INT_EN 			(1 <<  8)
+#define AD413X_WATERMARK(x) 			((x) & 0xFF)
+
+/* FIFO_STATUS Register */
+#define AD413X_MASTER_ERR 				(1 << 7)
+#define AD413X_FIFO_WRITE_ERR 			(1 << 6)
+#define AD413X_FIFO_READ_ERR 			(1 << 5)
+#define AD413X_THRES_HIGH_FLAG 			(1 << 4)
+#define AD413X_THRES_LOW_FLAG 			(1 << 3)
+#define AD413X_OVERRUN_FLAG 			(1 << 2)
+#define AD413X_WATERMARK_FLAG 			(1 << 1)
+#define AD413X_EMPTY_FLAG 				0x01
+
+/* FIFO_THRESHOLD Register */
+#define AD413X_THRES_HIGH_VAL(x)		(((x) & 0xFFF) << 12)
+#define AD413X_THRES_LOW_VAL(x)			((x) & 0xFFF)
+
+/* 8-bits wide checksum generated using the polynomial */
+#define AD413X_CRC8_POLY	0x07 // x^8 + x^2 + x^1 + x^0
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+enum ad413x_mclk_sel {
+	AD413X_INT_76_8_KHZ_OUT_OFF,
+	AD413X_INT_76_8_KHZ_OUT_ON,
+	AD413X_EXT_76_8KHZ,
+	AD413X_EXT_153_6_KHZ_DIV_2
+};
+
+enum ad413x_adc_mode {
+	AD413X_CONTINOUS_CONV_MODE = 0,
+	AD413X_SINGLE_CONV_MODE = 1,
+	AD413X_STANDBY_MODE = 2,
+	AD413X_PW_DOWN_MODE = 3,
+	AD413X_IDLE_MODE = 4,
+	AD413X_INT_OFFSET_CAL = 5,
+	AD413X_INT_GAIN_CAL = 6,
+	AD413X_SYS_OFFSET_CAL = 7,
+	AD413X_SYS_GAIN_CAL = 8,
+	AD413X_DUTY_CYCLING_MODE = 9,
+	AD413X_SINGLE_CONV_SYNC_IDLE_MODE = 10,
+	AD413X_DUTY_CYCLING_SYNC_STBY_MODE = 11
+};
+
+enum ad413x_ref_sel {
+	AD413X_REFIN1,
+	AD413X_REFIN2,
+	AD413X_REFOUT_AVSS,
+	AD413X_AVDD_AVSS
+};
+
+enum ad413x_filter {
+	AD413X_SYNC4_STANDALONE,
+	AD413X_SYNC4_SYNC1,
+	AD413X_SYNC3_STANDALONE,
+	AD413X_SYNC3_REJ60,
+	AD413X_SYNC3_SYNC1,
+	AD413X_SYNC3_PF1,
+	AD413X_SYNC3_PF2,
+	AD413X_SYNC3_PF3,
+	AD413X_SYNC3_PF4
+};
+
+enum ad413x_gain {
+	AD413X_GAIN_1,
+	AD413X_GAIN_2,
+	AD413X_GAIN_4,
+	AD413X_GAIN_8,
+	AD413X_GAIN_16,
+	AD413X_GAIN_32,
+	AD413X_GAIN_64,
+	AD413X_GAIN_128,
+};
+
+/* TBD */
+enum ad413x_chip_id {
+	AD4130_8 = 0x00
+};
+
+struct ad413x_preset {
+	enum ad413x_ref_sel ref_sel;
+	enum ad413x_gain gain;
+	enum ad413x_filter filter;
+};
+
+struct ad413x_channel {
+	uint8_t preset;
+	uint8_t enable;
+	uint8_t ain_p;
+	uint8_t ain_m;
+};
+
+struct ad413x_dev {
+	/* SPI */
+	struct spi_desc			*spi_dev;
+	/* GPIO - used to know when conversion is rdy */
+	struct irq_ctrl_desc *irq_desc;
+	uint32_t rdy_pin;
+	/* Device Settings */
+	struct ad413x_preset preset[8];
+	struct ad413x_channel ch[16];
+	enum ad413x_chip_id chip_id;
+	enum ad413x_mclk_sel mclk;
+	enum ad413x_adc_mode op_mode;
+	uint8_t bipolar;
+	uint8_t int_ref; //Internal Reference Enable
+};
+
+struct ad413x_init_param {
+	/* SPI */
+	struct spi_init_param	*spi_init;
+	/* GPIO - used to know when conversion is rdy */
+	struct irq_ctrl_desc *irq_desc;
+	uint32_t rdy_pin;
+	/* Device Settings */
+	struct ad413x_preset preset[8];
+	struct ad413x_channel ch[16];
+	enum ad413x_chip_id chip_id;
+	enum ad413x_mclk_sel mclk;
+	enum ad413x_adc_mode op_mode;
+	uint8_t bipolar;
+	uint8_t int_ref; //Internal Reference Enable
+};
+
+struct ad413x_callback_ctx {
+	struct ad413x_dev *dev;
+	int32_t *buffer;
+	int32_t buffer_size;
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+/* SPI write to device using a mask. */
+int32_t ad413x_spi_int_reg_write_msk(struct ad413x_dev *dev,
+				     uint32_t reg_addr,
+				     uint32_t data,
+				     uint32_t mask);
+/* Set the mode of the ADC. */
+int32_t ad413x_set_adc_mode(struct ad413x_dev *dev, enum ad413x_adc_mode mode);
+
+/* Set the gain. */
+int32_t ad413x_set_gain(struct ad413x_dev *dev, enum ad413x_gain gain,
+			uint8_t reg_nb);
+
+/* Set the reference. */
+int32_t ad413x_set_ref(struct ad413x_dev *dev, enum ad413x_ref_sel ref,
+		       uint8_t reg_nb);
+
+/* Set the filter */
+int32_t ad413x_set_filter(struct ad413x_dev *dev, enum ad413x_filter filter,
+			  uint8_t reg_nb);
+
+/* Set channel preset */
+int32_t ad413x_set_ch_preset(struct ad413x_dev *dev, uint8_t ch_nb,
+			     uint8_t preset_nb);
+
+/* Enable channel */
+int32_t ad413x_ch_en(struct ad413x_dev *dev, uint8_t ch_nb, uint8_t enable);
+
+/* Set ADC master clock mode. */
+int32_t ad413x_set_mclk(struct ad413x_dev *dev, enum ad413x_mclk_sel clk);
+
+/* Do a SPI software reset. */
+int32_t ad413x_spi_do_soft_reset(struct ad413x_dev *dev);
+
+/* SPI internal register write to device. */
+int32_t ad413x_spi_int_reg_write(struct ad413x_dev *dev,
+				 uint32_t reg_addr,
+				 uint32_t reg_data);
+
+/* SPI internal register read from device. */
+int32_t ad413x_spi_int_reg_read(struct ad413x_dev *dev,
+				uint32_t reg_addr,
+				uint32_t *reg_data);
+
+/* Fills buffer with data read from each active channel */
+int32_t ad413x_single_read(struct ad413x_dev *dev, int32_t *buffer,
+			   int32_t ch_nb);
+
+/* Fills buffer with data read continuously from each active channel */
+int32_t ad413x_continuous_read(struct ad413x_dev *dev, int32_t *buffer,
+			       int32_t ch_nb, int32_t sample_nb);
+
+/* Set adc bipolar/unipolar coding. */
+int32_t ad413x_adc_bipolar(struct ad413x_dev *dev, uint8_t enable);
+
+/* SPI internal DATA register read from device. */
+int32_t ad413x_spi_int_data_reg_read(struct ad413x_dev *dev,
+				     uint32_t *reg_data);
+
+/* Store presets for adc channels */
+int32_t ad413x_preset_store(struct ad413x_dev *dev, struct ad413x_preset preset,
+			    uint8_t preset_nb);
+
+/* Initialize the device. */
+int32_t ad413x_init(struct ad413x_dev **device,
+		    struct ad413x_init_param init_param);
+
+/* Remove the device. */
+int32_t ad413x_remove(struct ad413x_dev *dev);
+
+#endif // AD413X_H_

--- a/projects/ad413x/Makefile
+++ b/projects/ad413x/Makefile
@@ -1,0 +1,8 @@
+# Uncomment to use the desired platform
+# PLATFORM = xilinx
+
+include ../../tools/scripts/generic_variables.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/ad413x/src.mk
+++ b/projects/ad413x/src.mk
@@ -1,0 +1,39 @@
+################################################################################
+#									       #
+#     Shared variables:							       #
+#	- PROJECT							       #
+#	- DRIVERS							       #
+#	- INCLUDE							       #
+#	- PLATFORM_DRIVERS						       #
+#	- NO-OS								       #
+#									       #
+################################################################################
+
+SRC_DIRS += $(PROJECT)/src
+SRCS += $(DRIVERS)/api/spi.c \
+	$(DRIVERS)/api/irq.c \
+	$(DRIVERS)/api/gpio.c \
+	$(DRIVERS)/afe/ad413x/ad413x.c
+				
+SRCS += $(PLATFORM_DRIVERS)/xilinx_spi.c \
+	$(PLATFORM_DRIVERS)/xilinx_irq.c \
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
+	$(PLATFORM_DRIVERS)/xilinx_gpio_irq.c \
+	$(PLATFORM_DRIVERS)/delay.c \
+	$(NO-OS)/util/list.c
+
+INCS += $(DRIVERS)/afe/ad413x/ad413x.h
+
+INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/gpio_extra.h \
+	$(PLATFORM_DRIVERS)/gpio_irq_extra.h
+
+INCS += $(INCLUDE)/no-os/spi.h \
+	$(INCLUDE)/no-os/gpio.h \
+	$(INCLUDE)/no-os/error.h \
+	$(INCLUDE)/no-os/delay.h \
+	$(INCLUDE)/no-os/irq.h \
+	$(INCLUDE)/no-os/util.h \
+	$(INCLUDE)/no-os/print_log.h \
+	$(INCLUDE)/no-os/list.h

--- a/projects/ad413x/src/app/main.c
+++ b/projects/ad413x/src/app/main.c
@@ -1,0 +1,141 @@
+/***************************************************************************//**
+ *   @file   ad413x/src/app/main.c
+ *   @brief  Implementation of Main Function.
+ *   @author Porumb Andrei (andrei.porumb@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "no-os/irq.h"
+#include "irq_extra.h"
+#include "gpio_irq_extra.h"
+#include "no-os/spi.h"
+#include "no-os/gpio.h"
+#include "gpio_extra.h"
+#include "spi_extra.h"
+#include "ad413x.h"
+#include "no-os/error.h"
+#include "xparameters.h"
+#include "parameters.h"
+#include "no-os/print_log.h"
+#include <stdint.h>
+#include <inttypes.h>
+
+/***************************************************************************//**
+ * @brief main
+*******************************************************************************/
+int main()
+{
+	uint32_t ret;
+	int32_t i;
+
+	/* SPI instance */
+	struct xil_spi_init_param spi_extra = {
+		.type = SPI_PS,
+		.flags = 0U
+	};
+	struct spi_init_param spi_ip = {
+		.device_id = SPI_DEVICE_ID,
+		.max_speed_hz = 100000,
+		.mode = SPI_MODE_3,
+		.chip_select = 0U,
+		.bit_order = SPI_BIT_ORDER_MSB_FIRST,
+		.platform_ops = &xil_spi_ops,
+		.extra = &spi_extra
+	};
+
+	/* IRQ instance. */
+	struct irq_ctrl_desc *irq_desc;
+	struct xil_irq_init_param irq_extra = {
+		.type = IRQ_PS
+	};
+	struct irq_init_param irq_ip = {
+		.irq_ctrl_id = 0U,
+		.platform_ops = &xil_irq_ops,
+		.extra = &irq_extra
+	};
+
+	ret = irq_ctrl_init(&irq_desc, &irq_ip);
+	if(ret)
+		return FAILURE;
+	ret = irq_global_enable(irq_desc);
+	if(ret)
+		return FAILURE;
+
+	/* GPIO IRQ instance. */
+	struct irq_ctrl_desc *gpio_irq_desc;
+	struct xil_gpio_irq_init_param gpio_irq_extra = {
+		.parent_desc = irq_desc,
+		.gpio_device_id = XPAR_PS7_GPIO_0_DEVICE_ID
+	};
+	struct irq_init_param gpio_irq_ip = {
+		.irq_ctrl_id = GPIO_IRQ_ID,
+		.platform_ops = &xil_gpio_irq_ops,
+		.extra = &gpio_irq_extra
+	};
+
+	ret = irq_ctrl_init(&gpio_irq_desc, &gpio_irq_ip);
+	if(ret)
+		return FAILURE;
+
+	/* Device AD413X instance. */
+	struct ad413x_dev *ad413x_dev;
+	struct ad413x_init_param ad413x_dev_ip = {
+		.spi_init = &spi_ip,
+		.chip_id = AD4130_8,
+		.mclk = AD413X_INT_76_8_KHZ_OUT_OFF,
+		.op_mode = AD413X_SINGLE_CONV_MODE,
+		.irq_desc = gpio_irq_desc,
+		.rdy_pin = RDY_PIN,
+		.preset[0] = { AD413X_REFIN1, AD413X_GAIN_4, AD413X_SYNC4_STANDALONE},
+		.preset[1] = { AD413X_REFOUT_AVSS, AD413X_GAIN_16, AD413X_SYNC3_PF1},
+		.preset[2] = { AD413X_REFIN2, AD413X_GAIN_64, AD413X_SYNC3_STANDALONE},
+		.ch[0] = { 0, 1, 0, 0x13}, //ch 0, preset 0, enable, AIN0, DGND
+		.ch[1] = { 2, 1, 1, 0x13},   //ch 1, preset 2, enable, AIN1, DGND
+		.ch[2] = { 1, 1, 2, 0x13}, //ch 2, preset 1, enable, AIN2, DGND
+		.ch[6] = { 0, 1, 3, 0x13}, //ch 6, preset 0, enable, AIN3, DGND
+		.ch[12] = { 2, 0, 4, 0x13}, //ch 12, preset 2, disabled, AIN4, DGND
+		.bipolar = 0,
+		.int_ref = 1
+	};
+
+	ret = ad413x_init(&ad413x_dev, ad413x_dev_ip);
+	if(ret)
+		return FAILURE;
+
+	return SUCCESS;
+}

--- a/projects/ad413x/src/app/parameters.h
+++ b/projects/ad413x/src/app/parameters.h
@@ -1,0 +1,54 @@
+/***************************************************************************//**
+ *   @file   ad413x/src/app/parameters.h
+ *   @brief  Parameters Definitions.
+ *   @author Andrei Porumb (andrei.porumb@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef PARAMETERS_H
+#define PARAMETERS_H
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+#define BUF_LENGTH 	32U
+#define SPI_DEVICE_ID 	0U
+#define GPIO_OFFSET  	54U
+
+#define GPIO_DEVICE_ID  XPAR_PS7_GPIO_0_DEVICE_ID
+#define RDY_PIN   		GPIO_OFFSET
+#define GPIO_IRQ_ID 	52U
+
+#endif


### PR DESCRIPTION
AD413X driver created based on AD4130-8 chip. PR still in progress and marked as draft. Basic functions tested on hardware.