### PR TITLE
scripts: util.tcl: Fix HEAP symbol

### DIFF
--- a/tools/scripts/platform/xilinx/util.tcl
+++ b/tools/scripts/platform/xilinx/util.tcl
@@ -36,10 +36,11 @@ proc _replace_heap {} {
 	set temp [open [lindex $temp_name] w+]
 
 	while {[gets $file line] >= 0} {
-		if {[string first _HEAP_SIZE $line ] != -1} {
-			puts $temp "_HEAP_SIZE = 0x100000;"
+		if {[string first "_HEAP_SIZE = DEFINED(_HEAP_SIZE)" $line ] != -1} {
+			puts $temp "_HEAP_SIZE = DEFINED(_HEAP_SIZE) ? _HEAP_SIZE : 0x100000;"
+		} else {
+			puts $temp $line
 		}
-		puts $temp $line
 	}
 
 	close $file


### PR DESCRIPTION
This change replaces the default value assigned by the
auto-generated linker script instead of redefining the HEAP variable.
This commit fixes the file format so it can be interpreted by Vitis's
linker script GUI.

Signed-off-by: Sergiu Cuciurean <sergiu.cuciurean@analog.com>