### PR TITLE
drivers/platform/stm32: stm32 pwm support.

### DIFF
--- a/drivers/api/no_os_pwm.c
+++ b/drivers/api/no_os_pwm.c
@@ -1,0 +1,265 @@
+/***************************************************************************//**
+ *   @file   no_os_pwm.c
+ *   @brief  Implementation of the PWM Interface
+ *   @author Pratyush Mallick (pratyush.mallick@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <inttypes.h>
+#include "no_os_pwm.h"
+#include <stdlib.h>
+#include "no_os_error.h"
+
+/**
+ * @brief Initialize the PWM peripheral.
+ * @param desc - The PWM descriptor.
+ * @param param - The structure that contains the PWM parameters.
+ * @return 0 in case of success, -1 otherwise.
+ */
+int32_t no_os_pwm_init(struct no_os_pwm_desc **desc,
+		       const struct no_os_pwm_init_param *param)
+{
+	int32_t ret;
+
+	if (!param || !param->platform_ops)
+		return -EINVAL;
+
+	if (!param->platform_ops->pwm_ops_init)
+		return -ENOSYS;
+
+	ret = param->platform_ops->pwm_ops_init(desc, param);
+	if (ret)
+		return ret;
+
+	(*desc)->platform_ops = param->platform_ops;
+
+	return 0;
+}
+
+/**
+ * @brief Free the resources allocated by no_os_pwm_init().
+ * @param desc - The PWM descriptor.
+ * @return 0 in case of success, -1 otherwise.
+ */
+int32_t no_os_pwm_remove(struct no_os_pwm_desc *desc)
+{
+	if (!desc || !desc->platform_ops)
+		return -EINVAL;
+
+	if (!desc->platform_ops->pwm_ops_remove)
+		return -ENOSYS;
+
+	return desc->platform_ops->pwm_ops_remove(desc);
+}
+
+/**
+ * @brief Enable PWM signal generation.
+ * @param desc - The PWM descriptor.
+ * @return 0 in case of success, -1 otherwise.
+ */
+int32_t no_os_pwm_enable(struct no_os_pwm_desc *desc)
+{
+	if (!desc || !desc->platform_ops)
+		return -EINVAL;
+
+	if (!desc->platform_ops->pwm_ops_enable)
+		return -ENOSYS;
+
+	return desc->platform_ops->pwm_ops_enable(desc);
+}
+
+/**
+ * @brief Disable PWM signal generation.
+ * @param desc - The PWM descriptor.
+ * @return 0 in case of success, -1 otherwise.
+ */
+int32_t no_os_pwm_disable(struct no_os_pwm_desc *desc)
+{
+	if (!desc || !desc->platform_ops)
+		return -EINVAL;
+
+	if (!desc->platform_ops->pwm_ops_disable)
+		return -ENOSYS;
+
+	return desc->platform_ops->pwm_ops_disable(desc);
+}
+
+/**
+ * @brief Set the PWM period value.
+ * @param desc - The PWM descriptor.
+ * @param period_ns - The period value in nanoseconds.
+ * @return 0 in case of success, -1 otherwise.
+ */
+int32_t no_os_pwm_set_period(struct no_os_pwm_desc *desc,
+			     uint32_t period_ns)
+{
+	if (!desc || !desc->platform_ops)
+		return -EINVAL;
+
+	if (!desc->platform_ops->pwm_ops_set_period)
+		return -ENOSYS;
+
+	return desc->platform_ops->pwm_ops_set_period(desc, period_ns);
+}
+
+/**
+ * @brief Get the PWM period value.
+ * @param desc - The PWM descriptor.
+ * @param period_ns - The period value in nanoseconds.
+ * @return 0 in case of success, -1 otherwise.
+ */
+int32_t no_os_pwm_get_period(struct no_os_pwm_desc *desc,
+			     uint32_t *period_ns)
+{
+	if (!desc || !desc->platform_ops)
+		return -EINVAL;
+
+	if (!desc->platform_ops->pwm_ops_get_period)
+		return -ENOSYS;
+
+	return desc->platform_ops->pwm_ops_get_period(desc, period_ns);
+}
+
+/**
+ * @brief Set the PWM duty cycle.
+ * @param desc - The PWM descriptor.
+ * @param duty_cycle_ns - Duty cycle in nanoseconds.
+ * @return 0 in case of success, -1 otherwise.
+ */
+int32_t no_os_pwm_set_duty_cycle(struct no_os_pwm_desc *desc,
+				 uint32_t duty_cycle_ns)
+{
+	if (!desc || !desc->platform_ops)
+		return -EINVAL;
+
+	if (!desc->platform_ops->pwm_ops_set_duty_cycle)
+		return -ENOSYS;
+
+	return desc->platform_ops->pwm_ops_set_duty_cycle(desc, duty_cycle_ns);
+}
+
+/**
+ * @brief Get the PWM duty cycle.
+ * @param desc - The PWM descriptor.
+ * @param duty_cycle_ns - Duty cycle in nanoseconds.
+ * @return 0 in case of success, -1 otherwise.
+ */
+int32_t no_os_pwm_get_duty_cycle(struct no_os_pwm_desc *desc,
+				 uint32_t *duty_cycle_ns)
+{
+	if (!desc || !desc->platform_ops)
+		return -EINVAL;
+
+	if (!desc->platform_ops->pwm_ops_get_duty_cycle)
+		return -ENOSYS;
+
+	return desc->platform_ops->pwm_ops_get_duty_cycle(desc, duty_cycle_ns);
+}
+
+/**
+ * @brief Set the PWM phase value.
+ * @param desc - The PWM descriptor.
+ * @param phase_ns - Phase value in nanoseconds.
+ * @return 0 in case of success, -1 otherwise.
+ */
+int32_t no_os_pwm_set_phase(struct no_os_pwm_desc *desc,
+			    uint32_t phase_ns)
+{
+	if (!desc || !desc->platform_ops)
+		return -EINVAL;
+
+	if (!desc->platform_ops->pwm_ops_set_phase)
+		return -ENOSYS;
+
+	return desc->platform_ops->pwm_ops_set_phase(desc, phase_ns);
+}
+
+/**
+ * @brief Get the PWM phase value.
+ * @param desc - The PWM descriptor.
+ * @param phase_ns - Phase value in nanoseconds.
+ * @return 0 in case of success, -1 otherwise.
+ */
+int32_t no_os_pwm_get_phase(struct no_os_pwm_desc *desc,
+			    uint32_t *phase_ns)
+{
+	if (!desc || !desc->platform_ops)
+		return -EINVAL;
+
+	if (!desc->platform_ops->pwm_ops_get_phase)
+		return -ENOSYS;
+
+	return desc->platform_ops->pwm_ops_get_phase(desc, phase_ns);
+}
+
+/**
+ * @brief Set the PWM polarity.
+ * @param desc - The PWM descriptor.
+ * @param polarity - Polarity value.
+ *                   Example: NO_OS_PWM_POLARITY_HIGH
+ *                            NO_OS_PWM_POLARITY_LOW
+ * @return 0 in case of success, -1 otherwise.
+ */
+int32_t no_os_pwm_set_polarity(struct no_os_pwm_desc *desc,
+			       enum no_os_pwm_polarity polarity)
+{
+	if (!desc || !desc->platform_ops)
+		return -EINVAL;
+
+	if (!desc->platform_ops->pwm_ops_set_polarity)
+		return -ENOSYS;
+
+	return desc->platform_ops->pwm_ops_set_polarity(desc, polarity);
+}
+
+/**
+ * @brief Get the PWM polarity.
+ * @param desc - The PWM descriptor.
+ * @param polarity - Polarity value.
+ *                   Example: NO_OS_PWM_POLARITY_HIGH
+ *                            NO_OS_PWM_POLARITY_LOW
+ * @return 0 in case of success, -1 otherwise.
+ */
+int32_t no_os_pwm_get_polarity(struct no_os_pwm_desc *desc,
+			       enum no_os_pwm_polarity *polarity)
+{
+	if (!desc || !desc->platform_ops)
+		return -EINVAL;
+
+	if (!desc->platform_ops->pwm_ops_get_polarity)
+		return -ENOSYS;
+
+	return desc->platform_ops->pwm_ops_get_polarity(desc, polarity);
+}

--- a/drivers/axi_core/axi_pwmgen/axi_pwm.c
+++ b/drivers/axi_core/axi_pwmgen/axi_pwm.c
@@ -105,7 +105,7 @@ static int32_t axi_pwmgen_write_mask(uint32_t base, uint32_t offset,
  * @param [in] desc - Decriptor containing PWM generator parameters.
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_pwm_enable(struct no_os_pwm_desc *desc)
+int32_t axi_pwm_enable(struct no_os_pwm_desc *desc)
 {
 	struct axi_pwm_desc *axi_desc = desc->extra;
 	int ret;
@@ -126,7 +126,7 @@ int32_t no_os_pwm_enable(struct no_os_pwm_desc *desc)
  * @param [in] desc - Decriptor containing PWM generator parameters.
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_pwm_disable(struct no_os_pwm_desc *desc)
+int32_t axi_pwm_disable(struct no_os_pwm_desc *desc)
 {
 	struct axi_pwm_desc *axi_desc = desc->extra;
 	int ret;
@@ -148,7 +148,7 @@ int32_t no_os_pwm_disable(struct no_os_pwm_desc *desc)
  * @param [in] period_ns - PWM period.
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_pwm_set_period(struct no_os_pwm_desc *desc, uint32_t period_ns)
+int32_t axi_pwm_set_period(struct no_os_pwm_desc *desc, uint32_t period_ns)
 {
 	struct axi_pwm_desc *axi_desc = desc->extra;
 	uint32_t tmp, period_cnt;
@@ -176,7 +176,7 @@ int32_t no_os_pwm_set_period(struct no_os_pwm_desc *desc, uint32_t period_ns)
  * @param [out] period_ns - PWM period.
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_pwm_get_period(struct no_os_pwm_desc *desc, uint32_t *period_ns)
+int32_t axi_pwm_get_period(struct no_os_pwm_desc *desc, uint32_t *period_ns)
 {
 
 	*period_ns = desc->period_ns;
@@ -191,8 +191,8 @@ int32_t no_os_pwm_get_period(struct no_os_pwm_desc *desc, uint32_t *period_ns)
  * @param [in] duty_cycle_ns - PWM duty cycle.
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_pwm_set_duty_cycle(struct no_os_pwm_desc *desc,
-				 uint32_t duty_cycle_ns)
+int32_t axi_pwm_set_duty_cycle(struct no_os_pwm_desc *desc,
+			       uint32_t duty_cycle_ns)
 {
 	struct axi_pwm_desc *axi_desc = desc->extra;
 	uint32_t tmp, duty_cnt;
@@ -222,8 +222,8 @@ int32_t no_os_pwm_set_duty_cycle(struct no_os_pwm_desc *desc,
  * @param [out] duty_cycle_ns - PWM duty cycle.
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_pwm_get_duty_cycle(struct no_os_pwm_desc *desc,
-				 uint32_t *duty_cycle_ns)
+int32_t axi_pwm_get_duty_cycle(struct no_os_pwm_desc *desc,
+			       uint32_t *duty_cycle_ns)
 {
 	*duty_cycle_ns = desc->duty_cycle_ns;
 
@@ -237,7 +237,7 @@ int32_t no_os_pwm_get_duty_cycle(struct no_os_pwm_desc *desc,
  * @param [in] phase_ns - PWM phase.
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_pwm_set_phase(struct no_os_pwm_desc *desc, uint32_t phase_ns)
+int32_t axi_pwm_set_phase(struct no_os_pwm_desc *desc, uint32_t phase_ns)
 {
 	struct axi_pwm_desc *axi_desc = desc->extra;
 	uint32_t tmp, phase_cnt;
@@ -264,7 +264,7 @@ int32_t no_os_pwm_set_phase(struct no_os_pwm_desc *desc, uint32_t phase_ns)
  * @param [out] phase_ns - PWM phase.
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_pwm_get_phase(struct no_os_pwm_desc *desc, uint32_t *phase_ns)
+int32_t axi_pwm_get_phase(struct no_os_pwm_desc *desc, uint32_t *phase_ns)
 {
 	*phase_ns = desc->phase_ns;
 
@@ -278,8 +278,8 @@ int32_t no_os_pwm_get_phase(struct no_os_pwm_desc *desc, uint32_t *phase_ns)
  * @param [in] param - Structure containing the PWM generator init parameters.
  * @return 0 in case of success, -1 otherwise.
  */
-int32_t no_os_pwm_init(struct no_os_pwm_desc **desc,
-		       const struct no_os_pwm_init_param *param)
+int32_t axi_pwm_init(struct no_os_pwm_desc **desc,
+		     const struct no_os_pwm_init_param *param)
 {
 	struct no_os_pwm_desc *pwm_desc;
 	struct axi_pwm_init_param *axi_init;
@@ -337,19 +337,19 @@ int32_t no_os_pwm_init(struct no_os_pwm_desc **desc,
 	if (data != AXI_PWMGEN_TEST_DATA)
 		goto error_xdesc;
 
-	ret = no_os_pwm_set_period(pwm_desc, pwm_desc->period_ns);
+	ret = axi_pwm_set_period(pwm_desc, pwm_desc->period_ns);
 	if (ret != 0)
 		goto error_xdesc;
 
-	ret = no_os_pwm_set_duty_cycle(pwm_desc, pwm_desc->duty_cycle_ns);
+	ret = axi_pwm_set_duty_cycle(pwm_desc, pwm_desc->duty_cycle_ns);
 	if (ret != 0)
 		goto error_xdesc;
 
-	ret = no_os_pwm_set_phase(pwm_desc, pwm_desc->phase_ns);
+	ret = axi_pwm_set_phase(pwm_desc, pwm_desc->phase_ns);
 	if (ret != 0)
 		goto error_xdesc;
 
-	ret = no_os_pwm_enable(pwm_desc);
+	ret = axi_pwm_enable(pwm_desc);
 	if (ret != 0)
 		goto error_xdesc;
 
@@ -370,7 +370,7 @@ error_desc:
  * @param [in] desc - Pointer to the device handler.
  * @return 0 in case of success, -1 otherwise
  */
-int32_t no_os_pwm_remove(struct no_os_pwm_desc *desc)
+int32_t axi_pwm_remove(struct no_os_pwm_desc *desc)
 {
 	struct axi_pwm_desc *axi_desc = desc->extra;
 	int32_t ret;
@@ -389,3 +389,19 @@ int32_t no_os_pwm_remove(struct no_os_pwm_desc *desc)
 
 	return 0;
 }
+
+/**
+* @brief AXI platform specific PWM platform ops structure
+*/
+const struct no_os_pwm_platform_ops axi_pwm_ops = {
+	.pwm_ops_init = &axi_pwm_init,
+	.pwm_ops_enable = &axi_pwm_enable,
+	.pwm_ops_disable = &axi_pwm_disable,
+	.pwm_ops_set_period = &axi_pwm_set_period,
+	.pwm_ops_get_period = &axi_pwm_get_period,
+	.pwm_ops_set_duty_cycle = &axi_pwm_set_duty_cycle,
+	.pwm_ops_get_duty_cycle = &axi_pwm_get_duty_cycle,
+	.pwm_ops_set_phase = &axi_pwm_set_phase,
+	.pwm_ops_get_phase = &axi_pwm_get_phase,
+	.pwm_ops_remove = &axi_pwm_remove
+};

--- a/drivers/axi_core/axi_pwmgen/axi_pwm_extra.h
+++ b/drivers/axi_core/axi_pwmgen/axi_pwm_extra.h
@@ -44,6 +44,7 @@
 /***************************** Include Files **********************************/
 /******************************************************************************/
 #include <stdint.h>
+#include "no_os_pwm.h"
 
 /******************************************************************************/
 /*************************** Types Declarations *******************************/
@@ -75,5 +76,10 @@ struct axi_pwm_desc {
 	/** Used to store the period when the channel is disabled */
 	uint32_t ch_period;
 };
+
+/**
+ * @brief AXI specific PWM platform ops structure
+ */
+extern const struct no_os_pwm_platform_ops axi_pwm_ops;
 
 #endif

--- a/drivers/platform/aducm3029/aducm3029_pwm.c
+++ b/drivers/platform/aducm3029/aducm3029_pwm.c
@@ -50,8 +50,8 @@
 /************************ Functions Declarations ******************************/
 /******************************************************************************/
 
-static int32_t no_os_config_clock_init(ADI_TMR_CONFIG *cfg, uint32_t period,
-				       uint32_t duty, uint32_t *match)
+static int32_t aducm3029_config_clock_init(ADI_TMR_CONFIG *cfg, uint32_t period,
+		uint32_t duty, uint32_t *match)
 {
 	float		base_time;
 	float		aux;
@@ -111,7 +111,7 @@ static int32_t no_os_config_clock_init(ADI_TMR_CONFIG *cfg, uint32_t period,
 	return 0;
 }
 
-static int32_t no_os_update_pwm_config(struct no_os_pwm_desc *desc)
+static int32_t aducm3029_update_pwm_config(struct no_os_pwm_desc *desc)
 {
 	ADI_TMR_CONFIG		cfg;
 	ADI_TMR_PWM_CONFIG	pwm_cfg;
@@ -127,8 +127,8 @@ static int32_t no_os_update_pwm_config(struct no_os_pwm_desc *desc)
 		.bReloading = true,
 		.bSyncBypass = true
 	};
-	ret = no_os_config_clock_init(&cfg, desc->period_ns, desc->duty_cycle_ns,
-				      &match_val);
+	ret = aducm3029_config_clock_init(&cfg, desc->period_ns, desc->duty_cycle_ns,
+					  &match_val);
 	if (NO_OS_IS_ERR_VALUE(ret))
 		return ret;
 	do {
@@ -149,8 +149,8 @@ static int32_t no_os_update_pwm_config(struct no_os_pwm_desc *desc)
 }
 
 /* Initialize the PWM generator device */
-int32_t no_os_pwm_init(struct no_os_pwm_desc **desc,
-		       const struct no_os_pwm_init_param *param)
+int32_t aducm3029_pwm_init(struct no_os_pwm_desc **desc,
+			   const struct no_os_pwm_init_param *param)
 {
 	ADI_TMR_RESULT	ret;
 	struct no_os_pwm_desc	*ldesc;
@@ -174,7 +174,7 @@ int32_t no_os_pwm_init(struct no_os_pwm_desc **desc,
 	if (ret != ADI_TMR_SUCCESS)
 		goto error;
 
-	ret = no_os_update_pwm_config(ldesc);
+	ret = aducm3029_update_pwm_config(ldesc);
 	if (NO_OS_IS_ERR_VALUE(ret))
 		goto error;
 
@@ -189,7 +189,7 @@ error:
 }
 
 /* Free the resources used by the PWM generator device */
-int32_t no_os_pwm_remove(struct no_os_pwm_desc *desc)
+int32_t aducm3029_pwm_remove(struct no_os_pwm_desc *desc)
 {
 	if (!desc || !desc->extra)
 		return -EINVAL;
@@ -201,7 +201,7 @@ int32_t no_os_pwm_remove(struct no_os_pwm_desc *desc)
 }
 
 /* Enable PWM generator device */
-int32_t no_os_pwm_enable(struct no_os_pwm_desc *desc)
+int32_t aducm3029_pwm_enable(struct no_os_pwm_desc *desc)
 {
 	ADI_TMR_RESULT		ret;
 
@@ -216,7 +216,7 @@ int32_t no_os_pwm_enable(struct no_os_pwm_desc *desc)
 }
 
 /* Disable PWM generator device */
-int32_t no_os_pwm_disable(struct no_os_pwm_desc *desc)
+int32_t aducm3029_pwm_disable(struct no_os_pwm_desc *desc)
 {
 	ADI_TMR_RESULT		ret;
 
@@ -231,20 +231,20 @@ int32_t no_os_pwm_disable(struct no_os_pwm_desc *desc)
 }
 
 /* Set period of PWM generator device */
-int32_t no_os_pwm_set_period(struct no_os_pwm_desc *desc,
-			     uint32_t period_ns)
+int32_t aducm3029_pwm_set_period(struct no_os_pwm_desc *desc,
+				 uint32_t period_ns)
 {
 	if (!desc)
 		return -EINVAL;
 
 	desc->period_ns = period_ns;
 
-	return no_os_update_pwm_config(desc);
+	return aducm3029_update_pwm_config(desc);
 }
 
 /* Get period of PWM generator device */
-int32_t no_os_pwm_get_period(struct no_os_pwm_desc *desc,
-			     uint32_t *period_ns)
+int32_t aducm3029_pwm_get_period(struct no_os_pwm_desc *desc,
+				 uint32_t *period_ns)
 {
 	if (!desc || !period_ns)
 		return -EINVAL;
@@ -255,20 +255,20 @@ int32_t no_os_pwm_get_period(struct no_os_pwm_desc *desc,
 }
 
 /* Set duty cycle of PWM generator device */
-int32_t no_os_pwm_set_duty_cycle(struct no_os_pwm_desc *desc,
-				 uint32_t duty_cycle_ns)
+int32_t aducm3029_pwm_set_duty_cycle(struct no_os_pwm_desc *desc,
+				     uint32_t duty_cycle_ns)
 {
 	if (!desc)
 		return -EINVAL;
 
 	desc->duty_cycle_ns = duty_cycle_ns;
 
-	return no_os_update_pwm_config(desc);
+	return aducm3029_update_pwm_config(desc);
 }
 
 /* Get period of PWM generator device */
-int32_t no_os_pwm_get_duty_cycle(struct no_os_pwm_desc *desc,
-				 uint32_t *duty_cycle_ns)
+int32_t aducm3029_pwm_get_duty_cycle(struct no_os_pwm_desc *desc,
+				     uint32_t *duty_cycle_ns)
 {
 	if (!desc || !duty_cycle_ns)
 		return -EINVAL;
@@ -279,20 +279,20 @@ int32_t no_os_pwm_get_duty_cycle(struct no_os_pwm_desc *desc,
 }
 
 /* Set polarity of PWM generator device */
-int32_t no_os_pwm_set_polarity(struct no_os_pwm_desc *desc,
-			       enum no_os_pwm_polarity polarity)
+int32_t aducm3029_pwm_set_polarity(struct no_os_pwm_desc *desc,
+				   enum no_os_pwm_polarity polarity)
 {
 	if (!desc)
 		return -EINVAL;
 
 	desc->polarity = polarity;
 
-	return no_os_update_pwm_config(desc);
+	return aducm3029_update_pwm_config(desc);
 }
 
 /* Set polarity of PWM generator device */
-int32_t no_os_pwm_get_polarity(struct no_os_pwm_desc *desc,
-			       enum no_os_pwm_polarity *polarity)
+int32_t aducm3029_pwm_get_polarity(struct no_os_pwm_desc *desc,
+				   enum no_os_pwm_polarity *polarity)
 {
 	if (!desc || !polarity)
 		return -EINVAL;
@@ -301,3 +301,19 @@ int32_t no_os_pwm_get_polarity(struct no_os_pwm_desc *desc,
 
 	return 0;
 }
+
+/**
+* @brief ADUCM3029 platform specific PWM platform ops structure
+*/
+const struct no_os_pwm_platform_ops aducm3029_pwm_ops = {
+	.pwm_ops_init = &aducm3029_pwm_init,
+	.pwm_ops_enable = &aducm3029_pwm_enable,
+	.pwm_ops_disable = &aducm3029_pwm_disable,
+	.pwm_ops_set_period = &aducm3029_pwm_set_period,
+	.pwm_ops_get_period = &aducm3029_pwm_get_period,
+	.pwm_ops_set_duty_cycle = &aducm3029_pwm_set_duty_cycle,
+	.pwm_ops_get_duty_cycle = &aducm3029_pwm_get_duty_cycle,
+	.pwm_ops_set_polarity = &aducm3029_pwm_set_polarity,
+	.pwm_ops_get_polarity = &aducm3029_pwm_get_polarity,
+	.pwm_ops_remove = &aducm3029_pwm_remove
+};

--- a/drivers/platform/aducm3029/aducm3029_pwm.h
+++ b/drivers/platform/aducm3029/aducm3029_pwm.h
@@ -1,9 +1,8 @@
 /***************************************************************************//**
- *   @file   stm32/stm32_gpio.h
- *   @brief  Header file for stm32 gpio specifics.
- *   @author Darius Berghe (darius.berghe@analog.com)
+ *   @file   aducm3029_pwm.h
+ *   @brief  Header file for aducm3029 pwm specifics.
 ********************************************************************************
- * Copyright 2020(c) Analog Devices, Inc.
+ * Copyright 2023(c) Analog Devices, Inc.
  *
  * All rights reserved.
  *
@@ -36,40 +35,25 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
-#ifndef STM32_GPIO_H_
-#define STM32_GPIO_H_
 
-#include <stdint.h>
-#include <stdbool.h>
-#include "stm32_hal.h"
+#ifndef ADUCM3029_PWM_H_
+#define ADUCM3029_PWM_H_
 
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "no_os_pwm.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
 /**
- * @struct stm32_gpio_init_param
- * @brief Structure holding the initialization parameters for stm32 platform
+ * @brief ADUCM3029 specific PWM platform ops structure
  */
-struct stm32_gpio_init_param {
-	/** Output mode */
-	uint32_t mode;
-	/** Speed grade */
-	uint32_t speed;
-	/** Alternate functionality */
-	uint32_t alternate;
-};
+extern const struct no_os_pwm_platform_ops aducm3029_pwm_ops;
 
-/**
- * @struct stm32_gpio_desc
- * @brief stm32 platform specific gpio descriptor
- */
-struct stm32_gpio_desc {
-	/** Port */
-	GPIO_TypeDef *port;
-	/** GPIO configuration */
-	GPIO_InitTypeDef gpio_config;
-};
-
-/**
- * @brief stm32 platform specific gpio platform ops structure
- */
-extern const struct no_os_gpio_platform_ops stm32_gpio_ops;
-
-#endif
+#endif // ADUCM3029_PWM_H_

--- a/drivers/platform/aducm3029/iio_aducm3029.c
+++ b/drivers/platform/aducm3029/iio_aducm3029.c
@@ -46,6 +46,7 @@
 #include "no_os_gpio.h"
 #include "iio_aducm3029.h"
 #include "aducm3029_adc.h"
+#include "aducm3029_pwm.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
 
@@ -64,6 +65,7 @@ static struct no_os_pwm_init_param default_pwm_init_par = {
 	.duty_cycle_ns = 5000000,
 	.period_ns = 10000000,
 	.polarity = NO_OS_PWM_POLARITY_HIGH,
+	.platform_ops = &aducm3029_pwm_ops,
 	.extra = NULL
 };
 static struct no_os_gpio_init_param default_gpio_init_par = {

--- a/drivers/platform/mbed/mbed_pwm.cpp
+++ b/drivers/platform/mbed/mbed_pwm.cpp
@@ -63,8 +63,8 @@ extern "C"
  * @param	param[in] - The structure that contains the PWM init parameters.
  * @return	0 in case of success, negative error code otherwise.
  */
-int32_t no_os_pwm_init(struct no_os_pwm_desc **desc,
-		 const struct no_os_pwm_init_param *param)
+int32_t mbed_pwm_init(struct no_os_pwm_desc **desc,
+		      const struct no_os_pwm_init_param *param)
 {
 	struct no_os_pwm_desc *pwm_desc;
 	mbed::PwmOut *pwm;
@@ -117,7 +117,7 @@ err_pwm:
  * @param	desc[in] - Pointer where the configured instance is stored.
  * @return	0 in case of success, negative error code otherwise.
  */
-int32_t no_os_pwm_enable(struct no_os_pwm_desc *desc)
+int32_t mbed_pwm_enable(struct no_os_pwm_desc *desc)
 {
 	mbed::PwmOut *pwm;
 
@@ -138,7 +138,7 @@ int32_t no_os_pwm_enable(struct no_os_pwm_desc *desc)
  * @param	desc[in] - Pointer where the configured instance is stored.
  * @return	0 in case of success, negative error code otherwise.
  */
-int32_t no_os_pwm_disable(struct no_os_pwm_desc *desc)
+int32_t mbed_pwm_disable(struct no_os_pwm_desc *desc)
 {
 	mbed::PwmOut *pwm;
 
@@ -160,8 +160,8 @@ int32_t no_os_pwm_disable(struct no_os_pwm_desc *desc)
  * @param	period_ns[in] - PWM period.
  * @return	0 in case of success, negative error code otherwise.
  */
-int32_t no_os_pwm_set_period(struct no_os_pwm_desc *desc,
-		       uint32_t period_ns)
+int32_t mbed_pwm_set_period(struct no_os_pwm_desc *desc,
+			    uint32_t period_ns)
 {
 	mbed::PwmOut *pwm;
 
@@ -183,8 +183,8 @@ int32_t no_os_pwm_set_period(struct no_os_pwm_desc *desc,
  * @param	period_ns[in] - PWM period.
  * @return	0 in case of success, negative error code otherwise.
  */
-int32_t no_os_pwm_get_period(struct no_os_pwm_desc *desc,
-		       uint32_t *period_ns)
+int32_t mbed_pwm_get_period(struct no_os_pwm_desc *desc,
+			    uint32_t *period_ns)
 {
 	mbed::PwmOut *pwm;
 
@@ -206,8 +206,8 @@ int32_t no_os_pwm_get_period(struct no_os_pwm_desc *desc,
  * @param	duty_cycle_ns[in] - PWM duty cycle.
  * @return	0 in case of success, negative error code otherwise.
  */
-int32_t no_os_pwm_set_duty_cycle(struct no_os_pwm_desc *desc,
-			   uint32_t duty_cycle_ns)
+int32_t mbed_pwm_set_duty_cycle(struct no_os_pwm_desc *desc,
+				uint32_t duty_cycle_ns)
 {
 	mbed::PwmOut *pwm;
 
@@ -229,8 +229,8 @@ int32_t no_os_pwm_set_duty_cycle(struct no_os_pwm_desc *desc,
  * @param	duty_cycle_ns[in] - PWM duty cycle.
  * @return	0 in case of success, negative error code otherwise.
  */
-int32_t no_os_pwm_get_duty_cycle(struct no_os_pwm_desc *desc,
-			   uint32_t *duty_cycle_ns)
+int32_t mbed_pwm_get_duty_cycle(struct no_os_pwm_desc *desc,
+				uint32_t *duty_cycle_ns)
 {
 	mbed::PwmOut *pwm;
 
@@ -251,7 +251,7 @@ int32_t no_os_pwm_get_duty_cycle(struct no_os_pwm_desc *desc,
  * @param	desc[in, out] - Pointer where the configured instance is stored
  * @return	0 in case of success, negative error code otherwise.
  */
-int32_t no_os_pwm_remove(struct no_os_pwm_desc *desc)
+int32_t mbed_pwm_remove(struct no_os_pwm_desc *desc)
 {
 	if (!desc || !desc->extra)
 		return -EINVAL;
@@ -264,6 +264,20 @@ int32_t no_os_pwm_remove(struct no_os_pwm_desc *desc)
 
 	return 0;
 }
+
+/**
+* @brief Mbed platform specific PWM platform ops structure
+*/
+const struct no_os_pwm_platform_ops mbed_pwm_ops = {
+	.pwm_ops_init = &mbed_pwm_init,
+	.pwm_ops_enable = &mbed_pwm_enable,
+	.pwm_ops_disable = &mbed_pwm_disable,
+	.pwm_ops_set_period = &mbed_pwm_set_period,
+	.pwm_ops_get_period = &mbed_pwm_get_period,
+	.pwm_set_duty_cycle = &mbed_pwm_set_duty_cycle,
+	.pwm_ops_get_duty_cycle = &mbed_pwm_get_duty_cycle,
+	.pwm_ops_remove = &mbed_pwm_remove
+};
 
 #ifdef __cplusplus  // Closing extern c
 }

--- a/drivers/platform/mbed/mbed_pwm.h
+++ b/drivers/platform/mbed/mbed_pwm.h
@@ -62,9 +62,10 @@ struct mbed_pwm_desc {
 	void *pwm_obj;		// Mbed PWM instance/object
 };
 
-/******************************************************************************/
-/************************ Public Declarations *********************************/
-/******************************************************************************/
+/**
+ * @brief Mbed specific PWM platform ops structure
+ */
+extern const struct no_os_pwm_platform_ops mbed_pwm_ops;
 
 #ifdef __cplusplus // Closing extern c
 }

--- a/drivers/platform/stm32/stm32_gpio.c
+++ b/drivers/platform/stm32/stm32_gpio.c
@@ -128,6 +128,9 @@ static int32_t _gpio_init(struct no_os_gpio_desc *desc,
 	case GPIO_MODE_OUTPUT_PP:
 	case GPIO_MODE_OUTPUT_OD:
 		break;
+	case GPIO_MODE_AF_PP:
+		extra->gpio_config.Alternate = pextra->alternate;
+		break;
 	default:
 		return -EINVAL;
 	}

--- a/drivers/platform/stm32/stm32_pwm.c
+++ b/drivers/platform/stm32/stm32_pwm.c
@@ -1,0 +1,522 @@
+/***************************************************************************//**
+ *   @file   stm32/stm32_pwm.h
+ *   @brief  Implementation of stm32 pwm driver.
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include <stdlib.h>
+#include <errno.h>
+#include "no_os_util.h"
+#include "no_os_gpio.h"
+#include "no_os_pwm.h"
+#include "stm32_gpio.h"
+#include "stm32_pwm.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definition ***********************/
+/******************************************************************************/
+
+/* For 16-bit pwm timer */
+#define	PWM_DEFAULT_PERIOD	             0xffff
+#define NO_OS_CHN_TO_STM32_CHN(x)        (0x4*(x-1))
+#define FREQUENCY_HZ_TO_TIME_NS_FACTOR   1000000000.0
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+/**
+ * @brief Calculate the period in ticks.
+ * @param desc - STM32 PWM descriptor.
+ * @param timer_clk_hz - timer clock frequency.
+ * @param period_ns - timer period.
+ * @return return period value in ticks.
+ */
+static uint32_t _compute_period_ticks(struct stm32_pwm_desc *desc,
+				      uint32_t timer_clk_hz, uint32_t period_ns)
+{
+	float pwm_frequency;
+	uint32_t period;
+
+	/* Formula for timer period count calculation:
+	 * timer frequency = timer clock / (prescaler + 1)
+	 * pwm frequency = 1 / pwm period (sec)
+	 * timer period count = (timer frequency / pwm frequency) - 1
+	 * Example:
+	 * Timer clock = 216Mhz, pwm period = 1000ns, prescaler = 1
+	 * timer frequency = 216 / (0+1) = 216Mhz
+	 * pwm frequency = 1 / 1000ns = 1Mhz
+	 * timer period count = (216 / 1) - 1 = 215
+	 **/
+	/* Timer period is determined based on the timer peripheral frequency */
+	pwm_frequency = (1.0 / period_ns);
+	period = (uint32_t)(timer_clk_hz / (pwm_frequency *
+					    FREQUENCY_HZ_TO_TIME_NS_FACTOR)) - 1;
+
+	return period;
+}
+
+/**
+ * @brief Initialize the PWM Timer.
+ * @param desc - STM32 PWM descriptor.
+ * @param param - The structure containing PWM init parameters.
+ * @return 0 in case of success, negative error code otherwise.
+ * @note PWM Timer period is dependent upon the timer clock and prescaler value.
+ *       CounterMode is UP for timer frequency generation in below function.
+ */
+static int32_t stm32_init_timer(struct stm32_pwm_desc *desc,
+				const struct no_os_pwm_init_param *param)
+{
+	int32_t ret;
+	uint32_t period;
+	TIM_TypeDef *base = NULL;
+	uint32_t timer_frequency_hz;
+	struct stm32_pwm_init_param *sparam = param->extra;
+
+	if (sparam->get_timer_clock) {
+		timer_frequency_hz = sparam->get_timer_clock();
+		timer_frequency_hz *= sparam->clock_divider;
+		timer_frequency_hz /= NO_OS_BIT(sparam->prescaler);
+		period = _compute_period_ticks(desc, timer_frequency_hz, param->period_ns);
+	} else {
+		period = PWM_DEFAULT_PERIOD - 1;
+	}
+
+	switch (param->id) {
+#if defined(TIM1)
+	case 1:
+		base = TIM1;
+		break;
+#endif
+#if defined(TIM2)
+	case 2:
+		base = TIM2;
+		break;
+#endif
+#if defined(TIM3)
+	case 3:
+		base = TIM3;
+		break;
+#endif
+		break;
+#if defined(TIM4)
+	case 4:
+		base = TIM4;
+		break;
+#endif
+#if defined(TIM5)
+	case 5:
+		base = TIM5;
+		break;
+#endif
+#if defined(TIM6)
+	case 6:
+		base = TIM6;
+		break;
+#endif
+	default:
+		ret = -EINVAL;
+		goto error;
+	};
+
+	desc->htimer.Instance = base;
+	desc->htimer.Init.Prescaler = sparam->prescaler;
+	desc->htimer.Init.CounterMode = TIM_COUNTERMODE_UP;
+	desc->htimer.Init.Period = period;
+	desc->htimer.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+	desc->htimer.Init.AutoReloadPreload = sparam->timer_autoreload ?
+					      TIM_AUTORELOAD_PRELOAD_ENABLE : TIM_MASTERSLAVEMODE_DISABLE;
+	desc->htimer.Init.RepetitionCounter = 0;
+	desc->htimer.State = HAL_TIM_STATE_RESET;
+	if (HAL_TIM_Base_Init(&desc->htimer) != HAL_OK)
+		return -EIO;
+
+	if (HAL_TIM_PWM_Init(&desc->htimer) != HAL_OK)
+		return -EIO;
+
+	/* Store the timer specific configuration for later use.*/
+	desc->prescaler = sparam->prescaler;
+	desc->get_timer_clock = sparam->get_timer_clock;
+	desc->clock_divider = sparam->clock_divider;
+	desc->timer_autoreload = sparam->timer_autoreload;
+
+	return 0;
+error:
+	return ret;
+}
+
+/**
+ * @brief Initialize the PWM.
+ * @param desc - STM32 PWM descriptor.
+ * @param param - The structure containing PWM init parameters.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+static int32_t stm32_init_pwm(struct stm32_pwm_desc *desc,
+			      const struct no_os_pwm_init_param *param)
+{
+	uint32_t pwm_pulse_width;
+	float duty_cycle_percentage;
+	uint32_t ocmode;
+	uint32_t chn;
+	TIM_OC_InitTypeDef sConfigOC = {0};
+	uint32_t period = desc->htimer.Init.Period;
+	struct stm32_pwm_init_param *sparam = param->extra;
+
+	switch (sparam->mode) {
+	case TIM_OC_TOGGLE:
+		ocmode = TIM_OCMODE_TOGGLE;
+		break;
+	case TIM_OC_PWM1:
+		ocmode = TIM_OCMODE_PWM1;
+		break;
+	case TIM_OC_PWM2:
+		ocmode = TIM_OCMODE_PWM2;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	switch (sparam->timer_chn) {
+#if defined(TIM_CHANNEL_1)
+	case 1:
+		chn = TIM_CHANNEL_1;
+		break;
+#endif
+#if defined(TIM_CHANNEL_2)
+	case 2:
+		chn = TIM_CHANNEL_2;
+		break;
+#endif
+#if defined(TIM_CHANNEL_3)
+	case 3:
+		chn = TIM_CHANNEL_3;
+		break;
+#endif
+#if defined(TIM_CHANNEL_4)
+	case 4:
+		chn = TIM_CHANNEL_4;
+		break;
+#endif
+#if defined(TIM_CHANNEL_5)
+	case 5:
+		chn = TIM_CHANNEL_5;
+		break;
+#endif
+#if defined(TIM_CHANNEL_6)
+	case 6:
+		chn = TIM_CHANNEL_6;
+		break;
+#endif
+	default:
+		return -EINVAL;
+	};
+
+	/* Calculate the percentage duty cycle */
+	duty_cycle_percentage = ((float)param->duty_cycle_ns / param->period_ns) * 100;
+	pwm_pulse_width = (uint32_t)((period + 1) * duty_cycle_percentage) / (100 - 1);
+
+	sConfigOC.OCMode = ocmode;
+	sConfigOC.Pulse = pwm_pulse_width;
+	sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
+	sConfigOC.OCFastMode = TIM_OCFAST_DISABLE;
+	sConfigOC.OCIdleState = TIM_OCIDLESTATE_RESET;
+	sConfigOC.OCNIdleState = TIM_OCNIDLESTATE_RESET;
+	if (HAL_TIM_PWM_ConfigChannel(&desc->htimer, &sConfigOC, chn) != HAL_OK)
+		return -EIO;
+
+	desc->mode = sparam->mode;
+	desc->timer_chn = sparam->timer_chn;
+
+	return 0;
+}
+
+/**
+ * @brief Initialize the PWM.
+ * @param desc - PWM descriptor.
+ * @param param - The structure containing PWM init parameters.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int32_t stm32_pwm_init(struct no_os_pwm_desc **desc,
+		       const struct no_os_pwm_init_param *param)
+{
+	struct no_os_pwm_desc *descriptor;
+	struct stm32_pwm_desc *extra;
+	int32_t ret;
+
+	if (!desc || !param)
+		return -EINVAL;
+
+	descriptor = (struct no_os_pwm_desc *)calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	extra = (struct stm32_pwm_desc *)calloc(1, sizeof(*extra));
+	if (!extra) {
+		ret = -ENOMEM;
+		goto error_desc;
+	}
+
+	/* Initialize the PWM timer */
+	ret = stm32_init_timer(extra, param);
+	if (ret)
+		goto error_extra;
+
+	/* Initialize the PWM */
+	ret = stm32_init_pwm(extra, param);
+	if (ret)
+		goto error_extra;
+
+	/* Initialize the GPIO if timer output is required*/
+	if (param->pwm_gpio) {
+		ret = no_os_gpio_get(&descriptor->pwm_gpio, param->pwm_gpio);
+		if (ret)
+			goto error_extra;
+	}
+
+	descriptor->id = param->id;
+	descriptor->extra = extra;
+	descriptor->duty_cycle_ns = param->duty_cycle_ns;
+	descriptor->period_ns = param->period_ns;
+	descriptor->phase_ns = param->phase_ns;
+	descriptor->polarity = param->polarity;
+	*desc = descriptor;
+
+	return 0;
+error_extra:
+	free(extra);
+error_desc:
+	free(descriptor);
+
+	return ret;
+}
+
+/**
+ * @brief Free the resources allocated by stm32_pwm_init()
+ * @param desc - PWM descriptor
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int32_t stm32_pwm_remove(struct no_os_pwm_desc *desc)
+{
+	int32_t ret;
+	struct stm32_pwm_desc *extra;
+
+	if (!desc || !desc->extra)
+		return -EINVAL;
+
+	extra = desc->extra;
+
+	if (HAL_TIM_Base_DeInit(&extra->htimer) != HAL_OK)
+		return -EIO;
+
+	if (HAL_TIM_PWM_DeInit(&extra->htimer) != HAL_OK)
+		return -EIO;
+
+	ret = no_os_gpio_remove(extra->gpio);
+	if (ret)
+		return ret;
+
+	free(desc->extra);
+	free(desc);
+
+	return 0;
+}
+
+/**
+ * @brief Enable the PWM
+ * @param desc - PWM descriptor
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int32_t stm32_pwm_enable(struct no_os_pwm_desc *desc)
+{
+	int32_t ret;
+	uint32_t chn_num;
+	struct stm32_pwm_desc *sparam;
+
+	if (!desc)
+		return -EINVAL;
+
+	sparam = desc->extra;
+	chn_num = NO_OS_CHN_TO_STM32_CHN(sparam->timer_chn);
+
+	ret = HAL_TIM_PWM_Start(&sparam->htimer, chn_num);
+	if (ret != HAL_OK)
+		return -EIO;
+
+	return 0;
+}
+
+/**
+ * @brief Disable the PWM
+ * @param desc - PWM descriptor
+ * @return 0 in case of success, negative error otherwise.
+ */
+int32_t stm32_pwm_disable(struct no_os_pwm_desc *desc)
+{
+	int32_t ret;
+	uint32_t chn_num;
+	struct stm32_pwm_desc *sparam;
+
+	if (!desc)
+		return -EINVAL;
+
+	sparam = desc->extra;
+	chn_num = NO_OS_CHN_TO_STM32_CHN(sparam->timer_chn);
+
+	ret = HAL_TIM_PWM_Stop(&sparam->htimer, chn_num);
+	if (ret != HAL_OK)
+		return -EIO;
+
+	return 0;
+}
+
+/**
+ * @brief	Set the PWM period.
+ * @param	desc - Pointer where the configured instance is stored.
+ * @param	period_ns - PWM period.
+ * @return	0 in case of success, negative error code otherwise.
+ */
+int32_t stm32_pwm_set_period(struct no_os_pwm_desc *desc,
+			     uint32_t period_ns)
+{
+	int32_t ret;
+	struct no_os_pwm_init_param param;
+	struct stm32_pwm_init_param sparam;
+
+	param.id = desc->id;
+	param.duty_cycle_ns = desc->duty_cycle_ns;
+	param.period_ns = period_ns;
+	param.phase_ns = desc->phase_ns;
+	sparam.clock_divider = ((struct stm32_pwm_desc *)desc->extra)->clock_divider;
+	sparam.prescaler = ((struct stm32_pwm_desc *)desc->extra)->prescaler;
+	sparam.timer_autoreload = ((struct stm32_pwm_desc *)
+				   desc->extra)->timer_autoreload;
+	sparam.get_timer_clock = ((struct stm32_pwm_desc *)
+				  desc->extra)->get_timer_clock;
+	sparam.timer_chn = ((struct stm32_pwm_desc *)desc->extra)->timer_chn;
+	param.extra = &sparam;
+
+	if (!desc || !desc->extra)
+		return -EINVAL;
+
+	ret = stm32_init_timer(desc->extra, &param);
+	if (ret != HAL_OK)
+		return -EIO;
+
+	desc->period_ns = period_ns;
+
+	return 0;
+}
+
+/**
+ * @brief	Get the PWM period.
+ * @param	desc - Pointer where the configured instance is stored.
+ * @param	period_ns - PWM period.
+ * @return	0 in case of success, negative error code otherwise.
+ */
+int32_t stm32_pwm_get_period(struct no_os_pwm_desc *desc,
+			     uint32_t *period_ns)
+{
+	uint32_t timer_hz;
+
+	if (!desc || !desc->extra || !period_ns)
+		return -EINVAL;
+
+	struct stm32_pwm_desc *sparam = desc->extra;
+	timer_hz = sparam->get_timer_clock() * sparam->clock_divider;
+	timer_hz /= NO_OS_BIT(sparam->prescaler);
+
+	*period_ns = (uint32_t)((sparam->htimer.Init.Period + 1) *
+				(FREQUENCY_HZ_TO_TIME_NS_FACTOR / timer_hz));
+
+	return 0;
+}
+
+/**
+ * @brief	Set the PWM duty cycle.
+ * @param	desc - Pointer where the configured instance is stored.
+ * @param	duty_cycle_ns - PWM duty cycle.
+ * @return	0 in case of success, negative error code otherwise.
+ */
+int32_t stm32_pwm_set_duty_cycle(struct no_os_pwm_desc *desc,
+				 uint32_t duty_cycle_ns)
+{
+	int32_t ret;
+	struct no_os_pwm_init_param param;
+	struct stm32_pwm_init_param sparam;
+
+	if (!desc || !desc->extra)
+		return -EINVAL;
+
+	param.duty_cycle_ns = duty_cycle_ns;
+	param.period_ns = desc->period_ns;
+	param.phase_ns = desc->phase_ns;
+	sparam.mode = ((struct stm32_pwm_desc *)desc->extra)->mode;
+	sparam.timer_chn = ((struct stm32_pwm_desc *)desc->extra)->timer_chn;
+	param.extra = &sparam;
+
+	ret = stm32_init_pwm(desc->extra, &param);
+	if (ret != HAL_OK)
+		return -EIO;
+
+	desc->duty_cycle_ns = param.duty_cycle_ns;
+
+	return 0;
+}
+
+/**
+ * @brief	Get the PWM duty cycle.
+ * @param	desc - Pointer where the configured instance is stored.
+ * @param	duty_cycle_ns - PWM duty cycle.
+ * @return	0 in case of success, negative error code otherwise.
+ */
+int32_t stm32_pwm_get_duty_cycle(struct no_os_pwm_desc *desc,
+				 uint32_t *duty_cycle_ns)
+{
+	*duty_cycle_ns = desc->duty_cycle_ns;
+
+	return 0;
+}
+
+/**
+* @brief STM32 platform specific PWM platform ops structure
+*/
+const struct no_os_pwm_platform_ops stm32_pwm_ops = {
+	.pwm_ops_init = &stm32_pwm_init,
+	.pwm_ops_enable = &stm32_pwm_enable,
+	.pwm_ops_disable = &stm32_pwm_disable,
+	.pwm_ops_set_period = &stm32_pwm_set_period,
+	.pwm_ops_get_period = &stm32_pwm_get_period,
+	.pwm_ops_set_duty_cycle = &stm32_pwm_set_duty_cycle,
+	.pwm_ops_get_duty_cycle = &stm32_pwm_get_duty_cycle,
+	.pwm_ops_remove = &stm32_pwm_remove
+};

--- a/drivers/platform/stm32/stm32_pwm.h
+++ b/drivers/platform/stm32/stm32_pwm.h
@@ -1,9 +1,8 @@
 /***************************************************************************//**
- *   @file   stm32/stm32_gpio.h
- *   @brief  Header file for stm32 gpio specifics.
- *   @author Darius Berghe (darius.berghe@analog.com)
+ *   @file   stm32/stm32_pwm.h
+ *   @brief  Header file for stm32 pwm specifics.
 ********************************************************************************
- * Copyright 2020(c) Analog Devices, Inc.
+ * Copyright 2023(c) Analog Devices, Inc.
  *
  * All rights reserved.
  *
@@ -36,40 +35,79 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
-#ifndef STM32_GPIO_H_
-#define STM32_GPIO_H_
+#ifndef STM32_PWM_H_
+#define STM32_PWM_H_
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "no_os_gpio.h"
+#include "stm32_gpio.h"
 #include "stm32_hal.h"
 
-/**
- * @struct stm32_gpio_init_param
- * @brief Structure holding the initialization parameters for stm32 platform
- */
-struct stm32_gpio_init_param {
-	/** Output mode */
-	uint32_t mode;
-	/** Speed grade */
-	uint32_t speed;
-	/** Alternate functionality */
-	uint32_t alternate;
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <stdbool.h>
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+enum TimOCMode {
+	TIM_OC_TOGGLE = 0,
+	TIM_OC_PWM1 = 1,
+	TIM_OC_PWM2 = 2,
 };
 
 /**
- * @struct stm32_gpio_desc
- * @brief stm32 platform specific gpio descriptor
+ * @struct stm32_pwm_init_param
+ * @brief Structure holding the STM32 PWM parameters.
  */
-struct stm32_gpio_desc {
-	/** Port */
-	GPIO_TypeDef *port;
-	/** GPIO configuration */
-	GPIO_InitTypeDef gpio_config;
+struct stm32_pwm_init_param {
+	/** Timer prescaler */
+	uint32_t prescaler;
+	/** Timer autoreload enable */
+	bool timer_autoreload;
+	/** Timer output compare Mode */
+	enum TimOCMode mode;
+	/** PWM timer channel */
+	uint32_t timer_chn;
+	/** Get timer source clock function */
+	uint32_t (*get_timer_clock)(void);
+	/** Get timer source clock divider */
+	uint32_t clock_divider;
 };
 
 /**
- * @brief stm32 platform specific gpio platform ops structure
+ * @struct stm32_pwm_desc
+ * @brief Structure holding the STM32 PWM descriptor.
  */
-extern const struct no_os_gpio_platform_ops stm32_gpio_ops;
+struct stm32_pwm_desc {
+	/** PWM Timer Instance */
+	TIM_HandleTypeDef htimer;
+	/** Timer GPIO instance */
+	struct no_os_gpio_desc *gpio;
+	/** Timer prescaler */
+	uint32_t prescaler;
+	/** Timer autoreload enable */
+	bool timer_autoreload;
+	/** Timer output compare Mode */
+	enum TimOCMode mode;
+	/** PWM timer channel */
+	uint32_t timer_chn;
+	/** Get timer source clock function */
+	uint32_t (*get_timer_clock)(void);
+	/** Get timer source clock divider */
+	uint32_t clock_divider;
+};
 
-#endif
+/**
+ * @brief STM32 specific PWM platform ops structure
+ */
+extern const struct no_os_pwm_platform_ops stm32_pwm_ops;
+
+#endif // STM32_PWM_H_

--- a/include/no_os_pwm.h
+++ b/include/no_os_pwm.h
@@ -74,6 +74,10 @@ struct no_os_pwm_init_param {
 	uint32_t phase_ns;
 	/** PWM generator polarity */
 	enum no_os_pwm_polarity polarity;
+	/** PWM gpio pin init param*/
+	struct no_os_gpio_init_param *pwm_gpio;
+	/** PWM platform specific functions */
+	const struct no_os_pwm_platform_ops *platform_ops;
 	/** PWM extra parameters (device specific) */
 	void *extra;
 };
@@ -95,8 +99,47 @@ struct no_os_pwm_desc {
 	enum no_os_pwm_polarity polarity;
 	/** PWM generator enabled */
 	bool enabled;
+	/** PWM gpio pin instance */
+	struct no_os_gpio_desc *pwm_gpio;
+	/** PWM platform specific functions */
+	const struct no_os_pwm_platform_ops *platform_ops;
 	/** PWM extra parameters (device specific) */
 	void *extra;
+};
+
+/**
+ * @struct no_os_pwm_platform_ops
+ * @brief Structure holding PWM function pointers that point to the platform
+ * specific function
+ */
+struct no_os_pwm_platform_ops {
+	/** pwm initialization function pointer */
+	int32_t (*pwm_ops_init)(struct no_os_pwm_desc **,
+				const struct no_os_pwm_init_param *);
+	/** pwm enable function pointer */
+	int32_t (*pwm_ops_enable)(struct no_os_pwm_desc *);
+	/** pwm disable function pointer */
+	int32_t (*pwm_ops_disable)(struct no_os_pwm_desc *);
+	/** pwm set period function pointer */
+	int32_t (*pwm_ops_set_period)(struct no_os_pwm_desc *, uint32_t);
+	/** pwm get period function pointer */
+	int32_t (*pwm_ops_get_period)(struct no_os_pwm_desc *, uint32_t *);
+	/** pwm set duty cycle function pointer */
+	int32_t (*pwm_ops_set_duty_cycle)(struct no_os_pwm_desc *, uint32_t);
+	/** pwm get duty cycle function pointer */
+	int32_t (*pwm_ops_get_duty_cycle)(struct no_os_pwm_desc *, uint32_t *);
+	/** pwm set phase function pointer */
+	int32_t (*pwm_ops_set_phase)(struct no_os_pwm_desc *, uint32_t);
+	/** pwm get phase function pointer */
+	int32_t (*pwm_ops_get_phase)(struct no_os_pwm_desc *, uint32_t *);
+	/** pwm set polarity function pointer */
+	int32_t (*pwm_ops_set_polarity)(struct no_os_pwm_desc *,
+					enum no_os_pwm_polarity);
+	/** pwm get polarity function pointer */
+	int32_t (*pwm_ops_get_polarity)(struct no_os_pwm_desc *,
+					enum no_os_pwm_polarity *);
+	/** pwm remove function pointer */
+	int32_t(*pwm_ops_remove)(struct no_os_pwm_desc *);
 };
 
 /******************************************************************************/

--- a/projects/ad463x_fmcz/src.mk
+++ b/projects/ad463x_fmcz/src.mk
@@ -11,6 +11,7 @@
 
 SRCS := $(PROJECT)/src/ad463x_fmc.c
 SRCS += $(DRIVERS)/api/no_os_spi.c \
+	$(DRIVERS)/api/no_os_pwm.c \
 	$(DRIVERS)/api/no_os_gpio.c \
 	$(DRIVERS)/api/no_os_irq.c \
 	$(DRIVERS)/api/no_os_uart.c \

--- a/projects/ad463x_fmcz/src/ad463x_fmc.c
+++ b/projects/ad463x_fmcz/src/ad463x_fmc.c
@@ -118,6 +118,7 @@ int main()
 		.period_ns = 500,	/* 2Mhz */
 		.duty_cycle_ns = AD463X_TRIGGER_PULSE_WIDTH_NS,
 		.polarity = NO_OS_PWM_POLARITY_HIGH,
+		.platform_ops = &axi_pwm_ops,
 		.extra = &axi_pwm_init,
 	};
 

--- a/projects/ad469x_fmcz/src.mk
+++ b/projects/ad469x_fmcz/src.mk
@@ -11,6 +11,7 @@
 
 SRCS += $(PROJECT)/src/ad469x_fmcz.c
 SRCS += $(DRIVERS)/api/no_os_spi.c \
+	$(DRIVERS)/api/no_os_pwm.c \
 	$(DRIVERS)/api/no_os_gpio.c \
 	$(DRIVERS)/adc/ad469x/ad469x.c \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \

--- a/projects/ad469x_fmcz/src/ad469x_fmcz.c
+++ b/projects/ad469x_fmcz/src/ad469x_fmcz.c
@@ -165,6 +165,7 @@ int main()
 		.period_ns = 1000,	/* 1Mhz */
 		.duty_cycle_ns = 10,
 		.polarity = NO_OS_PWM_POLARITY_HIGH,
+		.platform_ops = &axi_pwm_ops,
 		.extra = &axi_pwm_init,
 	};
 

--- a/projects/ad713x_fmcz/src.mk
+++ b/projects/ad713x_fmcz/src.mk
@@ -13,6 +13,7 @@ SRC_DIRS += $(PROJECT)/src
 SRC_DIRS += $(DRIVERS)/adc/ad713x
 
 SRCS += $(DRIVERS)/api/no_os_spi.c \
+	$(DRIVERS)/api/no_os_pwm.c \
 	$(DRIVERS)/api/no_os_gpio.c \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine.c \

--- a/projects/ad713x_fmcz/src/ad713x_fmc.c
+++ b/projects/ad713x_fmcz/src/ad713x_fmc.c
@@ -180,6 +180,7 @@ int main()
 		.period_ns = 3333,
 		.duty_cycle_ns = 600,
 		.phase_ns = 0,
+		.platform_ops = &axi_pwm_ops,
 		.extra = &axi_zed_pwm_init
 	};
 

--- a/projects/adaq7980_sdz/src.mk
+++ b/projects/adaq7980_sdz/src.mk
@@ -11,6 +11,7 @@
 
 SRCS += $(PROJECT)/src/adaq7980_sdz.c
 SRCS += $(DRIVERS)/api/no_os_spi.c \
+	$(DRIVERS)/api/no_os_pwm.c \
 	$(DRIVERS)/api/no_os_gpio.c \
 	$(DRIVERS)/api/no_os_uart.c \
 	$(DRIVERS)/adc/adaq7980/adaq7980.c \

--- a/projects/cn0561/src.mk
+++ b/projects/cn0561/src.mk
@@ -13,6 +13,7 @@ SRC_DIRS += $(PROJECT)/src
 SRC_DIRS += $(DRIVERS)/adc/ad713x
 
 SRCS += $(DRIVERS)/api/no_os_spi.c \
+	$(DRIVERS)/api/no_os_pwm.c \
 	$(DRIVERS)/api/no_os_gpio.c \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine.c \

--- a/projects/cn0561/src/cn0561.c
+++ b/projects/cn0561/src/cn0561.c
@@ -143,6 +143,7 @@ int main()
 		.period_ns = 3400,
 		.duty_cycle_ns = 600,
 		.phase_ns = 0,
+		.platform_ops = &axi_pwm_ops,
 		.extra = &axi_zed_pwm_init
 	};
 

--- a/projects/iio_aducm3029/src.mk
+++ b/projects/iio_aducm3029/src.mk
@@ -8,7 +8,8 @@ SRC_DIRS += $(PROJECT)/src \
 		$(NO-OS)/util \
 		$(NO-OS)/include
 SRCS += $(NO-OS)/drivers/api/no_os_irq.c
-SRCS += $(NO-OS)/drivers/api/no_os_uart.c
+SRCS += $(NO-OS)/drivers/api/no_os_uart.c 
+SRCS += $(NO-OS)/drivers/api/no_os_pwm.c
 
 ifeq '$(TINYIIOD)' 'y'
 SRC_DIRS += $(NO-OS)/iio/iio_app

--- a/projects/iio_aducm3029/src/main.c
+++ b/projects/iio_aducm3029/src/main.c
@@ -45,6 +45,7 @@
 #include "platform_init.h"
 #include "no_os_error.h"
 #include "aducm3029_adc.h"
+#include "aducm3029_pwm.h"
 #include "no_os_uart.h"
 #include "aducm3029_uart.h"
 #include "no_os_pwm.h"
@@ -86,6 +87,7 @@ static int32_t init_pwms(struct no_os_pwm_desc **pwms)
 	struct no_os_pwm_init_param		pwm_init_par = {
 		.period_ns = 400000000,
 		.polarity = NO_OS_PWM_POLARITY_HIGH,
+		.platform_ops = &aducm3029_pwm_ops,
 		.extra = NULL
 	};
 	struct no_os_pwm_desc *pwm;


### PR DESCRIPTION
* Additionally the gpio pin for pwm requires to be configured as alternate functionality.