### PR TITLE
CN0561 example

### DIFF
--- a/drivers/adc/ad713x/ad713x.c
+++ b/drivers/adc/ad713x/ad713x.c
@@ -542,7 +542,7 @@ int32_t ad713x_init(struct ad713x_dev **device,
 	dev->dev_id = init_param->dev_id;
 
 	ret = ad713x_spi_reg_read(dev, AD713X_REG_CHIP_TYPE, &data);
-	if (IS_ERR_VALUE(ret))
+	if (NO_OS_IS_ERR_VALUE(ret))
 		goto error_gpio;
 	if (AD713X_CHIP_TYPE_BITS_MODE(data) != AD713X_CHIP_TYPE)
 		goto error_gpio;

--- a/drivers/adc/ad713x/ad713x.c
+++ b/drivers/adc/ad713x/ad713x.c
@@ -540,6 +540,7 @@ int32_t ad713x_init(struct ad713x_dev **device,
 		goto error_gpio;
 
 	dev->dev_id = init_param->dev_id;
+	dev->mode_master_nslave = init_param->mode_master_nslave;
 
 	ret = ad713x_spi_reg_read(dev, AD713X_REG_CHIP_TYPE, &data);
 	if (NO_OS_IS_ERR_VALUE(ret))

--- a/drivers/adc/ad713x/ad713x.c
+++ b/drivers/adc/ad713x/ad713x.c
@@ -541,6 +541,12 @@ int32_t ad713x_init(struct ad713x_dev **device,
 
 	dev->dev_id = init_param->dev_id;
 
+	ret = ad713x_spi_reg_read(dev, AD713X_REG_CHIP_TYPE, &data);
+	if (IS_ERR_VALUE(ret))
+		goto error_gpio;
+	if (AD713X_CHIP_TYPE_BITS_MODE(data) != AD713X_CHIP_TYPE)
+		goto error_gpio;
+
 	ret = ad713x_spi_reg_read(dev, AD713X_REG_DEVICE_CONFIG, &data);
 	if (NO_OS_IS_ERR_VALUE(ret))
 		goto error_gpio;

--- a/drivers/adc/ad713x/ad713x.h
+++ b/drivers/adc/ad713x/ad713x.h
@@ -661,7 +661,9 @@ enum ad713x_channels {
 	/** Channel 2 */
 	CH2,
 	/** Channel 3 */
-	CH3
+	CH3,
+	/** Max number of channels */
+	AD713X_CH_MAX
 };
 
 /**
@@ -700,6 +702,8 @@ struct ad713x_dev {
 	enum ad713x_adc_data_len	adc_data_len;
 	/** CRC option. */
 	enum ad713x_crc_header	crc_header;
+	/** MODE GPIO starting value */
+	bool mode_master_nslave;
 };
 
 /**

--- a/drivers/adc/ad713x/ad713x.h
+++ b/drivers/adc/ad713x/ad713x.h
@@ -173,6 +173,7 @@
  */
 #define AD713X_CHIP_TYPE_BITS_MSK			NO_OS_GENMASK(7, 0)
 #define AD713X_CHIP_TYPE_BITS_MODE(x)			(((x) & 0xFF) << 0)
+#define AD713X_CHIP_TYPE				0x07
 
 /*
  * AD713X_REG_PRODUCT_ID_LSB
@@ -575,7 +576,8 @@
 enum ad713x_supported_dev_ids {
 	ID_AD7132,
 	ID_AD7134,
-	ID_AD7136
+	ID_AD7136,
+	ID_AD4134
 };
 
 /**

--- a/drivers/adc/ad713x/iio_ad713x.c
+++ b/drivers/adc/ad713x/iio_ad713x.c
@@ -43,14 +43,536 @@
 /***************************** Include Files **********************************/
 /******************************************************************************/
 
-#include "iio_types.h"
+#include <errno.h>
+#include <string.h>
+
 #include "ad713x.h"
+#include "iio.h"
+#include "iio_ad713x.h"
+#include "iio_types.h"
+#include "no_os_util.h"
+#include "spi_engine.h"
+
+#define MEGA 1000000UL
 
 /******************************************************************************/
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
+/**
+ * @struct ad713x_iio
+ * @brief AD713x IIO private handler
+ */
+struct ad713x_iio {
+	/** AD713x driver handler */
+	struct ad713x_dev *drv_dev;
+	/** Generic IIO device handler */
+	struct iio_device *iio_dev;
+	/** Integer part of the ODR */
+	uint32_t odr_int;
+	/** Decimal part of the ODR */
+	uint32_t odr_flt;
+	/** Integer part of the VREF */
+	uint32_t vref_int;
+	/** Decimal part of the VREF */
+	uint32_t vref_micro;
+	/** SPI Engine driver handler */
+	struct no_os_spi_desc *spi_eng_desc;
+	/** Active channels mask */
+	uint32_t mask;
+	/** Invalidate the Data cache for the given address range */
+	void (*dcache_invalidate_range)(uint32_t address, uint32_t bytes_count);
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+#define AD713x_IIO_FUNC(_name)	static int _name(void *device, char *buf, \
+		uint32_t len, const struct iio_ch_info *channel, intptr_t priv)
+
+AD713x_IIO_FUNC(ad713x_iio_show_filter_3db);
+AD713x_IIO_FUNC(ad713x_iio_show_offset);
+AD713x_IIO_FUNC(ad713x_iio_store_offset);
+AD713x_IIO_FUNC(ad713x_iio_show_raw);
+AD713x_IIO_FUNC(ad713x_iio_show_odr);
+AD713x_IIO_FUNC(ad713x_iio_store_odr);
+AD713x_IIO_FUNC(ad713x_iio_show_scale);
+
+/******************************************************************************/
+/********************* Static Variables Definitions ***************************/
+/******************************************************************************/
+
+static struct iio_attribute channel_attributes[] = {
+	{
+		.name = "filter_low_pass_3db_frequency",
+		.priv = 0,
+		.shared = IIO_SEPARATE,
+		.show = ad713x_iio_show_filter_3db,
+		.store = NULL
+	},
+	{
+		.name = "offset",
+		.priv = 0,
+		.shared = IIO_SEPARATE,
+		.show = ad713x_iio_show_offset,
+		.store = ad713x_iio_store_offset
+	},
+	{
+		.name = "raw",
+		.priv = 0,
+		.shared = IIO_SEPARATE,
+		.show = ad713x_iio_show_raw,
+		.store = NULL
+	},
+	{
+		.name = "sampling_frequency",
+		.priv = 0,
+		.shared = IIO_SHARED_BY_ALL,
+		.show = ad713x_iio_show_odr,
+		.store = ad713x_iio_store_odr
+	},
+	{
+		.name = "scale",
+		.priv = 0,
+		.shared = IIO_SHARED_BY_ALL,
+		.show = ad713x_iio_show_scale,
+		.store = NULL
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+struct scan_type ad713x_iio_scan_type = {
+	.sign = 's',
+	.realbits = 24,
+	.storagebits = 32,
+	.shift = 8,
+	.is_big_endian = true
+};
+
+#define AD713X_IIO_CHANN_DEF(nm, ch1) \
+	{ \
+		.name = nm, \
+		.ch_type = IIO_VOLTAGE, \
+		.channel = ch1, \
+		.channel2 = 0, \
+		.address = ch1, \
+		.scan_index = ch1, \
+		.scan_type = &ad713x_iio_scan_type, \
+		.attributes = channel_attributes, \
+		.ch_out = IIO_DIRECTION_INPUT, \
+		.indexed = true, \
+		.diferential = false, \
+	}
+
+static struct iio_channel ad713x_channels[] = {
+	AD713X_IIO_CHANN_DEF("ch0", 0),
+	AD713X_IIO_CHANN_DEF("ch1", 1),
+	AD713X_IIO_CHANN_DEF("ch2", 2),
+	AD713X_IIO_CHANN_DEF("ch3", 3)
+};
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+/**
+ * @brief Transform decimal floating point into hexadecimal floating point for
+ *        the ODR register.
+ * @param [in] odr_flt - Decimal ODR in microhertz (no integer part)
+ * @return hexadecimal floating point
+ */
+static uint32_t _ad713x_odr_itoh_float_conversion(uint32_t odr_flt)
+{
+	int i;
+	uint32_t result = 0;
+
+	for (i = 1; i <= 8; i++) {
+		odr_flt *= 16;
+		result |= (odr_flt / MEGA) << (32 - 4 * i);
+		odr_flt %= MEGA;
+		if (!odr_flt)
+			break;
+	}
+
+	return result;
+}
+
+/**
+ * @brief Transform hexadecimal floating point into decimal floating point for
+ *        the ODR register.
+ * @param [in] odr_flt - Decimal ODR in microhertz (no integer part)
+ * @return decimal floating point
+ */
+static uint32_t _ad713x_odr_htoi_float_conversion(uint32_t odr_flt)
+{
+	return (uint32_t)(no_os_mul_u32_u32(odr_flt, 1000000) / 0x100000000ULL);
+}
+
+static int ad713x_iio_show_filter_3db(void *device, char *buf, uint32_t len,
+				      const struct iio_ch_info *channel,
+				      intptr_t priv)
+{
+	struct ad713x_iio	*iio_desc = (struct ad713x_iio *)device;
+	struct ad713x_dev	*desc = iio_desc->drv_dev;
+	uint8_t				value;
+	int32_t				ret;
+	uint32_t			val[2];
+	uint32_t			temp;
+	const uint32_t sinc_mult_micro[] = {0, 186100, 261700, 275300};
+	const uint32_t fir_mult_micro[] = {433000, 108250};
+
+	/** Slave ODR is controlled by external signal */
+	if (!desc->mode_master_nslave)
+		return -1;
+
+	ret = ad713x_spi_reg_read(desc, AD713X_REG_CHAN_DIG_FILTER_SEL, &value);
+	if (ret < 0)
+		return ret;
+
+	value = (value & AD713X_DIGFILTER_SEL_CH_MSK(channel->ch_num)) >>
+		(channel->ch_num * 2);
+	switch (value) {
+	case SINC6:
+	case SINC3:
+	case SINC3_50_60_REJ:
+		val[0] = no_os_mul_u32_u32(iio_desc->odr_int, sinc_mult_micro[value]) /
+			 MEGA;
+		temp = no_os_mul_u32_u32(iio_desc->odr_int, sinc_mult_micro[value]) %
+		       MEGA;
+		val[1] = no_os_mul_u32_u32(iio_desc->odr_flt, sinc_mult_micro[value]) +
+			 temp;
+
+		return iio_format_value(buf, len, IIO_VAL_INT_PLUS_MICRO, 2,
+					(int32_t *)val);
+	case FIR:
+		ret = ad713x_spi_reg_read(desc, AD713X_REG_FIR_BW_SEL, &value);
+		if (ret < 0)
+			return ret;
+		value = !!(value & AD713X_FIR_BW_SEL_CH_MSK(channel->ch_num));
+		val[0] =  no_os_mul_u32_u32(iio_desc->odr_int, fir_mult_micro[value]) /
+			  MEGA;
+		temp = no_os_mul_u32_u32(iio_desc->odr_int, fir_mult_micro[value]) %
+		       MEGA;
+		val[1] = no_os_mul_u32_u32(iio_desc->odr_flt, fir_mult_micro[value]) +
+			 temp;
+
+		return iio_format_value(buf, len, IIO_VAL_INT_PLUS_MICRO, 2,
+					(int32_t *)val);
+	default:
+		return -1;
+	}
+}
+
+static int ad713x_iio_show_offset(void *device, char *buf, uint32_t len,
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
+{
+	struct ad713x_iio	*iio_desc = (struct ad713x_iio *)device;
+	struct ad713x_dev	*desc = iio_desc->drv_dev;
+	uint8_t				reg_value;
+	const uint8_t		reg_addr[] = {
+		AD713X_REG_CH0_OFFSET_LSB,
+		AD713X_REG_CH1_OFFSET_LSB,
+		AD713X_REG_CH2_OFFSET_LSB,
+		AD713X_REG_CH3_OFFSET_LSB
+	};
+	uint32_t val = 0;
+	int i, ret;
+
+	for (i = 0; i < 3; i++) {
+		ret = ad713x_spi_reg_read(desc, reg_addr[channel->ch_num] + i,
+					  &reg_value);
+		if (ret < 0)
+			return ret;
+		if (i == 2)
+			reg_value &= 0x7F;
+		val |= (uint32_t)reg_value << (8 * i);
+	}
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, (int32_t *)&val);
+}
+
+static int ad713x_iio_store_offset(void *device, char *buf, uint32_t len,
+				   const struct iio_ch_info *channel,
+				   intptr_t priv)
+{
+	struct ad713x_iio	*iio_desc = (struct ad713x_iio *)device;
+	struct ad713x_dev	*desc = iio_desc->drv_dev;
+	uint32_t			val;
+	const uint8_t		reg_addr[] = {
+		AD713X_REG_CH0_OFFSET_LSB,
+		AD713X_REG_CH1_OFFSET_LSB,
+		AD713X_REG_CH2_OFFSET_LSB,
+		AD713X_REG_CH3_OFFSET_LSB
+	};
+	uint8_t reg_value;
+	int i, ret;
+
+	iio_parse_value(buf, IIO_VAL_INT, (int32_t *)&val, NULL);
+
+	for (i = 0; i < 3; i++) {
+		reg_value = (val >> (8 * i)) & 0xFF;
+		if (i == 2)
+			reg_value |= AD713X_CH_OFFSET_CAL_EN_MSK;
+		ret = ad713x_spi_reg_write(desc, reg_addr[channel->ch_num] + i,
+					   reg_value);
+		if (ret < 0)
+			return ret;
+	}
+
+	return ret;
+}
+
+static int ad713x_iio_show_raw(void *device, char *buf, uint32_t len,
+			       const struct iio_ch_info *channel,
+			       intptr_t priv)
+{
+	struct ad713x_iio	*iio_desc = (struct ad713x_iio *)device;
+	struct spi_engine_offload_message spi_engine_offload_message;
+	uint32_t spi_eng_msg_cmds[1];
+	uint32_t adc_buffer[3 * AD713X_CH_MAX] __attribute__((aligned));
+	int ret;
+	int32_t data;
+
+	spi_eng_msg_cmds[0] = READ(4);
+
+	spi_engine_offload_message.commands = spi_eng_msg_cmds;
+	spi_engine_offload_message.no_commands = NO_OS_ARRAY_SIZE(spi_eng_msg_cmds);
+	spi_engine_offload_message.commands_data = NULL;
+	spi_engine_offload_message.rx_addr = (uint32_t)adc_buffer;
+	spi_engine_offload_message.tx_addr = (uint32_t)NULL;
+
+	if (iio_desc->dcache_invalidate_range)
+		iio_desc->dcache_invalidate_range((uint32_t)adc_buffer,
+						  3 * iio_desc->iio_dev->num_ch * sizeof(uint32_t));
+
+	/** Take read 3 samples and use the one in the middle;
+	 *  workaround for a bug where the first and last samples are 0
+	 *  todo: investigate and fix bug */
+	ret = spi_engine_offload_transfer(iio_desc->spi_eng_desc,
+					  spi_engine_offload_message,
+					  3 * iio_desc->iio_dev->num_ch);
+	if (ret != 0)
+		return ret;
+
+	if (iio_desc->dcache_invalidate_range)
+		iio_desc->dcache_invalidate_range((uint32_t)adc_buffer,
+						  3 * iio_desc->iio_dev->num_ch * sizeof(uint32_t));
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, &data);
+}
+
+static int ad713x_iio_show_odr(void *device, char *buf, uint32_t len,
+			       const struct iio_ch_info *channel,
+			       intptr_t priv)
+{
+	struct ad713x_iio	*iio_desc = (struct ad713x_iio *)device;
+	struct ad713x_dev	*desc = iio_desc->drv_dev;
+	uint32_t odr_tab[2];
+
+	/** Slave ODR is controlled by external signal */
+	if (!desc->mode_master_nslave)
+		return -1;
+
+	odr_tab[0] = iio_desc->odr_int;
+	odr_tab[1] = iio_desc->odr_flt;
+
+	return iio_format_value(buf, len, IIO_VAL_INT_PLUS_MICRO, 2,
+				(int32_t *)odr_tab);
+}
+
+static int ad713x_iio_store_odr(void *device, char *buf, uint32_t len,
+				const struct iio_ch_info *channel,
+				intptr_t priv)
+{
+	struct ad713x_iio	*iio_desc = (struct ad713x_iio *)device;
+	struct ad713x_dev	*desc = iio_desc->drv_dev;
+	uint8_t reg_data;
+	uint32_t reg_int, reg_flt;
+	uint64_t odr_uhz, odr_ref = 24000000000000ULL, rest;
+	int i, ret;
+
+	/** Slave ODR is controlled by external signal */
+	if (!desc->mode_master_nslave)
+		return -1;
+
+	iio_parse_value(buf, IIO_VAL_INT_PLUS_MICRO,
+			(int32_t *)&iio_desc->odr_int, (int32_t *)&iio_desc->odr_flt);
+	odr_uhz = no_os_mul_u32_u32(iio_desc->odr_int, MEGA) + iio_desc->odr_flt;
+
+	rest = no_os_do_div(&odr_ref, odr_uhz);
+	reg_int = odr_ref;
+	rest *= MEGA;
+	no_os_do_div(&rest, odr_uhz);
+	reg_flt = _ad713x_odr_itoh_float_conversion(rest);
+
+	for (i = 0; i < 7; i++) {
+		if (i < 3)
+			reg_data = (reg_int >> (8 * i)) & 0xFF;
+		else
+			reg_data = (reg_flt >> (8 * (i - 3))) & 0xFF;
+		ret = ad713x_spi_reg_write(desc, AD713X_REG_ODR_VAL_INT_LSB + i,
+					   reg_data);
+		if (ret < 0)
+			return ret;
+	}
+
+	return ret;
+}
+
+static int ad713x_iio_show_scale(void *device, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel,
+				 intptr_t priv)
+{
+	struct ad713x_iio	*iio_desc = (struct ad713x_iio *)device;
+	uint32_t vref[2];
+	uint64_t reference_nv;
+
+	reference_nv = iio_desc->vref_int * 1000000000 +
+		       iio_desc->vref_micro * 1000;
+
+	no_os_do_div(&reference_nv, 0x7FFFFF);
+
+	vref[0] = reference_nv / 1000000000;
+	vref[1] = reference_nv % 1000000000;
+
+	/** Even though the voltage is calculated in nanovolts we need to
+	 *  say they are microvolts because we need the scale to be
+	 *  shown in milivolts instead of volts
+	 *  todo: fix if necessary */
+	return iio_format_value(buf, len, IIO_VAL_INT_PLUS_MICRO, 2,
+				(int32_t *)vref);
+}
+
+static int32_t ad713x_iio_prepare_transfer(struct ad713x_iio *desc,
+		uint32_t mask)
+{
+	if (!desc)
+		return -EINVAL;
+
+	desc->mask = mask;
+
+	return 0;
+}
+
+static int32_t ad713x_iio_read_dev(struct ad713x_iio *desc, uint32_t *buff,
+				   uint32_t nb_samples)
+{
+	struct spi_engine_offload_message msg;
+	uint32_t bytes;
+	int32_t  ret;
+	uint32_t spi_eng_msg_cmds[1];
+
+	if (!desc)
+		return -1;
+
+	bytes = nb_samples * desc->iio_dev->num_ch *
+		(desc->iio_dev->channels[0].scan_type->storagebits / 8);
+
+	spi_eng_msg_cmds[0] = READ(4);
+
+	msg.commands = spi_eng_msg_cmds;
+	msg.no_commands = NO_OS_ARRAY_SIZE(spi_eng_msg_cmds);
+	msg.commands_data = NULL;
+	msg.rx_addr = (uint32_t)buff;
+	msg.tx_addr = (uint32_t)NULL;
+
+	if (desc->dcache_invalidate_range)
+		desc->dcache_invalidate_range(msg.rx_addr, bytes);
+
+	ret = spi_engine_offload_transfer(desc->spi_eng_desc, msg, bytes);
+	if (ret < 0)
+		return ret;
+
+	if (desc->dcache_invalidate_range)
+		desc->dcache_invalidate_range(msg.rx_addr, bytes);
+
+	return nb_samples;
+}
+
+/**
+ * @brief Allocate memory for AD713x IIO handler.
+ * @param desc - Pointer to the IIO device structure.
+ * @param param - Pointer to the initialization structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int iio_ad713x_init(struct ad713x_iio **desc,
+		    struct ad713x_iio_init_param *param)
+{
+	struct ad713x_iio *device;
+	int32_t ret;
+	uint8_t reg_data;
+	uint64_t odr_mult, odr_ref = 24000000000000ULL, rest;
+	int i;
+
+	if (!param)
+		return -EINVAL;
+
+	device = (struct ad713x_iio *)calloc(1, sizeof(*device));
+	if (!device)
+		return -1;
+
+	device->drv_dev = param->drv_dev;
+	device->iio_dev = param->iio_dev;
+	device->spi_eng_desc = param->spi_eng_desc;
+	device->vref_int = param->vref_int;
+	device->vref_micro = param->vref_micro;
+	device->dcache_invalidate_range = param->dcache_invalidate_range;
+
+	for (i = 0; i < 7; i++) {
+		ret = ad713x_spi_reg_read(device->drv_dev,
+					  AD713X_REG_ODR_VAL_INT_LSB + i, &reg_data);
+		if (ret < 0)
+			goto dev_err;
+		if (i < 3)
+			device->odr_int |= reg_data << (8 * i);
+		else
+			device->odr_flt |= reg_data << (8 * (i - 3));
+	}
+	device->odr_flt = _ad713x_odr_htoi_float_conversion(device->odr_flt);
+	odr_mult = no_os_mul_u32_u32(device->odr_int, MEGA) + device->odr_flt;
+	rest = no_os_do_div(&odr_ref, odr_mult);
+	rest *= MEGA;
+	no_os_do_div(&rest, odr_mult);
+	device->odr_int = odr_ref;
+	device->odr_flt = rest;
+
+	*desc = device;
+
+	return 0;
+dev_err:
+	free(device);
+
+	return ret;
+}
+
+/**
+ * @brief Free memory allocated by iio_ad713x_init().
+ * @param desc - Pointer to the IIO device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int iio_ad713x_remove(struct ad713x_iio *desc)
+{
+	if (!desc)
+		return -EINVAL;
+
+	free(desc);
+
+	return 0;
+}
+
 struct iio_device ad713x_iio_desc = {
+	.num_ch = NO_OS_ARRAY_SIZE(ad713x_channels),
+	.channels = ad713x_channels,
+	.attributes = channel_attributes,
+	.debug_attributes = NULL,
+	.buffer_attributes = NULL,
+	.read_dev = (int32_t (*)())ad713x_iio_read_dev,
+	.write_dev = NULL,
+	.pre_enable = (int32_t (*)())ad713x_iio_prepare_transfer,
+	.post_disable = NULL,
+	.submit = NULL,
 	.debug_reg_read = (int32_t (*)()) ad713x_spi_reg_read,
 	.debug_reg_write = (int32_t (*)()) ad713x_spi_reg_write
 };

--- a/drivers/adc/ad713x/iio_ad713x.h
+++ b/drivers/adc/ad713x/iio_ad713x.h
@@ -46,12 +46,41 @@
 /******************************************************************************/
 
 #include "iio_types.h"
+#include "no_os_spi.h"
 
 /******************************************************************************/
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
+struct ad713x_iio;
+
+/**
+ * @struct ad713x_iio_init_param
+ * @brief AD713x IIO initialization structure
+ */
+struct ad713x_iio_init_param {
+	/** AD713x driver handler */
+	struct ad713x_dev *drv_dev;
+	/** Generic IIO device handler */
+	struct iio_device *iio_dev;
+	/** Integer part of the VREF */
+	uint32_t vref_int;
+	/** Decimal part of the VREF */
+	uint32_t vref_micro;
+	/** SPI Engine driver handler */
+	struct no_os_spi_desc *spi_eng_desc;
+	/** Invalidate the Data cache for the given address range */
+	void (*dcache_invalidate_range)(uint32_t address, uint32_t bytes_count);
+};
+
 extern struct iio_device ad713x_iio_desc;
+
+/** Allocate memory for AD713x IIO handler. */
+int iio_ad713x_init(struct ad713x_iio **desc,
+		    struct ad713x_iio_init_param *param);
+
+/** Free memory allocated by iio_ad713x_init(). */
+int iio_ad713x_remove(struct ad713x_iio *desc);
 
 #endif /* IIO_SUPPORT */
 

--- a/projects/cn0561/Makefile
+++ b/projects/cn0561/Makefile
@@ -1,0 +1,5 @@
+include ../../tools/scripts/generic_variables.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/cn0561/builds.json
+++ b/projects/cn0561/builds.json
@@ -1,0 +1,20 @@
+{
+  "xilinx": {
+    "iio_zed": {
+      "flags" : "TINYIIOD=y NEW_CFLAGS=-DCN0561_ZED_CARRIER",
+      "hardware" : ["cn0561_fmc_zed"]
+    },
+    "uart_zed": {
+      "flags" : "NEW_CFLAGS=-DCN0561_ZED_CARRIER",
+      "hardware" : ["cn0561_fmc_zed"]
+    },
+    "iio_cora": {
+      "flags" : "TINYIIOD=y NEW_CFLAGS=-DCN0561_CORAZ7S_CARRIER",
+      "hardware" : ["cn0561_ard_cora"]
+    },
+    "uart_cora": {
+      "flags" : "NEW_CFLAGS=-DCN0561_CORAZ7S_CARRIER",
+      "hardware" : ["cn0561_ard_cora"]
+    }
+  }
+}

--- a/projects/cn0561/src.mk
+++ b/projects/cn0561/src.mk
@@ -1,0 +1,58 @@
+################################################################################
+#									       #
+#     Shared variables:							       #
+#	- PROJECT							       #
+#	- DRIVERS							       #
+#	- INCLUDE							       #
+#	- PLATFORM_DRIVERS						       #
+#	- NO-OS								       #
+#									       #
+################################################################################
+
+SRC_DIRS += $(PROJECT)/src
+SRC_DIRS += $(DRIVERS)/adc/ad713x
+
+SRCS += $(DRIVERS)/api/no_os_spi.c \
+	$(DRIVERS)/api/no_os_gpio.c \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+	$(DRIVERS)/axi_core/spi_engine/spi_engine.c \
+	$(DRIVERS)/axi_core/axi_pwmgen/axi_pwm.c \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
+	$(NO-OS)/util/no_os_util.c \
+	$(NO-OS)/util/no_os_lf256fifo.c
+SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_gpio.c \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_spi.c \
+	$(PLATFORM_DRIVERS)/delay.c
+ifeq (y,$(strip $(TINYIIOD)))
+LIBRARIES += iio
+SRC_DIRS += $(NO-OS)/iio/iio_app
+SRCS += $(PLATFORM_DRIVERS)/no_os_uart.c \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c \
+	$(DRIVERS)/api/no_os_irq.c \
+	$(NO-OS)/util/no_os_fifo.c \
+	$(NO-OS)/util/no_os_list.c	
+endif
+INCS += $(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
+	$(DRIVERS)/axi_core/axi_pwmgen/axi_pwm_extra.h \
+	$(DRIVERS)/axi_core/spi_engine/spi_engine.h \
+	$(DRIVERS)/axi_core/spi_engine/spi_engine_private.h \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h
+INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/gpio_extra.h
+INCS +=	$(INCLUDE)/no_os_axi_io.h \
+	$(INCLUDE)/no_os_spi.h \
+	$(INCLUDE)/no_os_gpio.h \
+	$(INCLUDE)/no_os_error.h \
+	$(INCLUDE)/no_os_delay.h \
+	$(INCLUDE)/no_os_irq.h \
+	$(INCLUDE)/no_os_uart.h \
+	$(INCLUDE)/no_os_pwm.h \
+	$(INCLUDE)/no_os_util.h \
+	$(INCLUDE)/no_os_lf256fifo.h
+ifeq (y,$(strip $(TINYIIOD)))
+INCS += $(INCLUDE)/no_os_fifo.h \
+	$(INCLUDE)/no_os_list.h
+endif

--- a/projects/cn0561/src/README.md
+++ b/projects/cn0561/src/README.md
@@ -1,0 +1,11 @@
+This is a temporary project structure. The project uses a pecific vrsion of the
+platform drivers and SPI Engine drivers
+and will be updated to master status as soon as possible.
+
+To run the application:
+1. Make a SDK project using the AD7134_FMC HDF got from building the
+correspondent HDL source.
+2. Copy sources in this folder into the source folder of the project.
+3. Copy the device driver from the folder [no-OS_root]/drivers/adc/ad713x to the
+source folder of the project.
+

--- a/projects/cn0561/src/cn0561.c
+++ b/projects/cn0561/src/cn0561.c
@@ -1,0 +1,286 @@
+/***************************************************************************//**
+* @file cn0561.c
+* @brief Implementation of Main Function.
+* @authors Andrei Drimbarean (andrei.drimbarean@analog.com)
+********************************************************************************
+* Copyright 2022(c) Analog Devices, Inc.
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+* - Redistributions of source code must retain the above copyright
+* notice, this list of conditions and the following disclaimer.
+* - Redistributions in binary form must reproduce the above copyright
+* notice, this list of conditions and the following disclaimer in
+* the documentation and/or other materials provided with the
+* distribution.
+* - Neither the name of Analog Devices, Inc. nor the names of its
+* contributors may be used to endorse or promote products derived
+* from this software without specific prior written permission.
+* - The use of this software may or may not infringe the patent rights
+* of one or more patent holders. This license does not release you
+* from the requirement that you obtain separate licenses from these
+* patent holders to use this software.
+* - Use of the software either in source or binary form, must be run
+* on or directly connected to an Analog Devices Inc. component.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdio.h>
+#include <sleep.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <xil_cache.h>
+#include <xparameters.h>
+#include <math.h>
+#include "xil_printf.h"
+#include "spi_engine.h"
+#include "ad713x.h"
+#include "no_os_spi.h"
+#include "spi_extra.h"
+#include "no_os_delay.h"
+#include "no_os_gpio.h"
+#include "gpio_extra.h"
+#include "no_os_util.h"
+#include "no_os_error.h"
+#include "parameters.h"
+#include "no_os_pwm.h"
+#include "axi_pwm_extra.h"
+#include "clk_axi_clkgen.h"
+#include "axi_dmac.h"
+
+#ifdef IIO_SUPPORT
+#include "no_os_irq.h"
+#include "irq_extra.h"
+#include "no_os_uart.h"
+#include "uart_extra.h"
+#include "iio_ad713x.h"
+#include "iio.h"
+#include "iio_app.h"
+#endif // IIO_SUPPORT
+
+static uint32_t adc_buffer[ADC_BUFFER_SIZE] __attribute__((aligned));
+
+int main()
+{
+	struct axi_clkgen *clkgen_cn0561;
+	struct axi_clkgen_init clkgen_cn0561_init = {
+		.base = XPAR_AXI_CN0561_CLKGEN_BASEADDR,
+		.name = "cn0561_clkgen",
+		.parent_rate = 100000000
+	};
+	struct ad713x_dev *cn0561_dev;
+	struct ad713x_init_param cn0561_init_param;
+	uint32_t i = 0, j;
+	int32_t ret;
+	const float lsb = 4.096 / (pow(2, 23));
+	float data;
+	uint32_t spi_eng_dma_flg = DMA_LAST | DMA_PARTIAL_REPORTING_EN;
+	struct spi_engine_offload_init_param spi_engine_offload_init_param;
+	struct spi_engine_offload_message spi_engine_offload_message;
+	uint32_t spi_eng_msg_cmds[1];
+	static struct xil_spi_init_param spi_engine_init_params = {
+		.type = SPI_PS,
+	};
+	struct xil_gpio_init_param gpio_extra_param;
+	struct no_os_gpio_init_param cn0561_pnd = {
+		.number = GPIO_PDN,
+		.platform_ops = &xil_gpio_ops,
+		.extra = &gpio_extra_param
+	};
+#ifdef CN0561_ZED_CARRIER
+	struct no_os_gpio_init_param cn0561_mode = {
+		.number = GPIO_MODE,
+		.platform_ops = &xil_gpio_ops,
+		.extra = &gpio_extra_param
+	};
+	struct no_os_gpio_init_param cn0561_resetn = {
+		.number = GPIO_RESETN,
+		.platform_ops = &xil_gpio_ops,
+		.extra = &gpio_extra_param
+	};
+#endif
+	struct no_os_spi_desc *spi_eng_desc;
+	struct spi_engine_init_param spi_eng_init_param  = {
+		.type = SPI_ENGINE,
+		.spi_engine_baseaddr = CN0561_SPI_ENGINE_BASEADDR,
+		.cs_delay = 0,
+		.data_width = 32,
+		.ref_clk_hz = CN0561_SPI_ENG_REF_CLK_FREQ_HZ
+	};
+	const struct no_os_spi_init_param spi_eng_init_prm  = {
+		.chip_select = CN0561_SPI_CS,
+		.max_speed_hz = 24000000,
+		.mode = NO_OS_SPI_MODE_1,
+		.platform_ops = &spi_eng_platform_ops,
+		.extra = (void*)&spi_eng_init_param,
+	};
+
+	struct no_os_pwm_desc *axi_pwm;
+	struct axi_pwm_init_param axi_zed_pwm_init = {
+		.base_addr = XPAR_ODR_GENERATOR_BASEADDR,
+		.ref_clock_Hz = 100000000,
+		.channel = 0
+	};
+
+	struct no_os_pwm_init_param axi_pwm_init = {
+		.period_ns = 3400,
+		.duty_cycle_ns = 600,
+		.phase_ns = 0,
+		.extra = &axi_zed_pwm_init
+	};
+
+	gpio_extra_param.device_id = GPIO_DEVICE_ID;
+	gpio_extra_param.type = GPIO_PS;
+
+	cn0561_init_param.adc_data_len = ADC_24_BIT_DATA;
+	cn0561_init_param.clk_delay_en = false;
+	cn0561_init_param.crc_header = CRC_6;
+	cn0561_init_param.dev_id = ID_AD4134;
+	cn0561_init_param.format = QUAD_CH_PO;
+	cn0561_init_param.gpio_dclkio = NULL;
+	cn0561_init_param.gpio_dclkmode = NULL;
+	cn0561_init_param.gpio_pnd = &cn0561_pnd;
+#ifdef CN0561_ZED_CARRIER
+	cn0561_init_param.gpio_mode = &cn0561_mode;
+	cn0561_init_param.gpio_resetn = &cn0561_resetn;
+#else
+	cn0561_init_param.gpio_mode = NULL;
+	cn0561_init_param.gpio_resetn = NULL;
+#endif
+	cn0561_init_param.mode_master_nslave = false;
+	cn0561_init_param.dclkmode_free_ngated = false;
+	cn0561_init_param.dclkio_out_nin = false;
+	cn0561_init_param.pnd = true;
+	cn0561_init_param.spi_init_prm.chip_select = CN0561_SPI_CS;
+	cn0561_init_param.spi_init_prm.device_id = SPI_DEVICE_ID;
+	cn0561_init_param.spi_init_prm.max_speed_hz = 1000000;
+	cn0561_init_param.spi_init_prm.mode = NO_OS_SPI_MODE_0;
+	cn0561_init_param.spi_init_prm.platform_ops = &xil_spi_ops;
+	cn0561_init_param.spi_init_prm.extra = (void *)&spi_engine_init_params;
+	cn0561_init_param.spi_common_dev = 0;
+
+	spi_eng_msg_cmds[0] = READ(4);
+
+	Xil_ICacheEnable();
+	Xil_DCacheEnable();
+
+	ret = axi_clkgen_init(&clkgen_cn0561, &clkgen_cn0561_init);
+	if (ret != 0)
+		return -1;
+
+	ret = axi_clkgen_set_rate(clkgen_cn0561, CN0561_SPI_ENG_REF_CLK_FREQ_HZ);
+	if (ret != 0)
+		return -1;
+
+	ret = no_os_pwm_init(&axi_pwm, &axi_pwm_init);
+	if (ret != 0)
+		return ret;
+
+	ret = ad713x_init(&cn0561_dev, &cn0561_init_param);
+	if (ret != 0)
+		return -1;
+
+	no_os_mdelay(1000);
+
+	ret = ad713x_spi_reg_write(cn0561_dev, AD713X_REG_GPIO_DIR_CTRL, 0xE7);
+	if (ret != 0)
+		return -1;
+	ret = ad713x_spi_reg_write(cn0561_dev, AD713X_REG_GPIO_DATA, 0x84);
+	if (ret != 0)
+		return -1;
+
+	spi_engine_offload_init_param.rx_dma_baseaddr = CN0561_DMA_BASEADDR;
+	spi_engine_offload_init_param.offload_config = OFFLOAD_RX_EN;
+	spi_engine_offload_init_param.dma_flags = &spi_eng_dma_flg;
+
+	ret = no_os_spi_init(&spi_eng_desc, &spi_eng_init_prm);
+	if (ret != 0)
+		return -1;
+
+	ret = spi_engine_offload_init(spi_eng_desc, &spi_engine_offload_init_param);
+	if (ret != 0)
+		return -1;
+
+	spi_engine_offload_message.commands = spi_eng_msg_cmds;
+	spi_engine_offload_message.no_commands = NO_OS_ARRAY_SIZE(spi_eng_msg_cmds);
+	spi_engine_offload_message.commands_data = NULL;
+	spi_engine_offload_message.rx_addr = (uint32_t)adc_buffer;
+	spi_engine_offload_message.tx_addr = 0xA000000;
+
+#ifdef IIO_SUPPORT
+	struct iio_data_buffer rd_buff = {
+		.buff = (void *)adc_buffer,
+		.size = ADC_BUFFER_SIZE
+	};
+	struct ad713x_iio *iio_desc;
+	struct ad713x_iio_init_param iio_desc_param = {
+		.drv_dev = cn0561_dev,
+		.vref_int = 4,
+		.vref_micro = 96000,
+		.spi_eng_desc = spi_eng_desc,
+		.dcache_invalidate_range =
+		(void (*)(uint32_t,  uint32_t))Xil_DCacheInvalidateRange,
+		.iio_dev = &ad713x_iio_desc
+	};
+
+	ret = iio_ad713x_init(&iio_desc, &iio_desc_param);
+	if (ret < 0)
+		return ret;
+
+	struct iio_app_device devices[] = {
+		IIO_APP_DEVICE("ad4134", iio_desc, &ad713x_iio_desc,
+			       &rd_buff, NULL),
+	};
+
+	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+
+#endif /* IIO_SUPPORT */
+
+	ret = spi_engine_offload_transfer(spi_eng_desc, spi_engine_offload_message,
+					  (CN0561_FMC_CH_NO * CN0561_FMC_SAMPLE_NO));
+	if (ret != 0)
+		return ret;
+
+	Xil_DCacheInvalidateRange((INTPTR)adc_buffer,
+				  CN0561_FMC_SAMPLE_NO * CN0561_FMC_CH_NO *
+				  sizeof(uint32_t));
+
+	for(i = 0; i < CN0561_FMC_SAMPLE_NO; i++) {
+		j = 0;
+		printf("%lu: ", i);
+		while(j < CN0561_FMC_CH_NO) {
+			adc_buffer[CN0561_FMC_CH_NO*i+j] &= 0xffffff00;
+			adc_buffer[CN0561_FMC_CH_NO*i+j] >>= 8;
+			data = lsb * (int32_t)adc_buffer[CN0561_FMC_CH_NO*i+j];
+			if(data > 4.095)
+				data = data - 8.192;
+			printf("CH%lu: 0x%08lx = %+1.5fV ", j,
+			       adc_buffer[CN0561_FMC_CH_NO*i+j], data);
+			if(j == (CN0561_FMC_CH_NO - 1))
+				printf("\n");
+			j++;
+		}
+	}
+
+	ad713x_remove(cn0561_dev);
+	print("Bye\n\r");
+
+	return 0;
+}

--- a/projects/cn0561/src/parameters.h
+++ b/projects/cn0561/src/parameters.h
@@ -1,0 +1,85 @@
+/***************************************************************************//**
+ *   @file   parameters.h
+ *   @brief  Parameters Definitions.
+ *   @author Mihail Chindris (mihail.chindris@analog.com)
+********************************************************************************
+ * Copyright 2021(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <xparameters.h>
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+#define SPI_DEVICE_ID			XPAR_PS7_SPI_0_DEVICE_ID
+#define GPIO_DEVICE_ID			XPAR_PS7_GPIO_0_DEVICE_ID
+#define CN0561_DMA_BASEADDR		XPAR_AXI_CN0561_DMA_BASEADDR
+#define CN0561_SPI_ENGINE_BASEADDR	XPAR_CN0561_SPI_AXI_BASEADDR
+#define CN0561_SPI_ENG_REF_CLK_FREQ_HZ	96000000
+#define CN0561_SPI_CS			0
+#define GPIO_DEVICE_ID			XPAR_PS7_GPIO_0_DEVICE_ID
+#define GPIO_OFFSET			54
+#define GPIO_RESETN			GPIO_OFFSET + 32
+#define GPIO_PDN			GPIO_OFFSET + 33
+#define GPIO_MODE			GPIO_OFFSET + 34
+#define GPIO_PINBSPI		GPIO_OFFSET + 35
+#define GPIO_0				GPIO_OFFSET + 36
+#define GPIO_1				GPIO_OFFSET + 37
+#define GPIO_2				GPIO_OFFSET + 38
+#define GPIO_4				GPIO_OFFSET + 39
+#define GPIO_5				GPIO_OFFSET + 40
+#define GPIO_6				GPIO_OFFSET + 41
+#define GPIO_7				GPIO_OFFSET + 42
+#define CN0561_FMC_CH_NO		4
+#define CN0561_FMC_SAMPLE_NO	256
+
+#define ADC_BUFFER_SIZE			1000000
+
+//#define CN0561_CORAZ7S_CARRIER
+//#define CN0561_ZED_CARRIER
+
+#ifdef IIO_SUPPORT
+#define UART_BAUDRATE			115200
+#define UART_DEVICE_ID			XPAR_XUARTPS_0_DEVICE_ID
+#define UART_IRQ_ID				XPAR_XUARTPS_0_INTR
+#define INTC_DEVICE_ID			XPAR_SCUGIC_SINGLE_DEVICE_ID
+#endif // IIO_SUPPORT
+
+#endif /* __PARAMETERS_H__ */


### PR DESCRIPTION
Changes this patch:
 - add support for AD4134 to the AD713x driver;
 - add AD7134/AD4134 IIO driver;
 - add cn0561 support for Cora Z7 and Zed board carriers.