### PR TITLE
stm32 irq

### DIFF
--- a/drivers/api/irq.c
+++ b/drivers/api/irq.c
@@ -80,9 +80,9 @@ int32_t irq_ctrl_remove(struct irq_ctrl_desc *desc)
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t irq_register_callback(struct irq_ctrl_desc *desc, uint32_t irq_id,
-			      struct callback_desc *callback_desc)
+			      void *callback)
 {
-	return desc->platform_ops->register_callback(desc, irq_id, callback_desc);
+	return desc->platform_ops->register_callback(desc, irq_id, callback);
 }
 
 /**

--- a/drivers/api/irq.c
+++ b/drivers/api/irq.c
@@ -91,9 +91,9 @@ int32_t irq_register_callback(struct irq_ctrl_desc *desc, uint32_t irq_id,
  * @param irq_id - Interrupt identifier.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t irq_unregister(struct irq_ctrl_desc *desc, uint32_t irq_id)
+int32_t irq_unregister_callback(struct irq_ctrl_desc *desc, uint32_t irq_id, void *callback)
 {
-	return desc->platform_ops->unregister(desc, irq_id);
+	return desc->platform_ops->unregister_callback(desc, irq_id, callback);
 }
 
 /**

--- a/drivers/platform/aducm3029/aducm3029_irq.c
+++ b/drivers/platform/aducm3029/aducm3029_irq.c
@@ -144,8 +144,8 @@ int32_t aducm3029_irq_ctrl_remove(struct irq_ctrl_desc *desc)
 	adi_xint_UnInit();
 
 	/* Free UART */
-	irq_unregister(desc, ADUCM_UART_INT_ID);
-	irq_unregister(desc, ADUCM_RTC_INT_ID);
+	irq_unregister_callback(desc, ADUCM_UART_INT_ID, NULL);
+	irq_unregister_callback(desc, ADUCM_RTC_INT_ID, NULL);
 	free(desc->extra);
 	free(desc);
 	initialized = 0;
@@ -178,7 +178,7 @@ int32_t aducm3029_irq_register_callback(struct irq_ctrl_desc *desc,
 		return FAILURE;
 
 	if (!callback_desc)
-		return irq_unregister(desc, irq_id);
+		return irq_unregister_callback(desc, irq_id, NULL);
 
 	aducm_desc = desc->extra;
 
@@ -254,7 +254,7 @@ int32_t aducm3029_irq_register_callback(struct irq_ctrl_desc *desc,
  * @param irq_id - Id of the interrupt
  * @return \ref SUCCESS in case of success, \ref FAILURE otherwise.
  */
-int32_t aducm3029_irq_unregister(struct irq_ctrl_desc *desc, uint32_t irq_id)
+int32_t aducm3029_irq_unregister_callback(struct irq_ctrl_desc *desc, uint32_t irq_id, void *callback)
 {
 	struct aducm_irq_ctrl_desc	*aducm_desc;
 	struct uart_desc		*uart_desc;
@@ -469,7 +469,7 @@ int32_t aducm3029_irq_disable(struct irq_ctrl_desc *desc, uint32_t irq_id)
 const struct irq_platform_ops aducm_irq_ops = {
 	.init = &aducm3029_irq_ctrl_init,
 	.register_callback = &aducm3029_irq_register_callback,
-	.unregister = &aducm3029_irq_unregister,
+	.unregister_callback = &aducm3029_irq_unregister_callback,
 	.global_enable = &aducm3029_irq_global_enable,
 	.global_disable = &aducm3029_irq_global_disable,
 	.enable = &aducm3029_irq_enable,

--- a/drivers/platform/aducm3029/aducm3029_irq.c
+++ b/drivers/platform/aducm3029/aducm3029_irq.c
@@ -163,7 +163,7 @@ int32_t aducm3029_irq_ctrl_remove(struct irq_ctrl_desc *desc)
  */
 int32_t aducm3029_irq_register_callback(struct irq_ctrl_desc *desc,
 					uint32_t irq_id,
-					struct callback_desc *callback_desc)
+					void *callback)
 {
 	struct aducm_irq_ctrl_desc	*aducm_desc;
 	struct uart_desc		*uart_desc;
@@ -172,6 +172,7 @@ int32_t aducm3029_irq_register_callback(struct irq_ctrl_desc *desc,
 	struct gpio_desc		*gpio_desc;
 	uint16_t			gpio_pin;
 	uint8_t				gpio_port;
+	struct callback_desc *callback_desc = (struct callback_desc *)callback;
 
 	if (!desc || !desc->extra || !initialized ||  irq_id >= NB_INTERRUPTS)
 		return FAILURE;

--- a/drivers/platform/maxim/maxim_irq.c
+++ b/drivers/platform/maxim/maxim_irq.c
@@ -116,7 +116,7 @@ int32_t max_irq_register_callback(struct irq_ctrl_desc *desc, uint32_t irq_id,
  * @param irq_id - Id of the interrupt
  * @return -ENOSYS
  */
-int32_t max_irq_unregister(struct irq_ctrl_desc *desc, uint32_t irq_id)
+int32_t max_irq_unregister_callback(struct irq_ctrl_desc *desc, uint32_t irq_id, void *callback)
 {
 	return -ENOSYS;
 }
@@ -188,7 +188,7 @@ int32_t max_irq_disable(struct irq_ctrl_desc *desc, uint32_t irq_id)
 const struct irq_platform_ops irq_ops = {
 	.init = &max_irq_ctrl_init,
 	.register_callback = &max_irq_register_callback,
-	.unregister = &max_irq_unregister,
+	.unregister_callback = &max_irq_unregister_callback,
 	.global_enable = &max_irq_global_enable,
 	.global_disable = &max_irq_global_disable,
 	.enable = &max_irq_enable,

--- a/drivers/platform/maxim/maxim_irq.c
+++ b/drivers/platform/maxim/maxim_irq.c
@@ -105,7 +105,7 @@ int32_t max_irq_ctrl_remove(struct irq_ctrl_desc *desc)
  * @return -ENOSYS
  */
 int32_t max_irq_register_callback(struct irq_ctrl_desc *desc, uint32_t irq_id,
-				  struct callback_desc *callback_desc)
+				  void *callback_desc)
 {
 	return -ENOSYS;
 }

--- a/drivers/platform/stm32/stm32_irq.c
+++ b/drivers/platform/stm32/stm32_irq.c
@@ -1,0 +1,262 @@
+/***************************************************************************//**
+ *   @file   stm32/stm32_irq.c
+ *   @brief  Implementation of external irq driver.
+ *   @author Darius Berghe (darius.berghe@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/************************* Include Files **************************************/
+/******************************************************************************/
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <errno.h>
+#include "no-os/irq.h"
+#include "no-os/util.h"
+#include "stm32_irq.h"
+#include "stm32_hal.h"
+
+EXTI_HandleTypeDef *hexti[32];
+
+void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin)
+{
+	HAL_EXTI_IRQHandler(hexti[find_first_set_bit(GPIO_Pin)]);
+}
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+/**
+ * @brief Initialized the controller for the STM32 external interrupts
+ * @param desc - Pointer where the configured instance is stored
+ * @param param - Configuration information for the instance
+ * @return 0 in case of success, errno error codes otherwise.
+ */
+int32_t stm32_irq_ctrl_init(struct irq_ctrl_desc **desc,
+			    const struct irq_init_param *param)
+{
+	struct irq_ctrl_desc *descriptor;
+
+	if (!param)
+		return -EINVAL;
+
+	descriptor = calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	// unused, there is only 1 interrupt controller and that is NVIC
+	descriptor->irq_ctrl_id = param->irq_ctrl_id;
+	descriptor->source = param->source;
+	descriptor->platform_ops = param->platform_ops;
+	descriptor->extra = param->extra;
+
+	*desc = descriptor;
+
+	return 0;
+}
+
+/**
+ * @brief Free the resources allocated by irq_ctrl_init()
+ * @param desc - Interrupt controller descriptor.
+ * @return 0 in case of success, errno error codes otherwise.
+ */
+int32_t stm32_irq_ctrl_remove(struct irq_ctrl_desc *desc)
+{
+	if (desc)
+		free(desc);
+
+	return 0;
+}
+
+/**
+ * @brief Not implemented. On stm32 platform, trigger level is set in the app, prior to irq_* configuration.
+ * @param desc - gpio irq descriptor.
+ * @param irq_id - the pin number
+ * @param trig_l - the trigger condition.
+ * @return -ENOSYS
+ */
+int32_t stm32_trigger_level_set(struct irq_ctrl_desc *desc,
+				uint32_t irq_id,
+				enum irq_trig_level level)
+{
+	int ret;
+	EXTI_ConfigTypeDef config;
+	ret = HAL_EXTI_GetConfigLine(desc->extra, &config);
+	if (ret != HAL_OK)
+		return -EFAULT;
+
+	switch (level) {
+	case IRQ_EDGE_FALLING:
+		config.Trigger = EXTI_TRIGGER_FALLING;
+		break;
+	case IRQ_EDGE_RISING:
+		config.Trigger = EXTI_TRIGGER_RISING;
+		break;
+	case IRQ_EDGE_BOTH:
+		config.Trigger = EXTI_TRIGGER_RISING_FALLING;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	ret = HAL_EXTI_SetConfigLine(desc->extra, &config);
+	if (ret != HAL_OK)
+		return -EFAULT;
+
+	return 0;
+}
+
+/**
+ * @brief Not implemented.
+ * @param desc - The IRQ controller descriptor.
+ * @param irq_id - Interrupt identifier.
+ * @param callback_desc - Descriptor of the callback.
+ * @return -ENOSYS
+ */
+int32_t stm32_irq_register_callback(struct irq_ctrl_desc *desc, uint32_t irq_id,
+				    void *callback)
+{
+	int ret;
+
+	switch (desc->source) {
+	case NO_OS_GPIO_IRQ:
+		ret = HAL_EXTI_RegisterCallback(desc->extra,
+						((struct stm32_callback *)callback)->event,
+						((struct stm32_callback *)callback)->callback);
+		if (ret != HAL_OK) {
+			ret = -EFAULT;
+			break;
+		}
+		hexti[((EXTI_HandleTypeDef *)desc->extra)->Line & 0xff] = desc->extra;
+		break;
+	default:
+		ret = -EINVAL;
+		break;
+	}
+
+	return ret;
+}
+
+/**
+ * @brief Not implemented
+ * @param desc - Interrupt controller descriptor.
+ * @param irq_id - Id of the interrupt
+ * @return -ENOSYS
+ */
+int32_t stm32_irq_unregister_callback(struct irq_ctrl_desc *desc, uint32_t irq_id, void *callback)
+{
+	int ret;
+
+	switch (desc->source) {
+	case NO_OS_GPIO_IRQ:
+		hexti[((EXTI_HandleTypeDef *)desc->extra)->Line & 0xff] = NULL;
+		break;
+	default:
+		ret = -EINVAL;
+		break;
+	}
+
+	return ret;
+}
+
+/**
+ * @brief Enable all interrupts
+ * @param desc - Interrupt controller descriptor.
+ * @return 0
+ */
+int32_t stm32_irq_global_enable(struct irq_ctrl_desc *desc)
+{
+	__enable_irq();
+
+	return 0;
+}
+
+/**
+ * @brief Disable all interrupts
+ * @param desc - Interrupt controller descriptor.
+ * @return 0
+ */
+int32_t stm32_irq_global_disable(struct irq_ctrl_desc *desc)
+{
+	__disable_irq();
+
+	return 0;
+}
+
+/**
+ * @brief Enable a specific interrupt
+ * @param desc - Interrupt controller descriptor.
+ * @param irq_id - Interrupt identifier
+ * @return 0 in case of success, errno error codes otherwise.
+ */
+int32_t stm32_irq_enable(struct irq_ctrl_desc *desc, uint32_t irq_id)
+{
+	// TODO: add a proper priority setting function in irq.h instead of this default
+	HAL_NVIC_SetPriority(irq_id, 0, 0);
+
+	NVIC_EnableIRQ(irq_id);
+
+	return 0;
+}
+
+/**
+ * @brief Disable a specific interrupt
+ * @param desc - Interrupt controller descriptor.
+ * @param irq_id - Interrupt identifier
+ * @return 0 in case of success, -EINVAL otherwise.
+ */
+int32_t stm32_irq_disable(struct irq_ctrl_desc *desc, uint32_t irq_id)
+{
+	NVIC_DisableIRQ(irq_id);
+
+	return 0;
+}
+
+/**
+ * @brief stm32 specific IRQ platform ops structure
+ */
+const struct irq_platform_ops stm32_irq_ops = {
+	.init = &stm32_irq_ctrl_init,
+	.trigger_level_set = &stm32_trigger_level_set,
+	.register_callback = &stm32_irq_register_callback,
+	.unregister_callback = &stm32_irq_unregister_callback,
+	.global_enable = &stm32_irq_global_enable,
+	.global_disable = &stm32_irq_global_disable,
+	.enable = &stm32_irq_enable,
+	.disable = &stm32_irq_disable,
+	.remove = &stm32_irq_ctrl_remove
+};

--- a/drivers/platform/stm32/stm32_irq.h
+++ b/drivers/platform/stm32/stm32_irq.h
@@ -1,0 +1,56 @@
+/***************************************************************************//**
+ *   @file   stm32/irq_extra.h
+ *   @brief  Header file for stm32 irq specifics.
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef STM32_IRQ_H
+#define STM32_IRQ_H
+
+#include "no-os/irq.h"
+
+struct stm32_callback {
+	/* Callback function pointer. Used as the 3rd parameter of HAL_*_RegisterCallback(). */
+	void (*callback)(void);
+	/* Specific event that triggers the callback. Used as the 2nd parameter of HAL_*_RegisterCallback(). */
+	uint32_t event;
+};
+
+/**
+ * @brief stm32 platform specific irq platform ops structure
+ */
+extern const struct irq_platform_ops stm32_irq_ops;
+
+#endif

--- a/drivers/platform/xilinx/xilinx_gpio_irq.c
+++ b/drivers/platform/xilinx/xilinx_gpio_irq.c
@@ -241,10 +241,11 @@ int32_t xil_gpio_irq_trigger_level_set(struct irq_ctrl_desc *desc,
  */
 int32_t xil_gpio_irq_register_callback(struct irq_ctrl_desc *desc,
 				       uint32_t irq_id,
-				       struct callback_desc *callback_desc)
+				       void *callback)
 {
 	struct xil_callback_desc *dev_callback;
 	struct xil_gpio_irq_desc *extra;
+	struct callback_desc *callback_desc = (struct callback_desc *)callback;
 
 	dev_callback = (struct xil_callback_desc *)calloc(1, sizeof(*dev_callback));
 	if(!dev_callback)

--- a/drivers/platform/xilinx/xilinx_gpio_irq.c
+++ b/drivers/platform/xilinx/xilinx_gpio_irq.c
@@ -269,7 +269,7 @@ int32_t xil_gpio_irq_register_callback(struct irq_ctrl_desc *desc,
  * @param irq_id - Pin number.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t xil_gpio_irq_unregister(struct irq_ctrl_desc *desc, uint32_t irq_id)
+int32_t xil_gpio_irq_unregister_callback(struct irq_ctrl_desc *desc, uint32_t irq_id, void *callback)
 {
 	int32_t status;
 	struct xil_gpio_irq_desc *extra;
@@ -350,6 +350,6 @@ const struct irq_platform_ops xil_gpio_irq_ops = {
 	.disable = &xil_gpio_irq_disable,
 	.trigger_level_set = &xil_gpio_irq_trigger_level_set,
 	.register_callback = &xil_gpio_irq_register_callback,
-	.unregister = xil_gpio_irq_unregister,
+	.unregister_callback = xil_gpio_irq_unregister_callback,
 	.remove = &xil_gpio_irq_ctrl_remove
 };

--- a/drivers/platform/xilinx/xilinx_irq.c
+++ b/drivers/platform/xilinx/xilinx_irq.c
@@ -330,7 +330,7 @@ int32_t xil_irq_trigger_level_set(struct irq_ctrl_desc *desc, uint32_t irq_id,
  * @param irq_id - Interrupt identifier.
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
-int32_t xil_irq_unregister(struct irq_ctrl_desc *desc, uint32_t irq_id)
+int32_t xil_irq_unregister_callback(struct irq_ctrl_desc *desc, uint32_t irq_id, void *callback)
 {
 	struct xil_irq_desc *xil_dev = desc->extra;
 
@@ -374,7 +374,7 @@ int32_t xil_irq_ctrl_remove(struct irq_ctrl_desc *desc)
 const struct irq_platform_ops xil_irq_ops = {
 	.init = &xil_irq_ctrl_init,
 	.register_callback = &xil_irq_register_callback,
-	.unregister = &xil_irq_unregister,
+	.unregister_callback = &xil_irq_unregister_callback,
 	.global_enable = &xil_irq_global_enable,
 	.global_disable = &xil_irq_global_disable,
 	.trigger_level_set = &xil_irq_trigger_level_set,

--- a/drivers/platform/xilinx/xilinx_irq.c
+++ b/drivers/platform/xilinx/xilinx_irq.c
@@ -242,10 +242,10 @@ int32_t xil_irq_disable(struct irq_ctrl_desc *desc, uint32_t irq_id)
  * @return SUCCESS in case of success, FAILURE otherwise.
  */
 int32_t xil_irq_register_callback(struct irq_ctrl_desc *desc, uint32_t irq_id,
-				  struct callback_desc *callback_desc)
+				  void *callback)
 {
 	struct xil_irq_desc *xil_dev = desc->extra;
-
+	struct callback_desc *callback_desc = (struct callback_desc *)callback;
 	switch(xil_dev->type) {
 	case IRQ_PS:
 #ifdef XSCUGIC_H

--- a/include/no-os/irq.h
+++ b/include/no-os/irq.h
@@ -142,7 +142,8 @@ struct irq_platform_ops {
 	int32_t (*register_callback)(struct irq_ctrl_desc *desc, uint32_t irq_id,
 				     void *callback);
 	/** Unregisters a generic IRQ handling function */
-	int32_t (*unregister)(struct irq_ctrl_desc *desc, uint32_t irq_id);
+	int32_t (*unregister_callback)(struct irq_ctrl_desc *desc, uint32_t irq_id,
+					 void *callback);
 	/** Global interrupt enable */
 	int32_t (*global_enable)(struct irq_ctrl_desc *desc);
 	/** Global interrupt disable */
@@ -174,7 +175,8 @@ int32_t irq_register_callback(struct irq_ctrl_desc *desc, uint32_t irq_id,
 			      void *callback_desc);
 
 /* Unregisters a generic IRQ handling function */
-int32_t irq_unregister(struct irq_ctrl_desc *desc, uint32_t irq_id);
+int32_t irq_unregister_callback(struct irq_ctrl_desc *desc, uint32_t irq_id,
+				  void *callback_desc);
 
 /* Global interrupt enable */
 int32_t irq_global_enable(struct irq_ctrl_desc *desc);

--- a/include/no-os/irq.h
+++ b/include/no-os/irq.h
@@ -49,6 +49,9 @@
 /******************************************************************************/
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
+enum irq_source {
+	NO_OS_GPIO_IRQ,
+};
 
 /**
  * @enum irq_uart_event_e
@@ -85,6 +88,8 @@ struct irq_platform_ops ;
 struct irq_init_param {
 	/** Interrupt request controller ID. */
 	uint32_t	irq_ctrl_id;
+	/** Interrupt source peripheral. */
+	enum irq_source source;
 	/** Platform specific IRQ platform ops structure. */
 	const struct irq_platform_ops *platform_ops;
 	/** IRQ extra parameters (device specific) */
@@ -98,6 +103,8 @@ struct irq_init_param {
 struct irq_ctrl_desc {
 	/** Interrupt request controller ID. */
 	uint32_t	irq_ctrl_id;
+	/** Interrupt source peripheral. */
+	enum irq_source source;
 	/** Platform specific IRQ platform ops structure. */
 	const struct irq_platform_ops *platform_ops;
 	/** IRQ extra parameters (device specific) */

--- a/include/no-os/irq.h
+++ b/include/no-os/irq.h
@@ -112,7 +112,7 @@ struct irq_ctrl_desc {
 };
 
 /**
- * @struct callback_desc
+ * @struct callback_desc TODO: move this to each [platform]_irq.h.
  * @brief Structure describing a callback to be registered
  */
 struct callback_desc {
@@ -140,7 +140,7 @@ struct irq_platform_ops {
 			const struct irq_init_param *param);
 	/** Register a callback to handle the irq events */
 	int32_t (*register_callback)(struct irq_ctrl_desc *desc, uint32_t irq_id,
-				     struct callback_desc *callback_desc);
+				     void *callback);
 	/** Unregisters a generic IRQ handling function */
 	int32_t (*unregister)(struct irq_ctrl_desc *desc, uint32_t irq_id);
 	/** Global interrupt enable */
@@ -171,7 +171,7 @@ int32_t irq_ctrl_remove(struct irq_ctrl_desc *desc);
 
 /* Register a callback to handle the irq events */
 int32_t irq_register_callback(struct irq_ctrl_desc *desc, uint32_t irq_id,
-			      struct callback_desc *callback_desc);
+			      void *callback_desc);
 
 /* Unregisters a generic IRQ handling function */
 int32_t irq_unregister(struct irq_ctrl_desc *desc, uint32_t irq_id);

--- a/network/wifi/at_parser.c
+++ b/network/wifi/at_parser.c
@@ -973,7 +973,7 @@ int32_t at_init(struct at_desc **desc, const struct at_init_param *param)
 	return SUCCESS;
 
 free_irq:
-	irq_unregister(ldesc->irq_desc, ldesc->uart_irq_id);
+	irq_unregister_callback(ldesc->irq_desc, ldesc->uart_irq_id, &callback_desc);
 free_desc:
 	free(ldesc);
 	*desc = NULL;
@@ -992,7 +992,7 @@ int32_t at_remove(struct at_desc *desc)
 	if (!desc)
 		return FAILURE;
 
-	irq_unregister(desc->irq_desc, desc->uart_irq_id);
+	irq_unregister_calback(desc->irq_desc, desc->uart_irq_id, NULL);
 	free(desc);
 
 	return SUCCESS;

--- a/projects/iio_adpd1080/src/main.c
+++ b/projects/iio_adpd1080/src/main.c
@@ -174,7 +174,7 @@ static int32_t adpd1080pmod_32k_calib(struct adpd188_dev *adpd1080_dev)
 	if(status != SUCCESS)
 		goto finish;
 
-	status = irq_unregister(cal_irq, ADUCM_GPIO_A_INT_ID);
+	status = irq_unregister_callback(cal_irq, ADUCM_GPIO_A_INT_ID, &sync_gpio_cb);
 	if(status != SUCCESS)
 		goto gpio_finish;
 

--- a/tools/scripts/stm32.mk
+++ b/tools/scripts/stm32.mk
@@ -51,6 +51,9 @@ ASM_SRCS += $(call rwildcard, $(PROJECT_BUILD)/Startup,*.s)
 # Get the path of the interrupts file
 ITC = $(call rwildcard, $(PROJECT_BUILD)/Src,*_it.c)
 
+# Get the path of the hal config file
+HALCONF = $(call rwildcard, $(PROJECT_BUILD)/Inc,*_hal_conf.h)
+
 ifneq (,$(wildcard $(PROJECT_BUILD)))
 TARGET = $(shell sed -rn 's|^.*(STM32[A-Z][0-9][0-9][0-9]x+)"/>$$|\1|p' $(PROJECT_BUILDROOT)/.cproject | head -n 1)
 CFLAGS += -D$(TARGET)
@@ -84,6 +87,7 @@ $(PROJECT_TARGET)_configure:
 	$(call print,Configuring project)
 	$(MUTE) sed -i 's/ main(/ generated_main(/' $(PROJECT_BUILD)/Src/main.c $(HIDE)
 	$(MUTE) sed -i 's/HAL_GPIO_EXTI_IRQHandler/HAL_GPIO_EXTI_Callback/' $(ITC) $(HIDE)
+	$(MUTE) sed -i 's/USE_HAL_UART_REGISTER_CALLBACKS\s*0U/USE_HAL_UART_REGISTER_CALLBACKS\t1U/g' $(HALCONF) $(HIDE)
 	$(MUTE) $(call copy_file, $(PROJECT_BUILD)/Src/main.c, $(PROJECT_BUILD)/Src/generated_main.c) $(HIDE)
 	$(MUTE) $(call remove_file, $(PROJECT_BUILD)/Src/main.c) $(HIDE)
 

--- a/tools/scripts/stm32.mk
+++ b/tools/scripts/stm32.mk
@@ -91,7 +91,7 @@ $(PROJECT_TARGET):
 	$(MUTE) $(call set_one_time_rule,$@)
 
 $(PLATFORM)_sdkopen:
-	$(MUTE) $(STM32CUBEIDE)/$(IDE) -nosplash -import $(PROJECT_BUILDROOT) -data $(BUILD_DIR) $(HIDE)
+	$(STM32CUBEIDE)/$(IDE) -nosplash -import $(PROJECT_BUILDROOT) -data $(BUILD_DIR) &
 
 CFLAGS += -std=gnu11 \
 	-g3 \


### PR DESCRIPTION
What I propose here are 2 major changes to the main irq no-os API and structures:
1. register_calback should get a void * instead of struct calback_desc * as its last parameter
2. irq_init_param and irq_desc extended with an irq source

Then what follows is just the implementation on stm32.

Usage:
```
void ad5940_int_callback(void) {
        // This is the user callback
}

// -------------------------- Platform specific ----------------------------------
	EXTI_ConfigTypeDef ad5940_int_exticonfig = {
		.Line = EXTI_LINE_7,
		.Trigger = EXTI_TRIGGER_FALLING,
		.GPIOSel = EXTI_GPIOG,
		.Mode = EXTI_MODE_INTERRUPT,
	};
	EXTI_HandleTypeDef ad5940_int_hexti;
	ret = HAL_EXTI_SetConfigLine(&ad5940_int_hexti, &ad5940_int_exticonfig);
	if (ret != HAL_OK)
		return ret;

	struct stm32_callback ad5940_int_cb = {
			.callback = ad5940_int_callback,
			.event = HAL_EXTI_COMMON_CB_ID,
	};
	
// -------------------------- Generic irq API stuff ----------------------------------
	struct irq_init_param ad5940_int_ip = {
		.source = NO_OS_GPIO_IRQ,
		.platform_ops = &stm32_irq_ops,
		.extra = &ad5940_int_hexti, // <------- this is defined in the platform specific section above
	};
	struct irq_ctrl_desc *ad5940_int;
	ret = irq_ctrl_init(&ad5940_int, &ad5940_int_ip);
	if (ret < 0)
		return ret;

	ret = irq_register_callback(ad5940_int, AD5940_INT_EXTI_IRQn, 
	                                          &ad5940_int_cb);  // <------- this is defined in the platform specific section above
	if (ret < 0)
		return ret;

	ret = irq_trigger_level_set(ad5940_int, AD5940_INT_EXTI_IRQn, IRQ_EDGE_FALLING);
	if (ret < 0)
		return ret;

	ret = irq_enable(ad5940_int, AD5940_INT_EXTI_IRQn);
	if (ret < 0)
		return ret;
```

