### PR TITLE
Add support for pico platform in builds.json for eval-adxl355-pmdz project

### DIFF
--- a/projects/adxrs290-pmdz/builds.json
+++ b/projects/adxrs290-pmdz/builds.json
@@ -16,7 +16,7 @@
     "iio_example": {
       "flags": "IIO_EXAMPLE=y IIO_TRIGGER_EXAMPLE=n IIO_TIMER_TRIGGER_EXAMPLE=n"
     },
-    "iio_trigger_example_max32655": {
+    "iio_trigger_example": {
       "flags": "IIO_EXAMPLE=n IIO_TRIGGER_EXAMPLE=y IIO_TIMER_TRIGGER_EXAMPLE=n"
     },
     "iio_timer_trigger": {

--- a/projects/eval-adxl355-pmdz/builds.json
+++ b/projects/eval-adxl355-pmdz/builds.json
@@ -44,5 +44,16 @@
 	  "iio_example_max78000": {
       "flags" : "DUMMY_EXAMPLE=n IIO_EXAMPLE=y IIO_TRIGGER_EXAMPLE=n TARGET=max78000"
     }
+  },
+  "pico": {
+    "iio_example": {
+      "flags" : "DUMMY_EXAMPLE=n IIO_EXAMPLE=y IIO_TRIGGER_EXAMPLE=n"
+    },
+    "iio_trigger_example": {
+      "flags" : "DUMMY_EXAMPLE=n IIO_EXAMPLE=n IIO_TRIGGER_EXAMPLE=y"
+    },
+    "dummy_example": {
+      "flags" : "DUMMY_EXAMPLE=y IIO_EXAMPLE=n IIO_TRIGGER_EXAMPLE=n"
+    }
   }
 }


### PR DESCRIPTION
- Add pico platform to builds.json for eval-adxl355-pmdz project.
- Remove _max32655 from file name for pico platform in builds.json for adxrs290-pmdz project.