### PR TITLE
split_gain_table_abs_gain uint8_t -> int8_t

### DIFF
--- a/drivers/rf-transceiver/ad9361/ad9361.c
+++ b/drivers/rf-transceiver/ad9361/ad9361.c
@@ -574,7 +574,7 @@ static const uint8_t split_gain_table[RXGAIN_TBLS_END][SIZE_SPLIT_TABLE][3] = {
 	}
 };
 
-static const uint8_t
+static const int8_t
 split_gain_table_abs_gain[RXGAIN_TBLS_END][SIZE_SPLIT_TABLE] = {
 	{  /* 800 MHz */
 		-1, -1, -1, -1, -1, -1, -1, 2,


### PR DESCRIPTION
The table contains negative error codes which generates warnings.

https://ez.analog.com/microcontroller-no-os-drivers/f/q-a/556832/compiler-warning-integer-conversion-resulted-in-a-change-of-sign-in-no-os-drivers