### PR TITLE
drivers:platform:mbed Added I2C frequency set function call

### DIFF
--- a/drivers/platform/mbed/mbed_i2c.cpp
+++ b/drivers/platform/mbed/mbed_i2c.cpp
@@ -94,6 +94,8 @@ int32_t mbed_i2c_init(struct no_os_i2c_desc **desc,
 	if (!mbed_i2c_desc)
 		goto err_mbed_i2c_desc;
 
+	i2c->frequency(param->max_speed_hz);
+
 	mbed_i2c_desc->i2c_port = i2c;
 	i2c_desc->extra = mbed_i2c_desc;
 


### PR DESCRIPTION
Added mbed API call to set the I2C frequency set in init parameters.

Signed-off-by: MPhalke <mahesh.phalke@analog.com>