### PR TITLE
projects: swiot1l: Save channel configuration

### DIFF
--- a/projects/swiot1l/src/common/swiot.c
+++ b/projects/swiot1l/src/common/swiot.c
@@ -707,11 +707,8 @@ int swiot_iio_remove(struct swiot_iio_desc *swiot_desc)
 	no_os_gpio_remove(swiot_desc->psu_gpio);
 	no_os_gpio_remove(swiot_desc->identify_gpio);
 
-	for (i = 0; i < SWIOT_CHANNELS; i++) {
-		swiot_config[i].device = SWIOT_AD74413R;
-		swiot_config[i].function = AD74413R_HIGH_Z;
+	for (i = 0; i < SWIOT_CHANNELS; i++)
 		swiot_config[i].enabled = false;
-	}
 
 	free(swiot_desc);
 


### PR DESCRIPTION
## Pull Request Description

Currently, the channel configuration attributes of the swiot virtual IIO device are reset when the context is switched from runtime to config. Keep the device and function attribute values and set enabled to false instead. This improves usability when IIO clients are involved.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
