### PR TITLE
CODEOWNERS: add owners on ci related folders/files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,3 +9,7 @@
 
 ##### Global code owners (for whole files from repo) #####
 *	darius.berghe@analog.com ciprian.regus@analog.com dragos.bogdan@analog.com antoniu.miclaus@analog.com ramona.gradinariu@analog.com george.mois@analog.com
+/ci/    dragos.bogdan@analog.com antoniu.miclaus@analog.com ramona.gradinariu@analog.com stefan.raus@analog.com andreea.andrisan@analog.com
+/tools/scripts/ dragos.bogdan@analog.com antoniu.miclaus@analog.com ramona.gradinariu@analog.com stefan.raus@analog.com andreea.andrisan@analog.com
+azure-pipelines.yml  dragos.bogdan@analog.com antoniu.miclaus@analog.com ramona.gradinariu@analog.com stefan.raus@analog.com andreea.andrisan@analog.com
+build-projects.yml   dragos.bogdan@analog.com antoniu.miclaus@analog.com ramona.gradinariu@analog.com stefan.raus@analog.com andreea.andrisan@analog.com


### PR DESCRIPTION
This commits adds extra persons as code owners on CI-related folders/files.

## Pull Request Description

This PR add extra code owners on CI related folders and files.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
