### PR TITLE
tools: scripts: make TARGET case insensitive

### DIFF
--- a/tools/scripts/generic_variables.mk
+++ b/tools/scripts/generic_variables.mk
@@ -42,7 +42,7 @@ LINK_SRCS ?= y
 
 HARDWARE ?= $(wildcard *.xsa) $(wildcard *.hdf) $(wildcard *.sopcinfo) $(wildcard *.ioc) $(wildcard pinmux_config.c)
 #If platform not set get it from HARDWARE file
-ifneq '' '$(findstring max,$(TARGET))'
+ifneq '' '$(or $(findstring max,$(TARGET)), $(findstring MAX,$(TARGET)))'
 PLATFORM = maxim
 else
 ifeq '' '$(PLATFORM)'

--- a/tools/scripts/maxim.mk
+++ b/tools/scripts/maxim.mk
@@ -31,14 +31,14 @@ CFLAGS+=-D_STACK_SIZE=$(STACK_SIZE)
 endif
 
 TARGET?=max32660
-TARGET_NUMBER:=$(word 2,$(subst x, ,$(TARGET)))
+TARGET_NUMBER:=$(word 2,$(subst x, ,$(subst X, ,$(TARGET))))
 TARGET_UCASE=$(addprefix MAX,$(TARGET_NUMBER))
 TARGET_LCASE=$(addprefix max,$(TARGET_NUMBER))
 
-PLATFORM_DRIVERS := $(NO-OS)/drivers/platform/maxim/$(TARGET)
+PLATFORM_DRIVERS := $(NO-OS)/drivers/platform/maxim/$(TARGET_LCASE)
 
-ifeq ($(TARGET), $(filter $(TARGET),max32655 max32690))
-include $(MAXIM_LIBRARIES)/CMSIS/Device/Maxim/$(TARGET_UCASE)/Source/GCC/$(TARGET)_memory.mk
+ifeq ($(TARGET_LCASE), $(filter $(TARGET_LCASE),max32655 max32690))
+include $(MAXIM_LIBRARIES)/CMSIS/Device/Maxim/$(TARGET_UCASE)/Source/GCC/$(TARGET_LCASE)_memory.mk
 endif
 include $(MAXIM_LIBRARIES)/PeriphDrivers/$(TARGET_LCASE)_files.mk
 
@@ -76,7 +76,7 @@ ASFLAGS += -x assembler-with-cpp
 
 ASFLAGS += $(PROJ_AFLAGS)
 CFLAGS += -DTARGET_REV=$(TARGET_REV) \
-	-DTARGET=$(TARGET)		\
+	-DTARGET=$(TARGET_LCASE)		\
 	-DMAXIM_PLATFORM		\
 	-DTARGET_NUM=$(TARGET_NUMBER)
 
@@ -100,7 +100,7 @@ SRCS += $(MAXIM_LIBRARIES)/CMSIS/Device/Maxim/$(TARGET_UCASE)/Source/system_$(TA
 INCS += $(wildcard $(MAXIM_LIBRARIES)/CMSIS/Include/*.h)
 INCS += $(wildcard $(MAXIM_LIBRARIES)/CMSIS/Device/Maxim/$(TARGET_UCASE)/Include/*.h)
 
-ifeq ($(TARGET), max32650)
+ifeq ($(TARGET_LCASE), max32650)
 INCS := $(filter-out $(MAXIM_LIBRARIES)/CMSIS/Device/Maxim/$(TARGET_UCASE)/Include/mxc_device.h, $(INCS))
 endif
 


### PR DESCRIPTION
## Pull Request Description

This is a small suggestion for improvement.

Currently when using uppercase letters for specifying the maxim target an unrelated error is thrown.

Allow users to use both lower case and uppercase letters when specifying the target.

For maxim targets we already have uppercase and lowercase variables initialized with `TARGET_UCASE`, `TARGET_LCASE` so they can be directly used for this feature.

With this patch both versions work, for example:
`make TARGET=max32650`
`make TARGET=MAX32650`


## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
