### PR TITLE
Add support for AXI PWM Generator v2

### DIFF
--- a/drivers/axi_core/axi_pwmgen/axi_pwm_extra.h
+++ b/drivers/axi_core/axi_pwmgen/axi_pwm_extra.h
@@ -75,6 +75,8 @@ struct axi_pwm_desc {
 	uint32_t channel;
 	/** Used to store the period when the channel is disabled */
 	uint32_t ch_period;
+	/** Hardware version necessary for checking for the right register offsets  */
+	uint32_t hw_major_ver;
 };
 
 /**


### PR DESCRIPTION
## Pull Request Description

This introduces support for the AXI PWM Gen. IP Core v2, which has been released in the HDL repository. It includes a runtime check within the driver to ensure compatibility with v1.  This does not affect the existing projects.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
