### PR TITLE
iio_axi_adc: Allow custom scan type

### DIFF
--- a/drivers/axi_core/iio_axi_adc/iio_axi_adc.h
+++ b/drivers/axi_core/iio_axi_adc/iio_axi_adc.h
@@ -72,6 +72,8 @@ struct iio_axi_adc_desc {
 	struct iio_device dev_descriptor;
 	/** Channel names */
 	char (*ch_names)[20];
+	/** Custom data format */
+	struct scan_type *scan_type_common;
 };
 
 /**
@@ -88,6 +90,8 @@ struct iio_axi_adc_init_param {
 	/** Custom sampling frequency getter */
 	int (*get_sampling_frequency)(struct axi_adc *dev, uint32_t chan,
 				      uint64_t *sampling_freq_hz);
+	/** Custom data format (unpopulated if not used, set to default) */
+	struct scan_type *init_scan_type;
 };
 
 /******************************************************************************/


### PR DESCRIPTION
## Pull Request Description

Allow the setting of custom scan type for the AXI ADC channels.

Until now, only a fixed setting of 16 realbists and storagebits was possible.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
