### PR TITLE
drivers:platform:stm32:Fixes to Prescaler calculation

### DIFF
--- a/drivers/platform/stm32/stm32_pwm.c
+++ b/drivers/platform/stm32/stm32_pwm.c
@@ -107,7 +107,7 @@ static int32_t stm32_init_timer(struct stm32_pwm_desc *desc,
 	if (sparam->get_timer_clock) {
 		timer_frequency_hz = sparam->get_timer_clock();
 		timer_frequency_hz *= sparam->clock_divider;
-		timer_frequency_hz /= NO_OS_BIT(sparam->prescaler);
+		timer_frequency_hz /= sparam->prescaler;
 		period = _compute_period_ticks(desc, timer_frequency_hz, param->period_ns);
 	} else {
 		period = PWM_DEFAULT_PERIOD - 1;

--- a/drivers/platform/stm32/stm32_pwm.h
+++ b/drivers/platform/stm32/stm32_pwm.h
@@ -69,7 +69,7 @@ enum TimOCMode {
  * @brief Structure holding the STM32 PWM parameters.
  */
 struct stm32_pwm_init_param {
-	/** Timer prescaler */
+	/** Timer prescaler (0 to 0xFFFF) */
 	uint32_t prescaler;
 	/** Timer autoreload enable */
 	bool timer_autoreload;


### PR DESCRIPTION
The value of prescaler can be anything from 0 to 0xFFFF. Application of NO_OS_BIT() to the prescaler value changes the logic behind prescaler calculation.

Fixes: 9264d8983c4e434affd171c7e6b394826089fdb0 ("stm32 pwm support")

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
