### PR TITLE
max32650: Set IRQ action list as NULL on remove

### DIFF
--- a/drivers/platform/maxim/max32650/maxim_irq.c
+++ b/drivers/platform/maxim/max32650/maxim_irq.c
@@ -420,6 +420,7 @@ int32_t max_irq_ctrl_remove(struct no_os_irq_ctrl_desc *desc)
 		while (0 == no_os_list_get_first(_events[i].actions, &discard))
 			no_os_free(discard);
 		no_os_list_remove(_events[i].actions);
+		_events[i].actions = NULL;
 	}
 	no_os_free(desc);
 	nvic = NULL;


### PR DESCRIPTION
## Pull Request Description

This line was deleted by mistake in commit https://github.com/analogdevicesinc/no-OS/commit/a508f9bce73b2f7c7739435b2b561bac852bcb44
("drivers: platform: maxim: DMA API implementation"). Add it back.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
