### PR TITLE
drivers:power:ltc3337 Initial Implementation

### DIFF
--- a/drivers/power/ltc3337/ltc3337.c
+++ b/drivers/power/ltc3337/ltc3337.c
@@ -1,0 +1,719 @@
+/***************************************************************************//**
+ *   @file   ltc3337.c
+ *   @brief  Implementation file for the LTC3337 Driver
+ *   @author Brent Kowal (brent.kowal@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include <assert.h>
+#include <stdio.h>
+#include <errno.h>
+#include "ltc3337.h"
+#include "no_os_alloc.h"
+
+
+/**
+ * Structure supporting the iPeak lookup table
+ */
+struct ipeak_entry_t {
+	uint8_t  ipeak_ma;		//iPeak, in mA
+	uint32_t qlsb_na_hr;	//qLsb, nA-hr component
+};
+
+/**
+ * Lookup table for the iPeak values. This converts the 3-bit
+ * iPeak input configuration signals, to a iPeak current and qLsb
+ * values for Coulomb counter calculations
+ */
+static const struct ipeak_entry_t ipeak_lookup_table[LTC3337_NUM_IPEAKS] = {
+	{ .ipeak_ma = 5,   .qlsb_na_hr = 745700 },   //b000 - 5ma, 745.7 uA-hr
+	{ .ipeak_ma = 10,  .qlsb_na_hr = 1491000 },  //b001 - 10ma, 1.491 mA-hr
+	{ .ipeak_ma = 15,  .qlsb_na_hr = 2237000 },  //b010 - 15ma, 2.237 mA-hr
+	{ .ipeak_ma = 20,  .qlsb_na_hr = 2983000 },  //b011 - 20ma, 2.983 mA-hr
+	{ .ipeak_ma = 25,  .qlsb_na_hr = 3728000 },  //b100 - 25ma, 3.728 mA-hr
+	{ .ipeak_ma = 50,  .qlsb_na_hr = 7457000 },  //b101 - 50ma, 7.457 mA-hr
+	{ .ipeak_ma = 75,  .qlsb_na_hr = 11180000 }, //b110 - 75ma, 11.18 mA-hr
+	{ .ipeak_ma = 100, .qlsb_na_hr = 14910000 }, //b111 - 100ma, 14.91 mA-hr
+};
+
+/** Local Prototypes */
+static int ltc3337_read_reg(struct ltc3337_dev* dev, uint8_t reg,
+			    uint16_t* data);
+static int ltc3337_write_reg(struct ltc3337_dev* dev, uint8_t reg,
+			     uint16_t data);
+static uint32_t ltc3337_vbat_to_mv(uint16_t raw_value);
+static int16_t ltc3337_temp_reg_to_c(uint8_t raw_value);
+static uint8_t ltc3337_temp_c_to_reg(int16_t temp_c);
+static void ltc3337_charge_count_to_a(uint16_t charge_count, uint8_t prescale,
+				      uint32_t lsb_na, struct charge_count_t* value);
+static uint16_t ltc3337_a_to_charge_count(uint8_t prescale, uint32_t lsb_na,
+		struct charge_count_t* charge_a);
+
+
+/**
+ * Initializes the driver instance. Assigns the I2C bus and reads the
+ * IPK pins.  The prescaler is set to the user value, and the accumulated
+ * charge alarm is defaulted to maximum 0xFF
+ * @param device - Pointer to the device instance
+ * @param init_param - Initialization parameters
+ * @returns 0 on success, Non-0 on error
+ */
+int ltc3337_init(struct ltc3337_dev** device,
+		 struct ltc3337_init_param* init_param)
+{
+	int ret;
+	uint16_t reg_val;
+	struct ltc3337_dev *dev;
+
+	//Input parameter NULL checks
+	if((!device) || (!init_param))
+		return -EINVAL;
+
+	dev = (struct ltc3337_dev*)no_os_calloc(1, sizeof(struct ltc3337_dev));
+	if(!dev)
+		return  -ENOMEM;
+
+	ret = no_os_i2c_init(&dev->i2c_desc, &init_param->i2c_init);
+	if(ret) //Failure creating I2C
+		goto err;
+
+	ret = ltc3337_read_reg(dev, LTC3337_REG_C, &reg_val);
+	if(ret) //Failure on a I2C Read
+		goto comm_err;
+
+	//Success
+	dev->ipeak_latched = no_os_field_get(LTC3337_RC_IPK_PIN_MSK, reg_val);
+	reg_val = no_os_field_prep(LTC3337_RA_PRESCALE_MSK, init_param->prescale);
+	reg_val |= no_os_field_prep(LTC3337_RA_ALARM_LVL_MSK,
+				    LTC3337_OVERFLOW_ALARM_MAX);
+	dev->latched_reg_a = reg_val;
+	ret = ltc3337_write_reg(dev, LTC3337_REG_A, reg_val);
+	*device = dev;
+
+	return 0;
+
+comm_err:
+	no_os_i2c_remove(dev->i2c_desc);
+err:
+	no_os_free(dev);
+	return ret;
+}
+
+/**
+ * Uninitializes the device instance and frees up any allocated memory
+ * @param dev - Device to remove
+ * @returns 0 on success, non-0 on error
+ */
+int ltc3337_remove(struct ltc3337_dev* dev)
+{
+	int ret;
+
+	//Input parameter NULL check
+	if(!dev)
+		return -EINVAL;
+
+	ret = no_os_i2c_remove(dev->i2c_desc);
+	no_os_free(dev);
+
+	return ret;
+}
+
+/**
+ * Gets the current value of the requested voltage monitor in mV.
+ * @param dev - Device to read from
+ * @param source - Which voltage source to read
+ * @param value - Location to store calcualted value, in mV
+ * @returns 0 on success, Non-0 on error
+ */
+int ltc3337_get_voltage_mv(struct ltc3337_dev* dev,
+			   enum ltc3337_voltage_src_t source,
+			   uint32_t* value)
+{
+	uint8_t reg;
+	uint16_t reg_value;
+	int ret;
+
+	//Input parameter NULL checks
+	if((!dev) || (!value))
+		return -EINVAL;
+
+	switch(source) {
+	case BAT_IN_IPEAK_ON:
+		reg = LTC3337_REG_D;
+		break;
+	case BAT_IN_IPEAK_OFF:
+		reg = LTC3337_REG_E;
+		break;
+	case BAT_OUT_IPEAK_ON:
+		reg = LTC3337_REG_F;
+		break;
+	case BAT_OUT_IPEAK_OFF:
+		reg = LTC3337_REG_G;
+		break;
+	default:
+		//Invalid register
+		return -EINVAL;
+	}
+
+	ret = ltc3337_read_reg(dev, reg, &reg_value);
+	if(ret)
+		return ret;
+
+	reg_value = no_os_field_get(LTC3337_BATV_MSK, reg_value);
+	*value = ltc3337_vbat_to_mv(reg_value);
+
+	return 0;
+}
+
+/**
+ * Gets the current die temperature
+ * @param dev - Device to read from
+ * @param value - Location to store calculated value, in Deg C
+ * @returns 0 on success, Non-0 on error
+ */
+int ltc3337_get_temperature_c(struct ltc3337_dev* dev, int16_t* value)
+{
+	uint16_t reg_value;
+	int ret;
+
+	//Input parameter NULL checks
+	if((!dev) || (!value))
+		return -EINVAL;
+
+	ret = ltc3337_read_reg(dev, LTC3337_REG_C, &reg_value);
+	if(ret)
+		return ret;
+
+	*value = ltc3337_temp_reg_to_c(
+			 no_os_field_get(LTC3337_RC_DIE_TEMP_MSK, reg_value));
+
+	return 0;
+}
+
+/**
+ * Gets the current value of the accumulated charge register.  This function
+ * can return the raw value and/or the calculated value based on the prescaler
+ * and IPK settings of dev.
+ * @param dev - Device to read from
+ * @param value - Pointer to calculated storage location, or NULL
+ * @param raw_value - Pointer to raw storage location, or NULL
+ * @returns 0 on success, Non-0 on error
+ */
+int ltc3337_get_accumulated_charge(struct ltc3337_dev* dev,
+				   struct charge_count_t* value,
+				   uint16_t* raw_value)
+{
+	uint16_t reg_value;
+	uint8_t prescale;
+
+	int ret;
+
+	//Input parameter NULL check
+	if(!dev)
+		return -EINVAL;
+
+	ret = ltc3337_read_reg(dev, LTC3337_REG_B, &reg_value);
+	if(ret)
+		return ret;
+
+	if(raw_value)
+		*raw_value = reg_value;
+
+	if(value) {
+		prescale = no_os_field_get(LTC3337_RA_PRESCALE_MSK, dev->latched_reg_a);
+		ltc3337_charge_count_to_a(reg_value, prescale,
+					  ipeak_lookup_table[dev->ipeak_latched].qlsb_na_hr,
+					  value);
+	}
+
+	return 0;
+}
+
+/**
+ * Sets the prescaler value of the device.
+ * IMPORTANT: Changing the prescaler does not affect the value of the accumulated
+ * charge register. If the prescaler is set sometime following the initial
+ * runtime setup, after charge has been accumulated, the acccumulated charge
+ * register should be set according to the current value shifted by the
+ * difference in original and current prescaler. This driver does not
+ * automatically perform that action.
+ * IMPORTANT: Changing the prescaler does not alter the configuration of alarm.
+ * That may need to be changed if configured prior to the prescaler
+ * @param dev - Pointer to the device instance
+ * @param prescale - Prescaler value
+ * @returns 0 on success, Non-0 on error
+ */
+int ltc3337_set_prescaler(struct ltc3337_dev* dev, uint8_t prescale)
+{
+	uint16_t reg_value;
+	int ret;
+
+	//Input parameter NULL check
+	if(!dev)
+		return -EINVAL;
+
+	reg_value = dev->latched_reg_a;
+	reg_value &= ~(LTC3337_RA_PRESCALE_MSK);
+	reg_value |= no_os_field_prep(LTC3337_RA_PRESCALE_MSK, prescale);
+	ret = ltc3337_write_reg(dev, LTC3337_REG_A, reg_value);
+	if(ret)
+		return ret;
+
+	dev->latched_reg_a = reg_value;
+
+	return 0;
+}
+
+/**
+ * Set the alarm thresholds for hot and cold temperatures
+ * @param dev - Device to configure
+ * @param hot_alarm - Hot alarm threshold, in Degrees C
+ * @param cold_alarm - Cold alarm threshold, in Degrees C
+ * @returns 0 on success, Non-0 on error
+ */
+int ltc3337_set_temperature_alarms_c(struct ltc3337_dev* dev, int16_t hot_alarm,
+				     int16_t cold_alarm)
+{
+	uint16_t reg_val;
+	uint8_t temp_val;
+
+	//Input parameter NULL check
+	if(!dev)
+		return -EINVAL;
+
+	if((hot_alarm < LTC3337_MIN_TEMP_C) || (hot_alarm > LTC3337_MAX_TEMP_C) ||
+	    (cold_alarm < LTC3337_MIN_TEMP_C) || (cold_alarm > LTC3337_MAX_TEMP_C))
+		return -EINVAL;
+
+	temp_val = ltc3337_temp_c_to_reg(hot_alarm);
+	reg_val = no_os_field_prep(LTC3337_RH_HOT_ALARM_MSK, temp_val);
+	temp_val = ltc3337_temp_c_to_reg(cold_alarm);
+	reg_val |= no_os_field_prep(LTC3337_RH_COLD_ALARM_MSK, temp_val);
+
+	return ltc3337_write_reg(dev, LTC3337_REG_H, reg_val);
+}
+
+/**
+ * Sets the state of the coulomb counter shutdown function
+ * @param dev - Device to configure
+ * @param shutdown_en - 1 - Enable shutdown, 0 - Coulomb counter running
+ * @returns 0 on success, Non-0 on error
+ */
+int ltc3337_set_counter_shutdown(struct ltc3337_dev* dev, uint8_t shutdown_en)
+{
+	uint16_t reg_value;
+	int ret;
+
+	//Input parameter NULL check
+	if(!dev)
+		return -EINVAL;
+
+	reg_value = dev->latched_reg_a;
+
+	if(shutdown_en)
+		reg_value |= LTC3337_RA_SHTDN;
+	else
+		reg_value &= ~(LTC3337_RA_SHTDN);
+
+	ret = ltc3337_write_reg(dev, LTC3337_REG_A, reg_value);
+	if(ret)
+		return ret;
+
+	dev->latched_reg_a = reg_value;
+
+	return 0;
+}
+
+/**
+ * Sets the alarm level for the coulomb counter alarm. The input value is the
+ * raw register value, and can be calculated using LTC3337_CalculateChargeRegister
+ * or manually by hand.
+ * IMPORTANT: Only the upper 8-bits of the value are utilized. Use the roundUp
+ * flag to have the driver optionally round up to the next valid bit
+ * @param dev - Device to configure
+ * @param counter_reg_val - Register value, as if all 16-bits were utilized
+ * @param round_up - 1 -Have the driver round up to next usable alarm bit
+ * @returns 0 on success, Non-0 on error
+ */
+int ltc3337_set_counter_alarm(struct ltc3337_dev* dev, uint16_t counter_reg_val,
+			      uint8_t round_up)
+{
+	uint8_t data_to_set;
+	uint16_t reg_value;
+	int ret;
+
+	//Input parameter NULL check
+	if(!dev)
+		return -EINVAL;
+
+	reg_value = dev->latched_reg_a;
+
+	//Only the upper 8 bits are utilized
+	data_to_set = (counter_reg_val >> 8);
+
+	//If rounding was requested, check the if any of the lower bits are set,
+	//and if we wont overflow dataToSet beyond 8-bits, increment
+	if((round_up) && (counter_reg_val & 0xFF) && (data_to_set != 0xFF))
+		data_to_set++;
+
+	reg_value &= ~(LTC3337_RA_ALARM_LVL_MSK);
+	reg_value |= no_os_field_prep(LTC3337_RA_ALARM_LVL_MSK, data_to_set);
+
+	ret = ltc3337_write_reg(dev, LTC3337_REG_A, reg_value);
+	if(ret)
+		return ret;
+
+	dev->latched_reg_a = reg_value;
+
+	return 0;
+}
+
+/**
+ * Sets the level for the coulomb counter accumulated charge register.
+ * The input value is the raw register value, and can be calculated using
+ * LTC3337_CalculateChargeRegister or manually by hand.
+ * IMPORTANT: Only the upper 8-bits of the value are utilized. Use the roundUp
+ * flag to have the driver optionally round up to the next valid bit
+ * @param dev - Device to configure
+ * @param reg_value - Register value, as if all 16-bits were utilized
+ * @param round_up - 1 -Have the driver round up to next usable alarm bit
+ * @returns 0 on success, Non-0 on error
+ */
+int ltc3337_set_accumulated_charge(struct ltc3337_dev* dev, uint16_t reg_value,
+				   uint8_t round_up)
+{
+	uint16_t data_to_set;
+
+	//Input parameter NULL check
+	if(!dev)
+		return -EINVAL;
+
+	//Only upper 8-bits (MSB) are writable
+	data_to_set = reg_value & 0xFF00;
+
+	//If rounding up was requested, check if any of the lower 8-bits of the
+	//original value are set, and verify dataToSet will not overflow 16-bits
+	//if we increment
+	//Add 1 to the MSB of the data to set to account for rounding
+	//request
+	if((round_up) && (reg_value & 0xFF) && (data_to_set != 0xFF00))
+		data_to_set += 0x100;
+
+	return ltc3337_write_reg(dev, LTC3337_REG_B, data_to_set);
+}
+
+/**
+ * Reads and clears the interrupt status of the chip.  Since the die temp is
+ * also provided in the interrupt register, temperature is optionally provided
+ * as well. This allows a user to poll interrupt status and not accidentally
+ * clear interrupts by reading temperature inbetween interrupt polls.
+ * Use the LTC3337_RC_ macros to determine status of each interrupt in int_field
+ * @param dev - Device to read from
+ * @param int_field - Interrupt status bits
+ * @param temp_c - Location to store temperature (or NULL)
+ * @returns 0 on success, Non-0 on error
+ */
+int ltc3337_get_and_clear_interrupts(struct ltc3337_dev* dev,
+				     uint16_t* int_field,
+				     int16_t* temp_c)
+{
+	uint16_t write_reg_value;
+	int ret;
+
+	//Input parameter NULL checks
+	if((!dev) || (!int_field))
+		return -EINVAL;
+
+	ret = ltc3337_read_reg(dev, LTC3337_REG_C, int_field);
+	if(ret)
+		return ret;
+
+	write_reg_value = dev->latched_reg_a;
+	write_reg_value |= (LTC3337_RA_CLEAR_INT);
+	ret = ltc3337_write_reg(dev, LTC3337_REG_A, write_reg_value);
+	if(ret)
+		return ret;
+
+	if(temp_c)
+		*temp_c = ltc3337_temp_reg_to_c(no_os_field_get(LTC3337_RC_DIE_TEMP_MSK,
+						*int_field));
+
+	return 0;
+}
+
+/**
+ * Gets a register value equivalent of the provided charge in A/nA-hrs
+ * to be used in configuring the charge alarms, and resetting the charge
+ * register. This function does not access the device over the bus, but
+ * utilizes the latched prescaled and IPK values to perform the calculation
+ * @param dev - Device to utilize configuration from
+ * @param charge_a - Pointer to the charge values in A/nA-hrs
+ * @param reg_value - Pointer to store the output register value
+ * @returns 0 on success, Non-0 on error
+ */
+int ltc3337_calculate_charge_register(struct ltc3337_dev* dev,
+				      struct charge_count_t* charge_a,
+				      uint16_t* reg_value)
+{
+	uint8_t prescale;
+
+	//Input parameter NULL checks
+	if((!dev) || (!charge_a) || (!reg_value))
+		return -EINVAL;
+
+	prescale = no_os_field_get(LTC3337_RA_PRESCALE_MSK, dev->latched_reg_a);
+	*reg_value = ltc3337_a_to_charge_count(prescale,
+					       ipeak_lookup_table[dev->ipeak_latched].qlsb_na_hr,
+					       charge_a);
+
+	return 0;
+}
+
+/**
+ * Reads a register from the device.
+ * @param dev - Device instance
+ * @param reg - Register to read
+ * @param data - Data storage location
+ * @returns 0 on success, else on error
+ */
+static int ltc3337_read_reg(struct ltc3337_dev* dev, uint8_t reg,
+			    uint16_t* data)
+{
+	uint8_t reg_buf = reg;
+	uint8_t data_buf[2];
+	int ret;
+
+	//Input parameter NULL checks
+	if((!dev) || (!data))
+		return -EINVAL;
+
+	ret = no_os_i2c_write(dev->i2c_desc, &reg_buf, 1, 1);
+	if(ret)
+		return ret;
+
+	//Successful write
+	ret = no_os_i2c_read(dev->i2c_desc, data_buf, 2, 1);
+	if(ret)
+		return ret;
+
+	//Data comes Little Endian
+	*data = no_os_get_unaligned_le16(data_buf);
+
+	return 0;
+}
+
+/**
+ * Writes a register ont the device.
+ * @param dev - Device instance
+ * @param reg - Register to write
+ * @param data - Data to write
+ * @returns 0 on success, else on error
+ */
+static int ltc3337_write_reg(struct ltc3337_dev* dev, uint8_t reg,
+			     uint16_t data)
+{
+	uint8_t data_buf[3];
+
+	//Input parameter NULL check
+	if(!dev)
+		return -EINVAL;
+
+	//Register followed by Little Endian 16-bit word
+	data_buf[0] = reg;
+	data_buf[1] = (uint8_t)(data & 0xFF);
+	data_buf[2] = (uint8_t)((data >> 8) & 0xFF);
+
+	return no_os_i2c_write(dev->i2c_desc, data_buf, 3, 1);
+}
+
+/**
+ * Converts a raw register value for battery voltage to
+ * millivolts
+ * @param raw_value - Value to convert
+ * @returns Converted value in millivolts
+ */
+static uint32_t ltc3337_vbat_to_mv(uint16_t raw_value)
+{
+	//uV to mV, rounded to nearest mV
+	return NO_OS_DIV_ROUND_CLOSEST((uint32_t)raw_value * LTC3337_VLSB_UV,
+				       LTC3337_UV_TO_MV_SCALE);
+}
+
+/**
+ * Converts a raw register value for temperature to
+ * Degrees C
+ * @param raw_value - Value to convert
+ * @returns Converted value in Degrees C
+ */
+static int16_t ltc3337_temp_reg_to_c(uint8_t raw_value)
+{
+	//Rounded to the nearest C
+	return (int16_t)NO_OS_DIV_ROUND_CLOSEST((raw_value * LTC3337_TLSB_MC),
+						LTC3337_MC_TO_C_SCALE) +
+	       LTC3337_TEMP_MIN_C;
+}
+
+/**
+ * Converts a temperature in Deg C to the parts register
+ * equivalent
+ * @param temp_c - Temperature in C
+ * @returns Converted register value
+*/
+static uint8_t ltc3337_temp_c_to_reg(int16_t temp_c)
+{
+	int32_t working;
+
+	if(temp_c > LTC3337_MAX_TEMP_C )
+		return 0xFF;
+	else if(temp_c < LTC3337_MIN_TEMP_C)
+		return 0x00;
+	else {
+		working = (temp_c - LTC3337_TEMP_MIN_C) * LTC3337_MC_TO_C_SCALE;
+		//Round to the nearest
+		working = NO_OS_DIV_ROUND_CLOSEST(working, LTC3337_TLSB_MC);
+		return (uint8_t)working;
+	}
+}
+
+/**
+ * Converts a charge count register to accumulated charge in
+ * A/nA based on the prescaler qLSB values
+ * @param charge_count - Charge count register value
+ * @param prescale - Prescale value
+ * @param lsb_na - LSB value in Nano-amps
+ * @param ret_value - Pointer to return structure
+  */
+static void ltc3337_charge_count_to_a(uint16_t charge_count, uint8_t prescale,
+				      uint32_t lsb_na,       struct charge_count_t* ret_value)
+{
+	uint32_t qlsb_m_na;
+	uint32_t qlsb_m_remainder;
+	uint32_t whole_count, fract_count;
+
+	//Per the data sheet qLSB_M = (qLSB / 2*M)
+	//We can get qLSB_M by doing (qLSB >> M);
+	qlsb_m_na = (lsb_na >> prescale);
+
+	//Get the fractional bits we shifted out
+	qlsb_m_remainder = lsb_na & ((1 << prescale) - 1);
+
+	//In an effort to keep all the math 32-bit integer based, avoiding floats,
+	//to be portable across differnt systems:
+	//Let's convert our qlsb_m_nA to whole and fractional parts
+	//This is to prevent an overflow during the math.
+	//Worst case is 14910000 nA with a prescaler of 0. If we had a full counter
+	//(0xFFFF), multiplication works out to 0xE3_814C_7DD0, 32-bit overflow.
+	//Using base-2 components is easier programming wise, but using base-10
+	//helps track the units better:
+	//Divisor of 10,000 (10uA per whole value, 1nA per fract Value)
+	//  - 14910000 / 10000 = 1491 * 0xFFFF (full counter) = 0x5D2_FA2D
+	//  - 9,999 (Wost case remainder) * 0xFFFF = 0x270E_D8F1
+	whole_count = (uint32_t)charge_count * (qlsb_m_na / LTC3337_CALC_SCALE);
+	fract_count = (uint32_t)charge_count * (qlsb_m_na % LTC3337_CALC_SCALE);
+
+	ret_value->a_hr = whole_count /
+			  LTC3337_CALC_TO_WHOLE; //10uA per bit,  / 100,000 to get A
+	ret_value->na_hr = (whole_count % LTC3337_CALC_TO_WHOLE) *
+			   LTC3337_CALC_SCALE; //*10,000 nA per bit
+	ret_value->na_hr += fract_count; //Add in the other nA's
+
+	//Add back in the remainder after shifting out the prescaler
+	//Each LSB is 1/2^M nA
+	fract_count = qlsb_m_remainder * charge_count;
+	ret_value->na_hr += fract_count >> prescale;
+
+	//If the nA-hr component overflowed 1A, adjust accordingly
+	while(ret_value->na_hr > LTC3337_NANO_AMP) {
+		ret_value->a_hr++;
+		ret_value->na_hr -= LTC3337_NANO_AMP;
+	}
+}
+
+/**
+ * Converts a charge in A/nA-hr to an equivalent count register
+ * value to be used for setting alarms and clearing the register
+ * @param prescale - Prescale value
+ * @param lsb_na - LSB value in Nano-amps
+ * @param charge_a - Pointer to the charge value in A/nA-hrs
+ * @returns Equivalent register value based on parameters
+ */
+static uint16_t ltc3337_a_to_charge_count(uint8_t prescale, uint32_t lsb_na,
+		struct charge_count_t* charge_a)
+{
+	uint32_t qlsb_m_na;
+	uint32_t qlsb_m_remainder;
+	uint32_t bits_per_a;
+	uint32_t extra_per_a;
+	uint32_t working_count;
+	uint32_t remainder_count;
+	uint32_t fract_count;
+
+	//Per the data sheet qLSB_M = (qLSB / 2*M)
+	//We can get qLSB_M by doing (qLSB >> M);
+	qlsb_m_na = (lsb_na >> prescale);
+
+	//Get the fractional bits we shifted out
+	qlsb_m_remainder = lsb_na & ((1 << prescale) - 1);
+
+	//Calculate the number of bits for each A-hr
+	bits_per_a = LTC3337_NANO_AMP / qlsb_m_na;
+	extra_per_a = LTC3337_NANO_AMP % qlsb_m_na;
+
+	//Exceeds the bounds of the configuration, and could overflow
+	//the math.  Drop out now.
+	if(charge_a->a_hr > (UINT16_MAX / bits_per_a))
+		return UINT16_MAX;
+
+	//Get the baseline count
+	working_count = (charge_a->a_hr * bits_per_a);
+	working_count += (charge_a->na_hr / qlsb_m_na);
+
+	//Accumulate any remainders from the math, and add extra bits
+	//if we overflow qlsb_m_nA
+	remainder_count = (charge_a->a_hr * extra_per_a);
+	remainder_count += (charge_a->na_hr % qlsb_m_na);
+	working_count += (remainder_count / qlsb_m_na);
+
+	//Incorporate the fractional piece from the prescaler
+	//Since these fractional pieces would be more divising components
+	//We'll subtract the result
+	fract_count = working_count * qlsb_m_remainder;
+	working_count -= ((fract_count /
+			   lsb_na)); //divide by lsbna to negate the prescaler
+
+	if(working_count > UINT16_MAX) //Clamp to register max
+		return UINT16_MAX;
+	else
+		return working_count;
+}

--- a/drivers/power/ltc3337/ltc3337.h
+++ b/drivers/power/ltc3337/ltc3337.h
@@ -1,0 +1,187 @@
+/***************************************************************************//**
+ *   @file   ltc3337.h
+ *   @brief  Header file for the LTC3337 Driver
+ *   @author Brent Kowal (brent.kowal@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __LTC3337_H__
+#define __LTC3337_H__
+
+#include <stdint.h>
+#include "no_os_util.h"
+#include "no_os_i2c.h"
+
+#define LTC3337_I2C_ADDR			0x64 // b1100100[r/w] 0xC8, 0xC9
+
+#define LTC3337_MAX_TEMP_C			159  //Maximum temperature for alarms
+#define LTC3337_MIN_TEMP_C			-41  //Minimum temperature for alarms
+#define LTC3337_MAX_PRESCALE		15   //Maximum prescaler value
+
+#define LTC3337_OVERFLOW_ALARM_MAX	0xFF //Max value for overflow alarm
+
+#define LTC3337_REG_A	0x01 //Prescaler Select, IRQ Clear, Shutdown, Alarm Thresh
+
+#define LTC3337_RA_PRESCALE_MSK		NO_OS_GENMASK(3, 0)
+#define LTC3337_RA_CLEAR_INT		NO_OS_BIT(4)
+#define LTC3337_RA_CNT_CHK		NO_OS_BIT(5)
+#define LTC3337_RA_SHTDN		NO_OS_BIT(6)
+#define LTC3337_RA_ADC_CONV		NO_OS_BIT(7)
+#define LTC3337_RA_ALARM_LVL_MSK	NO_OS_GENMASK(15, 8)
+
+#define LTC3337_REG_B	0x02 //Accumulated Charge
+
+#define LTC3337_REG_C	0x03 //Status, Temperature
+//Use the following definitions for derterming interrupt status
+#define LTC3337_RC_OVERFLOW			NO_OS_BIT(0)
+#define LTC3337_RC_ALARM_TRIP		NO_OS_BIT(1)
+#define LTC3337_RC_ALARM_MIN		NO_OS_BIT(2)
+#define LTC3337_RC_ALARM_MAX		NO_OS_BIT(3)
+#define LTC3337_RC_ADC_READY		NO_OS_BIT(4)
+#define LTC3337_RC_IPK_PIN_MSK		NO_OS_GENMASK(7, 5)
+#define LTC3337_RC_DIE_TEMP_MSK		NO_OS_GENMASK(15, 8)
+
+#define LTC3337_REG_D	0x04 //BAT_IN V, Ipeak On
+#define LTC3337_REG_E	0x05 //BAT_IN V, Ipeak Off
+#define LTC3337_REG_F	0x06 //BAT_OUT V, Ipeak On
+#define LTC3337_REG_G	0x07 //BAT_OUT V, Ipeak Off
+#define LTC3337_BATV_MSK		NO_OS_GENMASK(11, 0)
+
+#define LTC3337_REG_H	0x08 //Temp Alarm Config
+#define LTC3337_RH_HOT_ALARM_MSK	NO_OS_GENMASK(15, 8)
+#define LTC3337_RH_COLD_ALARM_MSK	NO_OS_GENMASK(7, 0)
+
+#define LTC3337_VLSB_UV		1465 //1.465 mV = 1465 uV
+#define LTC3337_TLSB_MC		784  //0.784 Deg C = 784 mC
+#define LTC3337_TEMP_MIN_C	-41
+
+#define LTC3337_NUM_IPEAKS	8 //3-bit iPeak Input
+
+//Scale values used in integer match to calulate A/nA-hrs from counters
+#define LTC3337_NANO_AMP	1000000000
+#define LTC3337_CALC_SCALE	10000
+#define LTC3337_CALC_TO_WHOLE	(LTC3337_NANO_AMP / LTC3337_CALC_SCALE)
+
+//Scale value for converting uV to mV
+#define LTC3337_UV_TO_MV_SCALE	1000
+
+//Scale Value for converting mC to Deg C
+#define LTC3337_MC_TO_C_SCALE	1000
+
+/**
+ * Instance structure for the LTC3337 instance. Storage should be
+ * allocated in user's code. Fields should be used by the driver only,
+ * and not read or manipulated by the user
+ */
+struct ltc3337_dev {
+	struct no_os_i2c_desc *i2c_desc;	//I2C device
+	uint8_t ipeak_latched;				//iPeak value read at init
+	uint16_t latched_reg_a;				//Latched Register A value
+};
+
+/**
+ * Initialization parameters for the device
+ */
+struct ltc3337_init_param {
+	struct no_os_i2c_init_param i2c_init;	//I2C Configuration
+	uint8_t prescale;						//Initial device prescaler value
+};
+
+/**
+ * Structure for holding the accumulated charge calculation
+ */
+struct charge_count_t {
+	uint32_t a_hr;	//A-hrs
+	uint32_t na_hr;	//nA-hrs
+};
+
+/**
+ * Enumeration of sources for reading voltage
+ */
+enum ltc3337_voltage_src_t {
+	BAT_IN_IPEAK_ON,
+	BAT_IN_IPEAK_OFF,
+	BAT_OUT_IPEAK_ON,
+	BAT_OUT_IPEAK_OFF
+};
+
+/* Initializes the device instance */
+int ltc3337_init(struct ltc3337_dev** dev,
+		 struct ltc3337_init_param* init_param);
+
+/* Removes the device instance */
+int ltc3337_remove( struct ltc3337_dev* dev);
+
+/* Sets the device prescaler value */
+int ltc3337_set_prescaler(struct ltc3337_dev* dev, uint8_t prescale);
+
+/* Sets the temperature alarms, in Deg C */
+int ltc3337_set_temperature_alarms_c(struct ltc3337_dev* dev, int16_t hot_alarm,
+				     int16_t cold_alarm);
+
+/* Enabled / Disables the Coulomb counter shutdown */
+int ltc3337_set_counter_shutdown(struct ltc3337_dev* dev, uint8_t shutdown_en);
+
+/* Sets the couloumb counter alarm threshold */
+int ltc3337_set_counter_alarm(struct ltc3337_dev* dev, uint16_t reg_value,
+			      uint8_t round_up);
+
+/* Manually sets the accumulated charge register */
+int ltc3337_set_accumulated_charge(struct ltc3337_dev* dev, uint16_t reg_value,
+				   uint8_t round_up);
+
+/* Gets the current value of the accumulated charge register */
+int ltc3337_get_accumulated_charge(struct ltc3337_dev* dev,
+				   struct charge_count_t* value,
+				   uint16_t* raw_value);
+
+/* Reads the specified voltage source, in millivolts */
+int ltc3337_get_voltage_mv(struct ltc3337_dev* dev,
+			   enum ltc3337_voltage_src_t source,
+			   uint32_t* value);
+
+/* Gets the current die temperature, in Deg C */
+int ltc3337_get_temperature_c(struct ltc3337_dev* dev, int16_t* value);
+
+/* Gets the device interrupt status, and clears interrupts */
+int ltc3337_get_and_clear_interrupts(struct ltc3337_dev* dev,
+				     uint16_t* int_field,
+				     int16_t* temp_c);
+
+/* Calculates a charge register value based on A-Hr units */
+int ltc3337_calculate_charge_register(struct ltc3337_dev* dev,
+				      struct charge_count_t* charge_a,
+				      uint16_t* reg_value);
+
+#endif

--- a/projects/ltc3337/Makefile
+++ b/projects/ltc3337/Makefile
@@ -1,0 +1,8 @@
+# Select the example you want to enable by chossing y for enabling and n for disabling
+BASIC_EXAMPLE = y
+
+include ../../tools/scripts/generic_variables.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/ltc3337/builds.json
+++ b/projects/ltc3337/builds.json
@@ -1,0 +1,7 @@
+{
+    "maxim": {
+      "basic_example_max32655": {
+        "flags" : "BASIC_EXAMPLE=y TARGET=max32655"
+      }
+    }
+}

--- a/projects/ltc3337/src.mk
+++ b/projects/ltc3337/src.mk
@@ -1,0 +1,41 @@
+include $(PROJECT)/src/platform/$(PLATFORM)/platform_src.mk
+include $(PROJECT)/src/examples/examples_src.mk
+
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/main.c
+
+INCS += $(PROJECT)/src/common/common_data.h
+SRCS += $(PROJECT)/src/common/common_data.c
+	
+INCS += $(PROJECT)/src/platform/platform_includes.h
+
+INCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.h
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.c 
+
+INCS += $(INCLUDE)/no_os_delay.h     \
+		$(INCLUDE)/no_os_error.h     \
+		$(INCLUDE)/no_os_gpio.h      \
+		$(INCLUDE)/no_os_print_log.h \
+		$(INCLUDE)/no_os_i2c.h       \
+		$(INCLUDE)/no_os_alloc.h       \
+		$(INCLUDE)/no_os_mutex.h    \
+		$(INCLUDE)/no_os_irq.h      \
+		$(INCLUDE)/no_os_list.h      \
+		$(INCLUDE)/no_os_uart.h      \
+		$(INCLUDE)/no_os_spi.h      \
+		$(INCLUDE)/no_os_lf256fifo.h \
+		$(INCLUDE)/no_os_util.h 	\
+		$(INCLUDE)/no_os_units.h 
+
+SRCS += $(DRIVERS)/api/no_os_gpio.c \
+		$(NO-OS)/util/no_os_lf256fifo.c \
+		$(DRIVERS)/api/no_os_irq.c  \
+		$(DRIVERS)/api/no_os_i2c.c  \
+		$(DRIVERS)/api/no_os_uart.c \
+		$(DRIVERS)/api/no_os_spi.c \
+		$(NO-OS)/util/no_os_list.c \
+		$(NO-OS)/util/no_os_util.c \
+		$(NO-OS)/util/no_os_alloc.c \
+		$(NO-OS)/util/no_os_mutex.c
+
+INCS += $(DRIVERS)/power/ltc3337/ltc3337.h
+SRCS += $(DRIVERS)/power/ltc3337/ltc3337.c

--- a/projects/ltc3337/src/common/common_data.c
+++ b/projects/ltc3337/src/common/common_data.c
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ *   @file   common_data.c
+ *   @brief  Defines common data to be used by ltc3337 examples.
+ *   @author Brent Kowal (brent.kowal@analog.com)
+ ********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+#include "common_data.h"
+
+struct no_os_uart_init_param uip = {
+	.device_id = UART_DEVICE_ID,
+	.irq_id = UART_IRQ_ID,
+	.asynchronous_rx = true,
+	.baud_rate = UART_BAUDRATE,
+	.size = NO_OS_UART_CS_8,
+	.parity = NO_OS_UART_PAR_NO,
+	.stop = NO_OS_UART_STOP_1_BIT,
+	.platform_ops = UART_OPS,
+	.extra = UART_EXTRA,
+};
+
+const struct no_os_i2c_init_param ltc3337_i2c_ip = {
+	.device_id = I2C_DEVICE_ID,
+	.max_speed_hz = I2C_MAX_SPEED,
+	.slave_address = LTC3337_I2C_ADDR,
+	.platform_ops = I2C_OPS,
+	.extra = I2C_EXTRA,
+};
+
+struct ltc3337_init_param ltc3337_ip = {
+	.prescale = 10,
+	.i2c_init = ltc3337_i2c_ip,
+};

--- a/projects/ltc3337/src/common/common_data.h
+++ b/projects/ltc3337/src/common/common_data.h
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ *   @file   common_data.h
+ *   @brief  Defines common data to be used by ltc3337 examples.
+ *   @author Brent Kowal (brent.kowal@analog.com)
+ ********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#ifndef __COMMON_DATA_H__
+#define __COMMON_DATA_H__
+
+#include "platform_includes.h"
+#include "ltc3337.h"
+
+extern struct no_os_uart_init_param uip;
+
+extern const struct no_os_i2c_init_param ltc3337_i2c_ip;
+extern struct ltc3337_init_param ltc3337_ip;
+
+#endif /* __COMMON_DATA_H__ */

--- a/projects/ltc3337/src/examples/basic/basic_example.c
+++ b/projects/ltc3337/src/examples/basic/basic_example.c
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ *   @file   basic_example.c
+ *   @brief  Basic example code for ltc3337 project
+ *   @author Brent Kowal (brent.kowal@analog.com)
+ ********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+#include "basic_example.h"
+#include "common_data.h"
+#include "ltc3337.h"
+#include "no_os_print_log.h"
+#include "no_os_delay.h"
+
+/*****************************************************************************
+ * @brief Basic example main execution.
+ *
+ * @return ret - Result of the example execution. If working correctly, will
+ *               execute continuously the while(1) loop and will not return.
+ *******************************************************************************/
+int basic_example_main()
+{
+	struct ltc3337_dev *dev;
+	struct charge_count_t charge;
+	uint16_t value16;
+	uint32_t value32;
+	int16_t temp_value;
+
+	int ret;
+
+	ret = ltc3337_init(&dev, &ltc3337_ip);
+	if (ret)
+		goto error;
+
+	while (1) {
+		ret = ltc3337_get_accumulated_charge(dev, &charge, &value16);
+		if(ret)
+			goto free_dev;
+
+		pr_info("Accumulated Charge %d.%09d (0x%04X)\n", charge.a_hr, charge.na_hr,
+			value16);
+
+		ret = ltc3337_get_voltage_mv(dev, BAT_IN_IPEAK_OFF, &value32);
+		if(ret)
+			goto free_dev;
+
+		pr_info("Batt In, iPeak Off %d mV\n", value32);
+
+		ret = ltc3337_get_voltage_mv(dev, BAT_IN_IPEAK_ON, &value32);
+		if(ret)
+			goto free_dev;
+
+		pr_info("Batt In, iPeak On %d mV\n", value32);
+
+		ret = ltc3337_get_voltage_mv(dev, BAT_OUT_IPEAK_OFF, &value32);
+		if(ret)
+			goto free_dev;
+
+		pr_info("Batt Out, iPeak Off %d mV\n", value32);
+
+		ret = ltc3337_get_voltage_mv(dev, BAT_OUT_IPEAK_ON, &value32);
+		if(ret)
+			goto free_dev;
+
+		pr_info("Batt Out, iPeak On %d mV\n", value32);
+
+
+		ret = ltc3337_get_temperature_c(dev, &temp_value);
+		if(ret)
+			goto free_dev;
+
+		pr_info("Die Temp %d C\n", temp_value);
+
+		no_os_mdelay(2000);
+	}
+
+free_dev:
+	ltc3337_remove(dev);
+error:
+	pr_info("Error!\r\n");
+	return 0;
+}

--- a/projects/ltc3337/src/examples/basic/basic_example.h
+++ b/projects/ltc3337/src/examples/basic/basic_example.h
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ *   @file   basic_example.h
+ *   @brief  Basic example header for ltc3337 project
+ *   @author Brent Kowal (brent.kowal@analog.com)
+ ********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#ifndef __BASIC_EXAMPLE_H__
+#define __BASIC_EXAMPLE_H__
+
+int basic_example_main();
+
+#endif /* __BASIC_EXAMPLE_H__ */

--- a/projects/ltc3337/src/examples/examples_src.mk
+++ b/projects/ltc3337/src/examples/examples_src.mk
@@ -1,0 +1,8 @@
+ifeq (y,$(strip $(BASIC_EXAMPLE)))
+CFLAGS += -DBASIC_EXAMPLE=1
+SRCS += $(PROJECT)/src/examples/basic/basic_example.c
+INCS += $(PROJECT)/src/examples/basic/basic_example.h
+endif
+
+INCS += $(INCLUDE)/no_os_list.h \
+		$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h

--- a/projects/ltc3337/src/platform/maxim/main.c
+++ b/projects/ltc3337/src/platform/maxim/main.c
@@ -1,0 +1,75 @@
+/********************************************************************************
+ *   @file   main.c
+ *   @brief  Main file for Maxim platform of ltc3337 project.
+ *   @author Brent Kowal (brent.kowal@analog.com)
+ ********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+#include "platform_includes.h"
+#include "common_data.h"
+
+
+#ifdef BASIC_EXAMPLE
+#include "basic_example.h"
+#endif
+
+/*******************************************************************************
+ * @brief Main function execution for MAX32655 platform.
+ *
+ * @return ret - Result of the enabled examples execution.
+ *******************************************************************************/
+int main()
+{
+	int ret;
+
+#ifdef BASIC_EXAMPLE
+	struct no_os_uart_desc *uart;
+
+	ret = no_os_uart_init(&uart, &uip);
+	if (ret)
+		goto error;
+
+	no_os_uart_stdio(uart);
+	ret = basic_example_main();
+	if (ret)
+		goto error;
+#endif
+
+error:
+#ifdef BASIC_EXAMPLE
+	no_os_uart_remove(uart);
+#endif
+	return 0;
+}

--- a/projects/ltc3337/src/platform/maxim/parameters.c
+++ b/projects/ltc3337/src/platform/maxim/parameters.c
@@ -1,0 +1,47 @@
+/********************************************************************************
+ *   @file   parameters.c
+ *   @brief  Definition of maxim platform data used by ltc3337 project.
+ *   @author Brent Kowal (brent.kowal@analog.com)
+ ********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#include "parameters.h"
+
+struct max_uart_init_param max_uart_extra = {
+	.flow = UART_FLOW_DIS,
+};
+
+struct max_i2c_init_param max_i2c_extra = {
+	.vssel = MXC_GPIO_VSSEL_VDDIOH,
+};

--- a/projects/ltc3337/src/platform/maxim/parameters.h
+++ b/projects/ltc3337/src/platform/maxim/parameters.h
@@ -1,0 +1,68 @@
+/********************************************************************************
+ *   @brief  Definitions specific to Maxim platform used by ltc3337 project.
+ *   @author Brent Kowal (brent.kowal@analog.com)
+ ********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
+
+#include "maxim_uart.h"
+#include "maxim_uart_stdio.h"
+#include "maxim_i2c.h"
+#include "maxim_irq.h"
+#include "maxim_gpio.h"
+
+
+#define UART_IRQ_ID	UART0_IRQn
+#define UART_DEVICE_ID	0
+#define UART_BAUDRATE	57600
+#define UART_OPS	&max_uart_ops
+#define UART_EXTRA	&max_uart_extra
+
+
+#if (TARGET_NUM == 32655)
+#define I2C_DEVICE_ID	2
+#else
+#define I2C_DEVICE_ID	0
+#endif
+
+#define I2C_MAX_SPEED	100000
+#define I2C_OPS		&max_i2c_ops
+#define I2C_EXTRA	&max_i2c_extra
+
+extern struct max_uart_init_param max_uart_extra;
+extern struct max_i2c_init_param max_i2c_extra;
+
+#endif /* __PARAMETERS_H__ */

--- a/projects/ltc3337/src/platform/maxim/platform_src.mk
+++ b/projects/ltc3337/src/platform/maxim/platform_src.mk
@@ -1,0 +1,13 @@
+INCS += $(PLATFORM_DRIVERS)/maxim_delay.h     \
+	$(PLATFORM_DRIVERS)/maxim_gpio.h      \
+	$(PLATFORM_DRIVERS)/maxim_i2c.h       \
+	$(PLATFORM_DRIVERS)/maxim_irq.h      \
+	$(PLATFORM_DRIVERS)/maxim_uart.h      \
+	$(PLATFORM_DRIVERS)/maxim_uart_stdio.h
+
+	SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c     \
+		$(PLATFORM_DRIVERS)/maxim_gpio.c      \
+		$(PLATFORM_DRIVERS)/maxim_i2c.c       \
+		$(PLATFORM_DRIVERS)/maxim_irq.c      \
+		$(PLATFORM_DRIVERS)/maxim_uart.c      \
+		$(PLATFORM_DRIVERS)/maxim_uart_stdio.c

--- a/projects/ltc3337/src/platform/platform_includes.h
+++ b/projects/ltc3337/src/platform/platform_includes.h
@@ -1,0 +1,49 @@
+/********************************************************************************
+ *   @file   platform_includes.h
+ *   @brief  Includes for used platforms used by the ltc3337 project.
+ *   @author Brent Kowal (brent.kowal@analog.com)
+ ********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#ifndef __PLATFORM_INCLUDES_H__
+#define __PLATFORM_INCLUDES_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#ifdef MAXIM_PLATFORM
+#include "maxim/parameters.h"
+#endif
+
+#endif /* __PLATFORM_INCLUDES_H__ */


### PR DESCRIPTION
Initial implementation of the LTC3337 no-OS Driver. This adds support for the LTC3337 Primary Battery SOH Monitor and Coulomb Counter.

This driver is derived from the stand-alone demonstration application maintained at [LTC3337 Demo](https://github.com/BrentK-ADI/Demo-Projects/tree/main/ltc3337_demo)

The original driver source code at the above repo includes unit testing for verification of data type conversions and calculations.  

No-Os driver and provided example tested against a MAX32655FTHR board paired with a Mikroe BATT-4-MON Click (LTC3337).

New driver directory "power" created, mirroring the location of battery monitors/fuel gauges in the Linux kernel.