### PR TITLE
drivers: spi-engine: remove unused variable

### DIFF
--- a/drivers/axi_core/spi_engine/spi_engine.c
+++ b/drivers/axi_core/spi_engine/spi_engine.c
@@ -811,7 +811,6 @@ int32_t spi_engine_offload_transfer(struct no_os_spi_desc *desc,
 	struct spi_engine_msg	transfer;
 	struct spi_engine_desc	*eng_desc;
 	uint32_t 		i;
-	uint8_t 		word_length;
 
 	eng_desc = desc->extra;
 


### PR DESCRIPTION
During commit c24331264 ("drivers: axi_core: Fix offload xfer size") this was omitted (for removal).

Fixes: c24331264 ("drivers: axi_core: Fix offload xfer size")

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
