### PR TITLE
drivers: adc-dac: ad74413r: update read sequence

### DIFF
--- a/drivers/adc-dac/ad74413r/ad74413r.c
+++ b/drivers/adc-dac/ad74413r/ad74413r.c
@@ -186,6 +186,9 @@ int ad74413r_reg_read_raw(struct ad74413r_desc *desc, uint32_t addr,
 	if (ret)
 		return ret;
 
+	/* Make sure that NOP sequence is written for the second frame */
+	memset(val, AD74413R_NOP, AD74413R_FRAME_SIZE);
+
 	return no_os_spi_write_and_read(desc->comm_desc, val, AD74413R_FRAME_SIZE);
 }
 


### PR DESCRIPTION
Make sure that the second frame from the 2-stage readback is a NOP sequence as stated in the datasheet, page 52 of 70.

Fixes: 402288e ("drivers:adc-dac:ad74413r Added AD74413r driver")

Similar to: #1789 