### PR TITLE
tools: scripts: allow custom mbedtls config

### DIFF
--- a/tools/scripts/libraries.mk
+++ b/tools/scripts/libraries.mk
@@ -30,7 +30,10 @@ EXTRA_LIBS_PATHS			+= $(MBEDTLS_LIB_DIR)
 EXTRA_INC_PATHS		+= $(MBEDTLS_DIR)/include
 
 #Rules
+#If no application specific mbedtls config file is defined, use the standard one.
+ifeq ($(MBED_TLS_CONFIG_FILE),)
 MBED_TLS_CONFIG_FILE = $(NO-OS)/network/noos_mbedtls_config.h
+endif
 CLEAN_MBEDTLS	= $(call remove_file,$(MBEDTLS_LIB_DIR)/*.o $(MBEDTLS_LIBS))
 $(MBEDTLS_LIB_DIR)/libmbedcrypto.a: $(MBED_TLS_CONFIG_FILE)
 	-$(CLEAN_MBEDTLS)


### PR DESCRIPTION
mbedtls library can be build based on custom configuration file defined by the user. Although there is already a "generic" configuration file provided for the no-os framework (noos_mbedtls_config.h), allow the user to create its own custom config file since these are applications specific rather than framework specific.