### PR TITLE
drivers: platform: stm32_spi: Fix pwm init parameters

### DIFF
--- a/drivers/platform/stm32/stm32_spi.h
+++ b/drivers/platform/stm32/stm32_spi.h
@@ -65,7 +65,7 @@ struct stm32_spi_init_param {
 	struct no_os_dma_ch* txdma_ch;
 #ifdef HAL_TIM_MODULE_ENABLED
 	/** CS PWM Initialization Parameters */
-	const struct no_os_pwm_init *pwm_init;
+	const struct no_os_pwm_init_param *pwm_init;
 #endif
 };
 


### PR DESCRIPTION
The pwm init parameters is of the wrong type.
it should be no_os_pwm_init_param and not no_os_pwm_init.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
