### PR TITLE
Staging/ad9361 fmcomms5 work

### DIFF
--- a/drivers/rf-transceiver/ad9361/ad9361_conv.c
+++ b/drivers/rf-transceiver/ad9361/ad9361_conv.c
@@ -643,14 +643,13 @@ int32_t ad9361_post_setup(struct ad9361_rf_phy *phy)
 	flags = 0x0;
 
 	axi_adc_read(rx_adc, ADI_REG_ID, &id);
-	ret = ad9361_dig_tune(phy, (id) ?
-			      0 : 61440000, flags);
+	ret = ad9361_dig_tune(phy, 61440000, (id) ? flags | RESTORE_DEFAULT : flags);
 	if (ret < 0)
 		return ret;
 
 	if (flags & (DO_IDELAY | DO_ODELAY)) {
-		ret = ad9361_dig_tune(phy, (id) ?
-				      0 : 61440000, flags & BE_VERBOSE);
+		ret = ad9361_dig_tune(phy, 61440000,
+				      (id) ? flags | RESTORE_DEFAULT | BE_VERBOSE : flags | BE_VERBOSE);
 		if (ret < 0)
 			return ret;
 	}

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -608,13 +608,11 @@ int main(void)
 #ifdef DAC_DMA_EXAMPLE
 #ifdef FMCOMMS5
 	axi_dac_init(&ad9361_phy_b->tx_dac, &tx_dac_init);
-	axi_adc_init(&ad9361_phy_b->rx_adc, &rx_adc_init);
 	axi_dac_set_datasel(ad9361_phy_b->tx_dac, -1, AXI_DAC_DATA_SEL_DMA);
 	rx_adc_init.base = AD9361_RX_0_BASEADDR;
 	tx_dac_init.base = AD9361_TX_0_BASEADDR;
 #endif
 	axi_dac_init(&ad9361_phy->tx_dac, &tx_dac_init);
-	axi_adc_init(&ad9361_phy->rx_adc, &rx_adc_init);
 	extern const uint32_t sine_lut_iq[1024];
 	axi_dac_set_datasel(ad9361_phy->tx_dac, -1, AXI_DAC_DATA_SEL_DMA);
 	axi_dac_load_custom_data(ad9361_phy->tx_dac, sine_lut_iq,

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -100,9 +100,9 @@ static uint8_t out_buff[MAX_SIZE_BASE_ADDR];
 
 #if defined(DAC_DMA_EXAMPLE) || defined(IIO_SUPPORT)
 uint32_t dac_buffer[DAC_BUFFER_SAMPLES] __attribute__ ((aligned));
-uint16_t adc_buffer[ADC_BUFFER_SAMPLES * ADC_CHANNELS] __attribute__ ((
-			aligned));
 #endif
+uint16_t adc_buffer[ADC_BUFFER_SAMPLES * ADC_CHANNELS] __attribute__ ((
+	aligned));
 
 #define AD9361_ADC_DAC_BYTES_PER_SAMPLE 2
 


### PR DESCRIPTION
Correct axi_adc initialization.
Sync commit 8077957e (https://github.com/analogdevicesinc/linux/commit/8077957e8f81d539f05a7a065a6b17a2477c4a89) from ad9361 Linux driver.