### PR TITLE
Staging/delay

### DIFF
--- a/drivers/platform/xilinx/delay.c
+++ b/drivers/platform/xilinx/delay.c
@@ -58,7 +58,7 @@ void no_os_udelay(uint32_t usecs)
 #ifdef _XPARAMETERS_PS_H_
 	usleep(usecs);
 #else
-	usleep(usecs / 20);	// FIXME
+	usleep_MB(usecs);
 #endif
 }
 
@@ -72,6 +72,6 @@ void no_os_mdelay(uint32_t msecs)
 #ifdef _XPARAMETERS_PS_H_
 	usleep(msecs * 1000);
 #else
-	usleep(msecs * 50);	// FIXME
+	usleep_MB(msecs * 1000);
 #endif
 }

--- a/projects/ad3552r_fmcz/srcs/main.c
+++ b/projects/ad3552r_fmcz/srcs/main.c
@@ -196,6 +196,11 @@ int main()
 		}
 	};
 
+	/* Enable the instruction cache. */
+	Xil_ICacheEnable();
+	/* Enable the data cache. */
+	Xil_DCacheEnable();
+
 #ifndef IIO_SUPPORT
 	struct ad3552r_desc *dac;
 
@@ -249,6 +254,11 @@ int main()
 #endif
 
 	pr_debug("Bye\n");
+
+	/* Disable the instruction cache. */
+	Xil_DCacheDisable();
+	/* Disable the data cache. */
+	Xil_ICacheDisable();
 
 	return 0;
 }

--- a/projects/ad4110/src/app/main.c
+++ b/projects/ad4110/src/app/main.c
@@ -52,6 +52,7 @@
 #include "no_os_print_log.h"
 #include <stdint.h>
 #include <inttypes.h>
+#include <xil_cache.h>
 
 static int32_t data_buf[BUF_LENGTH];
 
@@ -76,6 +77,11 @@ int main()
 		.platform_ops = &xil_spi_ops,
 		.extra = &spi_extra
 	};
+
+	/* Enable the instruction cache. */
+	Xil_ICacheEnable();
+	/* Enable the data cache. */
+	Xil_DCacheEnable();
 
 	/* IRQ instance. */
 	struct no_os_irq_ctrl_desc *irq_desc;
@@ -140,6 +146,11 @@ int main()
 
 	for(i=0; i<BUF_LENGTH; i++)
 		printf("DATA[%"PRIi32"] = %"PRIi32" \n", i, data_buf[i]);
+
+	/* Disable the instruction cache. */
+	Xil_DCacheDisable();
+	/* Disable the data cache. */
+	Xil_ICacheDisable();
 
 	return 0;
 }

--- a/projects/ad463x_fmcz/src/ad463x_fmc.c
+++ b/projects/ad463x_fmcz/src/ad463x_fmc.c
@@ -139,6 +139,11 @@ int main()
 		(void (*)(uint32_t, uint32_t))Xil_DCacheInvalidateRange,
 	};
 
+	/* Enable the instruction cache. */
+	Xil_ICacheEnable();
+	/* Enable the data cache. */
+	Xil_DCacheEnable();
+
 	ret = ad463x_init(&dev, &ad463x_init_param);
 	if (ret != 0) {
 		pr_err("AD463x Initialization failed!");
@@ -213,6 +218,11 @@ int main()
 	ad463x_remove(dev);
 
 	pr_info("Done.\n");
+
+	/* Disable the instruction cache. */
+	Xil_DCacheDisable();
+	/* Disable the data cache. */
+	Xil_ICacheDisable();
 
 	return 0;
 }

--- a/projects/ad5758-sdz/src/app/ad5758_sdz.c
+++ b/projects/ad5758-sdz/src/app/ad5758_sdz.c
@@ -106,6 +106,11 @@ int main()
 	int32_t ret;
 	struct ad5758_dev *dev;
 
+	/* Enable the instruction cache. */
+	Xil_ICacheEnable();
+	/* Enable the data cache. */
+	Xil_DCacheEnable();
+
 	ret = ad5758_init(&dev, &ad5758_default_init_param);
 	if(ret)
 		return -1;
@@ -117,5 +122,11 @@ int main()
 		return -1;
 
 	printf("Success\n");
+
+	/* Disable the instruction cache. */
+	Xil_DCacheDisable();
+	/* Disable the data cache. */
+	Xil_ICacheDisable();
+
 	return 0;
 }

--- a/projects/ad6676-ebz/src/ad6676_ebz.c
+++ b/projects/ad6676-ebz/src/ad6676_ebz.c
@@ -355,6 +355,11 @@ int main(void)
 	ad6676_param.n_lanes = 2;
 	ad6676_param.frames_per_multiframe = 16;
 
+	/* Enable the instruction cache. */
+	Xil_ICacheEnable();
+	/* Enable the data cache. */
+	Xil_DCacheEnable();
+
 	// receiver DMA configuration
 	ret = no_os_gpio_get(&gpio_sysref, &gpio_sysref_param);
 	if(ret != 0)
@@ -462,6 +467,11 @@ int main(void)
 #endif
 
 	pr_info("Done.");
+
+	/* Disable the instruction cache. */
+	Xil_DCacheDisable();
+	/* Disable the data cache. */
+	Xil_ICacheDisable();
 
 	return 0;
 }

--- a/projects/ad7124-8pmdz/src/main.c
+++ b/projects/ad7124-8pmdz/src/main.c
@@ -56,6 +56,9 @@
 #include <sys/platform.h>
 #include "adi_initialize.h"
 #include <drivers/pwr/adi_pwr.h>
+#ifdef XILINX_PLATFORM
+#include <xil_cache.h>
+#endif
 
 #define MAX_SIZE_BASE_ADDR		1024
 
@@ -85,6 +88,13 @@ int main(void)
 
 	/* IRQ instance. */
 	struct no_os_irq_ctrl_desc *irq_desc;
+
+#ifdef XILINX_PLATFORM
+	/* Enable the instruction cache. */
+	Xil_ICacheEnable();
+	/* Enable the data cache. */
+	Xil_DCacheEnable();
+#endif //XILINX_PLATFORM
 
 	status = platform_init();
 	if (NO_OS_IS_ERR_VALUE(status))

--- a/projects/ad9081/src/app.c
+++ b/projects/ad9081/src/app.c
@@ -57,12 +57,12 @@
 #include "axi_dmac.h"
 #include "parameters.h"
 #include "app_config.h"
+#include "xil_cache.h"
 
 #ifdef IIO_SUPPORT
 #include "iio_app.h"
 #include "iio_axi_adc.h"
 #include "iio_axi_dac.h"
-#include "xil_cache.h"
 #endif
 
 #ifdef IIO_SUPPORT
@@ -217,6 +217,11 @@ int main(void)
 
 	printf("Hello\n");
 
+	/* Enable the instruction cache. */
+	Xil_ICacheEnable();
+	/* Enable the data cache. */
+	Xil_DCacheEnable();
+
 #ifdef QUAD_MXFE
 	struct xil_gpio_init_param  xil_gpio_param_2 = {
 #ifdef PLATFORM_MB
@@ -346,8 +351,18 @@ int main(void)
 
 	iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
 
+	/* Disable the instruction cache. */
+	Xil_DCacheDisable();
+	/* Disable the data cache. */
+	Xil_ICacheDisable();
+
 #else // IIO_SUPPORT
 	printf("Bye\n");
+
+	/* Disable the instruction cache. */
+	Xil_DCacheDisable();
+	/* Disable the data cache. */
+	Xil_ICacheDisable();
 
 	return 0;
 #endif

--- a/projects/ad9083/src/app.c
+++ b/projects/ad9083/src/app.c
@@ -56,10 +56,11 @@
 #include "iio_ad9083.h"
 #include "iio_axi_adc.h"
 #include "iio_app.h"
+#endif /* IIO_SUPPORT */
+
 #ifdef XILINX_PLATFORM
 #include <xil_cache.h>
 #endif /* XILINX_PLATFORM */
-#endif /* IIO_SUPPORT */
 
 /**
  * @brief Main application.
@@ -108,6 +109,13 @@ int main(void)
 	};
 
 	pr_info("Hello\n");
+
+#ifdef XILINX_PLATFORM
+	/* Enable the instruction cache. */
+	Xil_ICacheEnable();
+	/* Enable the data cache. */
+	Xil_DCacheEnable();
+#endif /* XILINX_PLATFORM */
 
 	status = app_clocking_init(&app_clocking, &app_clocking_init_param);
 	if (status != 0) {
@@ -221,6 +229,13 @@ int main(void)
 	status = app_clocking_remove(app_clocking);
 	if (status != 0)
 		pr_err("error: %"PRIi32" app_clocking_remove()\n", status);
+
+#ifdef XILINX_PLATFORM
+	/* Disable the instruction cache. */
+	Xil_ICacheDisable();
+	/* Disable the data cache. */
+	Xil_DCacheDisable();
+#endif /* XILINX_PLATFORM */
 
 	return status;
 }

--- a/projects/ad9172/src/main.c
+++ b/projects/ad9172/src/main.c
@@ -195,6 +195,13 @@ int main(void)
 	struct axi_dac *tx_dac;
 	int32_t status;
 
+#ifdef XILINX_PLATFORM
+	/* Enable the instruction cache. */
+	Xil_ICacheEnable();
+	/* Enable the data cache. */
+	Xil_DCacheEnable();
+#endif /* XILINX_PLATFORM */
+
 	status = hmc7044_init(&hmc7044_device, &hmc7044_param);
 	if (status != 0) {
 		printf("hmc7044_init() error: %"PRIi32"\n", status);
@@ -344,6 +351,13 @@ error_2:
 	axi_jesd204_tx_remove(tx_jesd);
 error_1:
 	hmc7044_remove(hmc7044_device);
+
+#ifdef XILINX_PLATFORM
+	/* Disable the instruction cache. */
+	Xil_ICacheDisable();
+	/* Disable the data cache. */
+	Xil_DCacheDisable();
+#endif /* XILINX_PLATFORM */
 
 	return 0;
 }

--- a/projects/ad9208/src/main.c
+++ b/projects/ad9208/src/main.c
@@ -60,6 +60,7 @@
 #include "spi_extra.h"
 #include "no_os_gpio.h"
 #include "gpio_extra.h"
+#include <xil_cache.h>
 
 #ifdef IIO_SUPPORT
 #include "iio_app.h"
@@ -425,6 +426,11 @@ int main(void)
 	int32_t status;
 	uint32_t size;
 
+	/* Enable the instruction cache. */
+	Xil_ICacheEnable();
+	/* Enable the data cache. */
+	Xil_DCacheEnable();
+
 	status = hmc7044_init(&hmc7044_device, &hmc7044_param);
 	if (status != 0) {
 		xil_printf("hmc7044_init() error: %"PRIi32"\n", status);
@@ -582,6 +588,11 @@ error_1:
 	hmc7044_remove(hmc7044_device);
 
 	xil_printf("Bye\n");
+
+	/* Disable the instruction cache. */
+	Xil_ICacheDisable();
+	/* Disable the data cache. */
+	Xil_DCacheDisable();
 
 	return 0;
 }

--- a/projects/ad9265-fmc-125ebz/src/ad9265_fmc_125ebz.c
+++ b/projects/ad9265-fmc-125ebz/src/ad9265_fmc_125ebz.c
@@ -102,6 +102,13 @@ int main(void)
 	};
 	struct ad9265_dev *ad9265_device;
 
+#ifdef XILINX_PLATFORM
+	/* Enable the instruction cache. */
+	Xil_ICacheEnable();
+	/* Enable the data cache. */
+	Xil_DCacheEnable();
+#endif /* XILINX_PLATFORM */
+
 	status = axi_adc_init(&ad9265_core,  &ad9265_core_param);
 	if (status != 0) {
 		pr_err("axi_adc_init() error: %s\n", ad9265_core->name);
@@ -171,6 +178,13 @@ int main(void)
 #endif
 
 	pr_info("Done\n");
+
+#ifdef XILINX_PLATFORM
+	/* Disable the instruction cache. */
+	Xil_ICacheDisable();
+	/* Disable the data cache. */
+	Xil_DCacheDisable();
+#endif /* XILINX_PLATFORM */
 
 	return 0;
 }

--- a/projects/ad9371/src/app/headless.c
+++ b/projects/ad9371/src/app/headless.c
@@ -314,6 +314,13 @@ int main(void)
 
 	printf("Please wait...\n");
 
+#ifdef XILINX_PLATFORM
+	/* Enable the instruction cache. */
+	Xil_ICacheEnable();
+	/* Enable the instruction cache. */
+	Xil_DCacheEnable();
+#endif //XILINX_PLATFORM
+
 	ret = platform_init();
 	if (ret != 0) {
 		printf("error: platform_init() failed\n");
@@ -1071,6 +1078,13 @@ int main(void)
 
 	printf("Done\n");
 
+#ifdef XILINX_PLATFORM
+	/* Disable the instruction cache. */
+	Xil_ICacheDisable();
+	/* Disable the data cache. */
+	Xil_DCacheDisable();
+#endif //XILINX_PLATFORM
+
 	return 0;
 
 error_11:
@@ -1110,5 +1124,13 @@ error_2:
 error_1:
 	platform_remove();
 error_0:
+
+#ifdef XILINX_PLATFORM
+	/* Disable the instruction cache. */
+	Xil_ICacheDisable();
+	/* Disable the data cache. */
+	Xil_DCacheDisable();
+#endif //XILINX_PLATFORM
+
 	return -1;
 }

--- a/projects/ad9434-fmc-500ebz/src/ad9434_fmc_500ebz.c
+++ b/projects/ad9434-fmc-500ebz/src/ad9434_fmc_500ebz.c
@@ -104,6 +104,12 @@ int main(void)
 	};
 	struct ad9434_dev *ad9434_device;
 
+	/* Instruction cache should be enabled for usleep functions to work. */
+	/* Enable the instruction cache. */
+	Xil_ICacheEnable();
+	/* Enable the data cache. */
+	Xil_DCacheEnable();
+
 	status = ad9434_setup(&ad9434_device, ad9434_param);
 	if (status != 0) {
 		pr_info("ad9434_setup() failed!\n");
@@ -183,6 +189,11 @@ int main(void)
 #endif
 
 	pr_info("Capture done.\n");
+
+	/* Disable the instruction cache. */
+	Xil_ICacheDisable();
+	/* Disable the data cache. */
+	Xil_DCacheDisable();
 
 	return 0;
 }

--- a/projects/ad9467/src/app/ad9467_fmc.c
+++ b/projects/ad9467/src/app/ad9467_fmc.c
@@ -119,7 +119,7 @@ int main()
 	uint8_t i;
 
 	Xil_DCacheDisable();
-	Xil_ICacheDisable();
+	Xil_ICacheEnable();
 
 	// SPI configuration
 	struct no_os_spi_init_param ad9467_spi_param = {
@@ -302,7 +302,7 @@ int main()
 	ad9517_remove(ad9517_device);
 
 	Xil_DCacheEnable();
-	Xil_ICacheEnable();
+	Xil_ICacheDisable();
 
 	return 0;
 }

--- a/projects/ad9656_fmc/src/app/ad9656_fmc.c
+++ b/projects/ad9656_fmc/src/app/ad9656_fmc.c
@@ -185,6 +185,11 @@ int main(void)
 
 	ad9656_param.lane_rate_kbps = 2500000;
 
+	/* Enable the instruction cache. */
+	Xil_ICacheEnable();
+	/* Enable the data cache. */
+	Xil_DCacheEnable();
+
 	// setup clocks
 	if (ad9508_setup(&ad9508_device, &ad9508_param) != 0)
 		printf("The ad9508 chip could not be setup correctly!\n");
@@ -303,6 +308,11 @@ int main(void)
 	ad9508_remove(ad9508_device);
 	ad9553_remove(ad9553_device);
 	ad9656_remove(ad9656_device);
+
+	/* Disable the instruction cache. */
+	Xil_ICacheDisable();
+	/* Disable the data cache. */
+	Xil_DCacheDisable();
 
 	return(0);
 }

--- a/projects/ad9739a-fmc-ebz/src/ad9739a_fmc_ebz.c
+++ b/projects/ad9739a-fmc-ebz/src/ad9739a_fmc_ebz.c
@@ -147,6 +147,11 @@ int main(void)
 	};
 	struct axi_dac	*ad9739a_core;
 
+	/* Enable the instruction cache. */
+	Xil_ICacheEnable();
+	/* Enable the data cache. */
+	Xil_DCacheEnable();
+
 	status = adf4350_setup(&adf4350_device, default_adf4350_init_param);
 	if (status != 0) {
 		pr_info("adf4350_setup() failed!");
@@ -230,6 +235,11 @@ int main(void)
 	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
 #endif
 	pr_info("Done.\n");
+
+	/* Disable the instruction cache. */
+	Xil_ICacheDisable();
+	/* Disable the data cache. */
+	Xil_DCacheDisable();
 
 	return 0;
 }

--- a/projects/adaq7980_sdz/src/adaq7980_sdz.c
+++ b/projects/adaq7980_sdz/src/adaq7980_sdz.c
@@ -125,7 +125,7 @@ int main()
 	};
 
 	Xil_DCacheDisable();
-	Xil_ICacheDisable();
+	Xil_ICacheEnable();
 
 	ret = adaq7980_setup(&dev, &adaq7980_init_param);
 	if (ret < 0)
@@ -141,6 +141,8 @@ int main()
 	}
 
 	printf("Success\n\r");
+
+	Xil_ICacheDisable();
 
 	return 0;
 }

--- a/projects/adf4377_sdz/src/app/adf4377_sdz.c
+++ b/projects/adf4377_sdz/src/app/adf4377_sdz.c
@@ -41,6 +41,7 @@
 /***************************** Include Files **********************************/
 /******************************************************************************/
 #include <xparameters.h>
+#include <xil_cache.h>
 #include "no_os_spi.h"
 #include "spi_extra.h"
 #include "no_os_gpio.h"
@@ -115,6 +116,11 @@ int main(void)
 		.clkout_op = ADF4377_CLKOUT_420MV
 	};
 
+	/* Enable the instruction cache. */
+	Xil_ICacheEnable();
+	/* Enable the data cache. */
+	Xil_DCacheEnable();
+
 	ret = adf4377_init(&dev, &adf4377_param);
 	if (ret != 0) {
 		pr_err("ADF4377 Initialization failed!\n");
@@ -140,6 +146,11 @@ int main(void)
 	};
 	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
 #endif
+
+	/* Disable the instruction cache. */
+	Xil_ICacheDisable();
+	/* Disable the data cache. */
+	Xil_DCacheDisable();
 
 	return adf4377_remove(dev);
 }

--- a/projects/adf5902_sdz/src/adf5902_sdz.c
+++ b/projects/adf5902_sdz/src/adf5902_sdz.c
@@ -41,6 +41,7 @@
 /***************************** Include Files **********************************/
 /******************************************************************************/
 #include <xparameters.h>
+#include <xil_cache.h>
 #include "no_os_spi.h"
 #include "spi_extra.h"
 #include "no_os_gpio.h"
@@ -191,6 +192,11 @@ int main(void)
 		.ramp_mode = ADF5902_CONTINUOUS_TRIANGULAR
 	};
 
+	/* Enable the instruction cache. */
+	Xil_ICacheEnable();
+	/* Enable the data cache. */
+	Xil_DCacheEnable();
+
 	ret = adf5902_init(&dev, &adf5902_param);
 	if (ret != 0) {
 		pr_err("ADF5902 Initialization failed!\n");
@@ -228,6 +234,11 @@ int main(void)
 	};
 	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
 #endif
+
+	/* Disable the instruction cache. */
+	Xil_ICacheDisable();
+	/* Disable the data cache. */
+	Xil_DCacheDisable();
 
 	ret = adf5902_remove(dev);
 

--- a/projects/adrv9009/src/app/headless.c
+++ b/projects/adrv9009/src/app/headless.c
@@ -247,6 +247,13 @@ int main(void)
 	hal[TALISE_B].spi_adrv_csn = ADRV_B_CS;
 #endif
 
+#ifndef ALTERA_PLATFORM
+	/* Enable the instruction cache. */
+	Xil_ICacheEnable();
+	/* Enable the data cache. */
+	Xil_DCacheEnable();
+#endif
+
 	printf("Hello\n");
 
 	/**********************************************************/
@@ -391,5 +398,13 @@ error_1:
 	clocking_deinit();
 error_0:
 	printf("Bye\n");
+
+#ifndef ALTERA_PLATFORM
+	/* Disable the instruction cache. */
+	Xil_ICacheDisable();
+	/* Disable the data cache. */
+	Xil_DCacheDisable();
+#endif
+
 	return 0;
 }

--- a/projects/display_demo/src/app/main.c
+++ b/projects/display_demo/src/app/main.c
@@ -119,6 +119,11 @@ int main(void)
 		.extra = &ssd1306_extra
 	};
 
+	/* Enable the instruction cache. */
+	Xil_ICacheEnable();
+	/* Enable the data cache. */
+	Xil_DCacheEnable();
+
 	/* Turn VBAT and VDD on, Zedboard platform specific */
 	ret = no_os_gpio_get(&vbat, &vbat_pin);
 	if (ret != 0)
@@ -147,6 +152,11 @@ int main(void)
 	ret = display_clear(dev);
 	if (ret != 0)
 		return -1;
+
+	/* Disable the instruction cache. */
+	Xil_ICacheDisable();
+	/* Disable the data cache. */
+	Xil_DCacheDisable();
 
 	return display_print_string(dev, msg, 0, 0);
 }

--- a/projects/fmcadc2/src/fmcadc2.c
+++ b/projects/fmcadc2/src/fmcadc2.c
@@ -154,6 +154,11 @@ int main(void)
 	ad9625_param.test_samples[2] = 0x777;
 	ad9625_param.test_samples[3] = 0x444;
 
+	/* Enable the instruction cache. */
+	Xil_ICacheEnable();
+	/* Enable the data cache. */
+	Xil_DCacheEnable();
+
 	// setup GPIOs
 	no_os_gpio_get(&gpio_sysref,  &gpio_sysref_param);
 	no_os_gpio_direction_output(gpio_sysref,  1);
@@ -249,6 +254,11 @@ int main(void)
 
 	ad9625_remove(ad9625_device);
 	no_os_gpio_remove(gpio_sysref);
+
+	/* Disable the instruction cache. */
+	Xil_ICacheDisable();
+	/* Disable the data cache. */
+	Xil_DCacheDisable();
 
 	return(0);
 }

--- a/projects/fmcadc5/src/fmcadc5.c
+++ b/projects/fmcadc5/src/fmcadc5.c
@@ -229,6 +229,11 @@ int main(void)
 	ad9625_1_param.test_samples[2] = 0x777;
 	ad9625_1_param.test_samples[3] = 0x444;
 
+	/* Enable the instruction cache. */
+	Xil_ICacheEnable();
+	/* Enable the data cache. */
+	Xil_DCacheEnable();
+
 	// setup GPIOs
 	no_os_gpio_get(&gpio_sysref,  &gpio_sysref_param);
 	no_os_gpio_get(&gpio_rst_0,  &gpio_rst_0_param);
@@ -403,6 +408,11 @@ int main(void)
 	no_os_gpio_remove(gpio_pwdn_0);
 	no_os_gpio_remove(gpio_pwdn_1);
 	no_os_gpio_remove(gpio_pwr_good);
+
+	/* Disable the instruction cache. */
+	Xil_ICacheDisable();
+	/* Disable the data cache. */
+	Xil_DCacheDisable();
 
 	return(0);
 }

--- a/projects/fmcdaq2/src/app/fmcdaq2.c
+++ b/projects/fmcdaq2/src/app/fmcdaq2.c
@@ -619,7 +619,7 @@ static int fmcdaq2_iio_init(struct fmcdaq2_dev *dev,
 
 #ifndef ALTERA_PLATFORM
 	Xil_DCacheDisable();
-	Xil_ICacheDisable();
+	Xil_ICacheEnable();
 #endif
 	dev_init->ad9144_dmac_param = (struct axi_dmac_init ) {
 		.name = "ad9144_dmac",

--- a/projects/fmcdaq3/src/app/fmcdaq3.c
+++ b/projects/fmcdaq3/src/app/fmcdaq3.c
@@ -440,6 +440,13 @@ int main(void)
 	// adc settings
 	ad9680_param.lane_rate_kbps = 12330000;
 
+#ifndef ALTERA_PLATFORM
+	/* Enable the instruction cache. */
+	Xil_ICacheEnable();
+	/* Enable the data cache. */
+	Xil_DCacheEnable();
+#endif
+
 	/* set GPIOs */
 	no_os_gpio_get(&dac_txen,  &dac_txen_param);
 	no_os_gpio_get(&adc_pd,    &adc_pd_param);
@@ -686,6 +693,13 @@ int main(void)
 	ad9680_remove(ad9680_device);
 	no_os_gpio_remove(dac_txen);
 	no_os_gpio_remove(adc_pd);
+
+#ifndef ALTERA_PLATFORM
+	/* Disable the instruction cache. */
+	Xil_ICacheDisable();
+	/* Disable the data cache. */
+	Xil_DCacheDisable();
+#endif
 
 	return(0);
 }

--- a/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
+++ b/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
@@ -352,6 +352,11 @@ int main(void)
 	ad9250_0_param.spi_init = ad9250_0_spi_param;
 	ad9250_1_param.spi_init = ad9250_1_spi_param;
 
+	/* Enable the instruction cache. */
+	Xil_ICacheEnable();
+	/* Enable the data cache. */
+	Xil_DCacheEnable();
+
 	// setup GPIOs
 	no_os_gpio_get(&gpio_sysref,  &gpio_sysref_param);
 	no_os_gpio_direction_output(gpio_sysref,  1);
@@ -581,6 +586,11 @@ int main(void)
 	ad9250_remove(ad9250_0_device);
 	ad9250_remove(ad9250_1_device);
 	no_os_gpio_remove(gpio_sysref);
+
+	/* Disable the instruction cache. */
+	Xil_ICacheDisable();
+	/* Disable the data cache. */
+	Xil_DCacheDisable();
 
 	return 0;
 }

--- a/projects/iio_demo/src/app/main.c
+++ b/projects/iio_demo/src/app/main.c
@@ -51,7 +51,6 @@
 #ifdef XILINX_PLATFORM
 #include <xparameters.h>
 #include <xil_cache.h>
-#include <xil_cache.h>
 #endif // XILINX_PLATFORM
 
 #ifdef ADUCM_PLATFORM
@@ -144,6 +143,14 @@ int main(void)
 		.dev_global_attr = 3333,
 		.dev_ch_attr = {1111,1112,1113,1114,1115,1116,1117,1118,1119,1120,1121,1122,1123,1124,1125,1126}
 	};
+
+#ifdef XILINX_PLATFORM
+	/* Enable the instruction cache. */
+	Xil_ICacheEnable();
+	/* Enable the data cache. */
+	Xil_DCacheEnable();
+#endif //XILINX_PLATFORM
+
 	status = adc_demo_init(&adc_desc, &adc_init_par);
 	if (status != 0)
 		return status;


### PR DESCRIPTION
The activation of instruction cache for Xilinx projects. This is necessary for the correct operation of the usleep() and msleep() functions, that call usleep_MB(). The usleep_MB() function requires the enabling of the instruction cache on Xilinx platforms.