### PR TITLE
stm32 updates

### DIFF
--- a/drivers/platform/stm32/stm32_hal.h
+++ b/drivers/platform/stm32/stm32_hal.h
@@ -2,6 +2,6 @@
 #define _STM32_HAL_H
 
 #include "main.h"
-extern void SystemClock_Config(void);
+int stm32_init(void);
 
 #endif

--- a/drivers/platform/stm32/stm32_uart.h
+++ b/drivers/platform/stm32/stm32_uart.h
@@ -49,12 +49,8 @@
  * @brief Specific initialization parameters for stm32 UART.
  */
 struct stm32_uart_init_param {
-	/** Specifies the Receive or Transmit mode. */
-	uint32_t mode;
-	/** Specifies the hardware flow control mode. */
-	uint32_t hw_flow_ctl;
-	/** Specifies oversampling mode. */
-	uint32_t over_sampling;
+	/** UART instance */
+	UART_HandleTypeDef *huart;
 	/** UART transaction timeout (HAL_IncTick() units) */
 	uint32_t timeout;
 };
@@ -64,8 +60,8 @@ struct stm32_uart_init_param {
  * @brief stm32 platform specific UART descriptor
  */
 struct stm32_uart_desc {
-	/** SPI instance */
-	UART_HandleTypeDef huart;
+	/** UART instance */
+	UART_HandleTypeDef *huart;
 	/** UART transaction timeout (HAL_IncTick() units) */
 	uint32_t timeout;
 };

--- a/iio/iio_app/iio_app.c
+++ b/iio/iio_app/iio_app.c
@@ -231,9 +231,7 @@ static int32_t uart_setup(struct uart_desc **uart_desc,
 	};
 #elif defined(STM32_PLATFORM)
 	static struct stm32_uart_init_param platform_uart_init_par = {
-		.mode = UART_MODE_TX_RX,
-		.hw_flow_ctl = UART_HWCONTROL_NONE,
-		.over_sampling = UART_OVERSAMPLING_16,
+		.huart = IIO_APP_HUART,
 	};
 #endif
 	static struct uart_init_param luart_par = {

--- a/projects/iio_demo/src/app/main.c
+++ b/projects/iio_demo/src/app/main.c
@@ -100,8 +100,7 @@ int32_t platform_init()
 		return FAILURE;
 	adi_initComponents();
 #elif defined(STM32_PLATFORM)
-	HAL_Init();
-	SystemClock_Config();
+	stm32_init();
 #endif
 	return 0;
 }

--- a/projects/iio_demo/src/app/parameters.h
+++ b/projects/iio_demo/src/app/parameters.h
@@ -51,6 +51,10 @@
 #include "irq_extra.h"
 #endif
 
+#ifdef STM32_PLATFORM
+#include "stm32_hal.h"
+#endif
+
 /******************************************************************************/
 /********************** Macros and Constants Definitions **********************/
 /******************************************************************************/
@@ -103,6 +107,8 @@
 #ifdef STM32_PLATFORM
 
 #define UART_DEVICE_ID	5
+extern UART_HandleTypeDef huart5;
+#define IIO_APP_HUART	(&huart5)
 #define UART_BAUDRATE	115200
 
 #endif // STM32_PLATFORM

--- a/tools/scripts/stm32.mk
+++ b/tools/scripts/stm32.mk
@@ -91,7 +91,7 @@ $(PROJECT_TARGET):
 	$(MUTE) $(call set_one_time_rule,$@)
 
 $(PLATFORM)_sdkopen:
-	$(MUTE) $(STM32CUBEIDE)/$(IDE) -nosplash -import $(PROJECT_BUILDROOT) -data $(BUILD_DIR) $(HIDE)
+	$(STM32CUBEIDE)/$(IDE) -nosplash -import $(PROJECT_BUILDROOT) -data $(BUILD_DIR) &
 
 CFLAGS += -std=gnu11 \
 	-g3 \

--- a/tools/scripts/stm32.mk
+++ b/tools/scripts/stm32.mk
@@ -82,7 +82,8 @@ $(PROJECT_TARGET):
 
 $(PROJECT_TARGET)_configure:
 	$(call print,Configuring project)
-	$(MUTE) sed -i 's/ main(/ generated_main(/' $(PROJECT_BUILD)/Src/main.c $(HIDE)
+	$(MUTE) sed -i 's/ main(/ stm32_init(/' $(PROJECT_BUILD)/Src/main.c $(HIDE)
+	$(MUTE) sed -i 's/while (1)/return 0;/' $(PROJECT_BUILD)/Src/main.c $(HIDE)
 	$(MUTE) sed -i 's/HAL_GPIO_EXTI_IRQHandler/HAL_GPIO_EXTI_Callback/' $(ITC) $(HIDE)
 	$(MUTE) $(call copy_file, $(PROJECT_BUILD)/Src/main.c, $(PROJECT_BUILD)/Src/generated_main.c) $(HIDE)
 	$(MUTE) $(call remove_file, $(PROJECT_BUILD)/Src/main.c) $(HIDE)


### PR DESCRIPTION
- open the sdk in background
- patching of the _it.c file (preparation for interrupts)
- stm32_init() common function instead of having the user call SystemClock_Config() and HAL_Init() (& fix broken projects)
- change the way stm32_uart_init_param looks like (& fix broken projects)