### PR TITLE
iio:iio_trigger: Change return type for iio_hw_trig_handler

### DIFF
--- a/iio/iio_trigger.c
+++ b/iio/iio_trigger.c
@@ -142,17 +142,15 @@ int iio_trig_disable(void *trig)
  * interrupt is asserted for the configured trigger.
  *
  * @param trig - Trigger structure which is linked to this handler.
- *
- * @return ret - Result of the hw trigger handler procedure.
 */
-int iio_hw_trig_handler(void *trig)
+void iio_hw_trig_handler(void *trig)
 {
 	if(!trig)
-		return -EINVAL;
+		return;
 
 	struct iio_hw_trig *desc = trig;
 
-	return iio_process_trigger_type(*desc->iio_desc, desc->name);
+	iio_process_trigger_type(*desc->iio_desc, desc->name);
 }
 
 /**

--- a/iio/iio_trigger.h
+++ b/iio/iio_trigger.h
@@ -135,7 +135,7 @@ int iio_trig_enable(void *trig);
 /** API to disable a hardware trigger */
 int iio_trig_disable(void *trig);
 /** API for hardware trigger handler */
-int iio_hw_trig_handler(void *trig);
+void iio_hw_trig_handler(void *trig);
 /** API to remove a hardware trigger */
 int iio_hw_trig_remove(struct iio_hw_trig *trig);
 #endif


### PR DESCRIPTION
Change return type for iio_hw_trig_handler from int to void seeing how the handler is called from interrupt and the
return value is never used.