### PR TITLE
ad-acevsecrdset-sl: state_machine.c: Print state once

### DIFF
--- a/projects/ad-acevsecrdset-sl/src/platform/parameters.h
+++ b/projects/ad-acevsecrdset-sl/src/platform/parameters.h
@@ -142,8 +142,6 @@
 #define RCD_TIME_REPEAT_INTERVAL        (10u)
 // Print values disable interval in seconds
 #define PRINT_VALUES_TIME               (4u)
-// Print charging disable interval in seconds
-#define PRINT_CHARGING_TIME             (3u)
 // The time rate used to compute Vin and Iout (multiple of 20ms)
 #define COMPUTE_VALUES_INTERVAL         (5u)
 // The time rate used to compute Vrelay (multiple of COMPUTE_VALUES_INTERVAL)

--- a/projects/ad-acevsecrdset-sl/src/state_machine/state_machine.c
+++ b/projects/ad-acevsecrdset-sl/src/state_machine/state_machine.c
@@ -106,14 +106,10 @@ int state_machine()
 	uint32_t rcd_test_s = current_time.s;
 	// The time interval in which the print values is disabled
 	uint32_t print_values_s = current_time.s;
-	// The time interval in which the print charging is disabled
-	uint32_t print_charging_s = current_time.s;
 	// The time passed since the last RCD test
 	uint32_t s_elapsed_since_rcd_test = 0;
 	// The time passed since the last print values
 	uint32_t s_elapsed_since_print_values = 0;
-	// The time passed since the last print charging
-	uint32_t s_elapsed_since_print_charging_state = 0;
 	// Time when values were interpreted
 	uint32_t recalc_time_us = current_time.us;
 	// Time passed from last values update
@@ -322,12 +318,6 @@ int state_machine()
 			// If time elapsed larger than PRINT_VALUES_TIME seconds, reenable print
 			if ((PRINT_VALUES_TIME < s_elapsed_since_print_values) && (0 == print_values))
 				print_values = 1;
-			// Compute time elapsed since last print values
-			s_elapsed_since_print_charging_state = current_time.s - print_charging_s;
-			// If time elapsed larger than PRINT_VALUES_TIME seconds, reenable print
-			if ((PRINT_CHARGING_TIME < s_elapsed_since_print_charging_state)
-			    && (0 == print_charging))
-				print_charging = 1;
 
 			reset_pwm_low_flag_state();
 		}
@@ -619,18 +609,28 @@ int state_machine()
 			case STATE_C:
 				// Debug message
 				if (stout->current_state != stout->previous_state) {
-					pr_debug("STATE C\n");
 					current_set = current_value_limit;
 					// Set the PWM value based on Iout value
 					pilot_pwm_timer_set_duty_cycle(stout, current_set);
+					print_charging = 1;
 				}
 				// If overtemperature detected limit the current to 10A else the current is 16A
 				if (S_M_OVER_TEMPERATURE_1 == event) {
 					current_value_limit = PWM_DUTY_10A;
-					//pr_debug("State C LIMIT CURRENT 10A\n");
+					if (1 == print_charging || current_set != current_value_limit) {
+						pilot_pwm_timer_set_duty_cycle(stout, current_value_limit);
+						current_set = current_value_limit;
+						pr_debug("STATE C LIMIT CURRENT 10A\n");
+						print_charging = 0;
+					}
 				} else {
 					current_value_limit = PWM_DUTY_16A;
-					//pr_debug("State C 16A\n");
+					if (1 == print_charging || current_set != current_value_limit) {
+						pilot_pwm_timer_set_duty_cycle(stout, current_value_limit);
+						current_set = current_value_limit;
+						pr_debug("STATE C 16A\n");
+						print_charging = 0;
+					}
 				}
 
 				// Check the diode before charging
@@ -658,20 +658,10 @@ int state_machine()
 				} else if ((S_M_CHARGING == event) && (LED_BLINKING_16A <= cnt_disp)) {
 					// The LED will blink with a higher frequency if Iout is 16A and with a lower one if Iout is 10A
 					interface_disp(stout);
-					if (1 == print_charging) {
-						pr_debug("State C 16A\n");
-						print_charging_s = current_time.s;
-						print_charging = 0;
-					}
 					cnt_disp = 0;
 				} else if ((S_M_OVER_TEMPERATURE_1 == event)
 					   && (LED_BLINKING_10A <= cnt_disp)) {
 					interface_disp(stout);
-					if (1 == print_charging) {
-						pr_debug("State C LIMIT CURRENT 10A\n");
-						print_charging_s = current_time.s;
-						print_charging = 0;
-					}
 					cnt_disp = 0;
 				}
 				// Increment the counter used for LED blinking
@@ -684,6 +674,7 @@ int state_machine()
 			// was initiated by the EV
 			case STATE_D:
 				if (stout->current_state != stout->previous_state) {
+					pr_debug("State D 10A \n");
 					// Set the CP PWM duty cycle based on the Iout limit
 					current_set = current_value_limit;
 					pilot_pwm_timer_set_duty_cycle(stout, current_set);
@@ -712,11 +703,6 @@ int state_machine()
 					cnt_disp = 0;
 				} else if ((S_M_CHARGING_D == event) && (LED_BLINKING_10A <= cnt_disp)) {
 					interface_disp(stout);
-					if (1 == print_charging) {
-						pr_debug("State D charging with 10A \n");
-						print_charging_s = current_time.s;
-						print_charging = 0;
-					}
 					cnt_disp = 0;
 				}
 				// Increment the counter used for LED blinking


### PR DESCRIPTION
## Pull Request Description

Print state and charging current only when entering the state. This will allow faster execution of the state machine and remove redundant debug messages.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
