### PR TITLE
API: Add i2c and spi bus instance

### DIFF
--- a/include/no_os_i2c.h
+++ b/include/no_os_i2c.h
@@ -47,6 +47,12 @@
 #include <stdint.h>
 
 /******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+#define I2C_MAX_BUS_NUMBER 4
+
+/******************************************************************************/
 /*************************** Types Declarations *******************************/
 /******************************************************************************/
 
@@ -75,10 +81,30 @@ struct no_os_i2c_init_param {
 };
 
 /**
+ * @struct no_os_i2cbus_desc
+ * @brief Structure holding I2C bus descriptor
+ */
+struct no_os_i2cbus_desc {
+	/** I2C bus mutex(lock)*/
+	void* mutex;
+	/** I2C bus Device ID */
+	uint32_t	device_id;
+	/** I2C bus maximum transfer speed supported */
+	uint32_t	max_speed_hz;
+	/** I2C bus platform specific functions */
+	const struct no_os_i2c_platform_ops *platform_ops;
+	/** I2C bus extra parameters (device specific parameters) */
+	void		*extra;
+};
+
+
+/**
  * @struct no_os_i2c_desc
- * @brief Structure holding I2C descriptor
+ * @brief Structure holding I2C address descriptor
  */
 struct no_os_i2c_desc {
+	/** I2C bus address*/
+	struct no_os_i2cbus_desc *bus;
 	/** Device ID */
 	uint32_t	device_id;
 	/** I2C maximum transfer speed supported */
@@ -130,5 +156,11 @@ int32_t no_os_i2c_read(struct no_os_i2c_desc *desc,
 		       uint8_t *data,
 		       uint8_t bytes_number,
 		       uint8_t stop_bit);
+
+/* Initialize I2C bus descriptor*/
+int32_t no_os_i2cbus_init(const struct no_os_i2c_init_param *param);
+
+/* Free the resources allocated for I2C  bus desc*/
+void no_os_i2cbus_remove(uint32_t bus_number);
 
 #endif // _NO_OS_I2C_H_

--- a/include/no_os_spi.h
+++ b/include/no_os_spi.h
@@ -52,6 +52,7 @@
 
 #define	NO_OS_SPI_CPHA	0x01
 #define	NO_OS_SPI_CPOL	0x02
+#define SPI_MAX_BUS_NUMBER 8
 
 /******************************************************************************/
 /*************************** Types Declarations *******************************/
@@ -137,11 +138,34 @@ struct no_os_spi_init_param {
 };
 
 /**
+ * @struct no_os_spibus_desc
+ * @brief SPI bus descriptor
+*/
+struct no_os_spibus_desc {
+	/** SPI bus mutex (lock) */
+	void 		*mutex;
+	/** SPI bus device id */
+	uint32_t	device_id;
+	/** SPI bus max speed */
+	uint32_t	max_speed_hz;
+	/** SPI bus mode */
+	enum no_os_spi_mode	mode;
+	/** SPI bus bit order */
+	enum no_os_spi_bit_order	bit_order;
+	/** SPI bus platform ops */
+	const struct no_os_spi_platform_ops *platform_ops;
+	/** SPI bus extra */
+	void		*extra;
+};
+
+/**
  * @struct no_os_spi_desc
  * @brief Structure holding SPI descriptor.
  */
 struct no_os_spi_desc {
-	/** Device ID */
+	/** SPI bus address */
+	struct no_os_spibus_desc	*bus;
+	/** SPI bus number (0 for SPI0, 1 for SPI1, ...) */
 	uint32_t	device_id;
 	/** maximum transfer speed */
 	uint32_t	max_speed_hz;
@@ -194,6 +218,12 @@ int32_t no_os_spi_write_and_read(struct no_os_spi_desc *desc,
 int32_t no_os_spi_transfer(struct no_os_spi_desc *desc,
 			   struct no_os_spi_msg *msgs,
 			   uint32_t len);
+
+/* Initialize SPI bus descriptor*/
+int32_t no_os_spibus_init(const struct no_os_spi_init_param *param);
+
+/* Free the resources allocated for SPI bus desc*/
+void no_os_spibus_remove(uint32_t bus_number);
 
 
 #endif // _NO_OS_SPI_H_

--- a/projects/ad400x-fmcz/src.mk
+++ b/projects/ad400x-fmcz/src.mk
@@ -16,7 +16,8 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine.c \
 	$(NO-OS)/util/no_os_util.c \
-	$(NO-OS)/util/no_os_alloc.c
+	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_delay.c
@@ -37,4 +38,5 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_uart.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_util.h \
-	$(INCLUDE)/no_os_alloc.h
+	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h

--- a/projects/ad4110/src.mk
+++ b/projects/ad4110/src.mk
@@ -22,7 +22,8 @@ SRCS += $(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_delay.c \
 	$(NO-OS)/util/no_os_list.c \
 	$(NO-OS)/util/no_os_util.c \
-	$(NO-OS)/util/no_os_alloc.c
+	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c
 
 INCS += $(DRIVERS)/afe/ad4110/ad4110.h
 
@@ -38,5 +39,6 @@ INCS += $(INCLUDE)/no_os_spi.h \
 	$(INCLUDE)/no_os_irq.h \
 	$(INCLUDE)/no_os_util.h \
 	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(INCLUDE)/no_os_list.h

--- a/projects/ad413x/src.mk
+++ b/projects/ad413x/src.mk
@@ -23,7 +23,8 @@ SRCS += $(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(NO-OS)/util/no_os_alloc.c \
 	$(NO-OS)/util/no_os_list.c \
 	$(NO-OS)/util/no_os_util.c \
-	$(NO-OS)/util/no_os_crc8.c
+	$(NO-OS)/util/no_os_crc8.c \
+	$(NO-OS)/util/no_os_mutex.c
 
 INCS += $(DRIVERS)/afe/ad413x/ad413x.h
 
@@ -41,7 +42,8 @@ INCS += $(INCLUDE)/no_os_spi.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(INCLUDE)/no_os_list.h \
 	$(INCLUDE)/no_os_crc8.h \
-	$(INCLUDE)/no_os_alloc.h
+	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h
 
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio

--- a/projects/ad463x_fmcz/src.mk
+++ b/projects/ad463x_fmcz/src.mk
@@ -21,7 +21,8 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/axi_core/axi_pwmgen/axi_pwm.c \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine.c \
 	$(NO-OS)/util/no_os_util.c \
-	$(NO-OS)/util/no_os_alloc.c
+	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
@@ -59,7 +60,8 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_util.h \
 	$(INCLUDE)/no_os_print_log.h \
-	$(INCLUDE)/no_os_alloc.h
+	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h
 ifeq (y,$(strip $(TINYIIOD)))
 INCS += $(DRIVERS)/adc/ad463x/iio_ad463x.h \
 	$(INCLUDE)/no_os_fifo.h \

--- a/projects/ad469x_fmcz/src.mk
+++ b/projects/ad469x_fmcz/src.mk
@@ -19,7 +19,8 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/axi_core/axi_pwmgen/axi_pwm.c \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine.c \
 	$(NO-OS)/util/no_os_util.c \
-	$(NO-OS)/util/no_os_alloc.c
+	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
@@ -56,7 +57,8 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_uart.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_util.h \
-	$(INCLUDE)/no_os_alloc.h
+	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h
 ifeq (y,$(strip $(TINYIIOD)))
 INCS += $(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_irq.h \

--- a/projects/ad5758-sdz/src.mk
+++ b/projects/ad5758-sdz/src.mk
@@ -7,7 +7,8 @@ SRCS += $(DRIVERS)/api/no_os_gpio.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_delay.c \
 	$(DRIVERS)/dac/ad5758/ad5758.c \
 	$(NO-OS)/util/no_os_util.c \
-        $(NO-OS)/util/no_os_alloc.c
+        $(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c
 
 INCS += $(INCLUDE)/no_os_gpio.h \
 	$(INCLUDE)/no_os_spi.h \
@@ -16,6 +17,7 @@ INCS += $(INCLUDE)/no_os_gpio.h \
         $(INCLUDE)/no_os_print_log.h \
         $(INCLUDE)/no_os_util.h \
         $(INCLUDE)/no_os_alloc.h \
+        $(INCLUDE)/no_os_mutex.h \
         $(PLATFORM_DRIVERS)/$(PLATFORM)_gpio.h \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_spi.h	\
 	$(DRIVERS)/dac/ad5758/ad5758.h

--- a/projects/ad5766-sdz/src.mk
+++ b/projects/ad5766-sdz/src.mk
@@ -17,7 +17,8 @@ SRCS += $(PROJECT)/src/ad5766_core.c \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine.c \
 	$(NO-OS)/util/no_os_util.c \
-	$(NO-OS)/util/no_os_alloc.c
+	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
@@ -37,4 +38,5 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_delay.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(INCLUDE)/no_os_util.h \
-	$(INCLUDE)/no_os_alloc.h
+	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h

--- a/projects/ad6676-ebz/src.mk
+++ b/projects/ad6676-ebz/src.mk
@@ -26,6 +26,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(DRIVERS)/adc/ad6676/ad6676.c \
 	$(NO-OS)/util/no_os_util.c \
 	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c \
 	$(NO-OS)/jesd204/jesd204-core.c \
 	$(NO-OS)/jesd204/jesd204-fsm.c
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
@@ -63,6 +64,7 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_util.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h \
 	$(INCLUDE)/jesd204.h \
 	$(NO-OS)/jesd204/jesd204-priv.h
 ifeq (y,$(strip $(TINYIIOD)))

--- a/projects/ad7124-4sdz/src.mk
+++ b/projects/ad7124-4sdz/src.mk
@@ -18,7 +18,8 @@ SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_delay.c \
 	$(NO-OS)/util/no_os_util.c \
-	$(NO-OS)/util/no_os_alloc.c
+	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c
 INCS += $(DRIVERS)/adc/ad7124/ad7124.h \
 	$(DRIVERS)/adc/ad7124/ad7124_regs.h
 
@@ -35,4 +36,5 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_uart.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_util.h \
-	$(INCLUDE)/no_os_alloc.h
+	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h

--- a/projects/ad713x_fmcz/src.mk
+++ b/projects/ad713x_fmcz/src.mk
@@ -20,7 +20,8 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/axi_core/axi_pwmgen/axi_pwm.c \
 	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
 	$(NO-OS)/util/no_os_util.c \
-	$(NO-OS)/util/no_os_alloc.c
+	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
@@ -55,7 +56,8 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_pwm.h \
 	$(INCLUDE)/no_os_util.h \
-	$(INCLUDE)/no_os_alloc.h
+	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h
 ifeq (y,$(strip $(TINYIIOD)))
 INCS += $(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_list.h

--- a/projects/ad719x/src.mk
+++ b/projects/ad719x/src.mk
@@ -27,7 +27,8 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/adc/ad719x/ad719x.c \
 	$(NO-OS)/util/no_os_list.c \
 	$(NO-OS)/util/no_os_util.c \
-	$(NO-OS)/util/no_os_alloc.c
+	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c
 
 INCS += $(DRIVERS)/adc/ad719x/ad719x.h
 
@@ -39,4 +40,5 @@ INCS += $(INCLUDE)/no_os_spi.h \
 	$(INCLUDE)/no_os_util.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(INCLUDE)/no_os_list.h \
-	$(INCLUDE)/no_os_alloc.h
+	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h

--- a/projects/ad738x_fmcz/src.mk
+++ b/projects/ad738x_fmcz/src.mk
@@ -15,7 +15,8 @@ SRCS += $(DRIVERS)/adc/ad738x/ad738x.c \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine.c \
 	$(NO-OS)/util/no_os_util.c \
-	$(NO-OS)/util/no_os_alloc.c
+	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_delay.c
@@ -32,4 +33,5 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_delay.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(INCLUDE)/no_os_util.h \
-	$(INCLUDE)/no_os_alloc.h
+	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h 

--- a/projects/ad74413r/src.mk
+++ b/projects/ad74413r/src.mk
@@ -23,7 +23,8 @@ INCS += $(INCLUDE)/no_os_delay.h     \
 		$(INCLUDE)/no_os_lf256fifo.h \
 		$(INCLUDE)/no_os_util.h \
 		$(INCLUDE)/no_os_units.h \
-		$(INCLUDE)/no_os_alloc.h
+		$(INCLUDE)/no_os_alloc.h \
+		$(INCLUDE)/no_os_mutex.h
 
 SRCS += $(DRIVERS)/api/no_os_gpio.c \
 		$(NO-OS)/util/no_os_lf256fifo.c \
@@ -33,7 +34,8 @@ SRCS += $(DRIVERS)/api/no_os_gpio.c \
 		$(NO-OS)/util/no_os_list.c \
 		$(NO-OS)/util/no_os_crc8.c \
 		$(NO-OS)/util/no_os_util.c \
-		$(NO-OS)/util/no_os_alloc.c
+		$(NO-OS)/util/no_os_alloc.c \
+		$(NO-OS)/util/no_os_mutex.c
 
 INCS += $(DRIVERS)/adc-dac/ad74413r/ad74413r.h
 SRCS += $(DRIVERS)/adc-dac/ad74413r/ad74413r.c

--- a/projects/ad74416h/src.mk
+++ b/projects/ad74416h/src.mk
@@ -26,7 +26,8 @@ INCS += $(INCLUDE)/no_os_delay.h     \
 		$(INCLUDE)/no_os_units.h \
 		$(INCLUDE)/no_os_init.h \
 		$(INCLUDE)/no_os_crc8.h \
-		$(INCLUDE)/no_os_alloc.h
+		$(INCLUDE)/no_os_alloc.h \
+		$(INCLUDE)/no_os_mutex.h
 
 SRCS += $(DRIVERS)/api/no_os_gpio.c \
 		$(DRIVERS)/api/no_os_i2c.c  \
@@ -38,7 +39,8 @@ SRCS += $(DRIVERS)/api/no_os_gpio.c \
 		$(NO-OS)/util/no_os_list.c \
 		$(NO-OS)/util/no_os_util.c \
 		$(NO-OS)/util/no_os_crc8.c \
-		$(NO-OS)/util/no_os_alloc.c
+		$(NO-OS)/util/no_os_alloc.c \
+		$(NO-OS)/util/no_os_mutex.c
 
 INCS += $(DRIVERS)/adc-dac/ad74416h/ad74416h.h
 SRCS += $(DRIVERS)/adc-dac/ad74416h/ad74416h.c

--- a/projects/ad7616-sdz/src.mk
+++ b/projects/ad7616-sdz/src.mk
@@ -16,7 +16,8 @@ SRCS += $(DRIVERS)/adc/ad7616/ad7616.c \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine.c \
 	$(NO-OS)/util/no_os_util.c \
-	$(NO-OS)/util/no_os_alloc.c
+	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
@@ -35,4 +36,5 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_delay.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(INCLUDE)/no_os_util.h \
-	$(INCLUDE)/no_os_alloc.h
+	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h

--- a/projects/ad7746-ebz/src.mk
+++ b/projects/ad7746-ebz/src.mk
@@ -7,6 +7,7 @@ SRCS += $(NO-OS)/util/no_os_util.c \
 	$(NO-OS)/util/no_os_lf256fifo.c \
 	$(NO-OS)/util/no_os_list.c \
 	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c \
 	$(PLATFORM_DRIVERS)/aducm3029_uart_stdio.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_rtc.c \
 	$(PLATFORM_DRIVERS)/platform_init.c \
@@ -31,6 +32,7 @@ INCS +=	$(INCLUDE)/no_os_uart.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(INCLUDE)/no_os_list.h \
 	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h \
 	$(PLATFORM_DRIVERS)/aducm3029_irq.h \
 	$(PLATFORM_DRIVERS)/aducm3029_i2c.h \
 	$(PLATFORM_DRIVERS)/aducm3029_timer.h \

--- a/projects/ad7768-1fmcz/src.mk
+++ b/projects/ad7768-1fmcz/src.mk
@@ -18,7 +18,8 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine.c \
 	$(NO-OS)/util/no_os_util.c \
-	$(NO-OS)/util/no_os_alloc.c
+	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
@@ -40,4 +41,5 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_irq.h \
 	$(INCLUDE)/no_os_uart.h \
 	$(INCLUDE)/no_os_util.h \
-	$(INCLUDE)/no_os_alloc.h
+	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h

--- a/projects/ad7768-evb/src.mk
+++ b/projects/ad7768-evb/src.mk
@@ -14,7 +14,8 @@ SRCS += $(PROJECT)/src/ad7768_evb.c
 SRCS += $(NO-OS)/util/no_os_fifo.c
 SRCS += $(NO-OS)/util/no_os_util.c
 SRCS += $(NO-OS)/util/no_os_list.c
-SRCS += $(NO-OS)/util/no_os_alloc.c
+SRCS += $(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c
 
 # Add to INCS inlcude files to be build in the project
 INCS += $(INCLUDE)/no_os_error.h
@@ -31,7 +32,8 @@ INCS +=	$(INCLUDE)/no_os_irq.h
 INCS += $(INCLUDE)/no_os_list.h
 INCS += $(INCLUDE)/no_os_fifo.h
 INCS += $(INCLUDE)/no_os_alloc.h
-INCS += $(PROJECT)/src/parameters.h
+INCS += $(PROJECT)/src/parameters.h \
+	$(INCLUDE)/no_os_mutex.h
 
 # Add to SRC_DIRS directories to be used in the build. All .c and .h files from
 # the directory and subdirectories will be added to the build (recursively)

--- a/projects/ad9081/src.mk
+++ b/projects/ad9081/src.mk
@@ -38,6 +38,7 @@ SRCS += $(PROJECT)/src/app.c \
 	$(NO-OS)/util/no_os_clk.c \
 	$(NO-OS)/util/no_os_util.c \
 	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c \
 	$(NO-OS)/jesd204/jesd204-core.c \
 	$(NO-OS)/jesd204/jesd204-fsm.c
 ifeq (y,$(strip $(QUAD_MXFE)))
@@ -99,6 +100,7 @@ INCS +=	$(PROJECT)/src/app_clock.h \
 	$(INCLUDE)/no_os_units.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h \
 	$(INCLUDE)/jesd204.h \
 	$(NO-OS)/jesd204/jesd204-priv.h
 ifeq (y,$(strip $(QUAD_MXFE)))

--- a/projects/ad9083/src.mk
+++ b/projects/ad9083/src.mk
@@ -35,6 +35,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(NO-OS)/util/no_os_clk.c \
 	$(NO-OS)/util/no_os_util.c \
 	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c \
 	$(NO-OS)/jesd204/jesd204-core.c \
 	$(NO-OS)/jesd204/jesd204-fsm.c
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
@@ -68,6 +69,7 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(INCLUDE)/no_os_util.h \
 	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h \
 	$(INCLUDE)/jesd204.h \
 	$(NO-OS)/jesd204/jesd204-priv.h
 ifeq (y,$(strip $(TINYIIOD)))

--- a/projects/ad9172/src.mk
+++ b/projects/ad9172/src.mk
@@ -31,6 +31,7 @@ SRCS += $(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c \
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
 	$(NO-OS)/util/no_os_util.c \
 	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c \
 	$(NO-OS)/jesd204/jesd204-core.c \
 	$(NO-OS)/jesd204/jesd204-fsm.c
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
@@ -72,6 +73,7 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_util.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h \
 	$(INCLUDE)/jesd204.h \
 	$(NO-OS)/jesd204/jesd204-priv.h
 ifeq (y,$(strip $(TINYIIOD)))

--- a/projects/ad9208/src.mk
+++ b/projects/ad9208/src.mk
@@ -43,6 +43,7 @@ SRCS += $(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
 	$(NO-OS)/util/no_os_util.c \
 	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c \
 	$(NO-OS)/jesd204/jesd204-core.c \
 	$(NO-OS)/jesd204/jesd204-fsm.c
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
@@ -65,5 +66,6 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_util.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h \
 	$(INCLUDE)/jesd204.h \
 	$(NO-OS)/jesd204/jesd204-priv.h

--- a/projects/ad9265-fmc-125ebz/src.mk
+++ b/projects/ad9265-fmc-125ebz/src.mk
@@ -19,7 +19,8 @@ SRCS += $(DRIVERS)/adc/ad9265/ad9265.c \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
 	$(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(NO-OS)/util/no_os_util.c \
-	$(NO-OS)/util/no_os_alloc.c
+	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c
 ifeq (y,$(strip $(TINYIIOD)))
 SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \
@@ -44,7 +45,8 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_delay.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(INCLUDE)/no_os_util.h \
-	$(INCLUDE)/no_os_alloc.h
+	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h
 ifeq (y,$(strip $(TINYIIOD)))
 INCS +=	$(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_irq.h \

--- a/projects/ad9361/src.mk
+++ b/projects/ad9361/src.mk
@@ -20,7 +20,8 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/api/no_os_gpio.c \
 	$(NO-OS)/util/no_os_util.c \
-	$(NO-OS)/util/no_os_alloc.c
+	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c
 SRCS +=	$(PLATFORM_DRIVERS)/$(PLATFORM)_axi_io.c
 SRCS +=	$(PLATFORM_DRIVERS)/$(PLATFORM)_spi.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_gpio.c
@@ -75,7 +76,8 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_error.h \
 	$(INCLUDE)/no_os_delay.h \
 	$(INCLUDE)/no_os_util.h \
-	$(INCLUDE)/no_os_alloc.h
+	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h
 ifeq (y,$(strip $(TINYIIOD)))
 
 ifeq (linux,$(strip $(PLATFORM)))

--- a/projects/ad9371/src.mk
+++ b/projects/ad9371/src.mk
@@ -31,6 +31,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c \
 	$(NO-OS)/util/no_os_util.c \
 	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c\
 	$(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/api/no_os_gpio.c \
 	$(NO-OS)/jesd204/jesd204-core.c \
@@ -107,6 +108,7 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_util.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h \
 	$(INCLUDE)/jesd204.h \
 	$(NO-OS)/jesd204/jesd204-priv.h
 ifeq (y,$(strip $(TINYIIOD)))

--- a/projects/ad9434-fmc-500ebz/src.mk
+++ b/projects/ad9434-fmc-500ebz/src.mk
@@ -19,7 +19,8 @@ SRCS += $(DRIVERS)/adc/ad9434/ad9434.c \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
 	$(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(NO-OS)/util/no_os_util.c \
-	$(NO-OS)/util/no_os_alloc.c
+	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c
 ifeq (y,$(strip $(TINYIIOD)))
 SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \
@@ -44,7 +45,8 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_delay.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(INCLUDE)/no_os_util.h \
-	$(INCLUDE)/no_os_alloc.h
+	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h
 ifeq (y,$(strip $(TINYIIOD)))
 INCS +=	$(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_irq.h \

--- a/projects/ad9467/src.mk
+++ b/projects/ad9467/src.mk
@@ -22,7 +22,8 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(DRIVERS)/frequency/ad9517/ad9517.c \
 	$(DRIVERS)/api/no_os_spi.c \
 	$(NO-OS)/util/no_os_util.c \
-	$(NO-OS)/util/no_os_alloc.c
+	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_delay.c
@@ -48,7 +49,8 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_error.h \
 	$(INCLUDE)/no_os_delay.h \
 	$(INCLUDE)/no_os_util.h \
-	$(INCLUDE)/no_os_alloc.h
+	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h
 ifeq (y,$(strip $(TINYIIOD)))
 INCS +=	$(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_irq.h \

--- a/projects/ad9656_fmc/src.mk
+++ b/projects/ad9656_fmc/src.mk
@@ -28,6 +28,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
         $(DRIVERS)/api/no_os_spi.c \
         $(NO-OS)/util/no_os_util.c \
         $(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c \
 	$(NO-OS)/jesd204/jesd204-core.c \
 	$(NO-OS)/jesd204/jesd204-fsm.c
 ifeq (y,$(strip $(TINYIIOD)))
@@ -63,6 +64,7 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
         $(INCLUDE)/no_os_units.h \
         $(INCLUDE)/no_os_print_log.h \
         $(INCLUDE)/no_os_alloc.h \
+        $(INCLUDE)/no_os_mutex.h \
 	$(INCLUDE)/jesd204.h \
 	$(NO-OS)/jesd204/jesd204-priv.h
 ifeq (y,$(strip $(TINYIIOD)))

--- a/projects/ad9739a-fmc-ebz/src.mk
+++ b/projects/ad9739a-fmc-ebz/src.mk
@@ -20,7 +20,8 @@ SRCS += $(DRIVERS)/dac/ad9739a/ad9739a.c \
 	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
 	$(NO-OS)/util/no_os_util.c \
-	$(NO-OS)/util/no_os_alloc.c
+	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c
 ifeq (y,$(strip $(TINYIIOD)))
 SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(DRIVERS)/axi_core/iio_axi_dac/iio_axi_dac.c \
@@ -47,7 +48,8 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_delay.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(INCLUDE)/no_os_util.h \
-	$(INCLUDE)/no_os_alloc.h
+	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h
 ifeq (y,$(strip $(TINYIIOD)))
 INCS +=	$(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_irq.h \

--- a/projects/ada4250_ardz/src.mk
+++ b/projects/ada4250_ardz/src.mk
@@ -9,6 +9,7 @@ SRC_DIRS += $(INCLUDE)
 SRCS += $(NO-OS)/util/no_os_util.c \
 	$(NO-OS)/util/no_os_list.c \
 	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c \
 	$(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/api/no_os_irq.c \
 	$(DRIVERS)/api/no_os_gpio.c \
@@ -28,6 +29,7 @@ INCS += $(INCLUDE)/no_os_spi.h \
 	$(INCLUDE)/no_os_uart.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h \
 	$(DRIVERS)/platform/$(PLATFORM)/$(PLATFORM)_spi.h \
 	$(DRIVERS)/platform/$(PLATFORM)/$(PLATFORM)_irq.h \
 	$(DRIVERS)/platform/$(PLATFORM)/aducm3029_gpio.h \

--- a/projects/adaq7980_sdz/src.mk
+++ b/projects/adaq7980_sdz/src.mk
@@ -20,7 +20,8 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/axi_core/axi_pwmgen/axi_pwm.c \
 	$(DRIVERS)/axi_core/spi_engine/spi_engine.c \
 	$(NO-OS)/util/no_os_util.c \
-	$(NO-OS)/util/no_os_alloc.c
+	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
@@ -46,4 +47,5 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_uart.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
 	$(INCLUDE)/no_os_util.h \
-	$(INCLUDE)/no_os_alloc.h
+	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h

--- a/projects/adaq8092_fmc/src.mk
+++ b/projects/adaq8092_fmc/src.mk
@@ -20,7 +20,8 @@ SRCS += $(DRIVERS)/adc/adaq8092/adaq8092.c \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
 	$(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(NO-OS)/util/no_os_util.c \
-	$(NO-OS)/util/no_os_alloc.c
+	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c
 ifeq (y,$(strip $(TINYIIOD)))
 SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c \
@@ -49,7 +50,8 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_delay.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(INCLUDE)/no_os_util.h \
-	$(INCLUDE)/no_os_alloc.h
+	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h
 ifeq (y,$(strip $(TINYIIOD)))
 INCS +=	$(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_irq.h \

--- a/projects/adf4377_sdz/src.mk
+++ b/projects/adf4377_sdz/src.mk
@@ -18,7 +18,8 @@ SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/xilinx_delay.c \
 	$(NO-OS)/util/no_os_util.c \
-	$(NO-OS)/util/no_os_alloc.c
+	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c
 ifeq (y,$(strip $(TINYIIOD)))
 LIBRARIES += iio
 SRCS += $(NO-OS)/util/no_os_fifo.c \
@@ -45,7 +46,8 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_delay.h \
 	$(INCLUDE)/no_os_util.h \
 	$(INCLUDE)/no_os_print_log.h \
-	$(INCLUDE)/no_os_alloc.h
+	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h
 ifeq (y,$(strip $(TINYIIOD)))
 INCS += $(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_irq.h \

--- a/projects/adf5902_sdz/src.mk
+++ b/projects/adf5902_sdz/src.mk
@@ -13,7 +13,8 @@ SRCS += $(PROJECT)/src/adf5902_sdz.c
 SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/api/no_os_gpio.c \
 	$(DRIVERS)/frequency/adf5902/adf5902.c \
-	$(NO-OS)/util/no_os_alloc.c
+	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
@@ -44,7 +45,8 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_delay.h \
 	$(INCLUDE)/no_os_util.h \
 	$(INCLUDE)/no_os_print_log.h \
-	$(INCLUDE)/no_os_alloc.h
+	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h
 ifeq (y,$(strip $(TINYIIOD)))
 INCS += $(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_irq.h \

--- a/projects/adin1110/src.mk
+++ b/projects/adin1110/src.mk
@@ -23,7 +23,8 @@ INCS += $(INCLUDE)/no_os_delay.h		\
 		$(INCLUDE)/no_os_uart.h		\
 		$(INCLUDE)/no_os_lf256fifo.h	\
 		$(INCLUDE)/no_os_util.h		\
-		$(INCLUDE)/no_os_units.h 
+		$(INCLUDE)/no_os_units.h	\
+		$(INCLUDE)/no_os_mutex.h 
 
 SRCS += $(DRIVERS)/api/no_os_gpio.c		\
 		$(NO-OS)/util/no_os_lf256fifo.c	\
@@ -33,7 +34,8 @@ SRCS += $(DRIVERS)/api/no_os_gpio.c		\
 		$(NO-OS)/util/no_os_list.c	\
 		$(NO-OS)/util/no_os_alloc.c	\
 		$(NO-OS)/util/no_os_crc8.c	\
-		$(NO-OS)/util/no_os_util.c
+		$(NO-OS)/util/no_os_util.c	\
+		$(NO-OS)/util/no_os_mutex.c
 
 INCS += $(DRIVERS)/net/adin1110/adin1110.h
 SRCS += $(DRIVERS)/net/adin1110/adin1110.c

--- a/projects/adrv9001/src.mk
+++ b/projects/adrv9001/src.mk
@@ -35,6 +35,7 @@ SRCS += $(PLATFORM_DRIVERS)/xilinx_gpio.c \
 	$(PLATFORM_DRIVERS)/xilinx_delay.c \
 	$(NO-OS)/util/no_os_util.c \
 	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c \
 	$(NO-OS)/util/no_os_clk.c \
 	$(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c \
@@ -49,6 +50,7 @@ INCS +=	$(INCLUDE)/no_os_spi.h \
 	$(INCLUDE)/no_os_util.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h \
 	$(INCLUDE)/no_os_clk.h \
 	$(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \
 	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.h \

--- a/projects/adrv9009/src.mk
+++ b/projects/adrv9009/src.mk
@@ -66,7 +66,8 @@ SRCS += $(NO-OS)/util/no_os_fifo.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c
 endif
 SRCS +=	$(NO-OS)/util/no_os_util.c \
-	$(NO-OS)/util/no_os_alloc.c
+	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c
 ifeq (xilinx,$(strip $(PLATFORM)))
 SRCS += $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
@@ -147,6 +148,7 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_delay.h \
 	$(INCLUDE)/no_os_util.h \
 	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h \
 	$(INCLUDE)/no_os_units.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(INCLUDE)/jesd204.h \

--- a/projects/adt7420-pmdz/src.mk
+++ b/projects/adt7420-pmdz/src.mk
@@ -23,7 +23,8 @@ INCS += $(INCLUDE)/no_os_delay.h     \
 		$(INCLUDE)/no_os_uart.h      \
 		$(INCLUDE)/no_os_lf256fifo.h \
 		$(INCLUDE)/no_os_util.h \
-		$(INCLUDE)/no_os_alloc.h
+		$(INCLUDE)/no_os_alloc.h \
+		$(INCLUDE)/no_os_mutex.h
 
 SRCS += $(DRIVERS)/api/no_os_gpio.c \
 		$(DRIVERS)/api/no_os_i2c.c  \
@@ -33,7 +34,8 @@ SRCS += $(DRIVERS)/api/no_os_gpio.c \
 		$(DRIVERS)/api/no_os_uart.c \
 		$(NO-OS)/util/no_os_list.c \
 		$(NO-OS)/util/no_os_util.c \
-		$(NO-OS)/util/no_os_alloc.c
+		$(NO-OS)/util/no_os_alloc.c \
+		$(NO-OS)/util/no_os_mutex.c
 
 INCS += $(DRIVERS)/temperature/adt7420/adt7420.h
 SRCS += $(DRIVERS)/temperature/adt7420/adt7420.c

--- a/projects/adt75/src.mk
+++ b/projects/adt75/src.mk
@@ -23,7 +23,8 @@ INCS += $(INCLUDE)/no_os_delay.h     		\
 		$(INCLUDE)/no_os_lf256fifo.h 	\
 		$(INCLUDE)/no_os_util.h 	\
 		$(INCLUDE)/no_os_units.h        \
-		$(INCLUDE)/no_os_alloc.h
+		$(INCLUDE)/no_os_alloc.h        \
+                $(INCLUDE)/no_os_mutex.h
 
 SRCS += $(NO-OS)/util/no_os_lf256fifo.c 	\
 		$(DRIVERS)/api/no_os_i2c.c  	\
@@ -32,7 +33,8 @@ SRCS += $(NO-OS)/util/no_os_lf256fifo.c 	\
 		$(DRIVERS)/api/no_os_gpio.c  	\
 		$(NO-OS)/util/no_os_util.c	\
 		$(NO-OS)/util/no_os_list.c      \
-		$(NO-OS)/util/no_os_alloc.c
+		$(NO-OS)/util/no_os_alloc.c 	\
+		$(NO-OS)/util/no_os_mutex.c
 
 SRCS += $(DRIVERS)/temperature/adt75/adt75.c
 INCS += $(DRIVERS)/temperature/adt75/adt75.h

--- a/projects/adv7511/src.mk
+++ b/projects/adv7511/src.mk
@@ -25,7 +25,8 @@ SRCS += $(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
 	$(DRIVERS)/api/no_os_timer.c \
 	$(NO-OS)/util/no_os_util.c \
 	$(NO-OS)/util/no_os_list.c \
-	$(NO-OS)/util/no_os_alloc.c
+	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
 	$(PLATFORM_DRIVERS)/xilinx_spi.c \
 	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
@@ -64,7 +65,8 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_i2c.h \
 	$(INCLUDE)/no_os_irq.h \
 	$(INCLUDE)/no_os_timer.h \
-	$(INCLUDE)/no_os_alloc.h
+	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h
 INCS +=	$(PROJECT)/TX/tx_lib.h \
 	$(PROJECT)/TX/HAL/COMMON/tx_cfg.h \
 	$(PROJECT)/TX/HAL/COMMON/tx_hal.h \

--- a/projects/adxrs290-pmdz/src.mk
+++ b/projects/adxrs290-pmdz/src.mk
@@ -27,7 +27,8 @@ INCS += $(INCLUDE)/no_os_delay.h        \
         $(INCLUDE)/no_os_lf256fifo.h    \
         $(INCLUDE)/no_os_util.h         \
         $(INCLUDE)/no_os_units.h        \
-        $(INCLUDE)/no_os_alloc.h
+        $(INCLUDE)/no_os_alloc.h        \
+        $(INCLUDE)/no_os_mutex.h
 
 SRCS += $(DRIVERS)/api/no_os_gpio.c     \
         $(NO-OS)/util/no_os_lf256fifo.c \
@@ -37,4 +38,5 @@ SRCS += $(DRIVERS)/api/no_os_gpio.c     \
         $(DRIVERS)/api/no_os_uart.c     \
         $(NO-OS)/util/no_os_list.c      \
         $(NO-OS)/util/no_os_util.c      \
-        $(NO-OS)/util/no_os_alloc.c
+        $(NO-OS)/util/no_os_alloc.c     \
+	$(NO-OS)/util/no_os_mutex.c

--- a/projects/cn0552/src.mk
+++ b/projects/cn0552/src.mk
@@ -1,6 +1,7 @@
 SRCS += $(NO-OS)/util/no_os_util.c \
 	$(NO-OS)/util/no_os_list.c \
 	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_delay.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_i2c.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c \
@@ -30,6 +31,7 @@ INCS +=	$(INCLUDE)/no_os_uart.h \
 	$(INCLUDE)/no_os_i2c.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.h \
 	$(PLATFORM_DRIVERS)/aducm3029_timer.h \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h \

--- a/projects/cn0561/src.mk
+++ b/projects/cn0561/src.mk
@@ -21,7 +21,8 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
 	$(NO-OS)/util/no_os_util.c \
 	$(NO-OS)/util/no_os_lf256fifo.c \
-	$(NO-OS)/util/no_os_alloc.c
+	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c
 SRCS +=	$(PLATFORM_DRIVERS)/$(PLATFORM)_axi_io.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_gpio.c \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_spi.c \
@@ -55,7 +56,8 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_pwm.h \
 	$(INCLUDE)/no_os_util.h \
 	$(INCLUDE)/no_os_lf256fifo.h \
-	$(INCLUDE)/no_os_alloc.h
+	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h
 ifeq (y,$(strip $(TINYIIOD)))
 INCS += $(INCLUDE)/no_os_fifo.h \
 	$(INCLUDE)/no_os_list.h

--- a/projects/cn0565/src.mk
+++ b/projects/cn0565/src.mk
@@ -13,7 +13,8 @@ INCS +=	$(INCLUDE)/no_os_uart.h \
 	$(INCLUDE)/no_os_irq.h \
 	$(INCLUDE)/no_os_rtc.h \
 	$(INCLUDE)/no_os_gpio.h \
-	$(INCLUDE)/no_os_alloc.h
+	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h
 
 SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/api/no_os_gpio.c \
@@ -25,6 +26,7 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(NO-OS)/util/no_os_list.c \
 	$(NO-OS)/util/no_os_util.c \
 	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c \
 	$(DRIVERS)/afe/ad5940/bia_measurement.c \
 	$(DRIVERS)/afe/ad5940/ad5940.c
 

--- a/projects/dc2903a/src.mk
+++ b/projects/dc2903a/src.mk
@@ -25,7 +25,8 @@ INCS += $(INCLUDE)/no_os_delay.h        \
         $(INCLUDE)/no_os_lf256fifo.h    \
         $(INCLUDE)/no_os_util.h         \
         $(INCLUDE)/no_os_units.h        \
-        $(INCLUDE)/no_os_alloc.h        
+        $(INCLUDE)/no_os_alloc.h        \
+        $(INCLUDE)/no_os_mutex.h  
 
 SRCS += $(NO-OS)/util/no_os_lf256fifo.c \
         $(DRIVERS)/api/no_os_irq.c      \
@@ -34,4 +35,5 @@ SRCS += $(NO-OS)/util/no_os_lf256fifo.c \
         $(DRIVERS)/api/no_os_uart.c     \
         $(NO-OS)/util/no_os_list.c      \
         $(NO-OS)/util/no_os_util.c      \
-        $(NO-OS)/util/no_os_alloc.c
+        $(NO-OS)/util/no_os_alloc.c     \
+	$(NO-OS)/util/no_os_mutex.c

--- a/projects/demo_esp/src.mk
+++ b/projects/demo_esp/src.mk
@@ -25,7 +25,9 @@ INCS += $(INCLUDE)/no_os_delay.h		\
 	$(INCLUDE)/no_os_util.h			\
 	$(INCLUDE)/no_os_list.h			\
 	$(INCLUDE)/no_os_circular_buffer.h	\
-	$(INCLUDE)/no_os_alloc.h
+	$(INCLUDE)/no_os_alloc.h		\
+	$(INCLUDE)/no_os_mutex.h
+
 
 SRCS += $(NO-OS)/util/no_os_lf256fifo.c		\
 	$(DRIVERS)/api/no_os_gpio.c		\
@@ -36,7 +38,8 @@ SRCS += $(NO-OS)/util/no_os_lf256fifo.c		\
 	$(NO-OS)/util/no_os_list.c		\
 	$(NO-OS)/util/no_os_circular_buffer.c	\
 	$(NO-OS)/util/no_os_util.c		\
-	$(NO-OS)/util/no_os_alloc.c
+	$(NO-OS)/util/no_os_alloc.c		\
+	$(NO-OS)/util/no_os_mutex.c
 
 SRC_DIRS += $(NO-OS)/network
 

--- a/projects/display_demo/src.mk
+++ b/projects/display_demo/src.mk
@@ -7,7 +7,8 @@ SRCS += $(PROJECT)/src/app/main.c \
         $(DRIVERS)/platform/xilinx/xilinx_spi.c \
         $(DRIVERS)/platform/xilinx/xilinx_gpio.c \
 	$(NO-OS)/util/no_os_font_8x8.c \
-        $(NO-OS)/util/no_os_alloc.c
+        $(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c
 
 INCS += $(INCLUDE)/no_os_gpio.h \
 	$(INCLUDE)/no_os_spi.h \
@@ -17,5 +18,6 @@ INCS += $(INCLUDE)/no_os_gpio.h \
         $(INCLUDE)/no_os_error.h \
         $(INCLUDE)/no_os_delay.h \
         $(INCLUDE)/no_os_alloc.h \
+        $(INCLUDE)/no_os_mutex.h \
         $(DRIVERS)/platform/xilinx/$(PLATFORM)_gpio.h \
 	$(DRIVERS)/platform/xilinx/$(PLATFORM)_spi.h

--- a/projects/eval-ade9430/src.mk
+++ b/projects/eval-ade9430/src.mk
@@ -16,6 +16,7 @@ INCS += $(INCLUDE)/no_os_delay.h     \
 	$(INCLUDE)/no_os_util.h \
 	$(INCLUDE)/no_os_units.h \
 	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h \
 	$(INCLUDE)/no_os_circular_buffer.h \
 	$(INCLUDE)/no_os_trng.h \
 	$(INCLUDE)/no_os_rtc.h \
@@ -49,6 +50,7 @@ SRCS += $(DRIVERS)/api/no_os_gpio.c \
 	$(NO-OS)/util/no_os_util.c	\
 	$(NO-OS)/util/no_os_circular_buffer.c \
 	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c \
 	$(DRIVERS)/display/nhd_c12832a1z/nhd_c12832a1z.c
 
 SRCS += $(PLATFORM_DRIVERS)/$(PLATFORM)_delay.c     \

--- a/projects/eval-adis/src.mk
+++ b/projects/eval-adis/src.mk
@@ -24,7 +24,8 @@ INCS += $(INCLUDE)/no_os_delay.h     \
 		$(INCLUDE)/no_os_lf256fifo.h \
 		$(INCLUDE)/no_os_util.h \
 		$(INCLUDE)/no_os_units.h \
-		$(INCLUDE)/no_os_alloc.h
+		$(INCLUDE)/no_os_alloc.h \
+        	$(INCLUDE)/no_os_mutex.h
 
 SRCS += $(DRIVERS)/api/no_os_gpio.c \
 		$(DRIVERS)/api/no_os_i2c.c  \
@@ -35,7 +36,8 @@ SRCS += $(DRIVERS)/api/no_os_gpio.c \
 		$(NO-OS)/util/no_os_list.c \
 		$(DRIVERS)/api/no_os_uart.c  \
 		$(NO-OS)/util/no_os_util.c \
-		$(NO-OS)/util/no_os_alloc.c
+		$(NO-OS)/util/no_os_alloc.c \
+		$(NO-OS)/util/no_os_mutex.c
 
 INCS += $(DRIVERS)/imu/adis.h \
 	$(DRIVERS)/imu/adis16505.h

--- a/projects/eval-adis1657x/src.mk
+++ b/projects/eval-adis1657x/src.mk
@@ -24,7 +24,8 @@ INCS += $(INCLUDE)/no_os_delay.h     \
 		$(INCLUDE)/no_os_lf256fifo.h \
 		$(INCLUDE)/no_os_util.h \
 		$(INCLUDE)/no_os_units.h \
-		$(INCLUDE)/no_os_alloc.h
+		$(INCLUDE)/no_os_alloc.h \
+		$(INCLUDE)/no_os_mutex.h
 
 SRCS += $(DRIVERS)/api/no_os_gpio.c \
 		$(DRIVERS)/api/no_os_i2c.c  \
@@ -35,7 +36,8 @@ SRCS += $(DRIVERS)/api/no_os_gpio.c \
 		$(NO-OS)/util/no_os_list.c \
 		$(DRIVERS)/api/no_os_uart.c  \
 		$(NO-OS)/util/no_os_util.c \
-		$(NO-OS)/util/no_os_alloc.c
+		$(NO-OS)/util/no_os_alloc.c \
+		$(NO-OS)/util/no_os_mutex.c
 
 INCS += $(DRIVERS)/imu/adis.h \
 	$(DRIVERS)/imu/adis1657x.h

--- a/projects/eval-adxl313z/src.mk
+++ b/projects/eval-adxl313z/src.mk
@@ -24,7 +24,8 @@ INCS += $(INCLUDE)/no_os_delay.h     \
 		$(INCLUDE)/no_os_util.h \
 		$(INCLUDE)/no_os_units.h \
 		$(INCLUDE)/no_os_init.h \
-		$(INCLUDE)/no_os_alloc.h
+		$(INCLUDE)/no_os_alloc.h \
+        	$(INCLUDE)/no_os_mutex.h
 
 SRCS += $(DRIVERS)/api/no_os_gpio.c \
 		$(DRIVERS)/api/no_os_i2c.c  \
@@ -34,7 +35,8 @@ SRCS += $(DRIVERS)/api/no_os_gpio.c \
 		$(NO-OS)/util/no_os_list.c \
 		$(DRIVERS)/api/no_os_uart.c \
 		$(NO-OS)/util/no_os_util.c \
-		$(NO-OS)/util/no_os_alloc.c
+		$(NO-OS)/util/no_os_alloc.c \
+        	$(NO-OS)/util/no_os_mutex.c
 
 INCS += $(DRIVERS)/accel/adxl313/adxl313.h
 SRCS += $(DRIVERS)/accel/adxl313/adxl313.c

--- a/projects/eval-adxl355-pmdz/src.mk
+++ b/projects/eval-adxl355-pmdz/src.mk
@@ -25,7 +25,8 @@ INCS += $(INCLUDE)/no_os_delay.h     \
 		$(INCLUDE)/no_os_util.h \
 		$(INCLUDE)/no_os_units.h \
 		$(INCLUDE)/no_os_init.h \
-		$(INCLUDE)/no_os_alloc.h
+		$(INCLUDE)/no_os_alloc.h \
+        	$(INCLUDE)/no_os_mutex.h
 
 SRCS += $(DRIVERS)/api/no_os_gpio.c \
 		$(DRIVERS)/api/no_os_i2c.c  \
@@ -36,7 +37,8 @@ SRCS += $(DRIVERS)/api/no_os_gpio.c \
 		$(DRIVERS)/api/no_os_uart.c \
 		$(NO-OS)/util/no_os_list.c \
 		$(NO-OS)/util/no_os_util.c \
-		$(NO-OS)/util/no_os_alloc.c
+		$(NO-OS)/util/no_os_alloc.c \
+        	$(NO-OS)/util/no_os_mutex.c
 
 INCS += $(DRIVERS)/accel/adxl355/adxl355.h
 SRCS += $(DRIVERS)/accel/adxl355/adxl355.c

--- a/projects/eval-adxl367z/src.mk
+++ b/projects/eval-adxl367z/src.mk
@@ -27,7 +27,8 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/accel/adxl367/adxl367.c \
 	$(NO-OS)/util/no_os_util.c \
 	$(NO-OS)/util/no_os_list.c \
-	$(NO-OS)/util/no_os_alloc.c
+	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c
 
 INCS += $(DRIVERS)/accel/adxl367/adxl367.h
 
@@ -38,4 +39,5 @@ INCS += $(INCLUDE)/no_os_spi.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(INCLUDE)/no_os_list.h \
 	$(INCLUDE)/no_os_error.h \
-	$(INCLUDE)/no_os_alloc.h
+	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h

--- a/projects/eval-ltc4306/src.mk
+++ b/projects/eval-ltc4306/src.mk
@@ -25,7 +25,8 @@ INCS += $(INCLUDE)/no_os_delay.h        \
         $(INCLUDE)/no_os_lf256fifo.h    \
         $(INCLUDE)/no_os_util.h         \
         $(INCLUDE)/no_os_units.h        \
-        $(INCLUDE)/no_os_alloc.h        
+        $(INCLUDE)/no_os_alloc.h        \
+        $(INCLUDE)/no_os_mutex.h  
 
 SRCS += $(NO-OS)/util/no_os_lf256fifo.c \
         $(DRIVERS)/api/no_os_irq.c      \
@@ -34,7 +35,8 @@ SRCS += $(NO-OS)/util/no_os_lf256fifo.c \
         $(DRIVERS)/api/no_os_uart.c     \
         $(NO-OS)/util/no_os_list.c      \
         $(NO-OS)/util/no_os_util.c      \
-        $(NO-OS)/util/no_os_alloc.c
+        $(NO-OS)/util/no_os_alloc.c     \
+        $(NO-OS)/util/no_os_mutex.c
 
 INCS += $(DRIVERS)/io-expander/ltc4306/ltc4306.h
 SRCS += $(DRIVERS)/io-expander/ltc4306/ltc4306.c

--- a/projects/fmcadc2/src.mk
+++ b/projects/fmcadc2/src.mk
@@ -23,6 +23,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(DRIVERS)/api/no_os_gpio.c \
 	$(NO-OS)/util/no_os_util.c \
 	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c \
 	$(NO-OS)/jesd204/jesd204-core.c \
 	$(NO-OS)/jesd204/jesd204-fsm.c
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
@@ -59,6 +60,7 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_delay.h \
 	$(INCLUDE)/no_os_util.h \
 	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(INCLUDE)/jesd204.h \
 	$(NO-OS)/jesd204/jesd204-priv.h

--- a/projects/fmcadc5/src.mk
+++ b/projects/fmcadc5/src.mk
@@ -24,6 +24,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(DRIVERS)/api/no_os_gpio.c \
 	$(NO-OS)/util/no_os_util.c \
 	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c \
 	$(NO-OS)/jesd204/jesd204-core.c \
 	$(NO-OS)/jesd204/jesd204-fsm.c
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
@@ -60,6 +61,7 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_util.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h \
 	$(INCLUDE)/jesd204.h \
 	$(NO-OS)/jesd204/jesd204-priv.h
 ifeq (y,$(strip $(TINYIIOD)))

--- a/projects/fmcdaq2/src.mk
+++ b/projects/fmcdaq2/src.mk
@@ -27,6 +27,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(DRIVERS)/api/no_os_gpio.c \
 	$(NO-OS)/util/no_os_util.c \
 	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c \
 	$(NO-OS)/jesd204/jesd204-core.c \
 	$(NO-OS)/jesd204/jesd204-fsm.c
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
@@ -75,6 +76,7 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_util.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h \
 	$(INCLUDE)/jesd204.h \
 	$(NO-OS)/jesd204/jesd204-priv.h
 ifeq (y,$(strip $(TINYIIOD)))

--- a/projects/fmcdaq3/src.mk
+++ b/projects/fmcdaq3/src.mk
@@ -27,6 +27,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(DRIVERS)/api/no_os_gpio.c \
 	$(NO-OS)/util/no_os_util.c \
 	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c \
 	$(NO-OS)/jesd204/jesd204-core.c \
 	$(NO-OS)/jesd204/jesd204-fsm.c
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
@@ -74,6 +75,7 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_delay.h \
 	$(INCLUDE)/no_os_util.h \
 	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(INCLUDE)/jesd204.h \
 	$(NO-OS)/jesd204/jesd204-priv.h

--- a/projects/fmcjesdadc1/src.mk
+++ b/projects/fmcjesdadc1/src.mk
@@ -25,6 +25,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(DRIVERS)/frequency/ad9517/ad9517.c \
 	$(NO-OS)/util/no_os_util.c \
 	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c \
 	$(NO-OS)/jesd204/jesd204-core.c \
 	$(NO-OS)/jesd204/jesd204-fsm.c
 SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
@@ -64,6 +65,7 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_util.h \
 	$(INCLUDE)/no_os_print_log.h \
 	$(INCLUDE)/no_os_alloc.h \
+	$(INCLUDE)/no_os_mutex.h \
 	$(INCLUDE)/jesd204.h \
 	$(NO-OS)/jesd204/jesd204-priv.h
 ifeq (y,$(strip $(TINYIIOD)))

--- a/projects/iio_demo/src.mk
+++ b/projects/iio_demo/src.mk
@@ -16,7 +16,8 @@ SRCS += $(DRIVERS)/api/no_os_uart.c     \
         $(NO-OS)/util/no_os_fifo.c      \
         $(NO-OS)/util/no_os_list.c      \
         $(NO-OS)/util/no_os_util.c      \
-        $(NO-OS)/util/no_os_alloc.c
+        $(NO-OS)/util/no_os_alloc.c     \
+        $(NO-OS)/util/no_os_mutex.c
 
 INCS += $(INCLUDE)/no_os_delay.h     \
         $(INCLUDE)/no_os_error.h     \
@@ -27,7 +28,8 @@ INCS += $(INCLUDE)/no_os_delay.h     \
         $(INCLUDE)/no_os_timer.h     \
         $(INCLUDE)/no_os_uart.h      \
         $(INCLUDE)/no_os_util.h      \
-        $(INCLUDE)/no_os_alloc.h
+        $(INCLUDE)/no_os_alloc.h     \
+        $(INCLUDE)/no_os_mutex.h
 
 INCS += $(DRIVERS)/adc/adc_demo/adc_demo.h \
         $(DRIVERS)/dac/dac_demo/dac_demo.h

--- a/projects/max11205pmb1/src.mk
+++ b/projects/max11205pmb1/src.mk
@@ -27,7 +27,8 @@ INCS += $(INCLUDE)/no_os_delay.h        \
         $(INCLUDE)/no_os_lf256fifo.h    \
         $(INCLUDE)/no_os_util.h         \
         $(INCLUDE)/no_os_units.h        \
-        $(INCLUDE)/no_os_alloc.h
+        $(INCLUDE)/no_os_alloc.h        \
+        $(INCLUDE)/no_os_mutex.h
 
 SRCS += $(DRIVERS)/api/no_os_gpio.c     \
         $(NO-OS)/util/no_os_lf256fifo.c \
@@ -37,4 +38,5 @@ SRCS += $(DRIVERS)/api/no_os_gpio.c     \
         $(DRIVERS)/api/no_os_uart.c     \
         $(NO-OS)/util/no_os_list.c      \
         $(NO-OS)/util/no_os_util.c      \
-        $(NO-OS)/util/no_os_alloc.c
+        $(NO-OS)/util/no_os_alloc.c     \
+        $(NO-OS)/util/no_os_mutex.c

--- a/projects/max31855/src.mk
+++ b/projects/max31855/src.mk
@@ -22,7 +22,8 @@ INCS += $(INCLUDE)/no_os_delay.h     \
 		$(INCLUDE)/no_os_uart.h      \
 		$(INCLUDE)/no_os_lf256fifo.h \
 		$(INCLUDE)/no_os_util.h 	\
-		$(INCLUDE)/no_os_units.h 
+		$(INCLUDE)/no_os_units.h	\
+                $(INCLUDE)/no_os_mutex.h 
 
 SRCS += $(DRIVERS)/api/no_os_gpio.c \
 		$(NO-OS)/util/no_os_lf256fifo.c \
@@ -31,7 +32,8 @@ SRCS += $(DRIVERS)/api/no_os_gpio.c \
 		$(DRIVERS)/api/no_os_uart.c \
 		$(NO-OS)/util/no_os_list.c \
 		$(NO-OS)/util/no_os_util.c \
-		$(NO-OS)/util/no_os_alloc.c
+		$(NO-OS)/util/no_os_alloc.c \
+                $(NO-OS)/util/no_os_mutex.c
 
 INCS += $(DRIVERS)/temperature/max31855/max31855.h
 SRCS += $(DRIVERS)/temperature/max31855/max31855.c


### PR DESCRIPTION
Adding SPI and I2C bus descriptors to the api:
* changed STM32 initialization
* added extra bus_desc struct to header files