### PR TITLE
JTAG_CABLE_ID specifier for maxim platform

### DIFF
--- a/tools/scripts/maxim.mk
+++ b/tools/scripts/maxim.mk
@@ -141,8 +141,11 @@ clean: clean_hex
 
 .PHONY: maxim_run
 $(PLATFORM)_run: all 
+ifneq ($(JTAG_CABLE_ID),)
+	@echo cmsis_dap_serial $(JTAG_CABLE_ID) > $(PLATFORM)_run
+endif
 	$(OPENOCD_BIN)/openocd -s $(OPENOCD_SCRIPTS) 		\
-		-f interface/cmsis-dap.cfg -f target/$(TARGETCFG) \
+		-f interface/cmsis-dap.cfg -f $(PLATFORM)_run -f target/$(TARGETCFG) \
 		-c "program $(BINARY) verify reset exit"
 
 .PHONY: debug


### PR DESCRIPTION
To find the serial number of the CMSIS-DAP interface:
	lsusb -v
	lsusb -v | grep iSerial

Then pass the serial number to the run command:
	make run JTAG_CABLE_ID=0123456789abcdef

This allows to target one particular CMSIS-DAP programmer if several of them are connected to the PC.

Signed-off-by: Darius Berghe <darius.berghe@analog.com>