### PR TITLE
tests: drivers: imu: Add unit tests for adis drivers

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,45 @@
+# Unit-testing with Ceedling
+
+## Tools
+In order to be able to run the available unit-tests, please install Ceedling on your machine from: http://www.throwtheswitch.org/ceedling
+
+## Running tests with Ceedling
+In order to run the available unit-tests, go to the desired test folder and run the following command:
+```
+ceedling test:all
+```
+
+## Generating coverage reports with Ceedling
+In order to generate coverage reports for the files which are tested, go to the desired test folder and run the following command:
+```
+ceedling gcov:all utils:gcov
+```
+The reports will be available in the test folder at the following path:
+```
+build/artifacts/gcov
+```
+
+## Clean the testing workspace with Ceedling
+In order to clean the Ceedling testing workspace, go to the desired test folder and run the following command:
+```
+ceedling clean
+```
+
+## Examples in No-OS
+### Running tests with Ceedling for IMU drivers:
+
+```
+no-OS/tests/drivers/imu> ceedling test:all
+```
+
+Generating coverage reports with Ceedling for IMU drivers:
+
+```
+no-OS/tests/drivers/imu> ceedling gcov:all utils:gcov
+```
+
+The generated reports will be available at the following path:
+
+```
+no-OS/tests/drivers/imu/build/artifacts/gcov
+```

--- a/tests/drivers/imu/project.yml
+++ b/tests/drivers/imu/project.yml
@@ -1,0 +1,104 @@
+---
+
+# Notes:
+# Sample project C code is not presently written to produce a release artifact.
+# As such, release build options are disabled.
+# This sample, therefore, only demonstrates running a collection of unit tests.
+
+:project:
+  :use_exceptions: FALSE
+  :use_test_preprocessor: TRUE
+  :use_auxiliary_dependencies: TRUE
+  :build_root: build
+#  :release_build: TRUE
+  :test_file_prefix: test_
+  :which_ceedling: gem
+  :ceedling_version: 0.31.1
+  :default_tasks:
+    - test:all
+
+#:test_build:
+#  :use_assembly: TRUE
+
+#:release_build:
+#  :output: MyApp.out
+#  :use_assembly: FALSE
+
+:environment:
+
+:extension:
+  :executable: .out
+
+:paths:
+  :test:
+    - +:test/**
+    - -:test/support
+  :source:
+    - ../../../drivers/imu/**
+    - ../../../include/**
+  :support:
+    - test/support
+  :libraries: []
+
+:defines:
+  # in order to add common defines:
+  #  1) remove the trailing [] from the :common: section
+  #  2) add entries to the :common: section (e.g. :test: has TEST defined)
+  :common: &common_defines []
+  :test:
+    - *common_defines
+    - TEST
+  :test_preprocess:
+    - *common_defines
+    - TEST
+
+:cmock:
+  :mock_prefix: mock_
+  :when_no_prototypes: :warn
+  :enforce_strict_ordering: TRUE
+  :plugins:
+    - :ignore
+    - :callback
+  :treat_as:
+    uint8:    HEX8
+    uint16:   HEX16
+    uint32:   UINT32
+    int8:     INT8
+    bool:     UINT8
+
+# Add -gcov to the plugins list to make sure of the gcov plugin
+# You will need to have gcov and gcovr both installed to make it work.
+# For more information on these options, see docs in plugins/gcov
+:gcov:
+  :reports:
+    - HtmlDetailed
+  :gcovr:
+    :html_medium_threshold: 75
+    :html_high_threshold: 90
+
+#:tools:
+# Ceedling defaults to using gcc for compiling, linking, etc.
+# As [:tools] is blank, gcc will be used (so long as it's in your system path)
+# See documentation to configure a given toolchain for use
+
+# LIBRARIES
+# These libraries are automatically injected into the build process. Those specified as
+# common will be used in all types of builds. Otherwise, libraries can be injected in just
+# tests or releases. These options are MERGED with the options in supplemental yaml files.
+:libraries:
+  :placement: :end
+  :flag: "-l${1}"
+  :path_flag: "-L ${1}"
+  :system: []    # for example, you might list 'm' to grab the math library
+  :test: []
+  :release: []
+
+:plugins:
+  :load_paths:
+    - "#{Ceedling.load_path}"
+  :enabled:
+    - stdout_pretty_tests_report
+    - module_generator
+    - raw_output_report
+    - gcov
+...

--- a/tests/drivers/imu/test/support/test_adis.c
+++ b/tests/drivers/imu/test/support/test_adis.c
@@ -1,0 +1,4064 @@
+/***************************************************************************//**
+ *   @file   adis_generic_tests.c
+ *   @brief  Implementation of adis_generic_tests.c
+ *   @author RBolboac (ramona.bolboaca@analog.com)
+ *******************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+/*******************************************************************************
+ *    INCLUDED FILES
+ ******************************************************************************/
+
+#include "unity.h"
+#include "adis.h"
+#include "mock_no_os_delay.h"
+#include "mock_no_os_util.h"
+#include "mock_no_os_i2c.h"
+#include "mock_no_os_gpio.h"
+#include "mock_no_os_spi.h"
+#include "mock_no_os_alloc.h"
+#include <errno.h>
+
+/*******************************************************************************
+ *    PRIVATE DATA
+ ******************************************************************************/
+
+static struct adis_dev device_alloc;
+static struct no_os_spi_desc spi_desc;
+static struct adis_init_param ip;
+static struct no_os_gpio_desc gpio_reset_desc;
+static int retval;
+
+/*******************************************************************************
+ *    PUBLIC DATA
+ ******************************************************************************/
+
+extern struct adis_chip_info *adis_chip_info;
+
+/*******************************************************************************
+ *    TESTS
+ ******************************************************************************/
+
+/**
+ * @brief Test adis_init with unsuccessful memory allocation.
+ */
+void test_adis_init_1(void)
+{
+	struct adis_dev *device;
+
+	no_os_calloc_IgnoreAndReturn(NULL);
+	retval = adis_init(&device, adis_chip_info);
+	TEST_ASSERT_EQUAL_INT(-ENOMEM, retval);
+}
+
+/**
+ * @brief Test adis_init with unsuccessful spi init.
+ */
+void test_adis_init_2(void)
+{
+	struct adis_dev *device;
+	device_alloc.spi_desc = &spi_desc;
+	adis_chip_info->ip = &ip;
+	no_os_calloc_IgnoreAndReturn(&device_alloc);
+	no_os_spi_init_IgnoreAndReturn(-1);
+	no_os_free_Ignore();
+	retval = adis_init(&device, adis_chip_info);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_init with unsuccessful gpio reset and has paging true.
+ */
+void test_adis_init_3(void)
+{
+	struct adis_dev *device;
+	device_alloc.spi_desc = &spi_desc;
+	adis_chip_info->ip = &ip;
+	device_alloc.gpio_reset = &gpio_reset_desc;
+	adis_chip_info->has_paging = true;
+
+	no_os_calloc_IgnoreAndReturn(&device_alloc);
+	no_os_spi_init_IgnoreAndReturn(0);
+	no_os_gpio_get_optional_IgnoreAndReturn(0);
+	no_os_gpio_direction_output_IgnoreAndReturn(-1);
+	no_os_gpio_remove_IgnoreAndReturn(0);
+	no_os_spi_remove_IgnoreAndReturn(0);
+	no_os_free_Ignore();
+	retval = adis_init(&device, adis_chip_info);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_init with unsuccessful initial startup with reset and
+ * has paging false.
+ */
+void test_adis_init_4(void)
+{
+	struct adis_dev *device;
+	device_alloc.spi_desc = &spi_desc;
+	adis_chip_info->ip = &ip;
+	device_alloc.gpio_reset = &gpio_reset_desc;
+	adis_chip_info->has_paging = false;
+
+	no_os_calloc_IgnoreAndReturn(&device_alloc);
+	no_os_spi_init_IgnoreAndReturn(0);
+	no_os_gpio_get_optional_IgnoreAndReturn(0);
+	no_os_gpio_direction_output_IgnoreAndReturn(0);
+	no_os_gpio_set_value_IgnoreAndReturn(-1);
+	retval = adis_init(&device, adis_chip_info);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_init with valid sync mode writing and gpio reset null.
+ */
+void test_adis_init_5(void)
+{
+	struct adis_dev *device;
+	device_alloc.spi_desc = &spi_desc;
+	device_alloc.gpio_reset = NULL;
+	ip.sync_mode = 0;
+	adis_chip_info->ip = &ip;
+
+	no_os_calloc_IgnoreAndReturn(&device_alloc);
+	no_os_spi_init_IgnoreAndReturn(0);
+	no_os_gpio_get_optional_IgnoreAndReturn(-1);
+	no_os_gpio_set_value_IgnoreAndReturn(0);
+	no_os_mdelay_Ignore();
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	retval = adis_init(&device, adis_chip_info);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_init with invalid sync mode writing.
+ */
+void test_adis_init_6(void)
+{
+	struct adis_dev *device;
+	device_alloc.spi_desc = &spi_desc;
+	ip.sync_mode = 5;
+	adis_chip_info->ip = &ip;
+	device_alloc.gpio_reset = &gpio_reset_desc;
+
+	no_os_calloc_IgnoreAndReturn(&device_alloc);
+	no_os_spi_init_IgnoreAndReturn(0);
+	no_os_gpio_get_optional_IgnoreAndReturn(0);
+	no_os_gpio_direction_output_IgnoreAndReturn(0);
+	no_os_gpio_set_value_IgnoreAndReturn(0);
+	no_os_mdelay_Ignore();
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_init(&device, adis_chip_info);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, retval);
+}
+
+/**
+ * @brief Test adis_remove with gpio_reset and spi_desc not null.
+ */
+void test_adis_remove_1(void)
+{
+	device_alloc.info = adis_chip_info;
+	device_alloc.gpio_reset = &gpio_reset_desc;
+	device_alloc.spi_desc = &spi_desc;
+
+	no_os_gpio_remove_IgnoreAndReturn(0);
+	no_os_spi_remove_IgnoreAndReturn(0);
+	no_os_free_Ignore();
+	adis_remove(&device_alloc);
+}
+
+/**
+ * @brief Test adis_remove with gpio_reset and spi_desc null.
+ */
+void test_adis_remove_2(void)
+{
+	device_alloc.info = adis_chip_info;
+	device_alloc.gpio_reset = NULL;
+	device_alloc.spi_desc = NULL;
+
+	no_os_free_Ignore();
+	adis_remove(&device_alloc);
+}
+
+/**
+ * @brief Test adis_adis_initial_startup with soft reset in case no reset pin is
+ * configured with invalid transfer for adis_cmd_sw_res.
+ */
+void test_adis_initial_startup_1(void)
+{
+	device_alloc.info = adis_chip_info;
+	device_alloc.gpio_reset = NULL;
+
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_initial_startup(&device_alloc);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_adis_initial_startup with soft reset in case no reset pin is
+ * configured  with invalid transfer for adis_cmd_snsr_self_test
+ */
+void test_adis_initial_startup_2(void)
+{
+	device_alloc.info = adis_chip_info;
+	device_alloc.gpio_reset = NULL;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_mdelay_Ignore();
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_initial_startup(&device_alloc);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_adis_initial_startup with soft reset in case no reset pin is
+ * configured  with invalid transfer for adis_cmd_fls_mem_test.
+ */
+void test_adis_initial_startup_3(void)
+{
+	device_alloc.info = adis_chip_info;
+	device_alloc.gpio_reset = NULL;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_mdelay_Ignore();
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_initial_startup(&device_alloc);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_read_reg with invalid size register write with current_page
+ * different from page.
+ */
+void test_adis_read_reg(void)
+{
+	uint32_t val;
+	device_alloc.info = adis_chip_info;
+	device_alloc.current_page = 1;
+
+	retval = adis_read_reg(&device_alloc, 0, &val, 5);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, retval);
+	device_alloc.current_page = 0;
+}
+
+/**
+ * @brief Test adis_write_reg with invalid size register write with current_page
+ * different from page.
+ */
+void test_adis_write_reg_1(void)
+{
+	device_alloc.info = adis_chip_info;
+	device_alloc.current_page = 1;
+
+	retval = adis_write_reg(&device_alloc, 0, 0, 5);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, retval);
+	device_alloc.current_page = 0;
+}
+
+/**
+ * @brief Test adis_write_reg with size equal to 1.
+ */
+void test_adis_write_reg_2(void)
+{
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	retval = adis_write_reg(&device_alloc, 0, 0, 1);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_field_s32 with invalid SPI transfer.
+ */
+extern int adis_read_field_s32(struct adis_dev *adis, struct adis_field field,
+			       int32_t *field_val);
+void test_adis_read_field_s32(void)
+{
+	struct adis_field field;
+	int32_t field_val;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_field_s32(&device_alloc,
+				     device_alloc.info->field_map->x_gyro, &field_val);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_read_diag_snsr_init_failure unsuccessful transfer.
+ */
+void test_adis_read_diag_snsr_init_failure_1(void)
+{
+	uint32_t snsr_init_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_diag_snsr_init_failure(&device_alloc, &snsr_init_failure);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_read_diag_snsr_init_failure successful transfer flag true.
+ */
+void test_adis_read_diag_snsr_init_failure_2(void)
+{
+	uint32_t snsr_init_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		device_alloc.info->field_map->diag_snsr_init_failure_mask);
+	retval = adis_read_diag_snsr_init_failure(&device_alloc, &snsr_init_failure);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(true, snsr_init_failure);
+}
+
+/**
+ * @brief Test adis_read_diag_snsr_init_failure successful transfer flag false.
+ */
+void test_adis_read_diag_snsr_init_failure_3(void)
+{
+	uint32_t snsr_init_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		!device_alloc.info->field_map->diag_snsr_init_failure_mask);
+	retval = adis_read_diag_snsr_init_failure(&device_alloc, &snsr_init_failure);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, snsr_init_failure);
+}
+
+/**
+ * @brief Test adis_read_diag_data_path_overrun unsuccessful transfer.
+ */
+void test_adis_read_diag_data_path_overrun_1(void)
+{
+	uint32_t data_path_overrun;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_diag_data_path_overrun(&device_alloc, &data_path_overrun);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_read_diag_data_path_overrun successful transfer flag true.
+ */
+void test_adis_read_diag_data_path_overrun_2(void)
+{
+	uint32_t data_path_overrun;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		device_alloc.info->field_map->diag_data_path_overrun_mask);
+	retval = adis_read_diag_data_path_overrun(&device_alloc, &data_path_overrun);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(true, data_path_overrun);
+}
+
+/**
+ * @brief Test adis_read_diag_data_path_overrun successful transfer flag false.
+ */
+void test_adis_read_diag_data_path_overrun_3(void)
+{
+	uint32_t data_path_overrun;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		!device_alloc.info->field_map->diag_data_path_overrun_mask);
+	retval = adis_read_diag_data_path_overrun(&device_alloc, &data_path_overrun);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, data_path_overrun);
+}
+
+/**
+ * @brief Test adis_read_diag_fls_mem_update_failure unsuccessful transfer.
+ */
+void test_adis_read_diag_fls_mem_update_failure_1(void)
+{
+	uint32_t fls_mem_update_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_diag_fls_mem_update_failure(&device_alloc,
+			&fls_mem_update_failure);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_read_diag_fls_mem_update_failure successful transfer flag true.
+ */
+void test_adis_read_diag_fls_mem_update_failure_2(void)
+{
+	uint32_t fls_mem_update_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		device_alloc.info->field_map->diag_fls_mem_update_failure_mask);
+	retval = adis_read_diag_fls_mem_update_failure(&device_alloc,
+			&fls_mem_update_failure);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(true, fls_mem_update_failure);
+}
+
+/**
+ * @brief Test adis_read_diag_fls_mem_update_failure successful transfer flag false.
+ */
+void test_adis_read_diag_fls_mem_update_failure_3(void)
+{
+	uint32_t fls_mem_update_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		!device_alloc.info->field_map->diag_fls_mem_update_failure_mask);
+	retval = adis_read_diag_fls_mem_update_failure(&device_alloc,
+			&fls_mem_update_failure);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, fls_mem_update_failure);
+}
+
+/**
+ * @brief Test adis_read_diag_spi_comm_err unsuccessful transfer.
+ */
+void test_adis_read_diag_spi_comm_err_1(void)
+{
+	uint32_t spi_comm_err;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_diag_spi_comm_err(&device_alloc, &spi_comm_err);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_read_diag_spi_comm_err successful transfer flag true.
+ */
+void test_adis_read_diag_spi_comm_err_2(void)
+{
+	uint32_t spi_comm_err;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		device_alloc.info->field_map->diag_spi_comm_err_mask);
+	retval = adis_read_diag_spi_comm_err(&device_alloc, &spi_comm_err);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(true, spi_comm_err);
+}
+
+/**
+ * @brief Test adis_read_diag_spi_comm_err successful transfer flag false.
+ */
+void test_adis_read_diag_spi_comm_err_3(void)
+{
+	uint32_t spi_comm_err;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		!device_alloc.info->field_map->diag_spi_comm_err_mask);
+	retval = adis_read_diag_spi_comm_err(&device_alloc, &spi_comm_err);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, spi_comm_err);
+}
+
+/**
+ * @brief Test adis_read_diag_standby_mode unsuccessful transfer.
+ */
+void test_adis_read_diag_standby_mode_1(void)
+{
+	uint32_t standby_mode;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_diag_standby_mode(&device_alloc, &standby_mode);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_read_diag_standby_mode successful transfer flag true.
+ */
+void test_adis_read_diag_standby_mode_2(void)
+{
+	uint32_t standby_mode;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		device_alloc.info->field_map->diag_standby_mode_mask);
+	retval = adis_read_diag_standby_mode(&device_alloc, &standby_mode);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(true, standby_mode);
+}
+
+/**
+ * @brief Test adis_read_diag_standby_mode successful transfer flag false.
+ */
+void test_adis_read_diag_standby_mode_3(void)
+{
+	uint32_t standby_mode;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		!device_alloc.info->field_map->diag_standby_mode_mask);
+	retval = adis_read_diag_standby_mode(&device_alloc, &standby_mode);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, standby_mode);
+}
+
+/**
+ * @brief Test adis_read_diag_snsr_failure unsuccessful transfer.
+ */
+void test_adis_read_diag_snsr_failure_1(void)
+{
+	uint32_t snsr_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_diag_snsr_failure(&device_alloc, &snsr_failure);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_read_diag_snsr_failure successful transfer flag true.
+ */
+void test_adis_read_diag_snsr_failure_2(void)
+{
+	uint32_t snsr_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		device_alloc.info->field_map->diag_snsr_failure_mask);
+	retval = adis_read_diag_snsr_failure(&device_alloc, &snsr_failure);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(true, snsr_failure);
+}
+
+/**
+ * @brief Test adis_read_diag_snsr_failure successful transfer flag false.
+ */
+void test_adis_read_diag_snsr_failure_3(void)
+{
+	uint32_t snsr_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		!device_alloc.info->field_map->diag_snsr_failure_mask);
+	retval = adis_read_diag_snsr_failure(&device_alloc, &snsr_failure);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, snsr_failure);
+}
+
+/**
+ * @brief Test adis_read_diag_mem_failure unsuccessful transfer.
+ */
+void test_adis_read_diag_mem_failure_1(void)
+{
+	uint32_t mem_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_diag_mem_failure(&device_alloc, &mem_failure);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_read_diag_mem_failure successful transfer flag true.
+ */
+void test_adis_read_diag_mem_failure_2(void)
+{
+	uint32_t mem_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		device_alloc.info->field_map->diag_mem_failure_mask);
+	retval = adis_read_diag_mem_failure(&device_alloc, &mem_failure);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(true, mem_failure);
+}
+
+/**
+ * @brief Test adis_read_diag_mem_failure successful transfer flag false.
+ */
+void test_adis_read_diag_mem_failure_3(void)
+{
+	uint32_t mem_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		!device_alloc.info->field_map->diag_mem_failure_mask);
+	retval = adis_read_diag_mem_failure(&device_alloc, &mem_failure);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, mem_failure);
+}
+
+/**
+ * @brief Test adis_read_diag_clk_err unsuccessful transfer.
+ */
+void test_adis_read_diag_clk_err_1(void)
+{
+	uint32_t clk_err;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_diag_clk_err(&device_alloc, &clk_err);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_read_diag_clk_err successful transfer flag true.
+ */
+void test_adis_read_diag_clk_err_2(void)
+{
+	uint32_t clk_err;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		device_alloc.info->field_map->diag_clk_err_mask);
+	retval = adis_read_diag_clk_err(&device_alloc, &clk_err);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(true, clk_err);
+}
+
+/**
+ * @brief Test adis_read_diag_clk_err successful transfer flag false.
+ */
+void test_adis_read_diag_clk_err_3(void)
+{
+	uint32_t clk_err;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		!device_alloc.info->field_map->diag_clk_err_mask);
+	retval = adis_read_diag_clk_err(&device_alloc, &clk_err);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, clk_err);
+}
+
+/**
+ * @brief Test adis_read_diag_gyro1_failure unsuccessful transfer.
+ */
+void test_adis_read_diag_gyro1_failure_1(void)
+{
+	uint32_t gyro1_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_diag_gyro1_failure(&device_alloc, &gyro1_failure);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_read_diag_gyro1_failure successful transfer flag true.
+ */
+void test_adis_read_diag_gyro1_failure_2(void)
+{
+	uint32_t gyro1_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		device_alloc.info->field_map->diag_gyro1_failure_mask);
+	retval = adis_read_diag_gyro1_failure(&device_alloc, &gyro1_failure);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(true, gyro1_failure);
+}
+
+/**
+ * @brief Test adis_read_diag_gyro1_failure successful transfer flag false.
+ */
+void test_adis_read_diag_gyro1_failure_3(void)
+{
+	uint32_t gyro1_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		!device_alloc.info->field_map->diag_gyro1_failure_mask);
+	retval = adis_read_diag_gyro1_failure(&device_alloc, &gyro1_failure);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, gyro1_failure);
+}
+
+/**
+ * @brief Test adis_read_diag_gyro2_failure unsuccessful transfer.
+ */
+void test_adis_read_diag_gyro2_failure_1(void)
+{
+	uint32_t gyro2_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_diag_gyro2_failure(&device_alloc, &gyro2_failure);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_read_diag_gyro2_failure successful transfer flag true.
+ */
+void test_adis_read_diag_gyro2_failure_2(void)
+{
+	uint32_t gyro2_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		device_alloc.info->field_map->diag_gyro2_failure_mask);
+	retval = adis_read_diag_gyro2_failure(&device_alloc, &gyro2_failure);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(true, gyro2_failure);
+}
+
+/**
+ * @brief Test adis_read_diag_gyro2_failure successful transfer flag false.
+ */
+void test_adis_read_diag_gyro2_failure_3(void)
+{
+	uint32_t gyro2_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		!device_alloc.info->field_map->diag_gyro2_failure_mask);
+	retval = adis_read_diag_gyro2_failure(&device_alloc, &gyro2_failure);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, gyro2_failure);
+}
+
+/**
+ * @brief Test adis_read_diag_accl_failure unsuccessful transfer.
+ */
+void test_adis_read_diag_accl_failure_1(void)
+{
+	uint32_t accl_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_diag_accl_failure(&device_alloc, &accl_failure);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_read_diag_accl_failure successful transfer flag true.
+ */
+void test_adis_read_diag_accl_failure_2(void)
+{
+	uint32_t accl_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		device_alloc.info->field_map->diag_accl_failure_mask);
+	retval = adis_read_diag_accl_failure(&device_alloc, &accl_failure);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(true, accl_failure);
+}
+
+/**
+ * @brief Test adis_read_diag_accl_failure successful transfer flag false.
+ */
+void test_adis_read_diag_accl_failure_3(void)
+{
+	uint32_t accl_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		!device_alloc.info->field_map->diag_accl_failure_mask);
+	retval = adis_read_diag_accl_failure(&device_alloc, &accl_failure);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, accl_failure);
+}
+
+/**
+ * @brief Test adis_read_diag_x_gyro_accl_failure unsuccessful transfer.
+ */
+void test_adis_read_diag_x_axis_gyro_failure_1(void)
+{
+	uint32_t x_axis_gyro_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_diag_x_axis_gyro_failure(&device_alloc,
+			&x_axis_gyro_failure);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_read_diag_x_axis_gyro_failure successful transfer flag true.
+ */
+void test_adis_read_diag_x_axis_gyro_failure_2(void)
+{
+	uint32_t x_axis_gyro_failure;
+	device_alloc.info = adis_chip_info;
+
+	/* Test successful transfer with flag set */
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		device_alloc.info->field_map->diag_x_axis_gyro_failure_mask);
+	retval = adis_read_diag_x_axis_gyro_failure(&device_alloc,
+			&x_axis_gyro_failure);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(true, x_axis_gyro_failure);
+}
+
+/**
+ * @brief Test adis_read_diag_x_axis_gyro_failure successful transfer flag false.
+ */
+void test_adis_read_diag_x_axis_gyro_failure_3(void)
+{
+	uint32_t x_axis_gyro_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		!device_alloc.info->field_map->diag_x_axis_gyro_failure_mask);
+	retval = adis_read_diag_x_axis_gyro_failure(&device_alloc,
+			&x_axis_gyro_failure);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, x_axis_gyro_failure);
+}
+
+/**
+ * @brief Test adis_read_diag_y_axis_gyro_failure unsuccessful transfer.
+ */
+void test_adis_read_diag_y_axis_gyro_failure_1(void)
+{
+	uint32_t y_axis_gyro_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_diag_y_axis_gyro_failure(&device_alloc,
+			&y_axis_gyro_failure);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_read_diag_y_axis_gyro_failure successful transfer flag true.
+ */
+void test_adis_read_diag_y_axis_gyro_failure_2(void)
+{
+	uint32_t y_axis_gyro_failure;
+	device_alloc.info = adis_chip_info;
+
+	/* Test successful transfer with flag set */
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		device_alloc.info->field_map->diag_y_axis_gyro_failure_mask);
+	retval = adis_read_diag_y_axis_gyro_failure(&device_alloc,
+			&y_axis_gyro_failure);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(true, y_axis_gyro_failure);
+}
+
+/**
+ * @brief Test adis_read_diag_y_axis_gyro_failure successful transfer flag false.
+ */
+void test_adis_read_diag_y_axis_gyro_failure_3(void)
+{
+	uint32_t y_axis_gyro_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		!device_alloc.info->field_map->diag_y_axis_gyro_failure_mask);
+	retval = adis_read_diag_y_axis_gyro_failure(&device_alloc,
+			&y_axis_gyro_failure);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, y_axis_gyro_failure);
+}
+
+
+/**
+ * @brief Test adis_read_diag_z_axis_gyro_failure unsuccessful transfer.
+ */
+void test_adis_read_diag_z_axis_gyro_failure_1(void)
+{
+	uint32_t z_axis_gyro_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_diag_z_axis_gyro_failure(&device_alloc,
+			&z_axis_gyro_failure);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_read_diag_z_axis_gyro_failure successful transfer flag true.
+ */
+void test_adis_read_diag_z_axis_gyro_failure_2(void)
+{
+	uint32_t z_axis_gyro_failure;
+	device_alloc.info = adis_chip_info;
+
+	/* Test successful transfer with flag set */
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		device_alloc.info->field_map->diag_z_axis_gyro_failure_mask);
+	retval = adis_read_diag_z_axis_gyro_failure(&device_alloc,
+			&z_axis_gyro_failure);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(true, z_axis_gyro_failure);
+}
+
+/**
+ * @brief Test adis_read_diag_z_axis_gyro_failure successful transfer flag false.
+ */
+void test_adis_read_diag_z_axis_gyro_failure_3(void)
+{
+	uint32_t z_axis_gyro_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		!device_alloc.info->field_map->diag_z_axis_gyro_failure_mask);
+	retval = adis_read_diag_z_axis_gyro_failure(&device_alloc,
+			&z_axis_gyro_failure);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, z_axis_gyro_failure);
+}
+
+/**
+ * @brief Test adis_read_diag_x_axis_accl_failure unsuccessful transfer.
+ */
+void test_adis_read_diag_x_axis_accl_failure_1(void)
+{
+	uint32_t x_axis_accl_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_diag_x_axis_accl_failure(&device_alloc,
+			&x_axis_accl_failure);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_read_diag_x_axis_accl_failure successful transfer flag true.
+ */
+void test_adis_read_diag_x_axis_accl_failure_2(void)
+{
+	uint32_t x_axis_accl_failure;
+	device_alloc.info = adis_chip_info;
+
+	/* Test successful transfer with flag set */
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		device_alloc.info->field_map->diag_x_axis_accl_failure_mask);
+	retval = adis_read_diag_x_axis_accl_failure(&device_alloc,
+			&x_axis_accl_failure);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(true, x_axis_accl_failure);
+}
+
+/**
+ * @brief Test adis_read_diag_x_axis_accl_failure successful transfer flag false.
+ */
+void test_adis_read_diag_x_axis_accl_failure_3(void)
+{
+	uint32_t x_axis_accl_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		!device_alloc.info->field_map->diag_x_axis_accl_failure_mask);
+	retval = adis_read_diag_x_axis_accl_failure(&device_alloc,
+			&x_axis_accl_failure);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, x_axis_accl_failure);
+}
+
+/**
+ * @brief Test adis_read_diag_y_axis_accl_failure unsuccessful transfer.
+ */
+void test_adis_read_diag_y_axis_accl_failure_1(void)
+{
+	uint32_t y_axis_accl_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_diag_y_axis_accl_failure(&device_alloc,
+			&y_axis_accl_failure);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_read_diag_y_axis_accl_failure successful transfer flag true.
+ */
+void test_adis_read_diag_y_axis_accl_failure_2(void)
+{
+	uint32_t y_axis_accl_failure;
+	device_alloc.info = adis_chip_info;
+
+	/* Test successful transfer with flag set */
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		device_alloc.info->field_map->diag_y_axis_accl_failure_mask);
+	retval = adis_read_diag_y_axis_accl_failure(&device_alloc,
+			&y_axis_accl_failure);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(true, y_axis_accl_failure);
+}
+
+/**
+ * @brief Test adis_read_diag_y_axis_accl_failure successful transfer flag false.
+ */
+void test_adis_read_diag_y_axis_accl_failure_3(void)
+{
+	uint32_t y_axis_accl_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		!device_alloc.info->field_map->diag_y_axis_accl_failure_mask);
+	retval = adis_read_diag_y_axis_accl_failure(&device_alloc,
+			&y_axis_accl_failure);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, y_axis_accl_failure);
+}
+
+
+/**
+ * @brief Test adis_read_diag_z_axis_accl_failure unsuccessful transfer.
+ */
+void test_adis_read_diag_z_axis_accl_failure_1(void)
+{
+	uint32_t z_axis_accl_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_diag_z_axis_accl_failure(&device_alloc,
+			&z_axis_accl_failure);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_read_diag_z_axis_accl_failure successful transfer flag true.
+ */
+void test_adis_read_diag_z_axis_accl_failure_2(void)
+{
+	uint32_t z_axis_accl_failure;
+	device_alloc.info = adis_chip_info;
+
+	/* Test successful transfer with flag set */
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		device_alloc.info->field_map->diag_z_axis_accl_failure_mask);
+	retval = adis_read_diag_z_axis_accl_failure(&device_alloc,
+			&z_axis_accl_failure);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(true, z_axis_accl_failure);
+}
+
+/**
+ * @brief Test adis_read_diag_z_axis_accl_failure successful transfer flag false.
+ */
+void test_adis_read_diag_z_axis_accl_failure_3(void)
+{
+	uint32_t z_axis_accl_failure;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		!device_alloc.info->field_map->diag_z_axis_accl_failure_mask);
+	retval = adis_read_diag_z_axis_accl_failure(&device_alloc,
+			&z_axis_accl_failure);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, z_axis_accl_failure);
+}
+
+/**
+ * @brief Test adis_read_diag_aduc_mcu_fault unsuccessful transfer.
+ */
+void test_adis_read_diag_aduc_mcu_fault_1(void)
+{
+	uint32_t aduc_mcu_fault;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_diag_aduc_mcu_fault(&device_alloc, &aduc_mcu_fault);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_read_diag_aduc_mcu_fault successful transfer flag true.
+ */
+void test_adis_read_diag_aduc_mcu_fault_2(void)
+{
+	uint32_t aduc_mcu_fault;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		device_alloc.info->field_map->diag_aduc_mcu_fault_mask);
+	retval = adis_read_diag_aduc_mcu_fault(&device_alloc, &aduc_mcu_fault);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(true, aduc_mcu_fault);
+}
+
+/**
+ * @brief Test adis_read_diag_aduc_mcu_fault successful transfer flag false.
+ */
+void test_adis_read_diag_aduc_mcu_fault_3(void)
+{
+	uint32_t aduc_mcu_fault;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(
+		!device_alloc.info->field_map->diag_aduc_mcu_fault_mask);
+	retval = adis_read_diag_aduc_mcu_fault(&device_alloc, &aduc_mcu_fault);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, aduc_mcu_fault);
+}
+
+/**
+ * @brief Test adis_read_diag_checksum_err flag true.
+ */
+void test_adis_read_diag_checksum_err_1(void)
+{
+	uint32_t checksum_err;
+	device_alloc.info = adis_chip_info;
+	device_alloc.diag_flags.checksum_err = true;
+
+	adis_read_diag_checksum_err(&device_alloc, &checksum_err);
+	TEST_ASSERT_EQUAL_INT(true, checksum_err);
+}
+
+/**
+ * @brief Test adis_read_diag_checksum_err flag false.
+ */
+void test_adis_read_diag_checksum_err_2(void)
+{
+	uint32_t checksum_err;
+	device_alloc.info = adis_chip_info;
+	device_alloc.diag_flags.checksum_err = false;
+
+	adis_read_diag_checksum_err(&device_alloc, &checksum_err);
+	TEST_ASSERT_EQUAL_INT(false, checksum_err);
+}
+
+/**
+ * @brief Test adis_read_diag_fls_mem_wr_cnt_exceed flag true.
+ */
+void test_adis_read_diag_fls_mem_wr_cnt_exceed_1(void)
+{
+	uint32_t fls_mem_wr_cnt_exceed;
+	device_alloc.info = adis_chip_info;
+	device_alloc.diag_flags.fls_mem_wr_cnt_exceed = true;
+
+	adis_read_diag_fls_mem_wr_cnt_exceed(&device_alloc, &fls_mem_wr_cnt_exceed);
+	TEST_ASSERT_EQUAL_INT(true, fls_mem_wr_cnt_exceed);
+}
+
+/**
+ * @brief Test adis_read_diag_fls_mem_wr_cnt_exceed flag false.
+ */
+void test_adis_read_diag_fls_mem_wr_cnt_exceed_2(void)
+{
+	uint32_t fls_mem_wr_cnt_exceed;
+	device_alloc.info = adis_chip_info;
+	device_alloc.diag_flags.fls_mem_wr_cnt_exceed = false;
+
+	adis_read_diag_fls_mem_wr_cnt_exceed(&device_alloc, &fls_mem_wr_cnt_exceed);
+	TEST_ASSERT_EQUAL_INT(false, fls_mem_wr_cnt_exceed);
+}
+
+/**
+ * @brief Test adis_read_x_gyro successful SPI transfer FIFO enabled.
+ */
+void test_adis_read_x_gyro_1(void)
+{
+	int32_t x_gyro;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = true;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	retval = adis_read_x_gyro(&device_alloc, &x_gyro);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, device_alloc.fifo_enabled);
+}
+
+/**
+ * @brief Test adis_read_x_gyro unsuccessful SPI transfer FIFO enabled.
+ */
+void test_adis_read_x_gyro_2(void)
+{
+	int32_t x_gyro;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = true;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_x_gyro(&device_alloc, &x_gyro);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+	TEST_ASSERT_EQUAL_INT(true, device_alloc.fifo_enabled);
+}
+
+/**
+ * @brief Test adis_read_x_gyro successful SPI transfer FIFO disabled.
+ */
+void test_adis_read_x_gyro_3(void)
+{
+	int32_t x_gyro;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = false;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	retval = adis_read_x_gyro(&device_alloc, &x_gyro);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_y_gyro successful SPI transfer FIFO enabled.
+ */
+void test_adis_read_y_gyro_1(void)
+{
+	int32_t y_gyro;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = true;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	retval = adis_read_y_gyro(&device_alloc, &y_gyro);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, device_alloc.fifo_enabled);
+}
+
+/**
+ * @brief Test adis_read_y_gyro unsuccessful SPI transfer FIFO enabled.
+ */
+void test_adis_read_y_gyro_2(void)
+{
+	int32_t y_gyro;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = true;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_y_gyro(&device_alloc, &y_gyro);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+	TEST_ASSERT_EQUAL_INT(true, device_alloc.fifo_enabled);
+}
+
+/**
+ * @brief Test adis_read_y_gyro successful SPI transfer FIFO disabled.
+ */
+void test_adis_read_y_gyro_3(void)
+{
+	int32_t y_gyro;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = false;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	retval = adis_read_y_gyro(&device_alloc, &y_gyro);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_z_gyro successful SPI transfer FIFO enabled.
+ */
+void test_adis_read_z_gyro_1(void)
+{
+	int32_t z_gyro;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = true;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	retval = adis_read_z_gyro(&device_alloc, &z_gyro);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, device_alloc.fifo_enabled);
+}
+
+/**
+ * @brief Test adis_read_z_gyro unsuccessful SPI transfer FIFO enabled.
+ */
+void test_adis_read_z_gyro_2(void)
+{
+	int32_t z_gyro;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = true;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_z_gyro(&device_alloc, &z_gyro);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+	TEST_ASSERT_EQUAL_INT(true, device_alloc.fifo_enabled);
+}
+
+/**
+ * @brief Test adis_read_z_gyro successful SPI transfer FIFO disabled.
+ */
+void test_adis_read_z_gyro_3(void)
+{
+	int32_t z_gyro;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = false;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	retval = adis_read_z_gyro(&device_alloc, &z_gyro);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_x_accl successful SPI transfer FIFO enabled.
+ */
+void test_adis_read_x_accl_1(void)
+{
+	int32_t x_accl;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = true;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	retval = adis_read_x_accl(&device_alloc, &x_accl);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, device_alloc.fifo_enabled);
+}
+
+/**
+ * @brief Test adis_read_x_accl unsuccessful SPI transfer FIFO enabled.
+ */
+void test_adis_read_x_accl_2(void)
+{
+	int32_t x_accl;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = true;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_x_accl(&device_alloc, &x_accl);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+	TEST_ASSERT_EQUAL_INT(true, device_alloc.fifo_enabled);
+}
+
+/**
+ * @brief Test adis_read_x_accl successful SPI transfer FIFO disabled.
+ */
+void test_adis_read_x_accl_3(void)
+{
+	int32_t x_accl;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = false;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	retval = adis_read_x_accl(&device_alloc, &x_accl);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_y_accl successful SPI transfer FIFO enabled.
+ */
+void test_adis_read_y_accl_1(void)
+{
+	int32_t y_accl;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = true;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	retval = adis_read_y_accl(&device_alloc, &y_accl);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, device_alloc.fifo_enabled);
+}
+
+/**
+ * @brief Test adis_read_y_accl unsuccessful SPI transfer FIFO enabled.
+ */
+void test_adis_read_y_accl_2(void)
+{
+	int32_t y_accl;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = true;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_y_accl(&device_alloc, &y_accl);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+	TEST_ASSERT_EQUAL_INT(true, device_alloc.fifo_enabled);
+}
+
+/**
+ * @brief Test adis_read_y_accl successful SPI transfer FIFO disabled.
+ */
+void test_adis_read_y_accl_3(void)
+{
+	int32_t y_accl;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = false;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	retval = adis_read_y_accl(&device_alloc, &y_accl);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_z_accl successful SPI transfer FIFO enabled.
+ */
+void test_adis_read_z_accl_1(void)
+{
+	int32_t z_accl;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = true;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	retval = adis_read_z_accl(&device_alloc, &z_accl);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, device_alloc.fifo_enabled);
+}
+
+/**
+ * @brief Test adis_read_z_accl unsuccessful SPI transfer FIFO enabled.
+ */
+void test_adis_read_z_accl_2(void)
+{
+	int32_t z_accl;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = true;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_z_accl(&device_alloc, &z_accl);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+	TEST_ASSERT_EQUAL_INT(true, device_alloc.fifo_enabled);
+}
+
+/**
+ * @brief Test adis_read_z_accl successful SPI transfer FIFO disabled.
+ */
+void test_adis_read_z_accl_3(void)
+{
+	int32_t z_accl;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = false;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	retval = adis_read_z_accl(&device_alloc, &z_accl);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_temp_out successful SPI transfer FIFO enabled.
+ */
+void test_adis_read_temp_out_1(void)
+{
+	int32_t temp_out;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = true;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	retval = adis_read_temp_out(&device_alloc, &temp_out);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, device_alloc.fifo_enabled);
+}
+
+/**
+ * @brief Test adis_read_temp_out unsuccessful SPI transfer FIFO enabled.
+ */
+void test_adis_read_temp_out_2(void)
+{
+	int32_t temp_out;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = true;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_temp_out(&device_alloc, &temp_out);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+	TEST_ASSERT_EQUAL_INT(true, device_alloc.fifo_enabled);
+}
+
+/**
+ * @brief Test adis_read_temp_out successful SPI transfer FIFO disabled.
+ */
+void test_adis_read_temp_out_3(void)
+{
+	int32_t temp_out;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = false;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	retval = adis_read_temp_out(&device_alloc, &temp_out);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_time_stamp on 2 bytes successful SPI transfer.
+ */
+void test_adis_read_time_stamp_size16(void)
+{
+	uint32_t time_stamp;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_time_stamp(&device_alloc, &time_stamp);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_time_stamp on 4 bytes successful SPI transfer.
+ */
+void test_adis_read_time_stamp_size32(void)
+{
+	uint32_t time_stamp;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_time_stamp(&device_alloc, &time_stamp);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_data_cntr successful SPI transfer.
+ */
+void test_adis_read_data_cntr(void)
+{
+	uint32_t data_ctnr;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_data_cntr(&device_alloc, &data_ctnr);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_x_deltang successful SPI transfer FIFO enabled.
+ */
+void test_adis_read_x_deltang_1(void)
+{
+	int32_t x_deltang;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = true;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	retval = adis_read_x_deltang(&device_alloc, &x_deltang);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, device_alloc.fifo_enabled);
+}
+
+/**
+ * @brief Test adis_read_x_deltang unsuccessful SPI transfer FIFO enabled.
+ */
+void test_adis_read_x_deltang_2(void)
+{
+	int32_t x_deltang;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = true;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_x_deltang(&device_alloc, &x_deltang);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+	TEST_ASSERT_EQUAL_INT(true, device_alloc.fifo_enabled);
+}
+
+/**
+ * @brief Test adis_read_x_deltang successful SPI transfer FIFO disabled.
+ */
+void test_adis_read_x_deltang_3(void)
+{
+	int32_t x_deltang;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = false;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	retval = adis_read_x_deltang(&device_alloc, &x_deltang);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_y_deltang successful SPI transfer FIFO enabled.
+ */
+void test_adis_read_y_deltang_1(void)
+{
+	int32_t y_deltang;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = true;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	retval = adis_read_y_deltang(&device_alloc, &y_deltang);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, device_alloc.fifo_enabled);
+}
+
+/**
+ * @brief Test adis_read_y_deltang unsuccessful SPI transfer FIFO enabled.
+ */
+void test_adis_read_y_deltang_2(void)
+{
+	int32_t y_deltang;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = true;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_y_deltang(&device_alloc, &y_deltang);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+	TEST_ASSERT_EQUAL_INT(true, device_alloc.fifo_enabled);
+}
+
+/**
+ * @brief Test adis_read_y_deltang successful SPI transfer FIFO disabled.
+ */
+void test_adis_read_y_deltang_3(void)
+{
+	int32_t y_deltang;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = false;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	retval = adis_read_y_deltang(&device_alloc, &y_deltang);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_z_deltang successful SPI transfer FIFO enabled.
+ */
+void test_adis_read_z_deltang_1(void)
+{
+	int32_t z_deltang;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = true;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	retval = adis_read_z_deltang(&device_alloc, &z_deltang);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, device_alloc.fifo_enabled);
+}
+
+/**
+ * @brief Test adis_read_z_deltang unsuccessful SPI transfer FIFO enabled.
+ */
+void test_adis_read_z_deltang_2(void)
+{
+	int32_t z_deltang;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = true;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_z_deltang(&device_alloc, &z_deltang);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+	TEST_ASSERT_EQUAL_INT(true, device_alloc.fifo_enabled);
+}
+
+/**
+ * @brief Test adis_read_z_deltang successful SPI transfer FIFO disabled.
+ */
+void test_adis_read_z_deltang_3(void)
+{
+	int32_t z_deltang;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = false;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	retval = adis_read_z_deltang(&device_alloc, &z_deltang);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_x_deltvel successful SPI transfer FIFO enabled.
+ */
+void test_adis_read_x_deltvel_1(void)
+{
+	int32_t x_deltvel;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = true;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	retval = adis_read_x_deltvel(&device_alloc, &x_deltvel);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, device_alloc.fifo_enabled);
+}
+
+/**
+ * @brief Test adis_read_x_deltvel unsuccessful SPI transfer FIFO enabled.
+ */
+void test_adis_read_x_deltvel_2(void)
+{
+	int32_t x_deltvel;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = true;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_x_deltvel(&device_alloc, &x_deltvel);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+	TEST_ASSERT_EQUAL_INT(true, device_alloc.fifo_enabled);
+}
+
+/**
+ * @brief Test adis_read_x_deltvel successful SPI transfer FIFO disabled.
+ */
+void test_adis_read_x_deltvel_3(void)
+{
+	int32_t x_deltvel;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = false;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	retval = adis_read_x_deltvel(&device_alloc, &x_deltvel);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_y_deltvel successful SPI transfer FIFO enabled.
+ */
+void test_adis_read_y_deltvel_1(void)
+{
+	int32_t y_deltvel;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = true;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	retval = adis_read_y_deltvel(&device_alloc, &y_deltvel);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, device_alloc.fifo_enabled);
+}
+
+/**
+ * @brief Test adis_read_y_deltvel unsuccessful SPI transfer FIFO enabled.
+ */
+void test_adis_read_y_deltvel_2(void)
+{
+	int32_t y_deltvel;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = true;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_y_deltvel(&device_alloc, &y_deltvel);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+	TEST_ASSERT_EQUAL_INT(true, device_alloc.fifo_enabled);
+}
+
+/**
+ * @brief Test adis_read_y_deltvel successful SPI transfer FIFO disabled.
+ */
+void test_adis_read_y_deltvel_3(void)
+{
+	int32_t y_deltvel;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = false;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	retval = adis_read_y_deltvel(&device_alloc, &y_deltvel);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_z_deltvel successful SPI transfer FIFO enabled.
+ */
+void test_adis_read_z_deltvel_1(void)
+{
+	int32_t z_deltvel;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = true;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	retval = adis_read_z_deltvel(&device_alloc, &z_deltvel);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, device_alloc.fifo_enabled);
+}
+
+/**
+ * @brief Test adis_read_z_deltvel unsuccessful SPI transfer FIFO enabled.
+ */
+void test_adis_read_z_deltvel_2(void)
+{
+	int32_t z_deltvel;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = true;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_z_deltvel(&device_alloc, &z_deltvel);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+	TEST_ASSERT_EQUAL_INT(true, device_alloc.fifo_enabled);
+}
+
+/**
+ * @brief Test adis_read_z_deltvel successful SPI transfer FIFO disabled.
+ */
+void test_adis_read_z_deltvel_3(void)
+{
+	int32_t z_deltvel;
+	device_alloc.info = adis_chip_info;
+	device_alloc.fifo_enabled = false;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	retval = adis_read_z_deltvel(&device_alloc, &z_deltvel);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_fifo_cnt successful SPI transfer.
+ */
+void test_adis_read_fifo_cnt(void)
+{
+	uint32_t fifo_cnt;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_fifo_cnt(&device_alloc, &fifo_cnt);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_spi_chksum successful SPI transfer.
+ */
+void test_adis_read_spi_chksum(void)
+{
+	uint32_t checksum;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_spi_chksum(&device_alloc, &checksum);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_xg_bias successful SPI transfer.
+ */
+void test_adis_read_xg_bias(void)
+{
+	int32_t xg_bias;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	retval = adis_read_xg_bias(&device_alloc, &xg_bias);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_xg_bias successful SPI transfer.
+ */
+void test_adis_write_xg_bias(void)
+{
+	int32_t xg_bias = 100;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(100);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	retval = adis_write_xg_bias(&device_alloc, xg_bias);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_yg_bias successful SPI transfer.
+ */
+void test_adis_read_yg_bias(void)
+{
+	int32_t yg_bias;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	retval = adis_read_yg_bias(&device_alloc, &yg_bias);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_yg_bias successful SPI transfer.
+ */
+void test_adis_write_yg_bias(void)
+{
+	int32_t yg_bias = 100;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(100);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	retval = adis_write_yg_bias(&device_alloc, yg_bias);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_zg_bias successful SPI transfer.
+ */
+void test_adis_read_zg_bias(void)
+{
+	int32_t zg_bias;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	retval = adis_read_zg_bias(&device_alloc, &zg_bias);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_zg_bias successful SPI transfer.
+ */
+void test_adis_write_zg_bias(void)
+{
+	int32_t zg_bias = 100;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(100);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	retval = adis_write_zg_bias(&device_alloc, zg_bias);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_xa_bias successful SPI transfer.
+ */
+void test_adis_read_xa_bias(void)
+{
+	int32_t xa_bias;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	retval = adis_read_xa_bias(&device_alloc, &xa_bias);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_xa_bias successful SPI transfer.
+ */
+void test_adis_write_xa_bias(void)
+{
+	int32_t xa_bias = 100;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(100);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	retval = adis_write_xa_bias(&device_alloc, xa_bias);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_ya_bias successful SPI transfer.
+ */
+void test_adis_read_ya_bias(void)
+{
+	int32_t ya_bias;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	retval = adis_read_ya_bias(&device_alloc, &ya_bias);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_ya_bias successful SPI transfer.
+ */
+void test_adis_write_ya_bias(void)
+{
+	int32_t ya_bias = 100;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(100);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	retval = adis_write_ya_bias(&device_alloc, ya_bias);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_za_bias successful SPI transfer.
+ */
+void test_adis_read_za_bias(void)
+{
+	int32_t za_bias;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	no_os_sign_extend32_IgnoreAndReturn(0);
+	no_os_find_last_set_bit_IgnoreAndReturn(0);
+	retval = adis_read_za_bias(&device_alloc, &za_bias);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_za_bias successful SPI transfer.
+ */
+void test_adis_write_za_bias(void)
+{
+	int32_t za_bias = 100;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(100);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	retval = adis_write_za_bias(&device_alloc, za_bias);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_fifo_en successful SPI transfer.
+ */
+void test_adis_read_fifo_en(void)
+{
+	uint32_t fifo_en;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_fifo_en(&device_alloc, &fifo_en);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_fifo_en successful SPI transfer with fifo enabled.
+ */
+void test_adis_write_fifo_en_1(void)
+{
+	uint32_t fifo_en = 1;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	retval = adis_write_fifo_en(&device_alloc, fifo_en);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(true, device_alloc.fifo_enabled);
+}
+
+/**
+ * @brief Test adis_write_fifo_en successful SPI transfer with fifo disabled.
+ */
+void test_adis_write_fifo_en_2(void)
+{
+	uint32_t fifo_en = 0;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	retval = adis_write_fifo_en(&device_alloc, fifo_en);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(false, device_alloc.fifo_enabled);
+}
+
+/**
+ * @brief Test adis_write_fifo_en successful SPI transfer with invalid value.
+ */
+void test_adis_write_fifo_en_3(void)
+{
+	uint32_t fifo_en = 2;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	retval = adis_write_fifo_en(&device_alloc, fifo_en);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, retval);
+}
+
+/**
+ * @brief Test adis_read_fifo_overflow successful SPI transfer.
+ */
+void test_adis_read_fifo_overflow(void)
+{
+	uint32_t fifo_overflow;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_fifo_overflow(&device_alloc, &fifo_overflow);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_fifo_overflow successful SPI transfer.
+ */
+void test_adis_write_fifo_overflow(void)
+{
+	uint32_t fifo_overflow = 1;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	retval = adis_write_fifo_overflow(&device_alloc, fifo_overflow);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_fifo_wm_int_en successful SPI transfer.
+ */
+void test_adis_read_fifo_wm_int_en(void)
+{
+	uint32_t fifo_wm_int_en;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_fifo_wm_int_en(&device_alloc, &fifo_wm_int_en);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_fifo_wm_int_en successful SPI transfer.
+ */
+void test_adis_write_fifo_wm_int_en(void)
+{
+	uint32_t fifo_wm_int_en = 1;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	retval = adis_write_fifo_wm_int_en(&device_alloc, fifo_wm_int_en);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_fifo_wm_int_pol successful SPI transfer.
+ */
+void test_adis_read_fifo_wm_int_pol(void)
+{
+	uint32_t fifo_wm_int_pol;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_fifo_wm_int_pol(&device_alloc, &fifo_wm_int_pol);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_fifo_wm_int_pol successful SPI transfer.
+ */
+void test_adis_write_fifo_wm_int_pol(void)
+{
+	uint32_t fifo_wm_int_pol = 1;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	retval = adis_write_fifo_wm_int_pol(&device_alloc, fifo_wm_int_pol);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_fifo_wm_lvl successful SPI transfer.
+ */
+void test_adis_read_fifo_wm_lvl(void)
+{
+	uint32_t fifo_wm_lvl;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_fifo_wm_lvl(&device_alloc, &fifo_wm_lvl);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_fifo_wm_lvl successful SPI transfer.
+ */
+void test_adis_write_fifo_wm_lvl(void)
+{
+	uint32_t fifo_wm_lvl = 1;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(512);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	retval = adis_write_fifo_wm_lvl(&device_alloc, fifo_wm_lvl);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_filt_size_var_b successful SPI transfer.
+ */
+void test_adis_read_filt_size_var_b(void)
+{
+	uint32_t filt_size_var_b;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_filt_size_var_b(&device_alloc, &filt_size_var_b);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_filt_size_var_b successful SPI transfer.
+ */
+void test_adis_write_filt_size_var_b_1(void)
+{
+	uint32_t filt_size_var_b = 1;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(adis_chip_info->filt_size_var_b_max);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	no_os_udelay_Ignore();
+	retval = adis_write_filt_size_var_b(&device_alloc, filt_size_var_b);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_filt_size_var_b invalid value.
+ */
+void test_adis_write_filt_size_var_b_2(void)
+{
+	uint32_t filt_size_var_b = adis_chip_info->filt_size_var_b_max + 1;
+	device_alloc.info = adis_chip_info;
+
+	retval = adis_write_filt_size_var_b(&device_alloc, filt_size_var_b);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, retval);
+}
+
+/**
+ * @brief Test adis_write_filt_size_var_b invalid write.
+ */
+void test_adis_write_filt_size_var_b_3(void)
+{
+	uint32_t filt_size_var_b = adis_chip_info->filt_size_var_b_max;
+	device_alloc.info = adis_chip_info;
+
+	filt_size_var_b = adis_chip_info->filt_size_var_b_max;
+	no_os_field_get_IgnoreAndReturn(adis_chip_info->filt_size_var_b_max - 1);
+	retval = adis_write_filt_size_var_b(&device_alloc, filt_size_var_b);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, retval);
+}
+
+/**
+ * @brief Test adis_read_gyro_meas_range successful SPI transfer.
+ */
+void test_adis_read_gyro_meas_range(void)
+{
+	uint32_t gyro_meas_range;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_gyro_meas_range(&device_alloc, &gyro_meas_range);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_dr_polarity successful SPI transfer.
+ */
+void test_adis_read_dr_polarity(void)
+{
+	uint32_t dr_polarity;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_dr_polarity(&device_alloc, &dr_polarity);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_dr_polarity successful SPI transfer.
+ */
+void test_adis_write_dr_polarity_1(void)
+{
+	uint32_t dr_polarity = 1;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	no_os_udelay_Ignore();
+	retval = adis_write_dr_polarity(&device_alloc, dr_polarity);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_dr_polarity invalid value.
+ */
+void test_adis_write_dr_polarity_2(void)
+{
+	uint32_t dr_polarity = 2;
+	device_alloc.info = adis_chip_info;
+
+	retval = adis_write_dr_polarity(&device_alloc, dr_polarity);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, retval);
+}
+
+/**
+ * @brief Test adis_write_dr_polarity invalid write.
+ */
+void test_adis_write_dr_polarity_3(void)
+{
+	uint32_t dr_polarity = 1;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_write_dr_polarity(&device_alloc, dr_polarity);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, retval);
+}
+
+/**
+ * @brief Test adis_read_sync_polarity successful SPI transfer.
+ */
+void test_adis_read_sync_polarity(void)
+{
+	uint32_t sync_polarity;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_sync_polarity(&device_alloc, &sync_polarity);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_sync_polarity successful SPI transfer.
+ */
+void test_adis_write_sync_polarity_1(void)
+{
+	uint32_t sync_polarity = 1;
+	device_alloc.info = adis_chip_info;
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	no_os_udelay_Ignore();
+	retval = adis_write_sync_polarity(&device_alloc, sync_polarity);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_sync_polarity invalid value.
+ */
+void test_adis_write_sync_polarity_2(void)
+{
+	uint32_t sync_polarity = 2;
+	device_alloc.info = adis_chip_info;
+
+	retval = adis_write_sync_polarity(&device_alloc, sync_polarity);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, retval);
+}
+
+/**
+ * @brief Test adis_write_sync_polarity invalid write.
+ */
+void test_adis_write_sync_polarity_3(void)
+{
+	uint32_t sync_polarity = 1;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_write_sync_polarity(&device_alloc, sync_polarity);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, retval);
+}
+
+/**
+ * @brief Test adis_read_sync_mode successful SPI transfer.
+ */
+void test_adis_read_sync_mode(void)
+{
+	uint32_t sync_mode;
+	device_alloc.info = adis_chip_info;
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_sync_mode(&device_alloc, &sync_mode);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_sync_mode invalid value for sync mode.
+ */
+void test_adis_write_sync_mode_1(void)
+{
+	uint32_t sync_mode;
+	uint32_t ext_clk = 0;
+	device_alloc.info = adis_chip_info;
+
+	sync_mode = adis_chip_info->sync_mode_max + 1;
+	retval = adis_write_sync_mode(&device_alloc, sync_mode, ext_clk);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, retval);
+}
+
+/**
+ * @brief Test adis_write_sync_mode with ADIS_SYNC_DIRECT with invalid external
+ * clock lower value.
+ */
+void test_adis_write_sync_mode_2(void)
+{
+	uint32_t sync_mode = ADIS_SYNC_DIRECT;
+	uint32_t ext_clk =
+		device_alloc.info->sync_clk_freq_limits[ADIS_SYNC_DIRECT].min_freq - 1;
+	device_alloc.info = adis_chip_info;
+
+	retval = adis_write_sync_mode(&device_alloc, sync_mode, ext_clk);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, retval);
+}
+
+/**
+ * @brief Test adis_write_sync_mode with ADIS_SYNC_DIRECT with invalid external
+ * clock upper value.
+ */
+void test_adis_write_sync_mode_3(void)
+{
+	uint32_t sync_mode = ADIS_SYNC_DIRECT;
+	uint32_t ext_clk =
+		device_alloc.info->sync_clk_freq_limits[ADIS_SYNC_DIRECT].max_freq + 1;
+	device_alloc.info = adis_chip_info;
+
+	retval = adis_write_sync_mode(&device_alloc, sync_mode, ext_clk);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, retval);
+}
+
+/**
+ * @brief Test adis_write_sync_mode with ADIS_SYNC_DIRECT with valid external
+ * clock.
+ */
+void test_adis_write_sync_mode_4(void)
+{
+	uint32_t sync_mode = ADIS_SYNC_DIRECT;
+	uint32_t ext_clk =
+		device_alloc.info->sync_clk_freq_limits[ADIS_SYNC_DIRECT].max_freq;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	retval = adis_write_sync_mode(&device_alloc, sync_mode, ext_clk);
+	TEST_ASSERT_EQUAL_INT(device_alloc.ext_clk, ext_clk);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_sync_mode with ADIS_SYNC_SCALED with invalid external
+ * clock lower value.
+ */
+void test_adis_write_sync_mode_5(void)
+{
+	uint32_t sync_mode = ADIS_SYNC_SCALED;
+	uint32_t ext_clk =
+		device_alloc.info->sync_clk_freq_limits[ADIS_SYNC_SCALED].min_freq - 1;
+	device_alloc.info = adis_chip_info;
+
+	retval = adis_write_sync_mode(&device_alloc, sync_mode, ext_clk);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, retval);
+}
+
+/**
+ * @brief Test adis_write_sync_mode with ADIS_SYNC_SCALED with valid external
+ * clock.
+ */
+void test_adis_write_sync_mode_6(void)
+{
+	uint32_t sync_mode = ADIS_SYNC_SCALED;
+	uint32_t ext_clk =
+		device_alloc.info->sync_clk_freq_limits[ADIS_SYNC_SCALED].min_freq;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(ADIS_SYNC_SCALED);
+	no_os_field_prep_IgnoreAndReturn(ADIS_SYNC_SCALED);
+	no_os_field_get_IgnoreAndReturn(ADIS_SYNC_SCALED);
+	no_os_field_get_IgnoreAndReturn(0xFFFF); // up_scale maximum
+	retval = adis_write_sync_mode(&device_alloc, sync_mode, ext_clk);
+	TEST_ASSERT_EQUAL_INT(device_alloc.ext_clk, ext_clk);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_sync_mode with ADIS_SYNC_SCALED with invalid transfer
+ * for up_scale.
+ */
+void test_adis_write_sync_mode_7(void)
+{
+	uint32_t sync_mode = ADIS_SYNC_SCALED;
+	uint32_t ext_clk = 10;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(ADIS_SYNC_SCALED);
+	no_os_field_get_IgnoreAndReturn(ADIS_SYNC_SCALED);
+	no_os_field_get_IgnoreAndReturn(0xFFFF); // up_scale maximum
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_write_sync_mode(&device_alloc, sync_mode, ext_clk);
+	TEST_ASSERT_EQUAL_INT(device_alloc.ext_clk, ext_clk);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_write_sync_mode with ADIS_SYNC_DEFAULT successful transfer.
+ */
+void test_adis_write_sync_mode_8(void)
+{
+	uint32_t sync_mode = ADIS_SYNC_DEFAULT;
+	uint32_t ext_clk = 10;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(ADIS_SYNC_DEFAULT);
+	no_os_field_prep_IgnoreAndReturn(ADIS_SYNC_DEFAULT);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(ADIS_SYNC_DEFAULT);
+	retval = adis_write_sync_mode(&device_alloc, sync_mode, ext_clk);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_sync_mode with ADIS_SYNC_OUTPUT successful transfer.
+ */
+void test_adis_write_sync_mode_9(void)
+{
+	uint32_t sync_mode = ADIS_SYNC_OUTPUT;
+	uint32_t ext_clk = 10;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(ADIS_SYNC_OUTPUT);
+	no_os_field_prep_IgnoreAndReturn(ADIS_SYNC_OUTPUT);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(ADIS_SYNC_OUTPUT);
+	retval = adis_write_sync_mode(&device_alloc, sync_mode, ext_clk);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_sens_bw successful SPI transfer.
+ */
+void test_adis_read_sens_bw(void)
+{
+	uint32_t sens_bw;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_sens_bw(&device_alloc, &sens_bw);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_sens_bw successful SPI transfer.
+ */
+void test_adis_write_sens_bw_1(void)
+{
+	uint32_t sens_bw = 1;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	no_os_mdelay_Ignore();
+	retval = adis_write_sens_bw(&device_alloc, sens_bw);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_sens_bw invalid write.
+ */
+void test_adis_write_sens_bw_2(void)
+{
+	uint32_t sens_bw = 1;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_write_sens_bw(&device_alloc, sens_bw);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, retval);
+}
+
+/**
+ * @brief Test adis_read_pt_of_perc_algnmt successful SPI transfer.
+ */
+void test_adis_read_pt_of_perc_algnmt(void)
+{
+	uint32_t pt_of_perc_algnmt;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_pt_of_perc_algnmt(&device_alloc, &pt_of_perc_algnmt);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_pt_of_perc_algnmt successful SPI transfer.
+ */
+void test_adis_write_pt_of_perc_algnmt_1(void)
+{
+	uint32_t pt_of_perc_algnmt = 1;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	no_os_udelay_Ignore();
+	retval = adis_write_pt_of_perc_algnmt(&device_alloc, pt_of_perc_algnmt);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_pt_of_perc_algnmt invalid write.
+ */
+void test_adis_write_pt_of_perc_algnmt_2(void)
+{
+	uint32_t pt_of_perc_algnmt = 1;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_write_pt_of_perc_algnmt(&device_alloc, pt_of_perc_algnmt);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, retval);
+}
+
+/**
+ * @brief Test adis_read_linear_accl_comp successful SPI transfer.
+ */
+void test_adis_read_linear_accl_comp(void)
+{
+	uint32_t linear_accl_comp;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_linear_accl_comp(&device_alloc, &linear_accl_comp);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_linear_accl_comp successful SPI transfer.
+ */
+void test_adis_write_linear_accl_comp_1(void)
+{
+	uint32_t linear_accl_comp = 1;
+	device_alloc.info = adis_chip_info;
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	no_os_udelay_Ignore();
+	retval = adis_write_linear_accl_comp(&device_alloc, linear_accl_comp);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_linear_accl_comp invalid write.
+ */
+void test_adis_write_linear_accl_comp_2(void)
+{
+	uint32_t linear_accl_comp = 1;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_write_linear_accl_comp(&device_alloc, linear_accl_comp);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, retval);
+}
+
+/**
+ * @brief Test adis_read_burst_sel successful SPI transfer.
+ */
+void test_adis_read_burst_sel(void)
+{
+	uint32_t burst_sel;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_burst_sel(&device_alloc, &burst_sel);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_burst_sel successful SPI transfer.
+ */
+void test_adis_write_burst_sel_1(void)
+{
+	uint32_t burst_sel = 1;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	no_os_udelay_Ignore();
+	retval = adis_write_burst_sel(&device_alloc, burst_sel);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_burst_sel invalid write.
+ */
+void test_adis_write_burst_sel_2(void)
+{
+	uint32_t burst_sel = 1;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_write_burst_sel(&device_alloc, burst_sel);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, retval);
+}
+
+/**
+ * @brief Test adis_read_burst32 successful SPI transfer.
+ */
+void test_adis_read_burst32(void)
+{
+	uint32_t burst32;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_burst32(&device_alloc, &burst32);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_burst32 successful SPI transfer.
+ */
+void test_adis_write_burst32_1(void)
+{
+	uint32_t burst32 = 1;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	no_os_udelay_Ignore();
+	retval = adis_write_burst32(&device_alloc, burst32);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_burst32 invalid write.
+ */
+void test_adis_write_burst32_2(void)
+{
+	uint32_t burst32 = 1;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_write_burst32(&device_alloc, burst32);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, retval);
+}
+
+/**
+ * @brief Test adis_read_timestamp32 successful SPI transfer.
+ */
+void test_adis_read_timestamp32(void)
+{
+	uint32_t timestamp32;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_timestamp32(&device_alloc, &timestamp32);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_timestamp32 successful SPI transfer.
+ */
+void test_adis_write_timestamp32_1(void)
+{
+	uint32_t timestamp32 = 1;
+	device_alloc.info = adis_chip_info;
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	no_os_udelay_Ignore();
+	retval = adis_write_timestamp32(&device_alloc, timestamp32);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_timestamp32 invalid write.
+ */
+void test_adis_write_timestamp32_2(void)
+{
+	uint32_t timestamp32 = 1;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_write_timestamp32(&device_alloc, timestamp32);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, retval);
+}
+
+/**
+ * @brief Test adis_read_sync_4khz successful SPI transfer.
+ */
+void test_adis_read_sync_4khz(void)
+{
+	uint32_t sync_4khz;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_sync_4khz(&device_alloc, &sync_4khz);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_sync_4khz successful SPI transfer with value 1.
+ */
+void test_adis_write_sync_4khz_1(void)
+{
+	uint32_t sync_4khz = 1;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	no_os_udelay_Ignore();
+	retval = adis_write_sync_4khz(&device_alloc, sync_4khz);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(device_alloc.int_clk, 4000);
+}
+
+/**
+ * @brief Test adis_write_sync_4khz successful SPI transfer with value 0.
+ */
+void test_adis_write_sync_4khz_2(void)
+{
+	uint32_t sync_4khz = 0;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	no_os_udelay_Ignore();
+	retval = adis_write_sync_4khz(&device_alloc, sync_4khz);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(device_alloc.int_clk, 2000);
+}
+
+/**
+ * @brief Test adis_write_sync_4khz invalid write.
+ */
+void test_adis_write_sync_4khz_3(void)
+{
+	uint32_t sync_4khz = 1;
+	device_alloc.info = adis_chip_info;
+
+	sync_4khz = 1;
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_write_sync_4khz(&device_alloc, sync_4khz);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, retval);
+}
+
+/**
+ * @brief Test adis_read_up_scale successful SPI transfer.
+ */
+void test_adis_read_up_scale(void)
+{
+	uint32_t up_scale;
+	device_alloc.info = adis_chip_info;
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_up_scale(&device_alloc, &up_scale);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_up_scale unsuccessful reading of sync mode.
+ */
+void test_adis_write_up_scale_1(void)
+{
+	uint32_t up_scale = 1;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_write_up_scale(&device_alloc, up_scale);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_write_up_scale with invalid up_scale parameter lower limit.
+ */
+void test_adis_write_up_scale_2(void)
+{
+	uint32_t up_scale = 0;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(ADIS_SYNC_SCALED);
+	no_os_field_get_IgnoreAndReturn(ADIS_SYNC_SCALED);
+	retval = adis_write_up_scale(&device_alloc, up_scale);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, retval);
+}
+
+/**
+ * @brief Test adis_write_up_scale with invalid up_scale parameter upper limit.
+ */
+void test_adis_write_up_scale_3(void)
+{
+	uint32_t up_scale = 2000;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(ADIS_SYNC_SCALED);
+	no_os_field_get_IgnoreAndReturn(ADIS_SYNC_SCALED);
+	retval = adis_write_up_scale(&device_alloc, up_scale);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, retval);
+}
+
+/**
+ * @brief Test adis_write_up_scale for sync mode != ADIS_SYNC_SCALED.
+ */
+void test_adis_write_up_scale_4(void)
+{
+	uint32_t up_scale = 0;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(ADIS_SYNC_DEFAULT);
+	no_os_field_get_IgnoreAndReturn(ADIS_SYNC_DEFAULT);
+	no_os_field_prep_IgnoreAndReturn(0);
+	retval = adis_write_up_scale(&device_alloc, up_scale);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_dec_rate successful SPI transfer.
+ */
+void test_adis_read_dec_rate(void)
+{
+	uint32_t dec_rate;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_dec_rate(&device_alloc, &dec_rate);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_dec_rate with invalid value.
+ */
+void test_adis_write_dec_rate_1(void)
+{
+	uint32_t dec_rate = adis_chip_info->dec_rate_max + 1;
+	device_alloc.info = adis_chip_info;
+
+	retval = adis_write_dec_rate(&device_alloc, dec_rate);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, retval);
+}
+
+/**
+ * @brief Test adis_write_dec_rate with valid value and unsuccessful SPI
+ * transfer.
+ */
+void test_adis_write_dec_rate_2(void)
+{
+	uint32_t dec_rate = 10;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	no_os_field_get_IgnoreAndReturn(dec_rate);
+	retval = adis_write_dec_rate(&device_alloc, dec_rate);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_write_dec_rate with valid value and successful SPI transfer.
+ */
+void test_adis_write_dec_rate_3(void)
+{
+	uint32_t dec_rate = 10;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(dec_rate);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	no_os_udelay_Ignore();
+	retval = adis_write_dec_rate(&device_alloc, dec_rate);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_bias_corr_tbc with successful SPI transfer.
+ */
+void test_adis_read_bias_corr_tbc(void)
+{
+	uint32_t bias_corr_tbc;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_bias_corr_tbc(&device_alloc, &bias_corr_tbc);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_bias_corr_tbc with invalid value.
+ */
+void test_adis_write_bias_corr_tbc_1(void)
+{
+	uint32_t bias_corr_tbc = adis_chip_info->bias_corr_tbc_max + 1;
+	device_alloc.info = adis_chip_info;
+
+	bias_corr_tbc = adis_chip_info->bias_corr_tbc_max + 1;
+	retval = adis_write_bias_corr_tbc(&device_alloc, bias_corr_tbc);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, retval);
+}
+
+/**
+ * @brief Test adis_write_bias_corr_tbc with valid value.
+ */
+void test_adis_write_bias_corr_tbc_2(void)
+{
+	uint32_t bias_corr_tbc = 1;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(bias_corr_tbc);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	retval = adis_write_bias_corr_tbc(&device_alloc, bias_corr_tbc);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_bias_corr_en_xg with successful SPI transfer.
+ */
+void test_adis_read_bias_corr_en_xg(void)
+{
+	uint32_t bias_corr_en_xg;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_bias_corr_en_xg(&device_alloc, &bias_corr_en_xg);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_bias_corr_en_xg with successful SPI transfer.
+ */
+void test_adis_write_bias_corr_en_xg(void)
+{
+	uint32_t bias_corr_en_xg = 1;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(bias_corr_en_xg);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	retval = adis_write_bias_corr_en_xg(&device_alloc, bias_corr_en_xg);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_bias_corr_en_yg with successful SPI transfer.
+ */
+void test_adis_read_bias_corr_en_yg(void)
+{
+	uint32_t bias_corr_en_yg;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_bias_corr_en_yg(&device_alloc, &bias_corr_en_yg);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_bias_corr_en_yg with successful SPI transfer.
+ */
+void test_adis_write_bias_corr_en_yg(void)
+{
+	uint32_t bias_corr_en_yg = 1;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(bias_corr_en_yg);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	retval = adis_write_bias_corr_en_yg(&device_alloc, bias_corr_en_yg);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_bias_corr_en_zg with successful SPI transfer.
+ */
+void test_adis_read_bias_corr_en_zg(void)
+{
+	uint32_t bias_corr_en_zg;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_bias_corr_en_zg(&device_alloc, &bias_corr_en_zg);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_bias_corr_en_zg with successful SPI transfer.
+ */
+void test_adis_write_bias_corr_en_zg(void)
+{
+	uint32_t bias_corr_en_zg = 1;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(bias_corr_en_zg);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	retval = adis_write_bias_corr_en_zg(&device_alloc, bias_corr_en_zg);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_bias_corr_en_xa with successful SPI transfer.
+ */
+void test_adis_read_bias_corr_en_xa(void)
+{
+	uint32_t bias_corr_en_xa;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_bias_corr_en_xa(&device_alloc, &bias_corr_en_xa);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_bias_corr_en_xa with successful SPI transfer.
+ */
+void test_adis_write_bias_corr_en_xa(void)
+{
+	uint32_t bias_corr_en_xa = 1;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(bias_corr_en_xa);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	retval = adis_write_bias_corr_en_xa(&device_alloc, bias_corr_en_xa);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_bias_corr_en_ya with successful SPI transfer.
+ */
+void test_adis_read_bias_corr_en_ya(void)
+{
+	uint32_t bias_corr_en_ya;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_bias_corr_en_ya(&device_alloc, &bias_corr_en_ya);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_bias_corr_en_ya with successful SPI transfer.
+ */
+void test_adis_write_bias_corr_en_ya(void)
+{
+	uint32_t bias_corr_en_ya = 1;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(bias_corr_en_ya);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	retval = adis_write_bias_corr_en_ya(&device_alloc, bias_corr_en_ya);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_bias_corr_en_za with successful SPI transfer.
+ */
+void test_adis_read_bias_corr_en_za(void)
+{
+	uint32_t bias_corr_en_za;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_bias_corr_en_za(&device_alloc, &bias_corr_en_za);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_bias_corr_en_za with successful SPI transfer.
+ */
+void test_adis_write_bias_corr_en_za(void)
+{
+	uint32_t bias_corr_en_za = 1;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(bias_corr_en_za);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	retval = adis_write_bias_corr_en_za(&device_alloc, bias_corr_en_za);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_cmd_bias_corr_update with successful SPI transfer.
+ */
+void test_adis_cmd_bias_corr_update(void)
+{
+	device_alloc.info = adis_chip_info;
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	retval = adis_cmd_bias_corr_update(&device_alloc);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_cmd_fact_calib_restore with unsuccessful SPI transfer.
+ */
+void test_adis_cmd_fact_calib_restore_1(void)
+{
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_cmd_fact_calib_restore(&device_alloc);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_cmd_fact_calib_restore with successful SPI transfer.
+ */
+void test_adis_cmd_fact_calib_restore_2(void)
+{
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_mdelay_Ignore();
+	retval = adis_cmd_fact_calib_restore(&device_alloc);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_cmd_snsr_self_test with unsuccessful SPI transfer.
+ */
+void test_adis_cmd_snsr_self_test_1(void)
+{
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_cmd_snsr_self_test(&device_alloc);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_cmd_snsr_self_test with successful SPI transfer.
+ */
+void test_adis_cmd_snsr_self_test_2(void)
+{
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_mdelay_Ignore();
+	retval = adis_cmd_snsr_self_test(&device_alloc);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_cmd_fls_mem_update with unsuccessful SPI transfer.
+ */
+void test_adis_cmd_fls_mem_update_1(void)
+{
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_cmd_fls_mem_update(&device_alloc);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_cmd_fls_mem_update with successful SPI transfer.
+ */
+void test_adis_cmd_fls_mem_update_2(void)
+{
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_mdelay_Ignore();
+	no_os_get_unaligned_be32_IgnoreAndReturn(1);
+	no_os_field_get_IgnoreAndReturn(1);
+	retval = adis_cmd_fls_mem_update(&device_alloc);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_cmd_fls_mem_test with unsuccessful SPI transfer.
+ */
+void test_adis_cmd_fls_mem_test_1(void)
+{
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_cmd_fls_mem_test(&device_alloc);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_cmd_fls_mem_test with successful SPI transfer.
+ */
+void test_adis_cmd_fls_mem_test_2(void)
+{
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_mdelay_Ignore();
+	retval = adis_cmd_fls_mem_test(&device_alloc);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_cmd_fifo_flush with successful SPI transfer.
+ */
+void test_adis_cmd_fifo_flush(void)
+{
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	retval = adis_cmd_fifo_flush(&device_alloc);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_cmd_sw_res with unsuccessful SPI transfer.
+ */
+void test_adis_cmd_sw_res_1(void)
+{
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_cmd_sw_res(&device_alloc);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_cmd_sw_res with successful SPI transfer.
+ */
+void test_adis_cmd_sw_res_2(void)
+{
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_mdelay_Ignore();
+	retval = adis_cmd_sw_res(&device_alloc);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_firm_rev with successful SPI read.
+ */
+void test_adis_read_firm_rev(void)
+{
+	uint32_t firm_rev;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_firm_rev(&device_alloc, &firm_rev);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_firm_d with successful SPI read.
+ */
+void test_adis_read_firm_d(void)
+{
+	uint32_t firm_d;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_firm_d(&device_alloc, &firm_d);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_firm_m with successful SPI read.
+ */
+void test_adis_read_firm_m(void)
+{
+	uint32_t firm_m;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_firm_m(&device_alloc, &firm_m);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_firm_y with successful SPI read.
+ */
+void test_adis_read_firm_y(void)
+{
+	uint32_t firm_y;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_firm_y(&device_alloc, &firm_y);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_prod_id with successful SPI read.
+ */
+void test_adis_read_prod_id(void)
+{
+	uint32_t prod_id;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_prod_id(&device_alloc, &prod_id);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_serial_num with successful SPI read.
+ */
+void test_adis_read_serial_num(void)
+{
+	uint32_t serial_num;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_serial_num(&device_alloc, &serial_num);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_usr_scr_1 with successful SPI read.
+ */
+void test_adis_read_usr_scr_1(void)
+{
+	uint32_t usr_scr_1;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_usr_scr_1(&device_alloc, &usr_scr_1);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_usr_scr_1 with successful SPI write.
+ */
+void test_adis_write_usr_scr_1(void)
+{
+	uint32_t usr_scr_1 = 100;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(usr_scr_1);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	retval = adis_write_usr_scr_1(&device_alloc, usr_scr_1);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_usr_scr_2 with successful SPI read.
+ */
+void test_adis_read_usr_scr_2(void)
+{
+	uint32_t usr_scr_2;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_usr_scr_2(&device_alloc, &usr_scr_2);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_usr_scr_2 with successful SPI write.
+ */
+void test_adis_write_usr_scr_2(void)
+{
+	uint32_t usr_scr_2 = 100;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(usr_scr_2);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	retval = adis_write_usr_scr_2(&device_alloc, usr_scr_2);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_usr_scr_3 with successful SPI read.
+ */
+void test_adis_read_usr_scr_3(void)
+{
+	uint32_t usr_scr_3;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(0);
+	retval = adis_read_usr_scr_3(&device_alloc, &usr_scr_3);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_write_usr_scr_3 with successful SPI write.
+ */
+void test_adis_write_usr_scr_3(void)
+{
+	uint32_t usr_scr_3 = 100;
+	device_alloc.info = adis_chip_info;
+
+	no_os_field_get_IgnoreAndReturn(usr_scr_3);
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	no_os_field_prep_IgnoreAndReturn(0);
+	retval = adis_write_usr_scr_3(&device_alloc, usr_scr_3);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_read_fls_mem_wr_cntr with unsuccessful SPI read.
+ */
+void test_adis_read_fls_mem_wr_cntr_1(void)
+{
+	uint32_t fls_mem_wr_cntr;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_read_fls_mem_wr_cntr(&device_alloc, &fls_mem_wr_cntr);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_read_fls_mem_wr_cntr with successful SPI read and with
+ * write counter higher than exceeded value.
+ */
+void test_adis_read_fls_mem_wr_cntr_2(void)
+{
+	uint32_t fls_mem_wr_cntr;
+	device_alloc.info = adis_chip_info;
+
+	device_alloc.diag_flags.fls_mem_wr_cnt_exceed = false;
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(adis_chip_info->fls_mem_wr_cntr_max+1);
+	retval = adis_read_fls_mem_wr_cntr(&device_alloc, &fls_mem_wr_cntr);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(true, device_alloc.diag_flags.fls_mem_wr_cnt_exceed);
+}
+
+/**
+ * @brief Test adis_read_fls_mem_wr_cntr with successful SPI read and with
+ * write counter lower than exceeded value.
+ */
+void test_adis_read_fls_mem_wr_cntr_3(void)
+{
+	uint32_t fls_mem_wr_cntr;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be32_IgnoreAndReturn(0);
+	no_os_field_get_IgnoreAndReturn(adis_chip_info->fls_mem_wr_cntr_max);
+	retval = adis_read_fls_mem_wr_cntr(&device_alloc, &fls_mem_wr_cntr);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(true, device_alloc.diag_flags.fls_mem_wr_cnt_exceed);
+}
+
+/**
+ * @brief Test adis_read_burst_data with unsuccessful SPI burst read.
+ */
+void test_adis_read_burst_data_1(void)
+{
+	device_alloc.info = adis_chip_info;
+	uint16_t burst_data[14] = {0};
+
+	no_os_spi_write_and_read_IgnoreAndReturn(-1);
+	retval = adis_read_burst_data(&device_alloc, 14, burst_data, 0);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_read_burst_data with unsuccessful SPI burst read when
+ * the previous burst request was successful.
+ */
+void test_adis_read_burst_data_2(void)
+{
+	device_alloc.info = adis_chip_info;
+	uint16_t burst_data[14] = {0};
+
+	no_os_spi_write_and_read_IgnoreAndReturn(0);
+	no_os_udelay_Ignore();
+	no_os_spi_write_and_read_IgnoreAndReturn(-1);
+	retval = adis_read_burst_data(&device_alloc, 14, burst_data, 0);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_read_burst_data with checksum error.
+ */
+void test_adis_read_burst_data_3(void)
+{
+	device_alloc.info = adis_chip_info;
+	uint16_t burst_data[14] = {0};
+
+	device_alloc.info = adis_chip_info;
+	no_os_spi_write_and_read_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	retval = adis_read_burst_data(&device_alloc, 14, burst_data, 0);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, retval);
+	TEST_ASSERT_EQUAL_INT(true, device_alloc.diag_flags.checksum_err);
+}
+
+/**
+ * @brief Test adis_read_burst_data with checksum error when
+ * the previous burst request was successful.
+ */
+void test_adis_read_burst_data_4(void)
+{
+	device_alloc.info = adis_chip_info;
+	uint16_t burst_data[14] = {0};
+
+	no_os_spi_write_and_read_IgnoreAndReturn(0);
+	no_os_udelay_Ignore();
+	no_os_spi_write_and_read_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(0);
+	retval = adis_read_burst_data(&device_alloc, 14, burst_data, 0);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, retval);
+	TEST_ASSERT_EQUAL_INT(true, device_alloc.diag_flags.checksum_err);
+}
+
+/**
+ * @brief Test adis_read_burst_data with unsuccessful SPI burst read when the
+ * message size requested is bigger than needed.
+ */
+void test_adis_read_burst_data_5(void)
+{
+	device_alloc.info = adis_chip_info;
+	uint16_t burst_data[20] = {0};
+
+	no_os_spi_write_and_read_IgnoreAndReturn(-1);
+	retval = adis_read_burst_data(&device_alloc, 20, burst_data, 0);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_update_ext_clk_freq with unsuccessful SPI read for
+ * sync mode.
+ */
+void test_adis_update_ext_clk_freq_1(void)
+{
+	uint32_t clk_freq = 100;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_update_ext_clk_freq(&device_alloc, clk_freq);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_update_ext_clk_freq with sync mode set to ADIS_SYNC_DEFAULT.
+ */
+void test_adis_update_ext_clk_freq_2(void)
+{
+	uint32_t clk_freq = 100;
+	device_alloc.info = adis_chip_info;
+
+	/* Test sync mode ADIS_SYNC_DEFAULT */
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(ADIS_SYNC_DEFAULT);
+	no_os_field_get_IgnoreAndReturn(ADIS_SYNC_DEFAULT);
+	retval = adis_update_ext_clk_freq(&device_alloc, clk_freq);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(clk_freq, device_alloc.ext_clk);
+}
+
+/**
+ * @brief Test adis_update_ext_clk_freq with sync mode set to ADIS_SYNC_OUTPUT.
+ */
+void test_adis_update_ext_clk_freq_3(void)
+{
+	uint32_t clk_freq = 100;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(ADIS_SYNC_OUTPUT);
+	no_os_field_get_IgnoreAndReturn(ADIS_SYNC_OUTPUT);
+	retval = adis_update_ext_clk_freq(&device_alloc, clk_freq);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(clk_freq, device_alloc.ext_clk);
+}
+
+/**
+ * @brief Test adis_update_ext_clk_freq with sync mode set to ADIS_SYNC_DIRECT
+ * with invalid clk_freq for lower limit.
+ */
+void test_adis_update_ext_clk_freq_4(void)
+{
+	uint32_t clk_freq = 0;
+	uint32_t clk_freq_before = device_alloc.ext_clk;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(ADIS_SYNC_DIRECT);
+	no_os_field_get_IgnoreAndReturn(ADIS_SYNC_DIRECT);
+	retval = adis_update_ext_clk_freq(&device_alloc, clk_freq);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, retval);
+	TEST_ASSERT_EQUAL_INT(clk_freq_before, device_alloc.ext_clk);
+}
+
+/**
+ * @brief Test adis_update_ext_clk_freq with sync mode set to ADIS_SYNC_DIRECT
+ * with invalid clk_freq for upper limit.
+ */
+void test_adis_update_ext_clk_freq_5(void)
+{
+	uint32_t clk_freq = 10000;
+	uint32_t clk_freq_before = device_alloc.ext_clk;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(ADIS_SYNC_DIRECT);
+	no_os_field_get_IgnoreAndReturn(ADIS_SYNC_DIRECT);
+	retval = adis_update_ext_clk_freq(&device_alloc, clk_freq);
+	TEST_ASSERT_EQUAL_INT(-EINVAL, retval);
+	TEST_ASSERT_EQUAL_INT(clk_freq_before, device_alloc.ext_clk);
+}
+
+/**
+ * @brief Test adis_update_ext_clk_freq with sync mode set to ADIS_SYNC_DIRECT
+ * with valid clk_freq.
+ */
+void test_adis_update_ext_clk_freq_6(void)
+{
+	uint32_t clk_freq = 2000;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(ADIS_SYNC_DIRECT);
+	no_os_field_get_IgnoreAndReturn(ADIS_SYNC_DIRECT);
+	retval = adis_update_ext_clk_freq(&device_alloc, clk_freq);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+	TEST_ASSERT_EQUAL_INT(clk_freq, device_alloc.ext_clk);
+}
+
+/**
+ * @brief Test adis_get_sync_clk_freq with unsuccessful SPI read for
+ * sync mode.
+ */
+void test_adis_get_sync_clk_freq_1(void)
+{
+	uint32_t clk_freq;
+	device_alloc.info = adis_chip_info;
+
+	/* Test invalid sync mode spi reading */
+	no_os_spi_transfer_IgnoreAndReturn(-1);
+	retval = adis_get_sync_clk_freq(&device_alloc, &clk_freq);
+	TEST_ASSERT_EQUAL_INT(-1, retval);
+}
+
+/**
+ * @brief Test adis_get_sync_clk_freq with sync mode set to ADIS_SYNC_DEFAULT.
+ */
+void test_adis_get_sync_clk_freq_2(void)
+{
+	uint32_t clk_freq;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(ADIS_SYNC_DEFAULT);
+	no_os_field_get_IgnoreAndReturn(ADIS_SYNC_DEFAULT);
+	retval = adis_get_sync_clk_freq(&device_alloc, &clk_freq);
+	TEST_ASSERT_EQUAL_INT(2000, clk_freq);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_get_sync_clk_freq with sync mode set to ADIS_SYNC_OUTPUT.
+ */
+void test_adis_get_sync_clk_freq_3(void)
+{
+	uint32_t clk_freq;
+	device_alloc.info = adis_chip_info;
+
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(ADIS_SYNC_OUTPUT);
+	no_os_field_get_IgnoreAndReturn(ADIS_SYNC_OUTPUT);
+	retval = adis_get_sync_clk_freq(&device_alloc, &clk_freq);
+	TEST_ASSERT_EQUAL_INT(2000, clk_freq);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}
+
+/**
+ * @brief Test adis_get_sync_clk_freq with sync mode set to ADIS_SYNC_DIRECT.
+ */
+void test_adis_get_sync_clk_freq_4(void)
+{
+	uint32_t clk_freq;
+	device_alloc.info = adis_chip_info;
+
+	device_alloc.ext_clk = 2100;
+	no_os_spi_transfer_IgnoreAndReturn(0);
+	no_os_get_unaligned_be16_IgnoreAndReturn(ADIS_SYNC_DIRECT);
+	no_os_field_get_IgnoreAndReturn(ADIS_SYNC_DIRECT);
+	retval = adis_get_sync_clk_freq(&device_alloc, &clk_freq);
+	TEST_ASSERT_EQUAL_INT(2100, clk_freq);
+	TEST_ASSERT_EQUAL_INT(0, retval);
+}

--- a/tests/drivers/imu/test/test_adis16505.c
+++ b/tests/drivers/imu/test/test_adis16505.c
@@ -1,0 +1,595 @@
+/***************************************************************************//**
+ *   @file   test_adis16505.c
+ *   @brief  Implementation of test_adis16505.c
+ *   @author RBolboac (ramona.bolboaca@analog.com)
+ *******************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+/*******************************************************************************
+ *    INCLUDED FILES
+ ******************************************************************************/
+
+#include "unity.h"
+#include "adis.h"
+#include "adis16505.h"
+#include "test_adis.c"
+#include "mock_no_os_delay.h"
+#include "mock_no_os_util.h"
+#include "mock_no_os_i2c.h"
+#include "mock_no_os_gpio.h"
+#include "mock_no_os_spi.h"
+#include "mock_no_os_alloc.h"
+#include <errno.h>
+
+/*******************************************************************************
+ *    PUBLIC DATA
+ ******************************************************************************/
+
+struct adis_chip_info *adis_chip_info;
+
+/*******************************************************************************
+ *    SETUP, TEARDOWN
+ ******************************************************************************/
+
+void setUp(void)
+{
+	adis_chip_info = &adis16505_chip_info;
+}
+
+void tearDown(void)
+{
+}
+
+/*******************************************************************************
+ *    TESTS
+ ******************************************************************************/
+
+void test_adis16505_init(void)
+{
+	test_adis_init_1();
+	test_adis_init_2();
+	test_adis_init_3();
+	test_adis_init_4();
+	test_adis_init_5();
+	test_adis_init_6();
+}
+
+void test_adis16505_remove(void)
+{
+	test_adis_remove_1();
+	test_adis_remove_2();
+}
+
+void test_adis16505_initial_startup(void)
+{
+	test_adis_initial_startup_1();
+	test_adis_initial_startup_2();
+	test_adis_initial_startup_3();
+}
+
+void test_adis16505_read_reg(void)
+{
+	test_adis_read_reg();
+}
+
+void test_adis16505_read_field_s32(void)
+{
+	test_adis_read_field_s32();
+}
+
+void test_adis16505_write_reg(void)
+{
+	test_adis_write_reg_1();
+	test_adis_write_reg_2();
+}
+
+void test_adis16505_read_diag_data_path_overrun(void)
+{
+	test_adis_read_diag_data_path_overrun_1();
+	test_adis_read_diag_data_path_overrun_2();
+	test_adis_read_diag_data_path_overrun_3();
+}
+
+void test_adis16505_read_diag_fls_mem_update_failure(void)
+{
+	test_adis_read_diag_fls_mem_update_failure_1();
+	test_adis_read_diag_fls_mem_update_failure_2();
+	test_adis_read_diag_fls_mem_update_failure_3();
+}
+
+void test_adis16505_read_diag_spi_comm_err(void)
+{
+	test_adis_read_diag_spi_comm_err_1();
+	test_adis_read_diag_spi_comm_err_2();
+	test_adis_read_diag_spi_comm_err_3();
+}
+
+void test_adis16505_read_diag_standby_mode(void)
+{
+	test_adis_read_diag_standby_mode_1();
+	test_adis_read_diag_standby_mode_2();
+	test_adis_read_diag_standby_mode_3();
+}
+
+void test_adis16505_read_diag_snsr_failure(void)
+{
+	test_adis_read_diag_snsr_failure_1();
+	test_adis_read_diag_snsr_failure_2();
+	test_adis_read_diag_snsr_failure_3();
+}
+
+void test_adis16505_read_diag_mem_failure(void)
+{
+	test_adis_read_diag_mem_failure_1();
+	test_adis_read_diag_mem_failure_2();
+	test_adis_read_diag_mem_failure_3();
+}
+
+void test_adis16505_read_diag_clk_err(void)
+{
+	test_adis_read_diag_clk_err_1();
+	test_adis_read_diag_clk_err_2();
+	test_adis_read_diag_clk_err_3();
+}
+
+void test_adis16505_read_diag_gyro2_failure(void)
+{
+	test_adis_read_diag_gyro2_failure_1();
+	test_adis_read_diag_gyro2_failure_2();
+	test_adis_read_diag_gyro2_failure_3();
+}
+
+void test_adis16505_read_diag_gyro1_failure(void)
+{
+	test_adis_read_diag_gyro1_failure_1();
+	test_adis_read_diag_gyro1_failure_2();
+	test_adis_read_diag_gyro1_failure_3();
+}
+
+void test_adis16505_read_diag_accl_failure(void)
+{
+	test_adis_read_diag_accl_failure_1();
+	test_adis_read_diag_accl_failure_2();
+	test_adis_read_diag_accl_failure_3();
+}
+
+void test_adis16505_read_diag_checksum_err(void)
+{
+	test_adis_read_diag_checksum_err_1();
+	test_adis_read_diag_checksum_err_2();
+}
+
+void test_adis16505_read_diag_fls_mem_wr_cnt_exceed(void)
+{
+	test_adis_read_diag_fls_mem_wr_cnt_exceed_1();
+	test_adis_read_diag_fls_mem_wr_cnt_exceed_2();
+}
+
+void test_adis16505_read_x_gyro(void)
+{
+	test_adis_read_x_gyro_3();
+}
+
+void test_adis16505_read_y_gyro(void)
+{
+	test_adis_read_y_gyro_3();
+}
+
+void test_adis16505_read_z_gyro(void)
+{
+	test_adis_read_z_gyro_3();
+}
+
+void test_adis16505_read_x_accl(void)
+{
+	test_adis_read_x_accl_3();
+}
+
+void test_adis16505_read_y_accl(void)
+{
+	test_adis_read_y_accl_3();
+}
+
+void test_adis16505_read_z_accl(void)
+{
+	test_adis_read_z_accl_3();
+}
+
+void test_adis16505_read_temp_out(void)
+{
+	test_adis_read_temp_out_3();
+}
+
+void test_adis16505_read_time_stamp(void)
+{
+	test_adis_read_time_stamp_size16();
+}
+
+void test_adis16505_read_data_cntr(void)
+{
+	test_adis_read_data_cntr();
+}
+
+void test_adis16505_read_x_deltang(void)
+{
+	test_adis_read_x_deltang_3();
+}
+
+void test_adis16505_read_y_deltang(void)
+{
+	test_adis_read_y_deltang_3();
+}
+
+void test_adis16505_read_z_deltang(void)
+{
+	test_adis_read_z_deltang_3();
+}
+
+void test_adis16505_read_x_deltvel(void)
+{
+	test_adis_read_x_deltvel_3();
+}
+
+void test_adis16505_read_y_deltvel(void)
+{
+	test_adis_read_y_deltvel_3();
+}
+
+void test_adis16505_read_z_deltvel(void)
+{
+	test_adis_read_z_deltvel_3();
+}
+
+void test_adis16505_read_xg_bias(void)
+{
+	test_adis_read_xg_bias();
+}
+
+void test_adis16505_write_xg_bias(void)
+{
+	test_adis_write_xg_bias();
+}
+
+void test_adis16505_read_yg_bias(void)
+{
+	test_adis_read_yg_bias();
+}
+
+void test_adis16505_write_yg_bias(void)
+{
+	test_adis_write_yg_bias();
+}
+
+void test_adis16505_read_zg_bias(void)
+{
+	test_adis_read_zg_bias();
+}
+
+void test_adis16505_write_zg_bias(void)
+{
+	test_adis_write_zg_bias();
+}
+
+void test_adis16505_read_xa_bias(void)
+{
+	test_adis_read_xa_bias();
+}
+
+void test_adis16505_write_xa_bias(void)
+{
+	test_adis_write_xa_bias();
+}
+
+void test_adis16505_read_ya_bias(void)
+{
+	test_adis_read_ya_bias();
+}
+
+void test_adis16505_write_ya_bias(void)
+{
+	test_adis_write_ya_bias();
+}
+
+void test_adis16505_read_za_bias(void)
+{
+	test_adis_read_za_bias();
+}
+
+void test_adis16505_write_za_bias(void)
+{
+	test_adis_write_za_bias();
+}
+
+
+void test_adis16505_read_filt_size_var_b(void)
+{
+	test_adis_read_filt_size_var_b();
+}
+
+void test_adis16505_write_filt_size_var_b(void)
+{
+	test_adis_write_filt_size_var_b_1();
+	test_adis_write_filt_size_var_b_2();
+	test_adis_write_filt_size_var_b_3();
+}
+
+void test_adis16505_read_gyro_meas_range(void)
+{
+	test_adis_read_gyro_meas_range();
+}
+
+void test_adis16505_read_dr_polarity(void)
+{
+	test_adis_read_dr_polarity();
+}
+
+void test_adis16505_write_dr_polarity(void)
+{
+	test_adis_write_dr_polarity_1();
+	test_adis_write_dr_polarity_2();
+	test_adis_write_dr_polarity_3();
+}
+
+void test_adis16505_read_sync_polarity(void)
+{
+	test_adis_read_sync_polarity();
+}
+
+void test_adis16505_write_sync_polarity(void)
+{
+	test_adis_write_sync_polarity_1();
+	test_adis_write_sync_polarity_2();
+	test_adis_write_sync_polarity_3();
+}
+
+void test_adis16505_read_sync_mode(void)
+{
+	test_adis_read_sync_mode();
+}
+
+void test_adis16505_write_sync_mode(void)
+{
+	test_adis_write_sync_mode_1();
+	test_adis_write_sync_mode_2();
+	test_adis_write_sync_mode_3();
+	test_adis_write_sync_mode_4();
+	test_adis_write_sync_mode_5();
+	test_adis_write_sync_mode_6();
+	test_adis_write_sync_mode_7();
+	test_adis_write_sync_mode_8();
+	test_adis_write_sync_mode_9();
+}
+
+void test_adis16505_read_sens_bw(void)
+{
+	test_adis_read_sens_bw();
+}
+
+void test_adis16505_write_sens_bw(void)
+{
+	test_adis_write_sens_bw_1();
+	test_adis_write_sens_bw_2();
+}
+
+void test_adis16505_read_pt_of_perc_algnmt(void)
+{
+	test_adis_read_pt_of_perc_algnmt();
+}
+
+void test_adis16505_write_pt_of_perc_algnmt(void)
+{
+	test_adis_write_pt_of_perc_algnmt_1();
+	test_adis_write_pt_of_perc_algnmt_2();
+}
+
+void test_adis16505_read_linear_accl_comp(void)
+{
+	test_adis_read_linear_accl_comp();
+}
+
+void test_adis16505_write_linear_accl_comp(void)
+{
+	test_adis_write_linear_accl_comp_1();
+	test_adis_write_linear_accl_comp_2();
+}
+
+void test_adis16505_read_burst_sel(void)
+{
+	test_adis_read_burst_sel();
+}
+
+void test_adis16505_write_burst_sel(void)
+{
+	test_adis_write_burst_sel_1();
+	test_adis_write_burst_sel_2();
+}
+
+void test_adis16505_read_burst32(void)
+{
+	test_adis_read_burst32();
+}
+
+void test_adis16505_write_burst32(void)
+{
+	test_adis_write_burst32_1();
+	test_adis_write_burst32_2();
+}
+
+void test_adis16505_read_up_scale(void)
+{
+	test_adis_read_up_scale();
+}
+
+void test_adis16505_write_up_scale(void)
+{
+	test_adis_write_up_scale_1();
+	test_adis_write_up_scale_2();
+	test_adis_write_up_scale_3();
+	test_adis_write_up_scale_4();
+}
+
+void test_adis16505_read_dec_rate(void)
+{
+	test_adis_read_dec_rate();
+}
+
+void test_adis16505_write_dec_rate(void)
+{
+	test_adis_write_dec_rate_1();
+	test_adis_write_dec_rate_2();
+	test_adis_write_dec_rate_3();
+}
+
+void test_adis16505_cmd_fact_calib_restore(void)
+{
+	test_adis_cmd_fact_calib_restore_1();
+	test_adis_cmd_fact_calib_restore_2();
+}
+
+void test_adis16505_cmd_snsr_self_test()
+{
+	test_adis_cmd_snsr_self_test_1();
+	test_adis_cmd_snsr_self_test_2();
+}
+
+void test_adis16505_cmd_fls_mem_update(void)
+{
+	test_adis_cmd_fls_mem_update_1();
+	test_adis_cmd_fls_mem_update_2();
+}
+
+void test_adis16505_cmd_fls_mem_test(void)
+{
+	test_adis_cmd_fls_mem_test_1();
+	test_adis_cmd_fls_mem_test_2();
+}
+
+void test_adis16505_cmd_sw_res(void)
+{
+	test_adis_cmd_sw_res_1();
+	test_adis_cmd_sw_res_2();
+}
+
+void test_adis16505_read_firm_rev(void)
+{
+	test_adis_read_firm_rev();
+}
+
+void test_adis16505_read_firm_d(void)
+{
+	test_adis_read_firm_d();
+}
+
+void test_adis16505_read_firm_m(void)
+{
+	test_adis_read_firm_m();
+}
+
+void test_adis16505_read_firm_y(void)
+{
+	test_adis_read_firm_y();
+}
+
+void test_adis16505_read_prod_id(void)
+{
+	test_adis_read_prod_id();
+}
+
+void test_adis16505_read_serial_num(void)
+{
+	test_adis_read_serial_num();
+}
+
+void test_adis16505_read_usr_scr_1(void)
+{
+	test_adis_read_usr_scr_1();
+}
+
+void test_adis16505_write_usr_scr_1(void)
+{
+	test_adis_write_usr_scr_1();
+}
+
+void test_adis16505_read_usr_scr_2(void)
+{
+	test_adis_read_usr_scr_2();
+}
+
+void test_adis16505_write_usr_scr_2(void)
+{
+	test_adis_write_usr_scr_2();
+}
+
+void test_adis16505_read_usr_scr_3(void)
+{
+	test_adis_read_usr_scr_3();
+}
+
+void test_adis16505_write_usr_scr_3(void)
+{
+	test_adis_write_usr_scr_3();
+}
+
+void test_adis16505_read_fls_mem_wr_cntr(void)
+{
+	test_adis_read_fls_mem_wr_cntr_1();
+	test_adis_read_fls_mem_wr_cntr_2();
+	test_adis_read_fls_mem_wr_cntr_3();
+}
+
+void test_adis16505_read_burst_data(void)
+{
+	test_adis_read_burst_data_1();
+	test_adis_read_burst_data_3();
+	test_adis_read_burst_data_5();
+}
+
+void test_adis16505_update_ext_clk_freq(void)
+{
+	test_adis_update_ext_clk_freq_1();
+	test_adis_update_ext_clk_freq_2();
+	test_adis_update_ext_clk_freq_3();
+	test_adis_update_ext_clk_freq_4();
+	test_adis_update_ext_clk_freq_5();
+	test_adis_update_ext_clk_freq_6();
+}
+
+void test_adis16505_get_sync_clk_freq(void)
+{
+	test_adis_get_sync_clk_freq_1();
+	test_adis_get_sync_clk_freq_2();
+	test_adis_get_sync_clk_freq_3();
+	test_adis_get_sync_clk_freq_4();
+}

--- a/tests/drivers/imu/test/test_adis1657x.c
+++ b/tests/drivers/imu/test/test_adis1657x.c
@@ -1,0 +1,822 @@
+/***************************************************************************//**
+ *   @file   test_adis1657x.c
+ *   @brief  Implementation of test_adis1657x.c
+ *   @author RBolboac (ramona.bolboaca@analog.com)
+ *******************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+/*******************************************************************************
+ *    INCLUDED FILES
+ ******************************************************************************/
+
+#include "unity.h"
+#include "adis.h"
+#include "adis1657x.h"
+#include "test_adis.c"
+#include "mock_no_os_delay.h"
+#include "mock_no_os_util.h"
+#include "mock_no_os_i2c.h"
+#include "mock_no_os_gpio.h"
+#include "mock_no_os_spi.h"
+#include "mock_no_os_alloc.h"
+#include <errno.h>
+
+/*******************************************************************************
+ *    PUBLIC DATA
+ ******************************************************************************/
+
+struct adis_chip_info *adis_chip_info;
+
+/*******************************************************************************
+ *    SETUP, TEARDOWN
+ ******************************************************************************/
+
+void setUp(void)
+{
+	adis_chip_info = &adis1657x_chip_info;
+}
+
+void tearDown(void)
+{
+}
+
+/*******************************************************************************
+ *    TESTS
+ ******************************************************************************/
+
+void test_adis1657x_init(void)
+{
+	test_adis_init_1();
+	test_adis_init_2();
+	test_adis_init_3();
+	test_adis_init_4();
+	test_adis_init_5();
+	test_adis_init_6();
+}
+
+void test_adis1657x_remove(void)
+{
+	test_adis_remove_1();
+	test_adis_remove_2();
+}
+
+void test_adis1657x_initial_startup(void)
+{
+	test_adis_initial_startup_1();
+	test_adis_initial_startup_2();
+	test_adis_initial_startup_3();
+}
+
+void test_adis1657x_read_reg(void)
+{
+	test_adis_read_reg();
+}
+
+void test_adis1657x_write_reg(void)
+{
+	test_adis_write_reg_1();
+	test_adis_write_reg_2();
+}
+
+void test_adis16505_read_field_s32(void)
+{
+	test_adis_read_field_s32();
+}
+
+void test_adis1657x_read_diag_snsr_init_failure(void)
+{
+	test_adis_read_diag_snsr_init_failure_1();
+	test_adis_read_diag_snsr_init_failure_2();
+	test_adis_read_diag_snsr_init_failure_3();
+}
+
+void test_adis1657x_read_diag_data_path_overrun(void)
+{
+	test_adis_read_diag_data_path_overrun_1();
+	test_adis_read_diag_data_path_overrun_2();
+	test_adis_read_diag_data_path_overrun_3();
+}
+
+void test_adis1657x_read_diag_fls_mem_update_failure(void)
+{
+	test_adis_read_diag_fls_mem_update_failure_1();
+	test_adis_read_diag_fls_mem_update_failure_2();
+	test_adis_read_diag_fls_mem_update_failure_3();
+}
+
+void test_adis1657x_read_diag_spi_comm_err(void)
+{
+	test_adis_read_diag_spi_comm_err_1();
+	test_adis_read_diag_spi_comm_err_2();
+	test_adis_read_diag_spi_comm_err_3();
+}
+
+void test_adis1657x_read_diag_standby_mode(void)
+{
+	test_adis_read_diag_standby_mode_1();
+	test_adis_read_diag_standby_mode_2();
+	test_adis_read_diag_standby_mode_3();
+}
+
+void test_adis1657x_read_diag_snsr_failure(void)
+{
+	test_adis_read_diag_snsr_failure_1();
+	test_adis_read_diag_snsr_failure_2();
+	test_adis_read_diag_snsr_failure_3();
+}
+
+void test_adis1657x_read_diag_mem_failure(void)
+{
+	test_adis_read_diag_mem_failure_1();
+	test_adis_read_diag_mem_failure_2();
+	test_adis_read_diag_mem_failure_3();
+}
+
+void test_adis1657x_read_diag_clk_err(void)
+{
+	test_adis_read_diag_clk_err_1();
+	test_adis_read_diag_clk_err_2();
+	test_adis_read_diag_clk_err_3();
+}
+
+void test_adis1657x_read_diag_x_axis_gyro_failure(void)
+{
+	test_adis_read_diag_x_axis_gyro_failure_1();
+	test_adis_read_diag_x_axis_gyro_failure_2();
+	test_adis_read_diag_x_axis_gyro_failure_3();
+}
+
+void test_adis1657x_read_diag_y_axis_gyro_failure(void)
+{
+	test_adis_read_diag_y_axis_gyro_failure_1();
+	test_adis_read_diag_y_axis_gyro_failure_2();
+	test_adis_read_diag_y_axis_gyro_failure_3();
+}
+
+void test_adis1657x_read_diag_z_axis_gyro_failure(void)
+{
+	test_adis_read_diag_z_axis_gyro_failure_1();
+	test_adis_read_diag_z_axis_gyro_failure_2();
+	test_adis_read_diag_z_axis_gyro_failure_3();
+}
+
+void test_adis1657x_read_diag_x_axis_accl_failure(void)
+{
+	test_adis_read_diag_x_axis_accl_failure_1();
+	test_adis_read_diag_x_axis_accl_failure_2();
+	test_adis_read_diag_x_axis_accl_failure_3();
+}
+
+void test_adis1657x_read_diag_y_axis_accl_failure(void)
+{
+	test_adis_read_diag_y_axis_accl_failure_1();
+	test_adis_read_diag_y_axis_accl_failure_2();
+	test_adis_read_diag_y_axis_accl_failure_3();
+}
+
+void test_adis1657x_read_diag_z_axis_accl_failure(void)
+{
+	test_adis_read_diag_z_axis_accl_failure_1();
+	test_adis_read_diag_z_axis_accl_failure_2();
+	test_adis_read_diag_z_axis_accl_failure_3();
+}
+
+void test_adis1657x_read_diag_aduc_mcu_fault(void)
+{
+	test_adis_read_diag_aduc_mcu_fault_1();
+	test_adis_read_diag_aduc_mcu_fault_2();
+	test_adis_read_diag_aduc_mcu_fault_3();
+}
+
+void test_adis1657x_read_diag_checksum_err(void)
+{
+	test_adis_read_diag_checksum_err_1();
+	test_adis_read_diag_checksum_err_2();
+}
+
+void test_adis1657x_read_diag_fls_mem_wr_cnt_exceed(void)
+{
+	test_adis_read_diag_fls_mem_wr_cnt_exceed_1();
+	test_adis_read_diag_fls_mem_wr_cnt_exceed_2();
+}
+
+void test_adis1657x_read_x_gyro(void)
+{
+	test_adis_read_x_gyro_1();
+	test_adis_read_x_gyro_2();
+	test_adis_read_x_gyro_3();
+}
+
+void test_adis1657x_read_y_gyro(void)
+{
+	test_adis_read_y_gyro_1();
+	test_adis_read_y_gyro_2();
+	test_adis_read_y_gyro_3();
+}
+
+void test_adis1657x_read_z_gyro(void)
+{
+	test_adis_read_z_gyro_1();
+	test_adis_read_z_gyro_2();
+	test_adis_read_z_gyro_3();
+}
+
+void test_adis1657x_read_x_accl(void)
+{
+	test_adis_read_x_accl_1();
+	test_adis_read_x_accl_2();
+	test_adis_read_x_accl_3();
+}
+
+void test_adis1657x_read_y_accl(void)
+{
+	test_adis_read_y_accl_1();
+	test_adis_read_y_accl_2();
+	test_adis_read_y_accl_3();
+}
+
+void test_adis1657x_read_z_accl(void)
+{
+	test_adis_read_z_accl_1();
+	test_adis_read_z_accl_2();
+	test_adis_read_z_accl_3();
+}
+
+void test_adis1657x_read_temp_out(void)
+{
+	test_adis_read_temp_out_1();
+	test_adis_read_temp_out_2();
+	test_adis_read_temp_out_3();
+}
+
+void test_adis1657x_read_time_stamp(void)
+{
+	test_adis_read_time_stamp_size32();
+}
+
+void test_adis1657x_read_data_cntr(void)
+{
+	test_adis_read_data_cntr();
+}
+
+void test_adis1657x_read_x_deltang(void)
+{
+	test_adis_read_x_deltang_1();
+	test_adis_read_x_deltang_2();
+	test_adis_read_x_deltang_3();
+}
+
+void test_adis1657x_read_y_deltang(void)
+{
+	test_adis_read_y_deltang_1();
+	test_adis_read_y_deltang_2();
+	test_adis_read_y_deltang_3();
+}
+
+void test_adis1657x_read_z_deltang(void)
+{
+	test_adis_read_z_deltang_1();
+	test_adis_read_z_deltang_2();
+	test_adis_read_z_deltang_3();
+}
+
+void test_adis1657x_read_x_deltvel(void)
+{
+	test_adis_read_x_deltvel_1();
+	test_adis_read_x_deltvel_2();
+	test_adis_read_x_deltvel_3();
+}
+
+void test_adis1657x_read_y_deltvel(void)
+{
+	test_adis_read_y_deltvel_1();
+	test_adis_read_y_deltvel_2();
+	test_adis_read_y_deltvel_3();
+}
+
+void test_adis1657x_read_z_deltvel(void)
+{
+	test_adis_read_z_deltvel_1();
+	test_adis_read_z_deltvel_2();
+	test_adis_read_z_deltvel_3();
+}
+
+void test_adis1657x_read_fifo_cnt(void)
+{
+	test_adis_read_fifo_cnt();
+}
+
+void test_adis1657x_read_spi_chksum(void)
+{
+	test_adis_read_spi_chksum();
+}
+
+void test_adis1657x_read_xg_bias(void)
+{
+	test_adis_read_xg_bias();
+}
+
+void test_adis1657x_write_xg_bias(void)
+{
+	test_adis_write_xg_bias();
+}
+
+void test_adis1657x_read_yg_bias(void)
+{
+	test_adis_read_yg_bias();
+}
+
+void test_adis1657x_write_yg_bias(void)
+{
+	test_adis_write_yg_bias();
+}
+
+void test_adis1657x_read_zg_bias(void)
+{
+	test_adis_read_zg_bias();
+}
+
+void test_adis1657x_write_zg_bias(void)
+{
+	test_adis_write_zg_bias();
+}
+
+void test_adis1657x_read_xa_bias(void)
+{
+	test_adis_read_xa_bias();
+}
+
+void test_adis1657x_write_xa_bias(void)
+{
+	test_adis_write_xa_bias();
+}
+
+void test_adis1657x_read_ya_bias(void)
+{
+	test_adis_read_ya_bias();
+}
+
+void test_adis1657x_write_ya_bias(void)
+{
+	test_adis_write_ya_bias();
+}
+
+void test_adis1657x_read_za_bias(void)
+{
+	test_adis_read_za_bias();
+}
+
+void test_adis1657x_write_za_bias(void)
+{
+	test_adis_write_za_bias();
+}
+
+void test_adis1657x_read_fifo_en(void)
+{
+	test_adis_read_fifo_en();
+}
+
+void test_adis1657x_write_fifo_en(void)
+{
+	test_adis_write_fifo_en_1();
+	test_adis_write_fifo_en_2();
+	test_adis_write_fifo_en_3();
+}
+
+void test_adis1657x_read_fifo_overflow(void)
+{
+	test_adis_read_fifo_overflow();
+}
+
+void test_adis1657x_write_fifo_overflow(void)
+{
+	test_adis_write_fifo_overflow();
+}
+
+void test_adis1657x_read_fifo_wm_int_en(void)
+{
+	test_adis_read_fifo_wm_int_en();
+}
+
+void test_adis1657x_write_fifo_wm_int_en(void)
+{
+	test_adis_write_fifo_wm_int_en();
+}
+
+void test_adis1657x_read_fifo_wm_int_pol(void)
+{
+	test_adis_read_fifo_wm_int_pol();
+}
+
+void test_adis1657x_write_fifo_wm_int_pol(void)
+{
+	test_adis_write_fifo_wm_int_pol();
+}
+
+void test_adis1657x_read_fifo_wm_lvl(void)
+{
+	test_adis_read_fifo_wm_lvl();
+}
+
+void test_adis1657x_write_fifo_wm_lvl(void)
+{
+	test_adis_write_fifo_wm_lvl();
+}
+
+void test_adis1657x_read_filt_size_var_b(void)
+{
+	test_adis_read_filt_size_var_b();
+}
+
+void test_adis1657x_write_filt_size_var_b(void)
+{
+	test_adis_write_filt_size_var_b_1();
+	test_adis_write_filt_size_var_b_2();
+	test_adis_write_filt_size_var_b_3();
+}
+
+void test_adis1657x_read_gyro_meas_range(void)
+{
+	test_adis_read_gyro_meas_range();
+}
+
+void test_adis1657x_read_dr_polarity(void)
+{
+	test_adis_read_dr_polarity();
+}
+
+void test_adis1657x_write_dr_polarity(void)
+{
+	test_adis_write_dr_polarity_1();
+	test_adis_write_dr_polarity_2();
+	test_adis_write_dr_polarity_3();
+}
+
+void test_adis1657x_read_sync_polarity(void)
+{
+	test_adis_read_sync_polarity();
+}
+
+void test_adis1657x_write_sync_polarity(void)
+{
+	test_adis_write_sync_polarity_1();
+	test_adis_write_sync_polarity_2();
+	test_adis_write_sync_polarity_3();
+}
+
+void test_adis1657x_read_sync_mode(void)
+{
+	test_adis_read_sync_mode();
+}
+
+void test_adis1657x_write_sync_mode(void)
+{
+	test_adis_write_sync_mode_1();
+	test_adis_write_sync_mode_2();
+	test_adis_write_sync_mode_3();
+	test_adis_write_sync_mode_4();
+	test_adis_write_sync_mode_5();
+	test_adis_write_sync_mode_6();
+	test_adis_write_sync_mode_7();
+	test_adis_write_sync_mode_8();
+	test_adis_write_sync_mode_9();
+}
+
+void test_adis1657x_read_sens_bw(void)
+{
+	test_adis_read_sens_bw();
+}
+
+void test_adis1657x_write_sens_bw(void)
+{
+	test_adis_write_sens_bw_1();
+	test_adis_write_sens_bw_2();
+}
+
+void test_adis1657x_read_pt_of_perc_algnmt(void)
+{
+	test_adis_read_pt_of_perc_algnmt();
+}
+
+void test_adis1657x_write_pt_of_perc_algnmt(void)
+{
+	test_adis_write_pt_of_perc_algnmt_1();
+	test_adis_write_pt_of_perc_algnmt_2();
+}
+
+void test_adis1657x_read_linear_accl_comp(void)
+{
+	test_adis_read_linear_accl_comp();
+}
+
+void test_adis1657x_write_linear_accl_comp(void)
+{
+	test_adis_write_linear_accl_comp_1();
+	test_adis_write_linear_accl_comp_2();
+}
+
+void test_adis1657x_read_burst_sel(void)
+{
+	test_adis_read_burst_sel();
+}
+
+void test_adis1657x_write_burst_sel(void)
+{
+	test_adis_write_burst_sel_1();
+	test_adis_write_burst_sel_2();
+}
+
+void test_adis1657x_read_burst32(void)
+{
+	test_adis_read_burst32();
+}
+
+void test_adis1657x_write_burst32(void)
+{
+	test_adis_write_burst32_1();
+	test_adis_write_burst32_2();
+}
+
+void test_adis1657x_read_timestamp32(void)
+{
+	test_adis_read_timestamp32();
+}
+
+void test_adis1657x_write_timestamp32(void)
+{
+	test_adis_write_timestamp32_1();
+	test_adis_write_timestamp32_2();
+}
+
+void test_adis1657x_read_sync_4khz(void)
+{
+	test_adis_read_sync_4khz();
+}
+
+void test_adis1657x_write_sync_4khz(void)
+{
+	test_adis_write_sync_4khz_1();
+	test_adis_write_sync_4khz_2();
+	test_adis_write_sync_4khz_3();
+}
+void test_adis1657x_read_up_scale(void)
+{
+	test_adis_read_up_scale();
+}
+
+void test_adis1657x_write_up_scale(void)
+{
+	test_adis_write_up_scale_1();
+	test_adis_write_up_scale_2();
+	test_adis_write_up_scale_3();
+	test_adis_write_up_scale_4();
+}
+
+void test_adis1657x_read_dec_rate(void)
+{
+	test_adis_read_dec_rate();
+}
+
+void test_adis1657x_write_dec_rate(void)
+{
+	test_adis_write_dec_rate_1();
+	test_adis_write_dec_rate_2();
+	test_adis_write_dec_rate_3();
+}
+
+void test_adis1657x_read_bias_corr_tbc(void)
+{
+	test_adis_read_bias_corr_tbc();
+}
+
+void test_adis1657x_write_bias_corr_tbc(void)
+{
+	test_adis_write_bias_corr_tbc_1();
+	test_adis_write_bias_corr_tbc_2();
+}
+
+void test_adis1657x_read_bias_corr_en_xg(void)
+{
+	test_adis_read_bias_corr_en_xg();
+}
+
+void test_adis1657x_write_bias_corr_en_xg(void)
+{
+	test_adis_write_bias_corr_en_xg();
+}
+
+void test_adis1657x_read_bias_corr_en_yg(void)
+{
+	test_adis_read_bias_corr_en_yg();
+}
+
+void test_adis1657x_write_bias_corr_en_yg(void)
+{
+	test_adis_write_bias_corr_en_yg();
+}
+
+void test_adis1657x_read_bias_corr_en_zg(void)
+{
+	test_adis_read_bias_corr_en_zg();
+}
+
+void test_adis1657x_write_bias_corr_en_zg(void)
+{
+	test_adis_write_bias_corr_en_zg();
+}
+
+void test_adis1657x_read_bias_corr_en_xa(void)
+{
+	test_adis_read_bias_corr_en_xa();
+}
+
+void test_adis1657x_write_bias_corr_en_xa(void)
+{
+	test_adis_write_bias_corr_en_xa();
+}
+
+void test_adis1657x_read_bias_corr_en_ya(void)
+{
+	test_adis_read_bias_corr_en_ya();
+}
+
+void test_adis1657x_write_bias_corr_en_ya(void)
+{
+	test_adis_write_bias_corr_en_ya();
+}
+
+void test_adis1657x_read_bias_corr_en_za(void)
+{
+	test_adis_read_bias_corr_en_za();
+}
+
+void test_adis1657x_write_bias_corr_en_za(void)
+{
+	test_adis_write_bias_corr_en_za();
+}
+
+void test_adis1657x_cmd_bias_corr_update(void)
+{
+	test_adis_cmd_bias_corr_update();
+}
+
+void test_adis1657x_cmd_fact_calib_restore(void)
+{
+	test_adis_cmd_fact_calib_restore_1();
+	test_adis_cmd_fact_calib_restore_2();
+}
+
+void test_adis1657x_cmd_snsr_self_test()
+{
+	test_adis_cmd_snsr_self_test_1();
+	test_adis_cmd_snsr_self_test_2();
+}
+
+void test_adis1657x_cmd_fls_mem_update(void)
+{
+	test_adis_cmd_fls_mem_update_1();
+	test_adis_cmd_fls_mem_update_2();
+}
+
+void test_adis1657x_cmd_fls_mem_test(void)
+{
+	test_adis_cmd_fls_mem_test_1();
+	test_adis_cmd_fls_mem_test_2();
+}
+
+void test_adis1657x_cmd_fifo_flush(void)
+{
+	test_adis_cmd_fifo_flush();
+}
+
+void test_adis1657x_cmd_sw_res(void)
+{
+	test_adis_cmd_sw_res_1();
+	test_adis_cmd_sw_res_2();
+}
+
+void test_adis1657x_read_firm_rev(void)
+{
+	test_adis_read_firm_rev();
+}
+
+void test_adis1657x_read_firm_d(void)
+{
+	test_adis_read_firm_d();
+}
+
+void test_adis1657x_read_firm_m(void)
+{
+	test_adis_read_firm_m();
+}
+
+void test_adis1657x_read_firm_y(void)
+{
+	test_adis_read_firm_y();
+}
+
+void test_adis1657x_read_prod_id(void)
+{
+	test_adis_read_prod_id();
+}
+
+void test_adis1657x_read_serial_num(void)
+{
+	test_adis_read_serial_num();
+}
+
+void test_adis1657x_read_usr_scr_1(void)
+{
+	test_adis_read_usr_scr_1();
+}
+
+void test_adis1657x_write_usr_scr_1(void)
+{
+	test_adis_write_usr_scr_1();
+}
+
+void test_adis1657x_read_usr_scr_2(void)
+{
+	test_adis_read_usr_scr_2();
+}
+
+void test_adis1657x_write_usr_scr_2(void)
+{
+	test_adis_write_usr_scr_2();
+}
+
+void test_adis1657x_read_usr_scr_3(void)
+{
+	test_adis_read_usr_scr_3();
+}
+
+void test_adis1657x_write_usr_scr_3(void)
+{
+	test_adis_write_usr_scr_3();
+}
+
+void test_adis1657x_read_fls_mem_wr_cntr(void)
+{
+	test_adis_read_fls_mem_wr_cntr_1();
+	test_adis_read_fls_mem_wr_cntr_2();
+	test_adis_read_fls_mem_wr_cntr_3();
+}
+
+void test_adis1657x_read_burst_data(void)
+{
+	test_adis_read_burst_data_1();
+	test_adis_read_burst_data_2();
+	test_adis_read_burst_data_3();
+	test_adis_read_burst_data_4();
+	test_adis_read_burst_data_5();
+}
+
+void test_adis1657x_update_ext_clk_freq(void)
+{
+	test_adis_update_ext_clk_freq_1();
+	test_adis_update_ext_clk_freq_2();
+	test_adis_update_ext_clk_freq_3();
+	test_adis_update_ext_clk_freq_4();
+	test_adis_update_ext_clk_freq_5();
+	test_adis_update_ext_clk_freq_6();
+}
+
+void test_adis1657x_get_sync_clk_freq(void)
+{
+	test_adis_get_sync_clk_freq_1();
+	test_adis_get_sync_clk_freq_2();
+	test_adis_get_sync_clk_freq_3();
+	test_adis_get_sync_clk_freq_4();
+}


### PR DESCRIPTION
Add unit tests for adis drivers using ceedling yml file. 
adis_generic_tests.c contain all tests in order to test adis.c file while test_adis16505 and test_adis1657x contain the specific tests for each device.