### PR TITLE
Exit iio_app on callback error

### DIFF
--- a/iio/iio_app/iio_app.c
+++ b/iio/iio_app/iio_app.c
@@ -398,8 +398,11 @@ int iio_app_run(struct iio_app_desc *app)
 		if (status && status != -EAGAIN && status != -ENOTCONN
 		    && status != -NO_OS_EOVERRUN)
 			return status;
-		if (app->post_step_callback)
+		if (app->post_step_callback) {
 			status = app->post_step_callback(app->arg);
+			if (status)
+				return status;
+		}
 	} while (true);
 }
 


### PR DESCRIPTION
The current implementation doesn't check the status value, thus making the scenario where the iio_app_desc is freed in the callback function (with the intent to stop the server) impossible.