### PR TITLE
include:no_os_timer: Rename load_value to ticks_count

### DIFF
--- a/drivers/platform/aducm3029/aducm3029_timer.c
+++ b/drivers/platform/aducm3029/aducm3029_timer.c
@@ -130,7 +130,7 @@ int32_t aducm3029_timer_init(struct no_os_timer_desc **desc,
 	aducm_timer_ip = param->extra;
 
 	ldesc->extra = aducm_desc;
-	ldesc->load_value = param->load_value;
+	ldesc->ticks_count = param->ticks_count;
 	ldesc->freq_hz = param->freq_hz;
 
 	if (param->id == 0) {
@@ -193,8 +193,8 @@ int32_t aducm3029_timer_init(struct no_os_timer_desc **desc,
 		}
 
 		freq /= prescaler;
-		tmr_conf.nLoad = param->load_value;
-		tmr_conf.nAsyncLoad = param->load_value;
+		tmr_conf.nLoad = param->ticks_count;
+		tmr_conf.nAsyncLoad = param->ticks_count;
 		tmr_conf.bReloading = true;
 		tmr_conf.bSyncBypass = true;
 		aducm_desc->tmr_conf = tmr_conf;
@@ -297,7 +297,7 @@ int32_t aducm3029_timer_stop(struct no_os_timer_desc *desc)
 		return -1;
 	if (desc->id == 0) {
 		no_os_timer_counter_get(desc, &counter);
-		desc->load_value = counter;
+		desc->ticks_count = counter;
 		if (nb_enables == 1)
 			while (ADI_TMR_DEVICE_BUSY == adi_tmr_Enable(0, false));
 		nb_enables--;
@@ -330,7 +330,7 @@ int32_t aducm3029_timer_counter_get(struct no_os_timer_desc *desc,
 
 	tmr_desc = desc->extra;
 	if (tmr_desc->started == 0) {
-		*counter = desc->load_value;
+		*counter = desc->ticks_count;
 		return 0;
 	}
 	/*
@@ -358,7 +358,7 @@ int32_t aducm3029_timer_counter_get(struct no_os_timer_desc *desc,
 		 */
 		*counter = (big_counter * desc->freq_hz) / NO_OS_FREQ_1KHZ;
 	}
-	*counter += desc->load_value;
+	*counter += desc->ticks_count;
 
 	return 0;
 }
@@ -380,7 +380,7 @@ int32_t aducm3029_timer_counter_set(struct no_os_timer_desc *desc,
 
 	tmr_desc = (struct aducm_timer_desc *)desc->extra;
 	tmr_desc->old_time = aducm3029_get_current_time(desc);
-	desc->load_value = new_val;
+	desc->ticks_count = new_val;
 
 	return 0;
 }

--- a/drivers/platform/aducm3029/delay.c
+++ b/drivers/platform/aducm3029/delay.c
@@ -81,7 +81,7 @@ static uint32_t initialize_timer(struct no_os_timer_desc **timer,
 
 	param.id = 0;
 	param.freq_hz = is_us ? 1000000u : 1000u;
-	param.load_value = 0;
+	param.ticks_count = 0;
 	param.platform_ops = &aducm3029_timer_ops;
 
 	if (is_us) {

--- a/drivers/platform/maxim/max32650/maxim_timer.c
+++ b/drivers/platform/maxim/max32650/maxim_timer.c
@@ -124,7 +124,7 @@ int max_timer_init(struct no_os_timer_desc **desc,
 
 	descriptor->id = param->id;
 	descriptor->freq_hz = param->freq_hz;
-	descriptor->load_value = param->load_value;
+	descriptor->ticks_count = param->ticks_count;
 	descriptor->platform_ops = param->platform_ops;
 
 	tmr_regs = MXC_TMR_GET_TMR(param->id);
@@ -135,7 +135,7 @@ int max_timer_init(struct no_os_timer_desc **desc,
 		goto free_cfg;
 
 	cfg->mode = TMR_MODE_CONTINUOUS;
-	cfg->cmp_cnt = descriptor->load_value;
+	cfg->cmp_cnt = descriptor->ticks_count;
 	cfg->pol = 1;
 	cfg->pres = prescaler;
 

--- a/drivers/platform/maxim/max32655/maxim_timer.c
+++ b/drivers/platform/maxim/max32655/maxim_timer.c
@@ -121,7 +121,7 @@ int max_timer_init(struct no_os_timer_desc **desc,
 
 	descriptor->id = param->id;
 	descriptor->freq_hz = param->freq_hz;
-	descriptor->load_value = param->load_value;
+	descriptor->ticks_count = param->ticks_count;
 	descriptor->platform_ops = param->platform_ops;
 
 	tmr_regs = MXC_TMR_GET_TMR(param->id);
@@ -134,7 +134,7 @@ int max_timer_init(struct no_os_timer_desc **desc,
 	cfg->bitMode = TMR_BIT_MODE_32;
 	cfg->mode = TMR_MODE_CONTINUOUS;
 	cfg->clock = MXC_TMR_APB_CLK;
-	cfg->cmp_cnt = descriptor->load_value;
+	cfg->cmp_cnt = descriptor->ticks_count;
 	cfg->pol = 1;
 	cfg->pres = prescaler;
 

--- a/drivers/platform/maxim/max32660/maxim_timer.c
+++ b/drivers/platform/maxim/max32660/maxim_timer.c
@@ -122,7 +122,7 @@ int max_timer_init(struct no_os_timer_desc **desc,
 
 	descriptor->id = param->id;
 	descriptor->freq_hz = param->freq_hz;
-	descriptor->load_value = param->load_value;
+	descriptor->ticks_count = param->ticks_count;
 	descriptor->platform_ops = param->platform_ops;
 
 	tmr_regs = MXC_TMR_GET_TMR(param->id);
@@ -135,7 +135,7 @@ int max_timer_init(struct no_os_timer_desc **desc,
 	cfg->bitMode = TMR_BIT_MODE_32;
 	cfg->mode = TMR_MODE_CONTINUOUS;
 	cfg->clock = MXC_TMR_HFIO_CLK;
-	cfg->cmp_cnt = descriptor->load_value;
+	cfg->cmp_cnt = descriptor->ticks_count;
 	cfg->pol = 1;
 	cfg->pres = prescaler;
 

--- a/drivers/platform/maxim/max32665/maxim_timer.c
+++ b/drivers/platform/maxim/max32665/maxim_timer.c
@@ -122,7 +122,7 @@ int max_timer_init(struct no_os_timer_desc **desc,
 
 	descriptor->id = param->id;
 	descriptor->freq_hz = param->freq_hz;
-	descriptor->load_value = param->load_value;
+	descriptor->ticks_count = param->ticks_count;
 	descriptor->platform_ops = param->platform_ops;
 
 	tmr_regs = MXC_TMR_GET_TMR(param->id);
@@ -133,7 +133,7 @@ int max_timer_init(struct no_os_timer_desc **desc,
 		goto free_cfg;
 
 	cfg->mode = TMR_MODE_CONTINUOUS;
-	cfg->cmp_cnt = descriptor->load_value;
+	cfg->cmp_cnt = descriptor->ticks_count;
 	cfg->pol = 1;
 	cfg->pres = prescaler;
 

--- a/drivers/platform/maxim/max78000/maxim_timer.c
+++ b/drivers/platform/maxim/max78000/maxim_timer.c
@@ -122,7 +122,7 @@ int max_timer_init(struct no_os_timer_desc **desc,
 
 	descriptor->id = param->id;
 	descriptor->freq_hz = param->freq_hz;
-	descriptor->load_value = param->load_value;
+	descriptor->ticks_count = param->ticks_count;
 	descriptor->platform_ops = param->platform_ops;
 
 	tmr_regs = MXC_TMR_GET_TMR(param->id);
@@ -135,7 +135,7 @@ int max_timer_init(struct no_os_timer_desc **desc,
 	cfg->bitMode = TMR_BIT_MODE_32;
 	cfg->mode = TMR_MODE_CONTINUOUS;
 	cfg->clock = MXC_TMR_APB_CLK;
-	cfg->cmp_cnt = descriptor->load_value;
+	cfg->cmp_cnt = descriptor->ticks_count;
 	cfg->pol = 1;
 	cfg->pres = prescaler;
 

--- a/drivers/platform/stm32/stm32_timer.c
+++ b/drivers/platform/stm32/stm32_timer.c
@@ -171,7 +171,7 @@ int32_t stm32_timer_init(struct no_os_timer_desc **desc,
 
 	/* Overwrite generated values with given values */
 	stm_desc->htimer->Init.Prescaler = src_freq/param->freq_hz;
-	stm_desc->htimer->Init.Period = param->load_value;
+	stm_desc->htimer->Init.Period = param->ticks_count;
 
 	ret = HAL_TIM_Base_Init(stm_desc->htimer);
 	if (ret != HAL_OK) {
@@ -183,7 +183,7 @@ int32_t stm32_timer_init(struct no_os_timer_desc **desc,
 	no_os_desc->extra = stm_desc->htimer;
 	no_os_desc->id = param->id;
 	no_os_desc->freq_hz = param->freq_hz;
-	no_os_desc->load_value = param->load_value;
+	no_os_desc->ticks_count = param->ticks_count;
 	*desc = no_os_desc;
 
 	return 0;
@@ -270,7 +270,7 @@ int32_t stm32_timer_counter_get(struct no_os_timer_desc *desc,
  */
 int32_t stm32_timer_counter_set(struct no_os_timer_desc *desc, uint32_t new_val)
 {
-	if (!desc || (new_val > desc->load_value))
+	if (!desc || (new_val > desc->ticks_count))
 		return -EINVAL;
 
 	__HAL_TIM_SetCounter((TIM_HandleTypeDef*)desc->extra, new_val);

--- a/drivers/platform/xilinx/no_os_timer.c
+++ b/drivers/platform/xilinx/no_os_timer.c
@@ -88,7 +88,7 @@ int32_t no_os_timer_init(struct no_os_timer_desc **desc,
 
 	dev->id = param->id;
 	dev->freq_hz = param->freq_hz;
-	dev->load_value = param->load_value;
+	dev->ticks_count = param->ticks_count;
 	dev->extra = xdesc;
 	xdesc->active_tmr = xinit->active_tmr;
 	xdesc->type = xinit->type;
@@ -110,7 +110,7 @@ int32_t no_os_timer_init(struct no_os_timer_desc **desc,
 		if (NO_OS_IS_ERR_VALUE(ret))
 			goto error_xdesc;
 
-		ret = no_os_timer_counter_set(dev, dev->load_value);
+		ret = no_os_timer_counter_set(dev, dev->ticks_count);
 		if (NO_OS_IS_ERR_VALUE(ret))
 			goto error_xdesc;
 
@@ -146,7 +146,7 @@ int32_t no_os_timer_init(struct no_os_timer_desc **desc,
 				   XTC_DOWN_COUNT_OPTION | XTC_INT_MODE_OPTION |
 				   XTC_AUTO_RELOAD_OPTION);
 		XTmrCtr_SetResetValue(xdesc->instance, xdesc->active_tmr,
-				      dev->load_value);
+				      dev->ticks_count);
 		break;
 #endif
 		goto error_xdesc;

--- a/include/no_os_timer.h
+++ b/include/no_os_timer.h
@@ -59,8 +59,8 @@ struct no_os_timer_desc {
 	uint16_t id;
 	/** timer count frequency (Hz) */
 	uint32_t freq_hz;
-	/** counter start value */
-	uint32_t load_value;
+	/** the number of ticks the timer counts until it resets */
+	uint32_t ticks_count;
 	/** Timer platform operations */
 	const struct no_os_timer_platform_ops *platform_ops;
 	/** timer extra parameters (device specific) */
@@ -83,8 +83,8 @@ struct no_os_timer_init_param {
 	uint16_t id;
 	/** timer count frequency (Hz) */
 	uint32_t freq_hz;
-	/** counter start value */
-	uint32_t load_value;
+	/** the number of ticks the timer counts until it resets */
+	uint32_t ticks_count;
 	/** Timer platform operations */
 	const struct no_os_timer_platform_ops *platform_ops;
 	/** timer extra parameters (device specific) */

--- a/libraries/mqtt/mqtt_noos_support.c
+++ b/libraries/mqtt/mqtt_noos_support.c
@@ -69,7 +69,7 @@ int32_t mqtt_timer_init(uint32_t timer_id, void *extra_init_param)
 	struct no_os_timer_init_param init_param = {
 		.id = timer_id,
 		.freq_hz = 1000,
-		.load_value = 0,
+		.ticks_count = 0,
 		.extra = extra_init_param
 	};
 	int32_t			ret;

--- a/projects/adv7511/src/main.c
+++ b/projects/adv7511/src/main.c
@@ -359,14 +359,14 @@ int main()
 	xil_timer_init.type = TIMER_PS;
 	timer_init.id = XPAR_XSCUTIMER_0_DEVICE_ID;
 	timer_init.freq_hz = XPAR_CPU_CORTEXA9_CORE_CLOCK_FREQ_HZ / 2;
-	timer_init.load_value = timer_init.freq_hz / 1000;
+	timer_init.ticks_count = timer_init.freq_hz / 1000;
 	timer_init.extra = &xil_timer_init;
 #else
 	xil_timer_init.active_tmr = 0;
 	xil_timer_init.type = TIMER_PL;
 	timer_init.id = XPAR_AXI_TIMER_DEVICE_ID;
 	timer_init.freq_hz = XPAR_AXI_TIMER_CLOCK_FREQ_HZ;
-	timer_init.load_value = timer_init.freq_hz / 1000;
+	timer_init.ticks_count = timer_init.freq_hz / 1000;
 	timer_init.extra = &xil_timer_init;
 #endif
 #if defined(_XPARAMETERS_PS_H_)

--- a/projects/adxrs290-pmdz/src/common/common_data.c
+++ b/projects/adxrs290-pmdz/src/common/common_data.c
@@ -97,7 +97,7 @@ struct iio_hw_trig_init_param adxrs290_gpio_trig_ip = {
 struct no_os_timer_init_param adxrs290_tip = {
 	.id = ADXRS290_TIMER_DEVICE_ID,
 	.freq_hz = ADXRS290_TIMER_FREQ_HZ,
-	.load_value = ADXRS290_TIMER_LOAD_VAL,
+	.ticks_count = ADXRS290_TIMER_TICKS_COUNT,
 	.platform_ops = TIMER_OPS,
 	.extra = ADXRS290_TIMER_EXTRA,
 };

--- a/projects/adxrs290-pmdz/src/platform/aducm3029/parameters.h
+++ b/projects/adxrs290-pmdz/src/platform/aducm3029/parameters.h
@@ -79,7 +79,7 @@
 extern struct aducm_timer_init_param adxrs290_xtip;
 #define ADXRS290_TIMER_DEVICE_ID    1
 #define ADXRS290_TIMER_FREQ_HZ      200 /* Not used - Used clock source frequency is the one specified in adxrs290_xtip */
-#define ADXRS290_TIMER_LOAD_VAL     0xffff
+#define ADXRS290_TIMER_TICKS_COUNT  0xffff
 #define ADXRS290_TIMER_EXTRA        &adxrs290_xtip
 #define TIMER_OPS                   &aducm3029_timer_ops
 

--- a/projects/iio_adpd1080/src/main.c
+++ b/projects/iio_adpd1080/src/main.c
@@ -76,7 +76,7 @@ static int32_t adpd1080pmod_32k_calib(struct adpd188_dev *adpd1080_dev)
 	struct no_os_timer_desc *cal_timer;
 	struct no_os_timer_init_param cal_timer_init = {
 		.id = 0,
-		.load_value = 0,
+		.ticks_count = 0,
 		.freq_hz = 1,
 		.extra = NULL
 	};

--- a/projects/iio_demo/src/common/common_data.c
+++ b/projects/iio_demo/src/common/common_data.c
@@ -87,7 +87,7 @@ struct iio_sw_trig_init_param dac_trig_ip = {
 struct no_os_timer_init_param adc_demo_tip = {
 	.id = ADC_DEMO_TIMER_DEVICE_ID,
 	.freq_hz = ADC_DEMO_TIMER_FREQ_HZ,
-	.load_value = ADC_DEMO_TIMER_LOAD_VAL,
+	.ticks_count = ADC_DEMO_TIMER_TICKS_COUNT,
 	.platform_ops = TIMER_OPS,
 	.extra = ADC_DEMO_TIMER_EXTRA,
 };
@@ -117,7 +117,7 @@ struct iio_hw_trig_init_param adc_demo_timer_trig_ip = {
 struct no_os_timer_init_param dac_demo_tip = {
 	.id = DAC_DEMO_TIMER_DEVICE_ID,
 	.freq_hz = DAC_DEMO_TIMER_FREQ_HZ,
-	.load_value = DAC_DEMO_TIMER_LOAD_VAL,
+	.ticks_count = DAC_DEMO_TIMER_TICKS_COUNT,
 	.platform_ops = TIMER_OPS,
 	.extra = DAC_DEMO_TIMER_EXTRA,
 };

--- a/projects/iio_demo/src/platform/stm32/parameters.h
+++ b/projects/iio_demo/src/platform/stm32/parameters.h
@@ -71,7 +71,7 @@ extern UART_HandleTypeDef huart5;
 extern stm32_timer_init_param adc_demo_xtip;
 #define ADC_DEMO_TIMER_DEVICE_ID    13
 #define ADC_DEMO_TIMER_FREQ_HZ      1000000
-#define ADC_DEMO_TIMER_LOAD_VAL     2000
+#define ADC_DEMO_TIMER_TICKS_COUNT  2000
 #define ADC_DEMO_TIMER_EXTRA        &adc_demo_xtip
 #define TIMER_OPS                   &stm32_timer_ops
 
@@ -89,7 +89,7 @@ extern TIM_HandleTypeDef htim13;
 extern stm32_timer_init_param dac_demo_xtip;
 #define DAC_DEMO_TIMER_DEVICE_ID    14
 #define DAC_DEMO_TIMER_FREQ_HZ      1000000
-#define DAC_DEMO_TIMER_LOAD_VAL     2000
+#define DAC_DEMO_TIMER_TICKS_COUNT  2000
 #define DAC_DEMO_TIMER_EXTRA        &dac_demo_xtip
 #define TIMER_OPS                   &stm32_timer_ops
 


### PR DESCRIPTION
The name load_value does not describe the parameter usage correctly. It implies that it is the start value of the timer, however we use it to describe the number of ticks the timer counts until it resets. A rename is done to better describe this parameter usage.

No functional changes.