### PR TITLE
Remove IRQ dependency on RTC

### DIFF
--- a/drivers/platform/maxim/max32650/maxim_irq.c
+++ b/drivers/platform/maxim/max32650/maxim_irq.c
@@ -49,12 +49,10 @@
 #include "uart.h"
 #include "tmr.h"
 #include "maxim_irq.h"
-#include "maxim_rtc.h"
 #include "max32650.h"
 #include "no_os_irq.h"
 #include "no_os_list.h"
 #include "no_os_uart.h"
-#include "no_os_rtc.h"
 #include "no_os_util.h"
 
 static struct event_list _events[] = {

--- a/drivers/platform/maxim/max32655/maxim_irq.c
+++ b/drivers/platform/maxim/max32655/maxim_irq.c
@@ -49,12 +49,10 @@
 #include "uart.h"
 #include "tmr.h"
 #include "maxim_irq.h"
-#include "maxim_rtc.h"
 #include "max32655.h"
 #include "no_os_irq.h"
 #include "no_os_list.h"
 #include "no_os_uart.h"
-#include "no_os_rtc.h"
 #include "no_os_util.h"
 
 static struct event_list _events[] = {

--- a/drivers/platform/maxim/max32660/maxim_irq.c
+++ b/drivers/platform/maxim/max32660/maxim_irq.c
@@ -49,12 +49,10 @@
 #include "uart.h"
 #include "tmr.h"
 #include "maxim_irq.h"
-#include "maxim_rtc.h"
 #include "max32660.h"
 #include "no_os_irq.h"
 #include "no_os_list.h"
 #include "no_os_uart.h"
-#include "no_os_rtc.h"
 #include "no_os_util.h"
 
 static struct event_list _events[] = {

--- a/drivers/platform/maxim/max32665/maxim_irq.c
+++ b/drivers/platform/maxim/max32665/maxim_irq.c
@@ -49,12 +49,10 @@
 #include "uart.h"
 #include "tmr.h"
 #include "maxim_irq.h"
-#include "maxim_rtc.h"
 #include "max32665.h"
 #include "no_os_irq.h"
 #include "no_os_list.h"
 #include "no_os_uart.h"
-#include "no_os_rtc.h"
 #include "no_os_util.h"
 
 static struct event_list _events[] = {

--- a/drivers/platform/maxim/max32670/maxim_irq.c
+++ b/drivers/platform/maxim/max32670/maxim_irq.c
@@ -49,12 +49,10 @@
 #include "uart.h"
 #include "tmr.h"
 #include "maxim_irq.h"
-#include "maxim_rtc.h"
 #include "max32670.h"
 #include "no_os_irq.h"
 #include "no_os_list.h"
 #include "no_os_uart.h"
-#include "no_os_rtc.h"
 #include "no_os_util.h"
 
 static struct event_list _events[] = {

--- a/drivers/platform/maxim/max78000/maxim_irq.c
+++ b/drivers/platform/maxim/max78000/maxim_irq.c
@@ -49,12 +49,10 @@
 #include "uart.h"
 #include "tmr.h"
 #include "maxim_irq.h"
-#include "maxim_rtc.h"
 #include "max78000.h"
 #include "no_os_irq.h"
 #include "no_os_list.h"
 #include "no_os_uart.h"
-#include "no_os_rtc.h"
 #include "no_os_util.h"
 
 static struct event_list _events[] = {

--- a/projects/ad74413r/src/platform/maxim/platform_src.mk
+++ b/projects/ad74413r/src/platform/maxim/platform_src.mk
@@ -1,19 +1,15 @@
-INCS += $(INCLUDE)/no_os_rtc.h
-
 INCS += $(PLATFORM_DRIVERS)/maxim_delay.h     \
         $(PLATFORM_DRIVERS)/maxim_gpio.h      \
         $(PLATFORM_DRIVERS)/maxim_hal.h       \
         $(PLATFORM_DRIVERS)/maxim_spi.h       \
         $(PLATFORM_DRIVERS)/maxim_gpio_irq.h  \
         $(PLATFORM_DRIVERS)/maxim_irq.h       \
-        $(PLATFORM_DRIVERS)/maxim_rtc.h       \
         $(PLATFORM_DRIVERS)/maxim_uart.h      \
         $(PLATFORM_DRIVERS)/maxim_uart_stdio.h
 
 SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c     \
         $(PLATFORM_DRIVERS)/maxim_gpio.c      \
         $(PLATFORM_DRIVERS)/maxim_spi.c       \
-        $(PLATFORM_DRIVERS)/maxim_rtc.c       \
         $(PLATFORM_DRIVERS)/maxim_gpio_irq.c  \
         $(PLATFORM_DRIVERS)/maxim_irq.c       \
         $(PLATFORM_DRIVERS)/maxim_uart.c      \

--- a/projects/adt75/src/platform/maxim/platform_src.mk
+++ b/projects/adt75/src/platform/maxim/platform_src.mk
@@ -2,7 +2,6 @@ INCS += $(PLATFORM_DRIVERS)/maxim_delay.h       \
         $(PLATFORM_DRIVERS)/maxim_hal.h         \
         $(PLATFORM_DRIVERS)/maxim_i2c.h         \
         $(PLATFORM_DRIVERS)/maxim_irq.h         \
-        $(PLATFORM_DRIVERS)/maxim_rtc.h         \
         $(PLATFORM_DRIVERS)/maxim_gpio.h        \
         $(PLATFORM_DRIVERS)/maxim_uart.h        \
         $(PLATFORM_DRIVERS)/maxim_uart_stdio.h
@@ -11,6 +10,5 @@ SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c     \
         $(PLATFORM_DRIVERS)/maxim_i2c.c       \
         $(PLATFORM_DRIVERS)/maxim_irq.c       \
         $(PLATFORM_DRIVERS)/maxim_gpio.c      \
-        $(PLATFORM_DRIVERS)/maxim_rtc.c       \
         $(PLATFORM_DRIVERS)/maxim_uart.c      \
         $(PLATFORM_DRIVERS)/maxim_uart_stdio.c

--- a/projects/adxrs290-pmdz/src/platform/maxim/platform_src.mk
+++ b/projects/adxrs290-pmdz/src/platform/maxim/platform_src.mk
@@ -1,18 +1,14 @@
-INCS += $(INCLUDE)/no_os_rtc.h
-
 INCS += $(PLATFORM_DRIVERS)/maxim_delay.h     \
         $(PLATFORM_DRIVERS)/maxim_gpio.h      \
         $(PLATFORM_DRIVERS)/maxim_spi.h       \
         $(PLATFORM_DRIVERS)/maxim_gpio_irq.h  \
         $(PLATFORM_DRIVERS)/maxim_irq.h       \
-        $(PLATFORM_DRIVERS)/maxim_rtc.h       \
         $(PLATFORM_DRIVERS)/maxim_uart.h      \
         $(PLATFORM_DRIVERS)/maxim_uart_stdio.h
 
 SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c     \
         $(PLATFORM_DRIVERS)/maxim_gpio.c      \
         $(PLATFORM_DRIVERS)/maxim_spi.c       \
-        $(PLATFORM_DRIVERS)/maxim_rtc.c       \
         $(PLATFORM_DRIVERS)/maxim_gpio_irq.c  \
         $(PLATFORM_DRIVERS)/maxim_irq.c       \
         $(PLATFORM_DRIVERS)/maxim_uart.c      \

--- a/projects/eval-adxl313z/src/platform/maxim/platform_src.mk
+++ b/projects/eval-adxl313z/src/platform/maxim/platform_src.mk
@@ -1,18 +1,14 @@
-INCS += $(INCLUDE)/no_os_rtc.h
-
 INCS += $(PLATFORM_DRIVERS)/maxim_delay.h     \
         $(PLATFORM_DRIVERS)/maxim_gpio.h      \
         $(PLATFORM_DRIVERS)/maxim_spi.h       \
         $(PLATFORM_DRIVERS)/maxim_gpio_irq.h  \
         $(PLATFORM_DRIVERS)/maxim_irq.h       \
-        $(PLATFORM_DRIVERS)/maxim_rtc.h       \
         $(PLATFORM_DRIVERS)/maxim_uart.h      \
         $(PLATFORM_DRIVERS)/maxim_uart_stdio.h
 
 SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c     \
         $(PLATFORM_DRIVERS)/maxim_gpio.c      \
         $(PLATFORM_DRIVERS)/maxim_spi.c       \
-        $(PLATFORM_DRIVERS)/maxim_rtc.c       \
         $(PLATFORM_DRIVERS)/maxim_gpio_irq.c  \
         $(PLATFORM_DRIVERS)/maxim_irq.c       \
         $(PLATFORM_DRIVERS)/maxim_uart.c      \

--- a/projects/eval-adxl355-pmdz/src/platform/maxim/platform_src.mk
+++ b/projects/eval-adxl355-pmdz/src/platform/maxim/platform_src.mk
@@ -1,18 +1,14 @@
-INCS += $(INCLUDE)/no_os_rtc.h
-
 INCS += $(PLATFORM_DRIVERS)/maxim_delay.h     \
         $(PLATFORM_DRIVERS)/maxim_gpio.h      \
         $(PLATFORM_DRIVERS)/maxim_spi.h       \
         $(PLATFORM_DRIVERS)/maxim_gpio_irq.h  \
         $(PLATFORM_DRIVERS)/maxim_irq.h       \
-        $(PLATFORM_DRIVERS)/maxim_rtc.h       \
         $(PLATFORM_DRIVERS)/maxim_uart.h      \
         $(PLATFORM_DRIVERS)/maxim_uart_stdio.h
 
 SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c     \
         $(PLATFORM_DRIVERS)/maxim_gpio.c      \
         $(PLATFORM_DRIVERS)/maxim_spi.c       \
-        $(PLATFORM_DRIVERS)/maxim_rtc.c       \
         $(PLATFORM_DRIVERS)/maxim_gpio_irq.c  \
         $(PLATFORM_DRIVERS)/maxim_irq.c       \
         $(PLATFORM_DRIVERS)/maxim_uart.c      \

--- a/projects/iio_demo/src/platform/maxim/platform_src.mk
+++ b/projects/iio_demo/src/platform/maxim/platform_src.mk
@@ -1,8 +1,5 @@
-INCS += $(INCLUDE)/no_os_rtc.h
-
 SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c	\
 	$(PLATFORM_DRIVERS)/maxim_irq.c		\
-	$(PLATFORM_DRIVERS)/maxim_rtc.c		\
 	$(PLATFORM_DRIVERS)/maxim_timer.c	\
 	$(PLATFORM_DRIVERS)/maxim_uart.c	\
 	$(PLATFORM_DRIVERS)/maxim_uart_stdio.c
@@ -10,7 +7,6 @@ SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c	\
 INCS += $(PLATFORM_DRIVERS)/maxim_irq.h		\
 	$(PLATFORM_DRIVERS)/maxim_uart.h	\
 	$(PLATFORM_DRIVERS)/maxim_timer.h	\
-	$(PLATFORM_DRIVERS)/maxim_rtc.h		\
 	$(PLATFORM_DRIVERS)/maxim_uart_stdio.h
 
 INCS += $(INCLUDE)/no_os_irq.h

--- a/projects/max11205pmb1/src/platform/maxim/platform_src.mk
+++ b/projects/max11205pmb1/src/platform/maxim/platform_src.mk
@@ -1,18 +1,14 @@
-INCS += $(INCLUDE)/no_os_rtc.h
-
 INCS += $(PLATFORM_DRIVERS)/maxim_delay.h     \
         $(PLATFORM_DRIVERS)/maxim_gpio.h      \
         $(PLATFORM_DRIVERS)/maxim_spi.h       \
         $(PLATFORM_DRIVERS)/maxim_gpio_irq.h  \
         $(PLATFORM_DRIVERS)/maxim_irq.h       \
-        $(PLATFORM_DRIVERS)/maxim_rtc.h       \
         $(PLATFORM_DRIVERS)/maxim_uart.h      \
         $(PLATFORM_DRIVERS)/maxim_uart_stdio.h
 
 SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c     \
         $(PLATFORM_DRIVERS)/maxim_gpio.c      \
         $(PLATFORM_DRIVERS)/maxim_spi.c       \
-        $(PLATFORM_DRIVERS)/maxim_rtc.c       \
         $(PLATFORM_DRIVERS)/maxim_gpio_irq.c  \
         $(PLATFORM_DRIVERS)/maxim_irq.c       \
         $(PLATFORM_DRIVERS)/maxim_uart.c      \


### PR DESCRIPTION
None of the no-OS specific RTC API was used for the interrupt driver, thus this dependency should be removed.