### PR TITLE
iio:iio.c: Add cyclic mode size checks in pop scan

### DIFF
--- a/iio/iio.c
+++ b/iio/iio.c
@@ -1423,18 +1423,16 @@ int iio_buffer_pop_scan(struct iio_buffer *buffer, void *data)
 	if (!buffer)
 		return -EINVAL;
 
-	if(!buffer->cyclic_info.is_cyclic)
-		return no_os_cb_read(buffer->buf, data, buffer->bytes_per_scan);
+	int ret;
 
-	memcpy(data,
-	       &buffer->buf->buff[buffer->cyclic_info.buff_index],
-	       buffer->bytes_per_scan);
+	ret = no_os_cb_read(buffer->buf, data, buffer->bytes_per_scan);
 
-	buffer->cyclic_info.buff_index += buffer->bytes_per_scan;
-	if (buffer->size == buffer->cyclic_info.buff_index)
-		buffer->cyclic_info.buff_index = 0;
+	if (buffer->cyclic_info.is_cyclic) {
+		if (buffer->buf->read.idx == buffer->buf->write.idx)
+			buffer->buf->read.idx = 0;
+	}
 
-	return 0;
+	return ret;
 }
 
 #if defined(NO_OS_NETWORKING) || defined(NO_OS_LWIP_NETWORKING)


### PR DESCRIPTION
## Pull Request Description

1. Use no_os_cb_read even in cyclic mode to check if there are samples available to be read
2. Refactor the function implementation

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
