### PR TITLE
network: wifi: fix ret type

### DIFF
--- a/network/wifi/at_parser.c
+++ b/network/wifi/at_parser.c
@@ -371,7 +371,7 @@ static inline void start_conn_read(struct at_desc *desc, bool is_new_message)
 	struct connection_desc	*conn;
 	uint8_t			*buff;
 	uint32_t		available_len;
-	uint32_t		ret;
+	int32_t			ret;
 
 	conn = &desc->conn[desc->current_conn];
 

--- a/network/wifi/wifi.c
+++ b/network/wifi/wifi.c
@@ -542,7 +542,7 @@ static int32_t wifi_socket_connect(struct wifi_desc *desc, uint32_t sock_id,
 				   struct socket_address *addr)
 {
 	union in_out_param	param;
-	uint32_t		ret;
+	int32_t			ret;
 	struct socket_desc	*sock;
 
 	if (!desc || !addr || sock_id >= NB_SOCKETS ||
@@ -592,7 +592,7 @@ static void _remove_server_back_log(struct wifi_desc *desc)
 static int32_t wifi_socket_disconnect(struct wifi_desc *desc, uint32_t sock_id)
 {
 	union in_out_param	param;
-	uint32_t		ret;
+	int32_t			ret;
 	struct socket_desc	*sock;
 
 	if (!desc || sock_id >= NB_SOCKETS)
@@ -635,7 +635,7 @@ static int32_t wifi_socket_send(struct wifi_desc *desc, uint32_t sock_id,
 				const void *data, uint32_t size)
 {
 	union in_out_param	param;
-	uint32_t		ret;
+	int32_t			ret;
 	struct socket_desc	*sock;
 	uint32_t		to_send;
 	uint32_t		i;


### PR DESCRIPTION
The type of ret should be signed int when passed to the `NO_OS_IS_ERR_VALUE` which checks if the variable is < 0.