### PR TITLE
drivers: digital-io: max22196 : Fix API call in driver source file

### DIFF
--- a/drivers/digital-io/max22196/max22196.c
+++ b/drivers/digital-io/max22196/max22196.c
@@ -358,7 +358,7 @@ int max22196_fault_mask_get(struct max22196_desc *desc,
 
 	switch (fault_mask) {
 	case MAX22196_GLOBAL_REFDISHTCFG:
-		ret = max22190_reg_read(desc, MAX22196_GLOBALCFG_REG, &reg_val);
+		ret = max22196_reg_read(desc, MAX22196_GLOBALCFG_REG, &reg_val);
 		if (ret)
 			return ret;
 		*enabled = no_os_field_get(desc, MAX22196_FAULT_MASK(fault_mask));


### PR DESCRIPTION
## Pull Request Description

In the driver's source file there is a typo in the fault_mask_get function and max22190_reg_read is called
instead of max22196_reg_read.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
