### PR TITLE
include: no_os_i2c: remove typedefs

### DIFF
--- a/drivers/accel/adxl313/adxl313.h
+++ b/drivers/accel/adxl313/adxl313.h
@@ -382,7 +382,7 @@ enum bit_action {
  */
 union adxl313_comm_init_param {
 	/** I2C Initialization structure. */
-	no_os_i2c_init_param i2c_init;
+	struct no_os_i2c_init_param i2c_init;
 	/** SPI Initialization structure. */
 	struct no_os_spi_init_param spi_init;
 } ;
@@ -482,7 +482,7 @@ union adxl313_act_inact_ctl_flags {
  */
 union adxl313_comm_desc {
 	/** I2C Descriptor */
-	no_os_i2c_desc *i2c_desc;
+	struct no_os_i2c_desc *i2c_desc;
 	/** SPI Descriptor */
 	struct no_os_spi_desc *spi_desc;
 };

--- a/drivers/accel/adxl345/adxl345.h
+++ b/drivers/accel/adxl345/adxl345.h
@@ -186,7 +186,7 @@
  */
 struct adxl345_dev {
 	/** I2C Descriptor */
-	no_os_i2c_desc	*i2c_desc;
+	struct no_os_i2c_desc	*i2c_desc;
 	/** SPI Descriptor */
 	struct no_os_spi_desc	*spi_desc;
 	/** Device Communication type: ADXL345_SPI_COMM, ADXL345_I2C_COMM */
@@ -203,7 +203,7 @@ struct adxl345_dev {
  */
 struct adxl345_init_param {
 	/** I2C Initialization structure. */
-	no_os_i2c_init_param	i2c_init;
+	struct no_os_i2c_init_param	i2c_init;
 	/** SPI Initialization structure. */
 	struct no_os_spi_init_param	spi_init;
 	/** Device Communication type: ADXL345_SPI_COMM, ADXL345_I2C_COMM */

--- a/drivers/accel/adxl355/adxl355.h
+++ b/drivers/accel/adxl355/adxl355.h
@@ -182,7 +182,7 @@ enum adxl355_int_pol {
 
 union adxl355_comm_init_param {
 	/** I2C Initialization structure. */
-	no_os_i2c_init_param i2c_init;
+	struct no_os_i2c_init_param i2c_init;
 	/** SPI Initialization structure. */
 	struct no_os_spi_init_param spi_init;
 } ;
@@ -247,7 +247,7 @@ struct adxl355_frac_repr {
 
 union adxl355_comm_desc {
 	/** I2C Descriptor */
-	no_os_i2c_desc *i2c_desc;
+	struct no_os_i2c_desc *i2c_desc;
 	/** SPI Descriptor */
 	struct no_os_spi_desc *spi_desc;
 };

--- a/drivers/accel/adxl367/adxl367.h
+++ b/drivers/accel/adxl367/adxl367.h
@@ -433,7 +433,7 @@ struct adxl367_dev {
 	/** SPI Descriptor */
 	struct no_os_spi_desc		*spi_desc;
 	/** I2C Descriptor */
-	no_os_i2c_desc  		*i2c_desc;
+	struct no_os_i2c_desc  		*i2c_desc;
 	/** Depending on ASEL pin, can be 0x53 or 0x1D. Only for I2C Comm. */
 	uint8_t i2c_slave_address;
 	/** Measurement Range: */
@@ -460,7 +460,7 @@ struct adxl367_init_param {
 	/** SPI Initialization structure. */
 	struct no_os_spi_init_param	spi_init;
 	/** I2C Initialization structure. */
-	no_os_i2c_init_param    	i2c_init;
+	struct no_os_i2c_init_param    	i2c_init;
 	/** Depending on ASEL pin, can be 0x53 or 0x1D. Only for I2C Comm. */
 	uint8_t 			i2c_slave_address;
 };

--- a/drivers/accel/adxl372/adxl372.h
+++ b/drivers/accel/adxl372/adxl372.h
@@ -369,7 +369,7 @@ struct adxl372_dev {
 	/* SPI */
 	struct no_os_spi_desc		*spi_desc;
 	/* I2C */
-	no_os_i2c_desc			*i2c_desc;
+	struct no_os_i2c_desc			*i2c_desc;
 	/* GPIO */
 	struct no_os_gpio_desc		*gpio_int1;
 	struct no_os_gpio_desc		*gpio_int2;
@@ -390,7 +390,7 @@ struct adxl372_init_param {
 	/* SPI */
 	struct no_os_spi_init_param		spi_init;
 	/* I2C */
-	no_os_i2c_init_param			i2c_init;
+	struct no_os_i2c_init_param			i2c_init;
 	/* GPIO */
 	struct no_os_gpio_init_param			gpio_int1;
 	struct no_os_gpio_init_param			gpio_int2;

--- a/drivers/adc-dac/ad5592r/ad5592r-base.h
+++ b/drivers/adc-dac/ad5592r/ad5592r-base.h
@@ -120,7 +120,7 @@ struct ad5592r_init_param {
 
 struct ad5592r_dev {
 	const struct ad5592r_rw_ops *ops;
-	no_os_i2c_desc *i2c;
+	struct no_os_i2c_desc *i2c;
 	struct no_os_spi_desc *spi;
 	uint16_t spi_msg;
 	uint8_t num_channels;

--- a/drivers/adc/ad7091r5/ad7091r5.h
+++ b/drivers/adc/ad7091r5/ad7091r5.h
@@ -203,7 +203,7 @@ enum ad7091r5_limit {
  */
 struct ad7091r5_init_param {
 	/* I2C */
-	no_os_i2c_init_param		*i2c_init;
+	struct no_os_i2c_init_param		*i2c_init;
 	/** RESET GPIO initialization structure. */
 	struct no_os_gpio_init_param	*gpio_resetn;
 };

--- a/drivers/adc/ad799x/ad799x.h
+++ b/drivers/adc/ad799x/ad799x.h
@@ -70,14 +70,14 @@ enum ad799x_type {
 
 struct ad799x_dev {
 	/* I2C */
-	no_os_i2c_desc	*i2c_desc;
+	struct no_os_i2c_desc	*i2c_desc;
 	/* Device Settings */
 	uint8_t         bits_number;
 };
 
 struct ad799x_init_param {
 	/* I2C */
-	no_os_i2c_init_param		i2c_init;
+	struct no_os_i2c_init_param		i2c_init;
 	/* Device Settings */
 	enum ad799x_type	part_number;
 };

--- a/drivers/cdc/ad7156/ad7156.h
+++ b/drivers/cdc/ad7156/ad7156.h
@@ -155,7 +155,7 @@
 
 struct ad7156_dev {
 	/* I2C */
-	no_os_i2c_desc	*i2c_desc;
+	struct no_os_i2c_desc	*i2c_desc;
 	/* Device Settings */
 	float ad7156_channel1_range;
 	float ad7156_channel2_range;
@@ -163,7 +163,7 @@ struct ad7156_dev {
 
 struct ad7156_init_param {
 	/* I2C */
-	no_os_i2c_init_param	i2c_init;
+	struct no_os_i2c_init_param	i2c_init;
 	/* Device Settings */
 	float ad7156_channel1_range;
 	float ad7156_channel2_range;

--- a/drivers/cdc/ad7746/ad7746.h
+++ b/drivers/cdc/ad7746/ad7746.h
@@ -187,7 +187,7 @@ struct ad7746_init_param {
 };
 
 struct ad7746_dev {
-	no_os_i2c_desc *i2c_dev;
+	struct no_os_i2c_desc *i2c_dev;
 	enum ad7746_id id;
 	uint8_t buf[AD7746_NUM_REGISTERS + 1u];
 	struct ad7746_setup setup;

--- a/drivers/dac/ad5629r/ad5629r.h
+++ b/drivers/dac/ad5629r/ad5629r.h
@@ -148,7 +148,7 @@ struct ad5629r_chip_info {
 
 struct ad5629r_dev {
 	/* I2C */
-	no_os_i2c_desc		*i2c_desc;
+	struct no_os_i2c_desc		*i2c_desc;
 	/* SPI */
 	struct no_os_spi_desc		*spi_desc;
 	/* GPIO */
@@ -160,7 +160,7 @@ struct ad5629r_dev {
 
 struct ad5629r_init_param {
 	/* I2C */
-	no_os_i2c_init_param	i2c_init;
+	struct no_os_i2c_init_param	i2c_init;
 	/* SPI */
 	struct no_os_spi_init_param	spi_init;
 	/* GPIO */

--- a/drivers/dac/ad5686/ad5686.h
+++ b/drivers/dac/ad5686/ad5686.h
@@ -187,7 +187,7 @@ struct ad5686_chip_info {
 
 struct ad5686_dev {
 	/* I2C */
-	no_os_i2c_desc	*i2c_desc;
+	struct no_os_i2c_desc	*i2c_desc;
 	/* SPI */
 	struct no_os_spi_desc	*spi_desc;
 	/* GPIO */
@@ -202,7 +202,7 @@ struct ad5686_dev {
 
 struct ad5686_init_param {
 	/* I2C */
-	no_os_i2c_init_param	i2c_init;
+	struct no_os_i2c_init_param	i2c_init;
 	/* SPI */
 	struct no_os_spi_init_param	spi_init;
 	/* GPIO */

--- a/drivers/impedance-analyzer/ad5933/ad5933.h
+++ b/drivers/impedance-analyzer/ad5933/ad5933.h
@@ -122,7 +122,7 @@
 
 struct ad5933_dev {
 	/* I2C */
-	no_os_i2c_desc	*i2c_desc;
+	struct no_os_i2c_desc	*i2c_desc;
 	/* Device Settings */
 	uint32_t current_sys_clk;
 	uint8_t current_clock_source;
@@ -132,7 +132,7 @@ struct ad5933_dev {
 
 struct ad5933_init_param {
 	/* I2C */
-	no_os_i2c_init_param	i2c_init;
+	struct no_os_i2c_init_param	i2c_init;
 	/* Device Settings */
 	uint32_t current_sys_clk;
 	uint8_t current_clock_source;

--- a/drivers/io-expander/adp5589/adp5589.h
+++ b/drivers/io-expander/adp5589/adp5589.h
@@ -333,12 +333,12 @@
 
 struct adp5589_dev {
 	/* I2C */
-	no_os_i2c_desc	*i2c_desc;
+	struct no_os_i2c_desc	*i2c_desc;
 };
 
 struct adp5589_init_param {
 	/* I2C */
-	no_os_i2c_init_param	i2c_init;
+	struct no_os_i2c_init_param	i2c_init;
 };
 
 

--- a/drivers/platform/xilinx/xilinx_i2c.c
+++ b/drivers/platform/xilinx/xilinx_i2c.c
@@ -161,7 +161,7 @@ int32_t xil_i2c_init(struct no_os_i2c_desc **desc,
 		     const struct no_os_i2c_init_param *param)
 {
 	int32_t		ret;
-	no_os_i2c_desc	*idesc;
+	struct no_os_i2c_desc	*idesc;
 	xil_i2c_desc	*xdesc;
 	xil_i2c_init_param	*xinit;
 

--- a/drivers/potentiometer/ad5110/ad5110.h
+++ b/drivers/potentiometer/ad5110/ad5110.h
@@ -72,14 +72,14 @@
 /******************************************************************************/
 struct ad5110_dev {
 	/* I2C */
-	no_os_i2c_desc	*i2c_desc;
+	struct no_os_i2c_desc	*i2c_desc;
 	/* Device Settings */
 	uint8_t ad5110_dev_addr;
 };
 
 struct ad5110_init_param {
 	/* I2C */
-	no_os_i2c_init_param	i2c_init;
+	struct no_os_i2c_init_param	i2c_init;
 	/* Device Settings */
 	uint8_t ad5110_dev_addr;
 };

--- a/drivers/potentiometer/ad525x/ad525x.h
+++ b/drivers/potentiometer/ad525x/ad525x.h
@@ -172,7 +172,7 @@ struct ad525x_chip_info {
 
 struct ad525x_dev {
 	/* I2C */
-	no_os_i2c_desc	*i2c_desc;
+	struct no_os_i2c_desc	*i2c_desc;
 	/* SPI */
 	struct no_os_spi_desc	*spi_desc;
 	/* GPIO */
@@ -186,7 +186,7 @@ struct ad525x_dev {
 
 struct ad525x_init_param {
 	/* I2C */
-	no_os_i2c_init_param	i2c_init;
+	struct no_os_i2c_init_param	i2c_init;
 	/* SPI */
 	struct no_os_spi_init_param	spi_init;
 	/* GPIO */

--- a/drivers/temperature/adt7420/adt7420.h
+++ b/drivers/temperature/adt7420/adt7420.h
@@ -144,7 +144,7 @@ enum adt7420_type {
 
 struct adt7420_dev {
 	/* I2C */
-	no_os_i2c_desc	*i2c_desc;
+	struct no_os_i2c_desc	*i2c_desc;
 	/* SPI */
 	struct no_os_spi_desc	*spi_desc;
 	/* Device Settings */
@@ -157,7 +157,7 @@ struct adt7420_dev {
 struct adt7420_init_param {
 	union interface_type {
 		/* I2C */
-		no_os_i2c_init_param	i2c_init;
+		struct no_os_i2c_init_param	i2c_init;
 		/* SPI */
 		struct no_os_spi_init_param	spi_init;
 	} interface_init;

--- a/include/no_os_i2c.h
+++ b/include/no_os_i2c.h
@@ -61,7 +61,7 @@ struct no_os_i2c_platform_ops ;
  * @struct no_os_i2c_init_param
  * @brief Structure holding the parameters for I2C initialization.
  */
-typedef struct no_os_i2c_init_param {
+struct no_os_i2c_init_param {
 	/** Device ID */
 	uint32_t	device_id;
 	/** I2C maximum transfer speed supported */
@@ -72,13 +72,13 @@ typedef struct no_os_i2c_init_param {
 	const struct no_os_i2c_platform_ops *platform_ops;
 	/** I2C extra parameters (device specific parameters) */
 	void		*extra;
-} no_os_i2c_init_param;
+};
 
 /**
  * @struct no_os_i2c_desc
  * @brief Structure holding I2C descriptor
  */
-typedef struct no_os_i2c_desc {
+struct no_os_i2c_desc {
 	/** Device ID */
 	uint32_t	device_id;
 	/** I2C maximum transfer speed supported */
@@ -89,7 +89,7 @@ typedef struct no_os_i2c_desc {
 	const struct no_os_i2c_platform_ops *platform_ops;
 	/** I2C extra parameters (device specific parameters) */
 	void		*extra;
-} no_os_i2c_desc;
+};
 
 /**
  * @struct no_os_i2c_platform_ops


### PR DESCRIPTION
Typedefs are no longer supported on the no-os repository.
Adjust drivers accordingly.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>