### PR TITLE
iio: Local backend support

### DIFF
--- a/iio/iio.c
+++ b/iio/iio.c
@@ -1912,7 +1912,20 @@ int iio_init(struct iio_desc **desc, struct iio_init_param *init_param)
 			goto free_pylink;
 	}
 #endif
-	else {
+	else if (init_param->phy_type == USE_LOCAL_BACKEND) {
+		ldesc->recv = init_param->local_backend->local_backend_event_read;
+		ldesc->send = init_param->local_backend->local_backend_event_write;
+
+		struct iiod_conn_data data = {
+			.conn = NULL,
+			.buf = init_param->local_backend->local_backend_buff,
+			.len = init_param->local_backend->local_backend_buff_len
+		};
+		ret = iiod_conn_add(ldesc->iiod, &data, &conn_id);
+		if (NO_OS_IS_ERR_VALUE(ret))
+			goto free_conns;
+		_push_conn(ldesc, conn_id);
+	} else {
 		ret = -EINVAL;
 		goto free_conns;
 	}

--- a/iio/iio.h
+++ b/iio/iio.h
@@ -57,6 +57,7 @@
 
 enum pysical_link_type {
 	USE_UART,
+	USE_LOCAL_BACKEND,
 #ifdef NO_OS_NETWORKING
 	USE_NETWORK
 #endif
@@ -97,6 +98,17 @@ struct iio_ctx_attr {
 	const char *value;
 };
 
+/**
+ * @struct iio_local_backend
+ * @brief Structure holding the local backend init parameters
+ */
+struct iio_local_backend {
+	int(*local_backend_event_read)(void *conn, uint8_t *buf, uint32_t len);
+	int(*local_backend_event_write)(void *conn, uint8_t *buf, uint32_t len);
+	char *local_backend_buff;
+	uint32_t local_backend_buff_len;
+};
+
 struct iio_init_param {
 	enum pysical_link_type	phy_type;
 	union {
@@ -105,6 +117,7 @@ struct iio_init_param {
 		struct tcp_socket_init_param *tcp_socket_init_param;
 #endif
 	};
+	struct iio_local_backend *local_backend;
 	struct iio_ctx_attr *ctx_attrs;
 	uint32_t nb_ctx_attr;
 	struct iio_device_init *devs;


### PR DESCRIPTION
Added local backend support to provide IIO communication interface to non-PC based clients. Example is local display library packaged into application binary, where display acts as an IIO client and communicate with IIO library using internal events.

Signed-off-by: MPhalke <mahesh.phalke@analog.com>