### PR TITLE
rename maxim_stdio.c/.h to maxim_uart_stdio.c/.h

### DIFF
--- a/drivers/platform/maxim/max32650/maxim_uart_stdio.c
+++ b/drivers/platform/maxim/max32650/maxim_uart_stdio.c
@@ -1,5 +1,5 @@
 /***************************************************************************//**
- *   @file   maxim_stdio.c
+ *   @file   maxim_uart_stdio.c
  *   @brief  Implementation file of MAX32660 UART driver stdout/stdin redirection.
  *   @author Ciprian Regus (ciprian.regus@analog.com)
  *
@@ -43,7 +43,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include "maxim_stdio.h"
+#include "maxim_uart_stdio.h"
 
 #include "mxc_sys.h"
 #include "no_os_uart.h"

--- a/drivers/platform/maxim/max32650/maxim_uart_stdio.h
+++ b/drivers/platform/maxim/max32650/maxim_uart_stdio.h
@@ -1,5 +1,5 @@
 /***************************************************************************//**
- *   @file   maxim_stdio.h
+ *   @file   maxim_uart_stdio.h
  *   @brief  Header file for UART driver stdout/stdin redirection.
  *   @author Ciprian Regus (ciprian.regus@analog.com)
 ********************************************************************************
@@ -36,8 +36,8 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
-#ifndef MAXIM_STDIO_H_
-#define MAXIM_STDIO_H_
+#ifndef MAXIM_UART_STDIO_H_
+#define MAXIM_UART_STDIO_H_
 
 #include <sys/stat.h>
 #include "no_os_uart.h"

--- a/drivers/platform/maxim/max32655/maxim_uart_stdio.c
+++ b/drivers/platform/maxim/max32655/maxim_uart_stdio.c
@@ -1,5 +1,5 @@
 /***************************************************************************//**
- *   @file   maxim_stdio.c
+ *   @file   maxim_uart_stdio.c
  *   @brief  Implementation file of MAX32660 UART driver stdout/stdin redirection.
  *   @author Ciprian Regus (ciprian.regus@analog.com)
  *
@@ -43,7 +43,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include "maxim_stdio.h"
+#include "maxim_uart_stdio.h"
 
 #include "mxc_sys.h"
 #include "no_os_uart.h"

--- a/drivers/platform/maxim/max32655/maxim_uart_stdio.h
+++ b/drivers/platform/maxim/max32655/maxim_uart_stdio.h
@@ -1,5 +1,5 @@
 /***************************************************************************//**
- *   @file   maxim_stdio.h
+ *   @file   maxim_uart_stdio.h
  *   @brief  Header file for UART driver stdout/stdin redirection.
  *   @author Ciprian Regus (ciprian.regus@analog.com)
 ********************************************************************************
@@ -36,8 +36,8 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
-#ifndef MAXIM_STDIO_H_
-#define MAXIM_STDIO_H_
+#ifndef MAXIM_UART_STDIO_H_
+#define MAXIM_UART_STDIO_H_
 
 #include <sys/stat.h>
 #include "no_os_uart.h"

--- a/drivers/platform/maxim/max32660/maxim_uart_stdio.c
+++ b/drivers/platform/maxim/max32660/maxim_uart_stdio.c
@@ -1,5 +1,5 @@
 /***************************************************************************//**
- *   @file   maxim_stdio.c
+ *   @file   maxim_uart_stdio.c
  *   @brief  Implementation file of MAX32660 UART driver stdout/stdin redirection.
  *   @author Ciprian Regus (ciprian.regus@analog.com)
  *
@@ -43,7 +43,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include "maxim_stdio.h"
+#include "maxim_uart_stdio.h"
 
 #include "mxc_sys.h"
 #include "no_os_uart.h"

--- a/drivers/platform/maxim/max32660/maxim_uart_stdio.h
+++ b/drivers/platform/maxim/max32660/maxim_uart_stdio.h
@@ -1,5 +1,5 @@
 /***************************************************************************//**
- *   @file   maxim_stdio.h
+ *   @file   maxim_uart_stdio.h
  *   @brief  Header file for UART driver stdout/stdin redirection.
  *   @author Ciprian Regus (ciprian.regus@analog.com)
 ********************************************************************************
@@ -36,8 +36,8 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
-#ifndef MAXIM_STDIO_H_
-#define MAXIM_STDIO_H_
+#ifndef MAXIM_UART_STDIO_H_
+#define MAXIM_UART_STDIO_H_
 
 #include <sys/stat.h>
 #include "no_os_uart.h"

--- a/drivers/platform/maxim/max32665/maxim_uart_stdio.c
+++ b/drivers/platform/maxim/max32665/maxim_uart_stdio.c
@@ -1,5 +1,5 @@
 /***************************************************************************//**
- *   @file   maxim_stdio.c
+ *   @file   maxim_uart_stdio.c
  *   @brief  Implementation file of MAX32660 UART driver stdout/stdin redirection.
  *   @author Ciprian Regus (ciprian.regus@analog.com)
  *
@@ -43,7 +43,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include "maxim_stdio.h"
+#include "maxim_uart_stdio.h"
 
 #include "mxc_sys.h"
 #include "no_os_uart.h"

--- a/drivers/platform/maxim/max32665/maxim_uart_stdio.h
+++ b/drivers/platform/maxim/max32665/maxim_uart_stdio.h
@@ -1,5 +1,5 @@
 /***************************************************************************//**
- *   @file   maxim_stdio.h
+ *   @file   maxim_uart_stdio.h
  *   @brief  Header file for UART driver stdout/stdin redirection.
  *   @author Ciprian Regus (ciprian.regus@analog.com)
 ********************************************************************************
@@ -36,8 +36,8 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
-#ifndef MAXIM_STDIO_H_
-#define MAXIM_STDIO_H_
+#ifndef MAXIM_UART_STDIO_H_
+#define MAXIM_UART_STDIO_H_
 
 #include <sys/stat.h>
 #include "no_os_uart.h"

--- a/drivers/platform/maxim/max78000/maxim_uart_stdio.c
+++ b/drivers/platform/maxim/max78000/maxim_uart_stdio.c
@@ -1,5 +1,5 @@
 /***************************************************************************//**
- *   @file   maxim_stdio.c
+ *   @file   maxim_uart_stdio.c
  *   @brief  Implementation file of MAX32660 UART driver stdout/stdin redirection.
  *   @author Ciprian Regus (ciprian.regus@analog.com)
  *
@@ -43,7 +43,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include "maxim_stdio.h"
+#include "maxim_uart_stdio.h"
 
 #include "mxc_sys.h"
 #include "no_os_uart.h"

--- a/drivers/platform/maxim/max78000/maxim_uart_stdio.h
+++ b/drivers/platform/maxim/max78000/maxim_uart_stdio.h
@@ -1,5 +1,5 @@
 /***************************************************************************//**
- *   @file   maxim_stdio.h
+ *   @file   maxim_uart_stdio.h
  *   @brief  Header file for UART driver stdout/stdin redirection.
  *   @author Ciprian Regus (ciprian.regus@analog.com)
 ********************************************************************************
@@ -36,8 +36,8 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
-#ifndef MAXIM_STDIO_H_
-#define MAXIM_STDIO_H_
+#ifndef MAXIM_UART_STDIO_H_
+#define MAXIM_UART_STDIO_H_
 
 #include <sys/stat.h>
 #include "no_os_uart.h"

--- a/projects/ad74413r/src/platform/maxim/parameters.h
+++ b/projects/ad74413r/src/platform/maxim/parameters.h
@@ -46,7 +46,7 @@
 #include "maxim_spi.h"
 #include "maxim_gpio.h"
 #include "maxim_uart.h"
-#include "maxim_stdio.h"
+#include "maxim_uart_stdio.h"
 
 /******************************************************************************/
 /********************** Macros and Constants Definitions **********************/

--- a/projects/ad74413r/src/platform/maxim/platform_src.mk
+++ b/projects/ad74413r/src/platform/maxim/platform_src.mk
@@ -8,7 +8,7 @@ INCS += $(PLATFORM_DRIVERS)/maxim_delay.h     \
         $(PLATFORM_DRIVERS)/maxim_irq.h       \
         $(PLATFORM_DRIVERS)/maxim_rtc.h       \
         $(PLATFORM_DRIVERS)/maxim_uart.h      \
-        $(PLATFORM_DRIVERS)/maxim_stdio.h
+        $(PLATFORM_DRIVERS)/maxim_uart_stdio.h
 
 SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c     \
         $(PLATFORM_DRIVERS)/maxim_gpio.c      \
@@ -17,4 +17,4 @@ SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c     \
         $(PLATFORM_DRIVERS)/maxim_gpio_irq.c  \
         $(PLATFORM_DRIVERS)/maxim_irq.c       \
         $(PLATFORM_DRIVERS)/maxim_uart.c      \
-        $(PLATFORM_DRIVERS)/maxim_stdio.c
+        $(PLATFORM_DRIVERS)/maxim_uart_stdio.c

--- a/projects/adt7420-pmdz/src/platform/maxim/parameters.h
+++ b/projects/adt7420-pmdz/src/platform/maxim/parameters.h
@@ -44,7 +44,7 @@
 /***************************** Include Files **********************************/
 /******************************************************************************/
 #include "maxim_uart.h"
-#include "maxim_stdio.h"
+#include "maxim_uart_stdio.h"
 #include "maxim_i2c.h"
 #include "maxim_irq.h"
 #include "maxim_gpio.h"

--- a/projects/adt7420-pmdz/src/platform/maxim/platform_src.mk
+++ b/projects/adt7420-pmdz/src/platform/maxim/platform_src.mk
@@ -6,7 +6,7 @@ INCS += $(PLATFORM_DRIVERS)/maxim_delay.h     \
 		$(PLATFORM_DRIVERS)/maxim_irq.h      \
 		$(PLATFORM_DRIVERS)/maxim_rtc.h      \
 		$(PLATFORM_DRIVERS)/maxim_uart.h      \
-		$(PLATFORM_DRIVERS)/maxim_stdio.h
+		$(PLATFORM_DRIVERS)/maxim_uart_stdio.h
 
 SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c     \
 		$(PLATFORM_DRIVERS)/maxim_gpio.c      \
@@ -14,4 +14,4 @@ SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c     \
 		$(PLATFORM_DRIVERS)/maxim_rtc.c       \
 		$(PLATFORM_DRIVERS)/maxim_irq.c      \
 		$(PLATFORM_DRIVERS)/maxim_uart.c      \
-		$(PLATFORM_DRIVERS)/maxim_stdio.c
+		$(PLATFORM_DRIVERS)/maxim_uart_stdio.c

--- a/projects/adxrs290-pmdz/src/platform/maxim/parameters.h
+++ b/projects/adxrs290-pmdz/src/platform/maxim/parameters.h
@@ -47,7 +47,7 @@
 #include "maxim_spi.h"
 #include "maxim_gpio.h"
 #include "maxim_uart.h"
-#include "maxim_stdio.h"
+#include "maxim_uart_stdio.h"
 
 /******************************************************************************/
 /********************** Macros and Constants Definitions **********************/

--- a/projects/adxrs290-pmdz/src/platform/maxim/platform_src.mk
+++ b/projects/adxrs290-pmdz/src/platform/maxim/platform_src.mk
@@ -7,7 +7,7 @@ INCS += $(PLATFORM_DRIVERS)/maxim_delay.h     \
         $(PLATFORM_DRIVERS)/maxim_irq.h       \
         $(PLATFORM_DRIVERS)/maxim_rtc.h       \
         $(PLATFORM_DRIVERS)/maxim_uart.h      \
-        $(PLATFORM_DRIVERS)/maxim_stdio.h
+        $(PLATFORM_DRIVERS)/maxim_uart_stdio.h
 
 SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c     \
         $(PLATFORM_DRIVERS)/maxim_gpio.c      \
@@ -16,4 +16,4 @@ SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c     \
         $(PLATFORM_DRIVERS)/maxim_gpio_irq.c  \
         $(PLATFORM_DRIVERS)/maxim_irq.c       \
         $(PLATFORM_DRIVERS)/maxim_uart.c      \
-        $(PLATFORM_DRIVERS)/maxim_stdio.c
+        $(PLATFORM_DRIVERS)/maxim_uart_stdio.c

--- a/projects/eval-adxl355-pmdz/src/platform/maxim/parameters.h
+++ b/projects/eval-adxl355-pmdz/src/platform/maxim/parameters.h
@@ -47,7 +47,7 @@
 #include "maxim_spi.h"
 #include "maxim_gpio.h"
 #include "maxim_uart.h"
-#include "maxim_stdio.h"
+#include "maxim_uart_stdio.h"
 
 /******************************************************************************/
 /********************** Macros and Constants Definitions **********************/

--- a/projects/eval-adxl355-pmdz/src/platform/maxim/platform_src.mk
+++ b/projects/eval-adxl355-pmdz/src/platform/maxim/platform_src.mk
@@ -7,7 +7,7 @@ INCS += $(PLATFORM_DRIVERS)/maxim_delay.h     \
         $(PLATFORM_DRIVERS)/maxim_irq.h       \
         $(PLATFORM_DRIVERS)/maxim_rtc.h       \
         $(PLATFORM_DRIVERS)/maxim_uart.h      \
-        $(PLATFORM_DRIVERS)/maxim_stdio.h
+        $(PLATFORM_DRIVERS)/maxim_uart_stdio.h
 
 SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c     \
         $(PLATFORM_DRIVERS)/maxim_gpio.c      \
@@ -16,4 +16,4 @@ SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c     \
         $(PLATFORM_DRIVERS)/maxim_gpio_irq.c  \
         $(PLATFORM_DRIVERS)/maxim_irq.c       \
         $(PLATFORM_DRIVERS)/maxim_uart.c      \
-        $(PLATFORM_DRIVERS)/maxim_stdio.c
+        $(PLATFORM_DRIVERS)/maxim_uart_stdio.c

--- a/projects/iio_demo/src/platform/maxim/parameters.h
+++ b/projects/iio_demo/src/platform/maxim/parameters.h
@@ -45,7 +45,7 @@
 /******************************************************************************/
 #include "maxim_irq.h"
 #include "maxim_uart.h"
-#include "maxim_stdio.h"
+#include "maxim_uart_stdio.h"
 #include "maxim_timer.h"
 #include "common_data.h"
 #include "no_os_util.h"

--- a/projects/iio_demo/src/platform/maxim/platform_src.mk
+++ b/projects/iio_demo/src/platform/maxim/platform_src.mk
@@ -5,13 +5,13 @@ SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c	\
 	$(PLATFORM_DRIVERS)/maxim_rtc.c		\
 	$(PLATFORM_DRIVERS)/maxim_timer.c	\
 	$(PLATFORM_DRIVERS)/maxim_uart.c	\
-	$(PLATFORM_DRIVERS)/maxim_stdio.c
+	$(PLATFORM_DRIVERS)/maxim_uart_stdio.c
 	
 INCS += $(PLATFORM_DRIVERS)/maxim_irq.h		\
 	$(PLATFORM_DRIVERS)/maxim_uart.h	\
 	$(PLATFORM_DRIVERS)/maxim_timer.h	\
 	$(PLATFORM_DRIVERS)/maxim_rtc.h		\
-	$(PLATFORM_DRIVERS)/maxim_stdio.h
+	$(PLATFORM_DRIVERS)/maxim_uart_stdio.h
 
 INCS += $(INCLUDE)/no_os_irq.h
 

--- a/projects/max11205pmb1/src/platform/maxim/parameters.h
+++ b/projects/max11205pmb1/src/platform/maxim/parameters.h
@@ -47,7 +47,7 @@
 #include "maxim_spi.h"
 #include "maxim_gpio.h"
 #include "maxim_uart.h"
-#include "maxim_stdio.h"
+#include "maxim_uart_stdio.h"
 
 /******************************************************************************/
 /********************** Macros and Constants Definitions **********************/

--- a/projects/max11205pmb1/src/platform/maxim/platform_src.mk
+++ b/projects/max11205pmb1/src/platform/maxim/platform_src.mk
@@ -7,7 +7,7 @@ INCS += $(PLATFORM_DRIVERS)/maxim_delay.h     \
         $(PLATFORM_DRIVERS)/maxim_irq.h       \
         $(PLATFORM_DRIVERS)/maxim_rtc.h       \
         $(PLATFORM_DRIVERS)/maxim_uart.h      \
-        $(PLATFORM_DRIVERS)/maxim_stdio.h
+        $(PLATFORM_DRIVERS)/maxim_uart_stdio.h
 
 SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c     \
         $(PLATFORM_DRIVERS)/maxim_gpio.c      \
@@ -16,4 +16,4 @@ SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c     \
         $(PLATFORM_DRIVERS)/maxim_gpio_irq.c  \
         $(PLATFORM_DRIVERS)/maxim_irq.c       \
         $(PLATFORM_DRIVERS)/maxim_uart.c      \
-        $(PLATFORM_DRIVERS)/maxim_stdio.c
+        $(PLATFORM_DRIVERS)/maxim_uart_stdio.c


### PR DESCRIPTION
to make it consistent with the other platforms imlpementing this feature.