### PR TITLE
drivers:adc:ad469x:Add API to configure VREF_SET

### DIFF
--- a/drivers/adc/ad469x/ad469x.c
+++ b/drivers/adc/ad469x/ad469x.c
@@ -838,6 +838,45 @@ int32_t ad469x_reset_dev(struct ad469x_dev *dev)
 }
 
 /**
+ * @brief Get the value of reference
+ * @param device AD469x Device instance.
+ * @param ref_set Value of VREF_SET
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int32_t ad469x_get_reference(struct ad469x_dev *device,
+			     enum ad469x_ref_set *ref_set)
+{
+	int32_t ret;
+	uint8_t reg_data;
+
+	if (!device)
+		return -EINVAL;
+
+	ret = ad469x_spi_reg_read(device, AD469x_REG_REF_CTRL, &reg_data);
+	if (ret)
+		return ret;
+
+	*ref_set = no_os_field_get(AD469x_REG_REF_VREF_SET_MASK, reg_data);
+
+	return 0;
+}
+
+/**
+ * @brief Set the value of reference
+ * @param device AD469x Device instance.
+ * @param ref_set Value of VREF_SET
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int32_t ad469x_set_reference(struct ad469x_dev *device,
+			     enum ad469x_ref_set ref_set)
+{
+	return ad469x_spi_write_mask(device,
+				     AD469x_REG_REF_CTRL,
+				     AD469x_REG_REF_VREF_SET_MASK,
+				     no_os_field_prep(AD469x_REG_REF_VREF_SET_MASK, ref_set));
+}
+
+/**
  * Configure the device with initial parameters.
  * @param [in, out] dev - The device structure.
  * @param [in] config_desc - Pointer to structure containing configuration

--- a/drivers/adc/ad469x/ad469x.h
+++ b/drivers/adc/ad469x/ad469x.h
@@ -232,6 +232,18 @@ enum ad469x_pin_pairing {
 };
 
 /**
+ * @enum ad469x_ref_set
+ * @brief Reference input range control
+ */
+enum ad469x_ref_set {
+	AD469x_2P4_2P75,
+	AD469x_2P75_3P25,
+	AD469x_3P25_3P75,
+	AD469x_3P75_4P5,
+	AD469x_4P5_5P1,
+};
+
+/**
  * @struct ad469x_init_param
  * @brief  Structure containing the init parameters needed by the ad469x device
  */
@@ -412,6 +424,14 @@ int32_t ad469x_reset_dev(struct ad469x_dev *dev);
 /* Configures the AD469x device */
 int32_t ad469x_config(struct ad469x_dev *dev,
 		      struct ad469x_init_param *config_desc);
+
+/* Get Reference */
+int32_t ad469x_get_reference(struct ad469x_dev *device,
+			     enum ad469x_ref_set *ref_set);
+
+/* Set reference */
+int32_t ad469x_set_reference(struct ad469x_dev *device,
+			     enum ad469x_ref_set ref_set);
 
 /* Initialize the device. */
 int32_t ad469x_init(struct ad469x_dev **device,


### PR DESCRIPTION
Add an API to get and set the value of VREF_SET in the Reference control register

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
