### PR TITLE
adc_demo, dac_demo: use submit function instead of read_dev, write_dev functions for buffer handling

### DIFF
--- a/drivers/adc/adc_demo/adc_demo.h
+++ b/drivers/adc/adc_demo/adc_demo.h
@@ -97,6 +97,8 @@ enum iio_adc_demo_attributes {
 	ADC_GLOBAL_ATTR,
 };
 
+extern const uint16_t sine_lut[128];
+
 /******************************************************************************/
 /************************ Functions Declarations ******************************/
 /******************************************************************************/
@@ -110,7 +112,7 @@ int32_t update_adc_channels(void *dev, uint32_t mask);
 
 int32_t close_adc_channels(void* dev);
 
-int32_t adc_read_samples(void* dev, uint16_t* buff, uint32_t samples);
+int32_t adc_submit_samples(struct iio_device_data *dev_data);
 
 int32_t adc_demo_reg_read(struct adc_demo_desc *desc, uint8_t reg_index,
 			  uint8_t *readval);

--- a/drivers/dac/dac_demo/dac_demo.h
+++ b/drivers/dac/dac_demo/dac_demo.h
@@ -109,7 +109,7 @@ int32_t update_dac_channels(void *dev, int32_t mask);
 
 int32_t close_dac_channels(void* dev);
 
-int32_t dac_write_samples(void* dev, uint16_t* buff, uint32_t samples);
+int32_t dac_submit_samples(struct iio_device_data *dev_data);
 
 int get_dac_demo_attr(void *device, char *buf, uint32_t len,
 		      const struct iio_ch_info *channel, intptr_t priv);


### PR DESCRIPTION
- Use submit function instead of read_dev for buffer readings.
- Move adc_submit_samples and adc_demo_trigger_handler implementations to iio_adc_demo.c.
- Use submit function instead of write_dev for buffer writings.
- Move dac_submit_samples and dac_demo_trigger_handler implementations to iio_dac_demo.c.