### PR TITLE
projects: adv7511: fix platform ops init

### DIFF
--- a/projects/adv7511/src/main.c
+++ b/projects/adv7511/src/main.c
@@ -360,7 +360,7 @@ int main()
 	timer_init.id = XPAR_XSCUTIMER_0_DEVICE_ID;
 	timer_init.freq_hz = XPAR_CPU_CORTEXA9_CORE_CLOCK_FREQ_HZ / 2;
 	timer_init.ticks_count = timer_init.freq_hz / 1000;
-	timer.platform_ops = &xil_timer_ops;
+	timer_init.platform_ops = &xil_timer_ops;
 	timer_init.extra = &xil_timer_init;
 #else
 	xil_timer_init.active_tmr = 0;
@@ -368,7 +368,7 @@ int main()
 	timer_init.id = XPAR_AXI_TIMER_DEVICE_ID;
 	timer_init.freq_hz = XPAR_AXI_TIMER_CLOCK_FREQ_HZ;
 	timer_init.ticks_count = timer_init.freq_hz / 1000;
-	timer.platform_ops = &xil_timer_ops;
+	timer_init.platform_ops = &xil_timer_ops;
 	timer_init.extra = &xil_timer_init;
 #endif
 #if defined(_XPARAMETERS_PS_H_)


### PR DESCRIPTION
Use proper timer init structure when assigning the xil_timer_ops structure.

Fixes: 62bf63b ("platform: xilinx: timer: use platform ops")
Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>