### PR TITLE
drivers: digital-io: max149x6 : Fix driver remove function

### DIFF
--- a/drivers/digital-io/max149x6/max14916.c
+++ b/drivers/digital-io/max149x6/max14916.c
@@ -238,66 +238,72 @@ int max14916_init(struct max149x6_desc **desc,
 	ret = no_os_gpio_get_optional(&descriptor->fault_gpio,
 				      param->fault_gpio_param);
 	if (ret)
-		goto spi_err;
+		goto gpio_err;
 
 	if (descriptor->fault_gpio) {
 		ret = no_os_gpio_direction_input(descriptor->fault_gpio);
 		if (ret)
-			goto gpio_err;
+			goto fault_gpio_err;
 	}
 
 	ret = no_os_gpio_get_optional(&descriptor->ready_gpio,
 				      param->ready_gpio_param);
 	if (ret)
-		goto spi_err;
+		goto fault_gpio_err;
 
 	if (descriptor->ready_gpio) {
 		ret = no_os_gpio_direction_input(descriptor->ready_gpio);
 		if (ret)
-			goto gpio_err;
+			goto ready_gpio_err;
 	}
 
 	ret = no_os_gpio_get_optional(&descriptor->synch_gpio,
 				      param->synch_gpio_param);
 	if (ret)
-		goto spi_err;
+		goto ready_gpio_err;
 
 	if (descriptor->synch_gpio) {
 		ret = no_os_gpio_direction_output(descriptor->synch_gpio,
 						  NO_OS_GPIO_HIGH);
 		if (ret)
-			goto gpio_err;
+			goto synch_gpio_err;
 	}
 
 	/* Clear the latched faults generated at power up */
 	ret = max149x6_reg_read(descriptor, MAX14916_OVR_LD_REG, &reg_val);
 	if (ret)
-		goto gpio_err;
+		goto synch_gpio_err;
 
 	ret = max149x6_reg_read(descriptor, MAX14916_OW_OFF_FAULT_REG,
 				&reg_val);
 	if (ret)
-		goto gpio_err;
+		goto synch_gpio_err;
 
 	ret = max149x6_reg_read(descriptor, MAX14916_SHD_VDD_FAULT_REG,
 				&reg_val);
 	if (ret)
-		goto gpio_err;
+		goto synch_gpio_err;
 
 	ret = max149x6_reg_read(descriptor, MAX14916_GLOB_ERR_REG, &reg_val);
 	if (ret)
-		goto gpio_err;
+		goto synch_gpio_err;
 
 	for(i = 0; i < MAX14916_CHANNELS; i++) {
 		ret = max14916_ch_set(descriptor, i, 0);
 		if (ret)
-			goto err;
+			goto synch_gpio_err;
 	}
 
 	*desc = descriptor;
 
 	return 0;
 
+synch_gpio_err:
+	no_os_gpio_remove(descriptor->synch_gpio);
+ready_gpio_err:
+	no_os_gpio_remove(descriptor->ready_gpio);
+fault_gpio_err:
+	no_os_gpio_remove(descriptor->fault_gpio);
 gpio_err:
 	no_os_gpio_remove(descriptor->en_gpio);
 spi_err:
@@ -319,8 +325,10 @@ int max14916_remove(struct max149x6_desc *desc)
 
 	no_os_spi_remove(desc->comm_desc);
 
-	if (desc->en_gpio)
-		no_os_gpio_remove(desc->en_gpio);
+	no_os_gpio_remove(desc->en_gpio);
+	no_os_gpio_remove(desc->fault_gpio);
+	no_os_gpio_remove(desc->ready_gpio);
+	no_os_gpio_remove(desc->synch_gpio);
 
 	no_os_free(desc);
 


### PR DESCRIPTION
## PR Description
Call API to remove all GPIOs of the max149x6 descriptor in the max14906 and max14916 remove functions.
To be merged before #1941

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
