### PR TITLE
Change MAX32670 UART to Initialize with APB CLK

### DIFF
--- a/drivers/platform/maxim/max32670/maxim_uart.c
+++ b/drivers/platform/maxim/max32670/maxim_uart.c
@@ -307,7 +307,7 @@ static int32_t max_uart_init(struct no_os_uart_desc **desc,
 		goto error;
 	}
 
-	ret = MXC_UART_Init(uart_regs, descriptor->baud_rate, MXC_UART_IBRO_CLK);
+	ret = MXC_UART_Init(uart_regs, descriptor->baud_rate, MXC_UART_APB_CLK);
 	if (ret != E_NO_ERROR) {
 		ret = -EINVAL;
 		goto error;


### PR DESCRIPTION
## Pull Request Description

MSDK board support packages and all other MAX32 No-OS drivers use APB CLK to initialize the UART, while MAX32670 uses IBRO. This caused issues printing to stdio/serial port on a project for me, so I'm submitting a fix to change this to APB CLK to match other implementations. This fix solved my problems with printing.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
