### PR TITLE
Remove pull field from STM32 GPIO extra param

### DIFF
--- a/drivers/platform/stm32/stm32_gpio.c
+++ b/drivers/platform/stm32/stm32_gpio.c
@@ -110,15 +110,28 @@ static int32_t _gpio_init(struct no_os_gpio_desc *desc,
 
 	/* copy the settings to gpio descriptor */
 	desc->number = param->number;
+	desc->pull = param->pull;
 	extra->port = pextra->port;
 	extra->mode = pextra->mode;
-	extra->pull = pextra->pull;
 	extra->speed = pextra->speed;
+
+	switch (param->pull) {
+	case NO_OS_PULL_NONE:
+		gis.Pull = GPIO_PuPd_NOPULL;
+		break;
+	case NO_OS_PULL_UP:
+		gis.Pull = GPIO_PdPu_UP;
+		break;
+	case NO_OS_PULL_DOWN:
+		gis.Pull = GPIO_PdPu_DOWN;
+		break;
+	default:
+		return -EINVAL;
+	}
 
 	/* configure gpio with user configuration */
 	gis.Pin = NO_OS_BIT(param->number);
 	gis.Mode = extra->mode;
-	gis.Pull = extra->pull;
 	gis.Speed = extra->speed;
 	HAL_GPIO_Init(extra->port, &gis);
 

--- a/drivers/platform/stm32/stm32_gpio.h
+++ b/drivers/platform/stm32/stm32_gpio.h
@@ -52,8 +52,6 @@ typedef struct stm32_gpio_init_param {
 	GPIO_TypeDef *port;
 	/** Output mode */
 	uint32_t mode;
-	/** Pull-up, Pull-down mode */
-	uint32_t pull;
 	/** Speed grade */
 	uint32_t speed;
 } stm32_gpio_init_param;
@@ -67,8 +65,6 @@ typedef struct stm32_gpio_desc {
 	GPIO_TypeDef *port;
 	/** Output mode */
 	uint32_t mode;
-	/** Pull-up, Pull-down mode */
-	uint32_t pull;
 	/** Speed grade */
 	uint32_t speed;
 } stm32_gpio_desc;

--- a/projects/adxrs290-pmdz/src/platform/stm32/parameters.c
+++ b/projects/adxrs290-pmdz/src/platform/stm32/parameters.c
@@ -52,6 +52,5 @@ struct stm32_spi_init_param adxrs290_spi_extra_ip  = {
 struct stm32_gpio_desc adxrs290_gpio_extra_ip = {
 	.mode = GPIO_MODE_IT_RISING,
 	.port = GPIOA,
-	.pull = GPIO_NOPULL,
 	.speed = GPIO_SPEED_FREQ_VERY_HIGH,
 };


### PR DESCRIPTION
Use the pull field from the no_os_gpio_param to initialize the GPIO
controller instead of the one from stm32_gpio_init_param.