### PR TITLE
Add max42500 driver and sample project

### DIFF
--- a/doc/sphinx/source/drivers/max42500.rst
+++ b/doc/sphinx/source/drivers/max42500.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../drivers/power/max42500/README.rst

--- a/doc/sphinx/source/drivers_doc.rst
+++ b/doc/sphinx/source/drivers_doc.rst
@@ -86,3 +86,4 @@ POWER MANAGEMENT
    drivers/ltc4296
    drivers/lt7182s
    drivers/lt8722
+   drivers/max42500

--- a/doc/sphinx/source/projects/max42500.rst
+++ b/doc/sphinx/source/projects/max42500.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../projects/max42500/README.rst

--- a/doc/sphinx/source/projects_doc.rst
+++ b/doc/sphinx/source/projects_doc.rst
@@ -72,6 +72,7 @@ POWER MANAGEMENT
    projects/ltc4296
    projects/lt7182s
    projects/lt8722
+   projects/max42500
 
 DAC
 ===

--- a/drivers/power/max42500/README.rst
+++ b/drivers/power/max42500/README.rst
@@ -1,0 +1,148 @@
+MAX42500 no-OS driver
+=====================
+
+Supported Devices
+-----------------
+`MAX42500 <https://www.analog.com/en/products/max42500>`_
+
+Overview
+--------
+
+The MAX42500 is a SoC power-system monitor with up to seven voltage monitor 
+inputs that will be SIL 3-Certified. Each input has programmable OV/UV 
+thresholds of between 2.5% and 10% with ±1.3% accuracy over the full temperature 
+range. Two of the inputs have a separate remote ground-sense input and support 
+DVS through the integrated I2C interface.
+
+The MAX42500 contains a programmable flexible power sequence recorder (FPSR). 
+This recorder stores power-up and power-down timestamps separately, and supports 
+on/off and sleep/standby power sequences. The MAX42500 also contains a 
+programmable challenge/response watchdog, which is accessible through the I2C 
+interface, along with a configurable RESET output.
+
+Applications
+------------
+* Industrial Process Control
+* Robotics
+* Remote Sensor Modules
+* Power System Supervision
+* MCU/SoC Monitoring
+
+MAX42500 Device Configuration
+-----------------------------
+
+Driver Initialization
+---------------------
+In order to be able to use the device, you will have to provide the support for 
+the communication protocol (I2C) alongside other GPIO pins if needed for the 
+specific application (depends on the way the device is used).
+
+The first API to be called is **max42500_init**. Make sure that it returns 0, which
+means that the driver was initialized correctly.
+
+Voltage Monitor
+---------------
+The MAX42500 has up to seven voltage monitor channels. Five of the monitors 
+feature single-ended inputs. For these channels, you first set a nominal
+voltage, followed by setting the overvoltage (OV) and undervoltage 
+(UV) thresholds as a percentage of that nominal voltage. The other two monitors 
+have differential inputs and share a remote ground-sense pin (INM). Unlike the 
+single-ended monitors, which use a nominal voltage plus percentage-based OV/UV 
+configuration, the differential inputs have independent OV and UV comparators, 
+each of which can be configured with its own reference voltage. 
+
+IN1 through IN4 have a nominal voltage set-point range of 0.50V to 3.6875V, 
+while IN5 has an extended range of 0.50V to 5.50V. This can be set using 
+**max42500_set_nominal_voltage** API. 
+
+The OV and UV thresholds can be set using
+**max42500_set_ov_thresh1** API and **max42500_set_uv_thresh1** API for IN1 
+through IN5, from 2.5% to 10% in 0.5% steps. IN6P and IN7P have the differential 
+configuration. Their OV and UV set points can range from 0.50V to 1.775V and can 
+be set using **max42500_set_ov_thresh2** API and **max42500_set_uv_thresh2** API.
+
+Aside from OV and UV comparators, every monitor channel also has an OFF 
+comparator that asserts when the monitor input voltage falls below 0.25V. The
+statuses of these comparators can be read using the **max42500_get_comp_status**
+API.
+
+Power-Up and Power-Down Timestamps
+-----------------------------------
+A power-up timestamp is recorded for an enabled channel when the associated 
+voltage rises above the programmed UV threshold. A power-down timestamp is 
+recorded for an enabled channel when the associated voltage falls below the 
+OFF threshold.
+
+The power-up and power-down timestamps can be read using the
+**max42500_get_power_up_timestamp** API and **max42500_get_power_down_timestamp**
+API respectively.
+
+Watchdog Configuration
+----------------------
+The device contains a windowed watchdog for external SoC monitoring. 
+Aside from configuring the watchdog in the device initialization, you can 
+enable or disable the watchdog using the **max42500_set_watchdog_enable** API. 
+To refresh the watchdog, you can use the **max42500_set_watchdog_key** API.
+
+RESET Hold Time Configuration
+-----------------------------
+The device features an open-drain interrupt/reset output that asserts low when 
+any mapped fault conditions occur. RESET remains asserted for a fixed timeout 
+period after all triggering fault conditions are removed. The fixed timeout 
+period can be set to 6μs, 8ms, 16ms, or 32ms using the 
+**max42500_set_watchdog_rhld** API.
+
+MAX42500 Driver Initialization Example
+--------------------------------------
+
+.. code-block:: bash
+
+	struct max42500_dev *device;
+	struct max_i2c_init_param max42500_i2c_ip;
+	struct max_gpio_init_param max42500_gpio_extra;
+
+	struct max42500_init_param max42500_ip = {
+		.comm_param = {
+			.device_id      = 0,
+			.max_speed_hz   = 400000,
+			.slave_address  = MAX42500_ADDR(0),
+			.platform_ops   = &max_i2c_ops,
+			.extra          = (void *)&max42500_i2c_ip,
+		},
+		.en0_param = {
+			.port           = 2,
+			.number         = 26,
+			.pull           = NO_OS_PULL_DOWN,
+			.platform_ops   = &max_gpio_ops,
+			.extra          = (void *)&max42500_gpio_extra,
+		},
+		.en1_param = {
+			.port           = 2,
+			.number         = 29,
+			.pull           = NO_OS_PULL_DOWN,
+			.platform_ops   = &max_gpio_ops,
+			.extra          = (void *)&max42500_gpio_extra,
+		},
+		.addr_param = {
+			.port           = 2,
+			.number         = 9,
+			.pull           = NO_OS_PULL_DOWN,
+			.platform_ops   = &max_gpio_ops,
+			.extra          = (void *)&max42500_gpio_extra,
+		},
+		.addr_sel   = 0,
+		.pece       = NO_OS_BIT(0),
+		.vmon_en    = NO_OS_BIT(0),
+		.vmon_vmpd  = NO_OS_BIT(7),
+		.reset_map  = NO_OS_BIT(0),
+		.wd_mode    = MAX42500_WD_MODE_SIMPLE,
+		.wd_en      = NO_OS_BIT(3),
+		.wd_close   = 0x00,
+		.wd_open    = 0x00,
+		.wd_cdiv    = 0x00,
+		.wd_1ud     = 0x00,
+	};
+
+	ret = max42500_init(&device, &max42500_ip);
+	if (ret)
+		goto error;

--- a/drivers/power/max42500/max42500.c
+++ b/drivers/power/max42500/max42500.c
@@ -1,0 +1,831 @@
+/***************************************************************************//**
+ *   @file   max42500.c
+ *   @brief  Source file of MAX42500 Driver.
+ *   @author Mark Sapungan (Mark.Sapungan@analog.com)
+ *   @author Joshua Maniti (Joshua.Maniti@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include "max42500.h"
+#include "no_os_error.h"
+#include "no_os_util.h"
+#include "no_os_alloc.h"
+#include "no_os_crc8.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+#define CRC8_PEC        0x07      /* Implements Polynomial X^8 + X^2 + X^1 +1 */
+
+/******************************************************************************/
+/************************ Variable Declarations ******************************/
+/******************************************************************************/
+NO_OS_DECLARE_CRC8_TABLE(max42500_crc8);
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+/******************************************************************************/
+
+/**
+ * @brief Set device state through EN0 and EN1 pins.
+ * @param desc - The device structure.
+ * @param state - Device state.
+ * @return 0 in case of success, error code otherwise.
+ */
+int max42500_set_state(struct max42500_dev *desc, enum max42500_state state)
+{
+	int ret;
+	uint8_t en0;
+	uint8_t en1;
+
+	if (!desc)
+		return -EINVAL;
+
+	switch (state) {
+	case MAX42500_STATE_OFF:
+		en0 = NO_OS_GPIO_LOW;
+		en1 = NO_OS_GPIO_LOW;
+		break;
+
+	case MAX42500_STATE_SLEEP:
+		en0 = NO_OS_GPIO_HIGH;
+		en1 = NO_OS_GPIO_LOW;
+		break;
+
+	case MAX42500_STATE_ON:
+		en0 = NO_OS_GPIO_HIGH;
+		en1 = NO_OS_GPIO_HIGH;
+		break;
+
+	default:
+		return -EINVAL;
+	}
+
+	ret = no_os_gpio_set_value(desc->en0, en0);
+	if (ret)
+		return ret;
+
+	return no_os_gpio_set_value(desc->en1, en1);
+}
+
+/**
+ * @brief Read a raw value from a register.
+ * @param desc - The device structure.
+ * @param reg_addr - Address of the register to be written.
+ * @param reg_data - Pointer to store the read data.
+ * @return 0 in case of success, error code otherwise.
+ */
+int max42500_reg_read(struct max42500_dev *desc,
+		      uint8_t reg_addr,
+		      uint8_t *reg_data)
+{
+	int ret;
+	uint8_t i2c_data[MAX42500_I2C_RD_FRAME_SIZE] = {0};
+	uint8_t bytes_number;
+	uint8_t crc;
+
+	/* PEC is computed over entire I2C frame from the first START condition */
+	i2c_data[0] = (desc->comm_desc->slave_address << 1);
+	i2c_data[1] = reg_addr;
+	i2c_data[2] = (desc->comm_desc->slave_address << 1) | 0x1;
+
+	/* I2C write target address */
+	bytes_number = 1;
+
+	ret = no_os_i2c_write(desc->comm_desc, &i2c_data[1], bytes_number, 0);
+	if (ret)
+		return ret;
+
+	/* Change read byte count if PECE is enabled (1-byte data. 1-byte PEC) */
+	bytes_number = (desc->pece) ? 2 : bytes_number;
+
+	ret = no_os_i2c_read(desc->comm_desc, &i2c_data[3], bytes_number, 1);
+	if (ret)
+		return ret;
+
+	if (desc->pece) {
+		/* Compute CRC over entire I2C frame */
+		crc = no_os_crc8(max42500_crc8, i2c_data,
+				 (MAX42500_I2C_RD_FRAME_SIZE - 1), 0);
+
+		if (i2c_data[4] != crc)
+			return -EIO;
+	}
+
+	*reg_data = i2c_data[3];
+
+	return 0;
+}
+
+/**
+ * @brief Write a raw value to a register.
+ * @param desc - The device structure.
+ * @param reg_addr - Address of the register to be written.
+ * @param data - Data to write to register.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int max42500_reg_write(struct max42500_dev *desc,
+		       uint8_t reg_addr,
+		       uint8_t data)
+{
+	uint8_t i2c_data[MAX42500_I2C_WR_FRAME_SIZE] = {0};
+	uint8_t bytes_number;
+
+	bytes_number = (desc->pece) ? (MAX42500_I2C_WR_FRAME_SIZE - 1) : 2;
+	i2c_data[0] = (desc->comm_desc->slave_address << 1);
+	i2c_data[1] = reg_addr;
+	i2c_data[2] = (uint8_t)(data & 0xFF);
+
+	if (desc->pece)
+		i2c_data[3] = no_os_crc8(max42500_crc8, i2c_data,
+					 bytes_number, 0);
+
+	return no_os_i2c_write(desc->comm_desc, &i2c_data[1], bytes_number, 1);
+}
+
+/**
+ * @brief Update a register's value based on a mask.
+ * @param desc - The device structure.
+ * @param reg_addr - Address of the register to be written.
+ * @param mask - The bits that may be modified.
+ * @param data - Data to write to register
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int max42500_reg_update(struct max42500_dev *desc,
+			uint8_t reg_addr,
+			uint8_t mask,
+			uint8_t data)
+{
+	int ret;
+	uint8_t reg_data;
+
+	ret = max42500_reg_read(desc, reg_addr, &reg_data);
+	if (ret)
+		return ret;
+
+	reg_data &= ~mask;
+	reg_data |= mask & data;
+
+	return max42500_reg_write(desc, reg_addr, reg_data);
+}
+
+/**
+ * @brief Set nominal voltage for VM1 to VM5.
+ * @param desc - The device structure.
+ * @param vm_in - The voltage monitor input.
+ * @param voltage - Nominal voltage to set in volts.
+ *                  Example: 0.5 to 3.6875 for VM1 to VM4
+ *                           0.5 to 5.6 for VM5
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int max42500_set_nominal_voltage(struct max42500_dev *desc,
+				 enum max42500_vm_input vm_in,
+				 float voltage)
+{
+	uint8_t reg_val;
+	uint8_t reg_addr;
+
+	switch (vm_in) {
+	case MAX42500_VM1:
+	case MAX42500_VM2:
+	case MAX42500_VM3:
+	case MAX42500_VM4:
+		if ((voltage < MAX42500_MIN_VNOM) ||
+		    (voltage > MAX42500_VNOM_MAX_VM1_VM4))
+			return -EINVAL;
+		reg_val = (uint8_t)((voltage - MAX42500_MIN_VNOM) /
+				    MAX42500_VNOM_STEP_VM1_VM4);
+		reg_addr = MAX42500_REG_VIN1 + vm_in;
+		break;
+	case MAX42500_VM5:
+		if ((voltage < MAX42500_MIN_VNOM) ||
+		    (voltage > MAX42500_VNOM_MAX_VM5))
+			return -EINVAL;
+		reg_val = (uint8_t)((voltage - MAX42500_MIN_VNOM) /
+				    MAX42500_VNOM_STEP_VM5);
+		reg_addr = MAX42500_REG_VIN5;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return max42500_reg_write(desc, reg_addr, reg_val);
+}
+
+/**
+ * @brief Get the status of the voltage monitor input.
+ * @param desc - The device structure.
+ * @param vm_in - The voltage monitor input.
+ * @param comp_stat - Status to read.
+ *                    Example: MAX42500_COMP_STAT_OFF - Comparator off status
+ *                             MAX42500_COMP_STAT_UV - Undervoltage status
+ *                             MAX42500_COMP_STAT_OV - Overvoltage status
+ * @param status - Pointer to store the status.
+ *                 Example: 0 - below OV threshold; above UV, OFF threshold
+ * 			    1 - above OV threshold; below UV, OFF threshold
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int max42500_get_comp_status(struct max42500_dev *desc,
+			     enum max42500_vm_input vm_in,
+			     enum max42500_comp_stat comp_stat,
+			     uint8_t *status)
+{
+	int ret;
+	uint8_t reg_addr;
+	uint8_t vm_in_status;
+
+	switch (comp_stat) {
+	case MAX42500_COMP_STAT_OFF:
+		reg_addr = MAX42500_REG_STATOFF;
+		break;
+	case MAX42500_COMP_STAT_UV:
+		reg_addr = MAX42500_REG_STATUV;
+		break;
+	case MAX42500_COMP_STAT_OV:
+		reg_addr = MAX42500_REG_STATOV;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	ret = max42500_reg_read(desc, reg_addr, &vm_in_status);
+	if (ret)
+		return ret;
+
+	*status = (uint8_t)no_os_field_get(NO_OS_BIT(vm_in), vm_in_status);
+
+	return 0;
+}
+
+
+/**
+ * @brief Set the overvoltage threshold of VM1 to VM5.
+ * @param desc - The device structure.
+ * @param vm_in - The voltage monitor input.
+ * @param thresh - The overvoltage threshold in percentage (2.5% to 10%).
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int max42500_set_ov_thresh1(struct max42500_dev *desc,
+			    enum max42500_vm_input vm_in,
+			    float thresh)
+{
+	uint8_t ov_val;
+
+	if ((thresh < MAX42500_MIN_THRESH_VM1_VM5) ||
+	    (thresh > MAX42500_MAX_THRESH_VM1_VM5))
+		return -EINVAL;
+
+	switch (vm_in) {
+	case MAX42500_VM1:
+	case MAX42500_VM2:
+	case MAX42500_VM3:
+	case MAX42500_VM4:
+	case MAX42500_VM5:
+		/* Compute the value of OV to be written in the register*/
+		ov_val = (uint8_t)
+			 NO_OS_DIV_ROUND_CLOSEST(((1 + (thresh / 100)) - 1.025),
+						 0.005);
+		return max42500_reg_update(desc,
+					   MAX42500_REG_OVUV1 + vm_in,
+					   NO_OS_GENMASK(7,4),
+					   no_os_field_prep(NO_OS_GENMASK(7,4),
+							   ov_val));
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Set the overvoltage threshold of VM6 and VM7.
+ * @param desc - The device structure.
+ * @param vm_in - The voltage monitor input.
+ * @param thresh - The overvoltage threshold in volts (0.5V to 1.775V).
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int max42500_set_ov_thresh2(struct max42500_dev *desc,
+			    enum max42500_vm_input vm_in,
+			    float thresh)
+{
+	uint8_t reg_addr;
+	uint8_t ov_val;
+
+	if ((thresh < MAX42500_MIN_THRESH_VM6_V7) ||
+	    (thresh > MAX42500_MAX_THRESH_VM6_V7))
+		return -EINVAL;
+
+	switch (vm_in) {
+	case MAX42500_VM6:
+		reg_addr = MAX42500_REG_VINO6;
+		break;
+	case MAX42500_VM7:
+		reg_addr = MAX42500_REG_VINO7;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	ov_val = (uint8_t)NO_OS_DIV_ROUND_CLOSEST((thresh - 0.5), 0.005);
+
+	return max42500_reg_write(desc, reg_addr, ov_val);
+}
+
+/**
+ * @brief Set the undervoltage threshold of VM1 to VM5.
+ * @param desc - The device structure.
+ * @param vm_in - The voltage monitor input.
+ * @param thresh - The undervoltage threshold in percentage (2.5% to 10%).
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int max42500_set_uv_thresh1(struct max42500_dev *desc,
+			    enum max42500_vm_input vm_in,
+			    float thresh)
+{
+	uint8_t uv_val;
+
+	if ((thresh < MAX42500_MIN_THRESH_VM1_VM5) ||
+	    (thresh > MAX42500_MAX_THRESH_VM1_VM5))
+		return -EINVAL;
+
+	switch (vm_in) {
+	case MAX42500_VM1:
+	case MAX42500_VM2:
+	case MAX42500_VM3:
+	case MAX42500_VM4:
+	case MAX42500_VM5:
+		uv_val = (uint8_t)
+			 NO_OS_DIV_ROUND_CLOSEST(((1 - (thresh / 100)) - 0.975),
+						 -0.005);
+		return max42500_reg_update(desc,
+					   MAX42500_REG_OVUV1 + vm_in,
+					   NO_OS_GENMASK(3,0),
+					   uv_val);
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Set the undervoltage threshold of VM6 and VM7.
+ * @param desc - The device structure.
+ * @param vm_in - The voltage monitor input.
+ * @param thresh - The overvoltage threshold in volts (0.5V to 1.775V).
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int max42500_set_uv_thresh2(struct max42500_dev *desc,
+			    enum max42500_vm_input vm_in,
+			    float thresh)
+{
+	uint8_t reg_addr;
+	uint8_t uv_val;
+
+	if ((thresh < MAX42500_MIN_THRESH_VM6_V7) ||
+	    (thresh > MAX42500_MAX_THRESH_VM6_V7))
+		return -EINVAL;
+
+	switch (vm_in) {
+	case MAX42500_VM6:
+		reg_addr = MAX42500_REG_VINU6;
+		break;
+	case MAX42500_VM7:
+		reg_addr = MAX42500_REG_VINU7;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	uv_val = (uint8_t)NO_OS_DIV_ROUND_CLOSEST((thresh - 0.5), 0.005);
+
+	return max42500_reg_write(desc, reg_addr, uv_val);
+}
+
+/**
+ * @brief Get the FPS clock divider value.
+ * @param desc - The device structure.
+ * @param fps_clk_div Pointer to a variable where the FPS clock divider value
+ *                    will be stored.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+static int max42500_get_fps_clk_div(struct max42500_dev *desc,
+				    uint8_t *fps_clk_div)
+{
+	int ret;
+	uint8_t reg_val;
+
+	ret = max42500_reg_read(desc, MAX42500_REG_FPSCFG1, &reg_val);
+	if (ret)
+		return ret;
+
+	*fps_clk_div = (uint8_t)no_os_field_get(NO_OS_GENMASK(2,0), reg_val);
+
+	return 0;
+}
+
+/**
+ * @brief Get the power-up timestamp for a specified voltage monitor input.
+ * @param desc - The device structure.
+ * @param vm_in - The voltage monitor input for which to get the timestamp.
+ * @param timestamp - The timestamp in microseconds.
+ *                    If the input voltage never rose above the UV threshold,
+ *                    the timestamp will be set to 0.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int max42500_get_power_up_timestamp(struct max42500_dev *desc,
+				    enum max42500_vm_input vm_in,
+				    uint8_t *timestamp)
+{
+	int ret;
+	uint8_t reg_val;
+	uint8_t fps_clk_div;
+
+	ret = max42500_reg_read(desc, MAX42500_REG_UTIME1 + vm_in, &reg_val);
+	if (ret)
+		return ret;
+
+	// Check if the input voltage rose above the UV threshold
+	if (reg_val == 0) {
+		// Input voltage never rose above UV threshold
+		*timestamp = 0;
+		return 0;
+	}
+
+	ret = max42500_get_fps_clk_div(desc, &fps_clk_div);
+	if (ret)
+		return ret;
+
+	*timestamp = (reg_val - 1) * 25 * (1 << fps_clk_div);
+
+	return 0;
+}
+
+/**
+ * @brief Get the power-down timestamp for a specified voltage monitor input.
+ * @param desc - The device structure.
+ * @param vm_in - The voltage monitor input for which to get the timestamp.
+ * @param timestamp - The timestamp in microseconds.
+ *                    If the input voltage never rose above the UV threshold,
+ *                    the timestamp will be set to 0.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int max42500_get_power_down_timestamp(struct max42500_dev *desc,
+				      enum max42500_vm_input vm_in,
+				      uint8_t *timestamp)
+{
+	int ret;
+	uint8_t reg_val;
+	uint8_t fps_clk_div;
+
+	ret = max42500_reg_read(desc, MAX42500_REG_DTIME1 + vm_in, &reg_val);
+	if (ret)
+		return ret;
+
+	// Check if the input voltage fell below the the OFF threshold
+	if (reg_val == 0) {
+		// Input voltage never fell below OFF threshold
+		*timestamp = 0;
+		return 0;
+	}
+
+	ret = max42500_get_fps_clk_div(desc, &fps_clk_div);
+	if (ret)
+		return ret;
+
+	*timestamp = (reg_val - 1) * 25 * (1 << fps_clk_div);
+
+	return 0;
+}
+
+/**
+ * @brief Enable/Disable watchdog
+ * @param desc - The device structure.
+ * @param wd_enable - Enable/disable MAX42500 watchdog.
+ * @return 0 in case of success, error code otherwise
+ */
+int max42500_set_watchdog_enable(struct max42500_dev *desc, bool wd_enable)
+{
+	int ret;
+	uint8_t reg_val;
+
+	ret = max42500_reg_read(desc, MAX42500_REG_WDCFG2, &reg_val);
+	if (ret)
+		return ret;
+
+	if (wd_enable)
+		reg_val |= NO_OS_BIT(3);
+	else
+		reg_val &= ~NO_OS_BIT(3);
+
+	return max42500_reg_write(desc, MAX42500_REG_WDCFG2, reg_val);
+}
+
+/**
+ * @brief 8-bit watchdog key computation.
+ * @param desc - The device structure.
+ * @param new_wd_key - New watchdog key.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+static int max42500_new_watchdog_key(struct max42500_dev *desc,
+				     uint8_t *new_wd_key)
+{
+	int ret;
+	uint8_t curr_wd_key;
+
+	ret = max42500_reg_read(desc, MAX42500_REG_WDKEY, &curr_wd_key);
+	if (ret)
+		return ret;
+
+	/* Calculate the new bit using the LFSR polynomial */
+	uint8_t new_bit = ((curr_wd_key >> 7) ^
+			   (curr_wd_key >> 5) ^
+			   (curr_wd_key >> 4) ^
+			   (curr_wd_key >> 3)) & 0x01;
+
+	/* Shift existing bits upwards toward MSb and insert the new bit as LSb */
+	*new_wd_key = (curr_wd_key << 1) | new_bit;
+
+	return 0;
+}
+
+/**
+ * @brief Update the watchdog key based on the mode and current value.
+ * @param desc - The device structure.
+ * @return 0 in case of success, error code otherwise.
+ */
+int max42500_set_watchdog_key(struct max42500_dev *desc)
+{
+	int ret;
+	uint8_t reg_val;
+	uint8_t wd_key;
+	uint8_t wd_mode;
+
+	ret = max42500_reg_read(desc, MAX42500_REG_WDKEY, &wd_key);
+	if (ret)
+		return ret;
+
+	ret = max42500_reg_read(desc, MAX42500_REG_WDCDIV, &reg_val);
+	if (ret)
+		return ret;
+
+	wd_mode = (uint8_t)no_os_field_get(NO_OS_BIT(6), reg_val);
+
+	/* Compute new watchdog key for challenge/response mode */
+	if (wd_mode == MAX42500_WD_MODE_CH_RESP)
+		max42500_new_watchdog_key(desc, &wd_key);
+
+	return max42500_reg_write(desc, MAX42500_REG_WDKEY, wd_key);
+}
+
+/** @brief Set watchdog reset hold time
+ * @param desc - The device structure.
+ * @param rhld - Reset hold time to set.
+ * @return 0 in case of success, error code otherwise
+ */
+int max42500_set_watchdog_rhld(struct max42500_dev *desc,
+			       enum max42500_wd_rhld rhld)
+{
+	return max42500_reg_update(desc,
+				   MAX42500_REG_RSTCTRL,
+				   NO_OS_GENMASK(1,0),
+				   rhld);
+}
+
+/**
+ * @brief Initialize the device structure.
+ * @param desc - The device structure to be initialized.
+ * @param init_param - Initialization parameter for the device descriptor.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int max42500_init(struct max42500_dev **desc,
+		  struct max42500_init_param *init_param)
+{
+	int ret;
+	struct max42500_dev *descriptor;
+	uint8_t device_id;
+
+	no_os_crc8_populate_msb(max42500_crc8, CRC8_PEC);
+
+	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	descriptor->pece = 0x00;
+
+	/* Initialize GPIOs for device pins */
+	ret = no_os_gpio_get(&descriptor->en0, &init_param->en0_param);
+	if (ret)
+		goto free_desc;
+
+	ret = no_os_gpio_get(&descriptor->en1, &init_param->en1_param);
+	if (ret)
+		goto free_en0;
+
+	ret = no_os_gpio_get(&descriptor->addr, &init_param->addr_param);
+	if (ret)
+		goto free_en1;
+
+	/* Enable EN0 and EN1 GPIO output with default values */
+	ret = no_os_gpio_direction_output(descriptor->en0, NO_OS_GPIO_HIGH);
+	if (ret)
+		goto free_addr;
+
+	ret = no_os_gpio_direction_output(descriptor->en1, NO_OS_GPIO_HIGH);
+	if (ret)
+		goto free_addr;
+
+	/* Enable I2C addr selection */
+	ret = no_os_gpio_direction_output(descriptor->addr, init_param->addr_sel);
+	if (ret)
+		goto free_addr;
+
+	/* Initialize I2C communication */
+	ret = no_os_i2c_init(&descriptor->comm_desc, &init_param->comm_param);
+	if (ret)
+		goto free_addr;
+
+	/* Check device silicon ID */
+	ret = max42500_reg_read(descriptor, MAX42500_REG_ID, &device_id);
+	if (ret)
+		goto free_i2c;
+
+	if (device_id != MAX42500_SILICON_ID) {
+		ret = -ENODEV;
+		goto free_i2c;
+	}
+
+	/* Configure PEC */
+	ret = max42500_reg_update(descriptor,
+				  MAX42500_REG_CONFIG1,
+				  NO_OS_BIT(0),
+				  init_param->pece);
+	if (ret)
+		goto free_i2c;
+
+	/* Set PEC enable/disable for subsequent register access */
+	descriptor->pece = init_param->pece;
+
+	/* Enable voltage monitor inputs */
+	ret = max42500_reg_update(descriptor,
+				  MAX42500_REG_VMON,
+				  NO_OS_GENMASK(6,0),
+				  init_param->vmon_en);
+	if (ret)
+		goto free_i2c;
+
+	/* Enable voltage monitor power-down */
+	ret = max42500_reg_update(descriptor,
+				  MAX42500_REG_VMON,
+				  NO_OS_BIT(7),
+				  init_param->vmon_vmpd);
+	if (ret)
+		goto free_i2c;
+
+	/* Enable input OV/UV mapping to reset pin */
+	ret = max42500_reg_update(descriptor,
+				  MAX42500_REG_RSTMAP,
+				  NO_OS_GENMASK(6,0),
+				  init_param->reset_map);
+	if (ret)
+		goto free_i2c;
+
+	/* Set watchdog mode */
+	ret = max42500_reg_update(descriptor,
+				  MAX42500_REG_WDCDIV,
+				  NO_OS_BIT(6),
+				  init_param->wd_mode << 6);
+	if (ret)
+		goto free_i2c;
+
+	/* Set watchdog clock div */
+	ret = max42500_reg_update(descriptor,
+				  MAX42500_REG_WDCDIV,
+				  NO_OS_GENMASK(5,0),
+				  init_param->wd_cdiv);
+	if (ret)
+		goto free_i2c;
+
+	/* Set watchdog open window */
+	ret = max42500_reg_update(descriptor,
+				  MAX42500_REG_WDCFG1,
+				  NO_OS_GENMASK(3,0),
+				  init_param->wd_open);
+	if (ret)
+		goto free_i2c;
+
+	/* Set watchdog close window */
+	ret = max42500_reg_update(descriptor,
+				  MAX42500_REG_WDCFG1,
+				  NO_OS_GENMASK(7,4),
+				  init_param->wd_close);
+	if (ret)
+		goto free_i2c;
+
+	/* Set watchdog first update window */
+	ret = max42500_reg_update(descriptor,
+				  MAX42500_REG_WDCFG2,
+				  NO_OS_GENMASK(2,0),
+				  init_param->wd_1ud);
+	if (ret)
+		goto free_i2c;
+
+	/* Set watchdog enable */
+	ret = max42500_reg_update(descriptor,
+				  MAX42500_REG_WDCFG2,
+				  NO_OS_BIT(3),
+				  init_param->wd_en);
+	if (ret)
+		goto free_i2c;
+
+	/* Update parameters */
+	descriptor->wd_mode = init_param->wd_mode;
+	descriptor->wd_cdiv = init_param->wd_cdiv;
+	descriptor->wd_close = init_param->wd_close;
+	descriptor->wd_open = init_param->wd_open;
+	descriptor->wd_1ud = init_param->wd_1ud;
+	descriptor->wd_en = init_param->wd_en;
+
+	/* Update descriptor */
+	*desc = descriptor;
+
+	return 0;
+
+free_i2c:
+	no_os_i2c_remove(descriptor->comm_desc);
+free_addr:
+	no_os_gpio_remove(descriptor->addr);
+free_en1:
+	no_os_gpio_remove(descriptor->en1);
+free_en0:
+	no_os_gpio_remove(descriptor->en0);
+free_desc:
+	no_os_free(descriptor);
+
+	return ret;
+}
+
+/**
+ * @brief Free the device descriptor.
+ * @param desc - The device structure.
+ * @return 0 in case of success, -EINVAL otherwise.
+ */
+int max42500_remove(struct max42500_dev *desc)
+{
+	int ret;
+
+	if (!desc)
+		return -EINVAL;
+
+	ret = no_os_i2c_remove(desc->comm_desc);
+	if (ret)
+		return ret;
+
+	ret = no_os_gpio_remove(desc->addr);
+	if (ret)
+		return ret;
+
+	ret = no_os_gpio_remove(desc->en1);
+	if (ret)
+		return ret;
+
+	ret = no_os_gpio_remove(desc->en0);
+	if (ret)
+		return ret;
+
+	no_os_free(desc);
+
+	return 0;
+}

--- a/drivers/power/max42500/max42500.h
+++ b/drivers/power/max42500/max42500.h
@@ -1,0 +1,306 @@
+/***************************************************************************//**
+ *   @file   max42500.h
+ *   @brief  Header file of MAX42500 Driver.
+ *   @author Mark Sapungan (Mark.Sapungan@analog.com)
+ *   @author Joshua Maniti (Joshua.Maniti@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __MAX42500_H__
+#define __MAX42500_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "no_os_i2c.h"
+#include "no_os_gpio.h"
+
+#define MAX42500_REG_ID                 0x00
+#define MAX42500_REG_CONFIG1            0x01
+#define MAX42500_REG_CONFIG2            0x02
+#define MAX42500_REG_VMON               0x03
+#define MAX42500_REG_RSTMAP             0x04
+#define MAX42500_REG_STATOV             0x05
+#define MAX42500_REG_STATUV             0x06
+#define MAX42500_REG_STATOFF            0x07
+#define MAX42500_REG_VIN1               0x08
+#define MAX42500_REG_VIN2               0x09
+#define MAX42500_REG_VIN3               0x0A
+#define MAX42500_REG_VIN4               0x0B
+#define MAX42500_REG_VIN5               0x0C
+#define MAX42500_REG_VINO6              0x0D
+#define MAX42500_REG_VINU6              0x0E
+#define MAX42500_REG_VINO7              0x0F
+#define MAX42500_REG_VINU7              0x10
+#define MAX42500_REG_OVUV1              0x11
+#define MAX42500_REG_OVUV2              0x12
+#define MAX42500_REG_OVUV3              0x13
+#define MAX42500_REG_OVUV4              0x14
+#define MAX42500_REG_OVUV5              0x15
+#define MAX42500_REG_FPSSTAT1           0x16
+#define MAX42500_REG_FPSCFG1            0x17
+#define MAX42500_REG_UTIME1             0x18
+#define MAX42500_REG_UTIME2             0x19
+#define MAX42500_REG_UTIME3             0x1A
+#define MAX42500_REG_UTIME4             0x1B
+#define MAX42500_REG_UTIME5             0x1C
+#define MAX42500_REG_UTIME6             0x1D
+#define MAX42500_REG_UTIME7             0x1E
+#define MAX42500_REG_DTIME1             0x1F
+#define MAX42500_REG_DTIME2             0x20
+#define MAX42500_REG_DTIME3             0x21
+#define MAX42500_REG_DTIME4             0x22
+#define MAX42500_REG_DTIME5             0x23
+#define MAX42500_REG_DTIME6             0x24
+#define MAX42500_REG_DTIME7             0x25
+#define MAX42500_REG_WDSTAT             0x26
+#define MAX42500_REG_WDCDIV             0x27
+#define MAX42500_REG_WDCFG1             0x28
+#define MAX42500_REG_WDCFG2             0x29
+#define MAX42500_REG_WDKEY              0x2A
+#define MAX42500_REG_WDLOCK             0x2B
+#define MAX42500_REG_RSTCTRL            0x2C
+#define MAX42500_REG_CID                0x2D
+
+/** X is set based on the pull configuration of the ADDR pin */
+#define MAX42500_ADDR(x)                (0x28 + (x))
+#define MAX42500_SILICON_ID             (0x30)
+#define MAX42500_I2C_WR_FRAME_SIZE      (4)
+#define MAX42500_I2C_RD_FRAME_SIZE      (5)
+
+/** MAX42500 Nominal voltage computation */
+#define MAX42500_VNOM_MAX_VM1_VM4       3.6875
+#define MAX42500_VNOM_MAX_VM5           5.6
+#define MAX42500_MIN_VNOM               0.5
+#define MAX42500_VNOM_STEP_VM1_VM4      0.0125
+#define MAX42500_VNOM_STEP_VM5          0.02
+
+/** MAX42500 Undervoltage/Overvoltage maximum and minimum thresholds*/
+#define MAX42500_MAX_THRESH_VM1_VM5     10
+#define MAX42500_MIN_THRESH_VM1_VM5     2.5
+#define MAX42500_MAX_THRESH_VM6_V7      1.775
+#define MAX42500_MIN_THRESH_VM6_V7      0.5
+
+/* MAX42500 device state */
+enum max42500_state {
+	MAX42500_STATE_OFF,
+	MAX42500_STATE_SLEEP,
+	MAX42500_STATE_ON,
+	MAX42500_STATE_MAX
+};
+
+/* MAX42500 voltage monitor input */
+enum max42500_vm_input {
+	MAX42500_VM1,
+	MAX42500_VM2,
+	MAX42500_VM3,
+	MAX42500_VM4,
+	MAX42500_VM5,
+	MAX42500_VM6,
+	MAX42500_VM7,
+	MAX42500_VM_MAX
+};
+
+/* MAX42500 comparator status */
+enum max42500_comp_stat {
+	MAX42500_COMP_STAT_OFF,
+	MAX42500_COMP_STAT_UV,
+	MAX42500_COMP_STAT_OV,
+	MAX42500_COMP_STAT_MAX
+};
+
+/* MAX42500 watchdog mode */
+enum max42500_wd_mode {
+	MAX42500_WD_MODE_CH_RESP,
+	MAX42500_WD_MODE_SIMPLE,
+	MAX42500_WD_MODE_MAX
+};
+
+/* MAX42500 reset hold/active timeout time. */
+enum max42500_wd_rhld {
+	MAX42500_WD_RHOLD_0_MS,
+	MAX42500_WD_RHOLD_8_MS,
+	MAX42500_WD_RHOLD_16_MS,
+	MAX42500_WD_RHOLD_32_MS,
+	MAX42500_WD_RHOLD_MAX
+};
+
+/**
+ * @brief Initialization parameter for the device descriptor
+ */
+struct max42500_init_param {
+	/* I2C */
+	struct no_os_i2c_init_param comm_param;
+	/* EN0 pin GPIO */
+	struct no_os_gpio_init_param en0_param;
+	/* EN1 pin GPIO */
+	struct no_os_gpio_init_param en1_param;
+	/* ADDR pin GPIO */
+	struct no_os_gpio_init_param addr_param;
+	/* ADDR selection  */
+	uint8_t addr_sel;
+	/* Packet error checking enable */
+	uint8_t pece;
+	/* Enabled voltage monitor inputs */
+	uint8_t vmon_en;
+	/* Voltage monitor power down enable */
+	uint8_t vmon_vmpd;
+	/* Enabled voltage monitor reset mapping */
+	uint8_t reset_map;
+	/* Watchdog mode */
+	enum max42500_wd_mode wd_mode;
+	/* Watchdog clock div */
+	uint8_t wd_cdiv;
+	/* Watchdog close window */
+	uint8_t wd_close;
+	/* Watchdog open window */
+	uint8_t wd_open;
+	/* Watchdog first update window */
+	uint8_t wd_1ud;
+	/* Watchdog enable */
+	uint8_t wd_en;
+};
+
+/**
+ * @brief max42500 device descriptor
+ */
+struct max42500_dev {
+	/* I2C */
+	struct no_os_i2c_desc *comm_desc;
+	/* EN0 pin GPIO */
+	struct no_os_gpio_desc *en0;
+	/* EN1 pin GPIO */
+	struct no_os_gpio_desc *en1;
+	/* ADDR pin GPIO */
+	struct no_os_gpio_desc *addr;
+	/* ADDR selection  */
+	uint8_t addr_sel;
+	/* Packet error checking enable */
+	uint8_t pece;
+	/* Enabled voltage monitor inputs */
+	uint8_t vmon_en;
+	/* Voltage monitor power down enable */
+	uint8_t vmon_vmpd;
+	/* Enabled voltage monitor reset mapping */
+	uint8_t reset_map;
+	/* Watchdog mode */
+	enum max42500_wd_mode wd_mode;
+	/* Watchdog clock div */
+	uint8_t wd_cdiv;
+	/* Watchdog close window */
+	uint8_t wd_close;
+	/* Watchdog open window */
+	uint8_t wd_open;
+	/* Watchdog first update window */
+	uint8_t wd_1ud;
+	/* Watchdog enable */
+	uint8_t wd_en;
+};
+
+/** Set device state through EN0 and EN1 pins */
+int max42500_set_state(struct max42500_dev *desc, enum max42500_state state);
+
+/** Read a register value */
+int max42500_reg_read(struct max42500_dev *desc,
+		      uint8_t reg_addr,
+		      uint8_t *reg_data);
+
+/** Write a register value */
+int max42500_reg_write(struct max42500_dev *desc,
+		       uint8_t reg_addr,
+		       uint8_t data);
+
+/** Update a register's value based on a mask */
+int max42500_reg_update(struct max42500_dev *desc,
+			uint8_t reg_addr,
+			uint8_t mask,
+			uint8_t data);
+
+/** Set nominal voltage for VM1 to VM5 */
+int max42500_set_nominal_voltage(struct max42500_dev *desc,
+				 enum max42500_vm_input vm_in,
+				 float voltage);
+
+/** Get the status of the voltage monitor input */
+int max42500_get_comp_status(struct max42500_dev *desc,
+			     enum max42500_vm_input vm_in,
+			     enum max42500_comp_stat comp_stat,
+			     uint8_t *status);
+
+/** Set the overvoltage threshold of VM1 to VM5 */
+int max42500_set_ov_thresh1(struct max42500_dev *desc,
+			    enum max42500_vm_input vm_in,
+			    float thresh);
+
+/** Set the overvoltage threshold of VM6 and VM7 */
+int max42500_set_ov_thresh2(struct max42500_dev *desc,
+			    enum max42500_vm_input vm_in,
+			    float thresh);
+
+/** Set the undervoltage threshold of VM1 to VM5 */
+int max42500_set_uv_thresh1(struct max42500_dev *desc,
+			    enum max42500_vm_input vm_in,
+			    float thresh);
+
+/** Set the undervoltage threshold of VM6 and VM7 */
+int max42500_set_uv_thresh2(struct max42500_dev *desc,
+			    enum max42500_vm_input vm_in,
+			    float thresh);
+
+/** Get the power-up timestamp for a specified voltage monitor input */
+int max42500_get_power_up_timestamp(struct max42500_dev *desc,
+				    enum max42500_vm_input vm_in,
+				    uint8_t *timestamp);
+
+/** Get the power-down timestamp for a specified voltage monitor input */
+int max42500_get_power_down_timestamp(struct max42500_dev *desc,
+				      enum max42500_vm_input vm_in,
+				      uint8_t *timestamp);
+
+/** Enable/Disable watchdog */
+int max42500_set_watchdog_enable(struct max42500_dev *desc, bool wd_enable);
+
+/** Update the watchdog key based on the mode and current value */
+int max42500_set_watchdog_key(struct max42500_dev *desc);
+
+/** Set watchdog reset hold time */
+int max42500_set_watchdog_rhld(struct max42500_dev *desc,
+			       enum max42500_wd_rhld rhld);
+
+/** Initialize the device structure */
+int max42500_init(struct max42500_dev **, struct max42500_init_param *);
+
+/** Free the device descriptor */
+int max42500_remove(struct max42500_dev *);
+
+#endif // __MAX42500_H__

--- a/projects/max42500/Makefile
+++ b/projects/max42500/Makefile
@@ -1,0 +1,7 @@
+BASIC_EXAMPLE = y
+
+include ../../tools/scripts/generic_variables.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/max42500/README.rst
+++ b/projects/max42500/README.rst
@@ -1,0 +1,102 @@
+MAX42500 no-OS Example Project
+==============================
+
+..contents::
+        :depth: 3
+
+Supported Evaluation Boards
+---------------------------
+
+* `MAX42500 <https://www.analog.com/en/products/max42500>`_
+
+Overview
+--------
+
+The MAX42500 evaluation board is a fully assembled and tested application 
+circuit for the MAX42500 seven-input industrial power-system monitor. The test 
+point taps allow for routing to the other subsystems for monitoring. A dedicated 
+I2C 4-pin header is included for easy interface to an MCU.
+
+Applications
+------------
+
+* Industrial Process Control
+* Robotics
+* Remote Sensor Modules
+* Power System Supervision
+* MCU/SoC Monitoring
+
+Hardware Specifications
+-----------------------
+
+Power Supply Requirements
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The MAX42500 evaluation device must be supplied with 3.3V or 5V.
+
+No-OS Build Setup
+-----------------
+
+Please see: https://wiki.analog.com/resources/no-os/build
+
+No-OS Supported Examples
+------------------------
+
+The initialization data used in the examples is taken out from **Project Common Data Path**.
+
+The macros used in Common Data are defined in platform specific files found in **Project Platform Configuration Path**.
+
+Basic example
+^^^^^^^^^^^^^^^^^^
+
+This is a simple example that initializes the MAX42500 device and configures the 
+nominal voltage and OV/UV thresholds of the voltage monitor input 1. In the while 
+loop, the example reads the status of the voltage monitor input and prints the 
+results to the console. Optionally, varying input signals can be applied to the 
+input voltage monitor pin to test and see the status of the pin.
+
+To build the basic example, ensure you have the following configuration 
+in the **Makefile**:
+
+.. code-block:: bash
+
+	# Select the example you want to enable by choosing y for enabling and n for disabling
+	BASIC_EXAMPLE = y
+
+No-OS Supported Platforms
+-------------------------
+
+Maxim Platform
+^^^^^^^^^^^^^^
+
+**Used hardware**
+
+* `MAX42500 <https://www.analog.com/en/products/max42500>`_
+* `AD-APARD32690-SL <https://www.analog.com/en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/ad-apard32690-sl.html>`_
+
++---------------------+---------------------+-----------------------------+
+| Max42500 test point | Function            | AD-APARD32690-SL Pin Number |
++=====================+=====================+=============================+
+| EN0_H               | Enable Input 0      | P2_26                       |
++---------------------+---------------------+-----------------------------+
+| GND (J31)           | Ground              | GND                         |
++---------------------+---------------------+-----------------------------+
+| EN1_H               | Enable Input 1      | P2_29                       |
++---------------------+---------------------+-----------------------------+
+| VSUP (J31)          | Power Supply        | 3V3                         |
++---------------------+---------------------+-----------------------------+
+| SDA                 | Serial Data Line    | P2_7                        |
++---------------------+---------------------+-----------------------------+
+| SCL                 | Serial Clock Line   | P2_8                        |
++---------------------+---------------------+-----------------------------+
+
+**Build Command**
+
+.. code-block:: bash
+
+        # to delete current build
+        make reset
+        # to build the project
+        make PLATFORM=maxim TARGET=max32690
+        # to flash the code
+        make run

--- a/projects/max42500/builds.json
+++ b/projects/max42500/builds.json
@@ -1,0 +1,7 @@
+{
+	"maxim": {
+		"basic_example_max32690": {
+			"flags" : "BASIC_EXAMPLE=y TARGET=max32690"
+		}
+	}
+}

--- a/projects/max42500/src.mk
+++ b/projects/max42500/src.mk
@@ -1,0 +1,44 @@
+include $(PROJECT)/src/platform/$(PLATFORM)/platform_src.mk
+include $(PROJECT)/src/examples/examples_src.mk
+
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/main.c
+
+INCS += $(PROJECT)/src/common/common_data.h
+SRCS += $(PROJECT)/src/common/common_data.c
+
+INCS += $(PROJECT)/src/platform/platform_includes.h
+
+INCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.h
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.c
+
+SRCS += $(DRIVERS)/api/no_os_uart.c     \
+	$(DRIVERS)/api/no_os_irq.c     	\
+	$(DRIVERS)/api/no_os_gpio.c     	\
+	$(DRIVERS)/api/no_os_timer.c     	\
+	$(DRIVERS)/api/no_os_dma.c     	\
+	$(DRIVERS)/api/no_os_i2c.c  \
+        $(NO-OS)/util/no_os_list.c      \
+        $(NO-OS)/util/no_os_lf256fifo.c \
+        $(NO-OS)/util/no_os_util.c      \
+        $(NO-OS)/util/no_os_alloc.c     \
+        $(NO-OS)/util/no_os_mutex.c     \
+        $(NO-OS)/util/no_os_crc8.c
+
+INCS += $(INCLUDE)/no_os_delay.h     \
+        $(INCLUDE)/no_os_error.h     \
+        $(INCLUDE)/no_os_init.h      \
+        $(INCLUDE)/no_os_timer.h      \
+        $(INCLUDE)/no_os_gpio.h      \
+        $(INCLUDE)/no_os_irq.h       \
+        $(INCLUDE)/no_os_dma.h       \
+        $(INCLUDE)/no_os_lf256fifo.h \
+        $(INCLUDE)/no_os_list.h      \
+        $(INCLUDE)/no_os_uart.h      \
+        $(INCLUDE)/no_os_util.h      \
+	$(INCLUDE)/no_os_i2c.h       \
+        $(INCLUDE)/no_os_alloc.h     \
+        $(INCLUDE)/no_os_mutex.h     \
+        $(INCLUDE)/no_os_crc8.h
+
+INCS += $(DRIVERS)/power/max42500/max42500.h
+SRCS += $(DRIVERS)/power/max42500/max42500.c

--- a/projects/max42500/src/common/common_data.c
+++ b/projects/max42500/src/common/common_data.c
@@ -1,0 +1,89 @@
+/***************************************************************************//**
+ *   @file   common_data.c
+ *   @brief  Defines common data to be used by max42500 examples.
+ *   @author Joshua Maniti (Joshua.Maniti@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "common_data.h"
+#include "maxim_gpio.h"
+#include "maxim_i2c.h"
+#include "maxim_uart.h"
+
+struct no_os_uart_init_param uart_ip = {
+	.device_id             = 0,
+	.asynchronous_rx       = false,
+	.baud_rate             = 115200,
+	.size                  = NO_OS_UART_CS_8,
+	.parity                = NO_OS_UART_PAR_NO,
+	.stop                  = NO_OS_UART_STOP_1_BIT,
+	.extra                 = &uart_extra_ip,
+	.platform_ops          = &max_uart_ops,
+};
+
+struct max42500_init_param max42500_ip = {
+	.comm_param = {
+		.device_id      = MAX42500_I2C_DEVICE_ID,
+		.max_speed_hz   = MAX42500_I2C_CLK_SPEED,
+		.slave_address  = MAX42500_I2C_ADDR,
+		.platform_ops   = &max_i2c_ops,
+		.extra          = (void *)&max42500_i2c_ip,
+	},
+	.en0_param = {
+		.port           = MAX42500_EN0_PORT,
+		.number         = MAX42500_EN0_PIN,
+		.pull           = NO_OS_PULL_DOWN,
+		.platform_ops   = &max_gpio_ops,
+		.extra          = (void *)&max42500_gpio_extra,
+	},
+	.en1_param = {
+		.port           = MAX42500_EN1_PORT,
+		.number         = MAX42500_EN1_PIN,
+		.pull           = NO_OS_PULL_DOWN,
+		.platform_ops   = &max_gpio_ops,
+		.extra          = (void *)&max42500_gpio_extra,
+	},
+	.addr_param = {
+		.port           = MAX42500_ADDR_PORT,
+		.number         = MAX42500_ADDR_PIN,
+		.pull           = NO_OS_PULL_DOWN,
+		.platform_ops   = &max_gpio_ops,
+		.extra          = (void *)&max42500_gpio_extra,
+	},
+	.addr_sel   = MAX42500_ADDR_SEL,
+	.pece       = MAX42500_PECE,
+	.vmon_en    = MAX42500_VMON_EN,
+	.vmon_vmpd  = MAX42500_VMON_VMPD,
+	.reset_map  = MAX42500_RESET_MAP,
+};

--- a/projects/max42500/src/common/common_data.h
+++ b/projects/max42500/src/common/common_data.h
@@ -1,0 +1,52 @@
+/***************************************************************************//**
+ *   @file   common_data.h
+ *   @brief  Defines common data to be used by max42500 examples.
+ *   @author Joshua Maniti (Joshua.Maniti@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __COMMON_DATA_H__
+#define __COMMON_DATA_H__
+
+#include "platform_includes.h"
+#include "no_os_uart.h"
+#include "no_os_util.h"
+#include "no_os_delay.h"
+#include "max42500.h"
+
+extern struct no_os_uart_init_param uart_ip;
+
+extern struct max42500_init_param max42500_ip;
+
+#endif /* __COMMON_DATA_H__ */

--- a/projects/max42500/src/examples/basic/basic_example.c
+++ b/projects/max42500/src/examples/basic/basic_example.c
@@ -1,0 +1,114 @@
+/***************************************************************************//**
+ *   @file   basic_example.c
+ *   @brief  Implementation of basic MAX42500 example
+ *   @author Joshua Maniti (Joshua.Maniti@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include <stdio.h>
+#include "common_data.h"
+
+/*******************************************************************************
+ * @brief MAX42500 basic example main execution.
+ *
+ * @return ret - Result of the example execution.
+*******************************************************************************/
+
+int basic_example_main(void)
+{
+	int ret;
+	struct no_os_uart_desc *uart_desc;
+	struct max42500_dev *device;
+	uint8_t off_stat;
+	uint8_t ov_stat;
+	uint8_t uv_stat;
+
+	ret = no_os_uart_init(&uart_desc, &uart_ip);
+	if (ret)
+		goto free_max42500;
+
+	no_os_uart_stdio(uart_desc);
+
+	printf("********** MAX42500 Voltage Monitor Tests **********\n\r");
+
+	/* Initializing the device MAX42500 */
+	ret = max42500_init(&device, &max42500_ip);
+	if (ret)
+		goto free_max42500;
+
+	ret = max42500_set_nominal_voltage(device, MAX42500_VM1, 2);
+	if (ret)
+		goto free_max42500;
+
+	ret = max42500_set_ov_thresh1(device, MAX42500_VM1, 10);
+	if (ret)
+		goto free_max42500;
+
+	ret = max42500_set_uv_thresh1(device, MAX42500_VM1, 10);
+	if (ret)
+		goto free_max42500;
+
+	while (1) {
+		max42500_get_comp_status(device,
+					 MAX42500_VM1, MAX42500_COMP_STAT_OFF,
+					 &off_stat);
+		max42500_get_comp_status(device,
+					 MAX42500_VM1,
+					 MAX42500_COMP_STAT_OV,
+					 &ov_stat);
+		max42500_get_comp_status(device,
+					 MAX42500_VM1,
+					 MAX42500_COMP_STAT_UV,
+					 &uv_stat);
+
+		if (off_stat) {
+			printf("   IN%d status: Voltage is below OFF threshold\n\r",
+			       MAX42500_VM1 + 1);
+		} else if (uv_stat) {
+			printf("   IN%d status: Undervoltage detected\n\r",
+			       MAX42500_VM1 + 1);
+		} else if (ov_stat) {
+			printf("   IN%d status: Overvoltage detected\n\r",
+			       MAX42500_VM1 + 1);
+		} else {
+			printf("   IN%d status: Voltage is within acceptable range\n\r",
+			       MAX42500_VM1 + 1);
+		}
+	}
+
+free_max42500:
+	printf("Error!\n\r");
+	max42500_remove(device);
+	return 0;
+}

--- a/projects/max42500/src/examples/basic/basic_example.h
+++ b/projects/max42500/src/examples/basic/basic_example.h
@@ -1,0 +1,44 @@
+/***************************************************************************//**
+ *   @file   basic_example.h
+ *   @brief  Header for the basic MAX42500 example
+ *   @author Joshua Maniti (Joshua.Maniti@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __BASIC_EXAMPLE_H__
+#define __BASIC_EXAMPLE_H__
+
+int basic_example_main(void);
+
+#endif /* __BASIC_EXAMPLE_H__ */

--- a/projects/max42500/src/examples/examples_src.mk
+++ b/projects/max42500/src/examples/examples_src.mk
@@ -1,0 +1,5 @@
+ifeq (y,$(strip $(BASIC_EXAMPLE)))
+CFLAGS += -DBASIC_EXAMPLE
+SRCS += $(PROJECT)/src/examples/basic/basic_example.c
+INCS += $(PROJECT)/src/examples/basic/basic_example.h
+endif

--- a/projects/max42500/src/platform/maxim/main.c
+++ b/projects/max42500/src/platform/maxim/main.c
@@ -1,0 +1,56 @@
+/***************************************************************************//**
+ *   @file   main.c
+ *   @brief  Main file for the MAX42500 project.
+ *   @author Joshua Maniti (Joshua.Maniti@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#if defined(BASIC_EXAMPLE)
+#include "basic_example.h"
+#endif
+
+/*******************************************************************************
+ * @brief Main function execution.
+ *
+ * @return ret - Result of the enabled examples execution.
+*******************************************************************************/
+
+int main()
+{
+#if defined(BASIC_EXAMPLE)
+	return basic_example_main();
+#else
+	return 0;
+#endif
+}

--- a/projects/max42500/src/platform/maxim/parameters.c
+++ b/projects/max42500/src/platform/maxim/parameters.c
@@ -1,0 +1,54 @@
+/***************************************************************************//**
+ *   @file   parameters.c
+ *   @brief  Definition of Maxim platform data used by max42500 project.
+ *   @author Joshua Maniti (Joshua.Maniti@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "parameters.h"
+#include "maxim_gpio.h"
+#include "maxim_i2c.h"
+#include "maxim_uart.h"
+
+struct max_uart_init_param uart_extra_ip = {
+	.flow = UART_FLOW_DIS
+};
+
+const struct max_i2c_init_param max42500_i2c_ip = {
+	.vssel = MXC_GPIO_VSSEL_VDDIOH,
+};
+
+const struct max_gpio_init_param max42500_gpio_extra = {
+	.vssel = MXC_GPIO_VSSEL_VDDIOH
+};

--- a/projects/max42500/src/platform/maxim/parameters.h
+++ b/projects/max42500/src/platform/maxim/parameters.h
@@ -1,0 +1,63 @@
+/***************************************************************************//**
+ *   @file   parameters.h
+ *   @brief  Definitions used by the MAX42500 project.
+ *   @author Joshua Maniti (Joshua.Maniti@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
+
+/* MAX42500 parameters */
+#define MAX42500_I2C_DEVICE_ID  (0)
+#define MAX42500_I2C_CLK_SPEED  (400000)
+#define MAX42500_I2C_ADDR       (MAX42500_ADDR(0))
+#define MAX42500_EN0_PORT       (2)
+#define MAX42500_EN0_PIN        (26)
+#define MAX42500_EN1_PORT       (2)
+#define MAX42500_EN1_PIN        (29)
+#define MAX42500_ADDR_PORT      (2)
+#define MAX42500_ADDR_PIN       (9)
+#define MAX42500_ADDR_SEL       (0)
+#define MAX42500_PECE           (NO_OS_BIT(0))
+#define MAX42500_VMON_EN        (NO_OS_BIT(MAX42500_VM1))
+#define MAX42500_VMON_VMPD      (NO_OS_BIT(7))
+#define MAX42500_RESET_MAP      (NO_OS_BIT(MAX42500_VM1) | \
+                                 NO_OS_BIT(7))
+
+extern struct max_uart_init_param uart_extra_ip;
+extern const struct max_i2c_init_param max42500_i2c_ip;
+extern const struct max_gpio_init_param max42500_gpio_extra;
+
+#endif /* __PARAMETERS_H__ */

--- a/projects/max42500/src/platform/maxim/platform_src.mk
+++ b/projects/max42500/src/platform/maxim/platform_src.mk
@@ -1,0 +1,15 @@
+SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c	\
+	$(PLATFORM_DRIVERS)/maxim_irq.c		\
+	$(PLATFORM_DRIVERS)/maxim_gpio.c	\
+	$(PLATFORM_DRIVERS)/../common/maxim_dma.c		\
+	$(PLATFORM_DRIVERS)/maxim_init.c	\
+	$(PLATFORM_DRIVERS)/maxim_uart.c	\
+	$(PLATFORM_DRIVERS)/maxim_i2c.c\
+	$(PLATFORM_DRIVERS)/maxim_uart_stdio.c
+	
+INCS += $(PLATFORM_DRIVERS)/maxim_irq.h		\
+	$(PLATFORM_DRIVERS)/maxim_uart.h	\
+	$(PLATFORM_DRIVERS)/../common/maxim_dma.h	\
+	$(PLATFORM_DRIVERS)/maxim_i2c.h		\
+	$(PLATFORM_DRIVERS)/maxim_gpio.h	\
+	$(PLATFORM_DRIVERS)/maxim_uart_stdio.h

--- a/projects/max42500/src/platform/platform_includes.h
+++ b/projects/max42500/src/platform/platform_includes.h
@@ -1,0 +1,46 @@
+/***************************************************************************//**
+ *   @file   platform_includes.h
+ *   @brief  Includes for used platforms used by max42500 project.
+ *   @author Joshua Maniti (Joshua.Maniti@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PLATFORM_INCLUDES_H__
+#define __PLATFORM_INCLUDES_H__
+
+#ifdef MAXIM_PLATFORM
+#include "maxim/parameters.h"
+#endif
+
+#endif /* __PLATFORM_INCLUDES_H__ */


### PR DESCRIPTION
## Pull Request Description

The MAX42500 is a SoC power-system monitor with up to seven voltage monitor inputs that will be SIL 3-Certified. Each input has programmable OV/UV thresholds of between 2.5% and 10% with ±1.3% accuracy over the full temperature range. Two of the inputs have a separate remote ground-sense input and support DVS through the integrated I2C interface.
The MAX42500 contains a programmable flexible power sequence recorder (FPSR). This recorder stores power-up and power-down timestamps separately, and supports on/off and sleep/standby power sequences. The MAX42500 also contains a programmable challenge/response watchdog, which is accessible through the I2C interface, along with a configurable RESET output.
The MAX42500 improves reliability while significantly reducing system size and component count as compared to separate ICs or discrete components. The MAX42500 is suitable for use in safety functions up to SIL 3. The device is designed to operate over the ambient temperature range of -40°C to +125°C.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [X] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [X] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [X] I have performed a self-review of the changes
- [X] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [X] I have tested in hardware affected projects, at the relevant boards
- [X] I have signed off all commits from this PR
- [X] I have updated the documentation (wiki pages, ReadMe etc), if applies
