### PR TITLE
ci: doxygen: Move doxygen doc from root to doxygen folder

### DIFF
--- a/ci/doxygen.sh
+++ b/ci/doxygen.sh
@@ -37,7 +37,8 @@ then
 
         git checkout gh-pages
 
-        cp -R ${TOP_DIR}/doc/doxygen/build/doxygen_doc/html/* ${TOP_DIR}
+	mkdir -p ${TOP_DIR}/doxygen
+        cp -R ${TOP_DIR}/doc/doxygen/build/doxygen_doc/html/* ${TOP_DIR}/doxygen/
 
         rm -rf ${TOP_DIR}/doc/doxygen
 


### PR DESCRIPTION
The sphinx documentation will provide the main index file.