### PR TITLE
drivers:adc:ad713x:Bug fix with AD7134 driver

### DIFF
--- a/drivers/adc/ad713x/ad713x.c
+++ b/drivers/adc/ad713x/ad713x.c
@@ -58,7 +58,7 @@
 /***************************** Variable definition ****************************/
 /******************************************************************************/
 
-static const int ad713x_output_data_frame[3][9][2] = {
+static const int ad713x_output_data_frame[4][9][2] = {
 	{
 		{ADC_16_BIT_DATA, CRC_6},
 		{ADC_24_BIT_DATA, CRC_6},


### PR DESCRIPTION
Bug fix to ensure that number of array elements dont exceed the array size

fixes: e1161fa ("drivers:adc:ad713x:add ad7134 data format")

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
