### PR TITLE
drivers: axi_core: Add spi engine stubs

### DIFF
--- a/drivers/axi_core/clk_axi_clkgen/clk_axi_clkgen.c
+++ b/drivers/axi_core/clk_axi_clkgen/clk_axi_clkgen.c
@@ -40,6 +40,8 @@
 /******************************************************************************/
 /***************************** Include Files **********************************/
 /******************************************************************************/
+#include "clk_axi_clkgen.h"
+#ifndef USE_STANDARD_SPI
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -48,7 +50,6 @@
 #include "no_os_alloc.h"
 #include "no_os_error.h"
 #include "no_os_delay.h"
-#include "clk_axi_clkgen.h"
 #include "no_os_axi_io.h"
 
 /******************************************************************************/
@@ -549,3 +550,22 @@ int32_t axi_clkgen_remove(struct axi_clkgen *clkgen)
 
 	return 0;
 }
+#else
+int32_t axi_clkgen_set_rate(struct axi_clkgen *clkgen, uint32_t rate)
+{
+	return 0;
+}
+int32_t axi_clkgen_get_rate(struct axi_clkgen *clkgen, uint32_t *rate)
+{
+	return 0;
+}
+int32_t axi_clkgen_init(struct axi_clkgen **clk,
+			const struct axi_clkgen_init *init)
+{
+	return 0;
+}
+int32_t axi_clkgen_remove(struct axi_clkgen *clkgen)
+{
+	return 0;
+}
+#endif

--- a/drivers/axi_core/spi_engine/spi_engine.c
+++ b/drivers/axi_core/spi_engine/spi_engine.c
@@ -44,7 +44,9 @@
 /* In debug mode the printf function used in displaying the messages is causing
 significant delays */
 //#define DEBUG_LEVEL 2
+#include "spi_engine.h"
 
+#ifndef USE_STANDARD_SPI
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -906,3 +908,59 @@ int32_t spi_engine_remove(struct no_os_spi_desc *desc)
 
 	return 0;
 }
+
+#else
+int32_t spi_engine_write(struct spi_engine_desc *desc,
+			 uint32_t reg_addr,
+			 uint32_t reg_data)
+{
+	return 0;
+}
+
+int32_t spi_engine_read(struct spi_engine_desc *desc,
+			uint32_t reg_addr,
+			uint32_t *reg_data)
+{
+	return 0;
+}
+
+int32_t spi_engine_init(struct no_os_spi_desc **desc,
+			const struct no_os_spi_init_param *param)
+{
+	return 0;
+}
+
+int32_t spi_engine_write_and_read(struct no_os_spi_desc *desc,
+				  uint8_t *data,
+				  uint16_t bytes_number)
+{
+	return 0;
+}
+
+int32_t spi_engine_remove(struct no_os_spi_desc *desc)
+{
+	return 0;
+}
+
+int32_t spi_engine_offload_init(struct no_os_spi_desc *desc,
+				const struct spi_engine_offload_init_param *param)
+{
+	return 0;
+}
+
+int32_t spi_engine_offload_transfer(struct no_os_spi_desc *desc,
+				    struct spi_engine_offload_message msg,
+				    uint32_t no_samples)
+{
+	return 0;
+}
+
+int32_t spi_engine_set_transfer_width(struct no_os_spi_desc *desc,
+				      uint8_t data_wdith)
+{
+	return 0;
+}
+
+void spi_engine_set_speed(struct no_os_spi_desc *desc,
+			  uint32_t speed_hz) { }
+#endif


### PR DESCRIPTION
Currently divers are using STANDARD_SPI macro to wrap all spi engine calls when the platform does not support spi_engine.

Add stub functions to spi_engine and clkgen so that drivers can avoid the use of STANDARD_SPI macro and use a runtime a flag instead.


## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
