### PR TITLE
drivers:platform:maxim: Fix I2C UB

### DIFF
--- a/drivers/platform/maxim/max32650/maxim_i2c.c
+++ b/drivers/platform/maxim/max32650/maxim_i2c.c
@@ -88,21 +88,21 @@ void I2C2_IRQHandler(void)
  */
 static int32_t _max_i2c_pins_config(uint32_t device_id, mxc_gpio_vssel_t vssel)
 {
-	mxc_gpio_cfg_t *i2c_pins;
+	mxc_gpio_cfg_t i2c_pins;
 
 	switch (device_id) {
 	case 0:
-		i2c_pins = (mxc_gpio_cfg_t *)&gpio_cfg_i2c0;
+		i2c_pins = gpio_cfg_i2c0;
 		break;
 	case 1:
-		i2c_pins = (mxc_gpio_cfg_t *)&gpio_cfg_i2c1;
+		i2c_pins = gpio_cfg_i2c1;
 		break;
 	default:
 		return -EINVAL;
 	}
 
-	i2c_pins->vssel = vssel;
-	MXC_GPIO_Config(i2c_pins);
+	i2c_pins.vssel = vssel;
+	MXC_GPIO_Config(&i2c_pins);
 
 	return 0;
 }

--- a/drivers/platform/maxim/max32655/maxim_i2c.c
+++ b/drivers/platform/maxim/max32655/maxim_i2c.c
@@ -88,24 +88,24 @@ void I2C2_IRQHandler(void)
  */
 static int32_t _max_i2c_pins_config(uint32_t device_id, mxc_gpio_vssel_t vssel)
 {
-	mxc_gpio_cfg_t *i2c_pins;
+	mxc_gpio_cfg_t i2c_pins;
 
 	switch (device_id) {
 	case 0:
-		i2c_pins = (mxc_gpio_cfg_t *)&gpio_cfg_i2c0;
+		i2c_pins = gpio_cfg_i2c0;
 		break;
 	case 1:
-		i2c_pins = (mxc_gpio_cfg_t *)&gpio_cfg_i2c1;
+		i2c_pins = gpio_cfg_i2c1;
 		break;
 	case 2:
-		i2c_pins = (mxc_gpio_cfg_t *)&gpio_cfg_i2c2;
+		i2c_pins = gpio_cfg_i2c2;
 		break;
 	default:
 		return -EINVAL;
 	}
 
-	i2c_pins->vssel = vssel;
-	MXC_GPIO_Config(i2c_pins);
+	i2c_pins.vssel = vssel;
+	MXC_GPIO_Config(&i2c_pins);
 
 	return 0;
 }

--- a/drivers/platform/maxim/max32660/maxim_i2c.c
+++ b/drivers/platform/maxim/max32660/maxim_i2c.c
@@ -89,21 +89,21 @@ void I2C2_IRQHandler(void)
  */
 static int32_t _max_i2c_pins_config(uint32_t device_id, mxc_gpio_vssel_t vssel)
 {
-	mxc_gpio_cfg_t *i2c_pins;
+	mxc_gpio_cfg_t i2c_pins;
 
 	switch (device_id) {
 	case 0:
-		i2c_pins = (mxc_gpio_cfg_t *)&gpio_cfg_i2c0;
+		i2c_pins = gpio_cfg_i2c0;
 		break;
 	case 1:
-		i2c_pins = (mxc_gpio_cfg_t *)&gpio_cfg_i2c1;
+		i2c_pins = gpio_cfg_i2c1;
 		break;
 	default:
 		return -EINVAL;
 	}
 
-	i2c_pins->vssel = vssel;
-	MXC_GPIO_Config(i2c_pins);
+	i2c_pins.vssel = vssel;
+	MXC_GPIO_Config(&i2c_pins);
 
 	return 0;
 }

--- a/drivers/platform/maxim/max32665/maxim_i2c.c
+++ b/drivers/platform/maxim/max32665/maxim_i2c.c
@@ -88,24 +88,24 @@ void I2C2_IRQHandler(void)
  */
 static int32_t _max_i2c_pins_config(uint32_t device_id, mxc_gpio_vssel_t vssel)
 {
-	mxc_gpio_cfg_t *i2c_pins;
+	mxc_gpio_cfg_t i2c_pins;
 
 	switch (device_id) {
 	case 0:
-		i2c_pins = (mxc_gpio_cfg_t *)&gpio_cfg_i2c0;
+		i2c_pins = gpio_cfg_i2c0;
 		break;
 	case 1:
-		i2c_pins = (mxc_gpio_cfg_t *)&gpio_cfg_i2c1;
+		i2c_pins = gpio_cfg_i2c1;
 		break;
 	case 2:
-		i2c_pins = (mxc_gpio_cfg_t *)&gpio_cfg_i2c2;
+		i2c_pins = gpio_cfg_i2c2;
 		break;
 	default:
 		return -EINVAL;
 	}
 
-	i2c_pins->vssel = vssel;
-	MXC_GPIO_Config(i2c_pins);
+	i2c_pins.vssel = vssel;
+	MXC_GPIO_Config(&i2c_pins);
 
 	return 0;
 }

--- a/drivers/platform/maxim/max32690/maxim_i2c.c
+++ b/drivers/platform/maxim/max32690/maxim_i2c.c
@@ -86,24 +86,24 @@ void I2C2_IRQHandler(void)
  */
 static int32_t _max_i2c_pins_config(uint32_t device_id, mxc_gpio_vssel_t vssel)
 {
-	mxc_gpio_cfg_t *i2c_pins;
+	mxc_gpio_cfg_t i2c_pins;
 
 	switch (device_id) {
 	case 0:
-		i2c_pins = (mxc_gpio_cfg_t *)&gpio_cfg_i2c0;
+		i2c_pins = gpio_cfg_i2c0;
 		break;
 	case 1:
-		i2c_pins = (mxc_gpio_cfg_t *)&gpio_cfg_i2c1;
+		i2c_pins = gpio_cfg_i2c1;
 		break;
 	case 2:
-		i2c_pins = (mxc_gpio_cfg_t *)&gpio_cfg_i2c2;
+		i2c_pins = gpio_cfg_i2c2;
 		break;
 	default:
 		return -EINVAL;
 	}
 
-	i2c_pins->vssel = vssel;
-	MXC_GPIO_Config(i2c_pins);
+	i2c_pins.vssel = vssel;
+	MXC_GPIO_Config(&i2c_pins);
 
 	return 0;
 }

--- a/drivers/platform/maxim/max78000/maxim_i2c.c
+++ b/drivers/platform/maxim/max78000/maxim_i2c.c
@@ -87,24 +87,24 @@ void I2C2_IRQHandler(void)
  */
 static int32_t _max_i2c_pins_config(uint32_t device_id, mxc_gpio_vssel_t vssel)
 {
-	mxc_gpio_cfg_t *i2c_pins;
+	mxc_gpio_cfg_t i2c_pins;
 
 	switch (device_id) {
 	case 0:
-		i2c_pins = (mxc_gpio_cfg_t *)&gpio_cfg_i2c0;
+		i2c_pins = gpio_cfg_i2c0;
 		break;
 	case 1:
-		i2c_pins = (mxc_gpio_cfg_t *)&gpio_cfg_i2c1;
+		i2c_pins = gpio_cfg_i2c1;
 		break;
 	case 2:
-		i2c_pins = (mxc_gpio_cfg_t *)&gpio_cfg_i2c2;
+		i2c_pins = gpio_cfg_i2c2;
 		break;
 	default:
 		return -EINVAL;
 	}
 
-	i2c_pins->vssel = vssel;
-	MXC_GPIO_Config(i2c_pins);
+	i2c_pins.vssel = vssel;
+	MXC_GPIO_Config(&i2c_pins);
 
 	return 0;
 }


### PR DESCRIPTION
Similar to 468f2789("drivers:platform:maxim: Fix UART UB"), create a new variable for gpio vssel configuration, instead of pointing to the SDK (const) declared one.