### PR TITLE
add script to convert Windows to Unix paths

### DIFF
--- a/tools/scripts/git-bash-paths.sh
+++ b/tools/scripts/git-bash-paths.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0+
+#
+# Copyright (C) 2024 Analog Devices, Inc.
+# Author: Darius Berghe darius.berghe@analog.com
+# 
+# Use this script to convert Windows paths to Unix (Git Bash)
+# paths from scripts that need to be sourced to set up the
+# environment.
+# 
+# Besides the path conversion it also filters out paths that
+# contain "gnuwin" keyword, because these typically contain
+# tools that overlap with Git Bash tools but may not work well.
+#
+# Usage:
+#   source git-bash-paths.sh path/to/yourscript.sh
+#
+script_to_source=$1
+
+# Capture the environment in the main shell
+original_env=$(/usr/bin/env)
+
+# Run the script in a subprocess, capturing the modified environment
+modified_env=$(bash -c "source $script_to_source; /usr/bin/env")
+
+# Convert and populate environments into associative arrays for easy comparison
+declare -A original_env_map modified_env_map
+
+while IFS='=' read -r key value; do
+    original_env_map["$key"]="$value"
+done <<< "$original_env"
+
+while IFS='=' read -r key value; do
+    modified_env_map["$key"]="$value"
+done <<< "$modified_env"
+
+# Find the differences
+for key in "${!modified_env_map[@]}"; do
+    if [[ "${original_env_map[$key]}" != "${modified_env_map[$key]}" ]]; then
+        if [[ -z "${original_env_map[$key]}" ]]; then
+            echo -n "Added: "
+        else
+            echo -n "Modified: "
+        fi
+        filteredpaths="${modified_env_map[$key]}"
+        if [[ "$key" == "PATH" ]]; then
+                unixpaths=$(echo ${modified_env_map[$key]} | sed -E 's|([A-Z]):\\|/\L\1/|g; s|\\|/|g')
+                filteredpaths=$(echo "$unixpaths" | tr ':' '\n' | grep -v "gnuwin" | paste -sd ':' -)
+        fi
+        echo "$key=$filteredpaths"
+        export "$key=$filteredpaths"
+    fi
+done
+


### PR DESCRIPTION
## Pull Request Description

When sourcing an environment script such as the Xilinx's settings64.sh, PATH entries need to be converted to Unix compatible paths. This script can be used to perform the conversion like this:

source tools/scripts/git-bash-paths.sh /c/Xilinx/Vitis/2022.2/settings64.sh

It's not necessarily specific to Xilinx platform but we're currently using it only for this purpose with possibility to extend it for other platforms.

Tested with Vitis 2022.2 on various projects for various targets such as zynq7000, microblaze, ultrascale.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
