### PR TITLE
Add AD7091R-2/-4/-8 driver and project

### DIFF
--- a/doc/sphinx/source/projects/ad7091r8-sdz.rst
+++ b/doc/sphinx/source/projects/ad7091r8-sdz.rst
@@ -1,0 +1,2 @@
+.. include:: ../../../../projects/ad7091r8-sdz/README.rst
+

--- a/doc/sphinx/source/projects_doc.rst
+++ b/doc/sphinx/source/projects_doc.rst
@@ -4,6 +4,13 @@ no-OS projects list
 
 The following sections contain code documentation for ADI no-OS projects.
 
+ANALOG TO DIGITAL CONVERTERS
+============================
+.. toctree::
+   :maxdepth: 1
+
+   projects/ad7091r8-sdz
+
 INERTIAL MEASUREMENT UNITS
 ==========================
 .. toctree::

--- a/drivers/adc/ad7091r8/ad7091r8.c
+++ b/drivers/adc/ad7091r8/ad7091r8.c
@@ -1,0 +1,545 @@
+/***************************************************************************//**
+ *   @file   ad7091r8.c
+ *   @brief  Implementation of AD7091R-8 Driver
+ *   @author Marcelo Schmitt (marcelo.schmitt@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <stdlib.h>
+#include <errno.h>
+
+#include "ad7091r8.h"
+#include "no_os_alloc.h"
+#include "no_os_error.h"
+#include "no_os_util.h"
+#include "no_os_delay.h"
+
+/**
+ * Pull the CONVST line up then down to signal to the start of a read/write
+ * operation.
+ * @param dev - The device structure.
+ */
+int ad7091r8_pulse_convst(struct ad7091r8_dev *dev)
+{
+	int ret;
+
+	if (!dev)
+		return -EINVAL;
+
+	ret = no_os_gpio_set_value(dev->gpio_convst, NO_OS_GPIO_LOW);
+	if (ret)
+		return ret;
+
+	return no_os_gpio_set_value(dev->gpio_convst, NO_OS_GPIO_HIGH);
+}
+
+/**
+ * Write to device.
+ * @param dev - The device structure.
+ * @param reg_addr - The register address.
+ * @param reg_data - The register data.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad7091r8_spi_reg_write(struct ad7091r8_dev *dev,
+			   uint8_t reg_addr,
+			   uint16_t reg_data)
+{
+	uint8_t buf[2];
+
+	if (!dev)
+		return -EINVAL;
+
+	/*
+	 * AD7091R-2/-4/-8 protocol (datasheet page 31) is to do a single SPI
+	 * transfer with reg address set in bits B15:B11 and value set in B9:B0.
+	 */
+	no_os_put_unaligned_be16(
+		no_os_field_prep(AD7091R8_REG_DATA_MSK, reg_data) |
+		no_os_field_prep(AD7091R8_RD_WR_FLAG_MSK, 1) |
+		no_os_field_prep(AD7091R8_REG_ADDR_MSK, reg_addr), buf);
+
+	return no_os_spi_write_and_read(dev->spi_desc, buf, 2);
+}
+
+/**
+ * Read from device.
+ * @param dev - The device structure.
+ * @param reg_addr - The register address.
+ * @param reg_data - The register data.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad7091r8_spi_reg_read(struct ad7091r8_dev *dev,
+			  uint8_t reg_addr,
+			  uint16_t *reg_data)
+{
+	uint8_t buf[2];
+	int ret;
+
+	if (!dev || !reg_data)
+		return -EINVAL;
+
+	if (reg_addr == AD7091R8_REG_RESULT) {
+		ret = ad7091r8_pulse_convst(dev);
+		if (ret)
+			return ret;
+	}
+
+	no_os_put_unaligned_be16(
+		no_os_field_prep(AD7091R8_RD_WR_FLAG_MSK, 0) |
+		no_os_field_prep(AD7091R8_REG_ADDR_MSK, reg_addr), buf);
+
+	/* Reg data only comes out on the next transfer (datasheet figure 52) */
+	ret = no_os_spi_write_and_read(dev->spi_desc, buf, 2);
+	if (ret)
+		return ret;
+
+	if (reg_addr == AD7091R8_REG_RESULT) {
+		ret = ad7091r8_pulse_convst(dev);
+		if (ret)
+			return ret;
+	}
+
+	no_os_put_unaligned_be16(
+		no_os_field_prep(AD7091R8_RD_WR_FLAG_MSK, 0) |
+		no_os_field_prep(AD7091R8_REG_ADDR_MSK, reg_addr), buf);
+
+	ret = no_os_spi_write_and_read(dev->spi_desc, buf, 2);
+	if (ret)
+		return ret;
+
+	*reg_data = no_os_get_unaligned_be16(buf);
+	return 0;
+}
+
+/**
+ * SPI write to device using a mask.
+ * @param dev - The device structure.
+ * @param reg_addr - The register address.
+ * @param mask - The mask.
+ * @param data - The register data.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad7091r8_spi_write_mask(struct ad7091r8_dev *dev,
+			    uint8_t reg_addr,
+			    uint16_t mask,
+			    uint16_t data)
+{
+	uint16_t reg_data;
+	int ret;
+
+	ret = ad7091r8_spi_reg_read(dev, reg_addr, &reg_data);
+	if (ret)
+		return ret;
+
+	reg_data &= ~mask;
+	reg_data |= data;
+
+	return ad7091r8_spi_reg_write(dev, reg_addr, reg_data);
+}
+
+/**
+ * @brief Set device sleep mode.
+ *
+ * @param dev - The device structure.
+ * @param mode - The device sleep mode to set.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad7091r8_set_sleep_mode(struct ad7091r8_dev *dev,
+			    enum ad7091r8_sleep_mode mode)
+{
+	return ad7091r8_spi_write_mask(dev, AD7091R8_REG_CONF,
+				       REG_CONF_SLEEP_MODE_MASK, mode);
+}
+
+/**
+ * Set output port value.
+ * @param dev - The device structure.
+ * @param port - Port number.
+ * @param value - Value.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad7091r8_set_port(struct ad7091r8_dev *dev, enum ad7091r8_port port,
+		      bool value)
+{
+	uint16_t mask;
+	uint16_t val;
+
+	switch (port) {
+	case AD7091R8_GPO0:
+		mask = REG_CONF_GPO0_MASK;
+		val = no_os_field_get(REG_CONF_GPO0_MASK, value);
+		break;
+	case AD7091R8_GPO1:
+		mask = REG_CONF_GPO1_MASK;
+		val = no_os_field_get(REG_CONF_GPO1_MASK, value);
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return ad7091r8_spi_write_mask(dev, AD7091R8_REG_CONF, mask, val);
+}
+
+/**
+ * Set GPO0 mode.
+ * @param dev - The device structure.
+ * @param mode - GPO0 new mode.
+ * @param is_cmos - 0: GPO0 is open drain
+ * 		  - 1: GPO0 is CMOS.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad7091r8_set_gpo0_mode(struct ad7091r8_dev *dev,
+			   enum ad7091r8_gpo0_mode mode, bool is_cmos)
+{
+	uint16_t value = mode;
+
+	if (is_cmos)
+		value |= NO_OS_BIT(6);
+
+	return ad7091r8_spi_write_mask(dev, AD7091R8_REG_CONF,
+				       REG_CONF_GPO0_MODE_MASK, value);
+}
+
+/**
+ * Set high limit, low limit, hysteresis.
+ * Device accepts 9 bits provided by the user and sets them as the MSBs.
+ * The 3 LSBs of the internal 12-bit registers are set either to 000 or 111.
+ * Round user input according to each case.
+ * @param dev - The device structure.
+ * @param limit - Limit.
+ * @param channel - Channel.
+ * @param value - Value.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad7091r8_set_limit(struct ad7091r8_dev *dev,
+		       enum ad7091r8_limit limit,
+		       uint8_t channel,
+		       uint16_t value)
+{
+	uint16_t reg;
+
+	switch (limit) {
+	case AD7091R8_LOW_LIMIT:
+		reg = AD7091R8_REG_CH_LOW_LIMIT(channel);
+		break;
+	case AD7091R8_HIGH_LIMIT:
+		reg = AD7091R8_REG_CH_HIGH_LIMIT(channel);
+		break;
+	case AD7091R8_HYSTERESIS:
+		reg = AD7091R8_REG_CH_HYSTERESIS(channel);
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return ad7091r8_spi_reg_write(dev, reg,
+				      no_os_field_get(AD7091R8_CONV_MASK, value));
+}
+
+/**
+ * Get alert.
+ * @param dev - The device structure.
+ * @param channel - Channel.
+ * @param alert - Alert type.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad7091r8_get_alert(struct ad7091r8_dev *dev, uint8_t channel,
+		       enum ad7091r8_alert_type *alert)
+{
+	int ret;
+	uint16_t data;
+
+	if (!dev || !alert)
+		return -EINVAL;
+
+	if (channel >= AD7091R_NUM_CHANNELS(dev->device_id))
+		return -EINVAL;
+
+	ret = ad7091r8_spi_reg_read(dev, AD7091R8_REG_ALERT, &data);
+	if (ret)
+		return ret;
+
+	*alert = REG_ALERT_MASK(data, channel);
+
+	return 0;
+}
+
+/**
+ * Get high limit, low limit, hysteresis.
+ * The 3 LSBs of the internal 12-bit registers are set either to 000 or 111.
+ * Adjust limit data to reflect actual limit in use by the device.
+ * @param dev - The device structure.
+ * @param limit - Limit.
+ * @param channel - Channel.
+ * @param value - Value.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad7091r8_get_limit(struct ad7091r8_dev *dev,
+		       enum ad7091r8_limit limit,
+		       uint8_t channel,
+		       uint16_t *value)
+{
+	uint16_t reg;
+
+	switch (limit) {
+	case AD7091R8_LOW_LIMIT:
+		reg = AD7091R8_REG_CH_LOW_LIMIT(channel);
+		break;
+	case AD7091R8_HIGH_LIMIT:
+		reg = AD7091R8_REG_CH_HIGH_LIMIT(channel);
+		break;
+	case AD7091R8_HYSTERESIS:
+		reg = AD7091R8_REG_CH_HYSTERESIS(channel);
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return ad7091r8_spi_reg_read(dev, reg, value);
+}
+
+/**
+ * @brief Initiate a software reset or hardware reset through the RESET pin.
+ * @param dev - ad7091r8_dev device handler.
+ * @param is_software - true: Software reset
+ * 		      - false: hardware reset
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad7091r8_reset(struct ad7091r8_dev *dev, bool is_software)
+{
+	int ret;
+
+	if (!dev)
+		return -EINVAL;
+
+	if (is_software) {
+		/* Bit is cleared automatically after reset */
+		return ad7091r8_spi_write_mask(dev, AD7091R8_REG_CONF,
+					       REG_CONF_RESET_MASK,
+					       NO_OS_BIT(9));
+	}
+	ret = no_os_gpio_set_value(dev->gpio_reset, NO_OS_GPIO_LOW);
+	if (ret)
+		return ret;
+
+	no_os_udelay(1);
+	return no_os_gpio_set_value(dev->gpio_reset, NO_OS_GPIO_HIGH);
+}
+
+/***************************************************************************//**
+ * Initializes the communication peripheral and the initial Values for
+ * AD7092R-8 Board.
+ * @param device     - The device structure.
+ * @param init_param - The structure that contains the device initial
+ * 		       parameters.
+ *
+ * @return ret - The result of the initialization procedure.
+ *               Example: -1 - SPI peripheral was not initialized or the
+ *                             device is not present.
+ *                         0 - SPI peripheral was initialized and the
+ *                             device is present.
+*******************************************************************************/
+int ad7091r8_init(struct ad7091r8_dev **device,
+		  struct ad7091r8_init_param *init_param)
+{
+	struct ad7091r8_dev *dev;
+	int ret;
+
+	if (!device)
+		return -EINVAL;
+
+	dev = (struct ad7091r8_dev *)no_os_calloc(1, sizeof(*dev));
+	if (!dev)
+		return -ENOMEM;
+
+	ret = no_os_spi_init(&dev->spi_desc, init_param->spi_init);
+	if (ret)
+		goto err_free_dev;
+
+	dev->device_id = init_param->device_id;
+
+	ret = no_os_gpio_get(&dev->gpio_convst, init_param->gpio_convst);
+	if (ret)
+		goto err_release_spi;
+
+	ret = no_os_gpio_direction_output(dev->gpio_convst, NO_OS_GPIO_HIGH);
+	if (ret)
+		goto err_release_convst;
+
+	ret = no_os_gpio_get_optional(&dev->gpio_reset, init_param->gpio_reset);
+	if (!ret && dev->gpio_reset) {
+		ret = no_os_gpio_direction_output(dev->gpio_reset,
+						  NO_OS_GPIO_HIGH);
+		if (ret)
+			goto err_release_reset;
+	}
+
+	ret = ad7091r8_reset(dev, !dev->gpio_reset);
+	if (ret)
+		goto err_release_reset;
+
+	/* Use external vref or enable internal vref */
+	dev->vref_mv = init_param->vref_mv;
+	if (!dev->vref_mv) {
+		dev->vref_mv = 2500;
+		ret = ad7091r8_set_sleep_mode(dev, AD7091R8_SLEEP_MODE_1);
+		if (ret)
+			goto err_release_reset;
+	}
+
+	/* Device powers-up in normal mode */
+	*device = dev;
+
+	return 0;
+
+err_release_reset:
+	no_os_gpio_remove(dev->gpio_reset);
+
+err_release_convst:
+	no_os_gpio_remove(dev->gpio_convst);
+
+err_release_spi:
+	no_os_spi_remove(dev->spi_desc);
+
+err_free_dev:
+	no_os_free(dev);
+	return ret;
+}
+
+/***************************************************************************//**
+ * @brief Free the resources allocated by ad7091r8_init().
+ *
+ * @param dev - The device structure.
+ *
+ * @return ret - The result of the remove procedure.
+*******************************************************************************/
+int ad7091r8_remove(struct ad7091r8_dev *dev)
+{
+	int ret;
+
+	ret = no_os_gpio_remove(dev->gpio_reset);
+	if (ret)
+		return ret;
+
+	ret = no_os_gpio_remove(dev->gpio_convst);
+	if (ret)
+		return ret;
+
+	ret = no_os_spi_remove(dev->spi_desc);
+	if (ret)
+		return ret;
+
+	no_os_free(dev);
+	return 0;
+}
+
+/**
+ * Set device channel.
+ * @param dev - The device structure.
+ * @param channel - Channel.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad7091r8_set_channel(struct ad7091r8_dev *dev, uint8_t channel)
+{
+	int ret;
+
+	if (!dev)
+		return -EINVAL;
+
+	if (channel >= AD7091R_NUM_CHANNELS(dev->device_id))
+		return -EINVAL;
+
+	ret = ad7091r8_pulse_convst(dev);
+	if (ret)
+		return ret;
+
+	return ad7091r8_spi_reg_write(dev, AD7091R8_REG_CHANNEL,
+				      NO_OS_BIT(channel));
+}
+
+/**
+ * Read one sample.
+ * @param dev - The device structure.
+ * @param channel - Channel.
+ * @param read_val - Value.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad7091r8_read_one(struct ad7091r8_dev *dev, uint8_t channel,
+		      uint16_t *read_val)
+{
+	int ret;
+
+	if (!dev || !read_val)
+		return -EINVAL;
+
+	if (channel >= AD7091R_NUM_CHANNELS(dev->device_id))
+		return -EINVAL;
+
+	ret = ad7091r8_set_channel(dev, channel);
+	if (ret)
+		return ret;
+
+	return ad7091r8_spi_reg_read(dev, AD7091R8_REG_RESULT, read_val);
+}
+
+/**
+ * Read the next channel set in the channel sequencer (channel register).
+ * @param dev - The device structure.
+ * @param read_val - Value.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad7091r8_sequenced_read(struct ad7091r8_dev *dev, uint16_t *read_val)
+{
+
+	uint8_t buf[2];
+	int ret;
+
+	if (!dev)
+		return -EINVAL;
+
+	ret = ad7091r8_pulse_convst(dev);
+	if (ret)
+		return ret;
+
+	no_os_put_unaligned_be16(0xf800, buf); /* NOP command */
+
+	ret = no_os_spi_write_and_read(dev->spi_desc, buf, 2);
+	if (ret)
+		return ret;
+
+	*read_val = no_os_get_unaligned_be16(buf);
+	return 0;
+}

--- a/drivers/adc/ad7091r8/ad7091r8.h
+++ b/drivers/adc/ad7091r8/ad7091r8.h
@@ -1,0 +1,267 @@
+/***************************************************************************//**
+ *   @file   ad7091r8.h
+ *   @brief  Implementation of AD7091R-8 driver header file.
+ *   @author Marcelo Schmitt (marcelo.schmitt@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef __AD7091R8_H__
+#define __AD7091R8_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdbool.h>
+
+#include "no_os_spi.h"
+#include "no_os_gpio.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+#define AD7091R_NUM_CHANNELS(id)	(1 << ((id) + 1))
+#define AD7091R8_BITS			12
+
+#define AD7091R8_CONV_MASK		NO_OS_GENMASK(AD7091R8_BITS - 1, 0)
+
+/* AD7091r8 registers */
+#define AD7091R8_REG_RESULT		0x00
+#define AD7091R8_REG_CHANNEL		0x01
+#define AD7091R8_REG_CONF		0x02
+#define AD7091R8_REG_ALERT		0x03
+#define AD7091R8_REG_CH_LOW_LIMIT(ch)	((ch) * 3 + 4)
+#define AD7091R8_REG_CH_HIGH_LIMIT(ch)	((ch) * 3 + 5)
+#define AD7091R8_REG_CH_HYSTERESIS(ch)	((ch) * 3 + 6)
+
+/* AD7091R8_REG_RESULT */
+#define AD7091R8_REG_RESULT_DATA_MASK	NO_OS_GENMASK(11, 0)
+#define AD7091R8_REG_RESULT_ALT_MASK	NO_OS_BIT(12)
+#define AD7091R8_REG_RESULT_CH_ID_MASK	NO_OS_GENMASK(15, 13)
+
+/* AD7091R8_REG_CONF */
+#define REG_CONF_SLEEP_MODE_MASK	NO_OS_GENMASK(1, 0)
+#define REG_CONF_GPO1_MASK		NO_OS_BIT(2)
+#define REG_CONF_GPO0_MASK		NO_OS_BIT(3)
+#define REG_CONF_GPO0_MODE_MASK		NO_OS_GENMASK(6, 4)
+#define REG_CONF_ALERT_STICKY_MASK	NO_OS_BIT(7)
+#define REG_CONF_RESET_MASK		NO_OS_BIT(9)
+
+/* AD7091R8_REG_ALERT */
+#define REG_ALERT_MASK(x, ch)		(x >> (ch * 2))
+
+/* AD7091R8 read/write protocol masks */
+#define AD7091R8_REG_DATA_MSK		NO_OS_GENMASK(9, 0)
+#define AD7091R8_RD_WR_FLAG_MSK		NO_OS_BIT(10)
+#define AD7091R8_REG_ADDR_MSK		NO_OS_GENMASK(15, 11)
+
+/*****************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+enum ad7091r8_device_id {
+	AD7091R2,
+	AD7091R4,
+	AD7091R8,
+};
+
+static char * const ad7091r8_names[] = {
+	[AD7091R2] = "ad7091r-2",
+	[AD7091R4] = "ad7091r-4",
+	[AD7091R8] = "ad7091r-8",
+};
+
+/**
+ * @enum ad7091r8_sleep_mode
+ * @brief Converter supported sleep modes
+ */
+enum ad7091r8_sleep_mode {
+	/** Default operation:
+	 * Sleep mode Off, Internal reference Off */
+	AD7091R8_SLEEP_MODE_0,
+	/** Sleep mode Off, Internal reference On */
+	AD7091R8_SLEEP_MODE_1,
+	/** Sleep mode On, Internal reference Off */
+	AD7091R8_SLEEP_MODE_2,
+	/** Sleep mode On, Internal reference On */
+	AD7091R8_SLEEP_MODE_3,
+};
+
+/**
+ * @enum ad7091r8_port
+ * @brief Converter general purpose outputs
+ */
+enum ad7091r8_port {
+	/** GPO0 */
+	AD7091R8_GPO0,
+	/** GPO1 */
+	AD7091R8_GPO1,
+};
+
+/**
+ * @enum ad7091r8_gpo0_mode
+ * @brief Port 0 configuration
+ */
+enum ad7091r8_gpo0_mode {
+	/** GPO0 is output port */
+	AD7091R8_GPO0_ENABLED = 0,
+	/** GPO0 is Alert indicator */
+	AD7091R8_GPO0_ALERT = 16,
+	/** GPO0 is busy indicator, device is converting */
+	AD7091R8_GPO0_BUSY = 48,
+};
+
+/**
+ * @enum ad7091r8_limit
+ * @brief Limit type
+ */
+enum ad7091r8_limit {
+	/** Low limit */
+	AD7091R8_LOW_LIMIT,
+	/** High limit */
+	AD7091R8_HIGH_LIMIT,
+	/** Hysteresis */
+	AD7091R8_HYSTERESIS,
+};
+
+/**
+ * @enum ad7091r8_alert_type
+ * @brief Alert status
+ */
+enum ad7091r8_alert_type {
+	/** No alert */
+	AD7091R8_NO_ALERT,
+	/** High alert */
+	AD7091R8_HIGH_ALERT,
+	/** Low alert */
+	AD7091R8_LOW_ALERT,
+};
+
+struct ad7091r8_dev {
+	/** SPI descriptor **/
+	//spi_desc *spi_desc;
+	struct no_os_spi_desc *spi_desc;
+	/* Reference voltage */
+	int vref_mv;
+	/* CONVST GPIO handler */
+	struct no_os_gpio_desc *gpio_convst;
+	/** RESET GPIO handler. */
+	struct no_os_gpio_desc	*gpio_reset;
+	/** ALERT GPIO handler. */
+	struct no_os_gpio_desc	*gpio_alert;
+	/* AD7091R specific device identifier */
+	enum ad7091r8_device_id device_id;
+};
+
+struct ad7091r8_init_param {
+	/* SPI initialization parameters */
+	struct no_os_spi_init_param *spi_init;
+	/* External Voltage Reference */
+	int vref_mv;
+	/* CONVST GPIO initialization parameters */
+	struct no_os_gpio_init_param *gpio_convst;
+	/* Reset GPIO initialization parameters */
+	struct no_os_gpio_init_param *gpio_reset;
+	/* Alert GPIO initialization parameters */
+	struct no_os_gpio_init_param *gpio_alert;
+	/* AD7091R specific device identifier */
+	enum ad7091r8_device_id device_id;
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+/* Initialize the device. */
+int ad7091r8_init(struct ad7091r8_dev **device,
+		  struct ad7091r8_init_param *init_param);
+
+/* Remove the device and release resources. */
+int ad7091r8_remove(struct ad7091r8_dev *dev);
+
+/* Set device sleep mode */
+int ad7091r8_set_sleep_mode(struct ad7091r8_dev *dev,
+			    enum ad7091r8_sleep_mode mode);
+
+/* Set device set port value */
+int ad7091r8_set_port(struct ad7091r8_dev *dev,
+		      enum ad7091r8_port port,
+		      bool value);
+
+/* Set device set GPO0 mode */
+int ad7091r8_set_gpo0_mode(struct ad7091r8_dev *dev,
+			   enum ad7091r8_gpo0_mode mode,
+			   bool is_cmos);
+
+/* Set high limit, low limit, hysteresis. */
+int ad7091r8_set_limit(struct ad7091r8_dev *dev,
+		       enum ad7091r8_limit limit,
+		       uint8_t channel,
+		       uint16_t value);
+
+/* Get alert. */
+int ad7091r8_get_alert(struct ad7091r8_dev *dev,
+		       uint8_t channel,
+		       enum ad7091r8_alert_type *alert);
+
+/* Get high limit, low limit, hysteresis. */
+int ad7091r8_get_limit(struct ad7091r8_dev *dev,
+		       enum ad7091r8_limit limit,
+		       uint8_t channel,
+		       uint16_t *value);
+
+/* Select device channel. */
+int ad7091r8_set_channel(struct ad7091r8_dev *dev,
+			 uint8_t channel);
+
+/* Read one sample. */
+int ad7091r8_read_one(struct ad7091r8_dev *dev,
+		      uint8_t chan,
+		      uint16_t *read_val);
+
+/* Read next channel set in the channel sequencer. */
+int ad7091r8_sequenced_read(struct ad7091r8_dev *dev,
+			    uint16_t *read_val);
+
+/* Read device register. */
+int ad7091r8_spi_reg_read(struct ad7091r8_dev *dev,
+			  uint8_t reg_addr,
+			  uint16_t *reg_data);
+
+/* Write to device register. */
+int ad7091r8_spi_reg_write(struct ad7091r8_dev *dev,
+			   uint8_t reg_addr,
+			   uint16_t reg_data);
+
+int ad7091r8_pulse_convst(struct ad7091r8_dev *dev);
+
+#endif // __AD7091R8_H__

--- a/drivers/adc/ad7091r8/iio_ad7091r8.c
+++ b/drivers/adc/ad7091r8/iio_ad7091r8.c
@@ -1,0 +1,368 @@
+/***************************************************************************//**
+ *   @file   iio_ad7091r8.c
+ *   @brief  Implementation of IIO AD7091R8 Driver.
+ *   @author Marcelo Schmitt (marcelo.schmitt@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdlib.h>
+#include <stdio.h>
+#include "no_os_error.h"
+#include "no_os_util.h"
+#include "iio_ad7091r8.h"
+#include "ad7091r8.h"
+#include "no_os_units.h"
+#include "no_os_alloc.h"
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+static int ad7091r8_iio_read_reg(struct ad7091r8_iio_dev *dev, uint32_t reg,
+				 uint32_t *readval);
+static int ad7091r8_iio_write_reg(struct ad7091r8_iio_dev *dev, uint32_t reg,
+				  uint32_t writeval);
+static int ad7091r8_iio_read_raw(void *dev, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel, intptr_t priv);
+static int ad7091r8_iio_read_scale(void *dev, char *buf, uint32_t len,
+				   const struct iio_ch_info *channel, intptr_t priv);
+static int ad7091r8_buffer_preenable(void* dev, uint32_t mask);
+static int32_t ad7091r8_trigger_handler(struct iio_device_data *iio_dev_data);
+
+/******************************************************************************/
+/************************ Variable Declarations ******************************/
+/******************************************************************************/
+static struct iio_attribute ad7091r8_iio_attrs[] = {
+	{
+		.name = "raw",
+		.show = ad7091r8_iio_read_raw,
+	},
+	{
+		.name   = "scale",
+		.shared = IIO_SHARED_BY_TYPE,
+		.show   = ad7091r8_iio_read_scale,
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct scan_type ad7091r8_iio_scan_type = {
+	.sign = 'u',
+	.realbits = 12,
+	.storagebits = 16,
+	.shift = 0,
+	.is_big_endian = false
+};
+
+#define AD7091R8_CHANNEL(index) {			\
+	.ch_type = IIO_VOLTAGE,				\
+	.indexed = 1,					\
+	.channel = index,				\
+	.scan_type = &ad7091r8_iio_scan_type,		\
+	.scan_index = index,				\
+	.attributes = ad7091r8_iio_attrs,		\
+	.ch_out = false					\
+}
+
+static struct iio_channel ad7091r2_channels[] = {
+	AD7091R8_CHANNEL(0),
+	AD7091R8_CHANNEL(1),
+};
+
+static struct iio_channel ad7091r4_channels[] = {
+	AD7091R8_CHANNEL(0),
+	AD7091R8_CHANNEL(1),
+	AD7091R8_CHANNEL(2),
+	AD7091R8_CHANNEL(3),
+};
+
+static struct iio_channel ad7091r8_channels[] = {
+	AD7091R8_CHANNEL(0),
+	AD7091R8_CHANNEL(1),
+	AD7091R8_CHANNEL(2),
+	AD7091R8_CHANNEL(3),
+	AD7091R8_CHANNEL(4),
+	AD7091R8_CHANNEL(5),
+	AD7091R8_CHANNEL(6),
+	AD7091R8_CHANNEL(7),
+};
+
+static struct iio_device ad7091r2_iio_device = ad7091r8_iio_device(
+			ad7091r2_channels);
+static struct iio_device ad7091r4_iio_device = ad7091r8_iio_device(
+			ad7091r4_channels);
+static struct iio_device ad7091r8_iio_device = ad7091r8_iio_device(
+			ad7091r8_channels);
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+static int ad7091r8_iio_read_reg(struct ad7091r8_iio_dev *dev, uint32_t reg,
+				 uint32_t *readval)
+{
+	uint16_t read_data;
+	int ret;
+
+	return ad7091r8_spi_reg_read(dev->ad7091r8_dev, reg, &read_data);
+	if (ret)
+		return ret;
+
+	*readval = read_data;
+	return 0;
+}
+
+static int ad7091r8_iio_write_reg(struct ad7091r8_iio_dev *dev, uint32_t reg,
+				  uint32_t writeval)
+{
+	return ad7091r8_spi_reg_write(dev->ad7091r8_dev, reg, writeval);
+}
+
+/***************************************************************************//**
+ * @brief Handles the read request for raw attribute.
+ *
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ *
+ * @return ret    - Result of the reading procedure.
+ *		    In case of success, the size of the read data is returned.
+*******************************************************************************/
+static int ad7091r8_iio_read_raw(void *dev, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct ad7091r8_iio_dev *iio_ad7091r8;
+	struct ad7091r8_dev *ad7091r8_dev;
+	int32_t read_val_32;
+	uint16_t read_val;
+	int ret;
+
+	if (!dev)
+		return -EINVAL;
+
+	iio_ad7091r8 = (struct ad7091r8_iio_dev *)dev;
+	ad7091r8_dev = iio_ad7091r8->ad7091r8_dev;
+	ret = ad7091r8_read_one(ad7091r8_dev, channel->ch_num, &read_val);
+	if (ret)
+		return ret;
+
+	if ((int16_t)no_os_field_get(AD7091R8_REG_RESULT_CH_ID_MASK, read_val)
+	    != channel->ch_num)
+		return -EIO;
+
+	read_val_32 = no_os_field_get(AD7091R8_REG_RESULT_DATA_MASK, read_val);
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, &read_val_32);
+}
+
+/***************************************************************************//**
+ * @brief Handles the read request for scale attribute.
+ *
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ *
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*******************************************************************************/
+static int ad7091r8_iio_read_scale(void *dev, char *buf, uint32_t len,
+				   const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct ad7091r8_iio_dev *iio_ad7091r8;
+	struct ad7091r8_dev *ad7091r8_dev;
+	int32_t vals[2];
+
+	if (!dev)
+		return -EINVAL;
+
+	iio_ad7091r8 = (struct ad7091r8_iio_dev *)dev;
+	ad7091r8_dev = iio_ad7091r8->ad7091r8_dev;
+	vals[0] = ad7091r8_dev->vref_mv;
+	vals[1] = 12;
+	return iio_format_value(buf, len, IIO_VAL_FRACTIONAL_LOG2, 2, vals);
+}
+
+/***************************************************************************//**
+ * @brief Prepares the device for buffered capture mode.
+ *
+ * @param dev     - The iio device structure.
+ * @param mask    - Mask of enabled/disabled channels.
+ *
+ * @return ret    - Result of the pre enable setup.
+ * 		    Zero in case of success, errno otherwise.
+*******************************************************************************/
+static int ad7091r8_buffer_preenable(void* dev, uint32_t mask)
+{
+	struct ad7091r8_iio_dev *iio_ad7091r8;
+	struct ad7091r8_dev *ad7091r8;
+	uint16_t dummy;
+	int ret;
+
+	if (!dev)
+		return -ENODEV;
+
+	iio_ad7091r8 = dev;
+	ad7091r8 = iio_ad7091r8->ad7091r8_dev;
+
+	/* Dummy read cycle to pulse CONVST */
+	ret = ad7091r8_pulse_convst(ad7091r8);
+	if (ret)
+		return ret;
+
+	/* Set enabled channels in the channel register */
+	ret = ad7091r8_spi_reg_write(ad7091r8, AD7091R8_REG_CHANNEL, mask);
+	if (ret)
+		return ret;
+
+	/* Dummy read cycle to let the conversion sequence get updated */
+	return ad7091r8_sequenced_read(ad7091r8, &dummy);
+}
+
+/***************************************************************************//**
+ * @brief Prepares the device for buffered capture mode.
+ *
+ * @param iio_dev_data    - Object with pointers to ad7091r8_iio_dev and buffer.
+ *
+ * @return ret            - Result of the trigger handler routine.
+ * 		            Zero in case of success, errno otherwise.
+*******************************************************************************/
+static int32_t ad7091r8_trigger_handler(struct iio_device_data *iio_dev_data)
+{
+	struct ad7091r8_iio_dev *iio_ad7091r8;
+	struct ad7091r8_dev *ad7091r8;
+	uint16_t data_buff[8]; /* Data buffer to store one sample-set. */
+	uint16_t read_val;
+	int i, k = 0;
+	int ret;
+
+	if (!iio_dev_data)
+		return -EINVAL;
+
+	iio_ad7091r8 = (struct ad7091r8_iio_dev *)iio_dev_data->dev;
+
+	if (!iio_ad7091r8)
+		return -EINVAL;
+
+	ad7091r8 = iio_ad7091r8->ad7091r8_dev;
+
+	/* For each enabled channel do a sequenced read and push result to buff */
+	for (i = 0; i < AD7091R_NUM_CHANNELS(ad7091r8->device_id); i++) {
+		if (iio_dev_data->buffer->active_mask & NO_OS_BIT(i)) {
+			ret = ad7091r8_sequenced_read(ad7091r8, &read_val);
+			if (ret)
+				return ret;
+
+			data_buff[k++] = read_val;
+		}
+	}
+
+	return iio_buffer_push_scan(iio_dev_data->buffer, data_buff);
+}
+
+/***************************************************************************//**
+ * @brief Initializes the AD7091R8 IIO driver
+ *
+ * @param iio_dev    - The iio device structure.
+ * @param init_param - The structure that contains the device initial
+ * 		       		   parameters.
+ *
+ * @return ret       - Result of the initialization procedure.
+*******************************************************************************/
+int ad7091r8_iio_init(struct ad7091r8_iio_dev **iio_dev,
+		      struct ad7091r8_iio_dev_init_param *init_param)
+{
+	int ret;
+	struct ad7091r8_iio_dev *desc;
+
+	if (!init_param || !init_param->ad7091r8_dev_init)
+		return -EINVAL;
+
+	desc = (struct ad7091r8_iio_dev *)no_os_calloc(1, sizeof(*desc));
+	if (!desc)
+		return -ENOMEM;
+
+	switch (init_param->ad7091r8_dev_init->device_id) {
+	case AD7091R2:
+		desc->iio_dev = &ad7091r2_iio_device;
+		break;
+	case AD7091R4:
+		desc->iio_dev = &ad7091r4_iio_device;
+		break;
+	case AD7091R8:
+		desc->iio_dev = &ad7091r8_iio_device;
+		break;
+	default:
+		ret = -EINVAL;
+		goto error_ad7091r8_init;
+	}
+
+	// Initialize ad7091r8 driver
+	ret = ad7091r8_init(&desc->ad7091r8_dev, init_param->ad7091r8_dev_init);
+	if (ret)
+		goto error_ad7091r8_init;
+
+	*iio_dev = desc;
+
+	return 0;
+
+error_ad7091r8_init:
+	no_os_free(desc);
+	return ret;
+}
+
+/***************************************************************************//**
+ * @brief Free the resources allocated by ad7091r8_iio_init().
+ *
+ * @param desc - The IIO device structure.
+ *
+ * @return ret - Result of the remove procedure.
+*******************************************************************************/
+int ad7091r8_iio_remove(struct ad7091r8_iio_dev *desc)
+{
+	int ret;
+
+	ret = ad7091r8_remove(desc->ad7091r8_dev);
+	if (ret)
+		return ret;
+
+	no_os_free(desc);
+
+	return 0;
+}

--- a/drivers/adc/ad7091r8/iio_ad7091r8.h
+++ b/drivers/adc/ad7091r8/iio_ad7091r8.h
@@ -1,0 +1,89 @@
+/***************************************************************************//**
+ *   @file   iio_ad7091r8.h
+ *   @brief  Header file of IIO AD7091R8 driver header file.
+ *   @author Marcelo Schmitt (marcelo.schmitt@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef IIO_AD7091R8_H
+#define IIO_AD7091R8_H
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "iio.h"
+
+/******************************************************************************/
+/***************************** Define Section *********************************/
+/******************************************************************************/
+#define ad7091r8_iio_device(chans) {					\
+	.num_ch = NO_OS_ARRAY_SIZE(chans),				\
+	.channels = chans,						\
+	.pre_enable = (int32_t (*)())ad7091r8_buffer_preenable,		\
+	.trigger_handler = (int32_t (*)())ad7091r8_trigger_handler,	\
+	.debug_reg_read = (int32_t (*)())ad7091r8_iio_read_reg,		\
+	.debug_reg_write = (int32_t (*)())ad7091r8_iio_write_reg	\
+}
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+extern struct iio_trigger ad7091r8_iio_timer_trig_desc;
+
+/** @struct ad7091r8_iio_dev
+ *  @brief AD7091r8 IIO device descriptor structure
+ */
+struct ad7091r8_iio_dev {
+	struct ad7091r8_dev *ad7091r8_dev;
+	struct iio_device *iio_dev;
+};
+
+/** @struct ad7091r8_iio_dev_init_param
+ *  @brief AD7091r8 IIO device initial parameters structure
+ */
+struct ad7091r8_iio_dev_init_param {
+	struct ad7091r8_init_param *ad7091r8_dev_init;
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+/*! Function to be called to initialize a AD7091R-2/-4/-8 device. */
+int ad7091r8_iio_init(struct ad7091r8_iio_dev **iio_dev,
+		      struct ad7091r8_iio_dev_init_param *init_param);
+
+/*! Function to be called to remove a AD7091R-2/-4/-8 device. */
+int ad7091r8_iio_remove(struct ad7091r8_iio_dev *desc);
+
+#endif /** IIO_AD7091R8_H */

--- a/drivers/adc/ad7091r8/iio_ad7091r8_trig.c
+++ b/drivers/adc/ad7091r8/iio_ad7091r8_trig.c
@@ -1,0 +1,59 @@
+/***************************************************************************//**
+ *   @file   iio_ad7091r8_trig.c
+ *   @brief  Implementation of iio_ad7091r8_trig.c
+ *   @author Marcelo Schmitt (marcelo.schmitt@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdlib.h>
+#include <string.h>
+#include "no_os_error.h"
+#include "iio.h"
+#include "iio_trigger.h"
+#include "iio_ad7091r8.h"
+
+/******************************************************************************/
+/************************ Variable Declarations *******************************/
+/******************************************************************************/
+#ifndef LINUX_PLATFORM
+struct iio_trigger ad7091r8_iio_timer_trig_desc = {
+	.is_synchronous = true,
+	.enable = iio_trig_enable,
+	.disable = iio_trig_disable,
+};
+#endif

--- a/projects/ad7091r8-sdz/Makefile
+++ b/projects/ad7091r8-sdz/Makefile
@@ -1,0 +1,23 @@
+# Targeted for Maxim MAX78000FTHR
+include ../../tools/scripts/generic_variables.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk
+
+# To choose the example at compile time, build with `make <EXAMPLE_NAME=y>`.
+# For instance, build with `make BASIC_EXAMPLE=y` to choose the BASIC_EXAMPLE.
+
+# Force select an example by assigning y for enabling.
+#BASIC_EXAMPLE = y
+
+# Force select an example by assigning y for enabling.
+# IIO_EXAMPLE = y
+
+# Force select an example by assigning y for enabling.
+# IIO_TIMER_TRIGGER_EXAMPLE = y
+
+# Select the device you want to enable by choosing y for enabling and n for disabling
+# AD7091R2 = y
+# AD7091R4 = y
+AD7091R8 = y

--- a/projects/ad7091r8-sdz/README.rst
+++ b/projects/ad7091r8-sdz/README.rst
@@ -1,0 +1,265 @@
+Evaluating AD7091R-2/-4/-8 Devices
+==================================
+
+
+Contents
+--------
+
+.. contents:: Table of Contents
+    :depth: 3
+
+Supported Devices
+-----------------
+
+* `AD7091R-2 <https://www.analog.com/AD7091R-2>`_
+* `AD7091R-4 <https://www.analog.com/AD7091R-4>`_
+* `AD7091R-8 <https://www.analog.com/AD7091R-8>`_
+
+Supported Evaluation Boards
+---------------------------
+
+* `EVAL-AD7091R-xSDZ <https://www.analog.com/eval-ad7091r-xsdz>`_
+
+Overview
+--------
+
+The ad7091r-2, ad7091r-4, and AD7091r-8 are 2-/4-/8-channel, ultra low power
+power dissipation, successive approximation register (SAR) analog-to-digital
+converter (ADC). The AD7091R-2/-4/-8 ADCs are multichannel versions of AD7091r.
+The AD7091R-2/AD7091R-4/AD7091R-8 operates from a single 2.7 V to 5.25 V power
+supply.
+
+See complementary documentation at
+https://wiki.analog.com/resources/tools-software/uc-drivers/ad7091r8.
+
+Hardware Specifications
+-----------------------
+
+Use the test points for interfacing the EVAL-AD7091R-xSDZ with the microcontroller.
+
+The instructions below describe how to set up EVAL-AD7091R-xSDZ_ with MAX78000FTHR_.
+
+The evaluation board default configuration is intended to work with
+EVAL-SDP-CB1Z_ so it must be adapted to connect to a different platform.
+
+
+**EVAL Board Jumper Links**
+
+For the jumper links, use the following configuration:
+
++------+---------------+
+| Link | Link Position |
++------+---------------+
+| LK1  |      B        |
++------+---------------+
+| LK2  |      B        |
++------+---------------+
+| LK3  |      B        |
++------+---------------+
+| LK8  |      A        |
++------+---------------+
+| LK9  |      B        |
++------+---------------+
+| LK11 |      A        |
++------+---------------+
+
+**EVAL Board Soldering Links**
+
+Use a soldering iron to change a few soldering links.
+
+  * Unsolder R126 (enable drive CS through CS test point)
+  * Unsolder R127 (enable drive SDI through SDI test point)
+  * Unsolder R128 (enable drive CONVST through CONVST test point)
+  * Unsolder SL19 (enable drive SCLK through SCLK test point)
+  * Unsolder SL20 (enable drive SDO through SDO test point)
+  * Power VDD and Vdrive supplied with MAX78000FTHR_ 3.3V pins.
+  * Solder R68 points together (enable drive the RESET pin through RESET test point)
+  * Unsolder LK13 and LK14 from position A and solder them in position C (tie MUX_OUT with ADC_IN).
+  * Unsolder SL09 and SL10 from position A and solder each of them to position B to allow the VIN7 signal to bypass the input buffer.
+
+
+.. _EVAL-AD7091R-xSDZ: https://www.analog.com/eval-ad7091r-xsdz
+.. _MAX78000FTHR: https://www.analog.com/en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/max78000fthr.html
+.. _EVAL-SDP-CB1Z: https://www.analog.com/en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/SDP-B.html
+
+
+No-OS Build Setup
+-----------------
+
+Please see: https://wiki.analog.com/resources/no-os/build
+
+No-OS Supported Examples
+------------------------
+
+The initialization data used in the examples is taken out from:
+`Project Common Data Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ad7091r8-sdz/src/common>`_
+
+The macros used in Common Data are defined in platform specific files found in:
+`Project Platform Configuration Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ad7091r8-sdz/src/platform>`_
+
+Basic example
+^^^^^^^^^^^^^
+
+This is a simple example which initializes the ad7091r-2/-4/-8 selected device
+and performs analog to digital conversions in a while loop with a period of 1s.
+The data is printed on the serial interface.
+
+In order to build the basic example project, add the following configuration in
+`Makefile <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ad7091r8-sdz/Makefile>`_
+
+.. code-block:: bash
+
+        # Force select an example by assigning y for enabling.
+        BASIC_EXAMPLE = y
+
+Alternatively, one can set the desired example flag when calling the compiler to
+make it build the project with the specified example.
+
+.. code-block:: bash
+
+        # Builds the project's basic example.
+        make BASIC_EXAMPLE=y
+
+IIO example
+^^^^^^^^^^^
+
+This project is actually a IIOD demo for EVAL-AD7091R-xSDZ device series.
+The project launches a IIOD server on the board so that the user may connect
+to it via an IIO client running in the microcontroller.
+Using IIO-Oscilloscope, the user can configure the ADC and view the measured
+data in the Digital Multi Meter tab (DMM).
+
+If you are not familiar with ADI IIO Application, please take a look at:
+`IIO No-OS <https://wiki.analog.com/resources/tools-software/no-os-software/iio>`_
+
+If you are not familiar with ADI IIO-Oscilloscope Client, please take a look at:
+`IIO Oscilloscope <https://wiki.analog.com/resources/tools-software/linux-software/iio_oscilloscope>`_
+
+The No-OS IIO Application together with the No-OS IIO ad7091r8 driver take care of
+all the back-end logic needed to setup the IIO server.
+
+This example initializes the IIO device and calls the IIO app as shown in:
+`IIO Example <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ad7091r8-sdz/src/examples/iio_example>`_
+
+This example supports single-shot ADC readings. At each read request, the
+ad7091r8 driver writes to the channel register (address 0x01) to set the desired
+channel for conversion, does a dummy conversion to allow the channel sequencer
+to update, then does the another conversion to get the date for the requested
+channel. Before every transfer during an ADC read procedure, the CONVST line is
+pulsed either to update the channel sequencer or to trigger an actual ADC read.
+The CONVST pin is not pulsed if only reading or writing to configuration
+registers.
+
+In order to build the IIO project make sure you have the following configuration in the
+`Makefile <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ad7091r8-sdz/Makefile>`_
+
+.. code-block:: bash
+
+        # Select the example you want to enable by choosing y for enabling and n for disabling
+        BASIC_EXAMPLE = n
+        IIO_EXAMPLE = y
+
+Alternatively, one can set the desired example flag when calling the compiler to
+make it build the project with the specified example.
+
+.. code-block:: bash
+
+        # Builds the project with a simple IIO example.
+        make IIO_EXAMPLE=y
+
+
+IIO timer trigger example
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This example extends the IIO example by enabling faster data capture rates
+triggered by a hardware timer.
+
+Using IIO-Oscilloscope, the user can configure the ADC and view the measured
+data on a plot.
+
+The captures happen at a predefined sample rate which is defined by the timer
+configuration at build time. The timer settings can be modified to reach slower
+or faster sample rates.
+
+The initialization data used in the timer is taken out from platform parameter
+files under subdirectories of
+`Project Platform Configuration Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ad7091r8-sdz/src/platform>`_
+
+The initialization of IIO device, buffer, and IIO app is done in:
+`IIO Timer Trigger Example <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ad7091r8-sdz/src/examples/iio_timer_trigger_example>`_
+
+The hardware timer periodically triggers an interrupt that runs a callback
+function. That callback function calls the IIO app which in turn calls the
+trigger handler in the ad7091r8 driver. The ad7091r8 trigger handler then runs
+the ADC to get samples from each enabled channel and pushed the data to a buffer
+which is latter delivered to the application.
+
+In order to build the IIO project make sure you have the following configuration in the
+`Makefile <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ad7091r8-sdz/Makefile>`_
+
+.. code-block:: bash
+
+        # Select the example you want to enable by choosing y for enabling and n for disabling
+        BASIC_EXAMPLE = n
+        IIO_TIMER_TRIGGER_EXAMPLE = y
+
+Alternatively, one can set the desired example flag when calling the compiler to
+make it build the project with the specified example.
+
+.. code-block:: bash
+
+        # Builds the project with an IIO example supporting buffered captures.
+        make IIO_TIMER_TRIGGER_EXAMPLE=y
+
+No-OS Supported Platforms
+-------------------------
+
+Maxim Platform
+^^^^^^^^^^^^^^
+
+**Used hardware**:
+
+* `EVAL-AD7091R-xSDZ <https://www.analog.com/eval-ad7091r-xsdz>`_ with
+* `MAX78000FTHR <https://www.analog.com/en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/max78000fthr.html>`_
+
+**EVAL Board and Microcontroller Connections**
+
+There are a number of connections to make between the ADC evaluation board and the microcontroller.
+
++-------------------------------+-------------------------------+-----------------------------------------+
+| EVAL-AD7091R-xSDZ_ test point | Pin Function                  | MAX78000FTHR_ Pin function (Pin number) |
++-------------------------------+-------------------------------+-----------------------------------------+
+| CS                            | Chip Select                   |          SS0     (P0_11)                |
++-------------------------------+-------------------------------+-----------------------------------------+
+| SCLK                          | Serial Clock                  |          SCLK    (P0_7)                 |
++-------------------------------+-------------------------------+-----------------------------------------+
+| SDO                           | Serial Data Out               |          MISO    (P0_6)                 |
++-------------------------------+-------------------------------+-----------------------------------------+
+| SDI                           | Serial Data In                |          MOSI    (P0_5)                 |
++-------------------------------+-------------------------------+-----------------------------------------+
+| RESET                         | ADC Reset                     |          GPIO    (P0_19)                |
++-------------------------------+-------------------------------+-----------------------------------------+
+| CONVST                        | Conversion Start Signal       |          GPIO    (P1_6)                 |
++-------------------------------+-------------------------------+-----------------------------------------+
+| VDRIVE (J4)                   | Digital Supply Voltage Input  |          3.3V    (pin 2)                |
++-------------------------------+-------------------------------+-----------------------------------------+
+| GND    (J4)                   | Digital Supply Voltage Ground |          GND     (pin 4)                |
++-------------------------------+-------------------------------+-----------------------------------------+
+| VDD (J9)                      | Power Supply Input            |          3.3V    (pin 2)                |
++-------------------------------+-------------------------------+-----------------------------------------+
+| GND (J9)                      | Power Supply Ground           |          GND     (pin 4)                |
++-------------------------------+-------------------------------+-----------------------------------------+
+
+**Build Command**
+
+.. code-block:: bash
+
+        # to delete current build
+        make reset
+        # to build the project
+        make PLATFORM=maxim TARGET=max78000
+        # to flash the code
+        make run
+        # to debug the code
+        make debug
+

--- a/projects/ad7091r8-sdz/builds.json
+++ b/projects/ad7091r8-sdz/builds.json
@@ -1,0 +1,25 @@
+{
+    "maxim": {
+        "basic_example_max78000_ad7091r8": {
+            "flags" : "BASIC_EXAMPLE=y IIO_EXAMPLE=n IIO_TIMER_TRIGGER_EXAMPLE=n TARGET=max78000 AD7091R8=y"
+        },
+        "iio_example_max78000_ad7091r2": {
+            "flags" : "BASIC_EXAMPLE=n IIO_EXAMPLE=y IIO_TIMER_TRIGGER_EXAMPLE=n TARGET=max78000 AD7091R2=y"
+        },
+        "iio_example_max78000_ad7091r8": {
+            "flags" : "BASIC_EXAMPLE=n IIO_EXAMPLE=y IIO_TIMER_TRIGGER_EXAMPLE=n TARGET=max78000 AD7091R4=y"
+        },
+        "iio_example_max78000_ad7091r8": {
+            "flags" : "BASIC_EXAMPLE=n IIO_EXAMPLE=y IIO_TIMER_TRIGGER_EXAMPLE=n TARGET=max78000 AD7091R8=y"
+        },
+        "iio_timer_trigger_example_max78000_ad7091r2": {
+            "flags" : "BASIC_EXAMPLE=n IIO_EXAMPLE=n IIO_TIMER_TRIGGER_EXAMPLE=y TARGET=max78000 AD7091R2=y"
+        },
+        "iio_timer_trigger_example_max78000_ad7091r8": {
+            "flags" : "BASIC_EXAMPLE=n IIO_EXAMPLE=n IIO_TIMER_TRIGGER_EXAMPLE=y TARGET=max78000 AD7091R4=y"
+        },
+        "iio_timer_trigger_example_max78000_ad7091r8": {
+            "flags" : "BASIC_EXAMPLE=n IIO_EXAMPLE=n IIO_TIMER_TRIGGER_EXAMPLE=y TARGET=max78000 AD7091R8=y"
+        }
+    }
+}

--- a/projects/ad7091r8-sdz/src.mk
+++ b/projects/ad7091r8-sdz/src.mk
@@ -1,0 +1,44 @@
+include $(PROJECT)/src/platform/$(PLATFORM)/platform_src.mk
+include $(PROJECT)/src/examples/examples_src.mk
+
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/main.c
+
+INCS += $(PROJECT)/src/common/common_data.h
+SRCS += $(PROJECT)/src/common/common_data.c
+
+INCS += $(PROJECT)/src/platform/platform_includes.h
+
+INCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.h
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.c
+
+INCS += $(INCLUDE)/no_os_delay.h     \
+		$(INCLUDE)/no_os_error.h     \
+		$(INCLUDE)/no_os_gpio.h      \
+		$(INCLUDE)/no_os_i2c.h       \
+		$(INCLUDE)/no_os_print_log.h \
+		$(INCLUDE)/no_os_spi.h       \
+		$(INCLUDE)/no_os_irq.h      \
+		$(INCLUDE)/no_os_list.h      \
+		$(INCLUDE)/no_os_timer.h      \
+		$(INCLUDE)/no_os_uart.h      \
+		$(INCLUDE)/no_os_lf256fifo.h \
+		$(INCLUDE)/no_os_util.h \
+		$(INCLUDE)/no_os_units.h \
+		$(INCLUDE)/no_os_init.h \
+		$(INCLUDE)/no_os_alloc.h \
+        	$(INCLUDE)/no_os_mutex.h
+
+SRCS += $(DRIVERS)/api/no_os_gpio.c \
+		$(DRIVERS)/api/no_os_i2c.c  \
+		$(NO-OS)/util/no_os_lf256fifo.c \
+		$(DRIVERS)/api/no_os_irq.c  \
+		$(DRIVERS)/api/no_os_spi.c  \
+		$(DRIVERS)/api/no_os_timer.c  \
+		$(DRIVERS)/api/no_os_uart.c \
+		$(NO-OS)/util/no_os_list.c \
+		$(NO-OS)/util/no_os_util.c \
+		$(NO-OS)/util/no_os_alloc.c \
+        	$(NO-OS)/util/no_os_mutex.c
+
+INCS += $(DRIVERS)/adc/ad7091r8/ad7091r8.h
+SRCS += $(DRIVERS)/adc/ad7091r8/ad7091r8.c

--- a/projects/ad7091r8-sdz/src/common/common_data.c
+++ b/projects/ad7091r8-sdz/src/common/common_data.c
@@ -1,0 +1,113 @@
+/***************************************************************************//**
+ *   @file   common_data.c
+ *   @brief  Defines common data to be used by ad7091r8-sdz example.
+ *   @author Marcelo Schmitt (marcelo.schmitt@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "common_data.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+struct no_os_uart_init_param ad7091r8_uart_ip = {
+	.device_id = UART_DEVICE_ID,
+	.irq_id = UART_IRQ_ID,
+	.asynchronous_rx = true,
+	.baud_rate = UART_BAUDRATE,
+	.size = NO_OS_UART_CS_8,
+	.parity = NO_OS_UART_PAR_NO,
+	.stop = NO_OS_UART_STOP_2_BIT,
+	.extra = UART_EXTRA,
+	.platform_ops = UART_OPS,
+};
+
+struct no_os_spi_init_param ad7091r8_spi_ip = {
+	.device_id = SPI_DEVICE_ID,
+	.max_speed_hz = SPI_BAUDRATE,
+	.bit_order = NO_OS_SPI_BIT_ORDER_MSB_FIRST,
+	.mode = NO_OS_SPI_MODE_0,
+	.platform_ops = SPI_OPS,
+	.chip_select = SPI_CS,
+	.extra = SPI_EXTRA,
+};
+
+struct ad7091r8_init_param ad7091r8_ip = {
+	.spi_init = &ad7091r8_spi_ip,
+	.gpio_convst = GPIO_CONVST_INIT,
+	.gpio_reset = GPIO_RESET_INIT,
+#ifdef AD7091R2_DEV
+	.device_id = AD7091R2,
+#elif defined AD7091R4_DEV
+	.device_id = AD7091R4,
+#else
+	.device_id = AD7091R8,
+#endif
+};
+
+#ifdef IIO_TIMER_TRIGGER_EXAMPLE
+/* AD7091R-8 timer init parameter */
+struct no_os_timer_init_param ad7091r8_timer_ip = {
+	.id = AD7091R8_TIMER_DEVICE_ID,
+	.freq_hz = AD7091R8_TIMER_FREQ_HZ,
+	.ticks_count = AD7091R8_TIMER_TICKS_COUNT,
+	.platform_ops = TIMER_OPS,
+	.extra = AD7091R8_TIMER_EXTRA,
+};
+
+/* AD7091R-8 timer irq init parameter */
+struct no_os_irq_init_param ad7091r8_timer_irq_ip = {
+	.irq_ctrl_id = 0,
+	.platform_ops = TIMER_IRQ_OPS,
+	.extra = AD7091R8_TIMER_IRQ_EXTRA,
+};
+
+/* AD7091R-8 timer trigger callback info */
+const struct iio_hw_trig_cb_info ad7091r8_timer_cb_info = {
+	.event = NO_OS_EVT_TIM_ELAPSED,
+	.peripheral = NO_OS_TIM_IRQ,
+	.handle = AD7091R8_TIMER_CB_HANDLE,
+};
+
+/* AD7091R-8 timer trigger init parameter */
+struct iio_hw_trig_init_param ad7091r8_timer_trig_ip = {
+	.irq_id = AD7091R8_TIMER_TRIG_IRQ_ID,
+	.cb_info = ad7091r8_timer_cb_info,
+	.name = AD7091R8_TIMER_TRIG_NAME,
+};
+#endif

--- a/projects/ad7091r8-sdz/src/common/common_data.h
+++ b/projects/ad7091r8-sdz/src/common/common_data.h
@@ -1,0 +1,68 @@
+/***************************************************************************//**
+ *   @file   ad7091r8-sdz/src/common/common_data.h
+ *   @brief  Defines common data to be used by ad7091r8-sdz examples.
+ *   @author Marcelo Schmitt (marcelo.schmitt@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __COMMON_DATA_H__
+#define __COMMON_DATA_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "platform_includes.h"
+#include "ad7091r8.h"
+#ifdef IIO_SUPPORT
+#include "iio_ad7091r8.h"
+#endif
+#if defined(IIO_TIMER_TRIGGER_EXAMPLE)
+#include "iio_trigger.h"
+#endif
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+extern struct no_os_uart_init_param ad7091r8_uart_ip;
+extern struct no_os_spi_init_param ad7091r8_spi_ip;
+extern struct ad7091r8_init_param ad7091r8_ip;
+
+#ifdef IIO_TIMER_TRIGGER_EXAMPLE
+#define AD7091R8_TIMER_TRIG_NAME "ad7091r8-timer-trig"
+extern struct no_os_timer_init_param ad7091r8_timer_ip;
+extern struct no_os_irq_init_param ad7091r8_timer_irq_ip;
+extern struct iio_hw_trig_init_param ad7091r8_timer_trig_ip;
+#endif
+
+#endif /* __COMMON_DATA_H__ */

--- a/projects/ad7091r8-sdz/src/examples/basic/basic_example.c
+++ b/projects/ad7091r8-sdz/src/examples/basic/basic_example.c
@@ -1,0 +1,91 @@
+/***************************************************************************//**
+ *   @file   basic_example.c
+ *   @brief  Basic example header for ad7091r8-sdz project
+ *   @author Marcelo Schmitt (marcelo.schmitt@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "basic_example.h"
+#include "common_data.h"
+#include "ad7091r8.h"
+#include "no_os_delay.h"
+#include "no_os_print_log.h"
+#include "no_os_util.h"
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+/***************************************************************************//**
+ * @brief Basic example main execution.
+ *
+ * @return ret - Result of the example execution. If working correctly, will
+ *               execute continuously the while(1) loop and will not return.
+*******************************************************************************/
+int basic_example_main()
+{
+	struct ad7091r8_dev *ad7091r8_dev;
+	uint16_t val;
+	int ret;
+
+	printf("AD7091R-8 basic_example - Read each channel sequentially\n\r");
+	/* Use ad7091r4_ip and ad7091r2_ip for AD7091R-4 and AD7091R-2 respectively */
+	ret = ad7091r8_init(&ad7091r8_dev, &ad7091r8_ip);
+	if (ret)
+		return ret;
+
+	/* Enable all channels */
+	ret = ad7091r8_spi_reg_write(ad7091r8_dev, 0x01, 0xFF);
+	if (ret)
+		goto error;
+
+	while(1) {
+		ret = ad7091r8_sequenced_read(ad7091r8_dev, &val);
+		if (ret)
+			goto error;
+
+		printf("Channel %d raw ADC output: %d\n\r",
+		       no_os_field_get(AD7091R8_REG_RESULT_CH_ID_MASK, val),
+		       no_os_field_get(AD7091R8_REG_RESULT_DATA_MASK, val));
+		no_os_mdelay(1000);
+	}
+
+error:
+	printf("Error on AD7091R-8 basic_example: %d\n\r", ret);
+	ad7091r8_remove(ad7091r8_dev);
+	return ret;
+}

--- a/projects/ad7091r8-sdz/src/examples/basic/basic_example.h
+++ b/projects/ad7091r8-sdz/src/examples/basic/basic_example.h
@@ -1,0 +1,51 @@
+/***************************************************************************//**
+ *   @file   basic_example.h
+ *   @brief  Basic example header for ad7091r8-sdz project
+ *   @author Marcelo Schmitt (marcelo.schmitt@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __BASIC_EXAMPLE_H__
+#define __BASIC_EXAMPLE_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+int basic_example_main();
+
+#endif /* __BASIC_EXAMPLE_H__ */

--- a/projects/ad7091r8-sdz/src/examples/examples_src.mk
+++ b/projects/ad7091r8-sdz/src/examples/examples_src.mk
@@ -1,0 +1,45 @@
+ifeq (y,$(strip $(AD7091R2)))
+CFLAGS += -DAD7091R2_DEV=1
+else ifeq (y,$(strip $(AD7091R4)))
+CFLAGS += -DAD7091R4_DEV=1
+else
+CFLAGS += -DAD7091R8_DEV=1
+endif
+
+INCS += $(INCLUDE)/no_os_list.h \
+		$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h
+
+ifeq (y,$(strip $(BASIC_EXAMPLE)))
+CFLAGS += -DBASIC_EXAMPLE=1
+SRCS += $(PROJECT)/src/examples/basic/basic_example.c
+INCS += $(PROJECT)/src/examples/basic/basic_example.h
+endif
+
+ifeq (y,$(strip $(IIO_EXAMPLE)))
+IIOD=y
+CFLAGS += -DIIO_EXAMPLE=1
+SRCS += $(PROJECT)/src/examples/iio_example/iio_example.c
+INCS += $(PROJECT)/src/examples/iio_example/iio_example.h
+endif
+
+ifeq (y,$(strip $(IIO_TIMER_TRIGGER_EXAMPLE)))
+IIOD=y
+CFLAGS += -DIIO_TIMER_TRIGGER_EXAMPLE=1
+SRCS += $(PROJECT)/src/examples/iio_timer_trigger_example/iio_timer_trigger_example.c
+INCS += $(PROJECT)/src/examples/iio_timer_trigger_example/iio_timer_trigger_example.h
+
+SRCS += $(NO-OS)/iio/iio_trigger.c
+INCS += $(NO-OS)/iio/iio_trigger.h
+
+SRCS += $(DRIVERS)/adc/ad7091r8/iio_ad7091r8_trig.c
+endif
+
+ifeq (y,$(strip $(IIOD)))
+SRC_DIRS += $(NO-OS)/iio/iio_app
+
+INCS += $(DRIVERS)/adc/ad7091r8/iio_ad7091r8.h
+SRCS += $(DRIVERS)/adc/ad7091r8/iio_ad7091r8.c
+
+INCS += $(INCLUDE)/no_os_list.h \
+		$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h
+endif

--- a/projects/ad7091r8-sdz/src/examples/iio_example/iio_example.c
+++ b/projects/ad7091r8-sdz/src/examples/iio_example/iio_example.c
@@ -1,0 +1,99 @@
+/***************************************************************************//**
+ *   @file   iio_example.c
+ *   @brief  Implementation of IIO example for eval-ad7091r8-sdz project.
+ *   @author Marcelo Schmitt (marcelo.schmitt@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "iio_example.h"
+#include "iio_ad7091r8.h"
+#include "common_data.h"
+#include "iio_app.h"
+#include "no_os_util.h"
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+/***************************************************************************//**
+ * @brief IIO example main execution.
+ *
+ * @return ret - Result of the example execution. If working correctly, will
+ *               execute continuously function iio_app_run and will not return.
+*******************************************************************************/
+
+int iio_example_main()
+{
+	struct ad7091r8_iio_dev *ad7091r8_iio_desc;
+	struct ad7091r8_iio_dev_init_param ad7091r8_iio_param;
+	struct iio_app_desc *app;
+	struct iio_app_init_param app_init_param = { 0 };
+	struct ad7091r8_init_param *ad7091r8_init_p;
+	int ret;
+
+	/* Use ad7091r4_ip and ad7091r2_ip for AD7091R-4 and AD7091R-2 respectively */
+	ad7091r8_init_p = &ad7091r8_ip;
+	ad7091r8_iio_param.ad7091r8_dev_init = ad7091r8_init_p;
+	ret = ad7091r8_iio_init(&ad7091r8_iio_desc, &ad7091r8_iio_param);
+	if (ret)
+		return ret;
+
+	struct iio_app_device iio_devices[] = {
+		{
+			.name = ad7091r8_names[ad7091r8_init_p->device_id],
+			.dev = ad7091r8_iio_desc,
+			.dev_descriptor = ad7091r8_iio_desc->iio_dev,
+		}
+	};
+
+	app_init_param.devices = iio_devices;
+	app_init_param.nb_devices = NO_OS_ARRAY_SIZE(iio_devices);
+	app_init_param.uart_init_params = ad7091r8_uart_ip;
+
+	ret = iio_app_init(&app, app_init_param);
+	if (ret)
+		goto remove_iio_ad7091r8;
+
+	ret = iio_app_run(app);
+
+	iio_app_remove(app);
+
+remove_iio_ad7091r8:
+	ad7091r8_iio_remove(ad7091r8_iio_desc);
+
+	return ret;
+}

--- a/projects/ad7091r8-sdz/src/examples/iio_example/iio_example.h
+++ b/projects/ad7091r8-sdz/src/examples/iio_example/iio_example.h
@@ -1,0 +1,51 @@
+/***************************************************************************//**
+ *   @file   iio_example.h
+ *   @brief  IIO example header for ad7091r8-sdz project
+ *   @author Marcelo Schmitt (marcelo.schmitt@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __IIO_EXAMPLE_H__
+#define __IIO_EXAMPLE_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+int iio_example_main();
+
+#endif /* __IIO_EXAMPLE_H__ */

--- a/projects/ad7091r8-sdz/src/examples/iio_timer_trigger_example/iio_timer_trigger_example.c
+++ b/projects/ad7091r8-sdz/src/examples/iio_timer_trigger_example/iio_timer_trigger_example.c
@@ -1,0 +1,167 @@
+/***************************************************************************//**
+ *   @file   iio_timer_trigger_example.c
+ *   @brief  Implementation of IIO timer trigger example for eval-ad7091r8-sdz project.
+ *   @author Marcelo Schmitt (marcelo.schmitt@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "iio_timer_trigger_example.h"
+#include "iio_ad7091r8.h"
+#include "common_data.h"
+#include "iio_app.h"
+#include "no_os_util.h"
+
+/******************************************************************************/
+/************************ Variable Declarations ******************************/
+/******************************************************************************/
+uint8_t ad7091r8_data_buffer[IIO_DATA_BUFFER_SIZE];
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+/***************************************************************************//**
+ * @brief IIO trigger example main execution.
+ *
+ * @return ret - Result of the example execution. If working correctly, will
+ *               execute continuously function iio_app_run and will not return.
+*******************************************************************************/
+
+int iio_timer_trigger_example_main()
+{
+	struct ad7091r8_iio_dev *ad7091r8_iio_desc;
+	struct ad7091r8_iio_dev_init_param ad7091r8_iio_param;
+	struct iio_app_desc *app;
+	struct iio_app_init_param app_init_param = { 0 };
+	struct ad7091r8_init_param *ad7091r8_init_p;
+	struct iio_data_buffer adc_buff = {
+		.buff = (void *)ad7091r8_data_buffer,
+		.size = IIO_DATA_BUFFER_SIZE
+	};
+	int ret;
+
+	/* adc trigger instance descriptor. */
+	struct iio_hw_trig *ad7091r8_timer_trig_desc;
+
+	/* adc timer descriptor */
+	struct no_os_timer_desc *ad7091r8_timer_desc;
+
+	/* ad7091r8 irq instance descriptor */
+	struct no_os_irq_ctrl_desc *ad7091r8_irq_desc;
+
+
+	/* Use ad7091r4_ip and ad7091r2_ip for AD7091R-4 and AD7091R-2 respectively */
+	ad7091r8_init_p = &ad7091r8_ip;
+	ad7091r8_iio_param.ad7091r8_dev_init = ad7091r8_init_p;
+	ret = ad7091r8_iio_init(&ad7091r8_iio_desc, &ad7091r8_iio_param);
+	if (ret)
+		return ret;
+
+	ret = no_os_timer_init(&ad7091r8_timer_desc, &ad7091r8_timer_ip);
+	if (ret)
+		goto remove_iio_ad7091r8;
+
+
+	ret = no_os_irq_ctrl_init(&ad7091r8_irq_desc, &ad7091r8_timer_irq_ip);
+	if (ret)
+		goto remove_timer;
+
+
+	ret = no_os_irq_set_priority(ad7091r8_irq_desc, AD7091R8_TIMER_IRQ_ID, 1);
+	if (ret)
+		goto remove_irq_ctrl;
+
+
+	ad7091r8_timer_irq_ip.extra = ad7091r8_timer_desc->extra;
+
+	ad7091r8_timer_trig_ip.irq_ctrl = ad7091r8_irq_desc;
+
+	/* Initialize hardware trigger */
+	ret = iio_hw_trig_init(&ad7091r8_timer_trig_desc, &ad7091r8_timer_trig_ip);
+	if (ret)
+		goto remove_irq_ctrl;
+
+	ret = no_os_timer_start(ad7091r8_timer_desc);
+	if (ret)
+		goto remove_hw_trigger;
+
+	struct iio_app_device iio_devices[] = {
+		IIO_APP_DEVICE(ad7091r8_names[ad7091r8_init_p->device_id],
+			       ad7091r8_iio_desc, ad7091r8_iio_desc->iio_dev,
+			       &adc_buff, NULL, NULL),
+	};
+
+	struct iio_trigger_init trigs[] = {
+		IIO_APP_TRIGGER(AD7091R8_TIMER_TRIG_NAME, ad7091r8_timer_trig_desc,
+				&ad7091r8_iio_timer_trig_desc),
+	};
+
+	/* Set device trigger */
+	iio_devices[0].default_trigger_id = "trigger0";
+
+	app_init_param.devices = iio_devices;
+	app_init_param.nb_devices = NO_OS_ARRAY_SIZE(iio_devices);
+	app_init_param.uart_init_params = ad7091r8_uart_ip;
+	app_init_param.trigs = trigs;
+	app_init_param.nb_trigs = NO_OS_ARRAY_SIZE(trigs);
+	app_init_param.irq_desc = NULL;
+
+	ret = iio_app_init(&app, app_init_param);
+	if (ret)
+		goto remove_hw_trigger;
+
+	/* Update the reference to iio_desc */
+	ad7091r8_timer_trig_desc->iio_desc = app->iio_desc;
+
+	ret = iio_app_run(app);
+
+	iio_app_remove(app);
+
+remove_hw_trigger:
+	iio_hw_trig_remove(ad7091r8_timer_trig_desc);
+
+remove_irq_ctrl:
+	no_os_irq_ctrl_remove(ad7091r8_irq_desc);
+
+remove_timer:
+	no_os_timer_remove(ad7091r8_timer_desc);
+
+remove_iio_ad7091r8:
+	ad7091r8_iio_remove(ad7091r8_iio_desc);
+
+	return ret;
+}

--- a/projects/ad7091r8-sdz/src/examples/iio_timer_trigger_example/iio_timer_trigger_example.h
+++ b/projects/ad7091r8-sdz/src/examples/iio_timer_trigger_example/iio_timer_trigger_example.h
@@ -1,0 +1,68 @@
+/***************************************************************************//**
+ *   @file   iio_timer_trigger_example.h
+ *   @brief  IIO timer trigger example header for ad7091r8-sdz project
+ *   @author Marcelo Schmitt (marcelo.schmitt@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __AD7091R8_IIO_TIMER_TRIGGER_EXAMPLE_H__
+#define __AD7091R8_IIO_TIMER_TRIGGER_EXAMPLE_H__
+
+#ifdef AD7091R2_DEV
+#define ADC_CHANNELS 2
+#elif defined AD7091R4_DEV
+#define ADC_CHANNELS 4
+#else
+#define ADC_CHANNELS 8
+#endif
+
+#ifndef IIO_DATA_BUFFER_SIZE
+#define IIO_DATA_BUFFER_SIZE (400 * ADC_CHANNELS * sizeof(int32_t))
+#endif
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+/******************************************************************************/
+/************************ Variable Declarations ******************************/
+/******************************************************************************/
+//extern uint16_t *ad7091r8_data_buffer;
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+int iio_timer_trigger_example_main();
+
+#endif /* __AD7091R8_IIO_TIMER_TRIGGER_EXAMPLE_H__ */

--- a/projects/ad7091r8-sdz/src/platform/maxim/main.c
+++ b/projects/ad7091r8-sdz/src/platform/maxim/main.c
@@ -1,0 +1,98 @@
+/***************************************************************************//**
+ *   @file   main.c
+ *   @brief  Main file for Maxim platform of ad7091r8-sdz project.
+ *   @author Marcelo Schmitt (marcelo.schmitt@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "no_os_delay.h"
+#include "no_os_uart.h"
+#include "no_os_error.h"
+#include "common_data.h"
+#include "platform_includes.h"
+
+#ifdef BASIC_EXAMPLE
+#include "basic_example.h"
+#endif
+
+#ifdef IIO_EXAMPLE
+#include "iio_example.h"
+#endif
+
+#ifdef IIO_TIMER_TRIGGER_EXAMPLE
+#include "iio_timer_trigger_example.h"
+#endif
+
+/***************************************************************************//**
+ * @brief Main function execution for Maxim platform.
+ *
+ * @return ret - Result of the enabled examples execution.
+*******************************************************************************/
+int main()
+{
+	int ret;
+
+#ifdef IIO_EXAMPLE
+	ret = iio_example_main();
+#endif
+
+#ifdef IIO_TIMER_TRIGGER_EXAMPLE
+	ret = iio_timer_trigger_example_main();
+#endif
+
+#ifdef BASIC_EXAMPLE
+	struct no_os_uart_desc *uart_desc;
+
+	ret = no_os_uart_init(&uart_desc, &ad7091r8_uart_ip);
+	if (NO_OS_IS_ERR_VALUE(ret))
+		return ret;
+
+	no_os_uart_stdio(uart_desc);
+	ret = basic_example_main();
+	no_os_uart_remove(uart_desc);
+#endif
+
+#if (BASIC_EXAMPLE + IIO_EXAMPLE + IIO_TIMER_TRIGGER_EXAMPLE == 0)
+#error At least one example has to be selected using y value in Makefile.
+#elif (BASIC_EXAMPLE + IIO_EXAMPLE + IIO_TIMER_TRIGGER_EXAMPLE > 1)
+#error Selected example projects cannot be enabled at the same time. \
+Please enable only one example and re-build the project.
+#endif
+
+	return ret;
+}

--- a/projects/ad7091r8-sdz/src/platform/maxim/parameters.c
+++ b/projects/ad7091r8-sdz/src/platform/maxim/parameters.c
@@ -1,0 +1,79 @@
+/***************************************************************************//**
+ *   @file   parameters.c
+ *   @brief  Definitions specific to Maxim platform used by eval-ad7091r8-sdz
+ *           project.
+ *   @author Marcelo Schmitt (marcelo.schmitt@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "parameters.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+struct max_uart_init_param ad7091r8_uart_extra_ip = {
+	.flow = UART_FLOW_DIS
+};
+
+struct max_spi_init_param ad7091r8_spi_extra_ip  = {
+	.num_slaves = 1,
+	.polarity = SPI_SS_POL_LOW,
+	.vssel = MXC_GPIO_VSSEL_VDDIOH,
+};
+
+struct max_gpio_init_param ad7091r8_gpio_extra_ip = {
+	.vssel = MXC_GPIO_VSSEL_VDDIOH,
+};
+
+/* Initialization for RESET GPIO. */
+struct no_os_gpio_init_param ad7091r8_gpio_reset_ip = {
+	.port = GPIO_RESET_PORT_NUM,
+	.number = GPIO_RESET_PIN_NUM,
+	.pull = NO_OS_PULL_NONE,
+	.platform_ops = GPIO_OPS,
+	.extra = GPIO_EXTRA
+};
+
+/* Initialization for CONVST GPIO. */
+struct no_os_gpio_init_param ad7091r8_gpio_convst_ip = {
+	.port = GPIO_CONVST_PORT_NUM,
+	.number = GPIO_CONVST_PIN_NUM,
+	.pull = NO_OS_PULL_NONE,
+	.platform_ops = GPIO_OPS,
+	.extra = GPIO_EXTRA
+};

--- a/projects/ad7091r8-sdz/src/platform/maxim/parameters.h
+++ b/projects/ad7091r8-sdz/src/platform/maxim/parameters.h
@@ -1,0 +1,109 @@
+/***************************************************************************//**
+ *   @file   parameters.h
+ *   @brief  Definitions specific to Maxim platform used by eval-ad7091r8-sdz
+ *           project.
+ *   @author Marcelo Schmitt (marcelo.schmitt@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "maxim_irq.h"
+#include "maxim_spi.h"
+#include "maxim_gpio.h"
+#include "maxim_uart.h"
+#include "maxim_uart_stdio.h"
+#include "maxim_timer.h"
+#include "no_os_timer.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+#ifdef IIO_SUPPORT
+#define INTC_DEVICE_ID		0
+#endif
+
+#define UART_DEVICE_ID		0
+#define UART_IRQ_ID		UART0_IRQn
+#define UART_BAUDRATE		115200
+#define UART_EXTRA		&ad7091r8_uart_extra_ip
+#define UART_OPS		&max_uart_ops
+#define INTC_DEVICE_ID		0
+#define SPI_DEVICE_ID		1
+#define SPI_CS			1
+#define SPI_BAUDRATE		200000
+#define SPI_OPS			&max_spi_ops
+#define SPI_EXTRA		&ad7091r8_spi_extra_ip
+
+#define GPIO_OPS		&max_gpio_ops
+#define GPIO_EXTRA		&ad7091r8_gpio_extra_ip
+#define GPIO_RESET_PIN_NUM	19
+#define GPIO_RESET_PORT_NUM	0
+#define GPIO_RESET_INIT		&ad7091r8_gpio_reset_ip
+#define GPIO_CONVST_PIN_NUM	6
+#define GPIO_CONVST_PORT_NUM	1
+#define GPIO_CONVST_INIT	&ad7091r8_gpio_convst_ip
+#define GPIO_IRQ_ID		0
+
+#ifdef IIO_TIMER_TRIGGER_EXAMPLE
+/* AD7091R-8 Timer settings */
+#define AD7091R8_TIMER_DEVICE_ID    0
+#define AD7091R8_TIMER_FREQ_HZ      1000000
+#define AD7091R8_TIMER_TICKS_COUNT  2000
+#define AD7091R8_TIMER_EXTRA        NULL
+#define TIMER_OPS                   &max_timer_ops
+
+/* AD7091R-8 Timer trigger settings */
+#define AD7091R8_TIMER_IRQ_ID       TMR0_IRQn
+#define TIMER_IRQ_OPS               &max_irq_ops
+#define AD7091R8_TIMER_IRQ_EXTRA    NULL
+
+/* AD7091R-8 timer trigger settings */
+#define AD7091R8_TIMER_CB_HANDLE    MXC_TMR0
+#define AD7091R8_TIMER_TRIG_IRQ_ID  TMR0_IRQn
+
+#endif /* IIO_TIMER_TRIGGER_EXAMPLE */
+
+extern struct max_uart_init_param ad7091r8_uart_extra_ip;
+extern struct max_spi_init_param ad7091r8_spi_extra_ip;
+extern struct max_gpio_init_param ad7091r8_gpio_extra_ip;
+extern struct no_os_gpio_init_param ad7091r8_gpio_reset_ip;
+extern struct no_os_gpio_init_param ad7091r8_gpio_convst_ip;
+
+#endif /* __PARAMETERS_H__ */

--- a/projects/ad7091r8-sdz/src/platform/maxim/platform_src.mk
+++ b/projects/ad7091r8-sdz/src/platform/maxim/platform_src.mk
@@ -1,0 +1,17 @@
+INCS += $(PLATFORM_DRIVERS)/maxim_gpio.h 	\
+	$(PLATFORM_DRIVERS)/maxim_spi.h		\
+	$(PLATFORM_DRIVERS)/maxim_gpio_irq.h	\
+	$(PLATFORM_DRIVERS)/maxim_irq.h		\
+	$(PLATFORM_DRIVERS)/maxim_timer.h	\
+	$(PLATFORM_DRIVERS)/maxim_uart.h	\
+	$(PLATFORM_DRIVERS)/maxim_uart_stdio.h
+
+SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c	\
+	$(PLATFORM_DRIVERS)/maxim_gpio.c	\
+	$(PLATFORM_DRIVERS)/maxim_spi.c		\
+	$(PLATFORM_DRIVERS)/maxim_gpio_irq.c	\
+	$(PLATFORM_DRIVERS)/maxim_irq.c		\
+	$(PLATFORM_DRIVERS)/maxim_timer.c	\
+	$(PLATFORM_DRIVERS)/maxim_uart.c	\
+	$(PLATFORM_DRIVERS)/maxim_init.c	\
+	$(PLATFORM_DRIVERS)/maxim_uart_stdio.c

--- a/projects/ad7091r8-sdz/src/platform/platform_includes.h
+++ b/projects/ad7091r8-sdz/src/platform/platform_includes.h
@@ -1,0 +1,53 @@
+/***************************************************************************//**
+ *   @file   platform_includes.h
+ *   @brief  Includes for used platforms used by eval-ad7091r8-sdz project.
+ *   @author Marcelo Schmitt (marcelo.schmitt@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PLATFORM_INCLUDES_H__
+#define __PLATFORM_INCLUDES_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#ifdef MAXIM_PLATFORM
+#include "maxim/parameters.h"
+#endif
+
+#ifdef IIO_SUPPORT
+#include "iio_app.h"
+#endif
+
+#endif /* __PLATFORM_INCLUDES_H__ */


### PR DESCRIPTION
Initial implementation of the ad7091r8 no-OS driver. This adds support for ad7091r-2/-4/-8 devices which roughly support the same operations as ad7091r5, but are interfaced through SPI.

Driver has now been tested with Maxim78000FTHR and ad7091r8-sdz evaluation board.

Other meaningful differences between ad7091r8 and ad7091r5 are:
- ad7091r8 has a normal mode which comprises ad7091r5's sample and command modes
- ad7091r8 has no autocycle mode
- ad7091r8 and ad7091r5 have slightly different register fields and contrast most on their configuration register
- ad7091r8 protocol requires a pulse in the CONVST pin and so the driver requests a GPIO for that during initialization


