### PR TITLE
drivers: spi_engine: Dont hardcode rx dma size

### DIFF
--- a/drivers/axi_core/spi_engine/spi_engine.c
+++ b/drivers/axi_core/spi_engine/spi_engine.c
@@ -863,7 +863,7 @@ int32_t spi_engine_offload_transfer(struct no_os_spi_desc *desc,
 	if(eng_desc->offload_config & OFFLOAD_RX_EN) {
 		struct axi_dma_transfer rx_transfer = {
 			// Number of bytes to write/read
-			.size = 4 * eng_desc->offload_tx_len * no_samples,
+			.size = eng_desc->offload_rx_dma->width_src * eng_desc->offload_tx_len * no_samples,
 			// Transfer done flag
 			.transfer_done = 0,
 			// Signal transfer mode


### PR DESCRIPTION
The rx offload size can be 2, 4 or more bytes, it should use the size read from the IP and not be hardcoded to 4.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
