### PR TITLE
projects: demo_esp: add maxim paltform support

### DIFF
--- a/projects/demo_esp/src.mk
+++ b/projects/demo_esp/src.mk
@@ -22,6 +22,7 @@ INCS += $(INCLUDE)/no_os_delay.h		\
 	$(INCLUDE)/no_os_irq.h			\
 	$(INCLUDE)/no_os_uart.h			\
 	$(INCLUDE)/no_os_lf256fifo.h		\
+	$(INCLUDE)/no_os_units.h		\
 	$(INCLUDE)/no_os_util.h			\
 	$(INCLUDE)/no_os_list.h			\
 	$(INCLUDE)/no_os_circular_buffer.h	\

--- a/projects/demo_esp/src/platform/maxim/main.c
+++ b/projects/demo_esp/src/platform/maxim/main.c
@@ -1,6 +1,6 @@
 /***************************************************************************//**
- *   @file   platform_includes.h
- *   @brief  Includes for used platforms used by demo_esp project.
+ *   @file   main.c
+ *   @brief  Main file for maxim platform of demo_esp project.
  *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
 ********************************************************************************
  * Copyright 2023(c) Analog Devices, Inc.
@@ -36,18 +36,31 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
-#ifndef __PLATFORM_INCLUDES_H__
-#define __PLATFORM_INCLUDES_H__
 
 /******************************************************************************/
 /***************************** Include Files **********************************/
 /******************************************************************************/
-#ifdef ADUCM_PLATFORM
-#include "aducm3029/parameters.h"
+#include "platform_includes.h"
+#include "common_data.h"
+#include "basic_example.h"
+
+/***************************************************************************//**
+ * @brief Main function execution for maxim platform.
+ *
+ * @return ret - Result of the enabled examples execution.
+*******************************************************************************/
+int main()
+{
+	int ret;
+
+	ret = basic_example_main();
+	if (ret)
+		goto error;
+
+#if (BASIC_EXAMPLE != 1)
+#error Please enable the example and re-build the project.
 #endif
 
-#ifdef MAXIM_PLATFORM
-#include "maxim/parameters.h"
-#endif
-
-#endif /* __PLATFORM_INCLUDES_H__ */
+error:
+	return ret;
+}

--- a/projects/demo_esp/src/platform/maxim/parameters.c
+++ b/projects/demo_esp/src/platform/maxim/parameters.c
@@ -1,6 +1,6 @@
 /***************************************************************************//**
- *   @file   platform_includes.h
- *   @brief  Includes for used platforms used by demo_esp project.
+ *   @file   parameters.c
+ *   @brief  Definition of maxim platform data used by demo_esp
  *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
 ********************************************************************************
  * Copyright 2023(c) Analog Devices, Inc.
@@ -36,18 +36,15 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
-#ifndef __PLATFORM_INCLUDES_H__
-#define __PLATFORM_INCLUDES_H__
 
 /******************************************************************************/
 /***************************** Include Files **********************************/
 /******************************************************************************/
-#ifdef ADUCM_PLATFORM
-#include "aducm3029/parameters.h"
-#endif
+#include "parameters.h"
 
-#ifdef MAXIM_PLATFORM
-#include "maxim/parameters.h"
-#endif
-
-#endif /* __PLATFORM_INCLUDES_H__ */
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+struct max_uart_init_param uart_extra_ip = {
+	.flow = UART_FLOW_DIS
+};

--- a/projects/demo_esp/src/platform/maxim/parameters.h
+++ b/projects/demo_esp/src/platform/maxim/parameters.h
@@ -1,6 +1,7 @@
 /***************************************************************************//**
- *   @file   platform_includes.h
- *   @brief  Includes for used platforms used by demo_esp project.
+ *   @file   parameters.h
+ *   @brief  Definitions specific to maxim platform used by demo_esp
+ *           project.
  *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
 ********************************************************************************
  * Copyright 2023(c) Analog Devices, Inc.
@@ -36,18 +37,34 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
-#ifndef __PLATFORM_INCLUDES_H__
-#define __PLATFORM_INCLUDES_H__
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
 
 /******************************************************************************/
 /***************************** Include Files **********************************/
 /******************************************************************************/
-#ifdef ADUCM_PLATFORM
-#include "aducm3029/parameters.h"
-#endif
+#include "stdio.h"
+#include "maxim_timer.h"
+#include "maxim_irq.h"
+#include "maxim_uart.h"
 
-#ifdef MAXIM_PLATFORM
-#include "maxim/parameters.h"
-#endif
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
 
-#endif /* __PLATFORM_INCLUDES_H__ */
+#define UART_CONFIG_BAUDRATE	115200
+#define UART_CONFIG_IRQ_ID	UART2_IRQn
+#define UART_DEVICE_ID		2
+#define UART_EXTRA		&uart_extra_ip
+
+#define TIMER_ID		1
+#define TIMER_FREQ		32000
+
+#define IRQ_OPS			&max_irq_ops
+#define UART_OPS		&max_uart_ops
+#define TIMER_OPS		&max_timer_ops
+#define TIMER_EXTRA		NULL
+
+extern struct max_uart_init_param uart_extra_ip;
+
+#endif /* __PARAMETERS_H__ */

--- a/projects/demo_esp/src/platform/maxim/platform_src.mk
+++ b/projects/demo_esp/src/platform/maxim/platform_src.mk
@@ -1,0 +1,17 @@
+INCS += $(PLATFORM_DRIVERS)/$(PLATFORM)_delay.h     \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_gpio.h      \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_spi.h       \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_gpio_irq.h  \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_irq.h       \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_rtc.h       \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h      \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_timer.h
+
+SRCS += $(PLATFORM_DRIVERS)/$(PLATFORM)_delay.c     \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_gpio.c      \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_spi.c       \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_rtc.c       \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_gpio_irq.c  \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c       \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_uart.c      \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_timer.c


### PR DESCRIPTION
Add support for maxim platform within the demo_esp project.

NOTE: Tested with esp8266.