### PR TITLE
tools:scripts: Fixed echo command printing into text file issue

### DIFF
--- a/tools/scripts/echo_remove.bat
+++ b/tools/scripts/echo_remove.bat
@@ -1,0 +1,16 @@
+:: Search and replace 'echo' string in input text file with single space
+@echo off 
+setlocal enabledelayedexpansion
+setlocal enableextensions
+
+set "search=echo"
+set "replace="
+
+:: Loop through all input text files
+for %%x in (%*) do (
+    echo %%x
+    for /f "delims=" %%i in ('type "%%x" ^& break ^> "%%x" ') do (
+        set "line=%%i"
+        >>"%%x" echo(!line:%search%=%replace%!)
+    )
+)

--- a/tools/scripts/generic.mk
+++ b/tools/scripts/generic.mk
@@ -388,7 +388,10 @@ pre_build:
 	$(MUTE) $(call ADD_BLANK_LINE_TO_FILE, $(PROJECT_OBJECT_FILES_NAMES_FILE)) $(cmd_separator)\
 		$(foreach object_file_name,$(sort $(OBJS)),$(call APPEND_TEXT_TO_FILE,$(object_file_name),$(PROJECT_OBJECT_FILES_NAMES_FILE))\
 		$(cmd_separator)) echo . $(HIDE)
-
+ifeq ($(OS), Windows_NT)
+	$(MUTE) cmd /C $(NO-OS)/tools/scripts/echo_remove.bat $(subst /,\,$(sort $(PROJECT_CFLAGS_NAMES_FILE))) $(subst /,\,$(sort $(PROJECT_CPPFLAGS_NAMES_FILE)))\
+				   $(subst /,\,$(sort $(PROJECT_ASFLAGS_NAMES_FILE))) $(subst /,\,$(sort $(PROJECT_OBJECT_FILES_NAMES_FILE)))
+endif
 
 $(BINARY): $(LIB_TARGETS) $(OBJS) $(ASM_OBJS) $(LSCRIPT) $(BOOTOBJ)
 	@$(call print,[LD] $(notdir $(OBJS)))


### PR DESCRIPTION
pre_build rule used in generic.mk file copies the dependencies such as c/cpp flags, object/include files paths into the text files, which are used later during compilation and linking stage. On windows-os, during the copying of dependencies into text file using echo inbuilt command, the echo command string itself is getting printed into the text files. Compiler is therefore unable to interpret this echo string during compile and link stage. This seems to be the limitation of windows-os as this issue has not been detected on the linux-os yet.
This patch is created as workaround for this issue. A batch file has been added, which searches and replaces any echo string present in the text files during pre-build stage. This is done if make build is running only on the windows-os.