### PR TITLE
ci: gen_dox: fix if statement

### DIFF
--- a/ci/gen_dox.sh
+++ b/ci/gen_dox.sh
@@ -66,7 +66,7 @@ The following sections contain code documentation for ADI no-OS drivers.
 						fi
 					done
 
-					if [ -z "$EXCLUDE_PART" ]
+					if [[ "$EXCLUDE_PART" -eq 0 ]]
 					then
 						#add link to driver
 						append_to_dox "- \link_to_subdir{/drivers/$(basename -- ${drv_type})/$(basename -- ${part}) \"$(basename -- ${part^^})\"}" drivers_page.dox


### PR DESCRIPTION
The `-z` condition does not work properly if EXCLUDE_PART is initialized
with 0. Use `-eq` instead.

Fixes: 4d39b40 ("ci: gen_dox: rework excluded paths handling")
Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>