### PR TITLE
drivers: adc: ad7779: fix reference set

### DIFF
--- a/drivers/adc/ad7779/ad7779.c
+++ b/drivers/adc/ad7779/ad7779.c
@@ -738,9 +738,9 @@ int32_t ad7779_set_reference_type(ad7779_dev *dev,
 	int32_t ret;
 
 	ret = ad7779_spi_int_reg_write_mask(dev,
-					    AD7779_REG_GENERAL_USER_CONFIG_1,
-					    AD7779_PDB_REFOUT_BUF,
-					    ref_type ? AD7779_PDB_REFOUT_BUF : 0);
+					    AD7779_REG_ADC_MUX_CONFIG,
+					    AD7779_REF_MUX_CTRL(0x3),
+					    AD7779_REF_MUX_CTRL(ref_type));
 	dev->ref_type = ref_type;
 
 	return ret;
@@ -759,10 +759,10 @@ int32_t ad7779_get_reference_type(ad7779_dev *dev,
 	uint8_t reg_data;
 
 	if (!dev->read_from_cache) {
-		ret = ad7779_spi_int_reg_read(dev, AD7779_REG_GENERAL_USER_CONFIG_1, &reg_data);
+		ret = ad7779_spi_int_reg_read(dev, AD7779_REG_ADC_MUX_CONFIG, &reg_data);
 		if (ret)
 			return ret;
-		*ref_type = no_os_field_get(AD7779_PDB_REFOUT_BUF, reg_data);
+		*ref_type = no_os_field_get(AD7779_REF_MUX_CTRL(0x3), reg_data);
 	} else {
 		*ref_type = dev->ref_type;
 	}

--- a/drivers/adc/ad7779/ad7779.h
+++ b/drivers/adc/ad7779/ad7779.h
@@ -122,6 +122,9 @@
 #define AD7779_DOUT_HEADER_FORMAT		(1 << 5)
 #define AD7779_DCLK_CLK_DIV(x)			(((x) & 0x7) << 1)
 
+/* AD7779_REG_ADC_MUX_CONFIG */
+#define AD7779_REF_MUX_CTRL(x)			(((x) & 0x3) << 6)
+
 /* AD7779_REG_GLOBAL_MUX_CONFIG */
 #define AD7779_GLOBAL_MUX_CTRL(x)		(((x) & 0x1F) << 3)
 
@@ -202,6 +205,8 @@ typedef enum {
 typedef enum {
 	AD7779_EXT_REF,
 	AD7779_INT_REF,
+	AD7779_EXT_SUPPLY,
+	AD7779_EXT_REF_INV,
 } ad7779_ref_type;
 
 typedef enum {


### PR DESCRIPTION
According to the datasheet (page 78), the ADC reference is set using the ADC_MUX_CONFIG register, REF_MUX_CTRL bits.

Fixes: 2b8c1f7 ("ad7779: Initial Preliminary Version")

NOTE: the implementation was done according to the driver previous implementation (mask defines, bit defines, etc)