### PR TITLE
drivers:platform: Add UART platform ops

### DIFF
--- a/drivers/api/no_os_uart.c
+++ b/drivers/api/no_os_uart.c
@@ -1,0 +1,182 @@
+/***************************************************************************//**
+ *   @file   no_os_uart.c
+ *   @brief  Implementation of the UART Interface
+ *   @author Ramona Bolboaca (ramona.bolboaca@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <inttypes.h>
+#include "no_os_uart.h"
+#include <stdlib.h>
+#include "no_os_error.h"
+
+/**
+ * @brief Initialize the UART communication peripheral.
+ * @param desc - The UART descriptor.
+ * @param param - The structure that contains the UART parameters.
+ * @return 0 in case of success, error code otherwise.
+ */
+int32_t no_os_uart_init(struct no_os_uart_desc **desc,
+			struct no_os_uart_init_param *param)
+{
+	int32_t ret;
+
+	if (!param || !param->platform_ops)
+		return -EINVAL;
+
+	if (!param->platform_ops->init)
+		return -ENOSYS;
+
+	ret = param->platform_ops->init(desc, param);
+	if (ret)
+		return ret;
+
+	(*desc)->platform_ops = param->platform_ops;
+
+	return 0;
+}
+
+/**
+ * @brief Free the resources allocated by no_os_uart_init().
+ * @param desc - The UART descriptor.
+ * @return 0 in case of success, error code otherwise.
+ */
+int32_t no_os_uart_remove(struct no_os_uart_desc *desc)
+{
+	if (!desc || !desc->platform_ops)
+		return -EINVAL;
+
+	if (!desc->platform_ops->remove)
+		return -ENOSYS;
+
+	return desc->platform_ops->remove(desc);
+}
+
+/**
+ * @brief Check if errors occurred on UART.
+ * @param desc - The UART descriptor.
+ * @return number of errors in case of success, error code otherwise.
+ */
+uint32_t no_os_uart_get_errors(struct no_os_uart_desc *desc)
+{
+	if (!desc || !desc->platform_ops)
+		return -EINVAL;
+
+	if (!desc->platform_ops->get_errors)
+		return -ENOSYS;
+
+	return desc->platform_ops->get_errors(desc);
+}
+
+/**
+ * @brief Read data from UART.
+ * @param desc - The UART descriptor.
+ * @param data - The buffer with the received data.
+ * @param bytes_number - Number of bytes to read.
+ * @return 0 in case of success, error code otherwise.
+ */
+int32_t no_os_uart_read(struct no_os_uart_desc *desc,
+			uint8_t *data,
+			uint32_t bytes_number)
+{
+	if (!desc || !desc->platform_ops || !data)
+		return -EINVAL;
+
+	if (!desc->platform_ops->read)
+		return -ENOSYS;
+
+	return desc->platform_ops->read(desc, data, bytes_number);
+}
+
+/**
+ * @brief Write to UART.
+ * @param desc - The UART descriptor.
+ * @param data - The buffer with the transmitted data.
+ * @param bytes_number - Number of bytes to write.
+ * @return 0 in case of success, error code otherwise.
+ */
+int32_t no_os_uart_write(struct no_os_uart_desc *desc,
+			 const uint8_t *data,
+			 uint32_t bytes_number)
+{
+	if (!desc || !desc->platform_ops || !data)
+		return -EINVAL;
+
+	if (!desc->platform_ops->write)
+		return -ENOSYS;
+
+	return desc->platform_ops->write(desc, data, bytes_number);
+}
+
+/**
+ * @brief Read data from UART non-blocking.
+ * @param desc - The UART descriptor.
+ * @param data - The buffer with the received data.
+ * @param bytes_number - Number of bytes to read.
+ * @return 0 in case of success, error code otherwise.
+ */
+int32_t no_os_uart_read_nonblocking(struct no_os_uart_desc *desc,
+				    uint8_t *data,
+				    uint32_t bytes_number)
+{
+	if (!desc || !desc->platform_ops || !data)
+		return -EINVAL;
+
+	if (!desc->platform_ops->read_nonblocking)
+		return -ENOSYS;
+
+	return desc->platform_ops->read_nonblocking(desc, data, bytes_number);
+}
+
+/**
+ * @brief Write to UART non-blocking.
+ * @param desc - The UART descriptor.
+ * @param data - The buffer with the transmitted data.
+ * @param bytes_number - Number of bytes to write.
+ * @return 0 in case of success, error code otherwise.
+ */
+int32_t no_os_uart_write_nonblocking(struct no_os_uart_desc *desc,
+				     const uint8_t *data,
+				     uint32_t bytes_number)
+{
+	if (!desc || !desc->platform_ops || !data)
+		return -EINVAL;
+
+	if (!desc->platform_ops->write_nonblocking)
+		return -ENOSYS;
+
+	return desc->platform_ops->write_nonblocking(desc, data, bytes_number);
+}
+

--- a/drivers/platform/aducm3029/aducm3029_uart.c
+++ b/drivers/platform/aducm3029/aducm3029_uart.c
@@ -152,8 +152,8 @@ static void free_desc_mem(struct no_os_uart_desc *desc)
  * @param bytes_number:	Number of bytes to be read. Between 1 and 1024
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
-			uint32_t bytes_number)
+static int32_t aducm3029_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
+				   uint32_t bytes_number)
 {
 	struct no_os_aducm_uart_desc	*extra;
 	uint32_t		errors;
@@ -179,7 +179,7 @@ int32_t no_os_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
 		return idx;
 	}
 
-	/* Wait until a previously no_os_uart_read_nonblocking ends */
+	/* Wait until a previously aducm3029_uart_read_nonblocking ends */
 	while (extra->read_desc.is_nonblocking)
 		;
 
@@ -208,8 +208,9 @@ failure:
  * @param bytes_number:	Number of bytes to be written. Between 1 and 1024
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
-			 uint32_t bytes_number)
+static int32_t aducm3029_uart_write(struct no_os_uart_desc *desc,
+				    const uint8_t *data,
+				    uint32_t bytes_number)
 {
 	struct no_os_aducm_uart_desc	*extra;
 	uint32_t		errors;
@@ -222,7 +223,7 @@ int32_t no_os_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
 	/* TODO: Add support for more than 1024 bytes */
 
 	extra = desc->extra;
-	/* Wait until a previously no_os_uart_write_nonblocking ends */
+	/* Wait until a previously aducm3029_uart_write_nonblocking ends */
 	while (extra->write_desc.is_nonblocking)
 		;
 
@@ -255,8 +256,9 @@ failure:
  * @param bytes_number:	Number of bytes to be read
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_uart_read_nonblocking(struct no_os_uart_desc *desc, uint8_t *data,
-				    uint32_t bytes_number)
+static int32_t aducm3029_uart_read_nonblocking(struct no_os_uart_desc *desc,
+		uint8_t *data,
+		uint32_t bytes_number)
 {
 	struct no_os_aducm_uart_desc	*extra;
 	uint32_t		to_read;
@@ -292,9 +294,9 @@ int32_t no_os_uart_read_nonblocking(struct no_os_uart_desc *desc, uint8_t *data,
  * @param bytes_number:	Number of bytes to be written
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_uart_write_nonblocking(struct no_os_uart_desc *desc,
-				     const uint8_t *data,
-				     uint32_t bytes_number)
+static int32_t aducm3029_uart_write_nonblocking(struct no_os_uart_desc *desc,
+		const uint8_t *data,
+		uint32_t bytes_number)
 {
 	struct no_os_aducm_uart_desc	*extra;
 	uint32_t		to_write;
@@ -328,8 +330,8 @@ int32_t no_os_uart_write_nonblocking(struct no_os_uart_desc *desc,
  * @param param: Descriptor used to configure the UART device
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_uart_init(struct no_os_uart_desc **desc,
-			struct no_os_uart_init_param *param)
+static int32_t aducm3029_uart_init(struct no_os_uart_desc **desc,
+				   struct no_os_uart_init_param *param)
 {
 	int ret;
 	ADI_UART_RESULT			uart_ret;
@@ -430,7 +432,7 @@ int32_t no_os_uart_init(struct no_os_uart_desc **desc,
 		if (ret < 0)
 			goto error_register;
 
-		ret = no_os_uart_read_nonblocking(descriptor, &c, 1);
+		ret = aducm3029_uart_read_nonblocking(descriptor, &c, 1);
 		if (ret < 0)
 			goto error_enable;
 	}
@@ -453,11 +455,11 @@ failure:
 }
 
 /**
- * @brief Free the resources allocated by \ref no_os_uart_init().
+ * @brief Free the resources allocated by \ref aducm3029_uart_init().
  * @param desc: Descriptor of the UART device
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_uart_remove(struct no_os_uart_desc *desc)
+static int32_t aducm3029_uart_remove(struct no_os_uart_desc *desc)
 {
 	struct no_os_aducm_uart_desc *aducm_desc;
 
@@ -485,7 +487,7 @@ int32_t no_os_uart_remove(struct no_os_uart_desc *desc)
  * @param desc: Descriptor of the UART device
  * @return 0 in case of success, -1 otherwise.
  */
-uint32_t no_os_uart_get_errors(struct no_os_uart_desc *desc)
+static uint32_t aducm3029_uart_get_errors(struct no_os_uart_desc *desc)
 {
 	struct no_os_aducm_uart_desc *extra;
 
@@ -497,4 +499,17 @@ uint32_t no_os_uart_get_errors(struct no_os_uart_desc *desc)
 
 	return ret;
 }
+
+/**
+ * @brief aducm3029 platform specific UART platform ops structure
+ */
+const struct no_os_uart_platform_ops aducm_uart_ops = {
+	.init = &aducm3029_uart_init,
+	.read = &aducm3029_uart_read,
+	.write = &aducm3029_uart_write,
+	.read_nonblocking = &aducm3029_uart_read_nonblocking,
+	.write_nonblocking = &aducm3029_uart_write_nonblocking,
+	.get_errors = &aducm3029_uart_get_errors,
+	.remove = &aducm3029_uart_remove
+};
 

--- a/drivers/platform/aducm3029/aducm3029_uart.h
+++ b/drivers/platform/aducm3029/aducm3029_uart.h
@@ -49,6 +49,7 @@
 #include <stdint.h>
 #include "no_os_error.h"
 #include "no_os_irq.h"
+#include "no_os_uart.h"
 
 /** Maximum number of bytes that can be transmitted on UART in one transfer */
 #define NO_OS_UART_MAX_BYTES	1024u
@@ -156,5 +157,10 @@ struct no_os_aducm_uart_desc {
 	/** RX complete callback */
 	struct no_os_callback_desc rx_callback;
 };
+
+/**
+* @brief aducm3029 platform specific UART platform ops structure
+*/
+extern const struct no_os_uart_platform_ops aducm_uart_ops;
 
 #endif /* ADUCM3029_UART_H_ */

--- a/drivers/platform/linux/linux_uart.c
+++ b/drivers/platform/linux/linux_uart.c
@@ -41,7 +41,6 @@
 /***************************** Include Files **********************************/
 /******************************************************************************/
 #include "no_os_error.h"
-#include "no_os_uart.h"
 #include "linux_uart.h"
 
 #include <fcntl.h>
@@ -76,8 +75,8 @@ struct linux_uart_desc {
  * @param param - The structure that contains the UART parameters.
  * @return 0 in case of success, error code otherwise.
  */
-int32_t no_os_uart_init(struct no_os_uart_desc **desc,
-			struct no_os_uart_init_param *param)
+static int32_t linux_uart_init(struct no_os_uart_desc **desc,
+			       struct no_os_uart_init_param *param)
 {
 	struct linux_uart_init_param *linux_init;
 	struct linux_uart_desc *linux_desc;
@@ -238,11 +237,11 @@ free_desc:
 };
 
 /**
- * @brief Free the resources allocated by no_os_uart_init().
+ * @brief Free the resources allocated by linux_uart_init().
  * @param desc - The UART descriptor.
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_uart_remove(struct no_os_uart_desc *desc)
+static int32_t linux_uart_remove(struct no_os_uart_desc *desc)
 {
 	struct linux_uart_desc *linux_desc;
 	int32_t ret;
@@ -266,8 +265,9 @@ int32_t no_os_uart_remove(struct no_os_uart_desc *desc)
  * @param bytes_number - Number of bytes to read.
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
-			 uint32_t bytes_number)
+static int32_t linux_uart_write(struct no_os_uart_desc *desc,
+				const uint8_t *data,
+				uint32_t bytes_number)
 {
 	struct linux_uart_desc *linux_desc;
 	uint32_t count = 0;
@@ -291,8 +291,8 @@ int32_t no_os_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
  * @param bytes_number - Number of bytes to read.
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
-			uint32_t bytes_number)
+static int32_t linux_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
+			       uint32_t bytes_number)
 {
 	struct linux_uart_desc *linux_desc;
 	uint32_t count = 0;
@@ -307,4 +307,14 @@ int32_t no_os_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
 	}
 
 	return 0;
+};
+
+/**
+ * @brief Linux platform specific UART platform ops structure
+ */
+const struct no_os_uart_platform_ops linux_uart_ops = {
+	.init = &linux_uart_init,
+	.read = &linux_uart_read,
+	.write = &linux_uart_write,
+	.remove = &linux_uart_remove
 };

--- a/drivers/platform/linux/linux_uart.h
+++ b/drivers/platform/linux/linux_uart.h
@@ -39,6 +39,8 @@
 #ifndef LINUX_UART_H_
 #define LINUX_UART_H_
 
+#include "no_os_uart.h"
+
 /**
  * @struct linux_uart_init_param
  * @brief Structure holding the initialization parameters for Linux platform
@@ -48,5 +50,10 @@ struct linux_uart_init_param {
 	/** UART device ID (/dev/"device_id") */
 	const char *device_id;
 };
+
+/**
+ * @brief Linux platform specific UART platform ops structure
+ */
+extern const struct no_os_uart_platform_ops linux_uart_ops;
 
 #endif // LINUX_UART_H_

--- a/drivers/platform/maxim/max32650/maxim_uart.c
+++ b/drivers/platform/maxim/max32650/maxim_uart.c
@@ -47,7 +47,6 @@
 #include "maxim_uart.h"
 #include "mxc_sys.h"
 #include "mxc_errors.h"
-#include "no_os_uart.h"
 #include "no_os_irq.h"
 #include "no_os_util.h"
 #include "no_os_lf256fifo.h"
@@ -66,13 +65,6 @@ static uint8_t c;
 /************************ Functions Definitions *******************************/
 /******************************************************************************/
 
-void uart_rx_callback(void *context)
-{
-	struct no_os_uart_desc *d = context;
-	lf256fifo_write(d->rx_fifo, c);
-	no_os_uart_read_nonblocking(d, &c, 1);
-}
-
 /**
  * @brief Read data from UART device. Blocking function.
  * @param desc - Instance of UART.
@@ -80,8 +72,8 @@ void uart_rx_callback(void *context)
  * @param bytes_number - Number of bytes to read.
  * @return positive number of received bytes in case of success, negative error code otherwise.
  */
-int32_t no_os_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
-			uint32_t bytes_number)
+static int32_t max_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
+			     uint32_t bytes_number)
 {
 	int32_t ret;
 	uint32_t i = 0;
@@ -113,8 +105,8 @@ int32_t no_os_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
  * @param bytes_number - Number of bytes to read.
  * @return 0 in case of success, errno codes otherwise.
  */
-int32_t no_os_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
-			 uint32_t bytes_number)
+static int32_t max_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
+			      uint32_t bytes_number)
 {
 	int32_t ret;
 
@@ -136,8 +128,9 @@ int32_t no_os_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
  * @param bytes_number - Number of bytes to read.
  * @return positive number of received bytes in case of success, negative error code otherwise.
  */
-int32_t no_os_uart_read_nonblocking(struct no_os_uart_desc *desc, uint8_t *data,
-				    uint32_t bytes_number)
+static int32_t max_uart_read_nonblocking(struct no_os_uart_desc *desc,
+		uint8_t *data,
+		uint32_t bytes_number)
 {
 	int32_t ret;
 	uint32_t id;
@@ -171,9 +164,9 @@ int32_t no_os_uart_read_nonblocking(struct no_os_uart_desc *desc, uint8_t *data,
  * @return 0 in case of success, errno codes otherwise.
  */
 
-int32_t no_os_uart_write_nonblocking(struct no_os_uart_desc *desc,
-				     const uint8_t *data,
-				     uint32_t bytes_number)
+static int32_t max_uart_write_nonblocking(struct no_os_uart_desc *desc,
+		const uint8_t *data,
+		uint32_t bytes_number)
 {
 	int32_t ret;
 	uint32_t id;
@@ -199,14 +192,21 @@ int32_t no_os_uart_write_nonblocking(struct no_os_uart_desc *desc,
 	return 0;
 }
 
+void uart_rx_callback(void *context)
+{
+	struct no_os_uart_desc *d = context;
+	lf256fifo_write(d->rx_fifo, c);
+	max_uart_read_nonblocking(d, &c, 1);
+}
+
 /**
  * @brief Initialize the UART communication peripheral.
  * @param desc - The UART descriptor.
  * @param param - The structure that contains the UART parameters.
  * @return 0 in case of success, errno codes otherwise.
  */
-int32_t no_os_uart_init(struct no_os_uart_desc **desc,
-			struct no_os_uart_init_param *param)
+static int32_t max_uart_init(struct no_os_uart_desc **desc,
+			     struct no_os_uart_init_param *param)
 {
 	int32_t ret;
 	int32_t stop, size, flow, parity;
@@ -363,7 +363,7 @@ int32_t no_os_uart_init(struct no_os_uart_desc **desc,
 		if (ret)
 			goto error_nvic;
 
-		ret = no_os_uart_read_nonblocking(descriptor, &c, 1);
+		ret = max_uart_read_nonblocking(descriptor, &c, 1);
 		if (ret)
 			goto error_nvic;
 	}
@@ -382,11 +382,11 @@ error_desc:
 }
 
 /**
- * @brief Free the resources allocated by no_os_uart_init().
+ * @brief Free the resources allocated by max_uart_init().
  * @param desc - The UART descriptor.
  * @return 0 in case of success, errno codes otherwise.
  */
-int32_t no_os_uart_remove(struct no_os_uart_desc *desc)
+static int32_t max_uart_remove(struct no_os_uart_desc *desc)
 {
 	if (!desc)
 		return -EINVAL;
@@ -402,7 +402,20 @@ int32_t no_os_uart_remove(struct no_os_uart_desc *desc)
  * @param desc - The UART descriptor.
  * @return -ENOSYS
  */
-uint32_t no_os_uart_get_errors(struct no_os_uart_desc *desc)
+static uint32_t max_uart_get_errors(struct no_os_uart_desc *desc)
 {
 	return -ENOSYS;
 }
+
+/**
+ * @brief Maxim platform specific UART platform ops structure
+ */
+const struct no_os_uart_platform_ops max_uart_ops = {
+	.init = &max_uart_init,
+	.read = &max_uart_read,
+	.write = &max_uart_write,
+	.read_nonblocking = &max_uart_read_nonblocking,
+	.write_nonblocking = &max_uart_write_nonblocking,
+	.get_errors = &max_uart_get_errors,
+	.remove = &max_uart_remove
+};

--- a/drivers/platform/maxim/max32650/maxim_uart.h
+++ b/drivers/platform/maxim/max32650/maxim_uart.h
@@ -43,6 +43,7 @@
 #include "uart.h"
 #include "no_os_irq.h"
 #include "max32650.h"
+#include "no_os_uart.h"
 
 /**
  * @brief UART flow control
@@ -67,5 +68,10 @@ struct max_uart_desc {
 	/** Controller that handles UART interrupts */
 	struct no_os_irq_ctrl_desc *nvic;
 };
+
+/**
+ * @brief Maxim specific UART platform ops structure
+ */
+extern const struct no_os_uart_platform_ops max_uart_ops;
 
 #endif

--- a/drivers/platform/maxim/max32655/maxim_uart.h
+++ b/drivers/platform/maxim/max32655/maxim_uart.h
@@ -43,6 +43,7 @@
 #include "uart.h"
 #include "no_os_irq.h"
 #include "max32655.h"
+#include "no_os_uart.h"
 
 /**
  * @brief UART flow control
@@ -67,5 +68,10 @@ struct max_uart_desc {
 	/** Controller that handles UART interrupts */
 	struct no_os_irq_ctrl_desc *nvic;
 };
+
+/**
+ * @brief Maxim specific UART platform ops structure
+ */
+extern const struct no_os_uart_platform_ops max_uart_ops;
 
 #endif

--- a/drivers/platform/maxim/max32660/maxim_uart.c
+++ b/drivers/platform/maxim/max32660/maxim_uart.c
@@ -47,7 +47,6 @@
 #include "maxim_uart.h"
 #include "mxc_sys.h"
 #include "mxc_errors.h"
-#include "no_os_uart.h"
 #include "no_os_irq.h"
 #include "no_os_util.h"
 #include "no_os_lf256fifo.h"
@@ -66,13 +65,6 @@ static uint8_t c;
 /************************ Functions Definitions *******************************/
 /******************************************************************************/
 
-void uart_rx_callback(void *context)
-{
-	struct no_os_uart_desc *d = context;
-	lf256fifo_write(d->rx_fifo, c);
-	no_os_uart_read_nonblocking(d, &c, 1);
-}
-
 /**
  * @brief Read data from UART device. Blocking function.
  * @param desc - Instance of UART.
@@ -80,8 +72,8 @@ void uart_rx_callback(void *context)
  * @param bytes_number - Number of bytes to read.
  * @return positive number of received bytes in case of success, negative error code otherwise.
  */
-int32_t no_os_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
-			uint32_t bytes_number)
+static int32_t max_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
+			     uint32_t bytes_number)
 {
 	int32_t ret;
 	uint32_t i = 0;
@@ -113,8 +105,8 @@ int32_t no_os_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
  * @param bytes_number - Number of bytes to read.
  * @return 0 in case of success, errno codes otherwise.
  */
-int32_t no_os_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
-			 uint32_t bytes_number)
+static int32_t max_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
+			      uint32_t bytes_number)
 {
 	int32_t ret;
 
@@ -136,8 +128,9 @@ int32_t no_os_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
  * @param bytes_number - Number of bytes to read.
  * @return positive number of received bytes in case of success, negative error code otherwise.
  */
-int32_t no_os_uart_read_nonblocking(struct no_os_uart_desc *desc, uint8_t *data,
-				    uint32_t bytes_number)
+static int32_t max_uart_read_nonblocking(struct no_os_uart_desc *desc,
+		uint8_t *data,
+		uint32_t bytes_number)
 {
 	int32_t ret;
 	uint32_t id;
@@ -171,9 +164,9 @@ int32_t no_os_uart_read_nonblocking(struct no_os_uart_desc *desc, uint8_t *data,
  * @return 0 in case of success, errno codes otherwise.
  */
 
-int32_t no_os_uart_write_nonblocking(struct no_os_uart_desc *desc,
-				     const uint8_t *data,
-				     uint32_t bytes_number)
+static int32_t max_uart_write_nonblocking(struct no_os_uart_desc *desc,
+		const uint8_t *data,
+		uint32_t bytes_number)
 {
 	int32_t ret;
 	uint32_t id;
@@ -199,14 +192,21 @@ int32_t no_os_uart_write_nonblocking(struct no_os_uart_desc *desc,
 	return 0;
 }
 
+void uart_rx_callback(void *context)
+{
+	struct no_os_uart_desc *d = context;
+	lf256fifo_write(d->rx_fifo, c);
+	max_uart_read_nonblocking(d, &c, 1);
+}
+
 /**
  * @brief Initialize the UART communication peripheral.
  * @param desc - The UART descriptor.
  * @param param - The structure that contains the UART parameters.
  * @return 0 in case of success, errno codes otherwise.
  */
-int32_t no_os_uart_init(struct no_os_uart_desc **desc,
-			struct no_os_uart_init_param *param)
+static int32_t max_uart_init(struct no_os_uart_desc **desc,
+			     struct no_os_uart_init_param *param)
 {
 	int32_t ret;
 	int32_t stop, size, flow, parity;
@@ -362,7 +362,7 @@ int32_t no_os_uart_init(struct no_os_uart_desc **desc,
 		if (ret)
 			goto error_nvic;
 
-		ret = no_os_uart_read_nonblocking(descriptor, &c, 1);
+		ret = max_uart_read_nonblocking(descriptor, &c, 1);
 		if (ret)
 			goto error_nvic;
 	}
@@ -379,11 +379,11 @@ error:
 }
 
 /**
- * @brief Free the resources allocated by no_os_uart_init().
+ * @brief Free the resources allocated by max_uart_init().
  * @param desc - The UART descriptor.
  * @return 0 in case of success, errno codes otherwise.
  */
-int32_t no_os_uart_remove(struct no_os_uart_desc *desc)
+static int32_t max_uart_remove(struct no_os_uart_desc *desc)
 {
 	if (!desc)
 		return -EINVAL;
@@ -399,7 +399,20 @@ int32_t no_os_uart_remove(struct no_os_uart_desc *desc)
  * @param desc - The UART descriptor.
  * @return -ENOSYS
  */
-uint32_t no_os_uart_get_errors(struct no_os_uart_desc *desc)
+static uint32_t max_uart_get_errors(struct no_os_uart_desc *desc)
 {
 	return -ENOSYS;
 }
+
+/**
+ * @brief Maxim platform specific UART platform ops structure
+ */
+const struct no_os_uart_platform_ops max_uart_ops = {
+	.init = &max_uart_init,
+	.read = &max_uart_read,
+	.write = &max_uart_write,
+	.read_nonblocking = &max_uart_read_nonblocking,
+	.write_nonblocking = &max_uart_write_nonblocking,
+	.get_errors = &max_uart_get_errors,
+	.remove = &max_uart_remove
+};

--- a/drivers/platform/maxim/max32660/maxim_uart.h
+++ b/drivers/platform/maxim/max32660/maxim_uart.h
@@ -43,6 +43,7 @@
 #include "uart.h"
 #include "no_os_irq.h"
 #include "max32660.h"
+#include "no_os_uart.h"
 
 /**
  * @brief UART flow control
@@ -67,5 +68,10 @@ struct max_uart_desc {
 	/** Controller that handles UART interrupts */
 	struct no_os_irq_ctrl_desc *nvic;
 };
+
+/**
+ * @brief Maxim specific UART platform ops structure
+ */
+extern const struct no_os_uart_platform_ops max_uart_ops;
 
 #endif

--- a/drivers/platform/maxim/max32665/maxim_uart.c
+++ b/drivers/platform/maxim/max32665/maxim_uart.c
@@ -47,7 +47,6 @@
 #include "maxim_uart.h"
 #include "mxc_sys.h"
 #include "mxc_errors.h"
-#include "no_os_uart.h"
 #include "no_os_irq.h"
 #include "no_os_util.h"
 #include "no_os_lf256fifo.h"
@@ -76,13 +75,6 @@ static void _discard_callback(mxc_uart_req_t *req, int result)
 
 }
 
-void uart_rx_callback(void *context)
-{
-	struct no_os_uart_desc *d = context;
-	lf256fifo_write(d->rx_fifo, c);
-	no_os_uart_read_nonblocking(d, &c, 1);
-}
-
 /**
  * @brief Read data from UART device. Blocking function.
  * @param desc - Instance of UART.
@@ -90,8 +82,8 @@ void uart_rx_callback(void *context)
  * @param bytes_number - Number of bytes to read.
  * @return positive number of received bytes in case of success, negative error code otherwise.
  */
-int32_t no_os_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
-			uint32_t bytes_number)
+static int32_t max_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
+			     uint32_t bytes_number)
 {
 	int32_t ret;
 	uint32_t i = 0;
@@ -123,8 +115,8 @@ int32_t no_os_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
  * @param bytes_number - Number of bytes to read.
  * @return 0 in case of success, errno codes otherwise.
  */
-int32_t no_os_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
-			 uint32_t bytes_number)
+static int32_t max_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
+			      uint32_t bytes_number)
 {
 	int32_t ret;
 
@@ -146,8 +138,9 @@ int32_t no_os_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
  * @param bytes_number - Number of bytes to read.
  * @return positive number of received bytes in case of success, negative error code otherwise.
  */
-int32_t no_os_uart_read_nonblocking(struct no_os_uart_desc *desc, uint8_t *data,
-				    uint32_t bytes_number)
+static int32_t max_uart_read_nonblocking(struct no_os_uart_desc *desc,
+		uint8_t *data,
+		uint32_t bytes_number)
 {
 	int32_t ret;
 	uint32_t id;
@@ -181,9 +174,9 @@ int32_t no_os_uart_read_nonblocking(struct no_os_uart_desc *desc, uint8_t *data,
  * @return 0 in case of success, errno codes otherwise.
  */
 
-int32_t no_os_uart_write_nonblocking(struct no_os_uart_desc *desc,
-				     const uint8_t *data,
-				     uint32_t bytes_number)
+static int32_t max_uart_write_nonblocking(struct no_os_uart_desc *desc,
+		const uint8_t *data,
+		uint32_t bytes_number)
 {
 	int32_t ret;
 	uint32_t id;
@@ -209,14 +202,21 @@ int32_t no_os_uart_write_nonblocking(struct no_os_uart_desc *desc,
 	return 0;
 }
 
+void uart_rx_callback(void *context)
+{
+	struct no_os_uart_desc *d = context;
+	lf256fifo_write(d->rx_fifo, c);
+	max_uart_read_nonblocking(d, &c, 1);
+}
+
 /**
  * @brief Initialize the UART communication peripheral.
  * @param desc - The UART descriptor.
  * @param param - The structure that contains the UART parameters.
  * @return 0 in case of success, errno codes otherwise.
  */
-int32_t no_os_uart_init(struct no_os_uart_desc **desc,
-			struct no_os_uart_init_param *param)
+static int32_t max_uart_init(struct no_os_uart_desc **desc,
+			     struct no_os_uart_init_param *param)
 {
 	int32_t ret;
 	int32_t stop, size, flow, parity;
@@ -372,7 +372,7 @@ int32_t no_os_uart_init(struct no_os_uart_desc **desc,
 		if (ret)
 			goto error_nvic;
 
-		ret = no_os_uart_read_nonblocking(descriptor, &c, 1);
+		ret = max_uart_read_nonblocking(descriptor, &c, 1);
 		if (ret)
 			goto error_nvic;
 	}
@@ -389,11 +389,11 @@ error:
 }
 
 /**
- * @brief Free the resources allocated by no_os_uart_init().
+ * @brief Free the resources allocated by max_uart_init().
  * @param desc - The UART descriptor.
  * @return 0 in case of success, errno codes otherwise.
  */
-int32_t no_os_uart_remove(struct no_os_uart_desc *desc)
+static int32_t max_uart_remove(struct no_os_uart_desc *desc)
 {
 	if (!desc)
 		return -EINVAL;
@@ -414,7 +414,20 @@ int32_t no_os_uart_remove(struct no_os_uart_desc *desc)
  * @param desc - The UART descriptor.
  * @return -ENOSYS
  */
-uint32_t no_os_uart_get_errors(struct no_os_uart_desc *desc)
+static uint32_t max_uart_get_errors(struct no_os_uart_desc *desc)
 {
 	return -ENOSYS;
 }
+
+/**
+ * @brief Maxim platform specific UART platform ops structure
+ */
+const struct no_os_uart_platform_ops max_uart_ops = {
+	.init = &max_uart_init,
+	.read = &max_uart_read,
+	.write = &max_uart_write,
+	.read_nonblocking = &max_uart_read_nonblocking,
+	.write_nonblocking = &max_uart_write_nonblocking,
+	.get_errors = &max_uart_get_errors,
+	.remove = &max_uart_remove
+};

--- a/drivers/platform/maxim/max32665/maxim_uart.h
+++ b/drivers/platform/maxim/max32665/maxim_uart.h
@@ -43,6 +43,7 @@
 #include "uart.h"
 #include "no_os_irq.h"
 #include "max32665.h"
+#include "no_os_uart.h"
 
 /**
  * @brief UART flow control
@@ -67,5 +68,10 @@ struct max_uart_desc {
 	/** Controller that handles UART interrupts */
 	struct no_os_irq_ctrl_desc *nvic;
 };
+
+/**
+ * @brief Maxim specific UART platform ops structure
+ */
+extern const struct no_os_uart_platform_ops max_uart_ops;
 
 #endif

--- a/drivers/platform/maxim/max32670/maxim_uart.c
+++ b/drivers/platform/maxim/max32670/maxim_uart.c
@@ -47,7 +47,6 @@
 #include "maxim_uart.h"
 #include "mxc_sys.h"
 #include "mxc_errors.h"
-#include "no_os_uart.h"
 #include "no_os_irq.h"
 #include "no_os_util.h"
 #include "no_os_lf256fifo.h"
@@ -67,26 +66,14 @@ static uint8_t c;
 /******************************************************************************/
 
 /**
- * @brief UART receive interrupt callback function
- * @param context - UART context
- * @return none
- */
-void uart_rx_callback(void *context)
-{
-	struct no_os_uart_desc *d = context;
-	lf256fifo_write(d->rx_fifo, c);
-	no_os_uart_read_nonblocking(d, &c, 1);
-}
-
-/**
  * @brief Read data from UART device. Blocking function.
  * @param desc - Instance of UART.
  * @param data - Pointer to buffer containing data.
  * @param bytes_number - Number of bytes to read.
  * @return positive number of received bytes in case of success, negative error code otherwise.
  */
-int32_t no_os_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
-			uint32_t bytes_number)
+static int32_t max_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
+			     uint32_t bytes_number)
 {
 	int32_t ret;
 	uint32_t i = 0;
@@ -118,8 +105,8 @@ int32_t no_os_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
  * @param bytes_number - Number of bytes to read.
  * @return 0 in case of success, errno codes otherwise.
  */
-int32_t no_os_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
-			 uint32_t bytes_number)
+static int32_t max_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
+			      uint32_t bytes_number)
 {
 	int32_t ret;
 
@@ -141,8 +128,9 @@ int32_t no_os_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
  * @param bytes_number - Number of bytes to read.
  * @return positive number of received bytes in case of success, negative error code otherwise.
  */
-int32_t no_os_uart_read_nonblocking(struct no_os_uart_desc *desc, uint8_t *data,
-				    uint32_t bytes_number)
+static int32_t max_uart_read_nonblocking(struct no_os_uart_desc *desc,
+		uint8_t *data,
+		uint32_t bytes_number)
 {
 	int32_t ret;
 	uint32_t id;
@@ -176,9 +164,9 @@ int32_t no_os_uart_read_nonblocking(struct no_os_uart_desc *desc, uint8_t *data,
  * @return 0 in case of success, errno codes otherwise.
  */
 
-int32_t no_os_uart_write_nonblocking(struct no_os_uart_desc *desc,
-				     const uint8_t *data,
-				     uint32_t bytes_number)
+static int32_t max_uart_write_nonblocking(struct no_os_uart_desc *desc,
+		const uint8_t *data,
+		uint32_t bytes_number)
 {
 	int32_t ret;
 	uint32_t id;
@@ -205,13 +193,25 @@ int32_t no_os_uart_write_nonblocking(struct no_os_uart_desc *desc,
 }
 
 /**
+ * @brief UART receive interrupt callback function
+ * @param context - UART context
+ * @return none
+ */
+void uart_rx_callback(void *context)
+{
+	struct no_os_uart_desc *d = context;
+	lf256fifo_write(d->rx_fifo, c);
+	max_uart_read_nonblocking(d, &c, 1);
+}
+
+/**
  * @brief Initialize the UART communication peripheral.
  * @param desc - The UART descriptor.
  * @param param - The structure that contains the UART parameters.
  * @return 0 in case of success, errno codes otherwise.
  */
-int32_t no_os_uart_init(struct no_os_uart_desc **desc,
-			struct no_os_uart_init_param *param)
+static int32_t max_uart_init(struct no_os_uart_desc **desc,
+			     struct no_os_uart_init_param *param)
 {
 	int32_t ret;
 	int32_t stop, size, flow, parity;
@@ -358,7 +358,7 @@ int32_t no_os_uart_init(struct no_os_uart_desc **desc,
 		if (ret)
 			goto error_nvic;
 
-		ret = no_os_uart_read_nonblocking(descriptor, &c, 1);
+		ret = max_uart_read_nonblocking(descriptor, &c, 1);
 		if (ret)
 			goto error_nvic;
 	}
@@ -375,11 +375,11 @@ error:
 }
 
 /**
- * @brief Free the resources allocated by no_os_uart_init().
+ * @brief Free the resources allocated by max_uart_init().
  * @param desc - The UART descriptor.
  * @return 0 in case of success, errno codes otherwise.
  */
-int32_t no_os_uart_remove(struct no_os_uart_desc *desc)
+static int32_t max_uart_remove(struct no_os_uart_desc *desc)
 {
 	if (!desc)
 		return -EINVAL;
@@ -395,7 +395,20 @@ int32_t no_os_uart_remove(struct no_os_uart_desc *desc)
  * @param desc - The UART descriptor.
  * @return -ENOSYS
  */
-uint32_t no_os_uart_get_errors(struct no_os_uart_desc *desc)
+static uint32_t max_uart_get_errors(struct no_os_uart_desc *desc)
 {
 	return -ENOSYS;
 }
+
+/**
+ * @brief Maxim platform specific UART platform ops structure
+ */
+const struct no_os_uart_platform_ops max_uart_ops = {
+	.init = &max_uart_init,
+	.read = &max_uart_read,
+	.write = &max_uart_write,
+	.read_nonblocking = &max_uart_read_nonblocking,
+	.write_nonblocking = &max_uart_write_nonblocking,
+	.get_errors = &max_uart_get_errors,
+	.remove = &max_uart_remove
+};

--- a/drivers/platform/maxim/max32670/maxim_uart.h
+++ b/drivers/platform/maxim/max32670/maxim_uart.h
@@ -43,6 +43,7 @@
 #include "uart.h"
 #include "no_os_irq.h"
 #include "max32670.h"
+#include "no_os_uart.h"
 
 /**
  * @brief UART flow control
@@ -66,5 +67,10 @@ struct max_uart_desc {
 	/** Controller that handles UART interrupts */
 	struct no_os_irq_ctrl_desc *nvic;
 };
+
+/**
+ * @brief Maxim specific UART platform ops structure
+ */
+extern const struct no_os_uart_platform_ops max_uart_ops;
 
 #endif

--- a/drivers/platform/maxim/max78000/maxim_uart.c
+++ b/drivers/platform/maxim/max78000/maxim_uart.c
@@ -47,7 +47,6 @@
 #include "maxim_uart.h"
 #include "mxc_sys.h"
 #include "mxc_errors.h"
-#include "no_os_uart.h"
 #include "no_os_irq.h"
 #include "no_os_util.h"
 #include "no_os_lf256fifo.h"
@@ -79,13 +78,6 @@ static void _discard_callback(mxc_uart_req_t *req, int result)
 
 }
 
-void uart_rx_callback(void *context)
-{
-	struct no_os_uart_desc *d = context;
-	lf256fifo_write(d->rx_fifo, c);
-	no_os_uart_read_nonblocking(d, &c, 1);
-}
-
 /**
  * @brief Read data from UART device. Blocking function.
  * @param desc - Instance of UART.
@@ -93,8 +85,8 @@ void uart_rx_callback(void *context)
  * @param bytes_number - Number of bytes to read.
  * @return positive number of received bytes in case of success, negative error code otherwise.
  */
-int32_t no_os_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
-			uint32_t bytes_number)
+static int32_t max_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
+			     uint32_t bytes_number)
 {
 	int32_t ret;
 	uint32_t i = 0;
@@ -126,8 +118,8 @@ int32_t no_os_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
  * @param bytes_number - Number of bytes to read.
  * @return 0 in case of success, errno codes otherwise.
  */
-int32_t no_os_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
-			 uint32_t bytes_number)
+static int32_t max_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
+			      uint32_t bytes_number)
 {
 	int32_t ret;
 
@@ -149,8 +141,9 @@ int32_t no_os_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
  * @param bytes_number - Number of bytes to read.
  * @return positive number of received bytes in case of success, negative error code otherwise.
  */
-int32_t no_os_uart_read_nonblocking(struct no_os_uart_desc *desc, uint8_t *data,
-				    uint32_t bytes_number)
+static int32_t max_uart_read_nonblocking(struct no_os_uart_desc *desc,
+		uint8_t *data,
+		uint32_t bytes_number)
 {
 	int32_t ret;
 	uint32_t id;
@@ -184,9 +177,9 @@ int32_t no_os_uart_read_nonblocking(struct no_os_uart_desc *desc, uint8_t *data,
  * @return 0 in case of success, errno codes otherwise.
  */
 
-int32_t no_os_uart_write_nonblocking(struct no_os_uart_desc *desc,
-				     const uint8_t *data,
-				     uint32_t bytes_number)
+static int32_t max_uart_write_nonblocking(struct no_os_uart_desc *desc,
+		const uint8_t *data,
+		uint32_t bytes_number)
 {
 	int32_t ret;
 	uint32_t id;
@@ -212,14 +205,21 @@ int32_t no_os_uart_write_nonblocking(struct no_os_uart_desc *desc,
 	return 0;
 }
 
+void uart_rx_callback(void *context)
+{
+	struct no_os_uart_desc *d = context;
+	lf256fifo_write(d->rx_fifo, c);
+	max_uart_read_nonblocking(d, &c, 1);
+}
+
 /**
  * @brief Initialize the UART communication peripheral.
  * @param desc - The UART descriptor.
  * @param param - The structure that contains the UART parameters.
  * @return 0 in case of success, errno codes otherwise.
  */
-int32_t no_os_uart_init(struct no_os_uart_desc **desc,
-			struct no_os_uart_init_param *param)
+static int32_t max_uart_init(struct no_os_uart_desc **desc,
+			     struct no_os_uart_init_param *param)
 {
 	int32_t ret;
 	int32_t stop, size, flow, parity;
@@ -375,7 +375,7 @@ int32_t no_os_uart_init(struct no_os_uart_desc **desc,
 		if (ret)
 			goto error_nvic;
 
-		ret = no_os_uart_read_nonblocking(descriptor, &c, 1);
+		ret = max_uart_read_nonblocking(descriptor, &c, 1);
 		if (ret)
 			goto error_nvic;
 	}
@@ -392,11 +392,11 @@ error:
 }
 
 /**
- * @brief Free the resources allocated by no_os_uart_init().
+ * @brief Free the resources allocated by max_uart_init().
  * @param desc - The UART descriptor.
  * @return 0 in case of success, errno codes otherwise.
  */
-int32_t no_os_uart_remove(struct no_os_uart_desc *desc)
+static int32_t max_uart_remove(struct no_os_uart_desc *desc)
 {
 	if (!desc)
 		return -EINVAL;
@@ -421,7 +421,20 @@ int32_t no_os_uart_remove(struct no_os_uart_desc *desc)
  * @param desc - The UART descriptor.
  * @return -ENOSYS
  */
-uint32_t no_os_uart_get_errors(struct no_os_uart_desc *desc)
+static uint32_t max_uart_get_errors(struct no_os_uart_desc *desc)
 {
 	return -ENOSYS;
 }
+
+/**
+ * @brief Maxim platform specific UART platform ops structure
+ */
+const struct no_os_uart_platform_ops max_uart_ops = {
+	.init = &max_uart_init,
+	.read = &max_uart_read,
+	.write = &max_uart_write,
+	.read_nonblocking = &max_uart_read_nonblocking,
+	.write_nonblocking = &max_uart_write_nonblocking,
+	.get_errors = &max_uart_get_errors,
+	.remove = &max_uart_remove
+};

--- a/drivers/platform/maxim/max78000/maxim_uart.h
+++ b/drivers/platform/maxim/max78000/maxim_uart.h
@@ -43,6 +43,7 @@
 #include "uart.h"
 #include "no_os_irq.h"
 #include "max78000.h"
+#include "no_os_uart.h"
 
 /**
  * @brief UART flow control
@@ -67,5 +68,10 @@ struct max_uart_desc {
 	/** Controller that handles UART interrupts */
 	struct no_os_irq_ctrl_desc *nvic;
 };
+
+/**
+ * @brief Maxim specific UART platform ops structure
+ */
+extern const struct no_os_uart_platform_ops max_uart_ops;
 
 #endif

--- a/drivers/platform/mbed/mbed_uart.cpp
+++ b/drivers/platform/mbed/mbed_uart.cpp
@@ -174,8 +174,8 @@ bool platform_usbcdc::data_transmited(void)
  * @param bytes_number[in] - Number of bytes to read.
  * @return 0 in case of success, negative error code otherwise.
  */
-int32_t no_os_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
-			uint32_t bytes_number)
+static int32_t mbed_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
+			      uint32_t bytes_number)
 {
 	mbed::BufferedSerial *uart;	// pointer to BufferedSerial/UART instance
 	platform_usbcdc *usb_cdc_dev;	// Pointer to usb cdc device class instance
@@ -214,8 +214,9 @@ int32_t no_os_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
  * @param bytes_number[in] - Number of bytes to read.
  * @return 0 in case of success, negative error code otherwise.
  */
-int32_t no_os_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
-			 uint32_t bytes_number)
+static int32_t mbed_uart_write(struct no_os_uart_desc *desc,
+			       const uint8_t *data,
+			       uint32_t bytes_number)
 {
 	mbed::BufferedSerial *uart;	// pointer to BufferedSerial/UART instance
 	platform_usbcdc *usb_cdc_dev;	// Pointer to usb cdc device class instance
@@ -269,9 +270,9 @@ int32_t no_os_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
  * @return 0 in case of success, negative error code otherwise.
  * @note Currently implemented only for UART and not for USBSerial (VCOM)
  */
-int32_t no_os_uart_read_nonblocking(struct no_os_uart_desc *desc,
-				    uint8_t *data,
-				    uint32_t bytes_number)
+static int32_t mbed_uart_read_nonblocking(struct no_os_uart_desc *desc,
+		uint8_t *data,
+		uint32_t bytes_number)
 {
 	mbed::BufferedSerial *uart;	// pointer to BufferedSerial/UART instance
 
@@ -299,9 +300,9 @@ int32_t no_os_uart_read_nonblocking(struct no_os_uart_desc *desc,
  * @return 0 in case of success, negative error code otherwise.
  * @note Currently implemented only for UART and not for USBSerial (VCOM)
  */
-int32_t no_os_uart_write_nonblocking(struct no_os_uart_desc *desc,
-				     const uint8_t *data,
-				     uint32_t bytes_number)
+static int32_t mbed_uart_write_nonblocking(struct no_os_uart_desc *desc,
+		const uint8_t *data,
+		uint32_t bytes_number)
 {
 	mbed::BufferedSerial *uart;		// pointer to BufferedSerial/UART instance
 
@@ -396,8 +397,8 @@ static int32_t mbed_uart_set_format(struct no_os_uart_init_param *param,
  * @param param[in] - The structure that contains the UART parameters.
  * @return 0 in case of success, negative error code otherwise.
  */
-int32_t no_os_uart_init(struct no_os_uart_desc **desc,
-			struct no_os_uart_init_param *param)
+static int32_t mbed_uart_init(struct no_os_uart_desc **desc,
+			      struct no_os_uart_init_param *param)
 {
 	mbed::BufferedSerial *uart;	// Pointer to new BufferedSerial/UART instance
 	platform_usbcdc *usb_cdc_dev;	// Pointer to usb cdc device class instance
@@ -476,11 +477,11 @@ err_mbed_uart_desc:
 }
 
 /**
- * @brief Free the resources allocated by no_os_uart_init().
+ * @brief Free the resources allocated by mbed_uart_init().
  * @param desc[in] - The UART descriptor.
  * @return 0 in case of success, negative error code otherwise.
  */
-int32_t no_os_uart_remove(struct no_os_uart_desc *desc)
+static int32_t mbed_uart_remove(struct no_os_uart_desc *desc)
 {
 	if (!desc || !desc->extra)
 		return -EINVAL;
@@ -502,6 +503,18 @@ int32_t no_os_uart_remove(struct no_os_uart_desc *desc)
 
 	return 0;
 }
+
+/**
+ * @brief Mbed platform specific UART platform ops structure
+ */
+const struct no_os_uart_platform_ops mbed_uart_ops = {
+	.init = &mbed_uart_init,
+	.read = &mbed_uart_read,
+	.write = &mbed_uart_write,
+	.read_nonblocking = &mbed_uart_read_nonblocking,
+	.write_nonblocking = &mbed_uart_write_nonblocking,
+	.remove = &mbed_uart_remove
+};
 
 #ifdef __cplusplus  // Closing extern c
 }

--- a/drivers/platform/mbed/mbed_uart.h
+++ b/drivers/platform/mbed/mbed_uart.h
@@ -88,6 +88,11 @@ struct mbed_uart_desc {
 	bool is_console_stdio_port; /* Set the UART/USB port for console stdio operation */
 };
 
+/**
+* @brief Mbed platform specific UART platform ops structure
+*/
+extern const struct no_os_uart_platform_ops mbed_uart_ops;
+
 /******************************************************************************/
 /************************ Functions Declarations ******************************/
 /******************************************************************************/

--- a/drivers/platform/pico/pico_uart.c
+++ b/drivers/platform/pico/pico_uart.c
@@ -72,8 +72,8 @@ void uart_rx_callback(void *context)
  * @param param - The structure that contains the UART parameters.
  * @return 0 in case of success, error code otherwise.
  */
-int32_t no_os_uart_init(struct no_os_uart_desc **desc,
-			struct no_os_uart_init_param *param)
+static int32_t pico_uart_init(struct no_os_uart_desc **desc,
+			      struct no_os_uart_init_param *param)
 {
 	struct pico_uart_desc *pico_uart;
 	struct pico_uart_init_param *pico_uart_ip;
@@ -207,11 +207,11 @@ error:
 }
 
 /**
- * @brief Free the resources allocated by no_os_uart_init().
+ * @brief Free the resources allocated by pico_uart_init().
  * @param desc - The UART descriptor.
  * @return 0 in case of success, error code otherwise.
  */
-int32_t no_os_uart_remove(struct no_os_uart_desc *desc)
+static int32_t pico_uart_remove(struct no_os_uart_desc *desc)
 {
 	struct pico_uart_desc *pico_uart;
 
@@ -243,8 +243,9 @@ int32_t no_os_uart_remove(struct no_os_uart_desc *desc)
  * @param bytes_number - Number of bytes to read.
  * @return 0 in case of success, error code otherwise.
  */
-int32_t no_os_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
-			 uint32_t bytes_number)
+static int32_t pico_uart_write(struct no_os_uart_desc *desc,
+			       const uint8_t *data,
+			       uint32_t bytes_number)
 {
 	struct pico_uart_desc *pico_uart;
 
@@ -268,8 +269,8 @@ int32_t no_os_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
  * @param bytes_number - Number of bytes to read.
  * @return positive number of received bytes in case of success, error code otherwise.
  */
-int32_t no_os_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
-			uint32_t bytes_number)
+static int32_t pico_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
+			      uint32_t bytes_number)
 {
 	struct pico_uart_desc *pico_uart;
 	int ret;
@@ -296,3 +297,13 @@ int32_t no_os_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
 
 	return bytes_number;
 }
+
+/**
+ * @brief pico platform specific UART platform ops structure
+ */
+const struct no_os_uart_platform_ops pico_uart_ops = {
+	.init = &pico_uart_init,
+	.read = &pico_uart_read,
+	.write = &pico_uart_write,
+	.remove = &pico_uart_remove
+};

--- a/drivers/platform/pico/pico_uart.h
+++ b/drivers/platform/pico/pico_uart.h
@@ -100,4 +100,9 @@ struct pico_uart_init_param {
 	enum uart_rx_gp uart_rx_pin;
 };
 
+/**
+ * @brief pico specific UART platform ops structure
+ */
+extern const struct no_os_uart_platform_ops pico_uart_ops;
+
 #endif

--- a/drivers/platform/stm32/stm32_uart.c
+++ b/drivers/platform/stm32/stm32_uart.c
@@ -60,8 +60,8 @@ void uart_rx_callback(void *context)
  * @param param - The structure that contains the UART parameters.
  * @return 0 in case of success, error code otherwise.
  */
-int32_t no_os_uart_init(struct no_os_uart_desc **desc,
-			struct no_os_uart_init_param *param)
+static int32_t stm32_uart_init(struct no_os_uart_desc **desc,
+			       struct no_os_uart_init_param *param)
 {
 	struct stm32_uart_init_param *suip;
 	struct stm32_uart_desc *sud;
@@ -179,11 +179,11 @@ error:
 }
 
 /**
- * @brief Free the resources allocated by no_os_uart_init().
+ * @brief Free the resources allocated by stm32_uart_init().
  * @param desc - The UART descriptor.
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_uart_remove(struct no_os_uart_desc *desc)
+static int32_t stm32_uart_remove(struct no_os_uart_desc *desc)
 {
 	struct stm32_uart_desc *sud;
 
@@ -212,8 +212,9 @@ int32_t no_os_uart_remove(struct no_os_uart_desc *desc)
  * @param bytes_number - Number of bytes to read.
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
-			 uint32_t bytes_number)
+static int32_t stm32_uart_write(struct no_os_uart_desc *desc,
+				const uint8_t *data,
+				uint32_t bytes_number)
 {
 	struct stm32_uart_desc *sud;
 	int32_t ret;
@@ -249,8 +250,8 @@ int32_t no_os_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
  * @param bytes_number - Number of bytes to read.
  * @return positive number of received bytes in case of success, negative error code otherwise.
  */
-int32_t no_os_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
-			uint32_t bytes_number)
+static int32_t stm32_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
+			       uint32_t bytes_number)
 {
 	struct stm32_uart_desc *sud;
 	uint32_t i = 0;
@@ -290,3 +291,13 @@ int32_t no_os_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
 
 	return bytes_number;
 }
+
+/**
+ * @brief STM32 platform specific UART platform ops structure
+ */
+const struct no_os_uart_platform_ops stm32_uart_ops = {
+	.init = &stm32_uart_init,
+	.read = &stm32_uart_read,
+	.write = &stm32_uart_write,
+	.remove = &stm32_uart_remove
+};

--- a/drivers/platform/stm32/stm32_uart.h
+++ b/drivers/platform/stm32/stm32_uart.h
@@ -71,4 +71,9 @@ struct stm32_uart_desc {
 	struct no_os_callback_desc rx_callback;
 };
 
+/**
+ * @brief STM32 specific UART platform ops structure
+ */
+extern const struct no_os_uart_platform_ops stm32_uart_ops;
+
 #endif

--- a/drivers/platform/xilinx/xilinx_uart.c
+++ b/drivers/platform/xilinx/xilinx_uart.c
@@ -107,7 +107,7 @@ static int32_t uart_fifo_insert(struct no_os_uart_desc *desc)
  * @param data - read value.
  * @return 0 in case of success, -1 otherwise.
  */
-static int32_t no_os_uart_read_byte(struct no_os_uart_desc *desc, uint8_t *data)
+static int32_t xil_uart_read_byte(struct no_os_uart_desc *desc, uint8_t *data)
 {
 	struct xil_uart_desc *xil_uart_desc = desc->extra;
 #ifdef XUARTLITE_H
@@ -157,12 +157,12 @@ static int32_t no_os_uart_read_byte(struct no_os_uart_desc *desc, uint8_t *data)
  * @param bytes_number - Number of bytes to read.
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
-			uint32_t bytes_number)
+static int32_t xil_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
+			     uint32_t bytes_number)
 {
 	int ret;
 	for (uint32_t i = 0; i < bytes_number; i++) {
-		ret = no_os_uart_read_byte(desc, &data[i]);
+		ret = xil_uart_read_byte(desc, &data[i]);
 		if (ret < 0)
 			return ret;
 	}
@@ -177,8 +177,8 @@ int32_t no_os_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
  * @param bytes_number - Number of bytes to read.
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
-			 uint32_t bytes_number)
+static int32_t xil_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
+			      uint32_t bytes_number)
 {
 	struct xil_uart_desc *xil_uart_desc = desc->extra;
 #ifdef XUARTLITE_H
@@ -330,8 +330,8 @@ static int32_t uart_irq_init(struct no_os_uart_desc *descriptor)
  * @param param - The structure that contains the UART parameters.
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_uart_init(struct no_os_uart_desc **desc,
-			struct no_os_uart_init_param *param)
+static int32_t xil_uart_init(struct no_os_uart_desc **desc,
+			     struct no_os_uart_init_param *param)
 {
 	struct no_os_uart_desc *descriptor;
 	struct xil_uart_init_param *xil_uart_init_param;
@@ -446,11 +446,11 @@ error_free_descriptor:
 }
 
 /**
- * @brief Free the resources allocated by no_os_uart_init().
+ * @brief Free the resources allocated by xil_uart_init().
  * @param desc - The UART descriptor.
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_uart_remove(struct no_os_uart_desc *desc)
+static int32_t xil_uart_remove(struct no_os_uart_desc *desc)
 {
 	struct xil_uart_desc *xil_uart_desc = desc->extra;
 	free(xil_uart_desc->instance);
@@ -465,7 +465,7 @@ int32_t no_os_uart_remove(struct no_os_uart_desc *desc)
  * @param desc - The UART descriptor.
  * @return number of errors.
  */
-uint32_t no_os_uart_get_errors(struct no_os_uart_desc *desc)
+static uint32_t xil_uart_get_errors(struct no_os_uart_desc *desc)
 {
 	struct xil_uart_desc *xil_uart_desc = desc->extra;
 	uint32_t total_error_count = xil_uart_desc->total_error_count;
@@ -474,8 +474,21 @@ uint32_t no_os_uart_get_errors(struct no_os_uart_desc *desc)
 	return total_error_count;
 }
 
-int32_t no_os_uart_read_nonblocking(struct no_os_uart_desc *desc, uint8_t *data,
-				    uint32_t bytes_number)
+static int32_t xil_uart_read_nonblocking(struct no_os_uart_desc *desc,
+		uint8_t *data,
+		uint32_t bytes_number)
 {
 	return -EINVAL;
 }
+
+/**
+ * @brief Xilinx platform specific UART platform ops structure
+ */
+const struct no_os_uart_platform_ops xil_uart_ops = {
+	.init = &xil_uart_init,
+	.read = &xil_uart_read,
+	.write = &xil_uart_write,
+	.read_nonblocking = &xil_uart_read_nonblocking,
+	.get_errors = &xil_uart_get_errors,
+	.remove = &xil_uart_remove
+};

--- a/drivers/platform/xilinx/xilinx_uart.h
+++ b/drivers/platform/xilinx/xilinx_uart.h
@@ -104,4 +104,9 @@ struct xil_uart_desc {
 	void				*instance;
 };
 
+/**
+ * @brief Xilinx platform specific UART platform ops structure
+ */
+extern const struct no_os_uart_platform_ops xil_uart_ops;
+
 #endif

--- a/iio/iio_app/iio_app.c
+++ b/iio/iio_app/iio_app.c
@@ -93,6 +93,22 @@
 #include "no_os_error.h"
 #endif
 
+#ifdef ADUCM_PLATFORM
+#define UART_OPS &aducm_uart_ops
+#elif LINUX_PLATFORM
+#define UART_OPS &linux_uart_ops
+#elif defined MAXIM_PLATFORM
+#define UART_OPS &max_uart_ops
+#elif defined PICO_PLATFORM
+#define UART_OPS &pico_uart_ops
+#elif defined STM32_PLATFORM
+#define UART_OPS &stm32_uart_ops
+#elif defined XILINX_PLATFORM
+#define UART_OPS &xil_uart_ops
+#else
+#error "UART_OPS not defined"
+#endif
+
 // The default baudrate iio_app will use to print messages to console.
 #define UART_BAUDRATE_DEFAULT	115200
 
@@ -260,6 +276,7 @@ static int32_t uart_setup(struct no_os_uart_desc **uart_desc,
 		.size = NO_OS_UART_CS_8,
 		.parity = NO_OS_UART_PAR_NO,
 		.stop = NO_OS_UART_STOP_1_BIT,
+		.platform_ops = UART_OPS,
 #ifndef ADUCM_PLATFORM
 		.extra = &platform_uart_init_par
 #endif

--- a/include/no_os_uart.h
+++ b/include/no_os_uart.h
@@ -97,6 +97,13 @@ enum no_os_uart_stop {
 };
 
 /**
+ * @struct no_os_uart_platform_ops
+ * @brief Structure holding UART function pointers that point to the platform
+ * specific function
+ */
+struct no_os_uart_platform_ops ;
+
+/**
  * @struct no_os_uart_init_param
  * @brief Structure holding the parameters for UART initialization
  */
@@ -115,6 +122,7 @@ struct no_os_uart_init_param {
 	enum no_os_uart_parity	parity;
 	/** UART number of stop bits */
 	enum no_os_uart_stop		stop;
+	const struct no_os_uart_platform_ops *platform_ops;
 	/** UART extra parameters (device specific) */
 	void		*extra;
 };
@@ -132,8 +140,32 @@ struct no_os_uart_desc {
 	struct lf256fifo *rx_fifo;
 	/** UART Baud Rate */
 	uint32_t 	baud_rate;
+	const struct no_os_uart_platform_ops *platform_ops;
 	/** UART extra parameters (device specific) */
 	void 		*extra;
+};
+
+/**
+ * @struct no_os_uart_platform_ops
+ * @brief Structure holding UART function pointers that point to the platform
+ * specific function
+ */
+struct no_os_uart_platform_ops {
+	/** UART initialization function pointer */
+	int32_t (*init)(struct no_os_uart_desc **, struct no_os_uart_init_param *);
+	/** UART read function pointer */
+	int32_t (*read)(struct no_os_uart_desc *, uint8_t *, uint32_t);
+	/** UART write function pointer */
+	int32_t (*write)(struct no_os_uart_desc *, const uint8_t *, uint32_t);
+	/** UART read non-blocking function pointer */
+	int32_t (*read_nonblocking)(struct no_os_uart_desc *, uint8_t *, uint32_t);
+	/** UART wrote non-blocking function pointer */
+	int32_t (*write_nonblocking)(struct no_os_uart_desc *, const uint8_t *,
+				     uint32_t);
+	/** UART remove function pointer */
+	int32_t (*remove)(struct no_os_uart_desc *);
+	/** UART get errors function pointer */
+	uint32_t (*get_errors)(struct no_os_uart_desc *);
 };
 
 /******************************************************************************/

--- a/projects/ad400x-fmcz/src.mk
+++ b/projects/ad400x-fmcz/src.mk
@@ -11,6 +11,7 @@
 
 SRCS += $(PROJECT)/src/ad400x_fmcz.c
 SRCS += $(DRIVERS)/api/no_os_spi.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(DRIVERS)/adc/ad400x/ad400x.c \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine.c \
@@ -33,4 +34,5 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_delay.h \
 	$(INCLUDE)/no_os_irq.h \
 	$(INCLUDE)/no_os_uart.h \
+	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_util.h

--- a/projects/ad413x/src.mk
+++ b/projects/ad413x/src.mk
@@ -46,6 +46,7 @@ SRCS += $(DRIVERS)/afe/ad413x/iio_ad413x.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.c \
 	$(NO-OS)/iio/iio_app/iio_app.c \
 	$(NO-OS)/util/no_os_fifo.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(NO-OS)/util/no_os_util.c
 INCS += $(DRIVERS)/afe/ad413x/iio_ad413x.h \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \

--- a/projects/ad463x_fmcz/src.mk
+++ b/projects/ad463x_fmcz/src.mk
@@ -13,6 +13,7 @@ SRCS := $(PROJECT)/src/ad463x_fmc.c
 SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/api/no_os_gpio.c \
 	$(DRIVERS)/api/no_os_irq.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(DRIVERS)/adc/ad463x/ad463x.c \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
 	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \

--- a/projects/ad469x_fmcz/src.mk
+++ b/projects/ad469x_fmcz/src.mk
@@ -30,6 +30,7 @@ SRCS += $(PLATFORM_DRIVERS)/$(PLATFORM)_uart.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c \
 	$(DRIVERS)/api/no_os_irq.c \
 	$(NO-OS)/util/no_os_fifo.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(NO-OS)/util/no_os_list.c						
 endif
 INCS += $(PROJECT)/src/parameters.h

--- a/projects/ad6676-ebz/src.mk
+++ b/projects/ad6676-ebz/src.mk
@@ -37,6 +37,7 @@ SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.c \
 	$(NO-OS)/util/no_os_lf256fifo.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(DRIVERS)/api/no_os_irq.c
 endif
 INCS +=	$(PROJECT)/src/app_config.h \

--- a/projects/ad7124-4sdz/src.mk
+++ b/projects/ad7124-4sdz/src.mk
@@ -11,6 +11,7 @@
 
 SRCS += $(PROJECT)/src/ad7124-4sdz.c
 SRCS += $(DRIVERS)/api/no_os_spi.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(DRIVERS)/adc/ad7124/ad7124.c \
 	$(DRIVERS)/adc/ad7124/ad7124_regs.c				
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
@@ -30,4 +31,5 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_delay.h \
 	$(INCLUDE)/no_os_irq.h \
 	$(INCLUDE)/no_os_uart.h \
+	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_util.h

--- a/projects/ad7124-8pmdz/src.mk
+++ b/projects/ad7124-8pmdz/src.mk
@@ -8,6 +8,7 @@ SRCS += $(NO-OS)/drivers/adc/ad7124/ad7124.c \
 	$(NO-OS)/drivers/adc/ad7124/iio_ad7124.c \
 	$(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/api/no_os_timer.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(DRIVERS)/api/no_os_irq.c
 
 # Add to INCS inlcude files to be build in the porject

--- a/projects/ad713x_fmcz/src.mk
+++ b/projects/ad713x_fmcz/src.mk
@@ -31,6 +31,7 @@ SRCS += $(PLATFORM_DRIVERS)/$(PLATFORM)_uart.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c \
 	$(DRIVERS)/api/no_os_irq.c \
 	$(NO-OS)/util/no_os_fifo.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(NO-OS)/util/no_os_list.c	
 endif
 INCS += $(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \

--- a/projects/ad74413r/src.mk
+++ b/projects/ad74413r/src.mk
@@ -28,6 +28,7 @@ SRCS += $(DRIVERS)/api/no_os_gpio.c \
 		$(NO-OS)/util/no_os_lf256fifo.c \
 		$(DRIVERS)/api/no_os_irq.c  \
 		$(DRIVERS)/api/no_os_spi.c  \
+		$(DRIVERS)/api/no_os_uart.c \
 		$(NO-OS)/util/no_os_list.c \
 		$(NO-OS)/util/no_os_crc8.c \
 		$(NO-OS)/util/no_os_util.c

--- a/projects/ad7746-ebz/src.mk
+++ b/projects/ad7746-ebz/src.mk
@@ -14,6 +14,7 @@ SRCS += $(NO-OS)/util/no_os_util.c \
 	$(DRIVERS)/api/no_os_i2c.c \
 	$(DRIVERS)/api/no_os_irq.c \
 	$(DRIVERS)/api/no_os_timer.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(PROJECT)/src/app/headless.c
 
 INCS +=	$(INCLUDE)/no_os_uart.h \

--- a/projects/ad7768-evb/src.mk
+++ b/projects/ad7768-evb/src.mk
@@ -66,5 +66,6 @@ SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(NO-OS)/util/no_os_list.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.c \
 	$(NO-OS)/util/no_os_lf256fifo.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c
 endif

--- a/projects/ad9081/src.mk
+++ b/projects/ad9081/src.mk
@@ -30,6 +30,7 @@ SRCS += $(PROJECT)/src/app.c \
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
 	$(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/api/no_os_gpio.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_delay.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \

--- a/projects/ad9083/src.mk
+++ b/projects/ad9083/src.mk
@@ -73,6 +73,7 @@ SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(NO-OS)/util/no_os_lf256fifo.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c \
 	$(DRIVERS)/api/no_os_irq.c \
+	$(DRIVERS)/api/no_os_uart.c
 
 INCS += $(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_irq.h \

--- a/projects/ad9172/src.mk
+++ b/projects/ad9172/src.mk
@@ -41,6 +41,7 @@ SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.c \
 	$(NO-OS)/util/no_os_lf256fifo.c \
 	$(PLATFORM_DRIVERS)/xilinx_irq.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(DRIVERS)/api/no_os_irq.c
 endif
 INCS += $(PROJECT)/src/parameters.h \

--- a/projects/ad9208/src.mk
+++ b/projects/ad9208/src.mk
@@ -23,6 +23,7 @@ SRC_DIRS += $(DRIVERS)/axi_core/iio_axi_adc \
 SRCS	+= $(PLATFORM_DRIVERS)/$(PLATFORM)_uart.c \
 		$(NO-OS)/util/no_os_lf256fifo.c \
 		$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c \
+		$(DRIVERS)/api/no_os_uart.c \
 		$(NO-OS)/util/no_os_list.c 
 INCS	+= $(INCLUDE)/no_os_uart.h \
 		$(INCLUDE)/no_os_lf256fifo.h \

--- a/projects/ad9265-fmc-125ebz/src.mk
+++ b/projects/ad9265-fmc-125ebz/src.mk
@@ -26,6 +26,7 @@ SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(NO-OS)/util/no_os_list.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.c \
 	$(NO-OS)/util/no_os_lf256fifo.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c
 endif
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \

--- a/projects/ad9361/src.mk
+++ b/projects/ad9361/src.mk
@@ -92,6 +92,8 @@ INCS += $(INCLUDE)/no_os_fifo.h \
 	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.h \
 	$(NO-OS)/iio/iio_app/iio_app.h \
 	$(INCLUDE)/no_os_circular_buffer.h
+
+SRCS += $(DRIVERS)/api/no_os_uart.c
 endif
 ifeq (xilinx,$(strip $(PLATFORM)))
 SRCS += $(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c \

--- a/projects/ad9371/src.mk
+++ b/projects/ad9371/src.mk
@@ -60,6 +60,7 @@ SRCS += $(PLATFORM_DRIVERS)/$(PLATFORM)_uart.c \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \
 	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.c \
 	$(NO-OS)/iio/iio_app/iio_app.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(DRIVERS)/api/no_os_irq.c
 endif
 INCS +=	$(PROJECT)/src/app/app_config.h \

--- a/projects/ad9434-fmc-500ebz/src.mk
+++ b/projects/ad9434-fmc-500ebz/src.mk
@@ -26,6 +26,7 @@ SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.c \
 	$(NO-OS)/util/no_os_lf256fifo.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(DRIVERS)/api/no_os_irq.c
 endif
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \

--- a/projects/ad9467/src.mk
+++ b/projects/ad9467/src.mk
@@ -32,6 +32,7 @@ SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(NO-OS)/util/no_os_list.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.c \
 	$(NO-OS)/util/no_os_lf256fifo.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c
 endif
 INCS +=	$(PROJECT)/src/app/app_config.h \

--- a/projects/ad9656_fmc/src.mk
+++ b/projects/ad9656_fmc/src.mk
@@ -34,6 +34,7 @@ SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(NO-OS)/util/no_os_list.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.c \
 	$(NO-OS)/util/no_os_lf256fifo.c \
+        $(DRIVERS)/api/no_os_uart.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c
 endif
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \

--- a/projects/ad9739a-fmc-ebz/src.mk
+++ b/projects/ad9739a-fmc-ebz/src.mk
@@ -27,6 +27,7 @@ SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(NO-OS)/util/no_os_list.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.c \
 	$(NO-OS)/util/no_os_lf256fifo.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c
 endif
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \

--- a/projects/ada4250_ardz/src.mk
+++ b/projects/ada4250_ardz/src.mk
@@ -12,6 +12,7 @@ SRCS += $(NO-OS)/util/no_os_util.c \
 	$(DRIVERS)/api/no_os_irq.c \
 	$(DRIVERS)/api/no_os_gpio.c \
 	$(DRIVERS)/api/no_os_timer.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(DRIVERS)/platform/$(PLATFORM)/$(PLATFORM)_spi.c \
 	$(DRIVERS)/platform/$(PLATFORM)/$(PLATFORM)_irq.c \
 	$(DRIVERS)/platform/$(PLATFORM)/$(PLATFORM)_gpio.c \

--- a/projects/adaq7980_sdz/src.mk
+++ b/projects/adaq7980_sdz/src.mk
@@ -12,6 +12,7 @@
 SRCS += $(PROJECT)/src/adaq7980_sdz.c
 SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/api/no_os_gpio.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(DRIVERS)/adc/adaq7980/adaq7980.c \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
 	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
@@ -41,4 +42,5 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_delay.h \
 	$(INCLUDE)/no_os_irq.h \
 	$(INCLUDE)/no_os_uart.h \
+	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_util.h

--- a/projects/adaq8092_fmc/src.mk
+++ b/projects/adaq8092_fmc/src.mk
@@ -27,6 +27,7 @@ SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(NO-OS)/util/no_os_list.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.c \
 	$(NO-OS)/util/no_os_lf256fifo.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c
 endif
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \

--- a/projects/adf4377_sdz/src.mk
+++ b/projects/adf4377_sdz/src.mk
@@ -25,6 +25,7 @@ SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.c \
 	$(NO-OS)/util/no_os_lf256fifo.c \
 	$(PLATFORM_DRIVERS)/irq.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(NO-OS)/iio/iio_app/iio_app.c \
 	$(DRIVERS)/frequency/adf4377/iio_adf4377.c
 endif

--- a/projects/adf5902_sdz/src.mk
+++ b/projects/adf5902_sdz/src.mk
@@ -25,6 +25,7 @@ SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(NO-OS)/util/no_os_lf256fifo.c \
 	$(PLATFORM_DRIVERS)/irq.c \
 	$(NO-OS)/iio/iio_app/iio_app.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(DRIVERS)/frequency/adf5902/iio_adf5902.c
 endif
 INCS +=	$(PROJECT)/src/app_config.h \

--- a/projects/adrv9001/src.mk
+++ b/projects/adrv9001/src.mk
@@ -64,6 +64,7 @@ SRCS += $(PLATFORM_DRIVERS)/$(PLATFORM)_uart.c \
 	$(NO-OS)/util/no_os_fifo.c \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \
 	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(DRIVERS)/api/no_os_irq.c
 INCS += $(INCLUDE)/no_os_uart.h \
 	$(INCLUDE)/no_os_lf256fifo.h \

--- a/projects/adrv9009/src.mk
+++ b/projects/adrv9009/src.mk
@@ -58,6 +58,7 @@ SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \
 	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.c \
 	$(DRIVERS)/api/no_os_irq.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.c \
 	$(NO-OS)/util/no_os_lf256fifo.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c

--- a/projects/adt7420-pmdz/src.mk
+++ b/projects/adt7420-pmdz/src.mk
@@ -28,6 +28,7 @@ SRCS += $(DRIVERS)/api/no_os_gpio.c \
 		$(NO-OS)/util/no_os_lf256fifo.c \
 		$(DRIVERS)/api/no_os_irq.c  \
 		$(DRIVERS)/api/no_os_spi.c  \
+		$(DRIVERS)/api/no_os_uart.c \
 		$(NO-OS)/util/no_os_list.c \
 		$(NO-OS)/util/no_os_util.c
 

--- a/projects/adxrs290-pmdz/src.mk
+++ b/projects/adxrs290-pmdz/src.mk
@@ -32,5 +32,6 @@ SRCS += $(DRIVERS)/api/no_os_gpio.c     \
         $(DRIVERS)/api/no_os_irq.c      \
          $(DRIVERS)/api/no_os_timer.c   \
         $(DRIVERS)/api/no_os_spi.c      \
+        $(DRIVERS)/api/no_os_uart.c     \
         $(NO-OS)/util/no_os_list.c      \
         $(NO-OS)/util/no_os_util.c

--- a/projects/cn0531/src.mk
+++ b/projects/cn0531/src.mk
@@ -13,6 +13,7 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/api/no_os_irq.c \
 	$(DRIVERS)/api/no_os_gpio.c \
 	$(DRIVERS)/api/no_os_timer.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(DRIVERS)/platform/$(PLATFORM)/$(PLATFORM)_spi.c
 INCS += $(INCLUDE)/no_os_spi.h \
 	$(DRIVERS)/platform/$(PLATFORM)/$(PLATFORM)_spi.h

--- a/projects/cn0552/src.mk
+++ b/projects/cn0552/src.mk
@@ -13,6 +13,7 @@ SRCS += $(NO-OS)/util/no_os_util.c \
 	$(DRIVERS)/api/no_os_irq.c \
 	$(DRIVERS)/api/no_os_i2c.c \
 	$(DRIVERS)/api/no_os_timer.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(PROJECT)/src/app/headless.c
 
 INCS +=	$(INCLUDE)/no_os_uart.h \

--- a/projects/cn0561/src.mk
+++ b/projects/cn0561/src.mk
@@ -30,6 +30,7 @@ SRC_DIRS += $(NO-OS)/iio/iio_app
 SRCS += $(PLATFORM_DRIVERS)/$(PLATFORM)_uart.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c \
 	$(DRIVERS)/api/no_os_irq.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(NO-OS)/util/no_os_fifo.c \
 	$(NO-OS)/util/no_os_list.c	
 endif

--- a/projects/cn0565/src.mk
+++ b/projects/cn0565/src.mk
@@ -19,6 +19,7 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/api/no_os_timer.c \
 	$(DRIVERS)/api/no_os_i2c.c \
 	$(DRIVERS)/api/no_os_irq.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(NO-OS)/util/no_os_lf256fifo.c \
 	$(NO-OS)/util/no_os_list.c \
 	$(NO-OS)/util/no_os_util.c \

--- a/projects/cn0565/src/app/main.c
+++ b/projects/cn0565/src/app/main.c
@@ -118,6 +118,11 @@ int main(void)
 #endif
 		.asynchronous_rx = true,
 		.irq_id = UART_IRQ_ID,
+#if defined(STM32_PLATFORM)
+		.platform_ops = &stm32_uart_ops,
+#elif defined(ADUCM_PLATFORM)
+		.platform_ops = &aducm_uart_ops,
+#endif
 	};
 
 	ret = no_os_uart_init(&uart, &uip);

--- a/projects/eval-adxl313z/src.mk
+++ b/projects/eval-adxl313z/src.mk
@@ -29,6 +29,7 @@ SRCS += $(DRIVERS)/api/no_os_gpio.c \
 		$(DRIVERS)/api/no_os_irq.c  \
 		$(DRIVERS)/api/no_os_spi.c  \
 		$(NO-OS)/util/no_os_list.c \
+		$(DRIVERS)/api/no_os_uart.c \
 		$(NO-OS)/util/no_os_util.c
 
 INCS += $(DRIVERS)/accel/adxl313/adxl313.h

--- a/projects/eval-adxl355-pmdz/src.mk
+++ b/projects/eval-adxl355-pmdz/src.mk
@@ -31,6 +31,7 @@ SRCS += $(DRIVERS)/api/no_os_gpio.c \
 		$(DRIVERS)/api/no_os_irq.c  \
 		$(DRIVERS)/api/no_os_spi.c  \
 		$(DRIVERS)/api/no_os_timer.c  \
+		$(DRIVERS)/api/no_os_uart.c \
 		$(NO-OS)/util/no_os_list.c \
 		$(NO-OS)/util/no_os_util.c
 

--- a/projects/eval-adxl367z/src/examples/examples_src.mk
+++ b/projects/eval-adxl367z/src/examples/examples_src.mk
@@ -16,6 +16,7 @@ SRC_DIRS += $(NO-OS)/iio/iio_app
 
 SRCS += $(DRIVERS)/accel/adxl367/iio_adxl367.c \
 	$(DRIVERS)/api/no_os_irq.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.c \
 	$(NO-OS)/util/no_os_fifo.c
 

--- a/projects/fmcadc2/src.mk
+++ b/projects/fmcadc2/src.mk
@@ -33,6 +33,7 @@ SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(NO-OS)/util/no_os_list.c \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \
 	$(DRIVERS)/api/no_os_irq.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.c \
 	$(NO-OS)/util/no_os_lf256fifo.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c

--- a/projects/fmcadc5/src.mk
+++ b/projects/fmcadc5/src.mk
@@ -34,6 +34,7 @@ SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(NO-OS)/util/no_os_list.c \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \
 	$(DRIVERS)/api/no_os_irq.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.c \
 	$(NO-OS)/util/no_os_lf256fifo.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c

--- a/projects/fmcdaq2/src.mk
+++ b/projects/fmcdaq2/src.mk
@@ -40,6 +40,7 @@ SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \
 	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.c \
 	$(DRIVERS)/api/no_os_irq.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.c \
 	$(NO-OS)/util/no_os_lf256fifo.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c

--- a/projects/fmcdaq3/src.mk
+++ b/projects/fmcdaq3/src.mk
@@ -40,6 +40,7 @@ SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(DRIVERS)/adc/ad9680/iio_ad9680.c \
 	$(DRIVERS)/dac/ad9152/iio_ad9152.c \
 	$(DRIVERS)/api/no_os_irq.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.c \
 	$(NO-OS)/util/no_os_lf256fifo.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c

--- a/projects/fmcjesdadc1/src.mk
+++ b/projects/fmcjesdadc1/src.mk
@@ -34,6 +34,7 @@ SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(NO-OS)/util/no_os_list.c \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \
 	$(DRIVERS)/api/no_os_irq.c \
+	$(DRIVERS)/api/no_os_uart.c \
 	$(NO-OS)/iio/iio_app/iio_app.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.c \
 	$(NO-OS)/util/no_os_lf256fifo.c \

--- a/projects/iio_adpd1080/src.mk
+++ b/projects/iio_adpd1080/src.mk
@@ -11,6 +11,7 @@ SRC_DIRS += $(INCLUDE)
 SRCS += $(DRIVERS)/api/no_os_gpio.c
 SRCS += $(DRIVERS)/api/no_os_irq.c
 SRCS +=	$(DRIVERS)/platform/$(PLATFORM)/$(PLATFORM)_irq.c
+SRCS += $(DRIVERS)/api/no_os_uart.c
 INCS += $(INCLUDE)/no_os_irq.h
 INCS += $(DRIVERS)/platform/$(PLATFORM)/aducm3029_irq.h
 

--- a/projects/iio_aducm3029/src.mk
+++ b/projects/iio_aducm3029/src.mk
@@ -8,6 +8,7 @@ SRC_DIRS += $(PROJECT)/src \
 		$(NO-OS)/util \
 		$(NO-OS)/include
 SRCS += $(NO-OS)/drivers/api/no_os_irq.c
+SRCS += $(NO-OS)/drivers/api/no_os_uart.c
 
 ifeq '$(TINYIIOD)' 'y'
 SRC_DIRS += $(NO-OS)/iio/iio_app

--- a/projects/iio_demo/src.mk
+++ b/projects/iio_demo/src.mk
@@ -12,7 +12,8 @@ INCS += $(PROJECT)/src/platform/platform_includes.h
 INCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.h
 SRCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.c 
 
-SRCS += $(NO-OS)/util/no_os_fifo.c      \
+SRCS += $(DRIVERS)/api/no_os_uart.c     \
+        $(NO-OS)/util/no_os_fifo.c      \
         $(NO-OS)/util/no_os_list.c      \
         $(NO-OS)/util/no_os_util.c
 

--- a/projects/max11205pmb1/src.mk
+++ b/projects/max11205pmb1/src.mk
@@ -32,5 +32,6 @@ SRCS += $(DRIVERS)/api/no_os_gpio.c     \
         $(DRIVERS)/api/no_os_irq.c      \
         $(DRIVERS)/api/no_os_timer.c    \
         $(DRIVERS)/api/no_os_spi.c      \
+        $(DRIVERS)/api/no_os_uart.c     \
         $(NO-OS)/util/no_os_list.c      \
         $(NO-OS)/util/no_os_util.c


### PR DESCRIPTION
Add UART platform ops for all platforms and adapt projects accordingly.

Signed-off-by: Ramona Bolboaca <ramona.bolboaca@analog.com>