### PR TITLE
iio_app: Add default trigger id to iio devices

### DIFF
--- a/iio/iio_app/iio_app.c
+++ b/iio/iio_app/iio_app.c
@@ -340,6 +340,7 @@ int iio_app_init(struct iio_app_desc **app,
 		iio_init_devs[i].name = app_init_param.devices[i].name;
 		iio_init_devs[i].dev = app_init_param.devices[i].dev;
 		iio_init_devs[i].dev_descriptor = app_init_param.devices[i].dev_descriptor;
+		iio_init_devs[i].trigger_id = app_init_param.devices[i].default_trigger_id;
 		buff = app_init_param.devices[i].read_buff ?
 		       app_init_param.devices[i].read_buff :
 		       app_init_param.devices[i].write_buff;

--- a/iio/iio_app/iio_app.h
+++ b/iio/iio_app/iio_app.h
@@ -46,12 +46,13 @@
 #include "no_os_error.h"
 #include "no_os_delay.h"
 
-#define IIO_APP_DEVICE(_name, _dev, _dev_descriptor, _read_buff, _write_buff) {\
+#define IIO_APP_DEVICE(_name, _dev, _dev_descriptor, _read_buff, _write_buff, _default_trigger_id) {\
 	.name = _name,\
 	.dev = _dev,\
 	.dev_descriptor = _dev_descriptor,\
 	.read_buff = _read_buff,\
-	.write_buff = _write_buff\
+	.write_buff = _write_buff,\
+	.default_trigger_id = _default_trigger_id\
 }
 
 #define IIO_APP_TRIGGER(_name, _trig, _trig_descriptor) {\
@@ -71,6 +72,7 @@ struct iio_app_device {
 	struct iio_device *dev_descriptor;
 	struct iio_data_buffer *read_buff;
 	struct iio_data_buffer *write_buff;
+	char *default_trigger_id;
 };
 
 /**

--- a/projects/ad3552r_fmcz/srcs/main.c
+++ b/projects/ad3552r_fmcz/srcs/main.c
@@ -254,7 +254,7 @@ int main()
 
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("ad3552r", iio_dac, iio_dac_descriptor, NULL,
-			       &wr_buff)
+			       &wr_buff, NULL)
 	};
 
 	err = 0;

--- a/projects/ad413x/src/app/main.c
+++ b/projects/ad413x/src/app/main.c
@@ -196,7 +196,7 @@ int main()
 			.dev = adciio,
 			.dev_descriptor = adciio->iio_dev,
 			.read_buff =  &iio_ad413x_read_buff,
-			.write_buff = NULL
+			.write_buff = NULL,
 		}
 	};
 

--- a/projects/ad463x_fmcz/src/ad463x_fmc.c
+++ b/projects/ad463x_fmcz/src/ad463x_fmc.c
@@ -227,7 +227,7 @@ int main()
 
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("ad463x", iio_ad463x, &iio_ad463x->iio_dev_desc,
-			       &rd_buff, NULL),
+			       &rd_buff, NULL, NULL),
 	};
 
 	app_init_param.devices = devices;

--- a/projects/ad469x_fmcz/src/ad469x_fmcz.c
+++ b/projects/ad469x_fmcz/src/ad469x_fmcz.c
@@ -237,7 +237,7 @@ int main()
 
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("ad469x", dev, &ad469x_iio_descriptor,
-			       &read_buff, NULL),
+			       &read_buff, NULL, NULL),
 	};
 
 	app_init_param.devices = devices;

--- a/projects/ad6676-ebz/src/ad6676_ebz.c
+++ b/projects/ad6676-ebz/src/ad6676_ebz.c
@@ -517,7 +517,7 @@ int main(void)
 	iio_axi_adc_get_dev_descriptor(iio_axi_adc_desc, &adc_dev_desc);
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("ad6676_dev", iio_axi_adc_desc,
-			       adc_dev_desc, &read_buff, NULL),
+			       adc_dev_desc, &read_buff, NULL, NULL),
 	};
 
 	app_init_param.devices = devices;

--- a/projects/ad7124-8pmdz/src/main.c
+++ b/projects/ad7124-8pmdz/src/main.c
@@ -166,7 +166,7 @@ int main(void)
 
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("ad7124-8", ad7124_device, &iio_ad7124_device,
-			       &iio_ad7124_read_buff, NULL)
+			       &iio_ad7124_read_buff, NULL, NULL)
 	};
 
 	app_init_param.devices = devices;

--- a/projects/ad713x_fmcz/src/ad713x_fmc.c
+++ b/projects/ad713x_fmcz/src/ad713x_fmc.c
@@ -327,11 +327,11 @@ int main()
 
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("dual_ad7134", iio_ad713x, ad713x_dev_desc,
-			       &rd_buff, NULL),
+			       &rd_buff, NULL, NULL),
 		IIO_APP_DEVICE("ad7134_1", ad713x_dev_1, &ad713x_iio_desc,
-			       NULL, NULL),
+			       NULL, NULL, NULL),
 		IIO_APP_DEVICE("ad7134_2", ad713x_dev_2, &ad713x_iio_desc,
-			       NULL, NULL)
+			       NULL, NULL, NULL)
 
 	};
 

--- a/projects/ad7768-evb/src/ad7768_evb.c
+++ b/projects/ad7768-evb/src/ad7768_evb.c
@@ -351,7 +351,7 @@ int main(void)
 
 	struct iio_app_device devs[] = {
 		IIO_APP_DEVICE("ad7768_dev", iio_axi_adc_desc, dev_desc,
-			       &read_buff, NULL),
+			       &read_buff, NULL, NULL),
 	};
 
 	app_init_param.devices = devs;

--- a/projects/ad9081/src/app.c
+++ b/projects/ad9081/src/app.c
@@ -367,8 +367,8 @@ int main(void)
 	};
 
 	struct iio_app_device devices[] = {
-		IIO_APP_DEVICE("axi_adc", iio_axi_adc_desc, adc_dev_desc, &read_buff, NULL),
-		IIO_APP_DEVICE("axi_dac", iio_axi_dac_desc, dac_dev_desc, NULL, &write_buff)
+		IIO_APP_DEVICE("axi_adc", iio_axi_adc_desc, adc_dev_desc, &read_buff, NULL, NULL),
+		IIO_APP_DEVICE("axi_dac", iio_axi_dac_desc, dac_dev_desc, NULL, &write_buff, NULL)
 	};
 
 	app_init_param.devices = devices;

--- a/projects/ad9083/src/app.c
+++ b/projects/ad9083/src/app.c
@@ -218,9 +218,9 @@ int main(void)
 
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("axi_adc", iio_axi_adc_desc,
-			       iio_adc_dev_desc, &read_buff, NULL),
+			       iio_adc_dev_desc, &read_buff, NULL, NULL),
 		IIO_APP_DEVICE("ad9083", app_ad9083->ad9083_phy,
-			       &ad9083_iio_descriptor, NULL, NULL)
+			       &ad9083_iio_descriptor, NULL, NULL, NULL)
 	};
 
 	app_init_param.devices = devices;

--- a/projects/ad9172/src/main.c
+++ b/projects/ad9172/src/main.c
@@ -370,7 +370,7 @@ int main(void)
 	};
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("axi_dac", iio_axi_dac_desc, dac_dev_desc,
-			       &write_buff, NULL),
+			       &write_buff, NULL, NULL),
 	};
 
 	app_init_param.devices = devices;

--- a/projects/ad9208/src/main.c
+++ b/projects/ad9208/src/main.c
@@ -139,9 +139,9 @@ int32_t start_iiod(struct axi_adc *rx_0_adc, struct axi_adc *rx_1_adc,
 
 	struct iio_app_device devices[2] = {
 		IIO_APP_DEVICE("axi_adc0", iio_axi_adc_0_desc, adc0_dev_desc,
-			       &rd_buff0, NULL),
+			       &rd_buff0, NULL, NULL),
 		IIO_APP_DEVICE("axi_adc1", iio_axi_adc_1_desc, adc1_dev_desc,
-			       &rd_buff1, NULL),
+			       &rd_buff1, NULL, NULL),
 	};
 
 	app_init_param.devices = devices;

--- a/projects/ad9265-fmc-125ebz/src/ad9265_fmc_125ebz.c
+++ b/projects/ad9265-fmc-125ebz/src/ad9265_fmc_125ebz.c
@@ -206,7 +206,7 @@ int main(void)
 
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("ad9265_dev", iio_axi_adc_desc, dev_desc,
-			       &read_buff, NULL),
+			       &read_buff, NULL, NULL),
 	};
 
 	app_init_param.devices = devices;

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -977,13 +977,13 @@ int main(void)
 #endif
 
 	struct iio_app_device devices[] = {
-		IIO_APP_DEVICE("cf-ad9361-lpc", iio_axi_adc_desc, adc_dev_desc, &read_buff, NULL),
-		IIO_APP_DEVICE("cf-ad9361-dds-core-lpc", iio_axi_dac_desc, dac_dev_desc, NULL, &write_buff),
-		IIO_APP_DEVICE("ad9361-phy", ad9361_phy, ad9361_dev_desc, NULL, NULL),
+		IIO_APP_DEVICE("cf-ad9361-lpc", iio_axi_adc_desc, adc_dev_desc, &read_buff, NULL, NULL),
+		IIO_APP_DEVICE("cf-ad9361-dds-core-lpc", iio_axi_dac_desc, dac_dev_desc, NULL, &write_buff, NULL),
+		IIO_APP_DEVICE("ad9361-phy", ad9361_phy, ad9361_dev_desc, NULL, NULL, NULL),
 #ifdef FMCOMMS5
-		IIO_APP_DEVICE("cf-ad9361-B", iio_axi_adc_b_desc, adc_b_dev_desc, &read_buff, NULL),
-		IIO_APP_DEVICE("cf-ad9361-dds-core-B", iio_axi_dac_b_desc, dac_b_dev_desc, NULL, &write_buff),
-		IIO_APP_DEVICE("ad9361-phy-B", ad9361_phy_b, ad9361_b_dev_desc, NULL, NULL)
+		IIO_APP_DEVICE("cf-ad9361-B", iio_axi_adc_b_desc, adc_b_dev_desc, &read_buff, NULL, NULL),
+		IIO_APP_DEVICE("cf-ad9361-dds-core-B", iio_axi_dac_b_desc, dac_b_dev_desc, NULL, &write_buff, NULL),
+		IIO_APP_DEVICE("ad9361-phy-B", ad9361_phy_b, ad9361_b_dev_desc, NULL, NULL, NULL)
 #endif
 	};
 

--- a/projects/ad9371/src/app/headless.c
+++ b/projects/ad9371/src/app/headless.c
@@ -1122,8 +1122,8 @@ int main(void)
 	};
 	iio_axi_dac_get_dev_descriptor(iio_axi_dac_desc, &dac_dev_desc);
 	struct iio_app_device devices[] = {
-		IIO_APP_DEVICE("cf-ad9371-lpc", iio_axi_adc_desc, adc_dev_desc, &read_buff, NULL),
-		IIO_APP_DEVICE("cf-ad9371-dds-core-lpc", iio_axi_dac_desc, dac_dev_desc, NULL, &write_buff)
+		IIO_APP_DEVICE("cf-ad9371-lpc", iio_axi_adc_desc, adc_dev_desc, &read_buff, NULL, NULL),
+		IIO_APP_DEVICE("cf-ad9371-dds-core-lpc", iio_axi_dac_desc, dac_dev_desc, NULL, &write_buff, NULL)
 	};
 
 	app_init_param.devices = devices;

--- a/projects/ad9434-fmc-500ebz/src/ad9434_fmc_500ebz.c
+++ b/projects/ad9434-fmc-500ebz/src/ad9434_fmc_500ebz.c
@@ -216,7 +216,7 @@ int main(void)
 	};
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("ad9434_dev", iio_axi_adc_desc, dev_desc,
-			       &read_buff, NULL),
+			       &read_buff, NULL, NULL),
 	};
 
 	app_init_param.devices = devices;

--- a/projects/ad9467/src/app/ad9467_fmc.c
+++ b/projects/ad9467/src/app/ad9467_fmc.c
@@ -479,7 +479,7 @@ int main()
 	};
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("ad9467", iio_axi_adc_desc, dev_desc, &read_buff,
-			       NULL),
+			       NULL, NULL),
 	};
 
 	app_init_param.devices = devices;

--- a/projects/ad9656_fmc/src/app/ad9656_fmc.c
+++ b/projects/ad9656_fmc/src/app/ad9656_fmc.c
@@ -335,7 +335,7 @@ int main(void)
 
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("ad9656_dev", iio_axi_adc_desc, dev_desc,
-			       &read_buff, NULL),
+			       &read_buff, NULL, NULL),
 	};
 
 	app_init_param.devices = devices;

--- a/projects/ad9739a-fmc-ebz/src/ad9739a_fmc_ebz.c
+++ b/projects/ad9739a-fmc-ebz/src/ad9739a_fmc_ebz.c
@@ -261,7 +261,7 @@ int main(void)
 	};
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("ad9739a_dev", iio_axi_dac_desc, dev_desc,
-			       &read_buff, NULL),
+			       &read_buff, NULL, NULL),
 	};
 
 	app_init_param.devices = devices;

--- a/projects/ada4250_ardz/src/ada4250_ardz.c
+++ b/projects/ada4250_ardz/src/ada4250_ardz.c
@@ -111,7 +111,7 @@ int main()
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("ADA4250", ada4250_dev,
 			       &ada4250_iio_descriptor,
-			       NULL, NULL)
+			       NULL, NULL, NULL)
 	};
 
 	app_init_param.devices = devices;

--- a/projects/adaq8092_fmc/src/adaq8092_fmc.c
+++ b/projects/adaq8092_fmc/src/adaq8092_fmc.c
@@ -250,7 +250,7 @@ int main(void)
 
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("adaq8092_dev", iio_axi_adc_desc, dev_desc,
-			       &read_buff, NULL),
+			       &read_buff, NULL, NULL),
 	};
 
 	app_init_param.devices = devices;

--- a/projects/adf4377_sdz/src/app/adf4377_sdz.c
+++ b/projects/adf4377_sdz/src/app/adf4377_sdz.c
@@ -142,7 +142,7 @@ int main(void)
 #ifdef IIO_SUPPORT
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("adf4377_dev", dev, &adf4377_iio_descriptor,
-			       NULL, NULL),
+			       NULL, NULL, NULL),
 	};
 	return iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 #endif

--- a/projects/adf5902_sdz/src/adf5902_sdz.c
+++ b/projects/adf5902_sdz/src/adf5902_sdz.c
@@ -230,7 +230,7 @@ int main(void)
 #ifdef IIO_SUPPORT
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("adf5902_dev", dev, &adf5902_iio_descriptor,
-			       NULL, NULL),
+			       NULL, NULL, NULL),
 	};
 	return iio_app_run(NULL, 0, devices, NO_OS_ARRAY_SIZE(devices));
 #endif

--- a/projects/adrv9009/src/app/headless.c
+++ b/projects/adrv9009/src/app/headless.c
@@ -136,11 +136,11 @@ int32_t start_iiod(struct axi_dmac *rx_dmac, struct axi_dmac *tx_dmac,
 	struct iio_app_device devices[] = {
 #ifndef ADRV9008_2
 		IIO_APP_DEVICE("axi_adc", iio_axi_adc_desc, adc_dev_desc,
-			       &read_buff, NULL),
+			       &read_buff, NULL, NULL),
 #endif
 #ifndef ADRV9008_1
 		IIO_APP_DEVICE("axi_dac", iio_axi_dac_desc, dac_dev_desc,
-			       NULL, &write_buff)
+			       NULL, &write_buff, NULL)
 #endif
 	};
 

--- a/projects/cn0531/src/main.c
+++ b/projects/cn0531/src/main.c
@@ -139,7 +139,7 @@ int main(void)
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("ad5791", ad5791_iio_handle,
 			       ad5791_iio_handle->ad5791_iio_dev,
-			       &iio_ad5791_read_buff, NULL)
+			       &iio_ad5791_read_buff, NULL, NULL)
 	};
 
 	app_init_param.devices = devices;

--- a/projects/cn0561/src/cn0561.c
+++ b/projects/cn0561/src/cn0561.c
@@ -264,7 +264,7 @@ int main()
 
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("ad4134", iio_desc, &ad713x_iio_desc,
-			       &rd_buff, NULL),
+			       &rd_buff, NULL, NULL),
 	};
 
 	app_init_param.devices = devices;

--- a/projects/fmcadc2/src/fmcadc2.c
+++ b/projects/fmcadc2/src/fmcadc2.c
@@ -280,7 +280,7 @@ int main(void)
 
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("axi-ad9625", iio_axi_adc_desc, adc_dev_desc,
-			       &read_buff, NULL),
+			       &read_buff, NULL, NULL),
 	};
 
 	app_init_param.devices = devices;

--- a/projects/fmcadc5/src/fmcadc5.c
+++ b/projects/fmcadc5/src/fmcadc5.c
@@ -427,7 +427,7 @@ int main(void)
 
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("axi-ad9625-0", iio_axi_adc_0_desc, adc_dev_0_desc,
-			       &read_buff0, NULL),
+			       &read_buff0, NULL, NULL),
 	};
 
 	app_init_param.devices = devices;

--- a/projects/fmcdaq2/src/app/fmcdaq2.c
+++ b/projects/fmcdaq2/src/app/fmcdaq2.c
@@ -797,13 +797,13 @@ static int fmcdaq2_iio_init(struct fmcdaq2_dev *dev,
 
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("axi_adc", iio_axi_adc_desc, adc_dev_desc,
-			       &read_buff, NULL),
+			       &read_buff, NULL, NULL),
 		IIO_APP_DEVICE("axi_dac", iio_axi_dac_desc, dac_dev_desc,
-			       NULL, &write_buff),
+			       NULL, &write_buff, NULL),
 		IIO_APP_DEVICE("ad9680_dev", dev->ad9680_device,
-			       &ad9680_iio_descriptor, NULL, NULL),
+			       &ad9680_iio_descriptor, NULL, NULL, NULL),
 		IIO_APP_DEVICE("ad9144_dev", dev->ad9144_device,
-			       &ad9144_iio_descriptor, NULL, NULL)
+			       &ad9144_iio_descriptor, NULL, NULL, NULL)
 	};
 
 	app_init_param.devices = devices;

--- a/projects/fmcdaq3/src/app/fmcdaq3.c
+++ b/projects/fmcdaq3/src/app/fmcdaq3.c
@@ -713,13 +713,13 @@ int main(void)
 
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("axi_adc", iio_axi_adc_desc, adc_dev_desc,
-			       &read_buff, NULL),
+			       &read_buff, NULL, NULL),
 		IIO_APP_DEVICE("axi_dac", iio_axi_dac_desc, dac_dev_desc,
-			       NULL, &write_buff),
+			       NULL, &write_buff, NULL),
 		IIO_APP_DEVICE("ad9680_dev", ad9680_device,
-			       &ad9680_iio_descriptor, NULL, NULL),
+			       &ad9680_iio_descriptor, NULL, NULL, NULL),
 		IIO_APP_DEVICE("ad9152_dev", ad9152_device,
-			       &ad9152_iio_descriptor, NULL, NULL),
+			       &ad9152_iio_descriptor, NULL, NULL, NULL),
 	};
 
 	app_init_param.devices = devices;

--- a/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
+++ b/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
@@ -627,7 +627,7 @@ int main(void)
 
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("axi_adc", iio_axi_adc_desc, adc_dev_desc,
-			       &g_read_buff, NULL),
+			       &g_read_buff, NULL, NULL),
 	};
 
 	app_init_param.devices = devices;

--- a/projects/iio_adpd1080/src/main.c
+++ b/projects/iio_adpd1080/src/main.c
@@ -420,7 +420,7 @@ int main(void)
 
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("adpd1080", adpd1080_iio_device, &iio_adpd188_device,
-			       &iio_adpd1080_read_buff, NULL)
+			       &iio_adpd1080_read_buff, NULL, NULL)
 	};
 
 	app_init_param.devices = devices;

--- a/projects/iio_aducm3029/src/main.c
+++ b/projects/iio_aducm3029/src/main.c
@@ -131,7 +131,7 @@ int main(void)
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("adcum3029", &g_aducm3029_desc,
 			       &iio_aducm3029_desc,
-			       &adc_read_buff, NULL)
+			       &adc_read_buff, NULL, NULL)
 	};
 
 	/**

--- a/projects/iio_demo/src/examples/iio_example/iio_example.c
+++ b/projects/iio_demo/src/examples/iio_example/iio_example.c
@@ -91,9 +91,9 @@ int iio_example_main()
 
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("adc_demo", adc_desc,
-			       &adc_demo_iio_descriptor,&adc_buff, NULL),
+			       &adc_demo_iio_descriptor,&adc_buff, NULL, NULL),
 		IIO_APP_DEVICE("dac_demo", dac_desc,
-			       &dac_demo_iio_descriptor,NULL, &dac_buff)
+			       &dac_demo_iio_descriptor,NULL, &dac_buff, NULL)
 	};
 
 	app_init_param.devices = devices;

--- a/projects/iio_demo/src/examples/iio_sw_trigger_example/iio_sw_trigger_example.c
+++ b/projects/iio_demo/src/examples/iio_sw_trigger_example/iio_sw_trigger_example.c
@@ -110,9 +110,9 @@ int iio_sw_trigger_example_main()
 
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("adc_demo", adc_desc,
-			       &adc_demo_iio_descriptor,&adc_buff, NULL),
+			       &adc_demo_iio_descriptor,&adc_buff, NULL, NULL),
 		IIO_APP_DEVICE("dac_demo", dac_desc,
-			       &dac_demo_iio_descriptor,NULL, &dac_buff)
+			       &dac_demo_iio_descriptor,NULL, &dac_buff, NULL)
 	};
 
 	struct iio_trigger_init trigs[] = {

--- a/projects/iio_demo/src/examples/iio_timer_trigger_example/iio_timer_trigger_example.c
+++ b/projects/iio_demo/src/examples/iio_timer_trigger_example/iio_timer_trigger_example.c
@@ -156,9 +156,9 @@ int iio_timer_trigger_example_main()
 
 	struct iio_app_device devices[] = {
 		IIO_APP_DEVICE("adc_demo", adc_desc,
-			       &adc_demo_iio_descriptor,&adc_buff, NULL),
+			       &adc_demo_iio_descriptor,&adc_buff, NULL, NULL),
 		IIO_APP_DEVICE("dac_demo", dac_desc,
-			       &dac_demo_iio_descriptor,NULL, &dac_buff)
+			       &dac_demo_iio_descriptor,NULL, &dac_buff, NULL)
 	};
 
 	struct iio_trigger_init trigs[] = {


### PR DESCRIPTION
In some cases we want to assign a trigger to a device at init time. This implementation adds default_trigger_id parameter to iio_app_device structure such that a trigger can be assigned to a device at init time.
The trigger id should be of the form "trigger0", "trigger1", etc.