### PR TITLE
platform:maxim:max*:maxim_init.c Add delay to init

### DIFF
--- a/drivers/platform/maxim/max32650/maxim_init.c
+++ b/drivers/platform/maxim/max32650/maxim_init.c
@@ -38,9 +38,12 @@
 *******************************************************************************/
 #include "no_os_init.h"
 #include "mxc_sys.h"
+#include "mxc_delay.h"
 
 /* ************************************************************************** */
 __weak int no_os_init(void)
 {
-	return SysTick_Config(SystemCoreClock / 1000);
+	SysTick_Config(SystemCoreClock / 1000);
+	/* This has o be performed so the en state of SysTick is saved. */
+	return MXC_Delay(1);
 }

--- a/drivers/platform/maxim/max32655/maxim_init.c
+++ b/drivers/platform/maxim/max32655/maxim_init.c
@@ -38,9 +38,12 @@
 *******************************************************************************/
 #include "no_os_init.h"
 #include "mxc_sys.h"
+#include "mxc_delay.h"
 
 /* ************************************************************************** */
 __weak int no_os_init(void)
 {
-	return SysTick_Config(SystemCoreClock / 1000);
+	SysTick_Config(SystemCoreClock / 1000);
+	/* This has o be performed so the en state of SysTick is saved. */
+	return MXC_Delay(1);
 }

--- a/drivers/platform/maxim/max32660/maxim_init.c
+++ b/drivers/platform/maxim/max32660/maxim_init.c
@@ -38,9 +38,12 @@
 *******************************************************************************/
 #include "no_os_init.h"
 #include "mxc_sys.h"
+#include "mxc_delay.h"
 
 /* ************************************************************************** */
 __weak int no_os_init(void)
 {
-	return SysTick_Config(SystemCoreClock / 1000);
+	SysTick_Config(SystemCoreClock / 1000);
+	/* This has o be performed so the en state of SysTick is saved. */
+	return MXC_Delay(1);
 }

--- a/drivers/platform/maxim/max32665/maxim_init.c
+++ b/drivers/platform/maxim/max32665/maxim_init.c
@@ -38,9 +38,12 @@
 *******************************************************************************/
 #include "no_os_init.h"
 #include "mxc_sys.h"
+#include "mxc_delay.h"
 
 /* ************************************************************************** */
 __weak int no_os_init(void)
 {
-	return SysTick_Config(SystemCoreClock / 1000);
+	SysTick_Config(SystemCoreClock / 1000);
+	/* This has o be performed so the en state of SysTick is saved. */
+	return MXC_Delay(1);
 }

--- a/drivers/platform/maxim/max32670/maxim_init.c
+++ b/drivers/platform/maxim/max32670/maxim_init.c
@@ -38,9 +38,12 @@
 *******************************************************************************/
 #include "no_os_init.h"
 #include "mxc_sys.h"
+#include "mxc_delay.h"
 
 /* ************************************************************************** */
 __weak int no_os_init(void)
 {
-	return SysTick_Config(SystemCoreClock / 1000);
+	SysTick_Config(SystemCoreClock / 1000);
+	/* This has o be performed so the en state of SysTick is saved. */
+	return MXC_Delay(1);
 }

--- a/drivers/platform/maxim/max78000/maxim_init.c
+++ b/drivers/platform/maxim/max78000/maxim_init.c
@@ -38,9 +38,12 @@
 *******************************************************************************/
 #include "no_os_init.h"
 #include "mxc_sys.h"
+#include "mxc_delay.h"
 
 /* ************************************************************************** */
 __weak int no_os_init(void)
 {
-	return SysTick_Config(SystemCoreClock / 1000);
+	SysTick_Config(SystemCoreClock / 1000);
+	/* This has o be performed so the en state of SysTick is saved. */
+	return MXC_Delay(1);
 }


### PR DESCRIPTION
Add MXC_Delay to Maximi init function so that the en state of the SysTick timer is saved.

Fixes: 2355712e2be55e019070b

Signed-off-by: George Mois <george.mois@analog.com>