### PR TITLE
Pqmon bugfix

### DIFF
--- a/projects/eval-pqmon/src/common/afe_config.c
+++ b/projects/eval-pqmon/src/common/afe_config.c
@@ -168,7 +168,7 @@ int config_afe_irq(void)
 	uint32_t config = 0;
 	status = afe_write_32bit_reg(REG_MASK0, (uint32_t *)&config);
 	if (status == 0) {
-		config = BITM_MASK0_RMSONERDY;
+		config = BITM_MASK0_RMSONERDY | BITM_MASK0_COH_PAGE_RDY;
 		status = afe_write_32bit_reg(REG_MASK0, (uint32_t *)&config);
 		if (status != 0) {
 			status = SYS_STATUS_AFE_MASK0_FAILED;

--- a/projects/eval-pqmon/src/common/iio_pqm.c
+++ b/projects/eval-pqmon/src/common/iio_pqm.c
@@ -462,7 +462,7 @@ int read_ch_attr(void *device, char *buf, uint32_t len,
 			for (int i = 0; i < PQLIB_MAX_HARMONICS - 1; i++) {
 				sprintf(buffTmp, "%f",
 					convert_pct_type(pqlibExample.output->params1012Cycles
-							 .voltageParams[channel->ch_num]
+							 .currentParams[channel->ch_num]
 							 .harmonics[i]));
 				strcat(buf, buffTmp);
 				if (i != PQLIB_MAX_HARMONICS - 1)
@@ -480,7 +480,7 @@ int read_ch_attr(void *device, char *buf, uint32_t len,
 			for (int i = 0; i < PQLIB_MAX_INTER_HARMONICS - 1; i++) {
 				sprintf(buffTmp, "%f",
 					convert_pct_type(pqlibExample.output->params1012Cycles
-							 .voltageParams[channel->ch_num]
+							 .currentParams[channel->ch_num]
 							 .interHarmonics[i]));
 				strcat(buf, buffTmp);
 				if (i != PQLIB_MAX_INTER_HARMONICS - 1)


### PR DESCRIPTION
## Pull Request Description

* Fix: tinyIIO has to return harmonics for current different from voltage
* For Harmonics calculation Waveform half buffer full should be the enabled interrupt in order to maintain the correct calculation of the FFT, otherwise the RMSONE interrupt remains the main input from ade9430 since it has the highest frequency

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
