### PR TITLE
Revert "iio: iio_app: print hello message later"

### DIFF
--- a/iio/iio_app/iio_app.c
+++ b/iio/iio_app/iio_app.c
@@ -340,6 +340,11 @@ int iio_app_init(struct iio_app_desc **app,
 	if (status < 0)
 		goto error_uart;
 
+	status = print_uart_hello_message(&uart_desc,
+					  &app_init_param.uart_init_params);
+	if (status < 0)
+		goto error;
+
 	application->uart_desc = uart_desc;
 #if defined(NO_OS_LWIP_NETWORKING)
 	status = lwip_network_setup(application, app_init_param, &iio_init_param);
@@ -399,11 +404,6 @@ int iio_app_init(struct iio_app_desc **app,
 		goto error;
 
 	no_os_free(iio_init_devs);
-
-	status = print_uart_hello_message(&uart_desc,
-					  &app_init_param.uart_init_params);
-	if (status < 0)
-		goto error;
 
 	*app = application;
 


### PR DESCRIPTION
This reverts commit 47e4fd3f239d82fd3266bd0f4a56e5a983a77fe5.

## Pull Request Description

The print_uart_hello_message() function initializes the uart descriptor used subsequently in the iio app initialization phase (it is passed to iio_init_param.uart_desc). 

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
