### PR TITLE
projects: eval-pqmon: iio_pqm.c: allow thd values over 100%

### DIFF
--- a/projects/eval-pqmon/src/common/iio_pqm.c
+++ b/projects/eval-pqmon/src/common/iio_pqm.c
@@ -402,9 +402,10 @@ int read_ch_attr(void *device, char *buf, uint32_t len,
 		case CHAN_THD:
 			return snprintf (
 				       buf, len, "%f",
-				       convert_pct_type (pqlibExample.output->params1012Cycles
-							 .voltageParams[channel->ch_num]
-							 .thd));
+				       ((float)(pqlibExample.output->params1012Cycles
+						.voltageParams[channel->ch_num]
+						.thd)
+					/ 100.0f));
 
 		case CHAN_VOLTAGE_UNDER_DEV:
 			return snprintf(
@@ -497,9 +498,10 @@ int read_ch_attr(void *device, char *buf, uint32_t len,
 		case CHAN_THD:
 			return snprintf (
 				       buf, len, "%f",
-				       convert_pct_type (pqlibExample.output->params1012Cycles
-							 .currentParams[channel->ch_num]
-							 .thd));
+				       (float)(pqlibExample.output->params1012Cycles
+					       .currentParams[channel->ch_num]
+					       .thd)
+				       / 100.0f);
 
 		default:
 			return snprintf(


### PR DESCRIPTION
Requested THD values have to be able to have values over 100%

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
