### PR TITLE
drivers: accel: adxl345: Read correct value for inact ctl

### DIFF
--- a/drivers/accel/adxl345/adxl345.c
+++ b/drivers/accel/adxl345/adxl345.c
@@ -470,7 +470,7 @@ void adxl345_set_inactivity_detection(struct adxl345_dev *dev,
 	uint8_t new_int_enable = 0;
 
 	old_act_inact_ctl = adxl345_get_register_value(dev,
-			    ADXL345_INT_ENABLE);
+			    ADXL345_ACT_INACT_CTL);
 	new_act_inact_ctl = old_act_inact_ctl & ~(ADXL345_INACT_ACDC |
 			    ADXL345_INACT_X_EN |
 			    ADXL345_INACT_Y_EN |


### PR DESCRIPTION
Read from ADXL345_ACT_INACT_CTL instead of ADXL345_INT_ENABLE register address to obtain the state of inactivity control register in adxl345_set_inactivity_detection API.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
