### PR TITLE
frequency: ad9528: ad9528.c: Set correct rate value in ad9528_clk_recalc_rate

### DIFF
--- a/drivers/frequency/ad9528/ad9528.c
+++ b/drivers/frequency/ad9528/ad9528.c
@@ -388,6 +388,8 @@ int32_t ad9528_clk_recalc_rate(struct no_os_clk_desc *desc,
 		val /= AD9528_CLK_DIST_DIV_REV(reg_val);
 	}
 
+	*rate = val;
+
 	return 0;
 }
 


### PR DESCRIPTION
Set the rate value in ad9528_clk_recalc_rate.

Fixes: ad66d6d ("drivers: frequency: ad9528: Add FSM ops")

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
