### PR TITLE
Add support for LT8491

### DIFF
--- a/doc/sphinx/source/drivers/lt8491.rst
+++ b/doc/sphinx/source/drivers/lt8491.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../drivers/power/lt8491/README.rst

--- a/doc/sphinx/source/drivers_doc.rst
+++ b/doc/sphinx/source/drivers_doc.rst
@@ -85,5 +85,6 @@ POWER MANAGEMENT
    drivers/ltc2992
    drivers/ltc4296
    drivers/lt7182s
+   drivers/lt8491
    drivers/lt8722
    drivers/max42500

--- a/doc/sphinx/source/projects/dc2703a.rst
+++ b/doc/sphinx/source/projects/dc2703a.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../projects/dc2703a/README.rst

--- a/doc/sphinx/source/projects_doc.rst
+++ b/doc/sphinx/source/projects_doc.rst
@@ -69,6 +69,7 @@ POWER MANAGEMENT
    :maxdepth: 1
 
    projects/adp1050
+   projects/dc2703a
    projects/ltc4296
    projects/lt7182s
    projects/lt8722

--- a/drivers/power/lt8491/README.rst
+++ b/drivers/power/lt8491/README.rst
@@ -1,0 +1,243 @@
+LT8491 no-OS driver
+=====================
+
+Supported Devices
+-----------------
+
+`LT8491 <https://www.analog.com/LT8491>`_
+
+Overview
+--------
+
+The LT8491 is a buck-boost switching regulator battery charger that implements a
+constant-current constant-voltage (CCCV) charging profile used for most battery
+types, including sealed lead-acid (SLA), flooded, gel and lithium-ion.
+
+The device operates from input voltages above, below or equal to the output
+voltage and can be powered by a solar panel or a DC power supply. On-chip logic
+provides automatic maximum power point tracking (MPPT) for solar powered
+applications. The LT8491 can perform automatic temperature compensation by
+sensing an external thermistor thermally coupled to the battery. The STATUS pin
+can be used to drive an LED indicator lamp. The device is available in a low
+profile (0.75mm) 7mm x 11mm 64-lead QFN package.
+
+Applications
+------------
+
+LT8491
+--------
+
+* Solar Powered Battery Chargers
+* Multiple Types of Lead-Acid Battery Charging
+* Li-Ion Battery Charger
+* Battery Equipped Industrial or Portable Military Equipment
+
+LT8491 Device Configuration
+-----------------------------
+
+Driver Initialization
+---------------------
+
+In order to be able to use the device, you will have to provide the support
+for the communication protocol (I2C).
+
+The first API to be called is **lt8491_init**. Make sure that it returns 0,
+which means that the driver was initialized correctly.
+
+Restarting LT8491
+-----------------
+
+The startup sequence is initiated when the VDD pin rises above 2.7V (typical).
+If the device is already powered on, the startup sequence can be re-initiated
+via **lt8491_restart_chip** API. This resets the device register values.
+
+Enabling or Disabling Charger
+-----------------------------
+
+Enabling or disabling charger is done using **lt8491_write_enable** API. This
+can also be read using **lt8491_read_enable** API. Enabling charger starts
+battery charging, restricts I2C write access, and commences telemetry
+acquisition.
+
+Charging Status
+---------------
+
+The charging status can be read via **lt8491_read_charging_status** API.
+
+1 indicates that battery charging is ongoing in one of the 4 charging stages
+(Stage 0 to 3).
+
+0 indicates that the charging is not active, and the power stage has been turned
+off. This is indicated due to any of the following conditions:
+
+* The charging logic is disabled
+* The charging has been stopped due to a fault condition
+* The charging has reached the done charging stage
+* The charging logic was recently enabled but the logic hasn't started Stage 0 charging yet
+
+Charging Stage
+--------------
+
+The charging stage can be read via **lt8491_read_charging_stage** API. Values
+read can be any of the following:
+
+* '0' - Stage 0
+* '1' - Stage 1
+* '2' - Stage 2
+* '3' - Stage 3
+* 'd' - Done Charging
+
+Configuring Telemetry
+---------------------
+
+Specific device registers must contain valid data before the LT8491 can properly
+calculate telemetry for volts, amprs, power, and efficiency. The contents of
+these registers don't affect any aspect of the charger's operation. The contents
+of these registers are only used by the LT8491 to calculate the read-only
+telemetry values.
+
+These register values can be set via setting the resistor values inside
+**lt8491_init_param** and using **lt8491_configure_telemetry** API.
+
+Telemetry Acquisition
+---------------------
+
+* TBAT - battery temperature in millidegrees Celsius read via **lt8491_read_tbat** API
+* POUT - power delivered out of the charger in milliWatts read via **lt8491_read_pout** API
+* PIN - power draw from VIN supply in milliWatts read via **lt8491_read_pin** API
+* EFF - power conversion efficiency in 0.001 % read via **lt8491_read_efficiency** API
+* IOUT - current flowing out of the charger in milliamps read via **lt8491_read_iout** API
+* IIN - current flowing into the charger in milliamps read via **lt8491_read_iin** API
+* VBAT - battery voltage in millivolts read via **lt8491_read_vbat** API
+* VIN - input voltage from the supply in millivolts read via **lt8491_read_vin** API
+
+Using Scratch Pad Register
+--------------------------
+
+The scratch pad register can be read and write via **lt8491_read_scratch** and
+**lt8491_write_scratch** APIs, respectively.
+
+Serial Number
+-------------
+
+LT8491 has a unique serial number that consists of three (3) 16-bit numbers that
+can be read via **lt8491_read_serial_id** API.
+
+LT8491 Driver Initialization Example
+--------------------------------------
+
+.. code-block:: bash
+
+	struct lt8491_device *dev;
+
+	struct no_os_uart_init_param uip = {
+		.device_id = UART_DEVICE_ID,
+		.baud_rate = UART_BAUDRATE,
+		.size = NO_OS_UART_CS_8,
+		.parity = NO_OS_UART_PAR_NO,
+		.stop = NO_OS_UART_STOP_1_BIT,
+		.platform_ops = UART_OPS,
+		.extra = UART_EXTRA,
+	};
+
+	const struct no_os_i2c_init_param lt8491_i2c_ip = {
+		.device_id = I2C_DEVICE_ID,
+		.max_speed_hz = 100000,
+		.slave_address = 0x10,
+		.platform_ops = I2C_OPS,
+		.extra = I2C_EXTRA,
+	};
+
+	struct lt8491_init_param lt8491_ip = {
+		.i2c_init_param = lt8491_i2c_ip,
+		.rsense1_micro_ohms = 5000,
+		.rimon_out_ohms = 124000,
+		.rsense2_micro_ohms = 3000,
+		.rdaco_ohms = 64900,
+		.rfbout1_ohms = 113000,
+		.rfbout2_ohms = 10000,
+		.rdaci_ohms = 7000,
+		.rfbin2_ohms = 3480,
+		.rfbin1_ohms = 10200,
+	};
+
+	ret = lt8491_init(&dev, &lt8491_ip);
+	if (ret)
+		goto error;
+
+LT8491 no-OS IIO support
+--------------------------
+
+The LT8491 IIO driver comes on top of the LT8491 driver and offers support
+for interfacing IIO clients through libiio.
+
+LT8491 IIO Device Configuration
+---------------------------------
+
+Channel Attributes
+------------------
+
+LT8491 has a total of 10 channel attributes:
+
+* ``in_temp_raw - raw battery temperature value``
+* ``in_temp_scale - scale that has to be applied to the raw value in order to obtain the temperature value in mC``
+* ``out_current_raw - raw current value flowing out of the charger``
+* ``out_current_scale - scale that has to be applied to the raw value in order to obtain the current value in mA``
+* ``in_current_supply_raw - raw current value flowing into the charger``
+* ``in_current_supply_scale - scale that has to be applied to the raw value in order to obtain the current value in mA``
+* ``out_voltage_raw - raw battery voltage value``
+* ``out_voltage_scale - scale that has to be applied to the raw value in order to obtain the voltage value in mV``
+* ``in_voltage_supply_raw - raw input voltage value``
+* ``in_voltage_supply_scale - scale that has to be applied to the raw value in order to obtain the voltage value in mV``
+
+Debug Attributes
+----------------
+
+The device has a total of 9 debug attributes:
+
+* ``pout - Power delivered out of the charger in milliWatts``
+* ``pin - Power draw from VIN supply in milliWatts``
+* ``efficiency - Power conversion efficiency in 0.001 %``
+* ``charging_stage - Charging stage``
+* ``charging_status - Charging status``
+* ``enable - Enable or disable charger``
+* ``reset - Restart LT8491``
+* ``scratch - Scratch pad register``
+* ``serial_id - Serial number``
+
+LT8491 IIO Driver Initialization Example
+------------------------------------------
+
+.. code-block:: bash
+
+	int ret;
+
+	struct lt8491_iio_device *lt8491_iio_dev;
+	struct lt8491_iio_init_param lt8491_iio_ip = {
+		.lt8491_init_param = &lt8491_ip,
+	};
+
+	struct iio_app_desc *app;
+	struct iio_app_init_param app_init_param = {0};
+
+	ret = lt8491_iio_init(&lt8491_iio_dev, &lt8491_iio_ip);
+	if (ret)
+		goto exit;
+
+	struct iio_app_device iio_devices[] = {
+		{
+			.name = "lt8491",
+			.dev = lt8491_iio_dev,
+			.dev_descriptor = lt8491_iio_dev->iio_dev,
+		},
+	};
+
+	app_init_param.devices = iio_devices;
+	app_init_param.nb_devices = NO_OS_ARRAY_SIZE(iio_devices);
+	app_init_param.uart_init_params = uip;
+
+	ret = iio_app_init(&app, app_init_param);
+	if (ret)
+		goto remove_iio_lt8491;
+
+	return iio_app_run(app);

--- a/drivers/power/lt8491/iio_lt8491.c
+++ b/drivers/power/lt8491/iio_lt8491.c
@@ -1,0 +1,507 @@
+/***************************************************************************//**
+ *   @file   iio_lt8491.c
+ *   @brief  Implementation of IIO LT8491 Driver.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <errno.h>
+#include "iio_lt8491.h"
+#include "lt8491.h"
+#include "no_os_alloc.h"
+#include "no_os_error.h"
+
+#define LT8491_IIO_CH_ATTR_RW(_name, _priv)	\
+	{					\
+		.name = _name,			\
+		.priv = _priv,			\
+		.show = lt8491_ch_attr_show,	\
+		.store = lt8491_ch_attr_store,	\
+	}
+
+#define LT8491_IIO_CH_ATTR_RO(_name, _priv)	\
+	{					\
+		.name = _name,			\
+		.priv = _priv,			\
+		.show = lt8491_ch_attr_show,	\
+		.store = NULL,			\
+	}
+
+#define LT8491_IIO_CH_ATTR_WO(_name, _priv)	\
+	{					\
+		.name = _name,			\
+		.priv = _priv,			\
+		.show = NULL,			\
+		.store = lt8491_ch_attr_store,	\
+	}
+
+#define LT8491_IIO_CH_ATTR_READ_RAW(_name, _priv)	\
+	{						\
+		.name = _name,				\
+		.priv = _priv,				\
+		.show = lt8491_read_raw,		\
+		.store = NULL,				\
+	}
+
+#define LT8491_IIO_CH_ATTR_READ_SCALE(_name, _priv)	\
+	{						\
+		.name = _name,				\
+		.priv = _priv,				\
+		.show = lt8491_read_scale,		\
+		.store = NULL,				\
+	}
+
+enum lt8491_attr_priv {
+	LT8491_TBAT,
+	LT8491_POUT,
+	LT8491_PIN,
+	LT8491_EFF,
+	LT8491_IOUT,
+	LT8491_IIN,
+	LT8491_VBAT,
+	LT8491_VIN,
+	LT8491_CHARGING_STAGE,
+	LT8491_CHARGING_STATUS,
+	LT8491_ENABLE,
+	LT8491_RESTART,
+	LT8491_SCRATCH,
+	LT8491_SERIAL_ID,
+};
+
+static int32_t lt8491_iio_reg_read(struct lt8491_iio_device *dev,
+				   uint32_t reg, uint32_t *readval)
+{
+	uint16_t temp;
+	int ret;
+
+	ret = lt8491_reg_read(dev->dev, (uint8_t)reg, &temp, false);
+	if (!ret)
+		*readval = temp;
+
+	return ret;
+}
+
+static int32_t lt8491_iio_reg_write(struct lt8491_iio_device *dev,
+				    uint32_t reg, uint32_t writeval)
+{
+	return lt8491_reg_write(dev->dev, (uint8_t)reg, (uint16_t)writeval,
+				false);
+}
+
+static int lt8491_ch_attr_show(void *ddev, char *buf,
+			       uint32_t len,
+			       const struct iio_ch_info *channel,
+			       intptr_t priv)
+{
+	struct lt8491_iio_device *dev = ddev;
+	int ret;
+	int32_t val;
+	uint32_t uval, uvals[3];
+
+	switch (priv) {
+	case LT8491_POUT:
+		ret = lt8491_read_pout(dev->dev, &uval);
+		if (ret)
+			return ret;
+
+		val = uval;
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	case LT8491_PIN:
+		ret = lt8491_read_pin(dev->dev, &uval);
+		if (ret)
+			return ret;
+
+		val = uval;
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	case LT8491_EFF:
+		ret = lt8491_read_efficiency(dev->dev, &uval);
+		if (ret)
+			return ret;
+
+		val = uval;
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	case LT8491_CHARGING_STAGE:
+		ret = lt8491_read_charging_stage(dev->dev, &uval);
+		if (ret)
+			return ret;
+
+		val = uval;
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	case LT8491_CHARGING_STATUS:
+		ret = lt8491_read_charging_status(dev->dev, &uval);
+		if (ret)
+			return ret;
+
+		val = uval;
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	case LT8491_ENABLE:
+		ret = lt8491_read_enable(dev->dev, &uval);
+		if (ret)
+			return ret;
+
+		val = uval;
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	case LT8491_SCRATCH:
+		ret = lt8491_read_scratch(dev->dev, &uval);
+		if (ret)
+			return ret;
+
+		val = uval;
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	case LT8491_SERIAL_ID:
+		ret = lt8491_read_serial_id(dev->dev, uvals);
+		if (ret)
+			return ret;
+
+		return iio_format_value(buf, len, IIO_VAL_INT_MULTIPLE,
+					NO_OS_ARRAY_SIZE(uvals),
+					(int32_t *)uvals);
+	default:
+		return -EOPNOTSUPP;
+	}
+}
+
+static int lt8491_ch_attr_store(void *ddev, char *buf,
+				uint32_t len,
+				const struct iio_ch_info *channel,
+				intptr_t priv)
+{
+	struct lt8491_iio_device *dev = ddev;
+	int32_t val;
+	int ret;
+
+	switch (priv) {
+	case LT8491_ENABLE:
+		ret = iio_parse_value(buf, IIO_VAL_INT, &val, NULL);
+		if (ret)
+			return ret;
+
+		if (val >> 1)
+			return -EINVAL;
+
+		ret = lt8491_write_enable(dev->dev, val);
+		if (ret)
+			return ret;
+
+		return len;
+	case LT8491_RESTART:
+		ret = iio_parse_value(buf, IIO_VAL_INT, &val, NULL);
+		if (ret)
+			return ret;
+
+		if (val >> 1)
+			return -EINVAL;
+
+		if (val) {
+			ret = lt8491_restart_chip(dev->dev);
+			if (ret)
+				return ret;
+		}
+
+		return len;
+	case LT8491_SCRATCH:
+		ret = iio_parse_value(buf, IIO_VAL_INT, &val, NULL);
+		if (ret)
+			return ret;
+
+		ret = lt8491_write_scratch(dev->dev, val);
+		if (ret)
+			return ret;
+
+		return len;
+	default:
+		return -EOPNOTSUPP;
+	}
+}
+
+static struct iio_attribute lt8491_debug_attrs[] = {
+	LT8491_IIO_CH_ATTR_RO("pout", LT8491_POUT),
+	LT8491_IIO_CH_ATTR_RO("pin", LT8491_PIN),
+	LT8491_IIO_CH_ATTR_RO("efficiency", LT8491_EFF),
+	LT8491_IIO_CH_ATTR_RO("charging_stage", LT8491_CHARGING_STAGE),
+	LT8491_IIO_CH_ATTR_RO("charging_status", LT8491_CHARGING_STATUS),
+	LT8491_IIO_CH_ATTR_RW("enable", LT8491_ENABLE),
+	LT8491_IIO_CH_ATTR_WO("reset", LT8491_RESTART),
+	LT8491_IIO_CH_ATTR_RW("scratch", LT8491_SCRATCH),
+	LT8491_IIO_CH_ATTR_RO("serial_id", LT8491_SERIAL_ID),
+	END_ATTRIBUTES_ARRAY
+};
+
+static int lt8491_read_raw(void *ddev, char *buf, uint32_t len,
+			   const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct lt8491_iio_device *dev = ddev;
+	int ret;
+	int32_t val;
+	uint32_t uval;
+
+	switch (priv) {
+	case LT8491_TBAT:
+		ret = lt8491_read_tbat(dev->dev, &val);
+		if (ret)
+			return ret;
+
+		val /= 100;
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	case LT8491_IOUT:
+		ret = lt8491_read_iout(dev->dev, &uval);
+		if (ret)
+			return ret;
+
+		val = uval;
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	case LT8491_IIN:
+		ret = lt8491_read_iin(dev->dev, &uval);
+		if (ret)
+			return ret;
+
+		val = uval;
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	case LT8491_VBAT:
+		ret = lt8491_read_vbat(dev->dev, &uval);
+		if (ret)
+			return ret;
+
+		val = uval / 10;
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	case LT8491_VIN:
+		ret = lt8491_read_vin(dev->dev, &uval);
+		if (ret)
+			return ret;
+
+		val = uval / 10;
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	default:
+		return -EOPNOTSUPP;
+	}
+}
+
+static int lt8491_read_scale(void *ddev, char *buf, uint32_t len,
+			     const struct iio_ch_info *channel, intptr_t priv)
+{
+	int32_t val;
+
+	switch (priv) {
+	case LT8491_TBAT:
+		val = 100;
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	case LT8491_IOUT:
+	case LT8491_IIN:
+		val = 1;
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	case LT8491_VBAT:
+	case LT8491_VIN:
+		val = 10;
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	default:
+		return -EOPNOTSUPP;
+	}
+}
+
+static struct scan_type lt8491_signed_scan_type = {
+	.sign = 's',
+	.realbits = 16,
+	.storagebits = 16,
+	.shift = 0,
+	.is_big_endian = false,
+};
+
+static struct scan_type lt8491_unsigned_scan_type = {
+	.sign = 's',
+	.realbits = 16,
+	.storagebits = 16,
+	.shift = 0,
+	.is_big_endian = false,
+};
+
+static struct iio_attribute lt8491_temp_ch_attrs[] = {
+	LT8491_IIO_CH_ATTR_READ_RAW("raw", LT8491_TBAT),
+	LT8491_IIO_CH_ATTR_READ_SCALE("scale", LT8491_TBAT),
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_attribute lt8491_out_current_ch_attrs[] = {
+	LT8491_IIO_CH_ATTR_READ_RAW("raw", LT8491_IOUT),
+	LT8491_IIO_CH_ATTR_READ_SCALE("scale", LT8491_IOUT),
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_attribute lt8491_in_current_ch_attrs[] = {
+	LT8491_IIO_CH_ATTR_READ_RAW("supply_raw", LT8491_IIN),
+	LT8491_IIO_CH_ATTR_READ_SCALE("supply_scale", LT8491_IIN),
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_attribute lt8491_out_voltage_ch_attrs[] = {
+	LT8491_IIO_CH_ATTR_READ_RAW("raw", LT8491_VBAT),
+	LT8491_IIO_CH_ATTR_READ_SCALE("scale", LT8491_VBAT),
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_attribute lt8491_in_voltage_ch_attrs[] = {
+	LT8491_IIO_CH_ATTR_READ_RAW("supply_raw", LT8491_VIN),
+	LT8491_IIO_CH_ATTR_READ_SCALE("supply_scale", LT8491_VIN),
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_channel lt8491_channels[] = {
+	{
+		.name = "temp",
+		.ch_type = IIO_TEMP,
+		.channel = 0,
+		.address = 0,
+		.scan_index = 0,
+		.scan_type = &lt8491_signed_scan_type,
+		.attributes = lt8491_temp_ch_attrs,
+		.ch_out = false,
+	}, {
+		.name = "current",
+		.ch_type = IIO_CURRENT,
+		.channel = 0,
+		.address = 0,
+		.scan_index = 0,
+		.scan_type = &lt8491_unsigned_scan_type,
+		.attributes = lt8491_out_current_ch_attrs,
+		.ch_out = true,
+	}, {
+		.name = "current",
+		.ch_type = IIO_CURRENT,
+		.channel = 0,
+		.address = 0,
+		.scan_index = 0,
+		.scan_type = &lt8491_unsigned_scan_type,
+		.attributes = lt8491_in_current_ch_attrs,
+		.ch_out = false,
+	}, {
+		.name = "voltage",
+		.ch_type = IIO_VOLTAGE,
+		.channel = 0,
+		.address = 0,
+		.scan_index = 0,
+		.scan_type = &lt8491_unsigned_scan_type,
+		.attributes = lt8491_out_voltage_ch_attrs,
+		.ch_out = true,
+	}, {
+		.name = "voltage",
+		.ch_type = IIO_VOLTAGE,
+		.channel = 0,
+		.address = 0,
+		.scan_index = 0,
+		.scan_type = &lt8491_unsigned_scan_type,
+		.attributes = lt8491_in_voltage_ch_attrs,
+		.ch_out = false,
+	}
+};
+
+static struct iio_device lt8491_iio_dev = {
+	.num_ch = NO_OS_ARRAY_SIZE(lt8491_channels),
+	.channels = lt8491_channels,
+	.debug_reg_read = (int32_t (*)()) lt8491_iio_reg_read,
+	.debug_reg_write = (int32_t (*)()) lt8491_iio_reg_write,
+	.debug_attributes = lt8491_debug_attrs,
+};
+
+/**
+ * @brief Initializes the LT8491 IIO driver
+ * @param iio_device - The iio device structure.
+ * @param iio_init_param - Parameters for the initialization of iio_dev
+ * @return 0 in case of success, errno errors otherwise
+ */
+int lt8491_iio_init(struct lt8491_iio_device **iio_device,
+		    struct lt8491_iio_init_param *iio_init_param)
+{
+	struct lt8491_iio_device *iio_device_temp;
+	int ret;
+
+	if (!iio_init_param || !iio_init_param->init_param)
+		return -EINVAL;
+
+	iio_device_temp = no_os_calloc(1, sizeof(*iio_device_temp));
+	if (!iio_device_temp)
+		return -ENOMEM;
+
+	ret = lt8491_init(&iio_device_temp->dev, iio_init_param->init_param);
+	if (ret)
+		goto free_dev;
+
+	ret = lt8491_restart_chip(iio_device_temp->dev);
+	if (ret)
+		goto remove_dev;
+
+	ret = lt8491_write_enable(iio_device_temp->dev, false);
+	if (ret)
+		goto remove_dev;
+
+	ret = lt8491_configure_telemetry(iio_device_temp->dev,
+					 iio_init_param->init_param);
+	if (ret)
+		goto remove_dev;
+
+	iio_device_temp->iio_dev = &lt8491_iio_dev;
+
+	*iio_device = iio_device_temp;
+
+	return 0;
+
+remove_dev:
+	lt8491_remove(iio_device_temp->dev);
+free_dev:
+	no_os_free(iio_device_temp);
+
+	return ret;
+}
+
+/**
+ * @brief Free resources allocated by the init function
+ * @param iio_device - The iio device structure.
+ * @return 0 in case of success, errno errors otherwise
+ */
+int lt8491_iio_remove(struct lt8491_iio_device *iio_device)
+{
+	lt8491_remove(iio_device->dev);
+
+	no_os_free(iio_device);
+
+	return 0;
+}

--- a/drivers/power/lt8491/iio_lt8491.h
+++ b/drivers/power/lt8491/iio_lt8491.h
@@ -1,0 +1,67 @@
+/***************************************************************************//**
+ *   @file   iio_lt8491.h
+ *   @brief  Implementation of IIO LT8491 Driver.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef __IIO_LT8491_H__
+#define __IIO_LT8491_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include "iio.h"
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+
+struct lt8491_iio_device {
+	struct lt8491_desc *dev;
+	struct iio_device *iio_dev;
+	uint32_t active_channels;
+	uint8_t no_active_channels;
+};
+
+struct lt8491_iio_init_param {
+	struct lt8491_init_param *init_param;
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+int lt8491_iio_init(struct lt8491_iio_device **iio_device,
+		    struct lt8491_iio_init_param *iio_init_param);
+
+int lt8491_iio_remove(struct lt8491_iio_device *iio_device);
+
+#endif	/* __IIO_LT8491_H__ */

--- a/drivers/power/lt8491/lt8491.c
+++ b/drivers/power/lt8491/lt8491.c
@@ -1,0 +1,567 @@
+/***************************************************************************//**
+ *   @file   lt8491.c
+ *   @brief  Implementation of LT8491 Driver.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "lt8491.h"
+#include "no_os_alloc.h"
+#include "no_os_error.h"
+#include "no_os_i2c.h"
+#include "no_os_print_log.h"
+#include "no_os_util.h"
+#include <string.h>
+
+/**
+ * @brief Read a register value
+ * @param dev - LT8491 descriptor
+ * @param addr - register address
+ * @param val - register value
+ * @param is_word - true if the register is 16-bit, false if 8-bit
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt8491_reg_read(struct lt8491_desc *dev, uint8_t addr, uint16_t *val,
+		    bool is_word)
+{
+	int ret;
+	uint8_t uval[2];
+
+	ret = no_os_i2c_write(dev->i2c_desc, &addr, 1, 0);
+	if (ret)
+		return ret;
+
+	if (is_word) {
+		ret = no_os_i2c_read(dev->i2c_desc, uval, 2, 1);
+		if (ret)
+			return ret;
+
+		*val = no_os_get_unaligned_le16(uval);
+	} else {
+		ret = no_os_i2c_read(dev->i2c_desc, uval, 1, 1);
+		if (ret)
+			return ret;
+
+		*val = uval[0];
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Write a register value
+ * @param dev - LT8491 descriptor
+ * @param addr - register address
+ * @param val - register value
+ * @param is_word - true if the register is 16-bit, false if 8-bit
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt8491_reg_write(struct lt8491_desc *dev, uint8_t addr, uint16_t val,
+		     bool is_word)
+{
+	uint8_t buff[] = {addr, val & 0xFF};
+	int ret;
+
+	if (is_word) {
+		ret = no_os_i2c_write(dev->i2c_desc, buff, 2, 1);
+		if (ret)
+			return ret;
+
+		buff[0] = addr + 1;
+		buff[1] = val >> 8;
+	}
+
+	return no_os_i2c_write(dev->i2c_desc, buff, 2, 1);
+}
+
+/**
+ * @brief Device and comm init function
+ * @param dev - LT8491 descriptor to be initialized
+ * @param init_param - Init parameter for descriptor
+ * @return 0 in case of success, errno errors otherwise
+ */
+int lt8491_init(struct lt8491_desc **dev,
+		struct lt8491_init_param *init_param)
+{
+	struct lt8491_desc *temp_dev;
+	int ret;
+
+	temp_dev = no_os_calloc(1, sizeof(*temp_dev));
+	if (!temp_dev)
+		return -ENOMEM;
+
+	ret = no_os_i2c_init(&temp_dev->i2c_desc, &init_param->i2c_init_param);
+	if (ret)
+		goto free_dev;
+
+	*dev = temp_dev;
+
+	return 0;
+
+free_dev:
+	no_os_free(temp_dev);
+
+	return ret;
+}
+
+/**
+ * @brief Free resources allocated by the init function
+ * @param dev - LT8491 descriptor
+ * @return 0 in case of success, errno errors otherwise
+ */
+int lt8491_remove(struct lt8491_desc *dev)
+{
+	int ret;
+
+	if (!dev)
+		return -ENODEV;
+
+	ret = no_os_i2c_remove(dev->i2c_desc);
+	if (ret)
+		return ret;
+
+	no_os_free(dev);
+
+	return 0;
+}
+
+/**
+ * @brief Device and comm init function
+ * @param dev - LT8491 descriptor to be initialized
+ * @param init_param - Init parameter for descriptor
+ * @return 0 in case of success, errno errors otherwise
+ */
+int lt8491_configure_telemetry(struct lt8491_desc *dev,
+			       struct lt8491_init_param *init_param)
+{
+	int ret;
+
+	ret = lt8491_reg_write(dev, LT8491_CFG_RSENSE1_REG,
+			       init_param->rsense1_micro_ohms / 10, true);
+	if (ret)
+		return ret;
+
+	ret = lt8491_reg_write(dev, LT8491_CFG_RIMON_OUT_REG,
+			       init_param->rimon_out_ohms / 10, true);
+	if (ret)
+		return ret;
+
+	ret = lt8491_reg_write(dev, LT8491_CFG_RSENSE2_REG,
+			       init_param->rsense2_micro_ohms / 10, true);
+	if (ret)
+		return ret;
+
+	ret = lt8491_reg_write(dev, LT8491_CFG_RDACO_REG,
+			       init_param->rdaco_ohms / 10, true);
+	if (ret)
+		return ret;
+
+	ret = lt8491_reg_write(dev, LT8491_CFG_RFBOUT1_REG,
+			       init_param->rfbout1_ohms / 100, true);
+	if (ret)
+		return ret;
+
+	ret = lt8491_reg_write(dev, LT8491_CFG_RFBOUT2_REG,
+			       init_param->rfbout2_ohms / 10, true);
+	if (ret)
+		return ret;
+
+	ret = lt8491_reg_write(dev, LT8491_CFG_RDACI_REG,
+			       init_param->rdaci_ohms / 10, true);
+	if (ret)
+		return ret;
+
+	ret = lt8491_reg_write(dev, LT8491_CFG_RFBIN2_REG,
+			       init_param->rfbin2_ohms / 10, true);
+	if (ret)
+		return ret;
+
+	ret = lt8491_reg_write(dev, LT8491_CFG_RFBIN1_REG,
+			       init_param->rfbin1_ohms / 100, true);
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
+static int __lt8491_update_telemetry(struct lt8491_desc *dev)
+{
+	return lt8491_reg_write(dev, LT8491_CTRL_UPDATE_TELEM, 0xAA, false);
+}
+
+/**
+ * @brief Read the telemetry battery temperature
+ * @param dev - LT8491 descriptor
+ * @param val - telemetry battery temperature in mC
+ * @return 0 in case of success, errno errors otherwise
+ */
+int lt8491_read_tbat(struct lt8491_desc *dev, int32_t *val)
+{
+	int ret;
+	uint16_t uval;
+
+	ret = __lt8491_update_telemetry(dev);
+	if (ret)
+		return ret;
+
+	ret = lt8491_reg_read(dev, LT8491_TELE_TBAT_REG, &uval, true);
+	if (ret)
+		return ret;
+
+	*val = no_os_sign_extend32(uval, 15) * 100;
+
+	return 0;
+}
+
+/**
+ * @brief Read the telemetry battery output power
+ * @param dev - LT8491 descriptor
+ * @param val - telemetry battery output power in mW
+ * @return 0 in case of success, errno errors otherwise
+ */
+int lt8491_read_pout(struct lt8491_desc *dev, uint32_t *val)
+{
+	int ret;
+	uint16_t uval;
+
+	ret = __lt8491_update_telemetry(dev);
+	if (ret)
+		return ret;
+
+	ret = lt8491_reg_read(dev, LT8491_TELE_POUT_REG, &uval, true);
+	if (ret)
+		return ret;
+
+	*val = uval * 10;
+
+	return 0;
+}
+
+/**
+ * @brief Read the telemetry battery input power
+ * @param dev - LT8491 descriptor
+ * @param val - telemetry battery input power in mW
+ * @return 0 in case of success, errno errors otherwise
+ */
+int lt8491_read_pin(struct lt8491_desc *dev, uint32_t *val)
+{
+	int ret;
+	uint16_t uval;
+
+	ret = __lt8491_update_telemetry(dev);
+	if (ret)
+		return ret;
+
+	ret = lt8491_reg_read(dev, LT8491_TELE_PIN_REG, &uval, true);
+	if (ret)
+		return ret;
+
+	*val = uval * 10;
+
+	return 0;
+}
+
+/**
+ * @brief Read the telemetry battery efficiency
+ * @param dev - LT8491 descriptor
+ * @param val - telemetry battery efficiency in m%
+ * @return 0 in case of success, errno errors otherwise
+ */
+int lt8491_read_efficiency(struct lt8491_desc *dev, uint32_t *val)
+{
+	int ret;
+	uint16_t uval;
+
+	ret = __lt8491_update_telemetry(dev);
+	if (ret)
+		return ret;
+
+	ret = lt8491_reg_read(dev, LT8491_TELE_EFF_REG, &uval, true);
+	if (ret)
+		return ret;
+
+	*val = uval * 10;
+
+	return 0;
+}
+
+/**
+ * @brief Read the telemetry battery output current
+ * @param dev - LT8491 descriptor
+ * @param val - telemetry battery output current in mA
+ * @return 0 in case of success, errno errors otherwise
+ */
+int lt8491_read_iout(struct lt8491_desc *dev, uint32_t *val)
+{
+	int ret;
+	uint16_t uval;
+
+	ret = __lt8491_update_telemetry(dev);
+	if (ret)
+		return ret;
+
+	ret = lt8491_reg_read(dev, LT8491_TELE_IOUT_REG, &uval, true);
+	if (ret)
+		return ret;
+
+	*val = uval;
+
+	return 0;
+}
+
+/**
+ * @brief Read the telemetry battery input current
+ * @param dev - LT8491 descriptor
+ * @param val - telemetry battery input current in mA
+ * @return 0 in case of success, errno errors otherwise
+ */
+int lt8491_read_iin(struct lt8491_desc *dev, uint32_t *val)
+{
+	int ret;
+	uint16_t uval;
+
+	ret = __lt8491_update_telemetry(dev);
+	if (ret)
+		return ret;
+
+	ret = lt8491_reg_read(dev, LT8491_TELE_IIN_REG, &uval, true);
+	if (ret)
+		return ret;
+
+	*val = uval;
+
+	return 0;
+}
+
+/**
+ * @brief Read the telemetry battery voltage
+ * @param dev - LT8491 descriptor
+ * @param val - telemetry battery voltage in mV
+ * @return 0 in case of success, errno errors otherwise
+ */
+int lt8491_read_vbat(struct lt8491_desc *dev, uint32_t *val)
+{
+	int ret;
+	uint16_t uval;
+
+	ret = __lt8491_update_telemetry(dev);
+	if (ret)
+		return ret;
+
+	ret = lt8491_reg_read(dev, LT8491_TELE_VBAT_REG, &uval, true);
+	if (ret)
+		return ret;
+
+	*val = uval * 10;
+
+	return 0;
+}
+
+/**
+ * @brief Read the telemetry input voltage
+ * @param dev - LT8491 descriptor
+ * @param val - telemetry input voltage in mV
+ * @return 0 in case of success, errno errors otherwise
+ */
+int lt8491_read_vin(struct lt8491_desc *dev, uint32_t *val)
+{
+	int ret;
+	uint16_t uval;
+
+	ret = __lt8491_update_telemetry(dev);
+	if (ret)
+		return ret;
+
+	ret = lt8491_reg_read(dev, LT8491_STAT_SUPPLY_REG, &uval, false);
+	if (ret)
+		return ret;
+
+	if (no_os_field_get(LT8491_PS_OR_SOLAR_MASK, uval))
+		ret = lt8491_reg_read(dev, LT8491_TELE_VIN_REG, &uval, true);
+	else
+		ret = lt8491_reg_read(dev, LT8491_TELE_VINR_REG, &uval, true);
+	if (ret)
+		return ret;
+
+	*val = uval * 10;
+
+	return 0;
+}
+
+/**
+ * @brief Read the telemetry battery charging stage
+ * @param dev - LT8491 descriptor
+ * @param uval - telemetry battery charging stage
+ * @return 0 in case of success, errno errors otherwise
+ */
+int lt8491_read_charging_stage(struct lt8491_desc *dev, uint32_t *uval)
+{
+	int ret;
+	uint16_t temp;
+
+	ret = lt8491_reg_read(dev, LT8491_STAT_CHARGER_REG, &temp, false);
+	if (ret)
+		return ret;
+
+	*uval = no_os_field_get(LT8491_CHRG_STAGE_MASK, temp);
+
+	return 0;
+}
+
+/**
+ * @brief Read the telemetry battery charging status
+ * @param dev - LT8491 descriptor
+ * @param charging - true if charging, false otherwise
+ * @return 0 in case of success, errno errors otherwise
+ */
+int lt8491_read_charging_status(struct lt8491_desc *dev, uint32_t *charging)
+{
+	int ret;
+	uint16_t uval;
+
+	ret = lt8491_reg_read(dev, LT8491_STAT_CHARGER_REG, &uval, false);
+	if (ret)
+		return ret;
+
+	*charging = !!no_os_field_get(LT8491_CHARGING_MASK, uval);
+
+	return 0;
+}
+
+/**
+ * @brief Read the telemetry battery charging enable
+ * @param dev - LT8491 descriptor
+ * @param enable - true if charging enable, false otherwise
+ * @return 0 in case of success, errno errors otherwise
+ */
+int lt8491_read_enable(struct lt8491_desc *dev, uint32_t *enable)
+{
+	int ret;
+	uint16_t uval;
+
+	ret = lt8491_reg_read(dev, LT8491_CTRL_CHRG_EN_REG, &uval, false);
+	if (ret)
+		return ret;
+
+	*enable = !!uval;
+
+	return 0;
+}
+
+/**
+ * @brief Write the telemetry battery charging enable
+ * @param dev - LT8491 descriptor
+ * @param enable - true if charging enable, false otherwise
+ * @return 0 in case of success, errno errors otherwise
+ */
+int lt8491_write_enable(struct lt8491_desc *dev, uint32_t enable)
+{
+	return lt8491_reg_write(dev, LT8491_CTRL_CHRG_EN_REG, enable, false);
+}
+
+/**
+ * @brief Restart the chip
+ * @param dev - LT8491 descriptor
+ * @return 0 in case of success, errno errors otherwise
+ */
+int lt8491_restart_chip(struct lt8491_desc *dev)
+{
+	int ret;
+
+	ret = lt8491_write_enable(dev, false);
+	if (ret)
+		return ret;
+
+	return lt8491_reg_write(dev, LT8491_CTRL_RESTART_CHIP_REG, 0x99, false);
+}
+
+/**
+ * @brief Read the scratch register
+ * @param dev - LT8491 descriptor
+ * @param val - scratch register value
+ * @return 0 in case of success, errno errors otherwise
+ */
+int lt8491_read_scratch(struct lt8491_desc *dev, uint32_t *val)
+{
+	uint16_t uval;
+	int ret;
+
+	ret = lt8491_reg_read(dev, LT8491_CFG_USER_CODE, &uval, true);
+	if (ret)
+		return ret;
+
+	*val = uval;
+
+	return 0;
+}
+
+/**
+ * @brief Write the scratch register
+ * @param dev - LT8491 descriptor
+ * @param val - scratch register value
+ * @return 0 in case of success, errno errors otherwise
+ */
+int lt8491_write_scratch(struct lt8491_desc *dev, uint32_t val)
+{
+	uint16_t uval = val;
+
+	return lt8491_reg_write(dev, LT8491_CFG_USER_CODE, uval, true);
+}
+
+/**
+ * @brief Read the serial ID
+ * @param dev - LT8491 descriptor
+ * @param val - serial ID value
+ * @return 0 in case of success, errno errors otherwise
+ */
+int lt8491_read_serial_id(struct lt8491_desc *dev, uint32_t *val)
+{
+	uint16_t uval[3];
+	int ret;
+
+	ret = lt8491_reg_read(dev, LT8491_MFR_DATA1_REG, &uval[0], true);
+	if (ret)
+		return ret;
+
+	val[0] = uval[0];
+
+	ret = lt8491_reg_read(dev, LT8491_MFR_DATA2_REG, &uval[1], true);
+	if (ret)
+		return ret;
+
+	val[1] = uval[1];
+
+	ret = lt8491_reg_read(dev, LT8491_MFR_DATA3_REG, &uval[2], true);
+	if (ret)
+		return ret;
+
+	val[2] = uval[2];
+
+	return 0;
+}

--- a/drivers/power/lt8491/lt8491.h
+++ b/drivers/power/lt8491/lt8491.h
@@ -1,0 +1,192 @@
+/***************************************************************************//**
+ *   @file   lt8491.h
+ *   @brief  Implementation of LT8491 Driver.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef __LT8491_H__
+#define __LT8491_H__
+
+#include "no_os_i2c.h"
+#include "no_os_util.h"
+
+#define LT8491_TELE_TBAT_REG 0x0
+#define LT8491_TELE_POUT_REG 0x2
+#define LT8491_TELE_PIN_REG  0x4
+#define LT8491_TELE_EFF_REG  0x6
+#define LT8491_TELE_IOUT_REG 0x8
+#define LT8491_TELE_IIN_REG  0xA
+#define LT8491_TELE_VBAT_REG 0xC
+#define LT8491_TELE_VIN_REG  0xE
+#define LT8491_TELE_VINR_REG 0x10
+
+#define LT8491_STAT_CHARGER_REG 0x12
+#define LT8491_STAT_SUPPLY_REG 0x14
+
+#define LT8491_CTRL_CHRG_EN_REG 0x23
+#define LT8491_CTRL_RESTART_CHIP_REG 0x24
+#define LT8491_CTRL_UPDATE_TELEM 0x26
+
+#define LT8491_CFG_RSENSE1_REG 0x28
+#define LT8491_CFG_RIMON_OUT_REG 0x2A
+#define LT8491_CFG_RSENSE2_REG 0x2C
+#define LT8491_CFG_RDACO_REG 0x2E
+#define LT8491_CFG_RFBOUT1_REG 0x30
+#define LT8491_CFG_RFBOUT2_REG 0x32
+#define LT8491_CFG_RDACI_REG 0x34
+#define LT8491_CFG_RFBIN2_REG 0x36
+#define LT8491_CFG_RFBIN1_REG 0x38
+#define LT8491_CFG_TBAT_MIN_REG 0x40
+#define LT8491_CFG_TBAT_MAX_REG 0x41
+#define LT8491_CFG_CHRG_MISC_REG 0x4D
+
+#define LT8491_CFG_USER_CODE 0x5A
+#define LT8491_MFR_DATA1_REG 0x5C
+#define LT8491_MFR_DATA2_REG 0x5E
+#define LT8491_MFR_DATA3_REG 0x60
+
+#define LT8491_CHRG_STAGE_MASK NO_OS_GENMASK(5, 3)
+#define LT8491_CHARGING_MASK NO_OS_BIT(2)
+
+#define LT8491_PS_OR_SOLAR_MASK NO_OS_BIT(3)
+
+/**
+ * @brief LT8491 charging stage
+ */
+enum lt8491_charging_stage {
+	LT8491_STAGE0,
+	LT8491_STAGE1,
+	LT8491_STAGE2,
+	LT8491_STAGE3,
+	LT8491_DONE_CHARGING,
+};
+
+/**
+ * @brief LT8491 descriptor
+ */
+struct lt8491_desc {
+	/** I2C Descriptor */
+	struct no_os_i2c_desc *i2c_desc;
+};
+
+/**
+ * @brief LT8491 init param
+ */
+struct lt8491_init_param {
+	/** Host processor I2C configuration */
+	struct no_os_i2c_init_param i2c_init_param;
+	/** Rsense1 in micro ohms */
+	unsigned int rsense1_micro_ohms;
+	/** Rimon out in ohms */
+	unsigned int rimon_out_ohms;
+	/** Rsense2 in micro ohms */
+	unsigned int rsense2_micro_ohms;
+	/** Rdaco in ohms */
+	unsigned int rdaco_ohms;
+	/** Rfbout1 in ohms */
+	unsigned int rfbout1_ohms;
+	/** Rfbout2 in ohms */
+	unsigned int rfbout2_ohms;
+	/** Rdaci in ohms */
+	unsigned int rdaci_ohms;
+	/** Rfbin2 in ohms */
+	unsigned int rfbin2_ohms;
+	/** Rfbin1 in ohms */
+	unsigned int rfbin1_ohms;
+};
+
+/** Read a register value */
+int lt8491_reg_read(struct lt8491_desc *dev, uint8_t addr, uint16_t *val,
+		    bool is_word);
+
+/** Write a register value */
+int lt8491_reg_write(struct lt8491_desc *dev, uint8_t addr, uint16_t val,
+		     bool is_word);
+
+/** Device and comm init function */
+int lt8491_init(struct lt8491_desc **dev,
+		struct lt8491_init_param *init_param);
+
+/** Free resources allocated by the init function */
+int lt8491_remove(struct lt8491_desc *dev);
+
+/** Device and comm init function */
+int lt8491_configure_telemetry(struct lt8491_desc *dev,
+			       struct lt8491_init_param *init_param);
+
+/** Read the telemetry battery temperature */
+int lt8491_read_tbat(struct lt8491_desc *dev, int32_t *val);
+
+/** Read the telemetry battery output power */
+int lt8491_read_pout(struct lt8491_desc *dev, uint32_t *val);
+
+/** Read the telemetry battery input power */
+int lt8491_read_pin(struct lt8491_desc *dev, uint32_t *val);
+
+/** Read the telemetry battery efficiency */
+int lt8491_read_efficiency(struct lt8491_desc *dev, uint32_t *val);
+
+/** Read the telemetry battery output current */
+int lt8491_read_iout(struct lt8491_desc *dev, uint32_t *val);
+
+/** Read the telemetry battery input current */
+int lt8491_read_iin(struct lt8491_desc *dev, uint32_t *val);
+
+/** Read the telemetry battery voltage */
+int lt8491_read_vbat(struct lt8491_desc *dev, uint32_t *val);
+
+/** Read the telemetry input voltage */
+int lt8491_read_vin(struct lt8491_desc *dev, uint32_t *val);
+
+/** Read the telemetry battery charging stage */
+int lt8491_read_charging_stage(struct lt8491_desc *dev, uint32_t *uval);
+
+/** Read the telemetry battery charging status */
+int lt8491_read_charging_status(struct lt8491_desc *dev, uint32_t *charging);
+
+/** Read the telemetry battery charging enable */
+int lt8491_read_enable(struct lt8491_desc *dev, uint32_t *enable);
+
+/** Write the telemetry battery charging enable */
+int lt8491_write_enable(struct lt8491_desc *dev, uint32_t enable);
+
+/** Restart the chip */
+int lt8491_restart_chip(struct lt8491_desc *dev);
+
+/** Read the scratch register */
+int lt8491_read_scratch(struct lt8491_desc *dev, uint32_t *val);
+
+/** Write the scratch register */
+int lt8491_write_scratch(struct lt8491_desc *dev, uint32_t val);
+
+/** Read the serial ID */
+int lt8491_read_serial_id(struct lt8491_desc *dev, uint32_t *val);
+
+#endif	/* __LT8491_H__ */

--- a/projects/dc2703a/Makefile
+++ b/projects/dc2703a/Makefile
@@ -1,0 +1,9 @@
+# Select the example you want to enable by choosing y for enabling and n for disabling
+BASIC_EXAMPLE = n
+IIO_EXAMPLE = y
+
+include ../../tools/scripts/generic_variables.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/dc2703a/README.rst
+++ b/projects/dc2703a/README.rst
@@ -1,0 +1,150 @@
+Evaluating the LT8491
+=======================
+
+.. contents::
+	:depth: 3
+
+Supported Evaluation Boards
+---------------------------
+
+* `DC2703A <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/dc2703a-a.html>`_
+
+Overview
+--------
+
+The DC2703A-A-KIT houses the DC2703A (LT8491 demo board). They provide a high
+performance buck-boost battery charger converter with an I2C interface for a
+microcontroller host. The LT8491 implements a maximum power point tracking
+(MPPT) function and flexible charging profiles, suitable for most battery types
+such as flooded and sealed lead acid batteries and Li-Ion batteries.
+
+Hardware Specifications
+-----------------------
+
+Power Supply Requirments
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+For this specific project, the DC2703A is powered by the 3V3 supply from the
+MAX32666FTHR.
+
+Board Connector and Jumper Settings
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Pin Description**
+
+	Please see the following table for the pin assignments:
+
+	+----------+-------------------------------------------+
+	| Name     | Description			       |
+	+----------+-------------------------------------------+
+	| VDD      | Connect to 3V3 supply		       |
+	+----------+-------------------------------------------+
+	| GND      | Connect to Ground			       |
+	+----------+-------------------------------------------+
+	| SCL      | Connect to I2C Clock (SCL)		       |
+	+----------+-------------------------------------------+
+	| SDA      | Connect to I2C Data (SDA)		       |
+	+----------+-------------------------------------------+
+
+No-OS Build Setup
+-----------------
+
+Please see: https://wiki.analog.com/resources/no-os/build
+
+No-OS Supported Examples
+------------------------
+
+The initialization data used in the examples is taken out from:
+`Project Common Data Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/dc2703a/src/common>`_
+
+The macros used in Common Data are defined in platform specific files found in:
+`Project Platform Configuration Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/dc2703a/src/platform>`_
+
+Basic example
+^^^^^^^^^^^^^
+
+This is a simple example that:
+
+* initializes the LT8491
+* software reset the LT8491
+* disables charger
+* writes-then-reads scratch pad
+* reads serial number
+* configures telemetry
+* enables charger
+* reads charging status and charging stage
+* and periodically reads telemetry data.
+
+In order to build the basic example make sure you have the following
+configuration in the
+`Makefile <https://github.com/analogdevicesinc/no-OS/tree/main/projects/dc2703a/Makefile>`_
+
+.. code-block:: bash
+
+	# Select the example you want to enable by choosing y for enabling and n for disabling
+	BASIC_EXAMPLE = y
+	IIO_EXAMPLE = n
+
+IIO example
+^^^^^^^^^^^
+
+This project is actually a IIOD demo for DC2703A. The project launches a IIOD
+server on the board so that the user may connect to it via an IIO client.
+
+Using IIO-Oscilloscope, the user can configure the device.
+
+If you are not familiar with ADI IIO Application, please take a look at:
+`IIO No-OS <https://wiki.analog.com/resources/tools-software/no-os-software/iio>`_
+
+If you are not familiar with ADI IIO-Oscilloscope Client, please take a look at:
+`IIO Oscilloscope <https://wiki.analog.com/resources/tools-software/linux-software/iio_oscilloscope>`_
+
+The No-OS IIO Application together with the No-OS IIO LT8491 driver take care
+of all the back-end logic needed to setup the IIO server.
+
+This example initializes the IIO device and calls the IIO app as shown in:
+`IIO Example <https://github.com/analogdevicesinc/no-OS/tree/main/projects/dc2703a/src/examples/iio_example>`_
+
+In order to build the IIO project make sure you have the following configuration
+in the
+`Makefile <https://github.com/analogdevicesinc/no-OS/tree/main/projects/dc2703a/Makefile>`_
+
+.. code-block:: bash
+
+        # Select the example you want to enable by choosing y for enabling and n for disabling
+        BASIC_EXAMPLE = n
+        IIO__EXAMPLE = y
+
+No-OS Supported Platforms
+-------------------------
+
+Maxim Platform
+^^^^^^^^^^^^^^
+
+**Used hardware**
+
+* `DC2703A <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/dc2703a-a.html>`_
+* `MAX32666FTHR <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/max32666fthr.html>`_
+
+**Connections**:
+
++-----------------------+-----------------------+------------------+
+| DC2703A Pin		| Function		| MAX32666FTHR Pin |
++-----------------------+-----------------------+------------------+
+| VDD                   | VDD			| 3V3              |
++-----------------------+-----------------------+------------------+
+| SCL                   | I2C Clock (SCL)	| P0_6 (I2C0_SCL)  |
++-----------------------+-----------------------+------------------+
+| SDA                   | I2C Data (SDA)	| P0_7 (I2C0_SDA)  |
++-----------------------+-----------------------+------------------+
+| GND                   | Ground (GND) 		| GND              |
++-----------------------+-----------------------+------------------+
+
+**Build Command**
+
+.. code-block:: bash
+
+	# to delete current build
+	make PLATFORM=maxim TARGET=max32665 reset
+	# to build the project and flash the code
+	make PLATFORM=maxim TARGET=max32665 run

--- a/projects/dc2703a/builds.json
+++ b/projects/dc2703a/builds.json
@@ -1,0 +1,10 @@
+{
+    "maxim": {
+      "basic_example_max32665": {
+        "flags" : "BASIC_EXAMPLE=y IIO_EXAMPLE=n TARGET=max32665"
+      },
+      "iio_example_max32665": {
+        "flags" : "BASIC_EXAMPLE=n IIO_EXAMPLE=y TARGET=max32665"
+      }
+    }
+  }

--- a/projects/dc2703a/src.mk
+++ b/projects/dc2703a/src.mk
@@ -1,0 +1,41 @@
+include $(PROJECT)/src/platform/$(PLATFORM)/platform_src.mk
+include $(PROJECT)/src/examples/examples_src.mk
+
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/main.c
+
+INCS += $(PROJECT)/src/common/common_data.h
+SRCS += $(PROJECT)/src/common/common_data.c
+
+INCS += $(PROJECT)/src/platform/platform_includes.h
+
+INCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.h
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.c
+
+INCS += $(INCLUDE)/no_os_delay.h     \
+		$(INCLUDE)/no_os_error.h     \
+		$(INCLUDE)/no_os_gpio.h      \
+		$(INCLUDE)/no_os_print_log.h \
+		$(INCLUDE)/no_os_i2c.h       \
+		$(INCLUDE)/no_os_alloc.h       \
+		$(INCLUDE)/no_os_irq.h      \
+		$(INCLUDE)/no_os_list.h      \
+		$(INCLUDE)/no_os_dma.h      \
+		$(INCLUDE)/no_os_uart.h      \
+		$(INCLUDE)/no_os_lf256fifo.h \
+		$(INCLUDE)/no_os_util.h 	\
+		$(INCLUDE)/no_os_units.h	\
+		$(INCLUDE)/no_os_mutex.h
+
+SRCS += $(DRIVERS)/api/no_os_gpio.c \
+		$(NO-OS)/util/no_os_lf256fifo.c \
+		$(DRIVERS)/api/no_os_irq.c  \
+		$(DRIVERS)/api/no_os_i2c.c  \
+		$(DRIVERS)/api/no_os_uart.c \
+		$(DRIVERS)/api/no_os_dma.c \
+		$(NO-OS)/util/no_os_list.c \
+		$(NO-OS)/util/no_os_util.c \
+		$(NO-OS)/util/no_os_alloc.c \
+		$(NO-OS)/util/no_os_mutex.c
+
+INCS += $(DRIVERS)/power/lt8491/lt8491.h
+SRCS += $(DRIVERS)/power/lt8491/lt8491.c

--- a/projects/dc2703a/src/common/common_data.c
+++ b/projects/dc2703a/src/common/common_data.c
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ *   @file   common_data.c
+ *   @brief  Defines common data to be used by lt8491 examples.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+#include "common_data.h"
+#include <stdbool.h>
+
+struct no_os_uart_init_param uip = {
+	.device_id = UART_DEVICE_ID,
+	.baud_rate = UART_BAUDRATE,
+	.size = NO_OS_UART_CS_8,
+	.parity = NO_OS_UART_PAR_NO,
+	.stop = NO_OS_UART_STOP_1_BIT,
+	.platform_ops = UART_OPS,
+	.extra = UART_EXTRA,
+};
+
+const struct no_os_i2c_init_param lt8491_i2c_ip = {
+	.device_id = I2C_DEVICE_ID,
+	.max_speed_hz = 100000,
+	.slave_address = 0x10,
+	.platform_ops = I2C_OPS,
+	.extra = I2C_EXTRA,
+};
+
+struct lt8491_init_param lt8491_ip = {
+	.i2c_init_param = lt8491_i2c_ip,
+	.rsense1_micro_ohms = 5000,
+	.rimon_out_ohms = 124000,
+	.rsense2_micro_ohms = 3000,
+	.rdaco_ohms = 64900,
+	.rfbout1_ohms = 113000,
+	.rfbout2_ohms = 10000,
+	.rdaci_ohms = 7000,
+	.rfbin2_ohms = 3480,
+	.rfbin1_ohms = 10200,
+};

--- a/projects/dc2703a/src/common/common_data.h
+++ b/projects/dc2703a/src/common/common_data.h
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ *   @file   common_data.h
+ *   @brief  Defines common data to be used by lt8491 examples.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#ifndef __COMMON_DATA_H__
+#define __COMMON_DATA_H__
+
+#include "platform_includes.h"
+#include "lt8491.h"
+#ifdef IIO_SUPPORT
+#include "iio_lt8491.h"
+#endif
+
+extern struct no_os_uart_init_param uip;
+
+extern const struct no_os_i2c_init_param lt8491_i2c_ip;
+extern struct lt8491_init_param lt8491_ip;
+
+#endif /* __COMMON_DATA_H__ */

--- a/projects/dc2703a/src/examples/basic/basic_example.c
+++ b/projects/dc2703a/src/examples/basic/basic_example.c
@@ -1,0 +1,183 @@
+/*******************************************************************************
+ *   @file   basic_example.c
+ *   @brief  Basic example code for lt8491 project
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+#include "basic_example.h"
+#include "common_data.h"
+#include "lt8491.h"
+#include "no_os_delay.h"
+#include "no_os_print_log.h"
+#include "no_os_units.h"
+/*****************************************************************************
+ * @brief Basic example main execution.
+ *
+ * @return ret - Result of the example execution. If working correctly, will
+ *               execute continuously the while(1) loop and will not return.
+ *******************************************************************************/
+int basic_example_main()
+{
+	struct lt8491_desc *dev;
+	int32_t val;
+	uint32_t uval, uvals[3];
+	int ret;
+
+	pr_info("\r\nRunning LT8491 Basic Example\r\n");
+
+	ret = lt8491_init(&dev, &lt8491_ip);
+	if (ret)
+		goto error;
+
+	pr_info("LT8491 Initialized\r\n");
+
+	ret = lt8491_restart_chip(dev);
+	if (ret)
+		goto free_dev;
+
+	pr_info("LT8491 Chip Restarted\r\n");
+
+	ret = lt8491_write_enable(dev, false);
+	if (ret)
+		goto free_dev;
+
+	pr_info("LT8491 Charging Disabled\r\n");
+
+	ret = lt8491_write_scratch(dev, 0x1234);
+	if (ret)
+		goto free_dev;
+
+	pr_info("LT8491 Scratch Written: 0x1234\r\n");
+
+	ret = lt8491_read_scratch(dev, &uval);
+	if (ret)
+		goto free_dev;
+
+	pr_info("LT8491 Scratch Read: 0x%04X\r\n", uval);
+
+	ret = lt8491_read_serial_id(dev, uvals);
+	if (ret)
+		goto free_dev;
+
+	pr_info("LT8491 Serial ID: %d %d %d\r\n", uvals[0], uvals[1],
+		uvals[2]);
+
+	ret = lt8491_configure_telemetry(dev, &lt8491_ip);
+	if (ret)
+		goto free_dev;
+
+	pr_info("LT8491 Telemetry Configured\r\n");
+
+	ret = lt8491_write_enable(dev, true);
+	if (ret)
+		goto free_dev;
+
+	pr_info("LT8491 Charging Enabled\r\n");
+
+	ret = lt8491_read_enable(dev, &uval);
+	if (ret)
+		goto free_dev;
+
+	pr_info("LT8491 Charging: %s\r\n", uval ? "Enabled" :
+		"Disabled");
+
+	ret = lt8491_read_charging_status(dev, &uval);
+	if (ret)
+		goto free_dev;
+
+	pr_info("LT8491 Charging Status: %s\r\n", uval ? "Charging" :
+		"Not Charging");
+
+	ret = lt8491_read_charging_stage(dev, &val);
+	if (ret)
+		goto free_dev;
+
+	pr_info("LT8491 Charging Stage: %c\r\n", (char)val);
+
+	while (1) {
+		ret = lt8491_read_tbat(dev, &val);
+		if (ret)
+			goto free_dev;
+
+		pr_info("LT8491 TBAT: %d\r\n", val);
+
+		ret = lt8491_read_pout(dev, &uval);
+		if (ret)
+			goto free_dev;
+
+		pr_info("LT8491 POUT: %d\r\n", uval);
+
+		ret = lt8491_read_pin(dev, &uval);
+		if (ret)
+			goto free_dev;
+
+		pr_info("LT8491 PIN: %d\r\n", uval);
+
+		ret = lt8491_read_efficiency(dev, &uval);
+		if (ret)
+			goto free_dev;
+
+		pr_info("LT8491 Efficiency: %d\r\n", uval);
+
+		ret = lt8491_read_iout(dev, &uval);
+		if (ret)
+			goto free_dev;
+
+		pr_info("LT8491 IOUT: %d\r\n", uval);
+
+		ret = lt8491_read_iin(dev, &uval);
+		if (ret)
+			goto free_dev;
+
+		pr_info("LT8491 IIN: %d\r\n", uval);
+
+		ret = lt8491_read_vbat(dev, &uval);
+		if (ret)
+			goto free_dev;
+
+		pr_info("LT8491 VBAT: %d\r\n", uval);
+
+		ret = lt8491_read_vin(dev, &uval);
+		if (ret)
+			goto free_dev;
+
+		pr_info("LT8491 VIN: %d\r\n", uval);
+
+		no_os_mdelay(5000);
+	}
+
+	return 0;
+
+free_dev:
+	lt8491_remove(dev);
+error:
+	pr_info("Error!\r\n");
+	return ret;
+}

--- a/projects/dc2703a/src/examples/basic/basic_example.h
+++ b/projects/dc2703a/src/examples/basic/basic_example.h
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ *   @file   basic_example.h
+ *   @brief  Basic example header for lt8491 project
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#ifndef __BASIC_EXAMPLE_H__
+#define __BASIC_EXAMPLE_H__
+
+int basic_example_main();
+
+#endif /* __BASIC_EXAMPLE_H__ */

--- a/projects/dc2703a/src/examples/examples_src.mk
+++ b/projects/dc2703a/src/examples/examples_src.mk
@@ -1,0 +1,21 @@
+ifeq (y,$(strip $(IIO_EXAMPLE)))
+IIOD=y
+CFLAGS += -DIIO_EXAMPLE=1
+SRCS += $(PROJECT)/src/examples/iio_example/iio_example.c
+INCS += $(PROJECT)/src/examples/iio_example/iio_example.h
+endif
+
+ifeq (y,$(strip $(BASIC_EXAMPLE)))
+CFLAGS += -DBASIC_EXAMPLE=1
+SRCS += $(PROJECT)/src/examples/basic/basic_example.c
+INCS += $(PROJECT)/src/examples/basic/basic_example.h
+endif
+
+ifeq (y,$(strip $(IIOD)))
+SRC_DIRS += $(NO-OS)/iio/iio_app
+INCS += $(DRIVERS)/power/lt8491/iio_lt8491.h
+SRCS += $(DRIVERS)/power/lt8491/iio_lt8491.c
+
+INCS += $(INCLUDE)/no_os_list.h \
+		$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h
+endif

--- a/projects/dc2703a/src/examples/iio_example/iio_example.c
+++ b/projects/dc2703a/src/examples/iio_example/iio_example.c
@@ -1,0 +1,81 @@
+/********************************************************************************
+ *   @file   iio_example.c
+ *   @brief  IIO example code for the lt8491 project
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+#include "iio_example.h"
+#include "common_data.h"
+#include "no_os_print_log.h"
+
+/*******************************************************************************
+ * @brief IIO example main execution.
+ *
+ * @return ret - Result of the example execution. If working correctly, will
+ *               execute continuously function iio_app_run and will not return.
+ *******************************************************************************/
+int iio_example_main()
+{
+	int ret;
+	struct lt8491_iio_device *lt8491_iio_dev;
+	struct lt8491_iio_init_param lt8491_iio_ip;
+	struct iio_app_desc *app;
+	struct iio_app_init_param app_init_param = {0};
+
+	lt8491_iio_ip.init_param = &lt8491_ip;
+	ret = lt8491_iio_init(&lt8491_iio_dev, &lt8491_iio_ip);
+	if (ret)
+		return ret;
+
+	struct iio_app_device iio_devices[] = {
+		{
+			.name = "lt8491",
+			.dev = lt8491_iio_dev,
+			.dev_descriptor = lt8491_iio_dev->iio_dev,
+		},
+	};
+
+	app_init_param.devices = iio_devices;
+	app_init_param.nb_devices = NO_OS_ARRAY_SIZE(iio_devices);
+	app_init_param.uart_init_params = uip;
+
+	ret = iio_app_init(&app, app_init_param);
+	if (ret)
+		goto error;
+
+	ret = iio_app_run(app);
+	if (ret)
+		pr_err("Error: iio_app_run: %d\r\n", ret);
+
+	iio_app_remove(app);
+error:
+	lt8491_iio_remove(lt8491_iio_dev);
+	return ret;
+}

--- a/projects/dc2703a/src/examples/iio_example/iio_example.h
+++ b/projects/dc2703a/src/examples/iio_example/iio_example.h
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ *   @file   iio_example.h
+ *   @brief  IIO example header for lt8491 project
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#ifndef __IIO_EXAMPLE_H__
+#define __IIO_EXAMPLE_H__
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+int iio_example_main();
+
+#endif /* __IIO_EXAMPLE_H__ */

--- a/projects/dc2703a/src/platform/maxim/main.c
+++ b/projects/dc2703a/src/platform/maxim/main.c
@@ -1,0 +1,80 @@
+/********************************************************************************
+ *   @file   main.c
+ *   @brief  Main file for Maxim platform of lt8491 project.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+#include "platform_includes.h"
+#include "common_data.h"
+
+#ifdef IIO_EXAMPLE
+#include "iio_example.h"
+#endif
+
+#ifdef BASIC_EXAMPLE
+#include "basic_example.h"
+#endif
+
+/*******************************************************************************
+ * @brief Main function execution for LT8491 platform.
+ *
+ * @return ret - Result of the enabled examples execution.
+ *******************************************************************************/
+int main()
+{
+#ifdef BASIC_EXAMPLE
+	int ret;
+	struct no_os_uart_desc *uart;
+
+	ret = no_os_uart_init(&uart, &uip);
+	if (ret)
+		goto error;
+
+	no_os_uart_stdio(uart);
+	ret = basic_example_main();
+	if (ret)
+		goto error;
+#endif
+
+#ifdef IIO_EXAMPLE
+	return iio_example_main();
+#endif
+
+#if (IIO_EXAMPLE + BASIC_EXAMPLE != 1)
+#error Selected example projects cannot be enabled at the same time. \
+Please enable only one example and re-build the project.
+#endif
+
+#ifdef BASIC_EXAMPLE
+error:
+	no_os_uart_remove(uart);
+#endif
+	return 0;
+}

--- a/projects/dc2703a/src/platform/maxim/parameters.c
+++ b/projects/dc2703a/src/platform/maxim/parameters.c
@@ -1,0 +1,42 @@
+/********************************************************************************
+ *   @file   parameters.c
+ *   @brief  Definition of maxim platform data used by lt8491 project.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#include "parameters.h"
+
+struct max_uart_init_param max_uart_extra = {
+	.flow = UART_FLOW_DIS,
+	.vssel = MXC_GPIO_VSSEL_VDDIOH
+};
+
+struct max_i2c_init_param max_i2c_extra = {
+	.vssel = MXC_GPIO_VSSEL_VDDIOH
+};

--- a/projects/dc2703a/src/platform/maxim/parameters.h
+++ b/projects/dc2703a/src/platform/maxim/parameters.h
@@ -1,0 +1,62 @@
+/********************************************************************************
+ *   @brief  Definitions specific to Maxim platform used by lt8491 project.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
+
+#include "maxim_uart.h"
+#include "maxim_uart_stdio.h"
+#include "maxim_i2c.h"
+
+#ifdef IIO_SUPPORT
+#define INTC_DEVICE_ID	0
+#endif
+#define UART_IRQ_ID	UART1_IRQn
+#define UART_DEVICE_ID	1
+#define UART_BAUDRATE	115200
+#define UART_OPS	&max_uart_ops
+#define UART_EXTRA      &max_uart_extra
+
+#if (TARGET_NUM == 32650) || (TARGET_NUM == 78000)
+#define I2C_DEVICE_ID    1
+#elif (TARGET_NUM == 32655)
+#define I2C_DEVICE_ID    2
+#elif (TARGET_NUM == 32665) || (TARGET_NUM == 32660) || (TARGET_NUM == 32690)
+#define I2C_DEVICE_ID    0
+#endif
+
+#define I2C_OPS         &max_i2c_ops
+#define I2C_EXTRA       &max_i2c_extra
+
+extern struct max_uart_init_param max_uart_extra;
+extern struct max_i2c_init_param max_i2c_extra;
+
+#endif /* __PARAMETERS_H__ */

--- a/projects/dc2703a/src/platform/maxim/platform_src.mk
+++ b/projects/dc2703a/src/platform/maxim/platform_src.mk
@@ -1,0 +1,14 @@
+INCS +=	$(PLATFORM_DRIVERS)/maxim_gpio.h      \
+		$(PLATFORM_DRIVERS)/maxim_i2c.h       \
+		$(PLATFORM_DRIVERS)/../common/maxim_dma.h       \
+		$(PLATFORM_DRIVERS)/maxim_irq.h      \
+		$(PLATFORM_DRIVERS)/maxim_uart.h      \
+		$(PLATFORM_DRIVERS)/maxim_uart_stdio.h
+
+SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c     \
+		$(PLATFORM_DRIVERS)/maxim_gpio.c      \
+		$(PLATFORM_DRIVERS)/maxim_i2c.c       \
+		$(PLATFORM_DRIVERS)/../common/maxim_dma.c       \
+		$(PLATFORM_DRIVERS)/maxim_irq.c      \
+		$(PLATFORM_DRIVERS)/maxim_uart.c      \
+		$(PLATFORM_DRIVERS)/maxim_uart_stdio.c

--- a/projects/dc2703a/src/platform/platform_includes.h
+++ b/projects/dc2703a/src/platform/platform_includes.h
@@ -1,0 +1,47 @@
+/********************************************************************************
+ *   @file   platform_includes.h
+ *   @brief  Includes for used platforms used by the lt8491 project.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#ifndef __PLATFORM_INCLUDES_H__
+#define __PLATFORM_INCLUDES_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#ifdef MAXIM_PLATFORM
+#include "maxim/parameters.h"
+#endif
+
+#ifdef IIO_SUPPORT
+#include "iio_app.h"
+#endif
+
+#endif /* __PLATFORM_INCLUDES_H__ */


### PR DESCRIPTION
## Pull Request Description

The LT8491 is a buck-boost switching regulator battery charger that implements a constant-current constant-voltage (CCCV) charging profile used for most battery types, including sealed lead-acid (SLA), flooded, gel and lithium-ion.

The device operates from input voltages above, below or equal to the output voltage and can be powered by a solar panel or a DC power supply. On-chip logic provides automatic maximum power point tracking (MPPT) for solar powered applications. The LT8491 can perform automatic temperature compensation by sensing an external thermistor thermally coupled to the battery. The STATUS pin can be used to drive an LED indicator lamp. The device is available in a low profile (0.75mm) 7mm x 11mm 64-lead QFN package.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
