### PR TITLE
jesd204: Adding jesd204-fsm support on no-OS

### DIFF
--- a/include/jesd204.h
+++ b/include/jesd204.h
@@ -1,0 +1,291 @@
+/**
+ * The JESD204 framework
+ *
+ * Copyright (c) 2022 Analog Devices Inc.
+ */
+#ifndef _JESD204_H_
+#define _JESD204_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+struct jesd204_dev;
+
+enum jesd204_subclass {
+	JESD204_SUBCLASS_0,
+	JESD204_SUBCLASS_1,
+	JESD204_SUBCLASS_2,
+};
+
+enum jesd204_version {
+	JESD204_VERSION_A,
+	JESD204_VERSION_B,
+	JESD204_VERSION_C,
+};
+
+/* JESD204C Supported encoding scheme */
+enum jesd204_encoder {
+	JESD204_ENCODER_UNKNOWN,
+	JESD204_ENCODER_8B10B,
+	JESD204_ENCODER_64B66B,
+	JESD204_ENCODER_64B80B,
+
+	JESD204_ENCODER_MAX
+};
+
+enum jesd204_sysref_mode {
+	JESD204_SYSREF_DISABLED,
+	JESD204_SYSREF_CONTINUOUS,
+	JESD204_SYSREF_ONESHOT,
+};
+
+enum jesd204_state_change_result {
+	JESD204_STATE_CHANGE_ERROR = -1,
+	JESD204_STATE_CHANGE_DEFER = 0,
+	JESD204_STATE_CHANGE_DONE,
+};
+
+#define JESD204_LINKS_ALL		((unsigned int)(-1))
+
+#define JESD204_LMFC_OFFSET_UNINITIALIZED	((uint16_t)-1)
+
+/** struct jesd204_sysref - JESD204 parameters for SYSREF
+ * @mode:			SYSREF mode (see @jesd204_sysref_mode)
+ * @capture_falling_edge:	true if it should capture falling edge
+ * @valid_falling_edge:		true if falling edge should be valid
+ * @lmfc_offset:		offset for LMFC
+ */
+struct jesd204_sysref {
+	enum jesd204_sysref_mode	mode;
+	uint8_t				capture_falling_edge;
+	uint8_t				valid_falling_edge;
+	uint16_t			lmfc_offset;
+};
+
+/**
+ * struct jesd204_link - JESD204 link configuration settings
+ * @link_id:			JESD204 link ID provided via DT configuration
+ * @error:			error code for this JESD204 link
+ * @is_transmit:		true if this link is transmit (digital to analog)
+ * @sample_rate:		sample rate for the link
+ * @sample_rate_div:		optional sample rate divider for the link
+ * 					final rate = sample_rate / sample_rate_div
+ * @num_lanes:			number of JESD204 lanes (L)
+ * @num_converters:		number of converters per link (M)
+ * @octets_per_frame:		number of octets per frame (F)
+ * @frames_per_multiframe:	number of frames per frame (K)
+ * @num_of_multiblocks_in_emb:	number of multiblocks in extended multiblock (E) (JESD204C)
+ * @bits_per_sample:		number of bits per sample (N')
+ * @converter_resolution:	converter resolution (N)
+ * @jesd_version:		JESD204 version (A, B or C) (JESDV)
+ * @jesd_encoder:		JESD204C encoder (8B10B, 64B66B, 64B80B)
+ * @subclass:			JESD204 subclass (0,1 or 2) (SUBCLASSV)
+ * @device_id:			device ID (DID)
+ * @bank_id:			bank ID (BID)
+ * @scrambling:			true if scrambling enabled (SCR)
+ * @high_density:		true if high-density format is used (HD)
+ * @ctrl_words_per_frame_clk:	number of control words per frame clock
+ *				period (CF)
+ * @ctrl_bits_per_sample:	number of control bits per sample (CS)
+ * @samples_per_conv_frame:	number of samples per converter per frame
+ *				cycle (S)
+ * @lane_ids:			array of lane IDs (LID); note that this is an
+ *				array the size of @num_lanes
+ * @sysref:			JESD204 sysref config, see @jesd204_sysref
+ * @dac_adj_resolution_steps:	number of adjustment resolution steps to adjust
+ *				DAC LMFC (ADJCNT) - Subclass 2 only
+ * @dac_adj_direction:		direction to adjust DAC LMFC (ADJDIR)
+ *				Subclass 2 only
+ * @dac_phase_adj:		true to do phase adjustment request to DAC
+ *				Subclass 2 only
+ */
+struct jesd204_link {
+	uint32_t link_id;
+	int error;
+
+	uint64_t sample_rate;
+	uint32_t sample_rate_div;
+
+	bool is_transmit;
+
+	uint8_t num_lanes;
+	uint8_t num_converters;
+	uint8_t octets_per_frame;
+	uint16_t frames_per_multiframe;
+	uint8_t num_of_multiblocks_in_emb; /* E */
+
+	uint8_t bits_per_sample;
+
+	uint8_t converter_resolution;
+	uint8_t jesd_version;
+	uint8_t jesd_encoder;
+	uint8_t subclass;
+
+	uint8_t device_id;
+	uint8_t bank_id;
+
+	uint8_t scrambling;
+	uint8_t high_density;
+
+	uint8_t ctrl_words_per_frame_clk;
+	uint8_t ctrl_bits_per_sample;
+	uint8_t samples_per_conv_frame;
+
+	uint8_t *lane_ids;
+
+	struct jesd204_sysref sysref;
+
+	/* Subclass 2 only */
+	uint8_t dac_adj_resolution_steps;
+	uint8_t dac_adj_direction;
+	uint8_t dac_phase_adj;
+};
+
+enum jesd204_state_op_reason {
+	JESD204_STATE_OP_REASON_INIT,
+	JESD204_STATE_OP_REASON_UNINIT,
+};
+
+static inline const char *jesd204_state_op_reason_str(enum
+		jesd204_state_op_reason reason)
+{
+	switch (reason) {
+	case JESD204_STATE_OP_REASON_INIT:
+		return "initialization";
+	case JESD204_STATE_OP_REASON_UNINIT:
+		return "uninitialization";
+	default:
+		return "unknown";
+	}
+}
+
+typedef int (*jesd204_sysref_cb)(struct jesd204_dev *jdev);
+
+typedef int (*jesd204_dev_cb)(struct jesd204_dev *jdev,
+			      enum jesd204_state_op_reason reason);
+
+typedef int (*jesd204_link_cb)(struct jesd204_dev *jdev,
+			       enum jesd204_state_op_reason,
+			       struct jesd204_link *lnk);
+
+enum jesd204_state_op_mode {
+	JESD204_STATE_OP_MODE_PER_LINK,
+	JESD204_STATE_OP_MODE_PER_DEVICE,
+};
+
+/**
+ * struct jesd204_state_op - JESD204 device per-state op
+ * @mode:		mode for this state op, depending on this @per_device or @per_link is called
+ * @per_device:		op called for each JESD204 **device** during a transition
+ * @per_link		op called for each JESD204 **link** individually during a transition
+ * // FIXME: maybe pass 'struct jesd204_sysref' for post_state_sysref, to make this configurable? we'll see later
+ * // FIXME: for now, the device should also be a top-level device, in case of multi-chip setups
+ * @post_state_sysref:	true if a SYSREF should be issued after the state change
+ */
+struct jesd204_state_op {
+	enum jesd204_state_op_mode	mode;
+	jesd204_dev_cb			per_device;
+	jesd204_link_cb			per_link;
+	bool				post_state_sysref;
+};
+
+enum jesd204_dev_op {
+	JESD204_OP_DEVICE_INIT,
+	JESD204_OP_LINK_INIT,
+	JESD204_OP_LINK_SUPPORTED,
+	JESD204_OP_LINK_PRE_SETUP,
+	JESD204_OP_CLK_SYNC_STAGE1,
+	JESD204_OP_CLK_SYNC_STAGE2,
+	JESD204_OP_CLK_SYNC_STAGE3,
+	JESD204_OP_LINK_SETUP,
+	JESD204_OP_OPT_SETUP_STAGE1,
+	JESD204_OP_OPT_SETUP_STAGE2,
+	JESD204_OP_OPT_SETUP_STAGE3,
+	JESD204_OP_OPT_SETUP_STAGE4,
+	JESD204_OP_OPT_SETUP_STAGE5,
+	JESD204_OP_CLOCKS_ENABLE,
+	JESD204_OP_LINK_ENABLE,
+	JESD204_OP_LINK_RUNNING,
+	JESD204_OP_OPT_POST_RUNNING_STAGE,
+
+	__JESD204_MAX_OPS,
+};
+
+/**
+ * struct jesd204_dev_data - JESD204 device initialization data
+ * @sysref_cb:		SYSREF callback, if this device/driver supports it
+ * @sizeof_priv:	amount of data to allocate for private information
+ * @max_num_links:	maximum number of JESD204 links this device can support
+ * @num_retries:	number of retries in case of error (only for top-level device)
+ * @state_ops:		ops for each state transition of type @struct jesd204_state_op
+ */
+struct jesd204_dev_data {
+	jesd204_sysref_cb			sysref_cb;
+	size_t					sizeof_priv;
+	unsigned int				max_num_links;
+	unsigned int				num_retries;
+	struct jesd204_state_op			state_ops[__JESD204_MAX_OPS];
+};
+
+/* no-OS specific */
+#define JESD204_MAX_TOPOLOGY_LINKS	16
+
+/* no-OS specific */
+struct jesd204_topology_dev {
+	struct jesd204_dev	*jdev;
+	bool			is_top_device;
+	bool			is_sysref_provider;
+	unsigned int		link_ids[JESD204_MAX_TOPOLOGY_LINKS];
+	unsigned int		links_number;
+};
+
+/* no-OS specific */
+struct jesd204_topology {
+	struct jesd204_dev_top		*dev_top;
+	struct jesd204_topology_dev	*devs;
+	unsigned int			devs_number;
+};
+
+/* no-OS specific */
+int jesd204_dev_register(struct jesd204_dev **jdev,
+			 const struct jesd204_dev_data *dev_data);
+
+/* no-OS specific */
+int jesd204_dev_unregister(struct jesd204_dev *jdev);
+
+/* no-OS specific */
+int jesd204_topology_init(struct jesd204_topology **topology,
+			  struct jesd204_topology_dev *devs,
+			  unsigned int devs_number);
+
+/* no-OS specific */
+int jesd204_topology_remove(struct jesd204_topology *topology);
+
+/* no-OS specific */
+int jesd204_fsm_start(struct jesd204_topology *topology, unsigned int link_idx);
+
+/* no-OS specific */
+int jesd204_fsm_stop(struct jesd204_topology *topology, unsigned int link_idx);
+
+void *jesd204_dev_priv(struct jesd204_dev *jdev);
+
+int jesd204_link_get_lmfc_lemc_rate(struct jesd204_link *lnk,
+				    unsigned long *rate_hz);
+
+int jesd204_link_get_rate_khz(struct jesd204_link *lnk,
+			      unsigned long *lane_rate_khz);
+
+int jesd204_link_get_device_clock(struct jesd204_link *lnk,
+				  unsigned long *device_clock);
+
+int jesd204_sysref_async(struct jesd204_dev *jdev);
+
+int jesd204_sysref_async_force(struct jesd204_dev *jdev);
+
+bool jesd204_dev_is_top(struct jesd204_dev *jdev);
+
+void jesd204_copy_link_params(struct jesd204_link *dst,
+			      const struct jesd204_link *src);
+
+#endif

--- a/jesd204/jesd204-core.c
+++ b/jesd204/jesd204-core.c
@@ -1,0 +1,399 @@
+/**
+ * The JESD204 framework - core logic
+ *
+ * Copyright (c) 2022 Analog Devices Inc.
+ */
+
+#include <stdlib.h>
+#include "no_os_error.h"
+#include "no_os_print_log.h"
+#include "no_os_util.h"
+#include "jesd204-priv.h"
+
+/* no-OS specific */
+static int jesd204_dev_alloc_links(struct jesd204_dev_top *jdev_top)
+{
+	struct jesd204_link_opaque *links;
+	unsigned int i;
+
+	links = (struct jesd204_link_opaque *)
+		calloc(1, jdev_top->num_links * sizeof(*links));
+	if (!links)
+		return -ENOMEM;
+	jdev_top->active_links = links;
+
+	for (i = 0; i < jdev_top->num_links; i++) {
+		links[i].jdev_top = jdev_top;
+		links[i].link_idx = i;
+		links[i].link.link_id = jdev_top->link_ids[i];
+	}
+
+	return 0;
+}
+
+/* no-OS specific */
+int jesd204_dev_register(struct jesd204_dev **jdev,
+			 const struct jesd204_dev_data *dev_data)
+{
+	struct jesd204_dev *dev;
+
+	if (!jdev)
+		return -EINVAL;
+
+	if (!dev_data)
+		return -EINVAL;
+
+	dev = (struct jesd204_dev *)calloc(1, sizeof(*dev));
+	if (!dev)
+		return -ENOMEM;
+
+	dev->priv = (void *)calloc(1, dev_data->sizeof_priv);
+
+	dev->dev_data = dev_data;
+
+	*jdev = dev;
+
+	return 0;
+}
+
+/* no-OS specific */
+int jesd204_dev_unregister(struct jesd204_dev *jdev)
+{
+	if (!jdev)
+		return -EINVAL;
+
+	free(jdev->priv);
+	free(jdev);
+
+	return 0;
+}
+
+/* no-OS specific */
+int jesd204_topology_init(struct jesd204_topology **topology,
+			  struct jesd204_topology_dev *devs,
+			  unsigned int devs_number)
+{
+	struct jesd204_topology *top;
+	int i, l, d = 0;
+
+	if (!topology)
+		return -EINVAL;
+
+	if (!devs)
+		return -EINVAL;
+
+	top = (struct jesd204_topology *)calloc(1, sizeof(*top));
+	if (!top)
+		return -ENOMEM;
+
+	top->dev_top = (struct jesd204_dev_top *)calloc(1, sizeof(*top->dev_top));
+	if (!top->dev_top) {
+		free(top);
+		return -ENOMEM;
+	}
+
+	top->devs_number = devs_number - 1;
+	top->devs = (struct jesd204_topology_dev *)calloc(1,
+			top->devs_number * sizeof(*top->devs));
+
+	for (i = 0; i < devs_number; i++) {
+		if (devs[i].is_top_device) {
+			top->dev_top->jdev = devs[i].jdev;
+			top->dev_top->jdev->is_top = true;
+			top->dev_top->jdev->topology = top;
+			top->dev_top->num_links = devs[i].links_number;
+			for (l = 0; l < devs[i].links_number; l++)
+				top->dev_top->link_ids[l] = devs[i].link_ids[l];
+			jesd204_dev_alloc_links(top->dev_top);
+		} else {
+			top->devs[d] = devs[i];
+			if (top->devs[d].is_sysref_provider)
+				top->dev_top->jdev_sysref = top->devs[d].jdev;
+			d++;
+		}
+	}
+
+	*topology = top;
+
+	return 0;
+}
+
+/* no-OS specific */
+int jesd204_topology_remove(struct jesd204_topology *topology)
+{
+	if (!topology)
+		return -EINVAL;
+
+	free(topology->dev_top);
+	free(topology);
+
+	return 0;
+}
+
+/* no-OS specific */
+struct jesd204_dev_top *jesd204_dev_get_topology_top_dev(
+	struct jesd204_dev *jdev)
+{
+	return jdev->topology->dev_top;
+}
+
+static int jesd204_link_validate_params(const struct jesd204_link *lnk)
+{
+	if (!lnk->num_lanes) {
+		pr_err("link[%u], number of lanes is zero\n", lnk->link_id);
+		return -EINVAL;
+	}
+
+	if (!lnk->num_converters) {
+		pr_err("link[%u], number of converters is zero\n", lnk->link_id);
+		return -EINVAL;
+	}
+
+	if (!lnk->bits_per_sample) {
+		pr_err("link[%u], bits-per-sample is zero\n", lnk->link_id);
+		return -EINVAL;
+	}
+
+	if (!lnk->sample_rate) {
+		pr_err("link[%u], sample rate is zero\n", lnk->link_id);
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+int jesd204_link_get_rate(struct jesd204_link *lnk, uint64_t *lane_rate_hz)
+{
+	uint64_t rate, encoding_n, encoding_d;
+	uint32_t sample_rate_div;
+	int ret;
+
+	ret = jesd204_link_validate_params(lnk);
+	if (ret)
+		return ret;
+
+	switch (lnk->jesd_version) {
+	case JESD204_VERSION_C:
+		switch (lnk->jesd_encoder) {
+		case JESD204_ENCODER_64B66B:
+			encoding_n = 66; /* JESD 204C */
+			encoding_d = 64;
+			break;
+		case JESD204_ENCODER_8B10B:
+			encoding_n = 10; /* JESD 204C */
+			encoding_d = 8;
+			break;
+		case JESD204_ENCODER_64B80B:
+			encoding_n = 80; /* JESD 204C */
+			encoding_d = 64;
+			break;
+		default:
+			return -EINVAL;
+		}
+		break;
+	default:
+		encoding_n = 10; /* JESD 204AB */
+		encoding_d = 8;
+		break;
+	}
+
+	sample_rate_div = lnk->sample_rate_div ? lnk->sample_rate_div : 1;
+
+	rate = lnk->num_converters * lnk->bits_per_sample *
+	       encoding_n * lnk->sample_rate;
+	no_os_do_div(&rate, lnk->num_lanes * encoding_d * sample_rate_div);
+
+	*lane_rate_hz = rate;
+
+	return 0;
+}
+
+int jesd204_link_get_rate_khz(struct jesd204_link *lnk,
+			      unsigned long *lane_rate_khz)
+{
+	uint64_t lane_rate_hz;
+	int ret;
+
+	ret = jesd204_link_get_rate(lnk, &lane_rate_hz);
+	if (ret)
+		return ret;
+
+	*lane_rate_khz = NO_OS_DIV_ROUND_CLOSEST_ULL(lane_rate_hz, 1000);
+
+	return ret;
+}
+
+int jesd204_link_get_device_clock(struct jesd204_link *lnk,
+				  unsigned long *device_clock)
+{
+	uint64_t lane_rate_hz;
+	uint32_t encoding_n;
+	int ret;
+
+	ret = jesd204_link_get_rate(lnk, &lane_rate_hz);
+	if (ret)
+		return ret;
+
+	switch (lnk->jesd_version) {
+	case JESD204_VERSION_C:
+		switch (lnk->jesd_encoder) {
+		case JESD204_ENCODER_64B66B:
+			encoding_n = 66; /* JESD 204C */
+			break;
+		case JESD204_ENCODER_8B10B:
+			encoding_n = 40; /* JESD 204ABC */
+			break;
+		case JESD204_ENCODER_64B80B:
+			encoding_n = 80; /* JESD 204C */
+			break;
+		default:
+			return -EINVAL;
+		}
+		break;
+	default:
+		encoding_n = 40; /* JESD 204AB */
+		break;
+	}
+
+	no_os_do_div(&lane_rate_hz, encoding_n);
+
+	*device_clock = lane_rate_hz;
+
+	return ret;
+}
+
+void jesd204_copy_link_params(struct jesd204_link *dst,
+			      const struct jesd204_link *src)
+{
+	dst->is_transmit = src->is_transmit;
+	dst->num_lanes = src->num_lanes;
+	dst->num_converters = src->num_converters;
+	dst->octets_per_frame = src->octets_per_frame;
+	dst->frames_per_multiframe = src->frames_per_multiframe;
+	dst->num_of_multiblocks_in_emb = src->num_of_multiblocks_in_emb;
+	dst->bits_per_sample = src->bits_per_sample;
+	dst->converter_resolution = src->converter_resolution;
+	dst->jesd_version = src->jesd_version;
+	dst->jesd_encoder = src->jesd_encoder;
+	dst->subclass = src->subclass;
+	dst->device_id = src->device_id;
+	dst->bank_id = src->bank_id;
+	dst->scrambling = src->scrambling;
+	dst->high_density = src->high_density;
+	dst->ctrl_words_per_frame_clk = src->ctrl_words_per_frame_clk;
+	dst->ctrl_bits_per_sample = src->ctrl_bits_per_sample;
+	dst->samples_per_conv_frame = src->samples_per_conv_frame;
+	dst->dac_adj_resolution_steps = src->dac_adj_resolution_steps;
+	dst->dac_adj_direction = src->dac_adj_direction;
+	dst->dac_phase_adj = src->dac_phase_adj;
+	dst->sysref.mode = dst->sysref.mode;
+	dst->sysref.capture_falling_edge = dst->sysref.capture_falling_edge;
+	dst->sysref.valid_falling_edge = dst->sysref.valid_falling_edge;
+	dst->sysref.lmfc_offset = dst->sysref.lmfc_offset;
+}
+
+int jesd204_link_get_lmfc_lemc_rate(struct jesd204_link *lnk,
+				    unsigned long *rate_hz)
+{
+	uint64_t lane_rate_hz;
+	uint32_t bkw;
+	int ret;
+
+	ret = jesd204_link_get_rate(lnk, &lane_rate_hz);
+	if (ret)
+		return ret;
+
+	switch (lnk->jesd_version) {
+	case JESD204_VERSION_C:
+		switch (lnk->jesd_encoder) {
+		case JESD204_ENCODER_64B66B:
+			bkw = 66; /* JESD 204C */
+		/* fall-through */
+		case JESD204_ENCODER_64B80B:
+			if (lnk->jesd_encoder == JESD204_ENCODER_64B80B)
+				bkw = 80; /* JESD 204C */
+
+			if (lnk->num_of_multiblocks_in_emb) {
+				no_os_do_div(&lane_rate_hz, bkw * 32 *
+					     lnk->num_of_multiblocks_in_emb);
+			} else {
+				lane_rate_hz *= 8;
+				no_os_do_div(&lane_rate_hz, bkw *
+					     lnk->octets_per_frame *
+					     lnk->frames_per_multiframe);
+			}
+			break;
+		case JESD204_ENCODER_8B10B:
+			no_os_do_div(&lane_rate_hz, 10 * lnk->octets_per_frame *
+				     lnk->frames_per_multiframe);
+			break;
+		default:
+			return -EINVAL;
+		}
+		break;
+	default:
+		no_os_do_div(&lane_rate_hz, 10 * lnk->octets_per_frame *
+			     lnk->frames_per_multiframe);
+		break;
+	}
+
+	*rate_hz = lane_rate_hz;
+
+	return 0;
+}
+
+int jesd204_sysref_async(struct jesd204_dev *jdev)
+{
+	struct jesd204_dev_top *jdev_top = jesd204_dev_get_topology_top_dev(jdev);
+	const struct jesd204_dev_data *dev_data;
+
+	if (!jdev_top)
+		return -EFAULT;
+
+	/* No SYSREF registered for this topology */
+	if (!jdev_top->jdev_sysref)
+		return 0;
+
+	if (!jdev_top->jdev_sysref->dev_data)
+		return -EFAULT;
+
+	dev_data = jdev_top->jdev_sysref->dev_data;
+
+	/* By now, this should have been validated to have sysref_cb() */
+	return dev_data->sysref_cb(jdev_top->jdev_sysref);
+}
+
+int jesd204_sysref_async_force(struct jesd204_dev *jdev)
+{
+	struct jesd204_dev_top *jdev_top = jesd204_dev_get_topology_top_dev(jdev);
+	const struct jesd204_dev_data *dev_data;
+
+	if (!jdev_top)
+		return -EFAULT;
+
+	/* Primary SYSREF registered for this topology? */
+	if (jdev_top->jdev_sysref)
+		return jesd204_sysref_async(jdev);
+
+	/* No SYSREF registered for this topology */
+	if (!jdev_top->jdev_sysref_sec)
+		return 0;
+
+	if (!jdev_top->jdev_sysref_sec->dev_data)
+		return -EFAULT;
+
+	dev_data = jdev_top->jdev_sysref_sec->dev_data;
+
+	/* By now, this should have been validated to have sysref_cb() */
+	return dev_data->sysref_cb(jdev_top->jdev_sysref_sec);
+}
+
+bool jesd204_dev_is_top(struct jesd204_dev *jdev)
+{
+	return jdev && jdev->is_top;
+}
+
+void *jesd204_dev_priv(struct jesd204_dev *jdev)
+{
+	return jdev->priv;
+}

--- a/jesd204/jesd204-fsm.c
+++ b/jesd204/jesd204-fsm.c
@@ -1,0 +1,101 @@
+/**
+ * The JESD204 framework - finite state machine logic
+ *
+ * Copyright (c) 2022 Analog Devices Inc.
+ */
+
+#include "no_os_error.h"
+#include "jesd204-priv.h"
+
+/* no-OS specific */
+int jesd204_fsm_start(struct jesd204_topology *topology, unsigned int link_idx)
+{
+	enum jesd204_state_op_reason reason = JESD204_STATE_OP_REASON_INIT;
+	struct jesd204_dev_top *jdev_top = topology->dev_top;
+	bool per_device_op_done[16];
+	enum jesd204_dev_op op;
+	int lnk_dev;
+	int lnk_id;
+	int dev;
+
+	for (op = 0; op < __JESD204_MAX_OPS; op++) {
+		for (dev = 0; dev < topology->devs_number; dev++)
+			per_device_op_done[dev] = false;
+
+		for (lnk_id = 0; lnk_id < jdev_top->num_links; lnk_id++) {
+			for (dev = 0; dev < topology->devs_number; dev++) {
+				for (lnk_dev = 0; lnk_dev < topology->devs[dev].links_number; lnk_dev++) {
+					if (topology->devs[dev].link_ids[lnk_dev] == jdev_top->link_ids[lnk_id]) {
+						if (topology->devs[dev].jdev->dev_data->state_ops[op].per_device
+						    && !per_device_op_done[dev]) {
+							topology->devs[dev].jdev->dev_data->state_ops[op].per_device(
+								topology->devs[dev].jdev, reason);
+							per_device_op_done[dev] = true;
+						}
+						if (topology->devs[dev].jdev->dev_data->state_ops[op].per_link)
+							topology->devs[dev].jdev->dev_data->state_ops[op].per_link(
+								topology->devs[dev].jdev, reason,
+								&jdev_top->active_links[lnk_id].link);
+					}
+				}
+			}
+			if (jdev_top->jdev->dev_data->state_ops[op].per_link) {
+				jdev_top->jdev->dev_data->state_ops[op].per_link(jdev_top->jdev, reason,
+						&jdev_top->active_links[lnk_id].link);
+				if (jdev_top->jdev->dev_data->state_ops[op].post_state_sysref)
+					jesd204_sysref_async(jdev_top->jdev);
+			}
+		}
+		if (jdev_top->jdev->dev_data->state_ops[op].per_device) {
+			jdev_top->jdev->dev_data->state_ops[op].per_device(jdev_top->jdev, reason);
+			if (jdev_top->jdev->dev_data->state_ops[op].post_state_sysref)
+				jesd204_sysref_async(jdev_top->jdev);
+		}
+	}
+
+	return 0;
+}
+
+/* no-OS specific */
+int jesd204_fsm_stop(struct jesd204_topology *topology, unsigned int link_idx)
+{
+	enum jesd204_state_op_reason reason = JESD204_STATE_OP_REASON_UNINIT;
+	struct jesd204_dev_top *jdev_top = topology->dev_top;
+	bool per_device_op_done[16];
+	int lnk_dev;
+	int lnk_id;
+	int dev;
+	int op;
+
+	for (op = __JESD204_MAX_OPS - 1; op >= 0; op--) {
+		for (dev = topology->devs_number - 1; dev >= 0 ; dev--)
+			per_device_op_done[dev] = false;
+
+		if (jdev_top->jdev->dev_data->state_ops[op].per_device)
+			jdev_top->jdev->dev_data->state_ops[op].per_device(jdev_top->jdev, reason);
+
+		for (lnk_id = jdev_top->num_links - 1; lnk_id >= 0; lnk_id--) {
+			if (jdev_top->jdev->dev_data->state_ops[op].per_link)
+				jdev_top->jdev->dev_data->state_ops[op].per_link(jdev_top->jdev, reason,
+						&jdev_top->active_links[lnk_id].link);
+			for (dev = topology->devs_number - 1; dev >= 0; dev--) {
+				for (lnk_dev = topology->devs[dev].links_number - 1; lnk_dev >= 0; lnk_dev--) {
+					if (topology->devs[dev].link_ids[lnk_dev] == jdev_top->link_ids[lnk_id]) {
+						if (topology->devs[dev].jdev->dev_data->state_ops[op].per_device
+						    && !per_device_op_done[dev]) {
+							topology->devs[dev].jdev->dev_data->state_ops[op].per_device(
+								topology->devs[dev].jdev, reason);
+							per_device_op_done[dev] = true;
+						}
+						if (topology->devs[dev].jdev->dev_data->state_ops[op].per_link)
+							topology->devs[dev].jdev->dev_data->state_ops[op].per_link(
+								topology->devs[dev].jdev, reason,
+								&jdev_top->active_links[lnk_id].link);
+					}
+				}
+			}
+		}
+	}
+
+	return 0;
+}

--- a/jesd204/jesd204-priv.h
+++ b/jesd204/jesd204-priv.h
@@ -1,0 +1,71 @@
+/**
+ * The JESD204 framework
+ *
+ * Copyright (c) 2022 Analog Devices Inc.
+ */
+
+#ifndef _JESD204_PRIV_H_
+#define _JESD204_PRIV_H_
+
+#include "jesd204.h"
+
+#define JESD204_MAX_LINKS	16
+
+/**
+ * struct jesd204_dev - JESD204 device
+ * @dev_data		ref to data provided by the driver registering with the framework
+ * @priv		private data to be returned to the driver
+ * @is_top		true if this device is a top device in a topology of
+ *			devices that make up a JESD204 link (typically the
+ *			device that is the ADC, DAC, or transceiver)
+ */
+struct jesd204_dev {
+	const struct jesd204_dev_data	*dev_data;
+	void				*priv;
+
+	bool				is_top;
+
+	/* no-OS specific */
+	struct jesd204_topology		*topology;
+};
+
+/**
+ * struct jesd204_link_opaque - JESD204 link information (opaque part)
+ * @link		public link information
+ * @jdev_top		JESD204 top level this links belongs to
+ * @link_idx		Index in the array of JESD204 links in @jdev_top
+ */
+struct jesd204_link_opaque {
+	struct jesd204_link		link;
+	struct jesd204_dev_top		*jdev_top;
+	unsigned int			link_idx;
+};
+
+/**
+ * struct jesd204_dev_top - JESD204 top device (in a JESD204 topology)
+ * @jdev		JESD204 device data
+ * @jdev_sysref		reference to the object that is the SYSREF provider for this topology
+ * @jdev_sysref_sec	reference to the object that is the secondary SYSREF provider
+ * 			for this topology, in case the primary jdev_sysref doesn't exist
+ * @link_ids		JESD204 link IDs for this top-level device
+ *			(connections should match against this)
+ * @num_links		number of links
+ * @active_links	active JESD204 link settings
+ */
+struct jesd204_dev_top {
+	/* no-OS specific */
+	struct jesd204_dev		*jdev;
+
+	struct jesd204_dev		*jdev_sysref;
+	struct jesd204_dev		*jdev_sysref_sec;
+
+	unsigned int			link_ids[JESD204_MAX_LINKS];
+	unsigned int			num_links;
+
+	struct jesd204_link_opaque	*active_links;
+};
+
+struct jesd204_dev_top *jesd204_dev_get_topology_top_dev(
+	struct jesd204_dev *jdev);
+
+#endif /* _JESD204_PRIV_H_ */


### PR DESCRIPTION
More details:
https://wiki.analog.com/resources/tools-software/linux-drivers/jesd204/jesd204-fsm-framework

The no-OS specific code is marked accordingly (/* no-OS specific */).

Signed-off-by: Dragos Bogdan <dragos.bogdan@analog.com>