### PR TITLE
ci: lib.sh: drop download scripts function call

### DIFF
--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -93,5 +93,3 @@ download_common_scripts() {
 			-O build/$script
 	done
 }
-
-download_common_scripts


### PR DESCRIPTION
## Pull Request Description

Remove the `download_common_scripts` function call.

The function should be called only on the repositories that actually need it.

The no-OS repository holds the scripts already, therefore downloading them again is redundant.

This should be merged preferably after:
https://github.com/analogdevicesinc/EVAL-ADICUP360/pull/33
https://github.com/analogdevicesinc/EVAL-ADICUP3029/pull/115
https://github.com/analogdevicesinc/m1k-fw/pull/35
https://github.com/analogdevicesinc/arduino/pull/34
https://github.com/analogdevicesinc/libtinyiiod/pull/49

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
