### PR TITLE
ADUCM3029 platform set irq priority

### DIFF
--- a/drivers/platform/aducm3029/aducm3029_irq.c
+++ b/drivers/platform/aducm3029/aducm3029_irq.c
@@ -481,7 +481,6 @@ int32_t aducm3029_irq_enable(struct no_os_irq_ctrl_desc *desc,
 		break;
 
 	case ADUCM_TIMER1_INT_ID:
-		NVIC_SetPriority(TMR1_EVT_IRQn, 2);
 		NVIC_EnableIRQ(TMR1_EVT_IRQn);
 		break;
 	default:
@@ -533,6 +532,25 @@ int32_t aducm3029_irq_disable(struct no_os_irq_ctrl_desc *desc,
 }
 
 /**
+ * @brief Set a priority level for an interrupt
+ * @param desc - Interrupt controller descriptor.
+ * @param irq_id - The interrupt vector entry id of the peripheral.
+ * @param priority_level - The interrupt priority level
+ * @return 0 in case of success, -EINVAL otherwise.
+ */
+static int32_t aducm3029_irq_set_priority(struct no_os_irq_ctrl_desc *desc,
+		uint32_t irq_id,
+		uint32_t priority_level)
+{
+	if (irq_id >= NVIC_INTS)
+		return -EINVAL;
+
+	NVIC_SetPriority(irq_id, priority_level);
+
+	return 0;
+}
+
+/**
  * @brief Aducm3029 platform specific IRQ platform ops structure
  */
 const struct no_os_irq_platform_ops aducm_irq_ops = {
@@ -543,5 +561,6 @@ const struct no_os_irq_platform_ops aducm_irq_ops = {
 	.global_disable = &aducm3029_irq_global_disable,
 	.enable = &aducm3029_irq_enable,
 	.disable = &aducm3029_irq_disable,
+	.set_priority = &aducm3029_irq_set_priority,
 	.remove = &aducm3029_irq_ctrl_remove
 };

--- a/projects/adxrs290-pmdz/src/common/common_data.c
+++ b/projects/adxrs290-pmdz/src/common/common_data.c
@@ -78,16 +78,14 @@ struct no_os_irq_init_param adxrs290_gpio_irq_ip = {
 	.extra = GPIO_IRQ_EXTRA,
 };
 
-const struct iio_hw_trig_cb_info gpio_cb_info = {
-	.event = NO_OS_EVT_GPIO,
-	.peripheral = NO_OS_GPIO_IRQ,
-	.handle = ADXRS290_GPIO_CB_HANDLE,
-};
-
 struct iio_hw_trig_init_param adxrs290_gpio_trig_ip = {
 	.irq_id = ADXRS290_GPIO_TRIG_IRQ_ID,
 	.irq_trig_lvl = NO_OS_IRQ_LEVEL_HIGH,
-	.cb_info = gpio_cb_info,
+	.cb_info = {
+		.event = NO_OS_EVT_GPIO,
+		.peripheral = NO_OS_GPIO_IRQ,
+		.handle = ADXRS290_GPIO_CB_HANDLE,
+	},
 	.name = ADXRS290_GPIO_TRIG_NAME,
 };
 #endif

--- a/projects/adxrs290-pmdz/src/platform/aducm3029/main.c
+++ b/projects/adxrs290-pmdz/src/platform/aducm3029/main.c
@@ -47,6 +47,10 @@
 #include "iio_example.h"
 #endif
 
+#ifdef IIO_TRIGGER_EXAMPLE
+#include "iio_trigger_example.h"
+#endif
+
 #ifdef IIO_TIMER_TRIGGER_EXAMPLE
 #include "iio_timer_trigger_example.h"
 #endif
@@ -72,7 +76,9 @@ int main()
 #endif
 
 #ifdef IIO_TRIGGER_EXAMPLE
-#error IIO_TRIGGER_EXAMPLE is not supported on ADUCM3029 platform for adxrs290-pmdz project.
+	ret = iio_trigger_example_main();
+	if (ret)
+		goto error;
 #endif
 
 #ifdef IIO_TIMER_TRIGGER_EXAMPLE
@@ -81,7 +87,7 @@ int main()
 		goto error;
 #endif
 
-#if (IIO_EXAMPLE + IIO_TIMER_TRIGGER_EXAMPLE != 1)
+#if (IIO_EXAMPLE + IIO_TRIGGER_EXAMPLE + IIO_TIMER_TRIGGER_EXAMPLE != 1)
 #error Selected example projects cannot be enabled at the same time. \
 Please enable only one example and re-build the project.
 #endif

--- a/projects/adxrs290-pmdz/src/platform/aducm3029/parameters.h
+++ b/projects/adxrs290-pmdz/src/platform/aducm3029/parameters.h
@@ -48,6 +48,7 @@
 #include "aducm3029_gpio.h"
 #include "spi_extra.h"
 #include "irq_extra.h"
+#include "aducm3029_gpio_irq.h"
 #include "aducm3029_timer.h"
 #include "no_os_timer.h"
 
@@ -60,7 +61,7 @@
 #define UART_BAUDRATE	115200
 
 #define SPI_DEVICE_ID   1
-#define SPI_BAUDRATE    1000000
+#define SPI_BAUDRATE    4000000
 #define SPI_CS          0
 #define SPI_OPS         &aducm_spi_ops
 #define SPI_EXTRA       &adxrs290_spi_extra_ip
@@ -71,7 +72,12 @@
 #define GPIO_EXTRA              NULL
 
 #ifdef IIO_TRIGGER_EXAMPLE
-#error IIO_TRIGGER_EXAMPLE is not supported on ADUCM3029 platform for adxrs290-pmdz project.
+#define GPIO_IRQ_ID     ADUCM_XINT_SOFT_CTRL /* External interrupt used (to be able to use high level trigger) */
+#define GPIO_IRQ_OPS    &aducm_gpio_irq_ops
+#define GPIO_IRQ_EXTRA  NULL /* Not used for aducm3029 platform */
+
+#define ADXRS290_GPIO_TRIG_IRQ_ID    ADI_XINT_EVENT_INT1 /* for EVAL-ADICUP3029 pin number 16 is connected to XINT1 */
+#define ADXRS290_GPIO_CB_HANDLE      NULL /* Not used for aducm3029 platform */
 #endif
 
 #ifdef IIO_TIMER_TRIGGER_EXAMPLE
@@ -84,7 +90,7 @@ extern struct aducm_timer_init_param adxrs290_timer_extra_ip;
 #define TIMER_OPS                   &aducm3029_timer_ops
 
 /* ADXRS290 Timer trigger settings */
-#define ADXRS290_TIMER_IRQ_ID       0 /* Not used */
+#define ADXRS290_TIMER_IRQ_ID       TMR1_EVT_IRQn /* IRQ id for TMR1 */
 #define TIMER_IRQ_OPS               &aducm_irq_ops
 #define ADADXRS290_TIMER_IRQ_EXTRA  NULL /* Not used */
 


### PR DESCRIPTION
- Added implementation for IRQ set_priority API for aducm3029 platform for NVIC controller.
- Added implementation for IRQ set_priority API for aducm3029 platform for GPIO controller.
- Added extra checks for irq_id in case of external interrupt event for GPIO controller.
- Fixed the trigger level setting for GPIO controller.
- Added GPIO trigger example for aducm3029 platform for adxrs290-pmdz project.
