### PR TITLE
adrv9002_conv.c: use PRBS7 mode for TX calibration when using LVDS SSI

### DIFF
--- a/drivers/rf-transceiver/navassa/adrv9002_conv.c
+++ b/drivers/rf-transceiver/navassa/adrv9002_conv.c
@@ -271,7 +271,7 @@ int adrv9002_check_tx_test_pattern(struct adrv9002_rf_phy *phy, const int chann)
 	adi_adrv9001_SsiTestModeData_e test_data = phy->ssi_type ==
 			ADI_ADRV9001_SSI_TYPE_CMOS ?
 			ADI_ADRV9001_SSI_TESTMODE_DATA_RAMP_NIBBLE :
-			ADI_ADRV9001_SSI_TESTMODE_DATA_PRBS15;
+			ADI_ADRV9001_SSI_TESTMODE_DATA_PRBS7;
 	struct adi_adrv9001_TxSsiTestModeCfg cfg = {0};
 	struct adi_adrv9001_TxSsiTestModeStatus status = {0};
 


### PR DESCRIPTION
See EZ thread: https://ez.analog.com/wide-band-rf-transceivers/design-support-adrv9001-adrv9007/f/q-a/568188/adrv9002-3-tx-issues-when-signal-magnitude-exceeds--2-14