### PR TITLE
ADT7420 declare i2c_extra for all examples

### DIFF
--- a/projects/adt7420-pmdz/src/platform/maxim/parameters.c
+++ b/projects/adt7420-pmdz/src/platform/maxim/parameters.c
@@ -49,8 +49,8 @@
 struct max_uart_init_param xuip = {
 	.flow = UART_FLOW_DIS,
 };
+#endif
 
 struct max_i2c_init_param adt7420_i2c_extra = {
-	.vssel = MXC_GPIO_VSSEL_VDDIOH;
+	.vssel = MXC_GPIO_VSSEL_VDDIOH
 };
-#endif


### PR DESCRIPTION
Declare the adt7420_i2c_extra for both the DUMMY and IIO examples, since it's used in both cases.
