### PR TITLE
Set correct baud for iio application for the ad9361 project

### DIFF
--- a/projects/ad9361/src/parameters.h
+++ b/projects/ad9361/src/parameters.h
@@ -48,7 +48,11 @@
 /******************************************************************************/
 /********************** Macros and Constants Definitions **********************/
 /******************************************************************************/
+#ifdef _XPARAMETERS_PS_H_
 #define UART_BAUDRATE 921600
+#else
+#define UART_BAUDRATE 115200
+#endif
 #ifdef XPAR_AXI_AD9361_0_BASEADDR
 #define AD9361_RX_0_BASEADDR		XPAR_AXI_AD9361_0_BASEADDR
 #define AD9361_TX_0_BASEADDR		XPAR_AXI_AD9361_0_BASEADDR + 0x4000


### PR DESCRIPTION
Set  baudrate of 115200 for IIO application on MB platforms.

Signed-off-by: George Mois <george.mois@analog.com>