### PR TITLE
drivers: dac: ad5791: lin_comp error handling

### DIFF
--- a/drivers/dac/ad5791/ad5791.c
+++ b/drivers/dac/ad5791/ad5791.c
@@ -391,8 +391,22 @@ int ad5791_spi_write_mask(struct ad5791_dev *dev,
 int ad5791_set_lin_comp(struct ad5791_dev *dev,
 			enum ad5791_lin_comp_select v_span)
 {
-	if(!dev || (dev->act_device != ID_AD5781 && dev->act_device != ID_AD5791))
+	if(!dev)
 		return -EINVAL;
+
+	switch(dev->act_device) {
+	case ID_AD5781:
+		if (v_span != AD5781_SPAN_UPTO_10V &&
+		    v_span != AD5781_SPAN_10V_TO_20V)
+			return -EINVAL;
+		break;
+	case ID_AD5791:
+		if (v_span == AD5781_SPAN_10V_TO_20V)
+			return -EINVAL;
+		break;
+	default:
+		return -EINVAL;
+	}
 
 	if (!v_span)
 		v_span |= NO_OS_BIT(4);


### PR DESCRIPTION
## Pull Request Description

The `enum ad5791_lin_comp_select` contains values for both ad5781 and ad5791 parts with respect to the voltage spans. Altough, the only value that is valid for both parts is `AD5781_SPAN_UPTO_10V`.

Update the error handling procedure such that incorrect values are not allowed to be set, based on the device type used with the driver.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
