### PR TITLE
ci: drop -j parameter for the astyle command

### DIFF
--- a/ci/astyle.sh
+++ b/ci/astyle.sh
@@ -106,7 +106,7 @@ run_astyle() {
 	git diff --name-only --diff-filter=d $COMMIT_RANGE | while read -r file; do
 		if is_source_file "$file" && is_valid_file "$file"
 		then
-			./build/astyle/build/gcc/bin/astyle -j${NUM_JOBS} --options="$(get_script_path astyle_config)" "$file"
+			./build/astyle/build/gcc/bin/astyle --options="$(get_script_path astyle_config)" "$file"
 		fi
 	done;
 


### PR DESCRIPTION
## Pull Request Description

Astyle command does not support -j<nr_of_threads> option.

The -j option is actually a shortcut for `--add-braces` option for
astyle tool.

Threrefore drop it.

Fixes: 8c5e44f ("ci: use all cpu cores")

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
