### PR TITLE
ad3552r_fmcz:srcs:main.c Update project

### DIFF
--- a/projects/ad3552r_fmcz/srcs/main.c
+++ b/projects/ad3552r_fmcz/srcs/main.c
@@ -147,7 +147,7 @@ int32_t run_example(struct ad3552r_desc *dac)
 		no_os_udelay(time_between_samples_us);
 
 		i = (i + 1) % nb_samples;
-		err = ad3552r_ldac_trigger(dac, AD3552R_MASK_ALL_CH);
+		err = ad3552r_ldac_trigger(dac, AD3552R_MASK_ALL_CH, false);
 	} while (!NO_OS_IS_ERR_VALUE(err));
 
 	return err;


### PR DESCRIPTION
Update project following driver changes: function ad3552r_ldac_trigger now has an extra input parameter.

Fixes: 6718061 ("drivers:dac:ad3552r: Update ad3552r driver")