### PR TITLE
tools:scripts:build_projects.py: update build dir for stm32 projects

### DIFF
--- a/build_projects.yml
+++ b/build_projects.yml
@@ -39,7 +39,7 @@ jobs:
     persistCredentials: true
   - script: |
       export BRANCH=$(branch)
-      python3 ./tools/scripts/build_projects.py . \
+      python3 ./tools/scripts/build_projects.py $(Build.Repository.LocalPath) \
         -export_dir $(RELEASE_DIR) \
         -log_dir $(LOG_DIR) \
         -builds_dir /no-OS_builds/builds \
@@ -72,7 +72,7 @@ jobs:
     submodules: true
     clean: true
     persistCredentials: true
-  - script: 'python3 ./tools/scripts/build_projects.py .
+  - script: 'python3 ./tools/scripts/build_projects.py $(Build.Repository.LocalPath)
                -export_dir $(RELEASE_DIR)
                -log_dir $(LOG_DIR)
                -builds_dir /no-OS_builds/builds
@@ -105,7 +105,7 @@ jobs:
     submodules: true
     clean: true
     persistCredentials: true
-  - script: 'python3 ./tools/scripts/build_projects.py .
+  - script: 'python3 ./tools/scripts/build_projects.py $(Build.Repository.LocalPath)
                -export_dir $(RELEASE_DIR)
                -log_dir $(LOG_DIR)
                -builds_dir /no-OS_builds/builds
@@ -138,7 +138,7 @@ jobs:
     submodules: true
     clean: true
     persistCredentials: true
-  - script: 'python3 ./tools/scripts/build_projects.py .
+  - script: 'python3 ./tools/scripts/build_projects.py $(Build.Repository.LocalPath)
                -export_dir $(RELEASE_DIR)
                -log_dir $(LOG_DIR)
                -builds_dir /no-OS_builds/builds
@@ -171,7 +171,7 @@ jobs:
     submodules: true
     clean: true
     persistCredentials: true
-  - script: 'python3 ./tools/scripts/build_projects.py .
+  - script: 'python3 ./tools/scripts/build_projects.py $(Build.Repository.LocalPath)
                -export_dir $(RELEASE_DIR)
                -log_dir $(LOG_DIR)
                -builds_dir /no-OS_builds/builds
@@ -204,7 +204,7 @@ jobs:
     submodules: true
     clean: true
     persistCredentials: true
-  - script: 'python3 ./tools/scripts/build_projects.py .
+  - script: 'python3 ./tools/scripts/build_projects.py $(Build.Repository.LocalPath)
                -export_dir $(RELEASE_DIR)
                -log_dir $(LOG_DIR)
                -builds_dir /no-OS_builds/builds

--- a/tools/scripts/build_projects.py
+++ b/tools/scripts/build_projects.py
@@ -262,7 +262,10 @@ class BuildConfig:
 				self.project, platform, build_name, hardware)
 			self.boot_dir = "%s_%s_%s_%s" % (
 				self.project, platform, build_name, hardware)
-		self.build_dir = os.path.join(self.builds_dir, short_build_dir)
+		if (platform == 'stm32'):
+			self.build_dir = os.path.join(self.project_dir, 'build')
+		else:
+			self.build_dir = os.path.join(self.builds_dir, short_build_dir)
 		self.binary = os.path.join(self.build_dir, self._binary)
 		self.export_file = os.path.join(self.build_dir, self.binary)
 		if (platform == 'aducm3029' or platform == 'stm32' or platform == 'maxim'):


### PR DESCRIPTION
## Pull Request Description

After the modifications for stm32 platform to support windows builds the BUILD_DIR variable from make won't be used anymore, always the build will be made in the project directory under build folder.

Changed also the relative path to absolute ones for python script.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [x] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
