### PR TITLE
drivers: ad5791: add support for rbuf gain of two config

### DIFF
--- a/drivers/dac/ad5791/ad5791.c
+++ b/drivers/dac/ad5791/ad5791.c
@@ -88,6 +88,7 @@ int32_t ad5791_init(struct ad5791_dev **device,
 		return -1;
 
 	dev->act_device = init_param.act_device;
+	dev->rbuf_gain2 = init_param.rbuf_gain2;
 
 	/* GPIO */
 	status = no_os_gpio_get(&dev->gpio_reset, &init_param.gpio_reset);
@@ -323,7 +324,12 @@ int32_t ad5791_setup(struct ad5791_dev *dev,
 	uint32_t new_ctrl = 0;
 	uint32_t val;
 	int32_t status = 0;
+	uint32_t rbuf_mask;
 
+	if (dev->rbuf_gain2)
+		rbuf_mask = 0;
+	else
+		rbuf_mask = AD5791_CTRL_RBUF_MASK;
 	/* Reads the control register in order to save the options related to the
 	   DAC output state that may have been configured previously. */
 	status = ad5791_get_register_value(dev, AD5791_REG_CTRL, &val);
@@ -335,7 +341,7 @@ int32_t ad5791_setup(struct ad5791_dev *dev,
 	old_ctrl = old_ctrl & ~(AD5791_CTRL_LINCOMP(-1) |
 				AD5791_CTRL_SDODIS_MASK |
 				AD5791_CTRL_BIN2SC_MASK |
-				AD5791_CTRL_RBUF_MASK);
+				rbuf_mask);
 	/* Sets the new state provided by the user. */
 	new_ctrl = old_ctrl | setup_word;
 	status = ad5791_set_register_value(dev,

--- a/drivers/dac/ad5791/ad5791.h
+++ b/drivers/dac/ad5791/ad5791.h
@@ -85,6 +85,7 @@ struct ad5791_dev {
 	struct no_os_gpio_desc	*gpio_ldac;
 	/* Device Settings */
 	enum ad5791_type act_device;
+	bool rbuf_gain2;
 };
 
 struct ad5791_init_param {
@@ -96,6 +97,7 @@ struct ad5791_init_param {
 	struct no_os_gpio_init_param		gpio_ldac;
 	/* Device Settings */
 	enum ad5791_type act_device;
+	bool					rbuf_gain2;
 };
 
 /******************************************************************************/


### PR DESCRIPTION
According to the datasheet, AD5791_CTRL_RBUF_MASK needs to be clared when an external amplifier is connected in a gain of two configuration. Added support for this feature.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
