### PR TITLE
drivers:axi_core:axi_dac_core Add rate member to init params

### DIFF
--- a/drivers/axi_core/axi_dac_core/axi_dac_core.c
+++ b/drivers/axi_core/axi_dac_core/axi_dac_core.c
@@ -951,7 +951,7 @@ int32_t axi_dac_init(struct axi_dac **dac_core,
 	axi_dac_write(dac, AXI_DAC_REG_RSTN,
 		      AXI_DAC_MMCM_RSTN | AXI_DAC_RSTN);
 
-	axi_dac_write(dac, AXI_DAC_REG_RATECNTRL, AXI_DAC_RATE(3));
+	axi_dac_write(dac, AXI_DAC_REG_RATECNTRL, AXI_DAC_RATE(init->rate));
 	axi_dac_data_setup(dac);
 	axi_dac_write(dac, AXI_DAC_REG_SYNC_CONTROL, AXI_DAC_SYNC);
 

--- a/drivers/axi_core/axi_dac_core/axi_dac_core.h
+++ b/drivers/axi_core/axi_dac_core/axi_dac_core.h
@@ -73,6 +73,8 @@ struct axi_dac_init {
 	uint8_t	num_channels;
 	/** DAC channels manual configuration */
 	struct axi_dac_channel *channels;
+	/** The effective DAC rate */
+	uint8_t rate;
 };
 
 enum axi_dac_data_sel {

--- a/projects/ad9081/src/app.c
+++ b/projects/ad9081/src/app.c
@@ -195,7 +195,8 @@ int main(void)
 	struct axi_dac_init tx_dac_init = {
 		.name = "tx_dac",
 		.base = TX_CORE_BASEADDR,
-		.channels = NULL
+		.channels = NULL,
+		.rate = 3
 	};
 	struct axi_dac *tx_dac;
 	struct axi_dmac_init rx_dmac_init = {

--- a/projects/ad9172/src/main.c
+++ b/projects/ad9172/src/main.c
@@ -175,7 +175,8 @@ int main(void)
 		"tx_dac",
 		TX_CORE_BASEADDR,
 		4,
-		NULL
+		NULL,
+		3
 	};
 
 #ifdef DMA_EXAMPLE

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -161,7 +161,8 @@ struct axi_dac_init tx_dac_init = {
 	"cf-ad9361-dds-core-lpc",
 	TX_CORE_BASEADDR,
 	4,
-	NULL
+	NULL,
+	3
 };
 struct axi_dmac_init rx_dmac_init = {
 	"rx_dmac",
@@ -554,8 +555,13 @@ int main(void)
 	default_init_param.gpio_cal_sw2.number = -1;
 #endif
 
-	if (AD9364_DEVICE)
+	if (AD9364_DEVICE) {
 		default_init_param.dev_sel = ID_AD9364;
+		tx_dac_init.num_channels = 2;
+		tx_dac_init.rate = 1;
+		rx_adc_init.num_channels = 2;
+		rx_adc_init.num_slave_channels = 0;
+	}
 	if (AD9363A_DEVICE)
 		default_init_param.dev_sel = ID_AD9363A;
 

--- a/projects/ad9371/src/app/headless.c
+++ b/projects/ad9371/src/app/headless.c
@@ -262,7 +262,8 @@ int main(void)
 		"tx_dac",
 		TX_CORE_BASEADDR,
 		4,
-		NULL
+		NULL,
+		3
 	};
 	struct axi_dac *tx_dac;
 	struct axi_adc_init rx_adc_init = {

--- a/projects/ad9739a-fmc-ebz/src/ad9739a_fmc_ebz.c
+++ b/projects/ad9739a-fmc-ebz/src/ad9739a_fmc_ebz.c
@@ -145,7 +145,8 @@ int main(void)
 		.name = "ad9739a_dac",
 		.base =	TX_CORE_BASEADDR,
 		.num_channels = 1,
-		.channels = &ad9739a_channels[0]
+		.channels = &ad9739a_channels[0],
+		.rate = 3
 	};
 	struct axi_dac	*ad9739a_core;
 

--- a/projects/adrv9001/src/app/headless.c
+++ b/projects/adrv9001/src/app/headless.c
@@ -282,6 +282,7 @@ int main(void)
 		.base = TX1_DAC_BASEADDR,
 		.num_channels = ADRV9001_I_Q_CHANNELS,
 		.channels = tx1_dac_channels,
+		.rate = 3
 	};
 
 #ifndef ADRV9002_RX2TX2
@@ -300,6 +301,7 @@ int main(void)
 		.base = TX2_DAC_BASEADDR,
 		.num_channels = ADRV9001_I_Q_CHANNELS,
 		.channels = tx2_dac_channels,
+		.rate = 3
 	};
 #endif
 	struct axi_dmac_init rx1_dmac_init = {

--- a/projects/adrv9009/src/app/headless.c
+++ b/projects/adrv9009/src/app/headless.c
@@ -210,7 +210,8 @@ int main(void)
 		"tx_dac",
 		TX_CORE_BASEADDR,
 		TALISE_NUM_CHANNELS,
-		NULL
+		NULL,
+		3
 	};
 	struct axi_dac *tx_dac;
 

--- a/projects/fmcdaq2/src/app/fmcdaq2.c
+++ b/projects/fmcdaq2/src/app/fmcdaq2.c
@@ -682,7 +682,8 @@ static int fmcdaq2_dac_init(struct fmcdaq2_dev *dev,
 		.name = "ad9144_dac",
 		.base =	TX_CORE_BASEADDR,
 		.num_channels = 2,
-		.channels = &dev->ad9144_channels[0]
+		.channels = &dev->ad9144_channels[0],
+		.rate = 3
 	};
 
 	for(uint32_t n=0;

--- a/projects/fmcdaq3/src/app/fmcdaq3.c
+++ b/projects/fmcdaq3/src/app/fmcdaq3.c
@@ -348,7 +348,8 @@ int main(void)
 		.name = "ad9152_dac",
 		.base =	TX_CORE_BASEADDR,
 		.num_channels = 2,
-		.channels = &ad9152_channels[0]
+		.channels = &ad9152_channels[0],
+		.rate = 3
 	};
 	struct axi_dac	*ad9152_core;
 


### PR DESCRIPTION
Add effective rate setting of the DAC initialization parameters.

The default rate was set to 3, causing faulty transmissions. Details in: https://ez.analog.com/microcontroller-no-os-drivers/f/q-a/568422/adrv9364-adc_dma_example-and-dac_dma_example