### PR TITLE
iio: Changes in __iio_str_parse for fractional part

### DIFF
--- a/iio/iio.c
+++ b/iio/iio.c
@@ -533,6 +533,11 @@ int32_t iio_parse_value(char *buf, enum iio_val fmt, int32_t *val,
 			return ret;
 		_fract *= 100000000;
 		break;
+	case IIO_VAL_FRACTIONAL:
+		ret = __iio_str_parse(buf, &integer, &_fract, false);
+		if (ret < 0)
+			return ret;
+		break;
 	case IIO_VAL_CHAR:
 		if (sscanf(buf, "%c", &ch) != 1)
 			return -EINVAL;

--- a/iio/iio.c
+++ b/iio/iio.c
@@ -499,7 +499,7 @@ static int32_t __iio_str_parse(char *buf, int32_t *integer, int32_t *_fract,
 	if (p == NULL)
 		return -EINVAL;
 
-	*_fract = strtol(p, NULL, 0);
+	*_fract = strtol(p, NULL, 10);
 
 	return 0;
 }


### PR DESCRIPTION
- Changes in __iio_str_parse: Given the fact that the received buffer contains data in decimal format, the fractional part should be obtained  using strtol for decimal base. If left as it is, with base 0, a string which contains the first character '0' will be formatted in octal base.
- Changes in iio_parse_value: Added handling for IIO_VAL_FRACTIONAL.