### PR TITLE
drivers:dac:ad5754r: Fix update method

### DIFF
--- a/drivers/dac/ad5754r/ad5754r.c
+++ b/drivers/dac/ad5754r/ad5754r.c
@@ -154,6 +154,7 @@ int ad5754r_update_bits(struct ad5754r_dev *dev,
 	if (ret)
 		return ret;
 
+	reg_data &= ~mask;
 	reg_data |= no_os_field_prep(mask, reg_val);
 
 	return ad5754r_write(dev, instr_addr, reg_data);


### PR DESCRIPTION
## Pull Request Description

Fix update_bits method by resetting masked locations before applying mask

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
