### PR TITLE
ad4110: change buffer type

### DIFF
--- a/drivers/afe/ad4110/ad4110.c
+++ b/drivers/afe/ad4110/ad4110.c
@@ -1034,8 +1034,8 @@ err_dev:
  *
  * @return 0 in case of success, negative error code otherwise.
 *******************************************************************************/
-int32_t ad4110_continuous_read(struct ad4110_dev *dev, int32_t *buffer,
-			       int32_t buffer_size)
+int32_t ad4110_continuous_read(struct ad4110_dev *dev, uint32_t *buffer,
+			       uint32_t buffer_size)
 {
 	int32_t ret;
 

--- a/drivers/afe/ad4110/ad4110.h
+++ b/drivers/afe/ad4110/ad4110.h
@@ -355,8 +355,8 @@ struct ad4110_init_param {
 
 struct ad4110_callback_ctx {
 	struct ad4110_dev *dev;
-	int32_t *buffer;
-	int32_t buffer_size;
+	uint32_t *buffer;
+	uint32_t buffer_size;
 };
 
 /******************************************************************************/
@@ -415,8 +415,8 @@ int32_t ad4110_spi_int_reg_read(struct ad4110_dev *dev,
 				uint32_t *reg_data);
 
 /* Fills buffer with buffer_size number of samples using irq */
-int32_t ad4110_continuous_read(struct ad4110_dev *dev, int32_t *buffer,
-			       int32_t buffer_size);
+int32_t ad4110_continuous_read(struct ad4110_dev *dev, uint32_t *buffer,
+			       uint32_t buffer_size);
 
 /* SPI internal DATA register read from device. */
 int32_t ad4110_spi_int_data_reg_read(struct ad4110_dev *dev,

--- a/projects/ad4110/src/app/main.c
+++ b/projects/ad4110/src/app/main.c
@@ -54,7 +54,7 @@
 #include <inttypes.h>
 #include <xil_cache.h>
 
-static int32_t data_buf[BUF_LENGTH];
+static uint32_t data_buf[BUF_LENGTH];
 
 /***************************************************************************//**
  * @brief main


### PR DESCRIPTION
Switch from int32_t to uint32_t since the adc resolution is 24-bit.

Fix incompatible types warnings.

Fixes: 8b68f1c ("drivers:afe:ad4110: Add continuous_read function")
Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>