### PR TITLE
Don't overwrite .vscode config if it already exists

### DIFF
--- a/tools/scripts/maxim.mk
+++ b/tools/scripts/maxim.mk
@@ -137,10 +137,17 @@ $(PLATFORM)_project:
 	$(MAKE) --no-print-directory $(PROJECT_TARGET)_configure
 
 $(PROJECT_TARGET)_configure:
-	$(file > $(CPP_PROP_JSON),$(CPP_FINAL_CONTENT))
-	$(file > $(SETTINGSJSON),$(VSC_SET_CONTENT))
-	$(file > $(LAUNCHJSON),$(VSC_LAUNCH_CONTENT))
-	$(file > $(TASKSJSON),$(VSC_TASKS_CONTENT))
+	$(file > $(CPP_PROP_JSON).default,$(CPP_FINAL_CONTENT))
+	$(file > $(SETTINGSJSON).default,$(VSC_SET_CONTENT))
+	$(file > $(LAUNCHJSON).default,$(VSC_LAUNCH_CONTENT))
+	$(file > $(TASKSJSON).default,$(VSC_TASKS_CONTENT))
+
+	[ -s $(CPP_PROP_JSON) ]	&& echo '.vscode/c_cpp_properties.json already exists, not overwriting'	|| cp $(CPP_PROP_JSON).default $(CPP_PROP_JSON)
+	[ -s $(SETTINGSJSON) ] 	&& echo '.vscode/settings.json already exists, not overwriting'			|| cp $(SETTINGSJSON).default $(SETTINGSJSON)
+	[ -s $(LAUNCHJSON) ] 	&& echo '.vscode/launch.json already exists, not overwriting'			|| cp $(LAUNCHJSON).default $(LAUNCHJSON)
+	[ -s $(TASKSJSON) ] 	&& echo '.vscode/tasks.json already exists, not overwriting'			|| cp $(TASKSJSON).default $(TASKSJSON)
+
+	rm $(CPP_PROP_JSON).default $(SETTINGSJSON).default $(LAUNCHJSON).default $(TASKSJSON).default
 
 $(PLATFORM)_sdkopen:
 	code $(PROJECT)

--- a/tools/scripts/stm32.mk
+++ b/tools/scripts/stm32.mk
@@ -103,10 +103,19 @@ $(PROJECT)_configure:
 	sed -i  's/HAL_NVIC_EnableIRQ(\EXTI/\/\/ HAL_NVIC_EnableIRQ\(EXTI/' $(PROJECT_BUILD)/Src/generated_main.c $(HIDE)
 	$(shell python $(PLATFORM_TOOLS)/exti_script.py $(ASM_SRCS) $(EXTI_GEN_FILE))
 	$(call copy_file, $(EXTI_GEN_FILE), $(PROJECT_BUILD)/Src/stm32_gpio_irq_generated.c) $(HIDE)
-	$(file > $(CPP_PROP_JSON),$(CPP_FINAL_CONTENT))
-	$(file > $(SETTINGSJSON),$(VSC_SET_CONTENT))
-	$(file > $(LAUNCHJSON),$(VSC_LAUNCH_CONTENT))
-	$(file > $(TASKSJSON),$(VSC_TASKS_CONTENT))
+
+	$(file > $(CPP_PROP_JSON).default,$(CPP_FINAL_CONTENT))
+	$(file > $(SETTINGSJSON).default,$(VSC_SET_CONTENT))
+	$(file > $(LAUNCHJSON).default,$(VSC_LAUNCH_CONTENT))
+	$(file > $(TASKSJSON).default,$(VSC_TASKS_CONTENT))
+
+	[ -s $(CPP_PROP_JSON) ]	&& echo '.vscode/c_cpp_properties.json already exists, not overwriting'	|| cp $(CPP_PROP_JSON).default $(CPP_PROP_JSON)
+	[ -s $(SETTINGSJSON) ] 	&& echo '.vscode/settings.json already exists, not overwriting'			|| cp $(SETTINGSJSON).default $(SETTINGSJSON)
+	[ -s $(LAUNCHJSON) ] 	&& echo '.vscode/launch.json already exists, not overwriting'			|| cp $(LAUNCHJSON).default $(LAUNCHJSON)
+	[ -s $(TASKSJSON) ] 	&& echo '.vscode/tasks.json already exists, not overwriting'			|| cp $(TASKSJSON).default $(TASKSJSON)
+
+	rm $(CPP_PROP_JSON).default $(SETTINGSJSON).default $(LAUNCHJSON).default $(TASKSJSON).default
+
 	$(MAKE) $(BINARY).openocd-cmsis
 	$(MAKE) $(BINARY).openocd
 


### PR DESCRIPTION
## Pull Request Description

(Referencing issue #2181, the following content is copied from there)

### Behaviour

The `$(PROJECT_TARGET)_configure` targets in [tools/scripts/stm32.mk](https://github.com/analogdevicesinc/no-OS/blob/main/tools/scripts/stm32.mk) and [tools/scripts/maxim.mk](https://github.com/analogdevicesinc/no-OS/blob/main/tools/scripts/maxim.mk) use the [GNU Make `file` function](https://www.gnu.org/software/make/manual/html_node/File-Function.html) to set up a default VS Code configuration for projects, with no regard to the contents of those files.

https://github.com/analogdevicesinc/no-OS/blob/3cb5f58f6815c4fa63b732bb5072d42483ad6f81/tools/scripts/maxim.mk#L139-L143

For context, the content of the files is generated in [vsc_intellisense.mk](https://github.com/analogdevicesinc/no-OS/blob/main/tools/scripts/vsc_intellisense.mk), [vsc_openocd_debug.mk](https://github.com/analogdevicesinc/no-OS/blob/main/tools/scripts/vsc_openocd_debug.mk), and [vsc_tasks.mk](https://github.com/analogdevicesinc/no-OS/blob/main/tools/scripts/vsc_tasks.mk).

### Impact

With the current makefiles, one may not change their VS Code config without it being reset to the no-OS defaults during the next build, which greatly hinders development. For instance, my WSL dev setup requires changing the gdb options in `launch.json`, but doing so is futile because the makefile resets my changes when building.

### Options

I suggest (this PR) adding a condition to only write to these files if they are empty or don't exist (i.e., during project setup), but keep their current content otherwise, to allow for customization of the config.

Despite some effort, I didn't manage to do it using just GNU Make syntax, but rather by changing the `file` call from `filename.json` to `filename.json.default`, and having some shell commands conditionally copy `filename.json.default` to `filename.json` if the latter doesn't exist. Finally, shell commands remove the `.default` files to keep the directory tidy.


## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
