### PR TITLE
drivers: power: ltp8800: Add LTP8800 driver

### DIFF
--- a/doc/sphinx/source/drivers/ltp8800.rst
+++ b/doc/sphinx/source/drivers/ltp8800.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../drivers/power/ltp8800/README.rst

--- a/doc/sphinx/source/drivers_doc.rst
+++ b/doc/sphinx/source/drivers_doc.rst
@@ -93,4 +93,5 @@ POWER MANAGEMENT
    drivers/ltc4296
    drivers/lt7182s
    drivers/lt8722
+   drivers/ltp8800
    drivers/max42500

--- a/doc/sphinx/source/projects/ltp8800.rst
+++ b/doc/sphinx/source/projects/ltp8800.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../projects/ltp8800/README.rst

--- a/doc/sphinx/source/projects_doc.rst
+++ b/doc/sphinx/source/projects_doc.rst
@@ -72,6 +72,7 @@ POWER MANAGEMENT
    projects/ltc4296
    projects/lt7182s
    projects/lt8722
+   projects/ltp8800
    projects/max42500
 
 DAC

--- a/drivers/power/ltp8800/README.rst
+++ b/drivers/power/ltp8800/README.rst
@@ -1,0 +1,249 @@
+LTP8800 no-OS driver
+====================
+
+Supported Devices
+-----------------
+
+`LTP8800-1A <https://www.analog.com/LTP8800-1A>`_
+`LTP8800-4A <https://www.analog.com/LTP8800-4A>`_
+`LTP8800-2 <https://www.analog.com/LTP8800-2>`_
+
+Overview
+--------
+
+The LTP8800 is a family of step-down μModule regulators that provides
+microprocessor core voltage from 54V power distribution architecture. LTP8800-4A
+features remote configurability and telemetry monitoring of power management
+parameters over PMBus—an open standard I2C-based digital interface protocol.
+
+Applications
+------------
+
+LTP8800
+-------
+
+* High Current Distributed Power Systems
+* Servers, Network, and Storage Equipment
+* Intelligent Energy Efficient Power Regulation
+
+LTP8800 Device Configuration
+----------------------------
+
+Driver Initialization
+---------------------
+
+In order to be able to use the device, you will have to provide the support
+for the communication protocol (I2C) alongside other GPIO pins if needed in the
+specific application (depends on the way the device is used).
+
+The first API to be called is **ltp8800_init**. Make sure that it return 0,
+which means that the driver was initialized correctly.
+
+The initialization API uses the device descriptor and an initialization
+parameter. The initialization parameter contains the optional GPIO pin
+parameters for interfacing with SMBALERT and CTRL pins, and configurations for
+external clock, polyphase, write protect and packet error checking.
+
+Compensation
+------------
+
+The device offers a programmable loop compensation to optimize the transient
+response without hardware change. The type 3 filter can be configured using the
+**ltp8800_loop_compensation** API.
+
+Polyphase Configuration
+-----------------------
+
+The device can be configured to operate in polyphase mode. When in polyphase,
+each device can be configured to operate in a specific phase. The phase can be
+set to a multiple of 22.5 degrees using the **ltp8800_interleave_order** API.
+
+Status Bytes
+------------
+
+Assertion in the status bytes/words indicates fault/warning in device input/
+output, temperature, and communication, memory and logic. These statuses can be
+accessed via the **ltp8800_read_status** API.
+
+Telemetry
+---------
+
+Measurements for each output channel can be read using the
+**ltp8800_read_value** API. Some telemetry values includes input/output voltage,
+input/output current, die temperature, and output power.
+
+Overvalue and Undervalue Limits Configuration
+---------------------------------------------
+
+Overvalue and undervalue limits sets the threshold at which the device voltage,
+current, and temperature must meet. When these measurements cross the limits, a
+status bit may be asserted. These limits can be configured using the
+**ltp8800_set_fault_limit** API.
+
+VIN Configuration
+-----------------
+
+VIN_ON and VIN_OFF command values sets the input voltage window at which power
+conversion will proceed. Both of which can be configured through the
+**ltp8800_set_vin** API.
+
+VOUT Configuration
+------------------
+
+The LTP8800 output voltage is programmable from 0.5V to 1.0V. These can be
+configured using the **ltp8800_vout_value** API.
+
+Clock Configuration
+-------------------
+
+When using the device in parallel with others of the same device, the PWM clock
+of all devices can be synchronized. Using an external clock or enabling the
+clock input can be configured using the **ltp8800_sync_config** API.
+
+Device Configuration in NVM
+---------------------------
+
+User settings can be saved in the non-volatile EEPROM of the device. This can be
+done using the **ltp8800_store_user_settings** API. Meanwhile, the settings from
+the EEPROM can be restored using the **ltp8800_restore_user_settings** API.
+
+LTP8800 Driver Initialization Example
+-------------------------------------
+
+.. code-block:: bash
+
+	struct ltp8800_dev *ltp8800_dev;
+	struct no_os_i2c_init_param ltp8800_i2c_ip = {
+		.device_id = I2C_DEVICE_ID,
+		.max_speed_hz = 100000,
+		.platform_ops = I2C_OPS,
+		.slave_address = LTP8800_PMBUS_ADDRESS,
+		.extra = I2C_EXTRA,
+        };
+
+	struct no_os_gpio_init_param ltp8800_ctrl_ip = {
+		.port = GPIO_CTRL_PORT,
+		.number = GPIO_CTRL_NUMBER,
+		.pull = NO_OS_PULL_UP,
+		.platform_ops = GPIO_OPS,
+		.extra = GPIO_EXTRA,
+	};
+
+	struct ltp8800_init_param ltp8800_ip = {
+		.i2c_init = &ltp8800_i2c_ip,
+		.smbalert_param = NULL,
+		.ctrl_param = &ltp8800_ctrl_ip,
+		.ext_clk_param = NULL,
+		.write_protect_en = false,
+		.external_clk_en = false,
+		.sync_en = false,
+		.crc_en = false,
+	};
+
+	ret = ltp8800_init(&ltp8800_dev, &ltp8800_ip);
+	if (ret)
+		goto error;
+
+LTP8800 no-OS IIO support
+-------------------------
+
+The LTP8800 IIO driver comes on top of the LTP8800 driver and offers support
+for interfacing IIO clients through libiio.
+
+LTP8800 IIO Device Configuration
+--------------------------------
+
+Channels
+--------
+
+The device has a total of 3 input channels and 2 output channels. The input
+consists of the input voltage, input current, and the forward diode
+temperature. The output consists of the output voltage and current.
+
+* ``vout - output voltage``
+* ``iout - output current``
+* ``vin - input voltage``
+* ``iin - input current``
+* ``temperature - forward diode temperature``
+
+Channel Attributes
+------------------
+
+EAch channels have 2 channel attributes:
+
+* ``raw - the raw value of the channel``
+* ``scale - the scale value of the channel calculated accordingly to each specific channel using a priv``
+
+Global Attributes
+-----------------
+
+The device has a total of 18 global attributes:
+
+* ``sync - Enable/Disable sync device configuration for polyphase application``
+* ``sync_available - Available state of the sync enable``
+* ``vout_command - VOUT_COMMAND value of the channel output``
+* ``vout_scale_loop - VOUT_COMMAND gain for the internal reference voltage``
+* ``vout_scale_monitor - VOUT_COMMAND gain for READ_VOUT``
+* ``vin_ov_fault_limit - Input overvoltage fault limit``
+* ``vin_uv_fault_limit - Input undervoltage fault limit``
+* ``iin_oc_fault_limit - Output overcurrent fault limit``
+* ``pout_op_fault_limit - Output overvoltage warning limit``
+* ``interleave_order - Polyphase order``
+* ``loop_pole - Compensation filter pole value``
+* ``loop_zero - Compensation filter zero value``
+* ``loop_hf_gain - Compensation filter high frequency gain``
+* ``loop_lf_gain - Compensation filter low frequency gain``
+* ``store_user_settings - Store user settings in NVM``
+* ``store_user_settings_available - Available store_user_settings option``
+* ``restore_user_settings - Restore user settings from NVM``
+* ``restore_user_settings_available - Available restore_user_settings option``
+
+Debug Attributes
+----------------
+
+The device has a total of 7 debug attributes:
+
+* ``status_vout - VOUT status byte value``
+* ``status_iout - IOUT status byte value``
+* ``status_input - INPUT status byte value``
+* ``status_mfr_specific - MFR_SPECIFIC status byte value``
+* ``status_word - Status word value``
+* ``status_temperature - TEMPERATURE status byte value of the device``
+* ``status_cml - CML status byte value of the device``
+
+LTP8800 IIO Driver Initialization Example
+-----------------------------------------
+
+.. code-block:: bash
+
+	int ret;
+
+	struct ltp8800_iio_desc *ltp8800_iio_desc;
+	struct ltp8800_iio_desc_init_param ltp8800_iio_ip = {
+		.ltp8800_init_param = &ltp8800_ip,
+	};
+
+	struct iio_app_desc *app;
+	struct iio_app_init_param app_init_param = { 0 };
+
+	ret = ltp8800_iio_init(&ltp8800_iio_desc, &ltp8800_iio_ip);
+	if (ret)
+		return ret;
+
+	struct iio_app_device iio_devices[] = {
+		{
+			.name = "ltp8800",
+			.dev = ltp8800_iio_desc,
+			.dev_descriptor = ltp8800_iio_desc->iio_dev,
+		}
+	};
+
+	app_init_param.devices = iio_devices;
+	app_init_param.nb_devices = NO_OS_ARRAY_SIZE(iio_devices);
+	app_init_param.uart_init_params = ltp8800_uart_ip;
+
+	ret = iio_app_init(&app, app_init_param);
+	if (ret)
+		return ret;
+
+	return iio_app_run(app);

--- a/drivers/power/ltp8800/iio_ltp8800.c
+++ b/drivers/power/ltp8800/iio_ltp8800.c
@@ -1,0 +1,1027 @@
+/***************************************************************************//**
+ *   @file   iio_ltp8800.c
+ *   @brief  Source file for the LTP8800 IIO Driver
+ *   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include "no_os_alloc.h"
+#include "no_os_error.h"
+#include "no_os_units.h"
+#include "no_os_util.h"
+
+#include "ltp8800.h"
+#include "iio_ltp8800.h"
+
+static const char *const ltp8800_enable_avail[2] = {
+	"disable", "enable"
+};
+
+static const char *const ltp8800_store_avail[2] = {
+	"store", "restore"
+};
+
+enum ltp8800_iio_chan_type {
+	LTP8800_IIO_VOUT_CHAN,
+	LTP8800_IIO_VIN_CHAN,
+	LTP8800_IIO_IOUT_CHAN,
+	LTP8800_IIO_IIN_CHAN,
+	LTP8800_IIO_TEMP_CHAN,
+};
+
+enum ltp8800_iio_user_settings {
+	LTP8800_IIO_STORE_USER_ALL,
+	LTP8800_IIO_RESTORE_USER_ALL,
+};
+
+static struct iio_device ltp8800_iio_dev;
+
+/**
+ * @brief Read register value.
+ * @param dev     - The iio device structure.
+ * @param reg	  - Register to read.
+ * @param readval - Read value.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int32_t ltp8800_iio_reg_read(void *dev, uint32_t reg, uint32_t *readval)
+{
+	struct ltp8800_iio_desc *iio_ltp8800 = dev;
+	struct ltp8800_dev *ltp8800 = iio_ltp8800->ltp8800_dev;
+	int ret;
+	uint8_t block[4] = {0};
+
+	switch (reg) {
+	case LTP8800_PAGE:
+		reg = LTP8800_OPERATION;
+	/* intentional fall through */
+	case LTP8800_OPERATION:
+	case LTP8800_WRITE_PROTECT:
+	case LTP8800_VOUT_MODE:
+	case LTP8800_STATUS_BYTE:
+	case LTP8800_STATUS_VOUT:
+	case LTP8800_STATUS_IOUT:
+	case LTP8800_STATUS_INPUT:
+	case LTP8800_STATUS_TEMPERATURE:
+	case LTP8800_STATUS_CML:
+	case LTP8800_STATUS_OTHER:
+	case LTP8800_STATUS_MFR_SPECIFIC:
+	case LTP8800_REVISION:
+	case LTP8800_NM_DIGFILT_POLE:
+	case LTP8800_NM_DIGFILT_ZERO:
+	case LTP8800_NM_DIGFILT_HF_GAIN:
+	case LTP8800_NM_DIGFILT_LF_GAIN:
+	case LTP8800_SYNC:
+		return ltp8800_read_byte(ltp8800, (uint16_t)reg,
+					 (uint8_t *)readval);
+	case LTP8800_VOUT_COMMAND:
+	case LTP8800_VOUT_SCALE_LOOP:
+	case LTP8800_VOUT_SCALE_MONITOR:
+	case LTP8800_FREQUENCY_SWITCH:
+	case LTP8800_VIN_ON:
+	case LTP8800_VIN_OFF:
+	case LTP8800_INTERLEAVE:
+	case LTP8800_VIN_OV_FAULT_LIMIT:
+	case LTP8800_VIN_UV_FAULT_LIMIT:
+	case LTP8800_IIN_OC_FAULT_LIMIT:
+	case LTP8800_POUT_OP_FAULT_LIMIT:
+	case LTP8800_STATUS_WORD:
+	case LTP8800_READ_VIN:
+	case LTP8800_READ_IIN:
+	case LTP8800_READ_VOUT:
+	case LTP8800_READ_IOUT:
+	case LTP8800_READ_TEMPERATURE_2:
+	case LTP8800_READ_TEMPERATURE_3:
+	case LTP8800_READ_DUTY_CYCLE:
+	case LTP8800_READ_FREQUENCY:
+	case LTP8800_READ_POUT:
+		return ltp8800_read_word(ltp8800, (uint16_t)reg,
+					 (uint16_t *)readval);
+	case LTP8800_MFR_ID:
+	case LTP8800_MFR_MODEL:
+	case LTP8800_MFR_REVISION:
+	case LTP8800_MFR_SERIAL:
+	case LTP8800_IC_DEVICE_ID:
+	case LTP8800_IC_DEVICE_REV:
+		ret = ltp8800_read_block_data(ltp8800, (uint16_t)reg, block, 4);
+		if (ret)
+			return ret;
+
+		*readval = no_os_get_unaligned_be32(block);
+
+		return 0;
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Write register value.
+ * @param dev     - The iio device structure.
+ * @param reg	  - Register to write.
+ * @param writeval - Value to write.
+ * @return ret    - Result of the writing procedure.
+*/
+static int32_t ltp8800_iio_reg_write(void *dev, uint32_t reg, uint32_t writeval)
+{
+	struct ltp8800_iio_desc *iio_ltp8800 = dev;
+	struct ltp8800_dev *ltp8800 = iio_ltp8800->ltp8800_dev;
+
+	switch (reg) {
+	case LTP8800_STORE_USER_ALL:
+	case LTP8800_RESTORE_USER_ALL:
+		return ltp8800_send_byte(ltp8800, (uint16_t)reg);
+	case LTP8800_WRITE_PROTECT:
+	case LTP8800_STATUS_BYTE:
+	case LTP8800_STATUS_VOUT:
+	case LTP8800_STATUS_IOUT:
+	case LTP8800_STATUS_INPUT:
+	case LTP8800_STATUS_TEMPERATURE:
+	case LTP8800_STATUS_CML:
+	case LTP8800_STATUS_OTHER:
+	case LTP8800_STATUS_MFR_SPECIFIC:
+	case LTP8800_REVISION:
+	case LTP8800_GO_CMD:
+	case LTP8800_NM_DIGFILT_POLE:
+	case LTP8800_NM_DIGFILT_ZERO:
+	case LTP8800_NM_DIGFILT_HF_GAIN:
+	case LTP8800_NM_DIGFILT_LF_GAIN:
+	case LTP8800_SYNC:
+	case LTP8800_EEPROM_PASSWORD:
+		return ltp8800_write_byte(ltp8800, (uint16_t)reg,
+					  (uint8_t)writeval);
+	case LTP8800_VOUT_COMMAND:
+	case LTP8800_VOUT_SCALE_LOOP:
+	case LTP8800_VOUT_SCALE_MONITOR:
+	case LTP8800_FREQUENCY_SWITCH:
+	case LTP8800_VIN_ON:
+	case LTP8800_VIN_OFF:
+	case LTP8800_INTERLEAVE:
+	case LTP8800_VIN_OV_FAULT_LIMIT:
+	case LTP8800_VIN_UV_FAULT_LIMIT:
+	case LTP8800_IIN_OC_FAULT_LIMIT:
+	case LTP8800_POUT_OP_FAULT_LIMIT:
+	case LTP8800_STATUS_WORD:
+	case LTP8800_READ_VIN:
+	case LTP8800_READ_IIN:
+	case LTP8800_READ_VOUT:
+	case LTP8800_READ_IOUT:
+	case LTP8800_READ_TEMPERATURE_2:
+	case LTP8800_READ_TEMPERATURE_3:
+	case LTP8800_READ_DUTY_CYCLE:
+	case LTP8800_READ_FREQUENCY:
+	case LTP8800_READ_POUT:
+		return ltp8800_write_word(ltp8800, (uint8_t)reg,
+					  (uint16_t)writeval);
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Handles the read request for raw attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int ltp8800_iio_read_raw(void *dev, char *buf, uint32_t len,
+				const struct iio_ch_info *channel,
+				intptr_t priv)
+{
+	struct ltp8800_iio_desc *iio_ltp8800 = dev;
+	struct ltp8800_dev *ltp8800 = iio_ltp8800->ltp8800_dev;
+	int ret;
+	int32_t value;
+	uint16_t temp;
+
+	switch (channel->address) {
+	case LTP8800_IIO_VIN_CHAN:
+		ret = ltp8800_read_word(ltp8800, LTP8800_READ_VIN, &temp);
+		break;
+	case LTP8800_IIO_VOUT_CHAN:
+		ret = ltp8800_read_word(ltp8800, LTP8800_READ_VOUT, &temp);
+		break;
+	case LTP8800_IIO_IIN_CHAN:
+		ret = ltp8800_read_word(ltp8800, LTP8800_READ_IIN, &temp);
+		break;
+	case LTP8800_IIO_IOUT_CHAN:
+		ret = ltp8800_read_word(ltp8800, LTP8800_READ_IOUT, &temp);
+		break;
+	case LTP8800_IIO_TEMP_CHAN:
+		ret = ltp8800_read_word(ltp8800, LTP8800_READ_TEMPERATURE_2,
+					&temp);
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	if (ret)
+		return ret;
+
+	value = (int32_t)temp;
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, &value);
+}
+
+/**
+ * @brief Handles the read request for scale attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int ltp8800_iio_read_scale(void *dev, char *buf, uint32_t len,
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
+{
+	struct ltp8800_iio_desc *iio_ltp8800 = dev;
+	struct ltp8800_dev *ltp8800 = iio_ltp8800->ltp8800_dev;
+	int ret, temp;
+	int32_t vals[2];
+
+	switch (channel->address) {
+	case LTP8800_IIO_VIN_CHAN:
+		ret = ltp8800_read_value(ltp8800, LTP8800_VIN, &temp);
+		break;
+	case LTP8800_IIO_VOUT_CHAN:
+		ret = ltp8800_read_value(ltp8800, LTP8800_VOUT, &temp);
+		break;
+	case LTP8800_IIO_IIN_CHAN:
+		ret = ltp8800_read_value(ltp8800, LTP8800_IIN, &temp);
+		break;
+	case LTP8800_IIO_IOUT_CHAN:
+		ret = ltp8800_read_value(ltp8800, LTP8800_IOUT, &temp);
+		break;
+	case LTP8800_IIO_TEMP_CHAN:
+		ret = ltp8800_read_value(ltp8800, LTP8800_FORWARD_DIODE_TEMP,
+					 &temp);
+		break;
+	default:
+		return -EINVAL;
+	}
+	if (ret)
+		return ret;
+
+	vals[0] = (int32_t)temp;
+	vals[1] = (int32_t)MILLI;
+
+	return iio_format_value(buf, len, IIO_VAL_FRACTIONAL, 2, vals);
+}
+
+/**
+ * @brief Handles the read request for sync_enable attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int ltp8800_iio_read_sync_enable(void *dev, char *buf, uint32_t len,
+					const struct iio_ch_info *channel,
+					intptr_t priv)
+{
+	struct ltp8800_iio_desc *iio_ltp8800 = dev;
+	struct ltp8800_dev *ltp8800 = iio_ltp8800->ltp8800_dev;
+	int ret;
+	uint32_t val;
+	uint8_t sync_en;
+
+	ret = ltp8800_read_byte(ltp8800, LTP8800_SYNC, &sync_en);
+	if (ret)
+		return ret;
+
+	val = !no_os_field_get(LTP8800_SYNC_ENABLE_BIT, sync_en);
+
+	return sprintf(buf, "%s ", ltp8800_enable_avail[val]);
+}
+
+/**
+ * @brief Handles the read request for sync_enable_available attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int ltp8800_iio_read_sync_enable_available(void *dev, char *buf,
+		uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	int length = 0;
+	uint32_t i;
+
+	for (i = 0; i < NO_OS_ARRAY_SIZE(ltp8800_enable_avail); i++)
+		length += sprintf(buf + length, "%s ", ltp8800_enable_avail[i]);
+
+	return length;
+}
+
+/**
+ * @brief Handles the write request for sync_enable attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int ltp8800_iio_write_sync_enable(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	struct ltp8800_iio_desc *iio_ltp8800 = dev;
+	struct ltp8800_dev *ltp8800 = iio_ltp8800->ltp8800_dev;
+	uint32_t i;
+
+	for (i = 0; i < NO_OS_ARRAY_SIZE(ltp8800_enable_avail); i++)
+		if (!strcmp(buf, ltp8800_enable_avail[i]))
+			break;
+
+	if (i == NO_OS_ARRAY_SIZE(ltp8800_enable_avail))
+		return -EINVAL;
+
+	return ltp8800_sync_config(ltp8800, (bool)!i);
+}
+
+/**
+ * @brief Handles the read request for vout-related attributes.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int ltp8800_iio_read_vout(void *dev, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel,
+				 intptr_t priv)
+{
+	struct ltp8800_iio_desc *iio_ltp8800 = dev;
+	struct ltp8800_dev *ltp8800 = iio_ltp8800->ltp8800_dev;
+	int ret, temp;
+	int32_t vals[2];
+
+	if (!dev)
+		return -EINVAL;
+
+	if (!iio_ltp8800->ltp8800_dev)
+		return -EINVAL;
+
+	ret = ltp8800_read_word_data(ltp8800, (uint16_t)priv, &temp);
+	if (ret)
+		return ret;
+
+	vals[0] = (temp / (int32_t)MILLI);
+	vals[1] = ((temp * (int32_t)MILLI) % (int32_t)MICRO);
+
+	return iio_format_value(buf, len, IIO_VAL_INT_PLUS_MICRO, 2, vals);
+}
+
+/**
+ * @brief Handles the write request for vou-related attributes.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int ltp8800_iio_write_vout(void *dev, char *buf, uint32_t len,
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
+{
+	struct ltp8800_iio_desc *iio_ltp8800 = dev;
+	struct ltp8800_dev *ltp8800 = iio_ltp8800->ltp8800_dev;
+	int32_t val1, val2;
+
+	iio_parse_value(buf, IIO_VAL_INT_PLUS_MICRO, &val1, &val2);
+
+	val1 = val1 * (int32_t)MILLI + val2 / (int32_t)MILLI;
+
+	return ltp8800_write_word_data(ltp8800, priv, val1);
+}
+
+/**
+ * @brief Handles the read request for limits global attributes.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int ltp8800_iio_read_limits(void *dev, char *buf, uint32_t len,
+				   const struct iio_ch_info *channel,
+				   intptr_t priv)
+{
+	struct ltp8800_iio_desc *iio_ltp8800 = dev;
+	struct ltp8800_dev *ltp8800 = iio_ltp8800->ltp8800_dev;
+	int ret, temp;
+	int32_t vals[2];
+
+	if (!dev)
+		return -EINVAL;
+
+	if (!iio_ltp8800->ltp8800_dev)
+		return -EINVAL;
+
+	ret = ltp8800_read_word_data(ltp8800, priv, &temp);
+	if (ret)
+		return ret;
+
+	if (priv == LTP8800_POUT_OP_FAULT_LIMIT) {
+		vals[0] = temp / (int32_t)MICRO;
+		vals[1] = (temp % (int32_t)MICRO);
+	} else {
+		vals[0] = (temp / (int32_t)MILLI);
+		vals[1] = ((temp * (int32_t)MILLI) % (int32_t)MICRO);
+	}
+
+	return iio_format_value(buf, len, IIO_VAL_INT_PLUS_MICRO, 2, vals);
+}
+
+/**
+ * @brief Handles the write request for limits global attributes.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int ltp8800_iio_write_limits(void *dev, char *buf, uint32_t len,
+				    const struct iio_ch_info *channel,
+				    intptr_t priv)
+{
+	struct ltp8800_iio_desc *iio_ltp8800 = dev;
+	struct ltp8800_dev *ltp8800 = iio_ltp8800->ltp8800_dev;
+	int32_t val1, val2;
+	bool negative;
+
+	iio_parse_value(buf, IIO_VAL_INT_PLUS_MICRO, &val1, &val2);
+
+	negative = (val1 < 0 || val2 < 0) ? true : false;
+	if (val1 < 0)
+		val1 = -val1;
+	if (val2 < 0)
+		val2 = -val2;
+
+	if (priv == LTP8800_POUT_OP_FAULT_LIMIT) {
+		val1 = val1 * (int32_t)MICRO + val2;
+	} else {
+		val1 = val1 * (int32_t)MILLI + val2 / (int32_t)MILLI;
+	}
+
+	if (negative)
+		val1 = -val1;
+
+	return ltp8800_set_fault_limit(ltp8800, (enum ltp8800_limit_type)priv,
+				       val1);
+}
+
+/**
+ * @brief Handles the read request for interleave attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int ltp8800_iio_read_interleave(void *dev, char *buf, uint32_t len,
+				       const struct iio_ch_info *channel,
+				       intptr_t priv)
+{
+	struct ltp8800_iio_desc *iio_ltp8800 = dev;
+	struct ltp8800_dev *ltp8800 = iio_ltp8800->ltp8800_dev;
+	int ret;
+	int32_t val;
+	uint16_t temp;
+
+	if (!dev)
+		return -EINVAL;
+
+	if (!iio_ltp8800->ltp8800_dev)
+		return -EINVAL;
+
+	ret = ltp8800_read_word(ltp8800, LTP8800_INTERLEAVE, &temp);
+	if (ret)
+		return ret;
+
+	val = no_os_field_get(LTP8800_INTERLEAVE_ORDER_MSK, temp);
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+}
+
+/**
+ * @brief Handles the write request for interleave attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int ltp8800_iio_write_interleave(void *dev, char *buf, uint32_t len,
+					const struct iio_ch_info *channel,
+					intptr_t priv)
+{
+	struct ltp8800_iio_desc *iio_ltp8800 = dev;
+	struct ltp8800_dev *ltp8800 = iio_ltp8800->ltp8800_dev;
+	int32_t val;
+
+	if (!dev)
+		return -EINVAL;
+
+	if (!iio_ltp8800->ltp8800_dev)
+		return -EINVAL;
+
+	iio_parse_value(buf, IIO_VAL_INT, &val, NULL);
+
+	return ltp8800_interleave_order(ltp8800, (uint8_t)val);
+}
+
+/**
+ * @brief Handles the read request for compensation-related attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int ltp8800_iio_read_loop(void *dev, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel,
+				 intptr_t priv)
+{
+	struct ltp8800_iio_desc *iio_ltp8800 = dev;
+	struct ltp8800_dev *ltp8800 = iio_ltp8800->ltp8800_dev;
+	int ret;
+	int32_t val;
+	uint8_t temp;
+
+	if (!dev)
+		return -EINVAL;
+
+	if (!iio_ltp8800->ltp8800_dev)
+		return -EINVAL;
+
+	ret = ltp8800_read_byte(ltp8800, (uint16_t)priv, &temp);
+	if (ret)
+		return ret;
+
+	val = (int32_t)temp;
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+}
+
+/**
+ * @brief Handles the write request for compensation-related attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int ltp8800_iio_write_loop(void *dev, char *buf, uint32_t len,
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
+{
+	struct ltp8800_iio_desc *iio_ltp8800 = dev;
+	struct ltp8800_dev *ltp8800 = iio_ltp8800->ltp8800_dev;
+	int32_t val;
+
+	if (!dev)
+		return -EINVAL;
+
+	if (!iio_ltp8800->ltp8800_dev)
+		return -EINVAL;
+
+	iio_parse_value(buf, IIO_VAL_INT, &val, NULL);
+
+	return ltp8800_write_byte(ltp8800, (uint16_t)priv, (uint8_t)val);
+}
+
+/**
+ * @brief Handles the read request for status debug attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int ltp8800_iio_read_status(void *dev, char *buf, uint32_t len,
+				   const struct iio_ch_info *channel,
+				   intptr_t priv)
+{
+	struct ltp8800_iio_desc *iio_ltp8800 = dev;
+	struct ltp8800_dev *ltp8800 = iio_ltp8800->ltp8800_dev;
+	int ret;
+	int32_t val;
+	uint16_t status_word;
+	uint8_t status_byte;
+
+	if (priv == LTP8800_STATUS_WORD) {
+		ret = ltp8800_read_word(ltp8800, LTP8800_STATUS_WORD,
+					&status_word);
+		if (ret)
+			return ret;
+
+		val = (int32_t)status_word;
+	} else {
+		ret = ltp8800_read_byte(ltp8800, (uint16_t)priv,
+					&status_byte);
+		if (ret)
+			return ret;
+
+		val = (int32_t)status_byte;
+	}
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+}
+
+/**
+ * @brief Handles the read request for user_settings_available attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int ltp8800_iio_user_settings_available(void *dev, char *buf,
+		uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	switch (priv) {
+	case LTP8800_IIO_STORE_USER_ALL:
+		return sprintf(buf, "%s ", ltp8800_store_avail[0]);
+	case LTP8800_IIO_RESTORE_USER_ALL:
+		return sprintf(buf, "%s ", ltp8800_store_avail[1]);
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Handles the EEPROM user settings attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int ltp8800_iio_user_settings(void *dev, char *buf, uint32_t len,
+				     const struct iio_ch_info *channel,
+				     intptr_t priv)
+{
+	struct ltp8800_iio_desc *iio_ltp8800 = dev;
+	struct ltp8800_dev *ltp8800 = iio_ltp8800->ltp8800_dev;
+
+	if (!dev)
+		return -EINVAL;
+
+	if (!iio_ltp8800->ltp8800_dev)
+		return -EINVAL;
+
+	switch (priv) {
+	case LTP8800_IIO_STORE_USER_ALL:
+		if (!strcmp(buf, ltp8800_store_avail[0]))
+			return ltp8800_store_user_settings(ltp8800);
+		break;
+	case LTP8800_IIO_RESTORE_USER_ALL:
+		if (!strcmp(buf, ltp8800_store_avail[1]))
+			return ltp8800_restore_user_settings(ltp8800);
+		break;
+	default:
+		break;
+	}
+
+	return -EINVAL;
+}
+
+/**
+ * @brief Initializes the LTP8800 IIO descriptor.
+ * @param iio_desc - The iio device descriptor.
+ * @param init_param - The structure that contains the device initial parameters.
+ * @return 0 in case of success, an error code otherwise.
+ */
+int ltp8800_iio_init(struct ltp8800_iio_desc **iio_desc,
+		     struct ltp8800_iio_desc_init_param *init_param)
+{
+	struct ltp8800_iio_desc *descriptor;
+	int ret;
+
+	if (!init_param || !init_param->ltp8800_init_param)
+		return -EINVAL;
+
+	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	ret = ltp8800_init(&descriptor->ltp8800_dev,
+			   init_param->ltp8800_init_param);
+	if (ret)
+		goto dev_err;
+
+	descriptor->iio_dev = &ltp8800_iio_dev;
+
+	*iio_desc = descriptor;
+
+	return 0;
+
+dev_err:
+	no_os_free(descriptor);
+
+	return ret;
+}
+
+/**
+ * @brief Free resources allocated by the init function.
+ * @param iio_desc - The iio device descriptor.
+ * @return 0 in case of success, an error code otherwise.
+ */
+int ltp8800_iio_remove(struct ltp8800_iio_desc *iio_desc)
+{
+	if (!iio_desc)
+		return -ENODEV;
+
+	no_os_free(iio_desc->iio_dev->channels);
+	ltp8800_remove(iio_desc->ltp8800_dev);
+	no_os_free(iio_desc);
+
+	return 0;
+}
+
+static struct iio_attribute ltp8800_chan_attrs[] = {
+	{
+		.name = "raw",
+		.show = ltp8800_iio_read_raw
+	},
+	{
+		.name = "scale",
+		.show = ltp8800_iio_read_scale
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_attribute ltp8800_global_attrs[] = {
+	{
+		.name = "sync",
+		.show = ltp8800_iio_read_sync_enable,
+		.store = ltp8800_iio_write_sync_enable,
+	},
+	{
+		.name = "sync_available",
+		.show = ltp8800_iio_read_sync_enable_available,
+		.shared = IIO_SHARED_BY_ALL
+	},
+	{
+		.name = "vout_command",
+		.show = ltp8800_iio_read_vout,
+		.store = ltp8800_iio_write_vout,
+		.priv = LTP8800_VOUT_COMMAND
+	},
+	{
+		.name = "vout_scale_loop",
+		.show = ltp8800_iio_read_vout,
+		.store = ltp8800_iio_write_vout,
+		.priv = LTP8800_VOUT_SCALE_LOOP
+	},
+	{
+		.name = "vout_scale_monitor",
+		.show = ltp8800_iio_read_vout,
+		.store = ltp8800_iio_write_vout,
+		.priv = LTP8800_VOUT_SCALE_MONITOR
+	},
+	{
+		.name = "vin_ov_fault_limit",
+		.show = ltp8800_iio_read_limits,
+		.store = ltp8800_iio_write_limits,
+		.priv = LTP8800_VIN_OV_FAULT_LIMIT
+	},
+	{
+		.name = "vin_uv_fault_limit",
+		.show = ltp8800_iio_read_limits,
+		.store = ltp8800_iio_write_limits,
+		.priv = LTP8800_VIN_UV_FAULT_LIMIT
+	},
+	{
+		.name = "iin_oc_fault_limit",
+		.show = ltp8800_iio_read_limits,
+		.store = ltp8800_iio_write_limits,
+		.priv = LTP8800_IIN_OC_FAULT_LIMIT
+	},
+	{
+		.name = "pout_op_fault_limit",
+		.show = ltp8800_iio_read_limits,
+		.store = ltp8800_iio_write_limits,
+		.priv = LTP8800_POUT_OP_FAULT_LIMIT
+	},
+	{
+		.name = "interleave_order",
+		.show = ltp8800_iio_read_interleave,
+		.store = ltp8800_iio_write_interleave,
+	},
+	{
+		.name = "loop_pole",
+		.show = ltp8800_iio_read_loop,
+		.store = ltp8800_iio_write_loop,
+		.priv = LTP8800_NM_DIGFILT_POLE
+	},
+	{
+		.name = "loop_zero",
+		.show = ltp8800_iio_read_loop,
+		.store = ltp8800_iio_write_loop,
+		.priv = LTP8800_NM_DIGFILT_ZERO
+	},
+	{
+		.name = "loop_hf_gain",
+		.show = ltp8800_iio_read_loop,
+		.store = ltp8800_iio_write_loop,
+		.priv = LTP8800_NM_DIGFILT_HF_GAIN
+	},
+	{
+		.name = "loop_lf_gain",
+		.show = ltp8800_iio_read_loop,
+		.store = ltp8800_iio_write_loop,
+		.priv = LTP8800_NM_DIGFILT_LF_GAIN
+	},
+	{
+		.name = "store_user_settings",
+		.show = ltp8800_iio_user_settings_available,
+		.store = ltp8800_iio_user_settings,
+		.priv = LTP8800_IIO_STORE_USER_ALL
+	},
+	{
+		.name = "store_user_settings_available",
+		.show = ltp8800_iio_user_settings_available,
+		.priv = LTP8800_IIO_STORE_USER_ALL,
+		.shared = IIO_SHARED_BY_ALL
+	},
+	{
+		.name = "restore_user_settings",
+		.show = ltp8800_iio_user_settings_available,
+		.store = ltp8800_iio_user_settings,
+		.priv = LTP8800_IIO_RESTORE_USER_ALL
+	},
+	{
+		.name = "restore_user_settings_available",
+		.show = ltp8800_iio_user_settings_available,
+		.priv = LTP8800_IIO_RESTORE_USER_ALL,
+		.shared = IIO_SHARED_BY_ALL
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_attribute ltp8800_debug_attrs[] = {
+	{
+		.name = "status_vout",
+		.show = ltp8800_iio_read_status,
+		.priv = LTP8800_STATUS_VOUT
+	},
+	{
+		.name = "status_iout",
+		.show = ltp8800_iio_read_status,
+		.priv = LTP8800_STATUS_IOUT
+	},
+	{
+		.name = "status_input",
+		.show = ltp8800_iio_read_status,
+		.priv = LTP8800_STATUS_INPUT
+	},
+	{
+		.name = "status_mfr_specific",
+		.show = ltp8800_iio_read_status,
+		.priv = LTP8800_STATUS_MFR_SPECIFIC
+	},
+	{
+		.name = "status_word",
+		.show = ltp8800_iio_read_status,
+		.priv = LTP8800_STATUS_WORD
+	},
+	{
+		.name = "status_temperature",
+		.show = ltp8800_iio_read_status,
+		.priv = LTP8800_STATUS_TEMPERATURE
+	},
+	{
+		.name = "status_cml",
+		.show = ltp8800_iio_read_status,
+		.priv = LTP8800_STATUS_CML
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_channel ltp8800_channels[] = {
+	{
+		.name = "vout",
+		.ch_type = IIO_VOLTAGE,
+		.indexed = 1,
+		.channel = 0,
+		.address = LTP8800_IIO_VOUT_CHAN,
+		.attributes = ltp8800_chan_attrs,
+		.ch_out = true
+	},
+	{
+		.name = "iout",
+		.ch_type = IIO_CURRENT,
+		.indexed = 1,
+		.channel = 0,
+		.address = LTP8800_IIO_IOUT_CHAN,
+		.attributes = ltp8800_chan_attrs,
+		.ch_out = true
+	},
+	{
+		.name = "vin",
+		.ch_type = IIO_VOLTAGE,
+		.indexed = 1,
+		.channel = 0,
+		.address = LTP8800_IIO_VIN_CHAN,
+		.attributes = ltp8800_chan_attrs,
+		.ch_out = false
+	},
+	{
+		.name = "iin",
+		.ch_type = IIO_CURRENT,
+		.indexed = 1,
+		.channel = 0,
+		.address = LTP8800_IIO_IIN_CHAN,
+		.attributes = ltp8800_chan_attrs,
+		.ch_out = false
+	},
+	{
+		.name = "temperature",
+		.ch_type = IIO_TEMP,
+		.indexed = 1,
+		.channel = 0,
+		.address = LTP8800_IIO_TEMP_CHAN,
+		.attributes = ltp8800_chan_attrs,
+		.ch_out = false
+	},
+};
+
+static struct iio_device ltp8800_iio_dev = {
+	.num_ch = NO_OS_ARRAY_SIZE(ltp8800_channels),
+	.channels = ltp8800_channels,
+	.attributes = ltp8800_global_attrs,
+	.debug_attributes = ltp8800_debug_attrs,
+	.debug_reg_read = ltp8800_iio_reg_read,
+	.debug_reg_write = ltp8800_iio_reg_write,
+};

--- a/drivers/power/ltp8800/iio_ltp8800.h
+++ b/drivers/power/ltp8800/iio_ltp8800.h
@@ -1,0 +1,62 @@
+/***************************************************************************//**
+ *   @file   iio_ltp8800.h
+ *   @brief  Header file for the LTP8800 IIO Driver
+ *   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef IIO_LTP8800_H
+#define IIO_LTP8800_H
+
+#include <stdbool.h>
+#include "iio.h"
+#include "ltp8800.h"
+
+/**
+ * @brief Structure holding the LTP8800 IIO device descriptor
+*/
+struct ltp8800_iio_desc {
+	struct ltp8800_dev *ltp8800_dev;
+	struct iio_device *iio_dev;
+};
+
+/**
+ * @brief Structure holding the LTP8800 IIO initialization parameter.
+*/
+struct ltp8800_iio_desc_init_param {
+	struct ltp8800_init_param *ltp8800_init_param;
+};
+
+/** Initializes the LTP8800 IIO descriptor. */
+int ltp8800_iio_init(struct ltp8800_iio_desc **,
+		     struct ltp8800_iio_desc_init_param *);
+
+/** Free resources allocated by the initialization function. */
+int ltp8800_iio_remove(struct ltp8800_iio_desc *);
+
+#endif /* IIO_LTP8800_H */

--- a/drivers/power/ltp8800/ltp8800.c
+++ b/drivers/power/ltp8800/ltp8800.c
@@ -1,0 +1,1018 @@
+/*******************************************************************************
+ *   @file   ltp8800.c
+ *   @brief  Source code of the LTP8800 Driver
+ *   @authors Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#include "no_os_units.h"
+#include "no_os_util.h"
+#include "no_os_delay.h"
+#include "no_os_alloc.h"
+#include "no_os_pwm.h"
+#include "no_os_i2c.h"
+#include "no_os_gpio.h"
+#include "no_os_crc8.h"
+
+#include "ltp8800.h"
+
+NO_OS_DECLARE_CRC8_TABLE(ltp8800_crc_table);
+
+/**
+ * @brief Converts value to LINEAR16 register data
+ *
+ * @param dev - Device structure
+ * @param data - Value to convert
+ * @param reg - Address of converted register data
+ * @param scale - Value scaling factor
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int ltp8800_data2reg_linear16(struct ltp8800_dev *dev, int data,
+				     uint16_t *reg, int scale)
+{
+	if (data <= 0)
+		return -EINVAL;
+	data <<= -(dev->lin16_exp);
+
+	data = NO_OS_DIV_ROUND_CLOSEST_ULL(data, scale);
+	*reg = (uint16_t)no_os_clamp(data, 0, 0xFFFF);
+
+	return 0;
+}
+
+/**
+ * @brief Converts value to LINEAR11 register data
+ *
+ * @param dev - Device structure
+ * @param data - Value to convert
+ * @param reg - Address of converted register data
+ * @param scale - Value scaling factor
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int ltp8800_data2reg_linear11(struct ltp8800_dev *dev, int data,
+				     uint16_t *reg, int scale)
+{
+	int exp = 0, mant = 0;
+	uint8_t negative = 0;
+
+	if (data < 0) {
+		negative = 1;
+		data = -data;
+	}
+
+	/* If value too high, continuously do m/2 until m < 1023. */
+	while (data >= LTP8800_LIN11_MANTISSA_MAX * scale &&
+	       exp < LTP8800_LIN11_EXPONENT_MAX) {
+		exp++;
+		data >>= 1;
+	}
+
+	/* If value too low, increase mantissa. */
+	while (data < LTP8800_LIN11_MANTISSA_MIN * scale &&
+	       exp > LTP8800_LIN11_EXPONENT_MIN) {
+		exp--;
+		data <<= 1;
+	}
+
+	mant = no_os_clamp(NO_OS_DIV_ROUND_CLOSEST_ULL(data, scale),
+			   0, 0x3FF);
+	if (negative)
+		mant = -mant;
+
+	*reg = no_os_field_prep(LTP8800_LIN11_MANTISSA_MSK, mant) |
+	       no_os_field_prep(LTP8800_LIN11_EXPONENT_MSK, exp);
+
+	return 0;
+}
+
+/**
+ * @brief Converts raw LINEAR16 register data to its actual value
+ *
+ * @param dev - Device structure
+ * @param reg - LINEAR16 data to convert
+ * @param data - Address of value
+ * @param scale - Value scaling factor
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int ltp8800_reg2data_linear16(struct ltp8800_dev *dev, uint16_t reg,
+				     int *data, int scale)
+{
+	int exp = dev->lin16_exp;
+	if (exp < 0)
+		exp = -exp;
+
+	*data = ((int)(reg) * scale) >> exp;
+
+	return 0;
+}
+
+/**
+ * @brief Converts raw LINEAR11 register data to its actual value
+ *
+ * @param dev - Device structure
+ * @param reg - LINEAR11 data to convert
+ * @param data - Address of value
+ * @param scale - Value scaling factor
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int ltp8800_reg2data_linear11(struct ltp8800_dev *dev, uint16_t reg,
+				     int *data, int scale)
+{
+	int val, exp, mant;
+
+	exp = LTP8800_LIN11_EXPONENT(reg);
+	mant = LTP8800_LIN11_MANTISSA(reg);
+
+	val = mant * scale;
+	if (exp >= 0)
+		*data = val << exp;
+	else
+		*data = val >> -exp;
+
+	return 0;
+}
+
+/**
+ * @brief Convert value to register data
+ *
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @param data - Value to convert
+ * @param reg - Address of register data
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int ltp8800_data2reg(struct ltp8800_dev *dev, uint16_t cmd,
+			    int data, uint16_t *reg)
+{
+	switch (cmd) {
+	case LTP8800_VOUT_COMMAND:
+	case LTP8800_READ_VOUT:
+		return ltp8800_data2reg_linear16(dev, data, reg,
+						 MILLIVOLT_PER_VOLT);
+	case LTP8800_VOUT_SCALE_LOOP:
+	case LTP8800_VOUT_SCALE_MONITOR:
+	case LTP8800_FREQUENCY_SWITCH:
+	case LTP8800_VIN_ON:
+	case LTP8800_VIN_OFF:
+	case LTP8800_VIN_OV_FAULT_LIMIT:
+	case LTP8800_VIN_UV_FAULT_LIMIT:
+	case LTP8800_IIN_OC_FAULT_LIMIT:
+	case LTP8800_READ_VIN:
+	case LTP8800_READ_IIN:
+	case LTP8800_READ_IOUT:
+	case LTP8800_READ_TEMPERATURE_2:
+	case LTP8800_READ_TEMPERATURE_3:
+	case LTP8800_READ_DUTY_CYCLE:
+	case LTP8800_READ_FREQUENCY:
+		return ltp8800_data2reg_linear11(dev, data, reg,
+						 MILLI);
+	case LTP8800_POUT_OP_FAULT_LIMIT:
+	case LTP8800_READ_POUT:
+		return ltp8800_data2reg_linear11(dev, data, reg,
+						 MICROWATT_PER_WATT);
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Convert register data to actual value
+ *
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @param reg - Register data to convert
+ * @param data - Address of converted value
+ * @return 0 in case of success, negative error code otherwise
+ */
+static int ltp8800_reg2data(struct ltp8800_dev *dev, uint16_t cmd,
+			    uint16_t reg, int *data)
+{
+	switch (cmd) {
+	case LTP8800_VOUT_COMMAND:
+	case LTP8800_READ_VOUT:
+		return ltp8800_reg2data_linear16(dev, reg, data,
+						 MILLIVOLT_PER_VOLT);
+	case LTP8800_VOUT_SCALE_LOOP:
+	case LTP8800_VOUT_SCALE_MONITOR:
+	case LTP8800_FREQUENCY_SWITCH:
+	case LTP8800_VIN_ON:
+	case LTP8800_VIN_OFF:
+	case LTP8800_VIN_OV_FAULT_LIMIT:
+	case LTP8800_VIN_UV_FAULT_LIMIT:
+	case LTP8800_IIN_OC_FAULT_LIMIT:
+	case LTP8800_READ_VIN:
+	case LTP8800_READ_IIN:
+	case LTP8800_READ_IOUT:
+	case LTP8800_READ_TEMPERATURE_2:
+	case LTP8800_READ_TEMPERATURE_3:
+	case LTP8800_READ_DUTY_CYCLE:
+	case LTP8800_READ_FREQUENCY:
+		return ltp8800_reg2data_linear11(dev, reg, data,
+						 MILLI);
+	case LTP8800_POUT_OP_FAULT_LIMIT:
+	case LTP8800_READ_POUT:
+		return ltp8800_reg2data_linear11(dev, reg, data,
+						 MICROWATT_PER_WATT);
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Perform packet-error checking via CRC
+ *
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @param buf - Pointer to the first packet buffer
+ * @param nbytes - Packet buffer size
+ * @param op - Operation performed. 0 for write, 1 for read
+ * @return PEC code of the PMBus packet
+ */
+static uint8_t ltp8800_pec(struct ltp8800_dev *dev, uint16_t cmd, uint8_t *buf,
+			   size_t nbytes, uint8_t op)
+{
+	uint8_t crc_buf[nbytes + op + 3];
+	uint8_t i = 0;
+
+	crc_buf[i++] = (dev->i2c_desc->slave_address << 1);
+
+	if (cmd >= LTP8800_EXTENDED_COMMAND_BEGIN)
+		crc_buf[i++] = no_os_field_get(LTP8800_COMMAND_MSB_MSK, cmd);
+
+	crc_buf[i++] = no_os_field_get(LTP8800_COMMAND_LSB_MSK, cmd);
+	if (op)
+		crc_buf[i++] = (dev->i2c_desc->slave_address << 1) | 1;
+
+	if (buf != NULL && nbytes > 0)
+		memcpy(&crc_buf[i], buf, nbytes);
+
+	return no_os_crc8(ltp8800_crc_table, crc_buf, nbytes + i, 0);
+}
+
+/**
+ * @brief Initialize the device structure
+ *
+ * @param device - Device structure
+ * @param init_param - Initialization parameters
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltp8800_init(struct ltp8800_dev **device,
+		 struct ltp8800_init_param *init_param)
+{
+	struct ltp8800_dev *dev;
+	int ret;
+	uint8_t block[2];
+	uint8_t ic_device_id[2] = LTP8800_IC_DEVICE_ID_VALUE;
+	uint8_t val;
+
+	dev = (struct ltp8800_dev *)no_os_calloc(1, sizeof(struct ltp8800_dev));
+	if (!dev)
+		return -ENOMEM;
+
+	/* Initialize I2C */
+	ret = no_os_i2c_init(&dev->i2c_desc, init_param->i2c_init);
+	if (ret)
+		goto i2c_err;
+
+	/* Identify device */
+	ret = ltp8800_read_block_data(dev, LTP8800_IC_DEVICE_ID, block, 2);
+	if (ret)
+		goto dev_err;
+	if (strncmp((char *)block, (char *)ic_device_id, 2)) {
+		ret = -EIO;
+		goto dev_err;
+	}
+
+	dev->crc_en = init_param->crc_en;
+
+	/* Populate CRC table for PEC */
+	if (dev->crc_en)
+		no_os_crc8_populate_msb(ltp8800_crc_table,
+					LTP8800_CRC_POLYNOMIAL);
+
+	ret = ltp8800_read_byte(dev, LTP8800_VOUT_MODE, &val);
+	if (ret)
+		goto dev_err;
+
+	dev->lin16_exp = (int)no_os_sign_extend32(val, 4);
+
+	/* Configure WRITE PROTECT */
+	ret = ltp8800_read_byte(dev, LTP8800_WRITE_PROTECT, &val);
+	if (ret)
+		goto dev_err;
+
+	val &= ~(LTP8800_WRITE_PROTECT_1_BIT);
+	val |= no_os_field_prep(LTP8800_WRITE_PROTECT_1_BIT,
+				init_param->write_protect_en);
+
+	ret = ltp8800_write_byte(dev, LTP8800_WRITE_PROTECT, val);
+	if (ret)
+		goto dev_err;
+
+	dev->write_protect_en = init_param->write_protect_en;
+
+	if (!dev->write_protect_en) {
+		/* Configure synchronization */
+		ret = ltp8800_sync_config(dev, init_param->sync_en);
+		if (ret)
+			goto dev_err;
+
+		/* Set PolyPhase order */
+		ret = ltp8800_interleave_order(dev,
+					       init_param->polyphase_order);
+		if (ret)
+			goto dev_err;
+	}
+
+	/* Initialize GPIO for ALERT */
+	ret = no_os_gpio_get_optional(&dev->smbalert_desc,
+				      init_param->smbalert_param);
+	if (ret)
+		goto dev_err;
+
+	ret = no_os_gpio_direction_input(dev->smbalert_desc);
+	if (ret)
+		goto dev_err;
+
+	/* Initialize GPIO for CTRL */
+	ret = no_os_gpio_get_optional(&dev->ctrl_desc,
+				      init_param->ctrl_param);
+	if (ret)
+		goto dev_err;
+
+	ret = no_os_gpio_direction_output(dev->ctrl_desc, NO_OS_GPIO_HIGH);
+	if (ret)
+		goto dev_err;
+
+	/* Initialize external clock for synchronization if used */
+	if (init_param->external_clk_en) {
+		ret = no_os_pwm_init(&dev->ext_clk_desc,
+				     init_param->ext_clk_param);
+		if (ret)
+			goto dev_err;
+	}
+
+	*device = dev;
+
+	return 0;
+
+dev_err:
+	no_os_gpio_remove(dev->ctrl_desc);
+	no_os_gpio_remove(dev->smbalert_desc);
+	no_os_i2c_remove(dev->i2c_desc);
+i2c_err:
+	no_os_free(dev);
+	return ret;
+}
+
+/**
+ * @brief Free or remove device instance
+ *
+ * @param dev - The device structure
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltp8800_remove(struct ltp8800_dev *dev)
+{
+	int ret;
+
+	ret = no_os_i2c_remove(dev->i2c_desc);
+	if (ret)
+		return ret;
+
+	ret = no_os_gpio_remove(dev->smbalert_desc);
+	if (ret)
+		return ret;
+
+	ret = no_os_gpio_remove(dev->ctrl_desc);
+	if (ret)
+		return ret;
+
+	if (dev->ext_clk_desc) {
+		ret = no_os_pwm_remove(dev->ext_clk_desc);
+		if (ret)
+			return ret;
+	}
+
+	no_os_free(dev);
+
+	return ret;
+}
+
+/**
+ * @brief Send a PMBus command to the device
+ *
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @return 0 in case of success, negative error code otherwise
+ */
+
+int ltp8800_send_byte(struct ltp8800_dev *dev, uint16_t cmd)
+{
+	uint8_t tx_buf[3];
+	uint8_t i = 0;
+
+	if (!dev)
+		return -EINVAL;
+
+	tx_buf[i++] = no_os_field_get(LTP8800_COMMAND_LSB_MSK, cmd);
+
+	if (cmd >= LTP8800_EXTENDED_COMMAND_BEGIN)
+		tx_buf[i++] = LTP8800_EXTENDED_COMMAND_PREFIX;
+
+	if (dev->crc_en)
+		tx_buf[i++] = ltp8800_pec(dev, cmd, NULL, 0, 0);
+
+	return no_os_i2c_write(dev->i2c_desc, tx_buf, i, 1);
+}
+
+/**
+ * @brief Perform a raw PMBus read byte operation
+ *
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @param data - Address of the byte read
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltp8800_read_byte(struct ltp8800_dev *dev, uint16_t cmd, uint8_t *data)
+{
+	int ret;
+	uint8_t cmd_buf[2];
+	uint8_t rx_buf[2];
+
+	if (!dev)
+		return -EINVAL;
+
+	if (cmd >= LTP8800_EXTENDED_COMMAND_BEGIN) {
+		no_os_put_unaligned_be16(cmd, cmd_buf);
+		ret = no_os_i2c_write(dev->i2c_desc, cmd_buf, 2, 0);
+	} else {
+		cmd_buf[0] = no_os_field_get(LTP8800_COMMAND_LSB_MSK, cmd);
+		ret = no_os_i2c_write(dev->i2c_desc, cmd_buf, 1, 0);
+	}
+	if (ret)
+		return ret;
+
+	if (dev->crc_en) {
+		ret = no_os_i2c_read(dev->i2c_desc, rx_buf, 2, 1);
+		if (ret)
+			return ret;
+
+		if (ltp8800_pec(dev, cmd, rx_buf, 1, 1) != rx_buf[1])
+			return -EBADMSG;
+
+		*data = rx_buf[0];
+		return ret;
+	} else
+		return no_os_i2c_read(dev->i2c_desc, data, 1, 1);
+}
+
+/**
+ * @brief Perform a raw PMBus write byte operation
+ *
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @param value - Byte to be written
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltp8800_write_byte(struct ltp8800_dev *dev, uint16_t cmd, uint8_t value)
+{
+	uint8_t tx_buf[4];
+	uint8_t i = 0;
+
+	if (!dev)
+		return -EINVAL;
+
+	if (cmd >= LTP8800_EXTENDED_COMMAND_BEGIN)
+		tx_buf[i++] = LTP8800_EXTENDED_COMMAND_PREFIX;
+
+	tx_buf[i++] = no_os_field_get(LTP8800_COMMAND_LSB_MSK, cmd);
+
+	tx_buf[i++] = value;
+
+	if (dev->crc_en)
+		tx_buf[i++] = ltp8800_pec(dev, cmd, &value, 1, 0);
+
+	return no_os_i2c_write(dev->i2c_desc, tx_buf, i, 1);
+}
+
+/**
+ * @brief Perform a raw PMBus read word operation
+ *
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @param word - Address of the read word
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltp8800_read_word(struct ltp8800_dev *dev, uint16_t cmd, uint16_t *word)
+{
+	int ret;
+	uint8_t rx_buf[3];
+	uint8_t cmd_buf[2];
+
+	if (!dev)
+		return -EINVAL;
+
+	if (cmd >= LTP8800_EXTENDED_COMMAND_BEGIN) {
+		no_os_put_unaligned_be16(cmd, cmd_buf);
+		ret = no_os_i2c_write(dev->i2c_desc, cmd_buf, 2, 0);
+	} else {
+		cmd_buf[0] = no_os_field_get(LTP8800_COMMAND_LSB_MSK, cmd);
+		ret = no_os_i2c_write(dev->i2c_desc, cmd_buf, 1, 0);
+	}
+	if (ret)
+		return ret;
+
+	if (dev->crc_en) {
+		ret = no_os_i2c_read(dev->i2c_desc, rx_buf, 3, 1);
+		if (ret)
+			return ret;
+
+		if (ltp8800_pec(dev, cmd, rx_buf, 2, 1) != rx_buf[2])
+			return -EBADMSG;
+	} else {
+		ret = no_os_i2c_read(dev->i2c_desc, rx_buf, 2, 1);
+		if(ret)
+			return ret;
+	}
+
+	*word = no_os_get_unaligned_le16(rx_buf);
+	return 0;
+}
+
+/**
+ * @brief Perform a raw PMBus write word operation
+ *
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @param word - Word to write
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltp8800_write_word(struct ltp8800_dev *dev, uint16_t cmd, uint16_t word)
+{
+	uint8_t tx_buf[5];
+	uint8_t i = 0;
+
+	if (!dev)
+		return -EINVAL;
+
+	if (cmd >= LTP8800_EXTENDED_COMMAND_BEGIN)
+		tx_buf[i++] = LTP8800_EXTENDED_COMMAND_PREFIX;
+
+	tx_buf[i++] = no_os_field_get(LTP8800_COMMAND_LSB_MSK, cmd);
+
+	no_os_put_unaligned_le16(word, &tx_buf[i]);
+	i += 2;
+
+	if (dev->crc_en)
+		tx_buf[i++] = ltp8800_pec(dev, cmd, &tx_buf[1], 2, 0);
+
+	return no_os_i2c_write(dev->i2c_desc, tx_buf, i, 1);
+}
+
+/**
+ * @brief Perform a PMBus read word operation and converts to actual value
+ *
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @param data - Address of data read
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltp8800_read_word_data(struct ltp8800_dev *dev, uint16_t cmd, int *data)
+{
+	int ret;
+	uint16_t reg;
+
+	ret = ltp8800_read_word(dev, cmd, &reg);
+	if (ret)
+		return ret;
+
+	return ltp8800_reg2data(dev, cmd, reg, data);
+}
+
+/**
+ * @brief Converts value to register data and do PMBus write word operation
+ *
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @param data - Value to write
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltp8800_write_word_data(struct ltp8800_dev *dev, uint16_t cmd, int data)
+{
+	int ret;
+	uint16_t reg;
+
+	ret = ltp8800_data2reg(dev, cmd, data, &reg);
+	if (ret)
+		return ret;
+
+	return ltp8800_write_word(dev, cmd, reg);
+}
+
+/**
+ * @brief Perform a PMBus read block operation
+ *
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @param data - Address of the read block
+ * @param nbytes - Size of the block in bytes
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltp8800_read_block_data(struct ltp8800_dev *dev, uint16_t cmd,
+			    uint8_t *data, size_t nbytes)
+{
+	int ret;
+	uint8_t rxbuf[nbytes + 2];
+	uint8_t cmd_buf[2];
+
+	if (!dev)
+		return -EINVAL;
+
+	if (cmd >= LTP8800_EXTENDED_COMMAND_BEGIN) {
+		no_os_put_unaligned_be16(cmd, cmd_buf);
+		ret = no_os_i2c_write(dev->i2c_desc, cmd_buf, 2, 0);
+	} else {
+		cmd_buf[0] = no_os_field_get(LTP8800_COMMAND_LSB_MSK, cmd);
+		ret = no_os_i2c_write(dev->i2c_desc, cmd_buf, 1, 0);
+	}
+	if (ret)
+		return ret;
+
+	if (dev->crc_en) {
+		ret = no_os_i2c_read(dev->i2c_desc, rxbuf, nbytes + 2, 1);
+		if (ret)
+			return ret;
+
+		if ((size_t)rxbuf[0] > nbytes)
+			return -EMSGSIZE;
+
+		if (ltp8800_pec(dev, cmd, rxbuf, nbytes + 1, 1) !=
+		    rxbuf[nbytes + 1])
+			return -EBADMSG;
+	} else {
+		ret = no_os_i2c_read(dev->i2c_desc, rxbuf, nbytes + 1, 1);
+		if(ret)
+			return ret;
+
+		if((size_t)rxbuf[0] > nbytes)
+			return -EMSGSIZE;
+	}
+
+	memcpy(data, &rxbuf[1], nbytes);
+
+	return 0;
+}
+
+/**
+ * @brief Read a value
+ *
+ * @param dev - Device structure
+ * @param value_type - Value type.
+ * 		       Example values: LTP8800_VIN
+ * 				       LTP8800_VOUT
+ * 				       LTP8800_IIN
+ * 				       LTP8800_IOUT
+ * 				       LTP8800_TEMP
+ * 				       LTP8800_FREQUENCY
+ * @param value - Address of the read value
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltp8800_read_value(struct ltp8800_dev *dev,
+		       enum ltp8800_value_type value_type,
+		       int *value)
+{
+	return ltp8800_read_word_data(dev, (uint8_t)value_type, value);
+}
+
+/**
+ * @brief Read statuses
+ *
+ * @param dev - Device structure
+ * @param status_type - Status type.
+ * 			Example values: LTP8800_STATUS_BYTE_TYPE
+ * 					LTP8800_STATUS_VOUT_TYPE
+ * 					LTP8800_STATUS_IOUT_TYPE
+ * 					LTP8800_STATUS_INPUT_TYPE
+ * 					LTP8800_STATUS_CML_TYPE
+ * @param status - Address of the status structure
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltp8800_read_status(struct ltp8800_dev *dev,
+			enum ltp8800_status_type status_type,
+			struct ltp8800_status *status)
+{
+	int ret;
+
+	if (status_type & LTP8800_STATUS_WORD_TYPE) {
+		ret = ltp8800_read_word(dev, LTP8800_STATUS_WORD,
+					&status->word);
+		if (ret)
+			return ret;
+	}
+
+	if (status_type & LTP8800_STATUS_BYTE_TYPE) {
+		ret = ltp8800_read_byte(dev, LTP8800_STATUS_BYTE,
+					&status->byte);
+		if (ret)
+			return ret;
+	}
+
+	if (status_type & LTP8800_STATUS_VOUT_TYPE) {
+		ret = ltp8800_read_byte(dev, LTP8800_STATUS_VOUT,
+					&status->vout);
+		if (ret)
+			return ret;
+	}
+
+	if (status_type & LTP8800_STATUS_IOUT_TYPE) {
+		ret = ltp8800_read_byte(dev, LTP8800_STATUS_IOUT,
+					&status->iout);
+		if (ret)
+			return ret;
+	}
+
+	if (status_type & LTP8800_STATUS_INPUT_TYPE) {
+		ret = ltp8800_read_byte(dev, LTP8800_STATUS_INPUT,
+					&status->input);
+		if (ret)
+			return ret;
+	}
+
+	if (status_type & LTP8800_STATUS_TEMP_TYPE) {
+		ret = ltp8800_read_byte(dev, LTP8800_STATUS_TEMPERATURE,
+					&status->temp);
+		if (ret)
+			return ret;
+	}
+
+	if (status_type & LTP8800_STATUS_CML_TYPE) {
+		ret = ltp8800_read_byte(dev, LTP8800_STATUS_CML,
+					&status->cml);
+		if (ret)
+			return ret;
+	}
+
+	if (status_type & LTP8800_STATUS_MFR_SPECIFIC_TYPE) {
+		ret = ltp8800_read_byte(dev, LTP8800_STATUS_MFR_SPECIFIC,
+					&status->mfr_specific);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Set output voltage command
+ *
+ * @param dev - Device structure
+ * @param vout_command - Output voltage in millivolts
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltp8800_vout_value(struct ltp8800_dev *dev, int vout_command)
+{
+	if (vout_command >= LTP8800_VOUT_COMMAND_MIN &&
+	    vout_command <= LTP8800_VOUT_COMMAND_MAX)
+		return ltp8800_write_word_data(dev, LTP8800_VOUT_COMMAND,
+					       vout_command);
+	else
+		return -EINVAL;
+}
+
+/**
+ * @brief Set output voltage and its upper limit
+ *
+ * @param dev - Device structure
+ * @param settings - Gain settings
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltp8800_vout_settings(struct ltp8800_dev *dev,
+			  enum ltp8800_vout_settings settings)
+{
+	int ret;
+
+	ret = ltp8800_write_word(dev, LTP8800_VOUT_COMMAND,
+				 LTP8800_VOUT_COMMAND_DEFAULT);
+	if (ret)
+		return ret;
+
+	ret = ltp8800_write_word(dev, LTP8800_VOUT_SCALE_LOOP,
+				 (uint16_t)settings);
+	if (ret)
+		return ret;
+
+	return ltp8800_write_word(dev, LTP8800_VOUT_SCALE_MONITOR,
+				  (uint16_t)settings);
+}
+
+/**
+ * @brief Set input voltage window at which power conversion will proceed
+ *
+ * @param dev - Device structure
+ * @param vin_on - Input voltage in millivolts at which conversion will start
+ * @param vin_off - Input voltage in millivolts at which conversion will stop
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltp8800_set_vin(struct ltp8800_dev *dev, int vin_on, int vin_off)
+{
+	int ret;
+
+	if (vin_on < vin_off)
+		return -EINVAL;
+
+	ret = ltp8800_write_word_data(dev, LTP8800_VIN_ON, vin_on);
+	if (ret)
+		return ret;
+
+	return ltp8800_write_word_data(dev, LTP8800_VIN_OFF, vin_off);
+}
+
+/**
+ * @brief Set overvalue and undervalue limits
+ *
+ * @param dev - Device structure
+ * @param limit - Limit value type.
+ * 		  Example: LTP8800_VIN_OV_FAULT_LIMIT_TYPE
+ * 			   LTP8800_VIN_UV_FAULT_LIMIT_TYPE
+ * 			   LTP8800_IIN_OC_FAULT_LIMIT_TYPE
+ * 			   LTP8800_POUT_OP_FAULT_LIMIT_TYPE
+ * @param limit_val - Limit value in milli-units for voltage and current, and
+ * 		      microseconds for timing.
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltp8800_set_fault_limit(struct ltp8800_dev *dev,
+			    enum ltp8800_limit_type limit,
+			    int limit_val)
+{
+	return ltp8800_write_word_data(dev, (uint16_t)limit, limit_val);
+}
+
+/**
+ * @brief Enable or disable sync pin
+ *
+ * @param dev - Device structure
+ * @param enable - Set to true to enable, or false to disable
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltp8800_sync_config(struct ltp8800_dev *dev, bool enable)
+{
+	int ret;
+	uint8_t val;
+
+	ret = ltp8800_read_byte(dev, LTP8800_SYNC, &val);
+	if (ret)
+		return ret;
+
+	val &= ~(LTP8800_SYNC_ENABLE_BIT);
+	val |= no_os_field_prep(LTP8800_SYNC_ENABLE_BIT, !enable);
+
+	ret = ltp8800_write_byte(dev, LTP8800_SYNC, val);
+	if (ret)
+		return ret;
+
+	return ltp8800_write_byte(dev, LTP8800_GO_CMD, LTP8800_SYNC_LATCH_BIT);
+}
+
+/**
+ * @brief Set phase order for polyphase application
+ *
+ * @param dev - Device structure
+ * @param order - Order number. The resulting phase offset of the device is
+ * 		  equivalent to this value multiplied by 22.5 degrees.
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltp8800_interleave_order(struct ltp8800_dev *dev, uint8_t order)
+{
+	int ret;
+	uint16_t val;
+
+	if (order > LTP8800_MAX_INTERLEAVE_ORDER)
+		return -EINVAL;
+
+	ret = ltp8800_read_word(dev, LTP8800_INTERLEAVE, &val);
+	if (ret)
+		return ret;
+
+	val &= ~(LTP8800_INTERLEAVE_ORDER_MSK);
+	val |= no_os_field_prep(LTP8800_INTERLEAVE_ORDER_MSK, order);
+
+	ret = ltp8800_write_word(dev, LTP8800_INTERLEAVE, val);
+	if (ret)
+		return ret;
+
+	dev->polyphase_order = order;
+
+	return 0;
+}
+
+/**
+ * @brief Program loop compensation for regulator transient response
+ *
+ * @param dev - Device structure
+ * @param pole - Pole setting
+ * @param zero - Zero setting
+ * @param hf_gain - High frequency gain setting
+ * @param lf_gain - Low frequence gain setting
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltp8800_loop_compensation(struct ltp8800_dev *dev,
+			      uint8_t pole,
+			      uint8_t zero,
+			      uint8_t hf_gain,
+			      uint8_t lf_gain)
+{
+	int ret;
+
+	ret = ltp8800_write_byte(dev, LTP8800_NM_DIGFILT_POLE, pole);
+	if (ret)
+		return ret;
+
+	ret = ltp8800_write_byte(dev, LTP8800_NM_DIGFILT_ZERO, zero);
+	if (ret)
+		return ret;
+
+	ret = ltp8800_write_byte(dev, LTP8800_NM_DIGFILT_HF_GAIN, hf_gain);
+	if (ret)
+		return ret;
+
+	return ltp8800_write_byte(dev, LTP8800_NM_DIGFILT_LF_GAIN, lf_gain);
+}
+
+/**
+ * @brief Set device state
+ *
+ * @param dev - Device structure
+ * @param state - Set to true to enable device, false to disable
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltp8800_set_device_state(struct ltp8800_dev *dev, bool state)
+{
+	return no_os_gpio_direction_output(dev->ctrl_desc, (uint8_t)state);
+}
+
+/**
+ * @brief Store user settings to EEPROM.
+ *
+ * @param dev - Device structure
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltp8800_store_user_settings(struct ltp8800_dev *dev)
+{
+	int ret, i;
+
+	/* Unlock EEPROM */
+	for (i = 0; i < 2; i++) {
+		ret = ltp8800_write_byte(dev, LTP8800_EEPROM_PASSWORD,
+					 LTP8800_EEPROM_PASSWORD_VALUE);
+		if (ret)
+			return ret;
+	}
+
+	ret = ltp8800_send_byte(dev, LTP8800_STORE_USER_ALL);
+	if (ret)
+		return ret;
+
+	return ltp8800_write_byte(dev, LTP8800_EEPROM_PASSWORD,
+				  LTP8800_EEPROM_LOCK_VALUE);
+}
+
+/**
+ * @brief Restore user settings.
+ *
+ * @param dev - Device structure
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltp8800_restore_user_settings(struct ltp8800_dev *dev)
+{
+	return ltp8800_send_byte(dev, LTP8800_RESTORE_USER_ALL);
+}

--- a/drivers/power/ltp8800/ltp8800.h
+++ b/drivers/power/ltp8800/ltp8800.h
@@ -1,0 +1,316 @@
+/*******************************************************************************
+ *   @file   ltp8800.h
+ *   @brief  Header file of the LTP8800 Driver
+ *   @authors Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __LTP8800_H__
+#define __LTP8800_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <stdint.h>
+#include <string.h>
+#include "no_os_util.h"
+#include "no_os_i2c.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+/* PMBus commands */
+#define LTP8800_PAGE				0x00
+#define LTP8800_OPERATION			0x01
+#define LTP8800_WRITE_PROTECT			0x10
+#define LTP8800_STORE_USER_ALL			0x15
+#define LTP8800_RESTORE_USER_ALL		0x16
+#define LTP8800_VOUT_MODE			0x20
+
+#define LTP8800_VOUT_COMMAND			0x21
+#define LTP8800_VOUT_SCALE_LOOP			0x29
+#define LTP8800_VOUT_SCALE_MONITOR		0x2A
+
+#define LTP8800_FREQUENCY_SWITCH		0x33
+#define LTP8800_VIN_ON				0x35
+#define LTP8800_VIN_OFF				0x36
+#define LTP8800_INTERLEAVE			0x37
+
+#define LTP8800_VIN_OV_FAULT_LIMIT		0x55
+#define LTP8800_VIN_UV_FAULT_LIMIT		0x59
+#define LTP8800_IIN_OC_FAULT_LIMIT		0x5B
+#define LTP8800_POUT_OP_FAULT_LIMIT		0x68
+
+#define LTP8800_STATUS_BYTE			0x78
+#define LTP8800_STATUS_WORD			0x79
+#define LTP8800_STATUS_VOUT			0x7A
+#define LTP8800_STATUS_IOUT			0x7B
+#define LTP8800_STATUS_INPUT			0x7C
+#define LTP8800_STATUS_TEMPERATURE		0x7D
+#define LTP8800_STATUS_CML			0x7E
+#define LTP8800_STATUS_OTHER			0x7F
+#define LTP8800_STATUS_MFR_SPECIFIC		0x80
+
+#define LTP8800_READ_VIN			0x88
+#define LTP8800_READ_IIN			0x89
+#define LTP8800_READ_VOUT			0x8B
+#define LTP8800_READ_IOUT			0x8C
+#define LTP8800_READ_TEMPERATURE_2		0x8E
+#define LTP8800_READ_TEMPERATURE_3		0x8F
+#define LTP8800_READ_DUTY_CYCLE			0x94
+#define LTP8800_READ_FREQUENCY			0x95
+#define LTP8800_READ_POUT			0x96
+
+#define LTP8800_REVISION			0x98
+#define LTP8800_MFR_ID				0x99
+#define LTP8800_MFR_MODEL			0x9A
+#define LTP8800_MFR_REVISION			0x9B
+#define LTP8800_MFR_SERIAL			0x9E
+#define LTP8800_IC_DEVICE_ID			0xAD
+#define LTP8800_IC_DEVICE_REV			0xAE
+
+#define LTP8800_EEPROM_PASSWORD			0xD5
+
+#define LTP8800_GO_CMD				0xFE00
+#define LTP8800_NM_DIGFILT_LF_GAIN		0xFE01
+#define LTP8800_NM_DIGFILT_ZERO			0xFE02
+#define LTP8800_NM_DIGFILT_POLE			0xFE03
+#define LTP8800_NM_DIGFILT_HF_GAIN		0xFE04
+#define LTP8800_SYNC				0xFE55
+
+/* PMBus-specific parameters */
+#define LTP8800_CRC_POLYNOMIAL			0x7
+#define LTP8800_VOUT_MODE_VAL_MSK		NO_OS_GENMASK(4,0)
+
+/* LINEAR data format params */
+#define LTP8800_LIN11_MANTISSA_MAX		1023L
+#define LTP8800_LIN11_MANTISSA_MIN		511L
+#define LTP8800_LIN11_EXPONENT_MAX		15
+#define LTP8800_LIN11_EXPONENT_MIN		-15
+#define LTP8800_LIN11_MANTISSA_MSK		NO_OS_GENMASK(10,0)
+#define LTP8800_LIN11_EXPONENT_MSK		NO_OS_GENMASK(15,11)
+#define LTP8800_LIN11_EXPONENT(x)		((int16_t)(x) >> 11)
+#define LTP8800_LIN11_MANTISSA(x)		(((int16_t)((x & 0x7FF) << 5)) >> 5)
+#define LTP8800_LIN16_EXPONENT			-14
+
+/* Extended commands constants */
+#define LTP8800_EXTENDED_COMMAND_PREFIX		0xFE
+#define LTP8800_EXTENDED_COMMAND_BEGIN		0xFE00
+#define LTP8800_COMMAND_LSB_MSK			NO_OS_GENMASK(7, 0)
+#define LTP8800_COMMAND_MSB_MSK			NO_OS_GENMASK(15, 8)
+
+/* Status types masks */
+#define LTP8800_STATUS_BYTE_TYPE_MSK		0x01
+#define LTP8800_STATUS_VOUT_TYPE_MSK		0x02
+#define LTP8800_STATUS_IOUT_TYPE_MSK		0x04
+#define LTP8800_STATUS_INPUT_TYPE_MSK		0x08
+#define LTP8800_STATUS_TEMP_TYPE_MSK		0x10
+#define LTP8800_STATUS_CML_TYPE_MSK		0x20
+#define LTP8800_STATUS_MFR_SPECIFIC_TYPE_MSK	0x40
+#define LTP8800_STATUS_WORD_TYPE_MSK		0x80
+#define LTP8800_STATUS_ALL_TYPE_MSK		0xFF
+
+/* LTP8800 configurable bits and masks */
+#define LTP8800_SYNC_ENABLE_BIT			NO_OS_BIT(6)
+#define LTP8800_SYNC_LATCH_BIT			NO_OS_BIT(6)
+#define LTP8800_WRITE_PROTECT_1_BIT		NO_OS_BIT(7)
+#define LTP8800_WRITE_PROTECT_2_BIT		NO_OS_BIT(6)
+#define LTP8800_WRITE_PROTECT_3_BIT		NO_OS_BIT(5)
+#define LTP8800_INTERLEAVE_ORDER_MSK		NO_OS_GENMASK(3, 0)
+
+/* LTP8800 device constants */
+#define LTP8800_IC_DEVICE_ID_VALUE		{0x41, 0x55}
+#define LTP8800_MAX_INTERLEAVE_ORDER		0xF
+#define LTP8800_VOUT_COMMAND_MAX		1100
+#define LTP8800_VOUT_COMMAND_MIN		500
+#define LTP8800_VOUT_COMMAND_DEFAULT		0x3000
+#define LTP8800_EEPROM_PASSWORD_VALUE		0xFF
+#define LTP8800_EEPROM_LOCK_VALUE		0xAB
+
+/* LTP8800 device settings */
+#define LTP8800_STATE_ON			1
+#define LTP8800_STATE_OFF			0
+
+enum ltp8800_value_type {
+	LTP8800_VIN = LTP8800_READ_VIN,
+	LTP8800_IIN = LTP8800_READ_IIN,
+	LTP8800_VOUT = LTP8800_READ_VOUT,
+	LTP8800_IOUT = LTP8800_READ_IOUT,
+	LTP8800_FORWARD_DIODE_TEMP = LTP8800_READ_TEMPERATURE_2,
+	LTP8800_REVERSE_DIODE_TEMP = LTP8800_READ_TEMPERATURE_3,
+	LTP8800_DUTY_CYCLE = LTP8800_READ_DUTY_CYCLE,
+	LTP8800_FREQUENCY = LTP8800_READ_FREQUENCY,
+	LTP8800_POUT = LTP8800_READ_POUT,
+};
+
+enum ltp8800_limit_type {
+	LTP8800_VIN_OV_FAULT_LIMIT_TYPE = LTP8800_VIN_OV_FAULT_LIMIT,
+	LTP8800_VIN_UV_FAULT_LIMIT_TYPE = LTP8800_VIN_UV_FAULT_LIMIT,
+	LTP8800_IIN_OC_FAULT_LIMIT_TYPE = LTP8800_IIN_OC_FAULT_LIMIT,
+	LTP8800_POUT_OP_FAULT_LIMIT_TYPE = LTP8800_POUT_OP_FAULT_LIMIT,
+};
+
+enum ltp8800_status_type {
+	LTP8800_STATUS_BYTE_TYPE = LTP8800_STATUS_BYTE_TYPE_MSK,
+	LTP8800_STATUS_VOUT_TYPE = LTP8800_STATUS_VOUT_TYPE_MSK,
+	LTP8800_STATUS_IOUT_TYPE = LTP8800_STATUS_IOUT_TYPE_MSK,
+	LTP8800_STATUS_INPUT_TYPE = LTP8800_STATUS_INPUT_TYPE_MSK,
+	LTP8800_STATUS_TEMP_TYPE = LTP8800_STATUS_TEMP_TYPE_MSK,
+	LTP8800_STATUS_CML_TYPE = LTP8800_STATUS_CML_TYPE_MSK,
+	LTP8800_STATUS_MFR_SPECIFIC_TYPE = LTP8800_STATUS_MFR_SPECIFIC_TYPE_MSK,
+	LTP8800_STATUS_WORD_TYPE = LTP8800_STATUS_WORD_TYPE_MSK,
+	LTP8800_STATUS_ALL_TYPE = LTP8800_STATUS_ALL_TYPE_MSK,
+};
+
+enum ltp8800_vout_settings {
+	LTP8800_VOUT_SETTING_ADI_FACTORY = 0xB2A6,
+	LTP8800_VOUT_SETTING_UNITY = 0xBA00,
+};
+
+struct ltp8800_dev {
+	struct no_os_i2c_desc *i2c_desc;
+	struct no_os_gpio_desc *smbalert_desc;
+	struct no_os_gpio_desc *ctrl_desc;
+	struct no_os_pwm_desc *ext_clk_desc;
+
+	int lin16_exp;
+	bool write_protect_en;
+	bool crc_en;
+	uint8_t polyphase_order;
+};
+
+struct ltp8800_init_param {
+	struct no_os_i2c_init_param *i2c_init;
+	struct no_os_gpio_init_param *smbalert_param;
+	struct no_os_gpio_init_param *ctrl_param;
+	struct no_os_pwm_init_param *ext_clk_param;
+
+	bool write_protect_en;
+	bool external_clk_en;
+	bool sync_en;
+	bool crc_en;
+	uint8_t polyphase_order;
+};
+
+struct ltp8800_status {
+	uint16_t word;
+	uint8_t byte;
+	uint8_t vout;
+	uint8_t iout;
+	uint8_t input;
+	uint8_t temp;
+	uint8_t cml;
+	uint8_t mfr_specific;
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+/* Initialize the device structure */
+int ltp8800_init(struct ltp8800_dev **device,
+		 struct ltp8800_init_param *init_param);
+
+/* Free or remove device instance */
+int ltp8800_remove(struct ltp8800_dev *dev);
+
+/* Send a PMBus command to the device */
+int ltp8800_send_byte(struct ltp8800_dev *dev, uint16_t cmd);
+
+/* Perform a PMBus read_byte operation */
+int ltp8800_read_byte(struct ltp8800_dev *dev, uint16_t cmd, uint8_t *data);
+
+/* Perform a PMBus write_byte operation */
+int ltp8800_write_byte(struct ltp8800_dev *dev, uint16_t cmd, uint8_t value);
+
+/* Perform a PMBus read_word operation */
+int ltp8800_read_word(struct ltp8800_dev *dev, uint16_t cmd, uint16_t *word);
+
+/* Perform a PMBus write_word operation */
+int ltp8800_write_word(struct ltp8800_dev *dev, uint16_t cmd, uint16_t word);
+
+/* Perform a PMBus read_word operation then perform conversion*/
+int ltp8800_read_word_data(struct ltp8800_dev *dev, uint16_t cmd, int *data);
+
+/* Perform conversion then perform a PMBus write_word operation */
+int ltp8800_write_word_data(struct ltp8800_dev *dev, uint16_t cmd, int data);
+
+/* Read a block of bytes */
+int ltp8800_read_block_data(struct ltp8800_dev *dev, uint16_t cmd,
+			    uint8_t *data, size_t nbytes);
+
+/* Read specific value type */
+int ltp8800_read_value(struct ltp8800_dev *dev,
+		       enum ltp8800_value_type value_type,
+		       int *value);
+
+/* Read status */
+int ltp8800_read_status(struct ltp8800_dev *dev,
+			enum ltp8800_status_type status_type,
+			struct ltp8800_status *status);
+
+/* Set VOUT command */
+int ltp8800_vout_value(struct ltp8800_dev *dev, int vout_command);
+
+/* Set gain settings */
+int ltp8800_vout_settings(struct ltp8800_dev *dev,
+			  enum ltp8800_vout_settings settings);
+
+/* Set VIN threshold when to start power conversion */
+int ltp8800_set_vin(struct ltp8800_dev *dev, int vin_on, int vin_off);
+
+/* Set fault/warning limit values */
+int ltp8800_set_fault_limit(struct ltp8800_dev *dev,
+			    enum ltp8800_limit_type limit,
+			    int limit_val);
+
+/* Enable/Disable multi-device synchronization */
+int ltp8800_sync_config(struct ltp8800_dev *dev, bool enable);
+
+/* Set PolyPhase order */
+int ltp8800_interleave_order(struct ltp8800_dev *dev, uint8_t order);
+
+/* Program loop compensation */
+int ltp8800_loop_compensation(struct ltp8800_dev *dev,
+			      uint8_t pole,
+			      uint8_t zero,
+			      uint8_t hf_gain,
+			      uint8_t lf_gain);
+
+/* Set device state */
+int ltp8800_set_device_state(struct ltp8800_dev *dev, bool state);
+
+/* Store user settings to EEPROM */
+int ltp8800_store_user_settings(struct ltp8800_dev *dev);
+
+/* Restore user settings from EEPROM */
+int ltp8800_restore_user_settings(struct ltp8800_dev *dev);
+
+#endif /* __LTP8800_H__ */

--- a/projects/ltp8800/Makefile
+++ b/projects/ltp8800/Makefile
@@ -1,0 +1,9 @@
+# Select the example you want to enable by choosing y for enabling and n for disabling
+BASIC_EXAMPLE = n
+IIO_EXAMPLE = y
+
+include ../../tools/scripts/generic_variables.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/ltp8800/README.rst
+++ b/projects/ltp8800/README.rst
@@ -1,0 +1,197 @@
+Evaluating the LTP8800
+======================
+
+.. contents::
+	:depth: 3
+
+Supported Evaluation Boards
+---------------------------
+
+* `DC3190A-A <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/dc3190a-a.html>`_
+* `DC3190A-B <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/dc3190a-b.html>`_
+* `DC3190B-E <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/dc3190b-e.html>`_
+
+Overview
+--------
+
+The evaluation board allows the LTP8800 to be powered up to default settings and
+produces power based on configuration resistors without the need for any serial
+bus communication. The board by default is set to output voltages of 0.8V for
+LTP8800-1A and LTP8800-4A, 0.75V for LTP8800-2. Each output is rated at 150A/
+200A/135A for LTP8800-1A/4A/2, respectively.
+
+Full performance details are provided in the LTP8800 data sheet, which should
+be consulted in conjunction with user guide.
+
+Hardware Specifications
+-----------------------
+
+Power Supply Requirements
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For this specific project an external power supply with outputs 3.3V, 7V and 54V
+must be used to power up the demo board.
+
+**Pin Description**
+
+	+-----+----------+-------------------------------------------+
+	| Pin |   Name 	 | Description				     |
+	+-----+----------+-------------------------------------------+
+	| 1   | SMBALERT | PMBus SMBALERT Signal		     |
+	+-----+----------+-------------------------------------------+
+	| 2   | ISHARE   | Analog Current Sharing Input/Output	     |
+	+-----+----------+-------------------------------------------+
+	| 3   | CTRL	 | Hardware ON/OFF control		     |
+	+-----+----------+-------------------------------------------+
+	| 4   | ADD	 | Address select			     |
+	+-----+----------+-------------------------------------------+
+	| 5   | VS+	 | Non-inverting voltage sense input	     |
+	+-----+----------+-------------------------------------------+
+	| 6   | VS-	 | Inverting voltage sense input	     |
+	+-----+----------+-------------------------------------------+
+	| 7   | SYNC	 | Synchronization input signal		     |
+	+-----+----------+-------------------------------------------+
+	| 8   | 3V3	 | Internal module power supply (7V)	     |
+	+-----+----------+-------------------------------------------+
+	| 9   | GND	 | Connect to Ground			     |
+	+-----+----------+-------------------------------------------+
+	| 10  | 7V0	 | Internal module power supply (7V)	     |
+	+-----+----------+-------------------------------------------+
+	| 11  | VOUT	 | Output Voltage			     |
+	+-----+----------+-------------------------------------------+
+	| 12  | VOUT	 | Output Voltage			     |
+	+-----+----------+-------------------------------------------+
+	| 13  | VOUT	 | Output Voltage			     |
+	+-----+----------+-------------------------------------------+
+	| 14  | GND	 | Ground				     |
+	+-----+----------+-------------------------------------------+
+	| 15  | GND	 | Ground				     |
+	+-----+----------+-------------------------------------------+
+	| 16  | VOUT	 | Output Voltage			     |
+	+-----+----------+-------------------------------------------+
+	| 17  | VOUT	 | Output Voltage			     |
+	+-----+----------+-------------------------------------------+
+	| 18  | VOUT	 | Output Voltage			     |
+	+-----+----------+-------------------------------------------+
+	| 19  | GND	 | Ground				     |
+	+-----+----------+-------------------------------------------+
+	| 20  | SCL	 | Serial Clock				     |
+	+-----+----------+-------------------------------------------+
+	| 21  | SDA	 | Serial Data				     |
+	+-----+----------+-------------------------------------------+
+	| 22  | VIN	 | Input Power Supply (45V to 65V)	     |
+	+-----+----------+-------------------------------------------+
+
+**Hardware Bringup**
+
+For reference, follow the Quick Start Procedure section of the corresponding
+demo board.
+`user guide <https://www.analog.com/media/en/technical-documentation/user-guides/dc3190a-a.pdf>`_.
+
+No-OS Build Setup
+-----------------
+
+Please see: https://wiki.analog.com/resources/no-os/build
+
+No-OS Supported Examples
+------------------------
+
+The initialization data used in the examples is taken out from:
+`Project Common Data Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ltp8800/src/common>`_
+
+The macros used in Common Data are defined in platform specific files found in:
+`Project Platform Configuration Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ltp8800/src/platform>`_
+
+Basic example
+^^^^^^^^^^^^^
+
+This is a simple example that initializes the LTP8800, and performs telemetry
+readings of the voltage, current and temperature of each output channel. Status
+bytes/words are also monitored in the example.
+
+In order to build the basic example make sure you have the following configuration in the Makefile
+`Makefile <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ltp8800/Makefile>`_
+
+.. code-block:: bash
+
+	# Select the example you want to enable by choosing y for enabling and n for disabling
+	BASIC_EXAMPLE = y
+	IIO_EXAMPLE = n
+
+IIO example
+^^^^^^^^^^^
+
+This project is actually a IIOD demo for DC3190A-A evaluation board.
+The project launches a IIOD server on the board so that the user may connect
+to it via an IIO client.
+
+If you are not familiar with ADI IIO Application, please take a look at:
+`IIO No-OS <https://wiki.analog.com/resources/tools-software/no-os-software/iio>`_
+
+If you are not familiar with ADI IIO-Oscilloscope Client, please take a look at:
+`IIO Oscilloscope <https://wiki.analog.com/resources/tools-software/linux-software/iio_oscilloscope>`_
+
+The No-OS IIO Application together with the No-OS IIO LTP8800 driver take care of
+all the back-end logic needed to setup the IIO server.
+
+This example initializes the IIO device and calls the IIO app as shown in:
+`IIO Example <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ltp8800/src/examples/iio_example>`_
+
+In order to build the IIO project make sure you have the following configuration in the
+`Makefile <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ltp8800/Makefile>`_
+
+.. code-block:: bash
+
+        # Select the example you want to enable by choosing y for enabling and n for disabling
+        BASIC_EXAMPLE = n
+        IIO__EXAMPLE = y
+
+No-OS Supported Platforms
+-------------------------
+
+Maxim Platform
+^^^^^^^^^^^^^^
+
+**Used hardware**
+
+* `DC3190A-A <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/dc3190a-a.html>`_
+* `MAX32666FTHR <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/max32666fthr.html>`_
+
+**Connections**:
+
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| DC3190A-A Pin Number	      |  Mnemonic  | Function					  | MAX32666FTHR Pin Number	|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 1			      | SMBALERT   | Do Not Connect				  | Do Not Connect	        |
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 2			      | ISHARE	   | Do Not Connect				  | Do Not Connect	        |
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 3			      | CTRL	   | Hardware ON/OFF control			  | P0_5/IO3			|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 7			      | SYNC	   | Do Not Connect				  | Do Not Connect		|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 8			      | 3V3	   | Power Supply (3V3)				  | 3V3 (optional, use external)|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 9			      | GND	   | Ground					  | GND				|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 10			      | BIAS	   | Connect to External Power Supply (7V0)	  | Do Not Connect		|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 11			      | VOUT	   | May connect to oscilloscope/load		  | Do Not Connect		|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 20			      | SCL	   | I2C Serial Clock				  | I2C0_SCL			|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 21			      | SDA	   | I2C Serial Data				  | I2C0_SDA			|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 22			      | VIN	   | Connect to External Power Supply (54V)	  | Do Not Connect		|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+
+**Build Command**
+
+.. code-block:: bash
+
+	# to delete current build
+	make reset
+	# to build the project
+	make PLATFORM=maxim TARGET=max32665
+	# to flash the code
+	make run

--- a/projects/ltp8800/builds.json
+++ b/projects/ltp8800/builds.json
@@ -1,0 +1,10 @@
+{
+	"maxim": {
+		"basic_example_max32666": {
+			"flags" : "BASIC_EXAMPLE=y IIO_EXAMPLE=n TARGET=max32665"
+		},
+		"iio_example_max32666": {
+			"flags" : "BASIC_EXAMPLE=n IIO_EXAMPLE=y TARGET=max32665"
+		}
+	}
+}

--- a/projects/ltp8800/src.mk
+++ b/projects/ltp8800/src.mk
@@ -1,0 +1,46 @@
+include $(PROJECT)/src/platform/$(PLATFORM)/platform_src.mk
+include $(PROJECT)/src/examples/examples_src.mk
+
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/main.c
+
+INCS += $(PROJECT)/src/common/common_data.h
+SRCS += $(PROJECT)/src/common/common_data.c
+	
+INCS += $(PROJECT)/src/platform/platform_includes.h
+
+INCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.h
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.c
+
+INCS += $(INCLUDE)/no_os_delay.h     		\
+		$(INCLUDE)/no_os_error.h     	\
+		$(INCLUDE)/no_os_list.h     	\
+		$(INCLUDE)/no_os_gpio.h      	\
+		$(INCLUDE)/no_os_dma.h      	\
+		$(INCLUDE)/no_os_print_log.h 	\
+		$(INCLUDE)/no_os_i2c.h       	\
+		$(INCLUDE)/no_os_irq.h		\
+		$(INCLUDE)/no_os_pwm.h       	\
+		$(INCLUDE)/no_os_rtc.h       	\
+		$(INCLUDE)/no_os_uart.h      	\
+		$(INCLUDE)/no_os_lf256fifo.h 	\
+		$(INCLUDE)/no_os_util.h 	\
+		$(INCLUDE)/no_os_units.h        \
+		$(INCLUDE)/no_os_alloc.h        \
+                $(INCLUDE)/no_os_mutex.h	\
+		$(INCLUDE)/no_os_crc8.h	
+
+SRCS += $(NO-OS)/util/no_os_lf256fifo.c 	\
+		$(DRIVERS)/api/no_os_i2c.c  	\
+		$(DRIVERS)/api/no_os_dma.c  	\
+		$(DRIVERS)/api/no_os_uart.c  	\
+		$(DRIVERS)/api/no_os_irq.c  	\
+		$(DRIVERS)/api/no_os_gpio.c  	\
+		$(DRIVERS)/api/no_os_pwm.c	\
+		$(NO-OS)/util/no_os_util.c	\
+		$(NO-OS)/util/no_os_list.c      \
+		$(NO-OS)/util/no_os_alloc.c 	\
+		$(NO-OS)/util/no_os_mutex.c	\
+		$(NO-OS)/util/no_os_crc8.c
+
+INCS += $(DRIVERS)/power/ltp8800/ltp8800.h
+SRCS += $(DRIVERS)/power/ltp8800/ltp8800.c

--- a/projects/ltp8800/src/common/common_data.c
+++ b/projects/ltp8800/src/common/common_data.c
@@ -1,0 +1,70 @@
+/***************************************************************************//**
+ *   @file   common_data.c
+ *   @brief  Defines common data to be used by ltp8800 examples.
+ *   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "common_data.h"
+
+struct no_os_uart_init_param ltp8800_uart_ip = {
+	.device_id = UART_DEVICE_ID,
+	.irq_id = UART_IRQ_ID,
+	.asynchronous_rx = true,
+	.baud_rate = UART_BAUDRATE,
+	.size = NO_OS_UART_CS_8,
+	.parity = NO_OS_UART_PAR_NO,
+	.stop = NO_OS_UART_STOP_1_BIT,
+	.platform_ops = UART_OPS,
+	.extra = UART_EXTRA,
+};
+
+struct no_os_i2c_init_param ltp8800_i2c_ip = {
+	.device_id = I2C_DEVICE_ID,
+	.max_speed_hz = 100000,
+	.platform_ops = I2C_OPS,
+	.slave_address = LTP8800_ADDRESS,
+	.extra = I2C_EXTRA,
+};
+
+struct no_os_gpio_init_param ltp8800_ctrl_gpio_ip = {
+	.port = CTRL_GPIO_PORT,
+	.number = CTRL_GPIO_NUMBER,
+	.pull = NO_OS_PULL_UP,
+	.platform_ops = CTRL_GPIO_OPS,
+	.extra = CTRL_GPIO_EXTRA,
+};
+
+struct ltp8800_init_param ltp8800_ip = {
+	.i2c_init = &ltp8800_i2c_ip,
+	.smbalert_param = NULL,
+	.ctrl_param = &ltp8800_ctrl_gpio_ip,
+	.ext_clk_param = NULL,
+	.external_clk_en = false,
+	.crc_en = true,
+};

--- a/projects/ltp8800/src/common/common_data.h
+++ b/projects/ltp8800/src/common/common_data.h
@@ -1,0 +1,46 @@
+/***************************************************************************//**
+ *   @file   common_data.h
+ *   @brief  Defines common data to be used by ltp8800 examples.
+ *   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __COMMON_DATA_H__
+#define __COMMON_DATA_H__
+
+#include "platform_includes.h"
+#include "no_os_i2c.h"
+#include "ltp8800.h"
+
+#define LTP8800_ADDRESS                         0x41
+
+extern struct no_os_uart_init_param ltp8800_uart_ip;
+extern struct no_os_i2c_init_param ltp8800_i2c_ip;
+extern struct ltp8800_init_param ltp8800_ip;
+
+#endif /* __COMMON_DATA_H__ */

--- a/projects/ltp8800/src/examples/basic/basic_example.c
+++ b/projects/ltp8800/src/examples/basic/basic_example.c
@@ -1,0 +1,123 @@
+/***************************************************************************//**
+ *   @file   basic_example.c
+ *   @brief  Basic example source file for ltp8800 project.
+ *   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "common_data.h"
+#include "basic_example.h"
+#include "no_os_delay.h"
+#include "no_os_print_log.h"
+#include "ltp8800.h"
+
+int basic_example_main()
+{
+	struct ltp8800_dev *dev;
+	struct ltp8800_status status;
+	int ret, vals[4];
+
+	pr_info("Running basic example.\n");
+
+	ret = ltp8800_init(&dev, &ltp8800_ip);
+	if (ret)
+		goto exit;
+
+	ret = ltp8800_vout_settings(dev, LTP8800_VOUT_SETTING_ADI_FACTORY);
+	if (ret)
+		goto exit;
+
+	ret = ltp8800_vout_value(dev, 800);
+	if (ret)
+		goto exit;
+
+	ret = ltp8800_set_vin(dev, 45000, 40000);
+	if (ret)
+		goto exit;
+
+	ret = ltp8800_set_fault_limit(dev, LTP8800_VIN_OV_FAULT_LIMIT_TYPE,
+				      65500);
+	if (ret)
+		goto exit;
+
+	ret = ltp8800_loop_compensation(dev, 120, 220, 95, 40);
+	if (ret)
+		goto exit;
+
+	while(1) {
+		ret = ltp8800_read_value(dev, LTP8800_VIN, &vals[0]);
+		if (ret)
+			goto exit;
+
+		ret = ltp8800_read_value(dev, LTP8800_VOUT, &vals[1]);
+		if (ret)
+			goto exit;
+
+		ret = ltp8800_read_value(dev, LTP8800_IOUT, &vals[2]);
+		if (ret)
+			goto exit;
+
+		ret = ltp8800_read_value(dev, LTP8800_FORWARD_DIODE_TEMP,
+					 &vals[3]);
+		if (ret)
+			goto exit;
+
+		ret = ltp8800_read_status(dev, LTP8800_STATUS_ALL_TYPE,
+					  &status);
+		if (status.vout) {
+			pr_debug("Status vout asserted.\n");
+		}
+		if (status.iout) {
+			pr_debug("Status iout asserted.\n");
+		}
+		if (status.input) {
+			pr_debug("Status input asserted.\n");
+		}
+		if (status.temp) {
+			pr_debug("Status temp asserted.\n");
+		}
+		if (status.cml) {
+			pr_debug("Status cml asserted.\n");
+		}
+		if (status.mfr_specific) {
+			pr_debug("Status mfr_specific asserted.\n");
+		}
+
+		pr_info("vin = %d mV | vout = %d mV | iout = %d mA | temp0 = %d C\n",
+			vals[0], vals[1], vals[2], vals[3] / 1000);
+
+		no_os_mdelay(500);
+	}
+
+exit:
+	pr_err("Error code: %d.\n", ret);
+	ltp8800_restore_user_settings(dev);
+	ltp8800_set_device_state(dev, LTP8800_STATE_OFF);
+	ltp8800_remove(dev);
+	return ret;
+}

--- a/projects/ltp8800/src/examples/basic/basic_example.h
+++ b/projects/ltp8800/src/examples/basic/basic_example.h
@@ -1,0 +1,38 @@
+/***************************************************************************//**
+ *   @file   basic_example.h
+ *   @brief  Basic example header file for ltp8800 project.
+ *   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __BASIC_EXAMPLE_H__
+#define __BASIC_EXAMPLE_H__
+
+int basic_example_main();
+
+#endif /* __BASIC_EXAMPLE_H__ */

--- a/projects/ltp8800/src/examples/examples_src.mk
+++ b/projects/ltp8800/src/examples/examples_src.mk
@@ -1,0 +1,28 @@
+ifeq (y,$(strip $(IIO_EXAMPLE)))
+IIOD=y
+CFLAGS += -DIIO_EXAMPLE=1
+SRCS += $(PROJECT)/src/examples/iio_example/iio_example.c
+INCS += $(PROJECT)/src/examples/iio_example/iio_example.h
+endif
+
+ifeq (y,$(strip $(BASIC_EXAMPLE)))
+CFLAGS += -DBASIC_EXAMPLE=1
+SRCS += $(PROJECT)/src/examples/basic/basic_example.c
+INCS += $(PROJECT)/src/examples/basic/basic_example.h
+endif
+
+ifeq (y, $(strip $(IIOD)))
+LIBRARIES += iio
+SRCS += $(NO-OS)/iio/iio_app/iio_app.c	\
+	$(DRIVERS)/power/ltp8800/iio_ltp8800.c	\
+	$(NO-OS)/iio/iio.c	\
+	$(NO-OS)/iio/iiod.c	\
+	$(NO-OS)/util/no_os_fifo.c
+
+INCS += $(NO-OS)/iio/iio_app/iio_app.h	\
+	$(DRIVERS)/power/ltp8800/iio_ltp8800.h	\
+	$(NO-OS)/iio/iio.h	\
+	$(NO-OS)/iio/iiod.h	\
+	$(NO-OS)/iio/iio_types.h	\
+	$(NO-OS)/include/no_os_fifo.h
+endif

--- a/projects/ltp8800/src/examples/iio_example/iio_example.c
+++ b/projects/ltp8800/src/examples/iio_example/iio_example.c
@@ -1,0 +1,81 @@
+/***************************************************************************//**
+ *   @file   iio_example.c
+ *   @brief  IIO example source file for ltp8800 project.
+ *   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "iio_example.h"
+#include "iio_ltp8800.h"
+#include "common_data.h"
+#include "no_os_print_log.h"
+#include "iio_app.h"
+
+int iio_example_main()
+{
+	int ret;
+
+	struct ltp8800_iio_desc *ltp8800_iio_desc;
+	struct ltp8800_iio_desc_init_param ltp8800_iio_ip = {
+		.ltp8800_init_param = &ltp8800_ip,
+	};
+
+	struct iio_app_desc *app;
+	struct iio_app_init_param app_init_param = { 0 };
+
+	ret = ltp8800_iio_init(&ltp8800_iio_desc, &ltp8800_iio_ip);
+	if (ret)
+		goto exit;
+
+	struct iio_app_device iio_devices[] = {
+		{
+			.name = "ltp8800",
+			.dev = ltp8800_iio_desc,
+			.dev_descriptor = ltp8800_iio_desc->iio_dev,
+		}
+	};
+
+	app_init_param.devices = iio_devices;
+	app_init_param.nb_devices = NO_OS_ARRAY_SIZE(iio_devices);
+	app_init_param.uart_init_params = ltp8800_uart_ip;
+
+	ret = iio_app_init(&app, app_init_param);
+	if (ret)
+		goto remove_iio_ltp8800;
+
+	ret = iio_app_run(app);
+
+	iio_app_remove(app);
+
+remove_iio_ltp8800:
+	ltp8800_iio_remove(ltp8800_iio_desc);
+exit:
+	if (ret)
+		pr_err("Error!\n");
+	return ret;
+}

--- a/projects/ltp8800/src/examples/iio_example/iio_example.h
+++ b/projects/ltp8800/src/examples/iio_example/iio_example.h
@@ -1,0 +1,38 @@
+/***************************************************************************//**
+ *   @file   iio_example.h
+ *   @brief  IIO example header file for ltp8800 project.
+ *   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __IIO_EXAMPLE_H__
+#define __IIO_EXAMPLE_H__
+
+int iio_example_main();
+
+#endif /* __IIO_EXAMPLE_H__ */

--- a/projects/ltp8800/src/platform/maxim/main.c
+++ b/projects/ltp8800/src/platform/maxim/main.c
@@ -1,0 +1,72 @@
+/***************************************************************************//**
+ *   @file   main.c
+ *   @brief  Main file for Maxim platform of ltp8800 project.
+ *   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "platform_includes.h"
+#include "common_data.h"
+#include "no_os_error.h"
+
+#ifdef BASIC_EXAMPLE
+#include "basic_example.h"
+#endif
+
+#ifdef IIO_EXAMPLE
+#include "iio_example.h"
+#endif
+
+int main()
+{
+	int ret = -EINVAL;
+
+#ifdef BASIC_EXAMPLE
+	struct no_os_uart_desc *uart_desc;
+
+	ret = no_os_uart_init(&uart_desc, &ltp8800_uart_ip);
+	if (ret)
+		return ret;
+
+	no_os_uart_stdio(uart_desc);
+	ret = basic_example_main();
+#endif
+
+#ifdef IIO_EXAMPLE
+	ret = iio_example_main();
+#endif
+
+#if (BASIC_EXAMPLE + IIO_EXAMPLE == 0)
+#error At least one example has to be selected using y value in Makefile.
+#elif (BASIC_EXAMPLE + IIO_EXAMPLE > 1)
+#error Selected example projects cannot be enabled at the same time. \
+Please enable only one example and re-build the project.
+#endif
+
+	return ret;
+}

--- a/projects/ltp8800/src/platform/maxim/parameters.c
+++ b/projects/ltp8800/src/platform/maxim/parameters.c
@@ -1,0 +1,45 @@
+/***************************************************************************//**
+ *   @file   parameters.c
+ *   @brief  Definition of Maxim platform data used by ltp8800 project.
+ *   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "parameters.h"
+
+struct max_uart_init_param ltp8800_uart_extra = {
+	.flow = UART_FLOW_DIS,
+};
+
+struct max_i2c_init_param ltp8800_i2c_extra = {
+	.vssel = MXC_GPIO_VSSEL_VDDIOH
+};
+
+struct max_gpio_init_param ltp8800_gpio_extra = {
+	.vssel = MXC_GPIO_VSSEL_VDDIOH
+};

--- a/projects/ltp8800/src/platform/maxim/parameters.h
+++ b/projects/ltp8800/src/platform/maxim/parameters.h
@@ -1,0 +1,65 @@
+/***************************************************************************//**
+ *   @file   parameters.h
+ *   @brief  Definition of Maxim platform data used by ltp8800 project.
+ *   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
+
+#include "maxim_irq.h"
+#include "maxim_i2c.h"
+#include "maxim_gpio.h"
+#include "maxim_uart.h"
+#include "maxim_uart_stdio.h"
+
+#ifdef IIO_SUPPORT
+#define INTC_DEVICE_ID		0
+#endif
+
+#define UART_DEVICE_ID		1
+#define UART_IRQ_ID		UART1_IRQn
+#define UART_BAUDRATE		115200
+#define	UART_OPS		&max_uart_ops
+#define UART_EXTRA		&ltp8800_uart_extra
+
+#define I2C_DEVICE_ID		0
+#define I2C_OPS			&max_i2c_ops
+#define I2C_EXTRA		&ltp8800_i2c_extra
+
+#define CTRL_GPIO_PORT		0
+#define CTRL_GPIO_NUMBER	5
+#define CTRL_GPIO_OPS		&max_gpio_ops
+#define CTRL_GPIO_EXTRA		&ltp8800_gpio_extra
+
+extern struct max_uart_init_param ltp8800_uart_extra;
+extern struct max_i2c_init_param ltp8800_i2c_extra;
+extern struct max_gpio_init_param ltp8800_gpio_extra;
+
+#endif /* __PARAMETERS_H__ */

--- a/projects/ltp8800/src/platform/maxim/platform_src.mk
+++ b/projects/ltp8800/src/platform/maxim/platform_src.mk
@@ -1,0 +1,16 @@
+INCS += $(PLATFORM_DRIVERS)/maxim_gpio.h      \
+        $(PLATFORM_DRIVERS)/maxim_gpio_irq.h  \
+        $(PLATFORM_DRIVERS)/maxim_irq.h       \
+        $(PLATFORM_DRIVERS)/../common/maxim_dma.h       \
+        $(PLATFORM_DRIVERS)/maxim_i2c.h       \
+        $(PLATFORM_DRIVERS)/maxim_uart.h      \
+        $(PLATFORM_DRIVERS)/maxim_uart_stdio.h
+
+SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c     \
+        $(PLATFORM_DRIVERS)/maxim_gpio.c      \
+        $(PLATFORM_DRIVERS)/maxim_gpio_irq.c  \
+        $(PLATFORM_DRIVERS)/maxim_irq.c       \
+        $(PLATFORM_DRIVERS)/../common/maxim_dma.c       \
+        $(PLATFORM_DRIVERS)/maxim_i2c.c       \
+        $(PLATFORM_DRIVERS)/maxim_uart.c      \
+        $(PLATFORM_DRIVERS)/maxim_uart_stdio.c

--- a/projects/ltp8800/src/platform/platform_includes.h
+++ b/projects/ltp8800/src/platform/platform_includes.h
@@ -1,0 +1,40 @@
+/***************************************************************************//**
+ *   @file   platform_includes.h
+ *   @brief  Includes for used platforms used by ltp8800 project.
+ *   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PLATFORM_INCLUDES_H__
+#define __PLATFORM_INCLUDES_H__
+
+#ifdef MAXIM_PLATFORM
+#include "maxim/parameters.h"
+#endif
+
+#endif /* __PLATFORM_INCLUDES_H__ */


### PR DESCRIPTION
## Add LTP8800 driver

The LTP8800 is a family of step-down μModule regulators that provides
microprocessor core voltage from 54V power distribution architecture. LTP8800
features remote configurability and telemetry monitoring of power management
parameters over PMBus—an open standard I2C-based digital interface protocol.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
