### PR TITLE
drivers:platform:stm32:Fixed typo in callback function

### DIFF
--- a/drivers/platform/stm32/stm32_tdm.c
+++ b/drivers/platform/stm32/stm32_tdm.c
@@ -204,7 +204,7 @@ int32_t stm32_tdm_init(struct no_os_tdm_desc **desc,
 		if (ret < 0)
 			goto error;
 
-		tdesc->rx_half_callback.callback = param->rx_complete_callback;;
+		tdesc->rx_half_callback.callback = param->rx_half_complete_callback;
 		tdesc->rx_half_callback.ctx = tdm_desc;
 		tdesc->rx_half_callback.event = NO_OS_EVT_DMA_RX_HALF_COMPLETE;
 		tdesc->rx_half_callback.peripheral = NO_OS_DMA_IRQ;


### PR DESCRIPTION
Fixed the typo with assigning the half complete callback