### PR TITLE
sg_handler issue fix during initialization

### DIFF
--- a/drivers/platform/stm32/stm32_dma.c
+++ b/drivers/platform/stm32/stm32_dma.c
@@ -228,6 +228,7 @@ int stm32_dma_init(struct no_os_dma_desc** desc,
 
 	descriptor->id = param->id;
 	descriptor->num_ch = param->num_ch;
+	descriptor->sg_handler = param->sg_handler;
 
 	for (i = 0; i < param->num_ch; i++) {
 		descriptor->channels[i].free = true;


### PR DESCRIPTION
DMA desc now takes the interrupt handler which is assigned to DMA init parameter

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
