### PR TITLE
platform: delay: add platform specific prefix

### DIFF
--- a/drivers/platform/altera/altera_delay.c
+++ b/drivers/platform/altera/altera_delay.c
@@ -1,6 +1,6 @@
 /***************************************************************************//**
- *   @file   xilinx/delay.c
- *   @brief  Implementation of Xilinx Delay Functions.
+ *   @file   altera/altera_delay.c
+ *   @brief  Implementation of Altera Delay Functions.
  *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
 ********************************************************************************
  * Copyright 2019(c) Analog Devices, Inc.
@@ -42,7 +42,6 @@
 /******************************************************************************/
 
 #include "no_os_delay.h"
-#include <sleep.h>
 
 /******************************************************************************/
 /************************ Functions Definitions *******************************/
@@ -55,11 +54,7 @@
  */
 void no_os_udelay(uint32_t usecs)
 {
-#ifdef _XPARAMETERS_PS_H_
 	usleep(usecs);
-#else
-	usleep_MB(usecs);
-#endif
 }
 
 /**
@@ -69,9 +64,5 @@ void no_os_udelay(uint32_t usecs)
  */
 void no_os_mdelay(uint32_t msecs)
 {
-#ifdef _XPARAMETERS_PS_H_
 	usleep(msecs * 1000);
-#else
-	usleep_MB(msecs * 1000);
-#endif
 }

--- a/drivers/platform/xilinx/xilinx_delay.c
+++ b/drivers/platform/xilinx/xilinx_delay.c
@@ -1,6 +1,6 @@
 /***************************************************************************//**
- *   @file   altera/delay.c
- *   @brief  Implementation of Altera Delay Functions.
+ *   @file   xilinx/xilinx_delay.c
+ *   @brief  Implementation of Xilinx Delay Functions.
  *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
 ********************************************************************************
  * Copyright 2019(c) Analog Devices, Inc.
@@ -42,6 +42,7 @@
 /******************************************************************************/
 
 #include "no_os_delay.h"
+#include <sleep.h>
 
 /******************************************************************************/
 /************************ Functions Definitions *******************************/
@@ -54,7 +55,11 @@
  */
 void no_os_udelay(uint32_t usecs)
 {
+#ifdef _XPARAMETERS_PS_H_
 	usleep(usecs);
+#else
+	usleep_MB(usecs);
+#endif
 }
 
 /**
@@ -64,5 +69,9 @@ void no_os_udelay(uint32_t usecs)
  */
 void no_os_mdelay(uint32_t msecs)
 {
+#ifdef _XPARAMETERS_PS_H_
 	usleep(msecs * 1000);
+#else
+	usleep_MB(msecs * 1000);
+#endif
 }

--- a/projects/ad400x-fmcz/src.mk
+++ b/projects/ad400x-fmcz/src.mk
@@ -17,7 +17,7 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(NO-OS)/util/no_os_util.c
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
-	$(PLATFORM_DRIVERS)/delay.c
+	$(PLATFORM_DRIVERS)/xilinx_delay.c
 INCS += $(DRIVERS)/adc/ad400x/ad400x.h \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine.h \

--- a/projects/ad4110/src.mk
+++ b/projects/ad4110/src.mk
@@ -19,7 +19,7 @@ SRCS += $(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_irq.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio_irq.c \
-	$(PLATFORM_DRIVERS)/delay.c \
+	$(PLATFORM_DRIVERS)/xilinx_delay.c \
 	$(NO-OS)/util/no_os_list.c
 
 INCS += $(DRIVERS)/afe/ad4110/ad4110.h

--- a/projects/ad413x/src.mk
+++ b/projects/ad413x/src.mk
@@ -19,7 +19,7 @@ SRCS += $(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_irq.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio_irq.c \
-	$(PLATFORM_DRIVERS)/delay.c \
+	$(PLATFORM_DRIVERS)/xilinx_delay.c \
 	$(NO-OS)/util/no_os_list.c \
 	$(NO-OS)/util/no_os_crc8.c
 

--- a/projects/ad463x_fmcz/src.mk
+++ b/projects/ad463x_fmcz/src.mk
@@ -22,7 +22,7 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
-	$(PLATFORM_DRIVERS)/delay.c
+	$(PLATFORM_DRIVERS)/xilinx_delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
 SRC_DIRS += $(NO-OS)/iio/iio_app

--- a/projects/ad469x_fmcz/src.mk
+++ b/projects/ad469x_fmcz/src.mk
@@ -21,7 +21,7 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
-	$(PLATFORM_DRIVERS)/delay.c
+	$(PLATFORM_DRIVERS)/xilinx_delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
 SRC_DIRS += $(NO-OS)/iio/iio_app	

--- a/projects/ad5758-sdz/src.mk
+++ b/projects/ad5758-sdz/src.mk
@@ -4,7 +4,7 @@ SRCS += $(DRIVERS)/api/no_os_gpio.c \
         $(DRIVERS)/api/no_os_spi.c \
         $(PLATFORM_DRIVERS)/$(PLATFORM)_spi.c \
         $(PLATFORM_DRIVERS)/$(PLATFORM)_gpio.c \
-	$(PLATFORM_DRIVERS)/delay.c \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_delay.c \
 	$(DRIVERS)/dac/ad5758/ad5758.c
 
 INCS += $(INCLUDE)/no_os_gpio.h \

--- a/projects/ad5766-sdz/src.mk
+++ b/projects/ad5766-sdz/src.mk
@@ -20,7 +20,7 @@ SRCS += $(PROJECT)/src/ad5766_core.c \
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
-	$(PLATFORM_DRIVERS)/delay.c
+	$(PLATFORM_DRIVERS)/xilinx_delay.c
 INCS += $(PROJECT)/src/parameters.h \
 	$(PROJECT)/src/ad5766_core.h \
 	$(DRIVERS)/dac/ad5766/ad5766.h \

--- a/projects/ad6676-ebz/src.mk
+++ b/projects/ad6676-ebz/src.mk
@@ -28,7 +28,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
-	$(PLATFORM_DRIVERS)/delay.c
+	$(PLATFORM_DRIVERS)/xilinx_delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
 SRCS += $(NO-OS)/util/no_os_fifo.c \

--- a/projects/ad7124-4sdz/src.mk
+++ b/projects/ad7124-4sdz/src.mk
@@ -15,7 +15,7 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/adc/ad7124/ad7124_regs.c				
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
-	$(PLATFORM_DRIVERS)/delay.c
+	$(PLATFORM_DRIVERS)/xilinx_delay.c
 INCS += $(DRIVERS)/adc/ad7124/ad7124.h \
 	$(DRIVERS)/adc/ad7124/ad7124_regs.h
 

--- a/projects/ad713x_fmcz/src.mk
+++ b/projects/ad713x_fmcz/src.mk
@@ -22,7 +22,7 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
-	$(PLATFORM_DRIVERS)/delay.c
+	$(PLATFORM_DRIVERS)/xilinx_delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
 SRC_DIRS += $(NO-OS)/iio/iio_app

--- a/projects/ad719x/src/platform/xilinx/platform_src.mk
+++ b/projects/ad719x/src/platform/xilinx/platform_src.mk
@@ -2,7 +2,7 @@ SRCS += $(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_irq.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio_irq.c \
-	$(PLATFORM_DRIVERS)/delay.c
+	$(PLATFORM_DRIVERS)/xilinx_delay.c
 
 INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \

--- a/projects/ad738x_fmcz/src.mk
+++ b/projects/ad738x_fmcz/src.mk
@@ -17,7 +17,7 @@ SRCS += $(DRIVERS)/adc/ad738x/ad738x.c \
 	$(NO-OS)/util/no_os_util.c
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
-	$(PLATFORM_DRIVERS)/delay.c
+	$(PLATFORM_DRIVERS)/xilinx_delay.c
 INCS += $(PROJECT)/src/app_config.h \
 	$(PROJECT)/src/parameters.h \
 	$(DRIVERS)/adc/ad738x/ad738x.h \

--- a/projects/ad7616-sdz/src.mk
+++ b/projects/ad7616-sdz/src.mk
@@ -19,7 +19,7 @@ SRCS += $(DRIVERS)/adc/ad7616/ad7616.c \
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
-	$(PLATFORM_DRIVERS)/delay.c
+	$(PLATFORM_DRIVERS)/xilinx_delay.c
 INCS += $(PROJECT)/src/parameters.h \
 	$(DRIVERS)/adc/ad7616/ad7616.h \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \

--- a/projects/ad7768-1fmcz/src.mk
+++ b/projects/ad7768-1fmcz/src.mk
@@ -21,7 +21,7 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
-	$(PLATFORM_DRIVERS)/delay.c
+	$(PLATFORM_DRIVERS)/xilinx_delay.c
 INCS += $(PROJECT)/src/parameters.h
 INCS += $(DRIVERS)/adc/ad7768-1/ad77681.h \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \

--- a/projects/ad9081/src.mk
+++ b/projects/ad9081/src.mk
@@ -31,7 +31,7 @@ SRCS += $(PROJECT)/src/app.c \
 	$(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/api/no_os_gpio.c \
 	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
-	$(PLATFORM_DRIVERS)/delay.c \
+	$(PLATFORM_DRIVERS)/xilinx_delay.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(NO-OS)/util/no_os_clk.c \

--- a/projects/ad9083/src.mk
+++ b/projects/ad9083/src.mk
@@ -37,7 +37,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
-	$(PLATFORM_DRIVERS)/delay.c
+	$(PLATFORM_DRIVERS)/xilinx_delay.c
 INCS += $(PROJECT)/src/app_ad9083.h \
 	$(PROJECT)/src/app_clocking.h \
 	$(PROJECT)/src/app_config.h \

--- a/projects/ad9172/src.mk
+++ b/projects/ad9172/src.mk
@@ -33,7 +33,7 @@ SRCS += $(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c \
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
-	$(PLATFORM_DRIVERS)/delay.c
+	$(PLATFORM_DRIVERS)/xilinx_delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(NO-OS)/util/no_os_list.c \

--- a/projects/ad9208/src.mk
+++ b/projects/ad9208/src.mk
@@ -44,7 +44,7 @@ SRCS += $(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
-	$(PLATFORM_DRIVERS)/delay.c
+	$(PLATFORM_DRIVERS)/xilinx_delay.c
 
 INCS += $(DRIVERS)/frequency/hmc7044/hmc7044.h \
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h \

--- a/projects/ad9265-fmc-125ebz/src.mk
+++ b/projects/ad9265-fmc-125ebz/src.mk
@@ -30,7 +30,7 @@ SRCS += $(NO-OS)/util/no_os_fifo.c \
 endif
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
-	$(PLATFORM_DRIVERS)/delay.c
+	$(PLATFORM_DRIVERS)/xilinx_delay.c
 INCS += $(PROJECT)/src/parameters.h \
 	$(DRIVERS)/adc/ad9265/ad9265.h \
 	$(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \

--- a/projects/ad9361/src.mk
+++ b/projects/ad9361/src.mk
@@ -26,7 +26,7 @@ SRCS +=	$(PLATFORM_DRIVERS)/$(PLATFORM)_spi.c \
 ifeq (linux,$(strip $(PLATFORM)))
 SRCS +=	$(PLATFORM_DRIVERS)/linux_delay.c
 else
-SRCS +=	$(PLATFORM_DRIVERS)/delay.c
+SRCS +=	$(PLATFORM_DRIVERS)/$(PLATFORM)_delay.c
 endif
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio

--- a/projects/ad9371/src.mk
+++ b/projects/ad9371/src.mk
@@ -37,6 +37,7 @@ SRCS += $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
 	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
 	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_delay.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c
 else
@@ -46,9 +47,9 @@ SRCS += $(DRIVERS)/axi_core/clk_altera_a10_fpll/clk_altera_a10_fpll.c \
 	$(DRIVERS)/axi_core/jesd204/altera_adxcvr.c \
 	$(PLATFORM_DRIVERS)/altera_axi_io.c \
 	$(PLATFORM_DRIVERS)/altera_spi.c \
-	$(PLATFORM_DRIVERS)/altera_gpio.c
+	$(PLATFORM_DRIVERS)/altera_gpio.c \
+	$(PLATFORM_DRIVERS)/altera_delay.c
 endif
-SRCS +=	$(PLATFORM_DRIVERS)/delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
 SRCS += $(PLATFORM_DRIVERS)/no_os_uart.c \

--- a/projects/ad9434-fmc-500ebz/src.mk
+++ b/projects/ad9434-fmc-500ebz/src.mk
@@ -30,7 +30,7 @@ SRCS += $(NO-OS)/util/no_os_fifo.c \
 endif
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
-	$(PLATFORM_DRIVERS)/delay.c
+	$(PLATFORM_DRIVERS)/xilinx_delay.c
 INCS += $(PROJECT)/src/parameters.h \
 	$(DRIVERS)/adc/ad9434/ad9434.h \
 	$(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \

--- a/projects/ad9467/src.mk
+++ b/projects/ad9467/src.mk
@@ -24,7 +24,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(NO-OS)/util/no_os_util.c
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
-	$(PLATFORM_DRIVERS)/delay.c
+	$(PLATFORM_DRIVERS)/xilinx_delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \

--- a/projects/ad9656_fmc/src.mk
+++ b/projects/ad9656_fmc/src.mk
@@ -38,7 +38,7 @@ SRCS += $(NO-OS)/util/no_os_fifo.c \
 endif
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
         $(PLATFORM_DRIVERS)/xilinx_spi.c \
-        $(PLATFORM_DRIVERS)/delay.c
+        $(PLATFORM_DRIVERS)/xilinx_delay.c
 INCS +=	$(PROJECT)/src/app/app_config.h \
         $(PROJECT)/src/devices/adi_hal/parameters.h \
         $(PROJECT)/src/app/ad9508.h \

--- a/projects/ad9739a-fmc-ebz/src.mk
+++ b/projects/ad9739a-fmc-ebz/src.mk
@@ -31,7 +31,7 @@ SRCS += $(NO-OS)/util/no_os_fifo.c \
 endif
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
-	$(PLATFORM_DRIVERS)/delay.c
+	$(PLATFORM_DRIVERS)/xilinx_delay.c
 INCS += $(PROJECT)/src/parameters.h \
 	$(DRIVERS)/frequency/adf4350/adf4350.h \
 	$(DRIVERS)/dac/ad9739a/ad9739a.h \

--- a/projects/adaq7980_sdz/src.mk
+++ b/projects/adaq7980_sdz/src.mk
@@ -21,7 +21,7 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
-	$(PLATFORM_DRIVERS)/delay.c
+	$(PLATFORM_DRIVERS)/xilinx_delay.c
 INCS += $(PROJECT)/src/parameters.h
 INCS += $(DRIVERS)/adc/adaq7980/adaq7980.h \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \

--- a/projects/adaq8092_fmc/src.mk
+++ b/projects/adaq8092_fmc/src.mk
@@ -32,7 +32,7 @@ endif
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
-	$(PLATFORM_DRIVERS)/delay.c
+	$(PLATFORM_DRIVERS)/xilinx_delay.c
 INCS += $(PROJECT)/src/parameters.h \
 	$(PROJECT)/src/app_config.h \
 	$(DRIVERS)/adc/adaq8092/adaq8092.h \

--- a/projects/adf4377_sdz/src.mk
+++ b/projects/adf4377_sdz/src.mk
@@ -16,7 +16,7 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
-	$(PLATFORM_DRIVERS)/delay.c \
+	$(PLATFORM_DRIVERS)/xilinx_delay.c \
 	$(NO-OS)/util/no_os_util.c
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio

--- a/projects/adf5902_sdz/src.mk
+++ b/projects/adf5902_sdz/src.mk
@@ -16,7 +16,7 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
-	$(PLATFORM_DRIVERS)/delay.c
+	$(PLATFORM_DRIVERS)/xilinx_delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
 SRCS += $(NO-OS)/util/no_os_fifo.c \

--- a/projects/adrv9001/src.mk
+++ b/projects/adrv9001/src.mk
@@ -31,7 +31,7 @@ SRCS += $(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(DRIVERS)/api/no_os_gpio.c \
 	$(DRIVERS)/api/no_os_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
-	$(PLATFORM_DRIVERS)/delay.c \
+	$(PLATFORM_DRIVERS)/xilinx_delay.c \
 	$(NO-OS)/util/no_os_util.c \
 	$(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c \

--- a/projects/adrv9009/src.mk
+++ b/projects/adrv9009/src.mk
@@ -68,6 +68,7 @@ SRCS += $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
 	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
 	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_delay.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c
 else
@@ -77,9 +78,9 @@ SRCS += $(DRIVERS)/axi_core/clk_altera_a10_fpll/clk_altera_a10_fpll.c \
 	$(DRIVERS)/axi_core/jesd204/altera_adxcvr.c \
 	$(PLATFORM_DRIVERS)/altera_axi_io.c \
 	$(PLATFORM_DRIVERS)/altera_spi.c \
-	$(PLATFORM_DRIVERS)/altera_gpio.c
+	$(PLATFORM_DRIVERS)/altera_gpio.c \
+	$(PLATFORM_DRIVERS)/altera_delay.c
 endif
-SRCS +=	$(PLATFORM_DRIVERS)/delay.c
 INCS +=	$(PROJECT)/src/app/app_config.h \
 	$(PROJECT)/src/app/app_clocking.h \
 	$(PROJECT)/src/app/app_jesd.h \

--- a/projects/adv7511/src.mk
+++ b/projects/adv7511/src.mk
@@ -27,7 +27,7 @@ SRCS += $(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
-	$(PLATFORM_DRIVERS)/delay.c \
+	$(PLATFORM_DRIVERS)/xilinx_delay.c \
 	$(PLATFORM_DRIVERS)/xilinx_i2c.c \
 	$(PLATFORM_DRIVERS)/xilinx_irq.c \
 	$(PLATFORM_DRIVERS)/no_os_timer.c

--- a/projects/cn0561/src.mk
+++ b/projects/cn0561/src.mk
@@ -23,7 +23,7 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 SRCS +=	$(PLATFORM_DRIVERS)/$(PLATFORM)_axi_io.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_gpio.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_spi.c \
-	$(PLATFORM_DRIVERS)/delay.c
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
 SRC_DIRS += $(NO-OS)/iio/iio_app

--- a/projects/eval-adxl367z/src/platform/xilinx/platform_src.mk
+++ b/projects/eval-adxl367z/src/platform/xilinx/platform_src.mk
@@ -1,6 +1,6 @@
 SRCS += $(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_i2c.c \
-	$(PLATFORM_DRIVERS)/delay.c
+	$(PLATFORM_DRIVERS)/xilinx_delay.c
 
 INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
 	$(PLATFORM_DRIVERS)/i2c_extra.h

--- a/projects/fmcadc2/src.mk
+++ b/projects/fmcadc2/src.mk
@@ -25,7 +25,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
-	$(PLATFORM_DRIVERS)/delay.c
+	$(PLATFORM_DRIVERS)/xilinx_delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
 SRC_DIRS += $(NO-OS)/iio/iio_app

--- a/projects/fmcadc5/src.mk
+++ b/projects/fmcadc5/src.mk
@@ -26,7 +26,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
-	$(PLATFORM_DRIVERS)/delay.c
+	$(PLATFORM_DRIVERS)/xilinx_delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
 SRC_DIRS += $(NO-OS)/iio/iio_app

--- a/projects/fmcdaq2/src.mk
+++ b/projects/fmcdaq2/src.mk
@@ -29,7 +29,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
-	$(PLATFORM_DRIVERS)/delay.c
+	$(PLATFORM_DRIVERS)/xilinx_delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
 SRC_DIRS += $(NO-OS)/iio/iio_app

--- a/projects/fmcdaq3/src.mk
+++ b/projects/fmcdaq3/src.mk
@@ -29,7 +29,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
-	$(PLATFORM_DRIVERS)/delay.c
+	$(PLATFORM_DRIVERS)/xilinx_delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
 SRC_DIRS += $(NO-OS)/iio/iio_app

--- a/projects/fmcjesdadc1/src.mk
+++ b/projects/fmcjesdadc1/src.mk
@@ -27,7 +27,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
-	$(PLATFORM_DRIVERS)/delay.c
+	$(PLATFORM_DRIVERS)/xilinx_delay.c
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
 SRCS += $(NO-OS)/util/no_os_fifo.c \

--- a/projects/iio_demo/src/platform/xilinx/platform_src.mk
+++ b/projects/iio_demo/src/platform/xilinx/platform_src.mk
@@ -1,4 +1,4 @@
-SRCS += $(PLATFORM_DRIVERS)/delay.c \
+SRCS += $(PLATFORM_DRIVERS)/$(PLATFORM)_delay.c \
 	$(DRIVERS)/api/no_os_irq.c
 	
 ifeq (y,$(strip $(NETWORKING)))


### PR DESCRIPTION
Add platform prefix to the delay source files.

Update projects accordingly.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>