### PR TITLE
ltc3350 driver files for no-OS

### DIFF
--- a/drivers/power/ltc3350/ltc3350.c
+++ b/drivers/power/ltc3350/ltc3350.c
@@ -1,0 +1,319 @@
+/***************************************************************************//**
+*   @file   ltc3350.c
+*   @brief  Implementation of LTC3350 Driver
+*   @authors Sankalp Khandkar (sankalp.khandkar@analog.com)
+*            Ignacio Rojas (ignacio.rojas@analog.com)
+********************************************************************************
+* Copyright 2023(c) Analog Devices, Inc.
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*  - Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*  - Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in
+*    the documentation and/or other materials provided with the
+*    distribution.
+*  - Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*  - The use of this software may or may not infringe the patent rights
+*    of one or more patent holders.  This license does not release you
+*    from the requirement that you obtain separate licenses from these
+*    patent holders to use this software.
+*  - Use of the software either in source or binary form, must be run
+*    on or directly connected to an Analog Devices Inc. component.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#include "no_os_util.h"
+#include "no_os_delay.h"
+#include "no_os_alloc.h"
+#include "no_os_i2c.h"
+
+#include "ltc3350.h"
+
+/***************************************************************************//**
+ * @brief Initializes the communication peripheral and checks if the LTC3350
+ *        part is present.
+ *
+ * @param device     - The device structure.
+ * @param init_param - The structure that contains the device initial
+ * 		       parameters.
+ *
+ * @return ret       - Result of the initialization procedure.
+*******************************************************************************/
+int ltc3350_init(struct ltc3350_dev **device,
+		 struct ltc3350_init_param *init_param)
+{
+	struct ltc3350_dev *dev;
+	int ret;
+	dev = (struct ltc3350_dev *)no_os_calloc(1, sizeof(*dev));
+	if (!dev)
+		return -ENOMEM;
+
+	ret = no_os_i2c_init(&dev->i2c_desc, &init_param->i2c_init);
+	if (ret)
+		goto err;
+
+	*device = dev;
+	return 0;
+
+err:
+	no_os_free(dev);
+	return ret;
+}
+
+/***************************************************************************//**
+ * @brief Free the resources allocated by ltc3350_init().
+ *
+ * @param dev 	- The device structure.
+ *
+ * @return ret 	- Result of the remove procedure.
+*******************************************************************************/
+int ltc3350_remove(struct ltc3350_dev *dev)
+{
+	int ret;
+
+	ret = no_os_i2c_remove(dev->i2c_desc);
+	if (ret)
+		return ret;
+
+	no_os_free(dev);
+
+	return ret;
+}
+
+/***************************************************************************//**
+ * @brief Reads data from the device (I2C).
+ *
+ * @param dev          - The device structure.
+ * @param base_address - Address of the base register.
+ * @param read_data    - The read data value
+ *
+ * @return ret         - Result of the reading procedure.
+*******************************************************************************/
+int ltc3350_read_device_data(struct ltc3350_dev *dev, uint8_t base_address,
+			     uint16_t *read_data)
+{
+	int ret;
+	uint8_t rx_buff[2] = {0};
+
+	ret = no_os_i2c_write(dev->i2c_desc, &base_address, 1, 1);
+	if (ret)
+		return ret;
+
+	ret = no_os_i2c_read(dev->i2c_desc, rx_buff, 2, 1);
+	if (ret)
+		return ret;
+
+	*read_data = (rx_buff[1] << 8) | rx_buff[0];
+
+	return ret;
+}
+
+/***************************************************************************//**
+ * @brief Writes data to the device (I2C)
+ *
+ * @param dev          	- The device structure.
+ * @param base_address 	- Address of the base register.
+ * @param write_data   	- The data which is going to be written.
+ *
+ * @return ret         	- Result of the writing procedure.
+*******************************************************************************/
+int ltc3350_write_device_data(struct ltc3350_dev *dev, uint8_t base_address,
+			      uint16_t write_data)
+{
+	uint8_t txbuff[3] = {0};
+
+	txbuff[0] = base_address;
+	txbuff[1] = write_data & 0xFF;
+	txbuff[2] = write_data >> 8;
+
+	return no_os_i2c_write(dev-> i2c_desc, txbuff, 3, 1);
+}
+
+#if	LTC3350_USE_MEASUREMENTS
+
+/***************************************************************************//**
+ * @brief  Gets number of capacitors configured based on PIN
+ *
+ * @param dev          	- The device structure.
+ * @param num_caps	- Number of capacitors configured.
+ *                        00-1 cap, 01 - 2 caps, 10 - 3caps and 11 - 4 caps
+ *
+ * @return ret         	- Result of the reading procedure.
+*******************************************************************************/
+int ltc3350_get_num_caps(struct ltc3350_dev *dev, uint8_t *num_caps)
+{
+	int ret;
+	uint16_t value;
+
+	ret = ltc3350_read_device_data(dev, LTC3350_AD_NUM_CAPS, &value);
+	if (ret)
+		return ret;
+
+	*num_caps = value + 1;
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * @brief Reads the ESR data.
+ *
+ * @param dev          	- The device structure.
+ * @param value 	- Measured ESR.
+ *
+ * @return ret         	- Result of the reading procedure.
+*******************************************************************************/
+int ltc3350_get_esr(struct ltc3350_dev *dev, uint16_t *value)
+{
+	int ret;
+	uint16_t read_value;
+
+	ret = ltc3350_read_device_data(dev, LTC3350_AD_MEAS_ESR, &read_value);
+	if (ret)
+		return	ret;
+
+	*value = read_value;
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * @brief Reads the Vcap data for selected capacitor
+
+ * @param dev          	- The device structure.
+ * @param n_cap 	- Number of capacitor to read, 0 for stack voltage
+ * @param value		- The read value
+ *
+ * @return ret         	- Result of the reading procedure.
+*******************************************************************************/
+int ltc3350_get_vcap(struct ltc3350_dev *dev, uint8_t n_cap, uint16_t *value)
+{
+	int ret;
+
+	if (n_cap > 4)
+		return -EINVAL;
+
+	if (!n_cap) {
+		return ltc3350_read_device_data(dev, LTC3350_AD_MEAS_VCAP, value);
+	} else {
+		return ltc3350_read_device_data(dev, LTC3350_AD_MEAS_VCAP1 + n_cap - 1,
+						value);
+	}
+
+}
+
+#endif
+
+#if LTC3350_USE_ALARMS
+
+/***************************************************************************//**
+ * @brief Set the selected alarm and its related threshold
+ *
+ * @param dev          		- The device structure.
+ * @param alarm 		- Alarm to be setted.
+ * @param alarm_threshold   	- The desired threshold value to the selected alarm.
+ *				  mV , Deg Celsius or uF
+ * @return ret         		- Result of the alarm setting operation.
+*******************************************************************************/
+int ltc3350_set_alarm(struct ltc3350_dev *dev, enum ltc3350_enum_alarms alarm,
+		      uint16_t alarm_threshold)
+{
+	int ret;
+	uint16_t alarm_mask;
+	uint16_t alarm_address;
+
+	ret = ltc3350_read_device_data(dev, LTC3350_AD_MSK_ALARMS, &alarm_mask);
+	if (ret)
+		return ret;
+
+	alarm_mask |= NO_OS_BIT(alarm);
+
+	ret = ltc3350_write_device_data(dev, LTC3350_AD_MSK_ALARMS, alarm_mask);
+	if (ret)
+		return ret;
+
+	alarm_address = LTC3350_AD_CAP_UV_LVL + alarm;
+
+	return ltc3350_write_device_data(dev, alarm_address, alarm_threshold);
+}
+
+/***************************************************************************//**
+ * @brief Mute an specific alarm
+ *
+ * @param dev          	- The device structure.
+ * @param alarm 	- Alarm to be muted.
+ *
+ * @return ret         	- Result of the writing procedure.
+*******************************************************************************/
+int ltc3350_mute_alarm(struct ltc3350_dev *dev, enum ltc3350_enum_alarms alarm)
+{
+	int ret;
+	uint16_t alarm_mask;
+
+	ret = ltc3350_read_device_data(dev, LTC3350_AD_MSK_ALARMS, &alarm_mask);
+	if (ret)
+		return ret;
+
+	alarm_mask &= ~NO_OS_BIT(alarm);
+
+	return ltc3350_write_device_data(dev, LTC3350_AD_MSK_ALARMS, alarm_mask);
+}
+
+/***************************************************************************//**
+ * @brief Get alarms status mask
+ *
+ * @param dev          	- The device structure.
+ * @param status	- Status mask of the alarms
+ *
+ * @return ret         	- Result of the reading procedure.
+*******************************************************************************/
+int ltc3350_get_alarm_status_mask(struct ltc3350_dev *dev, uint16_t *alarm_mask)
+{
+	int ret;
+	uint16_t read_val;
+
+	ret = ltc3350_read_device_data(dev, LTC3350_AD_ALARM_REG, &read_val);
+	if (ret)
+		return ret;
+
+	*alarm_mask = read_val;
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * @brief Clear alarms status mask
+ *
+ * @param dev          - The device structure.
+ *
+ * @return ret         - Result of the writing procedure.
+*******************************************************************************/
+int ltc3350_clear_alarm_status_mask(struct ltc3350_dev *dev)
+{
+	return ltc3350_write_device_data(dev, LTC3350_AD_CLR_ALARMS, 0x0000);
+}
+
+#endif

--- a/drivers/power/ltc3350/ltc3350.h
+++ b/drivers/power/ltc3350/ltc3350.h
@@ -1,0 +1,235 @@
+/***************************************************************************//**
+*   @file   ltc3350.c
+*   @brief  Implementation of LTC3350 Driver
+*   @authors Sankalp Khandkar (sankalp.khandkar@analog.com)
+*            Ignacio Rojas (ignacio.rojas@analog.com)
+********************************************************************************
+* Copyright 2023(c) Analog Devices, Inc.
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*  - Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*  - Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in
+*    the documentation and/or other materials provided with the
+*    distribution.
+*  - Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*  - The use of this software may or may not infringe the patent rights
+*    of one or more patent holders.  This license does not release you
+*    from the requirement that you obtain separate licenses from these
+*    patent holders to use this software.
+*  - Use of the software either in source or binary form, must be run
+*    on or directly connected to an Analog Devices Inc. component.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef __LTC3350_H__
+#define __LTC3350_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <stdint.h>
+#include <string.h>
+#include "no_os_util.h"
+#include "no_os_i2c.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+/* LTC3350 Register Map */
+#define LTC3350_AD_CLR_ALARMS                   0x00
+#define LTC3350_AD_MSK_ALARMS                   0x01
+#define LTC3350_AD_MSK_MON_STATUS               0x02
+#define LTC3350_AD_CAP_ESR_PER                  0x04
+#define LTC3350_AD_VCAPFB_DAC                   0x05
+#define LTC3350_AD_VSHUNT                       0x06
+#define LTC3350_AD_CAP_UV_LVL                   0x07
+#define LTC3350_AD_CAP_OV_LVL                   0x08
+#define LTC3350_AD_GPI_UV_LVL                   0x09
+#define LTC3350_AD_GPI_OV_LVL                   0x0A
+#define LTC3350_AD_VIN_UV_LVL                   0x0B
+#define LTC3350_AD_VIN_OV_LVL                   0x0C
+#define LTC3350_AD_VCAP_UV_LVL                  0x0D
+#define LTC3350_AD_VCAP_OV_LVL                  0x0E
+#define LTC3350_AD_VOUT_UV_LVL                  0x0F
+#define LTC3350_AD_VOUT_OV_LVL                  0x10
+#define LTC3350_AD_IIN_OC_LVL                   0x11
+#define LTC3350_AD_ICHG_UC_LVL                  0x12
+#define LTC3350_AD_DTEMP_COLD_LVL               0x13
+#define LTC3350_AD_DTEMP_HOT_LVL                0x14
+#define LTC3350_AD_ESR_HI_LVL                   0x15
+#define LTC3350_AD_CAP_LO_LVL                   0x16
+#define LTC3350_AD_CTL_REG                      0x17
+#define LTC3350_AD_NUM_CAPS                     0x1A
+#define LTC3350_AD_CHRG_STATUS                  0x1B
+#define LTC3350_AD_MON_STATUS                   0x1C
+#define LTC3350_AD_ALARM_REG                    0x1D
+#define LTC3350_AD_MEAS_CAP                     0x1E
+#define LTC3350_AD_MEAS_ESR                     0x1F
+#define LTC3350_AD_MEAS_VCAP1                   0x20
+#define LTC3350_AD_MEAS_VCAP2                   0x21
+#define LTC3350_AD_MEAS_VCAP3                   0x22
+#define LTC3350_AD_MEAS_VCAP4                   0x23
+#define LTC3350_AD_MEAS_GPI                     0x24
+#define LTC3350_AD_MEAS_VIN                     0x25
+#define LTC3350_AD_MEAS_VCAP                    0x26
+#define LTC3350_AD_MEAS_VOUT                    0x27
+#define LTC3350_AD_MEAS_IIN                     0x28
+#define LTC3350_AD_MEAS_ICHG                    0x29
+#define LTC3350_AD_MEAS_DTEMP                   0x2A
+
+/******************************************************************************/
+/******************* Driver pre-compile time settings *************************/
+/******************************************************************************/
+
+/**
+ * @brief   LTC3350 measurements configuration switch.
+ * @details If set to @p TRUE more configurations are available.
+ * @note    The default is @p TRUE.
+ */
+#ifndef LTC3350_USE_MEASUREMENTS
+#define LTC3350_USE_MEASUREMENTS               	1
+#endif
+
+/**
+ * @brief   LTC3350 alarms configuration switch.
+ * @details If set to @p TRUE more configurations are available.
+ * @note    The default is @p FALSE.
+ */
+#ifndef LTC3350_USE_ALARMS
+#define LTC3350_USE_ALARMS               	0
+#endif
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+
+/*LTC3350 alarms*/
+enum ltc3350_enum_alarms {
+	LTC3350_CAP_UV_LVL            = 0,
+	LTC3350_CAP_OV_LVL            = 1,
+	LTC3350_GPI_UV_LVL            = 2,
+	LTC3350_GPI_OV_LVL            = 3,
+	LTC3350_VIN_UV_LVL            = 4,
+	LTC3350_VIN_OV_LVL            = 5,
+	LTC3350_VCAP_UV_LVL           = 6,
+	LTC3350_VCAP_OV_LVL           = 7,
+	LTC3350_VOUT_UV_LVL           = 8,
+	LTC3350_VOUT_OV_LVL           = 9,
+	LTC3350_IIN_OC_LVL            = 10,
+	LTC3350_ICHG_UC_LVL           = 11,
+	LTC3350_DTEMP_COLD_LVL        = 12,
+	LTC3350_DTEMP_HOT_LVL         = 13,
+	LTC3350_ESR_HI_LVL            = 14,
+	LTC3350_CAP_LO_LVL            = 15
+};
+
+/*LTC3350 alarms_mask*/
+enum ltc3350_enum_alarms_mask {
+	LTC3350_CAP_UV_LVL_B_BIT      = NO_OS_BIT(0),
+	LTC3350_CAP_OV_LVL_BIT        = NO_OS_BIT(1),
+	LTC3350_GPI_UV_LVL_BIT        = NO_OS_BIT(2),
+	LTC3350_GPI_OV_LVL_BIT        = NO_OS_BIT(3),
+	LTC3350_VIN_UV_LVL_BIT        = NO_OS_BIT(4),
+	LTC3350_VIN_OV_LVL_BIT        = NO_OS_BIT(5),
+	LTC3350_VCAP_UV_LVL_BIT       = NO_OS_BIT(6),
+	LTC3350_VCAP_OV_LVL_BIT       = NO_OS_BIT(7),
+	LTC3350_VOUT_UV_LVL_BIT       = NO_OS_BIT(8),
+	LTC3350_VOUT_OV_LVL_BIT       = NO_OS_BIT(9),
+	LTC3350_IIN_OC_LVL_BIT        = NO_OS_BIT(10),
+	LTC3350_ICHG_UC_LVL_BIT       = NO_OS_BIT(11),
+	LTC3350_DTEMP_COLD_LVL_BIT    = NO_OS_BIT(12),
+	LTC3350_DTEMP_HOT_LVL_BIT     = NO_OS_BIT(13),
+	LTC3350_ESR_HI_LVL_BIT        = NO_OS_BIT(14),
+	LTC3350_CAP_LO_LVL_BIT        = NO_OS_BIT(15)
+};
+
+/**
+ * @brief Structure holding the parameters for LTC3350 device initialization.
+ * @struct ltc3350_init_param
+ */
+struct ltc3350_init_param {
+	/** Device Communication initialization structure I2C */
+	struct no_os_i2c_init_param i2c_init;
+};
+
+/**
+ * @brief LTC3350 Device structure.
+ * @struct ltc3350_dev
+ */
+struct ltc3350_dev {
+	/** Device I2C Communication */
+	struct no_os_i2c_desc *i2c_desc;
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+/*! NO OS Requirements */
+/*! Initialize the device driver before use. */
+int ltc3350_init(struct ltc3350_dev **device,
+		 struct ltc3350_init_param *init_param);
+/*! Free memory allocated by ltc3350_init(). */
+int ltc3350_remove(struct ltc3350_dev *dev);
+
+/*! General functions */
+/*! Read a device register through the I2C interface. */
+int ltc3350_read_device_data(struct ltc3350_dev *dev, uint8_t base_address,
+			     uint16_t *read_data);
+/*! Write a device register through the I2C interface. */
+int ltc3350_write_device_data(struct ltc3350_dev *dev, uint8_t base_address,
+			      uint16_t write_data);
+
+/*! LTC3350 functions */
+
+/* LTC3350_USE_MEASUREMENTS == 1 */
+
+#if LTC3350_USE_MEASUREMENTS
+
+/*! Gets number of capacitors configured */
+int ltc3350_get_num_caps(struct ltc3350_dev *dev, uint8_t *num_caps);
+
+/*! Reads the ESR data. */
+int ltc3350_get_esr(struct ltc3350_dev *dev, uint16_t *value);
+/*! Reads the Vcap data for selected n_cap, 0 for generic. */
+int ltc3350_get_vcap(struct ltc3350_dev *dev, uint8_t n_cap, uint16_t *value);
+
+#endif
+
+/* LTC3350_USE_ALARMS == 0 */
+
+#if LTC3350_USE_ALARMS
+
+/*! Set an specific alarm and its related threshold value. */
+int ltc3350_set_alarm(struct ltc3350_dev *dev, enum ltc3350_enum_alarms alarm,
+		      uint16_t alarm_threshold);
+/*! Mute an specific alarm. */
+int ltc3350_mute_alarm(struct ltc3350_dev *dev, enum ltc3350_enum_alarms alarm);
+/*! Get alarms status mask*/
+int ltc3350_get_alarm_status_mask(struct ltc3350_dev *dev,
+				  uint16_t *alarm_mask);
+/*! Clear alarms status mask*/
+int ltc3350_clear_alarm_status_mask(struct ltc3350_dev *dev);
+
+#endif
+
+#endif /* __LTC3350_H__ */


### PR DESCRIPTION
## Pull Request Description

The LTC3350 is a backup power controller that can charge and monitor a series stack of one to four supercapacitors. The LTC3350’s synchronous step-down controller drives N‑channel MOSFETs for constant current/constant voltage charging with a programmable input current limit. In addition, the step-down converter can run in reverse as a step-up converter to deliver power from the supercapacitor stack to the backup supply rail. Internal balancers eliminate the need for external balance resistors and each capacitor has a shunt regulator for overvoltage protection.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
