### PR TITLE
projects: eval-ade9430: fix spi param

### DIFF
--- a/projects/eval-ade9430/src/app/main.c
+++ b/projects/eval-ade9430/src/app/main.c
@@ -326,7 +326,7 @@ int main()
 
 	/* Platform SPI Initialization Parameters */
 	struct max_spi_init_param spi_extra_ip  = {
-		.numSlaves = 1,
+		.num_slaves = 1,
 		.polarity = SPI_SS_POL_LOW,
 		.vssel = MXC_GPIO_VSSEL_VDDIOH
 	};


### PR DESCRIPTION
After the merge of cea0997, the num slaves parameter naming was changed.

Adapt the project accordingly.