### PR TITLE
projects:ad9361:src:main.c IRQ example fix

### DIFF
--- a/drivers/platform/xilinx/xilinx_irq.c
+++ b/drivers/platform/xilinx/xilinx_irq.c
@@ -251,7 +251,7 @@ int32_t xil_irq_register_callback(struct no_os_irq_ctrl_desc *desc,
 	case IRQ_PS:
 #ifdef XSCUGIC_H
 		return XScuGic_Connect(xil_dev->instance, irq_id,
-				       (Xil_InterruptHandler) callback_desc->legacy_callback,
+				       (Xil_InterruptHandler) callback_desc->callback,
 				       callback_desc->ctx);
 #endif
 		break;
@@ -265,13 +265,13 @@ int32_t xil_irq_register_callback(struct no_os_irq_ctrl_desc *desc,
 			if (NO_OS_IS_ERR_VALUE(ret))
 				return -1;
 			XTmrCtr_SetHandler(callback_desc->legacy_config,
-					   (XTmrCtr_Handler)callback_desc->legacy_callback,
+					   (XTmrCtr_Handler)callback_desc->callback,
 					   callback_desc->ctx);
 
 			return 0;
 		}
 		return XIntc_Connect(xil_dev->instance, irq_id,
-				     (XInterruptHandler) callback_desc->legacy_callback,
+				     (XInterruptHandler) callback_desc->callback,
 				     callback_desc->ctx);
 #endif
 		break;

--- a/drivers/platform/xilinx/xilinx_irq.c
+++ b/drivers/platform/xilinx/xilinx_irq.c
@@ -334,7 +334,7 @@ int32_t xil_irq_trigger_level_set(struct no_os_irq_ctrl_desc *desc,
  * @return 0 in case of success, -1 otherwise.
  */
 int32_t xil_irq_unregister_callback(struct no_os_irq_ctrl_desc *desc,
-				    uint32_t irq_id, struct callback_desc *cb)
+				    uint32_t irq_id, struct no_os_callback_desc *cb)
 {
 	struct xil_irq_desc *xil_dev = desc->extra;
 

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -671,7 +671,7 @@ int main(void)
 
 	struct no_os_callback_desc rx_dmac_callback = {
 		.ctx = rx_dmac,
-		.legacy_callback = axi_dmac_default_isr,
+		.callback = axi_dmac_dev_to_mem_isr,
 	};
 
 	status = no_os_irq_register_callback(irq_desc,
@@ -699,7 +699,7 @@ int main(void)
 #ifdef ADC_DMA_IRQ_EXAMPLE
 	struct no_os_callback_desc tx_dmac_callback = {
 		.ctx = tx_dmac,
-		.legacy_callback = axi_dmac_default_isr,
+		.callback = axi_dmac_mem_to_dev_isr,
 	};
 
 	status = no_os_irq_register_callback(irq_desc,

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -675,16 +675,16 @@ int main(void)
 	};
 
 	status = no_os_irq_register_callback(irq_desc,
-					     XPAR_FABRIC_AXI_AD9361_ADC_DMA_IRQ_INTR, &rx_dmac_callback);
+					     AD9361_ADC_DMA_IRQ_INTR, &rx_dmac_callback);
 	if(status < 0)
 		return status;
 
 	status = no_os_irq_trigger_level_set(irq_desc,
-					     XPAR_FABRIC_AXI_AD9361_ADC_DMA_IRQ_INTR, NO_OS_IRQ_LEVEL_HIGH);
+					     AD9361_ADC_DMA_IRQ_INTR, NO_OS_IRQ_LEVEL_HIGH);
 	if(status < 0)
 		return status;
 
-	status = no_os_irq_enable(irq_desc, XPAR_FABRIC_AXI_AD9361_ADC_DMA_IRQ_INTR);
+	status = no_os_irq_enable(irq_desc, AD9361_ADC_DMA_IRQ_INTR);
 	if(status < 0)
 		return status;
 
@@ -703,11 +703,11 @@ int main(void)
 	};
 
 	status = no_os_irq_register_callback(irq_desc,
-					     XPAR_FABRIC_AXI_AD9361_DAC_DMA_IRQ_INTR, &tx_dmac_callback);
+					     AD9361_DAC_DMA_IRQ_INTR, &tx_dmac_callback);
 	if(status < 0)
 		return status;
 
-	status = no_os_irq_enable(irq_desc, XPAR_FABRIC_AXI_AD9361_DAC_DMA_IRQ_INTR);
+	status = no_os_irq_enable(irq_desc, AD9361_DAC_DMA_IRQ_INTR);
 	if(status < 0)
 		return status;
 #endif

--- a/projects/ad9361/src/parameters.h
+++ b/projects/ad9361/src/parameters.h
@@ -163,4 +163,14 @@
 #define GPIO_RESET_PIN	1006
 #endif
 
+/* Workaround for correcting the erroneous generation of defines
+ * for DMA IRQs from the *.xsa file. This is a HDL known issue. */
+#ifdef PLATFORM_ZYNQ
+#define AD9361_DAC_DMA_IRQ_INTR		88
+#define AD9361_ADC_DMA_IRQ_INTR		89
+#else
+#define AD9361_DAC_DMA_IRQ_INTR		XPAR_FABRIC_AXI_AD9361_DAC_DMA_IRQ_INTR
+#define AD9361_ADC_DMA_IRQ_INTR		XPAR_FABRIC_AXI_AD9361_ADC_DMA_IRQ_INTR
+#endif
+
 #endif // __PARAMETERS_H__


### PR DESCRIPTION
Specify correct callbacks for tx_dmac and rx_dmac.

Signed-off-by: George Mois <george.mois@analog.com>