### PR TITLE
platform:xilinx:timer: fix init function

### DIFF
--- a/drivers/platform/xilinx/xilinx_timer.c
+++ b/drivers/platform/xilinx/xilinx_timer.c
@@ -341,11 +341,11 @@ int32_t xilinx_timer_init(struct no_os_timer_desc **desc,
 			no_os_free(xdesc->instance);
 			goto error_xdesc;
 		}
-		ret = no_os_timer_count_clk_set(dev, param->freq_hz);
+		ret = xilinx_timer_count_clk_set(dev, param->freq_hz);
 		if (NO_OS_IS_ERR_VALUE(ret))
 			goto error_xdesc;
 
-		ret = no_os_timer_counter_set(dev, dev->ticks_count);
+		ret = xilinx_timer_counter_set(dev, dev->ticks_count);
 		if (NO_OS_IS_ERR_VALUE(ret))
 			goto error_xdesc;
 


### PR DESCRIPTION
Since the platform ops are populated in the generic timer api after the platform specific timer initialization, the `no_os_timer_count_clk_set` won't work properly when called inside the platform specific init function. Instead use directly the `xilinx_timer_count_clk_set` function.