### PR TITLE
adf4377: adjust output amplitude level values

### DIFF
--- a/drivers/frequency/adf4377/adf4377.h
+++ b/drivers/frequency/adf4377/adf4377.h
@@ -259,8 +259,8 @@
 
 /* ADF4377 REG0019 Bit Definition */
 #define ADF4377_CLKOUT_320MV            0x0
-#define ADF4377_CLKOUT_427MV            0x1
-#define ADF4377_CLKOUT_533MV            0x2
+#define ADF4377_CLKOUT_420MV            0x1
+#define ADF4377_CLKOUT_530MV            0x2
 #define ADF4377_CLKOUT_640MV            0x3
 
 #define ADF4377_PD_CLK_N_OP             0x0

--- a/projects/adf4377_sdz/src/app/adf4377_sdz.c
+++ b/projects/adf4377_sdz/src/app/adf4377_sdz.c
@@ -112,7 +112,7 @@ int main(void)
 		.muxout_select = ADF4377_MUXOUT_HIGH_Z,
 		.ref_doubler_en = ADF4377_REF_DBLR_DIS,
 		.f_clk = 1000000000,
-		.clkout_op = ADF4377_CLKOUT_427MV
+		.clkout_op = ADF4377_CLKOUT_420MV
 	};
 
 	ret = adf4377_init(&dev, &adf4377_param);


### PR DESCRIPTION
Adjust the output amplitude values according to the latest datasheet
version for adf4377.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>