### PR TITLE
projects: Remove iio_desc pointer assignment

### DIFF
--- a/projects/ad74413r/src/examples/iio_trigger_example/iio_trigger_example.c
+++ b/projects/ad74413r/src/examples/iio_trigger_example/iio_trigger_example.c
@@ -70,7 +70,6 @@ int iio_trigger_example_main()
 	int ret;
 	struct iio_hw_trig *ad74413r_trig_desc;
 	struct no_os_irq_ctrl_desc *ad74413r_irq_desc;
-	struct iio_desc *iio_desc;
 	struct iio_app_desc *app;
 	struct iio_app_init_param app_init_param = { 0 };
 
@@ -120,7 +119,6 @@ int iio_trigger_example_main()
 	ad74413r_gpio_trig_ip.irq_ctrl = ad74413r_irq_desc;
 
 	/* Initialize hardware trigger */
-	ad74413r_gpio_trig_ip.iio_desc = &iio_desc,
 	ret = iio_hw_trig_init(&ad74413r_trig_desc, &ad74413r_gpio_trig_ip);
 	if (ret)
 		return ret;

--- a/projects/adxrs290-pmdz/src/examples/iio_timer_trigger_example/iio_timer_trigger_example.c
+++ b/projects/adxrs290-pmdz/src/examples/iio_timer_trigger_example/iio_timer_trigger_example.c
@@ -76,7 +76,6 @@ int iio_timer_trigger_example_main()
 	struct iio_hw_trig *adxrs290_trig_desc;
 	struct no_os_timer_desc *adxrs290_timer_desc;
 	struct no_os_irq_ctrl_desc *adxrs290_timer_irq_desc;
-	struct iio_desc *iio_desc;
 
 	ret = adxrs290_init(&adxrs290_desc, &adxrs290_ip);
 	if (ret)
@@ -101,7 +100,6 @@ int iio_timer_trigger_example_main()
 	adxrs290_timer_trig_ip.cb_info.handle = adxrs290_timer_desc;
 
 	/* Initialize hardware trigger */
-	adxrs290_timer_trig_ip.iio_desc = &iio_desc,
 	ret = iio_hw_trig_init(&adxrs290_trig_desc, &adxrs290_timer_trig_ip);
 	if (ret)
 		return ret;

--- a/projects/adxrs290-pmdz/src/examples/iio_trigger_example/iio_trigger_example.c
+++ b/projects/adxrs290-pmdz/src/examples/iio_trigger_example/iio_trigger_example.c
@@ -74,7 +74,6 @@ int iio_trigger_example_main()
 	};
 	struct iio_hw_trig *adxrs290_trig_desc;
 	struct no_os_irq_ctrl_desc *adxrs290_irq_desc;
-	struct iio_desc *iio_desc;
 
 	ret = adxrs290_init(&adxrs290_desc, &adxrs290_ip);
 	if (ret)
@@ -96,7 +95,6 @@ int iio_trigger_example_main()
 		return ret;
 
 	/* Initialize hardware trigger */
-	adxrs290_gpio_trig_ip.iio_desc = &iio_desc,
 	ret = iio_hw_trig_init(&adxrs290_trig_desc, &adxrs290_gpio_trig_ip);
 	if (ret)
 		return ret;

--- a/projects/iio_demo/src/examples/iio_timer_trigger_example/iio_timer_trigger_example.c
+++ b/projects/iio_demo/src/examples/iio_timer_trigger_example/iio_timer_trigger_example.c
@@ -84,9 +84,6 @@ int iio_timer_trigger_example_main()
 	/* dac demo irq instance descriptor */
 	struct no_os_irq_ctrl_desc *dac_demo_irq_desc;
 
-	/* iio desc */
-	struct iio_desc *iio_desc;
-
 	/* iio application desc */
 	struct iio_app_desc *app;
 
@@ -141,12 +138,10 @@ int iio_timer_trigger_example_main()
 	dac_demo_timer_trig_ip.irq_ctrl = dac_demo_irq_desc;
 
 	/* Initialize hardware trigger */
-	adc_demo_timer_trig_ip.iio_desc = &iio_desc,
 	ret = iio_hw_trig_init(&adc_timer_trig_desc, &adc_demo_timer_trig_ip);
 	if (ret)
 		return ret;
 
-	dac_demo_timer_trig_ip.iio_desc = &iio_desc,
 	ret = iio_hw_trig_init(&dac_timer_trig_desc, &dac_demo_timer_trig_ip);
 	if (ret)
 		return ret;


### PR DESCRIPTION
Remove iio_desc pointer assignment: double pointer was removed in 2df74e4 ("iio::iio_trigger.* Rem double pointer in trig struct"), leave simple pointer assignation after iio_app_init is performed.

Fixes: 62db110 ("projects Update iio examples with iio_app_desc")