### PR TITLE
mqtt: expose timer init params

### DIFF
--- a/libraries/mqtt/mqtt_client.c
+++ b/libraries/mqtt/mqtt_client.c
@@ -112,7 +112,7 @@ int32_t mqtt_init(struct mqtt_desc **desc,
 	if (!ldesc)
 		return -1;
 
-	ret = mqtt_timer_init(param->timer_id, param->extra_timer_init_param);
+	ret = mqtt_timer_init(param->timer_init_param);
 	if (NO_OS_IS_ERR_VALUE(ret)) {
 		free(ldesc);
 		return -1;

--- a/libraries/mqtt/mqtt_client.h
+++ b/libraries/mqtt/mqtt_client.h
@@ -213,10 +213,8 @@ struct mqtt_init_param {
 	 * calling any MQTT client functions.
 	 */
 	struct tcp_socket_desc	*sock;
-	/** Id of the hardware timer to be used by the mqtt files */
-	uint32_t		timer_id;
-	/** Platform specific parameter to initialize a \ref timer_desc */
-	void			*extra_timer_init_param;
+	/** Parameter to initialize a \ref timer_desc */
+	struct no_os_timer_init_param	*timer_init_param;
 	/** Timeout for a MQTT command to be executed */
 	uint32_t		command_timeout_ms;
 	/** Buffer used by the client to read messages */

--- a/libraries/mqtt/mqtt_noos_support.c
+++ b/libraries/mqtt/mqtt_noos_support.c
@@ -64,17 +64,11 @@ static uint32_t			nb_references;
 /******************************************************************************/
 
 /* Allcoate resources for timer. Must be called from mqqt_init */
-int32_t mqtt_timer_init(uint32_t timer_id, void *extra_init_param)
+int32_t mqtt_timer_init(struct no_os_timer_init_param *timer_init_param)
 {
-	struct no_os_timer_init_param init_param = {
-		.id = timer_id,
-		.freq_hz = 1000,
-		.ticks_count = 0,
-		.extra = extra_init_param
-	};
 	int32_t			ret;
 
-	ret = no_os_timer_init(&timer, &init_param);
+	ret = no_os_timer_init(&timer, timer_init_param);
 	if (NO_OS_IS_ERR_VALUE(ret)) {
 		timer = NULL;
 		return -1;
@@ -91,7 +85,6 @@ int32_t mqtt_timer_init(uint32_t timer_id, void *extra_init_param)
 
 	return 0;
 }
-
 
 /* Remove resources allocated with \ref mqtt_timere_init. */
 void mqtt_timer_remove()

--- a/libraries/mqtt/mqtt_noos_support.h
+++ b/libraries/mqtt/mqtt_noos_support.h
@@ -46,6 +46,7 @@
 
 #include <stdint.h>
 #include "tcp_socket.h"
+#include "no_os_timer.h"
 
 /******************************************************************************/
 /*************************** Types Declarations *******************************/
@@ -87,7 +88,7 @@ struct network_port_noos {
 /******************************************************************************/
 
 /* Init porting file */
-int32_t mqtt_timer_init(uint32_t timer_id, void *extra_init_param);
+int32_t mqtt_timer_init(struct no_os_timer_init_param *timer_init_param);
 /* Uninit porting file */
 void mqtt_timer_remove();
 


### PR DESCRIPTION
Instead of allowing the user to configure only partially the timer for the mqtt, pass the entire init_param structure since some parameters might differ based on the platform used aside the platform ops.