### PR TITLE
doc: Add Makefile and repository to conf.py

### DIFF
--- a/doc/sphinx/source/Makefile
+++ b/doc/sphinx/source/Makefile
@@ -1,0 +1,13 @@
+SHELL         = /bin/bash
+SPHINXOPTS   ?=
+SPHINXBUILD  ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = ../build
+
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -17,6 +17,7 @@
 
 # -- Project information -----------------------------------------------------
 
+repository = 'no-OS'
 project = 'no-OS'
 copyright = '2023, Analog Devices, Inc.'
 author = 'Analog Devices, Inc.'


### PR DESCRIPTION
## Pull Request Description

Adds the default Sphinx Makefile with vars `SOURCEDIR` and `BUILDDIR` set.
I need this file to exist because [doctools](https://github.com/analogdevicesinc/doctools/blob/8192817d818b9fe0cd34dc69034619f9936d930d/adi_doctools/cli/aggregate.py#L157) needs to know the source and build paths.
Set values are consistent with the ones at [documentation.sh](https://github.com/analogdevicesinc/no-OS/blob/0f275e683906480b9478e4a01f2d8d983f328ff9/ci/documentation.sh#L113).
Created it in the `doc/sphinx/source` path instead of `doc/sphinx`  because it would be the only file at the latter path.
Also, includes `repository` var to `conf.py`, also used by doctools.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [X] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [X] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [X] I have performed a self-review of the changes
- [X] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [X] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
