### PR TITLE
drivers:api: bug fix in no_os_spibus_remove

### DIFF
--- a/drivers/api/no_os_spi.c
+++ b/drivers/api/no_os_spi.c
@@ -149,6 +149,7 @@ void no_os_spibus_remove(uint32_t bus_number)
 		if (bus) {
 			no_os_free(bus);
 			bus = NULL;
+			spi_table[bus_number] = NULL;
 		}
 	}
 }


### PR DESCRIPTION
initializing pointer to bus to NULL in spi_table when bus is freed.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
