### PR TITLE
Input parameter conditional checks always true

### DIFF
--- a/drivers/adc/ad9081/api/adi_ad9081_sync.c
+++ b/drivers/adc/ad9081/api/adi_ad9081_sync.c
@@ -359,7 +359,7 @@ int32_t adi_ad9081_jesd_sysref_irq_jitter_mux_set(adi_ad9081_device_t *device,
 	AD9081_NULL_POINTER_RETURN(device);
 	AD9081_LOG_FUNC();
 
-	if (pin != 0 || pin != 1) {
+	if (pin != 0 && pin != 1) {
 		return API_CMS_ERROR_INVALID_PARAM;
 	}
 

--- a/drivers/adc/ad9467/ad9467.c
+++ b/drivers/adc/ad9467/ad9467.c
@@ -633,7 +633,7 @@ int32_t ad9467_output_current_adj(struct ad9467_dev *dev,
 	int32_t ret = 0;
 	uint8_t read;
 
-	if((adj > 0) || (adj <= 7)) {
+	if((adj > 0) && (adj <= 7)) {
 		ret = ad9467_set_bits_to_reg(dev,
 					     AD9467_REG_OUT_ADJ,
 					     AD9467_OUT_ADJ_OUT_CURRENT(adj),


### PR DESCRIPTION
Super minor typos where some conditional statements are always true.

Fixes:
- On the AD9081, it will mask bits the LSB's and will set a new value, even if the input is out of range.
- On the AD9467, the jitter mux bit cannot be set and will always return API_CMS_ERROR_INVALID_PARAM.