### PR TITLE
drivers:adc:ad717x: Added num_setups in the init struct member

### DIFF
--- a/drivers/adc/ad717x/ad717x.c
+++ b/drivers/adc/ad717x/ad717x.c
@@ -812,8 +812,7 @@ int32_t AD717X_Init(ad717x_dev **device,
 	dev->active_device = init_param.active_device;
 	dev->num_channels = init_param.num_channels;
 
-	for (setup_index = 0; setup_index < NO_OS_ARRAY_SIZE(init_param.setups);
-	     setup_index++) {
+	for (setup_index = 0; setup_index < init_param.num_setups; setup_index++) {
 		/* Set Polarity */
 		ret = ad717x_set_polarity(dev, init_param.setups[setup_index].bi_unipolar,
 					  setup_index);

--- a/drivers/adc/ad717x/ad717x.h
+++ b/drivers/adc/ad717x/ad717x.h
@@ -299,6 +299,8 @@ typedef struct {
 	bool ref_en;
 	/* Number of Channels */
 	uint8_t num_channels;
+	/* Number of Setups */
+	uint8_t num_setups;
 	/* Channel Mapping */
 	struct ad717x_channel_map chan_map[AD717x_MAX_CHANNELS];
 	/* Setups */
@@ -521,6 +523,7 @@ typedef struct {
 #define AD717X_CHMAP_REG_AINNEG_MSK    		NO_OS_GENMASK(4,0)
 #define AD717X_ADCMODE_REG_MODE_MSK   		NO_OS_GENMASK(6,4)
 #define AD717X_SETUP_CONF_REG_REF_SEL_MSK	NO_OS_GENMASK(5,4)
+#define AD717x_ODR_MSK				NO_OS_GENMASK(4,0)
 
 /*****************************************************************************/
 /************************ Functions Declarations *****************************/

--- a/drivers/adc/ad717x/ad717x.h
+++ b/drivers/adc/ad717x/ad717x.h
@@ -604,4 +604,8 @@ int ad717x_enable_buffers(ad717x_dev* device, bool inbuf_en,
 int ad717x_single_read(ad717x_dev* device, uint8_t id,
 		       int32_t *adc_raw_data);
 
+/* Configure device ODR */
+int32_t ad717x_configure_device_odr(ad717x_dev *dev, uint8_t filtcon_id,
+				    uint8_t odr_sel);
+
 #endif /* __AD717X_H__ */


### PR DESCRIPTION
1) Updated the ad717x_init_param to add num_setups as a member
2) Utilized the num_setups in the for loop for configuring the SETUPCON registers

Signed-off-by: Janani Sunil <Janani.Sunil@analog.com>