### PR TITLE
tools: scripts: mbedtls: add custom setting

### DIFF
--- a/tools/scripts/libraries.mk
+++ b/tools/scripts/libraries.mk
@@ -39,6 +39,7 @@ $(MBEDTLS_LIB_DIR)/libmbedx509.a: $(MBEDTLS_LIB_DIR)/libmbedcrypto.a
 $(MBEDTLS_LIB_DIR)/libmbedtls.a: $(MBEDTLS_LIB_DIR)/libmbedx509.a
 
 # Custom settings
+CFLAGS 		+= -I$(MBEDTLS_DIR)/include
 CFLAGS 		+= -I$(dir $(MBED_TLS_CONFIG_FILE)) \
 			-DMBEDTLS_CONFIG_FILE=\"$(notdir $(MBED_TLS_CONFIG_FILE))\"
 else


### PR DESCRIPTION
Add extra CFLAG entry required for the noos_mbedtls_config.h include.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>