### PR TITLE
projects:adxrs290-pmdz: Fix SYNC pin mode for stm platfom

### DIFF
--- a/projects/adxrs290-pmdz/src/platform/stm32/parameters.c
+++ b/projects/adxrs290-pmdz/src/platform/stm32/parameters.c
@@ -50,7 +50,7 @@ struct stm32_spi_init_param adxrs290_spi_extra_ip  = {
 };
 
 struct stm32_gpio_init_param adxrs290_gpio_extra_ip = {
-	.mode = GPIO_MODE_IT_RISING,
+	.mode = GPIO_MODE_INPUT,
 	.port = GPIOA,
 	.speed = GPIO_SPEED_FREQ_VERY_HIGH,
 };


### PR DESCRIPTION
Change pin mode from GPIO_MODE_IT_RISING to GPIO_MODE_INPUT