### PR TITLE
drivers: ad400x: Support more pulsar parts

### DIFF
--- a/drivers/adc/ad400x/ad400x.c
+++ b/drivers/adc/ad400x/ad400x.c
@@ -52,19 +52,34 @@
 #include "no_os_alloc.h"
 #include "no_os_util.h"
 
-
 const struct ad400x_dev_info ad400x_devices[] = {
-	[ID_AD4000] = {.resolution = 16, .sign = 'u'},
-	[ID_AD4001] = {.resolution = 16, .sign = 's'},
-	[ID_AD4002] = {.resolution = 18, .sign = 'u'},
-	[ID_AD4003] = {.resolution = 18, .sign = 's'},
-	[ID_AD4004] = {.resolution = 16, .sign = 'u'},
-	[ID_AD4005] = {.resolution = 16, .sign = 's'},
-	[ID_AD4006] = {.resolution = 18, .sign = 'u'},
-	[ID_AD4007] = {.resolution = 18, .sign = 's'},
-	[ID_AD4011] = {.resolution = 18, .sign = 's'},
-	[ID_AD4020] = {.resolution = 20, .sign = 's'},
-	[ID_ADAQ4003] = {.resolution = 18, .sign = 's'}
+	[ID_AD4000] = {.resolution = 16, .sign = 'u', .max_rate = 2000},
+	[ID_AD4001] = {.resolution = 16, .sign = 's', .max_rate = 2000},
+	[ID_AD4002] = {.resolution = 18, .sign = 'u', .max_rate = 2000},
+	[ID_AD4003] = {.resolution = 18, .sign = 's', .max_rate = 2000},
+	[ID_AD4004] = {.resolution = 16, .sign = 'u', .max_rate = 1000},
+	[ID_AD4005] = {.resolution = 16, .sign = 's', .max_rate = 1000},
+	[ID_AD4006] = {.resolution = 18, .sign = 'u', .max_rate = 1000},
+	[ID_AD4007] = {.resolution = 18, .sign = 's', .max_rate = 1000},
+	[ID_AD4008] = {.resolution = 16, .sign = 'u', .max_rate = 500},
+	[ID_AD4010] = {.resolution = 18, .sign = 'u', .max_rate = 500},
+	[ID_AD4011] = {.resolution = 18, .sign = 's', .max_rate = 500},
+	[ID_AD4020] = {.resolution = 20, .sign = 's', .max_rate = 1800},
+	[ID_AD4021] = {.resolution = 20, .sign = 's', .max_rate = 1000},
+	[ID_AD4022] = {.resolution = 20, .sign = 's', .max_rate = 500},
+	[ID_ADAQ4003] = {.resolution = 18, .sign = 's',.max_rate = 2000},
+	[ID_AD7690] = {.resolution = 18, .sign = 's', .max_rate = 400},
+	[ID_AD7691] = {.resolution = 18, .sign = 's', .max_rate = 250},
+	[ID_AD7693] = {.resolution = 16, .sign = 's', .max_rate = 500},
+	[ID_AD7942] = {.resolution = 14, .sign = 'u', .max_rate = 250},
+	[ID_AD7944] = {.resolution = 14, .sign = 'u', .max_rate = 2500},
+	[ID_AD7946] = {.resolution = 14, .sign = 's', .max_rate = 500},
+	[ID_AD7980] = {.resolution = 16, .sign = 'u', .max_rate = 1000},
+	[ID_AD7982] = {.resolution = 18, .sign = 's', .max_rate = 1000},
+	[ID_AD7983] = {.resolution = 16, .sign = 'u', .max_rate = 1330},
+	[ID_AD7984] = {.resolution = 18, .sign = 's', .max_rate = 1330},
+	[ID_AD7985] = {.resolution = 16, .sign = 'u', .max_rate = 2500},
+	[ID_AD7986] = {.resolution = 18, .sign = 's', .max_rate = 2000},
 };
 
 /******************************************************************************/
@@ -337,6 +352,13 @@ int32_t ad400x_init(struct ad400x_dev **device,
 	ret = axi_clkgen_set_rate(dev->clkgen, init_param->axi_clkgen_rate);
 	if (ret)
 		goto error;
+
+	/* Calculate pwm rate given the part sample rate */
+	if (init_param->trigger_pwm_init->period_ns == 0) {
+		init_param->trigger_pwm_init->period_ns =
+			NO_OS_DIV_ROUND_UP(1000000, ad400x_devices[dev->dev_id].max_rate);
+		init_param->trigger_pwm_init->duty_cycle_ns = 10;
+	}
 
 	ret = no_os_pwm_init(&dev->trigger_pwm_desc, init_param->trigger_pwm_init);
 	if (ret)

--- a/drivers/adc/ad400x/ad400x.h
+++ b/drivers/adc/ad400x/ad400x.h
@@ -72,14 +72,31 @@ enum ad400x_supported_dev_ids {
 	ID_AD4005,
 	ID_AD4006,
 	ID_AD4007,
+	ID_AD4008,
+	ID_AD4010,
 	ID_AD4011,
 	ID_AD4020,
+	ID_AD4021,
+	ID_AD4022,
 	ID_ADAQ4003,
+	ID_AD7690,
+	ID_AD7691,
+	ID_AD7693,
+	ID_AD7942,
+	ID_AD7944,
+	ID_AD7946,
+	ID_AD7980,
+	ID_AD7982,
+	ID_AD7983,
+	ID_AD7984,
+	ID_AD7985,
+	ID_AD7986,
 };
 
 struct ad400x_dev_info {
 	uint16_t resolution;
 	char sign;
+	uint16_t max_rate;
 };
 
 struct ad400x_dev {

--- a/projects/ad400x-fmcz/src/common/common_data.c
+++ b/projects/ad400x-fmcz/src/common/common_data.c
@@ -83,8 +83,8 @@ struct axi_clkgen_init clkgen_init = {
 };
 
 struct no_os_pwm_init_param trigger_pwm_init = {
-	.period_ns = PWM_PERIOD,
-	.duty_cycle_ns = PWM_DUTY,
+	.period_ns = 0, /* set by driver max sample rate */
+	.duty_cycle_ns = 0,
 	.polarity = NO_OS_PWM_POLARITY_HIGH,
 	.platform_ops = PWM_OPS,
 	.extra = PWM_EXTRA,


### PR DESCRIPTION
Add more parts to the list of supported parts by the ad4000 drivers

the ad400x driver might need to be renamed to pulsar_adc at some point. 

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
