### PR TITLE
projects: ad9361: Add System ID support

### DIFF
--- a/projects/ad9361/src.mk
+++ b/projects/ad9361/src.mk
@@ -17,6 +17,7 @@ SRCS += $(DRIVERS)/rf-transceiver/ad9361/ad9361_api.c \
 SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
 	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.c \
 	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+	$(DRIVERS)/axi_core/axi_sysid/axi_sysid.c \
 	$(DRIVERS)/api/no_os_spi.c \
 	$(DRIVERS)/api/no_os_gpio.c \
 	$(NO-OS)/util/no_os_util.c \
@@ -62,7 +63,8 @@ INCS += $(DRIVERS)/rf-transceiver/ad9361/ad9361.h \
 INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \
 	$(DRIVERS)/axi_core/axi_dac_core/axi_dac_core.h \
 	$(INCLUDE)/no_os_irq.h \
-	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
+	$(DRIVERS)/axi_core/axi_sysid/axi_sysid.h
 ifeq (linux,$(strip $(PLATFORM)))
 CFLAGS += -DPLATFORM_MB
 INCS +=	$(PLATFORM_DRIVERS)/linux_spi.h \
@@ -77,7 +79,8 @@ INCS +=	$(INCLUDE)/no_os_axi_io.h \
 	$(INCLUDE)/no_os_delay.h \
 	$(INCLUDE)/no_os_util.h \
 	$(INCLUDE)/no_os_alloc.h \
-	$(INCLUDE)/no_os_mutex.h
+	$(INCLUDE)/no_os_mutex.h \
+	$(INCLUDE)/no_os_print_log.h
 ifeq (y,$(strip $(IIOD)))
 
 ifeq (linux,$(strip $(PLATFORM)))

--- a/projects/ad9361/src/parameters.h
+++ b/projects/ad9361/src/parameters.h
@@ -50,6 +50,7 @@
 /******************************************************************************/
 #ifdef _XPARAMETERS_PS_H_
 #define UART_BAUDRATE 921600
+#define SYSID_BASEADDR			XPAR_AXI_SYSID_0_BASEADDR
 #else
 #define UART_BAUDRATE 115200
 #endif


### PR DESCRIPTION
## Pull Request Description

Add the possibility to detect the FPGA board running the project.

Needed for setting the UART baudrate to 115200 instead of 921600 for IIOD in the case of a ZedBoard.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
