### PR TITLE
projects: ad-acevsecrdset-sl: Changed "Test supply ..." debug message

### DIFF
--- a/projects/ad-acevsecrdset-sl/src/self_test/self_test.c
+++ b/projects/ad-acevsecrdset-sl/src/self_test/self_test.c
@@ -96,8 +96,7 @@ int self_test_supply(struct stout *stout, struct rms_adc_values *rms_adc_values)
 		cnt++;
 	}
 	cnt = 0;
-	pr_debug("TEST SUPPLY: Vin %d mV, v1_rms_adc: %d, V2 %d mV\n",
-		 rms_adc_values->v1_rms, rms_adc_values->v1_rms_adc, rms_adc_values->v2_rms);
+	pr_debug("TEST SUPPLY: Vin %d mV \n", rms_adc_values->v1_rms);
 	if (INTF_INPUT_V_ERR_U != stout->err_status) {
 		if ((VIN_LOW_LIMIT < rms_adc_values->v1_rms)
 		    && (VIN_HIGH_LIMIT > rms_adc_values->v1_rms))


### PR DESCRIPTION
Removed v1(Vin) ADE rms value and v2(relay voltage) from the debug message.

## Pull Request Description

Changed the "Test supply" debug message. Removed two values and left only the rms supply voltage.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
