### PR TITLE
Make iio_app accept existing irq_desc

### DIFF
--- a/iio/iio_types.h
+++ b/iio/iio_types.h
@@ -215,6 +215,9 @@ struct iio_device_data {
  * @brief Structure holding channels and attributes of a device.
  */
 struct iio_device {
+	/** Structure for existing initialized irq controllers. Has to be
+	 * set to NULL if there isn't any irq controller initialized. */
+	struct irq_ctrl_desc *irq_desc;
 	/** Device number of channels */
 	uint16_t num_ch;
 	/** List of channels */


### PR DESCRIPTION
Proposed solution for my issue regarding using iio_app with an existing irq_desc.

If there isn't any existing irq_desc, device.dev_descriptor->irq_desc should be set to NULL.