### PR TITLE
drivers: platform: maxim: Fix no_os_time computation

### DIFF
--- a/drivers/platform/maxim/max32650/maxim_delay.c
+++ b/drivers/platform/maxim/max32650/maxim_delay.c
@@ -79,11 +79,18 @@ void no_os_mdelay(uint32_t msecs)
 struct no_os_time no_os_get_time(void)
 {
 	struct no_os_time t;
+	uint64_t sub_ms;
+	uint32_t systick_val;
+	uint64_t ticks;
 
-	t.s = _system_ticks / 1000;
+	SysTick->CTRL &= ~(SysTick_CTRL_TICKINT_Msk | SysTick_CTRL_ENABLE_Msk);
+	systick_val = SysTick->VAL;
+	ticks = _system_ticks;
+	SysTick->CTRL |= SysTick_CTRL_TICKINT_Msk | SysTick_CTRL_ENABLE_Msk;
 
-	t.us = (_system_ticks - t.s * 1000) * 1000 + SysTick->VAL /
-	       (SystemCoreClock / 1000000);
+	sub_ms = ((SysTick->LOAD - systick_val) * 1000) / SysTick->LOAD;
+	t.s = ticks / 1000;
+	t.us = (ticks - t.s * 1000) * 1000 + sub_ms;
 
 	return t;
 }

--- a/drivers/platform/maxim/max32655/maxim_delay.c
+++ b/drivers/platform/maxim/max32655/maxim_delay.c
@@ -79,11 +79,18 @@ void no_os_mdelay(uint32_t msecs)
 struct no_os_time no_os_get_time(void)
 {
 	struct no_os_time t;
+	uint64_t sub_ms;
+	uint32_t systick_val;
+	uint64_t ticks;
 
-	t.s = _system_ticks / 1000;
+	SysTick->CTRL &= ~(SysTick_CTRL_TICKINT_Msk | SysTick_CTRL_ENABLE_Msk);
+	systick_val = SysTick->VAL;
+	ticks = _system_ticks;
+	SysTick->CTRL |= SysTick_CTRL_TICKINT_Msk | SysTick_CTRL_ENABLE_Msk;
 
-	t.us = (_system_ticks - t.s * 1000) * 1000 + SysTick->VAL /
-	       (SystemCoreClock / 1000000);
+	sub_ms = ((SysTick->LOAD - systick_val) * 1000) / SysTick->LOAD;
+	t.s = ticks / 1000;
+	t.us = (ticks - t.s * 1000) * 1000 + sub_ms;
 
 	return t;
 }

--- a/drivers/platform/maxim/max32660/maxim_delay.c
+++ b/drivers/platform/maxim/max32660/maxim_delay.c
@@ -79,11 +79,18 @@ void no_os_mdelay(uint32_t msecs)
 struct no_os_time no_os_get_time(void)
 {
 	struct no_os_time t;
+	uint64_t sub_ms;
+	uint32_t systick_val;
+	uint64_t ticks;
 
-	t.s = _system_ticks / 1000;
+	SysTick->CTRL &= ~(SysTick_CTRL_TICKINT_Msk | SysTick_CTRL_ENABLE_Msk);
+	systick_val = SysTick->VAL;
+	ticks = _system_ticks;
+	SysTick->CTRL |= SysTick_CTRL_TICKINT_Msk | SysTick_CTRL_ENABLE_Msk;
 
-	t.us = (_system_ticks - t.s * 1000) * 1000 + SysTick->VAL /
-	       (SystemCoreClock / 1000000);
+	sub_ms = ((SysTick->LOAD - systick_val) * 1000) / SysTick->LOAD;
+	t.s = ticks / 1000;
+	t.us = (ticks - t.s * 1000) * 1000 + sub_ms;
 
 	return t;
 }

--- a/drivers/platform/maxim/max32665/maxim_delay.c
+++ b/drivers/platform/maxim/max32665/maxim_delay.c
@@ -79,11 +79,18 @@ void no_os_mdelay(uint32_t msecs)
 struct no_os_time no_os_get_time(void)
 {
 	struct no_os_time t;
+	uint64_t sub_ms;
+	uint32_t systick_val;
+	uint64_t ticks;
 
-	t.s = _system_ticks / 1000;
+	SysTick->CTRL &= ~(SysTick_CTRL_TICKINT_Msk | SysTick_CTRL_ENABLE_Msk);
+	systick_val = SysTick->VAL;
+	ticks = _system_ticks;
+	SysTick->CTRL |= SysTick_CTRL_TICKINT_Msk | SysTick_CTRL_ENABLE_Msk;
 
-	t.us = (_system_ticks - t.s * 1000) * 1000 + SysTick->VAL /
-	       (SystemCoreClock / 1000000);
+	sub_ms = ((SysTick->LOAD - systick_val) * 1000) / SysTick->LOAD;
+	t.s = ticks / 1000;
+	t.us = (ticks - t.s * 1000) * 1000 + sub_ms;
 
 	return t;
 }

--- a/drivers/platform/maxim/max32670/maxim_delay.c
+++ b/drivers/platform/maxim/max32670/maxim_delay.c
@@ -79,11 +79,18 @@ void no_os_mdelay(uint32_t msecs)
 struct no_os_time no_os_get_time(void)
 {
 	struct no_os_time t;
+	uint64_t sub_ms;
+	uint32_t systick_val;
+	uint64_t ticks;
 
-	t.s = _system_ticks / 1000;
+	SysTick->CTRL &= ~(SysTick_CTRL_TICKINT_Msk | SysTick_CTRL_ENABLE_Msk);
+	systick_val = SysTick->VAL;
+	ticks = _system_ticks;
+	SysTick->CTRL |= SysTick_CTRL_TICKINT_Msk | SysTick_CTRL_ENABLE_Msk;
 
-	t.us = (_system_ticks - t.s * 1000) * 1000 + SysTick->VAL /
-	       (SystemCoreClock / 1000000);
+	sub_ms = ((SysTick->LOAD - systick_val) * 1000) / SysTick->LOAD;
+	t.s = ticks / 1000;
+	t.us = (ticks - t.s * 1000) * 1000 + sub_ms;
 
 	return t;
 }

--- a/drivers/platform/maxim/max32690/maxim_delay.c
+++ b/drivers/platform/maxim/max32690/maxim_delay.c
@@ -79,11 +79,18 @@ void no_os_mdelay(uint32_t msecs)
 struct no_os_time no_os_get_time(void)
 {
 	struct no_os_time t;
+	uint64_t sub_ms;
+	uint32_t systick_val;
+	uint64_t ticks;
 
-	t.s = _system_ticks / 1000;
+	SysTick->CTRL &= ~(SysTick_CTRL_TICKINT_Msk | SysTick_CTRL_ENABLE_Msk);
+	systick_val = SysTick->VAL;
+	ticks = _system_ticks;
+	SysTick->CTRL |= SysTick_CTRL_TICKINT_Msk | SysTick_CTRL_ENABLE_Msk;
 
-	t.us = (_system_ticks - t.s * 1000) * 1000 + SysTick->VAL /
-	       (SystemCoreClock / 1000000);
+	sub_ms = ((SysTick->LOAD - systick_val) * 1000) / SysTick->LOAD;
+	t.s = ticks / 1000;
+	t.us = (ticks - t.s * 1000) * 1000 + sub_ms;
 
 	return t;
 }

--- a/drivers/platform/maxim/max78000/maxim_delay.c
+++ b/drivers/platform/maxim/max78000/maxim_delay.c
@@ -79,11 +79,18 @@ void no_os_mdelay(uint32_t msecs)
 struct no_os_time no_os_get_time(void)
 {
 	struct no_os_time t;
+	uint64_t sub_ms;
+	uint32_t systick_val;
+	uint64_t ticks;
 
-	t.s = _system_ticks / 1000;
+	SysTick->CTRL &= ~(SysTick_CTRL_TICKINT_Msk | SysTick_CTRL_ENABLE_Msk);
+	systick_val = SysTick->VAL;
+	ticks = _system_ticks;
+	SysTick->CTRL |= SysTick_CTRL_TICKINT_Msk | SysTick_CTRL_ENABLE_Msk;
 
-	t.us = (_system_ticks - t.s * 1000) * 1000 + SysTick->VAL /
-	       (SystemCoreClock / 1000000);
+	sub_ms = ((SysTick->LOAD - systick_val) * 1000) / SysTick->LOAD;
+	t.s = ticks / 1000;
+	t.us = (ticks - t.s * 1000) * 1000 + sub_ms;
 
 	return t;
 }


### PR DESCRIPTION
Fix the following issues related to the systick counter to no_os_time conversion:

- The systick couter is decreasing from SysTick->LOAD to 0 every millisecond (and generating an interrupt once it reaches 0), thus we need to use SysTick->LOAD - SysTick->VAL instead of only SysTick->VAL in order to count microseconds in the [0, 999] in the correct order. The current implmentation assumes the SysTick is increasing it's value.

- For the [0, 999] microsecond range, rewrite the expression in order to make it clearer what is being computed.

- Capture the values of _system_ticks and SysTick->VAL before computing the time since those operations are not atomic, and the systick's value will change in the meantime. This will result in invalid s and us values.

- Disable the systick counter before capturing _system_ticks and SysTick->VAL, since a count to 0 interrupt may be generated in between, leading to invalid time results.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
