### PR TITLE
tools: scripts: generic: drop unused flag

### DIFF
--- a/tools/scripts/generic.mk
+++ b/tools/scripts/generic.mk
@@ -153,8 +153,7 @@ CFLAGS += -Wall								\
 	 -Wno-unused-parameter						\
 	 -MMD 								\
 	 -MP								\
-	 -lm						
-	#-Werror
+	 -lm
 
 #------------------------------------------------------------------------------
 #                          COMMON INITIALIZATION


### PR DESCRIPTION
## Pull Request Description

The flag is probably here from the initial development of the generic.mk file and used for debugging purposes.
(ae7ad15)

Drop it completely.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
