### PR TITLE
no_os_uart_stdio common API across platforms

### DIFF
--- a/drivers/api/no_os_uart.c
+++ b/drivers/api/no_os_uart.c
@@ -180,3 +180,9 @@ int32_t no_os_uart_write_nonblocking(struct no_os_uart_desc *desc,
 	return desc->platform_ops->write_nonblocking(desc, data, bytes_number);
 }
 
+
+void __attribute__((weak)) no_os_uart_stdio(struct no_os_uart_desc *desc)
+{
+	/* This can optionally be implemented under drivers/platform.
+	 * It does nothing if unimplemented. */
+}

--- a/drivers/platform/aducm3029/aducm3029_uart_stdio.c
+++ b/drivers/platform/aducm3029/aducm3029_uart_stdio.c
@@ -49,7 +49,7 @@ static struct no_os_uart_desc *g_uart;
 #define STDOUT_FILENO 1
 #define STDERR_FILENO 2
 
-void init_uart_stdio(struct no_os_uart_desc *desc)
+void no_os_uart_stdio(struct no_os_uart_desc *desc)
 {
 	g_uart = desc;
 }

--- a/drivers/platform/aducm3029/aducm3029_uart_stdio.h
+++ b/drivers/platform/aducm3029/aducm3029_uart_stdio.h
@@ -41,6 +41,6 @@
 
 #include "no_os_uart.h"
 
-void init_uart_stdio(struct no_os_uart_desc *desc);
+void no_os_uart_stdio(struct no_os_uart_desc *desc);
 
 #endif //_ADUCM3029_UART_STDIO_H_

--- a/drivers/platform/maxim/max32650/maxim_stdio.c
+++ b/drivers/platform/maxim/max32650/maxim_stdio.c
@@ -58,7 +58,7 @@
 
 static struct no_os_uart_desc *guart = NULL;
 
-void maxim_uart_stdio(struct no_os_uart_desc *desc)
+void no_os_uart_stdio(struct no_os_uart_desc *desc)
 {
 	if (!desc)
 		return;

--- a/drivers/platform/maxim/max32650/maxim_stdio.h
+++ b/drivers/platform/maxim/max32650/maxim_stdio.h
@@ -42,7 +42,7 @@
 #include <sys/stat.h>
 #include "no_os_uart.h"
 
-void maxim_uart_stdio(struct no_os_uart_desc *);
+void no_os_uart_stdio(struct no_os_uart_desc *);
 int _isatty(int);
 int _write(int, char *, int);
 int _close(int);

--- a/drivers/platform/maxim/max32655/maxim_stdio.c
+++ b/drivers/platform/maxim/max32655/maxim_stdio.c
@@ -58,7 +58,7 @@
 
 static struct no_os_uart_desc *guart = NULL;
 
-void maxim_uart_stdio(struct no_os_uart_desc *desc)
+void no_os_uart_stdio(struct no_os_uart_desc *desc)
 {
 	if (!desc)
 		return;

--- a/drivers/platform/maxim/max32655/maxim_stdio.h
+++ b/drivers/platform/maxim/max32655/maxim_stdio.h
@@ -42,7 +42,7 @@
 #include <sys/stat.h>
 #include "no_os_uart.h"
 
-void maxim_uart_stdio(struct no_os_uart_desc *);
+void no_os_uart_stdio(struct no_os_uart_desc *);
 int _isatty(int);
 int _write(int, char *, int);
 int _close(int);

--- a/drivers/platform/maxim/max32660/maxim_stdio.c
+++ b/drivers/platform/maxim/max32660/maxim_stdio.c
@@ -58,7 +58,7 @@
 
 static struct no_os_uart_desc *guart = NULL;
 
-void maxim_uart_stdio(struct no_os_uart_desc *desc)
+void no_os_uart_stdio(struct no_os_uart_desc *desc)
 {
 	if (!desc)
 		return;

--- a/drivers/platform/maxim/max32660/maxim_stdio.h
+++ b/drivers/platform/maxim/max32660/maxim_stdio.h
@@ -42,7 +42,7 @@
 #include <sys/stat.h>
 #include "no_os_uart.h"
 
-void maxim_uart_stdio(struct no_os_uart_desc *);
+void no_os_uart_stdio(struct no_os_uart_desc *);
 int _isatty(int);
 int _write(int, char *, int);
 int _close(int);

--- a/drivers/platform/maxim/max32665/maxim_stdio.c
+++ b/drivers/platform/maxim/max32665/maxim_stdio.c
@@ -58,7 +58,7 @@
 
 static struct no_os_uart_desc *guart = NULL;
 
-void maxim_uart_stdio(struct no_os_uart_desc *desc)
+void no_os_uart_stdio(struct no_os_uart_desc *desc)
 {
 	if (!desc)
 		return;

--- a/drivers/platform/maxim/max32665/maxim_stdio.h
+++ b/drivers/platform/maxim/max32665/maxim_stdio.h
@@ -42,7 +42,7 @@
 #include <sys/stat.h>
 #include "no_os_uart.h"
 
-void maxim_uart_stdio(struct no_os_uart_desc *);
+void no_os_uart_stdio(struct no_os_uart_desc *);
 int _isatty(int);
 int _write(int, char *, int);
 int _close(int);

--- a/drivers/platform/maxim/max78000/maxim_stdio.c
+++ b/drivers/platform/maxim/max78000/maxim_stdio.c
@@ -58,7 +58,7 @@
 
 static struct no_os_uart_desc *guart = NULL;
 
-void maxim_uart_stdio(struct no_os_uart_desc *desc)
+void no_os_uart_stdio(struct no_os_uart_desc *desc)
 {
 	if (!desc)
 		return;

--- a/drivers/platform/maxim/max78000/maxim_stdio.h
+++ b/drivers/platform/maxim/max78000/maxim_stdio.h
@@ -42,7 +42,7 @@
 #include <sys/stat.h>
 #include "no_os_uart.h"
 
-void maxim_uart_stdio(struct no_os_uart_desc *);
+void no_os_uart_stdio(struct no_os_uart_desc *);
 int _isatty(int);
 int _write(int, char *, int);
 int _close(int);

--- a/drivers/platform/stm32/stm32_uart_stdio.c
+++ b/drivers/platform/stm32/stm32_uart_stdio.c
@@ -59,7 +59,7 @@
 
 static struct no_os_uart_desc *guart = NULL;
 
-void stm32_uart_stdio(struct no_os_uart_desc *desc)
+void no_os_uart_stdio(struct no_os_uart_desc *desc)
 {
 	if(!desc || !desc->extra)
 		return;

--- a/drivers/platform/stm32/stm32_uart_stdio.h
+++ b/drivers/platform/stm32/stm32_uart_stdio.h
@@ -43,7 +43,7 @@
 #include "no_os_uart.h"
 #include "stm32_uart.h"
 
-void stm32_uart_stdio(struct no_os_uart_desc *desc);
+void no_os_uart_stdio(struct no_os_uart_desc *desc);
 int _isatty(int fd);
 int _write(int fd, char* ptr, int len);
 int _close(int fd);

--- a/include/no_os_uart.h
+++ b/include/no_os_uart.h
@@ -199,4 +199,7 @@ int32_t no_os_uart_remove(struct no_os_uart_desc *desc);
 /* Check if UART errors occurred. */
 uint32_t no_os_uart_get_errors(struct no_os_uart_desc *desc);
 
+/* Make stdio to use this UART. */
+void no_os_uart_stdio(struct no_os_uart_desc *desc);
+
 #endif // _NO_OS_UART_H_

--- a/projects/ad74413r/src/platform/maxim/main.c
+++ b/projects/ad74413r/src/platform/maxim/main.c
@@ -68,7 +68,7 @@ int main()
 	if (ret)
 		return ret;
 
-	maxim_uart_stdio(uart_desc);
+	no_os_uart_stdio(uart_desc);
 	ret = dummy_example_main();
 #endif
 

--- a/projects/ad74413r/src/platform/stm32/main.c
+++ b/projects/ad74413r/src/platform/stm32/main.c
@@ -74,7 +74,7 @@ int main()
 	if (ret)
 		return ret;
 
-	stm32_uart_stdio(uart_desc);
+	no_os_uart_stdio(uart_desc);
 	ret = dummy_example_main();
 #endif
 

--- a/projects/ad7746-ebz/src/app/headless.c
+++ b/projects/ad7746-ebz/src/app/headless.c
@@ -127,7 +127,7 @@ int main(void)
 	if (ret < 0)
 		goto error;
 
-	init_uart_stdio(uart);
+	no_os_uart_stdio(uart);
 
 	pr_info("Hello!\n");
 

--- a/projects/adt7420-pmdz/src/platform/maxim/main.c
+++ b/projects/adt7420-pmdz/src/platform/maxim/main.c
@@ -73,7 +73,7 @@ int main()
 	if (ret)
 		goto error;
 
-	maxim_uart_stdio(uart);
+	no_os_uart_stdio(uart);
 	ret = dummy_example_main();
 	if (ret)
 		goto error;

--- a/projects/aducm3029_flash_demo/src/main.c
+++ b/projects/aducm3029_flash_demo/src/main.c
@@ -101,7 +101,7 @@ int main(int argc, char *argv[])
 	ret = no_os_uart_init(&uart_dut, &uart_init_par);
 	if (ret < 0)
 		return ret;
-	init_uart_stdio(uart_dut);
+	no_os_uart_stdio(uart_dut);
 
 	ret = no_os_flash_init(&flash_dut, &flash_init_par);
 	if (ret < 0)

--- a/projects/cn0565/src/app/main.c
+++ b/projects/cn0565/src/app/main.c
@@ -129,11 +129,8 @@ int main(void)
 	if (ret < 0)
 		return ret;
 
-#if defined(STM32_PLATFORM)
-	stm32_uart_stdio(uart);
-#elif defined(ADUCM_PLATFORM)
-	init_uart_stdio(uart);
-#endif
+	no_os_uart_stdio(uart);
+
 	printf("Hello!\n");
 #endif
 	struct no_os_i2c_init_param i2cip = {

--- a/projects/eval-adxl313z/src/platform/stm32/main.c
+++ b/projects/eval-adxl313z/src/platform/stm32/main.c
@@ -79,7 +79,7 @@ int main()
 	if (ret)
 		goto error;
 
-	stm32_uart_stdio(uart);
+	no_os_uart_stdio(uart);
 	ret = basic_example_main();
 	if (ret)
 		goto error;

--- a/projects/eval-adxl355-pmdz/src/platform/maxim/main.c
+++ b/projects/eval-adxl355-pmdz/src/platform/maxim/main.c
@@ -106,7 +106,7 @@ int main()
 	if (ret)
 		return ret;
 
-	maxim_uart_stdio(uart_desc);
+	no_os_uart_stdio(uart_desc);
 	ret = dummy_example_main();
 #endif
 

--- a/projects/eval-adxl355-pmdz/src/platform/stm32/main.c
+++ b/projects/eval-adxl355-pmdz/src/platform/stm32/main.c
@@ -84,7 +84,7 @@ int main()
 	if (ret)
 		return ret;
 
-	stm32_uart_stdio(uart_desc);
+	no_os_uart_stdio(uart_desc);
 	ret = dummy_example_main();
 #endif
 

--- a/projects/max11205pmb1/src/platform/maxim/main.c
+++ b/projects/max11205pmb1/src/platform/maxim/main.c
@@ -87,7 +87,7 @@ int main()
 	if (ret)
 		return ret;
 
-	maxim_uart_stdio(max11205_uart_desc);
+	no_os_uart_stdio(max11205_uart_desc);
 
 	ret = basic_example_main();
 #endif


### PR DESCRIPTION
This functionality was scattered around platforms under different names. Fix that, use a common name.

Because this is an optional feature, no_os_uart.c imlplements an empty version with weak linkage. This means that platforms that implement this feature override the weak function whereas the rest of them can simply not implement it.

Signed-off-by: Darius Berghe <darius.berghe@analog.com>