### PR TITLE
platform: pico: pico_gpio: Fix implementation for gpio dir set

### DIFF
--- a/drivers/platform/pico/pico_gpio.c
+++ b/drivers/platform/pico/pico_gpio.c
@@ -178,7 +178,7 @@ int32_t pico_gpio_direction_input(struct no_os_gpio_desc *desc)
 
 	pico_gpio = desc->extra;
 
-	gpio_set_input_enabled(desc->number, true);
+	gpio_set_dir(desc->number, false);
 	pico_gpio->input_enabled = true;
 
 	return 0;
@@ -202,8 +202,10 @@ int32_t pico_gpio_direction_output(struct no_os_gpio_desc *desc,
 
 	pico_gpio = desc->extra;
 
-	gpio_set_input_enabled(desc->number, false);
+	gpio_set_dir(desc->number, true);
 	pico_gpio->input_enabled = false;
+
+	gpio_put(desc->number, value == NO_OS_GPIO_HIGH ? true : false);
 
 	return 0;
 }


### PR DESCRIPTION
Fix implementation for setting gpio direction.
Use gpio_set_dir API instead of gpio_set_input_enabled.

Fixes: 8db5be8 ("platform:pico Add gpio driver")
Signed-off-by: Ramona Bolboaca <ramona.bolboaca@analog.com>