### PR TITLE
xilinx: build Vitis workspace to generate BOOT.BIN

### DIFF
--- a/tools/scripts/platform/xilinx/build_project.tcl
+++ b/tools/scripts/platform/xilinx/build_project.tcl
@@ -5,6 +5,6 @@ if { $argc != 1 } {
 
 sdk setws [lindex $argv 0]
 
-app build -name app
+app build -all
 
 exit


### PR DESCRIPTION
In Vitis, the created projects look like this in project explorer:

app_system
├── app
└── bsp

Previously we only built app, which also built bsp as a dependency.

But if we pass the -all flag, app_system is built too, and by doing so, a post-build rule is run that generates the BOOT.BIN every time.

Signed-off-by: Darius Berghe <darius.berghe@analog.com>