### PR TITLE
iio: iio_app: Check if uart_desc is allocated

### DIFF
--- a/iio/iio_app/iio_app.c
+++ b/iio/iio_app/iio_app.c
@@ -461,9 +461,11 @@ int iio_app_remove(struct iio_app_desc *app)
 		return ret;
 #endif
 
-	ret = no_os_uart_remove(app->uart_desc);
-	if (ret)
-		return ret;
+	if (app->uart_desc) {
+		ret = no_os_uart_remove(app->uart_desc);
+		if (ret)
+			return ret;
+	}
 
 	ret = iio_remove(app->iio_desc);
 	if (ret)


### PR DESCRIPTION
## Pull Request Description

Only free the uart decriptor if it was previously allocated in the init function. Otherwise, this causes the remove to fail.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
