### PR TITLE
drivers: frequency: admv1014: add support

### DIFF
--- a/drivers/frequency/admv1014/admv1014.c
+++ b/drivers/frequency/admv1014/admv1014.c
@@ -1,0 +1,483 @@
+/***************************************************************************//**
+ *   @file   admv1014.c
+ *   @brief  Implementation of admv1014 Driver.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <malloc.h>
+#include "admv1014.h"
+#include "no_os_error.h"
+
+/******************************************************************************/
+/*************************** Variables Definition *****************************/
+/******************************************************************************/
+
+static const int mixer_vgate_table[] = {
+	106, 107, 108, 110, 111, 112, 113, 114,
+	117, 118, 119, 120, 122, 123, 44, 45
+};
+
+/******************************************************************************/
+/************************** Functions Implementation **************************/
+/******************************************************************************/
+
+/**
+ * @brief Writes data to ADMV1014 over SPI.
+ * @param dev - The device structure.
+ * @param reg_addr - The register address.
+ * @param data - Data value to write.
+ * @return Returns 0 in case of success or negative error code otherwise.
+ */
+int admv1014_spi_write(struct admv1014_dev *dev, uint8_t reg_addr,
+		       uint16_t data)
+{
+	uint8_t buff[ADMV1014_BUFF_SIZE_BYTES];
+
+	/*
+	    |                Byte 0           |     Byte 1     |       Byte 2        |
+	    | 0 | Addr bits 5-0 | Data bit 15 | Data bits 14-7 | Data bits 6 - 0 | 0 |
+	*/
+	buff[0] = ADMV1014_SPI_WRITE_CMD | (reg_addr << 1) | (data >> 15);
+	buff[1] = data >> 7;
+	buff[2] = data << 1;
+
+	return no_os_spi_write_and_read(dev->spi_desc, buff,
+					ADMV1014_BUFF_SIZE_BYTES);
+}
+
+/**
+ * @brief Reads data from ADMV1014 over SPI.
+ * @param dev - The device structure.
+ * @param reg_addr - The register address.
+ * @param data - Data read from the device.
+ * @return Returns 0 in case of success or negative error code otherwise.
+ */
+int admv1014_spi_read(struct admv1014_dev *dev, uint8_t reg_addr,
+		      uint16_t *data)
+{
+	uint8_t buff[ADMV1014_BUFF_SIZE_BYTES];
+	int ret;
+
+	buff[0] = ADMV1014_SPI_READ_CMD | (reg_addr << 1);
+	buff[1] = 0;
+	buff[2] = 0;
+
+	ret = no_os_spi_write_and_read(dev->spi_desc, buff, ADMV1014_BUFF_SIZE_BYTES);
+	if(ret)
+		return ret;
+
+	/*
+	    |                Byte 0           |     Byte 1     |       Byte 2        |
+	    | 1 | Addr bits 5-0 | Data bit 15 | Data bits 14-7 | Data bits 6 - 0 | 0 |
+	*/
+	*data = ((buff[0] & NO_OS_BIT(0)) << 15 | buff[1] << 7 | buff[2] >> 1);
+
+	return 0;
+}
+
+/**
+ * @brief Update ADMV1014 register.
+ * @param dev - The device structure.
+ * @param reg_addr - The register address.
+ * @param mask - Mask for specific register bits to be updated.
+ * @param data - Data written to the device (requires prior bit shifting).
+ * @return Returns 0 in case of success or negative error code otherwise.
+ */
+int admv1014_spi_update_bits(struct admv1014_dev *dev, uint8_t reg_addr,
+			     uint16_t mask, uint16_t data)
+{
+	uint16_t read_val;
+	int ret;
+
+	ret = admv1014_spi_read(dev, reg_addr, &read_val);
+	if (ret)
+		return ret;
+
+	read_val &= ~mask;
+	read_val |= data;
+
+	return admv1014_spi_write(dev, reg_addr, read_val);
+}
+
+/**
+ * @brief Set Digital Rx Detector
+ * @param dev - The device structure.
+ * @param det_prog - Digital Rx Detector gain.
+ * @return Returns 0 in case of success or negative error code.
+ */
+int admv1014_set_det_prog(struct admv1014_dev *dev,
+			  enum admv1014_det_prog det_prog)
+{
+	return admv1014_spi_update_bits(dev, ADMV1014_REG_MIXER,
+					ADMV1014_DET_PROG_MSK,
+					no_os_field_prep(ADMV1014_DET_PROG_MSK, det_prog));
+}
+
+/**
+ * @brief Get Digital Rx Detector
+ * @param dev - The device structure.
+ * @param det_prog - Digital Rx Detector gain.
+ * @return Returns 0 in case of success or negative error code.
+ */
+int admv1014_get_det_prog(struct admv1014_dev *dev,
+			  enum admv1014_det_prog *det_prog)
+{
+	uint16_t data;
+	int ret;
+
+	ret = admv1014_spi_read(dev, ADMV1014_REG_MIXER, &data);
+	if (ret)
+		return ret;
+
+	*det_prog = no_os_field_get(ADMV1014_DET_PROG_MSK, data);
+
+	return 0;
+}
+
+/**
+ * @brief Set Baseband Amp Gain
+ * @param dev - The device structure.
+ * @param gain - Digital Rx Detector gain.
+ * @return Returns 0 in case of success or negative error code.
+ */
+int admv1014_set_bb_amp_gain(struct admv1014_dev *dev, uint8_t gain)
+{
+	return admv1014_spi_update_bits(dev, ADMV1014_REG_BB_AMP_AGC,
+					ADMV1014_BB_AMP_GAIN_CTRL_MSK,
+					no_os_field_prep(ADMV1014_BB_AMP_GAIN_CTRL_MSK, gain));
+}
+
+/**
+ * @brief Get Baseband Amp Gain
+ * @param dev - The device structure.
+ * @param gain - Digital Rx Detector gain.
+ * @return Returns 0 in case of success or negative error code.
+ */
+int admv1014_get_bb_amp_gain(struct admv1014_dev *dev, uint8_t *gain)
+{
+	uint16_t data;
+	int ret;
+
+	ret = admv1014_spi_read(dev, ADMV1014_REG_BB_AMP_AGC, &data);
+	if (ret)
+		return ret;
+
+	*gain = no_os_field_get(ADMV1014_BB_AMP_GAIN_CTRL_MSK, data);
+
+	return 0;
+}
+
+/**
+ * @brief Set LO Amp Phase
+ * @param dev - The device structure.
+ * @param i_phase - The I phase adjust value.
+ * @param q_phase - The Q phase adjust value.
+ * @return Returns 0 in case of success or negative error code.
+ */
+int admv1014_set_phase(struct admv1014_dev *dev, uint8_t i_phase,
+		       uint8_t q_phase)
+{
+	return admv1014_spi_update_bits(dev, ADMV1014_REG_LO_AMP_PHASE_ADJUST1,
+					ADMV1014_LOAMP_PH_ADJ_I_FINE_MSK |
+					ADMV1014_LOAMP_PH_ADJ_Q_FINE_MSK,
+					no_os_field_prep(ADMV1014_LOAMP_PH_ADJ_I_FINE_MSK, i_phase) |
+					no_os_field_prep(ADMV1014_LOAMP_PH_ADJ_Q_FINE_MSK, q_phase));
+}
+
+/**
+ * @brief Get LO Amp Phase
+ * @param dev - The device structure.
+ * @param i_phase - The I phase adjust value.
+ * @param q_phase - The Q phase adjust value.
+ * @return Returns 0 in case of success or negative error code.
+ */
+int admv1014_get_phase(struct admv1014_dev *dev, uint8_t *i_phase,
+		       uint8_t *q_phase)
+{
+	uint16_t data;
+	int ret;
+
+	ret = admv1014_spi_read(dev, ADMV1014_REG_LO_AMP_PHASE_ADJUST1, &data);
+	if (ret)
+		return ret;
+
+	*i_phase = no_os_field_get(ADMV1014_LOAMP_PH_ADJ_I_FINE_MSK, data);
+	*q_phase = no_os_field_get(ADMV1014_LOAMP_PH_ADJ_Q_FINE_MSK, data);
+
+	return 0;
+}
+
+/**
+ * @brief Set IF Amp Gain
+ * @param dev - The device structure.
+ * @param i_coarse_gain - The I coarse gain value.
+ * @param q_coarse_gain - The I coarse gain value.
+ * @param i_fine_gain - The Q fine gain value.
+ * @param q_fine_gain - The Q fine gain value.
+ * @return Returns 0 in case of success or negative error code.
+ */
+int admv1014_set_if_amp_gain(struct admv1014_dev *dev, uint8_t i_coarse_gain,
+			     uint8_t q_coarse_gain, uint8_t i_fine_gain, uint8_t q_fine_gain)
+
+{
+	int ret;
+
+	ret = admv1014_spi_update_bits(dev, ADMV1014_REG_IF_AMP,
+				       ADMV1014_IF_AMP_COARSE_GAIN_I_MSK |
+				       ADMV1014_IF_AMP_FINE_GAIN_Q_MSK |
+				       ADMV1014_IF_AMP_FINE_GAIN_I_MSK,
+				       no_os_field_prep(ADMV1014_IF_AMP_COARSE_GAIN_I_MSK, i_coarse_gain) |
+				       no_os_field_prep(ADMV1014_IF_AMP_FINE_GAIN_Q_MSK, q_fine_gain) |
+				       no_os_field_prep(ADMV1014_IF_AMP_FINE_GAIN_I_MSK, i_fine_gain));
+	if (ret)
+		return ret;
+
+	return admv1014_spi_update_bits(dev, ADMV1014_REG_IF_AMP_BB_AMP,
+					ADMV1014_IF_AMP_COARSE_GAIN_Q_MSK,
+					no_os_field_prep(ADMV1014_IF_AMP_COARSE_GAIN_Q_MSK, q_coarse_gain));
+}
+
+/**
+ * @brief Get IF Amp Gain
+ * @param dev - The device structure.
+ * @param i_coarse_gain - The I coarse gain value.
+ * @param q_coarse_gain - The I coarse gain value.
+ * @param i_fine_gain - The Q fine gain value.
+ * @param q_fine_gain - The Q fine gain value.
+ * @return Returns 0 in case of success or negative error code.
+ */
+int admv1014_get_if_amp_gain(struct admv1014_dev *dev, uint8_t *i_coarse_gain,
+			     uint8_t *q_coarse_gain, uint8_t *i_fine_gain, uint8_t *q_fine_gain)
+{
+	uint16_t data;
+	int ret;
+
+	ret = admv1014_spi_read(dev, ADMV1014_REG_IF_AMP, &data);
+	if (ret)
+		return ret;
+
+	*i_coarse_gain = no_os_field_get(ADMV1014_IF_AMP_COARSE_GAIN_I_MSK, data);
+	*q_fine_gain = no_os_field_get(ADMV1014_IF_AMP_FINE_GAIN_Q_MSK, data);
+	*i_fine_gain = no_os_field_get(ADMV1014_IF_AMP_FINE_GAIN_I_MSK, data);
+
+	ret = admv1014_spi_read(dev, ADMV1014_REG_IF_AMP_BB_AMP, &data);
+	if (ret)
+		return ret;
+
+	*i_coarse_gain = no_os_field_get(ADMV1014_IF_AMP_COARSE_GAIN_Q_MSK, data);
+
+	return 0;
+}
+
+/**
+ * @brief Update Quad Filters.
+ * @param dev - The device structure.
+ * @return Returns 0 in case of success or negative error code otherwise.
+ */
+static int admv1014_update_quad_filters(struct admv1014_dev *dev)
+{
+	unsigned int filt_raw;
+
+	if ((dev->lo_in < 5400000000) || (dev->lo_in > 10250000000))
+		return -EINVAL;
+
+	if ((dev->lo_in >= 5400000000) && (dev->lo_in <= 7000000000))
+		filt_raw = LO_BAND_5_4_TO_7_GHZ;
+	else if ((dev->lo_in > 7000000000) && (dev->lo_in <= 8000000000))
+		filt_raw = LO_BAND_5_4_TO_8_GHZ;
+	else if ((dev->lo_in > 8000000000) && (dev->lo_in <= 9200000000))
+		filt_raw = LO_BAND_6_6_TO_9_2_GHZ;
+	else
+		filt_raw = LO_BAND_8_62_TO_10_25_GHZ;
+
+	return admv1014_spi_update_bits(dev, ADMV1014_REG_QUAD,
+					ADMV1014_QUAD_FILTERS_MSK,
+					no_os_field_prep(ADMV1014_QUAD_FILTERS_MSK, filt_raw));
+}
+
+/**
+ * @brief Update Mixer Gate Voltage.
+ * @param dev - The device structure.
+ * @return Returns 0 in case of success or negative error code otherwise.
+ */
+static int admv1014_update_vcm_settings(struct admv1014_dev *dev)
+{
+	unsigned int i, vcm_comp, bb_sw_high_low_cm;
+	int ret;
+
+	/* See Datasheet Common-Mode Voltage Settings Table 6 */
+	for (i = 0; i < NO_OS_ARRAY_SIZE(mixer_vgate_table); i++) {
+		vcm_comp = 1050 + (i * 50) + (i / 8 * 50);
+		if (dev->vcm_mv == vcm_comp) {
+			ret = admv1014_spi_update_bits(dev, ADMV1014_REG_MIXER,
+						       ADMV1014_MIXER_VGATE_MSK,
+						       no_os_field_prep(ADMV1014_MIXER_VGATE_MSK,
+								       mixer_vgate_table[i]));
+			if (ret)
+				return ret;
+
+			bb_sw_high_low_cm = ~(i / 8);
+
+			return admv1014_spi_update_bits(dev, ADMV1014_REG_BB_AMP_AGC,
+							ADMV1014_BB_AMP_REF_GEN_MSK |
+							ADMV1014_BB_SWITCH_HIGH_LOW_CM_MSK,
+							no_os_field_prep(ADMV1014_BB_AMP_REF_GEN_MSK, i) |
+							no_os_field_prep(ADMV1014_BB_SWITCH_HIGH_LOW_CM_MSK,
+									bb_sw_high_low_cm));
+		}
+	}
+
+	return -EINVAL;
+}
+
+/**
+ * @brief Initializes the admv1014.
+ * @param device - The device structure.
+ * @param init_param - The structure containing the device initial parameters.
+ * @return Returns 0 in case of success or negative error code.
+ */
+int admv1014_init(struct admv1014_dev **device,
+		  struct admv1014_init_param *init_param)
+{
+	struct admv1014_dev *dev;
+	uint16_t chip_id, enable_reg, enable_reg_msk;
+	int ret;
+
+	dev = (struct admv1014_dev *)calloc(1, sizeof(*dev));
+	if (!dev)
+		return -ENOMEM;
+
+	/* SPI */
+	ret = no_os_spi_init(&dev->spi_desc, init_param->spi_init);
+	if (ret)
+		goto error_dev;
+
+	dev->lo_in = init_param->lo_in;
+	dev->input_mode = init_param->input_mode;
+	dev->quad_se_mode = init_param->quad_se_mode;
+	dev->det_en = init_param->det_en;
+	dev->vcm_mv = init_param->vcm_mv;
+	dev->p1db_comp_en = init_param->p1db_comp_en;
+
+	/* Perform a software reset */
+	ret = admv1014_spi_update_bits(dev, ADMV1014_REG_SPI_CONTROL,
+				       ADMV1014_SPI_SOFT_RESET_MSK,
+				       no_os_field_prep(ADMV1014_SPI_SOFT_RESET_MSK, 1));
+	if (ret)
+		goto error_spi;
+
+	ret = admv1014_spi_update_bits(dev, ADMV1014_REG_SPI_CONTROL,
+				       ADMV1014_SPI_SOFT_RESET_MSK,
+				       no_os_field_prep(ADMV1014_SPI_SOFT_RESET_MSK, 0));
+	if (ret)
+		goto error_spi;
+
+	ret = admv1014_spi_write(dev, ADMV1014_REG_VVA_TEMP_COMP, 0x727C);
+	if (ret)
+		goto error_spi;
+
+	ret = admv1014_spi_read(dev, ADMV1014_REG_SPI_CONTROL, &chip_id);
+	if (ret)
+		goto error_spi;
+
+	chip_id = no_os_field_get(ADMV1014_CHIP_ID_MSK, chip_id);
+	if (chip_id != ADMV1014_CHIP_ID) {
+		ret = -EINVAL;
+		goto error_spi;
+	}
+
+	ret = admv1014_spi_update_bits(dev, ADMV1014_REG_QUAD,
+				       ADMV1014_QUAD_SE_MODE_MSK,
+				       no_os_field_prep(ADMV1014_QUAD_SE_MODE_MSK,
+						       dev->quad_se_mode));
+	if (ret)
+		goto error_spi;
+
+	ret = admv1014_update_quad_filters(dev);
+	if (ret)
+		goto error_spi;
+
+	ret = admv1014_update_vcm_settings(dev);
+	if (ret)
+		goto error_spi;
+
+	enable_reg_msk = ADMV1014_P1DB_COMPENSATION_MSK |
+			 ADMV1014_IF_AMP_PD_MSK |
+			 ADMV1014_BB_AMP_PD_MSK |
+			 ADMV1014_DET_EN_MSK;
+
+	enable_reg = no_os_field_prep(ADMV1014_P1DB_COMPENSATION_MSK,
+				      dev->p1db_comp_en ? 3 : 0) |
+		     no_os_field_prep(ADMV1014_IF_AMP_PD_MSK, !(dev->input_mode)) |
+		     no_os_field_prep(ADMV1014_BB_AMP_PD_MSK, dev->input_mode) |
+		     no_os_field_prep(ADMV1014_DET_EN_MSK, dev->det_en);
+
+	ret = admv1014_spi_update_bits(dev, ADMV1014_REG_ENABLE, enable_reg_msk,
+				       enable_reg);
+	if (ret)
+		goto error_spi;
+
+	*device = dev;
+
+	return 0;
+error_spi:
+	no_os_spi_remove(dev->spi_desc);
+error_dev:
+	free(dev);
+
+	return ret;
+}
+
+/**
+ * @brief ADMV1014 Resources Deallocation.
+ * @param dev - The device structure.
+ * @return Returns 0 in case of success or negative error code otherwise.
+ */
+int admv1014_remove(struct admv1014_dev *dev)
+{
+	int ret;
+
+	ret = no_os_spi_remove(dev->spi_desc);
+	if (ret)
+		return ret;
+
+	free(dev);
+
+	return 0;
+}

--- a/drivers/frequency/admv1014/admv1014.h
+++ b/drivers/frequency/admv1014/admv1014.h
@@ -1,0 +1,271 @@
+/***************************************************************************//**
+ *   @file   admv1014.h
+ *   @brief  Header file for admv1014 Driver.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef ADMV1014_H_
+#define ADMV1014_H_
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdint.h>
+#include <stdbool.h>
+#include "no_os_spi.h"
+#include "no_os_util.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+/* ADMV1014 Register Map */
+#define ADMV1014_REG_SPI_CONTROL		0x00
+#define ADMV1014_REG_ALARM			0x01
+#define ADMV1014_REG_ALARM_MASKS		0x02
+#define ADMV1014_REG_ENABLE			0x03
+#define ADMV1014_REG_QUAD			0x04
+#define ADMV1014_REG_LO_AMP_PHASE_ADJUST1	0x05
+#define ADMV1014_REG_MIXER			0x07
+#define ADMV1014_REG_IF_AMP			0x08
+#define ADMV1014_REG_IF_AMP_BB_AMP		0x09
+#define ADMV1014_REG_BB_AMP_AGC			0x0A
+#define ADMV1014_REG_VVA_TEMP_COMP		0x0B
+
+/* ADMV1014_REG_SPI_CONTROL Map */
+#define ADMV1014_PARITY_EN_MSK			NO_OS_BIT(15)
+#define ADMV1014_SPI_SOFT_RESET_MSK		NO_OS_BIT(14)
+#define ADMV1014_CHIP_ID_MSK			NO_OS_GENMASK(11, 4)
+#define ADMV1014_CHIP_ID			0x9
+#define ADMV1014_REVISION_ID_MSK		NO_OS_GENMASK(3, 0)
+
+/* ADMV1014_REG_ALARM Map */
+#define ADMV1014_PARITY_ERROR_MSK		NO_OS_BIT(15)
+#define ADMV1014_TOO_FEW_ERRORS_MSK		NO_OS_BIT(14)
+#define ADMV1014_TOO_MANY_ERRORS_MSK		NO_OS_BIT(13)
+#define ADMV1014_ADDRESS_RANGE_ERROR_MSK	NO_OS_BIT(12)
+
+/* ADMV1014_REG_ENABLE Map */
+#define ADMV1014_IBIAS_PD_MSK			NO_OS_BIT(14)
+#define ADMV1014_P1DB_COMPENSATION_MSK		NO_OS_GENMASK(13, 12)
+#define ADMV1014_IF_AMP_PD_MSK			NO_OS_BIT(11)
+#define ADMV1014_QUAD_BG_PD_MSK			NO_OS_BIT(9)
+#define ADMV1014_BB_AMP_PD_MSK			NO_OS_BIT(8)
+#define ADMV1014_QUAD_IBIAS_PD_MSK		NO_OS_BIT(7)
+#define ADMV1014_DET_EN_MSK			NO_OS_BIT(6)
+#define ADMV1014_BG_PD_MSK			NO_OS_BIT(5)
+
+/* ADMV1014_REG_QUAD Map */
+#define ADMV1014_QUAD_SE_MODE_MSK		NO_OS_GENMASK(9, 6)
+#define ADMV1014_QUAD_FILTERS_MSK		NO_OS_GENMASK(3, 0)
+
+/* ADMV1014_REG_LO_AMP_PHASE_ADJUST1 Map */
+#define ADMV1014_LOAMP_PH_ADJ_I_FINE_MSK	NO_OS_GENMASK(15, 9)
+#define ADMV1014_LOAMP_PH_ADJ_Q_FINE_MSK	NO_OS_GENMASK(8, 2)
+
+/* ADMV1014_REG_MIXER Map */
+#define ADMV1014_MIXER_VGATE_MSK		NO_OS_GENMASK(15, 9)
+#define ADMV1014_DET_PROG_MSK			NO_OS_GENMASK(6, 0)
+
+/* ADMV1014_REG_IF_AMP Map */
+#define ADMV1014_IF_AMP_COARSE_GAIN_I_MSK	NO_OS_GENMASK(11, 8)
+#define ADMV1014_IF_AMP_FINE_GAIN_Q_MSK		NO_OS_GENMASK(7, 4)
+#define ADMV1014_IF_AMP_FINE_GAIN_I_MSK		NO_OS_GENMASK(3, 0)
+
+/* ADMV1014_REG_IF_AMP_BB_AMP Map */
+#define ADMV1014_IF_AMP_COARSE_GAIN_Q_MSK	NO_OS_GENMASK(15, 12)
+#define ADMV1014_BB_AMP_OFFSET_Q_MSK		NO_OS_GENMASK(9, 5)
+#define ADMV1014_BB_AMP_OFFSET_I_MSK		NO_OS_GENMASK(4, 0)
+
+/* ADMV1014_REG_BB_AMP_AGC Map */
+#define ADMV1014_BB_AMP_REF_GEN_MSK		NO_OS_GENMASK(6, 3)
+#define ADMV1014_BB_AMP_GAIN_CTRL_MSK		NO_OS_GENMASK(2, 1)
+#define ADMV1014_BB_SWITCH_HIGH_LOW_CM_MSK	NO_OS_BIT(0)
+
+/* ADMV1014_REG_VVA_TEMP_COMP Map */
+#define ADMV1014_VVA_TEMP_COMP_MSK		NO_OS_GENMASK(15, 0)
+
+/* ADMV1014 Miscellaneous Defines */
+#define ADMV1014_READ				NO_OS_BIT(7)
+#define ADMV1014_REG_ADDR_READ_MSK		NO_OS_GENMASK(6, 1)
+#define ADMV1014_REG_ADDR_WRITE_MSK		NO_OS_GENMASK(22, 17)
+#define ADMV1014_REG_DATA_MSK			NO_OS_GENMASK(16, 1)
+#define ADMV1014_NUM_REGULATORS			9
+
+/* Specifications */
+#define ADMV1014_BUFF_SIZE_BYTES		3
+#define ADMV1014_SPI_READ_CMD			NO_OS_BIT(7)
+#define ADMV1014_SPI_WRITE_CMD			(0 << 7)
+
+/**
+ * @enum admv1014_input_mode
+ * @brief Switch Intermediate Frequency or I/Q Mode
+ */
+enum admv1014_input_mode {
+	ADMV1014_IQ_MODE,
+	ADMV1014_IF_MODE,
+};
+
+/**
+ * @enum admv1014_quad_se_mode
+ * @brief Switch Differential/Single-Ended Modes
+ */
+enum admv1014_quad_se_mode {
+	ADMV1014_SE_MODE_POS = 6,
+	ADMV1014_SE_MODE_NEG = 9,
+	ADMV1014_SE_MODE_DIFF = 12,
+};
+
+/**
+ * @enum admv1014_quad_filters
+ * @brief LO Filters BW Selection
+ */
+enum admv1014_quad_filters {
+	LO_BAND_8_62_TO_10_25_GHZ = 0,
+	LO_BAND_6_6_TO_9_2_GHZ = 5,
+	LO_BAND_5_4_TO_8_GHZ = 10,
+	LO_BAND_5_4_TO_7_GHZ = 15
+};
+
+/**
+ * @enum admv1014_det_prog
+ * @brief Digital Rx Detector Program.
+ */
+enum admv1014_det_prog {
+	DET_PROG_NEG_12_DBM_TO_POS_4DBM = 0,
+	DET_PROG_NEG_13_DBM_TO_POS_3DBM = 1,
+	DET_PROG_NEG_14_DBM_TO_POS_2DBM = 2,
+	DET_PROG_NEG_15_DBM_TO_POS_1DBM = 4,
+	DET_PROG_NEG_15_5_DBM_TO_POS_0_5_DBM = 8,
+	DET_PROG_NEG_16_25_DBM_TO_NEG_0_25_DBM = 16,
+	DET_PROG_NEG_17_DBM_TO_NEG_1DBM = 32,
+	DET_PROG_NEG_18_DBM_TO_NEG_2DBM = 64,
+};
+/**
+ * @struct admv1014_init_param
+ * @brief ADMV1014 Initialization Parameters structure.
+ */
+struct admv1014_init_param {
+	/** SPI Initialization parameters */
+	struct no_os_spi_init_param	*spi_init;
+	/** LO Input Frequency */
+	unsigned long long		lo_in;
+	/** Input Mode */
+	enum admv1014_input_mode	input_mode;
+	/** Quad SE Mode */
+	enum admv1014_quad_se_mode	quad_se_mode;
+	/** Detector Enable */
+	bool				det_en;
+	/** Common-Mode Voltage (mV) */
+	unsigned int			vcm_mv;
+	/** P1DB Compensation Enable */
+	bool				p1db_comp_en;
+};
+
+/**
+ * @struct admv1014_dev
+ * @brief ADMV1014 Device Descriptor.
+ */
+struct admv1014_dev {
+	/** SPI Descriptor */
+	struct no_os_spi_desc		*spi_desc;
+	/** LO Input Frequency */
+	unsigned long long		lo_in;
+	/** Input Mode */
+	enum admv1014_input_mode	input_mode;
+	/** Quad SE Mode */
+	enum admv1014_quad_se_mode	quad_se_mode;
+	/** Detector Enable */
+	bool				det_en;
+	/** Common-Mode Voltage (mV) */
+	unsigned int			vcm_mv;
+	/** P1DB Compensation Enable */
+	bool				p1db_comp_en;
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+/** ADMV1014 SPI write */
+int admv1014_spi_write(struct admv1014_dev *dev, uint8_t reg_addr,
+		       uint16_t data);
+
+/* ADMV1014 Register Update */
+int admv1014_spi_update_bits(struct admv1014_dev *dev, uint8_t reg_addr,
+			     uint16_t mask, uint16_t data);
+
+/** ADMV1014 SPI Read */
+int admv1014_spi_read(struct admv1014_dev *dev, uint8_t reg_addr,
+		      uint16_t *data);
+
+/** Set Digital Rx Detector */
+int admv1014_set_det_prog(struct admv1014_dev *dev,
+			  enum admv1014_det_prog det_prog);
+
+/** Get Digital Rx Detector */
+int admv1014_get_det_prog(struct admv1014_dev *dev,
+			  enum admv1014_det_prog *det_prog);
+
+/** Set Baseband Amp Gain */
+int admv1014_set_bb_amp_gain(struct admv1014_dev *dev, uint8_t gain);
+
+/** Get Baseband Amp Gain */
+int admv1014_get_bb_amp_gain(struct admv1014_dev *dev, uint8_t *gain);
+
+/** Set LO Amp Phase */
+int admv1014_set_phase(struct admv1014_dev *dev, uint8_t i_phase,
+		       uint8_t q_phase);
+
+/** Get LO Amp Phase */
+int admv1014_get_phase(struct admv1014_dev *dev, uint8_t *i_phase,
+		       uint8_t *q_phase);
+
+/** Set IF Amp Gain */
+int admv1014_set_if_amp_gain(struct admv1014_dev *dev, uint8_t i_coarse_gain,
+			     uint8_t q_coarse_gain, uint8_t i_fine_gain, uint8_t q_fine_gain);
+
+/** Get IF Amp Gain */
+int admv1014_get_if_amp_gain(struct admv1014_dev *dev, uint8_t *i_coarse_gain,
+			     uint8_t *q_coarse_gain, uint8_t *i_fine_gain, uint8_t *q_fine_gain);
+
+/** ADMV1014 Initialization */
+int admv1014_init(struct admv1014_dev **device,
+		  struct admv1014_init_param *init_param);
+
+/** ADMV1014 Resources Deallocation */
+int admv1014_remove(struct admv1014_dev *dev);
+
+#endif /* ADMV1014_H_ */


### PR DESCRIPTION
The ADMV1014 is a silicon germanium (SiGe), wideband,
microwave downconverter optimized for point to point microwave
radio designs operating in the 24 GHz to 44 GHz frequency range.

Datasheet: https://www.analog.com/en/products/admv1014.html
Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>