### PR TITLE
add no-OS project name to iio context description

### DIFF
--- a/iio/iio.c
+++ b/iio/iio.c
@@ -109,8 +109,9 @@ static char header[] =
 	"<!ATTLIST debug-attribute name CDATA #REQUIRED>"
 	"<!ATTLIST buffer-attribute name CDATA #REQUIRED>"
 	"]>"
-	"<context name=\"xml\" description=\"no-OS "
-	NO_OS_TOSTRING(NO_OS_VERSION) "\" >";
+	"<context name=\"xml\" description=\"no-OS/projects/"
+	NO_OS_TOSTRING(NO_OS_PROJECT)" "
+	NO_OS_TOSTRING(NO_OS_VERSION)"\" >";
 static char header_end[] = "</context>";
 
 static const char * const iio_chan_type_string[] = {

--- a/tools/scripts/generic_variables.mk
+++ b/tools/scripts/generic_variables.mk
@@ -29,7 +29,8 @@ PLATFORM_DRIVERS	?= $(NO-OS)/drivers/platform/$(PLATFORM)
 GIT_VERSION := $(shell git describe --all --long --dirty=-modified)
 GIT_VERSION := $(subst heads/,,$(GIT_VERSION))
 GIT_VERSION := $(subst -0-g,-,$(GIT_VERSION))
-CFLAGS := -DNO_OS_VERSION=$(GIT_VERSION)
+CFLAGS := -DNO_OS_VERSION=$(GIT_VERSION) \
+		-DNO_OS_PROJECT=$(notdir $(PROJECT))
 #------------------------------------------------------------------------------
 #                          EVALUATE PLATFORM
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Add no-OS project name to the iio context description.

libiio v0.25 now handles the context description correctly with the serial backend by displaying it as-is instead of replacing it with other information.

This is useful to iio apps that need to know what firmware is running on the board (project name, git tag, revision).