### PR TITLE
RFC: Linux build fixes

### DIFF
--- a/drivers/axi_core/iio_axi_adc/iio_axi_adc.c
+++ b/drivers/axi_core/iio_axi_adc/iio_axi_adc.c
@@ -80,7 +80,7 @@ static int get_calibphase(void *device, char *buf, uint32_t len,
 		i++;
 	}
 
-	return i + snprintf(&buf[i], len, "%"PRIi32".%.6"PRIi32"", val, labs(val2));
+	return i + snprintf(&buf[i], len, "%"PRIi32".%.6"PRIi32"", val, abs(val2));
 }
 
 /**
@@ -134,7 +134,7 @@ static int get_calibscale(void *device, char *buf, uint32_t len,
 		i++;
 	}
 	ret = i + snprintf(&buf[i], len, "%"PRIi32".%.6"PRIi32"", val,
-			   labs(val2));
+			   abs(val2));
 
 	return ret;
 }

--- a/drivers/axi_core/iio_axi_adc/iio_axi_adc.c
+++ b/drivers/axi_core/iio_axi_adc/iio_axi_adc.c
@@ -358,12 +358,12 @@ int32_t	iio_axi_adc_read_dev(void *dev, void *buff, uint32_t nb_samples)
 	bytes = nb_samples * hweight8(iio_adc->mask) * (STORAGE_BITS / 8);
 
 	iio_adc->dmac->flags = 0;
-	ret = axi_dmac_transfer(iio_adc->dmac, (uint32_t)buff, bytes);
+	ret = axi_dmac_transfer(iio_adc->dmac, (uintptr_t)buff, bytes);
 	if (ret < 0)
 		return ret;
 
 	if (iio_adc->dcache_invalidate_range)
-		iio_adc->dcache_invalidate_range((uint32_t)buff, bytes);
+		iio_adc->dcache_invalidate_range((uintptr_t)buff, bytes);
 
 	return SUCCESS;
 }

--- a/drivers/axi_core/iio_axi_adc/iio_axi_adc.c
+++ b/drivers/axi_core/iio_axi_adc/iio_axi_adc.c
@@ -432,7 +432,7 @@ static int32_t iio_axi_adc_create_device_descriptor(
 		iio_device->channels[i] = default_channel;
 		iio_device->channels[i].name = desc->ch_names[i];
 		iio_device->channels[i].scan_index = i;
-		ret = sprintf(iio_device->channels[i].name, "voltage%"PRIi32"", i);
+		ret = sprintf(desc->ch_names[i], "voltage%"PRIi32"", i);
 		if (ret < 0)
 			goto error;
 	}

--- a/drivers/axi_core/iio_axi_adc/iio_axi_adc.c
+++ b/drivers/axi_core/iio_axi_adc/iio_axi_adc.c
@@ -44,6 +44,7 @@
 /******************************************************************************/
 
 #include <inttypes.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include "no-os/error.h"
 #include "iio.h"

--- a/drivers/axi_core/iio_axi_dac/iio_axi_dac.c
+++ b/drivers/axi_core/iio_axi_dac/iio_axi_dac.c
@@ -595,7 +595,7 @@ static int32_t iio_axi_dac_create_device_descriptor(
 		iio_device->channels[i] = default_voltage_channel;
 		iio_device->channels[i].scan_index = i;
 		iio_device->channels[i].name = desc->ch_names[i];
-		ret = sprintf(iio_device->channels[i].name, "voltage%"PRIi32"", i);
+		ret = sprintf(desc->ch_names[i], "voltage%"PRIi32"", i);
 		if (ret < 0)
 			goto error;
 	}
@@ -611,7 +611,7 @@ static int32_t iio_axi_dac_create_device_descriptor(
 		if (altvoltage_ch % 4 == 0 || altvoltage_ch % 4 == 1)
 			ch = 'I';
 		j = ((altvoltage_ch % 4) % 2) + 1;
-		ret = sprintf(iio_device->channels[i].name, "TX%"PRIi32"_%c_F%"PRIi32"",
+		ret = sprintf(desc->ch_names[i], "TX%"PRIi32"_%c_F%"PRIi32"",
 			      altvoltage_ch / 4 + 1, ch, j);
 		if (ret < 0)
 			goto error;

--- a/drivers/axi_core/iio_axi_dac/iio_axi_dac.c
+++ b/drivers/axi_core/iio_axi_dac/iio_axi_dac.c
@@ -44,6 +44,7 @@
 /******************************************************************************/
 #include <string.h>
 #include <inttypes.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include "no-os/error.h"
 #include "iio.h"

--- a/drivers/axi_core/iio_axi_dac/iio_axi_dac.c
+++ b/drivers/axi_core/iio_axi_dac/iio_axi_dac.c
@@ -82,7 +82,7 @@ static int get_voltage_calibscale(void *device, char *buf, uint32_t len,
 		i++;
 	}
 	ret = i + (int) snprintf(&buf[i], len, "%"PRIi32".%.6"PRIi32"", val,
-				 labs(val2));
+				 abs(val2));
 
 	return ret;
 }
@@ -109,7 +109,8 @@ static int get_voltage_calibphase(void *device, char *buf, uint32_t len,
 	if(val2 < 0 && val >= 0) {
 		i++;
 	}
-	return i + snprintf(&buf[i], len, "%"PRIi32".%.6"PRIi32"", val, labs(val2));
+
+	return i + snprintf(&buf[i], len, "%"PRIi32".%.6"PRIi32"", val, abs(val2));
 }
 
 /**

--- a/drivers/axi_core/iio_axi_dac/iio_axi_dac.c
+++ b/drivers/axi_core/iio_axi_dac/iio_axi_dac.c
@@ -507,11 +507,11 @@ int32_t iio_axi_dac_write_data(void *dev, void *buff, uint32_t nb_samples)
 	bytes = nb_samples * hweight8(iio_dac->mask) * (STORAGE_BITS / 8);
 
 	if(iio_dac->dcache_flush_range)
-		iio_dac->dcache_flush_range((uint32_t)buff, bytes);
+		iio_dac->dcache_flush_range((uintptr_t)buff, bytes);
 
 	iio_dac->dmac->flags = DMA_CYCLIC;
 
-	return axi_dmac_transfer(iio_dac->dmac, (uint32_t)buff, bytes);
+	return axi_dmac_transfer(iio_dac->dmac, (uintptr_t)buff, bytes);
 }
 
 enum ch_type {

--- a/drivers/rf-transceiver/ad9361/ad9361.h
+++ b/drivers/rf-transceiver/ad9361/ad9361.h
@@ -2831,9 +2831,9 @@
  * For more information see here: https://ez.analog.com/docs/DOC-12763
  */
 
-#define MIN_ADC_CLK			25000000UL /* 25 MHz */
+#define MIN_ADC_CLK			25000000U /* 25 MHz */
 //#define MIN_ADC_CLK			(MIN_BBPLL_FREQ / MAX_BBPLL_DIV) /* 11.17MHz */
-#define MAX_ADC_CLK			640000000UL /* 640 MHz */
+#define MAX_ADC_CLK			640000000U /* 640 MHz */
 #define MAX_DAC_CLK			(MAX_ADC_CLK / 2)
 
 /* Associated with outputs of stage */

--- a/drivers/rf-transceiver/ad9361/iio_ad9361.c
+++ b/drivers/rf-transceiver/ad9361/iio_ad9361.c
@@ -42,6 +42,7 @@
 /***************************** Include Files **********************************/
 /******************************************************************************/
 
+#include <sys/types.h>
 #include <inttypes.h>
 #include <string.h>
 #include <errno.h>
@@ -533,7 +534,7 @@ static int get_powerdown(void *device, char *buf, uint32_t len,
 	val = !!(ad9361_phy->cached_synth_pd[channel->ch_num ? 0 : 1] &
 		 RX_LO_POWER_DOWN);
 
-	return snprintf(buf, len, "%llu", val);
+	return snprintf(buf, len, "%"PRIu64, val);
 }
 
 /**
@@ -588,7 +589,7 @@ static int get_frequency(void *device, char *buf, uint32_t len,
 	val = ad9361_from_clk(clk_get_rate(ad9361_phy,
 					   ad9361_phy->ref_clk_scale[channel->ch_num ?
 									   TX_RFPLL : RX_RFPLL]));
-	return snprintf(buf, len, "%llu", (val));
+	return snprintf(buf, len, "%"PRIu64, val);
 }
 
 /**

--- a/drivers/rf-transceiver/ad9361/iio_ad9361.c
+++ b/drivers/rf-transceiver/ad9361/iio_ad9361.c
@@ -145,7 +145,7 @@ static int get_hardwaregain(void *device, char *buf, uint32_t len,
 		}
 		ret = i + (int) snprintf(&buf[i], len,
 					 "%"PRIi32".%.6"PRIi32" dB", val1,
-					 labs(val2));
+					 abs(val2));
 
 		return ret;
 	} else {

--- a/drivers/rf-transceiver/ad9361/iio_ad9361.c
+++ b/drivers/rf-transceiver/ad9361/iio_ad9361.c
@@ -1360,7 +1360,7 @@ static int get_rx_path_rates(void *device, char *buf, uint32_t len,
 			     const struct iio_ch_info *channel, intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
-	unsigned long clk[6];
+	uint32_t clk[6];
 	int ret = ad9361_get_trx_clock_chain(ad9361_phy, clk, NULL);
 
 	if (ret < 0)
@@ -1557,7 +1557,7 @@ static int get_tx_path_rates(void *device, char *buf, uint32_t len,
 			     const struct iio_ch_info *channel, intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
-	unsigned long clk[6];
+	uint32_t clk[6];
 	int ret = ad9361_get_trx_clock_chain(ad9361_phy, NULL, clk);
 
 	if (ret < 0)

--- a/iio/iio.c
+++ b/iio/iio.c
@@ -76,7 +76,7 @@
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
-static uint8_t uart_buff[IIOD_CONN_BUFFER_SIZE];
+static char uart_buff[IIOD_CONN_BUFFER_SIZE];
 
 static char header[] =
 	"<?xml version=\"1.0\" encoding=\"utf-8\"?>"

--- a/iio/iio.c
+++ b/iio/iio.c
@@ -300,13 +300,14 @@ static struct iio_dev_priv *get_iio_device(struct iio_desc *desc,
 static int iio_read_all_attr(struct attr_fun_params *params,
 			     struct iio_attribute *attributes)
 {
+	/* TODO Not sure if working corectly */
+	return -EINVAL;
+
+#if 0
 	int16_t i = 0, j = 0;
 	char local_buf[256];
 	int attr_length;
 	uint32_t *pattr_length;
-
-	/* TODO Not sure if working corectly */
-	return -EINVAL;
 
 	while (attributes[i].name) {
 		attr_length = attributes[i].show(params->dev_instance,
@@ -337,6 +338,7 @@ static int iio_read_all_attr(struct attr_fun_params *params,
 		return -ENOENT;
 
 	return j;
+#endif
 }
 
 /**
@@ -351,11 +353,12 @@ static int iio_read_all_attr(struct attr_fun_params *params,
 static int iio_write_all_attr(struct attr_fun_params *params,
 			      struct iio_attribute *attributes)
 {
-	int16_t i = 0, j = 0;
-	int16_t attr_length;
-
 	/* TODO Not sure if working corectly */
 	return -EINVAL;
+
+#if 0
+	int16_t i = 0, j = 0;
+	int16_t attr_length;
 
 	while (attributes[i].name) {
 		attr_length = bswap_constant_32((uint32_t)(params->buf + j));
@@ -373,6 +376,7 @@ static int iio_write_all_attr(struct attr_fun_params *params,
 		return -ENOENT;
 
 	return params->len;
+#endif
 }
 
 /**

--- a/iio/iio.c
+++ b/iio/iio.c
@@ -949,8 +949,8 @@ static int iio_read_buffer(struct iiod_ctx *ctx, const char *device, char *buf,
  * @param bytes_count - Number of bytes to write.
  * @return Bytes_count or negative value in case of error.
  */
-static int iio_write_buffer(struct iiod_ctx *ctx, const char *device, char *buf,
-			    uint32_t bytes)
+static int iio_write_buffer(struct iiod_ctx *ctx, const char *device,
+			    const char *buf, uint32_t bytes)
 {
 	struct iio_dev_priv	*dev;
 	int32_t			ret;

--- a/iio/iio.c
+++ b/iio/iio.c
@@ -1278,8 +1278,7 @@ static uint32_t iio_generate_device_xml(struct iio_device *device, char *name,
 static int32_t iio_init_xml(struct iio_desc *desc)
 {
 	struct iio_dev_priv *dev;
-	uint32_t size, of;
-	int32_t i;
+	uint32_t i, size, of;
 
 	/* -2 because of the 0 character */
 	size = sizeof(header) + sizeof(header_end) - 2;
@@ -1311,7 +1310,7 @@ static int32_t iio_init_xml(struct iio_desc *desc)
 }
 
 static int32_t iio_init_devs(struct iio_desc *desc,
-			     struct iio_device_init *devs, int32_t n)
+			     struct iio_device_init *devs, uint32_t n)
 {
 	uint32_t i;
 	int32_t ret;

--- a/iio/iio.h
+++ b/iio/iio.h
@@ -87,7 +87,7 @@ struct iio_init_param {
 #endif
 	};
 	struct iio_device_init *devs;
-	int32_t nb_devs;
+	uint32_t nb_devs;
 };
 
 /******************************************************************************/

--- a/iio/iio_app/iio_app.c
+++ b/iio/iio_app/iio_app.c
@@ -155,7 +155,7 @@ static int32_t print_uart_error_message(struct uart_desc **uart_desc,
 				  (int)status);
 #if defined(LINUX_PLATFORM) || defined(USE_TCP_SOCKET)
 	(void)msglen;
-	printf(message);
+	printf("%s", message);
 	return 0;
 #else
 	return iio_print_uart_info_message(uart_desc, uart_init_par, message,

--- a/iio/iio_app/iio_app.c
+++ b/iio/iio_app/iio_app.c
@@ -279,7 +279,7 @@ static int32_t irq_setup(struct irq_ctrl_desc **irq_desc)
 }
 #endif
 
-int32_t iio_app_run(struct iio_app_device *devices, int32_t len)
+int32_t iio_app_run(struct iio_app_device *devices, uint32_t len)
 {
 	int32_t			status;
 	struct iio_desc		*iio_desc;

--- a/iio/iio_app/iio_app.h
+++ b/iio/iio_app/iio_app.h
@@ -71,6 +71,6 @@ struct iio_app_device {
  * @param len - is the number of devices
  * @return 0 on success, negative value otherwise
  */
-int32_t iio_app_run(struct iio_app_device *devices, int32_t len);
+int32_t iio_app_run(struct iio_app_device *devices, uint32_t len);
 
 #endif

--- a/network/linux_socket/linux_socket.c
+++ b/network/linux_socket/linux_socket.c
@@ -42,6 +42,7 @@
 /******************************************************************************/
 
 #ifdef LINUX_PLATFORM
+#define _GNU_SOURCE
 
 #include "linux_socket.h"
 

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -738,7 +738,7 @@ int main(void)
 	/**
 	 * iio application configurations.
 	 */
-	struct iio_init_param iio_init_par;
+	//struct iio_init_param iio_init_par;
 
 	/**
 	 * iio axi adc configurations.

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -79,6 +79,11 @@
 #include "xil_cache.h"
 #endif //XILINX
 
+#if defined LINUX_PLATFORM || defined GENERIC_PLATFORM
+static uint8_t in_buff[MAX_SIZE_BASE_ADDR];
+static uint8_t out_buff[MAX_SIZE_BASE_ADDR];
+#endif
+
 #endif // IIO_SUPPORT
 
 /******************************************************************************/

--- a/projects/ad9361/src/parameters.h
+++ b/projects/ad9361/src/parameters.h
@@ -157,11 +157,8 @@
 
 #define MAX_SIZE_BASE_ADDR 0x1000
 
-static uint8_t in_buff[MAX_SIZE_BASE_ADDR];
-static uint8_t out_buff[MAX_SIZE_BASE_ADDR];
-
-#define DAC_DDR_BASEADDR	((uint32_t)out_buff)
-#define ADC_DDR_BASEADDR	((uint32_t)in_buff)
+#define DAC_DDR_BASEADDR	((uintptr_t)out_buff)
+#define ADC_DDR_BASEADDR	((uintptr_t)in_buff)
 
 #define GPIO_RESET_PIN	1006
 #endif

--- a/tools/scripts/generic.mk
+++ b/tools/scripts/generic.mk
@@ -198,18 +198,7 @@ endif
 #------------------------------------------------------------------------------
 CFLAGS += $(NEW_CFLAGS)
 CFLAGS += -Wall								\
-	 -Wmissing-field-initializers					\
-	 -Wclobbered 							\
-	 -Wempty-body 							\
-	 -Wignored-qualifiers 						\
-	 -Wmissing-parameter-type					\
-	 -Wno-format  							\
-	 -Wold-style-declaration					\
-	 -Woverride-init 						\
-	 -Wsign-compare							\
-	 -Wtype-limits							\
-	 -Wuninitialized						\
-	 -Wunused-but-set-parameter					\
+	 -Wextra							\
 	 -Wno-unused-parameter						\
 	 -MMD 								\
 	 -MP								\

--- a/tools/scripts/linux.mk
+++ b/tools/scripts/linux.mk
@@ -1,4 +1,4 @@
-CC = gcc
+CC ?= gcc
 
 BINARY		= $(BUILD_DIR)/$(PROJECT_NAME).out
 

--- a/util/circular_buffer.c
+++ b/util/circular_buffer.c
@@ -253,7 +253,7 @@ static int32_t cb_operation(struct circular_buffer *desc,
 			    bool is_read)
 {
 	uint8_t		*buff;
-	uint32_t	available_size;
+	uint32_t	available_size = 0;
 	int32_t		ret;
 	uint32_t	i;
 	bool		sticky_overrun;


### PR DESCRIPTION
Hi,
I made a series of patches which fixes a bunch of warnings and enables cross compiling with the generic Makefile:

`no-OS/projects/ad9361$ TINYIIOD="y" PLATFORM="linux" make`

Only warnings left after this series is a couple of
`warning: #warning "TCP socket communication is not secured"`

Only build path tested is projects/ad9361 for Linux.