### PR TITLE
add chibios platform support

### DIFF
--- a/drivers/platform/chibios/chibios_alloc.c
+++ b/drivers/platform/chibios/chibios_alloc.c
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ *   @file   chibios/chibios_alloc.c
+ *   @brief  Implementation of no-OS memory allocation functions.
+ *   @author Robert Budai (robert.budai@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "no_os_alloc.h"
+#include "hal.h"
+
+/**
+ * @brief Allocate memory and return a pointer to it.
+ * @param size - Size of the memory block, in bytes.
+ * @return Pointer to the allocated memory, or NULL if the request fails.
+ */
+__attribute__((weak)) void *no_os_malloc(size_t size)
+{
+	return chHeapAlloc(NULL, size);
+}
+
+/**
+ * @brief Allocate memory and return a pointer to it, set memory to 0.
+ * @param nitems - Number of elements to be allocated.
+ * @param size - Size of elements.
+ * @return Pointer to the allocated memory, or NULL if the request fails.
+ */
+__attribute__((weak)) void *no_os_calloc(size_t nitems, size_t size)
+{
+	void *ptr = chHeapAlloc(NULL, size);
+	if (ptr != NULL)
+		memset(ptr, 0, size);
+	return ptr;
+}
+
+/**
+ * @brief Deallocate memory previously allocated by a call to no_os_calloc
+ * 		  or no_os_malloc.
+ * @param ptr - Pointer to a memory block previously allocated by a call
+ * 		  to no_os_calloc or no_os_malloc.
+ * @return None.
+ */
+__attribute__((weak)) void no_os_free(void *ptr)
+{
+	chHeapFree(ptr);
+}

--- a/drivers/platform/chibios/chibios_delay.c
+++ b/drivers/platform/chibios/chibios_delay.c
@@ -1,0 +1,71 @@
+/***************************************************************************//**
+ *   @file   chibios/chibios_delay.c
+ *   @brief  Implementation of chibios delay functions.
+ *   @author Robert Budai (robert.budai@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "no_os_delay.h"
+#include "hal.h"
+
+/**
+ * @brief Generate miliseconds delay.
+ * @param msecs - Delay in miliseconds.
+ * @return None.
+ */
+void no_os_mdelay(uint32_t msecs)
+{
+	chThdSleepMilliseconds(msecs);
+}
+
+/**
+ * @brief Get current time.
+ * @return Current time structure from system start (seconds, microseconds).
+ */
+struct no_os_time no_os_get_time(void)
+{
+	unsigned long long Xtime_Global;
+	double fractional_part = 0;
+	struct no_os_time t;
+
+	Xtime_Global = chVTGetSystemTimeX();
+	t.s = Xtime_Global / 1000; // milliseconds
+
+	fractional_part = (double)Xtime_Global / 1000 - Xtime_Global / 1000;
+	t.us = fractional_part * 1000;
+	t.us *= 1000;
+
+	return t;
+}

--- a/drivers/platform/chibios/chibios_gpio.c
+++ b/drivers/platform/chibios/chibios_gpio.c
@@ -1,0 +1,296 @@
+/******************************************************************************
+ *   @file   chibios/chibios_gpio.c
+ *   @brief  Implementation of chibios gpio functionality.
+ *   @author Robert Budai (robert.budai@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include <stdlib.h>
+#include <errno.h>
+#include "no_os_util.h"
+#include "no_os_gpio.h"
+#include "no_os_alloc.h"
+#include "chibios_gpio.h"
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+/**
+ * @brief Prepare the GPIO descriptor.
+ * @param desc - The GPIO descriptor.
+ * @param param - The structure that contains the GPIO parameters.
+ * @return 0 in case of success, -1 otherwise.
+ */
+static int32_t _gpio_init(struct no_os_gpio_desc *desc,
+			  const struct no_os_gpio_init_param *param)
+{
+	struct chibios_gpio_desc *extra = desc->extra;
+	struct chibios_gpio_init_param *pextra = param->extra;
+
+	if (!param)
+		return -EINVAL;
+
+	//set GPIO pad to according mode
+	palSetPadMode(pextra->port, pextra->pad, pextra->mode);
+
+	/* copy the settings to gpio descriptor */
+	desc->port = (uint32_t) pextra->port;
+	desc->number = (uint32_t) pextra->pad;
+	desc->pull = (((uint32_t)pextra->mode & PAL_MODE_OUTPUT_PUSHPULL)
+		      || ((uint32_t)pextra->mode & PAL_MODE_OUTPUT_OPENDRAIN)) ? NO_OS_GPIO_OUT :
+		     NO_OS_GPIO_IN;
+	extra->port = pextra->port;
+	extra->pad = pextra->pad;
+	extra->mode = pextra->mode;
+
+	return 0;
+}
+
+/**
+ * @brief Obtain the GPIO descriptor.
+ * @param desc - The GPIO descriptor.
+ * @param param - GPIO initialization parameters
+ * @return 0 in case of success, -1 otherwise.
+ */
+int32_t chibios_gpio_get(struct no_os_gpio_desc **desc,
+			 const struct no_os_gpio_init_param *param)
+{
+	int32_t ret;
+	struct no_os_gpio_desc *descriptor;
+	struct chibios_gpio_desc *extra;
+
+	if (!desc || !param)
+		return -EINVAL;
+
+	descriptor = (struct no_os_gpio_desc *)no_os_calloc(sizeof(*descriptor));
+	if (!descriptor) {
+		ret = -ENOMEM;
+		goto error_1;
+	}
+	extra = (struct chibios_gpio_desc*)no_os_calloc(sizeof(*extra));
+	if (!extra) {
+		ret = -ENOMEM;
+		goto error_2;
+	}
+
+	descriptor->extra = extra;
+	ret = _gpio_init(descriptor, param);
+	if (!ret)
+		goto error_2;
+
+	*desc = descriptor;
+
+	return 0;
+error_2:
+	no_os_free(extra);
+error_1:
+	no_os_free(descriptor);
+
+	return ret;
+}
+
+/**
+ * @brief Get the value of an optional GPIO.
+ * @param desc - The GPIO descriptor.
+ * @param param - GPIO Initialization parameters.
+ * @return 0 in case of success, -1 otherwise.
+ */
+int32_t chibios_gpio_get_optional(struct no_os_gpio_desc **desc,
+				  const struct no_os_gpio_init_param *param)
+{
+	if (param == NULL) {
+		*desc = NULL;
+		return 0;
+	}
+
+	return chibios_gpio_get(desc, param);
+}
+
+/**
+ * @brief Free the resources allocated by no_os_gpio_get().
+ * @param desc - The GPIO descriptor.
+ * @return 0 in case of success, -1 otherwise.
+ */
+int32_t chibios_gpio_remove(struct no_os_gpio_desc *desc)
+{
+	if (desc != NULL)
+		no_os_free(desc->extra);
+
+	no_os_free(desc);
+
+	return 0;
+}
+
+/**
+ * @brief Enable the input direction of the specified GPIO.
+ * @param desc - The GPIO descriptor.
+ * @return 0 in case of success, -1 otherwise.
+ */
+int32_t chibios_gpio_direction_input(struct no_os_gpio_desc *desc)
+{
+	struct chibios_gpio_desc *extra;
+
+	if (!desc)
+		return -EINVAL;
+
+	if (!desc->extra)
+		return -EFAULT;
+
+	extra = desc->extra;
+
+	/* configure gpio with user configuration */
+	extra->mode =  PAL_MODE_INPUT;
+	palSetPadMode(extra->port, extra->pad, extra->mode);
+
+	return 0;
+}
+
+/**
+ * @brief Enable the output direction of the specified GPIO.
+ * @param desc - The GPIO descriptor.
+ * @param value - The value.
+ *                Example: NO_OS_GPIO_HIGH
+ *                         NO_OS_GPIO_LOW
+ * @return 0 in case of success, -1 otherwise.
+ */
+int32_t chibios_gpio_direction_output(struct no_os_gpio_desc *desc,
+				      uint8_t value)
+{
+	struct chibios_gpio_desc *extra;
+
+	if (!desc)
+		return -EINVAL;
+
+	if (!desc->extra)
+		return -EFAULT;
+	extra = desc->extra;
+
+	/* configure gpio with user configuration */
+	extra->mode = PAL_MODE_OUTPUT_PUSHPULL;
+	palSetPadMode(extra->port, extra->pad, extra->mode);
+
+	/* configure gpio output level */
+	palWritePad(extra->port, extra->pad, value);
+
+	return 0;
+}
+
+/**
+ * @brief Get the direction of the specified GPIO.
+ * @param desc - The GPIO descriptor.
+ * @param direction - The direction.
+ *                    Example: NO_OS_GPIO_OUT
+ *                             NO_OS_GPIO_IN
+ * @return 0 in case of success, -1 otherwise.
+ */
+int32_t chibios_gpio_get_direction(struct no_os_gpio_desc *desc,
+				   uint8_t *direction)
+{
+	if (!desc || !direction)
+		return -EINVAL;
+
+	struct chibios_gpio_desc *extra = desc->extra;
+	*direction = (((uint32_t)extra->mode & PAL_MODE_OUTPUT_PUSHPULL)
+		      || ((uint32_t)extra->mode & PAL_MODE_OUTPUT_OPENDRAIN)) ? NO_OS_GPIO_OUT :
+		     NO_OS_GPIO_IN;
+	return 0;
+}
+
+/**
+ * @brief Set the value of the specified GPIO.
+ * @param desc - The GPIO descriptor.
+ * @param value - The value.
+ *                Example: NO_OS_GPIO_HIGH
+ *                         NO_OS_GPIO_LOW
+ * @return 0 in case of success, -1 otherwise.
+ */
+int32_t chibios_gpio_set_value(struct no_os_gpio_desc *desc,
+			       uint8_t value)
+{
+	struct chibios_gpio_desc *extra;
+
+	if (!desc)
+		return -EINVAL;
+
+	if (!desc->extra)
+		return -EFAULT;
+
+	extra = desc->extra;
+
+	/* configure gpio output level */
+	palWritePad(extra->port, extra->pad, value);
+
+	return 0;
+}
+
+/**
+ * @brief Get the value of the specified GPIO.
+ * @param desc - The GPIO descriptor.
+ * @param value - The value.
+ *                Example: NO_OS_GPIO_HIGH
+ *                         NO_OS_GPIO_LOW
+ * @return 0 in case of success, -1 otherwise.
+ */
+int32_t chibios_gpio_get_value(struct no_os_gpio_desc *desc,
+			       uint8_t *value)
+{
+	struct chibios_gpio_desc *extra;
+
+	if (!desc || !value)
+		return -EINVAL;
+
+	if (!desc->extra)
+		return -EFAULT;
+
+	extra = desc->extra;
+
+	*value = (uint8_t)palReadPad(extra->port, extra->pad);
+
+	return 0;
+}
+
+/**
+ * @brief chibios platform specific GPIO platform ops structure
+ */
+const struct no_os_gpio_platform_ops chibios_gpio_ops = {
+	.gpio_ops_get = &chibios_gpio_get,
+	.gpio_ops_get_optional = &chibios_gpio_get_optional,
+	.gpio_ops_remove = &chibios_gpio_remove,
+	.gpio_ops_direction_input = &chibios_gpio_direction_input,
+	.gpio_ops_direction_output = &chibios_gpio_direction_output,
+	.gpio_ops_get_direction = &chibios_gpio_get_direction,
+	.gpio_ops_set_value = &chibios_gpio_set_value,
+	.gpio_ops_get_value = &chibios_gpio_get_value,
+};

--- a/drivers/platform/chibios/chibios_gpio.h
+++ b/drivers/platform/chibios/chibios_gpio.h
@@ -1,0 +1,77 @@
+/***************************************************************************//**
+ *   @file   chibios/chibios_gpio.h
+ *   @brief  Header file for chibios gpio specifics.
+ *   @author Robert Budai (robert.budai@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef CHIBIOS_GPIO_H_
+#define CHIBIOS_GPIO_H_
+
+#include <stdint.h>
+#include "no_os_gpio.h"
+#include "hal.h"
+
+/**
+ * @struct chibios_gpio_init_param
+ * @brief Structure holding the initialization parameters for chibios os
+ */
+struct chibios_gpio_init_param {
+	/** Port */
+	ioportid_t port;
+	/** Mask */
+	iopadid_t pad;
+	/** Mode */
+	iomode_t mode;
+};
+
+/**
+ * @struct chibios_gpio_desc
+ * @brief chibios platform specific gpio descriptor
+ */
+struct chibios_gpio_desc {
+	/** Port */
+	ioportid_t port;
+	/** Mask */
+	iopadid_t pad;
+	/** Mode */
+	iomode_t mode;
+};
+
+/**
+ * @brief chibios platform specific gpio platform ops structure
+ */
+extern const struct no_os_gpio_platform_ops chibios_gpio_ops;
+
+#endif

--- a/drivers/platform/chibios/chibios_i2c.c
+++ b/drivers/platform/chibios/chibios_i2c.c
@@ -1,0 +1,207 @@
+/***************************************************************************//**
+ *   @file   chibios/chibios_i2c.c
+ *   @brief  Implementation of chibios i2c driver.
+ *   @author Robert Budai (robert.budai@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+#include "no_os_util.h"
+#include "no_os_alloc.h"
+#include "no_os_i2c.h"
+#include "chibios_i2c.h"
+
+#if (HAL_USE_I2C==TRUE)
+
+/**
+ * @brief Initialize the I2C communication peripheral.
+ * @param desc - The I2C descriptor.
+ * @param param - The structure that contains the I2C parameters.
+ * @return 0 in case of success, -1 otherwise.
+ */
+int chibios_i2c_init(struct no_os_i2c_desc **desc,
+		     const struct no_os_i2c_init_param *param)
+{
+	int ret;
+	struct no_os_i2c_desc *descriptor;
+	struct chibios_i2c_desc *xdesc;
+
+	if (!desc || !param)
+		return -EINVAL;
+
+	descriptor = (struct no_os_i2c_desc *)no_os_calloc(1,
+			sizeof(struct no_os_i2c_desc));
+	if (!descriptor)
+		return -ENOMEM;
+
+	xdesc = (struct chibios_i2c_desc *)no_os_calloc(1,
+			sizeof(struct chibios_i2c_desc));
+	if (!xdesc) {
+		ret = -ENOMEM;
+		goto error_1;
+	}
+
+	descriptor->extra = xdesc;
+	descriptor->device_id = param->device_id;
+	descriptor->max_speed_hz = param->max_speed_hz;
+	descriptor->slave_address = param->slave_address;
+
+	xdesc->hi2c = ((struct chibios_i2c_init_param *)(param->extra))->hi2c;
+	xdesc->i2ccfg = ((struct chibios_i2c_init_param *)(param->extra))->i2ccfg;
+	xdesc->i2caddr = param->slave_address;
+
+	ret = i2cStart(xdesc->hi2c, xdesc->i2ccfg);
+	if (ret != I2C_NO_ERROR) {
+		ret = -EIO;
+		goto error_2;
+	}
+
+	*desc = descriptor;
+
+	return 0;
+error_2:
+	no_os_free(xdesc);
+error_1:
+	no_os_free(descriptor);
+	return ret;
+}
+
+/**
+ * @brief Free the resources allocated by no_os_i2c_init().
+ * @param desc - The I2C descriptor.
+ * @return 0 in case of success, -1 otherwise.
+ */
+int chibios_i2c_remove(struct no_os_i2c_desc *desc)
+{
+	struct chibios_i2c_desc *sdesc;
+
+	if (!desc || !desc->extra)
+		return -EINVAL;
+
+	sdesc = desc->extra;
+	i2cStop(sdesc->hi2c);
+	no_os_free(desc->extra);
+	no_os_free(desc);
+
+	return 0;
+}
+
+/**
+ * @brief I2C write transaction as master.
+ * @param desc - The I2C descriptor.
+ * @param data - The buffer with the data to transmit.
+ * @param bytes_number - Number of bytes in the buffer.
+ * @param stop_bit - Specifis whether to end the transaction with a stop bit.
+ * @return 0 in case of success, -1 otherwise.
+ */
+int chibios_i2c_write(struct no_os_i2c_desc *desc,
+		      uint8_t *data,
+		      uint8_t bytes_number,
+		      uint8_t stop_bit)
+{
+	int32_t ret;
+	struct chibios_i2c_desc *xdesc;
+
+	if (!desc || !desc->extra || !data)
+		return -EINVAL;
+
+	xdesc = desc->extra;
+
+	if (!stop_bit) {
+		chI2CBuffer = (uint8_t *)no_os_malloc(bytes_number*sizeof(uint8_t));
+		memcpy(chI2CBuffer, data, bytes_number);
+		buffSize = bytes_number;
+		ret = I2C_NO_ERROR;
+	} else {
+		ret = i2cMasterTransmitTimeout(xdesc->hi2c,  desc->slave_address, data,
+					       bytes_number, NULL, 0, TIME_INFINITE);
+	}
+
+	if (ret != I2C_NO_ERROR)
+		return -EIO;
+
+	return 0;
+}
+
+/**
+ * @brief I2C read transaction as master.
+ * @param desc - The I2C descriptor.
+ * @param data - The buffer where received data is to be stored.
+ * @param bytes_number - Number of bytes to receive.
+ * @param stop_bit - Specifis whether to end the transaction with a stop bit.
+ * @return 0 in case of success, -1 otherwise.
+ */
+
+int chibios_i2c_read(struct no_os_i2c_desc *desc,
+		     uint8_t *data,
+		     uint8_t bytes_number,
+		     uint8_t stop_bit)
+{
+	int32_t ret;
+	struct chibios_i2c_desc *xdesc;
+
+	if (!desc || !desc->extra || !data)
+		return -EINVAL;
+
+	xdesc = desc->extra;
+
+	if (!stop_bit) {
+//		no current implementation, (from no-os drivers only adxl372 uses consequtive reads without stop bit)
+		ret = I2C_NO_ERROR;
+	} else {
+		ret = i2cMasterTransmitTimeout(xdesc->hi2c,  desc->slave_address, chI2CBuffer,
+					       buffSize, data, bytes_number, TIME_INFINITE);
+		no_os_free(chI2CBuffer);
+		buffSize=0;
+	}
+
+	if (ret != I2C_NO_ERROR)
+		return -EIO;
+
+	return 0;
+}
+
+/**
+ * @brief chibios platform specific I2C platform ops structure
+ */
+const struct no_os_i2c_platform_ops chibios_i2c_ops = {
+	.i2c_ops_init = &chibios_i2c_init,
+	.i2c_ops_write = &chibios_i2c_write,
+	.i2c_ops_read = &chibios_i2c_read,
+	.i2c_ops_remove = &chibios_i2c_remove
+};
+
+#endif // HAL_USE_I2C

--- a/drivers/platform/chibios/chibios_i2c.h
+++ b/drivers/platform/chibios/chibios_i2c.h
@@ -1,0 +1,87 @@
+/***************************************************************************//**
+ *   @file   chibios/chibios_i2c.h
+ *   @brief  Header file for the chibios i2c driver.
+ *   @author Robert Budai (robert.budai@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef CHIBIOS_I2C_H_
+#define CHIBIOS_I2C_H_
+
+#include <stdint.h>
+#include "no_os_i2c.h"
+#include "hal.h"
+
+#if (HAL_USE_I2C==TRUE)
+
+/**
+ * @struct chibios_i2c_desc
+ * @brief chibios platform specific I2C descriptor iwth config and slave address parameters
+ */
+struct chibios_i2c_desc {
+	/** I2C instance */
+	I2CDriver *hi2c;
+	/** I2C init specific parameter*/
+	I2CConfig *i2ccfg;
+	/**I2C address*/
+	uint16_t i2caddr;
+};
+
+/**
+ * @struct chibios_i2c_init_param
+ * @brief ChibiOS i2c param struct
+ *
+ */
+struct chibios_i2c_init_param {
+	/** I2C instance*/
+	I2CDriver *hi2c;
+	/** I2C Config*/
+	I2CConfig *i2ccfg;
+};
+
+/**
+ * @brief chibios specific I2C platform ops structure
+ */
+extern const struct no_os_i2c_platform_ops chibios_i2c_ops;
+
+/**
+ * @brief global variable for temporary buffers for transmit and receive
+ *
+ */
+static uint8_t* chI2CBuffer;
+static uint16_t buffSize;
+
+#endif // HAL_USE_I2C==TRUE
+
+#endif // CHIBIOS_I2C_H_

--- a/drivers/platform/chibios/chibios_spi.c
+++ b/drivers/platform/chibios/chibios_spi.c
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ *   @file   chibios/chibios_spi.c
+ *   @brief  Implementation of chibios spi driver.
+ *   @author Robert Budai (robert.budai@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include <stdlib.h>
+#include <errno.h>
+#include "no_os_util.h"
+#include "no_os_spi.h"
+#include "no_os_alloc.h"
+#include "chibios_spi.h"
+
+#if (HAL_USE_SPI==TRUE)
+
+/**
+ * @brief Initialize the SPI communication peripheral.
+ * @param desc - The SPI descriptor.
+ * @param param - The structure that contains the SPI parameters.
+ * @return 0 in case of success, -1 otherwise.
+ */
+int32_t chibios_spi_init(struct no_os_spi_desc **desc,
+			 const struct no_os_spi_init_param *param)
+{
+	int32_t ret;
+
+	struct no_os_spi_desc *spi_desc;
+	struct chibios_spi_desc *sdesc;
+
+	if (!desc || !param)
+		return -EINVAL;
+
+	spi_desc = (struct no_os_spi_desc *)no_os_calloc(sizeof(*spi_desc));
+
+	if (!spi_desc) {
+		ret = -ENOMEM;
+		goto error_1;
+	}
+
+	sdesc = (struct chibios_spi_desc*)no_os_calloc(sizeof(*sdesc));
+
+	if (!sdesc) {
+		ret = -ENOMEM;
+		goto error_2;
+	}
+
+	sdesc->hspi = ((struct chibios_spi_init_param *)(param->extra))->hspi;
+	sdesc->spicfg = ((struct chibios_spi_init_param *)(param->extra))->spicfg;
+	spi_desc->extra = sdesc;
+
+	spiStart((sdesc->hspi), (sdesc->spicfg));
+
+	*desc = spi_desc;
+	return 0;
+
+error_2:
+	no_os_free(sdesc);
+error_1:
+	no_os_free(spi_desc);
+
+	return ret;
+
+}
+
+/**
+ * @brief Free the resources allocated by no_os_spi_init().
+ * @param desc - The SPI descriptor.
+ * @return 0 in case of success, -1 otherwise.
+ */
+int32_t chibios_spi_remove(struct no_os_spi_desc *desc)
+{
+	struct chibios_spi_desc *sdesc;
+
+	if (!desc || !desc->extra)
+		return -EINVAL;
+	sdesc = desc->extra;
+
+	spiStop(sdesc->hspi);
+
+	no_os_free(desc->extra);
+	no_os_free(desc);
+	desc = NULL;
+	return 0;
+}
+
+/**
+ * @brief Write and read data to/from SPI.
+ * @param desc - The SPI descriptor.
+ * @param data - The buffer with the transmitted/received data.
+ * @param bytes_number - Number of bytes to write/read.
+ * @return 0 in case of success, -1 otherwise.
+ */
+int32_t chibios_spi_write_and_read(struct no_os_spi_desc *desc,
+				   uint8_t *data,
+				   uint16_t bytes_number)
+{
+	struct chibios_spi_desc *sdesc = (struct chibios_spi_desc *)desc->extra;
+	// select device
+	spiSelect((sdesc->hspi));
+
+	//send and receive buffer
+	//switch implementation to support two word transfer as well
+	while(bytes_number--) {
+		spiExchange((sdesc->hspi), 1, data, data);
+		data++;
+	}
+	// unselect device
+	spiUnselect((sdesc->hspi));
+
+	return 0;
+}
+
+/**
+ * @brief chibios platform specific SPI platform ops structure
+ */
+const struct no_os_spi_platform_ops chibios_spi_ops = {
+	.init = &chibios_spi_init,
+	.write_and_read = &chibios_spi_write_and_read,
+	.remove = &chibios_spi_remove
+};
+
+#endif //HAL_USE_SPI==TRUE

--- a/drivers/platform/chibios/chibios_spi.h
+++ b/drivers/platform/chibios/chibios_spi.h
@@ -1,0 +1,84 @@
+/***************************************************************************//**
+ *   @file   chibios/chibios_spi.h
+ *   @brief  Header file for the chibios spi driver.
+ *   @author Robert Budai (robert.budai@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef CHIBIOS_SPI_H_
+#define CHIBIOS_SPI_H_
+
+#include <stdint.h>
+#include "no_os_spi.h"
+#include "hal.h"
+
+#if (HAL_USE_SPI==TRUE)
+
+/**
+ * @struct chibios_spi_init_param
+ * @brief Structure holding the initialization parameters for chibios platform
+ * specific SPI parameters.
+ */
+
+/*
+ * TO DO: extend SPI for more than 8 byte transfers (?)
+ * 1/2 word configuration
+ */
+
+struct chibios_spi_init_param {
+	/** SPI instance */
+	SPIDriver *hspi;
+	/**	SPI config struct*/
+	SPIConfig *spicfg;
+};
+
+/**
+ * @struct chibios_spi_desc
+ * @brief chibios platform specific SPI descriptor
+ */
+struct chibios_spi_desc {
+	/** SPI instance */
+	SPIDriver *hspi;
+	/**	SPI config struct*/
+	SPIConfig *spicfg;
+};
+
+/**
+ * @brief chibios specific SPI platform ops structure
+ */
+extern const struct no_os_spi_platform_ops chibios_spi_ops;
+
+#endif // HAL_USE_SPI==TRUE
+
+#endif // CHIBIOS_SPI_H_


### PR DESCRIPTION
PR:

- add platform support for ChibiOS (https://www.chibios.org/dokuwiki/doku.php)
- added api implementations: i2c, gpio, spi, memory allocation, delay
- currently build is done within the ChibiOS sdk
- example projects: https://github.com/rbudai98/chibiOS-drivers