### PR TITLE
MAX32665: change UART pins mapping

### DIFF
--- a/drivers/platform/maxim/max32665/maxim_uart.c
+++ b/drivers/platform/maxim/max32665/maxim_uart.c
@@ -309,7 +309,7 @@ int32_t no_os_uart_init(struct no_os_uart_desc **desc,
 		goto error;
 	}
 
-	ret = MXC_UART_Init(uart_regs, descriptor->baud_rate, MAP_A);
+	ret = MXC_UART_Init(uart_regs, descriptor->baud_rate, MAP_B);
 	if (ret != E_NO_ERROR) {
 		ret = -EINVAL;
 		goto error;
@@ -333,7 +333,7 @@ int32_t no_os_uart_init(struct no_os_uart_desc **desc,
 		goto error;
 	}
 
-	ret = MXC_UART_SetFlowCtrl(uart_regs, flow, 8, MAP_A);
+	ret = MXC_UART_SetFlowCtrl(uart_regs, flow, 8, MAP_B);
 	if (ret != E_NO_ERROR) {
 		ret = -EINVAL;
 		goto error;


### PR DESCRIPTION
Set the UART mapping, so that the RX/TX signals will be routed to the JTAG header on the MAX32665 FTHR board. Even though this is board specific, I think it would be useful to have these changes applied, as it's the only MAX32665/6 board we're using right now.

The MAP_X sets the GPIOs that will be configured as UART.
MAP_A: pins 20, 21.
MAP_B: pins 12, 13. 
