### PR TITLE
export elf files for non-xilinx platforms

### DIFF
--- a/tools/scripts/build_projects.py
+++ b/tools/scripts/build_projects.py
@@ -219,10 +219,13 @@ class BuildConfig:
 		self.binary = os.path.join(self.build_dir, self._binary)
 		self.export_file = os.path.join(self.build_dir, self.binary)
 		if (platform == 'aducm3029' or platform == 'stm32' or platform == 'maxim'):
+			self.export_elf_file = self.export_file
 			self.export_file = self.export_file.replace('.elf', '.hex')
 		if (platform == 'pico'):
+			self.export_elf_file = self.export_file
 			self.export_file = self.export_file.replace('.elf', '.uf2')
 		if (platform == 'mbed'):
+			self.export_elf_file = self.export_file
 			self.export_file = self.export_file.replace('.elf', '.bin')
 		if (platform == 'xilinx'):
 			self.export_boot_bin = os.path.join(self.build_dir, "output_boot_bin/BOOT.BIN")
@@ -360,6 +363,8 @@ def main():
 						else:
 							run_cmd("cp %s %s" %
 								(new_build.export_file, project_export))
+							run_cmd("cp %s %s" %
+								(new_build.export_elf_file, project_export))
 							binary_created = True
 			
 		fp.close()


### PR DESCRIPTION
## Pull Request Description

Exporting also .elf files for the non-xilinx platform not just the file with the specific format for every platform (.hex .uf2 .bin).
Also eliminating run_cmd_stm function because is not necessary anymore.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [x] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
