### PR TITLE
filter: admv8818: fix reg addr size

### DIFF
--- a/drivers/filter/admv8818/admv8818.c
+++ b/drivers/filter/admv8818/admv8818.c
@@ -75,13 +75,14 @@ static const unsigned long long freq_range_lpf[4][2] = {
  * @param data - Data value to write.
  * @return Returns 0 in case of success or negative error code otherwise.
  */
-int admv8818_spi_write(struct admv8818_dev *dev, uint8_t reg_addr,
+int admv8818_spi_write(struct admv8818_dev *dev, uint16_t reg_addr,
 		       uint8_t data)
 {
 	uint8_t buff[ADMV8818_BUFF_SIZE_BYTES];
 
-	buff[0] = reg_addr;
-	buff[1] = data;
+	buff[0] = no_os_field_get(NO_OS_GENMASK(15, 8), reg_addr);
+	buff[1] = no_os_field_get(NO_OS_GENMASK(7, 0), reg_addr);
+	buff[2] = data;
 
 	return no_os_spi_write_and_read(dev->spi_desc, buff,
 					ADMV8818_BUFF_SIZE_BYTES);
@@ -94,14 +95,16 @@ int admv8818_spi_write(struct admv8818_dev *dev, uint8_t reg_addr,
  * @param data - Data read from the device.
  * @return Returns 0 in case of success or negative error code otherwise.
  */
-int admv8818_spi_read(struct admv8818_dev *dev, uint8_t reg_addr,
+int admv8818_spi_read(struct admv8818_dev *dev, uint16_t reg_addr,
 		      uint8_t *data)
 {
 	uint8_t buff[ADMV8818_BUFF_SIZE_BYTES];
 	int ret;
 
-	buff[0] = ADMV8818_SPI_READ_CMD | reg_addr;
-	buff[1] = 0;
+	buff[0] = ADMV8818_SPI_READ_CMD | no_os_field_get(NO_OS_GENMASK(15, 8),
+			reg_addr);
+	buff[1] = no_os_field_get(NO_OS_GENMASK(7, 0), reg_addr);
+	buff[2] = 0;
 
 	ret = no_os_spi_write_and_read(dev->spi_desc, buff, ADMV8818_BUFF_SIZE_BYTES);
 	if(ret)
@@ -120,7 +123,7 @@ int admv8818_spi_read(struct admv8818_dev *dev, uint8_t reg_addr,
  * @param data - Data written to the device (requires prior bit shifting).
  * @return Returns 0 in case of success or negative error code otherwise.
  */
-int admv8818_spi_update_bits(struct admv8818_dev *dev, uint8_t reg_addr,
+int admv8818_spi_update_bits(struct admv8818_dev *dev, uint16_t reg_addr,
 			     uint8_t mask, uint8_t data)
 {
 	uint8_t read_val;

--- a/drivers/filter/admv8818/admv8818.h
+++ b/drivers/filter/admv8818/admv8818.h
@@ -104,7 +104,7 @@
 #define ADMV8818_LPF_WR0_MSK			NO_OS_GENMASK(3, 0)
 
 /* Specifications */
-#define ADMV8818_BUFF_SIZE_BYTES		2
+#define ADMV8818_BUFF_SIZE_BYTES		3
 #define ADMV8818_CHIP_ID			NO_OS_BIT(0)
 #define ADMV8818_SPI_READ_CMD			NO_OS_BIT(7)
 
@@ -148,15 +148,15 @@ struct admv8818_dev {
 };
 
 /** ADMV8818 SPI write */
-int admv8818_spi_write(struct admv8818_dev *dev, uint8_t reg_addr,
+int admv8818_spi_write(struct admv8818_dev *dev, uint16_t reg_addr,
 		       uint8_t data);
 
 /* ADMV8818 Register Update */
-int admv8818_spi_update_bits(struct admv8818_dev *dev, uint8_t reg_addr,
+int admv8818_spi_update_bits(struct admv8818_dev *dev, uint16_t reg_addr,
 			     uint8_t mask, uint8_t data);
 
 /** ADMV8818 SPI Read */
-int admv8818_spi_read(struct admv8818_dev *dev, uint8_t reg_addr,
+int admv8818_spi_read(struct admv8818_dev *dev, uint16_t reg_addr,
 		      uint8_t *data);
 
 /** Set the HPF Frequency */


### PR DESCRIPTION
## Pull Request Description

The reg address size should be 16 bits wide and not 8.

Fixes: 3755205 ("drivers:filter: add admv8818 support")

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
