### PR TITLE
Stm32 build fixes

### DIFF
--- a/tools/scripts/stm32.mk
+++ b/tools/scripts/stm32.mk
@@ -69,6 +69,8 @@ $(PROJECT_TARGET):
 	$(call print,Creating IDE project)
 	$(call mk_dir, $(BUILD_DIR))
 	$(call mk_dir, $(VSCODE_CFG_DIR))
+	@sed -i 's|TargetToolchain=.*|TargetToolchain=STM32CubeIDE|g' $(HARDWARE) $(HIDE)
+	@sed -i 's|UnderRoot=false|UnderRoot=true|g' $(HARDWARE) $(HIDE)
 	@echo config load $(HARDWARE) > $(BINARY).cubemx
 	@echo project name app >> $(BINARY).cubemx
 	@echo project toolchain STM32CubeIDE >> $(BINARY).cubemx

--- a/tools/scripts/stm32.mk
+++ b/tools/scripts/stm32.mk
@@ -18,9 +18,6 @@ $(error $(ENDL)$(ENDL)STM32CUBEMX not defined or not found at default path /opt/
 		Ex: export STM32CUBEMX=/opt/stm32cubemx$(ENDL)$(ENDL))
 endif # STM32CUBEMX check
 
-# Locate the compiler path under STM32CubeIDE plugins directory
-COMPILER_BIN = $(realpath $(dir $(call rwildcard, $(STM32CUBEIDE)/plugins, *arm-none-eabi-gcc)))
-
 # Locate openocd location under STM32CubeIDE plugins directory
 OPENOCD_SCRIPTS = $(realpath $(addsuffix ..,$(dir $(call rwildcard, $(STM32CUBEIDE)/plugins, *st_scripts/interface/stlink-dap.cfg))))
 OPENOCD_BIN = $(realpath $(dir $(call rwildcard, $(STM32CUBEIDE)/plugins, *bin/openocd)))
@@ -142,7 +139,13 @@ CC = arm-none-eabi-gcc
 GDB = arm-none-eabi-gdb
 GDB_PORT = 50000
 OC = arm-none-eabi-objcopy
-SIZE=arm-none-eabi-size
+SIZE = arm-none-eabi-size
+
+COMPILER_BIN = $(realpath $(dir $(shell which $(CC) 2>/dev/null)))
+ifeq (,$(COMPILER_BIN))
+COMPILER_BIN = $(realpath $(dir $(call rwildcard, $(STM32CUBEIDE)/plugins, *arm-none-eabi-gcc)))
+endif
+export PATH := $(COMPILER_BIN):$(PATH)
 
 .PHONY: $(BINARY).openocd-cmsis
 $(BINARY).openocd-cmsis:


### PR DESCRIPTION
## Pull Request Description

 stm32: prioritize system gcc over IDE gcc

Some users may not have the arm-none-eabi-gcc in their system so
test this first.

If it does not exist, Fallback to ST toolchain arm-none-eabi-gcc.

stm32 .ioc handling: force STM32CubeIDE
    
For the STM32CubeIDE project type generation in case .ioc files
specify otherwise because we don't support others.


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
