### PR TITLE
drivers: maxim: Fix UART write for MAX32670

### DIFF
--- a/drivers/platform/maxim/max32670/maxim_uart.c
+++ b/drivers/platform/maxim/max32670/maxim_uart.c
@@ -110,16 +110,32 @@ static int32_t max_uart_write(struct no_os_uart_desc *desc, const uint8_t *data,
 			      uint32_t bytes_number)
 {
 	int32_t ret;
+	int32_t transfered = 0;
+	int block_size = 8;
 
 	if(!desc || !data || !bytes_number)
 		return -EINVAL;
 
-	ret = MXC_UART_Write(MXC_UART_GET_UART(desc->device_id), data,
-			     (int *)&bytes_number);
-	if (ret != E_SUCCESS)
-		return -EIO;
+	while (bytes_number) {
+		if (bytes_number > 8)
+			block_size = 8;
+		else
+			block_size = bytes_number;
 
-	return bytes_number;
+		while(!(MXC_UART_GetStatus(MXC_UART_GET_UART(desc->device_id)) &
+			MXC_F_UART_STATUS_TX_EM));
+		ret = MXC_UART_Write(MXC_UART_GET_UART(desc->device_id),
+				     (uint8_t *)(data + transfered),
+				     &block_size);
+
+		transfered += block_size;
+		bytes_number -= block_size;
+
+		if (ret != E_SUCCESS)
+			return -EIO;
+	}
+
+	return transfered;
 }
 
 /**


### PR DESCRIPTION
## Pull Request Description

Apply a fix similar to 6437cd6e12 ("drivers:platform:maxim: Fix UART TX") for the UART writes using the MAX32670.
Reported in https://github.com/analogdevicesinc/no-OS/issues/2055.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
