### PR TITLE
adaq8092: update no-os functions

### DIFF
--- a/drivers/adc/adaq8092/adaq8092.c
+++ b/drivers/adc/adaq8092/adaq8092.c
@@ -43,7 +43,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include "adaq8092.h"
-#include "no-os/delay.h"
+#include "no_os_delay.h"
 
 /******************************************************************************/
 /************************ Functions Definitions *******************************/
@@ -64,7 +64,7 @@ int adaq8092_read(struct adaq8092_dev *dev, uint8_t reg_addr, uint8_t *reg_data)
 
 	buff[0] = ADAQ8092_SPI_READ | reg_addr;
 
-	ret = spi_write_and_read(dev->spi_desc, buff, 2);
+	ret = no_os_spi_write_and_read(dev->spi_desc, buff, 2);
 	if (ret)
 		return ret;
 
@@ -87,7 +87,7 @@ int adaq8092_write(struct adaq8092_dev *dev, uint8_t reg_addr, uint8_t reg_data)
 	buff[0] = reg_addr;
 	buff[1] = reg_data;
 
-	return spi_write_and_read(dev->spi_desc, buff, 2);
+	return no_os_spi_write_and_read(dev->spi_desc, buff, 2);
 }
 
 /**
@@ -132,68 +132,69 @@ int adaq8092_init(struct adaq8092_dev **device,
 		return -ENOMEM;
 
 	/* SPI Initialization*/
-	ret = spi_init(&dev->spi_desc, init_param.spi_init);
+	ret = no_os_spi_init(&dev->spi_desc, init_param.spi_init);
 	if (ret)
 		goto error_dev;
 
 	/* GPIO Initialization */
-	ret = gpio_get(&dev->gpio_adc_pd1, init_param.gpio_adc_pd1_param);
+	ret = no_os_gpio_get(&dev->gpio_adc_pd1, init_param.gpio_adc_pd1_param);
 	if (ret)
 		goto error_spi;
 
-	ret = gpio_get(&dev->gpio_adc_pd2, init_param.gpio_adc_pd2_param);
+	ret = no_os_gpio_get(&dev->gpio_adc_pd2, init_param.gpio_adc_pd2_param);
 	if (ret)
 		goto error_adc_pd1;
 
-	ret = gpio_get(&dev->gpio_en_1p8, init_param.gpio_en_1p8_param);
+	ret = no_os_gpio_get(&dev->gpio_en_1p8, init_param.gpio_en_1p8_param);
 	if (ret)
 		goto error_adc_pd2;
 
-	ret = gpio_get(&dev->gpio_par_ser, init_param.gpio_par_ser_param);
+	ret = no_os_gpio_get(&dev->gpio_par_ser, init_param.gpio_par_ser_param);
 	if (ret)
 		goto error_en_1p8;
 
 	/* Powerup Sequence */
-	ret = gpio_direction_output(dev->gpio_adc_pd1, GPIO_LOW);
+	ret = no_os_gpio_direction_output(dev->gpio_adc_pd1, NO_OS_GPIO_LOW);
 	if (ret)
 		goto error_par_ser;
 
-	ret = gpio_direction_output(dev->gpio_adc_pd2, GPIO_LOW);
+	ret = no_os_gpio_direction_output(dev->gpio_adc_pd2, NO_OS_GPIO_LOW);
 	if (ret)
 		goto error_par_ser;
 
-	ret = gpio_direction_output(dev->gpio_en_1p8, GPIO_LOW);
+	ret = no_os_gpio_direction_output(dev->gpio_en_1p8, NO_OS_GPIO_LOW);
 	if (ret)
 		goto error_par_ser;
 
-	ret = gpio_direction_output(dev->gpio_par_ser, GPIO_LOW);
+	ret = no_os_gpio_direction_output(dev->gpio_par_ser, NO_OS_GPIO_LOW);
 	if (ret)
 		goto error_par_ser;
 
-	mdelay(1000);
+	no_os_mdelay(1000);
 
-	ret = gpio_set_value(dev->gpio_en_1p8, GPIO_HIGH);
+	ret = no_os_gpio_set_value(dev->gpio_en_1p8, NO_OS_GPIO_HIGH);
 	if (ret)
 		goto error_par_ser;
 
-	mdelay(500);
+	no_os_mdelay(500);
 
-	ret = gpio_set_value(dev->gpio_adc_pd1, GPIO_HIGH);
+	ret = no_os_gpio_set_value(dev->gpio_adc_pd1, NO_OS_GPIO_HIGH);
 	if (ret)
 		goto error_par_ser;
 
-	mdelay(1);
+	no_os_mdelay(1);
 
-	ret = gpio_set_value(dev->gpio_adc_pd2, GPIO_HIGH);
+	ret = no_os_gpio_set_value(dev->gpio_adc_pd2, NO_OS_GPIO_HIGH);
 	if (ret)
 		goto error_par_ser;
 
 	/* Software Reset */
-	ret = adaq8092_write(dev,  ADAQ8092_REG_RESET, field_prep(ADAQ8092_RESET, 1));
+	ret = adaq8092_write(dev,  ADAQ8092_REG_RESET, no_os_field_prep(ADAQ8092_RESET,
+			     1));
 	if (ret)
 		goto error_par_ser;
 
-	mdelay(100);
+	no_os_mdelay(100);
 
 	/* Device Initialization */
 	ret = adaq8092_set_pd_mode(dev, init_param.pd_mode);
@@ -249,15 +250,15 @@ int adaq8092_init(struct adaq8092_dev **device,
 	return 0;
 
 error_par_ser:
-	gpio_remove(dev->gpio_par_ser);
+	no_os_gpio_remove(dev->gpio_par_ser);
 error_en_1p8:
-	gpio_remove(dev->gpio_en_1p8);
+	no_os_gpio_remove(dev->gpio_en_1p8);
 error_adc_pd2:
-	gpio_remove(dev->gpio_adc_pd2);
+	no_os_gpio_remove(dev->gpio_adc_pd2);
 error_adc_pd1:
-	gpio_remove(dev->gpio_adc_pd1);
+	no_os_gpio_remove(dev->gpio_adc_pd1);
 error_spi:
-	spi_remove(dev->spi_desc);
+	no_os_spi_remove(dev->spi_desc);
 error_dev:
 	free(dev);
 
@@ -273,23 +274,23 @@ int adaq8092_remove(struct adaq8092_dev *dev)
 {
 	int ret;
 
-	ret = spi_remove(dev->spi_desc);
+	ret = no_os_spi_remove(dev->spi_desc);
 	if (ret)
 		return ret;
 
-	ret = gpio_remove(dev->gpio_adc_pd1);
+	ret = no_os_gpio_remove(dev->gpio_adc_pd1);
 	if (ret)
 		return ret;
 
-	ret = gpio_remove(dev->gpio_adc_pd2);
+	ret = no_os_gpio_remove(dev->gpio_adc_pd2);
 	if (ret)
 		return ret;
 
-	ret = gpio_remove(dev->gpio_en_1p8);
+	ret = no_os_gpio_remove(dev->gpio_en_1p8);
 	if (ret)
 		return ret;
 
-	ret = gpio_remove(dev->gpio_par_ser);
+	ret = no_os_gpio_remove(dev->gpio_par_ser);
 	if (ret)
 		return ret;
 
@@ -311,7 +312,7 @@ int adaq8092_set_pd_mode(struct adaq8092_dev *dev,
 
 	ret = adaq8092_update_bits(dev, ADAQ8092_REG_POWERDOWN,
 				   ADAQ8092_POWERDOWN_MODE,
-				   field_prep(ADAQ8092_POWERDOWN_MODE, mode));
+				   no_os_field_prep(ADAQ8092_POWERDOWN_MODE, mode));
 	if (ret)
 		return ret;
 
@@ -343,7 +344,7 @@ int adaq8092_set_clk_pol_mode(struct adaq8092_dev *dev,
 
 	ret = adaq8092_update_bits(dev, ADAQ8092_REG_TIMING,
 				   ADAQ8092_CLK_INVERT,
-				   field_prep(ADAQ8092_CLK_INVERT, mode));
+				   no_os_field_prep(ADAQ8092_CLK_INVERT, mode));
 	if (ret)
 		return ret;
 
@@ -375,7 +376,7 @@ int adaq8092_set_clk_phase_mode(struct adaq8092_dev *dev,
 
 	ret = adaq8092_update_bits(dev, ADAQ8092_REG_TIMING,
 				   ADAQ8092_CLK_PHASE,
-				   field_prep(ADAQ8092_CLK_PHASE, mode));
+				   no_os_field_prep(ADAQ8092_CLK_PHASE, mode));
 	if (ret)
 		return ret;
 
@@ -408,7 +409,7 @@ int adaq8092_set_clk_dc_mode(struct adaq8092_dev *dev,
 
 	ret = adaq8092_update_bits(dev, ADAQ8092_REG_TIMING,
 				   ADAQ8092_CLK_DUTYCYCLE,
-				   field_prep(ADAQ8092_CLK_DUTYCYCLE, mode));
+				   no_os_field_prep(ADAQ8092_CLK_DUTYCYCLE, mode));
 	if (ret)
 		return ret;
 
@@ -440,7 +441,7 @@ int adaq8092_set_lvds_cur_mode(struct adaq8092_dev *dev,
 
 	ret = adaq8092_update_bits(dev, ADAQ8092_REG_OUTPUT_MODE,
 				   ADAQ8092_ILVDS,
-				   field_prep(ADAQ8092_ILVDS, mode));
+				   no_os_field_prep(ADAQ8092_ILVDS, mode));
 	if (ret)
 		return ret;
 
@@ -473,7 +474,7 @@ int adaq8092_set_lvds_term_mode(struct adaq8092_dev *dev,
 
 	ret = adaq8092_update_bits(dev, ADAQ8092_REG_OUTPUT_MODE,
 				   ADAQ8092_TERMON,
-				   field_prep(ADAQ8092_TERMON, mode));
+				   no_os_field_prep(ADAQ8092_TERMON, mode));
 	if (ret)
 		return ret;
 
@@ -506,7 +507,7 @@ int adaq8092_set_dout_en(struct adaq8092_dev *dev,
 
 	ret = adaq8092_update_bits(dev, ADAQ8092_REG_OUTPUT_MODE,
 				   ADAQ8092_OUTOFF,
-				   field_prep(ADAQ8092_OUTOFF, mode));
+				   no_os_field_prep(ADAQ8092_OUTOFF, mode));
 	if (ret)
 		return ret;
 
@@ -538,7 +539,7 @@ int adaq8092_set_dout_mode(struct adaq8092_dev *dev,
 
 	ret = adaq8092_update_bits(dev, ADAQ8092_REG_OUTPUT_MODE,
 				   ADAQ8092_OUTMODE,
-				   field_prep(ADAQ8092_OUTMODE, mode));
+				   no_os_field_prep(ADAQ8092_OUTMODE, mode));
 	if (ret)
 		return ret;
 
@@ -570,7 +571,7 @@ int adaq8092_set_test_mode(struct adaq8092_dev *dev,
 
 	ret = adaq8092_update_bits(dev, ADAQ8092_REG_DATA_FORMAT,
 				   ADAQ8092_OUTTEST,
-				   field_prep(ADAQ8092_OUTTEST, mode));
+				   no_os_field_prep(ADAQ8092_OUTTEST, mode));
 	if (ret)
 		return ret;
 
@@ -602,7 +603,7 @@ int adaq8092_set_alt_pol_en(struct adaq8092_dev *dev,
 
 	ret = adaq8092_update_bits(dev, ADAQ8092_REG_DATA_FORMAT,
 				   ADAQ8092_ABP,
-				   field_prep(ADAQ8092_ABP, mode));
+				   no_os_field_prep(ADAQ8092_ABP, mode));
 	if (ret)
 		return ret;
 
@@ -634,7 +635,7 @@ int adaq8092_set_data_rand_en(struct adaq8092_dev *dev,
 
 	ret = adaq8092_update_bits(dev, ADAQ8092_REG_DATA_FORMAT,
 				   ADAQ8092_RAND,
-				   field_prep(ADAQ8092_RAND, mode));
+				   no_os_field_prep(ADAQ8092_RAND, mode));
 	if (ret)
 		return ret;
 
@@ -666,7 +667,7 @@ int adaq8092_set_twos_comp(struct adaq8092_dev *dev,
 
 	ret = adaq8092_update_bits(dev, ADAQ8092_REG_DATA_FORMAT,
 				   ADAQ8092_TWOSCOMP,
-				   field_prep(ADAQ8092_TWOSCOMP, mode));
+				   no_os_field_prep(ADAQ8092_TWOSCOMP, mode));
 	if (ret)
 		return ret;
 

--- a/drivers/adc/adaq8092/adaq8092.h
+++ b/drivers/adc/adaq8092/adaq8092.h
@@ -44,15 +44,15 @@
 /******************************************************************************/
 #include <stdint.h>
 #include <string.h>
-#include "no-os/util.h"
-#include "no-os/spi.h"
-#include "no-os/gpio.h"
+#include "no_os_util.h"
+#include "no_os_spi.h"
+#include "no_os_gpio.h"
 
 /******************************************************************************/
 /********************** Macros and Constants Definitions **********************/
 /******************************************************************************/
 /* SPI commands */
-#define ADAQ8092_SPI_READ          	BIT(7)
+#define ADAQ8092_SPI_READ          	NO_OS_BIT(7)
 #define ADAQ8092_ADDR(x)		((x) & 0xFF)
 
 /* ADAQ8092 Register Map */
@@ -63,27 +63,27 @@
 #define ADAQ8092_REG_DATA_FORMAT	0x04
 
 /* ADAQ8092_REG_RESET Bit Definition */
-#define ADAQ8092_RESET			BIT(7)
+#define ADAQ8092_RESET			NO_OS_BIT(7)
 
 /* ADAQ8092_REG_POWERDOWN Bit Definition */
-#define ADAQ8092_POWERDOWN_MODE		GENMASK(1, 0)
+#define ADAQ8092_POWERDOWN_MODE		NO_OS_GENMASK(1, 0)
 
 /* ADAQ8092_REG_TIMING Bit Definition */
-#define ADAQ8092_CLK_INVERT		BIT(3)
-#define ADAQ8092_CLK_PHASE		GENMASK(2, 1)
-#define ADAQ8092_CLK_DUTYCYCLE		BIT(0)
+#define ADAQ8092_CLK_INVERT		NO_OS_BIT(3)
+#define ADAQ8092_CLK_PHASE		NO_OS_GENMASK(2, 1)
+#define ADAQ8092_CLK_DUTYCYCLE		NO_OS_BIT(0)
 
 /* ADAQ8092_REG_OUTPUT_MODE Bit Definition */
-#define ADAQ8092_ILVDS			GENMASK(6, 4)
-#define ADAQ8092_TERMON			BIT(3)
-#define ADAQ8092_OUTOFF			BIT(2)
-#define ADAQ8092_OUTMODE		GENMASK(1, 0)
+#define ADAQ8092_ILVDS			NO_OS_GENMASK(6, 4)
+#define ADAQ8092_TERMON			NO_OS_BIT(3)
+#define ADAQ8092_OUTOFF			NO_OS_BIT(2)
+#define ADAQ8092_OUTMODE		NO_OS_GENMASK(1, 0)
 
 /* ADAQ8092_REG_DATA_FORMAT Bit Definition */
-#define ADAQ8092_OUTTEST		GENMASK(5, 3)
-#define ADAQ8092_ABP			BIT(2)
-#define ADAQ8092_RAND			BIT(1)
-#define ADAQ8092_TWOSCOMP		BIT(0)
+#define ADAQ8092_OUTTEST		NO_OS_GENMASK(5, 3)
+#define ADAQ8092_ABP			NO_OS_BIT(2)
+#define ADAQ8092_RAND			NO_OS_BIT(1)
+#define ADAQ8092_TWOSCOMP		NO_OS_BIT(0)
 
 /******************************************************************************/
 /*************************** Types Declarations *******************************/
@@ -179,11 +179,11 @@ enum adaq8092_twoscomp {
  */
 struct adaq8092_init_param {
 	/** Device communication descriptor */
-	struct spi_init_param 		*spi_init;
-	struct gpio_init_param		*gpio_adc_pd1_param;
-	struct gpio_init_param		*gpio_adc_pd2_param;
-	struct gpio_init_param		*gpio_en_1p8_param;
-	struct gpio_init_param		*gpio_par_ser_param;
+	struct no_os_spi_init_param 	*spi_init;
+	struct no_os_gpio_init_param	*gpio_adc_pd1_param;
+	struct no_os_gpio_init_param	*gpio_adc_pd2_param;
+	struct no_os_gpio_init_param	*gpio_en_1p8_param;
+	struct no_os_gpio_init_param	*gpio_par_ser_param;
 	enum adaq8092_powerdown_modes	pd_mode;
 	enum adaq8092_clk_invert	clk_pol_mode;
 	enum adaq8092_clk_phase_delay	clk_phase_mode;
@@ -204,11 +204,11 @@ struct adaq8092_init_param {
  */
 struct adaq8092_dev {
 	/** Device communication descriptor */
-	struct spi_desc			*spi_desc;
-	struct gpio_desc		*gpio_adc_pd1;
-	struct gpio_desc		*gpio_adc_pd2;
-	struct gpio_desc		*gpio_en_1p8;
-	struct gpio_desc		*gpio_par_ser;
+	struct no_os_spi_desc		*spi_desc;
+	struct no_os_gpio_desc		*gpio_adc_pd1;
+	struct no_os_gpio_desc		*gpio_adc_pd2;
+	struct no_os_gpio_desc		*gpio_en_1p8;
+	struct no_os_gpio_desc		*gpio_par_ser;
 	enum adaq8092_powerdown_modes	pd_mode;
 	enum adaq8092_clk_invert	clk_pol_mode;
 	enum adaq8092_clk_phase_delay	clk_phase_mode;

--- a/projects/adaq8092_fmc/src.mk
+++ b/projects/adaq8092_fmc/src.mk
@@ -15,17 +15,17 @@ LIBRARIES += iio
 SRC_DIRS += $(NO-OS)/iio/iio_app
 endif
 SRCS += $(DRIVERS)/adc/adaq8092/adaq8092.c \
-	$(DRIVERS)/api/spi.c \
-	$(DRIVERS)/api/gpio.c \
+	$(DRIVERS)/api/no_os_spi.c \
+	$(DRIVERS)/api/no_os_gpio.c \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
 	$(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
-	$(NO-OS)/util/util.c
+	$(NO-OS)/util/no_os_util.c
 ifeq (y,$(strip $(TINYIIOD)))
-SRCS += $(NO-OS)/util/fifo.c \
+SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \
-	$(DRIVERS)/api/irq.c \
-	$(NO-OS)/util/list.c \
-	$(PLATFORM_DRIVERS)/uart.c \
+	$(DRIVERS)/api/no_os_irq.c \
+	$(NO-OS)/util/no_os_list.c \
+	$(PLATFORM_DRIVERS)/no_os_uart.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c
 endif
 SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
@@ -39,18 +39,18 @@ INCS += $(PROJECT)/src/parameters.h \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h
 INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
-INCS +=	$(INCLUDE)/no-os/axi_io.h \
-	$(INCLUDE)/no-os/spi.h \
-	$(INCLUDE)/no-os/gpio.h \
-	$(INCLUDE)/no-os/error.h \
-	$(INCLUDE)/no-os/delay.h \
-	$(INCLUDE)/no-os/print_log.h \
-	$(INCLUDE)/no-os/util.h
+INCS +=	$(INCLUDE)/no_os_axi_io.h \
+	$(INCLUDE)/no_os_spi.h \
+	$(INCLUDE)/no_os_gpio.h \
+	$(INCLUDE)/no_os_error.h \
+	$(INCLUDE)/no_os_delay.h \
+	$(INCLUDE)/no_os_print_log.h \
+	$(INCLUDE)/no_os_util.h
 ifeq (y,$(strip $(TINYIIOD)))
-INCS +=	$(INCLUDE)/no-os/fifo.h \
-	$(INCLUDE)/no-os/irq.h \
-	$(INCLUDE)/no-os/uart.h \
-	$(INCLUDE)/no-os/list.h \
+INCS +=	$(INCLUDE)/no_os_fifo.h \
+	$(INCLUDE)/no_os_irq.h \
+	$(INCLUDE)/no_os_uart.h \
+	$(INCLUDE)/no_os_list.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
 	$(PLATFORM_DRIVERS)/uart_extra.h \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h

--- a/projects/adaq8092_fmc/src/adaq8092_fmc.c
+++ b/projects/adaq8092_fmc/src/adaq8092_fmc.c
@@ -45,14 +45,14 @@
 #include "axi_adc_core.h"
 #include "axi_dmac.h"
 #include "adaq8092.h"
-#include "no-os/spi.h"
-#include "no-os/gpio.h"
+#include "no_os_spi.h"
+#include "no_os_gpio.h"
 #include "spi_extra.h"
 #include "parameters.h"
-#include "no-os/error.h"
+#include "no_os_error.h"
 #include "gpio_extra.h"
 
-#include "no-os/print_log.h"
+#include "no_os_print_log.h"
 
 #ifdef IIO_SUPPORT
 #include "iio_app.h"
@@ -80,7 +80,7 @@ int main(void)
 	};
 
 	/* SPI */
-	struct spi_init_param adaq8092_spi_param = {
+	struct no_os_spi_init_param adaq8092_spi_param = {
 		.device_id = SPI_DEVICE_ID,
 		.max_speed_hz =  1000000u,
 		.chip_select = 0,
@@ -95,25 +95,25 @@ int main(void)
 		.type = GPIO_PS
 	};
 
-	struct gpio_init_param gpio_par_ser_init_param = {
+	struct no_os_gpio_init_param gpio_par_ser_init_param = {
 		.number = GPIO_PAR_SER_NR,
 		.platform_ops = &xil_gpio_ops,
 		.extra = &xil_gpio_init
 	};
 
-	struct gpio_init_param gpio_adc_pd1_param = {
+	struct no_os_gpio_init_param gpio_adc_pd1_param = {
 		.number = GPIO_PD1_NR,
 		.platform_ops = &xil_gpio_ops,
 		.extra = &xil_gpio_init
 	};
 
-	struct gpio_init_param gpio_adc_pd2_param = {
+	struct no_os_gpio_init_param gpio_adc_pd2_param = {
 		.number = GPIO_PD2_NR,
 		.platform_ops = &xil_gpio_ops,
 		.extra = &xil_gpio_init
 	};
 
-	struct gpio_init_param gpio_en_1v8_param = {
+	struct no_os_gpio_init_param gpio_en_1v8_param = {
 		.number = GPIO_1V8_NR,
 		.platform_ops = &xil_gpio_ops,
 		.extra = &xil_gpio_init
@@ -219,7 +219,7 @@ int main(void)
 			       &read_buff, NULL),
 	};
 
-	return iio_app_run(devices, ARRAY_SIZE(devices));
+	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
 #endif
 
 	return 0;


### PR DESCRIPTION
Update no-os naming for the platform drivers.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>