### PR TITLE
rtc: update desc and init param

### DIFF
--- a/drivers/platform/aducm3029/aducm3029_irq.c
+++ b/drivers/platform/aducm3029/aducm3029_irq.c
@@ -167,7 +167,7 @@ int32_t aducm3029_irq_register_callback(struct no_os_irq_ctrl_desc *desc,
 {
 	struct aducm_irq_ctrl_desc	*aducm_desc;
 	struct no_os_uart_desc		*uart_desc;
-	struct rtc_desc			*rtc_desc;
+	struct no_os_rtc_desc			*rtc_desc;
 	struct aducm_rtc_desc		*rtc_extra;
 	struct no_os_gpio_desc		*gpio_desc;
 	uint16_t			gpio_pin;
@@ -259,7 +259,7 @@ int32_t aducm3029_irq_unregister_callback(struct no_os_irq_ctrl_desc *desc,
 {
 	struct aducm_irq_ctrl_desc	*aducm_desc;
 	struct no_os_uart_desc		*uart_desc;
-	struct rtc_desc			*rtc_desc;
+	struct no_os_rtc_desc			*rtc_desc;
 	struct aducm_rtc_desc		*rtc_extra;
 	struct no_os_gpio_desc		*gpio_desc;
 	uint8_t i;

--- a/drivers/platform/aducm3029/irq_extra.h
+++ b/drivers/platform/aducm3029/irq_extra.h
@@ -110,7 +110,7 @@ enum irq_mode {
  */
 struct rtc_irq_config {
 	/** RTC driver handler */
-	struct rtc_desc *rtc_handler;
+	struct no_os_rtc_desc *rtc_handler;
 	/** Active interrupts OR'ed together */
 	uint32_t active_interrupts;
 };

--- a/drivers/platform/aducm3029/no_os_rtc.c
+++ b/drivers/platform/aducm3029/no_os_rtc.c
@@ -57,14 +57,14 @@
  * @param init_param - The structure that contains the RTC initialization.
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_rtc_init(struct rtc_desc **device,
-		       struct rtc_init_param *init_param)
+int32_t no_os_rtc_init(struct no_os_rtc_desc **device,
+		       struct no_os_rtc_init_param *init_param)
 {
 	int32_t ret;
-	struct rtc_desc *dev;
+	struct no_os_rtc_desc *dev;
 	struct aducm_rtc_desc *adev;
 
-	dev = (struct rtc_desc *)calloc(1, sizeof(*dev));
+	dev = (struct no_os_rtc_desc *)calloc(1, sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -119,7 +119,7 @@ error_dev:
  * @param dev - The RTC descriptor.
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_rtc_remove(struct rtc_desc *dev)
+int32_t no_os_rtc_remove(struct no_os_rtc_desc *dev)
 {
 	int32_t ret;
 	struct aducm_rtc_desc *adev = dev->extra;
@@ -140,7 +140,7 @@ int32_t no_os_rtc_remove(struct rtc_desc *dev)
  * @param dev - The RTC descriptor.
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_rtc_start(struct rtc_desc *dev)
+int32_t no_os_rtc_start(struct no_os_rtc_desc *dev)
 {
 	struct aducm_rtc_desc *adev;
 
@@ -156,7 +156,7 @@ int32_t no_os_rtc_start(struct rtc_desc *dev)
  * @param dev - The RTC descriptor.
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_rtc_stop(struct rtc_desc *dev)
+int32_t no_os_rtc_stop(struct no_os_rtc_desc *dev)
 {
 	struct aducm_rtc_desc *adev;
 
@@ -173,7 +173,7 @@ int32_t no_os_rtc_stop(struct rtc_desc *dev)
  * @param tmr_cnt - Pointer where the read counter will be stored.
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_rtc_get_cnt(struct rtc_desc *dev, uint32_t *tmr_cnt)
+int32_t no_os_rtc_get_cnt(struct no_os_rtc_desc *dev, uint32_t *tmr_cnt)
 {
 	struct aducm_rtc_desc *adev = dev->extra;
 
@@ -186,7 +186,7 @@ int32_t no_os_rtc_get_cnt(struct rtc_desc *dev, uint32_t *tmr_cnt)
  * @param tmr_cnt - New value of the timer counter.
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_rtc_set_cnt(struct rtc_desc *dev, uint32_t tmr_cnt)
+int32_t no_os_rtc_set_cnt(struct no_os_rtc_desc *dev, uint32_t tmr_cnt)
 {
 	struct aducm_rtc_desc *adev = dev->extra;
 

--- a/drivers/platform/maxim/maxim_rtc.c
+++ b/drivers/platform/maxim/maxim_rtc.c
@@ -100,11 +100,11 @@ void RTC_IRQHandler()
  * @param init_param - The structure that contains the RTC initialization.
  * @return 0 in case of success, errno codes otherwise.
  */
-int32_t no_os_rtc_init(struct rtc_desc **device,
-		       struct rtc_init_param *init_param)
+int32_t no_os_rtc_init(struct no_os_rtc_desc **device,
+		       struct no_os_rtc_init_param *init_param)
 {
 	int32_t ret;
-	struct rtc_desc *dev;
+	struct no_os_rtc_desc *dev;
 
 	if(!init_param)
 		return -EINVAL;
@@ -138,7 +138,7 @@ error:
  * @param dev - The RTC descriptor.
  * @return 0 in case of success, errno codes otherwise.
  */
-int32_t no_os_rtc_remove(struct rtc_desc *dev)
+int32_t no_os_rtc_remove(struct no_os_rtc_desc *dev)
 {
 	if (!dev)
 		return -EINVAL;
@@ -153,7 +153,7 @@ int32_t no_os_rtc_remove(struct rtc_desc *dev)
  * @param dev - The RTC descriptor.
  * @return 0 in case of success, errno codes otherwise.
  */
-int32_t no_os_rtc_start(struct rtc_desc *dev)
+int32_t no_os_rtc_start(struct no_os_rtc_desc *dev)
 {
 	MXC_RTC_Start();
 
@@ -169,7 +169,7 @@ int32_t no_os_rtc_start(struct rtc_desc *dev)
  * @param dev - The RTC descriptor.
  * @return 0 in case of success, errno codes otherwise.
  */
-int32_t no_os_rtc_stop(struct rtc_desc *dev)
+int32_t no_os_rtc_stop(struct no_os_rtc_desc *dev)
 {
 	int32_t ret;
 
@@ -186,7 +186,7 @@ int32_t no_os_rtc_stop(struct rtc_desc *dev)
  * @param tmr_cnt - Pointer where the read counter will be stored.
  * @return 0 in case of success, errno codes otherwise.
  */
-int32_t no_os_rtc_get_cnt(struct rtc_desc *dev, uint32_t *tmr_cnt)
+int32_t no_os_rtc_get_cnt(struct no_os_rtc_desc *dev, uint32_t *tmr_cnt)
 {
 	if (MXC_RTC_CheckBusy())
 		return -EBUSY;
@@ -202,7 +202,7 @@ int32_t no_os_rtc_get_cnt(struct rtc_desc *dev, uint32_t *tmr_cnt)
  * @param tmr_cnt - New value of the timer counter.
  * @return 0 in case of success, errno codes otherwise.
  */
-int32_t no_os_rtc_set_cnt(struct rtc_desc *dev, uint32_t tmr_cnt)
+int32_t no_os_rtc_set_cnt(struct no_os_rtc_desc *dev, uint32_t tmr_cnt)
 {
 	mxc_rtc_regs_t *rtc_regs;
 

--- a/include/no_os_rtc.h
+++ b/include/no_os_rtc.h
@@ -51,10 +51,10 @@
 /******************************************************************************/
 
 /**
- * @struct rtc_desc
+ * @struct no_os_rtc_desc
  * @brief Structure holding RTC descriptor.
  */
-struct rtc_desc {
+struct no_os_rtc_desc {
 	/** ID of the real time clock core. */
 	uint8_t id;
 	/** Frequency of the RTC */
@@ -66,10 +66,10 @@ struct rtc_desc {
 };
 
 /**
- * @struct rtc_init_param
+ * @struct no_os_rtc_init_param
  * @brief Structure holding RTC initialization parameters.
  */
-struct rtc_init_param {
+struct no_os_rtc_init_param {
 	/** ID of the real time clock core. */
 	uint8_t id;
 	/** Frequency of the RTC */
@@ -85,22 +85,22 @@ struct rtc_init_param {
 /******************************************************************************/
 
 /** Initialize the RTC peripheral. */
-int32_t no_os_rtc_init(struct rtc_desc **device,
-		       struct rtc_init_param *init_param);
+int32_t no_os_rtc_init(struct no_os_rtc_desc **device,
+		       struct no_os_rtc_init_param *init_param);
 
 /** Free the resources allocated by no_os_rtc_init(). */
-int32_t no_os_rtc_remove(struct rtc_desc *dev);
+int32_t no_os_rtc_remove(struct no_os_rtc_desc *dev);
 
 /** Start the real time clock. */
-int32_t no_os_rtc_start(struct rtc_desc *dev);
+int32_t no_os_rtc_start(struct no_os_rtc_desc *dev);
 
 /** Stop the real time clock. */
-int32_t no_os_rtc_stop(struct rtc_desc *dev);
+int32_t no_os_rtc_stop(struct no_os_rtc_desc *dev);
 
 /** Get the current count for the real time clock. */
-int32_t no_os_rtc_get_cnt(struct rtc_desc *dev, uint32_t *tmr_cnt);
+int32_t no_os_rtc_get_cnt(struct no_os_rtc_desc *dev, uint32_t *tmr_cnt);
 
 /** Set the current count for the real time clock. */
-int32_t no_os_rtc_set_cnt(struct rtc_desc *dev, uint32_t tmr_cnt);
+int32_t no_os_rtc_set_cnt(struct no_os_rtc_desc *dev, uint32_t tmr_cnt);
 
 #endif // _NO_OS_RTC_H_


### PR DESCRIPTION
Use `no_os_` prefix for the device description and initialization
structure.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>