### PR TITLE
drivers: api: Fix variable assignment

### DIFF
--- a/drivers/api/no_os_i2c.c
+++ b/drivers/api/no_os_i2c.c
@@ -147,7 +147,7 @@ void no_os_i2cbus_remove(uint32_t bus_number)
 
 		if (bus != NULL) {
 			no_os_free(bus);
-			bus = NULL;
+			i2c_table[bus_number] = NULL;
 		}
 	}
 }


### PR DESCRIPTION
The intent is to set i2c_table[bus_number] to NULL, so that we know the memory has been freed. However, the current implementation just makes the bus variable point to NULL, while i2c_table[bus_number] remains unchaged.

Running the init(), remove(), init() sequence will result in using freed memory after the second init. Fix this by correctly setting the i2c_table array element to NULL.

Fixes: d4a9723 ("spi and i2c: added slave counter for deallocation check")

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
