### PR TITLE
tools: scripts: change hdl_branch search in artifactory

### DIFF
--- a/tools/scripts/build_projects.py
+++ b/tools/scripts/build_projects.py
@@ -183,10 +183,10 @@ def configfile_and_download_all_hw(_platform, noos, _builds_dir, hdl_branch):
 	if hdl_branch == "main":
 		hdl_branch_path = hdl_branch + '/hdl_output'
 	else:
-		if requests.get(server_base_path + 'dev/' + hdl_branch, stream=True).status_code == 200:
-			hdl_branch_path = 'dev/' + hdl_branch + '/hdl_output'
-		elif requests.get(server_base_path + 'releases/' + hdl_branch, stream=True).status_code == 200:
+		if requests.get(server_base_path + 'releases/' + hdl_branch, stream=True).status_code == 200:
 			hdl_branch_path = 'releases/' + hdl_branch + '/hdl_output'
+		elif requests.get(server_base_path + 'dev/' + hdl_branch, stream=True).status_code == 200:
+			hdl_branch_path = 'dev/' + hdl_branch + '/hdl_output'
 		else:
 			print("Error related to hdl branch name: " + hdl_branch)
 			exit()


### PR DESCRIPTION
## Pull Request Description

Two next_stable folders were created in artifactory for hdl project and the valid one is found now under releases path in artifactory.
In order to access the new folder the search needs to be done first in releases path.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [x] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
