### PR TITLE
ADXL355 fix hpf corner value setting 

### DIFF
--- a/drivers/accel/adxl355/adxl355.c
+++ b/drivers/accel/adxl355/adxl355.c
@@ -380,13 +380,17 @@ int adxl355_set_odr_lpf(struct adxl355_dev *dev,
 
 	current_op_mode = dev->op_mode;
 
-	if ((current_op_mode != ADXL355_STDBY_TEMP_ON_DRDY_ON)
-	    && (current_op_mode != ADXL355_STDBY_TEMP_OFF_DRDY_ON)
-	    && (current_op_mode != ADXL355_STDBY_TEMP_ON_DRDY_OFF)
-	    && (current_op_mode != ADXL355_STDBY_TEMP_OFF_DRDY_OFF)) {
+	switch(current_op_mode) {
+	case ADXL355_MEAS_TEMP_ON_DRDY_ON:
+	case ADXL355_MEAS_TEMP_OFF_DRDY_ON:
+	case ADXL355_MEAS_TEMP_ON_DRDY_OFF:
+	case ADXL355_MEAS_TEMP_OFF_DRDY_OFF:
 		ret = adxl355_set_op_mode(dev, ADXL355_STDBY_TEMP_ON_DRDY_ON);
 		if (ret)
 			return ret;
+		break;
+	default:
+		break;
 	}
 
 	ret = adxl355_read_device_data(dev, ADXL355_ADDR(ADXL355_FILTER),

--- a/drivers/accel/adxl355/adxl355.c
+++ b/drivers/accel/adxl355/adxl355.c
@@ -428,7 +428,7 @@ int adxl355_set_hpf_corner(struct adxl355_dev *dev,
 	if (ret)
 		return ret;
 	reg_value &= ~(ADXL355_HPF_FIELD_MSK);
-	reg_value |= hpf_corner_val & ADXL355_HPF_FIELD_MSK;
+	reg_value |= (hpf_corner_val << 4) & ADXL355_HPF_FIELD_MSK;
 
 	ret = adxl355_write_device_data(dev, ADXL355_ADDR(ADXL355_FILTER),
 					GET_ADXL355_TRANSF_LEN(ADXL355_FILTER), &reg_value);


### PR DESCRIPTION
- The hpf corner value has to be left shifted 4 times because hpf corner value bits are [6:4] in filter settings reg.
- Even though the hpf settings can be changed when the device is in measurement mode, it has been observed that the measurements are not correct when doing so. Because of this, the device will be set in standby mode also when changing the hpf value.
