### PR TITLE
 Minor fixes to support DAC streaming

### DIFF
--- a/drivers/platform/stm32/stm32_spi.c
+++ b/drivers/platform/stm32/stm32_spi.c
@@ -513,7 +513,7 @@ int32_t stm32_config_dma_and_start(struct no_os_spi_desc* desc,
 #endif
 		tx_ch_xfer[i].xfer_type = MEM_TO_DEV;
 		tx_ch_xfer[i].periph = NO_OS_DMA_IRQ;
-		tx_ch_xfer[i].length = 1;
+		tx_ch_xfer[i].length = msgs[i].bytes_number;
 
 		rx_ch_xfer[i].dst = msgs[i].rx_buff;
 #ifndef SPI_SR_RXNE
@@ -551,6 +551,13 @@ int32_t stm32_config_dma_and_start(struct no_os_spi_desc* desc,
 	ret = no_os_dma_xfer_start(sdesc->dma_desc, sdesc->rxdma_ch);
 	if (ret)
 		goto abort_transfer;
+
+	if (sdesc->txdma_ch)
+#if defined (STM32H5)
+		SET_BIT(sdesc->hspi.Instance->CFG1, SPI_CFG1_TXDMAEN);
+#else
+		SET_BIT(sdesc->hspi.Instance->CR2, SPI_CR2_TXDMAEN);
+#endif
 
 	if (sdesc->rxdma_ch)
 #if defined (STM32H5)
@@ -606,6 +613,12 @@ void stm32_spi_dma_callback(struct no_os_dma_xfer_desc *old_xfer,
 
 	if (sdesc->tx_pwm_desc)
 		no_os_pwm_disable(sdesc->tx_pwm_desc);
+#endif
+
+#if defined (STM32H5)
+	CLEAR_BIT(sdesc->hspi.Instance->CFG1, SPI_CFG1_TXDMAEN);
+#else
+	CLEAR_BIT(sdesc->hspi.Instance->CR2, SPI_CR2_TXDMAEN);
 #endif
 
 #if defined (STM32H5)

--- a/drivers/platform/stm32/stm32_spi.c
+++ b/drivers/platform/stm32/stm32_spi.c
@@ -171,7 +171,7 @@ int32_t stm32_spi_init(struct no_os_spi_desc **desc,
 	struct stm32_spi_desc *sdesc;
 	struct stm32_spi_init_param *sinit;
 
-	sdesc = (struct stm32_spi_desc*)no_os_calloc(1,sizeof(struct stm32_spi_desc));
+	sdesc = (struct stm32_spi_desc*)no_os_calloc(1, sizeof(struct stm32_spi_desc));
 	if (!sdesc) {
 		ret = -ENOMEM;
 		goto error;
@@ -374,7 +374,7 @@ int32_t stm32_spi_transfer(struct no_os_spi_desc *desc,
 		/* Assert CS */
 		gdesc->port->BSRR = NO_OS_BIT(sdesc->chip_select->number) << 16;
 
-		if(msgs[i].cs_delay_first)
+		if (msgs[i].cs_delay_first)
 			no_os_udelay(msgs[i].cs_delay_first);
 
 #ifndef SPI_SR_TXE
@@ -406,14 +406,14 @@ int32_t stm32_spi_transfer(struct no_os_spi_desc *desc,
 
 		while ((msgs[i].rx_buff && rx_cnt < msgs[i].bytes_number) ||
 		       (msgs[i].tx_buff && tx_cnt < msgs[i].bytes_number)) {
-			while(!(SPIx->SR & SPI_SR_TXE))
+			while (!(SPIx->SR & SPI_SR_TXE))
 				;
 			if (msgs[i].tx_buff)
 				*(volatile uint8_t *)&SPIx->DR = msgs[i].tx_buff[tx_cnt++];
 			else
 				*(volatile uint8_t *)&SPIx->DR = 0;
 
-			while(!(SPIx->SR & SPI_SR_RXNE))
+			while (!(SPIx->SR & SPI_SR_RXNE))
 				;
 			if (msgs[i].rx_buff)
 				msgs[i].rx_buff[rx_cnt++] = *(volatile uint8_t *)&SPIx->DR;
@@ -423,14 +423,14 @@ int32_t stm32_spi_transfer(struct no_os_spi_desc *desc,
 
 #endif
 
-		if(msgs[i].cs_delay_last)
+		if (msgs[i].cs_delay_last)
 			no_os_udelay(msgs[i].cs_delay_last);
 
 		if (msgs[i].cs_change)
 			/* De-assert CS */
 			gdesc->port->BSRR = NO_OS_BIT(sdesc->chip_select->number);
 
-		if(msgs[i].cs_change_delay)
+		if (msgs[i].cs_change_delay)
 			no_os_udelay(msgs[i].cs_change_delay);
 
 		if (ret)
@@ -692,7 +692,7 @@ int32_t stm32_spi_dma_transfer_sync(struct no_os_spi_desc* desc,
 	sdesc->stm32_spi_dma_done = false;
 	stm32_config_dma_and_start(desc, msgs, len, stm32_spi_dma_callback, desc);
 	timeout = msgs->bytes_number;
-	while(timeout--) {
+	while (timeout--) {
 		no_os_mdelay(1);
 		if (sdesc->stm32_spi_dma_done)
 			break;


### PR DESCRIPTION
    1. The length parameter of Tx channel is reverted back to take bytes_number.
    2. SPI Tx DMA is enabled

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
