### PR TITLE
add polling to tcp and ssl layer

### DIFF
--- a/tools/scripts/generic_variables.mk
+++ b/tools/scripts/generic_variables.mk
@@ -40,6 +40,11 @@ CFLAGS_MFLOAT_TYPE 	?= hard
 ifeq '$(NO_OS_USB_UART)' 'y'
 CFLAGS += -DNO_OS_USB_UART
 endif
+
+ifndef LWIP_POLLING_TIMEOUT_MS
+CFLAGS += -DLWIP_POLLING_TIMEOUT_MS=500
+endif
+
 #------------------------------------------------------------------------------
 #                          EVALUATE PLATFORM
 #------------------------------------------------------------------------------


### PR DESCRIPTION
## Pull Request Description

Building on this commit: https://github.com/analogdevicesinc/no-OS/commit/8ca2a15b8b7cc7a53985bf5a773bdd99f4bc63bc#diff-f9781ad4653f9192f0521846b4116a5b34ae3c2abd2c4256ee0a813e3f947aa4R158

Currently, all devices (ADIN1110 and ADIN2111) which may be used with
the LWIP sockets layer require polling for new frames.

This polling was already added before socket_recv() in the mqtt layer, now adding it to the tcp and ssl layers. 

## PR Type
- [X] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
