### PR TITLE
projects: iio_demo: linux: fix platform paths

### DIFF
--- a/projects/iio_demo/src/platform/linux/platform_src.mk
+++ b/projects/iio_demo/src/platform/linux/platform_src.mk
@@ -15,8 +15,8 @@ INCS += $(NO-OS)/network/linux_socket/linux_socket.h \
 SRCS += $(NO-OS)/util/no_os_circular_buffer.c
 INCS += $(INCLUDE)/no_os_circular_buffer.h
 
-SRCS += $(DRIVERS)/platform/generic/no_os_uart.c \
-	$(DRIVERS)/platform/generic/delay.c
+SRCS += $(DRIVERS)/platform/linux/linux_uart.c \
+	$(DRIVERS)/platform/linux/linux_delay.c
 
 
 INCS += $(INCLUDE)/no_os_gpio.h \


### PR DESCRIPTION
Fix the uart, delay platform driver source file paths.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>