### PR TITLE
drivers: accel: adxl355: Include no_os_delay.h

### DIFF
--- a/drivers/accel/adxl355/adxl355.c
+++ b/drivers/accel/adxl355/adxl355.c
@@ -43,6 +43,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include "adxl355.h"
+#include "no_os_delay.h"
 
 /******************************************************************************/
 /************************ Variable Declarations ******************************/


### PR DESCRIPTION
Include no_os_delay.h in adxl355.c

Fixes: 22ffa3c1 ("drivers: accel: adxl355: Add delay after soft reset")
Signed-off-by: Ramona Bolboaca <ramona.bolboaca@analog.com>