### PR TITLE
Maxim UART blocking

### DIFF
--- a/drivers/platform/maxim/max32650/maxim_uart.c
+++ b/drivers/platform/maxim/max32650/maxim_uart.c
@@ -139,17 +139,29 @@ static int32_t max_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
 static int32_t max_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
 			      uint32_t bytes_number)
 {
+	int32_t transfered = 0;
+	int block_size;
 	int32_t ret;
 
 	if(!desc || !data || !bytes_number)
 		return -EINVAL;
 
-	ret = MXC_UART_Write(MXC_UART_GET_UART(desc->device_id), (uint8_t *)data,
-			     (int *)&bytes_number);
-	if (ret != E_SUCCESS)
-		return -EIO;
+	while (bytes_number) {
+		block_size = no_os_min(MXC_UART_FIFO_DEPTH, bytes_number);
+		while(!(MXC_UART_GetStatus(MXC_UART_GET_UART(desc->device_id)) &
+			MXC_F_UART_STAT_TX_EMPTY));
+		ret = MXC_UART_Write(MXC_UART_GET_UART(desc->device_id),
+				     (uint8_t *)(data + transfered),
+				     &block_size);
 
-	return bytes_number;
+		transfered += block_size;
+		bytes_number -= block_size;
+
+		if (ret != E_SUCCESS)
+			return -EIO;
+	}
+
+	return transfered;
 }
 
 /**

--- a/drivers/platform/maxim/max32655/maxim_uart.c
+++ b/drivers/platform/maxim/max32655/maxim_uart.c
@@ -149,17 +149,29 @@ static int32_t max_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
 static int32_t max_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
 			      uint32_t bytes_number)
 {
+	int32_t transfered = 0;
+	int block_size;
 	int32_t ret;
 
 	if(!desc || !data || !bytes_number)
 		return -EINVAL;
 
-	ret = MXC_UART_Write(MXC_UART_GET_UART(desc->device_id), (uint8_t *)data,
-			     (int *)&bytes_number);
-	if (ret != E_SUCCESS)
-		return -EIO;
+	while (bytes_number) {
+		block_size = no_os_min(MXC_UART_FIFO_DEPTH, bytes_number);
+		while(!(MXC_UART_GetStatus(MXC_UART_GET_UART(desc->device_id)) &
+			MXC_F_UART_STATUS_TX_EM));
+		ret = MXC_UART_Write(MXC_UART_GET_UART(desc->device_id),
+				     (uint8_t *)(data + transfered),
+				     &block_size);
 
-	return bytes_number;
+		transfered += block_size;
+		bytes_number -= block_size;
+
+		if (ret != E_SUCCESS)
+			return -EIO;
+	}
+
+	return transfered;
 }
 
 /**

--- a/drivers/platform/maxim/max32660/maxim_uart.c
+++ b/drivers/platform/maxim/max32660/maxim_uart.c
@@ -136,17 +136,29 @@ static int32_t max_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
 static int32_t max_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
 			      uint32_t bytes_number)
 {
+	int32_t transfered = 0;
+	int block_size;
 	int32_t ret;
 
 	if(!desc || !data || !bytes_number)
 		return -EINVAL;
 
-	ret = MXC_UART_Write(MXC_UART_GET_UART(desc->device_id), (uint8_t *)data,
-			     (int *)&bytes_number);
-	if (ret != E_SUCCESS)
-		return -EIO;
+	while (bytes_number) {
+		block_size = no_os_min(MXC_UART_FIFO_DEPTH, bytes_number);
+		while(!(MXC_UART_GetStatus(MXC_UART_GET_UART(desc->device_id)) &
+			MXC_F_UART_STAT_TX_EMPTY));
+		ret = MXC_UART_Write(MXC_UART_GET_UART(desc->device_id),
+				     (uint8_t *)(data + transfered),
+				     &block_size);
 
-	return bytes_number;
+		transfered += block_size;
+		bytes_number -= block_size;
+
+		if (ret != E_SUCCESS)
+			return -EIO;
+	}
+
+	return transfered;
 }
 
 /**

--- a/drivers/platform/maxim/max32690/maxim_uart.c
+++ b/drivers/platform/maxim/max32690/maxim_uart.c
@@ -144,17 +144,29 @@ static int32_t max_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
 static int32_t max_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
 			      uint32_t bytes_number)
 {
+	int32_t transfered = 0;
+	int block_size;
 	int32_t ret;
 
 	if(!desc || !data || !bytes_number)
 		return -EINVAL;
 
-	ret = MXC_UART_Write(MXC_UART_GET_UART(desc->device_id), data,
-			     (int *)&bytes_number);
-	if (ret != E_SUCCESS)
-		return -EIO;
+	while (bytes_number) {
+		block_size = no_os_min(MXC_UART_FIFO_DEPTH, bytes_number);
+		while(!(MXC_UART_GetStatus(MXC_UART_GET_UART(desc->device_id)) &
+			MXC_F_UART_STATUS_TX_EM));
+		ret = MXC_UART_Write(MXC_UART_GET_UART(desc->device_id),
+				     (uint8_t *)(data + transfered),
+				     &block_size);
 
-	return bytes_number;
+		transfered += block_size;
+		bytes_number -= block_size;
+
+		if (ret != E_SUCCESS)
+			return -EIO;
+	}
+
+	return transfered;
 }
 
 /**

--- a/drivers/platform/maxim/max78000/maxim_uart.c
+++ b/drivers/platform/maxim/max78000/maxim_uart.c
@@ -155,7 +155,6 @@ static int32_t max_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
 static int32_t max_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
 			      uint32_t bytes_number)
 {
-	mxc_uart_req_t uart_req;
 	int32_t ret;
 	int32_t transfered = 0;
 	int block_size = 8;


### PR DESCRIPTION
Apply 75cdb79("drivers:platform:max78000: Fix blocking UART Tx") for all the other Maxim targets.