### PR TITLE
aducm3029: timer: update timer ops naming

### DIFF
--- a/drivers/platform/aducm3029/aducm3029_delay.c
+++ b/drivers/platform/aducm3029/aducm3029_delay.c
@@ -82,7 +82,7 @@ static uint32_t initialize_timer(struct no_os_timer_desc **timer,
 	param.id = 0;
 	param.freq_hz = is_us ? 1000000u : 1000u;
 	param.ticks_count = 0;
-	param.platform_ops = &aducm3029_timer_ops;
+	param.platform_ops = &aducm_timer_ops;
 
 	if (is_us) {
 		if (0 != no_os_timer_init(&dummy_timer, &param))

--- a/drivers/platform/aducm3029/aducm3029_timer.c
+++ b/drivers/platform/aducm3029/aducm3029_timer.c
@@ -437,7 +437,7 @@ int32_t aducm3029_timer_get_elapsed_time_nsec(struct no_os_timer_desc *desc,
 /**
  * @brief aducm3029 platform specific timer platform ops structure
  */
-const struct no_os_timer_platform_ops aducm3029_timer_ops = {
+const struct no_os_timer_platform_ops aducm_timer_ops = {
 	.init = &aducm3029_timer_init,
 	.start = &aducm3029_timer_start,
 	.stop = &aducm3029_timer_stop,

--- a/drivers/platform/aducm3029/aducm3029_timer.h
+++ b/drivers/platform/aducm3029/aducm3029_timer.h
@@ -99,6 +99,6 @@ struct aducm_timer_init_param {
 /**
  * @brief aducm3029 specific timer platform ops structure
  */
-extern const struct no_os_timer_platform_ops aducm3029_timer_ops;
+extern const struct no_os_timer_platform_ops aducm_timer_ops;
 
 #endif /* ADUCM3029_TIMER_H */

--- a/projects/adxrs290-pmdz/src/platform/aducm3029/parameters.h
+++ b/projects/adxrs290-pmdz/src/platform/aducm3029/parameters.h
@@ -90,7 +90,7 @@ extern struct aducm_timer_init_param adxrs290_timer_extra_ip;
 #define ADXRS290_TIMER_FREQ_HZ      200 /* Not used - Used clock source frequency is the one specified in adxrs290_timer_extra_ip */
 #define ADXRS290_TIMER_TICKS_COUNT  0xffff
 #define ADXRS290_TIMER_EXTRA        &adxrs290_timer_extra_ip
-#define TIMER_OPS                   &aducm3029_timer_ops
+#define TIMER_OPS                   &aducm_timer_ops
 
 /* ADXRS290 Timer trigger settings */
 #define ADXRS290_TIMER_IRQ_ID       TMR1_EVT_IRQn /* IRQ id for TMR1 */

--- a/projects/iio_adpd1080/src/main.c
+++ b/projects/iio_adpd1080/src/main.c
@@ -81,7 +81,7 @@ static int32_t adpd1080pmod_32k_calib(struct adpd188_dev *adpd1080_dev)
 		.id = 0,
 		.ticks_count = 0,
 		.freq_hz = 1,
-		.platform_ops = &aducm3029_timer_ops,
+		.platform_ops = &aducm_timer_ops,
 		.extra = NULL
 	};
 	struct no_os_gpio_desc *sync_gpio;


### PR DESCRIPTION
Align the timer ops structure naming with the rest of the platform ops specific structures for aducm3029. All the other interfaces: spi, gpio, i2c, irq are using `aducm_` prefix, the timer being the only one using `aducm3029_` prefix.