### PR TITLE
STM32 PWM driver issue fix

### DIFF
--- a/drivers/platform/stm32/stm32_pwm.c
+++ b/drivers/platform/stm32/stm32_pwm.c
@@ -601,7 +601,7 @@ int32_t stm32_pwm_set_period(struct no_os_pwm_desc *desc,
 {
 	int32_t ret;
 	struct no_os_pwm_init_param param;
-	struct stm32_pwm_init_param sparam;
+	struct stm32_pwm_init_param sparam = {0};
 
 	param.id = desc->id;
 	param.duty_cycle_ns = desc->duty_cycle_ns;


### PR DESCRIPTION
Zero initialized the structure as some of the parameters with garbage values were behaving in an undesirable manner in the stm32_init_timer() function when called

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
