### PR TITLE
Free the IIO xml desc

### DIFF
--- a/iio/iio.c
+++ b/iio/iio.c
@@ -1977,6 +1977,7 @@ int iio_remove(struct iio_desc *desc)
 	iiod_remove(desc->iiod);
 	no_os_free(desc->devs);
 	no_os_free(desc->trigs);
+	no_os_free(desc->xml_desc);
 	no_os_free(desc);
 
 	return 0;


### PR DESCRIPTION
Currently the xml decriptor is not freed when iio_remove() is called, which causes a memory leak. Free desc->xml_desc to fix the issue.