### PR TITLE
.gitignore: ignore generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ aducm_build
 *.sopcinfo
 
 local_variables.mk
+*generated*


### PR DESCRIPTION
For stm platform there are some extra source files generated. Make sure that these are ignored by git.