### PR TITLE
condition the vs code project configuration

### DIFF
--- a/tools/scripts/generic.mk
+++ b/tools/scripts/generic.mk
@@ -79,6 +79,7 @@ BINARY_FILE_NAME ?= $(PROJECT_NAME)
 BINARY			?=  $(BUILD_DIR)/$(BINARY_FILE_NAME).elf
 PROJECT_TARGET		= $(BUILD_DIR)/.project.target
 VSCODE_CFG_DIR	= $(PROJECT)/.vscode
+VSCODE_SUPPORT	?= no
 
 # New line variable
 define ENDL

--- a/tools/scripts/stm32.mk
+++ b/tools/scripts/stm32.mk
@@ -1,3 +1,5 @@
+VSCODE_SUPPORT = yes
+
 IDE = stm32cubeide
 STM32CUBEIDE ?= $(wildcard /opt/stm32cubeide)
 ifeq ($(STM32CUBEIDE),)

--- a/tools/scripts/vsc_intellisense.mk
+++ b/tools/scripts/vsc_intellisense.mk
@@ -1,6 +1,7 @@
 #
 #	Makefile to create project dependent configs files to enable VS Code IntelliSense
 #
+ifeq 'yes' '$(VSCODE_SUPPORT)'
 
 # Definitions
 CPP_PROP_TEMPLATE		= $(NO-OS)/tools/scripts/platform/template_c_cpp_properties.json
@@ -33,4 +34,6 @@ INCLUDEPATH_INTELLI		:= $(subst ${INCLUDE_NOOS_PATTERN},$(INCLUDE_NOOS_CORRECTED
 CPP_FINAL_CONTENT		:= $(file < $(CPP_PROP_TEMPLATE))
 CPP_FINAL_CONTENT		:= $(subst VSCODE_INCLUDEPATH_INTELLI,$(INCLUDEPATH_INTELLI),$(CPP_FINAL_CONTENT))
 CPP_FINAL_CONTENT 		:= $(subst VSCODE_DEFINES_INTELLI,$(DEFINES_INTELLI),$(CPP_FINAL_CONTENT))
+
+endif
 

--- a/tools/scripts/vsc_openocd_debug.mk
+++ b/tools/scripts/vsc_openocd_debug.mk
@@ -1,6 +1,7 @@
 #
 #	Makefile to create project dependent configs files for debugging with openocd
 #
+ifeq 'yes' '$(VSCODE_SUPPORT)'
 
 # Definitions
 SETTINGS_TEMPLATE	:= $(NO-OS)/tools/scripts/platform/template_settings.json
@@ -23,4 +24,6 @@ VSC_LAUNCH_CONTENT	:= $(subst VSCODE_SEARCH_DIR,"$(OPENOCD_SCRIPTS)",$(VSC_LAUNC
 VSC_LAUNCH_CONTENT	:= $(subst VSCODE_CMSISCFG_FILE,"$(BINARY).openocd-cmsis",$(VSC_LAUNCH_CONTENT))
 VSC_LAUNCH_CONTENT	:= $(subst VSCODE_STLINKCFG_FILE,"$(BINARY).openocd",$(VSC_LAUNCH_CONTENT))
 VSC_LAUNCH_CONTENT	:= $(subst VSCODE_SVD_FILE,"$(OPENOCD_SVD)/$(TARGETSVD).svd",$(VSC_LAUNCH_CONTENT))
+
+endif
 


### PR DESCRIPTION
## Pull Request Description
This is currently only supported on stm32, so limit it to that
platform. This fixes some issues with building for xilinx platform
which has a funky way of detecting the architecture (build/tmp/arch.txt)
which makes the builds fail. The failure is due to a which command
call without arguments and it all comes from vs code support.

https://ez.analog.com/microcontroller-no-os-drivers/f/q-a/576135/no-os-build-ad9081-vitis-2022-2

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
