### PR TITLE
platform: generic: add generic prefixes

### DIFF
--- a/drivers/platform/generic/generic_axi_io.c
+++ b/drivers/platform/generic/generic_axi_io.c
@@ -1,5 +1,5 @@
 /***************************************************************************//**
- *   @file   generic/axi_io.c
+ *   @file   generic/generic_axi_io.c
  *   @brief  Implementation of generic AXI IO
  *   @author Dragos Bogdan (dragos.bogdan@analog.com)
 ********************************************************************************

--- a/drivers/platform/generic/generic_delay.c
+++ b/drivers/platform/generic/generic_delay.c
@@ -1,5 +1,5 @@
 /***************************************************************************//**
- *   @file   generic/delay.c
+ *   @file   generic/generic_delay.c
  *   @brief  Implementation of Generic Platform Drivers.
  *   @author DBogdan (dragos.bogdan@analog.com)
 ********************************************************************************

--- a/drivers/platform/generic/generic_i2c.c
+++ b/drivers/platform/generic/generic_i2c.c
@@ -1,5 +1,5 @@
 /***************************************************************************//**
- *   @file   generic/i2c.c
+ *   @file   generic/generic_i2c.c
  *   @author DBogdan (dragos.bogdan@analog.com)
 ********************************************************************************
  * Copyright 2019(c) Analog Devices, Inc.

--- a/drivers/platform/generic/generic_timer.c
+++ b/drivers/platform/generic/generic_timer.c
@@ -1,5 +1,5 @@
 /***************************************************************************//**
-*   @file   generic/no_os_timer.c
+*   @file   generic/generic_timer.c
 *   @brief  Timer control module source.
 *   @author Andrei Drimbarean (andrei.drimbarean@analog.com)
 ********************************************************************************

--- a/drivers/platform/generic/generic_trng.c
+++ b/drivers/platform/generic/generic_trng.c
@@ -1,5 +1,5 @@
 /***************************************************************************//**
- *   @file   no_os_trng.c
+ *   @file   generic_trng.c
  *   @brief  Generic implementation of true random number generator
  *   @author Mihail Chindris (mihail.chindris@analog.com)
 ********************************************************************************

--- a/drivers/platform/generic/generic_uart.c
+++ b/drivers/platform/generic/generic_uart.c
@@ -1,5 +1,5 @@
 /***************************************************************************//**
- *   @file   generic/no_os_uart.c
+ *   @file   generic/generic_uart.c
  *   @author Cristian Pop (cristian.pop@analog.com)
 ********************************************************************************
  * Copyright 2019(c) Analog Devices, Inc.


### PR DESCRIPTION
Add `generic_prefix` to all generic platform driver implementations.