### PR TITLE
adc: ad405x: Fix AD4052 Production ID and Data format reset value.

### DIFF
--- a/drivers/adc/ad405x/ad405x.c
+++ b/drivers/adc/ad405x/ad405x.c
@@ -794,6 +794,10 @@ int ad405x_init(struct ad405x_dev **device,
 
 	switch (init_param.active_device) {
 	case ID_AD4050:
+		if (no_os_get_unaligned_be16(prod_id) != PROD_ID_AD4050)
+			goto error_spi;
+
+		break;
 	case ID_AD4052:
 		if (no_os_get_unaligned_be16(prod_id) != PROD_ID_AD4052)
 			goto error_spi;
@@ -818,7 +822,7 @@ int ad405x_init(struct ad405x_dev **device,
 	dev->gp1_mode = AD405X_GP_MODE_DEV_RDY;
 	dev->invert_on_chop_status = AD405X_INVERT_ON_CHOP_DISABLED;
 	dev->gp0_mode = AD405X_GP_MODE_HIGH_Z;
-	dev->data_format = AD405X_STRAIGHT_BINARY;
+	dev->data_format = AD405X_TWOS_COMPLEMENT;
 	dev->active_device = init_param.active_device;
 
 	*device = dev;

--- a/drivers/adc/ad405x/ad405x.h
+++ b/drivers/adc/ad405x/ad405x.h
@@ -224,7 +224,8 @@ enum ad405x_device_type {
 
 /** AD405X product ID */
 enum ad405x_product_id {
-	PROD_ID_AD4052 = 0x70
+	PROD_ID_AD4050 = 0x70,
+	PROD_ID_AD4052 = 0x72,
 };
 
 /**


### PR DESCRIPTION
## Pull Request Description

According to the [ad4052 datasheet](https://www.analog.com/media/en/technical-documentation/data-sheets/ad4052-ad4058.pdf)

```
PRODUCT_ID_L.PRODUCT_ID        value is 0x72                          (p. 54)
ADC_MODES.DATA_FORMAT    reset value is 0x01 Twos Complement (Signed) (p. 58)
```

For the data_fomat, the ad405x iio driver on pcf [always write this register on init](https://github.com/analogdevicesinc/precision-converters-firmware/blob/main/projects/ad405x_iio/app/ad405x_iio.c#L1507-L1511), so this mistake only affects users leveraging the no-OS driver directly.
The first should affect all.

## PR Type
- [X] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
