### PR TITLE
iio: iio.c: Fix buffer maximum length based on received request

### DIFF
--- a/iio/iio_types.h
+++ b/iio/iio_types.h
@@ -215,6 +215,8 @@ struct iio_buffer {
 	uint32_t size;
 	/* Number of bytes per sample * number of active channels */
 	uint32_t bytes_per_scan;
+	/* Number of requested samples */
+	uint32_t samples;
 	/* Buffer direction */
 	enum iio_buffer_direction dir;
 	/* Buffer where data is stored */


### PR DESCRIPTION
When using the statically allocated buffer with circular buffer, make sure the used size is a multiple of the total requested number of bytes from the iio client.
This has to be done because the circular buffer cannot handle memory wrapping.