### PR TITLE
drivers: meter: ade7816 : Add support for ADE7816

### DIFF
--- a/doc/sphinx/source/drivers/ade7816.rst
+++ b/doc/sphinx/source/drivers/ade7816.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../drivers/meter/ade7816/README.rst

--- a/doc/sphinx/source/drivers_doc.rst
+++ b/doc/sphinx/source/drivers_doc.rst
@@ -68,6 +68,13 @@ LED
 
    drivers/max25603
 
+METER
+=====
+.. toctree::
+   :maxdepth: 1
+
+   drivers/ade7816
+
 RF TRANSCEIVER
 ==============
 .. toctree::

--- a/drivers/meter/ade7816/README.rst
+++ b/drivers/meter/ade7816/README.rst
@@ -1,0 +1,131 @@
+ADE7816 no-OS documentation
+===========================
+
+Supported Devices
+-----------------
+
+`ADE7816 <https://www.analog.com/ADE7816>`
+
+Overview
+--------
+
+The ADE7816 is a highly accurate, multichannel metering
+device that is capable of measuring one voltage channel and up
+to six current channels. It measures line voltage and current and
+calculates active and reactive energy, as well as instantaneous rms
+voltage and current. The device incorporates seven sigma-delta
+(Σ-Δ) ADCs with a high accuracy energy measurement core.
+The six current input channels allow multiple loads to be measured
+simultaneously. The voltage channel and the six current channels
+each have a complete signal path allowing for a full range of
+measurements. Each input channel supports a flexible gain stage
+and is suitable for use with current transformers (CTs). Six on-
+chip digital integrators facilitate the use of the Rogowski coil
+sensors.
+
+ADE7816 Device Configuration
+----------------------------
+
+Both SPI or I2C communication protocols are supported but only one can be used
+and it is to be set at the device initialization.
+
+The first API to be called is **ade7816_init**. Make sure that it returns 0,
+which means that the driver was initialized correctly.
+
+Active and Reactive Energy Measurements
+---------------------------------------
+
+Bot active and reactive energy can be read from their registers by using either
+**ade7816_read_active_energy** or **ade7816_read_reactive_energy** APIs, more
+to this active and reactive energy threshold values can be set depending on the
+desired update rate.
+
+Line-Cycle mode and no-load conditions can be set by using
+**ade7816_set_lcycle_mode** API and **ade7816_set_no_load** API.
+
+Root Mean Square Measurement
+----------------------------
+
+The RMS value for any channel can be read using **ade7816_read_rms** API.
+
+Calibration
+-----------
+
+Gain, offset, phase and rms can be calibrated by using the following APIs:
+**ade7816_set_gain**, **ade7816_set_offset**, **ade7816_set_phase** and
+**ade7816_calib_rms**.
+
+Group Selection
+---------------
+
+Channels can be grouped in thirds (A,B,C or D,E,F) by using
+**ade7816_group_sel** API, more to this zero-crossing, peak detection, power
+direction and angle measurements are available by using the following APIs:
+**ade7816_zx_detect**, **ade7816_peak_detect**, **ade7816_power_dir** and
+**ade7816_angle_meas**.
+
+Interrupt Configuration
+-----------------------
+
+Each interrupt available on the IRQ0 and IRQ1 pins depending on the STATUS0
+and STATUS1 registers can be configured using **ade7816_set_interrupt** API.
+
+Default interrupt handlers are provided within the driver in case user doesn't
+assign a callback to the initialization parameter referring to the specific IRQ
+pin.
+
+Priorities for the interrupt handlers can also be configured by changing the
+priority variable in the initialization parameter structure before init.
+
+For a more detailed description about interrupt priorities see :
+`NoOS Interrupt API <https://wiki.analog.com/resources/no-os/drivers/interrupt>`
+
+RMS Scaling
+-----------
+
+RMS value can be scaled in microunits by using **ade7816_rms_to_micro** API.
+
+ADE7816 Driver Initialization Example
+--------------------------------------
+
+.. code-block:: bash
+
+	struct ade7816 *ade7816;
+	struct no_os_spi_init_param spi_ip = {
+		.device_id = 0,
+		.extra = &ade7816_spi_extra,
+		.max_speed_hz = 100000,
+		.platform_ops = &max_spi_ops,
+		.chip_select = 0,
+	};
+	struct ade7816_init_param max22196_ip = {
+		.spi_param = &ade7816_spi_ip,
+		.i2c_param = NULL,
+		.reset_param = &ade7816_reset_ip,
+		.ss_param = NULL,
+		.gpio_irq0_param = &ade7816_gpio_irq0_ip,
+		.gpio_irq1_param = NULL,
+		.active_irq = ADE7816_IRQ0,
+		.irq0_callback = NULL,
+		.comm_type = ADE7816_SPI,
+		.handle_irq0 = MXC_GPIO_GET_GPIO(2),
+		.irq0_priority = 1,
+	};
+
+	/** GPIO Pin Interrupt Controller */
+	struct no_os_irq_ctrl_desc *gpio_irq_desc;
+	struct no_os_irq_init_param gpio_irq_desc_param = {
+		.irq_ctrl_id = GPIO_IRQ_ID,
+		.platform_ops = GPIO_IRQ_OPS,
+		.extra = GPIO_IRQ_EXTRA
+	};
+
+	ret = no_os_irq_ctrl_init(&gpio_irq_desc, &gpio_irq_desc_param);
+	if (ret)
+		goto exit;
+
+	ade7816_ip.irq_ctrl = gpio_irq_desc;
+
+	ret = ade7816_init(&ade7816, &ade7816_ip);
+	if (ret)
+		goto error;

--- a/drivers/meter/ade7816/ade7816.c
+++ b/drivers/meter/ade7816/ade7816.c
@@ -1,0 +1,1694 @@
+/***************************************************************************//**
+ *   @file   ade7816.c
+ *   @brief  Source file of ADE7816 Driver.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+#include "no_os_alloc.h"
+#include "no_os_delay.h"
+#include "no_os_units.h"
+#include "ade7816.h"
+
+/**
+ * @brief Register read wrapper function
+ * @param desc - ADE7816 device descriptor.
+ * @param reg - Register Address value.
+ * @param val - Register Value to be read.
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_read_reg(struct ade7816_desc *desc, uint16_t reg, uint32_t *val)
+{
+	return desc->reg_read(desc, reg, val);
+}
+
+/**
+ * @brief Register write wrapper function
+ * @param desc - ADE7816 device descriptor
+ * @param reg - Register Address value.
+ * @param val - Register Value to be written.
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_write_reg(struct ade7816_desc *desc, uint16_t reg, uint32_t val)
+{
+	return desc->reg_write(desc, reg, val);
+}
+
+/**
+ * @brief Register update function
+ * @param desc - ADE7816 device descriptor.
+ * @param reg - address of the register.
+ * @param mask - bit mask of the field to be updated.
+ * @param val - value of the masked field. Should be bit shifted by using
+ * 		 no_os_field_prep(mask, val).
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7816_reg_update(struct ade7816_desc *desc, uint16_t reg, uint32_t mask,
+		       uint32_t val)
+{
+	uint32_t reg_val;
+	int ret;
+
+	ret = ade7816_read_reg(desc, reg, &reg_val);
+	if (ret)
+		return ret;
+
+	reg_val &= ~mask;
+	reg_val |= val;
+
+	return ade7816_write_reg(desc, reg, val);
+}
+
+/**
+ * @brief ADE7816 software reset function
+ * @param desc - ADE7816 device descriptor.
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_sw_reset(struct ade7816_desc *desc)
+{
+	int ret;
+
+	ret = ade7816_reg_update(desc, ADE7816_CONFIG_REG, ADE7816_SWRST_MASK,
+				 no_os_field_prep(ADE7816_SWRST_MASK, 1));
+	if (ret)
+		return ret;
+
+	no_os_mdelay(ADE7816_INIT_DELAY);
+
+	return 0;
+}
+
+/**
+ * @brief ADE7816 hardware reset function
+ * @param desc - ADE7816 device descriptor
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_hw_reset(struct ade7816_desc *desc)
+{
+	int ret;
+
+	ret = no_os_gpio_set_value(desc->reset_desc, NO_OS_GPIO_LOW);
+	if (ret)
+		return ret;
+
+	no_os_udelay(ADE7816_HWRST_DELAY);
+
+	ret = no_os_gpio_set_value(desc->reset_desc, NO_OS_GPIO_HIGH);
+	if (ret)
+		return ret;
+
+	no_os_mdelay(ADE7816_INIT_DELAY);
+
+	return 0;
+}
+
+/**
+ * @brief ADE7816 set communication function
+ * @param desc - ADE7816 device descriptor
+ * @param type - Communication type.
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_set_comm(struct ade7816_desc *desc, enum ade7816_comm_type type)
+{
+	int ret, i;
+
+	switch (type) {
+	case ADE7816_I2C:
+		desc->reg_read = ade7816_i2c_reg_read;
+		desc->reg_write = ade7816_i2c_reg_write;
+		desc->comm_type = ADE7816_I2C;
+
+		return ade7816_reg_update(desc, ADE7816_CONFIG2_REG,
+					  ADE7816_I2C_LOCK_MASK,
+					  no_os_field_prep(ADE7816_I2C_LOCK_MASK, 1));
+	case ADE7816_SPI:
+		desc->reg_read = ade7816_spi_reg_read;
+		desc->reg_write = ade7816_spi_reg_write;
+		desc->comm_type = ADE7816_SPI;
+
+		for (i = 0; i < 3; i++) {
+			ret = ade7816_write_reg(desc, 0xEBFF, 0);
+			if (ret)
+				return ret;
+		}
+
+		return ade7816_write_reg(desc, ADE7816_CONFIG2_REG, 0);
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief ADE7816 read active energy function
+ * @param desc - ADE7816 device descriptor
+ * @param chan - Channel number.
+ * @param val - Active energy value.
+ */
+int ade7816_read_active_energy(struct ade7816_desc *desc,
+			       enum ade7816_channel chan, int32_t *val)
+{
+	uint32_t reg_val;
+	int ret;
+
+	if (desc->lcycle_mode) {
+		ret = ade7816_reg_update(desc, ADE7816_LCYCMODE_REG,
+					 ADE7816_RSTREAD_MASK,
+					 no_os_field_prep(ADE7816_RSTREAD_MASK, 0));
+		if (ret)
+			return ret;
+	}
+
+	switch (chan) {
+	case ADE7816_CHANNEL_A:
+		ret = ade7816_read_reg(desc, ADE7816_AWATTHR_REG, &reg_val);
+		if (ret)
+			return ret;
+
+		break;
+	case ADE7816_CHANNEL_B:
+		ret = ade7816_read_reg(desc, ADE7816_BWATTHR_REG, &reg_val);
+		if (ret)
+			return ret;
+
+		break;
+	case ADE7816_CHANNEL_C:
+		ret = ade7816_read_reg(desc, ADE7816_CWATTHR_REG, &reg_val);
+		if (ret)
+			return ret;
+
+		break;
+	case ADE7816_CHANNEL_D:
+		ret = ade7816_read_reg(desc, ADE7816_DWATTHR_REG, &reg_val);
+		if (ret)
+			return ret;
+
+		break;
+	case ADE7816_CHANNEL_E:
+		ret = ade7816_read_reg(desc, ADE7816_EWATTHR_REG, &reg_val);
+		if (ret)
+			return ret;
+
+		break;
+	case ADE7816_CHANNEL_F:
+		ret = ade7816_read_reg(desc, ADE7816_FWATTHR_REG, &reg_val);
+		if (ret)
+			return ret;
+
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	*val = no_os_sign_extend32(reg_val, 30);
+
+	return 0;
+}
+
+/**
+ * @brief ADE7816 set active energy threshold value function
+ * @param desc - ADE7816 device descriptor.
+ * @param freq - Update rate frequency.
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_set_active_thr(struct ade7816_desc *desc, uint16_t freq)
+{
+	uint32_t msb, lsb, tmp;
+	int ret;
+
+	if (freq > 8000)
+		return -EINVAL;
+
+	tmp = (0x2000000 / freq) * 8000;
+
+	msb = no_os_field_get(ADE7816_THR_MSB_MASK, tmp);
+	lsb = no_os_field_get(ADE7816_THR_LSB_MASK, tmp);
+
+	ret = ade7816_write_reg(desc, ADE7816_WTHR1_REG, msb);
+	if (ret)
+		return ret;
+
+	return ade7816_write_reg(desc, ADE7816_WTHR0_REG, lsb);
+}
+
+/**
+ * @brief ADE7816 get active energy threshold value function
+ * @param desc - ADE7816 device descriptor.
+ * @param freq - Update rate frequency.
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_get_active_thr(struct ade7816_desc *desc, uint16_t *freq)
+{
+	uint32_t msb, lsb, tmp;
+	int ret;
+
+	ret = ade7816_read_reg(desc, ADE7816_WTHR1_REG, &msb);
+	if (ret)
+		return ret;
+
+	ret = ade7816_read_reg(desc, ADE7816_WTHR0_REG, &lsb);
+	if (ret)
+		return ret;
+
+	tmp = no_os_field_prep(ADE7816_THR_MSB_MASK, msb) |
+	      no_os_field_prep(ADE7816_THR_LSB_MASK, lsb);
+
+	*freq = (0x2000000 / tmp) * 8000;
+
+	return 0;
+}
+
+/**
+ * @brief ADE7816 read reactive energy value function
+ * @param desc - ADE7816 device descriptor.
+ * @param chan - Channel number.
+ * @param val - Reactive energy value.
+ * @return 0 in case of succes, negativeerror code otherwise.
+ */
+int ade7816_read_reactive_energy(struct ade7816_desc *desc,
+				 enum ade7816_channel chan, int32_t *val)
+{
+	uint32_t reg_val;
+	int ret;
+
+	if (desc->lcycle_mode) {
+		ret = ade7816_reg_update(desc, ADE7816_LCYCMODE_REG,
+					 ADE7816_RSTREAD_MASK,
+					 no_os_field_prep(ADE7816_RSTREAD_MASK, 0));
+		if (ret)
+			return ret;
+	}
+
+	switch (chan) {
+	case ADE7816_CHANNEL_A:
+		ret = ade7816_read_reg(desc, ADE7816_AVARHR_REG, &reg_val);
+		if (ret)
+			return ret;
+
+		break;
+	case ADE7816_CHANNEL_B:
+		ret = ade7816_read_reg(desc, ADE7816_BVARHR_REG, &reg_val);
+		if (ret)
+			return ret;
+
+		break;
+	case ADE7816_CHANNEL_C:
+		ret = ade7816_read_reg(desc, ADE7816_CVARHR_REG, &reg_val);
+		if (ret)
+			return ret;
+
+		break;
+	case ADE7816_CHANNEL_D:
+		ret = ade7816_read_reg(desc, ADE7816_DVARHR_REG, &reg_val);
+		if (ret)
+			return ret;
+
+		break;
+	case ADE7816_CHANNEL_E:
+		ret = ade7816_read_reg(desc, ADE7816_EVARHR_REG, &reg_val);
+		if (ret)
+			return ret;
+
+		break;
+	case ADE7816_CHANNEL_F:
+		ret = ade7816_read_reg(desc, ADE7816_FVARHR_REG, &reg_val);
+		if (ret)
+			return ret;
+
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	*val = no_os_sign_extend32(reg_val, 30);
+
+	return 0;
+}
+
+/**
+ * @brief ADE7816 set reactive energy threshold value function
+ * @param desc - ADE7816 device descriptor.
+ * @param freq - Update rate frequency.
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_set_reactive_thr(struct ade7816_desc *desc, uint16_t freq)
+{
+	uint32_t msb, lsb, tmp;
+	int ret;
+
+	if (freq > 8000)
+		return -EINVAL;
+
+	tmp = (0x2000000 / freq) * 8000;
+
+	msb = no_os_field_get(ADE7816_THR_MSB_MASK, tmp);
+	lsb = no_os_field_get(ADE7816_THR_LSB_MASK, tmp);
+
+	ret = ade7816_write_reg(desc, ADE7816_VARTHR1_REG, msb);
+	if (ret)
+		return ret;
+
+	return ade7816_write_reg(desc, ADE7816_VARTHR0_REG, lsb);
+}
+
+/**
+ * @brief ADE7816 get reactive energy threshold value function
+ * @param desc - ADE7816 device descriptor.
+ * @param freq - Update rate frequency.
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_get_reactive_thr(struct ade7816_desc *desc, uint16_t *freq)
+{
+	uint32_t msb, lsb, tmp;
+	int ret;
+
+	ret = ade7816_read_reg(desc, ADE7816_VARTHR1_REG, &msb);
+	if (ret)
+		return ret;
+
+	ret = ade7816_read_reg(desc, ADE7816_VARTHR0_REG, &lsb);
+	if (ret)
+		return ret;
+
+	tmp = no_os_field_prep(ADE7816_THR_MSB_MASK, msb) |
+	      no_os_field_prep(ADE7816_THR_LSB_MASK, lsb);
+
+	*freq = (0x2000000 / tmp) * 8000;
+
+	return 0;
+}
+
+/**
+ * @brief ADE7816 set line cycle mode function
+ * @param desc - ADE7816 device descriptor.
+ * @param enable - False = Disable
+ * 		    True = Enable
+ * @param cycles - Cycle lines number.
+ * @param lenergy - Set lenergy bit.
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_set_lcycle_mode(struct ade7816_desc *desc, bool enable,
+			    uint16_t cycles, bool lenergy)
+{
+	int ret;
+
+	if (enable) {
+		ret = ade7816_reg_update(desc, ADE7816_LCYCMODE_REG,
+					 ADE7816_RSTREAD_MASK,
+					 no_os_field_prep(ADE7816_RSTREAD_MASK, 0));
+		if (ret)
+			return ret;
+	}
+
+	ret = ade7816_reg_update(desc, ADE7816_LCYCMODE_REG, ADE7816_ZX_SEL_MASK,
+				 no_os_field_prep(ADE7816_ZX_SEL_MASK, enable));
+	if (ret)
+		return ret;
+
+	ret = ade7816_reg_update(desc, ADE7816_LCYCMODE_REG, ADE7816_LMASK,
+				 no_os_field_prep(ADE7816_LMASK, ADE7816_LINECYC_VAL(enable)));
+	if (ret)
+		return ret;
+
+	ret = ade7816_write_reg(desc, ADE7816_LINECYC_REG, enable ? cycles : 0);
+	if (ret)
+		return ret;
+
+	return ade7816_reg_update(desc, ADE7816_MASK0_REG, ADE7816_LENERGY_MASK,
+				  no_os_field_prep(ADE7816_LENERGY_MASK, lenergy));
+}
+
+/**
+ * @brief ADE7816 read root mean square measurement value function
+ * @param desc - ADE7816 device descriptor.
+ * @param chan - Channel number.
+ * @param rms - RMS value.
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_read_rms(struct ade7816_desc *desc, enum ade7816_channel chan,
+		     uint32_t *rms)
+{
+	switch (chan) {
+	case ADE7816_CHANNEL_A:
+		return ade7816_read_reg(desc, ADE7816_IARMS_REG, rms);
+	case ADE7816_CHANNEL_B:
+		return ade7816_read_reg(desc, ADE7816_IBRMS_REG, rms);
+	case ADE7816_CHANNEL_C:
+		return ade7816_read_reg(desc, ADE7816_ICRMS_REG, rms);
+	case ADE7816_CHANNEL_D:
+		return ade7816_read_reg(desc, ADE7816_IDRMS_REG, rms);
+	case ADE7816_CHANNEL_E:
+		return ade7816_read_reg(desc, ADE7816_IERMS_REG, rms);
+	case ADE7816_CHANNEL_F:
+		return ade7816_read_reg(desc, ADE7816_IFRMS_REG, rms);
+	case ADE7816_CHANNEL_VOLTAGE:
+		return ade7816_read_reg(desc, ADE7816_VRMS_REG, rms);
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief ADE7816 set no load condition function
+ * @param desc - ADE7816 device descriptor.
+ * @param voltage - Voltage percent of the full-scale (100.00% = 10000).
+ * @param current - Current percent of the full-scale (100.00% = 10000).
+ * @param enable - False = Disable
+ * 		   True = Enable
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_set_no_load(struct ade7816_desc *desc, uint16_t voltage,
+			uint16_t current, bool enable)
+{
+	int32_t apnoload;
+	int ret;
+
+	if (voltage > 10000 || current > 10000)
+		return -EINVAL;
+
+	if (enable)
+		apnoload = NO_OS_DIV_ROUND_CLOSEST(0x1FF6A6B * voltage * current, MICRO * 100);
+	else
+		apnoload = -1;
+
+	ret = ade7816_write_reg(desc, ADE7816_APNOLOAD_REG, apnoload);
+	if (ret)
+		return ret;
+
+	return ade7816_write_reg(desc, ADE7816_VARNOLOAD_REG, apnoload);
+}
+
+/**
+ * @brief ADE7816 set gain value for channel function
+ * @param desc -  ADE7816 device descriptor.
+ * @param chan - Channel number.
+ * @param scale - Scale percentage of full-scale (100.00% = 10000)
+ * @param gain - Gain type.
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_set_gain(struct ade7816_desc *desc, enum ade7816_channel chan,
+		     int16_t scale, enum ade7816_gain_type gain)
+{
+	int32_t gain_val;
+	uint16_t reg;
+
+	if (scale > 10000 || scale < -10000)
+		return -EINVAL;
+
+	gain_val = NO_OS_DIV_ROUND_CLOSEST_ULL(0x7FFFFF * scale, MILLI * 10);
+
+	switch (chan) {
+	case ADE7816_CHANNEL_A:
+		switch (gain) {
+		case ADE7816_CURRENT_GAIN:
+			reg = ADE7816_IAGAIN_REG;
+			break;
+		case ADE7816_ACTIVE_POWER_GAIN:
+			reg = ADE7816_AWGAIN_REG;
+			break;
+		case ADE7816_REACTIVE_POWER_GAIN:
+			reg = ADE7816_AVARGAIN_REG;
+			break;
+		default:
+			return -EINVAL;
+		}
+		break;
+	case ADE7816_CHANNEL_B:
+		switch (gain) {
+		case ADE7816_CURRENT_GAIN:
+			reg = ADE7816_IBGAIN_REG;
+			break;
+		case ADE7816_ACTIVE_POWER_GAIN:
+			reg = ADE7816_BWGAIN_REG;
+			break;
+		case ADE7816_REACTIVE_POWER_GAIN:
+			reg = ADE7816_BVARGAIN_REG;
+			break;
+		default:
+			return -EINVAL;
+		}
+		break;
+	case ADE7816_CHANNEL_C:
+		switch (gain) {
+		case ADE7816_CURRENT_GAIN:
+			reg = ADE7816_ICGAIN_REG;
+			break;
+		case ADE7816_ACTIVE_POWER_GAIN:
+			reg = ADE7816_CWGAIN_REG;
+			break;
+		case ADE7816_REACTIVE_POWER_GAIN:
+			reg = ADE7816_CVARGAIN_REG;
+			break;
+		default:
+			return -EINVAL;
+		}
+		break;
+	case ADE7816_CHANNEL_D:
+		switch (gain) {
+		case ADE7816_CURRENT_GAIN:
+			reg = ADE7816_IDGAIN_REG;
+			break;
+		case ADE7816_ACTIVE_POWER_GAIN:
+			reg = ADE7816_DWGAIN_REG;
+			break;
+		case ADE7816_REACTIVE_POWER_GAIN:
+			reg = ADE7816_DVARGAIN_REG;
+			break;
+		default:
+			return -EINVAL;
+		}
+		break;
+	case ADE7816_CHANNEL_E:
+		switch (gain) {
+		case ADE7816_CURRENT_GAIN:
+			reg = ADE7816_IEGAIN_REG;
+			break;
+		case ADE7816_ACTIVE_POWER_GAIN:
+			reg = ADE7816_EWGAIN_REG;
+			break;
+		case ADE7816_REACTIVE_POWER_GAIN:
+			reg = ADE7816_EVARGAIN_REG;
+			break;
+		default:
+			return -EINVAL;
+		}
+		break;
+	case ADE7816_CHANNEL_F:
+		switch (gain) {
+		case ADE7816_CURRENT_GAIN:
+			reg = ADE7816_IFGAIN_REG;
+			break;
+		case ADE7816_ACTIVE_POWER_GAIN:
+			reg = ADE7816_FWGAIN_REG;
+			break;
+		case ADE7816_REACTIVE_POWER_GAIN:
+			reg = ADE7816_FVARGAIN_REG;
+			break;
+		default:
+			return -EINVAL;
+		}
+		break;
+	case ADE7816_CHANNEL_VOLTAGE:
+		reg = ADE7816_VGAIN_REG;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return ade7816_write_reg(desc, reg, gain_val);
+}
+
+/**
+ * @brief ADE7816 get gain value for channel function
+ * @param desc -  ADE7816 device descriptor.
+ * @param chan - Channel number.
+ * @param scale - Scale percentage of full-scale (100.00% = 10000)
+ * @param gain - Gain type.
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_get_gain(struct ade7816_desc *desc, enum ade7816_channel chan,
+		     int16_t *scale, enum ade7816_gain_type gain)
+{
+	uint32_t reg_val;
+	int32_t gain_val;
+	uint16_t reg;
+	int ret;
+
+	switch (chan) {
+	case ADE7816_CHANNEL_A:
+		switch (gain) {
+		case ADE7816_CURRENT_GAIN:
+			reg = ADE7816_IAGAIN_REG;
+			break;
+		case ADE7816_ACTIVE_POWER_GAIN:
+			reg = ADE7816_AWGAIN_REG;
+			break;
+		case ADE7816_REACTIVE_POWER_GAIN:
+			reg = ADE7816_AVARGAIN_REG;
+			break;
+		default:
+			return -EINVAL;
+		}
+		break;
+	case ADE7816_CHANNEL_B:
+		switch (gain) {
+		case ADE7816_CURRENT_GAIN:
+			reg = ADE7816_IBGAIN_REG;
+			break;
+		case ADE7816_ACTIVE_POWER_GAIN:
+			reg = ADE7816_BWGAIN_REG;
+			break;
+		case ADE7816_REACTIVE_POWER_GAIN:
+			reg = ADE7816_BVARGAIN_REG;
+			break;
+		default:
+			return -EINVAL;
+		}
+		break;
+	case ADE7816_CHANNEL_C:
+		switch (gain) {
+		case ADE7816_CURRENT_GAIN:
+			reg = ADE7816_ICGAIN_REG;
+			break;
+		case ADE7816_ACTIVE_POWER_GAIN:
+			reg = ADE7816_CWGAIN_REG;
+			break;
+		case ADE7816_REACTIVE_POWER_GAIN:
+			reg = ADE7816_CVARGAIN_REG;
+			break;
+		default:
+			return -EINVAL;
+		}
+		break;
+	case ADE7816_CHANNEL_D:
+		switch (gain) {
+		case ADE7816_CURRENT_GAIN:
+			reg = ADE7816_IDGAIN_REG;
+			break;
+		case ADE7816_ACTIVE_POWER_GAIN:
+			reg = ADE7816_DWGAIN_REG;
+			break;
+		case ADE7816_REACTIVE_POWER_GAIN:
+			reg = ADE7816_DVARGAIN_REG;
+			break;
+		default:
+			return -EINVAL;
+		}
+		break;
+	case ADE7816_CHANNEL_E:
+		switch (gain) {
+		case ADE7816_CURRENT_GAIN:
+			reg = ADE7816_IEGAIN_REG;
+			break;
+		case ADE7816_ACTIVE_POWER_GAIN:
+			reg = ADE7816_EWGAIN_REG;
+			break;
+		case ADE7816_REACTIVE_POWER_GAIN:
+			reg = ADE7816_EVARGAIN_REG;
+			break;
+		default:
+			return -EINVAL;
+		}
+		break;
+	case ADE7816_CHANNEL_F:
+		switch (gain) {
+		case ADE7816_CURRENT_GAIN:
+			reg = ADE7816_IFGAIN_REG;
+			break;
+		case ADE7816_ACTIVE_POWER_GAIN:
+			reg = ADE7816_FWGAIN_REG;
+			break;
+		case ADE7816_REACTIVE_POWER_GAIN:
+			reg = ADE7816_FVARGAIN_REG;
+			break;
+		default:
+			return -EINVAL;
+		}
+		break;
+	case ADE7816_CHANNEL_VOLTAGE:
+		reg = ADE7816_VGAIN_REG;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	ret = ade7816_read_reg(desc, reg, &reg_val);
+	if (ret)
+		return ret;
+
+	gain_val = reg_val;
+
+	*scale = NO_OS_DIV_ROUND_CLOSEST(gain_val * MILLI * 10, 0x7FFFFF);
+
+	return 0;
+}
+
+/**
+ * @brief ADE7816 set offset value for channel function
+ * @param desc - ADE7816 device descriptor.
+ * @param chan - Channel number.
+ * @param scale - Scale percentage value (100.00% = 10000)
+ * @param gain - Gain type.
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_set_offset(struct ade7816_desc *desc, enum ade7816_channel chan,
+		       int16_t scale, enum ade7816_gain_type gain)
+{
+	int32_t offset;
+	uint16_t reg;
+
+	if (scale > 10000 || scale < -10000)
+		return -EINVAL;
+
+	offset = NO_OS_DIV_ROUND_CLOSEST_ULL(scale * MILLI * 10, 298);
+
+	switch (chan) {
+	case ADE7816_CHANNEL_A:
+		switch (gain) {
+		case ADE7816_ACTIVE_POWER_GAIN:
+			reg = ADE7816_AWATTOS_REG;
+			break;
+		case ADE7816_REACTIVE_POWER_GAIN:
+			reg = ADE7816_AVAROS_REG;
+			break;
+		default:
+			return -EINVAL;
+		}
+		break;
+	case ADE7816_CHANNEL_B:
+		switch (gain) {
+		case ADE7816_ACTIVE_POWER_GAIN:
+			reg = ADE7816_BWATTOS_REG;
+			break;
+		case ADE7816_REACTIVE_POWER_GAIN:
+			reg = ADE7816_BVAROS_REG;
+			break;
+		default:
+			return -EINVAL;
+		}
+		break;
+	case ADE7816_CHANNEL_C:
+		switch (gain) {
+		case ADE7816_ACTIVE_POWER_GAIN:
+			reg = ADE7816_CWATTOS_REG;
+			break;
+		case ADE7816_REACTIVE_POWER_GAIN:
+			reg = ADE7816_CVAROS_REG;
+			break;
+		default:
+			return -EINVAL;
+		}
+		break;
+	case ADE7816_CHANNEL_D:
+		switch (gain) {
+		case ADE7816_ACTIVE_POWER_GAIN:
+			reg = ADE7816_DWATTOS_REG;
+			break;
+		case ADE7816_REACTIVE_POWER_GAIN:
+			reg = ADE7816_DVAROS_REG;
+			break;
+		default:
+			return -EINVAL;
+		}
+		break;
+	case ADE7816_CHANNEL_E:
+		switch (gain) {
+		case ADE7816_ACTIVE_POWER_GAIN:
+			reg = ADE7816_EWATTOS_REG;
+			break;
+		case ADE7816_REACTIVE_POWER_GAIN:
+			reg = ADE7816_EVAROS_REG;
+			break;
+		default:
+			return -EINVAL;
+		}
+		break;
+	case ADE7816_CHANNEL_F:
+		switch (gain) {
+		case ADE7816_ACTIVE_POWER_GAIN:
+			reg = ADE7816_FWATTOS_REG;
+			break;
+		case ADE7816_REACTIVE_POWER_GAIN:
+			reg = ADE7816_FVAROS_REG;
+			break;
+		default:
+			return -EINVAL;
+		}
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return ade7816_write_reg(desc, reg, offset);
+}
+
+/**
+ * @brief ADE7816 get offset value for channel function
+ * @param desc - ADE7816 device descriptor.
+ * @param chan - Channel number.
+ * @param scale - Scale percentage value (100.00% = 10000)
+ * @param gain - Gain type.
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_get_offset(struct ade7816_desc *desc, enum ade7816_channel chan,
+		       int16_t *scale, enum ade7816_gain_type gain)
+{
+	uint32_t reg_val;
+	int32_t offset;
+	uint16_t reg;
+	int ret;
+
+	switch (chan) {
+	case ADE7816_CHANNEL_A:
+		switch (gain) {
+		case ADE7816_ACTIVE_POWER_GAIN:
+			reg = ADE7816_AWATTOS_REG;
+			break;
+		case ADE7816_REACTIVE_POWER_GAIN:
+			reg = ADE7816_AVAROS_REG;
+			break;
+		default:
+			return -EINVAL;
+		}
+		break;
+	case ADE7816_CHANNEL_B:
+		switch (gain) {
+		case ADE7816_ACTIVE_POWER_GAIN:
+			reg = ADE7816_BWATTOS_REG;
+			break;
+		case ADE7816_REACTIVE_POWER_GAIN:
+			reg = ADE7816_BVAROS_REG;
+			break;
+		default:
+			return -EINVAL;
+		}
+		break;
+	case ADE7816_CHANNEL_C:
+		switch (gain) {
+		case ADE7816_ACTIVE_POWER_GAIN:
+			reg = ADE7816_CWATTOS_REG;
+			break;
+		case ADE7816_REACTIVE_POWER_GAIN:
+			reg = ADE7816_CVAROS_REG;
+			break;
+		default:
+			return -EINVAL;
+		}
+		break;
+	case ADE7816_CHANNEL_D:
+		switch (gain) {
+		case ADE7816_ACTIVE_POWER_GAIN:
+			reg = ADE7816_DWATTOS_REG;
+			break;
+		case ADE7816_REACTIVE_POWER_GAIN:
+			reg = ADE7816_DVAROS_REG;
+			break;
+		default:
+			return -EINVAL;
+		}
+		break;
+	case ADE7816_CHANNEL_E:
+		switch (gain) {
+		case ADE7816_ACTIVE_POWER_GAIN:
+			reg = ADE7816_EWATTOS_REG;
+			break;
+		case ADE7816_REACTIVE_POWER_GAIN:
+			reg = ADE7816_EVAROS_REG;
+			break;
+		default:
+			return -EINVAL;
+		}
+		break;
+	case ADE7816_CHANNEL_F:
+		switch (gain) {
+		case ADE7816_ACTIVE_POWER_GAIN:
+			reg = ADE7816_FWATTOS_REG;
+			break;
+		case ADE7816_REACTIVE_POWER_GAIN:
+			reg = ADE7816_FVAROS_REG;
+			break;
+		default:
+			return -EINVAL;
+		}
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	ret = ade7816_read_reg(desc, reg, &reg_val);
+	if (ret)
+		return ret;
+
+	offset = reg_val;
+
+	*scale = NO_OS_DIV_ROUND_CLOSEST_ULL(offset * 298, MILLI * 10);
+
+	return 0;
+}
+
+/**
+ * @brief ADE7816 set phase calibration coefficient function
+ * @param desc - ADE7816 device descriptor.
+ * @param chan - Channel number.
+ * @param pcf_coeff - Phase coefficient value.
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_set_phase(struct ade7816_desc *desc, enum ade7816_channel chan,
+		      enum ade7816_pcf_coeff pcf_coeff)
+{
+	switch (chan) {
+	case ADE7816_CHANNEL_A:
+		return ade7816_write_reg(desc, ADE7816_PCF_A_COEFF_REG, pcf_coeff);
+	case ADE7816_CHANNEL_B:
+		return ade7816_write_reg(desc, ADE7816_PCF_B_COEFF_REG, pcf_coeff);
+	case ADE7816_CHANNEL_C:
+		return ade7816_write_reg(desc, ADE7816_PCF_C_COEFF_REG, pcf_coeff);
+	case ADE7816_CHANNEL_D:
+		return ade7816_write_reg(desc, ADE7816_PCF_D_COEFF_REG, pcf_coeff);
+	case ADE7816_CHANNEL_E:
+		return ade7816_write_reg(desc, ADE7816_PCF_E_COEFF_REG, pcf_coeff);
+	case ADE7816_CHANNEL_F:
+		return ade7816_write_reg(desc, ADE7816_PCF_F_COEFF_REG, pcf_coeff);
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief ADE7816 root mean square measurement calibration function
+ * @param desc - ADE7816 device descriptor.
+ * @param chan - Channel number.
+ * @param rms - Expected root mean square measurement value.
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_calib_rms(struct ade7816_desc *desc, enum ade7816_channel chan,
+		      int32_t rms)
+{
+	uint32_t reg_val;
+	uint16_t reg;
+	int ret;
+
+	switch (chan) {
+	case ADE7816_CHANNEL_VOLTAGE:
+		reg = ADE7816_VRMSOS_REG;
+		break;
+	case ADE7816_CHANNEL_A:
+		reg = ADE7816_IARMSOS_REG;
+		break;
+	case ADE7816_CHANNEL_B:
+		reg = ADE7816_IBRMSOS_REG;
+		break;
+	case ADE7816_CHANNEL_C:
+		reg = ADE7816_ICRMSOS_REG;
+		break;
+	case ADE7816_CHANNEL_D:
+		reg = ADE7816_IDRMSOS_REG;
+		break;
+	case ADE7816_CHANNEL_E:
+		reg = ADE7816_IERMSOS_REG;
+		break;
+	case ADE7816_CHANNEL_F:
+		reg = ADE7816_IFRMSOS_REG;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	ret = ade7816_write_reg(desc, reg, 0);
+	if (ret)
+		return ret;
+
+	ret = ade7816_read_rms(desc, chan, &reg_val);
+	if (ret)
+		return ret;
+
+	return ade7816_write_reg(desc, reg,
+				 NO_OS_DIV_ROUND_CLOSEST_ULL(rms*rms - reg_val * reg_val, 128));
+}
+
+/**
+ * @brief ADE7816 group selection for channels function
+ * @param desc - ADE7816 device descriptor.
+ * @param chan - Channel number.
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_group_sel(struct ade7816_desc *desc, enum ade7816_channel chan)
+{
+	switch (chan) {
+	case ADE7816_CHANNEL_A:
+	case ADE7816_CHANNEL_B:
+	case ADE7816_CHANNEL_C:
+		return ade7816_reg_update(desc, ADE7816_COMPMODE_REG,
+					  ADE7816_CHANNEL_SEL_MASK,
+					  no_os_field_prep(ADE7816_CHANNEL_SEL_MASK, 0));
+	case ADE7816_CHANNEL_D:
+	case ADE7816_CHANNEL_E:
+	case ADE7816_CHANNEL_F:
+		return ade7816_reg_update(desc, ADE7816_COMPMODE_REG,
+					  ADE7816_CHANNEL_SEL_MASK,
+					  no_os_field_prep(ADE7816_CHANNEL_SEL_MASK, 1));
+	default:
+		return -EINVAL;
+	}
+
+	desc->chan = chan;
+}
+
+/**
+ * @brief ADE7816 zero-crossing detection for channel function
+ * @param desc - ADE7816 device descriptor.
+ * @param chan - Channel number.
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_zx_detect(struct ade7816_desc *desc, enum ade7816_channel chan)
+{
+	int ret;
+
+	ret = ade7816_group_sel(desc, chan);
+	if (ret)
+		return ret;
+
+	/* Delay required for settling after changing channel selection for zx
+	 * detection.
+	 */
+	no_os_mdelay(10);
+
+	return 0;
+}
+
+/**
+ * @brief ADE7816 zero-crossing detection timeout value function
+ * @param desc - ADE7816 device descriptor.
+ * @param timeout_us - Timeout value in microseconds.
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_zx_timeout(struct ade7816_desc *desc, uint32_t timeout_us)
+{
+	return ade7816_write_reg(desc, ADE7816_ZXTOUT_REG,
+				 NO_OS_DIV_ROUND_CLOSEST_ULL(timeout_us * 10, 625));
+}
+
+/**
+ * @brief ADE7816 set peak detection for channel function
+ * @param desc- ADE7816 device descriptor.
+ * @param chan - Channel number.
+ * @param mmode - Measurement mode selection value.
+ * @param no_of_cycles - Set the line cycles number over which peak measurements
+ * 			 are performed.
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_peak_detect(struct ade7816_desc *desc, enum ade7816_channel chan,
+			enum ade7816_mmode_sel mmode, uint8_t no_of_cycles)
+{
+	int ret;
+
+	ret = ade7816_group_sel(desc, chan);
+	if (ret)
+		return ret;
+
+	ret = ade7816_write_reg(desc, ADE7816_MMODE_REG,
+				no_os_field_prep(ADE7816_MMODE_MASK, mmode));
+	if (ret)
+		return ret;
+
+	return ade7816_write_reg(desc, ADE7816_PEAKCYC_REG, no_of_cycles);
+}
+
+/**
+ * @brief ADE7816 set power direction for channel function
+ * @param desc - ADE7816 device descriptor.
+ * @param chan - Channel number.
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_power_dir(struct ade7816_desc *desc, enum ade7816_channel chan)
+{
+	int ret;
+
+	ret = ade7816_group_sel(desc, chan);
+	if (ret)
+		return ret;
+
+	switch (chan) {
+	case ADE7816_CHANNEL_A:
+	case ADE7816_CHANNEL_B:
+	case ADE7816_CHANNEL_C:
+		return ade7816_reg_update(desc, ADE7816_ACCMODE_REG, ADE7816_REVSEL_MASK,
+					  no_os_field_prep(ADE7816_REVSEL_MASK, 0));
+	case ADE7816_CHANNEL_D:
+	case ADE7816_CHANNEL_E:
+	case ADE7816_CHANNEL_F:
+		return ade7816_reg_update(desc, ADE7816_ACCMODE_REG, ADE7816_REVSEL_MASK,
+					  no_os_field_prep(ADE7816_REVSEL_MASK, 0x11));
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief ADE7816 get power direction for channel function
+ * @param desc - ADE7816 device descriptor.
+ * @param chan - Channel number.
+ * @param sign - Power direction sign.
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_read_dir(struct ade7816_desc *desc, enum ade7816_channel chan,
+		     bool *sign)
+{
+	uint32_t reg_val;
+	int ret;
+
+	if (desc->chan != chan)
+		return -EINVAL;
+
+	ret = ade7816_read_reg(desc, ADE7816_CHSIGN_REG, &reg_val);
+	if (ret)
+		return ret;
+
+	*sign = no_os_field_get(ADE7816_SIGN_MASK(chan), reg_val);
+
+	return 0;
+}
+
+/**
+ * @brief ADE7816 angle measurement function
+ * @param desc - ADE7816 device descriptor.
+ * @param chan - Channel number.
+ * @param sel - Angle selection value.
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_angle_meas(struct ade7816_desc *desc, enum ade7816_channel chan,
+		       enum ade7816_angle_sel sel)
+{
+	int ret;
+
+	ret = ade7816_group_sel(desc, chan);
+	if (ret)
+		return ret;
+
+	return ade7816_reg_update(desc, ADE7816_COMPMODE_REG,
+				  ADE7816_ANGLESEL_MASK,
+				  no_os_field_prep(ADE7816_ANGLESEL_MASK, sel));
+}
+
+/**
+ * @brief ADE7816 read period value function
+ * @param desc - ADE7816 device descriptor.
+ * @param period_us - Period value in microseconds.
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_read_period(struct ade7816_desc *desc, uint32_t *period_us)
+{
+	uint32_t reg_val;
+	int ret;
+
+	/* Delay required for internal filtering. */
+	no_os_mdelay(40);
+
+	ret = ade7816_read_reg(desc, ADE7816_PERIOD_REG, &reg_val);
+	if (ret)
+		return ret;
+
+	*period_us = NO_OS_DIV_ROUND_CLOSEST(no_os_field_get(ADE7816_FIRST_BYTE_MASK |
+					     ADE7816_SECOND_BYTE_MASK, reg_val) + 1, 0x256E3);
+
+	return 0;
+}
+
+/**
+ * @brief ADE7816 set interrupts function
+ * @param desc- ADE7816 device descriptor.
+ * @param status_int - Interrupt selection value.
+ * @param enable - False = Disable
+ * 		   True = Enable
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_set_interrupt(struct ade7816_desc *desc,
+			  enum ade7816_status_int status_int, bool enable)
+{
+	uint16_t reg = ADE7816_MASK0_REG;
+
+	if (status_int > 31) {
+		status_int -= 32;
+		reg = ADE7816_MASK1_REG;
+	}
+
+	return ade7816_reg_update(desc, reg, ADE7816_INT_MASK(status_int),
+				  no_os_field_prep(ADE7816_INT_MASK(status_int), enable));
+}
+
+/**
+ * @brief ADE7816 get interrupts function
+ * @param desc- ADE7816 device descriptor.
+ * @param status_int - Interrupt selection value.
+ * @param enable - False = Disable
+ * 		   True = Enable
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_get_interrupt(struct ade7816_desc *desc,
+			  enum ade7816_status_int status_int, bool *enable)
+{
+	uint32_t reg_val;
+	int ret;
+
+	ret = ade7816_read_reg(desc,
+			       status_int > 31 ? ADE7816_MASK1_REG : ADE7816_MASK0_REG, &reg_val);
+	if (ret)
+		return ret;
+
+	if (status_int > 31)
+		status_int -= 32;
+
+	*enable = no_os_field_get(ADE7816_INT_MASK(status_int), reg_val);
+
+	return 0;
+}
+
+/**
+ * @brief ADE7816 root mean square measurement value conversion to microunits
+ * 	  function
+ * @param desc - ADE7816 device descriptor.
+ * @param chan - Channel number.
+ * @param rms - RMS value.
+ * @param micro - RMs value in microunits.
+ * @returns 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_rms_to_micro(struct ade7816_desc *desc, enum ade7816_channel chan,
+			 uint32_t rms, uint32_t *micro)
+{
+	uint32_t reg_val, reg;
+	int ret;
+
+	switch (chan) {
+	case ADE7816_CHANNEL_A:
+		reg = ADE7816_PCF_A_COEFF_REG;
+
+		break;
+	case ADE7816_CHANNEL_B:
+		reg = ADE7816_PCF_B_COEFF_REG;
+
+		break;
+	case ADE7816_CHANNEL_C:
+		reg = ADE7816_PCF_C_COEFF_REG;
+
+		break;
+	case ADE7816_CHANNEL_D:
+		reg = ADE7816_PCF_D_COEFF_REG;
+
+		break;
+	case ADE7816_CHANNEL_E:
+		reg = ADE7816_PCF_E_COEFF_REG;
+
+		break;
+	case ADE7816_CHANNEL_F:
+		reg = ADE7816_PCF_F_COEFF_REG;
+
+		break;
+	case ADE7816_CHANNEL_VOLTAGE:
+		reg_val = ADE7816_PCF_50HZ;
+
+		goto exit;
+	default:
+		return -EINVAL;
+	}
+
+	ret = ade7816_read_reg(desc, reg, &reg_val);
+	if (ret)
+		return ret;
+
+exit:
+	rms /= 1000;
+	rms *= 345;
+
+	switch (reg_val) {
+	case ADE7816_PCF_50HZ:
+		*micro = NO_OS_DIV_ROUND_CLOSEST(rms * MILLI, 4192);
+
+		return 0;
+	case ADE7816_PCF_60HZ:
+		*micro = NO_OS_DIV_ROUND_CLOSEST_ULL(rms * MILLI, 3493);
+
+		return 0;
+	default:
+		return -EINVAL;
+	}
+}
+
+static void ade7816_irq0_handler(void *dev)
+{
+	struct ade7816_desc *desc = dev;
+	uint32_t reg_val;
+	int ret;
+
+	ret = ade7816_read_reg(desc, ADE7816_STATUS0_REG, &reg_val);
+
+	desc->status0 = reg_val;
+
+	ret = ade7816_write_reg(desc, ADE7816_STATUS0_REG, 0);
+}
+
+static void ade7816_irq1_handler(void *dev)
+{
+	struct ade7816_desc *desc = dev;
+	uint32_t reg_val;
+	int ret;
+
+	ret = no_os_irq_disable(desc->irq_ctrl,
+				desc->gpio_irq1_desc->number);
+
+	ret = ade7816_read_reg(desc, ADE7816_STATUS1_REG, &reg_val);
+
+	desc->status1 = reg_val;
+
+	ret = ade7816_write_reg(desc, ADE7816_STATUS1_REG, 0);
+	ret = no_os_irq_enable(desc->irq_ctrl, desc->irq_ctrl->irq_ctrl_id);
+}
+
+static int ade7816_irq_config(struct no_os_gpio_desc *gpio_irq,
+			      struct ade7816_init_param *init_param,
+			      struct no_os_callback_desc *irq_cb)
+{
+	int ret;
+
+	ret = no_os_gpio_direction_input(gpio_irq);
+	if (ret)
+		return ret;
+
+	ret = no_os_irq_register_callback(init_param->irq_ctrl,
+					  gpio_irq->number, &irq_cb);
+	if (ret)
+		return ret;
+
+	ret = no_os_irq_trigger_level_set(init_param->irq_ctrl,
+					  gpio_irq->number,
+					  NO_OS_IRQ_EDGE_FALLING);
+	if (ret)
+		goto remove_irq_cb;
+
+	ret = no_os_irq_set_priority(init_param->irq_ctrl,
+				     gpio_irq->number,
+				     init_param->irq0_priority);
+	if (ret)
+		goto remove_irq_cb;
+
+	ret = no_os_irq_disable(init_param->irq_ctrl,
+				gpio_irq->number);
+	if (ret)
+		goto remove_irq_cb;
+
+	return 0;
+
+remove_irq_cb:
+	no_os_irq_unregister_callback(init_param->irq_ctrl,
+				      gpio_irq->number, irq_cb);
+
+	return ret;
+}
+
+/**
+ * @brief Initialize and configure the ADE7816 device
+ * @param desc - device descriptor for the ADE7816 that will be initialized.
+ * @param init_param - initialization parameter for the device.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7816_init(struct ade7816_desc **desc,
+		 struct ade7816_init_param *init_param)
+{
+	struct no_os_callback_desc irq0_cb;
+	struct no_os_callback_desc irq1_cb;
+	struct ade7816_desc *descriptor;
+	uint32_t reg_val;
+	int ret;
+
+	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	switch (init_param->active_irq) {
+	case ADE7816_IRQ0:
+		if (!init_param->irq_ctrl)
+			goto remove_ade7816;
+
+		irq0_cb.callback = &ade7816_irq0_handler;
+		irq0_cb.ctx = descriptor;
+		irq0_cb.event = NO_OS_EVT_GPIO;
+		irq0_cb.peripheral = NO_OS_GPIO_IRQ;
+		irq0_cb.handle = init_param->handle_irq0;
+
+		if (init_param->irq0_callback)
+			irq0_cb.callback = init_param->irq0_callback;
+
+		ret = no_os_gpio_get(&descriptor->gpio_irq0_desc,
+				     init_param->gpio_irq0_param);
+		if (ret)
+			goto remove_ade7816;
+
+		ret = no_os_gpio_get_optional(&descriptor->gpio_irq1_desc,
+					      init_param->gpio_irq1_param);
+		if (ret)
+			goto remove_irq0;
+
+		break;
+	case ADE7816_IRQ1:
+		if (!init_param->irq_ctrl)
+			goto remove_ade7816;
+
+		irq1_cb.callback = &ade7816_irq1_handler;
+		irq1_cb.ctx = descriptor;
+		irq1_cb.event = NO_OS_EVT_GPIO;
+		irq1_cb.peripheral = NO_OS_GPIO_IRQ;
+		irq1_cb.handle = init_param->handle_irq1;
+
+		if (init_param->irq1_callback)
+			irq1_cb.callback = init_param->irq1_callback;
+
+		ret = no_os_gpio_get_optional(&descriptor->gpio_irq0_desc,
+					      init_param->gpio_irq0_param);
+		if (ret)
+			goto remove_ade7816;
+
+		ret = no_os_gpio_get(&descriptor->gpio_irq1_desc,
+				     init_param->gpio_irq1_param);
+		if (ret)
+			goto remove_irq0;
+
+		break;
+	case ADE7816_IRQ0_IRQ1:
+		if (!init_param->irq_ctrl)
+			goto remove_ade7816;
+
+		irq0_cb.callback = ade7816_irq0_handler;
+		irq0_cb.ctx = descriptor;
+		irq0_cb.event = NO_OS_EVT_GPIO;
+		irq0_cb.peripheral = NO_OS_GPIO_IRQ;
+		irq0_cb.handle = init_param->handle_irq0;
+
+		if (init_param->irq0_callback)
+			irq0_cb.callback = init_param->irq0_callback;
+
+		irq1_cb.callback = ade7816_irq1_handler;
+		irq1_cb.ctx = descriptor;
+		irq1_cb.event = NO_OS_EVT_GPIO;
+		irq1_cb.peripheral = NO_OS_GPIO_IRQ;
+		irq1_cb.handle = init_param->handle_irq1;
+
+		if (init_param->irq1_callback)
+			irq1_cb.callback = init_param->irq1_callback;
+
+		ret = no_os_gpio_get(&descriptor->gpio_irq0_desc,
+				     init_param->gpio_irq0_param);
+		if (ret)
+			goto remove_ade7816;
+
+		ret = no_os_gpio_get(&descriptor->gpio_irq1_desc,
+				     init_param->gpio_irq1_param);
+		if (ret)
+			goto remove_irq0;
+
+		break;
+	case ADE7816_NO_IRQ:
+		ret = no_os_gpio_get_optional(&descriptor->gpio_irq0_desc,
+					      init_param->gpio_irq0_param);
+		if (ret)
+			goto remove_ade7816;
+
+		ret = no_os_gpio_get_optional(&descriptor->gpio_irq1_desc,
+					      init_param->gpio_irq1_param);
+		if (ret)
+			goto remove_irq0;
+
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	if (descriptor->gpio_irq0_desc) {
+		ret = ade7816_irq_config(descriptor->gpio_irq0_desc,
+					 init_param, &irq0_cb);
+		if (ret)
+			goto remove_irq;
+
+		descriptor->irq0_cb = irq0_cb;
+	}
+
+	if (descriptor->gpio_irq1_desc) {
+		ret = ade7816_irq_config(descriptor->gpio_irq1_desc,
+					 init_param, &irq1_cb);
+		if (ret)
+			goto remove_irq;
+
+		descriptor->irq1_cb = irq1_cb;
+	}
+
+	descriptor->irq_ctrl = init_param->irq_ctrl;
+	descriptor->active_irq = init_param->active_irq;
+
+	ret = no_os_gpio_get_optional(&descriptor->reset_desc,
+				      init_param->reset_param);
+	if (ret)
+		goto remove_irq_cb;
+
+	if (descriptor->reset_desc) {
+		ret = no_os_gpio_direction_output(descriptor->reset_desc,
+						  NO_OS_GPIO_HIGH);
+		if (ret)
+			goto remove_reset;
+	}
+
+	ret = no_os_gpio_get_optional(&descriptor->ss_desc,
+				      init_param->ss_param);
+	if (ret)
+		goto remove_reset;
+
+	if (descriptor->ss_desc) {
+		ret = no_os_gpio_direction_output(descriptor->ss_desc,
+						  NO_OS_GPIO_LOW);
+		if (ret)
+			goto remove_ss;
+	}
+
+	switch (init_param->comm_type) {
+	case ADE7816_SPI:
+		descriptor->i2c_desc = NULL;
+
+		ret = no_os_spi_init(&descriptor->spi_desc,
+				     init_param->spi_param);
+		if (ret)
+			goto remove_ss;
+
+		ret = ade7816_set_comm(descriptor, ADE7816_SPI);
+		if (ret)
+			goto remove_spi;
+
+		break;
+	case ADE7816_I2C:
+		descriptor->spi_desc = NULL;
+
+		ret = no_os_i2c_init(&descriptor->i2c_desc,
+				     init_param->i2c_param);
+		if (ret)
+			goto remove_ss;
+
+		ret = ade7816_set_comm(descriptor, ADE7816_I2C);
+		if (ret)
+			goto remove_i2c;
+
+		break;
+	default:
+		ret = -EINVAL;
+		goto remove_reset;
+	}
+
+	no_os_mdelay(ADE7816_INIT_DELAY);
+
+	ret = ade7816_write_reg(descriptor, ADE7816_RUN_REG, 0x01);
+	if (ret)
+		goto remove_comm;
+
+	*desc = descriptor;
+
+	return 0;
+
+remove_comm:
+	no_os_spi_remove(descriptor->spi_desc);
+	no_os_i2c_remove(descriptor->i2c_desc);
+
+	goto remove_ss;
+remove_i2c:
+	no_os_i2c_remove(descriptor->i2c_desc);
+
+	goto remove_ss;
+remove_spi:
+	no_os_spi_remove(descriptor->spi_desc);
+remove_ss:
+	no_os_gpio_remove(descriptor->ss_desc);
+remove_reset:
+	no_os_gpio_remove(descriptor->reset_desc);
+remove_irq_cb:
+	if (descriptor->irq1_cb.callback)
+		no_os_irq_unregister_callback(init_param->irq_ctrl,
+					      descriptor->gpio_irq1_desc->number, &descriptor->irq1_cb);
+
+	if (descriptor->irq0_cb.callback)
+		no_os_irq_unregister_callback(init_param->irq_ctrl,
+					      descriptor->gpio_irq0_desc->number, &descriptor->irq0_cb);
+remove_irq:
+	if (init_param->active_irq == ADE7816_IRQ0_IRQ1 && descriptor->irq0_cb.callback)
+		no_os_irq_unregister_callback(init_param->irq_ctrl,
+					      descriptor->gpio_irq0_desc->number, &descriptor->irq0_cb);
+
+	no_os_gpio_remove(descriptor->gpio_irq1_desc);
+remove_irq0:
+	no_os_gpio_remove(descriptor->gpio_irq0_desc);
+remove_ade7816:
+	no_os_free(descriptor);
+
+	return ret;
+}
+
+/**
+ * @brief Free the resources allocated during init
+ * @param desc - device descriptor for the ADE7816 that will be initialized.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7816_remove(struct ade7816_desc *desc)
+{
+	if (!desc)
+		return -ENODEV;
+
+	no_os_spi_remove(desc->spi_desc);
+	no_os_i2c_remove(desc->i2c_desc);
+	no_os_gpio_remove(desc->ss_desc);
+	no_os_gpio_remove(desc->reset_desc);
+	switch (desc->active_irq) {
+	case ADE7816_NO_IRQ:
+		break;
+	case ADE7816_IRQ0:
+		no_os_irq_unregister_callback(desc->irq_ctrl, desc->gpio_irq0_desc->number,
+					      &desc->irq1_cb);
+
+		break;
+	case ADE7816_IRQ1:
+		no_os_irq_unregister_callback(desc->irq_ctrl, desc->gpio_irq1_desc->number,
+					      &desc->irq1_cb);
+
+		break;
+	case ADE7816_IRQ0_IRQ1:
+		no_os_irq_unregister_callback(desc->irq_ctrl, desc->gpio_irq0_desc->number,
+					      &desc->irq1_cb);
+		no_os_irq_unregister_callback(desc->irq_ctrl, desc->gpio_irq1_desc->number,
+					      &desc->irq1_cb);
+
+		break;
+	default:
+		break;
+	}
+	no_os_gpio_remove(desc->gpio_irq1_desc);
+	no_os_gpio_remove(desc->gpio_irq0_desc);
+	no_os_free(desc);
+
+	return 0;
+}

--- a/drivers/meter/ade7816/ade7816.h
+++ b/drivers/meter/ade7816/ade7816.h
@@ -1,0 +1,491 @@
+/***************************************************************************//**
+ *   @file   ade7816.h
+ *   @brief  Header file of ADE7816 Driver.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+#ifndef __ADE7816_H__
+#define __ADE7816_H__
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+#include "no_os_util.h"
+#include "no_os_spi.h"
+#include "no_os_gpio.h"
+#include "no_os_irq.h"
+#include "no_os_error.h"
+#include "no_os_i2c.h"
+
+#define ADE7816_VGAIN_REG			0x4380
+#define ADE7816_IAGAIN_REG			0x4381
+#define ADE7816_IBGAIN_REG			0x4382
+#define ADE7816_ICGAIN_REG			0x4383
+#define ADE7816_IDGAIN_REG			0x4384
+#define ADE7816_IEGAIN_REG			0x4385
+#define ADE7816_IFGAIN_REG			0x4386
+
+#define ADE7816_DICOEFF_REG			0x4388
+#define ADE7816_HPFDIS_REG			0x4389
+#define ADE7816_VRMSOS_REG			0x438A
+#define ADE7816_IARMSOS_REG			0x438B
+#define ADE7816_IBRMSOS_REG			0x438C
+#define ADE7816_ICRMSOS_REG			0x438D
+#define ADE7816_IDRMSOS_REG			0x438E
+#define ADE7816_IERMSOS_REG			0x438F
+#define ADE7816_IFRMSOS_REG			0x4390
+#define ADE7816_AWGAIN_REG			0x4391
+#define ADE7816_AWATTOS_REG			0x4392
+#define ADE7816_BWGAIN_REG			0x4393
+#define ADE7816_BWATTOS_REG			0x4394
+#define ADE7816_CWGAIN_REG			0x4395
+#define ADE7816_CWATTOS_REG			0x4396
+#define ADE7816_DWGAIN_REG			0x4397
+#define ADE7816_DWATTOS_REG			0x4398
+#define ADE7816_EWGAIN_REG			0x4399
+#define ADE7816_EWATTOS_REG			0x439A
+#define ADE7816_FWGAIN_REG			0x439B
+#define ADE7816_FWATTOS_REG			0x439C
+#define ADE7816_AVARGAIN_REG			0x439D
+#define ADE7816_AVAROS_REG			0x439E
+#define ADE7816_BVARGAIN_REG			0x439F
+#define ADE7816_BVAROS_REG			0x43A0
+#define ADE7816_CVARGAIN_REG			0x43A1
+#define ADE7816_CVAROS_REG			0x43A2
+#define ADE7816_DVARGAIN_REG			0x43A3
+#define ADE7816_DVAROS_REG			0x43A4
+#define ADE7816_EVARGAIN_REG			0x43A5
+#define ADE7816_EVAROS_REG			0x43A6
+#define ADE7816_FVARGAIN_REG			0x43A7
+#define ADE7816_FVAROS_REG			0x43A8
+
+#define ADE7816_WTHR1_REG			0x43AB
+#define ADE7816_WTHR0_REG			0x43AC
+#define ADE7816_VARTHR1_REG			0x43AD
+#define ADE7816_VARTHR0_REG			0x43AE
+#define ADE7816_APNOLOAD_REG			0x43AF
+#define ADE7816_VARNOLOAD_REG			0x43B0
+#define ADE7816_PCF_A_COEFF_REG			0x43B1
+#define ADE7816_PCF_B_COEFF_REG			0x43B3
+#define ADE7816_PCF_C_COEFF_REG			0x43B4
+#define ADE7816_PCF_D_COEFF_REG			0x43B5
+#define ADE7816_PCF_E_COEFF_REG			0x43B6
+#define ADE7816_PCF_F_COEFF_REG			0x43B7
+
+#define ADE7816_VRMS_REG			0x43C0
+#define ADE7816_IARMS_REG			0x43C1
+#define ADE7816_IBRMS_REG			0x43C2
+#define ADE7816_ICRMS_REG			0x43C3
+#define ADE7816_IDRMS_REG			0x43C4
+#define ADE7816_IERMS_REG			0x43C5
+#define ADE7816_IFRMS_REG			0x43C6
+
+#define ADE7816_RUN_REG				0xE228
+
+#define ADE7816_AWATTHR_REG			0xE400
+#define ADE7816_BWATTHR_REG			0xE401
+#define ADE7816_CWATTHR_REG			0xE402
+#define ADE7816_DWATTHR_REG			0xE403
+#define ADE7816_EWATTHR_REG			0xE404
+#define ADE7816_FWATTHR_REG			0xE405
+#define ADE7816_AVARHR_REG			0xE406
+#define ADE7816_BVARHR_REG			0xE407
+#define ADE7816_CVARHR_REG			0xE408
+#define ADE7816_DVARHR_REG			0xE409
+#define ADE7816_EVARHR_REG			0xE40A
+#define ADE7816_FVARHR_REG			0xE40B
+
+#define ADE7816_IPEAK_REG			0xE500
+#define ADE7816_VPEAK_REG			0xE501
+#define ADE7816_STATUS0_REG			0xE502
+#define ADE7816_STATUS1_REG			0xE503
+
+#define ADE7816_OIVL_REG			0xE507
+#define ADE7816_OVLVL_REG			0xE508
+#define ADE7816_SAGLVL_REG			0xE509
+#define ADE7816_MASK0_REG			0xE50A
+#define ADE7816_MASK1_REG			0xE50B
+#define ADE7816_IAVW_IDVW_REG			0xE50C
+#define ADE7816_IBVW_IEVW_REG			0xE50D
+#define ADE7816_ICVW_IFVW_REG			0xE50E
+
+#define ADE7816_VWV_REG				0xE510
+
+#define ADE7816_CHECKSUM_REG			0xE51F
+
+#define ADE7816_CHSTATUS_REG			0xE600
+#define ADE7816_ANGLE0_REG			0xE601
+#define ADE7816_ANGLE1_REG			0xE602
+#define ADE7816_ANGLE2_REG			0xE603
+
+#define ADE7816_PERIOD_REG			0xE607
+#define ADE7816_CHNOLOAD_REG			0xE608
+
+#define ADE7816_LINECYC_REG			0xE60C
+#define ADE7816_ZXTOUT_REG			0xE60D
+#define ADE7816_COMPMODE_REG			0xE60E
+#define ADE7816_GAIN_REG			0xE60F
+
+#define ADE7816_CHSIGN_REG			0xE617
+#define ADE7816_CONFIG_REG			0xE618
+
+#define ADE7816_MMODE_REG			0xE700
+#define ADE7816_ACCMODE_REG			0xE701
+#define ADE7816_LCYCMODE_REG			0xE702
+#define ADE7816_PEAKCYC_REG			0xE703
+#define ADE7816_SAGCYC_REG			0xE704
+
+#define ADE7816_HSDC_CFG_REG			0xE706
+#define ADE7816_VERSION_REG			0xE707
+
+#define ADE7816_CONFIG2_REG			0xEC01
+
+//MASK MACROS
+#define ADE7816_LSB_REG_MASK			NO_OS_GENMASK(7, 0)
+#define ADE7816_MSB_REG_MASK			NO_OS_GENMASK(15, 8)
+
+#define ADE7816_FOURTH_BYTE_MASK		NO_OS_GENMASK(31, 24)
+#define ADE7816_THIRD_BYTE_MASK			NO_OS_GENMASK(23, 16)
+#define ADE7816_SECOND_BYTE_MASK		NO_OS_GENMASK(15, 8)
+#define ADE7816_FIRST_BYTE_MASK			NO_OS_GENMASK(7, 0)
+
+#define ADE7816_SWRST_MASK			NO_OS_BIT(7)
+
+#define ADE7816_I2C_LOCK_MASK			NO_OS_BIT(1)
+
+#define ADE7816_ZSPE_MASK			NO_OS_GENMASK(27, 0)
+
+#define ADE7816_THR_MSB_MASK			NO_OS_GENMASK(31, 24)
+#define ADE7816_THR_LSB_MASK			NO_OS_GENMASK(23, 0)
+
+#define ADE7816_RSTREAD_MASK			NO_OS_BIT(6)
+
+#define ADE7816_LMASK				NO_OS_GENMASK(1, 0)
+#define ADE7816_ZX_SEL_MASK			NO_OS_BIT(3)
+
+#define ADE7816_LENERGY_MASK			NO_OS_BIT(5)
+
+#define ADE7816_CHANNEL_SEL_MASK		NO_OS_BIT(14)
+
+#define ADE7816_DREADY_MASK			NO_OS_BIT(17)
+
+#define ADE7816_MMODE_MASK			NO_OS_GENMASK(4, 2)
+
+#define ADE7816_REVSEL_MASK			NO_OS_GENMASK(7, 6)
+
+#define ADE7816_ANGLESEL_MASK			NO_OS_GENMASK(10, 9)
+
+#define ADE7816_SIGN_MASK(x)			(((x) > 3) ? ((x) - 4) : (x))
+
+#define ADE7816_INT_MASK(x)			NO_OS_BIT(x)
+
+#define ADE7816_INIT_DELAY			40
+#define ADE7816_HWRST_DELAY			10
+
+#define ADE7816_LINECYC_VAL(enable)		((enable) ? 0x11 : 0x00)
+
+#define ADE7816_CHECKSUM_VAL			0x33666787
+
+enum ade7816_comm_type {
+	ADE7816_I2C,
+	ADE7816_SPI
+};
+
+enum ade7816_channel {
+	ADE7816_CHANNEL_VOLTAGE,
+	ADE7816_CHANNEL_A,
+	ADE7816_CHANNEL_B,
+	ADE7816_CHANNEL_C,
+	ADE7816_CHANNEL_D,
+	ADE7816_CHANNEL_E,
+	ADE7816_CHANNEL_F,
+};
+
+enum ade7816_gain_type {
+	ADE7816_CURRENT_GAIN,
+	ADE7816_ACTIVE_POWER_GAIN,
+	ADE7816_REACTIVE_POWER_GAIN,
+};
+
+enum ade7816_mmode_sel {
+	ADE7816_PEAKSEL_0_AD,
+	ADE7816_PEAKSEL_1_BE,
+	ADE7816_PEAKSEL_2_CF,
+};
+
+enum ade7816_angle_sel {
+	ADE7816_VOLTAGE_CURRENT,
+	ADE7816_CURRENT_CURRENT = 2,
+};
+
+enum ade7816_status_int {
+	ADE7816_AEHF1_INT,
+	ADE7816_AEHF2_INT,
+	ADE7816_REHF1_INT,
+	ADE7816_REHF2_INT,
+	ADE7816_LENERGY_INT = 5,
+	ADE7816_REVAP1_INT,
+	ADE7816_REVAP2_INT,
+	ADE7816_REVAP3_INT,
+	ADE7816_REVRP1_INT = 10,
+	ADE7816_REVRP2_INT,
+	ADE7816_REVRP3_INT,
+	ADE7816_DREADY_INT = 17,
+	ADE7816_NLOAD1_INT = 32,
+	ADE7816_NLOAD2_INT,
+	ADE7816_ZXTOV_INT = 35,
+	ADE7816_ZXTOI1_INT = 38,
+	ADE7816_ZXTOI2_INT,
+	ADE7816_ZXTOI3_INT,
+	ADE7816_ZXV_INT,
+	ADE7816_ZXI1_INT = 44,
+	ADE7816_ZXI2_INT,
+	ADE7816_ZXI3_INT,
+	ADE7816_RSTDONE_INT,
+	ADE7816_SAG_INT,
+	ADE7816_OI_INT,
+	ADE7816_OV_INT,
+	ADE7816_PKI_INT = 55,
+	ADE7816_PKV_INT,
+};
+
+enum ade7816_active_irq {
+	ADE7816_NO_IRQ,
+	ADE7816_IRQ0,
+	ADE7816_IRQ1,
+	ADE7816_IRQ0_IRQ1,
+};
+
+enum ade7816_pcf_coeff {
+	ADE7816_PCF_50HZ = 0x400CA4,
+	ADE7816_PCF_60HZ = 0x401235,
+};
+
+struct ade7816_desc;
+
+typedef int (*ade7816_reg_read)(struct ade7816_desc *desc, uint16_t reg,
+				uint32_t *val);
+typedef int (*ade7816_reg_write)(struct ade7816_desc *desc, uint16_t reg,
+				 uint32_t val);
+
+struct ade7816_init_param {
+	struct no_os_spi_init_param *spi_param;
+	struct no_os_i2c_init_param *i2c_param;
+	struct no_os_gpio_init_param *reset_param;
+	struct no_os_gpio_init_param *ss_param;
+	struct no_os_gpio_init_param *gpio_irq0_param;
+	struct no_os_gpio_init_param *gpio_irq1_param;
+
+	struct no_os_irq_ctrl_desc *irq_ctrl;
+
+	enum ade7816_active_irq active_irq;
+	enum ade7816_comm_type comm_type;
+
+	uint32_t irq0_priority;
+	uint32_t irq1_priority;
+
+	void *handle_irq0;
+	void *handle_irq1;
+
+	/* External callback used to handle interrupt routine for GPIO
+	 * IRQ0/IRQ1.
+	 *
+	 * Setting one of it to NULL means driver defined callback is used for
+	 * it.
+	 */
+	void (*irq0_callback)(void *context);
+	void (*irq1_callback)(void *context);
+};
+
+struct ade7816_desc {
+	struct no_os_spi_desc *spi_desc;
+	struct no_os_i2c_desc *i2c_desc;
+
+	struct no_os_gpio_desc *reset_desc;
+	struct no_os_gpio_desc *ss_desc;
+	struct no_os_gpio_desc *gpio_irq0_desc;
+	struct no_os_gpio_desc *gpio_irq1_desc;
+	struct no_os_irq_ctrl_desc *irq_ctrl;
+	struct no_os_callback_desc irq0_cb;
+	struct no_os_callback_desc irq1_cb;
+
+	ade7816_reg_read reg_read;
+	ade7816_reg_write reg_write;
+
+	enum ade7816_active_irq active_irq;
+	enum ade7816_comm_type comm_type;
+	enum ade7816_channel chan;
+
+	uint32_t status0;
+	uint32_t status1;
+
+	bool lcycle_mode;
+};
+
+/** ADE7816 SPI Read Register function. */
+int ade7816_spi_reg_read(struct ade7816_desc *desc, uint16_t reg,
+			 uint32_t *val);
+
+/** ADE7816 SPI Write Register function. */
+int ade7816_spi_reg_write(struct ade7816_desc *desc, uint16_t reg,
+			  uint32_t val);
+
+/** ADE7816 I2C Read Register function. */
+int ade7816_i2c_reg_read(struct ade7816_desc *desc, uint16_t reg,
+			 uint32_t *val);
+
+/** ADE7816 I2C Write Register function. */
+int ade7816_i2c_reg_write(struct ade7816_desc *desc, uint16_t reg,
+			  uint32_t val);
+
+/** Register read wrapper function. */
+int ade7816_read_reg(struct ade7816_desc *desc, uint16_t reg, uint32_t *val);
+
+/** Register write wrapper function. */
+int ade7816_write_reg(struct ade7816_desc *desc, uint16_t reg, uint32_t val);
+
+/** Register update function. */
+int ade7816_reg_update(struct ade7816_desc *desc, uint16_t reg, uint32_t mask,
+		       uint32_t val);
+
+/** ADE7816 software reset function. */
+int ade7816_sw_reset(struct ade7816_desc *desc);
+
+/** ADE7816 hardware reset function. */
+int ade7816_hw_reset(struct ade7816_desc *desc);
+
+/** ADE7816 set communication function. */
+int ade7816_set_comm(struct ade7816_desc *desc, enum ade7816_comm_type type);
+
+/** ADE7816 read active energy function. */
+int ade7816_read_active_energy(struct ade7816_desc *desc,
+			       enum ade7816_channel chan, int32_t *val);
+
+/** ADE7816 set active energy threshold value function. */
+int ade7816_set_active_thr(struct ade7816_desc *desc, uint16_t freq);
+
+/** ADE7816 get active energy threshold value function. */
+int ade7816_get_active_thr(struct ade7816_desc *desc, uint16_t *freq);
+
+/** ADE7816 read reactive energy value function. */
+int ade7816_read_reactive_energy(struct ade7816_desc *desc,
+				 enum ade7816_channel chan, int32_t *val);
+
+/** ADE7816 set reactive energy threshold value function. */
+int ade7816_set_reactive_thr(struct ade7816_desc *desc, uint16_t freq);
+
+/** ADE7816 get reactive energy threshold value function. */
+int ade7816_get_reactive_thr(struct ade7816_desc *desc, uint16_t *freq);
+
+/** ADE7816 set line cycle mode function. */
+int ade7816_set_lcycle_mode(struct ade7816_desc *desc, bool enable,
+			    uint16_t cycles, bool lenergy);
+
+/** ADE7816 read root mean square measurement value function. */
+int ade7816_read_rms(struct ade7816_desc *desc, enum ade7816_channel chan,
+		     uint32_t *rms);
+
+/** ADE7816 set no load condition function. */
+int ade7816_set_no_load(struct ade7816_desc *desc, uint16_t voltage,
+			uint16_t current, bool enable);
+
+/** ADE7816 set gain value for channel function. */
+int ade7816_set_gain(struct ade7816_desc *desc, enum ade7816_channel chan,
+		     int16_t scale, enum ade7816_gain_type gain);
+
+/** ADE7816 get gain value for channel function. */
+int ade7816_get_gain(struct ade7816_desc *desc, enum ade7816_channel chan,
+		     int16_t *scale, enum ade7816_gain_type gain);
+
+/** ADE7816 set offset value for channel function. */
+int ade7816_set_offset(struct ade7816_desc *desc, enum ade7816_channel chan,
+		       int16_t scale, enum ade7816_gain_type gain);
+
+/** ADE7816 get offset value for channel function. */
+int ade7816_get_offset(struct ade7816_desc *desc, enum ade7816_channel chan,
+		       int16_t *scale, enum ade7816_gain_type gain);
+
+/** ADE7816 set phase calibration coefficient function. */
+int ade7816_set_phase(struct ade7816_desc *desc, enum ade7816_channel chan,
+		      enum ade7816_pcf_coeff pcf_coeff);
+
+/** ADE7816 root mean square measurement calibration function. */
+int ade7816_calib_rms(struct ade7816_desc *desc, enum ade7816_channel chan,
+		      int32_t rms);
+
+/** ADE7816 group selection for channels function. */
+int ade7816_group_sel(struct ade7816_desc *desc, enum ade7816_channel chan);
+
+/** ADE7816 zero-crossing detection for channel function. */
+int ade7816_zx_detect(struct ade7816_desc *desc, enum ade7816_channel chan);
+
+/** ADE7816 zero-crossing detection timeout value function. */
+int ade7816_zx_timeout(struct ade7816_desc *desc, uint32_t timeout_us);
+
+/** ADE7816 set peak detection for channel function. */
+int ade7816_peak_detect(struct ade7816_desc *desc, enum ade7816_channel chan,
+			enum ade7816_mmode_sel mmode, uint8_t no_of_cycles);
+
+/** ADE7816 set power direction for channel function. */
+int ade7816_power_dir(struct ade7816_desc *desc, enum ade7816_channel chan);
+
+/** ADE7816 get power direction for channel function. */
+int ade7816_read_dir(struct ade7816_desc *desc, enum ade7816_channel chan,
+		     bool *sign);
+
+/** ADE7816 angle measurement function. */
+int ade7816_angle_meas(struct ade7816_desc *desc, enum ade7816_channel chan,
+		       enum ade7816_angle_sel sel);
+
+/** ADE7816 read period value function. */
+int ade7816_read_period(struct ade7816_desc *desc, uint32_t *period_us);
+
+/** ADE7816 set interrupts function. */
+int ade7816_set_interrupt(struct ade7816_desc *desc,
+			  enum ade7816_status_int status_int, bool enable);
+
+/** ADE7816 get interrupts function. */
+int ade7816_get_interrupt(struct ade7816_desc *desc,
+			  enum ade7816_status_int status_int, bool *enable);
+
+/** ADE7816 root mean square measurement value conversion to microunits
+ *  function.
+ */
+int ade7816_rms_to_micro(struct ade7816_desc *desc, enum ade7816_channel chan,
+			 uint32_t rms, uint32_t *micro);
+
+/** Initialize and configure the ADE7816 device. */
+int ade7816_init(struct ade7816_desc **desc,
+		 struct ade7816_init_param *init_param);
+
+/** Free the resources allocated during init. */
+int ade7816_remove(struct ade7816_desc *desc);
+
+#endif /* __ADE7816_H__ */

--- a/drivers/meter/ade7816/ade7816_i2c.c
+++ b/drivers/meter/ade7816/ade7816_i2c.c
@@ -1,0 +1,135 @@
+/***************************************************************************//**
+ *   @file   ade7816_i2c.c
+ *   @brief  Source file of ADE7816 I2C Driver.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include "no_os_error.h"
+#include "no_os_i2c.h"
+#include "ade7816.h"
+
+/**
+ * @brief ADE7816 I2C Read Register function
+ * @param desc - ADE7816 device descriptor.
+ * @param reg - Register Address value.
+ * @param val - Register Value to be read.
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_i2c_reg_read(struct ade7816_desc *desc, uint16_t reg, uint32_t *val)
+{
+	uint8_t bytes_number;
+	uint32_t mask = 0;
+	uint8_t data[4];
+	int ret;
+
+	data[0] = no_os_field_get(ADE7816_MSB_REG_MASK, reg);
+	data[1] = no_os_field_get(ADE7816_LSB_REG_MASK, reg);
+
+	switch (reg) {
+	case ADE7816_VGAIN_REG ... ADE7816_FVAROS_REG:
+	case ADE7816_VARNOLOAD_REG:
+		bytes_number = 4;
+		mask = NO_OS_GENMASK(23, 0);
+		break;
+	case ADE7816_CHSTATUS_REG ... ADE7816_CONFIG_REG:
+		bytes_number = 2;
+		break;
+	case ADE7816_MMODE_REG ... ADE7816_CONFIG2_REG:
+		bytes_number = 1;
+		break;
+	default:
+		bytes_number = 4;
+		break;
+	}
+
+	ret = no_os_i2c_write(desc->i2c_desc, data, 2, 0);
+	if (ret)
+		return ret;
+
+	ret = no_os_i2c_read(desc->i2c_desc, data, bytes_number, 1);
+	if (ret)
+		return ret;
+
+	*val = no_os_get_unaligned_be32(data);
+
+	if (mask)
+		*val = no_os_field_get(*val, mask);
+
+	return 0;
+}
+
+/**
+ * @brief ADE7816 I2C Write Register function
+ * @param desc - ADE7816 device descriptor
+ * @param reg - Register Address value.
+ * @param val - Register Value to be written.
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_i2c_reg_write(struct ade7816_desc *desc, uint16_t reg, uint32_t val)
+{
+	uint8_t bytes_number;
+	uint32_t mask = 0;
+	uint8_t data[6];
+
+	data[0] = no_os_field_get(ADE7816_MSB_REG_MASK, reg);
+	data[1] = no_os_field_get(ADE7816_LSB_REG_MASK, reg);
+
+	switch (reg) {
+	case ADE7816_VGAIN_REG ... ADE7816_FVAROS_REG:
+	case ADE7816_VARNOLOAD_REG:
+		bytes_number = 4;
+		mask = NO_OS_GENMASK(23, 0);
+		break;
+	case ADE7816_CHSTATUS_REG ... ADE7816_CONFIG_REG:
+		bytes_number = 2;
+		break;
+	case ADE7816_MMODE_REG ... ADE7816_CONFIG2_REG:
+		bytes_number = 1;
+		break;
+	default:
+		bytes_number = 4;
+		break;
+	}
+
+	if (mask) {
+		val = no_os_sign_extend32(val, 23);
+		val = no_os_field_get(ADE7816_ZSPE_MASK, val);
+	}
+
+	data[2] = no_os_field_get(ADE7816_FOURTH_BYTE_MASK, val);
+	data[3] = no_os_field_get(ADE7816_THIRD_BYTE_MASK, val);
+	data[4] = no_os_field_get(ADE7816_SECOND_BYTE_MASK, val);
+	data[5] = no_os_field_get(ADE7816_FIRST_BYTE_MASK, val);
+
+	return no_os_i2c_write(desc->i2c_desc, data, 2 + bytes_number, 1);
+}

--- a/drivers/meter/ade7816/ade7816_spi.c
+++ b/drivers/meter/ade7816/ade7816_spi.c
@@ -1,0 +1,147 @@
+/***************************************************************************//**
+ *   @file   ade7816_spi.c
+ *   @brief  Source file of ADE7816 SPI Driver.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include "no_os_error.h"
+#include "no_os_spi.h"
+#include "ade7816.h"
+
+/**
+ * @brief ADE7816 SPI Read Register function
+ * @param desc - ADE7816 device descriptor.
+ * @param reg - Register Address value.
+ * @param val - Register Value to be read.
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_spi_reg_read(struct ade7816_desc *desc, uint16_t reg, uint32_t *val)
+{
+	uint8_t bytes_number;
+	uint32_t mask = 0;
+	uint8_t buff[7];
+	int ret;
+
+	buff[0] = 0x01;
+	buff[1] = no_os_field_get(ADE7816_MSB_REG_MASK, reg);
+	buff[2] = no_os_field_get(ADE7816_LSB_REG_MASK, reg);
+	buff[3] = buff[4] = buff[5] = buff[6] = 0x00;
+
+	switch (reg) {
+	case ADE7816_VGAIN_REG ... ADE7816_FVAROS_REG:
+	case ADE7816_VARNOLOAD_REG:
+		bytes_number = 4;
+		mask = NO_OS_GENMASK(23, 0);
+		break;
+	case ADE7816_CHSTATUS_REG ... ADE7816_CONFIG_REG:
+		bytes_number = 2;
+		break;
+	case ADE7816_MMODE_REG ... ADE7816_CONFIG2_REG:
+		bytes_number = 1;
+		break;
+	default:
+		bytes_number = 4;
+		break;
+	}
+
+	ret = no_os_spi_write_and_read(desc->spi_desc, buff, 3 + bytes_number);
+	if (ret)
+		return ret;
+
+	switch (bytes_number) {
+	case 1:
+		*val = buff[3];
+		break;
+	case 2:
+		*val = no_os_get_unaligned_be16(&buff[3]);
+		break;
+	case 4:
+		*val = no_os_get_unaligned_be32(&buff[3]);
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	if (mask)
+		*val = no_os_field_get(*val, mask);
+
+
+	return 0;
+}
+
+/**
+ * @brief ADE7816 SPI Write Register function
+ * @param desc - ADE7816 device descriptor
+ * @param reg - Register Address value.
+ * @param val - Register Value to be written.
+ * @return 0 in case of succes, negative error code otherwise.
+ */
+int ade7816_spi_reg_write(struct ade7816_desc *desc, uint16_t reg, uint32_t val)
+{
+	uint8_t bytes_number;
+	uint32_t mask = 0;
+	uint8_t buff[7];
+
+	buff[0] = 0x00;
+	buff[1] = no_os_field_get(ADE7816_MSB_REG_MASK, reg);
+	buff[2] = no_os_field_get(ADE7816_LSB_REG_MASK, reg);
+
+	switch (reg) {
+	case ADE7816_VGAIN_REG ... ADE7816_FVAROS_REG:
+	case ADE7816_VARNOLOAD_REG:
+		bytes_number = 4;
+		mask = NO_OS_GENMASK(23, 0);
+		break;
+	case ADE7816_CHSTATUS_REG ... ADE7816_CONFIG_REG:
+		bytes_number = 2;
+		break;
+	case ADE7816_MMODE_REG ... ADE7816_CONFIG2_REG:
+		bytes_number = 1;
+		break;
+	default:
+		bytes_number = 4;
+		break;
+	}
+
+	if (mask) {
+		val = no_os_sign_extend32(val, 23);
+		val = no_os_field_get(ADE7816_ZSPE_MASK, val);
+	}
+
+	buff[3] = no_os_field_get(ADE7816_FOURTH_BYTE_MASK, val);
+	buff[4] = no_os_field_get(ADE7816_THIRD_BYTE_MASK, val);
+	buff[5] = no_os_field_get(ADE7816_SECOND_BYTE_MASK, val);
+	buff[6] = no_os_field_get(ADE7816_FIRST_BYTE_MASK, val);
+
+	return no_os_spi_write_and_read(desc->spi_desc, buff, 3 + bytes_number);
+}

--- a/projects/ade7816/Makefile
+++ b/projects/ade7816/Makefile
@@ -1,0 +1,5 @@
+include ../../tools/scripts/generic_variables.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/ade7816/builds.json
+++ b/projects/ade7816/builds.json
@@ -1,0 +1,7 @@
+{
+	"maxim": {
+		"basic_example_max32690": {
+			"flags" : "TARGET=max32690"
+		}
+	}
+}

--- a/projects/ade7816/src.mk
+++ b/projects/ade7816/src.mk
@@ -1,0 +1,46 @@
+include $(PROJECT)/src/platform/$(PLATFORM)/platform_src.mk
+include $(PROJECT)/src/examples/examples_src.mk
+
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/main.c
+
+INCS += $(PROJECT)/src/common/common_data.h
+SRCS += $(PROJECT)/src/common/common_data.c
+
+INCS += $(PROJECT)/src/platform/platform_includes.h
+
+INCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.h
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.c
+
+INCS += $(INCLUDE)/no_os_delay.h		\
+	$(INCLUDE)/no_os_error.h		\
+	$(INCLUDE)/no_os_print_log.h		\
+	$(INCLUDE)/no_os_spi.h			\
+	$(INCLUDE)/no_os_gpio.h			\
+	$(INCLUDE)/no_os_alloc.h		\
+	$(INCLUDE)/no_os_irq.h			\
+	$(INCLUDE)/no_os_i2c.h			\
+	$(INCLUDE)/no_os_list.h			\
+	$(INCLUDE)/no_os_dma.h			\
+	$(INCLUDE)/no_os_uart.h			\
+	$(INCLUDE)/no_os_lf256fifo.h		\
+	$(INCLUDE)/no_os_util.h			\
+	$(INCLUDE)/no_os_units.h		\
+	$(INCLUDE)/no_os_mutex.h
+
+SRCS += $(DRIVERS)/api/no_os_spi.c		\
+	$(DRIVERS)/api/no_os_uart.c		\
+	$(DRIVERS)/api/no_os_irq.c		\
+	$(DRIVERS)/api/no_os_i2c.c		\
+	$(DRIVERS)/api/no_os_gpio.c		\
+	$(DRIVERS)/api/no_os_dma.c		\
+	$(NO-OS)/util/no_os_list.c		\
+	$(NO-OS)/util/no_os_alloc.c		\
+	$(NO-OS)/util/no_os_lf256fifo.c		\
+	$(NO-OS)/util/no_os_mutex.c		\
+	$(NO-OS)/util/no_os_util.c
+
+INCS += $(DRIVERS)/meter/ade7816/ade7816.h
+
+SRCS += $(DRIVERS)/meter/ade7816/ade7816.c	\
+	$(DRIVERS)/meter/ade7816/ade7816_spi.c	\
+	$(DRIVERS)/meter/ade7816/ade7816_i2c.c

--- a/projects/ade7816/src/common/common_data.c
+++ b/projects/ade7816/src/common/common_data.c
@@ -1,0 +1,82 @@
+/***************************************************************************//**
+ *   @file   common_data.c
+ *   @brief  Defines common data to be used by ade7816 example.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+#include "common_data.h"
+
+struct no_os_uart_init_param ade7816_uart_ip = {
+	.device_id = UART_DEVICE_ID,
+	.baud_rate = UART_BAUDRATE,
+	.size = NO_OS_UART_CS_8,
+	.platform_ops = UART_OPS,
+	.parity = NO_OS_UART_PAR_NO,
+	.stop = NO_OS_UART_STOP_1_BIT,
+	.extra = UART_EXTRA,
+};
+
+struct no_os_spi_init_param ade7816_spi_ip = {
+	.device_id = SPI_DEVICE_ID,
+	.extra = SPI_EXTRA,
+	.mode = NO_OS_SPI_MODE_0,
+	.max_speed_hz = SPI_BAUDRATE,
+	.platform_ops = SPI_OPS,
+	.chip_select = SPI_CS,
+};
+
+struct no_os_gpio_init_param ade7816_reset_ip = {
+	.port = GPIO_RESET_PORT_NUM,
+	.pull = NO_OS_PULL_NONE,
+	.number = GPIO_RESET_PIN_NUM,
+	.platform_ops = GPIO_OPS,
+	.extra = GPIO_EXTRA,
+};
+
+struct no_os_gpio_init_param ade7816_gpio_irq0_ip = {
+	.port = GPIO_IRQ0_PORT_NUM,
+	.pull = NO_OS_PULL_NONE,
+	.number = GPIO_IRQ0_PIN_NUM,
+	.platform_ops = GPIO_OPS,
+	.extra = GPIO_EXTRA,
+};
+
+struct ade7816_init_param ade7816_ip = {
+	.spi_param = &ade7816_spi_ip,
+	.i2c_param = NULL,
+	.reset_param = &ade7816_reset_ip,
+	.ss_param = NULL,
+	.gpio_irq0_param = &ade7816_gpio_irq0_ip,
+	.gpio_irq1_param = NULL,
+	.active_irq = ADE7816_IRQ0,
+	.irq0_callback = NULL,
+	.comm_type = ADE7816_SPI,
+	.handle_irq0 = GPIO_HANDLE,
+	.irq0_priority = 1,
+};

--- a/projects/ade7816/src/common/common_data.h
+++ b/projects/ade7816/src/common/common_data.h
@@ -1,0 +1,47 @@
+/***************************************************************************//**
+ *    @file  common_data.h
+ *   @brief  Defines common data to be used by ade7816 example.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+#ifndef __COMMON_DATA_H__
+#define __COMMON_DATA_H__
+
+#include "platform_includes.h"
+#include "ade7816.h"
+
+extern struct no_os_uart_init_param ade7816_uart_ip;
+extern struct no_os_spi_init_param ade7816_spi_ip;
+extern struct no_os_gpio_init_param ade7816_reset_ip;
+extern struct no_os_gpio_init_param ade7816_gpio_irq0_ip;
+extern struct no_os_gpio_init_param ade7816_gpio_irq1_ip;
+
+extern struct ade7816_init_param ade7816_ip;
+
+#endif /* __COMMON_DATA_H__ */

--- a/projects/ade7816/src/examples/basic/basic_example.c
+++ b/projects/ade7816/src/examples/basic/basic_example.c
@@ -1,0 +1,191 @@
+/***************************************************************************//**
+ *   @file   basic_example.c
+ *   @brief  Source file for basic example.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+#include "basic_example.h"
+#include "common_data.h"
+#include "no_os_delay.h"
+#include "no_os_print_log.h"
+#include "no_os_irq.h"
+#include "no_os_util.h"
+#include "no_os_units.h"
+
+/**
+ * @brief Basic example main execution
+ * @return ret - Result of the example execution. If working correctly, will
+ * 		 measure active and reactive energy and RMS for channel A and
+ * 		 for voltage stopping whenever an interrupt occurs and resulting
+ * 		 in a stoppage of the measurement.
+*/
+int basic_example_main()
+{
+	struct ade7816_desc *desc;
+	bool interrupt = false;
+	uint32_t rms, scaled;
+	int32_t val;
+	int ret;
+
+	/** GPIO Pin Interrupt Controller */
+	struct no_os_irq_ctrl_desc *gpio_irq_desc;
+	struct no_os_irq_init_param gpio_irq_desc_param = {
+		.irq_ctrl_id = GPIO_IRQ_ID,
+		.platform_ops = GPIO_IRQ_OPS,
+		.extra = GPIO_IRQ_EXTRA
+	};
+
+	ret = no_os_irq_ctrl_init(&gpio_irq_desc, &gpio_irq_desc_param);
+	if (ret)
+		goto exit;
+
+	ade7816_ip.irq_ctrl = gpio_irq_desc;
+
+	ret = ade7816_init(&desc, &ade7816_ip);
+	if (ret)
+		goto remove_irq;
+
+	ret = ade7816_zx_detect(desc, ADE7816_CHANNEL_A);
+	if (ret)
+		goto remove_ade7816;
+
+	ret = ade7816_set_phase(desc, ADE7816_CHANNEL_A, ADE7816_PCF_50HZ);
+	if (ret)
+		goto remove_ade7816;
+
+	ret = ade7816_set_phase(desc, ADE7816_CHANNEL_B, ADE7816_PCF_50HZ);
+	if (ret)
+		goto remove_ade7816;
+
+	ret = ade7816_set_phase(desc, ADE7816_CHANNEL_C, ADE7816_PCF_50HZ);
+	if (ret)
+		goto remove_ade7816;
+
+	ret = ade7816_set_phase(desc, ADE7816_CHANNEL_D, ADE7816_PCF_50HZ);
+	if (ret)
+		goto remove_ade7816;
+
+	ret = ade7816_set_phase(desc, ADE7816_CHANNEL_E, ADE7816_PCF_50HZ);
+	if (ret)
+		goto remove_ade7816;
+
+	ret = ade7816_set_phase(desc, ADE7816_CHANNEL_F, ADE7816_PCF_50HZ);
+	if (ret)
+		goto remove_ade7816;
+
+	ret = ade7816_set_active_thr(desc, 8000);
+	if (ret)
+		goto remove_ade7816;
+
+	ret = ade7816_set_reactive_thr(desc, 8000);
+	if (ret)
+		goto remove_ade7816;
+
+	ret = ade7816_reg_update(desc, ADE7816_MASK0_REG, NO_OS_BIT(10),
+				 NO_OS_BIT(10));
+	if (ret)
+		goto remove_ade7816;
+
+	ret = ade7816_write_reg(desc, ADE7816_DICOEFF_REG, 0xFFF8000);
+	if (ret)
+		goto remove_ade7816;
+
+	ret = ade7816_reg_update(desc, ADE7816_LCYCMODE_REG,
+				 ADE7816_RSTREAD_MASK,
+				 no_os_field_prep(ADE7816_RSTREAD_MASK, 0));
+	if (ret)
+		goto remove_ade7816;
+
+	desc->lcycle_mode = false;
+
+	ret = ade7816_write_reg(desc, ADE7816_STATUS0_REG, 0);
+	if (ret)
+		goto remove_ade7816;
+
+	ret = ade7816_read_reg(desc, ADE7816_MASK0_REG, &rms);
+	if (ret)
+		goto remove_ade7816;
+
+	ret = no_os_irq_enable(gpio_irq_desc, 21);
+	if (ret)
+		goto remove_ade7816;
+
+	while (!interrupt) {
+		pr_info("Channel A:\n");
+
+		ret = ade7816_read_active_energy(desc, ADE7816_CHANNEL_A, &val);
+		if (ret)
+			goto remove_ade7816;
+
+		pr_info("Accumulated Active Energy RAW: %d\n", val);
+
+		ret = ade7816_read_reactive_energy(desc, ADE7816_CHANNEL_A,
+						   &val);
+		if (ret)
+			goto remove_ade7816;
+
+		pr_info("Accumulated Reactive Energy RAW: %d\n", val);
+
+		ret = ade7816_read_rms(desc, ADE7816_CHANNEL_A, &rms);
+		if (ret)
+			goto remove_ade7816;
+
+		ret = ade7816_rms_to_micro(desc, ADE7816_CHANNEL_A, rms,
+					   &scaled);
+		if (ret)
+			goto remove_ade7816;
+
+		pr_info("IA_RMS: %d uA\n", scaled);
+
+		ret = ade7816_read_rms(desc, ADE7816_CHANNEL_VOLTAGE, &rms);
+		if (ret)
+			goto remove_ade7816;
+
+		ret = ade7816_rms_to_micro(desc, ADE7816_CHANNEL_VOLTAGE, rms,
+					   &scaled);
+		if (ret)
+			goto remove_ade7816;
+
+		pr_info("V_RMS: %d uV\n", scaled);
+
+		if (desc->status0) {
+			pr_info("DETECTED IRQ0 FALLING EDGE, STATUS RETURN : 0x%x\n", desc->status0);
+			interrupt = true;
+		}
+
+		no_os_mdelay(500);
+	}
+
+remove_ade7816:
+	ade7816_remove(desc);
+remove_irq:
+	no_os_irq_ctrl_remove(gpio_irq_desc);
+exit:
+	return ret;
+}

--- a/projects/ade7816/src/examples/basic/basic_example.h
+++ b/projects/ade7816/src/examples/basic/basic_example.h
@@ -1,0 +1,38 @@
+/***************************************************************************//**
+ *   @file   basic_example.h
+ *   @brief  Header file for basic example.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+#ifndef __BASIC_EXAMPLE_H__
+#define __BASIC_EXAMPLE_H__
+
+int basic_example_main();
+
+#endif /* __BASIC_EXAMPLE_H__ */

--- a/projects/ade7816/src/examples/examples_src.mk
+++ b/projects/ade7816/src/examples/examples_src.mk
@@ -1,0 +1,2 @@
+SRCS += $(PROJECT)/src/examples/basic/basic_example.c
+INCS += $(PROJECT)/src/examples/basic/basic_example.h

--- a/projects/ade7816/src/platform/maxim/main.c
+++ b/projects/ade7816/src/platform/maxim/main.c
@@ -1,0 +1,72 @@
+/***************************************************************************//**
+ *   @file   main.c
+ *   @brief  Main file for Maxim platform of ade7816 project.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+#include "platform_includes.h"
+#include "common_data.h"
+#include "no_os_error.h"
+#include "basic_example.h"
+
+int main()
+{
+	int ret = -EINVAL;
+
+	struct no_os_uart_desc *uart_desc;
+
+	/* NVIC Interrupt Controller specific for Maxim platform. */
+	struct no_os_irq_ctrl_desc *nvic_desc;
+	struct no_os_irq_init_param nvic_desc_param = {
+		.platform_ops = &max_irq_ops,
+	};
+
+	ret = no_os_uart_init(&uart_desc, &ade7816_uart_ip);
+	if (ret)
+		return ret;
+
+	ret = no_os_irq_ctrl_init(&nvic_desc, &nvic_desc_param);
+	if (ret)
+		goto ade7816_uart_remove;
+
+	ret = no_os_irq_enable(nvic_desc, NVIC_GPIO_IRQ);
+	if (ret)
+		goto ade7816_nvic_remove;
+
+	no_os_uart_stdio(uart_desc);
+
+	ret = basic_example_main();
+
+ade7816_nvic_remove:
+	no_os_irq_ctrl_remove(nvic_desc);
+ade7816_uart_remove:
+	no_os_uart_remove(uart_desc);
+
+	return ret;
+}

--- a/projects/ade7816/src/platform/maxim/parameters.c
+++ b/projects/ade7816/src/platform/maxim/parameters.c
@@ -1,0 +1,47 @@
+/***************************************************************************//**
+ *   @file   parameters.c
+ *   @brief  Definition of Maxim platform data used by ade7816 project.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+#include "parameters.h"
+
+struct max_uart_init_param ade7816_uart_extra = {
+	.flow = UART_FLOW_DIS,
+};
+
+struct max_spi_init_param ade7816_spi_extra = {
+	.num_slaves = 1,
+	.polarity = SPI_SS_POL_LOW,
+	.vssel = MXC_GPIO_VSSEL_VDDIOH
+};
+
+struct max_gpio_init_param ade7816_gpio_extra = {
+	.vssel = MXC_GPIO_VSSEL_VDDIOH,
+};

--- a/projects/ade7816/src/platform/maxim/parameters.h
+++ b/projects/ade7816/src/platform/maxim/parameters.h
@@ -1,0 +1,84 @@
+/***************************************************************************//**
+ *   @file   max14916/src/platform/maxim/parameters.h
+ *   @brief  Definition of Maxim platform data used by max14916 project.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2023(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
+
+#include "maxim_irq.h"
+#include "maxim_spi.h"
+#include "maxim_gpio.h"
+#include "maxim_gpio_irq.h"
+#include "maxim_uart.h"
+#include "maxim_uart_stdio.h"
+
+
+#if (TARGET_NUM == 32690)
+#define UART_IRQ_ID		UART0_IRQn
+#define UART_DEVICE_ID		0
+#define UART_BAUDRATE		57600
+#endif
+#define UART_EXTRA		&ade7816_uart_extra
+#define UART_OPS		&max_uart_ops
+
+#if (TARGET_NUM == 32690)
+#define SPI_DEVICE_ID		4
+#define SPI_CS			0
+#endif
+
+#define SPI_BAUDRATE		100000
+#define SPI_OPS			&max_spi_ops
+#define SPI_EXTRA		&ade7816_spi_extra
+
+#if (TARGET_NUM == 32690)
+#define GPIO_RESET_PORT_NUM	1
+#define GPIO_RESET_PIN_NUM	6
+
+#define GPIO_IRQ0_PORT_NUM	2
+#define GPIO_IRQ0_PIN_NUM	21
+
+#define GPIO_IRQ_ID		2
+#define GPIO_HANDLE		MXC_GPIO_GET_GPIO(2)
+
+#define GPIO_OPS		&max_gpio_ops
+#define GPIO_EXTRA		&ade7816_gpio_extra
+
+#define GPIO_IRQ_OPS		&max_gpio_irq_ops
+#define GPIO_IRQ_EXTRA		&ade7816_gpio_extra
+
+#define NVIC_GPIO_IRQ		GPIO2_IRQn
+#endif
+
+extern struct max_uart_init_param ade7816_uart_extra;
+extern struct max_gpio_init_param ade7816_gpio_extra;
+extern struct max_spi_init_param ade7816_spi_extra;
+
+#endif  /* __PARAMETERS_H__ */

--- a/projects/ade7816/src/platform/maxim/platform_src.mk
+++ b/projects/ade7816/src/platform/maxim/platform_src.mk
@@ -1,0 +1,19 @@
+INCS +=	$(PLATFORM_DRIVERS)/../common/maxim_dma.h	\
+	$(PLATFORM_DRIVERS)/maxim_gpio.h		\
+	$(PLATFORM_DRIVERS)/maxim_gpio_irq.h		\
+	$(PLATFORM_DRIVERS)/maxim_i2c.h			\
+	$(PLATFORM_DRIVERS)/maxim_irq.h			\
+	$(PLATFORM_DRIVERS)/maxim_spi.h			\
+	$(PLATFORM_DRIVERS)/maxim_uart.h		\
+	$(PLATFORM_DRIVERS)/maxim_uart_stdio.h
+
+
+SRCS += $(PLATFORM_DRIVERS)/../common/maxim_dma.c	\
+	$(PLATFORM_DRIVERS)/maxim_delay.c		\
+	$(PLATFORM_DRIVERS)/maxim_gpio.c		\
+	$(PLATFORM_DRIVERS)/maxim_gpio_irq.c		\
+	$(PLATFORM_DRIVERS)/maxim_i2c.c			\
+	$(PLATFORM_DRIVERS)/maxim_irq.c			\
+	$(PLATFORM_DRIVERS)/maxim_spi.c			\
+	$(PLATFORM_DRIVERS)/maxim_uart.c		\
+	$(PLATFORM_DRIVERS)/maxim_uart_stdio.c

--- a/projects/ade7816/src/platform/platform_includes.h
+++ b/projects/ade7816/src/platform/platform_includes.h
@@ -1,0 +1,40 @@
+/***************************************************************************//**
+ *   @file   platform_includes.h
+ *   @brief  Includes for used platforms used by ade7816 project.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+#ifndef __PLATFORM_INCLUDES_H__
+#define __PLATFORM_INCLUDES_H__
+
+#ifdef MAXIM_PLATFORM
+#include "maxim/parameters.h"
+#endif
+
+#endif /* __PLATFORM_INCLUDES_H__ */


### PR DESCRIPTION
## Pull Request Description

The ADE7816 is a highly accurate, multichannel metering
device that is capable of measuring one voltage channel and up
to six current channels. It measures line voltage and current and
calculates active and reactive energy, as well as instantaneous rms
voltage and current. The device incorporates seven sigma-delta
(Σ-Δ) ADCs with a high accuracy energy measurement core.
The six current input channels allow multiple loads to be measured
simultaneously. The voltage channel and the six current channels
each have a complete signal path allowing for a full range of
measurements.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
