### PR TITLE
adaq8092 driver + application

### DIFF
--- a/drivers/adc/adaq8092/adaq8092.c
+++ b/drivers/adc/adaq8092/adaq8092.c
@@ -1,0 +1,686 @@
+/***************************************************************************//**
+ *   @file   adaq8092.c
+ *   @brief  Implementation of ADAQ8092 Driver.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdlib.h>
+#include <errno.h>
+#include "adaq8092.h"
+#include "no-os/delay.h"
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+/******************************************************************************/
+
+/**
+ * @brief Read device register.
+ * @param dev - The device structure.
+ * @param reg_addr - The register address.
+ * @param reg_data - The data read from the register.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int adaq8092_read(struct adaq8092_dev *dev, uint8_t reg_addr, uint8_t *reg_data)
+{
+	int ret;
+	uint8_t buff[2] = {0};
+
+	buff[0] = ADAQ8092_SPI_READ | reg_addr;
+
+	ret = spi_write_and_read(dev->spi_desc, buff, 2);
+	if (ret)
+		return ret;
+
+	*reg_data = buff[1];
+
+	return 0;
+}
+
+/**
+ * @brief Write device register.
+ * @param dev- The device structure.
+ * @param reg_addr - The register address.
+ * @param reg_data - The data to be written.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int adaq8092_write(struct adaq8092_dev *dev, uint8_t reg_addr, uint8_t reg_data)
+{
+	uint8_t buff[2] = {0};
+
+	buff[0] = reg_addr;
+	buff[1] = reg_data;
+
+	return spi_write_and_read(dev->spi_desc, buff, 2);
+}
+
+/**
+ * @brief Update specific register bits.
+ * @param dev - The device structure.
+ * @param reg_addr - The register address.
+ * @param mask - Specific bits mask.
+ * @param reg_data - The data to be written.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int adaq8092_update_bits(struct adaq8092_dev *dev, uint8_t reg_addr,
+			 uint8_t mask, uint8_t reg_data)
+{
+	int ret;
+	uint8_t data;
+
+	ret = adaq8092_read(dev, reg_addr, &data);
+	if (ret)
+		return ret;
+
+	data &= ~mask;
+	data |= reg_data;
+
+	return adaq8092_write(dev, reg_addr, data);
+}
+
+/**
+ * @brief Initialize the device.
+ * @param device - The device structure.
+ * @param init_param - The structure that contains the device initial
+ * 		       parameters.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int adaq8092_init(struct adaq8092_dev **device,
+		  struct adaq8092_init_param init_param)
+{
+	struct adaq8092_dev *dev;
+	int ret;
+
+	dev = (struct adaq8092_dev *)calloc(1, sizeof(*dev));
+	if (!dev)
+		return -ENOMEM;
+
+	/* SPI Initialization*/
+	ret = spi_init(&dev->spi_desc, init_param.spi_init);
+	if (ret)
+		goto error_dev;
+
+	/* GPIO Initialization */
+	ret = gpio_get(&dev->gpio_adc_pd1, init_param.gpio_adc_pd1_param);
+	if (ret)
+		goto error_spi;
+
+	ret = gpio_get(&dev->gpio_adc_pd2, init_param.gpio_adc_pd2_param);
+	if (ret)
+		goto error_adc_pd1;
+
+	ret = gpio_get(&dev->gpio_en_1p8, init_param.gpio_en_1p8_param);
+	if (ret)
+		goto error_adc_pd2;
+
+	ret = gpio_get(&dev->gpio_par_ser, init_param.gpio_par_ser_param);
+	if (ret)
+		goto error_en_1p8;
+
+	/* Powerup Sequence */
+	ret = gpio_direction_output(dev->gpio_adc_pd1, GPIO_LOW);
+	if (ret)
+		goto error_par_ser;
+
+	ret = gpio_direction_output(dev->gpio_adc_pd2, GPIO_LOW);
+	if (ret)
+		goto error_par_ser;
+
+	ret = gpio_direction_output(dev->gpio_en_1p8, GPIO_LOW);
+	if (ret)
+		goto error_par_ser;
+
+	ret = gpio_direction_output(dev->gpio_par_ser, GPIO_LOW);
+	if (ret)
+		goto error_par_ser;
+
+	mdelay(1000);
+
+	ret = gpio_set_value(dev->gpio_en_1p8, GPIO_HIGH);
+	if (ret)
+		goto error_par_ser;
+
+	mdelay(500);
+
+	ret = gpio_set_value(dev->gpio_adc_pd1, GPIO_HIGH);
+	if (ret)
+		goto error_par_ser;
+
+	mdelay(1);
+
+	ret = gpio_set_value(dev->gpio_adc_pd2, GPIO_HIGH);
+	if (ret)
+		goto error_par_ser;
+
+	/* Software Reset */
+	ret = adaq8092_write(dev,  ADAQ8092_REG_RESET, field_prep(ADAQ8092_RESET, 1));
+	if (ret)
+		goto error_par_ser;
+
+	mdelay(100);
+
+	/* Device Initialization */
+	ret = adaq8092_set_pd_mode(dev, init_param.pd_mode);
+	if (ret)
+		goto error_par_ser;
+
+	ret = adaq8092_set_clk_pol_mode(dev, init_param.clk_pol_mode);
+	if (ret)
+		goto error_par_ser;
+
+	ret = adaq8092_set_clk_phase_mode(dev, init_param.clk_phase_mode);
+	if (ret)
+		goto error_par_ser;
+
+	ret = adaq8092_set_clk_dc_mode(dev, init_param.clk_dc_mode);
+	if (ret)
+		goto error_par_ser;
+
+	ret = adaq8092_set_lvds_cur_mode(dev, init_param.lvds_cur_mode);
+	if (ret)
+		goto error_par_ser;
+
+	ret = adaq8092_set_lvds_term_mode(dev, init_param.lvds_term_mode);
+	if (ret)
+		goto error_par_ser;
+
+	ret = adaq8092_set_dout_en(dev, init_param.dout_en);
+	if (ret)
+		goto error_par_ser;
+
+	ret = adaq8092_set_dout_mode(dev, init_param.dout_mode);
+	if (ret)
+		goto error_par_ser;
+
+	ret = adaq8092_set_test_mode(dev, init_param.test_mode);
+	if (ret)
+		goto error_par_ser;
+
+	ret = adaq8092_set_alt_pol_en(dev, init_param.alt_bit_pol_en);
+	if (ret)
+		goto error_par_ser;
+
+	ret = adaq8092_set_data_rand_en(dev, init_param.data_rand_en);
+	if (ret)
+		goto error_par_ser;
+
+	ret = adaq8092_set_twos_comp(dev, init_param.twos_comp);
+	if (ret)
+		goto error_par_ser;
+
+	*device = dev;
+
+	return 0;
+
+error_par_ser:
+	gpio_remove(dev->gpio_par_ser);
+error_en_1p8:
+	gpio_remove(dev->gpio_en_1p8);
+error_adc_pd2:
+	gpio_remove(dev->gpio_adc_pd2);
+error_adc_pd1:
+	gpio_remove(dev->gpio_adc_pd1);
+error_spi:
+	spi_remove(dev->spi_desc);
+error_dev:
+	free(dev);
+
+	return ret;
+}
+
+/**
+ * @brief Remove the device and release resources.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int adaq8092_remove(struct adaq8092_dev *dev)
+{
+	int ret;
+
+	ret = spi_remove(dev->spi_desc);
+	if (ret)
+		return ret;
+
+	ret = gpio_remove(dev->gpio_adc_pd1);
+	if (ret)
+		return ret;
+
+	ret = gpio_remove(dev->gpio_adc_pd2);
+	if (ret)
+		return ret;
+
+	ret = gpio_remove(dev->gpio_en_1p8);
+	if (ret)
+		return ret;
+
+	ret = gpio_remove(dev->gpio_par_ser);
+	if (ret)
+		return ret;
+
+	free(dev);
+
+	return ret;
+}
+
+/**
+ * @brief Set the device powerodown mode.
+ * @param dev - The device structure.
+ * @param mode - The device mode.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int adaq8092_set_pd_mode(struct adaq8092_dev *dev,
+			 enum adaq8092_powerdown_modes mode)
+{
+	int ret;
+
+	ret = adaq8092_update_bits(dev, ADAQ8092_REG_POWERDOWN,
+				   ADAQ8092_POWERDOWN_MODE,
+				   field_prep(ADAQ8092_POWERDOWN_MODE, mode));
+	if (ret)
+		return ret;
+
+	dev->pd_mode = mode;
+
+	return 0;
+}
+
+/**
+ * @brief Get the device powerdown mode.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+enum adaq8092_powerdown_modes adaq8092_get_pd_mode(struct adaq8092_dev *dev)
+{
+	return dev->pd_mode;
+}
+
+/**
+ * @brief Set the clock polarity mode.
+ * @param dev - The device structure.
+ * @param mode - The device mode.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int adaq8092_set_clk_pol_mode(struct adaq8092_dev *dev,
+			      enum adaq8092_clk_invert mode)
+{
+	int ret;
+
+	ret = adaq8092_update_bits(dev, ADAQ8092_REG_TIMING,
+				   ADAQ8092_CLK_INVERT,
+				   field_prep(ADAQ8092_CLK_INVERT, mode));
+	if (ret)
+		return ret;
+
+	dev->clk_pol_mode = mode;
+
+	return 0;
+}
+
+/**
+ * @brief Get the clock polarity mode.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+enum adaq8092_clk_invert adaq8092_get_clk_pol_mode(struct adaq8092_dev *dev)
+{
+	return dev->clk_pol_mode;
+}
+
+/**
+ * @brief Set the clock phase delay mode.
+ * @param dev - The device structure.
+ * @param mode - The device mode.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int adaq8092_set_clk_phase_mode(struct adaq8092_dev *dev,
+				enum adaq8092_clk_phase_delay mode)
+{
+	int ret;
+
+	ret = adaq8092_update_bits(dev, ADAQ8092_REG_TIMING,
+				   ADAQ8092_CLK_PHASE,
+				   field_prep(ADAQ8092_CLK_PHASE, mode));
+	if (ret)
+		return ret;
+
+	dev->clk_phase_mode = mode;
+
+	return 0;
+}
+
+/**
+ * @brief Get the clock phase delay mode.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+enum adaq8092_clk_phase_delay adaq8092_get_clk_phase_mode(
+	struct adaq8092_dev *dev)
+{
+	return dev->clk_phase_mode;
+}
+
+/**
+ * @brief Set the clock duty cycle stabilizer mode.
+ * @param dev - The device structure.
+ * @param mode - The device mode.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int adaq8092_set_clk_dc_mode(struct adaq8092_dev *dev,
+			     enum adaq8092_clk_dutycycle mode)
+{
+	int ret;
+
+	ret = adaq8092_update_bits(dev, ADAQ8092_REG_TIMING,
+				   ADAQ8092_CLK_DUTYCYCLE,
+				   field_prep(ADAQ8092_CLK_DUTYCYCLE, mode));
+	if (ret)
+		return ret;
+
+	dev->clk_dc_mode = mode;
+
+	return 0;
+}
+
+/**
+ * @brief Get the clock duty cycle stabilizer mode.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+enum adaq8092_clk_dutycycle adaq8092_get_clk_dc_mode(struct adaq8092_dev *dev)
+{
+	return dev->clk_dc_mode;
+}
+
+/**
+ * @brief Set the LVDS output current mode.
+ * @param dev - The device structure.
+ * @param mode - The device mode.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int adaq8092_set_lvds_cur_mode(struct adaq8092_dev *dev,
+			       enum adaq8092_lvds_out_current mode)
+{
+	int ret;
+
+	ret = adaq8092_update_bits(dev, ADAQ8092_REG_OUTPUT_MODE,
+				   ADAQ8092_ILVDS,
+				   field_prep(ADAQ8092_ILVDS, mode));
+	if (ret)
+		return ret;
+
+	dev->lvds_cur_mode = mode;
+
+	return 0;
+}
+
+/**
+ * @brief Get the LVDS output current mode.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+enum adaq8092_lvds_out_current adaq8092_get_lvds_cur_mode(
+	struct adaq8092_dev *dev)
+{
+	return dev->lvds_cur_mode;
+}
+
+/**
+ * @brief Set the LVDS internal temination mode.
+ * @param dev - The device structure.
+ * @param mode - The device mode.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int adaq8092_set_lvds_term_mode(struct adaq8092_dev *dev,
+				enum adaq8092_internal_term mode)
+{
+	int ret;
+
+	ret = adaq8092_update_bits(dev, ADAQ8092_REG_OUTPUT_MODE,
+				   ADAQ8092_TERMON,
+				   field_prep(ADAQ8092_TERMON, mode));
+	if (ret)
+		return ret;
+
+	dev->lvds_term_mode = mode;
+
+	return 0;
+}
+
+/**
+ * @brief Get the LVDS internal temination device mode.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+enum adaq8092_internal_term adaq8092_get_lvds_term_mode(
+	struct adaq8092_dev *dev)
+{
+	return dev->lvds_term_mode;
+}
+
+/**
+ * @brief Set digital outputs.
+ * @param dev - The device structure.
+ * @param mode - The device mode.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int adaq8092_set_dout_en(struct adaq8092_dev *dev,
+			 enum adaq8092_dout_enable mode)
+{
+	int ret;
+
+	ret = adaq8092_update_bits(dev, ADAQ8092_REG_OUTPUT_MODE,
+				   ADAQ8092_OUTOFF,
+				   field_prep(ADAQ8092_OUTOFF, mode));
+	if (ret)
+		return ret;
+
+	dev->dout_en = mode;
+
+	return 0;
+}
+
+/**
+ * @brief Get digital outputs.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+enum adaq8092_dout_enable adaq8092_get_dout_en(struct adaq8092_dev *dev)
+{
+	return dev->dout_en;
+}
+
+/**
+ * @brief Set the digital output mode.
+ * @param dev - The device structure.
+ * @param mode - The device mode.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int adaq8092_set_dout_mode(struct adaq8092_dev *dev,
+			   enum adaq8092_dout_modes mode)
+{
+	int ret;
+
+	ret = adaq8092_update_bits(dev, ADAQ8092_REG_OUTPUT_MODE,
+				   ADAQ8092_OUTMODE,
+				   field_prep(ADAQ8092_OUTMODE, mode));
+	if (ret)
+		return ret;
+
+	dev->dout_mode = mode;
+
+	return 0;
+}
+
+/**
+ * @brief Get the digital output mode.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+enum adaq8092_dout_modes adaq8092_get_dout_mode(struct adaq8092_dev *dev)
+{
+	return dev->dout_mode;
+}
+
+/**
+ * @brief Set digital output test pattern mode.
+ * @param dev - The device structure.
+ * @param mode - The device mode.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int adaq8092_set_test_mode(struct adaq8092_dev *dev,
+			   enum adaq8092_out_test_modes mode)
+{
+	int ret;
+
+	ret = adaq8092_update_bits(dev, ADAQ8092_REG_DATA_FORMAT,
+				   ADAQ8092_OUTTEST,
+				   field_prep(ADAQ8092_OUTTEST, mode));
+	if (ret)
+		return ret;
+
+	dev->test_mode = mode;
+
+	return 0;
+}
+
+/**
+ * @brief Get digital output test pattern mode.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+enum adaq8092_out_test_modes adaq8092_get_test_mode(struct adaq8092_dev *dev)
+{
+	return dev->test_mode;
+}
+
+/**
+ * @brief Set the alternate bit polarity mode.
+ * @param dev - The device structure.
+ * @param mode - The device mode.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int adaq8092_set_alt_pol_en(struct adaq8092_dev *dev,
+			    enum adaq8092_alt_bit_pol mode)
+{
+	int ret;
+
+	ret = adaq8092_update_bits(dev, ADAQ8092_REG_DATA_FORMAT,
+				   ADAQ8092_ABP,
+				   field_prep(ADAQ8092_ABP, mode));
+	if (ret)
+		return ret;
+
+	dev->alt_bit_pol_en = mode;
+
+	return 0;
+}
+
+/**
+ * @brief Get the alternate bit polarity mode.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+enum adaq8092_alt_bit_pol adaq8092_get_alt_pol_en(struct adaq8092_dev *dev)
+{
+	return dev->alt_bit_pol_en;
+}
+
+/**
+ * @brief Set the data output randomizer mode.
+ * @param dev - The device structure.
+ * @param mode - The device mode.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int adaq8092_set_data_rand_en(struct adaq8092_dev *dev,
+			      enum adaq8092_data_rand mode)
+{
+	int ret;
+
+	ret = adaq8092_update_bits(dev, ADAQ8092_REG_DATA_FORMAT,
+				   ADAQ8092_RAND,
+				   field_prep(ADAQ8092_RAND, mode));
+	if (ret)
+		return ret;
+
+	dev->data_rand_en = mode;
+
+	return 0;
+}
+
+/**
+ * @brief Get the data output randomizer mode.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+enum adaq8092_data_rand adaq8092_get_data_rand_en(struct adaq8092_dev *dev)
+{
+	return dev->data_rand_en;
+}
+
+/**
+ * @brief Set the Tows Complement mode.
+ * @param dev - The device structure.
+ * @param mode - The device mode.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int adaq8092_set_twos_comp(struct adaq8092_dev *dev,
+			   enum adaq8092_twoscomp mode)
+{
+	int ret;
+
+	ret = adaq8092_update_bits(dev, ADAQ8092_REG_DATA_FORMAT,
+				   ADAQ8092_TWOSCOMP,
+				   field_prep(ADAQ8092_TWOSCOMP, mode));
+	if (ret)
+		return ret;
+
+	dev->twos_comp = mode;
+
+	return 0;
+}
+
+/**
+ * @brief Get the Tows Complement mode.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+enum adaq8092_twoscomp adaq8092_get_twos_comp(struct adaq8092_dev *dev)
+{
+	return dev->twos_comp;
+}

--- a/drivers/adc/adaq8092/adaq8092.h
+++ b/drivers/adc/adaq8092/adaq8092.h
@@ -1,0 +1,336 @@
+/***************************************************************************//**
+ *   @file   adaq8092.h
+ *   @brief  Header file of ADAQ8092 Driver.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __ADAQ8092_H__
+#define __ADAQ8092_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdint.h>
+#include <string.h>
+#include "no-os/util.h"
+#include "no-os/spi.h"
+#include "no-os/gpio.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+/* SPI commands */
+#define ADAQ8092_SPI_READ          	BIT(7)
+#define ADAQ8092_ADDR(x)		((x) & 0xFF)
+
+/* ADAQ8092 Register Map */
+#define ADAQ8092_REG_RESET		0x00
+#define ADAQ8092_REG_POWERDOWN		0x01
+#define ADAQ8092_REG_TIMING		0x02
+#define ADAQ8092_REG_OUTPUT_MODE	0x03
+#define ADAQ8092_REG_DATA_FORMAT	0x04
+
+/* ADAQ8092_REG_RESET Bit Definition */
+#define ADAQ8092_RESET			BIT(7)
+
+/* ADAQ8092_REG_POWERDOWN Bit Definition */
+#define ADAQ8092_POWERDOWN_MODE		GENMASK(1, 0)
+
+/* ADAQ8092_REG_TIMING Bit Definition */
+#define ADAQ8092_CLK_INVERT		BIT(3)
+#define ADAQ8092_CLK_PHASE		GENMASK(2, 1)
+#define ADAQ8092_CLK_DUTYCYCLE		BIT(0)
+
+/* ADAQ8092_REG_OUTPUT_MODE Bit Definition */
+#define ADAQ8092_ILVDS			GENMASK(6, 4)
+#define ADAQ8092_TERMON			BIT(3)
+#define ADAQ8092_OUTOFF			BIT(2)
+#define ADAQ8092_OUTMODE		GENMASK(1, 0)
+
+/* ADAQ8092_REG_DATA_FORMAT Bit Definition */
+#define ADAQ8092_OUTTEST		GENMASK(5, 3)
+#define ADAQ8092_ABP			BIT(2)
+#define ADAQ8092_RAND			BIT(1)
+#define ADAQ8092_TWOSCOMP		BIT(0)
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+/* ADAQ8092 Power Down Modes */
+enum adaq8092_powerdown_modes {
+	ADAQ8092_NORMAL_OP,
+	ADAQ8092_CH1_NORMAL_CH2_NAP,
+	ADAQ8092_CH1_CH2_NAP,
+	ADAQ8092_SLEEP
+};
+
+/* ADAQ8092 Output Clock Invert */
+enum adaq8092_clk_invert {
+	ADAQ8092_CLK_POL_NORMAL,
+	ADAQ8092_CLK_POL_INVERTED
+};
+
+/* ADAQ8092 Output Clock Phase Delay Bits */
+enum adaq8092_clk_phase_delay {
+	ADAQ8092_NO_DELAY,
+	ADAQ8092_CLKOUT_DELAY_45DEG,
+	ADAQ8092_CLKOUT_DELAY_90DEG,
+	ADAQ8092_CLKOUT_DELAY_180DEG
+};
+
+/*ADAQ8092 Clock Duty Cycle Stabilizer */
+enum adaq8092_clk_dutycycle {
+	ADAQ8092_CLK_DC_STABILIZER_OFF,
+	ADAQ8092_CLK_DC_STABILIZER_ON,
+};
+
+/* ADAQ8092 LVDS Output Current */
+enum adaq8092_lvds_out_current {
+	ADAQ8092_3M5A = 0,
+	ADAQ8092_4MA = 1,
+	ADAQ8092_4M5A = 2,
+	ADAQ8092_3MA = 4,
+	ADAQ8092_2M5A = 5,
+	ADAQ8092_2M1A = 6,
+	ADAQ8092_1M75 = 7
+};
+
+/* ADAQ8092 LVDS Internal Termination */
+enum adaq8092_internal_term {
+	ADAQ8092_TERM_OFF,
+	ADAQ8092_TERM_ON
+};
+
+/* ADAQ8092 Digital Output */
+enum adaq8092_dout_enable {
+	ADAQ8092_DOUT_ON,
+	ADAQ8092_DOUT_OFF
+};
+
+/* ADAQ8092 Digital Output Mode */
+enum adaq8092_dout_modes {
+	ADAQ8092_FULL_RATE_CMOS,
+	ADAQ8092_DOUBLE_RATE_LVDS,
+	ADAQ8092_DOUBLE_RATE_CMOS
+};
+
+/* ADAQ8092 Digital Test Pattern */
+enum adaq8092_out_test_modes {
+	ADAQ8092_TEST_OFF = 0,
+	ADAQ8092_TEST_ONES = 1,
+	ADAQ8092_TEST_ZEROS = 3,
+	ADAQ8092_TEST_CHECKERBOARD = 5,
+	ADAQ8092_TEST_ALTERNATING = 7
+};
+
+/* ADAQ8092 Alternate Bit Polarity Mode */
+enum adaq8092_alt_bit_pol {
+	ADAQ8092_ALT_BIT_POL_OFF,
+	ADAQ8092_ALT_BIT_POL_ON
+};
+
+/* ADAQ8092 Data Output Randomizer*/
+enum adaq8092_data_rand {
+	ADAQ8092_DATA_RAND_OFF,
+	ADAQ8092_DATA_RAND_ON
+};
+
+/* ADAQ8092 Twos Complement Mode */
+enum adaq8092_twoscomp {
+	ADAQ8092_OFFSET_BINARY,
+	ADAQ8092_TWOS_COMPLEMENT
+};
+
+/**
+ * @struct adaq8092_init
+ * @brief ADAQ8092 Device structure.
+ */
+struct adaq8092_init_param {
+	/** Device communication descriptor */
+	struct spi_init_param 		*spi_init;
+	struct gpio_init_param		*gpio_adc_pd1_param;
+	struct gpio_init_param		*gpio_adc_pd2_param;
+	struct gpio_init_param		*gpio_en_1p8_param;
+	struct gpio_init_param		*gpio_par_ser_param;
+	enum adaq8092_powerdown_modes	pd_mode;
+	enum adaq8092_clk_invert	clk_pol_mode;
+	enum adaq8092_clk_phase_delay	clk_phase_mode;
+	enum adaq8092_clk_dutycycle	clk_dc_mode;
+	enum adaq8092_lvds_out_current	lvds_cur_mode;
+	enum adaq8092_internal_term	lvds_term_mode;
+	enum adaq8092_dout_enable	dout_en;
+	enum adaq8092_dout_modes	dout_mode;
+	enum adaq8092_out_test_modes	test_mode;
+	enum adaq8092_alt_bit_pol	alt_bit_pol_en;
+	enum adaq8092_data_rand		data_rand_en;
+	enum adaq8092_twoscomp		twos_comp;
+};
+
+/**
+ * @struct adaq8092_dev
+ * @brief ADAQ8092 Device structure.
+ */
+struct adaq8092_dev {
+	/** Device communication descriptor */
+	struct spi_desc			*spi_desc;
+	struct gpio_desc		*gpio_adc_pd1;
+	struct gpio_desc		*gpio_adc_pd2;
+	struct gpio_desc		*gpio_en_1p8;
+	struct gpio_desc		*gpio_par_ser;
+	enum adaq8092_powerdown_modes	pd_mode;
+	enum adaq8092_clk_invert	clk_pol_mode;
+	enum adaq8092_clk_phase_delay	clk_phase_mode;
+	enum adaq8092_clk_dutycycle	clk_dc_mode;
+	enum adaq8092_lvds_out_current	lvds_cur_mode;
+	enum adaq8092_internal_term	lvds_term_mode;
+	enum adaq8092_dout_enable	dout_en;
+	enum adaq8092_dout_modes	dout_mode;
+	enum adaq8092_out_test_modes	test_mode;
+	enum adaq8092_alt_bit_pol	alt_bit_pol_en;
+	enum adaq8092_data_rand		data_rand_en;
+	enum adaq8092_twoscomp		twos_comp;
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+/* Read device register. */
+int adaq8092_read(struct adaq8092_dev *dev, uint8_t reg_addr,
+		  uint8_t *reg_data);
+
+/* Write device register. */
+int adaq8092_write(struct adaq8092_dev *dev, uint8_t reg_addr,
+		   uint8_t reg_data);
+
+/* Update specific register bits. */
+int adaq8092_update_bits(struct adaq8092_dev *dev, uint8_t reg_addr,
+			 uint8_t mask, uint8_t reg_data);
+
+/* Initialize the device. */
+int adaq8092_init(struct adaq8092_dev **device,
+		  struct adaq8092_init_param init_param);
+
+/* Remove the device and release resources. */
+int adaq8092_remove(struct adaq8092_dev *dev);
+
+/* Set the device powerodown mode. */
+int adaq8092_set_pd_mode(struct adaq8092_dev *dev,
+			 enum adaq8092_powerdown_modes mode);
+
+/* Get the device powerdown mode. */
+enum adaq8092_powerdown_modes adaq8092_get_pd_mode(struct adaq8092_dev *dev);
+
+/* Set the clock polarity mode. */
+int adaq8092_set_clk_pol_mode(struct adaq8092_dev *dev,
+			      enum adaq8092_clk_invert mode);
+
+/* Get the clock polarity mode. */
+enum adaq8092_clk_invert adaq8092_get_clk_pol_mode(struct adaq8092_dev *dev);
+
+/* Set the clock phase delay mode. */
+int adaq8092_set_clk_phase_mode(struct adaq8092_dev *dev,
+				enum adaq8092_clk_phase_delay mode);
+
+/* Get the clock phase delay mode. */
+enum adaq8092_clk_phase_delay adaq8092_get_clk_phase_mode(
+	struct adaq8092_dev *dev);
+
+/* Set the clock duty cycle stabilizer mode. */
+int adaq8092_set_clk_dc_mode(struct adaq8092_dev *dev,
+			     enum adaq8092_clk_dutycycle mode);
+
+/* Get the clock duty cycle stabilizer mode. */
+enum adaq8092_clk_dutycycle adaq8092_get_clk_dc_mode(struct adaq8092_dev *dev);
+
+/* Set the LVDS output current mode. */
+int adaq8092_set_lvds_cur_mode(struct adaq8092_dev *dev,
+			       enum adaq8092_lvds_out_current mode);
+
+/* Get the LVDS output current mode. */
+enum adaq8092_lvds_out_current adaq8092_get_lvds_cur_mode(
+	struct adaq8092_dev *dev);
+
+/* Set the LVDS internal temination mode. */
+int adaq8092_set_lvds_term_mode(struct adaq8092_dev *dev,
+				enum adaq8092_internal_term mode);
+
+/* Get the LVDS internal temination device mode. */
+enum adaq8092_internal_term adaq8092_get_lvds_term_mode(
+	struct adaq8092_dev *dev);
+
+/* Set digital outputs. */
+int adaq8092_set_dout_en(struct adaq8092_dev *dev,
+			 enum adaq8092_dout_enable mode);
+
+/* Get digital outputs. */
+enum adaq8092_dout_enable adaq8092_get_dout_en(struct adaq8092_dev *dev);
+
+/* Set the digital output mode. */
+int adaq8092_set_dout_mode(struct adaq8092_dev *dev,
+			   enum adaq8092_dout_modes mode);
+
+/* Get the digital output mode. */
+enum adaq8092_dout_modes adaq8092_get_dout_mode(struct adaq8092_dev *dev);
+
+/* Set digital output test pattern mode. */
+int adaq8092_set_test_mode(struct adaq8092_dev *dev,
+			   enum adaq8092_out_test_modes mode);
+
+/* Get digital output test pattern mode. */
+enum adaq8092_out_test_modes adaq8092_get_test_mode(struct adaq8092_dev *dev);
+
+/* Set the alternate bit polarity mode. */
+int adaq8092_set_alt_pol_en(struct adaq8092_dev *dev,
+			    enum adaq8092_alt_bit_pol mode);
+
+/* Get the alternate bit polarity mode. */
+enum adaq8092_alt_bit_pol adaq8092_get_alt_pol_en(struct adaq8092_dev *dev);
+
+/* Set the data output randomizer mode. */
+int adaq8092_set_data_rand_en(struct adaq8092_dev *dev,
+			      enum adaq8092_data_rand mode);
+
+/* Get the data output randomizer mode. */
+enum adaq8092_data_rand adaq8092_get_data_rand_en(struct adaq8092_dev *dev);
+
+/* Set the Tows Complement mode. */
+int adaq8092_set_twos_comp(struct adaq8092_dev *dev,
+			   enum adaq8092_twoscomp mode);
+
+/* Get the Tows Complement mode. */
+enum adaq8092_twoscomp adaq8092_get_twos_comp(struct adaq8092_dev *dev);
+
+#endif /* __ADAQ8092_H__ */

--- a/projects/adaq8092_fmc/Makefile
+++ b/projects/adaq8092_fmc/Makefile
@@ -1,0 +1,5 @@
+include ../../tools/scripts/generic_variables.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/adaq8092_fmc/builds.json
+++ b/projects/adaq8092_fmc/builds.json
@@ -1,0 +1,12 @@
+{
+	"xilinx": {
+	  "demo": {
+		"flags" : "",
+		"hardware" : ["adaq8092_fmc_zed"]
+	  },
+	  "iio": {
+		"flags" : "TINYIIOD=y",
+		"hardware" : ["adaq8092_fmc_zed"]
+	  }
+	}
+}

--- a/projects/adaq8092_fmc/src.mk
+++ b/projects/adaq8092_fmc/src.mk
@@ -1,0 +1,57 @@
+################################################################################
+#									       #
+#     Shared variables:							       #
+#	- PROJECT							       #
+#	- DRIVERS							       #
+#	- INCLUDE							       #
+#	- PLATFORM_DRIVERS						       #
+#	- NO-OS								       #
+#									       #
+################################################################################
+
+SRCS := $(PROJECT)/src/adaq8092_fmc.c
+ifeq (y,$(strip $(TINYIIOD)))
+LIBRARIES += iio
+SRC_DIRS += $(NO-OS)/iio/iio_app
+endif
+SRCS += $(DRIVERS)/adc/adaq8092/adaq8092.c \
+	$(DRIVERS)/api/spi.c \
+	$(DRIVERS)/api/gpio.c \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+	$(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
+	$(NO-OS)/util/util.c
+ifeq (y,$(strip $(TINYIIOD)))
+SRCS += $(NO-OS)/util/fifo.c \
+	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \
+	$(DRIVERS)/api/irq.c \
+	$(NO-OS)/util/list.c \
+	$(PLATFORM_DRIVERS)/uart.c \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c
+endif
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_spi.c \
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
+	$(PLATFORM_DRIVERS)/delay.c
+INCS += $(PROJECT)/src/parameters.h \
+	$(PROJECT)/src/app_config.h \
+	$(DRIVERS)/adc/adaq8092/adaq8092.h \
+	$(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h
+INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
+	$(PLATFORM_DRIVERS)/gpio_extra.h
+INCS +=	$(INCLUDE)/no-os/axi_io.h \
+	$(INCLUDE)/no-os/spi.h \
+	$(INCLUDE)/no-os/gpio.h \
+	$(INCLUDE)/no-os/error.h \
+	$(INCLUDE)/no-os/delay.h \
+	$(INCLUDE)/no-os/print_log.h \
+	$(INCLUDE)/no-os/util.h
+ifeq (y,$(strip $(TINYIIOD)))
+INCS +=	$(INCLUDE)/no-os/fifo.h \
+	$(INCLUDE)/no-os/irq.h \
+	$(INCLUDE)/no-os/uart.h \
+	$(INCLUDE)/no-os/list.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h
+endif

--- a/projects/adaq8092_fmc/src/adaq8092_fmc.c
+++ b/projects/adaq8092_fmc/src/adaq8092_fmc.c
@@ -1,0 +1,226 @@
+/***************************************************************************//**
+ *   @file   adaq8092_fmc.c
+ *   @brief  ADAQ8092_FMC Application
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "xil_cache.h"
+#include "xparameters.h"
+#include "axi_adc_core.h"
+#include "axi_dmac.h"
+#include "adaq8092.h"
+#include "no-os/spi.h"
+#include "no-os/gpio.h"
+#include "spi_extra.h"
+#include "parameters.h"
+#include "no-os/error.h"
+#include "gpio_extra.h"
+
+#include "no-os/print_log.h"
+
+#ifdef IIO_SUPPORT
+#include "iio_app.h"
+#include "iio_axi_adc.h"
+#endif
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+#define ADAQ8092_SAMPLES_PER_CH	1000
+#define ADAQ8092_NUM_CH		2
+
+/***************************************************************************//**
+* @brief main
+*******************************************************************************/
+int main(void)
+{
+	int ret;
+	uint16_t adc_buffer[ADAQ8092_SAMPLES_PER_CH * ADAQ8092_NUM_CH]
+	__attribute__ ((aligned));
+
+	struct xil_spi_init_param xil_spi_init = {
+		.flags = 0,
+		.type = SPI_PS
+	};
+
+	/* SPI */
+	struct spi_init_param adaq8092_spi_param = {
+		.device_id = SPI_DEVICE_ID,
+		.max_speed_hz =  1000000u,
+		.chip_select = 0,
+		.mode = NO_OS_SPI_MODE_0,
+		.platform_ops = &xil_spi_ops,
+		.extra = &xil_spi_init
+	};
+
+	/* GPIO */
+	struct xil_gpio_init_param xil_gpio_init = {
+		.device_id = GPIO_DEVICE_ID,
+		.type = GPIO_PS
+	};
+
+	struct gpio_init_param gpio_par_ser_init_param = {
+		.number = GPIO_PAR_SER_NR,
+		.platform_ops = &xil_gpio_ops,
+		.extra = &xil_gpio_init
+	};
+
+	struct gpio_init_param gpio_adc_pd1_param = {
+		.number = GPIO_PD1_NR,
+		.platform_ops = &xil_gpio_ops,
+		.extra = &xil_gpio_init
+	};
+
+	struct gpio_init_param gpio_adc_pd2_param = {
+		.number = GPIO_PD2_NR,
+		.platform_ops = &xil_gpio_ops,
+		.extra = &xil_gpio_init
+	};
+
+	struct gpio_init_param gpio_en_1v8_param = {
+		.number = GPIO_1V8_NR,
+		.platform_ops = &xil_gpio_ops,
+		.extra = &xil_gpio_init
+	};
+
+	/* ADC Core */
+	struct axi_adc_init adaq8092_core_param = {
+		.name = "adaq8092_core",
+		.num_channels = 2,
+		.base = RX_CORE_BASEADDR
+	};
+	struct axi_adc *adaq8092_core;
+
+	/* AXI DMAC */
+	struct axi_dmac_init adaq8092_dmac_param = {
+		.name = "adaq8092_dmac",
+		.base = RX_DMA_BASEADDR,
+		.direction = DMA_DEV_TO_MEM,
+		.flags = 0
+	};
+	struct axi_dmac *adaq8092_dmac;
+
+	struct adaq8092_init_param adaq8092_init_param = {
+		.spi_init = &adaq8092_spi_param,
+		.gpio_adc_pd1_param = &gpio_adc_pd1_param,
+		.gpio_adc_pd2_param = &gpio_adc_pd2_param,
+		.gpio_en_1p8_param = &gpio_en_1v8_param,
+		.gpio_par_ser_param = &gpio_par_ser_init_param,
+		.pd_mode = ADAQ8092_NORMAL_OP,
+		.clk_pol_mode = ADAQ8092_CLK_POL_INVERTED,
+		.clk_phase_mode = ADAQ8092_NO_DELAY,
+		.clk_dc_mode = ADAQ8092_CLK_DC_STABILIZER_OFF,
+		.lvds_cur_mode = ADAQ8092_3M5A,
+		.lvds_term_mode = ADAQ8092_TERM_OFF,
+		.dout_en = ADAQ8092_DOUT_ON,
+		.dout_mode = ADAQ8092_DOUBLE_RATE_LVDS,
+		.test_mode = ADAQ8092_TEST_CHECKERBOARD,
+		.alt_bit_pol_en = ADAQ8092_ALT_BIT_POL_OFF,
+		.data_rand_en = ADAQ8092_DATA_RAND_OFF,
+		.twos_comp = ADAQ8092_TWOS_COMPLEMENT
+	};
+	struct adaq8092_dev *adaq8092_device;
+
+	ret = adaq8092_init(&adaq8092_device, adaq8092_init_param);
+	if (ret) {
+		pr_err("ADAQ8092 device initialization failed!");
+		return ret;
+	}
+
+	ret = axi_adc_init(&adaq8092_core,  &adaq8092_core_param);
+	if (ret) {
+		pr_err("axi_adc_init() error: %s\n", adaq8092_core->name);
+		return ret;
+	}
+
+	ret = axi_dmac_init(&adaq8092_dmac, &adaq8092_dmac_param);
+	if (ret) {
+		pr_err("axi_dmac_init() error: %s\n", adaq8092_dmac->name);
+		return ret;
+	}
+
+	pr_info("Start Caputre with Test pattern - Checkerboard \n");
+
+	ret = axi_dmac_transfer(adaq8092_dmac, (uintptr_t)adc_buffer,
+				sizeof(adc_buffer));
+	if (ret) {
+		pr_err("axi_dmac_transfer() failed!\n");
+		return ret;
+	}
+
+	for (int i = 0; i < ADAQ8092_SAMPLES_PER_CH; i+=2)
+		pr_info("CH1: %d CH2: %d \n",adc_buffer[i], adc_buffer[i+1]);
+
+	ret = adaq8092_set_test_mode(adaq8092_device, ADAQ8092_TEST_OFF);
+	if (ret)
+		return ret;
+
+	pr_info("\n Capture done.\n");
+
+#ifdef IIO_SUPPORT
+	struct iio_axi_adc_desc *iio_axi_adc_desc;
+	struct iio_device *dev_desc;
+	struct iio_axi_adc_init_param iio_axi_adc_init_par;
+	iio_axi_adc_init_par = (struct iio_axi_adc_init_param) {
+		.rx_adc = adaq8092_core,
+		.rx_dmac = adaq8092_dmac,
+		.dcache_invalidate_range = (void (*)(uint32_t,
+						     uint32_t))Xil_DCacheInvalidateRange
+	};
+
+	struct iio_data_buffer read_buff = {
+		.buff = (void *)adc_buffer,
+		.size = 0xFFFFFFFF,
+	};
+
+	ret = iio_axi_adc_init(&iio_axi_adc_desc, &iio_axi_adc_init_par);
+	if (ret < 0)
+		return ret;
+	iio_axi_adc_get_dev_descriptor(iio_axi_adc_desc, &dev_desc);
+
+	struct iio_app_device devices[] = {
+		IIO_APP_DEVICE("adaq8092_dev", iio_axi_adc_desc, dev_desc,
+			       &read_buff, NULL),
+	};
+
+	return iio_app_run(devices, ARRAY_SIZE(devices));
+#endif
+
+	return 0;
+}

--- a/projects/adaq8092_fmc/src/app_config.h
+++ b/projects/adaq8092_fmc/src/app_config.h
@@ -1,0 +1,46 @@
+/***************************************************************************//**
+ *   @file   adaq8092_fmc/src/app_config.h
+ *   @brief  Config file for ADAQ8092 project.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef APP_CONFIG_H_
+#define APP_CONFIG_H_
+
+//#define XILINX_PLATFORM
+//#define IIO_SUPPORT
+
+#endif /* APP_CONFIG_H_ */

--- a/projects/adaq8092_fmc/src/parameters.h
+++ b/projects/adaq8092_fmc/src/parameters.h
@@ -1,0 +1,61 @@
+/***************************************************************************//**
+ *   @file   parameters.h
+ *   @brief  Platform dependent parameters.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef _PARAMETERS_H_
+#define _PARAMETERS_H_
+
+#include <xparameters.h>
+
+#define SPI_DEVICE_ID				XPAR_PS7_SPI_0_DEVICE_ID
+#define RX_CORE_BASEADDR			XPAR_AXI_ADAQ8092_BASEADDR
+#define RX_DMA_BASEADDR				XPAR_AXI_ADAQ8092_DMA_BASEADDR
+#define UART_DEVICE_ID				XPAR_XUARTPS_0_DEVICE_ID
+#define UART_IRQ_ID				XPAR_XUARTPS_1_INTR
+#define UART_BAUDRATE                           115200
+#define INTC_DEVICE_ID				XPAR_SCUGIC_SINGLE_DEVICE_ID
+
+#define GPIO_DEVICE_ID				XPAR_PS7_GPIO_0_DEVICE_ID
+#define GPIO_OFFSET				32 + 54
+
+#define GPIO_PAR_SER_NR				GPIO_OFFSET
+#define GPIO_PD1_NR				GPIO_OFFSET+1
+#define GPIO_PD2_NR			    	GPIO_OFFSET+2
+#define GPIO_1V8_NR			   	GPIO_OFFSET+3
+
+#endif /* _PARAMETERS_H_ */


### PR DESCRIPTION
- Add support for ADAQ8092 14-bit, 105MSPS, Dual-Channel uModule Data Acquisition Solution.

- Add application example for ADAQ8092 FMC with Zedboard carrier.


Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>
