### PR TITLE
madura: adrv9025.c: Specify correct clks ops

### DIFF
--- a/drivers/rf-transceiver/madura/adrv9025.c
+++ b/drivers/rf-transceiver/madura/adrv9025.c
@@ -945,25 +945,24 @@ static int32_t adrv9025_bb_recalc_rate(struct no_os_clk_desc *desc,
 				       uint64_t *rate)
 {
 	struct adrv9025_rf_phy *adrv9025_dev;
-	uint64_t read_rate = 0;
-	int ret;
 
 	adrv9025_dev = desc->dev_desc;
 
-	ret = no_os_clk_recalc_rate(adrv9025_dev->dev_clk, &read_rate);
-	if (!ret)
-		*rate = read_rate;
+	if (!strcmp(desc->name, "-rx_sampl_clk"))
+		*rate = adrv9025_dev->rx_iqRate_kHz * 1000;
+	else if (!strcmp(desc->name, "-tx_sampl_clk"))
+		*rate = adrv9025_dev->tx_iqRate_kHz * 1000;
+	else
+		return -EINVAL;
 
-	return ret;
+	return 0;
 }
 
 static int32_t adrv9025_bb_set_rate(struct no_os_clk_desc *desc,
 				    uint64_t rate)
 {
-	struct adrv9025_rf_phy *adrv9025_dev;
-	adrv9025_dev = desc->dev_desc;
-
-	return no_os_clk_set_rate(adrv9025_dev->dev_clk, rate);
+	// Do nothing
+	return 0;
 }
 
 static int32_t adrv9025_bb_round_rate(struct no_os_clk_desc *desc,


### PR DESCRIPTION
The phy->clks ops allow for just the redaing of the rx_iqRate_kHz and tx_iqRate_kHz members of adrv9025_rf_phy.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
