### PR TITLE
drivers:adc:adaq8092: fix header comment

### DIFF
--- a/drivers/adc/adaq8092/adaq8092.h
+++ b/drivers/adc/adaq8092/adaq8092.h
@@ -174,8 +174,8 @@ enum adaq8092_twoscomp {
 };
 
 /**
- * @struct adaq8092_init
- * @brief ADAQ8092 Device structure.
+ * @struct adaq8092_init_param
+ * @brief ADAQ8092 Device initialization parameters.
  */
 struct adaq8092_init_param {
 	/** Device communication descriptor */


### PR DESCRIPTION
Fix the device initialization parameters structure header comment.

No functional changes.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>