### PR TITLE
CODEOWNERS: fix build projects file name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,4 +12,4 @@
 /ci/    dragos.bogdan@analog.com antoniu.miclaus@analog.com ramona.gradinariu@analog.com stefan.raus@analog.com andreea.andrisan@analog.com
 /tools/scripts/ dragos.bogdan@analog.com antoniu.miclaus@analog.com ramona.gradinariu@analog.com stefan.raus@analog.com andreea.andrisan@analog.com
 azure-pipelines.yml  dragos.bogdan@analog.com antoniu.miclaus@analog.com ramona.gradinariu@analog.com stefan.raus@analog.com andreea.andrisan@analog.com
-build-projects.yml   dragos.bogdan@analog.com antoniu.miclaus@analog.com ramona.gradinariu@analog.com stefan.raus@analog.com andreea.andrisan@analog.com
+build_projects.yml   dragos.bogdan@analog.com antoniu.miclaus@analog.com ramona.gradinariu@analog.com stefan.raus@analog.com andreea.andrisan@analog.com


### PR DESCRIPTION
Fix typo in the file name of the build projects yml file.

Fixes: 633ddd0 ("CODEOWNERS: add owners on ci related folders/files")

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
