### PR TITLE
xilinx.mk: remove sdkbuild dependency on all

### DIFF
--- a/tools/scripts/xilinx.mk
+++ b/tools/scripts/xilinx.mk
@@ -149,7 +149,7 @@ $(TEMP_DIR)/arch.txt: $(HARDWARE)
 	$(MUTE)	$(call tcl_util, get_arch) $(HIDE)
 
 PHONY += $(PLATFORM)_sdkbuild
-$(PLATFORM)_sdkbuild: all
+$(PLATFORM)_sdkbuild:
 	$(MUTE) $(MUTE) xsct $(NO-OS)/tools/scripts/platform/xilinx/build_project.tcl $(WORKSPACE) $(HIDE)
 
 PHONY += $(PLATFORM)_sdkclean


### PR DESCRIPTION
sdkbuild shouldn't depend on all rule.

Signed-off-by: Darius Berghe <darius.berghe@analog.com>