### PR TITLE
AD9113 remove silicon revision check

### DIFF
--- a/drivers/meter/ade9113/ade9113.c
+++ b/drivers/meter/ade9113/ade9113.c
@@ -361,16 +361,6 @@ int ade9113_init(struct ade9113_dev **device,
 
 	dev->ver_product = reg_val;
 
-	/* Read silicon revision */
-	ret = ade9113_get_silicon_revision(dev, &reg_val);
-	if (ret)
-		goto error_gpio;
-
-	if (reg_val != ADE9113_SILICON_REVISION) {
-		ret = -ENODEV;
-		goto error_gpio;
-	}
-
 	*device = dev;
 
 	return 0;

--- a/drivers/meter/ade9113/ade9113.h
+++ b/drivers/meter/ade9113/ade9113.h
@@ -212,9 +212,6 @@
 #define ADE9113_2_CHANNEL_ADE9112		1U
 #define ADE9113_NONISOLATED_ADE9103		3U
 
-/* Revision Value of ISO and NONISO Silicon */
-#define ADE9113_SILICON_REVISION		0x12
-
 /* Nominal reference voltage */
 #define ADE9113_VREF				(883883)
 


### PR DESCRIPTION
Remove silicon revision check in ADE9113 driver.

Remove the comparison to known silicon revisions, since the value in the register is subject to change with each silicon revision.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
