### PR TITLE
ci: documentation: add extra sphinx checks

### DIFF
--- a/ci/documentation.sh
+++ b/ci/documentation.sh
@@ -32,6 +32,67 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+. ./ci/lib.sh
+
+COMMIT_RANGE="$1"
+
+#################################################################
+# Check if the sphinx documentation is properly linked to the ToC
+#################################################################
+check_sphinx_doc() {
+        if [ -z "$COMMIT_RANGE" ]
+	then
+		COMMIT_RANGE="${COMMIT_RANGE}"
+	fi
+
+	if [ -z "$COMMIT_RANGE" ]  && [ -n "$TARGET_BRANCH" ]
+	then
+		git fetch --depth=50 origin $TARGET_BRANCH
+		git branch $TARGET_BRANCH origin/$TARGET_BRANCH
+		COMMIT_RANGE="${TARGET_BRANCH}.."
+	fi
+
+	if [ -z "$COMMIT_RANGE" ]
+	then
+		echo_green "Using only latest commit, since there is no Pull Request"
+		COMMIT_RANGE=HEAD~1
+	fi
+
+        if ! git rev-parse $COMMIT_RANGE ; then
+		echo_red "Failed to parse commit range '$COMMIT_RANGE'"
+		echo_green "Using only latest commit"
+		COMMIT_RANGE=HEAD~1
+	fi
+
+        git diff --name-only --diff-filter=d $COMMIT_RANGE | while read -r file
+        do
+                if [ $(basename "$file") = "README.rst" ]
+                then
+                        errors_found=0
+                        local fn_dir=$(basename "$(dirname "$file")")
+                        local sphinx_path="doc/sphinx/source"
+                        local top_dir=$(echo "$file" | cut -d'/' -f1)
+
+                        if ! [ -f "$sphinx_path/$top_dir/$fn_dir.rst" ];
+                        then
+                                echo_red "Missing $fn_dir.rst file at $sphinx_path/$top_dir"
+                                erros_found=1
+                        fi
+
+                        if ! grep -q "$top_dir/$fn_dir" "$sphinx_path/${top_dir}_doc.rst"
+                        then
+                                echo_red "Missing $top_dir/$fn_dir link inside $sphinx_path/${top_dir}_doc.rst"
+                                erros_found=1
+                        fi
+
+                        if [ $erros_found -eq 1 ]
+                        then
+                                exit 1
+                        fi
+                fi
+        done
+}
+
 ############################################################################
 # Check if the documentation will be generated w/o warnings or errors
 ############################################################################
@@ -114,6 +175,8 @@ update_gh_pages() {
                 echo_green "Documentation will be updated when this commit gets on master!"
         fi
 }
+
+check_sphinx_doc
 
 build_sphinx
 


### PR DESCRIPTION
## Pull Request Description

When a README.rst file is created/modified for a specific driver or project, the documentation CI checks if also the links to the table of contents are properly handled.

If no link is found under drivers_doc.rst or projects_doc.rst for that specific driver/project, the documentation fails.

If no .rst file is found for including the driver/project README.rst specific file, the documentation build fails.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
