### PR TITLE
drivers: digital-io: max22196 : Add support for MAX22194

### DIFF
--- a/drivers/digital-io/max22196/README.rst
+++ b/drivers/digital-io/max22196/README.rst
@@ -5,6 +5,7 @@ Supported Devices
 -----------------
 
 `MAX22196 <https://www.analog.com/MAX22196>`
+`MAX22194 <https://www.analog.com/MAX22194>`
 
 Overview
 --------
@@ -20,6 +21,9 @@ power dissipation while ensuring compliance with the IEC 61131-2 standard.
 With a single current-setting resistor, the inputs are individually 
 configurable for Type 1/3, Type 2, TTL or HTL (high-impedance 24V levels). 
 The current sinks or sources can be individually disabled.
+
+If using MAX22194 channels 5 to 8 won't be available so any API call with one of these
+channels will result in a -EINVAL errno code being returned.
 
 Applications
 ------------
@@ -80,6 +84,7 @@ MAX22196 Driver Initialization Example
 		.chip_select = 0,
 	};
 	struct max22196_init_param max22196_ip = {
+		.chip_id = ID_MAX22196,
 		.chip_address = 0,
 		.comm_desc = &spi_ip,
 	};
@@ -121,7 +126,7 @@ MAX22196 has 7 global attributes that can be configured as enabled/disabled :
 * refdi_sht_cfg - REFDI pin short detection.
 * clrf_filtr - Fix all input glitch filters to mid-scale value.
 * fspi_clr - Configures how the bits in the FAULT1 register are cleared.
-* led9 - LED9 control.
+* led9 - LED9 control. (attribute does not apply to MAX22194).
 * led_int - LED matrix user control of autonomous control selection.
 * gpo - Configure LO1 - LO6 outputs to be LED matrix or GPO drivers.
 

--- a/drivers/digital-io/max22196/iio_max22196.c
+++ b/drivers/digital-io/max22196/iio_max22196.c
@@ -844,7 +844,7 @@ int max22196_iio_init(struct max22196_iio_desc **iio_desc,
 	ret = max22196_init(&descriptor->max22196_desc,
 			    init_param->max22196_init_param);
 	if (ret)
-		goto free_desc;
+		goto free_dev;
 
 	descriptor->iio_dev = &max22196_iio_dev;
 
@@ -857,9 +857,7 @@ int max22196_iio_init(struct max22196_iio_desc **iio_desc,
 	return 0;
 
 free_dev:
-	max22196_remove(descriptor->max22196_desc);
-free_desc:
-	no_os_free(descriptor);
+	max22196_iio_remove(descriptor);
 	return ret;
 }
 

--- a/drivers/digital-io/max22196/max22196.c
+++ b/drivers/digital-io/max22196/max22196.c
@@ -523,12 +523,12 @@ int max22196_init(struct max22196_desc **desc,
 	if (param->crc_en) {
 		ret = no_os_gpio_get(&descriptor->crc_desc, param->crc_param);
 		if (ret)
-			goto spi_error;
+			goto error;
 
 		ret = no_os_gpio_direction_output(descriptor->crc_desc,
 						  NO_OS_GPIO_HIGH);
 		if (ret)
-			goto gpio_error;
+			goto error;
 
 		descriptor->crc_en = true;
 	}
@@ -539,22 +539,18 @@ int max22196_init(struct max22196_desc **desc,
 	/* Clear the latched faults generated at power-up of MAX22196. */
 	ret = max22196_reg_read(descriptor, MAX22196_FAULT1_REG, &reg_val);
 	if (ret)
-		goto gpio_error;
+		goto error;
 
 	ret = max22196_reg_read(descriptor, MAX22196_FAULT2_REG, &reg_val);
 	if (ret)
-		goto gpio_error;
+		goto error;
 
 	*desc = descriptor;
 
 	return 0;
-gpio_error:
-	if (param->crc_en)
-		no_os_gpio_remove(descriptor->crc_desc);
-spi_error:
-	no_os_spi_remove(descriptor->comm_desc);
+
 error:
-	no_os_free(descriptor);
+	max22196_remove(descriptor);
 
 	return ret;
 }

--- a/drivers/digital-io/max22196/max22196.h
+++ b/drivers/digital-io/max22196/max22196.h
@@ -48,6 +48,7 @@
 #define MAX22196_FRAME_SIZE		2
 
 #define MAX22196_CHANNELS		8
+#define MAX22194_CHANNELS		4
 
 #define MAX22196_CHN_CNT_RESET		0
 
@@ -84,6 +85,11 @@
 #define MAX22196_FAULT2_MASK		NO_OS_GENMASK(4, 0)
 
 #define MAX22196_FILTER_CLRFLT_MASK	NO_OS_BIT(3)
+
+enum max22196_chip_id {
+	ID_MAX22194,
+	ID_MAX22196
+};
 
 enum max22196_fault_mask {
 	MAX22196_GLOBAL_REFDISHTCFG,
@@ -134,6 +140,7 @@ struct max22196_init_param {
 	struct no_os_spi_init_param *comm_param;
 	struct no_os_gpio_init_param *crc_param;
 	bool crc_en;
+	enum max22196_chip_id chip_id;
 };
 
 struct max22196_desc {
@@ -143,6 +150,8 @@ struct max22196_desc {
 	uint8_t buff[MAX22196_FRAME_SIZE + 1];
 	uint8_t fault2en;
 	bool crc_en;
+	enum max22196_chip_id chip_id;
+	uint8_t max_chn_nb;
 };
 
 /** Register write function for MAX22196. */


### PR DESCRIPTION
## Pull Request Description

MAX22194 is the same as MAX22196 except it doesn't have the 5 to 8 channels and channel counting functionality, therefore
the first commit handles the compatibility of the driver for MAX22194 as well as the MAX22196 using a chip_id enum inside of the device descriptor as well as the initialization parameter.

The second commit only uses the new approach for avoiding memory leaks at initialization of the driver.

The third commit updates the README.rst file so any MAX22194 extra related documentation is included and therefore be found in the no-OS repository.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
