### PR TITLE
projects:eval-adxl355-pmdz: Add support for UART RX interrupt usage

### DIFF
--- a/projects/eval-adxl355-pmdz/sdp-ck1z.ioc
+++ b/projects/eval-adxl355-pmdz/sdp-ck1z.ioc
@@ -36,6 +36,7 @@ NVIC.PendSV_IRQn=true\:0\:0\:false\:false\:true\:false\:false
 NVIC.PriorityGroup=NVIC_PRIORITYGROUP_4
 NVIC.SVCall_IRQn=true\:0\:0\:false\:false\:true\:false\:false
 NVIC.SysTick_IRQn=true\:0\:0\:false\:false\:true\:false\:true
+NVIC.UART5_IRQn=true\:0\:0\:false\:false\:true\:true\:true
 NVIC.UsageFault_IRQn=true\:0\:0\:false\:false\:true\:false\:false
 PA15.GPIOParameters=GPIO_Speed,GPIO_Label
 PA15.GPIO_Label=ADXL355_CS

--- a/projects/eval-adxl355-pmdz/src/platform/stm32/parameters.h
+++ b/projects/eval-adxl355-pmdz/src/platform/stm32/parameters.h
@@ -56,7 +56,7 @@ extern UART_HandleTypeDef huart5;
 
 #ifdef IIO_SUPPORT
 #define IIO_APP_HUART	(&huart5)
-#define UART_IRQ_ID	0
+#define UART_IRQ_ID     UART5_IRQn
 #endif
 #define UART_DEVICE_ID      5
 #define UART_BAUDRATE  115200


### PR DESCRIPTION
Add support for UART RX interrupt usage since by default iio_app is using .asynchronous_rx = true.

Signed-off-by: Ramona Bolboaca <ramona.bolboaca@analog.com>