### PR TITLE
drivers: rtc: fix i2c desc declaration

### DIFF
--- a/drivers/rtc/pcf85263/pcf85263.h
+++ b/drivers/rtc/pcf85263/pcf85263.h
@@ -137,7 +137,7 @@ struct pcf85263_init_param {
  */
 struct pcf85263_dev {
 	/** Device communication descriptor */
-	struct no_os_spi_desc		*i2c_desc;
+	struct no_os_i2c_desc		*i2c_desc;
 	uint8_t				battery_en;
 };
 


### PR DESCRIPTION
Fix the type of the i2c_desc declaration.

Fixes: 03b470d ("drivers: rtc: pcf85263: initial commit")