### PR TITLE
Chibios/gpio: init ret guard bug fix

### DIFF
--- a/drivers/platform/chibios/chibios_gpio.c
+++ b/drivers/platform/chibios/chibios_gpio.c
@@ -107,7 +107,7 @@ int32_t chibios_gpio_get(struct no_os_gpio_desc **desc,
 
 	descriptor->extra = extra;
 	ret = _gpio_init(descriptor, param);
-	if (!ret)
+	if (ret)
 		goto error_2;
 
 	*desc = descriptor;


### PR DESCRIPTION
In file chibios_gpio.c:110 the ret val, should be inverse

Fixes: 26f0005("drivers/platform/chibios: chibios_gpio")