### PR TITLE
drivers:platform:stm32 Stop bit implementation.

### DIFF
--- a/drivers/platform/stm32/stm32_i2c.c
+++ b/drivers/platform/stm32/stm32_i2c.c
@@ -162,12 +162,15 @@ int32_t stm32_i2c_write(struct no_os_i2c_desc *desc,
 
 	xdesc = desc->extra;
 
-	// TODO: implement no stop bit
-	if (!stop_bit)
-		return -EINVAL;
+	if (!stop_bit) {
+		ret = HAL_I2C_Master_Seq_Transmit_IT(&xdesc->hi2c, desc->slave_address << 1,
+						     data,
+						     bytes_number, I2C_FIRST_FRAME);
+	} else {
+		ret = HAL_I2C_Master_Transmit(&xdesc->hi2c, desc->slave_address << 1, data,
+					      bytes_number, HAL_MAX_DELAY);
+	}
 
-	ret = HAL_I2C_Master_Transmit(&xdesc->hi2c, desc->slave_address << 1, data,
-				      bytes_number, HAL_MAX_DELAY);
 	if (ret != HAL_OK)
 		return -EIO;
 
@@ -196,12 +199,15 @@ int32_t stm32_i2c_read(struct no_os_i2c_desc *desc,
 
 	xdesc = desc->extra;
 
-	// TODO: implement no stop bit
-	if (!stop_bit)
-		return -EINVAL;
+	if (!stop_bit) {
+		ret = HAL_I2C_Master_Seq_Receive_IT(&xdesc->hi2c, desc->slave_address << 1,
+						    data,
+						    bytes_number, I2C_LAST_FRAME);
+	} else {
+		ret = HAL_I2C_Master_Receive(&xdesc->hi2c, desc->slave_address << 1, data,
+					     bytes_number, HAL_MAX_DELAY);
+	}
 
-	ret = HAL_I2C_Master_Receive(&xdesc->hi2c, desc->slave_address << 1, data,
-				     bytes_number, HAL_MAX_DELAY);
 	if (ret != HAL_OK)
 		return -EIO;
 


### PR DESCRIPTION
In order to read the board info from 24xx32a eeprom on the adi eval boards, repeated start condition is required. Hence, implemented I2C transaction with repeated start or stop bit option for stm32 platform.

Signed-off-by: Pratyush Mallick <Pratyush.Mallick@analog.com>