### PR TITLE
iio: Introduce iio_snprintf to harden printing to buffers

### DIFF
--- a/drivers/adc/ad7124/iio_ad7124.c
+++ b/drivers/adc/ad7124/iio_ad7124.c
@@ -196,7 +196,7 @@ static int ad7124_iio_read_offset_chan(void *device, char *buf, uint32_t len,
 	if (ret != SUCCESS)
 		return ret;
 
-	return snprintf(buf, len, "%"PRIX32"", value);
+	return iio_snprintf(buf, len, "%"PRIX32, value);
 }
 
 /**
@@ -269,7 +269,7 @@ static int ad7124_iio_read_raw_chan(void *device, char *buf, uint32_t len,
 	if (ret != SUCCESS)
 		return ret;
 
-	return snprintf(buf, len, "%"PRId32"", (uint32_t)value);
+	return iio_snprintf(buf, len, "%"PRId32, value);
 }
 
 /**
@@ -315,7 +315,7 @@ static int ad7124_iio_read_filter_3db(void *device, char *buf, uint32_t len,
 		return -EINVAL;
 	}
 
-	return snprintf(buf, len, "%"PRId32"", value);
+	return iio_snprintf(buf, len, "%"PRIu32, value);
 }
 
 /**
@@ -395,9 +395,9 @@ static int ad7124_iio_read_odr_chan(void *device, char *buf, uint32_t len,
 	if (ret != SUCCESS)
 		return ret;
 
-	odr = (uint32_t)ad7124_get_odr(desc, config_opt);
+	odr = (uint32_t) ad7124_get_odr(desc, config_opt);
 
-	return snprintf(buf, len, "%"PRId32"", odr);
+	return iio_snprintf(buf, len, "%"PRIu32, odr);
 }
 
 /**
@@ -466,7 +466,7 @@ static int ad7124_iio_read_scale_chan(void *device, char *buf, uint32_t len,
 	else
 		lsb_val = vref_mv / pow(2, (adc_bit_no + pga_bits));
 
-	return snprintf(buf, len, "%f", lsb_val);
+	return iio_snprintf(buf, len, "%f", lsb_val);
 }
 
 /**

--- a/drivers/adc/ad7799/iio_ad7799.c
+++ b/drivers/adc/ad7799/iio_ad7799.c
@@ -63,7 +63,7 @@ static int ad7799_iio_channel_read(void *device, char *buf, uint32_t len,
 	if (ret != SUCCESS)
 		return ret;
 
-	return snprintf(buf, len, "%d", data);
+	return iio_snprintf(buf, len, "%d", data);
 }
 
 /**
@@ -86,7 +86,7 @@ static int ad7799_iio_gain_read(void *device, char *buf, uint32_t len,
 	if (ret != SUCCESS)
 		return ret;
 
-	return snprintf(buf, len, "%d", gain);
+	return iio_snprintf(buf, len, "%d", gain);
 }
 
 /**

--- a/drivers/axi_core/iio_axi_adc/iio_axi_adc.c
+++ b/drivers/axi_core/iio_axi_adc/iio_axi_adc.c
@@ -76,11 +76,19 @@ static int get_calibphase(void *device, char *buf, uint32_t len,
 		return ret;
 
 	if (val2 < 0 && val >= 0) {
-		snprintf(buf, len, "-");
+		ret = iio_snprintf(buf, len, "-");
+		if (ret < 0)
+			return ret;
 		i++;
 	}
 
-	return i + snprintf(&buf[i], len, "%"PRIi32".%.6"PRIi32"", val, abs(val2));
+	ret = iio_snprintf(buf+i, len-i, "%"PRIi32".%.6"PRIi32"", val,
+			   abs(val2));
+
+	if (ret < 0)
+		return ret;
+
+	return i + ret;
 }
 
 /**
@@ -105,7 +113,7 @@ static int get_calibbias(void *device, char *buf, uint32_t len,
 	if (ret < 0)
 		return ret;
 
-	return snprintf(buf, len, "%"PRIi32"", val);
+	return iio_snprintf(buf, len, "%"PRIi32"", val);
 }
 
 /**
@@ -128,15 +136,19 @@ static int get_calibscale(void *device, char *buf, uint32_t len,
 		return ret;
 
 	if (val2 < 0 && val >= 0) {
-		ret = snprintf(buf, len, "-");
+		ret = iio_snprintf(buf, len, "-");
 		if (ret < 0)
 			return ret;
 		i++;
 	}
-	ret = i + snprintf(&buf[i], len, "%"PRIi32".%.6"PRIi32"", val,
+
+	ret = iio_snprintf(buf+i, len-i, "%"PRIi32".%.6"PRIi32"", val,
 			   abs(val2));
 
-	return ret;
+	if (ret < 0)
+		return ret;
+
+	return i + ret;
 }
 
 /**
@@ -181,7 +193,7 @@ static int get_sampling_frequency(void *device, char *buf, uint32_t len,
 	if (ret < 0)
 		return ret;
 
-	return snprintf(buf, len, "%"PRIi64"", sampling_freq_hz);
+	return iio_snprintf(buf, len, "%"PRIi64"", sampling_freq_hz);
 }
 
 /**

--- a/drivers/axi_core/iio_axi_dac/iio_axi_dac.c
+++ b/drivers/axi_core/iio_axi_dac/iio_axi_dac.c
@@ -69,22 +69,27 @@ static int get_voltage_calibscale(void *device, char *buf, uint32_t len,
 				  intptr_t priv)
 {
 	int32_t val, val2;
+	int i = 0;
 	struct iio_axi_dac_desc *iio_dac = (struct iio_axi_dac_desc*)device;
 	int ret = axi_dac_dds_get_calib_scale(iio_dac->dac, channel->ch_num,
 					      &val, &val2);
-	int32_t i = 0;
-	if(ret < 0)
+	if (ret < 0)
 		return ret;
-	if(val2 < 0 && val >= 0) {
-		ret = (int) snprintf(buf, len, "-");
-		if(ret < 0)
+
+	if (val2 < 0 && val >= 0) {
+		ret = iio_snprintf(buf, len, "-");
+		if (ret < 0)
 			return ret;
 		i++;
 	}
-	ret = i + (int) snprintf(&buf[i], len, "%"PRIi32".%.6"PRIi32"", val,
-				 abs(val2));
 
-	return ret;
+	ret = iio_snprintf(buf+i, len-i, "%"PRIi32".%.6"PRIi32"", val,
+			   abs(val2));
+
+	if (ret < 0)
+		return ret;
+
+	return i + ret;
 }
 
 /**
@@ -100,17 +105,25 @@ static int get_voltage_calibphase(void *device, char *buf, uint32_t len,
 				  intptr_t priv)
 {
 	int32_t val, val2;
-	int32_t i = 0;
+	int i = 0;
 	struct iio_axi_dac_desc* iio_dac = (struct iio_axi_dac_desc*)device;
 	int ret = axi_dac_dds_get_calib_phase(iio_dac->dac, channel->ch_num,
 					      &val, &val2);
-	if(ret < 0)
+	if (ret < 0)
 		return ret;
-	if(val2 < 0 && val >= 0) {
+
+	if (val2 < 0 && val >= 0) {
+		ret = iio_snprintf(buf, len, "-");
+		if (ret < 0)
+			return ret;
 		i++;
 	}
 
-	return i + snprintf(&buf[i], len, "%"PRIi32".%.6"PRIi32"", val, abs(val2));
+	ret = iio_snprintf(buf+i, len-i, "%"PRIi32".%.6"PRIi32"", val, abs(val2));
+	if (ret < 0)
+		return ret;
+
+	return i + ret;
 }
 
 /**
@@ -150,7 +163,7 @@ static int get_altvoltage_phase(void *device, char *buf, uint32_t len,
 	if (ret < 0)
 		return ret;
 
-	return snprintf(buf, len, "%"PRIu32"", phase);
+	return iio_snprintf(buf, len, "%"PRIu32"", phase);
 }
 
 /**
@@ -171,8 +184,8 @@ static int get_altvoltage_scale(void *device, char *buf, uint32_t len,
 	if (ret < 0)
 		return ret;
 
-	return snprintf(buf, len, "%"PRIi32".%.6"PRIi32"", (scale / 1000000),
-			(scale % 1000000));
+	return iio_snprintf(buf, len, "%"PRIi32".%.6"PRIi32"",
+			    (scale / 1000000), (scale % 1000000));
 }
 
 /**
@@ -193,7 +206,7 @@ static int get_altvoltage_frequency(void *device, char *buf, uint32_t len,
 	if (ret < 0)
 		return ret;
 
-	return snprintf(buf, len, "%"PRIi32"", freq);
+	return iio_snprintf(buf, len, "%"PRIi32"", freq);
 }
 
 /**

--- a/drivers/dac/ad5791/iio_ad5791.c
+++ b/drivers/dac/ad5791/iio_ad5791.c
@@ -71,7 +71,7 @@ static int ad5791_iio_get_scale(void *device, char *buf, uint32_t len,
 	int_part = vref64 / 1000000000ll;
 	fract_part = vref64 - int_part * 1000000000ll;
 
-	return snprintf(buf, len, "%"PRId32".%.9"PRId32"", int_part, fract_part);
+	return iio_snprintf(buf, len, "%"PRId32".%.9"PRId32"", int_part, fract_part);
 }
 
 /**
@@ -95,7 +95,7 @@ static int ad5791_iio_get_offset(void *device, char *buf, uint32_t len,
 	val64 /= iio_drv->vref_mv;
 	val64 = -val64;
 
-	return snprintf(buf, len, "%"PRIi32"", (int32_t)val64);
+	return iio_snprintf(buf, len, "%"PRIi32"", (int32_t)val64);
 }
 
 /**
@@ -122,7 +122,7 @@ static int ad5791_iio_get_raw(void *device, char *buf, uint32_t len,
 		return ret;
 	value &= 0xFFFFF;
 
-	return snprintf(buf, len, "%"PRIX32"", value);
+	return iio_snprintf(buf, len, "%"PRIX32"", value);
 }
 
 /**
@@ -184,7 +184,7 @@ static int ad5791_iio_get_powerdown(void *device, char *buf, uint32_t len,
 		pwrdwn = false;
 	}
 
-	return snprintf(buf, len, "%"PRId8"", pwrdwn);
+	return iio_snprintf(buf, len, "%"PRId8"", pwrdwn);
 }
 
 /**
@@ -249,8 +249,8 @@ static int ad5791_iio_get_pd_mode(void *device, char *buf, uint32_t len,
 {
 	struct ad5791_iio_desc *iio_drv = (struct ad5791_iio_desc *)device;
 
-	return snprintf(buf, len,
-			"%s", ad5791_iio_pwd_modes[iio_drv->curr_mode]);
+	return iio_snprintf(buf, len,
+			    "%s", ad5791_iio_pwd_modes[iio_drv->curr_mode]);
 }
 
 /**

--- a/drivers/dac/dac_demo/iio_dac_demo.c
+++ b/drivers/dac/dac_demo/iio_dac_demo.c
@@ -65,9 +65,9 @@ int get_dac_demo_attr(void *device, char *buf, uint32_t len,
 
 	switch(attr_id) {
 	case DAC_GLOBAL_ATTR:
-		return snprintf(buf,len,"%"PRIu32"",desc->dac_global_attr);
+		return iio_snprintf(buf, len, "%"PRIu32"", desc->dac_global_attr);
 	case DAC_CHANNEL_ATTR:
-		return snprintf(buf,len,"%"PRIu32"",desc->dac_ch_attr[channel->ch_num]);
+		return iio_snprintf(buf, len, "%"PRIu32"", desc->dac_ch_attr[channel->ch_num]);
 	default:
 		return -EINVAL;
 	}

--- a/drivers/gyro/adxrs290/iio_adxrs290.c
+++ b/drivers/gyro/adxrs290/iio_adxrs290.c
@@ -89,7 +89,7 @@ static int get_adxrs290_iio_ch_raw(void *device, char *buf, uint32_t len,
 	if (channel->ch_num == ADXRS290_CHANNEL_TEMP)
 		data = (data << 4) >> 4;
 
-	return snprintf(buf, len, "%d", data);
+	return iio_snprintf(buf, len, "%d", data);
 }
 
 
@@ -99,10 +99,10 @@ static int get_adxrs290_iio_ch_scale(void *device, char *buf, uint32_t len,
 {
 	if (channel->ch_num == ADXRS290_CHANNEL_TEMP)
 		// Temperature scale 1 LSB = 0.1 degree Celsius
-		return snprintf(buf, len, "100");
+		return iio_snprintf(buf, len, "100");
 
 	// Angular velocity scale 1 LSB = 0.005 degrees/sec = 0.000087266 rad/sec
-	return snprintf(buf, len, "0.000087266");
+	return iio_snprintf(buf, len, "0.000087266");
 }
 
 static int get_adxrs290_iio_ch_hpf(void *device, char *buf, uint32_t len,
@@ -114,9 +114,9 @@ static int get_adxrs290_iio_ch_hpf(void *device, char *buf, uint32_t len,
 	if (index > 0x0A)
 		index = 0x0A;
 
-	return snprintf(buf, len, "%d.%d",
-			adxrs290_hpf_3db_freq_hz_table[index][0],
-			adxrs290_hpf_3db_freq_hz_table[index][1]);
+	return iio_snprintf(buf, len, "%d.%d",
+			    adxrs290_hpf_3db_freq_hz_table[index][0],
+			    adxrs290_hpf_3db_freq_hz_table[index][1]);
 }
 
 static int set_adxrs290_iio_ch_hpf(void *device, char *buf, uint32_t len,
@@ -150,8 +150,8 @@ static int get_adxrs290_iio_ch_lpf(void *device, char *buf, uint32_t len,
 	if (index > 0x07)
 		index = 0x07;
 
-	return snprintf(buf, len, "%d.%d", adxrs290_lpf_3db_freq_hz_table[index][0],
-			adxrs290_lpf_3db_freq_hz_table[index][1]);
+	return iio_snprintf(buf, len, "%d.%d", adxrs290_lpf_3db_freq_hz_table[index][0],
+			    adxrs290_lpf_3db_freq_hz_table[index][1]);
 }
 
 static int set_adxrs290_iio_ch_lpf(void *device, char *buf, uint32_t len,

--- a/drivers/photo-electronic/adpd188/iio_adpd188.c
+++ b/drivers/photo-electronic/adpd188/iio_adpd188.c
@@ -125,7 +125,7 @@ static struct iio_channel adpd188_channels[] = {
  * @param len - Length of the output buffer.
  * @param channel - Structure containing the channel ID data.
  * @param priv - Private pointer not used in this case.
- * @return Length of the response or 0 in case of error.
+ * @return Number of bytes printed in the output buffer, or negative error code.
  */
 static int adpd188_iio_read_offset_chan(void *device, char *buf, uint32_t len,
 					const struct iio_ch_info *channel,
@@ -143,7 +143,7 @@ static int adpd188_iio_read_offset_chan(void *device, char *buf, uint32_t len,
 	if (ret != SUCCESS)
 		return ret;
 
-	return snprintf(buf, len, "%"PRIX16"", reg_val);
+	return iio_snprintf(buf, len, "%"PRIX16"", reg_val);
 }
 
 /**
@@ -191,7 +191,7 @@ static int adpd188_iio_change_offset_chan(void *device, char *buf,
  * @param len - Length of the output buffer.
  * @param channel - Structure containing the channel ID data.
  * @param priv - Private pointer not used in this case.
- * @return Length of the response or 0 in case of error.
+ * @return Number of bytes printed in the output buffer, or negative error code.
  */
 static int adpd188_iio_read_odr_chan(void *device, char *buf, uint32_t len,
 				     const struct iio_ch_info *channel,
@@ -206,7 +206,7 @@ static int adpd188_iio_read_odr_chan(void *device, char *buf, uint32_t len,
 	if (ret != SUCCESS)
 		return ret;
 
-	return snprintf(buf, len, "%"PRId16"", freq_hz);
+	return iio_snprintf(buf, len, "%"PRId16"", freq_hz);
 }
 
 /**
@@ -281,7 +281,7 @@ static int32_t adpd188_iio_standby_mode(struct adpd188_dev *desc)
  * @param len - Length of the output buffer.
  * @param channel - Structure containing the channel ID data.
  * @param priv - Private pointer not used in this case.
- * @return Length of the response or 0 in case of error.
+ * @return Number of bytes printed in the output buffer, or negative error code.
  */
 static int adpd188_iio_read_raw_chan(void *device, char *buf, uint32_t len,
 				     const struct iio_ch_info *channel,
@@ -320,7 +320,7 @@ static int adpd188_iio_read_raw_chan(void *device, char *buf, uint32_t len,
 	req_sample = data[(2 * channel->ch_num)] |
 		     (data[(2 * channel->ch_num + 1)] << 16);
 
-	return snprintf(buf, len, "%"PRIX32"", req_sample);
+	return iio_snprintf(buf, len, "%"PRIX32"", req_sample);
 }
 
 /**

--- a/drivers/photo-electronic/adpd410x/iio_adpd410x.c
+++ b/drivers/photo-electronic/adpd410x/iio_adpd410x.c
@@ -87,7 +87,7 @@ static int adpd410x_iio_read_raw_chan(void *device, char *buf, uint32_t len,
 	if (ret != SUCCESS)
 		return ret;
 
-	return snprintf(buf, len, "%d", data[channel->ch_num]);
+	return iio_snprintf(buf, len, "%d", data[channel->ch_num]);
 }
 
 /**
@@ -169,7 +169,7 @@ static int adpd410x_iio_get_sampling_freq(void *device, char *buf,
 	if (ret != SUCCESS)
 		return ret;
 
-	return snprintf(buf, len, "%d", sampling_freq);
+	return iio_snprintf(buf, len, "%d", sampling_freq);
 }
 
 static char const * const adpd410x_iio_timeslots[] = {
@@ -223,7 +223,7 @@ static int adpd410x_iio_get_last_timeslot(void *device, char *buf,
 	if (ret != SUCCESS)
 		return ret;
 
-	return snprintf(buf, len, "%d", timeslot_no);
+	return iio_snprintf(buf, len, "%d", timeslot_no);
 }
 
 /**
@@ -299,7 +299,7 @@ static int adpd410x_iio_get_opmode(void *device, char *buf, uint32_t len,
 	if (ret != SUCCESS)
 		return ret;
 
-	return snprintf(buf, len, "%d", mode);
+	return iio_snprintf(buf, len, "%d", mode);
 }
 
 /**

--- a/drivers/platform/aducm3029/iio_aducm3029.c
+++ b/drivers/platform/aducm3029/iio_aducm3029.c
@@ -148,10 +148,10 @@ int get_global_attr(void *device, char *buf, uint32_t len,
 	case PINMUX_PORT_1:
 	case PINMUX_PORT_2:
 		val = *pinmux_addrs[priv];
-		return snprintf(buf, len, "%"PRIx32"", val);
+		return iio_snprintf(buf, len, "%"PRIx32"", val);
 	case ADC_ENABLE:
 		val = !!desc->adc;
-		return snprintf(buf, len, "%"PRIu32"", val);
+		return iio_snprintf(buf, len, "%"PRIu32"", val);
 	}
 
 	return -EINVAL;
@@ -223,7 +223,7 @@ int get_pwm_attr(void *device, char *buf, uint32_t len,
 	if (IS_ERR_VALUE(ret))
 		return ret;
 
-	return snprintf(buf, len, "%"PRIu32"", val);
+	return iio_snprintf(buf, len, "%"PRIu32"", val);
 }
 
 /* Set gpio pwm attributes */
@@ -308,7 +308,7 @@ int get_gpio_attr(void *device, char *buf, uint32_t len,
 	if (IS_ERR_VALUE(ret))
 		return ret;
 
-	return snprintf(buf, len, "%"PRIu8"", val);
+	return iio_snprintf(buf, len, "%"PRIu8"", val);
 }
 
 /* Set gpio iio attributes */

--- a/drivers/rf-transceiver/ad9361/ad9361_conv.c
+++ b/drivers/rf-transceiver/ad9361/ad9361_conv.c
@@ -292,6 +292,7 @@ int32_t ad9361_dig_interface_timing_analysis(struct ad9361_rf_phy *phy,
 	int32_t i, j, len = 0;
 	uint8_t field[16][16];
 	uint8_t rx;
+	int ret;
 
 	dev_dbg(&phy->spi->dev, "%s:\n", __func__);
 
@@ -327,22 +328,49 @@ int32_t ad9361_dig_interface_timing_analysis(struct ad9361_rf_phy *phy,
 
 	ad9361_tx_mute(phy, 0);
 
-	len += snprintf(buf + len, buflen, "CLK: %"PRIu32" Hz 'o' = PASS\n",
-			clk_get_rate(phy, phy->ref_clk_scale[RX_SAMPL_CLK]));
-	len += snprintf(buf + len, buflen, "DC");
-	for (i = 0; i < 16; i++)
-		len += snprintf(buf + len, buflen, "%"PRIx32":", i);
-	len += snprintf(buf + len, buflen, "\n");
+	ret = snprintf(buf+len, buflen-len, "CLK: %"PRIu32" Hz 'o' = PASS\n",
+		       clk_get_rate(phy, phy->ref_clk_scale[RX_SAMPL_CLK]));
+	if (ret < 0 || ret >= buflen-len)
+		return -1;
+	len += ret;
+
+	ret = snprintf(buf+len, buflen-len, "DC");
+	if (ret < 0 || ret >= buflen-len)
+		return -1;
+	len += ret;
 
 	for (i = 0; i < 16; i++) {
-		len += snprintf(buf + len, buflen, "%"PRIx32":", i);
-		for (j = 0; j < 16; j++) {
-			len += snprintf(buf + len, buflen, "%c ",
-					(field[i][j] ? '.' : 'o'));
-		}
-		len += snprintf(buf + len, buflen, "\n");
+		ret = snprintf(buf+len, buflen-len, "%"PRIx32":", i);
+		if (ret < 0 || ret >= buflen-len)
+			return -1;
+		len += ret;
 	}
-	len += snprintf(buf + len, buflen, "\n");
+	ret = snprintf(buf+len, buflen-len, "\n");
+	if (ret < 0 || ret >= buflen-len)
+		return -1;
+	len += ret;
+
+	for (i = 0; i < 16; i++) {
+		ret = snprintf(buf+len, buflen-len, "%"PRIx32":", i);
+		if (ret < 0 || ret >= buflen-len)
+			return -1;
+		len += ret;
+		for (j = 0; j < 16; j++) {
+			ret = snprintf(buf+len, buflen-len, "%c ",
+				       (field[i][j] ? '.' : 'o'));
+			if (ret < 0 || ret >= buflen-len)
+				return -1;
+			len += ret;
+		}
+		ret = snprintf(buf+len, buflen-len, "\n");
+		if (ret < 0 || ret >= buflen-len)
+			return -1;
+		len += ret;
+	}
+	ret = snprintf(buf+len, buflen-len, "\n");
+	if (ret < 0 || ret >= buflen-len)
+		return -1;
+	len += ret;
 
 	return len;
 }

--- a/iio/iio.h
+++ b/iio/iio.h
@@ -45,6 +45,8 @@
 /***************************** Include Files **********************************/
 /******************************************************************************/
 
+#include <stdarg.h>
+#include <stddef.h>
 #include "iio_types.h"
 #include "no-os/uart.h"
 #ifdef ENABLE_IIO_NETWORK
@@ -102,6 +104,7 @@ int iio_remove(struct iio_desc *desc);
 /* Execut an iio step. */
 int iio_step(struct iio_desc *desc);
 
+int iio_snprintf(char *str, size_t size, const char *format, ...);
 int32_t iio_parse_value(char *buf, enum iio_val fmt,
 			int32_t *val, int32_t *val2);
 int iio_format_value(char *buf, uint32_t len, enum iio_val fmt,


### PR DESCRIPTION
Hi,

I have introduced iio_snprintf which should detect when buffer is too small and return error.

What do you think about it?

> Quote from 'man snprintf':
> 
> The functions snprintf() and vsnprintf() do not write more than size bytes
> (including the terminating null byte ('\0')). If the output was truncated due
> to this limit then the return value is the number of characters (excluding the
> terminating null byte) which would have been written to the final string if
> enough space had been available. Thus, a return value of size or more means
> that the output was truncated.
> 
> Signed-off-by: Alexander Vickberg <wickbergster@gmail.com>