### PR TITLE
drivers:platform:stm32:stm32_gpio.c Fix build for L5 family

### DIFF
--- a/drivers/platform/stm32/stm32_gpio.c
+++ b/drivers/platform/stm32/stm32_gpio.c
@@ -42,6 +42,10 @@
 #include "no_os_gpio.h"
 #include "stm32_gpio.h"
 
+#ifndef GPIO_MODE && defined(STM32L5)
+#define GPIO_MODE 0x00000003U
+#endif
+
 /******************************************************************************/
 /************************ Functions Definitions *******************************/
 /******************************************************************************/
@@ -98,8 +102,16 @@ static int32_t _gpio_init(struct no_os_gpio_desc *desc,
 		return -EINVAL;
 
 	switch (pextra->mode & GPIO_MODE) {
+#if defined(MODE_INPUT)
 	case MODE_INPUT:
+#else
+	case GPIO_MODE_INPUT:
+#endif
+#if defined(MODE_OUTPUT)
 	case MODE_OUTPUT:
+#else
+	case GPIO_MODE_OUTPUT_PP:
+#endif
 		break;
 	default:
 		return -EINVAL;


### PR DESCRIPTION
GPIO_MODE is defined in stm32l5xx_hal_gpio.c instead of stm32l5xx_hal_gpio.h so it has to be redefined in stm32_gpio.c before it is being used.
MODE_INPUT and MODE_OUTPUT are not defined in STM32 L5 hal, instead GPIO_MODE_INPUT and GPIO_MODE_OUTPUT_PP have to be used to obtain the same functionality.