### PR TITLE
projects:ad9371:src:headless.c ADXCVR init fix

### DIFF
--- a/projects/ad9371/src/app/headless.c
+++ b/projects/ad9371/src/app/headless.c
@@ -232,7 +232,6 @@ int main(void)
 		0,
 		3,
 		1,
-		1,
 		rx_lane_rate_khz,
 		mykDevice.clocks->deviceClock_kHz,
 	};
@@ -242,7 +241,6 @@ int main(void)
 		3,
 		3,
 		0,
-		0,
 		tx_lane_rate_khz,
 		mykDevice.clocks->deviceClock_kHz,
 	};
@@ -251,7 +249,6 @@ int main(void)
 		RX_OS_XCVR_BASEADDR,
 		0,
 		3,
-		1,
 		1,
 		rx_os_lane_rate_khz,
 		mykDevice.clocks->deviceClock_kHz,

--- a/projects/ad9371/src/app/headless.c
+++ b/projects/ad9371/src/app/headless.c
@@ -227,31 +227,31 @@ int main(void)
 	};
 #else
 	struct adxcvr_init rx_adxcvr_init = {
-		"rx_adxcvr",
-		RX_XCVR_BASEADDR,
-		0,
-		3,
-		1,
-		rx_lane_rate_khz,
-		mykDevice.clocks->deviceClock_kHz,
+		.name = "rx_adxcvr",
+		.base = RX_XCVR_BASEADDR,
+		.sys_clk_sel = ADXCVR_SYS_CLK_CPLL,
+		.out_clk_sel = ADXCVR_REFCLK,
+		.lpm_enable = 1,
+		.lane_rate_khz = rx_lane_rate_khz,
+		.ref_rate_khz = mykDevice.clocks->deviceClock_kHz,
 	};
 	struct adxcvr_init tx_adxcvr_init = {
-		"tx_adxcvr",
-		TX_XCVR_BASEADDR,
-		3,
-		3,
-		0,
-		tx_lane_rate_khz,
-		mykDevice.clocks->deviceClock_kHz,
+		.name = "tx_adxcvr",
+		.base = TX_XCVR_BASEADDR,
+		.sys_clk_sel = ADXCVR_SYS_CLK_QPLL0,
+		.out_clk_sel = ADXCVR_REFCLK,
+		.lpm_enable = 0,
+		.lane_rate_khz = tx_lane_rate_khz,
+		.ref_rate_khz = mykDevice.clocks->deviceClock_kHz,
 	};
 	struct adxcvr_init rx_os_adxcvr_init = {
-		"rx_os_adxcvr",
-		RX_OS_XCVR_BASEADDR,
-		0,
-		3,
-		1,
-		rx_os_lane_rate_khz,
-		mykDevice.clocks->deviceClock_kHz,
+		.name = "rx_os_adxcvr",
+		.base = RX_OS_XCVR_BASEADDR,
+		.sys_clk_sel = ADXCVR_SYS_CLK_CPLL,
+		.out_clk_sel = ADXCVR_REFCLK,
+		.lpm_enable = 1,
+		.lane_rate_khz = rx_os_lane_rate_khz,
+		.ref_rate_khz = mykDevice.clocks->deviceClock_kHz,
 	};
 #endif
 	struct adxcvr *rx_adxcvr;


### PR DESCRIPTION
The removal of the cpll_enable member from adxcvr_init and addition of member names in initialization.

Problem signaled by issue https://github.com/analogdevicesinc/no-OS/issues/1496

Signed-off-by: George Mois <george.mois@analog.com>