### PR TITLE
ci: doxygen: create .nojekyll file

### DIFF
--- a/ci/doxygen.sh
+++ b/ci/doxygen.sh
@@ -92,6 +92,9 @@ update_gh_pages() {
 
                 rm -rf ${TOP_DIR}/doc
 
+                # Create .nojekyll file
+                touch ${TOP_DIR}/.nojekyll
+
                 CURRENT_COMMIT=$(git log -1 --pretty=%B)
                 if [[ ${CURRENT_COMMIT:(-7)} != ${MASTER_COMMIT:0:7} ]]
                 then


### PR DESCRIPTION
## Pull Request Description

Prior to pushing new documentation build on gh-pages, create .nojekyll file in the root directory to avoid treating github pages as a Jekyll site.

Sphinx generates documentation in a way that is different from Jekyll, and we want to avoid any potential conflicts. In this specific case, the files from the `_static` are ignored by Jekyll and we don't want that to happen.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
