### PR TITLE
drivers:platform:maxim:max32670 Initial implementation of SPI drivers for MAX32670

### DIFF
--- a/drivers/platform/maxim/max32670/maxim_spi.c
+++ b/drivers/platform/maxim/max32670/maxim_spi.c
@@ -1,0 +1,237 @@
+/***************************************************************************//**
+ *   @file   maxim_spi.c
+ *   @brief  Implementation of SPI driver.
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/************************* Include Files **************************************/
+/******************************************************************************/
+
+#include <stdlib.h>
+#include <errno.h>
+#include "spi.h"
+#include "mxc_errors.h"
+#include "mxc_pins.h"
+#include "maxim_spi.h"
+#include "no_os_spi.h"
+#include "no_os_util.h"
+
+#define SPI_MASTER_MODE	1
+#define SPI_SINGLE_MODE	0
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+/**
+ * @brief Initialize the SPI communication peripheral.
+ * @param desc - The SPI descriptor.
+ * @param param - The structure that contains the SPI parameters.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+int32_t max_spi_init(struct no_os_spi_desc **desc,
+		     const struct no_os_spi_init_param *param)
+{
+	int32_t ret;
+	struct no_os_spi_desc *descriptor;
+	struct max_spi_init_param *eparam;
+
+	if (!param || !param->extra)
+		return -EINVAL;
+
+	descriptor = calloc(1, sizeof(*descriptor));
+
+	if (!descriptor)
+		return -ENOMEM;
+
+	eparam = param->extra;
+	descriptor->device_id = param->device_id;
+	descriptor->max_speed_hz = param->max_speed_hz;
+	descriptor->chip_select = param->chip_select;
+	descriptor->mode = param->mode;
+	descriptor->bit_order = param->bit_order;
+	descriptor->platform_ops = &max_spi_ops;
+
+	if (descriptor->device_id >= MXC_SPI_INSTANCES) {
+		ret = -EINVAL;
+		goto err;
+	}
+
+	ret = MXC_SPI_Init(MXC_SPI_GET_SPI(descriptor->device_id), SPI_MASTER_MODE,
+			   SPI_SINGLE_MODE,
+			   eparam->numSlaves, eparam->polarity, param->max_speed_hz);
+	if (ret) {
+		ret = -EINVAL;
+		goto err_init;
+	}
+
+	ret = MXC_SPI_SetMode(MXC_SPI_GET_SPI(descriptor->device_id),
+			      (mxc_spi_mode_t)descriptor->mode);
+	if (ret) {
+		ret = -EINVAL;
+		goto err_init;
+	}
+
+	ret = MXC_SPI_SetWidth(MXC_SPI_GET_SPI(descriptor->device_id),
+			       SPI_WIDTH_STANDARD);
+	if (ret) {
+		ret = -EINVAL;
+		goto err_init;
+	}
+
+	ret = MXC_SPI_SetDataSize(MXC_SPI_GET_SPI(descriptor->device_id), 8);
+	if (ret) {
+		ret = -EINVAL;
+		goto err_init;
+	}
+
+	*desc = descriptor;
+
+	return 0;
+err_init:
+	MXC_SPI_Shutdown(MXC_SPI_GET_SPI(descriptor->device_id));
+err:
+	free(descriptor);
+
+	return ret;
+}
+
+/**
+ * @brief Free the resources allocated by no_os_spi_init().
+ * @param desc - The SPI descriptor.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+int32_t max_spi_remove(struct no_os_spi_desc *desc)
+{
+	if (!desc)
+		return -EINVAL;
+
+	MXC_SPI_Shutdown(MXC_SPI_GET_SPI(desc->device_id));
+	free(desc);
+
+	return 0;
+}
+
+/**
+ * @brief Write and read data to/from SPI.
+ * @param desc - The SPI descriptor.
+ * @param data - The buffer with the transmitted/received data.
+ * @param bytes_number - Number of bytes to write/read.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+int32_t max_spi_write_and_read(struct no_os_spi_desc *desc,
+			       uint8_t *data,
+			       uint16_t bytes_number)
+{
+	int32_t ret;
+	uint8_t *tx_buffer;
+	uint8_t *rx_buffer;
+	mxc_spi_req_t req;
+
+	if (!desc || !data)
+		return -EINVAL;
+
+	rx_buffer = data;
+	tx_buffer = data;
+
+	req.spi = MXC_SPI_GET_SPI(desc->device_id);
+	req.ssIdx = desc->chip_select;
+	req.txData = tx_buffer;
+	req.txCnt = 0;
+	req.rxData = rx_buffer;
+	req.rxCnt= 0;
+	req.ssDeassert = 1;
+	req.txLen= bytes_number;
+	req.rxLen= bytes_number;
+
+	ret = MXC_SPI_MasterTransaction(&req);
+
+	if (ret == E_BAD_PARAM)
+		return -EINVAL;
+	if (ret == E_BAD_STATE)
+		return -EBUSY;
+
+	return 0;
+}
+
+/**
+ * @brief Write/read multiple messages to/from SPI.
+ * @param desc - The SPI descriptor.
+ * @param msgs - The messages array.
+ * @param len - Number of messages.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+int32_t max_spi_transfer(struct no_os_spi_desc *desc,
+			 struct no_os_spi_msg *msgs,
+			 uint32_t len)
+{
+	mxc_spi_req_t req;
+	int32_t ret;
+
+	if (!desc || !msgs)
+		return -EINVAL;
+
+	req.spi = MXC_SPI_GET_SPI(desc->device_id);
+	for (uint32_t i = 0; i < len; i++) {
+		req.txData = msgs[i].tx_buff;
+		req.rxData = msgs[i].rx_buff;
+		req.txCnt = 0;
+		req.rxCnt = 0;
+		req.ssDeassert = msgs[i].cs_change;
+		req.txLen = msgs[i].bytes_number;
+		req.rxLen = msgs[i].bytes_number;
+
+		ret = MXC_SPI_MasterTransaction(&req);
+
+		if (ret == E_BAD_PARAM)
+			return -EINVAL;
+		if (ret == E_BAD_STATE)
+			return -EBUSY;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief maxim platform specific SPI platform ops structure
+ */
+const struct no_os_spi_platform_ops max_spi_ops = {
+	.init = &max_spi_init,
+	.write_and_read = &max_spi_write_and_read,
+	.transfer = &max_spi_transfer,
+	.remove = &max_spi_remove
+};

--- a/drivers/platform/maxim/max32670/maxim_spi.h
+++ b/drivers/platform/maxim/max32670/maxim_spi.h
@@ -1,0 +1,66 @@
+/***************************************************************************//**
+ *   @file   maxim_spi.h
+ *   @brief  maxim specific header for SPI driver
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef MAXIM_SPI_H_
+#define MAXIM_SPI_H_
+
+#include <stdint.h>
+
+/**
+ * @brief maxim specific SPI platform ops structure
+ */
+extern const struct no_os_spi_platform_ops max_spi_ops;
+
+/**
+ * @brief Slave Select pin polarity
+ */
+enum spi_ss_polarity {
+	SPI_SS_POL_LOW,
+	SPI_SS_POL_HIGH
+};
+
+/**
+ * @brief Maxim specific SPI initialization parameters
+ */
+struct max_spi_init_param {
+	uint32_t numSlaves;
+	enum spi_ss_polarity polarity;
+};
+
+#endif


### PR DESCRIPTION
The SPI drivers for MAX32670 and similar to MAX32660. The source and header files are therefore
used from MAX32660 folder. The SPI communication is tested onto MAX32670 EVKIT MCU board and
it is working fine.
As code is used from MAX32660, original author information is kept as-is.

Signed-off-by: MPhalke <mahesh.phalke@analog.com>