### PR TITLE
Add PR Template and Code Owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# This file contains code owners for No-OS Pull Requests to master/main.
+# Code owners are added automatically as reviewers. All PRs open against 
+# master/main will require approval of at least one code owner.
+#
+# More general documentation about code owners can be found here:
+# https://github.blog/2017-07-06-introducing-code-owners/
+
+# CODEOWNERS file format: <pattern> + <mail address of one or more owners>
+
+##### Global code owners (for whole files from repo) #####
+*	darius.berghe@analog.com ciprian.regus@analog.com dragos.bogdan@analog.com antoniu.miclaus@analog.com ramona.gradinariu@analog.com george.mois@analog.com

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Pull Request Description
+
+Please replace this with a detailed description and motivation of the changes. 
+You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
+If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.
+
+## PR Type
+- [ ] Bug fix (change that fixes an issue)
+- [ ] New feature (change that adds new functionality)
+- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
+
+## PR Checklist
+- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
+- [ ] I have performed a self-review of the changes
+- [ ] I have commented my code, at least hard-to-understand parts
+- [ ] I have build all projects affected by the changes in this PR
+- [ ] I have tested in hardware affected projects, at the relevant boards
+- [ ] I have signed off all commits from this PR
+- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ aducm_project
 aducm_build
 .vscode
 .Xil
+.github/CODEOWNERS
+.github/PULL_REQUEST_TEMPLATE.md
 
 *.a
 *.o


### PR DESCRIPTION
This PR adds:

1.  CODEOWNERS
    Code owners are automatically added as reviewers whenever new PRs are open. Other reviewers can be added beside code owners. This works in combination with "Minimum number of reviewers" set to one - meaning that at least one code owner must approve the PR to be able to merge it.

2.  PULL_REQUEST_TEMPLATE
   PR Template main goal is to standardize the information contributors include when they open new PRs. Whenever a new PR is open, its body will be automatically populated with the content of PULL_REQUEST_TEMPLATE.md file. 