### PR TITLE
platform: maxim: i2c: remove unused variable

### DIFF
--- a/drivers/platform/maxim/max32650/maxim_i2c.c
+++ b/drivers/platform/maxim/max32650/maxim_i2c.c
@@ -124,7 +124,6 @@ static int32_t max_i2c_init(struct no_os_i2c_desc **desc,
 	int32_t ret;
 	struct max_i2c_extra *max_i2c;
 	mxc_i2c_regs_t *i2c_regs;
-	uint32_t current_freq = 0;
 	uint32_t freq;
 
 	if (!desc || !param || !param->extra)

--- a/drivers/platform/maxim/max32655/maxim_i2c.c
+++ b/drivers/platform/maxim/max32655/maxim_i2c.c
@@ -127,7 +127,6 @@ static int32_t max_i2c_init(struct no_os_i2c_desc **desc,
 	int32_t ret;
 	struct max_i2c_extra *max_i2c;
 	mxc_i2c_regs_t *i2c_regs;
-	uint32_t current_freq = 0;
 	uint32_t freq;
 
 	if (!desc || !param || !param->extra)

--- a/drivers/platform/maxim/max32660/maxim_i2c.c
+++ b/drivers/platform/maxim/max32660/maxim_i2c.c
@@ -125,7 +125,6 @@ static int32_t max_i2c_init(struct no_os_i2c_desc **desc,
 	int32_t ret;
 	struct max_i2c_extra *max_i2c;
 	mxc_i2c_regs_t *i2c_regs;
-	uint32_t current_freq = 0;
 	uint32_t freq;
 
 	if (!desc || !param || !param->extra)

--- a/drivers/platform/maxim/max32665/maxim_i2c.c
+++ b/drivers/platform/maxim/max32665/maxim_i2c.c
@@ -127,7 +127,6 @@ static int32_t max_i2c_init(struct no_os_i2c_desc **desc,
 	int32_t ret;
 	struct max_i2c_extra *max_i2c;
 	mxc_i2c_regs_t *i2c_regs;
-	uint32_t current_freq = 0;
 	uint32_t freq;
 
 	if (!desc || !param || !param->extra)


### PR DESCRIPTION
The `current_freq` variable is not used.