### PR TITLE
drivers:platform:max78000: Fixes on uart driver.

### DIFF
--- a/drivers/platform/maxim/max78000/maxim_uart.c
+++ b/drivers/platform/maxim/max78000/maxim_uart.c
@@ -155,17 +155,34 @@ static int32_t max_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
 static int32_t max_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
 			      uint32_t bytes_number)
 {
+	mxc_uart_req_t uart_req;
 	int32_t ret;
+	int32_t transfered = 0;
+	int block_size = 8;
 
 	if(!desc || !data || !bytes_number)
 		return -EINVAL;
 
-	ret = MXC_UART_Write(MXC_UART_GET_UART(desc->device_id), (uint8_t *)data,
-			     (int *)&bytes_number);
-	if (ret != E_SUCCESS)
-		return -EIO;
+	while (bytes_number) {
+		if (bytes_number > 8)
+			block_size = 8;
+		else
+			block_size = bytes_number;
 
-	return bytes_number;
+		while(!(MXC_UART_GetStatus(MXC_UART_GET_UART(desc->device_id)) &
+			MXC_F_UART_STATUS_TX_EM));
+		ret = MXC_UART_Write(MXC_UART_GET_UART(desc->device_id),
+				     (uint8_t *)(data + transfered),
+				     &block_size);
+
+		transfered += block_size;
+		bytes_number -= block_size;
+
+		if (ret != E_SUCCESS)
+			return -EIO;
+	}
+
+	return transfered;
 }
 
 /**

--- a/drivers/platform/maxim/max78000/maxim_uart.c
+++ b/drivers/platform/maxim/max78000/maxim_uart.c
@@ -391,10 +391,12 @@ static int32_t max_uart_init(struct no_os_uart_desc **desc,
 		goto error;
 	}
 
-	ret = MXC_UART_SetFlowCtrl(uart_regs, flow, 8);
-	if (ret != E_NO_ERROR) {
-		ret = -EINVAL;
-		goto error;
+	if (param->device_id == 0) {
+		ret = MXC_UART_SetFlowCtrl(uart_regs, flow, 8);
+		if (ret != E_NO_ERROR) {
+			ret = -EINVAL;
+			goto error;
+		}
 	}
 
 	*desc = descriptor;


### PR DESCRIPTION
Two changes needed on the MAX78000. These issues were encountered after trying the EVAL-ADE9430 with MAX78000.
1. The UART blocking Transmit for MAX78000 in no-OS do not have a check on the TX FIFO. This causes long strings to be cut during transmission when TX FIFO is hit.

2. MAX78000 driver init uses SetFlowCtrl for all UART IDX, however the MaximSDK SetFlowCtrl returns an error for non-UART0 which can cause the no-OS platform driver to error on UART init.