### PR TITLE
drivers: api: no_os_timer: Add const qualifier to timer init param

### DIFF
--- a/drivers/api/no_os_timer.c
+++ b/drivers/api/no_os_timer.c
@@ -61,7 +61,7 @@ static void *timer_mutex_table[TIMER_MAX_TABLE + 1];
  * @return 0 in case of success, negative error code otherwise
  */
 int32_t no_os_timer_init(struct no_os_timer_desc **desc,
-			 struct no_os_timer_init_param *param)
+			 const struct no_os_timer_init_param *param)
 {
 	int32_t ret;
 

--- a/drivers/platform/aducm3029/aducm3029_timer.c
+++ b/drivers/platform/aducm3029/aducm3029_timer.c
@@ -108,7 +108,7 @@ static void aducm3029_tmr_callback(void *param, uint32_t tmr_event, void *arg)
  * @return 0 in case of success, -1 otherwise.
  */
 int32_t aducm3029_timer_init(struct no_os_timer_desc **desc,
-			     struct no_os_timer_init_param *param)
+			     const struct no_os_timer_init_param *param)
 {
 	struct no_os_timer_desc *ldesc;
 	struct aducm_timer_desc *aducm_desc;

--- a/drivers/platform/generic/generic_timer.c
+++ b/drivers/platform/generic/generic_timer.c
@@ -57,7 +57,7 @@
  * @return 0 in case of success, negative error code otherwise
  */
 int32_t generic_timer_init(struct no_os_timer_desc **desc,
-			   struct no_os_timer_init_param *param)
+			   const struct no_os_timer_init_param *param)
 {
 	NO_OS_UNUSED_PARAM(desc);
 	NO_OS_UNUSED_PARAM(param);

--- a/drivers/platform/linux/linux_timer.c
+++ b/drivers/platform/linux/linux_timer.c
@@ -73,7 +73,7 @@ struct linux_timer_desc {
  * @return 0 in case of success, negative errno error codes otherwise.
  */
 int linux_timer_init(struct no_os_timer_desc **desc,
-		     struct no_os_timer_init_param *param)
+		     const struct no_os_timer_init_param *param)
 {
 	struct no_os_timer_desc *descriptor;
 	struct linux_timer_desc *linux_desc;

--- a/drivers/platform/maxim/max32650/maxim_timer.c
+++ b/drivers/platform/maxim/max32650/maxim_timer.c
@@ -100,7 +100,7 @@ static int _get_prescaler(uint32_t div, mxc_tmr_pres_t *prescaler)
  * @return 0 in case of success, negative errno error codes otherwise.
  */
 int max_timer_init(struct no_os_timer_desc **desc,
-		   struct no_os_timer_init_param *param)
+		   const struct no_os_timer_init_param *param)
 {
 	int ret;
 	uint32_t clk_div;

--- a/drivers/platform/maxim/max32655/maxim_timer.c
+++ b/drivers/platform/maxim/max32655/maxim_timer.c
@@ -98,7 +98,7 @@ static int _get_prescaler(uint32_t div, mxc_tmr_pres_t *prescaler)
  * @return 0 in case of success, negative errno error codes otherwise.
  */
 int max_timer_init(struct no_os_timer_desc **desc,
-		   struct no_os_timer_init_param *param)
+		   const struct no_os_timer_init_param *param)
 {
 	int ret;
 	mxc_tmr_pres_t prescaler;

--- a/drivers/platform/maxim/max32660/maxim_timer.c
+++ b/drivers/platform/maxim/max32660/maxim_timer.c
@@ -98,7 +98,7 @@ static int _get_prescaler(uint32_t div, mxc_tmr_pres_t *prescaler)
  * @return 0 in case of success, negative errno error codes otherwise.
  */
 int max_timer_init(struct no_os_timer_desc **desc,
-		   struct no_os_timer_init_param *param)
+		   const struct no_os_timer_init_param *param)
 {
 	int ret;
 	uint32_t clk_div;

--- a/drivers/platform/maxim/max32665/maxim_timer.c
+++ b/drivers/platform/maxim/max32665/maxim_timer.c
@@ -98,7 +98,7 @@ static int _get_prescaler(uint32_t div, mxc_tmr_pres_t *prescaler)
  * @return 0 in case of success, negative errno error codes otherwise.
  */
 int max_timer_init(struct no_os_timer_desc **desc,
-		   struct no_os_timer_init_param *param)
+		   const struct no_os_timer_init_param *param)
 {
 	int ret;
 	uint32_t clk_div;

--- a/drivers/platform/maxim/max32690/maxim_timer.c
+++ b/drivers/platform/maxim/max32690/maxim_timer.c
@@ -92,7 +92,7 @@ static int _get_prescaler(uint32_t div, mxc_tmr_pres_t *prescaler)
  * @return 0 in case of success, negative errno error codes otherwise.
  */
 int max_timer_init(struct no_os_timer_desc **desc,
-		   struct no_os_timer_init_param *param)
+		   const struct no_os_timer_init_param *param)
 {
 	int ret;
 	mxc_tmr_pres_t prescaler;

--- a/drivers/platform/maxim/max78000/maxim_timer.c
+++ b/drivers/platform/maxim/max78000/maxim_timer.c
@@ -98,7 +98,7 @@ static int _get_prescaler(uint32_t div, mxc_tmr_pres_t *prescaler)
  * @return 0 in case of success, negative errno error codes otherwise.
  */
 int max_timer_init(struct no_os_timer_desc **desc,
-		   struct no_os_timer_init_param *param)
+		   const struct no_os_timer_init_param *param)
 {
 	int ret;
 	mxc_tmr_pres_t prescaler;

--- a/drivers/platform/xilinx/xilinx_timer.c
+++ b/drivers/platform/xilinx/xilinx_timer.c
@@ -302,7 +302,7 @@ int32_t xilinx_timer_get_elapsed_time_nsec(struct no_os_timer_desc *desc,
  * @return 0 in case of success, -1 otherwise
  */
 int32_t xilinx_timer_init(struct no_os_timer_desc **desc,
-			  struct no_os_timer_init_param *param)
+			  const struct no_os_timer_init_param *param)
 {
 	int32_t ret;
 	struct no_os_timer_desc *dev;

--- a/include/no_os_timer.h
+++ b/include/no_os_timer.h
@@ -133,7 +133,7 @@ struct no_os_timer_platform_ops {
 
 /* Initialize hardware timer and the handler structure associated with it. */
 int32_t no_os_timer_init(struct no_os_timer_desc **desc,
-			 struct no_os_timer_init_param *param);
+			 const struct no_os_timer_init_param *param);
 
 /* Free the memory allocated by timer_setup(). */
 int32_t no_os_timer_remove(struct no_os_timer_desc *desc);


### PR DESCRIPTION
## Pull Request Description

Some platforms are missing the const qualifier in timer_init APIs. This commit adds the qualifier where needed, to fix compilation warnings.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
