### PR TITLE
drivers: imu: adis: Add tx_buff for all messages

### DIFF
--- a/drivers/imu/adis.c
+++ b/drivers/imu/adis.c
@@ -261,6 +261,7 @@ int adis_read_reg(struct adis_dev *adis,  uint32_t reg, uint32_t *val,
 			.cs_delay_last = adis->info->read_delay,
 		},
 		{
+			.tx_buff = adis->tx,
 			.rx_buff = adis->rx + 2,
 			.bytes_number = 2,
 			.cs_change = 1,


### PR DESCRIPTION
Maxim Platform needs tx_buff != NULL even if only receiving data, thus adding tx_buff to message.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
