### PR TITLE
drivers: platform: maxim : maxim_pwm.c

### DIFF
--- a/drivers/platform/maxim/max32650/maxim_pwm.c
+++ b/drivers/platform/maxim/max32650/maxim_pwm.c
@@ -201,6 +201,8 @@ int max_pwm_set_duty_cycle(struct no_os_pwm_desc *desc,
 
 	pwm_extra = desc->extra;
 
+	duty_cycle_ns = desc->period_ns - duty_cycle_ns;
+
 	duty_ticks = PeripheralClock / (NO_OS_DIV_ROUND_CLOSEST_ULL(NANO,
 					duty_cycle_ns) * MAX_PWM_PRESCALER_TRUE(pwm_extra->tmr_cfg.pres));
 
@@ -215,6 +217,8 @@ int max_pwm_set_duty_cycle(struct no_os_pwm_desc *desc,
 	/*  Set actual duty cycle value. */
 	desc->duty_cycle_ns = duty_ticks * MAX_PWM_PRESCALER_TRUE(
 				      pwm_extra->tmr_cfg.pres) * NO_OS_DIV_ROUND_CLOSEST_ULL(NANO,PeripheralClock);
+
+	desc->duty_cycle_ns = desc->period_ns - desc->duty_cycle_ns;
 
 	return 0;
 }

--- a/drivers/platform/maxim/max32655/maxim_pwm.c
+++ b/drivers/platform/maxim/max32655/maxim_pwm.c
@@ -200,6 +200,8 @@ int max_pwm_set_duty_cycle(struct no_os_pwm_desc *desc,
 
 	pwm_extra = desc->extra;
 
+	duty_cycle_ns = desc->period_ns - duty_cycle_ns;
+
 	duty_ticks = MXC_TMR_GetPeriod(MXC_TMR_GET_TMR(desc->id),
 				       MXC_TMR_APB_CLK,
 				       MAX_PWM_PRESCALER_TRUE(pwm_extra->tmr_cfg.pres),
@@ -216,6 +218,8 @@ int max_pwm_set_duty_cycle(struct no_os_pwm_desc *desc,
 	/*  Set actual duty cycle value. */
 	desc->duty_cycle_ns = duty_ticks * MAX_PWM_PRESCALER_TRUE(
 				      pwm_extra->tmr_cfg.pres) * NO_OS_DIV_ROUND_CLOSEST_ULL(NANO,PeripheralClock);
+
+	desc->duty_cycle_ns = desc->period_ns - desc->duty_cycle_ns;
 
 	return 0;
 }

--- a/drivers/platform/maxim/max32660/maxim_pwm.c
+++ b/drivers/platform/maxim/max32660/maxim_pwm.c
@@ -189,6 +189,8 @@ int max_pwm_set_duty_cycle(struct no_os_pwm_desc *desc,
 
 	pwm_extra = desc->extra;
 
+	duty_cycle_ns = desc->period_ns - duty_cycle_ns;
+
 	duty_ticks = MXC_TMR_GetPeriod(MXC_TMR_GET_TMR(desc->id),
 				       MAX_PWM_PRESCALER_TRUE(pwm_extra->tmr_cfg.pres),
 				       NO_OS_DIV_ROUND_CLOSEST_ULL(NANO, duty_cycle_ns));
@@ -204,6 +206,8 @@ int max_pwm_set_duty_cycle(struct no_os_pwm_desc *desc,
 	/*  Set actual duty cycle value. */
 	desc->duty_cycle_ns = duty_ticks * MAX_PWM_PRESCALER_TRUE(
 				      pwm_extra->tmr_cfg.pres) * NO_OS_DIV_ROUND_CLOSEST_ULL(NANO,PeripheralClock);
+
+	desc->duty_cycle_ns = desc->period_ns - desc->duty_cycle_ns;
 
 	return 0;
 }

--- a/drivers/platform/maxim/max32665/maxim_pwm.c
+++ b/drivers/platform/maxim/max32665/maxim_pwm.c
@@ -201,6 +201,8 @@ int max_pwm_set_duty_cycle(struct no_os_pwm_desc *desc,
 
 	pwm_extra = desc->extra;
 
+	duty_cycle_ns = desc->period_ns - duty_cycle_ns;
+
 	duty_ticks = PeripheralClock / (MAX_PWM_PRESCALER_TRUE(pwm_extra->tmr_cfg.pres)
 					* NO_OS_DIV_ROUND_CLOSEST_ULL(NANO, duty_cycle_ns));
 
@@ -215,6 +217,8 @@ int max_pwm_set_duty_cycle(struct no_os_pwm_desc *desc,
 	/*  Set actual duty cycle value. */
 	desc->duty_cycle_ns = duty_ticks * MAX_PWM_PRESCALER_TRUE(
 				      pwm_extra->tmr_cfg.pres) * NO_OS_DIV_ROUND_CLOSEST_ULL(NANO,PeripheralClock);
+
+	desc->duty_cycle_ns = desc->period_ns - desc->duty_cycle_ns;
 
 	return 0;
 }

--- a/drivers/platform/maxim/max32670/maxim_pwm.c
+++ b/drivers/platform/maxim/max32670/maxim_pwm.c
@@ -206,6 +206,8 @@ int max_pwm_set_duty_cycle(struct no_os_pwm_desc *desc,
 
 	pwm_extra = desc->extra;
 
+	duty_cycle_ns = desc->period_ns - duty_cycle_ns;
+
 	duty_ticks = MXC_TMR_GetPeriod(MXC_TMR_GET_TMR(desc->id),
 				       MXC_TMR_APB_CLK,
 				       MAX_PWM_PRESCALER_TRUE(pwm_extra->tmr_cfg.pres),
@@ -222,6 +224,8 @@ int max_pwm_set_duty_cycle(struct no_os_pwm_desc *desc,
 	/*  Set actual duty cycle value. */
 	desc->duty_cycle_ns = duty_ticks * MAX_PWM_PRESCALER_TRUE(
 				      pwm_extra->tmr_cfg.pres) * NO_OS_DIV_ROUND_CLOSEST_ULL(NANO,PeripheralClock);
+
+	desc->duty_cycle_ns = desc->period_ns - desc->duty_cycle_ns;
 
 	return 0;
 }

--- a/drivers/platform/maxim/max32690/maxim_pwm.c
+++ b/drivers/platform/maxim/max32690/maxim_pwm.c
@@ -206,6 +206,8 @@ int max_pwm_set_duty_cycle(struct no_os_pwm_desc *desc,
 
 	pwm_extra = desc->extra;
 
+	duty_cycle_ns = desc->period_ns - duty_cycle_ns;
+
 	duty_ticks = MXC_TMR_GetPeriod(MXC_TMR_GET_TMR(desc->id),
 				       MXC_TMR_APB_CLK,
 				       MAX_PWM_PRESCALER_TRUE(pwm_extra->tmr_cfg.pres),
@@ -222,6 +224,8 @@ int max_pwm_set_duty_cycle(struct no_os_pwm_desc *desc,
 	/*  Set actual duty cycle value. */
 	desc->duty_cycle_ns = duty_ticks * MAX_PWM_PRESCALER_TRUE(
 				      pwm_extra->tmr_cfg.pres) * NO_OS_DIV_ROUND_CLOSEST_ULL(NANO,PeripheralClock);
+
+	desc->duty_cycle_ns = desc->period_ns - desc->duty_cycle_ns;
 
 	return 0;
 }

--- a/drivers/platform/maxim/max78000/maxim_pwm.c
+++ b/drivers/platform/maxim/max78000/maxim_pwm.c
@@ -206,6 +206,8 @@ int max_pwm_set_duty_cycle(struct no_os_pwm_desc *desc,
 
 	pwm_extra = desc->extra;
 
+	duty_cycle_ns = desc->period_ns - duty_cycle_ns;
+
 	duty_ticks = MXC_TMR_GetPeriod(MXC_TMR_GET_TMR(desc->id),
 				       MXC_TMR_APB_CLK,
 				       MAX_PWM_PRESCALER_TRUE(pwm_extra->tmr_cfg.pres),
@@ -222,6 +224,8 @@ int max_pwm_set_duty_cycle(struct no_os_pwm_desc *desc,
 	/*  Set actual duty cycle value. */
 	desc->duty_cycle_ns = duty_ticks * MAX_PWM_PRESCALER_TRUE(
 				      pwm_extra->tmr_cfg.pres) * NO_OS_DIV_ROUND_CLOSEST_ULL(NANO,PeripheralClock);
+
+	desc->duty_cycle_ns = desc->period_ns - desc->duty_cycle_ns;
 
 	return 0;
 }


### PR DESCRIPTION
## Pull Request Description
When setting the PWM using Maxim's SDK, the pulse's off state ticks are actually being set, therefore compute the duty_ticks in an inverted sort of way in order to obtain the correct values to the PWM.

Needs to be merged before #2310 .

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
