### PR TITLE
stm32: Fix build

### DIFF
--- a/tools/scripts/stm32.mk
+++ b/tools/scripts/stm32.mk
@@ -51,6 +51,7 @@ PLATFORM_INCS += $(sort $(foreach h,$(EXTRA_INCS), -I$(dir $h)))
 
 # Get the path of the .s script
 STARTUP_FILE += $(call rwildcard, $(PROJECT_BUILD)/Startup,*.s)
+EXTRA_FILES += $(STARTUP_FILE)
 
 # Get the path of the interrupts file
 ITC = $(call rwildcard, $(PROJECT_BUILD)/Src,*_it.c)


### PR DESCRIPTION
## Pull Request Description

warning: cannot find entry symbol Reset_Handler; defaulting to 0000000008000000

Fixes: 420753309317 ("stm32: Fix STM32CUBEIDE build (Linux and Windows)")

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
