### PR TITLE
drivers: digital-io: max22196 : Add driver support for MAX22196

### DIFF
--- a/drivers/digital-io/max22196/README.rst
+++ b/drivers/digital-io/max22196/README.rst
@@ -1,0 +1,189 @@
+MAX22196 no-OS driver
+=====================
+
+Supported Devices
+-----------------
+
+`MAX22196 <https://www.analog.com/MAX22196>`
+
+Overview
+--------
+
+The MAX22196 is an industrial octal digital input that translates eight
+industrial 24V or TTL level inputs to logic level outputs. 
+The device has a serial interface allowing configuration and reading of 
+serialized data through SPI.
+
+The input channels are individually configurable as sinking (p-type) or 
+sourcing (n-type) inputs. Current limiters on each digital input minimize 
+power dissipation while ensuring compliance with the IEC 61131-2 standard. 
+With a single current-setting resistor, the inputs are individually 
+configurable for Type 1/3, Type 2, TTL or HTL (high-impedance 24V levels). 
+The current sinks or sources can be individually disabled.
+
+Applications
+------------
+* Programmable Logic Controllers
+* Factory Automation
+* Process Control
+
+MAX22196 Device Configuration
+-----------------------------
+
+In order to be able to use the device, you will have to provide the support
+for the communication protocol (SPI).
+
+The first API to be called is **max22196_init**. Make sure that it returns 0,
+which means that the driver was initialized correctly.
+
+Channel configuration
+---------------------
+
+Each channel can be configured in source mode or sink mode with the 
+**max22196_set_mode** API.
+More than that each channel's voltage threshold state and sink/source current
+can be set with **max22196_chan_cfg** API, as well as the channel counter
+that can be changed for both MSB and LSB Byte's with the help of
+**max22196_set_chan_cnt**, or read with **max22196_get_chan_cnt**.
+
+Filter configuration
+--------------------
+
+Each channel also has a filter that can be enabled/disabled, but also have
+a delay attached to it. The filter data can be set with the help of
+**max22196_filter_set**, and read with **max22196_filter_get** API.
+
+Global configuration
+--------------------
+
+In case of wanting to configure the global_cfg register, it can be done
+using the **max22196_global_cfg** API.
+
+Fault mask configuration
+------------------------
+
+Any fault mask can be separately configured with **max22196_fault_mask_set**
+API, and also read with **max22196_fault_mask_get** API.
+
+
+MAX22196 Driver Initialization Example
+--------------------------------------
+
+.. code-block:: bash
+
+	struct max22196_desc *max22196;
+	struct no_os_spi_init_param spi_ip = {
+		.device_id = 0,
+		.extra = &max22196_spi_extra,
+		.max_speed_hz = 100000,
+		.platform_ops = &max_spi_ops,
+		.chip_select = 0,
+	};
+	struct max22196_init_param max22196_ip = {
+		.chip_address = 0,
+		.comm_desc = &spi_ip,
+	};
+
+	ret = max22196_init(&max22196, &max22196_ip);
+	if (ret)
+		goto error;
+
+MAX22196 no-OS IIO support
+--------------------------
+
+The MAX22196 IIO driver comes on top of the MAX22196 driver and offers support
+for interfacing IIO clients through IIO lib.
+
+MAX22196 IIO Device Configuration
+---------------------------------
+
+Channel Attributes
+------------------
+
+MAX22196 has a total of 10 channel attributes :
+
+* raw - the state of the cannel.
+* offset - always 0.
+* scale - always 1.
+* filter_enable - 0 or 1 (depending on the state of the filter).
+* filter_delay - The filter's delay value if it is enabled (otherwise it is 50us).
+* filter_delay_available - List of delay available values.
+* di_mode - Digital Input mode, is the mode in which each channel is configured.
+* di_mode_available - List of digital input modes (Sink/Source).
+* current_source - Current source to be selected for each channel.
+* current_source_available - Current sources available for selection.
+
+Global Attributes
+-----------------
+
+MAX22196 has 7 global attributes that can be configured as enabled/disabled :
+
+* refdi_sht_cfg - REFDI pin short detection.
+* clrf_filtr - Fix all input glitch filters to mid-scale value.
+* fspi_clr - Configures how the bits in the FAULT1 register are cleared.
+* led9 - LED9 control.
+* led_int - LED matrix user control of autonomous control selection.
+* gpo - Configure LO1 - LO6 outputs to be LED matrix or GPO drivers.
+
+Debug Attributes
+----------------
+
+MAX22196 has 12 debug attributes :
+
+* fault1 - fault1 register value.
+* fault2 - fault2 register value.
+* vmlow_mask - Vm low voltage mask in the FAULT1EN register.
+* v24uv_mask - V24 undervoltage mask in the FAULT1EN register.
+* temp_alarm_mask - Temperature alarm mask in the FAULT1EN register.
+* otshdn1_mask - Thermal shutdown mask in the FAULT1EN register.
+* fault2_mask - Mask corresponding to FAULT2 bit in the FAULT1EN register.
+* rfdis_mask - Mask for short-circuit error on the REFDI pin in the FAULT2EN register.
+* rfdio_mask - Mask for open-circuit error on the REFDI pin in the FAULT2EN register.
+* otshdn2_mask - System thermal shutdown mask in the FAULT2EN register.
+* spi8clk_mask - Mask for number of SCLK cycles error in the FAULT2EN register.
+* vauv_mask - VA undervoltage mask in the FAULT2EN register.
+
+Device Channels
+---------------
+
+MAX22196 has a specific API, **max22196_iio_setup_channels** for configuring the
+channels at the initialization, therefore the channels can be configured as  
+enabled/disabled and attributes are assigned to each channel (if enabled).
+
+MAX22196 IIO Driver Initialization Example
+------------------------------------------
+
+.. code-block:: bash
+
+	struct max22196_iio_desc *max22196_iio_desc;
+	struct max22196_iio_desc_init_param max22196_iio_ip = {
+		.max22196_init_param = &max22196_ip,
+		.chans_enabled = {
+			true, true, true, false, false, false, false, false
+		},
+	};
+
+	struct iio_app_desc *app;
+	struct iio_app_init_param app_init_param = { 0 };
+
+	ret = max22196_iio_init(&max22196_iio_desc, &max22196_iio_ip);
+	if (ret)
+		goto error;
+
+	struct iio_app_device iio_devices[] = {
+		{
+			.name = "max22196",
+			.dev = max22196_iio_desc,
+			.dev_descriptor = max22196_iio_desc->iio_dev,
+		},
+	};
+
+	app_init_param.devices = iio_devices;
+	app_init_param.nb_devices = NO_OS_ARRAY_SIZE(iio_devices);
+	app_init_param.uart_init_params = max22196_uart_ip;
+
+	ret = iio_app_init(&app, app_init_param);
+	if (ret)
+		goto app_error;
+
+	return iio_app_run(app);

--- a/drivers/digital-io/max22196/iio_max22196.c
+++ b/drivers/digital-io/max22196/iio_max22196.c
@@ -1,0 +1,860 @@
+/***************************************************************************//**
+ *   @file   iio_max22196.c
+ *   @brief  Source file of IIO MAX22196 Driver.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include "no_os_error.h"
+#include "no_os_units.h"
+#include "no_os_util.h"
+
+#include "max22196.h"
+#include "iio_max22196.h"
+
+static int max22196_iio_read_raw(void *dev, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel,
+				 intptr_t priv);
+
+static int max22196_iio_read_scale(void *dev, char *buf, uint32_t len,
+				   const struct iio_ch_info *channel,
+				   intptr_t priv);
+
+static int max22196_iio_read_filter(void *dev, char *buf, uint32_t len,
+				    const struct iio_ch_info *channel,
+				    intptr_t priv);
+
+static int max22196_iio_write_filter(void *dev, char *buf, uint32_t len,
+				     const struct iio_ch_info *channel,
+				     intptr_t priv);
+
+static int max22196_iio_read_filter_delay(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv);
+
+static int max22196_iio_write_filter_delay(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv);
+
+static int max22196_iio_read_filter_available(void *dev, char *buf,
+		uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv);
+
+static int max22196_iio_read_di_mode(void *dev, char *buf, uint32_t len,
+				     const struct iio_ch_info *channel,
+				     intptr_t priv);
+
+static int max22196_iio_write_di_mode(void *dev, char *buf, uint32_t len,
+				      const struct iio_ch_info *channel,
+				      intptr_t priv);
+
+static int max22196_iio_read_di_mode_available(void *dev, char *buf,
+		uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv);
+
+static int max22196_iio_read_current(void *dev, char *buf, uint32_t len,
+				     const struct iio_ch_info *channel,
+				     intptr_t priv);
+
+static int max22196_iio_write_current(void *dev, char *buf, uint32_t len,
+				      const struct iio_ch_info *channel,
+				      intptr_t priv);
+
+static int max22196_iio_read_current_available(void *dev, char *buf,
+		uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv);
+
+static int max22196_iio_read_fault(void *dev, char *buf, uint32_t len,
+				   const struct iio_ch_info *channel,
+				   intptr_t priv);
+
+static int max22196_iio_read_fault_mask(void *dev, char *buf, uint32_t len,
+					const struct iio_ch_info *channel,
+					intptr_t priv);
+
+static int max22196_iio_write_fault_mask(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv);
+
+static int max22196_iio_write_global_cfg(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv);
+
+static int max22196_iio_reg_read(struct max22196_iio_desc *dev, uint32_t reg,
+				 uint32_t *readval);
+
+static int max22196_iio_reg_write(struct max22196_iio_desc *dev, uint32_t reg,
+				  uint32_t writeval);
+
+static const uint32_t max22196_delay_avail[8] = {
+	50, 100, 400, 800, 1800, 3200, 12800, 20000
+};
+
+static const char *const max22196_di_mode_avail[2] = {
+	[MAX22196_SOURCE_MODE] = "Source_Mode",
+	[MAX22196_SINK_MODE] = "Sink_Mode",
+};
+
+static const char *const max22196_current_avail[4] = {
+	[MAX22196_HTL_MODE] = "HTL_Mode",
+	[MAX22196_1X_CURRENT] = "1x_Current",
+	[MAX22196_3X_CURRENT] = "3x_Current",
+	[MAX22196_TTL_OP_OFF] = "TTL_Operation_OFF",
+};
+
+static struct iio_attribute max22196_attrs[] = {
+	{
+		.name = "raw",
+		.show = max22196_iio_read_raw,
+	},
+	{
+		.name = "scale",
+		.show = max22196_iio_read_scale,
+	},
+	{
+		.name = "filter_enable",
+		.show = max22196_iio_read_filter,
+		.store = max22196_iio_write_filter,
+	},
+	{
+		.name = "filter_delay",
+		.show = max22196_iio_read_filter_delay,
+		.store = max22196_iio_write_filter_delay,
+	},
+	{
+		.name = "filter_delay_available",
+		.show = max22196_iio_read_filter_available,
+		.shared = IIO_SHARED_BY_ALL,
+	},
+	{
+		.name = "di_mode",
+		.show = max22196_iio_read_di_mode,
+		.store = max22196_iio_write_di_mode,
+	},
+	{
+		.name = "di_mode_available",
+		.show = max22196_iio_read_di_mode_available,
+		.shared = IIO_SHARED_BY_ALL,
+	},
+	{
+		.name = "current_source",
+		.show = max22196_iio_read_current,
+		.store = max22196_iio_write_current,
+	},
+	{
+		.name = "current_source_available",
+		.show = max22196_iio_read_current_available,
+		.shared = IIO_SHARED_BY_ALL,
+	},
+	{
+		.name = "refdi_sht_cfg",
+		.store = max22196_iio_write_global_cfg,
+		.priv = MAX22196_GLOBAL_REFDISHTCFG
+	},
+	{
+		.name = "clrf_filtr",
+		.store = max22196_iio_write_global_cfg,
+		.priv = MAX22196_GLOBAL_CLRFILTR
+	},
+	{
+		.name = "fspi_clr",
+		.store = max22196_iio_write_global_cfg,
+		.priv = MAX22196_GLOBAL_FSPICLR
+	},
+	{
+		.name = "led9",
+		.store = max22196_iio_write_global_cfg,
+		.priv = MAX22196_GLOBAL_LED9
+	},
+	{
+		.name = "led_int",
+		.store = max22196_iio_write_global_cfg,
+		.priv = MAX22196_GLOBAL_LEDINT
+	},
+	{
+		.name = "gpo",
+		.store = max22196_iio_write_global_cfg,
+		.priv = MAX22196_GLOBAL_GPO
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_attribute max22196_debug_attrs[] = {
+	{
+		.name = "fault1",
+		.show = max22196_iio_read_fault,
+		.priv = MAX22196_IIO_FAULT1
+	},
+	{
+		.name = "fault2",
+		.show = max22196_iio_read_fault,
+		.priv = MAX22196_IIO_FAULT2
+	},
+	{
+		.name = "vmlow_mask",
+		.show = max22196_iio_read_fault_mask,
+		.store = max22196_iio_write_fault_mask,
+		.priv = MAX22196_FAULT1_VMLOW
+	},
+	{
+		.name = "v24uv_mask",
+		.show = max22196_iio_read_fault_mask,
+		.store = max22196_iio_write_fault_mask,
+		.priv = MAX22196_FAULT1_V24UV
+	},
+	{
+		.name = "temp_alarm_mask",
+		.show = max22196_iio_read_fault_mask,
+		.store = max22196_iio_write_fault_mask,
+		.priv = MAX22196_FAULT1_TEMPALM
+	},
+	{
+		.name = "otshdn1_mask",
+		.show = max22196_iio_read_fault_mask,
+		.store = max22196_iio_write_fault_mask,
+		.priv = MAX22196_FAULT1_OTSHDN1
+	},
+	{
+		.name = "fault2_mask",
+		.show = max22196_iio_read_fault_mask,
+		.store = max22196_iio_write_fault_mask,
+		.priv = MAX22196_FAULT1_FAULT2
+	},
+	{
+		.name = "rfdis_mask",
+		.show = max22196_iio_read_fault_mask,
+		.store = max22196_iio_write_fault_mask,
+		.priv = MAX22196_FAULT2_RFDIS
+	},
+	{
+		.name = "rfdio_mask",
+		.show = max22196_iio_read_fault_mask,
+		.store = max22196_iio_write_fault_mask,
+		.priv = MAX22196_FAULT2_RFDIO
+	},
+	{
+		.name = "otshdn2_mask",
+		.show = max22196_iio_read_fault_mask,
+		.store = max22196_iio_write_fault_mask,
+		.priv = MAX22196_FAULT2_OTSHDN2
+	},
+	{
+		.name = "spi8clk_mask",
+		.show = max22196_iio_read_fault_mask,
+		.store = max22196_iio_write_fault_mask,
+		.priv = MAX22196_FAULT2_SPI8CLK
+	},
+	{
+		.name = "vauv_mask",
+		.show = max22196_iio_read_fault_mask,
+		.store = max22196_iio_write_fault_mask,
+		.priv = MAX22196_FAULT2_VAUV
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+#define MAX22196_CHANNEL(_addr)			\
+	{					\
+		.ch_type = IIO_VOLTAGE,		\
+		.indexed = 1,			\
+		.channel = _addr,		\
+		.address = _addr,		\
+		.ch_out = false,		\
+		.attributes = max22196_attrs	\
+	}
+
+static struct iio_channel max22196_channels[] = {
+	MAX22196_CHANNEL(0),
+	MAX22196_CHANNEL(1),
+	MAX22196_CHANNEL(2),
+	MAX22196_CHANNEL(3),
+	MAX22196_CHANNEL(4),
+	MAX22196_CHANNEL(5),
+	MAX22196_CHANNEL(6),
+	MAX22196_CHANNEL(7)
+};
+
+static struct iio_device max22196_iio_dev = {
+	.num_ch = NO_OS_ARRAY_SIZE(max22196_channels),
+	.channels = max22196_channels,
+	.debug_reg_read = (int32_t (*)())max22196_iio_reg_read,
+	.debug_reg_write = (int32_t (*)())max22196_iio_reg_write,
+	.debug_attributes = max22196_debug_attrs
+};
+
+/**
+ * @brief Read the raw attribute for a specific channel
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max22196_iio_read_raw(void *dev, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel,
+				 intptr_t priv)
+{
+	struct max22196_iio_desc *desc = dev;
+	uint32_t val;
+	int ret, ch;
+
+	ch = channel->address;
+
+	ret = max22196_reg_read(desc->max22196_desc, MAX22196_DI_STATE_REG,
+				&val);
+	if (ret)
+		return ret;
+
+	val = no_os_field_get(MAX22196_DI_STATE_MASK(ch), val);
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, (int32_t *)&val);
+}
+
+/**
+ * @brief Read the scale attribute for a specific channel
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max22196_iio_read_scale(void *dev, char *buf, uint32_t len,
+				   const struct iio_ch_info *channel,
+				   intptr_t priv)
+{
+	int32_t val = 1;
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+}
+
+/**
+ * @brief Read the filter attribute for a specific channel
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max22196_iio_read_filter(void *dev, char *buf, uint32_t len,
+				    const struct iio_ch_info *channel,
+				    intptr_t priv)
+{
+	struct max22196_iio_desc *desc = dev;
+	uint32_t val;
+	int ret, ch;
+
+	ch = channel->address;
+
+	ret = max22196_reg_read(desc->max22196_desc, MAX22196_CFG_REG(ch),
+				&val);
+	if (ret)
+		return ret;
+
+	val = no_os_field_get(MAX22196_FLTEN_MASK, val);
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, (int32_t *)&val);
+}
+
+/**
+ * @brief Write the filter attribute for a specific channel
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max22196_iio_write_filter(void *dev, char *buf, uint32_t len,
+				     const struct iio_ch_info *channel,
+				     intptr_t priv)
+{
+	struct max22196_iio_desc *desc = dev;
+	int ch;
+	uint32_t val;
+
+	ch = channel->address;
+
+	iio_parse_value(buf, IIO_VAL_INT, (int32_t *)&val, NULL);
+
+	if (val > 1)
+		return -EINVAL;
+
+	return max22196_reg_update(desc->max22196_desc,
+				   MAX22196_CFG_REG(ch),
+				   MAX22196_FLTEN_MASK,
+				   no_os_field_prep(MAX22196_FLTEN_MASK, val));
+}
+
+/**
+ * @brief Read the filter delay attribute for a specific channel
+ * @param dev - The iio device structure
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor.
+ * @return 0 in case of succes, error code otherwise.
+*/
+static int max22196_iio_read_filter_delay(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	struct max22196_iio_desc *desc = dev;
+	int ret, ch;
+	uint32_t val;
+
+	ch = channel->address;
+
+	ret = max22196_reg_read(desc->max22196_desc, MAX22196_CFG_REG(ch),
+				&val);
+	if (ret)
+		return ret;
+
+	val = max22196_delay_avail[no_os_field_get(MAX22196_DELAY_MASK, val)];
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, (int32_t *)&val);
+}
+
+/**
+ * @brief Write the filter delay attribute for a specific channel
+ * @param dev - The iio device structure
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor.
+ * @return 0 in case of succes, error code otherwise.
+*/
+static int max22196_iio_write_filter_delay(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	struct max22196_iio_desc *desc = dev;
+	int ch;
+	uint32_t val, i;
+
+	ch = channel->address;
+
+	iio_parse_value(buf, IIO_VAL_INT, (int32_t *)&val, NULL);
+
+	for (i = 0; i < NO_OS_ARRAY_SIZE(max22196_delay_avail); i++)
+		if (val == max22196_delay_avail[i])
+			break;
+
+	if (i == NO_OS_ARRAY_SIZE(max22196_delay_avail))
+		return -EINVAL;
+
+	return max22196_reg_update(desc->max22196_desc,
+				   MAX22196_CFG_REG(ch),
+				   MAX22196_DELAY_MASK,
+				   no_os_field_prep(MAX22196_DELAY_MASK, i));
+}
+
+/**
+ * @brief Read the available values for filter delay attribute for a specific
+ * 	  channel
+ * @param dev - The iio device structure
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor.
+ * @return 0 in case of succes, error code otherwise.
+*/
+static int max22196_iio_read_filter_available(void *dev, char *buf,
+		uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	uint32_t avail_size = NO_OS_ARRAY_SIZE(max22196_delay_avail);
+	uint32_t length = 0;
+	uint32_t i;
+
+	for (i = 0; i < avail_size; i++)
+		length += sprintf(buf + length, "%d ", max22196_delay_avail[i]);
+
+	return length;
+}
+
+/**
+ * @brief Read the di mode attribute for a specific channel
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max22196_iio_read_di_mode(void *dev, char *buf, uint32_t len,
+				     const struct iio_ch_info *channel,
+				     intptr_t priv)
+{
+	struct max22196_iio_desc *desc = dev;
+	uint32_t val;
+	int ret, ch;
+
+	ch = channel->address;
+
+	ret = max22196_reg_read(desc->max22196_desc, MAX22196_CFG_REG(ch),
+				&val);
+	if (ret)
+		return ret;
+
+	val = no_os_field_get(MAX22196_SOURCE_MASK, val);
+
+	return sprintf(buf, "%s ", max22196_di_mode_avail[val]);
+}
+
+/**
+ * @brief Write the di mode attribute for a specific channel
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max22196_iio_write_di_mode(void *dev, char *buf, uint32_t len,
+				      const struct iio_ch_info *channel,
+				      intptr_t priv)
+{
+	struct max22196_iio_desc *desc = dev;
+	uint32_t i;
+	int ch;
+
+	ch = channel->address;
+
+	for (i = 0; i < NO_OS_ARRAY_SIZE(max22196_di_mode_avail); i++)
+		if (!strcmp(buf, max22196_di_mode_avail[i]))
+			break;
+
+	if (i == NO_OS_ARRAY_SIZE(max22196_di_mode_avail))
+		return -EINVAL;
+
+	return max22196_reg_update(desc->max22196_desc, MAX22196_CFG_REG(ch),
+				   MAX22196_SOURCE_MASK,
+				   no_os_field_prep(MAX22196_SOURCE_MASK, i));
+}
+
+/**
+ * @brief Read the di mode available attribute for a specific channel
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max22196_iio_read_di_mode_available(void *dev, char *buf,
+		uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	uint32_t avail_size = NO_OS_ARRAY_SIZE(max22196_di_mode_avail);
+	uint32_t length = 0;
+	uint32_t i;
+
+	for(i = 0; i < avail_size; i++)
+		length += sprintf(buf + length, "%s ", max22196_di_mode_avail[i]);
+
+	return length;
+}
+
+/**
+ * @brief Read the current attribute for a specific channel
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max22196_iio_read_current(void *dev, char *buf, uint32_t len,
+				     const struct iio_ch_info *channel,
+				     intptr_t priv)
+{
+	struct max22196_iio_desc *iio_desc = dev;
+	uint32_t val;
+	int ret, ch;
+
+	ch = channel->address;
+
+	ret = max22196_reg_read(iio_desc->max22196_desc, MAX22196_CFG_REG(ch),
+				&val);
+	if (ret)
+		return ret;
+
+	val = no_os_field_get(MAX22196_CURR_MASK, val);
+
+	return sprintf(buf, "%s", max22196_current_avail[val]);
+}
+
+/**
+ * @brief Write the current attribute for a specific channel
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max22196_iio_write_current(void *dev, char *buf, uint32_t len,
+				      const struct iio_ch_info *channel,
+				      intptr_t priv)
+{
+	struct max22196_iio_desc *desc = dev;
+	uint32_t i;
+	int ch;
+
+	ch = channel->address;
+
+	for (i = 0; i < NO_OS_ARRAY_SIZE(max22196_current_avail); i++)
+		if (!strcmp(buf, max22196_current_avail[i]))
+			break;
+
+	if (i == NO_OS_ARRAY_SIZE(max22196_current_avail))
+		return -EINVAL;
+
+	i = no_os_field_prep(MAX22196_CURR_MASK, i);
+
+	return max22196_reg_update(desc->max22196_desc, MAX22196_CFG_REG(ch),
+				   MAX22196_CURR_MASK, i);
+}
+
+/**
+ * @brief Read the current available attribute for a specific channel
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max22196_iio_read_current_available(void *dev, char *buf,
+		uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	int length = 0;
+	uint32_t i;
+
+	for (i = 0; i < NO_OS_ARRAY_SIZE(max22196_current_avail); i++)
+		length += sprintf(buf + length, "%s ", max22196_current_avail[i]);
+
+	return length;
+}
+
+/**
+ * @brief Read the fault debug attribute.
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+*/
+static int max22196_iio_read_fault(void *dev, char *buf, uint32_t len,
+				   const struct iio_ch_info *channel,
+				   intptr_t priv)
+{
+	struct max22196_iio_desc *desc = dev;
+	uint32_t val;
+	int ret;
+
+	switch (priv) {
+	case MAX22196_IIO_FAULT1:
+		ret = max22196_iio_reg_read(desc, MAX22196_FAULT1_REG, &val);
+		if (ret)
+			return ret;
+		break;
+	case MAX22196_IIO_FAULT2:
+		ret = max22196_iio_reg_read(desc, MAX22196_FAULT2_REG, &val);
+		if (ret)
+			return ret;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, (int32_t *)&val);
+}
+
+/**
+ * @brief Read fault mask debug attribute.
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+*/
+static int max22196_iio_read_fault_mask(void *dev, char *buf, uint32_t len,
+					const struct iio_ch_info *channel,
+					intptr_t priv)
+{
+	struct max22196_iio_desc *desc = dev;
+	int ret;
+	bool enabled;
+
+	ret = max22196_fault_mask_get(desc->max22196_desc, priv, &enabled);
+	if (ret)
+		return ret;
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, (int32_t *)&enabled);
+}
+
+/**
+ * @brief Write fault mask debug attribute.
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+*/
+static int max22196_iio_write_fault_mask(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	struct max22196_iio_desc *desc = dev;
+	uint32_t val;
+
+	iio_parse_value(buf, IIO_VAL_INT, (int32_t *)&val, NULL);
+
+	return max22196_fault_mask_set(desc->max22196_desc, priv, (bool)val);
+}
+
+/**
+ * @brief Global config register configuration wrapper.
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+*/
+static int max22196_iio_write_global_cfg(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	struct max22196_iio_desc *desc = dev;
+	uint32_t val;
+
+	iio_parse_value(buf, IIO_VAL_INT, (int32_t *)&val, NULL);
+
+	return max22196_global_cfg(desc->max22196_desc, priv, (bool)val);
+}
+
+/**
+ * @brief Register read wrapper
+ * @param dev - The iio device structure.
+ * @param reg - The register's address.
+ * @param readval - Register value
+ * @return 0 in case of success, error code otherwise
+ */
+static int max22196_iio_reg_read(struct max22196_iio_desc *dev, uint32_t reg,
+				 uint32_t *readval)
+{
+	return max22196_reg_read(dev->max22196_desc, reg, readval);
+}
+
+/**
+ * @brief Register write wrapper
+ * @param dev - The iio device structure.
+ * @param reg - The register's address.
+ * @param readval - Register value
+ * @return 0 in case of success, error code otherwise
+ */
+static int max22196_iio_reg_write(struct max22196_iio_desc *dev, uint32_t reg,
+				  uint32_t writeval)
+{
+	return max22196_reg_write(dev->max22196_desc, reg, writeval);
+}
+
+/**
+ * @brief Initializes the MAX22196 IIO descriptor.
+ * @param iio_desc - The iio device descriptor.
+ * @param init_param - The structure that contains the device initial parameters.
+ * @return 0 in case of success, an error code otherwise.
+ */
+int max22196_iio_init(struct max22196_iio_desc **iio_desc,
+		      struct max22196_iio_desc_init_param *init_param)
+{
+	struct max22196_iio_desc *descriptor;
+	int ret;
+
+	if (!init_param || !init_param->max22196_init_param)
+		return -EINVAL;
+
+	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	ret = max22196_init(&descriptor->max22196_desc,
+			    init_param->max22196_init_param);
+	if (ret)
+		goto free_desc;
+
+	descriptor->iio_dev = &max22196_iio_dev;
+
+	*iio_desc = descriptor;
+
+	return 0;
+
+free_desc:
+	no_os_free(descriptor);
+	return ret;
+}
+
+/**
+ * @brief Free resources allocated by the init function.
+ * @param iio_desc - The iio device descriptor.
+ * @return 0 in case of success, an error code otherwise.
+ */
+int max22196_iio_remove(struct max22196_iio_desc *iio_desc)
+{
+	if (!iio_desc)
+		return -ENODEV;
+
+	max22196_remove(iio_desc->max22196_desc);
+	no_os_free(iio_desc);
+
+	return 0;
+}

--- a/drivers/digital-io/max22196/iio_max22196.h
+++ b/drivers/digital-io/max22196/iio_max22196.h
@@ -1,0 +1,76 @@
+/***************************************************************************//**
+ *   @file   iio_max22196.h
+ *   @brief  Header file of IIO MAX22196 Driver.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef IIO_MAX22196_H
+#define IIO_MAX22196_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "iio.h"
+#include "max22196.h"
+
+#define MAX22196_GLOBAL_CLRFILTR	3
+
+enum max22196_iio_fault {
+	MAX22196_IIO_FAULT1,
+	MAX22196_IIO_FAULT2
+};
+
+/**
+ * @brief MAX22196 IIO descriptor
+*/
+struct max22196_iio_desc {
+	struct max22196_desc *max22196_desc;
+	struct iio_device *iio_dev;
+};
+
+/**
+ * @brief MAX22196 IIO initalization parameter
+*/
+struct max22196_iio_desc_init_param {
+	struct max22196_init_param *max22196_init_param;
+};
+
+/** Initializes the MAX22196 IIO descriptor. */
+int max22196_iio_init(struct max22196_iio_desc **,
+		      struct max22196_iio_desc_init_param *);
+
+/** Free resources allocated by the initialization function. */
+int max22196_iio_remove(struct max22196_iio_desc *);
+
+#endif /* IIO_MAX22196_H */

--- a/drivers/digital-io/max22196/max22196.c
+++ b/drivers/digital-io/max22196/max22196.c
@@ -1,0 +1,574 @@
+/***************************************************************************//**
+ *   @file   max22196.c
+ *   @brief  Source file of MAX22196 Driver.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include "max22196.h"
+#include "no_os_util.h"
+#include "no_os_alloc.h"
+
+/**
+ * @brief Compute the CRC5 value for an array of bytes when writing to MAX22196
+ * @param data - array of data to compute for.
+ * @param encode - boolean that tells if the input data is to encode or decode.
+ * @return the resulted CRC5
+ */
+static uint8_t max22196_crc(uint8_t *data, bool encode)
+{
+	uint8_t crc5_start = 0x1f;
+	uint8_t crc5_poly = 0x15;
+	uint8_t crc5_result = crc5_start;
+	uint8_t extra_byte = 0x00;
+	uint8_t data_bit;
+	uint8_t result_bit;
+	int i;
+
+	for (i = (encode) ? 0 : 2; i < 8; i++) {
+		data_bit = (data[0] >> (7 - i)) & 0x01;
+		result_bit = (crc5_result & 0x10) >> 4;
+		if (data_bit ^ result_bit)
+			crc5_result = crc5_poly ^ ((crc5_result << 1) & 0x1f);
+		else
+			crc5_result = (crc5_result << 1) & 0x1f;
+	}
+
+	for (i = 0; i < 8; i++) {
+		data_bit = (data[1] >> (7 - i)) & 0x01;
+		result_bit = (crc5_result & 0x10) >> 4;
+		if (data_bit ^ result_bit)
+			crc5_result = crc5_poly ^ ((crc5_result << 1) & 0x1f);
+		else
+			crc5_result = (crc5_result << 1) & 0x1f;
+	}
+
+	for (i = 0; i < 3; i++) {
+		data_bit = (extra_byte >> (7 - i)) & 0x01;
+		result_bit = (crc5_result & 0x10) >> 4;
+		if (data_bit ^ result_bit)
+			crc5_result = crc5_poly ^ ((crc5_result << 1) & 0x1f);
+		else
+			crc5_result = (crc5_result << 1) & 0x1f;
+	}
+
+	return crc5_result;
+}
+
+/**
+ * @brief MAX22196 register write function
+ * @param desc - The device descriptor for MAX22196.
+ * @param reg - The register where the information is to be written.
+ * @param val - The value to be written to reg.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22196_reg_write(struct max22196_desc *desc, uint32_t reg, uint32_t val)
+{
+	struct no_os_spi_msg xfer = {
+		.tx_buff = desc->buff,
+		.bytes_number = MAX22196_FRAME_SIZE,
+		.cs_change = 1,
+	};
+
+	desc->buff[0] = no_os_field_prep(MAX22196_ADDR_MASK, desc->chip_address) |
+			no_os_field_prep(MAX22196_REG_ADDR_MASK, reg) |
+			no_os_field_prep(MAX22196_RW_MASK, 1);
+	desc->buff[1] = val;
+
+	if (desc->crc_en) {
+		xfer.bytes_number++;
+		desc->buff[2] = max22196_crc(desc->buff, true);
+	}
+
+	return no_os_spi_transfer(desc->comm_desc, &xfer, 1);
+}
+
+/**
+ * @brief MAX22196 register read function
+ * @param desc - The device descriptor for MAX22196.
+ * @param reg - The register value where the data is read from.
+ * @param val - The value returned from read.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22196_reg_read(struct max22196_desc *desc, uint32_t reg, uint32_t *val)
+{
+	struct no_os_spi_msg xfer = {
+		.tx_buff = desc->buff,
+		.rx_buff = desc->buff,
+		.bytes_number = MAX22196_FRAME_SIZE,
+		.cs_change = 1,
+	};
+	uint8_t crc;
+	int ret;
+
+	if (desc->crc_en)
+		xfer.bytes_number++;
+
+	memset(desc->buff, 0, xfer.bytes_number);
+	desc->buff[0] = no_os_field_prep(MAX22196_ADDR_MASK, desc->chip_address) |
+			no_os_field_prep(MAX22196_REG_ADDR_MASK, reg) |
+			no_os_field_prep(MAX22196_RW_MASK, 0);
+
+	if (desc->crc_en)
+		desc->buff[2] = max22196_crc(&desc->buff[0], true);
+
+	ret = no_os_spi_transfer(desc->comm_desc, &xfer, 1);
+	if (ret)
+		return ret;
+
+	if (desc->crc_en) {
+		crc = max22196_crc(&desc->buff[0], false);
+		if (crc != desc->buff[2])
+			return -EINVAL;
+	}
+
+	*val = desc->buff[1];
+
+	return 0;
+}
+
+/**
+ * @brief - MAX22196 register update function
+ * @param desc - The device descriptor for MAX22196.
+ * @param reg - The register to be updated.
+ * @param mask - The specific mask where the value will be updated.
+ * @param val - The value that is to be written to the mask.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22196_reg_update(struct max22196_desc *desc, uint32_t reg, uint32_t mask,
+			uint32_t val)
+{
+	int ret;
+	uint32_t reg_val = 0;
+
+	ret = max22196_reg_read(desc, reg, &reg_val);
+	if (ret)
+		return ret;
+
+	reg_val &= ~mask;
+	reg_val |= mask & val;
+
+	return max22196_reg_write(desc, reg, reg_val);
+}
+
+/**
+ * @brief - MAX22196 function that helps setting the mode of the device.
+ * @param desc - The device descriptor for MAX22196
+ * @param ch - The channel for which the mode will be set.
+ * @param mode - The mode to be set.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22196_set_mode(struct max22196_desc *desc, uint32_t ch,
+		      enum max22196_mode mode)
+{
+	if (ch > MAX22196_CHANNELS - 1)
+		return -EINVAL;
+
+	return max22196_reg_update(desc, MAX22196_CFG_REG(ch),
+				   MAX22196_SOURCE_MASK,
+				   no_os_field_prep(MAX22196_SOURCE_MASK, mode));
+}
+
+/**
+ * @brief - MAX22196 channel configuration function
+ * @param desc - The device descriptor for MAX22196.
+ * @param ch - Channel for which the configuration is to be changed.
+ * @param hi_thr - Voltage threshold(0 for inactive, 1 for active).
+ * @param curr - Channel current to be set.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22196_chan_cfg(struct max22196_desc *desc, uint32_t ch, uint32_t hi_thr,
+		      enum max22196_curr curr)
+{
+	if (ch > MAX22196_CHANNELS - 1)
+		return -EINVAL;
+
+	return max22196_reg_update(desc, MAX22196_CFG_REG(ch),
+				   MAX22196_CFG_MASK,
+				   no_os_field_prep(MAX22196_HITHR_MASK, hi_thr)
+				   | no_os_field_prep(MAX22196_CURR_MASK, curr));
+}
+
+/**
+ * @brief - MAX22196 filter set function
+ * @param desc - MAX22196 device descriptor.
+ * @param ch - Channel to which the filter values will be applied to.
+ * @param flt_en - Filter enable value(0 for filter disabled,
+ * 		   1 for filter enable)
+ * @param clr_filtr - Clear filter and set delay value to mid-scale.
+ * @param delay - Filter delay to be set.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22196_filter_set(struct max22196_desc *desc, uint32_t ch,
+			uint32_t flt_en, uint32_t clr_filtr,
+			enum max22196_delay delay)
+{
+	int ret;
+
+	if (ch > MAX22196_CHANNELS - 1)
+		return -EINVAL;
+
+	ret =  max22196_reg_update(desc, MAX22196_CFG_REG(ch),
+				   MAX22196_CFG_MASK,
+				   no_os_field_prep(MAX22196_DELAY_MASK, delay) |
+				   no_os_field_prep(MAX22196_FLTEN_MASK, flt_en));
+	if (ret)
+		return ret;
+
+	return max22196_reg_update(desc, MAX22196_GLOBALCFG_REG,
+				   MAX22196_FILTER_CLRFLT_MASK,
+				   no_os_field_prep(MAX22196_FILTER_CLRFLT_MASK,
+						   clr_filtr));
+}
+
+/**
+ * @brief - MAX22196 filter get function
+ * @param desc - MAX22196 device descriptor.
+ * @param ch - Channel from which the filter values are read.
+ * @param flt_en - Variable through which the fillter's state is read.
+ * @param clr_filtr - Clear the filter value and set to mid-scale delay.
+ * @param delay - Filter delay value to be read for the MAX22196's specified
+ * 		  channel.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22196_filter_get(struct max22196_desc *desc, uint32_t ch,
+			uint32_t *flt_en, uint32_t *clr_filtr,
+			enum max22196_delay *delay)
+{
+	int ret;
+	uint32_t del_val;
+
+	if (ch > MAX22196_CHANNELS - 1)
+		return -EINVAL;
+
+	ret = max22196_reg_read(desc, MAX22196_CFG_REG(ch), &del_val);
+	if (ret)
+		return ret;
+
+	*delay = no_os_field_get(MAX22196_DELAY_MASK, del_val);
+	*flt_en = no_os_field_get(MAX22196_FLTEN_MASK, del_val);
+
+	ret = max22196_reg_read(desc, MAX22196_GLOBALCFG_REG, &del_val);
+	if (ret)
+		return ret;
+
+	*clr_filtr = no_os_field_get(MAX22196_FILTER_CLRFLT_MASK, del_val);
+
+	return 0;
+}
+
+/**
+ * @brief Set fault mask bits in the fault mask registers.
+ * @param desc - MAX22196 device descriptor.
+ * @param fault_mask - Requested fault to set mask to.
+ * @param enabled - Mask state to be set.
+ * @return - 0 in case of succes, negative error code otherwise.
+*/
+int max22196_fault_mask_set(struct max22196_desc *desc,
+			    enum max22196_fault_mask fault_mask,
+			    bool enabled)
+{
+	int ret;
+
+	switch (fault_mask) {
+	case MAX22196_GLOBAL_REFDISHTCFG:
+		return max22196_reg_update(desc, MAX22196_GLOBALCFG_REG,
+					   MAX22196_FAULT_MASK(fault_mask),
+					   no_os_field_prep(MAX22196_FAULT_MASK(fault_mask),
+							   enabled));
+	case MAX22196_FAULT1_VMLOW ... MAX22196_FAULT1_FAULT2:
+		return max22196_reg_update(desc, MAX22196_F1MASK_REG,
+					   MAX22196_FAULT_MASK(fault_mask),
+					   no_os_field_prep(MAX22196_FAULT_MASK(fault_mask),
+							   enabled));
+	case MAX22196_FAULT2_RFDIS ... MAX22196_FAULT2_VAUV:
+		ret = max22196_reg_update(desc, MAX22196_F1MASK_REG,
+					  MAX22196_FAULT_MASK(fault_mask - MAX22196_FAULT2_RFDIS),
+					  no_os_field_prep(MAX22196_FAULT_MASK(fault_mask - MAX22196_FAULT2_RFDIS),
+							  enabled));
+		if (ret)
+			return ret;
+
+		desc->fault2en &= ~MAX22196_FAULT_MASK(fault_mask -
+						       MAX22196_FAULT2_RFDIS);
+		desc->fault2en |= MAX22196_FAULT_MASK(fault_mask -
+						      MAX22196_FAULT2_RFDIS)
+				  & no_os_field_prep(MAX22196_FAULT_MASK(fault_mask -
+						     MAX22196_FAULT2_RFDIS),
+						     enabled);
+		desc->fault2en &= MAX22196_FAULT2_MASK;
+
+		return max22196_reg_update(desc, MAX22196_F1MASK_REG,
+					   MAX22196_FAULT_MASK(MAX22196_FAULT1_FAULT2),
+					   no_os_field_prep(MAX22196_FAULT_MASK(MAX22196_FAULT1_FAULT2),
+							   !!desc->fault2en));
+	default:
+		return -EINVAL;
+	}
+}
+
+
+/**
+ * @brief Get fault mask bits from the fault mask registers.
+ * @param desc - MAX22196 device descriptor.
+ * @param fault_mask - Requested fault to get mask from.
+ * @param enabled - Mask state to be read.
+ * @return - 0 in case of succes, negative error code otherwise.
+*/
+int max22196_fault_mask_get(struct max22196_desc *desc,
+			    enum max22196_fault_mask fault_mask,
+			    bool *enabled)
+{
+	int ret;
+	uint32_t reg_val;
+
+	switch (fault_mask) {
+	case MAX22196_GLOBAL_REFDISHTCFG:
+		ret = max22190_reg_read(desc, MAX22196_GLOBALCFG_REG, &reg_val);
+		if (ret)
+			return ret;
+		*enabled = no_os_field_get(desc, MAX22196_FAULT_MASK(fault_mask));
+
+		break;
+	case MAX22196_FAULT1_VMLOW ... MAX22196_FAULT1_FAULT2:
+		ret =  max22196_reg_read(desc, MAX22196_F1MASK_REG, &reg_val);
+		if (ret)
+			return ret;
+		*enabled = no_os_field_get(MAX22196_FAULT_MASK(fault_mask),
+					   reg_val);
+		break;
+	case MAX22196_FAULT2_RFDIS ... MAX22196_FAULT2_VAUV:
+		ret =  max22196_reg_read(desc, MAX22196_F2MASK_REG, &reg_val);
+		if (ret)
+			return ret;
+		*enabled = no_os_field_get(MAX22196_FAULT_MASK(fault_mask -
+					   MAX22196_FAULT2_RFDIS),
+					   reg_val);
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Set global configuration.
+ * @param desc - MAX22196 device descriptor.
+ * @param global_cfg - Specifc configuration to be set.
+ * @param enabled - State of the specific configuration.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22196_global_cfg(struct max22196_desc *desc,
+			enum max22196_global_cfg global_cfg, bool enabled)
+{
+	switch (global_cfg) {
+	case MAX22196_GLOBAL_FSPICLR ... MAX22196_GLOBAL_GPO:
+		return max22196_reg_update(desc, MAX22196_GLOBALCFG_REG,
+					   MAX22196_GLOBAL_MASK(global_cfg),
+					   no_os_field_prep(MAX22196_GLOBAL_MASK(global_cfg),
+							   enabled));
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief - MAX22196 channel counter set function
+ * @param desc - MAX22196 device descriptor.
+ * @param ch - MAX22196 channel to which the counter is set.
+ * @param cnt_msb_lsb_bytes - 8MSBs represent the MSB byte to be written to the
+ *			      specifc chanel's counter, 8LSBs represent the LSB
+ *			      byte.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22196_set_chan_cnt(struct max22196_desc *desc, uint32_t ch,
+			  uint16_t cnt_msb_lsb_bytes)
+{
+	int ret;
+	uint8_t msb_byte, lsb_byte;
+
+	if (ch > MAX22196_CHANNELS - 1)
+		return -EINVAL;
+
+	ret = max22196_reg_update(desc, MAX22196_START_STOP_REG,
+				  MAX22196_CNT_MASK(ch),
+				  no_os_field_prep(MAX22196_CNT_MASK(ch), 0));
+	if (ret)
+		return ret;
+
+	msb_byte = no_os_field_get(MAX22196_MSB_MASK, cnt_msb_lsb_bytes);
+	msb_byte = no_os_field_prep(MAX22196_CNT_BYTE_MASK, msb_byte);
+
+	ret = max22196_reg_write(desc, MAX22196_CNT_MSB_REG(ch),
+				 msb_byte);
+	if (ret)
+		return ret;
+
+	lsb_byte = no_os_field_get(MAX22196_LSB_MASK, cnt_msb_lsb_bytes);
+	lsb_byte = no_os_field_prep(MAX22196_CNT_BYTE_MASK, lsb_byte);
+
+	ret = max22196_reg_write(desc, MAX22196_CNT_LSB_REG(ch),
+				 lsb_byte);
+	if (ret)
+		return ret;
+
+	return max22196_reg_update(desc, MAX22196_START_STOP_REG,
+				   MAX22196_CNT_MASK(ch),
+				   no_os_field_prep(MAX22196_CNT_MASK(ch), 1));
+}
+
+/**
+ * @brief MAX22196 channel counter get function
+ * @param desc - MAX22196 device descriptor.
+ * @param ch - Channel for which the channel counter is read.
+ * @param cnt_msb_lsb_bytes - 8MSBs represent the MSB byte read from the specifc
+ *			      chanel's counter, 8LSBs represent the LSB byte.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22196_get_chan_cnt(struct max22196_desc *desc, uint32_t ch,
+			  uint16_t *cnt_msb_lsb_bytes)
+{
+	int ret;
+	uint32_t reg_val;
+
+	if (ch > MAX22196_CHANNELS - 1)
+		return -EINVAL;
+
+	ret = max22196_reg_update(desc, MAX22196_START_STOP_REG,
+				  MAX22196_CNT_MASK(ch),
+				  no_os_field_prep(MAX22196_CNT_MASK(ch), 0));
+	if (ret)
+		return ret;
+
+	ret = max22196_reg_read(desc, MAX22196_CNT_LSB_REG(ch), &reg_val);
+	if (ret)
+		return ret;
+
+	*cnt_msb_lsb_bytes = no_os_field_prep(MAX22196_LSB_MASK, reg_val);
+
+	ret = max22196_reg_read(desc, MAX22196_CNT_MSB_REG(ch), &reg_val);
+	if (ret)
+		return ret;
+
+	*cnt_msb_lsb_bytes |= no_os_field_prep(MAX22196_MSB_MASK, reg_val);
+
+	return max22196_reg_update(desc, MAX22196_START_STOP_REG,
+				   MAX22196_CNT_MASK(ch),
+				   no_os_field_prep(MAX22196_CNT_MASK(ch), 1));
+}
+
+/**
+ * @brief Initialize and configure the MAX22196 device.
+ * @param desc - device descriptor for the MAX22196 that will be initialized.
+ * @param param - initialization parameter for the device.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int max22196_init(struct max22196_desc **desc,
+		  struct max22196_init_param *param)
+{
+	struct max22196_desc *descriptor;
+	uint8_t reg_val;
+	int ret;
+
+	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+	ret = no_os_spi_init(&descriptor->comm_desc, param->comm_param);
+	if (ret)
+		goto error;
+
+	if (param->crc_en) {
+		ret = no_os_gpio_get(&descriptor->crc_desc, param->crc_param);
+		if (ret)
+			goto spi_error;
+
+		ret = no_os_gpio_direction_output(descriptor->crc_desc,
+						  NO_OS_GPIO_HIGH);
+		if (ret)
+			goto gpio_error;
+
+		descriptor->crc_en = true;
+	}
+
+	/* Clear the latched faults generated at power-up of MAX22196. */
+	ret = max22196_reg_read(descriptor, MAX22196_FAULT1_REG, &reg_val);
+	if (ret)
+		goto gpio_error;
+
+	ret = max22196_reg_read(descriptor, MAX22196_FAULT2_REG, &reg_val);
+	if (ret)
+		goto gpio_error;
+
+	*desc = descriptor;
+
+	return 0;
+gpio_error:
+	if (param->crc_en)
+		no_os_gpio_remove(descriptor->crc_desc);
+spi_error:
+	no_os_spi_remove(descriptor->comm_desc);
+error:
+	no_os_free(descriptor);
+
+	return ret;
+}
+
+/**
+ * @brief Free the resources allocated during init.
+ * @param desc - device descriptor for the MAX14916 that will be initialized.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int max22196_remove(struct max22196_desc *desc)
+{
+	int ret, i;
+
+	if (!desc)
+		return -ENODEV;
+
+	for (i = 0; i < MAX22196_CHANNELS; i++) {
+		ret = max22196_set_chan_cnt(desc, i, MAX22196_CHN_CNT_RESET);
+		if (ret)
+			return ret;
+	}
+
+	no_os_spi_remove(desc->comm_desc);
+	no_os_gpio_remove(desc->crc_desc);
+	no_os_free(desc);
+
+	return 0;
+}

--- a/drivers/digital-io/max22196/max22196.h
+++ b/drivers/digital-io/max22196/max22196.h
@@ -1,0 +1,195 @@
+/***************************************************************************//**
+ *   @file   max22196.h
+ *   @brief  Header file of MAX22196 Driver.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef _MAX22196_H
+#define _MAX22196_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "no_os_spi.h"
+#include "no_os_gpio.h"
+#include "no_os_util.h"
+
+#define MAX22196_FRAME_SIZE		2
+
+#define MAX22196_CHANNELS		8
+
+#define MAX22196_CHN_CNT_RESET		0
+
+#define MAX22196_DI_STATE_REG		0x00
+#define MAX22196_FAULT1_REG		0x01
+#define MAX22196_F1MASK_REG		0x02
+#define MAX22196_CFG_REG(x)		(0x03 + (x))
+#define MAX22196_GLOBALCFG_REG		0x0B
+#define MAX22196_LED_REG		0x0C
+#define MAX22196_FAULT2_REG		0x0D
+#define MAX22196_F2MASK_REG		0x0E
+#define MAX22196_START_STOP_REG		0x0F
+#define MAX22196_CNT_LSB_REG(x)		(0x10 + 2 * (x))
+#define MAX22196_CNT_MSB_REG(x)		(0x11 + 2 * (x))
+
+#define MAX22196_ADDR_MASK		NO_OS_GENMASK(7, 6)
+#define MAX22196_REG_ADDR_MASK		NO_OS_GENMASK(5, 1)
+#define MAX22196_RW_MASK		NO_OS_BIT(0)
+
+#define MAX22196_DI_STATE_MASK(x)	NO_OS_BIT(x)
+#define MAX22196_HITHR_MASK		NO_OS_BIT(7)
+#define MAX22196_SOURCE_MASK		NO_OS_BIT(6)
+#define MAX22196_CURR_MASK		NO_OS_GENMASK(5, 4)
+#define MAX22196_FLTEN_MASK		NO_OS_BIT(3)
+#define MAX22196_DELAY_MASK		NO_OS_GENMASK(2, 0)
+#define MAX22196_CNT_MASK(x)		NO_OS_BIT(x)
+#define MAX22196_CFG_MASK		(NO_OS_BIT(7) | NO_OS_GENMASK(5, 4))
+#define MAX22196_LSB_MASK		NO_OS_GENMASK(7, 0)
+#define MAX22196_MSB_MASK		NO_OS_GENMASK(15, 8)
+#define MAX22196_CNT_BYTE_MASK		NO_OS_GENMASK(7, 0)
+
+#define MAX22196_FAULT_MASK(x)		NO_OS_BIT(x)
+#define MAX22196_GLOBAL_MASK(x)		NO_OS_BIT(x)
+#define MAX22196_FAULT2_MASK		NO_OS_GENMASK(4, 0)
+
+#define MAX22196_FILTER_CLRFLT_MASK	NO_OS_BIT(3)
+
+enum max22196_fault_mask {
+	MAX22196_GLOBAL_REFDISHTCFG,
+	MAX22196_FAULT1_VMLOW,
+	MAX22196_FAULT1_V24UV,
+	MAX22196_FAULT1_TEMPALM,
+	MAX22196_FAULT1_OTSHDN1,
+	MAX22196_FAULT1_FAULT2,
+	MAX22196_FAULT2_RFDIS,
+	MAX22196_FAULT2_RFDIO,
+	MAX22196_FAULT2_OTSHDN2,
+	MAX22196_FAULT2_SPI8CLK,
+	MAX22196_FAULT2_VAUV
+};
+
+enum max22196_global_cfg {
+	MAX22196_GLOBAL_FSPICLR = 4,
+	MAX22196_GLOBAL_LED9,
+	MAX22196_GLOBAL_LEDINT,
+	MAX22196_GLOBAL_GPO
+};
+
+enum max22196_mode {
+	MAX22196_SINK_MODE,
+	MAX22196_SOURCE_MODE,
+};
+
+enum max22196_delay {
+	MAX22196_DELAY_50US,
+	MAX22196_DELAY_100US,
+	MAX22196_DELAY_400US,
+	MAX22196_DELAY_800US,
+	MAX22196_DELAY_1600US,
+	MAX22196_DELAY_3200US,
+	MAX22196_DELAY_128000US,
+	MAX22196_DELAY_20MS
+};
+
+enum max22196_curr {
+	MAX22196_HTL_MODE,
+	MAX22196_1X_CURRENT,
+	MAX22196_3X_CURRENT,
+	MAX22196_TTL_OP_OFF
+};
+
+struct max22196_init_param {
+	uint32_t chip_address;
+	struct no_os_spi_init_param *comm_param;
+	struct no_os_gpio_init_param *crc_param;
+	bool crc_en;
+};
+
+struct max22196_desc {
+	uint32_t chip_address;
+	struct no_os_spi_desc *comm_desc;
+	struct no_os_gpio_desc *crc_desc;
+	uint8_t buff[MAX22196_FRAME_SIZE + 1];
+	uint8_t fault2en;
+	bool crc_en;
+};
+
+/** Register write function for MAX22196. */
+int max22196_reg_write(struct max22196_desc *, uint32_t, uint32_t);
+
+/** Register read function for MAX22196. */
+int max22196_reg_read(struct max22196_desc *, uint32_t, uint32_t *);
+
+/** Register update function for MAX22196. */
+int max22196_reg_update(struct max22196_desc *, uint32_t, uint32_t, uint32_t);
+
+/** Set mode to a specific channel. */
+int max22196_set_mode(struct max22196_desc *, uint32_t, enum max22196_mode);
+
+/** Set configuration for a specific channel. */
+int max22196_chan_cfg(struct max22196_desc *, uint32_t, uint32_t,
+		      enum max22196_curr);
+
+/** Set filter values for a specific channel. */
+int max22196_filter_set(struct max22196_desc *, uint32_t, uint32_t, uint32_t,
+			enum max22196_delay);
+
+/** Read filter values for a specific channel. */
+int max22196_filter_get(struct max22196_desc *, uint32_t, uint32_t *,
+			uint32_t *, enum max22196_delay *);
+
+/** Set fault masks for requested fault. */
+int max22196_fault_mask_set(struct max22196_desc *, enum max22196_fault_mask,
+			    bool);
+
+/** Get fault masks state for requested fault. */
+int max22196_fault_mask_get(struct max22196_desc *, enum max22196_fault_mask,
+			    bool *);
+
+/** Set global configurations manually if desired. */
+int max22196_global_cfg(struct max22196_desc *, enum max22196_global_cfg, bool);
+
+/** Set channel counter for a specific channel. */
+int max22196_set_chan_cnt(struct max22196_desc *, uint32_t, uint16_t);
+
+/** Read channel counter for a specific channel. */
+int max22196_get_chan_cnt(struct max22196_desc *, uint32_t, uint16_t *);
+
+/** Initialize the MAX22196 descriptor. */
+int max22196_init(struct max22196_desc **, struct max22196_init_param *);
+
+/** Remove the resources allocated at init. */
+int max22196_remove(struct max22196_desc *);
+
+#endif /** _MAX22196_H */


### PR DESCRIPTION
## Pull Request Description

The MAX22196 is an industrial octal digital input that translates eight industrial 24V or TTL level inputs to logic level outputs. The device has a serial interface allowing configuration and reading of serialized data through SPI.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
