### PR TITLE
include: gpio: remove typedefs

### DIFF
--- a/drivers/adc/ad7616/ad7616.h
+++ b/drivers/adc/ad7616/ad7616.h
@@ -168,12 +168,12 @@ struct ad7616_init_param {
 	struct spi_engine_offload_init_param *offload_init_param;
 	uint32_t reg_access_speed;
 	/* GPIO */
-	no_os_gpio_init_param		*gpio_hw_rngsel0_param;
-	no_os_gpio_init_param		*gpio_hw_rngsel1_param;
-	no_os_gpio_init_param		*gpio_reset_param;
-	no_os_gpio_init_param		*gpio_os0_param;
-	no_os_gpio_init_param		*gpio_os1_param;
-	no_os_gpio_init_param		*gpio_os2_param;
+	struct no_os_gpio_init_param		*gpio_hw_rngsel0_param;
+	struct no_os_gpio_init_param		*gpio_hw_rngsel1_param;
+	struct no_os_gpio_init_param		*gpio_reset_param;
+	struct no_os_gpio_init_param		*gpio_os0_param;
+	struct no_os_gpio_init_param		*gpio_os1_param;
+	struct no_os_gpio_init_param		*gpio_os2_param;
 	/* Core */
 	uint32_t			core_baseaddr;
 	/* Device Settings */

--- a/drivers/adc/ad9081/ad9081.h
+++ b/drivers/adc/ad9081/ad9081.h
@@ -69,8 +69,8 @@ struct dac_settings_cache {
 };
 
 struct ad9081_phy {
-	no_os_spi_desc		*spi_desc;
-	no_os_gpio_desc		*gpio_reset;
+	struct no_os_spi_desc		*spi_desc;
+	struct no_os_gpio_desc		*gpio_reset;
 	struct no_os_clk		*jesd_rx_clk;
 	struct no_os_clk		*jesd_tx_clk;
 	struct no_os_clk		*dev_clk;
@@ -132,8 +132,8 @@ struct link_init_param {
 };
 
 struct ad9081_init_param {
-	no_os_spi_init_param	*spi_init;
-	no_os_gpio_init_param	*gpio_reset;
+	struct no_os_spi_init_param	*spi_init;
+	struct no_os_gpio_init_param	*gpio_reset;
 	struct no_os_clk	*dev_clk;
 	struct no_os_clk	*jesd_rx_clk;
 	struct no_os_clk	*jesd_tx_clk;

--- a/drivers/adc/ad9083/ad9083.h
+++ b/drivers/adc/ad9083/ad9083.h
@@ -56,11 +56,11 @@
  */
 struct ad9083_init_param {
 	/* SPI */
-	no_os_spi_init_param	*spi_init;
+	struct no_os_spi_init_param	*spi_init;
 	/* GPIO reset */
-	no_os_gpio_init_param	*gpio_reset;
+	struct no_os_gpio_init_param	*gpio_reset;
 	/* GPIO power down */
-	no_os_gpio_init_param	*gpio_pd;
+	struct no_os_gpio_init_param	*gpio_pd;
 	/* Settings selection */
 	uint8_t uc;
 	/* jesd receive clock */
@@ -73,13 +73,13 @@ struct ad9083_init_param {
  */
 struct ad9083_phy {
 	/* SPI */
-	no_os_spi_desc 	*spi_desc;
+	struct no_os_spi_desc 	*spi_desc;
 	/* GPIO */
-	no_os_gpio_desc	*gpio_reset;
+	struct no_os_gpio_desc	*gpio_reset;
 	/* GPIO power down */
-	no_os_gpio_desc	*gpio_pd;
+	struct no_os_gpio_desc	*gpio_pd;
 	/* GPIO reference selection */
-	no_os_gpio_desc	*gpio_ref_sel;
+	struct no_os_gpio_desc	*gpio_ref_sel;
 	/* adi ad9083 device*/
 	adi_ad9083_device_t	adi_ad9083;
 };

--- a/drivers/frequency/ad9528/ad9528.h
+++ b/drivers/frequency/ad9528/ad9528.h
@@ -479,9 +479,9 @@ struct ad9528_state {
 
 struct ad9528_dev {
 	/* SPI */
-	no_os_spi_desc *spi_desc;
+	struct no_os_spi_desc *spi_desc;
 	/* GPIO */
-	no_os_gpio_desc *gpio_resetb;
+	struct no_os_gpio_desc *gpio_resetb;
 	/* Device Settings */
 	struct ad9528_state ad9528_st;
 	struct ad9528_platform_data *pdata;
@@ -489,9 +489,9 @@ struct ad9528_dev {
 
 struct ad9528_init_param {
 	/* SPI */
-	no_os_spi_init_param spi_init;
+	struct no_os_spi_init_param spi_init;
 	/* GPIO */
-	no_os_gpio_init_param *gpio_resetb;
+	struct no_os_gpio_init_param *gpio_resetb;
 	/* Device Settings */
 	struct ad9528_platform_data *pdata;
 };

--- a/include/no_os_gpio.h
+++ b/include/no_os_gpio.h
@@ -82,7 +82,7 @@ enum no_os_gpio_pull_up {
  * @struct no_os_gpio_init_param
  * @brief Structure holding the parameters for GPIO initialization.
  */
-typedef struct no_os_gpio_init_param {
+struct no_os_gpio_init_param {
 	/** Port number */
 	int32_t		port;
 	/** GPIO number */
@@ -93,13 +93,13 @@ typedef struct no_os_gpio_init_param {
 	const struct no_os_gpio_platform_ops *platform_ops;
 	/** GPIO extra parameters (device specific) */
 	void		*extra;
-} no_os_gpio_init_param;
+};
 
 /**
  * @struct no_os_gpio_desc
  * @brief Structure holding the GPIO descriptor.
  */
-typedef struct no_os_gpio_desc {
+struct no_os_gpio_desc {
 	/** Port number */
 	int32_t		port;
 	/** GPIO number */
@@ -110,7 +110,7 @@ typedef struct no_os_gpio_desc {
 	const struct no_os_gpio_platform_ops *platform_ops;
 	/** GPIO extra parameters (device specific) */
 	void		*extra;
-} no_os_gpio_desc;
+};
 
 /**
  * @enum no_os_gpio_values

--- a/projects/fmcadc2/src/fmcadc2.c
+++ b/projects/fmcadc2/src/fmcadc2.c
@@ -103,7 +103,7 @@ int main(void)
 	gpio_sysref_param.platform_ops = &xil_gpio_ops;
 	gpio_sysref_param.extra = &xil_gpio_param;
 
-	no_os_gpio_desc *gpio_sysref;
+	struct no_os_gpio_desc *gpio_sysref;
 
 	struct adxcvr_init ad9625_xcvr_param = {
 		.name = "ad9152_xcvr",

--- a/projects/fmcadc5/src/fmcadc5.c
+++ b/projects/fmcadc5/src/fmcadc5.c
@@ -133,12 +133,12 @@ int main(void)
 	gpio_pwdn_1_param.extra = &xil_gpio_param;
 	gpio_pwr_good_param.extra = &xil_gpio_param;
 
-	no_os_gpio_desc *gpio_sysref;
-	no_os_gpio_desc *gpio_rst_0;
-	no_os_gpio_desc *gpio_rst_1;
-	no_os_gpio_desc *gpio_pwdn_0;
-	no_os_gpio_desc *gpio_pwdn_1;
-	no_os_gpio_desc *gpio_pwr_good;
+	struct no_os_gpio_desc *gpio_sysref;
+	struct no_os_gpio_desc *gpio_rst_0;
+	struct no_os_gpio_desc *gpio_rst_1;
+	struct no_os_gpio_desc *gpio_pwdn_0;
+	struct no_os_gpio_desc *gpio_pwdn_1;
+	struct no_os_gpio_desc *gpio_pwr_good;
 
 	struct adxcvr_init ad9625_0_xcvr_param = {
 		.name = "ad9152_0_xcvr",

--- a/projects/fmcdaq3/src/app/fmcdaq3.c
+++ b/projects/fmcdaq3/src/app/fmcdaq3.c
@@ -213,8 +213,8 @@ int main(void)
 	adc_pd_param.platform_ops = &altera_gpio_ops;
 #endif
 
-	no_os_gpio_desc *dac_txen;
-	no_os_gpio_desc *adc_pd;
+	struct no_os_gpio_desc *dac_txen;
+	struct no_os_gpio_desc *adc_pd;
 
 	struct ad9528_dev* ad9528_device;
 	struct ad9152_dev* ad9152_device;

--- a/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
+++ b/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
@@ -135,7 +135,7 @@ int main(void)
 	};
 	gpio_sysref_param.extra = &xil_gpio_param;
 
-	no_os_gpio_desc *gpio_sysref;
+	struct no_os_gpio_desc *gpio_sysref;
 
 	struct adxcvr_init ad9250_xcvr_param = {
 		.name = "ad9250_xcvr",


### PR DESCRIPTION
Using custom naming for data types is no longer supported in the no-OS
repository.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>