### PR TITLE
drivers: More driver fixes for offload_transfer size

### DIFF
--- a/drivers/adc/ad463x/ad463x.c
+++ b/drivers/adc/ad463x/ad463x.c
@@ -434,15 +434,15 @@ int32_t ad463x_read_data(struct ad463x_dev *dev,
 	msg.commands_data = commands_data;
 
 	if (dev->dcache_invalidate_range)
-		dev->dcache_invalidate_range(msg.rx_addr, samples * 2);
+		dev->dcache_invalidate_range(msg.rx_addr, samples * 2 * sizeof(buf[0]));
 
-	ret = spi_engine_offload_transfer(dev->spi_desc, msg,
-					  (int)(samples*4/dev->read_bytes_no));
+	/* both channels are read with a single transfer */
+	ret = spi_engine_offload_transfer(dev->spi_desc, msg, samples);
 	if (ret != 0)
 		return ret;
 
 	if (dev->dcache_invalidate_range)
-		dev->dcache_invalidate_range(msg.rx_addr, samples * 2);
+		dev->dcache_invalidate_range(msg.rx_addr, samples * 2 * sizeof(buf[0]));
 
 	return ret;
 }

--- a/drivers/adc/ad469x/ad469x.c
+++ b/drivers/adc/ad469x/ad469x.c
@@ -829,7 +829,7 @@ int32_t ad469x_read_data(struct ad469x_dev *dev,
 	msg.rx_addr = (uint32_t)buf;
 	msg.commands_data = commands_data;
 
-	ret = spi_engine_offload_transfer(dev->spi_desc, msg, samples * 2);
+	ret = spi_engine_offload_transfer(dev->spi_desc, msg, samples);
 	if (ret != 0)
 		return ret;
 

--- a/drivers/adc/ad713x/iio_ad713x.c
+++ b/drivers/adc/ad713x/iio_ad713x.c
@@ -468,8 +468,7 @@ static int32_t ad713x_iio_read_dev(struct ad713x_iio *desc, uint32_t *buff,
 	if (!desc)
 		return -1;
 
-	bytes = nb_samples * desc->iio_dev->num_ch *
-		(desc->iio_dev->channels[0].scan_type->storagebits / 8);
+	bytes = nb_samples * desc->iio_dev->num_ch * sizeof(buff[0]);
 
 	spi_eng_msg_cmds[0] = READ(4);
 
@@ -482,7 +481,7 @@ static int32_t ad713x_iio_read_dev(struct ad713x_iio *desc, uint32_t *buff,
 	if (desc->dcache_invalidate_range)
 		desc->dcache_invalidate_range(msg.rx_addr, bytes);
 
-	ret = spi_engine_offload_transfer(desc->spi_eng_desc, msg, bytes);
+	ret = spi_engine_offload_transfer(desc->spi_eng_desc, msg, nb_samples);
 	if (ret < 0)
 		return ret;
 

--- a/drivers/adc/ad713x/iio_dual_ad713x.c
+++ b/drivers/adc/ad713x/iio_dual_ad713x.c
@@ -121,10 +121,9 @@ static int32_t _iio_ad713x_read_dev(struct iio_ad713x *desc, uint32_t *buff,
 	if (!desc)
 		return -1;
 
-	bytes = nb_samples * desc->iio_dev_desc.num_ch *
-		(BITS_PER_SAMPLE / 8);
+	bytes = nb_samples * desc->iio_dev_desc.num_ch * sizeof(buff[0]);
 	msg = desc->spi_engine_offload_message;
-	ret = spi_engine_offload_transfer(desc->spi_eng_desc, *msg, bytes);
+	ret = spi_engine_offload_transfer(desc->spi_eng_desc, *msg, nb_samples);
 	if (ret < 0)
 		return ret;
 


### PR DESCRIPTION
There seems to have been some mixup between what "sample" means when using offload_transfer function. Drivers sometimes sending number of bytes, and sometimes sending number of chip samples to collect, when in reality The offload_transfer funtion parameters define the "sample" argument as "Number of time the messages will be transferred"

A bug were the spi_engine would trasfer less bytes than num_samples required, may have added to the mixup, making drivers ask for more messages to fill (and sometimes overrun) their data buffer.

Also, some chips collect one channel per offload transaction (ad400x, ad469x) while others collect multiple channels per offload transaction (ad4630x), perhaps ad713x?

ad400x (single channel, 32bit DMA) one message for single channel:
	total_offload_mesages = num_sampels

ad469x (16 channels, 32bit DMA) one message per channel:
	total_offload_mesages = num_sampels * num_channel_active.

ad4630x (2 channel, 64bit DMA) one message for 2 channels:
	total_offload_mesages = num_sampels;

ad713x (4 channel, 128bit DMA) one message for 4 channels:
	total_offload_mesages = num_sampels; (not tested in real hw!)

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
