### PR TITLE
drivers:platform:stm32:Fixes to PWM driver

### DIFF
--- a/drivers/platform/stm32/stm32_pwm.c
+++ b/drivers/platform/stm32/stm32_pwm.c
@@ -308,7 +308,17 @@ static int32_t stm32_init_pwm(struct stm32_pwm_desc *desc,
 
 	sConfigOC.OCMode = ocmode;
 	sConfigOC.Pulse = pwm_pulse_width;
-	sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
+	switch (param->polarity) {
+	case NO_OS_PWM_POLARITY_HIGH:
+		sConfigOC.OCPolarity = TIM_OCPOLARITY_HIGH;
+		break;
+	case NO_OS_PWM_POLARITY_LOW:
+		sConfigOC.OCPolarity = TIM_OCPOLARITY_LOW;
+		break;
+	default:
+		return -EINVAL;
+	};
+
 	sConfigOC.OCFastMode = TIM_OCFAST_DISABLE;
 	sConfigOC.OCIdleState = TIM_OCIDLESTATE_RESET;
 	sConfigOC.OCNIdleState = TIM_OCNIDLESTATE_RESET;


### PR DESCRIPTION
The PWM polarity was being hardcoded to TIM_OCPOLARITY_HIGH, despite there being a no-OS structure member for polarity

Fixes: 9264d89 ("stm32 pwm support")

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
