### PR TITLE
iio: ability to set IIO context attributes from application code

### DIFF
--- a/iio/iio.c
+++ b/iio/iio.c
@@ -1143,7 +1143,22 @@ static uint32_t iio_generate_device_xml(struct iio_device *device, char *name,
 		buff = ch_id;
 
 	i = 0;
-	i += snprintf(buff, no_os_max(n - i, 0),
+
+	/* Write context attributes */
+	if (device->context_attributes)
+		for (j = 0; device->context_attributes[j].name; j++) {
+			i += snprintf(buff + i,
+				      no_os_max(n - i, 0),
+				      "<context-attribute name=\"%s\" ",
+				      device->context_attributes[j].name);
+
+			i += snprintf(buff + i,
+				      no_os_max(n - i, 0),
+				      "value=\"%s\" />",
+				      device->context_attributes[j].value);
+		}
+
+	i += snprintf(buff + i, no_os_max(n - i, 0),
 		      "<device id=\"%s\" name=\"%s\">", id, name);
 
 	/* Write channels */

--- a/iio/iio_types.h
+++ b/iio/iio_types.h
@@ -115,6 +115,17 @@ enum iio_attribute_shared {
 };
 
 /**
+ * @struct iio_context_attribute
+ * @brief Structure holding the context attribute members
+ */
+struct iio_context_attribute {
+	/** Attribute name */
+	const char *name;
+	/** Attribute value */
+	const char *value;
+};
+
+/**
  * @struct iio_attribute
  * @brief Structure holding pointers to show and store functions.
  */
@@ -223,6 +234,8 @@ struct iio_device {
 	uint16_t num_ch;
 	/** List of channels */
 	struct iio_channel *channels;
+	/* Array of attributes. Last one should have its name set to NULL */
+	struct iio_context_attribute *context_attributes;
 	/** Array of attributes. Last one should have its name set to NULL */
 	struct iio_attribute *attributes;
 	/** Array of attributes. Last one should have its name set to NULL */


### PR DESCRIPTION
Implemented the changes in no-os IIO library to allow user to set the context attributes and values
from an application code.

Signed-off-by: mahphalke <Mahesh.Phalke@analog.com>