### PR TITLE
SPI: STM32: Dont enable/disable HAL on transfer

### DIFF
--- a/drivers/platform/stm32/stm32_spi.c
+++ b/drivers/platform/stm32/stm32_spi.c
@@ -143,7 +143,9 @@ static int stm32_spi_config(struct no_os_spi_desc *desc)
 		ret = -EIO;
 		goto error;
 	}
-
+#ifdef SPI_SR_TXE
+	__HAL_SPI_ENABLE(&sdesc->hspi);
+#endif
 	return 0;
 error:
 	return ret;
@@ -232,6 +234,9 @@ int32_t stm32_spi_remove(struct no_os_spi_desc *desc)
 		return -EINVAL;
 
 	sdesc = desc->extra;
+#ifdef SPI_SR_TXE
+	__HAL_SPI_DISABLE(&sdesc->hspi);
+#endif
 	HAL_SPI_DeInit(&sdesc->hspi);
 	no_os_gpio_remove(sdesc->chip_select);
 	no_os_free(desc->extra);
@@ -317,7 +322,6 @@ int32_t stm32_spi_transfer(struct no_os_spi_desc *desc,
 #else
 		rx_cnt = 0;
 		tx_cnt = 0;
-		__HAL_SPI_ENABLE(&sdesc->hspi);
 
 		while ((msgs[i].rx_buff && rx_cnt < msgs[i].bytes_number) ||
 		       (msgs[i].tx_buff && tx_cnt < msgs[i].bytes_number)) {
@@ -336,7 +340,6 @@ int32_t stm32_spi_transfer(struct no_os_spi_desc *desc,
 				(void)*(volatile uint8_t *)&SPIx->DR;
 		}
 
-		__HAL_SPI_DISABLE(&sdesc->hspi);
 #endif
 
 		if(msgs[i].cs_delay_last)


### PR DESCRIPTION
On SPI MODE 2, the first bit of data sent by the salve is wrong.

This happens because the platform spi driver disables the SPI HAL after each trasfer reulting on the clk line beeing put back to its default floating state. It may go to 0v or 1.8v depending on the gpio pull configuration. The spi transactions level is 3.3v.

Because of the software controlled CS, the CS pin is active when HAL is enabled for the next xfer creating an invalid clk edge seen by the slave. The result is that the fist bit of the data transfer is wrong.

Keep the HAL enabled and avoid enabling and disabling on each trasfer.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
