### PR TITLE
AD413x: add driver support and project

### DIFF
--- a/drivers/afe/ad413x/ad413x.c
+++ b/drivers/afe/ad413x/ad413x.c
@@ -1,0 +1,1106 @@
+/***************************************************************************//**
+ *   @file   ad413x.c
+ *   @brief  Implementation of AD413X Driver.
+ *   @author Andrei Porumb (andrei.porumb@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdio.h>
+#include <stdlib.h>
+#include "ad413x.h"
+#include "no_os_error.h"
+#include "no_os_irq.h"
+#include "no_os_print_log.h"
+#include "no_os_delay.h"
+#include "no_os_crc8.h"
+#include "no_os_spi.h"
+
+NO_OS_DECLARE_CRC8_TABLE(ad413x_crc8);
+uint32_t timeout = 0xFFFFFF;
+
+/******************************************************************************/
+/************************** Functions Implementation **************************/
+/******************************************************************************/
+
+/***************************************************************************//**
+ * IRQ handler for ADC read.
+*******************************************************************************/
+static void irq_adc_read(struct ad413x_callback_ctx *ctx)
+{
+	struct ad413x_dev *dev = ctx->dev;
+	timeout = 0xFFFFFF;
+	if(ctx->buffer_size > 0) {
+		ad413x_reg_read(ctx->dev, AD413X_REG_DATA, ctx->buffer);
+		ctx->buffer_size--;
+		ctx->buffer++;
+		no_os_irq_enable(dev->irq_desc, dev->rdy_pin);
+	} else {
+		no_os_irq_disable(dev->irq_desc, dev->rdy_pin);
+	}
+}
+
+/***************************************************************************//**
+ * SPI internal register write to device using a mask.
+ *
+ * @param dev      - The device structure.
+ * @param reg_addr - The register address.
+ * @param data     - The register data.
+ * @param mask     - The mask.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_reg_write_msk(struct ad413x_dev *dev,
+			     uint32_t reg_addr,
+			     uint32_t data,
+			     uint32_t mask)
+{
+	int32_t ret;
+	uint32_t reg_data;
+
+	ret = ad413x_reg_read(dev, reg_addr, &reg_data);
+	if (ret)
+		return ret;
+	reg_data &= ~mask;
+	reg_data |= data;
+	return ad413x_reg_write(dev, reg_addr, reg_data);
+}
+
+/***************************************************************************//**
+ * Set the mode of the ADC.
+ *
+ * @param dev       - The device structure.
+ * @param mode      - The ADC mode
+ *		      Accepted values: AD4110_CONTINOUS_CONV_MODE
+ *				       AD4110_SINGLE_CONV_MODE
+ *				       AD4110_STANDBY_MODE
+ *				       AD4110_PW_DOWN_MODE
+ *				       AD4110_SYS_OFFSET_CAL
+ *				       AD4110_SYS_GAIN_CAL
+ *
+ * @return 0 in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_set_adc_mode(struct ad413x_dev *dev, enum ad413x_adc_mode mode)
+{
+	int32_t ret;
+	ret = ad413x_reg_write_msk(dev,
+				   AD413X_REG_ADC_CTRL,
+				   AD413X_ADC_MODE(mode),
+				   AD413X_ADC_MODE(0xF));
+	if (ret)
+		return ret;
+
+	dev->op_mode = mode;
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * Set the internal reference.
+ *
+ * @param dev       - The device structure.
+ * @param int_ref   - The internal reference option.
+ *		      Accepted values: AD413X_INTREF_DISABLED
+ *					   AD413X_INTREF_2_5V,
+ *					   AD413X_INTREF_1_25V
+ *
+ * @return 0 in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_set_int_ref(struct ad413x_dev *dev, enum ad413x_int_ref int_ref)
+{
+	int32_t ret;
+	switch (int_ref) {
+	case AD413X_INTREF_DISABLED:
+		ret = ad413x_reg_write_msk(dev,
+					   AD413X_REG_ADC_CTRL,
+					   0U,
+					   AD413X_ADC_REF_EN);
+		break;
+
+	case AD413X_INTREF_2_5V:
+		ret = ad413x_reg_write_msk(dev,
+					   AD413X_REG_ADC_CTRL,
+					   AD413X_ADC_REF_EN,
+					   AD413X_ADC_REF_EN);
+		if (ret)
+			return ret;
+		ret = ad413x_reg_write_msk(dev,
+					   AD413X_REG_ADC_CTRL,
+					   0U,
+					   AD413X_ADC_REF_VAL);
+		break;
+
+	case AD413X_INTREF_1_25V:
+		ret = ad413x_reg_write_msk(dev,
+					   AD413X_REG_ADC_CTRL,
+					   AD413X_ADC_REF_EN,
+					   AD413X_ADC_REF_EN);
+		if (ret)
+			return ret;
+		ret = ad413x_reg_write_msk(dev,
+					   AD413X_REG_ADC_CTRL,
+					   AD413X_ADC_REF_VAL,
+					   AD413X_ADC_REF_VAL);
+		break;
+
+	default:
+		return -EINVAL;
+	}
+
+	if (ret)
+		return ret;
+
+	dev->int_ref = int_ref;
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * Enable/disable DATA_STAT field.
+ *
+ * @param dev       - The device structure.
+ * @param enable	- 0 DISABLE
+ * 					  1 ENABLE
+ *
+ * @return 0 in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_data_stat_en(struct ad413x_dev *dev, uint8_t enable)
+{
+	int32_t ret;
+	ret = ad413x_reg_write_msk(dev,
+				   AD413X_REG_ADC_CTRL,
+				   enable ? AD413X_ADC_DATA_STATUS : 0x0U,
+				   AD413X_ADC_DATA_STATUS);
+	if (ret)
+		return ret;
+
+	dev->data_stat = enable;
+
+	return 0;
+}
+/***************************************************************************//**
+ * Set the gain from configuration register.
+ *
+ * @param dev  - The device structure.
+ * @param gain - The gain value.
+ * 		 Accepted values: AD413X_GAIN_1
+ * 				  AD413X_GAIN_2
+ * 				  AD413X_GAIN_4
+ * 				  AD413X_GAIN_8
+ * 				  AD413X_GAIN_16
+ * 				  AD413X_GAIN_32
+ * 				  AD413X_GAIN_64
+ *				  AD413X_GAIN_128
+ * @param reg_nb - Number of Configuration Register
+ *
+ * @return 0 in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_set_gain(struct ad413x_dev *dev, enum ad413x_gain gain,
+			enum ad413x_preset_nb reg_nb)
+{
+	int32_t ret;
+
+	ret = ad413x_reg_write_msk(dev,
+				   AD413X_REG_CONFIG(reg_nb),
+				   AD413X_PGA_N(gain),
+				   AD413X_PGA_N(0xF));
+	if (ret)
+		return ret;
+
+	dev->preset[reg_nb].gain = gain;
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * Select reference from configuration register.
+ *
+ * @param dev  - The device structure.
+ * @param ref - The reference value.
+ * 		 Accepted values: AD413X_REFIN1
+ *					AD413X_REFIN2
+ *					AD413X_REFOUT_AVSS
+ *					AD413X_AVDD_AVSS
+ * @param reg_nb - Number of Configuration Register
+ *
+ * @return 0 in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_set_ref(struct ad413x_dev *dev, enum ad413x_ref_sel ref,
+		       enum ad413x_preset_nb reg_nb)
+{
+	int32_t ret;
+
+	ret = ad413x_reg_write_msk(dev,
+				   AD413X_REG_CONFIG(reg_nb),
+				   AD413X_REF_SEL_N(ref),
+				   AD413X_REF_SEL_N(0xF));
+	if (ret)
+		return ret;
+
+	dev->preset[reg_nb].ref_sel = ref;
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * Select the reference buffers.
+ *
+ * @param dev  - The device structure.
+ * @param ref_buf - The reference buffer status.
+ * @param reg_nb - Number of Configuration Register
+ *
+ * @return 0 in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_set_ref_buf(struct ad413x_dev *dev,
+			   struct ad413x_ref_buf ref_buf,
+			   enum ad413x_preset_nb reg_nb)
+{
+	int32_t ret;
+	uint32_t reg_val;
+
+	reg_val = no_os_field_prep(AD413X_REF_BUFP_N, ref_buf.ref_buf_p_en);
+	reg_val |= no_os_field_prep(AD413X_REF_BUFM_N, ref_buf.ref_buf_m_en);
+
+	ret = ad413x_reg_write_msk(dev,
+				   AD413X_REG_CONFIG(reg_nb),
+				   reg_val,
+				   AD413X_REF_BUF_MSK);
+	if (ret)
+		return ret;
+
+	dev->preset[reg_nb].ref_buf = ref_buf;
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * Select filter from filter register.
+ *
+ * @param dev  	 - The device structure.
+ * @param filter - The filter type.
+ * 		 Accepted values: AD413X_SYNC4_STANDALONE
+ *					AD413X_SYNC4_SYNC1
+ *					AD413X_SYNC3_STANDALONE
+ *					AD413X_SYNC3_REJ60
+ *					AD413X_SYNC3_SYNC1
+ *					AD413X_SYNC3_PF1
+ *					AD413X_SYNC3_PF2
+ *					AD413X_SYNC3_PF3
+ *					AD413X_SYNC3_PF4
+ * @param reg_nb - Number of Configuration Register
+ *
+ * @return 0 in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_set_filter(struct ad413x_dev *dev, enum ad413x_filter filter,
+			  enum ad413x_preset_nb reg_nb)
+{
+	int32_t ret;
+
+	ret = ad413x_reg_write_msk(dev,
+				   AD413X_REG_FILTER(reg_nb),
+				   AD413X_FILTER_MODE_N(filter),
+				   AD413X_FILTER_MODE_N(0xF));
+	if (ret)
+		return ret;
+
+	dev->preset[reg_nb].filter = filter;
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * Select settle time from filter register.
+ *
+ * @param dev  	 - The device structure.
+ * @param s_time - The settle time value.
+ * 		 Accepted values: AD413X_32_MCLK
+ *					AD413X_64_MCLK
+ *					AD413X_128_MCLK
+ *					AD413X_256_MCLK
+ *					AD413X_512_MCLK
+ *					AD413X_1024_MCLK
+ *					AD413X_2048_MCLK
+ *					AD413X_4096_MCLK
+ * @param reg_nb - Number of Configuration Register
+ *
+ * @return 0 in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_set_settle_time(struct ad413x_dev *dev,
+			       enum ad413x_settle_time s_time,
+			       enum ad413x_preset_nb reg_nb)
+{
+	int32_t ret;
+
+	ret = ad413x_reg_write_msk(dev,
+				   AD413X_REG_FILTER(reg_nb),
+				   AD413X_SETTLE_N(s_time),
+				   AD413X_SETTLE_N(0xFF));
+	if (ret)
+		return ret;
+
+	dev->preset[reg_nb].s_time = s_time;
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * Select excitation current value from config register.
+ *
+ * @param dev  	 - The device structure.
+ * @param iout0_exc - The Iout0 excitation current value.
+ * @param iout1_exc - The Iout1 excitation current value.
+ * 		 Accepted values: AD413X_EXC_OFF
+ *					AD413X_EXC_10UA
+ *					AD413X_EXC_20UA
+ *					AD413X_EXC_50UA
+ *					AD413X_EXC_100UA
+ *					AD413X_EXC_150UA
+ *					AD413X_EXC_200UA
+ *					AD413X_EXC_100NA
+ * @param reg_nb - Number of Configuration Register
+ *
+ * @return 0 in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_set_exc_current(struct ad413x_dev *dev,
+			       enum ad413x_exc_current iout0_exc,
+			       enum ad413x_exc_current iout1_exc,
+			       enum ad413x_preset_nb reg_nb)
+{
+	int32_t ret;
+
+	ret = ad413x_reg_write_msk(dev,
+				   AD413X_REG_CONFIG(reg_nb),
+				   AD413X_I_OUT0_N(iout0_exc) | AD413X_I_OUT1_N(iout1_exc),
+				   AD413X_I_OUT_MSK);
+	if (ret)
+		return ret;
+
+	dev->preset[reg_nb].iout0_exc_current = iout0_exc;
+	dev->preset[reg_nb].iout1_exc_current = iout1_exc;
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * Select preset for adc channel.
+ *
+ * @param dev  		- The device structure.
+ * @param ch_nb  	- The channel number.
+ * @param preset_nb - The preset number.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_set_ch_preset(struct ad413x_dev *dev, uint8_t ch_nb,
+			     enum ad413x_preset_nb preset_nb)
+{
+	int32_t ret;
+
+	ret = ad413x_reg_write_msk(dev,
+				   AD413X_REG_CHN(ch_nb),
+				   AD413X_SETUP_M(preset_nb),
+				   AD413X_SETUP_M(0xF));
+	if (ret)
+		return ret;
+
+	dev->ch[ch_nb].preset = preset_nb;
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * Select the excitation source pins.
+ *
+ * @param dev  		- The device structure.
+ * @param ch_nb  	- The channel number.
+ * @param iout0_exc_inp 	- IOUT0 excitation input pin.
+ * @param iout1_exc_inp 	- IOUT1 excitation input pin.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_ch_exc_input(struct ad413x_dev *dev, uint8_t ch_nb,
+			    enum ad413x_input iout0_exc_inp,
+			    enum ad413x_input iout1_exc_inp)
+{
+	int32_t ret;
+
+	ret = ad413x_reg_write_msk(dev,
+				   AD413X_REG_CHN(ch_nb),
+				   AD413X_I_OUT0_CH_M(iout0_exc_inp) |
+				   AD413X_I_OUT1_CH_M(iout1_exc_inp),
+				   AD413X_I_OUT_CH_MSK);
+	if (ret)
+		return ret;
+
+	dev->ch[ch_nb].iout0_exc_input = iout0_exc_inp;
+	dev->ch[ch_nb].iout1_exc_input = iout1_exc_inp;
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * Enable/disable channel.
+ *
+ * @param dev  		- The device structure.
+ * @param ch_nb  	- The channel number.
+ * @param enable 	- Channel status.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_ch_en(struct ad413x_dev *dev, uint8_t ch_nb, uint8_t enable)
+{
+	int32_t ret;
+
+	ret = ad413x_reg_write_msk(dev,
+				   AD413X_REG_CHN(ch_nb),
+				   enable ? AD413X_ENABLE_M : 0x0U,
+				   AD413X_ENABLE_M);
+	if (ret)
+		return ret;
+
+	dev->ch[ch_nb].enable = enable;
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * Enable/disable Power-Down Switch (PDSW).
+ *
+ * @param dev  		- The device structure.
+ * @param ch_nb  	- The channel number.
+ * @param pdsw_en 	- PDSW status.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_pdsw_en(struct ad413x_dev *dev, uint8_t ch_nb, bool pdsw_en)
+{
+	int32_t ret;
+
+	ret = ad413x_reg_write_msk(dev,
+				   AD413X_REG_CHN(ch_nb),
+				   pdsw_en ? AD413X_PDSW_M : 0x0U,
+				   AD413X_PDSW_M);
+	if (ret)
+		return ret;
+
+	dev->ch[ch_nb].pdsw_en = pdsw_en;
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * Enable/disable bipolar data coding.
+ *
+ * @param dev  		- The device structure.
+ * @param enable 	- 1 - Bipolar
+ * 					  0 - Unipolar
+ *
+ * @return 0 in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_adc_bipolar(struct ad413x_dev *dev, uint8_t enable)
+{
+	int32_t ret;
+
+	ret = ad413x_reg_write_msk(dev,
+				   AD413X_REG_ADC_CTRL,
+				   enable ? AD413X_ADC_BIPOLAR : 0x0U,
+				   AD413X_ADC_BIPOLAR);
+	if (ret)
+		return ret;
+
+	dev->bipolar = enable;
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * Set output VBIAS on analog inputs.
+ *
+ * @param dev  		- The device structure.
+ * @param v_bias_val 	- V_BIAS control register value
+ *
+ * @return 0 in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_set_v_bias(struct ad413x_dev *dev, uint16_t v_bias_val)
+{
+	int32_t ret;
+
+	ret = ad413x_reg_write(dev,
+			       AD413X_REG_VBIAS_CTRL,
+			       v_bias_val);
+	if (ret)
+		return ret;
+
+	dev->v_bias = v_bias_val;
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * Set standby control flags.
+ *
+ * @param dev  		- The device structure.
+ * @param standby_ctrl 	- Standby control value
+ *
+ * @return 0 in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_set_standby_ctrl(struct ad413x_dev *dev,
+				struct ad413x_standby_ctrl standby_ctrl)
+{
+	int32_t ret;
+	uint32_t reg_val;
+
+	reg_val = no_os_field_prep(AD413X_STBY_INTREF_EN,
+				   standby_ctrl.standby_int_ref_en);
+	reg_val |= no_os_field_prep(AD413X_STBY_REFHOL_EN,
+				    standby_ctrl.standby_ref_holder_en);
+	reg_val |= no_os_field_prep(AD413X_STBY_IEXC_EN, standby_ctrl.standby_iexc_en);
+	reg_val |= no_os_field_prep(AD413X_STBY_VBIAS_EN,
+				    standby_ctrl.standby_vbias_en);
+	reg_val |= no_os_field_prep(AD413X_STBY_BURNOUT_EN,
+				    standby_ctrl.standby_burnout_en);
+	reg_val |= no_os_field_prep(AD413X_STBY_PDSW_EN, standby_ctrl.standby_pdsw_en);
+	reg_val |= no_os_field_prep(AD413X_STBY_GPO_EN, standby_ctrl.standby_gpio_en);
+	reg_val |= no_os_field_prep(AD413X_STBY_DIAGNOSTICS_EN,
+				    standby_ctrl.standby_diagn_en);
+	reg_val |= no_os_field_prep(AD413X_STBY_OUT_EN, standby_ctrl.standby_output_en);
+
+	ret = ad413x_reg_write_msk(dev,
+				   AD413X_REG_MISC,
+				   reg_val,
+				   AD413X_STBY_CTRL_MSK);
+	if (ret)
+		return ret;
+
+	dev->standby_ctrl = standby_ctrl;
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * Set ADC master clock mode.
+ *
+ * @param dev  - The device structure.
+ * @param clk  - The clock mode.
+ * 		 Accepted values: AD413X_INT_76_8_KHZ_OUT_OFF
+ * 				  AD413X_INT_76_8_KHZ_OUT_ON
+ * 				  AD413X_EXT_76_8KHZ
+ * 				  AD413X_EXT_153_6_KHZ_DIV_2
+ *
+ * @return 0 in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_set_mclk(struct ad413x_dev *dev, enum ad413x_mclk_sel clk)
+{
+	int32_t ret;
+	ret = ad413x_reg_write_msk(dev,
+				   AD413X_REG_ADC_CTRL,
+				   AD413X_ADC_CNTRL_MCLK(clk),
+				   AD413X_ADC_CNTRL_MCLK(0xF));
+	if(ret)
+		return ret;
+
+	dev->mclk = clk;
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * Do a SPI software reset.
+ *
+ * @param dev - The device structure.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_do_soft_reset(struct ad413x_dev *dev)
+{
+	int32_t ret;
+	uint8_t buf [ 8 ] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+
+	/* The AD413X can be reset by writing a series of 64 consecutive 1s
+	 * to the DIN input */
+	ret = no_os_spi_write_and_read(dev->spi_dev, buf, 8);
+	if(ret)
+		return ret;
+
+	no_os_mdelay(5); // TBD
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * SPI internal register write to device.
+ *
+ * @param dev      - The device structure.
+ * @param reg_addr - The register address.
+ * @param reg_data - The register data.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_reg_write(struct ad413x_dev *dev,
+			 uint32_t reg_addr,
+			 uint32_t reg_data)
+{
+	uint8_t buf[5];
+
+	uint8_t data_size = AD413X_TRANSF_LEN(reg_addr);
+
+	buf[0] = AD413X_CMD_WR_COM_REG(reg_addr);
+
+	switch(data_size) {
+	case 1:
+		buf[1] = (reg_data & 0xFF);
+		break;
+
+	case 2:
+		buf[1] = (reg_data & 0xFF00) >> 8;
+		buf[2] = (reg_data & 0xFF);
+		break;
+
+	case 3:
+		buf[1] = (reg_data & 0xFF0000) >> 16;
+		buf[2] = (reg_data & 0xFF00) >> 8;
+		buf[3] = (reg_data & 0xFF);
+		break;
+
+	default:
+		return -EINVAL;
+	}
+
+	if (dev->spi_crc_en)
+		buf[data_size] = no_os_crc8(ad413x_crc8, buf, ++data_size, 0);
+
+	return no_os_spi_write_and_read(dev->spi_dev, buf, data_size + 1);
+}
+
+/***************************************************************************//**
+ * SPI internal register read from device.
+ *
+ * @param dev      - The device structure.
+ * @param reg_addr - The register address.
+ * @param reg_data - The register data.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_reg_read(struct ad413x_dev *dev,
+			uint32_t reg_addr,
+			uint32_t *reg_data)
+{
+	uint8_t ret;
+	uint8_t buf[] = {0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA};
+	uint32_t data;
+	uint8_t crc;
+
+	uint8_t data_size = AD413X_TRANSF_LEN(reg_addr);
+
+	buf[0] = AD413X_CMD_RD_COM_REG(reg_addr);
+
+	if ((reg_addr == AD413X_REG_DATA) && (dev->data_stat))
+		data_size++;
+
+	if (dev->spi_crc_en)
+		data_size++;
+
+	ret = no_os_spi_write_and_read(dev->spi_dev, buf, data_size + 1);
+	if (ret)
+		return ret;
+
+	if (dev->spi_crc_en) {
+		buf[0] = AD413X_CMD_RD_COM_REG(reg_addr);
+		crc = no_os_crc8(ad413x_crc8, buf, data_size, 0);
+		if (buf[data_size] != crc)
+			return -EBADMSG;
+		data_size--;
+	}
+
+	switch (data_size) {
+	case 1:
+		data = buf[1];
+		break;
+
+	case 2:
+		data = (buf[1] << 8) | buf[2];
+		break;
+
+	case 3:
+		data = (buf[1] << 16) | (buf[2] << 8) | buf[3];
+		break;
+
+	case 4:
+		data = (buf[1] << 24) | (buf[2] << 16) | (buf[3] << 8) | buf[4];
+		break;
+
+	default:
+		return -EINVAL;
+	}
+
+	*reg_data = data;
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * Single conversion of each adc active channel.
+ *
+ * @param dev	     - The device structure.
+ * @param buffer	 - Buffer to store read data. Buffer size needs to be at
+ * 					least equal to the number of active channels. Results will
+ * 					be stored in consecutive order of the active channels.
+ * @param ch_nb		 - Number of active channels.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_single_conv(struct ad413x_dev *dev, uint32_t *buffer,
+			   uint8_t ch_nb)
+{
+	int32_t ret;
+
+	struct ad413x_callback_ctx ctx = {
+		.dev = dev,
+		.buffer = buffer,
+		.buffer_size = ch_nb
+	};
+
+	struct no_os_callback_desc irq_callback = {
+		.callback = &irq_adc_read,
+		.ctx = &ctx
+	};
+
+	ret = no_os_irq_trigger_level_set(dev->irq_desc, dev->rdy_pin,
+					  NO_OS_IRQ_EDGE_FALLING);
+	if (ret)
+		return ret;
+
+	ret = no_os_irq_register_callback(dev->irq_desc, dev->rdy_pin, &irq_callback);
+	if (ret)
+		return ret;
+
+	ret = no_os_irq_enable(dev->irq_desc, dev->rdy_pin);
+	if (ret)
+		return ret;
+
+	ret = ad413x_set_adc_mode(dev, AD413X_SINGLE_CONV_MODE);
+	if (ret)
+		return ret;
+
+	while((ctx.buffer_size != 0U) && --timeout) ;
+
+	if (!timeout)
+		pr_err("Timeout error (%s)\n", __func__);
+
+	ret = no_os_irq_disable(dev->irq_desc, dev->rdy_pin);
+	if (ret)
+		return ret;
+
+	return no_os_irq_unregister_callback(dev->irq_desc, dev->rdy_pin,
+					     &irq_callback);
+}
+
+/***************************************************************************//**
+ * Continuous conversion of each adc active channel.
+ *
+ * @param dev        - The device structure.
+ * @param buffer	 - Buffer to store read data. Buffer size needs to be at
+ * 					least equal to the number of active channels * samples number.
+ * 					Results will be stored in consecutive order of the active
+ * 					channels.
+ * @param ch_nb		 - Number of active channels.
+ * @param sample_nb  - Samples number.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_continuous_conv(struct ad413x_dev *dev, uint32_t *buffer,
+			       uint8_t ch_nb, uint32_t sample_nb)
+{
+	int32_t ret;
+
+	struct ad413x_callback_ctx ctx = {
+		.dev = dev,
+		.buffer = buffer,
+		.buffer_size = ch_nb * sample_nb
+	};
+
+	struct no_os_callback_desc irq_callback = {
+		.callback = &irq_adc_read,
+		.ctx = &ctx
+	};
+
+	ret = no_os_irq_trigger_level_set(dev->irq_desc, dev->rdy_pin,
+					  NO_OS_IRQ_EDGE_FALLING);
+	if (ret)
+		return ret;
+
+	ret = no_os_irq_register_callback(dev->irq_desc, dev->rdy_pin, &irq_callback);
+	if (ret)
+		return ret;
+
+	ret = no_os_irq_enable(dev->irq_desc, dev->rdy_pin);
+	if (ret)
+		return ret;
+
+	ret = ad413x_set_adc_mode(dev, AD413X_CONTINOUS_CONV_MODE);
+	if (ret)
+		return ret;
+
+	while((ctx.buffer_size != 0U) && --timeout) ;
+
+	if (!timeout)
+		pr_err("Timeout error (%s)\n", __func__);
+
+	ret = ad413x_set_adc_mode(dev, AD413X_STANDBY_MODE);
+	if (ret)
+		return ret;
+
+	return no_os_irq_unregister_callback(dev->irq_desc, dev->rdy_pin,
+					     &irq_callback);
+}
+
+/***************************************************************************//**
+ * Store adc channel presets.
+ *
+ * @param dev        - The device structure.
+ * @param preset 	 - The structure to be saved as preset.
+ * @param preset_nb	 - Preset's number.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_preset_store(struct ad413x_dev *dev, struct ad413x_preset preset,
+			    enum ad413x_preset_nb preset_nb)
+{
+	int32_t ret;
+
+	ret = ad413x_set_gain(dev, preset.gain, preset_nb);
+	if (ret)
+		return ret;
+
+	ret = ad413x_set_ref(dev, preset.ref_sel, preset_nb);
+	if (ret)
+		return ret;
+
+	ret = ad413x_set_ref_buf(dev, preset.ref_buf, preset_nb);
+	if (ret)
+		return ret;
+
+	ret = ad413x_set_settle_time(dev, preset.s_time, preset_nb);
+	if (ret)
+		return ret;
+
+	ret = ad413x_set_exc_current(dev, preset.iout0_exc_current,
+				     preset.iout1_exc_current, preset_nb);
+	if (ret)
+		return ret;
+
+	return ad413x_set_filter(dev, preset.filter, preset_nb);
+}
+
+/***************************************************************************//**
+ * Initialize the device.
+ *
+ * @param device     - The device structure.
+ * @param init_param - The structure that contains the device initial
+ * 		       parameters.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_init(struct ad413x_dev **device,
+		    struct ad413x_init_param init_param)
+{
+	struct ad413x_dev *dev;
+	uint32_t reg_data;
+	int32_t ret;
+	int32_t i;
+
+	no_os_crc8_populate_msb(ad413x_crc8, AD413X_CRC8_POLY);
+
+	dev = (struct ad413x_dev *)malloc(sizeof(*dev));
+	if (!dev)
+		return -1;
+
+	dev->chip_id = init_param.chip_id;
+	dev->irq_desc = init_param.irq_desc;
+	dev->rdy_pin = init_param.rdy_pin;
+	dev->spi_crc_en = 0;
+
+	/* SPI */
+	ret = no_os_spi_init(&dev->spi_dev, init_param.spi_init);
+	if (ret)
+		goto err_dev;
+
+	/* Device Settings */
+	ret = ad413x_do_soft_reset(dev);
+	if (ret)
+		goto err_spi;
+
+	/* Reset POR flag */
+	ret = ad413x_reg_read(dev, AD413X_REG_STATUS, &reg_data);
+	if (ret)
+		return -1;
+
+	/* Change SPI to 4 wire*/
+	ret = ad413x_reg_write_msk(dev,
+				   AD413X_REG_ADC_CTRL,
+				   AD413X_ADC_CSB_EN,
+				   AD413X_ADC_CSB_EN);
+	if (ret)
+		goto err_spi;
+
+	/* TBD - chip ID is 0x00 for now */
+	ret = ad413x_reg_read(dev, AD413X_REG_ID, &reg_data);
+	if (ret)
+		goto err_spi;
+
+	switch(dev->chip_id) {
+	case AD4130_8:
+		if(reg_data != AD4130_8) {
+			goto err_spi;
+		}
+		break;
+	default:
+		goto err_spi;
+	}
+
+	ret = ad413x_set_adc_mode(dev, AD413X_STANDBY_MODE);
+	if (ret)
+		goto err_spi;
+
+	if (init_param.spi_crc_en) {
+		ret = ad413x_reg_write_msk(dev,
+					   AD413X_REG_ERROR_EN,
+					   AD413X_SPI_CRC_ERR_EN,
+					   AD413X_SPI_CRC_ERR_EN);
+		if (ret)
+			goto err_spi;
+		dev->spi_crc_en = init_param.spi_crc_en;
+	}
+
+	/* Preset configured and saved in dev */
+	for (i = 0; i < 8; i++) {
+		ret = ad413x_preset_store(dev, init_param.preset[i], i);
+		if (ret)
+			goto err_spi;
+	}
+
+	/* Channel setup */
+	for (i = 0; i < 16; i++) {
+		ret = ad413x_set_ch_preset(dev, i, init_param.ch[i].preset);
+		if (ret)
+			goto err_spi;
+
+		ret = ad413x_reg_write_msk(dev,
+					   AD413X_REG_CHN(i),
+					   AD413X_AINP_M(init_param.ch[i].ain_p),
+					   AD413X_AINP_M(0xFF));
+		if (ret)
+			goto err_spi;
+		dev->ch[i].ain_p = init_param.ch[i].ain_p;
+
+		ret = ad413x_reg_write_msk(dev,
+					   AD413X_REG_CHN(i),
+					   AD413X_AINM_M(init_param.ch[i].ain_m),
+					   AD413X_AINM_M(0xFF));
+		if (ret)
+			goto err_spi;
+		dev->ch[i].ain_m = init_param.ch[i].ain_m;
+
+		ret = ad413x_ch_exc_input(dev, i, init_param.ch[i].iout0_exc_input,
+					  init_param.ch[i].iout1_exc_input);
+		if (ret)
+			goto err_spi;
+
+		ret = ad413x_pdsw_en(dev, i, init_param.ch[i].pdsw_en);
+		if (ret)
+			goto err_spi;
+
+		ret = ad413x_ch_en(dev, i, init_param.ch[i].enable);
+		if (ret)
+			goto err_spi;
+	}
+
+	ret = ad413x_set_int_ref(dev, init_param.int_ref);
+	if (ret)
+		goto err_spi;
+
+	ret = ad413x_adc_bipolar(dev, init_param.bipolar);
+	if (ret)
+		goto err_spi;
+
+	ret = ad413x_set_v_bias(dev, init_param.v_bias);
+	if (ret)
+		goto err_spi;
+
+	ret = ad413x_set_standby_ctrl(dev, init_param.standby_ctrl);
+	if (ret)
+		goto err_spi;
+
+	ret = ad413x_set_mclk(dev, init_param.mclk);
+	if (ret)
+		goto err_spi;
+
+	ret = ad413x_data_stat_en(dev, init_param.data_stat);
+	if (ret)
+		goto err_spi;
+
+	*device = dev;
+
+	pr_info("AD413X successfully initialized\n");
+	return 0;
+
+err_spi:
+	no_os_spi_remove(dev->spi_dev);
+err_dev:
+	free(dev);
+	pr_err("AD413X initialization error (%d)\n", ret);
+	return ret;
+}
+
+/***************************************************************************//**
+ * @brief Free the resources allocated by ad413x_init().
+ *
+ * @param dev - The device structure.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+*******************************************************************************/
+int32_t ad413x_remove(struct ad413x_dev *dev)
+{
+	int32_t ret;
+
+	ret = no_os_spi_remove(dev->spi_dev);
+	if (ret)
+		return ret;
+
+	free(dev);
+
+	return 0;
+}

--- a/drivers/afe/ad413x/ad413x.h
+++ b/drivers/afe/ad413x/ad413x.h
@@ -1,0 +1,635 @@
+/***************************************************************************//**
+ *   @file   ad413x.h
+ *   @brief  Header file of AD413X Driver.
+ *   @author Andrei Porumb (andrei.porumb@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef AD413X_H_
+#define AD413X_H_
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdint.h>
+#include "no_os_delay.h"
+#include "no_os_gpio.h"
+#include "no_os_spi.h"
+#include "no_os_irq.h"
+#include "no_os_util.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+#define AD413X_CMD_WR_COM_REG(x)	(0x00 | ((x) & 0x3F)) // Write to Register x
+#define AD413X_CMD_RD_COM_REG(x) 	(0x40 | ((x) & 0x3F)) // Read from Register x
+
+/*************************** ADC Register Lengths *****************************/
+#define AD413X_R1B				(1 << 8)
+#define AD413X_R2B				(2 << 8)
+#define AD413X_R3B				(3 << 8)
+#define AD413X_TRANSF_LEN(x)			(((x) >> 8) & 0xFF)
+
+/***************************** ADC Register Map *******************************/
+#define AD413X_REG_STATUS 			(AD413X_R1B | 0x0)
+#define AD413X_REG_ADC_CTRL			(AD413X_R2B | 0x1)
+#define AD413X_REG_DATA				(AD413X_R3B | 0x2)
+#define AD413X_REG_IO_CTRL			(AD413X_R2B | 0x3)
+#define AD413X_REG_VBIAS_CTRL			(AD413X_R2B | 0x4)
+#define AD413X_REG_ID				(AD413X_R1B | 0x5)
+#define AD413X_REG_ERROR			(AD413X_R2B | 0x6)
+#define AD413X_REG_ERROR_EN			(AD413X_R2B | 0x7)
+#define AD413X_REG_MCLK_CNT			(AD413X_R1B | 0x8)
+#define AD413X_REG_CHN(x)			(AD413X_R3B | (0x09U + (x)))
+#define AD413X_REG_CONFIG(x)			(AD413X_R2B | (0x19U + (x)))
+#define AD413X_REG_FILTER(x)			(AD413X_R3B | (0x21U + (x)))
+#define AD413X_REG_OFFSET(x)			(AD413X_R3B | (0x29U + (x)))
+#define AD413X_REG_GAIN(x)			(AD413X_R3B | (0x31U + (x)))
+#define AD413X_REG_MISC				(AD413X_R2B | 0x39)
+#define AD413X_REG_FIFO_CTRL			(AD413X_R3B | 0x3A)
+#define AD413X_REG_FIFO_STS			(AD413X_R1B | 0x3B)
+#define AD413X_REG_FIFO_THRSHLD			(AD413X_R3B | 0x3C)
+#define AD413X_REG_FIFO_DATA			(AD413X_R3B | 0x3D)
+
+
+/* ADC_CONTROL Register */
+#define AD413X_ADC_BIPOLAR				NO_OS_BIT(14)
+#define AD413X_ADC_REF_VAL				NO_OS_BIT(13)
+#define AD413X_ADC_DOUT_DIS_DEL				NO_OS_BIT(12)
+#define AD413X_ADC_CONT_READ				NO_OS_BIT(11)
+#define AD413X_ADC_DATA_STATUS				NO_OS_BIT(10)
+#define AD413X_ADC_CSB_EN				NO_OS_BIT(9)
+#define AD413X_ADC_REF_EN				NO_OS_BIT(8)
+#define AD413X_ADC_DUTY_CYC_RATIO			NO_OS_BIT(6)
+#define AD413X_ADC_MODE(x)				(((x) & 0xF) << 2)
+#define AD413X_ADC_CNTRL_MCLK(x)			((x) & 0x3)
+
+/* IO_CONTROL Register */
+#define AD413X_SYNCB_CLEAR 				NO_OS_BIT(10)
+#define AD413X_INT_PIN_SEL(x) 				(((x) & 0x3) << 8)
+#define AD413X_GPO_DATA_P4 				NO_OS_BIT(7)
+#define AD413X_GPO_DATA_P3 				NO_OS_BIT(6)
+#define AD413X_GPO_DATA_P2 				NO_OS_BIT(5)
+#define AD413X_GPO_DATA_P1 				NO_OS_BIT(4)
+#define AD413X_GPO_CTRL_P4		 		NO_OS_BIT(3)
+#define AD413X_GPO_CTRL_P3		 		NO_OS_BIT(2)
+#define AD413X_GPO_CTRL_P2		 		NO_OS_BIT(1)
+#define AD413X_GPO_CTRL_P1		 		0x01
+
+/* VBIAS_CTRL Register */
+#define AD413X_VBIAS_15					NO_OS_BIT(15)
+#define AD413X_VBIAS_14					NO_OS_BIT(14)
+#define AD413X_VBIAS_13					NO_OS_BIT(13)
+#define AD413X_VBIAS_12					NO_OS_BIT(12)
+#define AD413X_VBIAS_11					NO_OS_BIT(11)
+#define AD413X_VBIAS_10					NO_OS_BIT(10)
+#define AD413X_VBIAS_9					NO_OS_BIT(9)
+#define AD413X_VBIAS_8					NO_OS_BIT(8)
+#define AD413X_VBIAS_7					NO_OS_BIT(7)
+#define AD413X_VBIAS_6					NO_OS_BIT(6)
+#define AD413X_VBIAS_5					NO_OS_BIT(5)
+#define AD413X_VBIAS_4					NO_OS_BIT(4)
+#define AD413X_VBIAS_3					NO_OS_BIT(3)
+#define AD413X_VBIAS_2					NO_OS_BIT(2)
+#define AD413X_VBIAS_1					NO_OS_BIT(1)
+#define AD413X_VBIAS_0					0x01
+
+/* ERROR Register */
+#define AD413X_AINP_OV_UV_ERR				NO_OS_BIT(11)
+#define AD413X_AINM_OV_UV_ERR				NO_OS_BIT(10)
+#define AD413X_REF_OV_UV_ERR				NO_OS_BIT(9)
+#define AD413X_REF_DETECT_ERR				NO_OS_BIT(8)
+#define AD413X_ADC_ERR					NO_OS_BIT(7)
+#define AD413X_SPI_IGNORE_ERR				NO_OS_BIT(6)
+#define AD413X_SPI_SCLK_CNT_ERR				NO_OS_BIT(5)
+#define AD413X_SPI_READ_ERR				NO_OS_BIT(4)
+#define AD413X_SPI_WRITE_ERR				NO_OS_BIT(3)
+#define AD413X_SPI_CRC_ERR				NO_OS_BIT(2)
+#define AD413X_MM_CRC_ERR				NO_OS_BIT(1)
+#define AD413X_ROM_CRC_ERR				0x01
+
+/* ERROR_EN Register */
+#define AD413X_MCLK_CNT_EN				NO_OS_BIT(12)
+#define AD413X_AINP_OV_UV_ERR_EN			NO_OS_BIT(11)
+#define AD413X_AINM_OV_UV_ERR_EN			NO_OS_BIT(10)
+#define AD413X_REF_OV_UV_ERR_EN				NO_OS_BIT(9)
+#define AD413X_REF_DETECT_ERR_EN			NO_OS_BIT(8)
+#define AD413X_ADC_ERR_EN				NO_OS_BIT(7)
+#define AD413X_SPI_IGNORE_ERR_EN			NO_OS_BIT(6)
+#define AD413X_SPI_SCLK_CNT_ERR_EN			NO_OS_BIT(5)
+#define AD413X_SPI_READ_ERR_EN				NO_OS_BIT(4)
+#define AD413X_SPI_WRITE_ERR_EN				NO_OS_BIT(3)
+#define AD413X_SPI_CRC_ERR_EN				NO_OS_BIT(2)
+#define AD413X_MM_CRC_ERR_EN				NO_OS_BIT(1)
+#define AD413X_ROM_CRC_ERR_EN				0x01
+
+/* CHANNEL_M Register */
+#define AD413X_ENABLE_M					NO_OS_BIT(23)
+#define AD413X_SETUP_M(x)				(((x) & 0x7) << 20)
+#define AD413X_PDSW_M					NO_OS_BIT(19)
+#define AD413X_THRES_EN_M				NO_OS_BIT(18)
+#define AD413X_AINP_M(x)				(((x) & 0x1F) << 13)
+#define AD413X_AINM_M(x)				(((x) & 0x1F) <<  8)
+#define AD413X_I_OUT1_CH_M(x)				(((x) & 0xF) <<   4)
+#define AD413X_I_OUT0_CH_M(x)				((x) & 0xF)
+#define AD413X_I_OUT_CH_MSK				NO_OS_GENMASK(7,0)
+
+/* CONFIG_N Register */
+#define AD413X_I_OUT1_N(x)				(((x) & 0x7) << 13)
+#define AD413X_I_OUT0_N(x)				(((x) & 0x7) << 10)
+#define AD413X_I_OUT_MSK				NO_OS_GENMASK(15,10)
+#define AD413X_BURNOUT_N(x)				(((x) & 0x3) <<  8)
+#define AD413X_REF_BUF_MSK				NO_OS_GENMASK(7,6)
+#define AD413X_REF_BUFP_N				NO_OS_BIT(7)
+#define AD413X_REF_BUFM_N				NO_OS_BIT(6)
+#define AD413X_REF_SEL_N(x)				(((x) & 0x3) <<  4)
+#define AD413X_PGA_N(x)					(((x) & 0x7) <<  1)
+#define AD413X_PGA_BYP_N				0x01
+
+/* FILTER_N Register */
+#define AD413X_SETTLE_N(x)				(((x) & 0x7) <<  21)
+#define AD413X_REPEAT_N(x)				(((x) & 0x1F) << 16)
+#define AD413X_FILTER_MODE_N(x)				(((x) & 0xF) <<  12)
+#define AD413X_FS_N(x)					((x) & 0x7FF)
+
+/* OFFSET_N Register */
+#define AD413X_OFFSET_N(x)				((x) & 0xFFFFFF)
+
+/* GAIN_N Register */
+#define AD413X_GAIN_N(x)				((x) & 0xFFFFFF)
+
+/* MISC Register */
+#define AD413X_BYPASS_OSC				NO_OS_BIT(15)
+#define AD413X_PD_ALDO					NO_OS_BIT(14)
+#define AD413X_CAL_RANGE_X2				NO_OS_BIT(13)
+#define AD413X_RESERVED(x)				(((x) & 0xF) << 9)
+#define AD413X_STBY_CTRL_MSK				NO_OS_GENMASK(8,0)
+#define AD413X_STBY_OUT_EN				NO_OS_BIT(8)
+#define AD413X_STBY_DIAGNOSTICS_EN			NO_OS_BIT(7)
+#define AD413X_STBY_GPO_EN				NO_OS_BIT(6)
+#define AD413X_STBY_PDSW_EN				NO_OS_BIT(5)
+#define AD413X_STBY_BURNOUT_EN				NO_OS_BIT(4)
+#define AD413X_STBY_VBIAS_EN				NO_OS_BIT(3)
+#define AD413X_STBY_IEXC_EN				NO_OS_BIT(2)
+#define AD413X_STBY_REFHOL_EN				NO_OS_BIT(1)
+#define AD413X_STBY_INTREF_EN				0x01
+
+/* FIFO_CONTROL Register */
+#define AD413X_ADD_FIFO_STATUS				NO_OS_BIT(19)
+#define AD413X_ADD_FIFO_HEADER				NO_OS_BIT(18)
+#define AD413X_FIFO_MODE(x) 				(((x) & 0x3) << 16)
+#define AD413X_FIFO_WRITE_ERR_INT_EN 			NO_OS_BIT(14)
+#define AD413X_FIFO_READ_ERR_INT_EN 			NO_OS_BIT(13)
+#define AD413X_THRES_HIGH_INT_EN 			NO_OS_BIT(12)
+#define AD413X_THRES_LOW_INT_EN  			NO_OS_BIT(11)
+#define AD413X_OVERRUN_INT_EN 				NO_OS_BIT(10)
+#define AD413X_WATERMARK_INT_EN 			NO_OS_BIT(9)
+#define AD413X_EMPTY_INT_EN 				NO_OS_BIT(8)
+#define AD413X_WATERMARK(x) 				((x) & 0xFF)
+
+/* FIFO_STATUS Register */
+#define AD413X_MASTER_ERR 				NO_OS_BIT(7)
+#define AD413X_FIFO_WRITE_ERR 				NO_OS_BIT(6)
+#define AD413X_FIFO_READ_ERR 				NO_OS_BIT(5)
+#define AD413X_THRES_HIGH_FLAG 				NO_OS_BIT(4)
+#define AD413X_THRES_LOW_FLAG 				NO_OS_BIT(3)
+#define AD413X_OVERRUN_FLAG 				NO_OS_BIT(2)
+#define AD413X_WATERMARK_FLAG 				NO_OS_BIT(1)
+#define AD413X_EMPTY_FLAG 				0x01
+
+/* FIFO_THRESHOLD Register */
+#define AD413X_THRES_HIGH_VAL(x)		(((x) & 0xFFF) << 12)
+#define AD413X_THRES_LOW_VAL(x)			((x) & 0xFFF)
+
+/* 8-bits wide checksum generated using the polynomial */
+#define AD413X_CRC8_POLY	0x07 // x^8 + x^2 + x^1 + x^0
+
+#define ENABLE				1U
+#define DISABLE				0U
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+/**
+ * @enum ad413x_input
+ * @brief ADC input sources for each channel.
+ */
+enum ad413x_input {
+	AD413X_AIN0,
+	AD413X_AIN1,
+	AD413X_AIN2,
+	AD413X_AIN3,
+	AD413X_AIN4,
+	AD413X_AIN5,
+	AD413X_AIN6,
+	AD413X_AIN7,
+	AD413X_AIN8,
+	AD413X_AIN9,
+	AD413X_AIN10,
+	AD413X_AIN11,
+	AD413X_AIN12,
+	AD413X_AIN13,
+	AD413X_AIN14,
+	AD413X_AIN15,
+	AD413X_TEMP,
+	AD413X_AVSS,
+	AD413X_INT_REF,
+	AD413X_DGND,
+	AD413X_AVDD_AVSS_6P,
+	AD413X_AVDD_AVSS_6M,
+	AD413X_IOVDD_DGND_6P,
+	AD413X_IOVDD_DGND_6M,
+	AD413X_ALDO_AVSS_6P,
+	AD413X_ALDO_AVSS_6M,
+	AD413X_DLDO_DGND_6P,
+	AD413X_DLDO_DGND_6M,
+	AD413X_V_MV_P,
+	AD413X_V_MV_M,
+};
+
+/**
+ * @enum ad413x_preset_nb
+ * @brief Preset number.
+ */
+enum ad413x_preset_nb {
+	AD413X_PRESET_0,
+	AD413X_PRESET_1,
+	AD413X_PRESET_2,
+	AD413X_PRESET_3,
+	AD413X_PRESET_4,
+	AD413X_PRESET_5,
+	AD413X_PRESET_6,
+	AD413X_PRESET_7
+};
+
+/**
+ * @enum ad413x_mclk_sel
+ * @brief Master clock options.
+ */
+enum ad413x_mclk_sel {
+	AD413X_INT_76_8_KHZ_OUT_OFF,
+	AD413X_INT_76_8_KHZ_OUT_ON,
+	AD413X_EXT_76_8KHZ,
+	AD413X_EXT_153_6_KHZ_DIV_2
+};
+
+/**
+ * @enum ad413x_adc_mode
+ * @brief ADC conversion modes.
+ */
+enum ad413x_adc_mode {
+	AD413X_CONTINOUS_CONV_MODE = 0,
+	AD413X_SINGLE_CONV_MODE = 1,
+	AD413X_STANDBY_MODE = 2,
+	AD413X_PW_DOWN_MODE = 3,
+	AD413X_IDLE_MODE = 4,
+	AD413X_INT_OFFSET_CAL = 5,
+	AD413X_INT_GAIN_CAL = 6,
+	AD413X_SYS_OFFSET_CAL = 7,
+	AD413X_SYS_GAIN_CAL = 8,
+	AD413X_DUTY_CYCLING_MODE = 9,
+	AD413X_SINGLE_CONV_SYNC_IDLE_MODE = 10,
+	AD413X_DUTY_CYCLING_SYNC_STBY_MODE = 11
+};
+
+/**
+ * @struct ad413x_ref_buf
+ * @brief ADC reference buffer selection.
+ */
+struct ad413x_ref_buf {
+	bool ref_buf_p_en;
+	bool ref_buf_m_en;
+};
+
+/**
+ * @enum ad413x_ref_sel
+ * @brief ADC reference selection.
+ */
+enum ad413x_ref_sel {
+	AD413X_REFIN1,
+	AD413X_REFIN2,
+	AD413X_REFOUT_AVSS,
+	AD413X_AVDD_AVSS
+};
+
+/**
+ * @enum ad413x_int_ref
+ * @brief Internal reference selection.
+ */
+enum ad413x_int_ref {
+	AD413X_INTREF_DISABLED,
+	AD413X_INTREF_2_5V,
+	AD413X_INTREF_1_25V
+};
+
+/**
+ * @enum ad413x_filter
+ * @brief Filter types.
+ */
+enum ad413x_filter {
+	AD413X_SYNC4_STANDALONE,
+	AD413X_SYNC4_SYNC1,
+	AD413X_SYNC3_STANDALONE,
+	AD413X_SYNC3_REJ60,
+	AD413X_SYNC3_SYNC1,
+	AD413X_SYNC3_PF1,
+	AD413X_SYNC3_PF2,
+	AD413X_SYNC3_PF3,
+	AD413X_SYNC3_PF4
+};
+
+/**
+ * @enum ad413x_gain
+ * @brief Gain options.
+ */
+enum ad413x_gain {
+	AD413X_GAIN_1,
+	AD413X_GAIN_2,
+	AD413X_GAIN_4,
+	AD413X_GAIN_8,
+	AD413X_GAIN_16,
+	AD413X_GAIN_32,
+	AD413X_GAIN_64,
+	AD413X_GAIN_128,
+};
+
+/**
+ * @enum ad413x_chip_id
+ * @brief Chip IDs.
+ */
+enum ad413x_chip_id {
+	/* TBD */
+	AD4130_8 = 0x00
+};
+
+/**
+ * @enum ad413x_settle_time
+ * @brief Channel settle time.
+ */
+enum ad413x_settle_time {
+	AD413X_32_MCLK,
+	AD413X_64_MCLK,
+	AD413X_128_MCLK,
+	AD413X_256_MCLK,
+	AD413X_512_MCLK,
+	AD413X_1024_MCLK,
+	AD413X_2048_MCLK,
+	AD413X_4096_MCLK
+};
+
+/**
+ * @enum ad413x_exc_current
+ * @brief Excitation current value
+ */
+enum ad413x_exc_current {
+	AD413X_EXC_OFF,
+	AD413X_EXC_10UA,
+	AD413X_EXC_20UA,
+	AD413X_EXC_50UA,
+	AD413X_EXC_100UA,
+	AD413X_EXC_150UA,
+	AD413X_EXC_200UA,
+	AD413X_EXC_100NA
+};
+
+/**
+ * @struct ad413x_standby_ctrl
+ * @brief Standby control flags
+ */
+struct ad413x_standby_ctrl {
+	bool standby_int_ref_en;
+	bool standby_ref_holder_en;
+	bool standby_iexc_en;
+	bool standby_vbias_en;
+	bool standby_burnout_en;
+	bool standby_pdsw_en;
+	bool standby_gpio_en;
+	bool standby_diagn_en;
+	bool standby_output_en;
+};
+
+/**
+ * @struct ad413x_preset
+ * @brief Preset setting.
+ */
+struct ad413x_preset {
+	struct ad413x_ref_buf ref_buf;
+	enum ad413x_ref_sel ref_sel;
+	enum ad413x_gain gain;
+	enum ad413x_filter filter;
+	/* By default, settle time = 32MCLK */
+	enum ad413x_settle_time s_time;
+	enum ad413x_exc_current iout0_exc_current;
+	enum ad413x_exc_current iout1_exc_current;
+};
+
+/**
+ * @struct ad413x_channel
+ * @brief Channel setting.
+ */
+struct ad413x_channel {
+	enum ad413x_preset_nb preset;
+	uint8_t enable;
+	enum ad413x_input ain_p;
+	enum ad413x_input ain_m;
+	enum ad413x_input iout0_exc_input;
+	enum ad413x_input iout1_exc_input;
+	bool pdsw_en;
+};
+
+/**
+ * @struct ad413x_dev
+ * @brief Device structure.
+ */
+struct ad413x_dev {
+	/* SPI */
+	struct no_os_spi_desc			*spi_dev;
+	/* GPIO - used to know when conversion is rdy */
+	struct no_os_irq_ctrl_desc *irq_desc;
+	uint32_t rdy_pin;
+	/* Device Settings */
+	struct ad413x_preset preset[8];
+	struct ad413x_channel ch[16];
+	enum ad413x_chip_id chip_id;
+	enum ad413x_mclk_sel mclk;
+	enum ad413x_adc_mode op_mode;
+	uint8_t bipolar;
+	enum ad413x_int_ref int_ref;
+	uint16_t v_bias;
+	struct ad413x_standby_ctrl standby_ctrl;
+	uint8_t data_stat;
+	uint8_t spi_crc_en;
+};
+
+/**
+ * @struct ad413x_init_param
+ * @brief Initial parameter structure.
+ */
+struct ad413x_init_param {
+	/* SPI */
+	struct no_os_spi_init_param	*spi_init;
+	/* GPIO - used to know when conversion is rdy */
+	struct no_os_irq_ctrl_desc *irq_desc;
+	uint32_t rdy_pin;
+	/* Device Settings */
+	struct ad413x_preset preset[8];
+	struct ad413x_channel ch[16];
+	enum ad413x_chip_id chip_id;
+	enum ad413x_mclk_sel mclk;
+	uint8_t bipolar;
+	enum ad413x_int_ref int_ref;
+	uint16_t v_bias;
+	struct ad413x_standby_ctrl standby_ctrl;
+	uint8_t data_stat;
+	uint8_t spi_crc_en;
+};
+
+/**
+ * @struct ad413x_callback_ctx
+ * @brief Callback structure.
+ */
+struct ad413x_callback_ctx {
+	struct ad413x_dev *dev;
+	int32_t *buffer;
+	int32_t buffer_size;
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+/* SPI write to device using a mask. */
+int32_t ad413x_reg_write_msk(struct ad413x_dev *dev,
+			     uint32_t reg_addr,
+			     uint32_t data,
+			     uint32_t mask);
+
+/* Set the mode of the ADC. */
+int32_t ad413x_set_adc_mode(struct ad413x_dev *dev, enum ad413x_adc_mode mode);
+
+/* Set the internal reference. */
+int32_t ad413x_set_int_ref(struct ad413x_dev *dev, enum ad413x_int_ref int_ref);
+
+/* Enable/disable DATA_STAT. */
+int32_t ad413x_data_stat_en(struct ad413x_dev *dev, uint8_t enable);
+
+/* Set the gain. */
+int32_t ad413x_set_gain(struct ad413x_dev *dev, enum ad413x_gain gain,
+			enum ad413x_preset_nb reg_nb);
+
+/* Set the reference. */
+int32_t ad413x_set_ref(struct ad413x_dev *dev, enum ad413x_ref_sel ref,
+		       enum ad413x_preset_nb reg_nb);
+
+/* Set the reference buffers */
+int32_t ad413x_set_ref_buf(struct ad413x_dev *dev,
+			   struct ad413x_ref_buf ref_buf,
+			   enum ad413x_preset_nb reg_nb);
+
+/* Set the filter */
+int32_t ad413x_set_filter(struct ad413x_dev *dev, enum ad413x_filter filter,
+			  enum ad413x_preset_nb reg_nb);
+
+/* Set settle time */
+int32_t ad413x_set_settle_time(struct ad413x_dev *dev,
+			       enum ad413x_settle_time s_time,
+			       enum ad413x_preset_nb reg_nb);
+
+/* Set excitation currents */
+int32_t ad413x_set_exc_current(struct ad413x_dev *dev,
+			       enum ad413x_exc_current iout0_exc,
+			       enum ad413x_exc_current iout1_exc,
+			       enum ad413x_preset_nb reg_nb);
+
+/* Set excitation source pins */
+int32_t ad413x_ch_exc_input(struct ad413x_dev *dev, uint8_t ch_nb,
+			    enum ad413x_input iout0_exc_inp,
+			    enum ad413x_input iout1_exc_inp);
+
+/* Set channel preset */
+int32_t ad413x_set_ch_preset(struct ad413x_dev *dev, uint8_t ch_nb,
+			     enum ad413x_preset_nb preset_nb);
+
+/* Enable channel */
+int32_t ad413x_ch_en(struct ad413x_dev *dev, uint8_t ch_nb, uint8_t enable);
+
+/* Enable PDSW */
+int32_t ad413x_pdsw_en(struct ad413x_dev *dev, uint8_t ch_nb, bool pdsw_en);
+
+/* Set output VBIAS */
+int32_t ad413x_set_v_bias(struct ad413x_dev *dev, uint16_t v_bias_val);
+
+/* Set standby control flags */
+int32_t ad413x_set_standby_ctrl(struct ad413x_dev *dev,
+				struct ad413x_standby_ctrl standby_ctrl);
+
+/* Set ADC master clock mode. */
+int32_t ad413x_set_mclk(struct ad413x_dev *dev, enum ad413x_mclk_sel clk);
+
+/* Do a SPI software reset. */
+int32_t ad413x_do_soft_reset(struct ad413x_dev *dev);
+
+/* SPI internal register write to device. */
+int32_t ad413x_reg_write(struct ad413x_dev *dev,
+			 uint32_t reg_addr,
+			 uint32_t reg_data);
+
+/* SPI internal register read from device. */
+int32_t ad413x_reg_read(struct ad413x_dev *dev,
+			uint32_t reg_addr,
+			uint32_t *reg_data);
+
+/* Fills buffer with data read from each active channel */
+int32_t ad413x_single_conv(struct ad413x_dev *dev, uint32_t *buffer,
+			   uint8_t ch_nb);
+
+/* Fills buffer with data from continuous conv mode from each active channel */
+int32_t ad413x_continuous_conv(struct ad413x_dev *dev, uint32_t *buffer,
+			       uint8_t ch_nb, uint32_t sample_nb);
+
+/* Set adc bipolar/unipolar coding. */
+int32_t ad413x_adc_bipolar(struct ad413x_dev *dev, uint8_t enable);
+
+/* Store presets for adc channels */
+int32_t ad413x_preset_store(struct ad413x_dev *dev, struct ad413x_preset preset,
+			    enum ad413x_preset_nb preset_nb);
+
+/* Initialize the device. */
+int32_t ad413x_init(struct ad413x_dev **device,
+		    struct ad413x_init_param init_param);
+
+/* Remove the device. */
+int32_t ad413x_remove(struct ad413x_dev *dev);
+
+#endif // AD413X_H_

--- a/drivers/afe/ad413x/iio_ad413x.c
+++ b/drivers/afe/ad413x/iio_ad413x.c
@@ -1,0 +1,474 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <inttypes.h>
+#include <math.h>
+#include "no_os_error.h"
+#include "no_os_delay.h"
+#include "iio.h"
+#include "iio_ad413x.h"
+#include "no_os_util.h"
+#include "ad413x.h"
+#include "gpio_irq_extra.h"
+
+struct scan_type ad413x_iio_scan_type = {
+	.sign = 'u',
+	.realbits = 24,
+	.storagebits = 32,
+	.shift = 0,
+	.is_big_endian = true
+};
+
+static int32_t _ad413x_read_register(void *device, uint32_t reg,
+				     uint32_t *readval)
+{
+	struct ad413x_iio_dev *iiodev = (struct ad413x_iio_dev *)device;
+
+	return ad413x_reg_read(iiodev->ad413x_dev, reg, readval);
+}
+
+static int32_t _ad413x_write_register(void *device, uint32_t reg,
+				      uint32_t writeval)
+{
+	struct ad413x_iio_dev *iiodev = (struct ad413x_iio_dev *)device;
+
+	return ad413x_reg_write(iiodev->ad413x_dev, reg, writeval);
+}
+
+static int32_t ad413x_iio_update_active_channels(void *device,
+		uint32_t mask)
+{
+	struct ad413x_iio_dev *iiodev = (struct ad413x_iio_dev *)device;
+	uint32_t ch_idx, readval;
+	int32_t ret;
+
+	while (mask) {
+		ch_idx = no_os_find_first_set_bit(mask);
+		mask &= ~(1 << ch_idx);
+		ret = ad413x_reg_read(iiodev->ad413x_dev, AD413X_REG_CHN(ch_idx), &readval);
+		if (ret)
+			return ret;
+		readval |= AD413X_ENABLE_M;
+		ret = ad413x_reg_write(iiodev->ad413x_dev, AD413X_REG_CHN(ch_idx), readval);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
+static int32_t ad413x_iio_get_active_channels(void *device,
+		uint32_t *mask)
+{
+	struct ad413x_iio_dev *iiodev = (struct ad413x_iio_dev *)device;
+	int32_t ret, ch_idx;
+	uint32_t readval;
+
+	*mask = 0;
+	for (ch_idx = 0; ch_idx < 16; ch_idx++) {
+		ret = ad413x_reg_read(iiodev->ad413x_dev, AD413X_REG_CHN(ch_idx), &readval);
+		if (ret)
+			return ret;
+		if (readval & AD413X_ENABLE_M)
+			*mask |= 1 << ch_idx;
+	}
+
+	return 0;
+}
+
+static int32_t ad413x_iio_close_channels(void *device)
+{
+	struct ad413x_iio_dev *iiodev = (struct ad413x_iio_dev *)device;
+	int32_t ret, ch_idx;
+	uint32_t readval;
+
+	for (ch_idx = 0; ch_idx < 16; ch_idx++) {
+		ret = ad413x_reg_read(iiodev->ad413x_dev, AD413X_REG_CHN(ch_idx), &readval);
+		if (ret)
+			return ret;
+		readval &= ~AD413X_ENABLE_M;
+		ad413x_reg_write(iiodev->ad413x_dev, AD413X_REG_CHN(ch_idx), readval);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
+static int32_t ad413x_select_channel(void *device,
+				     const struct iio_ch_info *ch_info)
+{
+	struct ad413x_iio_dev *iiodev = (struct ad413x_iio_dev *)device;
+	int32_t ret, idx;
+
+	for (idx = 0; idx < 16; idx++) {
+		ret = ad413x_ch_en(iiodev->ad413x_dev, idx, idx == ch_info->ch_num ? 1U : 0U);
+		if (ret)
+			return ret;
+	}
+
+	return ret;
+}
+
+
+static int ad413x_iio_read_calibscale(void *device, char *buf, uint32_t len,
+				      const struct iio_ch_info *channel,
+				      intptr_t priv)
+{
+	struct ad413x_iio_dev *iiodev = (struct ad413x_iio_dev *)device;
+	struct ad413x_dev *dev = iiodev->ad413x_dev;
+	int32_t vals;
+	uint8_t regval[2], pr_nb;
+	uint8_t reg;
+	int32_t ret;
+	enum ad413x_gain gain;
+
+	pr_nb = dev->ch[channel->ch_num].preset;
+	gain = dev->preset[pr_nb].gain;
+
+	switch (gain) {
+	case AD413X_GAIN_1:
+		vals = 1;
+		break;
+	case AD413X_GAIN_2:
+		vals = 2;
+		break;
+	case AD413X_GAIN_4:
+		vals = 4;
+		break;
+	case AD413X_GAIN_8:
+		vals = 8;
+		break;
+	case AD413X_GAIN_16:
+		vals = 16;
+		break;
+	case AD413X_GAIN_32:
+		vals = 32;
+		break;
+	case AD413X_GAIN_64:
+		vals = 64;
+		break;
+	case AD413X_GAIN_128:
+		vals = 128;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, &vals);
+}
+
+static int ad413x_iio_read_offset(void *device, char *buf, uint32_t len,
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
+{
+	struct ad413x_iio_dev *iiodev = (struct ad413x_iio_dev *)device;
+	struct ad413x_dev *dev = iiodev->ad413x_dev;
+	int32_t value, ret;
+	uint32_t readval;
+
+	ret = ad413x_reg_read(dev, AD413X_REG_ADC_CTRL, &readval);
+	if (ret)
+		return ret;
+
+	if (readval & AD413X_ADC_BIPOLAR)
+		value = -0x800000;
+	else
+		value = 0;
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, &value);
+}
+
+static int ad413x_iio_read_raw(void *device, char *buf, uint32_t len,
+			       const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct ad413x_iio_dev *iiodev = (struct ad413x_iio_dev *)device;
+	int32_t ret;
+	uint32_t value, reg_data;
+
+	ret = ad413x_select_channel(iiodev, channel);
+	if (ret)
+		return ret;
+
+	ret = ad413x_single_conv(iiodev->ad413x_dev, &value, 1);
+	if (ret)
+		return ret;
+
+	/* Check if data_en is enabled */
+	ret = ad413x_reg_read(iiodev->ad413x_dev, AD413X_REG_ADC_CTRL, &reg_data);
+	if (ret)
+		return ret;
+	if (reg_data | AD413X_ADC_DATA_STATUS)
+		value >>= 8;
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, &value);
+}
+
+static int ad413x_iio_scale_available(void *device, char *buf,
+				      uint32_t len,
+				      const struct iio_ch_info *channel, intptr_t priv)
+{
+	int32_t ret;
+	//        2.5V unipolar, 1.25V unipolar, 2.5V bipolar, 1.25V bipolar
+	strcpy(buf, "0.000149011U 0.000074505U 0.000298023B 0.000149011B");
+	return strlen(buf);
+}
+
+static int ad413x_iio_store_scale(void *device, char *buf, uint32_t len,
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
+{
+	struct ad413x_iio_dev *iiodev = (struct ad413x_iio_dev *)device;
+	struct ad413x_dev *dev = (struct ad413x_dev *)iiodev->ad413x_dev;
+	int32_t ret;
+	char polarity;
+
+	polarity = buf[11];
+
+	//delete last char
+	strcpy(&buf[11], &buf[12]);
+
+	switch (polarity) {
+	case 'U':
+		//unipolar
+		ret = ad413x_adc_bipolar(dev, 0U);
+		if (ret)
+			return ret;
+		if (!strcmp(buf, "0.000149011"))
+			ret = ad413x_set_int_ref(dev, AD413X_INTREF_2_5V);
+		else if (!strcmp(buf, "0.000074505"))
+			ret = ad413x_set_int_ref(dev, AD413X_INTREF_1_25V);
+		else
+			ret = -EINVAL;
+		break;
+	case 'B':
+		//bipolar
+		ret = ad413x_adc_bipolar(dev, 1U);
+		if (ret)
+			return ret;
+		if (!strcmp(buf, "0.000298023"))
+			ret = ad413x_set_int_ref(dev, AD413X_INTREF_2_5V);
+		else if (!strcmp(buf, "0.000149011"))
+			ret = ad413x_set_int_ref(dev, AD413X_INTREF_1_25V);
+		else
+			ret = -EINVAL;
+		break;
+	default:
+		ret = -EINVAL;
+	}
+
+	return ret;
+}
+
+static int ad413x_iio_read_scale(void *device, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel,
+				 intptr_t priv)
+{
+	struct ad413x_iio_dev *iiodev = (struct ad413x_iio_dev *)device;
+	uint8_t bi = 0, ref_val = 0;
+	int32_t valt, ret;
+	int32_t vals[2];
+	uint32_t readval;
+
+	ret = ad413x_reg_read(iiodev->ad413x_dev, AD413X_REG_ADC_CTRL, &readval);
+	if (ret)
+		return ret;
+
+	if (readval & AD413X_ADC_BIPOLAR)
+		bi = 1;
+
+	if (readval & AD413X_ADC_REF_VAL)
+		ref_val = 1;
+
+	if (bi) {
+		ad413x_iio_scan_type.sign = 's';
+		if (ref_val == 0) {
+			/* bipolar, 2.5Vref */
+			vals[0] = 2500;
+			vals[1] = 0x800000;
+			valt = IIO_VAL_FRACTIONAL;
+		} else {
+			/* bipolar, 1.25Vref */
+			vals[0] = 1250;
+			vals[1] = 0x800000;
+			valt = IIO_VAL_FRACTIONAL;
+		}
+	} else {
+		ad413x_iio_scan_type.sign = 'u';
+		if (ref_val == 0) {
+			/* unipolar, 2.5Vref */
+			vals[0] = 2500;
+			vals[1] = 0xFFFFFF;
+			valt = IIO_VAL_FRACTIONAL;
+		} else {
+			/* unipolar, 1.25Vref */
+			vals[0] = 1250;
+			vals[1] = 0xFFFFFF;
+			valt = IIO_VAL_FRACTIONAL;
+		}
+	}
+
+	return iio_format_value(buf, len, valt, 2, vals);
+}
+
+static int32_t ad413x_iio_read_samples(void *device,
+				       int32_t *buff,
+				       uint32_t nb_samples)
+{
+	struct ad413x_iio_dev *iiodev = (struct ad413x_iio_dev *)device;
+	int32_t ret, value, ch_nb = 0;
+	uint32_t ch_id = -1, test, mask;
+	ret = ad413x_iio_get_active_channels(device, &mask);
+	if (ret)
+		return ret;
+
+	while (mask) {
+		ch_nb += mask & 1;
+		mask >>= 1;
+	}
+
+	ret = ad413x_continuous_conv(iiodev->ad413x_dev, buff, ch_nb, nb_samples);
+	if (ret)
+		return ret;
+
+	return nb_samples;
+}
+
+static struct iio_attribute ad413x_iio_vin_attrs[] = {
+	{
+		.name = "raw",
+		.shared = IIO_SEPARATE,
+		.show = ad413x_iio_read_raw,
+		.store = NULL
+	},
+	{
+		.name = "scale",
+		.shared = IIO_SHARED_BY_ALL,
+		.show = ad413x_iio_read_scale,
+		.store = ad413x_iio_store_scale
+	},
+	{
+		.name = "offset",
+		.shared = IIO_SHARED_BY_ALL,
+		.show = ad413x_iio_read_offset,
+		.store = NULL
+	},
+	{
+		.name = "calibscale",
+		.shared = IIO_SEPARATE,
+		.show = ad413x_iio_read_calibscale,
+		.store = NULL
+	},
+	{
+		.name = "scale_options",
+		.shared = IIO_SHARED_BY_ALL,
+		.show = ad413x_iio_scale_available,
+		.store = NULL
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+enum ad413x_chan {
+	CH0,
+	CH1,
+	CH2,
+	CH3,
+	CH4,
+	CH5,
+	CH6,
+	CH7,
+	CH8,
+	CH9,
+	CH10,
+	CH11,
+	CH12,
+	CH13,
+	CH14,
+	CH15
+};
+
+#define AD413X_IIO_CHANN_DEF(nm, ch_nb) \
+	{ \
+		.name = nm, \
+		.ch_type = IIO_VOLTAGE, \
+		.indexed = true, \
+		.scan_type = &ad413x_iio_scan_type, \
+		.scan_index = ch_nb, \
+		.channel = ch_nb, \
+		.attributes = ad413x_iio_vin_attrs, \
+		.address = NULL, \
+		.ch_out = 0, \
+	}
+
+static struct iio_channel ad413x_channels[] = {
+	AD413X_IIO_CHANN_DEF("ch0",   0),
+	AD413X_IIO_CHANN_DEF("ch1",   1),
+	AD413X_IIO_CHANN_DEF("ch2",   2),
+	AD413X_IIO_CHANN_DEF("ch3",   3),
+	AD413X_IIO_CHANN_DEF("ch4",   4),
+	AD413X_IIO_CHANN_DEF("ch5",   5),
+	AD413X_IIO_CHANN_DEF("ch6",   6),
+	AD413X_IIO_CHANN_DEF("ch7",   7),
+	AD413X_IIO_CHANN_DEF("ch8",   8),
+	AD413X_IIO_CHANN_DEF("ch9",   9),
+	AD413X_IIO_CHANN_DEF("ch10", 10),
+	AD413X_IIO_CHANN_DEF("ch11", 11),
+	AD413X_IIO_CHANN_DEF("ch12", 12),
+	AD413X_IIO_CHANN_DEF("ch13", 13),
+	AD413X_IIO_CHANN_DEF("ch14", 14),
+	AD413X_IIO_CHANN_DEF("ch15", 15),
+};
+
+static struct iio_device ad413x_iio_device = {
+	.num_ch = NO_OS_ARRAY_SIZE(ad413x_channels),
+	.channels = ad413x_channels,
+	.attributes = NULL,
+	.debug_attributes = NULL,
+	.buffer_attributes = NULL,
+	.pre_enable = ad413x_iio_update_active_channels,
+	.post_disable = ad413x_iio_close_channels,
+	.read_dev = (int32_t (*)())ad413x_iio_read_samples,
+	.debug_reg_read = (int32_t (*)())_ad413x_read_register,
+	.debug_reg_write = (int32_t (*)())_ad413x_write_register
+};
+
+int32_t ad413x_iio_init(struct ad413x_iio_dev **iio_dev,
+			struct ad413x_iio_init_param init_param)
+{
+	int32_t ret;
+	struct ad413x_iio_dev *desc;
+	struct xil_gpio_irq_init_param *gpio_irq_extra;
+	gpio_irq_extra = (struct xil_gpio_irq_init_param *)
+			 init_param.ad413x_ip.irq_desc->extra;
+
+	desc = (struct ad413x_iio_dev *)calloc(1, sizeof(*desc));
+	if (!desc)
+		return -1;
+
+	desc->iio_dev = &ad413x_iio_device;
+	desc->iio_dev->irq_desc = gpio_irq_extra->parent_desc;
+
+	ret = ad413x_init(&desc->ad413x_dev, init_param.ad413x_ip);
+	if (ret != 0)
+		goto error_desc;
+
+	*iio_dev = desc;
+
+	return 0;
+error_desc:
+	free(desc);
+
+	return ret;
+}
+
+int32_t ad413x_iio_remove(struct ad413x_iio_dev *desc)
+{
+	int32_t ret;
+
+	ret = ad413x_remove(desc->ad413x_dev);
+	if (ret != 0)
+		return ret;
+
+	free(desc);
+
+	return 0;
+}

--- a/drivers/afe/ad413x/iio_ad413x.h
+++ b/drivers/afe/ad413x/iio_ad413x.h
@@ -1,0 +1,59 @@
+/***************************************************************************//**
+*   @file   iio_ad413x.h
+*   @brief  Header file of iio_ad413x
+*   @author Andrei Porumb (andrei.porumb@analog.com)
+********************************************************************************
+* Copyright 2022(c) Analog Devices, Inc.
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*  - Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*  - Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in
+*    the documentation and/or other materials provided with the
+*    distribution.
+*  - Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*  - The use of this software may or may not infringe the patent rights
+*    of one or more patent holders.  This license does not release you
+*    from the requirement that you obtain separate licenses from these
+*    patent holders to use this software.
+*  - Use of the software either in source or binary form, must be run
+*    on or directly connected to an Analog Devices Inc. component.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef IIO_AD413X_H
+#define IIO_AD413X_H
+
+#include "iio.h"
+#include "ad413x.h"
+
+struct ad413x_iio_dev {
+	struct ad413x_dev *ad413x_dev;
+	struct iio_device *iio_dev;
+};
+
+struct ad413x_iio_init_param {
+	struct ad413x_init_param ad413x_ip;
+};
+
+int32_t ad413x_iio_init(struct ad413x_iio_dev **iio_dev,
+			struct ad413x_iio_init_param init_param);
+int32_t ad413x_iio_remove(struct ad413x_iio_dev *desc);
+
+#endif /** IIO_AD413X_H */

--- a/projects/ad413x/Makefile
+++ b/projects/ad413x/Makefile
@@ -1,0 +1,9 @@
+# Uncomment to use the desired platform
+#PLATFORM = xilinx
+TINYIIOD ?= n
+
+include ../../tools/scripts/generic_variables.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/ad413x/src.mk
+++ b/projects/ad413x/src.mk
@@ -1,0 +1,55 @@
+################################################################################
+#									       #
+#     Shared variables:							       #
+#	- PROJECT							       #
+#	- DRIVERS							       #
+#	- INCLUDE							       #
+#	- PLATFORM_DRIVERS						       #
+#	- NO-OS								       #
+#									       #
+################################################################################
+
+SRC_DIRS += $(PROJECT)/src
+SRCS += $(DRIVERS)/api/no_os_spi.c \
+	$(DRIVERS)/api/no_os_irq.c \
+	$(DRIVERS)/api/no_os_gpio.c \
+	$(DRIVERS)/afe/ad413x/ad413x.c
+
+SRCS += $(PLATFORM_DRIVERS)/xilinx_spi.c \
+	$(PLATFORM_DRIVERS)/xilinx_irq.c \
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
+	$(PLATFORM_DRIVERS)/xilinx_gpio_irq.c \
+	$(PLATFORM_DRIVERS)/delay.c \
+	$(NO-OS)/util/no_os_list.c \
+	$(NO-OS)/util/no_os_crc8.c
+
+INCS += $(DRIVERS)/afe/ad413x/ad413x.h
+
+INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
+	$(PLATFORM_DRIVERS)/irq_extra.h \
+	$(PLATFORM_DRIVERS)/gpio_extra.h \
+	$(PLATFORM_DRIVERS)/gpio_irq_extra.h
+
+INCS += $(INCLUDE)/no_os_spi.h \
+	$(INCLUDE)/no_os_gpio.h \
+	$(INCLUDE)/no_os_error.h \
+	$(INCLUDE)/no_os_delay.h \
+	$(INCLUDE)/no_os_irq.h \
+	$(INCLUDE)/no_os_util.h \
+	$(INCLUDE)/no_os_print_log.h \
+	$(INCLUDE)/no_os_list.h \
+	$(INCLUDE)/no_os_crc8.h
+
+ifeq (y,$(strip $(TINYIIOD)))
+LIBRARIES += iio
+SRCS += $(DRIVERS)/afe/ad413x/iio_ad413x.c \
+	$(PLATFORM_DRIVERS)/no_os_uart.c \
+	$(NO-OS)/iio/iio_app/iio_app.c \
+	$(NO-OS)/util/no_os_fifo.c \
+	$(NO-OS)/util/no_os_util.c
+INCS += $(DRIVERS)/afe/ad413x/iio_ad413x.h \
+	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(NO-OS)/iio/iio_app/iio_app.h \
+	$(INCLUDE)/no_os_fifo.h \
+	$(INCLUDE)/no_os_uart.h
+endif

--- a/projects/ad413x/src/app/main.c
+++ b/projects/ad413x/src/app/main.c
@@ -1,0 +1,203 @@
+/***************************************************************************//**
+ *   @file   ad413x/src/app/main.c
+ *   @brief  Implementation of Main Function.
+ *   @author Porumb Andrei (andrei.porumb@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#ifdef IIO_SUPPORT
+#include "iio.h"
+#include "iio_ad413x.h"
+#include "iio_app.h"
+#endif
+#include "no_os_irq.h"
+#include "irq_extra.h"
+#include "gpio_irq_extra.h"
+#include "no_os_spi.h"
+#include "no_os_gpio.h"
+#include "gpio_extra.h"
+#include "spi_extra.h"
+#include "ad413x.h"
+#include "no_os_error.h"
+#include "xparameters.h"
+#include "parameters.h"
+#include "no_os_print_log.h"
+#include <stdint.h>
+#include <inttypes.h>
+
+#define MAX_SIZE_BASE_ADDR	25600
+
+static uint8_t in_buff[MAX_SIZE_BASE_ADDR];
+
+#define ADC_DDR_BASEADDR	((uint32_t)in_buff)
+
+/***************************************************************************//**
+ * @brief main
+*******************************************************************************/
+int main()
+{
+	uint32_t ret;
+	uint32_t buffer[20];
+	int32_t i;
+
+	/* SPI instance */
+	struct xil_spi_init_param spi_extra = {
+		.type = SPI_PS,
+		.flags = 0U
+	};
+	struct no_os_spi_init_param spi_ip = {
+		.device_id = SPI_DEVICE_ID,
+		.max_speed_hz = 100000,
+		.mode = NO_OS_SPI_MODE_3,
+		.chip_select = 0U,
+		.bit_order = NO_OS_SPI_BIT_ORDER_MSB_FIRST,
+		.platform_ops = &xil_spi_ops,
+		.extra = &spi_extra
+	};
+
+	/* IRQ instance. */
+	struct no_os_irq_ctrl_desc *irq_desc;
+	struct xil_irq_init_param irq_extra = {
+		.type = IRQ_PS
+	};
+	struct no_os_irq_init_param irq_ip = {
+		.irq_ctrl_id = INTC_DEVICE_ID,
+		.platform_ops = &xil_irq_ops,
+		.extra = &irq_extra
+	};
+
+	ret = no_os_irq_ctrl_init(&irq_desc, &irq_ip);
+	if (ret)
+		return -1;
+	ret = no_os_irq_global_enable(irq_desc);
+	if (ret)
+		return -1;
+
+	/* GPIO IRQ instance. */
+	struct no_os_irq_ctrl_desc *gpio_irq_desc;
+	struct xil_gpio_irq_init_param gpio_irq_extra = {
+		.parent_desc = irq_desc,
+		.gpio_device_id = XPAR_PS7_GPIO_0_DEVICE_ID
+	};
+	struct no_os_irq_init_param gpio_irq_ip = {
+		.irq_ctrl_id = GPIO_IRQ_ID,
+		.platform_ops = &xil_gpio_irq_ops,
+		.extra = &gpio_irq_extra
+	};
+
+	ret = no_os_irq_ctrl_init(&gpio_irq_desc, &gpio_irq_ip);
+	if (ret)
+		return -1;
+
+	/* Device AD413X instance. */
+	struct ad413x_dev *ad413x_dev;
+	struct ad413x_init_param ad413x_dev_ip = {
+		.spi_init = &spi_ip,
+		.chip_id = AD4130_8,
+		.mclk = AD413X_INT_76_8_KHZ_OUT_OFF,
+		.irq_desc = gpio_irq_desc,
+		.rdy_pin = RDY_PIN,
+		.preset[0] = { AD413X_REFIN1, AD413X_GAIN_1, AD413X_SYNC4_STANDALONE, AD413X_32_MCLK },
+		.preset[1] = { AD413X_REFOUT_AVSS, AD413X_GAIN_16, AD413X_SYNC3_PF1, AD413X_128_MCLK },
+		.ch[0]  = { AD413X_PRESET_0, ENABLE,  AD413X_AIN0,  AD413X_DGND },
+		.ch[1]  = { AD413X_PRESET_0, ENABLE,  AD413X_AIN1,  AD413X_DGND },
+		.ch[2]  = { AD413X_PRESET_0, DISABLE, AD413X_AIN2,  AD413X_DGND },
+		.ch[3]  = { AD413X_PRESET_0, DISABLE, AD413X_AIN3,  AD413X_DGND },
+		.ch[4]  = { AD413X_PRESET_0, DISABLE, AD413X_AIN4,  AD413X_DGND },
+		.ch[5]  = { AD413X_PRESET_0, DISABLE, AD413X_AIN5,  AD413X_DGND },
+		.ch[6]  = { AD413X_PRESET_0, DISABLE, AD413X_AIN6,  AD413X_DGND },
+		.ch[7]  = { AD413X_PRESET_0, DISABLE, AD413X_AIN7,  AD413X_DGND },
+		.ch[8]  = { AD413X_PRESET_0, DISABLE, AD413X_AIN8,  AD413X_DGND },
+		.ch[9]  = { AD413X_PRESET_0, DISABLE, AD413X_AIN9,  AD413X_DGND },
+		.ch[10] = { AD413X_PRESET_0, DISABLE, AD413X_AIN10, AD413X_DGND },
+		.ch[11] = { AD413X_PRESET_0, DISABLE, AD413X_AIN11, AD413X_DGND },
+		.ch[12] = { AD413X_PRESET_0, DISABLE, AD413X_AIN12, AD413X_DGND },
+		.ch[13] = { AD413X_PRESET_0, DISABLE, AD413X_AIN13, AD413X_DGND },
+		.ch[14] = { AD413X_PRESET_0, DISABLE, AD413X_AIN14, AD413X_DGND },
+		.ch[15] = { AD413X_PRESET_0, DISABLE, AD413X_AIN15, AD413X_DGND },
+		.bipolar = DISABLE,
+		.int_ref = AD413X_INTREF_2_5V,
+		.data_stat = ENABLE,
+		.spi_crc_en = ENABLE
+	};
+
+#ifndef IIO_SUPPORT
+	ret = ad413x_init(&ad413x_dev, ad413x_dev_ip);
+	if (ret)
+		return -1;
+
+	ret = ad413x_continuous_conv(ad413x_dev, buffer, 2, 10);
+	if (ret)
+		return -1;
+
+	for(i = 0; i < 20; i++)
+		printf("DATA[%"PRIi32"] = %"PRIi32" \n", i, buffer[i]);
+
+	return 0;
+#else
+
+	/* IIO device */
+	struct ad413x_iio_dev *adciio = NULL;
+	struct ad413x_iio_init_param adciio_init;
+
+	struct iio_data_buffer iio_ad413x_read_buff = {
+		.buff = ADC_DDR_BASEADDR,
+		.size = MAX_SIZE_BASE_ADDR,
+	};
+
+	adciio_init.ad413x_ip = ad413x_dev_ip;
+	ret = ad413x_iio_init(&adciio, adciio_init);
+	if (ret < 0)
+		goto error;
+
+	struct iio_app_device iio_devices[] = {
+		{
+			.name = "ad413x",
+			.dev = adciio,
+			.dev_descriptor = adciio->iio_dev,
+			.read_buff =  &iio_ad413x_read_buff,
+			.write_buff = NULL
+		}
+	};
+
+	ret = iio_app_run(iio_devices, NO_OS_ARRAY_SIZE(iio_devices));
+error:
+	ad413x_iio_remove(adciio);
+	return ret;
+#endif
+}

--- a/projects/ad413x/src/app/parameters.h
+++ b/projects/ad413x/src/app/parameters.h
@@ -1,0 +1,59 @@
+/***************************************************************************//**
+ *   @file   ad413x/src/app/parameters.h
+ *   @brief  Parameters Definitions.
+ *   @author Andrei Porumb (andrei.porumb@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef PARAMETERS_H
+#define PARAMETERS_H
+
+#include <xparameters.h>
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+#define SPI_DEVICE_ID 	0U
+#define GPIO_OFFSET  	54U
+
+#define RDY_PIN   	GPIO_OFFSET + 32U
+#define GPIO_IRQ_ID 	52U
+
+#define UART_DEVICE_ID	XPAR_XUARTPS_0_DEVICE_ID
+#define INTC_DEVICE_ID	XPAR_SCUGIC_SINGLE_DEVICE_ID
+#define UART_IRQ_ID		XPAR_XUARTPS_1_INTR
+#define UART_BAUDRATE	115200
+
+#endif


### PR DESCRIPTION
The driver and application are ported from bitbucket since the part is now released.

*NOTE:* missing builds.json file due to lack of .xsa file