### PR TITLE
Maxim RTC API update

### DIFF
--- a/drivers/platform/maxim/maxim_gpio_irq.c
+++ b/drivers/platform/maxim/maxim_gpio_irq.c
@@ -266,8 +266,6 @@ static int max_gpio_irq_trigger_level_set(struct no_os_irq_ctrl_desc *desc,
 {
 	int ret;
 	mxc_gpio_cfg_t cfg;
-	struct irq_action *action;
-	struct irq_action action_key = {.irq_id = irq_id};
 
 	const int32_t trig_level[5] = {
 		/** This is intentional, the levels are inverted in the SDK */
@@ -281,12 +279,8 @@ static int max_gpio_irq_trigger_level_set(struct no_os_irq_ctrl_desc *desc,
 	if (!desc || irq_id >= MXC_CFG_GPIO_PINS_PORT)
 		return -EINVAL;
 
-	ret = no_os_list_read_find(actions, (void **)&action, &action_key);
-	if (ret)
-		return -ENODEV;
-
 	cfg = (mxc_gpio_cfg_t) {
-		.port = action->handle,
+		.port = MXC_GPIO_GET_GPIO(desc->irq_ctrl_id),
 		.mask = NO_OS_BIT(irq_id)
 	};
 	MXC_GPIO_IntConfig(&cfg, trig_level[trig]);

--- a/drivers/platform/maxim/maxim_rtc.c
+++ b/drivers/platform/maxim/maxim_rtc.c
@@ -124,11 +124,8 @@ int32_t no_os_rtc_remove(struct no_os_rtc_desc *dev)
  */
 int32_t no_os_rtc_start(struct no_os_rtc_desc *dev)
 {
+	MXC_RTC_Wait_BusyToClear();
 	MXC_RTC_Start();
-
-	/** Wait for synchronization */
-	if (MXC_RTC_CheckBusy())
-		return -EBUSY;
 
 	return 0;
 }
@@ -140,11 +137,8 @@ int32_t no_os_rtc_start(struct no_os_rtc_desc *dev)
  */
 int32_t no_os_rtc_stop(struct no_os_rtc_desc *dev)
 {
-	int32_t ret;
-
-	ret = MXC_RTC_Stop();
-	if (ret == E_BUSY)
-		return -EBUSY;
+	MXC_RTC_Wait_BusyToClear();
+	MXC_RTC_Stop();
 
 	return 0;
 }
@@ -157,9 +151,6 @@ int32_t no_os_rtc_stop(struct no_os_rtc_desc *dev)
  */
 int32_t no_os_rtc_get_cnt(struct no_os_rtc_desc *dev, uint32_t *tmr_cnt)
 {
-	if (MXC_RTC_CheckBusy())
-		return -EBUSY;
-
 	*tmr_cnt = MXC_RTC_GetSecond();
 
 	return 0;
@@ -180,21 +171,19 @@ int32_t no_os_rtc_set_cnt(struct no_os_rtc_desc *dev, uint32_t tmr_cnt)
 
 	rtc_regs = MXC_RTC;
 
-	if (MXC_RTC_CheckBusy())
-		return -EBUSY;
-
+	MXC_RTC_Wait_BusyToClear();
 	rtc_regs->ctrl |= MXC_F_RTC_REVA_CTRL_WR_EN;
+
+	MXC_RTC_Wait_BusyToClear();
 	no_os_rtc_stop(dev);
 
-	if (MXC_RTC_CheckBusy())
-		return -EBUSY;
-
+	MXC_RTC_Wait_BusyToClear();
 	rtc_regs->sec = tmr_cnt;
+
+	MXC_RTC_Wait_BusyToClear();
 	no_os_rtc_start(dev);
 
-	if (MXC_RTC_CheckBusy())
-		return -EBUSY;
-
+	MXC_RTC_Wait_BusyToClear();
 	rtc_regs->ctrl &= ~MXC_F_RTC_REVA_CTRL_WR_EN;
 
 	return 0;


### PR DESCRIPTION
- Removed a useless list search in `trigger_level_set` function.
- Updated the `MXC_RTC_CheckBusy` function calls to `MXC_RTC_Wait_BusyToClear`, because the API changed in the last
SDK update.