### PR TITLE
Print binary size for Maxim

### DIFF
--- a/tools/scripts/aducm.mk
+++ b/tools/scripts/aducm.mk
@@ -121,6 +121,7 @@ LDFLAGS	= -Wl,--gc-sections -mcpu=cortex-m3 -mthumb -lm
 CC = arm-none-eabi-gcc
 AS = arm-none-eabi-gcc
 AR = arm-none-eabi-ar
+SIZE = arm-none-eabi-size
 
 HEX = $(basename $(BINARY)).hex
 

--- a/tools/scripts/altera.mk
+++ b/tools/scripts/altera.mk
@@ -42,6 +42,7 @@ LSCRIPT = $(BUILD_DIR)/bsp/linker.x
 LIB_PATHS += -L$(BUILD_DIR)/bsp
 
 CC = nios2-elf-gcc 
+SIZE = nios2-elf-size
 
 LD = nios2-elf-g++
 

--- a/tools/scripts/generic.mk
+++ b/tools/scripts/generic.mk
@@ -417,6 +417,7 @@ $(PROJECT_TARGET): $(LIB_TARGETS)
 
 # Platform specific post build dependencies can be added to this rule.
 post_build:
+	$(MUTE) $(SIZE) --format=Berkley $(BINARY) $(HEX)
 
 PHONY += update
 update: $(PROJECT_TARGET)

--- a/tools/scripts/linux.mk
+++ b/tools/scripts/linux.mk
@@ -1,4 +1,5 @@
 CC ?= gcc
+SIZE ?= size
 
 BINARY		= $(BUILD_DIR)/$(PROJECT_NAME).out
 

--- a/tools/scripts/maxim.mk
+++ b/tools/scripts/maxim.mk
@@ -7,6 +7,7 @@ AR=arm-none-eabi-ar
 AS=arm-none-eabi-gcc
 GDB=arm-none-eabi-gdb
 OC=arm-none-eabi-objcopy
+SIZE=arm-none-eabi-size
 
 ifeq ($(OS),Windows_NT)
 PYTHON = python

--- a/tools/scripts/mbed.mk
+++ b/tools/scripts/mbed.mk
@@ -22,6 +22,7 @@ LIB_FLAGS = -Wl,--start-group -lstdc++ -lsupc++ -lm -lc -lgcc -lnosys  -Wl,--end
 CC = arm-none-eabi-gcc
 CPP = arm-none-eabi-g++
 OC = arm-none-eabi-objcopy
+SIZE = arm-none-eabi-size
 
 # Project related build Files
 LSCRIPT = $(BUILD_DIR)/$(PROJECT_NAME)-linker-file.ld

--- a/tools/scripts/pico.mk
+++ b/tools/scripts/pico.mk
@@ -17,6 +17,7 @@ AR=arm-none-eabi-ar
 AS=arm-none-eabi-gcc
 GDB=gdb-multiarch
 OC=arm-none-eabi-objcopy	
+SIZE=arm-none-eabi-size
 
 # ELF2UF2 is used to convert elf binary in uf2 format
 # For flashing UF2 file can be dragged onto USB Mass Storage Device 

--- a/tools/scripts/stm32.mk
+++ b/tools/scripts/stm32.mk
@@ -136,6 +136,7 @@ AS = arm-none-eabi-gcc
 CC = arm-none-eabi-gcc
 GDB = arm-none-eabi-gdb
 OC = arm-none-eabi-objcopy
+SIZE=arm-none-eabi-size
 
 .PHONY: $(BINARY).openocd
 $(BINARY).openocd:

--- a/tools/scripts/xilinx.mk
+++ b/tools/scripts/xilinx.mk
@@ -61,6 +61,7 @@ ifneq (,$(findstring cortexa9,$(strip $(ARCH))))
 
 CC := arm-none-eabi-gcc
 AR := arm-none-eabi-ar
+SIZE := arm-none-eabi-size
 
 LD := $(CC)
 
@@ -83,6 +84,7 @@ ifneq (,$(findstring cortexa53,$(strip $(ARCH))))
 
 CC := aarch64-none-elf-gcc
 AR := aarch64-none-elf-ar
+SIZE := aarch64-none-elf-size
 
 LD := $(CC)
 endif
@@ -91,6 +93,7 @@ ifneq (,$(findstring cortexr5,$(strip $(ARCH))))
 
 CC := armr5-none-eabi-gcc 
 AR := armr5-none-eabi-ar
+SIZE := armr5-none-eabi-size
 
 LD := $(CC)
 
@@ -111,6 +114,7 @@ ifneq (,$(findstring cortexa72,$(strip $(ARCH))))
 
 CC := aarch64-none-elf-gcc
 AR := aarch64-none-elf-ar
+SIZE := aarch64-none-elf-size
 
 LD := $(CC)
 endif
@@ -123,9 +127,11 @@ ifneq (,$(findstring sys_mb,$(strip $(ARCH))))
 ifeq ($(OS), Windows_NT)
 CC := mb-gcc
 AR := mb-ar
+SIZE := mb-size
 else
 CC := microblaze-xilinx-elf-gcc
 AR := microblaze-xilinx-elf-ar
+SIZE := microblaze-xilinx-elf-size
 endif
 
 LD := $(CC)


### PR DESCRIPTION
Print the executable size (for .hex and .elf) after the compilation for Maxim platform.