### PR TITLE
drivers: adc-dac: ad74413r: Fix diag rate setting

### DIFF
--- a/drivers/adc-dac/ad74413r/ad74413r.c
+++ b/drivers/adc-dac/ad74413r/ad74413r.c
@@ -639,16 +639,14 @@ int ad74413r_set_adc_rate(struct ad74413r_desc *desc, uint32_t ch,
 int ad74413r_get_adc_diag_rate(struct ad74413r_desc *desc, uint32_t ch,
 			       enum ad74413r_adc_sample *val)
 {
-	uint16_t reg_val;
+	enum ad74413r_rejection rejection;
 	int ret;
 
-	ret = ad74413r_reg_read(desc, AD74413R_ADC_CONV_CTRL, &reg_val);
+	ret = ad74413r_get_adc_diag_rejection(desc, &rejection);
 	if (ret)
 		return ret;
 
-	reg_val = no_os_field_get(AD74413R_EN_REJ_DIAG_MASK, reg_val);
-
-	return ad74413r_rejection_to_rate(reg_val, val);
+	return ad74413r_rejection_to_rate(rejection, val);
 }
 
 /**
@@ -665,10 +663,10 @@ int ad74413r_set_adc_diag_rate(struct ad74413r_desc *desc, uint32_t ch,
 
 	switch (val) {
 	case AD74413R_ADC_SAMPLE_20HZ:
-		reg_val = no_os_field_prep(AD74413R_EN_REJ_DIAG_MASK, 1);
+		reg_val = 1;
 		break;
 	case AD74413R_ADC_SAMPLE_4800HZ:
-		reg_val = no_os_field_prep(AD74413R_EN_REJ_DIAG_MASK, 0);
+		reg_val = 0;
 		break;
 	default:
 		return -EINVAL;


### PR DESCRIPTION
## Pull Request Description

The ad74413r_reg_update() does the field prep. When setting the sampling rate for a diagnostics channel, the bitfield is shifted twice, which is wrong.

Also, there is already a function that reads a register value and converts it into a rejection value. So, this can be used instead of directly reading the register.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
