### PR TITLE
scripts:generic_variables.mk Fix NO_OS_VERSION

### DIFF
--- a/iio/iio.c
+++ b/iio/iio.c
@@ -73,6 +73,9 @@
 #define IIOD_CONN_BUFFER_SIZE	0x1000
 #define NO_TRIGGER				(uint32_t)-1
 
+#define NO_OS_STRINGIFY(x) #x
+#define NO_OS_TOSTRING(x) NO_OS_STRINGIFY(x)
+
 /******************************************************************************/
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
@@ -99,7 +102,8 @@ static char header[] =
 	"<!ATTLIST debug-attribute name CDATA #REQUIRED>"
 	"<!ATTLIST buffer-attribute name CDATA #REQUIRED>"
 	"]>"
-	"<context name=\"xml\" description=\"no-OS " NO_OS_VERSION "\" >";
+	"<context name=\"xml\" description=\"no-OS "
+	NO_OS_TOSTRING(NO_OS_VERSION) "\" >";
 static char header_end[] = "</context>";
 
 static const char * const iio_chan_type_string[] = {

--- a/tools/scripts/generic_variables.mk
+++ b/tools/scripts/generic_variables.mk
@@ -29,7 +29,7 @@ PLATFORM_DRIVERS	?= $(NO-OS)/drivers/platform/$(PLATFORM)
 GIT_VERSION := $(shell git describe --all --long --dirty=-modified)
 GIT_VERSION := $(subst heads/,,$(GIT_VERSION))
 GIT_VERSION := $(subst -0-g,-,$(GIT_VERSION))
-CFLAGS += -D NO_OS_VERSION=\"$(GIT_VERSION)\"
+CFLAGS += -DNO_OS_VERSION=$(GIT_VERSION)
 #------------------------------------------------------------------------------
 #                          EVALUATE PLATFORM
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Rewrite the NO_OS_VERSION compiler define and modify iio.c so that it is correctly included in the xml header.

Fixes: fdfaea1c8a6e

Signed-off-by: George Mois <george.mois@analog.com>