### PR TITLE
Align buffers for DMA transfers

### DIFF
--- a/drivers/axi_core/axi_dmac/axi_dmac.c
+++ b/drivers/axi_core/axi_dmac/axi_dmac.c
@@ -453,11 +453,19 @@ int32_t axi_dmac_transfer_start(struct axi_dmac *dmac,
 			dmac->init_addr = dmac->next_dest_addr;
 			axi_dmac_write(dmac, AXI_DMAC_REG_DEST_ADDRESS, dmac->next_dest_addr);
 			axi_dmac_write(dmac, AXI_DMAC_REG_DEST_STRIDE, 0x0);
+			if (dmac->transfer.dest_addr % (dmac->width_dst / 8)) {
+				printf("Destination address should be aligned with destination data path width.\n\n");
+				return -1;
+			}
 			break;
 		case DMA_MEM_TO_DEV:
 			dmac->init_addr = dmac->next_src_addr;
 			axi_dmac_write(dmac, AXI_DMAC_REG_SRC_ADDRESS, dmac->next_src_addr);
 			axi_dmac_write(dmac, AXI_DMAC_REG_SRC_STRIDE, 0x0);
+			if (dmac->transfer.src_addr % (dmac->width_src / 8)) {
+				printf("Source address should be aligned with source data path width.\n");
+				return -1;
+			}
 			break;
 		case DMA_MEM_TO_MEM:
 			dmac->init_addr = dmac->next_src_addr;
@@ -465,6 +473,11 @@ int32_t axi_dmac_transfer_start(struct axi_dmac *dmac,
 			axi_dmac_write(dmac, AXI_DMAC_REG_DEST_STRIDE, 0x0);
 			axi_dmac_write(dmac, AXI_DMAC_REG_SRC_ADDRESS, dmac->next_src_addr);
 			axi_dmac_write(dmac, AXI_DMAC_REG_SRC_STRIDE, 0x0);
+			if ((dmac->transfer.dest_addr % (dmac->width_dst / 8))
+			    || (dmac->transfer.src_addr % (dmac->width_src / 8))) {
+				printf("Source and destination addresses should be aligned with data path widths.\n");
+				return -1;
+			}
 			break;
 		default:
 			return -1; /* Other directions are not supported yet. */

--- a/drivers/rf-transceiver/madura/README.rst
+++ b/drivers/rf-transceiver/madura/README.rst
@@ -280,9 +280,9 @@ ADRV9025 IIO Driver Initialization Example
 	#define DAC_BUFFER_SAMPLES 8192
 	#define ADC_BUFFER_SAMPLES              16384
 	#define ADC_CHANNELS                    4
-	uint32_t dac_buffer[DAC_BUFFER_SAMPLES] __attribute__ ((aligned));
+	uint32_t dac_buffer[DAC_BUFFER_SAMPLES] __attribute__ ((aligned(1024)));
 	uint16_t adc_buffer[ADC_BUFFER_SAMPLES * ADC_CHANNELS] __attribute__ ((
-			aligned));
+			aligned(1024)));
 
 	/**
 	 * IIO application descriptor

--- a/projects/ad713x_fmcz/src/ad713x_fmc.c
+++ b/projects/ad713x_fmcz/src/ad713x_fmc.c
@@ -77,7 +77,7 @@
 #include "iio_app.h"
 #endif // IIO_SUPPORT
 
-static uint32_t adc_buffer[ADC_BUFFER_SIZE] __attribute__((aligned));
+static uint32_t adc_buffer[ADC_BUFFER_SIZE] __attribute__((aligned(1024)));
 
 int main()
 {

--- a/projects/ad9081/src/app.c
+++ b/projects/ad9081/src/app.c
@@ -69,8 +69,8 @@
 
 #ifdef IIO_SUPPORT
 
-static int16_t dac_buffer[MAX_DAC_BUF_SAMPLES] __attribute__ ((aligned));
-static int16_t adc_buffer[MAX_ADC_BUF_SAMPLES] __attribute__ ((aligned));
+static int16_t dac_buffer[MAX_DAC_BUF_SAMPLES] __attribute__ ((aligned(1024)));
+static int16_t adc_buffer[MAX_ADC_BUF_SAMPLES] __attribute__ ((aligned(1024)));
 
 #endif
 

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -100,10 +100,10 @@ static uint8_t out_buff[MAX_SIZE_BASE_ADDR];
 /******************************************************************************/
 
 #if defined(DMA_EXAMPLE) || defined(IIO_SUPPORT)
-uint32_t dac_buffer[DAC_BUFFER_SAMPLES] __attribute__ ((aligned));
+uint32_t dac_buffer[DAC_BUFFER_SAMPLES] __attribute__ ((aligned(1024)));
 #endif
 uint16_t adc_buffer[ADC_BUFFER_SAMPLES * ADC_CHANNELS] __attribute__ ((
-			aligned));
+			aligned(1024)));
 
 #define AD9361_ADC_DAC_BYTES_PER_SAMPLE 2
 

--- a/projects/ad9371/src/app/headless.c
+++ b/projects/ad9371/src/app/headless.c
@@ -80,9 +80,9 @@ extern ad9528Device_t clockAD9528_;
 extern mykonosDevice_t mykDevice;
 
 #if defined(DMA_EXAMPLE) || defined(IIO_SUPPORT)
-uint32_t dac_buffer[DAC_BUFFER_SAMPLES] __attribute__ ((aligned));
+uint32_t dac_buffer[DAC_BUFFER_SAMPLES] __attribute__ ((aligned(1024)));
 uint16_t adc_buffer[ADC_BUFFER_SAMPLES * ADC_CHANNELS] __attribute__ ((
-			aligned));
+			aligned(1024)));
 #endif
 /***************************************************************************//**
  * @brief main

--- a/projects/adrv9001/src/app/headless.c
+++ b/projects/adrv9001/src/app/headless.c
@@ -71,9 +71,9 @@
 /* ADC/DAC Buffers */
 #if defined(DMA_EXAMPLE) || defined(IIO_SUPPORT)
 static uint32_t dac_buffers[IIO_DEV_COUNT][DAC_BUFFER_SAMPLES]
-__attribute__((aligned));
+__attribute__((aligned(1024)));
 static uint16_t adc_buffers[IIO_DEV_COUNT][ADC_BUFFER_SAMPLES]
-__attribute__((aligned));
+__attribute__((aligned(1024)));
 #endif
 
 uint64_t sampling_freq;

--- a/projects/cn0561/src/cn0561.c
+++ b/projects/cn0561/src/cn0561.c
@@ -75,7 +75,7 @@
 #include "iio_app.h"
 #endif // IIO_SUPPORT
 
-static uint32_t adc_buffer[ADC_BUFFER_SIZE] __attribute__((aligned));
+static uint32_t adc_buffer[ADC_BUFFER_SIZE] __attribute__((aligned(1024)));
 
 int main()
 {

--- a/projects/fmcadc2/src/fmcadc2.c
+++ b/projects/fmcadc2/src/fmcadc2.c
@@ -65,7 +65,7 @@
 #include "xilinx_uart.h"
 #endif
 
-static int16_t adc_buff[ADC_MAX_SAMPLES] __attribute__((aligned));
+static int16_t adc_buff[ADC_MAX_SAMPLES] __attribute__((aligned(1024)));
 
 int main(void)
 {

--- a/projects/fmcadc5/src/fmcadc5.c
+++ b/projects/fmcadc5/src/fmcadc5.c
@@ -67,7 +67,7 @@
 #include "xilinx_uart.h"
 #endif
 
-static uint16_t adc_buff[ADC_MAX_SAMPLES] __attribute__((aligned));
+static uint16_t adc_buff[ADC_MAX_SAMPLES] __attribute__((aligned(1024)));
 
 int main(void)
 {


### PR DESCRIPTION
## Pull Request Description

Address Alignment

Software must program the SRC_ADDRESS and DEST_ADDRESS registers to be multiple of the corresponding MM data bus. The following conditions must hold:

    SRC_ADDRESS MOD (DMA_DATA_WIDTH_SRC/8) == 0
    DEST_ADDRESS MOD (DMA_DATA_WIDTH_DEST/8) == 0 

https://wiki.analog.com/resources/fpga/docs/axi_dmac 

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
