### PR TITLE
projects: add dc2903a example project

### DIFF
--- a/projects/dc2903a/Makefile
+++ b/projects/dc2903a/Makefile
@@ -1,0 +1,8 @@
+# Select the example you want to enable by chossing y for enabling and n for disabling
+BASIC_EXAMPLE=y
+
+include ../../tools/scripts/generic_variables.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/dc2903a/builds.json
+++ b/projects/dc2903a/builds.json
@@ -1,0 +1,7 @@
+{
+	"maxim": {
+		"basic_example_max32665": {
+			"flags": "BASIC_EXAMPLE=y TARGET=max32665"
+		}
+	}
+}

--- a/projects/dc2903a/src.mk
+++ b/projects/dc2903a/src.mk
@@ -1,0 +1,37 @@
+include $(PROJECT)/src/platform/$(PLATFORM)/platform_src.mk
+include $(PROJECT)/src/examples/examples_src.mk
+
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/main.c
+
+INCS += $(PROJECT)/src/common/common_data.h
+SRCS += $(PROJECT)/src/common/common_data.c
+
+INCS += $(PROJECT)/src/platform/platform_includes.h
+
+INCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.h
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.c
+
+INCS += $(DRIVERS)/dac/ltc2672/ltc2672.h
+SRCS += $(DRIVERS)/dac/ltc2672/ltc2672.c
+
+INCS += $(INCLUDE)/no_os_delay.h        \
+        $(INCLUDE)/no_os_error.h        \
+        $(INCLUDE)/no_os_print_log.h    \
+        $(INCLUDE)/no_os_spi.h          \
+        $(INCLUDE)/no_os_irq.h          \
+        $(INCLUDE)/no_os_list.h         \
+        $(INCLUDE)/no_os_uart.h         \
+        $(INCLUDE)/no_os_timer.h        \
+        $(INCLUDE)/no_os_lf256fifo.h    \
+        $(INCLUDE)/no_os_util.h         \
+        $(INCLUDE)/no_os_units.h        \
+        $(INCLUDE)/no_os_alloc.h        
+
+SRCS += $(NO-OS)/util/no_os_lf256fifo.c \
+        $(DRIVERS)/api/no_os_irq.c      \
+        $(DRIVERS)/api/no_os_timer.c    \
+        $(DRIVERS)/api/no_os_spi.c      \
+        $(DRIVERS)/api/no_os_uart.c     \
+        $(NO-OS)/util/no_os_list.c      \
+        $(NO-OS)/util/no_os_util.c      \
+        $(NO-OS)/util/no_os_alloc.c

--- a/projects/dc2903a/src/common/common_data.c
+++ b/projects/dc2903a/src/common/common_data.c
@@ -1,0 +1,70 @@
+/***************************************************************************//**
+ *   @file   common_data.c
+ *   @brief  Defines common data to be used by DC2903A examples.
+ *   @author JSanBuenaventura (jose.sanbuenaventura@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "common_data.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+struct no_os_uart_init_param ltc2672_uart_ip = {
+	.device_id = UART_DEVICE_ID,
+	.baud_rate = UART_BAUDRATE,
+	.size = NO_OS_UART_CS_8,
+	.parity = NO_OS_UART_PAR_NO,
+	.stop = NO_OS_UART_STOP_1_BIT,
+	.platform_ops = UART_OPS,
+	.extra = UART_EXTRA,
+};
+
+struct no_os_spi_init_param ltc2672_spi_ip = {
+	.device_id = SPI_DEVICE_ID,
+	.max_speed_hz = SPI_BAUDRATE,
+	.bit_order = NO_OS_SPI_BIT_ORDER_MSB_FIRST,
+	.mode = NO_OS_SPI_MODE_0,
+	.platform_ops = SPI_OPS,
+	.chip_select = SPI_CS,
+	.extra = SPI_EXTRA,
+};
+
+struct ltc2672_init_param ltc2672_ip = {
+	.id = LTC2672_VAR
+};

--- a/projects/dc2903a/src/common/common_data.h
+++ b/projects/dc2903a/src/common/common_data.h
@@ -1,0 +1,55 @@
+/***************************************************************************//**
+ *   @file   common_data.h
+ *   @brief  Defines common data to be used by DC2903A examples.
+ *   @author JSanBuenaventura (jose.sanbuenaventura@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __COMMON_DATA_H__
+#define __COMMON_DATA_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "platform_includes.h"
+#include "ltc2672.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+extern struct no_os_uart_init_param ltc2672_uart_ip;
+extern struct no_os_spi_init_param ltc2672_spi_ip;
+extern struct ltc2672_init_param ltc2672_ip;
+
+#endif /* __COMMON_DATA_H__ */

--- a/projects/dc2903a/src/examples/basic_example/basic_example.c
+++ b/projects/dc2903a/src/examples/basic_example/basic_example.c
@@ -1,0 +1,162 @@
+/***************************************************************************//**
+ *   @file   basic_example.c
+ *   @brief  Implementation of basic example for DC2903A project.
+ *   @author JSanBuenaventura (jose.sanbuenaventura@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "basic_example.h"
+#include "ltc2672.h"
+#include "common_data.h"
+#include "no_os_print_log.h"
+#include "no_os_delay.h"
+#include "no_os_util.h"
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+/***************************************************************************//**
+ * @brief basic example main execution.
+ *
+ * @return ret - Result of the example execution.
+*******************************************************************************/
+int basic_example_main()
+{
+	int i, ret, num_currents, toggle_times = 4;
+	bool toggle_flag = false;
+	float currents_to_set[] = {.21, .41, 1.21, 1.41}; // current to set in mA
+	float currents_to_toggle[] = {0.4, 0.1};
+	struct ltc2672_dev *ltc2672_desc;
+
+	num_currents = NO_OS_ARRAY_SIZE(currents_to_set);
+
+	/* Initialize device */
+	ret = ltc2672_init(&ltc2672_desc, &ltc2672_ip);
+	if (ret)
+		return ret;
+
+	/* Continuously configure the part and measure pins with multimeter for verification */
+	while (1) {
+		/*max current of 3.125mA*/
+		ret = ltc2672_set_span_all_channels(ltc2672_desc,
+						    LTC2672_50VREF);
+		if (ret) {
+			goto error;
+		}
+
+		/* Print Span set to all channels */
+		pr_info("All DAC channels have span config of 3.125mA\n");
+
+		for (i = 0; i < num_currents; i++) {
+			ret = ltc2672_set_current_all_channels(ltc2672_desc, currents_to_set[i]);
+			if (ret) {
+				goto error;
+			}
+
+			/* Print Current set to all channels */
+			pr_info("All DAC channels have current of: %0.2f mA\n", currents_to_set[i]);
+
+			/*Lengthy delay to better visualize the change in values*/
+			no_os_mdelay(1500);
+		}
+
+		/* Configure MUX pin to output the VREF measurement */
+		pr_info("MUX ouptut pin configured to measure VREF (~1.25V).\n");
+
+		ret = ltc2672_monitor_mux(ltc2672_desc, LTC2672_MUX_VREF);
+		if (ret) {
+			goto error;
+		}
+
+		/*Lengthy delay to better visualize the change in values*/
+		no_os_mdelay(2000);
+
+		/* Chip Power Down */
+		pr_info("Chip Power Down. All Channels and VREF should measure 0.\n");
+
+		ret = ltc2672_chip_power_down(ltc2672_desc);
+		if (ret) {
+			goto error;
+		}
+
+		/*Lengthy delay to better visualize the change in values*/
+		no_os_mdelay(2000);
+
+		/* Setup and Demo toggle function on OUT3 */
+		pr_info("Toggle function on OUT3. Current toggles between %0.2f and %0.2f mA.\n",
+			currents_to_toggle[0], currents_to_toggle[1]);
+
+		ret = ltc2672_setup_toggle_channel(ltc2672_desc, LTC2672_DAC3,
+						   currents_to_toggle[0], currents_to_toggle[1]);
+		if (ret) {
+			goto error;
+		}
+
+		ret = ltc2672_enable_toggle_channel(ltc2672_desc, 8);
+		if (ret) {
+			goto error;
+		}
+
+		for (i = 0; i < toggle_times; i++) {
+			toggle_flag ^= true;
+
+			ret = ltc2672_global_toggle(ltc2672_desc, toggle_flag);
+			if (ret) {
+				goto error;
+			}
+
+			/*Lengthy delay to better visualize the change in values*/
+			no_os_mdelay(2000);
+		}
+
+		ret = ltc2672_enable_toggle_channel(ltc2672_desc, 0);
+		if (ret) {
+			goto error;
+		}
+
+		/*Lengthy delay to better visualize the change in values*/
+		no_os_mdelay(2000);
+
+	}// end while
+
+	return 0;
+
+error:
+	ltc2672_remove(ltc2672_desc);
+	return ret;
+}

--- a/projects/dc2903a/src/examples/basic_example/basic_example.h
+++ b/projects/dc2903a/src/examples/basic_example/basic_example.h
@@ -1,0 +1,51 @@
+/***************************************************************************//**
+ *   @file   basic_example.h
+ *   @brief  basic example header for DC2903A project
+ *   @author JSanBuenaventura (jose.sanbuenaventura@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __BASIC_EXAMPLE_H__
+#define __BASIC_EXAMPLE_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+int basic_example_main();
+
+#endif /* __BASIC_EXAMPLE_H__ */

--- a/projects/dc2903a/src/examples/examples_src.mk
+++ b/projects/dc2903a/src/examples/examples_src.mk
@@ -1,0 +1,5 @@
+ifeq (y,$(strip $(BASIC_EXAMPLE)))
+CFLAGS += -DBASIC_EXAMPLE=1
+SRCS += $(PROJECT)/src/examples/basic_example/basic_example.c
+INCS += $(PROJECT)/src/examples/basic_example/basic_example.h
+endif

--- a/projects/dc2903a/src/platform/maxim/main.c
+++ b/projects/dc2903a/src/platform/maxim/main.c
@@ -1,0 +1,79 @@
+/***************************************************************************//**
+ *   @file   main.c
+ *   @brief  Main file for Maxim platform of DC2903A project.
+ *   @author JSanBuenaventura (jose.sanbuenaventura@analog.com)
+ *   @author MSosa (marcpaolo.sosa@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "platform_includes.h"
+#include "common_data.h"
+#include "basic_example.h"
+
+/***************************************************************************//**
+ * @brief Main function execution for maxim platform.
+ *
+ * @return ret - Result of the enabled examples execution.
+*******************************************************************************/
+int main()
+{
+	int ret;
+
+	ltc2672_ip.spi_init = ltc2672_spi_ip;
+
+	struct no_os_uart_desc *ltc2672_uart_desc;
+
+	ret = no_os_uart_init(&ltc2672_uart_desc, &ltc2672_uart_ip);
+	if (ret) {
+		goto error;
+	}
+
+	no_os_uart_stdio(ltc2672_uart_desc);
+
+	return basic_example_main();
+
+	return ret;
+
+#if (BASIC_EXAMPLE == 0)
+#error Enable BASIC_EXAMPLE by using y value in Makefile.
+#endif
+
+error:
+	no_os_uart_remove(ltc2672_uart_desc);
+	return ret;
+}

--- a/projects/dc2903a/src/platform/maxim/parameters.c
+++ b/projects/dc2903a/src/platform/maxim/parameters.c
@@ -1,0 +1,57 @@
+/***************************************************************************//**
+ *   @file   parameters.c
+ *   @brief  Definition of Maxim platform data used by DC2903A project.
+ *   @author JSanBuenaventura (jose.sanbuenaventura@analog.com)
+ *   @author MSosa (marcpaolo.sosa@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "parameters.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+struct max_uart_init_param ltc2672_uart_extra_ip = {
+	.flow = UART_FLOW_DIS,
+};
+
+struct max_spi_init_param ltc2672_spi_extra_ip  = {
+	.num_slaves = 1,
+	.polarity = SPI_SS_POL_LOW,
+	.vssel = MXC_GPIO_VSSEL_VDDIOH,
+};

--- a/projects/dc2903a/src/platform/maxim/parameters.h
+++ b/projects/dc2903a/src/platform/maxim/parameters.h
@@ -1,0 +1,73 @@
+/***************************************************************************//**
+ *   @file   parameters.h
+ *   @brief  Implementation of parameters.h
+ *   @author JSanBuenaventura (jose.sanbuenaventura@analog.com)
+ *   @author MSosa (marcpaolo.sosa@analog.com)
+ *******************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "maxim_irq.h"
+#include "maxim_spi.h"
+#include "maxim_uart.h"
+#include "maxim_uart_stdio.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+#define UART_OPS                &max_uart_ops
+#define UART_EXTRA              &ltc2672_uart_extra_ip
+extern struct max_uart_init_param ltc2672_uart_extra_ip;
+
+#define UART_DEVICE_ID          1
+#define UART_BAUDRATE           57600
+#define UART_IRQ_ID             UART1_IRQn
+
+#define LTC2672_VAR             LTC2672_12
+
+#define SPI_DEVICE_ID           1
+#define SPI_BAUDRATE            5000000
+#define SPI_CS                  0
+#define SPI_OPS                 &max_spi_ops
+#define SPI_EXTRA               &ltc2672_spi_extra_ip
+
+extern struct max_spi_init_param ltc2672_spi_extra_ip;
+
+#endif /* __PARAMETERS_H__ */

--- a/projects/dc2903a/src/platform/maxim/platform_src.mk
+++ b/projects/dc2903a/src/platform/maxim/platform_src.mk
@@ -1,0 +1,15 @@
+INCS += $(INCLUDE)/no_os_rtc.h
+
+INCS += $(PLATFORM_DRIVERS)/maxim_delay.h     \
+        $(PLATFORM_DRIVERS)/maxim_spi.h       \
+        $(PLATFORM_DRIVERS)/maxim_irq.h       \
+        $(PLATFORM_DRIVERS)/maxim_rtc.h       \
+        $(PLATFORM_DRIVERS)/maxim_uart.h      \
+        $(PLATFORM_DRIVERS)/maxim_uart_stdio.h
+
+SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c     \
+        $(PLATFORM_DRIVERS)/maxim_spi.c       \
+        $(PLATFORM_DRIVERS)/maxim_rtc.c       \
+        $(PLATFORM_DRIVERS)/maxim_irq.c       \
+        $(PLATFORM_DRIVERS)/maxim_uart.c      \
+        $(PLATFORM_DRIVERS)/maxim_uart_stdio.c

--- a/projects/dc2903a/src/platform/platform_includes.h
+++ b/projects/dc2903a/src/platform/platform_includes.h
@@ -1,0 +1,49 @@
+/***************************************************************************//**
+ *   @file   platform_includes.h
+ *   @brief  Includes for used platforms used by DC2903A project.
+ *   @author JSanBuenaventura (jose.sanbuenaventura@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PLATFORM_INCLUDES_H__
+#define __PLATFORM_INCLUDES_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#ifdef MAXIM_PLATFORM
+#include "maxim/parameters.h"
+#endif
+
+#endif /* __PLATFORM_INCLUDES_H__ */


### PR DESCRIPTION
add example project for dc2903a/ltc2672 eval-board.

Signed-off-by: Marc Paolo Sosa <marcpaolo.sosa@analog.com>