### PR TITLE
network: tcp_socket: fix config rng

### DIFF
--- a/network/tcp_socket.c
+++ b/network/tcp_socket.c
@@ -234,7 +234,7 @@ static int32_t stcp_socket_init(struct secure_socket_desc **desc,
 	/* Config Random number generator */
 	mbedtls_ssl_conf_rng(&ldesc->conf,
 			     (int (*)(void *, unsigned char *, size_t))
-			     trng_fill_buffer,
+			     no_os_trng_fill_buffer,
 			     (void *)ldesc->trng);
 
 	/* Set the resulting protocol configuration */


### PR DESCRIPTION
Update the true random generator fill buffer function with the correct naming.

Fixes: 44cdc3e ("include:*.h Add "no_os_" prefix to /include files")
Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>