### PR TITLE
Multi-JTAG support for Microblaze

### DIFF
--- a/tools/scripts/platform/xilinx/util.tcl
+++ b/tools/scripts/platform/xilinx/util.tcl
@@ -182,6 +182,9 @@ set ps_dict [dict create					\
 	"sys_mb" "*MicroBlaze #*"]
 
 proc _cpu_reset {cpu} {
+	if {$cpu == "sys_mb"} {
+		return
+	}
 	targets -set -filter {name =~ "APU*" && jtag_cable_name =~ "*$::jtagtarget*"}
 	stop
 	if {$cpu == "ps7_cortexa9_0"} {
@@ -228,8 +231,8 @@ proc _init_ps {cpu} {
 			targets -set -filter {name =~ "Cortex-R5 #0" && jtag_cable_name =~ "*$::jtagtarget*"}
 		}
 		"sys_mb" {
-			targets -set -filter {[dict get $::pl_dict $cpu]}
-
+			set name [dict get $::pl_dict $cpu]
+			targets -set -filter {name =~ "$name" && jtag_cable_name =~ "*$::jtagtarget*"}
 		}
 	}
 }
@@ -237,7 +240,9 @@ proc _init_ps {cpu} {
 proc _write_ps {cpu} {
 	set name [dict get $::ps_dict $cpu]
 	targets -set -filter {name =~  "$name" && jtag_cable_name =~ "*$::jtagtarget*"}
+	after 2000
 	dow "[file normalize $::binary]"
+	after 2000
 	con
 	disconnect
 }

--- a/tools/scripts/xilinx.mk
+++ b/tools/scripts/xilinx.mk
@@ -28,6 +28,7 @@ LIB_PATHS	+= -L$(BUILD_DIR)/bsp/$(ARCH)/lib
 PLATFORM_RELATIVE_PATH = $1
 PLATFORM_FULL_PATH = $1
 JTAG_CABLE_ID = $2
+TARGET_CPU ?= 0
 PROJECT_BUILD = $(BUILD_DIR)/app
 
 ################|--------------------------------------------------------------
@@ -140,7 +141,7 @@ $(BINARY): $(TEMP_DIR)/arch.txt
 
 PHONY += xilinx_run
 xilinx_run: all
-	$(MUTE) $(call tcl_util, upload) $(HIDE) $(JTAG_CABLE_ID)
+	$(MUTE) $(call tcl_util, upload) $(JTAG_CABLE_ID) $(HIDE)
 
 $(TEMP_DIR)/arch.txt: $(HARDWARE)
 	$(MUTE) $(call mk_dir,$(BUILD_DIR)/app $(BUILD_DIR)/app/src $(OBJECTS_DIR) $(TEMP_DIR)) $(HIDE)


### PR DESCRIPTION
Enhance utility script to support JTAG cable name for microblaze
platforms.

Signed-off-by: Travis F. Collins <travis.collins@analog.com>