### PR TITLE
projects: eval-adxl355-pmdz: Fix SPI interface id

### DIFF
--- a/projects/eval-adxl355-pmdz/src/platform/maxim/parameters.h
+++ b/projects/eval-adxl355-pmdz/src/platform/maxim/parameters.h
@@ -66,6 +66,9 @@
 #if (TARGET_NUM == 78000)
 #define SPI_DEVICE_ID   1
 #define SPI_CS          1
+#elif (TARGET_NUM == 32650)
+#define SPI_DEVICE_ID   1
+#define SPI_CS          0
 #else
 #define SPI_DEVICE_ID   0
 #define SPI_CS          0


### PR DESCRIPTION
For the MAX32650FTHR board, the exposed SPI interface is SPI1. Modify the macro accordingly.