### PR TITLE
Add driver for LT7170/LT7170-1, LT7171/LT7171-1

### DIFF
--- a/doc/sphinx/source/drivers/lt7170.rst
+++ b/doc/sphinx/source/drivers/lt7170.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../drivers/power/lt7170/README.rst

--- a/doc/sphinx/source/drivers_doc.rst
+++ b/doc/sphinx/source/drivers_doc.rst
@@ -76,5 +76,6 @@ POWER MANAGEMENT
    drivers/adp1050
    drivers/ltc2992
    drivers/ltc4296
+   drivers/lt7170
    drivers/lt7182s
    drivers/lt8722

--- a/doc/sphinx/source/projects/lt7170.rst
+++ b/doc/sphinx/source/projects/lt7170.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../projects/lt7170/README.rst

--- a/doc/sphinx/source/projects_doc.rst
+++ b/doc/sphinx/source/projects_doc.rst
@@ -70,6 +70,7 @@ POWER MANAGEMENT
 
    projects/adp1050
    projects/ltc4296
+   projects/lt7170
    projects/lt7182s
    projects/lt8722
 

--- a/drivers/power/lt7170/README.rst
+++ b/drivers/power/lt7170/README.rst
@@ -1,0 +1,287 @@
+LT7170 no-OS driver
+====================
+
+Supported Devices
+-----------------
+
+* `LT7170/LT7170-1 <https://www.analog.com/LT7170>`_
+* `LT7171/LT7171-1 <https://www.analog.com/LT7171>`_
+
+Overview
+--------
+
+The LT7170/LT7170-1 are monolithic DC/DC synchronous step-down regulators that 
+deliver up to 20 A of continuous output current. The LT7170-1 option has two 
+switching phases that are connected to two inductors to drive a 
+single-regulated output supply.
+
+Similarly, the LT7171/LT7171-1 are monolithic PolyPhase DC/DC synchronous 
+step-down regulators that also deliver up to 20A of continuous output current. 
+The LT7171-1 option has two switching phases that are connected to two 
+inductors to drive a single-regulated output supply.
+
+Both series offer quick, clean, low-overshoot switching edges deliver high 
+efficiency while minimizing electromagnetic interference (EMI) emissions.
+
+An I2C-based PMBus 1.3-compliant serial interface allows control of device 
+functions while providing telemetry information for system monitoring. The 
+LT7170/LT7170-1 and LT7171/LT7171-1 are supported by the LTpowerPlay graphical 
+user interface (GUI) tool.
+
+Applications
+------------
+
+LT7170
+-------
+
+* Communications, Storage, and Industrial Systems
+* Data Center and Solid-State Drives
+
+LT7170 Device Configuration
+----------------------------
+
+Driver Initialization
+---------------------
+
+In order to be able to use the device, you will have to provide the support
+for the communication protocol (I2C) alongside other GPIO pins if needed in the
+specific application (depends on the way the device is used).
+
+The first API to be called is **lt7170_init**. Make sure that it return 0,
+which means that the driver was initialized correctly.
+
+The initialization API uses the device descriptor and an initialization
+parameter. The initialization parameter contains the **chip_id** of the device 
+and the optional GPIO
+parameters for controlling POWER GOOD, RUN, FAULT and ALERT pins. Use of packet
+error checking and the external clock can also be configured in the parameter.
+These are defined in the header file of the driver.
+
+VOUT Configuration
+------------------
+
+The VOUT_COMMAND sets the output voltage, while the VOUT_MAX sets the upper
+limit on the commanded voltage. The output voltage and limit can be set using 
+the **lt7170_vout_value** API.
+
+The output voltage transition rate can be configured using the 
+**lt7170_vout_tr** API.
+
+Output voltage lower and higher margin can also be configured using the
+**lt7170_vout_margin** API.
+
+The OPERATION command via the **lt7170_set_operation** can be used to command
+the output voltage to be regulated at the high margin, low margin, or at the
+nominal VOUT_COMMAND. This can also be used to set a channel off.
+
+VIN Configuration
+-----------------
+
+VIN_ON and VIN_OFF command values sets the input voltage window at which power
+conversion will proceed. Both of which can be configured through the
+**lt7170_set_vin** API.
+
+Status Configuration
+--------------------
+
+Statuses bytes/words of the device can be read using **lt7170_read_status**
+API. Faults asserted by these statuses can be cleared using the
+**lt7170_clear_faults** API.
+
+Telemetry
+---------
+
+Measurements can be read using the **lt7170_read_value** API. Some telemetry 
+values includes input/output voltage,
+input/output current, external VCC, die temperature, and output power.
+
+The frequency at which telemetry values are converted, as well as enabling debug
+telemetries such as external VCC and ITH values, can be configured using the
+**lt7170_adc_control** API.
+
+Timing Configuration
+--------------------
+
+The TON_DELAY command sets the time from when a start condition is received
+until the output voltage starts to rise. The TON_RISE sets the time from the
+from the time the output starts to rise to the time the output enters the
+regulation band. The TOFF_DELAY command sets the time from when a stop condition
+is received until the output voltage starts to fall. The TOFF_FALL command sets
+the time from the end of the turn-off delay time until the output voltage is
+commanded to zero. These commands can be set using the **lt7170_set_timing**
+API.
+
+Overvalue and Undervalue Limits Configuration
+---------------------------------------------
+
+Overvalue and undervalue limits sets the threshold at which the device voltage,
+current, temperature, and timing must meet. When these measurements cross the
+limits, a status bit may be asserted. These limits can be configured using the
+**lt7170_set_limit** API.
+
+PWM Configuration
+-----------------
+
+The PWM can be set on forced continuous mode or on
+pulse skip mode. This can be set using the **lt7170_pwm_mode** API.
+
+The phase offset of the PWM can also be set using the
+**lt7170_pwm_phase** API.
+
+Clock Configuration
+-------------------
+
+When using the device in parallel with others of the same device, the PWM clock
+of all devices can be synchronized. Using an external clock or enabling the
+clock input can be configured using the **lt7170_sync_config** API.
+
+NVM commands
+------------
+
+The device has an internal EEPROM that saves the settings configured to the
+device even when power is removed. The **lt7170_nvm_cmd** API allows the user
+to lock and unlock EEPROM, and store, compare and restore user settings.
+
+Software Reset Configuration
+----------------------------
+
+Software Reset operation is available through **lt7170_software_reset** API.
+
+LT7170 Driver Initialization Example
+-------------------------------------
+
+.. code-block:: bash
+
+	struct lt7170_dev *lt7170_dev;
+        struct no_os_i2c_init_param lt7170_i2c_ip = {
+		.device_id = I2C_DEVICE_ID,
+		.max_speed_hz = 100000,
+		.platform_ops = I2C_OPS,
+		.slave_address = LT7170_PMBUS_ADDRESS,
+		.extra = I2C_EXTRA,
+	};
+
+	struct lt7170_init_param lt7170_ip = {
+		.i2c_init = &lt7170_i2c_ip,
+		.pg_param = NULL,
+		.run_param = NULL,
+		.alert_param = NULL,
+		.fault_param = NULL,
+		.fault_cfg = LT7170_FAULT_PIN_OUTPUT,
+		.chip_id = ID_LT7170,
+		.external_clk_en = false,
+		.crc_en = false,
+	};
+	ret = lt7170_init(&lt7170_dev, &lt7170_ip);
+	if (ret)
+		goto error;
+
+LT7170 no-OS IIO support
+-------------------------
+
+The LT7170 IIO driver comes on top of the LT7170 driver and offers support
+for interfacing IIO clients through libiio.
+
+LT7170 IIO Device Configuration
+--------------------------------
+
+Input Channel Attributes
+------------------------
+
+VIN/IIN/TEMP/VCC channels are the input channels of the LT7170 IIO
+device and each of them has a total of 2 channel attributes:
+
+* ``raw - the raw value of the channel``
+* ``scale - the scale value of the channel calculated accordingly using a priv``
+
+Output Channel Attributes
+-------------------------
+
+IOUT channel is an output channel with the following channel
+attributes:
+
+* ``raw - the raw value of the channel``
+* ``scale - the scale value of the channel calculated accordingly using a priv``
+
+Meanwhile, VOUT channel is an output channel with a separate channel
+attributes. Each channel has 11 attributes:
+
+* ``raw - the raw value of the channel``
+* ``scale - the scale value of the channel calculated accordingly using a priv``
+* ``enable - state of the channel``
+* ``enable_available - list of available states for the channel``
+* ``vout_command - VOUT_COMMAND value of the channel output``
+* ``vout_max - VOUT_COMMAND value of the channel output``
+* ``vout_margin_low - VOUT_MARGIN_LOW value of the channel output``
+* ``vout_margin_high - VOUT_MARGIN_HIGH value of the channel output``
+* ``phase - Phase offset value of the channel output``
+* ``pulse_skipping - PWM pulse skip mode of the channel output``
+* ``pulse_skipping_available - pulse skipping available states of the each channel``
+
+Global Attributes
+-----------------
+
+The device has a total of 12 global attributes:
+
+* ``freq_sync - Clock frequency sync enable of the device``
+* ``freq_sync_available - Available state of the clock sync enable``
+* ``frequency - Device switching frequency``
+* ``vout_ov_fault_limit - Output overvoltage fault limit``
+* ``vout_ov_warn_limit - Output overvoltage warning limit``
+* ``vout_uv_fault_limit - Output undervoltage fault limit``
+* ``vout_uv_warn_limit - Output undervoltage warning limit``
+* ``iin_oc_warn_limit - Input overcurrent warning limit``
+* ``iout_oc_warn_limit - Output overcurrent warning limit``
+* ``ot_fault_limit - Overtemperature fault limit for both channels``
+* ``ot_warn_limit - Overtemperature warning limit for both channels``
+* ``vin_uv_warn_limit - Output undervoltage warning limit for both channels``
+
+Debug Attributes
+----------------
+
+The device has a total of 7 debug attributes:
+
+* ``status_vout - VOUT status byte value of channel 0``
+* ``status_iout - IOUT status byte value of channel 0``
+* ``status_input - INPUT status byte value of channel 0``
+* ``status_mfr_specific - MFR_SPECIFIC status byte value of channel 0``
+* ``status_word - Status word value of the channel 0``
+* ``status_temperature - TEMPERATURE status byte value of the device``
+* ``status_cml - CML status byte value of the device``
+
+LT7170 IIO Driver Initialization Example
+-----------------------------------------
+
+.. code-block:: bash
+
+	int ret;
+
+	struct lt7170_iio_desc *lt7170_iio_desc;
+	struct lt7170_iio_desc_init_param lt7170_iio_ip = {
+		.lt7170_init_param = &lt7170_ip,
+	};
+
+	struct iio_app_desc *app;
+	struct iio_app_init_param app_init_param = { 0 };
+
+	ret = lt7170_iio_init(&lt7170_iio_desc, &lt7170_iio_ip);
+	if (ret)
+		return ret;
+
+	struct iio_app_device iio_devices[] = {
+		{
+			.name = "lt7170",
+			.dev = lt7170_iio_desc,
+			.dev_descriptor = lt7170_iio_desc->iio_dev,
+		}
+	};
+
+	app_init_param.devices = iio_devices;
+	app_init_param.nb_devices = NO_OS_ARRAY_SIZE(iio_devices);
+	app_init_param.uart_init_params = lt7170_uart_ip;
+
+	ret = iio_app_init(&app, app_init_param);
+	if (ret)
+		return ret;
+
+	return iio_app_run(app);

--- a/drivers/power/lt7170/iio_lt7170.c
+++ b/drivers/power/lt7170/iio_lt7170.c
@@ -1,0 +1,1039 @@
+/***************************************************************************//**
+ *   @file   iio_lt7170.c
+ *   @brief  Source file for the LT7170 IIO Driver
+ *   @author Cherrence Sarip (cherrence.sarip@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include "no_os_alloc.h"
+#include "no_os_error.h"
+#include "no_os_units.h"
+#include "no_os_util.h"
+
+#include "lt7170.h"
+#include "iio_lt7170.h"
+
+static const char *const lt7170_enable_avail[2] = {
+	"Disabled", "Enabled"
+};
+
+enum lt7170_iio_enable_type {
+	LT7170_IIO_OUTPUT_ENABLE,
+	LT7170_IIO_PULSE_ENABLE,
+	LT7170_IIO_SYNC_ENABLE,
+};
+
+enum lt7170_iio_pwm_params {
+	LT7170_IIO_PWM_FREQUENCY,
+	LT7170_IIO_PWM_PHASE,
+};
+
+enum lt7170_iio_chan_type {
+	LT7170_IIO_VOUT_CHAN,
+	LT7170_IIO_VIN_CHAN,
+	LT7170_IIO_IOUT_CHAN,
+	LT7170_IIO_TEMP_CHAN,
+	LT7170_IIO_VCC_CHAN,
+};
+
+static struct iio_device lt7170_iio_dev;
+
+/**
+ * @brief Read register value.
+ * @param dev     - The iio device structure.
+ * @param reg	  - Register to read.
+ * @param readval - Read value.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int32_t lt7170_iio_reg_read(void *dev, uint32_t reg, uint32_t *readval)
+{
+	struct lt7170_iio_desc *iio_lt7170 = dev;
+	struct lt7170_dev *lt7170 = iio_lt7170->lt7170_dev;
+	int ret;
+	uint8_t byte_val;
+	uint16_t word_val;
+	uint8_t block[4] = {0};
+
+	switch (reg) {
+	case LT7170_PAGE:
+	case LT7170_OPERATION:
+	case LT7170_ON_OFF_CONFIG:
+	case LT7170_WRITE_PROTECT:
+	case LT7170_CAPABILITY:
+	case LT7170_VOUT_MODE:
+	case LT7170_VOUT_OV_FAULT_RESPONSE:
+	case LT7170_VOUT_UV_FAULT_RESPONSE:
+	case LT7170_IOUT_OC_FAULT_RESPONSE:
+	case LT7170_OT_FAULT_RESPONSE:
+	case LT7170_VIN_OV_FAULT_RESPONSE:
+	case LT7170_TON_MAX_FAULT_RESPONSE:
+	case LT7170_STATUS_BYTE:
+	case LT7170_STATUS_VOUT:
+	case LT7170_STATUS_IOUT:
+	case LT7170_STATUS_INPUT:
+	case LT7170_STATUS_TEMPERATURE:
+	case LT7170_STATUS_CML:
+	case LT7170_STATUS_MFR_SPECIFIC:
+	case LT7170_REVISION:
+	case LT7170_MFR_FAULT_RESPONSE:
+	case LT7170_MFR_ADC_CONTROL:
+	case LT7170_MFR_COMMON:
+	case LT7170_MFR_CHANNEL_STATE:
+	case LT7170_MFR_SYNC_CONFIG:
+	case LT7170_MFR_RAIL_ADDRESS:
+	case LT7170_MFR_DISABLE_OUTPUT:
+		ret = lt7170_read_byte(lt7170, reg, &byte_val);
+		*readval = byte_val;
+		return ret;
+	case LT7170_VOUT_COMMAND:
+	case LT7170_VOUT_MAX:
+	case LT7170_VOUT_MARGIN_HIGH:
+	case LT7170_VOUT_MARGIN_LOW:
+	case LT7170_VOUT_TRANSITION_RATE:
+	case LT7170_FREQUENCY_SWITCH:
+	case LT7170_VIN_ON:
+	case LT7170_VIN_OFF:
+	case LT7170_IOUT_CAL_OFFSET:
+	case LT7170_VOUT_OV_FAULT_LIMIT:
+	case LT7170_VOUT_OV_WARN_LIMIT:
+	case LT7170_VOUT_UV_WARN_LIMIT:
+	case LT7170_VOUT_UV_FAULT_LIMIT:
+	case LT7170_IOUT_OC_WARN_LIMIT:
+	case LT7170_OT_FAULT_LIMIT:
+	case LT7170_OT_WARN_LIMIT:
+	case LT7170_VIN_UV_WARN_LIMIT:
+	case LT7170_TON_DELAY:
+	case LT7170_TON_RISE:
+	case LT7170_TON_MAX_FAULT_LIMIT:
+	case LT7170_TOFF_DELAY:
+	case LT7170_TOFF_FALL:
+	case LT7170_TOFF_MAX_WARN_LIMIT:
+	case LT7170_STATUS_WORD:
+	case LT7170_READ_VIN:
+	case LT7170_READ_VOUT:
+	case LT7170_READ_IOUT:
+	case LT7170_READ_TEMPERATURE_1:
+	case LT7170_READ_FREQUENCY:
+	case LT7170_MFR_USER_DATA_00:
+	case LT7170_MFR_USER_DATA_01:
+	case LT7170_MFR_READ_EXTVCC:
+	case LT7170_MFR_READ_ITH:
+	case LT7170_MFR_CHAN_CONFIG:
+	case LT7170_MFR_CONFIG_ALL:
+	case LT7170_MFR_FAULT_PROPAGATE:
+	case LT7170_MFR_READ_ASEL:
+	case LT7170_MFR_PWM_MODE:
+	case LT7170_MFR_IOUT_PEAK:
+	case LT7170_MFR_RETRY_DELAY:
+	case LT7170_MFR_VOUT_PEAK:
+	case LT7170_MFR_VIN_PEAK:
+	case LT7170_MFR_TEMPERATURE_1_PEAK:
+	case LT7170_MFR_DISCHARGE_THRESHOLD:
+	case LT7170_MFR_PADS:
+	case LT7170_MFR_SPECIAL_ID:
+	case LT7170_MFR_PGOOD_DELAY:
+	case LT7170_MFR_NOT_PGOOD_DELAY:
+	case LT7170_MFR_PWM_PHASE:
+		ret = lt7170_read_word(lt7170, reg, &word_val);
+		*readval = word_val;
+		return ret;
+	case LT7170_PAGE_PLUS_READ:
+	case LT7170_QUERY:
+	case LT7170_SMBALERT_MASK:
+	case LT7170_MFR_ID:
+	case LT7170_MFR_SERIAL:
+	case LT7170_IC_DEVICE_ID:
+	case LT7170_IC_DEVICE_REV:
+		ret = lt7170_read_block_data(lt7170, reg, &block[0], 4);
+		if (ret)
+			return ret;
+
+		*readval = no_os_get_unaligned_be32(block);
+
+		return 0;
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Write register value.
+ * @param dev     - The iio device structure.
+ * @param reg	  - Register to write.
+ * @param writeval - Value to write.
+ * @return ret    - Result of the writing procedure.
+*/
+static int32_t lt7170_iio_reg_write(void *dev, uint32_t reg, uint32_t writeval)
+{
+	struct lt7170_iio_desc *iio_lt7170 = dev;
+	struct lt7170_dev *lt7170 = iio_lt7170->lt7170_dev;
+
+	switch (reg) {
+	case LT7170_PAGE:
+	case LT7170_OPERATION:
+	case LT7170_ON_OFF_CONFIG:
+	case LT7170_WRITE_PROTECT:
+	case LT7170_VOUT_OV_FAULT_RESPONSE:
+	case LT7170_VOUT_UV_FAULT_RESPONSE:
+	case LT7170_IOUT_OC_FAULT_RESPONSE:
+	case LT7170_OT_FAULT_RESPONSE:
+	case LT7170_VIN_OV_FAULT_RESPONSE:
+	case LT7170_TON_MAX_FAULT_RESPONSE:
+	case LT7170_STATUS_BYTE:
+	case LT7170_STATUS_VOUT:
+	case LT7170_STATUS_IOUT:
+	case LT7170_STATUS_INPUT:
+	case LT7170_STATUS_TEMPERATURE:
+	case LT7170_STATUS_CML:
+	case LT7170_STATUS_MFR_SPECIFIC:
+	case LT7170_MFR_FAULT_RESPONSE:
+	case LT7170_MFR_ADC_CONTROL:
+	case LT7170_MFR_SYNC_CONFIG:
+	case LT7170_MFR_RAIL_ADDRESS:
+	case LT7170_MFR_DISABLE_OUTPUT:
+		return lt7170_write_byte(lt7170, reg, (uint8_t)writeval);
+	case LT7170_CLEAR_FAULTS:
+	case LT7170_STORE_USER_ALL:
+	case LT7170_RESTORE_USER_ALL:
+	case LT7170_MFR_CLEAR_PEAKS:
+	case LT7170_MFR_COMPARE_USER_ALL:
+	case LT7170_MFR_RESET:
+		return lt7170_send_byte(dev, reg);
+	case LT7170_ZONE_CONFIG:
+	case LT7170_ZONE_ACTIVE:
+	case LT7170_VOUT_COMMAND:
+	case LT7170_VOUT_MAX:
+	case LT7170_VOUT_MARGIN_HIGH:
+	case LT7170_VOUT_MARGIN_LOW:
+	case LT7170_VOUT_TRANSITION_RATE:
+	case LT7170_FREQUENCY_SWITCH:
+	case LT7170_VIN_ON:
+	case LT7170_VIN_OFF:
+	case LT7170_IOUT_CAL_OFFSET:
+	case LT7170_VOUT_OV_FAULT_LIMIT:
+	case LT7170_VOUT_OV_WARN_LIMIT:
+	case LT7170_VOUT_UV_WARN_LIMIT:
+	case LT7170_VOUT_UV_FAULT_LIMIT:
+	case LT7170_IOUT_OC_WARN_LIMIT:
+	case LT7170_OT_FAULT_LIMIT:
+	case LT7170_OT_WARN_LIMIT:
+	case LT7170_VIN_UV_WARN_LIMIT:
+	case LT7170_TON_DELAY:
+	case LT7170_TON_RISE:
+	case LT7170_TON_MAX_FAULT_LIMIT:
+	case LT7170_TOFF_DELAY:
+	case LT7170_TOFF_FALL:
+	case LT7170_TOFF_MAX_WARN_LIMIT:
+	case LT7170_STATUS_WORD:
+	case LT7170_MFR_USER_DATA_00:
+	case LT7170_MFR_USER_DATA_01:
+	case LT7170_MFR_CHAN_CONFIG:
+	case LT7170_MFR_CONFIG_ALL:
+	case LT7170_MFR_FAULT_PROPAGATE:
+	case LT7170_MFR_PWM_MODE:
+	case LT7170_MFR_RETRY_DELAY:
+	case LT7170_MFR_VOUT_PEAK:
+	case LT7170_MFR_VIN_PEAK:
+	case LT7170_MFR_TEMPERATURE_1_PEAK:
+	case LT7170_MFR_DISCHARGE_THRESHOLD:
+	case LT7170_MFR_PGOOD_DELAY:
+	case LT7170_MFR_NOT_PGOOD_DELAY:
+	case LT7170_MFR_PWM_PHASE:
+		return lt7170_write_word(lt7170, reg, (uint16_t)writeval);
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Handles the read request for raw attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int lt7170_iio_read_raw(void *dev, char *buf, uint32_t len,
+			       const struct iio_ch_info *channel,
+			       intptr_t priv)
+{
+	struct lt7170_iio_desc *iio_lt7170 = dev;
+	struct lt7170_dev *lt7170 = iio_lt7170->lt7170_dev;
+	int ret;
+	uint16_t value;
+
+	switch (channel->address) {
+	case LT7170_IIO_VIN_CHAN:
+		ret = lt7170_read_word(lt7170, LT7170_READ_VIN, &value);
+		break;
+	case LT7170_IIO_VOUT_CHAN:
+		ret = lt7170_read_word(lt7170, LT7170_READ_VOUT, &value);
+		break;
+	case LT7170_IIO_IOUT_CHAN:
+		ret = lt7170_read_word(lt7170, LT7170_READ_IOUT, &value);
+		break;
+	case LT7170_IIO_TEMP_CHAN:
+		ret = lt7170_read_word(lt7170, LT7170_READ_TEMPERATURE_1,
+				       &value);
+		break;
+	case LT7170_IIO_VCC_CHAN:
+		ret = lt7170_read_word(lt7170, LT7170_MFR_READ_EXTVCC, &value);
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	if (ret)
+		return ret;
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, (int32_t *)&value);
+}
+
+/**
+ * @brief Handles the read request for scale attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int lt7170_iio_read_scale(void *dev, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel,
+				 intptr_t priv)
+{
+	int vals[2], ret;
+	struct lt7170_iio_desc *iio_lt7170 = dev;
+	struct lt7170_dev *lt7170 = iio_lt7170->lt7170_dev;
+
+	switch (channel->address) {
+	case LT7170_IIO_VIN_CHAN:
+		ret = lt7170_read_value(lt7170, LT7170_READ_VIN, &vals[0]);
+		break;
+	case LT7170_IIO_VOUT_CHAN:
+		ret = lt7170_read_value(lt7170, LT7170_READ_VOUT, &vals[0]);
+		break;
+	case LT7170_IIO_IOUT_CHAN:
+		ret = lt7170_read_value(lt7170, LT7170_READ_IOUT, &vals[0]);
+		break;
+	case LT7170_IIO_TEMP_CHAN:
+		ret = lt7170_read_value(lt7170, LT7170_READ_TEMPERATURE_1,
+					&vals[0]);
+		break;
+	case LT7170_IIO_VCC_CHAN:
+		ret = lt7170_read_value(lt7170, LT7170_MFR_READ_EXTVCC,
+					&vals[0]);
+		break;
+	default:
+		return -EINVAL;
+	}
+	if (ret)
+		return ret;
+
+	vals[1] = (int)MILLI;
+
+	return iio_format_value(buf, len, IIO_VAL_FRACTIONAL,
+				2, (int32_t *)vals);
+}
+
+/**
+ * @brief Handles the read request for enable attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int lt7170_iio_read_enable(void *dev, char *buf, uint32_t len,
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
+{
+	struct lt7170_iio_desc *iio_lt7170 = dev;
+	struct lt7170_dev *lt7170 = iio_lt7170->lt7170_dev;
+	int ret;
+	uint32_t val;
+	uint16_t word;
+
+	switch (priv) {
+	case LT7170_IIO_OUTPUT_ENABLE:
+		ret = lt7170_read_word(lt7170, LT7170_MFR_PADS, &word);
+		if (ret)
+			return ret;
+
+		val = no_os_field_get(LT7170_PADS_RUN_BIT, word);
+
+		val = no_os_clamp(val, 0, 1);
+
+		return sprintf(buf, "%s ", lt7170_enable_avail[val]);
+	case LT7170_IIO_PULSE_ENABLE:
+		ret = lt7170_read_word(lt7170, LT7170_MFR_PWM_MODE, &word);
+		if (ret)
+			return ret;
+
+		val = no_os_clamp(no_os_field_get(LT7170_PWM_OP_MODE_BIT,
+						  word),
+				  0, 1);
+
+		return sprintf(buf, "%s ", lt7170_enable_avail[val]);
+	case LT7170_IIO_SYNC_ENABLE:
+		ret = lt7170_read_word(lt7170, LT7170_MFR_SYNC_CONFIG, &word);
+		if (ret)
+			return ret;
+
+		val = no_os_clamp(no_os_field_get(LT7170_SYNC_CLK_OUTPUT_BIT,
+						  word),
+				  0, 1);
+
+		return sprintf(buf, "%s ", lt7170_enable_avail[val]);
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Handles the read request for enable_available attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int lt7170_iio_read_enable_available(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	int length = 0;
+	uint32_t i;
+
+	for (i = 0; i < NO_OS_ARRAY_SIZE(lt7170_enable_avail); i++)
+		length += sprintf(buf + length, "%s ", lt7170_enable_avail[i]);
+
+	return length;
+}
+
+/**
+ * @brief Handles the write request for enable attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int lt7170_iio_write_enable(void *dev, char *buf, uint32_t len,
+				   const struct iio_ch_info *channel,
+				   intptr_t priv)
+{
+	struct lt7170_iio_desc *iio_lt7170 = dev;
+	struct lt7170_dev *lt7170 = iio_lt7170->lt7170_dev;
+	uint32_t i;
+
+	for (i = 0; i < NO_OS_ARRAY_SIZE(lt7170_enable_avail); i++)
+		if (!strcmp(buf, lt7170_enable_avail[i]))
+			break;
+
+	if (i == NO_OS_ARRAY_SIZE(lt7170_enable_avail))
+		return -EINVAL;
+
+	switch (priv) {
+	case LT7170_IIO_OUTPUT_ENABLE:
+		return lt7170_set_channel_state(lt7170, (bool)i);
+	case LT7170_IIO_PULSE_ENABLE:
+		return lt7170_pwm_mode(lt7170,
+				       (enum lt7170_pwm_mode)i);
+	case LT7170_IIO_SYNC_ENABLE:
+		return lt7170_sync_config(lt7170, !i, i);
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Handles the read request for vout attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int lt7170_iio_read_vout(void *dev, char *buf, uint32_t len,
+				const struct iio_ch_info *channel,
+				intptr_t priv)
+{
+	struct lt7170_iio_desc *iio_lt7170 = dev;
+	struct lt7170_dev *lt7170 = iio_lt7170->lt7170_dev;
+	int ret, vals[2];
+
+	if (!dev)
+		return -EINVAL;
+
+	if (!iio_lt7170->lt7170_dev)
+		return -EINVAL;
+
+	ret = lt7170_read_word_data(lt7170, (uint8_t)priv, &vals[1]);
+	if (ret)
+		return ret;
+
+	vals[0] = (int32_t)(vals[1] / (int)MILLI);
+	vals[1] = (int32_t)((vals[1] * (int)MILLI) % (int)MICRO);
+
+	return iio_format_value(buf, len, IIO_VAL_INT_PLUS_MICRO, 2,
+				(int32_t *)vals);
+}
+
+/**
+ * @brief Handles the write request for vout attributes.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int lt7170_iio_write_vout(void *dev, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel,
+				 intptr_t priv)
+{
+	struct lt7170_iio_desc *iio_lt7170 = dev;
+	struct lt7170_dev *lt7170 = iio_lt7170->lt7170_dev;
+	int val1, val2;
+
+	iio_parse_value(buf, IIO_VAL_INT_PLUS_MICRO, (int32_t *)&val1,
+			(int32_t *)&val2);
+
+	val1 = val1 * (int)MILLI + val2 / (int)MILLI;
+
+	return lt7170_write_word_data(lt7170, priv, val1);
+}
+
+/**
+ * @brief Handles the read request for pwm attributes.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int lt7170_iio_read_pwm(void *dev, char *buf, uint32_t len,
+			       const struct iio_ch_info *channel,
+			       intptr_t priv)
+{
+	struct lt7170_iio_desc *iio_lt7170 = dev;
+	struct lt7170_dev *lt7170 = iio_lt7170->lt7170_dev;
+	int ret, vals[2];
+
+	if (!dev)
+		return -EINVAL;
+
+	if (!iio_lt7170->lt7170_dev)
+		return -EINVAL;
+
+	switch (priv) {
+	case LT7170_IIO_PWM_FREQUENCY:
+		ret = lt7170_read_value(lt7170, LT7170_FREQUENCY, &vals[1]);
+		break;
+	case LT7170_IIO_PWM_PHASE:
+		ret = lt7170_read_word_data(lt7170, LT7170_MFR_PWM_PHASE,
+					    &vals[1]);
+		break;
+	default:
+		return -EINVAL;
+	}
+	if (ret)
+		return ret;
+
+	vals[0] = (int32_t)(vals[1] / (int)MILLI);
+	vals[1] = (int32_t)((vals[1] * (int)MILLI) % (int)MICRO);
+
+	return iio_format_value(buf, len, IIO_VAL_INT_PLUS_MICRO, 2,
+				(int32_t *)vals);
+}
+
+/**
+ * @brief Handles the write request for pwm attributes.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int lt7170_iio_write_pwm(void *dev, char *buf, uint32_t len,
+				const struct iio_ch_info *channel,
+				intptr_t priv)
+{
+	struct lt7170_iio_desc *iio_lt7170 = dev;
+	struct lt7170_dev *lt7170 = iio_lt7170->lt7170_dev;
+	int val1, val2;
+	bool negative;
+
+	iio_parse_value(buf, IIO_VAL_INT_PLUS_MICRO, (int32_t *)&val1,
+			(int32_t *)&val2);
+
+	negative = (val1 < 0 || val2 < 0) ? true : false;
+	if (val1 < 0)
+		val1 = -val1;
+	if (val2 < 0)
+		val2 = -val2;
+
+	val1 = val1 * (int)MILLI + val2 / (int)MILLI;
+
+	if (negative)
+		val1 = -val1;
+
+	switch (priv) {
+	case LT7170_IIO_PWM_FREQUENCY:
+		return lt7170_switch_freq(lt7170, val1);
+	case LT7170_IIO_PWM_PHASE:
+		return lt7170_pwm_phase(lt7170, val1);
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Handles the read request for limits global attributes.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int lt7170_iio_read_limits(void *dev, char *buf, uint32_t len,
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
+{
+	struct lt7170_iio_desc *iio_lt7170 = dev;
+	struct lt7170_dev *lt7170 = iio_lt7170->lt7170_dev;
+	int ret, vals[2];
+
+	if (!dev)
+		return -EINVAL;
+
+	if (!iio_lt7170->lt7170_dev)
+		return -EINVAL;
+
+	ret = lt7170_read_word_data(lt7170, priv, &vals[1]);
+	if (ret)
+		return ret;
+
+	vals[0] = (int32_t)(vals[1] / (int)MILLI);
+	vals[1] = (int32_t)((vals[1] * (int)MILLI) % (int)MICRO);
+
+	return iio_format_value(buf, len, IIO_VAL_INT_PLUS_MICRO, 2,
+				(int32_t *)vals);
+}
+
+/**
+ * @brief Handles the write request for limits global attributes.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int lt7170_iio_write_limits(void *dev, char *buf, uint32_t len,
+				   const struct iio_ch_info *channel,
+				   intptr_t priv)
+{
+	struct lt7170_iio_desc *iio_lt7170 = dev;
+	struct lt7170_dev *lt7170 = iio_lt7170->lt7170_dev;
+	int val1, val2;
+	bool negative;
+
+	iio_parse_value(buf, IIO_VAL_INT_PLUS_MICRO, (int32_t *)&val1,
+			(int32_t *)&val2);
+
+	negative = (val1 < 0 || val2 < 0) ? true : false;
+	if (val1 < 0)
+		val1 = -val1;
+	if (val2 < 0)
+		val2 = -val2;
+
+	val1 = val1 * (int)MILLI + val2 / (int)MILLI;
+
+	if (negative)
+		val1 = -val1;
+
+	return lt7170_set_limit(lt7170,
+				(enum lt7170_limit_type)priv, val1);
+}
+
+/**
+ * @brief Handles the read request for status debug attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int lt7170_iio_read_status(void *dev, char *buf, uint32_t len,
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
+{
+	struct lt7170_iio_desc *iio_lt7170 = dev;
+	struct lt7170_dev *lt7170 = iio_lt7170->lt7170_dev;
+	int ret;
+	int32_t val;
+	uint16_t status_word;
+	uint8_t status_byte;
+
+	if (priv == LT7170_STATUS_WORD) {
+		ret = lt7170_read_word(lt7170, LT7170_STATUS_WORD,
+				       &status_word);
+		if (ret)
+			return ret;
+
+		val = (int32_t)status_word;
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	} else {
+		ret = lt7170_read_byte(lt7170, (uint8_t)priv,
+				       &status_byte);
+		if (ret)
+			return ret;
+
+		val = (int32_t)status_byte;
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	}
+}
+
+/**
+ * @brief Initializes the LT7170 IIO descriptor.
+ * @param iio_desc - The iio device descriptor.
+ * @param init_param - The structure that contains the device initial parameters.
+ * @return 0 in case of success, an error code otherwise.
+ */
+int lt7170_iio_init(struct lt7170_iio_desc **iio_desc,
+		    struct lt7170_iio_desc_init_param *init_param)
+{
+	struct lt7170_iio_desc *descriptor;
+	int ret;
+
+	if (!init_param || !init_param->lt7170_init_param)
+		return -EINVAL;
+
+	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	ret = lt7170_init(&descriptor->lt7170_dev,
+			  init_param->lt7170_init_param);
+	if (ret)
+		goto dev_err;
+
+	descriptor->iio_dev = &lt7170_iio_dev;
+
+	*iio_desc = descriptor;
+
+	return 0;
+
+dev_err:
+	no_os_free(descriptor);
+
+	return ret;
+}
+
+/**
+ * @brief Free resources allocated by the init function.
+ * @param iio_desc - The iio device descriptor.
+ * @return 0 in case of success, an error code otherwise.
+ */
+int lt7170_iio_remove(struct lt7170_iio_desc *iio_desc)
+{
+	if (!iio_desc)
+		return -ENODEV;
+
+	no_os_free(iio_desc->iio_dev->channels);
+	lt7170_remove(iio_desc->lt7170_dev);
+	no_os_free(iio_desc);
+
+	return 0;
+}
+
+static struct iio_attribute lt7170_input_attrs[] = {
+	{
+		.name = "raw",
+		.show = lt7170_iio_read_raw
+	},
+	{
+		.name = "scale",
+		.show = lt7170_iio_read_scale
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_attribute lt7170_output_attrs[] = {
+	{
+		.name = "raw",
+		.show = lt7170_iio_read_raw
+	},
+	{
+		.name = "scale",
+		.show = lt7170_iio_read_scale
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_attribute lt7170_global_attrs[] = {
+	{
+		.name = "freq_sync",
+		.show = lt7170_iio_read_enable,
+		.store = lt7170_iio_write_enable,
+		.priv = LT7170_IIO_SYNC_ENABLE
+	},
+	{
+		.name = "freq_sync_available",
+		.show = lt7170_iio_read_enable_available,
+		.shared = IIO_SHARED_BY_ALL
+	},
+	{
+		.name = "frequency",
+		.show = lt7170_iio_read_pwm,
+		.store = lt7170_iio_write_pwm,
+		.priv = LT7170_IIO_PWM_FREQUENCY
+	},
+	{
+		.name = "vout_ov_fault_limit",
+		.show = lt7170_iio_read_limits,
+		.store = lt7170_iio_write_limits,
+		.priv = LT7170_VOUT_OV_FAULT_LIMIT
+	},
+	{
+		.name = "vout_ov_warn_limit",
+		.show = lt7170_iio_read_limits,
+		.store = lt7170_iio_write_limits,
+		.priv = LT7170_VOUT_OV_WARN_LIMIT
+	},
+	{
+		.name = "vout_uv_fault_limit",
+		.show = lt7170_iio_read_limits,
+		.store = lt7170_iio_write_limits,
+		.priv = LT7170_VOUT_UV_FAULT_LIMIT
+	},
+	{
+		.name = "vout_uv_warn_limit",
+		.show = lt7170_iio_read_limits,
+		.store = lt7170_iio_write_limits,
+		.priv = LT7170_VOUT_UV_WARN_LIMIT
+	},
+	{
+		.name = "iout_oc_warn_limit",
+		.show = lt7170_iio_read_limits,
+		.store = lt7170_iio_write_limits,
+		.priv = LT7170_IOUT_OC_WARN_LIMIT
+	},
+	{
+		.name = "ot_fault_limit",
+		.show = lt7170_iio_read_limits,
+		.store = lt7170_iio_write_limits,
+		.priv = LT7170_OT_FAULT_LIMIT
+	},
+	{
+		.name = "ot_warn_limit",
+		.show = lt7170_iio_read_limits,
+		.store = lt7170_iio_write_limits,
+		.priv = LT7170_OT_WARN_LIMIT
+	},
+	{
+		.name = "vin_uv_warn_limit",
+		.show = lt7170_iio_read_limits,
+		.store = lt7170_iio_write_limits,
+		.priv = LT7170_VIN_UV_WARN_LIMIT
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_attribute lt7170_debug_attrs[] = {
+	{
+		.name = "status_vout",
+		.show = lt7170_iio_read_status,
+		.priv = LT7170_STATUS_VOUT
+	},
+	{
+		.name = "status_iout",
+		.show = lt7170_iio_read_status,
+		.priv = LT7170_STATUS_IOUT
+	},
+	{
+		.name = "status_input",
+		.show = lt7170_iio_read_status,
+		.priv = LT7170_STATUS_INPUT
+	},
+	{
+		.name = "status_mfr_specific",
+		.show = lt7170_iio_read_status,
+		.priv = LT7170_STATUS_MFR_SPECIFIC
+	},
+	{
+		.name = "status_word",
+		.show = lt7170_iio_read_status,
+		.priv = LT7170_STATUS_WORD
+	},
+	{
+		.name = "status_temperature",
+		.show = lt7170_iio_read_status,
+		.priv = LT7170_STATUS_TEMPERATURE
+	},
+	{
+		.name = "status_cml",
+		.show = lt7170_iio_read_status,
+		.priv = LT7170_STATUS_CML
+	},
+	{
+		.name = "pads_enable",
+		.show = lt7170_iio_read_enable,
+		.store = lt7170_iio_write_enable,
+		.priv = LT7170_IIO_OUTPUT_ENABLE,
+	},
+	{
+		.name = "pads_enable_available",
+		.show = lt7170_iio_read_enable_available,
+		.shared = IIO_SHARED_BY_ALL
+	},
+	{
+		.name = "vout_command",
+		.show = lt7170_iio_read_vout,
+		.store = lt7170_iio_write_vout,
+		.priv = LT7170_VOUT_COMMAND
+	},
+	{
+		.name = "vout_max",
+		.show = lt7170_iio_read_vout,
+		.store = lt7170_iio_write_vout,
+		.priv = LT7170_VOUT_MAX
+	},
+	{
+		.name = "vout_margin_high",
+		.show = lt7170_iio_read_vout,
+		.store = lt7170_iio_write_vout,
+		.priv = LT7170_VOUT_MARGIN_HIGH
+	},
+	{
+		.name = "vout_margin_low",
+		.show = lt7170_iio_read_vout,
+		.store = lt7170_iio_write_vout,
+		.priv = LT7170_VOUT_MARGIN_LOW
+	},
+	{
+		.name = "phase",
+		.show = lt7170_iio_read_pwm,
+		.store = lt7170_iio_write_pwm,
+		.priv = LT7170_IIO_PWM_PHASE
+	},
+	{
+		.name = "pulse_skipping",
+		.show = lt7170_iio_read_enable,
+		.store = lt7170_iio_write_enable,
+		.priv = LT7170_IIO_PULSE_ENABLE
+	},
+	{
+		.name = "pulse_skipping_available",
+		.show = lt7170_iio_read_enable_available,
+		.shared = IIO_SHARED_BY_ALL
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_channel lt7170_channels[] = {
+	{
+		.name = "vin",
+		.ch_type = IIO_VOLTAGE,
+		.address = LT7170_IIO_VIN_CHAN,
+		.attributes = lt7170_input_attrs,
+		.ch_out = false
+	},
+	{
+		.name = "iout",
+		.ch_type = IIO_CURRENT,
+		.address = LT7170_IIO_IOUT_CHAN,
+		.attributes = lt7170_input_attrs,
+		.ch_out = true
+	},
+	{
+		.name = "vout",
+		.ch_type = IIO_VOLTAGE,
+		.address = LT7170_IIO_VOUT_CHAN,
+		.attributes = lt7170_output_attrs,
+		.ch_out = true
+	},
+	{
+		.name = "temperature",
+		.ch_type = IIO_TEMP,
+		.address = LT7170_IIO_TEMP_CHAN,
+		.attributes = lt7170_input_attrs,
+		.ch_out = false,
+	},
+	{
+		.name = "vcc",
+		.ch_type = IIO_VOLTAGE,
+		.address = LT7170_IIO_VCC_CHAN,
+		.attributes = lt7170_input_attrs,
+		.ch_out = false,
+	},
+};
+
+static struct iio_device lt7170_iio_dev = {
+	.num_ch = NO_OS_ARRAY_SIZE(lt7170_channels),
+	.channels = lt7170_channels,
+	.attributes = lt7170_global_attrs,
+	.debug_attributes = lt7170_debug_attrs,
+	.debug_reg_read = lt7170_iio_reg_read,
+	.debug_reg_write = lt7170_iio_reg_write,
+};

--- a/drivers/power/lt7170/iio_lt7170.h
+++ b/drivers/power/lt7170/iio_lt7170.h
@@ -1,0 +1,68 @@
+/***************************************************************************//**
+ *   @file   iio_lt7170.h
+ *   @brief  Header file for the LT7170 IIO Driver
+ *   @author Cherrence Sarip (cherrence.sarip@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef IIO_LT7170_H
+#define IIO_LT7170_H
+
+#include <stdbool.h>
+#include "iio.h"
+#include "lt7170.h"
+
+/**
+ * @brief Structure holding the LT7170 IIO device descriptor
+*/
+struct lt7170_iio_desc {
+	struct lt7170_dev *lt7170_dev;
+	struct iio_device *iio_dev;
+};
+
+/**
+ * @brief Structure holding the LT7170 IIO initialization parameter.
+*/
+struct lt7170_iio_desc_init_param {
+	struct lt7170_init_param *lt7170_init_param;
+};
+
+/** Initializes the LT7170 IIO descriptor. */
+int lt7170_iio_init(struct lt7170_iio_desc **,
+		    struct lt7170_iio_desc_init_param *);
+
+/** Free resources allocated by the initialization function. */
+int lt7170_iio_remove(struct lt7170_iio_desc *);
+
+#endif /* IIO_LT7170_H */

--- a/drivers/power/lt7170/lt7170.c
+++ b/drivers/power/lt7170/lt7170.c
@@ -1,0 +1,1059 @@
+/*******************************************************************************
+*   @file   lt7170.c
+*   @brief  Source code of the LT7170 Driver
+*   @authors Cherrence Sarip (cherrence.sarip@analog.com)
+********************************************************************************
+* Copyright 2024(c) Analog Devices, Inc.
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*  - Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*  - Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in
+*    the documentation and/or other materials provided with the
+*    distribution.
+*  - Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*  - The use of this software may or may not infringe the patent rights
+*    of one or more patent holders.  This license does not release you
+*    from the requirement that you obtain separate licenses from these
+*    patent holders to use this software.
+*  - Use of the software either in source or binary form, must be run
+*    on or directly connected to an Analog Devices Inc. component.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#include "no_os_units.h"
+#include "no_os_util.h"
+#include "no_os_delay.h"
+#include "no_os_alloc.h"
+#include "no_os_pwm.h"
+#include "no_os_i2c.h"
+#include "no_os_gpio.h"
+#include "no_os_crc8.h"
+
+#include "lt7170.h"
+
+NO_OS_DECLARE_CRC8_TABLE(lt7170_crc_table);
+
+static const struct lt7170_chip_info lt7170_info[] = {
+	[ID_LT7170] = {
+		.name = "LT7170",
+		.name_size = 6,
+	},
+	[ID_LT7170_1] = {
+		.name = "LT7170-1",
+		.name_size = 8,
+	},
+	[ID_LT7171] = {
+		.name = "LT7171",
+		.name_size = 6,
+	},
+	[ID_LT7171_1] = {
+		.name = "LT7171-1",
+		.name_size = 8
+	},
+};
+
+/**
+ * @brief Converts value to IEEE754 register data
+ * @param dev - Device structure
+ * @param data - Value to convert
+ * @param reg - Address of converted register data
+ * @param scale - Value scaling factor
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int lt7170_data2reg_ieee754(struct lt7170_dev *dev, int data,
+				   uint16_t *reg, int scale)
+{
+	uint16_t exponent = (15 + 10);
+	uint16_t sign = 0;
+	int mantissa;
+
+	/* simple case */
+	if (data == 0)
+		return 0;
+
+	if (data < 0) {
+		sign = 1;
+		data = -data;
+	}
+
+	if (scale > (int)MILLI)
+		data = NO_OS_DIV_ROUND_CLOSEST_ULL(data, scale/MILLI);
+	else
+		data *= (int)MILLI / scale;
+
+	/* Reduce large mantissa until it fits into 10 bit */
+	while ((data > LT7170_IEEE754_MAX_MANTISSA * scale) && exponent < 30) {
+		exponent++;
+		data >>= 1;
+	}
+	/*
+	 * Increase small mantissa to generate valid 'normal'
+	 * number
+	 */
+	while ((data < LT7170_IEEE754_MIN_MANTISSA * scale) && exponent > 1) {
+		exponent--;
+		data <<= 1;
+	}
+
+	/* Convert mantissa from scaled-units to units */
+	mantissa = NO_OS_DIV_ROUND_CLOSEST_ULL(data, scale);
+
+	mantissa = no_os_clamp(mantissa, LT7170_IEEE754_MIN_MANTISSA,
+			       LT7170_IEEE754_MAX_MANTISSA);
+
+	/* Convert to sign, 5 bit exponent, 10 bit mantissa */
+	*reg = no_os_field_prep(LT7170_IEEE754_SIGN_BIT, sign) |
+	       no_os_field_prep(LT7170_IEEE754_MANTISSA_MSK, mantissa) |
+	       no_os_field_prep(LT7170_IEEE754_EXPONENT_MSK, exponent);
+
+	return 0;
+}
+
+/**
+ * @brief Converts raw IEEE754 register data to its actual value
+ * @param dev - Device structure
+ * @param reg - IEEE754 data to convert
+ * @param data - Address of value
+ * @param scale - Value scaling factor
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int lt7170_reg2data_ieee754(struct lt7170_dev *dev, uint16_t reg,
+				   int *data, int scale)
+{
+	int val;
+	int exponent;
+	bool sign;
+
+	sign = no_os_field_get(LT7170_IEEE754_SIGN_BIT, reg);
+	exponent = no_os_field_get(LT7170_IEEE754_EXPONENT_MSK, reg);
+	val = no_os_field_get(LT7170_IEEE754_MANTISSA_MSK, reg);
+
+	if (exponent == 0) {			/* subnormal */
+		exponent = -(14 + 10);
+	} else if (exponent ==  0x1f) {		/* NaN, convert to min/max */
+		exponent = 0;
+		val = 65504;
+	} else {
+		exponent -= (15 + 10);		/* normal */
+		val |= 0x400;
+	}
+
+	val *= scale;
+
+	if (exponent >= 0)
+		val <<= exponent;
+	else
+		val >>= -exponent;
+
+	if (sign)
+		val = -val;
+
+	*data = val;
+
+	return 0;
+}
+
+/**
+ * @brief Convert value to register data
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @param data - Value to convert
+ * @param reg - Address of register data
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int lt7170_data2reg(struct lt7170_dev *dev, uint8_t cmd, int data,
+			   uint16_t *reg)
+{
+	switch (cmd) {
+	case LT7170_VOUT_COMMAND:
+	case LT7170_VOUT_MAX:
+	case LT7170_VOUT_MARGIN_HIGH:
+	case LT7170_VOUT_MARGIN_LOW:
+	case LT7170_FREQUENCY_SWITCH:
+	case LT7170_VIN_ON:
+	case LT7170_VIN_OFF:
+	case LT7170_VOUT_OV_FAULT_LIMIT:
+	case LT7170_VOUT_OV_WARN_LIMIT:
+	case LT7170_VOUT_UV_WARN_LIMIT:
+	case LT7170_VOUT_UV_FAULT_LIMIT:
+	case LT7170_VIN_UV_WARN_LIMIT:
+	case LT7170_READ_VIN:
+	case LT7170_READ_VOUT:
+	case LT7170_MFR_READ_EXTVCC:
+	case LT7170_MFR_READ_ITH:
+	case LT7170_MFR_VOUT_PEAK:
+	case LT7170_MFR_VIN_PEAK:
+	case LT7170_IOUT_CAL_OFFSET:
+	case LT7170_IOUT_OC_WARN_LIMIT:
+	case LT7170_OT_FAULT_LIMIT:
+	case LT7170_OT_WARN_LIMIT:
+	case LT7170_READ_IOUT:
+	case LT7170_READ_TEMPERATURE_1:
+	case LT7170_READ_FREQUENCY:
+	case LT7170_MFR_IOUT_PEAK:
+	case LT7170_MFR_RETRY_DELAY:
+	case LT7170_MFR_TEMPERATURE_1_PEAK:
+	case LT7170_MFR_READ_PWM_CFG:
+	case LT7170_MFR_READ_VOUT_CFG:
+	case LT7170_MFR_DISCHARGE_THRESHOLD:
+	case LT7170_MFR_PGOOD_DELAY:
+	case LT7170_MFR_NOT_PGOOD_DELAY:
+		return lt7170_data2reg_ieee754(dev, data, reg, MILLI);
+	default:
+		return -EINVAL;
+	}
+}
+
+static int lt7170_reg2data(struct lt7170_dev *dev, uint8_t cmd,
+			   uint16_t reg, int *data)
+{
+	switch (cmd) {
+	case LT7170_VOUT_COMMAND:
+	case LT7170_VOUT_MAX:
+	case LT7170_VOUT_MARGIN_HIGH:
+	case LT7170_VOUT_MARGIN_LOW:
+	case LT7170_FREQUENCY_SWITCH:
+	case LT7170_VIN_ON:
+	case LT7170_VIN_OFF:
+	case LT7170_VOUT_OV_FAULT_LIMIT:
+	case LT7170_VOUT_OV_WARN_LIMIT:
+	case LT7170_VOUT_UV_WARN_LIMIT:
+	case LT7170_VOUT_UV_FAULT_LIMIT:
+	case LT7170_VIN_UV_WARN_LIMIT:
+	case LT7170_READ_VIN:
+	case LT7170_READ_VOUT:
+	case LT7170_MFR_READ_EXTVCC:
+	case LT7170_MFR_READ_ITH:
+	case LT7170_MFR_VOUT_PEAK:
+	case LT7170_MFR_VIN_PEAK:
+	case LT7170_IOUT_CAL_OFFSET:
+	case LT7170_IOUT_OC_WARN_LIMIT:
+	case LT7170_OT_FAULT_LIMIT:
+	case LT7170_OT_WARN_LIMIT:
+	case LT7170_READ_IOUT:
+	case LT7170_READ_TEMPERATURE_1:
+	case LT7170_READ_FREQUENCY:
+	case LT7170_MFR_READ_ASEL:
+	case LT7170_MFR_IOUT_PEAK:
+	case LT7170_MFR_RETRY_DELAY:
+	case LT7170_MFR_TEMPERATURE_1_PEAK:
+	case LT7170_MFR_READ_PWM_CFG:
+	case LT7170_MFR_READ_VOUT_CFG:
+	case LT7170_MFR_DISCHARGE_THRESHOLD:
+	case LT7170_MFR_PGOOD_DELAY:
+	case LT7170_MFR_NOT_PGOOD_DELAY:
+		return lt7170_reg2data_ieee754(dev, reg, data, MILLI);
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Perform packet-error checking via CRC
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @param buf - Pointer to the first packet buffer
+ * @param nbytes - Packet buffer size
+ * @param op - Operation performed. 0 for write, 1 for read
+ * @return PEC code of the PMBus packet
+ */
+static uint8_t lt7170_pec(struct lt7170_dev *dev, uint8_t cmd, uint8_t *buf,
+			  size_t nbytes, uint8_t op)
+{
+	uint8_t crc_buf[nbytes + op + 2];
+
+	crc_buf[0] = (dev->i2c_desc->slave_address << 1);
+	crc_buf[1] = cmd;
+	if (op)
+		crc_buf[2] = (dev->i2c_desc->slave_address << 1) | 1;
+
+	if (buf != NULL && nbytes > 0)
+		memcpy(&crc_buf[2 + op], buf, nbytes);
+
+	return no_os_crc8(lt7170_crc_table, crc_buf, nbytes + op + 2, 0);
+}
+
+/**
+ * @brief Initialize the device structure
+ * @param device - Device structure
+ * @param init_param - Initialization parameters
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt7170_init(struct lt7170_dev **device,
+		struct lt7170_init_param *init_param)
+{
+	struct lt7170_dev *dev;
+	int ret;
+	uint16_t word;
+	uint8_t block[lt7170_info[init_param->chip_id].name_size];
+
+	dev = (struct lt7170_dev *)no_os_calloc(1, sizeof(struct lt7170_dev));
+	if (!dev) {
+		ret = -ENOMEM;
+	}
+
+	ret = no_os_i2c_init(&dev->i2c_desc, init_param->i2c_init);
+	if (ret)
+		goto i2c_err;
+
+	ret = lt7170_read_block_data(dev, LT7170_IC_DEVICE_ID, block,
+				     lt7170_info[init_param->chip_id].name_size);
+	if (ret)
+		goto dev_err;
+
+	if (strncmp((char *)block, lt7170_info[init_param->chip_id].name,
+		    lt7170_info[init_param->chip_id].name_size)) {
+		ret = -EIO;
+		goto dev_err;
+	}
+
+	/* Set PEC */
+	word = no_os_field_prep(LT7170_CONFIG_ALL_PEC_BIT,
+				(uint8_t)init_param->crc_en);
+	ret = lt7170_write_word(dev, LT7170_MFR_CONFIG_ALL, word);
+	if (ret)
+		goto dev_err;
+
+	dev->crc_en = init_param->crc_en;
+
+	/* Populate CRC table for PEC */
+	if (dev->crc_en)
+		no_os_crc8_populate_msb(lt7170_crc_table,
+					LT7170_CRC_POLYNOMIAL);
+
+	/* Initialize GPIO for PGOOD */
+	ret = no_os_gpio_get_optional(&dev->pg_desc, init_param->pg_param);
+	if (ret)
+		goto dev_err;
+
+	ret = no_os_gpio_direction_input(dev->pg_desc);
+	if (ret)
+		goto dev_err;
+
+	/* Initialize GPIO for RUN */
+	ret = no_os_gpio_get_optional(&dev->run_desc, init_param->run_param);
+	if (ret)
+		goto dev_err;
+
+	ret = no_os_gpio_direction_output(dev->run_desc, NO_OS_GPIO_HIGH);
+	if (ret)
+		goto dev_err;
+
+	/* Initialize GPIO for ALERT */
+	ret = no_os_gpio_get_optional(&dev->alert_desc,
+				      init_param->alert_param);
+	if (ret)
+		goto dev_err;
+
+	ret = no_os_gpio_direction_input(dev->alert_desc);
+	if (ret)
+		goto dev_err;
+
+	/* Initialize GPIO for FAULT */
+	ret = no_os_gpio_get_optional(&dev->fault_desc,
+				      init_param->fault_param);
+	if (ret)
+		goto dev_err;
+
+	if (init_param->fault_cfg == LT7170_FAULT_PIN_OUTPUT) {
+		ret = no_os_gpio_direction_output(dev->fault_desc,
+						  NO_OS_GPIO_HIGH);
+		if (ret)
+			goto dev_err;
+	} else {
+		ret = no_os_gpio_direction_input(dev->fault_desc);
+		if (ret)
+			goto dev_err;
+	}
+
+	/* Initialize external clock for synchronization if used */
+	if (init_param->external_clk_en) {
+		ret = no_os_pwm_init(&dev->sync_desc, init_param->sync_param);
+		if (ret)
+			goto dev_err;
+
+		ret = lt7170_sync_config(dev, false, true);
+		if (ret)
+			goto dev_err;
+	}
+
+	/* Set operation */
+	ret = lt7170_set_operation(dev, LT7170_OPERATION_ON);
+	if (ret)
+		goto dev_err;
+
+	/* Clear faults */
+	ret = lt7170_clear_faults(dev);
+	if (ret)
+		goto dev_err;
+
+	*device = dev;
+
+	return 0;
+
+dev_err:
+	no_os_i2c_remove(dev->i2c_desc);
+i2c_err:
+	no_os_free(dev);
+	return ret;
+}
+
+/**
+ * @brief Free or remove device instance
+ * @param dev - The device structure
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt7170_remove(struct lt7170_dev *dev)
+{
+	int ret;
+
+	ret = no_os_i2c_remove(dev->i2c_desc);
+	if (ret)
+		return ret;
+
+	ret = no_os_gpio_remove(dev->pg_desc);
+	if (ret)
+		return ret;
+
+	ret = no_os_gpio_remove(dev->run_desc);
+	if (ret)
+		return ret;
+
+	ret = no_os_gpio_remove(dev->alert_desc);
+	if (ret)
+		return ret;
+
+	ret = no_os_gpio_remove(dev->fault_desc);
+	if (ret)
+		return ret;
+
+	if (dev->sync_desc) {
+		ret = no_os_pwm_remove(dev->sync_desc);
+		if (ret)
+			return ret;
+	}
+
+	no_os_free(dev);
+
+	return ret;
+}
+
+/**
+ * @brief Send a PMBus command to the device
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt7170_send_byte(struct lt7170_dev *dev, uint8_t cmd)
+{
+	int ret;
+	uint8_t tx_buf[2] = {0};
+
+	tx_buf[0] = cmd;
+	if (dev->crc_en)
+		tx_buf[1] = lt7170_pec(dev, cmd, NULL, 0, 0);
+
+	return no_os_i2c_write(dev->i2c_desc, tx_buf, dev->crc_en + 1, 1);
+}
+
+/**
+ * @brief Perform a raw PMBus read byte operation
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @param data - Address of the byte read
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt7170_read_byte(struct lt7170_dev *dev, uint8_t cmd, uint8_t *data)
+{
+	int ret;
+	uint8_t rx_buf[2];
+
+	ret = no_os_i2c_write(dev->i2c_desc, &cmd, 1, 0);
+	if (ret)
+		return ret;
+
+	if (dev->crc_en) {
+		ret = no_os_i2c_read(dev->i2c_desc, rx_buf, 2, 1);
+		if (ret)
+			return ret;
+
+		if (lt7170_pec(dev, cmd, rx_buf, 1, 1) != rx_buf[1])
+			return -EBADMSG;
+
+		*data = rx_buf[0];
+		return ret;
+	} else {
+		return no_os_i2c_read(dev->i2c_desc, data, 1, 1);
+	}
+}
+
+/**
+ * @brief Perform a raw PMBus write byte operation
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @param value - Byte to be written
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt7170_write_byte(struct lt7170_dev *dev, uint8_t cmd, uint8_t value)
+{
+	int ret;
+	uint8_t tx_buf[3] = {0};
+
+	tx_buf[0] = cmd;
+	tx_buf[1] = value;
+
+	if (dev->crc_en)
+		tx_buf[2] = lt7170_pec(dev, cmd, &value, 1, 0);
+
+	return no_os_i2c_write(dev->i2c_desc, tx_buf, dev->crc_en + 2, 1);
+}
+
+/**
+ * @brief Perform a raw PMBus read word operation
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @param word - Address of the read word
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt7170_read_word(struct lt7170_dev *dev, uint8_t cmd, uint16_t *word)
+{
+	int ret;
+	uint8_t rx_buf[3] = {0};
+
+	ret = no_os_i2c_write(dev->i2c_desc, &cmd, 1, 0);
+	if (ret)
+		return ret;
+
+	if (dev->crc_en) {
+		ret = no_os_i2c_read(dev->i2c_desc, rx_buf, 3, 1);
+		if (ret)
+			return ret;
+
+		if (lt7170_pec(dev, cmd, rx_buf, 2, 1) != rx_buf[2])
+			return -EBADMSG;
+	} else {
+		ret = no_os_i2c_read(dev->i2c_desc, rx_buf, 2, 1);
+		if(ret)
+			return ret;
+	}
+
+	*word = no_os_get_unaligned_le16(rx_buf);
+	return 0;
+}
+
+/**
+ * @brief Perform a raw PMBus write word operation
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @param word - Word to write
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt7170_write_word(struct lt7170_dev *dev, uint8_t cmd, uint16_t word)
+{
+	int ret;
+	uint8_t tx_buf[4] = {0};
+
+	tx_buf[0] = cmd;
+	no_os_put_unaligned_le16(word, &tx_buf[1]);
+
+	if (dev->crc_en)
+		tx_buf[3] = lt7170_pec(dev, cmd, &tx_buf[1], 2, 0);
+
+	return no_os_i2c_write(dev->i2c_desc, tx_buf, dev->crc_en + 3, 1);
+}
+
+/**
+ * @brief Perform a PMBus read word operation and converts to actual value
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @param data - Address of data read
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt7170_read_word_data(struct lt7170_dev *dev, uint8_t cmd, int *data)
+{
+	int ret;
+	uint16_t reg;
+
+	ret = lt7170_read_word(dev, cmd, &reg);
+	if (ret)
+		return ret;
+
+	return lt7170_reg2data(dev, cmd, reg, data);
+}
+
+/**
+ * @brief Converts value to register data and do PMBus write word operation
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @param data - Value to write
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt7170_write_word_data(struct lt7170_dev *dev, uint8_t cmd, int data)
+{
+	int ret;
+	uint16_t reg;
+
+	ret = lt7170_data2reg(dev, cmd, data, &reg);
+	if (ret)
+		return ret;
+
+	return lt7170_write_word(dev, cmd, reg);
+}
+
+/**
+ * @brief Perform a PMBus read block operation
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @param data - Address of the read block
+ * @param nbytes - Size of the block in bytes
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt7170_read_block_data(struct lt7170_dev *dev, uint8_t cmd, uint8_t *data,
+			   size_t nbytes)
+{
+	int ret;
+	uint8_t rxbuf[nbytes + 2];
+
+	ret = no_os_i2c_write(dev->i2c_desc, &cmd, 1, 0);
+	if(ret)
+		return ret;
+
+	if (dev->crc_en) {
+		ret = no_os_i2c_read(dev->i2c_desc, rxbuf, nbytes + 2, 1);
+		if (ret)
+			return ret;
+
+		if ((size_t)rxbuf[0] > nbytes)
+			return -EMSGSIZE;
+
+		if (lt7170_pec(dev, cmd, rxbuf, nbytes + 1, 1) !=
+		    rxbuf[nbytes + 1])
+			return -EBADMSG;
+	} else {
+		ret = no_os_i2c_read(dev->i2c_desc, rxbuf, nbytes + 1, 1);
+		if(ret)
+			return ret;
+
+		if((size_t)rxbuf[0] > nbytes)
+			return -EMSGSIZE;
+	}
+
+	memcpy(data, &rxbuf[1], nbytes);
+
+	return 0;
+}
+
+/**
+ * @brief Read a value
+ * @param dev - Device structure
+ * @param value_type - Value type.
+ * 		       Example values: LT7170_VIN
+ * 				       LT7170_VOUT
+ * 				       LT7170_IOUT
+ * 				       LT7170_TEMP
+ * 				       LT7170_FREQUENCY
+ * @param value - Address of the read value
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt7170_read_value(struct lt7170_dev *dev, enum lt7170_value_type value_type,
+		      int *value)
+{
+	return lt7170_read_word_data(dev, (uint8_t)value_type, value);
+}
+
+/**
+ * @brief Read statuses
+ * @param dev - Device structure
+ * @param status_type - Status type.
+ * 			Example values: LT7170_STATUS_BYTE_TYPE
+ * 					LT7170_STATUS_VOUT_TYPE
+ * 					LT7170_STATUS_IOUT_TYPE
+ * 					LT7170_STATUS_INPUT_TYPE
+ * 					LT7170_STATUS_CML_TYPE
+ * @param status - Address of the status structure
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt7170_read_status(struct lt7170_dev *dev,
+		       enum lt7170_status_type status_type,
+		       struct lt7170_status *status)
+{
+	int ret;
+
+	if (status_type & LT7170_STATUS_WORD_TYPE) {
+		ret = lt7170_read_word(dev, LT7170_STATUS_WORD,
+				       &status->word);
+		if (ret)
+			return ret;
+	}
+
+	if (status_type & LT7170_STATUS_BYTE_TYPE) {
+		ret = lt7170_read_byte(dev, LT7170_STATUS_BYTE,
+				       &status->byte);
+		if (ret)
+			return ret;
+	}
+
+	if (status_type & LT7170_STATUS_VOUT_TYPE) {
+		ret = lt7170_read_byte(dev, LT7170_STATUS_VOUT,
+				       &status->vout);
+		if (ret)
+			return ret;
+	}
+
+	if (status_type & LT7170_STATUS_IOUT_TYPE) {
+		ret = lt7170_read_byte(dev, LT7170_STATUS_IOUT,
+				       &status->iout);
+		if (ret)
+			return ret;
+	}
+
+	if (status_type & LT7170_STATUS_INPUT_TYPE) {
+		ret = lt7170_read_byte(dev, LT7170_STATUS_INPUT,
+				       &status->input);
+		if (ret)
+			return ret;
+	}
+
+	if (status_type & LT7170_STATUS_TEMP_TYPE) {
+		ret = lt7170_read_byte(dev,
+				       LT7170_STATUS_TEMPERATURE,
+				       &status->temp);
+		if (ret)
+			return ret;
+	}
+
+	if (status_type & LT7170_STATUS_CML_TYPE) {
+		ret = lt7170_read_byte(dev,
+				       LT7170_STATUS_CML, &status->cml);
+		if (ret)
+			return ret;
+	}
+
+	if (status_type & LT7170_STATUS_MFR_SPECIFIC_TYPE) {
+		ret = lt7170_read_byte(dev,
+				       LT7170_STATUS_MFR_SPECIFIC,
+				       &status->mfr_specific);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Set output voltage and its upper limit
+ * @param dev - Device structure
+ * @param vout_command - Output voltage in millivolts
+ * @param vout_max - Output voltage upper limit in millivolts
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt7170_vout_value(struct lt7170_dev *dev, int vout_command, int vout_max)
+{
+	int ret;
+
+	ret = lt7170_write_word_data(dev, LT7170_VOUT_COMMAND, vout_command);
+	if (ret)
+		return ret;
+
+	return lt7170_write_word_data(dev, LT7170_VOUT_MAX, vout_max);
+}
+
+/**
+ * @brief Set output voltage transition rate
+ * @param dev - Device structure
+ * @param tr - Transition rate in V/s or mV/ms
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt7170_vout_tr(struct lt7170_dev *dev, int tr)
+{
+	return lt7170_write_word_data(dev, LT7170_VOUT_TRANSITION_RATE, tr);
+}
+
+/**
+ * @brief Set output voltage margin
+ * @param dev - Device structure
+ * @param margin_high - Upper margin in millivolts
+ * @param margin_low - Lower margin in millivolts
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt7170_vout_margin(struct lt7170_dev *dev, int margin_high, int margin_low)
+{
+	int ret;
+
+	if (margin_high < margin_low)
+		return -EINVAL;
+
+	ret = lt7170_write_word_data(dev, LT7170_VOUT_MARGIN_HIGH, margin_high);
+	if (ret)
+		return ret;
+
+	return lt7170_write_word_data(dev, LT7170_VOUT_MARGIN_LOW, margin_low);
+}
+
+/**
+ * @brief Set input voltage window at which power conversion will proceed
+ * @param dev - Device structure
+ * @param vin_on - Input voltage in millivolts at which conversion will start
+ * @param vin_off - Input voltage in millivolts at which conversion will stop
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt7170_set_vin(struct lt7170_dev *dev, int vin_on, int vin_off)
+{
+	int ret;
+
+	if (vin_on < vin_off)
+		return -EINVAL;
+
+	if (vin_on < LT7170_VIN_ON_MIN || vin_on > LT7170_VIN_ON_MAX)
+		return -EINVAL;
+
+	if (vin_off < LT7170_VIN_OFF_MIN || vin_off > LT7170_VIN_OFF_MAX)
+		return -EINVAL;
+
+	ret = lt7170_write_word_data(dev, LT7170_VIN_ON, vin_on);
+	if (ret)
+		return ret;
+
+	return lt7170_write_word_data(dev, LT7170_VIN_OFF, vin_off);
+}
+
+/**
+ * @brief Set timing values
+ * @param dev - Device structure
+ * @param timing_type - Timing value type.
+ * 			Example: LT7170_TON_DELAY_TYPE
+ * 				 LT7170_TON_RISE_TYPE
+ * 				 LT7170_TOFF_DELAY_TYPE
+ * 				 LT7170_RETRY_DELAY_TYPE
+ * @param time - Time value in microseconds
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt7170_set_timing(struct lt7170_dev *dev,
+		      enum lt7170_timing_type timing_type, int time) // in us
+{
+	return lt7170_write_word_data(dev, timing_type, time);
+}
+
+/**
+ * @brief Set switching frequency
+ * @param dev - Device structure
+ * @param freq - Frequency to set in Hz. Value should be between 400000 Hz and
+ * 		 4000000 Hz.
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt7170_switch_freq(struct lt7170_dev *dev, int freq)
+{
+	if (freq < LT7170_FREQ_MIN || freq > LT7170_FREQ_MAX)
+		return -EINVAL;
+
+	freq *= MILLI;
+	return lt7170_write_word_data(dev, LT7170_FREQUENCY_SWITCH, freq);
+}
+
+/**
+ * @brief Set output PWM mode
+ * @param dev - Device structure
+ * @param pwm_mode - PWM mode of the output channel.
+ * 		     Example: LT7170_PWM_FORCED_CONTINUOUS_MODE
+ * 			      LT7170_PWM_PULSE_SKIP_MODE
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt7170_pwm_mode(struct lt7170_dev *dev, enum lt7170_pwm_mode pwm_mode)
+{
+	int ret;
+	uint16_t temp_word;
+
+	ret = lt7170_read_word(dev, LT7170_MFR_PWM_MODE, &temp_word);
+	if (ret)
+		return ret;
+
+	temp_word &= ~(LT7170_PWM_OP_MODE_BIT);
+	temp_word |= no_os_field_prep(LT7170_PWM_OP_MODE_BIT, pwm_mode);
+
+	return lt7170_write_word(dev, LT7170_MFR_PWM_MODE, temp_word);
+}
+
+/**
+ * @brief Set output PWM phase
+ * @param dev - Device structure
+ * @param phase - Phase in milli-degrees
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt7170_pwm_phase(struct lt7170_dev *dev, int phase)
+{
+	phase %= LT7170_PHASE_FULL_MILLI;
+	if (phase < 0)
+		phase += LT7170_PHASE_FULL_MILLI;
+
+	return lt7170_write_word_data(dev, LT7170_MFR_PWM_PHASE, phase);
+}
+
+/**
+ * @brief Set overvalue and undervalue limits
+ * @param dev - Device structure
+ * @param limit - Limit value type.
+ * 			Example: LT7170_VOUT_OV_FAULT_LIMIT_TYPE
+ * 				 LT7170_OT_WARN_LIMIT_TYPE
+ * 				 LT7170_TON_MAX_FAULT_LIMIT_TYPE
+ * 				 LT7170_VIN_UV_WARN_LIMIT_TYPE
+ * @param limit_val - Limit value in milli-units for voltage and current, and
+ * 		      microseconds for timing.
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt7170_set_limit(struct lt7170_dev *dev, enum lt7170_limit_type limit,
+		     int limit_val)
+{
+	return lt7170_write_word_data(dev, (uint8_t)limit, limit_val);
+}
+
+/**
+ * @brief Set channel operation
+ * @param dev - Device structure
+ * @param operation - Operation.
+ * 		      Accepted values are: LT7170_OPERATION_OFF
+ * 					   LT7170_OPERATION_ON
+ * 					   LT7170_OPERATION_MARGIN_HIGH
+ * 					   LT7170_OPERATION_MARGIN_LOW
+ * 					   LT7170_OPERATION_SEQ_OFF
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt7170_set_operation(struct lt7170_dev *dev,
+			 enum lt7170_operation_type operation)
+{
+	return lt7170_write_byte(dev, LT7170_OPERATION, (uint8_t)operation);
+}
+
+/**
+ * @brief Set channel state using the RUN pin.
+ * @param dev - Device structure
+ * @param state - true for ON, false for OFF
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt7170_set_channel_state(struct lt7170_dev *dev, bool state)
+{
+	return no_os_gpio_direction_output(dev->run_desc, state);
+}
+
+/**
+ * @brief Configure SYNC pin for clock synchronization
+ * @param dev - Device structure
+ * @param input_clk - Enable to use SYNC clock input
+ * @param output_clk - Enable to use SYNC output clock
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt7170_sync_config(struct lt7170_dev *dev, bool input_clk, bool output_clk)
+{
+	int ret;
+	uint8_t temp;
+
+	ret = lt7170_read_byte(dev, LT7170_MFR_SYNC_CONFIG, &temp);
+	if (ret)
+		return ret;
+
+	temp &= ~(LT7170_SYNC_CLK_INPUT_BIT | LT7170_SYNC_CLK_OUTPUT_BIT);
+	temp |= no_os_field_prep(LT7170_SYNC_CLK_INPUT_BIT, !input_clk) |
+		no_os_field_prep(LT7170_SYNC_CLK_OUTPUT_BIT, output_clk);
+
+	return lt7170_write_byte(dev,
+				 LT7170_MFR_SYNC_CONFIG, temp);
+}
+
+/**
+ * @brief Configure ADC control
+ * @param dev - Device structure
+ * @param low_freq_telemetry - Enable for low frequency telemetry (every 100ms)
+ * @param debug_telemetry - Enable for debug telemetry with EXTVcc and Ith
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt7170_adc_control(struct lt7170_dev *dev, bool low_freq_telemetry,
+		       bool debug_telemetry)
+{
+	return lt7170_write_byte(dev, LT7170_MFR_ADC_CONTROL,
+				 no_os_field_prep(LT7170_ADC_CTRL_DEBUG_BIT,
+						 (uint8_t)debug_telemetry) |
+				 no_os_field_prep(LT7170_ADC_CTRL_LOW_FREQ_BIT,
+						 (uint8_t)low_freq_telemetry));
+}
+
+/**
+ * @brief Perform commands for non-volatile memory (NVM)
+ * @param dev - Device structure
+ * @param cmd - NVM commands.
+ * 		Example: LT7170_LOCK_USER
+ * 			 LT7170_UNLOCK_USER
+ * 			 LT7170_STORE_USER
+ * 			 LT7170_COMPARE_USER
+ * 			 LT7170_RESTORE_USER
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt7170_nvm_cmd(struct lt7170_dev *dev, enum lt7170_nvm_cmd_type cmd)
+{
+	int ret;
+
+	switch (cmd) {
+	case LT7170_LOCK_USER:
+		return lt7170_write_byte(dev, LT7170_MFR_NVM_USER_WP, 1);
+	case LT7170_UNLOCK_USER:
+		return lt7170_write_byte(dev, LT7170_MFR_NVM_USER_WP, 0);
+	case LT7170_STORE_USER:
+	case LT7170_COMPARE_USER:
+		return lt7170_send_byte(dev, (uint8_t)cmd);
+	case LT7170_RESTORE_USER:
+		ret = lt7170_send_byte(dev, (uint8_t)cmd);
+		if (ret)
+			return ret;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Clear all asserted faults
+ * @param dev - Device structure
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt7170_clear_faults(struct lt7170_dev *dev)
+{
+	return lt7170_send_byte(dev, LT7170_CLEAR_FAULTS);
+}
+
+/**
+ * @brief Perform a device software reset
+ * @param dev - Device structure
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt7170_software_reset(struct lt7170_dev *dev)
+{
+	int ret;
+
+	ret = lt7170_send_byte(dev, LT7170_MFR_RESET);
+	if (ret)
+		return ret;
+
+	return 0;
+}

--- a/drivers/power/lt7170/lt7170.h
+++ b/drivers/power/lt7170/lt7170.h
@@ -1,0 +1,449 @@
+/*******************************************************************************
+*   @file   lt7170.h
+*   @brief  Header file of the LT7170 Driver
+*   @authors Cherrence Sarip (cherrence.sarip@analog.com)
+********************************************************************************
+* Copyright 2024(c) Analog Devices, Inc.
+*
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*  - Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*  - Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in
+*    the documentation and/or other materials provided with the
+*    distribution.
+*  - Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*  - The use of this software may or may not infringe the patent rights
+*    of one or more patent holders.  This license does not release you
+*    from the requirement that you obtain separate licenses from these
+*    patent holders to use this software.
+*  - Use of the software either in source or binary form, must be run
+*    on or directly connected to an Analog Devices Inc. component.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef __LT7170_H__
+#define __LT7170_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <stdint.h>
+#include <string.h>
+#include "no_os_util.h"
+#include "no_os_i2c.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+/* PMBus commands */
+#define LT7170_PAGE				0x00
+#define LT7170_OPERATION			0x01
+#define LT7170_ON_OFF_CONFIG			0x02
+#define LT7170_CLEAR_FAULTS			0x03
+#define LT7170_PAGE_PLUS_WRITE			0x05
+#define LT7170_PAGE_PLUS_READ			0x06
+#define LT7170_ZONE_CONFIG			0x07
+#define LT7170_ZONE_ACTIVE			0x08
+
+#define LT7170_WRITE_PROTECT			0x10
+
+#define LT7170_STORE_USER_ALL			0x15
+#define LT7170_RESTORE_USER_ALL			0x16
+
+#define LT7170_CAPABILITY			0x19
+#define LT7170_QUERY				0x1A
+#define LT7170_SMBALERT_MASK			0x1B
+
+#define LT7170_VOUT_MODE			0x20
+#define LT7170_VOUT_COMMAND			0x21
+#define LT7170_VOUT_MAX				0x24
+#define LT7170_VOUT_MARGIN_HIGH			0x25
+#define LT7170_VOUT_MARGIN_LOW			0x26
+#define LT7170_VOUT_TRANSITION_RATE		0x27
+
+#define LT7170_FREQUENCY_SWITCH			0x33
+#define LT7170_VIN_ON				0x35
+#define LT7170_VIN_OFF				0x36
+
+#define LT7170_IOUT_CAL_OFFSET			0x39
+#define LT7170_VOUT_OV_FAULT_LIMIT		0x40
+#define LT7170_VOUT_OV_FAULT_RESPONSE		0x41
+#define LT7170_VOUT_OV_WARN_LIMIT		0x42
+#define LT7170_VOUT_UV_WARN_LIMIT		0x43
+#define LT7170_VOUT_UV_FAULT_LIMIT		0x44
+#define LT7170_VOUT_UV_FAULT_RESPONSE		0x45
+#define LT7170_IOUT_OC_FAULT_RESPONSE		0x47
+#define LT7170_IOUT_OC_WARN_LIMIT		0x4A
+
+#define LT7170_OT_FAULT_LIMIT			0x4F
+#define LT7170_OT_FAULT_RESPONSE		0x50
+#define LT7170_OT_WARN_LIMIT			0x51
+
+#define LT7170_VIN_OV_FAULT_RESPONSE		0x56
+#define LT7170_VIN_UV_WARN_LIMIT		0x58
+
+#define LT7170_TON_DELAY			0x60
+#define LT7170_TON_RISE				0x61
+#define LT7170_TON_MAX_FAULT_LIMIT		0x62
+#define LT7170_TON_MAX_FAULT_RESPONSE		0x63
+#define LT7170_TOFF_DELAY			0x64
+#define LT7170_TOFF_FALL			0x65
+#define LT7170_TOFF_MAX_WARN_LIMIT		0x66
+
+#define LT7170_STATUS_BYTE			0x78
+#define LT7170_STATUS_WORD			0x79
+#define LT7170_STATUS_VOUT			0x7A
+#define LT7170_STATUS_IOUT			0x7B
+#define LT7170_STATUS_INPUT			0x7C
+#define LT7170_STATUS_TEMPERATURE		0x7D
+#define LT7170_STATUS_CML			0x7E
+#define LT7170_STATUS_MFR_SPECIFIC		0x80
+
+#define LT7170_READ_VIN				0x88
+#define LT7170_READ_VOUT			0x8B
+#define LT7170_READ_IOUT			0x8C
+#define LT7170_READ_TEMPERATURE_1		0x8D
+#define LT7170_READ_FREQUENCY			0x95
+
+#define LT7170_REVISION				0x98
+#define LT7170_MFR_ID				0x99
+#define LT7170_MFR_SERIAL			0x9E
+
+#define LT7170_IC_DEVICE_ID			0xAD
+#define LT7170_IC_DEVICE_REV			0xAE
+
+#define LT7170_MFR_NVM_UNLOCK			0xBD
+#define LT7170_MFR_NVM_USER_WRITES_REMAINING	0xBE
+#define LT7170_MFR_NVM_DATA			0xBF
+#define LT7170_MFR_USER_DATA_00			0xC9
+#define LT7170_MFR_USER_DATA_01			0xCA
+#define LT7170_MFR_READ_EXTVCC			0xCD
+#define LT7170_MFR_READ_ITH			0xCE
+#define LT7170_MFR_CHAN_CONFIG			0xD0
+#define LT7170_MFR_CONFIG_ALL			0xD1
+#define LT7170_MFR_FAULT_PROPAGATE		0xD2
+#define LT7170_MFR_READ_ASEL			0xD3
+#define LT7170_MFR_PWM_MODE			0xD4
+#define LT7170_MFR_FAULT_RESPONSE		0xD5
+#define LT7170_MFR_IOUT_PEAK			0xD7
+#define LT7170_MFR_ADC_CONTROL			0xD8
+#define LT7170_MFR_RETRY_DELAY			0xDB
+#define LT7170_MFR_VOUT_PEAK			0xDD
+#define LT7170_MFR_VIN_PEAK			0xDE
+#define LT7170_MFR_TEMPERATURE_1_PEAK		0xDF
+#define LT7170_MFR_READ_PWM_CFG			0xE0
+#define LT7170_MFR_READ_VOUT_CFG		0xE1
+#define LT7170_MFR_CLEAR_PEAKS			0xE3
+#define LT7170_MFR_DISCHARGE_THRESHOLD		0xE4
+#define LT7170_MFR_PADS				0xE5
+#define LT7170_MFR_I2C_ADDRESS			0xE6
+#define LT7170_MFR_SPECIAL_ID			0xE7
+#define LT7170_MFR_COMMON			0xEF
+#define LT7170_MFR_COMPARE_USER_ALL		0xF0
+#define LT7170_MFR_CHANNEL_STATE		0xF1
+#define LT7170_MFR_PGOOD_DELAY			0xF2
+#define LT7170_MFR_NOT_PGOOD_DELAY		0xF3
+#define LT7170_MFR_PWM_PHASE			0xF5
+#define LT7170_MFR_SYNC_CONFIG			0xF6
+#define LT7170_MFR_PIN_CONFIG_STATUS		0xF7
+#define LT7170_MFR_RAIL_ADDRESS			0xFA
+#define LT7170_MFR_DISABLE_OUTPUT		0xFB
+#define LT7170_MFR_NVM_USER_WP			0xFC
+#define LT7170_MFR_RESET			0xFD
+
+/* PMBus-specific parameters */
+#define LT7170_CRC_POLYNOMIAL			0x7
+#define LT7170_VOUT_MODE_VAL_MSK		NO_OS_GENMASK(4,0)
+
+/* IEEE754 data format params */
+#define LT7170_IEEE754_SIGN_BIT			NO_OS_BIT(15)
+#define LT7170_IEEE754_EXPONENT_MSK		NO_OS_GENMASK(14, 10)
+#define LT7170_IEEE754_MANTISSA_MSK		NO_OS_GENMASK(9, 0)
+#define LT7170_IEEE754_MAX_MANTISSA		0x7ff
+#define LT7170_IEEE754_MIN_MANTISSA		0x400
+
+/* Device specific constants */
+#define LT7170_FREQ_MIN				400000
+#define LT7170_FREQ_MAX				4000000
+#define LT7170_VIN_ON_MIN			1400
+#define LT7170_VIN_ON_MAX			16000
+#define LT7170_VIN_OFF_MIN			1350
+#define LT7170_VIN_OFF_MAX			16000
+#define LT7170_PHASE_FULL_MILLI			360000
+
+/* Status types masks */
+#define LT7170_STATUS_BYTE_TYPE_MSK		0x01
+#define LT7170_STATUS_VOUT_TYPE_MSK		0x02
+#define LT7170_STATUS_IOUT_TYPE_MSK		0x04
+#define LT7170_STATUS_INPUT_TYPE_MSK		0x08
+#define LT7170_STATUS_TEMP_TYPE_MSK		0x10
+#define LT7170_STATUS_CML_TYPE_MSK		0x20
+#define LT7170_STATUS_MFR_SPECIFIC_TYPE_MSK	0x40
+#define LT7170_STATUS_WORD_TYPE_MSK		0x80
+#define LT7170_STATUS_ALL_TYPE_MSK		0xFF
+
+/* LT7170 configurable bits and masks */
+#define LT7170_PWM_OP_MODE_BIT			NO_OS_BIT(0)
+#define LT7170_SYNC_CLK_INPUT_BIT		NO_OS_BIT(1)
+#define LT7170_SYNC_CLK_OUTPUT_BIT		NO_OS_BIT(0)
+#define LT7170_ADC_CTRL_LOW_FREQ_BIT		NO_OS_BIT(1)
+#define LT7170_ADC_CTRL_DEBUG_BIT		NO_OS_BIT(0)
+#define LT7170_CONFIG_ALL_PEC_BIT		NO_OS_BIT(2)
+#define LT7170_PADS_RUN_BIT			NO_OS_BIT(2)
+
+#define LT7170_SPECIAL_ID_VALUE			0x1C1D
+
+enum lt7170_chip_id {
+	ID_LT7170,
+	ID_LT7170_1,
+	ID_LT7171,
+	ID_LT7171_1,
+};
+
+enum lt7170_fault_pin_config {
+	LT7170_FAULT_PIN_INPUT,
+	LT7170_FAULT_PIN_OUTPUT,
+};
+
+enum lt7170_operation_type {
+	LT7170_OPERATION_OFF = 0x00,
+	LT7170_OPERATION_ON = 0x80,
+	LT7170_OPERATION_MARGIN_HIGH = 0x98,
+	LT7170_OPERATION_MARGIN_LOW = 0xA8,
+	LT7170_OPERATION_SEQ_OFF = 0x40,
+};
+
+enum lt7170_value_type {
+	LT7170_VIN = LT7170_READ_VIN,
+	LT7170_VOUT = LT7170_READ_VOUT,
+	LT7170_IOUT = LT7170_READ_IOUT,
+	LT7170_TEMP = LT7170_READ_TEMPERATURE_1,
+	LT7170_FREQUENCY = LT7170_READ_FREQUENCY,
+	LT7170_ITH = LT7170_MFR_READ_ITH,
+	LT7170_EXTVCC = LT7170_MFR_READ_EXTVCC,
+	LT7170_IOUT_PEAK = LT7170_MFR_IOUT_PEAK,
+	LT7170_VOUT_PEAK = LT7170_MFR_VOUT_PEAK,
+	LT7170_VIN_PEAK = LT7170_MFR_VIN_PEAK,
+	LT7170_TEMP_PEAK = LT7170_MFR_TEMPERATURE_1_PEAK,
+};
+
+enum lt7170_limit_type {
+	LT7170_VOUT_OV_FAULT_LIMIT_TYPE = LT7170_VOUT_OV_FAULT_LIMIT,
+	LT7170_VOUT_OV_WARN_LIMIT_TYPE = LT7170_VOUT_OV_WARN_LIMIT,
+	LT7170_VOUT_UV_FAULT_LIMIT_TYPE = LT7170_VOUT_UV_FAULT_LIMIT,
+	LT7170_VOUT_UV_WARN_LIMIT_TYPE = LT7170_VOUT_UV_WARN_LIMIT,
+	LT7170_IOUT_OC_WARN_LIMIT_TYPE = LT7170_IOUT_OC_WARN_LIMIT,
+	LT7170_OT_FAULT_LIMIT_TYPE = LT7170_OT_FAULT_LIMIT,
+	LT7170_OT_WARN_LIMIT_TYPE = LT7170_OT_WARN_LIMIT,
+	LT7170_VIN_UV_WARN_LIMIT_TYPE = LT7170_VIN_UV_WARN_LIMIT,
+	LT7170_TON_MAX_FAULT_LIMIT_TYPE = LT7170_TON_MAX_FAULT_LIMIT,
+	LT7170_TOFF_MAX_WARN_LIMIT_TYPE = LT7170_TOFF_MAX_WARN_LIMIT,
+};
+
+enum lt7170_status_type {
+	LT7170_STATUS_BYTE_TYPE = LT7170_STATUS_BYTE_TYPE_MSK,
+	LT7170_STATUS_VOUT_TYPE = LT7170_STATUS_VOUT_TYPE_MSK,
+	LT7170_STATUS_IOUT_TYPE = LT7170_STATUS_IOUT_TYPE_MSK,
+	LT7170_STATUS_INPUT_TYPE = LT7170_STATUS_INPUT_TYPE_MSK,
+	LT7170_STATUS_TEMP_TYPE = LT7170_STATUS_TEMP_TYPE_MSK,
+	LT7170_STATUS_CML_TYPE = LT7170_STATUS_CML_TYPE_MSK,
+	LT7170_STATUS_MFR_SPECIFIC_TYPE = LT7170_STATUS_MFR_SPECIFIC_TYPE_MSK,
+	LT7170_STATUS_WORD_TYPE = LT7170_STATUS_WORD_TYPE_MSK,
+	LT7170_STATUS_ALL_TYPE = LT7170_STATUS_ALL_TYPE_MSK,
+};
+
+enum lt7170_timing_type {
+	LT7170_TON_DELAY_TYPE = LT7170_TON_DELAY,
+	LT7170_TON_RISE_TYPE = LT7170_TON_RISE,
+	LT7170_TOFF_DELAY_TYPE = LT7170_TOFF_DELAY,
+	LT7170_TOFF_FALL_TYPE = LT7170_TOFF_FALL,
+	LT7170_RETRY_DELAY = LT7170_MFR_RETRY_DELAY,
+};
+
+enum lt7170_nvm_cmd_type {
+	LT7170_LOCK_USER,
+	LT7170_UNLOCK_USER,
+	LT7170_STORE_USER = LT7170_STORE_USER_ALL,
+	LT7170_RESTORE_USER = LT7170_RESTORE_USER_ALL,
+	LT7170_COMPARE_USER = LT7170_MFR_COMPARE_USER_ALL,
+};
+
+enum lt7170_pwm_mode {
+	LT7170_PWM_FORCED_CONTINUOUS_MODE,
+	LT7170_PWM_PULSE_SKIP_MODE,
+};
+
+struct lt7170_dev {
+	struct no_os_i2c_desc *i2c_desc;
+	struct no_os_gpio_desc *pg_desc;
+	struct no_os_gpio_desc *run_desc;
+	struct no_os_gpio_desc *alert_desc;
+	struct no_os_gpio_desc *fault_desc;
+	struct no_os_pwm_desc *sync_desc;
+
+	enum lt7170_chip_id chip_id;
+	bool crc_en;
+};
+
+struct lt7170_init_param {
+	struct no_os_i2c_init_param *i2c_init;
+	struct no_os_gpio_init_param *pg_param;
+	struct no_os_gpio_init_param *run_param;
+	struct no_os_gpio_init_param *alert_param;
+	struct no_os_gpio_init_param *fault_param;
+	struct no_os_pwm_init_param *sync_param;
+
+	enum lt7170_chip_id chip_id;
+	enum lt7170_fault_pin_config fault_cfg;
+
+	bool external_clk_en;
+	bool crc_en;
+};
+
+struct lt7170_chip_info {
+	char *name;
+	uint8_t name_size;
+};
+
+struct lt7170_status {
+	uint16_t word;
+	uint8_t byte;
+	uint8_t vout;
+	uint8_t iout;
+	uint8_t input;
+	uint8_t temp;
+	uint8_t cml;
+	uint8_t mfr_specific;
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+/* Initialize the device structure */
+int lt7170_init(struct lt7170_dev **dev,
+		struct lt7170_init_param *init_param);
+
+/* Free or remove device instance */
+int lt7170_remove(struct lt7170_dev *dev);
+
+/* Send a PMBus command to the device */
+int lt7170_send_byte(struct lt7170_dev *dev, uint8_t cmd);
+
+/* Perform a PMBus read_byte operation */
+int lt7170_read_byte(struct lt7170_dev *dev,
+		     uint8_t cmd, uint8_t *data);
+
+/*  Perform a PMBus write_byte operation */
+int lt7170_write_byte(struct lt7170_dev *dev,
+		      uint8_t cmd, uint8_t value);
+
+/* Perform a PMBus read_word operation */
+int lt7170_read_word(struct lt7170_dev *dev,
+		     uint8_t cmd, uint16_t *word);
+
+/* Perform a PMBus write_word operation */
+int lt7170_write_word(struct lt7170_dev *dev,
+		      uint8_t cmd, uint16_t word);
+
+/* Perform a PMBus read_word operation then perform conversion*/
+int lt7170_read_word_data(struct lt7170_dev *dev,
+			  uint8_t cmd, int *data);
+
+/* Perform conversion then perform a PMBus write_word operation */
+int lt7170_write_word_data(struct lt7170_dev *dev,
+			   uint8_t cmd, int data);
+
+/* Read a block of bytes */
+int lt7170_read_block_data(struct lt7170_dev *dev,
+			   uint8_t cmd, uint8_t *data, size_t nbytes);
+
+/* Read specific value type */
+int lt7170_read_value(struct lt7170_dev *dev,
+		      enum lt7170_value_type value_type,
+		      int *value);
+
+/* Read status */
+int lt7170_read_status(struct lt7170_dev *dev,
+		       enum lt7170_status_type status_type,
+		       struct lt7170_status *status);
+
+/* Set VOUT parameters: VOUT_COMMAND and VOUT_MAX */
+int lt7170_vout_value(struct lt7170_dev *dev,
+		      int vout_command, int vout_max);
+
+/* Set VOUT transition rate */
+int lt7170_vout_tr(struct lt7170_dev *dev, int tr);
+
+/* Set VOUT margins */
+int lt7170_vout_margin(struct lt7170_dev *dev,
+		       int margin_high, int margin_low);
+
+/* Set VIN threshold when to start power conversion */
+int lt7170_set_vin(struct lt7170_dev *dev,
+		   int vin_on, int vin_off);
+
+/* Set timing values */
+int lt7170_set_timing(struct lt7170_dev *dev,
+		      enum lt7170_timing_type timing_type, int time);
+
+/* Set switching frequency */
+int lt7170_switch_freq(struct lt7170_dev *dev, int freq);
+
+/* Set PWM mode of a channel */
+int lt7170_pwm_mode(struct lt7170_dev *dev,
+		    enum lt7170_pwm_mode pwm_mode);
+
+/* Set PWM phase offset of a channel */
+int lt7170_pwm_phase(struct lt7170_dev *dev,
+		     int phase);
+
+/* Set fault/warning limit values */
+int lt7170_set_limit(struct lt7170_dev *dev,
+		     enum lt7170_limit_type limit, int limit_val);
+
+/* Set operation */
+int lt7170_set_operation(struct lt7170_dev *dev,
+			 enum lt7170_operation_type operation);
+
+/* Set channel state */
+int lt7170_set_channel_state(struct lt7170_dev *dev,
+			     bool state);
+
+/* Set clock synchronization configs */
+int lt7170_sync_config(struct lt7170_dev *dev,
+		       bool input_clk,
+		       bool output_clk);
+
+/* Set ADC telemetry control */
+int lt7170_adc_control(struct lt7170_dev *dev, bool low_freq_telemetry,
+		       bool debug_telemetry);
+
+/* NVM/EEPROM user commands */
+int lt7170_nvm_cmd(struct lt7170_dev *dev, enum lt7170_nvm_cmd_type cmd);
+
+/* Clear status registers */
+int lt7170_clear_faults(struct lt7170_dev *dev);
+
+/* Software reset */
+int lt7170_software_reset(struct lt7170_dev *dev);
+
+#endif /* __LT7170_H__ */

--- a/projects/lt7170/Makefile
+++ b/projects/lt7170/Makefile
@@ -1,0 +1,9 @@
+# Select the example you want to enable by choosing y for enabling and n for disabling
+BASIC_EXAMPLE = n
+IIO_EXAMPLE = y
+
+include ../../tools/scripts/generic_variables.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/lt7170/README.rst
+++ b/projects/lt7170/README.rst
@@ -1,0 +1,173 @@
+Evaluating the LT7170
+======================
+
+.. contents::
+	:depth: 3
+
+Supported Evaluation Boards
+---------------------------
+
+* `EVAL-LT7170-AZ <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-lt7170-az.html>`_
+* `EVAL-LT7170-1-AZ <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-lt7170-1-az.html>`_
+* `EVAL-LT7171-AZ <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-lt7171-az.html>`_
+* `EVAL-LT7171-1-AZ <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-lt7171-1-az.html>`_
+
+Overview
+--------
+
+The EVAL-LT7170-AZ and EVAL-LT7170-1-AZ power up to default settings and 
+produce power based on the NVM configuration without requiring any serial bus 
+communication. Both can supply up to 20A continuous load current.
+
+The EVAL-LT7171-AZ and EVAL-LT7171-1-AZ also power up to default settings and 
+produce power based on the NVM configuration without requiring any serial bus 
+communication. Both can supply up to 40A continuous load current.
+
+For full performance details, refer to the LT7170/LT7170-1 and LT7171/LT7171-1 
+data sheets, which should be consulted in conjunction with the user guide.
+
+Hardware Specifications
+-----------------------
+
+Power Supply Requirements
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For this specific project an external power supply with output of 4V to 20V can
+be used to power up the demo board.
+
+**Pin Description**
+
+	+-----+----------+-------------------------------------------+
+	| Pin |   Name 	 | Description				     |
+	+-----+----------+-------------------------------------------+
+	| 1   | VEMI     | Power Supply, 2.9V - 16V		     |
+	+-----+----------+-------------------------------------------+
+	| 2   | GND      | Connect to Ground			     |
+	+-----+----------+-------------------------------------------+
+	| 3   | VOUT     | Connect to Load			     |
+	+-----+----------+-------------------------------------------+
+	| 4   | EXTVCC	 | Do Not Connect			     |
+	+-----+----------+-------------------------------------------+
+	| 5   | PGOOD	 | GPIO (Optional)			     |
+	+-----+----------+-------------------------------------------+
+	| 6   | ALERT	 | GPIO (Optional)			     |
+	+-----+----------+-------------------------------------------+
+	| 7   | FAULT	 | GPIO (Optional)			     |
+	+-----+----------+-------------------------------------------+
+	| 8   | SYNC	 | Do Not Connect			     |
+	+-----+----------+-------------------------------------------+
+	|  9  | SHARE_CLK| Do Not Connect			     |
+	+-----+----------+-------------------------------------------+
+	| 10  | SCL	 | I2C Serial Clock			     |
+	+-----+----------+-------------------------------------------+
+	| 11  | SDA      | I2C Serial Data			     |
+	+-----+----------+-------------------------------------------+
+
+**Hardware Bringup**
+
+For reference, consult the Quick Start Procedure section in the user guide for the corresponding demo board:
+`EVAL-LT7170-AZ user guide <https://www.analog.com/media/en/technical-documentation/user-guides/eval-lt7170-az.pdf>`_,
+`EVAL-LT7170-1-AZ user guide <https://www.analog.com/media/en/technical-documentation/user-guides/eval-lt7170-1-az.pdf>`_,
+`EVAL-LT7171-AZ user guide <https://www.analog.com/media/en/technical-documentation/user-guides/eval-lt7171-az-ug.pdf>`_, and
+`EVAL-LT7171-1-AZ user guide <https://www.analog.com/media/en/technical-documentation/user-guides/eval-lt7171-1-az.pdf>`_.
+
+No-OS Build Setup
+-----------------
+
+Please see: https://wiki.analog.com/resources/no-os/build
+
+No-OS Supported Examples
+------------------------
+
+The initialization data used in the examples is taken out from:
+`Project Common Data Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/lt7170/src/common>`_
+
+The macros used in Common Data are defined in platform specific files found in:
+`Project Platform Configuration Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/lt7170/src/platform>`_
+
+Basic example
+^^^^^^^^^^^^^
+
+This is a simple example that initializes the LT7170, and performs telemetry
+readings of the voltage, current and temperature. Status bytes/words are also 
+monitored in the example.
+
+In order to build the basic example make sure you have the following 
+configuration in the Makefile
+`Makefile <https://github.com/analogdevicesinc/no-OS/tree/main/projects/lt7170/Makefile>`_
+
+.. code-block:: bash
+
+	# Select the example you want to enable by choosing y for enabling and n for disabling
+	BASIC_EXAMPLE = y
+	IIO_EXAMPLE = n
+
+IIO example
+^^^^^^^^^^^
+
+This project is actually a IIOD demo for DC2836A evaluation board.
+The project launches a IIOD server on the board so that the user may connect
+to it via an IIO client.
+
+If you are not familiar with ADI IIO Application, please take a look at:
+`IIO No-OS <https://wiki.analog.com/resources/tools-software/no-os-software/iio>`_
+
+If you are not familiar with ADI IIO-Oscilloscope Client, please take a look at:
+`IIO Oscilloscope <https://wiki.analog.com/resources/tools-software/linux-software/iio_oscilloscope>`_
+
+The No-OS IIO Application together with the No-OS IIO LT7170 driver take care of
+all the back-end logic needed to setup the IIO server.
+
+This example initializes the IIO device and calls the IIO app as shown in:
+`IIO Example <https://github.com/analogdevicesinc/no-OS/tree/main/projects/lt7170/src/examples/iio_example>`_
+
+In order to build the IIO project make sure you have the following 
+configuration in the
+`Makefile <https://github.com/analogdevicesinc/no-OS/tree/main/projects/lt7170/Makefile>`_
+
+.. code-block:: bash
+
+        # Select the example you want to enable by choosing y for enabling and n for disabling
+        BASIC_EXAMPLE = n
+        IIO__EXAMPLE = y
+
+No-OS Supported Platforms
+-------------------------
+
+Maxim Platform
+^^^^^^^^^^^^^^
+
+**Used hardware**
+
+* `EVAL-LT7170-AZ <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-lt7170-az.html>`_
+* `EVAL-LT7170-1-AZ <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-lt7170-1-az.html>`_
+* `EVAL-LT7171-AZ <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-lt7171-az.html>`_
+* `EVAL-LT7171-1-AZ <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-lt7171-1-az.html>`_
+* `MAX32666FTHR <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/max32666fthr.html>`_
+
+**Connections**:
+
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| EVAL-LT7170-AZ Pin Number   |  Mnemonic  | Function					  | MAX32666FTHR Pin Number	|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 1			      | VEMI	   | External Power Supply, 2.9V - 16V		  | Do Not Connect	        |
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 2			      | END	   | Connect to Ground				  | GND			        |
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 3			      | VOUT	   | May connect to Scopy/Load			  | Do Not Connect		|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 10			      | SCL	   | I2C Serial Clock				  | I2C0_SCL			|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 11			      | SDA	   | I2C Serial Data				  | I2C0_SDA			|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+
+**Build Command**
+
+.. code-block:: bash
+
+	# to delete current build
+	make reset
+	# to build the project
+	make PLATFORM=maxim TARGET=max32665
+	# to flash the code
+	make run

--- a/projects/lt7170/builds.json
+++ b/projects/lt7170/builds.json
@@ -1,0 +1,10 @@
+{
+	"maxim": {
+		"basic_example_max32666": {
+			"flags" : "BASIC_EXAMPLE=y IIO_EXAMPLE=n TARGET=max32665"
+		},
+		"iio_example_max32666": {
+			"flags" : "BASIC_EXAMPLE=n IIO_EXAMPLE=y TARGET=max32665"
+		}
+	}
+}

--- a/projects/lt7170/src.mk
+++ b/projects/lt7170/src.mk
@@ -1,0 +1,46 @@
+include $(PROJECT)/src/platform/$(PLATFORM)/platform_src.mk
+include $(PROJECT)/src/examples/examples_src.mk
+
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/main.c
+
+INCS += $(PROJECT)/src/common/common_data.h
+SRCS += $(PROJECT)/src/common/common_data.c
+	
+INCS += $(PROJECT)/src/platform/platform_includes.h
+
+INCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.h
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.c
+
+INCS += $(INCLUDE)/no_os_delay.h     		\
+		$(INCLUDE)/no_os_error.h     	\
+		$(INCLUDE)/no_os_list.h     	\
+		$(INCLUDE)/no_os_gpio.h      	\
+		$(INCLUDE)/no_os_dma.h      	\
+		$(INCLUDE)/no_os_print_log.h 	\
+		$(INCLUDE)/no_os_i2c.h       	\
+		$(INCLUDE)/no_os_irq.h		\
+		$(INCLUDE)/no_os_pwm.h       	\
+		$(INCLUDE)/no_os_rtc.h       	\
+		$(INCLUDE)/no_os_uart.h      	\
+		$(INCLUDE)/no_os_lf256fifo.h 	\
+		$(INCLUDE)/no_os_util.h 	\
+		$(INCLUDE)/no_os_units.h        \
+		$(INCLUDE)/no_os_alloc.h        \
+                $(INCLUDE)/no_os_mutex.h	\
+		$(INCLUDE)/no_os_crc8.h	
+
+SRCS += $(NO-OS)/util/no_os_lf256fifo.c 	\
+		$(DRIVERS)/api/no_os_i2c.c  	\
+		$(DRIVERS)/api/no_os_dma.c  	\
+		$(DRIVERS)/api/no_os_uart.c  	\
+		$(DRIVERS)/api/no_os_irq.c  	\
+		$(DRIVERS)/api/no_os_gpio.c  	\
+		$(DRIVERS)/api/no_os_pwm.c	\
+		$(NO-OS)/util/no_os_util.c	\
+		$(NO-OS)/util/no_os_list.c      \
+		$(NO-OS)/util/no_os_alloc.c 	\
+		$(NO-OS)/util/no_os_mutex.c	\
+		$(NO-OS)/util/no_os_crc8.c
+
+INCS += $(DRIVERS)/power/lt7170/lt7170.h
+SRCS += $(DRIVERS)/power/lt7170/lt7170.c

--- a/projects/lt7170/src/common/common_data.c
+++ b/projects/lt7170/src/common/common_data.c
@@ -1,0 +1,71 @@
+/***************************************************************************//**
+ *   @file   common_data.c
+ *   @brief  Defines common data to be used by lt7170 examples.
+ *   @author Cherrence Sarip (cherrence.sarip@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "common_data.h"
+
+struct no_os_uart_init_param lt7170_uart_ip = {
+	.device_id = UART_DEVICE_ID,
+	.irq_id = UART_IRQ_ID,
+	.asynchronous_rx = true,
+	.baud_rate = UART_BAUDRATE,
+	.size = NO_OS_UART_CS_8,
+	.parity = NO_OS_UART_PAR_NO,
+	.stop = NO_OS_UART_STOP_1_BIT,
+	.platform_ops = UART_OPS,
+	.extra = UART_EXTRA,
+};
+
+struct no_os_i2c_init_param lt7170_i2c_ip = {
+	.device_id = I2C_DEVICE_ID,
+	.max_speed_hz = 100000,
+	.platform_ops = I2C_OPS,
+	.slave_address = LT7170_PMBUS_ADDRESS,
+	.extra = I2C_EXTRA,
+};
+
+struct lt7170_init_param lt7170_ip = {
+	.i2c_init = &lt7170_i2c_ip,
+	.pg_param = NULL,
+	.run_param = NULL,
+	.alert_param = NULL,
+	.fault_param = NULL,
+	.fault_cfg = LT7170_FAULT_PIN_OUTPUT,
+	.chip_id = ID_LT7170,
+	.external_clk_en = false,
+	.crc_en = false,
+};

--- a/projects/lt7170/src/common/common_data.h
+++ b/projects/lt7170/src/common/common_data.h
@@ -1,0 +1,52 @@
+/***************************************************************************//**
+ *   @file   common_data.h
+ *   @brief  Defines common data to be used by lt7170 examples.
+ *   @author Cherrence Sarip (cherrence.sarip@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __COMMON_DATA_H__
+#define __COMMON_DATA_H__
+
+#include "platform_includes.h"
+#include "no_os_i2c.h"
+#include "lt7170.h"
+
+#define LT7170_PMBUS_ADDRESS                   0x4F
+
+extern struct no_os_uart_init_param lt7170_uart_ip;
+extern struct no_os_i2c_init_param lt7170_i2c_ip;
+extern struct lt7170_init_param lt7170_ip;
+
+#endif /* __COMMON_DATA_H__ */

--- a/projects/lt7170/src/examples/basic/basic_example.c
+++ b/projects/lt7170/src/examples/basic/basic_example.c
@@ -1,0 +1,101 @@
+/***************************************************************************//**
+ *   @file   basic_example.c
+ *   @brief  Basic example source file for lt7170 project.
+ *   @author Cherrence Sarip (cherrence.sarip@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "common_data.h"
+#include "basic_example.h"
+#include "no_os_delay.h"
+#include "no_os_print_log.h"
+#include "lt7170.h"
+
+int basic_example_main()
+{
+	struct lt7170_dev *dev;
+	struct lt7170_status status;
+	int ret, vals[4];
+
+	pr_info("Running basic example.\n");
+
+	ret = lt7170_init(&dev, &lt7170_ip);
+	if (ret)
+		goto exit;
+
+	while(1) {
+		ret = lt7170_read_value(dev, LT7170_VIN, &vals[0]);
+		if (ret)
+			goto exit;
+
+		ret = lt7170_read_value(dev, LT7170_VOUT, &vals[1]);
+		if (ret)
+			goto exit;
+
+		ret = lt7170_read_value(dev, LT7170_IOUT, &vals[2]);
+		if (ret)
+			goto exit;
+
+		ret = lt7170_read_value(dev, LT7170_TEMP, &vals[3]);
+		if (ret)
+			goto exit;
+
+		ret = lt7170_read_status(dev, LT7170_STATUS_ALL_TYPE,
+					 &status);
+		if (status.vout)
+			pr_info("Status vout asserted.\n");
+		if (status.iout)
+			pr_info("Status iout asserted.\n");
+		if (status.input)
+			pr_info("Status input asserted.\n");
+		if (status.temp)
+			pr_info("Status temp asserted.\n");
+		if (status.cml)
+			pr_info("Status cml asserted.\n");
+		if (status.mfr_specific)
+			pr_info("Status mfr_specific asserted.\n");
+
+		pr_info("vin = %d mV | vout = %d mV | iout = %d mA | temp = %d C\n",
+			vals[0], vals[1], vals[2],
+			vals[3] / 1000);
+
+		pr_info("\n");
+		no_os_mdelay(500);
+	}
+
+exit:
+	pr_err("Error code: %d.\n", ret);
+	lt7170_remove(dev);
+	return ret;
+}

--- a/projects/lt7170/src/examples/basic/basic_example.h
+++ b/projects/lt7170/src/examples/basic/basic_example.h
@@ -1,0 +1,44 @@
+/***************************************************************************//**
+ *   @file   basic_example.h
+ *   @brief  Basic example header file for lt7170 project.
+ *   @author Cherrence Sarip (cherrence.sarip@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __BASIC_EXAMPLE_H__
+#define __BASIC_EXAMPLE_H__
+
+int basic_example_main();
+
+#endif /* __BASIC_EXAMPLE_H__ */

--- a/projects/lt7170/src/examples/examples_src.mk
+++ b/projects/lt7170/src/examples/examples_src.mk
@@ -1,0 +1,28 @@
+ifeq (y,$(strip $(IIO_EXAMPLE)))
+IIOD=y
+CFLAGS += -DIIO_EXAMPLE=1
+SRCS += $(PROJECT)/src/examples/iio_example/iio_example.c
+INCS += $(PROJECT)/src/examples/iio_example/iio_example.h
+endif
+
+ifeq (y,$(strip $(BASIC_EXAMPLE)))
+CFLAGS += -DBASIC_EXAMPLE=1
+SRCS += $(PROJECT)/src/examples/basic/basic_example.c
+INCS += $(PROJECT)/src/examples/basic/basic_example.h
+endif
+
+ifeq (y, $(strip $(IIOD)))
+LIBRARIES += iio
+SRCS += $(NO-OS)/iio/iio_app/iio_app.c	\
+	$(DRIVERS)/power/lt7170/iio_lt7170.c	\
+	$(NO-OS)/iio/iio.c	\
+	$(NO-OS)/iio/iiod.c	\
+	$(NO-OS)/util/no_os_fifo.c
+
+INCS += $(NO-OS)/iio/iio_app/iio_app.h	\
+	$(DRIVERS)/power/lt7170/iio_lt7170.h	\
+	$(NO-OS)/iio/iio.h	\
+	$(NO-OS)/iio/iiod.h	\
+	$(NO-OS)/iio/iio_types.h	\
+	$(NO-OS)/include/no_os_fifo.h
+endif

--- a/projects/lt7170/src/examples/iio_example/iio_example.c
+++ b/projects/lt7170/src/examples/iio_example/iio_example.c
@@ -1,0 +1,87 @@
+/***************************************************************************//**
+ *   @file   iio_example.c
+ *   @brief  IIO example source file for lt7170 project.
+ *   @author Cherrence Sarip (cherrence.sarip@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "iio_example.h"
+#include "iio_lt7170.h"
+#include "common_data.h"
+#include "no_os_print_log.h"
+#include "iio_app.h"
+
+int iio_example_main()
+{
+	int ret;
+
+	struct lt7170_iio_desc *lt7170_iio_desc;
+	struct lt7170_iio_desc_init_param lt7170_iio_ip = {
+		.lt7170_init_param = &lt7170_ip,
+	};
+
+	struct iio_app_desc *app;
+	struct iio_app_init_param app_init_param = { 0 };
+
+	ret = lt7170_iio_init(&lt7170_iio_desc, &lt7170_iio_ip);
+	if (ret)
+		goto exit;
+
+	struct iio_app_device iio_devices[] = {
+		{
+			.name = "lt7170",
+			.dev = lt7170_iio_desc,
+			.dev_descriptor = lt7170_iio_desc->iio_dev,
+		}
+	};
+
+	app_init_param.devices = iio_devices;
+	app_init_param.nb_devices = NO_OS_ARRAY_SIZE(iio_devices);
+	app_init_param.uart_init_params = lt7170_uart_ip;
+
+	ret = iio_app_init(&app, app_init_param);
+	if (ret)
+		goto remove_iio_lt7170;
+
+	ret = iio_app_run(app);
+
+	iio_app_remove(app);
+
+remove_iio_lt7170:
+	lt7170_iio_remove(lt7170_iio_desc);
+exit:
+	if (ret)
+		pr_info("Error!\n");
+	return ret;
+}

--- a/projects/lt7170/src/examples/iio_example/iio_example.h
+++ b/projects/lt7170/src/examples/iio_example/iio_example.h
@@ -1,0 +1,44 @@
+/***************************************************************************//**
+ *   @file   iio_example.h
+ *   @brief  IIO example header file for lt7170 project.
+ *   @author Cherrence Sarip (cherrence.sarip@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __IIO_EXAMPLE_H__
+#define __IIO_EXAMPLE_H__
+
+int iio_example_main();
+
+#endif /* __IIO_EXAMPLE_H__ */

--- a/projects/lt7170/src/platform/maxim/main.c
+++ b/projects/lt7170/src/platform/maxim/main.c
@@ -1,0 +1,78 @@
+/***************************************************************************//**
+ *   @file   main.c
+ *   @brief  Main file for Maxim platform of lt7170 project.
+ *   @author Cherrence Sarip (cherrence.sarip@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "platform_includes.h"
+#include "common_data.h"
+#include "no_os_error.h"
+
+#ifdef BASIC_EXAMPLE
+#include "basic_example.h"
+#endif
+
+#ifdef IIO_EXAMPLE
+#include "iio_example.h"
+#endif
+
+int main()
+{
+	int ret = -EINVAL;
+
+#ifdef BASIC_EXAMPLE
+	struct no_os_uart_desc *uart_desc;
+
+	ret = no_os_uart_init(&uart_desc, &lt7170_uart_ip);
+	if (ret)
+		return ret;
+
+	no_os_uart_stdio(uart_desc);
+	ret = basic_example_main();
+#endif
+
+#ifdef IIO_EXAMPLE
+	ret = iio_example_main();
+#endif
+
+#if (BASIC_EXAMPLE + IIO_EXAMPLE == 0)
+#error At least one example has to be selected using y value in Makefile.
+#elif (BASIC_EXAMPLE + IIO_EXAMPLE > 1)
+#error Selected example projects cannot be enabled at the same time. \
+Please enable only one example and re-build the project.
+#endif
+
+	return ret;
+}

--- a/projects/lt7170/src/platform/maxim/parameters.c
+++ b/projects/lt7170/src/platform/maxim/parameters.c
@@ -1,0 +1,47 @@
+/***************************************************************************//**
+ *   @file   parameters.c
+ *   @brief  Definition of Maxim platform data used by lt7170 project.
+ *   @author Cherrence Sarip (cherrence.sarip@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "parameters.h"
+
+struct max_uart_init_param lt7170_uart_extra = {
+	.flow = UART_FLOW_DIS,
+};
+
+struct max_i2c_init_param lt7170_i2c_extra = {
+	.vssel = MXC_GPIO_VSSEL_VDDIOH
+};

--- a/projects/lt7170/src/platform/maxim/parameters.h
+++ b/projects/lt7170/src/platform/maxim/parameters.h
@@ -1,0 +1,65 @@
+/***************************************************************************//**
+ *   @file   parameters.h
+ *   @brief  Definition of Maxim platform data used by lt7170 project.
+ *   @author Cherrence Sarip (cherrence.sarip@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
+
+#include "maxim_irq.h"
+#include "maxim_i2c.h"
+#include "maxim_gpio.h"
+#include "maxim_uart.h"
+#include "maxim_uart_stdio.h"
+
+#ifdef IIO_SUPPORT
+#define INTC_DEVICE_ID		0
+#endif
+
+#define UART_DEVICE_ID		1
+#define UART_IRQ_ID		UART1_IRQn
+#define UART_BAUDRATE		115200
+#define	UART_OPS		&max_uart_ops
+#define UART_EXTRA		&lt7170_uart_extra
+
+#define I2C_DEVICE_ID		0
+#define I2C_OPS			&max_i2c_ops
+#define I2C_EXTRA		&lt7170_i2c_extra
+
+extern struct max_uart_init_param lt7170_uart_extra;
+extern struct max_i2c_init_param lt7170_i2c_extra;
+
+#endif /* __PARAMETERS_H__ */

--- a/projects/lt7170/src/platform/maxim/platform_src.mk
+++ b/projects/lt7170/src/platform/maxim/platform_src.mk
@@ -1,0 +1,16 @@
+INCS += $(PLATFORM_DRIVERS)/maxim_gpio.h      \
+        $(PLATFORM_DRIVERS)/maxim_gpio_irq.h  \
+        $(PLATFORM_DRIVERS)/maxim_irq.h       \
+        $(PLATFORM_DRIVERS)/../common/maxim_dma.h       \
+        $(PLATFORM_DRIVERS)/maxim_i2c.h       \
+        $(PLATFORM_DRIVERS)/maxim_uart.h      \
+        $(PLATFORM_DRIVERS)/maxim_uart_stdio.h
+
+SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c     \
+        $(PLATFORM_DRIVERS)/maxim_gpio.c      \
+        $(PLATFORM_DRIVERS)/maxim_gpio_irq.c  \
+        $(PLATFORM_DRIVERS)/maxim_irq.c       \
+        $(PLATFORM_DRIVERS)/../common/maxim_dma.c       \
+        $(PLATFORM_DRIVERS)/maxim_i2c.c       \
+        $(PLATFORM_DRIVERS)/maxim_uart.c      \
+        $(PLATFORM_DRIVERS)/maxim_uart_stdio.c

--- a/projects/lt7170/src/platform/platform_includes.h
+++ b/projects/lt7170/src/platform/platform_includes.h
@@ -1,0 +1,46 @@
+/***************************************************************************//**
+ *   @file   platform_includes.h
+ *   @brief  Includes for used platforms used by lt7170 project.
+ *   @author Cherrence Sarip (cherrence.sarip@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PLATFORM_INCLUDES_H__
+#define __PLATFORM_INCLUDES_H__
+
+#ifdef MAXIM_PLATFORM
+#include "maxim/parameters.h"
+#endif
+
+#endif /* __PLATFORM_INCLUDES_H__ */


### PR DESCRIPTION
## Pull Request Description

The LT7170/LT7170-1 are monolithic DC/DC synchronous step-down regulators that 
deliver up to 20 A of continuous output current. The LT7170-1 option has two 
switching phases that are connected to two inductors to drive a 
single-regulated output supply.

Similarly, the LT7171/LT7171-1 are monolithic PolyPhase DC/DC synchronous 
step-down regulators that also deliver up to 20A of continuous output current. 
The LT7171-1 option has two switching phases that are connected to two 
inductors to drive a single-regulated output supply.

Both series offer quick, clean, low-overshoot switching edges deliver high 
efficiency while minimizing electromagnetic interference (EMI) emissions.

An I2C-based PMBus 1.3-compliant serial interface allows control of device 
functions while providing telemetry information for system monitoring. The 
LT7170/LT7170-1 and LT7171/LT7171-1 are supported by the LTpowerPlay graphical 
user interface (GUI) tool.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
