### PR TITLE
drivers:platform:stm32:Added support for STM32H5 in the DMA driver

### DIFF
--- a/drivers/platform/stm32/stm32_dma.c
+++ b/drivers/platform/stm32/stm32_dma.c
@@ -70,11 +70,55 @@ int stm32_dma_config_xfer(struct no_os_dma_ch *channel,
 
 	/* Note: Channel number is assigned via the Instance for MCU
 	 * families other than STM32F2, STM32F4 and STM32F7 */
-#if defined (STM32F2) || defined (STM32F4) || defined (STM32F7)
-	sdma_ch->hdma->Init.Channel = sdma_ch->ch_num;
-#else
+#if defined (STM32H5)
 	sdma_ch->hdma->Instance = sdma_ch->ch_num;
+#else
+	sdma_ch->hdma->Init.Channel = sdma_ch->ch_num;
 #endif
+#if defined (STM32H5)
+	sdma_ch->hdma->Init.DestInc = sdma_ch->mem_increment ? DMA_DINC_INCREMENTED :
+				      DMA_DINC_FIXED;
+	sdma_ch->hdma->Init.SrcInc = sdma_ch->per_increment ? DMA_SINC_INCREMENTED :
+				     DMA_SINC_FIXED;
+
+	switch (sdma_ch->mem_data_alignment) {
+	case DATA_ALIGN_BYTE:
+		sdma_ch->hdma->Init.DestDataWidth = DMA_DEST_DATAWIDTH_BYTE;
+		break;
+	case DATA_ALIGN_HALF_WORD:
+		sdma_ch->hdma->Init.DestDataWidth = DMA_DEST_DATAWIDTH_HALFWORD;
+		break;
+	case DATA_ALIGN_WORD:
+		sdma_ch->hdma->Init.DestDataWidth = DMA_DEST_DATAWIDTH_WORD;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	switch (sdma_ch->per_data_alignment) {
+	case DATA_ALIGN_BYTE:
+		sdma_ch->hdma->Init.SrcDataWidth = DMA_SRC_DATAWIDTH_BYTE;
+		break;
+	case DATA_ALIGN_HALF_WORD:
+		sdma_ch->hdma->Init.SrcDataWidth = DMA_SRC_DATAWIDTH_HALFWORD;
+		break;
+	case DATA_ALIGN_WORD:
+		sdma_ch->hdma->Init.SrcDataWidth = DMA_SRC_DATAWIDTH_WORD;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	switch (sdma_ch->dma_mode) {
+	case DMA_NORMAL_MODE:
+		sdma_ch->hdma->Init.Mode = DMA_NORMAL;
+		break;
+	case DMA_CIRCULAR_MODE:
+		return -ENOTSUP;
+	default:
+		return -EINVAL;
+	}
+#else
 	sdma_ch->hdma->Init.MemInc = sdma_ch->mem_increment ? DMA_MINC_ENABLE :
 				     DMA_MINC_DISABLE;
 	sdma_ch->hdma->Init.PeriphInc = sdma_ch->per_increment ? DMA_PINC_ENABLE :
@@ -118,6 +162,7 @@ int stm32_dma_config_xfer(struct no_os_dma_ch *channel,
 	default:
 		return -EINVAL;
 	}
+#endif
 
 	switch (xfer->xfer_type) {
 	case MEM_TO_MEM:


### PR DESCRIPTION
## Pull Request Description

The DMA drivers specific to STM32 did not have support for STM32H5 which lead to build errors in certain projects.

In this Pull Request, we can find changes made according to the DMA handler of STM32H5 for proper initialization in the driver.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
