### PR TITLE
network: tcp_socket: initialization updates

### DIFF
--- a/network/tcp_socket.c
+++ b/network/tcp_socket.c
@@ -199,7 +199,7 @@ static int32_t stcp_socket_init(struct secure_socket_desc **desc,
 		mbedtls_ssl_conf_ca_chain(&ldesc->conf, &ldesc->cacert, NULL );
 		/* Verify server identity */
 		mbedtls_ssl_conf_authmode(&ldesc->conf,
-					  MBEDTLS_SSL_VERIFY_REQUIRED);
+					  param->cert_verify_mode);
 	} else {
 		/* Do not verify server identity */
 		mbedtls_ssl_conf_authmode(&ldesc->conf,

--- a/network/tcp_socket.c
+++ b/network/tcp_socket.c
@@ -242,6 +242,10 @@ static int32_t stcp_socket_init(struct secure_socket_desc **desc,
 	if (NO_OS_IS_ERR_VALUE(ret))
 		goto exit;
 
+	ret = mbedtls_ssl_set_hostname(&ldesc->ssl, param->hostname);
+	if (NO_OS_IS_ERR_VALUE(ret))
+		goto exit;
+
 	/* Set socket callbacks */
 	mbedtls_ssl_set_bio(&ldesc->ssl, sock,
 			    (mbedtls_ssl_send_t *)tls_net_send,

--- a/network/tcp_socket.c
+++ b/network/tcp_socket.c
@@ -169,6 +169,7 @@ static int32_t stcp_socket_init(struct secure_socket_desc **desc,
 	mbedtls_x509_crt_init(&ldesc->cacert);
 	mbedtls_x509_crt_init(&ldesc->clicert);
 	mbedtls_pk_init(&ldesc->pkey);
+	mbedtls_ssl_init(&ldesc->ssl);
 
 	ret = no_os_trng_init(&ldesc->trng, param->trng_init_param);
 	if (NO_OS_IS_ERR_VALUE(ret)) {

--- a/network/tcp_socket.h
+++ b/network/tcp_socket.h
@@ -67,6 +67,8 @@ struct tcp_socket_desc;
 struct secure_init_param {
 	/** Init param for true random number generator */
 	struct no_os_trng_init_param	*trng_init_param;
+	/** Server Hostname */
+	uint8_t			*hostname;
 	/**
 	  * Certificate authority certificate.
 	  * If set, server identity will be verified, otherwise not.

--- a/network/tcp_socket.h
+++ b/network/tcp_socket.h
@@ -69,6 +69,14 @@ struct secure_init_param {
 	struct no_os_trng_init_param	*trng_init_param;
 	/** Server Hostname */
 	uint8_t			*hostname;
+	/** Certificate Verification Mode:
+	 * MBEDTLS_SSL_VERIFY_NONE: peer certificate is not checked
+	 * MBEDTLS_SSL_VERIFY_OPTIONAL: peer certificate is checked, however the
+	 * handshake continues even if verification failed;
+	 * MBEDTLS_SSL_VERIFY_REQUIRED: peer *must* present a valid certificate,
+	 * handshake is aborted if verification failed.
+	 */
+	int			cert_verify_mode;
 	/**
 	  * Certificate authority certificate.
 	  * If set, server identity will be verified, otherwise not.


### PR DESCRIPTION
- network:tcp_socket: set hostname
- network:tcp_socket: init SSL context
- network:tcp_socket: do not force cert verify

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>