### PR TITLE
adrv9009: src: app: app_transceiver.c: Fix deinit

### DIFF
--- a/projects/adrv9009/src/app/app_transceiver.c
+++ b/projects/adrv9009/src/app/app_transceiver.c
@@ -196,7 +196,7 @@ void fpga_xcvr_deinit(void)
 	adxcvr_remove(rx_os_adxcvr);
 	adxcvr_remove(tx_adxcvr);
 #endif
-#ifndef ADRV9008_1
+#ifndef ADRV9008_2
 	adxcvr_remove(rx_adxcvr);
 #endif
 }


### PR DESCRIPTION
## Pull Request Description

Set the deinit function to remove the rx_adxcvr component for ADRV9009 and ADRV9008-1 devices (ADRV9008-2 does not have Rx).

Fixes: b013932 ("projects:adrv9009:add support for adrv9008-1/2")

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
