### PR TITLE
add Mbed platform support to no-OS

### DIFF
--- a/libraries/mbed/mbed_app.json
+++ b/libraries/mbed/mbed_app.json
@@ -1,0 +1,20 @@
+{
+    "config": {
+        "usb_speed": {
+            "help": "USE_USB_OTG_FS or USE_USB_OTG_HS or USE_USB_HS_IN_FS",
+            "value": "USE_USB_OTG_HS"
+        }
+    },
+    "requires": ["bare-metal", "drivers-usb", "events"],
+    "macros": [
+		"IIO_IGNORE_BUFF_OVERRUN_ERR",
+		"USE_STANDARD_SPI"
+    ],
+    "target_overrides": {
+        "*": {
+            "platform.default-serial-baud-rate": 230400,
+            "target.printf_lib": "std",
+			"target.device_has_remove": ["CAN"]
+        }
+    }
+}

--- a/projects/adt7420-pmdz/src/platform/mbed/main.c
+++ b/projects/adt7420-pmdz/src/platform/mbed/main.c
@@ -1,9 +1,9 @@
 /***************************************************************************//**
- *   @file   platform_includes.h
- *   @brief  Includes for used platforms used by adt7420-pmdz project.
- *   @author RNechita (ramona.nechita@analog.com)
+ *   @file   main.c
+ *   @brief  Main file for Mbed platform of adt7420-pmdz project.
+ *   @author CMinajigi (chandrakant.minajigi@analog.com)
 ********************************************************************************
- * Copyright 2022(c) Analog Devices, Inc.
+ * Copyright 2023(c) Analog Devices, Inc.
  *
  * All rights reserved.
  *
@@ -36,20 +36,54 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
-#ifndef __PLATFORM_INCLUDES_H__
-#define __PLATFORM_INCLUDES_H__
 
 /******************************************************************************/
 /***************************** Include Files **********************************/
 /******************************************************************************/
-#ifdef MAXIM_PLATFORM
-#include "maxim/parameters.h"
-#elif  MBED_PLATFORM
-#include "mbed/parameters.h"
+#include "platform_includes.h"
+#include "common_data.h"
+
+#ifdef IIO_EXAMPLE
+#include "iio_example.h"
 #endif
 
-#ifdef IIO_SUPPORT
-#include "iio_app.h"
+#ifdef DUMMY_EXAMPLE
+#include "dummy_example.h"
 #endif
 
-#endif /* __PLATFORM_INCLUDES_H__ */
+/***************************************************************************//**
+ * @brief Main function for Mbed platform.
+ *
+ * @return ret - Result of the enabled examples.
+*******************************************************************************/
+
+int main()
+{
+	int ret;
+#ifdef IIO_EXAMPLE
+	ret = iio_example_main();
+	if (ret)
+		return ret;
+#endif
+
+#ifdef DUMMY_EXAMPLE
+	struct no_os_uart_desc* uart;
+	ret = no_os_uart_init(&uart, &uip);
+	if (ret) {
+		no_os_uart_remove(uart);
+		return ret;
+	}
+	no_os_uart_stdio(uart);
+	ret = dummy_example_main();
+	if (ret) {
+		no_os_uart_remove(uart);
+		return ret;
+	}
+#endif
+
+#if (IIO_EXAMPLE+DUMMY_EXAMPLE != 1)
+#error Selected example projects cannot be enabled at the same time. \
+Please enable only one example and re-build the project.
+#endif
+	return 0;
+}

--- a/projects/adt7420-pmdz/src/platform/mbed/parameters.c
+++ b/projects/adt7420-pmdz/src/platform/mbed/parameters.c
@@ -1,9 +1,9 @@
 /***************************************************************************//**
- *   @file   platform_includes.h
- *   @brief  Includes for used platforms used by adt7420-pmdz project.
- *   @author RNechita (ramona.nechita@analog.com)
+ *   @file   parameters.c
+ *   @brief  Definition of Mbed platform data used by adt7420-pmdz project.
+ *   @author CMinajigi (chandrakant.minajigi@analog.com)
 ********************************************************************************
- * Copyright 2022(c) Analog Devices, Inc.
+ * Copyright 2023(c) Analog Devices, Inc.
  *
  * All rights reserved.
  *
@@ -36,20 +36,21 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
-#ifndef __PLATFORM_INCLUDES_H__
-#define __PLATFORM_INCLUDES_H__
 
 /******************************************************************************/
 /***************************** Include Files **********************************/
 /******************************************************************************/
-#ifdef MAXIM_PLATFORM
-#include "maxim/parameters.h"
-#elif  MBED_PLATFORM
-#include "mbed/parameters.h"
-#endif
+#include "parameters.h"
 
-#ifdef IIO_SUPPORT
-#include "iio_app.h"
-#endif
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+struct mbed_uart_init_param xuip = {
+	.uart_tx_pin = UART_TX_PIN,
+	.uart_rx_pin = UART_RX_PIN
+};
 
-#endif /* __PLATFORM_INCLUDES_H__ */
+struct mbed_i2c_init_param adt7420_i2c_extra = {
+	.i2c_sda_pin = I2C_SDA,
+	.i2c_scl_pin = I2C_SCL
+};

--- a/projects/adt7420-pmdz/src/platform/mbed/parameters.h
+++ b/projects/adt7420-pmdz/src/platform/mbed/parameters.h
@@ -1,9 +1,10 @@
 /***************************************************************************//**
- *   @file   platform_includes.h
- *   @brief  Includes for used platforms used by adt7420-pmdz project.
- *   @author RNechita (ramona.nechita@analog.com)
+ *   @file   parameters.h
+ *   @brief  Definitions specific to Mbed platform used by adt7420-pmdz
+ *           project.
+ *   @author CMinajigi (chandrakant.minajigi@analog.com)
 ********************************************************************************
- * Copyright 2022(c) Analog Devices, Inc.
+ * Copyright 2023(c) Analog Devices, Inc.
  *
  * All rights reserved.
  *
@@ -36,20 +37,35 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
-#ifndef __PLATFORM_INCLUDES_H__
-#define __PLATFORM_INCLUDES_H__
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
 
 /******************************************************************************/
 /***************************** Include Files **********************************/
 /******************************************************************************/
-#ifdef MAXIM_PLATFORM
-#include "maxim/parameters.h"
-#elif  MBED_PLATFORM
-#include "mbed/parameters.h"
-#endif
+#include <PinNames.h>
+#include "mbed_uart.h"
+#include "mbed_i2c.h"
+#include "no_os_uart.h"
 
-#ifdef IIO_SUPPORT
-#include "iio_app.h"
-#endif
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
 
-#endif /* __PLATFORM_INCLUDES_H__ */
+#define UART_TX_PIN	    CONSOLE_TX
+#define	UART_RX_PIN	    CONSOLE_RX
+#define UART_DEVICE_ID  0
+#define UART_IRQ_ID     0
+#define UART_BAUDRATE   115200
+#define UART_OPS        &mbed_uart_ops
+
+/* I2C Pin mapping for Arduino interface */
+#define I2C_SCL         ARDUINO_UNO_D15
+#define I2C_SDA         ARDUINO_UNO_D14
+#define I2C_DEVICE_ID   0
+#define I2C_OPS         &mbed_i2c_ops
+
+extern struct mbed_uart_init_param xuip;
+extern struct mbed_i2c_init_param adt7420_i2c_extra;
+
+#endif /* __PARAMETERS_H__ */

--- a/projects/adt7420-pmdz/src/platform/mbed/platform_src.mk
+++ b/projects/adt7420-pmdz/src/platform/mbed/platform_src.mk
@@ -1,0 +1,14 @@
+INCS += $(PLATFORM_DRIVERS)/mbed_uart.h      \
+		$(PLATFORM_DRIVERS)/mbed_i2c.h       \
+		$(PLATFORM_DRIVERS)/mbed_gpio.h      \
+		$(PLATFORM_DRIVERS)/mbed_irq.h       \
+		$(PLATFORM_DRIVERS)/mbed_gpio_irq.h  \
+		$(PLATFORM_DRIVERS)/mbed_spi.h
+
+SRCS += $(PLATFORM_DRIVERS)/mbed_uart.cpp       \
+		$(PLATFORM_DRIVERS)/mbed_i2c.cpp        \
+		$(PLATFORM_DRIVERS)/mbed_gpio.cpp       \
+		$(PLATFORM_DRIVERS)/mbed_irq.cpp        \
+		$(PLATFORM_DRIVERS)/mbed_gpio_irq.cpp   \
+		$(PLATFORM_DRIVERS)/mbed_spi.cpp        \
+		$(PLATFORM_DRIVERS)/mbed_delay.cpp

--- a/tools/scripts/libraries.mk
+++ b/tools/scripts/libraries.mk
@@ -121,6 +121,10 @@ INC_PATHS += $(EXTRA_INC_PATHS)
 LIBS += $(LIB_FLAGS)
 endif
 
+ifeq (mbed,$(strip $(PLATFORM)))
+CLEAN_MBED_OS = $(call remove_dir_action,$(MBED_OS_BUILD_DIRECTORY) $(MBED_APP_JSON_DIRECTORY))
+endif
+
 # Build project Release Configuration
 PHONY := libs
 libs: $(LIB_TARGETS)
@@ -132,3 +136,4 @@ clean_libs:
 	-$(CLEAN_MQTT)
 	-$(CLEAN_IIO)
 	-$(CLEAN_AZURE)
+	-$(CLEAN_MBED_OS)

--- a/tools/scripts/mbed.mk
+++ b/tools/scripts/mbed.mk
@@ -1,0 +1,104 @@
+# For Mbed Platform SDP_K1 is default but can be changed by giving specific Mbed supported board name to TARGET_BOARD variable while giving make command
+TARGET_BOARD = SDP_K1
+COMPILER = GCC_ARM
+
+# Build directory for Mbed Platform
+PROJECT_BUILD = $(BUILD_DIR)
+
+# Mbed-OS related paths and files
+MBED_OS_DIRECTORY = $(NO-OS)/libraries/mbed
+MBED_OS_BUILD_DIRECTORY = $(MBED_OS_DIRECTORY)/BUILD/$(TARGET_BOARD)/$(COMPILER)
+MBED_OS_LIBRARY = $(MBED_OS_BUILD_DIRECTORY)/libmbed-os.a
+MBED_APP_JSON_DIRECTORY = $(MBED_OS_DIRECTORY)/mbed-app-json
+
+# Finding linker-script in Mbed-OS build directory
+LINKER_SCRIPT_BEFORE_PREPROCESSING = $(sort $(call rwildcard,$(MBED_OS_BUILD_DIRECTORY),*.ld))
+
+PLATFORM_RELATIVE_PATH = $1
+PLATFORM_FULL_PATH = $1
+
+# compiler name and standard libraries
+LIB_FLAGS = -Wl,--start-group -lstdc++ -lsupc++ -lm -lc -lgcc -lnosys  -Wl,--end-group
+CC = arm-none-eabi-gcc
+CPP = arm-none-eabi-g++
+OC = arm-none-eabi-objcopy
+
+# Project related build Files
+MBED_OS_INCLUDE_PATHS_NAMES = $(BUILD_DIR)/mbed-os-include-path-names.txt
+LSCRIPT = $(BUILD_DIR)/$(PROJECT_NAME)-linker-file.ld
+PROJECT_BIN_FILE = $(subst elf,bin,$(BINARY))
+PROJECT_MAP_FILE = $(subst elf,map,$(BINARY))
+
+# Reading Flags and Object Files and Include files for mbed-os
+MBED_GENERATED_ARCHIVE_FILE = $(MBED_OS_BUILD_DIRECTORY)/.archive_files.txt
+UPDATED_MBED_GENERATED_ARCHIVE_FILE = $(MBED_OS_BUILD_DIRECTORY)/.updated_archive_files.txt
+READ_MBED_GENERATED_PROFILE_C_FILE = $(shell $(call read_file ,$(MBED_OS_BUILD_DIRECTORY)/.profile-c))
+READ_MBED_GENERATED_PROFILE_CPP_FILE = $(shell $(call read_file ,$(MBED_OS_BUILD_DIRECTORY)/.profile-cxx))
+READ_MBED_GENERATED_PROFILE_ASM_FILE = $(shell $(call read_file ,$(MBED_OS_BUILD_DIRECTORY)/.profile-asm))
+READ_MBED_GENERATED_PROFILE_LINKER_FILE = $(shell $(call read_file ,$(MBED_OS_BUILD_DIRECTORY)/.profile-ld))
+READ_MBED_GENERATED_INCLUDE_FILE = $(shell $(call read_file ,$(MBED_OS_BUILD_DIRECTORY)/.includes_*))
+
+NULL := 
+COMMA :=,
+SPACE := $(NULL) $(NULL)
+
+MBED_C_FLAGS = $(subst ",,$(subst $(COMMA), ,$(patsubst {"flags":[%,%,$(firstword $(subst ]$(COMMA)"macros", "macros",$(subst $(SPACE),,$(READ_MBED_GENERATED_PROFILE_C_FILE)))))))
+MBED_C_SYMBOLS = $(patsubst %,-D%,$(subst ",,$(subst $(COMMA), ,$(patsubst %]},%,$(lastword $(subst "symbols":[,"symbols":[ ,$(subst $(SPACE),,$(READ_MBED_GENERATED_PROFILE_C_FILE))))))))
+CFLAGS += $(MBED_C_FLAGS) $(MBED_C_SYMBOLS) -include $(MBED_OS_BUILD_DIRECTORY)/mbed_config.h -DMBED_PLATFORM $(TEST_FLAGS)
+
+MBED_CPP_FLAGS = $(subst ",,$(subst $(COMMA), ,$(patsubst {"flags":[%,%,$(firstword $(subst ]$(COMMA)"macros", "macros",$(subst $(SPACE),,$(READ_MBED_GENERATED_PROFILE_CPP_FILE)))))))
+MBED_CPP_SYMBOLS = $(patsubst %,-D%,$(subst ",,$(subst $(COMMA), ,$(patsubst %]},%,$(lastword $(subst "symbols":[,"symbols":[ ,$(subst $(SPACE),,$(READ_MBED_GENERATED_PROFILE_CPP_FILE))))))))
+CPPFLAGS += $(MBED_CPP_FLAGS) $(MBED_CPP_SYMBOLS) -include $(MBED_OS_BUILD_DIRECTORY)/mbed_config.h -DMBED_PLATFORM $(TEST_FLAGS)
+
+MBED_ASM_FLAGS = $(subst ",,$(subst $(COMMA), ,$(patsubst {"flags":[%,%,$(firstword $(subst ]$(COMMA)"macros", "macros",$(subst $(SPACE),,$(READ_MBED_GENERATED_PROFILE_ASM_FILE)))))))
+MBED_ASM_SYMBOLS = $(patsubst %,-D%,$(subst ",,$(subst $(COMMA), ,$(patsubst %]},%,$(lastword $(subst "symbols":[,"symbols":[ ,$(subst $(SPACE),,$(READ_MBED_GENERATED_PROFILE_ASM_FILE))))))))
+ASFLAGS += $(MBED_ASM_FLAGS) $(MBED_ASM_SYMBOLS) -include $(MBED_OS_BUILD_DIRECTORY)/mbed_config.h -DMBED_PLATFORM $(TEST_FLAGS)
+
+MBED_LINKER_FLAGS = $(subst ",,$(subst "$(COMMA)", ,$(patsubst {"flags":[%,%,$(firstword $(subst ]$(COMMA)"macros", "macros",$(subst $(SPACE),,$(READ_MBED_GENERATED_PROFILE_LINKER_FILE)))))))
+MBED_LINKER_SYMBOLS = $(patsubst %,-D%,$(subst ",,$(subst $(COMMA), ,$(patsubst %]},%,$(lastword $(subst "symbols":[,"symbols":[ ,$(subst $(SPACE),,$(READ_MBED_GENERATED_PROFILE_LINKER_FILE))))))))
+LDFLAGS += $(MBED_LINKER_FLAGS)
+
+# Preprocessor flags for linker Script
+MBED_PREPROCESSOR_FLAGS = arm-none-eabi-cpp -E -P $(LDFLAGS)
+
+# Map file compiler flag
+LDFLAGS += $(MBED_LINKER_SYMBOLS) -Wl,-Map=$(PROJECT_MAP_FILE)
+
+# Updating mbed generated archive file
+UPDATE_MBED_GENERATED_ARCHIVE_FILE = $(addprefix $(MBED_OS_DIRECTORY)/, $(shell $(call read_file ,$(MBED_GENERATED_ARCHIVE_FILE))))
+
+# Platform include paths
+MBED_PLATFORM_INCLUDE_PATHS = $(patsubst %,%/,$(patsubst %,-I%,$(patsubst mbed-os%,$(MBED_OS_DIRECTORY)/mbed-os%,$(patsubst -I%,%,$(subst ",,$(READ_MBED_GENERATED_INCLUDE_FILE))))))
+PLATFORM_INCS = @$(MBED_OS_INCLUDE_PATHS_NAMES)
+
+# Extra files for build
+EXTRA_FILES =@$(UPDATED_MBED_GENERATED_ARCHIVE_FILE)
+
+# Rule for building Mbed-OS
+$(PROJECT_TARGET): MBED-OS-build
+	-$(MUTE) $(call mk_dir,$(BUILD_DIR)) $(HIDE)
+	$(MUTE) $(call print, putting mbed-os include path names and object files names to text file)
+	$(MUTE) $(call ADD_BLANK_LINE, $(MBED_OS_INCLUDE_PATHS_NAMES)) $(cmd_separator) $(foreach file,$(sort $(MBED_PLATFORM_INCLUDE_PATHS)),$(call APPEND_TO_FILE,$(file),$(MBED_OS_INCLUDE_PATHS_NAMES)) $(cmd_separator)) echo . $(HIDE)
+	$(MUTE) $(call ADD_BLANK_LINE, $(UPDATED_MBED_GENERATED_ARCHIVE_FILE)) $(cmd_separator) $(foreach file,$(sort $(UPDATE_MBED_GENERATED_ARCHIVE_FILE)),$(call APPEND_TO_FILE,$(file),$(UPDATED_MBED_GENERATED_ARCHIVE_FILE)) $(cmd_separator)) echo . $(HIDE)
+	$(MUTE) $(call set_one_time_rule,$@)
+
+$(MBED_OS_LIBRARY):
+	$(MUTE) $(MAKE) --no-print-directory MBED-OS-build $(HIDE)
+
+PHONY_TARGET += MBED-OS-build 
+MBED-OS-build:
+	-$(MUTE) $(call mk_dir,$(MBED_APP_JSON_DIRECTORY)) $(HIDE)
+	$(MUTE) $(call copy_file,$(MBED_OS_DIRECTORY)/mbed_app.json,$(MBED_APP_JSON_DIRECTORY)/) $(HIDE)
+	cd $(MBED_OS_DIRECTORY) $(cmd_separator) mbed config root . $(cmd_separator) mbed compile --source $(MBED_OS_DIRECTORY)/mbed-os --source $(MBED_APP_JSON_DIRECTORY) -m $(TARGET_BOARD) -t $(COMPILER) --build $(MBED_OS_BUILD_DIRECTORY) --library
+	$(MUTE) $(call print, Mbed-OS build completed)
+
+# Linker-Script Preprocessing
+$(LSCRIPT): $(LINKER_SCRIPT_BEFORE_PREPROCESSING)
+	$(MUTE) $(MBED_PREPROCESSOR_FLAGS) $< -o $@
+
+# Binary file creation from elf file
+$(PROJECT_BIN_FILE):$(BINARY)
+	$(MUTE) $(OC) -O binary $< $@
+	$(call print,Done $(PROJECT_BIN_FILE))
+
+post_build: $(PROJECT_BIN_FILE)


### PR DESCRIPTION
- Added Mbed code support for adt7420-pmdz project.
- Modified iio_app.c file to support iio_example for Mbed platform.
- Created new mbed directory in libraries for mbed-os related files.
- Added mbed-os as the submodule to no-OS repository.
- Added make based build support for Mbed platform.

Note: For make based Mbed build we need to install some tool like mbed-cli1 and we need to set up some environment variables. 