### PR TITLE
xilinx:xilinx_delay.c Remove use of float

### DIFF
--- a/drivers/platform/xilinx/xilinx_delay.c
+++ b/drivers/platform/xilinx/xilinx_delay.c
@@ -44,6 +44,7 @@
 #include "no_os_delay.h"
 #include <sleep.h>
 #ifdef _XPARAMETERS_PS_H_
+#include "no_os_util.h"
 #include "xtime_l.h"
 #endif
 
@@ -85,25 +86,14 @@ void no_os_mdelay(uint32_t msecs)
  */
 struct no_os_time no_os_get_time(void)
 {
+	struct no_os_time t = {0, 0};
 #ifdef _XPARAMETERS_PS_H_
 	unsigned long long Xtime_Global;
-	float fractional_part = 0;
-#endif
-	struct no_os_time t;
+	uint32_t rem;
 
-#ifdef _XPARAMETERS_PS_H_
 	XTime_GetTime(&Xtime_Global);
-	t.s = Xtime_Global / COUNTS_PER_SECOND;
-#else
-	t.s = 0;
-#endif
-
-#ifdef _XPARAMETERS_PS_H_
-	fractional_part = (float)Xtime_Global / COUNTS_PER_SECOND - Xtime_Global /
-			  COUNTS_PER_SECOND;
-	t.us = fractional_part * 1000000;
-#else
-	t.us = 0;
+	t.s = no_os_div_u64_rem(Xtime_Global, COUNTS_PER_SECOND, &rem);
+	t.us = no_os_div_u64((uint64_t)rem * 1000000, COUNTS_PER_SECOND);
 #endif
 
 	return t;

--- a/projects/ad5758-sdz/src.mk
+++ b/projects/ad5758-sdz/src.mk
@@ -5,13 +5,15 @@ SRCS += $(DRIVERS)/api/no_os_gpio.c \
         $(PLATFORM_DRIVERS)/$(PLATFORM)_spi.c \
         $(PLATFORM_DRIVERS)/$(PLATFORM)_gpio.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_delay.c \
-	$(DRIVERS)/dac/ad5758/ad5758.c
+	$(DRIVERS)/dac/ad5758/ad5758.c \
+	$(NO-OS)/util/no_os_util.c
 
 INCS += $(INCLUDE)/no_os_gpio.h \
 	$(INCLUDE)/no_os_spi.h \
         $(INCLUDE)/no_os_error.h \
         $(INCLUDE)/no_os_delay.h \
         $(INCLUDE)/no_os_print_log.h \
+        $(INCLUDE)/no_os_util.h \
         $(PLATFORM_DRIVERS)/$(PLATFORM)_gpio.h \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_spi.h	\
 	$(DRIVERS)/dac/ad5758/ad5758.h

--- a/projects/ad7124-4sdz/src.mk
+++ b/projects/ad7124-4sdz/src.mk
@@ -16,7 +16,8 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/adc/ad7124/ad7124_regs.c				
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
-	$(PLATFORM_DRIVERS)/xilinx_delay.c
+	$(PLATFORM_DRIVERS)/xilinx_delay.c \
+	$(NO-OS)/util/no_os_util.c
 INCS += $(DRIVERS)/adc/ad7124/ad7124.h \
 	$(DRIVERS)/adc/ad7124/ad7124_regs.h
 

--- a/projects/ad719x/src.mk
+++ b/projects/ad719x/src.mk
@@ -25,7 +25,8 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/api/no_os_irq.c \
 	$(DRIVERS)/api/no_os_gpio.c \
 	$(DRIVERS)/adc/ad719x/ad719x.c \
-	$(NO-OS)/util/no_os_list.c
+	$(NO-OS)/util/no_os_list.c \
+	$(NO-OS)/util/no_os_util.c
 
 INCS += $(DRIVERS)/adc/ad719x/ad719x.h
 


### PR DESCRIPTION
Remove use of float in microsecond calculation.

Signed-off-by: George Mois <george.mois@analog.com>