### PR TITLE
include: Add constant GENMASK macro

### DIFF
--- a/include/no_os_util.h
+++ b/include/no_os_util.h
@@ -83,12 +83,10 @@
 
 #define NO_OS_BITS_PER_LONG 32
 
-#define NO_OS_GENMASK(h, l) ({ 					\
-		uint32_t t = (uint32_t)(~0UL);			\
-		t = t << (NO_OS_BITS_PER_LONG - (h - l + 1));		\
-		t = t >> (NO_OS_BITS_PER_LONG - (h + 1));		\
-		t;						\
-})
+#define NO_OS_GENMASK(h, l) (					\
+	(((uint32_t)(~0UL) << (l))) &				\
+	(((uint32_t)(~0UL) >> (NO_OS_BITS_PER_LONG - (h + 1))))	\
+)
 
 #define no_os_bswap_constant_32(x) \
 	((((x) & 0xff000000) >> 24) | (((x) & 0x00ff0000) >>  8) | \


### PR DESCRIPTION
Replace non-constant GENMASK macro with constant alternative.
This is the [implementation in the Linux kernel](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/bits.h?h=v6.7-rc4#n33).

## Pull Request Description

Allows to use GENMASK in header files and the assembly is much simpler.
Assembly comparison:
* [Master](https://godbolt.org/z/nTW1ndvc3)
* [PR](https://godbolt.org/z/j8djah9o4)

## PR Type
- [X] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [X] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [X] I have performed a self-review of the changes
- [X] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [X] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
