### PR TITLE
ci: doxygen.sh: fix build content handling

### DIFF
--- a/ci/doxygen.sh
+++ b/ci/doxygen.sh
@@ -80,21 +80,17 @@ update_gh_pages() {
 
                 git checkout gh-pages
 
-                # Clear previous content in the doxygen folder
-                rm -rf ${TOP_DIR}/doxygen
+                # Clear previous content in the root folder except the doc path which holds new builds
+                find ${TOP_DIR} -mindepth 1 -maxdepth 1 ! -name "doc" -exec rm -r {} \;
 
+                # Create doxygen folder holding new build content
                 mkdir -p ${TOP_DIR}/doxygen
                 cp -R ${TOP_DIR}/doc/doxygen/build/doxygen_doc/html/* ${TOP_DIR}/doxygen/
 
-                rm -rf ${TOP_DIR}/doc/doxygen
-
-                # Remove root content except the doxygen folder
-                find ${TOP_DIR} -mindepth 1 -maxdepth 1 ! -name "doxygen" -exec rm -r {} \;
-
-                # Add sphinx generated doc to root folder
+                # Add sphinx build content to root folder
                 cp -R ${TOP_DIR}/doc/sphinx/build/* ${TOP_DIR}
 
-                rm -rf ${TOP_DIR}/doc/sphinx
+                rm -rf ${TOP_DIR}/doc
 
                 CURRENT_COMMIT=$(git log -1 --pretty=%B)
                 if [[ ${CURRENT_COMMIT:(-7)} != ${MASTER_COMMIT:0:7} ]]


### PR DESCRIPTION
The current approach deletes the new sphinx build content before being copied to the root path of the gh-pages branch.

Handle things differently to avoid deleting build contents for doxygen and sphinx which lie unde the `doc` path.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
