### PR TITLE
buid_projects.yml: set timeout for all platforms

### DIFF
--- a/build_projects.yml
+++ b/build_projects.yml
@@ -61,6 +61,7 @@ jobs:
       publishLocation: 'pipeline'
 
 - job: STM32
+  timeoutInMinutes: 200
   pool:
     name: Default
     demands:
@@ -93,6 +94,7 @@ jobs:
       publishLocation: 'pipeline'
 
 - job: Maxim
+  timeoutInMinutes: 200
   pool:
     name: Default
     demands:
@@ -125,6 +127,7 @@ jobs:
       publishLocation: 'pipeline'
 
 - job: Mbed
+  timeoutInMinutes: 200
   pool:
     name: Default
     demands:
@@ -157,6 +160,7 @@ jobs:
       publishLocation: 'pipeline'
 
 - job: Pico
+  timeoutInMinutes: 200
   pool:
     name: Default
     demands:
@@ -189,6 +193,7 @@ jobs:
       publishLocation: 'pipeline'
 
 - job: ADuCM3029
+  timeoutInMinutes: 200
   pool:
     name: Default
     demands:


### PR DESCRIPTION
## Pull Request Description
Similar to the Xilinx job, increase all the platform timeouts to a custom value of 200.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
