### PR TITLE
drivers: temperature: max31875: fix read function

### DIFF
--- a/drivers/temperature/max31875/max31875.c
+++ b/drivers/temperature/max31875/max31875.c
@@ -123,7 +123,7 @@ int32_t max31875_reg_write_mask(struct max31875_dev *dev,
 	if (!dev)
 		return -EINVAL;
 
-	ret = max31875_reg_read(dev, reg, regval);
+	ret = max31875_reg_read(dev, reg, &regval);
 	if (NO_OS_IS_ERR_VALUE(ret))
 		return ret;
 


### PR DESCRIPTION
The `regval` is passed as reference to the max31875_reg_read function.

Fixes: 2b9c133 ("drivers:temperature:max31875: initial commit")
Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>