### PR TITLE
MAX31855 thermocouple driver

### DIFF
--- a/drivers/temperature/max31855/iio_max31855.c
+++ b/drivers/temperature/max31855/iio_max31855.c
@@ -1,0 +1,341 @@
+/***************************************************************************//**
+ *   @file   iio_max31855.c
+ *   @brief  Implementation of IIO MAX31855 driver.
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <errno.h>
+#include <stdlib.h>
+#include "iio_max31855.h"
+#include "max31855.h"
+#include "no_os_util.h"
+#include "iio.h"
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+static int max31855_iio_read_raw(void *dev, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel, intptr_t priv);
+static int max31855_iio_read_scale(void *dev, char *buf, uint32_t len,
+				   const struct iio_ch_info *channel, intptr_t priv);
+static int max31855_iio_update_channels(void *dev, uint32_t mask);
+static int max31855_iio_reg_read(struct max31855_iio_dev *dev, uint32_t reg,
+				 uint32_t *readval);
+static int max31855_iio_read_samples(void* dev, uint16_t* buff,
+				     uint32_t samples);
+
+/******************************************************************************/
+/************************ Variable Declarations ******************************/
+/******************************************************************************/
+
+static struct iio_attribute max31855_iio_temp_attrs[] = {
+	{
+		.name = "raw",
+		.show = max31855_iio_read_raw
+	},
+	{
+		.name = "scale",
+		.show = max31855_iio_read_scale
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct scan_type scan_internal = {
+	.sign = 's',
+	.realbits = 12,
+	.storagebits = 16,
+	.shift = 4,
+	.is_big_endian = false
+};
+
+static struct scan_type scan_thermocouple = {
+	.sign = 's',
+	.realbits = 14,
+	.storagebits = 16,
+	.shift = 2,
+	.is_big_endian = false
+};
+
+static struct iio_channel max31855_channels[] = {
+	{
+		.name = "i_temp",
+		.ch_type = IIO_TEMP,
+		.address = 0,
+		.channel2 = IIO_MOD_TEMP_AMBIENT,
+		.modified = true,
+		.scan_index = 1,
+		.scan_type = &scan_internal,
+		.attributes = max31855_iio_temp_attrs
+	},
+	{
+		.name = "t_temp",
+		.ch_type = IIO_TEMP,
+		.address = 2,
+		.scan_index = 0,
+		.scan_type = &scan_thermocouple,
+		.attributes = max31855_iio_temp_attrs
+	}
+};
+
+static struct iio_device max31855_iio_dev = {
+	.num_ch = NO_OS_ARRAY_SIZE(max31855_channels),
+	.channels = max31855_channels,
+	.pre_enable = (int32_t (*)())max31855_iio_update_channels,
+	.read_dev = (int32_t (*)())max31855_iio_read_samples,
+	.debug_reg_read = (int32_t (*)())max31855_iio_reg_read
+};
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+/******************************************************************************/
+
+/**
+ * @brief Initializes the MAX31855 IIO driver
+ * @param iio_dev - The iio device structure.
+ * @param init_param - Parameters for the initialization of iio_dev
+ * @return 0 in case of success, errno errors otherwise
+ */
+int max31855_iio_init(struct max31855_iio_dev **iio_dev,
+		      struct max31855_iio_dev_init_param *init_param)
+{
+	int ret;
+	struct max31855_iio_dev *descriptor;
+
+	if (!init_param)
+		return -EINVAL;
+
+	descriptor = calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	ret = max31855_init(&descriptor->max31855_desc, init_param->max31855_dev_init);
+	if (ret)
+		goto init_err;
+
+	descriptor->iio_dev = &max31855_iio_dev;
+
+	*iio_dev = descriptor;
+
+	return 0;
+init_err:
+	free(descriptor);
+
+	return ret;
+}
+
+/**
+ * @brief Free resources allocated by the init function
+ * @param desc - The iio device structure.
+ * @return 0 in case of success, errno errors otherwise
+ */
+int max31855_iio_remove(struct max31855_iio_dev *desc)
+{
+	int ret;
+
+	ret = max31855_remove(desc->max31855_desc);
+	if (ret)
+		return ret;
+
+	free(desc);
+
+	return 0;
+}
+
+/**
+ * @brief Updates the number of active channels
+ * @param dev - The iio device structure.
+ * @param mask - Bit mask containing active channels
+ * @return 0 in case of success, errno errors otherwise
+ */
+static int max31855_iio_update_channels(void *dev, uint32_t mask)
+{
+	struct max31855_iio_dev *iio_max31855;
+
+	if (!dev)
+		return -EINVAL;
+
+	iio_max31855 = dev;
+
+	iio_max31855->active_channels = mask;
+	iio_max31855->no_of_active_channels = no_os_hweight8((uint8_t)mask);
+
+	return 0;
+}
+
+/**
+ * @brief MAX31855 reg read wrapper
+ * @param dev - The iio device structure.
+ * @param reg - Register address (unused)
+ * @param readval - Register value
+ * @return 0 in case of success, errno errors otherwise
+ */
+static int max31855_iio_reg_read(struct max31855_iio_dev *dev, uint32_t reg,
+				 uint32_t *readval)
+{
+	return max31855_read_raw(dev->max31855_desc, readval);
+}
+
+/**
+ * @brief Handles the read request for raw attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - 0 in case of success, errno errors otherwise
+*/
+static int max31855_iio_read_raw(void *dev, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel, intptr_t priv)
+{
+	int ret;
+	struct max31855_iio_dev *max31855_iio;
+	struct max31855_dev *max31855_dev;
+	uint32_t buff;
+	uint32_t temp;
+
+	if (!dev)
+		return -EINVAL;
+
+	max31855_iio = dev;
+	max31855_dev = max31855_iio->max31855_desc;
+
+	switch (channel->type) {
+	case IIO_TEMP:
+		ret = max31855_read_raw(max31855_dev, &buff);
+		if (ret)
+			return ret;
+
+		switch(channel->address) {
+		case 0:
+			temp = no_os_field_get(NO_OS_GENMASK(15, 4), buff);
+			temp = no_os_sign_extend32(temp, 11);
+			break;
+		case 2:
+			temp = no_os_field_get(NO_OS_GENMASK(31, 18), buff);
+			temp = no_os_sign_extend32(temp, 13);
+			break;
+		default:
+			return -EINVAL;
+		}
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &temp);
+
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Handles the read request for scale attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - 0 in case of success, errno errors otherwise
+*/
+static int max31855_iio_read_scale(void *dev, char *buf, uint32_t len,
+				   const struct iio_ch_info *channel, intptr_t priv)
+{
+	int32_t val[2] = {0};
+
+	switch (channel->type) {
+	case IIO_TEMP:
+		switch (channel->address) {
+		case 0:
+			val[0] = 62;
+			val[1] = 500000;
+			return iio_format_value(buf, len, IIO_VAL_INT_PLUS_MICRO, 2, val);
+		case 2:
+			val[0] = 250;
+			return iio_format_value(buf, len, IIO_VAL_INT, 1, val);
+		default:
+			return -EINVAL;
+		}
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Reads the number of given samples for the selected channels
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param samples - Number of samples to be returned
+ * @return ret    - 0 in case of success, errno errors otherwise
+*/
+static int max31855_iio_read_samples(void* dev, uint16_t* buff,
+				     uint32_t samples)
+{
+	int ret;
+	int16_t i_temp;
+	int16_t t_temp;
+	uint32_t raw_buff;
+	struct max31855_iio_dev *max31855_iio;
+	struct max31855_dev *max31855_dev;
+
+	if (!dev)
+		return -EINVAL;
+
+	max31855_iio = dev;
+	max31855_dev = max31855_iio->max31855_desc;
+
+	for (uint32_t i = 0; i < samples * max31855_iio->no_of_active_channels;) {
+		ret = max31855_read_raw(max31855_dev, &raw_buff);
+		if (ret)
+			return ret;
+
+		if (max31855_iio->active_channels & NO_OS_BIT(0)) {
+			t_temp = no_os_field_get(NO_OS_GENMASK(31, 16), raw_buff);
+			buff[i] = t_temp;
+			i++;
+		}
+
+		if (max31855_iio->active_channels & NO_OS_BIT(1)) {
+			i_temp = no_os_field_get(NO_OS_GENMASK(15, 0), raw_buff);
+			buff[i] = i_temp;
+			i++;
+		}
+	}
+
+	return samples;
+}

--- a/drivers/temperature/max31855/iio_max31855.h
+++ b/drivers/temperature/max31855/iio_max31855.h
@@ -1,0 +1,72 @@
+/***************************************************************************//**
+ *   @file   iio_max31855.h
+ *   @brief  Header file of IIO MAX31855 driver.
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef IIO_MAX31855_H
+#define IIO_MAX31855_H
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include "iio.h"
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+
+struct max31855_iio_dev {
+	struct max31855_dev *max31855_desc;
+	struct iio_device *iio_dev;
+	uint32_t active_channels;
+	uint8_t no_of_active_channels;
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+struct max31855_iio_dev_init_param {
+	struct max31855_init_param *max31855_dev_init;
+};
+
+int max31855_iio_init(struct max31855_iio_dev **,
+		      struct max31855_iio_dev_init_param *);
+int max31855_iio_remove(struct max31855_iio_dev *);
+
+#endif

--- a/drivers/temperature/max31855/max31855.c
+++ b/drivers/temperature/max31855/max31855.c
@@ -1,0 +1,165 @@
+/***************************************************************************//**
+ *   @file   max31855.c
+ *   @brief  Implementation of MAX31855 Driver.
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <errno.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include "max31855.h"
+#include "no_os_spi.h"
+#include "no_os_util.h"
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+/******************************************************************************/
+
+/**
+ * @brief Device and comm init function
+ * @param device - MAX31855 descriptor to be initialized
+ * @param init_param - Init parameter for descriptor
+ * @return 0 in case of success, errno errors otherwise
+ */
+int max31855_init(struct max31855_dev **device,
+		  struct max31855_init_param *init_param)
+{
+	int ret;
+	struct max31855_dev *descriptor;
+
+	descriptor = calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	ret = no_os_spi_init(&descriptor->comm_desc, &init_param->spi_init);
+	if (ret)
+		goto spi_err;
+
+	*device = descriptor;
+
+	return 0;
+spi_err:
+	free(descriptor);
+
+	return ret;
+}
+/**
+ * @brief Remove resources allocated by the init function
+ * @param device - MAX31855 descriptor
+ * @return 0 in case of success, errno errors otherwise
+ */
+int max31855_remove(struct max31855_dev *device)
+{
+	int ret;
+	if (!device)
+		return -ENODEV;
+
+	ret = no_os_spi_remove(device->comm_desc);
+	if (ret)
+		return -EINVAL;
+
+	free(device);
+
+	return 0;
+}
+
+/**
+ * @brief Read raw register value
+ * @param device - MAX31855 descriptor
+ * @param val - register value
+ * @return 0 in case of success, negative error code otherwise
+ */
+int max31855_read_raw(struct max31855_dev *device, uint32_t *val)
+{
+	int ret;
+	uint8_t raw_array[4];
+
+	ret = no_os_spi_write_and_read(device->comm_desc, raw_array, 4);
+	if (ret)
+		return ret;
+
+	*val = no_os_get_unaligned_be32(raw_array);
+	device->fault.value = MAX31855_GET_FAULT_BIT(*val);
+	if (MAX31855_GET_FAULT_BIT(*val)) {
+		device->fault.value = MAX31855_GET_FAULTS(*val);
+		return -1;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Read thermocouple and internal temperatures (converted in deg. C)
+ * @param device - MAX31855 descriptor
+ * @param thermocouple_temp - thermocouple probe temperature (deg. C)
+ * @param internal_temp - board's temperature (used as reference)
+ * @return 0 in case of success, errno errors otherwise
+ */
+int max31855_read_temp(struct max31855_dev *device,
+		       struct max31855_decimal *thermocouple_temp,
+		       struct max31855_decimal *internal_temp)
+{
+	int ret;
+	uint32_t buff;
+	uint32_t i_temp;
+	uint32_t t_temp;
+
+	if (!device)
+		return -ENODEV;
+
+	ret = max31855_read_raw(device, &buff);
+	if (ret)
+		return ret;
+
+	i_temp = MAX31855_GET_INTERNAL_TEMP(buff);
+	t_temp = MAX31855_GET_THERMOCOUPLE_TEMP(buff);
+	i_temp = no_os_sign_extend32(i_temp, MAX31855_INTERNAL_TEMP_SIGN_POS);
+	t_temp = no_os_sign_extend32(t_temp, MAX31855_THERMOCOUPLE_TEMP_SIGN_POS);
+
+	thermocouple_temp->integer = no_os_div_s64_rem(t_temp,
+				     MAX31855_THERMOCOUPLE_TEMP_DEC_DIV,
+				     &thermocouple_temp->decimal);
+	internal_temp->integer = no_os_div_s64_rem(i_temp,
+				 MAX31855_INTERNAL_TEMP_DEC_DIV,
+				 &internal_temp->decimal);
+
+	return 0;
+}

--- a/drivers/temperature/max31855/max31855.h
+++ b/drivers/temperature/max31855/max31855.h
@@ -1,0 +1,121 @@
+/***************************************************************************//**
+ *   @file   max31855.c
+ *   @brief  Implementation of MAX31855 Driver.
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef __MAX31855_H__
+#define __MAX31855_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <stdint.h>
+#include "no_os_spi.h"
+#include "no_os_util.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+#define MAX31855_GET_INTERNAL_TEMP(x)		(no_os_field_get(NO_OS_GENMASK(15, 4), x))
+#define MAX31855_GET_FAULT_BIT(x)		(no_os_field_get(NO_OS_BIT(16), x))
+#define MAX31855_GET_THERMOCOUPLE_TEMP(x)	(no_os_field_get(NO_OS_GENMASK(31, 18), x))
+#define MAX31855_GET_FAULTS(x)			(no_os_field_get(NO_OS_GENMASK(2, 0), x))
+
+/**
+ * Decimal resolution for the 2 temperatures (0.25 C and 0.0625 C / LSB).
+ * integer_temp = raw_temp / dec_div.
+ */
+#define MAX31855_THERMOCOUPLE_TEMP_DEC_DIV	4
+#define MAX31855_INTERNAL_TEMP_DEC_DIV	 	16
+
+/** Sign bit position */
+#define MAX31855_THERMOCOUPLE_TEMP_SIGN_POS	13
+#define MAX31855_INTERNAL_TEMP_SIGN_POS		11
+
+/**
+ * @brief MAX31855 comm init param
+ */
+struct max31855_init_param {
+	struct no_os_spi_init_param spi_init;
+};
+
+/**
+ * @brief interger/decimal format used for temperature representation
+ */
+struct max31855_decimal {
+	int32_t integer;
+	int32_t decimal;
+};
+
+struct _max31855_fault_sts_mask {
+	/** Thermocouple is short circuited to VCC */
+	uint8_t SCV:1;
+	/** Thermocouple is short circuited to GND */
+	uint8_t SCG:1;
+	/** Thermocouple probe not connected */
+	uint8_t OC:1;
+};
+
+union max31855_fault_sts {
+	struct _max31855_fault_sts_mask fields;
+	uint8_t value;
+};
+
+/**
+ * @brief MAX31855 descriptor
+ */
+struct max31855_dev {
+	struct no_os_spi_desc *comm_desc;
+	union max31855_fault_sts fault;
+};
+
+/** Device and comm init function */
+int max31855_init(struct max31855_dev **, struct max31855_init_param *);
+
+/** Free resources allocated by the init function */
+int max31855_remove(struct max31855_dev *);
+
+/** Read raw register value */
+int max31855_read_raw(struct max31855_dev *, uint32_t *);
+
+/** Read thermocouple and internal temperatures (converted in deg. C) */
+int max31855_read_temp(struct max31855_dev *, struct max31855_decimal *,
+		       struct max31855_decimal *);
+
+#endif

--- a/iio/iio.c
+++ b/iio/iio.c
@@ -117,6 +117,7 @@ static const char * const iio_modifier_names[] = {
 	[IIO_MOD_X] = "x",
 	[IIO_MOD_Y] = "y",
 	[IIO_MOD_Z] = "z",
+	[IIO_MOD_TEMP_AMBIENT] = "ambient"
 };
 
 /* Parameters used in show and store functions */

--- a/iio/iio_types.h
+++ b/iio/iio_types.h
@@ -86,6 +86,7 @@ enum iio_modifier {
 	IIO_MOD_X,
 	IIO_MOD_Y,
 	IIO_MOD_Z,
+	IIO_MOD_TEMP_AMBIENT
 };
 
 /**


### PR DESCRIPTION
The MAX31855 performs cold-junction compensation
and digitizes the signal from a K-, J-, N-, T-, S-, R-, or
E-type thermocouple. The data is output in a signed
14-bit, SPI-compatible, read-only format. This converter
resolves temperatures to 0.25°C, allows readings as
high as +1800°C and as low as -270°C, and exhibits
thermocouple accuracy of ±2°C for temperatures ranging
from -200°C to +700°C for K-type thermocouples.

Signed-off-by: Ciprian Regus <ciprian.regus@analog.com>