### PR TITLE
drivers:ad719x: Minor Updates

### DIFF
--- a/drivers/adc/ad719x/ad719x.c
+++ b/drivers/adc/ad719x/ad719x.c
@@ -159,9 +159,11 @@ int ad719x_init(struct ad719x_dev **device,
 	if (ret != 0)
 		goto error_sync;
 
-	ret = ad719x_set_bridge_switch(dev, init_param.bpdsw_mode);
-	if (ret != 0)
-		goto error_sync;
+	if (dev->chip_id != AD7194) {
+		ret = ad719x_set_bridge_switch(dev, init_param.bpdsw_mode);
+		if (ret != 0)
+			goto error_sync;
+	}
 
 	ret = ad719x_set_operating_mode(dev, init_param.operating_mode);
 	if (ret != 0)
@@ -412,6 +414,11 @@ int ad719x_channels_select(struct ad719x_dev *dev,
 			return -EINVAL;
 		}
 	}
+
+	if (dev->chip_id == AD7194)
+		return ad719x_set_masked_register_value(dev, AD719X_REG_CONF,
+							AD719X_CONF_CHAN(0x1FF), AD719X_CONF_CHAN(chn_mask),
+							3);
 
 	return ad719x_set_masked_register_value(dev, AD719X_REG_CONF,
 						AD719X_CONF_CHAN(0x3FF), AD719X_CONF_CHAN(chn_mask),


### PR DESCRIPTION
Fixed bridge switch return check to
not return error for ad7194
Updated channel select API
for ad7194 as previous mask didn't apply
for ad7194.

## Pull Request Description

The modification in channel select API is needed as previous mask applied was not for ad7194. 

The return check after bridge switch had to be updated since in bridge switch API if it was ad7194 device it returned an error and the whole no-os initialization failed.

## PR Type
- [X] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [X] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [X] I have performed a self-review of the changes
- [X] I have commented my code, at least hard-to-understand parts
- [X] I have build all projects affected by the changes in this PR
- [X] I have tested in hardware affected projects, at the relevant boards
- [X] I have signed off all commits from this PR
- [X] I have updated the documentation (wiki pages, ReadMe etc), if applies
