### PR TITLE
drivers: jesd204 :jesd204-core: copy_link_params() sysref param fix 2021_R2

### DIFF
--- a/jesd204/jesd204-core.c
+++ b/jesd204/jesd204-core.c
@@ -286,10 +286,10 @@ void jesd204_copy_link_params(struct jesd204_link *dst,
 	dst->dac_adj_resolution_steps = src->dac_adj_resolution_steps;
 	dst->dac_adj_direction = src->dac_adj_direction;
 	dst->dac_phase_adj = src->dac_phase_adj;
-	dst->sysref.mode = dst->sysref.mode;
-	dst->sysref.capture_falling_edge = dst->sysref.capture_falling_edge;
-	dst->sysref.valid_falling_edge = dst->sysref.valid_falling_edge;
-	dst->sysref.lmfc_offset = dst->sysref.lmfc_offset;
+	dst->sysref.mode = src->sysref.mode;
+	dst->sysref.capture_falling_edge = src->sysref.capture_falling_edge;
+	dst->sysref.valid_falling_edge = src->sysref.valid_falling_edge;
+	dst->sysref.lmfc_offset = src->sysref.lmfc_offset;
 }
 
 int jesd204_link_get_lmfc_lemc_rate(struct jesd204_link *lnk,


### PR DESCRIPTION
jesd204_copy_link_params() copy the SYSREF settings form source to destination.

Fixes: 08747d9 (jesd204: Adding jesd204-fsm support on no-OS)
Signed-off-by: George Mois <george.mois@analog.com>