### PR TITLE
drivers: digital-io: max22190 : Add max22190 driver support

### DIFF
--- a/doc/sphinx/source/drivers/max22190.rst
+++ b/doc/sphinx/source/drivers/max22190.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../drivers/digital-io/max22190/README.rst

--- a/doc/sphinx/source/drivers_doc.rst
+++ b/doc/sphinx/source/drivers_doc.rst
@@ -24,6 +24,7 @@ DIGITAL INPUT/OUTPUT
    :maxdepth: 1
 
    drivers/max149x6
+   drivers/max22190
 
 INERTIAL MEASUREMENT UNITS
 ==========================

--- a/drivers/digital-io/max22190/README.rst
+++ b/drivers/digital-io/max22190/README.rst
@@ -1,0 +1,176 @@
+MAX22190 no-OS driver
+=====================
+
+Supported Devices
+-----------------
+
+`MAX22190 <https://www.analog.com/MAX22190>`_
+
+Overview
+--------
+
+The MAX22190 is an IEC 61131-2 compliant industrial digital input device.
+The MAX22190 translates eight, 24V current-sinking, industrial inputs to a 
+serialized SPI-compatible output that interfaces with 3V to 5.5V logic.
+A current setting resistor allows the MAX22190 to be configured for Type 1, 
+Type 2, or Type 3 inputs. Field wiring is verified for proximity switches, 
+by a second threshold detector on each input. When wire-break is enabled, 
+the active-low FAULT output is asserted and a register flag is set if the 
+input current drops below the wire-break threshold for more than 20ms. 
+Additional diagnostics that assert the active-ow FAULT pin include: 
+overtemperature, low 24V field supply, 24V field supply missing, 
+CRC communication error, etc.
+
+Applications
+------------
+
+MAX22190
+--------
+
+* Building Automation
+* Industrial Automation
+* Process Automation
+* Programmable Logic Controllers
+
+MAX22190 Device Configuration
+-----------------------------
+
+Driver Initialization
+---------------------
+
+In order to be able to use the device, you will have to provide the support
+for the communication protocol (SPI).
+
+The first API to be called is **max22190_init**. Make sure that it returns 0,
+which means that the driver was initialized correctly.
+
+Channel Configuration
+---------------------
+
+Each channel's state can be set with the **max22190_chan_state** API.
+The user can also set a wire break detection for the channel with
+**max22190_wbe_set** API, and read the Wire Break state with
+**max22190_wbe_get** API.
+
+Filter Configuration
+--------------------
+
+Filter can be bypassed for each channel separately, although if they are not,
+the user can set a filter delay.
+All this can be done with the **max22190_filter_set** API, and also the user
+can read the filter configuration for each channel with **max22190_filter_get**.
+
+Fault Enable Configuration
+--------------------------
+
+Fault Enable bits can be configured with the help of the
+**max22190_fault_enable_set** API and read with **max22190_fault_enable_get**.
+If an enable bit is set, then the fault will be signaled in the fault register,
+otherwise it will not.
+
+MAX22190 Driver Initialization Example
+--------------------------------------
+
+.. code-block:: bash
+
+	struct max22190_desc *max22190_desc;
+	struct no_os_spi_init_param max22190_spi_ip = {
+		.device_id = 0,
+		.extra = &max22190_spi_extra,
+		.max_speed_hz = 100000,
+		.platform_ops = &max_spi_ops,
+		.chip_select = 1,
+	};
+	struct max22190_init_param max22190_ip = {
+		.comm_param = &max22190_spi_ip,
+		.crc_en = false,
+	};
+	ret = max22190_init(&max22190_desc, &max22190_ip);
+	if (ret)
+		goto error;
+
+MAX22190 no-OS IIO support
+--------------------------
+
+The MAX22190 IIO driver comes on top of the MAX22190 driver and offers support
+for interfacing IIO clients through libiio.
+
+MAX22190 IIO Device Configuration
+---------------------------------
+
+Channel Attributes
+------------------
+
+MAX22190 has a total of 6 channel attributes:
+
+* ``raw - the state of a channel``
+* ``offset - always 0``
+* ``scale - always 1``
+* ``filter_bypass - determines if the filter is used on the requested channel or not.``
+* ``filter_delay - if the filter_bypass is set to 1, the filter's delay can be set from here.``
+* ``filter_delay_available - list of possible filter delay's.``
+
+Debug Attributes
+----------------
+
+ * ``fault1 - fault1 register value``
+ * ``fault2 - fault2 register value``
+ * ``wbg_enable - Wire Break detection asserted to fault pin``
+ * ``24vm_enable - 24V Supply Missing detection asserted to fault pin``
+ * ``24vl_enable - 24V Supply Low detection asserted to fault pin``
+ * ``alrmt1_enable - Alarm 1 threshold detection asserted to fault pin``
+ * ``alrmt2_enable - Alarm 2 threshold detection asserted to fault pin``
+ * ``fault2_enable - Any bit from fault2 is asserted to fault pin``
+ * ``rfwbs_enable - RFWB short detection is asserted to fault pin``
+ * ``rfwbo_enable - RFWB open detection is asserted to fault pin``
+ * ``rfdis_enable - RFDI short detection is asserted to fault pin``
+ * ``rfdio_enable - RFDI open detection is asserted to fault pin``
+ * ``otshdn_enable - Overtemperature shutdown``
+ * ``fault8ck_enable - SPI receives bad number of clock pulses``
+
+Device Channels
+---------------
+
+MAX22190 has a specific API, **max22190_iio_setup_channels** for configuring the
+channels at the initialization, therefore the channels can be enabled or
+disabled at initialization only.
+
+MAX22190 IIO Driver Initialization Example
+------------------------------------------
+
+.. code-block:: bash
+
+	int ret;
+
+	struct max22190_iio_desc *max22190_iio_desc;
+	struct max22190_iio_desc_init_param max22190_iio_ip = {
+		.max22190_init_param = &max22190_ip,
+		.ch_enabled = {
+			true, true, true, false, false, false, false, false
+		},
+	};
+
+	struct iio_app_desc *app;
+	struct iio_app_init_param app_init_param = { 0 };
+
+	ret = max22190_iio_init(&max22190_iio_desc, &max22190_iio_ip);
+	if (ret)
+		goto error;
+
+	struct iio_app_device iio_devices[] = {
+		{
+			.name = "max22190",
+			.dev = max22190_iio_desc,
+			.dev_descriptor = max22190_iio_desc->iio_dev,
+		},
+	};
+
+	app_init_param.devices = iio_devices;
+	app_init_param.nb_devices = NO_OS_ARRAY_SIZE(iio_devices);
+	app_init_param.uart_init_params = max22190_uart_ip;
+
+	ret = iio_app_init(&app, app_init_param);
+	if (ret)
+		goto app_error;
+
+	return iio_app_run(app);

--- a/drivers/digital-io/max22190/iio_max22190.c
+++ b/drivers/digital-io/max22190/iio_max22190.c
@@ -1,0 +1,595 @@
+/***************************************************************************//**
+ *   @file   iio_max22190.c
+ *   @brief  Source file of MAX22190 IIO Driver.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include "no_os_alloc.h"
+#include "no_os_error.h"
+#include "no_os_units.h"
+#include "no_os_util.h"
+
+#include "max22190.h"
+#include "iio_max22190.h"
+
+static int max22190_iio_read_raw(void *dev, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel,
+				 intptr_t priv);
+
+static int max22190_iio_read_scale(void *dev, char *buf, uint32_t len,
+				   const struct iio_ch_info *channel,
+				   intptr_t priv);
+
+static int max22190_iio_read_filter(void *dev, char *buf, uint32_t len,
+				    const struct iio_ch_info *channel,
+				    intptr_t priv);
+
+static int max22190_iio_write_filter(void *dev, char *buf, uint32_t len,
+				     const struct iio_ch_info *channel,
+				     intptr_t priv);
+
+static int max22190_iio_read_filter_delay(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv);
+
+static int max22190_iio_write_filter_delay(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv);
+
+static int max22190_iio_read_filter_available(void *dev, char *buf,
+		uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv);
+
+static int max22190_iio_read_fault(void *dev, char *buf, uint32_t len,
+				   const struct iio_ch_info *channel,
+				   intptr_t priv);
+
+static int max22190_iio_read_fault_enable(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv);
+
+static int max22190_iio_write_fault_enable(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv);
+
+static int max22190_iio_reg_read(struct max22190_iio_desc *dev, uint32_t reg,
+				 uint32_t *readval);
+
+static int max22190_iio_reg_write(struct max22190_iio_desc *dev, uint32_t reg,
+				  uint32_t writeval);
+
+static const uint32_t max22190_delay_avail[8] = {
+	50, 100, 400, 800, 1800, 3200, 12800, 20000
+};
+
+static struct iio_attribute max22190_attrs[] = {
+	{
+		.name = "raw",
+		.show = max22190_iio_read_raw,
+	},
+	{
+		.name = "scale",
+		.show = max22190_iio_read_scale,
+	},
+	{
+		.name = "filter_bypass",
+		.show = max22190_iio_read_filter,
+		.store = max22190_iio_write_filter,
+	},
+	{
+		.name = "filter_delay",
+		.show = max22190_iio_read_filter_delay,
+		.store = max22190_iio_write_filter_delay,
+	},
+	{
+		.name = "filter_delay_available",
+		.show = max22190_iio_read_filter_available,
+		.shared = IIO_SHARED_BY_ALL
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_attribute max22190_debug_attrs[] = {
+	{
+		.name = "fault1",
+		.show = max22190_iio_read_fault,
+		.priv = MAX22190_IIO_FAULT1
+	},
+	{
+		.name = "fault2",
+		.show = max22190_iio_read_fault,
+		.priv = MAX22190_IIO_FAULT2
+	},
+	{
+		.name = "wbg_enable",
+		.show = max22190_iio_read_fault_enable,
+		.store = max22190_iio_write_fault_enable,
+		.priv = MAX22190_FAULT1_WBGE
+	},
+	{
+		.name = "24vm_enable",
+		.show = max22190_iio_read_fault_enable,
+		.store = max22190_iio_write_fault_enable,
+		.priv = MAX22190_FAULT1_24VME
+	},
+	{
+		.name = "24vl_enable",
+		.show = max22190_iio_read_fault_enable,
+		.store = max22190_iio_write_fault_enable,
+		.priv = MAX22190_FAULT1_24VLE
+	},
+	{
+		.name = "alrmt1_enable",
+		.show = max22190_iio_read_fault_enable,
+		.store = max22190_iio_write_fault_enable,
+		.priv = MAX22190_FAULT1_ALRMT1E
+	},
+	{
+		.name = "alrmt2_enable",
+		.show = max22190_iio_read_fault_enable,
+		.store = max22190_iio_write_fault_enable,
+		.priv = MAX22190_FAULT1_ALRMT2E
+	},
+	{
+		.name = "fault2_enable",
+		.show = max22190_iio_read_fault_enable,
+		.store = max22190_iio_write_fault_enable,
+		.priv = MAX22190_FAULT1_FAULT2E
+	},
+	{
+		.name = "rfwbs_enable",
+		.show = max22190_iio_read_fault_enable,
+		.store = max22190_iio_write_fault_enable,
+		.priv = MAX22190_FAULT2_RFWBSE
+	},
+	{
+		.name = "rfwbo_enable",
+		.show = max22190_iio_read_fault_enable,
+		.store = max22190_iio_write_fault_enable,
+		.priv = MAX22190_FAULT2_RFWBOE
+	},
+	{
+		.name = "rfdis_enable",
+		.show = max22190_iio_read_fault_enable,
+		.store = max22190_iio_write_fault_enable,
+		.priv = MAX22190_FAULT2_RFDISE
+	},
+	{
+		.name = "rfdio_enable",
+		.show = max22190_iio_read_fault_enable,
+		.store = max22190_iio_write_fault_enable,
+		.priv = MAX22190_FAULT2_RFDIOE
+	},
+	{
+		.name = "otshdn_enable",
+		.show = max22190_iio_read_fault_enable,
+		.store = max22190_iio_write_fault_enable,
+		.priv = MAX22190_FAULT2_OTSHDNE
+	},
+	{
+		.name = "fault8ck_enable",
+		.show = max22190_iio_read_fault_enable,
+		.store = max22190_iio_write_fault_enable,
+		.priv = MAX22190_FAULT2_FAULT8CKE
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+#define MAX22190_CHANNEL(_addr)			\
+        {					\
+            	.ch_type = IIO_VOLTAGE,		\
+        	.indexed = 1,			\
+		.channel = _addr,		\
+	    	.address = _addr,		\
+		.attributes = max22190_attrs,	\
+		.ch_out = false,		\
+	}
+
+static struct iio_channel max22190_channels[] = {
+	MAX22190_CHANNEL(0),
+	MAX22190_CHANNEL(1),
+	MAX22190_CHANNEL(2),
+	MAX22190_CHANNEL(3),
+	MAX22190_CHANNEL(4),
+	MAX22190_CHANNEL(5),
+	MAX22190_CHANNEL(6),
+	MAX22190_CHANNEL(7)
+};
+
+
+static struct iio_device max22190_iio_dev = {
+	.num_ch = NO_OS_ARRAY_SIZE(max22190_channels),
+	.channels = max22190_channels,
+	.debug_reg_read = (int32_t (*)())max22190_iio_reg_read,
+	.debug_reg_write = (int32_t (*)())max22190_iio_reg_write,
+	.debug_attributes = max22190_debug_attrs,
+};
+
+/**
+ * @brief Read the raw attribute for a specific channel
+ * @param dev - The iio device structure
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor.
+ * @return 0 in case of succes, error code otherwise.
+*/
+static int max22190_iio_read_raw(void *dev, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel,
+				 intptr_t priv)
+{
+	struct max22190_iio_desc *desc = dev;
+	uint32_t val;
+	int ret, ch;
+
+	ch = channel->address;
+
+	ret = max22190_reg_read(desc->max22190_desc, MAX22190_DIGITAL_INPUT_REG,
+				&val);
+	if (ret)
+		return ret;
+
+	val = no_os_field_get(MAX22190_CH_STATE_MASK(ch), val);
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, (int32_t *)&val);
+}
+
+/**
+ * @brief Read the scale attribute for a specific channel
+ * @param dev - The iio device structure
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor.
+ * @return 0 in case of succes, error code otherwise.
+*/
+static int max22190_iio_read_scale(void *dev, char *buf, uint32_t len,
+				   const struct iio_ch_info *channel,
+				   intptr_t priv)
+{
+	int32_t val = 1;
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+}
+
+/**
+ * @brief Read the filter bypass attribute for a specific channel
+ * @param dev - The iio device structure
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor.
+ * @return 0 in case of succes, error code otherwise.
+*/
+static int max22190_iio_read_filter(void *dev, char *buf, uint32_t len,
+				    const struct iio_ch_info *channel,
+				    intptr_t priv)
+{
+	struct max22190_iio_desc *desc = dev;
+	uint32_t val;
+	int ret, ch;
+
+	ch = channel->address;
+
+	ret = max22190_reg_read(desc->max22190_desc, MAX22190_FILTER_IN_REG(ch),
+				&val);
+	if (ret)
+		return ret;
+
+	val = no_os_field_get(MAX22190_FBP_MASK, val);
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, (int32_t *)&val);
+}
+
+/**
+ * @brief Write the filter bypass attribute for a specific channel
+ * @param dev - The iio device structure
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor.
+ * @return 0 in case of succes, error code otherwise.
+*/
+static int max22190_iio_write_filter(void *dev, char *buf, uint32_t len,
+				     const struct iio_ch_info *channel,
+				     intptr_t priv)
+{
+	struct max22190_iio_desc *desc = dev;
+	int ch;
+	uint32_t val;
+
+	ch = channel->address;
+
+	iio_parse_value(buf, IIO_VAL_INT, (int32_t *)&val, NULL);
+
+	if (val > 1)
+		return -EINVAL;
+
+	return max22190_reg_update(desc->max22190_desc,
+				   MAX22190_FILTER_IN_REG(ch),
+				   MAX22190_FBP_MASK,
+				   no_os_field_prep(MAX22190_FBP_MASK,val));
+}
+
+/**
+ * @brief Read the filter delay attribute for a specific channel
+ * @param dev - The iio device structure
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor.
+ * @return 0 in case of succes, error code otherwise.
+*/
+static int max22190_iio_read_filter_delay(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	struct max22190_iio_desc *desc = dev;
+	int ret, ch;
+	uint32_t val;
+
+	ch = channel->address;
+
+	ret = max22190_reg_read(desc->max22190_desc, MAX22190_FILTER_IN_REG(ch),
+				&val);
+	if (ret)
+		return ret;
+
+	val = max22190_delay_avail[no_os_field_get(MAX22190_DELAY_MASK, val)];
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, (int32_t *)&val);
+}
+
+/**
+ * @brief Write the filter delay attribute for a specific channel
+ * @param dev - The iio device structure
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor.
+ * @return 0 in case of succes, error code otherwise.
+*/
+static int max22190_iio_write_filter_delay(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	struct max22190_iio_desc *desc = dev;
+	int ch;
+	uint32_t val, i;
+
+	ch = channel->address;
+
+	iio_parse_value(buf, IIO_VAL_INT, (int32_t *)&val, NULL);
+
+	for (i = 0; i < NO_OS_ARRAY_SIZE(max22190_delay_avail); i++)
+		if (val == max22190_delay_avail[i])
+			break;
+
+	if (i == NO_OS_ARRAY_SIZE(max22190_delay_avail))
+		return -EINVAL;
+
+	return max22190_reg_update(desc->max22190_desc,
+				   MAX22190_FILTER_IN_REG(ch),
+				   MAX22190_DELAY_MASK,
+				   no_os_field_prep(MAX22190_DELAY_MASK, i));
+}
+
+/**
+ * @brief Read the available values for filter delay attribute for a specific
+ * 	  channel
+ * @param dev - The iio device structure
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor.
+ * @return 0 in case of succes, error code otherwise.
+*/
+static int max22190_iio_read_filter_available(void *dev, char *buf,
+		uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	uint32_t avail_size = NO_OS_ARRAY_SIZE(max22190_delay_avail);
+	uint32_t length = 0;
+	uint32_t i;
+
+	for (i = 0; i < avail_size; i++)
+		length += sprintf(buf + length, "%d ", max22190_delay_avail[i]);
+
+	return length;
+}
+
+/**
+ * @brief Read the fault1 or fault 2 attribute for a specific channel
+ * @param dev - The iio device structure
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor.
+ * @return 0 in case of succes, error code otherwise.
+*/
+static int max22190_iio_read_fault(void *dev, char *buf, uint32_t len,
+				   const struct iio_ch_info *channel,
+				   intptr_t priv)
+{
+	struct max22190_iio_desc *desc = dev;
+	uint32_t val;
+	int ret;
+
+	switch(priv) {
+	case MAX22190_IIO_FAULT1:
+		ret = max22190_reg_read(desc->max22190_desc, MAX22190_FAULT1_REG, &val);
+		if (ret)
+			return ret;
+		break;
+	case MAX22190_IIO_FAULT2:
+		ret = max22190_reg_read(desc->max22190_desc, MAX22190_FAULT2_REG, &val);
+		if (ret)
+			return ret;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, (int32_t *)&val);
+}
+
+/****
+ * @brief Read fault enable wrapper.
+ * @param dev - The iio device structure
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor.
+ * @return 0 in case of succes, error code otherwise.
+*/
+static int max22190_iio_read_fault_enable(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	struct max22190_iio_desc *desc = dev;
+	bool val;
+	int ret;
+
+	ret =  max22190_fault_enable_get(desc->max22190_desc, priv, &val);
+	if (ret)
+		return ret;
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, (int32_t *)&val);
+}
+
+/****
+ * @brief Write fault enable wrapper.
+ * @param dev - The iio device structure
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor.
+ * @return 0 in case of succes, error code otherwise.
+*/
+static int max22190_iio_write_fault_enable(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	struct max22190_iio_desc *desc = dev;
+	uint32_t val;
+
+	iio_parse_value(buf, IIO_VAL_INT, (int32_t *)&val, NULL);
+
+	return max22190_fault_enable_set(desc->max22190_desc, priv, (bool)val);
+}
+
+/**
+ * @brief Register read wrapper
+ * @param dev - The iio device structure.
+ * @param reg - The register's address.
+ * @param readval - Register value.
+ * @return 0 in case of succes, error code otherwise
+*/
+static int max22190_iio_reg_read(struct max22190_iio_desc *dev, uint32_t reg,
+				 uint32_t *readval)
+{
+	return max22190_reg_read(dev->max22190_desc, reg, readval);
+}
+
+/**
+ * @brief Register write wrapper
+ * @param dev - The iio device structure.
+ * @param reg - The register's address.
+ *
+ * @param writeval - Register value.
+ *
+ * @return 0 in case of succes, error code otherwise
+*/
+static int max22190_iio_reg_write(struct max22190_iio_desc *dev, uint32_t reg,
+				  uint32_t writeval)
+{
+	return max22190_reg_write(dev->max22190_desc, reg, writeval);
+}
+
+/**
+ * @brief Initializes the MAX22190 IIO Descriptor
+ * @param iio_desc - The iio device descriptor.
+ * @param init_param - The structure that contains the device intial parameters.
+ * @return 0 in case of succes, an error code otherwise.
+*/
+int max22190_iio_init(struct max22190_iio_desc **iio_desc,
+		      struct max22190_iio_desc_init_param *init_param)
+{
+	struct max22190_iio_desc *descriptor;
+	int ret;
+
+	if (!init_param || !init_param->max22190_init_param)
+		return -EINVAL;
+
+	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	ret = max22190_init(&descriptor->max22190_desc,
+			    init_param->max22190_init_param);
+	if (ret)
+		goto free_desc;
+
+	descriptor->iio_dev = &max22190_iio_dev;
+
+	*iio_desc = descriptor;
+
+	return 0;
+
+free_desc:
+	no_os_free(descriptor);
+	return ret;
+}
+
+/**
+ * @brief Free the resources allocated by max22190_iio_init().
+ * @param iio_desc - The IIO device structure.
+ * @return ret - Result of the remove procedure.
+*/
+int max22190_iio_remove(struct max22190_iio_desc *iio_desc)
+{
+	if (!iio_desc)
+		return -ENODEV;
+
+	max22190_remove(iio_desc->max22190_desc);
+	no_os_free(iio_desc);
+
+	return 0;
+}

--- a/drivers/digital-io/max22190/iio_max22190.h
+++ b/drivers/digital-io/max22190/iio_max22190.h
@@ -1,0 +1,75 @@
+/***************************************************************************//**
+ *   @file   iio_max22190.h
+ *   @brief  Header file of MAX22190 IIO Driver.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef IIO_MAX22190_H
+#define IIO_MAX22190_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "iio.h"
+#include "iio_types.h"
+#include "max22190.h"
+
+enum max22190_iio_attr {
+	MAX22190_IIO_FAULT1,
+	MAX22190_IIO_FAULT2,
+};
+
+/**
+ * @brief MAX22190 IIO descriptor
+*/
+struct max22190_iio_desc {
+	struct max22190_desc *max22190_desc;
+	struct iio_device *iio_dev;
+};
+
+/**
+ * @brief MAX22190 IIO initalization parameter
+*/
+struct max22190_iio_desc_init_param {
+	struct max22190_init_param *max22190_init_param;
+};
+
+/** Initializes the MAX22190 IIO descriptor. */
+int max22190_iio_init(struct max22190_iio_desc **,
+		      struct max22190_iio_desc_init_param *);
+
+/** Free resources allocated by the initalization function. */
+int max22190_iio_remove(struct max22190_iio_desc *);
+
+#endif /* IIO_MAX22190_H */

--- a/drivers/digital-io/max22190/max22190.c
+++ b/drivers/digital-io/max22190/max22190.c
@@ -1,0 +1,511 @@
+/***************************************************************************//**
+ *   @file   max22190.c
+ *   @brief  Source file of MAX22190 Driver.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include "max22190.h"
+#include "no_os_util.h"
+#include "no_os_alloc.h"
+
+/**
+ * @brief Compute the CRC5 value for MAX22190
+ * @param data - Data array to calculate CRC for.
+ * @return CRC result.
+*/
+static uint8_t max22190_crc(uint8_t *data)
+{
+	int length = 19;
+	uint8_t crc_step, tmp;
+	uint8_t crc_init = 0x7;
+	uint8_t crc_poly = 0x35;
+	int i;
+
+	/**
+	 * This is the C custom implementation of CRC function for MAX22190, and
+	 * can be found here:
+	 * https://www.analog.com/en/design-notes/guidelines-to-implement-crc-algorithm.html
+	*/
+	uint32_t datainput = (uint32_t)((data[0] << 16) + (data[1] << 8) + data[2]);
+
+	datainput = (datainput & 0xFFFFE0) + crc_init;
+
+	tmp = (uint8_t)((datainput & 0xFC0000) >> 18);
+
+	if ((tmp & 0x20) == 0x20)
+		crc_step = (uint8_t)(tmp ^ crc_poly);
+	else
+		crc_step = tmp;
+
+	for (i = 0; i < length - 1; i++) {
+		tmp = (uint8_t)(((crc_step & 0x1F) << 1) +
+				((datainput >> (length -2 - i)) & 0x01));
+
+		if ((tmp & 0x20) == 0x20)
+			crc_step = (uint8_t)(tmp ^ crc_poly);
+		else
+			crc_step = tmp;
+	}
+
+	return (uint8_t)(crc_step & 0x1F);
+}
+
+/**
+ * @brief Set filter delay, wite break detection and if the filter is used or
+ * 	  bypassed.
+ * @param desc - MAX22190 device descriptor.
+ * @param ch - The channel to which the filter corresponds(0 based).
+ * @param clrf - Filter operation  (0 - normal operation, 1 - filters fixed at
+ * 				    mid -scale value for the chosen delay).
+ * @param fbp - Filter usage(used - 0, bypassed - 1).
+ * @param delay - Filter delay.
+ * @return 0 in case of success, negative error code otherwise.
+*/
+int max22190_filter_set(struct max22190_desc *desc, uint32_t ch, uint32_t clrf,
+			uint32_t fbp, enum max22190_delay delay)
+{
+	int ret;
+
+	if (ch > MAX22190_CHANNELS - 1)
+		return -EINVAL;
+
+	ret = max22190_reg_update(desc, MAX22190_FILTER_IN_REG(ch),
+				  MAX22190_FBP_MASK | MAX22190_DELAY_MASK,
+				  no_os_field_prep(MAX22190_FBP_MASK, fbp) |
+				  no_os_field_prep(MAX22190_DELAY_MASK, delay));
+	if (ret)
+		return ret;
+
+	return max22190_reg_update(desc, MAX22190_CONFIG_REG,
+				   MAX22190_CFG_CLRF_MASK,
+				   no_os_field_prep(MAX22190_CFG_CLRF_MASK,
+						   clrf));
+}
+
+/**
+ * @brief Get filter delay, wite break detection and if the filter is used or
+ * 	  bypassed.
+ * @param desc - MAX22190 device descriptor.
+ * @param ch - The channel to which the filter corresponds(0 based).
+ * @param clrf - Filter operation  (0 - normal operation, 1 - filters fixed at
+ * 				    mid -scale value for the chosen delay).
+ * @param fbp - Filter usage(used - 0, bypassed - 1).
+ * @param delay - Filter delay.
+ * @return 0 in case of success, negative error code otherwise.
+*/
+int max22190_filter_get(struct max22190_desc *desc, uint32_t ch, uint32_t *clrf,
+			uint32_t *fbp, enum max22190_delay *delay)
+{
+	int ret;
+	uint32_t read_byte;
+
+	if (ch > MAX22190_CHANNELS - 1)
+		return -EINVAL;
+
+	ret = max22190_reg_read(desc, MAX22190_FILTER_IN_REG(ch), &read_byte);
+	if (ret)
+		return ret;
+
+	*fbp = no_os_field_get(MAX22190_FBP_MASK, read_byte);
+	*delay = no_os_field_get(MAX22190_DELAY_MASK, read_byte);
+
+	ret = max22190_reg_read(desc, MAX22190_CONFIG_REG, &read_byte);
+	if (ret)
+		return ret;
+
+	*clrf = no_os_field_get(MAX22190_CFG_CLRF_MASK, read_byte);
+
+	return 0;
+}
+
+/**
+ * @brief Switch selected channel's state to disabled or enabled.
+ * @param desc - MAX22190 device descriptor.
+ * @param ch - Channel to disable/enable(0 based).
+ * @param state - The state requested.
+ * @return 0 in case of success, negative error code otherwise.
+*/
+int max22190_chan_state(struct max22190_desc *desc, uint32_t ch,
+			enum max22190_ch_state state)
+{
+	int ret;
+
+	if (ch > MAX22190_CHANNELS - 1)
+		return -EINVAL;
+
+	ret = max22190_reg_update(desc, MAX22190_INPUT_EN_REG,
+				  MAX22190_CH_STATE_MASK(ch), state);
+	if (ret)
+		return ret;
+
+	desc->channels[ch] = state;
+
+	return 0;
+}
+
+/**
+ * @brief Get Wire Break detection for requested channel
+ * @param desc - MAX22190 device descriptor.
+ * @param ch - Channel to read the WBE from.
+ * @param enabled - State of the WBE for the specific channel returned after
+ * 		    reading the register.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22190_wbe_get(struct max22190_desc *desc, uint32_t ch, bool *enabled)
+{
+	int ret;
+	uint32_t reg_val;
+
+	if (ch > MAX22190_CHANNELS - 1)
+		return -EINVAL;
+
+	ret = max22190_reg_read(desc, MAX22190_FILTER_IN_REG(ch), &reg_val);
+	if (ret)
+		return ret;
+
+	*enabled = no_os_field_get(MAX22190_FAULT2_WBE_MASK, reg_val);
+
+	return 0;
+}
+
+/**
+ * @brief Set Wire Break detection for requested channel
+ * @param desc - MAX22190 device descriptor.
+ * @param ch - Channel to set the WBE to.
+ * @param enabled - State of the WBE for the specific channel to be set.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22190_wbe_set(struct max22190_desc *desc, uint32_t ch, bool enabled)
+{
+	if (ch > MAX22190_CHANNELS - 1)
+		return -EINVAL;
+
+	return max22190_reg_update(desc, MAX22190_FILTER_IN_REG(ch),
+				   MAX22190_FAULT2_WBE_MASK,
+				   no_os_field_prep(MAX22190_FAULT2_WBE_MASK,
+						   enabled));
+}
+
+/**
+ * @brief Get fault enable from the fault registers
+ * @param desc - MAX22190 device descriptor
+ * @param fault_enable - Specific fault enable to read
+ * @param enabled - State of the selected enable (0 for disabled, 1 for enabled)
+ * @return 0 in case of succes, negative error code otherwise
+*/
+int max22190_fault_enable_get(struct max22190_desc *desc,
+			      enum max22190_fault_enable fault_enable,
+			      bool *enabled)
+{
+	int ret;
+	uint32_t reg_val;
+
+	switch(fault_enable) {
+	case MAX22190_FAULT1_WBGE ... MAX22190_FAULT1_FAULT2E:
+		ret = max22190_reg_read(desc, MAX22190_FAULT1_EN_REG, &reg_val);
+		if (ret)
+			return ret;
+		*enabled = no_os_field_get(MAX22190_FAULT_MASK(fault_enable),
+					   reg_val);
+		break;
+	case MAX22190_FAULT2_RFWBSE ... MAX22190_FAULT2_FAULT8CKE:
+		ret = max22190_reg_read(desc, MAX22190_FAULT2_EN_REG, &reg_val);
+		if (ret)
+			return ret;
+		*enabled = no_os_field_get(MAX22190_FAULT_MASK(fault_enable -
+					   MAX22190_FAULT2_RFWBSE), reg_val);
+		break;
+	case MAX22190_CFG_24VF:
+		ret = max22190_reg_read(desc, MAX22190_CONFIG_REG, &reg_val);
+		if (ret)
+			return ret;
+		*enabled = no_os_field_get(MAX22190_CFG_24VF_MASK, reg_val);
+		break;
+	case MAX22190_CFG_REFDI_SH_ENA:
+		ret = max22190_reg_read(desc, MAX22190_CONFIG_REG, &reg_val);
+		if (ret)
+			return ret;
+		*enabled = no_os_field_get(MAX22190_CFG_REFDI_MASK, reg_val);
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Set fault enable in the fault registers
+ * @param desc - MAX22190 device descriptor
+ * @param fault_enable - Specific fault enable to write
+ * @param enabled - State of the selected enable (0 for disabled, 1 for enabled)
+ * @return 0 in case of succes, negative error code otherwise
+*/
+int max22190_fault_enable_set(struct max22190_desc *desc,
+			      enum max22190_fault_enable fault_enable,
+			      bool enabled)
+{
+	int ret, i;
+	uint32_t reg_val;
+
+	switch(fault_enable) {
+	case MAX22190_FAULT1_WBGE ... MAX22190_FAULT1_FAULT2E:
+		return max22190_reg_update(desc, MAX22190_FAULT1_EN_REG,
+					   MAX22190_FAULT_MASK(fault_enable),
+					   no_os_field_prep(MAX22190_FAULT_MASK(fault_enable),
+							   enabled));
+	case MAX22190_FAULT2_RFWBSE ... MAX22190_FAULT2_FAULT8CKE:
+		ret = max22190_reg_update(desc, MAX22190_FAULT2_EN_REG,
+					  MAX22190_FAULT_MASK(fault_enable -
+							  MAX22190_FAULT2_RFWBSE),
+					  no_os_field_prep(MAX22190_FAULT_MASK(fault_enable -
+							  MAX22190_FAULT2_RFWBSE),
+							  enabled));
+		if (ret)
+			return ret;
+
+		/* Setting the bit corresponding to the specific fault enable
+		   in the fault2en variable of the descriptor. */
+		desc->fault2en &= ~MAX22190_FAULT_MASK(fault_enable -
+						       MAX22190_FAULT2_RFWBSE);
+		desc->fault2en |= MAX22190_FAULT_MASK(fault_enable -
+						      MAX22190_FAULT2_RFWBSE)
+				  & no_os_field_prep(MAX22190_FAULT_MASK(fault_enable -
+						     MAX22190_FAULT2_RFWBSE),
+						     enabled);
+		desc->fault2en &= MAX22190_FAULT2_EN_MASK;
+
+		return max22190_reg_update(desc, MAX22190_FAULT1_EN_REG,
+					   MAX22190_FAULT_MASK(MAX22190_FAULT1_FAULT2E),
+					   no_os_field_prep(MAX22190_FAULT_MASK(MAX22190_FAULT1_FAULT2E),
+							   !!desc->fault2en));
+	case MAX22190_CFG_24VF:
+		return max22190_reg_update(desc, MAX22190_CONFIG_REG,
+					   MAX22190_CFG_24VF_MASK,
+					   no_os_field_prep(MAX22190_CFG_24VF_MASK,
+							   enabled));
+	case MAX22190_CFG_REFDI_SH_ENA:
+		return max22190_reg_update(desc, MAX22190_CONFIG_REG,
+					   MAX22190_CFG_REFDI_MASK,
+					   no_os_field_prep(MAX22190_CFG_REFDI_MASK,
+							   enabled));
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Register read function for MAX22190
+ * @param desc - MAX22190 device descriptor.
+ * @param addr - Register address from which data is read.
+ * @param val - The value received from the read operation.
+ * @return 0 in case of success, negative error code otherwise.
+*/
+int max22190_reg_read(struct max22190_desc *desc, uint32_t addr, uint32_t *val)
+{
+	struct no_os_spi_msg xfer = {
+		.tx_buff = desc->buff,
+		.rx_buff = desc->buff,
+		.bytes_number = MAX22190_FRAME_SIZE,
+		.cs_change = 1,
+	};
+	uint8_t crc;
+	int ret;
+
+	if (desc->crc_en)
+		xfer.bytes_number++;
+
+	memset(desc->buff, 0, xfer.bytes_number);
+	desc->buff[0] = no_os_field_prep(MAX22190_ADDR_MASK, addr) |
+			no_os_field_prep(MAX22190_RW_MASK, 0);
+
+	if (desc->crc_en)
+		desc->buff[2] = max22190_crc(&desc->buff[0]);
+
+	ret = no_os_spi_transfer(desc->comm_desc, &xfer, 1);
+	if (ret)
+		return ret;
+
+	if (desc->crc_en) {
+		crc = max22190_crc(&desc->buff[0]);
+		if (crc != (desc->buff[2] & 0x1F))
+			return -EINVAL;
+	}
+
+	*val = desc->buff[1];
+
+	return 0;
+}
+
+/**
+ * @brief Register write function for MAX22190
+ * @param desc - MAX22190 device descriptor.
+ * @param addr - Register value to which data is written.
+ * @param val - Value which is to be written to requested register.
+ * @return 0 in case of success, negative error code otherwise.
+*/
+int max22190_reg_write(struct max22190_desc *desc, uint32_t addr, uint32_t val)
+{
+	struct no_os_spi_msg xfer = {
+		.tx_buff = desc->buff,
+		.bytes_number = MAX22190_FRAME_SIZE,
+		.cs_change = 1,
+	};
+
+	if (desc->crc_en)
+		xfer.bytes_number++;
+
+	memset(desc->buff, 0, xfer.bytes_number);
+	desc->buff[0] = no_os_field_prep(MAX22190_ADDR_MASK, addr) |
+			no_os_field_prep(MAX22190_RW_MASK, 1);
+	desc->buff[1] = val;
+
+	if (desc->crc_en)
+		desc->buff[2] = max22190_crc(desc->buff);
+
+	return no_os_spi_transfer(desc->comm_desc, &xfer, 1);
+}
+
+/**
+ * @brief Register update function for MAX22190
+ * @param desc - MAX22190 device descriptor.
+ * @param addr - Register valueto wich data is updated.
+ * @param mask - Corresponding mask to the data that will be updated.
+ * @param val - Updated value to be written in the register at update.
+ * @return 0 in case of success, negative error code otherwise.
+*/
+int max22190_reg_update(struct max22190_desc *desc, uint32_t addr,
+			uint32_t mask, uint32_t val)
+{
+	int ret;
+	uint32_t reg_val = 0;
+
+	ret = max22190_reg_read(desc, addr, &reg_val);
+	if (ret)
+		return ret;
+
+	reg_val &= ~mask;
+	reg_val |= mask & val;
+
+	return max22190_reg_write(desc, addr, reg_val);
+}
+
+/**
+ * @brief MAX22190 Initialization function
+ * @param desc - MAX22190 device descriptor.
+ * @param param - MAX22190 initalization parameter.
+ * @return 0 in case of success, negative error code otherwise.
+*/
+int max22190_init(struct max22190_desc **desc,
+		  struct max22190_init_param *param)
+{
+	struct max22190_desc *descriptor;
+	int ret, i;
+
+	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	ret = no_os_spi_init(&descriptor->comm_desc, param->comm_param);
+	if (ret)
+		goto err;
+
+	descriptor->crc_en = param->crc_en;
+
+	ret = no_os_gpio_get_optional(&descriptor->en_gpio,
+				      param->en_gpio_param);
+	if (ret)
+		goto spi_err;
+
+	if (descriptor->en_gpio) {
+		ret = no_os_gpio_set_value(descriptor->en_gpio,
+					   NO_OS_GPIO_HIGH);
+		if (ret)
+			goto gpio_err;
+	}
+
+	/* Clearing latched faults generated on power-up and setting POR bit to
+	   0. */
+	ret = max22190_reg_update(descriptor, MAX22190_FAULT1_REG,
+				  MAX22190_POR_MASK,
+				  no_os_field_prep(MAX22190_POR_MASK, 0));
+	if (ret)
+		goto gpio_err;
+
+	/* Fault 2 Enable Register is 0 at power-up except RFWBO pin. */
+	descriptor->fault2en = 0;
+
+	*desc = descriptor;
+
+	return 0;
+
+gpio_err:
+	no_os_gpio_remove(descriptor->en_gpio);
+spi_err:
+	no_os_spi_remove(descriptor->comm_desc);
+err:
+	no_os_free(descriptor);
+
+	return ret;
+}
+
+/**
+ * @brief Free the resources allocated by initialization
+ * @param desc - MAX22190 device descriptor.
+ * @return 0 in case of success, negative error code otherwise.
+*/
+int max22190_remove(struct max22190_desc *desc)
+{
+	int ret;
+	int i;
+
+	if (!desc)
+		return -ENODEV;
+
+	for(i = 0; i < MAX22190_CHANNELS; i++) {
+		ret = max22190_chan_state(desc, i, MAX22190_CH_OFF);
+		if (ret)
+			return ret;
+	}
+
+	no_os_spi_remove(desc->comm_desc);
+	no_os_gpio_remove(desc->en_gpio);
+	no_os_free(desc);
+
+	return 0;
+}

--- a/drivers/digital-io/max22190/max22190.h
+++ b/drivers/digital-io/max22190/max22190.h
@@ -1,0 +1,172 @@
+/***************************************************************************//**
+ *   @file   max22190.h
+ *   @brief  Header file of MAX22190 Driver.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef _MAX22190_H
+#define _MAX22190_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "no_os_gpio.h"
+#include "no_os_spi.h"
+#include "no_os_util.h"
+
+#define MAX22190_FRAME_SIZE		2
+#define MAX22190_CHANNELS		8
+#define MAX22190_FAULT2_ENABLES		5
+
+#define MAX22190_WIRE_BREAK_REG		0x0
+#define MAX22190_DIGITAL_INPUT_REG	0x2
+#define MAX22190_FAULT1_REG		0x4
+#define MAX22190_FILTER_IN_REG(x)	(0x6 + (2 * (x)))
+#define MAX22190_CONFIG_REG		0x18
+#define MAX22190_INPUT_EN_REG		0x1A
+#define MAX22190_FAULT2_REG		0x1C
+#define MAX22190_FAULT2_EN_REG		0x1E
+#define MAX22190_GPO_REG		0x22
+#define MAX22190_FAULT1_EN_REG		0x24
+
+#define MAX22190_NO_OP_REG		0x26
+
+#define MAX22190_CH_STATE_MASK(x)	NO_OS_BIT(x)
+#define MAX22190_DELAY_MASK		NO_OS_GENMASK(2, 0)
+#define MAX22190_FBP_MASK		NO_OS_BIT(3)
+#define MAX22190_WBE_MASK		NO_OS_BIT(4)
+#define MAX22190_RW_MASK		NO_OS_BIT(7)
+#define MAX22190_ADDR_MASK		NO_OS_GENMASK(6, 0)
+#define MAX22190_ALARM_MASK		NO_OS_GENMASK(4, 3)
+#define MAX22190_POR_MASK		NO_OS_BIT(6)
+
+#define MAX22190_FAULT_MASK(x)		NO_OS_BIT(x)
+#define MAX22190_FAULT2_WBE_MASK	NO_OS_BIT(4)
+
+#define MAX22190_FAULT2_EN_MASK		NO_OS_GENMASK(5, 0)
+
+#define MAX22190_CFG_REFDI_MASK		NO_OS_BIT(0)
+#define MAX22190_CFG_CLRF_MASK		NO_OS_BIT(3)
+#define MAX22190_CFG_24VF_MASK		NO_OS_BIT(4)
+
+enum max22190_ch_state {
+	MAX22190_CH_OFF,
+	MAX22190_CH_ON
+};
+
+struct max22190_init_param {
+	struct no_os_spi_init_param *comm_param;
+	struct no_os_gpio_init_param *en_gpio_param;
+	bool crc_en;
+};
+
+struct max22190_desc {
+	struct no_os_spi_desc *comm_desc;
+	struct no_os_gpio_desc *en_gpio;
+	uint8_t buff[MAX22190_FRAME_SIZE + 1];
+	enum max22190_ch_state channels[MAX22190_CHANNELS];
+	uint8_t fault2en;
+	bool crc_en;
+};
+
+enum max22190_delay {
+	MAX22190_DELAY_50US,
+	MAX22190_DELAY_100US,
+	MAX22190_DELAY_400US,
+	MAX22190_DELAY_800US,
+	MAX22190_DELAY_1800US,
+	MAX22190_DELAY_3200US,
+	MAX22190_DELAY_12800US,
+	MAX22190_DELAY_20MS
+};
+
+enum max22190_fault_enable {
+	MAX22190_FAULT1_WBGE,
+	MAX22190_FAULT1_24VME,
+	MAX22190_FAULT1_24VLE,
+	MAX22190_FAULT1_ALRMT1E,
+	MAX22190_FAULT1_ALRMT2E,
+	MAX22190_FAULT1_FAULT2E,
+	MAX22190_FAULT2_RFWBSE,
+	MAX22190_FAULT2_RFWBOE,
+	MAX22190_FAULT2_RFDISE,
+	MAX22190_FAULT2_RFDIOE,
+	MAX22190_FAULT2_OTSHDNE,
+	MAX22190_FAULT2_FAULT8CKE,
+	MAX22190_CFG_24VF,
+	MAX22190_CFG_REFDI_SH_ENA,
+};
+
+/** Set filter values for specific channel. */
+int max22190_filter_set(struct max22190_desc *, uint32_t, uint32_t,
+			uint32_t, enum max22190_delay);
+
+/** Get filter values for specific channel. */
+int max22190_filter_get(struct max22190_desc *, uint32_t, uint32_t *,
+			uint32_t *, enum max22190_delay *);
+
+/** Switch the state of a specific channel to disabled/enabled. */
+int max22190_chan_state(struct max22190_desc *, uint32_t,
+			enum max22190_ch_state);
+
+/** Get the Wire Break detection state of a specific channel. */
+int max22190_wbe_get(struct max22190_desc *, uint32_t, bool *);
+
+/** Set the Wire Break detection for specific channel. */
+int max22190_wbe_set(struct max22190_desc *, uint32_t, bool);
+
+/** Set fault enable bit in the fault registers. */
+int max22190_fault_enable_set(struct max22190_desc *,
+			      enum max22190_fault_enable, bool);
+
+/** Get fault enable bit from the fault registers. */
+int max22190_fault_enable_get(struct max22190_desc *,
+			      enum max22190_fault_enable, bool *);
+
+/** Read the register of the MAX22190 device. */
+int max22190_reg_read(struct max22190_desc *, uint32_t, uint32_t *);
+
+/** Write the register of the MAX22190 device. */
+int max22190_reg_write(struct max22190_desc *, uint32_t, uint32_t);
+
+/** Update the register of the MAX22190 device. */
+int max22190_reg_update(struct max22190_desc *, uint32_t, uint32_t, uint32_t);
+
+/** Initialize and configure the MAX14916 device. */
+int max22190_init(struct max22190_desc **, struct max22190_init_param *);
+
+/** Free the resources allocated by the initalization function. */
+int max22190_remove(struct max22190_desc *);
+
+#endif


### PR DESCRIPTION
## Pull Request Description

MAX22190 is an octal industrial digital input device with diagnostics that communicates through a SPI interface.
The files added by this PR have been tested with the MAX22190 PMB connected to a max32690 microcontroller.
The driver has the basic api for init, remove, register read, write and update, but also a custom CRC5 algorithm specific for this device 
alongside its specific api(filter_get, filter_set, chan_state).

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
