### PR TITLE
drivers:ad7124:Fix for set polarity

### DIFF
--- a/drivers/adc/ad7124/ad7124.c
+++ b/drivers/adc/ad7124/ad7124.c
@@ -847,15 +847,16 @@ int ad7124_set_polarity(struct ad7124_dev* device,
 			uint8_t setup_id)
 {
 	int ret;
+	uint32_t reg_data;
 
 	if (bipolar)
-		bipolar = AD7124_CFG_REG_BIPOLAR;
+		reg_data = AD7124_CFG_REG_BIPOLAR;
 	else
-		bipolar = 0x0U;
+		reg_data = 0x0U;
 
 	ret = ad7124_reg_write_msk(device,
 				   AD7124_CFG0_REG+setup_id,
-				   bipolar,
+				   reg_data,
 				   AD7124_CFG_REG_BIPOLAR);
 	if (ret)
 		return ret;


### PR DESCRIPTION
Adding another variable with data type uint32_t
to hold the value to be written for bipolar mode.

## Pull Request Description

As bool data type was used for bipolar variable it could be assigned to only true or false and didn't hold the intended value 
AD7124_CFG_REG_BIPOLAR (2048).  Made necessary adjustments to code. 

## PR Type
- [X] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [X] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [X] I have performed a self-review of the changes
- [X] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [X] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
