### PR TITLE
drivers: adc: ad9208: fix ifdef statement

### DIFF
--- a/drivers/adc/ad9208/ad9208_api/api_def.h
+++ b/drivers/adc/ad9208/ad9208_api/api_def.h
@@ -27,7 +27,7 @@
 #define ALL -1
 
 #define DIV_U64_REM(x, y, r) no_os_div64_u64_rem(x, y, r)
-#ifndef DIV_U64
+#ifndef NO_OS_DIV_U64
 #define NO_OS_DIV_U64(x, y) no_os_div_u64(x, y)
 #endif
 #define DIV_S64(x, y) no_os_div_s64(x, y)


### PR DESCRIPTION
Fix ifdef statement for `NO_OS_DIV_U64`.

Fixes: 108ffba ("include:no_os_util.h Add no_os_prefix to functions, enums, structures.")
Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>