### PR TITLE
platform: maxim: max32690: Include gpio.h

### DIFF
--- a/drivers/platform/maxim/max32690/maxim_i2c.h
+++ b/drivers/platform/maxim/max32690/maxim_i2c.h
@@ -44,6 +44,7 @@
 #include "i2c_regs.h"
 #include "max32690.h"
 #include "no_os_i2c.h"
+#include "gpio.h"
 
 #ifndef MXC_I2C_GET_I2C
 #define MXC_I2C_GET_I2C(i)	((i) == 0 ? MXC_I2C0 :		\

--- a/drivers/platform/maxim/max32690/maxim_spi.h
+++ b/drivers/platform/maxim/max32690/maxim_spi.h
@@ -42,6 +42,7 @@
 
 #include <stdint.h>
 #include "no_os_spi.h"
+#include "gpio.h"
 
 /**
  * @brief maxim specific SPI platform ops structure

--- a/drivers/platform/maxim/max32690/maxim_uart.h
+++ b/drivers/platform/maxim/max32690/maxim_uart.h
@@ -44,6 +44,7 @@
 #include "no_os_irq.h"
 #include "max32690.h"
 #include "no_os_uart.h"
+#include "gpio.h"
 
 /**
  * @brief UART flow control


### PR DESCRIPTION
Currently, the gpio.h header is not included in some header files which use GPIO specific data types. This may or may not result in compilation errors depending if a header which includes gpio.h is included before in a specific source file.

Fix this by explicitly including gpio.h whenever necessary.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
