### PR TITLE
projects: Add platform_ops entry to struct no_os_uart_init_param

### DIFF
--- a/projects/ad74413r/src/common/common_data.c
+++ b/projects/ad74413r/src/common/common_data.c
@@ -52,6 +52,7 @@ struct no_os_uart_init_param ad74413r_uart_ip = {
 	.size = NO_OS_UART_CS_8,
 	.parity = NO_OS_UART_PAR_NO,
 	.stop = NO_OS_UART_STOP_1_BIT,
+	.platform_ops = UART_OPS,
 	.extra = UART_EXTRA,
 };
 #endif

--- a/projects/ad74413r/src/platform/maxim/parameters.h
+++ b/projects/ad74413r/src/platform/maxim/parameters.h
@@ -59,6 +59,7 @@
 
 #define UART_DEVICE_ID  0
 #define UART_BAUDRATE   57600
+#define UART_OPS        &max_uart_ops
 #define UART_EXTRA      &ad74413r_uart_extra_ip
 
 #define SPI_DEVICE_ID   1

--- a/projects/ad74413r/src/platform/stm32/parameters.h
+++ b/projects/ad74413r/src/platform/stm32/parameters.h
@@ -65,6 +65,7 @@ extern UART_HandleTypeDef huart3;
 #define UART_DEVICE_ID  3
 #define UART_BAUDRATE   115200
 #define UART_EXTRA      &ad74413r_uart_extra_ip
+#define UART_OPS        &stm32_uart_ops
 
 #define SPI_DEVICE_ID   1
 #define SPI_BAUDRATE    1000000

--- a/projects/ad7746-ebz/src/app/headless.c
+++ b/projects/ad7746-ebz/src/app/headless.c
@@ -78,6 +78,7 @@ int main(void)
 		.size = NO_OS_UART_CS_8,
 		.parity = NO_OS_UART_PAR_NO,
 		.stop = NO_OS_UART_STOP_1_BIT,
+		.platform_ops = &aducm_uart_ops,
 	};
 #ifdef IIO_SUPPORT
 	struct ad7746_iio_dev *adciio = NULL;

--- a/projects/adt7420-pmdz/src/common/common_data.c
+++ b/projects/adt7420-pmdz/src/common/common_data.c
@@ -52,6 +52,7 @@ struct no_os_uart_init_param uip = {
 	.size = NO_OS_UART_CS_8,
 	.parity = NO_OS_UART_PAR_NO,
 	.stop = NO_OS_UART_STOP_1_BIT,
+	.platform_ops = UART_OPS,
 	.extra = &xuip,
 };
 #endif

--- a/projects/adt7420-pmdz/src/platform/maxim/parameters.h
+++ b/projects/adt7420-pmdz/src/platform/maxim/parameters.h
@@ -59,6 +59,7 @@
 #endif
 #define UART_DEVICE_ID  0
 #define UART_BAUDRATE   57600
+#define UART_OPS        &max_uart_ops
 
 #define I2C_DEVICE_ID    2
 #define I2C_OPS         &max_i2c_ops

--- a/projects/aducm3029_flash_demo/src/main.c
+++ b/projects/aducm3029_flash_demo/src/main.c
@@ -49,7 +49,7 @@
 #include "no_os_irq.h"
 #include "platform_init.h"
 #include "no_os_uart.h"
-#include "xilinx_uart.h"
+#include "aducm3029_uart.h"
 #include "uart_stdio.h"
 
 /***************************************************************************//**
@@ -77,6 +77,7 @@ int main(int argc, char *argv[])
 		.parity = NO_OS_UART_PAR_NO,
 		.size = NO_OS_UART_CS_8,
 		.stop = NO_OS_UART_STOP_1_BIT,
+		.platform_ops = &aducm_uart_ops,
 	};
 	struct no_os_irq_ctrl_desc *irq_dut;
 	int32_t platform_irq_init_par = 0;

--- a/projects/eval-adxl313z/src/common/common_data.c
+++ b/projects/eval-adxl313z/src/common/common_data.c
@@ -53,6 +53,7 @@ struct no_os_uart_init_param uip = {
 	.parity = NO_OS_UART_PAR_NO,
 	.stop = NO_OS_UART_STOP_1_BIT,
 	.extra = &xuip,
+	.platform_ops = UART_OPS,
 };
 #endif
 

--- a/projects/eval-adxl313z/src/platform/stm32/parameters.h
+++ b/projects/eval-adxl313z/src/platform/stm32/parameters.h
@@ -62,6 +62,7 @@ extern UART_HandleTypeDef huart2;
 #endif
 #define UART_DEVICE_ID      2
 #define UART_BAUDRATE  115200
+#define UART_OPS        &stm32_uart_ops
 
 #define SPI_DEVICE_ID    1
 #define SPI_CS          4

--- a/projects/eval-adxl355-pmdz/src/common/common_data.c
+++ b/projects/eval-adxl355-pmdz/src/common/common_data.c
@@ -53,6 +53,7 @@ struct no_os_uart_init_param adxl355_uart_ip = {
 	.parity = NO_OS_UART_PAR_NO,
 	.stop = NO_OS_UART_STOP_1_BIT,
 	.extra = UART_EXTRA,
+	.platform_ops = UART_OPS,
 };
 #endif
 

--- a/projects/eval-adxl355-pmdz/src/platform/maxim/parameters.h
+++ b/projects/eval-adxl355-pmdz/src/platform/maxim/parameters.h
@@ -61,6 +61,7 @@
 #define UART_DEVICE_ID  0
 #define UART_BAUDRATE   57600
 #define UART_EXTRA      &adxl355_uart_extra_ip
+#define UART_OPS        &max_uart_ops
 
 #if (TARGET_NUM == 78000)
 #define SPI_DEVICE_ID   1

--- a/projects/eval-adxl355-pmdz/src/platform/pico/parameters.h
+++ b/projects/eval-adxl355-pmdz/src/platform/pico/parameters.h
@@ -60,6 +60,7 @@
 #define UART_BAUDRATE   115200
 #define UART_IRQ_ID     20
 #define UART_EXTRA      &adxl355_uart_extra_ip
+#define UART_OPS        &pico_uart_ops
 
 #define UART_TX_PIN     UART0_TX_GP0
 #define UART_RX_PIN     UART0_RX_GP1

--- a/projects/eval-adxl355-pmdz/src/platform/stm32/parameters.h
+++ b/projects/eval-adxl355-pmdz/src/platform/stm32/parameters.h
@@ -65,6 +65,7 @@ extern UART_HandleTypeDef huart5;
 #define UART_DEVICE_ID  5
 #define UART_BAUDRATE   115200
 #define UART_EXTRA      &adxl355_uart_extra_ip
+#define UART_OPS        &stm32_uart_ops
 
 #define SPI_DEVICE_ID   1
 #define SPI_BAUDRATE    4000000

--- a/projects/iio_aducm3029/src/main.c
+++ b/projects/iio_aducm3029/src/main.c
@@ -72,6 +72,7 @@ static int32_t initialize_uart(struct no_os_uart_desc **uart)
 		.size =  NO_OS_UART_CS_8,
 		.device_id = UART_DEVICE_ID,
 		.baud_rate = UART_BAUDRATE,
+		.platform_ops = &aducm_uart_ops,
 	};
 
 	return no_os_uart_init(uart, &uart_init_par);

--- a/projects/max11205pmb1/src/common/common_data.c
+++ b/projects/max11205pmb1/src/common/common_data.c
@@ -52,6 +52,7 @@ struct no_os_uart_init_param max11205_uart_ip = {
 	.size = NO_OS_UART_CS_8,
 	.parity = NO_OS_UART_PAR_NO,
 	.stop = NO_OS_UART_STOP_1_BIT,
+	.platform_ops = UART_OPS,
 	.extra = UART_EXTRA,
 };
 #endif

--- a/projects/max11205pmb1/src/platform/maxim/parameters.h
+++ b/projects/max11205pmb1/src/platform/maxim/parameters.h
@@ -53,6 +53,7 @@
 /********************** Macros and Constants Definitions **********************/
 /******************************************************************************/
 #ifdef BASIC_EXAMPLE
+#define UART_OPS                &max_uart_ops
 #define UART_EXTRA              &max11205_uart_extra_ip
 extern struct max_uart_init_param max11205_uart_extra_ip;
 #endif


### PR DESCRIPTION
Add missing platform_ops entry to struct no_os_uart_init_param.

Fixes: f6f2df33 ("drivers:platform: Add UART platform ops")
Signed-off-by: Ramona Bolboaca <ramona.bolboaca@analog.com>