### PR TITLE
Wip/bl/ad3552r

### DIFF
--- a/drivers/dac/ad3552r/ad3552r.c
+++ b/drivers/dac/ad3552r/ad3552r.c
@@ -1418,6 +1418,18 @@ int32_t ad3552r_ldac_trigger(struct ad3552r_desc *desc, uint16_t mask,
 	return 0;
 }
 
+int32_t ad3552r_set_asynchronous(struct ad3552r_desc *desc, uint8_t enable)
+{
+	int err;
+
+	err = no_os_gpio_set_value(desc->ldac,
+				   enable ? NO_OS_GPIO_LOW : NO_OS_GPIO_HIGH);
+	if (NO_OS_IS_ERR_VALUE(err))
+		return err;
+
+	return 0;
+}
+
 static int32_t ad3552r_write_all_channels(struct ad3552r_desc *desc,
 		uint16_t *data,
 		enum ad3552r_write_mode mode)

--- a/drivers/dac/ad3552r/ad3552r.c
+++ b/drivers/dac/ad3552r/ad3552r.c
@@ -1470,7 +1470,7 @@ int32_t ad3552r_write_samples(struct ad3552r_desc *desc, uint16_t *data,
 {
 	uint32_t i;
 	int32_t err;
-	uint8_t addr, is_input, ch;
+	uint8_t addr, is_dac, ch;
 
 	if (ch_mask == AD3552R_MASK_ALL_CH &&
 	    desc->ch_data[0].fast_en != desc->ch_data[1].fast_en)
@@ -1488,8 +1488,8 @@ int32_t ad3552r_write_samples(struct ad3552r_desc *desc, uint16_t *data,
 	}
 
 	ch = no_os_find_first_set_bit(ch_mask);
-	is_input = (mode == AD3552R_WRITE_DAC_REGS);
-	addr = ad3552r_get_code_reg_addr(ch, is_input, desc->ch_data[ch].fast_en);
+	is_dac = (mode == AD3552R_WRITE_DAC_REGS);
+	addr = ad3552r_get_code_reg_addr(ch, is_dac, desc->ch_data[ch].fast_en);
 	for (i = 0; i < samples; ++i) {
 		err = ad3552r_write_reg(desc, addr, data[i]);
 		if (NO_OS_IS_ERR_VALUE(err))

--- a/drivers/dac/ad3552r/ad3552r.h
+++ b/drivers/dac/ad3552r/ad3552r.h
@@ -405,6 +405,7 @@ struct ad3552r_desc {
 	uint8_t chip_id;
 	uint8_t crc_en : 1;
 	uint8_t is_simultaneous : 1;
+	uint8_t single_transfer : 1;
 };
 
 struct ad3552r_custom_output_range_cfg {
@@ -449,6 +450,7 @@ struct ad3552r_init_param {
 	/* Set to enable CRC */
 	bool crc_en;
 	bool is_simultaneous;
+	bool single_transfer;
 };
 
 /*****************************************************************************/

--- a/drivers/dac/ad3552r/ad3552r.h
+++ b/drivers/dac/ad3552r/ad3552r.h
@@ -508,6 +508,8 @@ int32_t ad3552r_get_offset(struct ad3552r_desc *desc, uint8_t ch,
 int32_t ad3552r_ldac_trigger(struct ad3552r_desc *desc, uint16_t mask,
 			     uint8_t is_fast);
 
+int32_t ad3552r_set_asynchronous(struct ad3552r_desc *desc, uint8_t enable);
+
 /* Send one sample at a time, one after an other or at a LDAC_period interval.
  * If LDAC pin set, send LDAC signal. Otherwise software LDAC is used. */
 int32_t ad3552r_write_samples(struct ad3552r_desc *desc, uint16_t *data,

--- a/projects/ad3552r_fmcz/srcs/parameters.h
+++ b/projects/ad3552r_fmcz/srcs/parameters.h
@@ -52,6 +52,7 @@
 /******************************************************************************/
 
 /* GPIO Indexes */
+#ifndef XILINX_PLATFORM
 #define GPIO_RESET_N				0
 #define GPIO_LDAC_N				1
 #define GPIO_SPI_QPI				2
@@ -61,6 +62,17 @@
 #define GPIO_GREEN				6 //GPIO_7
 #define GPIO_BLUE				7 //GPIO_8
 #define TOTAL_GPIOS				8
+#else
+#define GPIO_LDAC_N		0
+#define GPIO_ALERT_N		1
+#define GPIO_RED		2 /* GPIO_6 */
+#define GPIO_GREEN		3 /* GPIO_7 */
+#define GPIO_BLUE		4 /* GPIO_8 */
+#define GPIO_9			5
+#define GPIO_RESET_N		6
+#define GPIO_SPI_QPI		7
+#define TOTAL_GPIOS		8
+#endif /* XILINX_PLATFORM */
 
 #define GPIO_BANK_0_PINS	32
 #define GPIO_BANK_1_PINS	22


### PR DESCRIPTION
## Pull Request Description

Add zedboard Xilinx support to ad3552r driver and demo.
Tested generic-spi, 1024 samples syn waves visible on both channels, with or without crc.
Further improvements will follow.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
Could not test on SDP-H1 right now, my setup is with Zedboard.
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
