### PR TITLE
Using no os scripts

### DIFF
--- a/projects/adrv9001/Makefile
+++ b/projects/adrv9001/Makefile
@@ -1,9 +1,4 @@
 TINYIIOD ?= n
-CFLAGS = -DADI_DYNAMIC_PROFILE_LOAD \
-	 -DADI_COMMON_VERBOSE=1 \
-	 -DADI_ADRV9001_ARM_VERBOSE \
-	 -DADI_VALIDATE_PARAMS \
-	 $(CFLAGS_REVISION)
 
 include ../../tools/scripts/generic_variables.mk
 

--- a/projects/adrv9001/src.mk
+++ b/projects/adrv9001/src.mk
@@ -81,3 +81,9 @@ INCS += $(INCLUDE)/no_os_uart.h \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h \
 	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.h
 endif
+
+CFLAGS = -DADI_DYNAMIC_PROFILE_LOAD \
+	 -DADI_COMMON_VERBOSE=1 \
+	 -DADI_ADRV9001_ARM_VERBOSE \
+	 -DADI_VALIDATE_PARAMS \
+	 $(CFLAGS_REVISION)

--- a/tools/scripts/generic.mk
+++ b/tools/scripts/generic.mk
@@ -254,14 +254,14 @@ INCS     += $(foreach dir, $(SRC_DIRS), $(call rwildcard, $(dir),*.h))
 
 # Recursive ignored files. If a directory is in the variable IGNORED_FILES,
 # all files from inside the directory will be ignored
-ALL_IGNORED_FILES = $(foreach dir, $(IGNORED_FILES), $(call rwildcard, $(dir),*))
+ALL_IGNORED_FILES += $(foreach dir, $(IGNORED_FILES), $(call rwildcard, $(dir),*))
 
 # Remove ignored files
 SRCS     := $(filter-out $(ALL_IGNORED_FILES),$(SRCS))
 INCS     := $(filter-out $(ALL_IGNORED_FILES),$(INCS))
 
 # Get all src files that are not in SRC_DRIS
-FILES_OUT_OF_DIRS := $(filter-out $(call rwildcard, $(SRC_DIRS),*), $(SRCS) $(INCS)) 
+FILES_OUT_OF_DIRS := $(filter-out $(foreach source_directory_name,$(sort $(SRC_DIRS)),$(wildcard $(source_directory_name)/*)),$(SRCS) $(INCS))
 
 REL_SRCS = $(addprefix $(OBJECTS_DIR)/,$(call get_relative_path,$(SRCS_IN_BUILD) $(PLATFORM_SRCS)))
 OBJS = $(patsubst %.cpp,%.o,$(patsubst %.c,%.o,$(REL_SRCS)))
@@ -286,7 +286,7 @@ INCS := $(sort $(INCS))
 CREATED_DIRECTORIES += noos root $(PROJECT_NAME)
 SRCS_IN_BUILD = $(call relative_to_project, $(SRCS))
 INCS_IN_BUILD = $(call relative_to_project, $(INCS))
-DIRS_TO_CREATE = $(sort $(dir $(call relative_to_project, $(FILES_OUT_OF_DIRS) $(SRC_DIRS) $(PLATFORM_DIRS))))
+DIRS_TO_CREATE = $(sort $(call relative_to_project, $(dir $(FILES_OUT_OF_DIRS)) $(SRC_DIRS) $(PLATFORM_DIRS)))
 # Prefixes from get_relative_path
 DIRS_TO_REMOVE = $(addprefix $(PROJECT_BUILD)/,$(CREATED_DIRECTORIES))
 
@@ -407,10 +407,7 @@ update: $(PROJECT_TARGET)
 	@$(call print, $(ACTION) srcs to created project)
 	$(MUTE) $(call remove_dir,$(DIRS_TO_REMOVE)) $(HIDE)
 	$(MUTE) -$(call mk_dir,$(DIRS_TO_CREATE)) $(HIDE)
-	$(MUTE) $(foreach dir,$(sort $(SRC_DIRS)),\
-		$(call update_dir,$(dir),$(call relative_to_project,$(dir))) $(HIDE)\
-		$(cmd_separator)) echo . $(HIDE)
-	$(MUTE) $(foreach file,$(sort $(FILES_OUT_OF_DIRS)),\
+	$(MUTE) $(foreach file,$(sort $(SRCS) $(INCS)),\
 		$(call update_file,$(file),$(call relative_to_project,$(file))) $(HIDE)\
 		$(cmd_separator)) echo . $(HIDE)
 	$(MUTE) $(MAKE) --no-print-directory pre_build MAKEFLAGS=$(MAKEOVERRIDES)

--- a/tools/scripts/generic_variables.mk
+++ b/tools/scripts/generic_variables.mk
@@ -29,7 +29,7 @@ PLATFORM_DRIVERS	?= $(NO-OS)/drivers/platform/$(PLATFORM)
 GIT_VERSION := $(shell git describe --all --long --dirty=-modified)
 GIT_VERSION := $(subst heads/,,$(GIT_VERSION))
 GIT_VERSION := $(subst -0-g,-,$(GIT_VERSION))
-CFLAGS += -DNO_OS_VERSION=$(GIT_VERSION)
+CFLAGS := -DNO_OS_VERSION=$(GIT_VERSION)
 #------------------------------------------------------------------------------
 #                          EVALUATE PLATFORM
 #------------------------------------------------------------------------------

--- a/tools/scripts/mbed.mk
+++ b/tools/scripts/mbed.mk
@@ -24,7 +24,6 @@ CPP = arm-none-eabi-g++
 OC = arm-none-eabi-objcopy
 
 # Project related build Files
-MBED_OS_INCLUDE_PATHS_NAMES = $(BUILD_DIR)/mbed-os-include-path-names.txt
 LSCRIPT = $(BUILD_DIR)/$(PROJECT_NAME)-linker-file.ld
 PROJECT_BIN_FILE = $(subst elf,bin,$(BINARY))
 PROJECT_MAP_FILE = $(subst elf,map,$(BINARY))
@@ -44,15 +43,15 @@ SPACE := $(NULL) $(NULL)
 
 MBED_C_FLAGS = $(subst ",,$(subst $(COMMA), ,$(patsubst {"flags":[%,%,$(firstword $(subst ]$(COMMA)"macros", "macros",$(subst $(SPACE),,$(READ_MBED_GENERATED_PROFILE_C_FILE)))))))
 MBED_C_SYMBOLS = $(patsubst %,-D%,$(subst ",,$(subst $(COMMA), ,$(patsubst %]},%,$(lastword $(subst "symbols":[,"symbols":[ ,$(subst $(SPACE),,$(READ_MBED_GENERATED_PROFILE_C_FILE))))))))
-CFLAGS += $(MBED_C_FLAGS) $(MBED_C_SYMBOLS) -include $(MBED_OS_BUILD_DIRECTORY)/mbed_config.h -DMBED_PLATFORM $(TEST_FLAGS)
+CFLAGS += $(MBED_C_FLAGS) $(MBED_C_SYMBOLS) -include $(MBED_OS_BUILD_DIRECTORY)/mbed_config.h -DMBED_PLATFORM
 
 MBED_CPP_FLAGS = $(subst ",,$(subst $(COMMA), ,$(patsubst {"flags":[%,%,$(firstword $(subst ]$(COMMA)"macros", "macros",$(subst $(SPACE),,$(READ_MBED_GENERATED_PROFILE_CPP_FILE)))))))
 MBED_CPP_SYMBOLS = $(patsubst %,-D%,$(subst ",,$(subst $(COMMA), ,$(patsubst %]},%,$(lastword $(subst "symbols":[,"symbols":[ ,$(subst $(SPACE),,$(READ_MBED_GENERATED_PROFILE_CPP_FILE))))))))
-CPPFLAGS += $(MBED_CPP_FLAGS) $(MBED_CPP_SYMBOLS) -include $(MBED_OS_BUILD_DIRECTORY)/mbed_config.h -DMBED_PLATFORM $(TEST_FLAGS)
+CPPFLAGS += $(MBED_CPP_FLAGS) $(MBED_CPP_SYMBOLS) -include $(MBED_OS_BUILD_DIRECTORY)/mbed_config.h -DMBED_PLATFORM
 
 MBED_ASM_FLAGS = $(subst ",,$(subst $(COMMA), ,$(patsubst {"flags":[%,%,$(firstword $(subst ]$(COMMA)"macros", "macros",$(subst $(SPACE),,$(READ_MBED_GENERATED_PROFILE_ASM_FILE)))))))
 MBED_ASM_SYMBOLS = $(patsubst %,-D%,$(subst ",,$(subst $(COMMA), ,$(patsubst %]},%,$(lastword $(subst "symbols":[,"symbols":[ ,$(subst $(SPACE),,$(READ_MBED_GENERATED_PROFILE_ASM_FILE))))))))
-ASFLAGS += $(MBED_ASM_FLAGS) $(MBED_ASM_SYMBOLS) -include $(MBED_OS_BUILD_DIRECTORY)/mbed_config.h -DMBED_PLATFORM $(TEST_FLAGS)
+ASFLAGS += $(MBED_ASM_FLAGS) $(MBED_ASM_SYMBOLS) -include $(MBED_OS_BUILD_DIRECTORY)/mbed_config.h -DMBED_PLATFORM
 
 MBED_LINKER_FLAGS = $(subst ",,$(subst "$(COMMA)", ,$(patsubst {"flags":[%,%,$(firstword $(subst ]$(COMMA)"macros", "macros",$(subst $(SPACE),,$(READ_MBED_GENERATED_PROFILE_LINKER_FILE)))))))
 MBED_LINKER_SYMBOLS = $(patsubst %,-D%,$(subst ",,$(subst $(COMMA), ,$(patsubst %]},%,$(lastword $(subst "symbols":[,"symbols":[ ,$(subst $(SPACE),,$(READ_MBED_GENERATED_PROFILE_LINKER_FILE))))))))
@@ -69,7 +68,7 @@ UPDATE_MBED_GENERATED_ARCHIVE_FILE = $(addprefix $(MBED_OS_DIRECTORY)/, $(shell 
 
 # Platform include paths
 MBED_PLATFORM_INCLUDE_PATHS = $(patsubst %,%/,$(patsubst %,-I%,$(patsubst mbed-os%,$(MBED_OS_DIRECTORY)/mbed-os%,$(patsubst -I%,%,$(subst ",,$(READ_MBED_GENERATED_INCLUDE_FILE))))))
-PLATFORM_INCS = @$(MBED_OS_INCLUDE_PATHS_NAMES)
+PLATFORM_INCS = $(MBED_PLATFORM_INCLUDE_PATHS)
 
 # Extra files for build
 EXTRA_FILES =@$(UPDATED_MBED_GENERATED_ARCHIVE_FILE)
@@ -77,9 +76,8 @@ EXTRA_FILES =@$(UPDATED_MBED_GENERATED_ARCHIVE_FILE)
 # Rule for building Mbed-OS
 $(PROJECT_TARGET): MBED-OS-build
 	-$(MUTE) $(call mk_dir,$(BUILD_DIR)) $(HIDE)
-	$(MUTE) $(call print, putting mbed-os include path names and object files names to text file)
-	$(MUTE) $(call ADD_BLANK_LINE, $(MBED_OS_INCLUDE_PATHS_NAMES)) $(cmd_separator) $(foreach file,$(sort $(MBED_PLATFORM_INCLUDE_PATHS)),$(call APPEND_TO_FILE,$(file),$(MBED_OS_INCLUDE_PATHS_NAMES)) $(cmd_separator)) echo . $(HIDE)
-	$(MUTE) $(call ADD_BLANK_LINE, $(UPDATED_MBED_GENERATED_ARCHIVE_FILE)) $(cmd_separator) $(foreach file,$(sort $(UPDATE_MBED_GENERATED_ARCHIVE_FILE)),$(call APPEND_TO_FILE,$(file),$(UPDATED_MBED_GENERATED_ARCHIVE_FILE)) $(cmd_separator)) echo . $(HIDE)
+	$(MUTE) $(call print, putting mbed-os object files names to text file)
+	$(MUTE) $(call ADD_BLANK_LINE_TO_FILE, $(UPDATED_MBED_GENERATED_ARCHIVE_FILE)) $(cmd_separator) $(foreach mbed_os_object_file,$(sort $(UPDATE_MBED_GENERATED_ARCHIVE_FILE)),$(call APPEND_TEXT_TO_FILE,$(mbed_os_object_file),$(UPDATED_MBED_GENERATED_ARCHIVE_FILE)) $(cmd_separator)) echo . $(HIDE)
 	$(MUTE) $(call set_one_time_rule,$@)
 
 $(MBED_OS_LIBRARY):
@@ -89,7 +87,7 @@ PHONY_TARGET += MBED-OS-build
 MBED-OS-build:
 	-$(MUTE) $(call mk_dir,$(MBED_APP_JSON_DIRECTORY)) $(HIDE)
 	$(MUTE) $(call copy_file,$(MBED_OS_DIRECTORY)/mbed_app.json,$(MBED_APP_JSON_DIRECTORY)/) $(HIDE)
-	cd $(MBED_OS_DIRECTORY) $(cmd_separator) mbed config root . $(cmd_separator) mbed compile --source $(MBED_OS_DIRECTORY)/mbed-os --source $(MBED_APP_JSON_DIRECTORY) -m $(TARGET_BOARD) -t $(COMPILER) --build $(MBED_OS_BUILD_DIRECTORY) --library
+	$(MUTE) cd $(MBED_OS_DIRECTORY) $(cmd_separator) mbed config root . $(cmd_separator) mbed compile --source $(MBED_OS_DIRECTORY)/mbed-os --source $(MBED_APP_JSON_DIRECTORY) -m $(TARGET_BOARD) -t $(COMPILER) --build $(MBED_OS_BUILD_DIRECTORY) --library
 	$(MUTE) $(call print, Mbed-OS build completed)
 
 # Linker-Script Preprocessing


### PR DESCRIPTION
1. Added commands to create text files which contains cflags, cppflags and as flags which can be used in compilation step to avoid path length issues in window's.
2. If FLAGS contains \" then it is replaced by \\\" so that flgs text file can contain \"
3. Used := variable assignment for CFLAGS to avoid repeating of flags in compilation step. So we must use CFLAGS after inclusion of generic variable makefile.
4. Provided method to exclude source file from a directory in build.
