### PR TITLE
projects: adt75: fix iio_example

### DIFF
--- a/projects/adt75/src/examples/iio_example/iio_example.c
+++ b/projects/adt75/src/examples/iio_example/iio_example.c
@@ -88,5 +88,5 @@ int iio_example_main()
 		}
 	};
 
-	return iio_app_run(iio_devices, NO_OS_ARRAY_SIZE(iio_devices));
+	return iio_app_run(NULL, 0, iio_devices, NO_OS_ARRAY_SIZE(iio_devices));
 }


### PR DESCRIPTION
Add missing parameters for the iio_app_run function call.

Fixes: 52e38c6 ("projects: adt75: ADT75 project")
Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>