### PR TITLE
ci: move NUM_JOBS variable to lib.sh

### DIFF
--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -34,6 +34,7 @@
 #List of excluded driver folders for the documentation generation.
 
 COMMON_SCRIPTS="astyle.sh astyle_config cppcheck.sh"
+NUM_JOBS=$(nproc)
 
 get_script_path() {
 	local script="$1"

--- a/ci/run_build.sh
+++ b/ci/run_build.sh
@@ -39,7 +39,6 @@ sudo apt-get update
 
 TOP_DIR="$(pwd)"
 DEPS_DIR="${TOP_DIR}/deps"
-NUM_JOBS=$(nproc)
 
 . ./ci/lib.sh
 


### PR DESCRIPTION
## Pull Request Description

The common scripts from lib.sh are using also NUM_JOBS variable when propagated on other repositories which download and use these scripts. (EVAL-ADICUP3029, EVAL-ADICUP360, libtinyiiod, etc.)

Make sure that the variable is populated on other repositories too.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
