### PR TITLE
projects:iio_adpd1080: implement sample rate increase

### DIFF
--- a/projects/iio_adpd1080/src/main.c
+++ b/projects/iio_adpd1080/src/main.c
@@ -397,6 +397,10 @@ int main(void)
 	if(status != 0)
 		return -1;
 
+	status = adpd188_adc_fsample_set(adpd1080_iio_device->drv_dev, 512.0);
+	if(status != 0)
+		return -1;
+
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("adpd1080", adpd1080_iio_device, &iio_adpd188_device,
 			       &iio_adpd1080_read_buff, NULL)


### PR DESCRIPTION
Increase sample rate in firmware as opposed to pyadi application to work
around IIOD UART bug. This change can be reverted after the IIOD bug is
solved, but will work after that as well and is functionally correct.

Signed-off-by: Andrei Drimbarean <Andrei.Drimbarean@analog.com>