### PR TITLE
IIOD pointer fix

### DIFF
--- a/iio/iio.c
+++ b/iio/iio.c
@@ -151,7 +151,7 @@ struct iio_buffer_priv {
  */
 struct iio_dev_priv {
 	/** Will be: iio:device[0...n] n beeing the count of registerd devices*/
-	char			dev_id[21];
+	char			dev_id[MAX_DEV_ID];
 	/** Device name */
 	const char		*name;
 	/** Physical instance of a device */
@@ -175,7 +175,7 @@ struct iio_dev_priv {
  */
 struct iio_trig_priv {
 	/** Will be: iio:trigger[0...n] */
-	char	id[22];
+	char	id[MAX_TRIG_ID];
 	/** Trigger name */
 	char	*name;
 	/** Physical instance of a trigger */
@@ -283,7 +283,7 @@ static inline struct iio_channel *iio_get_channel(const char *channel,
 		struct iio_device *desc, bool ch_out)
 {
 	int16_t i = 0;
-	char	ch_id[64];
+	char	ch_id[MAX_CHN_ID];
 
 	while (i < desc->num_ch) {
 		_print_ch_id(ch_id, &desc->channels[i]);
@@ -739,7 +739,7 @@ static int iio_read_attr(struct iiod_ctx *ctx, const char *device,
 			return -ENOENT;
 		}
 
-		if (attr->channel) {
+		if (attr->channel[0] != '\0') {
 			ch_out = attr->type == IIO_ATTR_TYPE_CH_OUT ? 1 : 0;
 			ch = iio_get_channel(attr->channel, dev->dev_descriptor,
 					     ch_out);
@@ -815,7 +815,7 @@ static int iio_write_attr(struct iiod_ctx *ctx, const char *device,
 			return -ENOENT;
 		}
 
-		if (attr->channel) {
+		if (attr->channel[0] != '\0') {
 			ch_out = attr->type == IIO_ATTR_TYPE_CH_OUT ? 1 : 0;
 			ch = iio_get_channel(attr->channel, dev->dev_descriptor,
 					     ch_out);

--- a/iio/iio.c
+++ b/iio/iio.c
@@ -1157,6 +1157,7 @@ static int iio_close_dev(struct iiod_ctx *ctx, const char *device)
 		trig = &desc->trigs[dev->trig_idx];
 		if (trig->descriptor->disable)
 			ret = trig->descriptor->disable(trig->instance);
+		dev->trig_idx = NO_TRIGGER;
 	}
 
 	return ret;

--- a/iio/iiod.c
+++ b/iio/iiod.c
@@ -200,7 +200,7 @@ static int32_t iiod_parse_rw_attr(const char *token, struct comand_desc *res,
 	    res->type == IIO_ATTR_TYPE_CH_OUT) {
 		if (!token)
 			return -EINVAL;
-		res->channel = token;
+		strncpy(res->channel, token, sizeof(res->channel));
 		token = strtok_r(NULL, delim, ctx);
 	}
 
@@ -209,12 +209,12 @@ static int32_t iiod_parse_rw_attr(const char *token, struct comand_desc *res,
 			return -EINVAL;
 
 		if (*token >= '0' && *token <= '9') {
-			res->attr = "";
+			memset(res->attr, 0, sizeof(res->attr));
 
 			return parse_num(token, &res->bytes_count, 10);
 		}
 
-		res->attr = token;
+		strncpy(res->attr, token, sizeof(res->attr));
 		token = strtok_r(NULL, delim, ctx);
 		if (!token)
 			return -EINVAL;
@@ -223,9 +223,9 @@ static int32_t iiod_parse_rw_attr(const char *token, struct comand_desc *res,
 	}
 
 	if (token)
-		res->attr = token;
+		strncpy(res->attr, token, sizeof(res->attr));
 	else
-		res->attr = "";
+		memset(res->attr, 0, sizeof(res->attr));
 
 	return 0;
 }
@@ -254,7 +254,7 @@ int32_t iiod_parse_line(char *buf, struct comand_desc *res, char **ctx)
 		break;
 	}
 
-	res->device = token;
+	strncpy(res->device, token, sizeof(res->device));
 	token = strtok_r(NULL, delim, ctx);
 	switch (res->cmd) {
 	case IIOD_CMD_CLOSE:
@@ -270,9 +270,9 @@ int32_t iiod_parse_line(char *buf, struct comand_desc *res, char **ctx)
 		return parse_num(token, &res->bytes_count, 10);
 	case IIOD_CMD_SETTRIG:
 		if (token)
-			res->trigger = token;
+			strncpy(res->trigger, token, sizeof(res->trigger));
 		else
-			res->trigger = "";
+			memset(res->trigger, 0, sizeof(res->trigger));
 
 		return 0;
 	case IIOD_CMD_SET:

--- a/iio/iiod.h
+++ b/iio/iiod.h
@@ -48,6 +48,11 @@
 #define IIOD_VERSION		"1.1.0000000"
 #define IIOD_VERSION_LEN	(sizeof(IIOD_VERSION) - 1)
 
+#define MAX_DEV_ID		64
+#define MAX_TRIG_ID		64
+#define MAX_CHN_ID		64
+#define MAX_ATTR_NAME		256
+
 enum iio_attr_type {
 	IIO_ATTR_TYPE_DEBUG,
 	IIO_ATTR_TYPE_BUFFER,

--- a/iio/iiod_private.h
+++ b/iio/iiod_private.h
@@ -90,10 +90,10 @@ struct comand_desc {
 	uint32_t bytes_count;
 	uint32_t count;
 	bool cyclic;
-	const char *device;
-	const char *channel;
-	const char *attr;
-	const char *trigger;
+	char device[MAX_DEV_ID];
+	char channel[MAX_CHN_ID];
+	char attr[MAX_ATTR_NAME];
+	char trigger[MAX_TRIG_ID];
 	enum iio_attr_type type;
 };
 


### PR DESCRIPTION
- Reset the trigger id assigned to a device when the close command is received.
- Use array of chars instead of pointers for device id, trigger id, channel id and attribute name. With current implementation the pointers point to parser_buf which can change over the execution of the program, leading to unwanted changes for device id, trigger id, channel id or attribute name. This can happen when iiod_read_line reads a few characters, modifying parser_buf, but then returns an error (because not all data has been yet received). In this scenario iiod_parse_line is not called and device id, trigger id, channel id or attribute name will have garbage values until iiod_parse_line is called again.