### PR TITLE
drivers:platform: Remove redundant desc->platform_ops init

### DIFF
--- a/drivers/platform/aducm3029/aducm3029_gpio_irq.c
+++ b/drivers/platform/aducm3029/aducm3029_gpio_irq.c
@@ -134,7 +134,6 @@ static int aducm_gpio_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 		goto error_dev;
 
 	descriptor->irq_ctrl_id = param->irq_ctrl_id;
-	descriptor->platform_ops = &aducm_gpio_irq_ops;
 	descriptor->extra = extra;
 
 	ret = no_os_list_init(&extra->actions, NO_OS_LIST_PRIORITY_LIST,

--- a/drivers/platform/maxim/max32650/maxim_gpio.c
+++ b/drivers/platform/maxim/max32650/maxim_gpio.c
@@ -122,7 +122,6 @@ int32_t max_gpio_get(struct no_os_gpio_desc **desc,
 	descriptor->port = param->port;
 	descriptor->number = param->number;
 	descriptor->pull = param->pull;
-	descriptor->platform_ops = param->platform_ops;
 	descriptor->extra = g_cfg;
 
 	MXC_GPIO_Init(param->port);

--- a/drivers/platform/maxim/max32650/maxim_gpio_irq.c
+++ b/drivers/platform/maxim/max32650/maxim_gpio_irq.c
@@ -123,7 +123,6 @@ static int max_gpio_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 		return -ENOMEM;
 
 	descriptor->irq_ctrl_id = param->irq_ctrl_id;
-	descriptor->platform_ops = &max_gpio_irq_ops;
 	descriptor->extra = param->extra;
 
 	ret = no_os_list_init(&actions, NO_OS_LIST_PRIORITY_LIST, irq_action_cmp);

--- a/drivers/platform/maxim/max32650/maxim_irq.c
+++ b/drivers/platform/maxim/max32650/maxim_irq.c
@@ -259,7 +259,6 @@ int32_t max_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 		return -ENOMEM;
 
 	descriptor->irq_ctrl_id = param->irq_ctrl_id;
-	descriptor->platform_ops = param->platform_ops;
 	descriptor->extra = param->extra;
 
 	*desc = descriptor;

--- a/drivers/platform/maxim/max32650/maxim_spi.c
+++ b/drivers/platform/maxim/max32650/maxim_spi.c
@@ -219,7 +219,6 @@ int32_t max_spi_init(struct no_os_spi_desc **desc,
 	descriptor->chip_select = param->chip_select;
 	descriptor->mode = param->mode;
 	descriptor->bit_order = param->bit_order;
-	descriptor->platform_ops = &max_spi_ops;
 	descriptor->extra = eparam;
 
 	if (descriptor->device_id >= MXC_SPI_INSTANCES) {

--- a/drivers/platform/maxim/max32650/maxim_timer.c
+++ b/drivers/platform/maxim/max32650/maxim_timer.c
@@ -125,7 +125,6 @@ int max_timer_init(struct no_os_timer_desc **desc,
 	descriptor->id = param->id;
 	descriptor->freq_hz = param->freq_hz;
 	descriptor->ticks_count = param->ticks_count;
-	descriptor->platform_ops = param->platform_ops;
 
 	tmr_regs = MXC_TMR_GET_TMR(param->id);
 

--- a/drivers/platform/maxim/max32655/maxim_gpio.c
+++ b/drivers/platform/maxim/max32655/maxim_gpio.c
@@ -122,7 +122,6 @@ int32_t max_gpio_get(struct no_os_gpio_desc **desc,
 	descriptor->port = param->port;
 	descriptor->number = param->number;
 	descriptor->pull = param->pull;
-	descriptor->platform_ops = param->platform_ops;
 	descriptor->extra = g_cfg;
 
 	MXC_GPIO_Init(param->port);

--- a/drivers/platform/maxim/max32655/maxim_gpio_irq.c
+++ b/drivers/platform/maxim/max32655/maxim_gpio_irq.c
@@ -123,7 +123,6 @@ static int max_gpio_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 		return -ENOMEM;
 
 	descriptor->irq_ctrl_id = param->irq_ctrl_id;
-	descriptor->platform_ops = &max_gpio_irq_ops;
 	descriptor->extra = param->extra;
 
 	ret = no_os_list_init(&actions, NO_OS_LIST_PRIORITY_LIST, irq_action_cmp);

--- a/drivers/platform/maxim/max32655/maxim_irq.c
+++ b/drivers/platform/maxim/max32655/maxim_irq.c
@@ -259,7 +259,6 @@ int32_t max_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 		return -ENOMEM;
 
 	descriptor->irq_ctrl_id = param->irq_ctrl_id;
-	descriptor->platform_ops = param->platform_ops;
 	descriptor->extra = param->extra;
 
 	*desc = descriptor;

--- a/drivers/platform/maxim/max32655/maxim_spi.c
+++ b/drivers/platform/maxim/max32655/maxim_spi.c
@@ -135,7 +135,6 @@ int32_t max_spi_init(struct no_os_spi_desc **desc,
 	descriptor->chip_select = param->chip_select;
 	descriptor->mode = param->mode;
 	descriptor->bit_order = param->bit_order;
-	descriptor->platform_ops = &max_spi_ops;
 	descriptor->extra = eparam;
 
 	if (descriptor->device_id >= MXC_SPI_INSTANCES) {

--- a/drivers/platform/maxim/max32655/maxim_timer.c
+++ b/drivers/platform/maxim/max32655/maxim_timer.c
@@ -122,7 +122,6 @@ int max_timer_init(struct no_os_timer_desc **desc,
 	descriptor->id = param->id;
 	descriptor->freq_hz = param->freq_hz;
 	descriptor->ticks_count = param->ticks_count;
-	descriptor->platform_ops = param->platform_ops;
 
 	tmr_regs = MXC_TMR_GET_TMR(param->id);
 

--- a/drivers/platform/maxim/max32660/maxim_gpio.c
+++ b/drivers/platform/maxim/max32660/maxim_gpio.c
@@ -122,7 +122,6 @@ int32_t max_gpio_get(struct no_os_gpio_desc **desc,
 	descriptor->port = param->port;
 	descriptor->number = param->number;
 	descriptor->pull = param->pull;
-	descriptor->platform_ops = param->platform_ops;
 	descriptor->extra = g_cfg;
 
 	MXC_GPIO_Init(param->port);

--- a/drivers/platform/maxim/max32660/maxim_gpio_irq.c
+++ b/drivers/platform/maxim/max32660/maxim_gpio_irq.c
@@ -123,7 +123,6 @@ static int max_gpio_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 		return -ENOMEM;
 
 	descriptor->irq_ctrl_id = param->irq_ctrl_id;
-	descriptor->platform_ops = &max_gpio_irq_ops;
 	descriptor->extra = param->extra;
 
 	ret = no_os_list_init(&actions, NO_OS_LIST_PRIORITY_LIST, irq_action_cmp);

--- a/drivers/platform/maxim/max32660/maxim_irq.c
+++ b/drivers/platform/maxim/max32660/maxim_irq.c
@@ -259,7 +259,6 @@ int32_t max_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 		return -ENOMEM;
 
 	descriptor->irq_ctrl_id = param->irq_ctrl_id;
-	descriptor->platform_ops = param->platform_ops;
 	descriptor->extra = param->extra;
 
 	*desc = descriptor;

--- a/drivers/platform/maxim/max32660/maxim_spi.c
+++ b/drivers/platform/maxim/max32660/maxim_spi.c
@@ -125,7 +125,6 @@ int32_t max_spi_init(struct no_os_spi_desc **desc,
 	descriptor->chip_select = param->chip_select;
 	descriptor->mode = param->mode;
 	descriptor->bit_order = param->bit_order;
-	descriptor->platform_ops = &max_spi_ops;
 	descriptor->extra = eparam;
 
 	if (descriptor->device_id >= MXC_SPI_INSTANCES) {

--- a/drivers/platform/maxim/max32660/maxim_timer.c
+++ b/drivers/platform/maxim/max32660/maxim_timer.c
@@ -123,7 +123,6 @@ int max_timer_init(struct no_os_timer_desc **desc,
 	descriptor->id = param->id;
 	descriptor->freq_hz = param->freq_hz;
 	descriptor->ticks_count = param->ticks_count;
-	descriptor->platform_ops = param->platform_ops;
 
 	tmr_regs = MXC_TMR_GET_TMR(param->id);
 

--- a/drivers/platform/maxim/max32665/maxim_gpio.c
+++ b/drivers/platform/maxim/max32665/maxim_gpio.c
@@ -122,7 +122,6 @@ int32_t max_gpio_get(struct no_os_gpio_desc **desc,
 	descriptor->port = param->port;
 	descriptor->number = param->number;
 	descriptor->pull = param->pull;
-	descriptor->platform_ops = param->platform_ops;
 	descriptor->extra = g_cfg;
 
 	MXC_GPIO_Init(param->port);

--- a/drivers/platform/maxim/max32665/maxim_gpio_irq.c
+++ b/drivers/platform/maxim/max32665/maxim_gpio_irq.c
@@ -123,7 +123,6 @@ static int max_gpio_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 		return -ENOMEM;
 
 	descriptor->irq_ctrl_id = param->irq_ctrl_id;
-	descriptor->platform_ops = &max_gpio_irq_ops;
 	descriptor->extra = param->extra;
 
 	ret = no_os_list_init(&actions, NO_OS_LIST_PRIORITY_LIST, irq_action_cmp);

--- a/drivers/platform/maxim/max32665/maxim_irq.c
+++ b/drivers/platform/maxim/max32665/maxim_irq.c
@@ -259,7 +259,6 @@ int32_t max_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 		return -ENOMEM;
 
 	descriptor->irq_ctrl_id = param->irq_ctrl_id;
-	descriptor->platform_ops = param->platform_ops;
 	descriptor->extra = param->extra;
 
 	*desc = descriptor;

--- a/drivers/platform/maxim/max32665/maxim_spi.c
+++ b/drivers/platform/maxim/max32665/maxim_spi.c
@@ -214,7 +214,6 @@ int32_t max_spi_init(struct no_os_spi_desc **desc,
 	descriptor->chip_select = param->chip_select;
 	descriptor->mode = param->mode;
 	descriptor->bit_order = param->bit_order;
-	descriptor->platform_ops = &max_spi_ops;
 	descriptor->extra = eparam;
 
 	if (descriptor->device_id >= MXC_SPI_INSTANCES) {

--- a/drivers/platform/maxim/max32665/maxim_timer.c
+++ b/drivers/platform/maxim/max32665/maxim_timer.c
@@ -123,7 +123,6 @@ int max_timer_init(struct no_os_timer_desc **desc,
 	descriptor->id = param->id;
 	descriptor->freq_hz = param->freq_hz;
 	descriptor->ticks_count = param->ticks_count;
-	descriptor->platform_ops = param->platform_ops;
 
 	tmr_regs = MXC_TMR_GET_TMR(param->id);
 

--- a/drivers/platform/maxim/max32670/maxim_gpio.c
+++ b/drivers/platform/maxim/max32670/maxim_gpio.c
@@ -131,7 +131,6 @@ int32_t max_gpio_get(struct no_os_gpio_desc **desc,
 	descriptor->port = param->port;
 	descriptor->number = param->number;
 	descriptor->pull = param->pull;
-	descriptor->platform_ops = param->platform_ops;
 	descriptor->extra = g_cfg;
 
 	MXC_GPIO_Init(param->port);

--- a/drivers/platform/maxim/max32670/maxim_gpio_irq.c
+++ b/drivers/platform/maxim/max32670/maxim_gpio_irq.c
@@ -123,7 +123,6 @@ static int max_gpio_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 		return -ENOMEM;
 
 	descriptor->irq_ctrl_id = param->irq_ctrl_id;
-	descriptor->platform_ops = &max_gpio_irq_ops;
 	descriptor->extra = param->extra;
 
 	ret = no_os_list_init(&actions, NO_OS_LIST_PRIORITY_LIST, irq_action_cmp);

--- a/drivers/platform/maxim/max32670/maxim_irq.c
+++ b/drivers/platform/maxim/max32670/maxim_irq.c
@@ -261,7 +261,6 @@ int max_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 		return -ENOMEM;
 
 	descriptor->irq_ctrl_id = param->irq_ctrl_id;
-	descriptor->platform_ops = param->platform_ops;
 	descriptor->extra = param->extra;
 
 	*desc = descriptor;

--- a/drivers/platform/maxim/max32670/maxim_spi.c
+++ b/drivers/platform/maxim/max32670/maxim_spi.c
@@ -125,7 +125,6 @@ int32_t max_spi_init(struct no_os_spi_desc **desc,
 	descriptor->chip_select = param->chip_select;
 	descriptor->mode = param->mode;
 	descriptor->bit_order = param->bit_order;
-	descriptor->platform_ops = &max_spi_ops;
 	descriptor->extra = eparam;
 
 	if (descriptor->device_id >= MXC_SPI_INSTANCES) {

--- a/drivers/platform/maxim/max78000/maxim_gpio.c
+++ b/drivers/platform/maxim/max78000/maxim_gpio.c
@@ -122,7 +122,6 @@ int32_t max_gpio_get(struct no_os_gpio_desc **desc,
 	descriptor->port = param->port;
 	descriptor->number = param->number;
 	descriptor->pull = param->pull;
-	descriptor->platform_ops = param->platform_ops;
 	descriptor->extra = g_cfg;
 
 	MXC_GPIO_Init(param->port);

--- a/drivers/platform/maxim/max78000/maxim_gpio_irq.c
+++ b/drivers/platform/maxim/max78000/maxim_gpio_irq.c
@@ -123,7 +123,6 @@ static int max_gpio_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 		return -ENOMEM;
 
 	descriptor->irq_ctrl_id = param->irq_ctrl_id;
-	descriptor->platform_ops = &max_gpio_irq_ops;
 	descriptor->extra = param->extra;
 
 	ret = no_os_list_init(&actions, NO_OS_LIST_PRIORITY_LIST, irq_action_cmp);

--- a/drivers/platform/maxim/max78000/maxim_irq.c
+++ b/drivers/platform/maxim/max78000/maxim_irq.c
@@ -259,7 +259,6 @@ int32_t max_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 		return -ENOMEM;
 
 	descriptor->irq_ctrl_id = param->irq_ctrl_id;
-	descriptor->platform_ops = param->platform_ops;
 	descriptor->extra = param->extra;
 
 	*desc = descriptor;

--- a/drivers/platform/maxim/max78000/maxim_spi.c
+++ b/drivers/platform/maxim/max78000/maxim_spi.c
@@ -135,7 +135,6 @@ int32_t max_spi_init(struct no_os_spi_desc **desc,
 	descriptor->chip_select = param->chip_select;
 	descriptor->mode = param->mode;
 	descriptor->bit_order = param->bit_order;
-	descriptor->platform_ops = &max_spi_ops;
 	descriptor->extra = eparam;
 
 	if (descriptor->device_id >= MXC_SPI_INSTANCES) {

--- a/drivers/platform/maxim/max78000/maxim_timer.c
+++ b/drivers/platform/maxim/max78000/maxim_timer.c
@@ -123,7 +123,6 @@ int max_timer_init(struct no_os_timer_desc **desc,
 	descriptor->id = param->id;
 	descriptor->freq_hz = param->freq_hz;
 	descriptor->ticks_count = param->ticks_count;
-	descriptor->platform_ops = param->platform_ops;
 
 	tmr_regs = MXC_TMR_GET_TMR(param->id);
 

--- a/drivers/platform/mbed/mbed_gpio_irq.cpp
+++ b/drivers/platform/mbed/mbed_gpio_irq.cpp
@@ -184,7 +184,6 @@ int32_t mbed_gpio_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 		goto err_mbed_irq_desc;
 
 	irq_desc->irq_ctrl_id = param->irq_ctrl_id;
-	irq_desc->platform_ops = &mbed_gpio_irq_ops;
 
 	/* Copy the Mbed IRQ init parameters */
 	mbed_gpio_irq_desc->gpio_irq_pin = ((struct mbed_gpio_irq_init_param *)

--- a/drivers/platform/mbed/mbed_irq.cpp
+++ b/drivers/platform/mbed/mbed_irq.cpp
@@ -139,7 +139,6 @@ int32_t mbed_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 		goto err_mbed_irq_desc;
 
 	irq_desc->irq_ctrl_id = param->irq_ctrl_id;
-	irq_desc->platform_ops = &mbed_irq_ops;
 
 	/* Copy the Mbed IRQ init parameters */
 	mbed_irq_desc->ticker_period_usec = ((struct mbed_irq_init_param *)

--- a/drivers/platform/pico/pico_gpio_irq.c
+++ b/drivers/platform/pico/pico_gpio_irq.c
@@ -125,7 +125,6 @@ static int32_t pico_gpio_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 
 		gpio_irq_desc->extra = pico_gpio_irq;
 		gpio_irq_desc->irq_ctrl_id = param->irq_ctrl_id;
-		gpio_irq_desc->platform_ops = param->platform_ops;
 
 		ret = no_os_list_init(&actions, NO_OS_LIST_PRIORITY_LIST, irq_action_cmp);
 		if (ret)

--- a/drivers/platform/pico/pico_irq.c
+++ b/drivers/platform/pico/pico_irq.c
@@ -187,7 +187,6 @@ int32_t pico_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 
 	/* There is only 1 interrupt controller and that is NVIC */
 	descriptor->irq_ctrl_id = param->irq_ctrl_id;
-	descriptor->platform_ops = param->platform_ops;
 	descriptor->extra = param->extra;
 
 	*desc = descriptor;

--- a/drivers/platform/pico/pico_spi.c
+++ b/drivers/platform/pico/pico_spi.c
@@ -165,7 +165,6 @@ int32_t pico_spi_init(struct no_os_spi_desc **desc,
 
 	/* Only MSB is supported */
 	descriptor->bit_order = NO_OS_SPI_BIT_ORDER_MSB_FIRST;
-	descriptor->platform_ops = &pico_spi_ops;
 
 	pico_spi_ip = param->extra;
 	pico_spi->spi_cs_pin = pico_spi_ip->spi_cs_pin;

--- a/drivers/platform/stm32/stm32_gpio_irq.c
+++ b/drivers/platform/stm32/stm32_gpio_irq.c
@@ -174,7 +174,6 @@ static int32_t stm32_gpio_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 
 		gpio_irq_desc->extra = sdesc;
 		gpio_irq_desc->irq_ctrl_id = param->irq_ctrl_id;
-		gpio_irq_desc->platform_ops = param->platform_ops;
 
 		ret = no_os_list_init(&actions, NO_OS_LIST_PRIORITY_LIST, irq_action_cmp);
 		if (ret)

--- a/drivers/platform/stm32/stm32_irq.c
+++ b/drivers/platform/stm32/stm32_irq.c
@@ -155,7 +155,6 @@ int32_t stm32_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 
 	// unused, there is only 1 interrupt controller and that is NVIC
 	descriptor->irq_ctrl_id = param->irq_ctrl_id;
-	descriptor->platform_ops = param->platform_ops;
 	descriptor->extra = param->extra;
 
 	*desc = descriptor;


### PR DESCRIPTION
Remove redundant desc->platform_ops initialization in drivers. 
The assignment is already performed in no_os_%peripheral%_init()

Signed-off-by: Ramona Bolboaca <ramona.bolboaca@analog.com>