### PR TITLE
adrv9009: headless.c: Remove ObsRx for ADRV9008-1

### DIFF
--- a/projects/adrv9009/src/app/headless.c
+++ b/projects/adrv9009/src/app/headless.c
@@ -361,13 +361,13 @@ int main(void)
 
 #endif
 
+#ifndef ADRV9008_1
 	status = axi_adc_init(&rx_os_adc, &rx_os_adc_init);
 	if (status) {
 		printf("OBS axi_adc_init() failed with status %d\n", status);
 		goto error_3;
 	}
 
-#ifndef ADRV9008_1
 	status = axi_dmac_init(&tx_dmac, &tx_dmac_init);
 	if (status) {
 		printf("axi_dmac_init() tx init error: %d\n", status);


### PR DESCRIPTION
## Pull Request Description

Remove the Obs Rx ADC for the ADRV9008-1 device.

Fixes: 926a732 ("adrv9009: Add ADRV9008_2 Rx obs components")

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
