### PR TITLE
build_projects.yml: add hdl_branch parameter

### DIFF
--- a/build_projects.yml
+++ b/build_projects.yml
@@ -31,7 +31,8 @@ jobs:
                -export_dir $(RELEASE_DIR)
                -log_dir $(LOG_DIR)
                -builds_dir /no-OS_builds/builds
-               -platform xilinx'
+               -platform xilinx
+               -hdl_branch $(HDL_BRANCH)'
     displayName: 'Run project build'
   - task: PublishPipelineArtifact@1
     timeoutInMinutes: 10
@@ -62,7 +63,8 @@ jobs:
                -export_dir $(RELEASE_DIR)
                -log_dir $(LOG_DIR)
                -builds_dir /no-OS_builds/builds
-               -platform stm32'
+               -platform stm32
+               -hdl_branch $(HDL_BRANCH)'
     displayName: 'Run project build'
   - task: PublishPipelineArtifact@1
     timeoutInMinutes: 10
@@ -93,7 +95,8 @@ jobs:
                -export_dir $(RELEASE_DIR)
                -log_dir $(LOG_DIR)
                -builds_dir /no-OS_builds/builds
-               -platform maxim'
+               -platform maxim
+               -hdl_branch $(HDL_BRANCH)'
     displayName: 'Run project build'
   - task: PublishPipelineArtifact@1
     timeoutInMinutes: 10
@@ -124,7 +127,8 @@ jobs:
                -export_dir $(RELEASE_DIR)
                -log_dir $(LOG_DIR)
                -builds_dir /no-OS_builds/builds
-               -platform mbed'
+               -platform mbed
+               -hdl_branch $(HDL_BRANCH)'
     displayName: 'Run project build'
   - task: PublishPipelineArtifact@1
     timeoutInMinutes: 10
@@ -155,7 +159,8 @@ jobs:
                -export_dir $(RELEASE_DIR)
                -log_dir $(LOG_DIR)
                -builds_dir /no-OS_builds/builds
-               -platform pico'
+               -platform pico
+               -hdl_branch $(HDL_BRANCH)'
     displayName: 'Run project build'
   - task: PublishPipelineArtifact@1
     timeoutInMinutes: 10
@@ -186,7 +191,8 @@ jobs:
                -export_dir $(RELEASE_DIR)
                -log_dir $(LOG_DIR)
                -builds_dir /no-OS_builds/builds
-               -platform aducm3029'
+               -platform aducm3029
+               -hdl_branch $(HDL_BRANCH)'
     displayName: 'Run project build'
   - task: PublishPipelineArtifact@1
     timeoutInMinutes: 10


### PR DESCRIPTION
## Pull Request Description

Instead of going on default case, parametrize the hdl_branch used for projects builds using a an Azure environment variable alongside LOGS_DIR and RELEASE_DIR passed to the build_projects.py script. In this manner we keep under control the versions of the hdl used for building projects and folder structure of the builds.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
