### PR TITLE
accel: adxl313: adxl313.h: Fix ADXL314 scale factor

### DIFF
--- a/drivers/accel/adxl313/adxl313.h
+++ b/drivers/accel/adxl313/adxl313.h
@@ -212,7 +212,7 @@
 /* Self-test multiplication factor */
 #define ADXL312_SELF_TEST_MULT					2900
 #define ADXL313_SELF_TEST_MULT					976
-#define ADXL314_SELF_TEST_MULT					4883
+#define ADXL314_SELF_TEST_MULT					48830
 #define ADXL313_SELF_TEST_DIV					1000
 
 /* Self-test minimum deviation for ADXL312, mg */


### PR DESCRIPTION
## Pull Request Description

The datasheet specifies a 48.83 mg/LSB scale factor, and not 4.883 mg/LSB.

Fixes: 48d3db8 ("drivers:accel_adxl313: ADXL313 driver update")

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
