### PR TITLE
Use port in no_os_gpio_init_param in STM32 platforms

### DIFF
--- a/drivers/platform/stm32/stm32_gpio.c
+++ b/drivers/platform/stm32/stm32_gpio.c
@@ -58,6 +58,8 @@ static int32_t _gpio_init(struct no_os_gpio_desc *desc,
 	int32_t ret = 0;
 	struct stm32_gpio_desc *extra = desc->extra;
 	struct stm32_gpio_init_param *pextra = param->extra;
+	uint32_t mode = GPIO_MODE_INPUT;
+	uint32_t speed = GPIO_SPEED_FREQ_LOW;
 
 	if (!param)
 		return -EINVAL;
@@ -112,10 +114,15 @@ static int32_t _gpio_init(struct no_os_gpio_desc *desc,
 	else
 		return -EINVAL;
 
-	if (!IS_GPIO_MODE(pextra->mode))
+	if (param->extra) {
+		mode = pextra->mode;
+		speed = pextra->speed;
+	}
+
+	if (!IS_GPIO_MODE(mode))
 		return -EINVAL;
 
-	switch (pextra->mode) {
+	switch (mode) {
 	case GPIO_MODE_INPUT:
 	case GPIO_MODE_OUTPUT_PP:
 	case GPIO_MODE_OUTPUT_OD:
@@ -147,8 +154,8 @@ static int32_t _gpio_init(struct no_os_gpio_desc *desc,
 
 	/* configure gpio with user configuration */
 	extra->gpio_config.Pin = NO_OS_BIT(param->number);
-	extra->gpio_config.Mode = pextra->mode;
-	extra->gpio_config.Speed = pextra->speed;
+	extra->gpio_config.Mode = mode;
+	extra->gpio_config.Speed = speed;
 
 	HAL_GPIO_Init(extra->port, &extra->gpio_config);
 

--- a/drivers/platform/stm32/stm32_gpio.c
+++ b/drivers/platform/stm32/stm32_gpio.c
@@ -118,6 +118,7 @@ static int32_t _gpio_init(struct no_os_gpio_desc *desc,
 	switch (pextra->mode) {
 	case GPIO_MODE_INPUT:
 	case GPIO_MODE_OUTPUT_PP:
+	case GPIO_MODE_OUTPUT_OD:
 		break;
 	default:
 		return -EINVAL;
@@ -277,7 +278,8 @@ int32_t stm32_gpio_direction_output(struct no_os_gpio_desc *desc,
 	HAL_GPIO_WritePin(extra->port, NO_OS_BIT(desc->number), (GPIO_PinState)value);
 
 	/* configure gpio with user configuration */
-	extra->gpio_config.Mode = GPIO_MODE_OUTPUT_PP;
+	if (extra->gpio_config.Mode == GPIO_MODE_INPUT)
+		extra->gpio_config.Mode = GPIO_MODE_OUTPUT_PP;
 	HAL_GPIO_Init(extra->port, &extra->gpio_config);
 
 	return 0;
@@ -298,8 +300,10 @@ int32_t stm32_gpio_get_direction(struct no_os_gpio_desc *desc,
 		return -EINVAL;
 
 	struct stm32_gpio_desc *extra = desc->extra;
-	*direction = (extra->gpio_config.Mode & GPIO_MODE_OUTPUT_PP) ? NO_OS_GPIO_OUT :
-		     NO_OS_GPIO_IN;
+	if (!extra->gpio_config.Mode)
+		*direction = NO_OS_GPIO_IN;
+	else
+		*direction = NO_OS_GPIO_OUT;
 	return 0;
 }
 

--- a/drivers/platform/stm32/stm32_gpio.c
+++ b/drivers/platform/stm32/stm32_gpio.c
@@ -63,35 +63,51 @@ static int32_t _gpio_init(struct no_os_gpio_desc *desc,
 		return -EINVAL;
 
 	/* enable gpio port in RCC */
-	if (pextra->port == GPIOA)
+	if (param->port == 0) {
 		__HAL_RCC_GPIOA_CLK_ENABLE();
+		extra->port = GPIOA;
+	}
 #ifdef GPIOB
-	else if (pextra->port == GPIOB)
+	else if (param->port == 1) {
 		__HAL_RCC_GPIOB_CLK_ENABLE();
+		extra->port = GPIOB;
+	}
 #endif
 #ifdef GPIOC
-	else if (pextra->port == GPIOC)
+	else if (param->port == 2) {
 		__HAL_RCC_GPIOC_CLK_ENABLE();
+		extra->port = GPIOC;
+	}
 #endif
 #ifdef GPIOD
-	else if (pextra->port == GPIOD)
+	else if (param->port == 3) {
 		__HAL_RCC_GPIOD_CLK_ENABLE();
+		extra->port = GPIOD;
+	}
 #endif
 #ifdef GPIOE
-	else if (pextra->port == GPIOE)
+	else if (param->port == 4) {
 		__HAL_RCC_GPIOE_CLK_ENABLE();
+		extra->port = GPIOE;
+	}
 #endif
 #ifdef GPIOF
-	else if (pextra->port == GPIOF)
+	else if (param->port == 5) {
 		__HAL_RCC_GPIOF_CLK_ENABLE();
+		extra->port = GPIOF;
+	}
 #endif
 #ifdef GPIOG
-	else if (pextra->port == GPIOG)
+	else if (param->port == 6) {
 		__HAL_RCC_GPIOG_CLK_ENABLE();
+		extra->port = GPIOG;
+	}
 #endif
 #ifdef GPIOH
-	else if (pextra->port == GPIOH)
+	else if (param->port == 7) {
 		__HAL_RCC_GPIOH_CLK_ENABLE();
+		extra->port = GPIOH;
+	}
 #endif
 	else
 		return -EINVAL;
@@ -108,9 +124,9 @@ static int32_t _gpio_init(struct no_os_gpio_desc *desc,
 	}
 
 	/* copy the settings to gpio descriptor */
+	desc->port = param->port;
 	desc->number = param->number;
 	desc->pull = param->pull;
-	extra->port = pextra->port;
 
 	switch (param->pull) {
 	case NO_OS_PULL_NONE:

--- a/drivers/platform/stm32/stm32_gpio.h
+++ b/drivers/platform/stm32/stm32_gpio.h
@@ -48,8 +48,6 @@
  * @brief Structure holding the initialization parameters for stm32 platform
  */
 struct stm32_gpio_init_param {
-	/** Port */
-	GPIO_TypeDef *port;
 	/** Output mode */
 	uint32_t mode;
 	/** Speed grade */

--- a/drivers/platform/stm32/stm32_spi.c
+++ b/drivers/platform/stm32/stm32_spi.c
@@ -186,9 +186,9 @@ int32_t stm32_spi_init(struct no_os_spi_desc **desc,
 	spi_desc->extra = sdesc;
 	sinit = param->extra;
 
-	csip_extra.port = sinit->chip_select_port;
 	csip_extra.mode = GPIO_MODE_OUTPUT_PP;
 	csip_extra.speed = GPIO_SPEED_FREQ_LOW;
+	csip.port = sinit->chip_select_port;
 	csip.number = param->chip_select;
 	csip.pull = NO_OS_PULL_NONE;
 	csip.extra = &csip_extra;

--- a/drivers/platform/stm32/stm32_spi.h
+++ b/drivers/platform/stm32/stm32_spi.h
@@ -50,7 +50,7 @@
  */
 struct stm32_spi_init_param {
 	/** Chip select port */
-	GPIO_TypeDef *chip_select_port;
+	uint32_t chip_select_port;
 	/** Get perihperal source clock function */
 	uint32_t (*get_input_clock)(void);
 };

--- a/projects/ad74413r/src/platform/stm32/parameters.h
+++ b/projects/ad74413r/src/platform/stm32/parameters.h
@@ -70,7 +70,7 @@ extern UART_HandleTypeDef huart3;
 #define SPI_DEVICE_ID   1
 #define SPI_BAUDRATE    1000000
 #define SPI_CS          14
-#define SPI_CS_PORT     GPIOD
+#define SPI_CS_PORT     3
 #define SPI_OPS         &stm32_spi_ops
 #define SPI_EXTRA       &ad74413r_spi_extra_ip
 

--- a/projects/adxrs290-pmdz/src/platform/stm32/parameters.c
+++ b/projects/adxrs290-pmdz/src/platform/stm32/parameters.c
@@ -51,6 +51,5 @@ struct stm32_spi_init_param adxrs290_spi_extra_ip  = {
 
 struct stm32_gpio_init_param adxrs290_gpio_extra_ip = {
 	.mode = GPIO_MODE_INPUT,
-	.port = GPIOA,
 	.speed = GPIO_SPEED_FREQ_VERY_HIGH,
 };

--- a/projects/adxrs290-pmdz/src/platform/stm32/parameters.h
+++ b/projects/adxrs290-pmdz/src/platform/stm32/parameters.h
@@ -65,7 +65,7 @@ extern UART_HandleTypeDef huart5;
 #define SPI_DEVICE_ID   1
 #define SPI_BAUDRATE    4000000
 #define SPI_CS          15
-#define SPI_CS_PORT     GPIOA
+#define SPI_CS_PORT     0
 #define SPI_OPS         &stm32_spi_ops
 #define SPI_EXTRA       &adxrs290_spi_extra_ip
 

--- a/projects/cn0565/src/app/main.c
+++ b/projects/cn0565/src/app/main.c
@@ -176,12 +176,12 @@ int main(void)
 
 #if defined(STM32_PLATFORM)
 	struct stm32_gpio_init_param reset_xgip = {
-		.port = GPIOD,
 		.mode = GPIO_MODE_OUTPUT_PP,
 		.speed = GPIO_SPEED_FREQ_VERY_HIGH,
 	};
 #endif
 	struct no_os_gpio_init_param reset_gip = {
+		.port = 3,
 		.number = RESET_PIN,
 		.pull = NO_OS_PULL_NONE,
 #if defined(STM32_PLATFORM)
@@ -194,13 +194,13 @@ int main(void)
 
 #if defined(STM32_PLATFORM)
 	struct stm32_gpio_init_param gp0_xgip = {
-		.port = GPIOG,
 		.mode = GPIO_MODE_INPUT,
 		.speed = GPIO_SPEED_FREQ_VERY_HIGH,
 	};
 #endif
 
 	struct no_os_gpio_init_param gp0_gip = {
+		.port = 6,
 		.number = GP0_PIN,
 		.pull = NO_OS_PULL_NONE,
 #if defined(STM32_PLATFORM)

--- a/projects/cn0565/src/app/parameters.h
+++ b/projects/cn0565/src/app/parameters.h
@@ -62,7 +62,7 @@
 
 #define SPI_DEVICE_ID		1
 #define SPI_CS			15
-#define SPI_CS_PORT		GPIOA
+#define SPI_CS_PORT		0
 #define INTC_DEVICE_ID		0
 #define INT_IRQn		EXTI9_5_IRQn
 #define UART_DEVICE_ID		5

--- a/projects/eval-adxl313z/src/platform/stm32/parameters.h
+++ b/projects/eval-adxl313z/src/platform/stm32/parameters.h
@@ -66,7 +66,7 @@ extern UART_HandleTypeDef huart2;
 
 #define SPI_DEVICE_ID    1
 #define SPI_CS          4
-#define SPI_CS_PORT     GPIOA
+#define SPI_CS_PORT     0
 #define SPI_OPS         &stm32_spi_ops
 
 extern struct stm32_uart_init_param xuip;

--- a/projects/eval-adxl355-pmdz/src/platform/stm32/parameters.h
+++ b/projects/eval-adxl355-pmdz/src/platform/stm32/parameters.h
@@ -70,7 +70,7 @@ extern UART_HandleTypeDef huart5;
 #define SPI_DEVICE_ID   1
 #define SPI_BAUDRATE    4000000
 #define SPI_CS          15
-#define SPI_CS_PORT     GPIOA
+#define SPI_CS_PORT     0
 #define SPI_OPS         &stm32_spi_ops
 #define SPI_EXTRA       &adxl355_spi_extra_ip
 


### PR DESCRIPTION
Use port in no_os_gpio_init_param in GPIO initialization for STM32 platforms and remove port from stm32_gpio_init_param.