### PR TITLE
include: no_os_spi: remove typedefs

### DIFF
--- a/drivers/accel/adxl313/adxl313.h
+++ b/drivers/accel/adxl313/adxl313.h
@@ -384,7 +384,7 @@ union adxl313_comm_init_param {
 	/** I2C Initialization structure. */
 	no_os_i2c_init_param i2c_init;
 	/** SPI Initialization structure. */
-	no_os_spi_init_param spi_init;
+	struct no_os_spi_init_param spi_init;
 } ;
 
 /**
@@ -484,7 +484,7 @@ union adxl313_comm_desc {
 	/** I2C Descriptor */
 	no_os_i2c_desc *i2c_desc;
 	/** SPI Descriptor */
-	no_os_spi_desc *spi_desc;
+	struct no_os_spi_desc *spi_desc;
 };
 
 /**

--- a/drivers/accel/adxl345/adxl345.h
+++ b/drivers/accel/adxl345/adxl345.h
@@ -188,7 +188,7 @@ struct adxl345_dev {
 	/** I2C Descriptor */
 	no_os_i2c_desc	*i2c_desc;
 	/** SPI Descriptor */
-	no_os_spi_desc	*spi_desc;
+	struct no_os_spi_desc	*spi_desc;
 	/** Device Communication type: ADXL345_SPI_COMM, ADXL345_I2C_COMM */
 	uint8_t		communication_type;
 	/** Measurement range */
@@ -205,7 +205,7 @@ struct adxl345_init_param {
 	/** I2C Initialization structure. */
 	no_os_i2c_init_param	i2c_init;
 	/** SPI Initialization structure. */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/** Device Communication type: ADXL345_SPI_COMM, ADXL345_I2C_COMM */
 	uint8_t		communication_type;
 	/** Measurement range */

--- a/drivers/accel/adxl355/adxl355.h
+++ b/drivers/accel/adxl355/adxl355.h
@@ -184,7 +184,7 @@ union adxl355_comm_init_param {
 	/** I2C Initialization structure. */
 	no_os_i2c_init_param i2c_init;
 	/** SPI Initialization structure. */
-	no_os_spi_init_param spi_init;
+	struct no_os_spi_init_param spi_init;
 } ;
 
 /**
@@ -249,7 +249,7 @@ union adxl355_comm_desc {
 	/** I2C Descriptor */
 	no_os_i2c_desc *i2c_desc;
 	/** SPI Descriptor */
-	no_os_spi_desc *spi_desc;
+	struct no_os_spi_desc *spi_desc;
 };
 
 /**

--- a/drivers/accel/adxl362/adxl362.h
+++ b/drivers/accel/adxl362/adxl362.h
@@ -202,7 +202,7 @@
  */
 struct adxl362_dev {
 	/** SPI Descriptor */
-	no_os_spi_desc	*spi_desc;
+	struct no_os_spi_desc	*spi_desc;
 	/** Measurement Range: */
 	uint8_t		selected_range;
 };
@@ -213,7 +213,7 @@ struct adxl362_dev {
  */
 struct adxl362_init_param {
 	/** SPI Initialization structure. */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 };
 
 /******************************************************************************/

--- a/drivers/accel/adxl367/adxl367.h
+++ b/drivers/accel/adxl367/adxl367.h
@@ -431,7 +431,7 @@ struct adxl367_dev {
 	/** Communication type - I2C or SPI. */
 	enum adxl367_comm_type		comm_type;
 	/** SPI Descriptor */
-	no_os_spi_desc			*spi_desc;
+	struct no_os_spi_desc		*spi_desc;
 	/** I2C Descriptor */
 	no_os_i2c_desc  		*i2c_desc;
 	/** Depending on ASEL pin, can be 0x53 or 0x1D. Only for I2C Comm. */
@@ -458,7 +458,7 @@ struct adxl367_init_param {
 	/** Communication type - I2C or SPI. */
 	enum adxl367_comm_type 		comm_type;
 	/** SPI Initialization structure. */
-	no_os_spi_init_param		spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/** I2C Initialization structure. */
 	no_os_i2c_init_param    	i2c_init;
 	/** Depending on ASEL pin, can be 0x53 or 0x1D. Only for I2C Comm. */

--- a/drivers/accel/adxl372/adxl372.h
+++ b/drivers/accel/adxl372/adxl372.h
@@ -367,7 +367,7 @@ typedef int32_t (*adxl372_reg_read_multi_func)(struct adxl372_dev *dev,
 
 struct adxl372_dev {
 	/* SPI */
-	no_os_spi_desc			*spi_desc;
+	struct no_os_spi_desc		*spi_desc;
 	/* I2C */
 	no_os_i2c_desc			*i2c_desc;
 	/* GPIO */
@@ -388,7 +388,7 @@ struct adxl372_dev {
 
 struct adxl372_init_param {
 	/* SPI */
-	no_os_spi_init_param			spi_init;
+	struct no_os_spi_init_param		spi_init;
 	/* I2C */
 	no_os_i2c_init_param			i2c_init;
 	/* GPIO */

--- a/drivers/adc-dac/ad5592r/ad5592r-base.h
+++ b/drivers/adc-dac/ad5592r/ad5592r-base.h
@@ -121,7 +121,7 @@ struct ad5592r_init_param {
 struct ad5592r_dev {
 	const struct ad5592r_rw_ops *ops;
 	no_os_i2c_desc *i2c;
-	no_os_spi_desc *spi;
+	struct no_os_spi_desc *spi;
 	uint16_t spi_msg;
 	uint8_t num_channels;
 	uint16_t cached_dac[8];

--- a/drivers/adc/ad400x/ad400x.h
+++ b/drivers/adc/ad400x/ad400x.h
@@ -71,7 +71,7 @@ extern const uint16_t ad400x_device_resol[];
 
 struct ad400x_dev {
 	/* SPI */
-	no_os_spi_desc *spi_desc;
+	struct no_os_spi_desc *spi_desc;
 	/* Register access speed */
 	uint32_t reg_access_speed;
 	/* Device Settings */
@@ -80,7 +80,7 @@ struct ad400x_dev {
 
 struct ad400x_init_param {
 	/* SPI */
-	no_os_spi_init_param spi_init;
+	struct no_os_spi_init_param spi_init;
 	/* Register access speed */
 	uint32_t reg_access_speed;
 	/* Device Settings */

--- a/drivers/adc/ad469x/ad469x.h
+++ b/drivers/adc/ad469x/ad469x.h
@@ -237,7 +237,7 @@ enum ad469x_pin_pairing {
  */
 struct ad469x_init_param {
 	/* SPI */
-	no_os_spi_init_param		*spi_init;
+	struct no_os_spi_init_param		*spi_init;
 #if !defined(USE_STANDARD_SPI)
 	/* SPI module offload init */
 	struct spi_engine_offload_init_param *offload_init_param;
@@ -282,7 +282,7 @@ struct ad469x_init_param {
  */
 struct ad469x_dev {
 	/* SPI descriptor */
-	no_os_spi_desc		*spi_desc;
+	struct no_os_spi_desc		*spi_desc;
 #if !defined(USE_STANDARD_SPI)
 	/* Clock gen for hdl design structure */
 	struct axi_clkgen	*clkgen;

--- a/drivers/adc/ad6673/ad6673.h
+++ b/drivers/adc/ad6673/ad6673.h
@@ -522,7 +522,7 @@ enum shadow_registers {
 
 struct ad6673_dev {
 	/* SPI */
-	no_os_spi_desc		*spi_desc;
+	struct no_os_spi_desc		*spi_desc;
 	/* Device Settings */
 	struct ad6673_state ad6673_st;
 	int32_t shadow_regs[SHADOW_REGISTER_COUNT];
@@ -530,7 +530,7 @@ struct ad6673_dev {
 
 struct ad6673_init_param {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 };
 
 /******************************************************************************/

--- a/drivers/adc/ad6676/ad6676.h
+++ b/drivers/adc/ad6676/ad6676.h
@@ -327,12 +327,12 @@ struct ad6676_init_param {
 	uint8_t 	frames_per_multiframe;
 	uint64_t	m;
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 };
 
 struct ad6676_dev {
 	/* SPI */
-	no_os_spi_desc *spi_desc;
+	struct no_os_spi_desc *spi_desc;
 };
 
 /******************************************************************************/

--- a/drivers/adc/ad7091r/ad7091r.h
+++ b/drivers/adc/ad7091r/ad7091r.h
@@ -52,12 +52,12 @@
 
 struct ad7091r_dev {
 	/* SPI */
-	no_os_spi_desc	*spi_desc;
+	struct no_os_spi_desc	*spi_desc;
 };
 
 struct ad7091r_init_param {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 };
 
 /******************************************************************************/

--- a/drivers/adc/ad7124/ad7124.h
+++ b/drivers/adc/ad7124/ad7124.h
@@ -345,7 +345,7 @@ enum ad7124_registers {
  */
 struct ad7124_dev {
 	/* SPI */
-	no_os_spi_desc		*spi_desc;
+	struct no_os_spi_desc		*spi_desc;
 	/* Device Settings */
 	struct ad7124_st_reg	*regs;
 	int16_t use_crc;
@@ -355,7 +355,7 @@ struct ad7124_dev {
 
 struct ad7124_init_param {
 	/* SPI */
-	no_os_spi_init_param		*spi_init;
+	struct no_os_spi_init_param		*spi_init;
 	/* Device Settings */
 	struct ad7124_st_reg	*regs;
 	int16_t spi_rdy_poll_cnt;

--- a/drivers/adc/ad717x/ad717x.h
+++ b/drivers/adc/ad717x/ad717x.h
@@ -264,7 +264,7 @@ typedef struct {
  */
 typedef struct {
 	/* SPI */
-	no_os_spi_desc		*spi_desc;
+	struct no_os_spi_desc		*spi_desc;
 	/* Device Settings */
 	ad717x_st_reg		*regs;
 	uint8_t			num_regs;
@@ -289,7 +289,7 @@ typedef struct {
 
 typedef struct {
 	/* SPI */
-	no_os_spi_init_param		spi_init;
+	struct no_os_spi_init_param		spi_init;
 	/* Device Settings */
 	ad717x_st_reg		*regs;
 	uint8_t			num_regs;

--- a/drivers/adc/ad719x/ad719x.h
+++ b/drivers/adc/ad719x/ad719x.h
@@ -194,7 +194,7 @@ enum ad719x_chip_id {
 
 struct ad719x_dev {
 	/* SPI */
-	no_os_spi_desc		*spi_desc;
+	struct no_os_spi_desc		*spi_desc;
 	/* GPIO */
 	struct no_os_gpio_desc	*gpio_miso;
 	struct no_os_gpio_desc	*sync_pin;
@@ -212,7 +212,7 @@ struct ad719x_dev {
 
 struct ad719x_init_param {
 	/* SPI */
-	no_os_spi_init_param		*spi_init;
+	struct no_os_spi_init_param		*spi_init;
 	/* GPIO */
 	struct no_os_gpio_init_param	*gpio_miso;
 	/* Optional GPIO pin - only for multiple devices */

--- a/drivers/adc/ad7280a/ad7280a.h
+++ b/drivers/adc/ad7280a/ad7280a.h
@@ -170,7 +170,7 @@
 /******************************************************************************/
 struct ad7280a_dev {
 	/* SPI */
-	no_os_spi_desc		*spi_desc;
+	struct no_os_spi_desc		*spi_desc;
 	/* GPIO */
 	struct no_os_gpio_desc	*gpio_pd;
 	struct no_os_gpio_desc	*gpio_cnvst;
@@ -183,7 +183,7 @@ struct ad7280a_dev {
 
 struct ad7280a_init_param {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/* GPIO */
 	struct no_os_gpio_init_param	gpio_pd;
 	struct no_os_gpio_init_param	gpio_cnvst;

--- a/drivers/adc/ad738x/ad738x.h
+++ b/drivers/adc/ad738x/ad738x.h
@@ -154,7 +154,7 @@ enum ad738x_ref_sel {
 
 struct ad738x_dev {
 	/* SPI */
-	no_os_spi_desc		*spi_desc;
+	struct no_os_spi_desc		*spi_desc;
 #if !defined(USE_STANDARD_SPI)
 	/** SPI module offload init */
 	struct spi_engine_offload_init_param *offload_init_param;
@@ -169,7 +169,7 @@ struct ad738x_dev {
 
 struct ad738x_init_param {
 	/* SPI */
-	no_os_spi_init_param		*spi_param;
+	struct no_os_spi_init_param		*spi_param;
 #if !defined(USE_STANDARD_SPI)
 	/** SPI module offload init */
 	struct spi_engine_offload_init_param *offload_init_param;

--- a/drivers/adc/ad74xx/ad74xx.h
+++ b/drivers/adc/ad74xx/ad74xx.h
@@ -78,7 +78,7 @@ enum ad74xx_type {
 
 struct ad74xx_dev {
 	/* SPI */
-	no_os_spi_desc		*spi_desc;
+	struct no_os_spi_desc		*spi_desc;
 	/* GPIO */
 	struct no_os_gpio_desc	*gpio_cs;
 	/* Device Settings */
@@ -88,7 +88,7 @@ struct ad74xx_dev {
 
 struct ad74xx_init_param {
 	/* SPI */
-	no_os_spi_init_param		spi_init;
+	struct no_os_spi_init_param		spi_init;
 	/* GPIO */
 	struct no_os_gpio_init_param	gpio_cs;
 	/* Device Settings */

--- a/drivers/adc/ad7606/ad7606.h
+++ b/drivers/adc/ad7606/ad7606.h
@@ -270,7 +270,7 @@ struct ad7606_digital_diag {
  */
 struct ad7606_dev {
 	/** SPI descriptor*/
-	no_os_spi_desc *spi_desc;
+	struct no_os_spi_desc *spi_desc;
 	/** RESET GPIO descriptor */
 	struct no_os_gpio_desc *gpio_reset;
 	/** CONVST GPIO descriptor */
@@ -323,7 +323,7 @@ struct ad7606_dev {
  */
 struct ad7606_init_param {
 	/** SPI initialization parameters */
-	no_os_spi_init_param spi_init;
+	struct no_os_spi_init_param spi_init;
 	/** RESET GPIO initialization parameters */
 	struct no_os_gpio_init_param *gpio_reset;
 	/** CONVST GPIO initialization parameters */

--- a/drivers/adc/ad7689/ad7689.h
+++ b/drivers/adc/ad7689/ad7689.h
@@ -155,7 +155,7 @@ struct ad7689_init_param {
 	/** ADC specific parameters */
 	struct ad7689_config config;
 	/** SPI initialization parameters */
-	no_os_spi_init_param spi_init;
+	struct no_os_spi_init_param spi_init;
 };
 
 struct ad7689_dev {
@@ -166,7 +166,7 @@ struct ad7689_dev {
 	/** AD7689 configs (configs[1] - in use, configs[0] - will be in use during next transaction) */
 	struct ad7689_config configs[2];
 	/** SPI descriptor*/
-	no_os_spi_desc *spi_desc;
+	struct no_os_spi_desc *spi_desc;
 };
 
 int32_t ad7689_init(struct ad7689_dev **dev,

--- a/drivers/adc/ad7768-1/ad77681.h
+++ b/drivers/adc/ad7768-1/ad77681.h
@@ -527,7 +527,7 @@ struct ad77681_status_registers {
 
 struct ad77681_dev {
 	/* SPI */
-	no_os_spi_desc			*spi_desc;
+	struct no_os_spi_desc			*spi_desc;
 	/* Configuration */
 	enum ad77681_power_mode		power_mode;
 	enum ad77681_mclk_div		mclk_div;
@@ -553,7 +553,7 @@ struct ad77681_dev {
 
 struct ad77681_init_param {
 	/* SPI */
-	no_os_spi_init_param			spi_eng_dev_init;
+	struct no_os_spi_init_param			spi_eng_dev_init;
 	/* Configuration */
 	enum ad77681_power_mode		power_mode;
 	enum ad77681_mclk_div		mclk_div;

--- a/drivers/adc/ad7768/ad7768.h
+++ b/drivers/adc/ad7768/ad7768.h
@@ -192,7 +192,7 @@ typedef enum {
 } ad7768_dec_rate;
 
 typedef struct {
-	no_os_spi_desc			*spi_desc;
+	struct no_os_spi_desc			*spi_desc;
 	struct no_os_gpio_desc	*gpio_reset;
 	uint8_t			gpio_reset_value;
 	struct no_os_gpio_desc	*gpio_mode0;
@@ -215,7 +215,7 @@ typedef struct {
 
 typedef struct {
 	/* SPI */
-	no_os_spi_init_param			spi_init;
+	struct no_os_spi_init_param			spi_init;
 	/* GPIO */
 	struct no_os_gpio_init_param		gpio_reset;
 	uint8_t				gpio_reset_value;

--- a/drivers/adc/ad7779/ad7779.h
+++ b/drivers/adc/ad7779/ad7779.h
@@ -241,7 +241,7 @@ typedef enum {
 
 typedef struct {
 	/* SPI */
-	no_os_spi_desc		*spi_desc;
+	struct no_os_spi_desc		*spi_desc;
 	/* GPIO */
 	struct no_os_gpio_desc	*gpio_reset;
 	struct no_os_gpio_desc	*gpio_mode0;
@@ -276,7 +276,7 @@ typedef struct {
 
 typedef struct {
 	/* SPI */
-	no_os_spi_init_param		spi_init;
+	struct no_os_spi_init_param		spi_init;
 	/* GPIO */
 	struct no_os_gpio_init_param	gpio_reset;
 	struct no_os_gpio_init_param	gpio_mode0;

--- a/drivers/adc/ad7780/ad7780.h
+++ b/drivers/adc/ad7780/ad7780.h
@@ -96,7 +96,7 @@
 
 struct ad7780_dev {
 	/* SPI */
-	no_os_spi_desc	*spi_desc;
+	struct no_os_spi_desc	*spi_desc;
 	/* GPIO */
 	struct no_os_gpio_desc	*gpio_pdrst;
 	struct no_os_gpio_desc	*gpio_miso;
@@ -106,7 +106,7 @@ struct ad7780_dev {
 
 struct ad7780_init_param {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/* GPIO */
 	struct no_os_gpio_init_param	gpio_pdrst;
 	struct no_os_gpio_init_param	gpio_miso;

--- a/drivers/adc/ad7980/ad7980.h
+++ b/drivers/adc/ad7980/ad7980.h
@@ -61,14 +61,14 @@
 
 struct ad7980_dev {
 	/* SPI */
-	no_os_spi_desc	*spi_desc;
+	struct no_os_spi_desc	*spi_desc;
 	/* GPIO */
 	struct no_os_gpio_desc	*gpio_cs;
 };
 
 struct ad7980_init_param {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/* GPIO */
 	struct no_os_gpio_init_param	gpio_cs;
 };

--- a/drivers/adc/ad9208/ad9208.h
+++ b/drivers/adc/ad9208/ad9208.h
@@ -91,7 +91,7 @@ struct ad9208_ddc {
 
 typedef struct ad9208_dev {
 	/* SPI */
-	no_os_spi_desc *spi_desc;
+	struct no_os_spi_desc *spi_desc;
 	/* GPIO */
 	struct no_os_gpio_desc *gpio_powerdown;
 	struct ad9208_state *st;
@@ -131,7 +131,7 @@ struct ad9208_state {
 
 typedef struct ad9208_init_param {
 	/* SPI */
-	no_os_spi_init_param *spi_init;
+	struct no_os_spi_init_param *spi_init;
 	/* GPIO */
 	struct no_os_gpio_init_param gpio_powerdown;
 	uint64_t sampling_frequency_hz;

--- a/drivers/adc/ad9250/ad9250.h
+++ b/drivers/adc/ad9250/ad9250.h
@@ -519,7 +519,7 @@ enum shadow_registers {
 
 struct ad9250_dev {
 	/* SPI */
-	no_os_spi_desc		*spi_desc;
+	struct no_os_spi_desc		*spi_desc;
 	/* Device Settings */
 	struct ad9250_state ad9250_st;
 	int32_t shadow_regs[SHADOW_REGISTER_COUNT];
@@ -527,7 +527,7 @@ struct ad9250_dev {
 
 struct ad9250_init_param {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/* Device Settings */
 	struct ad9250_state ad9250_st_init;
 };

--- a/drivers/adc/ad9265/ad9265.h
+++ b/drivers/adc/ad9265/ad9265.h
@@ -95,7 +95,7 @@
 /******************************************************************************/
 struct ad9265_init_param {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/* Device Settings */
 	uint8_t		output_mode;
 	uint8_t		dco;			// data clock output
@@ -105,7 +105,7 @@ struct ad9265_init_param {
 
 struct ad9265_dev {
 	/* SPI */
-	no_os_spi_desc *spi_desc;
+	struct no_os_spi_desc *spi_desc;
 };
 
 /******************************************************************************/

--- a/drivers/adc/ad9434/ad9434.h
+++ b/drivers/adc/ad9434/ad9434.h
@@ -97,12 +97,12 @@
 
 struct ad9434_dev {
 	/* SPI */
-	no_os_spi_desc *spi_desc;
+	struct no_os_spi_desc *spi_desc;
 };
 
 struct ad9434_init_param {
 	/* SPI */
-	no_os_spi_init_param spi_init;
+	struct no_os_spi_init_param spi_init;
 };
 
 /******************************************************************************/

--- a/drivers/adc/ad9467/ad9467.h
+++ b/drivers/adc/ad9467/ad9467.h
@@ -130,12 +130,12 @@
 /******************************************************************************/
 struct ad9467_dev {
 	/* SPI */
-	no_os_spi_desc	*spi_desc;
+	struct no_os_spi_desc	*spi_desc;
 };
 
 struct ad9467_init_param {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 };
 
 /******************************************************************************/

--- a/drivers/adc/ad9625/ad9625.h
+++ b/drivers/adc/ad9625/ad9625.h
@@ -83,7 +83,7 @@
 
 struct ad9625_init_param {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/* Device Settings */
 	uint32_t	lane_rate_kbps;
 	uint32_t	test_samples[4];
@@ -91,7 +91,7 @@ struct ad9625_init_param {
 
 struct ad9625_dev {
 	/* SPI */
-	no_os_spi_desc		*spi_desc;
+	struct no_os_spi_desc		*spi_desc;
 };
 
 /******************************************************************************/

--- a/drivers/adc/ad9680/ad9680.h
+++ b/drivers/adc/ad9680/ad9680.h
@@ -82,12 +82,12 @@
 /******************************************************************************/
 struct ad9680_dev {
 	/* SPI */
-	no_os_spi_desc	*spi_desc;
+	struct no_os_spi_desc	*spi_desc;
 };
 
 struct ad9680_init_param {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/* Device Settings */
 	uint32_t	lane_rate_kbps;
 };

--- a/drivers/adc/adaq7980/adaq7980.h
+++ b/drivers/adc/adaq7980/adaq7980.h
@@ -55,7 +55,7 @@
  */
 struct adaq7980_init_param {
 	/* SPI */
-	no_os_spi_init_param		*spi_init;
+	struct no_os_spi_init_param		*spi_init;
 	/* SPI module offload init */
 	struct spi_engine_offload_init_param *offload_init_param;
 	/* PWM generator init structure */
@@ -70,7 +70,7 @@ struct adaq7980_init_param {
  */
 struct adaq7980_dev {
 	/* SPI descriptor */
-	no_os_spi_desc		*spi_desc;
+	struct no_os_spi_desc		*spi_desc;
 	/* Trigger conversion PWM generator descriptor */
 	struct no_os_pwm_desc		*trigger_pwm_desc;
 	/* SPI module offload init */

--- a/drivers/dac/ad5421/ad5421.h
+++ b/drivers/dac/ad5421/ad5421.h
@@ -89,7 +89,7 @@
 
 struct ad5421_dev {
 	/* SPI */
-	no_os_spi_desc		*spi_desc;
+	struct no_os_spi_desc		*spi_desc;
 	/* GPIO */
 	struct no_os_gpio_desc	*gpio_ldac;
 	struct no_os_gpio_desc	*gpio_faultin;
@@ -97,7 +97,7 @@ struct ad5421_dev {
 
 struct ad5421_init_param {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/* GPIO */
 	struct no_os_gpio_init_param	gpio_ldac;
 	struct no_os_gpio_init_param	gpio_faultin;

--- a/drivers/dac/ad5446/ad5446.h
+++ b/drivers/dac/ad5446/ad5446.h
@@ -97,7 +97,7 @@ enum ad5446_type_t {
 
 struct ad5446_dev {
 	/* SPI */
-	no_os_spi_desc		*spi_desc;
+	struct no_os_spi_desc	*spi_desc;
 	/* GPIO */
 	struct no_os_gpio_desc	*gpio_ladc;
 	struct no_os_gpio_desc	*gpio_clrout;
@@ -107,7 +107,7 @@ struct ad5446_dev {
 
 struct ad5446_init_param {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/* GPIO */
 	struct no_os_gpio_init_param	gpio_ladc;
 	struct no_os_gpio_init_param	gpio_clrout;

--- a/drivers/dac/ad5449/ad5449.h
+++ b/drivers/dac/ad5449/ad5449.h
@@ -75,7 +75,7 @@ struct ad5449_chip_info {
 
 struct ad5449_dev {
 	/* SPI */
-	no_os_spi_desc		*spi_desc;
+	struct no_os_spi_desc	*spi_desc;
 	/* GPIO */
 	struct no_os_gpio_desc	*gpio_ldac;
 	struct no_os_gpio_desc	*gpio_clr;
@@ -86,7 +86,7 @@ struct ad5449_dev {
 
 struct ad5449_init_param {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/* GPIO */
 	struct no_os_gpio_init_param	gpio_ldac;
 	struct no_os_gpio_init_param	gpio_clr;

--- a/drivers/dac/ad5628/ad5628.h
+++ b/drivers/dac/ad5628/ad5628.h
@@ -100,12 +100,12 @@
 
 struct ad5628_dev {
 	/* SPI */
-	no_os_spi_desc	*spi_desc;
+	struct no_os_spi_desc	*spi_desc;
 };
 
 struct ad5628_init_param {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 };
 
 /******************************************************************************/

--- a/drivers/dac/ad5629r/ad5629r.h
+++ b/drivers/dac/ad5629r/ad5629r.h
@@ -150,7 +150,7 @@ struct ad5629r_dev {
 	/* I2C */
 	no_os_i2c_desc		*i2c_desc;
 	/* SPI */
-	no_os_spi_desc		*spi_desc;
+	struct no_os_spi_desc		*spi_desc;
 	/* GPIO */
 	struct no_os_gpio_desc	*gpio_ldac;
 	struct no_os_gpio_desc	*gpio_clr;
@@ -162,7 +162,7 @@ struct ad5629r_init_param {
 	/* I2C */
 	no_os_i2c_init_param	i2c_init;
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/* GPIO */
 	struct no_os_gpio_init_param	gpio_ldac;
 	struct no_os_gpio_init_param	gpio_clr;

--- a/drivers/dac/ad5686/ad5686.h
+++ b/drivers/dac/ad5686/ad5686.h
@@ -189,7 +189,7 @@ struct ad5686_dev {
 	/* I2C */
 	no_os_i2c_desc	*i2c_desc;
 	/* SPI */
-	no_os_spi_desc	*spi_desc;
+	struct no_os_spi_desc	*spi_desc;
 	/* GPIO */
 	struct no_os_gpio_desc	*gpio_reset;
 	struct no_os_gpio_desc	*gpio_ldac;
@@ -204,7 +204,7 @@ struct ad5686_init_param {
 	/* I2C */
 	no_os_i2c_init_param	i2c_init;
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/* GPIO */
 	struct no_os_gpio_init_param	gpio_reset;
 	struct no_os_gpio_init_param	gpio_ldac;

--- a/drivers/dac/ad5755/ad5755.h
+++ b/drivers/dac/ad5755/ad5755.h
@@ -338,7 +338,7 @@ enum ad5755_type_t {
 
 struct ad5755_dev {
 	/* SPI */
-	no_os_spi_desc		*spi_desc;
+	struct no_os_spi_desc		*spi_desc;
 	/* GPIO */
 	struct no_os_gpio_desc	*gpio_ldac;
 	struct no_os_gpio_desc	*gpio_rst;
@@ -351,7 +351,7 @@ struct ad5755_dev {
 
 struct ad5755_init_param {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/* GPIO */
 	struct no_os_gpio_init_param	gpio_ldac;
 	struct no_os_gpio_init_param	gpio_rst;

--- a/drivers/dac/ad5761r/ad5761r.h
+++ b/drivers/dac/ad5761r/ad5761r.h
@@ -125,7 +125,7 @@ enum ad5761r_range {
 
 struct ad5761r_dev {
 	/* SPI */
-	no_os_spi_desc	*spi_desc;
+	struct no_os_spi_desc	*spi_desc;
 	/* GPIO */
 	struct no_os_gpio_desc	*gpio_reset;
 	uint8_t		gpio_reset_value;
@@ -147,7 +147,7 @@ struct ad5761r_dev {
 
 struct ad5761r_init_param {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/* GPIO */
 	struct no_os_gpio_init_param	gpio_reset;
 	uint8_t		gpio_reset_value;

--- a/drivers/dac/ad5766/ad5766.h
+++ b/drivers/dac/ad5766/ad5766.h
@@ -140,7 +140,7 @@ enum ad5766_clr {
 
 struct ad5766_dev {
 	/* SPI */
-	no_os_spi_desc		*spi_desc;
+	struct no_os_spi_desc		*spi_desc;
 	/* GPIO */
 	struct no_os_gpio_desc		*gpio_reset;
 	/* Device Settings */
@@ -149,7 +149,7 @@ struct ad5766_dev {
 
 struct ad5766_init_param {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/* GPIO */
 	struct no_os_gpio_init_param	gpio_reset;
 	/* Device Settings */

--- a/drivers/dac/ad5770r/ad5770r.h
+++ b/drivers/dac/ad5770r/ad5770r.h
@@ -297,7 +297,7 @@ struct ad5770r_alarm_cfg {
 
 struct ad5770r_dev {
 	/* SPI */
-	no_os_spi_desc				*spi_desc;
+	struct no_os_spi_desc			*spi_desc;
 	/* GPIO */
 	/** note: the GPIOs are optional */
 	struct no_os_gpio_desc			*gpio_alarm_n;
@@ -323,7 +323,7 @@ struct ad5770r_dev {
 
 struct ad5770r_init_param {
 	/* SPI */
-	no_os_spi_init_param				spi_init;
+	struct no_os_spi_init_param			spi_init;
 	/* GPIO */
 	struct no_os_gpio_init_param			*gpio_alarm_n;
 	struct no_os_gpio_init_param			*gpio_reset_n;

--- a/drivers/dac/ad5791/ad5791.h
+++ b/drivers/dac/ad5791/ad5791.h
@@ -66,7 +66,7 @@ struct ad5791_chip_info {
 
 struct ad5791_dev {
 	/* SPI */
-	no_os_spi_desc		*spi_desc;
+	struct no_os_spi_desc	*spi_desc;
 	/* GPIO */
 	struct no_os_gpio_desc	*gpio_reset;
 	struct no_os_gpio_desc	*gpio_clr;
@@ -77,7 +77,7 @@ struct ad5791_dev {
 
 struct ad5791_init_param {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/* GPIO */
 	struct no_os_gpio_init_param		gpio_reset;
 	struct no_os_gpio_init_param		gpio_clr;

--- a/drivers/dac/ad7303/ad7303.h
+++ b/drivers/dac/ad7303/ad7303.h
@@ -65,12 +65,12 @@
 
 struct ad7303_dev {
 	/* SPI */
-	no_os_spi_desc		*spi_desc;
+	struct no_os_spi_desc		*spi_desc;
 };
 
 struct ad7303_init_param {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 };
 
 /******************************************************************************/

--- a/drivers/dac/ad9144/ad9144.h
+++ b/drivers/dac/ad9144/ad9144.h
@@ -1362,7 +1362,7 @@
 /******************************************************************************/
 struct ad9144_dev {
 	/* SPI */
-	no_os_spi_desc *spi_desc;
+	struct no_os_spi_desc *spi_desc;
 
 	uint32_t sample_rate_khz;
 	uint8_t num_converters;
@@ -1371,7 +1371,7 @@ struct ad9144_dev {
 
 struct ad9144_init_param {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/* Device Settings */
 	uint8_t		spi3wire; // set device spi intereface 3/4 wires
 	uint8_t		interpolation; // interpolation factor

--- a/drivers/dac/ad9152/ad9152.h
+++ b/drivers/dac/ad9152/ad9152.h
@@ -1346,7 +1346,7 @@
 
 struct ad9152_init_param {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/* Device Settings */
 	uint32_t stpl_samples[2][4];
 	uint32_t interpolation;
@@ -1356,7 +1356,7 @@ struct ad9152_init_param {
 
 struct ad9152_dev {
 	/* SPI */
-	no_os_spi_desc *spi_desc;
+	struct no_os_spi_desc *spi_desc;
 };
 
 /******************************************************************************/

--- a/drivers/dac/ad917x/ad9172.h
+++ b/drivers/dac/ad917x/ad9172.h
@@ -46,7 +46,7 @@
 
 typedef struct ad9172_dev {
 	/* SPI */
-	no_os_spi_desc		*spi_desc;
+	struct no_os_spi_desc		*spi_desc;
 	/* GPIO */
 	struct no_os_gpio_desc	*gpio_reset;
 	struct no_os_gpio_desc	*gpio_txen0;
@@ -84,7 +84,7 @@ struct ad9172_state {
 
 typedef struct ad9172_init_param {
 	/* SPI */
-	no_os_spi_init_param *spi_init;
+	struct no_os_spi_init_param *spi_init;
 	/* GPIO */
 	struct no_os_gpio_init_param gpio_txen0;
 	struct no_os_gpio_init_param gpio_txen1;

--- a/drivers/dac/ad9739a/ad9739a.h
+++ b/drivers/dac/ad9739a/ad9739a.h
@@ -218,7 +218,7 @@
 
 struct ad9739a_dev {
 	/* SPI */
-	no_os_spi_desc *spi_desc;
+	struct no_os_spi_desc *spi_desc;
 };
 
 /**
@@ -227,7 +227,7 @@ struct ad9739a_dev {
  */
 struct ad9739a_init_param {
 	/** SPI Initialization parameters */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/** magnitude of the offset for the DACCLK_P. */
 	uint8_t		common_mode_voltage_dacclk_p;
 	/** magnitude of the offset for the DACCLK_N. */

--- a/drivers/dac/ltc268x/ltc268x.h
+++ b/drivers/dac/ltc268x/ltc268x.h
@@ -139,7 +139,7 @@ enum ltc268x_device_id {
 };
 
 struct ltc268x_dev {
-	no_os_spi_desc			*spi_desc;
+	struct no_os_spi_desc			*spi_desc;
 	enum ltc268x_device_id   dev_id;
 	uint16_t			pwd_dac_setting;
 	uint16_t			dither_toggle_en;
@@ -155,7 +155,7 @@ struct ltc268x_dev {
 
 struct ltc268x_init_param {
 	/* SPI */
-	no_os_spi_init_param 			spi_init;
+	struct no_os_spi_init_param 			spi_init;
 	enum ltc268x_device_id          dev_id;
 	uint16_t			pwd_dac_setting;
 	uint16_t			dither_toggle_en;

--- a/drivers/frequency/ad9517/ad9517.h
+++ b/drivers/frequency/ad9517/ad9517.h
@@ -393,7 +393,7 @@ struct ad9517_state {
 
 struct ad9517_dev {
 	/* SPI */
-	no_os_spi_desc	    *spi_desc;
+	struct no_os_spi_desc	    *spi_desc;
 	/* Device Settings */
 	struct ad9517_state ad9517_st;
 	enum ad9517_type	ad9517_type;
@@ -401,7 +401,7 @@ struct ad9517_dev {
 
 struct ad9517_init_param {
 	/* SPI */
-	no_os_spi_init_param	    spi_init;
+	struct no_os_spi_init_param    spi_init;
 	/* Device Settings */
 	struct ad9517_state ad9517_st;
 	enum ad9517_type	ad9517_type;

--- a/drivers/frequency/ad9523/ad9523.h
+++ b/drivers/frequency/ad9523/ad9523.h
@@ -476,7 +476,7 @@ enum ad9523_out_frequencies {
 
 struct ad9523_dev {
 	/* SPI */
-	no_os_spi_desc			*spi_desc;
+	struct no_os_spi_desc		*spi_desc;
 	/* Device Settings */
 	struct ad9523_state		ad9523_st;
 	struct ad9523_platform_data	*pdata;
@@ -484,7 +484,7 @@ struct ad9523_dev {
 
 struct ad9523_init_param {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/* Device Settings */
 	struct ad9523_platform_data	*pdata;
 };

--- a/drivers/frequency/ad9833/ad9833.h
+++ b/drivers/frequency/ad9833/ad9833.h
@@ -114,7 +114,7 @@ enum ad9833_type {
 
 struct ad9833_dev {
 	/* SPI */
-	no_os_spi_desc			*spi_desc;
+	struct no_os_spi_desc		*spi_desc;
 	/* GPIO */
 	struct no_os_gpio_desc		*gpio_psel;
 	struct no_os_gpio_desc		*gpio_fsel;
@@ -129,7 +129,7 @@ struct ad9833_dev {
 
 struct ad9833_init_param {
 	/* SPI */
-	no_os_spi_init_param			spi_init;
+	struct no_os_spi_init_param		spi_init;
 	/* GPIO */
 	struct no_os_gpio_init_param		gpio_psel;
 	struct no_os_gpio_init_param		gpio_fsel;

--- a/drivers/frequency/adf4106/adf4106.h
+++ b/drivers/frequency/adf4106/adf4106.h
@@ -348,7 +348,7 @@ struct adf4106_chip_info {
 
 struct adf4106_dev {
 	/* SPI */
-	no_os_spi_desc		*spi_desc;
+	struct no_os_spi_desc		*spi_desc;
 	/* GPIO */
 	struct no_os_gpio_desc	*gpio_le;
 	struct no_os_gpio_desc	*gpio_ce;
@@ -367,7 +367,7 @@ struct adf4106_dev {
 
 struct adf4106_init_param {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/* GPIO */
 	struct no_os_gpio_init_param		gpio_le;
 	struct no_os_gpio_init_param		gpio_ce;

--- a/drivers/frequency/adf4153/adf4153.h
+++ b/drivers/frequency/adf4153/adf4153.h
@@ -333,7 +333,7 @@ struct adf4153_settings_t {
 
 struct adf4153_dev {
 	/* SPI */
-	no_os_spi_desc		*spi_desc;
+	struct no_os_spi_desc	*spi_desc;
 	/* GPIO */
 	struct no_os_gpio_desc	*gpio_le;
 	struct no_os_gpio_desc	*gpio_ce;
@@ -361,7 +361,7 @@ struct adf4153_dev {
 
 struct adf4153_init_param {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/* GPIO */
 	struct no_os_gpio_init_param	gpio_le;
 	struct no_os_gpio_init_param	gpio_ce;

--- a/drivers/frequency/adf4156/adf4156.h
+++ b/drivers/frequency/adf4156/adf4156.h
@@ -209,7 +209,7 @@ struct adf4156_state {
 
 struct adf4156_dev {
 	/* SPI */
-	no_os_spi_desc		*spi_desc;
+	struct no_os_spi_desc		*spi_desc;
 	/* GPIO */
 	struct no_os_gpio_desc	*gpio_le;
 	struct no_os_gpio_desc	*gpio_ce;
@@ -219,7 +219,7 @@ struct adf4156_dev {
 
 struct adf4156_init_param {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/* GPIO */
 	struct no_os_gpio_init_param	gpio_le;
 	struct no_os_gpio_init_param	gpio_ce;

--- a/drivers/frequency/adf4157/adf4157.h
+++ b/drivers/frequency/adf4157/adf4157.h
@@ -203,7 +203,7 @@ struct adf4157_state {
 
 struct adf4157_dev {
 	/* SPI */
-	no_os_spi_desc	*spi_desc;
+	struct no_os_spi_desc	*spi_desc;
 	/* GPIO */
 	struct no_os_gpio_desc	*gpio_le;
 	struct no_os_gpio_desc	*gpio_ce;
@@ -213,7 +213,7 @@ struct adf4157_dev {
 
 struct adf4157_init_param {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/* GPIO */
 	struct no_os_gpio_init_param	gpio_le;
 	struct no_os_gpio_init_param	gpio_ce;

--- a/drivers/frequency/adf4350/adf4350.h
+++ b/drivers/frequency/adf4350/adf4350.h
@@ -146,7 +146,7 @@ struct adf4350_platform_data {
 
 typedef struct {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 
 	/* Device settings */
 	uint32_t	clkin;
@@ -181,7 +181,7 @@ typedef struct {
 } adf4350_init_param;
 
 typedef struct {
-	no_os_spi_desc	*spi_desc;
+	struct no_os_spi_desc	*spi_desc;
 	struct adf4350_platform_data *pdata;
 	uint32_t	clkin;
 	uint32_t	chspc;	/* Channel Spacing */

--- a/drivers/frequency/adf4371/adf4371.h
+++ b/drivers/frequency/adf4371/adf4371.h
@@ -64,7 +64,7 @@ struct adf4371_chan_spec {
 };
 
 struct adf4371_dev {
-	no_os_spi_desc	*spi_desc;
+	struct no_os_spi_desc	*spi_desc;
 	bool		spi_3wire_en;
 	uint32_t	num_channels;
 	struct adf4371_channel_config	channel_cfg[4];
@@ -87,7 +87,7 @@ struct adf4371_dev {
 };
 
 struct adf4371_init_param {
-	no_os_spi_init_param	*spi_init;
+	struct no_os_spi_init_param	*spi_init;
 	bool		spi_3wire_enable;
 	uint32_t	clkin_frequency;
 	bool		differential_ref_clock;

--- a/drivers/frequency/adf5355/adf5355.h
+++ b/drivers/frequency/adf5355/adf5355.h
@@ -208,7 +208,7 @@ enum adf5355_mux_out_sel {
  * @brief  Device descriptor.
  */
 struct adf5355_dev {
-	no_os_spi_desc	*spi_desc;
+	struct no_os_spi_desc	*spi_desc;
 	enum adf5355_device_id      dev_id;
 	bool                        all_synced;
 	uint32_t                    regs[ADF5355_REG_NUM];
@@ -249,7 +249,7 @@ struct adf5355_dev {
  * @brief  Structure containing the initialization parameters.
  */
 struct adf5355_init_param {
-	no_os_spi_init_param	*spi_init;
+	struct no_os_spi_init_param	*spi_init;
 	enum adf5355_device_id      dev_id;
 	uint64_t                    freq_req;
 	uint8_t                     freq_req_chan;

--- a/drivers/frequency/hmc7044/hmc7044.h
+++ b/drivers/frequency/hmc7044/hmc7044.h
@@ -67,7 +67,7 @@ struct hmc7044_chan_spec {
 };
 
 struct hmc7044_dev {
-	no_os_spi_desc	*spi_desc;
+	struct no_os_spi_desc	*spi_desc;
 	bool		is_hmc7043;
 	uint32_t	clkin_freq[4];
 	uint32_t	clkin_freq_ccf[4];
@@ -91,7 +91,7 @@ struct hmc7044_dev {
 };
 
 struct hmc7044_init_param {
-	no_os_spi_init_param	*spi_init;
+	struct no_os_spi_init_param	*spi_init;
 	bool		is_hmc7043;
 	uint32_t	clkin_freq[4];
 	uint32_t	clkin_freq_ccf[4];

--- a/drivers/gyro/adxrs453/adxrs453.h
+++ b/drivers/gyro/adxrs453/adxrs453.h
@@ -69,12 +69,12 @@
 
 struct adxrs453_dev {
 	/* SPI */
-	no_os_spi_desc	*spi_desc;
+	struct no_os_spi_desc	*spi_desc;
 };
 
 struct adxrs453_init_param {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 };
 
 /******************************************************************************/

--- a/drivers/mux/adgs1408/adgs1408.h
+++ b/drivers/mux/adgs1408/adgs1408.h
@@ -154,7 +154,7 @@ struct adgs1408_rrobin_config {
 
 struct adgs1408_dev {
 	/* SPI */
-	no_os_spi_desc	*spi_desc;
+	struct no_os_spi_desc	*spi_desc;
 	/* Device Settings */
 	enum adgs1408_state	crc_en;
 	enum adgs1408_state	burst_mode_en;
@@ -166,7 +166,7 @@ struct adgs1408_dev {
 
 struct adgs1408_init_param {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/* Device Settings */
 	enum adgs1408_state	crc_en;
 	enum adgs1408_state	burst_mode_en;

--- a/drivers/mux/adgs5412/adgs5412.h
+++ b/drivers/mux/adgs5412/adgs5412.h
@@ -107,7 +107,7 @@ typedef enum {
 
 typedef struct {
 	/* SPI */
-	no_os_spi_desc	*spi_desc;
+	struct no_os_spi_desc	*spi_desc;
 	/* Device Settings */
 	adgs5412_state	crc_en;
 	adgs5412_state	burst_mode_en;
@@ -116,7 +116,7 @@ typedef struct {
 
 typedef struct {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/* Device Settings */
 	adgs5412_state	crc_en;
 	adgs5412_state	burst_mode_en;

--- a/drivers/platform/altera/altera_spi.c
+++ b/drivers/platform/altera/altera_spi.c
@@ -61,7 +61,7 @@
 int32_t altera_spi_init(struct no_os_spi_desc **desc,
 			const struct no_os_spi_init_param *param)
 {
-	no_os_spi_desc *descriptor;
+	struct no_os_spi_desc *descriptor;
 	struct altera_spi_desc *altera_descriptor;
 	struct altera_spi_init_param *altera_param;
 

--- a/drivers/potentiometer/ad525x/ad525x.h
+++ b/drivers/potentiometer/ad525x/ad525x.h
@@ -174,7 +174,7 @@ struct ad525x_dev {
 	/* I2C */
 	no_os_i2c_desc	*i2c_desc;
 	/* SPI */
-	no_os_spi_desc	*spi_desc;
+	struct no_os_spi_desc	*spi_desc;
 	/* GPIO */
 	struct no_os_gpio_desc	*gpio_reset;
 	struct no_os_gpio_desc	*gpio_shutdown;
@@ -188,7 +188,7 @@ struct ad525x_init_param {
 	/* I2C */
 	no_os_i2c_init_param	i2c_init;
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/* GPIO */
 	struct no_os_gpio_init_param	gpio_reset;
 	struct no_os_gpio_init_param	gpio_shutdown;

--- a/drivers/rf-transceiver/adf7023/adf7023.h
+++ b/drivers/rf-transceiver/adf7023/adf7023.h
@@ -375,7 +375,7 @@ struct adf7023_bbram {
 
 struct adf7023_dev {
 	/* SPI */
-	no_os_spi_desc		*spi_desc;
+	struct no_os_spi_desc		*spi_desc;
 	/* GPIO */
 	struct no_os_gpio_desc	*gpio_cs;
 	struct no_os_gpio_desc	*gpio_miso;
@@ -385,7 +385,7 @@ struct adf7023_dev {
 
 struct adf7023_init_param {
 	/* SPI */
-	no_os_spi_init_param	spi_init;
+	struct no_os_spi_init_param	spi_init;
 	/* GPIO */
 	struct no_os_gpio_init_param	gpio_cs;
 	struct no_os_gpio_init_param	gpio_miso;

--- a/drivers/temperature/adt7420/adt7420.h
+++ b/drivers/temperature/adt7420/adt7420.h
@@ -146,7 +146,7 @@ struct adt7420_dev {
 	/* I2C */
 	no_os_i2c_desc	*i2c_desc;
 	/* SPI */
-	no_os_spi_desc	*spi_desc;
+	struct no_os_spi_desc	*spi_desc;
 	/* Device Settings */
 	enum adt7420_type active_device;
 	/* Device Settings */
@@ -159,7 +159,7 @@ struct adt7420_init_param {
 		/* I2C */
 		no_os_i2c_init_param	i2c_init;
 		/* SPI */
-		no_os_spi_init_param	spi_init;
+		struct no_os_spi_init_param	spi_init;
 	} interface_init;
 	/* Device Settings */
 	uint8_t		resolution_setting;

--- a/include/no_os_spi.h
+++ b/include/no_os_spi.h
@@ -61,7 +61,7 @@
  * @enum no_os_spi_mode
  * @brief SPI configuration for clock phase and polarity.
  */
-typedef enum no_os_spi_mode {
+enum no_os_spi_mode {
 	/** Data on rising, shift out on falling */
 	NO_OS_SPI_MODE_0 = (0 | 0),
 	/** Data on falling, shift out on rising */
@@ -70,18 +70,18 @@ typedef enum no_os_spi_mode {
 	NO_OS_SPI_MODE_2 = (NO_OS_SPI_CPOL | 0),
 	/** Data on rising, shift out on falling */
 	NO_OS_SPI_MODE_3 = (NO_OS_SPI_CPOL | NO_OS_SPI_CPHA)
-} no_os_spi_mode;
+};
 
 /**
  * @enum no_os_spi_bit_order
  * @brief SPI configuration for bit order (MSB/LSB).
  */
-typedef enum no_os_spi_bit_order {
+enum no_os_spi_bit_order {
 	/** Most-significant bit (MSB) first */
 	NO_OS_SPI_BIT_ORDER_MSB_FIRST = 0,
 	/** Least-significant bit (LSB) first */
 	NO_OS_SPI_BIT_ORDER_LSB_FIRST = 1,
-} no_os_spi_bit_order;
+};
 
 /**
  * @struct no_os_spi_msg_list
@@ -109,7 +109,7 @@ struct no_os_spi_platform_ops ;
  * @struct no_os_spi_init_param
  * @brief Structure holding the parameters for SPI initialization
  */
-typedef struct no_os_spi_init_param {
+struct no_os_spi_init_param {
 	/** Device ID */
 	uint32_t	device_id;
 	/** maximum transfer speed */
@@ -123,13 +123,13 @@ typedef struct no_os_spi_init_param {
 	const struct no_os_spi_platform_ops *platform_ops;
 	/**  SPI extra parameters (device specific) */
 	void		*extra;
-} no_os_spi_init_param;
+};
 
 /**
  * @struct no_os_spi_desc
  * @brief Structure holding SPI descriptor.
  */
-typedef struct no_os_spi_desc {
+struct no_os_spi_desc {
 	/** Device ID */
 	uint32_t	device_id;
 	/** maximum transfer speed */
@@ -143,7 +143,7 @@ typedef struct no_os_spi_desc {
 	const struct no_os_spi_platform_ops *platform_ops;
 	/**  SPI extra parameters (device specific) */
 	void		*extra;
-} no_os_spi_desc;
+};
 
 /**
  * @struct no_os_spi_platform_ops


### PR DESCRIPTION
Typedefs are no longer supported on the no-os repository. Adjust drivers
accordingly.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>