### PR TITLE
tools: scripts: fix maxim target handling

### DIFF
--- a/tools/scripts/generic_variables.mk
+++ b/tools/scripts/generic_variables.mk
@@ -42,6 +42,9 @@ LINK_SRCS ?= y
 
 HARDWARE ?= $(wildcard *.xsa) $(wildcard *.hdf) $(wildcard *.sopcinfo) $(wildcard *.ioc) $(wildcard pinmux_config.c)
 #If platform not set get it from HARDWARE file
+ifneq '' '$(findstring max,$(TARGET))'
+PLATFORM = maxim
+else
 ifeq '' '$(PLATFORM)'
 ifneq '' '$(findstring .xsa,$(HARDWARE))'
 PLATFORM = xilinx
@@ -57,9 +60,6 @@ PLATFORM = stm32
 else
 ifneq '' '$(findstring pinmux_config.c,$(HARDWARE))'
 PLATFORM = aducm3029
-else
-ifneq '' '$(findstring max,$(TARGET))'
-PLATFORM = maxim
 else
 $(error No HARDWARE or TARGET found. Please specify one of them.)
 endif


### PR DESCRIPTION


## Pull Request Description

If a hardware file exists (.xsa, .hdf, .ioc, etc) even though the max target is specified the build will perform for the first hardware file that is found.

Fixes: ded4e85 ("tools: scripts: generic_variables: handle maxim")

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
