### PR TITLE
drivers: dac: ad5791: Fix linearity compensation API

### DIFF
--- a/drivers/dac/ad5791/ad5791.c
+++ b/drivers/dac/ad5791/ad5791.c
@@ -395,7 +395,7 @@ int ad5791_set_lin_comp(struct ad5791_dev *dev,
 		return -EINVAL;
 
 	if (!v_span)
-		v_span |= NO_OS_BIT(4);
+		v_span |= NO_OS_BIT(3);
 
 	return ad5791_spi_write_mask(dev,
 				     AD5791_REG_CTRL,


### PR DESCRIPTION
Correct lin_comp API in accordance with the register map.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
