### PR TITLE
power: ltc4296: add driver & appplication

### DIFF
--- a/doc/sphinx/source/drivers/ltc4296.rst
+++ b/doc/sphinx/source/drivers/ltc4296.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../drivers/power/ltc4296/README.rst

--- a/doc/sphinx/source/drivers_doc.rst
+++ b/doc/sphinx/source/drivers_doc.rst
@@ -64,3 +64,4 @@ POWER MANAGEMENT
    :maxdepth: 1
 
    drivers/adp1050
+   drivers/ltc4296

--- a/doc/sphinx/source/projects/ltc4296.rst
+++ b/doc/sphinx/source/projects/ltc4296.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../projects/ltc4296/README.rst

--- a/doc/sphinx/source/projects_doc.rst
+++ b/doc/sphinx/source/projects_doc.rst
@@ -63,6 +63,7 @@ POWER MANAGEMENT
    :maxdepth: 1
 
    projects/adp1050
+   projects/ltc4296
 
 DAC
 ===

--- a/drivers/power/ltc4296/README.rst
+++ b/drivers/power/ltc4296/README.rst
@@ -1,0 +1,105 @@
+LTC4296 no-OS driver
+====================
+
+Supported Devices
+-----------------
+
+`LTC4296-1 <www.analog.com/en/products/ltc4296-1.html>`_
+
+Overview
+--------
+
+The `LTC4296-1 <www.analog.com/en/products/ltc4296-1.html>`_ is an IEEE
+802.3cg-compliant, five port, single-pair power over Ethernet (SPoE), power
+sourcing equipment (PSE) controller. SPoE simplifies system design and
+installation with standardized power and Ethernet data over a single-pair cable.
+The LTC4296-1 is designed for interoperability with 802.3cg powered devices
+(PDs) in 24 V or 54 V systems. The LTC4296-1 delivers power using external, low
+drain-to-source on resistance (RDS(ON)), N-channel metal-oxide semiconductor
+field-effect transistors (MOS-FETs), which minimize voltage drop and ensure
+application ruggedness.
+High-side circuit breakers with foldback, analog current limit (ACL) provide
+controlled inrush and short-circuit protection. An optional low-side circuit
+breaker protects the negative output against backfeed faults, and ground faults
+in nonisolated applications. PD classification via the serial communication
+classification protocol (SCCP)and maintain full voltage signature (MFVS) ensure
+full operating voltage is only applied to the cable when a PD is present. The
+SWx pins disconnect port power snubbers during detection and classification.
+PD initiated sleep and wake-up are supported. The WAKEUP pin supports wake-up
+forwarding. Telemetry, status, and software control features are accessed via a
+serial peripheral interface (SPI) bus interface with packet error code (PEC)
+protection.
+
+Applications
+------------
+
+* Operational technology (OT) systems
+* Building and factory automation systems
+* Field instruments and switches
+* Security systems
+* Traffic control systems
+
+LTC4296 Device Configuration
+----------------------------
+
+Driver Initialization
+---------------------
+
+In order to be able to use the device, you will have to provide the support for
+the communication protocol (SPI).
+
+The first API to be called is **ltc4296_init**. Make sure that it returns 0,
+which means that the driver was initialized correctly. This function will also
+reset the LTC4296 by performing a soft reset, putting the device in a known
+state. 
+
+
+LTC4296 Driver Initialization Example
+-------------------------------------
+
+SPI Communication Example
+-------------------------
+
+.. code-block:: bash
+
+	struct ltc4296_dev *dev;
+	int ret;
+
+	struct no_os_uart_init_param ltc4296_uart_ip = {
+		.device_id = UART_DEVICE_ID,
+		.baud_rate = UART_BAUDRATE,
+		.size = NO_OS_UART_CS_8,
+		.parity = NO_OS_UART_PAR_NO,
+		.stop = NO_OS_UART_STOP_1_BIT,
+		.platform_ops = UART_OPS,
+		.extra = UART_EXTRA,
+	};
+
+	struct no_os_spi_init_param ltc4296_spi_ip = {
+		.device_id = SPI_DEVICE_ID,
+		.max_speed_hz = SPI_BAUDRATE,
+		.bit_order = NO_OS_SPI_BIT_ORDER_MSB_FIRST,
+		.mode = NO_OS_SPI_MODE_0,
+		.platform_ops = SPI_OPS,
+		.chip_select = SPI_CS,
+		.extra = SPI_EXTRA,
+	};
+
+	struct ltc4296_init_param ltc4296_ip = {
+		.spi_init = &ltc4296_spi_ip,
+	};
+
+	ret = ltc4296_init(&ltc4296_desc, &ltc4296_ip);
+	if (ret) {
+		pr_info("Initialization error!\n");
+		return ret;
+	}
+
+	ret = ltc4296_port_prebias(ltc4296_desc, LTC_PORT0, LTC_CFG_APL_MODE);
+	if (ret) {
+		goto err;
+	}
+
+	ret = ltc4296_port_en(ltc4296_desc, LTC_PORT0);
+	if (ret)
+		goto err;

--- a/drivers/power/ltc4296/ltc4296.c
+++ b/drivers/power/ltc4296/ltc4296.c
@@ -1,0 +1,1098 @@
+/***************************************************************************//**
+ *   @file   ltc4296.c
+ *   @brief  Implementation file for the LTC4296 Driver
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdio.h>
+#include <errno.h>
+#include "ltc4296.h"
+#include "no_os_alloc.h"
+#include "no_os_delay.h"
+#include "no_os_print_log.h"
+#include "no_os_util.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+/* LTC4296_1_IGAIN / Rsense[port_no]
+ * {(0.1/3), (0.1/1.5), (0.1/0.68), (0.1/0.25), (0.1/0.1)} */
+static const int ltc4296_spoe_rsense[LTC4296_MAX_PORTS] = {333, 666, 1470, 4000, 10000};
+
+/* Value of RSense resistor for each port in mOhm */
+static const int ltc4296_spoe_sense_resistor[LTC4296_MAX_PORTS] = {3000, 1500, 680, 250, 100};
+
+int ltc4296_spoe_vol_range_mv[12][2] = { {20000,30000},  /* SPoE Class 10         */
+	{20000,30000},  /* SPoE Class 11         */
+	{20000,30000},  /* SPoE Class 12         */
+	{50000,58000},  /* SPoE Class 13         */
+	{50000,58000},  /* SPoE Class 14         */
+	{50000,58000},  /* SPoE Class 15         */
+	{9600,15000},   /* APL Class A           */
+	{9600,15000},   /* APL Class A noAutoNeg */
+	{9600,15000},   /* APL Class C           */
+	{46000,50000},  /* APL Class 3           */
+	{9600,15000},   /* Production Power Test */
+	{9600,15000}    /* APL Class A oldAPL    */
+};
+
+/* Stirng to print the different classes of LTC4296-1  */
+char* ltc4296_class_str[12][25] = { {"SPOE CLASS 10"},
+	{"SPOE CLASS 11"},
+	{"SPOE CLASS 12"},
+	{"SPOE CLASS 13"},
+	{"SPOE CLASS 14"},
+	{"SPOE CLASS 15"},
+	{"APL CLASS A"},
+	{"APL CLASS A"}, /* No Autoneg */
+	{"APL CLASS C"},
+	{"APL CLASS 3"},
+	{"BOARD PRODUCTION TEST"},
+	{"APL CLASS A"} /* OLD Demo */
+};
+
+static uint8_t set_port_vout[LTC4296_MAX_PORTS] = {0x04, 0x06, 0x08, 0x0A, 0x0C};
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+
+/**
+ * @brief Compute the PEC.
+ * @param data - The input data
+ * @param seed - The seed.
+ * @return the packet error code.
+ */
+static uint8_t ltc4296_get_pec_byte(uint8_t data, uint8_t seed)
+{
+	uint8_t pec = seed;
+	uint8_t din, in0, in1, in2;
+	int bit;
+	for (bit = 7; bit >= 0; bit--) {
+		din = (data >> bit) & 0x01;
+		in0 = din ^ ( (pec >> 7) & 0x01 );
+		in1 = in0 ^ ( pec & 0x01);
+		in2 = in0 ^ ( (pec >> 1) & 0x01 );
+		pec = (pec << 1);
+		pec &= ~(0x07);
+		pec = pec | in0 | (in1 << 1) | (in2 << 2);
+	}
+
+	return pec;
+}
+
+/**
+ * @brief Register Read
+ * @param dev - The device structure
+ * @param reg - The register value
+ * @param data - The data read from the device.
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_reg_read(struct ltc4296_dev *dev, uint8_t reg, uint16_t *data)
+{
+	int ret;
+	uint8_t r_buf[5] = {0};
+
+	if (!dev || !data)
+		return -EINVAL;
+
+	r_buf[0] = reg << 1 | LTC4296_SPI_READ;
+	r_buf[1] = ltc4296_get_pec_byte(r_buf[0], 0x41);
+
+	ret = no_os_spi_write_and_read(dev->spi_desc, r_buf, 5);
+	if (ret)
+		return ret;
+
+	*data = no_os_get_unaligned_be16(&r_buf[2]);
+
+	return 0;
+}
+
+/**
+ * @brief Register Write
+ * @param dev - The device structure
+ * @param reg - The register value
+ * @param data - The data written to the device
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_reg_write(struct ltc4296_dev *dev, uint8_t reg, uint16_t data)
+{
+	uint8_t w_buf[5] = {0};
+
+	if (!dev)
+		return -EINVAL;
+
+	w_buf[0] = reg << 1 | LTC4296_SPI_WRITE;
+	w_buf[1] = ltc4296_get_pec_byte(w_buf[0], 0x41);
+	no_os_put_unaligned_be16(data, &w_buf[2]);
+	w_buf[4] = ltc4296_get_pec_byte(w_buf[3], ltc4296_get_pec_byte(w_buf[2], 0x41));
+
+	return no_os_spi_write_and_read(dev->spi_desc, w_buf, 5);
+}
+
+/**
+ * @brief Software reset
+ * @param dev - The device structure
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_reset(struct ltc4296_dev *dev)
+{
+	int ret;
+
+	if (!dev)
+		return -EINVAL;
+
+	ret = ltc4296_reg_write(dev, LTC4296_REG_GCMD,
+				no_os_field_prep(LTC4296_SW_RESET_MSK, LTC4296_RESET_CODE));
+	if (ret)
+		return ret;
+
+	/* Delay required after performing a software reset */
+	no_os_mdelay(1);
+
+	return 0;
+}
+
+/**
+ * @brief Get port address
+ * @param port_no - The port number
+ * @param port_offset - The port offset
+ * @param port_addr - The port address
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_get_port_addr(enum ltc4296_port port_no,
+			  enum ltc4296_port_reg_offset_e port_offset,
+			  uint8_t *port_addr)
+{
+	if (!port_addr)
+		return -EINVAL;
+
+	*port_addr = (((port_no + 1) << 4) + port_offset);
+
+	return 0;
+}
+
+/**
+ * @brief Clear global faults
+ * @param dev - The device structure
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_clear_global_faults(struct ltc4296_dev *dev)
+{
+	if (!dev)
+		return -EINVAL;
+
+	/* GFLTEV = clear all faults
+	 * LTC4296_LOW_CKT_BRK_FAULT | LTC4296_MEMORY_FAULT |
+	 * LTC4296_PEC_FAULT | LTC4296_COMMAND_FAULT | LTC4296_UVLO_DIGITAL */
+	return ltc4296_reg_write(dev, LTC4296_REG_GFLTEV, 0x001F);
+}
+
+/**
+ * @brief Clear circuit break faults
+ * @param dev - The device structure
+ * @return 0 in case of success, negative code otherwise
+ */
+int  ltc4296_clear_ckt_breaker(struct ltc4296_dev *dev)
+{
+	int ret;
+	uint16_t val = 0;
+
+	if (!dev)
+		return -EINVAL;
+
+	ret = ltc4296_reg_read(dev, LTC4296_REG_GFLTEV, &val);
+	if (ret)
+		return ret;
+
+	val = val | LTC4296_LOW_CKT_BRK_FAULT_MSK;
+
+	/* GFLTEV = clear LTC4296_LOW_CKT_BRK_FAULT by writing 1 to the bit*/
+	return ltc4296_reg_write(dev, LTC4296_REG_GFLTEV, val);
+}
+
+/**
+ * @brief Read global faults
+ * @param dev - The device structure
+ * @param g_events - The global events data read
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_read_global_faults(struct ltc4296_dev *dev, uint16_t *g_events)
+{
+	if (!dev)
+		return -EINVAL;
+
+	/* GFLTEV = clear all faults
+	 * LTC4296_LOW_CKT_BRK_FAULT | LTC4296_MEMORY_FAULT |
+	 * LTC4296_PEC_FAULT | LTC4296_COMMAND_FAULT | LTC4296_UVLO_DIGITAL */
+	return ltc4296_reg_read(dev, LTC4296_REG_GFLTEV, g_events);
+}
+
+/**
+ * @brief Device unlock
+ * @param dev - The device structure
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_unlock(struct ltc4296_dev *dev)
+{
+	if (!dev)
+		return -EINVAL;
+
+	return ltc4296_reg_write(dev, LTC4296_REG_GCMD,
+				 LTC4296_UNLOCK_KEY);/*GCMD = unlock_key,*/
+}
+
+/**
+ * @brief Check device state
+ * @param dev - The device structure
+ * @param state - The state of the device
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_is_locked(struct ltc4296_dev *dev, enum ltc4296_state *state)
+{
+	uint16_t val16;
+	int ret;
+
+	if (!dev || !state)
+		return -EINVAL;
+
+	ret = ltc4296_reg_read(dev, LTC4296_REG_GCMD, &val16);
+	if (ret)
+		return ret;
+
+	if ((val16 & LTC4296_UNLOCK_KEY) == LTC4296_UNLOCK_KEY)
+		*state = LTC_UNLOCKED;
+	else
+		*state = LTC_LOCKED;
+
+	return 0;
+}
+
+/**
+ * @brief Read global ADC
+ * @param dev - The device structure
+ * @param port_voltage_mv - The port voltage in mV
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_read_gadc(struct ltc4296_dev *dev, int *port_voltage_mv)
+{
+	int ret;
+	uint16_t val16;
+
+	if (!dev || !port_voltage_mv)
+		return -EINVAL;
+
+	ret = ltc4296_reg_read(dev, LTC4296_REG_GADCDAT, &val16);
+	if (ret)
+		return ret;
+	if ((val16 & LTC4296_GADC_NEW_MSK) != LTC4296_GADC_NEW_MSK)
+		return ADI_LTC_INVALID_ADC_VOLTAGE;
+
+	/* A new ADC value is available */
+	*port_voltage_mv = (((val16 & LTC4296_GADC_MSK) - LTC4296_ADC_OFFSET) *
+			    LTC4296_VGAIN);
+
+	return 0;
+}
+
+/**
+ * @brief Set the global ADC to measure voltage
+ * @param dev - The device structure
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_set_gadc_vin(struct ltc4296_dev *dev)
+{
+	int ret;
+
+	if (!dev)
+		return -EINVAL;
+
+	/* LTC4296-1 Set global ADC to measure Vin
+	GADCCFG = ContModeLowGain | Vin */
+	ret = ltc4296_reg_write(dev, LTC4296_REG_GADCCFG, 0x0041);
+	if (ret)
+		return ret;
+
+	no_os_mdelay(4); /* Delay of 4ms*/
+
+	return 0;
+}
+
+/**
+ * @brief Check if input voltage is valid.
+ * @param dev - The device structure
+ * @param port_vin_mv - The input voltage in mV
+ * @param ltcboard_class - The board class
+ * @param vin_valid - Valid input voltage
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_is_vin_valid(struct ltc4296_dev *dev, int port_vin_mv,
+			 enum ltc4296_board_class ltcboard_class, bool *vin_valid)
+{
+	if (!dev || !vin_valid)
+		return -EINVAL;
+
+	if ((port_vin_mv <= ltc4296_spoe_vol_range_mv[ltcboard_class][LTC4296_VMAX])
+	    && (port_vin_mv >= ltc4296_spoe_vol_range_mv[ltcboard_class][LTC4296_VMIN]) ) {
+		*vin_valid = true;
+	} else {
+		/* Voltage is out of range of the MIN/MAX value*/
+		*vin_valid = false;
+	}
+	return 0;
+}
+
+/**
+ * @brief Check if output voltage is valid.
+ * @param dev - The device structure
+ * @param port_vout_mv - The output voltage in mV
+ * @param ltcboard_class - The board class
+ * @param vout_valid - Valid input voltage
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_is_vout_valid(struct ltc4296_dev *dev, int port_vout_mv,
+			  enum ltc4296_board_class ltcboard_class, bool *vout_valid)
+{
+	if (!dev || !vout_valid)
+		return -EINVAL;
+
+	if ((port_vout_mv <= ltc4296_spoe_vol_range_mv[ltcboard_class][LTC4296_VMAX])
+	    && (port_vout_mv >= ltc4296_spoe_vol_range_mv[ltcboard_class][LTC4296_VMIN]) ) {
+		*vout_valid =  true;
+	} else {
+		/* Voltage is out of range of the MIN/MAX value*/
+		*vout_valid = false;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Disable the global ADC.
+ * @param dev - The device structure
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_disable_gadc(struct ltc4296_dev *dev)
+{
+	int ret;
+
+	if (!dev)
+		return -EINVAL;
+
+	ret = ltc4296_reg_write(dev, LTC4296_REG_GADCCFG, 0x0000);
+	if (ret)
+		return ret;
+
+	no_os_mdelay(4); /* Delay of 4ms*/
+
+	return 0;
+}
+
+/**
+ * @brief Read Port Events.
+ * @param dev - The device structure
+ * @param port_no - The port number
+ * @param port_events - The port events read
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_read_port_events(struct ltc4296_dev *dev, enum ltc4296_port port_no,
+			     uint16_t *port_events)
+{
+	int ret;
+	uint8_t port_addr = 0;
+
+	if (!dev || !port_events)
+		return -EINVAL;
+
+	ret = ltc4296_get_port_addr(port_no, LTC_PORT_EVENTS, &port_addr);
+	if (ret)
+		return ret;
+
+	return ltc4296_reg_read(dev, port_addr, port_events);
+}
+
+/**
+ * @brief Clear Port Events.
+ * @param dev - The device structure
+ * @param port_no - The port number
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_clear_port_events(struct ltc4296_dev *dev,
+			      enum ltc4296_port port_no)
+{
+	int ret;
+	uint8_t port_addr = 0;
+
+	if (!dev)
+		return -EINVAL;
+
+	ret = ltc4296_get_port_addr(port_no, LTC_PORT_EVENTS, &port_addr);
+	if (ret)
+		return ret;
+
+	return ltc4296_reg_write(dev, port_addr, 0x3FF);
+}
+
+/**
+ * @brief Read Port Status.
+ * @param dev - The device structure
+ * @param port_no - The port number
+ * @param port_status - The port status
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_read_port_status(struct ltc4296_dev *dev, enum ltc4296_port port_no,
+			     uint16_t *port_status)
+{
+	int ret;
+	uint8_t port_addr = 0;
+
+	if (!dev || !port_status)
+		return -EINVAL;
+
+	ret = ltc4296_get_port_addr(port_no, LTC_PORT_STATUS, &port_addr);
+	if (ret)
+		return ret;
+
+	return ltc4296_reg_read(dev, port_addr, port_status);
+}
+
+/**
+ * @brief Check if port is enabled/disabled
+ * @param dev - The device structure
+ * @param port_no - The port number
+ * @param port_chk - The port is enabled/disabled
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_is_port_disabled(struct ltc4296_dev *dev, enum ltc4296_port port_no,
+			     enum ltc4296_port_status *port_chk)
+{
+	int ret;
+	uint16_t port_status = 0;
+	uint8_t port_addr = 0;
+
+	if (!dev || !port_chk)
+		return -EINVAL;
+
+	ret = ltc4296_get_port_addr(port_no, LTC_PORT_STATUS, &port_addr);
+	if (ret)
+		return ret;
+
+	ret = ltc4296_reg_read(dev, port_addr, &port_status);
+	if (ret)
+		return ret;
+
+	if ((port_status & LTC4296_PSE_STATUS_MSK) == LTC_PSE_STATUS_DISABLED) {
+		*port_chk = LTC_PORT_DISABLED;
+	} else {
+		*port_chk = LTC_PORT_ENABLED;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Check if port is disabled
+ * @param dev - The device structure
+ * @param port_no - The port number
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_port_disable(struct ltc4296_dev *dev, enum ltc4296_port port_no)
+{
+	int ret;
+	uint8_t port_addr = 0;
+
+	if (!dev)
+		return -EINVAL;
+
+	ret = ltc4296_get_port_addr(port_no, LTC_PORT_CFG0, &port_addr);
+	if (ret)
+		return ret;
+	/* Write 0 to disable port*/
+	return ltc4296_reg_write(dev, port_addr, 0x0000);
+}
+
+/**
+ * @brief Check if port delivers power
+ * @param dev - The device structure
+ * @param port_no - The port number
+ * @param pwr_status - The PSE Status of the port
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_is_port_deliver_pwr(struct ltc4296_dev *dev,
+				enum ltc4296_port port_no,
+				enum ltc4296_pse_status *pwr_status)
+{
+	int ret;
+	uint16_t port_status;
+	uint8_t port_addr = 0;
+
+	if (!dev || !pwr_status)
+		return -EINVAL;
+
+	ret = ltc4296_get_port_addr(port_no, LTC_PORT_STATUS, &port_addr);
+	if (ret)
+		return ret;
+
+	ret = ltc4296_reg_read(dev, port_addr, &port_status);
+	if (ret)
+		return ret;
+
+	if ((port_status & LTC4296_PSE_STATUS_MSK) == LTC_PSE_STATUS_DELIVERING) {
+		*pwr_status = LTC_PSE_STATUS_DELIVERING;
+	} else {
+		*pwr_status = LTC_PSE_STATUS_UNKNOWN;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Check if port has stable power
+ * @param dev - The device structure
+ * @param port_no - The port number
+ * @param pwr_status - The power status
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_is_port_pwr_stable(struct ltc4296_dev *dev,
+			       enum ltc4296_port port_no, bool *pwr_status)
+{
+	int ret;
+	uint16_t port_status;
+	uint8_t port_addr = 0;
+
+	if (!dev || !pwr_status)
+		return -EINVAL;
+
+	ret = ltc4296_get_port_addr(port_no, LTC_PORT_STATUS, &port_addr);
+	if (ret)
+		return ret;
+
+	ret = ltc4296_reg_read(dev, port_addr, &port_status);
+	if (ret)
+		return ret;
+
+	if ((port_status & LTC4296_POWER_STABLE_MSK) == LTC4296_POWER_STABLE_MSK) {
+		*pwr_status =  true;
+	} else {
+		*pwr_status = false;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Read port ADC
+ * @param dev - The device structure
+ * @param port_no - The port number
+ * @param port_i_out_ma - The port current in mA.
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_read_port_adc(struct ltc4296_dev *dev, enum ltc4296_port port_no,
+			  int *port_i_out_ma)
+{
+	int ret;
+	uint8_t port_addr = 0;
+	uint16_t val16;
+
+	if (!dev || !port_i_out_ma)
+		return -EINVAL;
+
+	ret = ltc4296_get_port_addr(port_no, LTC_PORT_ADCDAT, &port_addr);
+	if (ret)
+		return ret;
+
+	ret = ltc4296_reg_read(dev, port_addr, &val16);
+	if (ret)
+		return ret;
+
+	if ((val16 & LTC4296_NEW_MSK) == LTC4296_NEW_MSK)
+		/* A new ADC value is available */
+		*port_i_out_ma =( ((val16 & 0x0FFF) - LTC4296_ADC_OFFSET) *
+				  ltc4296_spoe_rsense[port_no] /
+				  10);
+	else
+		return ADI_LTC_INVALID_ADC_PORT_CURRENT;
+
+	return 0;
+}
+
+/**
+ * @brief Stimulate valid wake-up signature for a port
+ * @param dev - The device structure
+ * @param port_no - The port number
+ * @param mode - The device configuration mode
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_port_prebias(struct ltc4296_dev *dev, enum ltc4296_port port_no,
+			 enum ltc4296_config mode)
+{
+	int ret;
+	uint8_t port_addr = 0;
+
+	if (!dev)
+		return -EINVAL;
+
+	ret = ltc4296_get_port_addr(port_no, LTC_PORT_CFG1, &port_addr);
+	if (ret)
+		return ret;
+
+	if (mode == LTC_CFG_SCCP_MODE)
+		return ltc4296_reg_write(dev, port_addr, 0x0108);
+	else if (mode == LTC_CFG_APL_MODE)
+		return ltc4296_reg_write(dev, port_addr, 0x0109);
+	else
+		return -EINVAL;
+}
+
+/**
+ * @brief Enable specific port
+ * @param dev - The device structure
+ * @param port_no - The port number
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_port_en(struct ltc4296_dev *dev, enum ltc4296_port port_no)
+{
+	int ret;
+	uint8_t port_addr = 0;
+
+	if (!dev)
+		return -EINVAL;
+
+	ret = ltc4296_get_port_addr(port_no, LTC_PORT_CFG0, &port_addr);
+	if (ret)
+		return ret;
+
+	return ltc4296_reg_write(dev, port_addr, (LTC4296_SW_EN_MSK |
+				 LTC4296_SW_POWER_AVAILABLE_MSK |
+				 LTC4296_SW_PSE_READY_MSK |
+				 LTC4296_TMFVDO_TIMER_DISABLE_MSK));
+}
+
+/**
+ * @brief Enable specific port and classify
+ * @param dev - The device structure
+ * @param port_no - The port number
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_port_en_and_classification(struct ltc4296_dev *dev,
+				       enum ltc4296_port port_no)
+{
+	int ret;
+	uint8_t port_addr = 0;
+
+	if (!dev)
+		return -EINVAL;
+
+	ret = ltc4296_get_port_addr(port_no, LTC_PORT_CFG0, &port_addr);
+	if (ret)
+		return ret;
+
+	return ltc4296_reg_write(dev, port_addr,
+				 (LTC4296_SW_EN_MSK | LTC4296_SW_PSE_READY_MSK |
+				  LTC4296_SET_CLASSIFICATION_MODE_MSK));
+}
+
+/**
+ * @brief Set port to maintain full voltage signature.
+ * @param dev - The device structure
+ * @param port_no - The port number
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_set_port_mfvs(struct ltc4296_dev *dev, enum ltc4296_port port_no)
+{
+	int ret;
+	uint8_t port_addr = 0;
+	uint16_t val16;
+	int mfvs_threshold, val;
+
+	if (!dev)
+		return -EINVAL;
+
+	ret = ltc4296_get_port_addr(port_no, LTC_PORT_ADCCFG, &port_addr);
+	if (ret)
+		return ret;
+
+	/* LTC4296-1 Set Port ADC MFVS Threshold Value */
+	val = ltc4296_spoe_sense_resistor[port_no];
+	mfvs_threshold = (625 * val / 10);
+	/* Round of to the nearest integer */
+	val16 = NO_OS_DIV_ROUND_CLOSEST(mfvs_threshold, 1000);
+
+	return ltc4296_reg_write(dev, port_addr, val16);
+}
+
+/**
+ * @brief Set port to power mode.
+ * @param dev - The device structure
+ * @param port_no - The port number
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_set_port_pwr(struct ltc4296_dev *dev, enum ltc4296_port port_no)
+{
+	int ret;
+	uint8_t port_addr = 0;
+
+	if (!dev)
+		return -EINVAL;
+
+	ret = ltc4296_get_port_addr(port_no, LTC_PORT_CFG0, &port_addr);
+	if (ret)
+		return ret;
+
+	return ltc4296_reg_write(dev, port_addr,
+				 (LTC4296_SW_EN_MSK | LTC4296_SW_POWER_AVAILABLE_MSK |
+				  LTC4296_SW_PSE_READY_MSK | LTC4296_SET_CLASSIFICATION_MODE_MSK |
+				  LTC4296_END_CLASSIFICATION_MSK));
+}
+
+/**
+ * @brief Force port to power mode.
+ * @param dev - The device structure
+ * @param port_no - The port number
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_force_port_pwr(struct ltc4296_dev *dev, enum ltc4296_port port_no)
+{
+	int ret;
+	uint8_t port_addr = 0;
+
+	if (!dev)
+		return -EINVAL;
+
+	ret = ltc4296_get_port_addr(port_no, LTC_PORT_CFG0, &port_addr);
+	if (ret)
+		return ret;
+
+	return ltc4296_reg_write(dev, port_addr,
+				 (LTC4296_SW_EN_MSK | LTC4296_SW_POWER_AVAILABLE_MSK |
+				  LTC4296_SW_PSE_READY_MSK | LTC4296_TMFVDO_TIMER_DISABLE_MSK) );
+}
+
+/**
+ * @brief Set port is able to source power.
+ * @param dev - The device structure
+ * @param port_no - The port number
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_port_pwr_available(struct ltc4296_dev *dev,
+			       enum ltc4296_port port_no)
+{
+	int ret;
+	uint8_t port_addr = 0;
+
+	if (!dev)
+		return -EINVAL;
+
+	ret = ltc4296_get_port_addr(port_no, LTC_PORT_CFG0, &port_addr);
+	if (ret)
+		return ret;
+	/* LTC4296-1 Port Clear Classification & PSE Ready, Set Power Available
+	* PxCFG0=en|power_available
+	*/
+	return ltc4296_reg_write(dev, port_addr,
+				 (LTC4296_SW_EN_MSK | LTC4296_SW_POWER_AVAILABLE_MSK));
+}
+
+/**
+ * @brief Configure Global ADC to read output voltage
+ * @param dev - The device structure
+ * @param port_no - The port number
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_set_gadc_vout(struct ltc4296_dev *dev, enum ltc4296_port port_no)
+{
+	uint16_t val16;
+
+	if (!dev)
+		return -EINVAL;
+
+	/* LTC4296-1 Set global ADC to measure Port Vout
+		GADCCFG=ContModeLowGain|VoutPort2 */
+
+	val16 = (0x001F & set_port_vout[port_no]);
+	/* Set Continuous mode with LOW GAIN bit */
+	val16 = (val16 | 0x40);
+
+	return ltc4296_reg_write(dev, LTC4296_REG_GADCCFG, val16);
+}
+
+/**
+ * @brief Print global faults
+ * @param g_events - The global events data
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_print_global_faults(uint16_t g_events)
+{
+	if ((g_events & LTC4296_LOW_CKT_BRK_FAULT_MSK) == LTC4296_LOW_CKT_BRK_FAULT_MSK)
+		pr_info("LTC4296-1 low side fault, too high current or negative voltage on output \n");
+	else if ((g_events & LTC4296_MEMORY_FAULT_MSK) == LTC4296_MEMORY_FAULT_MSK)
+		pr_info("LTC4296-1 memory fault \n");
+	else if ((g_events & LTC4296_PEC_FAULT_MSK) == LTC4296_PEC_FAULT_MSK)
+		pr_info("LTC4296-1 pec fault \n");
+	else if ((g_events & LTC4296_COMMAND_FAULT_MSK) == LTC4296_COMMAND_FAULT_MSK)
+		pr_info("LTC4296-1 command fault \n");
+	else if ((g_events & LTC4296_UVLO_DIGITAL_MSK) == LTC4296_UVLO_DIGITAL_MSK)
+		pr_info("LTC4296-1  UVLO, too low input voltage fault \n");
+
+	return 0;
+}
+
+/**
+ * @brief Print port events
+ * @param port_no - The port number
+ * @param port_events - The port events data
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_print_port_events(enum ltc4296_port port_no, uint16_t port_events)
+{
+	if ((port_events & LTC4296_LSNS_REVERSE_FAULT_MSK) ==
+	    LTC4296_LSNS_REVERSE_FAULT_MSK)
+		pr_info("LTC4296-1 port%d LSNS_REVERSE_FAULT, negative low side current \n",
+			port_no);
+
+	if ((port_events & LTC4296_LSNS_FORWARD_FAULT_MSK) ==
+	    LTC4296_LSNS_FORWARD_FAULT_MSK)
+		pr_info("LTC4296-1 port%d LSNS_FORWARD_FAULT, too high low side current \n",
+			port_no);
+
+	if ((port_events & LTC4296_PD_WAKEUP_MSK) == LTC4296_PD_WAKEUP_MSK)
+		pr_info("LTC4296-1 port%d PD_WAKEUP, wake up requested by PD \n",port_no);
+
+	if ((port_events & LTC4296_TINRUSH_TIMER_DONE_MSK) ==
+	    LTC4296_TINRUSH_TIMER_DONE_MSK)
+		pr_info("LTC4296-1 port%d TINRUSH_TIMER_DONE, too long time to power on \n",
+			port_no);
+
+	if ((port_events & LTC4296_MFVS_TIMEOUT_MSK) == LTC4296_MFVS_TIMEOUT_MSK)
+		pr_info("LTC4296-1 port%d MFVS_TIMEOUT, PD disconnected \n",port_no);
+
+	if ((port_events & LTC4296_OVERLOAD_DETECTED_IPOWERED_MSK) ==
+	    LTC4296_OVERLOAD_DETECTED_IPOWERED_MSK)
+		pr_info("LTC4296-1 port%d OVERLOAD_DETECTED_IPOWERED, too high output current \n",
+			port_no);
+
+	if ((port_events & LTC4296_OVERLOAD_DETECTED_ISLEEP_MSK) ==
+	    LTC4296_OVERLOAD_DETECTED_ISLEEP_MSK)
+		pr_info("LTC4296-1 port%d OVERLOAD_DETECTED_ISLEEP, un-powered port overloaded \n",
+			port_no);
+
+	if ((port_events & LTC4296_TOFF_TIMER_DONE_MSK) == LTC4296_TOFF_TIMER_DONE_MSK)
+		pr_info("LTC4296-1 port%d TOFF_TIMER_DONE, too long time to power off \n",
+			port_no);
+
+	return 0;
+}
+
+/**
+ * @brief Check global events
+ * @param dev - The device structure
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_chk_global_events(struct ltc4296_dev *dev)
+{
+	int ret;
+	enum ltc4296_state state;
+	uint16_t global_events = 0;
+
+	if (!dev)
+		return -EINVAL;
+
+	/* Check if LTC4296-1 is locked */
+	ret = ltc4296_is_locked(dev, &state);
+	if (ret)
+		return ret;
+
+	if (state == LTC_LOCKED) {
+		/* Unlock the LTC4296_1 */
+		pr_info("PSE initiated ... \n");
+		ret = ltc4296_reset(dev);
+		if (ret)
+			return ret;
+
+		ret = ltc4296_unlock(dev);
+		if (ret)
+			return ret;
+
+		ret = ltc4296_clear_global_faults(dev);
+		if (ret)
+			return ret;
+
+		return ADI_LTC_DISCONTINUE_SCCP;
+	} else {
+		ret = ltc4296_read_global_faults(dev, &global_events);
+		if (ret)
+			return ret;
+
+		ret = ltc4296_print_global_faults(global_events);
+		if (ret)
+			return ret;
+
+		if ((global_events & LTC4296_LOW_CKT_BRK_FAULT_MSK) ==
+		    LTC4296_LOW_CKT_BRK_FAULT_MSK) {
+			ret = ltc4296_clear_ckt_breaker(dev);
+			if (ret)
+				return ret;
+
+			return ADI_LTC_DISCONTINUE_SCCP;
+		} else if (((global_events & LTC4296_MEMORY_FAULT_MSK) ==
+			    LTC4296_MEMORY_FAULT_MSK)   ||
+			   ((global_events & LTC4296_PEC_FAULT_MSK) == LTC4296_PEC_FAULT_MSK) ||
+			   ((global_events & LTC4296_COMMAND_FAULT_MSK) == LTC4296_COMMAND_FAULT_MSK) ||
+			   ((global_events & LTC4296_UVLO_DIGITAL_MSK) == LTC4296_UVLO_DIGITAL_MSK)   ) {
+			/* Global events other than circuit breaker ?*/
+			ret = ltc4296_reset(dev);
+			if (ret)
+				return ret;
+
+			ret = ltc4296_unlock(dev);
+			if (ret)
+				return ret;
+
+			ret = ltc4296_clear_global_faults(dev);
+			if (ret)
+				return ret;
+
+			return ADI_LTC_DISCONTINUE_SCCP;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Check port events
+ * @param dev - The device structure
+ * @param ltc4296_port - The port number
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_chk_port_events(struct ltc4296_dev *dev,
+			    enum ltc4296_port ltc4296_port)
+{
+	int ret;
+	uint16_t port_events = 0;
+
+	if (!dev)
+		return -EINVAL;
+
+	/* Read the Port Events */
+	ret = ltc4296_read_port_events(dev, ltc4296_port, &port_events);
+	if (ret)
+		return ret;
+
+	/* Report only in case of port event other than signature */
+	ret = ltc4296_print_port_events(ltc4296_port, port_events);
+	if (ret)
+		return ret;
+
+	return ltc4296_clear_port_events(dev, ltc4296_port);
+}
+
+/**
+ * @brief Device initialization
+ * @param device - The device structure
+ * @param init_param - The initialization parameters
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_init(struct ltc4296_dev **device,
+		 struct ltc4296_init_param *init_param)
+{
+	struct ltc4296_dev *dev;
+	uint16_t value;
+	int ret;
+
+	if ((!device) || (!init_param))
+		return -EINVAL;
+
+	dev = (struct ltc4296_dev*)no_os_calloc(1, sizeof(struct ltc4296_dev));
+	if (!dev)
+		return  -ENOMEM;
+
+	ret = no_os_spi_init(&dev->spi_desc, init_param->spi_init);
+	if (ret)
+		goto err;
+
+	ret = ltc4296_reset(dev);
+	if (ret)
+		goto err_spi;
+
+	ret = ltc4296_reg_write(dev, LTC4296_REG_GCMD, LTC4296_UNLOCK_KEY);
+	if (ret)
+		goto err_spi;
+
+	ret = ltc4296_reg_read(dev, LTC4296_REG_GCMD, &value);
+	if (ret)
+		goto err_spi;
+
+	if (value != LTC4296_UNLOCK_KEY) {
+		pr_err("Device locked. Write Access is disabled");
+		ret = -EINVAL;
+		goto err_spi;
+	}
+
+	*device = dev;
+
+	return 0;
+
+err_spi:
+	no_os_spi_remove(dev);
+err:
+	no_os_free(dev);
+
+	return ret;
+}
+
+/**
+ * @brief Free allocated resources
+ * @param dev - The device structure
+ * @return 0 in case of success, negative code otherwise
+ */
+int ltc4296_remove(struct ltc4296_dev* dev)
+{
+	int ret;
+
+	ret = no_os_spi_remove(dev->spi_desc);
+	if (ret)
+		return ret;
+
+	no_os_free(dev);
+
+	return 0;
+}
+

--- a/drivers/power/ltc4296/ltc4296.h
+++ b/drivers/power/ltc4296/ltc4296.h
@@ -1,0 +1,480 @@
+/***************************************************************************//**
+ *   @file   ltc4296.h
+ *   @brief  Header file for the LTC4296 Driver
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef __LTC4296_H__
+#define __LTC4296_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdint.h>
+#include "no_os_util.h"
+#include "no_os_spi.h"
+#include "no_os_gpio.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+#define LTC4296_REG_GFLTEV        	0x02
+#define LTC4296_REG_GFLTMSK       	0x03
+#define LTC4296_REG_GCAP          	0x06
+#define LTC4296_REG_GIOST         	0x07
+#define LTC4296_REG_GCMD          	0x08
+#define LTC4296_REG_GCFG          	0x09
+#define LTC4296_REG_GADCCFG       	0x0A
+#define LTC4296_REG_GADCDAT       	0x0B
+#define LTC4296_REG_P0EV          	0x10
+#define LTC4296_REG_P0ST          	0x12
+#define LTC4296_REG_P0CFG0        	0x13
+#define LTC4296_REG_P0CFG1        	0x14
+#define LTC4296_REG_P0ADCCFG      	0x15
+#define LTC4296_REG_P0ADCDAT      	0x16
+#define LTC4296_REG_P0SELFTEST    	0x17
+#define LTC4296_REG_P1EV          	0x20
+#define LTC4296_REG_P1ST          	0x22
+#define LTC4296_REG_P1CFG0        	0x23
+#define LTC4296_REG_P1CFG1        	0x24
+#define LTC4296_REG_P1ADCCFG      	0x25
+#define LTC4296_REG_P1ADCDAT      	0x26
+#define LTC4296_REG_P1SELFTEST    	0x27
+#define LTC4296_REG_P2EV          	0x30
+#define LTC4296_REG_P2ST          	0x32
+#define LTC4296_REG_P2CFG0        	0x33
+#define LTC4296_REG_P2CFG1       	0x34
+#define LTC4296_REG_P2ADCCFG      	0x35
+#define LTC4296_REG_P2ADCDAT      	0x36
+#define LTC4296_REG_P2SELFTEST   	0x37
+#define LTC4296_REG_P3EV          	0x40
+#define LTC4296_REG_P3ST          	0x42
+#define LTC4296_REG_P3CFG0        	0x43
+#define LTC4296_REG_P3CFG1        	0x44
+#define LTC4296_REG_P3ADCCFG      	0x45
+#define LTC4296_REG_P3ADCDAT     	0x46
+#define LTC4296_REG_P3SELFTEST    	0x47
+#define LTC4296_REG_P4EV          	0x50
+#define LTC4296_REG_P4ST          	0x52
+#define LTC4296_REG_P4CFG0        	0x53
+#define LTC4296_REG_P4CFG1      	0x54
+#define LTC4296_REG_P4ADCCFG      	0x55
+#define LTC4296_REG_P4ADCDAT     	0x56
+#define LTC4296_REG_P4SELFTEST    	0x57
+
+/* LTC4296_REG_GFLTEV */
+#define LTC4296_UVLO_DIGITAL_MSK	NO_OS_BIT(4)
+#define LTC4296_COMMAND_FAULT_MSK	NO_OS_BIT(3)
+#define LTC4296_PEC_FAULT_MSK		NO_OS_BIT(2)
+#define LTC4296_MEMORY_FAULT_MSK	NO_OS_BIT(1)
+#define LTC4296_LOW_CKT_BRK_FAULT_MSK	NO_OS_BIT(0)
+
+/* LTC4296_REG_GCAP */
+#define LTC4296_SCCP_SUPPORT_MSK             NO_OS_BIT(6)
+#define LTC4296_WAKE_FWD_SUPPORT_MSK         NO_OS_BIT(5)
+#define LTC4296_NUMPORTS_MSK                 NO_OS_GENMASK(4, 0)
+
+/* LTC4296_REG_GIOST */
+#define LTC4296_PG_OUT4_MSK			NO_OS_BIT(8)
+#define LTC4296_PG_OUT3_MSK			NO_OS_BIT(7)
+#define LTC4296_PG_OUT2_MSK			NO_OS_BIT(6)
+#define LTC4296_PG_OUT1_MSK			NO_OS_BIT(5)
+#define LTC4296_PG_OUT0_MSK			NO_OS_BIT(4)
+#define LTC4296_PAD_AUTO_MSK			NO_OS_BIT(3)
+#define LTC4296_PAD_WAKEUP_MSK			NO_OS_BIT(2)
+#define LTC4296_PAD_WAKEUP_DRIVE_MSK		NO_OS_BIT(1)
+
+/* LTC4296_REG_GCMD */
+#define LTC4296_SW_RESET_MSK			NO_OS_GENMASK(15, 8)
+#define LTC4296_WRITE_PROTECT_MSK		NO_OS_GENMASK(7, 0)
+
+/* LTC4296_REG_GCFG */
+#define LTC4296_MASK_LOWFAULT_MSK		NO_OS_BIT(5)
+#define LTC4296_TLIM_DISABLE_MSK		NO_OS_BIT(4)
+#define LTC4296_TLIM_TIMER_SLEEP_MSK		NO_OS_GENMASK(3, 2)
+#define LTC4296_REFRESH_MSK			NO_OS_BIT(1)
+#define LTC4296_SW_VIN_PGOOD_MSK		NO_OS_BIT(0)
+
+/* LTC4296_REG_GADCCFG */
+#define LTC4296_GADC_SAMPLE_MODE_MSK		NO_OS_GENMASK(6, 5)
+#define LTC4296_GADC_SEL_MSK			NO_OS_GENMASK(4, 0)
+
+/* LTC4296_REG_GADCDAT */
+#define LTC4296_GADC_MISSED_MSK			NO_OS_BIT(13)
+#define LTC4296_GADC_NEW_MSK			NO_OS_BIT(12)
+#define LTC4296_GADC_MSK			NO_OS_GENMASK(11, 0)
+
+/* LTC4296_REG_PXEV */
+#define LTC4296_VALID_SIGNATURE_MSK		NO_OS_BIT(9)
+#define LTC4296_INVALID_SIGNATURE_MSK		NO_OS_BIT(8)
+#define LTC4296_TOFF_TIMER_DONE_MSK		NO_OS_BIT(7)
+#define LTC4296_OVERLOAD_DETECTED_ISLEEP_MSK	NO_OS_BIT(6)
+#define LTC4296_OVERLOAD_DETECTED_IPOWERED_MSK	NO_OS_BIT(5)
+#define LTC4296_MFVS_TIMEOUT_MSK		NO_OS_BIT(4)
+#define LTC4296_TINRUSH_TIMER_DONE_MSK		NO_OS_BIT(3)
+#define LTC4296_PD_WAKEUP_MSK			NO_OS_BIT(2)
+#define LTC4296_LSNS_FORWARD_FAULT_MSK		NO_OS_BIT(1)
+#define LTC4296_LSNS_REVERSE_FAULT_MSK		NO_OS_BIT(0)
+
+/* LTC4296_REG_PXST */
+#define LTC4296_DET_VHIGH_MSK			NO_OS_BIT(13)
+#define LTC4296_DET_VLOW_MSK			NO_OS_BIT(12)
+#define LTC4296_POWER_STABLE_HI_MSK		NO_OS_BIT(11)
+#define LTC4296_POWER_STABLE_LO_MSK		NO_OS_BIT(10)
+#define LTC4296_POWER_STABLE_MSK		NO_OS_BIT(9)
+#define LTC4296_OVERLOAD_HELD_MSK		NO_OS_BIT(8)
+#define LTC4296_PI_SLEEPING_MSK			NO_OS_BIT(7)
+#define LTC4296_PI_PREBIASED_MSK		NO_OS_BIT(6)
+#define LTC4296_PI_DETECTING_MSK		NO_OS_BIT(5)
+#define LTC4296_PI_POWERED_MSK			NO_OS_BIT(4)
+#define LTC4296_PI_DISCHARGE_EN_MSK		NO_OS_BIT(3)
+#define LTC4296_PSE_STATUS_MSK			NO_OS_GENMASK(2, 0)
+
+/* LTC4296_REG_PXCFG0 */
+#define LTC4296_SW_INRUSH_MSK			NO_OS_BIT(15)
+#define LTC4296_END_CLASSIFICATION_MSK		NO_OS_BIT(14)
+#define LTC4296_SET_CLASSIFICATION_MODE_MSK	NO_OS_BIT(13)
+#define LTC4296_DISABLE_DETECTION_PULLUP_MSK	NO_OS_BIT(12)
+#define LTC4296_TDET_DISABLE_MSK		NO_OS_BIT(11)
+#define LTC4296_FOLDBACK_DISABLE_MSK		NO_OS_BIT(10)
+#define LTC4296_SOFT_START_DISABLE_MSK		NO_OS_BIT(9)
+#define LTC4296_TOFF_TIMER_DISABLE_MSK		NO_OS_BIT(8)
+#define LTC4296_TMFVDO_TIMER_DISABLE_MSK	NO_OS_BIT(7)
+#define LTC4296_SW_PSE_READY_MSK		NO_OS_BIT(6)
+#define LTC4296_SW_POWER_AVAILABLE_MSK		NO_OS_BIT(5)
+#define LTC4296_UPSTREAM_WAKEUP_DISABLE_MSK	NO_OS_BIT(4)
+#define LTC4296_DOWNSTREAM_WAKEUP_DISABLE_MSK	NO_OS_BIT(3)
+#define LTC4296_SW_PSE_WAKEUP_MSK		NO_OS_BIT(2)
+#define LTC4296_HW_EN_MASK_MSK			NO_OS_BIT(1)
+#define LTC4296_SW_EN_MSK			NO_OS_BIT(0)
+
+/* LTC4296_REG_PXCFG1 */
+#define LTC4296_PREBIAS_OVERRIDE_GOOD_MSK	NO_OS_BIT(8)
+#define LTC4296_TLIM_TIMER_TOP_MSK		NO_OS_GENMASK(7, 6)
+#define LTC4296_TOD_TRESTART_TIMER_MSK		NO_OS_GENMASK(5, 4)
+#define LTC4296_TINRUSH_TIMER_MSK		NO_OS_GENMASK(3, 2)
+#define LTC4296_SIG_OVERRIDE_BAD_MSK		NO_OS_BIT(1)
+#define LTC4296_SIG_OVERRIDE_GOOD_MSK		NO_OS_BIT(0)
+
+/* LTC4296_REG_PXADCCFG */
+#define LTC4296_MFVS_THRESHOLD_MSK		NO_OS_GENMASK(7, 0)
+
+/* LTC4296_REG_PXADCDAT */
+#define LTC4296_MISSED_MSK			NO_OS_BIT(13)
+#define LTC4296_NEW_MSK				NO_OS_BIT(12)
+#define LTC4296_SOURCE_CURRENT_MSK		NO_OS_GENMASK(11, 0)
+
+/* Miscellaneous Definitions*/
+#define LTC4296_SPI_READ			0x01
+#define LTC4296_SPI_WRITE			0x00
+
+#define LTC4296_RESET_CODE			0x73
+#define LTC4296_UNLOCK_KEY			0x05
+#define LTC4296_LOCK_KEY			0xA0
+
+#define LTC4296_ADC_OFFSET			2049
+
+#define LTC4296_VGAIN				35230 / 1000
+#define LTC4296_IGAIN				1 / 10
+
+#define LTC4296_VMAX         			1
+#define LTC4296_VMIN        			0
+
+#define LTC4296_MAX_PORTS			5
+
+#define RTESTLOAD              			200 /*(ohm)*/
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+
+/**
+ * @brief Device Structure
+ */
+struct ltc4296_dev {
+	struct no_os_spi_desc *spi_desc;
+};
+
+/**
+ * @brief Initialization Structure
+ */
+struct ltc4296_init_param {
+	struct no_os_spi_init_param *spi_init;
+};
+
+/**
+ * @brief Device State
+ */
+enum ltc4296_state {
+	LTC_UNLOCKED = 0,
+	LTC_LOCKED
+};
+
+/**
+ * @brief Device Port Numbers
+ */
+enum ltc4296_port {
+	LTC_PORT0 = 0,
+	LTC_PORT1,
+	LTC_PORT2,
+	LTC_PORT3,
+	LTC_PORT4,
+	LTC_NO_PORT
+};
+
+/**
+ * @brief Device Port Status
+ */
+enum ltc4296_port_status {
+	LTC_PORT_DISABLED = 0,
+	LTC_PORT_ENABLED
+};
+
+/**
+ * @brief Device PSE Status
+ */
+enum ltc4296_pse_status {
+	LTC_PSE_STATUS_DISABLED = 0,      /*  000b Port is disabled                */
+	LTC_PSE_STATUS_SLEEPING,          /*  001b Port is in sleeping             */
+	LTC_PSE_STATUS_DELIVERING,        /*  010b Port is delivering power        */
+	LTC_PSE_STATUS_SEARCHING,         /*  011b Port is searching               */
+	LTC_PSE_STATUS_ERROR,             /*  100b Port is in error                */
+	LTC_PSE_STATUS_IDLE,              /*  101b Port is idle                    */
+	LTC_PSE_STATUS_PREPDET,           /*  110b Port is preparing for detection */
+	LTC_PSE_STATUS_UNKNOWN            /*  111b Port is in an unknown state     */
+};
+
+/**
+ * @brief Board Classes
+ */
+enum ltc4296_board_class {
+	SPOE_CLASS10 = 0,
+	SPOE_CLASS11,
+	SPOE_CLASS12,
+	SPOE_CLASS13,
+	SPOE_CLASS14,
+	SPOE_CLASS15,
+	APL_CLASSA,
+	APL_CLASSA_NOAUTONEG,
+	APL_CLASSC,
+	APL_CLASS3,
+	PRODUCTION_POWER_TEST,
+	APL_CLASSA_OLD_DEMO,
+	SPOE_OFF,
+	PRODUCTION_DATA_TEST,
+	RESERVED,
+	DEBUGMODE
+};
+
+/**
+ * @brief Device Configuration Modes
+ */
+enum ltc4296_config {
+	LTC_CFG_SCCP_MODE = 0,
+	LTC_CFG_APL_MODE,
+	LTC_CFG_RESET
+};
+
+/**
+ * @brief Device Port Register offsets
+ */
+enum ltc4296_port_reg_offset_e {
+	LTC_PORT_EVENTS   = 0,
+	LTC_PORT_STATUS   = 2,
+	LTC_PORT_CFG0     = 3,
+	LTC_PORT_CFG1     = 4,
+	LTC_PORT_ADCCFG   = 5,
+	LTC_PORT_ADCDAT   = 6,
+	LTC_PORT_SELFTEST = 7
+};
+
+/**
+ * @brief Device Result Codes
+ */
+enum adi_ltc_result {
+	ADI_LTC_SUCCESS = 0,                  /*!< Success                                                    */
+	ADI_LTC_DISCONTINUE_SCCP,             /*!< Discontinue the SCCP configuration cycle.                  */
+	ADI_LTC_SCCP_COMPLETE,                /*!< Complete SCCP configuration cycle.                         */
+	ADI_LTC_SCCP_PD_DETECTION_FAILED,     /*!< PD Detection failed                                        */
+	ADI_LTC_SCCP_PD_NOT_PRESENT,          /*!< SCCP  PD not present                                       */
+	ADI_LTC_SCCP_PD_RES_INVALID,          /*!< PD Response is invalid                                     */
+	ADI_LTC_SCCP_PD_PRESENT,              /*!< PD is present.                                             */
+	ADI_LTC_SCCP_PD_CLASS_COMPATIBLE,     /*!< PD Class is compatible                                     */
+	ADI_LTC_SCCP_PD_CLASS_NOT_SUPPORTED,  /*!< PD Class is out of range                                   */
+	ADI_LTC_SCCP_PD_CLASS_NOT_COMPATIBLE, /*!< PD Class is not compatible                                 */
+	ADI_LTC_SCCP_PD_LINE_NOT_HIGH,        /*!< PD line has not gone HIGH                                  */
+	ADI_LTC_SCCP_PD_LINE_NOT_LOW,         /*!< PD line has not gone LOW                                   */
+	ADI_LTC_SCCP_PD_CRC_FAILED,           /*!< CRC received from PD is incorrect                          */
+	ADI_LTC_APL_COMPLETE,                 /*!< Complete APL configuration cycle.                          */
+	ADI_LTC_DISCONTINUE_APL,              /*!< Discontinue the APL configuration cycle.                   */
+	ADI_LTC_INVALID_ADC_VOLTAGE,          /*!< Invalid ADC Accumulation result.                           */
+	ADI_LTC_INVALID_ADC_PORT_CURRENT,     /*!< Invalid ADC Port Current                                   */
+	ADI_LTC_TEST_COMPLETE,                /*!< LTC Test complete.                                         */
+	ADI_LTC_DISCONTINUE_TEST,             /*!< LTC Discontinue Test.                                      */
+	ADI_LTC_TEST_FAILED,                  /*!< LTC Test Failed.                                           */
+	ADI_LTC_INVALID_VIN                   /*!< VIN is invalid                                             */
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+/** Register Write */
+int ltc4296_reg_write(struct ltc4296_dev *dev, uint8_t reg, uint16_t data);
+
+/** Register Read */
+int ltc4296_reg_read(struct ltc4296_dev *dev, uint8_t reg, uint16_t *data);
+
+/** Register Write */
+int ltc4296_reset(struct ltc4296_dev *dev);
+
+/** Get port address */
+int ltc4296_get_port_addr(enum ltc4296_port port_no,
+			  enum ltc4296_port_reg_offset_e port_offset,
+			  uint8_t *port_addr);
+
+/** Clear global faults */
+int ltc4296_clear_global_faults(struct ltc4296_dev *dev);
+
+/** Clear circuit break faults */
+int ltc4296_clear_ckt_breaker(struct ltc4296_dev *dev);
+
+/** Read global faults */
+int ltc4296_read_global_faults(struct ltc4296_dev *dev, uint16_t *g_events);
+
+/** Device unlock */
+int ltc4296_unlock(struct ltc4296_dev *dev);
+
+/** Check device state */
+int ltc4296_is_locked(struct ltc4296_dev *dev, enum ltc4296_state *state);
+
+/** Read global ADC */
+int ltc4296_read_gadc(struct ltc4296_dev *dev, int *port_voltage_mv);
+
+/** Set the global ADC to measure voltage */
+int ltc4296_set_gadc_vin(struct ltc4296_dev *dev);
+
+/** Check if input voltage is valid */
+int ltc4296_is_vin_valid(struct ltc4296_dev *dev, int port_vin_mv,
+			 enum ltc4296_board_class ltcboard_class, bool *vin_valid);
+
+/** Check if output voltage is valid. */
+int ltc4296_is_vout_valid(struct ltc4296_dev *dev, int port_vout_mv,
+			  enum ltc4296_board_class ltcboard_class, bool *vout_valid);
+
+/** Disable the global ADC */
+int ltc4296_disable_gadc(struct ltc4296_dev *dev);
+
+/** Read Port Events */
+int ltc4296_read_port_events(struct ltc4296_dev *dev, enum ltc4296_port port_no,
+			     uint16_t *port_events);
+
+/** Clear Port Events */
+int ltc4296_clear_port_events(struct ltc4296_dev *dev,
+			      enum ltc4296_port port_no);
+
+/** Read Port Status */
+int ltc4296_read_port_status(struct ltc4296_dev *dev, enum ltc4296_port port_no,
+			     uint16_t *port_status);
+
+/** Check if port is enabled/disabled */
+int ltc4296_is_port_disabled(struct ltc4296_dev *dev, enum ltc4296_port port_no,
+			     enum ltc4296_port_status *port_chk);
+
+/** Check if port is disabled */
+int ltc4296_port_disable(struct ltc4296_dev *dev, enum ltc4296_port port_no);
+
+/** Check if port delivers power */
+int ltc4296_is_port_deliver_pwr(struct ltc4296_dev *dev,
+				enum ltc4296_port port_no,
+				enum ltc4296_pse_status *pwr_status);
+
+/** Check if port has stable power */
+int ltc4296_is_port_pwr_stable(struct ltc4296_dev *dev,
+			       enum ltc4296_port port_no, bool *pwr_status);
+
+/** Read port ADC */
+int ltc4296_read_port_adc(struct ltc4296_dev *dev, enum ltc4296_port port_no,
+			  int *port_i_out_ma);
+
+/** Stimulate valid wake-up signature for a port */
+int ltc4296_port_prebias(struct ltc4296_dev *dev, enum ltc4296_port port_no,
+			 enum ltc4296_config mode);
+
+/** Enable specific port */
+int ltc4296_port_en(struct ltc4296_dev *dev, enum ltc4296_port port_no);
+
+/** Enable specific port and classify */
+int ltc4296_port_en_and_classification(struct ltc4296_dev *dev,
+				       enum ltc4296_port port_no);
+
+/** Set port to maintain full voltage signature. */
+int ltc4296_set_port_mfvs(struct ltc4296_dev *dev, enum ltc4296_port port_no);
+
+/** Set port to power mode. */
+int ltc4296_set_port_pwr(struct ltc4296_dev *dev, enum ltc4296_port port_no);
+
+/** Force port to power mode. */
+int ltc4296_force_port_pwr(struct ltc4296_dev *dev, enum ltc4296_port port_no);
+
+/** Set port is able to source power. */
+int ltc4296_port_pwr_available(struct ltc4296_dev *dev,
+			       enum ltc4296_port port_no);
+
+/** Configure Global ADC to read output voltage */
+int ltc4296_set_gadc_vout(struct ltc4296_dev *dev, enum ltc4296_port port_no);
+
+/** Print global faults */
+int ltc4296_print_global_faults(uint16_t g_events);
+
+/** Print port events */
+int ltc4296_print_port_events(enum ltc4296_port port_no, uint16_t port_events);
+
+/** Check global events */
+int ltc4296_chk_global_events(struct ltc4296_dev *dev);
+
+/** Check port events */
+int ltc4296_chk_port_events(struct ltc4296_dev *dev,
+			    enum ltc4296_port ltc4296_port);
+
+/** Device initialization */
+int ltc4296_init(struct ltc4296_dev** device,
+		 struct ltc4296_init_param* init_param);
+
+/** Free allocated resources */
+int ltc4296_remove(struct ltc4296_dev* dev);
+
+#endif

--- a/projects/ltc4296/Makefile
+++ b/projects/ltc4296/Makefile
@@ -1,0 +1,8 @@
+# Select the example you want to enable by choosing y for enabling and n for disabling
+BASIC_EXAMPLE = y
+
+include ../../tools/scripts/generic_variables.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/ltc4296/README.rst
+++ b/projects/ltc4296/README.rst
@@ -1,0 +1,66 @@
+Evaluating the LTC4296
+======================
+
+
+Contents
+--------
+
+.. contents:: Table of Contents
+	:depth: 3
+
+
+Overview
+--------
+
+The evaluation board allows the LTC4296-1 to be exercised without the need for
+external components.
+
+Full performance details are provided in the LTC4296 data sheet, which should
+be consulted in conjunction with user guide.
+
+No-OS Build Setup
+-----------------
+
+Please see: https://wiki.analog.com/resources/no-os/build
+
+No-OS Supported Examples
+------------------------
+
+The initialization data used in the examples is taken out from:
+`Project Common Data Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ltc4296/src/common>`_
+
+The macros used in Common Data are defined in platform specific files found in:
+`Project Platform Configuration Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ltc4296/src/platform>`_
+
+Basic example
+^^^^^^^^^^^^^
+
+This is a simple example that initializes the LTC4296, unlock the chip and enables power on all
+avaliable ports.
+
+
+In order to build the basic example make sure you have the following configuration in the Makefile
+`Makefile <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ltc4296/Makefile>`_
+
+
+.. code-block:: bash
+
+        # Select the example you want to enable by choosing y for enabling and n for disabling
+        BASIC_EXAMPLE = y
+
+No-OS Supported Platforms
+-------------------------
+
+Maxim Platform
+^^^^^^^^^^^^^^
+
+**Build Command**
+
+.. code-block:: bash
+
+	# to delete current build
+	make reset
+	# to build the project
+	make PLATFORM=maxim TARGET=max32690
+	# to flash the code
+	make run

--- a/projects/ltc4296/builds.json
+++ b/projects/ltc4296/builds.json
@@ -1,0 +1,7 @@
+{
+	"maxim": {
+		"basic_example_max32690": {
+			"flags" : "BASIC_EXAMPLE=y TARGET=max32690"
+		}
+	}
+}

--- a/projects/ltc4296/src.mk
+++ b/projects/ltc4296/src.mk
@@ -1,0 +1,44 @@
+include $(PROJECT)/src/platform/$(PLATFORM)/platform_src.mk
+include $(PROJECT)/src/examples/examples_src.mk
+
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/main.c
+
+INCS += $(PROJECT)/src/common/common_data.h
+SRCS += $(PROJECT)/src/common/common_data.c
+	
+INCS += $(PROJECT)/src/platform/platform_includes.h
+
+INCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.h
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.c
+
+INCS += $(INCLUDE)/no_os_delay.h     		\
+		$(INCLUDE)/no_os_error.h     	\
+		$(INCLUDE)/no_os_list.h     	\
+		$(INCLUDE)/no_os_gpio.h      	\
+		$(INCLUDE)/no_os_dma.h      	\
+		$(INCLUDE)/no_os_print_log.h 	\
+		$(INCLUDE)/no_os_spi.h       	\
+		$(INCLUDE)/no_os_irq.h		\
+		$(INCLUDE)/no_os_pwm.h       	\
+		$(INCLUDE)/no_os_rtc.h       	\
+		$(INCLUDE)/no_os_uart.h      	\
+		$(INCLUDE)/no_os_lf256fifo.h 	\
+		$(INCLUDE)/no_os_util.h 	\
+		$(INCLUDE)/no_os_units.h        \
+		$(INCLUDE)/no_os_alloc.h        \
+                $(INCLUDE)/no_os_mutex.h	
+
+SRCS += $(NO-OS)/util/no_os_lf256fifo.c 	\
+		$(DRIVERS)/api/no_os_spi.c  	\
+		$(DRIVERS)/api/no_os_dma.c  	\
+		$(DRIVERS)/api/no_os_uart.c  	\
+		$(DRIVERS)/api/no_os_irq.c  	\
+		$(DRIVERS)/api/no_os_gpio.c  	\
+		$(DRIVERS)/api/no_os_pwm.c	\
+		$(NO-OS)/util/no_os_util.c	\
+		$(NO-OS)/util/no_os_list.c      \
+		$(NO-OS)/util/no_os_alloc.c 	\
+		$(NO-OS)/util/no_os_mutex.c	
+
+INCS += $(DRIVERS)/power/ltc4296/ltc4296.h
+SRCS += $(DRIVERS)/power/ltc4296/ltc4296.c

--- a/projects/ltc4296/src/common/common_data.c
+++ b/projects/ltc4296/src/common/common_data.c
@@ -1,0 +1,63 @@
+/***************************************************************************//**
+ *   @file   common_data.c
+ *   @brief  Defines common data to be used by ltc4296 examples.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "common_data.h"
+
+struct no_os_uart_init_param ltc4296_uart_ip = {
+	.device_id = UART_DEVICE_ID,
+	.baud_rate = UART_BAUDRATE,
+	.size = NO_OS_UART_CS_8,
+	.parity = NO_OS_UART_PAR_NO,
+	.stop = NO_OS_UART_STOP_1_BIT,
+	.platform_ops = UART_OPS,
+	.extra = UART_EXTRA,
+};
+
+struct no_os_spi_init_param ltc4296_spi_ip = {
+	.device_id = SPI_DEVICE_ID,
+	.max_speed_hz = SPI_BAUDRATE,
+	.bit_order = NO_OS_SPI_BIT_ORDER_MSB_FIRST,
+	.mode = NO_OS_SPI_MODE_0,
+	.platform_ops = SPI_OPS,
+	.chip_select = SPI_CS,
+	.extra = SPI_EXTRA,
+};
+
+struct ltc4296_init_param ltc4296_ip = {
+	.spi_init = &ltc4296_spi_ip,
+};

--- a/projects/ltc4296/src/common/common_data.h
+++ b/projects/ltc4296/src/common/common_data.h
@@ -1,0 +1,52 @@
+/***************************************************************************//**
+ *   @file   common_data.h
+ *   @brief  Defines common data to be used by ltc4296 examples.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __COMMON_DATA_H__
+#define __COMMON_DATA_H__
+
+#include "platform_includes.h"
+#include "no_os_spi.h"
+#include "no_os_gpio.h"
+#include "no_os_pwm.h"
+#include "ltc4296.h"
+
+extern struct no_os_uart_init_param ltc4296_uart_ip;
+extern struct no_os_spi_init_param ltc4296_spi_ip;
+extern struct ltc4296_init_param ltc4296_ip;
+
+#endif /* __COMMON_DATA_H__ */

--- a/projects/ltc4296/src/examples/basic/basic_example.c
+++ b/projects/ltc4296/src/examples/basic/basic_example.c
@@ -1,0 +1,106 @@
+/***************************************************************************//**
+ *   @file   basic_example.c
+ *   @brief  Basic example source file for ltc4296 project.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "common_data.h"
+#include "basic_example.h"
+#include "no_os_delay.h"
+#include "no_os_spi.h"
+#include "no_os_print_log.h"
+#include "no_os_util.h"
+#include "no_os_pwm.h"
+#include "ltc4296.h"
+
+int basic_example_main()
+{
+	int ret;
+
+	struct ltc4296_dev *ltc4296_desc;
+
+	ret = ltc4296_init(&ltc4296_desc, &ltc4296_ip);
+	if (ret) {
+		pr_info("Initialization error!\n");
+		return ret;
+	}
+
+	ret = ltc4296_port_prebias(ltc4296_desc, LTC_PORT0, LTC_CFG_APL_MODE);
+	if (ret)
+		goto err;
+
+	ret = ltc4296_port_en(ltc4296_desc, LTC_PORT0);
+	if (ret)
+		goto err;
+
+	no_os_mdelay(100);
+
+	ltc4296_port_prebias(ltc4296_desc, LTC_PORT1, LTC_CFG_APL_MODE);
+	if (ret)
+		goto err;
+
+	ltc4296_port_en(ltc4296_desc, LTC_PORT1);
+	if (ret)
+		goto err;
+
+	no_os_mdelay(100);
+
+	ret = ltc4296_port_prebias(ltc4296_desc, LTC_PORT2, LTC_CFG_APL_MODE);
+	if (ret)
+		goto err;
+
+	ret = ltc4296_port_en(ltc4296_desc, LTC_PORT2);
+	if (ret)
+		goto err;
+
+	no_os_mdelay(100);
+
+	ret = ltc4296_port_prebias(ltc4296_desc, LTC_PORT3, LTC_CFG_APL_MODE);
+	if (ret)
+		goto err;
+
+	ret = ltc4296_port_en(ltc4296_desc, LTC_PORT3);
+	if (ret)
+		goto err;
+
+	no_os_mdelay(100);
+
+	return 0;
+
+err:
+	ltc4296_remove(ltc4296_desc);
+
+	return ret;
+}

--- a/projects/ltc4296/src/examples/basic/basic_example.h
+++ b/projects/ltc4296/src/examples/basic/basic_example.h
@@ -1,0 +1,44 @@
+/***************************************************************************//**
+ *   @file   basic_example.h
+ *   @brief  Basic example header file for ltc4296 project.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __BASIC_EXAMPLE_H__
+#define __BASIC_EXAMPLE_H__
+
+int basic_example_main();
+
+#endif /* __BASIC_EXAMPLE_H__ */

--- a/projects/ltc4296/src/examples/examples_src.mk
+++ b/projects/ltc4296/src/examples/examples_src.mk
@@ -1,0 +1,5 @@
+ifeq (y,$(strip $(BASIC_EXAMPLE)))
+CFLAGS += -DBASIC_EXAMPLE=1
+SRCS += $(PROJECT)/src/examples/basic/basic_example.c
+INCS += $(PROJECT)/src/examples/basic/basic_example.h
+endif

--- a/projects/ltc4296/src/platform/maxim/main.c
+++ b/projects/ltc4296/src/platform/maxim/main.c
@@ -1,0 +1,66 @@
+/***************************************************************************//**
+ *   @file   main.c
+ *   @brief  Main file for Maxim platform of ltc4296 project.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "platform_includes.h"
+#include "common_data.h"
+#include "no_os_error.h"
+
+#ifdef BASIC_EXAMPLE
+#include "basic_example.h"
+#endif
+
+int main()
+{
+	int ret = -EINVAL;
+
+	struct no_os_uart_desc *uart_desc;
+
+	ret = no_os_uart_init(&uart_desc, &ltc4296_uart_ip);
+	if (ret)
+		return ret;
+
+	no_os_uart_stdio(uart_desc);
+	ret = basic_example_main();
+	no_os_uart_remove(uart_desc);
+
+#if (BASIC_EXAMPLE == 0)
+#error At least one example has to be selected using y value in Makefile.
+#endif
+
+	return ret;
+}

--- a/projects/ltc4296/src/platform/maxim/parameters.c
+++ b/projects/ltc4296/src/platform/maxim/parameters.c
@@ -1,0 +1,47 @@
+/***************************************************************************//**
+ *   @file   parameters.c
+ *   @brief  Definition of Maxim platform data used by ltc4296 project.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "parameters.h"
+
+struct max_uart_init_param ltc4296_uart_extra = {
+	.flow = UART_FLOW_DIS,
+};
+
+struct max_spi_init_param ltc4296_spi_extra = {
+	.vssel = MXC_GPIO_VSSEL_VDDIOH
+};

--- a/projects/ltc4296/src/platform/maxim/parameters.h
+++ b/projects/ltc4296/src/platform/maxim/parameters.h
@@ -1,0 +1,63 @@
+/***************************************************************************//**
+ *   @file   parameters.h
+ *   @brief  Definition of Maxim platform data used by ltc4296 project.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
+
+#include "maxim_irq.h"
+#include "maxim_spi.h"
+#include "maxim_gpio.h"
+#include "maxim_uart.h"
+#include "maxim_uart_stdio.h"
+
+#define UART_DEVICE_ID		0
+#define UART_BAUDRATE		57600
+#define	UART_OPS		&max_uart_ops
+#define UART_EXTRA		&ltc4296_uart_extra
+
+#define SPI_DEVICE_ID   	0
+#define SPI_BAUDRATE    	50000
+#define SPI_CS          	1
+#define SPI_OPS        	 	&max_spi_ops
+#define SPI_EXTRA       	&ltc4296_spi_extra
+
+extern struct max_uart_init_param ltc4296_uart_extra;
+extern struct max_spi_init_param ltc4296_spi_extra;
+extern struct max_gpio_init_param ltc4296_pg_alt_extra;
+
+#endif /* __PARAMETERS_H__ */

--- a/projects/ltc4296/src/platform/maxim/platform_src.mk
+++ b/projects/ltc4296/src/platform/maxim/platform_src.mk
@@ -1,0 +1,16 @@
+INCS += $(PLATFORM_DRIVERS)/maxim_gpio.h      \
+        $(PLATFORM_DRIVERS)/maxim_gpio_irq.h  \
+        $(PLATFORM_DRIVERS)/maxim_irq.h       \
+        $(PLATFORM_DRIVERS)/../common/maxim_dma.h       \
+        $(PLATFORM_DRIVERS)/maxim_spi.h       \
+        $(PLATFORM_DRIVERS)/maxim_uart.h      \
+        $(PLATFORM_DRIVERS)/maxim_uart_stdio.h
+
+SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c     \
+        $(PLATFORM_DRIVERS)/maxim_gpio.c      \
+        $(PLATFORM_DRIVERS)/maxim_gpio_irq.c  \
+        $(PLATFORM_DRIVERS)/maxim_irq.c       \
+        $(PLATFORM_DRIVERS)/../common/maxim_dma.c       \
+        $(PLATFORM_DRIVERS)/maxim_spi.c       \
+        $(PLATFORM_DRIVERS)/maxim_uart.c      \
+        $(PLATFORM_DRIVERS)/maxim_uart_stdio.c

--- a/projects/ltc4296/src/platform/platform_includes.h
+++ b/projects/ltc4296/src/platform/platform_includes.h
@@ -1,0 +1,46 @@
+/***************************************************************************//**
+ *   @file   platform_includes.h
+ *   @brief  Includes for used platforms used by ltc4296 project.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PLATFORM_INCLUDES_H__
+#define __PLATFORM_INCLUDES_H__
+
+#ifdef MAXIM_PLATFORM
+#include "maxim/parameters.h"
+#endif
+
+#endif /* __PLATFORM_INCLUDES_H__ */


### PR DESCRIPTION
## Pull Request Description

The LTC4296-1 is an IEEE 802.3cg-compliant, five port, single-pair
power over Ethernet (SPoE), power sourcing equipment (PSE)
controller. SPoE simplifies system design and installation with
standardized power and Ethernet data over a single-pair cable. The
LTC4296-1 is designed for interoperability with 802.3cg powered
devices (PDs) in 24 V or 54 V systems.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
