### PR TITLE
adrv902x: Fix uart src in platform_src.mk

### DIFF
--- a/projects/adrv902x/src/platform/xilinx/platform_src.mk
+++ b/projects/adrv902x/src/platform/xilinx/platform_src.mk
@@ -6,7 +6,7 @@ SRCS += $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.c \
 	$(PLATFORM_DRIVERS)/xilinx_delay.c
 	
 ifeq (y,$(strip $(IIOD)))
-SRCS += $(PLATFORM_DRIVERS)/$xilinx_uart.c
+SRCS += $(PLATFORM_DRIVERS)/xilinx_uart.c
 endif
 	
 INCS += $(DRIVERS)/axi_core/jesd204/xilinx_transceiver.h \


### PR DESCRIPTION
Fix the xilinx_uart.c src in the platform_src.mk file.

Fixes: ab393ac ("projects: adrv9025: Madura project")

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
