### PR TITLE
Fsm update - rename jesd init functions

### DIFF
--- a/drivers/axi_core/jesd204/axi_jesd204_rx.c
+++ b/drivers/axi_core/jesd204/axi_jesd204_rx.c
@@ -914,8 +914,8 @@ err:
  * @param init - The structure containing the device initial parameters.
  * @return Returns 0 in case of success or negative error code otherwise.
  */
-int32_t axi_jesd204_rx_init_jesd_fsm(struct axi_jesd204_rx **jesd204,
-				     const struct jesd204_rx_init *init)
+int32_t axi_jesd204_rx_init(struct axi_jesd204_rx **jesd204,
+			    const struct jesd204_rx_init *init)
 {
 	struct axi_jesd204_rx_jesd204_priv *priv;
 	struct axi_jesd204_rx *jesd;

--- a/drivers/axi_core/jesd204/axi_jesd204_rx.c
+++ b/drivers/axi_core/jesd204/axi_jesd204_rx.c
@@ -838,8 +838,8 @@ static const struct jesd204_dev_data jesd204_axi_jesd204_rx_init = {
  * @param init - The structure containing the device initial parameters.
  * @return Returns 0 in case of success or negative error code otherwise.
  */
-int32_t axi_jesd204_rx_init(struct axi_jesd204_rx **jesd204,
-			    const struct jesd204_rx_init *init)
+int32_t axi_jesd204_rx_init_legacy(struct axi_jesd204_rx **jesd204,
+				   const struct jesd204_rx_init *init)
 {
 	struct axi_jesd204_rx *jesd;
 	uint32_t synth_1;

--- a/drivers/axi_core/jesd204/axi_jesd204_rx.h
+++ b/drivers/axi_core/jesd204/axi_jesd204_rx.h
@@ -128,8 +128,8 @@ int32_t axi_jesd204_rx_watchdog(struct axi_jesd204_rx *jesd);
 int32_t axi_jesd204_rx_init_legacy(struct axi_jesd204_rx **jesd204,
 				   const struct jesd204_rx_init *init);
 /** Device initialization, JESD FSM ON */
-int32_t axi_jesd204_rx_init_jesd_fsm(struct axi_jesd204_rx **jesd204,
-				     const struct jesd204_rx_init *init);
+int32_t axi_jesd204_rx_init(struct axi_jesd204_rx **jesd204,
+			    const struct jesd204_rx_init *init);
 /** Resources Deallocation */
 int32_t axi_jesd204_rx_remove(struct axi_jesd204_rx *jesd);
 #endif

--- a/drivers/axi_core/jesd204/axi_jesd204_rx.h
+++ b/drivers/axi_core/jesd204/axi_jesd204_rx.h
@@ -125,8 +125,8 @@ int32_t axi_jesd204_rx_laneinfo_read(struct axi_jesd204_rx *jesd,
 /** JESD204 RX Watchdog */
 int32_t axi_jesd204_rx_watchdog(struct axi_jesd204_rx *jesd);
 /** Device initialization */
-int32_t axi_jesd204_rx_init(struct axi_jesd204_rx **jesd204,
-			    const struct jesd204_rx_init *init);
+int32_t axi_jesd204_rx_init_legacy(struct axi_jesd204_rx **jesd204,
+				   const struct jesd204_rx_init *init);
 /** Device initialization, JESD FSM ON */
 int32_t axi_jesd204_rx_init_jesd_fsm(struct axi_jesd204_rx **jesd204,
 				     const struct jesd204_rx_init *init);

--- a/drivers/axi_core/jesd204/axi_jesd204_tx.c
+++ b/drivers/axi_core/jesd204/axi_jesd204_tx.c
@@ -822,8 +822,8 @@ err:
  * @param init - The structure containing the device initial parameters.
  * @return Returns 0 in case of success or negative error code otherwise.
  */
-int32_t axi_jesd204_tx_init_jesd_fsm(struct axi_jesd204_tx **jesd204,
-				     const struct jesd204_tx_init *init)
+int32_t axi_jesd204_tx_init(struct axi_jesd204_tx **jesd204,
+			    const struct jesd204_tx_init *init)
 {
 	struct axi_jesd204_tx_jesd204_priv *priv;
 	struct axi_jesd204_tx *jesd;

--- a/drivers/axi_core/jesd204/axi_jesd204_tx.c
+++ b/drivers/axi_core/jesd204/axi_jesd204_tx.c
@@ -732,8 +732,8 @@ static const struct jesd204_dev_data jesd204_axi_jesd204_tx_init = {
  * @param init - The structure containing the device initial parameters.
  * @return Returns 0 in case of success or negative error code otherwise.
  */
-int32_t axi_jesd204_tx_init(struct axi_jesd204_tx **jesd204,
-			    const struct jesd204_tx_init *init)
+int32_t axi_jesd204_tx_init_legacy(struct axi_jesd204_tx **jesd204,
+				   const struct jesd204_tx_init *init)
 {
 	struct axi_jesd204_tx *jesd;
 	uint32_t synth_1;

--- a/drivers/axi_core/jesd204/axi_jesd204_tx.h
+++ b/drivers/axi_core/jesd204/axi_jesd204_tx.h
@@ -144,8 +144,8 @@ uint32_t axi_jesd204_tx_status_read(struct axi_jesd204_tx *jesd);
 int32_t axi_jesd204_tx_init_legacy(struct axi_jesd204_tx **jesd204,
 				   const struct jesd204_tx_init *init);
 /** Device initialization, JED FSM ON */
-int32_t axi_jesd204_tx_init_jesd_fsm(struct axi_jesd204_tx **jesd204,
-				     const struct jesd204_tx_init *init);
+int32_t axi_jesd204_tx_init(struct axi_jesd204_tx **jesd204,
+			    const struct jesd204_tx_init *init);
 /** Resources Deallocation */
 int32_t axi_jesd204_tx_remove(struct axi_jesd204_tx *jesd);
 #endif

--- a/drivers/axi_core/jesd204/axi_jesd204_tx.h
+++ b/drivers/axi_core/jesd204/axi_jesd204_tx.h
@@ -141,8 +141,8 @@ int32_t axi_jesd204_tx_lane_clk_disable(struct axi_jesd204_tx *jesd);
 /** JESD204 TX Status Read */
 uint32_t axi_jesd204_tx_status_read(struct axi_jesd204_tx *jesd);
 /** Device initialization */
-int32_t axi_jesd204_tx_init(struct axi_jesd204_tx **jesd204,
-			    const struct jesd204_tx_init *init);
+int32_t axi_jesd204_tx_init_legacy(struct axi_jesd204_tx **jesd204,
+				   const struct jesd204_tx_init *init);
 /** Device initialization, JED FSM ON */
 int32_t axi_jesd204_tx_init_jesd_fsm(struct axi_jesd204_tx **jesd204,
 				     const struct jesd204_tx_init *init);

--- a/projects/ad6676-ebz/src/ad6676_ebz.c
+++ b/projects/ad6676-ebz/src/ad6676_ebz.c
@@ -390,9 +390,9 @@ int main(void)
 	}
 
 	// setup JESD core
-	ret = axi_jesd204_rx_init(&ad6676_jesd, &ad6676_jesd_param);
+	ret = axi_jesd204_rx_init_legacy(&ad6676_jesd, &ad6676_jesd_param);
 	if (ret != 0) {
-		pr_err("error: %s: axi_jesd204_rx_init() failed\n", ad6676_jesd->name);
+		pr_err("error: %s: axi_jesd204_rx_init_legacy() failed\n", ad6676_jesd->name);
 	}
 
 	ret = axi_jesd204_rx_lane_clk_enable(ad6676_jesd);

--- a/projects/ad9081/src/app_jesd.c
+++ b/projects/ad9081/src/app_jesd.c
@@ -142,13 +142,13 @@ int32_t app_jesd_init(struct no_os_clk clk[2],
 
 	tx_jesd_init.lane_clk = tx_adxcvr->clk_out;
 
-	ret = axi_jesd204_tx_init_jesd_fsm(&tx_jesd, &tx_jesd_init);
+	ret = axi_jesd204_tx_init(&tx_jesd, &tx_jesd_init);
 	if (ret)
 		return ret;
 
 	clk[1].clk_desc = tx_jesd->lane_clk;
 
-	ret = axi_jesd204_rx_init_jesd_fsm(&rx_jesd, &rx_jesd_init);
+	ret = axi_jesd204_rx_init(&rx_jesd, &rx_jesd_init);
 	if (ret)
 		return ret;
 

--- a/projects/ad9083/src/app_jesd.c
+++ b/projects/ad9083/src/app_jesd.c
@@ -97,9 +97,9 @@ int32_t app_jesd_init(struct app_jesd **app, struct app_jesd_init *init_param)
 		.ref_rate_khz = clk_hz[1] / 1000,		/* FPGA_CLK ref */
 	};
 
-	status = axi_jesd204_rx_init(&app_jesd->rx_jesd, &rx_jesd_init);
+	status = axi_jesd204_rx_init_legacy(&app_jesd->rx_jesd, &rx_jesd_init);
 	if (status != 0) {
-		pr_err("error: %s: axi_jesd204_rx_init() failed\n", rx_jesd_init.name);
+		pr_err("error: %s: axi_jesd204_rx_init_legacy() failed\n", rx_jesd_init.name);
 		goto error_0;
 	}
 

--- a/projects/ad9172/src/main.c
+++ b/projects/ad9172/src/main.c
@@ -208,9 +208,9 @@ int main(void)
 		goto error_1;
 	}
 
-	status = axi_jesd204_tx_init(&tx_jesd, &tx_jesd_init);
+	status = axi_jesd204_tx_init_legacy(&tx_jesd, &tx_jesd_init);
 	if (status != 0) {
-		printf("error: %s: axi_jesd204_tx_init() failed\n", tx_jesd_init.name);
+		printf("error: %s: axi_jesd204_tx_init_legacy() failed\n", tx_jesd_init.name);
 		goto error_2;
 	}
 

--- a/projects/ad9208/src/main.c
+++ b/projects/ad9208/src/main.c
@@ -505,9 +505,9 @@ int main(void)
 		goto error_2;
 	}
 
-	status = axi_jesd204_rx_init(&rx_0_jesd, &rx_0_jesd_init);
+	status = axi_jesd204_rx_init_legacy(&rx_0_jesd, &rx_0_jesd_init);
 	if (status != 0) {
-		xil_printf("error: %s: axi_jesd204_rx_init() failed\n",
+		xil_printf("error: %s: axi_jesd204_rx_init_legacy() failed\n",
 			   rx_0_jesd_init.name);
 		goto error_3;
 	}
@@ -547,9 +547,9 @@ int main(void)
 		goto error_7;
 	}
 
-	status = axi_jesd204_rx_init(&rx_1_jesd, &rx_1_jesd_init);
+	status = axi_jesd204_rx_init_legacy(&rx_1_jesd, &rx_1_jesd_init);
 	if (status != 0) {
-		xil_printf("error: %s: axi_jesd204_rx_init() failed\n",
+		xil_printf("error: %s: axi_jesd204_rx_init_legacy() failed\n",
 			   rx_1_jesd_init.name);
 		goto error_8;
 	}

--- a/projects/ad9371/src/app/headless.c
+++ b/projects/ad9371/src/app/headless.c
@@ -437,19 +437,19 @@ int main(void)
 #endif
 
 	/* Initialize JESDs */
-	status = axi_jesd204_rx_init(&rx_jesd, &rx_jesd_init);
+	status = axi_jesd204_rx_init_legacy(&rx_jesd, &rx_jesd_init);
 	if (status != 0) {
-		printf("error: %s: axi_jesd204_rx_init() failed\n", rx_jesd_init.name);
+		printf("error: %s: axi_jesd204_rx_init_legacy() failed\n", rx_jesd_init.name);
 		goto error_4;
 	}
-	status = axi_jesd204_tx_init(&tx_jesd, &tx_jesd_init);
+	status = axi_jesd204_tx_init_legacy(&tx_jesd, &tx_jesd_init);
 	if (status != 0) {
-		printf("error: %s: axi_jesd204_tx_init() failed\n", tx_jesd_init.name);
+		printf("error: %s: axi_jesd204_tx_init_legacy() failed\n", tx_jesd_init.name);
 		goto error_5;
 	}
-	status = axi_jesd204_rx_init(&rx_os_jesd, &rx_os_jesd_init);
+	status = axi_jesd204_rx_init_legacy(&rx_os_jesd, &rx_os_jesd_init);
 	if (status != 0) {
-		printf("error: %s: axi_jesd204_rx_init() failed\n", rx_jesd_init.name);
+		printf("error: %s: axi_jesd204_rx_init_legacy() failed\n", rx_jesd_init.name);
 		goto error_6;
 	}
 

--- a/projects/ad9656_fmc/src/app/ad9656_fmc.c
+++ b/projects/ad9656_fmc/src/app/ad9656_fmc.c
@@ -214,8 +214,8 @@ int main(void)
 		printf("error: %s: adxcvr_clk_enable() failed\n", ad9656_xcvr->name);
 	}
 
-	if (axi_jesd204_rx_init(&ad9656_jesd, &ad9656_jesd_param) != 0) {
-		printf("error: %s: axi_jesd204_rx_init() failed\n", ad9656_jesd->name);
+	if (axi_jesd204_rx_init_legacy(&ad9656_jesd, &ad9656_jesd_param) != 0) {
+		printf("error: %s: axi_jesd204_rx_init_legacy() failed\n", ad9656_jesd->name);
 	}
 
 	if (axi_jesd204_rx_lane_clk_enable(ad9656_jesd) != 0) {

--- a/projects/adrv9009/src/app/app_jesd.c
+++ b/projects/adrv9009/src/app/app_jesd.c
@@ -105,21 +105,22 @@ adiHalErr_t jesd_init(uint32_t rx_div40_rate_hz,
 
 	/* Initialize JESD */
 #ifndef ADRV9008_2
-	status = axi_jesd204_rx_init(&rx_jesd, &rx_jesd_init);
+	status = axi_jesd204_rx_init_legacy(&rx_jesd, &rx_jesd_init);
 	if (status != 0) {
-		printf("error: %s: axi_jesd204_rx_init() failed\n", rx_jesd_init.name);
+		printf("error: %s: axi_jesd204_rx_init_legacy() failed\n", rx_jesd_init.name);
 		goto error_5;
 	}
 #endif
 #ifndef ADRV9008_1
-	status = axi_jesd204_tx_init(&tx_jesd, &tx_jesd_init);
+	status = axi_jesd204_tx_init_legacy(&tx_jesd, &tx_jesd_init);
 	if (status != 0) {
-		printf("error: %s: axi_jesd204_tx_init() failed\n", tx_jesd_init.name);
+		printf("error: %s: axi_jesd204_tx_init_legacy() failed\n", tx_jesd_init.name);
 		goto error_6;
 	}
-	status = axi_jesd204_rx_init(&rx_os_jesd, &rx_os_jesd_init);
+	status = axi_jesd204_rx_init_legacy(&rx_os_jesd, &rx_os_jesd_init);
 	if (status != 0) {
-		printf("error: %s: axi_jesd204_rx_init() failed\n", rx_os_jesd_init.name);
+		printf("error: %s: axi_jesd204_rx_init_legacy() failed\n",
+		       rx_os_jesd_init.name);
 		goto error_7;
 	}
 

--- a/projects/fmcadc2/src/fmcadc2.c
+++ b/projects/fmcadc2/src/fmcadc2.c
@@ -180,9 +180,9 @@ int main(void)
 	}
 
 	// setup JESD core
-	status = axi_jesd204_rx_init(&ad9625_jesd, &ad9625_jesd_param);
+	status = axi_jesd204_rx_init_legacy(&ad9625_jesd, &ad9625_jesd_param);
 	if (status != 0) {
-		printf("error: %s: axi_jesd204_rx_init() failed\n", ad9625_jesd->name);
+		printf("error: %s: axi_jesd204_rx_init_legacy() failed\n", ad9625_jesd->name);
 	}
 	status = axi_jesd204_rx_lane_clk_enable(ad9625_jesd);
 	if (status != 0) {

--- a/projects/fmcadc5/src/fmcadc5.c
+++ b/projects/fmcadc5/src/fmcadc5.c
@@ -278,9 +278,9 @@ int main(void)
 	struct s_i5g *i5g_core;
 
 	// setup JESD core
-	status = axi_jesd204_rx_init(&ad9625_0_jesd, &ad9625_0_jesd_param);
+	status = axi_jesd204_rx_init_legacy(&ad9625_0_jesd, &ad9625_0_jesd_param);
 	if (status != 0) {
-		printf("error: %s: axi_jesd204_rx_init() failed\n", ad9625_0_jesd->name);
+		printf("error: %s: axi_jesd204_rx_init_legacy() failed\n", ad9625_0_jesd->name);
 	}
 	status = axi_jesd204_rx_lane_clk_enable(ad9625_0_jesd);
 	if (status != 0) {
@@ -288,9 +288,9 @@ int main(void)
 		       ad9625_0_jesd->name);
 	}
 
-	status = axi_jesd204_rx_init(&ad9625_1_jesd, &ad9625_1_jesd_param);
+	status = axi_jesd204_rx_init_legacy(&ad9625_1_jesd, &ad9625_1_jesd_param);
 	if (status != 0) {
-		printf("error: %s: axi_jesd204_rx_init() failed\n", ad9625_1_jesd->name);
+		printf("error: %s: axi_jesd204_rx_init_legacy() failed\n", ad9625_1_jesd->name);
 	}
 	status = axi_jesd204_rx_lane_clk_enable(ad9625_1_jesd);
 	if (status != 0) {

--- a/projects/fmcdaq2/src/app/app_config.h
+++ b/projects/fmcdaq2/src/app/app_config.h
@@ -48,6 +48,4 @@
 //#define DMA_EXAMPLE
 //#define IIO_SUPPORT
 
-//#define JESD_FSM_ON
-
 #endif /* APP_CONFIG_H_ */

--- a/projects/fmcdaq2/src/app/fmcdaq2.c
+++ b/projects/fmcdaq2/src/app/fmcdaq2.c
@@ -551,10 +551,10 @@ static int fmcdaq2_trasnceiver_setup(struct fmcdaq2_dev *dev,
 
 	dev_init->ad9144_jesd_param.lane_clk = dev->ad9144_xcvr->clk_out;
 
-	status = axi_jesd204_tx_init_jesd_fsm(&dev->ad9144_jesd,
-					      &dev_init->ad9144_jesd_param);
+	status = axi_jesd204_tx_init(&dev->ad9144_jesd,
+				     &dev_init->ad9144_jesd_param);
 	if (status) {
-		printf("error: %s: axi_jesd204_tx_init_jesd_fsm() failed\n",
+		printf("error: %s: axi_jesd204_tx_init() failed\n",
 		       dev_init->ad9144_jesd_param.name);
 		return status;
 	}
@@ -577,10 +577,10 @@ static int fmcdaq2_trasnceiver_setup(struct fmcdaq2_dev *dev,
 
 	dev_init->ad9680_jesd_param.lane_clk = dev->ad9680_xcvr->clk_out;
 
-	status = axi_jesd204_rx_init_jesd_fsm(&dev->ad9680_jesd,
-					      &dev_init->ad9680_jesd_param);
+	status = axi_jesd204_rx_init(&dev->ad9680_jesd,
+				     &dev_init->ad9680_jesd_param);
 	if (status) {
-		printf("error: %s: axi_jesd204_rx_init_jesd_fsm() failed\n",
+		printf("error: %s: axi_jesd204_rx_init() failed\n",
 		       dev_init->ad9680_jesd_param.name);
 		return status;
 	}

--- a/projects/fmcdaq3/src/app/fmcdaq3.c
+++ b/projects/fmcdaq3/src/app/fmcdaq3.c
@@ -512,9 +512,9 @@ int main(void)
 	if (status != 0) {
 		printf("error: ad9680_setup() failed\n");
 	}
-	status = axi_jesd204_tx_init(&ad9152_jesd, &ad9152_jesd_param);
+	status = axi_jesd204_tx_init_legacy(&ad9152_jesd, &ad9152_jesd_param);
 	if (status != 0) {
-		printf("error: %s: axi_jesd204_rx_init() failed\n", ad9152_jesd->name);
+		printf("error: %s: axi_jesd204_rx_init_legacy() failed\n", ad9152_jesd->name);
 	}
 	status = axi_jesd204_tx_lane_clk_enable(ad9152_jesd);
 	if (status != 0) {
@@ -541,9 +541,9 @@ int main(void)
 		printf("error: %s: adxcvr_clk_enable() failed\n", ad9680_xcvr->name);
 	}
 #endif
-	status = axi_jesd204_rx_init(&ad9680_jesd, &ad9680_jesd_param);
+	status = axi_jesd204_rx_init_legacy(&ad9680_jesd, &ad9680_jesd_param);
 	if (status != 0) {
-		printf("error: %s: axi_jesd204_rx_init() failed\n", ad9680_jesd->name);
+		printf("error: %s: axi_jesd204_rx_init_legacy() failed\n", ad9680_jesd->name);
 	}
 	status = axi_jesd204_rx_lane_clk_enable(ad9680_jesd);
 	if (status != 0) {

--- a/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
+++ b/projects/fmcjesdadc1/src/app/fmcjesdadc1.c
@@ -487,9 +487,9 @@ int main(void)
 	}
 
 	// setup JESD core
-	status = axi_jesd204_rx_init(&ad9250_jesd, &ad9250_jesd_param);
+	status = axi_jesd204_rx_init_legacy(&ad9250_jesd, &ad9250_jesd_param);
 	if (status != 0) {
-		printf("error: %s: axi_jesd204_rx_init() failed\n", ad9250_jesd->name);
+		printf("error: %s: axi_jesd204_rx_init_legacy() failed\n", ad9250_jesd->name);
 	}
 	status = axi_jesd204_rx_lane_clk_enable(ad9250_jesd);
 	if (status != 0) {


### PR DESCRIPTION
## Pull Request Description

Remove the option to not use JESD FSM for the fmcdaq2 project and rename the jesd init functions (add legacy suffix for non-FSM functions).

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
