### PR TITLE
projects:ad3552r_fmcz: add IIO driver conditionally

### DIFF
--- a/projects/ad3552r_fmcz/src.mk
+++ b/projects/ad3552r_fmcz/src.mk
@@ -1,12 +1,15 @@
 #See No-OS/tool/scripts/src_model.mk for variable description
 
 SRC_DIRS += $(PROJECT)/srcs			\
-		$(NO-OS)/drivers/dac/ad3552r	\
 		$(NO-OS)/drivers/api		\
 		$(PLATFORM_DRIVERS)		\
 		$(NO-OS)/util			\
 		$(INCLUDE)
+SRCS += $(NO-OS)/drivers/dac/ad3552r/ad3552r.c
+INCS += $(NO-OS)/drivers/dac/ad3552r/ad3552r.h
 
 ifeq (y,$(strip $(TINYIIOD)))
 SRC_DIRS += $(NO-OS)/iio/iio_app
+SRCS += $(NO-OS)/drivers/dac/ad3552r/iio_ad3552r.c
+INCS += $(NO-OS)/drivers/dac/ad3552r/iio_ad3552r.h
 endif


### PR DESCRIPTION
If IIO example is not desired the IIO library is not used, but the AD3552R
IIO driver is linked and built. Since the IIO driver for AD3552R depends on
the IIO library, the build throws an error.

Signed-off-by: Andrei Drimbarean <Andrei.Drimbarean@analog.com>