### PR TITLE
iio:iio.c: Reset trigger id of the device optional macro.

### DIFF
--- a/iio/iio.c
+++ b/iio/iio.c
@@ -1171,7 +1171,9 @@ static int iio_close_dev(struct iiod_ctx *ctx, const char *device)
 		trig = &desc->trigs[dev->trig_idx];
 		if (trig->descriptor->disable)
 			ret = trig->descriptor->disable(trig->instance);
+#ifndef IIO_IGNORE_SET_TRIGGER
 		dev->trig_idx = NO_TRIGGER;
+#endif
 	}
 
 	return ret;


### PR DESCRIPTION
Suggest to add this macro as the firmware based on iio code is used across multiple ecosystems ranging from pyadi-iio to Matlab and not all of these platform support setting trigger id using impulse generator. Also the impulse generator in IIO oscilloscope doesn't work for windows version.