### PR TITLE
platform: drivers: maxim: Assign the proper irq_ctrl_desc

### DIFF
--- a/drivers/platform/maxim/max32650/maxim_irq.c
+++ b/drivers/platform/maxim/max32650/maxim_irq.c
@@ -388,7 +388,7 @@ int32_t max_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 		return -EINVAL;
 
 	if (nvic) {
-		descriptor = nvic;
+		*desc = nvic;
 		return 0;
 	}
 

--- a/drivers/platform/maxim/max32655/maxim_irq.c
+++ b/drivers/platform/maxim/max32655/maxim_irq.c
@@ -371,7 +371,7 @@ int32_t max_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 		return -EINVAL;
 
 	if (nvic) {
-		descriptor = nvic;
+		*desc = nvic;
 		return 0;
 	}
 

--- a/drivers/platform/maxim/max32660/maxim_irq.c
+++ b/drivers/platform/maxim/max32660/maxim_irq.c
@@ -371,7 +371,7 @@ int32_t max_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 		return -EINVAL;
 
 	if (nvic) {
-		descriptor = nvic;
+		*desc = nvic;
 		return 0;
 	}
 

--- a/drivers/platform/maxim/max32665/maxim_irq.c
+++ b/drivers/platform/maxim/max32665/maxim_irq.c
@@ -392,7 +392,7 @@ int32_t max_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 		return -EINVAL;
 
 	if (nvic) {
-		descriptor = nvic;
+		*desc = nvic;
 		return 0;
 	}
 

--- a/drivers/platform/maxim/max32670/maxim_irq.c
+++ b/drivers/platform/maxim/max32670/maxim_irq.c
@@ -255,7 +255,7 @@ int max_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 		return -EINVAL;
 
 	if (nvic) {
-		descriptor = nvic;
+		*desc = nvic;
 		return 0;
 	}
 

--- a/drivers/platform/maxim/max32690/maxim_irq.c
+++ b/drivers/platform/maxim/max32690/maxim_irq.c
@@ -379,7 +379,7 @@ int32_t max_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 		return -EINVAL;
 
 	if (nvic) {
-		descriptor = nvic;
+		*desc = nvic;
 		return 0;
 	}
 

--- a/drivers/platform/maxim/max78000/maxim_irq.c
+++ b/drivers/platform/maxim/max78000/maxim_irq.c
@@ -371,7 +371,7 @@ int32_t max_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 		return -EINVAL;
 
 	if (nvic) {
-		descriptor = nvic;
+		*desc = nvic;
 		return 0;
 	}
 


### PR DESCRIPTION
Assign the user's no_os_irq_ctrl_desc instead of the local one.

Fixes: 353a1bf57 ("drivers: platform: maxim: Fix irq_desc removal")

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
