### PR TITLE
Revert "iio:iio.c: Reset trigger id of the device when closing device"

### DIFF
--- a/iio/iio.c
+++ b/iio/iio.c
@@ -1171,7 +1171,6 @@ static int iio_close_dev(struct iiod_ctx *ctx, const char *device)
 		trig = &desc->trigs[dev->trig_idx];
 		if (trig->descriptor->disable)
 			ret = trig->descriptor->disable(trig->instance);
-		dev->trig_idx = NO_TRIGGER;
 	}
 
 	return ret;


### PR DESCRIPTION
@pcercuei confirmed that the behavior of the regular IIOD is to leave the trigger assigned to the device even after a close command is received.
Thus reverting the changes in which the trigger id was unassigned when a close command is received.

https://github.com/analogdevicesinc/no-OS/pull/1553 is no longer needed if this revert is merged. 