### PR TITLE
tools: scripts: export .tar.gz archive instead of .zip

### DIFF
--- a/tools/scripts/build_projects.py
+++ b/tools/scripts/build_projects.py
@@ -229,7 +229,7 @@ class BuildConfig:
 			self.export_file = self.export_file.replace('.elf', '.bin')
 		if (platform == 'xilinx'):
 			self.export_boot_bin = os.path.join(self.build_dir, "output_boot_bin/BOOT.BIN")
-			self.export_archive = os.path.join(self.build_dir, "bootgen_sysfiles.zip")
+			self.export_archive = os.path.join(self.build_dir, "bootgen_sysfiles.tar.gz")
 
 	def build(self):
 		global log_file

--- a/tools/scripts/xilinx.mk
+++ b/tools/scripts/xilinx.mk
@@ -266,14 +266,14 @@ endif
 	$(call copy_file,$(TEMP_DIR)/*.bit,$(BOOT_BIN_DIR)) $(HIDE)
 	$(call copy_file,$(FSBL_PATH),$(BOOT_BIN_DIR)) $(HIDE)
 	$(call copy_file,$(BINARY),$(BOOT_BIN_DIR)) $(HIDE)
-	tar -czvf $(BUILD_DIR)/bootgen_sysfiles.tar.gz --force-local --exclude 'BOOT.BIN' -C $(BOOT_BIN_DIR) . $(HIDE)
+	tar -czvf $(BUILD_DIR)/bootgen_sysfiles.tar.gz --transform 's/^\(\.\/\|\.\)//' --force-local --exclude 'BOOT.BIN' -C $(BOOT_BIN_DIR) . $(HIDE)
 else
 	$(call print,Creating archive with files)
 	$(call remove_dir,$(BUILD_DIR)/boot_files) $(HIDE)
 	$(call mk_dir,$(BUILD_DIR)/boot_files) $(HIDE)
 	$(call copy_file,$(TEMP_DIR)/*.bit,$(BUILD_DIR)/boot_files) $(HIDE)
 	$(call copy_file,$(BINARY),$(BUILD_DIR)/boot_files) $(HIDE)
-	tar -czvf $(BUILD_DIR)/bootgen_sysfiles.tar.gz --force-local -C $(BUILD_DIR)/boot_files . $(HIDE)
+	tar -czvf $(BUILD_DIR)/bootgen_sysfiles.tar.gz --transform 's/^\(\.\/\|\.\)//' --force-local -C $(BUILD_DIR)/boot_files . $(HIDE)
 endif
 endif
 


### PR DESCRIPTION
## Pull Request Description

For Xilinx projects bootgen_sysfiles archives are created, first were saved as .zip and were changed to .tag.gz, but the pipeline was still looking for .zip file.
Also a new option was added to tar command in order to eliminate concatenation of the parent directory in the path.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [x] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
