### PR TITLE
drivers:platform:stm32:Restructure extra gpio desc

### DIFF
--- a/drivers/platform/stm32/stm32_gpio.h
+++ b/drivers/platform/stm32/stm32_gpio.h
@@ -63,10 +63,8 @@ struct stm32_gpio_init_param {
 struct stm32_gpio_desc {
 	/** Port */
 	GPIO_TypeDef *port;
-	/** Output mode */
-	uint32_t mode;
-	/** Speed grade */
-	uint32_t speed;
+	/** GPIO configuration */
+	GPIO_InitTypeDef gpio_config;
 };
 
 /**

--- a/drivers/platform/stm32/stm32_spi.c
+++ b/drivers/platform/stm32/stm32_spi.c
@@ -84,10 +84,10 @@ int32_t stm32_spi_init(struct no_os_spi_desc **desc,
 	sinit = param->extra;
 
 	csip_extra.port = sinit->chip_select_port;
-	csip_extra.pull = GPIO_NOPULL;
 	csip_extra.mode = GPIO_MODE_OUTPUT_PP;
 	csip_extra.speed = GPIO_SPEED_FREQ_LOW;
 	csip.number = param->chip_select;
+	csip.pull = NO_OS_PULL_NONE;
 	csip.extra = &csip_extra;
 	csip.platform_ops = &stm32_gpio_ops;
 	ret = no_os_gpio_get(&sdesc->chip_select, &csip);


### PR DESCRIPTION
Add a field of type GPIO_InitTypeDef for the stm32 platform specific
gpio descriptor, instead of storing each of the structure's fields.

This fixes 3d616520f6fe03f8c34ea8e009eb9e942f1d1dd3.