### PR TITLE
iio_demo for maxim

### DIFF
--- a/projects/iio_demo/src/platform/maxim/main.c
+++ b/projects/iio_demo/src/platform/maxim/main.c
@@ -1,7 +1,7 @@
 /***************************************************************************//**
- *   @file   platform_includes.h
- *   @brief  Includes for used platforms used by iio_demo project.
- *   @author RBolboac (ramona.bolboaca@analog.com)
+ *   @file   main.c
+ *   @brief  Main file for Maxim platform of iio_demo project.
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
 ********************************************************************************
  * Copyright 2022(c) Analog Devices, Inc.
  *
@@ -36,26 +36,48 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
-#ifndef __PLATFORM_INCLUDES_H__
-#define __PLATFORM_INCLUDES_H__
 
 /******************************************************************************/
 /***************************** Include Files **********************************/
 /******************************************************************************/
-#ifdef STM32_PLATFORM
-#include "stm32/parameters.h"
-#elif defined MAXIM_PLATFORM
-#include "maxim/parameters.h"
-#elif defined XILINX_PLATFORM
-#include "xilinx/parameters.h"
-#elif defined ADUCM_PLATFORM
-#include "aducm3029/parameters.h"
-#elif defined LINUX_PLATFORM
-#include "linux/parameters.h"
+#include "platform_includes.h"
+#include "common_data.h"
+
+#ifdef IIO_EXAMPLE
+#include "iio_example.h"
 #endif
 
-#ifdef IIO_SUPPORT
-#include "iio_app.h"
+#ifdef IIO_TRIGGER_EXAMPLE
+#include "iio_trigger_example.h"
 #endif
 
-#endif /* __PLATFORM_INCLUDES_H__ */
+/***************************************************************************//**
+ * @brief Main function execution for Maxim platform.
+ *
+ * @return ret - Result of the enabled examples execution.
+*******************************************************************************/
+int main()
+{
+	int ret = -1;
+
+#if TARGET_NUM==32660
+#error TARGET MAX32660 not supported
+#endif
+
+#ifdef IIO_EXAMPLE
+	ret = iio_example_main();
+#endif
+
+#ifdef IIO_TRIGGER_EXAMPLE
+#error Software trigger is not supported over UART.
+#endif
+
+#if (IIO_EXAMPLE + IIO_TRIGGER_EXAMPLE == 0)
+#error At least one example has to be selected using y value in Makefile.
+#elif (IIO_EXAMPLE + IIO_TRIGGER_EXAMPLE > 1)
+#error Selected example projects cannot be enabled at the same time. \
+Please enable only one example and re-build the project.
+#endif
+
+	return ret;
+}

--- a/projects/iio_demo/src/platform/maxim/parameters.c
+++ b/projects/iio_demo/src/platform/maxim/parameters.c
@@ -1,7 +1,7 @@
 /***************************************************************************//**
- *   @file   platform_includes.h
- *   @brief  Includes for used platforms used by iio_demo project.
- *   @author RBolboac (ramona.bolboaca@analog.com)
+ *   @file   parameters.c
+ *   @brief  Definition of Maxim platform data used by iio_demo project.
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
 ********************************************************************************
  * Copyright 2022(c) Analog Devices, Inc.
  *
@@ -36,26 +36,8 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
-#ifndef __PLATFORM_INCLUDES_H__
-#define __PLATFORM_INCLUDES_H__
 
 /******************************************************************************/
 /***************************** Include Files **********************************/
 /******************************************************************************/
-#ifdef STM32_PLATFORM
-#include "stm32/parameters.h"
-#elif defined MAXIM_PLATFORM
-#include "maxim/parameters.h"
-#elif defined XILINX_PLATFORM
-#include "xilinx/parameters.h"
-#elif defined ADUCM_PLATFORM
-#include "aducm3029/parameters.h"
-#elif defined LINUX_PLATFORM
-#include "linux/parameters.h"
-#endif
-
-#ifdef IIO_SUPPORT
-#include "iio_app.h"
-#endif
-
-#endif /* __PLATFORM_INCLUDES_H__ */
+#include "parameters.h"

--- a/projects/iio_demo/src/platform/maxim/parameters.h
+++ b/projects/iio_demo/src/platform/maxim/parameters.h
@@ -1,7 +1,8 @@
 /***************************************************************************//**
- *   @file   platform_includes.h
- *   @brief  Includes for used platforms used by iio_demo project.
- *   @author RBolboac (ramona.bolboaca@analog.com)
+ *   @file   parameters.h
+ *   @brief  Definitions specific to Maxim platform used by iio_demo
+ *           project.
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
 ********************************************************************************
  * Copyright 2022(c) Analog Devices, Inc.
  *
@@ -36,26 +37,29 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
-#ifndef __PLATFORM_INCLUDES_H__
-#define __PLATFORM_INCLUDES_H__
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
 
 /******************************************************************************/
 /***************************** Include Files **********************************/
 /******************************************************************************/
-#ifdef STM32_PLATFORM
-#include "stm32/parameters.h"
-#elif defined MAXIM_PLATFORM
-#include "maxim/parameters.h"
-#elif defined XILINX_PLATFORM
-#include "xilinx/parameters.h"
-#elif defined ADUCM_PLATFORM
-#include "aducm3029/parameters.h"
-#elif defined LINUX_PLATFORM
-#include "linux/parameters.h"
-#endif
+#include "irq_extra.h"
+#include "maxim_uart.h"
+#include "maxim_stdio.h"
+#include "common_data.h"
+#include "no_os_util.h"
 
-#ifdef IIO_SUPPORT
-#include "iio_app.h"
-#endif
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+#define MAX_SIZE_BASE_ADDR	(SAMPLES_PER_CHANNEL * DEMO_CHANNELS * \
+					sizeof(uint16_t))
 
-#endif /* __PLATFORM_INCLUDES_H__ */
+#define SAMPLES_PER_CHANNEL_PLATFORM 2000
+
+#define INTC_DEVICE_ID	0
+#define UART_IRQ_ID    	UART0_IRQn
+#define UART_DEVICE_ID	0
+#define UART_BAUDRATE	57600
+
+#endif /* __PARAMETERS_H__ */

--- a/projects/iio_demo/src/platform/maxim/platform_src.mk
+++ b/projects/iio_demo/src/platform/maxim/platform_src.mk
@@ -1,0 +1,17 @@
+INCS += $(INCLUDE)/no_os_rtc.h
+
+SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c	\
+	$(PLATFORM_DRIVERS)/maxim_irq.c		\
+	$(PLATFORM_DRIVERS)/maxim_rtc.c		\
+	$(PLATFORM_DRIVERS)/maxim_uart.c	\
+	$(PLATFORM_DRIVERS)/maxim_stdio.c
+	
+INCS += $(PLATFORM_DRIVERS)/irq_extra.h		\
+	$(PLATFORM_DRIVERS)/maxim_hal.h		\
+	$(PLATFORM_DRIVERS)/maxim_uart.h	\
+	$(PLATFORM_DRIVERS)/rtc_extra.h		\
+	$(PLATFORM_DRIVERS)/maxim_stdio.h
+	
+SRCS += $(DRIVERS)/api/no_os_irq.c
+
+SRCS += $(NO-OS)/util/no_os_lf256fifo.c


### PR DESCRIPTION
Implemented support for iio_demo on Maxim platform. For now, the baudrate will be set to 57600.
Tested on MAX32650 and MAX32655.