### PR TITLE
stm32 gpio irq: use HAL macro instead of EXTI->PR

### DIFF
--- a/drivers/platform/stm32/stm32_gpio_irq.c
+++ b/drivers/platform/stm32/stm32_gpio_irq.c
@@ -94,9 +94,9 @@ void HAL_GPIO_EXTI_Callback(uint16_t pin)
 
 	key.irq_id = no_os_find_first_set_bit(pin);
 
-	if (EXTI->PR & pin) {
+	if (__HAL_GPIO_EXTI_GET_IT(pin)) {
 		/* Clear pending bit */
-		EXTI->PR = pin;
+		__HAL_GPIO_EXTI_CLEAR_IT(pin);
 
 		ret = no_os_list_read_find(actions, (void **)&action, &key);
 		if (ret)


### PR DESCRIPTION
EXTI->PR is availabe on most but not all stm32 MCU's. L4 family
for example defines PR1 and PR2 registers instead of just PR
hence the build fails without this modification.

Signed-off-by: Darius Berghe <darius.berghe@analog.com>