### PR TITLE
platform: uart: update header file

### DIFF
--- a/drivers/platform/xilinx/xilinx_uart.c
+++ b/drivers/platform/xilinx/xilinx_uart.c
@@ -37,7 +37,7 @@
 #include <stdlib.h>
 #include "no_os_error.h"
 #include "no_os_uart.h"
-#include "uart_extra.h"
+#include "xilinx_uart.h"
 #ifdef XPAR_XUARTPS_NUM_INSTANCES
 #include "no_os_irq.h"
 #include "no_os_fifo.h"

--- a/drivers/platform/xilinx/xilinx_uart.h
+++ b/drivers/platform/xilinx/xilinx_uart.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *   @file   xilinx/uart_extra.h
+ *   @file   xilinx/xilinx_uart.h
  *   @brief  Header containing types used in the uart driver.
  *   @author Cristian Pop (cristian.pop@analog.com)
 ********************************************************************************
@@ -37,8 +37,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 
-#ifndef UART_EXTRA_H_
-#define UART_EXTRA_H_
+#ifndef XILINX_UART_H_
+#define XILINX_UART_H_
 
 /******************************************************************************/
 /***************************** Include Files **********************************/

--- a/iio/iio_app/iio_app.c
+++ b/iio/iio_app/iio_app.c
@@ -56,7 +56,7 @@
 #include "no_os_error.h"
 #endif
 #if defined(XILINX_PLATFORM)
-#include "uart_extra.h"
+#include "xilinx_uart.h"
 #include "irq_extra.h"
 #endif
 #if defined(STM32_PLATFORM)

--- a/projects/ad400x-fmcz/src.mk
+++ b/projects/ad400x-fmcz/src.mk
@@ -24,7 +24,7 @@ INCS += $(DRIVERS)/adc/ad400x/ad400x.h \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine_private.h
 INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
 INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_spi.h \

--- a/projects/ad413x/src.mk
+++ b/projects/ad413x/src.mk
@@ -48,7 +48,7 @@ SRCS += $(DRIVERS)/afe/ad413x/iio_ad413x.c \
 	$(NO-OS)/util/no_os_fifo.c \
 	$(NO-OS)/util/no_os_util.c
 INCS += $(DRIVERS)/afe/ad413x/iio_ad413x.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(NO-OS)/iio/iio_app/iio_app.h \
 	$(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_uart.h

--- a/projects/ad463x_fmcz/src.mk
+++ b/projects/ad463x_fmcz/src.mk
@@ -43,7 +43,7 @@ INCS += $(DRIVERS)/adc/ad463x/ad463x.h \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine_private.h
 INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
 INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_spi.h \

--- a/projects/ad469x_fmcz/src.mk
+++ b/projects/ad469x_fmcz/src.mk
@@ -41,7 +41,7 @@ INCS += $(DRIVERS)/adc/ad469x/ad469x.h \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine_private.h
 INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
 INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_spi.h \
@@ -60,5 +60,5 @@ INCS += $(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_list.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h				
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h				
 endif

--- a/projects/ad469x_fmcz/src/ad469x_fmcz.c
+++ b/projects/ad469x_fmcz/src/ad469x_fmcz.c
@@ -57,7 +57,7 @@
 #include "iio.h"
 #include "iio_app.h"
 #include "iio_types.h"
-#include "uart_extra.h"
+#include "xilinx_uart.h"
 #include "xil_cache.h"
 #endif // IIO_SUPPORT
 

--- a/projects/ad6676-ebz/src.mk
+++ b/projects/ad6676-ebz/src.mk
@@ -65,6 +65,6 @@ INCS += $(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_list.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h
 endif

--- a/projects/ad7124-4sdz/src.mk
+++ b/projects/ad7124-4sdz/src.mk
@@ -21,7 +21,7 @@ INCS += $(DRIVERS)/adc/ad7124/ad7124.h \
 
 INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
 INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_spi.h \

--- a/projects/ad7124-8pmdz/src/main.c
+++ b/projects/ad7124-8pmdz/src/main.c
@@ -56,7 +56,7 @@
 #ifdef XILINX_PLATFORM
 #include <xil_cache.h>
 #include "irq_extra.h"
-#include "uart_extra.h"
+#include "xilinx_uart.h"
 #include "spi_extra.h"
 #endif
 #ifdef ADUCM_PLATFORM

--- a/projects/ad713x_fmcz/src.mk
+++ b/projects/ad713x_fmcz/src.mk
@@ -40,7 +40,7 @@ INCS += $(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
 	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h
 INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
 INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_spi.h \

--- a/projects/ad713x_fmcz/src/ad713x_fmc.c
+++ b/projects/ad713x_fmcz/src/ad713x_fmc.c
@@ -70,7 +70,7 @@
 #include "no_os_irq.h"
 #include "irq_extra.h"
 #include "no_os_uart.h"
-#include "uart_extra.h"
+#include "xilinx_uart.h"
 #include "iio_dual_ad713x.h"
 #include "iio_ad713x.h"
 #include "iio.h"

--- a/projects/ad74413r/src/examples/examples_src.mk
+++ b/projects/ad74413r/src/examples/examples_src.mk
@@ -31,5 +31,5 @@ SRCS += $(DRIVERS)/adc-dac/ad74413r/iio_ad74413r_trig.c
 endif
 
 INCS += $(INCLUDE)/no_os_list.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h
 endif

--- a/projects/ad7768-1fmcz/src.mk
+++ b/projects/ad7768-1fmcz/src.mk
@@ -29,7 +29,7 @@ INCS += $(DRIVERS)/adc/ad7768-1/ad77681.h \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine_private.h
 INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
 INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_spi.h \

--- a/projects/ad7768-evb/src.mk
+++ b/projects/ad7768-evb/src.mk
@@ -59,7 +59,7 @@ INCS +=	$(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_list.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h
 SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \

--- a/projects/ad9081/src.mk
+++ b/projects/ad9081/src.mk
@@ -103,7 +103,7 @@ INCS += $(NO-OS)/iio/iio_app/iio_app.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_irq.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_list.h \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h \

--- a/projects/ad9083/src.mk
+++ b/projects/ad9083/src.mk
@@ -80,7 +80,7 @@ INCS += $(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_list.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h \
 	$(NO-OS)/iio/iio_app/iio_app.h
 endif

--- a/projects/ad9172/src.mk
+++ b/projects/ad9172/src.mk
@@ -74,6 +74,6 @@ INCS += $(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_list.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.h
 endif

--- a/projects/ad9208/src.mk
+++ b/projects/ad9208/src.mk
@@ -29,7 +29,7 @@ INCS	+= $(INCLUDE)/no_os_uart.h \
 		$(INCLUDE)/no_os_list.h \
 		$(INCLUDE)/no_os_irq.h \
 		$(PLATFORM_DRIVERS)/irq_extra.h \
-		$(PLATFORM_DRIVERS)/uart_extra.h
+		$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h
 		
 endif
 

--- a/projects/ad9265-fmc-125ebz/src.mk
+++ b/projects/ad9265-fmc-125ebz/src.mk
@@ -49,6 +49,6 @@ INCS +=	$(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_list.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h
 endif

--- a/projects/ad9361/src.mk
+++ b/projects/ad9361/src.mk
@@ -100,5 +100,5 @@ SRCS += $(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c \
 INCS += $(PLATFORM_DRIVERS)/irq_extra.h \
 	$(PLATFORM_DRIVERS)/spi_extra.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h	
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h	
 endif

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -75,7 +75,7 @@
 #include "iio_app.h"
 
 #ifdef XILINX_PLATFORM
-#include "uart_extra.h"
+#include "xilinx_uart.h"
 #include "xil_cache.h"
 #endif //XILINX
 

--- a/projects/ad9371/src.mk
+++ b/projects/ad9371/src.mk
@@ -109,7 +109,7 @@ INCS += $(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_list.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h \
 	$(NO-OS)/iio/iio_app/iio_app.h \
 	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.h

--- a/projects/ad9434-fmc-500ebz/src.mk
+++ b/projects/ad9434-fmc-500ebz/src.mk
@@ -49,6 +49,6 @@ INCS +=	$(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_list.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h
 endif

--- a/projects/ad9467/src.mk
+++ b/projects/ad9467/src.mk
@@ -53,6 +53,6 @@ INCS +=	$(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_list.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h
 endif

--- a/projects/ad9656_fmc/src.mk
+++ b/projects/ad9656_fmc/src.mk
@@ -65,6 +65,6 @@ INCS +=	$(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_list.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h
 endif

--- a/projects/ad9739a-fmc-ebz/src.mk
+++ b/projects/ad9739a-fmc-ebz/src.mk
@@ -51,6 +51,6 @@ INCS +=	$(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_list.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.h
 endif

--- a/projects/adaq7980_sdz/src.mk
+++ b/projects/adaq7980_sdz/src.mk
@@ -31,7 +31,7 @@ INCS += $(DRIVERS)/adc/adaq7980/adaq7980.h \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine_private.h
 INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
 INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_spi.h \

--- a/projects/adaq8092_fmc/src.mk
+++ b/projects/adaq8092_fmc/src.mk
@@ -54,6 +54,6 @@ INCS +=	$(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_list.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h
 endif

--- a/projects/adf4377_sdz/src.mk
+++ b/projects/adf4377_sdz/src.mk
@@ -50,6 +50,6 @@ INCS += $(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_list.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(NO-OS)/iio/iio_app/iio_app.h
 endif

--- a/projects/adf5902_sdz/src.mk
+++ b/projects/adf5902_sdz/src.mk
@@ -49,6 +49,6 @@ INCS += $(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_list.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(NO-OS)/iio/iio_app/iio_app.h
 endif

--- a/projects/adrv9001/src.mk
+++ b/projects/adrv9001/src.mk
@@ -69,7 +69,7 @@ INCS += $(INCLUDE)/no_os_uart.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_irq.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_list.h \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h \

--- a/projects/adrv9009/src.mk
+++ b/projects/adrv9009/src.mk
@@ -151,7 +151,7 @@ INCS +=	$(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_list.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h \
 	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.h
 endif

--- a/projects/adt7420-pmdz/src/examples/examples_src.mk
+++ b/projects/adt7420-pmdz/src/examples/examples_src.mk
@@ -18,5 +18,5 @@ INCS += $(DRIVERS)/temperature/adt7420/iio_adt7420.h
 SRCS += $(DRIVERS)/temperature/adt7420/iio_adt7420.c 
 
 INCS += $(INCLUDE)/no_os_list.h \
-		$(PLATFORM_DRIVERS)/uart_extra.h
+		$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h
 endif

--- a/projects/aducm3029_flash_demo/src/main.c
+++ b/projects/aducm3029_flash_demo/src/main.c
@@ -49,7 +49,7 @@
 #include "no_os_irq.h"
 #include "platform_init.h"
 #include "no_os_uart.h"
-#include "uart_extra.h"
+#include "xilinx_uart.h"
 #include "uart_stdio.h"
 
 /***************************************************************************//**

--- a/projects/cn0561/src.mk
+++ b/projects/cn0561/src.mk
@@ -40,7 +40,7 @@ INCS += $(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
 	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h
 INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(PLATFORM_DRIVERS)/gpio_extra.h
 INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_spi.h \

--- a/projects/cn0561/src/cn0561.c
+++ b/projects/cn0561/src/cn0561.c
@@ -69,7 +69,7 @@
 #include "no_os_irq.h"
 #include "irq_extra.h"
 #include "no_os_uart.h"
-#include "uart_extra.h"
+#include "xilinx_uart.h"
 #include "iio_ad713x.h"
 #include "iio.h"
 #include "iio_app.h"

--- a/projects/cn0565/src.mk
+++ b/projects/cn0565/src.mk
@@ -64,7 +64,7 @@ SRCS += $(PLATFORM_DRIVERS)/aducm3029_delay.c \
 
 INCS +=	$(INCLUDE)/no_os_delay.h \
 	$(PLATFORM_DRIVERS)/aducm3029_uart_stdio.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(PLATFORM_DRIVERS)/aducm3029_irq.h \
 	$(PLATFORM_DRIVERS)/aducm3029_gpio_irq.h \
 	$(PLATFORM_DRIVERS)/aducm3029_spi.h \

--- a/projects/eval-adxl313z/src/examples/examples_src.mk
+++ b/projects/eval-adxl313z/src/examples/examples_src.mk
@@ -18,5 +18,5 @@ INCS += $(DRIVERS)/accel/adxl313/iio_adxl313.h
 SRCS += $(DRIVERS)/accel/adxl313/iio_adxl313.c
 
 INCS += $(INCLUDE)/no_os_list.h \
-		$(PLATFORM_DRIVERS)/uart_extra.h
+		$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h
 endif

--- a/projects/eval-adxl355-pmdz/src/examples/examples_src.mk
+++ b/projects/eval-adxl355-pmdz/src/examples/examples_src.mk
@@ -31,5 +31,5 @@ SRCS += $(DRIVERS)/accel/adxl355/iio_adxl355_trig.c
 endif
 
 INCS += $(INCLUDE)/no_os_list.h \
-		$(PLATFORM_DRIVERS)/uart_extra.h
+		$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h
 endif

--- a/projects/eval-adxl367z/src/platform/xilinx/platform_src.mk
+++ b/projects/eval-adxl367z/src/platform/xilinx/platform_src.mk
@@ -7,7 +7,7 @@ INCS +=	$(PLATFORM_DRIVERS)/spi_extra.h \
 
 ifeq (y,$(strip $(IIO_EXAMPLE)))
 
-INCS += $(PLATFORM_DRIVERS)/uart_extra.h \
+INCS += $(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h
 
 SRCS += $(PLATFORM_DRIVERS)/xilinx_irq.c

--- a/projects/fmcadc2/src.mk
+++ b/projects/fmcadc2/src.mk
@@ -62,6 +62,6 @@ INCS += $(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_list.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h
 endif

--- a/projects/fmcadc5/src.mk
+++ b/projects/fmcadc5/src.mk
@@ -62,6 +62,6 @@ INCS += $(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_list.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h
 endif

--- a/projects/fmcdaq2/src.mk
+++ b/projects/fmcdaq2/src.mk
@@ -77,7 +77,7 @@ INCS += $(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_list.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h \
 	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.h
 endif

--- a/projects/fmcdaq3/src.mk
+++ b/projects/fmcdaq3/src.mk
@@ -77,7 +77,7 @@ INCS += $(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_list.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h \
 	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.h
 endif

--- a/projects/fmcjesdadc1/src.mk
+++ b/projects/fmcjesdadc1/src.mk
@@ -66,7 +66,7 @@ INCS += $(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_list.h \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \
 	$(NO-OS)/iio/iio_app/iio_app.h \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h
 endif

--- a/projects/iio_demo/src/examples/examples_src.mk
+++ b/projects/iio_demo/src/examples/examples_src.mk
@@ -40,4 +40,4 @@ SRCS += $(DRIVERS)/adc/adc_demo/iio_adc_demo.c \
         $(DRIVERS)/dac/dac_demo/iio_dac_demo.c
 
 INCS += $(INCLUDE)/no_os_list.h \
-        $(PLATFORM_DRIVERS)/uart_extra.h
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h

--- a/projects/iio_demo/src/platform/xilinx/platform_src.mk
+++ b/projects/iio_demo/src/platform/xilinx/platform_src.mk
@@ -22,4 +22,4 @@ SRCS += $(NO-OS)/util/no_os_lf256fifo.c  \
 INCS += $(INCLUDE)/no_os_rtc.h          \
 	$(INCLUDE)/no_os_gpio.h         \
 	$(PLATFORM_DRIVERS)/irq_extra.h \
-	$(PLATFORM_DRIVERS)/uart_extra.h
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h


### PR DESCRIPTION
Rename `uart_extra` to platform specific header file.

Update projects accordingly.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>