### PR TITLE
adc: ad9081: Update API to Version 1.5.0

### DIFF
--- a/drivers/adc/ad9081/api/adi_ad9081_adc.c
+++ b/drivers/adc/ad9081/api/adi_ad9081_adc.c
@@ -100,7 +100,7 @@ adi_ad9081_adc_analog_input_buffer_set(adi_ad9081_device_t *device,
 		return API_CMS_ERROR_INVALID_PARAM;
 	}
 	err = adi_ad9081_hal_bf_set(
-		device, 0x2112, 0x0,
+		device, 0x2112, 0x100,
 		1); /* CAL_FREEZE_GLOBAL freeze calibration for reconfig of common-mode loop*/
 	AD9081_ERROR_RETURN(err);
 	err = adi_ad9081_adc_core_analog_regs_enable_set(
@@ -122,7 +122,7 @@ adi_ad9081_adc_analog_input_buffer_set(adi_ad9081_device_t *device,
 		device, 0x1733, 0x300,
 		cmin_out_pulldown); /* SPI_CMIN_OUT_PULDWN pulls VCMx pin low when common mode buffer is disabled*/
 	AD9081_ERROR_RETURN(err);
-	err = adi_ad9081_hal_bf_set(device, 0x2112, 0x0,
+	err = adi_ad9081_hal_bf_set(device, 0x2112, 0x100,
 				    0); /* CAL_FREEZE_GLOBAL */
 	AD9081_ERROR_RETURN(err);
 
@@ -429,9 +429,137 @@ int32_t adi_ad9081_adc_smon_en_to_gpio_mapping_set(adi_ad9081_device_t *device,
 	return API_CMS_ERROR_OK;
 }
 
-int32_t adi_ad9081_adc_rxen1_gpio_ctrl_set(adi_ad9081_device_t *device,
-					   uint8_t spi_en, uint8_t pol,
-					   uint8_t rxen)
+int32_t adi_ad9081_adc_adc0_rxen_pwdn_ctrl_set(adi_ad9081_device_t *device,
+					       uint8_t rxen0_0f_ctrl_en,
+					       uint8_t rxengp0_0f_ctrl_en,
+					       uint8_t rxen0_0s_ctrl_en,
+					       uint8_t rxengp0_0s_ctrl_en)
+{
+	int32_t err;
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_LOG_FUNC();
+	AD9081_INVALID_PARAM_RETURN(rxen0_0f_ctrl_en > 1);
+	AD9081_INVALID_PARAM_RETURN(rxengp0_0f_ctrl_en > 1);
+	AD9081_INVALID_PARAM_RETURN(rxen0_0s_ctrl_en > 1);
+	AD9081_INVALID_PARAM_RETURN(rxengp0_0s_ctrl_en > 1);
+
+	err = adi_ad9081_hal_bf_set(device, REG_RXEN_NOVALP_CTRL1_ADDR,
+				    BF_RXEN0_0F_CTRL_INFO, rxen0_0f_ctrl_en);
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(device, REG_RXEN_NOVALP_CTRL1_ADDR,
+				    BF_RXENGP0_0F_CTRL_INFO,
+				    rxengp0_0f_ctrl_en);
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(device, REG_RXEN_NOVALP_CTRL1_ADDR,
+				    BF_RXEN0_0S_CTRL_INFO, rxen0_0s_ctrl_en);
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(device, REG_RXEN_NOVALP_CTRL1_ADDR,
+				    BF_RXENGP0_0S_CTRL_INFO,
+				    rxengp0_0s_ctrl_en);
+	AD9081_ERROR_RETURN(err);
+
+	return API_CMS_ERROR_OK;
+}
+
+int32_t adi_ad9081_adc_adc1_rxen_pwdn_ctrl_set(adi_ad9081_device_t *device,
+					       uint8_t rxen1_1f_ctrl_en,
+					       uint8_t rxengp1_1f_ctrl_en,
+					       uint8_t rxen1_1s_ctrl_en,
+					       uint8_t rxengp1_1s_ctrl_en)
+{
+	int32_t err;
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_LOG_FUNC();
+	AD9081_INVALID_PARAM_RETURN(rxen1_1f_ctrl_en > 1);
+	AD9081_INVALID_PARAM_RETURN(rxengp1_1f_ctrl_en > 1);
+	AD9081_INVALID_PARAM_RETURN(rxen1_1s_ctrl_en > 1);
+	AD9081_INVALID_PARAM_RETURN(rxengp1_1s_ctrl_en > 1);
+
+	err = adi_ad9081_hal_bf_set(device, REG_RXEN_NOVALP_CTRL1_ADDR,
+				    BF_RXEN1_1F_CTRL_INFO, rxen1_1f_ctrl_en);
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(device, REG_RXEN_NOVALP_CTRL1_ADDR,
+				    BF_RXENGP1_1F_CTRL_INFO,
+				    rxengp1_1f_ctrl_en);
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(device, REG_RXEN_NOVALP_CTRL1_ADDR,
+				    BF_RXEN1_1S_CTRL_INFO, rxen1_1s_ctrl_en);
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(device, REG_RXEN_NOVALP_CTRL1_ADDR,
+				    BF_RXENGP1_1S_CTRL_INFO,
+				    rxengp1_1s_ctrl_en);
+	AD9081_ERROR_RETURN(err);
+
+	return API_CMS_ERROR_OK;
+}
+
+int32_t adi_ad9081_adc_adc2_rxen_pwdn_ctrl_set(adi_ad9081_device_t *device,
+					       uint8_t rxen0_2f_ctrl_en,
+					       uint8_t rxengp0_2f_ctrl_en,
+					       uint8_t rxen0_2s_ctrl_en,
+					       uint8_t rxengp0_2s_ctrl_en)
+{
+	int32_t err;
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_LOG_FUNC();
+	AD9081_INVALID_PARAM_RETURN(rxen0_2f_ctrl_en > 1);
+	AD9081_INVALID_PARAM_RETURN(rxengp0_2f_ctrl_en > 1);
+	AD9081_INVALID_PARAM_RETURN(rxen0_2s_ctrl_en > 1);
+	AD9081_INVALID_PARAM_RETURN(rxengp0_2s_ctrl_en > 1);
+
+	err = adi_ad9081_hal_bf_set(device, REG_RXEN_NOVALP_CTRL2_ADDR,
+				    BF_RXEN0_2F_CTRL_INFO, rxen0_2f_ctrl_en);
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(device, REG_RXEN_NOVALP_CTRL2_ADDR,
+				    BF_RXENGP0_2F_CTRL_INFO,
+				    rxengp0_2f_ctrl_en);
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(device, REG_RXEN_NOVALP_CTRL2_ADDR,
+				    BF_RXEN0_2S_CTRL_INFO, rxen0_2s_ctrl_en);
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(device, REG_RXEN_NOVALP_CTRL2_ADDR,
+				    BF_RXENGP0_2S_CTRL_INFO,
+				    rxengp0_2s_ctrl_en);
+	AD9081_ERROR_RETURN(err);
+
+	return API_CMS_ERROR_OK;
+}
+
+int32_t adi_ad9081_adc_adc3_rxen_pwdn_ctrl_set(adi_ad9081_device_t *device,
+					       uint8_t rxen1_3f_ctrl_en,
+					       uint8_t rxengp1_3f_ctrl_en,
+					       uint8_t rxen1_3s_ctrl_en,
+					       uint8_t rxengp1_3s_ctrl_en)
+{
+	int32_t err;
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_LOG_FUNC();
+	AD9081_INVALID_PARAM_RETURN(rxen1_3f_ctrl_en > 1);
+	AD9081_INVALID_PARAM_RETURN(rxengp1_3f_ctrl_en > 1);
+	AD9081_INVALID_PARAM_RETURN(rxen1_3s_ctrl_en > 1);
+	AD9081_INVALID_PARAM_RETURN(rxengp1_3s_ctrl_en > 1);
+
+	err = adi_ad9081_hal_bf_set(device, REG_RXEN_NOVALP_CTRL2_ADDR,
+				    BF_RXEN1_3F_CTRL_INFO, rxen1_3f_ctrl_en);
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(device, REG_RXEN_NOVALP_CTRL2_ADDR,
+				    BF_RXENGP1_3F_CTRL_INFO,
+				    rxengp1_3f_ctrl_en);
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(device, REG_RXEN_NOVALP_CTRL2_ADDR,
+				    BF_RXEN1_3S_CTRL_INFO, rxen1_3s_ctrl_en);
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_bf_set(device, REG_RXEN_NOVALP_CTRL2_ADDR,
+				    BF_RXENGP1_3S_CTRL_INFO,
+				    rxengp1_3s_ctrl_en);
+	AD9081_ERROR_RETURN(err);
+
+	return API_CMS_ERROR_OK;
+}
+
+int32_t adi_ad9081_adc_rxengp0_ctrl_set(adi_ad9081_device_t *device,
+					uint8_t spi_en, uint8_t pol,
+					uint8_t rxen)
 {
 	int32_t err;
 	AD9081_NULL_POINTER_RETURN(device);
@@ -450,9 +578,9 @@ int32_t adi_ad9081_adc_rxen1_gpio_ctrl_set(adi_ad9081_device_t *device,
 	return API_CMS_ERROR_OK;
 }
 
-int32_t adi_ad9081_adc_rxen3_gpio_ctrl_set(adi_ad9081_device_t *device,
-					   uint8_t spi_en, uint8_t pol,
-					   uint8_t rxen)
+int32_t adi_ad9081_adc_rxengp1_ctrl_set(adi_ad9081_device_t *device,
+					uint8_t spi_en, uint8_t pol,
+					uint8_t rxen)
 {
 	int32_t err;
 	AD9081_NULL_POINTER_RETURN(device);
@@ -471,9 +599,10 @@ int32_t adi_ad9081_adc_rxen3_gpio_ctrl_set(adi_ad9081_device_t *device,
 	return API_CMS_ERROR_OK;
 }
 
-int32_t adi_ad9081_adc_cddc_fddc_jtx_clk_en_via_rxen1_gpio_set(
-	adi_ad9081_device_t *device, uint8_t cddcs, uint8_t fddcs, uint8_t adcs,
-	uint8_t jtx, uint8_t jtx_phy)
+int32_t adi_ad9081_adc_rxengp0_sel_set(adi_ad9081_device_t *device,
+				       uint8_t cddcs, uint8_t fddcs,
+				       uint8_t adcs, uint8_t jtx,
+				       uint8_t jtx_phy)
 {
 	int32_t err;
 	AD9081_NULL_POINTER_RETURN(device);
@@ -501,9 +630,10 @@ int32_t adi_ad9081_adc_cddc_fddc_jtx_clk_en_via_rxen1_gpio_set(
 	return API_CMS_ERROR_OK;
 }
 
-int32_t adi_ad9081_adc_cddc_fddc_jtx_clk_en_via_rxen3_gpio_set(
-	adi_ad9081_device_t *device, uint8_t cddcs, uint8_t fddcs, uint8_t adcs,
-	uint8_t jtx, uint8_t jtx_phy)
+int32_t adi_ad9081_adc_rxengp1_sel_set(adi_ad9081_device_t *device,
+				       uint8_t cddcs, uint8_t fddcs,
+				       uint8_t adcs, uint8_t jtx,
+				       uint8_t jtx_phy)
 {
 	int32_t err;
 	AD9081_NULL_POINTER_RETURN(device);
@@ -1294,7 +1424,6 @@ int32_t adi_ad9081_adc_ddc_coarse_nco_ftw_set(adi_ad9081_device_t *device,
 	AD9081_ERROR_RETURN(err);
 #endif
 
-	/* ad9081api-536 */
 	if ((cddcs & AD9081_ADC_CDDC_0) > 0) {
 		err = adi_ad9081_adc_ddc_coarse_nco_phase_offset_set(
 			device, AD9081_ADC_CDDC_0, ftw << 3);
@@ -2283,11 +2412,12 @@ int32_t adi_ad9081_adc_core_setup(adi_ad9081_device_t *device,
 	return API_CMS_ERROR_OK;
 }
 
-int32_t adi_ad9081_adc_config(adi_ad9081_device_t *device, uint8_t cddcs,
-			      uint8_t fddcs, int64_t cddc_shift[4],
-			      int64_t fddc_shift[8], uint8_t cddc_dcm[4],
-			      uint8_t fddc_dcm[8], uint8_t cc2r_en[4],
-			      uint8_t fc2r_en[8])
+int32_t
+adi_ad9081_adc_path_or_bypass_config(adi_ad9081_device_t *device, uint8_t cddcs,
+				     uint8_t fddcs, int64_t cddc_shift[4],
+				     int64_t fddc_shift[8], uint8_t cddc_dcm[4],
+				     uint8_t fddc_dcm[8], uint8_t cc2r_en[4],
+				     uint8_t fc2r_en[8], uint8_t bypass_mode)
 {
 	int32_t err;
 	uint64_t adc_freq_hz, ftw;
@@ -2450,94 +2580,149 @@ int32_t adi_ad9081_adc_config(adi_ad9081_device_t *device, uint8_t cddcs,
 		device, AD9081_ADC_PFIR_ADC_PAIR0, 0,
 		((die_id & 0x80) == 0) ? 1 : 0);
 	AD9081_ERROR_RETURN(err);
-
-	/* enable coarse and fine nco */
-	err = adi_ad9081_adc_ddc_coarse_nco_enable_set(device, cddcs);
-	AD9081_ERROR_RETURN(err);
-	fddcs_enabled = fddcs;
-	for (i = 0; i < 8; i++) {
-		fddc = fddcs & (AD9081_ADC_FDDC_0 << i);
-		if ((fddc > 0) && (fddc_dcm[i] == AD9081_FDDC_DCM_1)) {
-			fddcs_enabled &=
-				~fddc; /* do not enable fddc if its dcm is 1 */
+	if (!bypass_mode) {
+		/* enable coarse and fine nco */
+		err = adi_ad9081_adc_ddc_coarse_nco_enable_set(device, cddcs);
+		AD9081_ERROR_RETURN(err);
+		fddcs_enabled = fddcs;
+		for (i = 0; i < 8; i++) {
+			fddc = fddcs & (AD9081_ADC_FDDC_0 << i);
+			if ((fddc > 0) && (fddc_dcm[i] == AD9081_FDDC_DCM_1)) {
+				fddcs_enabled &=
+					~fddc; /* do not enable fddc if its dcm is 1 */
+			}
 		}
-	}
-	err = adi_ad9081_adc_ddc_fine_nco_enable_set(device, fddcs_enabled);
-	AD9081_ERROR_RETURN(err);
+		err = adi_ad9081_adc_ddc_fine_nco_enable_set(device,
+							     fddcs_enabled);
+		AD9081_ERROR_RETURN(err);
 
-	/* set coarse ddc */
-	for (i = 0; i < 4; i++) {
-		cddc = cddcs & (AD9081_ADC_CDDC_0 << i);
-		if (cddc > 0) {
-			err = adi_ad9081_adc_ddc_coarse_dcm_set(device, cddc,
-								cddc_dcm[i]);
-			AD9081_ERROR_RETURN(err);
-			err = adi_ad9081_adc_ddc_coarse_c2r_set(device, cddc,
-								cc2r_en[i]);
-			AD9081_ERROR_RETURN(err);
-			err = adi_ad9081_adc_ddc_coarse_gain_set(device, cddc,
-								 0);
-			AD9081_ERROR_RETURN(err);
-			err = adi_ad9081_adc_ddc_coarse_nco_mode_set(
-				device, cddc,
-				(cddc_shift[i] == 0) ? AD9081_ADC_NCO_ZIF :
-						       AD9081_ADC_NCO_VIF);
-			AD9081_ERROR_RETURN(err);
-			err = adi_ad9081_adc_ddc_coarse_nco_set(device, cddc,
-								cddc_shift[i]);
-			AD9081_ERROR_RETURN(err);
+		/* set coarse ddc */
+		for (i = 0; i < 4; i++) {
+			cddc = cddcs & (AD9081_ADC_CDDC_0 << i);
+			if (cddc > 0) {
+				err = adi_ad9081_adc_ddc_coarse_dcm_set(
+					device, cddc, cddc_dcm[i]);
+				AD9081_ERROR_RETURN(err);
+				err = adi_ad9081_adc_ddc_coarse_c2r_set(
+					device, cddc, cc2r_en[i]);
+				AD9081_ERROR_RETURN(err);
+				err = adi_ad9081_adc_ddc_coarse_gain_set(
+					device, cddc, 0);
+				AD9081_ERROR_RETURN(err);
+				err = adi_ad9081_adc_ddc_coarse_nco_mode_set(
+					device, cddc,
+					(cddc_shift[i] == 0) ?
+						AD9081_ADC_NCO_ZIF :
+						AD9081_ADC_NCO_VIF);
+				AD9081_ERROR_RETURN(err);
+				err = adi_ad9081_adc_ddc_coarse_nco_set(
+					device, cddc, cddc_shift[i]);
+				AD9081_ERROR_RETURN(err);
+			}
 		}
+	} else {
+		/* Disable coarse and fine ddcs */
+		err = adi_ad9081_adc_ddc_coarse_nco_enable_set(device, 0x0F);
+		AD9081_ERROR_RETURN(err);
+		err = adi_ad9081_adc_ddc_fine_nco_enable_set(device, 0xFF);
+		AD9081_ERROR_RETURN(err);
 	}
 
 	/* set fine ddc complex-real enable, decimation ratio, default gain and nco mode */
 	for (i = 0; i < 8; i++) {
-		fddc = fddcs & (AD9081_ADC_FDDC_0 << i);
-		if (fddc > 0) {
-			err = adi_ad9081_adc_ddc_fine_dcm_set(device, fddc,
-							      fddc_dcm[i]);
-			AD9081_ERROR_RETURN(err);
-			err = adi_ad9081_adc_ddc_fine_c2r_set(device, fddc,
-							      fc2r_en[i]);
-			AD9081_ERROR_RETURN(err);
-			err = adi_ad9081_adc_ddc_fine_gain_set(device, fddc, 0);
-			AD9081_ERROR_RETURN(err);
-			err = adi_ad9081_adc_ddc_fine_nco_mode_set(
-				device, fddc,
-				(fddc_shift[i] == 0) ? AD9081_ADC_NCO_ZIF :
-						       AD9081_ADC_NCO_VIF);
-			AD9081_ERROR_RETURN(err);
+		if (!bypass_mode) {
+			fddc = fddcs & (AD9081_ADC_FDDC_0 << i);
+			if (fddc > 0) {
+				err = adi_ad9081_adc_ddc_fine_dcm_set(
+					device, fddc, fddc_dcm[i]);
+				AD9081_ERROR_RETURN(err);
+				err = adi_ad9081_adc_ddc_fine_c2r_set(
+					device, fddc, fc2r_en[i]);
+				AD9081_ERROR_RETURN(err);
+				err = adi_ad9081_adc_ddc_fine_gain_set(device,
+								       fddc, 0);
+				AD9081_ERROR_RETURN(err);
+				err = adi_ad9081_adc_ddc_fine_nco_mode_set(
+					device, fddc,
+					(fddc_shift[i] == 0) ?
+						AD9081_ADC_NCO_ZIF :
+						AD9081_ADC_NCO_VIF);
+				AD9081_ERROR_RETURN(err);
 
-			j = (i < 4) ?
-				    ((cddc_fddc_xbar & (1 << i)) > 0 ? 1 : 0) :
-				    ((cddc_fddc_xbar & (1 << i)) > 0 ? 3 : 2);
-			cddc_dcm_value = adi_ad9081_adc_ddc_coarse_dcm_decode(
-				cddc_dcm[j]);
-			adc_freq_hz = device->dev_info.adc_freq_hz;
+				j = (i < 4) ? ((cddc_fddc_xbar & (1 << i)) > 0 ?
+						       1 :
+						       0) :
+					      ((cddc_fddc_xbar & (1 << i)) > 0 ?
+						       3 :
+						       2);
+				cddc_dcm_value =
+					adi_ad9081_adc_ddc_coarse_dcm_decode(
+						cddc_dcm[j]);
+				adc_freq_hz = device->dev_info.adc_freq_hz;
 #ifdef __KERNEL__
-			adc_freq_hz = div_u64(adc_freq_hz, cddc_dcm_value);
+				adc_freq_hz =
+					div_u64(adc_freq_hz, cddc_dcm_value);
 #else
-			adc_freq_hz = adc_freq_hz / cddc_dcm_value;
+				adc_freq_hz = adc_freq_hz / cddc_dcm_value;
 #endif
-			adc_freq_hz = (cc2r_en[j] > 0) ? (adc_freq_hz * 2) :
-							 adc_freq_hz;
-			err = adi_ad9081_hal_calc_tx_nco_ftw(
-				device, adc_freq_hz, fddc_shift[i], &ftw);
-			AD9081_ERROR_RETURN(err);
-			err = adi_ad9081_adc_ddc_fine_nco_ftw_set(device, fddc,
-								  ftw, 0, 0);
-			AD9081_ERROR_RETURN(err);
+				adc_freq_hz = (cc2r_en[j] > 0) ?
+						      (adc_freq_hz * 2) :
+						      adc_freq_hz;
+				err = adi_ad9081_hal_calc_tx_nco_ftw(
+					device, adc_freq_hz, fddc_shift[i],
+					&ftw);
+				AD9081_ERROR_RETURN(err);
+				err = adi_ad9081_adc_ddc_fine_nco_ftw_set(
+					device, fddc, ftw, 0, 0);
+				AD9081_ERROR_RETURN(err);
 
-			fddc_dcm_value =
-				adi_ad9081_adc_ddc_fine_dcm_decode(fddc_dcm[i]);
-			overall_dcm_value = cddc_dcm_value * fddc_dcm_value;
-			overall_dcm_value = (cc2r_en[j] > 0) ?
-						    (overall_dcm_value / 2) :
-						    overall_dcm_value;
+				fddc_dcm_value =
+					adi_ad9081_adc_ddc_fine_dcm_decode(
+						fddc_dcm[i]);
+				overall_dcm_value =
+					cddc_dcm_value * fddc_dcm_value;
+				overall_dcm_value =
+					(cc2r_en[j] > 0) ?
+						(overall_dcm_value / 2) :
+						overall_dcm_value;
+				err = adi_ad9081_adc_ddc_fine_overall_dcm_set(
+					device, fddc, overall_dcm_value);
+				AD9081_ERROR_RETURN(err);
+			}
+		} else {
 			err = adi_ad9081_adc_ddc_fine_overall_dcm_set(
-				device, fddc, overall_dcm_value);
+				device, AD9081_ADC_FDDC_0 << i, 1);
 			AD9081_ERROR_RETURN(err);
 		}
 	}
+
+	return API_CMS_ERROR_OK;
+}
+
+int32_t adi_ad9081_adc_bypass_config(adi_ad9081_device_t *device)
+{
+	int32_t err;
+
+	err = adi_ad9081_adc_path_or_bypass_config(device, 0, 0, NULL, NULL,
+						   NULL, NULL, NULL, NULL, 1);
+	AD9081_ERROR_RETURN(err);
+
+	return API_CMS_ERROR_OK;
+}
+
+int32_t adi_ad9081_adc_config(adi_ad9081_device_t *device, uint8_t cddcs,
+			      uint8_t fddcs, int64_t cddc_shift[4],
+			      int64_t fddc_shift[8], uint8_t cddc_dcm[4],
+			      uint8_t fddc_dcm[8], uint8_t cc2r_en[4],
+			      uint8_t fc2r_en[8])
+{
+	int32_t err;
+
+	err = adi_ad9081_adc_path_or_bypass_config(device, cddcs, fddcs,
+						   cddc_shift, fddc_shift,
+						   cddc_dcm, fddc_dcm, cc2r_en,
+						   fc2r_en, 0);
+	AD9081_ERROR_RETURN(err);
 
 	return API_CMS_ERROR_OK;
 }
@@ -4208,6 +4393,191 @@ int32_t adi_ad9081_adc_smon_next_sync_mode_set(adi_ad9081_device_t *device,
 			AD9081_ERROR_RETURN(err);
 		}
 	}
+
+	return API_CMS_ERROR_OK;
+}
+
+int32_t
+adi_ad9081_adc_data_inversion_dc_coupling_set(adi_ad9081_device_t *device,
+					      adi_ad9081_adc_select_e adc_sel,
+					      uint8_t enable)
+{
+	int32_t err;
+	uint32_t reg_customer_up_transfer_addr = 0x2100;
+	uint32_t reg_user_settings_adc_cal_addr = 0x2115;
+	uint32_t reg_data_inversion_dc_coupling_addr = 0x2111;
+	uint8_t data_inversion_setting = 0x0;
+	int i = 0;
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_LOG_FUNC();
+	AD9081_INVALID_PARAM_RETURN(enable > 1);
+
+	err = adi_ad9081_hal_reg_get(device,
+				     reg_data_inversion_dc_coupling_addr,
+				     &data_inversion_setting);
+	AD9081_ERROR_RETURN(err);
+
+	if (enable) {
+		for (i = 0; i < 4; i++) {
+			if ((1 << i) & adc_sel) {
+				data_inversion_setting |= (0x1 << i);
+			}
+		}
+	} else {
+		for (i = 0; i < 4; i++) {
+			if ((1 << i) & adc_sel) {
+				data_inversion_setting &= ~(0x1 << i);
+			}
+		}
+	}
+	err = adi_ad9081_hal_reg_set(device,
+				     reg_data_inversion_dc_coupling_addr,
+				     data_inversion_setting);
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_reg_set(
+		device, reg_user_settings_adc_cal_addr,
+		1); /* Enable user-defined ADC calibration settings */
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_reg_set(device, reg_customer_up_transfer_addr,
+				     1); /* Trigger Data Transfer */
+	AD9081_ERROR_RETURN(err);
+
+	return API_CMS_ERROR_OK;
+}
+
+int32_t
+adi_ad9081_adc_offset_timing_calibration_set(adi_ad9081_device_t *device,
+					     adi_ad9081_adc_select_e adc_sel,
+					     uint8_t enable)
+{
+	int32_t err;
+	uint32_t reg_customer_up_transfer_addr = 0x2100;
+	uint32_t reg_user_settings_adc_cal_addr = 0x2115;
+	uint32_t reg_offset_timing_calibration_addr = 0x2116;
+	uint8_t offset_timing_calibration_setting = 0x0;
+	int i = 0;
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_LOG_FUNC();
+	AD9081_INVALID_PARAM_RETURN(enable > 1);
+
+	err = adi_ad9081_hal_reg_get(device, reg_offset_timing_calibration_addr,
+				     &offset_timing_calibration_setting);
+	AD9081_ERROR_RETURN(err);
+
+	if (enable) {
+		for (i = 0; i < 4; i++) {
+			if ((1 << i) & adc_sel) {
+				offset_timing_calibration_setting |= (0x1 << i);
+			}
+		}
+	} else {
+		for (i = 0; i < 4; i++) {
+			if ((1 << i) & adc_sel) {
+				offset_timing_calibration_setting &=
+					~(0x1 << i);
+			}
+		}
+	}
+	err = adi_ad9081_hal_reg_set(device, reg_offset_timing_calibration_addr,
+				     offset_timing_calibration_setting);
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_reg_set(
+		device, reg_user_settings_adc_cal_addr,
+		1); /* Enable user-defined ADC calibration settings */
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_reg_set(device, reg_customer_up_transfer_addr,
+				     1); /* Trigger Data Transfer */
+	AD9081_ERROR_RETURN(err);
+
+	return API_CMS_ERROR_OK;
+}
+
+int32_t adi_ad9081_adc_gain_calibration_set(adi_ad9081_device_t *device,
+					    adi_ad9081_adc_select_e adc_sel,
+					    uint8_t enable)
+{
+	int32_t err;
+	uint32_t reg_customer_up_transfer_addr = 0x2100;
+	uint32_t reg_user_settings_adc_cal_addr = 0x2115;
+	uint32_t reg_gain_calibration_addr = 0x2117;
+	uint8_t gain_calibration_setting = 0x0;
+	int i = 0;
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_LOG_FUNC();
+	AD9081_INVALID_PARAM_RETURN(enable > 1);
+
+	err = adi_ad9081_hal_reg_get(device, reg_gain_calibration_addr,
+				     &gain_calibration_setting);
+	AD9081_ERROR_RETURN(err);
+
+	if (enable) {
+		for (i = 0; i < 4; i++) {
+			if ((1 << i) & adc_sel) {
+				gain_calibration_setting |= (0x1 << i);
+			}
+		}
+	} else {
+		for (i = 0; i < 4; i++) {
+			if ((1 << i) & adc_sel) {
+				gain_calibration_setting &= ~(0x1 << i);
+			}
+		}
+	}
+	err = adi_ad9081_hal_reg_set(device, reg_gain_calibration_addr,
+				     gain_calibration_setting);
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_reg_set(
+		device, reg_user_settings_adc_cal_addr,
+		1); /* Enable user-defined ADC calibration settings */
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_reg_set(device, reg_customer_up_transfer_addr,
+				     1); /* Trigger Data Transfer */
+	AD9081_ERROR_RETURN(err);
+
+	return API_CMS_ERROR_OK;
+}
+
+int32_t adi_ad9081_adc_offset_calibration_set(adi_ad9081_device_t *device,
+					      adi_ad9081_adc_select_e adc_sel,
+					      uint8_t enable)
+{
+	int32_t err;
+	uint32_t reg_customer_up_transfer_addr = 0x2100;
+	uint32_t reg_user_settings_adc_cal_addr = 0x2115;
+	uint32_t reg_offset_calibration_addr = 0x2117;
+	uint8_t offset_calibration_setting = 0x0;
+	int i = 0;
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_LOG_FUNC();
+	AD9081_INVALID_PARAM_RETURN(enable > 1);
+
+	err = adi_ad9081_hal_reg_get(device, reg_offset_calibration_addr,
+				     &offset_calibration_setting);
+	AD9081_ERROR_RETURN(err);
+
+	if (enable) {
+		for (i = 0; i < 4; i++) {
+			if ((1 << i) & adc_sel) {
+				offset_calibration_setting |= (0x1 << (4 + i));
+			}
+		}
+	} else {
+		for (i = 0; i < 4; i++) {
+			if ((1 << i) & adc_sel) {
+				offset_calibration_setting &= ~(0x1 << (4 + i));
+			}
+		}
+	}
+	err = adi_ad9081_hal_reg_set(device, reg_offset_calibration_addr,
+				     offset_calibration_setting);
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_reg_set(
+		device, reg_user_settings_adc_cal_addr,
+		1); /* Enable user-defined ADC calibration settings */
+	AD9081_ERROR_RETURN(err);
+	err = adi_ad9081_hal_reg_set(device, reg_customer_up_transfer_addr,
+				     1); /* Trigger Data Transfer */
+	AD9081_ERROR_RETURN(err);
 
 	return API_CMS_ERROR_OK;
 }

--- a/drivers/adc/ad9081/api/adi_ad9081_config.h
+++ b/drivers/adc/ad9081/api/adi_ad9081_config.h
@@ -39,7 +39,7 @@
 #define __FUNCTION_NAME__ __FUNCTION__
 #endif
 
-#define AD9081_API_REV 0x00010202
+#define AD9081_API_REV 0x00010500
 #define AD9081_API_HW_RESET_LOW 600000
 #define AD9081_API_RESET_WAIT 500000
 #define AD9081_PLL_LOCK_TRY 75
@@ -48,6 +48,7 @@
 #define AD9081_JESD_MAN_CAL_WAIT 200000
 #define AD9081_JESD_RX_204C_CAL_WAIT 500000
 #define AD9081_JESD_FG_CAL_WAIT 200000
+#define AD9081_JESD_BG_CAL_WAIT 10000
 #define AD9081_SERDES_RST_WAIT 50000
 #define AD9081_DESER_MODE_204B_BR_TRESH 8000000000ULL
 #define AD9081_DESER_MODE_204C_BR_TRESH 16000000000ULL
@@ -636,23 +637,6 @@ int32_t adi_ad9081_adc_common_hop_en_set(adi_ad9081_device_t *device,
 					 uint8_t enable);
 
 /**
- * \brief Enables trig NCO reset for specified coarse DDCs.
- *
- *
- * \param[in]  device	         Pointer to device handler structure.
- * \param[in]  cddcs             0bXXXX, set X==1 to specify cddcs you wish to affect:
- *                                  Bit 3: cddc 3  (MSB)
- *                                  Bit 2: cddc 2
- *                                  Bit 1: cddc 1
- *                                  Bit 0: cddc 0  (LSB)
- * \param[in]  enable            1: enable, 0: disable.
- *
- * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
- */
-int32_t adi_ad9081_adc_ddc_coarse_trig_nco_reset_enable_set(
-	adi_ad9081_device_t *device, uint8_t cddcs, uint8_t enable);
-
-/**
  * \brief Changes Profile Update Mode/ Phase Update Mode for specified coarse DDCs.
  *
  *
@@ -956,6 +940,39 @@ adi_ad9081_jesd_determine_common_nc(adi_ad9081_jesd_link_select_e links,
  */
 int32_t adi_ad9081_jesd_sysref_d2acenter_enable_set(adi_ad9081_device_t *device,
 						    uint8_t enable);
+
+/**
+ * \brief Set hardware sysref control
+ *
+ * \param[in] device      Pointer to the device structure
+ *
+ * \return API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
+int32_t adi_ad9081_sync_sysref_ctrl(adi_ad9081_device_t *device);
+
+/**
+ * \brief Sets JTX_BR_LOG2_RATIO for specified links.
+ *
+ * \param[in]   device           Pointer to device handler structure.
+ * \param[in]   chip_op_mode     Chip operating mode, 1 : Tx Only, 2 : Rx Only, 3 : Tx + Rx Only.
+ * \param[in]   jesd_param       @see adi_cms_jesd_param_t, pass array with 2 elements for dual link.
+ * \param[in]   links            Choose AD9081 link(s) to set mask for:
+ *                                  0x1 - AD9081_LINK_0
+ *                                  0x2 - AD9081_LINK_1
+ *                                  0x3 - Both
+ * \param[in]   jtx_lane_rate    jtx_lane_rate[0] - lane rate in bps for AD9081_LINK_0.
+ *                               jtx_lane_rate[1] - lane rate in bps for AD9081_LINK_1.
+ * \param[out]  jtx_brr          jtx_brr[0] - JTX_BR_LOG2_RATIO value for AD9081_LINK_0.
+ *                               jtx_brr[1] - JTX_BR_LOG2_RATIO value for AD9081_LINK_1.
+ *
+ * \returns API_CMS_ERROR_OK is returned upon success. Otherwise, a failure code.
+ */
+int32_t adi_ad9081_jesd_tx_calc_br_ratio(adi_ad9081_device_t *device,
+					 adi_cms_chip_op_mode_t chip_op_mode,
+					 adi_cms_jesd_param_t *jesd_param,
+					 adi_ad9081_jesd_link_select_e links,
+					 uint64_t jtx_lane_rate[2],
+					 uint8_t jtx_brr[2]);
 
 #if AD9081_USE_FLOATING_TYPE > 0
 int32_t adi_ad9081_hal_calc_nco_ftw_f(adi_ad9081_device_t *device, double freq,

--- a/drivers/adc/ad9081/api/adi_ad9081_sync.c
+++ b/drivers/adc/ad9081/api/adi_ad9081_sync.c
@@ -58,7 +58,8 @@ int32_t adi_ad9081_jesd_sysref_input_mode_set(
 		return API_CMS_ERROR_INVALID_PARAM;
 	}
 
-	adi_ad9081_jesd_sysref_d2acenter_enable_set(device, 1);
+	err = adi_ad9081_jesd_sysref_d2acenter_enable_set(device, 1);
+	AD9081_ERROR_RETURN(err);
 
 	/* 1: AC couple, 0: DC couple */
 	err = adi_ad9081_hal_bf_set(
@@ -78,7 +79,87 @@ int32_t adi_ad9081_jesd_sysref_input_mode_set(
 		enable_capture); /* not paged, spi_sysref_en@sysref_control */
 	AD9081_ERROR_RETURN(err);
 
-	adi_ad9081_jesd_sysref_d2acenter_enable_set(device, 0);
+	err = adi_ad9081_jesd_sysref_d2acenter_enable_set(device, 0);
+	AD9081_ERROR_RETURN(err);
+
+	return API_CMS_ERROR_OK;
+}
+
+int32_t adi_ad9081_sync_sysref_input_config_set(
+	adi_ad9081_device_t *device, adi_cms_signal_coupling_e coupling_mode,
+	adi_cms_signal_type_e signal_type, uint8_t sysref_single_end_p,
+	uint8_t sysref_single_end_n)
+{
+	int32_t err;
+	AD9081_LOG_FUNC();
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_INVALID_PARAM_RETURN(sysref_single_end_n > 15 ||
+				    sysref_single_end_n < 0);
+	AD9081_INVALID_PARAM_RETURN(sysref_single_end_p > 15 ||
+				    sysref_single_end_p < 0);
+	AD9081_INVALID_PARAM_RETURN(coupling_mode != COUPLING_AC &&
+				    coupling_mode != COUPLING_DC);
+	AD9081_INVALID_PARAM_RETURN(signal_type == SIGNAL_UNKNOWN);
+
+	if ((coupling_mode == COUPLING_AC &&
+	     (signal_type == SIGNAL_LVDS || signal_type == SIGNAL_CML ||
+	      signal_type == SIGNAL_LVPECL)) ||
+	    coupling_mode == COUPLING_DC) {
+		err = adi_ad9081_jesd_sysref_input_mode_set(
+			device, 1, 1,
+			(signal_type == SIGNAL_LVDS ||
+			 signal_type == SIGNAL_CML ||
+			 signal_type == SIGNAL_LVPECL) ?
+				0 :
+				1);
+		AD9081_ERROR_RETURN(err);
+		err = adi_ad9081_jesd_sysref_d2acenter_enable_set(device, 1);
+		AD9081_ERROR_RETURN(err);
+		err = adi_ad9081_hal_bf_set(
+			device, 0x0fb9, 0x100,
+			(coupling_mode == COUPLING_AC) ?
+				0 :
+				1); /* not paged, sysref_dc_mode_sel */
+		AD9081_ERROR_RETURN(err);
+		err = adi_ad9081_hal_bf_set(
+			device, 0x0fb9, 0x104,
+			(signal_type == SIGNAL_CMOS) ?
+				1 :
+				0); /* not paged, sysref_single_end_mode_sel */
+		AD9081_ERROR_RETURN(err);
+
+		/* for 1.8V CMOS or higher, set ground ref resistor to 6.3 kohm. For 1.5V CMOS, set to 7.9 kohm.*/
+		if (signal_type == SIGNAL_CMOS) {
+			err = adi_ad9081_hal_bf_set(
+				device, 0x0fba, 0x400,
+				sysref_single_end_p); /* not paged, sysref_single_end_p */
+			AD9081_ERROR_RETURN(err);
+			err = adi_ad9081_hal_bf_set(
+				device, 0x0fba, 0x404,
+				sysref_single_end_n); /* not paged, sysref_single_end_n */
+			AD9081_ERROR_RETURN(err);
+		}
+		err = adi_ad9081_jesd_sysref_d2acenter_enable_set(device, 0);
+		AD9081_ERROR_RETURN(err);
+	} else {
+		AD9081_LOG_ERR(
+			"The SYSREF receiver input buffer cannot be configured in the mode specified.");
+		return API_CMS_ERROR_INVALID_PARAM;
+	}
+
+	return API_CMS_ERROR_OK;
+}
+
+int32_t adi_ad9081_sync_sysref_ctrl(adi_ad9081_device_t *device)
+{
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_NULL_POINTER_RETURN(device->clk_info.sysref_clk);
+	AD9081_NULL_POINTER_RETURN(device->clk_info.sysref_ctrl);
+
+	if (API_CMS_ERROR_OK !=
+	    device->clk_info.sysref_ctrl(device->clk_info.sysref_clk)) {
+		return API_CMS_ERROR_SYSREF_CTRL;
+	}
 
 	return API_CMS_ERROR_OK;
 }
@@ -129,6 +210,12 @@ int32_t adi_ad9081_jesd_oneshot_sync(adi_ad9081_device_t *device,
 				    BF_SYSREF_MODE_ONESHOT_INFO,
 				    1); /* not paged */
 	AD9081_ERROR_RETURN(err);
+
+	if (device->clk_info.sysref_mode == SYSREF_ONESHOT) {
+		err = adi_ad9081_sync_sysref_ctrl(device);
+		AD9081_ERROR_RETURN(err);
+	}
+
 	if (err = adi_ad9081_hal_bf_wait_to_clear(
 		    device, REG_SYSREF_MODE_ADDR,
 		    BF_SYSREF_MODE_ONESHOT_INFO), /* not paged */
@@ -288,12 +375,16 @@ int32_t adi_ad9081_jesd_sysref_monitor_phase_get(adi_ad9081_device_t *device,
 	AD9081_NULL_POINTER_RETURN(sysref_phase);
 	AD9081_LOG_FUNC();
 
+	/* Write strobe to trigger a value update */
+	err = adi_ad9081_hal_bf_set(device, REG_SYSREF_PHASE0_ADDR, 0x800,
+				    0x00);
+
 	err = adi_ad9081_hal_bf_get(device, REG_SYSREF_PHASE0_ADDR, 0x800,
 				    &phase0_val, sizeof(uint8_t));
 	err = adi_ad9081_hal_bf_get(device, REG_SYSREF_PHASE1_ADDR, 0x400,
 				    &phase1_val, sizeof(uint8_t));
 
-	*sysref_phase = (phase0_val << 8) + phase1_val;
+	*sysref_phase = (phase1_val << 8) + phase0_val;
 
 	AD9081_ERROR_RETURN(err);
 
@@ -386,6 +477,149 @@ adi_ad9081_jesd_sysref_oneshot_sync_done_get(adi_ad9081_device_t *device,
 
 	if (*sync_done != 1) {
 		AD9081_LOG_ERR("oneshot sync not finished.");
+	}
+
+	return API_CMS_ERROR_OK;
+}
+
+int32_t adi_ad9081_sync_calc_jrx_lmfc_lemc(uint64_t dac_clk,
+					   uint8_t main_interp,
+					   uint8_t ch_interp,
+					   adi_cms_jesd_param_t *jesd_param,
+					   uint64_t *lmfc_freq)
+{
+	if (lmfc_freq == NULL) {
+		return API_CMS_ERROR_NULL_PARAM;
+	}
+
+#ifdef __KERNEL__
+	*lmfc_freq =
+		div64_u64(dac_clk, jesd_param->jesd_s * jesd_param->jesd_k *
+					   main_interp * ch_interp);
+#else
+	*lmfc_freq = (dac_clk) / (jesd_param->jesd_s * jesd_param->jesd_k *
+				  main_interp * ch_interp);
+#endif
+	return API_CMS_ERROR_OK;
+}
+
+int32_t adi_ad9081_sync_calc_jtx_lmfc_lemc(uint64_t adc_clk,
+					   uint8_t cddc_dcm[4],
+					   uint8_t fddc_dcm[8],
+					   adi_ad9081_jesd_link_select_e links,
+					   adi_cms_jesd_param_t jesd_param[2],
+					   uint64_t *lmfc_freq)
+{
+	uint64_t lmfc_link0, lmfc_link1, gcd, min_link, max_link, lmfc_gcd;
+	uint8_t cdcm, fdcm;
+	if (lmfc_freq == NULL) {
+		return API_CMS_ERROR_NULL_PARAM;
+	}
+
+	cdcm = adi_ad9081_adc_ddc_coarse_dcm_decode(cddc_dcm[0]);
+	fdcm = adi_ad9081_adc_ddc_fine_dcm_decode(fddc_dcm[0]);
+
+	if (jesd_param->jesd_duallink > 0) {
+#ifdef __KERNEL__
+		/* link 0 */
+		lmfc_link0 = div64_u64(adc_clk, jesd_param[0].jesd_s *
+							jesd_param[0].jesd_k *
+							cdcm * fdcm);
+
+		/* link 1 */
+		lmfc_link1 = div64_u64(adc_clk, jesd_param[1].jesd_s *
+							jesd_param[1].jesd_k *
+							cdcm * fdcm);
+#else
+		/* link 0 */
+		lmfc_link0 = (adc_clk) / (jesd_param[0].jesd_s *
+					  jesd_param[0].jesd_k * cdcm * fdcm);
+
+		/* link 1 */
+		lmfc_link1 = (adc_clk) / (jesd_param[1].jesd_s *
+					  jesd_param[1].jesd_k * cdcm * fdcm);
+#endif
+
+		/* gcd between links */
+		max_link = (lmfc_link0 >= lmfc_link1) ? lmfc_link0 : lmfc_link1;
+		min_link = (lmfc_link0 >= lmfc_link1) ? lmfc_link1 : lmfc_link0;
+		gcd = adi_api_utils_gcd(min_link, max_link);
+		lmfc_gcd = gcd;
+	} else {
+		/* link 0 */
+#ifdef __KERNEL__
+		lmfc_link0 = div64_u64(adc_clk, jesd_param[0].jesd_s *
+							jesd_param[0].jesd_k *
+							cdcm * fdcm);
+#else
+		lmfc_link0 = (adc_clk) / (jesd_param[0].jesd_s *
+					  jesd_param[0].jesd_k * cdcm * fdcm);
+#endif
+		lmfc_gcd = lmfc_link0;
+	}
+
+	*lmfc_freq = lmfc_gcd;
+	return API_CMS_ERROR_OK;
+}
+
+int32_t adi_ad9081_sync_sysref_frequency_set(
+	adi_ad9081_device_t *device, uint64_t *sysref_freq, uint64_t dac_clk,
+	uint64_t adc_clk, uint8_t main_interp, uint8_t ch_interp,
+	uint8_t cddc_dcm[4], uint8_t fddc_dcm[8],
+	adi_ad9081_jesd_link_select_e jtx_links,
+	adi_cms_jesd_param_t *jrx_param, adi_cms_jesd_param_t jtx_param[2])
+{
+	uint64_t jrx_lmfc, jtx_lmfc, max_lmfc, min_lmfc, gcd = 0;
+	int32_t err;
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_NULL_POINTER_RETURN(sysref_freq);
+	AD9081_NULL_POINTER_RETURN(jrx_param);
+	AD9081_LOG_FUNC();
+
+	/* jrx */
+	err = adi_ad9081_sync_calc_jrx_lmfc_lemc(
+		dac_clk, main_interp, ch_interp, jrx_param, &jrx_lmfc);
+	AD9081_ERROR_RETURN(err);
+
+	/* jtx */
+	err = adi_ad9081_sync_calc_jtx_lmfc_lemc(
+		adc_clk, cddc_dcm, fddc_dcm, jtx_links, jtx_param, &jtx_lmfc);
+	AD9081_ERROR_RETURN(err);
+
+	/* gcd */
+	max_lmfc = (jrx_lmfc >= jtx_lmfc) ? jrx_lmfc : jtx_lmfc;
+	min_lmfc = (jrx_lmfc >= jtx_lmfc) ? jtx_lmfc : jrx_lmfc;
+	gcd = adi_api_utils_gcd(min_lmfc, max_lmfc);
+	*sysref_freq = gcd;
+
+	return API_CMS_ERROR_OK;
+}
+
+int32_t
+adi_ad9081_sync_jrx_tpl_phase_diff_get(adi_ad9081_device_t *device,
+				       adi_ad9081_jesd_link_select_e links,
+				       uint8_t *jrx_phase_diff)
+{
+	int32_t err;
+	AD9081_NULL_POINTER_RETURN(device);
+	AD9081_NULL_POINTER_RETURN(jrx_phase_diff);
+	AD9081_LOG_FUNC();
+
+	if ((links & AD9081_LINK_0) > 0) {
+		err = adi_ad9081_jesd_rx_link_select_set(device, AD9081_LINK_0);
+		AD9081_ERROR_RETURN(err);
+		err = adi_ad9081_hal_bf_get(device, REG_JRX_TPL_5_ADDR,
+					    BF_JRX_TPL_PHASE_DIFF_INFO,
+					    jrx_phase_diff, 1);
+		AD9081_ERROR_RETURN(err);
+	}
+	if ((links & AD9081_LINK_1) > 0) {
+		err = adi_ad9081_jesd_rx_link_select_set(device, AD9081_LINK_1);
+		AD9081_ERROR_RETURN(err);
+		err = adi_ad9081_hal_bf_get(device, REG_JRX_TPL_5_ADDR,
+					    BF_JRX_TPL_PHASE_DIFF_INFO,
+					    jrx_phase_diff, 1);
+		AD9081_ERROR_RETURN(err);
 	}
 
 	return API_CMS_ERROR_OK;

--- a/drivers/adc/ad9081/api/adi_cms_api_common.h
+++ b/drivers/adc/ad9081/api/adi_cms_api_common.h
@@ -20,11 +20,73 @@
 #include <linux/kernel.h>
 #include <linux/math64.h>
 #include <linux/delay.h>
+#include <linux/gcd.h>
+
+static inline int32_t adi_api_utils_is_power_of_two(uint64_t x)
+{
+	return (u32) is_power_of_2(x);
+}
+
+static inline int32_t adi_api_utils_gcd(int32_t u, int32_t v)
+{
+	return (u32) gcd(u, v);
+}
+
+static inline uint32_t adi_api_utils_log2(uint32_t a)
+{
+	uint8_t b = 0;
+
+	while (a >>= 1)
+		b++;
+
+	return b; /* log2(a) , only for power of 2 numbers */
+}
+
 #else
 #include <stdio.h>
 #include <stdint.h>
 #include <stddef.h>
 #include <stdarg.h>
+
+static inline int32_t adi_api_utils_is_power_of_two(uint64_t x)
+{
+	if (x == 0)
+		return 0;
+
+	while (x != 1) {
+		if (x % 2 != 0)
+			return 0;
+		x = x / 2;
+	}
+
+	return 1;
+}
+
+static inline int32_t adi_api_utils_gcd(int32_t u, int32_t v)
+{
+	uint32_t div;
+	uint32_t common_div = 1;
+
+	if ((u == 0) || (v == 0))
+		return (((u) > (v)) ? (u) : (v));
+
+	for (div = 1; (div <= u) && (div <= v); div++)
+		if (!(u % div) && !(v % div))
+			common_div = div;
+
+	return common_div;
+}
+
+static inline uint32_t adi_api_utils_log2(uint32_t a)
+{
+	uint8_t b = 0;
+
+	while (a >>= 1)
+		b++;
+
+	return b; /* log2(a) , only for power of 2 numbers */
+}
+
 #endif
 #include "adi_cms_api_config.h"
 
@@ -69,7 +131,8 @@ typedef enum {
 	API_CMS_ERROR_LOG_WRITE = -68, /*!< Log write error */
 	API_CMS_ERROR_LOG_CLOSE = -69, /*!< Log close error */
 	API_CMS_ERROR_DELAY_US = -70, /*!< Delay error */
-	API_CMS_ERROR_PD_STBY_PIN_CTRL = -71 /*!< PD STBY function error */
+	API_CMS_ERROR_PD_STBY_PIN_CTRL = -71, /*!< PD STBY function error */
+	API_CMS_ERROR_SYSREF_CTRL = -72 /*!< SYSREF enable function error */
 
 } adi_cms_error_e;
 
@@ -246,6 +309,15 @@ typedef struct {
 	uint8_t jesd_mode_s_sel; /*!< JESD mode S value */
 } adi_cms_jesd_param_t;
 
+/*!
+ * @brief  Enumerate ADI Device Operating Mode
+ */
+typedef enum {
+	TX_ONLY = 1, /*!< Chip using Tx path only */
+	RX_ONLY = 2, /*!< Chip using Rx path only */
+	TX_RX_ONLY = 3 /*!< Chip using Tx + Rx both paths */
+} adi_cms_chip_op_mode_t;
+
 /**
  * @brief  Platform dependent SPI access functions.
  *
@@ -399,6 +471,17 @@ typedef int32_t (*adi_pd_stby_pin_ctrl_t)(void *user_data, uint8_t enable);
  * @return Any non-zero value indicates an error
  */
 typedef int32_t (*adi_reset_pin_ctrl_t)(void *user_data, uint8_t enable);
+
+/**
+ * @brief sysref control function
+ *
+ * @param sysref_clk   A void pointer to a structure containing the clock source
+ *                     required by the function to control the hardware sysref control.
+ *
+ * @return 0 for success
+ * @return Any non-zero value indicates an error
+ */
+typedef int32_t (*adi_sysref_ctrl_t)(void *sysref_clk);
 
 /**
  * @brief   Control function for GPIO write.


### PR DESCRIPTION
version 1.5.0
 * Power savings optimizations and access to Rx Power Controllers
 * Ability to bypass JESD204c calibration and load coefficients manually
 * Support for half rate 2D eye scan

version 1.4.0
 * Optimized ADC bypass path for FBW mode
 * New function adi_ad9081_sync_sysref_input_config_set()
 * Configure the sysref input receiver circuit based on AC/DC coupling, signal type, etc.
 * Quarter rate eye scan debug functionality

version 1.3.1
 * Changed reference name for sysref clock source in adi_adxxxx_device_t struct from clk_src to sysref_clk

version 1.3.0
 * Update missing JES204B lcpll values, adi_adxxxx_jesd_tx_pll_startup, Missing JES204B lcpll values leads to PLL startup issues
 * Added call to bitfield JRX_SYSREF_FOR_STARTUP_I NFO, adi_adxxxx_jesd_rx_link_config_set, JRX_SYSREF_FOR_STARTU P_INFO needs to be enabled when part is in Subclass 1
 * Added call to bitfield BF_JTX_SYSREF_FOR_STARTU P_INFO, adi_adxxxx_jesd_tx_link_config_set, JTX_SYSREF_FOR_STARTU P_INFO needs to be enabled when part is in Subclass 1
 * Modified oneshot sync procedure to include HAL callback that issues a single pulse SYSREF signal, adi_adxxxx_jesd_oneshot_sync, If in single pulse SYSREF mode, procedure requires the pulse to be issued once.
 * Updated sysref monitor mode phase get function to include write strobe and display phase value correctly, adi_adxxxx_jesd_sysref_monitor_p hase_get, Write strobe is needed for sysref phase to trigger a value update. The phase value needed to be correctly calculated from two bitfield reads.
 * Fixed incorrect use of "||" to "&&" in adi_adxxxx_jesd_sysref_irq_jitter_ mux_set(), Parameter check was always failing
 * Modified full bandwidth mode function to support AD9207 and AD9209, with adi_adxxxx_jesd_tx_fbw_sel_set,  AD9207 and AD9209 support full bandwidth mode