### PR TITLE
drivers: frequency: hmc7044: use no_os_calloc

### DIFF
--- a/drivers/frequency/hmc7044/hmc7044.c
+++ b/drivers/frequency/hmc7044/hmc7044.c
@@ -1493,11 +1493,11 @@ int32_t hmc7044_init(struct hmc7044_dev **device,
 		return ret;
 
 	if (init_param->export_no_os_clk) {
-		clocks = malloc(HMC7044_NUM_CHAN * sizeof(struct no_os_clk_desc *));
+		clocks = no_os_calloc(HMC7044_NUM_CHAN, sizeof(struct no_os_clk_desc *));
 		if (!clocks)
 			return -1;
 		for (i = 0; i < HMC7044_NUM_CHAN; i++) {
-			clocks[i] = malloc(sizeof(struct no_os_clk_desc));
+			clocks[i] = no_os_calloc(1, sizeof(struct no_os_clk_desc));
 			if (!clocks[i])
 				return -1;
 			/* Initialize clk component */


### PR DESCRIPTION
## Pull Request Description

Switch to using no_os dedicated memory allocation functions.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
