### PR TITLE
spi-engine: fix word length zero 

### DIFF
--- a/drivers/axi_core/spi_engine/spi_engine.c
+++ b/drivers/axi_core/spi_engine/spi_engine.c
@@ -56,6 +56,7 @@ significant delays */
 #include "no_os_axi_io.h"
 #include "no_os_error.h"
 #include "no_os_alloc.h"
+#include "no_os_util.h"
 #include "spi_engine.h"
 
 /**
@@ -172,7 +173,7 @@ static uint8_t spi_get_words_number(struct spi_engine_desc *desc,
 	uint8_t xfer_word_len;
 	uint8_t words_number;
 
-	xfer_word_len = desc->data_width / 8;
+	xfer_word_len = NO_OS_DIV_ROUND_UP(desc->data_width, 8);
 	words_number = bytes_number / xfer_word_len;
 
 	if ((bytes_number % xfer_word_len) != 0)
@@ -191,7 +192,7 @@ static uint8_t spi_get_word_lenght(struct spi_engine_desc *desc)
 {
 	uint8_t word_lenght;
 
-	word_lenght = desc->data_width / 8;
+	word_lenght = NO_OS_DIV_ROUND_UP(desc->data_width, 8);
 
 	return word_lenght;
 }


### PR DESCRIPTION
If data_width value is lower than 8 bits, the word length is set to zero and no data is transfered. Rounding Up the word length also fixes undersampling problem when data_width is not a multiple of 8.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
