### PR TITLE
Fix AD5421 driver bugs

### DIFF
--- a/drivers/dac/ad5421/ad5421.c
+++ b/drivers/dac/ad5421/ad5421.c
@@ -376,7 +376,7 @@ int32_t ad5421_set(struct ad5421_dev *dev,
 	status = no_os_spi_write_and_read(dev->spi_desc,
 					  tx_buffer,
 					  3);
-	if (status != 3) {
+	if (status != 0) {
 		return -1;
 	} else {
 		return 0;
@@ -393,13 +393,13 @@ int32_t ad5421_set(struct ad5421_dev *dev,
 int32_t ad5421_get(struct ad5421_dev *dev)
 {
 	int32_t return_val = 0;
-	uint8_t rx_buffer[3] = {0, 0, 0};
+	uint8_t rx_buffer[3] = {AD5421_NO_OP, 0, 0};
 	int8_t status = 0;
 
 	status = no_os_spi_write_and_read(dev->spi_desc,
 					  rx_buffer,
 					  3);
-	if (status != 3) {
+	if (status != 0) {
 		return -1;
 	}
 	return_val |= (int32_t)(rx_buffer[1] << 8);

--- a/drivers/dac/ad5421/ad5421.h
+++ b/drivers/dac/ad5421/ad5421.h
@@ -51,6 +51,7 @@
 #define AD5421_CMDWRGAIN        4
 #define AD5421_CMDRST			7
 #define AD5421_CMDMEASVTEMP     8
+#define AD5421_NO_OP			9
 #define AD5421_CMDRDDAC         129
 #define AD5421_CMDRDCTRL		130
 #define AD5421_CMDRDOFFSET      131


### PR DESCRIPTION
## Pull Request Description

AD5421 driver had a bug when integrating into a custom example:
- SPI R/W status checks check against an expected length, rather than 0/-1 which is what the No-OS API comments indicate it should return.
- Very minor: I added the "No-Op" code from AD5421 datasheet (0x09). Currently the driver sends 0x00 which should suffice for reading data back, but I added 0x09 to match what the AD5421 GUI sends.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
