### PR TITLE
projects: ad400x_fmcz: Fix enable offload flag

### DIFF
--- a/projects/ad400x-fmcz/src/examples/examples_src.mk
+++ b/projects/ad400x-fmcz/src/examples/examples_src.mk
@@ -6,7 +6,7 @@ INCS += $(PROJECT)/src/examples/basic_example/basic_example.h
 endif
 
 ifeq (xilinx,$(PLATFORM))
-CFLAGS += -DSPI_ENGINE_OFFLOAD_EXAMPLE
+CFLAGS += -DSPI_ENGINE_OFFLOAD_ENABLE
 endif
 ifeq (stm32,$(PLATFORM))
 CFLAGS += -DUSE_STANDARD_SPI


### PR DESCRIPTION
## Pull Request Description

The flag to enable offload for the xilinix platform is wrong. Correct this so that offload is enabled by default for the xilinx platform.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
