### PR TITLE
Fix timer driver (MAX32660)

### DIFF
--- a/drivers/platform/maxim/max32660/maxim_timer.c
+++ b/drivers/platform/maxim/max32660/maxim_timer.c
@@ -132,9 +132,7 @@ int max_timer_init(struct no_os_timer_desc **desc,
 	if (ret)
 		goto free_cfg;
 
-	cfg->bitMode = TMR_BIT_MODE_32;
 	cfg->mode = TMR_MODE_CONTINUOUS;
-	cfg->clock = MXC_TMR_HFIO_CLK;
 	cfg->cmp_cnt = descriptor->ticks_count;
 	cfg->pol = 1;
 	cfg->pres = prescaler;


### PR DESCRIPTION
Due to an SDK update, some fields were removed from the mxc_tmr_cfg_t struct. Do not set these since they are now undefined.