### PR TITLE
tools: scripts: fix mbedtls integration

### DIFF
--- a/tools/scripts/libraries.mk
+++ b/tools/scripts/libraries.mk
@@ -71,7 +71,7 @@ include $(NO-OS)/tools/scripts/mqtt_srcs.mk
 
 endif
 
-LIB_TARGETS			+= $(IIO_LIB) $(MBEDTLS_TARGETS) $(FATFS_LIB) $(MQTT_LIB)
+LIB_TARGETS			+= $(IIO_LIB) $(MBEDTLS_LIBS) $(FATFS_LIB) $(MQTT_LIB)
 EXTRA_LIBS_NAMES	= $(subst lib,,$(basename $(notdir $(EXTRA_LIBS))))
 LIB_FLAGS			+= $(addprefix -l,$(EXTRA_LIBS_NAMES))
 LIB_PATHS			+= $(addprefix -L,$(EXTRA_LIBS_PATHS))


### PR DESCRIPTION
Use the proper lib target variable for the mbedtls library.

Fixes: d842815 ("tools:scripts: Move libraries code to libraries.mk")
Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>