### PR TITLE
drivers:photo-electronic:iio_adpd188: scan index

### DIFF
--- a/drivers/photo-electronic/adpd188/iio_adpd188.c
+++ b/drivers/photo-electronic/adpd188/iio_adpd188.c
@@ -103,6 +103,7 @@ struct scan_type adpd188_iio_scan_type = {
 		.name = nm, \
 		.ch_type = IIO_CURRENT, \
 		.channel = ch1, \
+		.scan_index = ch1, \
 		.scan_type = &adpd188_iio_scan_type, \
 		.attributes = adpd188_channel_attributes, \
 		.indexed = 1, \


### PR DESCRIPTION
Add scan_index property to the iio adpd188 channel definition such that the iio channels are properly indexed.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>