### PR TITLE
drivers: platform: maxim: Fix DMA remove

### DIFF
--- a/drivers/platform/maxim/common/maxim_dma.c
+++ b/drivers/platform/maxim/common/maxim_dma.c
@@ -135,9 +135,7 @@ static int maxim_dma_remove(struct no_os_dma_desc *desc)
 	MAX_DMA->cn &= MAX_DMA_IRQ_EN_ALL_CH;
 	no_os_irq_ctrl_remove(desc->irq_ctrl);
 
-	for (i = 0; i < desc->num_ch; i++)
-		no_os_free(&desc->channels[i]);
-
+	no_os_free(desc->channels);
 	no_os_free(desc);
 	dma_descriptor = NULL;
 


### PR DESCRIPTION
## Pull Request Description

no_os_free() only has to be called once for the entire channels array, otherwise, a double free will occur.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
