### PR TITLE
Pico support for adxl355 and pico platform changes

### DIFF
--- a/drivers/platform/pico/pico_uart.c
+++ b/drivers/platform/pico/pico_uart.c
@@ -111,12 +111,9 @@ int32_t no_os_uart_init(struct no_os_uart_desc **desc,
 	descriptor->device_id = param->device_id;
 	descriptor->irq_id = param->irq_id;
 	descriptor->extra = pico_uart;
-
-	uart_init(pico_uart->uart_instance, param->baud_rate);
-
 	pico_uart_ip = param->extra;
-	gpio_set_function(pico_uart_ip->uart_tx_pin, GPIO_FUNC_UART);
-	gpio_set_function(pico_uart_ip->uart_rx_pin, GPIO_FUNC_UART);
+	stdio_uart_init_full(pico_uart->uart_instance, param->baud_rate,
+			     pico_uart_ip->uart_tx_pin, pico_uart_ip->uart_rx_pin);
 
 	uart_set_hw_flow(pico_uart->uart_instance, false, false);
 

--- a/projects/eval-adxl355-pmdz/src.mk
+++ b/projects/eval-adxl355-pmdz/src.mk
@@ -19,6 +19,7 @@ INCS += $(INCLUDE)/no_os_delay.h     \
 		$(INCLUDE)/no_os_spi.h       \
 		$(INCLUDE)/no_os_irq.h      \
 		$(INCLUDE)/no_os_list.h      \
+		$(INCLUDE)/no_os_timer.h      \
 		$(INCLUDE)/no_os_uart.h      \
 		$(INCLUDE)/no_os_lf256fifo.h \
 		$(INCLUDE)/no_os_util.h \
@@ -29,6 +30,7 @@ SRCS += $(DRIVERS)/api/no_os_gpio.c \
 		$(NO-OS)/util/no_os_lf256fifo.c \
 		$(DRIVERS)/api/no_os_irq.c  \
 		$(DRIVERS)/api/no_os_spi.c  \
+		$(DRIVERS)/api/no_os_timer.c  \
 		$(NO-OS)/util/no_os_list.c \
 		$(NO-OS)/util/no_os_util.c
 

--- a/projects/eval-adxl355-pmdz/src/platform/pico/main.c
+++ b/projects/eval-adxl355-pmdz/src/platform/pico/main.c
@@ -1,6 +1,6 @@
 /***************************************************************************//**
- *   @file   platform_includes.h
- *   @brief  Includes for used platforms used by eval-adxl355-pmdz project.
+ *   @file   main.c
+ *   @brief  Main file for pico platform of eval-adxl355-pmdz project.
  *   @author RBolboac (ramona.bolboaca@analog.com)
 ********************************************************************************
  * Copyright 2022(c) Analog Devices, Inc.
@@ -36,26 +36,60 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
-#ifndef __PLATFORM_INCLUDES_H__
-#define __PLATFORM_INCLUDES_H__
 
 /******************************************************************************/
 /***************************** Include Files **********************************/
 /******************************************************************************/
-#ifdef STM32_PLATFORM
-#include "stm32/parameters.h"
+#include "platform_includes.h"
+#include "common_data.h"
+#include "no_os_error.h"
+
+#ifdef IIO_EXAMPLE
+#include "iio_example.h"
 #endif
 
-#ifdef MAXIM_PLATFORM
-#include "maxim/parameters.h"
+#ifdef IIO_TRIGGER_EXAMPLE
+#include "iio_trigger_example.h"
 #endif
 
-#ifdef PICO_PLATFORM
-#include "pico/parameters.h"
+#ifdef DUMMY_EXAMPLE
+#include "dummy_example.h"
 #endif
 
-#ifdef IIO_SUPPORT
-#include "iio_app.h"
+/***************************************************************************//**
+ * @brief Main function execution for pico platform.
+ *
+ * @return ret - Result of the enabled examples execution.
+*******************************************************************************/
+int main()
+{
+	int ret = -EINVAL;
+	adxl355_ip.comm_init.spi_init = adxl355_spi_ip;
+
+#ifdef IIO_EXAMPLE
+	ret = iio_example_main();
 #endif
 
-#endif /* __PLATFORM_INCLUDES_H__ */
+#ifdef IIO_TRIGGER_EXAMPLE
+	ret = iio_trigger_example_main();
+#endif
+
+#ifdef DUMMY_EXAMPLE
+	struct no_os_uart_desc *uart_desc;
+
+	ret = no_os_uart_init(&uart_desc, &adxl355_uart_ip);
+	if (ret)
+		return ret;
+
+	ret = dummy_example_main();
+#endif
+
+#if (DUMMY_EXAMPLE + IIO_EXAMPLE + IIO_TRIGGER_EXAMPLE == 0)
+#error At least one example has to be selected using y value in Makefile.
+#elif (DUMMY_EXAMPLE + IIO_EXAMPLE + IIO_TRIGGER_EXAMPLE > 1)
+#error Selected example projects cannot be enabled at the same time. \
+Please enable only one example and re-build the project.
+#endif
+
+	return ret;
+}

--- a/projects/eval-adxl355-pmdz/src/platform/pico/parameters.c
+++ b/projects/eval-adxl355-pmdz/src/platform/pico/parameters.c
@@ -1,6 +1,6 @@
 /***************************************************************************//**
- *   @file   platform_includes.h
- *   @brief  Includes for used platforms used by eval-adxl355-pmdz project.
+ *   @file   parameters.c
+ *   @brief  Definition of pico platform data used by eval-adxl355-pmdz project.
  *   @author RBolboac (ramona.bolboaca@analog.com)
 ********************************************************************************
  * Copyright 2022(c) Analog Devices, Inc.
@@ -36,26 +36,23 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
-#ifndef __PLATFORM_INCLUDES_H__
-#define __PLATFORM_INCLUDES_H__
 
 /******************************************************************************/
 /***************************** Include Files **********************************/
 /******************************************************************************/
-#ifdef STM32_PLATFORM
-#include "stm32/parameters.h"
-#endif
+#include "parameters.h"
 
-#ifdef MAXIM_PLATFORM
-#include "maxim/parameters.h"
-#endif
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+struct pico_spi_init_param adxl355_spi_extra_ip  = {
+	.spi_tx_pin = SPI0_TX_GP19,
+	.spi_rx_pin = SPI0_RX_GP16,
+	.spi_sck_pin = SPI0_SCK_GP18,
+	.spi_cs_pin = SPI0_CS_GP17
+};
 
-#ifdef PICO_PLATFORM
-#include "pico/parameters.h"
-#endif
-
-#ifdef IIO_SUPPORT
-#include "iio_app.h"
-#endif
-
-#endif /* __PLATFORM_INCLUDES_H__ */
+struct pico_uart_init_param adxl355_uart_extra_ip = {
+	.uart_tx_pin = UART_TX_PIN,
+	.uart_rx_pin = UART_RX_PIN,
+};

--- a/projects/eval-adxl355-pmdz/src/platform/pico/parameters.h
+++ b/projects/eval-adxl355-pmdz/src/platform/pico/parameters.h
@@ -1,6 +1,7 @@
 /***************************************************************************//**
- *   @file   platform_includes.h
- *   @brief  Includes for used platforms used by eval-adxl355-pmdz project.
+ *   @file   parameters.h
+ *   @brief  Definitions specific to pico platform used by eval-adxl355-pmdz
+ *           project.
  *   @author RBolboac (ramona.bolboaca@analog.com)
 ********************************************************************************
  * Copyright 2022(c) Analog Devices, Inc.
@@ -36,26 +37,54 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
-#ifndef __PLATFORM_INCLUDES_H__
-#define __PLATFORM_INCLUDES_H__
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
 
 /******************************************************************************/
 /***************************** Include Files **********************************/
 /******************************************************************************/
-#ifdef STM32_PLATFORM
-#include "stm32/parameters.h"
+#include "common_data.h"
+#include "no_os_util.h"
+#include "pico_uart.h"
+#include "pico_spi.h"
+#include "pico_gpio.h"
+#include "pico_gpio_irq.h"
+#include "pico_irq.h"
+#include "pico_timer.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+#define UART_DEVICE_ID  0
+#define UART_BAUDRATE   115200
+#define UART_IRQ_ID     20
+#define UART_EXTRA      &adxl355_uart_extra_ip
+
+#define UART_TX_PIN     UART0_TX_GP0
+#define UART_RX_PIN     UART0_RX_GP1
+
+#define SPI_DEVICE_ID   0
+#define SPI_BAUDRATE    1000000
+#define SPI_CS          SPI0_CS_GP17
+#define SPI_OPS         &pico_spi_ops
+#define SPI_EXTRA       &adxl355_spi_extra_ip
+
+extern struct pico_spi_init_param adxl355_spi_extra_ip;
+extern struct pico_uart_init_param adxl355_uart_extra_ip;
+
+#define GPIO_DRDY_PIN_NUM   20
+#define GPIO_DRDY_PORT_NUM  0 /* Not used for pico platform */
+#define GPIO_OPS            &pico_gpio_ops
+#define GPIO_EXTRA          NULL /* Not used for pico platform */
+
+#ifdef IIO_TRIGGER_EXAMPLE
+#define ADXL355_GPIO_TRIG_IRQ_ID     GPIO_DRDY_PIN_NUM
+#define ADXL355_GPIO_CB_HANDLE       NULL /* Not used in pico platform */
+
+#define GPIO_IRQ_ID             GPIO_DRDY_PIN_NUM
+#define GPIO_IRQ_OPS            &pico_gpio_irq_ops
+#define GPIO_IRQ_EXTRA          NULL /* Not used for pico platform */
 #endif
 
-#ifdef MAXIM_PLATFORM
-#include "maxim/parameters.h"
-#endif
-
-#ifdef PICO_PLATFORM
-#include "pico/parameters.h"
-#endif
-
-#ifdef IIO_SUPPORT
-#include "iio_app.h"
-#endif
-
-#endif /* __PLATFORM_INCLUDES_H__ */
+#endif /* __PARAMETERS_H__ */

--- a/projects/eval-adxl355-pmdz/src/platform/pico/platform_src.mk
+++ b/projects/eval-adxl355-pmdz/src/platform/pico/platform_src.mk
@@ -1,0 +1,14 @@
+INCS += $(PLATFORM_DRIVERS)/pico_gpio.h     \
+        $(PLATFORM_DRIVERS)/pico_gpio_irq.h \
+        $(PLATFORM_DRIVERS)/pico_irq.h      \
+        $(PLATFORM_DRIVERS)/pico_spi.h      \
+        $(PLATFORM_DRIVERS)/pico_timer.h    \
+        $(PLATFORM_DRIVERS)/pico_uart.h
+
+SRCS += $(PLATFORM_DRIVERS)/pico_delay.c    \
+        $(PLATFORM_DRIVERS)/pico_gpio.c     \
+        $(PLATFORM_DRIVERS)/pico_gpio_irq.c \
+        $(PLATFORM_DRIVERS)/pico_irq.c      \
+        $(PLATFORM_DRIVERS)/pico_spi.c      \
+        $(PLATFORM_DRIVERS)/pico_timer.c    \
+        $(PLATFORM_DRIVERS)/pico_uart.c

--- a/tools/scripts/pico.mk
+++ b/tools/scripts/pico.mk
@@ -297,7 +297,6 @@ LDFLAGS += -Wl,--wrap=__popcountdi2
 LDFLAGS += -Wl,--wrap=__clz
 LDFLAGS += -Wl,--wrap=__clzl
 LDFLAGS += -Wl,--wrap=__clzll
-LDFLAGS += -Wl,--wrap=__aeabi_ldivmod
 LDFLAGS += -Wl,--wrap=sqrt
 LDFLAGS += -Wl,--wrap=cos
 LDFLAGS += -Wl,--wrap=sin


### PR DESCRIPTION
- Initialize uart with stdio API to be able to use stdio related functions (e.g. printf).
- Remove wrap function for ldivmod to avoid linker errors when no_os_util is used.
- Rework spi driver for pico platform: use CS as GPIO (if used as SPI function the CS is deasserted by
default after every 8 bits), use pico_spi_transfer in pico_spi_write_and_read to remove duplicated code, use only chip_select for the slave_id creation
- Add support for pico platform for eval-adxl355-pmdz for dummy example, iio example and iio example with gpio trigger.

