### PR TITLE
drivers: platform: maxim: add uart_stdio for max32670

### DIFF
--- a/drivers/platform/maxim/max32670/maxim_uart_stdio.c
+++ b/drivers/platform/maxim/max32670/maxim_uart_stdio.c
@@ -1,0 +1,138 @@
+/***************************************************************************//**
+ *   @file   maxim_uart_stdio.c
+ *   @brief  Implementation file of MAX32660 UART driver stdout/stdin redirection.
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+ *
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "maxim_uart_stdio.h"
+
+#include "mxc_sys.h"
+#include "no_os_uart.h"
+#include "uart.h"
+
+#include <unistd.h>
+#include <sys/stat.h>
+
+#define STDIN_FILENO	0   /**> Definition of stdin */
+#define STDOUT_FILENO   1   /**> Definition of stdout */
+#define STDERR_FILENO   2   /**> Definition of stderr */
+
+static struct no_os_uart_desc *guart = NULL;
+
+void no_os_uart_stdio(struct no_os_uart_desc *desc)
+{
+	if (!desc)
+		return;
+	guart = desc;
+
+	setvbuf(stdout, NULL, _IONBF, 0);
+}
+
+int _close(int file)
+{
+	if (file >= STDIN_FILENO && file <= STDERR_FILENO)
+		return 0;
+
+	errno = EBADF;
+	return -1;
+}
+int _isatty(int file)
+{
+	if (file >= STDIN_FILENO && file <= STDERR_FILENO)
+		return 1;
+
+	errno = EBADF;
+	return 0;
+}
+int _lseek(int file, off_t offset, int whence)
+{
+	(void) file;
+	(void) offset;
+	(void) whence;
+
+	errno = EBADF;
+	return -1;
+}
+int _fstat(int file, struct stat *st)
+{
+	if (file >= STDIN_FILENO && file <= STDERR_FILENO) {
+		st->st_mode = S_IFCHR;
+		return 0;
+	}
+
+	errno = EBADF;
+	return 0;
+}
+
+int _read(int file, char *ptr, int len)
+{
+	int ret;
+
+	if (file == STDIN_FILENO) {
+		ret = no_os_uart_read(guart, (uint8_t *)ptr, len);
+		if (ret < 0) {
+			errno = -ret;
+			return -1;
+		}
+
+		return ret;
+	}
+	errno = EBADF;
+	return -1;
+}
+
+int _write(int file, char *ptr, int len)
+{
+	int ret;
+
+	if (file == STDOUT_FILENO || file == STDERR_FILENO) {
+		ret = no_os_uart_write(guart, (uint8_t *)ptr, len);
+		if (ret < 0) {
+			errno = -ret;
+			return -1;
+		}
+
+		return ret;
+	}
+	errno = EBADF;
+	return -1;
+}

--- a/drivers/platform/maxim/max32670/maxim_uart_stdio.h
+++ b/drivers/platform/maxim/max32670/maxim_uart_stdio.h
@@ -1,0 +1,53 @@
+/***************************************************************************//**
+ *   @file   maxim_uart_stdio.h
+ *   @brief  Header file for UART driver stdout/stdin redirection.
+ *   @author Ciprian Regus (ciprian.regus@analog.com)
+********************************************************************************
+ * Copyright 2022(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef MAXIM_UART_STDIO_H_
+#define MAXIM_UART_STDIO_H_
+
+#include <sys/stat.h>
+#include "no_os_uart.h"
+
+void no_os_uart_stdio(struct no_os_uart_desc *);
+int _isatty(int);
+int _write(int, char *, int);
+int _close(int);
+int _lseek(int, off_t, int);
+int _read(int, char *, int);
+int _fstat(int, struct stat *);
+
+#endif


### PR DESCRIPTION
## Pull Request Description

This PR is to have the maxim_uart_stdio available for max32670 platform. Upon inspection, the same file is used for all maxim platforms and so the same file is used for max32670.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
