### PR TITLE
drivers:platform:maxim: Fix UART UB

### DIFF
--- a/drivers/platform/maxim/max32650/maxim_uart.c
+++ b/drivers/platform/maxim/max32650/maxim_uart.c
@@ -74,24 +74,24 @@ static uint8_t c;
  */
 static int32_t _max_uart_pins_config(uint32_t device_id, mxc_gpio_vssel_t vssel)
 {
-	mxc_gpio_cfg_t *uart_pins;
+	mxc_gpio_cfg_t uart_pins;
 
 	switch (device_id) {
 	case 0:
-		uart_pins = (mxc_gpio_cfg_t *)&gpio_cfg_uart0;
+		uart_pins = gpio_cfg_uart0;
 		break;
 	case 1:
-		uart_pins = (mxc_gpio_cfg_t *)&gpio_cfg_uart1;
+		uart_pins = gpio_cfg_uart1;
 		break;
 	case 2:
-		uart_pins = (mxc_gpio_cfg_t *)&gpio_cfg_uart2;
+		uart_pins = gpio_cfg_uart2;
 		break;
 	default:
 		return -EINVAL;
 	}
 
-	uart_pins->vssel = vssel;
-	MXC_GPIO_Config(uart_pins);
+	uart_pins.vssel = vssel;
+	MXC_GPIO_Config(&uart_pins);
 
 	return 0;
 }

--- a/drivers/platform/maxim/max32655/maxim_uart.c
+++ b/drivers/platform/maxim/max32655/maxim_uart.c
@@ -84,24 +84,24 @@ static void _discard_callback(mxc_uart_req_t *req, int result)
  */
 static int32_t _max_uart_pins_config(uint32_t device_id, mxc_gpio_vssel_t vssel)
 {
-	mxc_gpio_cfg_t *uart_pins;
+	mxc_gpio_cfg_t uart_pins;
 
 	switch (device_id) {
 	case 0:
-		uart_pins = (mxc_gpio_cfg_t *)&gpio_cfg_uart0;
+		uart_pins = gpio_cfg_uart0;
 		break;
 	case 1:
-		uart_pins = (mxc_gpio_cfg_t *)&gpio_cfg_uart1;
+		uart_pins = gpio_cfg_uart1;
 		break;
 	case 2:
-		uart_pins = (mxc_gpio_cfg_t *)&gpio_cfg_uart2;
+		uart_pins = gpio_cfg_uart2;
 		break;
 	default:
 		return -EINVAL;
 	}
 
-	uart_pins->vssel = vssel;
-	MXC_GPIO_Config(uart_pins);
+	uart_pins.vssel = vssel;
+	MXC_GPIO_Config(&uart_pins);
 
 	return 0;
 }

--- a/drivers/platform/maxim/max32660/maxim_uart.c
+++ b/drivers/platform/maxim/max32660/maxim_uart.c
@@ -74,21 +74,21 @@ static uint8_t c;
  */
 static int32_t _max_uart_pins_config(uint32_t device_id, mxc_gpio_vssel_t vssel)
 {
-	mxc_gpio_cfg_t *uart_pins;
+	mxc_gpio_cfg_t uart_pins;
 
 	switch (device_id) {
 	case 0:
-		uart_pins = (mxc_gpio_cfg_t *)&gpio_cfg_uart0;
+		uart_pins = gpio_cfg_uart0;
 		break;
 	case 1:
-		uart_pins = (mxc_gpio_cfg_t *)&gpio_cfg_uart1a;
+		uart_pins = gpio_cfg_uart1a;
 		break;
 	default:
 		return -EINVAL;
 	}
 
-	uart_pins->vssel = vssel;
-	MXC_GPIO_Config(uart_pins);
+	uart_pins.vssel = vssel;
+	MXC_GPIO_Config(&uart_pins);
 
 	return 0;
 }

--- a/drivers/platform/maxim/max32665/maxim_uart.c
+++ b/drivers/platform/maxim/max32665/maxim_uart.c
@@ -84,24 +84,24 @@ static void _discard_callback(mxc_uart_req_t *req, int result)
  */
 static int32_t _max_uart_pins_config(uint32_t device_id, mxc_gpio_vssel_t vssel)
 {
-	mxc_gpio_cfg_t *uart_pins;
+	mxc_gpio_cfg_t uart_pins;
 
 	switch (device_id) {
 	case 0:
-		uart_pins = (mxc_gpio_cfg_t *)&gpio_cfg_uart0b;
+		uart_pins = gpio_cfg_uart0b;
 		break;
 	case 1:
-		uart_pins = (mxc_gpio_cfg_t *)&gpio_cfg_uart1b;
+		uart_pins = gpio_cfg_uart1b;
 		break;
 	case 2:
-		uart_pins = (mxc_gpio_cfg_t *)&gpio_cfg_uart2b;
+		uart_pins = gpio_cfg_uart2b;
 		break;
 	default:
 		return -EINVAL;
 	}
 
-	uart_pins->vssel = vssel;
-	MXC_GPIO_Config(uart_pins);
+	uart_pins.vssel = vssel;
+	MXC_GPIO_Config(&uart_pins);
 
 	return 0;
 }

--- a/drivers/platform/maxim/max32690/maxim_uart.c
+++ b/drivers/platform/maxim/max32690/maxim_uart.c
@@ -76,27 +76,27 @@ static void _discard_callback(mxc_uart_req_t *req, int result)
  */
 static int32_t _max_uart_pins_config(uint32_t device_id, mxc_gpio_vssel_t vssel)
 {
-	mxc_gpio_cfg_t *uart_pins;
+	mxc_gpio_cfg_t uart_pins;
 
 	switch (device_id) {
 	case 0:
-		uart_pins = (mxc_gpio_cfg_t *)&gpio_cfg_uart0;
+		uart_pins = gpio_cfg_uart0;
 		break;
 	case 1:
-		uart_pins = (mxc_gpio_cfg_t *)&gpio_cfg_uart1;
+		uart_pins = gpio_cfg_uart1;
 		break;
 	case 2:
-		uart_pins = (mxc_gpio_cfg_t *)&gpio_cfg_uart2;
+		uart_pins = gpio_cfg_uart2;
 		break;
 	case 3:
-		uart_pins = (mxc_gpio_cfg_t *)&gpio_cfg_uart3;
+		uart_pins = gpio_cfg_uart3;
 		break;
 	default:
 		return -EINVAL;
 	}
 
-	uart_pins->vssel = vssel;
-	MXC_GPIO_Config(uart_pins);
+	uart_pins.vssel = vssel;
+	MXC_GPIO_Config(&uart_pins);
 
 	return 0;
 }

--- a/drivers/platform/maxim/max78000/maxim_uart.c
+++ b/drivers/platform/maxim/max78000/maxim_uart.c
@@ -87,27 +87,27 @@ static void _discard_callback(mxc_uart_req_t *req, int result)
  */
 static int32_t _max_uart_pins_config(uint32_t device_id, mxc_gpio_vssel_t vssel)
 {
-	mxc_gpio_cfg_t *uart_pins;
+	mxc_gpio_cfg_t uart_pins;
 
 	switch (device_id) {
 	case 0:
-		uart_pins = (mxc_gpio_cfg_t *)&gpio_cfg_uart0;
+		uart_pins = gpio_cfg_uart0;
 		break;
 	case 1:
-		uart_pins = (mxc_gpio_cfg_t *)&gpio_cfg_uart1;
+		uart_pins = gpio_cfg_uart1;
 		break;
 	case 2:
-		uart_pins = (mxc_gpio_cfg_t *)&gpio_cfg_uart2;
+		uart_pins = gpio_cfg_uart2;
 		break;
 	case 3:
-		uart_pins = (mxc_gpio_cfg_t *)&gpio_cfg_uart3;
+		uart_pins = gpio_cfg_uart3;
 		break;
 	default:
 		return -EINVAL;
 	}
 
-	uart_pins->vssel = vssel;
-	MXC_GPIO_Config(uart_pins);
+	uart_pins.vssel = vssel;
+	MXC_GPIO_Config(&uart_pins);
 
 	return 0;
 }


### PR DESCRIPTION
Currently, when setting the voltage level of the UART interface, it is done by changing the vssel field of a struct defined in the SDK (which is used to configure some GPIOs as UART alternate function). However, these structs are defined as const, and as such, modifying it's fields is undefined behavior.

The initialization sequence is still correct, since the voltage level is set after the UART interface is configured.

Fixes: 269807a ("platform: maxim: Remove discarded const warning")