### PR TITLE
Ad9081 clocks

### DIFF
--- a/drivers/adc/ad9081/ad9081.c
+++ b/drivers/adc/ad9081/ad9081.c
@@ -499,7 +499,7 @@ static int32_t ad9081_setup(struct ad9081_phy *phy)
 	uint64_t rx_lane_rate_kbps;
 	uint32_t timeout;
 
-	no_os_clk_recalc_rate(phy->dev_clk, &dev_frequency_hz);
+	no_os_clk_recalc_rate(phy->dev_clk->clk_desc, &dev_frequency_hz);
 
 	tx_lane_rate_kbps = ad9081_calc_lanerate(&phy->jrx_link_tx,
 			    phy->dac_frequency_hz,
@@ -507,13 +507,13 @@ static int32_t ad9081_setup(struct ad9081_phy *phy)
 
 	/* The 204c calibration routine requires the link to be up */
 	if (phy->jesd_tx_clk) {
-		ret = no_os_clk_set_rate(phy->jesd_tx_clk, tx_lane_rate_kbps);
+		ret = no_os_clk_set_rate(phy->jesd_tx_clk->clk_desc, tx_lane_rate_kbps);
 		if (ret < 0) {
 			printf("Failed to set lane rate to %llu kHz: %"PRId32"\n",
 			       tx_lane_rate_kbps, ret);
 		}
 		if (phy->jrx_link_tx.jesd_param.jesd_jesdv == 2) {
-			ret = no_os_clk_enable(phy->jesd_tx_clk);
+			ret = no_os_clk_enable(phy->jesd_tx_clk->clk_desc);
 			if (ret < 0) {
 				printf("Failed to enable JESD204 link: %"PRId32"\n", ret);
 				return ret;
@@ -704,7 +704,7 @@ static int32_t ad9081_setup(struct ad9081_phy *phy)
 				    phy->adc_frequency_hz,
 				    dcm);
 
-		ret = no_os_clk_set_rate(phy->jesd_rx_clk, rx_lane_rate_kbps);
+		ret = no_os_clk_set_rate(phy->jesd_rx_clk->clk_desc, rx_lane_rate_kbps);
 		if (ret < 0) {
 			printf("Failed to set lane rate to %llu kHz: %"PRId32"\n",
 			       rx_lane_rate_kbps, ret);
@@ -744,7 +744,7 @@ static int32_t ad9081_setup(struct ad9081_phy *phy)
 	if (phy->jesd_rx_clk) {
 		timeout = 2000;
 		while(timeout) {
-			ret = no_os_clk_enable(phy->jesd_rx_clk);
+			ret = no_os_clk_enable(phy->jesd_rx_clk->clk_desc);
 			if (ret) {
 				no_os_mdelay(100);
 				timeout -= 100;
@@ -763,7 +763,7 @@ static int32_t ad9081_setup(struct ad9081_phy *phy)
 	    (phy->jrx_link_tx.jesd_param.jesd_jesdv == 1)) {
 		timeout = 2000;
 		while(timeout) {
-			ret = no_os_clk_enable(phy->jesd_tx_clk);
+			ret = no_os_clk_enable(phy->jesd_tx_clk->clk_desc);
 			if (ret) {
 				no_os_mdelay(100);
 				timeout -= 100;
@@ -798,11 +798,11 @@ static int32_t ad9081_setup(struct ad9081_phy *phy)
 					return ret;
 
 				if (phy->jesd_tx_clk) {
-					no_os_clk_disable(phy->jesd_tx_clk);
+					no_os_clk_disable(phy->jesd_tx_clk->clk_desc);
 
 					no_os_mdelay(100);
 
-					ret = no_os_clk_enable(phy->jesd_tx_clk);
+					ret = no_os_clk_enable(phy->jesd_tx_clk->clk_desc);
 					if (ret < 0) {
 						printf("Failed to enable JESD204 link: %"PRId32"\n",
 						       ret);

--- a/drivers/axi_core/jesd204/jesd204_clk.c
+++ b/drivers/axi_core/jesd204/jesd204_clk.c
@@ -41,6 +41,8 @@
 /***************************** Include Files **********************************/
 /******************************************************************************/
 #include "no_os_error.h"
+#include "no_os_alloc.h"
+#include "no_os_clk.h"
 #include "jesd204_clk.h"
 
 /******************************************************************************/
@@ -122,3 +124,114 @@ int32_t jesd204_clk_set_rate(struct jesd204_clk *clk, uint32_t chan,
 
 	return 0;
 }
+
+/**
+ * @brief Initialize the CLK structure.
+ *
+ * @param desc - The CLK descriptor.
+ * @param init_param - The structure holding the device initial parameters.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+static int jesd204_no_os_clk_init(struct no_os_clk_desc **desc,
+				  const struct no_os_clk_init_param *init_param)
+{
+	struct jesd204_clk  *jesd204_clk_d;
+
+	/* Exit if we have no init_params */
+	if (!init_param) {
+		return -EINVAL;
+	}
+
+	*desc = no_os_calloc(1, sizeof(**desc));
+	/* Exit if memory cannot be allocated */
+	if(!*desc)
+		goto error;
+
+	jesd204_clk_d = init_param->dev_desc;
+	/* Exit if no hardware device specified in init_param */
+	if(!jesd204_clk_d)
+		goto error;
+
+	(*desc)->name = init_param->name;
+	(*desc)->hw_ch_num = init_param->hw_ch_num;
+
+	(*desc)->dev_desc = (void *)no_os_calloc(1, sizeof(struct jesd204_clk));
+
+	(*desc)->dev_desc = init_param->dev_desc;
+
+	return 0;
+error:
+	free(*desc);
+	return -ENOMEM;
+}
+
+/**
+ * @brief Remove the CLK structure.
+ *
+ * @param desc - The CLK descriptor.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+static int jesd204_no_os_clk_remove(struct no_os_clk_desc *desc)
+{
+	struct jesd204_clk  *jesd204_clk_dev;
+
+	jesd204_clk_dev = desc->dev_desc;
+
+	if(!jesd204_clk_dev)
+		return -ENODEV;
+
+	free(desc);
+
+	return 0;
+}
+
+/*
+ * @brief Start the clock.
+ *
+ * @param desc - The CLK descriptor.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+static int jesd204_no_os_clk_enable(struct no_os_clk_desc *desc)
+{
+	return jesd204_clk_enable(desc->dev_desc);
+}
+
+/*
+ * @brief Stop the clock.
+ *
+ * @param desc - The CLK descriptor.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+static int jesd204_no_os_clk_disable(struct no_os_clk_desc *desc)
+{
+	return jesd204_clk_disable(desc->dev_desc);
+}
+
+/*
+ * @brief Set clock rate.
+ *
+ * @param desc - The CLK descriptor.
+ * @param rate - Clock rate.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+static int jesd204_no_os_clk_set_rate(struct no_os_clk_desc *desc,
+				      uint64_t rate)
+{
+	return jesd204_clk_set_rate(desc->dev_desc, 0, (uint32_t)rate);
+}
+
+/*
+ * @brief jesd204 platform specific CLK platform ops structure
+ */
+const struct no_os_clk_platform_ops jesd204_clk_ops = {
+	.init = &jesd204_no_os_clk_init,
+	.clk_enable = &jesd204_no_os_clk_enable,
+	.clk_disable = &jesd204_no_os_clk_disable,
+	.clk_set_rate = &jesd204_no_os_clk_set_rate,
+	.remove = &jesd204_no_os_clk_remove
+};

--- a/drivers/axi_core/jesd204/jesd204_clk.h
+++ b/drivers/axi_core/jesd204/jesd204_clk.h
@@ -56,6 +56,11 @@ struct jesd204_clk {
 	struct axi_jesd204_tx *jesd_tx;
 };
 
+/**
+ * @brief jesd204 specific CLK platform ops structure
+ */
+extern const struct no_os_clk_platform_ops jesd204_clk_ops;
+
 /******************************************************************************/
 /************************ Functions Declarations ******************************/
 /******************************************************************************/

--- a/drivers/frequency/hmc7044/hmc7044.h
+++ b/drivers/frequency/hmc7044/hmc7044.h
@@ -68,6 +68,8 @@ struct hmc7044_chan_spec {
 
 struct hmc7044_dev {
 	struct no_os_spi_desc	*spi_desc;
+	/* CLK descriptors */
+	struct no_os_clk_desc	**clk_desc;
 	bool		is_hmc7043;
 	uint32_t	clkin_freq[4];
 	uint32_t	clkin_freq_ccf[4];
@@ -92,6 +94,8 @@ struct hmc7044_dev {
 
 struct hmc7044_init_param {
 	struct no_os_spi_init_param	*spi_init;
+	/* Init CLK channel descriptors */
+	bool		export_no_os_clk;
 	bool		is_hmc7043;
 	uint32_t	clkin_freq[4];
 	uint32_t	clkin_freq_ccf[4];
@@ -113,6 +117,11 @@ struct hmc7044_init_param {
 	uint32_t	num_channels;
 	struct hmc7044_chan_spec	*channels;
 };
+
+/**
+ * @brief hmc7044 specific CLK platform ops structure
+ */
+extern const struct no_os_clk_platform_ops hmc7044_clk_ops;
 
 /******************************************************************************/
 /************************ Functions Declarations ******************************/

--- a/projects/ad9081/src.mk
+++ b/projects/ad9081/src.mk
@@ -100,7 +100,9 @@ INCS +=	$(PROJECT)/src/app_clock.h \
 	$(INCLUDE)/no_os_units.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_uart.h \
 	$(INCLUDE)/no_os_mutex.h \
+	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/jesd204.h \
 	$(NO-OS)/jesd204/jesd204-priv.h
 ifeq (y,$(strip $(QUAD_MXFE)))

--- a/projects/ad9081/src/app_clock.c
+++ b/projects/ad9081/src/app_clock.c
@@ -339,9 +339,6 @@ int32_t app_clock_init(struct no_os_clk dev_refclk[MULTIDEVICE_INSTANCE_COUNT])
 	}
 #else
 	hmc7044_hw.dev = hmc7044_dev;
-	hmc7044_hw.dev_clk_recalc_rate = hmc7044_clk_recalc_rate;
-	hmc7044_hw.dev_clk_round_rate = hmc7044_clk_round_rate;
-	hmc7044_hw.dev_clk_set_rate = hmc7044_clk_set_rate;
 
 	dev_refclk[0].hw = &hmc7044_hw;
 	dev_refclk[0].hw_ch_num = 0;

--- a/projects/ad9081/src/app_clock.c
+++ b/projects/ad9081/src/app_clock.c
@@ -346,6 +346,21 @@ int32_t app_clock_init(struct no_os_clk dev_refclk[MULTIDEVICE_INSTANCE_COUNT])
 	dev_refclk[0].hw = &hmc7044_hw;
 	dev_refclk[0].hw_ch_num = 0;
 	dev_refclk[0].name = "dev_refclk";
+
+	struct no_os_clk_desc *clk_desc;
+	struct no_os_clk_init_param clk_desc_init = { 0 };
+
+	clk_desc_init.dev_desc = hmc7044_dev;
+	clk_desc_init.hw_ch_num = 0;
+	clk_desc_init.name = "dev_refclk";
+	clk_desc_init.platform_ops = &hmc7044_clk_ops;
+
+	ret = no_os_clk_init(&clk_desc, &clk_desc_init);
+	if (ret)
+		return ret;
+
+	dev_refclk[0].clk_desc = clk_desc;
+
 #endif
 
 	return 0;

--- a/projects/ad9081/src/app_jesd.c
+++ b/projects/ad9081/src/app_jesd.c
@@ -175,5 +175,33 @@ int32_t app_jesd_init(struct no_os_clk clk[2],
 	clk[1].name = "jesd_tx";
 	clk[1].hw = &jesd_tx_hw;
 
+	struct no_os_clk_desc *rx_jesd_clk_desc;
+	struct no_os_clk_desc *tx_jesd_clk_desc;
+
+	struct no_os_clk_init_param rx_clk_desc_init = { 0 };
+	struct no_os_clk_init_param tx_clk_desc_init = { 0 };
+
+	rx_clk_desc_init.dev_desc = &rx_jesd_clk;
+	rx_clk_desc_init.hw_ch_num = 0;
+	rx_clk_desc_init.name = "jesd_rx";
+	rx_clk_desc_init.platform_ops = &jesd204_clk_ops;
+
+	ret = no_os_clk_init(&rx_jesd_clk_desc, &rx_clk_desc_init);
+	if (ret)
+		return ret;
+
+	clk[0].clk_desc = rx_jesd_clk_desc;
+
+	tx_clk_desc_init.dev_desc = &tx_jesd_clk;
+	tx_clk_desc_init.hw_ch_num = 0;
+	tx_clk_desc_init.name = "jesd_tx";
+	tx_clk_desc_init.platform_ops = &jesd204_clk_ops;
+
+	ret = no_os_clk_init(&tx_jesd_clk_desc, &tx_clk_desc_init);
+	if (ret)
+		return ret;
+
+	clk[1].clk_desc = tx_jesd_clk_desc;
+
 	return 0;
 }

--- a/projects/ad9081/src/app_jesd.c
+++ b/projects/ad9081/src/app_jesd.c
@@ -160,14 +160,8 @@ int32_t app_jesd_init(struct no_os_clk clk[2],
 	tx_jesd_clk.jesd_tx = tx_jesd;
 
 	jesd_rx_hw.dev = &rx_jesd_clk;
-	jesd_rx_hw.dev_clk_enable = jesd204_clk_enable;
-	jesd_rx_hw.dev_clk_disable = jesd204_clk_disable;
-	jesd_rx_hw.dev_clk_set_rate = jesd204_clk_set_rate;
 
 	jesd_tx_hw.dev = &tx_jesd_clk;
-	jesd_tx_hw.dev_clk_enable = jesd204_clk_enable;
-	jesd_tx_hw.dev_clk_disable = jesd204_clk_disable;
-	jesd_tx_hw.dev_clk_set_rate = jesd204_clk_set_rate;
 
 	clk[0].name = "jesd_rx";
 	clk[0].hw = &jesd_rx_hw;

--- a/projects/ad9172/src.mk
+++ b/projects/ad9172/src.mk
@@ -31,6 +31,7 @@ SRCS += $(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c \
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
 	$(NO-OS)/util/no_os_util.c \
 	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_clk.c \
 	$(NO-OS)/util/no_os_mutex.c \
 	$(NO-OS)/jesd204/jesd204-core.c \
 	$(NO-OS)/jesd204/jesd204-fsm.c
@@ -73,6 +74,7 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_util.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_clk.h \
 	$(INCLUDE)/no_os_mutex.h \
 	$(INCLUDE)/jesd204.h \
 	$(NO-OS)/jesd204/jesd204-priv.h

--- a/projects/ad9208/src.mk
+++ b/projects/ad9208/src.mk
@@ -43,6 +43,7 @@ SRCS += $(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
 	$(NO-OS)/util/no_os_util.c \
 	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_clk.c \
 	$(NO-OS)/util/no_os_mutex.c \
 	$(NO-OS)/jesd204/jesd204-core.c \
 	$(NO-OS)/jesd204/jesd204-fsm.c
@@ -66,6 +67,7 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_util.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_clk.h \
 	$(INCLUDE)/no_os_mutex.h \
 	$(INCLUDE)/jesd204.h \
 	$(NO-OS)/jesd204/jesd204-priv.h

--- a/projects/adrv9009/src.mk
+++ b/projects/adrv9009/src.mk
@@ -67,7 +67,8 @@ SRCS += $(NO-OS)/util/no_os_fifo.c \
 endif
 SRCS +=	$(NO-OS)/util/no_os_util.c \
 	$(NO-OS)/util/no_os_alloc.c \
-	$(NO-OS)/util/no_os_mutex.c
+	$(NO-OS)/util/no_os_mutex.c \
+	$(NO-OS)/util/no_os_clk.c
 ifeq (xilinx,$(strip $(PLATFORM)))
 SRCS += $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
@@ -151,6 +152,7 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_mutex.h \
 	$(INCLUDE)/no_os_units.h \
 	$(INCLUDE)/no_os_print_log.h \
+	$(INCLUDE)/no_os_clk.h \
 	$(INCLUDE)/jesd204.h \
 	$(NO-OS)/jesd204/jesd204-priv.h
 ifeq (y,$(strip $(TINYIIOD)))


### PR DESCRIPTION
Use no-os Clock infrastructure for the AD9081 project. 

- non-QUAD_MXFE devices 