### PR TITLE
README.rst: drop redundant ToC string

### DIFF
--- a/projects/ad7091r8-sdz/README.rst
+++ b/projects/ad7091r8-sdz/README.rst
@@ -1,11 +1,7 @@
 Evaluating AD7091R-2/-4/-8 Devices
 ==================================
 
-
-Contents
---------
-
-.. contents:: Table of Contents
+.. contents::
     :depth: 3
 
 Supported Devices

--- a/projects/ad7616-st/README.rst
+++ b/projects/ad7616-st/README.rst
@@ -1,10 +1,7 @@
 Evaluating AD7616 on SDP-K1
 ===========================
 
-Contents
---------
-
-.. contents:: Table of Contents
+.. contents::
     :depth: 3
 
 Supported Evaluation Boards

--- a/projects/adp1050/README.rst
+++ b/projects/adp1050/README.rst
@@ -1,11 +1,7 @@
 Evaluating the ADP1050
 ======================
 
-
-Contents
---------
-
-.. contents:: Table of Contents
+.. contents::
 	:depth: 3
 
 Supported Evaluation Boards

--- a/projects/eval-adis1646x/README.rst
+++ b/projects/eval-adis1646x/README.rst
@@ -1,11 +1,7 @@
 Evaluating the ADIS1646X Family
 ===============================
 
-
-Contents
---------
-
-.. contents:: Table of Contents
+.. contents::
     :depth: 3
 
 Supported Evaluation Boards

--- a/projects/eval-adis1647x/README.rst
+++ b/projects/eval-adis1647x/README.rst
@@ -1,11 +1,7 @@
 Evaluating the ADIS1647X Family
 ===============================
 
-
-Contents
---------
-
-.. contents:: Table of Contents
+.. contents::
     :depth: 3
 
 Supported Evaluation Boards

--- a/projects/eval-adis1650x/README.rst
+++ b/projects/eval-adis1650x/README.rst
@@ -1,11 +1,7 @@
 Evaluating the ADIS1650X Family
 ===============================
 
-
-Contents
---------
-
-.. contents:: Table of Contents
+.. contents::
     :depth: 3
 
 Supported Evaluation Boards

--- a/projects/eval-adis1657x/README.rst
+++ b/projects/eval-adis1657x/README.rst
@@ -1,11 +1,7 @@
 Evaluating the ADIS1657X Family
 ===============================
 
-
-Contents
---------
-
-.. contents:: Table of Contents
+.. contents::
     :depth: 3
 
 Supported Evaluation Boards

--- a/projects/max14914/README.rst
+++ b/projects/max14914/README.rst
@@ -1,11 +1,7 @@
 Evaluating the MAX14914
 =======================
 
-
-Contents
---------
-
-.. contents:: Table of Contents
+.. contents::
 	:depth: 3
 
 Supported Evaluation Boards

--- a/projects/max14919/README.rst
+++ b/projects/max14919/README.rst
@@ -1,11 +1,7 @@
 Evaluating the MAX14919
 =======================
 
-
-Contents
---------
-
-.. contents:: Table of Contents
+.. contents::
 	:depth: 3
 
 Supported Evaluation Boards

--- a/projects/max2201x/README.rst
+++ b/projects/max2201x/README.rst
@@ -1,11 +1,7 @@
 Evaluating the MAX2201X
 =======================
 
-
-Contents
---------
-
-.. contents:: Table of Contents
+.. contents::
 	:depth: 3
 
 Supported Evaluation Boards


### PR DESCRIPTION
## Pull Request Description

The syntax used to create Table of Contents for .rst files does not require adding extra string.

Both sphinx generated files and github previews parse this approach in an odd/redundant manner since all these filest already contain a header named "Contents" which is generated via syntax.

Example on how it currently looks:
![image](https://github.com/analogdevicesinc/no-OS/assets/26061529/d9b3b3f3-1fd8-461e-a6e0-1805bac8e007)

After this patch the automatically generated "Contents" string will be displayed only.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
