### PR TITLE
tools: generic.mk: add NO_OS_INC_DIRS build var for pulling header files tools

### DIFF
--- a/projects/ad7606x-fmc/src.mk
+++ b/projects/ad7606x-fmc/src.mk
@@ -1,16 +1,25 @@
 # Project includes + source code
-INCS := $(PROJECT)/src/parameters.h      \
-        $(PROJECT)/src/common_data.h
 SRCS := $(PROJECT)/src/common_data.c
+
+NO_OS_INC_DIRS := \
+	$(INCLUDE) \
+	$(PROJECT)/src/ \
+	$(PLATFORM_DRIVERS) \
+	$(DRIVERS)/api/ \
+	$(DRIVERS)/axi_core/axi_dmac/ \
+	$(DRIVERS)/axi_core/spi_engine/ \
+	$(DRIVERS)/axi_core/axi_pwmgen/ \
+	$(DRIVERS)/axi_core/clk_axi_clkgen/ \
+	$(DRIVERS)/axi_core/axi_adc_core/ \
+	$(DRIVERS)/adc/ad7606/
 
 ifeq (y,$(strip $(IIO_EXAMPLE)))
 IIOD=y
 SRCS += $(PROJECT)/src/iio_example.c
 
-INCS += $(DRIVERS)/adc/ad7606/iio_ad7606.h \
-        $(PLATFORM_DRIVERS)/xilinx_uart.h \
-        $(PLATFORM_DRIVERS)/xilinx_irq.h \
-        $(NO-OS)/iio/iio_app/iio_app.h
+NO_OS_INC_DIRS += \
+        $(NO-OS)/iio/iio_app/
+
 SRCS += $(DRIVERS)/adc/ad7606/iio_ad7606.c \
         $(PLATFORM_DRIVERS)/xilinx_uart.c \
         $(PLATFORM_DRIVERS)/xilinx_irq.c \
@@ -21,7 +30,6 @@ SRCS += $(PROJECT)/src/basic_example.c
 endif
 
 # The driver targeted by this project
-INCS += $(DRIVERS)/adc/ad7606/ad7606.h
 SRCS += $(DRIVERS)/adc/ad7606/ad7606.c
 
 SRCS += $(DRIVERS)/api/no_os_uart.c     \
@@ -38,36 +46,6 @@ SRCS += $(DRIVERS)/api/no_os_uart.c     \
         $(NO-OS)/util/no_os_util.c
 
 
-INCS += $(INCLUDE)/no_os_delay.h     \
-        $(INCLUDE)/no_os_error.h     \
-        $(INCLUDE)/no_os_fifo.h      \
-        $(INCLUDE)/no_os_irq.h       \
-        $(INCLUDE)/no_os_lf256fifo.h \
-        $(INCLUDE)/no_os_list.h      \
-        $(INCLUDE)/no_os_dma.h       \
-        $(INCLUDE)/no_os_timer.h     \
-        $(INCLUDE)/no_os_uart.h      \
-        $(INCLUDE)/no_os_util.h      \
-        $(INCLUDE)/no_os_alloc.h     \
-        $(INCLUDE)/no_os_mutex.h     \
-        $(INCLUDE)/no_os_pwm.h       \
-        $(INCLUDE)/no_os_print_log.h \
-        $(INCLUDE)/no_os_axi_io.h    \
-        $(INCLUDE)/no_os_gpio.h      \
-        $(INCLUDE)/no_os_spi.h       \
-        $(INCLUDE)/no_os_crc.h       \
-        $(INCLUDE)/no_os_crc8.h      \
-        $(INCLUDE)/no_os_crc16.h     \
-        $(INCLUDE)/no_os_crc24.h     \
-        $(INCLUDE)/no_os_print_log.h
-
-INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \
-        $(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.h \
-        $(DRIVERS)/axi_core/axi_pwmgen/axi_pwm_extra.h \
-        $(DRIVERS)/axi_core/spi_engine/spi_engine.h \
-        $(DRIVERS)/axi_core/spi_engine/spi_engine_private.h \
-        $(DRIVERS)/axi_core/axi_dmac/axi_dmac.h
-
 SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
         $(DRIVERS)/axi_core/clk_axi_clkgen/clk_axi_clkgen.c \
         $(DRIVERS)/axi_core/axi_pwmgen/axi_pwm.c \
@@ -76,8 +54,6 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
         $(DRIVERS)/api/no_os_spi.c \
         $(DRIVERS)/api/no_os_pwm.c
 
-INCS += $(PLATFORM_DRIVERS)/xilinx_gpio.h \
-        $(PLATFORM_DRIVERS)/xilinx_spi.h
 SRCS += $(PLATFORM_DRIVERS)/xilinx_axi_io.c \
         $(PLATFORM_DRIVERS)/xilinx_gpio.c \
         $(PLATFORM_DRIVERS)/xilinx_delay.c

--- a/tools/scripts/generic.mk
+++ b/tools/scripts/generic.mk
@@ -174,6 +174,8 @@ ifeq (y,$(strip $(DISABLE_SECURE_SOCKET)))
 CFLAGS += -DDISABLE_SECURE_SOCKET
 endif
 
+# Mbed also has an INC_DIRS variable, so this needs to be NO_OS_INC_DIRS
+NO_OS_INC_DIRS := $(patsubst %/,%,$(NO_OS_INC_DIRS))
 SRC_DIRS := $(patsubst %/,%,$(SRC_DIRS))
 
 # Get all .c, .cpp and .h files from SRC_DIRS
@@ -182,6 +184,7 @@ SRCS     += $(foreach dir, $(SRC_DIRS), $(call rwildcard, $(dir),*.cpp))
 ASM_SRCS += $(foreach dir, $(SRC_DIRS), $(call rwildcard, $(dir),*.S))
 ASM_SRCS += $(foreach dir, $(SRC_DIRS), $(call rwildcard, $(dir),*.s))
 INCS     += $(foreach dir, $(SRC_DIRS), $(call rwildcard, $(dir),*.h))
+INCS     += $(foreach dir, $(NO_OS_INC_DIRS), $(call rwildcard, $(dir),*.h))
 
 # Recursive ignored files. If a directory is in the variable IGNORED_FILES,
 # all files from inside the directory will be ignored


### PR DESCRIPTION
## Pull Request Description

This is inspired by the SRC_DIRS build variable, but only focuses on
include files. Using the SRC_DIRS can be problematic, as it pulls
every .c & .h file from a directory.
    
But in some cases, we just want to pull in the header files. These header
files will only get compiled if a .c file pulls them in.
    
If this build variable is unspecified, it will be empty, so nothing will be
done (to potentially affect current projects).

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
