### PR TITLE
Stm32 vscode support

### DIFF
--- a/tools/scripts/generic.mk
+++ b/tools/scripts/generic.mk
@@ -78,6 +78,7 @@ PLATFORM_TOOLS	= $(NO-OS)/tools/scripts/platform/$(PLATFORM)
 BINARY_FILE_NAME ?= $(PROJECT_NAME)
 BINARY			?=  $(BUILD_DIR)/$(BINARY_FILE_NAME).elf
 PROJECT_TARGET		= $(BUILD_DIR)/.project.target
+VSCODE_CFG_DIR	= $(PROJECT)/.vscode
 
 # New line variable
 define ENDL
@@ -234,6 +235,11 @@ OBJS_FILE = $(BUILD_DIR)/$(PROJECT_NAME)-objs.txt
 CFLAGS_FILE = $(BUILD_DIR)/$(PROJECT_NAME)-cflags.txt
 CPPFLAGS_FILE = $(BUILD_DIR)/$(PROJECT_NAME)-cppflags.txt
 ASFLAGS_FILE = $(BUILD_DIR)/$(PROJECT_NAME)-asflags.txt
+
+# Prepare for VS Code Debug Intellisense applied at target $(PROJECT_TARGET)_configure - depends on a complete CFLAGS
+include ../../tools/scripts/vsc_intellisense.mk
+# Prepare for VS Code Debug config applied at target $(PROJECT_TARGET)_configure
+include ../../tools/scripts/vsc_openocd_debug.mk
 
 #------------------------------------------------------------------------------
 #                             Generic Goals                         

--- a/tools/scripts/platform/template_c_cpp_properties.json
+++ b/tools/scripts/platform/template_c_cpp_properties.json
@@ -1,0 +1,18 @@
+{
+    "configurations": [
+        {
+            "name": "Linux",
+            "includePath": [
+                VSCODE_INCLUDEPATH_INTELLI
+            ],
+            "defines": [
+                VSCODE_DEFINES_INTELLI
+            ],
+            "compilerPath": "/usr/bin/arm-none-eabi-gcc",
+            "cStandard": "gnu11",
+            "cppStandard": "gnu++11",
+            "intelliSenseMode": "linux-gcc-arm"
+        }
+    ],
+    "version": 4
+}

--- a/tools/scripts/platform/template_launch.json
+++ b/tools/scripts/platform/template_launch.json
@@ -1,0 +1,35 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "cwd": "${workspaceFolder}",
+            "executable": VSCODE_ELF_FILE,
+            "name": "OpenOCD(stlink-dap)",
+            "request": "launch",
+            "type": "cortex-debug",
+            "servertype": "openocd",
+            "svdFile": VSCODE_SVD_FILE,
+            "configFiles": [
+                VSCODE_STLINKCFG_FILE
+            ],
+            "searchDir": [ VSCODE_SEARCH_DIR ],
+            "runToEntryPoint": "main",
+            "showDevDebugOutput": "none"
+        },
+        {
+            "cwd": "${workspaceFolder}",
+            "executable": VSCODE_ELF_FILE,
+            "name": "OpenOCD(cmsis-dap)",
+            "request": "launch",
+            "type": "cortex-debug",
+            "servertype": "openocd",
+            "svdFile": VSCODE_SVD_FILE,
+            "configFiles": [
+                VSCODE_CMSISCFG_FILE
+            ],
+            "searchDir": [ VSCODE_SEARCH_DIR ],
+            "runToEntryPoint": "main",
+            "showDevDebugOutput": "none"
+        }
+    ]
+}

--- a/tools/scripts/platform/template_settings.json
+++ b/tools/scripts/platform/template_settings.json
@@ -1,0 +1,4 @@
+{
+    "cortex-debug.gdbPath": VSCODE_GDB_PATH,
+    "cortex-debug.openocdPath": VSCODE_OPENOCD_PATH
+}

--- a/tools/scripts/vsc_intellisense.mk
+++ b/tools/scripts/vsc_intellisense.mk
@@ -1,0 +1,36 @@
+#
+#	Makefile to create project dependent configs files to enable VS Code IntelliSense
+#
+
+# Definitions
+CPP_PROP_TEMPLATE		= $(NO-OS)/tools/scripts/platform/template_c_cpp_properties.json
+CPP_PROP_JSON	 		= $(VSCODE_CFG_DIR)/c_cpp_properties.json
+COMMA 					= ,
+
+# Remove -I and -D
+FLAGS_WITHOUT_D 		= $(sort $(subst -D,,$(filter -D%, $(CFLAGS))))
+INCS_WITHOUT_I 			= $(sort $(subst -I,,$(filter -I%, $(CFLAGS))))
+
+# Add quotation marks
+INCLUDEPATH_INTELLI		:= $(patsubst %,"%",$(strip $(INCS_WITHOUT_I)))
+DEFINES_INTELLI			:= $(patsubst %,"%",$(strip $(FLAGS_WITHOUT_D)))
+
+# Add Comma after each include/define but exclude last item
+INCLUDEPATH_INTELLI		:= $(subst " ,"$(COMMA) ,$(INCLUDEPATH_INTELLI))
+DEFINES_INTELLI			:= $(subst " ,"$(COMMA) ,$(DEFINES_INTELLI))
+
+# Correct include path to point at the source not at the build directory
+INCLUDE_CORE_PATTERN 	= $(PROJECT_BUILD)/$(PROJECT_NAME)
+INCLUDE_CORE_CORRECTED	= $(PROJECT)
+INCLUDE_NOOS_PATTERN	= $(PROJECT_BUILD)/noos
+INCLUDE_NOOS_CORRECTED	= $(NO-OS)
+
+# Apply the path corrections
+INCLUDEPATH_INTELLI		:= $(subst ${INCLUDE_CORE_PATTERN},$(INCLUDE_CORE_CORRECTED),$(strip $(INCLUDEPATH_INTELLI)))
+INCLUDEPATH_INTELLI		:= $(subst ${INCLUDE_NOOS_PATTERN},$(INCLUDE_NOOS_CORRECTED),$(strip $(INCLUDEPATH_INTELLI)))
+
+# Read content of template into variable and subst keywords
+CPP_FINAL_CONTENT		:= $(file < $(CPP_PROP_TEMPLATE))
+CPP_FINAL_CONTENT		:= $(subst VSCODE_INCLUDEPATH_INTELLI,$(INCLUDEPATH_INTELLI),$(CPP_FINAL_CONTENT))
+CPP_FINAL_CONTENT 		:= $(subst VSCODE_DEFINES_INTELLI,$(DEFINES_INTELLI),$(CPP_FINAL_CONTENT))
+

--- a/tools/scripts/vsc_openocd_debug.mk
+++ b/tools/scripts/vsc_openocd_debug.mk
@@ -1,0 +1,26 @@
+#
+#	Makefile to create project dependent configs files for debugging with openocd
+#
+
+# Definitions
+SETTINGS_TEMPLATE	:= $(NO-OS)/tools/scripts/platform/template_settings.json
+LAUNCH_TEMPLATE		:= $(NO-OS)/tools/scripts/platform/template_launch.json
+SETTINGSJSON 		:= $(VSCODE_CFG_DIR)/settings.json
+LAUNCHJSON 			:= $(VSCODE_CFG_DIR)/launch.json
+
+# Determine arm-none-eabi-gdb path
+GDB_PATH			:= $(realpath $(dir $(shell which $(GDB))))
+
+# Read content of settings template into variable and subst keywords
+VSC_SET_CONTENT		:= $(file < $(SETTINGS_TEMPLATE))
+VSC_SET_CONTENT		:= $(subst VSCODE_GDB_PATH,"$(GDB_PATH)/$(GDB)",$(VSC_SET_CONTENT))
+VSC_SET_CONTENT		:= $(subst VSCODE_OPENOCD_PATH,"$(OPENOCD_BIN)/openocd",$(VSC_SET_CONTENT))
+
+# Read content of launch template into variable and subst keywords
+VSC_LAUNCH_CONTENT	:= $(file < $(LAUNCH_TEMPLATE))
+VSC_LAUNCH_CONTENT	:= $(subst VSCODE_ELF_FILE,"$(BINARY)",$(VSC_LAUNCH_CONTENT))
+VSC_LAUNCH_CONTENT	:= $(subst VSCODE_SEARCH_DIR,"$(OPENOCD_SCRIPTS)",$(VSC_LAUNCH_CONTENT))
+VSC_LAUNCH_CONTENT	:= $(subst VSCODE_CMSISCFG_FILE,"$(BINARY).openocd-cmsis",$(VSC_LAUNCH_CONTENT))
+VSC_LAUNCH_CONTENT	:= $(subst VSCODE_STLINKCFG_FILE,"$(BINARY).openocd",$(VSC_LAUNCH_CONTENT))
+VSC_LAUNCH_CONTENT	:= $(subst VSCODE_SVD_FILE,"$(OPENOCD_SVD)/$(TARGETSVD).svd",$(VSC_LAUNCH_CONTENT))
+


### PR DESCRIPTION
## Pull Request Description

This feature update enables the use of the popular VS Code editor for debugging and intellisense.
An update of the no-OS built process is provided to automatically create the necessary config files.
Template config files are filled with the necessary information. These files can be found at $(no-OS-Path)/tools/scripts/templates
To make the intellisense feature of VS Code usable the project dependent include paths 
and defines are derived from the CFLAGS variable and parsed via the template to the c_cpp_properties.json file.
Debugging with VS Code is restricted for now to the stm32 platform and OpenOCD debugger cmsis-dap and stlink-dap. 
The debugging config files are settings.json and launch.json.
The necessary information is mainly collected from already available variables of the stm32.mk file.
Due to limited availability of hardware tests have been done with the ADI SDP-K1 development board.
Darius Berghe helped testing with stm32 nucleo board.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
