### PR TITLE
Dev/spi cs delay pico

### DIFF
--- a/drivers/platform/pico/pico_spi.c
+++ b/drivers/platform/pico/pico_spi.c
@@ -46,6 +46,7 @@
 #include "no_os_spi.h"
 #include "pico_spi.h"
 #include "pico/stdlib.h"
+#include "no_os_delay.h"
 #include "hardware/resets.h"
 
 /******************************************************************************/
@@ -243,12 +244,21 @@ int32_t pico_spi_transfer(struct no_os_spi_desc *desc,
 		/* Assert CS */
 		gpio_put(pico_spi->spi_cs_pin, 0);
 
+		if(msgs[i].cs_delay_first)
+			no_os_udelay(msgs[i].cs_delay_first);
+
 		spi_write_read_blocking(pico_spi->spi_instance, msgs[i].tx_buff,
 					msgs[i].rx_buff, msgs[i].bytes_number);
+
+		if(msgs[i].cs_delay_last)
+			no_os_udelay(msgs[i].cs_delay_last);
 
 		if (msgs[i].cs_change)
 			/* De-assert CS */
 			gpio_put(pico_spi->spi_cs_pin, 1);
+
+		if(msgs[i].cs_change_delay)
+			no_os_udelay(msgs[i].cs_change_delay);
 	}
 
 	return 0;

--- a/include/no_os_spi.h
+++ b/include/no_os_spi.h
@@ -96,6 +96,15 @@ struct no_os_spi_msg {
 	uint32_t		bytes_number;
 	/** If set, CS will be deasserted after the transfer */
 	uint8_t			cs_change;
+	/**
+	 * Minimum delay (in us) between the CS de-assert event of the current message
+	 * and the assert of the next one.
+	 */
+	uint32_t		cs_change_delay;
+	/** Delay (in us) between the CS assert and the first SCLK edge. */
+	uint32_t		cs_delay_first;
+	/** Delay (in us) between the last SCLK edge and the CS deassert */
+	uint32_t		cs_delay_last;
 };
 
 /**


### PR DESCRIPTION
- add chip select delay parameters for SPI messages in no_os_spi
- use SPI CS as GPIO instead of using pull-up and pull-down in pico platform
- add SPI CS delays in spi_transfer API for pico platform