### PR TITLE
Change project titles from "Evaluating the XX" to "XX no-OS Example P…

### DIFF
--- a/projects/ad400x-fmcz/README.rst
+++ b/projects/ad400x-fmcz/README.rst
@@ -1,5 +1,5 @@
-Evaluating AD400x on ZED and SDP-K1
-====================================
+AD400x no-OS Example Project on ZED and SDP-K1
+==============================================
 
 Contents
 --------

--- a/projects/ad469x_fmcz/README.rst
+++ b/projects/ad469x_fmcz/README.rst
@@ -1,5 +1,5 @@
-Evaluating the AD469x
-======================
+AD469x no-OS Example Project
+============================
 
 
 Contents

--- a/projects/ad7091r8-sdz/README.rst
+++ b/projects/ad7091r8-sdz/README.rst
@@ -1,5 +1,5 @@
-Evaluating AD7091R-2/-4/-8 Devices
-==================================
+AD7091R-2/-4/-8 no-OS Example Project
+=====================================
 
 .. contents::
     :depth: 3

--- a/projects/ad7616-st/README.rst
+++ b/projects/ad7616-st/README.rst
@@ -1,5 +1,5 @@
-Evaluating AD7616 on SDP-K1
-===========================
+AD7616 no-OS Example Project on SDP-K1
+======================================
 
 .. contents::
     :depth: 3

--- a/projects/ad796x_fmcz/README.rst
+++ b/projects/ad796x_fmcz/README.rst
@@ -1,5 +1,5 @@
-Evaluating the AD796x
-======================
+AD796x no-OS Example Project
+============================
 
 
 Contents

--- a/projects/adf4382/README.rst
+++ b/projects/adf4382/README.rst
@@ -1,5 +1,5 @@
-Evaluating the ADF4382
-======================
+ADF4382 no-OS Example Project
+=============================
 
 Contents
 --------

--- a/projects/adp1050/README.rst
+++ b/projects/adp1050/README.rst
@@ -1,5 +1,5 @@
-Evaluating the ADP1050
-======================
+ADP1050 no-OS Example Project
+=============================
 
 .. contents::
 	:depth: 3

--- a/projects/adrv902x/README.rst
+++ b/projects/adrv902x/README.rst
@@ -1,6 +1,5 @@
-============================
-adrv902x no-OS Sample Poject
-============================
+adrv902x no-OS Example Project
+==============================
 
 Supported Devices
 =================

--- a/projects/apard32690/README.rst
+++ b/projects/apard32690/README.rst
@@ -1,5 +1,5 @@
-Evaluating the AD-APARD32690-SL
-===============================
+AD-APARD32690-SL no-OS Example Project
+======================================
 
 Prerequisites
 -------------

--- a/projects/eval-ade9430/README.rst
+++ b/projects/eval-ade9430/README.rst
@@ -1,5 +1,5 @@
-EVAL-ADE9430 Sensor-to-Cloud
-============================
+EVAL-ADE9430 Sensor-to-Cloud no-OS Example Project
+==================================================
 
 Building project
 ----------------

--- a/projects/eval-adis1646x/README.rst
+++ b/projects/eval-adis1646x/README.rst
@@ -1,5 +1,5 @@
-Evaluating the ADIS1646X Family
-===============================
+ADIS1646X Family no-OS Example Project
+======================================
 
 .. contents::
     :depth: 3

--- a/projects/eval-adis1647x/README.rst
+++ b/projects/eval-adis1647x/README.rst
@@ -1,5 +1,5 @@
-Evaluating the ADIS1647X Family
-===============================
+ADIS1647X Family no-OS Example Project
+======================================
 
 .. contents::
     :depth: 3

--- a/projects/eval-adis1650x/README.rst
+++ b/projects/eval-adis1650x/README.rst
@@ -1,5 +1,5 @@
-Evaluating the ADIS1650X Family
-===============================
+ADIS1650X Family no-OS Example Project
+======================================
 
 .. contents::
     :depth: 3

--- a/projects/eval-adis1654x/README.rst
+++ b/projects/eval-adis1654x/README.rst
@@ -1,5 +1,5 @@
-Evaluating the ADIS1654X Family
-===============================
+ADIS1654X Family no-OS Example Project
+======================================
 
 
 Contents

--- a/projects/eval-adis1655x/README.rst
+++ b/projects/eval-adis1655x/README.rst
@@ -1,5 +1,5 @@
-Evaluating the ADIS1655X Family
-===============================
+ADIS1655X Family no-OS Example Project
+======================================
 
 
 Contents

--- a/projects/eval-adis1657x/README.rst
+++ b/projects/eval-adis1657x/README.rst
@@ -1,5 +1,5 @@
-Evaluating the ADIS1657X Family
-===============================
+ADIS1657X Family no-OS Example Project
+======================================
 
 .. contents::
     :depth: 3

--- a/projects/eval-pqmon/README.md
+++ b/projects/eval-pqmon/README.md
@@ -1,5 +1,5 @@
-Evaluating the AD-PQMON-SL kit
-===============================
+AD-PQMON-SL kit no-OS Example Project
+=====================================
 
 ## Overview
 

--- a/projects/ltc4296/README.rst
+++ b/projects/ltc4296/README.rst
@@ -1,5 +1,5 @@
-Evaluating the LTC4296
-======================
+LTC4296 no-OS Example Project
+=============================
 
 
 Contents

--- a/projects/max14914/README.rst
+++ b/projects/max14914/README.rst
@@ -1,5 +1,5 @@
-Evaluating the MAX14914
-=======================
+MAX14914 no-OS Example Project
+==============================
 
 .. contents::
 	:depth: 3

--- a/projects/max14919/README.rst
+++ b/projects/max14919/README.rst
@@ -1,5 +1,5 @@
-Evaluating the MAX14919
-=======================
+MAX14919 no-OS Example Project
+==============================
 
 .. contents::
 	:depth: 3

--- a/projects/max2201x/README.rst
+++ b/projects/max2201x/README.rst
@@ -1,5 +1,5 @@
-Evaluating the MAX2201X
-=======================
+MAX2201X no-OS Example Project
+==============================
 
 .. contents::
 	:depth: 3


### PR DESCRIPTION
## Pull Request Description

Propose renaming example project documentation pages to "xx no-OS Example Project" to avoid confusion. "Evaluating the" is ambiguous, since "evaluation" can be done using other platforms / frameworks such as Linux and Zephyr. It also implies performance measurements or other system level testing, whereas the purpose of the no-OS project doc is building and running the example (more involved tests should be deferred to the board's user guide.)

This board's documentation is being updated, and it's a typical example that targets multiple platforms:
https://mthoren-adi.github.io/documentation/eval/user-guide/eval-adxl355-pmdz/index.html
Once the ADXL355 no-OS Example Project page is up, the user guide will link to it.


## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)
- [x] Enhancement

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
