### PR TITLE
drivers: stm32: gpio: fix header defines

### DIFF
--- a/drivers/platform/stm32/stm32_gpio.h
+++ b/drivers/platform/stm32/stm32_gpio.h
@@ -36,8 +36,8 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
-#ifndef GPIO_EXTRA_H_
-#define GPIO_EXTRA_H_
+#ifndef STM32_GPIO_H_
+#define STM32_GPIO_H_
 
 #include <stdint.h>
 #include <stdbool.h>


### PR DESCRIPTION
Fix ifndef and define for stm32_gpio header file.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>