### PR TITLE
iio: Disable trigger before calling post_disable

### DIFF
--- a/iio/iio.c
+++ b/iio/iio.c
@@ -1219,19 +1219,19 @@ static int iio_close_dev(struct iiod_ctx *ctx, const char *device)
 		dev->buffer.allocated = 0;
 	}
 
-	dev->buffer.public.active_mask = 0;
-	if (dev->dev_descriptor->post_disable) {
-		ret = dev->dev_descriptor->post_disable(dev->dev_instance);
-		if (ret)
-			return ret;
-	}
-
 	desc = ctx->instance;
 	if(dev->trig_idx != NO_TRIGGER) {
 		trig = &desc->trigs[dev->trig_idx];
-		if (trig->descriptor->disable)
+		if (trig->descriptor->disable) {
 			ret = trig->descriptor->disable(trig->instance);
+			if (ret)
+				return ret;
+		}
 	}
+
+	dev->buffer.public.active_mask = 0;
+	if (dev->dev_descriptor->post_disable)
+		ret = dev->dev_descriptor->post_disable(dev->dev_instance);
 
 	return ret;
 }


### PR DESCRIPTION
## Pull Request Description

There is no reason to have the trigger enabled during the post_disable call. Usually, this function is used to disable channels, thus having a data ready interrupt occur during this may lead to bus contention.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
