### PR TITLE
Dev/fix stm l5 build

### DIFF
--- a/drivers/platform/stm32/stm32_gpio.c
+++ b/drivers/platform/stm32/stm32_gpio.c
@@ -42,10 +42,6 @@
 #include "no_os_gpio.h"
 #include "stm32_gpio.h"
 
-#ifndef GPIO_MODE && defined(STM32L5)
-#define GPIO_MODE 0x00000003U
-#endif
-
 /******************************************************************************/
 /************************ Functions Definitions *******************************/
 /******************************************************************************/
@@ -102,16 +98,8 @@ static int32_t _gpio_init(struct no_os_gpio_desc *desc,
 		return -EINVAL;
 
 	switch (pextra->mode & GPIO_MODE) {
-#if defined(MODE_INPUT)
 	case MODE_INPUT:
-#else
-	case GPIO_MODE_INPUT:
-#endif
-#if defined(MODE_OUTPUT)
 	case MODE_OUTPUT:
-#else
-	case GPIO_MODE_OUTPUT_PP:
-#endif
 		break;
 	default:
 		return -EINVAL;

--- a/drivers/platform/stm32/stm32_gpio.c
+++ b/drivers/platform/stm32/stm32_gpio.c
@@ -97,9 +97,12 @@ static int32_t _gpio_init(struct no_os_gpio_desc *desc,
 	else
 		return -EINVAL;
 
-	switch (pextra->mode & GPIO_MODE) {
-	case MODE_INPUT:
-	case MODE_OUTPUT:
+	if (!IS_GPIO_MODE(pextra->mode))
+		return -EINVAL;
+
+	switch (pextra->mode) {
+	case GPIO_MODE_INPUT:
+	case GPIO_MODE_OUTPUT_PP:
 		break;
 	default:
 		return -EINVAL;
@@ -280,7 +283,8 @@ int32_t stm32_gpio_get_direction(struct no_os_gpio_desc *desc,
 		return -EINVAL;
 
 	struct stm32_gpio_desc *extra = desc->extra;
-	*direction = (extra->mode & GPIO_MODE) ? NO_OS_GPIO_OUT : NO_OS_GPIO_IN;
+	*direction = (extra->mode & GPIO_MODE_OUTPUT_PP) ? NO_OS_GPIO_OUT :
+		     NO_OS_GPIO_IN;
 	return 0;
 }
 


### PR DESCRIPTION
- revert commit 6a503d47eb05b2c0159a907e69cb2917ec8bbba0.
- Use GPIO_MODE_INPUT instead of MODE_INPUT and GPIO_MODE_OUTPUT_PP instead of MODE_OUTPUT.
- Replace the usage of GPIO_MODE mask with the usage of IS_GPIO_MODE to check wether the provided gpio mode is valid.
- When setting the direction of a pin, use GPIO_MODE_OUTPUT_PP mask instead of GPIO_MODE.


