### PR TITLE
Xilinx/timer init bug fix

### DIFF
--- a/drivers/platform/xilinx/xilinx_timer.c
+++ b/drivers/platform/xilinx/xilinx_timer.c
@@ -90,6 +90,7 @@ int32_t xilinx_timer_init(struct no_os_timer_desc **desc,
 	dev->id = param->id;
 	dev->freq_hz = param->freq_hz;
 	dev->ticks_count = param->ticks_count;
+	dev->platform_ops = param->platform_ops;
 	dev->extra = xdesc;
 	xdesc->active_tmr = xinit->active_tmr;
 	xdesc->type = xinit->type;


### PR DESCRIPTION
Since dev->platform_ops is not assigned no_os_timer_count_clk_set and no_os_timer_counter_set will always return -EINVAL. The timer will never be initialized.