### PR TITLE
Fix SPI struct field access

### DIFF
--- a/drivers/platform/maxim/max32650/maxim_spi.c
+++ b/drivers/platform/maxim/max32650/maxim_spi.c
@@ -437,7 +437,7 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 
 		if (msgs[i].tx_buff) {
 			/* Set the transfer size in the TX direction */
-			spi->ctrl1 = msgs->bytes_number;
+			spi->ctrl1 = msgs[i].bytes_number;
 			tx_done = false;
 			/* Enable the TX FIFO */
 			spi->dma |= MXC_F_SPI_DMA_TX_FIFO_EN;
@@ -448,7 +448,7 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 		if (msgs[i].rx_buff) {
 			/* Set the transfer size in the RX direction */
 			spi->ctrl1 |= no_os_field_prep(MXC_F_SPI_CTRL1_RX_NUM_CHAR,
-						       msgs->bytes_number);
+						       msgs[i].bytes_number);
 			/* Enable the RX FIFO */
 			spi->dma |= MXC_F_SPI_DMA_RX_FIFO_EN;
 			rx_done = false;

--- a/drivers/platform/maxim/max32655/maxim_spi.c
+++ b/drivers/platform/maxim/max32655/maxim_spi.c
@@ -348,7 +348,7 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 
 		if (msgs[i].tx_buff) {
 			/* Set the transfer size in the TX direction */
-			spi->ctrl1 = msgs->bytes_number;
+			spi->ctrl1 = msgs[i].bytes_number;
 			tx_done = false;
 			/* Enable the TX FIFO */
 			spi->dma |= MXC_F_SPI_DMA_TX_FIFO_EN;
@@ -359,7 +359,7 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 		if (msgs[i].rx_buff) {
 			/* Set the transfer size in the RX direction */
 			spi->ctrl1 |= no_os_field_prep(MXC_F_SPI_CTRL1_RX_NUM_CHAR,
-						       msgs->bytes_number);
+						       msgs[i].bytes_number);
 			/* Enable the RX FIFO */
 			spi->dma |= MXC_F_SPI_DMA_RX_FIFO_EN;
 			rx_done = false;

--- a/drivers/platform/maxim/max32660/maxim_spi.c
+++ b/drivers/platform/maxim/max32660/maxim_spi.c
@@ -341,7 +341,7 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 
 		if (msgs[i].tx_buff) {
 			/* Set the transfer size in the TX direction */
-			spi->ctrl1 = msgs->bytes_number;
+			spi->ctrl1 = msgs[i].bytes_number;
 			tx_done = false;
 			/* Enable the TX FIFO */
 			spi->dma |= MXC_F_SPI_DMA_TX_FIFO_EN;
@@ -352,7 +352,7 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 		if (msgs[i].rx_buff) {
 			/* Set the transfer size in the RX direction */
 			spi->ctrl1 |= no_os_field_prep(MXC_F_SPI_CTRL1_RX_NUM_CHAR,
-						       msgs->bytes_number);
+						       msgs[i].bytes_number);
 			/* Enable the RX FIFO */
 			spi->dma |= MXC_F_SPI_DMA_RX_FIFO_EN;
 			rx_done = false;

--- a/drivers/platform/maxim/max32665/maxim_spi.c
+++ b/drivers/platform/maxim/max32665/maxim_spi.c
@@ -428,7 +428,7 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 
 		if (msgs[i].tx_buff) {
 			/* Set the transfer size in the TX direction */
-			spi->ctrl1 = msgs->bytes_number;
+			spi->ctrl1 = msgs[i].bytes_number;
 			tx_done = false;
 			/* Enable the TX FIFO */
 			spi->dma |= MXC_F_SPI_DMA_TX_FIFO_EN;
@@ -439,7 +439,7 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 		if (msgs[i].rx_buff) {
 			/* Set the transfer size in the RX direction */
 			spi->ctrl1 |= no_os_field_prep(MXC_F_SPI_CTRL1_RX_NUM_CHAR,
-						       msgs->bytes_number);
+						       msgs[i].bytes_number);
 			/* Enable the RX FIFO */
 			spi->dma |= MXC_F_SPI_DMA_RX_FIFO_EN;
 			rx_done = false;

--- a/drivers/platform/maxim/max32690/maxim_spi.c
+++ b/drivers/platform/maxim/max32690/maxim_spi.c
@@ -431,7 +431,7 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 
 		if (msgs[i].tx_buff) {
 			/* Set the transfer size in the TX direction */
-			spi->ctrl1 = msgs->bytes_number;
+			spi->ctrl1 = msgs[i].bytes_number;
 			tx_done = false;
 			/* Enable the TX FIFO */
 			spi->dma |= MXC_F_SPI_DMA_TX_FIFO_EN;
@@ -442,7 +442,7 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 		if (msgs[i].rx_buff) {
 			/* Set the transfer size in the RX direction */
 			spi->ctrl1 |= no_os_field_prep(MXC_F_SPI_CTRL1_RX_NUM_CHAR,
-						       msgs->bytes_number);
+						       msgs[i].bytes_number);
 			/* Enable the RX FIFO */
 			spi->dma |= MXC_F_SPI_DMA_RX_FIFO_EN;
 			rx_done = false;

--- a/drivers/platform/maxim/max78000/maxim_spi.c
+++ b/drivers/platform/maxim/max78000/maxim_spi.c
@@ -345,7 +345,7 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 
 		if (msgs[i].tx_buff) {
 			/* Set the transfer size in the TX direction */
-			spi->ctrl1 = msgs->bytes_number;
+			spi->ctrl1 = msgs[i].bytes_number;
 			tx_done = false;
 			/* Enable the TX FIFO */
 			spi->dma |= MXC_F_SPI_DMA_TX_FIFO_EN;
@@ -356,7 +356,7 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 		if (msgs[i].rx_buff) {
 			/* Set the transfer size in the RX direction */
 			spi->ctrl1 |= no_os_field_prep(MXC_F_SPI_CTRL1_RX_NUM_CHAR,
-						       msgs->bytes_number);
+						       msgs[i].bytes_number);
 			/* Enable the RX FIFO */
 			spi->dma |= MXC_F_SPI_DMA_RX_FIFO_EN;
 			rx_done = false;


### PR DESCRIPTION
## Pull Request Description

msgs is an array of structs, so its fields should be accessed as msgs[i].field instead.

Fixes: b46faa65227 ("drivers: platform: maxim: Update spi_transfer")

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
