### PR TITLE
save max specific uart descriptor

### DIFF
--- a/drivers/platform/maxim/max32650/maxim_uart.c
+++ b/drivers/platform/maxim/max32650/maxim_uart.c
@@ -270,6 +270,7 @@ static int32_t max_uart_init(struct no_os_uart_desc **desc,
 		ret = -ENOMEM;
 		goto error_desc;
 	}
+	descriptor->extra = max_uart;
 	uart_regs = MXC_UART_GET_UART(param->device_id);
 	eparam = param->extra;
 

--- a/drivers/platform/maxim/max32655/maxim_uart.c
+++ b/drivers/platform/maxim/max32655/maxim_uart.c
@@ -280,6 +280,7 @@ static int32_t max_uart_init(struct no_os_uart_desc **desc,
 		ret = -ENOMEM;
 		goto error;
 	}
+	descriptor->extra = max_uart;
 	uart_regs = MXC_UART_GET_UART(param->device_id);
 	eparam = param->extra;
 

--- a/drivers/platform/maxim/max32660/maxim_uart.c
+++ b/drivers/platform/maxim/max32660/maxim_uart.c
@@ -267,6 +267,7 @@ static int32_t max_uart_init(struct no_os_uart_desc **desc,
 		ret = -ENOMEM;
 		goto error;
 	}
+	descriptor->extra = max_uart;
 	uart_regs = MXC_UART_GET_UART(param->device_id);
 	eparam = param->extra;
 

--- a/drivers/platform/maxim/max32665/maxim_uart.c
+++ b/drivers/platform/maxim/max32665/maxim_uart.c
@@ -280,6 +280,7 @@ static int32_t max_uart_init(struct no_os_uart_desc **desc,
 		ret = -ENOMEM;
 		goto error;
 	}
+	descriptor->extra = max_uart;
 	uart_regs = MXC_UART_GET_UART(param->device_id);
 	eparam = param->extra;
 

--- a/drivers/platform/maxim/max32670/maxim_uart.c
+++ b/drivers/platform/maxim/max32670/maxim_uart.c
@@ -233,6 +233,7 @@ static int32_t max_uart_init(struct no_os_uart_desc **desc,
 		ret = -ENOMEM;
 		goto error;
 	}
+	descriptor->extra = max_uart;
 	uart_regs = MXC_UART_GET_UART(param->device_id);
 	eparam = param->extra;
 

--- a/drivers/platform/maxim/max32690/maxim_uart.c
+++ b/drivers/platform/maxim/max32690/maxim_uart.c
@@ -275,6 +275,7 @@ static int32_t max_uart_init(struct no_os_uart_desc **desc,
 		ret = -ENOMEM;
 		goto error;
 	}
+	descriptor->extra = max_uart;
 	uart_regs = MXC_UART_GET_UART(param->device_id);
 	eparam = param->extra;
 

--- a/drivers/platform/maxim/max78000/maxim_uart.c
+++ b/drivers/platform/maxim/max78000/maxim_uart.c
@@ -290,6 +290,7 @@ static int32_t max_uart_init(struct no_os_uart_desc **desc,
 		ret = -ENOMEM;
 		goto error;
 	}
+	descriptor->extra = max_uart;
 	uart_regs = MXC_UART_GET_UART(param->device_id);
 	eparam = param->extra;
 


### PR DESCRIPTION


## Pull Request Description

Fix the fact that the extra field of no_os_uart_desc was not being populated with the maxim specific structure.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
