### PR TITLE
drivers:platform:stm32:Update STM32 I2C Drivers

### DIFF
--- a/drivers/platform/stm32/stm32_i2c.c
+++ b/drivers/platform/stm32/stm32_i2c.c
@@ -55,6 +55,7 @@ int32_t stm32_i2c_init(struct no_os_i2c_desc **desc,
 	int32_t ret;
 	struct no_os_i2c_desc *descriptor;
 	struct stm32_i2c_desc *xdesc;
+	struct stm32_i2c_init_param *i2cinit;
 	I2C_TypeDef *base = NULL;
 
 	if (!desc || !param)
@@ -71,6 +72,7 @@ int32_t stm32_i2c_init(struct no_os_i2c_desc **desc,
 		goto error_1;
 	}
 
+	i2cinit = param->extra;
 	descriptor->extra = xdesc;
 
 	switch (param->device_id) {
@@ -95,8 +97,12 @@ int32_t stm32_i2c_init(struct no_os_i2c_desc **desc,
 	};
 
 	xdesc->hi2c.Instance = base;
+#if defined (STM32F4) || defined (STM32F1) || defined (STM32F2) || defined (STM32L1)
 	xdesc->hi2c.Init.ClockSpeed = param->max_speed_hz;
 	xdesc->hi2c.Init.DutyCycle = I2C_DUTYCYCLE_2;
+#else
+	xdesc->hi2c.Init.Timing = i2cinit->i2c_timing;
+#endif
 	xdesc->hi2c.Init.OwnAddress1 = 0;
 	xdesc->hi2c.Init.AddressingMode = I2C_ADDRESSINGMODE_7BIT;
 	xdesc->hi2c.Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;

--- a/drivers/platform/stm32/stm32_i2c.h
+++ b/drivers/platform/stm32/stm32_i2c.h
@@ -53,6 +53,16 @@ struct stm32_i2c_desc {
 };
 
 /**
+ * @struct stm32_i2c_init_param
+ * @brief Structure holding the initialization parameters for stm32 platform
+ * specific I2C parameters.
+ */
+struct stm32_i2c_init_param {
+	/** I2C Timing */
+	uint32_t i2c_timing;
+};
+
+/**
  * @brief stm32 specific I2C platform ops structure
  */
 extern const struct no_os_i2c_platform_ops stm32_i2c_ops;


### PR DESCRIPTION
An STM32F4 macro check has been added for usage two structure members in the stm32_i2c.c, that aren't a part of STM32L5, STM32H5 family.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
