### PR TITLE
drivers: temperature: max31827: Add driver support for MAX31827/MAX31828/MAX31829

### DIFF
--- a/doc/sphinx/source/drivers/max31827.rst
+++ b/doc/sphinx/source/drivers/max31827.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../drivers/temperature/max31827/README.rst

--- a/doc/sphinx/source/drivers_doc.rst
+++ b/doc/sphinx/source/drivers_doc.rst
@@ -68,6 +68,13 @@ RF TRANSCEIVER
 
    drivers/madura
 
+TEMPERATURE
+==============
+.. toctree::
+   :maxdepth: 1
+
+   drivers/max31827
+
 POWER MANAGEMENT
 ================
 .. toctree::

--- a/doc/sphinx/source/projects/max31827-evkit.rst
+++ b/doc/sphinx/source/projects/max31827-evkit.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../projects/max31827-evkit/README.rst

--- a/doc/sphinx/source/projects_doc.rst
+++ b/doc/sphinx/source/projects_doc.rst
@@ -79,3 +79,10 @@ DAC
    :maxdepth: 1
 
    projects/max2201x
+
+TEMPERATURE
+==============
+.. toctree::
+   :maxdepth: 1
+
+   projects/max31827-evkit

--- a/drivers/temperature/max31827/README.rst
+++ b/drivers/temperature/max31827/README.rst
@@ -1,0 +1,181 @@
+MAX31827 no-OS driver
+=====================
+
+Supported Devices
+-----------------
+
+`MAX31827 <https://www.analog.com/MAX31827>`_
+
+`MAX31828 <https://www.analog.com/MAX31828>`_
+
+`MAX31829 <https://www.analog.com/MAX31829>`_
+
+Overview
+--------
+
+The MAX31827 is a ±1°C accuracy from -40°C to +125°C (12 bits) local temperature
+switch and sensor with I2C/SMBus interface. The combination of small 6-bump
+wafer-level package (WLP) and high accuracy makes this temperature sensor/switch
+ideal for a wide range of applications. It can be used as a temperature switch
+with preconfigured thresholds and/or as a temperature sensor with I2C interface.
+When the part operates as an independent temperature switch, the I2C interface
+doesn't have to be used. This enables use of the part in systems that require
+thermal protection implemented in hardware, without the need for reconfiguration
+or use of software/firmware during normal operation.
+
+Applications
+------------
+
+MAX31827
+--------
+
+* Battery-Powered Equipment 
+* Handheld Electronics 
+* Data Communications Equipment 
+* Servers 
+* Industrial Equipment 
+
+MAX31827 Device Configuration
+-----------------------------
+
+Driver Initialization
+---------------------
+
+In order to be able to use the device, you will have to provide the support
+for the communication protocol (I2C).
+
+The first API to be called is **max31827_init**. Make sure that it returns 0,
+which means that the driver was initialized correctly.
+
+Inside the **max31827_init** API, **max31827_init_client** API is called to
+setup the values inside the Configuration Register.
+
+MAX31827 Device Measurements
+----------------------------
+
+Temperature Data (Input)
+------------------------
+
+The data can be obtained by calling **max31827_read_temp_input** API. The
+temperature is in milli-degrees Celsius, with scaling already applied.
+
+Temperature Data (Thresholds and Hysteresis)
+--------------------------------------------
+
+The data can be obtained by calling **max31827_read_temp** API. The
+temperature is in milli-degrees Celsius, with scaling already applied.
+
+Shutdown Write
+--------------
+
+The **max31827_shutdown_write** API is used to write in certain registers that
+needs the device to be in shutdown mode.
+
+Before the Temperature Threshold Alarm, Alarm Hysteresis Threshold and
+Resolution bits from Configuration register are changed over I2C, the part must
+be in shutdown mode.
+
+Write Alarm Temperature Values
+------------------------------
+
+The **max31827_write_alarm_val** API is used to write the Temperature Threshold
+Alarm and Alarm Hysteresis Threshold temperature values.
+
+MAX31827 Driver Initialization Example
+--------------------------------------
+
+.. code-block:: bash
+
+	struct max31827_device *dev;
+
+	struct no_os_uart_init_param uip = {
+		.device_id = UART_DEVICE_ID,
+		.baud_rate = UART_BAUDRATE,
+		.size = NO_OS_UART_CS_8,
+		.parity = NO_OS_UART_PAR_NO,
+		.stop = NO_OS_UART_STOP_1_BIT,
+		.platform_ops = UART_OPS,
+		.extra = UART_EXTRA,
+	};
+
+	const struct no_os_i2c_init_param max31827_i2c_ip = {
+		.device_id = I2C_DEVICE_ID,
+		.max_speed_hz = 100000,
+		.slave_address = 0x42,
+		.platform_ops = I2C_OPS,
+		.extra = I2C_EXTRA,
+	};
+
+	struct max31827_init_param max31827_ip = {
+		.i2c_init_param = max31827_i2c_ip,
+		.comp_int = 0,
+		.alarm_pol = 0,
+		.fault_q = 1,
+		.timeout_enable = 0,
+	};
+
+	ret = max31827_init(&dev, &max31827_ip);
+	if (ret)
+		goto error;
+
+MAX31827 no-OS IIO support
+--------------------------
+
+The MAX31827 IIO driver comes on top of the MAX31827 driver and offers support
+for interfacing IIO clients through libiio.
+
+MAX31827 IIO Device Configuration
+---------------------------------
+
+Global Attributes
+-----------------
+
+The device has a total of 10 global attributes:
+
+* ``temp_enable - enables or disables automatic mode``
+* ``temp_input - Temperature input value in millidegree Celsius``
+* ``temp_min - Minimum temperature threshold in millidegree Celsius``
+* ``temp_min_hyst - Minimum temperature hysteresis threshold in millidegree Celsius``
+* ``temp_min_alarm - Minimum temperature alarm state``
+* ``temp_max - Maximum temperature threshold in millidegree Celsius``
+* ``temp_max_hyst - Maximum temperature hysteresis threshold in millidegree Celsius``
+* ``temp_max_alarm - Maximum temperature alarm state``
+* ``temp_resolution - Temperature resolution in millidegree Celsius``
+* ``update_interval - Update interval in milliseconds``
+
+MAX31827 IIO Driver Initialization Example
+------------------------------------------
+
+.. code-block:: bash
+
+	int ret;
+
+	struct max31827_iio_device *max31827_iio_dev;
+	struct max31827_iio_init_param max31827_iio_ip = {
+		.max31827_init_param = &max31827_ip,
+	};
+
+	struct iio_app_desc *app;
+	struct iio_app_init_param app_init_param = {0};
+
+	ret = max31827_iio_init(&max31827_iio_dev, &max31827_iio_ip);
+	if (ret)
+		goto exit;
+
+	struct iio_app_device iio_devices[] = {
+		{
+			.name = "max31827",
+			.dev = max31827_iio_dev,
+			.dev_descriptor = max31827_iio_dev->iio_dev,
+		},
+	};
+
+	app_init_param.devices = iio_devices;
+	app_init_param.nb_devices = NO_OS_ARRAY_SIZE(iio_devices);
+	app_init_param.uart_init_params = uip;
+
+	ret = iio_app_init(&app, app_init_param);
+	if (ret)
+		goto remove_iio_max31827;
+
+	return iio_app_run(app);

--- a/drivers/temperature/max31827/iio_max31827.c
+++ b/drivers/temperature/max31827/iio_max31827.c
@@ -1,0 +1,394 @@
+/***************************************************************************//**
+ *   @file   iio_max31827.c
+ *   @brief  Implementation of IIO MAX31827 Driver.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <errno.h>
+#include "iio_max31827.h"
+#include "max31827.h"
+#include "no_os_alloc.h"
+#include "no_os_error.h"
+
+#define MAX31827_IIO_CH_ATTR_RW(_name, _priv)  \
+	{                                       \
+		.name = _name,                      \
+		.priv = _priv,                      \
+		.show = max31827_ch_attr_show,      \
+		.store = max31827_ch_attr_store,    \
+	}
+
+#define MAX31827_IIO_CH_ATTR_RO(_name, _priv)  \
+	{                                       \
+		.name = _name,                      \
+		.priv = _priv,                      \
+		.show = max31827_ch_attr_show,      \
+		.store = NULL,    \
+	}
+
+enum max31827_ch_attr_priv {
+	MAX31827_T_ENABLE,
+	MAX31827_T_INPUT,
+	MAX31827_T_MIN,
+	MAX31827_T_MIN_HYST,
+	MAX31827_T_MIN_ALARM,
+	MAX31827_T_MAX,
+	MAX31827_T_MAX_HYST,
+	MAX31827_T_MAX_ALARM,
+	MAX31827_T_RESOLUTION,
+	MAX31827_C_UPDATE_INTERVAL,
+};
+
+static int32_t max31827_iio_reg_read(struct max31827_iio_device *dev,
+				     uint32_t reg, uint32_t *readval)
+{
+	return max31827_reg_read(dev->dev, (uint8_t)reg, (uint16_t*)readval);
+}
+
+static int32_t max31827_iio_reg_write(struct max31827_iio_device *dev,
+				      uint32_t reg, uint32_t writeval)
+{
+	return max31827_reg_write(dev->dev, reg, writeval);
+}
+
+static int max31827_ch_attr_show(void *ddev, char *buf,
+				 uint32_t len,
+				 const struct iio_ch_info *channel,
+				 intptr_t priv)
+{
+	struct max31827_iio_device *dev = ddev;
+	int ret;
+	int32_t val;
+	uint16_t uval;
+
+	switch (priv) {
+	case MAX31827_T_ENABLE:
+		ret = max31827_reg_read(dev->dev, MAX31827_CONF_REG, &uval);
+		if (ret)
+			return ret;
+
+		val = !!no_os_field_get(MAX31827_CONF_1SHOT_MASK |
+					MAX31827_CONF_CNV_RATE_MASK, uval);
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	case MAX31827_T_INPUT:
+		ret = max31827_read_temp_input(dev->dev, &val);
+		if (ret)
+			return ret;
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	case MAX31827_T_MIN:
+		ret = max31827_read_temp(dev->dev, MAX31827_TL_REG, &val);
+		if (ret)
+			return ret;
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	case MAX31827_T_MIN_HYST:
+		ret = max31827_read_temp(dev->dev, MAX31827_TL_HYST_REG, &val);
+		if (ret)
+			return ret;
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	case MAX31827_T_MIN_ALARM:
+		ret = max31827_reg_read(dev->dev, MAX31827_CONF_REG, &uval);
+		if (ret)
+			return ret;
+
+		val = MAX31827_CONF_U_TEMP_STAT(uval);
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	case MAX31827_T_MAX:
+		ret = max31827_read_temp(dev->dev, MAX31827_TH_REG, &val);
+		if (ret)
+			return ret;
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	case MAX31827_T_MAX_HYST:
+		ret = max31827_read_temp(dev->dev, MAX31827_TH_HYST_REG, &val);
+		if (ret)
+			return ret;
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	case MAX31827_T_MAX_ALARM:
+		ret = max31827_reg_read(dev->dev, MAX31827_CONF_REG, &uval);
+		if (ret)
+			return ret;
+
+		val = MAX31827_CONF_O_TEMP_STAT(uval);
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	case MAX31827_T_RESOLUTION:
+		ret = max31827_reg_read(dev->dev, MAX31827_CONF_REG, &uval);
+		if (ret)
+			return ret;
+
+		val = max31827_resolutions[MAX31827_CONF_RESO(uval)];
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	case MAX31827_C_UPDATE_INTERVAL:
+		ret = max31827_reg_read(dev->dev, MAX31827_CONF_REG, &uval);
+		if (ret)
+			return ret;
+
+		val = max31827_conversions[MAX31827_CONF_CNV_RATE(uval)];
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	default:
+		return -EOPNOTSUPP;
+	}
+}
+
+static int max31827_ch_attr_store(void *ddev, char *buf,
+				  uint32_t len,
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
+{
+	struct max31827_iio_device *dev = ddev;
+	unsigned int idx;
+	int32_t val;
+	int ret;
+
+	switch (priv) {
+	case MAX31827_T_ENABLE:
+		ret = iio_parse_value(buf, IIO_VAL_INT, &val, NULL);
+		if (ret < 0)
+			return ret;
+
+		if (val >> 1)
+			return -EOPNOTSUPP;
+
+		dev->dev->enable = val;
+
+		ret = max31827_reg_update_bits(dev->dev,
+					       MAX31827_CONF_REG,
+					       MAX31827_CONF_1SHOT_MASK |
+					       MAX31827_CONF_CNV_RATE_MASK,
+					       MAX31827_DEVICE_ENABLE(val));
+
+		break;
+	case MAX31827_T_MIN:
+		ret = iio_parse_value(buf, IIO_VAL_INT, &val, NULL);
+		if (ret < 0)
+			return ret;
+
+		ret = max31827_write_alarm_val(dev->dev, MAX31827_TL_REG, val);
+
+		break;
+	case MAX31827_T_MIN_HYST:
+		ret = iio_parse_value(buf, IIO_VAL_INT, &val, NULL);
+		if (ret < 0)
+			return ret;
+
+		ret = max31827_write_alarm_val(dev->dev, MAX31827_TL_HYST_REG,
+					       val);
+
+		break;
+	case MAX31827_T_MAX:
+		ret = iio_parse_value(buf, IIO_VAL_INT, &val, NULL);
+		if (ret < 0)
+			return ret;
+
+		ret = max31827_write_alarm_val(dev->dev, MAX31827_TH_REG, val);
+
+		break;
+	case MAX31827_T_MAX_HYST:
+		ret = iio_parse_value(buf, IIO_VAL_INT, &val, NULL);
+		if (ret < 0)
+			return ret;
+
+		ret = max31827_write_alarm_val(dev->dev, MAX31827_TH_HYST_REG,
+					       val);
+
+		break;
+	case MAX31827_T_RESOLUTION:
+		idx = MAX31827_RES_8_BIT;
+
+		ret = iio_parse_value(buf, IIO_VAL_INT, &val, NULL);
+		if (ret < 0)
+			return ret;
+
+		/**
+		 * Convert the desired resolution into register
+		 * bits. idx is already initialized with 0.
+		 *
+		 * This was inspired by lm73 driver.
+		 */
+		while (idx < NO_OS_ARRAY_SIZE(max31827_resolutions) &&
+		       val < max31827_resolutions[idx])
+			idx++;
+
+		if (idx == NO_OS_ARRAY_SIZE(max31827_resolutions))
+			idx--;
+
+		ret = max31827_shutdown_write(dev->dev, MAX31827_CONF_REG,
+					      MAX31827_CONF_RESO_MASK, idx);
+
+		if (!ret)
+			dev->dev->resolution = idx;
+
+		break;
+	case MAX31827_C_UPDATE_INTERVAL:
+		idx = MAX31827_CNV_1_DIV_64_HZ;
+
+		ret = iio_parse_value(buf, IIO_VAL_INT, &val, NULL);
+		if (ret < 0)
+			return ret;
+
+		if (!dev->dev->enable)
+			return -EOPNOTSUPP;
+
+		/**
+		 * Convert the desired conversion rate into register
+		 * bits. idx is already initialized with 1.
+		 *
+		 * This was inspired by lm73 driver.
+		 */
+		while (idx < NO_OS_ARRAY_SIZE(max31827_conversions) &&
+		       val < max31827_conversions[idx])
+			idx++;
+
+		if (idx == NO_OS_ARRAY_SIZE(max31827_conversions))
+			idx--;
+
+		ret = max31827_reg_update_bits(dev->dev, MAX31827_CONF_REG,
+					       MAX31827_CONF_CNV_RATE_MASK,
+					       idx);
+		if (!ret)
+			dev->dev->update_interval = val;
+
+		break;
+	default:
+		return -EOPNOTSUPP;
+	}
+
+	if (ret)
+		return ret;
+
+	return len;
+}
+
+static struct iio_attribute max31827_iio_ch_attrs[] = {
+	MAX31827_IIO_CH_ATTR_RW("temp_enable", MAX31827_T_ENABLE),
+	MAX31827_IIO_CH_ATTR_RO("temp_input", MAX31827_T_INPUT),
+	MAX31827_IIO_CH_ATTR_RW("temp_min", MAX31827_T_MIN),
+	MAX31827_IIO_CH_ATTR_RW("temp_min_hyst", MAX31827_T_MIN_HYST),
+	MAX31827_IIO_CH_ATTR_RO("temp_min_alarm", MAX31827_T_MIN_ALARM),
+	MAX31827_IIO_CH_ATTR_RW("temp_max", MAX31827_T_MAX),
+	MAX31827_IIO_CH_ATTR_RW("temp_max_hyst", MAX31827_T_MAX_HYST),
+	MAX31827_IIO_CH_ATTR_RO("temp_max_alarm", MAX31827_T_MAX_ALARM),
+	MAX31827_IIO_CH_ATTR_RW("temp_resolution", MAX31827_T_RESOLUTION),
+	MAX31827_IIO_CH_ATTR_RW("update_interval", MAX31827_C_UPDATE_INTERVAL),
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct scan_type max31827_iio_scan_type = {
+	.sign = 's',
+	.realbits = 13,
+	.storagebits = 16,
+	.shift = 0,
+	.is_big_endian = false,
+};
+
+static struct iio_channel max31827_channels[] = {
+	{
+		.name = "temp",
+		.ch_type = IIO_TEMP,
+		.channel = 0,
+		.address = 0,
+		.scan_index = 0,
+		.scan_type = &max31827_iio_scan_type,
+		.attributes = max31827_iio_ch_attrs,
+		.ch_out = false,
+	}
+};
+
+static struct iio_device max31827_iio_dev = {
+	.num_ch = NO_OS_ARRAY_SIZE(max31827_channels),
+	.channels = max31827_channels,
+	.debug_reg_read = (int32_t (*)()) max31827_iio_reg_read,
+	.debug_reg_write = (int32_t (*)()) max31827_iio_reg_write,
+	.attributes = max31827_iio_ch_attrs,
+};
+
+/**
+ * @brief Initializes the MAX31827 IIO driver
+ * @param iio_device - The iio device structure.
+ * @param iio_init_param - Parameters for the initialization of iio_dev
+ * @return 0 in case of success, errno errors otherwise
+ */
+int max31827_iio_init(struct max31827_iio_device **iio_device,
+		      struct max31827_iio_init_param *iio_init_param)
+{
+	struct max31827_iio_device *iio_device_temp;
+	int ret;
+
+	if (!iio_init_param || !iio_init_param->init_param)
+		return -EINVAL;
+
+	iio_device_temp = no_os_calloc(1, sizeof(*iio_device_temp));
+	if (!iio_device_temp)
+		return -ENOMEM;
+
+	ret = max31827_init(&iio_device_temp->dev, iio_init_param->init_param);
+	if (ret) {
+		no_os_free(iio_device_temp);
+		return ret;
+	}
+
+	iio_device_temp->iio_dev = &max31827_iio_dev;
+
+	*iio_device = iio_device_temp;
+
+	return 0;
+}
+
+/**
+ * @brief Free resources allocated by the init function
+ * @param iio_device - The iio device structure.
+ * @return 0 in case of success, errno errors otherwise
+ */
+int max31827_iio_remove(struct max31827_iio_device *iio_device)
+{
+	int ret;
+
+	ret = max31827_remove(iio_device->dev);
+	if (ret)
+		return ret;
+
+	no_os_free(iio_device);
+
+	return 0;
+}

--- a/drivers/temperature/max31827/iio_max31827.h
+++ b/drivers/temperature/max31827/iio_max31827.h
@@ -1,0 +1,73 @@
+/***************************************************************************//**
+ *   @file   iio_max31827.h
+ *   @brief  Implementation of IIO MAX31827 Driver.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef __IIO_MAX31827_H__
+#define __IIO_MAX31827_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include "iio.h"
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+
+struct max31827_iio_device {
+	struct max31827_device *dev;
+	struct iio_device *iio_dev;
+	uint32_t active_channels;
+	uint8_t no_active_channels;
+};
+
+struct max31827_iio_init_param {
+	struct max31827_init_param *init_param;
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+int max31827_iio_init(struct max31827_iio_device **iio_device,
+		      struct max31827_iio_init_param *iio_init_param);
+
+int max31827_iio_remove(struct max31827_iio_device *iio_device);
+
+#endif	/* __IIO_MAX31827_H__ */

--- a/drivers/temperature/max31827/max31827.c
+++ b/drivers/temperature/max31827/max31827.c
@@ -1,0 +1,381 @@
+/***************************************************************************//**
+ *   @file   max31827.c
+ *   @brief  Implementation of MAX31827 Driver.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include "max31827.h"
+#include "no_os_alloc.h"
+#include "no_os_delay.h"
+#include "no_os_error.h"
+#include "no_os_i2c.h"
+#include "no_os_print_log.h"
+#include "no_os_units.h"
+#include "no_os_util.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+/**
+ * @brief MAX31827 conversion period in ms
+ */
+const uint16_t max31827_conversions[] = {
+	[MAX31827_CNV_1_DIV_64_HZ] = 64000,
+	[MAX31827_CNV_1_DIV_32_HZ] = 32000,
+	[MAX31827_CNV_1_DIV_16_HZ] = 16000,
+	[MAX31827_CNV_1_DIV_4_HZ] = 4000,
+	[MAX31827_CNV_1_HZ] = 1000,
+	[MAX31827_CNV_4_HZ] = 250,
+	[MAX31827_CNV_8_HZ] = 125,
+};
+
+/**
+ * @brief MAX31827 temperature resolution
+ */
+const uint16_t max31827_resolutions[] = {
+	[MAX31827_RES_8_BIT] = 1000,
+	[MAX31827_RES_9_BIT] = 500,
+	[MAX31827_RES_10_BIT] = 250,
+	[MAX31827_RES_12_BIT] = 62,
+};
+
+/**
+ * @brief MAX31827 temperature conversion times in us
+ */
+const int max31827_conv_times[] = {
+	[MAX31827_RES_8_BIT] = 8750,
+	[MAX31827_RES_9_BIT] = 17500,
+	[MAX31827_RES_10_BIT] = 35000,
+	[MAX31827_RES_12_BIT] = 140000,
+};
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+/******************************************************************************/
+
+/**
+ * @brief Read a register value
+ * @param dev - MAX31827 descriptor
+ * @param addr - register address
+ * @param val - register value
+ * @return 0 in case of success, negative error code otherwise
+ */
+int max31827_reg_read(struct max31827_device *dev, uint8_t addr, uint16_t *val)
+{
+	int ret;
+	uint8_t uval[2];
+
+	ret = no_os_i2c_write(dev->i2c_desc, &addr, 1, 0);
+	if (ret)
+		return ret;
+
+	ret = no_os_i2c_read(dev->i2c_desc, uval, 2, 1);
+	if (ret)
+		return ret;
+
+	*val = no_os_get_unaligned_be16(uval);
+
+	return 0;
+}
+
+/**
+ * @brief Write a register value
+ * @param dev - MAX31827 descriptor
+ * @param addr - register address
+ * @param val - register value
+ * @return 0 in case of success, negative error code otherwise
+ */
+int max31827_reg_write(struct max31827_device *dev, uint8_t addr, uint16_t val)
+{
+	uint8_t buff[3] = {addr, val >> 8, val & 0xFF};
+
+	return no_os_i2c_write(dev->i2c_desc, buff, NO_OS_ARRAY_SIZE(buff), 1);
+}
+
+/**
+ * @brief Read-modify-write operation
+ * @param dev - MAX31827 descriptor
+ * @param addr - register address
+ * @param mask - Mask for specific register bits to be updated
+ * @param val - register value
+ * @return 0 in case of success, negative error code otherwise
+ */
+int max31827_reg_update_bits(struct max31827_device *dev, uint8_t addr,
+			     uint16_t mask, uint16_t val)
+{
+	int ret;
+	uint16_t regval;
+
+	ret = max31827_reg_read(dev, addr, &regval);
+	if (ret)
+		return ret;
+
+	regval &= ~mask;
+	regval |= no_os_field_prep(mask, val);
+
+	return max31827_reg_write(dev, addr, regval);
+}
+
+/**
+ * @brief Device and comm init function
+ * @param dev - MAX31827 descriptor to be initialized
+ * @param init_param - Init parameter for descriptor
+ * @return 0 in case of success, errno errors otherwise
+ */
+int max31827_init(struct max31827_device **dev,
+		  struct max31827_init_param *init_param)
+{
+	struct max31827_device *temp_dev;
+	int ret;
+
+	temp_dev = no_os_calloc(1, sizeof(*temp_dev));
+	if (!temp_dev)
+		return -ENOMEM;
+
+	ret = no_os_i2c_init(&temp_dev->i2c_desc, &init_param->i2c_init_param);
+	if (ret)
+		goto free_dev;
+
+	temp_dev->enable = true;
+	temp_dev->resolution = MAX31827_RES_12_BIT;
+	temp_dev->update_interval = max31827_conversions[MAX31827_CNV_1_HZ];
+
+	ret = max31827_init_client(temp_dev, init_param);
+	if (ret)
+		goto remove_i2c;
+
+	*dev = temp_dev;
+
+	return 0;
+
+remove_i2c:
+	ret = no_os_i2c_remove(temp_dev->i2c_desc);
+	if (ret)
+		pr_err("Failed to remove I2C descriptor\r\n");
+
+free_dev:
+	no_os_free(temp_dev);
+
+	return ret;
+}
+
+/**
+ * @brief Free resources allocated by the init function
+ * @param dev - MAX31827 descriptor
+ * @return 0 in case of success, errno errors otherwise
+ */
+int max31827_remove(struct max31827_device *dev)
+{
+	int ret;
+
+	if (!dev)
+		return -ENODEV;
+
+	ret = no_os_i2c_remove(dev->i2c_desc);
+	if (ret)
+		return ret;
+
+	no_os_free(dev);
+
+	return 0;
+}
+
+/**
+ * @brief Initialize MAX31827 device setup
+ * @param dev - MAX31827 descriptor to be initialized
+ * @param init_param - Init parameter for descriptor
+ * @return 0 in case of success, errno errors otherwise
+ */
+int max31827_init_client(struct max31827_device *dev,
+			 struct max31827_init_param *init_param)
+{
+	unsigned int res = 0;
+	uint32_t lsb_idx;
+
+	res |= MAX31827_DEVICE_ENABLE(1);
+
+	res |= MAX31827_CONF_RESO_MASK;
+
+	res |= no_os_field_prep(MAX31827_CONF_COMP_INT_MASK,
+				init_param->comp_int);
+
+	res |= no_os_field_prep(MAX31827_CONF_TIMEOUT_MASK,
+				!init_param->timeout_enable);
+
+	res |= no_os_field_prep(MAX31827_CONF_ALRM_POL_MASK,
+				init_param->alarm_pol);
+
+	if (init_param->fault_q)
+		lsb_idx = no_os_find_first_set_bit(init_param->fault_q);
+
+	if (no_os_hweight32(init_param->fault_q) != 1 || lsb_idx > 3) {
+		pr_err("Fault queue should be one of these: 1, 2, 4, 8\r\n");
+		return -EINVAL;
+	}
+
+	res |= no_os_field_prep(MAX31827_CONF_FLT_Q_MASK, lsb_idx);
+
+	return max31827_reg_write(dev, MAX31827_CONF_REG, res);
+}
+
+/**
+ * @brief Read a temperature from a register
+ * @param dev - MAX31827 descriptor
+ * @param addr - register address
+ * @param val - temperature value
+ * @return 0 in case of success, negative error code otherwise
+ */
+int max31827_read_temp(struct max31827_device *dev, uint8_t addr, int32_t *val)
+{
+	int ret;
+	uint16_t uval;
+	int32_t data;
+
+	ret = max31827_reg_read(dev, addr, &uval);
+	if (ret)
+		return ret;
+
+	data = (no_os_sign_extend32(uval, 15) * MILLI);
+
+	*val = data >> 4;
+
+	return 0;
+}
+
+/**
+ * @brief Read input temperature
+ * @param dev - MAX31827 descriptor
+ * @param val - temperature value
+ * @return 0 in case of success, negative error code otherwise
+ */
+int max31827_read_temp_input(struct max31827_device *dev, int32_t *val)
+{
+	int ret;
+
+	if (!dev->enable) {
+		ret = max31827_reg_update_bits(dev, MAX31827_CONF_REG,
+					       MAX31827_CONF_1SHOT_MASK, 1);
+		if (ret)
+			return ret;
+
+		no_os_udelay(max31827_conv_times[dev->resolution]);
+	}
+
+	/**
+	 * For 12-bit resolution the conversion time is 140 ms,
+	 * thus an additional 15 ms is needed to complete the
+	 * conversion: 125 ms + 15 ms = 140 ms
+	 */
+	if (dev->resolution == MAX31827_RES_12_BIT &&
+	    dev->update_interval == max31827_conversions[MAX31827_CNV_8_HZ])
+		no_os_udelay(15000);
+
+	return max31827_read_temp(dev, MAX31827_T_REG, val);
+}
+
+/**
+ * @brief Shutdown then write register value
+ * @param dev - MAX31827 descriptor
+ * @param reg - register address
+ * @param mask - Mask for specific register bits to be updated
+ * @param val - register value (requires prior bit shifting)
+ * @return 0 in case of success, negative error code otherwise
+ */
+int max31827_shutdown_write(struct max31827_device *dev, uint8_t reg,
+			    uint16_t mask, uint16_t val)
+{
+	uint16_t cfg;
+	uint16_t cnv_rate;
+	int ret;
+
+	/**
+	 * Before the Temperature Threshold Alarm, Alarm Hysteresis Threshold
+	 * and Resolution bits from Configuration register are changed over I2C,
+	 * the part must be in shutdown mode.
+	 */
+	if (!dev->enable) {
+		if (!mask)
+			return max31827_reg_write(dev, reg, val);
+		else
+			return max31827_reg_update_bits(dev, reg, mask, val);
+	}
+
+	ret = max31827_reg_read(dev, MAX31827_CONF_REG, &cfg);
+	if (ret)
+		return ret;
+
+	cnv_rate = no_os_field_prep(MAX31827_CONF_CNV_RATE_MASK, cfg);
+	cfg = cfg & ~(MAX31827_CONF_1SHOT_MASK | MAX31827_CONF_CNV_RATE_MASK);
+	ret = max31827_reg_write(dev, MAX31827_CONF_REG, cfg);
+	if (ret)
+		return ret;
+
+	if (!mask)
+		ret = max31827_reg_write(dev, reg, val);
+	else
+		ret = max31827_reg_update_bits(dev, reg, mask, val);
+	if (ret)
+		return ret;
+
+	return max31827_reg_update_bits(dev, MAX31827_CONF_REG,
+					MAX31827_CONF_CNV_RATE_MASK, cnv_rate);
+}
+
+/**
+ * @brief Write the alarm value to the specified register
+ * @param dev - MAX31827 descriptor
+ * @param reg - register address
+ * @param val - temperature value
+ * @return 0 in case of success, negative error code otherwise
+ */
+int max31827_write_alarm_val(struct max31827_device *dev, unsigned int reg,
+			     int32_t val)
+{
+	int32_t data;
+	bool sign = (val < 0);
+
+	data = sign ? -val : val;
+
+	data = ((data << 4) / MILLI) * (sign ? -1 : 1);
+
+	return max31827_shutdown_write(dev, reg, 0, data);
+}

--- a/drivers/temperature/max31827/max31827.h
+++ b/drivers/temperature/max31827/max31827.h
@@ -1,0 +1,184 @@
+/***************************************************************************//**
+ *   @file   max31827.h
+ *   @brief  Implementation of MAX31827 Driver.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef __MAX31827_H__
+#define __MAX31827_H__
+
+#include "no_os_i2c.h"
+#include "no_os_util.h"
+
+#define MAX31827_T_REG	0x0
+#define MAX31827_CONF_REG	0x2
+#define MAX31827_TH_REG	0x4
+#define MAX31827_TL_REG 0x6
+#define MAX31827_TH_HYST_REG	0x8
+#define MAX31827_TL_HYST_REG	0xA
+
+#define MAX31827_CONF_1SHOT_MASK	NO_OS_BIT(0)
+#define MAX31827_CONF_CNV_RATE_MASK	NO_OS_GENMASK(3, 1)
+#define MAX31827_CONF_PEC_EN_MASK	NO_OS_BIT(4)
+#define MAX31827_CONF_TIMEOUT_MASK	NO_OS_BIT(5)
+#define MAX31827_CONF_RESO_MASK	NO_OS_GENMASK(7, 6)
+#define MAX31827_CONF_ALRM_POL_MASK	NO_OS_BIT(8)
+#define MAX31827_CONF_COMP_INT_MASK	NO_OS_BIT(9)
+#define MAX31827_CONF_FLT_Q_MASK	NO_OS_GENMASK(11, 10)
+#define MAX31827_CONF_U_TEMP_STAT_MASK	NO_OS_BIT(14)
+#define MAX31827_CONF_O_TEMP_STAT_MASK	NO_OS_BIT(15)
+
+#define MAX31827_CONF_CNV_RATE(x) \
+	no_os_field_get(MAX31827_CONF_CNV_RATE_MASK, x)
+#define MAX31827_CONF_RESO(x) \
+	no_os_field_get(MAX31827_CONF_RESO_MASK, x)
+#define MAX31827_CONF_U_TEMP_STAT(x) \
+	no_os_field_get(MAX31827_CONF_U_TEMP_STAT_MASK, x)
+#define MAX31827_CONF_O_TEMP_STAT(x) \
+	no_os_field_get(MAX31827_CONF_O_TEMP_STAT_MASK, x)
+
+#define MAX31827_ALRM_POL_LOW	0x0
+#define MAX31827_ALRM_POL_HIGH	0x1
+#define MAX31827_FLT_Q_1	0x0
+#define MAX31827_FLT_Q_4	0x2
+
+#define MAX31827_M_DGR_TO_16_BIT(x)	(((x) << 4) / 1000)
+#define MAX31827_DEVICE_ENABLE(x)	((x) ? 0xA : 0x0)
+
+/**
+ * @brief MAX31827 conversion rate
+ */
+enum max31827_cnv {
+	MAX31827_CNV_1_DIV_64_HZ = 1,
+	MAX31827_CNV_1_DIV_32_HZ,
+	MAX31827_CNV_1_DIV_16_HZ,
+	MAX31827_CNV_1_DIV_4_HZ,
+	MAX31827_CNV_1_HZ,
+	MAX31827_CNV_4_HZ,
+	MAX31827_CNV_8_HZ,
+};
+
+/**
+ * @brief MAX31827 temperature resolution
+ */
+enum max31827_resolution {
+	MAX31827_RES_8_BIT = 0,
+	MAX31827_RES_9_BIT,
+	MAX31827_RES_10_BIT,
+	MAX31827_RES_12_BIT,
+};
+
+/**
+ * @brief MAX31827 conversion period in ms
+ */
+extern const uint16_t max31827_conversions[8];
+
+/**
+ * @brief MAX31827 temperature resolution
+ */
+extern const uint16_t max31827_resolutions[4];
+
+/**
+ * @brief MAX31827 temperature conversion times in us
+ */
+extern const int max31827_conv_times[4];
+
+/**
+ * @brief MAX31827 descriptor
+ */
+struct max31827_device {
+	/** I2C Descriptor */
+	struct no_os_i2c_desc *i2c_desc;
+	/** Enables device */
+	bool enable;
+	/** Temperature resolution */
+	unsigned int resolution;
+	/** Conversion period */
+	unsigned int update_interval;
+};
+
+/**
+ * @brief MAX31827 init param
+ */
+struct max31827_init_param {
+	/** Host processor I2C configuration */
+	struct no_os_i2c_init_param i2c_init_param;
+	/** Alarm mode */
+	bool comp_int;
+	/** Alarm active state */
+	bool alarm_pol;
+	/** Fault queue length */
+	uint8_t fault_q;
+	/** Enables timeout */
+	bool timeout_enable;
+};
+
+/** Read a register value */
+int max31827_reg_read(struct max31827_device *dev, uint8_t addr, uint16_t *val);
+
+/** Write a register value */
+int max31827_reg_write(struct max31827_device *dev, uint8_t addr, uint16_t val);
+
+/** Read-modify-write operation */
+int max31827_reg_update_bits(struct max31827_device *dev, uint8_t addr,
+			     uint16_t mask, uint16_t val);
+
+/** Device and comm init function */
+int max31827_init(struct max31827_device **dev,
+		  struct max31827_init_param *init_param);
+
+/** Free resources allocated by the init function */
+int max31827_remove(struct max31827_device *dev);
+
+/** Initialize MAX31827 device setup */
+int max31827_init_client(struct max31827_device *dev,
+			 struct max31827_init_param *init_param);
+
+/** Read a temperature from a register */
+int max31827_read_temp(struct max31827_device *dev, uint8_t addr, int32_t *val);
+
+/** Read input temperature */
+int max31827_read_temp_input(struct max31827_device *dev, int32_t *val);
+
+/** Shutdown then write register value */
+int max31827_shutdown_write(struct max31827_device *dev, uint8_t reg,
+			    uint16_t mask, uint16_t val);
+
+/** Write the alarm value to the specified register */
+int max31827_write_alarm_val(struct max31827_device *dev, unsigned int reg,
+			     int32_t val);
+
+#endif	/* __MAX31827_H__ */

--- a/projects/max31827-evkit/Makefile
+++ b/projects/max31827-evkit/Makefile
@@ -1,0 +1,9 @@
+# Select the example you want to enable by choosing y for enabling and n for disabling
+BASIC_EXAMPLE = n
+IIO_EXAMPLE = y
+
+include ../../tools/scripts/generic_variables.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/max31827-evkit/README.rst
+++ b/projects/max31827-evkit/README.rst
@@ -1,0 +1,139 @@
+Evaluating the MAX31827
+=======================
+
+.. contents::
+	:depth: 3
+
+Supported Evaluation Boards
+---------------------------
+
+* `MAX31827EVKIT <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/max31827evkit.html>`_
+
+Overview
+--------
+
+The MAX31827 evaluation kit (EV kit) demonstrates the MAX31827 I2C temperature
+switch and sensor with hardware-selectable address and alarm. The MAX31827 EV
+kit comes with the 6-pin WLP MAX31827ANTABRPF+ installed.
+
+Hardware Specifications
+-----------------------
+
+Power Supply Requirments
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+For this specific project, the MAX31827EVKIT is powered by the 3V3 supply from
+the MAX32666FTHR.
+
+Board Connector and Jumper Settings
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Pin Description**
+
+	Please see the following table for the pin assignments:
+
+	+----------+-------------------------------------------+
+	| Name     | Description			       |
+	+----------+-------------------------------------------+
+	| VDD      | Connect to 3V3 supply		       |
+	+----------+-------------------------------------------+
+	| GND      | Connect to Ground			       |
+	+----------+-------------------------------------------+
+	| SCL      | Connect to I2C Clock (SCL)		       |
+	+----------+-------------------------------------------+
+	| SDA      | Connect to I2C Data (SDA)		       |
+	+----------+-------------------------------------------+
+
+No-OS Build Setup
+-----------------
+
+Please see: https://wiki.analog.com/resources/no-os/build
+
+No-OS Supported Examples
+------------------------
+
+The initialization data used in the examples is taken out from:
+`Project Common Data Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/max31827-evkit/src/common>`_
+
+The macros used in Common Data are defined in platform specific files found in:
+`Project Platform Configuration Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/max31827-evkit/src/platform>`_
+
+Basic example
+^^^^^^^^^^^^^
+
+This is a simple example that initializes the MAX31827 and reads input
+temperature periodically.
+
+In order to build the basic example make sure you have the following
+configuration in the
+`Makefile <https://github.com/analogdevicesinc/no-OS/tree/main/projects/max31827-evkit/Makefile>`_
+
+.. code-block:: bash
+
+	# Select the example you want to enable by choosing y for enabling and n for disabling
+	BASIC_EXAMPLE = y
+	IIO_EXAMPLE = n
+
+IIO example
+^^^^^^^^^^^
+
+This project is actually a IIOD demo for MAX31827EVKIT. The project launches a
+IIOD server on the board so that the user may connect to it via an IIO client.
+
+Using IIO-Oscilloscope, the user can configure the device.
+
+If you are not familiar with ADI IIO Application, please take a look at:
+`IIO No-OS <https://wiki.analog.com/resources/tools-software/no-os-software/iio>`_
+
+If you are not familiar with ADI IIO-Oscilloscope Client, please take a look at:
+`IIO Oscilloscope <https://wiki.analog.com/resources/tools-software/linux-software/iio_oscilloscope>`_
+
+The No-OS IIO Application together with the No-OS IIO MAX31827 driver take care
+of all the back-end logic needed to setup the IIO server.
+
+This example initializes the IIO device and calls the IIO app as shown in:
+`IIO Example <https://github.com/analogdevicesinc/no-OS/tree/main/projects/max31827-evkit/src/examples/iio_example>`_
+
+In order to build the IIO project make sure you have the following configuration
+in the
+`Makefile <https://github.com/analogdevicesinc/no-OS/tree/main/projects/max31827-evkit/Makefile>`_
+
+.. code-block:: bash
+
+        # Select the example you want to enable by choosing y for enabling and n for disabling
+        BASIC_EXAMPLE = n
+        IIO__EXAMPLE = y
+
+No-OS Supported Platforms
+-------------------------
+
+Maxim Platform
+^^^^^^^^^^^^^^
+
+**Used hardware**
+
+* `MAX31827EVKIT <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/max31827evkit.html>`_
+* `MAX32666FTHR <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/max32666fthr.html>`_
+
+**Connections**:
+
++-----------------------+-----------------------+------------------+
+| MAX31827EVKIT Pin	| Function		| MAX32666FTHR Pin |
++-----------------------+-----------------------+------------------+
+| VDD                   | VDD			| 3V3              |
++-----------------------+-----------------------+------------------+
+| SCL                   | I2C Clock (SCL)	| P0_6 (I2C0_SCL)  |
++-----------------------+-----------------------+------------------+
+| SDA                   | I2C Data (SDA)	| P0_7 (I2C0_SDA)  |
++-----------------------+-----------------------+------------------+
+| GND                   | Ground (GND) 		| GND              |
++-----------------------+-----------------------+------------------+
+
+**Build Command**
+
+.. code-block:: bash
+
+	# to delete current build
+	make PLATFORM=maxim TARGET=max32665 reset
+	# to build the project and flash the code
+	make PLATFORM=maxim TARGET=max32665 run

--- a/projects/max31827-evkit/builds.json
+++ b/projects/max31827-evkit/builds.json
@@ -1,0 +1,10 @@
+{
+    "maxim": {
+      "basic_example_max32665": {
+        "flags" : "BASIC_EXAMPLE=y IIO_EXAMPLE=n TARGET=max32665"
+      },
+      "iio_example_max32665": {
+        "flags" : "BASIC_EXAMPLE=n IIO_EXAMPLE=y TARGET=max32665"
+      }
+    }
+  }

--- a/projects/max31827-evkit/src.mk
+++ b/projects/max31827-evkit/src.mk
@@ -1,0 +1,41 @@
+include $(PROJECT)/src/platform/$(PLATFORM)/platform_src.mk
+include $(PROJECT)/src/examples/examples_src.mk
+
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/main.c
+
+INCS += $(PROJECT)/src/common/common_data.h
+SRCS += $(PROJECT)/src/common/common_data.c
+
+INCS += $(PROJECT)/src/platform/platform_includes.h
+
+INCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.h
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.c
+
+INCS += $(INCLUDE)/no_os_delay.h     \
+		$(INCLUDE)/no_os_error.h     \
+		$(INCLUDE)/no_os_gpio.h      \
+		$(INCLUDE)/no_os_print_log.h \
+		$(INCLUDE)/no_os_i2c.h       \
+		$(INCLUDE)/no_os_alloc.h       \
+		$(INCLUDE)/no_os_irq.h      \
+		$(INCLUDE)/no_os_list.h      \
+		$(INCLUDE)/no_os_dma.h      \
+		$(INCLUDE)/no_os_uart.h      \
+		$(INCLUDE)/no_os_lf256fifo.h \
+		$(INCLUDE)/no_os_util.h 	\
+		$(INCLUDE)/no_os_units.h	\
+		$(INCLUDE)/no_os_mutex.h
+
+SRCS += $(DRIVERS)/api/no_os_gpio.c \
+		$(NO-OS)/util/no_os_lf256fifo.c \
+		$(DRIVERS)/api/no_os_irq.c  \
+		$(DRIVERS)/api/no_os_i2c.c  \
+		$(DRIVERS)/api/no_os_uart.c \
+		$(DRIVERS)/api/no_os_dma.c \
+		$(NO-OS)/util/no_os_list.c \
+		$(NO-OS)/util/no_os_util.c \
+		$(NO-OS)/util/no_os_alloc.c \
+		$(NO-OS)/util/no_os_mutex.c
+
+INCS += $(DRIVERS)/temperature/max31827/max31827.h
+SRCS += $(DRIVERS)/temperature/max31827/max31827.c

--- a/projects/max31827-evkit/src/common/common_data.c
+++ b/projects/max31827-evkit/src/common/common_data.c
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ *   @file   common_data.c
+ *   @brief  Defines common data to be used by max31827 examples.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+#include "common_data.h"
+#include <stdbool.h>
+
+struct no_os_uart_init_param uip = {
+	.device_id = UART_DEVICE_ID,
+	.baud_rate = UART_BAUDRATE,
+	.size = NO_OS_UART_CS_8,
+	.parity = NO_OS_UART_PAR_NO,
+	.stop = NO_OS_UART_STOP_1_BIT,
+	.platform_ops = UART_OPS,
+	.extra = UART_EXTRA,
+};
+
+const struct no_os_i2c_init_param max31827_i2c_ip = {
+	.device_id = I2C_DEVICE_ID,
+	.max_speed_hz = 100000,
+	.slave_address = 0x42,
+	.platform_ops = I2C_OPS,
+	.extra = I2C_EXTRA,
+};
+
+struct max31827_init_param max31827_ip = {
+	.i2c_init_param = max31827_i2c_ip,
+	.comp_int = 0,
+	.alarm_pol = 0,
+	.fault_q = 1,
+	.timeout_enable = 0,
+};

--- a/projects/max31827-evkit/src/common/common_data.h
+++ b/projects/max31827-evkit/src/common/common_data.h
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ *   @file   common_data.h
+ *   @brief  Defines common data to be used by max31827 examples.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#ifndef __COMMON_DATA_H__
+#define __COMMON_DATA_H__
+
+#include "platform_includes.h"
+#include "max31827.h"
+#ifdef IIO_SUPPORT
+#include "iio_max31827.h"
+#endif
+
+extern struct no_os_uart_init_param uip;
+
+extern const struct no_os_i2c_init_param max31827_i2c_ip;
+extern struct max31827_init_param max31827_ip;
+
+#endif /* __COMMON_DATA_H__ */

--- a/projects/max31827-evkit/src/examples/basic/basic_example.c
+++ b/projects/max31827-evkit/src/examples/basic/basic_example.c
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ *   @file   basic_example.c
+ *   @brief  Basic example code for max31827 project
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+#include "basic_example.h"
+#include "common_data.h"
+#include "max31827.h"
+#include "no_os_delay.h"
+#include "no_os_print_log.h"
+#include "no_os_units.h"
+/*****************************************************************************
+ * @brief Basic example main execution.
+ *
+ * @return ret - Result of the example execution. If working correctly, will
+ *               execute continuously the while(1) loop and will not return.
+ *******************************************************************************/
+int basic_example_main()
+{
+	struct max31827_device *dev;
+	int ret;
+	int32_t val;
+	int idx;
+
+	pr_info("\r\nRunning MAX31827 Basic Example\r\n");
+
+	ret = max31827_init(&dev, &max31827_ip);
+	if (ret)
+		goto error;
+
+	while (1) {
+		ret = max31827_read_temp_input(dev, &val);
+		if (ret)
+			goto free_dev;
+
+		pr_info("Temperature: %d mC\r\n", val);
+
+		no_os_mdelay(1000);
+	}
+
+free_dev:
+	max31827_remove(dev);
+error:
+	pr_info("Error!\r\n");
+	return ret;
+}

--- a/projects/max31827-evkit/src/examples/basic/basic_example.h
+++ b/projects/max31827-evkit/src/examples/basic/basic_example.h
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ *   @file   basic_example.h
+ *   @brief  Basic example header for max31827 project
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#ifndef __BASIC_EXAMPLE_H__
+#define __BASIC_EXAMPLE_H__
+
+int basic_example_main();
+
+#endif /* __BASIC_EXAMPLE_H__ */

--- a/projects/max31827-evkit/src/examples/examples_src.mk
+++ b/projects/max31827-evkit/src/examples/examples_src.mk
@@ -1,0 +1,21 @@
+ifeq (y,$(strip $(IIO_EXAMPLE)))
+IIOD=y
+CFLAGS += -DIIO_EXAMPLE=1
+SRCS += $(PROJECT)/src/examples/iio_example/iio_example.c
+INCS += $(PROJECT)/src/examples/iio_example/iio_example.h
+endif
+
+ifeq (y,$(strip $(BASIC_EXAMPLE)))
+CFLAGS += -DBASIC_EXAMPLE=1
+SRCS += $(PROJECT)/src/examples/basic/basic_example.c
+INCS += $(PROJECT)/src/examples/basic/basic_example.h
+endif
+
+ifeq (y,$(strip $(IIOD)))
+SRC_DIRS += $(NO-OS)/iio/iio_app
+INCS += $(DRIVERS)/temperature/max31827/iio_max31827.h
+SRCS += $(DRIVERS)/temperature/max31827/iio_max31827.c
+
+INCS += $(INCLUDE)/no_os_list.h \
+		$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h
+endif

--- a/projects/max31827-evkit/src/examples/iio_example/iio_example.c
+++ b/projects/max31827-evkit/src/examples/iio_example/iio_example.c
@@ -1,0 +1,87 @@
+/********************************************************************************
+ *   @file   iio_example.c
+ *   @brief  IIO example code for the max31827 project
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+#include "iio_example.h"
+#include "common_data.h"
+#include "no_os_print_log.h"
+
+/*******************************************************************************
+ * @brief IIO example main execution.
+ *
+ * @return ret - Result of the example execution. If working correctly, will
+ *               execute continuously function iio_app_run and will not return.
+ *******************************************************************************/
+int iio_example_main()
+{
+	int ret;
+	struct max31827_iio_device *max31827_iio_dev;
+	struct max31827_iio_init_param max31827_iio_ip;
+	struct iio_app_desc *app;
+	struct iio_app_init_param app_init_param = {0};
+
+	max31827_iio_ip.init_param = &max31827_ip;
+	ret = max31827_iio_init(&max31827_iio_dev, &max31827_iio_ip);
+	if (ret)
+		return ret;
+
+	struct iio_app_device iio_devices[] = {
+		{
+			.name = "max31827",
+			.dev = max31827_iio_dev,
+			.dev_descriptor = max31827_iio_dev->iio_dev,
+		},
+	};
+
+	app_init_param.devices = iio_devices;
+	app_init_param.nb_devices = NO_OS_ARRAY_SIZE(iio_devices);
+	app_init_param.uart_init_params = uip;
+
+	ret = iio_app_init(&app, app_init_param);
+	if (ret)
+		goto error;
+
+	ret = iio_app_run(app);
+	if (ret)
+		pr_err("Error: iio_app_run: %d\r\n", ret);
+
+	iio_app_remove(app);
+error:
+	max31827_iio_remove(max31827_iio_dev);
+	return ret;
+}

--- a/projects/max31827-evkit/src/examples/iio_example/iio_example.h
+++ b/projects/max31827-evkit/src/examples/iio_example/iio_example.h
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ *   @file   iio_example.h
+ *   @brief  IIO example header for max31827 project
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#ifndef __IIO_EXAMPLE_H__
+#define __IIO_EXAMPLE_H__
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+int iio_example_main();
+
+#endif /* __IIO_EXAMPLE_H__ */

--- a/projects/max31827-evkit/src/platform/maxim/main.c
+++ b/projects/max31827-evkit/src/platform/maxim/main.c
@@ -1,0 +1,86 @@
+/********************************************************************************
+ *   @file   main.c
+ *   @brief  Main file for Maxim platform of max31827 project.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+#include "platform_includes.h"
+#include "common_data.h"
+
+#ifdef IIO_EXAMPLE
+#include "iio_example.h"
+#endif
+
+#ifdef BASIC_EXAMPLE
+#include "basic_example.h"
+#endif
+
+/*******************************************************************************
+ * @brief Main function execution for MAX31827 platform.
+ *
+ * @return ret - Result of the enabled examples execution.
+ *******************************************************************************/
+int main()
+{
+#ifdef BASIC_EXAMPLE
+	int ret;
+	struct no_os_uart_desc *uart;
+
+	ret = no_os_uart_init(&uart, &uip);
+	if (ret)
+		goto error;
+
+	no_os_uart_stdio(uart);
+	ret = basic_example_main();
+	if (ret)
+		goto error;
+#endif
+
+#ifdef IIO_EXAMPLE
+	return iio_example_main();
+#endif
+
+#if (IIO_EXAMPLE + BASIC_EXAMPLE != 1)
+#error Selected example projects cannot be enabled at the same time. \
+Please enable only one example and re-build the project.
+#endif
+
+#ifdef BASIC_EXAMPLE
+error:
+	no_os_uart_remove(uart);
+#endif
+	return 0;
+}

--- a/projects/max31827-evkit/src/platform/maxim/parameters.c
+++ b/projects/max31827-evkit/src/platform/maxim/parameters.c
@@ -1,0 +1,48 @@
+/********************************************************************************
+ *   @file   parameters.c
+ *   @brief  Definition of maxim platform data used by max31827 project.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#include "parameters.h"
+
+struct max_uart_init_param max_uart_extra = {
+	.flow = UART_FLOW_DIS,
+	.vssel = MXC_GPIO_VSSEL_VDDIOH
+};
+
+struct max_i2c_init_param max_i2c_extra = {
+	.vssel = MXC_GPIO_VSSEL_VDDIOH
+};

--- a/projects/max31827-evkit/src/platform/maxim/parameters.h
+++ b/projects/max31827-evkit/src/platform/maxim/parameters.h
@@ -1,0 +1,68 @@
+/********************************************************************************
+ *   @brief  Definitions specific to Maxim platform used by max31827 project.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
+
+#include "maxim_uart.h"
+#include "maxim_uart_stdio.h"
+#include "maxim_i2c.h"
+
+#ifdef IIO_SUPPORT
+#define INTC_DEVICE_ID	0
+#endif
+#define UART_IRQ_ID	UART1_IRQn
+#define UART_DEVICE_ID	1
+#define UART_BAUDRATE	115200
+#define UART_OPS	&max_uart_ops
+#define UART_EXTRA      &max_uart_extra
+
+#if (TARGET_NUM == 32650) || (TARGET_NUM == 78000)
+#define I2C_DEVICE_ID    1
+#elif (TARGET_NUM == 32655)
+#define I2C_DEVICE_ID    2
+#elif (TARGET_NUM == 32665) || (TARGET_NUM == 32660) || (TARGET_NUM == 32690)
+#define I2C_DEVICE_ID    0
+#endif
+
+#define I2C_OPS         &max_i2c_ops
+#define I2C_EXTRA       &max_i2c_extra
+
+extern struct max_uart_init_param max_uart_extra;
+extern struct max_i2c_init_param max_i2c_extra;
+
+#endif /* __PARAMETERS_H__ */

--- a/projects/max31827-evkit/src/platform/maxim/platform_src.mk
+++ b/projects/max31827-evkit/src/platform/maxim/platform_src.mk
@@ -1,0 +1,14 @@
+INCS +=	$(PLATFORM_DRIVERS)/maxim_gpio.h      \
+		$(PLATFORM_DRIVERS)/maxim_i2c.h       \
+		$(PLATFORM_DRIVERS)/../common/maxim_dma.h       \
+		$(PLATFORM_DRIVERS)/maxim_irq.h      \
+		$(PLATFORM_DRIVERS)/maxim_uart.h      \
+		$(PLATFORM_DRIVERS)/maxim_uart_stdio.h
+
+SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c     \
+		$(PLATFORM_DRIVERS)/maxim_gpio.c      \
+		$(PLATFORM_DRIVERS)/maxim_i2c.c       \
+		$(PLATFORM_DRIVERS)/../common/maxim_dma.c       \
+		$(PLATFORM_DRIVERS)/maxim_irq.c      \
+		$(PLATFORM_DRIVERS)/maxim_uart.c      \
+		$(PLATFORM_DRIVERS)/maxim_uart_stdio.c

--- a/projects/max31827-evkit/src/platform/platform_includes.h
+++ b/projects/max31827-evkit/src/platform/platform_includes.h
@@ -1,0 +1,53 @@
+/********************************************************************************
+ *   @file   platform_includes.h
+ *   @brief  Includes for used platforms used by the max31827 project.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#ifndef __PLATFORM_INCLUDES_H__
+#define __PLATFORM_INCLUDES_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#ifdef MAXIM_PLATFORM
+#include "maxim/parameters.h"
+#endif
+
+#ifdef IIO_SUPPORT
+#include "iio_app.h"
+#endif
+
+#endif /* __PLATFORM_INCLUDES_H__ */


### PR DESCRIPTION
## Pull Request Description

The MAX31827 is a ±1°C accuracy from -40°C to +125°C (12 bits) local temperature switch and sensor with I2C/SMBus interface. The combination of small 6-bump wafer-level package (WLP) and high accuracy makes this temperature sensor/switch ideal for a wide range of applications. It can be used as a temperature switch with preconfigured thresholds and/or as a temperature sensor with I2C interface. When the part operates as an independent temperature switch, the I2C interface doesn't have to be used. This enables use of the part in systems that require thermal protection implemented in hardware, without the need for reconfiguration or use of software/firmware during normal operation.

The driver also supports MAX31828 and MAX31829.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
