### PR TITLE
stm32: Enable Windows support and fix STM32CUBEIDE build

### DIFF
--- a/tools/scripts/stm32.mk
+++ b/tools/scripts/stm32.mk
@@ -50,7 +50,7 @@ EXTRA_INCS += $(call rwildcard, $(PROJECT_BUILD)/Inc, *.h)
 PLATFORM_INCS += $(sort $(foreach h,$(EXTRA_INCS), -I$(dir $h)))
 
 # Get the path of the .s script
-ASM_SRCS += $(call rwildcard, $(PROJECT_BUILD)/Startup,*.s)
+STARTUP_FILE += $(call rwildcard, $(PROJECT_BUILD)/Startup,*.s)
 
 # Get the path of the interrupts file
 ITC = $(call rwildcard, $(PROJECT_BUILD)/Src,*_it.c)
@@ -116,7 +116,7 @@ endif
 		-import "build/app" -data "build" \
 		$(HIDE)
 	sed -i  's/HAL_NVIC_EnableIRQ(\EXTI/\/\/ HAL_NVIC_EnableIRQ\(EXTI/' $(PROJECT_BUILD)/Src/generated_main.c $(HIDE)
-	$(shell python $(PLATFORM_TOOLS)/exti_script.py $(ASM_SRCS) $(EXTI_GEN_FILE))
+	$(shell python $(PLATFORM_TOOLS)/exti_script.py $(STARTUP_FILE) $(EXTI_GEN_FILE))
 	$(call copy_file, $(EXTI_GEN_FILE), $(PROJECT_BUILD)/Src/stm32_gpio_irq_generated.c) $(HIDE)
 
 	$(file > $(CPP_PROP_JSON).default,$(CPP_FINAL_CONTENT))


### PR DESCRIPTION
## Pull Request Description

**stm32: Enable Windows support** 

Passing the correct .jar file to java and using the relative paths instead of full paths are the required changes to enable the Windows building.

To avoid incompatibility issues, use the Java Runtime Environment provided by STM32CubeMX.
e.g.:
   export PATH=$PATH:/c/STMicroelectronics/STM32CubeMX/jre/bin
The other 2 environment variables required (similar to Linux) are STM32CUBEMX and STM32CUBEIDE.
e.g.:
   export STM32CUBEMX=/c/STMicroelectronics/STM32CubeMX
   export STM32CUBEIDE=/c/STMicroelectronics/STM32CubeIDE

**stm32: Fix STM32CUBEIDE build (Linux and Windows)**

generic.mk is linking $(ASM_SRCS), so, the startup file ends up being included
twice. This breaks the build of the project in STM32CUBEIDE.

Use a different name (e.g., STARTUP_FILE instead of ASM_SRCS) since the intend
in this case is to use this information only locally.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
