### PR TITLE
ad9361: src: main.c: Set DAC rate for 1r1t mode

### DIFF
--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -562,6 +562,13 @@ int main(void)
 		tx_dac_init.rate = 1;
 		rx_adc_init.num_channels = 2;
 		rx_adc_init.num_slave_channels = 0;
+	} else {
+		if (!default_init_param.two_rx_two_tx_mode_enable) {
+			tx_dac_init.num_channels = 2;
+			tx_dac_init.rate = 1;
+			rx_adc_init.num_channels = 2;
+			rx_adc_init.num_slave_channels = 0;
+		}
 	}
 	if (AD9363A_DEVICE)
 		default_init_param.dev_sel = ID_AD9363A;


### PR DESCRIPTION
Set tx_dac rate to 1 for 1r1t mode fo AD9361.

Problem signaled and solved in the following two EZ threads:
https://ez.analog.com/microcontroller-no-os-drivers/f/q-a/581897/no-os-1r1t-dac-dma
https://ez.analog.com/microcontroller-no-os-drivers/f/q-a/571313/ad9364-dac-rate/498804?queryID=92a6dba6aaea82ca5f95812696f18cc2&objectId=0479fa6a-6177-4c34-8bc3-cd9264901e12&eztype=Forum%20Reply

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
