### PR TITLE
ci: run_build: ensure wget command exists

### DIFF
--- a/ci/run_build.sh
+++ b/ci/run_build.sh
@@ -68,6 +68,7 @@ ensure_command_exists() {
 }
 
 ensure_command_exists sudo
+ensure_command_exists wget
 
 build_astyle() {
     . ./ci/astyle.sh


### PR DESCRIPTION
## Pull Request Description

Call `ensure_command_exists wget` prior to running build functions.

The command is used both in `build_astyle` function and `build_documentation`.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
