### PR TITLE
drivers:platform:maxim:maxim_irq.c: Fixed overflow

### DIFF
--- a/drivers/platform/maxim/maxim_irq.c
+++ b/drivers/platform/maxim/maxim_irq.c
@@ -65,7 +65,7 @@ static struct event_list _events[] = {
 };
 
 extern mxc_uart_req_t uart_irq_state[MXC_UART_INSTANCES];
-extern is_callback;
+extern bool is_callback;
 
 /******************************************************************************/
 /************************ Functions Definitions *******************************/


### PR DESCRIPTION
Declaring is_callback as extern without a type modifier
resulted in using int as it's type (even though is_callback
was declared globally as bool). This caused an overflow to occur,
overwriting the next global variable.