### PR TITLE
build_projects.yml: fix publish artifacts issues 

### DIFF
--- a/build_projects.yml
+++ b/build_projects.yml
@@ -34,7 +34,7 @@ jobs:
     condition: eq(variables.isMaster, true)
     inputs:
       targetPath: '$(Build.Repository.LocalPath)/$(RELEASE_DIR)'
-      artifact: '$(ARTIFACT_NAME)'
+      artifact: '$(ARTIFACT_NAME)_Xilinx'
       publishLocation: 'pipeline'
   - task: PublishPipelineArtifact@1
     condition: true
@@ -65,7 +65,7 @@ jobs:
     condition: eq(variables.isMaster, true)
     inputs:
       targetPath: '$(Build.Repository.LocalPath)/$(RELEASE_DIR)'
-      artifact: '$(ARTIFACT_NAME)'
+      artifact: '$(ARTIFACT_NAME)_STM32'
       publishLocation: 'pipeline'
   - task: PublishPipelineArtifact@1
     condition: true
@@ -96,7 +96,7 @@ jobs:
     condition: eq(variables.isMaster, true)
     inputs:
       targetPath: '$(Build.Repository.LocalPath)/$(RELEASE_DIR)'
-      artifact: '$(ARTIFACT_NAME)'
+      artifact: '$(ARTIFACT_NAME)_Maxim'
       publishLocation: 'pipeline'
   - task: PublishPipelineArtifact@1
     condition: true
@@ -127,7 +127,7 @@ jobs:
     condition: eq(variables.isMaster, true)
     inputs:
       targetPath: '$(Build.Repository.LocalPath)/$(RELEASE_DIR)'
-      artifact: '$(ARTIFACT_NAME)'
+      artifact: '$(ARTIFACT_NAME)_Mbed'
       publishLocation: 'pipeline'
   - task: PublishPipelineArtifact@1
     condition: true
@@ -158,7 +158,7 @@ jobs:
     condition: eq(variables.isMaster, true)
     inputs:
       targetPath: '$(Build.Repository.LocalPath)/$(RELEASE_DIR)'
-      artifact: '$(ARTIFACT_NAME)'
+      artifact: '$(ARTIFACT_NAME)_Pico'
       publishLocation: 'pipeline'
   - task: PublishPipelineArtifact@1
     condition: true
@@ -189,7 +189,7 @@ jobs:
     condition: eq(variables.isMaster, true)
     inputs:
       targetPath: '$(Build.Repository.LocalPath)/$(RELEASE_DIR)'
-      artifact: '$(ARTIFACT_NAME)'
+      artifact: '$(ARTIFACT_NAME)_ADuCM3029'
       publishLocation: 'pipeline'
   - task: PublishPipelineArtifact@1
     condition: true


### PR DESCRIPTION
After recent restructure of the projects build infrastructure, multiple
jobs produce artifacts under the same $(ARTIFACT_NAME) path.

This causes errors in the PublishPipelineArtifact stage of each job.

Similar to the logs handling for each job, add a platform suggestive
prefix for the artifacts.

Fixes: https://github.com/analogdevicesinc/no-OS/commit/5490fa4598801b4f5581fdbd447b662d91c6971e ("CI:configure new agent for projects build")
Signed-off-by: Antoniu Miclaus <antoniu.miclaus@analog.com>