### PR TITLE
spi-engine: fix data_width read from HDL

### DIFF
--- a/drivers/axi_core/spi_engine/spi_engine.c
+++ b/drivers/axi_core/spi_engine/spi_engine.c
@@ -666,7 +666,9 @@ int32_t spi_engine_init(struct no_os_spi_desc **desc,
 
 	/* Get current data width */
 	spi_engine_read(eng_desc, SPI_ENGINE_REG_DATA_WIDTH, &data_width);
-	eng_desc->max_data_width = data_width;
+	/* Only the lower 16 bits are relevant for the actual data-width */
+	eng_desc->max_data_width = no_os_field_get(SPI_ENGINE_REG_DATA_WIDTH_MSK,
+				   data_width);
 
 	spi_engine_set_transfer_width(*desc, spi_engine_init->data_width);
 

--- a/drivers/axi_core/spi_engine/spi_engine_private.h
+++ b/drivers/axi_core/spi_engine/spi_engine_private.h
@@ -65,6 +65,10 @@
 #define SPI_ENGINE_REG_SDI_DATA_FIFO		0xE8
 #define SPI_ENGINE_REG_SDI_DATA_FIFO_PEEK	0xEC
 
+/* Bit definitions for SPI_ENGINE_REG_DATA_WIDTH register */
+#define SPI_ENGINE_REG_NUM_OF_SDI_MSK		NO_OS_GENMASK(23, 16)
+#define SPI_ENGINE_REG_DATA_WIDTH_MSK		NO_OS_GENMASK(15, 0)
+
 /******************************************************************************/
 /************************ Spi Engine register parameters **********************/
 /******************************************************************************/


### PR DESCRIPTION
## Pull Request Description

It's only the lower 16 bits that are actually the data-width in register 0xC.
Bits 23:16 are NUM_SDI.
```
      8'h03: up_rdata_ff <= {8'b0, NUM_OF_SDI, DATA_WIDTH};
```

Link:
  https://github.com/analogdevicesinc/hdl/blob/d95528a533cefc6d82b9fdebd30ee85b3e10c880/library/spi_engine/axi_spi_engine/axi_spi_engine.v#L348

## PR Type
- [x] Bug fix (change that fixes an issue)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
