### PR TITLE
tools:scripts:platform:xilinx:util.tcl make run command update

### DIFF
--- a/tools/scripts/platform/xilinx/util.tcl
+++ b/tools/scripts/platform/xilinx/util.tcl
@@ -240,7 +240,8 @@ proc _write_ps {cpu} {
 
 proc upload {} {
 	openhw $::hw
-	set bitstream $::hw_path/system_top.bit
+	set bitstream [file rootname $::hw]
+	append bitstream ".bit"
 	set cpu [_get_processor]
 
 	# Connect to the fpga


### PR DESCRIPTION
The update of the make run command so that it accepts arbitrary bit file names for programming the FPGA (other than system_top.bit).

Signed-off-by: George Mois <george.mois@analog.com>