### PR TITLE
iio: Add handling for SET command

### DIFF
--- a/iio/iio.c
+++ b/iio/iio.c
@@ -349,6 +349,30 @@ static struct iio_trig_priv *get_iio_trig_device(struct iio_desc *desc,
 }
 
 /**
+ * @brief Sets buffers count.
+ * @param ctx           - IIO instance and conn instance.
+ * @param device        - String containing device name.
+ * @param buffers_count - Value to be set.
+ * @return Positive if index was set, negative if not.
+ */
+static int iio_set_buffers_count(struct iiod_ctx *ctx, const char *device,
+				 uint32_t buffers_count)
+{
+	struct iio_desc *desc = ctx->instance;
+
+	if(!get_iio_device(desc, device))
+		return -ENODEV;
+
+	/* Our implementation uses a circular buffer to send/receive data so
+	 * only 1 is a valid value.
+	 */
+	if (buffers_count != 1)
+		return -EINVAL;
+
+	return 0;
+}
+
+/**
  * @brief Read all attributes from an attribute list.
  * @param device - Physical instance of a device.
  * @param buf - Buffer where values are read.
@@ -1867,6 +1891,7 @@ int iio_init(struct iio_desc **desc, struct iio_init_param *init_param)
 	ops->close = iio_close_dev;
 	ops->send = iio_send;
 	ops->recv = iio_recv;
+	ops->set_buffers_count = iio_set_buffers_count;
 
 	iiod_param.instance = ldesc;
 	iiod_param.ops = ops;

--- a/iio/iiod.c
+++ b/iio/iiod.c
@@ -170,7 +170,7 @@ static int32_t iiod_parse_set(const char *token, struct comand_desc *res,
 	if (!token)
 		return -EINVAL;
 
-	if (strcmp(token, "BUFFERS_COUNT") != 0)
+	if (!strcmp(token, "BUFFERS_COUNT"))
 		return -EINVAL;
 
 	token = strtok_r(NULL, delim, ctx);
@@ -459,7 +459,7 @@ static int32_t call_op(struct iiod_ops *ops, struct comand_desc *data,
 		return ops->set_trigger(ctx, data->device, data->trigger,
 					strlen(data->trigger));
 	case IIOD_CMD_SET:
-		break;
+		return ops->set_buffers_count(ctx, data->device, data->count);
 	default:
 		break;
 	}


### PR DESCRIPTION
Currently SET command always returns -EINVAL.
Modify implementation such that SET command is working with BUFFERS_SIZE equal to 1, which actually describes the back-end implementation we are using (only one circular buffer is available).