### PR TITLE
projects: eval-ade9430: add support

### DIFF
--- a/projects/eval-ade9430/Makefile
+++ b/projects/eval-ade9430/Makefile
@@ -1,0 +1,5 @@
+include ../../tools/scripts/generic_variables.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/eval-ade9430/README.md
+++ b/projects/eval-ade9430/README.md
@@ -1,0 +1,52 @@
+# EVAL-ADE9430 Project
+
+## Building project
+
+The project was developed on max32650 and supports multiple configurations:
+ - non-encrypted communication with a MQTT Broker.
+ - encrypted communication with Azure IoT Hub (with the option of configurating
+   and registering the device in the cloud via the Azure Device Provisioning
+   Service prior to the IoT Hub connection and telemetry data publishing)
+
+Default configuration: simple, non-encrypted connection.
+
+### Building attributes
+
+|  Libraries      |                Description                        |
+| --------------- | ------------------------------------------------- |
+|  AZURE_IOT_HUB  |  Enable the Azure IoT encrypted connection.       |
+
+|  C Flags        |                Description                        |
+| --------------- | ------------------------------------------------- |
+|  CONFIG_DPS     |  Enable the device registering in the cloud.      |
+|  RTC_DEFAULT    |  Set the default date and time for the RTC.       |
+
+**Build Configuration Examples:** 
+
+1. `make TARGET=max32650`
+
+ - Default usage of the project consisting of simple, non-encrypted connection
+   to a MQTT broker.
+
+2. `make TARGET=max32650 NEW_CFLAGS=-DRTC_SET_DEFAULT`
+
+ - Default usage of the project consisting of simple, non-encrypted connection
+   to a MQTT broker, including the RTC default date and time set required for
+   obtaining relevant timestamp values.
+
+3. `make TARGET=max32650 AZURE_IOT_HUB=y`
+
+ - Encrypted connection and telemetry data publishing into the Azure IoT Hub.
+
+4. `make TARGET=max32650 AZURE_IOT_HUB=y NEW_CFLAGS=-DCONFIG_DPS`
+
+ - Encrypted connection to the Azure Device Provisioning Service for the device
+   registering in the cloud, followed by encrypted connection and telemetry
+   data publishing into the Azure IoT Hub.
+
+5. `make TARGET=max32650 AZURE_IOT_HUB=y NEW_CFLAGS=-DCONFIG_DPS NEW_CFLAGS=-DRTC_SET_DEFAULT`
+
+ - Encrypted connection to the Azure Device Provisioning Service for the device
+   registering in the cloud, followed by encrypted connection and telemetry
+   data publishing into the Azure IoT Hub, including the RTC default date and
+   time set required for obtaining relevand timestamp values.

--- a/projects/eval-ade9430/builds.json
+++ b/projects/eval-ade9430/builds.json
@@ -1,0 +1,22 @@
+{
+  "maxim": {
+    "eval_ade9430_example": {
+      "flags" : "TARGET=max32650"
+    },
+    "eval_ade9430_example_rtc": {
+      "flags" : "TARGET=max32650 NEW_CFLAGS=-DRTC_SET_DEFAULT"
+    },
+    "eval_ade9430_azure_iot_hub": {
+      "flags" : "TARGET=max32650 AZURE_IOT_HUB=y"
+    },
+    "eval_ade9430_azure_iot_hub_rtc": {
+      "flags" : "TARGET=max32650 AZURE_IOT_HUB=y NEW_CFLAGS=-DRTC_SET_DEFAULT"
+    },
+    "eval_ade9430_azure_iot_hub_dps": {
+      "flags" : "TARGET=max32650 AZURE_IOT_HUB=y NEW_CFLAGS=-DCONFIG_DPS"
+    },
+    "eval_ade9430_azure_iot_hub_dps_rtc": {
+      "flags" : "TARGET=max32650 AZURE_IOT_HUB=y NEW_CFLAGS=-DCONFIG_DPS NEW_CFLAGS=-DRTC_SET_DEFAULT"
+    }
+  }
+}

--- a/projects/eval-ade9430/src.mk
+++ b/projects/eval-ade9430/src.mk
@@ -1,0 +1,77 @@
+SRCS += $(PROJECT)/src/app/main.c
+
+INCS += $(PROJECT)/src/app/parameters.h
+
+INCS += $(INCLUDE)/no_os_delay.h     \
+	$(INCLUDE)/no_os_error.h     \
+	$(INCLUDE)/no_os_gpio.h      \
+	$(INCLUDE)/no_os_i2c.h       \
+	$(INCLUDE)/no_os_print_log.h \
+	$(INCLUDE)/no_os_spi.h       \
+	$(INCLUDE)/no_os_irq.h      \
+	$(INCLUDE)/no_os_list.h      \
+	$(INCLUDE)/no_os_timer.h      \
+	$(INCLUDE)/no_os_uart.h      \
+	$(INCLUDE)/no_os_lf256fifo.h \
+	$(INCLUDE)/no_os_util.h \
+	$(INCLUDE)/no_os_units.h \
+	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_circular_buffer.h \
+	$(INCLUDE)/no_os_trng.h \
+	$(INCLUDE)/no_os_rtc.h \
+	$(DRIVERS)/rtc/pcf85263/pcf85263.h \
+	$(DRIVERS)/meter/ade9430/ade9430.h \
+	$(DRIVERS)/display/nhd_c12832a1z/nhd_c12832a1z.h \
+
+INCS += $(PLATFORM_DRIVERS)/$(PLATFORM)_delay.h     \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_gpio.h      \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_spi.h       \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_i2c.h       \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_gpio_irq.h  \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_irq.h       \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_rtc.h       \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h      \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_timer.h     \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_trng.h
+
+SRCS += $(DRIVERS)/api/no_os_gpio.c \
+	$(DRIVERS)/meter/ade9430/ade9430.c \
+	$(DRIVERS)/rtc/pcf85263/pcf85263.c \
+	$(DRIVERS)/api/no_os_i2c.c  \
+	$(NO-OS)/util/no_os_lf256fifo.c \
+	$(DRIVERS)/api/no_os_gpio.c  \
+	$(DRIVERS)/api/no_os_irq.c  \
+	$(DRIVERS)/api/no_os_spi.c  \
+	$(DRIVERS)/api/no_os_uart.c  \
+	$(DRIVERS)/api/no_os_timer.c  \
+	$(DRIVERS)/api/no_os_trng.c  \
+	$(NO-OS)/util/no_os_list.c \
+	$(NO-OS)/util/no_os_util.c	\
+	$(NO-OS)/util/no_os_circular_buffer.c \
+	$(NO-OS)/util/no_os_alloc.c \
+	$(DRIVERS)/display/nhd_c12832a1z/nhd_c12832a1z.c
+
+SRCS += $(PLATFORM_DRIVERS)/$(PLATFORM)_delay.c     \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_gpio.c      \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_spi.c       \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_i2c.c       \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_rtc.c       \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_gpio_irq.c  \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c       \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_uart.c      \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_timer.c      \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_trng.c
+
+SRC_DIRS += $(NO-OS)/network
+
+LIBRARIES += mqtt
+
+ifeq (y,$(strip $(AZURE_IOT_HUB)))
+INCS += $(PROJECT)/src/app/iot_sample_common.h
+SRCS += $(PROJECT)/src/app/iot_sample_common.c
+
+MBED_TLS_CONFIG_FILE = $(PROJECT)/src/app/noos_mbedtls_config.h
+
+LIBRARIES += mbedtls
+LIBRARIES += azure-sdk-for-c
+endif

--- a/projects/eval-ade9430/src/app/iot_sample_common.c
+++ b/projects/eval-ade9430/src/app/iot_sample_common.c
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+// Required for sleep(unsigned int)
+#include <unistd.h>
+
+#include <azure/az_core.h>
+#include <azure/az_iot.h>
+
+#include "iot_sample_common.h"
+
+//
+// MQTT endpoints
+//
+static az_span const mqtt_url_prefix = AZ_SPAN_LITERAL_FROM_STR("ssl://");
+static az_span const mqtt_url_suffix = AZ_SPAN_LITERAL_FROM_STR(":8883");
+static az_span const provisioning_global_endpoint
+	= AZ_SPAN_LITERAL_FROM_STR("ssl://global.azure-devices-provisioning.net:8883");
+
+//
+// Functions
+//
+void iot_sample_create_mqtt_endpoint(
+	iot_sample_type type,
+	char* out_endpoint,
+	size_t endpoint_size)
+{
+	if (type == PAHO_IOT_HUB) {
+		int32_t const required_size = az_span_size(mqtt_url_prefix)
+					      + az_span_size(mqtt_url_suffix)
+					      + (int32_t)sizeof('\0');
+
+		if ((size_t)required_size > endpoint_size) {
+			IOT_SAMPLE_LOG_ERROR("Failed to create MQTT endpoint: Buffer is too small.");
+			exit(1);
+		}
+
+		az_span hub_mqtt_endpoint = az_span_create((uint8_t*)out_endpoint,
+					    (int32_t)endpoint_size);
+		az_span remainder = az_span_copy(hub_mqtt_endpoint, mqtt_url_prefix);
+		remainder = az_span_copy(remainder, mqtt_url_suffix);
+		az_span_copy_u8(remainder, '\0');
+	} else if (type == PAHO_IOT_PROVISIONING) {
+		int32_t const required_size
+			= az_span_size(provisioning_global_endpoint) + (int32_t)sizeof('\0');
+
+		if ((size_t)required_size > endpoint_size) {
+			IOT_SAMPLE_LOG_ERROR("Failed to create MQTT endpoint: Buffer is too small.");
+			exit(1);
+		}
+
+		az_span provisioning_mqtt_endpoint
+			= az_span_create((uint8_t*)out_endpoint, (int32_t)endpoint_size);
+		az_span remainder = az_span_copy(provisioning_mqtt_endpoint,
+						 provisioning_global_endpoint);
+		az_span_copy_u8(remainder, '\0');
+	} else {
+		IOT_SAMPLE_LOG_ERROR("Failed to create MQTT endpoint: Sample type undefined.");
+		exit(1);
+	}
+
+	IOT_SAMPLE_LOG_SUCCESS("MQTT endpoint created at \"%s\".", out_endpoint);
+}

--- a/projects/eval-ade9430/src/app/iot_sample_common.h
+++ b/projects/eval-ade9430/src/app/iot_sample_common.h
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#ifndef IOT_SAMPLE_COMMON_H
+#define IOT_SAMPLE_COMMON_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <azure/az_core.h>
+
+//
+// Logging
+//
+#define IOT_SAMPLE_LOG_ERROR(...)                                                  \
+  do                                                                               \
+  {                                                                                \
+    (void)fprintf(stderr, "ERROR:\t\t%s:%s():%d: ", __FILE__, __func__, __LINE__); \
+    (void)fprintf(stderr, __VA_ARGS__);                                            \
+    (void)fprintf(stderr, "\n");                                                   \
+    fflush(stdout);                                                                \
+    fflush(stderr);                                                                \
+  } while (0)
+
+#define IOT_SAMPLE_LOG_SUCCESS(...) \
+  do                                \
+  {                                 \
+    (void)printf("SUCCESS:\t");     \
+    (void)printf(__VA_ARGS__);      \
+    (void)printf("\n");             \
+  } while (0)
+
+#define IOT_SAMPLE_LOG(...)    \
+  do                           \
+  {                            \
+    (void)printf("\t\t");      \
+    (void)printf(__VA_ARGS__); \
+    (void)printf("\n");        \
+  } while (0)
+
+typedef enum {
+	PAHO_IOT_HUB,
+	PAHO_IOT_PROVISIONING
+} iot_sample_type;
+
+/*
+ * @brief Builds an MQTT endpoint c-string for an Azure IoT Hub or provisioning service.
+ *
+ * @param[in] type The enumerated type of the sample.
+ * @param[out] endpoint A buffer with sufficient capacity to hold the built endpoint. If
+ * successful, contains a null-terminated string of the endpoint.
+ * @param[in] endpoint_size The size of \p out_endpoint in bytes.
+ */
+void iot_sample_create_mqtt_endpoint(
+	iot_sample_type type,
+	char* endpoint,
+	size_t endpoint_size);
+
+#endif // IOT_SAMPLE_COMMON_H

--- a/projects/eval-ade9430/src/app/main.c
+++ b/projects/eval-ade9430/src/app/main.c
@@ -1,0 +1,815 @@
+/***************************************************************************//**
+ *   @file   main.c
+ *   @brief  Main file for EVAL-ADE9430 project.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "no_os_error.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "no_os_uart.h"
+#include "no_os_gpio.h"
+#include "no_os_delay.h"
+#include "no_os_timer.h"
+#include "no_os_i2c.h"
+#include "mqtt_client.h"
+#include "ade9430.h"
+#include "pcf85263.h"
+#include "nhd_c12832a1z.h"
+
+#include "maxim_gpio.h"
+#include "maxim_uart.h"
+#include "maxim_irq.h"
+#include "maxim_i2c.h"
+#include "maxim_spi.h"
+#include "maxim_timer.h"
+#include "maxim_trng.h"
+#include "no_os_irq.h"
+#include "no_os_error.h"
+#include "no_os_print_log.h"
+
+#include "wifi.h"
+#include "tcp_socket.h"
+
+#ifndef DISABLE_SECURE_SOCKET
+#include "az_iot_hub_client.h"
+#include "az_iot_provisioning_client.h"
+#endif
+
+#include "parameters.h"
+
+#ifndef DISABLE_SECURE_SOCKET
+
+static az_iot_hub_client my_client;
+
+static char mqtt_hub_user_name[256];
+static char mqtt_hub_client_id[64];
+
+static char reported_topic[128];
+
+static char mqtt_dps_user_name[256];
+static char mqtt_dps_client_id[CLIENT_ID_BUFFER_LENGTH];
+
+static uint8_t mqtt_payload[MQTT_PAYLOAD_BUFFER_LENGTH];
+static size_t mqtt_payload_length;
+
+static char register_topic_buffer[REGISTER_TOPIC_BUFFER_LENGTH];
+#endif
+
+#ifndef DISABLE_SECURE_SOCKET
+/* create_and_configure_mqtt_client_for_provisioning */
+int create_and_configure_mqtt_client_for_provisioning(void)
+{
+	int ret;
+	char mqtt_endpoint_buffer[PROVISIONING_ENDPOINT_BUFFER_LENGTH];
+	az_iot_provisioning_client provisioning_client;
+	az_span custom_registration_payload_property
+		= AZ_SPAN_LITERAL_FROM_STR(AZ_IOT_PROVISIONING_CUSTOM_PAYLOAD);
+
+	iot_sample_create_mqtt_endpoint(SAMPLE_TYPE,
+					mqtt_endpoint_buffer,
+					sizeof(mqtt_endpoint_buffer));
+
+	ret = az_iot_provisioning_client_init(&provisioning_client,
+					      az_span_create_from_str(mqtt_endpoint_buffer),
+					      az_span_create_from_str(AZ_IOT_PROVISIONING_ID_SCOPE),
+					      az_span_create_from_str(AZ_IOT_PROVISIONING_REGISTRATION_ID),
+					      NULL);
+	if (ret != AZ_OK)
+		return ret;
+
+	// Get the MQTT client id used for the MQTT connection.
+	ret = az_iot_provisioning_client_get_client_id(&provisioning_client,
+			mqtt_dps_client_id,
+			sizeof(mqtt_dps_client_id),
+			NULL);
+	if (ret != AZ_OK)
+		return ret;
+
+	ret = az_iot_provisioning_client_get_user_name(&provisioning_client,
+			mqtt_dps_user_name,
+			sizeof(mqtt_dps_user_name),
+			NULL);
+	if (ret != AZ_OK)
+		return ret;
+
+	ret = az_iot_provisioning_client_register_get_publish_topic(
+		      &provisioning_client,
+		      register_topic_buffer,
+		      sizeof(register_topic_buffer),
+		      NULL);
+	if (ret != AZ_OK)
+		return ret;
+
+	return az_iot_provisioning_client_get_request_payload(
+		       &provisioning_client,
+		       custom_registration_payload_property,
+		       NULL,
+		       mqtt_payload,
+		       sizeof(mqtt_payload),
+		       &mqtt_payload_length);
+}
+
+/* create_and_configure_mqtt_client_for_iot_hub */
+int create_and_configure_mqtt_client_for_iot_hub(void)
+{
+	int ret;
+	size_t mqtt_hub_user_name_length, mqtt_hub_client_id_length;
+	az_span my_iothub_hostname = AZ_SPAN_LITERAL_FROM_STR(SERVER_ADDR);
+	az_span my_device_id = AZ_SPAN_LITERAL_FROM_STR(
+				       AZ_IOT_PROVISIONING_REGISTRATION_ID);
+	az_span my_request_id = AZ_SPAN_LITERAL_FROM_STR("1");
+
+	az_iot_hub_client_options options = az_iot_hub_client_options_default();
+
+	// Initialize the hub client with hostname, device id, and default connection options.
+	ret = az_iot_hub_client_init(&my_client, my_iothub_hostname,
+				     my_device_id, &options);
+	if (ret != AZ_OK)
+		return ret;
+
+	// Get the MQTT client id used for the MQTT connection.
+	ret = az_iot_hub_client_get_client_id(&my_client, mqtt_hub_client_id,
+					      sizeof(mqtt_hub_client_id),
+					      &mqtt_hub_client_id_length);
+	if (ret != AZ_OK)
+		return ret;
+
+	// Get the MQTT user name to connect.
+	ret = az_iot_hub_client_get_user_name(&my_client, mqtt_hub_user_name,
+					      sizeof(mqtt_hub_user_name),
+					      &mqtt_hub_user_name_length);
+	if (ret != AZ_OK)
+		return ret;
+
+	return az_iot_hub_client_properties_get_reported_publish_topic(&my_client,
+			my_request_id,
+			reported_topic,
+			sizeof(reported_topic),
+			NULL);
+}
+#endif
+
+int read_and_send(struct mqtt_desc *mqtt, struct ade9430_dev *ade9430_dev,
+		  struct nhd_c12832a1z_dev *nhd_c12832a1z_dev,
+		  struct pcf85263_dev *pcf85263_dev)
+{
+	struct mqtt_message	msg;
+	struct pcf85263_date	ts;
+	char			buff[100], telemetry_topic[128];
+	uint32_t		len;
+	int			ret;
+
+	ret = ade9430_read_temp(ade9430_dev);
+	if (ret) {
+		pr_err("Error reading ADE9430 temperature!\n");
+		return ret;
+	}
+
+	ret = ade9430_read_data_ph(ade9430_dev, ADE9430_PHASE_A);
+	if (ret) {
+		pr_err("Error reading ADE9430 phase data!\n");
+		return ret;
+	}
+
+	/* Serialize data */
+	len = sprintf(buff, "Temp: %d\nAIRMS: %d\nAVRMS: %d\nAWATT: %d",
+		      ade9430_dev->temp_deg,
+		      ade9430_dev->irms_val,
+		      ade9430_dev->vrms_val,
+		      ade9430_dev->watt_val);
+
+	ret = nhd_c12832a1z_print_string(nhd_c12832a1z_dev, buff);
+	if (ret) {
+		pr_err("Error printing LCD data!\n");
+		return ret;
+	}
+
+	ret = pcf85263_read_ts(pcf85263_dev, &ts);
+	if (ret) {
+		pr_err("Error reading timestamp!\n");
+		return ret;
+	}
+	len = sprintf(buff,
+		      "Temp: %d;AIRMS: %d;AVRMS: %d;AWATT: %d;timestamp:20%02x-%02x-%02xT%02x:%02x:%02x+02:00",
+		      ade9430_dev->temp_deg,
+		      ade9430_dev->irms_val,
+		      ade9430_dev->vrms_val,
+		      ade9430_dev->watt_val,
+		      ts.year,
+		      ts.mon,
+		      ts.day,
+		      ts.hr,
+		      ts.min,
+		      ts.sec);
+
+	/* Get the topic to send a telemetry message */
+#ifndef DISABLE_SECURE_SOCKET
+	ret = az_iot_hub_client_telemetry_get_publish_topic(&my_client, NULL,
+			telemetry_topic,
+			sizeof(telemetry_topic), NULL);
+	if (ret != AZ_OK) {
+		pr_err("Error getting telemetry topic!\n");
+		return ret;
+	}
+#else
+	sprintf(telemetry_topic, MQTT_PUBLISH_TOPIC);
+#endif
+
+	/* Send the telemetry message with the MQTT client */
+	msg = (struct mqtt_message) {
+#ifndef DISABLE_SECURE_SOCKET
+		.qos = AZ_HUB_CLIENT_DEFAULT_MQTT_TELEMETRY_QOS,
+#else
+		.qos = MQTT_QOS0,
+#endif
+		.payload = buff,
+		.len = len,
+		.retained = false
+	};
+	return mqtt_publish(mqtt, telemetry_topic, &msg);
+}
+
+void mqtt_message_handler(struct mqtt_message_data *msg)
+{
+	char	buff[101];
+	int32_t	len;
+
+	/* Message.payload don't have at the end '\0' so we have to add it. */
+	len = msg->message.len > 100 ? 100 : msg->message.len;
+	memcpy(buff, msg->message.payload, len);
+	buff[len] = 0;
+
+	pr_info("Topic:%s -- Payload: %s\n", msg->topic, buff);
+}
+
+/***************************************************************************//**
+ * @brief Main function execution for maxim platform.
+ *
+ * @return ret - Result of the enabled examples execution.
+*******************************************************************************/
+int main()
+{
+	int ret;
+	uint32_t len;
+	uint8_t send_buff[BUFF_LEN];
+	uint8_t read_buff[BUFF_LEN];
+
+	struct max_i2c_init_param i2c_extra = {
+		.vssel = MXC_GPIO_VSSEL_VDDIOH
+	};
+
+	/* I2C Initialization Parameters */
+	struct no_os_i2c_init_param i2c_ip = {
+		.device_id = 1,
+		.max_speed_hz = 100000,
+		.slave_address = 0x51,
+		.platform_ops = &max_i2c_ops,
+		.extra = &i2c_extra
+	};
+
+	/* RTC Initialization Parameters */
+	struct pcf85263_init_param pcf85263_ip = {
+		.i2c_init = &i2c_ip,
+		.battery_en = 1,
+	};
+
+#ifdef RTC_SET_DEFAULT
+	struct pcf85263_date pcf85263_date = {
+		.sec = RTC_SEC_DEFAULT,
+		.min = RTC_MIN_DEFAULT,
+		.hr = RTC_HR_DEFAULT,
+		.day = RTC_DAY_DEFAULT,
+		.mon = RTC_MON_DEFAULT,
+		.year = RTC_YEAR_DEFAULT,
+	};
+#endif
+	struct pcf85263_dev *pcf85263_device;
+
+	/* Platform SPI Initialization Parameters */
+	struct max_spi_init_param spi_extra_ip  = {
+		.numSlaves = 1,
+		.polarity = SPI_SS_POL_LOW,
+		.vssel = MXC_GPIO_VSSEL_VDDIOH
+	};
+
+	/* Energy Meter SPI Initialization Parameters */
+	struct no_os_spi_init_param spi_egy_ip = {
+		.device_id = 1,
+		.max_speed_hz = 1000000,
+		.bit_order = NO_OS_SPI_BIT_ORDER_MSB_FIRST,
+		.mode = NO_OS_SPI_MODE_0,
+		.platform_ops = &max_spi_ops,
+		.chip_select = 0,
+		.extra = &spi_extra_ip,
+	};
+
+	/* ADE9430 Initialization Parameters */
+	struct ade9430_init_param ade9430_ip = {
+		.spi_init = &spi_egy_ip,
+		.temp_en = true,
+	};
+	struct ade9430_dev *ade9430_device;
+
+	struct no_os_spi_init_param spi_lcd_ip = {
+		.device_id = 1,
+		.max_speed_hz = 1000000,
+		.bit_order = NO_OS_SPI_BIT_ORDER_MSB_FIRST,
+		.mode = NO_OS_SPI_MODE_3,
+		.platform_ops = &max_spi_ops,
+		.chip_select = 2,
+		.extra = &spi_extra_ip,
+	};
+
+	struct max_gpio_init_param gpio_extra_ip = {
+		.vssel = MXC_GPIO_VSSEL_VDDIOH,
+	};
+
+	struct no_os_gpio_init_param gpio_dc_ip = {
+		.port = 2,
+		.number = 15,
+		.pull = NO_OS_PULL_NONE,
+		.platform_ops = &max_gpio_ops,
+		.extra = &gpio_extra_ip,
+	};
+
+	struct no_os_gpio_init_param gpio_lcd_rst_ip = {
+		.port = 1,
+		.number = 25,
+		.pull = NO_OS_PULL_NONE,
+		.platform_ops = &max_gpio_ops,
+		.extra = &gpio_extra_ip,
+	};
+
+	struct no_os_gpio_init_param gpio_wifi_rst_ip = {
+		.port = 2,
+		.number = 13,
+		.pull = NO_OS_PULL_NONE,
+		.platform_ops = &max_gpio_ops,
+		.extra = &gpio_extra_ip
+	};
+	struct no_os_gpio_desc *wifi_rst_gpio;
+
+	/* Display Initialization parameters */
+	struct nhd_c12832a1z_init_param nhd_c12832a1z_ip = {
+		.spi_ip = &spi_lcd_ip,
+		.dc_pin_ip = &gpio_dc_ip,
+		.reset_pin_ip = &gpio_lcd_rst_ip
+	};
+	struct nhd_c12832a1z_dev *nhd_c12832a1z_device;
+
+	struct no_os_irq_init_param irq_init_param = {
+		.irq_ctrl_id = INTC_DEVICE_ID,
+		.platform_ops = &max_irq_ops,
+		.extra = NULL
+	};
+	struct no_os_irq_ctrl_desc *irq_desc;
+
+	struct max_uart_init_param ip = {
+		.flow = UART_FLOW_DIS
+	};
+
+	struct no_os_uart_init_param luart_par = {
+		.device_id = UART_DEVICE_ID,
+		.irq_id = UART_IRQ_ID,
+		.asynchronous_rx = true,
+		.baud_rate = UART_BAUDRATE,
+		.size = NO_OS_UART_CS_8,
+		.parity = NO_OS_UART_PAR_NO,
+		.stop = NO_OS_UART_STOP_1_BIT,
+		.platform_ops = &max_uart_ops,
+		.extra = &ip
+	};
+	struct no_os_uart_desc *uart_desc;
+
+	ret = pcf85263_init(&pcf85263_device, pcf85263_ip);
+	if (ret) {
+		pr_err("Error RTC initialization!\n");
+		goto error_pcf;
+	}
+
+#ifdef RTC_SET_DEFAULT
+	ret = pcf85263_set_date(pcf85263_device, pcf85263_date);
+	if (ret) {
+		pr_err("Error setting RTC initial date and time!\n");
+		goto error_pcf;
+	}
+#endif
+
+	/* Hardware Reset for the Wifi Module */
+	ret = no_os_gpio_get(&wifi_rst_gpio, &gpio_wifi_rst_ip);
+	if (ret) {
+		pr_err("Error getting wifi reset gpio!\n");
+		goto error_pcf;
+	}
+
+	ret = no_os_gpio_direction_output(wifi_rst_gpio, NO_OS_GPIO_LOW);
+	if (ret) {
+		pr_err("Error setting wifi reset gpio low!\n");
+		goto error_gpio_rst;
+	}
+
+	no_os_mdelay(500);
+
+	ret = no_os_gpio_set_value(wifi_rst_gpio, NO_OS_GPIO_HIGH);
+	if (ret) {
+		pr_err("Error setting wifi reset gpio high!\n");
+		goto error_gpio_rst;
+	}
+
+	/* Allow the wifi module to bring up after reset */
+	no_os_mdelay(2000);
+
+	ret = ade9430_init(&ade9430_device, ade9430_ip);
+	if (ret) {
+		pr_err("Error ADE9430 initialization!\n");
+		goto error_ade9430;
+	}
+
+	ret = ade9430_set_egy_model(ade9430_device, ADE9430_EGY_NR_SAMPLES,
+				    ADE9430_SAMPLES_NR);
+	if (ret) {
+		pr_err("Error setting the energy use model!\n");
+		goto error_ade9430;
+	}
+
+	ret = nhd_c12832a1z_init(&nhd_c12832a1z_device, nhd_c12832a1z_ip);
+	if (ret) {
+		pr_err("Error LCD initialization!\n");
+		goto error_nhd;
+	}
+
+	ret = no_os_irq_ctrl_init(&irq_desc, &irq_init_param);
+	if (ret) {
+		pr_err("Error irq controller initialization!\n");
+		goto error_nhd;
+	}
+
+	ret = no_os_irq_global_enable(irq_desc);
+	if (ret) {
+		pr_err("Error irq global enable!\n");
+		goto error_irq;
+	}
+
+	ret = no_os_uart_init(&uart_desc, &luart_par);
+	if (ret) {
+		pr_err("Error no_os_uart_init!\n");
+		goto error_irq;
+	}
+
+	static struct wifi_desc *wifi;
+	struct wifi_init_param wifi_param = {
+		.irq_desc = irq_desc,
+		.uart_desc = uart_desc,
+		.uart_irq_conf = uart_desc,
+		.uart_irq_id = UART_IRQ_ID,
+		.sw_reset_en = false
+	};
+	ret = wifi_init(&wifi, &wifi_param);
+	if (ret) {
+		pr_err("Error wifi_init!\n");
+		goto error_uart;
+	}
+
+	ret = wifi_connect(wifi, WIFI_SSID, WIFI_PWD);
+	if (ret) {
+		pr_err("Error wifi connection!\n");
+		goto error_wifi;
+	}
+
+	struct tcp_socket_init_param socket_param;
+	struct tcp_socket_desc	*sock;
+	socket_param.max_buff_size = 0;
+
+	wifi_get_network_interface(wifi, &socket_param.net);
+	if (ret) {
+		pr_err("Error getting wifi network interface!\n");
+		goto error_wifi;
+	}
+
+	struct no_os_timer_init_param timer_init_param = {
+		.id = TIMER_ID,
+		.freq_hz = 32000,
+		.ticks_count = 0,
+		.platform_ops = &max_timer_ops,
+		.extra = NULL
+	};
+
+	struct mqtt_connect_config conn_config = {
+		.version = MQTT_CONFIG_VERSION,
+		.keep_alive_ms = MQTT_CONFIG_KEEP_ALIVE,
+		.password = MQTT_CONFIG_CLI_PASS
+	};
+
+	struct socket_address mqtt_broker_addr = {
+		.port = SERVER_PORT
+	};
+
+	/* Initialize mqtt descriptor */
+	struct mqtt_init_param  mqtt_init_param = {
+		.timer_init_param = &timer_init_param,
+		.command_timeout_ms = MQTT_CONFIG_CMD_TIMEOUT,
+		.send_buff = send_buff,
+		.read_buff = read_buff,
+		.send_buff_size = BUFF_LEN,
+		.read_buff_size = BUFF_LEN,
+		.message_handler = mqtt_message_handler
+	};
+	struct mqtt_desc		*mqtt;
+
+#ifndef DISABLE_SECURE_SOCKET
+	struct mqtt_message	msg;
+	char my_ca_cert[] = CA_CERT;
+	char my_cli_cert[] = DEVICE_CERT;
+	char my_cli_pk[] = DEVICE_PRIVATE_KEY;
+
+	struct no_os_trng_init_param trng_ip = {
+		.platform_ops = &max_trng_ops
+	};
+
+	struct secure_init_param sip = {
+		.trng_init_param = &trng_ip,
+		.ca_cert = my_ca_cert,
+		.ca_cert_len = NO_OS_ARRAY_SIZE(my_ca_cert),
+		.cli_cert = my_cli_cert,
+		.cli_cert_len = NO_OS_ARRAY_SIZE(my_cli_cert),
+		.cli_pk = my_cli_pk,
+		.cli_pk_len = NO_OS_ARRAY_SIZE(my_cli_pk),
+		.cert_verify_mode = MBEDTLS_SSL_VERIFY_NONE
+	};
+
+	socket_param.secure_init_param = &sip;
+
+#ifdef CONFIG_DPS
+	mqtt_broker_addr.addr = DPS_SERVER_ADDR;
+	sip.hostname = DPS_SERVER_ADDR;
+
+	ret = socket_init(&sock, &socket_param);
+	if (ret) {
+		pr_err("Error Azure DPS socket initalization!\n");
+		goto error_wifi;
+	}
+
+	ret = socket_connect(sock, &mqtt_broker_addr);
+	if (ret) {
+		pr_err("Error Azure DPS socket connect!\n");
+		goto error_sock;
+	}
+
+	mqtt_init_param.sock = sock;
+
+	ret = create_and_configure_mqtt_client_for_provisioning();
+	if (ret != AZ_OK)
+		goto error_sock;
+
+	pr_info("Connection with \"%s\" established\n", mqtt_broker_addr.addr);
+
+	ret = mqtt_init(&mqtt, &mqtt_init_param);
+	if (ret) {
+		pr_err("Error Azure DPS mqtt init!\n");
+		goto error_sock;
+	}
+
+	conn_config.client_name = mqtt_dps_client_id;
+	conn_config.username = mqtt_dps_user_name;
+
+	ret = mqtt_connect(mqtt, &conn_config, NULL);
+	if (ret) {
+		pr_err("Error Azure DPS mqtt connect!\n");
+		goto error_mqtt;
+	}
+
+	ret = mqtt_subscribe(mqtt, AZ_IOT_PROVISIONING_CLIENT_REGISTER_SUBSCRIBE_TOPIC,
+			     1, NULL);
+	if (ret) {
+		pr_err("Error Azure DPS MQTT subscribe!\n");
+		goto error_mqtt;
+	}
+	pr_info("Subscribed to topic: %s\n",
+		AZ_IOT_HUB_CLIENT_TWIN_RESPONSE_SUBSCRIBE_TOPIC);
+
+	msg = (struct mqtt_message) {
+		.qos = MQTT_QOS1,
+		.payload = mqtt_payload,
+		.len = (int)mqtt_payload_length,
+		.retained = false
+	};
+
+	ret = mqtt_publish(mqtt, register_topic_buffer, &msg);
+	if (ret) {
+		pr_err("Error Azure DPS mqtt publish!\n");
+		goto error_mqtt;
+	}
+
+	ret = mqtt_disconnect(mqtt);
+	if (ret) {
+		pr_err("Error Azure DPS mqtt disconnect!\n");
+		goto error_mqtt;
+	}
+
+	ret = mqtt_remove(mqtt);
+	if (ret) {
+		pr_err("Error Azure DPS mqtt remove!\n");
+		goto error_sock;
+	}
+
+	ret = socket_disconnect(sock);
+	if (ret) {
+		pr_err("Error Azure DPS socket disconnect!\n");
+		goto error_sock;
+	}
+
+	ret = socket_remove(sock);
+	if (ret) {
+		pr_err("Error Azure DPS socket remove!\n");
+		goto error_wifi;
+	}
+#endif
+	mqtt_broker_addr.addr = SERVER_ADDR;
+	sip.hostname = SERVER_ADDR;
+
+	ret = socket_init(&sock, &socket_param);
+	if (ret) {
+		pr_err("Error Azure Hub socket init!\n");
+		goto error_wifi;;
+	}
+
+	ret = socket_connect(sock, &mqtt_broker_addr);
+	if (ret) {
+		pr_err("Error Azure Hub socket connect!\n");
+		goto error_sock;
+	}
+
+	mqtt_init_param.sock = sock;
+
+	ret = mqtt_init(&mqtt, &mqtt_init_param);
+	if (ret) {
+		pr_err("Error Azure Hub mqtt_init!\n");
+		goto error_sock;
+	}
+
+	ret = create_and_configure_mqtt_client_for_iot_hub();
+	if (ret != AZ_OK)
+		goto error_mqtt;
+
+	conn_config.client_name = mqtt_hub_client_id;
+	conn_config.username = mqtt_hub_user_name;
+
+	ret = mqtt_connect(mqtt, &conn_config, NULL);
+	if (ret) {
+		pr_err("Error Azure Hub mqtt connect!\n");
+		goto error_mqtt;
+	}
+
+	//Subscribe to twin response topic
+	ret = mqtt_subscribe(mqtt, AZ_IOT_HUB_CLIENT_TWIN_RESPONSE_SUBSCRIBE_TOPIC,
+			     MQTT_QOS0, NULL);
+	if (ret) {
+		pr_err("Error Azure Hub mqtt subscribe!\n");
+		goto error_mqtt;
+	}
+
+	pr_info("Subscribed to topic: %s\n",
+		AZ_IOT_HUB_CLIENT_TWIN_RESPONSE_SUBSCRIBE_TOPIC);
+
+	char twin_buff[100];
+	len = sprintf(twin_buff, "{\"key\":\"value\"}");
+
+	msg = (struct mqtt_message) {
+		.qos = AZ_HUB_CLIENT_DEFAULT_MQTT_TELEMETRY_QOS,
+		.payload = twin_buff,
+		.len = len,
+		.retained = false
+	};
+
+	ret = mqtt_publish(mqtt, reported_topic, &msg);
+	if (ret)
+		goto error_mqtt;
+
+	ret = mqtt_yield(mqtt, SCAN_SENSOR_TIME);
+	if (ret) {
+		pr_err("Error Azure Hub mqtt yield!\n");
+		goto error_mqtt;
+	}
+#else
+	mqtt_broker_addr.addr = SERVER_ADDR;
+
+	ret = socket_init(&sock, &socket_param);
+	if (ret) {
+		pr_err("Error socket_init!\n");
+		goto error_wifi;
+	}
+
+	ret = socket_connect(sock, &mqtt_broker_addr);
+	if (ret) {
+		pr_err("Error socket_connect!\n");
+		goto error_sock;
+	}
+
+	mqtt_init_param.sock = sock;
+
+	ret = mqtt_init(&mqtt, &mqtt_init_param);
+	if (ret) {
+		pr_err("Error mqtt_init!\n");
+		goto error_sock;
+	}
+
+	conn_config.client_name = MQTT_CONFIG_CLIENT_NAME;
+	conn_config.username = MQTT_CONFIG_CLI_USER;
+
+	ret = mqtt_connect(mqtt, &conn_config, NULL);
+	if (ret) {
+		pr_err("Error mqtt_connect!\n");
+		goto error_mqtt;
+	}
+
+	pr_info("Connected to mqtt broker\n");
+
+	ret = mqtt_subscribe(mqtt, MQTT_SUBSCRIBE_TOPIC, MQTT_QOS0, NULL);
+	if (ret) {
+		pr_err("Error mqtt_subscribe!\n");
+		goto error_mqtt;
+	}
+
+	pr_info("Subscribed to topic: %s\n", MQTT_SUBSCRIBE_TOPIC);
+#endif
+
+	while (true) {
+		ret = read_and_send(mqtt, ade9430_device, nhd_c12832a1z_device,
+				    pcf85263_device);
+		if (ret) {
+			pr_err("Error read_and_send!\n");
+			goto error_mqtt;
+		}
+
+		pr_info("Data sent to broker\n");
+
+		/* Dispatch new mqtt mesages if any during SCAN_SENSOR_TIME */
+		ret = mqtt_yield(mqtt, SCAN_SENSOR_TIME);
+		if (ret) {
+			pr_err("Error mqtt_yield!\n");
+			goto error_mqtt;
+		}
+	}
+
+	return 0;
+
+error_mqtt:
+	mqtt_remove(mqtt);
+error_sock:
+	socket_remove(sock);
+error_wifi:
+	wifi_remove(wifi);
+error_uart:
+	no_os_uart_remove(uart_desc);
+error_irq:
+	no_os_irq_ctrl_remove(irq_desc);
+error_nhd:
+	nhd_c12832a1z_remove(nhd_c12832a1z_device);
+error_ade9430:
+	ade9430_remove(ade9430_device);
+error_gpio_rst:
+	no_os_gpio_remove(wifi_rst_gpio);
+error_pcf:
+	pcf85263_remove(pcf85263_device);
+
+	return ret;
+}

--- a/projects/eval-ade9430/src/app/noos_mbedtls_config.h
+++ b/projects/eval-ade9430/src/app/noos_mbedtls_config.h
@@ -1,0 +1,241 @@
+/***************************************************************************//**
+ *   @file   noos_mbedtls_config.h
+ *   @brief  Config to build mbedtls library
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ *   @copyright
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef NOOS_MBEDTLS_CONFIG_H
+#define NOOS_MBEDTLS_CONFIG_H
+
+/******************************************************************************/
+/***************************** User configuration *****************************/
+/******************************************************************************/
+
+/*
+ * For an easy configuration of mbedtls library only this macros from user
+ * configuration should be modified. For more in deepth configuration see
+ * https://tls.mbed.org/ and noos/libraries/mbedtls/includes/config.h
+ */
+
+#define MBEDTLS_DEBUG_C
+#define MBEDTLS_ERROR_C
+
+/* Latest supported version by mbedtls */
+#define ENABLE_TLS1_2
+
+/*
+ * Enabled chipersuites.
+ * Ordered from most preferred to least preferred in terms of security.
+ *
+ * These are the chipersuites supported by http://test.mosquitto.org
+ * or the local mqtt server: https://mosquitto.org/download
+ * For the moment there will be examples only for this servers but these
+ * chipersuites should work for other servers too.
+ */
+
+//#define ENABLE_CHIPERSUITE_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+//#define ENABLE_CHIPERSUITE_ECDHE_RSA_WITH_AES_256_CBC_SHA
+#define ENABLE_CHIPERSUITE_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+//#define ENABLE_CHIPERSUITE_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+//#define ENABLE_CHIPERSUITE_ECDHE_RSA_WITH_AES_128_CBC_SHA
+
+/* Eliptic curves to be used by the chiper */
+#define ENABLE_ECP_DP_SECP256R1_ENABLED
+//#define ENABLE_ECP_DP_SECP384R1_ENABLED
+
+/*
+ * Parse certificates in PEM format.
+ * If not defined, only DER format can be used.
+ * On ADuCM3029 DER is recommended due to memmory limitations
+ */
+#define ENABLE_PEM_CERT
+
+/*
+ * Maximum length (in bytes) of incoming and outgoing plaintext fragments.
+ * If not defined, default of 16kb will be used.
+ * 2000 is a eoungh to do the tls handshake and is no to much
+ * platforms with memory constrains like ADuCM3029
+ */
+//#define MAX_CONTENT_LEN 2500
+
+/*
+ * ENABLE_MEMORY_OPTIMIZATIONS should be defined in the case memory
+ * is not enough. This could happen is using both a secure connection with
+ * server an client verification.
+ */
+#define ENABLE_MEMORY_OPTIMIZATIONS
+
+/******************************************************************************/
+/********************* Minimal tls client requirements ************************/
+/******************************************************************************/
+
+/* Minimal requirements */
+/* Hardware entropy is used (trng.h) */
+#define MBEDTLS_NO_PLATFORM_ENTROPY
+/* Needed in order to use TLS features */
+#define MBEDTLS_SSL_TLS_C
+/* TLS Client features */
+#define MBEDTLS_SSL_CLI_C
+
+/*
+ * Define available chippersuites. Available only if the requierements are meet.
+ * The requierements are generated depending on user configuration
+ */
+#define MBEDTLS_SSL_CIPHERSUITES \
+	MBEDTLS_TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,\
+	MBEDTLS_TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,\
+	MBEDTLS_TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,\
+	MBEDTLS_TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,\
+	MBEDTLS_TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+
+/******************************************************************************/
+/*************** Configuration depending on user input ************************/
+/******************************************************************************/
+
+#ifdef MAX_CONTENT_LEN
+#define MBEDTLS_SSL_MAX_CONTENT_LEN	MAX_CONTENT_LEN
+#endif
+
+#ifdef ENABLE_TLS1_2
+
+#define MBEDTLS_SSL_PROTO_TLS1_2
+
+/* Key exchange enabled types */
+#if (defined(ENABLE_CHIPERSUITE_ECDHE_RSA_WITH_AES_256_GCM_SHA384) || \
+	defined(ENABLE_CHIPERSUITE_ECDHE_RSA_WITH_AES_256_CBC_SHA)    || \
+	defined(ENABLE_CHIPERSUITE_ECDHE_RSA_WITH_AES_128_GCM_SHA256) || \
+	defined(ENABLE_CHIPERSUITE_ECDHE_RSA_WITH_AES_128_CBC_SHA256) || \
+	defined(ENABLE_CHIPERSUITE_ECDHE_RSA_WITH_AES_128_CBC_SHA) )
+
+/* Enable KEY_EXCHANGE_ECDHE_RSA_ENABLED if used one of these chipersuites is defined */
+#define MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
+
+#endif /* Chipers that use ENABLE_KEY_EXCHANGE_ECDHE_RSA_ENABLED */
+#endif /* ENABLE_TLS1_2 */
+
+#ifdef ENABLE_MEMORY_OPTIMIZATIONS
+
+#define MBEDTLS_AES_ROM_TABLES
+#define MBEDTLS_ECP_WINDOW_SIZE 2
+
+#endif /* ENABLE_MEMORY_OPTIMIZATIONS */
+
+#ifdef ENABLE_PEM_CERT
+
+#define MBEDTLS_BASE64_C
+#define MBEDTLS_PEM_PARSE_C
+
+#endif /* ENABLE_PEM_CERT */
+
+/******************************************************************************/
+/**************** Solve dependencies needed by modules ************************/
+/******************************************************************************/
+
+/* Dependencies for MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED */
+#ifdef MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
+
+#define MBEDTLS_RSA_C
+#define MBEDTLS_BIGNUM_C
+#define MBEDTLS_OID_C
+#define MBEDTLS_ECDH_C
+#define MBEDTLS_ECP_C
+#define MBEDTLS_PK_C
+#define MBEDTLS_PK_PARSE_C
+#define MBEDTLS_PKCS1_V15
+#define MBEDTLS_ASN1_PARSE_C
+#define MBEDTLS_X509_USE_C
+#define MBEDTLS_X509_CRT_PARSE_C
+
+#ifdef ENABLE_ECP_DP_SECP256R1_ENABLED
+#define MBEDTLS_ECP_DP_SECP256R1_ENABLED
+#endif
+#ifdef ENABLE_ECP_DP_SECP384R1_ENABLED
+#define MBEDTLS_ECP_DP_SECP384R1_ENABLED
+#endif
+
+#endif /* MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED */
+
+#ifdef MBEDTLS_SSL_TLS_C
+#define MBEDTLS_MD_C
+#define MBEDTLS_CIPHER_C
+#endif /* MBEDTLS_SSL_TLS_C */
+
+#if (defined(ENABLE_CHIPERSUITE_ECDHE_RSA_WITH_AES_256_GCM_SHA384) ||\
+		defined(ENABLE_CHIPERSUITE_ECDHE_RSA_WITH_AES_256_CBC_SHA) ||\
+		defined(ENABLE_CHIPERSUITE_ECDHE_RSA_WITH_AES_128_CBC_SHA) ||\
+		defined(ENABLE_CHIPERSUITE_ECDHE_RSA_WITH_AES_128_GCM_SHA256) ||\
+		defined(ENABLE_CHIPERSUITE_ECDHE_RSA_WITH_AES_128_CBC_SHA256) )
+
+# define MBEDTLS_AES_C
+
+# if (defined(ENABLE_CHIPERSUITE_ECDHE_RSA_WITH_AES_256_CBC_SHA) || \
+	defined(ENABLE_CHIPERSUITE_ECDHE_RSA_WITH_AES_128_CBC_SHA) || \
+	defined(ENABLE_CHIPERSUITE_ECDHE_RSA_WITH_AES_128_CBC_SHA256) )
+#  define MBEDTLS_CIPHER_MODE_CBC
+#  if defined(ENABLE_CHIPERSUITE_ECDHE_RSA_WITH_AES_128_CBC_SHA256)
+#   define MBEDTLS_SHA256_C
+#  endif
+#  if (defined(ENABLE_CHIPERSUITE_ECDHE_RSA_WITH_AES_256_CBC_SHA) || \
+	defined(ENABLE_CHIPERSUITE_ECDHE_RSA_WITH_AES_128_CBC_SHA))
+#   define MBEDTLS_SHA1_C
+#  endif
+# endif
+
+# if (defined(ENABLE_CHIPERSUITE_ECDHE_RSA_WITH_AES_128_GCM_SHA256) || \
+	defined(ENABLE_CHIPERSUITE_ECDHE_RSA_WITH_AES_256_GCM_SHA384))
+#  define MBEDTLS_GCM_C
+#  if (defined(ENABLE_CHIPERSUITE_ECDHE_RSA_WITH_AES_128_GCM_SHA256))
+#   define MBEDTLS_SHA256_C
+#  endif
+#  if (defined(ENABLE_CHIPERSUITE_ECDHE_RSA_WITH_AES_256_GCM_SHA384))
+#   define MBEDTLS_SHA512_C
+#  endif
+# endif
+
+#endif
+
+#ifdef MBEDTLS_SSL_PROTO_TLS1_2
+#if (!defined(MBEDTLS_SHA512_C) && !defined(MBEDTLS_SHA256_C) &&\
+		!defined(MBEDTLS_SHA1_C))
+#define MBEDTLS_SHA256_C
+#endif
+#endif /* MBEDTLS_SSL_PROTO_TLS1_2 */
+
+/* Check if the configuration is ok */
+#include "mbedtls/check_config.h"
+
+#endif /* NOOS_MBEDTLS_CONFIG_H */

--- a/projects/eval-ade9430/src/app/parameters.h
+++ b/projects/eval-ade9430/src/app/parameters.h
@@ -1,0 +1,191 @@
+/***************************************************************************//**
+ *   @file   parameters.h
+ *   @brief  Definitions specific to Maxim platform used by eval-ade9430
+ *           project.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#ifndef DISABLE_SECURE_SOCKET
+#include "iot_sample_common.h"
+#endif
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+#define UART_DEVICE_ID		1
+#define INTC_DEVICE_ID		0
+#define UART_IRQ_ID		UART1_IRQn
+#define UART_BAUDRATE		57600
+
+#ifdef RTC_SET_DEFAULT
+/* RTC BCD Format (example 26.01.2023-13:15:00) */
+#define RTC_SEC_DEFAULT		0x0
+#define RTC_MIN_DEFAULT		0x15
+#define RTC_HR_DEFAULT		0x13
+#define RTC_DAY_DEFAULT		0x26
+#define RTC_MON_DEFAULT		0x1
+#define RTC_YEAR_DEFAULT	0x23
+#endif
+
+/* 1 sec acuumulation */
+#define ADE9430_SAMPLES_NR  7999
+
+/* Wifi Parameters */
+#define WIFI_SSID	            "WifiSSID"
+#define WIFI_PWD	            "WifiPassword"
+
+#ifndef DISABLE_SECURE_SOCKET
+/* Server Port is common for both IoT and DPS */
+#define SERVER_PORT				8883
+/* Azure IoT Hub Server Address */
+#define SERVER_ADDR				"iot-hub-mopdcwnti4mly.azure-devices.net"
+/* Azure Device Provisioning Service Server Address */
+#define DPS_SERVER_ADDR				"dps-mopdcwnti4mly.azure-devices-provisioning.net"
+#define AZ_IOT_PROVISIONING_CUSTOM_PAYLOAD	"{\"modelId\":\"dtmi:com:analog:ADX12345;1\"}"
+#define AZ_IOT_PROVISIONING_ID_SCOPE		"0ne009919BB"
+#define AZ_IOT_PROVISIONING_REGISTRATION_ID	"EnergyMonitoringDevice1"
+#define SAMPLE_TYPE				PAHO_IOT_PROVISIONING
+#define REGISTER_TOPIC_BUFFER_LENGTH		128
+#define PROVISIONING_ENDPOINT_BUFFER_LENGTH	256
+#define MQTT_PAYLOAD_BUFFER_LENGTH		256
+#define CLIENT_ID_BUFFER_LENGTH			128
+#else
+/* MQTT Broker Parameters, non-encrypted communication */
+#define SERVER_PORT             1883
+#define SERVER_ADDR             "192.168.128.123"
+#define MQTT_PUBLISH_TOPIC	"ade9430"
+#define MQTT_SUBSCRIBE_TOPIC	"maxim_messages"
+#define MQTT_CONFIG_CLIENT_NAME	"maxim-client"
+#define MQTT_CONFIG_CLI_USER	NULL
+#endif
+
+#define BUFF_LEN		200
+#define TIMER_ID		1
+#define MQTT_CONFIG_CMD_TIMEOUT	20000
+
+/* For Azure encrypted communication MQTT version 3.1.1. is required.*/
+#ifndef DISABLE_SECURE_SOCKET
+#define MQTT_CONFIG_VERSION     MQTT_VERSION_3_1_1
+#else
+#define MQTT_CONFIG_VERSION     MQTT_VERSION_3_1
+#endif
+
+#define MQTT_CONFIG_CLI_PASS	NULL
+#define MQTT_CONFIG_KEEP_ALIVE	7200
+#define SCAN_SENSOR_TIME	500
+
+#ifndef DISABLE_SECURE_SOCKET
+/* Populate here your CA certificate content */
+#define CA_CERT                                                            \
+    "-----BEGIN CERTIFICATE-----\r\n"                                      \
+	"MIIDHzCCAgegAwIBAgIUCFbk7jeOFFqrrLVQjCoLQDCvNp0wDQYJKoZIhvcNAQEL\r\n"	\
+	"BQAwHzEdMBsGA1UEAwwUQW5hbG9nIERldmljZXMsIEluYy4wHhcNMjMwMjI3MTAw\r\n"	\
+	"NjQwWhcNMzIxMTI2MTAwNjQwWjAfMR0wGwYDVQQDDBRBbmFsb2cgRGV2aWNlcywg\r\n"	\
+	"SW5jLjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAPLUgsHWu4SCB11U\r\n"	\
+	"GxlmqJ3pIzP4YWdH/cww2K+OjCS4KWy5Fb//KlZMxXjZeJ6iAd5pcOvcsE4w5CQM\r\n"	\
+	"kRVxdqzLmLcVsh9hMW+dB+Aeeura8pav7TtlO3BOZxsQN/PWi8AX5g8rjO5xC9hs\r\n"	\
+	"9kxR5MAXlUOlq9WJ2T8xdtxZSQHT5pnrHEVnjd72rZlC2rAS8vYTrMxQLWm2GK+2\r\n"	\
+	"7jYhQ9jSKuvy/g5XSYI0OHlWFrzo1fDuR/Ma5aJZBzBRKOKAXl2uFweiEYVH1sZe\r\n"	\
+	"iztZlhxtxHAfJHVhnEL/wf7GnaAClCoMd4amxBuiESxrP+DU/lwwNerBbB+wMxqr\r\n"	\
+	"n+/Hb2MCAwEAAaNTMFEwHQYDVR0OBBYEFIfN1T+xxFvPuxcT8ROronOnTQDhMB8G\r\n"	\
+	"A1UdIwQYMBaAFIfN1T+xxFvPuxcT8ROronOnTQDhMA8GA1UdEwEB/wQFMAMBAf8w\r\n"	\
+	"DQYJKoZIhvcNAQELBQADggEBADpA6t61wwEqQ4yBXWk9sX5dW3NQpj/FigpWIUnf\r\n"	\
+	"geQedXfrn/zZFOC7iA05uHdjRpP+Fp4ebJNxHOMbL7TCMPOG+SBYgbMv9ZgRDAYj\r\n"	\
+	"Ca3Osm53EqeMi+26ka6xkBEHYZ+vVt1bwZOjwxzX56J6lNiKLvgQgn9EgeKpQker\r\n"	\
+	"lV12T04/NgeIm38mfRqxueYG22YrLuo+dzijwzY2wwBGntwFviXWLGDYMGiBMPSp\r\n"	\
+	"VtB5eptX+YUdO84E+86irjOIrsgqO1G7MYu8beuonIrjgmtApOtT7xPPDS39YO1J\r\n"	\
+	"mQoyLhuU7nr8QZbiLTi+dSBlytJFvPkgjrgqR7WWkLPEj0w=\r\n"	\
+    "-----END CERTIFICATE-----\r\n"
+
+/* Populate here your device certificate content */
+#define DEVICE_CERT                                                        \
+    "-----BEGIN CERTIFICATE-----\n"                                        \
+	"MIICyDCCAbACFFJnmg1mTQALnBB/w4LUQTQ+hckpMA0GCSqGSIb3DQEBCwUAMB8x\r\n" 	\
+	"HTAbBgNVBAMMFEFuYWxvZyBEZXZpY2VzLCBJbmMuMB4XDTIzMDIyNzEwMTM1NloX\r\n"	\
+	"DTIzMDMyOTEwMTM1NlowIjEgMB4GA1UEAwwXRW5lcmd5TW9uaXRvcmluZ0Rldmlj\r\n"	\
+	"ZTEwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDHjhmvEevCFkVm8g7D\r\n"	\
+	"+9DJQHwt/pmWOg11EwmsmuaCt3V+j6KfujJRoqCUqlc0/vvqiaUKxlqKRq9Rdjnq\r\n"	\
+	"YKcYvWOHT+pXpRlNPxbL/u9gL1t2PTb67UWYKQRYUaP+lH9UFJamKcVd6rDpJDbD\r\n"	\
+	"lruzQUr542G5zlzeIsT8Bw9p2Qtk54bdenMK8bcGKcJTUSlLP++30lj1E5dg57XD\r\n"	\
+	"uMiwz/dP3TC01/807K59vR3IwSCQUIbes1h3n4xTbgJrl1jx/G1FzGi/Oo5OBIQB\r\n"	\
+	"3JFIs8nMMAElGutOAdznyLTzK0IzzvJylJeOJtlbafv2KB1CehNFkXVgkqnugZSX\r\n"	\
+	"Vf4ZAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAAkI4/Bfo9bUUWmbzsfPRAACa1yr\r\n"	\
+	"ZYhPm7gjB3UO2TNI1+kZq1mbptm4AQlRKHZOc4RwOKw2+gEc++FwK9v8Ai1EcVgW\r\n"	\
+	"bCgmL1fWzxwmPCAatjWAIXIwtao4g3xPFOSw8Afg54upUNLzpLHyxyuByLOIs+TQ\r\n"	\
+	"qCpjNXMsBblrU+7XOjo0Z5qxyWGxzFkI+/MfW9F5+q0dt77f6GxBmEAj42HIou32\r\n"	\
+	"B8CohaPoJ8qJAWd9X+zKGzzstXEmmnlSX0T1H3jaL+ENRNzWpMT6ASt3u+Mq+WpY\r\n"	\
+	"che9sgKqK4yPsqewrBSacSORc0aY+Htp1MwVWjnhKI/X+7eEV6CQ3Y7FYoc=\r\n"	\
+    "-----END CERTIFICATE-----\r\n";
+
+/* Populate here your device private key content */
+#define DEVICE_PRIVATE_KEY                                                 \
+    "-----BEGIN PRIVATE KEY-----\n"                                        \
+	"MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDHjhmvEevCFkVm\r\n"	\
+	"8g7D+9DJQHwt/pmWOg11EwmsmuaCt3V+j6KfujJRoqCUqlc0/vvqiaUKxlqKRq9R\r\n"	\
+	"djnqYKcYvWOHT+pXpRlNPxbL/u9gL1t2PTb67UWYKQRYUaP+lH9UFJamKcVd6rDp\r\n"	\
+	"JDbDlruzQUr542G5zlzeIsT8Bw9p2Qtk54bdenMK8bcGKcJTUSlLP++30lj1E5dg\r\n"	\
+	"57XDuMiwz/dP3TC01/807K59vR3IwSCQUIbes1h3n4xTbgJrl1jx/G1FzGi/Oo5O\r\n"	\
+	"BIQB3JFIs8nMMAElGutOAdznyLTzK0IzzvJylJeOJtlbafv2KB1CehNFkXVgkqnu\r\n"	\
+	"gZSXVf4ZAgMBAAECggEAb6Um5XXHSw0ewxvF+wwVoaL8VtdMomnUQZ3nGbSIJrXx\r\n"	\
+	"fF9sAqUvpdCwurwakkHeOzfLKJ4U5avqRk8409JDamn7Fyc02tg5sagMXxFAZ7XX\r\n"	\
+	"G+3fpr+84gaAsdDrSXFXU3k5V7mi/Ipjc+yY3xCj7wQmqGv4rvWvq3AUeVSR4Qta\r\n"	\
+	"aq/yELOc6zkCuXoPVht6E5xsqhYE428MUVq3T8VJ8fIm410ymDRcroAeobhxzflO\r\n"	\
+	"MOX84byL7kLt6QboOHoxUV/BBH8UQWQvZv8aP1gXvPp84jj+pAcf1MdF1sLR4yGa\r\n"	\
+	"Mh5KkmcHi95SjvDS0B4Z3D2WgiN7IjeQ2tt0+TF+KQKBgQDqa9FmDEczE6aiJXCq\r\n"	\
+	"XnP2J4e4V1WCHpNN2YUcogEWHtEN97XE3Sc7iqoYSCZW7cuR3nG8fqsiIcqf2hn7\r\n"	\
+	"bfopUDqmNeV0xLCoDCXeuDnEkRrBBQXTPDoyekFH8KtqLvAFJApPBnX0TbU7bkzO\r\n"	\
+	"gEqXLNJlK4MJRCSAWV2V+v8BiwKBgQDZ7KfypeaByTLwOB4WtmlwFZWq8EFN6Wwx\r\n"	\
+	"5i3Eo8l5vhtkWws+DyJpBPpX+TAIpnYQ4PSMPNxsft2YFygIR5eBEoIEBtbDfiUv\r\n"	\
+	"svlEH6+f+71wabu0ePkMTdEf8pl36YEspFq+0Iz+o53EiqGHb+kLTDc81CAQVBl2\r\n"	\
+	"xaKQgDorawKBgQDlYLCZ2QPGL8FKQbZXjmqLfyynLRWnZ8GdWG2OkdrcSTUoJK1A\r\n"	\
+	"v2FHOqyra9XQE4iw5+eEmLFdiZEaDzCDPJ6e1Dk/L9ehBWESXiikIMGt3IpAOmjz\r\n"	\
+	"w6fygnvkJ9Oi5+DGNvi7UMgUUAE48PnIyfGysRICGqxyYbIRwN/5BIuHdwKBgCcI\r\n"	\
+	"3/BzzP00Z95lfuY8mFhOVXe//0KQbCPoAgy19dHLvqZUNIhSN6yuCpWVeggioQVW\r\n"	\
+	"9hbkk+sPMmwawb3x7O5evVExVGjCALExkrqkHlY+xmkLV2b1QE725V2em+TBu7Se\r\n"	\
+	"X+7L9mVqM0lQN6zF2+19ImvP50pldgYzUnIltcWvAoGAcolYRYjTo3gjxwD9xhAq\r\n"	\
+	"TLmCEugNmiYkCHgdOWmkHk+5AOJkctkwCGGu9+Bz1yJ46Afvv6uRO540QJKdaHBS\r\n"	\
+	"np2l72ukSASAVaM1S+HyPrz9s1bCTIpB82kHKHuxx4SSSrLuxUkRLz7rZkRvsEai\r\n"	\
+	"mKmY/gyPLJZRq4Lr1lOwoCM=\r\n"	\
+    "-----END PRIVATE KEY-----\r\n";
+#endif
+
+#endif /* __PARAMETERS_H__ */


### PR DESCRIPTION
Add support for EVAL-ADE9430 Energy Meter project.

More information is provided in the [README.md](https://github.com/analogdevicesinc/no-OS/blob/staging/ade9430_prj/projects/eval-ade9430/README.md) file.

**NOTES:**
 - Most of the parameters related to the Azure IoT and secure connection (such as certificates) were left populated with custom user specific values with the intention of providing proper example on how the formatting (i.e. cretificates) / configuration / server related values should look.
 - The project is using the old structure (since it consists a lot of initializations / re-initializations, splitting it into way too many files it is pretty hard to follow, in my opinion 😄 )

