### PR TITLE
ad9361:src:main Set swap ports to 0 for ad9364

### DIFF
--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -558,7 +558,8 @@ int main(void)
 #endif
 
 #ifdef ADI_RF_SOM_CMOS
-	default_init_param.swap_ports_enable = 1;
+	if (AD9361_DEVICE)
+		default_init_param.swap_ports_enable = 1;
 	default_init_param.lvds_mode_enable = 0;
 	default_init_param.lvds_rx_onchip_termination_enable = 0;
 	default_init_param.full_port_enable = 1;

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -102,7 +102,7 @@ static uint8_t out_buff[MAX_SIZE_BASE_ADDR];
 uint32_t dac_buffer[DAC_BUFFER_SAMPLES] __attribute__ ((aligned));
 #endif
 uint16_t adc_buffer[ADC_BUFFER_SAMPLES * ADC_CHANNELS] __attribute__ ((
-	aligned));
+			aligned));
 
 #define AD9361_ADC_DAC_BYTES_PER_SAMPLE 2
 


### PR DESCRIPTION
Disable swap-ports-enable for CMOS Mode in case ofad9364 device.

Signed-off-by: George Mois <george.mois@analog.com>