### PR TITLE
JTAG_CABLE_ID for aducm3029 platform

### DIFF
--- a/tools/scripts/aducm.mk
+++ b/tools/scripts/aducm.mk
@@ -152,11 +152,11 @@ $(PIN_MUX): $(PROJECT_PIN_MUX)
 # Upload binary to target
 PHONY += aducm3029_run
 ifeq ($(wildcard $(BUILD_DIR)),)
-aducm3029_run: all
+aducm3029_run: all $(BINARY).id
 else
-aducm3029_run: $(BINARY)
+aducm3029_run: $(BINARY) $(BINARY).id
 endif
-	$(MUTE) openocd -s "$(OPENOCD_SCRIPTS)" -f interface/cmsis-dap.cfg \
+	$(MUTE) openocd -s "$(OPENOCD_SCRIPTS)" -f $(BINARY).id \
 		-s "$(ADUCM_DFP)/openocd/scripts" -f target/aducm3029.cfg \
 		-c "program  $(BINARY) verify reset exit" $(HIDE)
 

--- a/tools/scripts/generic.mk
+++ b/tools/scripts/generic.mk
@@ -339,6 +339,13 @@ $(BINARY): $(LIB_TARGETS) $(OBJS) $(ASM_OBJS) $(LSCRIPT) $(BOOTOBJ)
 			 $(ASM_OBJS) $(LIB_FLAGS)
 	$(MUTE) $(MAKE) --no-print-directory post_build
 
+PHONY += $(BINARY).id
+$(BINARY).id:
+	@echo interface cmsis-dap > $(BINARY).id
+ifneq ($(JTAG_CABLE_ID),)
+	@echo cmsis_dap_serial $(JTAG_CABLE_ID) >> $(BINARY).id
+endif
+
 PHONY += run
 run: $(PLATFORM)_run
 	@$(call print,$(notdir $(BINARY)) uploaded to board)

--- a/tools/scripts/maxim.mk
+++ b/tools/scripts/maxim.mk
@@ -145,13 +145,11 @@ clean_hex:
 
 clean: clean_hex
 
-.PHONY: maxim_run
-$(PLATFORM)_run: all 
-ifneq ($(JTAG_CABLE_ID),)
-	@echo cmsis_dap_serial $(JTAG_CABLE_ID) > $(PLATFORM)_run
-endif
-	$(OPENOCD_BIN)/openocd -s $(OPENOCD_SCRIPTS) 		\
-		-f interface/cmsis-dap.cfg -f $(PLATFORM)_run -f target/$(TARGETCFG) \
+.PHONY: $(PLATFORM)_run
+$(PLATFORM)_run: all $(BINARY).id
+	$(OPENOCD_BIN)/openocd -s "$(OPENOCD_SCRIPTS)" \
+		-f $(BINARY).id \
+		-f target/$(TARGETCFG) \
 		-c "program $(BINARY) verify reset exit"
 
 .PHONY: debug


### PR DESCRIPTION
Move part of the logic to generic.mk (previously in maxim.mk). Use the generated .id file to specify the JTAG device serial no for both aducm3029 and maxim platforms.

Signed-off-by: Darius Berghe <darius.berghe@analog.com>