### PR TITLE
drivers:dac:ltc2688: Minor Update

### DIFF
--- a/drivers/dac/ltc2688/ltc2688.c
+++ b/drivers/dac/ltc2688/ltc2688.c
@@ -395,6 +395,8 @@ int32_t ltc2688_set_voltage(struct ltc2688_dev *dev, uint8_t channel,
 	if(code > 0xFFFF)
 		code = 0xFFFF;
 
+	dev->dac_code[channel] = code;
+
 	/* Write to the Data Register of the DAC. */
 	return _ltc2688_spi_write(dev, LTC2688_CMD_CH_CODE_UPDATE(channel), code);
 }

--- a/drivers/dac/ltc2688/ltc2688.c
+++ b/drivers/dac/ltc2688/ltc2688.c
@@ -140,8 +140,16 @@ static int32_t _ltc2688_spi_update_bits(struct ltc2688_dev *dev, uint8_t reg,
  */
 int32_t ltc2688_set_pwr_dac(struct ltc2688_dev *dev, uint16_t setting)
 {
-	return _ltc2688_spi_write(dev, LTC2688_CMD_POWERDOWN_REG,
-				  setting);
+	int32_t ret;
+
+	ret = _ltc2688_spi_write(dev, LTC2688_CMD_POWERDOWN_REG,
+				 setting);
+	if (ret < 0)
+		return ret;
+
+	dev->pwd_dac_setting = setting;
+
+	return 0;
 }
 
 /**

--- a/drivers/dac/ltc2688/ltc2688.h
+++ b/drivers/dac/ltc2688/ltc2688.h
@@ -139,6 +139,7 @@ struct ltc2688_dev {
 	uint16_t			pwd_dac_setting;
 	uint16_t			dither_toggle_en;
 	bool				dither_mode[16];
+	uint16_t			dac_code[16];
 	enum ltc2688_voltage_range 	crt_range[16];
 	enum ltc2688_dither_phase	dither_phase[16];
 	enum ltc2688_dither_period	dither_period[16];


### PR DESCRIPTION
Added an extra parameter in device descriptor to store the computed dac code.

Signed-off-by: Pratyush Mallick <Pratyush.Mallick@analog.com>