### PR TITLE
ci: use all cpu cores

### DIFF
--- a/ci/astyle.sh
+++ b/ci/astyle.sh
@@ -96,7 +96,7 @@ build_astyle() {
 		wget --no-check-certificate "https://sourceforge.net/projects/astyle/files/astyle/astyle 3.1/astyle_3.1_linux.tar.gz"
 		tar -xzf astyle_3.1_linux.tar.gz
 		pushd ./astyle/build/gcc
-		make -j3
+		make -j${NUM_JOBS}
 		popd
 		popd
 	fi
@@ -106,7 +106,7 @@ run_astyle() {
 	git diff --name-only --diff-filter=d $COMMIT_RANGE | while read -r file; do
 		if is_source_file "$file" && is_valid_file "$file"
 		then
-			./build/astyle/build/gcc/bin/astyle --options="$(get_script_path astyle_config)" "$file"
+			./build/astyle/build/gcc/bin/astyle -j${NUM_JOBS} --options="$(get_script_path astyle_config)" "$file"
 		fi
 	done;
 

--- a/ci/cppcheck.sh
+++ b/ci/cppcheck.sh
@@ -54,7 +54,7 @@ parse_cppcheck_options() {
 }
 
 run_cppcheck() {
-	cppcheck --quiet --force --error-exitcode=1 $CPPCHECK_OPTIONS .
+	cppcheck -j${NUM_JOBS} --quiet --force --error-exitcode=1 $CPPCHECK_OPTIONS .
 }
 
 build_cppheck

--- a/ci/documentation.sh
+++ b/ci/documentation.sh
@@ -37,7 +37,7 @@
 ############################################################################
 build_doxygen() {
         pushd ${TOP_DIR}/doc/doxygen
-        (cd build && ! make doc 2>&1 | grep -E "warning:|error:") || {
+        (cd build && ! make -j${NUM_JOBS} doc 2>&1 | grep -E "warning:|error:") || {
                 echo_red "Documentation incomplete or errors in the generation of it have occured!"
                 exit 1
         }
@@ -49,7 +49,7 @@ build_doxygen() {
 build_sphinx() {
         pushd ${TOP_DIR}/doc/sphinx
 
-        sphinx-build -W ./source/ ./build
+        sphinx-build -j${NUM_JOBS} -W ./source/ ./build
 
         popd
 }

--- a/ci/run_build.sh
+++ b/ci/run_build.sh
@@ -39,6 +39,7 @@ sudo apt-get update
 
 TOP_DIR="$(pwd)"
 DEPS_DIR="${TOP_DIR}/deps"
+NUM_JOBS=$(nproc)
 
 . ./ci/lib.sh
 
@@ -53,7 +54,7 @@ build_cppcheck() {
 build_drivers() {
     sudo apt-get install gcc-arm-none-eabi libnewlib-arm-none-eabi
     git submodule update --init libraries/iio/libtinyiiod
-    make -C ./drivers -f Makefile -j
+    make -j${NUM_JOBS} -C ./drivers -f Makefile
 }
 
 build_documentation() {


### PR DESCRIPTION
## Pull Request Description

Add NUM_JOBS variable holding the available number of cpu cores on a build agent.

Use all avaliable cores for all ci builds.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
