### PR TITLE
drivers: meter: ade7913: Add driver

### DIFF
--- a/drivers/meter/ade7913/ade7913.c
+++ b/drivers/meter/ade7913/ade7913.c
@@ -1,0 +1,2311 @@
+/***************************************************************************//**
+*   @file   ade7913.c
+*   @brief  Implementation of ADE7913 Driver.
+*   @author George Mois (george.mois@analog.com)
+********************************************************************************
+* Copyright 2023(c) Analog Devices, Inc.
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*  - Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*  - Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in
+*    the documentation and/or other materials provided with the
+*    distribution.
+*  - Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*  - The use of this software may or may not infringe the patent rights
+*    of one or more patent holders.  This license does not release you
+*    from the requirement that you obtain separate licenses from these
+*    patent holders to use this software.
+*  - Use of the software either in source or binary form, must be run
+*    on or directly connected to an Analog Devices Inc. component.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdlib.h>
+#include <errno.h>
+#include <math.h>
+#include "ade7913.h"
+#include "no_os_delay.h"
+#include "no_os_units.h"
+#include "no_os_alloc.h"
+#include "no_os_crc8.h"
+#include "no_os_crc16.h"
+#include "no_os_print_log.h"
+
+NO_OS_DECLARE_CRC8_TABLE(ade7913_crc8);
+NO_OS_DECLARE_CRC16_TABLE(ade7913_crc16);
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+/**
+ * @brief Read device register.
+ * @param dev - The device structure.
+ * @param reg_addr - The register address.
+ * @param reg_data - The data read from the register.
+ * @param op_mode - Long/short write operation.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_read(struct ade7913_dev *dev, uint8_t reg_addr, uint8_t *reg_data,
+		 enum ade7913_operation_e op_mode)
+{
+	int ret;
+	/* CRC computed for sent commands */
+	uint8_t crc8;
+	/* CRC computed for read response messages */
+	uint16_t crc16;
+	/* CRC received with read response messages */
+	uint16_t recv_crc;
+	/* no of read bytes, depends on long/short operation and on CRC enable state */
+	uint8_t no_of_read_bytes = 4;
+	/* offset of data read in the read buffer */
+	uint8_t data_byte_offset = 3;
+	/* position of byte in guffer to start read to */
+	uint8_t position = 12;
+	/* buffer for data read (large enough for a long read) */
+	uint8_t buff[16] = { 0 };
+	/* index */
+	uint8_t i;
+
+	/* set read bit */
+	buff[12] = ADE7913_SPI_READ | 0x00;
+	/* set long operation bit */
+	if (op_mode == ADE7913_L_OP)
+		buff[12] = ADE7913_OP_MODE_LONG | buff[12];
+	/* set address to read from */
+	buff[13] = reg_addr;
+
+	/* compute CRC and add it to command */
+	crc8 = no_os_crc8(ade7913_crc8, &buff[12], 3, 0);
+	crc8 ^= 0x55;
+	buff[15] = crc8;
+	no_of_read_bytes = 6;
+	position = 10;
+
+	/* set message structure for long operations */
+	if (op_mode == ADE7913_L_OP) {
+		no_of_read_bytes = 16;
+		position = 0;
+		data_byte_offset = 13;
+	}
+
+	/* send read command */
+	ret = no_os_spi_write_and_read(dev->spi_desc, &buff[position],
+				       no_of_read_bytes);
+	if (ret)
+		return ret;
+
+	/* reset command buffer */
+	for (i = 0; i < 16; i++)
+		buff[i] = 0;
+
+	/* set long operation bit */
+	if (op_mode == ADE7913_L_OP)
+		buff[12] = ADE7913_OP_MODE_LONG | buff[12];
+
+	/* compute CRC and add it to command if CRC enabled */
+	crc8 = no_os_crc8(ade7913_crc8, &buff[12], 3, 0);
+	crc8 ^= 0x55;
+	buff[15] = crc8;
+
+	/* send read command */
+	ret = no_os_spi_write_and_read(dev->spi_desc, &buff[position],
+				       no_of_read_bytes);
+	if (ret)
+		return ret;
+
+	/* check received CRC, if enabled */
+	if (dev->crc_en) {
+		crc16 = no_os_crc16(ade7913_crc16, &buff[position], no_of_read_bytes - 2,
+				    ADE7913_CRC16_INIT_VAL);
+
+		recv_crc = no_os_get_unaligned_le16(&buff[position + no_of_read_bytes - 2]);
+
+		if (recv_crc != crc16) {
+			/* if we read 0s on SPI then there is no communication */
+			if (!recv_crc)
+				return -ENODEV;
+			/* the application should handle this result */
+			return -EPROTO;
+		}
+	}
+
+	if (op_mode == ADE7913_L_OP) {
+		dev->i_wav = no_os_sign_extend32(no_os_get_unaligned_le24(&buff[1]), 23);
+		dev->v1_wav = no_os_sign_extend32(no_os_get_unaligned_le24(&buff[5]), 23);
+		dev->v2_wav = no_os_sign_extend32(no_os_get_unaligned_le24(&buff[9]), 23);
+	}
+
+	/* set read data */
+	*reg_data = buff[position + data_byte_offset];
+
+	return 0;
+}
+
+/**
+ * @brief Write device register.
+ * @param dev- The device structure.
+ * @param reg_addr - The register address.
+ * @param reg_data - The data to be written.
+ * @param op_mode - Long/short write operation.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_write(struct ade7913_dev *dev, uint8_t reg_addr, uint8_t reg_data,
+		  enum ade7913_operation_e op_mode)
+{
+	uint8_t crc;
+	uint8_t buff[4] = {0};
+
+	if (op_mode == ADE7913_L_OP)
+		buff[0] |= ADE7913_OP_MODE_LONG;
+	buff[1] = reg_addr;
+	buff[2] = reg_data;
+
+	crc = no_os_crc8(ade7913_crc8, buff, 3, 0);
+	crc ^= 0x55;
+	buff[3] = crc;
+
+	return no_os_spi_write_and_read(dev->spi_desc, buff, 4);
+}
+
+/**
+ * @brief Update specific register bits.
+ * @param dev - The device structure.
+ * @param reg_addr - The register address.
+ * @param mask - Specific bits mask.
+ * @param reg_data - The data to be written.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+static int ade7913_update_bits(struct ade7913_dev *dev, uint8_t reg_addr,
+			       uint8_t mask, uint8_t reg_data)
+{
+	int ret;
+	uint8_t data;
+
+	ret = ade7913_read(dev, reg_addr, &data, ADE7913_S_OP);
+	if (ret)
+		return ret;
+
+	data &= ~mask;
+	data |= reg_data & mask;
+
+	return ade7913_write(dev, reg_addr, data, ADE7913_S_OP);
+}
+
+/**
+ * @brief GPIO interrupt handler for data ready.
+ * @param dev - The device structure.
+ */
+static void ade7913_irq_handler(void *dev)
+{
+	struct ade7913_dev *desc = dev;
+	uint8_t reg_val;
+	int ret;
+
+	/* Disable interrupt while reading data. */
+	ret = no_os_irq_disable(desc->irq_ctrl, desc->gpio_rdy->number);
+	if (ret)
+		return;
+
+	/* READ the data and place it in device structure */
+	ret = ade7913_read(dev, ADE7913_REG_CONFIG0, &reg_val, ADE7913_L_OP);
+	if (ret)
+		return;
+
+	/* Reenable interrupt */
+	ret = no_os_irq_enable(desc->irq_ctrl,
+			       desc->gpio_rdy->number);
+
+	return;
+}
+
+/**
+ * @brief Initialize the device.
+ * @param device - The device structure.
+ * @param init_param - The structure that contains the device initial
+ * 		       parameters.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_init(struct ade7913_dev **device,
+		 struct ade7913_init_param init_param)
+{
+	struct ade7913_dev *dev;
+	uint8_t reg_val;
+	int ret;
+	int timeout = 0;
+
+	if (!init_param.irq_ctrl)
+		return -EINVAL;
+
+	dev = (struct ade7913_dev *)no_os_calloc(1, sizeof(*dev));
+	if (!dev)
+		return -ENOMEM;
+
+	struct no_os_callback_desc irq_cb = {
+		.callback = ade7913_irq_handler,
+		.ctx = dev,
+		.event = NO_OS_EVT_GPIO,
+		.peripheral = NO_OS_GPIO_IRQ
+	};
+
+	if (init_param.drdy_callback)
+		irq_cb.callback = init_param.drdy_callback;
+
+	/* SPI Initialization */
+	ret = no_os_spi_init(&dev->spi_desc, init_param.spi_init);
+	if (ret)
+		goto error_dev;
+
+	ret = no_os_gpio_get_optional(&dev->gpio_rdy, init_param.gpio_rdy);
+	if (ret)
+		goto error_spi;
+
+	if (dev->gpio_rdy) {
+		ret = no_os_gpio_direction_input(dev->gpio_rdy);
+		if (ret)
+			goto error_gpio;
+	}
+
+	ret = no_os_irq_register_callback(init_param.irq_ctrl,
+					  dev->gpio_rdy->number, &irq_cb);
+	if (ret)
+		goto error_gpio;
+
+	dev->irq_cb = irq_cb;
+
+	ret = no_os_irq_trigger_level_set(init_param.irq_ctrl,
+					  dev->gpio_rdy->number, NO_OS_IRQ_EDGE_FALLING);
+	if (ret)
+		goto error_irq;
+
+	ret = no_os_irq_set_priority(init_param.irq_ctrl, dev->gpio_rdy->number, 3);
+	if (ret)
+		goto error_irq;
+
+	ret = no_os_irq_disable(init_param.irq_ctrl,
+				dev->gpio_rdy->number);
+	if (ret)
+		goto error_irq;
+
+	dev->irq_ctrl = init_param.irq_ctrl;
+
+	ret = no_os_gpio_get_optional(&dev->gpio_reset, init_param.gpio_reset);
+	if (ret)
+		goto error_spi;
+
+	if (dev->gpio_reset) {
+		ret = no_os_gpio_direction_output(dev->gpio_reset, NO_OS_GPIO_HIGH);
+		if (ret)
+			goto error_gpio;
+	}
+
+	/* Create the CRC-8 lookup table for polynomial ADE7913_CRC8_POLY */
+	no_os_crc8_populate_msb(ade7913_crc8, ADE7913_CRC8_POLY);
+
+	/* Create the CRC-16 lookup table for polynomial ADE7913_CRC8_POLY */
+	no_os_crc16_populate_msb(ade7913_crc16, ADE7913_CRC16_POLY);
+
+	/* CRC enabled by default */
+	dev->crc_en = 1;
+
+	/* Reset device */
+	ret = no_os_gpio_set_value(dev->gpio_reset, NO_OS_GPIO_LOW);
+	if (ret)
+		goto error_gpio;
+
+	no_os_mdelay(10);
+
+	ret = no_os_gpio_set_value(dev->gpio_reset, NO_OS_GPIO_HIGH);
+	if (ret)
+		goto error_gpio;
+
+	no_os_mdelay(50);
+
+	do {
+		ret = ade7913_get_com_up(dev, &reg_val);
+		if (ret)
+			goto error_gpio;
+
+		no_os_mdelay(5);
+		timeout++;
+		if (timeout == 20) {
+			ret = -ENOTCONN;
+			goto error_gpio;
+		}
+	} while (!reg_val);
+
+	/* Read version product */
+	ret = ade7913_get_version_product(dev, &reg_val);
+	if (ret)
+		goto error_gpio;
+
+	dev->ver_product = reg_val;
+
+	/* Read silicon revision */
+	ret = ade7913_get_silicon_revision(dev, &reg_val);
+	if (ret)
+		goto error_gpio;
+
+	if (reg_val != ADE7913_SILICON_REVISION) {
+		ret = -ENODEV;
+		goto error_gpio;
+	}
+
+	*device = dev;
+
+	return 0;
+
+error_irq:
+	no_os_irq_unregister_callback(init_param.irq_ctrl, dev->gpio_rdy->number,
+				      &irq_cb);
+error_gpio:
+	no_os_gpio_remove(dev->gpio_rdy);
+error_spi:
+	no_os_spi_remove(dev->spi_desc);
+error_dev:
+	no_os_free(dev);
+
+	return ret;
+}
+
+/**
+ * @brief Remove the device and release resources.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_remove(struct ade7913_dev *dev)
+{
+	int ret;
+
+	ret = no_os_spi_remove(dev->spi_desc);
+	if (ret)
+		return ret;
+
+	ret = no_os_gpio_remove(dev->gpio_rdy);
+	if (ret)
+		return ret;
+
+	ret = no_os_gpio_remove(dev->gpio_reset);
+	if (ret)
+		return ret;
+
+	ret = no_os_irq_unregister_callback(dev->irq_ctrl, dev->gpio_rdy->number,
+					    &dev->irq_cb);
+	if (ret)
+		return ret;
+
+	no_os_free(dev);
+
+	return 0;
+}
+
+/**
+ * @brief Reset the device using SW reset.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_sw_reset(struct ade7913_dev *dev)
+{
+	int ret;
+	uint8_t ver_product;
+
+	ret = ade7913_write(dev, ADE7913_REG_SWRST, ADE7913_SWRST_CMD, ADE7913_S_OP);
+	if (ret)
+		return ret;
+
+	dev->crc_en = 1;
+
+	/* Wait for device to initialize */ // ToDo - check required timing
+	no_os_mdelay(100);
+
+	/* Read version product */
+	ret = ade7913_get_version_product(dev, &ver_product);
+	if (ret)
+		return ret;
+
+	dev->ver_product = ver_product;
+
+	return 0;
+}
+
+/**
+ * @brief Reset the device using SW reset.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_hw_reset(struct ade7913_dev *dev)
+{
+	int ret;
+	uint8_t ver_product;
+
+	ret = no_os_gpio_set_value(dev->gpio_reset, NO_OS_GPIO_LOW);
+	if (ret)
+		return ret;
+
+	no_os_mdelay(10);
+
+	ret = no_os_gpio_set_value(dev->gpio_reset, NO_OS_GPIO_HIGH);
+	if (ret)
+		return ret;
+
+	dev->crc_en = 1;
+
+	/* Wait for device to initialize */ // ToDo - check required timing
+	no_os_mdelay(100);
+
+	/* Read version product */
+	ret = ade7913_get_version_product(dev, &ver_product);
+	if (ret)
+		return ret;
+
+	dev->ver_product = ver_product;
+
+	return 0;
+}
+
+/**
+ * @brief Convert a 24-bit raw sample to millivolts.
+ * @param dev - The device structure.
+ * @param ch - Device channel.
+ * @param mv_val - Value in millivolts.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_convert_to_millivolts(struct ade7913_dev *dev,
+				  enum ade7913_wav_e ch, int32_t *mv_val)
+{
+	int64_t value = 0;
+
+	if (!dev)
+		return	-ENODEV;
+
+	if (ch > ADE7913_V2_WAV)
+		return	-EINVAL;
+
+	switch (ch) {
+	case ADE7913_I_WAV:
+		/* times 2, two's complement data */
+		// Scale is 0,03125 = 3125/100000 = 1/32 = 1/2^5
+		value = ((int64_t)ADE7913_VREF * dev->i_wav) / (1 << 28);
+		break;
+	case ADE7913_V1_WAV:
+		value = ((int64_t)ADE7913_VREF * dev->v1_wav) / (1 << 23);
+		break;
+	default:
+		value = ((int64_t)ADE7913_VREF * dev->v2_wav) / (1 << 23);
+		break;
+	}
+
+	*mv_val = (int32_t)value;
+
+	return 0;
+}
+
+/**
+ * @brief Get STREAM_DBG mode.
+ * @param dev - The device structure.
+ * @param stream_dbg - Read debug mode setting read.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_stream_dbg_mode(struct ade7913_dev *dev,
+				enum ade7913_stream_debug_e *stream_dbg)
+{
+	int ret;
+	uint8_t reg_val;
+
+	if (!stream_dbg)
+		return -EINVAL;
+
+	ret = ade7913_read(dev, ADE7913_REG_CONFIG0, &reg_val, ADE7913_S_OP);
+	if (ret)
+		return ret;
+
+	switch (reg_val & ADE7913_STREAM_DBG_MSK) {
+	case 0:
+		*stream_dbg = ADE7913_STREAM_NORMAL_MODE;
+		break;
+	case 1:
+		*stream_dbg = ADE7913_STREAM_STATIC_MODE;
+		break;
+	case 2:
+		*stream_dbg = ADE7913_STREAM_INCREMENTS_MODE;
+		break;
+	default:
+		*stream_dbg = ADE7913_STREAM_FUNCTIONAL_MODE;
+		break;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Set STREAM_DBG mode.
+ * @param dev - The device structure.
+ * @param stream_dbg - Stream debug mode setting.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_set_stream_dbg_mode(struct ade7913_dev *dev,
+				enum ade7913_stream_debug_e stream_dbg)
+{
+	if (stream_dbg > ADE7913_STREAM_FUNCTIONAL_MODE)
+		return -EINVAL;
+
+	return ade7913_update_bits(dev, ADE7913_REG_CONFIG0, ADE7913_STREAM_DBG_MSK,
+				   no_os_field_prep(ADE7913_STREAM_DBG_MSK, stream_dbg));
+}
+
+/**
+ * @brief Get CRC enable on SPI write setting.
+ * @param dev - The device structure.
+ * @param crc_en_state - Read CRC setting.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_crc_en_state(struct ade7913_dev *dev,
+			     uint8_t *crc_en_state)
+{
+	int ret;
+	uint8_t reg_val;
+
+	if (!crc_en_state)
+		return -EINVAL;
+
+	*crc_en_state = dev->crc_en;
+
+	ret = ade7913_read(dev, ADE7913_REG_CONFIG0, &reg_val, ADE7913_S_OP);
+	if (ret)
+		return ret;
+
+	if (reg_val & ADE7913_CRC_EN_SPI_WRITE_MSK)
+		*crc_en_state = 1;
+
+	dev->crc_en = *crc_en_state;
+
+	return 0;
+}
+
+/**
+ * @brief Set CRC enable on SPI write setting.
+ * @param dev - The device structure.
+ * @param crc_en_state - Read CRC setting.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_set_crc_en_state(struct ade7913_dev *dev,
+			     uint8_t crc_en_state)
+{
+	int ret;
+
+	if (crc_en_state > 1)
+		return -EINVAL;
+
+	ret = ade7913_update_bits(dev, ADE7913_REG_CONFIG0,
+				  ADE7913_CRC_EN_SPI_WRITE_MSK,
+				  no_os_field_prep(ADE7913_CRC_EN_SPI_WRITE_MSK, crc_en_state));
+
+	if (ret)
+		return ret;
+
+	dev->crc_en = crc_en_state;
+
+	return 0;
+}
+
+/**
+ * @brief Lock device.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_wr_lock(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_write(dev, ADE7913_REG_WR_LOCK, ADE7913_LOCK_KEY, ADE7913_S_OP);
+}
+
+/**
+ * @brief Unlock device.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_wr_unlock(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_write(dev, ADE7913_REG_WR_LOCK, ADE7913_UNLOCK_KEY,
+			     ADE7913_S_OP);
+}
+
+/**
+ * @brief Write value in the scratchpad register.
+ * @param dev - The device structure.
+ * @param val - The value to be written.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_write_scratchpad(struct ade7913_dev *dev,
+			     uint8_t val)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_write(dev, ADE7913_REG_SCRATCH, val, ADE7913_S_OP);
+}
+
+/**
+ * @brief Get the value stired in the scratchpad register.
+ * @param dev - The device structure.
+ * @param val - The read value.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_read_scratchpad(struct ade7913_dev *dev,
+			    uint8_t *val)
+{
+	int ret;
+	uint8_t reg_val;
+
+	if (!val)
+		return -EINVAL;
+
+	ret = ade7913_read(dev, ADE7913_REG_SCRATCH, &reg_val, ADE7913_S_OP);
+	if (ret)
+		return ret;
+
+	*val = reg_val;
+
+	return 0;
+}
+
+/**
+ * @brief Set normal mode of operation.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_set_normal_mode(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_set_stream_dbg_mode(dev, ADE7913_STREAM_NORMAL_MODE);
+}
+
+/**
+ * @brief Set static mode of operation.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_set_static_mode(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_set_stream_dbg_mode(dev, ADE7913_STREAM_STATIC_MODE);
+}
+
+/**
+ * @brief Set data increments mode of operation.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_set_data_increments_mode(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_set_stream_dbg_mode(dev, ADE7913_STREAM_INCREMENTS_MODE);
+}
+
+/**
+ * @brief Get ECC or PHY Error Count on ISO to NONISO Communications.
+ * @param dev - The device structure.
+ * @param err_count - Read erro count.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_err_count(struct ade7913_dev *dev,
+			  uint8_t *err_count)
+{
+	if (!err_count)
+		return -EINVAL;
+
+	return ade7913_read(dev, ADE7913_REG_COM_FLT_COUNT, err_count, ADE7913_S_OP);
+}
+
+/**
+ * @brief Invert V2 channel inputs.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_invert_v2_inputs(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_update_bits(dev, ADE7913_REG_CONFIG_FILT,
+				   ADE7913_V2_ADC_INVERT_MSK, no_os_field_prep(ADE7913_V2_ADC_INVERT_MSK, ENABLE));
+}
+
+/**
+ * @brief Invert V1 channel inputs.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_invert_v1_inputs(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_update_bits(dev, ADE7913_REG_CONFIG_FILT,
+				   ADE7913_V1_ADC_INVERT_MSK, no_os_field_prep(ADE7913_V1_ADC_INVERT_MSK, ENABLE));
+}
+
+/**
+ * @brief Invert I channel inputs.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_invert_i_inputs(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_update_bits(dev, ADE7913_REG_CONFIG_FILT,
+				   ADE7913_I_ADC_INVERT_MSK, no_os_field_prep(ADE7913_I_ADC_INVERT_MSK, ENABLE));
+}
+
+/**
+ * @brief Disable invert V2 channel inputs.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_invert_v2_inputs_disable(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_update_bits(dev, ADE7913_REG_CONFIG_FILT,
+				   ADE7913_V2_ADC_INVERT_MSK, no_os_field_prep(ADE7913_V2_ADC_INVERT_MSK,
+						   DISABLE));
+}
+
+/**
+ * @brief Disable invert V1 channel inputs.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_invert_v1_inputs_disable(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_update_bits(dev, ADE7913_REG_CONFIG_FILT,
+				   ADE7913_V1_ADC_INVERT_MSK, no_os_field_prep(ADE7913_V1_ADC_INVERT_MSK,
+						   DISABLE));
+}
+
+/**
+ * @brief Disable invert I channel inputs.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_invert_i_inputs_disable(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_update_bits(dev, ADE7913_REG_CONFIG_FILT,
+				   ADE7913_I_ADC_INVERT_MSK, no_os_field_prep(ADE7913_I_ADC_INVERT_MSK, DISABLE));
+}
+
+/**
+ * @brief Set filter bandwidth to 2.7 kHz at 8ksps output data rate.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_set_lpf_bw_2_7(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_update_bits(dev, ADE7913_REG_CONFIG_FILT,
+				   ADE7913_LPF_BW_MSK, no_os_field_prep(ADE7913_LPF_BW_MSK, DISABLE));
+}
+
+/**
+ * @brief Set filter bandwidth to 3.3 kHz at 8ksps output data rate.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_set_lpf_bw_3_3(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_update_bits(dev, ADE7913_REG_CONFIG_FILT,
+				   ADE7913_LPF_BW_MSK, no_os_field_prep(ADE7913_LPF_BW_MSK, ENABLE));
+}
+
+/**
+ * @brief Set digital signal processing configuration.
+ * @param dev - The device structure.
+ * @param config - The ADE7913 DSP configuration.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_set_dsp_config(struct ade7913_dev *dev,
+			   enum ade7913_datapath_config_e config)
+{
+	if (config > ADE7913_SINC3_LPF_EN_1_KHZ_SAMPLING)
+		return -EINVAL;
+
+	if (config > ADE7913_SINC3_LPF_EN_1_KHZ_SAMPLING)
+		return -EINVAL;
+
+	return ade7913_update_bits(dev, ADE7913_REG_CONFIG_FILT,
+				   ADE7913_DATAPATH_CONFIG_MSK, no_os_field_prep(ADE7913_DATAPATH_CONFIG_MSK,
+						   config));
+}
+
+/**
+ * @brief Enable write access to DC_OFFSET_MODE register.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_enable_wa_dc_offset_mode(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_update_bits(dev, ADE7913_REG_CONFIG_ISO_ACC,
+				   ADE7913_ISO_WR_ACC_EN_MSK, no_os_field_prep(ADE7913_ISO_WR_ACC_EN_MSK, ENABLE));
+}
+
+/**
+ * @brief Disable write access to DC_OFFSET_MODE register.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_disable_wa_dc_offset_mode(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_update_bits(dev, ADE7913_REG_CONFIG_ISO_ACC,
+				   ADE7913_ISO_WR_ACC_EN_MSK, no_os_field_prep(ADE7913_ISO_WR_ACC_EN_MSK,
+						   DISABLE));
+}
+
+/**
+ * @brief Get register map CRC.
+ * @param dev - The device structure.
+ * @param crc - CRC value.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_crc(struct ade7913_dev *dev, uint16_t *crc)
+{
+	int ret;
+	uint8_t reg_val[2];
+
+	if (!crc)
+		return -EINVAL;
+
+	ret = ade7913_read(dev, ADE7913_REG_CRC_RESULT_HI, &reg_val[1], ADE7913_S_OP);
+	if (ret)
+		return ret;
+	ret = ade7913_read(dev, ADE7913_REG_CRC_RESULT_LO, &reg_val[0], ADE7913_S_OP);
+	if (ret)
+		return ret;
+
+	*crc = no_os_get_unaligned_le16(reg_val);
+
+	return 0;
+}
+
+/**
+ * @brief Refresh EFuse Memory.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_efuse_refresh(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_update_bits(dev, ADE7913_REG_EFUSE_REFRESH,
+				   ADE7913_EFUSE_REFRESH_MSK, no_os_field_prep(ADE7913_EFUSE_REFRESH_MSK, ENABLE));
+}
+
+/**
+ * @brief Select EMI frequency hopping.
+ * @param dev - The device structure.
+ * @param config - EMI frequency hopping selection.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_set_emi_config(struct ade7913_dev *dev,
+			   enum ade7913_emi_config_e config)
+{
+	if (config > ADE7913_RANDOM_HOPPING_FREQUENCY)
+		return -EINVAL;
+
+	return ade7913_update_bits(dev, ADE7913_REG_EMI_CONFIG,
+				   ADE7913_EMI_CONFIG_MSK, no_os_field_prep(ADE7913_EMI_CONFIG_MSK, config));
+}
+
+/**
+ * @brief Get EMI HI mask.
+ * @param dev - The device structure.
+ * @param msk - EMI HI mask.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_emi_hi_mask(struct ade7913_dev *dev, uint8_t *msk)
+{
+	if (!msk)
+		return -EINVAL;
+
+	return ade7913_read(dev, ADE7913_REG_EMI_HI_MASK, msk, ADE7913_S_OP);
+}
+
+/**
+ * @brief Get EMI LO mask.
+ * @param dev - The device structure.
+ * @param msk - EMI LO mask.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_emi_lo_mask(struct ade7913_dev *dev, uint8_t *msk)
+{
+	if (!msk)
+		return -EINVAL;
+
+	return ade7913_read(dev, ADE7913_REG_EMI_LO_MASK, msk, ADE7913_S_OP);
+}
+
+/**
+ * @brief Set EMI HI mask.
+ * @param dev - The device structure.
+ * @param msk - EMI HI mask set.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_set_emi_hi_mask(struct ade7913_dev *dev, uint8_t msk)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_write(dev, ADE7913_REG_EMI_HI_MASK, msk, ADE7913_S_OP);
+}
+
+/**
+ * @brief Set EMI LO mask.
+ * @param dev - The device structure.
+ * @param msk - EMI LO mask set.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_set_emi_lo_mask(struct ade7913_dev *dev, uint8_t msk)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_write(dev, ADE7913_REG_EMI_LO_MASK, msk, ADE7913_S_OP);
+}
+
+/**
+ * @brief Get EMI HI limit.
+ * @param dev - The device structure.
+ * @param limit - Read EMI HI limit.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_emi_hi_limit(struct ade7913_dev *dev, uint8_t *limit)
+{
+	if (!limit)
+		return -EINVAL;
+
+	return ade7913_read(dev, ADE7913_REG_EMI_HI_LIMIT, limit, ADE7913_S_OP);
+}
+
+/**
+ * @brief Get EMI MID limit.
+ * @param dev - The device structure.
+ * @param limit - Read EMI MID limit.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_emi_mid_limit(struct ade7913_dev *dev, uint8_t *limit)
+{
+	if (!limit)
+		return -EINVAL;
+
+	return ade7913_read(dev, ADE7913_REG_EMI_MID_LIMIT, limit, ADE7913_S_OP);
+}
+
+/**
+ * @brief Get EMI LO limit.
+ * @param dev - The device structure.
+ * @param limit - Read EMI LO limit.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_emi_lo_limit(struct ade7913_dev *dev, uint8_t *limit)
+{
+	if (!limit)
+		return -EINVAL;
+
+	return ade7913_read(dev, ADE7913_REG_EMI_LO_LIMIT, limit, ADE7913_S_OP);
+}
+
+/**
+ * @brief Enable/disable interrupt.
+ * @param dev - The device structure.
+ * @param reg_addr - MASK register address.
+ * @param int_msk - Interrupt mask.
+ * @param en - Enable/Disable.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_control_interrupt(struct ade7913_dev *dev, uint8_t reg_addr,
+			      uint8_t int_msk, uint8_t en)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_update_bits(dev, reg_addr,
+				   int_msk, no_os_field_prep(int_msk, en));
+}
+
+/**
+ * @brief Enable STATUS1X interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_enable_status1x_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK0,
+					 ADE7913_STATUS1X_MSK, ENABLE);
+}
+
+/**
+ * @brief Disable STATUS1X interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_disable_status1x_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK0,
+					 ADE7913_STATUS1X_MSK, DISABLE);
+}
+
+/**
+ * @brief Enable STATUS2X interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_enable_status2x_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK0,
+					 ADE7913_STATUS2X_MSK, ENABLE);
+}
+
+/**
+ * @brief Disable STATUS2X interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_disable_status2x_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK0,
+					 ADE7913_STATUS2X_MSK, DISABLE);
+}
+
+/**
+ * @brief Enable COM_UP interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_enable_com_up_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK0,
+					 ADE7913_COM_UP_MSK, ENABLE);
+}
+
+/**
+ * @brief Disable COM_UP interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_disable_com_up_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK0,
+					 ADE7913_COM_UP_MSK, DISABLE);
+}
+
+/**
+ * @brief Enable CRC_CHG interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_enable_crc_chg_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK0,
+					 ADE7913_CRC_CHG_MSK, ENABLE);
+}
+
+/**
+ * @brief Disable CRC_CHG interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_disable_crc_chg_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK0,
+					 ADE7913_CRC_CHG_MSK, DISABLE);
+}
+
+/**
+ * @brief Enable SPI_CRC_ERR interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_enable_spi_crc_err_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK0,
+					 ADE7913_SPI_CRC_ERR_MSK, ENABLE);
+}
+
+/**
+ * @brief Disable SPI_CRC_ERR interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_disable_spi_crc_err_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK0,
+					 ADE7913_SPI_CRC_ERR_MSK, DISABLE);
+}
+
+/**
+ * @brief Enable COMFLT_ERR interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_enable_comflt_err_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK0,
+					 ADE7913_COMFLT_ERR_MSK, ENABLE);
+}
+
+/**
+ * @brief Disable COMFLT_ERR interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_disable_comflt_err_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK0,
+					 ADE7913_COMFLT_ERR_MSK, DISABLE);
+}
+
+/**
+ * @brief Enable V2_WAV_OVRNG interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_enable_v2_wav_ovrng_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK1,
+					 ADE7913_V2_WAV_OVRNG_MSK, ENABLE);
+}
+
+/**
+ * @brief Disable V2_WAV_OVRNG interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_disable_v2_wav_ovrng_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK1,
+					 ADE7913_V2_WAV_OVRNG_MSK, DISABLE);
+}
+
+/**
+ * @brief Enable V1_WAV_OVRNG interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_enable_v1_wav_ovrng_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK1,
+					 ADE7913_V1_WAV_OVRNG_MSK, ENABLE);
+}
+
+/**
+ * @brief Disable V1_WAV_OVRNG interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_disable_v1_wav_ovrng_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK1,
+					 ADE7913_V1_WAV_OVRNG_MSK, DISABLE);
+}
+
+/**
+ * @brief Enable I_WAV_OVRNG interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_enable_i_wav_ovrng_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK1,
+					 ADE7913_I_WAV_OVRNG_MSK, ENABLE);
+}
+
+/**
+ * @brief Disable I_WAV_OVRNG interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_disable_i_wav_ovrng_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK1,
+					 ADE7913_I_WAV_OVRNG_MSK, DISABLE);
+}
+
+/**
+ * @brief Enable ADC_SYNC_DONE interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_enable_adc_sync_done_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK1,
+					 ADE7913_ADC_SYNC_DONE_MSK, ENABLE);
+}
+
+/**
+ * @brief Disable ADC_SYNC_DONE interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_disable_adc_sync_done_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK1,
+					 ADE7913_ADC_SYNC_DONE_MSK, DISABLE);
+}
+
+/**
+ * @brief Enable ISO_CLK_STBL_ERR interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_enable_iso_clk_stbl_err_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK2,
+					 ADE7913_ISO_CLK_STBL_ERR_MSK, ENABLE);
+}
+
+/**
+ * @brief Disable ISO_CLK_STBL_ERR interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_disable_iso_clk_stbl_err_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK2,
+					 ADE7913_ISO_CLK_STBL_ERR_MSK, DISABLE);
+}
+
+/**
+ * @brief Enable ISO_PHY_CRC_ERR interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_enable_iso_phy_crc_err_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK2,
+					 ADE7913_ISO_PHY_CRC_ERR_MSK, ENABLE);
+}
+
+/**
+ * @brief Disable ISO_PHY_CRC_ERR interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_disable_iso_phy_crc_err_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK2,
+					 ADE7913_ISO_PHY_CRC_ERR_MSK, DISABLE);
+}
+
+/**
+ * @brief Enable ISO_EFUSE_MEM_ERR interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_enable_iso_efuse_mem_err_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK2,
+					 ADE7913_ISO_EFUSE_MEM_ERR_MSK, ENABLE);
+}
+
+/**
+ * @brief Disable ISO_EFUSE_MEM_ERR interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_disable_iso_efuse_mem_err_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK2,
+					 ADE7913_ISO_EFUSE_MEM_ERR_MSK, DISABLE);
+}
+
+/**
+ * @brief Enable ISO_DIG_MOD_V2_OVF interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_enable_iso_dig_mod_v2_ovf_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK2,
+					 ADE7913_ISO_DIG_MOD_V2_OVF_MSK, ENABLE);
+}
+
+/**
+ * @brief Disable ISO_DIG_MOD_V2_OVF interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_disable_iso_dig_mod_v2_ovf_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK2,
+					 ADE7913_ISO_DIG_MOD_V2_OVF_MSK, DISABLE);
+}
+
+/**
+ * @brief Enable ISO_DIG_MOD_V1_OVF interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_enable_iso_dig_mod_v1_ovf_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK2,
+					 ADE7913_ISO_DIG_MOD_V1_OVF_MSK, ENABLE);
+}
+
+/**
+ * @brief Disable ISO_DIG_MOD_V1_OVF interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_disable_iso_dig_mod_v1_ovf_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK2,
+					 ADE7913_ISO_DIG_MOD_V1_OVF_MSK, DISABLE);
+}
+
+/**
+ * @brief Enable ISO_DIG_MOD_I_OVF interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_enable_iso_dig_mod_i_ovf_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK2,
+					 ADE7913_ISO_DIG_MOD_I_OVF_MSK, ENABLE);
+}
+
+/**
+ * @brief Disable ISO_DIG_MOD_I_OVF interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_disable_iso_dig_mod_i_ovf_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK2,
+					 ADE7913_ISO_DIG_MOD_I_OVF_MSK, DISABLE);
+}
+
+/**
+ * @brief Enable ISO_TEST_MMR_ERR interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_enable_iso_test_mmr_err_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK2,
+					 ADE7913_ISO_TEST_MMR_ERR_MSK, ENABLE);
+}
+
+/**
+ * @brief Disable ISO_TEST_MMR_ERR interrupt.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_disable_iso_test_mmr_err_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_control_interrupt(dev, ADE7913_REG_MASK2,
+					 ADE7913_ISO_TEST_MMR_ERR_MSK, DISABLE);
+}
+
+/**
+ * @brief Select zero crossing edge.
+ * @param dev - The device structure.
+ * @param sel - Zero crossing edge selection.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_select_zero_crossing_edge(struct ade7913_dev *dev,
+				      enum ade7913_zx_edge_sel_e sel)
+{
+	if (!dev)
+		return -ENODEV;
+
+	if (sel > ADE7913_ZX_DETECT_BOTH_SLOPES)
+		return -EINVAL;
+
+	return ade7913_update_bits(dev, ADE7913_REG_CONFIG_ZX,
+				   ADE7913_ZX_EDGE_SEL_MSK, no_os_field_prep(ADE7913_ZX_EDGE_SEL_MSK, sel));
+}
+
+/**
+ * @brief Select zero crossing channel.
+ * @param dev - The device structure.
+ * @param cfg - Zero crossing channel selection.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_select_zero_crossing_channel(struct ade7913_dev *dev,
+		enum ade7913_zx_channel_cfg_e cfg)
+{
+	if (!dev)
+		return -ENODEV;
+
+	if (cfg > ADE7913_ZX_V2_SEL)
+		return -EINVAL;
+
+	return ade7913_update_bits(dev, ADE7913_REG_CONFIG_ZX,
+				   ADE7913_ZX_CHANNEL_CONFIG_MSK, no_os_field_prep(ADE7913_ZX_CHANNEL_CONFIG_MSK,
+						   cfg));
+}
+
+/**
+ * @brief ADC prepare broadcast.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_adc_prepare_broadcast(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_update_bits(dev, ADE7913_REG_SYNC_SNAP,
+				   ADE7913_PREP_BROADCAST_MSK, no_os_field_prep(ADE7913_PREP_BROADCAST_MSK,
+						   ENABLE));
+}
+
+/**
+ * @brief ADC align.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_adc_align(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_update_bits(dev, ADE7913_REG_SYNC_SNAP,
+				   ADE7913_ALIGN_MSK, no_os_field_prep(ADE7913_ALIGN_MSK,
+						   ENABLE));
+}
+
+/**
+ * @brief ADC snapshot.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_adc_snapshot(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_update_bits(dev, ADE7913_REG_SYNC_SNAP,
+				   ADE7913_SNAPSHOT_MSK, no_os_field_prep(ADE7913_SNAPSHOT_MSK,
+						   ENABLE));
+}
+
+/**
+ * @brief Get interrupt indicator from STATUS register.
+ * @param dev - The device structure.
+ * @param addr - Register address.
+ * @param msk - Interrupt mask.
+ * @param status - Status indicator.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_int_status(struct ade7913_dev *dev, uint8_t addr, uint8_t msk,
+			   uint8_t *status)
+{
+	uint8_t reg_val;
+	int ret;
+
+	if (!status)
+		return -EINVAL;
+
+	ret = ade7913_read(dev, addr, &reg_val, ADE7913_S_OP);
+	if (ret)
+		return ret;
+
+	*status = no_os_test_bit(no_os_find_first_set_bit(msk), &reg_val);
+
+	return 0;
+}
+
+/**
+ * @brief Get STATUSx register value.
+ * @param dev - The device structure.
+ * @param addr - Register address.
+ * @param status - 8-bit register value.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_statusx_val(struct ade7913_dev *dev, uint8_t addr,
+			    uint8_t *status)
+{
+	uint8_t reg_val;
+	int ret;
+
+	if (!status)
+		return -EINVAL;
+
+	ret = ade7913_read(dev, addr, &reg_val, ADE7913_S_OP);
+	if (ret)
+		return ret;
+
+	*status = reg_val;
+
+	return 0;
+}
+
+/**
+ * @brief Get STATUS1 indicator.
+ * @param dev - The device structure.
+ * @param status - Status indicator.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_status1x(struct ade7913_dev *dev, uint8_t *status)
+{
+	return ade7913_get_int_status(dev, ADE7913_REG_STATUS0, ADE7913_STATUS1X_MSK,
+				      status);
+}
+
+/**
+ * @brief Get STATUS2 indicator.
+ * @param dev - The device structure.
+ * @param status - Status indicator.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_status2x(struct ade7913_dev *dev, uint8_t *status)
+{
+	return ade7913_get_int_status(dev, ADE7913_REG_STATUS0, ADE7913_STATUS2X_MSK,
+				      status);
+}
+
+/**
+ * @brief Get RESET_DONE indicator.
+ * @param dev - The device structure.
+ * @param status - Status indicator.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_reset_done(struct ade7913_dev *dev, uint8_t *status)
+{
+	return ade7913_get_int_status(dev, ADE7913_REG_STATUS0, ADE7913_RESET_DONE_MSK,
+				      status);
+}
+
+/**
+ * @brief Get COM_UP indicator.
+ * @param dev - The device structure.
+ * @param status - Status indicator.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_com_up(struct ade7913_dev *dev, uint8_t *status)
+{
+	return ade7913_get_int_status(dev, ADE7913_REG_STATUS0, ADE7913_COM_UP_MSK,
+				      status);
+}
+
+/**
+ * @brief Get CRC_CHG indicator.
+ * @param dev - The device structure.
+ * @param status - Status indicator.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_crc_chg(struct ade7913_dev *dev, uint8_t *status)
+{
+	return ade7913_get_int_status(dev, ADE7913_REG_STATUS0, ADE7913_CRC_CHG_MSK,
+				      status);
+}
+
+/**
+ * @brief Get EFUSE_MEM_ERR indicator.
+ * @param dev - The device structure.
+ * @param status - Status indicator.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_efuse_mem_err(struct ade7913_dev *dev, uint8_t *status)
+{
+	return ade7913_get_int_status(dev, ADE7913_REG_STATUS0,
+				      ADE7913_EFUSE_MEM_ERR_MSK,
+				      status);
+}
+
+/**
+ * @brief Get SPI_CRC_ERR indicator.
+ * @param dev - The device structure.
+ * @param status - Status indicator.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_spi_crc_err(struct ade7913_dev *dev, uint8_t *status)
+{
+	return ade7913_get_int_status(dev, ADE7913_REG_STATUS0, ADE7913_SPI_CRC_ERR_MSK,
+				      status);
+}
+
+/**
+ * @brief Get COMFLT_ERR indicator.
+ * @param dev - The device structure.
+ * @param status - Status indicator.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_comflt_err(struct ade7913_dev *dev, uint8_t *status)
+{
+	return ade7913_get_int_status(dev, ADE7913_REG_STATUS0, ADE7913_COMFLT_ERR_MSK,
+				      status);
+}
+
+/**
+ * @brief Clear the RESET_DONE int mask.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_clear_reset_done_int(struct ade7913_dev *dev)
+{
+	return ade7913_write(dev, ADE7913_REG_STATUS0, ADE7913_RESET_DONE_MSK,
+			     ADE7913_S_OP);
+}
+
+/**
+ * @brief Clear the COM_UP int mask.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_clear_com_up_int(struct ade7913_dev *dev)
+{
+	return ade7913_write(dev, ADE7913_REG_STATUS0, ADE7913_COM_UP_MSK,
+			     ADE7913_S_OP);
+}
+
+/**
+ * @brief Clear the CRC_CHG int mask.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_clear_crc_chg_int(struct ade7913_dev *dev)
+{
+	return ade7913_write(dev, ADE7913_REG_STATUS0, ADE7913_CRC_CHG_MSK,
+			     ADE7913_S_OP);
+}
+
+/**
+ * @brief Clear the SPI_CRC_ERR int mask.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_clear_spi_crc_err_int(struct ade7913_dev *dev)
+{
+	return ade7913_write(dev, ADE7913_REG_STATUS0, ADE7913_SPI_CRC_ERR_MSK,
+			     ADE7913_S_OP);
+}
+
+/**
+ * @brief Clear the COMFLT_ERR int mask.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_clear_comflt_err_int(struct ade7913_dev *dev)
+{
+	return ade7913_write(dev, ADE7913_REG_STATUS0, ADE7913_COM_UP_MSK,
+			     ADE7913_S_OP);
+}
+
+/**
+ * @brief Get V2_WAV_OVRNG indicator.
+ * @param dev - The device structure.
+ * @param status - Status indicator.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_v2_wav_ovrng(struct ade7913_dev *dev, uint8_t *status)
+{
+	return ade7913_get_int_status(dev, ADE7913_REG_STATUS1,
+				      ADE7913_V2_WAV_OVRNG_MSK,
+				      status);
+}
+
+/**
+ * @brief Clear the V2_WAV_OVRNG int mask.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_clear_v2_wav_ovrng_int(struct ade7913_dev *dev)
+{
+	return ade7913_write(dev, ADE7913_REG_STATUS1, ADE7913_V2_WAV_OVRNG_MSK,
+			     ADE7913_S_OP);
+}
+
+/**
+ * @brief Get V1_WAV_OVRNG indicator.
+ * @param dev - The device structure.
+ * @param status - Status indicator.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_v1_wav_ovrng(struct ade7913_dev *dev, uint8_t *status)
+{
+	return ade7913_get_int_status(dev, ADE7913_REG_STATUS1,
+				      ADE7913_V1_WAV_OVRNG_MSK,
+				      status);
+}
+
+/**
+ * @brief Clear the V1_WAV_OVRNG int mask.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_clear_v1_wav_ovrng_int(struct ade7913_dev *dev)
+{
+	return ade7913_write(dev, ADE7913_REG_STATUS1, ADE7913_V1_WAV_OVRNG_MSK,
+			     ADE7913_S_OP);
+}
+
+/**
+ * @brief Get I_WAV_OVRNG indicator.
+ * @param dev - The device structure.
+ * @param status - Status indicator.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_i_wav_ovrng(struct ade7913_dev *dev, uint8_t *status)
+{
+	return ade7913_get_int_status(dev, ADE7913_REG_STATUS1, ADE7913_I_WAV_OVRNG_MSK,
+				      status);
+}
+
+/**
+ * @brief Clear the I_WAV_OVRNG int mask.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_clear_i_wav_ovrng_int(struct ade7913_dev *dev)
+{
+	return ade7913_write(dev, ADE7913_REG_STATUS1, ADE7913_I_WAV_OVRNG_MSK,
+			     ADE7913_S_OP);
+}
+
+/**
+ * @brief Get ADC_SYNC_DONE indicator.
+ * @param dev - The device structure.
+ * @param status - Status indicator.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_adc_sync_done(struct ade7913_dev *dev, uint8_t *status)
+{
+	return ade7913_get_int_status(dev, ADE7913_REG_STATUS1,
+				      ADE7913_ADC_SYNC_DONE_MSK,
+				      status);
+}
+
+/**
+ * @brief Clear the ADC_SYNC_DONE int mask.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_clear_adc_sync_done_int(struct ade7913_dev *dev)
+{
+	return ade7913_write(dev, ADE7913_REG_STATUS1, ADE7913_ADC_SYNC_DONE_MSK,
+			     ADE7913_S_OP);
+}
+
+/**
+ * @brief Get ISO_CLK_STBL_ERR indicator.
+ * @param dev - The device structure.
+ * @param status - Status indicator.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_iso_clk_stbl_err(struct ade7913_dev *dev, uint8_t *status)
+{
+	return ade7913_get_int_status(dev, ADE7913_REG_STATUS2,
+				      ADE7913_ISO_CLK_STBL_ERR_MSK,
+				      status);
+}
+
+/**
+ * @brief Clear the ISO_CLK_STBL_ERR int mask.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_clear_iso_clk_stbl_err_int(struct ade7913_dev *dev)
+{
+	return ade7913_write(dev, ADE7913_REG_STATUS2, ADE7913_ISO_CLK_STBL_ERR_MSK,
+			     ADE7913_S_OP);
+}
+
+/**
+ * @brief Get ISO_PHY_CRC_ERR indicator.
+ * @param dev - The device structure.
+ * @param status - Status indicator.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_iso_phy_crc_err(struct ade7913_dev *dev, uint8_t *status)
+{
+	return ade7913_get_int_status(dev, ADE7913_REG_STATUS2,
+				      ADE7913_ISO_PHY_CRC_ERR_MSK,
+				      status);
+}
+
+/**
+ * @brief Clear the ISO_PHY_CRC_ERR int mask.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_clear_iso_phy_crc_err_int(struct ade7913_dev *dev)
+{
+	return ade7913_write(dev, ADE7913_REG_STATUS2, ADE7913_ISO_PHY_CRC_ERR_MSK,
+			     ADE7913_S_OP);
+}
+
+/**
+ * @brief Get ISO_EFUSE_MEM_ERR indicator.
+ * @param dev - The device structure.
+ * @param status - Status indicator.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_iso_efuse_mem_err_err(struct ade7913_dev *dev, uint8_t *status)
+{
+	return ade7913_get_int_status(dev, ADE7913_REG_STATUS2,
+				      ADE7913_ISO_EFUSE_MEM_ERR_MSK,
+				      status);
+}
+
+/**
+ * @brief Clear the ISO_EFUSE_MEM_ERR int mask.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_clear_iso_efuse_mem_err_int(struct ade7913_dev *dev)
+{
+	return ade7913_write(dev, ADE7913_REG_STATUS2, ADE7913_ISO_EFUSE_MEM_ERR_MSK,
+			     ADE7913_S_OP);
+}
+
+/**
+ * @brief Get ISO_DIG_MOD_V2_OVF indicator.
+ * @param dev - The device structure.
+ * @param status - Status indicator.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_iso_dig_mod_v2_ovf(struct ade7913_dev *dev, uint8_t *status)
+{
+	return ade7913_get_int_status(dev, ADE7913_REG_STATUS2,
+				      ADE7913_ISO_DIG_MOD_V2_OVF_MSK,
+				      status);
+}
+
+/**
+ * @brief Clear the ISO_DIG_MOD_V2_OVF int mask.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_clear_iso_dig_mod_v2_ovf_int(struct ade7913_dev *dev)
+{
+	return ade7913_write(dev, ADE7913_REG_STATUS2, ADE7913_ISO_DIG_MOD_V2_OVF_MSK,
+			     ADE7913_S_OP);
+}
+
+/**
+ * @brief Get ISO_DIG_MOD_V1_OVF indicator.
+ * @param dev - The device structure.
+ * @param status - Status indicator.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_iso_dig_mod_v1_ovf(struct ade7913_dev *dev, uint8_t *status)
+{
+	return ade7913_get_int_status(dev, ADE7913_REG_STATUS2,
+				      ADE7913_ISO_DIG_MOD_V1_OVF_MSK,
+				      status);
+}
+
+/**
+ * @brief Clear the ISO_DIG_MOD_V1_OVF int mask.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_clear_iso_dig_mod_v1_ovf_int(struct ade7913_dev *dev)
+{
+	return ade7913_write(dev, ADE7913_REG_STATUS2, ADE7913_ISO_DIG_MOD_V1_OVF_MSK,
+			     ADE7913_S_OP);
+}
+
+/**
+ * @brief Get ISO_DIG_MOD_I_OVF indicator.
+ * @param dev - The device structure.
+ * @param status - Status indicator.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_iso_dig_mod_i_ovf(struct ade7913_dev *dev, uint8_t *status)
+{
+	return ade7913_get_int_status(dev, ADE7913_REG_STATUS2,
+				      ADE7913_ISO_DIG_MOD_I_OVF_MSK,
+				      status);
+}
+
+/**
+ * @brief Clear the ISO_DIG_MOD_I_OVF int mask.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_clear_iso_dig_mod_i_ovf_int(struct ade7913_dev *dev)
+{
+	return ade7913_write(dev, ADE7913_REG_STATUS2, ADE7913_ISO_DIG_MOD_I_OVF_MSK,
+			     ADE7913_S_OP);
+}
+
+/**
+ * @brief Get ISO_TEST_MMR_ERR indicator.
+ * @param dev - The device structure.
+ * @param status - Status indicator.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_iso_test_mmr_err(struct ade7913_dev *dev, uint8_t *status)
+{
+	return ade7913_get_int_status(dev, ADE7913_REG_STATUS2,
+				      ADE7913_ISO_TEST_MMR_ERR_MSK,
+				      status);
+}
+
+/**
+ * @brief Clear the ISO_TEST_MMR_ERR int mask.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_clear_iso_test_mmr_err_int(struct ade7913_dev *dev)
+{
+	return ade7913_write(dev, ADE7913_REG_STATUS2, ADE7913_ISO_TEST_MMR_ERR_MSK,
+			     ADE7913_S_OP);
+}
+
+/**
+ * @brief Get ISO_STATUS_RD_ECC_ERR indicator.
+ * @param dev - The device structure.
+ * @param status - Status indicator.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_iso_status_rd_ecc_err(struct ade7913_dev *dev, uint8_t *status)
+{
+	return ade7913_get_int_status(dev, ADE7913_REG_COM_FLT_TYPE,
+				      ADE7913_ISO_STATUS_RD_ECC_ERR_MSK,
+				      status);
+}
+
+/**
+ * @brief Get ISO_PHY_ERR indicator.
+ * @param dev - The device structure.
+ * @param status - Status indicator.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_iso_phy_err(struct ade7913_dev *dev, uint8_t *status)
+{
+	return ade7913_get_int_status(dev, ADE7913_REG_COM_FLT_TYPE,
+				      ADE7913_ISO_PHY_ERR_MSK,
+				      status);
+}
+
+/**
+ * @brief Get ISO_ECC_ERR indicator.
+ * @param dev - The device structure.
+ * @param status - Status indicator.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_iso_ecc_err(struct ade7913_dev *dev, uint8_t *status)
+{
+	return ade7913_get_int_status(dev, ADE7913_REG_COM_FLT_TYPE,
+				      ADE7913_ISO_ECC_ERR_MSK,
+				      status);
+}
+
+/**
+ * @brief Get CRC_DONE indicator.
+ * @param dev - The device structure.
+ * @param status - Status indicator.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_crc_done_flag(struct ade7913_dev *dev, uint8_t *status)
+{
+	return ade7913_get_int_status(dev, ADE7913_REG_CONFIG_CRC,
+				      ADE7913_CRC_DONE_MSK,
+				      status);
+}
+
+/**
+ * @brief Clear the CRC_DONE int mask.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_clear_crc_done_int(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_write(dev, ADE7913_REG_CONFIG_CRC, ADE7913_CRC_DONE_MSK,
+			     ADE7913_S_OP);
+}
+
+/**
+ * @brief Force background register map CRC recalculation.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_force_crc_recalculation(struct ade7913_dev *dev)
+{
+	if (!dev)
+		return -ENODEV;
+
+	return ade7913_write(dev, ADE7913_REG_CONFIG_CRC, ADE7913_CRC_FORCE_MSK,
+			     ADE7913_S_OP);
+}
+
+/**
+ * @brief Get SILICON_REVISION value.
+ * @param dev - The device structure.
+ * @param silicon_rev - Read silicon revision value.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_silicon_revision(struct ade7913_dev *dev, uint8_t *silicon_rev)
+{
+	if (!silicon_rev)
+		return -EINVAL;
+
+	return ade7913_read(dev, ADE7913_REG_SILICON_REVISION, silicon_rev,
+			    ADE7913_S_OP);
+}
+
+/**
+ * @brief Get VERSION_PRODUCT value.
+ * @param dev - The device structure.
+ * @param ver_product - VErsion product value.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_version_product(struct ade7913_dev *dev, uint8_t *ver_product)
+{
+	int ret;
+	uint8_t reg_val;
+
+	if (!ver_product)
+		return -EINVAL;
+
+	ret = ade7913_read(dev, ADE7913_REG_VERSION_PRODUCT, &reg_val,
+			   ADE7913_S_OP);
+
+	if (ret)
+		return ret;
+
+	switch (reg_val) {
+	case 0:
+		*ver_product = ADE7913_3_CHANNEL_ADE7913;
+		break;
+	case 1:
+		*ver_product = ADE7913_2_CHANNEL_ADE9112;
+		break;
+	case 3:
+		*ver_product = ADE7913_NONISOLATED_ADE9103;
+		break;
+	default:
+		ret = -ENODEV;
+		break;
+	}
+
+	return ret;
+}
+
+/**
+ * @brief Get wave value.
+ * @param dev - The device structure.
+ * @param selection - Wave selection.
+ * @param val - Read I_WAV value.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_get_wav(struct ade7913_dev *dev, enum ade7913_wav_e selection,
+		    uint32_t *val)
+{
+	int ret;
+	uint8_t reg_val;
+	uint32_t value;
+
+	if (!val)
+		return -EINVAL;
+
+	if (selection > ADE7913_V2_WAV)
+		return -EINVAL;
+
+	ret = ade7913_read(dev, ADE7913_REG_I_WAV_HI + 3 * selection, &reg_val,
+			   ADE7913_S_OP);
+	if (ret)
+		return ret;
+
+	value = reg_val;
+	value <<= 8;
+
+	ret = ade7913_read(dev, ADE7913_REG_I_WAV_MD + 3 * selection, &reg_val,
+			   ADE7913_S_OP);
+	if (ret)
+		return ret;
+
+	value |= reg_val;
+	value <<= 8;
+
+	ret = ade7913_read(dev, ADE7913_REG_I_WAV_LO + 3 * selection, &reg_val,
+			   ADE7913_S_OP);
+	if (ret)
+		return ret;
+
+	value |= reg_val;
+
+	*val = value;
+
+	return 0;
+}
+
+/**
+ * @brief DRDY inerrupt enable.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_drdy_int_enable(struct ade7913_dev *dev)
+{
+	return no_os_irq_enable(dev->irq_ctrl, dev->gpio_rdy->number);
+}
+
+/**
+ * @brief DRDY inerrupt disable.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7913_drdy_int_disable(struct ade7913_dev *dev)
+{
+	return no_os_irq_disable(dev->irq_ctrl, dev->gpio_rdy->number);
+}

--- a/drivers/meter/ade7913/ade7913.h
+++ b/drivers/meter/ade7913/ade7913.h
@@ -1,0 +1,785 @@
+/***************************************************************************//**
+ *   @file   ade7913.h
+ *   @brief  Header file of ADE7913 Driver.
+ *   @author George Mois (george.mois@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __ADE7913_H__
+#define __ADE7913_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include "no_os_util.h"
+#include "no_os_spi.h"
+#include "no_os_gpio.h"
+#include "no_os_irq.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+/* SPI commands */
+#define ADE7913_SPI_READ			NO_OS_BIT(7)
+
+/* Long/Short operation bit, set for lon read/write */
+#define ADE7913_OP_MODE_LONG			NO_OS_BIT(6)
+
+/* ADE7913 CRC constants */
+#define ADE7913_CRC8_POLY			0x07
+#define ADE7913_CRC16_POLY			0x1021
+#define ADE7913_CRC16_INIT_VAL			0xFFFF
+
+/* ENABLE and DISABLE */
+#define ENABLE					1u
+#define DISABLE					0u
+
+/* ADE7913 Register Map */
+#define ADE7913_REG_SWRST			0x001
+#define ADE7913_REG_CONFIG0			0x002
+#define ADE7913_REG_CONFIG_FILT			0x003
+#define ADE7913_REG_CONFIG_ISO_ACC		0x005
+#define ADE7913_REG_CRC_RESULT_HI		0x006
+#define ADE7913_REG_CRC_RESULT_LO		0x007
+#define ADE7913_REG_EFUSE_REFRESH		0x008
+#define ADE7913_REG_EMI_CONFIG			0x009
+#define ADE7913_REG_EMI_HI_MASK			0x00A
+#define ADE7913_REG_EMI_LO_MASK			0x00B
+#define ADE7913_REG_EMI_HI_LIMIT		0x00C
+#define ADE7913_REG_EMI_MID_LIMIT		0x00D
+#define ADE7913_REG_EMI_LO_LIMIT		0x00E
+#define ADE7913_REG_MASK0			0x00F
+#define ADE7913_REG_MASK1			0x010
+#define ADE7913_REG_MASK2			0x011
+#define ADE7913_REG_CONFIG_ZX			0x012
+#define ADE7913_REG_SCRATCH			0x013
+#define ADE7913_REG_SYNC_SNAP			0x014
+#define ADE7913_REG_COUNTER_HI			0x015
+#define ADE7913_REG_COUNTER_LO			0x016
+#define ADE7913_REG_SNAPSHOT_COUNT_HI		0x017
+#define ADE7913_REG_SNAPSHOT_COUNT_LO		0x018
+#define ADE7913_REG_WR_LOCK			0x01F
+#define ADE7913_REG_STATUS0			0x020
+#define ADE7913_REG_STATUS1			0x021
+#define ADE7913_REG_STATUS2			0x022
+#define ADE7913_REG_COM_FLT_TYPE		0x023
+#define ADE7913_REG_COM_FLT_COUNT		0x024
+#define ADE7913_REG_CONFIG_CRC			0x025
+#define ADE7913_REG_I_WAV_HI			0x026
+#define ADE7913_REG_I_WAV_MD			0x027
+#define ADE7913_REG_I_WAV_LO 			0x028
+#define ADE7913_REG_V1_WAV_HI			0x029
+#define ADE7913_REG_V1_WAV_MD			0x02A
+#define ADE7913_REG_V1_WAV_LO			0x02B
+#define ADE7913_REG_V2_WAV_HI			0x02C
+#define ADE7913_REG_V2_WAV_MD			0x02D
+#define ADE7913_REG_V2_WAV_LO			0x02E
+#define ADE7913_REG_UNIQUE_PART_ID_5		0x075
+#define ADE7913_REG_UNIQUE_PART_ID_4		0x076
+#define ADE7913_REG_UNIQUE_PART_ID_3		0x077
+#define ADE7913_REG_UNIQUE_PART_ID_2		0x078
+#define ADE7913_REG_UNIQUE_PART_ID_1		0x079
+#define ADE7913_REG_UNIQUE_PART_ID_0		0x07A
+#define ADE7913_REG_SILICON_REVISION		0x07D
+#define ADE7913_REG_VERSION_PRODUCT		0x07E
+
+/* ADE7913 SWRST command */
+#define ADE7913_SWRST_CMD			0xD6
+
+/* ADE7913_REG_CONFIG0 Bit Definition */
+#define ADE7913_STREAM_DBG_MSK			NO_OS_GENMASK(3, 2)
+#define ADE7913_CRC_EN_SPI_WRITE_MSK		NO_OS_BIT(1)
+#define ADE7913_CLOUT_EN_MSK			NO_OS_BIT(0)
+
+/* ADE7913_REG_CONFIG_FILT Bit Definition */
+#define ADE7913_V2_ADC_INVERT_MSK		NO_OS_BIT(6)
+#define ADE7913_V1_ADC_INVERT_MSK		NO_OS_BIT(5)
+#define ADE7913_I_ADC_INVERT_MSK		NO_OS_BIT(4)
+#define ADE7913_LPF_BW_MSK			NO_OS_BIT(3)
+#define ADE7913_DATAPATH_CONFIG_MSK		NO_OS_GENMASK(2, 0)
+
+/* ADE7913_REG_CONFIG_ISO_ACC Bit Definition */
+#define ADE7913_ISO_WR_ACC_EN_MSK		NO_OS_BIT(0)
+
+/* ADE7913_REG_EFUSE_REFRESH Bit Definition */
+#define ADE7913_EFUSE_REFRESH_MSK		NO_OS_BIT(0)
+
+/* ADE7913_REG_EMI_CONFIG Bit Definition */
+#define ADE7913_EMI_CONFIG_MSK			NO_OS_GENMASK(2, 0)
+
+/* ADE7913_REG_MASK0/ADE7913_REG_STATUS0 Bit Definition */
+#define ADE7913_STATUS1X_MSK	 		NO_OS_BIT(7)
+#define ADE7913_STATUS2X_MSK 			NO_OS_BIT(6)
+#define ADE7913_COM_UP_MSK	 		NO_OS_BIT(4)
+#define ADE7913_CRC_CHG_MSK 			NO_OS_BIT(3)
+#define ADE7913_SPI_CRC_ERR_MSK 		NO_OS_BIT(1)
+#define ADE7913_COMFLT_ERR_MSK			NO_OS_BIT(0)
+
+/* ADE7913_REG_MASK1/ADE7913_REG_STATUS1 Bit Definition */
+#define ADE7913_V2_WAV_OVRNG_MSK		NO_OS_BIT(3)
+#define ADE7913_V1_WAV_OVRNG_MSK		NO_OS_BIT(2)
+#define ADE7913_I_WAV_OVRNG_MSK			NO_OS_BIT(1)
+#define ADE7913_ADC_SYNC_DONE_MSK		NO_OS_BIT(0)
+
+/* ADE7913_REG_MASK2/ADE7913_REG_STATUS2 Bit Definition */
+#define ADE7913_ISO_CLK_STBL_ERR_MSK		NO_OS_BIT(6)
+#define ADE7913_ISO_PHY_CRC_ERR_MSK		NO_OS_BIT(5)
+#define ADE7913_ISO_EFUSE_MEM_ERR_MSK		NO_OS_BIT(4)
+#define ADE7913_ISO_DIG_MOD_V2_OVF_MSK		NO_OS_BIT(3)
+#define ADE7913_ISO_DIG_MOD_V1_OVF_MSK		NO_OS_BIT(2)
+#define ADE7913_ISO_DIG_MOD_I_OVF_MSK		NO_OS_BIT(1)
+#define ADE7913_ISO_TEST_MMR_ERR_MSK		NO_OS_BIT(0)
+
+/* ADE7913_REG_CONFIG_ZX Bit Definition */
+#define ADE7913_ZX_EDGE_SEL_MSK			NO_OS_GENMASK(3, 2)
+#define ADE7913_ZX_CHANNEL_CONFIG_MSK		NO_OS_GENMASK(1, 0)
+
+/* ADE7913_REG_SYNC_SNAP Bit Definition */
+#define ADE7913_PREP_BROADCAST_MSK		NO_OS_BIT(2)
+#define ADE7913_ALIGN_MSK			NO_OS_BIT(1)
+#define ADE7913_SNAPSHOT_MSK			NO_OS_BIT(0)
+
+/* ADE7913_REG_COUNTER_HI Bit Definition */
+#define ADE7913_COUNTER_HI_MSK			NO_OS_GENMASK(5, 0)
+
+/* ADE7913_REG_COUNTER_LO Bit Definition */
+#define ADE7913_COUNTER_LO_MSK			NO_OS_GENMASK(8, 0)
+
+/* ADE7913_REG_SNAPSHOT_COUNT_HI Bit Definition */
+#define ADE7913_SNAPSHOT_COUNT_HI_MSK		NO_OS_GENMASK(5, 0)
+
+/* ADE7913_REG_SNAPSHOT_COUNT_LO Bit Definition */
+#define ADE7913_SNAPSHOT_COUNT_LO_MSK		NO_OS_GENMASK(7, 0)
+
+/* ADE7913_REG_STATUS0 Bit Definition */
+#define ADE7913_RESET_DONE_MSK			NO_OS_BIT(5)
+#define ADE7913_EFUSE_MEM_ERR_MSK		NO_OS_BIT(2)
+
+/* ADE7913_REG_COM_FLT_TYPE Bit Definition */
+#define ADE7913_ISO_STATUS_RD_ECC_ERR_MSK	NO_OS_BIT(2)
+#define ADE7913_ISO_PHY_ERR_MSK			NO_OS_BIT(1)
+#define ADE7913_ISO_ECC_ERR_MSK			NO_OS_BIT(1)
+
+/* ADE7913_REG_CONFIG_CRC Bit Definition */
+#define ADE7913_CRC_DONE_MSK			NO_OS_BIT(1)
+#define ADE7913_CRC_FORCE_MSK			NO_OS_BIT(0)
+
+/* ADE7913_REG_SILICON_REVISION Bit Definition */
+#define ADE7913_NONISO_CHIP_REV_MSK		NO_OS_GENMASK(7, 4)
+#define ADE7913_ISO_CHIP_REV_MSK		NO_OS_GENMASK(3, 0)
+
+/* Configuration Register Write Lock */
+#define ADE7913_LOCK_KEY			0XD4
+#define ADE7913_UNLOCK_KEY			0X5E
+
+/* Version Product */
+#define ADE7913_3_CHANNEL_ADE7913		0U
+#define ADE7913_2_CHANNEL_ADE9112		1U
+#define ADE7913_NONISOLATED_ADE9103		3U
+
+/* Revision Value of ISO and NONISO Silicon */
+#define ADE7913_SILICON_REVISION		0x12
+
+/* Nominal reference voltage */
+#define ADE7913_VREF				(883883)
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+
+/**
+ * @enum ade7913_stream_debug_e
+ * @brief ADE7913 Stream Debug.
+ */
+enum ade7913_stream_debug_e {
+	/* Normal Mode */
+	ADE7913_STREAM_NORMAL_MODE = 0,
+	/* Static Mode */
+	ADE7913_STREAM_STATIC_MODE,
+	/* Data Increments at ADC Conversion Rate */
+	ADE7913_STREAM_INCREMENTS_MODE,
+	/* Same as functional mode */
+	ADE7913_STREAM_FUNCTIONAL_MODE
+};
+
+/**
+ * @enum ade7913_datapath_config_e
+ * @brief ADE7913 digital signal processing configuration.
+ */
+enum ade7913_datapath_config_e {
+	/* Sinc3, 32KHz Sampling */
+	ADE7913_SINC3_32_KHZ_SAMPLING = 0,
+	/* Sinc3, Low-Pass Filter (LPF) Enabled, 32kHz Sampling */
+	ADE7913_SINC3_LPF_EN_32_KHZ_SAMPLING,
+	/* Sinc3, Compensation Enabled, LPF Enabled, 32KHz Sampling */
+	ADE7913_SINC3_COMP_EN_LPF_EN_32_KHZ_SAMPLING,
+	/* Sinc3, LPF Enabled, 8KHz Sampling */
+	ADE7913_SINC3_LPF_EN_8_KHZ_SAMPLING,
+	/* Sinc3, Compensation Enabled, LPF Enabled, 8KHz Sampling */
+	ADE7913_SINC3_COMP_EN_LPF_EN_8_KHZ_SAMPLING,
+	/* Sinc3, LPF Enabled, 4kHz Sampling. */
+	ADE7913_SINC3_LPF_EN_4_KHZ_SAMPLING,
+	/* Sinc3, LPF Enabled, 2kHz Sampling. */
+	ADE7913_SINC3_LPF_EN_2_KHZ_SAMPLING,
+	/* Sinc3, LPF Enabled, 1kHz Sampling. */
+	ADE7913_SINC3_LPF_EN_1_KHZ_SAMPLING
+};
+
+/**
+ * @enum ade7913_emi_config_e
+ * @brief ADE7913 EMI Frequency Hopping Selection.
+ */
+enum ade7913_emi_config_e {
+	/* Sawtooth Frequency Rising */
+	ADE7913_SAWTOOTH_FREQUENCY_RISING = 0,
+	/* Sawtooth Frequency Falling */
+	ADE7913_SAWTOOTH_FREQUENCY_FALLING,
+	/* Ramp */
+	ADE7913_RAMP,
+	/* Random Hopping Frequency */
+	ADE7913_RANDOM_HOPPING_FREQUENCY
+};
+
+/**
+ * @enum ade7913_zx_edge_sel_e
+ * @brief ADE7913 Zero Crossing Edge Select.
+ */
+enum ade7913_zx_edge_sel_e {
+	/* ZX Pin Reflects the Sign of the Input Signal */
+	ADE7913_ZX_INPUT_SIGNAL_SIGN = 0,
+	/* Detect Zero Crossings with Positive Slope */
+	ADE7913_ZX_DETECT_POSITIVE_SLOPE,
+	/* Detect Zero Crossings with Negative Slope */
+	ADE7913_ZX_DETECT_NEGATIVE_SLOPE,
+	/* Detect Zero Crossings with Positive or Negative Slopes */
+	ADE7913_ZX_DETECT_BOTH_SLOPES
+};
+
+/**
+ * @enum ade7913_zx_channel_cfg_e
+ * @brief ADE7913 Zero Crossing Channel Select.
+ */
+enum ade7913_zx_channel_cfg_e {
+	/* Disable Zero Crossing Output */
+	ADE7913_ZX_DISABLE = 0,
+	/* Output Zero Crossing Function from the I Channel on ZX Pin */
+	ADE7913_ZX_I_SEL,
+	/* Output Zero Crossing Function from the V1 Channel on ZX Pin */
+	ADE7913_ZX_V1_SEL,
+	/* Output Zero Crossing Function from the V2 Channel on ZX Pin */
+	ADE7913_ZX_V2_SEL
+};
+
+/**
+ * @enum ade7913_operation_e
+ * @brief ADE7913 long/short operation mode.
+ */
+enum ade7913_operation_e {
+	/* Long read/write operations */
+	ADE7913_L_OP = 0,
+	/* Short read/write operations */
+	ADE7913_S_OP
+};
+
+/**
+ * @enum ade7913_wav_e
+ * @brief ADE7913 waveorm data.
+ */
+enum ade7913_wav_e {
+	/* I_WAV */
+	ADE7913_I_WAV = 0,
+	/* V1_WAV */
+	ADE7913_V1_WAV,
+	/* V1_WAV */
+	ADE7913_V2_WAV
+};
+
+
+/**
+ * @struct ade7913_init_param
+ * @brief ADE7913 Device initialization parameters.
+ */
+struct ade7913_init_param {
+	/* Device communication descriptor */
+	struct no_os_spi_init_param 	*spi_init;
+	/** GPIO RDY descriptor used to signal when ADC data is available */
+	struct no_os_gpio_init_param	*gpio_rdy;
+	/** GPIO RESET descriptor used to reset device (HW reset) */
+	struct no_os_gpio_init_param  	*gpio_reset;
+	/** IRQ device descriptor used to handle interrupt routine for GPIO RDY */
+	struct no_os_irq_ctrl_desc 	*irq_ctrl;
+	/** External callback used to handle interrupt routine for GPIO RDY */
+	/** Set to NULL if callback defined in driver used */
+	void (*drdy_callback)(void *context);
+};
+
+/**
+ * @struct ade7913_dev
+ * @brief ADE7913 Device structure.
+ */
+struct ade7913_dev {
+	/* Device communication descriptor */
+	struct no_os_spi_desc		*spi_desc;
+	/* Version product */
+	uint8_t 			ver_product;
+	/* CRC setting */
+	uint8_t				crc_en;
+	/* I_WAV */
+	int32_t				i_wav;
+	/* V1_WAV */
+	int32_t				v1_wav;
+	/* V2_WAV */
+	int32_t				v2_wav;
+	/** GPIO RDY descriptor used to signal when ADC data is available */
+	struct no_os_gpio_desc  	*gpio_rdy;
+	/** GPIO RESET descriptor used to reset device (HW reset) */
+	struct no_os_gpio_desc  	*gpio_reset;
+	/** IRQ device descriptor used to handle interrupt routine for GPIO RDY */
+	struct no_os_irq_ctrl_desc 	*irq_ctrl;
+	/** IRQ callback used to handle interrupt routine for GPIO RDY */
+	struct no_os_callback_desc	irq_cb;
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+/* Read device register. */
+int ade7913_read(struct ade7913_dev *dev, uint8_t reg_addr,
+		 uint8_t *reg_data, enum ade7913_operation_e op_mode);
+
+/* Write device register. */
+int ade7913_write(struct ade7913_dev *dev, uint8_t reg_addr,
+		  uint8_t reg_data, enum ade7913_operation_e op_mode);
+
+/* Initialize the device. */
+int ade7913_init(struct ade7913_dev **device,
+		 struct ade7913_init_param init_param);
+
+/* Remove the device and release resources. */
+int ade7913_remove(struct ade7913_dev *dev);
+
+/* Reset the device using SW reset. */
+int ade7913_sw_reset(struct ade7913_dev *dev);
+
+/* Reset the device using HW reset. */
+int ade7913_hw_reset(struct ade7913_dev *dev);
+
+/* Convert a 24-bit raw sample to millivolts. */
+int ade7913_convert_to_millivolts(struct ade7913_dev *dev,
+				  enum ade7913_wav_e ch, int32_t *mv_val);
+
+/* Get STREAM_DBG mode. */
+int ade7913_get_stream_dbg_mode(struct ade7913_dev *dev,
+				enum ade7913_stream_debug_e *stream_dbg);
+
+/* Set STREAM_DBG mode. */
+int ade7913_set_stream_dbg_mode(struct ade7913_dev *dev,
+				enum ade7913_stream_debug_e stream_dbg);
+
+/*  Get CRC enable on SPI write setting. */
+int ade7913_get_crc_en_state(struct ade7913_dev *dev,
+			     uint8_t *crc_en_state);
+
+/* Set CRC enable on SPI write setting. */
+int ade7913_set_crc_en_state(struct ade7913_dev *dev,
+			     uint8_t crc_en_state);
+
+/* Lock device. */
+int ade7913_wr_lock(struct ade7913_dev *dev);
+
+/* Unlock device. */
+int ade7913_wr_unlock(struct ade7913_dev *dev);
+
+/*  Write value in the scratchpad register. */
+int ade7913_write_scratchpad(struct ade7913_dev *dev,
+			     uint8_t val);
+
+/* Get the value stired in the scratchpad register. */
+int ade7913_read_scratchpad(struct ade7913_dev *dev,
+			    uint8_t *val);
+
+/* Set normal mode of operation. */
+int ade7913_set_normal_mode(struct ade7913_dev *dev);
+
+/* Set static mode of operation. */
+int ade7913_set_static_mode(struct ade7913_dev *dev);
+
+/* Set static mode of operation. */
+int ade7913_set_data_increments_mode(struct ade7913_dev *dev);
+
+/* Get ECC or PHY Error Count on ISO to NONISO Communications. */
+int ade7913_get_err_count(struct ade7913_dev *dev,
+			  uint8_t *err_count);
+
+/* Invert V2 channel inputs. */
+int ade7913_invert_v2_inputs(struct ade7913_dev *dev);
+
+/* Invert V1 channel inputs. */
+int ade7913_invert_v1_inputs(struct ade7913_dev *dev);
+
+/* Invert I channel inputs. */
+int ade7913_invert_i_inputs(struct ade7913_dev *dev);
+
+/* Disable invert V2 channel inputs. */
+int ade7913_invert_v2_inputs_disable(struct ade7913_dev *dev);
+
+/* Disable invert V1 channel inputs. */
+int ade7913_invert_v1_inputs_disable(struct ade7913_dev *dev);
+
+/* Disable invert I channel inputs. */
+int ade7913_invert_i_inputs_disable(struct ade7913_dev *dev);
+
+/* Set filter bandwidth to 2.7 kHz at 8ksps output data rate. */
+int ade7913_set_lpf_bw_2_7(struct ade7913_dev *dev);
+
+/* Set filter bandwidth to 3.3 kHz at 8ksps output data rate. */
+int ade7913_set_lpf_bw_3_3(struct ade7913_dev *dev);
+
+/* Set digital signal processing configuration. */
+int ade7913_set_dsp_config(struct ade7913_dev *dev,
+			   enum ade7913_datapath_config_e config);
+
+/* Enable write access to DC_OFFSET_MODE register. */
+int ade7913_enable_wa_dc_offset_mode(struct ade7913_dev *dev);
+
+/* Disable write access to DC_OFFSET_MODE register. */
+int ade7913_disable_wa_dc_offset_mode(struct ade7913_dev *dev);
+
+/* Get register map CRC. */
+int ade7913_get_crc(struct ade7913_dev *dev, uint16_t *crc);
+
+/* Refresh EFuse Memory. */
+int ade7913_efuse_refresh(struct ade7913_dev *dev);
+
+/* Select EMI frequency hopping. */
+int ade7913_set_emi_config(struct ade7913_dev *dev,
+			   enum ade7913_emi_config_e config);
+
+/* Get EMI HI mask. */
+int ade7913_get_emi_hi_mask(struct ade7913_dev *dev, uint8_t *msk);
+
+/* Get EMI LO mask. */
+int ade7913_get_emi_lo_mask(struct ade7913_dev *dev, uint8_t *msk);
+
+/* Set EMI HI mask. */
+int ade7913_set_emi_hi_mask(struct ade7913_dev *dev, uint8_t msk);
+
+/* Set EMI LO mask. */
+int ade7913_set_emi_lo_mask(struct ade7913_dev *dev, uint8_t msk);
+
+/* Get EMI HI limit. */
+int ade7913_get_emi_hi_limit(struct ade7913_dev *dev, uint8_t *limit);
+
+/* Get EMI MID limit. */
+int ade7913_get_emi_mid_limit(struct ade7913_dev *dev, uint8_t *limit);
+
+/* Get EMI LO limit. */
+int ade7913_get_emi_lo_limit(struct ade7913_dev *dev, uint8_t *limit);
+
+/* Enable/Disable interrupt. */
+int ade7913_control_interrupt(struct ade7913_dev *dev, uint8_t reg_addr,
+			      uint8_t int_msk, uint8_t en);
+
+/* Enable STATUS1X interrupt. */
+int ade7913_enable_status1x_int(struct ade7913_dev *dev);
+
+/* Disable STATUS1X interrupt. */
+int ade7913_disable_status1x_int(struct ade7913_dev *dev);
+
+/* Enable STATUS2X interrupt. */
+int ade7913_enable_status2x_int(struct ade7913_dev *dev);
+
+/* Disable STATUS2X interrupt. */
+int ade7913_disable_status2x_int(struct ade7913_dev *dev);
+
+/* Enable COM_UP interrupt. */
+int ade7913_enable_com_up_int(struct ade7913_dev *dev);
+
+/* Disable COM_UP interrupt. */
+int ade7913_disable_com_up_int(struct ade7913_dev *dev);
+
+/* Enable CRC_CHG interrupt. */
+int ade7913_enable_crc_chg_int(struct ade7913_dev *dev);
+
+/* Disable CRC_CHG interrupt. */
+int ade7913_disable_crc_chg_int(struct ade7913_dev *dev);
+
+/* Enable SPI_CRC_ERR interrupt. */
+int ade7913_enable_spi_crc_err_int(struct ade7913_dev *dev);
+
+/* Disable SPI_CRC_ERR interrupt. */
+int ade7913_disable_spi_crc_err_int(struct ade7913_dev *dev);
+
+/* Enable COMFLT_ERR interrupt. */
+int ade7913_enable_comflt_err_int(struct ade7913_dev *dev);
+
+/* Disable COMFLT_ERR interrupt. */
+int ade7913_disable_comflt_err_int(struct ade7913_dev *dev);
+
+/* Enable V2_WAV_OVRNG interrupt. */
+int ade7913_enable_v2_wav_ovrng_int(struct ade7913_dev *dev);
+
+/* Disable V2_WAV_OVRNG interrupt. */
+int ade7913_disable_v2_wav_ovrng_int(struct ade7913_dev *dev);
+
+/* Enable V1_WAV_OVRNG interrupt. */
+int ade7913_enable_v1_wav_ovrng_int(struct ade7913_dev *dev);
+
+/* Disable V1_WAV_OVRNG interrupt. */
+int ade7913_disable_v1_wav_ovrng_int(struct ade7913_dev *dev);
+
+/* Enable I_WAV_OVRNG interrupt. */
+int ade7913_enable_i_wav_ovrng_int(struct ade7913_dev *dev);
+
+/* Disable I_WAV_OVRNG interrupt. */
+int ade7913_disable_i_wav_ovrng_int(struct ade7913_dev *dev);
+
+/* Enable ADC_SYNC_DONE interrupt. */
+int ade7913_enable_adc_sync_done_int(struct ade7913_dev *dev);
+
+/* Disable ADC_SYNC_DONE interrupt. */
+int ade7913_disable_adc_sync_done_int(struct ade7913_dev *dev);
+
+/* Enable ISO_CLK_STBL_ERR interrupt. */
+int ade7913_enable_iso_clk_stbl_err_int(struct ade7913_dev *dev);
+
+/* Disable ISO_CLK_STBL_ERR interrupt. */
+int ade7913_disable_iso_clk_stbl_err_int(struct ade7913_dev *dev);
+
+/* Enable ISO_PHY_CRC_ERR interrupt. */
+int ade7913_enable_iso_phy_crc_err_int(struct ade7913_dev *dev);
+
+/* Disable ISO_PHY_CRC_ERR interrupt. */
+int ade7913_disable_iso_phy_crc_err_int(struct ade7913_dev *dev);
+
+/* Enable ISO_EFUSE_MEM_ERR interrupt. */
+int ade7913_enable_iso_efuse_mem_err_int(struct ade7913_dev *dev);
+
+/* Disable ISO_EFUSE_MEM_ERR interrupt. */
+int ade7913_disable_iso_efuse_mem_err_int(struct ade7913_dev *dev);
+
+/* Enable ISO_DIG_MOD_V2_OVF interrupt. */
+int ade7913_enable_iso_dig_mod_v2_ovf_int(struct ade7913_dev *dev);
+
+/* Disable ISO_DIG_MOD_V2_OVF interrupt. */
+int ade7913_disable_iso_dig_mod_v2_ovf_int(struct ade7913_dev *dev);
+
+/* Enable ISO_DIG_MOD_V1_OVF interrupt. */
+int ade7913_enable_iso_dig_mod_v1_ovf_int(struct ade7913_dev *dev);
+
+/* Disable ISO_DIG_MOD_V1_OVF interrupt. */
+int ade7913_disable_iso_dig_mod_v1_ovf_int(struct ade7913_dev *dev);
+
+/* Enable ISO_DIG_MOD_I_OVF interrupt. */
+int ade7913_enable_iso_dig_mod_i_ovf_int(struct ade7913_dev *dev);
+
+/* Disable ISO_DIG_MOD_I_OVF interrupt. */
+int ade7913_disable_iso_dig_mod_i_ovf_int(struct ade7913_dev *dev);
+
+/* Enable ISO_TEST_MMR_ERR interrupt. */
+int ade7913_enable_iso_test_mmr_err_int(struct ade7913_dev *dev);
+
+/* Disable ISO_TEST_MMR_ERR interrupt. */
+int ade7913_disable_iso_test_mmr_err_int(struct ade7913_dev *dev);
+
+/* Select zero crossing edge. */
+int ade7913_select_zero_crossing_edge(struct ade7913_dev *dev,
+				      enum ade7913_zx_edge_sel_e sel);
+
+/* Select zero crossing channel. */
+int ade7913_select_zero_crossing_channel(struct ade7913_dev *dev,
+		enum ade7913_zx_channel_cfg_e cfg);
+
+/* ADC prepare broadcast. */
+int ade7913_adc_prepare_broadcast(struct ade7913_dev *dev);
+
+/* ADC align. */
+int ade7913_adc_align(struct ade7913_dev *dev);
+
+/* ADC snapshot. */
+int ade7913_adc_snapshot(struct ade7913_dev *dev);
+
+/* Get interrupt indicator from STATUS register. */
+int ade7913_get_int_status(struct ade7913_dev *dev, uint8_t addr, uint8_t msk,
+			   uint8_t *status);
+
+/* Get STATUSx register value. */
+int ade7913_get_statusx_val(struct ade7913_dev *dev, uint8_t addr,
+			    uint8_t *status);
+
+/* Get STATUS1X Indicator. */
+int ade7913_get_status1x(struct ade7913_dev *dev, uint8_t *status);
+
+/* Get STATUS2 indicator. */
+int ade7913_get_status2x(struct ade7913_dev *dev, uint8_t *status);
+
+/* Get RESET_DONE indicator. */
+int ade7913_get_reset_done(struct ade7913_dev *dev, uint8_t *status);
+
+/* Get COM_UP indicator. */
+int ade7913_get_com_up(struct ade7913_dev *dev, uint8_t *status);
+
+/* Get CRC_CHG indicator. */
+int ade7913_get_crc_chg(struct ade7913_dev *dev, uint8_t *status);
+
+/* Get EFUSE_MEM_ERR indicator. */
+int ade7913_get_efuse_mem_err(struct ade7913_dev *dev, uint8_t *status);
+
+/* Get SPI_CRC_ERR indicator. */
+int ade7913_get_spi_crc_err(struct ade7913_dev *dev, uint8_t *status);
+
+/* Get COMFLT_ERR indicator. */
+int ade7913_get_comflt_err(struct ade7913_dev *dev, uint8_t *status);
+
+/* Clear the RESET_DONE int mask. */
+int ade7913_clear_reset_done_int(struct ade7913_dev *dev);
+
+/* Clear the COM_UP int mask. */
+int ade7913_clear_com_up_int(struct ade7913_dev *dev);
+
+/* Clear the CRC_CHG int mask. */
+int ade7913_clear_crc_chg_int(struct ade7913_dev *dev);
+
+/* Clear the SPI_CRC_ERR int mask. */
+int ade7913_clear_spi_crc_err_int(struct ade7913_dev *dev);
+
+/* Clear the COMFLT_ERR int mask. */
+int ade7913_clear_comflt_err_int(struct ade7913_dev *dev);
+
+/* Get V2_WAV_OVRNG indicator. */
+int ade7913_get_v2_wav_ovrng(struct ade7913_dev *dev, uint8_t *status);
+
+/* Clear the V2_WAV_OVRNG int mask. */
+int ade7913_clear_v2_wav_ovrng_int(struct ade7913_dev *dev);
+
+/* Get V1_WAV_OVRNG indicator. */
+int ade7913_get_v1_wav_ovrng(struct ade7913_dev *dev, uint8_t *status);
+
+/* Clear the V1_WAV_OVRNG int mask. */
+int ade7913_clear_v1_wav_ovrng_int(struct ade7913_dev *dev);
+
+/* Get I_WAV_OVRNG indicator. */
+int ade7913_get_i_wav_ovrng(struct ade7913_dev *dev, uint8_t *status);
+
+/* Clear the I_WAV_OVRNG int mask. */
+int ade7913_clear_i_wav_ovrng_int(struct ade7913_dev *dev);
+
+/* Get ADC_SYNC_DONE indicator. */
+int ade7913_get_adc_sync_done(struct ade7913_dev *dev, uint8_t *status);
+
+/* Clear the ADC_SYNC_DONE int mask. */
+int ade7913_clear_adc_sync_done_int(struct ade7913_dev *dev);
+
+/* Get ISO_CLK_STBL_ERR indicator. */
+int ade7913_get_iso_clk_stbl_err(struct ade7913_dev *dev, uint8_t *status);
+
+/* Clear the ISO_CLK_STBL_ERR int mask. */
+int ade7913_clear_iso_clk_stbl_err_int(struct ade7913_dev *dev);
+
+/* Get ISO_PHY_CRC_ERR indicator. */
+int ade7913_get_iso_phy_crc_err(struct ade7913_dev *dev, uint8_t *status);
+
+/* Clear the ISO_PHY_CRC_ERR int mask. */
+int ade7913_clear_iso_phy_crc_err_int(struct ade7913_dev *dev);
+
+/* Get ISO_EFUSE_MEM_ERR indicator. */
+int ade7913_get_iso_efuse_mem_err_err(struct ade7913_dev *dev, uint8_t *status);
+
+/* Clear the ISO_EFUSE_MEM_ERR int mask. */
+int ade7913_clear_iso_efuse_mem_err_int(struct ade7913_dev *dev);
+
+/* Get ISO_DIG_MOD_V2_OVF indicator. */
+int ade7913_get_iso_dig_mod_v2_ovf(struct ade7913_dev *dev, uint8_t *status);
+
+/* Clear the ISO_DIG_MOD_V2_OVF int mask. */
+int ade7913_clear_iso_dig_mod_v2_ovf_int(struct ade7913_dev *dev);
+
+/* Get ISO_DIG_MOD_V1_OVF indicator. */
+int ade7913_get_iso_dig_mod_v1_ovf(struct ade7913_dev *dev, uint8_t *status);
+
+/* Clear the ISO_DIG_MOD_V1_OVF int mask. */
+int ade7913_clear_iso_dig_mod_v1_ovf_int(struct ade7913_dev *dev);
+
+/* Get ISO_DIG_MOD_I_OVF indicator. */
+int ade7913_get_iso_dig_mod_i_ovf(struct ade7913_dev *dev, uint8_t *status);
+
+/* Clear the ISO_DIG_MOD_I_OVF int mask. */
+int ade7913_clear_iso_dig_mod_i_ovf_int(struct ade7913_dev *dev);
+
+/* Get ISO_TEST_MMR_ERR indicator. */
+int ade7913_get_iso_test_mmr_err(struct ade7913_dev *dev, uint8_t *status);
+
+/* Clear the ISO_TEST_MMR_ERR int mask. */
+int ade7913_clear_iso_test_mmr_err_int(struct ade7913_dev *dev);
+
+/* Get ISO_STATUS_RD_ECC_ERR indicator. */
+int ade7913_get_iso_status_rd_ecc_err(struct ade7913_dev *dev, uint8_t *status);
+
+/* Get ISO_PHY_ERR indicator. */
+int ade7913_get_iso_phy_err(struct ade7913_dev *dev, uint8_t *status);
+
+/* Get ISO_ECC_ERR indicator. */
+int ade7913_get_iso_ecc_err(struct ade7913_dev *dev, uint8_t *status);
+
+/* Get CRC_DONE indicator. */
+int ade7913_get_crc_done_flag(struct ade7913_dev *dev, uint8_t *status);
+
+/* Clear the CRC_DONE int mask. */
+int ade7913_clear_crc_done_int(struct ade7913_dev *dev);
+
+/* Force background register map CRC recalculation. */
+int ade7913_force_crc_recalculation(struct ade7913_dev *dev);
+
+/* Get SILICON_REVISION value. */
+int ade7913_get_silicon_revision(struct ade7913_dev *dev, uint8_t *silicon_rev);
+
+/* Get VERSION_PRODUCT value. */
+int ade7913_get_version_product(struct ade7913_dev *dev, uint8_t *ver_product);
+
+/* Get wave value. */
+int ade7913_get_wav(struct ade7913_dev *dev, enum ade7913_wav_e selection,
+		    uint32_t *val);
+
+/* DRDY inerrupt enable. */
+int ade7913_drdy_int_enable(struct ade7913_dev *dev);
+
+/* DRDY inerrupt disable. */
+int ade7913_drdy_int_disable(struct ade7913_dev *dev);
+
+#endif // __ADE7913_H__


### PR DESCRIPTION
Add driver for the ADE7913 3-Channel, Isolated, Sigma Delta ADC with SPI.

## Pull Request Description

The ADE7913 are isolated, 3-channel Σ-Δ ADCs for a variety of applications such as shunt-based polyphase meters, power quality monitoring, solar inverters, process monitoring and protective devices.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
