### PR TITLE
drivers:eeprom:24xx32a setting i2c stop bit during eeprom address write

### DIFF
--- a/drivers/eeprom/24xx32a/24xx32a.c
+++ b/drivers/eeprom/24xx32a/24xx32a.c
@@ -130,7 +130,7 @@ int32_t eeprom_24xx32a_read(struct no_os_eeprom_desc *desc, uint32_t address,
 	for (indx = 0; indx < bytes; indx++) {
 		no_os_put_unaligned_be16(curr_address, buff);
 
-		ret = no_os_i2c_write(eeprom_dev->i2c_desc, buff, sizeof(buff), 1);
+		ret = no_os_i2c_write(eeprom_dev->i2c_desc, buff, sizeof(buff), 0);
 		if (ret)
 			return ret;
 


### PR DESCRIPTION
As per datasheet, the stop condition is not expected after sending address bytes. Instead, repeated start condition needs to be generated (which would be done by subsequent i2c_read function call). Therefore, set stop bit to 0.

Signed-off-by: MPhalke <mahesh.phalke@analog.com>