### PR TITLE
MAX14906 driver

### DIFF
--- a/drivers/digital-io/max14906/iio_max14906.c
+++ b/drivers/digital-io/max14906/iio_max14906.c
@@ -1,0 +1,640 @@
+/***************************************************************************//**
+ *   @file   iio_max14906.c
+ *   @brief  Source file of IIO MAX14906 Driver.
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include "no_os_alloc.h"
+#include "no_os_error.h"
+#include "no_os_units.h"
+#include "no_os_util.h"
+
+#include "max14906.h"
+#include "iio_max14906.h"
+
+#define MAX14906_CHANNEL(_addr)			\
+        {					\
+            	.ch_type = IIO_VOLTAGE,		\
+        	.indexed = 1,			\
+		.channel = _addr,		\
+	    	.address = _addr,		\
+	}
+
+static int max14906_iio_read_raw(void *dev, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel, intptr_t priv);
+static int max14906_iio_write_raw(void *dev, char *buf, uint32_t len,
+				  const struct iio_ch_info *channel, intptr_t priv);
+static int max14906_iio_read_offset(void *dev, char *buf, uint32_t len,
+				    const struct iio_ch_info *channel, intptr_t priv);
+static int max14906_iio_read_scale(void *dev, char *buf, uint32_t len,
+				   const struct iio_ch_info *channel, intptr_t priv);
+static int max14906_iio_read_do_mode(void *dev, char *buf, uint32_t len,
+				     const struct iio_ch_info *channel, intptr_t priv);
+static int max14906_iio_read_do_mode_avail(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv);
+static int max14906_iio_write_do_mode(void *dev, char *buf, uint32_t len,
+				      const struct iio_ch_info *channel, intptr_t priv);
+static int max14906_iio_read_climit(void *dev, char *buf, uint32_t len,
+				    const struct iio_ch_info *channel, intptr_t priv);
+static int max14906_iio_write_climit(void *dev, char *buf, uint32_t len,
+				     const struct iio_ch_info *channel, intptr_t priv);
+static int max14906_iio_read_climit_avail(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv);
+static int max14906_iio_read_config_iec(void *dev, char *buf, uint32_t len,
+					const struct iio_ch_info *channel, intptr_t priv);
+static int max14906_iio_write_config_iec(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel, intptr_t priv);
+static int max14906_iio_read_config_iec_available(void *dev, char *buf,
+		uint32_t len, const struct iio_ch_info *channel,
+		intptr_t priv);
+
+static int max14906_iio_reg_read(struct max14906_iio_desc *, uint32_t,
+				 uint32_t *);
+static int max14906_iio_reg_write(struct max14906_iio_desc *, uint32_t,
+				  uint32_t);
+
+static const uint32_t max14906_limit_avail[4] = {600, 130, 300, 1200};
+
+static struct iio_attribute max14906_out_attrs[] = {
+	{
+		.name = "raw",
+		.show = max14906_iio_read_raw,
+		.store = max14906_iio_write_raw,
+	},
+	{
+		.name = "offset",
+		.show = max14906_iio_read_offset,
+	},
+	{
+		.name = "scale",
+		.show = max14906_iio_read_scale,
+	},
+	{
+		.name = "do_mode",
+		.show = max14906_iio_read_do_mode,
+		.store = max14906_iio_write_do_mode,
+	},
+	{
+		.name = "do_mode_available",
+		.shared = IIO_SHARED_BY_ALL,
+		.show = max14906_iio_read_do_mode_avail
+	},
+	{
+		.name = "current_limit",
+		.show = max14906_iio_read_climit,
+		.store = max14906_iio_write_climit,
+	},
+	{
+		.name = "current_limit_available",
+		.shared = IIO_SHARED_BY_ALL,
+		.show = max14906_iio_read_climit_avail
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_attribute max14906_in_attrs[] = {
+	{
+		.name = "raw",
+		.show = max14906_iio_read_raw,
+		.store = max14906_iio_write_raw,
+	},
+	{
+		.name = "offset",
+		.show = max14906_iio_read_offset,
+	},
+	{
+		.name = "scale",
+		.show = max14906_iio_read_scale,
+	},
+	{
+		.name = "IEC_type",
+		.shared = IIO_SHARED_BY_DIR,
+		.show = max14906_iio_read_config_iec,
+		.store = max14906_iio_write_config_iec,
+	},
+	{
+		.name = "IEC_type_available",
+		.show = max14906_iio_read_config_iec_available,
+	},
+
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_device max14906_iio_dev = {
+	.debug_reg_read = (int32_t (*)())max14906_iio_reg_read,
+	.debug_reg_write = (int32_t (*)())max14906_iio_reg_write,
+};
+
+/**
+ * @brief Read the raw attribute for a specific channel
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max14906_iio_read_raw(void *dev, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct max14906_iio_desc *desc = dev;
+	uint32_t val;
+	int ret;
+
+	ret = max14906_ch_get(desc->max14906_desc, channel->address, &val);
+	if (ret)
+		return ret;
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, (int32_t *)&val);
+}
+
+/**
+ * @brief Write the raw attribute for a specific channel
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max14906_iio_write_raw(void *dev, char *buf, uint32_t len,
+				  const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct max14906_iio_desc *desc = dev;
+	int32_t val;
+
+	if (!channel->ch_out)
+		return -EINVAL;
+
+	iio_parse_value(buf, IIO_VAL_INT, &val, NULL);
+
+	return max14906_ch_set(desc->max14906_desc, channel->address, val);
+}
+
+/**
+ * @brief Read the offset attribute for a specific channel.
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max14906_iio_read_offset(void *dev, char *buf, uint32_t len,
+				    const struct iio_ch_info *channel, intptr_t priv)
+{
+	int32_t val = 0;
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+}
+
+/**
+ * @brief Read the scale attribute for a specific channel.
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max14906_iio_read_scale(void *dev, char *buf, uint32_t len,
+				   const struct iio_ch_info *channel, intptr_t priv)
+{
+	int32_t val = 1;
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+}
+
+/**
+ * @brief Read the do_mode attribute for a specific channel.
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max14906_iio_read_do_mode(void *dev, char *buf, uint32_t len,
+				     const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct max14906_iio_desc *iio_desc = dev;
+	struct max14906_desc *desc = iio_desc->max14906_desc;
+	uint32_t val;
+	int ret;
+
+	ret = max14906_reg_read(desc, MAX14906_CONFIG_DO_REG, &val);
+	if (ret)
+		return ret;
+
+	val = no_os_field_get(MAX14906_DO_MASK(channel->address), val);
+
+	return sprintf(buf, "%s", max14906_do_mode_avail[val]);
+}
+
+/**
+ * @brief Get the list of available values for the do_mode attribute.
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max14906_iio_read_do_mode_avail(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	int length = 0;
+	int i;
+
+	for (i = 0; i < 4; i++)
+		length += sprintf(buf + length, "%s ", max14906_do_mode_avail[i]);
+
+	return length;
+}
+
+/**
+ * @brief Write the do_mode attribute for a specific channel.
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max14906_iio_write_do_mode(void *dev, char *buf, uint32_t len,
+				      const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct max14906_iio_desc *iio_desc = dev;
+	struct max14906_desc *desc = iio_desc->max14906_desc;
+	uint32_t i;
+
+	for (i = 0; i < NO_OS_ARRAY_SIZE(max14906_do_mode_avail); i++)
+		if (!strcmp(buf, max14906_do_mode_avail[i]))
+			break;
+
+	if (i == NO_OS_ARRAY_SIZE(max14906_do_mode_avail))
+		return -EINVAL;
+
+	i = no_os_field_prep(MAX14906_DO_MASK(channel->address), i);
+
+	return max14906_reg_update(desc, MAX14906_CONFIG_DO_REG,
+				   MAX14906_DO_MASK(channel->address), i);
+}
+
+/**
+ * @brief Read the current_limit attribute for a specific channel.
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max14906_iio_read_climit(void *dev, char *buf, uint32_t len,
+				    const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct max14906_iio_desc *iio_desc = dev;
+	struct max14906_desc *desc = iio_desc->max14906_desc;
+	uint32_t current_limit;
+	int ret;
+
+	ret = max14906_reg_read(desc, MAX14906_CONFIG_CURR_LIM, &current_limit);
+	if (ret)
+		return ret;
+
+	current_limit = no_os_field_get(MAX14906_CL_MASK(channel->ch_num),
+					current_limit);
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1,
+				(int32_t *)&max14906_limit_avail[current_limit]);
+}
+
+/**
+ * @brief Write the current_limit attribute for a specific channel.
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max14906_iio_write_climit(void *dev, char *buf, uint32_t len,
+				     const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct max14906_iio_desc *iio_desc = dev;
+	struct max14906_desc *desc = iio_desc->max14906_desc;
+	uint32_t val;
+	uint32_t i;
+
+	iio_parse_value(buf, IIO_VAL_INT, (int32_t *)&val, NULL);
+
+	for (i = 0; i < NO_OS_ARRAY_SIZE(max14906_limit_avail) ; i++) {
+		if (val == max14906_limit_avail[i])
+			break;
+
+		if (i == NO_OS_ARRAY_SIZE(max14906_limit_avail) - 1)
+			return -EINVAL;
+	}
+
+	return max14906_reg_update(desc, MAX14906_CONFIG_CURR_LIM,
+				   MAX14906_CL_MASK(channel->ch_num),
+				   no_os_field_prep(MAX14906_CL_MASK(channel->ch_num), i));
+}
+
+/**
+ * @brief Get the list of available values for the current_limit attribute.
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max14906_iio_read_climit_avail(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	uint32_t length = 0;
+	uint32_t i;
+
+	for (i = 0; i < NO_OS_ARRAY_SIZE(max14906_limit_avail); i++)
+		length += sprintf(buf + length, "%d ", max14906_limit_avail[i]);
+
+	return length;
+}
+
+/**
+ * @brief Read the IEC_type attribute for a specific channel.
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max14906_iio_read_config_iec(void *dev, char *buf, uint32_t len,
+					const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct max14906_iio_desc *iio_desc = dev;
+	enum max14906_iec_type iec_type;
+	struct max14906_desc *desc;
+	uint32_t val;
+	int ret;
+
+	desc = iio_desc->max14906_desc;
+	ret = max14906_reg_read(desc, MAX14906_CONFIG_DI_REG, &val);
+	if (ret)
+		return ret;
+
+	iec_type = no_os_field_get(MAX14906_IEC_TYPE_MASK, val);
+	strcpy(buf, max14906_iec_avail[iec_type]);
+
+	return strlen(buf);
+}
+
+/**
+ * @brief Write the IEC_type attribute for a specific channel.
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max14906_iio_write_config_iec(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct max14906_iio_desc *iio_desc = dev;
+	enum max14906_iec_type iec_type;
+	struct max14906_desc *desc;
+	uint8_t val;
+	size_t i;
+
+	desc = iio_desc->max14906_desc;
+	for (i = 0; i < NO_OS_ARRAY_SIZE(max14906_iec_avail); i++) {
+		if (!strcmp(buf, max14906_iec_avail[i])) {
+			iec_type = i;
+			break;
+		}
+
+		if (i == NO_OS_ARRAY_SIZE(max14906_iec_avail) - 1)
+			return -EINVAL;
+	}
+
+	val = no_os_field_prep(MAX14906_IEC_TYPE_MASK, iec_type);
+
+	return max14906_reg_update(desc, MAX14906_CONFIG_DI_REG,
+				   MAX14906_IEC_TYPE_MASK, val);
+}
+
+/**
+ * @brief Get a list of available values for the IEC_type attribute.
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max14906_iio_read_config_iec_available(void *dev, char *buf,
+		uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	uint32_t avail_size = NO_OS_ARRAY_SIZE(max14906_iec_avail);
+	uint32_t length = 0;
+	uint32_t i;
+
+	for (i = 0; i < avail_size; i++)
+		length += sprintf(buf + length, "%s ", max14906_iec_avail[i]);
+
+	return length;
+}
+
+/**
+ * @brief Configure a set if IIO channels based on the operation modes of the enabled
+ * physical channels.
+ * @param desc - The iio device descriptor.
+ * @return 0 in case of success, an error code otherwise.
+ */
+int max14906_iio_setup_channels(struct max14906_iio_desc *desc)
+{
+	struct iio_channel *max14906_iio_channels;
+	uint32_t enabled_ch = 0;
+	uint32_t ch_offset = 0;
+	uint32_t i;
+	int ret;
+
+	for (i = 0; i < MAX14906_CHANNELS; i++)
+		if (desc->channel_configs[i].enabled)
+			enabled_ch++;
+
+	max14906_iio_channels = no_os_calloc(enabled_ch,
+					     sizeof(*max14906_iio_channels));
+	if (!max14906_iio_channels)
+		return -ENOMEM;
+
+	for (i = 0; i < MAX14906_CHANNELS; i++) {
+		if (!desc->channel_configs[i].enabled ||
+		    desc->channel_configs[i].function == MAX14906_HIGH_Z) {
+			ret = max14906_ch_func(desc->max14906_desc, i, MAX14906_HIGH_Z);
+			if (ret)
+				goto free_channels;
+			continue;
+		}
+
+		max14906_iio_channels[ch_offset] = (struct iio_channel)MAX14906_CHANNEL(i);
+
+		/* Set the direction and attributes based on configuration */
+		if (desc->channel_configs[i].function == MAX14906_IN) {
+			max14906_iio_channels[ch_offset].attributes = max14906_in_attrs;
+			max14906_iio_channels[ch_offset].ch_out = 0;
+		} else {
+			max14906_iio_channels[ch_offset].attributes = max14906_out_attrs;
+			max14906_iio_channels[ch_offset].ch_out = 1;
+		}
+
+		ch_offset++;
+		ret = max14906_ch_func(desc->max14906_desc, i,
+				       desc->channel_configs[i].function);
+		if (ret)
+			goto free_channels;
+	}
+
+	desc->iio_dev->channels = max14906_iio_channels;
+	desc->iio_dev->num_ch = enabled_ch;
+
+	return 0;
+
+free_channels:
+	no_os_free(max14906_iio_channels);
+
+	return ret;
+}
+
+/**
+ * @brief Register read wrapper
+ * @param dev - The iio device structure.
+ * @param reg - The register's address.
+ * @param readval - Register value
+ * @return 0 in case of success, error code otherwise
+ */
+static int max14906_iio_reg_read(struct max14906_iio_desc *dev, uint32_t reg,
+				 uint32_t *readval)
+{
+	return max14906_reg_read(dev->max14906_desc, reg, readval);
+}
+
+/**
+ * @brief Register write wrapper
+ * @param dev - The iio device structure.
+ * @param reg - The register's address.
+ * @param readval - Register value
+ * @return 0 in case of success, error code otherwise
+ */
+static int max14906_iio_reg_write(struct max14906_iio_desc *dev, uint32_t reg,
+				  uint32_t writeval)
+{
+	return max14906_reg_write(dev->max14906_desc, reg, writeval);
+}
+
+/**
+ * @brief Initializes the MAX14906 IIO descriptor.
+ * @param iio_desc - The iio device descriptor.
+ * @param init_param - The structure that contains the device initial parameters.
+ * @return 0 in case of success, an error code otherwise.
+ */
+int max14906_iio_init(struct max14906_iio_desc **iio_desc,
+		      struct max14906_iio_desc_init_param *init_param)
+{
+	struct max14906_iio_desc *descriptor;
+	int ret;
+
+	if (!init_param || !init_param->max14906_init_param)
+		return -EINVAL;
+
+	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	ret = max14906_init(&descriptor->max14906_desc,
+			    init_param->max14906_init_param);
+	if (ret)
+		goto free_desc;
+
+	descriptor->iio_dev = &max14906_iio_dev;
+
+	memcpy(&descriptor->channel_configs, &init_param->channel_configs,
+	       sizeof(descriptor->channel_configs));
+	ret = max14906_iio_setup_channels(descriptor);
+	if (ret)
+		goto free_dev;
+
+	*iio_desc = descriptor;
+
+	return 0;
+
+free_dev:
+	max14906_remove(descriptor->max14906_desc);
+free_desc:
+	no_os_free(descriptor);
+
+	return ret;
+}
+
+/**
+ * @brief Free resources allocated by the init function.
+ * @param iio_desc - The iio device descriptor.
+ * @return 0 in case of success, an error code otherwise.
+ */
+int max14906_iio_remove(struct max14906_iio_desc *iio_desc)
+{
+	if (!iio_desc)
+		return -ENODEV;
+
+	no_os_free(iio_desc->iio_dev->channels);
+	max14906_remove(iio_desc->max14906_desc);
+	no_os_free(iio_desc);
+
+	iio_desc = NULL;
+
+	return 0;
+}

--- a/drivers/digital-io/max14906/iio_max14906.h
+++ b/drivers/digital-io/max14906/iio_max14906.h
@@ -1,0 +1,102 @@
+/***************************************************************************//**
+ *   @file   iio_max14906.h
+ *   @brief  Header file of MAX14906 IIO Driver.
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef IIO_MAX14906_H
+#define IIO_MAX14906_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "iio.h"
+#include "max14906.h"
+
+#define MAX14906_FUNCTION_CNT	3
+
+/**
+ * @brief Available functions for each channel of the device.
+ */
+static const char *const max14906_function_avail[MAX14906_FUNCTION_CNT] = {
+	[MAX14906_OUT] = "output",
+	[MAX14906_IN] = "input",
+	[MAX14906_HIGH_Z] = "high_z"
+};
+
+/**
+ * @brief Available values for the do_mode attribute.
+ */
+static const char *const max14906_do_mode_avail[4] = {
+	[MAX14906_HIGH_SIDE] = "High_side",
+	[MAX14906_HIGH_SIDE_INRUSH] = "High_side_2x_inrush",
+	[MAX14906_PUSH_PULL_CLAMP] = "Push_pull_clamp",
+	[MAX14906_PUSH_PULL] = "Push_pull",
+};
+
+/**
+ * @brief Available values for the IEC_type attribute.
+ */
+static const char *const max14906_iec_avail[2] = {
+	"Type_1_3",
+	"Type_2"
+};
+
+/**
+ * @brief MAX14906 specific IIO descriptor.
+ */
+struct max14906_iio_desc {
+	struct max14906_desc *max14906_desc;
+	struct iio_device *iio_dev;
+	uint32_t active_channels;
+	uint32_t no_active_channels;
+	struct max14906_ch_config channel_configs[MAX14906_CHANNELS];
+};
+
+/**
+ * @brief Initialization parameter for the MAX14906 IIO descriptor.
+ */
+struct max14906_iio_desc_init_param {
+	struct max14906_init_param *max14906_init_param;
+	struct max14906_ch_config channel_configs[MAX14906_CHANNELS];
+};
+
+/** Initializes the MAX14906 IIO descriptor */
+int max14906_iio_init(struct max14906_iio_desc **,
+		      struct max14906_iio_desc_init_param *);
+
+/** Free resources allocated by the init function */
+int max14906_iio_remove(struct max14906_iio_desc *);
+
+#endif /* IIO_MAX14906_H */

--- a/drivers/digital-io/max14906/max14906.c
+++ b/drivers/digital-io/max14906/max14906.c
@@ -1,0 +1,415 @@
+/***************************************************************************//**
+ *   @file   max14906.c
+ *   @brief  Source file of MAX14906 Driver.
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include "max14906.h"
+#include "no_os_util.h"
+#include "no_os_alloc.h"
+
+/**
+ * @brief Compute the CRC5 value for an array of bytes when writing to MAX14906
+ * @param data - array of data to encode
+ * @return the resulted CRC5
+ */
+static uint8_t max14906_crc(uint8_t *data, bool encode)
+{
+	uint8_t crc5_start = 0x1f;
+	uint8_t crc5_poly = 0x15;
+	uint8_t crc5_result = crc5_start;
+	uint8_t extra_byte = 0x00;
+	uint8_t data_bit;
+	uint8_t result_bit;
+	int i;
+
+	/*
+	 * This is a custom implementation of a CRC5 algorithm, detailed here:
+	 * https://www.analog.com/en/app-notes/how-to-program-the-max14906-quadchannel-industrial-digital-output-digital-input.html
+	 */
+
+	for (i = (encode) ? 0 : 2; i < 8; i++) {
+		data_bit = (data[0] >> (7 - i)) & 0x01;
+		result_bit = (crc5_result & 0x10) >> 4;
+		if (data_bit ^ result_bit)
+			crc5_result = crc5_poly ^ ((crc5_result << 1) & 0x1f);
+		else
+			crc5_result = (crc5_result << 1) & 0x1f;
+	}
+
+	for (i = 0; i < 8; i++) {
+		data_bit = (data[1] >> (7 - i)) & 0x01;
+		result_bit = (crc5_result & 0x10) >> 4;
+		if (data_bit ^ result_bit)
+			crc5_result = crc5_poly ^ ((crc5_result << 1) & 0x1f);
+		else
+			crc5_result = (crc5_result << 1) & 0x1f;
+	}
+
+	for (i = 0; i < 3; i++) {
+		data_bit = (extra_byte >> (7 - i)) & 0x01;
+		result_bit = (crc5_result & 0x10) >> 4;
+		if (data_bit ^ result_bit)
+			crc5_result = crc5_poly ^ ((crc5_result << 1) & 0x1f);
+		else
+			crc5_result = (crc5_result << 1) & 0x1f;
+	}
+
+	return crc5_result;
+}
+
+/**
+ * @brief Write the value of a device register
+ * @param desc - device descriptor for the MAX14906
+ * @param addr - address of the register
+ * @param val - value of the register
+ * @return 0 in case of success, negative error code otherwise
+ */
+int max14906_reg_write(struct max14906_desc *desc, uint32_t addr, uint32_t val)
+{
+	struct no_os_spi_msg xfer = {
+		.tx_buff = desc->buff,
+		.bytes_number = MAX14906_FRAME_SIZE,
+		.cs_change = 1,
+	};
+
+	desc->buff[0] = no_os_field_prep(MAX14906_CHIP_ADDR_MASK, desc->chip_address) |
+			no_os_field_prep(MAX14906_ADDR_MASK, addr) |
+			no_os_field_prep(MAX14906_RW_MASK, 1);
+	desc->buff[1] = val;
+
+	if (desc->crc_en) {
+		xfer.bytes_number++;
+		desc->buff[2] = max14906_crc(desc->buff, true);
+	}
+
+	return no_os_spi_transfer(desc->comm_desc, &xfer, 1);
+}
+
+/**
+ * @brief Read the value of a device register
+ * @param desc - device descriptor for the MAX14906
+ * @param addr - address of the register
+ * @param val - value of the register
+ * @return 0 in case of success, negative error code otherwise
+ */
+int max14906_reg_read(struct max14906_desc *desc, uint32_t addr, uint32_t *val)
+{
+	struct no_os_spi_msg xfer = {
+		.tx_buff = desc->buff,
+		.rx_buff = desc->buff,
+		.bytes_number = MAX14906_FRAME_SIZE,
+		.cs_change = 1,
+	};
+	uint8_t crc;
+	int ret;
+
+	if (desc->crc_en)
+		xfer.bytes_number++;
+
+	memset(desc->buff, 0, xfer.bytes_number);
+	desc->buff[0] = no_os_field_prep(MAX14906_CHIP_ADDR_MASK, desc->chip_address) |
+			no_os_field_prep(MAX14906_ADDR_MASK, addr) |
+			no_os_field_prep(MAX14906_RW_MASK, 0);
+
+	if (desc->crc_en)
+		desc->buff[2] = max14906_crc(&desc->buff[0], true);
+
+	ret = no_os_spi_transfer(desc->comm_desc, &xfer, 1);
+	if (ret)
+		return ret;
+
+	if (desc->crc_en) {
+		crc = max14906_crc(&desc->buff[0], false);
+		if (crc != desc->buff[2])
+			return -EINVAL;
+	}
+
+	*val = desc->buff[1];
+
+	return 0;
+}
+
+/**
+ * @brief Update the value of a device register (read/write sequence).
+ * @param desc - device descriptor for the MAX14906
+ * @param addr - address of the register
+ * @param mask - bit mask of the field to be updated
+ * @param val - value of the masked field. Should be bit shifted by using
+ * 		 no_os_field_prep(mask, val)
+ * @return 0 in case of success, negative error code otherwise
+ */
+int max14906_reg_update(struct max14906_desc *desc, uint32_t addr,
+			uint32_t mask, uint32_t val)
+{
+	int ret;
+	uint32_t reg_val = 0;
+
+	ret = max14906_reg_read(desc, addr, &reg_val);
+	if (ret)
+		return ret;
+
+	reg_val &= ~mask;
+	reg_val |= mask & val;
+
+	return max14906_reg_write(desc, addr, reg_val);
+}
+
+/**
+ * @brief Read the (voltage) state of a channel (works for both input or output).
+ * @param desc - device descriptor for the MAX14906
+ * @param ch - channel index (0 based).
+ * @param val - binary value representing a channel's voltage level (0 or 1).
+ * @return 0 in case of success, negative error code otherwise
+ */
+int max14906_ch_get(struct max14906_desc *desc, uint32_t ch, uint32_t *val)
+{
+	int ret;
+
+	if (ch >= MAX14906_CHANNELS)
+		return -EINVAL;
+
+	ret = max14906_reg_read(desc, MAX14906_DOILEVEL_REG, val);
+	if (ret)
+		return ret;
+
+	*val = no_os_field_get(MAX14906_DOI_LEVEL_MASK(ch), *val);
+
+	return 0;
+}
+
+/**
+ * @brief Write the (logic) state of a channel (only for output channels).
+ * @param desc - device descriptor for the MAX14906
+ * @param ch - channel index (0 based).
+ * @param val - binary value representing a channel's voltage level (0 or 1).
+ * @return 0 in case of success, negative error code otherwise
+ */
+int max14906_ch_set(struct max14906_desc *desc, uint32_t ch, uint32_t val)
+{
+	if (ch >= MAX14906_CHANNELS)
+		return -EINVAL;
+
+	return max14906_reg_update(desc, MAX14906_SETOUT_REG,
+				   MAX14906_HIGHO_MASK(ch), (val) ?
+				   MAX14906_HIGHO_MASK(ch) : 0);
+}
+
+/**
+ * @brief Configure a channel's function.
+ * @param desc - device descriptor for the MAX14906
+ * @param ch - channel index (0 based).
+ * @param function - channel configuration (input, output or high-z).
+ * @return 0 in case of success, negative error code otherwise
+ */
+int max14906_ch_func(struct max14906_desc *desc, uint32_t ch,
+		     enum max14906_function function)
+{
+	uint8_t setout_reg_val;
+	int ret = 0;
+
+	switch (function) {
+	case MAX14906_HIGH_Z:
+		setout_reg_val = MAX14906_IN;
+		ret = max14906_reg_update(desc, MAX14906_CONFIG_DO_REG, MAX14906_DO_MASK(ch),
+					  no_os_field_prep(MAX14906_DO_MASK(ch),
+							  MAX14906_PUSH_PULL));
+		break;
+
+	case MAX14906_IN:
+		setout_reg_val = MAX14906_IN;
+		ret = max14906_reg_update(desc, MAX14906_CONFIG_DO_REG, MAX14906_DO_MASK(ch),
+					  no_os_field_prep(MAX14906_DO_MASK(ch),
+							  MAX14906_HIGH_SIDE));
+		break;
+
+	case MAX14906_OUT:
+		setout_reg_val = MAX14906_OUT;
+		break;
+
+	default:
+		return -EINVAL;
+	}
+
+	if (ret)
+		return ret;
+
+	return max14906_reg_update(desc, MAX14906_SETOUT_REG, MAX14906_CH_DIR_MASK(ch),
+				   no_os_field_prep(MAX14906_CH_DIR_MASK(ch), setout_reg_val));
+}
+
+/**
+ * @brief Configure the current limit for output channels
+ * @param desc - device descriptor for the MAX14906
+ * @param ch - channel index (0 based).
+ * @param climit - current limit value.
+ * @return 0 in case of success, negative error code otherwise
+ */
+int max14906_climit_set(struct max14906_desc *desc, uint32_t ch,
+			enum max14906_climit climit)
+{
+	return max14906_reg_update(desc, MAX14906_CONFIG_CURR_LIM, MAX14906_CL_MASK(ch),
+				   no_os_field_prep(MAX14906_CL_MASK(ch), climit));
+}
+
+/**
+ * @brief Read an output channel's current limit
+ * @param desc - device descriptor for the MAX14906
+ * @param ch - channel index (0 based).
+ * @param climit - current limit value.
+ * @return 0 in case of success, negative error code otherwise
+ */
+int max14906_climit_get(struct max14906_desc *desc, uint32_t ch,
+			enum max14906_climit *climit)
+{
+	uint32_t reg_val;
+	int ret;
+
+	if (!climit)
+		return -EINVAL;
+
+	ret = max14906_reg_read(desc, MAX14906_CONFIG_CURR_LIM, &reg_val);
+	if (ret)
+		return ret;
+
+	*climit = no_os_field_get(MAX14906_CL_MASK(ch), reg_val);
+
+	return 0;
+}
+
+/**
+ * @brief Initialize and configure the MAX14906 device
+ * @param desc - device descriptor for the MAX14906 that will be initialized.
+ * @param param - initialization parameter for the device.
+ * @return 0 in case of success, negative error code otherwise
+ */
+int max14906_init(struct max14906_desc **desc,
+		  struct max14906_init_param *param)
+{
+	struct max14906_desc *descriptor;
+	uint32_t reg_val;
+	int ret;
+	int i;
+
+	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	ret = no_os_spi_init(&descriptor->comm_desc, param->comm_param);
+	if (ret)
+		goto err;
+
+	descriptor->crc_en = param->crc_en;
+
+	ret = no_os_gpio_get_optional(&descriptor->en_gpio, param->en_gpio_param);
+	if (ret)
+		goto spi_err;
+
+	if (descriptor->en_gpio) {
+		ret = no_os_gpio_set_value(descriptor->en_gpio, NO_OS_GPIO_HIGH);
+		if (ret)
+			goto gpio_err;
+	}
+
+	/* Clear the latched faults generated at power up */
+	ret = max14906_reg_read(descriptor, MAX14906_OVR_LD_REG, &reg_val);
+	if (ret)
+		goto gpio_err;
+
+	ret = max14906_reg_read(descriptor, MAX14906_OPN_WIR_FLT_REG, &reg_val);
+	if (ret)
+		goto gpio_err;
+
+	ret = max14906_reg_read(descriptor, MAX14906_SHD_VDD_FLT_REG, &reg_val);
+	if (ret)
+		goto gpio_err;
+
+	ret = max14906_reg_read(descriptor, MAX14906_GLOBAL_FLT_REG, &reg_val);
+	if (ret)
+		goto gpio_err;
+
+	for (i = 0; i < MAX14906_CHANNELS; i++) {
+		ret = max14906_ch_func(descriptor, i, MAX14906_HIGH_Z);
+		if (ret)
+			goto gpio_err;
+	}
+
+	*desc = descriptor;
+
+	return 0;
+
+gpio_err:
+	no_os_gpio_remove(descriptor->en_gpio);
+spi_err:
+	no_os_spi_remove(descriptor->comm_desc);
+err:
+	no_os_free(descriptor);
+
+	return ret;
+}
+
+/**
+ * @brief Free the resources allocated during init and place all the channels in high-z.
+ * @param desc - device descriptor for the MAX14906 that will be initialized.
+ * @return 0 in case of success, negative error code otherwise
+ */
+int max14906_remove(struct max14906_desc *desc)
+{
+	int ret;
+	int i;
+
+	if (!desc)
+		return -ENODEV;
+
+	for (i = 0; i < MAX14906_CHANNELS; i++) {
+		ret = max14906_ch_func(desc, i, MAX14906_HIGH_Z);
+		if (ret)
+			return ret;
+	}
+
+	no_os_spi_remove(desc->comm_desc);
+
+	if (desc->en_gpio)
+		no_os_gpio_remove(desc->en_gpio);
+
+	no_os_free(desc);
+
+	desc = NULL;
+
+	return 0;
+}

--- a/drivers/digital-io/max14906/max14906.h
+++ b/drivers/digital-io/max14906/max14906.h
@@ -1,0 +1,181 @@
+/***************************************************************************//**
+ *   @file   max14906.h
+ *   @brief  Header file of MAX14906 Driver.
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef _MAX14906_H
+#define _MAX14906_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "no_os_gpio.h"
+#include "no_os_spi.h"
+#include "no_os_util.h"
+
+#define MAX14906_FRAME_SIZE		2
+#define MAX14906_CHANNELS		4
+
+#define MAX14906_SETOUT_REG		0x0
+#define MAX14906_SETLED_REG		0x1
+#define MAX14906_DOILEVEL_REG		0x2
+#define MAX14906_INT_REG		0x3
+#define MAX14906_OVR_LD_REG		0x4
+#define MAX14906_OPN_WIR_FLT_REG	0x5
+#define MAX14906_SHD_VDD_FLT_REG	0x6
+#define MAX14906_GLOBAL_FLT_REG		0x7
+#define MAX14906_CONFIG1_REG		0xA
+#define MAX14906_CONFIG2_REG		0xB
+#define MAX14906_CONFIG_DI_REG		0xC
+#define MAX14906_CONFIG_DO_REG		0xD
+#define MAX14906_CONFIG_CURR_LIM	0xE
+#define MAX14906_CONFIG_MASK		0xF
+
+/* DoiLevel register */
+#define MAX14906_DOI_LEVEL_MASK(x)	NO_OS_BIT(x)
+
+/* SetOUT register */
+#define MAX14906_HIGHO_MASK(x)		NO_OS_BIT(x)
+
+#define MAX14906_CHIP_ADDR_MASK		NO_OS_GENMASK(7, 6)
+#define MAX14906_ADDR_MASK		NO_OS_GENMASK(4, 1)
+#define MAX14906_RW_MASK		NO_OS_BIT(0)
+
+#define MAX14906_DO_MASK(x)		(NO_OS_GENMASK(1, 0) << (2 * (x)))
+#define MAX14906_CH_DIR_MASK(x)		NO_OS_BIT((x) + 4)
+#define MAX14906_CH(x)			(x)
+#define MAX14906_IEC_TYPE_MASK		NO_OS_BIT(7)
+#define MAX14906_CL_MASK(x)		(NO_OS_GENMASK(1, 0) << (2 * (x)))
+
+/* Config1 register */
+#define MAX14906_SLED_MASK		NO_OS_BIT(1)
+#define MAX14906_FLED_MASK		NO_OS_BIT(0)
+
+enum max14906_iec_type {
+	MAX14906_TYPE_1_3,
+	MAX14906_TYPE_2,
+};
+
+/**
+ * @brief Channel configuration options.
+ */
+enum max14906_function {
+	MAX14906_OUT,
+	MAX14906_IN,
+	MAX14906_HIGH_Z
+};
+
+/**
+ * @brief Configuration options for the output driver (on each channel).
+ */
+enum max14906_do_mode {
+	MAX14906_HIGH_SIDE,
+	MAX14906_HIGH_SIDE_INRUSH,
+	MAX14906_PUSH_PULL_CLAMP,
+	MAX14906_PUSH_PULL
+};
+
+/**
+ * @brief Current limit options for output channels.
+ */
+enum max14906_climit {
+	MAX14906_CL_600,
+	MAX14906_CL_130,
+	MAX14906_CL_300,
+	MAX14906_CL_1200,
+};
+
+/**
+ * @brief Configuration structure for a MAX14906 channel.
+ */
+struct max14906_ch_config {
+	bool enabled;
+	enum max14906_function function;
+};
+
+/**
+ * @brief Initialization parameter for the MAX14906 device.
+ */
+struct max14906_init_param {
+	uint32_t chip_address;
+	struct no_os_spi_init_param *comm_param;
+	struct no_os_gpio_init_param *en_gpio_param;
+	struct max14906_ch_config ch_config[MAX14906_CHANNELS];
+	bool crc_en;
+};
+
+/**
+ * @brief Device descriptor for MAX14906.
+ */
+struct max14906_desc {
+	uint32_t chip_address;
+	struct no_os_spi_desc *comm_desc;
+	struct no_os_gpio_desc *en_gpio;
+	uint8_t buff[MAX14906_FRAME_SIZE + 1];
+	bool crc_en;
+};
+
+/** Write the value of a device register */
+int max14906_reg_write(struct max14906_desc *, uint32_t, uint32_t);
+
+/** Read the value of a device register */
+int max14906_reg_read(struct max14906_desc *, uint32_t, uint32_t *);
+
+/** Update the value of a device register */
+int max14906_reg_update(struct max14906_desc *, uint32_t, uint32_t, uint32_t);
+
+/** Read the state of a channel */
+int max14906_ch_get(struct max14906_desc *, uint32_t, uint32_t *);
+
+/** Set the state of a channel */
+int max14906_ch_set(struct max14906_desc *, uint32_t, uint32_t);
+
+/** Configure a channel's function */
+int max14906_ch_func(struct max14906_desc *, uint32_t, enum max14906_function);
+
+/** Configure the current limit for output channels */
+int max14906_climit_set(struct max14906_desc *, uint32_t, enum max14906_climit);
+
+/** Read an output channel's current limit */
+int max14906_climit_get(struct max14906_desc *, uint32_t,
+			enum max14906_climit *);
+
+/** Initialize and configure the MAX14906 device */
+int max14906_init(struct max14906_desc **, struct max14906_init_param *);
+
+/** Free the resources allocated during init and place all the channels in high-z. */
+int max14906_remove(struct max14906_desc *);
+
+#endif


### PR DESCRIPTION
The MAX14906 is an IEC 61131-2 compliant, high-speed, four-channel industrial digital output, digital input device
that can be configured on a per-channel basis as a high-side (HS) switch, push-pull (PP) driver, or a Type 1 and 3,
or Type 2 digital input. The MAX14906 is specified for operation with a supply voltage up to 40V and is tolerant to
65V.