### PR TITLE
ad7606: add PWM and AXI clock-gen support for driver

### DIFF
--- a/drivers/adc/ad7606/ad7606.c
+++ b/drivers/adc/ad7606/ad7606.c
@@ -228,6 +228,8 @@ static const uint16_t tconv_max[] = {
 struct ad7606_axi_dev {
 	/* Clock gen for hdl design structure */
 	struct axi_clkgen *clkgen;
+	/* Trigger conversion PWM generator descriptor */
+	struct no_os_pwm_desc *trigger_pwm_desc;
 };
 
 /**
@@ -1197,6 +1199,10 @@ static int32_t ad7606_axi_init(struct ad7606_dev *device,
 	if (ret != 0)
 		goto error;
 
+	ret = no_os_pwm_init(&axi->trigger_pwm_desc, axi_init->trigger_pwm_init);
+	if (ret != 0)
+		goto error;
+
 	/* Note: more validation will be added later */
 error:
 	return ret;
@@ -1368,6 +1374,7 @@ void ad7606_axi_remove(struct ad7606_dev *dev)
 
 	axi = &dev->axi_dev;
 
+	no_os_pwm_remove(axi->trigger_pwm_desc);
 	axi_clkgen_remove(axi->clkgen);
 }
 

--- a/drivers/adc/ad7606/ad7606.c
+++ b/drivers/adc/ad7606/ad7606.c
@@ -221,6 +221,58 @@ static const uint16_t tconv_max[] = {
 	324	/* AD7606_OSR_256 */
 };
 
+/**
+ * @struct ad7606_dev
+ * @brief Device driver structure
+ */
+struct ad7606_dev {
+	/** SPI descriptor*/
+	struct no_os_spi_desc *spi_desc;
+	/** RESET GPIO descriptor */
+	struct no_os_gpio_desc *gpio_reset;
+	/** CONVST GPIO descriptor */
+	struct no_os_gpio_desc *gpio_convst;
+	/** BUSY GPIO descriptor */
+	struct no_os_gpio_desc *gpio_busy;
+	/** STBYn GPIO descriptor */
+	struct no_os_gpio_desc *gpio_stby_n;
+	/** RANGE GPIO descriptor */
+	struct no_os_gpio_desc *gpio_range;
+	/** OS0 GPIO descriptor */
+	struct no_os_gpio_desc *gpio_os0;
+	/** OS1 GPIO descriptor */
+	struct no_os_gpio_desc *gpio_os1;
+	/** OS2 GPIO descriptor */
+	struct no_os_gpio_desc *gpio_os2;
+	/** PARn/SER GPIO descriptor */
+	struct no_os_gpio_desc *gpio_par_ser;
+	/** Device ID */
+	enum ad7606_device_id device_id;
+	/** Oversampling settings */
+	struct ad7606_oversampling oversampling;
+	/** Whether the device is running in hardware or software mode */
+	bool sw_mode;
+	/** Whether the device is running in register or ADC reading mode */
+	bool reg_mode;
+	/** Number of DOUT lines supported by the device */
+	enum ad7606_dout_format max_dout_lines;
+	/** Configuration register settings */
+	struct ad7606_config config;
+	/** Digital diagnostics register settings */
+	struct ad7606_digital_diag digital_diag_enable;
+	/** Number of input channels of the device */
+	uint8_t num_channels;
+	/** Channel offset calibration */
+	int8_t offset_ch[AD7606_MAX_CHANNELS];
+	/** Channel phase calibration */
+	uint8_t phase_ch[AD7606_MAX_CHANNELS];
+	/** Channel gain calibration */
+	uint8_t gain_ch[AD7606_MAX_CHANNELS];
+	/** Channel operating range */
+	struct ad7606_range range_ch[AD7606_MAX_CHANNELS];
+	/** Data buffer (used internally by the SPI communication functions) */
+	uint8_t data[28];
+};
 
 /***************************************************************************//**
  * @brief Read a device register via SPI.

--- a/drivers/adc/ad7606/ad7606.h
+++ b/drivers/adc/ad7606/ad7606.h
@@ -50,6 +50,7 @@
 #include "no_os_spi.h"
 #include "no_os_util.h"
 
+#include "no_os_pwm.h"
 #include "clk_axi_clkgen.h"
 
 /******************************************************************************/
@@ -281,6 +282,8 @@ struct ad7606_axi_init_param {
 	struct axi_clkgen_init *clkgen_init;
 	/* Clock generator rate */
 	uint32_t axi_clkgen_rate;
+	/* PWM generator init structure */
+	struct no_os_pwm_init_param *trigger_pwm_init;
 };
 
 /**

--- a/drivers/adc/ad7606/ad7606.h
+++ b/drivers/adc/ad7606/ad7606.h
@@ -268,54 +268,7 @@ struct ad7606_digital_diag {
  * @struct ad7606_dev
  * @brief Device driver structure
  */
-struct ad7606_dev {
-	/** SPI descriptor*/
-	struct no_os_spi_desc *spi_desc;
-	/** RESET GPIO descriptor */
-	struct no_os_gpio_desc *gpio_reset;
-	/** CONVST GPIO descriptor */
-	struct no_os_gpio_desc *gpio_convst;
-	/** BUSY GPIO descriptor */
-	struct no_os_gpio_desc *gpio_busy;
-	/** STBYn GPIO descriptor */
-	struct no_os_gpio_desc *gpio_stby_n;
-	/** RANGE GPIO descriptor */
-	struct no_os_gpio_desc *gpio_range;
-	/** OS0 GPIO descriptor */
-	struct no_os_gpio_desc *gpio_os0;
-	/** OS1 GPIO descriptor */
-	struct no_os_gpio_desc *gpio_os1;
-	/** OS2 GPIO descriptor */
-	struct no_os_gpio_desc *gpio_os2;
-	/** PARn/SER GPIO descriptor */
-	struct no_os_gpio_desc *gpio_par_ser;
-	/** Device ID */
-	enum ad7606_device_id device_id;
-	/** Oversampling settings */
-	struct ad7606_oversampling oversampling;
-	/** Whether the device is running in hardware or software mode */
-	bool sw_mode;
-	/** Whether the device is running in register or ADC reading mode */
-	bool reg_mode;
-	/** Number of DOUT lines supported by the device */
-	enum ad7606_dout_format max_dout_lines;
-	/** Configuration register settings */
-	struct ad7606_config config;
-	/** Digital diagnostics register settings */
-	struct ad7606_digital_diag digital_diag_enable;
-	/** Number of input channels of the device */
-	uint8_t num_channels;
-	/** Channel offset calibration */
-	int8_t offset_ch[AD7606_MAX_CHANNELS];
-	/** Channel phase calibration */
-	uint8_t phase_ch[AD7606_MAX_CHANNELS];
-	/** Channel gain calibration */
-	uint8_t gain_ch[AD7606_MAX_CHANNELS];
-	/** Channel operating range */
-	struct ad7606_range range_ch[AD7606_MAX_CHANNELS];
-	/** Data buffer (used internally by the SPI communication functions) */
-	uint8_t data[28];
-};
+struct ad7606_dev;
 
 /**
  * @struct ad7606_dev

--- a/drivers/adc/ad7606/ad7606.h
+++ b/drivers/adc/ad7606/ad7606.h
@@ -50,6 +50,8 @@
 #include "no_os_spi.h"
 #include "no_os_util.h"
 
+#include "clk_axi_clkgen.h"
+
 /******************************************************************************/
 /********************** Macros and Constants Definitions **********************/
 /******************************************************************************/
@@ -271,12 +273,25 @@ struct ad7606_digital_diag {
 struct ad7606_dev;
 
 /**
- * @struct ad7606_dev
+ * @struct ad7606_axi_init_param
+ * @brief AXI driver(s) initialization parameters
+ */
+struct ad7606_axi_init_param {
+	/* Clock generator init parameters */
+	struct axi_clkgen_init *clkgen_init;
+	/* Clock generator rate */
+	uint32_t axi_clkgen_rate;
+};
+
+/**
+ * @struct ad7606_init_param
  * @brief Device driver initialization parameters
  */
 struct ad7606_init_param {
 	/** SPI initialization parameters */
 	struct no_os_spi_init_param spi_init;
+	/* AXI initialization parameters */
+	struct ad7606_axi_init_param *axi_init;
 	/** RESET GPIO initialization parameters */
 	struct no_os_gpio_init_param *gpio_reset;
 	/** CONVST GPIO initialization parameters */


### PR DESCRIPTION
## Pull Request Description

This is just a preliminary change that can go in before others, to add AXI/SPI-engine support to the driver.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
