### PR TITLE
platform: typedefs remove

### DIFF
--- a/drivers/platform/stm32/stm32_gpio.h
+++ b/drivers/platform/stm32/stm32_gpio.h
@@ -47,7 +47,7 @@
  * @struct stm32_gpio_init_param
  * @brief Structure holding the initialization parameters for stm32 platform
  */
-typedef struct stm32_gpio_init_param {
+struct stm32_gpio_init_param {
 	/** Port */
 	GPIO_TypeDef *port;
 	/** Output mode */
@@ -56,13 +56,13 @@ typedef struct stm32_gpio_init_param {
 	uint32_t pull;
 	/** Speed grade */
 	uint32_t speed;
-} stm32_gpio_init_param;
+};
 
 /**
  * @struct stm32_gpio_desc
  * @brief stm32 platform specific gpio descriptor
  */
-typedef struct stm32_gpio_desc {
+struct stm32_gpio_desc {
 	/** Port */
 	GPIO_TypeDef *port;
 	/** Output mode */
@@ -71,7 +71,7 @@ typedef struct stm32_gpio_desc {
 	uint32_t pull;
 	/** Speed grade */
 	uint32_t speed;
-} stm32_gpio_desc;
+};
 
 /**
  * @brief stm32 platform specific gpio platform ops structure

--- a/drivers/platform/stm32/stm32_spi.c
+++ b/drivers/platform/stm32/stm32_spi.c
@@ -74,7 +74,7 @@ int32_t stm32_spi_init(struct no_os_spi_desc **desc,
 	struct no_os_gpio_init_param csip;
 	struct stm32_gpio_init_param csip_extra;
 
-	sdesc = (stm32_spi_desc*)calloc(1,sizeof(stm32_spi_desc));
+	sdesc = (struct stm32_spi_desc*)calloc(1,sizeof(struct stm32_spi_desc));
 	if (!sdesc) {
 		ret = -ENOMEM;
 		goto error;

--- a/drivers/platform/stm32/stm32_spi.h
+++ b/drivers/platform/stm32/stm32_spi.h
@@ -48,23 +48,23 @@
  * @brief Structure holding the initialization parameters for stm32 platform
  * specific SPI parameters.
  */
-typedef struct stm32_spi_init_param {
+struct stm32_spi_init_param {
 	/** Chip select port */
 	GPIO_TypeDef *chip_select_port;
 	/** Get perihperal source clock function */
 	uint32_t (*get_input_clock)(void);
-} stm32_spi_init_param;
+};
 
 /**
  * @struct stm32_spi_desc
  * @brief stm32 platform specific SPI descriptor
  */
-typedef struct stm32_spi_desc {
+struct stm32_spi_desc {
 	/** SPI instance */
 	SPI_HandleTypeDef hspi;
 	/** Chip select gpio descriptor */
 	struct no_os_gpio_desc *chip_select;
-} stm32_spi_desc;
+};
 
 /**
  * @brief stm32 specific SPI platform ops structure

--- a/drivers/platform/stm32/stm32_tdm.c
+++ b/drivers/platform/stm32/stm32_tdm.c
@@ -79,7 +79,7 @@ int32_t stm32_tdm_init(struct no_os_tdm_desc **desc,
 	struct stm32_tdm_desc *tdesc;
 	struct stm32_tdm_init_param *tinit;
 
-	tdesc = (stm32_tdm_desc*)calloc(1,sizeof(stm32_tdm_desc));
+	tdesc = (struct stm32_tdm_desc*)calloc(1,sizeof(struct stm32_tdm_desc));
 	if (!tdesc) {
 		ret = -ENOMEM;
 		goto error;

--- a/drivers/platform/stm32/stm32_tdm.h
+++ b/drivers/platform/stm32/stm32_tdm.h
@@ -48,19 +48,19 @@
  * @brief Structure holding the initialization parameters for stm32 platform
  * specific TDM parameters.
  */
-typedef struct stm32_tdm_init_param {
+struct stm32_tdm_init_param {
 	/** Device ID */
 	SAI_Block_TypeDef *base;
-} stm32_tdm_init_param;
+};
 
 /**
  * @struct stm32_tdm_desc
  * @brief stm32 platform specific TDM descriptor
  */
-typedef struct stm32_tdm_desc {
+struct stm32_tdm_desc {
 	/** TDM instance */
 	SAI_HandleTypeDef hsai;
-} stm32_tdm_desc;
+};
 
 /**
  * @brief stm32 specific TDM platform ops structure

--- a/drivers/platform/stm32/stm32_timer.h
+++ b/drivers/platform/stm32/stm32_timer.h
@@ -49,18 +49,18 @@
  * @brief Structure holding the initialization parameters for stm32 platform
  * specific timer parameters.
  */
-typedef struct stm32_timer_init_param {
+struct stm32_timer_init_param {
 	TIM_HandleTypeDef *htimer;
-} stm32_timer_init_param;
+};
 
 /**
  * @struct stm32_timer_desc
  * @brief stm32 platform specific timer descriptor
  */
-typedef struct stm32_timer_desc {
+struct stm32_timer_desc {
 	/** timer instance */
 	TIM_HandleTypeDef *htimer;
-} stm32_timer_desc;
+};
 
 /**
  * @brief stm32 specific timer platform ops structure

--- a/drivers/platform/xilinx/gpio_extra.h
+++ b/drivers/platform/xilinx/gpio_extra.h
@@ -55,37 +55,37 @@
  * @enum xil_gpio_type
  * @brief Xilinx platform architecture sections
  */
-typedef enum xil_gpio_type {
+enum xil_gpio_type {
 	/** Programmable Logic */
 	GPIO_PL,
 	/** Processing System */
 	GPIO_PS
-} xil_gpio_type;
+};
 
 /**
  * @struct xil_gpio_init_param
  * @brief Structure holding the initialization parameters for Xilinx platform
  * specific GPIO parameters.
  */
-typedef struct xil_gpio_init_param {
+struct xil_gpio_init_param {
 	/** Xilinx architecture */
 	enum xil_gpio_type	type;
 	/** Device ID */
 	uint32_t		device_id;
-} xil_gpio_init_param;
+};
 
 /**
  * @struct xil_gpio_desc
  * @brief Xilinx platform specific GPIO descriptor
  */
-typedef struct xil_gpio_desc {
+struct xil_gpio_desc {
 	/** Xilinx architecture */
 	enum xil_gpio_type	type;
 	/** Xilinx GPIO configuration */
 	void			*config;
 	/** Xilinx GPIO Instance */
 	void			*instance;
-} xil_gpio_desc;
+};
 
 /**
  * @brief Xilinx platform specific gpio platform ops structure

--- a/drivers/platform/xilinx/i2c_extra.h
+++ b/drivers/platform/xilinx/i2c_extra.h
@@ -66,18 +66,18 @@ enum xil_i2c_type {
  * @brief Structure holding the initialization parameters for Xilinx platform
  * specific I2C parameters.
  */
-typedef struct xil_i2c_init_param {
+struct xil_i2c_init_param {
 	/** Xilinx architecture */
 	enum xil_i2c_type	type;
 	/** Device ID */
 	uint32_t		device_id;
-} xil_i2c_init_param;
+};
 
 /**
  * @struct xil_i2c_desc
  * @brief Xilinx platform specific I2C descriptor
  */
-typedef struct xil_i2c_desc {
+struct xil_i2c_desc {
 	/** Xilinx architecture */
 	enum xil_i2c_type	type;
 	/** Device ID */
@@ -86,7 +86,7 @@ typedef struct xil_i2c_desc {
 	void			*config;
 	/** Xilinx I2C Instance */
 	void			*instance;
-} xil_i2c_desc;
+};
 
 /**
  * @brief Xilinx platform specific i2c platform ops structure

--- a/drivers/platform/xilinx/spi_extra.h
+++ b/drivers/platform/xilinx/spi_extra.h
@@ -75,18 +75,18 @@ enum xil_spi_type {
  * @brief Structure holding the initialization parameters for Xilinx platform
  * specific SPI parameters when using xil_spi_ops.
  */
-typedef struct xil_spi_init_param {
+struct xil_spi_init_param {
 	/** Xilinx architecture */
 	enum xil_spi_type	type;
 	/** SPI flags */
 	uint32_t		flags;
-} xil_spi_init_param;
+};
 
 /**
  * @struct xil_spi_desc
  * @brief Xilinx platform specific SPI descriptor
  */
-typedef struct xil_spi_desc {
+struct xil_spi_desc {
 	/** Xilinx architecture */
 	enum xil_spi_type	type;
 	/** SPI flags */
@@ -95,7 +95,7 @@ typedef struct xil_spi_desc {
 	void			*config;
 	/** SPI instance */
 	void			*instance;
-} xil_spi_desc;
+};
 
 /**
  * @brief SPI engine platform ops structure

--- a/drivers/platform/xilinx/xilinx_gpio.c
+++ b/drivers/platform/xilinx/xilinx_gpio.c
@@ -191,7 +191,7 @@ int32_t xil_gpio_get_optional(struct no_os_gpio_desc **desc,
 int32_t xil_gpio_remove(struct no_os_gpio_desc *desc)
 {
 	if (desc != NULL) {
-		free(((xil_gpio_desc *)(desc->extra))->instance);
+		free(((struct xil_gpio_desc *)(desc->extra))->instance);
 		free(desc->extra);
 		free(desc);
 	}

--- a/drivers/platform/xilinx/xilinx_i2c.c
+++ b/drivers/platform/xilinx/xilinx_i2c.c
@@ -162,8 +162,8 @@ int32_t xil_i2c_init(struct no_os_i2c_desc **desc,
 {
 	int32_t		ret;
 	struct no_os_i2c_desc	*idesc;
-	xil_i2c_desc	*xdesc;
-	xil_i2c_init_param	*xinit;
+	struct xil_i2c_desc	*xdesc;
+	struct xil_i2c_init_param	*xinit;
 
 	idesc = (struct no_os_i2c_desc *)malloc(sizeof(*idesc));
 	xdesc = (struct xil_i2c_desc *)malloc(sizeof(*xdesc));
@@ -316,7 +316,7 @@ error:
  */
 int32_t xil_i2c_remove(struct no_os_i2c_desc *desc)
 {
-	xil_i2c_desc	*xdesc;
+	struct xil_i2c_desc	*xdesc;
 	int32_t		ret;
 
 	xdesc = desc->extra;
@@ -394,7 +394,7 @@ int32_t xil_i2c_write(struct no_os_i2c_desc *desc,
 		      uint8_t bytes_number,
 		      uint8_t stop_bit)
 {
-	xil_i2c_desc	*xdesc;
+	struct xil_i2c_desc	*xdesc;
 	int32_t		ret;
 
 	xdesc = desc->extra;
@@ -459,7 +459,7 @@ int32_t xil_i2c_read(struct no_os_i2c_desc *desc,
 		     uint8_t bytes_number,
 		     uint8_t stop_bit)
 {
-	xil_i2c_desc	*xdesc;
+	struct xil_i2c_desc	*xdesc;
 	int32_t		ret;
 
 	xdesc = desc->extra;

--- a/drivers/platform/xilinx/xilinx_spi.c
+++ b/drivers/platform/xilinx/xilinx_spi.c
@@ -84,7 +84,7 @@ static int32_t spi_init_pl(struct no_os_spi_desc *desc,
 	struct xil_spi_desc 		*xdesc;
 	struct xil_spi_init_param	*xinit;
 
-	xdesc = (xil_spi_desc*)malloc(sizeof(xil_spi_desc));
+	xdesc = (struct xil_spi_desc*)malloc(sizeof(struct xil_spi_desc));
 	if(!xdesc) {
 		free(xdesc);
 		return -1;
@@ -158,7 +158,7 @@ static int32_t spi_init_ps(struct no_os_spi_desc *desc,
 	uint32_t			prescaler = 0u;
 	uint32_t			input_clock = 0u;
 
-	xdesc = (xil_spi_desc*)malloc(sizeof(xil_spi_desc));
+	xdesc = (struct xil_spi_desc*)malloc(sizeof(struct xil_spi_desc));
 	if(!xdesc) {
 		free(xdesc);
 		return -1;

--- a/projects/adrv9009/src/app/headless.c
+++ b/projects/adrv9009/src/app/headless.c
@@ -197,7 +197,7 @@ int main(void)
 	extern const uint32_t sine_lut_iq[1024];
 #endif
 #ifndef ALTERA_PLATFORM
-	xil_spi_init_param hal_spi_param = {
+	struct xil_spi_init_param hal_spi_param = {
 #ifdef PLATFORM_MB
 		.type = SPI_PL,
 #else

--- a/projects/iio_demo/src/platform/stm32/parameters.h
+++ b/projects/iio_demo/src/platform/stm32/parameters.h
@@ -68,7 +68,7 @@ extern UART_HandleTypeDef huart5;
 
 #ifdef IIO_TIMER_TRIGGER_EXAMPLE
 /* Adc Demo Timer settings */
-extern stm32_timer_init_param adc_demo_xtip;
+extern struct stm32_timer_init_param adc_demo_xtip;
 #define ADC_DEMO_TIMER_DEVICE_ID    13
 #define ADC_DEMO_TIMER_FREQ_HZ      1000000
 #define ADC_DEMO_TIMER_TICKS_COUNT  2000
@@ -86,7 +86,7 @@ extern TIM_HandleTypeDef htim13;
 #define ADC_DEMO_TIMER_TRIG_IRQ_ID  TIM8_UP_TIM13_IRQn
 
 /* Dac Demo Timer settings */
-extern stm32_timer_init_param dac_demo_xtip;
+extern struct stm32_timer_init_param dac_demo_xtip;
 #define DAC_DEMO_TIMER_DEVICE_ID    14
 #define DAC_DEMO_TIMER_FREQ_HZ      1000000
 #define DAC_DEMO_TIMER_TICKS_COUNT  2000


### PR DESCRIPTION
Remove typedefs for the platform drivers since they are no longer supported on the no-os repository.