### PR TITLE
use wildcard when dealing with .bit file

### DIFF
--- a/tools/scripts/xilinx.mk
+++ b/tools/scripts/xilinx.mk
@@ -31,7 +31,7 @@ define create_bif_file
 	@echo the_ROM_image: > $(BOOT_BIN_DIR)/project.bif
 	@echo { >> $(BOOT_BIN_DIR)/project.bif
 	@echo $1 $(FSBL_PATH) >> $(BOOT_BIN_DIR)/project.bif
-	@echo $2 $(TEMP_DIR)/system_top.bit >> $(BOOT_BIN_DIR)/project.bif
+	@echo $2 $(TEMP_DIR)/*.bit >> $(BOOT_BIN_DIR)/project.bif
 	@echo $3 $(BINARY) >> $(BOOT_BIN_DIR)/project.bif
 	@echo } >> $(BOOT_BIN_DIR)/project.bif
 	@echo >> $(BOOT_BIN_DIR)/project.bif
@@ -263,7 +263,7 @@ ifeq ($(findstring cortexr5,$(strip $(ARCH))),cortexr5)
 	$(call create_bif_file,[bootloader$(comma)destination_cpu = r5-0],[destination_device = pl],[destinatio_cpu = r5-0]) $(HIDE)
 	bootgen -arch zynqmp -image $(BOOT_BIN_DIR)/project.bif -o $(BOOT_BIN_DIR)/BOOT.BIN -w $(HIDE)
 endif
-	$(call copy_file,$(TEMP_DIR)/system_top.bit,$(BOOT_BIN_DIR)) $(HIDE)
+	$(call copy_file,$(TEMP_DIR)/*.bit,$(BOOT_BIN_DIR)) $(HIDE)
 	$(call copy_file,$(FSBL_PATH),$(BOOT_BIN_DIR)) $(HIDE)
 	$(call copy_file,$(BINARY),$(BOOT_BIN_DIR)) $(HIDE)
 	tar -czvf $(BUILD_DIR)/bootgen_sysfiles.tar.gz --force-local --exclude 'BOOT.BIN' -C $(BOOT_BIN_DIR) . $(HIDE)
@@ -271,7 +271,7 @@ else
 	$(call print,Creating archive with files)
 	$(call remove_dir,$(BUILD_DIR)/boot_files) $(HIDE)
 	$(call mk_dir,$(BUILD_DIR)/boot_files) $(HIDE)
-	$(call copy_file,$(TEMP_DIR)/system_top.bit,$(BUILD_DIR)/boot_files) $(HIDE)
+	$(call copy_file,$(TEMP_DIR)/*.bit,$(BUILD_DIR)/boot_files) $(HIDE)
 	$(call copy_file,$(BINARY),$(BUILD_DIR)/boot_files) $(HIDE)
 	tar -czvf $(BUILD_DIR)/bootgen_sysfiles.tar.gz --force-local -C $(BUILD_DIR)/boot_files . $(HIDE)
 endif


### PR DESCRIPTION
## Pull Request Description

Xilinx tools name the .bit file differently. Use wildcard to accomodate the following, regardless of Xilinx tools version:
 - system.bit
 - system_top.bit

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
