### PR TITLE
drivers: platform: maxim: Fix irq_desc removal

### DIFF
--- a/drivers/platform/maxim/max32650/maxim_irq.c
+++ b/drivers/platform/maxim/max32650/maxim_irq.c
@@ -72,6 +72,7 @@ static struct event_list _events[] = {
 	[NO_OS_EVT_USB] = {.event = NO_OS_EVT_USB},
 };
 
+static struct no_os_irq_ctrl_desc *nvic;
 extern mxc_uart_req_t uart_irq_state[MXC_UART_INSTANCES];
 extern bool is_callback;
 
@@ -386,6 +387,11 @@ int32_t max_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 	if (!param)
 		return -EINVAL;
 
+	if (nvic) {
+		descriptor = nvic;
+		return 0;
+	}
+
 	descriptor = no_os_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
@@ -394,6 +400,7 @@ int32_t max_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 	descriptor->extra = param->extra;
 
 	*desc = descriptor;
+	nvic = descriptor;
 
 	return 0;
 }
@@ -415,6 +422,7 @@ int32_t max_irq_ctrl_remove(struct no_os_irq_ctrl_desc *desc)
 		no_os_list_remove(_events[i].actions);
 	}
 	no_os_free(desc);
+	nvic = NULL;
 
 	return 0;
 }

--- a/drivers/platform/maxim/max32655/maxim_irq.c
+++ b/drivers/platform/maxim/max32655/maxim_irq.c
@@ -70,6 +70,7 @@ static struct event_list _events[] = {
 	[NO_OS_EVT_DMA_TX_COMPLETE] = {.event = NO_OS_EVT_DMA_TX_COMPLETE},
 };
 
+static struct no_os_irq_ctrl_desc *nvic;
 extern mxc_uart_req_t uart_irq_state[MXC_UART_INSTANCES];
 extern bool is_callback;
 
@@ -369,6 +370,11 @@ int32_t max_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 	if (!param)
 		return -EINVAL;
 
+	if (nvic) {
+		descriptor = nvic;
+		return 0;
+	}
+
 	descriptor = no_os_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
@@ -377,6 +383,7 @@ int32_t max_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 	descriptor->extra = param->extra;
 
 	*desc = descriptor;
+	nvic = descriptor;
 
 	return 0;
 }
@@ -399,6 +406,7 @@ int32_t max_irq_ctrl_remove(struct no_os_irq_ctrl_desc *desc)
 		_events[i].actions = NULL;
 	}
 	no_os_free(desc);
+	nvic = NULL;
 
 	return 0;
 }

--- a/drivers/platform/maxim/max32660/maxim_irq.c
+++ b/drivers/platform/maxim/max32660/maxim_irq.c
@@ -70,6 +70,7 @@ static struct event_list _events[] = {
 	[NO_OS_EVT_DMA_TX_COMPLETE] = {.event = NO_OS_EVT_DMA_TX_COMPLETE},
 };
 
+static struct no_os_irq_ctrl_desc *nvic;
 extern mxc_uart_req_t uart_irq_state[MXC_UART_INSTANCES];
 extern bool is_callback;
 
@@ -369,6 +370,11 @@ int32_t max_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 	if (!param)
 		return -EINVAL;
 
+	if (nvic) {
+		descriptor = nvic;
+		return 0;
+	}
+
 	descriptor = no_os_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
@@ -377,6 +383,7 @@ int32_t max_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 	descriptor->extra = param->extra;
 
 	*desc = descriptor;
+	nvic = descriptor;
 
 	return 0;
 }
@@ -399,6 +406,7 @@ int32_t max_irq_ctrl_remove(struct no_os_irq_ctrl_desc *desc)
 		_events[i].actions = NULL;
 	}
 	no_os_free(desc);
+	nvic = NULL;
 
 	return 0;
 }

--- a/drivers/platform/maxim/max32665/maxim_irq.c
+++ b/drivers/platform/maxim/max32665/maxim_irq.c
@@ -71,6 +71,7 @@ static struct event_list _events[] = {
 	[NO_OS_EVT_USB] = {.event = NO_OS_EVT_USB},
 };
 
+static struct no_os_irq_ctrl_desc *nvic;
 extern mxc_uart_req_t uart_irq_state[MXC_UART_INSTANCES];
 extern bool is_callback;
 
@@ -390,6 +391,11 @@ int32_t max_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 	if (!param)
 		return -EINVAL;
 
+	if (nvic) {
+		descriptor = nvic;
+		return 0;
+	}
+
 	descriptor = no_os_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
@@ -398,6 +404,7 @@ int32_t max_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 	descriptor->extra = param->extra;
 
 	*desc = descriptor;
+	nvic = descriptor;
 
 	return 0;
 }
@@ -420,6 +427,7 @@ int32_t max_irq_ctrl_remove(struct no_os_irq_ctrl_desc *desc)
 		_events[i].actions = NULL;
 	}
 	no_os_free(desc);
+	nvic = NULL;
 
 	return 0;
 }

--- a/drivers/platform/maxim/max32670/maxim_irq.c
+++ b/drivers/platform/maxim/max32670/maxim_irq.c
@@ -63,6 +63,7 @@ static struct event_list _events[] = {
 	[NO_OS_EVT_TIM_ELAPSED] = {.event = NO_OS_EVT_TIM_ELAPSED},
 };
 
+static struct no_os_irq_ctrl_desc *nvic;
 extern mxc_uart_req_t uart_irq_state[MXC_UART_INSTANCES];
 extern bool is_callback;
 
@@ -253,6 +254,11 @@ int max_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 	if (!param)
 		return -EINVAL;
 
+	if (nvic) {
+		descriptor = nvic;
+		return 0;
+	}
+
 	descriptor = no_os_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
@@ -261,6 +267,7 @@ int max_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 	descriptor->extra = param->extra;
 
 	*desc = descriptor;
+	nvic = descriptor;
 
 	return 0;
 }
@@ -284,6 +291,7 @@ int max_irq_ctrl_remove(struct no_os_irq_ctrl_desc *desc)
 		_events[i].actions = NULL;
 	}
 	no_os_free(desc);
+	nvic = NULL;
 
 	return 0;
 }

--- a/drivers/platform/maxim/max32690/maxim_irq.c
+++ b/drivers/platform/maxim/max32690/maxim_irq.c
@@ -67,6 +67,7 @@ static struct event_list _events[] = {
 	[NO_OS_EVT_USB] = {.event = NO_OS_EVT_USB},
 };
 
+static struct no_os_irq_ctrl_desc *nvic;
 extern mxc_uart_req_t uart_irq_state[MXC_UART_INSTANCES];
 extern bool is_callback;
 
@@ -377,6 +378,11 @@ int32_t max_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 	if (!param)
 		return -EINVAL;
 
+	if (nvic) {
+		descriptor = nvic;
+		return 0;
+	}
+
 	descriptor = no_os_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
@@ -385,6 +391,7 @@ int32_t max_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 	descriptor->extra = param->extra;
 
 	*desc = descriptor;
+	nvic = descriptor;
 
 	return 0;
 }
@@ -407,6 +414,7 @@ int32_t max_irq_ctrl_remove(struct no_os_irq_ctrl_desc *desc)
 		_events[i].actions = NULL;
 	}
 	free(desc);
+	nvic = NULL;
 
 	return 0;
 }

--- a/drivers/platform/maxim/max78000/maxim_irq.c
+++ b/drivers/platform/maxim/max78000/maxim_irq.c
@@ -70,6 +70,7 @@ static struct event_list _events[] = {
 	[NO_OS_EVT_DMA_TX_COMPLETE] = {.event = NO_OS_EVT_DMA_TX_COMPLETE},
 };
 
+static struct no_os_irq_ctrl_desc *nvic;
 extern mxc_uart_req_t uart_irq_state[MXC_UART_INSTANCES];
 extern bool is_callback;
 
@@ -369,6 +370,11 @@ int32_t max_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 	if (!param)
 		return -EINVAL;
 
+	if (nvic) {
+		descriptor = nvic;
+		return 0;
+	}
+
 	descriptor = no_os_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
@@ -377,6 +383,7 @@ int32_t max_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 	descriptor->extra = param->extra;
 
 	*desc = descriptor;
+	nvic = descriptor;
 
 	return 0;
 }
@@ -399,6 +406,7 @@ int32_t max_irq_ctrl_remove(struct no_os_irq_ctrl_desc *desc)
 		_events[i].actions = NULL;
 	}
 	no_os_free(desc);
+	nvic = NULL;
 
 	return 0;
 }


### PR DESCRIPTION
Currently, there may be multiple interrupt controllers allocated, even though there is only one hardware instance (NVIC). The issue is that is no_os_irq_ctrl_remove() is called for an interrupt controller with ref = 0, all the callback functions will be removed, even those which were registered using another controller.

Fix this by turning the interrupt controller into a shared reference, thus max_irq_ctrl_remove() will only be called once ref = 0.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
