### PR TITLE
tools: scripts: Delete .vscode on reset

### DIFF
--- a/tools/scripts/generic.mk
+++ b/tools/scripts/generic.mk
@@ -400,7 +400,7 @@ clean:
 
 # Remove the whole build directory
 PHONY += reset
-reset: clean_libs
+reset: clean_libs sdkclean
 	$(call print,[Delete] $(BUILD_DIR))
 	$(call remove_dir,$(BUILD_DIR))
 

--- a/tools/scripts/maxim.mk
+++ b/tools/scripts/maxim.mk
@@ -153,6 +153,7 @@ $(PLATFORM)_sdkopen:
 	code $(PROJECT)
 
 $(PLATFORM)_sdkclean: clean
+	$(call remove_dir,$(VSCODE_CFG_DIR))
 
 $(PLATFORM)_sdkbuild: build
 

--- a/tools/scripts/stm32.mk
+++ b/tools/scripts/stm32.mk
@@ -214,6 +214,7 @@ $(PLATFORM)_sdkclean:
 	$(call remove_dir,$(DEBUG_DIR)) $(HIDE)
 	$(call print,[Delete] SDK artefacts from $(RELEASE_DIR))
 	$(call remove_dir,$(RELEASE_DIR)) $(HIDE)
+	$(call remove_dir,$(VSCODE_CFG_DIR))
 
 clean_hex:
 	@$(call print,[Delete] $(HEX))


### PR DESCRIPTION
After 86d407b("tools:scripts: Don't overwrite .vscode config if it already exists") the vscode configuration files (contents of the .vscode directory) are no longer overwritten on every make build. This may lead to confusion if the build was acciedentally done for a different platform than the one intended.

Such a situation may occur if the user runs "make build" (without the PLATFORM variable), resulting in generating the vscode configurations for the STM32 platform. From this point there is no way to change the target to another platform using the build system. Fix this by removing the .vscode directory on "make reset".

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
