### PR TITLE
drivers: api: no_os_irq: Fix check in no_os_irq_set_priority

### DIFF
--- a/drivers/api/no_os_irq.c
+++ b/drivers/api/no_os_irq.c
@@ -219,7 +219,7 @@ int32_t no_os_irq_set_priority(struct no_os_irq_ctrl_desc *desc,
 			       uint32_t irq_id,
 			       uint32_t priority_level)
 {
-	if (!desc || desc->platform_ops)
+	if (!desc || !desc->platform_ops)
 		return -EINVAL;
 
 	if (!desc->platform_ops->set_priority)


### PR DESCRIPTION
Return EINVAL only if pltform_ops is not defined.

Fixes: c2f01550 ("drivers: api: Fix the API pointer checks")
Signed-off-by: Ramona Bolboaca <ramona.bolboaca@analog.com>