### PR TITLE
drivers:dac:ad9144:ad9144.c: Fix broken check of NCO phase offset

### DIFF
--- a/drivers/dac/ad9144/ad9144.c
+++ b/drivers/dac/ad9144/ad9144.c
@@ -374,7 +374,7 @@ int32_t ad9144_set_nco(struct ad9144_dev *dev, int32_t f_carrier_khz,
 	uint64_t ftw;
 	int32_t ret;
 
-	if (phase > abs(180))
+	if (phase < -180 || phase >= 180)
 		return FAILURE;
 	if (f_carrier_khz < 0) {
 		f_carrier_khz *= -1;


### PR DESCRIPTION
Call to abs() has no effect. Data sheet for AD9144 rev. C pg. 70 says
allowed range is: -180 <= phase < 180.

Signed-off-by: Alexander Vickberg <wickbergster@gmail.com>