### PR TITLE
drivers:platform:stm32: Update SPI desc frequency with configured frequency

### DIFF
--- a/drivers/platform/stm32/stm32_spi.c
+++ b/drivers/platform/stm32/stm32_spi.c
@@ -58,31 +58,41 @@ static int stm32_spi_config(struct no_os_spi_desc *desc)
 		switch (div) {
 		case 0 ... 2:
 			prescaler = SPI_BAUDRATEPRESCALER_2;
+			desc->max_speed_hz = sdesc->input_clock / 2;
 			break;
 		case 3 ... 4:
 			prescaler = SPI_BAUDRATEPRESCALER_4;
+			desc->max_speed_hz = sdesc->input_clock / 4;
 			break;
 		case 5 ... 8:
 			prescaler = SPI_BAUDRATEPRESCALER_8;
+			desc->max_speed_hz = sdesc->input_clock / 8;
 			break;
 		case 9 ... 16:
 			prescaler = SPI_BAUDRATEPRESCALER_16;
+			desc->max_speed_hz = sdesc->input_clock / 16;
 			break;
 		case 17 ... 32:
 			prescaler = SPI_BAUDRATEPRESCALER_32;
+			desc->max_speed_hz = sdesc->input_clock / 32;
 			break;
 		case 33 ... 64:
 			prescaler = SPI_BAUDRATEPRESCALER_64;
+			desc->max_speed_hz = sdesc->input_clock / 64;
 			break;
 		case 65 ... 128:
 			prescaler = SPI_BAUDRATEPRESCALER_128;
+			desc->max_speed_hz = sdesc->input_clock / 128;
 			break;
 		default:
 			prescaler = SPI_BAUDRATEPRESCALER_256;
+			desc->max_speed_hz = sdesc->input_clock / 256;
 			break;
 		}
-	} else
+	} else {
 		prescaler = SPI_BAUDRATEPRESCALER_64;
+		desc->max_speed_hz = sdesc->input_clock / 64;
+	}
 
 	switch (desc->device_id) {
 #if defined(SPI1)


### PR DESCRIPTION
Update SPI descriptor clock frequency value with configured value instead of retaining init params value.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
