### PR TITLE
ci: astyle: skip certificate check

### DIFF
--- a/ci/astyle.sh
+++ b/ci/astyle.sh
@@ -56,7 +56,7 @@ if [ ! -d build/astyle/build/gcc ]
 then	
 	mkdir -p build
 	pushd build
-	wget "https://sourceforge.net/projects/astyle/files/astyle/astyle 3.1/astyle_3.1_linux.tar.gz"
+	wget --no-check-certificate "https://sourceforge.net/projects/astyle/files/astyle/astyle 3.1/astyle_3.1_linux.tar.gz"
 	tar -xzf astyle_3.1_linux.tar.gz
 	pushd ./astyle/build/gcc
 	make -j3


### PR DESCRIPTION
Fix possible error when downloading astyle:

"ERROR: cannot verify downloads.sourceforge.net's ceritficate."

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>