### PR TITLE
drivers:adc:ad717x:Add support to AD4116

### DIFF
--- a/drivers/adc/ad717x/ad717x.c
+++ b/drivers/adc/ad717x/ad717x.c
@@ -2,7 +2,7 @@
 *   @file    AD717X.c
 *   @brief   AD717X implementation file.
 *   	     Devices: AD7172-2, AD7172-4, AD7173-8, AD7175-2, AD7175-8, AD7176-2
-*            AD7177-2, AD4111, AD4112, AD4114, AD4115
+*            AD7177-2, AD4111, AD4112, AD4114, AD4115, AD4116
 *   @author  acozma (andrei.cozma@analog.com)
 *            dnechita (dan.nechita@analog.com)
 *
@@ -144,6 +144,7 @@ int ad717x_connect_analog_input(ad717x_dev *device, uint8_t channel_id,
 	case ID_AD4112 :
 	case ID_AD4114 :
 	case ID_AD4115 :
+	case ID_AD4116 :
 		/* Clear and Set the required analog input pair to channel */
 		channel_reg->value  &= ~AD717x_CHANNEL_INPUT_MASK;
 		channel_reg->value |= AD4111_CHMAP_REG_INPUT(analog_input.analog_input_pairs);

--- a/drivers/adc/ad717x/ad717x.h
+++ b/drivers/adc/ad717x/ad717x.h
@@ -2,7 +2,7 @@
 *   @file    AD717X.h
 *   @brief   AD717X header file.
 *   	     Devices: AD7172-2, AD7172-4, AD7173-8, AD7175-2, AD7175-8, AD7176-2,
-*            AD7177-2, AD4111, AD4112, AD4114, AD4115
+*            AD7177-2, AD4111, AD4112, AD4114, AD4115, AD4116
 *   @author  acozma (andrei.cozma@analog.com)
 *            dnechita (dan.nechita@analog.com)
 *******************************************************************************
@@ -149,6 +149,7 @@ enum ad717x_device_type {
 	ID_AD4112,
 	ID_AD4114,
 	ID_AD4115,
+	ID_AD4116,
 	ID_AD7172_2,
 	ID_AD7172_4,
 	ID_AD7173_8,


### PR DESCRIPTION
1) Added an element for AD4116 in the ad717x_device_type enum 
2) Added a case for AD4116 in the ad717x_connect_analog_input() switch case 
3) Updated doxygen file headers

Signed-off-by: Janani Sunil <janani.sunil@analog.com>