### PR TITLE
stm32 build hang workaround

### DIFF
--- a/tools/scripts/build_projects.py
+++ b/tools/scripts/build_projects.py
@@ -214,7 +214,7 @@ class BuildConfig:
 			err = run_cmd(cmd + ' reset')
 			if err != 0:
 				return err
-			err = run_cmd(cmd + ' -j%d all' % (multiprocessing.cpu_count() - 1))
+			err = run_cmd("timeout 200s " + cmd + ' VERBOSE=y -j%d all' % (multiprocessing.cpu_count() - 1))
 			if err != 0:
 				return err
 		else:
@@ -305,9 +305,10 @@ def main():
 							#Keyboard interrupt
 							exit()
 						continue
-					run_cmd("cp %s %s" % 
-						(new_build.export_file, project_export))
-					binary_created = True
+					else:
+						run_cmd("cp %s %s" % 
+							(new_build.export_file, project_export))
+						binary_created = True
 			
 		fp.close()
 


### PR DESCRIPTION
Due to a yet elusive problem, stm32cubemx sometimes hangs while building
on azure.

This commit adds a workaround to not block the other builds by
time bounding the make all execution.

It seems reverting stm32cubemx to 6.3.0 would fix the problem, but 6.3.0
has another issue that was the reason we currently  use 6.5.0.

So this workaround should be removed once 6.6.0 arrives and fixes the
code generation hanging problem.

Signed-off-by: Darius Berghe <darius.berghe@analog.com>