### PR TITLE
ad413x: iio: rework irq desc assignment

### DIFF
--- a/drivers/afe/ad413x/iio_ad413x.c
+++ b/drivers/afe/ad413x/iio_ad413x.c
@@ -8,7 +8,6 @@
 #include "iio_ad413x.h"
 #include "no_os_util.h"
 #include "ad413x.h"
-#include "gpio_irq_extra.h"
 
 struct scan_type ad413x_iio_scan_type = {
 	.sign = 'u',
@@ -436,16 +435,13 @@ int32_t ad413x_iio_init(struct ad413x_iio_dev **iio_dev,
 {
 	int32_t ret;
 	struct ad413x_iio_dev *desc;
-	struct xil_gpio_irq_init_param *gpio_irq_extra;
-	gpio_irq_extra = (struct xil_gpio_irq_init_param *)
-			 init_param.ad413x_ip.irq_desc->extra;
 
 	desc = (struct ad413x_iio_dev *)calloc(1, sizeof(*desc));
 	if (!desc)
 		return -1;
 
 	desc->iio_dev = &ad413x_iio_device;
-	desc->iio_dev->irq_desc = gpio_irq_extra->parent_desc;
+	desc->iio_dev->irq_desc = init_param.irq_desc;
 
 	ret = ad413x_init(&desc->ad413x_dev, init_param.ad413x_ip);
 	if (ret != 0)

--- a/drivers/afe/ad413x/iio_ad413x.h
+++ b/drivers/afe/ad413x/iio_ad413x.h
@@ -50,6 +50,7 @@ struct ad413x_iio_dev {
 
 struct ad413x_iio_init_param {
 	struct ad413x_init_param ad413x_ip;
+	struct no_os_irq_ctrl_desc *irq_desc;
 };
 
 int32_t ad413x_iio_init(struct ad413x_iio_dev **iio_dev,

--- a/projects/ad413x/src/app/main.c
+++ b/projects/ad413x/src/app/main.c
@@ -174,13 +174,18 @@ int main()
 	/* IIO device */
 	struct ad413x_iio_dev *adciio = NULL;
 	struct ad413x_iio_init_param adciio_init;
+	struct xil_gpio_irq_init_param *iio_gpio_irq_extra;
 
 	struct iio_data_buffer iio_ad413x_read_buff = {
 		.buff = ADC_DDR_BASEADDR,
 		.size = MAX_SIZE_BASE_ADDR,
 	};
 
+	iio_gpio_irq_extra = (struct xil_gpio_irq_init_param *)
+			     adciio_init.ad413x_ip.irq_desc->extra;
+
 	adciio_init.ad413x_ip = ad413x_dev_ip;
+	adciio_init->irq_desc = iio_gpio_irq_extra->parent_desc;
 	ret = ad413x_iio_init(&adciio, adciio_init);
 	if (ret < 0)
 		goto error;


### PR DESCRIPTION
Add irq descriptor as member of the ad413x_iio_init_param structure and
initialized it in the main application.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>