### PR TITLE
platform: axi_io: adapt projects to new prefix

### DIFF
--- a/drivers/platform/altera/altera_axi_io.c
+++ b/drivers/platform/altera/altera_axi_io.c
@@ -1,5 +1,5 @@
 /***************************************************************************//**
- *   @file   altera/axi_io.c
+ *   @file   altera/altera_axi_io.c
  *   @brief  Implementation of Altera AXI IO .
  *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
 ********************************************************************************

--- a/drivers/platform/linux/linux_axi_io.c
+++ b/drivers/platform/linux/linux_axi_io.c
@@ -1,5 +1,5 @@
 /***************************************************************************//**
- *   @file   linux/axi_io.c
+ *   @file   linux/linux_axi_io.c
  *   @brief  Implementation of AXI IO through UIO/devmem.
  *   @author Dragos Bogdan (dragos.bogdan@analog.com)
 ********************************************************************************

--- a/drivers/platform/xilinx/xilinx_axi_io.c
+++ b/drivers/platform/xilinx/xilinx_axi_io.c
@@ -1,5 +1,5 @@
 /***************************************************************************//**
- *   @file   xilinx/axi_io.c
+ *   @file   xilinx/xilinx_axi_io.c
  *   @brief  Implementation of Xilinx AXI IO.
  *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
 ********************************************************************************

--- a/projects/ad400x-fmcz/src.mk
+++ b/projects/ad400x-fmcz/src.mk
@@ -15,7 +15,7 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine.c \
 	$(NO-OS)/util/no_os_util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/delay.c
 INCS += $(DRIVERS)/adc/ad400x/ad400x.h \

--- a/projects/ad463x_fmcz/src.mk
+++ b/projects/ad463x_fmcz/src.mk
@@ -19,7 +19,7 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/axi_core/axi_pwmgen/axi_pwm.c \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine.c \
 	$(NO-OS)/util/no_os_util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/delay.c

--- a/projects/ad469x_fmcz/src.mk
+++ b/projects/ad469x_fmcz/src.mk
@@ -18,7 +18,7 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/axi_core/axi_pwmgen/axi_pwm.c \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine.c \
 	$(NO-OS)/util/no_os_util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/delay.c

--- a/projects/ad5766-sdz/src.mk
+++ b/projects/ad5766-sdz/src.mk
@@ -17,7 +17,7 @@ SRCS += $(PROJECT)/src/ad5766_core.c \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine.c \
 	$(NO-OS)/util/no_os_util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/delay.c

--- a/projects/ad6676-ebz/src.mk
+++ b/projects/ad6676-ebz/src.mk
@@ -25,7 +25,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(DRIVERS)/api/no_os_gpio.c \
 	$(DRIVERS)/adc/ad6676/ad6676.c \
 	$(NO-OS)/util/no_os_util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/delay.c

--- a/projects/ad7124-4sdz/src.mk
+++ b/projects/ad7124-4sdz/src.mk
@@ -13,7 +13,7 @@ SRCS += $(PROJECT)/src/ad7124-4sdz.c
 SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/adc/ad7124/ad7124.c \
 	$(DRIVERS)/adc/ad7124/ad7124_regs.c				
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/delay.c
 INCS += $(DRIVERS)/adc/ad7124/ad7124.h \

--- a/projects/ad713x_fmcz/src.mk
+++ b/projects/ad713x_fmcz/src.mk
@@ -19,7 +19,7 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/axi_core/axi_pwmgen/axi_pwm.c \
 	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
 	$(NO-OS)/util/no_os_util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/delay.c

--- a/projects/ad738x_fmcz/src.mk
+++ b/projects/ad738x_fmcz/src.mk
@@ -15,7 +15,7 @@ SRCS += $(DRIVERS)/adc/ad738x/ad738x.c \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine.c \
 	$(NO-OS)/util/no_os_util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/delay.c
 INCS += $(PROJECT)/src/app_config.h \

--- a/projects/ad7616-sdz/src.mk
+++ b/projects/ad7616-sdz/src.mk
@@ -16,7 +16,7 @@ SRCS += $(DRIVERS)/adc/ad7616/ad7616.c \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine.c \
 	$(NO-OS)/util/no_os_util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/delay.c

--- a/projects/ad7768-1fmcz/src.mk
+++ b/projects/ad7768-1fmcz/src.mk
@@ -18,7 +18,7 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine.c \
 	$(NO-OS)/util/no_os_util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/delay.c

--- a/projects/ad9081/src.mk
+++ b/projects/ad9081/src.mk
@@ -30,7 +30,7 @@ SRCS += $(PROJECT)/src/app.c \
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
 	$(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/api/no_os_gpio.c \
-	$(PLATFORM_DRIVERS)/axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/delay.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \

--- a/projects/ad9083/src.mk
+++ b/projects/ad9083/src.mk
@@ -34,7 +34,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
 	$(NO-OS)/util/no_os_clk.c \
 	$(NO-OS)/util/no_os_util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/delay.c

--- a/projects/ad9172/src.mk
+++ b/projects/ad9172/src.mk
@@ -30,7 +30,7 @@ SRCS += $(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c \
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
 	$(NO-OS)/util/no_os_util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/delay.c

--- a/projects/ad9208/src.mk
+++ b/projects/ad9208/src.mk
@@ -41,7 +41,7 @@ SRCS += $(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c \
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
 	$(NO-OS)/util/no_os_util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/delay.c

--- a/projects/ad9265-fmc-125ebz/src.mk
+++ b/projects/ad9265-fmc-125ebz/src.mk
@@ -28,7 +28,7 @@ SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(NO-OS)/util/no_os_lf256fifo.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c
 endif
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/delay.c
 INCS += $(PROJECT)/src/parameters.h \

--- a/projects/ad9361/src.mk
+++ b/projects/ad9361/src.mk
@@ -20,7 +20,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/api/no_os_gpio.c \
 	$(NO-OS)/util/no_os_util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c
+SRCS +=	$(PLATFORM_DRIVERS)/$(PLATFORM)_axi_io.c
 SRCS +=	$(PLATFORM_DRIVERS)/$(PLATFORM)_spi.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_gpio.c
 ifeq (linux,$(strip $(PLATFORM)))

--- a/projects/ad9371/src.mk
+++ b/projects/ad9371/src.mk
@@ -36,6 +36,7 @@ ifeq (xilinx,$(strip $(PLATFORM)))
 SRCS += $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
 	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
+	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c
 else
@@ -43,11 +44,11 @@ SRCS += $(DRIVERS)/axi_core/clk_altera_a10_fpll/clk_altera_a10_fpll.c \
 	$(DRIVERS)/axi_core/jesd204/altera_a10_atx_pll.c \
 	$(DRIVERS)/axi_core/jesd204/altera_a10_cdr_pll.c \
 	$(DRIVERS)/axi_core/jesd204/altera_adxcvr.c \
+	$(PLATFORM_DRIVERS)/altera_axi_io.c \
 	$(PLATFORM_DRIVERS)/altera_spi.c \
 	$(PLATFORM_DRIVERS)/altera_gpio.c
 endif
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
-	$(PLATFORM_DRIVERS)/delay.c
+SRCS +=	$(PLATFORM_DRIVERS)/delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
 SRCS += $(PLATFORM_DRIVERS)/no_os_uart.c \

--- a/projects/ad9434-fmc-500ebz/src.mk
+++ b/projects/ad9434-fmc-500ebz/src.mk
@@ -28,7 +28,7 @@ SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c \
 	$(DRIVERS)/api/no_os_irq.c
 endif
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/delay.c
 INCS += $(PROJECT)/src/parameters.h \

--- a/projects/ad9467/src.mk
+++ b/projects/ad9467/src.mk
@@ -22,7 +22,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(DRIVERS)/frequency/ad9517/ad9517.c \
 	$(DRIVERS)/api/no_os_spi.c \
 	$(NO-OS)/util/no_os_util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/delay.c
 ifeq (y,$(strip $(TINYIIOD)))

--- a/projects/ad9656_fmc/src.mk
+++ b/projects/ad9656_fmc/src.mk
@@ -36,7 +36,7 @@ SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(NO-OS)/util/no_os_lf256fifo.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c
 endif
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
         $(PLATFORM_DRIVERS)/xilinx_spi.c \
         $(PLATFORM_DRIVERS)/delay.c
 INCS +=	$(PROJECT)/src/app/app_config.h \

--- a/projects/ad9739a-fmc-ebz/src.mk
+++ b/projects/ad9739a-fmc-ebz/src.mk
@@ -29,7 +29,7 @@ SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(NO-OS)/util/no_os_lf256fifo.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c
 endif
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/delay.c
 INCS += $(PROJECT)/src/parameters.h \

--- a/projects/adaq7980_sdz/src.mk
+++ b/projects/adaq7980_sdz/src.mk
@@ -18,7 +18,7 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/axi_core/axi_pwmgen/axi_pwm.c \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine.c \
 	$(NO-OS)/util/no_os_util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/delay.c

--- a/projects/adaq8092_fmc/src.mk
+++ b/projects/adaq8092_fmc/src.mk
@@ -29,7 +29,7 @@ SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(NO-OS)/util/no_os_lf256fifo.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c
 endif
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/delay.c

--- a/projects/adf4377_sdz/src.mk
+++ b/projects/adf4377_sdz/src.mk
@@ -13,7 +13,7 @@ SRCS += $(PROJECT)/src/app/adf4377_sdz.c
 SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/api/no_os_gpio.c \
 	$(DRIVERS)/frequency/adf4377/adf4377.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/delay.c \

--- a/projects/adf5902_sdz/src.mk
+++ b/projects/adf5902_sdz/src.mk
@@ -13,7 +13,7 @@ SRCS += $(PROJECT)/src/adf5902_sdz.c
 SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/api/no_os_gpio.c \
 	$(DRIVERS)/frequency/adf5902/adf5902.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/delay.c

--- a/projects/adrv9001/src.mk
+++ b/projects/adrv9001/src.mk
@@ -36,7 +36,7 @@ SRCS += $(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
-	$(PLATFORM_DRIVERS)/axi_io.c
+	$(PLATFORM_DRIVERS)/xilinx_axi_io.c
 INCS +=	$(INCLUDE)/no_os_spi.h \
 	$(PLATFORM_DRIVERS)/spi_extra.h \
 	$(INCLUDE)/no_os_gpio.h \

--- a/projects/adrv9009/src.mk
+++ b/projects/adrv9009/src.mk
@@ -67,6 +67,7 @@ ifeq (xilinx,$(strip $(PLATFORM)))
 SRCS += $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
 	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
+	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c
 else
@@ -74,11 +75,11 @@ SRCS += $(DRIVERS)/axi_core/clk_altera_a10_fpll/clk_altera_a10_fpll.c \
 	$(DRIVERS)/axi_core/jesd204/altera_a10_atx_pll.c \
 	$(DRIVERS)/axi_core/jesd204/altera_a10_cdr_pll.c \
 	$(DRIVERS)/axi_core/jesd204/altera_adxcvr.c \
+	$(PLATFORM_DRIVERS)/altera_axi_io.c \
 	$(PLATFORM_DRIVERS)/altera_spi.c \
 	$(PLATFORM_DRIVERS)/altera_gpio.c
 endif
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
-	$(PLATFORM_DRIVERS)/delay.c
+SRCS +=	$(PLATFORM_DRIVERS)/delay.c
 INCS +=	$(PROJECT)/src/app/app_config.h \
 	$(PROJECT)/src/app/app_clocking.h \
 	$(PROJECT)/src/app/app_jesd.h \

--- a/projects/adv7511/src.mk
+++ b/projects/adv7511/src.mk
@@ -24,7 +24,7 @@ SRCS += $(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
 	$(DRIVERS)/api/no_os_irq.c \
 	$(NO-OS)/util/no_os_util.c \
 	$(NO-OS)/util/no_os_list.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/delay.c \

--- a/projects/cn0561/src.mk
+++ b/projects/cn0561/src.mk
@@ -20,7 +20,7 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
 	$(NO-OS)/util/no_os_util.c \
 	$(NO-OS)/util/no_os_lf256fifo.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+SRCS +=	$(PLATFORM_DRIVERS)/$(PLATFORM)_axi_io.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_gpio.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_spi.c \
 	$(PLATFORM_DRIVERS)/delay.c

--- a/projects/fmcadc2/src.mk
+++ b/projects/fmcadc2/src.mk
@@ -22,7 +22,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/api/no_os_gpio.c \
 	$(NO-OS)/util/no_os_util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/delay.c

--- a/projects/fmcadc5/src.mk
+++ b/projects/fmcadc5/src.mk
@@ -23,7 +23,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/api/no_os_gpio.c \
 	$(NO-OS)/util/no_os_util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/delay.c

--- a/projects/fmcdaq2/src.mk
+++ b/projects/fmcdaq2/src.mk
@@ -26,7 +26,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/api/no_os_gpio.c \
 	$(NO-OS)/util/no_os_util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/delay.c

--- a/projects/fmcdaq3/src.mk
+++ b/projects/fmcdaq3/src.mk
@@ -26,7 +26,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/api/no_os_gpio.c \
 	$(NO-OS)/util/no_os_util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/delay.c

--- a/projects/fmcjesdadc1/src.mk
+++ b/projects/fmcjesdadc1/src.mk
@@ -24,7 +24,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(DRIVERS)/adc/ad9250/ad9250.c \
 	$(DRIVERS)/frequency/ad9517/ad9517.c \
 	$(NO-OS)/util/no_os_util.c
-SRCS +=	$(PLATFORM_DRIVERS)/axi_io.c \
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/delay.c


### PR DESCRIPTION
Add platform specific prefix to the axi_io implementations.

Update the projects accordingly.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>