### PR TITLE
libraries: add mbed-os submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ sw.elf
 xsct.log
 RemoteSystemsTempFiles
 build
+BUILD
+mbed-app-json
+.mbed
 projects/*/build_*
 dfp_drivers
 aducm_project

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "libraries/azure-sdk-for-c"]
 	path = libraries/azure/azure-sdk-for-c
 	url = https://github.com/Azure/azure-sdk-for-c.git
+[submodule "libraries/mbed/mbed-os"]
+	path = libraries/mbed/mbed-os
+	url = https://github.com/ARMmbed/mbed-os


### PR DESCRIPTION

The library is required to build projects for the mbed platform in
conjunction with https://github.com/analogdevicesinc/no-OS/commit/f8b147b38ba70c1e2541b9a3a5d0009776e8f8d7 .