### PR TITLE
drivers: api: add i3c ; drivers: platform: stm32

### DIFF
--- a/drivers/api/no_os_i3c.c
+++ b/drivers/api/no_os_i3c.c
@@ -1,0 +1,698 @@
+/***************************************************************************//**
+ *   @file   no_os_i3c.c
+ *   @brief  Implementation of the I3C Interface
+ *   @author Jorge Marques (jorge.marques@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+#include "no_os_i3c.h"
+#include "no_os_error.h"
+#include "no_os_mutex.h"
+#include "no_os_alloc.h"
+
+/**
+ * @brief i3c_table contains the pointers towards the I3C buses.
+*/
+struct no_os_i3c_bus_desc *i3c_table [NO_OS_I3C_MAX_BUS_NUMBER + 1] = {NULL};
+
+static enum no_os_i3c_slot_status no_os_i3c_addr_get_status(
+	struct no_os_i3c_bus_desc *desc, uint8_t addr);
+static bool no_os_i3c_addr_is_avail(struct no_os_i3c_bus_desc *desc,
+				    uint8_t addr);
+static void no_os_i3c_addr_init(struct no_os_i3c_bus_desc *desc);
+
+/**
+ * @brief Initialize the I3C device.
+ * If the bus of the I3C device is not initialized, it will call to init it.
+ * @param desc - The I3C device descriptor.
+ * @param param - The structure that contains the I3C device parameters, to match PID.
+ * @return 0 in case of success, error code otherwise.
+ */
+int no_os_i3c_init(struct no_os_i3c_desc **desc,
+		   const struct no_os_i3c_init_param *param)
+{
+	int ret;
+	struct no_os_i3c_desc *device_desc;
+	struct no_os_i3c_bus_desc **bus_desc;
+	struct no_os_i3c_bus_init_param *param_bus;
+	struct no_os_i3c_desc **it;
+	uint8_t i;
+
+	if (!param->bus->device_id ||
+	    param->bus->device_id > NO_OS_I3C_MAX_BUS_NUMBER)
+
+		return -EINVAL;
+
+	bus_desc = &i3c_table[param->bus->device_id - 1];
+	if (!*bus_desc) {
+		/* Initialize bus if not already */
+		ret = no_os_i3c_init_bus(bus_desc, param->bus);
+		if (ret)
+			return ret;
+	}
+
+	/* Initialize device */
+	param_bus = param->bus;
+
+	device_desc = (struct no_os_i3c_desc *)no_os_malloc(
+			      sizeof(struct no_os_i3c_desc));
+	if (!device_desc)
+		return -ENOMEM;
+
+	/* Set is_attached flag */
+	if (!param->is_i3c || param->is_static)
+		device_desc->is_attached = 1;
+	else {
+		for (i = 0; i < NO_OS_I3C_MAX_DEV_NUMBER; i++) {
+			if ((*bus_desc)->daa_candidates[i].pid == param->pid)
+				break;
+		}
+
+		if (i == NO_OS_I3C_MAX_DEV_NUMBER) {
+			ret = -EFAULT;
+			goto error_device;
+		}
+		device_desc->is_attached = (*bus_desc)->daa_candidates[i].is_attached;
+		if (!device_desc->is_attached) {
+			ret = -EPERM;
+			goto error_device;
+		}
+	}
+
+	/* Copy from init param to dev descriptor */
+	device_desc->pid = param->pid;
+	device_desc->addr = param->addr;
+	device_desc->is_static = param->is_static;
+	device_desc->is_i3c = param->is_i3c;
+	device_desc->platform_ops = param_bus->platform_ops;
+	device_desc->bus = *bus_desc;
+	device_desc->event_callback = NULL;
+
+	/* Find free slot */
+	it = (*bus_desc)->devs;
+	while (it < (*bus_desc)->devs + NO_OS_I3C_MAX_DEV_NUMBER) {
+		if (!*it)
+			break;
+		it++;
+	};
+	if (it == (*bus_desc)->devs + NO_OS_I3C_MAX_DEV_NUMBER)
+		goto error_device;
+
+	*it = device_desc;
+
+	ret = device_desc->platform_ops->i3c_ops_init(device_desc, param);
+	if (ret)
+		goto error_device;
+
+	ret = device_desc->platform_ops->i3c_ops_is_dev_ready(device_desc);
+	if (ret)
+		goto error_device;
+
+	*desc = device_desc;
+	return 0;
+
+error_device:
+	no_os_free(device_desc);
+
+	return ret;
+}
+
+/**
+ * @brief Initialize the I3C bus.
+ * @param desc - The I3C bus descriptor.
+ * @param param - The structure that contains the I3C bus parameters.
+ * @return 0 in case of success, error code otherwise.
+ */
+int no_os_i3c_init_bus(struct no_os_i3c_bus_desc **desc,
+		       const struct no_os_i3c_bus_init_param *param)
+{
+	struct no_os_i3c_bus_desc *bus_desc;
+	bool has_static_i3c_addr = 0;
+	int ret;
+	int i = 0;
+	uint8_t data;
+	const struct no_os_i3c_init_param **it;
+
+	if (!param || !param->platform_ops)
+		return -EINVAL;
+	if (!param->platform_ops->i3c_ops_init_bus ||
+	    !param->platform_ops->i3c_ops_remove_bus)
+		return -ENOSYS;
+
+	bus_desc = (struct no_os_i3c_bus_desc *)no_os_calloc(1,
+			sizeof(struct no_os_i3c_bus_desc));
+	if (!bus_desc)
+		return -ENOMEM;
+
+	bus_desc->device_id = param->device_id;
+	bus_desc->num_devs = param->num_devs;
+	bus_desc->num_devs_unknown = 0;
+	bus_desc->async_irq = 0;
+	bus_desc->platform_ops = param->platform_ops;
+
+	/*
+	 * Execute the platform specific init routine,
+	 * which allocate the extra features.
+	 */
+	ret = param->platform_ops->i3c_ops_init_bus(bus_desc, param);
+	if (ret)
+		goto error_bus_1;
+
+	i3c_table[param->device_id - 1] = bus_desc;
+
+	no_os_i3c_addr_init(bus_desc);
+
+	/*
+	 * Set status for addr, and
+	 * If a device supports static addr, set it with CCC STAASA.
+	 * If not, add to the PID-DA LUT for the DAA procedure.
+	 */
+	for (it = param->devs; it < param->devs + param->num_devs; it++) {
+		if (!*it)
+			continue;
+
+		if (!no_os_i3c_addr_is_avail(bus_desc, (*it)->addr)) {
+			ret = -EINVAL;
+			goto error_bus_2;
+		}
+
+		if ((*it)->is_i3c) {
+			if ((*it)->is_static) {
+				has_static_i3c_addr = 1;
+				no_os_i3c_addr_set_status(bus_desc, (*it)->addr,
+							  NO_OS_I3C_ADDR_SLOT_I3C_DEV);
+			} else {
+				bus_desc->daa_candidates[i].pid = (*it)->pid;
+				bus_desc->daa_candidates[i].addr = (*it)->addr;
+				i++;
+			}
+		} else
+			no_os_i3c_addr_set_status(bus_desc, (*it)->addr,
+						  NO_OS_I3C_ADDR_SLOT_I2C_DEV);
+	}
+
+	/* Ensure other candidates fields are empty */
+	memset(&bus_desc->daa_candidates[i], 0,
+	       sizeof(struct no_os_i3c_daa_lut) * (NO_OS_I3C_MAX_DEV_NUMBER - i));
+
+	/* Reset fully every device on the bus */
+	data = NO_OS_I3C_CCC_RSTACT_WHOLE_TARGET;
+	ret = no_os_i3c_send_ccc(*desc,
+				 NO_OS_I3C_BCAST_ADDR,
+				 NO_OS_I3C_CCC_RSTACT_BCAST, &data);
+	if (ret)
+		goto error_bus_2;
+	/* Set I3C devices that support static addresses to use them */
+	if (has_static_i3c_addr) {
+		ret = no_os_i3c_send_ccc(bus_desc, NO_OS_I3C_BCAST_ADDR, NO_OS_I3C_CCC_SETAASA,
+					 NULL);
+		if (ret)
+			goto error_bus_2;
+	}
+
+	ret = no_os_i3c_do_daa(bus_desc, 1);
+	if (ret)
+		goto error_bus_2;
+
+	no_os_mutex_init(bus_desc->mutex);
+	*desc = bus_desc;
+
+	return 0;
+
+error_bus_2:
+	ret = param->platform_ops->i3c_ops_remove_bus(bus_desc);
+error_bus_1:
+	no_os_free(bus_desc);
+
+	return ret;
+}
+
+/**
+ * @brief Free the resources allocated by no_os_i3c_init().
+ * @param desc - The I3C device descriptor.
+ * @return 0 in case of success, error code otherwise.
+ */
+int no_os_i3c_remove(struct no_os_i3c_desc *desc)
+{
+	struct no_os_i3c_bus_desc *bus_desc;
+	struct no_os_i3c_desc **it;
+
+	if (!desc || !desc->platform_ops)
+		return -EINVAL;
+
+	if (!desc->platform_ops->i3c_ops_remove)
+		return -ENOSYS;
+
+	bus_desc = desc->bus;
+	it = bus_desc->devs;
+	while (it < bus_desc->devs + NO_OS_I3C_MAX_DEV_NUMBER) {
+		if (*it == desc)
+			*it = NULL;
+		it++;
+	}
+
+	/* Only error case is !desc */
+	desc->platform_ops->i3c_ops_remove(desc);
+	no_os_free(desc);
+
+	return 0;
+}
+
+/**
+ * @brief Free the resources allocated by no_os_i3c_init_bus.
+ * Must remove all devices first, if not, -EFAULT is returned.
+ * @param desc - The I3C bus descriptor.
+ * @return 0 in case of success, error code otherwise.
+ */
+int no_os_i3c_remove_bus(struct no_os_i3c_bus_desc *desc)
+{
+	struct no_os_i3c_desc **it;
+
+	if (!desc || !desc->platform_ops)
+		return -EINVAL;
+
+	if (!desc->platform_ops->i3c_ops_remove_bus)
+		return -ENOSYS;
+
+	/* Verify if all devices are removed */
+	for (it = desc->devs; it < desc->devs + NO_OS_I3C_MAX_DEV_NUMBER; it++) {
+		if (*it)
+			return -EFAULT;
+	}
+
+	no_os_mutex_remove(desc->mutex);
+
+	/* Only error case is !desc */
+	desc->platform_ops->i3c_ops_remove_bus(desc);
+
+	i3c_table[desc->device_id - 1] = NULL;
+	no_os_free(desc);
+
+	return 0;
+}
+
+/**
+ * @brief Do DAA to assign the dynamic addresses.
+ * @param desc - The I3C descriptor.
+ * @param rstdaa - Do RSTDAA CCC before the DAA.
+ * @return 0 in case of success, error code otherwise.
+ */
+int no_os_i3c_do_daa(struct no_os_i3c_bus_desc *desc, bool rstdaa)
+{
+	if (!desc || !desc->platform_ops)
+		return -EINVAL;
+
+	if (!desc->platform_ops->i3c_ops_do_daa)
+		return -ENOSYS;
+
+	return desc->platform_ops->i3c_ops_do_daa(desc, rstdaa);
+}
+
+/**
+ * @brief Send CCC, either to a device device or broadcast to all.
+ * @param desc - The I3C descriptor.
+ * @param addr - Device address or broadcast address.
+ * @param ccc - CCC RnW, CCC Length, CCC ID.
+ * @param data - The buffer with the transmitted/received data.
+ * @return 0 in case of success, error code otherwise.
+ */
+int no_os_i3c_send_ccc(struct no_os_i3c_bus_desc *desc,
+		       uint8_t addr,
+		       uint32_t ccc,
+		       uint8_t *data)
+{
+	int ret;
+
+	if (!desc || !desc->platform_ops)
+		return -EINVAL;
+
+	if (!desc->platform_ops->i3c_ops_send_ccc)
+		return -ENOSYS;
+
+	if ((NO_OS_I3C_CCC_GET_RNW(ccc) && addr == NO_OS_I3C_BCAST_ADDR) ||
+	    ((addr == NO_OS_I3C_BCAST_ADDR) && (ccc & NO_OS_I3C_CCC_DIRECT)) ||
+	    ((addr != NO_OS_I3C_BCAST_ADDR) && !(ccc & NO_OS_I3C_CCC_DIRECT)))
+		return -EINVAL;
+
+	no_os_mutex_lock(desc->mutex);
+	ret = desc->platform_ops->i3c_ops_send_ccc(desc, addr, NO_OS_I3C_CCC_ADDR(ccc),
+			NO_OS_I3C_CCC_GET_RNW(ccc), NO_OS_I3C_CCC_GET_DEF(ccc),
+			data, NO_OS_I3C_CCC_GET_LEN(ccc));
+	no_os_mutex_unlock(desc->mutex);
+
+	return ret;
+}
+
+/**
+ * @brief Send CCC to device device.
+ * @param desc - The I3C descriptor.
+ * @param ccc - CCC RnW, CCC length, CCC id.
+ * @param data - The buffer with the transmitted/received data.
+ * @return 0 in case of success, error code otherwise.
+ */
+int no_os_i3c_send_direct_ccc(struct no_os_i3c_desc *desc,
+			      uint32_t ccc,
+			      uint8_t *data)
+{
+	if (!desc || !desc->bus)
+		return -EINVAL;
+	if (!(ccc & NO_OS_I3C_CCC_DIRECT))
+		return -EINVAL;
+
+	return no_os_i3c_send_ccc(desc->bus, desc->addr, ccc, data);
+}
+
+/**
+ * @brief Write data to device device.
+ * @param desc - The I3C descriptor.
+ * @param data - The buffer with the transmitted data.
+ * @param size - Number of bytes to write.
+ * @return 0 in case of success, error code otherwise.
+ */
+int no_os_i3c_write(struct no_os_i3c_desc *desc,
+		    uint8_t *data,
+		    uint8_t size)
+{
+	int ret;
+
+	if (!desc || !desc->platform_ops)
+		return -EINVAL;
+
+	if (!desc->platform_ops->i3c_ops_write)
+		return -ENOSYS;
+
+	no_os_mutex_lock(desc->bus->mutex);
+	ret = desc->bus->platform_ops->i3c_ops_write(desc,
+			data, size);
+	no_os_mutex_unlock(desc->bus->mutex);
+
+	return ret;
+}
+
+/**
+ * @brief Read data from device device.
+ * @param desc - The I3C descriptor.
+ * @param data - The buffer with the received data.
+ * @param size - Number of bytes to read.
+ * @return 0 in case of success, error code otherwise.
+ */
+int no_os_i3c_read(struct no_os_i3c_desc *desc,
+		   uint8_t *data,
+		   uint8_t size)
+{
+	int ret;
+
+	if (!desc || !desc->platform_ops)
+		return -EINVAL;
+
+	if (!desc->platform_ops->i3c_ops_read)
+		return -ENOSYS;
+
+	no_os_mutex_lock(desc->bus->mutex);
+	ret = desc->bus->platform_ops->i3c_ops_read(desc,
+			data, size);
+	no_os_mutex_unlock(desc->bus->mutex);
+
+	return ret;
+}
+
+/**
+ * @brief Read and write the device.
+ * @param desc - The I3C descriptor.
+ * @param tx_data - The buffer with the transmitted data.
+ * @param tx_data_len - Number of bytes to write.
+ * @param rx_data - The buffer with the received data.
+ * @param rx_data_len - Number of bytes to read.
+ * @return 0 in case of success, -1 otherwise.
+ */
+int no_os_i3c_write_and_read(struct no_os_i3c_desc *desc,
+			     uint8_t *tx_data,
+			     uint8_t tx_data_len,
+			     uint8_t *rx_data,
+			     uint8_t rx_data_len)
+{
+	int ret;
+
+	if (!desc || !desc->platform_ops)
+		return -EINVAL;
+
+	if (!desc->platform_ops->i3c_ops_read)
+		return -ENOSYS;
+
+	no_os_mutex_lock(desc->bus->mutex);
+	ret = desc->bus->platform_ops->i3c_ops_write_and_read(desc,
+			tx_data, tx_data_len, rx_data, rx_data_len);
+	no_os_mutex_unlock(desc->bus->mutex);
+
+	return ret;
+}
+
+/**
+ * @brief Configure I3C interrupts.
+ * @param desc - The I3C descriptor.
+ * @param irq - The interrupt type to enable.
+ * @param en - 1 to enable, 0 to disable irq type.
+ * @return 0 in case of success, -1 otherwise.
+ */
+int no_os_i3c_conf_irq(struct no_os_i3c_bus_desc *desc,
+		       uint8_t irq, bool en)
+{
+	if (!desc || !desc->platform_ops)
+		return -EINVAL;
+
+	if (!desc->platform_ops->i3c_ops_conf_irq)
+		return -ENOSYS;
+
+	return desc->platform_ops->i3c_ops_conf_irq(desc, irq, en);
+}
+
+/**
+ * @brief Enable I3C non-blocking interrupts.
+ * @param desc - The I3C descriptor.
+ * @param en - 1 to enable, 0 to disable async callback.
+ * @return 0 in case of success, -EINVAL otherwise.
+ */
+int no_os_i3c_async_irq(struct no_os_i3c_bus_desc *desc, bool en)
+{
+	if (!desc)
+		return -EINVAL;
+
+	desc->async_irq = en;
+	return 0;
+}
+
+/**
+ * @brief Wait I3C interrupt.
+ * Set async_irq on call to false to ensure single entry point.
+ * @param desc - The I3C descriptor.
+ * @param irq - The interrupt to wait for.
+ * @return 0 in case of success, -EINVAL if in async mode or error codes.
+ */
+int no_os_i3c_wait_irq(struct no_os_i3c_bus_desc* desc,
+		       uint8_t irq)
+{
+	if (!desc || desc->async_irq)
+		return -EINVAL;
+
+	while (!(desc->irq_events & irq)) {}
+
+	return no_os_i3c_call_irq(desc);
+}
+
+/**
+ * @brief Non-blocking I3C interrupt.
+ * Since a payload is always retrieved with it, also update the no_os_i3c_ccc_info fields.
+ * @param desc - The I3C descriptor.
+ * @return 0 in case of success, error code otherwise.
+ */
+int no_os_i3c_call_irq(struct no_os_i3c_bus_desc* desc)
+{
+	struct no_os_i3c_desc **it;
+	int ret;
+
+	if (!desc || !desc->platform_ops)
+		return -EINVAL;
+
+	if (!desc->platform_ops->i3c_ops_get_ccc_info)
+		return -ENOSYS;
+
+	ret = desc->platform_ops->i3c_ops_get_ccc_info(desc, desc->irq_events);
+	if (ret)
+		return ret;
+
+	it = desc->devs;
+	while (it < desc->devs + NO_OS_I3C_MAX_DEV_NUMBER) {
+		if (*it && (*it)->addr == desc->ccc_info.ibi_cr_addr) {
+			if ((*it)->event_callback) {
+				(*it)->event_callback((*it), desc->ccc_info.ibi_payload,
+						      desc->ccc_info.ibi_payload_len);
+			}
+			break;
+		}
+		it++;
+	};
+
+	return ret;
+}
+
+/**
+ * @brief Get a free address.
+ * @param desc - The I3C bus descriptor.
+ * @param start_addr - Start address to search from.
+ * @return The free address or 0 if no address is available.
+ */
+uint8_t no_os_i3c_addr_get_free(struct no_os_i3c_bus_desc *desc,
+				uint8_t start_addr)
+{
+	enum no_os_i3c_slot_status status;
+	uint8_t addr;
+
+	for (addr = start_addr; addr < NO_OS_I3C_MAX_ADDR; addr++) {
+		status = no_os_i3c_addr_get_status(desc, addr);
+		if (status == NO_OS_I3C_ADDR_SLOT_FREE)
+			return addr;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Set status of an address.
+ * @param desc - The I3C bus descriptor.
+ * @param addr - The address to set.
+ * @param status - The value to write.
+ */
+void no_os_i3c_addr_set_status(struct no_os_i3c_bus_desc *desc,
+			       uint8_t addr, enum no_os_i3c_slot_status status)
+{
+	unsigned int slot, bitpos;
+	unsigned int *ptr;
+
+	if (addr > NO_OS_I3C_I2C_MAX_ADDR)
+		return;
+
+	slot = NO_OS_I3C_ADDR_GET_SLOT(addr);
+	bitpos = NO_OS_I3C_ADDR_GET_POS(addr);
+
+	ptr = desc->addrslots + slot;
+	// Unset old value
+	*ptr &= ~(NO_OS_I3C_ADDR_SLOT_STATUS_MASK << bitpos);
+	// Set new value
+	*ptr |= (status & NO_OS_I3C_ADDR_SLOT_STATUS_MASK) << bitpos;
+}
+
+/**
+ * @brief Get status of an address.
+ * @param desc - The I3C bus descriptor.
+ * @param start_addr - Start address to search from.
+ * @return The free address or -ENOMEM if no available address.
+ */
+static enum no_os_i3c_slot_status no_os_i3c_addr_get_status(
+	struct no_os_i3c_bus_desc *desc, uint8_t addr)
+{
+	unsigned int slot, bitpos;
+	enum no_os_i3c_slot_status status;
+
+	if (addr > NO_OS_I3C_I2C_MAX_ADDR)
+		return NO_OS_I3C_ADDR_SLOT_RSVD;
+
+	slot = NO_OS_I3C_ADDR_GET_SLOT(addr);
+	bitpos = NO_OS_I3C_ADDR_GET_POS(addr);
+
+	status = desc->addrslots[slot];
+	status >>= bitpos;
+
+	return status & NO_OS_I3C_ADDR_SLOT_STATUS_MASK;
+}
+
+/**
+ * @brief Check if address is available.
+ * @param desc - The I3C bus descriptor.
+ * @param addr - Address to check.
+ * @return 1 if available, 0 if not.
+ */
+static bool no_os_i3c_addr_is_avail(struct no_os_i3c_bus_desc *desc,
+				    uint8_t addr)
+{
+	enum no_os_i3c_slot_status status;
+
+	status = no_os_i3c_addr_get_status(desc, addr);
+
+	return status == NO_OS_I3C_ADDR_SLOT_FREE;
+}
+
+/**
+ * @brief Initialize address buffer, reserving reserved addresses.
+ * @param desc - The I3C bus descriptor.
+ */
+static void no_os_i3c_addr_init(struct no_os_i3c_bus_desc *desc)
+{
+	/* Addresses 0 to 7 are reserved. */
+	for (int i = 0; i < 8; i++)
+		no_os_i3c_addr_set_status(desc, i, NO_OS_I3C_ADDR_SLOT_RSVD);
+
+	/*
+	 * Reserve broadcast address and all addresses that might collide
+	 * with the broadcast address when facing a single bit error.
+	 */
+	no_os_i3c_addr_set_status(desc, NO_OS_I3C_BCAST_ADDR,
+				  NO_OS_I3C_ADDR_SLOT_RSVD);
+	for (int i = 0; i < 7; i++)
+		no_os_i3c_addr_set_status(desc, NO_OS_I3C_BCAST_ADDR ^ NO_OS_BIT(i),
+					  NO_OS_I3C_ADDR_SLOT_RSVD);
+}
+
+/**
+ * @brief Attach event callback.
+ * @param desc - The I3C device descriptor.
+ * @param callback - Method to call on event.
+ */
+void no_os_i3c_attach_callback(struct no_os_i3c_desc *desc,
+			       void (*callback)(struct no_os_i3c_desc*, uint32_t, uint32_t))
+{
+	desc->event_callback = callback;
+}
+
+/**
+ * @brief Detach event callback.
+ * @param desc - The I3C device descriptor.
+ */
+void no_os_i3c_detach_callback(struct no_os_i3c_desc *desc)
+{
+	no_os_i3c_attach_callback(desc, NULL);
+}

--- a/drivers/platform/stm32/stm32_i3c.c
+++ b/drivers/platform/stm32/stm32_i3c.c
@@ -1,0 +1,747 @@
+/***************************************************************************//**
+ *   @file   stm32/stm32_i3c.c
+ *   @brief  Implementation of stm32 I3C driver.
+ *   @author Jorge Marques (jorge.marques@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include "no_os_util.h"
+#include "no_os_alloc.h"
+#include "no_os_i3c.h"
+#include "stm32_i3c.h"
+
+static int32_t stm32_i3c_config_extra(struct no_os_i3c_desc *desc,
+				      struct stm32_i3c_device_desc *xdesc);
+static inline void stm32_i3c_find_i3c_table(I3C_HandleTypeDef *hi3c,
+		struct no_os_i3c_bus_desc **iter);
+static inline int32_t stm32_i3c_wait_ready(I3C_HandleTypeDef *hi3c);
+
+/**
+ * @brief I3C target request a dynamic address callback.
+ * When called, assigns a dynamic address to the target.
+ * @param hi3c - Pointer to an I3C_HandleTypeDef structure that contains the
+ * configuration information for the specified I3C.
+ * @param targetPayload - The {BCR, DCR, PID} yielded by the device during
+ * the DAA.
+ */
+void HAL_I3C_TgtReqDynamicAddrCallback(I3C_HandleTypeDef *hi3c,
+				       uint64_t targetPayload)
+{
+	uint8_t addr;
+	uint64_t pid;
+	struct no_os_i3c_bus_desc *it;
+	uint8_t i, j;
+
+	no_os_memswap64(&targetPayload, sizeof(targetPayload), sizeof(targetPayload));
+	pid = STM32_I3C_TP_PID(targetPayload);
+
+	stm32_i3c_find_i3c_table(hi3c, &it);
+	if (!it)
+		return;
+
+	/* Search for device with pid */
+	for (i = 0 ; i < NO_OS_I3C_MAX_DEV_NUMBER; i++) {
+		if (pid == it->daa_candidates[i].pid)
+			break;
+	}
+
+	if (i == NO_OS_I3C_MAX_DEV_NUMBER) {
+		/* Device is unknown */
+		/* No error handling, #free_addr >> #devs_on_bus */
+		addr = no_os_i3c_addr_get_free(it, 8);
+		if (HAL_I3C_Ctrl_SetDynAddr(hi3c, addr) != HAL_OK)
+			return;
+		j = (it)->num_devs_unknown;
+		(it)->daa_unknown[j].pid = pid;
+		(it)->daa_unknown[j].addr = addr;
+		(it)->daa_unknown[j].is_attached = 1;
+		if (j < NO_OS_I3C_MAX_DEV_NUMBER - 1)
+			(it)->num_devs_unknown++;
+	} else {
+		/* Device is known */
+		addr = (it)->daa_candidates[i].addr;
+		if (HAL_I3C_Ctrl_SetDynAddr(hi3c, addr) != HAL_OK)
+			return;
+		(it)->daa_candidates[i].is_attached = 1;
+	}
+
+	/* Send associated dynamic address */
+	no_os_i3c_addr_set_status(it, addr, NO_OS_I3C_ADDR_SLOT_I3C_DEV);
+
+	/* Don't store BCR and DCR, device_desc may not be initialized */
+}
+
+/**
+ * @brief Controller dynamic address assignment Complete callback.
+ * @param hi3c - Pointer to an I3C_HandleTypeDef structure that contains the
+ * configuration information for the specified I3C.
+ */
+void HAL_I3C_CtrlDAACpltCallback(I3C_HandleTypeDef *hi3c) {}
+/**
+ * @brief Controller Transmit Complete callback.
+ * @param hi3c - Pointer to an I3C_HandleTypeDef structure that contains the
+ * configuration information for the specified I3C.
+ */
+void HAL_I3C_CtrlTxCpltCallback(I3C_HandleTypeDef *hi3c) {}
+
+/**
+ * @brief Controller Reception Complete callback.
+ * @param hi3c - Pointer to an I3C_HandleTypeDef structure that contains the
+ * configuration information for the specified I3C.
+ */
+void HAL_I3C_CtrlRxCpltCallback(I3C_HandleTypeDef *hi3c) {}
+
+/*
+ * @brief Error callback.
+ * @param hi3c - Pointer to an I3C_HandleTypeDef structure that contains the
+ * configuration information for the specified I3C.
+ */
+void HAL_I3C_ErrorCallback(I3C_HandleTypeDef *hi3c) {}
+
+/*
+ * @brief When the multiple transfer of CCC, I3C private or I2C transfer is
+ * completed callback.
+ * @param hi3c - Pointer to an I3C_HandleTypeDef structure that contains the
+ * configuration information for the specified I3C.
+ */
+void HAL_I3C_CtrlMultipleXferCpltCallback(I3C_HandleTypeDef *hi3c) {}
+
+/*
+ * @brief Callback for asynchronous events, like IBI and Hot-join.
+ * @param hi3c - Pointer to an I3C_HandleTypeDef structure that contains the
+ * configuration information for the specified I3C.
+ * @param eventId - Event identifier.
+ */
+void HAL_I3C_NotifyCallback(I3C_HandleTypeDef *hi3c, uint32_t eventId)
+{
+	struct no_os_i3c_bus_desc *it;
+
+	stm32_i3c_find_i3c_table(hi3c, &it);
+	if (!it)
+		return;
+
+	if ((eventId & EVENT_ID_IBI) == EVENT_ID_IBI)
+		it->irq_events |= NO_OS_I3C_IRQ_IBI;
+	if ((eventId & EVENT_ID_HJ) == EVENT_ID_HJ)
+		it->irq_events |= NO_OS_I3C_IRQ_HJ;
+	if ((eventId & EVENT_ID_CR) == EVENT_ID_CR)
+		it->irq_events |= NO_OS_I3C_IRQ_CR;
+
+	if (it->async_irq)
+		no_os_i3c_call_irq(it);
+
+	return;
+}
+
+/**
+ * @brief Initialize the I3C device.
+ * @param desc - The I3C device descriptor.
+ * @param param - The structure that contains the I3C parameters (unused).
+ * @return 0 in case of success, error code otherwise.
+ */
+int stm32_i3c_init(struct no_os_i3c_desc *desc,
+		   const struct no_os_i3c_init_param *param)
+{
+	struct stm32_i3c_device_desc *xdesc;
+
+	if (!desc)
+		return -EINVAL;
+
+	xdesc = (struct stm32_i3c_device_desc *)no_os_calloc(1,
+			sizeof(struct stm32_i3c_device_desc));
+	if (!xdesc)
+		return -ENOMEM;
+
+	if (stm32_i3c_config_extra(desc, xdesc)) {
+		no_os_free(xdesc);
+		return -EIO;
+	}
+
+	desc->extra = xdesc;
+
+	return 0;
+}
+
+/**
+ * @brief Initialize the I3C bus.
+ * @param desc - The I3C bus descriptor.
+ * @param param - The structure that contains the I3C parameters.
+ * @return 0 in case of success, error code otherwise.
+ */
+int stm32_i3c_init_bus(struct no_os_i3c_bus_desc *desc,
+		       const struct no_os_i3c_bus_init_param *param)
+{
+	struct stm32_i3c_init_param *bus_init;
+	struct stm32_i3c_bus_desc *xdesc;
+
+	if (!desc || !param)
+		return -EINVAL;
+
+	switch (param->device_id) {
+#if defined(I3C1)
+	case 1:
+		break;
+#endif
+#if defined(I3C2)
+	case 2:
+		break;
+#endif
+#if defined(I3C3)
+	case 3:
+		break;
+#endif
+	default:
+		return -EINVAL;
+	};
+
+	xdesc = (struct stm32_i3c_bus_desc *)no_os_calloc(1,
+			sizeof(struct stm32_i3c_bus_desc));
+	if (!xdesc)
+		return -ENOMEM;
+
+	bus_init = param->extra;
+	xdesc->hi3c = bus_init->hi3c;
+	desc->extra = xdesc;
+
+	return 0;
+}
+
+/**
+ * @brief Do I3C DAA to assign the dynamic addresses.
+ * @param desc - The I3C bus descriptor.
+ * @param rstdaa - Unassigned the DA of devices already assigned.
+ * @return 0 in case of success, error code otherwise.
+ */
+int stm32_i3c_do_daa(struct no_os_i3c_bus_desc *desc, bool rstdaa)
+{
+	struct stm32_i3c_bus_desc *xdesc;
+
+	if (!desc || !desc->extra)
+		return -EINVAL;
+
+	xdesc = desc->extra;
+	if (HAL_I3C_Ctrl_DynAddrAssign_IT(xdesc->hi3c,
+					  rstdaa ? I3C_RSTDAA_THEN_ENTDAA : I3C_ONLY_ENTDAA) != HAL_OK)
+		return -EIO;
+
+	/*
+	 * Wait DAA to finish.
+	 */
+	while (HAL_I3C_GetState(xdesc->hi3c) != HAL_I3C_STATE_READY) {}
+
+	return 0;
+}
+
+/**
+ * @brief Free the resources allocated by stm32_i3c_init().
+ * @param desc - The I3C  device descriptor.
+ * @return 0 in case of success, -EINVAL otherwise.
+ */
+int stm32_i3c_remove(struct no_os_i3c_desc *desc)
+{
+	if (!desc)
+		return -EINVAL;
+
+	if (desc->extra) {
+		no_os_free(desc->extra);
+		desc->extra = NULL;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Deinit I3C bus and free resources allocated by stm32_i3c_init_bus().
+ * @param desc - The I3C  bus descriptor.
+ * @return 0 in case of success, -EINVAL otherwise.
+ */
+int stm32_i3c_remove_bus(struct no_os_i3c_bus_desc *desc)
+{
+	struct stm32_i3c_bus_desc *xdesc;
+
+	if (!desc)
+		return -EINVAL;
+
+	if (desc->extra) {
+		xdesc = desc->extra;
+		HAL_I3C_DeInit(xdesc->hi3c);
+		no_os_free(desc->extra);
+		desc->extra = NULL;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Send CCC as bus.
+ * Retrieve data is only valid for unicast commands.
+ * Multi frames are not supported such as:
+ * * Read CCCs with a defining bytes.
+ * @param desc - The I3C descriptor.
+ * @param addr - Address to send to.
+ * @param id - CCC ID.
+ * @param rnw - True if the CCC should retrieve data from the device.
+ * @param defining - Contain defining byte.
+ * @param data - The buffer with the data to transmit.
+ * @param size - Number of bytes in the buffer.
+ * @return 0 in case of success, error code otherwise.
+ */
+int stm32_i3c_send_ccc(struct no_os_i3c_bus_desc *desc,
+		       uint8_t addr,
+		       uint8_t id,
+		       bool rnw,
+		       bool defining,
+		       uint8_t *data,
+		       uint8_t size)
+{
+	int ret;
+	struct stm32_i3c_bus_desc *xdesc;
+	bool bcast;
+	uint32_t option;
+	/* Buffers are filled by the HAL. */
+	/* CtrlBuf size requirements:
+	 * Direct CCC: CtrlBuf.Size >= 2*#frames
+	 * Broadcast CCC: CtrlBuf.Size >= #frames
+	 */
+	uint32_t ctrl_buffer[2];
+	uint8_t tx_buffer[0xF];
+	uint8_t rx_buffer[0xF];
+
+	if (size > sizeof(rx_buffer) / sizeof(uint8_t))
+		return -ENOMEM;
+	/* Dual frames not implemented */
+	if (rnw & defining)
+		return -EOPNOTSUPP;
+
+	bcast = addr == NO_OS_I3C_BCAST_ADDR;
+
+	I3C_CCCTypeDef ccc_descriptor = {
+		/* TargetAddr, CCC Value */
+		(bcast ? 0 : addr), id,
+		/* {CCC data + defbyte pointer, CCC size + defining} */
+		{rnw ? NULL : data, size + defining},
+		/* Direction */
+		(rnw ? HAL_I3C_DIRECTION_READ : HAL_I3C_DIRECTION_WRITE)
+	};
+
+	if (!desc || !desc->extra || !data)
+		return -EINVAL;
+
+	xdesc = desc->extra;
+	xdesc->xfer.CtrlBuf.pBuffer = ctrl_buffer;
+	xdesc->xfer.CtrlBuf.Size = sizeof(ctrl_buffer) / sizeof(uint32_t);
+	/*
+	 * Rx/TxBuf.Size is the sum of all I3C_CCCTypeDef {CCC size + byte}.
+	 */
+	xdesc->xfer.RxBuf.pBuffer = rx_buffer;
+	xdesc->xfer.TxBuf.pBuffer = tx_buffer;
+	if (rnw) {
+		xdesc->xfer.TxBuf.Size = 0;
+		xdesc->xfer.RxBuf.Size = size;
+	} else {
+		xdesc->xfer.TxBuf.Size = size + defining;
+		xdesc->xfer.RxBuf.Size = 0;
+	}
+
+	if (defining) {
+		option = (bcast ? I3C_BROADCAST_WITH_DEFBYTE_STOP :
+			  I3C_DIRECT_WITH_DEFBYTE_STOP);
+	} else {
+		option = (bcast ? I3C_BROADCAST_WITHOUT_DEFBYTE_STOP :
+			  I3C_DIRECT_WITHOUT_DEFBYTE_STOP);
+	}
+	if (HAL_I3C_AddDescToFrame(xdesc->hi3c,
+				   &ccc_descriptor,
+				   NULL,
+				   &xdesc->xfer,
+				   1,
+				   option
+				  ) != HAL_OK)
+		return -EIO;
+
+	if (rnw) {
+		while (HAL_I3C_Ctrl_ReceiveCCC_IT(xdesc->hi3c, &xdesc->xfer) != HAL_OK) {}
+	} else {
+		while (HAL_I3C_Ctrl_TransmitCCC_IT(xdesc->hi3c, &xdesc->xfer) != HAL_OK) {}
+	}
+
+	ret = stm32_i3c_wait_ready(xdesc->hi3c);
+	if (ret)
+		return ret;
+
+	/* If receive, copy read value */
+	if (rnw) memcpy(data, rx_buffer, size);
+
+	return 0;
+}
+
+/**
+ * @brief I3C private write transaction as bus.
+ * @param desc - The I3C descriptor.
+ * @param data - The buffer with the data to transmit.
+ * @param data_len - Number of bytes in the buffer.
+ * @return 0 in case of success, -EINVAL or -EIO otherwise.
+ */
+int stm32_i3c_write(struct no_os_i3c_desc *desc,
+		    uint8_t *data,
+		    uint8_t data_len)
+{
+	struct stm32_i3c_bus_desc *xdesc;
+	I3C_ControlTypeDef ctrl_buffer;
+	I3C_PrivateTypeDef private_descriptor = {
+		desc->addr, {data, data_len}, {NULL, 0}, HAL_I3C_DIRECTION_WRITE
+	};
+
+	if (!desc || !desc->bus || !desc->bus->extra || !data)
+		return -EINVAL;
+
+	xdesc = desc->bus->extra;
+	xdesc->xfer.CtrlBuf.pBuffer = (uint32_t *)&ctrl_buffer;
+	xdesc->xfer.CtrlBuf.Size = 1;
+	xdesc->xfer.TxBuf.pBuffer = data;
+	xdesc->xfer.TxBuf.Size = data_len;
+
+	if (HAL_I3C_AddDescToFrame(xdesc->hi3c,
+				   NULL,
+				   &private_descriptor,
+				   &xdesc->xfer,
+				   xdesc->xfer.CtrlBuf.Size,
+				   desc->is_i3c ?
+				   I3C_PRIVATE_WITHOUT_ARB_RESTART : I2C_PRIVATE_WITHOUT_ARB_RESTART
+				  ) != HAL_OK)
+		return -EIO;
+
+	if (HAL_I3C_Ctrl_Transmit_IT(xdesc->hi3c, &xdesc->xfer) != HAL_OK)
+		return -EIO;
+
+	return stm32_i3c_wait_ready(xdesc->hi3c);
+}
+
+/**
+ * @brief I3C private read transaction as bus.
+ * @param desc - The I3C descriptor.
+ * @param data - The buffer where received data is to be stored.
+ * @param data_len - Number of bytes to receive.
+ * @return 0 in case of success, -EINVAL or -EIO otherwise.
+ */
+int stm32_i3c_read(struct no_os_i3c_desc *desc,
+		   uint8_t *data,
+		   uint8_t data_len)
+{
+	struct stm32_i3c_bus_desc *xdesc;
+	I3C_ControlTypeDef ctrl_buffer;
+	I3C_PrivateTypeDef private_descriptor = {desc->addr, {NULL, 0}, {data, data_len}, HAL_I3C_DIRECTION_READ};
+
+	if (!desc || !desc->bus || !desc->bus->extra || !data)
+		return -EINVAL;
+
+	xdesc = desc->bus->extra;
+	xdesc->xfer.CtrlBuf.pBuffer = (uint32_t *)&ctrl_buffer;
+	xdesc->xfer.CtrlBuf.Size = 1;
+	xdesc->xfer.RxBuf.pBuffer = data;
+	xdesc->xfer.RxBuf.Size = data_len;
+
+	if (HAL_I3C_AddDescToFrame(xdesc->hi3c,
+				   NULL,
+				   &private_descriptor,
+				   &xdesc->xfer,
+				   xdesc->xfer.CtrlBuf.Size,
+				   desc->is_i3c ?
+				   I3C_PRIVATE_WITHOUT_ARB_RESTART : I2C_PRIVATE_WITHOUT_ARB_RESTART
+				  ) != HAL_OK)
+		return -EIO;
+
+	if (HAL_I3C_Ctrl_Receive_IT(xdesc->hi3c, &xdesc->xfer) != HAL_OK)
+		return -EIO;
+
+	return stm32_i3c_wait_ready(xdesc->hi3c);
+}
+
+/**
+ * @brief I3C private write and read transaction as bus.
+ * @param desc - The I3C descriptor.
+ * @param tx_data - The buffer with the transmitted data.
+ * @param tx_data_len - Number of bytes to write.
+ * @param rx_data - The buffer with the received data.
+ * @param rx_data_len - Number of bytes to read.
+ * @return 0 in case of success, -EINVAL or -EIO otherwise.
+ */
+int stm32_i3c_write_and_read(struct no_os_i3c_desc *desc,
+			     uint8_t *tx_data,
+			     uint8_t tx_data_len,
+			     uint8_t *rx_data,
+			     uint8_t rx_data_len)
+{
+	struct stm32_i3c_bus_desc *xdesc;
+	I3C_ControlTypeDef ctrl_buffer;
+	I3C_PrivateTypeDef private_descriptor = {desc->addr, {tx_data, tx_data_len}, {rx_data, rx_data_len}, HAL_I3C_DIRECTION_BOTH};
+
+	if (!desc || !desc->bus || !desc->bus->extra || !tx_data || !rx_data)
+		return -EINVAL;
+
+	xdesc = desc->bus->extra;
+	xdesc->xfer.CtrlBuf.pBuffer = (uint32_t *)&ctrl_buffer;
+	xdesc->xfer.CtrlBuf.Size = 1;
+	xdesc->xfer.TxBuf.pBuffer = tx_data;
+	xdesc->xfer.TxBuf.Size = tx_data_len;
+	xdesc->xfer.RxBuf.pBuffer = rx_data;
+	xdesc->xfer.RxBuf.Size = rx_data_len;
+
+	if (HAL_I3C_AddDescToFrame(xdesc->hi3c,
+				   NULL,
+				   &private_descriptor,
+				   &xdesc->xfer,
+				   xdesc->xfer.CtrlBuf.Size,
+				   desc->is_i3c ?
+				   I3C_PRIVATE_WITHOUT_ARB_STOP : I2C_PRIVATE_WITHOUT_ARB_STOP
+				  ) != HAL_OK)
+		return -EIO;
+
+	if (HAL_I3C_Ctrl_Receive_IT(xdesc->hi3c, &xdesc->xfer) != HAL_OK)
+		return -EIO;
+
+	return stm32_i3c_wait_ready(xdesc->hi3c);
+}
+
+/**
+ * @brief Check if I3C device is ready.
+ * @param desc - The I3C descriptor.
+ * @return 0 in case of success, -EIO in case of error.
+ */
+int stm32_i3c_is_dev_ready(struct no_os_i3c_desc* desc)
+{
+	struct stm32_i3c_bus_desc *xdesc;
+
+	if (!desc || !desc->bus || !desc->bus->extra)
+		return -EINVAL;
+
+	xdesc = desc->bus->extra;
+	if (HAL_I3C_Ctrl_IsDeviceI3C_Ready(xdesc->hi3c, desc->addr, 300,
+					   1000) != HAL_OK)
+		return -EIO;
+	return 0;
+}
+
+/**
+ * @brief Configure I3C interrupts.
+ * @param desc - The I3C descriptor.
+ * @param irq - The interrupt type to enable/disable.
+ * @param en - 1 to enable, 0 to disable irq type.
+ * @return 0 in case of success, error code otherwise.
+ */
+int stm32_i3c_conf_irq(struct no_os_i3c_bus_desc* desc,
+		       uint8_t irq, bool en)
+{
+	struct stm32_i3c_bus_desc *xdesc;
+	uint32_t value;
+
+	if (!desc || !desc->extra)
+		return -EINVAL;
+
+	switch (irq) {
+	case NO_OS_I3C_IRQ_IBI:
+		value = HAL_I3C_IT_IBIIE;
+		break;
+	case NO_OS_I3C_IRQ_HJ:
+		value = HAL_I3C_IT_HJIE;
+		break;
+	case NO_OS_I3C_IRQ_CR:
+		value = HAL_I3C_IT_CRIE;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	xdesc = desc->extra;
+	if (en) {
+		if (HAL_I3C_ActivateNotification(xdesc->hi3c, NULL, value) != HAL_OK)
+			return -EIO;
+	} else {
+		if (HAL_I3C_DeactivateNotification(xdesc->hi3c, value) != HAL_OK)
+			return -EIO;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Update I3C CCC info.
+ * @param desc - The I3C descriptor.
+ * @param irq - The interrupt type to update the field.
+ * @return 0 in case of success, error code otherwise.
+ */
+int stm32_i3c_get_ccc_info(struct no_os_i3c_bus_desc* desc,
+			   uint8_t irq)
+{
+	struct stm32_i3c_bus_desc *xdesc;
+	uint32_t event;
+
+	switch (irq) {
+	case NO_OS_I3C_IRQ_IBI:
+		event = EVENT_ID_IBI;
+		break;
+	case NO_OS_I3C_IRQ_HJ:
+		event = EVENT_ID_CR;
+		break;
+	case NO_OS_I3C_IRQ_CR:
+		event = EVENT_ID_HJ;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	xdesc = desc->extra;
+	if (HAL_I3C_GetCCCInfo(xdesc->hi3c, event, &xdesc->ccc_info) != HAL_OK)
+		return -EIO;
+
+	desc->ccc_info.ibi_cr_addr = xdesc->ccc_info.IBICRTgtAddr;
+	desc->ccc_info.ibi_payload_len = xdesc->ccc_info.IBITgtNbPayload;
+	desc->ccc_info.ibi_payload = xdesc->ccc_info.IBITgtPayload;
+
+	desc->irq_events &= ~irq;
+
+	return 0;
+}
+
+/**
+ * @brief Configure the bus according the new device.
+ * @param desc - The I3C device descriptor.
+ * @return 0 in case of success, error code otherwise.
+ */
+static int32_t stm32_i3c_config_extra(struct no_os_i3c_desc *desc,
+				      struct stm32_i3c_device_desc *xdesc)
+{
+	int ret = 0;
+	I3C_DeviceConfTypeDef *dev_conf;
+	struct stm32_i3c_bus_desc *mxdesc;
+	struct no_os_i3c_desc **it;
+	uint8_t dev_index = 0;
+	uint8_t bcr;
+
+	if (!desc->is_i3c)
+		return 0;
+
+	/* Get BCR info */
+	ret = no_os_i3c_send_direct_ccc(desc, NO_OS_I3C_CCC_GETBCR, &bcr);
+	if (ret)
+		return ret;
+
+	/* DeviceIndex is array position + 1, since 0 is the controller */
+	it = desc->bus->devs;
+	for (; it < desc->bus->devs + NO_OS_I3C_MAX_DEV_NUMBER; it++, dev_index++) {
+		if (!*it)
+			continue;
+		if (*it == desc)
+			break;
+	};
+	dev_conf = &(xdesc->dev_conf);
+	dev_conf->DeviceIndex        = dev_index + 1;
+	dev_conf->TargetDynamicAddr  = desc->addr;
+	dev_conf->IBIAck             = NO_OS_I3C_BCR_IBI_REQUEST_CAPABLE(bcr);
+	dev_conf->IBIPayload         = NO_OS_I3C_BCR_IBI_PAYLOAD(bcr);
+	dev_conf->CtrlRoleReqAck     = NO_OS_I3C_BCR_DEVICE_ROLE(bcr);
+	dev_conf->CtrlStopTransfer   = DISABLE;
+
+	mxdesc = desc->bus->extra;
+	if (HAL_I3C_Ctrl_ConfigBusDevices(mxdesc->hi3c, dev_conf, 1U) != HAL_OK)
+		return -EIO;
+
+	return 0;
+}
+
+/**
+ * @brief Search for no_os_i3c_bus_desc by matching I3C_HandleTypeDef.
+ * @param hi3c - The STM32 I3C bus descriptor.
+ * @param iter - Iterator to store the I3C bus descriptor, NULL if not found.
+ */
+static inline void stm32_i3c_find_i3c_table(I3C_HandleTypeDef *hi3c,
+		struct no_os_i3c_bus_desc **iter)
+{
+	struct stm32_i3c_bus_desc *sdesc;
+	struct no_os_i3c_bus_desc **it;
+	/*
+	 * Find bus that triggered
+	 */
+	for (it = i3c_table; it < i3c_table + NO_OS_I3C_MAX_BUS_NUMBER; it++) {
+		if (!*it)
+			continue;
+
+		sdesc = (*it)->extra;
+		if (sdesc->hi3c == hi3c) {
+			*iter = *it;
+			return;
+		}
+	}
+	*iter = NULL;
+};
+
+/**
+ * @brief Halt execution until the I3C controller go to ready or error state.
+ * @param hi3c - The STM32 I3C bus descriptor.
+ * @return 0 on success and -EIO in case of error.
+ */
+static inline int32_t stm32_i3c_wait_ready(I3C_HandleTypeDef *hi3c)
+{
+	uint8_t state;
+
+	state = HAL_I3C_GetState(hi3c);
+	while (state != HAL_I3C_STATE_READY &&
+	       state != HAL_I3C_STATE_LISTEN &&
+	       state != HAL_I3C_STATE_ERROR) {
+		state = HAL_I3C_GetState(hi3c);
+	}
+
+	return state == HAL_I3C_STATE_ERROR ? -EIO : 0;
+};
+
+/**
+ * @brief stm32 platform specific I3C platform ops structure.
+ */
+const struct no_os_i3c_platform_ops stm32_i3c_ops = {
+	.i3c_ops_init_bus = &stm32_i3c_init_bus,
+	.i3c_ops_init = &stm32_i3c_init,
+	.i3c_ops_do_daa = &stm32_i3c_do_daa,
+	.i3c_ops_send_ccc = &stm32_i3c_send_ccc,
+	.i3c_ops_write = &stm32_i3c_write,
+	.i3c_ops_read = &stm32_i3c_read,
+	.i3c_ops_write_and_read = &stm32_i3c_write_and_read,
+	.i3c_ops_remove_bus = &stm32_i3c_remove_bus,
+	.i3c_ops_remove = &stm32_i3c_remove,
+	.i3c_ops_is_dev_ready = &stm32_i3c_is_dev_ready,
+	.i3c_ops_conf_irq = &stm32_i3c_conf_irq,
+	.i3c_ops_get_ccc_info = &stm32_i3c_get_ccc_info,
+};

--- a/drivers/platform/stm32/stm32_i3c.h
+++ b/drivers/platform/stm32/stm32_i3c.h
@@ -1,0 +1,89 @@
+/***************************************************************************//**
+ *   @file   stm32/stm32_i3c.h
+ *   @brief  Header file for the stm32 I3C driver.
+ *   @author Jorge Marques (jorge.marques@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef STM32_I3C_H_
+#define STM32_I3C_H_
+
+#include <stdint.h>
+#include "no_os_i3c.h"
+#include "stm32_hal.h"
+
+#define STM32_I3C_TP_PID(x)	(x >> 16)
+
+/**
+ * @struct stm32_i3c_bus_desc
+ * @brief STM32 platform specific I3C bus descriptor.
+ */
+struct stm32_i3c_bus_desc {
+	/** I3C instance */
+	I3C_HandleTypeDef *hi3c;
+	/** I3C context buffer */
+	I3C_XferTypeDef xfer;
+	/** I3C CCC info */
+	I3C_CCCInfoTypeDef ccc_info;
+};
+
+/**
+ * @struct stm32_i3c_device_desc
+ * @brief STM32 platform specific I3C device descriptor.
+ */
+struct stm32_i3c_device_desc {
+	/** I3C device configuration */
+	I3C_DeviceConfTypeDef dev_conf;
+};
+
+/**
+ * @struct stm32_i3c_init_param
+ * @brief Structure holding the initialization parameters I3C bus.
+ */
+struct stm32_i3c_init_param {
+	/** I3C instance */
+	I3C_HandleTypeDef *hi3c;
+};
+
+/**
+ * @brief i3c_table contains the pointers towards the I3C buses.
+ */
+extern struct no_os_i3c_bus_desc *i3c_table [];
+
+/**
+ * @brief STM32 specific I3C platform ops structure.
+ */
+extern const struct no_os_i3c_platform_ops stm32_i3c_ops;
+
+#endif // STM32_I3C_H_

--- a/include/no_os_i3c.h
+++ b/include/no_os_i3c.h
@@ -1,0 +1,411 @@
+/***************************************************************************//**
+ *   @file   no_os_i3c.h
+ *   @brief  Header file of I3C Interface
+ *   @author Jorge Marques (jorge.marques@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *  - Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *  - The use of this software may or may not infringe the patent rights
+ *    of one or more patent holders.  This license does not release you
+ *    from the requirement that you obtain separate licenses from these
+ *    patent holders to use this software.
+ *  - Use of the software either in source or binary form, must be run
+ *    on or directly connected to an Analog Devices Inc. component.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, NON-INFRINGEMENT,
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL ANALOG DEVICES BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, INTELLECTUAL PROPERTY RIGHTS, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef _NO_OS_I3C_H_
+#define _NO_OS_I3C_H_
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include <stdint.h>
+#include "no_os_util.h"
+
+/******************************************************************************/
+/********************** Macros and Constants Definitions **********************/
+/******************************************************************************/
+
+#define NO_OS_I3C_MAX_BUS_NUMBER	3
+#define NO_OS_I3C_MAX_DEV_NUMBER	15
+/* I²C/I3C address are 7-bit (not considering extended 10-bit I²C) */
+#define NO_OS_I3C_I2C_MAX_ADDR		0x7F
+#define NO_OS_I3C_MAX_ADDR		NO_OS_I3C_I2C_MAX_ADDR
+#define NO_OS_I3C_BCAST_ADDR		0x7E
+/* 2-bit flags packed in addrslots */
+#define NO_OS_I3C_ADDR_FLAG_SIZE	2
+#define NO_OS_I3C_ADDR_PER_SLOT		((unsigned int)(sizeof(unsigned int)*8 / NO_OS_I3C_ADDR_FLAG_SIZE))
+#define NO_OS_I3C_ADDR_GET_SLOT(x)	((x) / NO_OS_I3C_ADDR_PER_SLOT)
+#define NO_OS_I3C_ADDR_GET_POS(x)	(((x) % NO_OS_I3C_ADDR_PER_SLOT) * NO_OS_I3C_ADDR_FLAG_SIZE)
+#define NO_OS_I3C_ADDRSLOTS_SIZE	\
+	(NO_OS_I3C_I2C_MAX_ADDR / NO_OS_I3C_ADDR_PER_SLOT) + !!(NO_OS_I3C_I2C_MAX_ADDR % NO_OS_I3C_ADDR_PER_SLOT)
+
+/* I3C CCC (Common Command Codes) related definitions */
+#define NO_OS_I3C_CCC_BCAST		0
+#define NO_OS_I3C_CCC_DIRECT		NO_OS_BIT(7)
+
+#define NO_OS_I3C_CCC_ID(id, type)	((id) | (type))
+
+#define NO_OS_I3C_CCC_ADDR(x)		((x) & 0xFF)
+#define NO_OS_I3C_CCC_GET_LEN(x)	(((x) >> 8) & 0x0000FF)
+#define NO_OS_I3C_CCC_SET_LEN(x)	(((x) << 8) & 0x00FF00)
+#define NO_OS_I3C_CCC_GET_DEF(x)	(((x) >> 17) & NO_OS_BIT(0))
+#define NO_OS_I3C_CCC_SET_DEF   	NO_OS_BIT(17)
+#define NO_OS_I3C_CCC_GET_RNW(x)	(((x) >> 16) & NO_OS_BIT(0))
+#define NO_OS_I3C_CCC_SET_RNW(x)	(((x) << 16) & NO_OS_BIT(16))
+
+/**
+ * Commands valid in both broadcast and direct modes
+ * type: NO_OS_I3C_CCC_DIRECT, NO_OS_I3C_CCC_BCAST
+ */
+#define NO_OS_I3C_CCC_ENEC_DIRECT	0x80 | NO_OS_I3C_CCC_SET_LEN(1)
+#define NO_OS_I3C_CCC_DISEC_DIRECT	0x81 | NO_OS_I3C_CCC_SET_LEN(1)
+#define NO_OS_I3C_CCC_ENEC_BCAST	0x00 | NO_OS_I3C_CCC_SET_DEF
+#define NO_OS_I3C_CCC_DISEC_BCAST	0x01 | NO_OS_I3C_CCC_SET_DEF
+#define NO_OS_I3C_CCC_ENTAS(as, type)	NO_OS_I3C_CCC_ID((0x2 + (as)), (type))
+#define NO_OS_I3C_CCC_RSTDAA(type)	NO_OS_I3C_CCC_ID(0x6, (type))
+#define NO_OS_I3C_CCC_SETMWL(type)	NO_OS_I3C_CCC_ID(0x9, (type)) | NO_OS_I3C_CCC_SET_LEN(2)
+#define NO_OS_I3C_CCC_SETMRL(type)	NO_OS_I3C_CCC_ID(0xa, (type)) | NO_OS_I3C_CCC_SET_LEN(2)
+#define NO_OS_I3C_CCC_SETXTIME_BCAST	0x28 | NO_OS_I3C_CCC_SET_DEF
+#define NO_OS_I3C_CCC_SETXTIME_DIRECT	0x98 | NO_OS_I3C_CCC_SET_DEF
+#define NO_OS_I3C_CCC_RSTACT_BCAST	0x2a | NO_OS_I3C_CCC_SET_DEF
+#define NO_OS_I3C_CCC_RSTACT_DIRECT	0x9a | NO_OS_I3C_CCC_SET_DEF
+#define NO_OS_I3C_CCC_RSTACT_I3C_ONLY	    0x1
+#define NO_OS_I3C_CCC_RSTACT_WHOLE_TARGET   0x2
+
+/* Broadcast-only commands */
+#define NO_OS_I3C_CCC_ENTDAA		NO_OS_I3C_CCC_ID(0x7, NO_OS_I3C_CCC_BCAST)
+#define NO_OS_I3C_CCC_DEFSLVS		NO_OS_I3C_CCC_ID(0x8, NO_OS_I3C_CCC_BCAST)
+#define NO_OS_I3C_CCC_ENTTM		NO_OS_I3C_CCC_ID(0xb, NO_OS_I3C_CCC_BCAST)
+#define NO_OS_I3C_CCC_ENTHDR(x)		NO_OS_I3C_CCC_ID((0x20 + (x)), NO_OS_I3C_CCC_BCAST)
+#define NO_OS_I3C_CCC_SETAASA		NO_OS_I3C_CCC_ID(0x29, NO_OS_I3C_CCC_BCAST)
+
+/* Unicast-only commands */
+#define NO_OS_I3C_CCC_SETDASA		NO_OS_I3C_CCC_ID(0x7, NO_OS_I3C_CCC_DIRECT)
+#define NO_OS_I3C_CCC_SETNEWDA		NO_OS_I3C_CCC_ID(0x8, NO_OS_I3C_CCC_DIRECT)
+#define NO_OS_I3C_CCC_GETMWL		NO_OS_I3C_CCC_ID(0xb, NO_OS_I3C_CCC_DIRECT)
+#define NO_OS_I3C_CCC_GETMRL		NO_OS_I3C_CCC_ID(0xc, NO_OS_I3C_CCC_DIRECT)
+#define NO_OS_I3C_CCC_GETPID		(NO_OS_I3C_CCC_ID(0xd, NO_OS_I3C_CCC_DIRECT) | NO_OS_I3C_CCC_SET_LEN(6) | NO_OS_I3C_CCC_SET_RNW(1))
+#define NO_OS_I3C_CCC_GETBCR		(NO_OS_I3C_CCC_ID(0xe, NO_OS_I3C_CCC_DIRECT) | NO_OS_I3C_CCC_SET_LEN(1) | NO_OS_I3C_CCC_SET_RNW(1))
+#define NO_OS_I3C_CCC_GETDCR		(NO_OS_I3C_CCC_ID(0xf, NO_OS_I3C_CCC_DIRECT) | NO_OS_I3C_CCC_SET_LEN(1) | NO_OS_I3C_CCC_SET_RNW(1))
+#define NO_OS_I3C_CCC_GETSTATUS		(NO_OS_I3C_CCC_ID(0x10, NO_OS_I3C_CCC_DIRECT) | NO_OS_I3C_CCC_SET_LEN(2) | NO_OS_I3C_CCC_SET_RNW(1))
+#define NO_OS_I3C_CCC_GETACCMST		NO_OS_I3C_CCC_ID(0x11, NO_OS_I3C_CCC_DIRECT)
+#define NO_OS_I3C_CCC_SETBRGTGT		NO_OS_I3C_CCC_ID(0x13, NO_OS_I3C_CCC_DIRECT)
+#define NO_OS_I3C_CCC_GETMXDS		NO_OS_I3C_CCC_ID(0x14, NO_OS_I3C_CCC_DIRECT)
+#define NO_OS_I3C_CCC_GETHDRCAP		NO_OS_I3C_CCC_ID(0x15, NO_OS_I3C_CCC_DIRECT)
+#define NO_OS_I3C_CCC_GETXTIME		NO_OS_I3C_CCC_ID(0x19, NO_OS_I3C_CCC_DIRECT)
+
+#define NO_OS_I3C_CCC_EVENT_SIR		NO_OS_BIT(0)
+#define NO_OS_I3C_CCC_EVENT_MR		NO_OS_BIT(1)
+#define NO_OS_I3C_CCC_EVENT_HJ		NO_OS_BIT(3)
+/**
+ * List of possible IRQ events.
+ */
+#define NO_OS_I3C_IRQ_IBI   0x1
+#define NO_OS_I3C_IRQ_HJ    0x2
+#define NO_OS_I3C_IRQ_CR    0x4
+/**
+ * Extract capabilities from BCR
+ */
+#define NO_OS_I3C_BCR_IBI_REQUEST_CAPABLE(bcr)    !!((bcr) & (1 << 1))
+#define NO_OS_I3C_BCR_IBI_PAYLOAD(bcr)            !!((bcr) & (1 << 2))
+#define NO_OS_I3C_BCR_DEVICE_ROLE(bcr)            (((bcr) && NO_OS_GENMASK(7,6)) >> 6)
+
+/**
+ * @enum no_os_i3c_slot_status - I3C address slot status
+ *
+ * @brief On an I3C bus, addresses are assigned dynamically, and we need to
+ * know which addresses are free to use and which ones are already assigned.
+ *
+ * Addresses marked as reserved are those reserved by the I3C protocol
+ * (broadcast address, ...).
+ */
+enum no_os_i3c_slot_status {
+	/** Address is free */
+	NO_OS_I3C_ADDR_SLOT_FREE,
+	/** Address is reserved */
+	NO_OS_I3C_ADDR_SLOT_RSVD,
+	/** Address is assigned to an I2C device */
+	NO_OS_I3C_ADDR_SLOT_I2C_DEV,
+	/** Address is assigned to an I3C device */
+	NO_OS_I3C_ADDR_SLOT_I3C_DEV,
+	/** Address slot mask */
+	NO_OS_I3C_ADDR_SLOT_STATUS_MASK = 3,
+};
+
+/**
+ * @union no_os_i3c_ccc_info
+ */
+struct no_os_i3c_ccc_info {
+	/** I3C bus receive Target Address during IBI or Bus Role Request event. */
+	uint32_t ibi_cr_addr;
+	/** I3C bus get Number of Data Payload after an IBI event. */
+	uint32_t ibi_payload_len;
+	/** I3C bus received IBI Payload. */
+	uint32_t ibi_payload;
+};
+
+/**
+ * @struct no_os_i3c_daa_lut
+ * @brief Stores the PID + DA information to look-up during the DAA.
+ * Should be used only for device initialization, since it may
+ * go outdated.
+ */
+struct no_os_i3c_daa_lut {
+	bool is_attached;
+	uint8_t addr;
+	uint64_t pid;
+};
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+
+/**
+ * @struct no_os_i3c_platform_ops
+ * @brief Structure holding I3C function pointers that point to the platform
+ * specific function.
+ */
+struct no_os_i3c_platform_ops;
+
+/**
+ * @struct no_os_i3c_bus_desc
+ * @brief Structure holding I3C bus descriptor.
+ */
+struct no_os_i3c_bus_desc {
+	/** I3C bus mutex(lock)*/
+	void*		mutex;
+	/** Device ID*/
+	uint8_t		device_id;
+	/** Non-Expected number of devices on bus */
+	uint8_t		num_devs_unknown;
+	/** Expected number of devices on bus */
+	uint8_t		num_devs;
+	/**
+	 * A bitmap with 2-bits per-slot to encode the address status and
+	 * ease the DAA (Dynamic Address Assignment) procedure (see
+	 * enum ::no_os_i3c_slot_status).
+	 */
+	unsigned int addrslots[NO_OS_I3C_ADDRSLOTS_SIZE];
+	/** PID + DA LUT for DAA procedure */
+	struct no_os_i3c_daa_lut    daa_candidates[NO_OS_I3C_MAX_DEV_NUMBER];
+	/** To store unknown devices assigned during DAA procedure */
+	struct no_os_i3c_daa_lut    daa_unknown[NO_OS_I3C_MAX_DEV_NUMBER];
+	/** Devices descriptors */
+	struct no_os_i3c_desc	*devs[NO_OS_I3C_MAX_DEV_NUMBER];
+	/** IRQ flags */
+	uint8_t irq_events;
+	/** CCC info obtained after an IRQ */
+	struct no_os_i3c_ccc_info	ccc_info;
+	/** Trigger IRQ callback asyncronous (non-blocking) */
+	bool                            async_irq;
+	/** I3C platform specific functions */
+	const struct no_os_i3c_platform_ops *platform_ops;
+	/** I3C bus extra parameters */
+	void		*extra;
+};
+
+/**
+ * @struct no_os_i3c_bus_init_param
+ * @brief Structure holding the parameters for I3C initialization.
+ */
+struct no_os_i3c_bus_init_param {
+	/** Device ID */
+	const uint32_t	device_id;
+	/** I3C platform specific functions */
+	const struct	no_os_i3c_platform_ops *platform_ops;
+	/** Expected number of devices on bus */
+	const uint8_t	num_devs;
+	/** Expected devices on bus */
+	const struct	no_os_i3c_init_param **devs;
+	/** I3C extra parameters (device specific) */
+	void		*extra;
+};
+
+/**
+ * @struct no_os_i3c_init_param
+ * @brief Structure holding the parameters for I3C initialization.
+ * Works like a device tree, the values are copied to no_os_i3c_desc
+ * during I3C initialization.
+ * Set is_static to 1 if the device provides a Static Address and is
+ * desired to use it instead of assigning a Dynamic Address during the
+ * DAA.
+ * is_i3c has higher precedence than is_static, and therefore
+ * is_static does not matter when is_i3c is 0.
+ */
+struct no_os_i3c_init_param {
+	/** Pointer to bus init param */
+	struct no_os_i3c_bus_init_param	*bus;
+	/** Provisioned ID */
+	uint64_t	pid;
+	/** Dynamic or static address */
+	uint8_t		addr;
+	/** Is the address static */
+	bool		is_static;
+	/** Is I3C or I2C */
+	bool		is_i3c;
+};
+
+/**
+ * @struct no_os_i3c_desc
+ * @brief Structure holding I3C device descriptor.
+ */
+struct no_os_i3c_desc {
+	/** Provisioned ID */
+	uint64_t	pid;
+	/** Dynamic or static address*/
+	uint8_t		addr;
+	/** Is I3C or I2C? */
+	bool		is_i3c;
+	/** Is attached? */
+	bool		is_attached;
+	/** Is the address static? */
+	bool		is_static;
+	/** I3C extra parameters (device specific) */
+	void		*extra;
+	/** Callback on event*/
+	void (*event_callback)(struct no_os_i3c_desc*, uint32_t, uint32_t);
+	/** I3C platform specific functions */
+	const struct no_os_i3c_platform_ops *platform_ops;
+	/** I3C bus */
+	struct no_os_i3c_bus_desc *bus;
+};
+
+/**
+ * @struct no_os_i3c_platform_ops
+ * @brief Structure holding I3C function pointers that point to the platform
+ * specific function.
+ */
+struct no_os_i3c_platform_ops {
+	/** I3C initialization function pointer */
+	int (*i3c_ops_init_bus)(struct no_os_i3c_bus_desc *,
+				const struct no_os_i3c_bus_init_param *);
+	/** I3C initialization function pointer */
+	int (*i3c_ops_init)(struct no_os_i3c_desc *,
+			    const struct no_os_i3c_init_param *);
+	/** I3C do daa function pointer */
+	int (*i3c_ops_do_daa)(struct no_os_i3c_bus_desc *, bool);
+	/** I3C send ccc function pointer */
+	int (*i3c_ops_send_ccc)(struct no_os_i3c_bus_desc *, uint8_t, uint8_t,
+				bool, bool, uint8_t *, uint8_t);
+	/** I3C private write function pointer */
+	int (*i3c_ops_write)(struct no_os_i3c_desc *, uint8_t *, uint8_t);
+	/** I3C private read function pointer */
+	int (*i3c_ops_read)(struct no_os_i3c_desc *, uint8_t *, uint8_t);
+	/** I3C private write and read function pointer */
+	int (*i3c_ops_write_and_read)(struct no_os_i3c_desc *, uint8_t *, uint8_t,
+				      uint8_t *, uint8_t);
+	/** I3C remove function pointer */
+	int (*i3c_ops_remove_bus)(struct no_os_i3c_bus_desc *);
+	/** I3C remove function pointer */
+	int (*i3c_ops_remove)(struct no_os_i3c_desc *);
+	/** I3C check is device on the bus is ready */
+	int (*i3c_ops_is_dev_ready)(struct no_os_i3c_desc *);
+	/** I3C configure the enabled irq */
+	int (*i3c_ops_conf_irq)(struct no_os_i3c_bus_desc *,
+				uint8_t, bool);
+	/** I3C fetch CCC info */
+	int (*i3c_ops_get_ccc_info)(struct no_os_i3c_bus_desc *,
+				    uint8_t);
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+/* Initialize the I3C device. */
+int no_os_i3c_init(struct no_os_i3c_desc **desc,
+		   const struct no_os_i3c_init_param *param);
+
+/* Initialize the I3C bus. */
+int no_os_i3c_init_bus(struct no_os_i3c_bus_desc **desc,
+		       const struct no_os_i3c_bus_init_param *param);
+
+/* Free the resources allocated by no_os_i3c_init. */
+int no_os_i3c_remove(struct no_os_i3c_desc *desc);
+
+/* Free the resources allocated by no_os_i3c_init_bus + no_os_i3c_init. */
+int no_os_i3c_remove_bus(struct no_os_i3c_bus_desc *desc);
+
+/* Do I3C DAA to assign the dynamic addresses. */
+int no_os_i3c_do_daa(struct no_os_i3c_bus_desc *desc, bool rstdaa);
+
+/* Send CCC on the bus (direct or broadcast). */
+int no_os_i3c_send_ccc(struct no_os_i3c_bus_desc *desc,
+		       uint8_t addr, uint32_t ccc, uint8_t *data);
+
+/* Send CCC to a device device. */
+int no_os_i3c_send_direct_ccc(struct no_os_i3c_desc *desc,
+			      uint32_t ccc, uint8_t *data);
+
+/* Write data to a device device. */
+int no_os_i3c_write(struct no_os_i3c_desc *desc,
+		    uint8_t *data,
+		    uint8_t size);
+
+/* Read data from a device device. */
+int no_os_i3c_read(struct no_os_i3c_desc *desc,
+		   uint8_t *data,
+		   uint8_t size);
+
+/* Write and read data from a device device. */
+int no_os_i3c_write_and_read(struct no_os_i3c_desc *desc,
+			     uint8_t *tx_data,
+			     uint8_t tx_data_len,
+			     uint8_t *rx_data,
+			     uint8_t rx_data_len);
+
+/* Configure enabled interrupt. */
+int no_os_i3c_conf_irq(struct no_os_i3c_bus_desc *desc,
+		       uint8_t irq, bool en);
+
+/* Wait I3C interrupt. */
+int no_os_i3c_wait_irq(struct no_os_i3c_bus_desc* desc,
+		       uint8_t irq);
+
+/* Non-blocking I3C interrupt. */
+int no_os_i3c_call_irq(struct no_os_i3c_bus_desc* desc);
+
+/* Enable I3C non-blocking interrupts. */
+int no_os_i3c_async_irq(struct no_os_i3c_bus_desc *desc, bool en);
+
+/* Get a free address. */
+uint8_t no_os_i3c_addr_get_free(struct no_os_i3c_bus_desc *desc,
+				uint8_t start_addr);
+
+/* Set status of an address. */
+void no_os_i3c_addr_set_status(struct no_os_i3c_bus_desc *desc,
+			       uint8_t addr, enum no_os_i3c_slot_status status);
+
+/* Attach event callback. */
+void no_os_i3c_attach_callback(struct no_os_i3c_desc *desc,
+			       void (*callback)(struct no_os_i3c_desc*, uint32_t, uint32_t));
+
+/* Detach event callback. */
+void no_os_i3c_detach_callback(struct no_os_i3c_desc *desc);
+
+#endif // _NO_OS_I3C_H_


### PR DESCRIPTION
## Pull Request Description

Some new boards from STM32 add a new protocol called I3C.
This pr adds an I3C API layer and STM32 I3C platform implementation.
This resource from STM32 gives a good overview on the protocol:
https://www.st.com/resource/en/application_note/an5879-introduction-to-i3c-for-stm32-mcus-stmicroelectronics.pdf
The specification is available at:
https://www.mipi.org/mipi-i3c-hci-download

The API was tested on the following boards:
nucleo-h503rb (mainly) nucleo-h563zi
focusing on the transactions and IBI feature

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [X] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [X] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [X] I have performed a self-review of the changes
- [X] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [X] I have tested in hardware affected projects, at the relevant boards
- [X] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
