### PR TITLE
tools: scripts: generic_variables: handle maxim

### DIFF
--- a/tools/scripts/generic_variables.mk
+++ b/tools/scripts/generic_variables.mk
@@ -57,7 +57,11 @@ else
 ifneq '' '$(findstring pinmux_config.c,$(HARDWARE))'
 PLATFORM = aducm3029
 else
+ifneq '' '$(findstring max,$(TARGET))'
+PLATFORM = maxim
+else
 $(error No HARDWARE found)
+endif
 endif
 endif
 endif


### PR DESCRIPTION
## Pull Request Description

If a TARGET is specified as parameter to the make command and has the `max` prefix, then assume that the PLATFORM=maxim.

This patch allows building maxim platform projects without specifying explicitly the platform if there is a maxim TARGET set.

Example:
`make PLATFORM=maxim TARGET=max32650`
can be called now simply
`make TARGET=max32650`

A similar approach is already implemented for the xilinx projects where if a user sets the HARDWARE variable, the PLATFORM is set automatically to `xilinx`.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
