### PR TITLE
drivers: digital-io : Fix compliation warnings for MAX22190 and MAX22196.

### DIFF
--- a/drivers/digital-io/max22190/max22190.c
+++ b/drivers/digital-io/max22190/max22190.c
@@ -280,8 +280,7 @@ int max22190_fault_enable_set(struct max22190_desc *desc,
 			      enum max22190_fault_enable fault_enable,
 			      bool enabled)
 {
-	int ret, i;
-	uint32_t reg_val;
+	int ret;
 
 	switch(fault_enable) {
 	case MAX22190_FAULT1_WBGE ... MAX22190_FAULT1_FAULT2E:
@@ -435,7 +434,7 @@ int max22190_init(struct max22190_desc **desc,
 		  struct max22190_init_param *param)
 {
 	struct max22190_desc *descriptor;
-	int ret, i;
+	int ret;
 
 	descriptor = no_os_calloc(1, sizeof(*descriptor));
 	if (!descriptor)

--- a/drivers/digital-io/max22196/iio_max22196.c
+++ b/drivers/digital-io/max22196/iio_max22196.c
@@ -42,6 +42,7 @@
 #include "no_os_error.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
+#include "no_os_alloc.h"
 
 #include "max22196.h"
 #include "iio_max22196.h"

--- a/drivers/digital-io/max22196/max22196.c
+++ b/drivers/digital-io/max22196/max22196.c
@@ -361,7 +361,7 @@ int max22196_fault_mask_get(struct max22196_desc *desc,
 		ret = max22196_reg_read(desc, MAX22196_GLOBALCFG_REG, &reg_val);
 		if (ret)
 			return ret;
-		*enabled = no_os_field_get(desc, MAX22196_FAULT_MASK(fault_mask));
+		*enabled = no_os_field_get(MAX22196_FAULT_MASK(fault_mask), reg_val);
 
 		break;
 	case MAX22196_FAULT1_VMLOW ... MAX22196_FAULT1_FAULT2:
@@ -502,7 +502,7 @@ int max22196_init(struct max22196_desc **desc,
 		  struct max22196_init_param *param)
 {
 	struct max22196_desc *descriptor;
-	uint8_t reg_val;
+	uint32_t reg_val;
 	int ret;
 
 	descriptor = no_os_calloc(1, sizeof(*descriptor));


### PR DESCRIPTION
## Pull Request Description

MAX22190 has compliation warnings consisting of unused variables in the max22190.c source file.
MAX22196 has compliation warnings in both max22196.c and iio_max22196 source files consisting of :
- Unincluded header files.
- Bad API calls of no_os_util.h API.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
