### PR TITLE
Fix MAX32690APARD TCP Example Static IP Configuration

### DIFF
--- a/projects/apard32690/Makefile
+++ b/projects/apard32690/Makefile
@@ -4,6 +4,8 @@ APARD32690_ECHO_SERVER_EXAMPLE = y
 PLATFORM=maxim
 TARGET=max32690
 
+APARD32690_STATIC_IP=y
+
 include ../../tools/scripts/generic_variables.mk
 
 include src.mk
@@ -15,7 +17,7 @@ APARD32690_STATIC_IP = n
 endif
 
 ifeq (y,$(strip $(APARD32690_STATIC_IP)))
-NO_OS_IP=169.254.97.40
-NO_OS_NETMASK=255.255.255.0
-NO_OS_GATEWAY=0.0.0.0
+NO_OS_IP=\"169.254.97.40\"
+NO_OS_NETMASK=\"255.255.255.0\"
+NO_OS_GATEWAY=\"0.0.0.0\"
 endif

--- a/projects/apard32690/README.rst
+++ b/projects/apard32690/README.rst
@@ -18,7 +18,7 @@ This example is meant to print "Hello world" over UART0. Make sure to have jumpe
 
 2. tcp_echo_server (selected by default) - may be selected by setting the APARD32690_ECHO_SERVER_EXAMPLE = y (and all the other examples to n) in the main Makefile.
 This will start a TCP server using the interface ADIN1110 is connected to (IP: 169.254.97.40 port: 10000). It will reply back to the connected client with the
-characters it receives.
+characters it receives. The actual IP address, netmask, and gateway used at runtime are printed on the serial port connected through the debug adapter. 
 
 The host running the client may require network settings in order to communicate with a device using the 169.254.97.40 IP. These usually include adding a static route
 for the said IP address.

--- a/projects/apard32690/src/examples/examples_src.mk
+++ b/projects/apard32690/src/examples/examples_src.mk
@@ -25,7 +25,7 @@ SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c	\
 	$(PLATFORM_DRIVERS)/maxim_irq.c		\
 	$(PLATFORM_DRIVERS)/maxim_gpio.c	\
 	$(PLATFORM_DRIVERS)/maxim_spi.c		\
-	$(PLATFORM_DRIVERS)/maxim_dma.c		\
+	$(PLATFORM_DRIVERS)/../common/maxim_dma.c		\
 	$(PLATFORM_DRIVERS)/maxim_timer.c	\
 	$(PLATFORM_DRIVERS)/maxim_init.c	\
 	$(PLATFORM_DRIVERS)/maxim_uart.c	\
@@ -34,7 +34,7 @@ SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c	\
 INCS += $(PLATFORM_DRIVERS)/maxim_irq.h		\
 	$(PLATFORM_DRIVERS)/maxim_uart.h	\
 	$(PLATFORM_DRIVERS)/maxim_timer.h	\
-	$(PLATFORM_DRIVERS)/maxim_dma.h	\
+	$(PLATFORM_DRIVERS)/../common/maxim_dma.h	\
 	$(PLATFORM_DRIVERS)/maxim_gpio.h	\
 	$(PLATFORM_DRIVERS)/maxim_spi.h		\
 	$(PLATFORM_DRIVERS)/maxim_uart_stdio.h

--- a/projects/apard32690/src/examples/examples_src.mk
+++ b/projects/apard32690/src/examples/examples_src.mk
@@ -2,6 +2,9 @@ ifeq (y,$(strip $(APARD32690_ECHO_SERVER_EXAMPLE)))
 CFLAGS += -DAPARD32690_ECHO_SERVER_EXAMPLE=1
 LIBRARIES += lwip
 CFLAGS += -DNO_OS_STATIC_IP
+CFLAGS += -DNO_OS_IP=${NO_OS_IP}
+CFLAGS += -DNO_OS_NETMASK=${NO_OS_NETMASK}
+CFLAGS += -DNO_OS_GATEWAY=${NO_OS_GATEWAY}
 CFLAGS += -DNO_OS_LWIP_NETWORKING
 INCS += $(INCLUDE)/no_os_crc8.h
 INCS += $(DRIVERS)/net/adin1110/adin1110.h
@@ -22,7 +25,7 @@ SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c	\
 	$(PLATFORM_DRIVERS)/maxim_irq.c		\
 	$(PLATFORM_DRIVERS)/maxim_gpio.c	\
 	$(PLATFORM_DRIVERS)/maxim_spi.c		\
-	$(PLATFORM_DRIVERS)/../common/maxim_dma.c		\
+	$(PLATFORM_DRIVERS)/maxim_dma.c		\
 	$(PLATFORM_DRIVERS)/maxim_timer.c	\
 	$(PLATFORM_DRIVERS)/maxim_init.c	\
 	$(PLATFORM_DRIVERS)/maxim_uart.c	\
@@ -31,7 +34,7 @@ SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c	\
 INCS += $(PLATFORM_DRIVERS)/maxim_irq.h		\
 	$(PLATFORM_DRIVERS)/maxim_uart.h	\
 	$(PLATFORM_DRIVERS)/maxim_timer.h	\
-	$(PLATFORM_DRIVERS)/../common/maxim_dma.h	\
+	$(PLATFORM_DRIVERS)/maxim_dma.h	\
 	$(PLATFORM_DRIVERS)/maxim_gpio.h	\
 	$(PLATFORM_DRIVERS)/maxim_spi.h		\
 	$(PLATFORM_DRIVERS)/maxim_uart_stdio.h


### PR DESCRIPTION
## Pull Request Description

Fix for Issue #2172 . Static IP configuration for MAX32690APARD example does not function as described in the documentation. Reason is due to some mishandling of Makefile scripts and preprocessor macros for IP addresses. Fix requires no code changes, only Makefile + README changes. 

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
