### PR TITLE
tools:scripts: Modify build script for stm32

### DIFF
--- a/tools/scripts/build_projects.py
+++ b/tools/scripts/build_projects.py
@@ -214,7 +214,7 @@ class BuildConfig:
 			err = run_cmd(cmd + ' reset')
 			if err != 0:
 				return err
-			err = run_cmd(cmd + ' -j%d all' % (multiprocessing.cpu_count() - 1))
+			err = run_cmd(cmd + ' -j%d all' % (multiprocessing.cpu_count() - 2))
 			if err != 0:
 				return err
 		else:


### PR DESCRIPTION
Modify build script for stm32 such that the number of parallel
jobs is equal to (multiprocessing.cpu_count() - 2)

Signed-off-by: Ramona Bolboaca <ramona.bolboaca@analog.com>