### PR TITLE
Add missing header

### DIFF
--- a/drivers/platform/maxim/max32650/maxim_gpio.h
+++ b/drivers/platform/maxim/max32650/maxim_gpio.h
@@ -44,6 +44,7 @@
 #include "no_os_irq.h"
 #include "no_os_gpio.h"
 #include "max32650.h"
+#include "gpio.h"
 
 #define N_PINS	MXC_CFG_GPIO_PINS_PORT
 #define N_PORTS	MXC_CFG_GPIO_INSTANCES

--- a/drivers/platform/maxim/max32650/maxim_spi.h
+++ b/drivers/platform/maxim/max32650/maxim_spi.h
@@ -42,6 +42,7 @@
 
 #include <stdint.h>
 #include "max32650.h"
+#include "gpio.h"
 
 /**
  * @brief maxim specific SPI platform ops structure

--- a/drivers/platform/maxim/max32655/maxim_gpio.h
+++ b/drivers/platform/maxim/max32655/maxim_gpio.h
@@ -44,6 +44,7 @@
 #include "no_os_irq.h"
 #include "no_os_gpio.h"
 #include "max32655.h"
+#include "gpio.h"
 
 #define N_PINS	MXC_CFG_GPIO_PINS_PORT
 #define N_PORTS	MXC_CFG_GPIO_INSTANCES

--- a/drivers/platform/maxim/max32655/maxim_i2c.h
+++ b/drivers/platform/maxim/max32655/maxim_i2c.h
@@ -44,6 +44,7 @@
 #include <stdint.h>
 #include "i2c_regs.h"
 #include "max32655.h"
+#include "gpio.h"
 
 /**
  * @struct max_i2c_extra

--- a/drivers/platform/maxim/max32655/maxim_spi.h
+++ b/drivers/platform/maxim/max32655/maxim_spi.h
@@ -42,6 +42,7 @@
 
 #include <stdint.h>
 #include "max32655.h"
+#include "gpio.h"
 
 /**
  * @brief maxim specific SPI platform ops structure

--- a/drivers/platform/maxim/max32655/maxim_uart.h
+++ b/drivers/platform/maxim/max32655/maxim_uart.h
@@ -44,6 +44,7 @@
 #include "no_os_irq.h"
 #include "max32655.h"
 #include "no_os_uart.h"
+#include "gpio.h"
 
 /**
  * @brief UART flow control

--- a/drivers/platform/maxim/max32660/maxim_gpio.h
+++ b/drivers/platform/maxim/max32660/maxim_gpio.h
@@ -44,6 +44,7 @@
 #include "no_os_irq.h"
 #include "no_os_gpio.h"
 #include "max32660.h"
+#include "gpio.h"
 
 #define N_PINS	MXC_CFG_GPIO_PINS_PORT
 #define N_PORTS	MXC_CFG_GPIO_INSTANCES

--- a/drivers/platform/maxim/max32660/maxim_i2c.h
+++ b/drivers/platform/maxim/max32660/maxim_i2c.h
@@ -44,6 +44,7 @@
 #include <stdint.h>
 #include "i2c_regs.h"
 #include "max32660.h"
+#include "gpio.h"
 
 /**
  * @struct max_i2c_extra

--- a/drivers/platform/maxim/max32660/maxim_spi.h
+++ b/drivers/platform/maxim/max32660/maxim_spi.h
@@ -42,6 +42,7 @@
 
 #include <stdint.h>
 #include "max32660.h"
+#include "gpio.h"
 
 /**
  * @brief maxim specific SPI platform ops structure

--- a/drivers/platform/maxim/max32660/maxim_uart.h
+++ b/drivers/platform/maxim/max32660/maxim_uart.h
@@ -44,6 +44,7 @@
 #include "no_os_irq.h"
 #include "max32660.h"
 #include "no_os_uart.h"
+#include "gpio.h"
 
 /**
  * @brief UART flow control

--- a/drivers/platform/maxim/max32665/maxim_gpio.h
+++ b/drivers/platform/maxim/max32665/maxim_gpio.h
@@ -44,6 +44,7 @@
 #include "no_os_irq.h"
 #include "no_os_gpio.h"
 #include "max32665.h"
+#include "gpio.h"
 
 #define N_PINS	MXC_CFG_GPIO_PINS_PORT
 #define N_PORTS	MXC_CFG_GPIO_INSTANCES

--- a/drivers/platform/maxim/max32665/maxim_i2c.h
+++ b/drivers/platform/maxim/max32665/maxim_i2c.h
@@ -44,6 +44,7 @@
 #include <stdint.h>
 #include "i2c_regs.h"
 #include "max32665.h"
+#include "gpio.h"
 
 /**
  * @struct max_i2c_extra

--- a/drivers/platform/maxim/max32665/maxim_spi.h
+++ b/drivers/platform/maxim/max32665/maxim_spi.h
@@ -41,6 +41,7 @@
 #define MAXIM_SPI_H_
 
 #include <stdint.h>
+#include "gpio.h"
 
 /**
  * @brief maxim specific SPI platform ops structure

--- a/drivers/platform/maxim/max32665/maxim_uart.h
+++ b/drivers/platform/maxim/max32665/maxim_uart.h
@@ -44,6 +44,7 @@
 #include "no_os_irq.h"
 #include "max32665.h"
 #include "no_os_uart.h"
+#include "gpio.h"
 
 /**
  * @brief UART flow control

--- a/drivers/platform/maxim/max32670/maxim_gpio.h
+++ b/drivers/platform/maxim/max32670/maxim_gpio.h
@@ -48,6 +48,7 @@
 #include "no_os_irq.h"
 #include "no_os_gpio.h"
 #include "max32670.h"
+#include "gpio.h"
 
 /******************************************************************************/
 /********************** Macros an Constants Definitions ***********************/

--- a/drivers/platform/maxim/max78000/maxim_gpio.h
+++ b/drivers/platform/maxim/max78000/maxim_gpio.h
@@ -44,6 +44,7 @@
 #include "no_os_irq.h"
 #include "no_os_gpio.h"
 #include "max78000.h"
+#include "gpio.h"
 
 #define N_PINS	MXC_CFG_GPIO_PINS_PORT
 #define N_PORTS	MXC_CFG_GPIO_INSTANCES

--- a/drivers/platform/maxim/max78000/maxim_i2c.h
+++ b/drivers/platform/maxim/max78000/maxim_i2c.h
@@ -44,6 +44,7 @@
 #include <stdint.h>
 #include "i2c_regs.h"
 #include "max78000.h"
+#include "gpio.h"
 
 #ifndef MXC_I2C_GET_I2C
 #define MXC_I2C_GET_I2C(i)	((i) == 0 ? MXC_I2C0 :		\

--- a/drivers/platform/maxim/max78000/maxim_spi.h
+++ b/drivers/platform/maxim/max78000/maxim_spi.h
@@ -41,6 +41,7 @@
 #define MAXIM_SPI_H_
 
 #include <stdint.h>
+#include "gpio.h"
 
 /**
  * @brief maxim specific SPI platform ops structure

--- a/drivers/platform/maxim/max78000/maxim_uart.h
+++ b/drivers/platform/maxim/max78000/maxim_uart.h
@@ -44,6 +44,7 @@
 #include "no_os_irq.h"
 #include "max78000.h"
 #include "no_os_uart.h"
+#include "gpio.h"
 
 /**
  * @brief UART flow control


### PR DESCRIPTION
The gpio.h header is required for the vssel configuration.