### PR TITLE
Ad4110 drdy pin set

### DIFF
--- a/projects/ad4110/src/app/parameters.h
+++ b/projects/ad4110/src/app/parameters.h
@@ -45,9 +45,9 @@
 /******************************************************************************/
 #define BUF_LENGTH 	32U
 #define SPI_DEVICE_ID 	0U
-#define GPIO_OFFSET  	31U
+#define GPIO_OFFSET  	54U
 
-#define NREADY_PIN   	GPIO_OFFSET + 1U
+#define NREADY_PIN   	GPIO_OFFSET + 32U
 #define GPIO_IRQ_ID 	52U
 
 #endif


### PR DESCRIPTION
Specify JB1 as DRDY pin for the AD4110 project. A connection between DOUT and JB1 will be required.