### PR TITLE
adc-dac: ad74416h: add missing breaks

### DIFF
--- a/drivers/adc-dac/ad74416h/ad74416h.c
+++ b/drivers/adc-dac/ad74416h/ad74416h.c
@@ -91,8 +91,10 @@ int ad74416h_dac_voltage_to_code(struct ad74416h_desc *desc, int32_t mvolts,
 	switch(desc->id) {
 	case ID_AD74414H:
 		res = AD74414H_DAC_RESOLUTION;
+		break;
 	case ID_AD74416H:
 		res = AD74416H_DAC_RESOLUTION;
+		break;
 	default:
 		return -EINVAL;
 	}
@@ -134,8 +136,10 @@ int ad74416h_dac_current_to_code(struct ad74416h_desc *desc, uint32_t uamps,
 	switch(desc->id) {
 	case ID_AD74414H:
 		res = AD74414H_DAC_RESOLUTION;
+		break;
 	case ID_AD74416H:
 		res = AD74416H_DAC_RESOLUTION;
+		break;
 	default:
 		return -EINVAL;
 	}


### PR DESCRIPTION
## Pull Request Description

Add missing break statements in the switch cases for device id.

Fixes: 44aa88f ("adc-dac: ad74416h: add dac resolution for ad74414h")

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
