### PR TITLE
Fix spi engine offload

### DIFF
--- a/drivers/adc/ad400x/ad400x.c
+++ b/drivers/adc/ad400x/ad400x.c
@@ -193,7 +193,7 @@ static int32_t ad400x_read_data_offload(struct ad400x_dev *dev,
 	msg.rx_addr = buf;
 	msg.commands_data = commands_data;
 
-	ret = spi_engine_offload_transfer(dev->spi_desc, msg, samples * 4);
+	ret = spi_engine_offload_transfer(dev->spi_desc, msg, samples);
 	if (ret)
 		return ret;
 

--- a/drivers/axi_core/axi_dmac/axi_dmac.c
+++ b/drivers/axi_core/axi_dmac/axi_dmac.c
@@ -285,9 +285,12 @@ static int32_t axi_dmac_detect_caps(struct axi_dmac *dmac)
 	uint32_t reg_val, initial_reg_val = 0;
 	uint32_t src_mem_mapped = 0;
 	uint32_t dest_mem_mapped = 0;
+	uint32_t intf_desc = 0;
 
 	dmac->max_length = -1;
 	dmac->direction = INVALID_DIR;
+	dmac->width_dst = -1;
+	dmac->width_src = -1;
 
 	/* Check if HW cyclic possible */
 	axi_dmac_read(dmac, AXI_DMAC_REG_FLAGS, &initial_reg_val);
@@ -307,6 +310,11 @@ static int32_t axi_dmac_detect_caps(struct axi_dmac *dmac)
 	axi_dmac_read(dmac, AXI_DMAC_REG_DEST_ADDRESS, &dest_mem_mapped);
 	axi_dmac_write(dmac, AXI_DMAC_REG_SRC_ADDRESS, 0xffffffff);
 	axi_dmac_read(dmac, AXI_DMAC_REG_SRC_ADDRESS, &src_mem_mapped);
+	axi_dmac_read(dmac, AXI_DMAC_REG_INTF_DESC, &intf_desc);
+	dmac->width_dst = no_os_field_get(AXI_DMAC_DMA_BPB_DEST, intf_desc);
+	dmac->width_dst = (1 << dmac->width_dst);
+	dmac->width_src = no_os_field_get(AXI_DMAC_DMA_BPB_SRC, intf_desc);
+	dmac->width_src = (1 << dmac->width_src);
 
 	if (dest_mem_mapped && !src_mem_mapped) {
 		dmac->direction = DMA_DEV_TO_MEM;

--- a/drivers/axi_core/axi_dmac/axi_dmac.h
+++ b/drivers/axi_core/axi_dmac/axi_dmac.h
@@ -54,7 +54,9 @@
 #define AXI_DMAC_IRQ_EOT			NO_OS_BIT(1)
 
 #define AXI_DMAC_REG_INTF_DESC		0x010
+#define AXI_DMAC_DMA_BPB_DEST		NO_OS_GENMASK(3,0)
 #define AXI_DMAC_DMA_TYPE_DEST		NO_OS_GENMASK(5,4)
+#define AXI_DMAC_DMA_BPB_SRC		NO_OS_GENMASK(11,8)
 #define AXI_DMAC_DMA_TYPE_SRC		NO_OS_GENMASK(13,12)
 //Define macro for src and dest
 
@@ -118,6 +120,8 @@ struct axi_dmac {
 	enum dma_direction direction;
 	bool hw_cyclic;
 	uint32_t max_length;
+	uint32_t width_dst;
+	uint32_t width_src;
 	volatile struct axi_dma_transfer transfer;
 	//Current sub-transfer properties
 	uint32_t init_addr;

--- a/drivers/axi_core/spi_engine/spi_engine.c
+++ b/drivers/axi_core/spi_engine/spi_engine.c
@@ -844,12 +844,10 @@ int32_t spi_engine_offload_transfer(struct no_os_spi_desc *desc,
 
 	/* Start transfer */
 	spi_engine_write(eng_desc, SPI_ENGINE_REG_OFFLOAD_CTRL(0), 0x0001);
-
-	word_length = spi_get_word_lenght(eng_desc);
 	if(eng_desc->offload_config & OFFLOAD_TX_EN) {
 		struct axi_dma_transfer tx_transfer = {
 			// Number of bytes to write/read
-			.size = word_length * eng_desc->offload_tx_len * no_samples,
+			.size = eng_desc->offload_tx_dma->width_src * eng_desc->offload_tx_len * no_samples,
 			// Transfer done flag
 			.transfer_done = 0,
 			// Signal transfer mode
@@ -865,7 +863,7 @@ int32_t spi_engine_offload_transfer(struct no_os_spi_desc *desc,
 	if(eng_desc->offload_config & OFFLOAD_RX_EN) {
 		struct axi_dma_transfer rx_transfer = {
 			// Number of bytes to write/read
-			.size = word_length * eng_desc->offload_tx_len * no_samples,
+			.size = 4 * eng_desc->offload_tx_len * no_samples,
 			// Transfer done flag
 			.transfer_done = 0,
 			// Signal transfer mode


### PR DESCRIPTION
## Fix spi engine offload

The bytes that are transfered on dma per sample depend
on the DMA_DATA_WIDTH_SRC of the dma IP not on the data_width
bytes sent by the spi_engine on the spi bus.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
