### PR TITLE
ad9361:ad9361_api.c Set gpio_desc_sync as output

### DIFF
--- a/drivers/rf-transceiver/ad9361/ad9361_api.c
+++ b/drivers/rf-transceiver/ad9361/ad9361_api.c
@@ -503,6 +503,8 @@ int32_t ad9361_init (struct ad9361_rf_phy **ad9361_phy,
 
 	no_os_gpio_direction_output(phy->gpio_desc_resetb, 0);
 
+	no_os_gpio_direction_output(phy->gpio_desc_sync, 0);
+
 	no_os_spi_init(&phy->spi, &init_param->spi_param);
 
 	phy->pdata->port_ctrl.digital_io_ctrl = 0;


### PR DESCRIPTION
Set the direction of the SYNC GPIO as output for achieving correct multichip synchronization.