### PR TITLE
build_projects.yml: add specific release timeout

### DIFF
--- a/build_projects.yml
+++ b/build_projects.yml
@@ -27,6 +27,7 @@ jobs:
                -builds_dir $(BUILDS_DIR)'
     displayName: 'Run project build'
   - task: PublishPipelineArtifact@1
+    timeoutInMinutes: 10
     condition: eq(variables.isMaster, true)
     inputs:
       targetPath: '$(Build.Repository.LocalPath)/$(RELEASE_DIR)'


### PR DESCRIPTION
The current timeout is around 1min and blocks the publishing of the
release artifacts in the releases section.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>