### PR TITLE
drivers:adc:ad469x: Minor Updates.

### DIFF
--- a/drivers/adc/ad469x/ad469x.c
+++ b/drivers/adc/ad469x/ad469x.c
@@ -353,9 +353,10 @@ int32_t ad469x_std_pin_pairing(struct ad469x_dev *dev,
 {
 	dev->std_seq_pin_pairing = pin_pair;
 
-	return ad469x_spi_reg_write(dev,
-				    AD469x_REG_CONFIG_IN(0),
-				    AD469x_REG_CONFIG_IN_MODE(pin_pair));
+	return ad469x_spi_write_mask(dev,
+				     AD469x_REG_CONFIG_IN(0),
+				     AD469x_REG_CONFIG_IN_MODE_MASK,
+				     AD469x_REG_CONFIG_IN_MODE(pin_pair));
 }
 
 /**

--- a/drivers/adc/ad469x/ad469x.h
+++ b/drivers/adc/ad469x/ad469x.h
@@ -114,6 +114,14 @@
 #define AD469x_SETUP_CYC_CTRL_MASK		(0x01 << 1)
 #define AD469x_SETUP_CYC_CTRL_SINGLE(x)		((x & 0x01) << 1)
 
+/* AD469x_REG_REF_CTRL */
+#define AD469x_REG_REF_VREF_SET_MASK		(0x07 << 2)
+#define AD469x_REG_REF_VREF_SET(x)          ((x & 0x07) << 2)
+#define AD469x_REG_REF_VREF_REFHIZ_MASK		(0x07 << 1)
+#define AD469x_REG_REF_VREF_REFHIZ(x)		((x & 0x01) << 1)
+#define AD469x_REG_REF_VREF_REFBUF_MASK		0x01
+#define AD469x_REG_REF_VREF_REFBUF(x)		(x & 0x01)
+
 /* AD469x_REG_GP_MODE */
 #define AD469x_GP_MODE_BUSY_GP_EN_MASK		(0x01 << 1)
 #define AD469x_GP_MODE_BUSY_GP_EN(x)		((x & 0x01) << 1)


### PR DESCRIPTION
* Added macros for configuring reference control register.
* Updated the ad469x_std_pin_pairing() function so that only the desired
  bits of the register are updated.

Signed-off-by: Pratyush Mallick <Pratyush.Mallick@analog.com>