### PR TITLE
Add correct value for irq_ctrl_id in projects

### DIFF
--- a/projects/adxrs290-pmdz/src/common/common_data.c
+++ b/projects/adxrs290-pmdz/src/common/common_data.c
@@ -104,7 +104,7 @@ struct no_os_timer_init_param adxrs290_tip = {
 
 /* ADXRS290 timer irq init parameter */
 struct no_os_irq_init_param adxrs290_timer_irq_ip = {
-	.irq_ctrl_id = ADXRS290_TIMER_IRQ_ID,
+	.irq_ctrl_id = 0,
 	.platform_ops = TIMER_IRQ_OPS,
 	.extra = ADADXRS290_TIMER_IRQ_EXTRA,
 };

--- a/projects/adxrs290-pmdz/src/platform/pico/parameters.h
+++ b/projects/adxrs290-pmdz/src/platform/pico/parameters.h
@@ -100,7 +100,7 @@ extern struct pico_spi_init_param adxrs290_spi_extra_ip;
 #define TIMER_OPS                   &pico_timer_ops
 
 /* ADXRS290 Timer trigger settings */
-#define ADXRS290_TIMER_IRQ_ID       0 /* For alarm0 */
+#define ADXRS290_TIMER_IRQ_ID       0 /* for TIMER_IRQ_0 */
 #define TIMER_IRQ_OPS               &pico_irq_ops
 #define ADADXRS290_TIMER_IRQ_EXTRA  NULL /* Not used for pico platform */
 

--- a/projects/iio_demo/src/common/common_data.c
+++ b/projects/iio_demo/src/common/common_data.c
@@ -94,7 +94,7 @@ struct no_os_timer_init_param adc_demo_tip = {
 
 /* Adc Demo timer irq init parameter */
 struct no_os_irq_init_param adc_demo_timer_irq_ip = {
-	.irq_ctrl_id = ADC_DEMO_TIMER_IRQ_ID,
+	.irq_ctrl_id = 0,
 	.platform_ops = TIMER_IRQ_OPS,
 	.extra = ADC_DEMO_TIMER_IRQ_EXTRA,
 };
@@ -124,7 +124,7 @@ struct no_os_timer_init_param dac_demo_tip = {
 
 /* Dac Demo timer irq init parameter */
 struct no_os_irq_init_param dac_demo_timer_irq_ip = {
-	.irq_ctrl_id = DAC_DEMO_TIMER_IRQ_ID,
+	.irq_ctrl_id = 0,
 	.platform_ops = TIMER_IRQ_OPS,
 	.extra = DAC_DEMO_TIMER_IRQ_EXTRA,
 };


### PR DESCRIPTION
irq_ctrl_id should be 0 (specific to NVIC IRQ controller) for timer interrupts.