### PR TITLE
drivers:adc-dac:ad74413r: Fix rejection lookup

### DIFF
--- a/drivers/adc-dac/ad74413r/ad74413r.c
+++ b/drivers/adc-dac/ad74413r/ad74413r.c
@@ -67,7 +67,7 @@ static const unsigned int ad74413r_debounce_map[AD74413R_DIN_DEBOUNCE_LEN] = {
 };
 
 /** The time required for an ADC conversion by rejection (us) */
-static const uint32_t conv_times_ad74413r[] = { 208, 833, 50000, 100000 };
+static const uint32_t conv_times_ad74413r[] = { 50000, 208, 100000, 833 };
 static const uint32_t conv_times_ad74412r[] = { 50000, 208};
 
 /******************************************************************************/


### PR DESCRIPTION
## Pull Request Description

Fix the order of the conv times, so they'll match the EN_50_60_HZ values in the ADC_CONFIGx register.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
