### PR TITLE
drivers: ad74416h: update read sequence

### DIFF
--- a/drivers/adc-dac/ad74416h/ad74416h.c
+++ b/drivers/adc-dac/ad74416h/ad74416h.c
@@ -129,6 +129,9 @@ int ad74416h_reg_read_raw(struct ad74416h_desc *desc, uint32_t addr,
 	if (ret)
 		return ret;
 
+	/* Make sure that NOP sequence is written for the second frame */
+	memset(val, AD74416H_NOP, AD74416H_FRAME_SIZE);
+
 	return no_os_spi_write_and_read(desc->spi_desc, val, AD74416H_FRAME_SIZE);
 }
 


### PR DESCRIPTION
Make sure that the second frame from the 2-stage readback is a NOP sequence.