### PR TITLE
Dma example support versal

### DIFF
--- a/legacy/scripts/xilinx_capture.tcl
+++ b/legacy/scripts/xilinx_capture.tcl
@@ -125,7 +125,7 @@ for {set index 1} {$index < $num_of_samples} {incr index 2} {
 		set sample [expr {$data & 0xFFFFFF}]
 		if { $num_of_channels == 1 } {
 			puts $f($ch_x_index) $sample
-		} else
+		} else {
 			for {set n 1} {$n < $num_of_channels } {incr n 1} {
 				if {$ch_x_index < $num_of_channels} {
 					set ch_x_index [expr $ch_x_index + 1]
@@ -140,6 +140,7 @@ for {set index 1} {$index < $num_of_samples} {incr index 2} {
 					set sample [expr {$data & 0xFFFFFF}]
 				}
 			}
+		}
 	} else {
 		puts "ERROR: Unsupported number of bits/sample"
 		exit

--- a/legacy/scripts/xilinx_capture.tcl
+++ b/legacy/scripts/xilinx_capture.tcl
@@ -26,6 +26,10 @@ if {$m_type == "MICROBLAZE"} {
   targets -set -filter {name =~ "*MicroBlaze #0*"}
 }
 
+if {$m_type == "VERSAL"} {
+  targets -set -filter {name =~ "*A72*#0*"}
+}
+
 after 1000
 
 if { $storage_bits  == "" } {


### PR DESCRIPTION
Add support for Versal in the script that downloads memory contents from the device.