### PR TITLE
ad2s1210: Add methods for hysteresis and excitation frequency

### DIFF
--- a/drivers/resolver/ad2s1210/ad2s1210.c
+++ b/drivers/resolver/ad2s1210/ad2s1210.c
@@ -120,6 +120,52 @@ int ad2s1210_reg_read(struct ad2s1210_dev *dev, uint8_t addr, uint8_t *val)
 }
 
 /*******************************************************************************
+* @brief Gets the the hysteresis enable value.
+*
+* @param dev - Device descriptor.
+*
+* @return Returns 1 in case of enabled 0 if disabled or negative error code
+*******************************************************************************/
+int ad2s1210_hysteresis_is_enabled(struct ad2s1210_dev *dev)
+{
+	int ret;
+	uint8_t control;
+
+	ret = ad2s1210_reg_read(dev,  AD2S1210_REG_CONTROL, &control);
+	if (ret)
+		return ret;
+
+	if (control & AD2S1210_ENABLE_HYSTERESIS)
+		return 1;
+
+	return 0;
+}
+
+/*******************************************************************************
+* @brief Sets the hysteresis enable value
+*
+* @param dev - Device descriptor.
+* @param fexcit - pointer to store the excitation frequency
+*
+* @return Returns negative error code or 0 in case of success.
+*******************************************************************************/
+int ad2s1210_set_hysteresis(struct ad2s1210_dev *dev, bool enable)
+{
+	int ret;
+	uint8_t control;
+
+	ret = ad2s1210_reg_read(dev,  AD2S1210_REG_CONTROL, &control);
+	if (ret)
+		return ret;
+
+	control &= ~AD2S1210_ENABLE_HYSTERESIS;
+	if (enable)
+		control |= AD2S1210_ENABLE_HYSTERESIS;
+
+	return ad2s1210_reg_write(dev,  AD2S1210_REG_CONTROL, control);
+}
+
+/*******************************************************************************
 * @brief Read a device register
 *
 * @param dev - Device descriptor.

--- a/drivers/resolver/ad2s1210/ad2s1210.h
+++ b/drivers/resolver/ad2s1210/ad2s1210.h
@@ -59,6 +59,7 @@
 #define AD2S1210_CONTROL_RES_MASK	NO_OS_GENMASK(1, 0)
 #define AD2S1210_CONTROL_RES0_MASK	NO_OS_BIT(0)
 #define AD2S1210_CONTROL_RES1_MASK	NO_OS_BIT(1)
+#define AD2S1210_ENABLE_HYSTERESIS	NO_OS_BIT(4)
 
 #define AD2S1210_REG_SOFT_RESET		0xF0
 #define AD2S1210_REG_FAULT		0xFF
@@ -117,5 +118,6 @@ int ad2s1210_reg_read(struct ad2s1210_dev *dev, uint8_t addr,
 		      uint8_t *val);
 int ad2s1210_spi_single_conversion(struct ad2s1210_dev *dev,
 				   enum ad2s1210_channel chn, uint16_t *data);
-
+int ad2s1210_hysteresis_is_enabled(struct ad2s1210_dev *dev);
+int ad2s1210_set_hysteresis(struct ad2s1210_dev *dev, bool enable);
 #endif

--- a/drivers/resolver/ad2s1210/ad2s1210.h
+++ b/drivers/resolver/ad2s1210/ad2s1210.h
@@ -66,6 +66,14 @@
 
 #define AD2S1210_REG_MIN		AD2S1210_REG_POSITION
 
+#define AD2S1210_MIN_CLKIN	6144000
+#define AD2S1210_MAX_CLKIN	10240000
+#define AD2S1210_MIN_EXCIT	2000
+#define AD2S1210_MAX_EXCIT	20000
+#define AD2S1210_STEP_EXCIT	250
+#define AD2S1210_MIN_FCW	0x4
+#define AD2S1210_MAX_FCW	0x50
+
 enum ad2s1210_mode {
 	MODE_POS,
 	MODE_RESERVED,
@@ -93,6 +101,7 @@ struct ad2s1210_init_param {
 	struct no_os_gpio_init_param gpio_res1;
 	struct no_os_gpio_init_param gpio_sample;
 	int8_t resolution;
+	uint32_t clkin_hz;
 };
 
 struct ad2s1210_dev {
@@ -107,6 +116,7 @@ struct ad2s1210_dev {
 	struct no_os_gpio_desc *gpio_res0;
 	struct no_os_gpio_desc *gpio_res1;
 	struct no_os_gpio_desc *gpio_sample;
+	uint32_t clkin_hz;
 };
 
 int ad2s1210_init(struct ad2s1210_dev **dev,
@@ -120,4 +130,8 @@ int ad2s1210_spi_single_conversion(struct ad2s1210_dev *dev,
 				   enum ad2s1210_channel chn, uint16_t *data);
 int ad2s1210_hysteresis_is_enabled(struct ad2s1210_dev *dev);
 int ad2s1210_set_hysteresis(struct ad2s1210_dev *dev, bool enable);
+int ad2s1210_reinit_excitation_frequency(struct ad2s1210_dev *dev,
+		uint16_t fexcit);
+int ad2s1210_get_excitation_frequency(struct ad2s1210_dev *dev,
+				      uint16_t *fexcit);
 #endif


### PR DESCRIPTION
## ad2s1210: Add methods for hysteresis and excitation frequency

The work on linux driver currently added some attributes that are not implemented:
* set and get hysteresis
* output channel for excitation frequency 
* a couple of label attributes for channels. 

These patches add setter and getter methods  for hysteresis and excitation frequency
So the corresponding attributes can be implemented on the ad2s1210 project. 
the intention is to keep no-os attributes/channels aligned with the upstream Linux driver,
so that any user application will work without any modifications with either of the two. 

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
