### PR TITLE
NO_OS_VERSION: git branch, hash and modified

### DIFF
--- a/iio/iio.c
+++ b/iio/iio.c
@@ -99,8 +99,7 @@ static char header[] =
 	"<!ATTLIST debug-attribute name CDATA #REQUIRED>"
 	"<!ATTLIST buffer-attribute name CDATA #REQUIRED>"
 	"]>"
-	"<context name=\"xml\" description=\"no-OS analog 1.1.0-g0000000 #1 Tue Nov 26 09:52:32 IST 2019 armv7l\" >"
-	"<context-attribute name=\"no-OS\" value=\"1.1.0-g0000000\" />";
+	"<context name=\"xml\" description=\"no-OS " NO_OS_VERSION "\" >";
 static char header_end[] = "</context>";
 
 static const char * const iio_chan_type_string[] = {

--- a/tools/scripts/generic_variables.mk
+++ b/tools/scripts/generic_variables.mk
@@ -26,6 +26,10 @@ INCLUDE			?= $(NO-OS)/include
 DRIVERS 		?= $(NO-OS)/drivers
 PLATFORM_DRIVERS	?= $(NO-OS)/drivers/platform/$(PLATFORM)
 
+GIT_VERSION := $(shell git describe --all --long --dirty=-modified)
+GIT_VERSION := $(subst heads/,,$(GIT_VERSION))
+GIT_VERSION := $(subst -0-g,-,$(GIT_VERSION))
+CFLAGS += -D NO_OS_VERSION=\"$(GIT_VERSION)\"
 #------------------------------------------------------------------------------
 #                          EVALUATE PLATFORM
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Add the NO_OS_VERSION compiler define that contains:
- git branch name
- git hash
- optionally, the -modified suffix

Examples:
master-9271c4ee2-modified
2019_r2-abcdef123

Signed-off-by: Darius Berghe <darius.berghe@analog.com>