### PR TITLE
azure library updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,5 +8,5 @@
 	path = libraries/iio/libtinyiiod
 	url = https://github.com/analogdevicesinc/libtinyiiod
 [submodule "libraries/azure-sdk-for-c"]
-	path = libraries/azure-sdk-for-c
+	path = libraries/azure/azure-sdk-for-c
 	url = https://github.com/Azure/azure-sdk-for-c.git

--- a/libraries/azure/noos-azure-toolchain.cmake
+++ b/libraries/azure/noos-azure-toolchain.cmake
@@ -1,0 +1,5 @@
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_PROCESSOR arm)
+set(CMAKE_C_COMPILER arm-none-eabi-gcc)
+set(CMAKE_CXX_COMPILER arm-none-eabi-g++)
+string(APPEND CMAKE_C_FLAGS_INIT " -mcpu=cortex-m4 -ffreestanding -nostdlib -mthumb -mfloat-abi=hard")

--- a/tools/scripts/azure_sdk_for_c.mk
+++ b/tools/scripts/azure_sdk_for_c.mk
@@ -1,4 +1,4 @@
-AZURE_DIR = $(NO-OS)/libraries/azure-sdk-for-c
+AZURE_DIR = $(NO-OS)/libraries/azure/azure-sdk-for-c
 AZURE_DIR_BUILD = $(AZURE_DIR)/build
 AZURE_DIR_BUILD_LIBS = $(AZURE_DIR_BUILD)/sdk/src/azure
 

--- a/tools/scripts/libraries.mk
+++ b/tools/scripts/libraries.mk
@@ -95,7 +95,7 @@ EXTRA_LIBS_PATHS		+= $(AZURE_DIR_BUILD_LIBS)/core
 
 AZURE_BUILD_CMD = $(shell mkdir -p $(AZURE_DIR_BUILD) && \
 		    cd $(AZURE_DIR_BUILD) && \
-		    cmake -DCMAKE_TOOLCHAIN_FILE=../cmake-modules/gcc-arm-toolchain.cmake .. >/dev/null && \
+		    cmake -DCMAKE_TOOLCHAIN_FILE=../../noos-azure-toolchain.cmake .. >/dev/null && \
 		    cmake --build . >/dev/null)
 
 CLEAN_AZURE = $(shell rm -rf $(AZURE_DIR_BUILD))


### PR DESCRIPTION
- move submodule under `libraries/azure` folder
- add custom no-os cmake toolchain file for the azure library

Should fix the build issues related to: #1682 