### PR TITLE
Removal of  warnings generated during make for the fmcdaq2 project

### DIFF
--- a/drivers/axi_core/jesd204/axi_adxcvr.c
+++ b/drivers/axi_core/jesd204/axi_adxcvr.c
@@ -312,8 +312,8 @@ int adxcvr_clk_set_rate(struct adxcvr *xcvr,
 
 			ret = xilinx_xcvr_write_prog_div(&xcvr->xlx_xcvr,
 							 ADXCVR_DRP_PORT_CHANNEL(i),
-							 xcvr->tx_enable ? -1 : prog_div,
-							 xcvr->tx_enable ? prog_div : -1);
+							 xcvr->tx_enable ? -1 : (int32_t)prog_div,
+							 xcvr->tx_enable ? (int32_t)prog_div : -1);
 			if (ret < 0)
 				return ret;
 		}

--- a/drivers/axi_core/jesd204/xilinx_transceiver.c
+++ b/drivers/axi_core/jesd204/xilinx_transceiver.c
@@ -130,7 +130,7 @@ static int xilinx_xcvr_drp_read(struct xilinx_xcvr *xcvr,
 
 	ret = adxcvr_drp_read(xcvr->ad_xcvr, drp_port, reg, val);
 	if (ret) {
-		pr_err("%s: Failed to read reg %"PRIu32"-0x%"PRIX32": %"PRId32"\n",
+		pr_err("%s: Failed to read reg %"PRIu32"-0x%"PRIX32": %d\n",
 		       __func__, drp_port, reg, ret);
 
 		return -1;
@@ -153,14 +153,14 @@ static int xilinx_xcvr_drp_write(struct xilinx_xcvr *xcvr,
 
 	ret = adxcvr_drp_write(xcvr->ad_xcvr, drp_port, reg, val);
 	if (ret) {
-		pr_err("%s: Failed to write reg %"PRIu32"-0x%"PRIX32": %"PRId32"\n",
+		pr_err("%s: Failed to write reg %"PRIu32"-0x%"PRIX32": %d\n",
 		       __func__, drp_port, reg, ret);
 		return ret;
 	}
 
 	ret = xilinx_xcvr_drp_read(xcvr, drp_port, reg, &read_val);
 	if (ret) {
-		pr_err("%s: Failed to check reg %"PRIu32"-0x%"PRIX32": %"PRId32"\n",
+		pr_err("%s: Failed to check reg %"PRIu32"-0x%"PRIX32": %d\n",
 		       __func__, drp_port, reg, ret);
 		return ret;
 	}

--- a/drivers/axi_core/jesd204/xilinx_transceiver.c
+++ b/drivers/axi_core/jesd204/xilinx_transceiver.c
@@ -1722,7 +1722,7 @@ int xilinx_xcvr_prbsel_enc_get(struct xilinx_xcvr *xcvr, uint32_t prbs,
 {
 	const uint8_t gthy_prbs_lut[] = {0, 7, 9, 15, 23, 31};
 	const uint8_t gtx_prbs_lut[] = {0, 7, 15, 23, 31};
-	int i;
+	unsigned int i;
 
 	switch (xcvr->type) {
 	case XILINX_XCVR_TYPE_S7_GTX2:

--- a/drivers/dac/ad9144/ad9144.c
+++ b/drivers/dac/ad9144/ad9144.c
@@ -687,7 +687,6 @@ int32_t ad9144_short_pattern_test(struct ad9144_dev *dev,
 
 	uint32_t dac = 0;
 	uint32_t sample = 0;
-	uint8_t status = 0;
 	int32_t ret = 0;
 
 	for (dac = 0; dac < dev->num_converters; dac++) {
@@ -709,10 +708,9 @@ int32_t ad9144_short_pattern_test(struct ad9144_dev *dev,
 						      REG_SHORT_TPL_TEST_3,
 						      0x01, 0x00);
 			if (ret == -1)
-				printf("%s : short-pattern-test mismatch (0x%x, 0x%x 0x%x, 0x%x)!.\n",
+				printf("%s : short-pattern-test mismatch (%#06lx, %#06lx, %#06lx)!.\n",
 				       __func__, dac, sample,
-				       init_param->stpl_samples[dac][sample],
-				       status);
+				       init_param->stpl_samples[dac][sample]);
 		}
 	}
 	return 0;

--- a/drivers/frequency/ad9523/ad9523.c
+++ b/drivers/frequency/ad9523/ad9523.c
@@ -235,7 +235,7 @@ int32_t ad9523_calibrate(struct ad9523_dev *dev)
 			AD9523_READBACK_1,
 			&reg_data);
 	if ((reg_data & 0x1) != 0x0) {
-		printf("AD9523: VCO calibration failed (%x)!\n", reg_data);
+		printf("AD9523: VCO calibration failed (%#06lx)!\n", reg_data);
 		return(-1);
 	}
 
@@ -289,14 +289,16 @@ int32_t ad9523_status(struct ad9523_dev *dev)
 
 	ret = 0;
 	if ((reg_data & AD9523_READBACK_0_STAT_VCXO) != AD9523_READBACK_0_STAT_VCXO) {
-		printf("AD9523: VCXO status errors (%x)!\n", reg_data);
+		printf("AD9523: VCXO status errors (%#06lx)!\n", reg_data);
 		ret = -1;
 	}
+
 	if ((reg_data & AD9523_READBACK_0_STAT_PLL2_LD) !=
 	    AD9523_READBACK_0_STAT_PLL2_LD) {
-		printf("AD9523: PLL2 NOT locked (%x)!\n", reg_data);
+		printf("AD9523: PLL2 NOT locked (%#06lx)!\n", reg_data);
 		ret = -1;
 	}
+
 	return(ret);
 }
 
@@ -482,7 +484,7 @@ int32_t ad9523_setup(struct ad9523_dev **device,
 		return ret;
 
 	if (reg_data != 0xAD95) {
-		printf("AD9523: SPI write-verify failed (0x%X)!\n\r",
+		printf("AD9523: SPI write-verify failed (%#06lX)!\n\r",
 		       reg_data);
 		return -1;
 	}

--- a/projects/fmcdaq2/src/app/fmcdaq2.c
+++ b/projects/fmcdaq2/src/app/fmcdaq2.c
@@ -517,12 +517,12 @@ static int fmcdaq2_test(struct fmcdaq2_dev *dev,
 
 	status = axi_jesd204_rx_status_read(dev->ad9680_jesd);
 	if (status != 0) {
-		printf("axi_jesd204_rx_status_read() error: %"PRIi32"\n", status);
+		printf("axi_jesd204_rx_status_read() error: %d\n", status);
 	}
 
 	status = axi_jesd204_tx_status_read(dev->ad9144_jesd);
 	if (status != 0) {
-		printf("axi_jesd204_tx_status_read() error: %"PRIi32"\n", status);
+		printf("axi_jesd204_tx_status_read() error: %d\n", status);
 	}
 
 	status = ad9144_status(dev->ad9144_device);


### PR DESCRIPTION
Fixes for solving the problems that generate warnings during the make process for the fmcdaq2 project. 

These will decrease the number of warnings for other projects using the modified driver files.