### PR TITLE
projects: max14906 : Fix maxim interrupt handling for MAX14906 project

### DIFF
--- a/projects/max14906/src/platform/maxim/main.c
+++ b/projects/max14906/src/platform/maxim/main.c
@@ -58,22 +58,22 @@ int main()
 
 #ifdef BASIC_EXAMPLE
 	struct no_os_uart_desc *uart_desc;
-	struct no_os_irq_ctrl_desc *gpio_irq_desc;
-	struct no_os_irq_init_param gpio_irq_desc_param = {
-		.irq_ctrl_id = GPIO_IRQ_ID,
-		.platform_ops = GPIO_IRQ_OPS,
-		.extra = NULL
+
+	/* NVIC Interrupt Controller specific for Maxim platform. */
+	struct no_os_irq_ctrl_desc *nvic_desc;
+	struct no_os_irq_init_param nvic_desc_param = {
+		.platform_ops = &max_irq_ops,
 	};
 
 	ret = no_os_uart_init(&uart_desc, &max14906_uart_ip);
 	if (ret)
 		return ret;
 
-	ret = no_os_irq_ctrl_init(&gpio_irq_desc, &gpio_irq_desc_param);
+	ret = no_os_irq_ctrl_init(&nvic_desc, &nvic_desc_param);
 	if (ret)
 		goto max14906_uart_remove;
 
-	ret = no_os_irq_enable(gpio_irq_desc, GPIO0_IRQn);
+	ret = no_os_irq_enable(nvic_desc, NVIC_GPIO_IRQ);
 	if (ret)
 		goto max14906_irq_ctrl_remove;
 
@@ -82,7 +82,7 @@ int main()
 	ret = basic_example_main();
 
 max14906_irq_ctrl_remove:
-	no_os_irq_ctrl_remove(gpio_irq_desc);
+	no_os_irq_ctrl_remove(nvic_desc);
 max14906_uart_remove:
 	no_os_uart_remove(uart_desc);
 

--- a/projects/max14906/src/platform/maxim/parameters.h
+++ b/projects/max14906/src/platform/maxim/parameters.h
@@ -82,15 +82,18 @@ extern struct max_spi_init_param max14906_spi_extra;
 #define GPIO_EXTRA	&max14906_gpio_extra_ip
 #define GPIO_IRQ_OPS	&max_gpio_irq_ops
 #define GPIO_IRQ_EXTRA	NULL
+
 extern struct max_gpio_init_param max14906_gpio_extra_ip;
 #if (TARGET_NUM == 32665)
 #define GPIO_FAULT_PORT_NUM	0
 #define GPIO_FAULT_PIN_NUM	5
 #define GPIO_IRQ_ID		0
+#define NVIC_GPIO_IRQ		GPIO0_IRQn
 #elif (TARGET_NUM == 32690)
 #define GPIO_FAULT_PORT_NUM	2
 #define GPIO_FAULT_PIN_NUM	21
 #define GPIO_IRQ_ID		2
+#define NVIC_GPIO_IRQ		GPIO2_IRQn
 #endif
 #endif
 


### PR DESCRIPTION
## Pull Request Description

Fix maxim interrupt handling bug consisting of NVIC controller not being properly initialized.

Fixes: '3ceb54f' ("projects: max14906 : Change interrupt support for MAXIM platform")

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
