### PR TITLE
ci: doxygen: do not remove .git folder

### DIFF
--- a/ci/doxygen.sh
+++ b/ci/doxygen.sh
@@ -81,7 +81,7 @@ update_gh_pages() {
                 git checkout gh-pages
 
                 # Clear previous content in the root folder except the doc path which holds new builds
-                find ${TOP_DIR} -mindepth 1 -maxdepth 1 ! -name "doc" -exec rm -r {} \;
+                find ${TOP_DIR} -mindepth 1 -maxdepth 1 ! \( -name "doc" -o -name ".git" \) -exec rm -r {} \;
 
                 # Create doxygen folder holding new build content
                 mkdir -p ${TOP_DIR}/doxygen


### PR DESCRIPTION
## Pull Request Description
When pushing new documentation on gh-pages the .git folder needs to be available in the ${TOP_DIR}. Therefore exclude it from removal alongside the "doc" folder.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
