### PR TITLE
platform: generic: use util macros

### DIFF
--- a/drivers/platform/generic/delay.c
+++ b/drivers/platform/generic/delay.c
@@ -42,6 +42,7 @@
 /******************************************************************************/
 
 #include "no_os_delay.h"
+#include "no_os_util.h"
 
 /******************************************************************************/
 /************************ Functions Definitions *******************************/
@@ -54,9 +55,7 @@
  */
 void no_os_udelay(uint32_t usecs)
 {
-	if (usecs) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(usecs);
 }
 
 /**
@@ -66,7 +65,5 @@ void no_os_udelay(uint32_t usecs)
  */
 void no_os_mdelay(uint32_t msecs)
 {
-	if (msecs) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(msecs);
 }

--- a/drivers/platform/generic/generic_gpio.c
+++ b/drivers/platform/generic/generic_gpio.c
@@ -58,13 +58,8 @@
 int32_t generic_gpio_get(struct no_os_gpio_desc **desc,
 			 const struct no_os_gpio_init_param *param)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (param) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(desc);
+	NO_OS_UNUSED_PARAM(param);
 
 	return 0;
 }
@@ -93,9 +88,7 @@ int32_t generic_gpio_get_optional(struct no_os_gpio_desc **desc,
  */
 int32_t generic_gpio_remove(struct no_os_gpio_desc *desc)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(desc);
 
 	return 0;
 }
@@ -107,9 +100,7 @@ int32_t generic_gpio_remove(struct no_os_gpio_desc *desc)
  */
 int32_t generic_gpio_direction_input(struct no_os_gpio_desc *desc)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(desc);
 
 	return 0;
 }
@@ -125,13 +116,8 @@ int32_t generic_gpio_direction_input(struct no_os_gpio_desc *desc)
 int32_t generic_gpio_direction_output(struct no_os_gpio_desc *desc,
 				      uint8_t value)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (value) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(desc);
+	NO_OS_UNUSED_PARAM(value);
 
 	return 0;
 }
@@ -147,13 +133,8 @@ int32_t generic_gpio_direction_output(struct no_os_gpio_desc *desc,
 int32_t generic_gpio_get_direction(struct no_os_gpio_desc *desc,
 				   uint8_t *direction)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (direction) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(desc);
+	NO_OS_UNUSED_PARAM(direction);
 
 	return 0;
 }
@@ -170,13 +151,8 @@ int32_t generic_gpio_get_direction(struct no_os_gpio_desc *desc,
 int32_t generic_gpio_set_value(struct no_os_gpio_desc *desc,
 			       uint8_t value)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (value) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(desc);
+	NO_OS_UNUSED_PARAM(value);
 
 	return 0;
 }
@@ -192,13 +168,8 @@ int32_t generic_gpio_set_value(struct no_os_gpio_desc *desc,
 int32_t generic_gpio_get_value(struct no_os_gpio_desc *desc,
 			       uint8_t *value)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (value) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(desc);
+	NO_OS_UNUSED_PARAM(value);
 
 	return 0;
 }

--- a/drivers/platform/generic/generic_spi.c
+++ b/drivers/platform/generic/generic_spi.c
@@ -42,6 +42,7 @@
 
 #include "no_os_error.h"
 #include "no_os_spi.h"
+#include "no_os_util.h"
 
 /******************************************************************************/
 /************************ Functions Definitions *******************************/
@@ -56,13 +57,8 @@
 int32_t generic_spi_init(struct no_os_spi_desc **desc,
 			 const struct no_os_spi_init_param *param)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (param->max_speed_hz) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(desc);
+	NO_OS_UNUSED_PARAM(param);
 
 	return 0;
 }
@@ -74,9 +70,7 @@ int32_t generic_spi_init(struct no_os_spi_desc **desc,
  */
 int32_t generic_spi_remove(struct no_os_spi_desc *desc)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(desc);
 
 	return 0;
 }
@@ -92,17 +86,9 @@ int32_t generic_spi_write_and_read(struct no_os_spi_desc *desc,
 				   uint8_t *data,
 				   uint16_t bytes_number)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (data) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (bytes_number) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(desc);
+	NO_OS_UNUSED_PARAM(data);
+	NO_OS_UNUSED_PARAM(bytes_number);
 
 	return 0;
 }

--- a/drivers/platform/generic/i2c.c
+++ b/drivers/platform/generic/i2c.c
@@ -42,6 +42,7 @@
 
 #include "no_os_error.h"
 #include "no_os_i2c.h"
+#include "no_os_util.h"
 
 /******************************************************************************/
 /************************ Functions Definitions *******************************/
@@ -56,13 +57,8 @@
 int32_t no_os_i2c_init(struct no_os_i2c_desc **desc,
 		       const struct no_os_i2c_init_param *param)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (param->max_speed_hz) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(desc);
+	NO_OS_UNUSED_PARAM(param);
 
 	return 0;
 }
@@ -74,9 +70,7 @@ int32_t no_os_i2c_init(struct no_os_i2c_desc **desc,
  */
 int32_t no_os_i2c_remove(struct no_os_i2c_desc *desc)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(desc);
 
 	return 0;
 }
@@ -96,21 +90,10 @@ int32_t no_os_i2c_write(struct no_os_i2c_desc *desc,
 			uint8_t bytes_number,
 			uint8_t stop_bit)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (data) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (bytes_number) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (stop_bit) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(desc);
+	NO_OS_UNUSED_PARAM(data);
+	NO_OS_UNUSED_PARAM(bytes_number);
+	NO_OS_UNUSED_PARAM(stop_bit);
 
 	return 0;
 }
@@ -130,21 +113,10 @@ int32_t no_os_i2c_read(struct no_os_i2c_desc *desc,
 		       uint8_t bytes_number,
 		       uint8_t stop_bit)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (data) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (bytes_number) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (stop_bit) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(desc);
+	NO_OS_UNUSED_PARAM(data);
+	NO_OS_UNUSED_PARAM(bytes_number);
+	NO_OS_UNUSED_PARAM(stop_bit);
 
 	return 0;
 }

--- a/drivers/platform/generic/no_os_timer.c
+++ b/drivers/platform/generic/no_os_timer.c
@@ -43,6 +43,7 @@
 
 #include "no_os_error.h"
 #include "no_os_timer.h"
+#include "no_os_util.h"
 
 /******************************************************************************/
 /************************ Functions Definitions *******************************/
@@ -58,12 +59,8 @@
 int32_t no_os_timer_init(struct no_os_timer_desc **desc,
 			 struct no_os_timer_init_param *param)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
-	if (param) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(desc);
+	NO_OS_UNUSED_PARAM(param);
 
 	return 0;
 }
@@ -75,9 +72,7 @@ int32_t no_os_timer_init(struct no_os_timer_desc **desc,
  */
 int32_t no_os_timer_remove(struct no_os_timer_desc *desc)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(desc);
 
 	return 0;
 }
@@ -89,9 +84,7 @@ int32_t no_os_timer_remove(struct no_os_timer_desc *desc)
  */
 int32_t no_os_timer_start(struct no_os_timer_desc *desc)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(desc);
 
 	return 0;
 }
@@ -103,9 +96,7 @@ int32_t no_os_timer_start(struct no_os_timer_desc *desc)
  */
 int32_t no_os_timer_stop(struct no_os_timer_desc *desc)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(desc);
 
 	return 0;
 }
@@ -119,13 +110,8 @@ int32_t no_os_timer_stop(struct no_os_timer_desc *desc)
 int32_t no_os_timer_counter_get(struct no_os_timer_desc *desc,
 				uint32_t *counter)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (counter) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(desc);
+	NO_OS_UNUSED_PARAM(counter);
 
 	return 0;
 }
@@ -138,13 +124,8 @@ int32_t no_os_timer_counter_get(struct no_os_timer_desc *desc,
  */
 int32_t no_os_timer_counter_set(struct no_os_timer_desc *desc, uint32_t new_val)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (new_val) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(desc);
+	NO_OS_UNUSED_PARAM(new_val);
 
 	return 0;
 }
@@ -158,13 +139,8 @@ int32_t no_os_timer_counter_set(struct no_os_timer_desc *desc, uint32_t new_val)
 int32_t no_os_timer_count_clk_get(struct no_os_timer_desc *desc,
 				  uint32_t *freq_hz)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (freq_hz) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(desc);
+	NO_OS_UNUSED_PARAM(freq_hz);
 
 	return 0;
 }
@@ -178,13 +154,8 @@ int32_t no_os_timer_count_clk_get(struct no_os_timer_desc *desc,
 int32_t no_os_timer_count_clk_set(struct no_os_timer_desc *desc,
 				  uint32_t freq_hz)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (freq_hz) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(desc);
+	NO_OS_UNUSED_PARAM(freq_hz);
 
 	return 0;
 }

--- a/drivers/platform/generic/no_os_uart.c
+++ b/drivers/platform/generic/no_os_uart.c
@@ -43,6 +43,7 @@
 #include <stdio.h>
 #include "no_os_error.h"
 #include "no_os_uart.h"
+#include "no_os_util.h"
 
 /******************************************************************************/
 /************************ Functions Definitions *******************************/
@@ -58,17 +59,9 @@
 int32_t no_os_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
 			uint32_t bytes_number)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (data) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (bytes_number) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(desc);
+	NO_OS_UNUSED_PARAM(data);
+	NO_OS_UNUSED_PARAM(bytes_number);
 
 	return 0;
 }
@@ -83,17 +76,9 @@ int32_t no_os_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
 int32_t no_os_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
 			 uint32_t bytes_number)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (data) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (bytes_number) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(desc);
+	NO_OS_UNUSED_PARAM(data);
+	NO_OS_UNUSED_PARAM(bytes_number);
 
 	return 0;
 }
@@ -110,17 +95,9 @@ int32_t no_os_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
 int32_t no_os_uart_read_nonblocking(struct no_os_uart_desc *desc, uint8_t *data,
 				    uint32_t bytes_number)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (data) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (bytes_number) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(desc);
+	NO_OS_UNUSED_PARAM(data);
+	NO_OS_UNUSED_PARAM(bytes_number);
 
 	return 0;
 }
@@ -138,17 +115,9 @@ int32_t no_os_uart_write_nonblocking(struct no_os_uart_desc *desc,
 				     const uint8_t *data,
 				     uint32_t bytes_number)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (data) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (bytes_number) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(desc);
+	NO_OS_UNUSED_PARAM(data);
+	NO_OS_UNUSED_PARAM(bytes_number);
 
 	return 0;
 }
@@ -162,13 +131,8 @@ int32_t no_os_uart_write_nonblocking(struct no_os_uart_desc *desc,
 int32_t no_os_uart_init(struct no_os_uart_desc **desc,
 			struct no_os_uart_init_param *param)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
-
-	if (param) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(desc);
+	NO_OS_UNUSED_PARAM(param);
 
 	return 0;
 }
@@ -180,9 +144,7 @@ int32_t no_os_uart_init(struct no_os_uart_desc **desc,
  */
 int32_t no_os_uart_remove(struct no_os_uart_desc *desc)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(desc);
 
 	return 0;
 }
@@ -194,9 +156,7 @@ int32_t no_os_uart_remove(struct no_os_uart_desc *desc)
  */
 uint32_t no_os_uart_get_errors(struct no_os_uart_desc *desc)
 {
-	if (desc) {
-		// Unused variable - fix compiler warning
-	}
+	NO_OS_UNUSED_PARAM(desc);
 
 	return 0;
 }


### PR DESCRIPTION
Use NO_OS_UNUSED_PARAM macro for the unused parameters in the function
implementations.