### PR TITLE
drivers: ad7799: iio: fix variable type

### DIFF
--- a/drivers/adc/ad7799/iio_ad7799.c
+++ b/drivers/adc/ad7799/iio_ad7799.c
@@ -57,7 +57,8 @@ static int ad7799_iio_channel_read(void *device, char *buf, uint32_t len,
 				   const struct iio_ch_info *channel)
 {
 	struct ad7799_dev *dev = (struct ad7799_dev *)device;
-	int32_t ret, data;
+	int32_t ret;
+	uint32_t data;
 
 	ret = ad7799_get_channel(dev, channel->ch_num, &data);
 	if (ret != 0)


### PR DESCRIPTION
After the latest changes of the iio driver, the `data` variable should
be of unsigned type.

Fixes: 1737aec ("drivers:adc:ad7799_iio: read raw data")
Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>