### PR TITLE
adxrs453: Fix value returned by register read

### DIFF
--- a/drivers/gyro/adxrs453/adxrs453.c
+++ b/drivers/gyro/adxrs453/adxrs453.c
@@ -131,9 +131,9 @@ uint16_t adxrs453_get_register_value(struct adxrs453_dev *dev,
 	data_buffer[7] = data_buffer[3];
 	no_os_spi_write_and_read(dev->spi_desc, data_buffer, 4);
 	no_os_spi_write_and_read(dev->spi_desc, &data_buffer[4], 4);
-	register_value = ((uint16_t)data_buffer[1] << 11) |
-			 ((uint16_t)data_buffer[2] << 3) |
-			 (data_buffer[3] >> 5);
+	register_value = ((uint16_t)data_buffer[5] << 11) |
+			 ((uint16_t)data_buffer[6] << 3) |
+			 (data_buffer[7] >> 5);
 
 	return register_value;
 }


### PR DESCRIPTION
Value returned by register read was actually the result from the previous command.

Issue is repeatable:
 - Attempt to read the part ID register (assuming it wasn't the last register read since power on)
 - Result back will not match.
 - Subsequent read of the part ID register will return the correct result, but its really the value from the previous request.

<img width="773" alt="image" src="https://user-images.githubusercontent.com/1046093/158505931-bd2023f3-eb10-4a53-87e0-8d49ce195323.png">
