### PR TITLE
Adt7420 driver corrections

### DIFF
--- a/drivers/temperature/adt7420/adt7420.c
+++ b/drivers/temperature/adt7420/adt7420.c
@@ -380,10 +380,7 @@ float adt7420_get_temperature(struct adt7420_dev *dev)
 	if (adt7420_is_spi(dev))
 		adt7420_reg_read(dev, ADT7320_REG_TEMP, &temp);
 	else {
-		uint8_t temp_msb = 0, temp_lsb = 0;
-		adt7420_reg_read(dev, ADT7420_REG_TEMP_MSB, &temp_msb);
-		adt7420_reg_read(dev, ADT7420_REG_TEMP_LSB, &temp_lsb);
-		temp = (temp_msb << 8) | temp_lsb;
+		adt7420_reg_read(dev, ADT7420_REG_TEMP_MSB, &temp);
 	}
 
 	if (dev->resolution_setting) {

--- a/drivers/temperature/adt7420/adt7420.h
+++ b/drivers/temperature/adt7420/adt7420.h
@@ -74,15 +74,15 @@
 #define ADT7320_READ_CMD		0b01000000 // SPI read command
 
 /* ADT7420 (I2C) registers */
-#define ADT7420_REG_TEMP_MSB		0x00 // Temperature value MSB
+#define ADT7420_REG_TEMP_MSB		(ADT7320_L16 |0x00) // Temperature value MSB
 #define ADT7420_REG_TEMP_LSB		0x01 // Temperature value LSB
 #define ADT7420_REG_STATUS		0x02 // Status
 #define ADT7420_REG_CONFIG		0x03 // Configuration
-#define ADT7420_REG_T_HIGH_MSB		0x04 // Temperature HIGH setpoint MSB
+#define ADT7420_REG_T_HIGH_MSB		(ADT7320_L16 |0x04 )// Temperature HIGH setpoint MSB
 #define ADT7420_REG_T_HIGH_LSB		0x05 // Temperature HIGH setpoint LSB
-#define ADT7420_REG_T_LOW_MSB		0x06 // Temperature LOW setpoint MSB
+#define ADT7420_REG_T_LOW_MSB		(ADT7320_L16 |0x06) // Temperature LOW setpoint MSB
 #define ADT7420_REG_T_LOW_LSB		0x07 // Temperature LOW setpoint LSB
-#define ADT7420_REG_T_CRIT_MSB		0x08 // Temperature CRIT setpoint MSB
+#define ADT7420_REG_T_CRIT_MSB		(ADT7320_L16 |0x08) // Temperature CRIT setpoint MSB
 #define ADT7420_REG_T_CRIT_LSB		0x09 // Temperature CRIT setpoint LSB
 #define ADT7420_REG_HIST		0x0A // Temperature HYST setpoint
 #define ADT7420_REG_ID			0x0B // ID
@@ -175,15 +175,23 @@ extern const struct adt7420_chip_info chip_info[];
 
 /*! Reads the value of a register */
 int adt7420_reg_read(struct adt7420_dev *dev,
-		     uint8_t register_address, uint16_t *data);
+		     uint16_t register_address, uint16_t *data);
 
 /* Read-modify-write operation*/
 int adt7420_reg_update_bits(struct adt7420_dev *dev,
-			    uint8_t register_address, uint8_t mask, uint8_t value);
+			    uint16_t register_address, uint8_t mask, uint8_t value);
+
+/* Write to SPI register */
+int adt7420_spi_reg_write(struct adt7420_dev *dev, uint16_t register_address,
+			  uint32_t data);
+
+/* Write to I2C register */
+int adt7420_i2c_reg_write(struct adt7420_dev *dev, uint16_t register_address,
+			  uint32_t data);
 
 /*Sets register value*/
 int adt7420_reg_write(struct adt7420_dev *dev,
-		      uint8_t register_address,
+		      uint16_t register_address,
 		      uint32_t data);
 
 /*! Initializes the comm. peripheral and checks if the device is present. */
@@ -209,11 +217,11 @@ float adt7420_get_temperature(struct adt7420_dev *dev);
 
 /*! Read the register value for I2C interface devices */
 int adt7420_i2c_reg_read(struct adt7420_dev *dev,
-			 uint8_t register_address, uint8_t *data);
+			 uint16_t register_address, uint16_t *data);
 
 /*! Read the register value for SPI interface devices */
 int adt7420_spi_reg_read(struct adt7420_dev *dev,
-			 uint8_t register_address, uint16_t *data);
+			 uint16_t register_address, uint16_t *data);
 
 /*! Check if the interface of the selected device is SPI */
 bool adt7420_is_spi(struct adt7420_dev *dev);


### PR DESCRIPTION
1) Changes with SPI/I2C write function structuring
2) Changes with num_bytes calculation in SPI register read function
3) Updates with temperature register read function
4) Updated all register addresses for SPI to uint16_t as the 9th bit is set to represent that it is a 16 bit register in certain cases.
5) Added switch cases for I2C for determining the register size 