### PR TITLE
util: add proper support for hweigth8/16/32

### DIFF
--- a/drivers/adc-dac/ad5592r/ad5592r.c
+++ b/drivers/adc-dac/ad5592r/ad5592r.c
@@ -150,7 +150,7 @@ int32_t ad5592r_multi_read_adc(struct ad5592r_dev *dev, uint16_t chans,
 	if (!dev)
 		return -1;
 
-	samples = no_os_hweight8(chans);
+	samples = no_os_hweight16(chans);
 
 	dev->spi_msg = swab16((uint16_t)(AD5592R_REG_ADC_SEQ << 11) | chans);
 

--- a/drivers/adc-dac/ad5592r/ad5593r.c
+++ b/drivers/adc-dac/ad5592r/ad5593r.c
@@ -144,7 +144,7 @@ int32_t ad5593r_multi_read_adc(struct ad5592r_dev *dev, uint16_t chans,
 	if (!dev)
 		return -1;
 
-	samples = no_os_hweight8(chans);
+	samples = no_os_hweight16(chans);
 
 	data[0] = AD5593R_MODE_CONF | AD5592R_REG_ADC_SEQ;
 	data[1] = chans >> 8;

--- a/drivers/adc/ad469x/ad469x.c
+++ b/drivers/adc/ad469x/ad469x.c
@@ -494,7 +494,7 @@ int32_t ad469x_std_sequence_ch(struct ad469x_dev *dev, uint16_t ch_mask)
 	if (ret != 0)
 		return ret;
 
-	dev->num_slots = no_os_hweight8(ch_mask);
+	dev->num_slots = no_os_hweight16(ch_mask);
 
 	return ret;
 }

--- a/drivers/axi_core/iio_axi_adc/iio_axi_adc.c
+++ b/drivers/axi_core/iio_axi_adc/iio_axi_adc.c
@@ -355,7 +355,7 @@ int32_t	iio_axi_adc_read_dev(void *dev, void *buff, uint32_t nb_samples)
 		return -1;
 
 	iio_adc = (struct iio_axi_adc_desc *)dev;
-	bytes = nb_samples * no_os_hweight8(iio_adc->mask) * (STORAGE_BITS / 8);
+	bytes = nb_samples * no_os_hweight32(iio_adc->mask) * (STORAGE_BITS / 8);
 
 	iio_adc->dmac->flags = 0;
 	ret = axi_dmac_transfer(iio_adc->dmac, (uintptr_t)buff, bytes);

--- a/drivers/axi_core/iio_axi_dac/iio_axi_dac.c
+++ b/drivers/axi_core/iio_axi_dac/iio_axi_dac.c
@@ -504,7 +504,7 @@ int32_t iio_axi_dac_write_data(void *dev, void *buff, uint32_t nb_samples)
 		return -1;
 
 	iio_dac = (struct iio_axi_dac_desc *)dev;
-	bytes = nb_samples * no_os_hweight8(iio_dac->mask) * (STORAGE_BITS / 8);
+	bytes = nb_samples * no_os_hweight32(iio_dac->mask) * (STORAGE_BITS / 8);
 
 	if(iio_dac->dcache_flush_range)
 		iio_dac->dcache_flush_range((uintptr_t)buff, bytes);

--- a/drivers/dac/ad3552r/iio_ad3552r.c
+++ b/drivers/dac/ad3552r/iio_ad3552r.c
@@ -221,7 +221,7 @@ static int32_t iio_ad3552r_wr_dev(struct iio_ad3552r_desc *iio_dac,
 	static int c = 0;
 	c++;
 
-	for (i = 0; i < nb_samples * no_os_hweight8(iio_dac->mask); ++i)
+	for (i = 0; i < nb_samples * no_os_hweight32(iio_dac->mask); ++i)
 		buff[i] = no_os_get_unaligned_be16((uint8_t *)&buff[i]);
 
 	return ad3552r_write_samples(iio_dac->dac, buff, nb_samples,

--- a/drivers/platform/aducm3029/adc.c
+++ b/drivers/platform/aducm3029/adc.c
@@ -97,9 +97,9 @@ int32_t aducm3029_adc_read(struct adc_desc *desc, uint16_t *buff,
 
 	for (i = 0; i < nb_samples; i++) {
 		adi_buff.nChannels = desc->ch_mask;
-		adi_buff.pDataBuffer = buff + i * no_os_hweight8(desc->ch_mask);
+		adi_buff.pDataBuffer = buff + i * no_os_hweight32(desc->ch_mask);
 		adi_buff.nNumConversionPasses = 1;
-		adi_buff.nBuffSize = no_os_hweight8(desc->ch_mask) * sizeof(uint16_t);
+		adi_buff.nBuffSize = no_os_hweight32(desc->ch_mask) * sizeof(uint16_t);
 		ret = adi_adc_SubmitBuffer(desc->dev, &adi_buff);
 		if (ret != ADI_ADC_SUCCESS)
 			return -ret;

--- a/include/no_os_util.h
+++ b/include/no_os_util.h
@@ -143,8 +143,12 @@ void no_os_rational_best_approximation(uint32_t given_numerator,
 				       uint32_t max_denominator,
 				       uint32_t *best_numerator,
 				       uint32_t *best_denominator);
-/* Calculate the number of set bits. */
-uint32_t no_os_hweight8(uint32_t word);
+/* Calculate the number of set bits (8-bit size). */
+unsigned int no_os_hweight8(uint8_t word);
+/* Calculate the number of set bits (16-bit size). */
+unsigned int no_os_hweight16(uint16_t word);
+/* Calculate the number of set bits (32-bit size). */
+unsigned int no_os_hweight32(uint32_t word);
 /* Calculate the quotient and the remainder of an integer division. */
 uint64_t no_os_do_div(uint64_t* n,
 		      uint64_t base);

--- a/projects/iio_aducm3029/src/main.c
+++ b/projects/iio_aducm3029/src/main.c
@@ -165,7 +165,7 @@ int main(void)
 		ADUCM3029_CH(5) |
 		0;
 	char buff[100];
-	uint32_t active_ch = no_os_hweight8(ch_mask);
+	uint32_t active_ch = no_os_hweight32(ch_mask);
 	uint32_t nb_samples = 10;
 	uint32_t i,j,k;
 

--- a/util/no_os_util.c
+++ b/util/no_os_util.c
@@ -172,9 +172,9 @@ void no_os_rational_best_approximation(uint32_t given_numerator,
 }
 
 /**
- * Calculate the number of set bits.
+ * Calculate the number of set bits (8-bit size).
  */
-uint32_t no_os_hweight8(uint32_t word)
+unsigned int no_os_hweight8(uint8_t word)
 {
 	uint32_t count = 0;
 
@@ -185,6 +185,24 @@ uint32_t no_os_hweight8(uint32_t word)
 	}
 
 	return count;
+}
+
+/**
+ * Calculate the number of set bits (16-bit size).
+ */
+unsigned int no_os_hweight16(uint16_t word)
+{
+	return no_os_hweight8(word >> 8) +
+	       no_os_hweight8(word);
+}
+
+/**
+ * Calculate the number of set bits (32-bit size).
+ */
+unsigned int no_os_hweight32(uint32_t word)
+{
+	return no_os_hweight16(word >> 16) +
+	       no_os_hweight16(word);
 }
 
 /**


### PR DESCRIPTION
The current hweigth8 function was inconcludent since it was implemented
to support 32-bit size words.

Add separate functions for hweight8/hweigth16/hweight32 similar with the
linux implementation.

Update drivers/projects accordingly.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>