### PR TITLE
drivers: digital-io: max22200 : Add driver support for MAX22200

### DIFF
--- a/doc/sphinx/source/drivers/max22200.rst
+++ b/doc/sphinx/source/drivers/max22200.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../drivers/digital-io/max22200/README.rst

--- a/doc/sphinx/source/drivers_doc.rst
+++ b/doc/sphinx/source/drivers_doc.rst
@@ -26,6 +26,7 @@ DIGITAL INPUT/OUTPUT
    drivers/max149x6
    drivers/max22190
    drivers/max22196
+   drivers/max22200
 
 INERTIAL MEASUREMENT UNITS
 ==========================

--- a/drivers/digital-io/max22200/README.rst
+++ b/drivers/digital-io/max22200/README.rst
@@ -1,0 +1,243 @@
+MAX22200 no-OS driver
+=====================
+
+Supported Devices
+-----------------
+
+`MAX22200 <https://www.analog.com/MAX22200>`
+
+Overview
+--------
+
+The MAX22200 is an octal 36V serial-controlled solenoid driver.
+Each channel features a low impedance (200mΩ typ) push-pull output stage with 
+sink-and-source driving capability and up to 1ARMS driving current. 
+A serial interface (SPI) that also supports daisy-chain configurations is 
+provided to individually control each channel.
+
+Applications
+------------
+
+* Relays Driver
+* Solenoid, Valves, Electromagnetic Drivers
+* Generic Low-Side and High-Side Switch Applications
+* Latched (Bi-Stable) Solenoid Valve Drivers
+* Brushed DC Motor Driver
+
+MAX22200 Device Configuration
+-----------------------------
+
+In order to use the MAX22200, you will have to provide support for the
+communication protocol (SPI), but also a GPIO for the CMD pin since before every
+SPI transaction  there needs to be a SPI write to the Command Register while
+CMD pin is logic high, and then performing the actual SPI transaction with CMD
+pin logic low.
+Also the ENABLE pin needs to be logic high for the device to be able to be
+initialized.
+
+The first API to be called is **max22200_init**. Make sure that it returns 0,
+which means that the driver was initialized correctly.
+
+Chopping frequency can also be changed with **max22200_set_chop_freq**.
+
+External trigger configuration
+------------------------------
+
+An external trigger can be assigned to the TRIG pin, but in order for that to
+work a GPIO initalization parameter for the trig pin needs to be set so the GPIO
+is initialized and controlled by the master.
+This can be used in both Half and Full Bridge modes for applications like
+DC motor drivers.
+
+The state of the trigger can be change with the help of
+**max22200_set_trig_state** API.
+
+Channel configuration
+---------------------
+
+Each channel can be configured in a lot of ways, but the first one of all is
+the **max22200_set_ch_state** which is to be called by the user after the
+initialization is performed correctly in order to activate a specific channel.
+
+After that the channel's configuration can be changed on-the-fly.
+
+HIT time and current can be changed with **max22200_set_ch_hit**.
+HOLD current can be changed with **max222000_set_ch_hold**.
+
+Scale can be set for a channel with **max22200_set_ch_scale** which for
+half the fullscale will double the resistor and the current will be reduced
+to half.
+
+Channel trigger can be changed to be either controlled by the SPI interface
+or the external trigger with **max22200_set_ch_trig**.
+
+Channel mode and frequency can also be set with the help of
+**max22200_set_ch_mode** and **max22200_set_ch_freq**.
+
+And at last for every channel there are some specific enables that the user
+can enable/disable with the help of **max22200_set_ch_enable**.
+
+For every API to set a channel configuration in the CFG CH register there is
+also a API to get a channel configuration form the CFG CH register.
+
+Fault mask configuration
+------------------------
+
+Fault masks can be set for the whole device in the STATUS register with the
+help of **max22200_fault_mask_set**, and read with **max22200_fault_mask_get**.
+
+DPM configuration
+-----------------
+
+Detection of plunger movement can be configured as well with the help of the
+**max22200_set_cfg_dpm** where the user can set specific values for the DPM.
+The same specific values can be read with the help of **max22200_get_cfg_dpm**.
+
+MAX22200 Driver Initialization Example
+--------------------------------------
+
+.. code-block:: bash
+
+	struct max22200_desc *max22200;
+	struct no_os_spi_init_param spi_ip = {
+		.device_id = 0,
+		.extra = &max22200_spi_extra,
+		.max_speed_hz = 100000,
+		.platform_ops = &max_spi_ops,
+		.chip_select = 0,
+	};
+	struct no_os_gpio_init_param cmd_ip = {
+		.port = 0,
+		.pull = NO_OS_PULL_NONE,
+		.number = 5,
+		.platform_ops = &max_gpio_ops,
+		.extra = &max22200_gpio_extra,
+	};
+	struct max22200_init_param max22200_ip = {
+		.comm_desc = &spi_ip,
+		.cmd_param = &cmd_ip,
+		.ch_config = {
+		MAX22200_INDEPENDENT_MODE,
+		MAX22200_INDEPENDENT_MODE,
+		MAX22200_INDEPENDENT_MODE,
+		MAX22200_INDEPENDENT_MODE,
+		}
+	};
+
+	ret = max22200_init(&max22200, &max22200_ip);
+	if (ret)
+		goto error;
+
+Basic Example Channel Configuration Table
+-----------------------------------------
+
++---------+---------+----------------+-------+------+-----------+-------+---------+
+| Channel |  State  | Operation Mode | Drive | Side | Frequency | Scale | Trigger |
++---------+---------+----------------+-------+------+-----------+-------+---------+
+|  OUT0   | Enabled |  HALF-BRIDGE   |  CDR  |  LS  |   40KHz   |   FS  |   SPI   |
++---------+---------+----------------+-------+------+-----------+-------+---------+
+|  OUT1   | Enabled |  HALF-BRIDGE   |  CDR  |  LS  |   40KHz   |   FS  |   SPI   |
++---------+---------+----------------+-------+------+-----------+-------+---------+
+|  OUT2   |Disabled |  INDEPENDENT   |  CDR  |  LS  |   80KHz   |   FS  |   SPI   |
++---------+---------+----------------+-------+------+-----------+-------+---------+
+|  OUT3   |Disabled |  INDEPENDENT   |  CDR  |  LS  |   80KHZ   |   FS  |   SPI   | 
++---------+---------+----------------+-------+------+-----------+-------+---------+
+|  OUT4   |Disabled |  INDEPENDENT   |  CDR  |  LS  |   80KHZ   |   FS  |   SPI   |
++---------+---------+----------------+-------+------+-----------+-------+---------+
+|  OUT5   |Disabled |  INDEPENDENT   |  CDR  |  LS  |   80KHZ   |   FS  |   SPI   |
++---------+---------+----------------+-------+------+-----------+-------+---------+
+|  OUT6   |Disabled |  INDEPENDENT   |  CDR  |  LS  |   80KHZ   |   FS  |   SPI   |
++---------+---------+----------------+-------+------+-----------+-------+---------+
+|  OUT7   |Disabled |  INDEPENDENT   |  CDR  |  LS  |   80KHZ   |   FS  |   SPI   |
++---------+---------+----------------+-------+------+-----------+-------+---------+
+
+MAX22200 no-OS IIO support
+--------------------------
+
+Channel Attributes
+------------------
+
+* raw - state of the channel.
+* scale - scale of the channel.
+* scale_available - available scales for the channel.
+* hit_current - HIT current to be set in the CFG_CH register.
+* hit_time - HIT time to be set in the CFG_CH register.
+* hold_current - HOLD current to be set in the CFG_CH register.
+* channel_trig - ONCH_SPI/EXT_TRIG trigger selection for the channel.
+* channel_trig_available - available trigger for the channel.
+* channel_drive - Channel's voltage or current drive.
+* channel_drive_available - Channel available drives.
+* channel_side - LOW/HIGH SIDE selection for the channel.
+* channel_side_available - Available sides for the channel.
+* channel_op_mode - Channel operation mode selection.
+* channel_op_mode_available - Channel operation modes available for the channel.
+* channel_freq - Channel frequency to be selected. Calculated using the device frequency.
+* channel_freq_available - Channel frequencies available for the channel.
+* slew_rate_control - Slew Rate Control enable/disable.
+* open_load_detection - Open Load Detection enable/disable.
+* dpm_enable - Detection of Plunger Movement enable/disable.
+* hit_current_check - HIT current check enable/disable.
+
+Global Attributes
+-----------------
+
+* chopping_frequency - Chopping frequency selection.
+* chopping_frequency_available  Chopping frequencies available for the device.
+* external_trig_state - External trigger's state (enabled = 1/disabled = 0).
+
+Debug Attributes
+----------------
+
+* thermal_protection_mask - Mask for the thermal protection of the device.
+* overcurrent_protection_mask - Mask for the overcurrent protection of the device.
+* open_load_mask - Mask for the open load detection of the device.
+* hit_current_fault_mask - Mask for the hit current fault of the device.
+* dpm_fault_mask - Mask for the detection of plunger movement fault of the device.
+* com_err_mask - Mask for the communication error detection of the device.
+* uvlo_mask - Mask for the Undervoltage Low detection of the device.
+
+Device Channels
+---------------
+
+MAX22200 has a specific API, **max22200_iio_setup_channels** for configuring the
+channels at the initialization, therefore the channels can be configured as  
+enabled/disabled and attributes are assigned to each channel (if enabled).
+
+MAX22200 IIO Driver Initialization Example
+------------------------------------------
+
+.. code-block:: bash
+
+	struct max22200_iio_desc *max22200_iio_desc;
+	struct max22200_iio_desc_init_param max22200_iio_ip = {
+		.max22200_init_param = &max22200_ip,
+		.ch_enable = {
+			true, false, false, false, false, false, false, false
+		},
+	};
+
+	struct iio_app_desc *app;
+	struct iio_app_init_param app_init_param = { 0 };
+
+	ret = max22200_iio_init(&max22200_iio_desc, &max22200_iio_ip);
+	if (ret)
+		goto exit;
+
+	struct iio_app_device iio_devices[] = {
+		{
+			.name = "max22200",
+			.dev = max22200_iio_desc,
+			.dev_descriptor = max22200_iio_desc->iio_dev,
+			.read_buff = NULL,
+		},
+	};
+
+	app_init_param.devices = iio_devices;
+	app_init_param.nb_devices = NO_OS_ARRAY_SIZE(iio_devices);
+	app_init_param.uart_init_params = max22200_uart_ip;
+
+	ret = iio_app_init(&app, app_init_param);
+	if (ret)
+		goto remove_iio_max22200;
+
+	ret = iio_app_run(app);

--- a/drivers/digital-io/max22200/iio_max22200.c
+++ b/drivers/digital-io/max22200/iio_max22200.c
@@ -1,0 +1,1096 @@
+/***************************************************************************//**
+ *   @file   iio_max22200.c
+ *   @brief  Source file of IIO MAX22200 Driver.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include "no_os_alloc.h"
+#include "no_os_error.h"
+#include "no_os_units.h"
+#include "no_os_util.h"
+
+#include "iio_max22200.h"
+
+#define MAX22200_CHANNEL(_addr)		\
+	{				\
+		.ch_type = IIO_VOLTAGE,	\
+		.indexed = true,	\
+		.channel = _addr,	\
+		.address = _addr,	\
+	}
+
+static int max22200_iio_read_raw(void *dev, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel,
+				 intptr_t priv);
+
+static int max22200_iio_write_raw(void *dev, char *buf, uint32_t len,
+				  const struct iio_ch_info *channel,
+				  intptr_t priv);
+
+static int max22200_iio_read_scale(void *dev, char *buf, uint32_t len,
+				   const struct iio_ch_info *channel,
+				   intptr_t priv);
+
+static int max22200_iio_read_hit(void *dev, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel,
+				 intptr_t priv);
+
+static int max22200_iio_read_hold(void *dev, char *buf, uint32_t len,
+				  const struct iio_ch_info *channel,
+				  intptr_t priv);
+
+static int max22200_iio_read_channel_trig(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv);
+
+static int max22200_iio_read_ch_mode(void *dev, char *buf, uint32_t len,
+				     const struct iio_ch_info *channel,
+				     intptr_t priv);
+
+static int max22200_iio_read_channel_freq(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv);
+
+static int max22200_iio_read_enable(void *dev, char *buf, uint32_t len,
+				    const struct iio_ch_info *channel,
+				    intptr_t priv);
+
+static int max22200_iio_read_fault_mask(void *dev, char *buf, uint32_t len,
+					const struct iio_ch_info *channel,
+					intptr_t priv);
+
+static int max22200_iio_read_chopping_freq(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv);
+
+static int max22200_iio_read_available(void *dev, char *buf, uint32_t len,
+				       const struct iio_ch_info *channel,
+				       intptr_t priv);
+
+static int max22200_iio_reg_read(struct max22200_iio_desc *, uint32_t,
+				 uint32_t *);
+
+static int max22200_iio_write_ch_mode(void *dev, char *buf, uint32_t len,
+				      const struct iio_ch_info *channel,
+				      intptr_t priv);
+
+static int max22200_iio_write_enable(void *dev, char *buf, uint32_t len,
+				     const struct iio_ch_info *channel,
+				     intptr_t priv);
+
+static int max22200_iio_write_fault_mask(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv);
+
+static int max22200_iio_write_trig_state(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv);
+
+static int max22200_iio_write_chopping_freq(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv);
+
+static int max22200_iio_write_ch_avail_attrs(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv);
+
+static int max22200_iio_write_channel_attrs(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv);
+
+static int max22200_iio_reg_write(struct max22200_iio_desc *, uint32_t,
+				  uint32_t);
+
+static struct iio_attribute max22200_attrs[] = {
+	{
+		.name = "raw",
+		.show = max22200_iio_read_raw,
+		.store = max22200_iio_write_raw
+	},
+	{
+		.name = "scale",
+		.show = max22200_iio_read_scale,
+		.store = max22200_iio_write_ch_avail_attrs,
+		.priv = MAX22200_IIO_SCALE
+	},
+	{
+		.name = "scale_available",
+		.show = max22200_iio_read_available,
+		.priv = MAX22200_IIO_SCALE_AVAILABLE,
+		.shared = IIO_SHARED_BY_ALL
+	},
+	{
+		.name = "hit_current",
+		.show = max22200_iio_read_hit,
+		.store = max22200_iio_write_channel_attrs,
+		.priv = MAX22200_IIO_HIT_CURRENT
+	},
+	{
+		.name = "hit_time",
+		.show = max22200_iio_read_hit,
+		.store = max22200_iio_write_channel_attrs,
+		.priv = MAX22200_IIO_HIT_TIME
+	},
+	{
+		.name = "hold_current",
+		.show = max22200_iio_read_hold,
+		.store = max22200_iio_write_channel_attrs,
+		.priv = MAX22200_IIO_HOLD_CURRENT
+	},
+	{
+		.name = "channel_trig",
+		.show = max22200_iio_read_channel_trig,
+		.store = max22200_iio_write_ch_avail_attrs,
+		.priv = MAX22200_IIO_CH_TRIG
+	},
+	{
+		.name = "channel_trig_available",
+		.show = max22200_iio_read_available,
+		.priv = MAX22200_IIO_CH_TRIG_AVAILABLE,
+		.shared = IIO_SHARED_BY_ALL
+	},
+	{
+		.name = "channel_drive",
+		.show = max22200_iio_read_ch_mode,
+		.store = max22200_iio_write_ch_mode,
+		.priv = MAX22200_IIO_CH_DRIVE
+	},
+	{
+		.name = "channel_drive_available",
+		.show = max22200_iio_read_available,
+		.priv = MAX22200_IIO_CH_DRIVE_AVAILABLE,
+		.shared = IIO_SHARED_BY_ALL
+	},
+	{
+		.name = "channel_side",
+		.show = max22200_iio_read_ch_mode,
+		.store = max22200_iio_write_ch_mode,
+		.priv = MAX22200_IIO_CH_SIDE
+	},
+	{
+		.name = "channel_side_available",
+		.show = max22200_iio_read_available,
+		.priv = MAX22200_IIO_CH_SIDE_AVAILABLE,
+		.shared = IIO_SHARED_BY_ALL
+	},
+	{
+		.name = "channel_op_mode",
+		.show = max22200_iio_read_ch_mode,
+		.store = max22200_iio_write_ch_mode,
+		.priv = MAX22200_IIO_CH_OP_MODE
+	},
+	{
+		.name = "channel_op_mode_available",
+		.show = max22200_iio_read_available,
+		.priv = MAX22200_IIO_CH_OP_MODE_AVAILABLE,
+		.shared = IIO_SHARED_BY_ALL
+	},
+	{
+		.name = "channel_freq",
+		.show = max22200_iio_read_channel_freq,
+		.store = max22200_iio_write_ch_avail_attrs,
+		.priv = MAX22200_IIO_CH_FREQ
+	},
+	{
+		.name = "channel_freq_available",
+		.show = max22200_iio_read_available,
+		.priv = MAX22200_IIO_CH_FREQ_AVAILABLE,
+		.shared = IIO_SHARED_BY_ALL
+	},
+	{
+		.name = "slew_rate_control",
+		.show = max22200_iio_read_enable,
+		.store = max22200_iio_write_enable,
+		.priv = MAX22200_SRC
+	},
+	{
+		.name = "open_load_detection",
+		.show = max22200_iio_read_enable,
+		.store = max22200_iio_write_enable,
+		.priv = MAX22200_OL_ENABLE
+	},
+	{
+		.name = "dpm_enable",
+		.show = max22200_iio_read_enable,
+		.store = max22200_iio_write_enable,
+		.priv = MAX22200_DPM_ENABLE
+	},
+	{
+		.name = "hit_currrent_check",
+		.show = max22200_iio_read_enable,
+		.store = max22200_iio_write_enable,
+		.priv = MAX22200_HHF_ENABLE
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_attribute max22200_debug_attrs[] = {
+	{
+		.name = "thermal_protection_mask",
+		.show = max22200_iio_read_fault_mask,
+		.store = max22200_iio_write_fault_mask,
+		.priv = MAX22200_M_OVT
+	},
+	{
+		.name = "overcurrent_protection_mask",
+		.show = max22200_iio_read_fault_mask,
+		.store = max22200_iio_write_fault_mask,
+		.priv = MAX22200_M_OCP
+	},
+	{
+		.name = "open_load_mask",
+		.show = max22200_iio_read_fault_mask,
+		.store = max22200_iio_write_fault_mask,
+		.priv = MAX22200_M_OLF
+	},
+	{
+		.name = "hit_current_fault_mask",
+		.show = max22200_iio_read_fault_mask,
+		.store = max22200_iio_write_fault_mask,
+		.priv = MAX22200_M_HHF
+	},
+	{
+		.name = "dpm_fault_mask",
+		.show = max22200_iio_read_fault_mask,
+		.store = max22200_iio_write_fault_mask,
+		.priv = MAX22200_M_DPM
+	},
+	{
+		.name = "com_err_mask",
+		.show = max22200_iio_read_fault_mask,
+		.store = max22200_iio_write_fault_mask,
+		.priv = MAX22200_M_COMF
+	},
+	{
+		.name = "uvlo_mask",
+		.show = max22200_iio_read_fault_mask,
+		.store = max22200_iio_write_fault_mask,
+		.priv = MAX22200_M_UVM
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_attribute max22200_global_attrs[] = {
+	{
+		.name = "chopping_frequency",
+		.show = max22200_iio_read_chopping_freq,
+		.store = max22200_iio_write_chopping_freq,
+		.shared = IIO_SHARED_BY_ALL
+	},
+	{
+		.name = "chopping_frequency_available",
+		.show = max22200_iio_read_available,
+		.priv = MAX22200_IIO_CHOP_FREQ_AVAILABLE,
+		.shared = IIO_SHARED_BY_ALL
+	},
+	{
+		.name = "external_trig_state",
+		.store = max22200_iio_write_trig_state,
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_device max22200_iio_dev = {
+	.debug_reg_read = (int32_t (*)())max22200_iio_reg_read,
+	.debug_reg_write = (int32_t (*)())max22200_iio_reg_write,
+	.debug_attributes = max22200_debug_attrs,
+	.attributes = max22200_global_attrs
+};
+
+/**
+ * @brief Read the raw attribute for a specific channel (state of the channel)
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max22200_iio_read_raw(void *dev, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel,
+				 intptr_t priv)
+{
+	struct max22200_iio_desc *desc = dev;
+	bool ch_state;
+	int32_t val;
+	int ret;
+
+	ret = max22200_get_ch_state(desc->max22200_desc, channel->address,
+				    &ch_state);
+	if (ret)
+		return ret;
+
+	val = ch_state ? 1 : 0;
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+}
+
+/**
+ * @brief Read the scale attribute for a specific channel.
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max22200_iio_read_scale(void *dev, char *buf, uint32_t len,
+				   const struct iio_ch_info *channel,
+				   intptr_t priv)
+{
+	struct max22200_iio_desc *desc = dev;
+	enum max22200_scale ch_scale;
+	int ret;
+
+	ret = max22200_get_ch_scale(desc->max22200_desc, channel->address,
+				    &ch_scale);
+	if (ret)
+		return ret;
+
+	strcpy(buf, max22200_scale_avail[ch_scale]);
+
+	return strlen(buf);
+}
+
+/**
+ * @brief Read the hit attribute.
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+*/
+static int max22200_iio_read_hit(void *dev, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel,
+				 intptr_t priv)
+{
+	struct max22200_iio_desc *desc = dev;
+	int32_t hit_c, hit_t;
+	uint8_t hit_c_byte, hit_t_byte;
+	int ret;
+
+	ret = max22200_get_ch_hit(desc->max22200_desc, channel->address,
+				  &hit_c_byte, &hit_t_byte);
+	if (ret)
+		return ret;
+
+	hit_c = hit_c_byte;
+	hit_t = hit_t_byte;
+
+	switch (priv) {
+	case MAX22200_IIO_HIT_CURRENT:
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &hit_c);
+	case MAX22200_IIO_HIT_TIME:
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &hit_t);
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Read the hit attribute.
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+*/
+static int max22200_iio_read_hold(void *dev, char *buf, uint32_t len,
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
+{
+	struct max22200_iio_desc *desc = dev;
+	int32_t val;
+	uint8_t hold_byte;
+	int ret;
+
+	ret = max22200_get_ch_hold(desc->max22200_desc, channel->address,
+				   &hold_byte);
+	if (ret)
+		return ret;
+
+	val = hold_byte;
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+}
+
+/**
+ * @brief Read the channel_trig attribute.
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+*/
+static int max22200_iio_read_channel_trig(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	struct max22200_iio_desc *desc = dev;
+	enum max22200_trig ch_trig;
+	int32_t val;
+	int ret;
+
+	ret = max22200_get_ch_trig(desc->max22200_desc, channel->address,
+				   &ch_trig);
+	if (ret)
+		return ret;
+
+	val = ch_trig;
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+}
+
+/**
+ * @brief Read the channel_drive/channel_side/channel_op_mode attribute.
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+*/
+static int max22200_iio_read_ch_mode(void *dev, char *buf, uint32_t len,
+				     const struct iio_ch_info *channel,
+				     intptr_t priv)
+{
+	struct max22200_iio_desc *desc = dev;
+	enum max22200_ch_drive ch_drive;
+	enum max22200_ch_side ch_side;
+	enum max22200_ch_op_mode ch_op_mode;
+	int ret;
+
+	ret = max22200_get_ch_mode(desc->max22200_desc, channel->address,
+				   &ch_drive, &ch_side, &ch_op_mode);
+	if (ret)
+		return ret;
+
+	switch (priv) {
+	case MAX22200_IIO_CH_DRIVE:
+		return sprintf(buf, "%s ", max22200_ch_drive_avail[ch_drive]);
+	case MAX22200_IIO_CH_SIDE:
+		return sprintf(buf, "%s ", max22200_ch_side_avail[ch_side]);
+	case MAX22200_IIO_CH_OP_MODE:
+		return sprintf(buf, "%s ",
+			       max22200_ch_op_mode_avail[ch_op_mode]);
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Read the channel_freq attribute for a specific channel
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max22200_iio_read_channel_freq(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	struct max22200_iio_desc *desc = dev;
+	enum max22200_ch_freq ch_freq;
+	int ret;
+
+	ret = max22200_get_ch_freq(desc->max22200_desc, channel->address,
+				   &ch_freq);
+	if (ret)
+		return ret;
+
+	return sprintf(buf, "%s ", max22200_channel_freq_avail[ch_freq]);
+}
+
+/**
+ * @brief Read the enable attribute for a specific channel
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max22200_iio_read_enable(void *dev, char *buf, uint32_t len,
+				    const struct iio_ch_info *channel,
+				    intptr_t priv)
+{
+	struct max22200_iio_desc *desc = dev;
+	bool ch_enable;
+	int32_t val;
+	int ret;
+
+	ret = max22200_get_ch_enable(desc->max22200_desc, channel->address,
+				     priv, &ch_enable);
+	if (ret)
+		return ret;
+
+	val = ch_enable ? 1 : 0;
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+}
+
+/**
+ * @brief Read the fault_mask debug attribute for MAX22200 IIO descriptor
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max22200_iio_read_fault_mask(void *dev, char *buf, uint32_t len,
+					const struct iio_ch_info *channel,
+					intptr_t priv)
+{
+	struct max22200_iio_desc *desc = dev;
+	int32_t val;
+	bool enabled;
+	int ret;
+
+	ret = max22200_fault_mask_get(desc->max22200_desc, priv, &enabled);
+	if (ret)
+		return ret;
+
+	val = enabled ? 1 : 0;
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+}
+
+/**
+ * @brief Read the chopping_freq attribute for a specific channel
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max22200_iio_read_chopping_freq(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	struct max22200_iio_desc *desc = dev;
+	enum max22200_chopping_freq chopping_freq;
+	int32_t val;
+	int ret;
+
+	ret = max22200_get_chop_freq(desc->max22200_desc, &chopping_freq);
+	if (ret)
+		return ret;
+
+	val = chopping_freq;
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+}
+
+/**
+ * @brief Read the available attribute for a specific channel
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max22200_iio_read_available(void *dev, char *buf, uint32_t len,
+				       const struct iio_ch_info *channel,
+				       intptr_t priv)
+{
+	uint32_t length = 0;
+	uint32_t i;
+
+	switch (priv) {
+	case MAX22200_IIO_SCALE_AVAILABLE:
+		for (i = 0; i < NO_OS_ARRAY_SIZE(max22200_scale_avail); i++)
+			length += sprintf(buf + length, "%s ", max22200_scale_avail[i]);
+
+		return length;
+	case MAX22200_IIO_CH_TRIG_AVAILABLE:
+		for (i = 0; i < NO_OS_ARRAY_SIZE(max22200_channel_trig_avail); i++)
+			length += sprintf(buf + length, "%s ", max22200_channel_trig_avail[i]);
+
+		return length;
+	case MAX22200_IIO_CH_FREQ_AVAILABLE:
+		for (i = 0; i < NO_OS_ARRAY_SIZE(max22200_channel_freq_avail); i++)
+			length += sprintf(buf + length, "%s ",
+					  max22200_channel_freq_avail[i]);
+
+		return length;
+	case MAX22200_IIO_CHOP_FREQ_AVAILABLE:
+		for (i = 0; i < NO_OS_ARRAY_SIZE(max22200_chopping_freq_avail); i++)
+			length += sprintf(buf + length, "%s ",
+					  max22200_chopping_freq_avail[i]);
+
+		return length;
+	case MAX22200_IIO_CH_DRIVE_AVAILABLE:
+		for (i = 0; i < NO_OS_ARRAY_SIZE(max22200_ch_drive_avail); i++)
+			length += sprintf(buf + length, "%s ",
+					  max22200_ch_drive_avail[i]);
+
+		return length;
+	case MAX22200_IIO_CH_SIDE_AVAILABLE:
+		for (i = 0; i < NO_OS_ARRAY_SIZE(max22200_ch_side_avail); i++)
+			length += sprintf(buf + length, "%s ",
+					  max22200_ch_side_avail[i]);
+
+		return length;
+	case MAX22200_IIO_CH_OP_MODE_AVAILABLE:
+		for (i = 0; i < NO_OS_ARRAY_SIZE(max22200_ch_op_mode_avail); i++)
+			length += sprintf(buf + length, "%s ",
+					  max22200_ch_op_mode_avail[i]);
+
+		return length;
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Register read wrapper
+ * @param dev - The iio device structure.
+ * @param reg - The register's address.
+ * @param readval - Register value
+ * @return 0 in case of success, error code otherwise
+ */
+static int max22200_iio_reg_read(struct max22200_iio_desc *dev, uint32_t reg,
+				 uint32_t *readval)
+{
+	return max22200_reg_read(dev->max22200_desc, reg, readval);
+}
+
+/**
+ * @brief Write the raw attribute for a specific channel (state of the channel)
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max22200_iio_write_raw(void *dev, char *buf, uint32_t len,
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
+{
+	struct max22200_iio_desc *desc = dev;
+	int32_t val;
+
+	iio_parse_value(buf, IIO_VAL_INT, &val, NULL);
+
+	return max22200_set_ch_state(desc->max22200_desc, channel->address,
+				     val ? true : false);
+}
+
+/**
+ * @brief Write the ch_mode attribute for a specific channel.
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max22200_iio_write_ch_mode(void *dev, char *buf, uint32_t len,
+				      const struct iio_ch_info *channel,
+				      intptr_t priv)
+{
+	struct max22200_iio_desc *desc = dev;
+	enum max22200_ch_drive ch_drive;
+	enum max22200_ch_side ch_side;
+	enum max22200_ch_op_mode ch_op_mode;
+	size_t i;
+	int ret;
+
+	ret = max22200_get_ch_mode(desc->max22200_desc, channel->address,
+				   &ch_drive, &ch_side, &ch_op_mode);
+	if (ret)
+		return ret;
+
+	switch (priv) {
+	case MAX22200_IIO_CH_DRIVE:
+		for (i = 0; i < NO_OS_ARRAY_SIZE(max22200_ch_drive_avail); i++) {
+			if (!strcmp(buf, max22200_ch_drive_avail[i])) {
+				ch_drive = i;
+
+				return max22200_set_ch_mode(desc->max22200_desc, channel->address, ch_drive,
+							    ch_side, ch_op_mode);
+			}
+		}
+
+		return -EINVAL;
+	case MAX22200_IIO_CH_SIDE:
+		for (i = 0; i < NO_OS_ARRAY_SIZE(max22200_ch_side_avail); i++) {
+			if (!strcmp(buf, max22200_ch_side_avail[i])) {
+				ch_side = i;
+
+				return max22200_set_ch_mode(desc->max22200_desc, channel->address, ch_drive,
+							    ch_side, ch_op_mode);
+			}
+		}
+
+		return -EINVAL;
+	case MAX22200_IIO_CH_OP_MODE:
+		for (i = 0; i < NO_OS_ARRAY_SIZE(max22200_ch_op_mode_avail); i++) {
+			if (!strcmp(buf, max22200_ch_op_mode_avail[i])) {
+				ch_op_mode = i;
+
+				return max22200_set_ch_mode(desc->max22200_desc, channel->address, ch_drive,
+							    ch_side, ch_op_mode);
+			}
+		}
+
+		return -EINVAL;
+	default:
+		return -EINVAL;
+	}
+
+
+}
+
+/**
+ * @brief Write the channel_enable attribute for a specific channel.
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max22200_iio_write_enable(void *dev, char *buf, uint32_t len,
+				     const struct iio_ch_info *channel,
+				     intptr_t priv)
+{
+	struct max22200_iio_desc *desc = dev;
+	int32_t val;
+
+	iio_parse_value(buf, IIO_VAL_INT, &val, NULL);
+
+	return max22200_set_ch_enable(desc->max22200_desc, channel->address,
+				      priv, val ? true : false);
+}
+
+/**
+ * @brief Write the fault_mask debug attribute for MAX22200 IIO device.
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max22200_iio_write_fault_mask(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	struct max22200_iio_desc *desc = dev;
+	int32_t val;
+
+	iio_parse_value(buf, IIO_VAL_INT, &val, NULL);
+
+	return max22200_fault_mask_set(desc->max22200_desc, priv, val ? true : false);
+}
+
+/**
+ * @brief Write the fault_mask debug attribute for MAX22200 IIO device.
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max22200_iio_write_trig_state(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	struct max22200_iio_desc *desc = dev;
+	int32_t val;
+
+	iio_parse_value(buf, IIO_VAL_INT, &val, NULL);
+
+	return max22200_set_trig_state(desc->max22200_desc,
+				       val ? true : false);
+}
+
+/**
+ * @brief Write the chopping_freq attribute for MAX22200 IIO device.
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max22200_iio_write_chopping_freq(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	struct max22200_iio_desc *desc = dev;
+	enum max22200_chopping_freq chopping_freq;
+	size_t i;
+
+	for (i = 0; i < NO_OS_ARRAY_SIZE(max22200_chopping_freq_avail); i++) {
+		if (!strcmp(buf, max22200_chopping_freq_avail[i])) {
+			chopping_freq = i;
+
+			return max22200_set_chop_freq(desc->max22200_desc, chopping_freq);
+		}
+	}
+
+	return -EINVAL;
+}
+
+/**
+ * @brief Write any channel attribute with an available attribute related to it
+ * 	  for MAX22200 IIO device.
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max22200_iio_write_ch_avail_attrs(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	struct max22200_iio_desc *desc = dev;
+	uint32_t val;
+	size_t i;
+
+	switch (priv) {
+	case MAX22200_IIO_SCALE:
+		for(i = 0; i < NO_OS_ARRAY_SIZE(max22200_scale_avail); i++) {
+			if (!strcmp(buf, max22200_scale_avail[i])) {
+				val = no_os_field_prep(MAX22200_HFS_MASK, i);
+
+				return max22200_set_ch_scale(desc->max22200_desc, channel->address,
+							     val ? MAX22200_HALF_FULL_SCALE : MAX22200_FULLSCALE);
+			}
+		}
+
+		return -EINVAL;
+	case MAX22200_IIO_CH_TRIG:
+		for (i = 0; i < NO_OS_ARRAY_SIZE(max22200_channel_trig_avail); i++) {
+			if (!strcmp(buf, max22200_channel_trig_avail[i])) {
+				val = no_os_field_prep(MAX22200_TRGNSP_IO_MASK, i);
+
+				return max22200_set_ch_trig(desc->max22200_desc, channel->address,
+							    val ? MAX22200_TRIG : MAX22200_ONCH_SPI);
+			}
+		}
+
+		return -EINVAL;
+	case MAX22200_IIO_CH_FREQ:
+		for (i = 0; i < NO_OS_ARRAY_SIZE(max22200_channel_freq_avail); i++)
+			if (!strcmp(buf, max22200_channel_freq_avail[i]))
+				return max22200_set_ch_freq(desc->max22200_desc, channel->address,
+							    (enum max22200_ch_freq)i);
+
+		return -EINVAL;
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Write hit_current/hit_time/hold_current attribute
+ * 	  for MAX22200 IIO device.
+ * @param dev - The iio device structure.
+ * @param buf - Buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Private descriptor
+ * @return 0 in case of success, error code otherwise
+ */
+static int max22200_iio_write_channel_attrs(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	struct max22200_iio_desc *desc = dev;
+	uint32_t val;
+	uint8_t read_byte1, read_byte2;
+	int ret;
+
+	iio_parse_value(buf, IIO_VAL_INT, (int32_t *)&val, NULL);
+
+	switch (priv) {
+	case MAX22200_IIO_HIT_CURRENT:
+		if (val > MAX22200_HIT_MAX_VAL)
+			return -EINVAL;
+
+		ret = max22200_get_ch_hit(desc->max22200_desc, channel->address,
+					  &read_byte1, &read_byte2);
+		if (ret)
+			return ret;
+
+		return max22200_set_ch_hit(desc->max22200_desc,
+					   channel->address, (uint8_t)val,
+					   read_byte2);
+	case MAX22200_IIO_HIT_TIME:
+		if (val > MAX22200_HIT_T_MAX_VAL)
+			return -EINVAL;
+		ret = max22200_get_ch_hit(desc->max22200_desc, channel->address,
+					  &read_byte1, &read_byte2);
+		if (ret)
+			return ret;
+
+		return max22200_set_ch_hit(desc->max22200_desc,
+					   channel->address, read_byte1,
+					   (uint8_t)val);
+	case MAX22200_IIO_HOLD_CURRENT:
+		if (val > MAX22200_HOLD_MAX_VAL)
+			return -EINVAL;
+
+		return max22200_set_ch_hold(desc->max22200_desc, channel->address,
+					    (uint8_t)val);
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Register write wrapper
+ * @param dev - The iio device structure.
+ * @param reg - The register's address.
+ * @param readval - Register value
+ * @return 0 in case of success, error code otherwise
+ */
+static int max22200_iio_reg_write(struct max22200_iio_desc *dev, uint32_t reg,
+				  uint32_t writeval)
+{
+	return max22200_reg_write(dev->max22200_desc, reg, writeval);
+}
+
+int max22200_iio_setup_channels(struct max22200_iio_desc *desc, bool *ch_enable)
+{
+	struct iio_channel *max22200_iio_channels;
+	uint32_t enabled_ch = 0;
+	uint32_t ch_offset = 0;
+	uint32_t i;
+	int ret;
+
+	for (i = 0; i < MAX22200_CHANNELS; i++)
+		if (ch_enable[i])
+			enabled_ch++;
+
+	max22200_iio_channels = no_os_calloc(enabled_ch,
+					     sizeof(*max22200_iio_channels));
+
+	if (!max22200_iio_channels)
+		return -ENOMEM;
+
+	for (i = 0; i < MAX22200_CHANNELS; i++) {
+		if (ch_enable[i]) {
+			max22200_iio_channels[ch_offset] = (struct iio_channel)MAX22200_CHANNEL(i);
+			max22200_iio_channels[ch_offset].attributes = max22200_attrs;
+			max22200_iio_channels[ch_offset].ch_out = true;
+			ch_offset++;
+			ret = max22200_set_ch_state(desc->max22200_desc, i,
+						    true);
+			if (ret)
+				return ret;
+		}
+	}
+
+	desc->iio_dev->channels = max22200_iio_channels;
+	desc->iio_dev->num_ch = enabled_ch;
+
+	return 0;
+}
+
+/**
+ * @brief Initializes the MAX22200 IIO descriptor.
+ * @param iio_desc - The iio device descriptor.
+ * @param init_param - The structure that contains the device initial parameters.
+ * @return 0 in case of success, an error code otherwise.
+ */
+int max22200_iio_init(struct max22200_iio_desc **iio_desc,
+		      struct max22200_iio_desc_init_param *init_param)
+{
+	struct max22200_iio_desc *descriptor;
+	int ret;
+
+	if (!init_param || !init_param->max22200_init_param)
+		return -EINVAL;
+
+	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	ret = max22200_init(&descriptor->max22200_desc,
+			    init_param->max22200_init_param);
+	if (ret)
+		goto free_desc;
+
+	descriptor->iio_dev = &max22200_iio_dev;
+
+	ret = max22200_iio_setup_channels(descriptor, init_param->ch_enable);
+	if (ret)
+		goto free_dev;
+
+	*iio_desc = descriptor;
+
+	return 0;
+free_dev:
+	max22200_remove(descriptor->max22200_desc);
+free_desc:
+	no_os_free(descriptor);
+	return ret;
+}
+
+/**
+ * @brief Free resources allocated by the init function.
+ * @param iio_desc - The iio device descriptor.
+ * @return 0 in case of success, an error code otherwise.
+ */
+int max22200_iio_remove(struct max22200_iio_desc *iio_desc)
+{
+	if (!iio_desc)
+		return -ENODEV;
+
+	no_os_free(iio_desc->iio_dev->channels);
+	max22200_remove(iio_desc->max22200_desc);
+	no_os_free(iio_desc);
+
+	return 0;
+}

--- a/drivers/digital-io/max22200/iio_max22200.h
+++ b/drivers/digital-io/max22200/iio_max22200.h
@@ -1,0 +1,143 @@
+/***************************************************************************//**
+ *   @file   iio_max22200.h
+ *   @brief  Header file of IIO MAX22200 Driver.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef IIO_MAX22200_H
+#define IIO_MAX22200_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "iio.h"
+#include "max22200.h"
+
+#define MAX22200_HOLD_MAX_VAL	0xFF
+#define MAX22200_HIT_T_MAX_VAL	0xFF
+
+enum max22200_iio_fault_mask {
+	MAX22200_IIO_UVM_MASK = 1,
+	MAX22200_IIO_COMER_MASK,
+	MAX22200_IIO_DPM_MASK,
+	MAX22200_IIO_HHF_MASK,
+	MAX22200_IIO_OLF_MASK,
+	MAX22200_IIO_OCP_MASK,
+	MAX22200_IIO_OVT_MASK
+};
+
+enum max22200_iio_ch_attrs {
+	MAX22200_IIO_SCALE,
+	MAX22200_IIO_HIT_CURRENT,
+	MAX22200_IIO_HIT_TIME,
+	MAX22200_IIO_HOLD_CURRENT,
+	MAX22200_IIO_CH_TRIG,
+	MAX22200_IIO_CH_DRIVE,
+	MAX22200_IIO_CH_SIDE,
+	MAX22200_IIO_CH_OP_MODE,
+	MAX22200_IIO_CH_FREQ,
+};
+
+enum max22200_iio_available {
+	MAX22200_IIO_SCALE_AVAILABLE,
+	MAX22200_IIO_CH_TRIG_AVAILABLE,
+	MAX22200_IIO_CH_FREQ_AVAILABLE,
+	MAX22200_IIO_CHOP_FREQ_AVAILABLE,
+	MAX22200_IIO_CH_DRIVE_AVAILABLE,
+	MAX22200_IIO_CH_SIDE_AVAILABLE,
+	MAX22200_IIO_CH_OP_MODE_AVAILABLE
+};
+
+static const char *const max22200_scale_avail[2] = {
+	"fullscale",
+	"half_fullscale"
+};
+
+static const char *const max22200_channel_trig_avail[2] = {
+	"onch_spi",
+	"ext_trig"
+};
+
+static const char *const max22200_ch_drive_avail[2] = {
+	"current_drive",
+	"voltage_dri"
+};
+
+static const char *const max22200_ch_side_avail[2] = {
+	"low_side",
+	"high_side"
+};
+
+static const char *const max22200_ch_op_mode_avail[3] = {
+	"independent_mode",
+	"parallel_mode",
+	"half_bridge_mode",
+};
+
+static const char *const max22200_channel_freq_avail[4] = {
+	"freqmain_div_4",
+	"freqmain_div_3",
+	"freqmain_div_2",
+	"freqmain"
+};
+
+static const char *const max22200_chopping_freq_avail[2] = {
+	"100KHz",
+	"80KHz"
+};
+
+/**
+ * @brief MAX22200 specific IIO descriptor.
+*/
+struct max22200_iio_desc {
+	struct max22200_desc *max22200_desc;
+	struct iio_device *iio_dev;
+};
+
+/**
+ * @brief Initalization parameter fr the MAX22200 IIO descriptor.
+*/
+struct max22200_iio_desc_init_param {
+	struct max22200_init_param *max22200_init_param;
+	bool ch_enable[MAX22200_CHANNELS];
+};
+
+/** Initializes the MAXX22200 IIO descriptor. */
+int max22200_iio_init(struct max22200_iio_desc **,
+		      struct max22200_iio_desc_init_param *);
+
+/** Free resources allocated by the init function. */
+int max22200_iio_remove(struct max22200_iio_desc *);
+
+#endif /** IIO_MAX22200_H */

--- a/drivers/digital-io/max22200/max22200.c
+++ b/drivers/digital-io/max22200/max22200.c
@@ -1,0 +1,903 @@
+/***************************************************************************//**
+ *   @file   max22200.c
+ *   @brief  Source file of MAX22200 Driver.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include <no_os_error.h>
+#include <stdlib.h>
+#include <string.h>
+#include "max22200.h"
+#include "no_os_util.h"
+#include "no_os_alloc.h"
+#include "no_os_delay.h"
+
+/**
+ * @brief Read data from desired register for MAX22200
+ * @param desc - MAX22200 device descriptor.
+ * @param reg - Register address to read data from.
+ * @param val - Value read from the register.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22200_reg_read(struct max22200_desc *desc, uint32_t reg, uint32_t *val)
+{
+	int ret;
+	struct no_os_spi_msg xfer = {
+		.tx_buff = desc->buff,
+		.rx_buff = desc->buff,
+		.bytes_number = 1,
+		.cs_change = 1,
+	};
+
+	desc->buff[0] = no_os_field_prep(MAX22200_RW_MASK, 0) |
+			no_os_field_prep(MAX22200_ADDR_MASK, reg);
+
+	ret = no_os_gpio_set_value(desc->cmd_desc, NO_OS_GPIO_HIGH);
+	if (ret)
+		return ret;
+
+	ret = no_os_spi_transfer(desc->comm_desc, &xfer, 1);
+	if (ret)
+		return ret;
+
+	if (!no_os_field_get(reg, MAX22200_R1B))
+		xfer.bytes_number = MAX22200_FRAME_SIZE;
+
+	ret = no_os_gpio_set_value(desc->cmd_desc, NO_OS_GPIO_LOW);
+	if (ret)
+		return ret;
+
+	ret = no_os_spi_transfer(desc->comm_desc, &xfer, 1);
+	if (ret)
+		return ret;
+
+	if (no_os_field_get(reg, MAX22200_R1B))
+		*val = desc->buff[0];
+	else
+		*val = no_os_get_unaligned_be32(desc->buff);
+
+	return 0;
+}
+
+/**
+ * @brief Write data to desired register for MAX22200
+ * @param desc - MAXX22200 device descriptor.
+ * @param reg - Register address to write data to.
+ * @param val - Value to be written to the register.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22200_reg_write(struct max22200_desc *desc, uint32_t reg, uint32_t val)
+{
+	int ret;
+	struct no_os_spi_msg xfer = {
+		.tx_buff = desc->buff,
+		.rx_buff = desc->buff,
+		.bytes_number = 1,
+		.cs_change = 1,
+	};
+
+	if (no_os_field_get(reg, MAX22200_R1B) && val > 0xFF)
+		return -EINVAL;
+
+	desc->buff[0] = no_os_field_prep(MAX22200_RW_MASK, 1) |
+			no_os_field_prep(MAX22200_ADDR_MASK, reg);
+
+	ret = no_os_gpio_set_value(desc->cmd_desc, NO_OS_GPIO_HIGH);
+	if (ret)
+		return ret;
+
+	ret = no_os_spi_transfer(desc->comm_desc, &xfer, 1);
+	if (ret)
+		return ret;
+
+	if (!no_os_field_get(reg, MAX22200_R1B)) {
+		xfer.bytes_number = MAX22200_FRAME_SIZE;
+		no_os_put_unaligned_le32(val, desc->buff);
+	} else {
+		desc->buff[0] = val;
+	}
+
+	ret = no_os_gpio_set_value(desc->cmd_desc, NO_OS_GPIO_LOW);
+	if (ret)
+		return ret;
+
+	return no_os_spi_transfer(desc->comm_desc, &xfer, 1);
+}
+
+/**
+ * @brief Update data in the desired register.
+ * @param desc - MAX22200 device descriptor.
+ * @param reg - Register address to update data to.
+ * @param mask - Bit mask of the field to be updated.
+ * @param val - Value to be updated in the desired register.
+ * 		Should be bit shifted by using no_os_field_prep(mask, val)
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22200_reg_update(struct max22200_desc *desc, uint32_t reg, uint32_t mask,
+			uint32_t val)
+{
+	int ret;
+	uint32_t reg_val = 0;
+
+	ret = max22200_reg_read(desc, reg, &reg_val);
+	if (ret)
+		return ret;
+
+	reg_val &= ~mask;
+	reg_val |= mask & val;
+
+	return max22200_reg_write(desc, reg, reg_val);
+}
+
+/**
+ * @brief Set external trigger's state of the MAX22200
+ * @param desc - MAX22200 device descriptor.
+ * @param trig_state - State to change to.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22200_set_trig_state(struct max22200_desc *desc, bool trig_state)
+{
+	if (!desc->trig_desc)
+		return -EINVAL;
+
+	return no_os_gpio_set_value(desc->trig_desc,
+				    trig_state ? NO_OS_GPIO_HIGH : NO_OS_GPIO_LOW);
+}
+
+/**
+ * @brief Set channel state for specific channel
+ * @param desc - MAX22200 device descriptor.
+ * @param ch - Channel number.
+ * @param ch_state - Channel's state to be changed into.
+ * @return 0 in case of succces, negative error code otherwise.
+*/
+int max22200_set_ch_state(struct max22200_desc *desc, uint32_t ch,
+			  bool ch_state)
+{
+	if (ch > MAX22200_MAX_CHN_IDX)
+		return -EINVAL;
+
+	return max22200_reg_update(desc, MAX22200_STATUS_REG, MAX22200_ONCH_MASK(ch),
+				   no_os_field_prep(MAX22200_ONCH_MASK(ch), ch_state));
+}
+
+/**
+ * @brief Set fault mask bits in the status register.
+ * @param desc - MAX22200 device descriptor.
+ * @param fault_mask - Desired fault mask bit to set.
+ * @param enabled - enabled/disabled state of the mask.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22200_fault_mask_set(struct max22200_desc *desc,
+			    enum max22200_fault_mask fault_mask, bool enabled)
+{
+	if (fault_mask == MAX22200_M_HHF && desc->chan_drive == MAX22200_VOLTAGE_DRIVE)
+		return -EINVAL;
+
+	return max22200_reg_update(desc, MAX22200_STATUS_REG,
+				   MAX22200_STATUS_FAULT_MASK(fault_mask),
+				   no_os_field_prep(MAX22200_STATUS_FAULT_MASK(fault_mask), enabled));
+}
+
+/**
+ * @brief Set chopping frequency value.
+ * @param desc - MAX22200 device descriptor.
+ * @param chopping_freq - Chopping frequency value.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22200_set_chop_freq(struct max22200_desc *desc,
+			   enum max22200_chopping_freq chopping_freq)
+{
+	return max22200_reg_update(desc, MAX22200_STATUS_REG, MAX22200_STATUS_FREQ_MASK,
+				   no_os_field_prep(MAX22200_STATUS_FREQ_MASK, chopping_freq));
+}
+
+/**
+ * @brief Set channel HIT time and HIT current.
+ * @param desc - MAX22200 device descriptor.
+ * @param ch - Channel for which HIT time is to be set.(0 based)
+ * @param hit_current - HIT current value, it shall not be greater than 127
+ * 			since the value is stored only on 7 bits in the
+ * 			channel's configuration register.
+ * @param hit_time - HIT time value to be set.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22200_set_ch_hit(struct max22200_desc *desc, uint32_t ch,
+			uint8_t hit_current, uint8_t hit_time)
+{
+	int ret;
+
+	if (ch > MAX22200_MAX_CHN_IDX)
+		return -EINVAL;
+
+	if (hit_current > MAX22200_HIT_MAX_VAL)
+		return -EINVAL;
+
+	ret = max22200_reg_update(desc, MAX22200_CFG_CH(ch), MAX22200_HIT_MASK,
+				  no_os_field_prep(MAX22200_HIT_MASK, (uint32_t)hit_current));
+	if (ret)
+		return ret;
+
+	return max22200_reg_update(desc, MAX22200_CFG_CH(ch), MAX22200_HIT_T_MASK,
+				   no_os_field_prep(MAX22200_HIT_T_MASK, (uint32_t)hit_time));
+}
+
+/**
+ * @brief Set channel hold current
+ * @param desc - MAX22200 device descriptor.
+ * @param ch - Channel's number (0 based).
+ * @param hold_current - Hold current value to be set. It shall not be greater
+ * 			 than 127 since the value it's stored on 7 bits in
+ * 			 the channel's configuration register.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22200_set_ch_hold(struct max22200_desc *desc, uint32_t ch,
+			 uint8_t hold_current)
+{
+	if (ch > MAX22200_MAX_CHN_IDX)
+		return -EINVAL;
+
+	if (hold_current > MAX22200_HIT_MAX_VAL)
+		return -EINVAL;
+
+	return max22200_reg_update(desc, MAX22200_CFG_CH(ch), MAX22200_HOLD_MASK,
+				   no_os_field_prep(MAX22200_HOLD_MASK, (uint32_t)hold_current));
+}
+
+/**
+ * @brief Set channel's scale to fullscale or half fullscale.
+ * @param desc - MAX22200 device dscriptor.
+ * @param ch - Channel's number (0 based).
+ * @param scale - Scale value.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22200_set_ch_scale(struct max22200_desc *desc, uint32_t ch,
+			  enum max22200_scale scale)
+{
+	if (ch > MAX22200_MAX_CHN_IDX)
+		return -EINVAL;
+
+	if (scale == MAX22200_HALF_FULL_SCALE && desc->chan_side == MAX22200_HIGH_SIDE)
+		return -EINVAL;
+
+	return max22200_reg_update(desc, MAX22200_CFG_CH(ch), MAX22200_HFS_MASK,
+				   no_os_field_prep(MAX22200_HFS_MASK, scale));
+}
+
+/**
+ * @brief Set channel's trigger to be either SPI or external trigger.
+ * @param desc - MAX22200 device descriptor.
+ * @param ch - Channel's number (0 based).
+ * @param trig - Trigger to be set. If external trigger is requested but no
+ * 		 external's trigger descriptor was initialized, will return
+ * 		 negative error code.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22200_set_ch_trig(struct max22200_desc *desc, uint32_t ch,
+			 enum max22200_trig trig)
+{
+	if (ch > MAX22200_MAX_CHN_IDX)
+		return -EINVAL;
+
+	if (trig == MAX22200_TRIG && !desc->trig_desc)
+		return -EINVAL;
+
+	return max22200_reg_update(desc, MAX22200_CFG_CH(ch), MAX22200_TRGNSP_IO_MASK,
+				   no_os_field_prep(MAX22200_TRGNSP_IO_MASK, trig));
+}
+
+/**
+ * @brief Set chanmel operation mode, high-side/low-side and drive.
+ * @param desc - MAX22200 device descriptor.
+ * @param ch - Channel number (0 based).
+ * @param ch_drive - Voltage/Current drive.
+ * @param ch_side - High-Side/Low-Side.
+ * @param ch_op_mode - Independent/Half-Bridge/Full-Bridge mode.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22200_set_ch_mode(struct max22200_desc *desc, uint32_t ch,
+			 enum max22200_ch_drive ch_drive,
+			 enum max22200_ch_side ch_side,
+			 enum max22200_ch_op_mode ch_op_mode)
+{
+	int ret;
+	uint32_t mask, val;
+
+	if (ch > MAX22200_MAX_CHN_IDX)
+		return -EINVAL;
+
+	if (ch_side == MAX22200_HIGH_SIDE && ch_drive == MAX22200_CURRENT_DRIVE)
+		return -EINVAL;
+
+	mask = MAX22200_CH_MODE_MASK(ch);
+	val = no_os_field_prep(MAX22200_CH_MODE_MASK(ch), (uint32_t)ch_op_mode);
+
+	ret = max22200_reg_update(desc, MAX22200_STATUS_REG, mask, val);
+	if (ret)
+		return ret;
+
+	/* Channels are configured 2 by 2, either they are configured as
+	   Independent, Half-Bridge or Full-Bridge, thereby ch_config[0] is
+	   the configuration for channels 0 and 1, ch_config[1] is the
+	   configuration for channels 1 and 2, and so on. */
+	desc->ch_config[ch / 2] = ch_op_mode;
+
+	mask = MAX22200_VDRNCDR_MASK | MAX22200_HSNLS_MASK;
+	val = no_os_field_prep(MAX22200_VDRNCDR_MASK, (uint32_t)ch_drive) |
+	      no_os_field_prep(MAX22200_HSNLS_MASK, (uint32_t)ch_side);
+
+	ret = max22200_reg_update(desc, MAX22200_CFG_CH(ch) | MAX22200_R1B,
+				  mask, val);
+	if (ret)
+		return ret;
+
+	desc->chan_side = ch_side;
+
+	return 0;
+}
+
+/**
+ * @brief Set channel's frequency.
+ * @param desc - MAX22200 device descriptor
+ * @param ch - Channel's number (0 based).
+ * @param ch_freq - 80KHz/100KHz frequency.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22200_set_ch_freq(struct max22200_desc *desc, uint32_t ch,
+			 enum max22200_ch_freq ch_freq)
+{
+	if (ch > MAX22200_MAX_CHN_IDX)
+		return -EINVAL;
+
+	return max22200_reg_update(desc, MAX22200_CFG_CH(ch) | MAX22200_R1B,
+				   MAX22200_FREQ_CFG_MASK,
+				   no_os_field_prep(MAX22200_FREQ_CFG_MASK, ch_freq));
+}
+
+/**
+ * @brief Set channel's enables for different checks, detection and functions.
+ * @param desc - MAX22200 device descriptor.
+ * @param ch - Channel's number (0 based).
+ * @param ch_enable - Channel enable to be set.
+ * @param enabled - Disabled/Enabled state.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22200_set_ch_enable(struct max22200_desc *desc, uint32_t ch,
+			   enum max22200_ch_enable ch_enable, bool enabled)
+{
+	if (ch > MAX22200_MAX_CHN_IDX)
+		return -EINVAL;
+
+	return max22200_reg_update(desc, MAX22200_CFG_CH(ch) | MAX22200_R1B,
+				   MAX22200_CH_ENABLE_MASK(ch_enable),
+				   no_os_field_prep(MAX22200_CH_ENABLE_MASK(ch_enable), enabled));
+}
+
+/**
+ * @brief Set configuration DPM.
+ * @param desc - MAX22200 device descriptor.
+ * @param dpm_istart_byte - Detection of plunger movement starting current
+ * @param dpm_tdeb_ipth_byte - Detection of plunger movement debounce time.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22200_set_cfg_dpm(struct max22200_desc *desc, uint8_t dpm_istart_byte,
+			 uint8_t dpm_tdeb_ipth_byte)
+{
+	uint32_t val, mask;
+
+	if (dpm_istart_byte > MAX22200_HIT_MAX_VAL)
+		return -EINVAL;
+
+	mask = MAX22200_DPM_ISTART_MASK | MAX22200_DPM_TDEB_MASK |
+	       MAX22200_DPM_IPTH_MASK;
+	val = no_os_field_prep(MAX22200_DPM_ISTART_MASK, dpm_istart_byte) |
+	      no_os_field_prep(MAX22200_DPM_TDEB_MASK | MAX22200_DPM_IPTH_MASK,
+			       dpm_tdeb_ipth_byte);
+
+	return max22200_reg_update(desc, MAX22200_CFG_DPM_REG, mask, val);
+}
+
+/**
+ * @brief Fault mask bit get function
+ * @param desc - MAX22200 device descriptor.
+ * @param fault_mask - Fault mask specific bit to read the state for.
+ * @param enabled - State of the bit.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22200_fault_mask_get(struct max22200_desc * desc,
+			    enum max22200_fault_mask fault_mask, bool *enabled)
+{
+	int ret;
+	uint32_t reg_val;
+
+	ret = max22200_reg_read(desc, MAX22200_STATUS_REG, &reg_val);
+	if (ret)
+		return ret;
+
+	*enabled = no_os_field_get(MAX22200_STATUS_FAULT_MASK(fault_mask),
+				   reg_val);
+
+	return 0;
+}
+
+/**
+ * @brief Read the state of a channel
+ * @param desc - MAX22200 device descriptor
+ * @param ch - Channel number (0 based).
+ * @param ch_state - State of the channel.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22200_get_ch_state(struct max22200_desc *desc, uint32_t ch,
+			  bool *ch_state)
+{
+	int ret;
+	uint32_t reg_val;
+
+	if (ch < MAX22200_CHANNELS - 1)
+		return -EINVAL;
+
+	ret = max22200_reg_read(desc, MAX22200_STATUS_REG, &reg_val);
+	if (ret)
+		return ret;
+
+	*ch_state = no_os_field_get(MAX22200_ONCH_MASK(ch), reg_val);
+
+	return 0;
+}
+
+/**
+ * @brief Read chopping frequency
+ * @param desc - MAX22200 device descriptor.
+ * @param chopping_freq - Pointer of the variable holding the value of the
+ * 			  chopping frequency.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22200_get_chop_freq(struct max22200_desc *desc,
+			   enum max22200_chopping_freq *chopping_freq)
+{
+	int ret;
+	uint32_t reg_val;
+
+	ret = max22200_reg_read(desc, MAX22200_STATUS_REG, &reg_val);
+	if (ret)
+		return ret;
+
+	*chopping_freq = no_os_field_get(MAX22200_STATUS_FREQ_MASK, reg_val);
+
+	return 0;
+}
+
+/**
+ * @brief Read channel HIT configuration.
+ * @param desc - MAX22200 device descriptor.
+ * @param ch - Channel's number (0 based).
+ * @param hit_current - HIT current value read from the device.
+ * @param hit_time - HIT time value read from the device.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22200_get_ch_hit(struct max22200_desc *desc, uint32_t ch,
+			uint8_t *hit_current, uint8_t *hit_time)
+{
+	int ret;
+	uint32_t reg_val;
+
+	if (ch > MAX22200_MAX_CHN_IDX)
+		return -EINVAL;
+
+	ret = max22200_reg_read(desc, MAX22200_CFG_CH(ch), &reg_val);
+	if (ret)
+		return ret;
+
+	*hit_current = no_os_field_get(MAX22200_HIT_MASK, reg_val);
+	*hit_time = no_os_field_get(MAX22200_HIT_T_MASK, reg_val);
+
+	return 0;
+}
+
+/**
+ * @brief Read channel HOLD configuration.
+ * @param desc - MAX22200 device descriptor.
+ * @param ch - Channel's number (0 based).
+ * @param hold_current - HOLD current value read from the device.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22200_get_ch_hold(struct max22200_desc *desc, uint32_t ch,
+			 uint8_t *hold_current)
+{
+	int ret;
+	uint32_t reg_val;
+
+	if (ch > MAX22200_MAX_CHN_IDX)
+		return -EINVAL;
+
+	ret = max22200_reg_read(desc, MAX22200_CFG_CH(ch), &reg_val);
+	if (ret)
+		return ret;
+
+	*hold_current = no_os_field_get(MAX22200_HOLD_MASK, reg_val);
+
+	return 0;
+}
+
+/**
+ * @brief Read channel's scale.
+ * @param desc - MAX22200 device descriptor.
+ * @param ch - Channel's number (0 based).
+ * @param scale - Scale read from device's channel.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22200_get_ch_scale(struct max22200_desc *desc, uint32_t ch,
+			  enum max22200_scale *scale)
+{
+	int ret;
+	uint32_t reg_val;
+
+	if (ch > MAX22200_MAX_CHN_IDX)
+		return -EINVAL;
+
+	ret = max22200_reg_read(desc,MAX22200_CFG_CH(ch), &reg_val);
+	if (ret)
+		return ret;
+
+	*scale = no_os_field_get(MAX22200_HFS_MASK, reg_val);
+
+	return 0;
+}
+
+/**
+ * @brief Read channel's selected trigger for specific channel.
+ * @param desc - MAX22200 device descriptor.
+ * @param ch - Channel's number (0 based).
+ * @param trig - Selected trigger for the channel requested read from the
+ * 		 device.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22200_get_ch_trig(struct max22200_desc *desc, uint32_t ch,
+			 enum max22200_trig *trig)
+{
+	int ret;
+	uint32_t reg_val;
+
+	if (ch > MAX22200_MAX_CHN_IDX)
+		return -EINVAL;
+
+	ret = max22200_reg_read(desc, MAX22200_CFG_CH(ch), &reg_val);
+	if (ret)
+		return ret;
+
+	*trig = no_os_field_get(MAX22200_TRGNSP_IO_MASK, reg_val);
+
+	return 0;
+}
+
+/**
+ * @brief Read channel's mode configuration
+ * @param desc - MAX22200 device descriptor.
+ * @param ch - Channel's number (0 based).
+ * @param ch_drive - Channel's drive read from the device.
+ * @param ch_side - Channel's high-side/low-side configuraton read from the
+ * 		    device.
+ * @param ch_op_mode - Channel's operation mode read from the device.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22200_get_ch_mode(struct max22200_desc *desc, uint32_t ch,
+			 enum max22200_ch_drive *ch_drive,
+			 enum max22200_ch_side *ch_side,
+			 enum max22200_ch_op_mode *ch_op_mode)
+{
+	int ret;
+	uint32_t reg_val;
+
+	if (ch > MAX22200_MAX_CHN_IDX)
+		return -EINVAL;
+
+	ret = max22200_reg_read(desc, MAX22200_CFG_CH(ch) | MAX22200_R1B,
+				&reg_val);
+	if (ret)
+		return ret;
+
+	*ch_drive = no_os_field_get(MAX22200_VDRNCDR_MASK, reg_val);
+	*ch_side = no_os_field_get(MAX22200_HSNLS_MASK, reg_val);
+
+	ret = max22200_reg_read(desc, MAX22200_STATUS_REG, &reg_val);
+	if (ret)
+		return ret;
+
+	*ch_op_mode = no_os_field_get(MAX22200_CH_MODE_MASK(ch), reg_val);
+
+	return 0;
+}
+
+/**
+ * @brief Read channel's frequency
+ * @param desc - MAX22200 device descriptor.
+ * @param ch - Channel's number (0 based).
+ * @param ch_freq - Channel's frequency value read from the device.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22200_get_ch_freq(struct max22200_desc *desc, uint32_t ch,
+			 enum max22200_ch_freq *ch_freq)
+{
+	int ret;
+	uint32_t reg_val;
+
+	if (ch > MAX22200_MAX_CHN_IDX)
+		return -EINVAL;
+
+	ret = max22200_reg_read(desc, MAX22200_CFG_CH(ch), &reg_val);
+	if (ret)
+		return ret;
+
+	*ch_freq = no_os_field_get(MAX22200_FREQ_CFG_MASK, reg_val);
+
+	return 0;
+}
+
+/**
+ * @brief Read channel's enable bits state
+ * @param desc - MAX22200 device descriptor.
+ * @param ch - Channel's number (0 based).
+ * @param ch_enable - Requested channel enable bit to read the state for.
+ * @param enabled - Requested enabled bit state.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22200_get_ch_enable(struct max22200_desc *desc, uint32_t ch,
+			   enum max22200_ch_enable ch_enable, bool *enabled)
+{
+	int ret;
+	uint32_t reg_val;
+
+	if (ch > MAX22200_MAX_CHN_IDX)
+		return -EINVAL;
+
+	ret = max22200_reg_read(desc, MAX22200_CFG_CH(ch) | MAX22200_R1B,
+				&reg_val);
+	if (ret)
+		return ret;
+
+	*enabled = no_os_field_get(MAX22200_CH_ENABLE_MASK(ch_enable),
+				   reg_val);
+
+	return 0;
+}
+
+/**
+ * @brief Read configuration for the detection of the plunger movement of the
+ * 	  device
+ * @param desc - MAX22200 device descriptor.
+ * @param dpm_istart_byte - Detection of plunger movement starting current
+ * 			    value.
+ * @param dpm_tdeb_ipth_byte - Detection of plunger movement debounce time
+ * 			       value.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22200_get_cfg_dpm(struct max22200_desc *desc, uint8_t *dpm_istart_byte,
+			 uint8_t *dpm_tdeb_ipth_byte)
+{
+	int ret;
+	uint32_t reg_val;
+
+	ret = max22200_reg_read(desc, MAX22200_CFG_DPM_REG, &reg_val);
+	if (ret)
+		return ret;
+
+	*dpm_istart_byte = no_os_field_get(MAX22200_DPM_ISTART_MASK, reg_val);
+	*dpm_tdeb_ipth_byte = no_os_field_get(MAX22200_DPM_TDEB_MASK, reg_val) |
+			      no_os_field_get(MAX22200_DPM_IPTH_MASK, reg_val);
+
+	return 0;
+}
+
+/**
+ * @brief MAX22200 descriptor initialization function.
+ * @param desc - MAX22200 device descriptor.
+ * @param init_param - Initialization parameter containing data about the device
+ * 		       descriptor to be initialized.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22200_init(struct max22200_desc **desc,
+		  struct max22200_init_param *init_param)
+{
+	struct max22200_desc *descriptor;
+	uint32_t reg_val;
+	uint32_t status_reg = 0;
+	int ret, i;
+
+	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	ret = no_os_spi_init(&descriptor->comm_desc, init_param->comm_param);
+	if (ret)
+		goto err;
+
+	/* Time between enable pin set and device power-up. */
+	no_os_udelay(500);
+
+	ret = no_os_gpio_get(&descriptor->cmd_desc,
+			     init_param->cmd_param);
+	if (ret)
+		goto spi_err;
+
+	ret = no_os_gpio_direction_output(descriptor->cmd_desc, NO_OS_GPIO_LOW);
+	if (ret)
+		goto cmd_err;
+
+	/* Enable pin is optional to be connected to master through GPIO and be
+	   controlled in this way, but mandatory to be logic high (3.3V) in
+	   order for the device to be enabled. */
+	ret = no_os_gpio_get_optional(&descriptor->enable_desc,
+				      init_param->enable_param);
+	if (ret)
+		goto cmd_err;
+
+	if (descriptor->enable_desc) {
+		ret = no_os_gpio_direction_output(descriptor->enable_desc,
+						  NO_OS_GPIO_HIGH);
+		if (ret)
+			goto enable_err;
+	}
+
+	ret = no_os_gpio_get_optional(&descriptor->trig_desc,
+				      init_param->trig_param);
+	if (ret)
+		goto enable_err;
+
+	/* External trigger if used, is set logic LOW at initialization.
+	   Can be set logic HIGH in case of choosing to use the external
+	   trigger for Full-Bridge Mode. */
+	if (descriptor->trig_desc) {
+		ret = no_os_gpio_direction_output(descriptor->trig_desc,
+						  NO_OS_GPIO_LOW);
+		if (ret)
+			goto trig_err;
+	}
+
+	ret = no_os_gpio_get_optional(&descriptor->fault_desc,
+				      init_param->fault_param);
+	if (ret)
+		goto trig_err;
+
+	if (descriptor->fault_desc) {
+		ret = no_os_gpio_direction_input(descriptor->fault_desc);
+		if (ret)
+			goto fault_err;
+	}
+
+	ret = max22200_reg_read(descriptor, MAX22200_STATUS_REG, &reg_val);
+	if (ret)
+		goto fault_err;
+
+	/* Getting channel mode info from init_param */
+	for (i = 0; i < MAX22200_CHANNELS_CONFIG; i++)
+		status_reg |= no_os_field_prep(MAX22200_CH_MODE_MASK(i),
+					       *(init_param->ch_config + i));
+
+	/* Writing to the status register the mode of the channels and
+	   setting active bit to 1. */
+	status_reg |= no_os_field_prep(MAX22200_ACTIVE_MASK, 1);
+	ret = max22200_reg_write(descriptor, MAX22200_STATUS_REG,
+				 status_reg);
+	if (ret)
+		goto fault_err;
+
+	/* Configuring channels at startup. */
+	for (i = 0; i < MAX22200_CHANNELS; i++) {
+		ret = max22200_set_ch_scale(descriptor, i, MAX22200_FULLSCALE);
+		if (ret)
+			goto fault_err;
+
+		ret = max22200_set_ch_hold(descriptor, i, MAX22200_HIT_MAX_VAL);
+		if (ret)
+			goto fault_err;
+
+		ret = max22200_set_ch_trig(descriptor, i, MAX22200_ONCH_SPI);
+		if (ret)
+			goto fault_err;
+
+		ret = max22200_set_ch_hit(descriptor, i, MAX22200_HIT_MAX_VAL,
+					  MAX22200_HIT_NO_TIME);
+		if (ret)
+			goto fault_err;
+	}
+
+	/* Delay needed from setting active bit to 1 and configuring channels
+	   to normal operation. */
+	no_os_udelay(2500);
+
+	/* Reading from the status register again to clear faults. */
+	ret = max22200_reg_read(descriptor, MAX22200_STATUS_REG, &reg_val);
+	if (ret)
+		goto fault_err;
+
+	descriptor->chan_side = MAX22200_LOW_SIDE;
+	descriptor->chan_drive = MAX22200_CURRENT_DRIVE;
+
+	*desc = descriptor;
+
+	return 0;
+
+fault_err:
+	no_os_gpio_remove(descriptor->fault_desc);
+trig_err:
+	no_os_gpio_remove(descriptor->trig_desc);
+enable_err:
+	no_os_gpio_remove(descriptor->enable_desc);
+cmd_err:
+	no_os_gpio_remove(descriptor->cmd_desc);
+spi_err:
+	no_os_spi_remove(descriptor->comm_desc);
+err:
+	no_os_free(descriptor);
+	return ret;
+}
+
+/**
+ * @brief Deallocates all the resources used at initialization.
+ * @param desc - MAX22200 device descriptor.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max22200_remove(struct max22200_desc *desc)
+{
+	int ret, i;
+
+	if (!desc)
+		return -ENODEV;
+
+	for (i = 0; i < MAX22200_CHANNELS; i++) {
+		ret = max22200_set_ch_state(desc, i, false);
+		if (ret)
+			return ret;
+	}
+
+	ret = max22200_reg_update(desc, MAX22200_STATUS_REG | MAX22200_R1B,
+				  MAX22200_ACTIVE_MASK, 0);
+	if (ret)
+		return ret;
+
+	ret = no_os_gpio_set_value(desc->enable_desc, NO_OS_GPIO_LOW);
+	if (ret)
+		return ret;
+
+	no_os_spi_remove(desc->comm_desc);
+	no_os_gpio_remove(desc->enable_desc);
+	no_os_gpio_remove(desc->cmd_desc);
+	no_os_gpio_remove(desc->trig_desc);
+	no_os_gpio_remove(desc->fault_desc);
+
+	no_os_free(desc);
+
+	return 0;
+}

--- a/drivers/digital-io/max22200/max22200.h
+++ b/drivers/digital-io/max22200/max22200.h
@@ -1,0 +1,268 @@
+/***************************************************************************//**
+ *   @file   max22200.h
+ *   @brief  Header file of MAX22200 Driver.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef _MAX22200_H
+#define _MAX22200_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "no_os_gpio.h"
+#include "no_os_spi.h"
+#include "no_os_util.h"
+
+#define MAX22200_FRAME_SIZE		4
+
+#define MAX22200_CHANNELS		8
+#define MAX22200_CHANNELS_CONFIG	4
+#define MAX22200_MAX_CHN_IDX		7
+#define MAX22200_HIT_MAX_VAL		0x7F
+#define MAX22200_HIT_NO_TIME		0x00
+
+#define MAX22200_R1B			NO_OS_BIT(0)
+
+#define MAX22200_STATUS_REG		0x00
+#define MAX22200_CFG_CH(x)		(0x02 + (0x02 * (x)))
+#define MAX22200_FAULT_REG		0x0C
+#define MAX22200_CFG_DPM_REG		0x0E
+
+/* Write/Read Masks */
+#define MAX22200_RW_MASK		NO_OS_BIT(7)
+#define MAX22200_ADDR_MASK		NO_OS_GENMASK(6, 0)
+
+/* Status Register Masks */
+#define MAX22200_ONCH_MASK(x)		NO_OS_BIT((x) + 24)
+#define MAX22200_STATUS_ONCH_MASK	NO_OS_GENMASK(31, 24)
+#define MAX22200_STATUS_FREQ_MASK	NO_OS_BIT(16)
+#define MAX22200_STATUS_FAULT_MASK(x)	NO_OS_BIT(x)
+#define MAX22200_STATUS_MODE_MASK	NO_OS_GENMASK(15, 8)
+#define MAX22200_CH_MODE_MASK(x)	NO_OS_GENMASK(8 + (2 * (x)), 9 + (2 * (x)))
+#define MAX22200_STATUS_FLAG_MASK	NO_OS_GENMASK(7, 0)
+#define MAX22200_ACTIVE_MASK		NO_OS_BIT(0)
+
+/* CFG CH Register Masks */
+#define MAX22200_HFS_MASK		NO_OS_BIT(31)
+#define MAX22200_HOLD_MASK		NO_OS_GENMASK(30, 24)
+#define MAX22200_TRGNSP_IO_MASK		NO_OS_BIT(23)
+#define MAX22200_HIT_MASK		NO_OS_GENMASK(22, 16)
+#define MAX22200_HIT_T_MASK		NO_OS_GENMASK(15, 8)
+#define MAX22200_VDRNCDR_MASK		NO_OS_BIT(7)
+#define MAX22200_HSNLS_MASK		NO_OS_BIT(6)
+#define MAX22200_FREQ_CFG_MASK		NO_OS_GENMASK(5, 4)
+#define MAX22200_CH_ENABLE_MASK(x)	NO_OS_BIT(x)
+
+/* CFG DPM Register Masks */
+#define MAX22200_DPM_ISTART_MASK	NO_OS_GENMASK(14, 8)
+#define MAX22200_DPM_TDEB_MASK		NO_OS_GENMASK(7, 4)
+#define MAX22200_DPM_IPTH_MASK		NO_OS_GENMASK(3, 0)
+
+enum max22200_fault_mask {
+	MAX22200_M_UVM = 17,
+	MAX22200_M_COMF,
+	MAX22200_M_DPM,
+	MAX22200_M_HHF,
+	MAX22200_M_OLF,
+	MAX22200_M_OCP,
+	MAX22200_M_OVT
+};
+
+enum max22200_chopping_freq {
+	MAX22200_FREQ_100KHZ,
+	MAX22200_FREQ_80KHZ
+};
+
+enum max22200_ch_op_mode {
+	MAX22200_INDEPENDENT_MODE,
+	MAX22200_PARALLEL_MODE,
+	MAX22200_HALF_BRIDGE_MODE,
+};
+
+enum max22200_scale {
+	MAX22200_FULLSCALE,
+	MAX22200_HALF_FULL_SCALE
+};
+
+enum max22200_trig {
+	MAX22200_ONCH_SPI,
+	MAX22200_TRIG
+};
+
+enum max22200_ch_drive {
+	MAX22200_CURRENT_DRIVE,
+	MAX22200_VOLTAGE_DRIVE
+};
+
+enum max22200_ch_side {
+	MAX22200_LOW_SIDE,
+	MAX22200_HIGH_SIDE
+};
+
+enum max22200_ch_freq {
+	MAX22200_FREQMAIN_DIV_4,
+	MAX22200_FREQMAIN_DIV_3,
+	MAX22200_FREQMAIN_DIV_2,
+	MAX22200_FREQMAIN
+};
+
+enum max22200_ch_enable {
+	MAX22200_HHF_ENABLE,
+	MAX22200_DPM_ENABLE,
+	MAX22200_OL_ENABLE,
+	MAX22200_SRC
+};
+
+struct max22200_init_param {
+	struct no_os_spi_init_param *comm_param;
+	struct no_os_gpio_init_param *fault_param;
+	struct no_os_gpio_init_param *enable_param;
+	struct no_os_gpio_init_param *cmd_param;
+	struct no_os_gpio_init_param *trig_param;
+	enum max22200_ch_op_mode ch_config[MAX22200_CHANNELS_CONFIG];
+};
+
+struct max22200_desc {
+	struct no_os_spi_desc *comm_desc;
+	struct no_os_gpio_desc *fault_desc;
+	struct no_os_gpio_desc *enable_desc;
+	struct no_os_gpio_desc *cmd_desc;
+	struct no_os_gpio_desc *trig_desc;
+	uint8_t buff[MAX22200_FRAME_SIZE];
+	enum max22200_ch_op_mode ch_config[MAX22200_CHANNELS_CONFIG];
+	enum max22200_ch_side chan_side;
+	enum max22200_ch_drive chan_drive;
+};
+
+/** Read data from desired register for MAX22200. */
+int max22200_reg_read(struct max22200_desc *, uint32_t, uint32_t *);
+
+/** Write data to desired register for MAX22200 */
+int max22200_reg_write(struct max22200_desc *, uint32_t, uint32_t);
+
+/** Update data in the desired register. */
+int max22200_reg_update(struct max22200_desc *, uint32_t, uint32_t, uint32_t);
+
+/** Set external trigger's state of the MAX22200. */
+int max22200_set_trig_state(struct max22200_desc *, bool);
+
+/** Set channel state for specific channel. */
+int max22200_set_ch_state(struct max22200_desc *, uint32_t, bool);
+
+/** Set fault mask bits in the status register. */
+int max22200_fault_mask_set(struct max22200_desc *, enum max22200_fault_mask,
+			    bool);
+
+/** Set device frequency value. */
+int max22200_set_chop_freq(struct max22200_desc *, enum max22200_chopping_freq);
+
+/** Set channel HIT time and HIT current. */
+int max22200_set_ch_hit(struct max22200_desc *, uint32_t, uint8_t, uint8_t);
+
+/** Set channel hold current. */
+int max22200_set_ch_hold(struct max22200_desc *, uint32_t, uint8_t);
+
+/** Set channel's scale to fullscale or half fullscale. */
+int max22200_set_ch_scale(struct max22200_desc *, uint32_t,
+			  enum max22200_scale);
+
+/** Set channel's trigger to be either SPI or external trigger. */
+int max22200_set_ch_trig(struct max22200_desc *, uint32_t, enum max22200_trig);
+
+/** Set chanmel operation mode, high-side/low-side and drive. */
+int max22200_set_ch_mode(struct max22200_desc *, uint32_t,
+			 enum max22200_ch_drive, enum max22200_ch_side,
+			 enum max22200_ch_op_mode);
+
+/** Set channel's frequency. */
+int max22200_set_ch_freq(struct max22200_desc *, uint32_t,
+			 enum max22200_ch_freq);
+
+/** Set channel's enables for different checks, detection and functions. */
+int max22200_set_ch_enable(struct max22200_desc *, uint32_t,
+			   enum max22200_ch_enable, bool);
+
+/** Set configuration DPM. */
+int max22200_set_cfg_dpm(struct max22200_desc *, uint8_t, uint8_t);
+
+/** Fault mask bit get function */
+int max22200_fault_mask_get(struct max22200_desc *, enum max22200_fault_mask,
+			    bool *);
+
+/** Get the state of a specific channel. */
+int max22200_get_ch_state(struct max22200_desc *, uint32_t, bool *);
+
+/** Read device frequency */
+int max22200_get_chop_freq(struct max22200_desc *,
+			   enum max22200_chopping_freq *);
+
+/** Read channel HIT configuration. */
+int max22200_get_ch_hit(struct max22200_desc *, uint32_t, uint8_t *, uint8_t *);
+
+/** Read channel HOLD configuration. */
+int max22200_get_ch_hold(struct max22200_desc *, uint32_t, uint8_t *);
+
+/** Read channel's scale. */
+int max22200_get_ch_scale(struct max22200_desc *, uint32_t,
+			  enum max22200_scale *);
+
+/** Read channel's selected trigger for specific channel. */
+int max22200_get_ch_trig(struct max22200_desc *, uint32_t,
+			 enum max22200_trig *);
+
+/** Read channel's mode configuration. */
+int max22200_get_ch_mode(struct max22200_desc *, uint32_t,
+			 enum max22200_ch_drive *, enum max22200_ch_side *,
+			 enum max22200_ch_op_mode *);
+
+/** Read channel's frequency. */
+int max22200_get_ch_freq(struct max22200_desc *, uint32_t,
+			 enum max22200_ch_freq *);
+
+/** Read channel's enable bits state. */
+int max22200_get_ch_enable(struct max22200_desc *, uint32_t,
+			   enum max22200_ch_enable, bool *);
+
+/** Read configuration for the detection of the plunger movement of the
+    device. */
+int max22200_get_cfg_dpm(struct max22200_desc *, uint8_t *, uint8_t *);
+
+/** MAX22200 device initialization function. */
+int max22200_init(struct max22200_desc **, struct max22200_init_param *);
+
+/** Deallocates all the resources used at initialization. */
+int max22200_remove(struct max22200_desc *);
+
+#endif /* _MAX22200_H */


### PR DESCRIPTION
## Pull Request Description

Add driver support for MAX22200.

The MAX22200 is an octal 36V serial-controlled solenoid driver.
Each channel features a low impedance (200mΩ typ) push-pull output stage with sink-and-source driving
capability and up to 1ARMS driving current. A serial interface (SPI) that also supports daisy-chain configurations is
provided to individually control each channel

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
