### PR TITLE
scripts: generic.mk: Use NO-OS instead of relative path

### DIFF
--- a/tools/scripts/generic.mk
+++ b/tools/scripts/generic.mk
@@ -237,9 +237,9 @@ CPPFLAGS_FILE = $(BUILD_DIR)/$(PROJECT_NAME)-cppflags.txt
 ASFLAGS_FILE = $(BUILD_DIR)/$(PROJECT_NAME)-asflags.txt
 
 # Prepare for VS Code Debug Intellisense applied at target $(PROJECT_TARGET)_configure - depends on a complete CFLAGS
-include ../../tools/scripts/vsc_intellisense.mk
+include $(NO-OS)/tools/scripts/vsc_intellisense.mk
 # Prepare for VS Code Debug config applied at target $(PROJECT_TARGET)_configure
-include ../../tools/scripts/vsc_openocd_debug.mk
+include $(NO-OS)/tools/scripts/vsc_openocd_debug.mk
 
 #------------------------------------------------------------------------------
 #                             Generic Goals                         


### PR DESCRIPTION
Use NO-OS path value instead of relative path in generic.mk
reported here: https://github.com/analogdevicesinc/no-OS/issues/2012  

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
