### PR TITLE
maxim_irq: remove from list on irq_ctrl_remove

### DIFF
--- a/drivers/platform/maxim/max32650/maxim_irq.c
+++ b/drivers/platform/maxim/max32650/maxim_irq.c
@@ -275,7 +275,7 @@ int32_t max_irq_ctrl_remove(struct no_os_irq_ctrl_desc *desc)
 		return -EINVAL;
 
 	for (uint32_t i = 0; i < NO_OS_ARRAY_SIZE(_events); i++) {
-		while (0 == no_os_list_read_first(_events[i].actions, &discard))
+		while (0 == no_os_list_get_first(_events[i].actions, &discard))
 			no_os_free(discard);
 		no_os_list_remove(_events[i].actions);
 	}

--- a/drivers/platform/maxim/max32655/maxim_irq.c
+++ b/drivers/platform/maxim/max32655/maxim_irq.c
@@ -275,7 +275,7 @@ int32_t max_irq_ctrl_remove(struct no_os_irq_ctrl_desc *desc)
 		return -EINVAL;
 
 	for (uint32_t i = 0; i < NO_OS_ARRAY_SIZE(_events); i++) {
-		while (0 == no_os_list_read_first(_events[i].actions, &discard))
+		while (0 == no_os_list_get_first(_events[i].actions, &discard))
 			no_os_free(discard);
 		no_os_list_remove(_events[i].actions);
 	}

--- a/drivers/platform/maxim/max32660/maxim_irq.c
+++ b/drivers/platform/maxim/max32660/maxim_irq.c
@@ -275,7 +275,7 @@ int32_t max_irq_ctrl_remove(struct no_os_irq_ctrl_desc *desc)
 		return -EINVAL;
 
 	for (uint32_t i = 0; i < NO_OS_ARRAY_SIZE(_events); i++) {
-		while (0 == no_os_list_read_first(_events[i].actions, &discard))
+		while (0 == no_os_list_get_first(_events[i].actions, &discard))
 			no_os_free(discard);
 		no_os_list_remove(_events[i].actions);
 	}

--- a/drivers/platform/maxim/max32665/maxim_irq.c
+++ b/drivers/platform/maxim/max32665/maxim_irq.c
@@ -275,7 +275,7 @@ int32_t max_irq_ctrl_remove(struct no_os_irq_ctrl_desc *desc)
 		return -EINVAL;
 
 	for (uint32_t i = 0; i < NO_OS_ARRAY_SIZE(_events); i++) {
-		while (0 == no_os_list_read_first(_events[i].actions, &discard))
+		while (0 == no_os_list_get_first(_events[i].actions, &discard))
 			no_os_free(discard);
 		no_os_list_remove(_events[i].actions);
 	}

--- a/drivers/platform/maxim/max32670/maxim_irq.c
+++ b/drivers/platform/maxim/max32670/maxim_irq.c
@@ -278,7 +278,7 @@ int max_irq_ctrl_remove(struct no_os_irq_ctrl_desc *desc)
 		return -EINVAL;
 
 	for (i = 0; i < NO_OS_ARRAY_SIZE(_events); i++) {
-		while (0 == no_os_list_read_first(_events[i].actions, &discard))
+		while (0 == no_os_list_get_first(_events[i].actions, &discard))
 			no_os_free(discard);
 		no_os_list_remove(_events[i].actions);
 	}

--- a/drivers/platform/maxim/max32690/maxim_irq.c
+++ b/drivers/platform/maxim/max32690/maxim_irq.c
@@ -267,7 +267,7 @@ int32_t max_irq_ctrl_remove(struct no_os_irq_ctrl_desc *desc)
 		return -EINVAL;
 
 	for (uint32_t i = 0; i < NO_OS_ARRAY_SIZE(_events); i++) {
-		while (0 == no_os_list_read_first(_events[i].actions, &discard))
+		while (0 == no_os_list_get_first(_events[i].actions, &discard))
 			free(discard);
 		no_os_list_remove(_events[i].actions);
 	}

--- a/drivers/platform/maxim/max78000/maxim_irq.c
+++ b/drivers/platform/maxim/max78000/maxim_irq.c
@@ -275,7 +275,7 @@ int32_t max_irq_ctrl_remove(struct no_os_irq_ctrl_desc *desc)
 		return -EINVAL;
 
 	for (uint32_t i = 0; i < NO_OS_ARRAY_SIZE(_events); i++) {
-		while (0 == no_os_list_read_first(_events[i].actions, &discard))
+		while (0 == no_os_list_get_first(_events[i].actions, &discard))
 			no_os_free(discard);
 		no_os_list_remove(_events[i].actions);
 	}


### PR DESCRIPTION


## Pull Request Description
Remove items from list (empty it!) when doing irq_ctrl_remove. Previously, the items were being read with no_os_list_read_first which does not remove the item being read.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
