### PR TITLE
iio_adxl355: Remove empty line from available items list

### DIFF
--- a/drivers/accel/adxl355/adxl355.c
+++ b/drivers/accel/adxl355/adxl355.c
@@ -692,8 +692,8 @@ int adxl355_set_fifo_samples(struct adxl355_dev *dev, uint8_t reg_value)
  *
  * @return ret         - Result of the configuration procedure.
 *******************************************************************************/
-int adxl355_get_raw_fifo_data (struct adxl355_dev *dev, uint8_t *fifo_entries,
-			       uint32_t *raw_x, uint32_t *raw_y, uint32_t *raw_z)
+int adxl355_get_raw_fifo_data(struct adxl355_dev *dev, uint8_t *fifo_entries,
+			      uint32_t *raw_x, uint32_t *raw_y, uint32_t *raw_z)
 {
 	int ret;
 
@@ -734,10 +734,10 @@ int adxl355_get_raw_fifo_data (struct adxl355_dev *dev, uint8_t *fifo_entries,
  *
  * @return ret         - Result of the configuration procedure.
 *******************************************************************************/
-int adxl355_get_fifo_data (struct adxl355_dev *dev, uint8_t *fifo_entries,
-			   struct adxl355_frac_repr *x,
-			   struct adxl355_frac_repr *y,
-			   struct adxl355_frac_repr *z)
+int adxl355_get_fifo_data(struct adxl355_dev *dev, uint8_t *fifo_entries,
+			  struct adxl355_frac_repr *x,
+			  struct adxl355_frac_repr *y,
+			  struct adxl355_frac_repr *z)
 {
 	int ret;
 	uint32_t raw_x[32];
@@ -770,8 +770,8 @@ int adxl355_get_fifo_data (struct adxl355_dev *dev, uint8_t *fifo_entries,
  *
  * @return ret         - Result of the configuration procedure.
 *******************************************************************************/
-int adxl355_conf_act_en (struct adxl355_dev *dev,
-			 union adxl355_act_en_flags act_config)
+int adxl355_conf_act_en(struct adxl355_dev *dev,
+			union adxl355_act_en_flags act_config)
 {
 	int ret;
 	uint8_t reg_val = act_config.value;
@@ -793,7 +793,7 @@ int adxl355_conf_act_en (struct adxl355_dev *dev,
  *
  * @return ret    - Result of the configuration procedure.
 *******************************************************************************/
-int adxl355_conf_act_thr (struct adxl355_dev *dev, uint16_t act_thr)
+int adxl355_conf_act_thr(struct adxl355_dev *dev, uint16_t act_thr)
 {
 	int ret;
 	uint8_t data[2] = {act_thr >> 8, (uint8_t)act_thr};
@@ -834,8 +834,8 @@ int adxl355_set_act_cnt_reg(struct adxl355_dev *dev, uint8_t act_cnt)
  *
  * @return ret     - Result of the configuration procedure.
 *******************************************************************************/
-int adxl355_config_int_pins (struct adxl355_dev *dev,
-			     union adxl355_int_mask int_conf)
+int adxl355_config_int_pins(struct adxl355_dev *dev,
+			    union adxl355_int_mask int_conf)
 {
 	uint8_t reg_val = int_conf.value;
 

--- a/drivers/accel/adxl355/adxl355.h
+++ b/drivers/accel/adxl355/adxl355.h
@@ -338,13 +338,13 @@ int adxl355_get_nb_of_fifo_entries(struct adxl355_dev *dev, uint8_t *reg_value);
 int adxl355_set_fifo_samples(struct adxl355_dev *dev, uint8_t reg_value);
 
 /*! Reads fifo data and returns the raw values. */
-int adxl355_get_raw_fifo_data (struct adxl355_dev *dev, uint8_t *fifo_entries,
-			       uint32_t *raw_x, uint32_t *raw_y, uint32_t *raw_z);
+int adxl355_get_raw_fifo_data(struct adxl355_dev *dev, uint8_t *fifo_entries,
+			      uint32_t *raw_x, uint32_t *raw_y, uint32_t *raw_z);
 
 /*! Reads fifo data and returns the values converted in g. */
-int adxl355_get_fifo_data (struct adxl355_dev *dev, uint8_t *fifo_entries,
-			   struct adxl355_frac_repr *x, struct adxl355_frac_repr *y,
-			   struct adxl355_frac_repr *z);
+int adxl355_get_fifo_data(struct adxl355_dev *dev, uint8_t *fifo_entries,
+			  struct adxl355_frac_repr *x, struct adxl355_frac_repr *y,
+			  struct adxl355_frac_repr *z);
 
 /*! Configures the activity enable register. */
 int adxl355_conf_act_en(struct adxl355_dev *dev,

--- a/drivers/accel/adxl355/iio_adxl355.c
+++ b/drivers/accel/adxl355/iio_adxl355.c
@@ -805,7 +805,8 @@ static int adxl355_iio_read_hpf_available(void *dev, char *buf, uint32_t len,
 			vals[1] = iio_adxl355->adxl355_hpf_3db_table[i][1];
 			iio_format_value(buffer, len, IIO_VAL_INT_PLUS_MICRO, 2, vals);
 			strcat(buf, buffer);
-			strcat(buf, " ");
+			if (i < NO_OS_ARRAY_SIZE(iio_adxl355->adxl355_hpf_3db_table) - 1)
+				strcat(buf, " ");
 		}
 		return strlen(buf);
 	default:
@@ -842,7 +843,8 @@ static int adxl355_iio_read_samp_freq_avail(void *dev, char *buf,
 			vals[1] = adxl355_iio_odr_table[i][1];
 			iio_format_value(buffer, sizeof(buffer), IIO_VAL_INT_PLUS_MICRO, 2, vals);
 			strcat(buf, buffer);
-			strcat(buf, " ");
+			if (i < NO_OS_ARRAY_SIZE(adxl355_iio_odr_table) - 1)
+				strcat(buf, " ");
 		}
 		return strlen(buf);
 	default:


### PR DESCRIPTION
- Remove empty items from available frequency and hpf frequency lists.
- Remove not needed white spaces. 
