### PR TITLE
Call no_os_init() during board init

### DIFF
--- a/drivers/platform/maxim/max32650/maxim_init.c
+++ b/drivers/platform/maxim/max32650/maxim_init.c
@@ -47,3 +47,8 @@ __weak int no_os_init(void)
 	/* This has o be performed so the en state of SysTick is saved. */
 	return MXC_Delay(1);
 }
+
+int Board_Init(void)
+{
+	return no_os_init();
+}

--- a/drivers/platform/maxim/max32655/maxim_init.c
+++ b/drivers/platform/maxim/max32655/maxim_init.c
@@ -47,3 +47,8 @@ __weak int no_os_init(void)
 	/* This has o be performed so the en state of SysTick is saved. */
 	return MXC_Delay(1);
 }
+
+int Board_Init(void)
+{
+	return no_os_init();
+}

--- a/drivers/platform/maxim/max32660/maxim_init.c
+++ b/drivers/platform/maxim/max32660/maxim_init.c
@@ -47,3 +47,8 @@ __weak int no_os_init(void)
 	/* This has o be performed so the en state of SysTick is saved. */
 	return MXC_Delay(1);
 }
+
+int Board_Init(void)
+{
+	return no_os_init();
+}

--- a/drivers/platform/maxim/max32665/maxim_init.c
+++ b/drivers/platform/maxim/max32665/maxim_init.c
@@ -47,3 +47,8 @@ __weak int no_os_init(void)
 	/* This has o be performed so the en state of SysTick is saved. */
 	return MXC_Delay(1);
 }
+
+int Board_Init(void)
+{
+	return no_os_init();
+}

--- a/drivers/platform/maxim/max32670/maxim_init.c
+++ b/drivers/platform/maxim/max32670/maxim_init.c
@@ -47,3 +47,8 @@ __weak int no_os_init(void)
 	/* This has o be performed so the en state of SysTick is saved. */
 	return MXC_Delay(1);
 }
+
+int Board_Init(void)
+{
+	return no_os_init();
+}

--- a/drivers/platform/maxim/max32690/maxim_init.c
+++ b/drivers/platform/maxim/max32690/maxim_init.c
@@ -47,3 +47,8 @@ __weak int no_os_init(void)
 	/* This has o be performed so the en state of SysTick is saved. */
 	return MXC_Delay(1);
 }
+
+int Board_Init(void)
+{
+	return no_os_init();
+}

--- a/drivers/platform/maxim/max78000/maxim_init.c
+++ b/drivers/platform/maxim/max78000/maxim_init.c
@@ -47,3 +47,8 @@ __weak int no_os_init(void)
 	/* This has o be performed so the en state of SysTick is saved. */
 	return MXC_Delay(1);
 }
+
+int Board_Init(void)
+{
+	return no_os_init();
+}

--- a/projects/adt7420-pmdz/src/platform/maxim/main.c
+++ b/projects/adt7420-pmdz/src/platform/maxim/main.c
@@ -42,7 +42,6 @@
 /******************************************************************************/
 #include "platform_includes.h"
 #include "common_data.h"
-#include "no_os_init.h"
 
 #ifdef IIO_EXAMPLE
 #include "iio_example.h"
@@ -60,8 +59,6 @@
 int main()
 {
 	int ret;
-
-	no_os_init();
 
 #ifdef IIO_EXAMPLE
 	ret = iio_example_main();

--- a/projects/eval-adxl313z/src/platform/maxim/main.c
+++ b/projects/eval-adxl313z/src/platform/maxim/main.c
@@ -43,7 +43,6 @@
 #include <errno.h>
 #include "platform_includes.h"
 #include "common_data.h"
-#include "no_os_init.h"
 
 #ifdef IIO_EXAMPLE
 #include "iio_example.h"
@@ -63,10 +62,6 @@ int main()
 	int ret = -EINVAL;
 
 	adxl313_user_init.comm_init.spi_init = sip;
-
-	ret = no_os_init();
-	if (ret)
-		goto error;
 
 #ifdef IIO_EXAMPLE
 	ret = iio_example_main();

--- a/projects/eval-ltc4306/src/platform/maxim/main.c
+++ b/projects/eval-ltc4306/src/platform/maxim/main.c
@@ -42,7 +42,6 @@
 /******************************************************************************/
 #include "platform_includes.h"
 #include "common_data.h"
-#include "no_os_init.h"
 #include "basic_example.h"
 
 /***************************************************************************//**
@@ -56,8 +55,6 @@ int main()
 
 	ltc4306_user_init.i2c_init = iip;
 	max538x_user_init.i2c_init = iip;
-
-	no_os_init();
 
 	struct no_os_uart_desc *uart;
 

--- a/projects/swiot1l/src/platform/maxim/main.c
+++ b/projects/swiot1l/src/platform/maxim/main.c
@@ -39,7 +39,6 @@
 #include "platform_includes.h"
 #include "common_data.h"
 #include "no_os_error.h"
-#include "no_os_init.h"
 
 #include "swiot_fw.h"
 
@@ -52,10 +51,6 @@ int main()
 {
 	struct no_os_uart_desc *uart_desc;
 	int ret;
-
-	ret = no_os_init();
-	if (ret)
-		return ret;
 
 	ret = no_os_uart_init(&uart_desc, &uart_ip);
 	if (ret)


### PR DESCRIPTION
## Pull Request Description

no_os_init() is supposed to be called for any project running on Maxim. The Board_Init() function is called in the SDK before main(), so we can also do no_os_init().

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
