### PR TITLE
iio and iio_app: user specified context attributes

### DIFF
--- a/iio/iio.h
+++ b/iio/iio.h
@@ -86,8 +86,15 @@ struct iio_trigger_init {
 	struct iio_trigger *descriptor;
 };
 
-struct iio_cntx_attr_init {
-	struct iio_context_attribute *descriptor;
+/**
+ * @struct iio_ctx_attr
+ * @brief Structure holding the context attribute members
+ */
+struct iio_ctx_attr {
+	/** Attribute name */
+	const char *name;
+	/** Attribute value */
+	const char *value;
 };
 
 struct iio_init_param {
@@ -98,8 +105,8 @@ struct iio_init_param {
 		struct tcp_socket_init_param *tcp_socket_init_param;
 #endif
 	};
-	struct iio_cntx_attr_init *cntx_attrs;
-	uint32_t nb_cntx_attrs;
+	struct iio_ctx_attr *ctx_attrs;
+	uint32_t nb_ctx_attr;
 	struct iio_device_init *devs;
 	uint32_t nb_devs;
 	struct iio_trigger_init *trigs;

--- a/iio/iio_app/iio_app.c
+++ b/iio/iio_app/iio_app.c
@@ -325,6 +325,8 @@ static int32_t irq_setup(struct no_os_irq_ctrl_desc **irq_desc)
 
 /**
  * @brief IIO Application API with trigger initialization.
+ * @param ctx_attrs - array of context attributes.
+ * @param nb_ctx_attr - number of attributes in ctx_attrs.
  * @param devices  - IIO devices to be used.
  * @param nb_devs  - Number of devices to be used.
  * @param trigs    - IIO triggers to be used.
@@ -333,7 +335,9 @@ static int32_t irq_setup(struct no_os_irq_ctrl_desc **irq_desc)
  * @param iio_desc - IIO descriptor to be returned.
  * @return 0 in case of success or negative value otherwise.
  */
-int32_t iio_app_run_with_trigs(struct iio_app_device *devices, uint32_t nb_devs,
+int32_t iio_app_run_with_trigs(struct iio_ctx_attr *ctx_attrs,
+			       uint32_t nb_ctx_attr,
+			       struct iio_app_device *devices, uint32_t nb_devs,
 			       struct iio_trigger_init *trigs, int32_t nb_trigs,
 			       void *irq_desc, struct iio_desc **iio_desc)
 {
@@ -412,7 +416,8 @@ int32_t iio_app_run_with_trigs(struct iio_app_device *devices, uint32_t nb_devs,
 	iio_init_param.nb_devs = nb_devs;
 	iio_init_param.trigs = trigs;
 	iio_init_param.nb_trigs = nb_trigs;
-	iio_init_param.cntx_attrs = NULL;
+	iio_init_param.ctx_attrs = ctx_attrs;
+	iio_init_param.nb_ctx_attr = nb_ctx_attr;
 	status = iio_init(iio_desc, &iio_init_param);
 	if(status < 0)
 		goto error;
@@ -427,12 +432,14 @@ error:
 	return status;
 }
 
-int32_t iio_app_run(struct iio_app_device *devices, uint32_t len)
+int32_t iio_app_run(struct iio_ctx_attr *ctx_attrs, uint32_t nb_ctx_attr,
+		    struct iio_app_device *devices, uint32_t len)
 {
 	struct iio_desc	*iio_desc;
 	void *irq_desc = NULL;
 
-	return iio_app_run_with_trigs(devices, len, NULL, 0, irq_desc, &iio_desc);
+	return iio_app_run_with_trigs(ctx_attrs, nb_ctx_attr, devices, len, NULL, 0,
+				      irq_desc, &iio_desc);
 }
 
 #endif

--- a/iio/iio_app/iio_app.h
+++ b/iio/iio_app/iio_app.h
@@ -74,13 +74,18 @@ struct iio_app_device {
  * @brief Register devices and start an iio application
  *
  * Configuration for communication is done in parameters.h
+ * @param ctx_attrs - array of context attribute name/value pairs.
+ * @param nb_ctx_attr - number of context attributes in the array above.
  * @param devices - is an array of devices to register to iiod
  * @param len - is the number of devices
  * @return 0 on success, negative value otherwise
  */
-int32_t iio_app_run(struct iio_app_device *devices, uint32_t len);
+int32_t iio_app_run(struct iio_ctx_attr *ctx_attrs, uint32_t nb_ctx_attr,
+		    struct iio_app_device *devices, uint32_t len);
 
-int32_t iio_app_run_with_trigs(struct iio_app_device *devices, uint32_t len,
+int32_t iio_app_run_with_trigs(struct iio_ctx_attr *ctx_attrs,
+			       uint32_t nb_ctx_attr,
+			       struct iio_app_device *devices, uint32_t len,
 			       struct iio_trigger_init *trigs, int32_t nb_trigs,
 			       void *irq_desc, struct iio_desc **iio_desc);
 #endif

--- a/iio/iio_types.h
+++ b/iio/iio_types.h
@@ -121,17 +121,6 @@ enum iio_attribute_shared {
 };
 
 /**
- * @struct iio_context_attribute
- * @brief Structure holding the context attribute members
- */
-struct iio_context_attribute {
-	/** Attribute name */
-	const char *name;
-	/** Attribute value */
-	const char *value;
-};
-
-/**
  * @struct iio_attribute
  * @brief Structure holding pointers to show and store functions.
  */

--- a/projects/ad3552r_fmcz/srcs/main.c
+++ b/projects/ad3552r_fmcz/srcs/main.c
@@ -247,7 +247,7 @@ int main()
 
 	err = 0;
 	while (err >= 0) {
-		err = iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+		err = iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 	}
 
 	iio_ad3552r_remove(iio_dac);

--- a/projects/ad413x/src/app/main.c
+++ b/projects/ad413x/src/app/main.c
@@ -200,7 +200,7 @@ int main()
 		}
 	};
 
-	ret = iio_app_run(iio_devices, NO_OS_ARRAY_SIZE(iio_devices));
+	ret = iio_app_run(NULL, 0, iio_devices, NO_OS_ARRAY_SIZE(iio_devices));
 error:
 	ad413x_iio_remove(adciio);
 	return ret;

--- a/projects/ad463x_fmcz/src/ad463x_fmc.c
+++ b/projects/ad463x_fmcz/src/ad463x_fmc.c
@@ -211,7 +211,7 @@ int main()
 			       &rd_buff, NULL),
 	};
 
-	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+	return iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 
 #endif
 

--- a/projects/ad469x_fmcz/src/ad469x_fmcz.c
+++ b/projects/ad469x_fmcz/src/ad469x_fmcz.c
@@ -221,7 +221,7 @@ int main()
 			       &read_buff, NULL),
 	};
 
-	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+	return iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 
 #endif // IIO_SUPPORT
 

--- a/projects/ad6676-ebz/src/ad6676_ebz.c
+++ b/projects/ad6676-ebz/src/ad6676_ebz.c
@@ -498,7 +498,7 @@ int main(void)
 			       adc_dev_desc, &read_buff, NULL),
 	};
 
-	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+	return iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 
 #endif
 

--- a/projects/ad7124-8pmdz/src/main.c
+++ b/projects/ad7124-8pmdz/src/main.c
@@ -139,6 +139,6 @@ int main(void)
 			       &iio_ad7124_read_buff, NULL)
 	};
 
-	return iio_app_run(devices, NUMBER_OF_DEVICES);
+	return iio_app_run(NULL, 0, devices, NUMBER_OF_DEVICES);
 }
 

--- a/projects/ad713x_fmcz/src/ad713x_fmc.c
+++ b/projects/ad713x_fmcz/src/ad713x_fmc.c
@@ -312,7 +312,7 @@ int main()
 
 	};
 
-	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+	return iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 
 #endif /* IIO_SUPPORT */
 

--- a/projects/ad74413r/src/examples/iio_example/iio_example.c
+++ b/projects/ad74413r/src/examples/iio_example/iio_example.c
@@ -109,5 +109,5 @@ int iio_example_main()
 		}
 	};
 
-	return iio_app_run(iio_devices, NO_OS_ARRAY_SIZE(iio_devices));
+	return iio_app_run(NULL, 0, iio_devices, NO_OS_ARRAY_SIZE(iio_devices));
 }

--- a/projects/ad74413r/src/examples/iio_trigger_example/iio_trigger_example.c
+++ b/projects/ad74413r/src/examples/iio_trigger_example/iio_trigger_example.c
@@ -137,7 +137,8 @@ int iio_trigger_example_main()
 				&ad74413r_iio_trig_desc)
 	};
 
-	return iio_app_run_with_trigs(iio_devices, NO_OS_ARRAY_SIZE(iio_devices),
+	return iio_app_run_with_trigs(NULL, 0, iio_devices,
+				      NO_OS_ARRAY_SIZE(iio_devices),
 				      trigs, NO_OS_ARRAY_SIZE(trigs), ad74413r_irq_desc, &iio_desc);
 
 }

--- a/projects/ad7746-ebz/src/app/headless.c
+++ b/projects/ad7746-ebz/src/app/headless.c
@@ -207,7 +207,7 @@ error:
 		}
 	};
 
-	ret = iio_app_run(iio_devices, NO_OS_ARRAY_SIZE(iio_devices));
+	ret = iio_app_run(NULL, 0, iio_devices, NO_OS_ARRAY_SIZE(iio_devices));
 error:
 	ad7746_iio_remove(adciio);
 	return ret;

--- a/projects/ad7768-evb/src/ad7768_evb.c
+++ b/projects/ad7768-evb/src/ad7768_evb.c
@@ -334,7 +334,7 @@ int main(void)
 			       &read_buff, NULL),
 	};
 
-	return iio_app_run(devs, NO_OS_ARRAY_SIZE(devs));
+	return iio_app_run(NULL, 0, devs, NO_OS_ARRAY_SIZE(devs));
 #endif
 
 	/* Disable the instruction cache. */

--- a/projects/ad9081/src/app.c
+++ b/projects/ad9081/src/app.c
@@ -347,7 +347,7 @@ int main(void)
 		IIO_APP_DEVICE("axi_dac", iio_axi_dac_desc, dac_dev_desc, NULL, &write_buff)
 	};
 
-	iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+	iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 
 	/* Disable the instruction cache. */
 	Xil_DCacheDisable();

--- a/projects/ad9083/src/app.c
+++ b/projects/ad9083/src/app.c
@@ -199,7 +199,7 @@ int main(void)
 			       &ad9083_iio_descriptor, NULL, NULL)
 	};
 
-	status = iio_app_run(devices, 2);
+	status = iio_app_run(NULL, 0, devices, 2);
 	if (status != 0)
 		pr_err("error: %"PRIi32" iio_app_run()\n", status);
 

--- a/projects/ad9172/src/main.c
+++ b/projects/ad9172/src/main.c
@@ -350,7 +350,7 @@ int main(void)
 			       &write_buff, NULL),
 	};
 
-	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+	return iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 
 #endif
 

--- a/projects/ad9208/src/main.c
+++ b/projects/ad9208/src/main.c
@@ -121,7 +121,7 @@ int32_t start_iiod(struct axi_adc *rx_0_adc, struct axi_adc *rx_1_adc,
 			       &rd_buff1, NULL),
 	};
 
-	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+	return iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 }
 
 #endif /*IIO_SUPPORT */

--- a/projects/ad9265-fmc-125ebz/src/ad9265_fmc_125ebz.c
+++ b/projects/ad9265-fmc-125ebz/src/ad9265_fmc_125ebz.c
@@ -190,7 +190,7 @@ int main(void)
 			       &read_buff, NULL),
 	};
 
-	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+	return iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 #endif
 
 	pr_info("Done\n");

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -898,7 +898,7 @@ int main(void)
 		IIO_APP_DEVICE("ad9361-phy", ad9361_phy, ad9361_dev_desc, NULL, NULL)
 	};
 
-	iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+	iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 
 #endif // IIO_SUPPORT
 

--- a/projects/ad9371/src/app/headless.c
+++ b/projects/ad9371/src/app/headless.c
@@ -1092,7 +1092,7 @@ int main(void)
 		IIO_APP_DEVICE("cf-ad9371-dds-core-lpc", iio_axi_dac_desc, dac_dev_desc, NULL, &write_buff)
 	};
 
-	iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+	iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 
 #endif // IIO_SUPPORT
 

--- a/projects/ad9434-fmc-500ebz/src/ad9434_fmc_500ebz.c
+++ b/projects/ad9434-fmc-500ebz/src/ad9434_fmc_500ebz.c
@@ -201,7 +201,7 @@ int main(void)
 			       &read_buff, NULL),
 	};
 
-	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+	return iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 #endif
 
 	pr_info("Capture done.\n");

--- a/projects/ad9467/src/app/ad9467_fmc.c
+++ b/projects/ad9467/src/app/ad9467_fmc.c
@@ -308,7 +308,7 @@ int main()
 			       NULL),
 	};
 
-	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+	return iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 #endif
 
 	printf("Done.\n\r");

--- a/projects/ad9656_fmc/src/app/ad9656_fmc.c
+++ b/projects/ad9656_fmc/src/app/ad9656_fmc.c
@@ -316,7 +316,7 @@ int main(void)
 			       &read_buff, NULL),
 	};
 
-	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+	return iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 #endif
 
 	/* Memory deallocation for devices and spi */

--- a/projects/ad9739a-fmc-ebz/src/ad9739a_fmc_ebz.c
+++ b/projects/ad9739a-fmc-ebz/src/ad9739a_fmc_ebz.c
@@ -244,7 +244,7 @@ int main(void)
 			       &read_buff, NULL),
 	};
 
-	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+	return iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 #endif
 	pr_info("Done.\n");
 

--- a/projects/ada4250_ardz/src/ada4250_ardz.c
+++ b/projects/ada4250_ardz/src/ada4250_ardz.c
@@ -99,5 +99,5 @@ int main()
 			       NULL, NULL)
 	};
 
-	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+	return iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 }

--- a/projects/adaq8092_fmc/src/adaq8092_fmc.c
+++ b/projects/adaq8092_fmc/src/adaq8092_fmc.c
@@ -234,7 +234,7 @@ int main(void)
 			       &read_buff, NULL),
 	};
 
-	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+	return iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 #endif
 
 	return 0;

--- a/projects/adf4377_sdz/src/app/adf4377_sdz.c
+++ b/projects/adf4377_sdz/src/app/adf4377_sdz.c
@@ -144,7 +144,7 @@ int main(void)
 		IIO_APP_DEVICE("adf4377_dev", dev, &adf4377_iio_descriptor,
 			       NULL, NULL),
 	};
-	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+	return iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 #endif
 
 	/* Disable the instruction cache. */

--- a/projects/adf5902_sdz/src/adf5902_sdz.c
+++ b/projects/adf5902_sdz/src/adf5902_sdz.c
@@ -232,7 +232,7 @@ int main(void)
 		IIO_APP_DEVICE("adf5902_dev", dev, &adf5902_iio_descriptor,
 			       NULL, NULL),
 	};
-	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+	return iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 #endif
 
 	/* Disable the instruction cache. */

--- a/projects/adrv9001/src/app/headless.c
+++ b/projects/adrv9001/src/app/headless.c
@@ -225,7 +225,7 @@ static int32_t iio_run(struct iio_axi_adc_init_param *adc_pars,
 		app_devices[a].write_buff = &iio_dac_buffers[i];
 	}
 
-	return iio_app_run(app_devices, NO_OS_ARRAY_SIZE(app_devices));
+	return iio_app_run(NULL, 0, app_devices, NO_OS_ARRAY_SIZE(app_devices));
 }
 #endif
 

--- a/projects/adrv9009/src/app/headless.c
+++ b/projects/adrv9009/src/app/headless.c
@@ -118,7 +118,7 @@ int32_t start_iiod(struct axi_dmac *rx_dmac, struct axi_dmac *tx_dmac,
 #endif
 	};
 
-	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+	return iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 }
 
 #endif // IIO_SUPPORT

--- a/projects/adt7420-pmdz/src/examples/iio_example/iio_example.c
+++ b/projects/adt7420-pmdz/src/examples/iio_example/iio_example.c
@@ -87,5 +87,5 @@ int iio_example_main()
 		}
 	};
 
-	iio_app_run(iio_devices, NO_OS_ARRAY_SIZE(iio_devices));
+	iio_app_run(NULL, 0, iio_devices, NO_OS_ARRAY_SIZE(iio_devices));
 }

--- a/projects/adxrs290-pmdz/src/examples/iio_example/iio_example.c
+++ b/projects/adxrs290-pmdz/src/examples/iio_example/iio_example.c
@@ -82,5 +82,5 @@ int iio_example_main()
 		}
 	};
 
-	return iio_app_run(iio_devices, NO_OS_ARRAY_SIZE(iio_devices));
+	return iio_app_run(NULL, 0, iio_devices, NO_OS_ARRAY_SIZE(iio_devices));
 }

--- a/projects/adxrs290-pmdz/src/examples/iio_timer_trigger_example/iio_timer_trigger_example.c
+++ b/projects/adxrs290-pmdz/src/examples/iio_timer_trigger_example/iio_timer_trigger_example.c
@@ -124,6 +124,7 @@ int iio_timer_trigger_example_main()
 				&adxrs290_iio_trig_desc)
 	};
 
-	return iio_app_run_with_trigs(iio_devices, NO_OS_ARRAY_SIZE(iio_devices),
+	return iio_app_run_with_trigs(NULL, 0, iio_devices,
+				      NO_OS_ARRAY_SIZE(iio_devices),
 				      trigs, NO_OS_ARRAY_SIZE(trigs), adxrs290_timer_irq_desc, &iio_desc);
 }

--- a/projects/adxrs290-pmdz/src/examples/iio_trigger_example/iio_trigger_example.c
+++ b/projects/adxrs290-pmdz/src/examples/iio_trigger_example/iio_trigger_example.c
@@ -115,6 +115,7 @@ int iio_trigger_example_main()
 				&adxrs290_iio_trig_desc)
 	};
 
-	return iio_app_run_with_trigs(iio_devices, NO_OS_ARRAY_SIZE(iio_devices),
+	return iio_app_run_with_trigs(NULL, 0, iio_devices,
+				      NO_OS_ARRAY_SIZE(iio_devices),
 				      trigs, NO_OS_ARRAY_SIZE(trigs), adxrs290_irq_desc, &iio_desc);
 }

--- a/projects/cn0531/src/main.c
+++ b/projects/cn0531/src/main.c
@@ -127,6 +127,6 @@ int main(void)
 			       &iio_ad5791_read_buff, NULL)
 	};
 
-	return iio_app_run(devices, NUMBER_OF_DEVICES);
+	return iio_app_run(NULL, 0, devices, NUMBER_OF_DEVICES);
 }
 

--- a/projects/cn0552/src/app/headless.c
+++ b/projects/cn0552/src/app/headless.c
@@ -95,7 +95,7 @@ int32_t main(void)
 		}
 	};
 
-	ret = iio_app_run(iio_devices, NO_OS_ARRAY_SIZE(iio_devices));
+	ret = iio_app_run(NULL, 0, iio_devices, NO_OS_ARRAY_SIZE(iio_devices));
 error:
 	ad7746_iio_remove(adciio);
 	return ret;

--- a/projects/cn0561/src/cn0561.c
+++ b/projects/cn0561/src/cn0561.c
@@ -249,7 +249,7 @@ int main()
 			       &rd_buff, NULL),
 	};
 
-	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+	return iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 
 #endif /* IIO_SUPPORT */
 

--- a/projects/cn0565/src/app/main.c
+++ b/projects/cn0565/src/app/main.c
@@ -306,7 +306,7 @@ int main(void)
 		},
 	};
 
-	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+	return iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 #endif
 
 	printf("Bye!\n");

--- a/projects/eval-adxl313z/src/examples/iio_example/iio_example.c
+++ b/projects/eval-adxl313z/src/examples/iio_example/iio_example.c
@@ -103,5 +103,5 @@ int iio_example_main()
 		}
 	};
 
-	return iio_app_run(iio_devices, NO_OS_ARRAY_SIZE(iio_devices));
+	return iio_app_run(NULL, 0, iio_devices, NO_OS_ARRAY_SIZE(iio_devices));
 }

--- a/projects/eval-adxl355-pmdz/src/examples/iio_example/iio_example.c
+++ b/projects/eval-adxl355-pmdz/src/examples/iio_example/iio_example.c
@@ -87,5 +87,5 @@ int iio_example_main()
 		}
 	};
 
-	return iio_app_run(iio_devices, NO_OS_ARRAY_SIZE(iio_devices));
+	return iio_app_run(NULL, 0, iio_devices, NO_OS_ARRAY_SIZE(iio_devices));
 }

--- a/projects/eval-adxl355-pmdz/src/examples/iio_trigger_example/iio_trigger_example.c
+++ b/projects/eval-adxl355-pmdz/src/examples/iio_trigger_example/iio_trigger_example.c
@@ -115,6 +115,7 @@ int iio_trigger_example_main()
 				&adxl355_iio_trig_desc)
 	};
 
-	return iio_app_run_with_trigs(iio_devices, NO_OS_ARRAY_SIZE(iio_devices),
+	return iio_app_run_with_trigs(NULL, 0, iio_devices,
+				      NO_OS_ARRAY_SIZE(iio_devices),
 				      trigs, NO_OS_ARRAY_SIZE(trigs), adxl355_irq_desc, &iio_desc);
 }

--- a/projects/eval-adxl367z/src/examples/iio_example/iio_example.c
+++ b/projects/eval-adxl367z/src/examples/iio_example/iio_example.c
@@ -88,5 +88,5 @@ int iio_example_main()
 		}
 	};
 
-	return iio_app_run(iio_devices, NO_OS_ARRAY_SIZE(iio_devices));
+	return iio_app_run(NULL, 0, iio_devices, NO_OS_ARRAY_SIZE(iio_devices));
 }

--- a/projects/fmcadc2/src/fmcadc2.c
+++ b/projects/fmcadc2/src/fmcadc2.c
@@ -261,7 +261,7 @@ int main(void)
 			       &read_buff, NULL),
 	};
 
-	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+	return iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 #endif
 
 	printf("adc2: setup and configuration is done\n");

--- a/projects/fmcadc5/src/fmcadc5.c
+++ b/projects/fmcadc5/src/fmcadc5.c
@@ -407,7 +407,7 @@ int main(void)
 			       &read_buff0, NULL),
 	};
 
-	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+	return iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 #endif
 
 	printf("adc5: setup and configuration is done\n");

--- a/projects/fmcdaq2/src/app/fmcdaq2.c
+++ b/projects/fmcdaq2/src/app/fmcdaq2.c
@@ -781,7 +781,7 @@ static int fmcdaq2_iio_init(struct fmcdaq2_dev *dev,
 			       &ad9144_iio_descriptor, NULL, NULL)
 	};
 
-	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+	return iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 #endif
 
 	return 0;

--- a/projects/fmcdaq3/src/app/fmcdaq3.c
+++ b/projects/fmcdaq3/src/app/fmcdaq3.c
@@ -696,7 +696,7 @@ int main(void)
 			       &ad9152_iio_descriptor, NULL, NULL),
 	};
 
-	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+	return iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 
 #endif
 

--- a/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
+++ b/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
@@ -606,7 +606,7 @@ int main(void)
 			       &g_read_buff, NULL),
 	};
 
-	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+	return iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 
 #endif
 

--- a/projects/iio_adpd1080/src/main.c
+++ b/projects/iio_adpd1080/src/main.c
@@ -405,6 +405,6 @@ int main(void)
 			       &iio_adpd1080_read_buff, NULL)
 	};
 
-	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+	return iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 }
 

--- a/projects/iio_aducm3029/src/main.c
+++ b/projects/iio_aducm3029/src/main.c
@@ -133,7 +133,7 @@ int main(void)
 	ch.ch_num = 8;
 	set_pwm_attr(&g_aducm3029_desc, "1", 1, &ch, PWM_ENABLE);
 
-	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+	return iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 #endif
 
 	struct adc_init_param	adc_init_param = {0};

--- a/projects/iio_demo/src/examples/iio_example/iio_example.c
+++ b/projects/iio_demo/src/examples/iio_example/iio_example.c
@@ -90,5 +90,5 @@ int iio_example_main()
 			       &dac_demo_iio_descriptor,NULL, &dac_buff)
 	};
 
-	return iio_app_run(devices, NO_OS_ARRAY_SIZE(devices));
+	return iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 }

--- a/projects/iio_demo/src/examples/iio_sw_trigger_example/iio_sw_trigger_example.c
+++ b/projects/iio_demo/src/examples/iio_sw_trigger_example/iio_sw_trigger_example.c
@@ -117,6 +117,6 @@ int iio_sw_trigger_example_main()
 				&dac_iio_sw_trig_desc),
 	};
 
-	return iio_app_run_with_trigs(devices, NO_OS_ARRAY_SIZE(devices),
+	return iio_app_run_with_trigs(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices),
 				      trigs, NO_OS_ARRAY_SIZE(trigs), NULL, &iio_desc);
 }

--- a/projects/iio_demo/src/examples/iio_timer_trigger_example/iio_timer_trigger_example.c
+++ b/projects/iio_demo/src/examples/iio_timer_trigger_example/iio_timer_trigger_example.c
@@ -168,6 +168,6 @@ int iio_timer_trigger_example_main()
 				&dac_iio_timer_trig_desc)
 	};
 
-	return iio_app_run_with_trigs(devices, NO_OS_ARRAY_SIZE(devices),
+	return iio_app_run_with_trigs(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices),
 				      trigs, NO_OS_ARRAY_SIZE(trigs), NULL, &iio_desc);
 }

--- a/projects/max11205pmb1/src/examples/iio_example/iio_example.c
+++ b/projects/max11205pmb1/src/examples/iio_example/iio_example.c
@@ -99,5 +99,5 @@ int iio_example_main()
 		}
 	};
 
-	return iio_app_run(iio_devices, NO_OS_ARRAY_SIZE(iio_devices));
+	return iio_app_run(NULL, 0, iio_devices, NO_OS_ARRAY_SIZE(iio_devices));
 }


### PR DESCRIPTION
The user may initialize iio_app with custom context attributes that end up in the iio device xml.

Usage example (iio_ctx_attrs):
```
	struct iio_app_device iio_devices[] = {
		{
			.name = "hmc6300",
			.dev = iio_tx,
			.dev_descriptor = iio_tx->iio_dev,
		},
		{
			.name = "hmc6301",
			.dev = iio_rx,
			.dev_descriptor = iio_rx->iio_dev,
		},
	};

	struct iio_ctx_attr iio_ctx_attrs[] = {
		{
			.name = "fw_version",
			.value = NO_OS_VERSION
		},
		{
			.name = "hw_model",
			.value = "ADMV9621"
		},
	};

	ret = iio_app_run(iio_ctx_attrs, NO_OS_ARRAY_SIZE(iio_ctx_attrs), iio_devices, NO_OS_ARRAY_SIZE(iio_devices));
```