### PR TITLE
fix stm32 uart read by returning -EAGAIN

### DIFF
--- a/drivers/platform/stm32/stm32_uart.c
+++ b/drivers/platform/stm32/stm32_uart.c
@@ -257,7 +257,7 @@ int32_t no_os_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
 		while(i < bytes_number) {
 			ret = lf256fifo_read(desc->rx_fifo, &data[i]);
 			if (ret < 0)
-				break;
+				return i ? i : -EAGAIN;
 			i++;
 		}
 		return i;


### PR DESCRIPTION
Two possible values may be returned here:
- 0 works ok for our iio implementation, but doesn't play well
  with stdio _read which expects negative error code here.
- -EAGAIN works well with both iio and stdio _read expected
  return values.

Therefore, use -EAGAIN.

Signed-off-by: Darius Berghe <darius.berghe@analog.com>