### PR TITLE
IIO Trigger now support with example on EVAL-ADXL355-PMDZ

### DIFF
--- a/drivers/accel/adxl355/adxl355.c
+++ b/drivers/accel/adxl355/adxl355.c
@@ -201,7 +201,7 @@ error_com:
 	else
 		no_os_i2c_remove(dev->com_desc.i2c_desc);
 	free(dev);
-	return ret;
+	return -1;
 error_dev:
 	free(dev);
 	return ret;

--- a/drivers/accel/adxl355/iio_adxl355.h
+++ b/drivers/accel/adxl355/iio_adxl355.h
@@ -51,7 +51,7 @@
 #define TRIG_MAX_NAME_SIZE 20
 
 extern struct iio_trigger adxl355_iio_trigger_desc;
-
+extern struct iio_trigger adxl355_iio_software_trigger_desc;
 /******************************************************************************/
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
@@ -81,6 +81,11 @@ struct adxl355_iio_trig_init_param {
 	const char                  *name;
 };
 
+struct adxl355_iio_sw_trig_init_param {
+	struct iio_desc	**iio_desc;
+	const char      *name;
+};
+
 /******************************************************************************/
 /************************ Functions Declarations ******************************/
 /******************************************************************************/
@@ -91,6 +96,8 @@ int adxl355_iio_remove(struct adxl355_iio_dev *desc);
 
 int iio_adxl355_trigger_init(struct adxl355_iio_trig **iio_trig,
 			     struct adxl355_iio_trig_init_param *init_param);
+int iio_adxl355_software_trigger_init(struct adxl355_iio_trig **iio_trig,
+				      struct adxl355_iio_sw_trig_init_param *init_param);
 
 void iio_adxl355_trigger_remove(struct adxl355_iio_trig *trig);
 

--- a/drivers/accel/adxl355/iio_adxl355_trig.c
+++ b/drivers/accel/adxl355/iio_adxl355_trig.c
@@ -151,14 +151,18 @@ int iio_adxl355_trigger_init(struct adxl355_iio_trig **iio_trig,
 	struct adxl355_iio_trig *trig_desc;
 	int ret;
 
+	if (!init_param->iio_desc || !init_param->name)
+		return  -EINVAL;
+
 	trig_desc = (struct adxl355_iio_trig*)calloc(1, sizeof(*trig_desc));
 	if (!trig_desc)
 		return -ENOMEM;
 
 	trig_desc->iio_desc = init_param->iio_desc;
-	trig_desc->irq_init_param = init_param->irq_init_param;
+
 	strncpy(trig_desc->name, init_param->name, TRIG_MAX_NAME_SIZE);
 
+	trig_desc->irq_init_param = init_param->irq_init_param;
 	trig_desc->irq_ctrl = init_param->irq_ctrl;
 
 	struct no_os_callback_desc adxl355_int_cb = {

--- a/drivers/accel/adxl355/iio_adxl355_trig.c
+++ b/drivers/accel/adxl355/iio_adxl355_trig.c
@@ -207,6 +207,8 @@ int iio_adxl355_software_trigger_init(struct adxl355_iio_trig **iio_trig,
 		return  -EINVAL;
 
 	trig_desc = (struct adxl355_iio_trig*)calloc(1, sizeof(*trig_desc));
+	if (!trig_desc)
+		return -ENOMEM;
 
 	trig_desc->iio_desc = init_param->iio_desc;
 

--- a/iio/iio_types.h
+++ b/iio/iio_types.h
@@ -212,6 +212,8 @@ struct iio_device_data {
 };
 
 struct iio_trigger {
+	/** If true the trigger handler will be called in interrupt context
+	 *  If false the handler will be called from iio_step */
 	bool is_synchronous;
 	/** Array of attributes. Last one should have its name set to NULL */
 	struct iio_attribute *attributes;

--- a/projects/eval-adxl355-pmdz/src/common/common_data.c
+++ b/projects/eval-adxl355-pmdz/src/common/common_data.c
@@ -67,6 +67,10 @@ struct adxl355_iio_trig_init_param adxl355_iio_trig_user_init = {
 	.irq_init_param = &adxl355_int_ip,
 	.name = IIO_ADXL355_TRIGGER_NAME,
 };
+
+struct adxl355_iio_sw_trig_init_param adxl355_iio_sw_trig_user_init = {
+	.name = IIO_ADXL355_SW_TRIGGER_NAME,
+};
 #endif
 
 struct no_os_spi_init_param sip = {

--- a/projects/eval-adxl355-pmdz/src/common/common_data.h
+++ b/projects/eval-adxl355-pmdz/src/common/common_data.h
@@ -57,7 +57,9 @@ extern struct no_os_uart_init_param uip;
 
 #ifdef IIO_TRIGGER_EXAMPLE
 #define IIO_ADXL355_TRIGGER_NAME "adxl355-dev0"
+#define IIO_ADXL355_SW_TRIGGER_NAME "adxl355-sw-trig"
 extern struct adxl355_iio_trig_init_param adxl355_iio_trig_user_init;
+extern struct adxl355_iio_sw_trig_init_param adxl355_iio_sw_trig_user_init;
 #endif
 
 extern struct no_os_spi_init_param sip;

--- a/projects/eval-adxl355-pmdz/src/examples/iio_trigger_example/iio_trigger_example.c
+++ b/projects/eval-adxl355-pmdz/src/examples/iio_trigger_example/iio_trigger_example.c
@@ -69,6 +69,7 @@ int iio_trigger_example_main ()
 	int ret;
 
 	struct adxl355_iio_trig *adxl355_iio_trig;
+	struct adxl355_iio_trig *adxl355_iio_sw_trig;
 	struct adxl355_iio_dev *adxl355_iio_desc;
 	struct adxl355_iio_dev_init_param adxl355_iio_init_par;
 	struct no_os_irq_ctrl_desc *adxl355_irq_ctrl;
@@ -90,9 +91,16 @@ int iio_trigger_example_main ()
 		return ret;
 	adxl355_iio_trig_user_init.irq_ctrl = adxl355_irq_ctrl;
 
+	/* Initialize hardware trigger */
 	adxl355_iio_trig_user_init.iio_desc = &iio_desc,
 	iio_adxl355_trigger_init(&adxl355_iio_trig, &adxl355_iio_trig_user_init);
 
+	/* Initialize software trigger */
+	adxl355_iio_sw_trig_user_init.iio_desc = &iio_desc;
+	iio_adxl355_software_trigger_init(&adxl355_iio_sw_trig,
+					  &adxl355_iio_sw_trig_user_init);
+
+	/* List of devices */
 	struct iio_app_device iio_devices[] = {
 		{
 			.name = "adxl355",
@@ -102,9 +110,12 @@ int iio_trigger_example_main ()
 		}
 	};
 
+	/* List of triggers */
 	struct iio_trigger_init trigs[] = {
 		IIO_APP_TRIGGER(IIO_ADXL355_TRIGGER_NAME, adxl355_iio_trig,
-				&adxl355_iio_trigger_desc)
+				&adxl355_iio_trigger_desc),
+		IIO_APP_TRIGGER(IIO_ADXL355_SW_TRIGGER_NAME, adxl355_iio_sw_trig,
+				&adxl355_iio_software_trigger_desc)
 	};
 
 	return iio_app_run_with_trigs(iio_devices, NO_OS_ARRAY_SIZE(iio_devices),


### PR DESCRIPTION
- drivers:accel:adxl355 Moddified return value for error_com label 
- Added doxy comment for is_synchronous field from iio_trigger structure.
- Added null pointer check in iio_adxl355_trigger_init for init_param->iio_desc and init_param->name.
- Added IIO Trigger now support with example on EVAL-ADXL355-PMDZ
