### PR TITLE
display: nhd: fix function call for spi

### DIFF
--- a/drivers/display/nhd_c12832a1z/nhd_c12832a1z.c
+++ b/drivers/display/nhd_c12832a1z/nhd_c12832a1z.c
@@ -576,7 +576,7 @@ int nhd_c12832a1z_remove(struct nhd_c12832a1z_dev *dev)
 	if (ret)
 		return ret;
 
-	ret = no_os_gpio_remove(dev->spi_desc);
+	ret = no_os_spi_remove(dev->spi_desc);
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
Call `no_os_spi_remove` function for the spi descriptor.

Fixes: e88cc38 ("drivers: display: nhd_c12832a1z: initial commit")