### PR TITLE
ci: documentation: treat sphinx warnings as errors

### DIFF
--- a/ci/documentation.sh
+++ b/ci/documentation.sh
@@ -49,7 +49,7 @@ build_doxygen() {
 build_sphinx() {
         pushd ${TOP_DIR}/doc/sphinx
 
-        sphinx-build ./source/ ./build
+        sphinx-build -W ./source/ ./build
 
         popd
 }

--- a/ci/documentation.sh
+++ b/ci/documentation.sh
@@ -115,8 +115,8 @@ update_gh_pages() {
         fi
 }
 
-build_doxygen
-
 build_sphinx
+
+build_doxygen
 
 update_gh_pages


### PR DESCRIPTION
## Pull Request Description

In the same manner as the doxygen build, treat warnings as errors.

Sphinx build treats some relevant issues as warnings (such as incorrect links/paths, etc.)

These should be detected by the ci build and not mark the build as successful.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
