### PR TITLE
iio: iio_app: Remove error.h inclusion for all plaforms

### DIFF
--- a/iio/iio_app/iio_app.c
+++ b/iio/iio_app/iio_app.c
@@ -48,10 +48,10 @@
 #include "parameters.h"
 #include "no-os/uart.h"
 #include "no-os/delay.h"
-#include "no-os/error.h"
 
 #if defined(ADUCM_PLATFORM) || defined(XILINX_PLATFORM)
 #include "no-os/irq.h"
+#include "no-os/error.h"
 #include "irq_extra.h"
 #include "uart_extra.h"
 #endif
@@ -70,6 +70,7 @@
 #ifdef LINUX_PLATFORM
 #include "linux_socket.h"
 #include "tcp_socket.h"
+#include "no-os/error.h"
 #endif
 
 // The default baudrate iio_app will use to print messages to console.


### PR DESCRIPTION
- iio: iio_app: Remove error.h inclusion for all plaforms
- Include error.h only for ADUCM_PLATFORM, XILINX_PLATFORM and LINUX_PLATFORM platforms because for STM32_PLATFORM it generates a compilation error due to redefinition of SUCCESS
