### PR TITLE
drivers: adc: ad713x: add ad4134 data format

### DIFF
--- a/drivers/adc/ad713x/ad713x.c
+++ b/drivers/adc/ad713x/ad713x.c
@@ -84,6 +84,15 @@ static const int ad713x_output_data_frame[3][9][2] = {
 		{ADC_16_BIT_DATA, CRC_8},
 		{INVALID}
 	},
+	{
+		{ADC_16_BIT_DATA, NO_CRC},
+		{ADC_16_BIT_DATA, CRC_6},
+		{ADC_24_BIT_DATA, NO_CRC},
+		{ADC_24_BIT_DATA, CRC_6},
+		{ADC_16_BIT_DATA, CRC_8},
+		{ADC_24_BIT_DATA, CRC_8},
+		{INVALID}
+	},
 };
 
 /******************************************************************************/


### PR DESCRIPTION
The output data frame for the ad4134 device was missing.

Fixes: 6eda224 ("drivers:adc:ad713x: update driver to work with new silicon")
Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>

Related issue: #1568 