### PR TITLE
drivers: dac: ad5791: Add spi mask functions, APIs

### DIFF
--- a/drivers/dac/ad5791/ad5791.c
+++ b/drivers/dac/ad5791/ad5791.c
@@ -381,3 +381,24 @@ int ad5791_spi_write_mask(struct ad5791_dev *dev,
 	return ad5791_set_register_value(dev, register_address, reg_data);
 }
 
+/***************************************************************************//**
+ * @brief	Set Linearity error compensation based on the reference voltage span.
+ *
+ * @param	dev		- The device structure.
+ * @param	v_span	- voltage span to set the corresponding lin_comp value.
+ * @return	0 in case of success, negative error code otherwise.
+ */
+int ad5791_set_lin_comp(struct ad5791_dev *dev,
+			enum ad5791_lin_comp_select v_span)
+{
+	if(!dev || (dev->act_device != ID_AD5781 && dev->act_device != ID_AD5791))
+		return -EINVAL;
+
+	if (!v_span)
+		v_span |= NO_OS_BIT(4);
+
+	return ad5791_spi_write_mask(dev,
+				     AD5791_REG_CTRL,
+				     AD5791_CTRL_LINCOMP_MASK,
+				     AD5791_CTRL_LINCOMP(v_span));
+}

--- a/drivers/dac/ad5791/ad5791.h
+++ b/drivers/dac/ad5791/ad5791.h
@@ -62,6 +62,16 @@ enum ad5791_type {
 	ID_AD5791
 };
 
+/* Possible voltage spans for linearity error compensation */
+enum ad5791_lin_comp_select {
+	AD5781_SPAN_UPTO_10V = 0,
+	AD5781_SPAN_10V_TO_20V = 4,
+	AD5791_SPAN_10V_TO_12V = 1,
+	AD5791_SPAN_12V_TO_16V = 2,
+	AD5791_SPAN_16V_TO_19V = 3,
+	AD5791_SPAN_19V_TO_20V = 4
+};
+
 struct ad5791_chip_info {
 	uint32_t resolution;
 };
@@ -196,5 +206,9 @@ int ad5791_spi_write_mask(struct ad5791_dev *dev,
 			  uint8_t register_address,
 			  uint32_t mask,
 			  uint32_t value);
+
+/*! Set Linearity error compensation based on the reference voltage span. */
+int ad5791_set_lin_comp(struct ad5791_dev *dev,
+			enum ad5791_lin_comp_select v_span);
 
 #endif /* __AD5791_H__ */

--- a/drivers/dac/ad5791/ad5791.h
+++ b/drivers/dac/ad5791/ad5791.h
@@ -47,6 +47,8 @@
 #include "no_os_delay.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
+#include "no_os_util.h"
+#include "no_os_error.h"
 
 /******************************************************************************/
 /*************************** Types Declarations *******************************/
@@ -130,12 +132,16 @@ struct ad5791_init_param {
 #define AD5791_ADDR_REG(x)         (((uint32_t)(x) & 0x7) << 20)
 
 /* Control Register bit Definition */
-#define AD5791_CTRL_LINCOMP(x)   (((x) & 0xF) << 6) // Linearity error compensation.
-#define AD5791_CTRL_SDODIS       (1 << 5) // SDO pin enable/disable control.
-#define AD5791_CTRL_BIN2SC       (1 << 4) // DAC register coding selection.
-#define AD5791_CTRL_DACTRI       (1 << 3) // DAC tristate control.
-#define AD5791_CTRL_OPGND        (1 << 2) // Output ground clamp control.
-#define AD5791_CTRL_RBUF         (1 << 1) // Output amplifier configuration control.
+#define AD5791_CTRL_LINCOMP_MASK   NO_OS_GENMASK(9,6) // Linearity error compensation.
+#define AD5791_CTRL_LINCOMP(x)     (((x) & 0xF) << 6)
+#define AD5791_CTRL_SDODIS_MASK    NO_OS_BIT(5)       // SDO pin enable/disable control.
+#define AD5791_CTRL_SDODIS(x)      ((x & 0x01) << 5)
+#define AD5791_CTRL_BIN2SC_MASK    NO_OS_BIT(4)       // DAC register coding selection.
+#define AD5791_CTRL_BIN2SC(x)      ((x & 0x01) << 4)
+#define AD5791_CTRL_DACTRI         NO_OS_BIT(3)       // DAC tristate control.
+#define AD5791_CTRL_OPGND          NO_OS_BIT(2)       // Output ground clamp control.
+#define AD5791_CTRL_RBUF_MASK      NO_OS_BIT(1)       // Output amplifier configuration control.
+#define AD5791_CTRL_RBUF(x)        ((x & 0x01) << 1)
 
 /* Software Control Register bit definition */
 #define AD5791_SOFT_CTRL_RESET      (1 << 2) // RESET function.
@@ -184,5 +190,11 @@ int32_t ad5791_soft_instruction(struct ad5791_dev *dev,
     error compensation. */
 int32_t ad5791_setup(struct ad5791_dev *dev,
 		     uint32_t setup_word);
+
+/*! SPI write to device using a mask. */
+int ad5791_spi_write_mask(struct ad5791_dev *dev,
+			  uint8_t register_address,
+			  uint32_t mask,
+			  uint32_t value);
 
 #endif /* __AD5791_H__ */

--- a/legacy/device_commands/AD5791/Command.c
+++ b/legacy/device_commands/AD5791/Command.c
@@ -348,7 +348,7 @@ void SetCoding(double* param, char paramNo) // "coding=" command
 
         if(codingStyle == 0)
         {
-            AD5791_Setup(rbuf * AD5791_CTRL_RBUF);
+            AD5791_Setup(rbuf * AD5791_CTRL_RBUF_MASK);
             /* Write to DAC register */
             AD5791_SetDacValue(registerValue);
             CONSOLE_Print("%s%d(two's complement)\r\n",cmdList[2].name,
@@ -356,7 +356,7 @@ void SetCoding(double* param, char paramNo) // "coding=" command
         }
         else
         {
-            AD5791_Setup(AD5791_CTRL_BIN2SC | rbuf * AD5791_CTRL_RBUF);
+            AD5791_Setup(AD5791_CTRL_BIN2SC_MASK | rbuf * AD5791_CTRL_RBUF_MASK);
             /* Write to DAC register */
             AD5791_SetDacValue(registerValue);
             /* Send feedback to user for coding change */
@@ -653,8 +653,8 @@ void SetRbuf(double* param, char paramNo) // "rbuf=" command
         rbuf = (unsigned char)param[0];
 
         regValue = AD5791_GetRegisterValue(AD5791_REG_CTRL);
-        regValue &= ~AD5791_CTRL_RBUF;
-        regValue |= rbuf * AD5791_CTRL_RBUF;
+        regValue &= ~AD5791_CTRL_RBUF_MASK;
+        regValue |= rbuf * AD5791_CTRL_RBUF_MASK;
         AD5791_SetRegisterValue(AD5791_REG_CTRL,regValue);
 
         /* Send feedback to user */

--- a/projects/cn0531/src/main.c
+++ b/projects/cn0531/src/main.c
@@ -130,7 +130,7 @@ int main(void)
 					   AD5791_REG_CTRL, &val);
 	if (status < 0)
 		return status;
-	val &= ~(AD5791_CTRL_OPGND | AD5791_CTRL_RBUF);
+	val &= ~(AD5791_CTRL_OPGND | AD5791_CTRL_RBUF_MASK);
 	status = ad5791_set_register_value(ad5791_iio_handle->ad5791_handle,
 					   AD5791_REG_CTRL, (uint32_t)val);
 	if (status != 0)


### PR DESCRIPTION
Add SPI read/write mask functions, linearity error compensation select API support.