### PR TITLE
tools: xilinx: util.tcl: Add remote flash

### DIFF
--- a/tools/scripts/platform/xilinx/util.tcl
+++ b/tools/scripts/platform/xilinx/util.tcl
@@ -242,7 +242,11 @@ proc upload {} {
 	set cpu [_get_processor]
 
 	# Connect to the fpga
-	connect
+  if { [info exists ::env(XSCT_REMOTE_HOST)] && [info exists ::env(XSCT_REMOTE_PORT)] } {
+    connect -host "$::env(XSCT_REMOTE_HOST)" -port "$::env(XSCT_REMOTE_PORT)"
+  } else {
+    connect
+  }
 
 	# Reset and stop the ARM CPU before we re-program the FPGA if we are on a ZYNQ.
 	# Otherwise undefined behavior can occur.


### PR DESCRIPTION
## Pull Request Description

Enables remote flash capability for xilinx platform when both
`XSCT_REMOTE_HOST` and `XSCT_REMOTE_PORT` to a host running `hw_server`

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
