### PR TITLE
adc: adc_demo: iio_adc_demo: Fix memory access

### DIFF
--- a/drivers/adc/adc_demo/iio_adc_demo.c
+++ b/drivers/adc/adc_demo/iio_adc_demo.c
@@ -147,6 +147,7 @@ int32_t adc_submit_samples(struct iio_device_data *dev_data)
 	uint32_t ch = -1;
 	uint16_t buff[TOTAL_ADC_CHANNELS];
 	uint32_t i;
+	uint16_t *ch_buf_ptr;
 
 	if(!dev_data)
 		return -ENODEV;
@@ -165,8 +166,10 @@ int32_t adc_submit_samples(struct iio_device_data *dev_data)
 	}
 
 	for(i = 0; i < dev_data->buffer->size / dev_data->buffer->bytes_per_scan; i++) {
-		while(get_next_ch_idx(desc->active_ch, ch, &ch))
-			buff[k++] = *(*(desc->ext_buff + ch) + (i % desc->ext_buff_len));
+		while(get_next_ch_idx(desc->active_ch, ch, &ch)) {
+			ch_buf_ptr = (uint16_t*)desc->ext_buff + (ch * desc->ext_buff_len);
+			buff[k++] = ch_buf_ptr[i];
+		}
 		k = 0;
 		iio_buffer_push_scan(dev_data->buffer, buff);
 	}
@@ -189,6 +192,7 @@ int32_t adc_demo_trigger_handler(struct iio_device_data *dev_data)
 	uint32_t ch = -1;
 	uint16_t buff[TOTAL_ADC_CHANNELS];
 	static uint32_t i = 0;
+	uint16_t *ch_buf_ptr;
 
 	if (!dev_data)
 		return -EINVAL;
@@ -207,8 +211,10 @@ int32_t adc_demo_trigger_handler(struct iio_device_data *dev_data)
 		return iio_buffer_push_scan(dev_data->buffer, buff);
 	}
 
-	while(get_next_ch_idx(desc->active_ch, ch, &ch))
-		buff[k++] = *(*(desc->ext_buff + ch) + i);
+	while(get_next_ch_idx(desc->active_ch, ch, &ch)) {
+		ch_buf_ptr = (uint16_t*)desc->ext_buff + (ch * desc->ext_buff_len);
+		buff[k++] = ch_buf_ptr[i];
+	}
 	if (i == (desc->ext_buff_len - 1))
 		i = 0;
 	else


### PR DESCRIPTION
Fix ext_buf memory access in iio_adc_demo.

Fixes: c81e7eab ("drivers: adc: adc_demo: fix syntax error")
Signed-off-by: Ramona Bolboaca <ramona.bolboaca@analog.com>