### PR TITLE
drivers:adc:ad4080: Fix driver init

### DIFF
--- a/drivers/adc/ad4080/ad4080.c
+++ b/drivers/adc/ad4080/ad4080.c
@@ -978,8 +978,10 @@ int ad4080_init(struct ad4080_dev **device,
 	if (ret)
 		goto error_spi;
 
-	if (data != AD4080_CHIP_ID)
+	if (data != AD4080_CHIP_ID) {
+		ret = -EINVAL;
 		goto error_spi;
+	}
 
 	/* Software Reset */
 	ret = ad4080_soft_reset(dev);
@@ -997,8 +999,6 @@ int ad4080_init(struct ad4080_dev **device,
 	if (ret)
 		goto error_spi;
 
-	*device = dev;
-
 	/* Configuration SPI Interface Initialization */
 	ret = ad4080_configuration_intf_init(dev, init_param);
 	if (ret)
@@ -1013,6 +1013,8 @@ int ad4080_init(struct ad4080_dev **device,
 	ret = ad4080_set_mspi_drv(dev, init_param.mspi_drv) ;
 	if (ret)
 		goto error_spi;
+
+	*device = dev;
 
 	return 0;
 


### PR DESCRIPTION
## Pull Request Description

Fix ad4080 driver init method
1. Prevent premature assignment of device structure instance before reg configuration is successful
2. Return error if ID does not match

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
