### PR TITLE
drivers: maxim: spi: use snake case

### DIFF
--- a/drivers/platform/maxim/max32650/maxim_spi.c
+++ b/drivers/platform/maxim/max32650/maxim_spi.c
@@ -248,7 +248,7 @@ static int _max_spi_config(struct no_os_spi_desc *desc)
 
 	ret = MXC_SPI_Init(MXC_SPI_GET_SPI(desc->device_id), SPI_MASTER_MODE,
 			   SPI_SINGLE_MODE,
-			   eparam->numSlaves, eparam->polarity, desc->max_speed_hz);
+			   eparam->num_slaves, eparam->polarity, desc->max_speed_hz);
 	if (ret) {
 		ret = -EINVAL;
 		goto err_init;

--- a/drivers/platform/maxim/max32650/maxim_spi.h
+++ b/drivers/platform/maxim/max32650/maxim_spi.h
@@ -55,7 +55,7 @@ enum spi_ss_polarity {
 };
 
 struct max_spi_init_param {
-	uint32_t numSlaves;
+	uint32_t num_slaves;
 	enum spi_ss_polarity polarity;
 	mxc_gpio_vssel_t vssel;
 };

--- a/drivers/platform/maxim/max32655/maxim_spi.c
+++ b/drivers/platform/maxim/max32655/maxim_spi.c
@@ -164,7 +164,7 @@ static int _max_spi_config(struct no_os_spi_desc *desc)
 
 	ret = MXC_SPI_Init(MXC_SPI_GET_SPI(desc->device_id), SPI_MASTER_MODE,
 			   SPI_SINGLE_MODE,
-			   eparam->numSlaves, eparam->polarity, desc->max_speed_hz, spi_pins_config);
+			   eparam->num_slaves, eparam->polarity, desc->max_speed_hz, spi_pins_config);
 	if (ret) {
 		ret = -EINVAL;
 		goto err_init;

--- a/drivers/platform/maxim/max32655/maxim_spi.h
+++ b/drivers/platform/maxim/max32655/maxim_spi.h
@@ -55,7 +55,7 @@ enum spi_ss_polarity {
 };
 
 struct max_spi_init_param {
-	uint32_t numSlaves;
+	uint32_t num_slaves;
 	enum spi_ss_polarity polarity;
 	mxc_gpio_vssel_t vssel;
 };

--- a/drivers/platform/maxim/max32660/maxim_spi.c
+++ b/drivers/platform/maxim/max32660/maxim_spi.c
@@ -153,7 +153,7 @@ static int _max_spi_config(struct no_os_spi_desc *desc)
 
 	ret = MXC_SPI_Init(MXC_SPI_GET_SPI(desc->device_id), SPI_MASTER_MODE,
 			   SPI_SINGLE_MODE,
-			   eparam->numSlaves, eparam->polarity, desc->max_speed_hz);
+			   eparam->num_slaves, eparam->polarity, desc->max_speed_hz);
 	if (ret) {
 		ret = -EINVAL;
 		goto err_init;

--- a/drivers/platform/maxim/max32660/maxim_spi.h
+++ b/drivers/platform/maxim/max32660/maxim_spi.h
@@ -55,7 +55,7 @@ enum spi_ss_polarity {
 };
 
 struct max_spi_init_param {
-	uint32_t numSlaves;
+	uint32_t num_slaves;
 	enum spi_ss_polarity polarity;
 	mxc_gpio_vssel_t vssel;
 };

--- a/drivers/platform/maxim/max32665/maxim_spi.c
+++ b/drivers/platform/maxim/max32665/maxim_spi.c
@@ -240,7 +240,7 @@ static int _max_spi_config(struct no_os_spi_desc *desc)
 
 	ret = MXC_SPI_Init(MXC_SPI_GET_SPI(desc->device_id), SPI_MASTER_MODE,
 			   SPI_SINGLE_MODE,
-			   eparam->numSlaves, eparam->polarity, desc->max_speed_hz, MAP_A);
+			   eparam->num_slaves, eparam->polarity, desc->max_speed_hz, MAP_A);
 	if (ret) {
 		ret = -EINVAL;
 		goto err_init;

--- a/drivers/platform/maxim/max32665/maxim_spi.h
+++ b/drivers/platform/maxim/max32665/maxim_spi.h
@@ -54,7 +54,7 @@ enum spi_ss_polarity {
 };
 
 struct max_spi_init_param {
-	uint32_t numSlaves;
+	uint32_t num_slaves;
 	enum spi_ss_polarity polarity;
 	mxc_gpio_vssel_t vssel;
 };

--- a/drivers/platform/maxim/max32670/maxim_spi.c
+++ b/drivers/platform/maxim/max32670/maxim_spi.c
@@ -68,7 +68,7 @@ static int _max_spi_config(struct no_os_spi_desc *desc)
 
 	ret = MXC_SPI_Init(MXC_SPI_GET_SPI(desc->device_id), SPI_MASTER_MODE,
 			   SPI_SINGLE_MODE,
-			   eparam->numSlaves, eparam->polarity, desc->max_speed_hz);
+			   eparam->num_slaves, eparam->polarity, desc->max_speed_hz);
 	if (ret) {
 		ret = -EINVAL;
 		goto err_init;

--- a/drivers/platform/maxim/max32670/maxim_spi.h
+++ b/drivers/platform/maxim/max32670/maxim_spi.h
@@ -59,7 +59,7 @@ enum spi_ss_polarity {
  * @brief Maxim specific SPI initialization parameters
  */
 struct max_spi_init_param {
-	uint32_t numSlaves;
+	uint32_t num_slaves;
 	enum spi_ss_polarity polarity;
 };
 

--- a/drivers/platform/maxim/max78000/maxim_spi.c
+++ b/drivers/platform/maxim/max78000/maxim_spi.c
@@ -159,7 +159,7 @@ static int _max_spi_config(struct no_os_spi_desc *desc)
 
 	ret = MXC_SPI_Init(MXC_SPI_GET_SPI(desc->device_id), SPI_MASTER_MODE,
 			   SPI_SINGLE_MODE,
-			   eparam->numSlaves, eparam->polarity, desc->max_speed_hz, spi_pins_config);
+			   eparam->num_slaves, eparam->polarity, desc->max_speed_hz, spi_pins_config);
 	if (ret) {
 		ret = -EINVAL;
 		goto err_init;

--- a/drivers/platform/maxim/max78000/maxim_spi.h
+++ b/drivers/platform/maxim/max78000/maxim_spi.h
@@ -54,7 +54,7 @@ enum spi_ss_polarity {
 };
 
 struct max_spi_init_param {
-	uint32_t numSlaves;
+	uint32_t num_slaves;
 	enum spi_ss_polarity polarity;
 	mxc_gpio_vssel_t vssel;
 };

--- a/projects/ad74413r/src/platform/maxim/parameters.c
+++ b/projects/ad74413r/src/platform/maxim/parameters.c
@@ -50,7 +50,7 @@ struct max_uart_init_param ad74413r_uart_extra_ip = {
 };
 
 struct max_spi_init_param ad74413r_spi_extra_ip  = {
-	.numSlaves = 1,
+	.num_slaves = 1,
 	.polarity = SPI_SS_POL_LOW,
 	.vssel = MXC_GPIO_VSSEL_VDDIOH,
 };

--- a/projects/adxrs290-pmdz/src/platform/maxim/parameters.c
+++ b/projects/adxrs290-pmdz/src/platform/maxim/parameters.c
@@ -54,7 +54,7 @@ struct max_gpio_init_param adxrs290_gpio_extra_ip = {
 };
 
 struct max_spi_init_param adxrs290_spi_extra_ip  = {
-	.numSlaves = 1,
+	.num_slaves = 1,
 	.polarity = SPI_SS_POL_LOW,
 	.vssel = MXC_GPIO_VSSEL_VDDIOH,
 };

--- a/projects/eval-adis/src/platform/maxim/parameters.c
+++ b/projects/eval-adis/src/platform/maxim/parameters.c
@@ -56,7 +56,7 @@ struct max_gpio_init_param adis16505_gpio_extra_ip = {
 };
 
 struct max_spi_init_param adis16505_spi_extra_ip  = {
-	.numSlaves = 1,
+	.num_slaves = 1,
 	.polarity = SPI_SS_POL_LOW,
 	.vssel = MXC_GPIO_VSSEL_VDDIOH,
 };

--- a/projects/eval-adxl313z/src/platform/maxim/parameters.c
+++ b/projects/eval-adxl313z/src/platform/maxim/parameters.c
@@ -50,7 +50,7 @@ struct max_uart_init_param xuip = {
 };
 
 struct max_spi_init_param xsip  = {
-	.numSlaves = 1,
+	.num_slaves = 1,
 	.polarity = SPI_SS_POL_LOW,
 	.vssel = MXC_GPIO_VSSEL_VDDIOH
 };

--- a/projects/eval-adxl355-pmdz/src/platform/maxim/parameters.c
+++ b/projects/eval-adxl355-pmdz/src/platform/maxim/parameters.c
@@ -65,7 +65,7 @@ struct max_gpio_init_param adxl355_gpio_extra_ip = {
 #endif
 
 struct max_spi_init_param adxl355_spi_extra_ip  = {
-	.numSlaves = 1,
+	.num_slaves = 1,
 	.polarity = SPI_SS_POL_LOW,
 	.vssel = MXC_GPIO_VSSEL_VDDIOH,
 };

--- a/projects/max11205pmb1/src/platform/maxim/parameters.c
+++ b/projects/max11205pmb1/src/platform/maxim/parameters.c
@@ -54,7 +54,7 @@ struct max_gpio_init_param max11205_gpio_extra_ip = {
 };
 
 struct max_spi_init_param max11205_spi_extra_ip  = {
-	.numSlaves = 1,
+	.num_slaves = 1,
 	.polarity = SPI_SS_POL_LOW,
 	.vssel = MXC_GPIO_VSSEL_VDDIOH,
 };


### PR DESCRIPTION
For the number of slaves parameter camel case is used.

Switch to snake case to align with the rest of the parameters and comply to the current approach used in the no-OS framework.