### PR TITLE
drivers: accel: adxl367: fix sign extend

### DIFF
--- a/drivers/accel/adxl367/adxl367.c
+++ b/drivers/accel/adxl367/adxl367.c
@@ -204,8 +204,8 @@ int adxl367_self_test(struct adxl367_dev *dev)
 		return ret;
 	x_axis_2 += read_val >> 2;
 	// extend sign to 16 bits
-	if (x_axis_1 & NO_OS_BIT(13))
-		x_axis_1 |= NO_OS_GENMASK(15, 14);
+	if (x_axis_2 & NO_OS_BIT(13))
+		x_axis_2 |= NO_OS_GENMASK(15, 14);
 
 	ret = adxl367_set_power_mode(dev, ADXL367_OP_STANDBY);
 	if (ret)


### PR DESCRIPTION


## Pull Request Description

Perform sign extend on the variable x_axis_2 instead of x_axis_1. The sign extend operation for x_axis_1 is already done after the variable is composed.

Fixes: 2e4f0c3 ("drivers:accel: Create ADXL367 Driver")

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
