### PR TITLE
drivers:platform:maxim:max32670 Initial implementation of UART platform drivers

### DIFF
--- a/drivers/platform/maxim/max32670/maxim_uart.c
+++ b/drivers/platform/maxim/max32670/maxim_uart.c
@@ -1,0 +1,401 @@
+/***************************************************************************//**
+ *   @file   maxim_uart.c
+ *   @brief  Source file of UART driver for STM32
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/************************* Include Files **************************************/
+/******************************************************************************/
+
+#include <errno.h>
+#include <stdlib.h>
+#include "maxim_irq.h"
+#include "maxim_uart.h"
+#include "mxc_sys.h"
+#include "mxc_errors.h"
+#include "no_os_uart.h"
+#include "no_os_irq.h"
+#include "no_os_util.h"
+#include "no_os_lf256fifo.h"
+#include "uart.h"
+
+/**
+* @brief Descriptors to hold the state of nonblocking read and writes
+* on each port
+*/
+mxc_uart_req_t uart_irq_state[MXC_UART_INSTANCES];
+bool is_callback;
+
+static uint8_t c;
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+/**
+ * @brief UART receive interrupt callback function
+ * @param context - UART context
+ * @return none
+ */
+void uart_rx_callback(void *context)
+{
+	struct no_os_uart_desc *d = context;
+	lf256fifo_write(d->rx_fifo, c);
+	no_os_uart_read_nonblocking(d, &c, 1);
+}
+
+/**
+ * @brief Read data from UART device. Blocking function.
+ * @param desc - Instance of UART.
+ * @param data - Pointer to buffer containing data.
+ * @param bytes_number - Number of bytes to read.
+ * @return positive number of received bytes in case of success, negative error code otherwise.
+ */
+int32_t no_os_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
+			uint32_t bytes_number)
+{
+	int32_t ret;
+	uint32_t i = 0;
+
+	if (!desc || !data || !bytes_number)
+		return -EINVAL;
+
+	if (desc->rx_fifo) {
+		for (i = 0; i < bytes_number; i++) {
+			ret = lf256fifo_read(desc->rx_fifo, &data[i]);
+			if (ret)
+				return i ? (int32_t)i : -EAGAIN;
+		}
+		return i;
+	}
+
+	ret = MXC_UART_Read(MXC_UART_GET_UART(desc->device_id), data,
+			    (int *)&bytes_number);
+	if (ret != E_SUCCESS)
+		return -EIO;
+
+	return bytes_number;
+}
+
+/**
+ * @brief Write data to UART device. Blocking function.
+ * @param desc - Instance of UART.
+ * @param data - Pointer to buffer containing data.
+ * @param bytes_number - Number of bytes to read.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+int32_t no_os_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
+			 uint32_t bytes_number)
+{
+	int32_t ret;
+
+	if(!desc || !data || !bytes_number)
+		return -EINVAL;
+
+	ret = MXC_UART_Write(MXC_UART_GET_UART(desc->device_id), data,
+			     (int *)&bytes_number);
+	if (ret != E_SUCCESS)
+		return -EIO;
+
+	return bytes_number;
+}
+
+/**
+ * @brief Read data from UART device. Non blocking function.
+ * @param desc - Instance of UART.
+ * @param data - Pointer to buffer containing data.
+ * @param bytes_number - Number of bytes to read.
+ * @return positive number of received bytes in case of success, negative error code otherwise.
+ */
+int32_t no_os_uart_read_nonblocking(struct no_os_uart_desc *desc, uint8_t *data,
+				    uint32_t bytes_number)
+{
+	int32_t ret;
+	uint32_t id;
+
+	if (!desc || !data || !bytes_number)
+		return -EINVAL;
+
+	id = desc->device_id;
+	uart_irq_state[id].uart = MXC_UART_GET_UART(id);
+	uart_irq_state[id].rxData = data;
+	uart_irq_state[id].rxLen = bytes_number;
+	uart_irq_state[id].txData = NULL;
+	uart_irq_state[id].txLen = 0;
+	uart_irq_state[id].rxCnt = 0;
+	uart_irq_state[id].callback = max_uart_callback;
+
+	if (!is_callback) {
+		ret = MXC_UART_TransactionAsync(&uart_irq_state[id]);
+		if (ret == E_BUSY)
+			return -EBUSY;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Write data to UART device. Non blocking function.
+ * @param desc - Instance of UART.
+ * @param data - Pointer to buffer containing data.
+ * @param bytes_number - Number of bytes to read.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+
+int32_t no_os_uart_write_nonblocking(struct no_os_uart_desc *desc,
+				     const uint8_t *data,
+				     uint32_t bytes_number)
+{
+	int32_t ret;
+	uint32_t id;
+
+	if (!desc || !data || !bytes_number)
+		return -EINVAL;
+
+	id = desc->device_id;
+	uart_irq_state[id].uart = MXC_UART_GET_UART(id);
+	uart_irq_state[id].txData = data;
+	uart_irq_state[id].txLen = bytes_number;
+	uart_irq_state[id].rxData = NULL;
+	uart_irq_state[id].rxLen = 0;
+	uart_irq_state[id].txCnt = 0;
+	uart_irq_state[id].callback = max_uart_callback;
+
+	if (!is_callback) {
+		ret = MXC_UART_TransactionAsync(&uart_irq_state[id]);
+		if (ret == E_BUSY)
+			return -EBUSY;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Initialize the UART communication peripheral.
+ * @param desc - The UART descriptor.
+ * @param param - The structure that contains the UART parameters.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+int32_t no_os_uart_init(struct no_os_uart_desc **desc,
+			struct no_os_uart_init_param *param)
+{
+	int32_t ret;
+	int32_t stop, size, flow, parity;
+	mxc_uart_regs_t *uart_regs;
+	struct max_uart_init_param *eparam;
+	struct no_os_uart_desc *descriptor;
+	struct max_uart_desc *max_uart;
+
+	if (!param || !param->extra)
+		return -EINVAL;
+
+	descriptor = calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	max_uart = calloc(1, sizeof(*max_uart));
+	if (!descriptor) {
+		ret = -ENOMEM;
+		goto error;
+	}
+	uart_regs = MXC_UART_GET_UART(param->device_id);
+	eparam = param->extra;
+
+	descriptor->device_id = param->device_id;
+	descriptor->baud_rate = param->baud_rate;
+
+	switch(param->parity) {
+	case NO_OS_UART_PAR_NO:
+		parity = MXC_UART_PARITY_DISABLE;
+		break;
+	case NO_OS_UART_PAR_ODD:
+		parity = MXC_UART_PARITY_ODD_0;
+		break;
+	case NO_OS_UART_PAR_EVEN:
+		parity = MXC_UART_PARITY_EVEN_0;
+		break;
+	default:
+		ret = -EINVAL;
+		goto error;
+	}
+
+	switch(param->size) {
+	case NO_OS_UART_CS_5:
+		size = 5;
+		break;
+	case NO_OS_UART_CS_6:
+		size = 6;
+		break;
+	case NO_OS_UART_CS_7:
+		size = 7;
+		break;
+	case NO_OS_UART_CS_8:
+		size = 8;
+		break;
+	default:
+		ret = -EINVAL;
+		goto error;
+	}
+
+	switch(param->stop) {
+	case NO_OS_UART_STOP_1_BIT:
+		stop = MXC_UART_STOP_1;
+		break;
+	case NO_OS_UART_STOP_2_BIT:
+		stop = MXC_UART_STOP_2;
+		break;
+	default:
+		ret = -EINVAL;
+		goto error;
+	}
+
+	switch (eparam->flow) {
+	case MAX_UART_FLOW_DIS:
+		flow = MXC_UART_FLOW_DIS;
+		break;
+	case MAX_UART_FLOW_EN:
+		flow = MXC_UART_FLOW_EN;
+		break;
+	default:
+		ret = -EINVAL;
+		goto error;
+	}
+
+	ret = MXC_UART_Init(uart_regs, descriptor->baud_rate, MXC_UART_IBRO_CLK);
+	if (ret != E_NO_ERROR) {
+		ret = -EINVAL;
+		goto error;
+	}
+
+	ret = MXC_UART_SetDataSize(uart_regs, size);
+	if (ret != E_NO_ERROR) {
+		ret = -EINVAL;
+		goto error;
+	}
+
+	ret = MXC_UART_SetParity(uart_regs, parity);
+	if (ret != E_NO_ERROR) {
+		ret = -EINVAL;
+		goto error;
+	}
+
+	ret = MXC_UART_SetStopBits(uart_regs, stop);
+	if (ret != E_NO_ERROR) {
+		ret = -EINVAL;
+		goto error;
+	}
+
+	ret = MXC_UART_SetFlowCtrl(uart_regs, flow, 8);
+	if (ret != E_NO_ERROR) {
+		ret = -EINVAL;
+		goto error;
+	}
+
+	*desc = descriptor;
+
+	if (param->asynchronous_rx) {
+		ret = lf256fifo_init(&descriptor->rx_fifo);
+		if (ret)
+			goto error;
+
+		struct no_os_irq_init_param nvic_ip = {
+			.platform_ops = &max_irq_ops,
+		};
+
+		ret = no_os_irq_ctrl_init(&max_uart->nvic, &nvic_ip);
+		if (ret)
+			goto error;
+
+		struct no_os_callback_desc uart_rx_cb = {
+			.callback = uart_rx_callback,
+			.ctx = descriptor,
+			.event = NO_OS_EVT_UART_RX_COMPLETE,
+			.peripheral = NO_OS_UART_IRQ,
+			.handle = MXC_UART_GET_UART(descriptor->device_id)
+		};
+
+		ret = no_os_irq_register_callback(max_uart->nvic,
+						  MXC_UART_GET_IRQ(descriptor->device_id),
+						  &uart_rx_cb);
+		if (ret)
+			goto error_nvic;
+
+		ret = no_os_irq_enable(max_uart->nvic, MXC_UART_GET_IRQ(descriptor->device_id));
+		if (ret)
+			goto error_nvic;
+
+		ret = no_os_uart_read_nonblocking(descriptor, &c, 1);
+		if (ret)
+			goto error_nvic;
+	}
+
+	return 0;
+error_nvic:
+	no_os_irq_ctrl_remove(max_uart->nvic);
+error:
+	free(max_uart);
+	free(descriptor);
+	MXC_UART_Shutdown(uart_regs);
+
+	return ret;
+}
+
+/**
+ * @brief Free the resources allocated by no_os_uart_init().
+ * @param desc - The UART descriptor.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+int32_t no_os_uart_remove(struct no_os_uart_desc *desc)
+{
+	if (!desc)
+		return -EINVAL;
+
+	MXC_UART_Shutdown(MXC_UART_GET_UART(desc->device_id));
+	free(desc);
+
+	return 0;
+}
+
+/**
+ * @brief Not implemented.
+ * @param desc - The UART descriptor.
+ * @return -ENOSYS
+ */
+uint32_t no_os_uart_get_errors(struct no_os_uart_desc *desc)
+{
+	return -ENOSYS;
+}

--- a/drivers/platform/maxim/max32670/maxim_uart.h
+++ b/drivers/platform/maxim/max32670/maxim_uart.h
@@ -1,0 +1,70 @@
+/***************************************************************************//**
+ *   @file   maxim_uart.h
+ *   @brief  Header file of UART driver.
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef _MAXIM_UART_H_
+#define _MAXIM_UART_H_
+
+#include "uart.h"
+#include "no_os_irq.h"
+#include "max32670.h"
+
+/**
+ * @brief UART flow control
+ */
+enum max_uart_flow_ctrl {
+	MAX_UART_FLOW_DIS,
+	MAX_UART_FLOW_EN
+};
+
+/**
+ * @brief Aditional UART config parameters
+ */
+struct max_uart_init_param {
+	enum max_uart_flow_ctrl flow;
+};
+
+/**
+ * @brief Platform specific UART state
+ */
+struct max_uart_desc {
+	/** Controller that handles UART interrupts */
+	struct no_os_irq_ctrl_desc *nvic;
+};
+
+#endif


### PR DESCRIPTION
The baseline code for this is taken from UART implementation of MAX32660.
Below minor changes done w.r.t. to implementation:
1. Removed the switch case for UART 'mark' and 'space' parity as MAX32670 does not
support these parity modes. For odd and even parity, MAX32670 provides two modes-
mode0 and mode1. As no_os_uart_parity enum provides only odd and even parity settings,
mode0 of odd and even parity is used for max32670. This is done in uart init function.

2. MAX32670 does not support low and high flow control. It supports only enable/disable of flow control.
So, for both low and high flow enum switch case, MXC_UART_FLOW_EN value is set. This is done in uart init function.

3. 3rd argument to MXC_UART_Init() function is set as MXC_UART_APB_CLK. This is the max UART clock frequency
possible for this device (system_clock / 2 = 100Mhz/2 = 50Mhz).

4. Removed the FIFO implementation for uart write and read functions and replaced it wih non-fifo blocking
uart write/read. While transmitting data to IIO client over UART, it has been observed that FIFO implementation
is quite slower and take more execution time. While capturing ADC data in the background using interrupt and
periodically transmitting data over UART (based on request from IIO client), the FIFO implementation
results into loss of UART communication after running data capture for minute or so. With non-fifo
implementation, the UART communication and continuous data capturing works for longer time without any failure.
Both FIFO and non-fifo are of blocking type, so assumption is made that we have choice to use one of it.

Signed-off-by: MPhalke <mahesh.phalke@analog.com>