### PR TITLE
libraries: add azure-sdk-for-c support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "libraries/iio/libtinyiiod"]
 	path = libraries/iio/libtinyiiod
 	url = https://github.com/analogdevicesinc/libtinyiiod
+[submodule "libraries/azure-sdk-for-c"]
+	path = libraries/azure-sdk-for-c
+	url = https://github.com/Azure/azure-sdk-for-c.git

--- a/tools/scripts/azure_sdk_for_c.mk
+++ b/tools/scripts/azure_sdk_for_c.mk
@@ -1,0 +1,5 @@
+AZURE_DIR = $(NO-OS)/libraries/azure-sdk-for-c
+AZURE_DIR_BUILD = $(AZURE_DIR)/build
+AZURE_DIR_BUILD_LIBS = $(AZURE_DIR_BUILD)/sdk/src/azure
+
+SRC_DIRS += $(AZURE_DIR)/sdk/inc


### PR DESCRIPTION
Integrate azure-sdk-for-c into the no-os framework.

Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>