### PR TITLE
madura: adrv9025_conv.c: Set tx_dac clock value

### DIFF
--- a/drivers/rf-transceiver/madura/adrv9025_conv.c
+++ b/drivers/rf-transceiver/madura/adrv9025_conv.c
@@ -8,6 +8,8 @@
 
 #include "no_os_print_log.h"
 #include "axi_adc_core.h"
+#include "axi_dac_core.h"
+#include "no_os_delay.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
 #include "adrv9025.h"
@@ -40,6 +42,9 @@ int adrv9025_hdl_loopback(struct adrv9025_rf_phy *phy, bool enable)
 int adrv9025_post_setup(struct adrv9025_rf_phy *phy)
 {
 	unsigned tmp, num_chan;
+	uint64_t clock_hz;
+	uint32_t ratio;
+	uint32_t freq;
 	int i;
 
 	num_chan = 8;
@@ -60,6 +65,13 @@ int adrv9025_post_setup(struct adrv9025_rf_phy *phy)
 			      AXI_ADC_FORMAT_SIGNEXT | AXI_ADC_FORMAT_ENABLE |
 			      AXI_ADC_ENABLE | AXI_ADC_IQCOR_ENB);
 	}
+
+	no_os_mdelay(100);
+	axi_adc_read(phy->rx_adc, 0x4054, &freq);
+	axi_adc_read(phy->rx_adc, 0x4058, &ratio);
+	clock_hz = freq * ratio;
+	clock_hz = (clock_hz * 390625) >> 8;
+	phy->tx_dac->clock_hz = clock_hz;
 
 	return 0;
 }


### PR DESCRIPTION
## Pull Request Description

Set the clock_hz value for the tx_dac structure.

Fixes: 9a11234 ("drivers: rf-transceiver: madura: Add driver")

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
