### PR TITLE
tools: generic.mk: re-generate object files if flags.txt files have changed

### DIFF
--- a/tools/scripts/generic.mk
+++ b/tools/scripts/generic.mk
@@ -301,32 +301,41 @@ LSCRIPT_FLAG = -T$(LSCRIPT)
 endif
 
 define generate_cflags_func
-echo $(subst \",\\\",$(1)) >> $(CFLAGS_FILE)
+echo $(subst \",\\\",$(1)) >> $(CFLAGS_FILE).tmp
 endef
 
 define generate_cppflags_func
-echo $(subst \",\\\",$(1)) >> $(CPPFLAGS_FILE)
+echo $(subst \",\\\",$(1)) >> $(CPPFLAGS_FILE).tmp
 endef
 
 define generate_asflags_func
-echo $(subst \",\\\",$(1)) >> $(ASFLAGS_FILE)
+echo $(subst \",\\\",$(1)) >> $(ASFLAGS_FILE).tmp
 endef
 
 define generate_objs_func
-echo $(1) >> $(OBJS_FILE)
+echo $(1) >> $(OBJS_FILE).tmp
+endef
+
+define overwrite_file_if_different
+	diff $(1) $(2) &> /dev/null || mv -f $(1) $(2)
+endef
+
+define generate_flags_file
+	echo -n > $(1).tmp
+	$(call process_items_in_chunks,$(2),10,$(3))
+	$(call overwrite_file_if_different,$(1).tmp,$(1))
+	rm -f $(1).tmp
 endef
 
 PHONY += pre_build
 pre_build:
 	$(call print,Generating build flags)
-	echo -n > $(CFLAGS_FILE)
-	$(call process_items_in_chunks,$(CFLAGS),10,generate_cflags_func)
-	echo -n > $(CPPFLAGS_FILE)
-	$(call process_items_in_chunks,$(CPPFLAGS),10,generate_cppflags_func)
-	echo -n > $(ASFLAGS_FILE)
-	$(call process_items_in_chunks,$(ASFLAGS),10,generate_asflags_func)
-	echo -n > $(OBJS_FILE)
-	$(call process_items_in_chunks,$(sort $(OBJS)),10,generate_objs_func)
+	$(call generate_flags_file,$(CFLAGS_FILE),$(CFLAGS),generate_cflags_func)
+	$(call generate_flags_file,$(CPPFLAGS_FILE),$(CPPFLAGS),generate_cppflags_func)
+	$(call generate_flags_file,$(ASFLAGS_FILE),$(ASFLAGS),generate_asflags_func)
+	$(call generate_flags_file,$(OBJS_FILE),$(OBJS),generate_objs_func)
+
+$(OBJS): $(CFLAGS_FILE) $(CPPFLAGS_FILE) $(ASFLAGS_FILE) $(OBJS_FILE)
 
 $(BINARY): $(LIB_TARGETS) $(OBJS) $(ASM_OBJS) $(LSCRIPT) $(BOOTOBJ)
 	$(call print,[LD] $(notdir $(OBJS)))

--- a/tools/scripts/generic.mk
+++ b/tools/scripts/generic.mk
@@ -253,6 +253,7 @@ PHONY += all
 ifneq ($(wildcard $(BUILD_LOCK)),)
 all:
 	$(call print_build_type,$(PLATFORM))
+	$(MAKE) --no-print-directory update
 	$(MAKE) --no-print-directory build
 	$(call print,Done ($(notdir $(BUILD_DIR))/$(notdir $(BINARY))))
 else


### PR DESCRIPTION
## Pull Request Description

    In case CFLAGS,CPPFLAGS,ASFLAGS and OBJS lists change, their respective
    files will also change. This should re-trigger a build.
    
    The 'pre_build' rule is run via the 'update' build rule, which is now
    getting called everything we build 'all'.
    When the 'pre_build' gets run, we re-generate all flags.txt files, and
    overwrite them if they changed.
    When they change, the object file will rebuild.


## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
