### PR TITLE
drivers:adc: Add ad405x no-OS drivers

### DIFF
--- a/doc/sphinx/source/drivers/ad405x.rst
+++ b/doc/sphinx/source/drivers/ad405x.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../drivers/adc/ad405x/README.rst

--- a/doc/sphinx/source/drivers_doc.rst
+++ b/doc/sphinx/source/drivers_doc.rst
@@ -17,6 +17,7 @@ ANALOG TO DIGITAL CONVERTERS
    :maxdepth: 1
 
    drivers/adm1177
+   drivers/ad405x
 
 AXI CORES
 =========

--- a/drivers/adc/ad405x/README.rst
+++ b/drivers/adc/ad405x/README.rst
@@ -1,0 +1,115 @@
+AD405X no-OS Driver
+===================
+
+Supported Devices
+-----------------
+
+`AD4052 <https://www.analog.com/AD4052>`_
+
+Overview
+--------
+
+The AD4052 is a low power, compact 16-bit successive approximation register (SAR) analog-to-digital converter (ADC) designed
+for battery powered precision measurement and monitoring applications. The AD4052 feature set supports event-driven programming
+for dynamic tradeoff between system power and precision. Using
+a patented, power efficient window comparator, the AD4052 autonomously monitors signals while the host sleeps. The programmable
+averaging filter enables on-demand high resolution measurements
+for optimizing precision for the power consumed.
+
+The AD4052 includes AFE control signals to minimize the complexity of host timers. The control signals automate the power cycling
+of the AFE relative to ADC sampling to reduce system power while
+minimizing settling error artifacts. The Easy Drive analog inputs
+enables compact and low power signal conditioning circuitry by
+reducing the dependence on high-speed ADC driver amplifiers. The
+small 3.4 pF sampling capacitors result in low dynamic and average
+input current, broadening compatibility with low power amplifiers or
+direct sensor interfacing. The AD4052 wide common mode input
+range supports both differential and single-ended input signals.
+
+The AD4052 features a 4-wire SPI with a dedicated CNV input.
+Cyclic redundancy check (CRC) is available on all interface read
+and write operations and internal memory to ensure reliable device
+configuration and operation.
+
+AD405X Device Configuration
+---------------------------
+
+Driver Initialization
+---------------------
+
+In order to be able to use the device, you will have to provide the support for
+the communication protocol (SPI) as well as 3 external GPIOs for the CNV pin and two 
+general-purpose input/output pins (GP0 and GP1).
+
+The first API to be called is **ad405x_init**. Make sure that it returns 0,
+which means that the driver was intialized correctly.
+
+GPIO Configuration
+-----------------------------
+
+The device has two general purpose input/output pins GPIO controller. 
+General Purpose Output 1, GP1, is a digital output hat can be configured as multiple device status signals.
+General Purpose Input/Output 0. GP0 is a digital input/output that can be configured as multiple device
+control or status signals.
+In the driver files the **ad405x_set_gp_mode** can be found and used to choose the specific signal for the GPIOs.
+
+Channel Configuration
+---------------------
+
+Channel data can be fetched with **ad405x_read_val**.
+
+The channel data format can be set using **ad405x_set_data_format**
+
+Channel operation mode can also be configured using **ad405x_set_operating_mode**.
+
+Soft Reset
+----------
+
+The device can be soft reseted by using **ad405x_soft_reset**.
+
+MAX2201X Driver Initialization Example
+--------------------------------------
+
+.. code-block:: bash
+
+	struct ad405x_dev *ad405x;
+	struct no_os_spi_init_param spi_init_params = {
+		.device_id = 0,
+		.max_speed_hz = 22500000,
+		.mode = NO_OS_SPI_MODE_0,
+		.chip_select = 15,
+		.bit_order = NO_OS_SPI_BIT_ORDER_MSB_FIRST,
+		.platform_ops = &spi_ops,
+		.extra = &spi_extra_init_params,
+	};
+	struct no_os_gpio_init_param gpio_cnv_param = {
+		.port = 0,
+		.number = 10,
+		.platform_ops = &gpio_ops,
+		.extra = &cnv_extra_init_params
+	};
+	struct no_os_gpio_init_param gpio_gpio0_param = {
+		.port = 1,
+		.number = 15,
+		.platform_ops = &gpio_ops,
+		.extra = &gp0_extra_init_params
+	};
+	struct no_os_gpio_init_param gpio_gpio1_param = {
+		.port = 6,
+		.number = 11,
+		.platform_ops = &gpio_ops,
+		.extra = &gp1_extra_init_params
+	};
+	struct ad405x_init_param ad405x_init_params = {
+		.spi_init = &spi_init_params,
+		.active_device = 0,
+		.gpio_cnv = &gpio_cnv_param,
+		.gpio_gpio0 = &gpio_gpio0_param,
+		.gpio_gpio1 = &gpio_gpio1_param,
+		.rate = AD405X_2_MSPS,
+		.filter_length = AD405X_LENGTH_2,
+		.operation_mode = AD405X_CONFIG_MODE_OP
+	};
+	ret = ad405x_init(&ad405x, &ad405x_init_params);
+	if (ret)
+		goto error;

--- a/drivers/adc/ad405x/ad405x.c
+++ b/drivers/adc/ad405x/ad405x.c
@@ -1,0 +1,880 @@
+/********************************************************************************
+ *   @file   ad405x.c
+ *   @brief  Implementation of AD405X Driver.
+ *   @author George Mois (george.mois@analog.com)
+ *   @author Ribhu Das Purkayastha (ribhu.daspurkayastha@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <stdlib.h>
+#include <errno.h>
+#include "ad405x.h"
+#include "no_os_delay.h"
+#include "no_os_print_log.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+/*
+ * Reset pattern bytes.
+ */
+static const uint8_t reset_pattern_buff[18] = {
+	0xFF,
+	0xFF,
+	0xFF,
+	0xFF,
+	0xFF,
+	0xFE,
+	0xFF,
+	0xFF,
+	0xFF,
+	0xFF,
+	0xFF,
+	0xFE,
+	0xFF,
+	0xFF,
+	0xFF,
+	0xFF,
+	0xFF,
+	0xFE
+};
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+/******************************************************************************/
+
+/**
+ * @brief Write device register.
+ * @param dev- The device structure.
+ * @param reg_addr - The register address.
+ * @param reg_val - The data to be written.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad405x_write(struct ad405x_dev *dev, uint8_t reg_addr, uint8_t reg_val)
+{
+	uint8_t buff[2] = { 0 };
+
+	if (!dev)
+		return -EINVAL;
+
+	/* Should check if address on 15 bits and if reg is 16 bits. */
+
+	buff[0] = reg_addr;
+	buff[1] = reg_val;
+
+	return no_os_spi_write_and_read(dev->spi_desc, buff, 2);
+}
+
+/**
+ * @brief Read device register.
+ * @param dev - The device structure.
+ * @param reg_addr - The register address.
+ * @param reg_val - The data read from the register.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad405x_read(struct ad405x_dev *dev, uint8_t reg_addr, uint8_t *reg_val)
+{
+	int32_t ret;
+	uint8_t buff[2] = { 0 };
+
+	if (!dev)
+		return -EINVAL;
+
+	buff[0] = AD405X_SPI_READ | reg_addr;
+
+	ret = no_os_spi_write_and_read(dev->spi_desc, buff, 2);
+	if (ret)
+		return ret;
+
+	*reg_val = buff[1];
+
+	return 0;
+}
+
+/**
+ * @brief Update specific register bits.
+ * @param dev - The device structure.
+ * @param reg_addr - The register address.
+ * @param mask - Specific bits mask.
+ * @param reg_val - The data to be written.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad405x_update_bits(struct ad405x_dev *dev,
+		       uint8_t reg_addr,
+		       uint8_t mask,
+		       uint8_t reg_val)
+{
+	int ret;
+	uint8_t data;
+
+	if (!dev)
+		return -EINVAL;
+
+	ret = ad405x_read(dev, reg_addr, &data);
+	if (ret)
+		return ret;
+
+	data &= ~mask;
+	data |= reg_val;
+
+	return ad405x_write(dev, reg_addr, data);
+}
+
+/**
+ * @brief Send EXIT command.
+ * @param dev- The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad405x_exit_command(struct ad405x_dev *dev)
+{
+	int ret;
+	uint8_t buff[1] = { 0xA8 };
+
+	if (!dev)
+		return -EINVAL;
+
+	ret = no_os_spi_write_and_read(dev->spi_desc, buff, 1);
+	if (!ret)
+		dev->operation_mode = AD405X_CONFIG_MODE_OP;
+
+	return ret;
+}
+
+/**
+ * Send RESET pattern command.
+ * @param dev- The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad405x_reset_pattern_command(struct ad405x_dev *dev)
+{
+	int ret;
+
+	if (!dev)
+		return -EINVAL;
+
+	ret = no_os_spi_write_and_read(dev->spi_desc, reset_pattern_buff, 18);
+	if (!ret)
+		dev->operation_mode = AD405X_CONFIG_MODE_OP;
+
+	return ret;
+}
+
+/**
+ * @brief Software reset the device.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad405x_soft_reset(struct ad405x_dev *dev)
+{
+	int ret;
+
+	if (!dev)
+		return -EINVAL;
+
+	ret = ad405x_update_bits(dev,
+				 AD405X_REG_INTERFACE_CONFIG_A,
+				 AD405X_SW_RESET_MSK,
+				 AD405X_SW_RESET);
+	if (ret)
+		return ret;
+
+	return ad405x_update_bits(dev,
+				  AD405X_REG_INTERFACE_CONFIG_A,
+				  AD405X_SW_RESET_MSK,
+				  0);
+}
+
+/**
+ * @brief Enter ADC Mode
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad405x_set_adc_mode(struct ad405x_dev *dev)
+{
+	int ret;
+
+	if (!dev)
+		return -EINVAL;
+
+	/* Set ADC mode. */
+	ret = ad405x_update_bits(dev,
+				 AD405X_REG_ADC_MODES,
+				 AD405X_ADC_MODES_MSK,
+				 AD405X_SAMPLE_MODE);
+	if (ret)
+		return ret;
+
+	/* Enter ADC_MODE. */
+	ret = ad405x_update_bits(dev,
+				 AD405X_REG_MODE_SET,
+				 AD405X_ENTER_ADC_MODE_MSK,
+				 no_os_field_prep(AD405X_ENTER_ADC_MODE_MSK, 1));
+	if (ret)
+		return ret;
+
+	dev->operation_mode = AD405X_ADC_MODE_OP;
+
+	return 0;
+}
+
+/**
+ * @brief Enter Burst Averaging Mode
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad405x_set_burst_averaging_mode(struct ad405x_dev *dev)
+{
+	int ret;
+
+	if (!dev)
+		return -EINVAL;
+
+	/* Set Burst Averaging mode. */
+	ret = ad405x_update_bits(dev,
+				 AD405X_REG_ADC_MODES,
+				 AD405X_ADC_MODES_MSK,
+				 AD405X_BURST_AVERAGING_MODE);
+	if (ret)
+		return ret;
+
+	/* Enter ADC_MODE. */
+	ret = ad405x_update_bits(dev,
+				 AD405X_REG_MODE_SET,
+				 AD405X_ENTER_ADC_MODE_MSK,
+				 no_os_field_prep(AD405X_ENTER_ADC_MODE_MSK, 1));
+	if (ret)
+		return ret;
+
+	dev->operation_mode = AD405X_BURST_AVERAGING_MODE_OP;
+
+	return 0;
+}
+
+/**
+ * @brief Enter Config Mode
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad405x_set_config_mode(struct ad405x_dev *dev)
+{
+	int ret;
+
+	if (!dev)
+		return -EINVAL;
+
+	/* Send EXIT command . */
+	ret = ad405x_exit_command(dev);
+	if (ret)
+		return ret;
+
+	dev->operation_mode = AD405X_CONFIG_MODE_OP;
+
+	return 0;
+}
+
+/**
+ * @brief Set operation mode
+ * @param dev - The device structure.
+ * @param mode - Operation mode.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad405x_set_operation_mode(struct ad405x_dev *dev,
+			      enum ad405x_operation_mode mode)
+{
+	int ret;
+
+	if (!dev)
+		return -EINVAL;
+
+	if (dev->operation_mode != mode) {
+		if (dev->operation_mode != AD405X_CONFIG_MODE_OP) {
+			ret = ad405x_exit_command(dev);
+			if (ret)
+				return ret;
+		}
+
+		switch (mode) {
+		case AD405X_CONFIG_MODE_OP:
+			return 0;
+		case AD405X_ADC_MODE_OP:
+			return ad405x_set_adc_mode(dev);
+		case AD405X_BURST_AVERAGING_MODE_OP:
+			return ad405x_set_burst_averaging_mode(dev);
+		default:
+			return -EINVAL;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Toggle the CNV pin to start a conversion.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad405x_convst(struct ad405x_dev *dev)
+{
+	int ret;
+
+	ret = no_os_gpio_set_value(dev->gpio_cnv, NO_OS_GPIO_HIGH);
+	if (ret)
+		return ret;
+
+	/** CNV High Time 10 ns */
+	no_os_udelay(1);
+
+	ret = no_os_gpio_set_value(dev->gpio_cnv, NO_OS_GPIO_LOW);
+	if (ret)
+		return ret;
+
+	/* Conversion Time (CNV Rising Edge to Data Ready) 250ns */
+	no_os_udelay(1);
+
+	return 0;
+}
+
+/**
+ * @brief Read conversion data.
+ * @param dev - The device structure.
+ * @param data - Pointer to location of buffer where to store the data.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad405x_spi_data_read(struct ad405x_dev *dev, int32_t *data)
+{
+	int ret = 0;
+	uint16_t bytes_number = 2;
+	uint8_t data_read[4] = { 0x00 };
+
+	switch (dev->operation_mode) {
+	case AD405X_ADC_MODE_OP:
+		bytes_number = 2;
+		break;
+	case AD405X_BURST_AVERAGING_MODE_OP:
+		bytes_number += dev->active_device;
+		break;
+	default:
+		bytes_number = 2;
+		break;
+	}
+
+	ret = no_os_spi_write_and_read(dev->spi_desc, data_read, bytes_number);
+	if (ret)
+		return ret;
+
+	switch (bytes_number) {
+	case 2:
+		*data = no_os_get_unaligned_be16(data_read);
+		break;
+	case 3:
+		*data = no_os_get_unaligned_be24(data_read);
+		break;
+	default:
+		*data = no_os_get_unaligned_be16(data_read);
+		break;
+	}
+
+	return ret;
+}
+
+/**
+ * @brief Trigger conversion and read data.
+ * @param dev - The device structure.
+ * @param data - Pointer to location of buffer where to store the data.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad405x_read_val(struct ad405x_dev *dev, int32_t *data)
+{
+	int ret;
+	int32_t data_read;
+
+	ret = ad405x_convst(dev);
+	if (ret)
+		return -EINVAL;
+
+	ret = ad405x_spi_data_read(dev, &data_read);
+	if (!ret)
+		*data = data_read;
+
+	return ret;
+}
+
+/**
+ * @brief Select sample rate for Burst and Autonomous Modes
+ * @param dev - The device structure.
+ * @param rate - Sample rate.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad405x_set_sample_rate(struct ad405x_dev *dev,
+			   enum ad405x_sample_rate rate)
+{
+	int ret;
+
+	if (!dev)
+		return -EINVAL;
+
+	ret = ad405x_update_bits(dev,
+				 AD405X_REG_TIMER_CONFIG,
+				 AD405X_FS_BURST_AUTO_MSK,
+				 no_os_field_prep(AD405X_FS_BURST_AUTO_MSK, rate));
+	if (ret)
+		return ret;
+
+	dev->rate = rate;
+
+	return 0;
+}
+
+/**
+ * @brief Set averaging filter window length
+ * @param dev - The device structure.
+ * @param length - Averaging filter window length.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad405x_set_averaging_filter_length(struct ad405x_dev *dev,
+				       enum ad405x_avg_filter_l length)
+{
+	int ret;
+
+	if (!dev)
+		return -EINVAL;
+
+	/* Restrict filter length depending on active device selected */
+	switch (dev->active_device) {
+	case ID_AD4050:
+		if (length > AD405X_LENGTH_256)
+			return -EINVAL;
+		break;
+	case ID_AD4052:
+		break;
+
+	default:
+		return -EINVAL;
+	}
+	ret = ad405x_update_bits(dev,
+				 AD405X_REG_AVG_CONFIG,
+				 AD405X_AVG_WIN_LEN_MSK,
+				 no_os_field_prep(AD405X_AVG_WIN_LEN_MSK, length));
+	if (ret)
+		return ret;
+
+	dev->filter_length = length;
+
+	return 0;
+}
+
+/**
+ * @brief Get averaging filter window length
+ * @param dev - The device structure.
+ * @return Average filter value
+ */
+enum ad405x_avg_filter_l ad405x_get_averaging_filter_length(
+	struct ad405x_dev *dev)
+{
+	if (!dev)
+		return -EINVAL;
+
+	return dev->filter_length;
+}
+
+/**
+ * @brief Set DEV_EN signal polarity
+ * @param dev - The device structure.
+ * @param polarity - DEV_EN signal polarity.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad405x_set_dev_en_polarity(struct ad405x_dev *dev,
+			       enum ad405x_dev_en_polarity polarity)
+{
+	int ret;
+
+	if (!dev)
+		return -EINVAL;
+
+	ret = ad405x_update_bits(dev,
+				 AD405X_REG_GPIO_CONFIG,
+				 AD405X_DEV_EN_POL_MSK,
+				 no_os_field_prep(AD405X_DEV_EN_POL_MSK, polarity));
+	if (ret)
+		return ret;
+
+	dev->polarity = polarity;
+
+	return 0;
+}
+
+/**
+ * @brief Get DEV_EN signal polarity
+ * @param dev - The device structure.
+ * @return DEV_EN signal polarity
+ */
+enum ad405x_dev_en_polarity ad405x_get_dev_en_polarity(struct ad405x_dev *dev)
+{
+	if (!dev)
+		return -EINVAL;
+
+	return dev->polarity;
+}
+
+/**
+ * @brief Enable INVERT_ON_CHOP
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad405x_enable_invert_on_chop(struct ad405x_dev *dev)
+{
+	int ret;
+
+	if (!dev)
+		return -EINVAL;
+
+	ret = ad405x_update_bits(dev,
+				 AD405X_REG_GPIO_CONFIG,
+				 AD405X_INVERT_ON_CHOP_MSK,
+				 no_os_field_prep(AD405X_INVERT_ON_CHOP_MSK, AD405X_INVERT_ON_CHOP_ENABLED));
+	if (ret)
+		return ret;
+
+	dev->invert_on_chop_status = AD405X_INVERT_ON_CHOP_ENABLED;
+
+	return 0;
+}
+
+/**
+ * @brief Disable INVERT_ON_CHOP
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad405x_disable_invert_on_chop(struct ad405x_dev *dev)
+{
+	int ret;
+
+	if (!dev)
+		return -EINVAL;
+
+	ret = ad405x_update_bits(dev,
+				 AD405X_REG_GPIO_CONFIG,
+				 AD405X_INVERT_ON_CHOP_MSK,
+				 no_os_field_prep(AD405X_INVERT_ON_CHOP_MSK, AD405X_INVERT_ON_CHOP_DISABLED));
+	if (ret)
+		return ret;
+
+	dev->invert_on_chop_status = AD405X_INVERT_ON_CHOP_DISABLED;
+
+	return 0;
+}
+
+/**
+ * @brief Get INVERT_ON_CHOP setting
+ * @param dev - The device structure.
+ * @return INVERT_ON_CHOP setting
+ */
+enum ad405x_invert_on_chop ad405x_get_invert_on_chop_state(
+	struct ad405x_dev *dev)
+{
+	if (!dev)
+		return -EINVAL;
+
+	return dev->invert_on_chop_status;
+}
+
+/**
+ * @brief Set GP mode
+ * @param dev - The device structure.
+ * @param gp - GP1/GP0 select.
+ * @param mode - mode select.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad405x_set_gp_mode(struct ad405x_dev *dev,
+		       enum ad405x_gp_select gp,
+		       enum ad405x_gp_mode mode)
+{
+	int ret;
+	unsigned char msk;
+
+	if (!dev)
+		return -EINVAL;
+
+	switch(gp) {
+	case AD405X_GP_0 :
+		msk = AD405X_GP0_MODE_MSK;
+		break;
+	case AD405X_GP_1 :
+		msk = AD405X_GP1_MODE_MSK;
+		break;
+	default :
+		return -EINVAL;
+	}
+
+	if (gp == AD405X_GP_0 && mode == AD405X_GP_MODE_DEV_RDY)
+		return -EINVAL;
+
+	ret = ad405x_update_bits(dev,
+				 AD405X_REG_GPIO_CONFIG,
+				 msk,
+				 no_os_field_prep(msk, mode));
+	if (ret)
+		return ret;
+
+	switch(gp) {
+	case AD405X_GP_0 :
+		dev->gp0_mode = mode;
+		break;
+	case AD405X_GP_1 :
+		dev->gp1_mode = mode;
+		break;
+	default :
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+/** G */
+/**
+ * @brief Get GP mode setting
+ * @param dev - The device structure.
+ * @param gp - GP1/GP0 select.
+ * @return GP mode.
+ */
+enum ad405x_gp_mode ad405x_get_gp_mode(
+	struct ad405x_dev *dev,
+	enum ad405x_gp_select gp)
+{
+	if (!dev)
+		return -EINVAL;
+
+	switch(gp) {
+	case AD405X_GP_0 :
+		return dev->gp0_mode;
+	case AD405X_GP_1 :
+		return dev->gp1_mode;
+	default :
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Set output data format.
+ * @param dev - The device structure.
+ * @param data_format - format select.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad405x_set_data_format(struct ad405x_dev *dev,
+			   enum ad405x_out_data_format data_format)
+{
+	int ret;
+
+	if (!dev)
+		return -EINVAL;
+
+	ret = ad405x_update_bits(dev,
+				 AD405X_REG_ADC_MODES,
+				 AD405X_ADC_DATA_FORMAT_MSK,
+				 no_os_field_prep(AD405X_ADC_DATA_FORMAT_MSK, data_format));
+	if (ret)
+		return ret;
+
+	dev->data_format = data_format;
+
+	return 0;
+}
+
+/* Internal function that initializes GPIOs. */
+static int ad405x_request_gpios(struct ad405x_dev *dev,
+				struct ad405x_init_param *init_param)
+{
+	int32_t ret;
+
+	/* CNV */
+	ret = no_os_gpio_get_optional(&dev->gpio_cnv, init_param->gpio_cnv);
+	if (ret < 0)
+		return ret;
+
+	if (dev->gpio_cnv) {
+		ret = no_os_gpio_direction_output(dev->gpio_cnv, NO_OS_GPIO_LOW);
+		if (ret)
+			return ret;
+	}
+
+	/* GPIO0 */
+	ret = no_os_gpio_get_optional(&dev->gpio_gpio0, init_param->gpio_gpio0);
+	if (ret < 0)
+		return ret;
+
+	if (dev->gpio_gpio0) {
+		ret = no_os_gpio_direction_input(dev->gpio_gpio0);
+		if (ret)
+			return ret;
+	}
+
+	/* GPIO1 */
+	ret = no_os_gpio_get_optional(&dev->gpio_gpio1, init_param->gpio_gpio1);
+	if (ret < 0)
+		return ret;
+
+	if (dev->gpio_gpio1) {
+		ret = no_os_gpio_direction_input(dev->gpio_gpio1);
+		if (ret)
+			return ret;
+	}
+
+	return ret;
+}
+
+/**
+ * @brief Initialize the device.
+ * @param device - The device structure.
+ * @param init_param - The structure that contains the device initial
+ * 		       parameters.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad405x_init(struct ad405x_dev **device,
+		struct ad405x_init_param init_param)
+{
+	struct ad405x_dev *dev;
+	uint8_t data;
+	uint8_t prod_id[2];
+	int ret;
+
+	dev = (struct ad405x_dev *)calloc(1, sizeof(*dev));
+	if (!dev)
+		return - ENOMEM;
+
+	/* SPI Initialization */
+	ret = no_os_spi_init(&dev->spi_desc, init_param.spi_init);
+	if (ret)
+		goto error_dev;
+
+	/* Reset device using RESET pattern */
+	ret = ad405x_reset_pattern_command(dev);
+	if (ret) {
+		pr_info("Reset failed!\n");
+		return - 1;
+	}
+
+	/* Verify product ID and active device */
+	ret = ad405x_read(dev, AD405X_REG_PRODUCT_ID_H, &prod_id[0]);
+	if (ret)
+		goto error_spi;
+
+	ret = ad405x_read(dev, AD405X_REG_PRODUCT_ID_L, &prod_id[1]);
+	if (ret)
+		goto error_spi;
+
+	switch (init_param.active_device) {
+	case ID_AD4050:
+	case ID_AD4052:
+		if (no_os_get_unaligned_be16(prod_id) != PROD_ID_AD4052)
+			goto error_spi;
+
+		break;
+
+	default:
+		goto error_spi;
+	}
+
+	ret = ad405x_request_gpios(dev, &init_param);
+	if (ret)
+		goto error_dev;
+
+	/* Software Reset */
+	ret = ad405x_soft_reset(dev);
+	if (ret)
+		goto error_spi;
+
+	dev->operation_mode = AD405X_CONFIG_MODE_OP;
+	dev->polarity = AD405X_DEV_EN_ACTIVE_HIGH;
+	dev->gp1_mode = AD405X_GP_MODE_DEV_RDY;
+	dev->invert_on_chop_status = AD405X_INVERT_ON_CHOP_DISABLED;
+	dev->gp0_mode = AD405X_GP_MODE_HIGH_Z;
+	dev->data_format = AD405X_STRAIGHT_BINARY;
+	dev->active_device = init_param.active_device;
+
+	*device = dev;
+
+	return 0;
+
+error_spi :
+	no_os_spi_remove(dev->spi_desc);
+error_dev :
+	free(dev);
+
+	return ret;
+}
+
+/**
+ * @brief Remove the device and release resources.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad405x_remove(struct ad405x_dev *dev)
+{
+	int ret;
+
+	if (!dev)
+		return -EINVAL;
+
+	if (dev->gpio_cnv) {
+		ret = no_os_gpio_remove(dev->gpio_cnv);
+		if (ret)
+			return ret;
+	}
+
+	if (dev->gpio_gpio0) {
+		ret = no_os_gpio_remove(dev->gpio_gpio0);
+		if (ret)
+			return ret;
+	}
+
+	if (dev->gpio_gpio1) {
+		ret = no_os_gpio_remove(dev->gpio_gpio1);
+		if (ret)
+			return ret;
+	}
+
+
+	ret = no_os_spi_remove(dev->spi_desc);
+	if (ret)
+		return ret;
+
+	free(dev);
+
+	return ret;
+}

--- a/drivers/adc/ad405x/ad405x.h
+++ b/drivers/adc/ad405x/ad405x.h
@@ -1,0 +1,393 @@
+/*******************************************************************************
+ *   @file   ad405x.h
+ *   @brief  Header file of AD405X Driver.
+ *   @author George Mois (george.mois@analog.com)
+ *	 @author Ribhu Das Purkayastha (ribhu.daspurkayastha@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef __AD405X_H__
+#define __AD405X_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <stdint.h>
+#include <string.h>
+#include "no_os_util.h"
+#include "no_os_spi.h"
+#include "no_os_gpio.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+/** Register Definition */
+#define AD405X_REG_INTERFACE_CONFIG_A		0x00
+#define AD405X_REG_INTERFACE_CONFIG_B		0x01
+#define AD405X_REG_DEVICE_CONFIG		0x02
+#define AD405X_REG_DEVICE_TYPE			0x03
+#define AD405X_REG_PRODUCT_ID_L			0x04
+#define AD405X_REG_PRODUCT_ID_H			0x05
+#define AD405X_REG_CHIP_GRADE			0x06
+#define AD405X_REG_SCRATCH_PAD			0x0A
+#define AD405X_REG_SPI_REVISION			0x0B
+#define AD405X_REG_VENDOR_L			0x0C
+#define AD405X_REG_VENDOR_H			0x0D
+#define AD405X_REG_STREAM_MODE			0x0E
+#define AD405X_REG_TRANSFER_CONFIG		0x0F
+#define AD405X_REG_INTERFACE_CONFIG_C		0x10
+#define AD405X_REG_INTERFACE_STATUS		0x11
+#define AD405X_REG_MODE_SET			0x20
+#define AD405X_REG_ADC_MODES			0x21
+#define AD405X_REG_ADC_CONFIG			0x22
+#define AD405X_REG_AVG_CONFIG			0x23
+#define AD405X_REG_GPIO_CONFIG			0x24
+#define AD405X_REG_INTR_CONFIG			0x25
+#define AD405X_REG_CHOP_CONFIG			0x26
+#define AD405X_REG_TIMER_CONFIG			0x27
+#define AD405X_REG_MAX_THRESH			0x28
+#define AD405X_REG_MIN_THRESH			0x2A
+#define AD405X_REG_MAX_HYST			0x2C
+#define AD405X_REG_MIN_HYST			0x2D
+#define AD405X_REG_MON_VAL			0x2E
+#define AD405X_REG_FUSE_CRC			0x40
+#define AD405X_REG_DEVICE_STATUS		0x41
+#define AD405X_REG_MAX_INTR			0x42
+#define AD405X_REG_MIN_INTR			0x44
+
+/** AD405X_REG_INTERFACE_CONFIG_A Bit Definition */
+#define AD405X_SW_RESET_MSK			NO_OS_BIT(7) | NO_OS_BIT(0)
+
+/** AD405X_REG_INTERFACE_CONFIG_B Bit Definition */
+#define AD405X_SINGLE_INST_MSK			NO_OS_BIT(7) /* Should be set to 0. */
+#define AD405X_SHORT_INST_MSK			NO_OS_BIT(3)
+
+/** AD405X_REG_INTERFACE_CONFIG_C Bit Definition */
+#define AD405X_STRICT_REG_ACCESS_MSK		NO_OS_BIT(5)
+
+/** AD405X_REG_ADC_MODES Bit definition */
+#define AD405X_ADC_DATA_FORMAT_MSK      NO_OS_BIT(7)
+#define AD405X_ADC_MODES_MSK			NO_OS_GENMASK(1, 0)
+#define AD405X_SAMPLE_MODE      		0x00
+#define AD405X_BURST_AVERAGING_MODE		NO_OS_BIT(0)
+#define AD405X_AVERAGING_MODE      		NO_OS_BIT(1)
+#define AD405X_AUTONOMOUS_MODE			NO_OS_GENMASK(1, 0)
+
+/** AD405X_REG_MODE_SET Bit definition */
+#define AD405X_ENTER_ADC_MODE_MSK		NO_OS_BIT(0)
+#define AD405X_ENTER_ADC_MODE     		NO_OS_BIT(0)
+
+/** AD405X_REG_TIMER_CONFIG Bit Definitions */
+#define AD405X_FS_BURST_AUTO_MSK		NO_OS_GENMASK(7, 4)
+
+/** AD405X_REG_AVG_CONFIG Bit Definitions */
+#define AD405X_AVG_WIN_LEN_MSK			NO_OS_GENMASK(3, 0)
+
+/** AD405X_REG_GPIO_CONFIG Bit Definitions */
+#define AD405X_DEV_EN_POL_MSK				NO_OS_BIT(7)
+#define AD405X_GP1_MODE_MSK				NO_OS_GENMASK(6, 4)
+#define AD405X_INVERT_ON_CHOP_MSK			NO_OS_BIT(3)
+#define AD405X_GP0_MODE_MSK				NO_OS_GENMASK(2, 0)
+
+#define AD405X_DEV_EN_POL_LOW				~NO_OS_BIT(7)
+#define AD405X_DEV_EN_POL_HIGH				NO_OS_BIT(7)
+
+#define AD405X_INVERT_ON_CHOP_OFF			~NO_OS_BIT(3)
+#define AD405X_INVERT_ON_CHOP_ON			NO_OS_BIT(3)
+
+/** Miscellaneous Definitions */
+#define AD405X_SW_RESET				NO_OS_BIT(7) | NO_OS_BIT(0)
+#define AD405X_SPI_READ        			NO_OS_BIT(7)
+#define BYTE_ADDR_H				NO_OS_GENMASK(15, 8)
+#define BYTE_ADDR_L				NO_OS_GENMASK(7, 0)
+#define AD405X_DEVICE_TYPE			NO_OS_GENMASK(2, 0)
+
+/******************************************************************************/
+/************************ Types Declarations **********************************/
+/******************************************************************************/
+
+/** AD405X modes of operations */
+enum ad405x_operation_mode {
+	AD405X_CONFIG_MODE_OP,
+	AD405X_ADC_MODE_OP,
+	AD405X_AVERAGING_MODE_OP,
+	AD405X_BURST_AVERAGING_MODE_OP,
+	AD405X_PERSISTENT_AUTO_MODE_OP,
+	AD405X_NON_PERSISTENT_AUTO_MODE_OP
+};
+
+/** AD405X sample rate for burst and autonomous modes */
+enum ad405x_sample_rate {
+	AD405X_2_MSPS,
+	AD405X_1_MSPS,
+	AD405X_333_KSPS,
+	AD405X_100_KSPS,
+	AD405X_33_KSPS,
+	AD405X_10_KSPS,
+	AD405X_3_KSPS,
+	AD405X_1_KSPS,
+	AD405X_500_SPS,
+	AD405X_333_SPS,
+	AD405X_250_SPS,
+	AD405X_200_SPS,
+	AD405X_166_SPS,
+	AD405X_140_SPS,
+	AD405X_125_SPS,
+	AD405X_111_SPS
+};
+
+/** AD405X averaging filter window length */
+enum ad405x_avg_filter_l {
+	AD405X_LENGTH_2,
+	AD405X_LENGTH_4,
+	AD405X_LENGTH_8,
+	AD405X_LENGTH_16,
+	AD405X_LENGTH_32,
+	AD405X_LENGTH_64,
+	AD405X_LENGTH_128,
+	AD405X_LENGTH_256,
+	AD405X_LENGTH_512,
+	AD405X_LENGTH_1024,
+	AD405X_LENGTH_2048,
+	AD405X_LENGTH_4096
+};
+
+/** AD405X DEV_EN polarity */
+enum ad405x_dev_en_polarity {
+	AD405X_DEV_EN_ACTIVE_LOW,
+	AD405X_DEV_EN_ACTIVE_HIGH
+};
+
+/** AD405X INVERT_ON_CHOP status */
+enum ad405x_invert_on_chop {
+	AD405X_INVERT_ON_CHOP_DISABLED,
+	AD405X_INVERT_ON_CHOP_ENABLED
+};
+
+/** AD405X GP0, GP1 mode */
+enum ad405x_gp_mode {
+	AD405X_GP_MODE_HIGH_Z,
+	AD405X_GP_MODE_INTR,
+	AD405X_GP_MODE_DRDY,
+	AD405X_GP_MODE_DEV_EN,
+	AD405X_GP_MODE_CHOP,
+	AD405X_GP_MODE_LOW,
+	AD405X_GP_MODE_HIGH,
+	AD405X_GP_MODE_DEV_RDY
+};
+
+/** AD405X GP selection */
+enum ad405x_gp_select {
+	AD405X_GP_0,
+	AD405X_GP_1
+};
+
+/** AD405X output data format selection */
+enum ad405x_out_data_format {
+	AD405X_STRAIGHT_BINARY,
+	AD405X_TWOS_COMPLEMENT
+};
+
+/** AD405X device type section */
+enum ad405x_device_type {
+	ID_AD4050,
+	ID_AD4052
+};
+
+/** AD405X product ID */
+enum ad405x_product_id {
+	PROD_ID_AD4052 = 0x70
+};
+
+/**
+ * @struct ad405x_dev
+ * @brief AD405X Device structure.
+ */
+struct ad405x_dev {
+	/** SPI */
+	struct no_os_spi_desc	*spi_desc;
+	/** Active device */
+	enum ad405x_device_type active_device;
+	/** Mode of operations */
+	enum ad405x_operation_mode operation_mode;
+	/** CNV GPIO descriptor */
+	struct no_os_gpio_desc *gpio_cnv;
+	/** GPIO0 GPIO descriptor */
+	struct no_os_gpio_desc *gpio_gpio0;
+	/** GPIO1 GPIO descriptor */
+	struct no_os_gpio_desc *gpio_gpio1;
+	/** Sample rate for Burst and Autonomous Modes */
+	enum ad405x_sample_rate rate;
+	/** Averaging filter window length */
+	enum ad405x_avg_filter_l filter_length;
+	/** DEV_EN signal polarity */
+	enum ad405x_dev_en_polarity polarity;
+	/** GP1 mode */
+	enum ad405x_gp_mode gp1_mode;
+	/** INVERT_ON_CHOP setting */
+	enum ad405x_invert_on_chop invert_on_chop_status;
+	/** GP0 mode */
+	enum ad405x_gp_mode gp0_mode;
+	/** Output data format */
+	enum ad405x_out_data_format data_format;
+};
+
+/**
+ * @struct AD405X_init_param
+ * @brief AD405X Device initialization parameters.
+ */
+struct ad405x_init_param {
+	/** SPI */
+	struct no_os_spi_init_param	*spi_init;
+	/** Active device */
+	enum ad405x_device_type active_device;
+	/** Mode of operations */
+	enum ad405x_operation_mode operation_mode;
+	/** CNV GPIO descriptor */
+	struct no_os_gpio_init_param *gpio_cnv;
+	/** GPIO0 GPIO descriptor */
+	struct no_os_gpio_init_param *gpio_gpio0;
+	/** GPIO1 GPIO descriptor */
+	struct no_os_gpio_init_param *gpio_gpio1;
+	/** sample rate for Burst and Autonomous Modes */
+	enum ad405x_sample_rate rate;
+	/** Averaging filter window length */
+	enum ad405x_avg_filter_l filter_length;
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+/** Write data into a register */
+int ad405x_write(struct ad405x_dev *dev,
+		 uint8_t reg_addr,
+		 uint8_t reg_val);
+
+/** Read data from a register */
+int ad405x_read(struct ad405x_dev *dev,
+		uint8_t reg_addr,
+		uint8_t *reg_val);
+
+/** Update specific register bits */
+int ad405x_update_bits(struct ad405x_dev *dev,
+		       uint8_t reg_addr,
+		       uint8_t mask,
+		       uint8_t reg_val);
+
+/** Send EXIT command. */
+int ad405x_exit_command(struct ad405x_dev *dev);
+
+/** Send RESET command. */
+int ad405x_reset_pattern_command(struct ad405x_dev *dev);
+
+/** Software Reset. */
+int ad405x_soft_reset(struct ad405x_dev *dev);
+
+/** Enter ADC Mode */
+int ad405x_set_adc_mode(struct ad405x_dev *dev);
+
+/** Enter Burst Averaging Mode */
+int ad405x_set_burst_averaging_mode(struct ad405x_dev *dev);
+
+/** Enter Config Mode */
+int ad405x_set_config_mode(struct ad405x_dev *dev);
+
+/** Set operation mode */
+int ad405x_set_operation_mode(struct ad405x_dev *dev,
+			      enum ad405x_operation_mode mode);
+
+/** Toggle the CNV pin to start a conversion. */
+int ad405x_convst(struct ad405x_dev *dev);
+
+/** Read conversion data. */
+int ad405x_spi_data_read(struct ad405x_dev *dev,
+			 int32_t *data);
+
+/** Trigger conversion adn read data. */
+int ad405x_read_val(struct ad405x_dev *dev, int32_t *data);
+
+/** Select sample rate for Burst and Autonomous Modes. */
+int ad405x_set_sample_rate(struct ad405x_dev *dev,
+			   enum ad405x_sample_rate rate);
+
+/** Set averaging filter window length */
+int ad405x_set_averaging_filter_length(struct ad405x_dev *dev,
+				       enum ad405x_avg_filter_l length);
+
+/** Get averaging filter window length */
+enum ad405x_avg_filter_l ad405x_get_averaging_filter_length(
+	struct ad405x_dev *dev);
+
+/** Set DEV_EN signal polarity */
+int ad405x_set_dev_en_polarity(struct ad405x_dev *dev,
+			       enum ad405x_dev_en_polarity polarity);
+
+/** Get DEV_EN signal polarity */
+enum ad405x_dev_en_polarity ad405x_get_dev_en_polarity(struct ad405x_dev *dev);
+
+/** Enable INVERT_ON_CHOP */
+int ad405x_enable_invert_on_chop(struct ad405x_dev *dev);
+
+/** Disable INVERT_ON_CHOP */
+int ad405x_disable_invert_on_chop(struct ad405x_dev *dev);
+
+/** Get INVERT_ON_CHOP setting */
+enum ad405x_invert_on_chop ad405x_get_invert_on_chop_state(
+	struct ad405x_dev *dev);
+
+/** Set GP mode */
+int ad405x_set_gp_mode(struct ad405x_dev *dev,
+		       enum ad405x_gp_select gp,
+		       enum ad405x_gp_mode mode);
+
+/** Get GP mode setting */
+enum ad405x_gp_mode ad405x_get_gp_mode(
+	struct ad405x_dev *dev, enum ad405x_gp_select gp);
+
+/** Set adc output data format */
+int ad405x_set_data_format(struct ad405x_dev *dev,
+			   enum ad405x_out_data_format data_format);
+
+/** Initialize the device. */
+int ad405x_init(struct ad405x_dev **device,
+		struct ad405x_init_param init_param);
+
+/** Remove the device and release resources. */
+int ad405x_remove(struct ad405x_dev *dev);
+
+#endif /* __AD405X_H__ */


### PR DESCRIPTION
## Pull Request Description

1. Add support for sample, averaging and burst averaging modes
2. Add support for spi read-write
3. Add bitfield definitions and apis for modifying and accessing bitfields

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
