### PR TITLE
axi_core: jesd204: axi_jesd204_*x.c Fix lane clock

### DIFF
--- a/drivers/axi_core/jesd204/axi_jesd204_rx.c
+++ b/drivers/axi_core/jesd204/axi_jesd204_rx.c
@@ -51,6 +51,7 @@
 #include "axi_jesd204_rx.h"
 #include "no_os_axi_io.h"
 #include "no_os_print_log.h"
+#include "jesd204_clk.h"
 
 /******************************************************************************/
 /********************** Macros and Constants Definitions **********************/
@@ -995,6 +996,10 @@ int32_t axi_jesd204_rx_init_jesd_fsm(struct axi_jesd204_rx **jesd204,
 		ret = -ENOMEM;
 		goto err_1;
 	}
+
+	struct jesd204_clk *clk1 = init->lane_clk.dev_desc;
+	clk1->jesd_tx = NULL;
+	clk1->jesd_rx = jesd;
 
 	ret = no_os_clk_init(&clk_desc, &init->lane_clk);
 	if (ret)

--- a/drivers/axi_core/jesd204/axi_jesd204_tx.c
+++ b/drivers/axi_core/jesd204/axi_jesd204_tx.c
@@ -51,6 +51,7 @@
 #include "no_os_axi_io.h"
 #include "no_os_delay.h"
 #include "no_os_print_log.h"
+#include "jesd204_clk.h"
 
 /******************************************************************************/
 /********************** Macros and Constants Definitions **********************/
@@ -907,6 +908,10 @@ int32_t axi_jesd204_tx_init_jesd_fsm(struct axi_jesd204_tx **jesd204,
 		ret = -ENOMEM;
 		goto err_1;
 	}
+
+	struct jesd204_clk *clk1 = init->lane_clk.dev_desc;
+	clk1->jesd_tx = jesd;
+	clk1->jesd_rx = NULL;
 
 	ret = no_os_clk_init(&clk_desc, &init->lane_clk);
 	if (ret)

--- a/projects/ad6676-ebz/src.mk
+++ b/projects/ad6676-ebz/src.mk
@@ -20,6 +20,8 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c \
+	$(DRIVERS)/axi_core/jesd204/jesd204_clk.c \
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
 	$(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/api/no_os_gpio.c \
@@ -52,6 +54,8 @@ INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \
 	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h \
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h \
+	$(DRIVERS)/axi_core/jesd204/jesd204_clk.h \
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h \
 	$(DRIVERS)/io-expander/demux_spi/demux_spi.h \
 	$(DRIVERS)/adc/ad6676/ad6676.h

--- a/projects/ad9172/src.mk
+++ b/projects/ad9172/src.mk
@@ -28,6 +28,7 @@ SRCS += $(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c \
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c \
+	$(DRIVERS)/axi_core/jesd204/jesd204_clk.c \
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
 	$(NO-OS)/util/no_os_util.c \
 	$(NO-OS)/util/no_os_alloc.c \
@@ -63,6 +64,7 @@ INCS += $(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.h \
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h \
+	$(DRIVERS)/axi_core/jesd204/jesd204_clk.h \
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h
 INCS +=	$(PLATFORM_DRIVERS)/$(PLATFORM)_spi.h \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_gpio.h

--- a/projects/ad9208/src.mk
+++ b/projects/ad9208/src.mk
@@ -40,6 +40,7 @@ SRCS += $(DRIVERS)/api/no_os_spi.c \
 SRCS += $(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c \
+	$(DRIVERS)/axi_core/jesd204/jesd204_clk.c \
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
 	$(NO-OS)/util/no_os_util.c \
 	$(NO-OS)/util/no_os_alloc.c \
@@ -56,6 +57,7 @@ INCS += $(DRIVERS)/frequency/hmc7044/hmc7044.h \
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h \
+	$(DRIVERS)/axi_core/jesd204/jesd204_clk.h \
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h
 INCS +=	$(PLATFORM_DRIVERS)/$(PLATFORM)_spi.h \
 	$(PLATFORM_DRIVERS)/$(PLATFORM)_gpio.h

--- a/projects/ad9371/src.mk
+++ b/projects/ad9371/src.mk
@@ -29,6 +29,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c \
+	$(DRIVERS)/axi_core/jesd204/jesd204_clk.c \
 	$(NO-OS)/util/no_os_clk.c \
 	$(NO-OS)/util/no_os_util.c \
 	$(NO-OS)/util/no_os_alloc.c \
@@ -88,7 +89,8 @@ INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \
 	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.h \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h \
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h \
+	$(DRIVERS)/axi_core/jesd204/jesd204_clk.h
 ifeq (xilinx,$(strip $(PLATFORM)))
 INCS += $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h \
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h \

--- a/projects/ad9656_fmc/src.mk
+++ b/projects/ad9656_fmc/src.mk
@@ -21,6 +21,8 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
         $(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
         $(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
         $(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c \
+        $(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c \
+        $(DRIVERS)/axi_core/jesd204/jesd204_clk.c \
         $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
         $(DRIVERS)/adc/ad9656/ad9656.c \
         $(DRIVERS)/frequency/ad9553/ad9553.c \
@@ -52,6 +54,8 @@ INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \
         $(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h \
         $(DRIVERS)/axi_core/jesd204/axi_adxcvr.h \
         $(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h \
+        $(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h \
+        $(DRIVERS)/axi_core/jesd204/jesd204_clk.h \
         $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h \
         $(DRIVERS)/frequency/ad9553/ad9553.h \
         $(DRIVERS)/frequency/ad9508/ad9508.h \

--- a/projects/adrv9009/src.mk
+++ b/projects/adrv9009/src.mk
@@ -48,6 +48,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c \
+	$(DRIVERS)/axi_core/jesd204/jesd204_clk.c \
 	$(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/api/no_os_gpio.c \
 	$(NO-OS)/jesd204/jesd204-core.c \
@@ -129,7 +130,8 @@ INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \
 	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.h \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h \
-	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h \
+	$(DRIVERS)/axi_core/jesd204/jesd204_clk.h
 ifeq (xilinx,$(strip $(PLATFORM)))
 INCS += $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h \
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h \

--- a/projects/fmcadc2/src.mk
+++ b/projects/fmcadc2/src.mk
@@ -17,6 +17,8 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c \
+	$(DRIVERS)/axi_core/jesd204/jesd204_clk.c \
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
 	$(DRIVERS)/adc/ad9625/ad9625.c \
 	$(DRIVERS)/api/no_os_spi.c \
@@ -50,6 +52,8 @@ INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \
 	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h \
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h \
+	$(DRIVERS)/axi_core/jesd204/jesd204_clk.h \
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h \
 	$(DRIVERS)/adc/ad9625/ad9625.h					
 INCS +=	$(PLATFORM_DRIVERS)/$(PLATFORM)_spi.h \

--- a/projects/fmcadc5/src.mk
+++ b/projects/fmcadc5/src.mk
@@ -18,6 +18,8 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c \
+	$(DRIVERS)/axi_core/jesd204/jesd204_clk.c \
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
 	$(DRIVERS)/adc/ad9625/ad9625.c \
 	$(DRIVERS)/api/no_os_spi.c \
@@ -50,6 +52,8 @@ INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \
 	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h \
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h \
+	$(DRIVERS)/axi_core/jesd204/jesd204_clk.h \
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h \
 	$(DRIVERS)/adc/ad9625/ad9625.h					
 INCS +=	$(PLATFORM_DRIVERS)/$(PLATFORM)_spi.h \

--- a/projects/fmcdaq3/src.mk
+++ b/projects/fmcdaq3/src.mk
@@ -19,6 +19,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c \
+	$(DRIVERS)/axi_core/jesd204/jesd204_clk.c \
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
 	$(DRIVERS)/frequency/ad9528/ad9528.c \
 	$(DRIVERS)/adc/ad9680/ad9680.c \
@@ -63,6 +64,7 @@ INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h \
+	$(DRIVERS)/axi_core/jesd204/jesd204_clk.h \
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h \
 	$(DRIVERS)/frequency/ad9528/ad9528.h \
 	$(DRIVERS)/adc/ad9680/ad9680.h \

--- a/projects/fmcjesdadc1/src.mk
+++ b/projects/fmcjesdadc1/src.mk
@@ -17,6 +17,8 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.c \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.c \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.c \
+	$(DRIVERS)/axi_core/jesd204/jesd204_clk.c \
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
 	$(DRIVERS)/io-expander/demux_spi/demux_spi.c \
 	$(DRIVERS)/api/no_os_spi.c \
@@ -52,6 +54,8 @@ INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \
 	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h \
 	$(DRIVERS)/axi_core/jesd204/axi_adxcvr.h \
 	$(DRIVERS)/axi_core/jesd204/axi_jesd204_rx.h \
+	$(DRIVERS)/axi_core/jesd204/axi_jesd204_tx.h \
+	$(DRIVERS)/axi_core/jesd204/jesd204_clk.h \
 	$(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h \
 	$(DRIVERS)/io-expander/demux_spi/demux_spi.h \
 	$(DRIVERS)/adc/ad9250/ad9250.h \


### PR DESCRIPTION
## Pull Request Description

Fix the lane clock initialization in axi_jesd204_rx.c and axi_jesd204_tx.c (set the jesd_rx or jesd_tx member of the jesd204_clock structure to the corresponding AXI jesd structure.

Fixes: https://github.com/analogdevicesinc/no-OS/commit/43da1f0153340d2f849ee3872f842bc860b7d59a ("axi_core: jesd204: axi_jesd204: Add lane clock")

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
