### PR TITLE
ci: cppcheck: use specific version

### DIFF
--- a/ci/cppcheck.sh
+++ b/ci/cppcheck.sh
@@ -35,7 +35,17 @@
 set -e
 
 build_cppheck() {
-	sudo apt-get install cppcheck
+	mkdir -p build
+	pushd build
+
+	# libtinyxml2-a is a dependency package for cppcheck-1.90
+	wget http://mirrors.kernel.org/ubuntu/pool/universe/t/tinyxml2/libtinyxml2-6a_7.0.0+dfsg-1build1_amd64.deb
+	sudo dpkg -i ./libtinyxml2-6a_7.0.0+dfsg-1build1_amd64.deb
+
+	wget http://mirrors.kernel.org/ubuntu/pool/universe/c/cppcheck/cppcheck_1.90-4build1_amd64.deb
+	sudo dpkg -i ./cppcheck_1.90-4build1_amd64.deb
+
+	popd
 }
 
 parse_cppcheck_options() {

--- a/drivers/frequency/hmc7044/hmc7044.c
+++ b/drivers/frequency/hmc7044/hmc7044.c
@@ -1476,7 +1476,7 @@ int32_t hmc7044_init(struct hmc7044_dev **device,
 	struct hmc7044_dev *dev;
 	int32_t ret;
 	unsigned int i;
-	struct no_os_clk_desc **clocks;
+	struct no_os_clk_desc **clocks = NULL;
 	struct no_os_clk_init_param clk_init;
 	const char *names[HMC7044_NUM_CHAN] = {
 		"clock_0", "clock_1", "clock_2", "clock_3", "clock_4",


### PR DESCRIPTION
## Pull Request Description

Download and install specific cppcheck version for the ci builds.

This should fix also the https://github.com/analogdevicesinc/EVAL-ADICUP3029 and https://github.com/analogdevicesinc/EVAL-ADICUP360 buids.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
