### PR TITLE
Irq rem legacy members

### DIFF
--- a/drivers/afe/ad4110/ad4110.c
+++ b/drivers/afe/ad4110/ad4110.c
@@ -1055,7 +1055,7 @@ int32_t ad4110_continuous_read(struct ad4110_dev *dev, uint32_t *buffer,
 	};
 
 	struct no_os_callback_desc irq_callback = {
-		.legacy_callback = &irq_adc_read,
+		.callback = &irq_adc_read,
 		.ctx = &ctx
 	};
 

--- a/drivers/platform/xilinx/xilinx_gpio_irq.c
+++ b/drivers/platform/xilinx/xilinx_gpio_irq.c
@@ -93,7 +93,7 @@ static void xil_gpio_irq_handler(struct xil_gpio_irq_desc *param)
 			callback_desc->triggered = false;
 			XGpioPs_IntrDisablePin(&param->my_Gpio, callback_desc->pin_nb);
 			XGpioPs_IntrClearPin(&param->my_Gpio, callback_desc->pin_nb);
-			callback_desc->callback.legacy_callback(callback_desc->callback.ctx, 0U, NULL);
+			callback_desc->callback.callback(callback_desc->callback.ctx);
 			if(callback_desc->enabled)
 				XGpioPs_IntrEnablePin(&param->my_Gpio, callback_desc->pin_nb);
 		}
@@ -188,7 +188,7 @@ int32_t xil_gpio_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 	if(status)
 		goto error_op;
 
-	callback.legacy_callback = &xil_gpio_irq_handler;
+	callback.callback = &xil_gpio_irq_handler;
 	callback.ctx = ldesc->extra;
 	status = no_os_irq_register_callback(xil_desc->parent_desc, ldesc->irq_ctrl_id,
 					     &callback);
@@ -254,7 +254,7 @@ int32_t xil_gpio_irq_register_callback(struct no_os_irq_ctrl_desc *desc,
 		return -1;
 
 	dev_callback->pin_nb = irq_id;
-	dev_callback->callback.legacy_callback = callback_desc->legacy_callback;
+	dev_callback->callback.callback = callback_desc->callback;
 	dev_callback->callback.ctx = callback_desc->ctx;
 	dev_callback->triggered = false;
 

--- a/drivers/platform/xilinx/xilinx_irq.c
+++ b/drivers/platform/xilinx/xilinx_irq.c
@@ -262,10 +262,10 @@ int32_t xil_irq_register_callback(struct no_os_irq_ctrl_desc *desc,
 			int32_t ret;
 
 			ret = XIntc_Connect(xil_dev->instance, irq_id,
-					    XTmrCtr_InterruptHandler, callback_desc->legacy_config);
+					    XTmrCtr_InterruptHandler, NULL);
 			if (NO_OS_IS_ERR_VALUE(ret))
 				return -1;
-			XTmrCtr_SetHandler(callback_desc->legacy_config,
+			XTmrCtr_SetHandler(xil_dev->instance,
 					   (XTmrCtr_Handler)callback_desc->callback,
 					   callback_desc->ctx);
 

--- a/include/no_os_irq.h
+++ b/include/no_os_irq.h
@@ -136,18 +136,8 @@ struct no_os_irq_ctrl_desc {
 struct no_os_callback_desc {
 	/** Callback to be called when the event an event occurs. */
 	void (*callback)(void *context);
-	/**
-	 * Callback to be called when the event an event occurs
-	 *  @param ctx - Same as \ref no_os_callback_desc.ctx
-	 *  @param event - Event that generated the callback
-	 *  @param extra - Platform specific data
-	 */
-	void (*legacy_callback)(void *ctx, uint32_t event,
-				void *extra); /* TODO: remove this. */
 	/** Parameter to be passed when the callback is called */
 	void *ctx;
-	/** Platform specific configuration for a callback */
-	void *legacy_config; /* TODO: remove this. */
 	/** Platform specific event that triggers the calling of the callback. */
 	enum no_os_irq_event event;
 	/** Interrupt source peripheral specifier. */
@@ -165,7 +155,7 @@ struct no_os_irq_platform_ops {
 	/** Initialize a interrupt controller peripheral. */
 	int32_t (*init)(struct no_os_irq_ctrl_desc **desc,
 			const struct no_os_irq_init_param *param);
-	/** Register a legacy_callback to handle the irq events */
+	/** Register a callback to handle the irq events */
 	int32_t (*register_callback)(struct no_os_irq_ctrl_desc *desc, uint32_t irq_id,
 				     struct no_os_callback_desc *callback);
 	/** Unregisters a generic IRQ handling function */


### PR DESCRIPTION
Remove legacy_callback and legacy_config members in the callback descriptor structure.