### PR TITLE
mbedtls_config: update to default values

### DIFF
--- a/network/noos_mbedtls_config.h
+++ b/network/noos_mbedtls_config.h
@@ -90,7 +90,7 @@
  * 2000 is a eoungh to do the tls handshake and is no to much
  * platforms with memory constrains like ADuCM3029
  */
-#define MAX_CONTENT_LEN 2500
+//#define MAX_CONTENT_LEN 2500
 
 /*
  * ENABLE_MEMORY_OPTIMIZATIONS should be defined in the case memory


### PR DESCRIPTION
[network: mbedtls_config: use default buffer length](https://github.com/analogdevicesinc/no-OS/commit/422cf57ab2d7cea79a02a3b754409d0b2206c32d)