### PR TITLE
build_projects.yml: increase timeout for Xilinx job

### DIFF
--- a/build_projects.yml
+++ b/build_projects.yml
@@ -26,6 +26,7 @@ variables:
 
 jobs:
 - job: Xilinx
+  timeoutInMinutes: 200
   pool:
     name: Default
     demands:


### PR DESCRIPTION
## Pull Request Description

The default timeout for azure jobs is 60 minutes but when hardware files from hdl are seen as new, the build will take almost 3 hours.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [x] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
