### PR TITLE
projects: cn0561: update hardware files namings

### DIFF
--- a/projects/cn0561/builds.json
+++ b/projects/cn0561/builds.json
@@ -2,19 +2,19 @@
   "xilinx": {
     "iio_zed": {
       "flags" : "TINYIIOD=y NEW_CFLAGS=-DCN0561_ZED_CARRIER",
-      "hardware" : ["cn0561_fmc_zed"]
+      "hardware" : ["cn0561_zed"]
     },
     "uart_zed": {
       "flags" : "NEW_CFLAGS=-DCN0561_ZED_CARRIER",
-      "hardware" : ["cn0561_fmc_zed"]
+      "hardware" : ["cn0561_zed"]
     },
     "iio_cora": {
       "flags" : "TINYIIOD=y NEW_CFLAGS=-DCN0561_CORAZ7S_CARRIER",
-      "hardware" : ["cn0561_ard_cora"]
+      "hardware" : ["cn0561_coraz7s"]
     },
     "uart_cora": {
       "flags" : "NEW_CFLAGS=-DCN0561_CORAZ7S_CARRIER",
-      "hardware" : ["cn0561_ard_cora"]
+      "hardware" : ["cn0561_coraz7s"]
     }
   }
 }


### PR DESCRIPTION
Rename hardware files used for building cn0561 to match the latest hdl releases.