### PR TITLE
Fix xilinx repetitive irq triggering

### DIFF
--- a/drivers/platform/xilinx/xilinx_gpio_irq.c
+++ b/drivers/platform/xilinx/xilinx_gpio_irq.c
@@ -306,6 +306,7 @@ int32_t xil_gpio_irq_enable(struct irq_ctrl_desc *desc, uint32_t irq_id)
 		status = iterator_move(extra->it, 1);
 		if(callback_desc->pin_nb == irq_id) {
 			callback_desc->enabled = true;
+			XGpioPs_IntrClearPin(&extra->my_Gpio, irq_id);
 			break;
 		}
 	}


### PR DESCRIPTION
Before this commit, interrupt callback was executed even if the event
occurred before the interrupt enabling. After this commit, only events which
occur after interrupt enabling will trigger the interrupt.

