### PR TITLE
spi-engine: de-pointerize the dma_flags field in init params

### DIFF
--- a/drivers/axi_core/spi_engine/spi_engine.c
+++ b/drivers/axi_core/spi_engine/spi_engine.c
@@ -768,10 +768,10 @@ int32_t spi_engine_offload_init(struct no_os_spi_desc *desc,
 
 	eng_desc->offload_config = param->offload_config;
 
-	if(!(param->dma_flags)) {
+	if(!param->dma_flags) {
 		eng_desc->cyclic = CYCLIC;
 	} else {
-		if((*(param->dma_flags)) & DMA_CYCLIC)
+		if(param->dma_flags & DMA_CYCLIC)
 			eng_desc->cyclic = CYCLIC;
 		else
 			eng_desc->cyclic = NO;

--- a/drivers/axi_core/spi_engine/spi_engine.h
+++ b/drivers/axi_core/spi_engine/spi_engine.h
@@ -148,7 +148,7 @@ struct spi_engine_offload_init_param {
 	/** Base address where the TX DMAC core is situated */
 	uint32_t	tx_dma_baseaddr;
 	/** DMAC flags - if not initialized, the default value is DMA_CYCLIC */
-	uint32_t	*dma_flags;
+	uint32_t	dma_flags;
 	/** Offload's module transfer direction : TX, RX or both */
 	uint8_t		offload_config;
 };

--- a/projects/ad713x_fmcz/src/ad713x_fmc.c
+++ b/projects/ad713x_fmcz/src/ad713x_fmc.c
@@ -261,7 +261,7 @@ int main()
 
 	spi_engine_offload_init_param.rx_dma_baseaddr = AD7134_DMA_BASEADDR;
 	spi_engine_offload_init_param.offload_config = OFFLOAD_RX_EN;
-	spi_engine_offload_init_param.dma_flags = &spi_eng_dma_flg;
+	spi_engine_offload_init_param.dma_flags = spi_eng_dma_flg;
 
 	ret = no_os_spi_init(&spi_eng_desc, &spi_eng_init_prm);
 	if (ret != 0)

--- a/projects/cn0561/src/cn0561.c
+++ b/projects/cn0561/src/cn0561.c
@@ -233,7 +233,7 @@ int main()
 
 	spi_engine_offload_init_param.rx_dma_baseaddr = CN0561_DMA_BASEADDR;
 	spi_engine_offload_init_param.offload_config = OFFLOAD_RX_EN;
-	spi_engine_offload_init_param.dma_flags = &spi_eng_dma_flg;
+	spi_engine_offload_init_param.dma_flags = spi_eng_dma_flg;
 
 	ret = no_os_spi_init(&spi_eng_desc, &spi_eng_init_prm);
 	if (ret != 0)


### PR DESCRIPTION
## Pull Request Description

The 'dma_flags' field in the spi_engine_offload_init_param struct is a pointer to an uint32_t.
This seems a bit much; if this field is 0 (not initialized), the default behavior (or CYCLIC DMA) is maintained.
It mostly looks like un-necessary reference/dereference.

Also, there are only 2 projects that use this field. Changing them to the new behavior looks simple.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
