### PR TITLE
frequency: admv1013: add mixer_vgate corner cases

### DIFF
--- a/drivers/frequency/admv1013/admv1013.c
+++ b/drivers/frequency/admv1013/admv1013.c
@@ -136,9 +136,9 @@ static int admv1013_update_mixer_vgate(struct admv1013_dev *dev)
 {
 	unsigned int mixer_vgate;
 
-	if (dev->vcm_uv < 1800000)
+	if (dev->vcm_uv <= 1800000)
 		mixer_vgate = MIXER_GATE_0_to_1_8_V(dev->vcm_uv);
-	else if (dev->vcm_uv > 1800000 && dev->vcm_uv < 2600000)
+	else if (dev->vcm_uv > 1800000 && dev->vcm_uv <= 2600000)
 		mixer_vgate = MIXER_GATE_1_8_to_2_6_V(dev->vcm_uv);
 	else
 		return -EINVAL;


### PR DESCRIPTION
## Pull Request Description

Include the corner cases in the computation of the MIXER_VGATE register value.

According to the datasheet: The MIXER_VGATE values follows the VCM such as, that for a 0V to 1.8V VCM, MIXER_VGATE = 23.89 VCM + 81, and for a > 1.8V to 2.6V VCM, MIXER_VGATE = 23.75 VCM + 1.25.

Fixes: a306e3c ("drivers: frequency: admv1013: add support")
Link: https://lore.kernel.org/all/20230807143806.6954-1-antoniu.miclaus@analog.com/

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
