### PR TITLE
drivers: ad7606: pass channel init params to dev struct

### DIFF
--- a/drivers/adc/ad7606/ad7606.c
+++ b/drivers/adc/ad7606/ad7606.c
@@ -1164,6 +1164,11 @@ int32_t ad7606_init(struct ad7606_dev **device,
 	if (ret < 0)
 		goto error;
 
+	/* Copy init parameters here, ad7606_reset() will clear these */
+	memcpy(dev->gain_ch, init_param->gain_ch, sizeof(dev->gain_ch));
+	memcpy(dev->phase_ch, init_param->phase_ch, sizeof(dev->phase_ch));
+	memcpy(dev->offset_ch, init_param->offset_ch, sizeof(dev->offset_ch));
+
 	/* wait DEVICE_SETUP time */
 	no_os_udelay(253);
 


### PR DESCRIPTION
The ad7606_reset() function will clear the channel gain/offset/phase parameters.
As such, the ad7606_init() function will never initialize these parameters.

To fix that, we just memcpy() them right after a call to ad7606_reset().

Fixes: c5ce09e9c0 ("ad7606: Add basic support for AD7606 family of devices")

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
