### PR TITLE
Allow for IP setting at compile time

### DIFF
--- a/network/lwip_raw_socket/lwip_socket.c
+++ b/network/lwip_raw_socket/lwip_socket.c
@@ -285,6 +285,9 @@ int32_t no_os_lwip_init(struct lwip_network_desc **desc,
 	struct lwip_network_desc *descriptor;
 	struct netif *netif_descriptor;
 	ip4_addr_t ipaddr, netmask, gw;
+	uint32_t raw_netmask[4] = {0};
+	uint32_t raw_gateway[4] = {0};
+	uint32_t raw_ip[4] = {0};
 	int ret;
 	int i;
 
@@ -308,10 +311,24 @@ int32_t no_os_lwip_init(struct lwip_network_desc **desc,
 
 	lwip_init();
 
-#ifdef NO_OS_STATIC_IP
-	IP4_ADDR(&ipaddr, 169, 254, 97, 40);
-	IP4_ADDR(&netmask, 255, 255, 0, 0);
-	IP4_ADDR(&gw, 0, 0, 0, 0);
+#ifdef NO_OS_IP
+#ifndef NO_OS_NETMASK
+#error NO_OS_NETMASK not defined
+#endif
+#ifndef NO_OS_GATEWAY
+#error NO_OS_GATEWAY not defined
+#endif
+	sscanf(NO_OS_IP, "%d.%d.%d.%d", &raw_ip[0], &raw_ip[1], &raw_ip[2],
+	       &raw_ip[3]);
+	sscanf(NO_OS_NETMASK, "%d.%d.%d.%d", &raw_netmask[0], &raw_netmask[1],
+	       &raw_netmask[2], &raw_netmask[3]);
+	sscanf(NO_OS_GATEWAY, "%d.%d.%d.%d", &raw_gateway[0], &raw_gateway[1],
+	       &raw_gateway[2], &raw_gateway[3]);
+
+	IP4_ADDR(&ipaddr, raw_ip[0], raw_ip[1], raw_ip[2], raw_ip[3]);
+	IP4_ADDR(&netmask, raw_netmask[0], raw_netmask[1], raw_netmask[2],
+		 raw_netmask[3]);
+	IP4_ADDR(&gw, raw_gateway[0], raw_gateway[1], raw_gateway[2], raw_gateway[3]);
 #else
 	ip4_addr_set_zero(&ipaddr);
 	ip4_addr_set_zero(&netmask);
@@ -332,7 +349,7 @@ int32_t no_os_lwip_init(struct lwip_network_desc **desc,
 
 	netif_set_link_up(netif_descriptor);
 
-#ifndef NO_OS_STATIC_IP
+#ifndef NO_OS_IP
 	uint32_t dhcp_timeout = 20000;
 	ret = dhcp_start(netif_descriptor);
 	if (ret)

--- a/projects/apard32690/Makefile
+++ b/projects/apard32690/Makefile
@@ -9,3 +9,13 @@ include ../../tools/scripts/generic_variables.mk
 include src.mk
 
 include ../../tools/scripts/generic.mk
+
+ifndef APARD32690_STATIC_IP
+APARD32690_STATIC_IP = n
+endif
+
+ifeq (y,$(strip $(APARD32690_STATIC_IP)))
+NO_OS_IP=169.254.97.40
+NO_OS_NETMASK=255.255.255.0
+NO_OS_GATEWAY=0.0.0.0
+endif

--- a/projects/swiot1l/Makefile
+++ b/projects/swiot1l/Makefile
@@ -1,6 +1,16 @@
 PLATFORM = maxim
 TARGET = max32650
 
+ifndef SWIOT1L_STATIC_IP
+SWIOT1L_STATIC_IP = n
+endif
+
+ifeq (y,$(strip $(SWIOT1L_STATIC_IP)))
+NO_OS_IP=169.254.97.40
+NO_OS_NETMASK=255.255.255.0
+NO_OS_GATEWAY=0.0.0.0
+endif
+
 include ../../tools/scripts/generic_variables.mk
 
 include src.mk
@@ -10,11 +20,3 @@ include ../../tools/scripts/generic.mk
 CFLAGS += -DNO_OS_LWIP_NETWORKING
 CFLAGS += -DIIO_IGNORE_BUFF_OVERRUN_ERR
 CFLAGS += -DNO_OS_LWIP_INIT_ONETIME=1
-
-ifndef NO_OS_STATIC_IP
-NO_OS_STATIC_IP = n
-endif
-
-ifeq (y,$(strip $(NO_OS_STATIC_IP)))
-CFLAGS += -DNO_OS_STATIC_IP
-endif

--- a/projects/swiot1l/builds.json
+++ b/projects/swiot1l/builds.json
@@ -1,10 +1,10 @@
 {
 	"maxim": {
 	  "swiot1l_dhcp": {
-	    "flags" : "RELEASE=y NO_OS_STATIC_IP=n"
+	    "flags" : "RELEASE=y SWIOT1L_STATIC_IP=n"
 	  },
 	  "swiot1l_static_ip": {
-	    "flags" : "RELEASE=y NO_OS_STATIC_IP=y"
+	    "flags" : "RELEASE=y SWIOT1L_STATIC_IP=y"
 	  }
 	}
 }

--- a/tools/scripts/lwip.mk
+++ b/tools/scripts/lwip.mk
@@ -17,3 +17,15 @@ INCS += $(NO-OS)/network/lwip_raw_socket/lwip_socket.h
 INCS += $(NO-OS)/network/tcp_socket.h
 SRCS += $(NO-OS)/network/tcp_socket.c
 SRCS += $(NO-OS)/network/lwip_raw_socket/lwip_socket.c
+
+ifdef NO_OS_IP
+CFLAGS += -DNO_OS_IP=\"$(NO_OS_IP)\"
+endif
+
+ifdef NO_OS_NETMASK
+CFLAGS += -DNO_OS_NETMASK=\"$(NO_OS_NETMASK)\"
+endif
+
+ifdef NO_OS_GATEWAY
+CFLAGS += -DNO_OS_GATEWAY=\"$(NO_OS_GATEWAY)\"
+endif


### PR DESCRIPTION
## Pull Request Description
Add compile flags for IP, netmask and gateway. These take effect when using the networking layer based on lwip sockets and allow the user to configure these parameters, instead of using the predefined ones we currently have. Change project makefiles in order to keep the current IP settings.

The format should be (similar for the other ones): NO_OS_IP = A.B.C.D

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
