### PR TITLE
drivers:platform:aducm3029: Add timer support

### DIFF
--- a/drivers/platform/aducm3029/aducm3029_timer.c
+++ b/drivers/platform/aducm3029/aducm3029_timer.c
@@ -1,5 +1,5 @@
 /***************************************************************************//**
- *   @file   aducm3029/no_os_timer.c
+ *   @file   aducm3029/aducm3029_timer.c
  *   @brief  Implementation of TIMER driver for ADuCM302x.
  *
  *   This driver enables the user to create multiple instance of a
@@ -47,7 +47,7 @@
 
 #include <stdlib.h>
 #include <drivers/tmr/adi_tmr.h>
-#include "timer_extra.h"
+#include "aducm3029_timer.h"
 #include "no_os_timer.h"
 #include "no_os_error.h"
 
@@ -68,7 +68,7 @@
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
-/** Incremented each millisecond by \ref no_os_tmr_callback() */
+/** Incremented each millisecond by \ref aducm3029_tmr_callback() */
 static volatile uint64_t	g_count;
 /** Counts the number of instances created */
 static uint32_t			nb_instances;
@@ -87,7 +87,7 @@ static uint32_t			timer_id;
  * @param tmr_event - Unused
  * @param arg - Unused
  */
-static void no_os_tmr_callback(void *param, uint32_t tmr_event, void *arg)
+static void aducm3029_tmr_callback(void *param, uint32_t tmr_event, void *arg)
 {
 	g_count++;
 }
@@ -108,8 +108,8 @@ static void no_os_tmr_callback(void *param, uint32_t tmr_event, void *arg)
  * is unused and should be NULL.
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_timer_init(struct no_os_timer_desc **desc,
-			 struct no_os_timer_init_param *param)
+int32_t aducm3029_timer_init(struct no_os_timer_desc **desc,
+			     struct no_os_timer_init_param *param)
 {
 	struct no_os_timer_desc *ldesc;
 	struct aducm_timer_desc *aducm_desc;
@@ -129,7 +129,7 @@ int32_t no_os_timer_init(struct no_os_timer_desc **desc,
 
 	if (nb_instances == 0) {
 		timer_id = param->id;
-		adi_tmr_Init(timer_id, no_os_tmr_callback, NULL, true);
+		adi_tmr_Init(timer_id, aducm3029_tmr_callback, NULL, true);
 		/* Set the timer configuration */
 		tmr_conf.bCountingUp = false;
 		tmr_conf.bPeriodic = true;
@@ -161,7 +161,7 @@ int32_t no_os_timer_init(struct no_os_timer_desc **desc,
  * @param desc - Descriptor of the timer instance.
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_timer_remove(struct no_os_timer_desc *desc)
+int32_t aducm3029_timer_remove(struct no_os_timer_desc *desc)
 {
 	if (!desc)
 		return -1;
@@ -178,7 +178,7 @@ int32_t no_os_timer_remove(struct no_os_timer_desc *desc)
 	return 0;
 }
 
-static inline uint64_t no_os_get_current_time(struct no_os_timer_desc *desc)
+static inline uint64_t aducm3029_get_current_time(struct no_os_timer_desc *desc)
 {
 	uint16_t		count_us = 0;
 
@@ -198,7 +198,7 @@ static inline uint64_t no_os_get_current_time(struct no_os_timer_desc *desc)
  * @param desc - Descriptor of the timer instance.
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_timer_start(struct no_os_timer_desc *desc)
+int32_t aducm3029_timer_start(struct no_os_timer_desc *desc)
 {
 	struct aducm_timer_desc *tmr_desc;
 
@@ -210,7 +210,7 @@ int32_t no_os_timer_start(struct no_os_timer_desc *desc)
 		return -1;
 	if (nb_enables == 0)
 		while (ADI_TMR_DEVICE_BUSY == adi_tmr_Enable(timer_id, true));
-	tmr_desc->old_time = no_os_get_current_time(desc);
+	tmr_desc->old_time = aducm3029_get_current_time(desc);
 	tmr_desc->started = true;
 	nb_enables++;
 
@@ -224,7 +224,7 @@ int32_t no_os_timer_start(struct no_os_timer_desc *desc)
  * @param desc - Descriptor of the timer instance.
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_timer_stop(struct no_os_timer_desc *desc)
+int32_t aducm3029_timer_stop(struct no_os_timer_desc *desc)
 {
 	uint32_t		counter;
 	struct aducm_timer_desc *tmr_desc;
@@ -252,8 +252,8 @@ int32_t no_os_timer_stop(struct no_os_timer_desc *desc)
  * @param counter - Pointer were the timer counter is stored.
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_timer_counter_get(struct no_os_timer_desc *desc,
-				uint32_t *counter)
+int32_t aducm3029_timer_counter_get(struct no_os_timer_desc *desc,
+				    uint32_t *counter)
 {
 	struct aducm_timer_desc	*tmr_desc;
 	uint16_t		count_us;
@@ -306,7 +306,8 @@ int32_t no_os_timer_counter_get(struct no_os_timer_desc *desc,
  * @param new_val - Value of the new counter to be set
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_timer_counter_set(struct no_os_timer_desc *desc, uint32_t new_val)
+int32_t aducm3029_timer_counter_set(struct no_os_timer_desc *desc,
+				    uint32_t new_val)
 {
 	struct aducm_timer_desc	*tmr_desc;
 
@@ -314,7 +315,7 @@ int32_t no_os_timer_counter_set(struct no_os_timer_desc *desc, uint32_t new_val)
 		return -1;
 
 	tmr_desc = (struct aducm_timer_desc *)desc->extra;
-	tmr_desc->old_time = no_os_get_current_time(desc);
+	tmr_desc->old_time = aducm3029_get_current_time(desc);
 	desc->load_value = new_val;
 
 	return 0;
@@ -326,8 +327,8 @@ int32_t no_os_timer_counter_set(struct no_os_timer_desc *desc, uint32_t new_val)
  * @param freq_hz - Pointer where the frequency value will be stored
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_timer_count_clk_get(struct no_os_timer_desc *desc,
-				  uint32_t *freq_hz)
+int32_t aducm3029_timer_count_clk_get(struct no_os_timer_desc *desc,
+				      uint32_t *freq_hz)
 {
 	if (!desc || !freq_hz)
 		return -1;
@@ -344,8 +345,8 @@ int32_t no_os_timer_count_clk_get(struct no_os_timer_desc *desc,
  * @param freq_hz - Value of the new frequency to be set
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_timer_count_clk_set(struct no_os_timer_desc *desc,
-				  uint32_t freq_hz)
+int32_t aducm3029_timer_count_clk_set(struct no_os_timer_desc *desc,
+				      uint32_t freq_hz)
 {
 	if (!desc || ((struct aducm_timer_desc*)desc->extra)->started)
 		return -1;
@@ -354,3 +355,31 @@ int32_t no_os_timer_count_clk_set(struct no_os_timer_desc *desc,
 
 	return 0;
 }
+
+/**
+ * @brief Get the elapsed time in nsec for the timer.
+ * @param [in] desc         - Pointer to the device handler.
+ * @param [in] elapsed_time - The elapsed time in nsec.
+ * @return 0 in case of success, error code otherwise.
+ */
+int32_t aducm3029_timer_get_elapsed_time_nsec(struct no_os_timer_desc *desc,
+		uint64_t *elapsed_time)
+{
+	/* Function not implemented because it is not needed at the moment */
+	return -ENOSYS;
+}
+
+/**
+ * @brief aducm3029 platform specific timer platform ops structure
+ */
+const struct no_os_timer_platform_ops aducm3029_timer_ops = {
+	.init = &aducm3029_timer_init,
+	.start = &aducm3029_timer_start,
+	.stop = &aducm3029_timer_stop,
+	.counter_get = &aducm3029_timer_counter_get,
+	.counter_set = &aducm3029_timer_counter_set,
+	.count_clk_get = &aducm3029_timer_count_clk_get,
+	.count_clk_set = &aducm3029_timer_count_clk_set,
+	.get_elapsed_time_nsec = &aducm3029_timer_get_elapsed_time_nsec,
+	.remove = &aducm3029_timer_remove
+};

--- a/drivers/platform/aducm3029/aducm3029_timer.h
+++ b/drivers/platform/aducm3029/aducm3029_timer.h
@@ -1,5 +1,5 @@
 /***************************************************************************//**
- *   @file   timer_extra.h
+ *   @file   aducm3029_timer.h
  *   @brief  Header file of TIMER driver for ADuCM302x
  *   @author Mihail Chindris (mihail.chindris@analog.com)
 ********************************************************************************
@@ -37,8 +37,15 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 
-#ifndef TIMER_EXTRA_H
-#define TIMER_EXTRA_H
+#ifndef ADUCM3029_TIMER_H
+#define ADUCM3029_TIMER_H
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdint.h>
+#include "no_os_util.h"
+#include "no_os_timer.h"
 
 /******************************************************************************/
 /************************** Types Declarations *******************************/
@@ -55,4 +62,9 @@ struct aducm_timer_desc {
 	bool		started;
 };
 
-#endif /* TIMER_EXTRA_H */
+/**
+ * @brief aducm3029 specific timer platform ops structure
+ */
+extern const struct no_os_timer_platform_ops aducm3029_timer_ops;
+
+#endif /* ADUCM3029_TIMER_H */

--- a/drivers/platform/aducm3029/aducm3029_timer.h
+++ b/drivers/platform/aducm3029/aducm3029_timer.h
@@ -46,10 +46,33 @@
 #include <stdint.h>
 #include "no_os_util.h"
 #include "no_os_timer.h"
+#include <drivers/tmr/adi_tmr.h>
 
 /******************************************************************************/
 /************************** Types Declarations *******************************/
 /******************************************************************************/
+/**
+ * @enum avail_freqs
+ * @brief  It lists the available source frequencies for timer instance 1
+ */
+enum avail_freqs {
+	PCLK_DIV1,
+	PCLK_DIV16,
+	PCLK_DIV64,
+	PCLK_DIV256,
+	HFOSC_DIV1,
+	HFOSC_DIV16,
+	HFOSC_DIV64,
+	HFOSC_DIV256,
+	LFOSC_DIV1,
+	LFOSC_DIV16,
+	LFOSC_DIV64,
+	LFOSC_DIV256,
+	LFXTAL_DIV1,
+	LFXTAL_DIV16,
+	LFXTAL_DIV64,
+	LFXTAL_DIV256,
+};
 
 /**
  * @struct aducm_timer_desc
@@ -60,6 +83,17 @@ struct aducm_timer_desc {
 	uint64_t	old_time;
 	/** 1 if the instance is counting, 0 otherwise */
 	bool		started;
+	/** Timer configuration for adum3029 */
+	ADI_TMR_CONFIG	tmr_conf;
+};
+
+/**
+ * @struct aducm_timer_desc
+ * @brief  It stores instance values specific for the ADuCM302x implementation
+ */
+struct aducm_timer_init_param {
+	/** Selected frequency for timer clock source */
+	enum avail_freqs source_freq;
 };
 
 /**

--- a/drivers/platform/aducm3029/delay.c
+++ b/drivers/platform/aducm3029/delay.c
@@ -44,6 +44,7 @@
 #include "no_os_delay.h"
 #include "no_os_timer.h"
 #include "no_os_error.h"
+#include "aducm3029_timer.h"
 
 /******************************************************************************/
 /****************************** Global Variables*******************************/
@@ -81,6 +82,7 @@ static uint32_t initialize_timer(struct no_os_timer_desc **timer,
 	param.id = 0;
 	param.freq_hz = is_us ? 1000000u : 1000u;
 	param.load_value = 0;
+	param.platform_ops = &aducm3029_timer_ops;
 
 	if (is_us) {
 		if (0 != no_os_timer_init(&dummy_timer, &param))

--- a/drivers/platform/aducm3029/irq_extra.h
+++ b/drivers/platform/aducm3029/irq_extra.h
@@ -53,9 +53,6 @@
 /********************** Macros and Constants Definitions **********************/
 /******************************************************************************/
 
-/** Number of available interrupts */
-#define NB_INTERRUPTS		2u
-
 /** RTC interrupt defines */
 #define RTC_COUNT_INT		ADI_RTC_COUNT_INT
 #define RTC_COUNT_ROLLOVER_INT	ADI_RTC_COUNT_ROLLOVER_INT
@@ -73,6 +70,10 @@ enum irq_id {
 	ADUCM_UART_INT_ID,
 	/** RTC interrupt ID*/
 	ADUCM_RTC_INT_ID,
+	/** TIMER1 interrupt ID */
+	ADUCM_TIMER1_INT_ID,
+	/** Number of available interrupts */
+	NB_INTERRUPTS,
 };
 
 /**

--- a/projects/ad7124-8pmdz/src.mk
+++ b/projects/ad7124-8pmdz/src.mk
@@ -7,6 +7,7 @@ SRC_DIRS += $(NO-OS)/iio/iio_app
 SRCS += $(NO-OS)/drivers/adc/ad7124/ad7124.c \
 	$(NO-OS)/drivers/adc/ad7124/iio_ad7124.c \
 	$(DRIVERS)/api/no_os_spi.c \
+	$(DRIVERS)/api/no_os_timer.c \
 	$(DRIVERS)/api/no_os_irq.c
 
 # Add to INCS inlcude files to be build in the porject

--- a/projects/ad7746-ebz/src.mk
+++ b/projects/ad7746-ebz/src.mk
@@ -1,7 +1,6 @@
 CFLAGS += -DENABLE_UART_STDIO
 SRCS += $(NO-OS)/util/no_os_util.c \
 	$(PLATFORM_DRIVERS)/delay.c \
-	$(PLATFORM_DRIVERS)/no_os_timer.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_i2c.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c \
 	$(PLATFORM_DRIVERS)/no_os_uart.c \
@@ -10,9 +9,11 @@ SRCS += $(NO-OS)/util/no_os_util.c \
 	$(PLATFORM_DRIVERS)/uart_stdio.c \
 	$(PLATFORM_DRIVERS)/no_os_rtc.c \
 	$(PLATFORM_DRIVERS)/platform_init.c \
+	$(PLATFORM_DRIVERS)/aducm3029_timer.c \
 	$(DRIVERS)/cdc/ad7746/ad7746.c \
 	$(DRIVERS)/api/no_os_i2c.c \
 	$(DRIVERS)/api/no_os_irq.c \
+	$(DRIVERS)/api/no_os_timer.c \
 	$(PROJECT)/src/app/headless.c
 
 INCS +=	$(INCLUDE)/no_os_uart.h \
@@ -29,7 +30,7 @@ INCS +=	$(INCLUDE)/no_os_uart.h \
 	$(INCLUDE)/no_os_list.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
 	$(PLATFORM_DRIVERS)/i2c_extra.h \
-	$(PLATFORM_DRIVERS)/timer_extra.h \
+	$(PLATFORM_DRIVERS)/aducm3029_timer.h \
 	$(PLATFORM_DRIVERS)/uart_extra.h \
 	$(PLATFORM_DRIVERS)/uart_stdio.h \
 	$(PLATFORM_DRIVERS)/rtc_extra.h \

--- a/projects/ada4250_ardz/src.mk
+++ b/projects/ada4250_ardz/src.mk
@@ -11,12 +11,13 @@ SRCS += $(NO-OS)/util/no_os_util.c \
 	$(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/api/no_os_irq.c \
 	$(DRIVERS)/api/no_os_gpio.c \
+	$(DRIVERS)/api/no_os_timer.c \
 	$(DRIVERS)/platform/$(PLATFORM)/$(PLATFORM)_spi.c \
 	$(DRIVERS)/platform/$(PLATFORM)/$(PLATFORM)_irq.c \
 	$(DRIVERS)/platform/$(PLATFORM)/$(PLATFORM)_gpio.c \
+	$(DRIVERS)/platform/$(PLATFORM)/$(PLATFORM)_timer.c \
 	$(DRIVERS)/platform/$(PLATFORM)/no_os_rtc.c \
 	$(DRIVERS)/platform/$(PLATFORM)/delay.c \
-	$(DRIVERS)/platform/$(PLATFORM)/no_os_timer.c \
 	$(NO-OS)/util/no_os_lf256fifo.c \
 	$(DRIVERS)/platform/$(PLATFORM)/no_os_uart.c
 
@@ -24,13 +25,12 @@ INCS += $(INCLUDE)/no_os_spi.h \
 	$(INCLUDE)/no_os_irq.h \
 	$(INCLUDE)/no_os_uart.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
-	$(INCLUDE)/no_os_timer.h \
 	$(DRIVERS)/platform/$(PLATFORM)/spi_extra.h \
 	$(DRIVERS)/platform/$(PLATFORM)/irq_extra.h \
 	$(DRIVERS)/platform/$(PLATFORM)/aducm3029_gpio.h \
 	$(DRIVERS)/platform/$(PLATFORM)/uart_extra.h \
 	$(DRIVERS)/platform/$(PLATFORM)/rtc_extra.h \
-	$(DRIVERS)/platform/$(PLATFORM)/timer_extra.h
+	$(DRIVERS)/platform/$(PLATFORM)/$(PLATFORM)_timer.h
 
 IGNORED_FILES += $(PLATFORM_DRIVERS)/uart_stdio.c
 IGNORED_FILES += $(PLATFORM_DRIVERS)/uart_stdio.h

--- a/projects/aducm_blinky_example/src.mk
+++ b/projects/aducm_blinky_example/src.mk
@@ -30,7 +30,8 @@ rwildcard = $(wildcard $1$2) $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2
 SRCS += $(DRIVERS)/api/no_os_gpio.c \
         $(DRIVERS)/api/no_os_i2c.c  \
         $(DRIVERS)/api/no_os_irq.c  \
-        $(DRIVERS)/api/no_os_spi.c
+        $(DRIVERS)/api/no_os_spi.c  \
+		$(DRIVERS)/api/no_os_timer.c
 
 SRCS += $(foreach dir, $(REMAINING_DIRECORIES), $(call rwildcard, $(dir),*.c))
 INCS += $(foreach dir, $(REMAINING_DIRECORIES), $(call rwildcard, $(dir),*.h))

--- a/projects/adxrs290-pmdz/Makefile
+++ b/projects/adxrs290-pmdz/Makefile
@@ -1,6 +1,7 @@
 # Select the example you want to enable by chossing y for enabling and n for disabling
-IIO_EXAMPLE = y
+IIO_EXAMPLE = n
 IIO_TRIGGER_EXAMPLE = n
+IIO_TIMER_TRIGGER_EXAMPLE = y
 
 include ../../tools/scripts/generic_variables.mk
 

--- a/projects/adxrs290-pmdz/builds.json
+++ b/projects/adxrs290-pmdz/builds.json
@@ -1,15 +1,15 @@
 {
   "aducm3029": {
     "iio_example":  {
-      "flags" : "IIO_EXAMPLE=y IIO_TRIGGER_EXAMPLE=n"
+      "flags" : "IIO_EXAMPLE=y IIO_TRIGGER_EXAMPLE=n IIO_TIMER_TRIGGER_EXAMPLE=n"
     },
-    "iio_example_wifi":  {
-      "flags" : "IIO_EXAMPLE=y IIO_TRIGGER_EXAMPLE=n USE_TCP_SOCKET=y"
+    "iio_timer_trigger": {
+      "flags": "IIO_EXAMPLE=n IIO_SW_TRIGGER_EXAMPLE=n IIO_TIMER_TRIGGER_EXAMPLE=y"
     }
   },
   "stm32": {
 	"iio_example": {
-      "flags" : "IIO_EXAMPLE=y IIO_TRIGGER_EXAMPLE=n"
+      "flags" : "IIO_EXAMPLE=y IIO_TRIGGER_EXAMPLE=n IIO_TIMER_TRIGGER_EXAMPLE=n"
     }
   }
 }

--- a/projects/adxrs290-pmdz/src.mk
+++ b/projects/adxrs290-pmdz/src.mk
@@ -3,6 +3,7 @@ include $(PROJECT)/src/examples/examples_src.mk
 
 SRCS += $(PROJECT)/src/platform/$(PLATFORM)/main.c
 
+INCS += $(PROJECT)/src/common/app_config.h
 INCS += $(PROJECT)/src/common/common_data.h
 SRCS += $(PROJECT)/src/common/common_data.c
 

--- a/projects/adxrs290-pmdz/src/common/common_data.c
+++ b/projects/adxrs290-pmdz/src/common/common_data.c
@@ -91,3 +91,33 @@ struct iio_hw_trig_init_param adxrs290_gpio_trig_ip = {
 	.name = ADXRS290_GPIO_TRIG_NAME,
 };
 #endif
+
+#ifdef IIO_TIMER_TRIGGER_EXAMPLE
+/* ADXRS290 timer init parameter */
+struct no_os_timer_init_param adxrs290_tip = {
+	.id = ADXRS290_TIMER_DEVICE_ID,
+	.freq_hz = ADXRS290_TIMER_FREQ_HZ,
+	.load_value = ADXRS290_TIMER_LOAD_VAL,
+	.platform_ops = TIMER_OPS,
+	.extra = ADXRS290_TIMER_EXTRA,
+};
+
+/* ADXRS290 timer irq init parameter */
+struct no_os_irq_init_param adxrs290_timer_irq_ip = {
+	.irq_ctrl_id = ADXRS290_TIMER_IRQ_ID,
+	.platform_ops = TIMER_IRQ_OPS,
+	.extra = ADADXRS290_TIMER_IRQ_EXTRA,
+};
+
+/* ADXRS290 timer trigger init parameter */
+struct iio_hw_trig_init_param adxrs290_timer_trig_ip = {
+	.irq_id = ADXRS290_TIMER_TRIG_IRQ_ID,
+	.cb_info = {
+		.event = NO_OS_EVT_TIM_ELAPSED,
+		.peripheral = NO_OS_TIM_IRQ,
+		.handle = ADXRS290_TIMER_CB_HANDLE,
+	},
+	.name = ADXRS290_TIMER_TRIG_NAME,
+};
+
+#endif

--- a/projects/adxrs290-pmdz/src/common/common_data.h
+++ b/projects/adxrs290-pmdz/src/common/common_data.h
@@ -46,7 +46,7 @@
 #include "adxrs290.h"
 #ifdef IIO_SUPPORT
 #include "iio_adxrs290.h"
-#ifdef IIO_TRIGGER_EXAMPLE
+#if defined(IIO_TRIGGER_EXAMPLE) || defined(IIO_TIMER_TRIGGER_EXAMPLE)
 #include "iio_trigger.h"
 #endif
 #endif
@@ -63,6 +63,13 @@ extern struct adxrs290_init_param adxrs290_ip;
 
 extern struct iio_hw_trig_init_param adxrs290_gpio_trig_ip;
 extern struct no_os_irq_init_param adxrs290_gpio_irq_ip;
+#endif
+
+#ifdef IIO_TIMER_TRIGGER_EXAMPLE
+#define ADXRS290_TIMER_TRIG_NAME "adxrs290_timer_trig"
+extern struct no_os_timer_init_param adxrs290_tip;
+extern struct no_os_irq_init_param adxrs290_timer_irq_ip;
+extern struct iio_hw_trig_init_param adxrs290_timer_trig_ip;
 #endif
 
 #endif /* __COMMON_DATA_H__ */

--- a/projects/adxrs290-pmdz/src/examples/examples_src.mk
+++ b/projects/adxrs290-pmdz/src/examples/examples_src.mk
@@ -12,6 +12,13 @@ SRCS += $(PROJECT)/src/examples/iio_trigger_example/iio_trigger_example.c
 INCS += $(PROJECT)/src/examples/iio_trigger_example/iio_trigger_example.h
 endif
 
+ifeq (y,$(strip $(IIO_TIMER_TRIGGER_EXAMPLE)))
+TINYIIOD=y
+CFLAGS += -DIIO_TIMER_TRIGGER_EXAMPLE=1
+SRCS += $(PROJECT)/src/examples/iio_timer_trigger_example/iio_timer_trigger_example.c
+INCS += $(PROJECT)/src/examples/iio_timer_trigger_example/iio_timer_trigger_example.h
+endif
+
 ifeq (y,$(strip $(TINYIIOD)))
 SRC_DIRS += $(NO-OS)/iio/iio_app
 SRCS += $(NO-OS)/iio/iio_trigger.c

--- a/projects/adxrs290-pmdz/src/examples/iio_timer_trigger_example/iio_timer_trigger_example.h
+++ b/projects/adxrs290-pmdz/src/examples/iio_timer_trigger_example/iio_timer_trigger_example.h
@@ -1,7 +1,6 @@
 /***************************************************************************//**
- *   @file   parameters.h
- *   @brief  Definitions specific to STM32 platform used by eval-adxrs290-pmdz
- *           project.
+ *   @file   iio_timer_trigger_example.h
+ *   @brief  IIO timer trigger example header for iio_demo project
  *   @author RBolboac (ramona.bolboaca@analog.com)
 ********************************************************************************
  * Copyright 2022(c) Analog Devices, Inc.
@@ -37,62 +36,16 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
-#ifndef __PARAMETERS_H__
-#define __PARAMETERS_H__
+#ifndef __IIO_TIMER_TRIGGER_EXAMPLE_H__
+#define __IIO_TIMER_TRIGGER_EXAMPLE_H__
 
 /******************************************************************************/
 /***************************** Include Files **********************************/
 /******************************************************************************/
-#include "stdio.h"
-#include "platform_init.h"
-#include "aducm3029_gpio.h"
-#include "spi_extra.h"
-#include "irq_extra.h"
-#include "aducm3029_timer.h"
-#include "no_os_timer.h"
 
 /******************************************************************************/
-/********************** Macros and Constants Definitions **********************/
+/************************ Functions Declarations ******************************/
 /******************************************************************************/
-#define UART_DEVICE_ID	0
-#define INTC_DEVICE_ID	0
-#define UART_IRQ_ID		ADUCM_UART_INT_ID
-#define UART_BAUDRATE	115200
+int iio_timer_trigger_example_main();
 
-#define SPI_DEVICE_ID   1
-#define SPI_BAUDRATE    1000000
-#define SPI_CS          0
-#define SPI_OPS         &aducm_spi_ops
-#define SPI_EXTRA       &adxrs290_spi_extra_ip
-
-#define GPIO_SYNC_PIN_NUM       0x10
-#define GPIO_SYNC_PORT_NUM      0
-#define GPIO_OPS                &aducm_gpio_ops
-#define GPIO_EXTRA              NULL
-
-#ifdef IIO_TRIGGER_EXAMPLE
-#error IIO_TRIGGER_EXAMPLE is not supported on ADUCM3029 platform for adxrs290-pmdz project.
-#endif
-
-#ifdef IIO_TIMER_TRIGGER_EXAMPLE
-/* ADXRS290 Timer settings */
-extern struct aducm_timer_init_param adxrs290_xtip;
-#define ADXRS290_TIMER_DEVICE_ID    1
-#define ADXRS290_TIMER_FREQ_HZ      200 /* Not used - Used clock source frequency is the one specified in adxrs290_xtip */
-#define ADXRS290_TIMER_LOAD_VAL     0xffff
-#define ADXRS290_TIMER_EXTRA        &adxrs290_xtip
-#define TIMER_OPS                   &aducm3029_timer_ops
-
-/* ADXRS290 Timer trigger settings */
-#define ADXRS290_TIMER_IRQ_ID       0 /* Not used */
-#define TIMER_IRQ_OPS               &aducm_irq_ops
-#define ADADXRS290_TIMER_IRQ_EXTRA  NULL /* Not used */
-
-/* ADXRS290 timer trigger settings */
-#define ADXRS290_TIMER_CB_HANDLE    0 /* Device descriptor is being used as a handle in this case */
-#define ADXRS290_TIMER_TRIG_IRQ_ID  ADUCM_TIMER1_INT_ID
-#endif
-
-extern struct aducm_spi_init_param adxrs290_spi_extra_ip;
-
-#endif /* __PARAMETERS_H__ */
+#endif /* __IIO_TIMER_TRIGGER_EXAMPLE_H__ */

--- a/projects/adxrs290-pmdz/src/platform/aducm3029/main.c
+++ b/projects/adxrs290-pmdz/src/platform/aducm3029/main.c
@@ -47,8 +47,8 @@
 #include "iio_example.h"
 #endif
 
-#ifdef IIO_TRIGGER_EXAMPLE
-#include "iio_trigger_example.h"
+#ifdef IIO_TIMER_TRIGGER_EXAMPLE
+#include "iio_timer_trigger_example.h"
 #endif
 
 /***************************************************************************//**
@@ -75,7 +75,13 @@ int main()
 #error IIO_TRIGGER_EXAMPLE is not supported on ADUCM3029 platform for adxrs290-pmdz project.
 #endif
 
-#if (IIO_EXAMPLE + IIO_TRIGGER_EXAMPLE != 1)
+#ifdef IIO_TIMER_TRIGGER_EXAMPLE
+	ret = iio_timer_trigger_example_main();
+	if (ret)
+		goto error;
+#endif
+
+#if (IIO_EXAMPLE + IIO_TIMER_TRIGGER_EXAMPLE != 1)
 #error Selected example projects cannot be enabled at the same time. \
 Please enable only one example and re-build the project.
 #endif

--- a/projects/adxrs290-pmdz/src/platform/aducm3029/parameters.c
+++ b/projects/adxrs290-pmdz/src/platform/aducm3029/parameters.c
@@ -51,3 +51,7 @@ struct aducm_spi_init_param adxrs290_spi_extra_ip = {
 	.half_duplex = false,
 	.master_mode = MASTER
 };
+
+struct aducm_timer_init_param adxrs290_xtip = {
+	.source_freq = PCLK_DIV256,
+};

--- a/projects/adxrs290-pmdz/src/platform/aducm3029/platform_src.mk
+++ b/projects/adxrs290-pmdz/src/platform/aducm3029/platform_src.mk
@@ -8,8 +8,11 @@ endif
 ifeq (y,$(strip $(ENABLE_IIO_NETWORK)))
 DISABLE_SECURE_SOCKET ?= y
 SRC_DIRS += $(NO-OS)/network
+
 SRCS	 += $(NO-OS)/util/no_os_circular_buffer.c
 INCS	 += $(INCLUDE)/no_os_circular_buffer.h
 endif
-SRC_DIRS += $(INCLUDE)
 SRC_DIRS += $(PLATFORM_DRIVERS)
+SRC_DIRS += $(INCLUDE)
+
+SRCS += $(DRIVERS)/api/no_os_timer.c

--- a/projects/adxrs290-pmdz/src/platform/maxim/main.c
+++ b/projects/adxrs290-pmdz/src/platform/maxim/main.c
@@ -93,6 +93,10 @@ int main()
 		goto error;
 #endif
 
+#ifdef IIO_TIMER_TRIGGER_EXAMPLE
+#error IIO_TIMER_TRIGGER_EXAMPLE is not supported on maxim platform.
+#endif
+
 #if (IIO_EXAMPLE + IIO_TRIGGER_EXAMPLE == 0)
 #error At least one example has to be selected using y value in Makefile.
 #elif (IIO_EXAMPLE + IIO_TRIGGER_EXAMPLE > 1)

--- a/projects/adxrs290-pmdz/src/platform/stm32/main.c
+++ b/projects/adxrs290-pmdz/src/platform/stm32/main.c
@@ -74,6 +74,10 @@ int main()
 #error IIO_TRIGGER_EXAMPLE is not supported on STM32 platform.
 #endif
 
+#ifdef IIO_TIMER_TRIGGER_EXAMPLE
+#error IIO_TIMER_TRIGGER_EXAMPLE is not supported on STM32 platform.
+#endif
+
 #if (IIO_EXAMPLE + IIO_TRIGGER_EXAMPLE != 1)
 #error Selected example projects cannot be enabled at the same time. \
 Please enable only one example and re-build the project.

--- a/projects/cn0531/src.mk
+++ b/projects/cn0531/src.mk
@@ -12,6 +12,7 @@ SRC_DIRS += $(INCLUDE)
 SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/api/no_os_irq.c \
 	$(DRIVERS)/api/no_os_gpio.c \
+	$(DRIVERS)/api/no_os_timer.c \
 	$(DRIVERS)/platform/$(PLATFORM)/$(PLATFORM)_spi.c
 INCS += $(INCLUDE)/no_os_spi.h \
 	$(DRIVERS)/platform/$(PLATFORM)/spi_extra.h

--- a/projects/cn0552/src.mk
+++ b/projects/cn0552/src.mk
@@ -1,17 +1,18 @@
 SRCS += $(NO-OS)/util/no_os_util.c \
 	$(NO-OS)/util/no_os_list.c \
 	$(PLATFORM_DRIVERS)/delay.c \
-	$(PLATFORM_DRIVERS)/no_os_timer.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_i2c.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c \
 	$(PLATFORM_DRIVERS)/no_os_uart.c \
 	$(NO-OS)/util/no_os_lf256fifo.c \
 	$(PLATFORM_DRIVERS)/no_os_rtc.c \
 	$(PLATFORM_DRIVERS)/platform_init.c \
+	$(PLATFORM_DRIVERS)/aducm3029_timer.c \
 	$(DRIVERS)/cdc/ad7746/ad7746.c \
 	$(DRIVERS)/cdc/ad7746/iio_ad7746.c \
 	$(DRIVERS)/api/no_os_irq.c \
 	$(DRIVERS)/api/no_os_i2c.c \
+	$(DRIVERS)/api/no_os_timer.c \
 	$(PROJECT)/src/app/headless.c
 
 INCS +=	$(INCLUDE)/no_os_uart.h \
@@ -27,7 +28,7 @@ INCS +=	$(INCLUDE)/no_os_uart.h \
 	$(INCLUDE)/no_os_i2c.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/timer_extra.h \
+	$(PLATFORM_DRIVERS)/aducm3029_timer.h \
 	$(PLATFORM_DRIVERS)/uart_extra.h \
 	$(PLATFORM_DRIVERS)/rtc_extra.h \
 	$(PLATFORM_DRIVERS)/platform_init.h \

--- a/projects/iio_adpd1080/src.mk
+++ b/projects/iio_adpd1080/src.mk
@@ -14,7 +14,8 @@ SRCS +=	$(DRIVERS)/platform/$(PLATFORM)/$(PLATFORM)_irq.c
 INCS += $(INCLUDE)/no_os_irq.h
 INCS += $(DRIVERS)/platform/$(PLATFORM)/irq_extra.h
 
-SRCS += $(DRIVERS)/api/no_os_i2c.c
+SRCS += $(DRIVERS)/api/no_os_i2c.c \
+		$(DRIVERS)/api/no_os_timer.c
 SRCS +=	$(DRIVERS)/platform/$(PLATFORM)/$(PLATFORM)_i2c.c
 INCS += $(INCLUDE)/no_os_i2c.h
 INCS += $(DRIVERS)/platform/$(PLATFORM)/i2c_extra.h

--- a/projects/iio_aducm3029/src.mk
+++ b/projects/iio_aducm3029/src.mk
@@ -13,5 +13,7 @@ ifeq '$(TINYIIOD)' 'y'
 SRC_DIRS += $(NO-OS)/iio/iio_app
 SRCS += $(NO-OS)/drivers/api/no_os_gpio.c \
         $(NO-OS)/drivers/api/no_os_i2c.c  \
-        $(NO-OS)/drivers/api/no_os_spi.c
+        $(NO-OS)/drivers/api/no_os_irq.c  \
+        $(NO-OS)/drivers/api/no_os_spi.c  \
+		$(NO-OS)/drivers/api/no_os_timer.c
 endif

--- a/projects/iio_demo/src/platform/aducm3029/platform_src.mk
+++ b/projects/iio_demo/src/platform/aducm3029/platform_src.mk
@@ -12,17 +12,18 @@ DISABLE_SECURE_SOCKET ?= y
 SRC_DIRS += $(NO-OS)/network
 
 SRCS += $(NO-OS)/util/no_os_circular_buffer.c \
-	$(PLATFORM_DRIVERS)/no_os_timer.c
+	$(DRIVERS)/api/no_os_timer.c
 	
 INCS += $(INCLUDE)/no_os_circular_buffer.h \
 	$(INCLUDE)/no_os_timer.h           \
-	$(PLATFORM_DRIVERS)/timer_extra.h  \
+	$(PLATFORM_DRIVERS)/aducm3029_timer.h  \
 	$(PLATFORM_DRIVERS)/rtc_extra.h
 endif
 
 SRCS += $(NO-OS)/util/no_os_lf256fifo.c  \
 	$(PLATFORM_DRIVERS)/no_os_uart.c \
-	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_timer.c
 
 INCS += $(INCLUDE)/no_os_rtc.h          \
 	$(INCLUDE)/no_os_gpio.h         \

--- a/tools/scripts/iio_srcs.mk
+++ b/tools/scripts/iio_srcs.mk
@@ -11,7 +11,4 @@ INCS += $(INCLUDE)/no_os_circular_buffer.h
 ifeq (y,$(strip $(ENABLE_IIO_NETWORK)))
 DISABLE_SECURE_SOCKET ?= y
 SRC_DIRS += $(NO-OS)/network
-ifeq (aducm3029,$(strip $(PLATFORM)))
-SRCS	 += $(PLATFORM_DRIVERS)/no_os_timer.c
-endif
 endif


### PR DESCRIPTION
- Add timer support for aducm3029 platform and adapt projects accordingly.
- Add trigger timer support for aducm3029 and interrupt timer support.
- Add example with timer trigger for adxrs290-pmdz project for aducm3029.