### PR TITLE
Maxim SPI reconfiguration

### DIFF
--- a/drivers/platform/maxim/max32655/maxim_spi.c
+++ b/drivers/platform/maxim/max32655/maxim_spi.c
@@ -57,6 +57,57 @@
 /************************ Functions Definitions *******************************/
 /******************************************************************************/
 
+static int _max_spi_config(struct no_os_spi_desc *desc)
+{
+	struct max_spi_init_param *eparam = desc->extra;
+	int32_t ret;
+
+	mxc_spi_pins_t spi_pins_config = {
+		.clock = true,
+		.ss0 = (desc->chip_select == 0) ? true : false,
+		.ss1 = (desc->chip_select == 1) ? true : false,
+		.ss2 = (desc->chip_select == 2) ? true : false,
+		.miso = true,
+		.mosi = true,
+		.sdio2 = false,
+		.sdio3 = false,
+		.vddioh = true,
+	};
+
+	ret = MXC_SPI_Init(MXC_SPI_GET_SPI(desc->device_id), SPI_MASTER_MODE,
+			   SPI_SINGLE_MODE,
+			   eparam->numSlaves, eparam->polarity, desc->max_speed_hz, spi_pins_config);
+	if (ret) {
+		ret = -EINVAL;
+		goto err_init;
+	}
+
+	ret = MXC_SPI_SetMode(MXC_SPI_GET_SPI(desc->device_id),
+			      (mxc_spi_mode_t)desc->mode);
+	if (ret) {
+		ret = -EINVAL;
+		goto err_init;
+	}
+
+	ret = MXC_SPI_SetWidth(MXC_SPI_GET_SPI(desc->device_id), SPI_WIDTH_STANDARD);
+	if (ret) {
+		ret = -EINVAL;
+		goto err_init;
+	}
+
+	ret = MXC_SPI_SetDataSize(MXC_SPI_GET_SPI(desc->device_id), 8);
+	if (ret) {
+		ret = -EINVAL;
+		goto err_init;
+	}
+
+	return 0;
+err_init:
+	MXC_SPI_Shutdown(MXC_SPI_GET_SPI(desc->device_id));
+
+	return ret;
+}
+
 /**
  * @brief Initialize the SPI communication peripheral.
  * @param desc - The SPI descriptor.
@@ -85,51 +136,16 @@ int32_t max_spi_init(struct no_os_spi_desc **desc,
 	descriptor->mode = param->mode;
 	descriptor->bit_order = param->bit_order;
 	descriptor->platform_ops = &max_spi_ops;
+	descriptor->extra = eparam;
 
 	if (descriptor->device_id >= MXC_SPI_INSTANCES) {
 		ret = -EINVAL;
 		goto err;
 	}
 
-	mxc_spi_pins_t spi_pins_config = {
-		.clock = true,
-		.ss0 = (descriptor->chip_select == 0) ? true : false,
-		.ss1 = (descriptor->chip_select == 1) ? true : false,
-		.ss2 = (descriptor->chip_select == 2) ? true : false,
-		.miso = true,
-		.mosi = true,
-		.sdio2 = false,
-		.sdio3 = false,
-		.vddioh = true
-	};
-
-	ret = MXC_SPI_Init(MXC_SPI_GET_SPI(descriptor->device_id), SPI_MASTER_MODE,
-			   SPI_SINGLE_MODE,
-			   eparam->numSlaves, eparam->polarity, param->max_speed_hz, spi_pins_config);
-
-	if (ret) {
-		ret = -EINVAL;
+	ret = _max_spi_config(descriptor);
+	if (ret)
 		goto err_init;
-	}
-
-	ret = MXC_SPI_SetMode(MXC_SPI_GET_SPI(descriptor->device_id), descriptor->mode);
-	if (ret) {
-		ret = -EINVAL;
-		goto err_init;
-	}
-
-	ret = MXC_SPI_SetWidth(MXC_SPI_GET_SPI(descriptor->device_id),
-			       SPI_WIDTH_STANDARD);
-	if (ret) {
-		ret = -EINVAL;
-		goto err_init;
-	}
-
-	ret = MXC_SPI_SetDataSize(MXC_SPI_GET_SPI(descriptor->device_id), 8);
-	if (ret) {
-		ret = -EINVAL;
-		goto err_init;
-	}
 
 	*desc = descriptor;
 
@@ -159,48 +175,6 @@ int32_t max_spi_remove(struct no_os_spi_desc *desc)
 }
 
 /**
- * @brief Write and read data to/from SPI.
- * @param desc - The SPI descriptor.
- * @param data - The buffer with the transmitted/received data.
- * @param bytes_number - Number of bytes to write/read.
- * @return 0 in case of success, errno codes otherwise.
- */
-int32_t max_spi_write_and_read(struct no_os_spi_desc *desc,
-			       uint8_t *data,
-			       uint16_t bytes_number)
-{
-	int32_t ret;
-	uint8_t *tx_buffer;
-	uint8_t *rx_buffer;
-	mxc_spi_req_t req;
-
-	if (!desc || !data)
-		return -EINVAL;
-
-	rx_buffer = data;
-	tx_buffer = data;
-
-	req.spi = MXC_SPI_GET_SPI(desc->device_id);
-	req.ssIdx = desc->chip_select;
-	req.txData = tx_buffer;
-	req.txCnt = 0;
-	req.rxData = rx_buffer;
-	req.rxCnt= 0;
-	req.ssDeassert = 1;
-	req.txLen= bytes_number;
-	req.rxLen= bytes_number;
-
-	ret = MXC_SPI_MasterTransaction(&req);
-
-	if (ret == E_BAD_PARAM)
-		return -EINVAL;
-	if (ret == E_BAD_STATE)
-		return -EBUSY;
-
-	return 0;
-}
-
-/**
  * @brief Write/read multiple messages to/from SPI.
  * @param desc - The SPI descriptor.
  * @param msgs - The messages array.
@@ -211,11 +185,22 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 			 struct no_os_spi_msg *msgs,
 			 uint32_t len)
 {
+	static uint32_t last_slave_id[MXC_SPI_INSTANCES];
 	mxc_spi_req_t req;
+	uint32_t slave_id;
 	int32_t ret;
 
 	if (!desc || !msgs)
 		return -EINVAL;
+
+	slave_id = desc->chip_select;
+	if (slave_id != last_slave_id[desc->device_id]) {
+		ret = _max_spi_config(desc);
+		if (ret)
+			return ret;
+
+		last_slave_id[desc->device_id] = slave_id;
+	}
 
 	req.spi = MXC_SPI_GET_SPI(desc->device_id);
 	for (uint32_t i = 0; i < len; i++) {
@@ -236,6 +221,27 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 	}
 
 	return 0;
+}
+
+/**
+ * @brief Write and read data to/from SPI.
+ * @param desc - The SPI descriptor.
+ * @param data - The buffer with the transmitted/received data.
+ * @param bytes_number - Number of bytes to write/read.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+int32_t max_spi_write_and_read(struct no_os_spi_desc *desc,
+			       uint8_t *data,
+			       uint16_t bytes_number)
+{
+	struct no_os_spi_msg xfer = {
+		.rx_buff = data,
+		.tx_buff = data,
+		.bytes_number = bytes_number,
+		.cs_change = 1,
+	};
+
+	return max_spi_transfer(desc, &xfer, 1);
 }
 
 /**

--- a/drivers/platform/maxim/max32660/maxim_spi.c
+++ b/drivers/platform/maxim/max32660/maxim_spi.c
@@ -57,6 +57,47 @@
 /************************ Functions Definitions *******************************/
 /******************************************************************************/
 
+static int _max_spi_config(struct no_os_spi_desc *desc)
+{
+	int32_t ret;
+	struct max_spi_init_param *eparam;
+
+	eparam = desc->extra;
+
+	ret = MXC_SPI_Init(MXC_SPI_GET_SPI(desc->device_id), SPI_MASTER_MODE,
+			   SPI_SINGLE_MODE,
+			   eparam->numSlaves, eparam->polarity, desc->max_speed_hz);
+	if (ret) {
+		ret = -EINVAL;
+		goto err_init;
+	}
+
+	ret = MXC_SPI_SetMode(MXC_SPI_GET_SPI(desc->device_id),
+			      (mxc_spi_mode_t)desc->mode);
+	if (ret) {
+		ret = -EINVAL;
+		goto err_init;
+	}
+
+	ret = MXC_SPI_SetWidth(MXC_SPI_GET_SPI(desc->device_id), SPI_WIDTH_STANDARD);
+	if (ret) {
+		ret = -EINVAL;
+		goto err_init;
+	}
+
+	ret = MXC_SPI_SetDataSize(MXC_SPI_GET_SPI(desc->device_id), 8);
+	if (ret) {
+		ret = -EINVAL;
+		goto err_init;
+	}
+
+	return 0;
+err_init:
+	MXC_SPI_Shutdown(MXC_SPI_GET_SPI(desc->device_id));
+
+	return ret;
+}
+
 /**
  * @brief Initialize the SPI communication peripheral.
  * @param desc - The SPI descriptor.
@@ -85,39 +126,16 @@ int32_t max_spi_init(struct no_os_spi_desc **desc,
 	descriptor->mode = param->mode;
 	descriptor->bit_order = param->bit_order;
 	descriptor->platform_ops = &max_spi_ops;
+	descriptor->extra = eparam;
 
 	if (descriptor->device_id >= MXC_SPI_INSTANCES) {
 		ret = -EINVAL;
 		goto err;
 	}
 
-	ret = MXC_SPI_Init(MXC_SPI_GET_SPI(descriptor->device_id), SPI_MASTER_MODE,
-			   SPI_SINGLE_MODE,
-			   eparam->numSlaves, eparam->polarity, param->max_speed_hz);
-	if (ret) {
-		ret = -EINVAL;
+	ret = _max_spi_config(descriptor);
+	if (ret)
 		goto err_init;
-	}
-
-	ret = MXC_SPI_SetMode(MXC_SPI_GET_SPI(descriptor->device_id),
-			      (mxc_spi_mode_t)descriptor->mode);
-	if (ret) {
-		ret = -EINVAL;
-		goto err_init;
-	}
-
-	ret = MXC_SPI_SetWidth(MXC_SPI_GET_SPI(descriptor->device_id),
-			       SPI_WIDTH_STANDARD);
-	if (ret) {
-		ret = -EINVAL;
-		goto err_init;
-	}
-
-	ret = MXC_SPI_SetDataSize(MXC_SPI_GET_SPI(descriptor->device_id), 8);
-	if (ret) {
-		ret = -EINVAL;
-		goto err_init;
-	}
 
 	*desc = descriptor;
 
@@ -147,48 +165,6 @@ int32_t max_spi_remove(struct no_os_spi_desc *desc)
 }
 
 /**
- * @brief Write and read data to/from SPI.
- * @param desc - The SPI descriptor.
- * @param data - The buffer with the transmitted/received data.
- * @param bytes_number - Number of bytes to write/read.
- * @return 0 in case of success, errno codes otherwise.
- */
-int32_t max_spi_write_and_read(struct no_os_spi_desc *desc,
-			       uint8_t *data,
-			       uint16_t bytes_number)
-{
-	int32_t ret;
-	uint8_t *tx_buffer;
-	uint8_t *rx_buffer;
-	mxc_spi_req_t req;
-
-	if (!desc || !data)
-		return -EINVAL;
-
-	rx_buffer = data;
-	tx_buffer = data;
-
-	req.spi = MXC_SPI_GET_SPI(desc->device_id);
-	req.ssIdx = desc->chip_select;
-	req.txData = tx_buffer;
-	req.txCnt = 0;
-	req.rxData = rx_buffer;
-	req.rxCnt= 0;
-	req.ssDeassert = 1;
-	req.txLen= bytes_number;
-	req.rxLen= bytes_number;
-
-	ret = MXC_SPI_MasterTransaction(&req);
-
-	if (ret == E_BAD_PARAM)
-		return -EINVAL;
-	if (ret == E_BAD_STATE)
-		return -EBUSY;
-
-	return 0;
-}
-
-/**
  * @brief Write/read multiple messages to/from SPI.
  * @param desc - The SPI descriptor.
  * @param msgs - The messages array.
@@ -199,11 +175,22 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 			 struct no_os_spi_msg *msgs,
 			 uint32_t len)
 {
+	static uint32_t last_slave_id[MXC_SPI_INSTANCES];
 	mxc_spi_req_t req;
+	uint32_t slave_id;
 	int32_t ret;
 
 	if (!desc || !msgs)
 		return -EINVAL;
+
+	slave_id = desc->chip_select;
+	if (slave_id != last_slave_id[desc->device_id]) {
+		ret = _max_spi_config(desc);
+		if (ret)
+			return ret;
+
+		last_slave_id[desc->device_id] = slave_id;
+	}
 
 	req.spi = MXC_SPI_GET_SPI(desc->device_id);
 	for (uint32_t i = 0; i < len; i++) {
@@ -224,6 +211,27 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 	}
 
 	return 0;
+}
+
+/**
+ * @brief Write and read data to/from SPI.
+ * @param desc - The SPI descriptor.
+ * @param data - The buffer with the transmitted/received data.
+ * @param bytes_number - Number of bytes to write/read.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+int32_t max_spi_write_and_read(struct no_os_spi_desc *desc,
+			       uint8_t *data,
+			       uint16_t bytes_number)
+{
+	struct no_os_spi_msg xfer = {
+		.rx_buff = data,
+		.tx_buff = data,
+		.bytes_number = bytes_number,
+		.cs_change = 1,
+	};
+
+	return max_spi_transfer(desc, &xfer, 1);
 }
 
 /**

--- a/drivers/platform/maxim/max32665/maxim_spi.c
+++ b/drivers/platform/maxim/max32665/maxim_spi.c
@@ -140,6 +140,53 @@ static int32_t _max_spi_enable_ss(uint32_t id, uint32_t chip_select)
 	return 0;
 }
 
+static int _max_spi_config(struct no_os_spi_desc *desc)
+{
+	struct max_spi_init_param *eparam;
+	int32_t ret;
+
+	eparam = desc->extra;
+
+	ret = MXC_SPI_Init(MXC_SPI_GET_SPI(desc->device_id), SPI_MASTER_MODE,
+			   SPI_SINGLE_MODE,
+			   eparam->numSlaves, eparam->polarity, desc->max_speed_hz, MAP_A);
+	if (ret) {
+		ret = -EINVAL;
+		goto err_init;
+	}
+
+	ret = _max_spi_enable_ss(desc->device_id, desc->chip_select);
+	if (ret) {
+		ret = -EINVAL;
+		goto err_init;
+	}
+
+	ret = MXC_SPI_SetMode(MXC_SPI_GET_SPI(desc->device_id),
+			      (mxc_spi_mode_t)desc->mode);
+	if (ret) {
+		ret = -EINVAL;
+		goto err_init;
+	}
+
+	ret = MXC_SPI_SetWidth(MXC_SPI_GET_SPI(desc->device_id), SPI_WIDTH_STANDARD);
+	if (ret) {
+		ret = -EINVAL;
+		goto err_init;
+	}
+
+	ret = MXC_SPI_SetDataSize(MXC_SPI_GET_SPI(desc->device_id), 8);
+	if (ret) {
+		ret = -EINVAL;
+		goto err_init;
+	}
+
+	return 0;
+err_init:
+	MXC_SPI_Shutdown(MXC_SPI_GET_SPI(desc->device_id));
+
+	return ret;
+}
+
 /**
  * @brief Initialize the SPI communication peripheral.
  * @param desc - The SPI descriptor.
@@ -168,46 +215,16 @@ int32_t max_spi_init(struct no_os_spi_desc **desc,
 	descriptor->mode = param->mode;
 	descriptor->bit_order = param->bit_order;
 	descriptor->platform_ops = &max_spi_ops;
+	descriptor->extra = eparam;
 
 	if (descriptor->device_id >= MXC_SPI_INSTANCES) {
 		ret = -EINVAL;
 		goto err;
 	}
 
-	ret = MXC_SPI_Init(MXC_SPI_GET_SPI(descriptor->device_id), SPI_MASTER_MODE,
-			   SPI_SINGLE_MODE,
-			   eparam->numSlaves, eparam->polarity, param->max_speed_hz, MAP_A);
-
-	if (ret) {
-		ret = -EINVAL;
+	ret = _max_spi_config(descriptor);
+	if (ret)
 		goto err_init;
-	}
-
-	ret = _max_spi_enable_ss(descriptor->device_id, descriptor->chip_select);
-	if (ret) {
-		ret = -EINVAL;
-		goto err_init;
-	}
-
-	ret = MXC_SPI_SetMode(MXC_SPI_GET_SPI(descriptor->device_id),
-			      (mxc_spi_mode_t)descriptor->mode);
-	if (ret) {
-		ret = -EINVAL;
-		goto err_init;
-	}
-
-	ret = MXC_SPI_SetWidth(MXC_SPI_GET_SPI(descriptor->device_id),
-			       SPI_WIDTH_STANDARD);
-	if (ret) {
-		ret = -EINVAL;
-		goto err_init;
-	}
-
-	ret = MXC_SPI_SetDataSize(MXC_SPI_GET_SPI(descriptor->device_id), 8);
-	if (ret) {
-		ret = -EINVAL;
-		goto err_init;
-	}
 
 	*desc = descriptor;
 
@@ -237,48 +254,6 @@ int32_t max_spi_remove(struct no_os_spi_desc *desc)
 }
 
 /**
- * @brief Write and read data to/from SPI.
- * @param desc - The SPI descriptor.
- * @param data - The buffer with the transmitted/received data.
- * @param bytes_number - Number of bytes to write/read.
- * @return 0 in case of success, errno codes otherwise.
- */
-int32_t max_spi_write_and_read(struct no_os_spi_desc *desc,
-			       uint8_t *data,
-			       uint16_t bytes_number)
-{
-	int32_t ret;
-	uint8_t *tx_buffer;
-	uint8_t *rx_buffer;
-	mxc_spi_req_t req;
-
-	if (!desc || !data)
-		return -EINVAL;
-
-	rx_buffer = data;
-	tx_buffer = data;
-
-	req.spi = MXC_SPI_GET_SPI(desc->device_id);
-	req.ssIdx = desc->chip_select;
-	req.txData = tx_buffer;
-	req.txCnt = 0;
-	req.rxData = rx_buffer;
-	req.rxCnt= 0;
-	req.ssDeassert = 1;
-	req.txLen= bytes_number;
-	req.rxLen= bytes_number;
-
-	ret = MXC_SPI_MasterTransaction(&req);
-
-	if (ret == E_BAD_PARAM)
-		return -EINVAL;
-	if (ret == E_BAD_STATE)
-		return -EBUSY;
-
-	return 0;
-}
-
-/**
  * @brief Write/read multiple messages to/from SPI.
  * @param desc - The SPI descriptor.
  * @param msgs - The messages array.
@@ -289,11 +264,22 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 			 struct no_os_spi_msg *msgs,
 			 uint32_t len)
 {
+	static uint32_t last_slave_id[MXC_SPI_INSTANCES];
 	mxc_spi_req_t req;
+	uint32_t slave_id;
 	int32_t ret;
 
 	if (!desc || !msgs)
 		return -EINVAL;
+
+	slave_id = desc->chip_select;
+	if (slave_id != last_slave_id[desc->device_id]) {
+		ret = _max_spi_config(desc);
+		if (ret)
+			return ret;
+
+		last_slave_id[desc->device_id] = slave_id;
+	}
 
 	req.spi = MXC_SPI_GET_SPI(desc->device_id);
 	for (uint32_t i = 0; i < len; i++) {
@@ -314,6 +300,27 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 	}
 
 	return 0;
+}
+
+/**
+ * @brief Write and read data to/from SPI.
+ * @param desc - The SPI descriptor.
+ * @param data - The buffer with the transmitted/received data.
+ * @param bytes_number - Number of bytes to write/read.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+int32_t max_spi_write_and_read(struct no_os_spi_desc *desc,
+			       uint8_t *data,
+			       uint16_t bytes_number)
+{
+	struct no_os_spi_msg xfer = {
+		.rx_buff = data,
+		.tx_buff = data,
+		.bytes_number = bytes_number,
+		.cs_change = 1,
+	};
+
+	return max_spi_transfer(desc, &xfer, 1);
 }
 
 /**

--- a/drivers/platform/maxim/max32670/maxim_spi.c
+++ b/drivers/platform/maxim/max32670/maxim_spi.c
@@ -57,6 +57,47 @@
 /************************ Functions Definitions *******************************/
 /******************************************************************************/
 
+static int _max_spi_config(struct no_os_spi_desc *desc)
+{
+	int32_t ret;
+	struct max_spi_init_param *eparam;
+
+	eparam = desc->extra;
+
+	ret = MXC_SPI_Init(MXC_SPI_GET_SPI(desc->device_id), SPI_MASTER_MODE,
+			   SPI_SINGLE_MODE,
+			   eparam->numSlaves, eparam->polarity, desc->max_speed_hz);
+	if (ret) {
+		ret = -EINVAL;
+		goto err_init;
+	}
+
+	ret = MXC_SPI_SetMode(MXC_SPI_GET_SPI(desc->device_id),
+			      (mxc_spi_mode_t)desc->mode);
+	if (ret) {
+		ret = -EINVAL;
+		goto err_init;
+	}
+
+	ret = MXC_SPI_SetWidth(MXC_SPI_GET_SPI(desc->device_id), SPI_WIDTH_STANDARD);
+	if (ret) {
+		ret = -EINVAL;
+		goto err_init;
+	}
+
+	ret = MXC_SPI_SetDataSize(MXC_SPI_GET_SPI(desc->device_id), 8);
+	if (ret) {
+		ret = -EINVAL;
+		goto err_init;
+	}
+
+	return 0;
+err_init:
+	MXC_SPI_Shutdown(MXC_SPI_GET_SPI(descriptor->device_id));
+
+	return ret;
+}
+
 /**
  * @brief Initialize the SPI communication peripheral.
  * @param desc - The SPI descriptor.
@@ -85,39 +126,16 @@ int32_t max_spi_init(struct no_os_spi_desc **desc,
 	descriptor->mode = param->mode;
 	descriptor->bit_order = param->bit_order;
 	descriptor->platform_ops = &max_spi_ops;
+	descriptor->extra = eparam;
 
 	if (descriptor->device_id >= MXC_SPI_INSTANCES) {
 		ret = -EINVAL;
 		goto err;
 	}
 
-	ret = MXC_SPI_Init(MXC_SPI_GET_SPI(descriptor->device_id), SPI_MASTER_MODE,
-			   SPI_SINGLE_MODE,
-			   eparam->numSlaves, eparam->polarity, param->max_speed_hz);
-	if (ret) {
-		ret = -EINVAL;
-		goto err_init;
-	}
-
-	ret = MXC_SPI_SetMode(MXC_SPI_GET_SPI(descriptor->device_id),
-			      (mxc_spi_mode_t)descriptor->mode);
-	if (ret) {
-		ret = -EINVAL;
-		goto err_init;
-	}
-
-	ret = MXC_SPI_SetWidth(MXC_SPI_GET_SPI(descriptor->device_id),
-			       SPI_WIDTH_STANDARD);
-	if (ret) {
-		ret = -EINVAL;
-		goto err_init;
-	}
-
-	ret = MXC_SPI_SetDataSize(MXC_SPI_GET_SPI(descriptor->device_id), 8);
-	if (ret) {
-		ret = -EINVAL;
-		goto err_init;
-	}
+	ret = _max_spi_config(descriptor);
+	if (ret)
+		return ret;
 
 	*desc = descriptor;
 
@@ -147,48 +165,6 @@ int32_t max_spi_remove(struct no_os_spi_desc *desc)
 }
 
 /**
- * @brief Write and read data to/from SPI.
- * @param desc - The SPI descriptor.
- * @param data - The buffer with the transmitted/received data.
- * @param bytes_number - Number of bytes to write/read.
- * @return 0 in case of success, errno codes otherwise.
- */
-int32_t max_spi_write_and_read(struct no_os_spi_desc *desc,
-			       uint8_t *data,
-			       uint16_t bytes_number)
-{
-	int32_t ret;
-	uint8_t *tx_buffer;
-	uint8_t *rx_buffer;
-	mxc_spi_req_t req;
-
-	if (!desc || !data)
-		return -EINVAL;
-
-	rx_buffer = data;
-	tx_buffer = data;
-
-	req.spi = MXC_SPI_GET_SPI(desc->device_id);
-	req.ssIdx = desc->chip_select;
-	req.txData = tx_buffer;
-	req.txCnt = 0;
-	req.rxData = rx_buffer;
-	req.rxCnt= 0;
-	req.ssDeassert = 1;
-	req.txLen= bytes_number;
-	req.rxLen= bytes_number;
-
-	ret = MXC_SPI_MasterTransaction(&req);
-
-	if (ret == E_BAD_PARAM)
-		return -EINVAL;
-	if (ret == E_BAD_STATE)
-		return -EBUSY;
-
-	return 0;
-}
-
-/**
  * @brief Write/read multiple messages to/from SPI.
  * @param desc - The SPI descriptor.
  * @param msgs - The messages array.
@@ -199,11 +175,22 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 			 struct no_os_spi_msg *msgs,
 			 uint32_t len)
 {
+	static uint32_t last_slave_id[MXC_SPI_INSTANCES];
 	mxc_spi_req_t req;
+	uint32_t slave_id;
 	int32_t ret;
 
 	if (!desc || !msgs)
 		return -EINVAL;
+
+	slave_id = desc->chip_select;
+	if (slave_id != last_slave_id[desc->device_id]) {
+		ret = _max_spi_config(desc);
+		if (ret)
+			return ret;
+
+		last_slave_id[desc->device_id] = slave_id;
+	}
 
 	req.spi = MXC_SPI_GET_SPI(desc->device_id);
 	for (uint32_t i = 0; i < len; i++) {
@@ -224,6 +211,27 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 	}
 
 	return 0;
+}
+
+/**
+ * @brief Write and read data to/from SPI.
+ * @param desc - The SPI descriptor.
+ * @param data - The buffer with the transmitted/received data.
+ * @param bytes_number - Number of bytes to write/read.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+int32_t max_spi_write_and_read(struct no_os_spi_desc *desc,
+			       uint8_t *data,
+			       uint16_t bytes_number)
+{
+	struct no_os_spi_msg xfer = {
+		.rx_buff = data,
+		.tx_buff = data,
+		.bytes_number = bytes_number,
+		.cs_change = 1,
+	};
+
+	return max_spi_transfer(desc, &xfer, 1);
 }
 
 /**

--- a/drivers/platform/maxim/max78000/maxim_spi.c
+++ b/drivers/platform/maxim/max78000/maxim_spi.c
@@ -57,6 +57,57 @@
 /************************ Functions Definitions *******************************/
 /******************************************************************************/
 
+static int _max_spi_config(struct no_os_spi_desc *desc)
+{
+	struct max_spi_init_param *eparam = desc->extra;
+	int32_t ret;
+
+	mxc_spi_pins_t spi_pins_config = {
+		.clock = true,
+		.ss0 = (desc->chip_select == 0) ? true : false,
+		.ss1 = (desc->chip_select == 1) ? true : false,
+		.ss2 = (desc->chip_select == 2) ? true : false,
+		.miso = true,
+		.mosi = true,
+		.sdio2 = false,
+		.sdio3 = false,
+		.vddioh = true,
+	};
+
+	ret = MXC_SPI_Init(MXC_SPI_GET_SPI(desc->device_id), SPI_MASTER_MODE,
+			   SPI_SINGLE_MODE,
+			   eparam->numSlaves, eparam->polarity, desc->max_speed_hz, spi_pins_config);
+	if (ret) {
+		ret = -EINVAL;
+		goto err_init;
+	}
+
+	ret = MXC_SPI_SetMode(MXC_SPI_GET_SPI(desc->device_id),
+			      (mxc_spi_mode_t)desc->mode);
+	if (ret) {
+		ret = -EINVAL;
+		goto err_init;
+	}
+
+	ret = MXC_SPI_SetWidth(MXC_SPI_GET_SPI(desc->device_id), SPI_WIDTH_STANDARD);
+	if (ret) {
+		ret = -EINVAL;
+		goto err_init;
+	}
+
+	ret = MXC_SPI_SetDataSize(MXC_SPI_GET_SPI(desc->device_id), 8);
+	if (ret) {
+		ret = -EINVAL;
+		goto err_init;
+	}
+
+	return 0;
+err_init:
+	MXC_SPI_Shutdown(MXC_SPI_GET_SPI(desc->device_id));
+
+	return ret;
+}
+
 /**
  * @brief Initialize the SPI communication peripheral.
  * @param desc - The SPI descriptor.
@@ -85,51 +136,16 @@ int32_t max_spi_init(struct no_os_spi_desc **desc,
 	descriptor->mode = param->mode;
 	descriptor->bit_order = param->bit_order;
 	descriptor->platform_ops = &max_spi_ops;
+	descriptor->extra = eparam;
 
 	if (descriptor->device_id >= MXC_SPI_INSTANCES) {
 		ret = -EINVAL;
 		goto err;
 	}
 
-	mxc_spi_pins_t spi_pins_config = {
-		.clock = true,
-		.ss0 = (descriptor->chip_select == 0) ? true : false,
-		.ss1 = (descriptor->chip_select == 1) ? true : false,
-		.ss2 = (descriptor->chip_select == 2) ? true : false,
-		.miso = true,
-		.mosi = true,
-		.sdio2 = false,
-		.sdio3 = false,
-		.vddioh = true
-	};
-
-	ret = MXC_SPI_Init(MXC_SPI_GET_SPI(descriptor->device_id), SPI_MASTER_MODE,
-			   SPI_SINGLE_MODE,
-			   eparam->numSlaves, eparam->polarity, param->max_speed_hz, spi_pins_config);
-	if (ret) {
-		ret = -EINVAL;
+	ret = _max_spi_config(descriptor);
+	if (ret)
 		goto err_init;
-	}
-
-	ret = MXC_SPI_SetMode(MXC_SPI_GET_SPI(descriptor->device_id),
-			      (mxc_spi_mode_t)descriptor->mode);
-	if (ret) {
-		ret = -EINVAL;
-		goto err_init;
-	}
-
-	ret = MXC_SPI_SetWidth(MXC_SPI_GET_SPI(descriptor->device_id),
-			       SPI_WIDTH_STANDARD);
-	if (ret) {
-		ret = -EINVAL;
-		goto err_init;
-	}
-
-	ret = MXC_SPI_SetDataSize(MXC_SPI_GET_SPI(descriptor->device_id), 8);
-	if (ret) {
-		ret = -EINVAL;
-		goto err_init;
-	}
 
 	*desc = descriptor;
 
@@ -160,48 +176,6 @@ int32_t max_spi_remove(struct no_os_spi_desc *desc)
 }
 
 /**
- * @brief Write and read data to/from SPI.
- * @param desc - The SPI descriptor.
- * @param data - The buffer with the transmitted/received data.
- * @param bytes_number - Number of bytes to write/read.
- * @return 0 in case of success, errno codes otherwise.
- */
-int32_t max_spi_write_and_read(struct no_os_spi_desc *desc,
-			       uint8_t *data,
-			       uint16_t bytes_number)
-{
-	int32_t ret;
-	uint8_t *tx_buffer;
-	uint8_t *rx_buffer;
-	mxc_spi_req_t req;
-
-	if (!desc || !data)
-		return -EINVAL;
-
-	rx_buffer = data;
-	tx_buffer = data;
-
-	req.spi = MXC_SPI_GET_SPI(desc->device_id);
-	req.ssIdx = desc->chip_select;
-	req.txData = tx_buffer;
-	req.txCnt = 0;
-	req.rxData = rx_buffer;
-	req.rxCnt= 0;
-	req.ssDeassert = 1;
-	req.txLen= bytes_number;
-	req.rxLen= bytes_number;
-
-	ret = MXC_SPI_MasterTransaction(&req);
-
-	if (ret == E_BAD_PARAM)
-		return -EINVAL;
-	if (ret == E_BAD_STATE)
-		return -EBUSY;
-
-	return 0;
-}
-
-/**
  * @brief Write/read multiple messages to/from SPI.
  * @param desc - The SPI descriptor.
  * @param msgs - The messages array.
@@ -212,11 +186,22 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 			 struct no_os_spi_msg *msgs,
 			 uint32_t len)
 {
+	static uint32_t last_slave_id[MXC_SPI_INSTANCES];
 	mxc_spi_req_t req;
+	uint32_t slave_id;
 	int32_t ret;
 
 	if (!desc || !msgs)
 		return -EINVAL;
+
+	slave_id = desc->chip_select;
+	if (slave_id != last_slave_id[desc->device_id]) {
+		ret = _max_spi_config(desc);
+		if (ret)
+			return ret;
+
+		last_slave_id[desc->device_id] = slave_id;
+	}
 
 	req.spi = MXC_SPI_GET_SPI(desc->device_id);
 	for (uint32_t i = 0; i < len; i++) {
@@ -237,6 +222,27 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 	}
 
 	return 0;
+}
+
+/**
+ * @brief Write and read data to/from SPI.
+ * @param desc - The SPI descriptor.
+ * @param data - The buffer with the transmitted/received data.
+ * @param bytes_number - Number of bytes to write/read.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+int32_t max_spi_write_and_read(struct no_os_spi_desc *desc,
+			       uint8_t *data,
+			       uint16_t bytes_number)
+{
+	struct no_os_spi_msg xfer = {
+		.rx_buff = data,
+		.tx_buff = data,
+		.bytes_number = bytes_number,
+		.cs_change = 1,
+	};
+
+	return max_spi_transfer(desc, &xfer, 1);
 }
 
 /**


### PR DESCRIPTION
- implement SPI reconfiguration before transfers.
- replace `spi_write_and_read()` with a `spi_transfer()` call.