### PR TITLE
build_projects.yml: update script call

### DIFF
--- a/build_projects.yml
+++ b/build_projects.yml
@@ -20,7 +20,7 @@ jobs:
     submodules: true
     clean: true
     persistCredentials: true
-  - script: 'python3 ./tools/scripts/build_projects.py . 
+  - script: 'sudo python3 ./tools/scripts/build_projects.py . 
                -export_dir $(RELEASE_DIR)
                -log_dir $(LOG_DIR)
                -builds_dir $(BUILDS_DIR)'


### PR DESCRIPTION
In preparation for the migration on the new server for the project builds, the BUILDS_DIR variable in the azure pipeline variables group has changed to `/no-OS_builds/builds` instead of a home folder path for specific user. To avoid sporadic build errors due to denied permissions when manipulating project build files under the new BUILDS_DIR folder, run with sudo permissions the build_projects.py script inside azure pipeline.