### PR TITLE
drivers:platform:mbed: Analog In/out platform drivers

### DIFF
--- a/drivers/platform/mbed/mbed_ain.cpp
+++ b/drivers/platform/mbed/mbed_ain.cpp
@@ -1,0 +1,168 @@
+/***************************************************************************//**
+ *   @file   mbed_ain.cpp
+ *   @brief  Implementation of Mbed specific analog input functionality
+********************************************************************************
+ * Copyright (c) 2021-22 Analog Devices, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <mbed.h>
+
+// Platform drivers needs to be C-compatible to work with other drivers
+#ifdef __cplusplus
+extern "C"
+{
+#endif //  _cplusplus
+
+#include "no_os_ain.h"
+#include "mbed_ain_aout.h"
+#include "no_os_error.h"
+
+/******************************************************************************/
+/********************** Variables and User defined data types *****************/
+/******************************************************************************/
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+/**
+ * @brief Read voltage from analog input pin.
+ * @param desc[in] - Analog input descriptor.
+ * @param value[in,out] - Analog input value.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int32_t no_os_ain_get_voltage(struct no_os_ain_desc *desc, float *value)
+{
+	/* Pointer to analog input object */
+	mbed::AnalogIn *analog_input;
+
+	if (!desc || !desc->extra || !value)
+		return -EINVAL;
+
+	analog_input = (AnalogIn *)((struct mbed_ain_desc *)
+				    desc->extra)->ain_obj;
+	*value = analog_input->read_voltage();
+
+	return 0;
+}
+
+/**
+ * @brief Initialize the Analog Input Pin.
+ * @param desc[in, out] - Analog input descriptor structure.
+ * @param param[in] - Structure that contains analog input
+ *                    initialization parameters.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int32_t no_os_ain_init(struct no_os_ain_desc **desc,
+		       const struct no_os_ain_init_param *param)
+{
+	mbed::AnalogIn *analog_input;
+	struct no_os_ain_desc *noos_ain_desc;
+	struct mbed_ain_desc *mbed_analog_in_desc;
+
+	if (!desc || !param)
+		return -EINVAL;
+
+	/* Allocate memory for general analog input descriptor */
+	noos_ain_desc = (struct no_os_ain_desc *)calloc(1, sizeof(*noos_ain_desc));
+	if (!noos_ain_desc)
+		return -ENOMEM;
+
+	/* Configure pin number and reference voltage*/
+	noos_ain_desc->vref = param->vref;
+
+	/* Allocate memory for mbed specific analog input descriptor
+	 * for future use */
+	mbed_analog_in_desc = (struct mbed_ain_desc *)calloc(1, sizeof(
+				      *mbed_analog_in_desc));
+	if (!mbed_analog_in_desc)
+		goto err_mbed_ain_desc;
+
+	if (((struct mbed_ain_init_param *)param->extra)->number) {
+		/* Create and initialize mbed analog input object */
+		analog_input = new AnalogIn((PinName)((struct mbed_ain_init_param *)
+						      param->extra)->number, param->vref);
+		if (!analog_input)
+			goto err_ain_obj;
+	} else {
+		goto err_ain_pin;
+	}
+
+	mbed_analog_in_desc->ain_obj = analog_input;
+	noos_ain_desc->extra = mbed_analog_in_desc;
+	*desc = noos_ain_desc;
+	return 0;
+
+
+err_ain_obj:
+	free(analog_input);
+err_ain_pin:
+	free(mbed_analog_in_desc);
+err_mbed_ain_desc:
+	free(noos_ain_desc);
+
+	return -ENOMEM;
+}
+
+/**
+ * @brief Deallocate resources allocated by no_os_ain_init().
+ * @param desc[in, out] - Analog input descriptor.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int32_t no_os_ain_remove(struct no_os_ain_desc *desc)
+{
+	if (!desc || !desc->extra)
+		return -EINVAL;
+
+	if (((struct mbed_ain_desc *)desc->extra)->ain_obj)
+		delete((mbed::AnalogIn *)((struct mbed_ain_desc *)desc->
+					  extra)->ain_obj);
+
+	if ((struct mbed_ain_desc *)desc->extra)
+		free((struct mbed_ain_desc *)desc->extra);
+
+	free(desc);
+
+	return 0;
+}
+#ifdef __cplusplus
+}
+#endif //  _cplusplus

--- a/drivers/platform/mbed/mbed_ain_aout.h
+++ b/drivers/platform/mbed/mbed_ain_aout.h
@@ -1,0 +1,110 @@
+/***************************************************************************//*
+* @file    mbed_ain_aout.h
+* @brief   Header containing extra types required for
+*          analog in/output functionality
+******************************************************************************
+* Copyright (c) 2021-22 Analog Devices, Inc.
+* All rights reserved.
+*
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef MBED_AIN_AOUT_H
+#define MBED_AIN_AOUT_H
+
+// Platform support needs to be C-compatible to work with other drivers
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*****************************************************************************/
+/***************************** Include Files *********************************/
+/*****************************************************************************/
+
+#include "stdio.h"
+#include "stdint.h"
+
+/*****************************************************************************/
+/********************** Macros and Constants Definition **********************/
+/*****************************************************************************/
+
+/******************************************************************************/
+/********************** Variables and User defined data types *****************/
+/******************************************************************************/
+/**
+ * @struct mbed_analog_init_param
+ * @brief Structure holding the Analog input init parameters for mbed platform.
+ */
+struct mbed_ain_init_param {
+	/* Analog input pin number */
+	int32_t	number;
+};
+
+/**
+ * @struct mbed_analog_in_desc
+ * @brief Analog input specific descriptor for the mbed platform.
+ */
+struct mbed_ain_desc {
+	/* Analog input pin number */
+	int32_t	number;
+	/* Analog Input instance (mbed::AnalogIn) */
+	void *ain_obj;
+};
+
+/**
+* @struct mbed_analog_out_desc
+* @brief Structure holding the Analog output init parameters for mbed platform.
+*/
+struct mbed_aout_init_param {
+	/* Analog output pin number */
+	int32_t	number;
+};
+
+/**
+ * @struct mbed_analog_out_desc
+ * @brief Analog output pin specific descriptor for the mbed platform.
+ */
+struct mbed_aout_desc {
+	/* Analog output pin number */
+	int32_t	number;
+	/* Analog Output instance (mbed::AnalogOut) */
+	void *aout_obj;
+};
+
+/******************************************************************************/
+/*****************************Function Declarations****************************/
+/******************************************************************************/
+
+#ifdef __cplusplus // Closing extern c
+}
+#endif
+
+#endif /* MBED_AIN_AOUT_H */

--- a/drivers/platform/mbed/mbed_aout.cpp
+++ b/drivers/platform/mbed/mbed_aout.cpp
@@ -1,0 +1,181 @@
+/***************************************************************************//**
+ *   @file   mbed_aout.cpp
+ *   @brief  Implementation of Mbed specific analog output functionality
+********************************************************************************
+ * Copyright (c) 2021-22 Analog Devices, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <mbed.h>
+
+// Platform drivers needs to be C-compatible to work with other drivers
+#ifdef __cplusplus
+extern "C"
+{
+#endif //  _cplusplus
+
+#include "no_os_aout.h"
+#include "no_os_error.h"
+#include "mbed_ain_aout.h"
+
+/******************************************************************************/
+/********************** Variables and User defined data types *****************/
+/******************************************************************************/
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+/**
+ * @brief Write voltage to analog output pin.
+ * @param desc[in] - Analog output descriptor.
+ * @param value[in] - Analog output value in volts.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int32_t no_os_aout_set_voltage(struct no_os_aout_desc *desc, float value)
+{
+	mbed::AnalogOut *analog_output; // Pointer to analog output object
+	float volt_mapped;	// Analog voltage
+
+	if (!desc || !desc->extra)
+		return -EINVAL;
+
+	/* Mbed AnalogOut APIs accept voltage in range from 0.0f
+	 * (representing DAC min output range / 0%) to 1.0f (representing
+	 * DAC max output range / 100%). Hence we need to map the voltage levels
+	 * before passing it to mbed APIs */
+	if (value >= desc->aout_min_v && value <= desc->aout_max_v) {
+		volt_mapped = ((value - desc->aout_min_v) /
+			       (desc->aout_max_v - desc->aout_min_v));
+	} else {
+		return -EINVAL;
+	}
+
+	analog_output = (AnalogOut *)((struct mbed_aout_desc *)
+				      desc->extra)->aout_obj;
+	analog_output->write(volt_mapped);
+
+	return 0;
+}
+
+/**
+ * @brief Initialize the analog output pin.
+ * @param desc[in, out] - Analog output descriptor structure.
+ * @param param[in] - Structure that contains analog output
+ *                    initialization parameters.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int32_t no_os_mbed_aout_init(struct no_os_aout_desc **desc,
+			     const struct no_os_aout_init_param *param)
+{
+	mbed::AnalogOut *analog_output;
+	struct no_os_aout_desc *noos_aout_desc;
+	struct mbed_aout_desc *mbed_analog_out_desc;
+
+	if (!desc || !param)
+		return -EINVAL;
+
+	/* Allocate memory for general analog output descriptor */
+	noos_aout_desc = (struct no_os_aout_desc *) calloc(1,
+			 sizeof(*noos_aout_desc));
+	if (!noos_aout_desc)
+		return -ENOMEM;
+
+	/* Configure pin number,DAC max and min range */
+	noos_aout_desc->aout_min_v = param->aout_min_v;
+	noos_aout_desc->aout_max_v = param->aout_max_v;
+
+	/* Allocate memory for mbed specific analog output descriptor
+	* for future use */
+	mbed_analog_out_desc = (struct mbed_aout_desc *) calloc(1,
+			       sizeof(*mbed_analog_out_desc));
+	if (!mbed_analog_out_desc)
+		goto err_mbed_analog_out_desc;
+
+	if (((struct mbed_aout_init_param *)param->extra)->number) {
+		/* Create and initialize mbed analog output object */
+		analog_output = new AnalogOut((PinName)((struct mbed_aout_init_param *)
+							param->extra)->number);
+		if (!analog_output)
+			goto err_aout_obj;
+	} else {
+		goto err_analog_pin;
+	}
+
+	mbed_analog_out_desc->aout_obj = analog_output;
+	noos_aout_desc->extra = mbed_analog_out_desc;
+	*desc = noos_aout_desc;
+	return 0;
+
+err_aout_obj:
+	free(analog_output);
+err_analog_pin:
+	free(mbed_analog_out_desc);
+err_mbed_analog_out_desc:
+	free(noos_aout_desc);
+
+	return -ENOMEM;
+}
+
+/**
+ * @brief Deallocate resources allocated by mbed_aout_init().
+ * @param desc[in, out] - Analog output descriptor.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int32_t no_os_aout_remove(struct no_os_aout_desc *desc)
+{
+	if (!desc || !desc->extra)
+		return -EINVAL;
+
+	if (((struct mbed_aout_desc *)desc->extra)->aout_obj)
+		delete((mbed::AnalogOut *)((struct mbed_aout_desc *)
+					   desc->extra)->aout_obj);
+
+	if ((struct mbed_aout_desc *)desc->extra)
+		free((struct mbed_aout_desc *)desc->extra);
+
+	free(desc);
+
+	return 0;
+}
+
+#ifdef __cplusplus
+}
+#endif //  _cplusplus

--- a/include/no_os_ain.h
+++ b/include/no_os_ain.h
@@ -1,0 +1,91 @@
+/***************************************************************************//**
+ *   @file   no_os_ain.h
+ *   @author PMallick (Pratyush.Mallick@analog.com)
+********************************************************************************
+ * Copyright (c) 2021-22 Analog Devices, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef NO_OS_AIN_H
+#define NO_OS_AIN_H
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <stdint.h>
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+
+/**
+ * @struct ain_init_param
+ * @brief Structure holding parameters for analog input initialization
+ */
+struct no_os_ain_init_param {
+	/* Analog input reference voltage */
+	float vref;
+	/* Analog extra parameters (device specific) */
+	void *extra;
+};
+
+/**
+ * @struct ain_desc
+ * @brief Structure holding analog input descriptor
+ */
+struct no_os_ain_desc {
+	/* Analog input reference voltage */
+	float vref;
+	/* Analog extra parameters (device specific) */
+	void *extra;
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+/* Read analog input voltage */
+int32_t no_os_ain_get_voltage(struct no_os_ain_desc *desc, float *value);
+
+/* Initialize the analog input peripheral*/
+int32_t no_os_ain_init(struct no_os_ain_desc **desc,
+		       const struct no_os_ain_init_param *param);
+
+/* Free the resources allocated by no_os_ain_init() */
+int32_t no_os_ain_remove(struct no_os_ain_desc *desc);
+
+#endif	// end of NO_OS_AIN_H

--- a/include/no_os_aout.h
+++ b/include/no_os_aout.h
@@ -1,0 +1,99 @@
+/***************************************************************************//**
+ *   @file   no_os_aout.h
+ *   @author PMallick (Pratyush.Mallick@analog.com)
+********************************************************************************
+ * Copyright (c) 2021-22 Analog Devices, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef NO_OS_AOUT_H
+#define NO_OS_AOUT_H
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <stdint.h>
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+
+/**
+ * @struct aout_init_param
+ * @brief Structure holding the parameters for analog output initialization
+ */
+struct no_os_aout_init_param {
+	/* Min output range of DAC in volts */
+	float aout_min_v;
+	/* Max output range of DAC in volts */
+	float aout_max_v;
+	/* Analog output reference voltage */
+	float vref;
+	/* Analog extra parameters (device specific) */
+	void *extra;
+};
+
+/**
+ * @struct aout_desc
+ * @brief Structure holding analog output descriptor
+ */
+struct no_os_aout_desc {
+	/* Min output value of DAC in volts */
+	float aout_min_v;
+	/* Max output value of DAC in volts */
+	float aout_max_v;
+	/* Analog output reference voltage */
+	float vref;
+	/* Analog extra parameters (device specific) */
+	void *extra;
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+/* Write analog output voltage */
+int32_t no_os_aout_set_voltage(struct no_os_aout_desc *desc, float value);
+
+/* Initialize the analog output peripheral */
+int32_t no_so_aout_init(struct no_os_aout_desc **desc,
+			const struct no_os_aout_init_param *param);
+
+/* Free the resources allocated by no_os_aout_init() */
+int32_t no_os_aout_remove(struct no_os_aout_desc *desc);
+
+#endif	// end of NO_OS_AOUT_H


### PR DESCRIPTION
1. Implemented the Analog Input/Output no-OS header files and added it the include/ directory.
2. Added mbed specific implementation of Analog Input/Output platform drivers.

Signed-off-by: Pratyush Mallick <Pratyush.Mallick@analog.com>