### PR TITLE
projects: eval-adxl355-pmdz: add units.h to src.mk

### DIFF
--- a/projects/eval-adxl355-pmdz/src.mk
+++ b/projects/eval-adxl355-pmdz/src.mk
@@ -21,7 +21,8 @@ INCS += $(INCLUDE)/no_os_delay.h     \
 		$(INCLUDE)/no_os_list.h      \
 		$(INCLUDE)/no_os_uart.h      \
 		$(INCLUDE)/no_os_lf256fifo.h \
-		$(INCLUDE)/no_os_util.h 
+		$(INCLUDE)/no_os_util.h \
+		$(INCLUDE)/no_os_units.h
 
 SRCS += $(DRIVERS)/api/no_os_gpio.c \
 		$(DRIVERS)/api/no_os_i2c.c  \


### PR DESCRIPTION
With d5bd455 no_os_units.h is used with iio_adxl355.

Update src.mk of eval-adxl355-pmdz project accordingly.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>