### PR TITLE
Maxim RX/TX SPI transfer length

### DIFF
--- a/drivers/platform/maxim/max32650/maxim_spi.c
+++ b/drivers/platform/maxim/max32650/maxim_spi.c
@@ -294,8 +294,8 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 		req.txCnt = 0;
 		req.rxCnt = 0;
 		req.ssDeassert = msgs[i].cs_change;
-		req.txLen = msgs[i].bytes_number;
-		req.rxLen = msgs[i].bytes_number;
+		req.txLen = req.txData ? msgs[i].bytes_number : 0;
+		req.rxLen = req.rxData ? msgs[i].bytes_number : 0;
 
 		ret = MXC_SPI_MasterTransaction(&req);
 

--- a/drivers/platform/maxim/max32655/maxim_spi.c
+++ b/drivers/platform/maxim/max32655/maxim_spi.c
@@ -210,8 +210,8 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 		req.txCnt = 0;
 		req.rxCnt = 0;
 		req.ssDeassert = msgs[i].cs_change;
-		req.txLen = msgs[i].bytes_number;
-		req.rxLen = msgs[i].bytes_number;
+		req.txLen = req.txData ? msgs[i].bytes_number : 0;
+		req.rxLen = req.rxData ? msgs[i].bytes_number : 0;
 
 		ret = MXC_SPI_MasterTransaction(&req);
 

--- a/drivers/platform/maxim/max32660/maxim_spi.c
+++ b/drivers/platform/maxim/max32660/maxim_spi.c
@@ -200,8 +200,8 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 		req.txCnt = 0;
 		req.rxCnt = 0;
 		req.ssDeassert = msgs[i].cs_change;
-		req.txLen = msgs[i].bytes_number;
-		req.rxLen = msgs[i].bytes_number;
+		req.txLen = req.txData ? msgs[i].bytes_number : 0;
+		req.rxLen = req.rxData ? msgs[i].bytes_number : 0;
 
 		ret = MXC_SPI_MasterTransaction(&req);
 

--- a/drivers/platform/maxim/max32665/maxim_spi.c
+++ b/drivers/platform/maxim/max32665/maxim_spi.c
@@ -289,8 +289,8 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 		req.txCnt = 0;
 		req.rxCnt = 0;
 		req.ssDeassert = msgs[i].cs_change;
-		req.txLen = msgs[i].bytes_number;
-		req.rxLen = msgs[i].bytes_number;
+		req.txLen = req.txData ? msgs[i].bytes_number : 0;
+		req.rxLen = req.rxData ? msgs[i].bytes_number : 0;
 
 		ret = MXC_SPI_MasterTransaction(&req);
 

--- a/drivers/platform/maxim/max32670/maxim_spi.c
+++ b/drivers/platform/maxim/max32670/maxim_spi.c
@@ -200,8 +200,8 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 		req.txCnt = 0;
 		req.rxCnt = 0;
 		req.ssDeassert = msgs[i].cs_change;
-		req.txLen = msgs[i].bytes_number;
-		req.rxLen = msgs[i].bytes_number;
+		req.txLen = req.txData ? msgs[i].bytes_number : 0;
+		req.rxLen = req.rxData ? msgs[i].bytes_number : 0;
 
 		ret = MXC_SPI_MasterTransaction(&req);
 

--- a/drivers/platform/maxim/max78000/maxim_spi.c
+++ b/drivers/platform/maxim/max78000/maxim_spi.c
@@ -211,8 +211,8 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 		req.txCnt = 0;
 		req.rxCnt = 0;
 		req.ssDeassert = msgs[i].cs_change;
-		req.txLen = msgs[i].bytes_number;
-		req.rxLen = msgs[i].bytes_number;
+		req.txLen = req.txData ? msgs[i].bytes_number : 0;
+		req.rxLen = req.rxData ? msgs[i].bytes_number : 0;
 
 		ret = MXC_SPI_MasterTransaction(&req);
 


### PR DESCRIPTION
Either the TX or RX buffer may be NULL in case only one direction is required. Set the transfer length to 0 in such case.