### PR TITLE
drivers:platform:stm32:stm32_timer.h: Fix includes

### DIFF
--- a/drivers/platform/stm32/stm32_timer.h
+++ b/drivers/platform/stm32/stm32_timer.h
@@ -41,8 +41,7 @@
 
 #include <stdint.h>
 #include "no_os_timer.h"
-#include "stm32f4xx_hal.h"
-#include "stm32f4xx_hal_tim.h"
+#include "stm32_hal.h"
 
 /**
  * @struct stm32_timer_init_param


### PR DESCRIPTION
Remove family specific includes and simply use stm32_hal.h header file.

Signed-off-by: Ramona Bolboaca <ramona.bolboaca@analog.com>