### PR TITLE
drivers:platform:stm32:stm32_uart.c Fill desc

### DIFF
--- a/drivers/platform/stm32/stm32_uart.c
+++ b/drivers/platform/stm32/stm32_uart.c
@@ -162,6 +162,9 @@ static int32_t stm32_uart_init(struct no_os_uart_desc **desc,
 		}
 	}
 
+	descriptor->device_id = param->device_id;
+	descriptor->baud_rate = param->baud_rate;
+
 	*desc = descriptor;
 
 	return 0;


### PR DESCRIPTION
Populate all the members of no_os_uart_desc in stm32_uart_init.

Signed-off-by: George Mois <george.mois@analog.com>