### PR TITLE
projects:eval-adxl355-pmdz: Fixed maxim build

### DIFF
--- a/projects/eval-adxl355-pmdz/src/platform/maxim/parameters.h
+++ b/projects/eval-adxl355-pmdz/src/platform/maxim/parameters.h
@@ -61,6 +61,7 @@
 
 #define UART_DEVICE_ID  0
 #define UART_BAUDRATE   57600
+#define UART_EXTRA      &adxl355_uart_extra_ip
 
 #define SPI_DEVICE_ID   0
 #define SPI_BAUDRATE    1000000


### PR DESCRIPTION
The build on Maxim failed because a define was missing.