### PR TITLE
adrv9009: headless.c: Set DMA data type for DAC DMA example

### DIFF
--- a/projects/adrv9009/src/app/headless.c
+++ b/projects/adrv9009/src/app/headless.c
@@ -414,6 +414,7 @@ int main(void)
 	no_os_gpio_direction_output(gpio_plddrbypass, 1);
 
 #ifndef ADRV9008_1
+	axi_dac_set_datasel(tx_dac, -1, AXI_DAC_DATA_SEL_DMA);
 	axi_dac_load_custom_data(tx_dac, sine_lut_iq,
 				 NO_OS_ARRAY_SIZE(sine_lut_iq),
 				 DAC_DDR_BASEADDR);


### PR DESCRIPTION
## Pull Request Description

Set DMA data type for DAC in the case of DMA example.

Fixes: f9992d9 ("projects: adrv9009: Add an example for using DAC DMA")

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
