### PR TITLE
drivers:adc:ad713x:Added a delay after GPIO operations

### DIFF
--- a/drivers/adc/ad713x/ad713x.c
+++ b/drivers/adc/ad713x/ad713x.c
@@ -453,6 +453,8 @@ static int32_t ad713x_init_gpio(struct ad713x_dev *dev,
 		no_os_mdelay(100);
 	}
 
+	no_os_mdelay(10);
+
 	return 0;
 }
 


### PR DESCRIPTION
Added a delay after the GPIO operations as the device needs a 10 ms delay to come out of power down state. The power down operation has been added as a part of the ad713x_init_gpio().