### PR TITLE
drivers: adc: ad469x: fix channel mask

### DIFF
--- a/drivers/adc/ad469x/ad469x.c
+++ b/drivers/adc/ad469x/ad469x.c
@@ -484,7 +484,7 @@ int32_t ad469x_std_sequence_ch(struct ad469x_dev *dev, uint16_t ch_mask)
 
 	ret = ad469x_spi_reg_write(dev,
 				   AD469x_REG_STD_SEQ_CONFIG,
-				   0x0f & ch_mask);
+				   0xff & ch_mask);
 	if (ret != 0)
 		return ret;
 


### PR DESCRIPTION
Fixes mask for the number of active channels when writing the
AD469x_REG_STD_SEQ_CONFIG register.

Fix issue reported at #1294.

Fixes: 0db1a92 ("ad469x: Add channel sequencer implementation")
Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>