### PR TITLE
Addition of ADXCVR status bits for more specific check

### DIFF
--- a/drivers/axi_core/jesd204/axi_adxcvr.c
+++ b/drivers/axi_core/jesd204/axi_adxcvr.c
@@ -353,7 +353,7 @@ int32_t adxcvr_status_error(struct adxcvr *xcvr)
 	do {
 		no_os_mdelay(1);
 		adxcvr_read(xcvr, ADXCVR_REG_STATUS, &status);
-	} while ((timeout--) && (status == 0));
+	} while ((timeout--) && !(status & ADXCVR_STATUS));
 
 	if (!status)
 		return -1;


### PR DESCRIPTION
The checking of status bits [5] and [6] introduced in the ADXCVR HDL and the synchronization with the Linux driver for staus check.