### PR TITLE
drivers:afe:ad413x Updated chip ID

### DIFF
--- a/drivers/afe/ad413x/ad413x.c
+++ b/drivers/afe/ad413x/ad413x.c
@@ -976,7 +976,6 @@ int32_t ad413x_init(struct ad413x_dev **device,
 	if (ret)
 		goto err_spi;
 
-	/* TBD - chip ID is 0x00 for now */
 	ret = ad413x_reg_read(dev, AD413X_REG_ID, &reg_data);
 	if (ret)
 		goto err_spi;

--- a/drivers/afe/ad413x/ad413x.h
+++ b/drivers/afe/ad413x/ad413x.h
@@ -390,8 +390,7 @@ enum ad413x_gain {
  * @brief Chip IDs.
  */
 enum ad413x_chip_id {
-	/* TBD */
-	AD4130_8 = 0x00
+	AD4130_8 = 0x04
 };
 
 /**


### PR DESCRIPTION
Updated chip ID to 0x4 as released silicon has configured same

Signed-off-by: MPhalke <mahesh.phalke@analog.com>