### PR TITLE
drivers:dac:ltc2672: Fix current_to_code api

### DIFF
--- a/drivers/dac/ltc2672/ltc2672.c
+++ b/drivers/dac/ltc2672/ltc2672.c
@@ -155,7 +155,7 @@ uint32_t ltc2672_current_to_code(struct ltc2672_dev *device,
 		current_code = ((dac_current * LTC2672_12BIT_RESO) /
 				device->max_currents[out_ch]);
 	else
-		current_code = ((dac_current * LTC2672_16BIT_RESO) /
+		current_code = (((uint64_t)dac_current * LTC2672_16BIT_RESO) /
 				device->max_currents[out_ch]);
 
 	return current_code;


### PR DESCRIPTION
Fix overflow of intermediate conversion value of
current in uA to code.

Fixes: 51f92f898c950b8e317cce2daca11da153ea6a10 ("dac: ltc2672: Remove float type usage")

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
