### PR TITLE
Revert "platform: maxim: spi: fix spi modes"

### DIFF
--- a/drivers/platform/maxim/max32650/maxim_spi.c
+++ b/drivers/platform/maxim/max32650/maxim_spi.c
@@ -245,7 +245,6 @@ static int _max_spi_config(struct no_os_spi_desc *desc)
 {
 	struct max_spi_init_param *eparam;
 	struct max_spi_state *st;
-	mxc_spi_mode_t mode;
 	int32_t ret;
 
 	st = desc->extra;
@@ -263,24 +262,7 @@ static int _max_spi_config(struct no_os_spi_desc *desc)
 	if (ret)
 		goto err_init;
 
-	/* For Maxim Platforms SPI Mode 1 and 2 are reversed */
-	switch (desc->mode) {
-	case NO_OS_SPI_MODE_1:
-		mode = SPI_MODE_2;
-		break;
-	case NO_OS_SPI_MODE_2:
-		mode = SPI_MODE_1;
-		break;
-	case NO_OS_SPI_MODE_0:
-	/* fallthrough */
-	case NO_OS_SPI_MODE_3:
-		mode = (mxc_spi_mode_t)desc->mode;
-		break;
-	default:
-		return -EINVAL;
-	}
-
-	ret = MXC_SPI_SetMode(MXC_SPI_GET_SPI(desc->device_id), mode);
+	ret = MXC_SPI_SetMode(MXC_SPI_GET_SPI(desc->device_id), desc->mode);
 	if (ret) {
 		ret = -EINVAL;
 		goto err_init;

--- a/drivers/platform/maxim/max32655/maxim_spi.c
+++ b/drivers/platform/maxim/max32655/maxim_spi.c
@@ -149,7 +149,6 @@ static int _max_spi_config(struct no_os_spi_desc *desc)
 {
 	struct max_spi_init_param *eparam;
 	struct max_spi_state *st;
-	mxc_spi_mode_t mode;
 	int32_t ret;
 
 	st = desc->extra;
@@ -175,23 +174,8 @@ static int _max_spi_config(struct no_os_spi_desc *desc)
 		goto err_init;
 	}
 
-	/* For Maxim Platforms SPI Mode 1 and 2 are reversed */
-	switch (desc->mode) {
-	case NO_OS_SPI_MODE_1:
-		mode = SPI_MODE_2;
-		break;
-	case NO_OS_SPI_MODE_2:
-		mode = SPI_MODE_1;
-		break;
-	case NO_OS_SPI_MODE_0:
-	case NO_OS_SPI_MODE_3:
-		mode = (mxc_spi_mode_t)desc->mode;
-		break;
-	default:
-		return -EINVAL;
-	}
-
-	ret = MXC_SPI_SetMode(MXC_SPI_GET_SPI(desc->device_id), mode);
+	ret = MXC_SPI_SetMode(MXC_SPI_GET_SPI(desc->device_id),
+			      (mxc_spi_mode_t)desc->mode);
 	if (ret) {
 		ret = -EINVAL;
 		goto err_init;

--- a/drivers/platform/maxim/max32660/maxim_spi.c
+++ b/drivers/platform/maxim/max32660/maxim_spi.c
@@ -151,7 +151,6 @@ static int _max_spi_config(struct no_os_spi_desc *desc)
 	struct max_spi_state *st;
 	struct max_spi_init_param *eparam;
 	mxc_gpio_cfg_t spi_pins = gpio_cfg_spi0;
-	mxc_spi_mode_t mode;
 
 	st = desc->extra;
 	eparam = st->init_param;
@@ -167,24 +166,8 @@ static int _max_spi_config(struct no_os_spi_desc *desc)
 	spi_pins.vssel = eparam->vssel;
 	MXC_GPIO_Config(&spi_pins);
 
-	/* For Maxim Platforms SPI Mode 1 and 2 are reversed */
-	switch (desc->mode) {
-	case NO_OS_SPI_MODE_1:
-		mode = SPI_MODE_2;
-		break;
-	case NO_OS_SPI_MODE_2:
-		mode = SPI_MODE_1;
-		break;
-	case NO_OS_SPI_MODE_0:
-	/* fallthrough */
-	case NO_OS_SPI_MODE_3:
-		mode = (mxc_spi_mode_t)desc->mode;
-		break;
-	default:
-		return -EINVAL;
-	}
-
-	ret = MXC_SPI_SetMode(MXC_SPI_GET_SPI(desc->device_id), mode);
+	ret = MXC_SPI_SetMode(MXC_SPI_GET_SPI(desc->device_id),
+			      (mxc_spi_mode_t)desc->mode);
 	if (ret) {
 		ret = -EINVAL;
 		goto err_init;

--- a/drivers/platform/maxim/max32665/maxim_spi.c
+++ b/drivers/platform/maxim/max32665/maxim_spi.c
@@ -237,7 +237,6 @@ static int _max_spi_config(struct no_os_spi_desc *desc)
 {
 	struct max_spi_init_param *eparam;
 	struct max_spi_state *st;
-	mxc_spi_mode_t mode;
 	int32_t ret;
 
 	st = desc->extra;
@@ -255,23 +254,8 @@ static int _max_spi_config(struct no_os_spi_desc *desc)
 	if (ret)
 		goto err_init;
 
-	/* For Maxim Platforms SPI Mode 1 and 2 are reversed */
-	switch (desc->mode) {
-	case NO_OS_SPI_MODE_1:
-		mode = SPI_MODE_2;
-		break;
-	case NO_OS_SPI_MODE_2:
-		mode = SPI_MODE_1;
-		break;
-	case NO_OS_SPI_MODE_0:
-	case NO_OS_SPI_MODE_3:
-		mode = (mxc_spi_mode_t)desc->mode;
-		break;
-	default:
-		return -EINVAL;
-	}
-
-	ret = MXC_SPI_SetMode(MXC_SPI_GET_SPI(desc->device_id), mode);
+	ret = MXC_SPI_SetMode(MXC_SPI_GET_SPI(desc->device_id),
+			      (mxc_spi_mode_t)desc->mode);
 	if (ret) {
 		ret = -EINVAL;
 		goto err_init;

--- a/drivers/platform/maxim/max32670/maxim_spi.c
+++ b/drivers/platform/maxim/max32670/maxim_spi.c
@@ -61,7 +61,6 @@ static int _max_spi_config(struct no_os_spi_desc *desc)
 {
 	int32_t ret;
 	struct max_spi_init_param *eparam;
-	mxc_spi_mode_t mode;
 
 	eparam = desc->extra;
 
@@ -73,24 +72,8 @@ static int _max_spi_config(struct no_os_spi_desc *desc)
 		goto err_init;
 	}
 
-	/* For Maxim Platforms SPI Mode 1 and 2 are reversed */
-	switch (desc->mode) {
-	case NO_OS_SPI_MODE_1:
-		mode = SPI_MODE_2;
-		break;
-	case NO_OS_SPI_MODE_2:
-		mode = SPI_MODE_1;
-		break;
-	case NO_OS_SPI_MODE_0:
-	/* fallthrough */
-	case NO_OS_SPI_MODE_3:
-		mode = (mxc_spi_mode_t)desc->mode;
-		break;
-	default:
-		return -EINVAL;
-	}
-
-	ret = MXC_SPI_SetMode(MXC_SPI_GET_SPI(desc->device_id), mode);
+	ret = MXC_SPI_SetMode(MXC_SPI_GET_SPI(desc->device_id),
+			      (mxc_spi_mode_t)desc->mode);
 	if (ret) {
 		ret = -EINVAL;
 		goto err_init;

--- a/drivers/platform/maxim/max78000/maxim_spi.c
+++ b/drivers/platform/maxim/max78000/maxim_spi.c
@@ -144,7 +144,6 @@ static int _max_spi_config(struct no_os_spi_desc *desc)
 {
 	struct max_spi_init_param *eparam;
 	struct max_spi_state *st;
-	mxc_spi_mode_t mode;
 	int32_t ret;
 
 	st = desc->extra;
@@ -170,24 +169,8 @@ static int _max_spi_config(struct no_os_spi_desc *desc)
 		goto err_init;
 	}
 
-	/* For Maxim Platforms SPI Mode 1 and 2 are reversed */
-	switch (desc->mode) {
-	case NO_OS_SPI_MODE_1:
-		mode = SPI_MODE_2;
-		break;
-	case NO_OS_SPI_MODE_2:
-		mode = SPI_MODE_1;
-		break;
-	case NO_OS_SPI_MODE_0:
-	/* fallthrough */
-	case NO_OS_SPI_MODE_3:
-		mode = (mxc_spi_mode_t)desc->mode;
-		break;
-	default:
-		return -EINVAL;
-	}
-
-	ret = MXC_SPI_SetMode(MXC_SPI_GET_SPI(desc->device_id), mode);
+	ret = MXC_SPI_SetMode(MXC_SPI_GET_SPI(desc->device_id),
+			      (mxc_spi_mode_t)desc->mode);
 	if (ret) {
 		ret = -EINVAL;
 		goto err_init;


### PR DESCRIPTION
## Pull Request Description

This workaround is no longer needed since the SPI modes were fixed in the Maxim SDK.

https://github.com/Analog-Devices-MSDK/msdk/commit/50e0979357700daeea48fcd38b900148b1621ad4

This reverts commit 2032bde0e80468723c443def0def2a79fd21e31d.

Requires an SDK update on the build server

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [x] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
