### PR TITLE
drivers: accel: adxl367: update self test delay

### DIFF
--- a/drivers/accel/adxl367/adxl367.c
+++ b/drivers/accel/adxl367/adxl367.c
@@ -43,6 +43,7 @@
 #include <stdlib.h>
 #include "adxl367.h"
 #include "no_os_delay.h"
+#include "no_os_error.h"
 #include "no_os_util.h"
 #include "no_os_alloc.h"
 #include "no_os_print_log.h"
@@ -166,6 +167,25 @@ int adxl367_self_test(struct adxl367_dev *dev)
 	int ret;
 	int16_t x_axis_1, x_axis_2, dif, min, max;
 	uint8_t read_val;
+	uint32_t st_delay_ms;
+
+	// 4 / ODR value in ms
+	switch (dev->odr) {
+	case ADXL367_ODR_12P5HZ:
+		st_delay_ms = 320;
+	case ADXL367_ODR_25HZ:
+		st_delay_ms = 160;
+	case ADXL367_ODR_50HZ:
+		st_delay_ms = 80;
+	case ADXL367_ODR_100HZ:
+		st_delay_ms = 40;
+	case ADXL367_ODR_200HZ:
+		st_delay_ms = 20;
+	case ADXL367_ODR_400HZ:
+		st_delay_ms = 10;
+	default:
+		return -EINVAL;
+	}
 
 	ret = adxl367_set_power_mode(dev, ADXL367_OP_MEASURE);
 	if (ret)
@@ -175,8 +195,8 @@ int adxl367_self_test(struct adxl367_dev *dev)
 				    ADXL367_SELF_TEST_ST);
 	if (ret)
 		return ret;
-	// 4 / lowest ODR = 80ms
-	no_os_mdelay(80);
+	// 4 / ODR delay
+	no_os_mdelay(st_delay_ms);
 	ret = adxl367_get_register_value(dev, &read_val, ADXL367_REG_XDATA_H, 1);
 	if (ret)
 		return ret;
@@ -193,8 +213,8 @@ int adxl367_self_test(struct adxl367_dev *dev)
 				    ADXL367_SELF_TEST_ST_FORCE, ADXL367_SELF_TEST_ST_FORCE);
 	if (ret)
 		return ret;
-	// 4 / lowest ODR = 80ms
-	no_os_mdelay(80);
+	// 4 / ODR delay
+	no_os_mdelay(st_delay_ms);
 	ret = adxl367_get_register_value(dev, &read_val, ADXL367_REG_XDATA_H, 1);
 	if (ret)
 		return ret;


### PR DESCRIPTION
## Pull Request Description

The wait times in the self test procedure, according to the datasheet are 4 / ODR (current set value). Moreover, the current value set as default delay (80ms) does not correspond to the lowest ODR value, as stated in the code comments.

Update the self test procedure by using the delay corresponding to the current ODR value that is set.

Fixes: 2e4f0c3 ("drivers:accel: Create ADXL367 Driver")

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
