### PR TITLE
drivers:adc:ad738x Added standard SPI support

### DIFF
--- a/drivers/adc/ad738x/ad738x.h
+++ b/drivers/adc/ad738x/ad738x.h
@@ -45,6 +45,9 @@
 /***************************** Include Files **********************************/
 /******************************************************************************/
 #include "no_os_util.h"
+#if defined(USE_STANDARD_SPI)
+#include "no_os_spi.h"
+#endif
 
 /******************************************************************************/
 /********************** Macros and Constants Definitions **********************/
@@ -152,8 +155,10 @@ enum ad738x_ref_sel {
 struct ad738x_dev {
 	/* SPI */
 	no_os_spi_desc		*spi_desc;
+#if !defined(USE_STANDARD_SPI)
 	/** SPI module offload init */
 	struct spi_engine_offload_init_param *offload_init_param;
+#endif
 	/* Device Settings */
 	enum ad738x_conv_mode 	conv_mode;
 	enum ad738x_ref_sel		ref_sel;
@@ -165,8 +170,10 @@ struct ad738x_dev {
 struct ad738x_init_param {
 	/* SPI */
 	no_os_spi_init_param		*spi_param;
+#if !defined(USE_STANDARD_SPI)
 	/** SPI module offload init */
 	struct spi_engine_offload_init_param *offload_init_param;
+#endif
 	/* Device Settings */
 	enum ad738x_conv_mode	conv_mode;
 	enum ad738x_ref_sel		ref_sel;


### PR DESCRIPTION
Change 1:
Added standard SPI support for ad738x drivers to work with baremetal systems.
- The SPI engine functionality has been enabled by default. If macro 'USE_STANDARD_SPI' is added,
- the SPI engine code is replaced with standard no-os platform drivers SPI code.
- This change is similar to what has been done on ad4696 drivers.

Change 2:
Fixed the register data read function
As per ad7380 datasheet (Rev A, Page 27, section-ADDRESSING REGISTERS), to read the register data, the command needs to be send twice.
First word (2-bytes) of data read request, holds the command to inform register address to ADC.
Second word (2-bytes) of data request, is dummy read (NOP) to read the contents of that register.
Behavior is tested on SDP-K1 board using AD7380FMCZ board.

Signed-off-by: MPhalke <mahesh.phalke@analog.com>