### PR TITLE
drivers:platform:xilinx:xilinx_i2c.c NO_OS_ typo correction

### DIFF
--- a/drivers/platform/xilinx/xilinx_i2c.c
+++ b/drivers/platform/xilinx/xilinx_i2c.c
@@ -256,9 +256,9 @@ pl_error:
 
 		tab_check_ps.device_id = xdesc->device_id;
 
-		if (!NO_OS_NO_OS_IS_ERR_VALUE(no_os_list_read_find(ps_list,
-					      (void **)&temp_el_ps,
-					      &tab_check_ps))) {
+		if (!NO_OS_IS_ERR_VALUE(no_os_list_read_find(ps_list,
+					(void **)&temp_el_ps,
+					&tab_check_ps))) {
 			xdesc->instance = temp_el_ps->instance;
 			temp_el_ps->inst_no++;
 			break;


### PR DESCRIPTION
The removal of the NO_OS_ prefix that was added two times for
the NO_OS_IS_ERR_VALUE macro.

Signed-off-by: George Mois <george.mois@analog.com>