### PR TITLE
drivers: spi_engine: Add idle SDO state option

### DIFF
--- a/drivers/axi_core/spi_engine/spi_engine.c
+++ b/drivers/axi_core/spi_engine/spi_engine.c
@@ -519,6 +519,7 @@ static int32_t spi_engine_compile_message(struct no_os_spi_desc *desc,
 		struct spi_engine_msg *msg)
 {
 	struct spi_engine_desc	*desc_extra;
+	uint8_t cfg_reg;
 
 	desc_extra = desc->extra;
 
@@ -535,14 +536,19 @@ static int32_t spi_engine_compile_message(struct no_os_spi_desc *desc,
 					    desc_extra->data_width));
 	/*
 	 * Configure the spi mode :
+	 * 	- sdo_idle_state
 	 *	- 3 wire
 	 *	- CPOL
 	 *	- CPHA
 	 */
+	cfg_reg = desc->mode;
+	if (desc_extra->sdo_idle_state != 0)
+		cfg_reg |= SPI_ENGINE_CONFIG_SDO_IDLE;
+
 	spi_engine_queue_append_cmd(&msg->cmds,
 				    SPI_ENGINE_CMD_CONFIG(
 					    SPI_ENGINE_CMD_REG_CONFIG,
-					    desc->mode));
+					    cfg_reg));
 
 	/* Add a sync command to signal that the transfer has finished */
 	spi_engine_queue_add_cmd(&msg->cmds, SPI_ENGINE_CMD_SYNC(_sync_id));

--- a/drivers/axi_core/spi_engine/spi_engine.h
+++ b/drivers/axi_core/spi_engine/spi_engine.h
@@ -97,6 +97,8 @@ struct spi_engine_init_param {
 	uint32_t		cs_delay;
 	/** Data with of one SPI transfer ( in bits ) */
 	uint8_t			data_width;
+	/**  output of SDO when CS is inactive or read-only transfers */
+	uint8_t			sdo_idle_state;
 };
 
 
@@ -135,6 +137,8 @@ struct spi_engine_desc {
 	uint8_t			data_width;
 	/** The maximum data width supported by the engine */
 	uint8_t 		max_data_width;
+	/**  output of SDO when CS is inactive or read-only transfers */
+	uint8_t			sdo_idle_state;
 };
 
 

--- a/drivers/axi_core/spi_engine/spi_engine_private.h
+++ b/drivers/axi_core/spi_engine/spi_engine_private.h
@@ -94,6 +94,7 @@
 #define SPI_ENGINE_CONFIG_CPHA			NO_OS_BIT(0)
 #define SPI_ENGINE_CONFIG_CPOL			NO_OS_BIT(1)
 #define SPI_ENGINE_CONFIG_3WIRE			NO_OS_BIT(2)
+#define SPI_ENGINE_CONFIG_SDO_IDLE		NO_OS_BIT(3)
 #define SPI_ENGINE_VERSION_MAJOR(x) 		((x >> 16) & 0xff)
 #define SPI_ENGINE_VERSION_MINOR(x) 		((x >> 8) & 0xff)
 #define SPI_ENGINE_VERSION_PATCH(x) 		(x & 0xff)


### PR DESCRIPTION

## Pull Request Description

Some devices need SDO to be high on idle. Allow the projects to configure this option. (added on spi_engine 1.3)

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
