### PR TITLE
drivers: digital-io: max14919 : Add MAX14919 driver support

### DIFF
--- a/doc/sphinx/source/drivers/max14919.rst
+++ b/doc/sphinx/source/drivers/max14919.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../drivers/digital-io/max14919/README.rst

--- a/doc/sphinx/source/drivers_doc.rst
+++ b/doc/sphinx/source/drivers_doc.rst
@@ -31,6 +31,7 @@ DIGITAL INPUT/OUTPUT
    :maxdepth: 1
 
    drivers/max14914
+   drivers/max14919
    drivers/max149x6
    drivers/max22190
    drivers/max22196

--- a/doc/sphinx/source/projects/max14919.rst
+++ b/doc/sphinx/source/projects/max14919.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../projects/max14919/README.rst

--- a/doc/sphinx/source/projects_doc.rst
+++ b/doc/sphinx/source/projects_doc.rst
@@ -41,3 +41,4 @@ DIGITAL-IO
    :maxdepth: 1
 
    projects/max14914
+   projects/max14919

--- a/drivers/digital-io/max14919/README.rst
+++ b/drivers/digital-io/max14919/README.rst
@@ -1,0 +1,126 @@
+MAX14919 no-OS driver
+=====================
+
+Supported Devices
+-----------------
+
+`MAX14919 <https://www.analog.com/MAX14919>`_
+
+Overview
+--------
+
+The MAX14919/MAX14919A industrial-protected quad-channel lowside switch features
+140mΩ (typ) on-resistance (RON) per channel with integrated ±1kV/42Ω surge
+protection for robust operation.
+
+Resistor-settable accurate current limiting provides guaranteed operating
+currents in the range of 100mA to 800mA. Loads that draw large activation
+or inrush currents are supported using the 2x inrush load-current option.
+The outputs can be connected in parallel to achieve higher load currents.
+The four switches are pin-controlled to allow for simple and fast
+switching of up to 500kHz.
+
+The MAX14919/MAX14919A features reverse current detection.
+The MAX14919 implements reverse-current protection by driving an external FET
+for non-capacitive loads. The MAX14919A has reverse current indication.
+
+Applications
+------------
+
+MAX14919
+--------
+
+* Industrial Digital Outputs
+* Relay and Solenoid Drivers
+* PLC and DCS Systems
+* Motor Control
+
+MAX14919 Device Configuration
+-----------------------------
+
+Driver Initialization
+---------------------
+
+In order to use the device, you will have to provide support for at least
+5 GPIO pins, and 2 more optional GPIO pins in case you want to use those
+specific device functions:
+
+* IN GPIOs x4 (mandatory)
+* FAULT GPIO (mandatory)
+* IN_RUSH GPIO (optional - used for current limiting)
+* REV GPIO (optional - used for detection of reverse current's polarity)
+
+Theese pins will be initialized alongside the device using
+**max14919_init** API.
+
+State Configuration
+-------------------
+
+The MAX14919 OUTPUT channels can be configured with the **max14919_set_out**
+API where an state array should be passed as an argument to set the OUTPUT
+channels state.
+
+Fault Detection
+---------------
+
+Fault detection is available through **max14919_get_fault** API.
+
+Current Limiting and Reverse Polarity
+-------------------------------------
+
+Current Limiting is available through the **max14919_set_climit** API if the
+IN_RUSH GPIO has been initialized.
+
+Reverse Polarity of the current detection is available through the
+**max14919_detect_rev** API if a REV GPIO has been initialized.
+
+MAX14919 Driver Initialization Example
+--------------------------------------
+
+.. code-block:: bash
+
+	struct max14919_desc *max14919_desc;
+	struct no_os_gpio_init_param *max14919_in_ip[4] = {
+		{
+			.port = 1,
+			.pull = NO_OS_PULL_NONE,
+			.number = 0,
+			.platform_ops = &max_gpio_ops,
+			.extra = &max14919_gpio_extra_ip,
+		},
+		{
+			.port = 1,
+			.pull = NO_OS_PULL_NONE,
+			.number = 1,
+			.platform_ops = &max_gpio_ops,
+			.extra = &max14919_gpio_extra_ip,
+		},
+		{
+			.port = 1,
+			.pull = NO_OS_PULL_NONE,
+			.number = 2,
+			.platform_ops = &max_gpio_ops,
+			.extra = &max14919_gpio_extra_ip,
+		},
+		{
+			.port = 1,
+			.pull = NO_OS_PULL_NONE,
+			.number = 3,
+			.platform_ops = &max_gpio_ops,
+			.extra = &max14919_gpio_extra_ip,
+		},
+	};
+	struct no_os_gpio_init_param max14919_fault_ip = {
+		.port = 2,
+		.pull = NO_OS_PULL_NONE,
+		.number = 21,
+		.platform_ops = &max_gpio_ops,
+		.extra = &max14919_gpio_extra_ip,
+	};
+	struct max14919_init_param max14919_ip = {
+		.in_param = max14919_in_ip,
+		.fault_param = &max14919_fault_ip,
+	};
+	ret = max14919(&max14919_desc, &max14919_ip);
+	if (ret)
+		goto error;

--- a/drivers/digital-io/max14919/max14919.c
+++ b/drivers/digital-io/max14919/max14919.c
@@ -1,0 +1,213 @@
+/***************************************************************************//**
+ *   @file   max14919.c
+ *   @brief  Source file of MAX14919 Driver.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "max14919.h"
+#include "no_os_alloc.h"
+
+/**
+ * @brief Set the OUT channels state
+ * @param desc - MAX14919 device descriptor
+ * @param state - OUT channels state array containing information about the to
+ * 		  be set channels state.
+ * @return 0 in case of succes, negative error code otherwise
+*/
+int max14919_set_out(struct max14919_desc *desc, enum max14919_out_state *state)
+{
+	int ret, i;
+
+	if (!desc)
+		return -ENODEV;
+
+	if (!desc->in_desc || !desc->out_state)
+		return -EINVAL;
+
+	for (i = 0; i < MAX14919_OUT_CHANNELS; i++) {
+		ret = no_os_gpio_set_value(desc->in_desc[i],
+					   state[i] ? NO_OS_GPIO_LOW : NO_OS_GPIO_HIGH);
+		if (ret)
+			return ret;
+
+		desc->out_state[i] = state[i];
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Set current limiting
+ * @param desc - MAX14919 devce descriptor
+ * @param state - State to be set.
+ * 		  TRUE - on.
+ * 		  FALSE - off.
+ * @return 0 in case of succes, negative error code otherwise
+*/
+int max14919_set_climit(struct max14919_desc *desc, bool state)
+{
+	if (!desc)
+		return -ENODEV;
+
+	if (!desc->inrush_desc)
+		return -EINVAL;
+
+	return no_os_gpio_set_value(desc->inrush_desc,
+				    state ? NO_OS_GPIO_HIGH : NO_OS_GPIO_LOW);
+}
+
+/**
+ * @brief Get the FAULT state of the device
+ * @param desc - MAX14919 device descriptor
+ * @param fault - Fault state of the MAX14919
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max14919_get_fault(struct max14919_desc *desc, uint8_t* fault)
+{
+	if (!desc)
+		return -ENODEV;
+
+	if (!desc->fault_desc)
+		return -EINVAL;
+
+	return no_os_gpio_get_value(desc->fault_desc, fault);
+}
+
+/**
+ * @brief Detect reverse polarity of the current
+ * @param desc - MAX14919 device descriptor
+ * @param rev - Reverse polarity state
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max14919_detect_rev(struct max14919_desc *desc, uint8_t* rev)
+{
+	if (!desc)
+		return -ENODEV;
+
+	if (!desc->rev_desc)
+		return -EINVAL;
+
+	return no_os_gpio_get_value(desc->rev_desc, rev);
+}
+
+/**
+ * @brief Initialize the MAX14919 device descriptor
+ * @param desc - MAX14919 device descriptor
+ * @param init_param - MAX14919 initialization parameter
+ * @return 0 in case of succes, negative error code otherwise
+*/
+int max14919_init(struct max14919_desc **desc,
+		  struct max14919_init_param *init_param)
+{
+	struct max14919_desc *descriptor;
+	int ret, i;
+
+	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	for (i = 0; i < MAX14919_OUT_CHANNELS; i++) {
+		ret = no_os_gpio_get(&descriptor->in_desc[i], init_param->in_param[i]);
+		if (ret)
+			goto error;
+
+		ret = no_os_gpio_direction_output(descriptor->in_desc[i], NO_OS_GPIO_HIGH);
+		if (ret)
+			goto error;
+
+		descriptor->out_state[i] = MAX14919_OUT_OFF;
+	}
+
+	ret = no_os_gpio_get_optional(&descriptor->inrush_desc,
+				      init_param->inrush_param);
+	if (ret)
+		goto error;
+
+	if (descriptor->inrush_desc) {
+		ret = no_os_gpio_direction_output(descriptor->inrush_desc, NO_OS_GPIO_LOW);
+		if (ret)
+			goto error;
+	}
+
+	ret = no_os_gpio_get_optional(&descriptor->rev_desc, init_param->rev_param);
+	if (ret)
+		goto error;
+
+	if (descriptor->rev_desc) {
+		ret = no_os_gpio_direction_input(descriptor->rev_desc);
+		if (ret)
+			goto error;
+	}
+
+	ret = no_os_gpio_get(&descriptor->fault_desc, init_param->fault_param);
+	if (ret)
+		goto error;
+
+	ret = no_os_gpio_direction_input(descriptor->fault_desc);
+	if (ret)
+		goto error;
+
+	*desc = descriptor;
+
+	return 0;
+
+error:
+	max14919_remove(descriptor);
+
+	return ret;
+}
+
+/**
+ * @brief Free resources allocated by the init function
+ * @param desc - MAX14919 device descriptor
+ * @return 0 in case of succes, negative error code otherwise
+*/
+int max14919_remove(struct max14919_desc *desc)
+{
+	int i;
+
+	if (!desc)
+		return -ENODEV;
+
+	for (i = 0; i < MAX14919_OUT_CHANNELS; i++) {
+		no_os_gpio_remove(desc->in_desc[i]);
+	}
+	no_os_gpio_remove(desc->inrush_desc);
+	no_os_gpio_remove(desc->rev_desc);
+	no_os_gpio_remove(desc->fault_desc);
+	no_os_free(desc);
+
+	return 0;
+}

--- a/drivers/digital-io/max14919/max14919.h
+++ b/drivers/digital-io/max14919/max14919.h
@@ -1,0 +1,103 @@
+/***************************************************************************//**
+ *   @file   max14919.h
+ *   @brief  Header file of MAX14919 Driver.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef _MAX14919_H
+#define _MAX14919_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "no_os_gpio.h"
+#include "no_os_util.h"
+#include "no_os_error.h"
+
+#define MAX14919_OUT_CHANNELS		4
+
+enum max14919_out_state {
+	MAX14919_OUT_OFF,
+	MAX14919_OUT_ON
+};
+
+enum max14919_out_chan {
+	MAX14919_OUT1,
+	MAX14919_OUT2,
+	MAX14919_OUT3,
+	MAX14919_OUT4
+};
+
+/**
+ * @brief Structure holding the MAX14919 initialization parameter
+*/
+struct max14919_init_param {
+	struct no_os_gpio_init_param *in_param[MAX14919_OUT_CHANNELS];
+	struct no_os_gpio_init_param *inrush_param;
+	struct no_os_gpio_init_param *fault_param;
+	struct no_os_gpio_init_param *rev_param;
+};
+
+/**
+ * @brief Structure holding te MAX14919 device descriptor
+*/
+struct max14919_desc {
+	struct no_os_gpio_desc *in_desc[MAX14919_OUT_CHANNELS];
+	struct no_os_gpio_desc *inrush_desc;
+	struct no_os_gpio_desc *fault_desc;
+	struct no_os_gpio_desc *rev_desc;
+	enum max14919_out_state out_state[MAX14919_OUT_CHANNELS];
+};
+
+/** Set output channels state. */
+int max14919_set_out(struct max14919_desc *desc,
+		     enum max14919_out_state *state);
+
+/** Set 2x current limiting state. */
+int max14919_set_climit(struct max14919_desc *desc, bool state);
+
+/** Get FAULT state from the FAULT pin. */
+int max14919_get_fault(struct max14919_desc *desc, uint8_t* fault);
+
+/** Detect REV polarity of the current. */
+int max14919_detect_rev(struct max14919_desc *desc, uint8_t* rev);
+
+/** Initialize the MAX14919 device descriptor. */
+int max14919_init(struct max14919_desc **desc,
+		  struct max14919_init_param *init_param);
+
+/** Free resources allocated by the init function. */
+int max14919_remove(struct max14919_desc *desc);
+
+#endif /* _MAX14919_H */

--- a/projects/max14919/Makefile
+++ b/projects/max14919/Makefile
@@ -1,0 +1,8 @@
+# Select the example you want to enable by choosing y for enabling and n for disabling
+BASIC_EXAMPLE = y
+
+include ../../tools/scripts/generic_variables.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/max14919/README.rst
+++ b/projects/max14919/README.rst
@@ -1,0 +1,147 @@
+Evaluating the MAX14919
+=======================
+
+
+Contents
+--------
+
+.. contents:: Table of Contents
+	:depth: 3
+
+Supported Evaluation Boards
+---------------------------
+
+* `MAX14919PMB <https://www.analog.com/MAX14919PMB>`_
+
+Overview
+--------
+
+The MAX14919 PMB provides a proven design to evaluate the MAX14919 industrial-grade quad low-side
+switch with 140mΩ (typ) RON and ±1kV/42Ω surge protection.
+
+Applications
+------------
+
+* Industrial Digital Outputs
+* Motor Control
+* PLC and DCS Systems
+* Relay and Solenoid Drivers
+
+Hardware Specifications
+-----------------------
+
+Power Supply Requirments
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The MAX14919PMB device needs to be supplied with a 3.3V voltage.
+
+**Pin Description**
+
+	Please see te following table for the pin assignments for the
+	following connectors:
+
+	T1:
+
+	+-----+----------+-------------------------------------------+
+	| Pin |   Name 	 | Description				     |
+	+-----+----------+-------------------------------------------+
+	| 1   | IN1	 | IN1 Logic Input (GPIO)		     |
+	+-----+----------+-------------------------------------------+
+	| 2   | IN2      | IN2 Logic Input (GPIO)	             |
+	+-----+----------+-------------------------------------------+
+	| 3   | IN3	 | IN3 Logic Input (GPIO)		     |
+	+-----+----------+-------------------------------------------+
+	| 4   | IN4	 | IN4 Logic Input (GPIO)		     |
+	+-----+----------+-------------------------------------------+
+	| 5   | GND	 | Connect to Ground.			     |
+	+-----+----------+-------------------------------------------+
+	| 6   | VL       | Power Supply, +3.3V		             |
+	+-----+----------+-------------------------------------------+
+	| 7   | INRUSH	 | IN_RUSH Logic Input (GPIO)		     |
+	+-----+----------+-------------------------------------------+
+	| 8   | FAULT	 | FAULT Logic Output (GPIO)		     |
+	+-----+----------+-------------------------------------------+
+	| 9   | REV	 | REV Logic Output (GPIO)		     |
+	+-----+----------+-------------------------------------------+
+	| 10  | DNC	 | Do Not Connect			     |
+	+-----+----------+-------------------------------------------+
+	| 11  | GND	 | Connect to GROUND			     |
+	+-----+----------+-------------------------------------------+
+	| 12  | VL	 | Power Supply, +3.3V			     |
+	+-----+----------+-------------------------------------------+
+
+No-OS Build Setup
+-----------------
+
+Please see: https://wiki.analog.com/resources/no-os/build
+
+No-OS Supported Examples
+------------------------
+
+The initialization data used in the examples is taken out from:
+`Project Common Data Path <https://github.com/analogdevicesinc/no-OS/tree/master/projects/max14919/src/common>`_
+
+The macros used in Common Data are defined in platform specific files found in:
+`Project Platform Configuration Path <https://github.com/analogdevicesinc/no-OS/tree/master/projects/max14919/src/platform>`_
+
+Basic example
+^^^^^^^^^^^^^
+
+This is a simple example which initializes the max14919 and sets the output
+channel 2 on, after which is detects faults, reverse polarity and sets 2x
+current limit for the device.
+
+
+In order to build the basic example make sure you have the following configuration in the Makefile
+`Makefile <https://github.com/analogdevicesinc/no-OS/tree/master/projects/max14919/Makefile>`_
+
+.. code-block:: bash
+
+	# Select the example you want to enable by choosing y for enabling and n for disabling
+	BASIC_EXAMPLE = y
+
+No-OS Supported Platforms
+-------------------------
+
+Maxim Platform
+^^^^^^^^^^^^^^
+
+**Used hardware**
+
+* `MAX14919PMB <https://www.analog.com/MAX14919PMB>`_
+* `AD-APARD32690-SL <https://www.analog.com/en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/ad-apard32690-sl.html>`_
+
++------------------------+----------+-------------------------------------------+-----------------------------+
+| MAX14919PMB Pin Name   | Mnemonic | Function					| AD-APARD32690-SL Pin Number |
++------------------------+----------+-------------------------------------------+-----------------------------+
+| IN1(1)		 | IN1	    | IN1 LOGIC INPUT(GPIO)			| P1_0			      |      
++------------------------+----------+-------------------------------------------+-----------------------------+
+| IN1(2)		 | IN2      | IN2 LOGIC INPUT(GPIO)			| P1_1	      		      |
++------------------------+----------+-------------------------------------------+-----------------------------+
+| IN1(3)		 | IN3      | IN3 LOGIC INPUT(GPIO)			| P1_2		      	      |
++------------------------+----------+-------------------------------------------+-----------------------------+
+| IN1(4)		 | IN4      | IN LOGIC INPUT(GPIO)			| P1_3		      	      |
++------------------------+----------+-------------------------------------------+-----------------------------+
+| FAULT			 | FAULT    | FAULT LOGIC OUTPUT(GPIO)			| P1_6			      |
++------------------------+----------+-------------------------------------------+-----------------------------+
+| REV			 | REV	    | REV LOGIC OUTPUT(GPIO)			| P1_4			      |
++------------------------+----------+-------------------------------------------+-----------------------------+
+| INRUSH		 | IN_RUSH  | INRUSH LOGIC INPUT(GPIO)			| P2_21			      |
++------------------------+----------+-------------------------------------------+-----------------------------+
+| GND			 | GND      | Ground					| GND			      |
++------------------------+----------+-------------------------------------------+-----------------------------+
+| GNDB			 | GND      | Ground					| GND			      |
++------------------------+----------+-------------------------------------------+-----------------------------+
+| VL			 | VL	    | Power Supply, +3.3V			| 3V3			      |
++------------------------+----------+-------------------------------------------+-----------------------------+
+
+**Build Command**
+
+.. code-block:: bash
+
+	# to delete current build
+	make reset
+	# to build the project
+	make PLATFORM=maxim TARGET=max32690
+	# to flash the code
+	make run

--- a/projects/max14919/builds.json
+++ b/projects/max14919/builds.json
@@ -1,0 +1,7 @@
+{
+	"maxim": {
+		"basic_example_max32690": {
+			"flags" : "BASIC_EXAMPLE=y TARGET=max32690"
+		}
+	}
+}

--- a/projects/max14919/src.mk
+++ b/projects/max14919/src.mk
@@ -1,0 +1,37 @@
+include $(PROJECT)/src/platform/$(PLATFORM)/platform_src.mk
+include $(PROJECT)/src/examples/examples_src.mk
+
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/main.c
+
+INCS += $(PROJECT)/src/common/common_data.h
+SRCS += $(PROJECT)/src/common/common_data.c
+
+INCS += $(PROJECT)/src/platform/platform_includes.h
+
+INCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.h
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.c
+
+INCS += $(INCLUDE)/no_os_delay.h     \
+		$(INCLUDE)/no_os_error.h     \
+		$(INCLUDE)/no_os_gpio.h      \
+		$(INCLUDE)/no_os_print_log.h \
+		$(INCLUDE)/no_os_alloc.h       \
+		$(INCLUDE)/no_os_irq.h      \
+		$(INCLUDE)/no_os_list.h      \
+		$(INCLUDE)/no_os_uart.h      \
+		$(INCLUDE)/no_os_lf256fifo.h \
+		$(INCLUDE)/no_os_util.h 	\
+		$(INCLUDE)/no_os_units.h	\
+                $(INCLUDE)/no_os_mutex.h	
+
+SRCS += $(DRIVERS)/api/no_os_gpio.c \
+		$(NO-OS)/util/no_os_lf256fifo.c \
+		$(DRIVERS)/api/no_os_irq.c  \
+		$(DRIVERS)/api/no_os_uart.c \
+		$(NO-OS)/util/no_os_list.c \
+		$(NO-OS)/util/no_os_util.c \
+		$(NO-OS)/util/no_os_alloc.c \
+                $(NO-OS)/util/no_os_mutex.c	
+
+INCS += $(DRIVERS)/digital-io/max14919/max14919.h
+SRCS += $(DRIVERS)/digital-io/max14919/max14919.c

--- a/projects/max14919/src/common/common_data.c
+++ b/projects/max14919/src/common/common_data.c
@@ -1,0 +1,116 @@
+/***************************************************************************//**
+ *   @file   common_data.c
+ *   @brief  Defines common data to be used by max14919 example.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "common_data.h"
+
+struct no_os_uart_init_param max14919_uart_ip = {
+	.device_id = UART_DEVICE_ID,
+	.baud_rate = UART_BAUDRATE,
+	.size = NO_OS_UART_CS_8,
+	.platform_ops = UART_OPS,
+	.parity = NO_OS_UART_PAR_NO,
+	.stop = NO_OS_UART_STOP_1_BIT,
+	.extra = UART_EXTRA,
+};
+
+struct no_os_gpio_init_param max14919_fault_ip = {
+	.port = GPIO_FAULT_PORT_NUM,
+	.pull = NO_OS_PULL_NONE,
+	.number = GPIO_FAULT_PIN_NUM,
+	.platform_ops = GPIO_OPS,
+	.extra = GPIO_EXTRA,
+};
+
+struct no_os_gpio_init_param max14919_in_ip[4] = {
+	{
+		.port = GPIO_IN_PORT_NUM,
+		.pull = NO_OS_PULL_NONE,
+		.number = GPIO_IN_PIN_NUM(0),
+		.platform_ops = GPIO_OPS,
+		.extra = GPIO_EXTRA,
+	},
+	{
+		.port = GPIO_IN_PORT_NUM,
+		.pull = NO_OS_PULL_NONE,
+		.number = GPIO_IN_PIN_NUM(1),
+		.platform_ops = GPIO_OPS,
+		.extra = GPIO_EXTRA,
+	},
+	{
+		.port = GPIO_IN_PORT_NUM,
+		.pull = NO_OS_PULL_NONE,
+		.number = GPIO_IN_PIN_NUM(2),
+		.platform_ops = GPIO_OPS,
+		.extra = GPIO_EXTRA,
+	},
+	{
+		.port = GPIO_IN_PORT_NUM,
+		.pull = NO_OS_PULL_NONE,
+		.number = GPIO_IN_PIN_NUM(3),
+		.platform_ops = GPIO_OPS,
+		.extra = GPIO_EXTRA,
+	},
+};
+
+struct no_os_gpio_init_param max14919_in_rush_ip = {
+	.port = GPIO_IN_RUSH_PORT_NUM,
+	.pull = NO_OS_PULL_NONE,
+	.number = GPIO_IN_RUSH_PIN_NUM,
+	.platform_ops = GPIO_OPS,
+	.extra = GPIO_EXTRA,
+};
+
+struct no_os_gpio_init_param max14919_rev_ip = {
+	.port = GPIO_REV_PORT_NUM,
+	.pull = NO_OS_PULL_NONE,
+	.number = GPIO_REV_PIN_NUM,
+	.platform_ops = GPIO_OPS,
+	.extra = GPIO_EXTRA,
+};
+
+struct max14919_init_param max14919_ip = {
+	.in_param = {
+		[0] = &max14919_in_ip[0],
+		[1] = &max14919_in_ip[1],
+		[2] = &max14919_in_ip[2],
+		[3] = &max14919_in_ip[3]
+	},
+	.fault_param = &max14919_fault_ip,
+	.inrush_param = &max14919_in_rush_ip,
+	.rev_param = &max14919_rev_ip,
+};

--- a/projects/max14919/src/common/common_data.h
+++ b/projects/max14919/src/common/common_data.h
@@ -1,0 +1,52 @@
+/***************************************************************************//**
+ *   @file   common_data.h
+ *   @brief  Defines common data to be used by max14919 example.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __COMMON_DATA_H__
+#define __COMMON_DATA_H__
+
+#include "platform_includes.h"
+#include "max14919.h"
+
+extern struct no_os_uart_init_param max14919_uart_ip;
+extern struct no_os_gpio_init_param max14919_fault_ip;
+extern struct no_os_gpio_init_param max14919_in_ip[4];
+extern struct no_os_gpio_init_param max14919_in_rush_ip;
+extern struct no_os_gpio_init_param max14919_rev_ip;
+extern struct max14919_init_param max14919_ip;
+
+#endif /* __COMMON_DATA_H__ */

--- a/projects/max14919/src/examples/basic/basic_example.c
+++ b/projects/max14919/src/examples/basic/basic_example.c
@@ -1,0 +1,110 @@
+/***************************************************************************//**
+ *   @file   basic_example.c
+ *   @brief  Source file for basic example.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "basic_example.h"
+#include "common_data.h"
+#include "max14919.h"
+#include "no_os_delay.h"
+#include "no_os_print_log.h"
+
+int basic_example_main()
+{
+	struct max14919_desc *desc;
+	enum max14919_out_state state[4] = {
+		MAX14919_OUT_OFF,
+		MAX14919_OUT_ON,
+		MAX14919_OUT_OFF,
+		MAX14919_OUT_OFF
+	};
+	int ret;
+	uint8_t gpio_state;
+
+	ret = max14919_init(&desc, &max14919_ip);
+	if (ret)
+		goto exit;
+
+	ret = max14919_set_out(desc, state);
+	if (ret)
+		goto free_max14919;
+
+	pr_info("MAX14919 output channel 2 is ON.\n");
+
+	ret = max14919_get_fault(desc, &gpio_state);
+	if (ret)
+		goto free_max14919;
+
+	switch (gpio_state) {
+	case 0:
+		pr_info("MAX14919 detected faults.\n");
+		break;
+	case 1:
+		pr_info("MAX14919 detected no faults.\n");
+		break;
+	default:
+		goto free_max14919;
+	}
+
+	ret = max14919_detect_rev(desc, &gpio_state);
+	if (ret)
+		goto free_max14919;
+
+	switch (gpio_state) {
+	case 0:
+		pr_info("Current polarity is normal.\n");
+		break;
+	case 1:
+		pr_info("Current polarity is reversed.\n");
+		break;
+	default:
+		goto free_max14919;
+	}
+
+	ret = max14919_set_climit(desc, true);
+	if (ret)
+		goto free_max14919;
+
+	pr_info("2x Current Limiting has been activated.");
+
+free_max14919:
+	max14919_remove(desc);
+exit:
+	if (ret)
+		pr_info("Error!\n");
+
+	return ret;
+}

--- a/projects/max14919/src/examples/basic/basic_example.h
+++ b/projects/max14919/src/examples/basic/basic_example.h
@@ -1,0 +1,44 @@
+/***************************************************************************//**
+ *   @file   basic_example.c
+ *   @brief  Header file for basic example.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __BASIC_EXAMPLE_H__
+#define __BASIC_EXAMPLE_H__
+
+int basic_example_main();
+
+#endif /* __BASIC_EXAMPLE_H__ */

--- a/projects/max14919/src/examples/examples_src.mk
+++ b/projects/max14919/src/examples/examples_src.mk
@@ -1,0 +1,5 @@
+ifeq (y, $(strip $(BASIC_EXAMPLE)))
+CFLAGS += -DBASIC_EXAMPLE=1
+SRCS += $(PROJECT)/src/examples/basic/basic_example.c
+INCS += $(PROJECT)/src/examples/basic/basic_example.h
+endif

--- a/projects/max14919/src/platform/maxim/main.c
+++ b/projects/max14919/src/platform/maxim/main.c
@@ -1,0 +1,61 @@
+/***************************************************************************//**
+ *   @file   main.c
+ *   @brief  Main file for Maxim platform of max14919 project.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "platform_includes.h"
+#include "common_data.h"
+#include "no_os_error.h"
+#include "basic_example.h"
+
+int main()
+{
+	int ret = -EINVAL;
+
+	struct no_os_uart_desc *uart_desc;
+
+	ret = no_os_uart_init(&uart_desc, &max14919_uart_ip);
+	if (ret)
+		return ret;
+
+	no_os_uart_stdio(uart_desc);
+
+	ret = basic_example_main();
+
+	no_os_uart_remove(uart_desc);
+
+	return ret;
+}

--- a/projects/max14919/src/platform/maxim/parameters.c
+++ b/projects/max14919/src/platform/maxim/parameters.c
@@ -1,0 +1,47 @@
+/***************************************************************************//**
+ *   @file   parameters.c
+ *   @brief  Definition of Maxim platform data used by max14919 project.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "parameters.h"
+
+struct max_uart_init_param max14919_uart_extra = {
+	.flow = UART_FLOW_DIS,
+};
+
+struct max_gpio_init_param max14919_gpio_extra_ip = {
+	.vssel = MXC_GPIO_VSSEL_VDDIOH
+};

--- a/projects/max14919/src/platform/maxim/parameters.h
+++ b/projects/max14919/src/platform/maxim/parameters.h
@@ -1,0 +1,69 @@
+/***************************************************************************//**
+ *   @file   parameters.c
+ *   @brief  Definition of Maxim platform data used by max14919 project.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
+
+#include "maxim_irq.h"
+#include "maxim_gpio.h"
+#include "maxim_gpio_irq.h"
+#include "maxim_uart.h"
+#include "maxim_uart_stdio.h"
+
+#define UART_IRQ_ID		UART0_IRQn
+#define UART_DEVICE_ID		0
+#define UART_BAUDRATE		57600
+#define UART_EXTRA		&max14919_uart_extra
+#define UART_OPS		&max_uart_ops
+
+// GPIOs
+#define GPIO_OPS		&max_gpio_ops
+#define GPIO_EXTRA		&max14919_gpio_extra_ip
+#define GPIO_FAULT_PORT_NUM	1
+#define GPIO_FAULT_PIN_NUM	6
+#define GPIO_IN_PORT_NUM	1
+#define GPIO_IN_PIN_NUM(x)	(x)
+#define GPIO_IN_RUSH_PORT_NUM	2
+#define GPIO_IN_RUSH_PIN_NUM	21
+#define GPIO_REV_PORT_NUM	1
+#define GPIO_REV_PIN_NUM	4
+
+extern struct max_gpio_init_param max14919_gpio_extra_ip;
+extern struct max_uart_init_param max14919_uart_extra;
+
+#endif /* __PARAMETERS_H__ */

--- a/projects/max14919/src/platform/maxim/platform_src.mk
+++ b/projects/max14919/src/platform/maxim/platform_src.mk
@@ -1,0 +1,12 @@
+INCS += $(PLATFORM_DRIVERS)/maxim_gpio.h \
+	$(PLATFORM_DRIVERS)/maxim_uart.h \
+	$(PLATFORM_DRIVERS)/maxim_uart_stdio.h \
+	$(PLATFORM_DRIVERS)/maxim_irq.h 	\
+	$(PLATFORM_DRIVERS)/maxim_gpio_irq.h
+
+SRCS += $(PLATFORM_DRIVERS)/maxim_gpio.c \
+	$(PLATFORM_DRIVERS)/maxim_uart.c \
+	$(PLATFORM_DRIVERS)/maxim_uart_stdio.c \
+	$(PLATFORM_DRIVERS)/maxim_irq.c \
+	$(PLATFORM_DRIVERS)/maxim_delay.c 	\
+	$(PLATFORM_DRIVERS)/maxim_gpio_irq.c

--- a/projects/max14919/src/platform/platform_includes.h
+++ b/projects/max14919/src/platform/platform_includes.h
@@ -1,0 +1,46 @@
+/***************************************************************************//**
+ *   @file   platform_includes.h
+ *   @brief  Includes for used platforms used by max14919s project.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PLATFORM_INCLUDES_H__
+#define __PLATFORM_INCLUDES_H__
+
+#ifdef MAXIM_PLATFORM
+#include "maxim/parameters.h"
+#endif
+
+#endif /* __PLATFORM_INCLUDES_H__ */


### PR DESCRIPTION
## Pull Request Description

The MAX14919/MAX14919A industrial-protected quad-channel lowside switch features 140mΩ (typ) on-resistance (RON) per channel with integrated ±1kV/42Ω surge protection for robust operation.

Resistor-settable accurate current limiting provides guaranteed operating currents in the range of 100mA to 800mA. Loads that draw large activation or inrush currents are supported using the 2x inrush load-current option. The outputs can be connected in parallel to achieve higher load currents. The four switches are pin-controlled to allow for simple and fast switching of up to 500kHz.

The MAX14919/MAX14919A features reverse current detection. The MAX14919 implements reverse-current protection by driving an external FET for non-capacitive loads. The MAX14919A has reverse current indication.

The device itself doesn't have any SPI/I2C communication protocol, so the driver consists off no-OS GPIOs structures commanding GPIO pins to be high or low in order to set the OUTPUT channels states, get FAULT information, get current polarity information or set current limiting.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
