### PR TITLE
ad2s1210: Use mask to select conversion data

### DIFF
--- a/drivers/resolver/ad2s1210/ad2s1210.h
+++ b/drivers/resolver/ad2s1210/ad2s1210.h
@@ -74,6 +74,9 @@
 #define AD2S1210_MIN_FCW	0x4
 #define AD2S1210_MAX_FCW	0x50
 
+#define AD2S1210_POS_MASK	NO_OS_BIT(0)
+#define AD2S1210_VEL_MASK	NO_OS_BIT(1)
+
 enum ad2s1210_mode {
 	MODE_POS,
 	MODE_RESERVED,
@@ -127,7 +130,8 @@ int ad2s1210_reg_write(struct ad2s1210_dev *dev, uint8_t addr,
 int ad2s1210_reg_read(struct ad2s1210_dev *dev, uint8_t addr,
 		      uint8_t *val);
 int ad2s1210_spi_single_conversion(struct ad2s1210_dev *dev,
-				   enum ad2s1210_channel chn, uint16_t *data);
+				   uint32_t active_mask,
+				   void *data, uint32_t size);
 int ad2s1210_hysteresis_is_enabled(struct ad2s1210_dev *dev);
 int ad2s1210_set_hysteresis(struct ad2s1210_dev *dev, bool enable);
 int ad2s1210_reinit_excitation_frequency(struct ad2s1210_dev *dev,


### PR DESCRIPTION
## ad2s1210: Use mask to select conversion data
    
Currently "single_conversion" returns either a position
or a velocity of a sample, but not both at the same
time.

Pass a bitmask of active channels as parameter so that
the user can either request position, velocity or both.

This will allow to graph position and velocity
of the same sample.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [X] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [X] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [X] I have performed a self-review of the changes
- [X] I have commented my code, at least hard-to-understand parts
- [X] I have build all projects affected by the changes in this PR
- [X] I have tested in hardware affected projects, at the relevant boards
- [X] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
