### PR TITLE
iio: Add cyclic buffer support

### DIFF
--- a/iio/iio_types.h
+++ b/iio/iio_types.h
@@ -206,6 +206,11 @@ enum iio_buffer_direction {
 	IIO_DIRECTION_OUTPUT
 };
 
+struct iio_cyclic_buffer_info {
+	bool is_cyclic;
+	uint32_t buff_index;
+};
+
 struct iio_buffer {
 	/* Mask with active channels */
 	uint32_t active_mask;
@@ -217,6 +222,8 @@ struct iio_buffer {
 	enum iio_buffer_direction dir;
 	/* Buffer where data is stored */
 	struct no_os_circular_buffer *buf;
+	/* Stores cyclic buffer specific information */
+	struct iio_cyclic_buffer_info cyclic_info;
 };
 
 struct iio_device_data {

--- a/iio/iiod_private.h
+++ b/iio/iiod_private.h
@@ -137,7 +137,9 @@ struct iiod_conn_priv {
 		/* I/O operations for WRITE cmd */
 		IIOD_READING_WRITE_DATA,
 		/* Set when a operation is finalized */
-		IIOD_LINE_DONE
+		IIOD_LINE_DONE,
+		/* Pushing  cyclic buffer until IIO device is closed  */
+		IIOD_PUSH_CYCLIC_BUFFER,
 	} state;
 
 	/* Buffer to store received line */
@@ -157,6 +159,8 @@ struct iiod_conn_priv {
 	char buf_mask[10];
 	/* Context for strtok_r function */
 	char *strtok_ctx;
+	/* True if the device was open with cyclic buffer flag */
+	bool is_cyclic_buffer;
 };
 
 /* Private iiod information */


### PR DESCRIPTION
Add cyclic buffer support when cyclic flag is given in OPEN command. The cyclic flag is kept until a CLOSE command is received.
When a device is opened in cyclic mode, the first buffer of samples pushed by the client, will be pushed continuously to the iio driver. submit function will be called continuously with the given samples.