### PR TITLE
Mach1 multibyte reg access

### DIFF
--- a/drivers/adc/ad4080/ad4080.c
+++ b/drivers/adc/ad4080/ad4080.c
@@ -716,6 +716,78 @@ enum ad4080_fifo_mode ad4080_get_fifo_mode(struct ad4080_dev *dev)
 }
 
 /**
+ * @brief Configure the config SPI interface during initialization
+ * @param dev - The device structure.
+ * @param init_param - The structure that contains the device initial
+ * 		       parameters.
+ * @return 0 in case of success, negative error code otherwise
+ */
+init ad4080_configuration_intf_init(struct ad4080_dev *dev,
+				   struct ad4080_init_param init_param)
+{
+	int ret;
+	
+	if (!dev)
+		return -EINVAL;
+
+	ret = ad4080_set_single_instr(dev, init_param.single_instr);
+	if (ret)
+		return ret;
+	
+	ret = ad4080_set_short_instr(dev, init_param.short_instr);
+	if (ret)
+		return ret;
+	
+	ret = ad4080_set_strict_reg_access(dev, init_param.strict_reg);
+	if (ret)
+		return ret;
+		
+	return 0;
+}
+
+/**
+ * @brief Configure the data interface during initialization
+ * @param dev - The device structure.
+ * @param init_param - The structure that contains the device initial
+ * 		       parameters.
+ * @return 0 in case of success, negative error code otherwise
+ */
+init ad4080_data_intf_init(struct ad4080_dev *dev,
+				   struct ad4080_init_param init_param)
+{
+	int ret;
+	
+	if (!dev)
+		return -EINVAL;
+
+	ret = ad4080_set_cnv_spi_lvds_lanes(dev, init_param.cnv_spi_lvds_lanes);
+	if (ret)
+		return ret;
+	
+	ret = ad4080_set_conv_data_spi_lvds(dev, init_param.conv_data_spi_lvds) ;
+	if (ret)
+		return ret;
+	
+	ret = ad4080_set_lvds_cnv_clk_cnt(dev, init_param.lvds_cnv_clk_cnt) ;
+	if (ret)
+		return ret;
+	
+	ret = ad4080_set_lvds_self_clk_mode(dev, init_param.lvds_self_clk_mode) ;
+	if (ret)
+		return ret;
+	
+	ret = ad4080_set_lvds_vod(dev, init_param.lvds_vod) ;
+	if (ret)
+		return ret;
+	
+	ret = ad4080_set_lvds_cnv_clk_mode(dev, init_param.cnv_clk_mode) ;
+	if (ret)
+		return ret;
+	
+	return 0;
+}
+
+/**
  * @brief Initialize the device.
  * @param device - The device structure.
  * @param init_param - The structure that contains the device initial
@@ -762,6 +834,21 @@ int ad4080_init(struct ad4080_dev **device,
 		goto error_spi;
 
 	*device = dev;
+	
+	/* Configuration SPI Interface Initialization */
+	ret = ad4080_configuration_intf_init(dev, init_param);
+	if (ret)
+		goto error_spi;
+	
+	/* Data Interface Initialization */
+	ret = ad4080_data_intf_init(dev, init_param);
+	if (ret)
+		goto error_spi;	
+	
+	/* Set SDO Output Drive Current Strength */
+	ret = ad4080_set_mspi_drv(dev, init_param.mspi_drv) ;
+	if (ret)
+		goto error_spi;
 
 	return 0;
 

--- a/drivers/adc/ad4080/ad4080.h
+++ b/drivers/adc/ad4080/ad4080.h
@@ -424,6 +424,14 @@ int ad4080_set_fifo_mode(struct ad4080_dev *dev,
 /** Get AD4080 Conversion Data FIFO Mode */
 enum ad4080_fifo_mode ad4080_get_fifo_mode(struct ad4080_dev *dev);
 
+/** Configure the config SPI interface during initialization */
+int ad4080_configuration_intf_init(struct ad4080_dev *device,
+		struct ad4080_init_param init_param);
+
+/** Configure the data interface during initialization */
+int ad4080_data_intf_init(struct ad4080_dev *device,
+		struct ad4080_init_param init_param);
+
 /** Initialize the device. */
 int ad4080_init(struct ad4080_dev **device,
 		struct ad4080_init_param init_param);

--- a/drivers/adc/ad4080/ad4080.h
+++ b/drivers/adc/ad4080/ad4080.h
@@ -54,29 +54,40 @@
 /********************** Macros and Constants Definitions **********************/
 /******************************************************************************/
 
+#define AD4080_R1B				(1ul << 16)
+#define AD4080_R2B				(2ul << 16)
+#define AD4080_LEN(x)			((x) >> 16)
+#define AD4080_ADDR(x)			((x) & 0xFFFF)
+
 /** Register Definition */
-#define AD4080_REG_INTERFACE_CONFIG_A		0x0000
-#define AD4080_REG_INTERFACE_CONFIG_B		0x0001
-#define AD4080_REG_CHIP_TYPE			0x0003
-#define AD4080_REG_PRODUCT_ID_L			0x0004
-#define AD4080_REG_PRODUCT_ID_H			0x0005
-#define AD4080_REG_CHIP_GRADE			0x0006
-#define AD4080_REG_SCRATCH_PAD			0x000A
-#define AD4080_REG_SPI_REVISION			0x000B
-#define AD4080_REG_VENDOR_L			0x000C
-#define AD4080_REG_VENDOR_H			0x000D
-#define AD4080_REG_STREAM_MODE			0x000E
-#define AD4080_REG_TRANSFER_CONFIG		0x000F
-#define AD4080_REG_INTERFACE_CONFIG_C		0x0010
-#define AD4080_REG_INTERFACE_STATUS_A		0x0011
-#define AD4080_REG_DEVICE_STATUS		0x0014
-#define AD4080_REG_DATA_INTF_CONFIG_A		0x0015
-#define AD4080_REG_DATA_INTF_CONFIG_B		0x0016
-#define AD4080_REG_DATA_INTF_CONFIG_C		0x0017
-#define AD4080_REG_PWR_CTRL			0x0018
-#define AD4080_REG_FIFO_CONFIG			0x001C
-#define AD4080_REG_FIFO_WATERMARK		0x001D
-#define AD4080_REG_GAIN				0x0027
+#define AD4080_REG_INTERFACE_CONFIG_A		AD4080_R1B | 0x0000
+#define AD4080_REG_INTERFACE_CONFIG_B		AD4080_R1B | 0x0001
+#define AD4080_REG_DEVICE_CONFIG		AD4080_R1B | 0x0002
+#define AD4080_REG_CHIP_TYPE			AD4080_R1B | 0x0003
+#define AD4080_REG_PRODUCT_ID_L			AD4080_R1B | 0x0004
+#define AD4080_REG_PRODUCT_ID_H			AD4080_R1B | 0x0005
+#define AD4080_REG_CHIP_GRADE			AD4080_R1B | 0x0006
+#define AD4080_REG_SCRATCH_PAD			AD4080_R1B | 0x000A
+#define AD4080_REG_SPI_REVISION			AD4080_R1B | 0x000B
+#define AD4080_REG_VENDOR_L			AD4080_R1B | 0x000C
+#define AD4080_REG_VENDOR_H			AD4080_R1B | 0x000D
+#define AD4080_REG_STREAM_MODE			AD4080_R1B | 0x000E
+#define AD4080_REG_TRANSFER_CONFIG		AD4080_R1B | 0x000F
+#define AD4080_REG_INTERFACE_CONFIG_C		AD4080_R1B | 0x0010
+#define AD4080_REG_INTERFACE_STATUS_A		AD4080_R1B | 0x0011
+#define AD4080_REG_DEVICE_STATUS		AD4080_R1B | 0x0014
+#define AD4080_REG_DATA_INTF_CONFIG_A		AD4080_R1B | 0x0015
+#define AD4080_REG_DATA_INTF_CONFIG_B		AD4080_R1B | 0x0016
+#define AD4080_REG_DATA_INTF_CONFIG_C		AD4080_R1B | 0x0017
+#define AD4080_REG_PWR_CTRL			AD4080_R1B | 0x0018
+#define AD4080_REG_GPIO_CONFIG_A		AD4080_R1B | 0x0019
+#define AD4080_REG_GPIO_CONFIG_B		AD4080_R1B | 0x001A
+#define AD4080_REG_GPIO_CONFIG_C		AD4080_R1B | 0x001B
+#define AD4080_REG_FIFO_CONFIG			AD4080_R1B | 0x001C
+#define AD4080_REG_FIFO_WATERMARK		AD4080_R2B | 0x001D
+#define AD4080_REG_FIFO_STATUS		AD4080_R1B | 0x0023
+#define AD4080_REG_OFFSET			AD4080_R2B | 0x0025
+#define AD4080_REG_GAIN				AD4080_R2B | 0x0027
 
 /** AD4080_REG_INTERFACE_CONFIG_A Bit Definition */
 #define AD4080_SW_RESET_MSK			NO_OS_BIT(7) | NO_OS_BIT(0)
@@ -120,6 +131,11 @@
 #define BYTE_ADDR_H				NO_OS_GENMASK(15, 8)
 #define BYTE_ADDR_L				NO_OS_GENMASK(7, 0)
 #define AD4080_CHIP_ID				NO_OS_GENMASK(2, 0)
+
+#define AD4080_NUM_REGS			18  // Number of valid registers (mb regs considered a single entity)
+
+#define LONG_INSTR_LENGTH		2	// bytes
+#define SHORT_INSTR_LENGTH		1	// bytes
 
 /******************************************************************************/
 /************************ Types Declarations **********************************/
@@ -302,13 +318,15 @@ struct ad4080_init_param {
 	enum ad4080_fifo_mode fifo_mode;
 };
 /** Writes data into a register.  */
-int ad4080_write(struct ad4080_dev *dev, uint16_t reg_addr, uint8_t reg_val);
+int ad4080_write(struct ad4080_dev *dev, uint32_t reg_addr, uint32_t reg_val);
 
 /** Reads data from a register. */
-int ad4080_read(struct ad4080_dev *dev, uint16_t reg_addr, uint8_t *reg_val);
+int ad4080_read(struct ad4080_dev *dev, uint32_t reg_addr, uint32_t *reg_val);
 
 /** Update specific register bits */
-int ad4080_update_bits(struct ad4080_dev *dev, uint16_t reg_addr, uint8_t mask,
+int ad4080_update_bits(struct ad4080_dev *dev,
+		       uint16_t reg_addr,
+		       uint8_t mask,
 		       uint8_t reg_val);
 
 /** Software Reset. */

--- a/drivers/adc/ad4080/ad4080_regs.c
+++ b/drivers/adc/ad4080/ad4080_regs.c
@@ -1,0 +1,69 @@
+/***************************************************************************//**
+ *   @file   ad4080_regs.c
+ *   @brief  Source file for the ad4080 registers map
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "ad4080_regs.h"
+
+const uint32_t ad4080_regs[] = {
+	AD4080_REG_INTERFACE_CONFIG_A,
+	AD4080_REG_INTERFACE_CONFIG_B,
+	AD4080_REG_DEVICE_CONFIG,
+	AD4080_REG_CHIP_TYPE,
+	AD4080_REG_PRODUCT_ID_L,
+	AD4080_REG_PRODUCT_ID_H,
+	AD4080_REG_CHIP_GRADE,
+	AD4080_REG_SCRATCH_PAD,
+	AD4080_REG_SPI_REVISION,
+	AD4080_REG_VENDOR_L,
+	AD4080_REG_VENDOR_H,
+	AD4080_REG_STREAM_MODE,
+	AD4080_REG_TRANSFER_CONFIG,
+	AD4080_REG_INTERFACE_CONFIG_C,
+	AD4080_REG_INTERFACE_STATUS_A,
+	AD4080_REG_DEVICE_STATUS,
+	AD4080_REG_DATA_INTF_CONFIG_A,
+	AD4080_REG_DATA_INTF_CONFIG_B,
+	AD4080_REG_DATA_INTF_CONFIG_C,
+	AD4080_REG_PWR_CTRL,
+	AD4080_REG_GPIO_CONFIG_A,
+	AD4080_REG_GPIO_CONFIG_B,
+	AD4080_REG_GPIO_CONFIG_C,
+	AD4080_REG_FIFO_CONFIG,
+	AD4080_REG_FIFO_WATERMARK,
+	AD4080_REG_FIFO_STATUS,
+	AD4080_REG_OFFSET,
+	AD4080_REG_GAIN,
+};

--- a/drivers/adc/ad4080/ad4080_regs.h
+++ b/drivers/adc/ad4080/ad4080_regs.h
@@ -1,0 +1,46 @@
+/***************************************************************************//**
+ *   @file   ad4080_regs.h
+ *   @brief  Header file for the ad4080 registers map
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+
+#ifndef __AD4080_REGS_H__
+#define __AD4080_REGS_H__
+
+#include "ad4080.h"
+
+extern const uint32_t ad4080_regs[];
+
+#endif /* __AD7124_REGS_H__ */


### PR DESCRIPTION
Add support for multibyte reg access

Add support for reg config interface modes such as: address ascension, single instr/streaming modes, short instruction mode, and strict register access modes.