### PR TITLE
ad4110:src.mk Add no_os_util.c to sources

### DIFF
--- a/projects/ad4110/builds.json
+++ b/projects/ad4110/builds.json
@@ -1,0 +1,8 @@
+{
+	"xilinx": {
+		"uart": {
+			"flags" : "",
+			"hardware" : ["ad4110_zed"]
+	  	}
+	}
+}

--- a/projects/ad4110/src.mk
+++ b/projects/ad4110/src.mk
@@ -20,7 +20,8 @@ SRCS += $(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio_irq.c \
 	$(PLATFORM_DRIVERS)/xilinx_delay.c \
-	$(NO-OS)/util/no_os_list.c
+	$(NO-OS)/util/no_os_list.c \
+	$(NO-OS)/util/no_os_util.c
 
 INCS += $(DRIVERS)/afe/ad4110/ad4110.h
 


### PR DESCRIPTION
Add no_os_util.c to sources. Required after the addition of timestamps.