### PR TITLE
iio:iio_trigger: Add generic trigger APIs

### DIFF
--- a/iio/iio.c
+++ b/iio/iio.c
@@ -988,8 +988,10 @@ static void iio_process_async_triggers(struct iio_desc *desc)
  * type (sync or async with the interrupt).
  * @param desc         - IIO descriptor.
  * @param trigger_name - Trigger name.
+ *
+ * @return ret - Result of the processing procedure.
  */
-void iio_process_trigger_type(struct iio_desc *desc, char *trigger_name)
+int iio_process_trigger_type(struct iio_desc *desc, char *trigger_name)
 {
 	uint32_t i;
 	uint32_t trig_id;
@@ -998,7 +1000,7 @@ void iio_process_trigger_type(struct iio_desc *desc, char *trigger_name)
 	trig_id = iio_get_trig_idx_by_name(desc, trigger_name);
 
 	if (trig_id == NO_TRIGGER)
-		return;
+		return -EINVAL;
 
 	struct iio_dev_priv *dev;
 
@@ -1014,6 +1016,8 @@ void iio_process_trigger_type(struct iio_desc *desc, char *trigger_name)
 			}
 		}
 	}
+
+	return 0;
 }
 
 static uint32_t bytes_per_scan(struct iio_channel *channels, uint32_t mask)

--- a/iio/iio.h
+++ b/iio/iio.h
@@ -116,7 +116,7 @@ int iio_step(struct iio_desc *desc);
    called in interrupt context if trigger is synchronous with the interrupt
    (is_synchronous = true) or will be called from iio_step if trigger is
    asynchronous (is_synchronous = false) */
-void iio_process_trigger_type(struct iio_desc *desc, char *trigger_name);
+int iio_process_trigger_type(struct iio_desc *desc, char *trigger_name);
 
 int32_t iio_parse_value(char *buf, enum iio_val fmt,
 			int32_t *val, int32_t *val2);

--- a/iio/iio_trigger.c
+++ b/iio/iio_trigger.c
@@ -1,0 +1,238 @@
+/***************************************************************************//**
+ *   @file   iio_trigger.c
+ *   @brief  Implementation of generic iio trigger.
+ *   @author RBolboac (ramona.bolboaca@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdlib.h>
+#include <string.h>
+#include "no_os_error.h"
+#include "iio.h"
+#include "iio_trigger.h"
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+#ifndef LINUX_PLATFORM
+/**
+ * @brief Initialize hardware trigger.
+ *
+ * @param iio_trig   - The iio trigger structure.
+ * @param init_param - The structure that contains the trigger initial params.
+ *
+ * @return ret       - Result of the initialization procedure.
+ */
+int iio_hw_trig_init(struct iio_hw_trig **iio_trig,
+		     struct iio_hw_trig_init_param *init_param)
+{
+	struct iio_hw_trig *trig_desc;
+	int ret;
+
+	if (!init_param->iio_desc || !init_param->name)
+		return -EINVAL;
+
+	trig_desc = (struct iio_hw_trig*)calloc(1, sizeof(*trig_desc));
+	if (!trig_desc)
+		return -ENOMEM;
+
+	trig_desc->iio_desc = init_param->iio_desc;
+	strncpy(trig_desc->name, init_param->name, TRIG_MAX_NAME_SIZE);
+	trig_desc->irq_ctrl = init_param->irq_ctrl;
+	trig_desc->irq_id = init_param->irq_id;
+	trig_desc->irq_trig_lvl = init_param->irq_trig_lvl;
+
+	struct no_os_callback_desc irq_cb = {
+		.callback = iio_hw_trig_handler,
+		.ctx = trig_desc,
+		.event = init_param->cb_info.event,
+		.handle = init_param->cb_info.handle,
+		.peripheral = init_param->cb_info.peripheral
+	};
+
+	ret = no_os_irq_register_callback(trig_desc->irq_ctrl,
+					  trig_desc->irq_id, &irq_cb);
+	if (ret)
+		goto error;
+
+	ret = no_os_irq_trigger_level_set(trig_desc->irq_ctrl,
+					  trig_desc->irq_id, trig_desc->irq_trig_lvl);
+	if (ret)
+		goto error;
+
+	*iio_trig = trig_desc;
+
+	return 0;
+error:
+	free(trig_desc);
+	return ret;
+}
+
+/**
+ * @brief Enable system interrupt which is linked to the given trigger.
+ *
+ * @param trig - Trigger structure.
+ *
+ * @return ret - Result of the enable procedure.
+*/
+int iio_trig_enable(void *trig)
+{
+	if(!trig)
+		return -EINVAL;
+
+	struct iio_hw_trig *desc = trig;
+
+	return no_os_irq_enable(desc->irq_ctrl, desc->irq_id);
+}
+
+/**
+ * @brief Disable system interrupt which is linked to the given trigger.
+ *
+ * @param trig - Trigger structure.
+ *
+ * @return ret - Result of the disable procedure.
+*/
+int iio_trig_disable(void *trig)
+{
+	if(!trig)
+		return -EINVAL;
+
+	struct iio_hw_trig *desc = trig;
+
+	return no_os_irq_disable(desc->irq_ctrl, desc->irq_id);
+}
+
+/**
+ * @brief Trigger interrupt handler. This function will be called when a system
+ * interrupt is asserted for the configured trigger.
+ *
+ * @param trig - Trigger structure which is linked to this handler.
+ *
+ * @return ret - Result of the hw trigger handler procedure.
+*/
+int iio_hw_trig_handler(void *trig)
+{
+	if(!trig)
+		return -EINVAL;
+
+	struct iio_hw_trig *desc = trig;
+
+	return iio_process_trigger_type(*desc->iio_desc, desc->name);
+}
+
+/**
+ * @brief Free the resources allocated by iio_hw_trig_init().
+ *
+ * @param trig - The trigger structure.
+ *
+ * @return ret - Result of the remove procedure.
+*/
+int iio_hw_trig_remove(struct iio_hw_trig *trig)
+{
+	if(trig)
+		free(trig);
+
+	return 0;
+}
+#endif
+
+/**
+ * @brief Initialize software trigger.
+ *
+ * @param iio_trig   - The iio trigger structure.
+ * @param init_param - The structure that contains the sw trigger initial params.
+ *
+ * @return ret       - Result of the initialization procedure.
+*/
+int iio_sw_trig_init(struct iio_sw_trig **iio_trig,
+		     struct iio_sw_trig_init_param *init_param)
+{
+	struct iio_sw_trig *trig_desc;
+
+	if (!init_param->iio_desc || !init_param->name)
+		return -EINVAL;
+
+	trig_desc = (struct iio_sw_trig*)calloc(1, sizeof(*trig_desc));
+	if (!trig_desc)
+		return -ENOMEM;
+
+	trig_desc->iio_desc = init_param->iio_desc;
+	strncpy(trig_desc->name, init_param->name, TRIG_MAX_NAME_SIZE);
+
+	*iio_trig = trig_desc;
+
+	return 0;
+}
+
+/**
+ * @brief Handles the write request for trigger_now attribute.
+ *
+ * @param trig    - The iio trigger structure.
+ * @param buf     - Command buffer to be filled with the data to be written.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info (is NULL).
+ * @param priv    - Command attribute id.
+ *
+ * @return ret    - Result of the sw trigger handler procedure.
+*/
+int iio_sw_trig_handler(void *trig, char *buf, uint32_t len,
+			const struct iio_ch_info *channel,
+			intptr_t priv)
+{
+	if(!trig)
+		return -EINVAL;
+
+	struct iio_sw_trig *desc = trig;
+
+	return iio_process_trigger_type(*desc->iio_desc, desc->name);
+}
+
+/**
+ * @brief Free the resources allocated by iio_sw_trig_init().
+ *
+ * @param trig - The trigger structure.
+ *
+ * @return ret - Result of the remove procedure.
+*/
+int iio_sw_trig_remove(struct iio_sw_trig *trig)
+{
+	if(trig)
+		free(trig);
+
+	return 0;
+}

--- a/iio/iio_trigger.h
+++ b/iio/iio_trigger.h
@@ -1,0 +1,153 @@
+/***************************************************************************//**
+ *   @file   iio_trigger.h
+ *   @brief  Header file for iio_trigger.
+ *   @author RBolboac(ramona.bolboaca@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef IIO_TRIGGER_H_
+#define IIO_TRIGGER_H_
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "iio.h"
+#include "iio_types.h"
+#include "no_os_irq.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+#define TRIG_MAX_NAME_SIZE 20
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+/**
+ * @struct iio_hw_trig
+ * @brief IIO hardware trigger structure
+ */
+struct iio_hw_trig {
+	/** IIO descriptor */
+	struct iio_desc	**iio_desc;
+	/** Interrupt descriptor to be linked with the trigger */
+	struct no_os_irq_ctrl_desc *irq_ctrl;
+	/** Interrupt id to be linked with the trigger */
+	uint32_t irq_id;
+	/** Interrupt trigger level */
+	enum no_os_irq_trig_level irq_trig_lvl;
+	/** Device trigger name */
+	char name[TRIG_MAX_NAME_SIZE + 1];
+};
+
+/**
+ * @struct iio_hw_trig_cb_info
+ * @brief Hardware trigger callback extra information structure
+ */
+struct iio_hw_trig_cb_info {
+	/** Platform specific event that triggers the calling of the callback. */
+	enum no_os_irq_event event;
+	/** Interrupt source peripheral specifier. */
+	enum no_os_irq_peripheral peripheral;
+	/** This will be used to store HAL specific descriptors */
+	void *handle;
+};
+
+/**
+ * @struct iio_hw_trig_init_param
+ * @brief IIO hardware trigger initialization structure
+ */
+struct iio_hw_trig_init_param {
+	/** IIO descriptor */
+	struct iio_desc **iio_desc;
+	/** Interrupt descriptor to be linked with the trigger */
+	struct no_os_irq_ctrl_desc *irq_ctrl;
+	/** Interrupt id to be linked with the trigger */
+	uint32_t irq_id;
+	/** Interrupt trigger level */
+	enum no_os_irq_trig_level irq_trig_lvl;
+	/** Additional interrupt callback information */
+	struct iio_hw_trig_cb_info cb_info;
+	/** Device trigger name */
+	const char *name;
+};
+
+/**
+ * @struct iio_sw_trig
+ * @brief IIO software trigger structure
+ */
+struct iio_sw_trig {
+	/** IIO descriptor */
+	struct iio_desc **iio_desc;
+	/** Device trigger name */
+	char name[TRIG_MAX_NAME_SIZE + 1];
+};
+
+/**
+ * @struct iio_sw_trig_init_param
+ * @brief IIO software trigger initialization structure
+ */
+struct iio_sw_trig_init_param {
+	/** IIO descriptor */
+	struct iio_desc **iio_desc;
+	/** Device trigger name */
+	const char *name;
+};
+
+#ifndef LINUX_PLATFORM
+/** API to initialize a hardware trigger */
+int iio_hw_trig_init(struct iio_hw_trig **iio_trig,
+		     struct iio_hw_trig_init_param *init_param);
+/** API to enable a hardware  trigger */
+int iio_trig_enable(void *trig);
+/** API to disable a hardware trigger */
+int iio_trig_disable(void *trig);
+/** API for hardware trigger handler */
+int iio_hw_trig_handler(void *trig);
+/** API to remove a hardware trigger */
+int iio_hw_trig_remove(struct iio_hw_trig *trig);
+#endif
+
+/** API to initialize a software trigger */
+int iio_sw_trig_init(struct iio_sw_trig **iio_trig,
+		     struct iio_sw_trig_init_param *init_param);
+/** API for software trigger handler */
+int iio_sw_trig_handler(void *trig, char *buf, uint32_t len,
+			const struct iio_ch_info *channel,
+			intptr_t priv);
+/** API to remove a software trigger */
+int iio_trig_remove(struct iio_sw_trig *trig);
+
+#endif /* IIO_TRIGGER_H_ */


### PR DESCRIPTION
Add generic trigger APIs for hardware and software triggers which shall be used by all IIO devices with trigger capabilities.

There are two types of triggers which can be instantiated:

1. software trigger: 
- does not require any interrupt mapping
- is generated by writing the attribute of the trigger device
- are not supported over serial communication
Example of software trigger initialization for a device:

```
static struct iio_attribute trig_attr[] = {
	{
		.name = "trigger_now",
		.store = iio_sw_trig_handler
	},
	END_ATTRIBUTES_ARRAY
};

struct iio_trigger sw_trig_desc = {
	.is_synchronous = true,
	.attributes = trig_attr,
};
```
In case of a software trigger, the is_synchronous flag specifies whether the measurement is performed from the context of the software trigger handler (.is_synchronous = true), or from the context of the iio application (.is_synchronous = false). In case is_synchronous is set to false, depending on the frequency of the software trigger, some triggers might be missed and the number of data samples might be less than the number of generated triggers. 
2. hardware trigger:
- requires an interrupt mapping, at the moment no-os supports only GPIO interrupts used as hardware triggers
- is generated when a per-configured GPIO interrupt is taking place.
Example of hardware trigger initialization for a device:
```
struct iio_trigger hw_trig_desc = {
	.is_synchronous = true,
	.enable = iio_trig_enable,
	.disable = iio_trig_disable
};
```
In case of a hardware trigger, the is_synchronous flag specifies whether the measurement is performed from the context of the interrupt handler (.is_synchronous = true), or from the context of the iio application (.is_synchronous = false). In case is_synchronous is set to false, depending on the frequency of the trigger, some triggers might be missed and the number of data samples might be less than the number of generated triggers. 