### PR TITLE
projects: ad5460: drop IIO_EXAMPLE

### DIFF
--- a/projects/ad5460/src/platform/mbed/main.c
+++ b/projects/ad5460/src/platform/mbed/main.c
@@ -73,7 +73,7 @@ int main()
 	}
 #endif
 
-#if (IIO_EXAMPLE+BASIC_EXAMPLE != 1)
+#if (BASIC_EXAMPLE != 1)
 #error Selected example projects cannot be enabled at the same time. \
 Please enable only one example and re-build the project.
 #endif


### PR DESCRIPTION
There is no IIO_EXAMPLE usage currenly in the project.

Fixes: dac70d6 ("projects: ad5460: add initial example")

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
