### PR TITLE
UART write blocking fix

### DIFF
--- a/drivers/platform/maxim/maxim_uart.c
+++ b/drivers/platform/maxim/maxim_uart.c
@@ -176,6 +176,8 @@ int32_t no_os_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
 		bytes_number -= written;
 	}
 
+	while(MXC_UART_GetTXFIFOAvailable(uart_regs) - MXC_UART_FIFO_DEPTH);
+
 	return total_written;
 }
 


### PR DESCRIPTION
This change makes the no_os_uart_write to return only when
all the bytes were transmitted. Before this, the function
only blocked until all the bytes were in the TX fifo, which
caused a problem when using a read_nonblocking after the
no_os_uart_write, since that flushes both TX and RX fifos.

Example:
```
uint8_t a[] = "123456789";
no_os_uart_write(uart, a, 9);
// ...
no_os_uart_read_nonblocking(...); // flushes the TX fifo, while just some bytes were transmitted
```

Signed-off-by: Ciprian Regus <ciprian.regus@analog.com>