### PR TITLE
ci: lib: move ensure command exists to run_build

### DIFF
--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -75,8 +75,6 @@ ensure_command_exists() {
 	return 1
 }
 
-ensure_command_exists sudo
-
 echo_red() { printf "\033[1;31m$*\033[m\n"; }
 echo_green() { printf "\033[1;32m$*\033[m\n"; }
 

--- a/ci/run_build.sh
+++ b/ci/run_build.sh
@@ -42,6 +42,8 @@ DEPS_DIR="${TOP_DIR}/deps"
 
 . ./ci/lib.sh
 
+ensure_command_exists sudo
+
 build_astyle() {
     . ./ci/astyle.sh
 }


### PR DESCRIPTION
There is no need to call ensure_command_exists sudo in lib.sh

Move it to run_build.sh which calls subsequent scripts that actually use sudo.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
