### PR TITLE
drivers:platform:maxim: Fixed errors and warnings

### DIFF
--- a/drivers/platform/maxim/max32660/maxim_i2c.c
+++ b/drivers/platform/maxim/max32660/maxim_i2c.c
@@ -47,7 +47,7 @@
 #include "no_os_util.h"
 #include "maxim_i2c.h"
 #include "mxc_errors.h"
-#include "max32660l.h"
+#include "max32660.h"
 
 #define I2C_MASTER_MODE	1
 

--- a/drivers/platform/maxim/max32665/maxim_i2c.c
+++ b/drivers/platform/maxim/max32665/maxim_i2c.c
@@ -60,7 +60,7 @@ static uint32_t nb_created_desc[MXC_I2C_INSTANCES];
  */
 void I2C0_IRQHandler(void)
 {
-	MXC_I2C_AsyncHandler(MXC_I2C0);
+	MXC_I2C_AsyncHandler(MXC_I2C0_BUS0);
 }
 
 /**
@@ -69,13 +69,13 @@ void I2C0_IRQHandler(void)
  */
 void I2C1_IRQHandler(void)
 {
-	MXC_I2C_AsyncHandler(MXC_I2C1);
+	MXC_I2C_AsyncHandler(MXC_BASE_I2C1_BUS0);
 }
 
 #ifdef MXC_I2C2
 void I2C2_IRQHandler(void)
 {
-	MXC_I2C_AsyncHandler(MXC_I2C2);
+	MXC_I2C_AsyncHandler(MXC_BASE_I2C2_BUS0);
 }
 #endif
 

--- a/drivers/platform/maxim/max78000/maxim_i2c.c
+++ b/drivers/platform/maxim/max78000/maxim_i2c.c
@@ -40,6 +40,7 @@
 
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "i2c.h"
 #include "no_os_error.h"
@@ -95,7 +96,6 @@ static int32_t max_i2c_init(struct no_os_i2c_desc **desc,
 	int32_t ret;
 	struct max_i2c_extra *max_i2c;
 	mxc_i2c_regs_t *i2c_regs;
-	uint32_t current_freq = 0;
 	uint32_t freq;
 
 	if (!desc || !param)
@@ -202,7 +202,6 @@ static int32_t max_i2c_write(struct no_os_i2c_desc *desc,
 	mxc_i2c_req_t req;
 	struct max_i2c_extra *max_i2c_desc;
 	void *ptr;
-	int32_t ret;
 
 	if (!desc || !desc->extra)
 		return -EINVAL;

--- a/drivers/platform/maxim/max78000/maxim_i2c.h
+++ b/drivers/platform/maxim/max78000/maxim_i2c.h
@@ -45,7 +45,7 @@
 #include "i2c_regs.h"
 
 #ifndef MXC_I2C_GET_I2C
-#define MXC_I2C_GET_I2C (i)	((i) == 0 ? MXC_I2C0 :		\
+#define MXC_I2C_GET_I2C(i)	((i) == 0 ? MXC_I2C0 :		\
                                 (i) == 1 ? MXC_I2C1 :		\
                                 (i) == 2 ? MXC_I2C2 : 0)
 #endif


### PR DESCRIPTION
Fixed compilation errors and warnings for the I2C driver on Maxim
platform.