### PR TITLE
mbed platform : add build support

### DIFF
--- a/projects/adt7420-pmdz/builds.json
+++ b/projects/adt7420-pmdz/builds.json
@@ -36,5 +36,10 @@
       "iio_example_max32690": {
         "flags" : "DUMMY_EXAMPLE=n IIO_EXAMPLE=y TARGET=max32690"
       }
+    },
+    "mbed": {
+      "dummy_example_mbed": {
+        "flags" : "DUMMY_EXAMPLE=y IIO_EXAMPLE=n"
+      }
     }
 }

--- a/tools/scripts/build_projects.py
+++ b/tools/scripts/build_projects.py
@@ -204,6 +204,8 @@ class BuildConfig:
 			self.export_file = self.export_file.replace('.elf', '.hex')
 		if (platform == 'pico'):
 			self.export_file = self.export_file.replace('.elf', '.uf2')
+		if (platform == 'mbed'):
+			self.export_file = self.export_file.replace('.elf', '.bin')
 
 	def build(self):
 		global log_file


### PR DESCRIPTION
- [tools:scripts:build_projects: add mbed support](https://github.com/analogdevicesinc/no-OS/commit/3a56a0a3a993606aee19ee50522d791f21be14f4)
 - [projects: adt7420-pmdz: add mbed build support](https://github.com/analogdevicesinc/no-OS/commit/53f25a56cb06d6216886037531c43ee9ef4c3908)
