### PR TITLE
drivers: led: max25603 : Add support for MAX25603

### DIFF
--- a/doc/sphinx/source/drivers/max25603.rst
+++ b/doc/sphinx/source/drivers/max25603.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../drivers/led/max25603/README.rst

--- a/doc/sphinx/source/drivers_doc.rst
+++ b/doc/sphinx/source/drivers_doc.rst
@@ -61,6 +61,13 @@ INERTIAL MEASUREMENT UNITS
 
    drivers/imu
 
+LED
+===
+.. toctree::
+   :maxdepth: 1
+
+   drivers/max25603
+
 RF TRANSCEIVER
 ==============
 .. toctree::

--- a/drivers/led/max25603/README.rst
+++ b/drivers/led/max25603/README.rst
@@ -1,0 +1,63 @@
+MAX25603 no-OS driver
+=====================
+
+Supported Devices
+-----------------
+
+`MAX25603 <https://www.analog.com/MAX25603>`_
+
+Overview
+--------
+
+The MAX25603 is a synchronous four-switch, buckboost LED driver controller
+suitable for multifunction automotive combination head lamps.
+
+The controller regulates the LED current for LED string voltages from 0V to 60V.
+The MAX25603 can be used as a seamless buck-boost LED driver for applications
+that require an efficient buck-boost LED driver with synchronous rectification.
+
+The MAX25603 is ideal for high-power applications that require a current source
+with PWM dimming capability.
+
+Applications
+------------
+
+MAX25603
+--------
+
+* Combination Automotive Head Lamps
+
+MAX25603 Device Configuration
+-----------------------------
+
+Driver Initialization
+---------------------
+The first API to be called is **max25603_init**. Make sure that it returns 0,
+which means that the driver was initialized correctly.
+
+Global Configuration
+--------------------
+
+**max25603_enable** - API designed to enable either LOW or HIGH BEAM or disable
+them.
+
+**max25603_sel_comp** - API designed to select which comparator to use
+(drive high when dimming on either set of LED strings).
+
+MAX25603 Driver Initialization Example
+--------------------------------------
+
+.. code-block:: bash
+
+	struct max25603_desc *max25603_desc;
+	struct max25603_init_param max25603_ip = {
+		.en1_param = &max25603_en1_ip,
+		.en2_param = &max25603_en2_ip,
+		.flt_param = NULL,
+		.shunt_param = &max25603_shunt_ip,
+		.sw_freq = MAX25603_SW_FREQ_200KHZ,
+	};
+
+	ret = max25603_init(&max25603_desc, &max25603_ip);
+	if (ret)
+		goto error;

--- a/drivers/led/max25603/max25603.c
+++ b/drivers/led/max25603/max25603.c
@@ -1,0 +1,318 @@
+/***************************************************************************//**
+ *   @file   max25603.c
+ *   @brief  Source file of MAX25603 Driver.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "max25603.h"
+#include "no_os_delay.h"
+#include "no_os_units.h"
+#include "no_os_alloc.h"
+
+/**
+ * @brief MAX25603 select comparator function
+ * @param desc - MAX25603 device descriptor
+ * @param comp - Comparator selected to be used at the GATE's output
+ * @return 0 in case of succes, negative error code otherwise
+ */
+int max25603_sel_comp(struct max25603_desc *desc, enum max25603_comp comp)
+{
+	enum no_os_gpio_values gpio_val;
+	int ret;
+
+	gpio_val = comp == MAX25603_COMP2 ? NO_OS_GPIO_HIGH : NO_OS_GPIO_LOW;
+	ret = no_os_gpio_set_value(desc->shunt_desc, gpio_val);
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
+/**
+ * @brief MAX25603 set and configure ENABLE PWM dimming.
+ * @param desc - MAX25603 device descriptor
+ * @param enable - Enable pin to be configured/enabled.
+ * @param freq_hz - Enable pin PWM's frequency in Hz.
+ * @param duty - Duty cycle percentage (from 0 to 100)
+ * @return 0 in case of succes, negative error code otherwise
+ */
+int max25603_set_enable(struct max25603_desc *desc, enum max25603_enable enable,
+			uint32_t freq_hz, uint8_t duty)
+{
+	uint32_t period_ns;
+	int ret;
+
+	if (duty > 100)
+		return -EINVAL;
+
+	period_ns = NO_OS_DIV_ROUND_CLOSEST_ULL(NANO, freq_hz);
+
+	switch (enable) {
+	case MAX25603_DISABLE_EN:
+		ret = no_os_pwm_disable(desc->en1_desc);
+		if (ret)
+			return ret;
+
+		ret = no_os_pwm_disable(desc->en2_desc);
+		if (ret)
+			return ret;
+
+		break;
+	case MAX25603_EN1:
+		ret = no_os_pwm_disable(desc->en1_desc);
+		if (ret)
+			return ret;
+
+		if (!duty)
+			return 0;
+
+		ret = no_os_pwm_set_period(desc->en1_desc, period_ns);
+		if (ret)
+			return ret;
+
+		ret = no_os_pwm_set_duty_cycle(desc->en1_desc,
+					       (period_ns * (100 - duty)) / 100);
+		if (ret)
+			return ret;
+
+		return no_os_pwm_enable(desc->en1_desc);
+	case MAX25603_EN2:
+		ret = no_os_pwm_disable(desc->en2_desc);
+		if (ret)
+			return ret;
+
+		if (!duty)
+			return 0;
+
+		ret = no_os_pwm_set_period(desc->en2_desc, period_ns);
+		if (ret)
+			return ret;
+
+		ret = no_os_pwm_set_duty_cycle(desc->en2_desc,
+					       (period_ns * (100 - duty)) / 100);
+		if (ret)
+			return ret;
+
+		return no_os_pwm_enable(desc->en2_desc);
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief MAX25603 set and configure BEAM PWM dimming.
+ * @param desc - MAX25603 device descriptor
+ * @param beam - Beam pin to be configured/enabled.
+ * @param freq_hz - Beam pin PWM's frequency in Hz.
+ * @param duty - Duty cycle percentage (from 0 to 100)
+ * @return 0 in case of succes, negative error code otherwise
+ */
+int max25603_set_beam(struct max25603_desc *desc, enum max25603_beam beam,
+		      uint32_t freq_hz, uint8_t duty)
+{
+	uint32_t period_ns;
+	int ret;
+
+	if (duty > 100)
+		return -EINVAL;
+
+	period_ns = NO_OS_DIV_ROUND_CLOSEST_ULL(NANO, freq_hz);
+
+	switch (beam) {
+	case MAX25603_DISABLE_BEAM:
+		ret = max25603_set_beam(desc, MAX25603_LOW_BEAM,
+					NO_OS_DIV_ROUND_CLOSEST_ULL(NANO, desc->lb_desc->period_ns), 100);
+		if (ret)
+			return ret;
+
+		ret = max25603_set_beam(desc, MAX25603_HIGH_BEAM,
+					NO_OS_DIV_ROUND_CLOSEST_ULL(NANO, desc->hb_desc->period_ns), 100);
+		if (ret)
+			return ret;
+
+		break;
+	case MAX25603_HIGH_BEAM:
+		if (!duty)
+			return no_os_pwm_set_duty_cycle(desc->hb_desc, desc->hb_desc->period_ns);
+
+		ret = no_os_pwm_disable(desc->hb_desc);
+		if (ret)
+			return ret;
+
+		ret = no_os_pwm_set_period(desc->hb_desc, period_ns);
+		if (ret)
+			return ret;
+
+		ret = no_os_pwm_set_duty_cycle(desc->hb_desc, (period_ns * (100 - duty)) / 100);
+		if (ret)
+			return ret;
+
+		ret = no_os_pwm_enable(desc->hb_desc);
+		if (ret)
+			return ret;
+
+		break;
+	case MAX25603_LOW_BEAM:
+		if (!duty)
+			return no_os_pwm_set_duty_cycle(desc->lb_desc, desc->lb_desc->period_ns);
+
+		ret = no_os_pwm_disable(desc->lb_desc);
+		if (ret)
+			return ret;
+
+		ret = no_os_pwm_set_period(desc->lb_desc, period_ns);
+		if (ret)
+			return ret;
+
+		ret = no_os_pwm_set_duty_cycle(desc->lb_desc, (period_ns * (100 - duty)) / 100);
+		if (ret)
+			return ret;
+
+		ret = no_os_pwm_enable(desc->lb_desc);
+		if (ret)
+			return ret;
+
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	desc->beam = beam;
+
+	return 0;
+}
+
+/**
+ * @brief MAX25603 descriptor initialization function.
+ * @param desc - MAX25603 device descriptor.
+ * @param init_param - Initialization parameter containing data about the device
+ * 		       descriptor to be initialized.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max25603_init(struct max25603_desc **desc,
+		  struct max25603_init_param *init_param)
+{
+	struct max25603_desc *descriptor;
+	int ret;
+
+	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	ret = no_os_pwm_init(&descriptor->en1_desc, init_param->en1_param);
+	if (ret)
+		goto err;
+
+	ret = no_os_pwm_init(&descriptor->en2_desc, init_param->en2_param);
+	if (ret)
+		goto en1_err;
+
+	ret = no_os_pwm_init(&descriptor->hb_desc, init_param->hb_param);
+	if (ret)
+		goto en2_err;
+
+	ret = no_os_pwm_init(&descriptor->lb_desc, init_param->lb_param);
+	if (ret)
+		goto hb_err;
+
+	ret = max25603_set_enable(descriptor, MAX25603_DISABLE_EN, 0, 0);
+	if (ret)
+		goto lb_err;
+
+	ret = max25603_set_beam(descriptor, MAX25603_DISABLE_BEAM, 0, 0);
+	if (ret)
+		goto hb_err;
+
+	ret = no_os_gpio_get_optional(&descriptor->shunt_desc,
+				      init_param->shunt_param);
+	if (ret)
+		goto hb_err;
+
+	if (descriptor->shunt_desc) {
+		ret = no_os_gpio_direction_output(descriptor->shunt_desc,
+						  NO_OS_GPIO_LOW);
+		if (ret)
+			goto shunt_err;
+	}
+
+	descriptor->comp = MAX25603_COMP1;
+
+	ret = no_os_gpio_get_optional(&descriptor->flt_desc,
+				      init_param->flt_param);
+	if (ret)
+		goto shunt_err;
+
+	if (descriptor->flt_desc) {
+		ret = no_os_gpio_direction_input(descriptor->flt_desc);
+		if (ret)
+			goto flt_err;
+	}
+
+	*desc = descriptor;
+
+	return 0;
+
+flt_err:
+	no_os_gpio_remove(descriptor->flt_desc);
+shunt_err:
+	no_os_gpio_remove(descriptor->shunt_desc);
+lb_err:
+	no_os_pwm_remove(descriptor->lb_desc);
+hb_err:
+	no_os_pwm_remove(descriptor->hb_desc);
+en2_err:
+	no_os_pwm_remove(descriptor->en2_desc);
+en1_err:
+	no_os_pwm_remove(descriptor->en1_desc);
+err:
+	no_os_free(descriptor);
+
+	return ret;
+}
+
+/**
+ * @brief Deallocates all the resources used at initialization.
+ * @param desc - MAX25603 device descriptor.
+ * @return 0 in case of succes, negative error code otherwise.
+*/
+int max25603_remove(struct max25603_desc *desc)
+{
+	if (!desc)
+		return -ENODEV;
+
+	no_os_gpio_remove(desc->flt_desc);
+	no_os_gpio_remove(desc->shunt_desc);
+	no_os_pwm_remove(desc->lb_desc);
+	no_os_pwm_remove(desc->hb_desc);
+	no_os_pwm_remove(desc->en2_desc);
+	no_os_pwm_remove(desc->en1_desc);
+	no_os_free(desc);
+
+	return 0;
+}

--- a/drivers/led/max25603/max25603.h
+++ b/drivers/led/max25603/max25603.h
@@ -1,0 +1,103 @@
+/***************************************************************************//**
+ *   @file   max25603.h
+ *   @brief  Header file of MAX25603 Driver.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __MAX25603_H__
+#define __MAX25603_H__
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include "no_os_gpio.h"
+#include "no_os_pwm.h"
+#include "no_os_util.h"
+#include "no_os_error.h"
+
+enum max25603_comp {
+	MAX25603_COMP1,
+	MAX25603_COMP2
+};
+
+enum max25603_enable {
+	MAX25603_DISABLE_EN,
+	MAX25603_EN1,
+	MAX25603_EN2,
+};
+
+enum max25603_beam {
+	MAX25603_DISABLE_BEAM,
+	MAX25603_HIGH_BEAM,
+	MAX25603_LOW_BEAM,
+};
+
+struct max25603_init_param {
+	struct no_os_gpio_init_param *shunt_param;
+	struct no_os_gpio_init_param *flt_param;
+
+	struct no_os_pwm_init_param *en1_param;
+	struct no_os_pwm_init_param *en2_param;
+	struct no_os_pwm_init_param *lb_param;
+	struct no_os_pwm_init_param *hb_param;
+};
+
+struct max25603_desc {
+	struct no_os_gpio_desc *shunt_desc;
+	struct no_os_gpio_desc *flt_desc;
+
+	struct no_os_pwm_desc *en1_desc;
+	struct no_os_pwm_desc *en2_desc;
+	struct no_os_pwm_desc *lb_desc;
+	struct no_os_pwm_desc *hb_desc;
+
+	enum max25603_enable enable;
+	enum max25603_beam beam;
+	enum max25603_comp comp;
+};
+
+/** MAX25603 select comparator function. */
+int max25603_sel_comp(struct max25603_desc *desc, enum max25603_comp comp);
+
+/** MAX25603 set and configure ENABLE PWM dimming. */
+int max25603_set_enable(struct max25603_desc *desc, enum max25603_enable enable,
+			uint32_t freq_hz, uint8_t duty);
+
+/** MAX25603 set and configure BEAM PWM dimming. */
+int max25603_set_beam(struct max25603_desc *desc, enum max25603_beam beam,
+		      uint32_t freq_hz, uint8_t duty);
+
+/** MAX25603 device initialization function.  */
+int max25603_init(struct max25603_desc **desc,
+		  struct max25603_init_param *init_param);
+
+/** Deallocates all resouces used at initialization. */
+int max25603_remove(struct max25603_desc *desc);
+
+#endif /* __MAX25603_H__ */

--- a/projects/max25603/Makefile
+++ b/projects/max25603/Makefile
@@ -1,0 +1,5 @@
+include ../../tools/scripts/generic_variables.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/max25603/builds.json
+++ b/projects/max25603/builds.json
@@ -1,0 +1,7 @@
+{
+	"maxim": {
+		"basic_example_max32690": {
+			"flags" : "TARGET=max32690"
+		}
+	}
+}

--- a/projects/max25603/src.mk
+++ b/projects/max25603/src.mk
@@ -1,0 +1,41 @@
+include $(PROJECT)/src/platform/$(PLATFORM)/platform_src.mk
+include $(PROJECT)/src/examples/examples_src.mk
+
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/main.c
+
+INCS += $(PROJECT)/src/common/common_data.h
+SRCS += $(PROJECT)/src/common/common_data.c
+
+INCS += $(PROJECT)/src/platform/platform_includes.h
+
+INCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.h
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.c
+
+INCS += $(INCLUDE)/no_os_delay.h	\
+	$(INCLUDE)/no_os_error.h	\
+	$(INCLUDE)/no_os_gpio.h		\
+	$(INCLUDE)/no_os_print_log.h	\
+	$(INCLUDE)/no_os_alloc.h	\
+	$(INCLUDE)/no_os_irq.h		\
+	$(INCLUDE)/no_os_list.h		\
+	$(INCLUDE)/no_os_dma.h		\
+	$(INCLUDE)/no_os_uart.h		\
+	$(INCLUDE)/no_os_lf256fifo.h	\
+	$(INCLUDE)/no_os_util.h		\
+	$(INCLUDE)/no_os_units.h	\
+	$(INCLUDE)/no_os_pwm.h		\
+	$(INCLUDE)/no_os_mutex.h
+
+SRCS += $(DRIVERS)/api/no_os_gpio.c	\
+	$(NO-OS)/util/no_os_lf256fifo.c \
+	$(DRIVERS)/api/no_os_irq.c	\
+	$(DRIVERS)/api/no_os_uart.c	\
+	$(DRIVERS)/api/no_os_dma.c	\
+	$(DRIVERS)/api/no_os_pwm.c	\
+	$(NO-OS)/util/no_os_list.c	\
+	$(NO-OS)/util/no_os_util.c	\
+	$(NO-OS)/util/no_os_alloc.c	\
+	$(NO-OS)/util/no_os_mutex.c
+
+INCS += $(DRIVERS)/led/max25603/max25603.h
+SRCS += $(DRIVERS)/led/max25603/max25603.c

--- a/projects/max25603/src/common/common_data.c
+++ b/projects/max25603/src/common/common_data.c
@@ -1,0 +1,97 @@
+/***************************************************************************//**
+ *   @file   common_data.c
+ *   @brief  Common data used by the MAX25603 project.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "common_data.h"
+
+
+struct no_os_uart_init_param max25603_uart_ip = {
+	.device_id = UART_DEVICE_ID,
+	.baud_rate = UART_BAUDRATE,
+	.size = NO_OS_UART_CS_8,
+	.platform_ops = UART_OPS,
+	.parity = NO_OS_UART_PAR_NO,
+	.stop = NO_OS_UART_STOP_1_BIT,
+	.extra = UART_EXTRA,
+};
+
+struct no_os_gpio_init_param max25603_shunt_ip = {
+	.port = GPIO_SHUNT_PORT_NUM,
+	.pull = NO_OS_PULL_NONE,
+	.number = GPIO_SHUNT_PIN_NUM,
+	.platform_ops = GPIO_OPS,
+	.extra = GPIO_EXTRA,
+};
+
+struct no_os_pwm_init_param max25603_en1_ip = {
+	.id = PWM_EN1_ID,
+	.period_ns = PWM_EN1_PERIOD_NS,
+	.duty_cycle_ns = PWM_EN1_DUTY_NS,
+	.polarity = NO_OS_PWM_POLARITY_HIGH,
+	.platform_ops = PWM_OPS,
+	.extra = PWM_EXTRA,
+};
+
+struct no_os_pwm_init_param max25603_en2_ip = {
+	.id = PWM_EN2_ID,
+	.period_ns = PWM_EN2_PERIOD_NS,
+	.duty_cycle_ns = PWM_EN2_DUTY_NS,
+	.polarity = NO_OS_PWM_POLARITY_HIGH,
+	.platform_ops = PWM_OPS,
+	.extra = PWM_EXTRA,
+};
+
+struct no_os_pwm_init_param max25603_hb_ip = {
+	.id = PWM_HB_ID,
+	.period_ns = PWM_HB_PERIOD_NS,
+	.duty_cycle_ns = PWM_HB_DUTY_NS,
+	.polarity = NO_OS_PWM_POLARITY_HIGH,
+	.platform_ops = PWM_OPS,
+	.extra = PWM_EXTRA,
+};
+
+struct no_os_pwm_init_param max25603_lb_ip = {
+	.id = PWM_LB_ID,
+	.period_ns = PWM_LB_PERIOD_NS,
+	.duty_cycle_ns = PWM_LB_DUTY_NS,
+	.polarity = NO_OS_PWM_POLARITY_HIGH,
+	.platform_ops = PWM_OPS,
+	.extra = PWM_EXTRA,
+};
+
+struct max25603_init_param max25603_ip = {
+	.en1_param = &max25603_en1_ip,
+	.en2_param = &max25603_en2_ip,
+	.flt_param = NULL,
+	.hb_param = &max25603_hb_ip,
+	.lb_param = &max25603_lb_ip,
+	.shunt_param = &max25603_shunt_ip,
+};

--- a/projects/max25603/src/common/common_data.h
+++ b/projects/max25603/src/common/common_data.h
@@ -1,0 +1,48 @@
+/***************************************************************************//**
+ *   @file   common_data.h
+ *   @brief  Common data used by the MAX25603 project.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __COMMON_DATA_H__
+#define __COMMON_DATA_H__
+
+#include "platform_includes.h"
+#include "max25603.h"
+
+extern struct no_os_uart_init_param max25603_uart_ip;
+extern struct no_os_gpio_init_param max25603_shunt_ip;
+extern struct no_os_gpio_init_param max25603_flt_ip;
+extern struct no_os_pwm_init_param max25603_en1_ip;
+extern struct no_os_pwm_init_param max25603_en2_ip;
+extern struct no_os_pwm_init_param max25603_hb_ip;
+extern struct no_os_pwm_init_param max25603_lb_ip;
+extern struct max25603_init_param max25603_ip;
+
+#endif /* __COMMON_DATA_H__ */

--- a/projects/max25603/src/examples/basic/basic_example.c
+++ b/projects/max25603/src/examples/basic/basic_example.c
@@ -1,0 +1,77 @@
+/***************************************************************************//**
+ *   @file   basic_example.c
+ *   @brief  Source file for basic example.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "basic_example.h"
+#include "common_data.h"
+#include "max25603.h"
+#include "no_os_delay.h"
+#include "no_os_print_log.h"
+#include "no_os_irq.h"
+
+int basic_example_main()
+{
+	struct max25603_desc *max25603_desc;
+	int ret;
+
+	ret = max25603_init(&max25603_desc, &max25603_ip);
+	if (ret)
+		goto exit;
+
+	ret = max25603_sel_comp(max25603_desc, MAX25603_COMP1);
+	if (ret)
+		goto remove_max25603;
+
+	ret = max25603_set_enable(max25603_desc, MAX25603_EN2, 100000, 100);
+	if (ret)
+		goto remove_max25603;
+
+	ret = max25603_set_beam(max25603_desc, MAX25603_LOW_BEAM, 50, 50);
+	if (ret)
+		goto remove_max25603;
+
+	no_os_mdelay(5000);
+
+	ret = max25603_set_beam(max25603_desc, MAX25603_DISABLE_BEAM, 0, 0);
+	if (ret)
+		goto remove_max25603;
+
+	ret = max25603_set_enable(max25603_desc, MAX25603_DISABLE_EN, 0, 0);
+	if (ret)
+		goto remove_max25603;
+
+remove_max25603:
+	max25603_remove(max25603_desc);
+exit:
+	if (ret)
+		pr_info("Error!\n");
+	return ret;
+}

--- a/projects/max25603/src/examples/basic/basic_example.h
+++ b/projects/max25603/src/examples/basic/basic_example.h
@@ -1,0 +1,38 @@
+/***************************************************************************//**
+ *   @file   basic_example.h
+ *   @brief  Header file for basic example.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __BASIC_EXAMPLE_H__
+#define __BASIC_EXAMPLE_H__
+
+int basic_example_main();
+
+#endif /* __BASIC_EXAMPLE_H__ */

--- a/projects/max25603/src/examples/examples_src.mk
+++ b/projects/max25603/src/examples/examples_src.mk
@@ -1,0 +1,2 @@
+SRCS += $(PROJECT)/src/examples/basic/basic_example.c
+INCS += $(PROJECT)/src/examples/basic/basic_example.h

--- a/projects/max25603/src/platform/maxim/main.c
+++ b/projects/max25603/src/platform/maxim/main.c
@@ -1,0 +1,55 @@
+/***************************************************************************//**
+ *   @file   main.c
+ *   @brief  Main file for Maxim platform of MAX25603 project.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "platform_includes.h"
+#include "common_data.h"
+#include "no_os_error.h"
+#include "basic_example.h"
+
+int main()
+{
+	int ret = -EINVAL;
+
+	struct no_os_uart_desc *uart_desc;
+
+	ret = no_os_uart_init(&uart_desc, &max25603_uart_ip);
+	if (ret)
+		return ret;
+
+	no_os_uart_stdio(uart_desc);
+
+	ret = basic_example_main();
+
+	no_os_uart_remove(uart_desc);
+
+	return ret;
+}

--- a/projects/max25603/src/platform/maxim/parameters.c
+++ b/projects/max25603/src/platform/maxim/parameters.c
@@ -1,0 +1,45 @@
+/***************************************************************************//**
+ *   @file   parameters.c
+ *   @brief  Definition of Maxim platform data used by MAX25603 project.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "parameters.h"
+
+struct max_uart_init_param max25603_uart_extra = {
+	.flow = UART_FLOW_DIS,
+};
+
+struct max_gpio_init_param max25603_gpio_extra = {
+	.vssel = MXC_GPIO_VSSEL_VDDIOH,
+};
+
+struct max_pwm_init_param max25603_pwm_extra = {
+	.vssel = MXC_GPIO_VSSEL_VDDIOH,
+};

--- a/projects/max25603/src/platform/maxim/parameters.h
+++ b/projects/max25603/src/platform/maxim/parameters.h
@@ -1,0 +1,87 @@
+/***************************************************************************//**
+ *   @file   parameters.h
+ *   @brief  Definition of Maxim platform data used by MAX25603 project.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
+
+#include "maxim_pwm.h"
+#include "maxim_gpio.h"
+#include "maxim_uart.h"
+#include "maxim_uart_stdio.h"
+
+
+#if (TARGET_NUM == 32690)
+#define	UART_IRQ_ID		UART0_IRQn
+#define UART_DEVICE_ID		0
+#define UART_BAUDRATE		57600
+#endif
+
+#define UART_EXTRA		&max25603_uart_extra
+#define UART_OPS		&max_uart_ops
+
+#if (TARGET_NUM == 32690)
+#define PWM_EN1_ID		3
+#define PWM_EN1_PERIOD_NS	200000000
+#define PWM_EN1_DUTY_NS		100000000
+
+#define PWM_EN2_ID		2
+#define PWM_EN2_PERIOD_NS	200000000
+#define PWM_EN2_DUTY_NS		100000000
+
+#define PWM_LB_ID		1
+#define PWM_LB_PERIOD_NS	200000000
+#define PWM_LB_DUTY_NS		100000000
+
+#define PWM_HB_ID		0
+#define PWM_HB_PERIOD_NS	200000000
+#define PWM_HB_DUTY_NS		100000000
+#endif
+
+#define PWM_EXTRA		&max25603_pwm_extra
+#define PWM_OPS			&max_pwm_ops
+
+#if (TARGET_NUM == 32690)
+#define GPIO_SHUNT_PORT_NUM	1
+#define GPIO_SHUNT_PIN_NUM	6
+
+#define GPIO_FLT_PORT_NUM	2
+#define GPIO_FLT_PIN_NUM	21
+#endif
+
+#define GPIO_OPS		&max_gpio_ops
+#define GPIO_EXTRA		&max25603_gpio_extra
+
+extern struct max_uart_init_param max25603_uart_extra;
+extern struct max_pwm_init_param max25603_pwm_extra;
+extern struct max_gpio_init_param max25603_gpio_extra;
+
+#endif /* __PARAMETERS_H__ */

--- a/projects/max25603/src/platform/maxim/platform_src.mk
+++ b/projects/max25603/src/platform/maxim/platform_src.mk
@@ -1,0 +1,16 @@
+INCS += $(PLATFORM_DRIVERS)/maxim_gpio.h		\
+	$(PLATFORM_DRIVERS)/maxim_spi.h			\
+	$(PLATFORM_DRIVERS)/../common/maxim_dma.h	\
+	$(PLATFORM_DRIVERS)/maxim_irq.h			\
+	$(PLATFORM_DRIVERS)/maxim_pwm.h			\
+	$(PLATFORM_DRIVERS)/maxim_uart.h		\
+	$(PLATFORM_DRIVERS)/maxim_uart_stdio.h		\
+	$(PLATFORM_DRIVERS)/maxim_gpio_irq.h
+
+SRCS += $(PLATFORM_DRIVERS)/maxim_gpio.c		\
+	$(PLATFORM_DRIVERS)/maxim_irq.c			\
+	$(PLATFORM_DRIVERS)/maxim_delay.c		\
+	$(PLATFORM_DRIVERS)/maxim_pwm.c			\
+	$(PLATFORM_DRIVERS)/maxim_uart.c		\
+	$(PLATFORM_DRIVERS)/maxim_uart_stdio.c		\
+	$(PLATFORM_DRIVERS)/maxim_gpio_irq.c

--- a/projects/max25603/src/platform/platform_includes.h
+++ b/projects/max25603/src/platform/platform_includes.h
@@ -1,0 +1,40 @@
+/***************************************************************************//**
+ *   @file   platform_includes.h
+ *   @brief  Includes for used platforms used by MAX25603 project.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PLATFORM_INCLUDES_H__
+#define __PLATFORM_INCLUDES_H__
+
+#ifdef MAXIM_PLATFORM
+#include "maxim/parameters.h"
+#endif
+
+#endif /* __PLATFORM_INCLUDES_H__ */


### PR DESCRIPTION
## Pull Request Description

The MAX25603 is a synchronous four-switch, buckboost LED driver controller suitable for multifunction automotive combination head lamps. The controller regulates the LED current for LED string voltages from 0V to 60V. The MAX25603 can be used as a seamless buck-boost LED driver for applications that require an efficient buck-boost LED driver with synchronous rectification. The MAX25603 is ideal for high-power applications that require a current source with PWM dimming capability.

1st commit : driver files
2nd commit : driver documentation file
3rd commit : project files

Needs to be merged after #2327 .

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
