### PR TITLE
Add uart_map in MAX32665 uart extras.

### DIFF
--- a/drivers/platform/maxim/max32660/maxim_uart.c
+++ b/drivers/platform/maxim/max32660/maxim_uart.c
@@ -244,6 +244,7 @@ static int32_t max_uart_init(struct no_os_uart_desc **desc,
 {
 	int32_t ret;
 	int32_t stop, size, flow, parity;
+	sys_map_t map;
 	mxc_uart_regs_t *uart_regs;
 	struct max_uart_init_param *eparam;
 	struct no_os_uart_desc *descriptor;
@@ -334,7 +335,22 @@ static int32_t max_uart_init(struct no_os_uart_desc **desc,
 		goto error;
 	}
 
-	ret = MXC_UART_Init(uart_regs, descriptor->baud_rate, MAP_A);
+	switch (eparam->map) {
+	case UART_MAP_A:
+		map = MAP_A;
+		break;
+	case UART_MAP_B:
+		map = MAP_B;
+		break;
+	case UART_MAP_C:
+		map = MAP_C;
+		break;
+	default:
+		ret = -EINVAL;
+		goto error;
+	}
+
+	ret = MXC_UART_Init(uart_regs, descriptor->baud_rate, map);
 	if (ret != E_NO_ERROR) {
 		ret = -EINVAL;
 		goto error;

--- a/drivers/platform/maxim/max32660/maxim_uart.h
+++ b/drivers/platform/maxim/max32660/maxim_uart.h
@@ -50,10 +50,20 @@ enum max_uart_flow_ctrl {
 };
 
 /**
+ * @brief UART pin mapping select
+ */
+enum max_uart_map {
+	UART_MAP_A,
+	UART_MAP_B,
+	UART_MAP_C,
+};
+
+/**
  * @brief Aditional UART config parameters
  */
 struct max_uart_init_param {
 	enum max_uart_flow_ctrl flow;
+	enum max_uart_map map;
 	mxc_gpio_vssel_t vssel;
 };
 

--- a/drivers/platform/maxim/max32665/maxim_uart.c
+++ b/drivers/platform/maxim/max32665/maxim_uart.c
@@ -257,6 +257,7 @@ static int32_t max_uart_init(struct no_os_uart_desc **desc,
 {
 	int32_t ret;
 	int32_t stop, size, flow, parity;
+	sys_map_t map;
 	mxc_uart_regs_t *uart_regs;
 	struct max_uart_init_param *eparam;
 	struct no_os_uart_desc *descriptor;
@@ -347,7 +348,19 @@ static int32_t max_uart_init(struct no_os_uart_desc **desc,
 		goto error;
 	}
 
-	ret = MXC_UART_Init(uart_regs, descriptor->baud_rate, MAP_B);
+	switch (eparam->map) {
+	case UART_MAP_A:
+		map = MAP_A;
+		break;
+	case UART_MAP_B:
+		map = MAP_B;
+		break;
+	default:
+		ret = -EINVAL;
+		goto error;
+	}
+
+	ret = MXC_UART_Init(uart_regs, descriptor->baud_rate, map);
 	if (ret != E_NO_ERROR) {
 		ret = -EINVAL;
 		goto error;
@@ -375,7 +388,7 @@ static int32_t max_uart_init(struct no_os_uart_desc **desc,
 		goto error;
 	}
 
-	ret = MXC_UART_SetFlowCtrl(uart_regs, flow, 8, MAP_B);
+	ret = MXC_UART_SetFlowCtrl(uart_regs, flow, 8, map);
 	if (ret != E_NO_ERROR) {
 		ret = -EINVAL;
 		goto error;

--- a/drivers/platform/maxim/max32665/maxim_uart.h
+++ b/drivers/platform/maxim/max32665/maxim_uart.h
@@ -50,10 +50,19 @@ enum max_uart_flow_ctrl {
 };
 
 /**
+ * @brief UART pin mapping select
+ */
+enum max_uart_map {
+	UART_MAP_B,
+	UART_MAP_A,
+};
+
+/**
  * @brief Aditional UART config parameters
  */
 struct max_uart_init_param {
 	enum max_uart_flow_ctrl flow;
+	enum max_uart_map map;
 	mxc_gpio_vssel_t vssel;
 };
 


### PR DESCRIPTION
## Pull Request Description

This adds max_uart_map in the init_param of the MAX32665 UART driver.
By default, the console UART for the MAX32665FTHR uses MAP_B, while the
EvKit_V1's uses MAP_A based on their corresponding BSPs [here](https://github.com/analogdevicesinc/msdk/blob/main/Libraries/Boards/MAX32665/FTHR/Source/board.c#L98) and [here](https://github.com/analogdevicesinc/msdk/blob/main/Libraries/Boards/MAX32665/EvKit_V1/Source/board.c#L248).

The sys_map_t is undocumented in the MSDK docs but it appears it sets
specific GPIO configs which varies with different board form factors according
to [here](https://github.com/analogdevicesinc/msdk/blob/main/Libraries/PeriphDrivers/Source/UART/uart_me14.c#L64). This change will allow users to access EvKit_V1 UART at the application
level without touching the platform drivers.

Furthermore, this introduces the new enum max_uart_map that sets MAP_B
as default to avoid breaking changes with adjacent projects that uses the
MAX32665FTHR board.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
