### PR TITLE
ad796x: Add project and driver for ad796x-fmc

### DIFF
--- a/doc/sphinx/source/drivers/ad796x.rst
+++ b/doc/sphinx/source/drivers/ad796x.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../drivers/adc/ad796x/README.rst

--- a/doc/sphinx/source/drivers_doc.rst
+++ b/doc/sphinx/source/drivers_doc.rst
@@ -18,6 +18,7 @@ ANALOG TO DIGITAL CONVERTERS
 
    drivers/adm1177
    drivers/ad405x
+   drivers/ad796x
 
 AXI CORES
 =========

--- a/doc/sphinx/source/projects/ad796x_fmcz.rst
+++ b/doc/sphinx/source/projects/ad796x_fmcz.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../projects/ad796x_fmcz/README.rst

--- a/doc/sphinx/source/projects_doc.rst
+++ b/doc/sphinx/source/projects_doc.rst
@@ -64,6 +64,7 @@ ADC
    :maxdepth: 1
 
    projects/ad7616-st
+   projects/ad796x_fmcz
 
 POWER MANAGEMENT
 ================

--- a/drivers/adc/ad796x/README.rst
+++ b/drivers/adc/ad796x/README.rst
@@ -1,0 +1,218 @@
+AD796X no-OS driver
+====================
+
+Supported Devices
+-----------------
+
+`AD7960 <https://www.analog.com/en/products/ad7960.html>`_
+
+Overview
+--------
+
+The EVAL-AD7960FMCZ is a fully featured evaluation Kit designed to demonstrate
+the performance of the low power 18-bit,5 MSPS PulSAR® Differential ADC AD7960.
+
+This board operates in conjunction with the Zedboard. The evaluation software
+is provided to enable the user to perform detailed analysis of the AD7960's
+performance. The technical user guide includes the detailed description of
+the operation and set up of the evaluation board and software when operated
+with the System Demonstration Platform board.
+
+
+AD796X Device Configuration
+----------------------------
+
+Driver Initialization
+^^^^^^^^^^^^^^^^^^^^^^
+
+In order to be able to use the device, the pulsar lvds HDL is used. The usage
+of the driver is:
+
+**ad796x_init** is called with the settings dma, pwm, clkgen, and the 4 gpios to
+set the operation mode.
+
+**ad796x_read_data** called to fill a buffer with n number of samples.
+
+**ad796x_remove** Free the allocated resources
+
+AD796X Driver Initialization Example
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+	uint32_t *buf = (uintptr_t)ADC_DDR_BASEADDR;
+	int i, ret;
+	struct ad796x_dev *adc_dev;
+
+	struct axi_adc_init ad796x_core_ip = {
+		.name = "ad796x_core",
+		.num_channels = 1,
+		.base = RX_CORE_BASEADDR
+	};
+
+	struct axi_clkgen_init clkgen_ip = {
+		.name = "rx_clkgen",
+		.base = RX_CLKGEN_BASEADDR,
+		.parent_rate = 100000000,
+	};
+
+	struct axi_dmac_init dmac_ip = {
+		.name = "ad796x_dmac",
+		.base = RX_DMA_BASEADDR,
+		.irq_option = IRQ_DISABLED
+	};
+
+	struct axi_pwm_init_param axi_pwm_0_extra = {
+		.base_addr = AXI_PWMGEN_BASEADDR,
+		.ref_clock_Hz = 125000000,
+		.channel = 0
+	};
+
+	struct no_os_pwm_init_param axi_pwm_0_ip = {
+		.period_ns = PWM_0_PERIOD_NS,
+		.duty_cycle_ns = PWM_0_DUTY_NS,
+		.phase_ns = PWM_0_PHASE,
+		.platform_ops = &axi_pwm_ops,
+		.extra = &axi_pwm_0_extra
+	};
+
+	struct axi_pwm_init_param axi_pwm_1_extra = {
+		.base_addr = AXI_PWMGEN_BASEADDR,
+		.ref_clock_Hz = 125000000,
+		.channel = 1
+	};
+
+	struct no_os_pwm_init_param axi_pwm_1_ip = {
+		.period_ns = PWM_1_PERIOD_NS,
+		.duty_cycle_ns = PWM_1_DUTY_NS,
+		.phase_ns = PWM_1_PHASE,
+		.platform_ops = &axi_pwm_ops,
+		.extra = &axi_pwm_1_extra
+	};
+
+	struct xil_gpio_init_param xil_gpio_init = {
+		.device_id = GPIO_DEVICE_ID,
+		.type = GPIO_PS
+	};
+
+	struct no_os_gpio_init_param gpio_adc_en3_fmc_ip = {
+		.number = GPIO_EN3_FMC,
+		.platform_ops = GPIO_OPS,
+		.extra = GPIO_EXTRA
+	};
+
+	struct no_os_gpio_init_param gpio_adc_en2_fmc_ip = {
+		.number = GPIO_EN2_FMC,
+		.platform_ops = GPIO_OPS,
+		.extra = GPIO_EXTRA
+	};
+
+	struct no_os_gpio_init_param gpio_adc_en1_fmc_ip = {
+		.number = GPIO_EN1_FMC,
+		.platform_ops = GPIO_OPS,
+		.extra = GPIO_EXTRA
+	};
+
+	struct no_os_gpio_init_param gpio_adc_en0_fmc_ip = {
+		.number = GPIO_EN0_FMC,
+		.platform_ops = GPIO_OPS,
+		.extra = GPIO_EXTRA
+	};
+
+	struct ad796x_init_param ad796x_init_param = {
+		.ad796x_core_ip = &ad796x_core_ip,
+		.clkgen_ip = &clkgen_ip,
+		.dmac_ip = &dmac_ip,
+		.axi_pwm_0_ip = &axi_pwm_0_ip,
+		.axi_pwm_1_ip = &axi_pwm_1_ip,
+		.gpio_ip[3] = &gpio_adc_en3_fmc_ip,
+		.gpio_ip[2] = &gpio_adc_en2_fmc_ip,
+		.gpio_ip[1] = &gpio_adc_en1_fmc_ip,
+		.gpio_ip[0] = &gpio_adc_en0_fmc_ip,
+		.mode = AD796X_MODE1_EXT_REF_5P0,
+	};
+
+	ret = ad796x_init(&adc_dev, &ad796x_init_param);
+	if (ret)
+		return ret;
+
+	pr_info("Capture start.\n");
+	ret = ad796x_read_data(adc_dev, buf, SAMPLES_PER_CHANNEL);
+	if (ret) {
+		pr_err("read data error %d\n", ret);
+		ad796x_remove(adc_dev);
+		return ret;
+	}
+
+	for (i = 0; i < SAMPLES_PER_CHANNEL; i++, buf++)
+		printf("CH1: %ld\n", *buf);
+
+
+	return ad796x_remove(adc_dev);
+
+AD796X no_OS IIO Support
+-------------------------
+
+The AD796X uses the iio_axi_adc driver to provide iio support.
+
+
+AD796X IIO Driver Initialization Example
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+	struct ad796x_dev *adc_dev;
+	struct iio_app_desc *app;
+	struct iio_app_init_param app_init_param = { 0 };
+	struct iio_axi_adc_desc *iio_axi_adc_desc;
+	struct iio_device *dev_desc;
+	struct iio_data_buffer adc_buff = {
+		.buff = (void *)ADC_DDR_BASEADDR,
+		.size = MAX_SIZE_BASE_ADDR
+	};
+	struct scan_type init_scan_type = {
+		.sign = 's',
+		.realbits = 32,
+		.storagebits = 32,
+		.shift = 0,
+		.is_big_endian = false
+	};
+
+	ret = ad796x_init(&adc_dev, &ad796x_init_param);
+	if (ret) {
+		pr_err("Error: ad796x_init: %d\n", ret);
+		return ret;
+	}
+
+	struct iio_axi_adc_init_param iio_axi_adc_init_par = {
+		.rx_adc = adc_dev->ad796x_core,
+		.rx_dmac = adc_dev->axi_dmac,
+		.scan_type_common = &init_scan_type,
+		.dcache_invalidate_range = (void (*)(uint32_t,
+						     uint32_t))Xil_DCacheInvalidateRange,
+	};
+
+	ret = iio_axi_adc_init(&iio_axi_adc_desc, &iio_axi_adc_init_par);
+	if (ret) {
+		pr_err("Error: iio_axi_adc_init: %d\n", ret);
+		goto err_adc_init;
+	}
+
+	iio_axi_adc_get_dev_descriptor(iio_axi_adc_desc, &dev_desc);
+
+	struct iio_app_device devices[] = {
+		IIO_APP_DEVICE("ad796x", iio_axi_adc_desc,
+			       dev_desc, &adc_buff, NULL, NULL),
+	};
+
+	app_init_param.devices = devices;
+	app_init_param.nb_devices = NO_OS_ARRAY_SIZE(devices);
+	app_init_param.uart_init_params = iio_uart_ip;
+
+	ret = iio_app_init(&app, app_init_param);
+	if (ret) {
+		pr_err("Error: iio_app_init: %d\n", ret);
+		goto err_app_init;
+	}
+
+	ret = iio_app_run(app);

--- a/drivers/adc/ad796x/ad796x.c
+++ b/drivers/adc/ad796x/ad796x.c
@@ -1,0 +1,259 @@
+/***************************************************************************//**
+ *   @file   ad796x.c
+ *   @brief  Implementation of AD796X Driver.
+ *   @author Axel Haslam (ahaslam@baylibre.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdlib.h>
+#include <errno.h>
+#include "ad796x.h"
+#include "no_os_alloc.h"
+#include "no_os_print_log.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+#define AD796X_BYTES_PER_SAMPLE		4
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+/* gpio values for the respective mode {en0, en1, en2, en3} */
+static uint8_t ad796x_modes[][AD796X_NUM_GPIOS] = {
+	[AD796X_MODE1_EXT_REF_5P0] =		{1, 0, 0, 1},
+	[AD796X_MODE2_INT_REF_4P0] =		{1, 0, 0, 1},
+	[AD796X_MODE3_EXT_REF_4P0] =		{0, 1, 0, 1},
+	[AD796X_MODE4_SNOOZE] =			{1, 1, 0, 1},
+	[AD796X_MODE5_TEST] =			{0, 0, 1, 0},
+	[AD796X_MODE6_INVALID] =		{0, 0, 1, 1},
+	[AD796X_MODE7_EXT_REF_5P0_9MHZ] =	{1, 0, 1, 1},
+	[AD796X_MODE8_INT_REF_4P0_9MHZ] =	{1, 0, 1, 1},
+	[AD796X_MODE9_EXT_REF_4P0_9MHZ] =	{0, 1, 1, 1},
+	[AD796X_MODE10_SNOOZE2] =		{1, 1, 1, 1},
+};
+
+/**
+ * @brief Read data samples from adc
+ * @param dev - The device structure.
+ * @param buf - The buffer to fill.
+ * @param samples - number of samples to read.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int32_t ad796x_read_data(struct ad796x_dev *dev,
+			 uint32_t *buf,
+			 uint16_t samples)
+{
+	int ret;
+	struct 	axi_dma_transfer read_transfer = {
+		.size = samples * AD796X_BYTES_PER_SAMPLE,
+		.transfer_done = 0,
+		.cyclic = NO,
+		.src_addr = 0,
+		.dest_addr = (uintptr_t)buf,
+	};
+
+	ret = axi_dmac_transfer_start(dev->axi_dmac, &read_transfer);
+	if (ret) {
+		pr_err("axi_dmac_transfer_start() failed!\n");
+		return ret;
+	}
+
+	return axi_dmac_transfer_wait_completion(dev->axi_dmac, 3000);
+}
+
+/**
+ * @brief Remove the device gpio resources.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+static int ad796x_gpio_remove(struct ad796x_dev *dev)
+{
+	int ret, i;
+
+	if (!dev)
+		return -EINVAL;
+
+	for (i = 0; i < AD796X_NUM_GPIOS; i++) {
+		ret = no_os_gpio_remove(dev->gpio_en[i]);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Initialize the device gpios.
+ * @param device - The device structure.
+ * @param init_param - The structure that contains the device initial
+ * 		       parameters.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+static int ad796x_gpio_init(struct ad796x_dev *dev,
+			    struct ad796x_init_param *init_param)
+{
+	int ret, i;
+
+	if (!dev || !init_param)
+		return -EINVAL;
+
+	for (i = 0; i < AD796X_NUM_GPIOS; i++) {
+		ret = no_os_gpio_get_optional(&dev->gpio_en[i], init_param->gpio_ip[i]);
+		if (ret)
+			goto error;
+
+		if (!dev->gpio_en[i])
+			continue;
+
+		ret = no_os_gpio_direction_output(dev->gpio_en[i],
+						  ad796x_modes[init_param->mode][i]);
+		if (ret)
+			goto error;
+	}
+
+	return 0;
+error:
+	ad796x_gpio_remove(dev);
+	return ret;
+}
+
+/**
+ * @brief Initialize the device.
+ * @param device - The device structure.
+ * @param init_param - The structure that contains the device initial
+ * 		       parameters.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad796x_init(struct ad796x_dev **device,
+		struct ad796x_init_param *init_param)
+{
+	struct ad796x_dev *dev;
+	int ret;
+
+	dev = (struct ad796x_dev *)no_os_calloc(1, sizeof(*dev));
+	if (!dev)
+		return -ENOMEM;
+
+	ret = ad796x_gpio_init(dev, init_param);
+	if (ret)
+		goto error;
+
+	ret = axi_clkgen_init(&dev->clkgen, init_param->clkgen_ip);
+	if (ret) {
+		pr_err("error: axi_clkgen_init error: %d\n", ret);
+		goto error;
+	}
+
+	ret = axi_clkgen_set_rate(dev->clkgen, 125000000);
+	if (ret) {
+		pr_err("error: axi_clkgen_set_rate error: %d\n", ret);
+		goto error;
+	}
+
+	ret = no_os_pwm_init(&dev->axi_pwm_0, init_param->axi_pwm_0_ip);
+	if (ret) {
+		pr_err("error: no_os_pwm_init error: %d\n", ret);
+		goto error;
+	}
+
+	ret = no_os_pwm_init(&dev->axi_pwm_1, init_param->axi_pwm_1_ip);
+	if (ret) {
+		pr_err("error: no_os_pwm_init error: %d\n", ret);
+		goto error;
+	}
+
+	ret = axi_adc_init(&dev->ad796x_core, init_param->ad796x_core_ip);
+	if (ret) {
+		pr_err("axi_adc_init error: %d\n", ret);
+		goto error;
+	}
+
+	ret = axi_dmac_init(&dev->axi_dmac, init_param->dmac_ip);
+	if (ret) {
+		pr_err("axi_dmac_init error: %d\n", ret);
+		goto error;
+	}
+
+	*device = dev;
+
+	return 0;
+
+error:
+	ad796x_remove(dev);
+	return ret;
+}
+
+/**
+ * @brief Remove the device and release resources.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad796x_remove(struct ad796x_dev *dev)
+{
+	int ret;
+
+	if (!dev)
+		return -EINVAL;
+
+	ret = axi_adc_remove(dev->ad796x_core);
+	if (ret)
+		return ret;
+
+	ret = no_os_pwm_remove(dev->axi_pwm_1);
+	if (ret)
+		return ret;
+
+	ret = no_os_pwm_remove(dev->axi_pwm_0);
+	if (ret)
+		return ret;
+
+	ret = axi_clkgen_remove(dev->clkgen);
+	if (ret)
+		return ret;
+
+	ret = ad796x_gpio_remove(dev);
+	if (ret)
+		return ret;
+
+	no_os_free(dev);
+
+	return ret;
+}

--- a/drivers/adc/ad796x/ad796x.h
+++ b/drivers/adc/ad796x/ad796x.h
@@ -1,0 +1,115 @@
+/***************************************************************************//**
+ *   @file   ad796x.h
+ *   @brief  Header file of AD796X Driver.
+ *   @author Axel Haslam (ahaslam@baylibre.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __AD796X_H__
+#define __AD796X_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "no_os_gpio.h"
+#include "no_os_pwm.h"
+#include "axi_dmac.h"
+#include "clk_axi_clkgen.h"
+#include "axi_adc_core.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+enum ad796x_mode {
+	AD796X_MODE0_POWER_DOWN,
+	AD796X_MODE1_EXT_REF_5P0,
+	AD796X_MODE2_INT_REF_4P0,
+	AD796X_MODE3_EXT_REF_4P0,
+	AD796X_MODE4_SNOOZE,
+	AD796X_MODE5_TEST,
+	AD796X_MODE6_INVALID,
+	AD796X_MODE7_EXT_REF_5P0_9MHZ,
+	AD796X_MODE8_INT_REF_4P0_9MHZ,
+	AD796X_MODE9_EXT_REF_4P0_9MHZ,
+	AD796X_MODE10_SNOOZE2,
+};
+
+#define AD796X_NUM_GPIOS	4
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+/**
+ * @struct ad796x_init_param
+ * @brief AD796X Device initialization parameters.
+ */
+struct ad796x_init_param {
+	struct axi_adc_init		*ad796x_core_ip;
+	struct axi_clkgen_init		*clkgen_ip;
+	struct axi_dmac_init		*dmac_ip;
+	struct no_os_pwm_init_param	*axi_pwm_0_ip;
+	struct no_os_pwm_init_param	*axi_pwm_1_ip;
+	struct no_os_gpio_init_param	*gpio_ip[AD796X_NUM_GPIOS];
+	enum ad796x_mode mode;
+};
+
+/**
+ * @struct ad796x_dev
+ * @brief AD796X Device structure.
+ */
+struct ad796x_dev {
+	struct axi_adc			*ad796x_core;
+	struct axi_clkgen		*clkgen;
+	struct axi_dmac			*axi_dmac;
+	struct no_os_pwm_desc		*axi_pwm_0;
+	struct no_os_pwm_desc		*axi_pwm_1;
+	struct no_os_gpio_desc		*gpio_en[AD796X_NUM_GPIOS];
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+/* Initialize the device. */
+int ad796x_init(struct ad796x_dev **device,
+		struct ad796x_init_param *init_param);
+
+/* Remove the device and release resources. */
+int ad796x_remove(struct ad796x_dev *dev);
+
+/* Read samples from the device */
+int32_t ad796x_read_data(struct ad796x_dev *dev, uint32_t *buf,
+			 uint16_t samples);
+
+#endif /* __AD796X_H__ */

--- a/drivers/axi_core/axi_dmac/axi_dmac.c
+++ b/drivers/axi_core/axi_dmac/axi_dmac.c
@@ -342,13 +342,17 @@ int32_t axi_dmac_init(struct axi_dmac **dmac_core,
 	dmac->base = init->base;
 	dmac->irq_option = init->irq_option;
 
+	int32_t status = axi_dmac_detect_caps(dmac);
+	if (status < 0)
+		goto free;
+
 	*dmac_core = dmac;
 
-	int32_t status = axi_dmac_detect_caps(*dmac_core);
-	if (status < 0)
-		return -1;
-
 	return 0;
+
+free:
+	no_os_free(dmac);
+	return -1;
 }
 
 /*******************************************************************************

--- a/drivers/axi_core/iio_axi_adc/iio_axi_adc.c
+++ b/drivers/axi_core/iio_axi_adc/iio_axi_adc.c
@@ -43,9 +43,9 @@
 /***************************** Include Files **********************************/
 /******************************************************************************/
 
-#include <inttypes.h>
-#include <stdio.h>
 #include <stdlib.h>
+#include <stdio.h>
+#include <inttypes.h>
 #include "no_os_error.h"
 #include "no_os_alloc.h"
 #include "iio.h"

--- a/projects/ad796x_fmcz/Makefile
+++ b/projects/ad796x_fmcz/Makefile
@@ -1,0 +1,12 @@
+# Uncomment to use the desired platform
+# PLATFORM = xilinx
+
+# Select the example you want to enable by choosing y for enabling and n for disabling
+IIO_EXAMPLE = y
+BASIC_EXAMPLE = n
+
+include ../../tools/scripts/generic_variables.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/ad796x_fmcz/README.rst
+++ b/projects/ad796x_fmcz/README.rst
@@ -1,0 +1,108 @@
+Evaluating the AD796x
+======================
+
+
+Contents
+--------
+
+.. contents:: Table of Contents
+	:depth: 3
+
+Supported Evaluation Boards
+---------------------------
+
+* `AD796xDC1-EVALZ <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-AD796x.html#eb-documentation>`_
+
+Overview
+--------
+
+The EVAL-AD7960FMCZ is a fully featured evaluation Kit designed to demonstrate
+the performance of the low power 18-bit,5 MSPS PulSAR® Differential ADC AD7960.
+
+This board operates in conjunction with the Zedboard. The evaluation software
+is provided to enable the user to perform detailed analysis of the AD7960's
+performance. The technical user guide includes the detailed description of
+the operation and set up of the evaluation board and software when operated
+with the System Demonstration Platform board.
+
+No-OS Build Setup
+-----------------
+
+Please see: https://wiki.analog.com/resources/no-os/build
+
+No-OS Supported Examples
+------------------------
+
+The initialization data used in the examples is taken out from:
+`Project Common Data Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ad796x_fmcz/src/common>`_
+
+The macros used in Common Data are defined in platform specific files found in:
+`Project Platform Configuration Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ad796x_fmcz/src/platform>`_
+
+Basic example
+^^^^^^^^^^^^^
+
+This is a simple example that initializes the AD796x, collects a numer of samples
+and prints the result on the uart.
+
+In order to build the basic example make sure you have the following configuration in the Makefile
+`Makefile <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ad796x_fmcz/Makefile>`_
+
+.. code-block:: bash
+
+	# Select the example you want to enable by choosing y for enabling and n for disabling
+	BASIC_EXAMPLE = y
+	IIO_EXAMPLE = n
+
+IIO example
+^^^^^^^^^^^
+
+This project is actually a IIOD demo for EVAL-AD7960FMCZ evaluation board.
+The project launches a IIOD server on the board so that the user may connect
+to it via an IIO client.
+Using IIO-Oscilloscope, the user can configure the IMU and view the measured data on a plot.
+
+If you are not familiar with ADI IIO Application, please take a look at:
+`IIO No-OS <https://wiki.analog.com/resources/tools-software/no-os-software/iio>`_
+
+If you are not familiar with ADI IIO-Oscilloscope Client, please take a look at:
+`IIO Oscilloscope <https://wiki.analog.com/resources/tools-software/linux-software/iio_oscilloscope>`_
+
+The No-OS IIO Application together with the No-OS IIO AD796x driver take care of
+all the back-end logic needed to setup the IIO server.
+
+This example initializes the IIO device and calls the IIO app as shown in:
+`IIO Example <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ad796x_fmcz/src/examples/iio_example>`_
+
+In order to build the IIO project make sure you have the following configuration in the
+`Makefile <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ad796x_fmcz/Makefile>`_
+
+.. code-block:: bash
+
+        # Select the example you want to enable by choosing y for enabling and n for disabling
+        BASIC_EXAMPLE = n
+        IIO__EXAMPLE = y
+
+No-OS Supported Platforms
+-------------------------
+
+Xilinx platorm
+^^^^^^^^^^^^^^
+
+**Used hardware**
+
+* `eval-ad7960 <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-ad7960.html>`_
+* `Zedboard <https://www.analog.com/en/resources/reference-designs/powering-zynq-evaluation-development-board-zedboard.html>`_
+
+
+**Build Command**
+
+.. code-block:: bash
+
+        cp <SOME_PATH>/system_top.xsa .
+        # to delete current build
+        make reset
+        # to build the project
+        make
+        # to flash the code
+        make run

--- a/projects/ad796x_fmcz/builds.json
+++ b/projects/ad796x_fmcz/builds.json
@@ -1,0 +1,10 @@
+{
+  "xilinx": {
+    "iio": {
+      "flags": "IIO_EXAMPLE=y BASIC_EXAMPLE=n",
+      "hardware": [
+        "pulsar_lvds_adc_zed"
+      ]
+    }
+  }
+}

--- a/projects/ad796x_fmcz/src.mk
+++ b/projects/ad796x_fmcz/src.mk
@@ -1,0 +1,60 @@
+include $(PROJECT)/src/platform/$(PLATFORM)/platform_src.mk
+include $(PROJECT)/src/examples/examples_src.mk
+
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/main.c
+
+INCS += $(PROJECT)/src/common/common_data.h
+SRCS += $(PROJECT)/src/common/common_data.c
+
+INCS += $(PROJECT)/src/platform/platform_includes.h
+
+INCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.h
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.c
+
+SRCS += $(DRIVERS)/api/no_os_uart.c     \
+        $(NO-OS)/util/no_os_fifo.c      \
+        $(NO-OS)/util/no_os_list.c      \
+        $(NO-OS)/util/no_os_util.c      \
+        $(NO-OS)/util/no_os_alloc.c     \
+        $(NO-OS)/util/no_os_mutex.c     \
+        $(DRIVERS)/api/no_os_gpio.c	\
+	$(NO-OS)/util/no_os_util.c
+
+
+INCS += $(INCLUDE)/no_os_delay.h     \
+        $(INCLUDE)/no_os_error.h     \
+        $(INCLUDE)/no_os_fifo.h      \
+        $(INCLUDE)/no_os_irq.h       \
+        $(INCLUDE)/no_os_lf256fifo.h \
+        $(INCLUDE)/no_os_list.h      \
+        $(INCLUDE)/no_os_dma.h      \
+        $(INCLUDE)/no_os_timer.h     \
+        $(INCLUDE)/no_os_uart.h      \
+        $(INCLUDE)/no_os_util.h      \
+        $(INCLUDE)/no_os_alloc.h     \
+        $(INCLUDE)/no_os_mutex.h     \
+        $(INCLUDE)/no_os_pwm.h       \
+        $(INCLUDE)/no_os_print_log.h \
+        $(INCLUDE)/no_os_axi_io.h    \
+        $(INCLUDE)/no_os_gpio.h    \
+	$(INCLUDE)/no_os_print_log.h
+
+INCS +=	$(DRIVERS)/adc/ad796x/ad796x.h
+SRCS += $(DRIVERS)/adc/ad796x/ad796x.c
+
+INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h \
+	$(DRIVERS)/axi_core/axi_pwmgen/axi_pwm_extra.h \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.h\
+
+
+SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
+	$(DRIVERS)/axi_core/axi_pwmgen/axi_pwm.c \
+	$(DRIVERS)/axi_core/axi_dmac/axi_dmac.c \
+	$(DRIVERS)/api/no_os_pwm.c
+
+INCS += $(PLATFORM_DRIVERS)/xilinx_gpio.h
+SRCS +=	$(PLATFORM_DRIVERS)/xilinx_axi_io.c \
+	$(PLATFORM_DRIVERS)/xilinx_gpio.c \
+	$(PLATFORM_DRIVERS)/xilinx_delay.c

--- a/projects/ad796x_fmcz/src/common/common_data.c
+++ b/projects/ad796x_fmcz/src/common/common_data.c
@@ -1,0 +1,155 @@
+/***************************************************************************//**
+ *   @file   common_data.c
+ *   @brief  Defines common data to be used by iio examples.
+ *   @author Axel Haslam (ahaslam@baylibre.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "common_data.h"
+#include "no_os_gpio.h"
+#include "no_os_pwm.h"
+#include "ad796x.h"
+#include "axi_dmac.h"
+#include "clk_axi_clkgen.h"
+#include "axi_adc_core.h"
+#include "axi_pwm_extra.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+#ifdef IIO_EXAMPLE
+struct no_os_uart_init_param iio_uart_ip = {
+	.device_id = UART_DEVICE_ID,
+	.irq_id = UART_IRQ_ID,
+	.asynchronous_rx = true,
+	.baud_rate = UART_BAUDRATE,
+	.size = NO_OS_UART_CS_8,
+	.parity = NO_OS_UART_PAR_NO,
+	.stop = NO_OS_UART_STOP_1_BIT,
+	.extra = UART_EXTRA,
+	.platform_ops = UART_OPS,
+};
+#endif
+
+struct axi_adc_init ad796x_core_ip = {
+	.name = "ad796x_core",
+	.num_channels = 1,
+	.base = RX_CORE_BASEADDR
+};
+
+struct axi_clkgen_init clkgen_ip = {
+	.name = "rx_clkgen",
+	.base = RX_CLKGEN_BASEADDR,
+	.parent_rate = 100000000,
+};
+
+struct axi_dmac_init dmac_ip = {
+	.name = "ad796x_dmac",
+	.base = RX_DMA_BASEADDR,
+	.irq_option = IRQ_DISABLED
+};
+
+struct axi_pwm_init_param axi_pwm_0_extra = {
+	.base_addr = AXI_PWMGEN_BASEADDR,
+	.ref_clock_Hz = 125000000,
+	.channel = 0
+};
+
+struct no_os_pwm_init_param axi_pwm_0_ip = {
+	.period_ns = PWM_0_PERIOD_NS,
+	.duty_cycle_ns = PWM_0_DUTY_NS,
+	.phase_ns = PWM_0_PHASE,
+	.platform_ops = &axi_pwm_ops,
+	.extra = &axi_pwm_0_extra
+};
+
+struct axi_pwm_init_param axi_pwm_1_extra = {
+	.base_addr = AXI_PWMGEN_BASEADDR,
+	.ref_clock_Hz = 125000000,
+	.channel = 1
+};
+
+struct no_os_pwm_init_param axi_pwm_1_ip = {
+	.period_ns = PWM_1_PERIOD_NS,
+	.duty_cycle_ns = PWM_1_DUTY_NS,
+	.phase_ns = PWM_1_PHASE,
+	.platform_ops = &axi_pwm_ops,
+	.extra = &axi_pwm_1_extra
+};
+
+struct xil_gpio_init_param xil_gpio_init = {
+	.device_id = GPIO_DEVICE_ID,
+	.type = GPIO_PS
+};
+
+struct no_os_gpio_init_param gpio_adc_en3_fmc_ip = {
+	.number = GPIO_EN3_FMC,
+	.platform_ops = GPIO_OPS,
+	.extra = GPIO_EXTRA
+};
+
+struct no_os_gpio_init_param gpio_adc_en2_fmc_ip = {
+	.number = GPIO_EN2_FMC,
+	.platform_ops = GPIO_OPS,
+	.extra = GPIO_EXTRA
+};
+
+struct no_os_gpio_init_param gpio_adc_en1_fmc_ip = {
+	.number = GPIO_EN1_FMC,
+	.platform_ops = GPIO_OPS,
+	.extra = GPIO_EXTRA
+};
+
+struct no_os_gpio_init_param gpio_adc_en0_fmc_ip = {
+	.number = GPIO_EN0_FMC,
+	.platform_ops = GPIO_OPS,
+	.extra = GPIO_EXTRA
+};
+
+struct ad796x_init_param ad796x_init_param = {
+	.ad796x_core_ip = &ad796x_core_ip,
+	.clkgen_ip = &clkgen_ip,
+	.dmac_ip = &dmac_ip,
+	.axi_pwm_0_ip = &axi_pwm_0_ip,
+	.axi_pwm_1_ip = &axi_pwm_1_ip,
+	.gpio_ip[3] = &gpio_adc_en3_fmc_ip,
+	.gpio_ip[2] = &gpio_adc_en2_fmc_ip,
+	.gpio_ip[1] = &gpio_adc_en1_fmc_ip,
+	.gpio_ip[0] = &gpio_adc_en0_fmc_ip,
+	.mode = AD796X_MODE1_EXT_REF_5P0,
+};

--- a/projects/ad796x_fmcz/src/common/common_data.h
+++ b/projects/ad796x_fmcz/src/common/common_data.h
@@ -1,0 +1,60 @@
+/***************************************************************************//**
+ *   @file   ad796x_fmcz/src/common/common_data.h
+ *   @brief  Defines common data to be used by iio examples.
+ *   @author Axel Haslam (ahaslam@baylibre.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __COMMON_DATA_H__
+#define __COMMON_DATA_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "platform_includes.h"
+#include "no_os_util.h"
+#include "ad796x.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+#define SAMPLES_PER_CHANNEL     SAMPLES_PER_CHANNEL_PLATFORM
+extern struct no_os_uart_init_param iio_uart_ip;
+extern struct ad796x_init_param ad796x_init_param;
+
+#ifdef IIO_EXAMPLE
+extern struct no_os_uart_init_param iio_uart_ip;
+#endif
+
+#endif /* __COMMON_DATA_H__ */

--- a/projects/ad796x_fmcz/src/examples/basic_example/basic_example.c
+++ b/projects/ad796x_fmcz/src/examples/basic_example/basic_example.c
@@ -1,0 +1,84 @@
+/***************************************************************************//**
+ *   @file   basic_example.c
+ *   @brief  Implementation of BASIC example
+ *   @author Axel Haslam (ahaslam@baylibre.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "basic_example.h"
+#include "common_data.h"
+#include "ad796x.h"
+#include "no_os_print_log.h"
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+/***************************************************************************//**
+ * @brief BASIC example main execution.
+ *
+ * @return ret - Result of the example execution. If working correctly, will
+ *               execute continuously function basic_app_run and will not return.
+*******************************************************************************/
+int basic_example_main()
+{
+	uint32_t *buf = (uintptr_t)ADC_DDR_BASEADDR;
+	int i, ret;
+	struct ad796x_dev *adc_dev;
+
+	pr_info("init\n");
+
+	ret = ad796x_init(&adc_dev, &ad796x_init_param);
+	if (ret)
+		return ret;
+
+	pr_info("Capture start.\n");
+	ret = ad796x_read_data(adc_dev, buf, SAMPLES_PER_CHANNEL);
+	if (ret) {
+		pr_err("read data error %d\n", ret);
+		ad796x_remove(adc_dev);
+		return ret;
+	}
+
+	for (i = 0; i < SAMPLES_PER_CHANNEL; i++, buf++)
+		printf("CH1: %ld\n", *buf);
+
+	pr_info("\n Capture done.\n");
+
+	return ad796x_remove(adc_dev);
+}

--- a/projects/ad796x_fmcz/src/examples/basic_example/basic_example.h
+++ b/projects/ad796x_fmcz/src/examples/basic_example/basic_example.h
@@ -1,0 +1,47 @@
+/***************************************************************************//**
+ *   @file   basic_example.h
+ *   @brief  BASIC example header
+ *   @author Axel Haslam (ahaslam@baylibre.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __BASIC_EXAMPLE_H__
+#define __BASIC_EXAMPLE_H__
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+int basic_example_main();
+
+#endif /* __BASIC_EXAMPLE_H__ */

--- a/projects/ad796x_fmcz/src/examples/examples_src.mk
+++ b/projects/ad796x_fmcz/src/examples/examples_src.mk
@@ -1,0 +1,24 @@
+ifeq (y,$(strip $(IIO_EXAMPLE)))
+CFLAGS += -DIIO_EXAMPLE=1
+SRCS += $(PROJECT)/src/examples/iio_example/iio_example.c
+INCS += $(PROJECT)/src/examples/iio_example/iio_example.h
+
+SRCS += $(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.c
+INCS += $(DRIVERS)/axi_core/iio_axi_adc/iio_axi_adc.h
+
+IIOD=y
+SRC_DIRS += $(NO-OS)/iio/iio_app
+endif
+
+ifeq (y,$(strip $(BASIC_EXAMPLE)))
+CFLAGS += -DBASIC_EXAMPLE=1
+SRCS += $(PROJECT)/src/examples/basic_example/basic_example.c
+INCS += $(PROJECT)/src/examples/basic_example/basic_example.h
+endif
+
+INCS += $(DRIVERS)/adc/ad796x/ad796x.h
+
+SRCS += $(DRIVERS)/adc/ad796x/ad796x.c
+
+INCS += $(INCLUDE)/no_os_list.h \
+        $(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h

--- a/projects/ad796x_fmcz/src/examples/iio_example/iio_example.c
+++ b/projects/ad796x_fmcz/src/examples/iio_example/iio_example.c
@@ -1,0 +1,129 @@
+/***************************************************************************//**
+ *   @file   iio_example.c
+ *   @brief  Implementation of IIO example for iio project.
+ *   @author Axel Haslam (ahaslam@baylibre.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "iio_example.h"
+#include "common_data.h"
+#include "ad796x.h"
+#include "no_os_util.h"
+#include "iio_app.h"
+#include "iio_axi_adc.h"
+#include "no_os_print_log.h"
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+/***************************************************************************//**
+ * @brief IIO example main execution.
+ *
+ * @return ret - Result of the example execution. If working correctly, will
+ *               execute continuously function iio_app_run and will not return.
+*******************************************************************************/
+int iio_example_main()
+{
+	int ret;
+
+	struct ad796x_dev *adc_dev;
+	struct iio_app_desc *app;
+	struct iio_app_init_param app_init_param = { 0 };
+	struct iio_axi_adc_desc *iio_axi_adc_desc;
+	struct iio_device *dev_desc;
+	struct iio_data_buffer adc_buff = {
+		.buff = (void *)ADC_DDR_BASEADDR,
+		.size = MAX_SIZE_BASE_ADDR
+	};
+	struct scan_type init_scan_type = {
+		.sign = 's',
+		.realbits = 32,
+		.storagebits = 32,
+		.shift = 0,
+		.is_big_endian = false
+	};
+
+	ret = ad796x_init(&adc_dev, &ad796x_init_param);
+	if (ret) {
+		pr_err("Error: ad796x_init: %d\n", ret);
+		return ret;
+	}
+
+	struct iio_axi_adc_init_param iio_axi_adc_init_par = {
+		.rx_adc = adc_dev->ad796x_core,
+		.rx_dmac = adc_dev->axi_dmac,
+		.scan_type_common = &init_scan_type,
+		.dcache_invalidate_range = (void (*)(uint32_t,
+						     uint32_t))DCACHE_INVALIDATE,
+	};
+
+	ret = iio_axi_adc_init(&iio_axi_adc_desc, &iio_axi_adc_init_par);
+	if (ret) {
+		pr_err("Error: iio_axi_adc_init: %d\n", ret);
+		goto err_adc_init;
+	}
+
+	iio_axi_adc_get_dev_descriptor(iio_axi_adc_desc, &dev_desc);
+
+	struct iio_app_device devices[] = {
+		IIO_APP_DEVICE("ad796x", iio_axi_adc_desc,
+			       dev_desc, &adc_buff, NULL, NULL),
+	};
+
+	app_init_param.devices = devices;
+	app_init_param.nb_devices = NO_OS_ARRAY_SIZE(devices);
+	app_init_param.uart_init_params = iio_uart_ip;
+
+	ret = iio_app_init(&app, app_init_param);
+	if (ret) {
+		pr_err("Error: iio_app_init: %d\n", ret);
+		goto err_app_init;
+	}
+
+	ret = iio_app_run(app);
+	if (ret)
+		pr_err("iio_app_run error: %d\n", ret);
+
+	iio_app_remove(app);
+err_app_init:
+	iio_axi_adc_remove(iio_axi_adc_desc);
+err_adc_init:
+	ad796x_remove(adc_dev);
+	return ret;
+}

--- a/projects/ad796x_fmcz/src/examples/iio_example/iio_example.h
+++ b/projects/ad796x_fmcz/src/examples/iio_example/iio_example.h
@@ -1,0 +1,47 @@
+/***************************************************************************//**
+ *   @file   iio_example.h
+ *   @brief  IIO example header for iio project
+ *   @author Axel Haslam (ahaslam@baylibre.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __IIO_EXAMPLE_H__
+#define __IIO_EXAMPLE_H__
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+int iio_example_main();
+
+#endif /* __IIO_EXAMPLE_H__ */

--- a/projects/ad796x_fmcz/src/platform/platform_includes.h
+++ b/projects/ad796x_fmcz/src/platform/platform_includes.h
@@ -1,0 +1,53 @@
+/***************************************************************************//**
+ *   @file   platform_includes.h
+ *   @brief  Includes for used platforms used by iio project.
+ *   @author Axel Haslam (ahaslam@baylibre.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PLATFORM_INCLUDES_H__
+#define __PLATFORM_INCLUDES_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#if defined XILINX_PLATFORM
+#include "xilinx/parameters.h"
+#endif
+
+#ifdef IIO_SUPPORT
+#include "iio_app.h"
+#endif
+
+#endif /* __PLATFORM_INCLUDES_H__ */

--- a/projects/ad796x_fmcz/src/platform/xilinx/main.c
+++ b/projects/ad796x_fmcz/src/platform/xilinx/main.c
@@ -1,0 +1,74 @@
+/***************************************************************************//**
+ *   @file   main.c
+ *   @brief  Main file for xilinx platform of iio project.
+ *   @author Axel Haslam (ahaslam@baylibre.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "platform_includes.h"
+#include "common_data.h"
+#include "no_os_error.h"
+
+#ifdef IIO_EXAMPLE
+#include "iio_example.h"
+#elif BASIC_EXAMPLE
+#include "basic_example.h"
+#endif
+
+/***************************************************************************//**
+ * @brief Main function execution for xilinx platform.
+ *
+ * @return ret - Result of the enabled examples execution.
+*******************************************************************************/
+int main()
+{
+	int ret = -EINVAL;
+
+	/* Enable the instruction cache. */
+	Xil_ICacheEnable();
+	/* Enable the data cache. */
+	Xil_DCacheEnable();
+#ifdef IIO_EXAMPLE
+	ret = iio_example_main();
+#elif BASIC_EXAMPLE
+	ret = basic_example_main();
+#else
+#error At least one example has to be selected using y value in Makefile.
+#endif
+	return ret;
+}

--- a/projects/ad796x_fmcz/src/platform/xilinx/parameters.c
+++ b/projects/ad796x_fmcz/src/platform/xilinx/parameters.c
@@ -1,0 +1,52 @@
+/***************************************************************************//**
+ *   @file   parameters.c
+ *   @brief  Definition of xilinx platform data used by iio project.
+ *   @author Axel Haslam (ahaslam@baylibre.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "parameters.h"
+
+struct xil_uart_init_param iio_uart_extra_ip = {
+#ifdef XPAR_XUARTLITE_NUM_INSTANCES
+	.type = UART_PL,
+#else
+	.type = UART_PS,
+	.irq_id = UART_IRQ_ID
+#endif
+};

--- a/projects/ad796x_fmcz/src/platform/xilinx/parameters.h
+++ b/projects/ad796x_fmcz/src/platform/xilinx/parameters.h
@@ -1,0 +1,111 @@
+/***************************************************************************//**
+ *   @file   parameters.h
+ *   @brief  Definitions specific to xilinx platform used by iio
+ *           project.
+ *   @author Axel Haslam (ahaslam@baylibre.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <xparameters.h>
+#include <xil_cache.h>
+#include <xilinx_uart.h>
+#include "xilinx_gpio.h"
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+#ifdef _XPARAMETERS_PS_H_
+#define UART_DEVICE_ID		XPAR_XUARTPS_0_DEVICE_ID
+#define INTC_DEVICE_ID		XPAR_SCUGIC_SINGLE_DEVICE_ID
+
+#ifdef XPS_BOARD_ZCU102
+#define UART_IRQ_ID		XPAR_XUARTPS_0_INTR
+#else
+#define UART_IRQ_ID		XPAR_XUARTPS_1_INTR
+#endif
+
+#else // _XPARAMETERS_PS_H_
+#define UART_DEVICE_ID		XPAR_AXI_UART_DEVICE_ID
+#define INTC_DEVICE_ID		XPAR_INTC_SINGLE_DEVICE_ID
+#define UART_IRQ_ID		XPAR_AXI_INTC_AXI_UART_INTERRUPT_INTR
+#endif // _XPARAMETERS_PS_H_
+
+#define UART_EXTRA		&iio_uart_extra_ip
+#define UART_OPS		&xil_uart_ops
+
+extern struct xil_uart_init_param iio_uart_extra_ip;
+
+#define RX_CORE_BASEADDR	XPAR_AXI_PULSAR_LVDS_BASEADDR
+#define RX_DMA_BASEADDR		XPAR_AXI_PULSAR_LVDS_DMA_BASEADDR
+#define RX_CLKGEN_BASEADDR	XPAR_REFERENCE_CLKGEN_BASEADDR
+#define AXI_PWMGEN_BASEADDR	XPAR_AXI_PWM_GEN_BASEADDR
+#define ADC_DDR_BASEADDR	XPAR_DDR_MEM_BASEADDR + 0x800000
+
+#define GPIO_DEVICE_ID		XPAR_PS7_GPIO_0_DEVICE_ID
+#define GPIO_OFFSET		32 + 54
+
+#define GPIO_EN0_FMC		GPIO_OFFSET
+#define GPIO_EN1_FMC		GPIO_OFFSET+1
+#define GPIO_EN2_FMC		GPIO_OFFSET+2
+#define GPIO_EN3_FMC		GPIO_OFFSET+3
+
+/* This value can be modified based on the number
+of samples needed to be stored in the device buffer
+and based on the available RAM memory of the platform */
+#define SAMPLES_PER_CHANNEL_PLATFORM	20000
+#define MAX_SIZE_BASE_ADDR		(SAMPLES_PER_CHANNEL_PLATFORM * 4)
+
+#define UART_BAUDRATE		115200
+
+extern struct axi_pwm_init_param axi_pwm_0_extra;
+#define PWM_0_PERIOD_NS		200
+#define PWM_0_DUTY_NS		16
+#define PWM_0_PHASE		0
+
+#define PWM_1_PERIOD_NS		200
+#define PWM_1_DUTY_NS		144
+#define PWM_1_PHASE		0
+
+#define GPIO_OPS		&xil_gpio_ops
+#define GPIO_EXTRA		&xil_gpio_init
+
+#define DCACHE_INVALIDATE	Xil_DCacheInvalidateRange
+
+#endif /* __PARAMETERS_H__ */
+

--- a/projects/ad796x_fmcz/src/platform/xilinx/platform_src.mk
+++ b/projects/ad796x_fmcz/src/platform/xilinx/platform_src.mk
@@ -1,0 +1,25 @@
+SRCS += $(PLATFORM_DRIVERS)/$(PLATFORM)_delay.c \
+	$(DRIVERS)/api/no_os_irq.c \
+	$(DRIVERS)/api/no_os_timer.c
+	
+ifeq (y,$(strip $(NETWORKING)))
+DISABLE_SECURE_SOCKET ?= y
+SRC_DIRS += $(NO-OS)/network
+endif
+
+SRCS += $(NO-OS)/util/no_os_circular_buffer.c \
+	$(PLATFORM_DRIVERS)/xilinx_timer.c
+
+INCS += $(INCLUDE)/no_os_circular_buffer.h \
+	$(INCLUDE)/no_os_timer.h           \
+	$(PLATFORM_DRIVERS)/xilinx_timer.h  \
+	$(PLATFORM_DRIVERS)/rtc_extra.h
+
+SRCS += $(NO-OS)/util/no_os_lf256fifo.c  \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.c \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.c
+
+INCS += $(INCLUDE)/no_os_rtc.h          \
+	$(INCLUDE)/no_os_gpio.h         \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_irq.h \
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h


### PR DESCRIPTION
This adds driver files and a project test the ad796x series of pulsar Differential ADC.

The HDL for this project is still not merged, and probably its why CI is failing.
perhaps review can start without the HDL 

this was tested using the HDL binary at https://github.com/adi-ses/sea-misc/tree/main/AD796x-PRJ

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
