### PR TITLE
Dev/ade7978

### DIFF
--- a/drivers/meter/ade7978/ade7978.c
+++ b/drivers/meter/ade7978/ade7978.c
@@ -1,0 +1,554 @@
+/***************************************************************************//**
+ *   @file   ade7978.c
+ *   @brief  Implementation of ADE7978 Driver.
+ *   @author REtz (radu.etz@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <stdlib.h>
+#include <errno.h>
+#include "ade7978.h"
+#include "no_os_delay.h"
+#include "no_os_units.h"
+#include "no_os_alloc.h"
+
+/**
+ * @brief Read device register.
+ * @param dev - The device structure.
+ * @param reg_addr - The register address.
+ * @param reg_data - The data read from the register.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7978_read(struct ade7978_dev *dev, uint16_t reg_addr, uint32_t *reg_data)
+{
+	int ret;
+	/* data buffer large enough for 32 bits reg */
+	uint8_t buff[7] = { 0 };
+	/* register addres */
+	uint32_t addr;
+
+	if (!dev)
+		return -ENODEV;
+	if (!reg_data)
+		return -EINVAL;
+
+	buff[0] = ADE7978_SPI_READ_CMD;
+	no_os_put_unaligned_be16(reg_addr, &buff[1]);
+
+	/* 8 bits registers */
+	if (IS_8BITS_REG(reg_addr)) {
+		ret = no_os_spi_write_and_read(dev->spi_desc, buff, 4);
+		if (ret)
+			return ret;
+
+		*reg_data = buff[3];
+
+	} else if (IS_16BITS_REG(reg_addr)) {
+		/* 16 bits registers */
+		ret = no_os_spi_write_and_read(dev->spi_desc, buff, 5);
+		if (ret)
+			return ret;
+
+		*reg_data = no_os_get_unaligned_be16(&buff[3]);
+	} else {
+		/* 32 bits registers */
+		ret = no_os_spi_write_and_read(dev->spi_desc, buff, 7);
+		if (ret)
+			return ret;
+
+		*reg_data = no_os_get_unaligned_be32(&buff[3]);
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Write device register.
+ * @param dev- The device structure.
+ * @param reg_addr - The register address.
+ * @param reg_data - The data to be written.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7978_write(struct ade7978_dev *dev, uint16_t reg_addr, uint32_t reg_data)
+{
+	/* data buffer */
+	uint8_t buff[7] = { 0 };
+	int i;
+
+	if (!dev)
+		return -ENODEV;
+	/* write operation */
+	buff[0] = ADE7978_SPI_WRITE_CMD;
+	no_os_put_unaligned_be16(reg_addr, &buff[1]);
+
+	/* 8 bits registers */
+	if (IS_8BITS_REG(reg_addr)) {
+		buff[3] = (uint8_t)reg_data;
+
+		return no_os_spi_write_and_read(dev->spi_desc, buff, 4);
+	}
+
+	/* 16 bits registers */
+	if (IS_16BITS_REG(reg_addr)) {
+		no_os_put_unaligned_be16(reg_data, &buff[3]);
+
+		return no_os_spi_write_and_read(dev->spi_desc, buff, 5);
+	}
+
+	/* 32 bits registers */
+	no_os_put_unaligned_be32(reg_data, &buff[3]);
+
+	return no_os_spi_write_and_read(dev->spi_desc, buff, 7);
+}
+
+/**
+ * @brief Update specific register bits.
+ * @param dev - The device structure.
+ * @param reg_addr - The register address.
+ * @param mask - Specific bits mask.
+ * @param reg_data - The data to be written.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7978_update_bits(struct ade7978_dev *dev, uint16_t reg_addr,
+			uint32_t mask, uint32_t reg_data)
+{
+	int ret;
+	/* register value read */
+	uint32_t data;
+
+	ret = ade7978_read(dev, reg_addr, &data);
+	if (ret)
+		return ret;
+
+	data &= ~mask;
+	data |= reg_data & mask;
+
+	return ade7978_write(dev, reg_addr, data);
+}
+
+/**
+ * @brief Get interrupt indicator from STATUS0 register.
+ * @param dev - The device structure.
+ * @param msk - Interrupt mask.
+ * @param status - Status indicator.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7978_get_int_status0(struct ade7978_dev *dev, uint32_t msk,
+			    uint8_t *status)
+{
+	int ret;
+	/* register value read */
+	uint32_t reg_val;
+
+	if (!status)
+		return -EINVAL;
+
+	ret = ade7978_read(dev, ADE7978_REG_STATUS0, &reg_val);
+	if (ret)
+		return ret;
+
+	*status = no_os_test_bit(no_os_find_first_set_bit(msk), &reg_val);
+
+	return 0;
+}
+
+/**
+ * @brief Get interrupt indicator from STATUS1 register.
+ * @param dev - The device structure.
+ * @param msk - Interrupt mask.
+ * @param status - Status indicator.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7978_get_int_status1(struct ade7978_dev *dev, uint32_t msk,
+			    uint8_t *status)
+{
+	int ret;
+	/* register value read */
+	uint32_t reg_val;
+
+	if (!status)
+		return -EINVAL;
+
+	ret = ade7978_read(dev, ADE7978_REG_STATUS1, &reg_val);
+	if (ret)
+		return ret;
+
+	*status = no_os_test_bit(no_os_find_first_set_bit(msk), &reg_val);
+
+	return 0;
+}
+
+/**
+ * @brief Read the measurements for specific phase.
+ * @param dev - The device structure.
+ * @param phase - ADE7978 Phase.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7978_read_data_ph(struct ade7978_dev *dev, enum ade7978_phase phase)
+{
+	int ret;
+	/* register value */
+	uint32_t temp;
+	/* i rms phase register addr */
+	uint32_t irms_reg;
+	/* v rms phase register addr */
+	uint32_t vrms_reg;
+	/* v2 rms phase register addr */
+	uint32_t v2rms_reg;
+	/* temperature value for phase */
+	uint32_t temperature;
+	/* intermediate values used for computation */
+	uint64_t val_int;
+
+	if (!dev)
+		return -ENODEV;
+
+	/* select the phase for values read */
+	switch (phase) {
+	case ADE7978_PHASE_A:
+		irms_reg = ADE7978_REG_AIRMS;
+		vrms_reg = ADE7978_REG_AVRMS;
+		if (dev->temp_en)
+			temperature = ADE7978_REG_ATEMP;
+		else
+			v2rms_reg = ADE7978_REG_AV2RMS;
+		break;
+	case ADE7978_PHASE_B:
+		irms_reg = ADE7978_REG_BIRMS;
+		vrms_reg = ADE7978_REG_BVRMS;
+		if (dev->temp_en)
+			temperature = ADE7978_REG_BTEMP;
+		else
+			v2rms_reg = ADE7978_REG_BV2RMS;
+		break;
+	case ADE7978_PHASE_C:
+		irms_reg = ADE7978_REG_CIRMS;
+		vrms_reg = ADE7978_REG_CVRMS;
+		if (dev->temp_en)
+			temperature = ADE7978_REG_CTEMP;
+		else
+			v2rms_reg = ADE7978_REG_CV2RMS;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	ret = ade7978_read(dev, irms_reg, &temp);
+	if (ret)
+		return ret;
+	/* Current rms value in ADC code */
+	dev->irms_val = temp;
+
+	ret = ade7978_read(dev, vrms_reg, &temp);
+	if (ret)
+		return ret;
+	/* Voltage rms value in ADC code */
+	dev->vrms_val = temp;
+
+	if (dev->temp_en) {
+		ret = ade7978_read(dev, temperature, &temp);
+		if (ret)
+			return ret;
+		/* Temperature measurement in ADC code */
+		dev->temperature = temp;
+	} else {
+		ret = ade7978_read(dev, v2rms_reg, &temp);
+		if (ret)
+			return ret;
+		/* Voltage 2 rms value in ADC code */
+		dev->v2rms_val = temp;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Initialize the device.
+ * @param device - The device structure.
+ * @param init_param - The structure that contains the device initial
+ * 		       parameters.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7978_init(struct ade7978_dev **device,
+		 struct ade7978_init_param init_param)
+{
+	int ret;
+	/* device structure */
+	struct ade7978_dev *dev;
+	/* chip id read value */
+	uint32_t chip_id;
+	/* data read */
+	uint32_t data;
+
+	dev = (struct ade7978_dev *)no_os_calloc(1, sizeof(*dev));
+	if (!dev)
+		return -ENOMEM;
+
+	/* Hard reset the device */
+	if (!init_param.reset_desc) {
+		ret = - EINVAL;
+		goto error_dev;
+	}
+	dev->reset_desc = init_param.reset_desc;
+	ret = no_os_gpio_set_value(dev->reset_desc,
+				   NO_OS_GPIO_LOW);
+	if (ret)
+		goto error_dev;
+
+	/* delay reset */
+	no_os_mdelay(1);
+	ret = no_os_gpio_set_value(dev->reset_desc,
+				   NO_OS_GPIO_HIGH);
+	if (ret)
+		goto error_dev;
+
+	/* wait for device to initialize after hardware reset */
+	/* >= 100 ms see datasheet. */
+	no_os_mdelay(ADE7978_RESET_RECOVER);
+
+	/* SPI Initialization */
+	ret = no_os_spi_init(&dev->spi_desc, init_param.spi_init);
+	if (ret)
+		goto error_dev;
+
+	/* Select the SPI as the serial interface */
+	/* Execute three SPI writes to an unallocated address space -> see datasheet. */
+	for (int i = 0; i < 3; i++) {
+		ret = ade7978_write(dev, ADE7978_SET_SPI_ADDR, ADE7978_DUMB_VAL);
+		if (ret)
+			goto error_spi;
+	}
+
+	/* Check the rstdone bit */
+	do {
+		ret = ade7978_get_int_status1(dev, ADE7978_STATUS1_RSTDONE, &data);
+		if (ret)
+			goto error_spi;
+	} while (!data);
+
+	/* Temperature read enable/disable */
+	dev->temp_en = init_param.temp_en;
+
+	/* Reset status bits */
+	ret = ade7978_write(dev, ADE7978_REG_STATUS1, 0xFFFF);
+	if (ret)
+		goto error_spi;
+	ret = ade7978_write(dev, ADE7978_REG_STATUS1, 0xFFFF);
+	if (ret)
+		goto error_spi;
+
+	/* Lock the SPI port as active */
+	ret = ade7978_update_bits(dev, ADE7978_REG_CONFIG2, ADE7978_I2C_LOCK,
+				  no_os_field_prep(ADE7978_I2C_LOCK, ENABLE));
+	if (ret)
+		goto error_spi;
+
+	/* Use a valid register with default value different from 0 */
+	ret = ade7978_read(dev, ADE7978_REG_CFMODE, &chip_id);
+	if (ret)
+		goto error_spi;
+
+	if (chip_id != ADE7978_CHIP_ID) {
+		pr_err("Device ID error \n");
+		goto error_spi;
+	}
+
+	*device = dev;
+
+	return 0;
+
+error_spi:
+	no_os_spi_remove(dev->spi_desc);
+error_dev:
+	no_os_free(dev);
+
+	return ret;
+}
+
+/**
+ * @brief Setup the device.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7978_setup(struct ade7978_dev *dev)
+{
+	int ret;
+	/* data read */
+	uint32_t data;
+
+	/* Initialize the current gain registers */
+	ret = ade7978_write(dev, ADE7978_REG_AIGAIN, 0x0000);
+	if (ret)
+		return ret;
+	ret = ade7978_write(dev, ADE7978_REG_BIGAIN, 0x0000);
+	if (ret)
+		return ret;
+	ret = ade7978_write(dev, ADE7978_REG_CIGAIN, 0x0000);
+	if (ret)
+		return ret;
+	ret = ade7978_write(dev, ADE7978_REG_NIGAIN, 0x0000);
+	if (ret)
+		return ret;
+	/* Initialize here all the other data memory RAM registers. Write
+	the last register in the queue three times to ensure that its
+	value is written into the RAM*/
+	for (int i = 0; i < 3; i++) {
+		ret = ade7978_write(dev, ADE7978_REG_NIGAIN, 0x0000);
+		if (ret)
+			return ret;
+	}
+
+	/* Select frequency 50 Hz */
+	ret = ade7978_update_bits(dev, ADE7978_REG_COMPMODE, ADE7978_SELFREQ,
+				  no_os_field_prep(ADE7978_SELFREQ, ADE7978_SELFREQ_50));
+	if (ret)
+		return ret;
+
+	/* Enable DSP RAM protection */
+	ret = ade7978_write(dev, ADE7978_RAM_PROTECTION1, ADE7978_RAM_PROT_VAL1);
+	if (ret)
+		return ret;
+	ret = ade7978_write(dev, ADE7978_RAM_PROTECTION2, ADE7978_RAM_PROT_VAL2);
+	if (ret)
+		return ret;
+
+	/* Select the second voltage channel for temperature measurement
+	if temp_en active */
+	if (dev->temp_en) {
+		ret = ade7978_update_bits(dev, ADE7978_REG_CONFIG3, ADE7978_VA2_EN,
+					  no_os_field_prep(ADE7978_VA2_EN, DISABLE));
+		if (ret)
+			return ret;
+		ret = ade7978_update_bits(dev, ADE7978_REG_CONFIG3, ADE7978_VB2_EN,
+					  no_os_field_prep(ADE7978_VB2_EN, DISABLE));
+		if (ret)
+			return ret;
+		ret = ade7978_update_bits(dev, ADE7978_REG_CONFIG3, ADE7978_VC2_EN,
+					  no_os_field_prep(ADE7978_VC2_EN, DISABLE));
+		if (ret)
+			return ret;
+		ret = ade7978_update_bits(dev, ADE7978_REG_CONFIG3, ADE7978_VN2_EN,
+					  no_os_field_prep(ADE7978_VN2_EN, DISABLE));
+		if (ret)
+			return ret;
+	}
+
+	/* Dumb read of energy registers to erase their contents */
+	ret = ade7978_read(dev, ADE7978_REG_AWATTHR, &data);
+	if (ret)
+		return ret;
+	ret = ade7978_read(dev, ADE7978_REG_BWATTHR, &data);
+	if (ret)
+		return ret;
+	ret = ade7978_read(dev, ADE7978_REG_CWATTHR, &data);
+	if (ret)
+		return ret;
+	ret = ade7978_read(dev, ADE7978_REG_AVAHR, &data);
+	if (ret)
+		return ret;
+	ret = ade7978_read(dev, ADE7978_REG_BVAHR, &data);
+	if (ret)
+		return ret;
+	ret = ade7978_read(dev, ADE7978_REG_CVAHR, &data);
+	if (ret)
+		return ret;
+	ret = ade7978_read(dev, ADE7978_REG_AFWATTHR, &data);
+	if (ret)
+		return ret;
+	ret = ade7978_read(dev, ADE7978_REG_BFWATTHR, &data);
+	if (ret)
+		return ret;
+	ret = ade7978_read(dev, ADE7978_REG_CFWATTHR, &data);
+	if (ret)
+		return ret;
+	ret = ade7978_read(dev, ADE7978_REG_AFVARHR, &data);
+	if (ret)
+		return ret;
+	ret = ade7978_read(dev, ADE7978_REG_BFVARHR, &data);
+	if (ret)
+		return ret;
+	ret = ade7978_read(dev, ADE7978_REG_CFVARHR, &data);
+	if (ret)
+		return ret;
+	ret = ade7978_read(dev, ADE7978_REG_AVAHR, &data);
+	if (ret)
+		return ret;
+	ret = ade7978_read(dev, ADE7978_REG_BVAHR, &data);
+	if (ret)
+		return ret;
+	ret = ade7978_read(dev, ADE7978_REG_CVAHR, &data);
+	if (ret)
+		return ret;
+
+	/* Enable pulses at CF1, CF2, CF3 */
+	ret = ade7978_update_bits(dev, ADE7978_REG_CFMODE, ADE7978_CF1DIS,
+				  no_os_field_prep(ADE7978_CF1DIS, DISABLE));
+	if (ret)
+		return ret;
+	ret = ade7978_update_bits(dev, ADE7978_REG_CFMODE, ADE7978_CF2DIS,
+				  no_os_field_prep(ADE7978_CF2DIS, DISABLE));
+	if (ret)
+		return ret;
+	ret = ade7978_update_bits(dev, ADE7978_REG_CFMODE, ADE7978_CF3DIS,
+				  no_os_field_prep(ADE7978_CF3DIS, DISABLE));
+	if (ret)
+		return ret;
+
+	/* Enable the DSP */
+	ret = ade7978_write(dev, ADE7978_REG_RUN, ADE7978_RUN_ON);
+	if (ret)
+		return ret;
+
+	/* Clear reset done flag (int0 output becomes high) */
+	ade7978_update_bits(dev, ADE7978_REG_STATUS1, ADE7978_STATUS1_RSTDONE,
+			    no_os_field_prep(ADE7978_STATUS1_RSTDONE, ENABLE));
+	if (ret)
+		return ret;
+	/* Enable dready interrupt */
+	return ade7978_update_bits(dev, ADE7978_REG_MASK0, ADE7978_STATUS0_DREADY,
+				   no_os_field_prep(ADE7978_STATUS0_DREADY, ENABLE));
+}
+
+/**
+ * @brief Remove the device and release resources.
+ * @param dev - The device structure.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ade7978_remove(struct ade7978_dev *dev)
+{
+	int ret;
+
+	ret = no_os_spi_remove(dev->spi_desc);
+	if (ret)
+		return ret;
+
+	no_os_free(dev);
+
+	return 0;
+}

--- a/drivers/meter/ade7978/ade7978.h
+++ b/drivers/meter/ade7978/ade7978.h
@@ -1,0 +1,738 @@
+/***************************************************************************//**
+ *   @file   ade7978.h
+ *   @brief  Header file of ADE7978 Driver.
+ *   @author REtz (radu.etz@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __ADE7978_H__
+#define __ADE7978_H__
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include "no_os_util.h"
+#include "no_os_spi.h"
+#include "no_os_gpio.h"
+#include "no_os_print_log.h"
+
+/* SPI commands */
+#define ADE7978_SPI_READ_CMD        	0x01
+#define ADE7978_SPI_WRITE_CMD       	0x00
+
+#define ENABLE                  	0x0001
+#define DISABLE                 	0x0000
+
+/* ADE7978 Register Map */
+#define ADE7978_REG_AIGAIN		0x4380
+#define ADE7978_REG_AVGAIN		0x4381
+#define ADE7978_REG_AV2GAIN		0x4382
+#define ADE7978_REG_BIGAIN		0x4383
+#define ADE7978_REG_BVGAIN		0x4384
+#define ADE7978_REG_BV2GAIN		0x4385
+#define ADE7978_REG_CIGAIN		0x4386
+#define ADE7978_REG_CVGAIN		0x4387
+#define ADE7978_REG_CV2GAIN		0x4388
+#define ADE7978_REG_NIGAIN		0x4389
+#define ADE7978_REG_NVGAIN		0x438A
+#define ADE7978_REG_NV2GAIN		0x438B
+#define ADE7978_REG_AIRMSOS		0x438C
+#define ADE7978_REG_AVRMSOS		0x438D
+#define ADE7978_REG_AV2RMSOS		0x438E
+#define ADE7978_REG_BIRMSOS 		0x438F
+#define ADE7978_REG_BVRMSOS 		0x4390
+#define ADE7978_REG_BV2RMSOS		0x4391
+#define ADE7978_REG_CIRMSOS		0x4392
+#define ADE7978_REG_CVRMSOS		0x4393
+#define ADE7978_REG_CV2RMSOS 		0x4394
+#define ADE7978_REG_NIRMSOS 		0x4395
+#define ADE7978_REG_NVRMSOS 		0x4396
+#define ADE7978_REG_NV2RMSOS 		0x4397
+#define ADE7978_REG_ISUMLVL		0x4398
+#define ADE7978_REG_APGAIN		0x4399
+#define ADE7978_REG_BPGAIN		0x439A
+#define ADE7978_REG_CPGAIN		0x439B
+#define ADE7978_REG_AWATTOS		0x439C
+#define ADE7978_REG_BWATTOS		0x439D
+#define ADE7978_REG_CWATTOS		0x439E
+#define ADE7978_REG_AVAROS		0x439F
+#define ADE7978_REG_BVAROS		0x43A0
+#define ADE7978_REG_CVAROS		0x43A1
+#define ADE7978_REG_AFWATTOS		0x43A3
+#define ADE7978_REG_BFWATTOS		0x43A4
+#define ADE7978_REG_CFWATTOS		0x43A5
+#define ADE7978_REG_AFVAROS		0x43A6
+#define ADE7978_REG_BFVAROS     	0x43A7
+#define ADE7978_REG_CFVAROS		0x43A8
+#define ADE7978_REG_AFIRMSOS		0x43A9
+#define ADE7978_REG_BFIRMSOS		0x43AA
+#define ADE7978_REG_CFIRMSOS		0x43AB
+#define ADE7978_REG_AFVRMSOS		0x43AC
+#define ADE7978_REG_BFVRMSOS		0x43AD
+#define ADE7978_REG_CFVRMSOS		0x43AE
+#define ADE7978_REG_TEMPCO		0x43AF
+#define ADE7978_REG_ATEMP0		0x43B0
+#define ADE7978_REG_BTEMP0		0x43B1
+#define ADE7978_REG_CTEMP0 		0x43B2
+#define ADE7978_REG_NTEMPO		0x43B3
+#define ADE7978_REG_ATGAIN		0x43B4
+#define ADE7978_REG_BTGAIN		0x43B5
+#define ADE7978_REG_CTGAIN		0x43B6
+#define ADE7978_REG_NTGAIN		0x43B7
+#define ADE7978_REG_AIRMS		0x43C0
+#define ADE7978_REG_AVRMS		0x43C1
+#define ADE7978_REG_AV2RMS		0x43C2
+#define ADE7978_REG_BIRMS		0x43C3
+#define ADE7978_REG_BVRMS		0x43C4
+#define ADE7978_REG_BV2RMS		0x43C5
+#define ADE7978_REG_CIRMS		0x43C6
+#define ADE7978_REG_CVRMS		0x43C7
+#define ADE7978_REG_CV2RMS		0x43C8
+#define ADE7978_REG_NIRMS		0X43C9
+#define ADE7978_REG_ISUM		0X43CA
+#define ADE7978_REG_ATEMP		0X43CB
+#define ADE7978_REG_BTEMP		0X43CC
+#define ADE7978_REG_CTEMP		0X43CD
+#define ADE7978_REG_NTEMP		0X43CE
+
+/* Internal DSP memory RAM registers */
+#define ADE7978_REG_RUN			0xE228
+
+/* Billable registers */
+#define ADE7978_REG_AWATTHR		0xE400
+#define ADE7978_REG_BWATTHR		0xE401
+#define ADE7978_REG_CWATTHR		0xE402
+#define ADE7978_REG_AFWATTHR		0xE403
+#define ADE7978_REG_BFWATTHR		0xE404
+#define ADE7978_REG_CFWATTHR		0xE405
+#define ADE7978_REG_AVARHR		0xE406
+#define ADE7978_REG_BVARHR		0xE407
+#define ADE7978_REG_CVARHR		0xE408
+#define ADE7978_REG_AFVARHR		0xE409
+#define ADE7978_REG_BFVARHR		0xE40A
+#define ADE7978_REG_CFVARHR		0xE40B
+#define ADE7978_REG_AVAHR		0xE40C
+#define ADE7978_REG_BVAHR		0xE40D
+#define ADE7978_REG_CVAHR		0xE40E
+
+/* Configuration and PQ registers */
+#define ADE7978_REG_IPEAK		0xE500
+#define ADE7978_REG_VPEAK		0xE501
+#define ADE7978_REG_STATUS0		0xE502
+#define ADE7978_REG_STATUS1		0xE503
+#define ADE7978_REG_OILVL	 	0xE507
+#define ADE7978_REG_OVLVL	 	0xE508
+#define ADE7978_REG_SAGLVL	 	0xE509
+#define ADE7978_REG_MASK0	 	0xE50A
+#define ADE7978_REG_MASK1	 	0xE50B
+#define ADE7978_REG_IAWV	 	0xE50C
+#define ADE7978_REG_IBWV	 	0xE50D
+#define ADE7978_REG_ICWV	 	0xE50E
+#define ADE7978_REG_INWV	 	0xE50F
+#define ADE7978_REG_VAWV		0xE510
+#define ADE7978_REG_VBWV		0xE511
+#define ADE7978_REG_VCWV		0xE512
+#define ADE7978_REG_VA2WV		0xE513
+#define ADE7978_REG_VB2WV		0xE514
+#define ADE7978_REG_VC2WV		0xE515
+#define ADE7978_REG_VNWV		0xE516
+#define ADE7978_REG_VN2WV		0xE517
+#define ADE7978_REG_AWATT		0xE518
+#define ADE7978_REG_BWATT		0xE519
+#define ADE7978_REG_CWATT		0xE51A
+#define ADE7978_REG_AVAR	    	0xE51B
+#define ADE7978_REG_BVAR		0xE51C
+#define ADE7978_REG_CVAR		0xE51D
+#define ADE7978_REG_AVA			0xE51E
+#define ADE7978_REG_BVA			0xE51F
+#define ADE7978_REG_CVA			0xE520
+#define ADE7978_REG_AVTHD		0xE521
+#define ADE7978_REG_AITHD		0xE522
+#define ADE7978_REG_BVTHD		0xE523
+#define ADE7978_REG_BITHD		0xE524
+#define ADE7978_REG_CVTHD		0xE525
+#define ADE7978_REG_CITHD		0xE526
+#define ADE7978_REG_NVRMS		0xE530
+#define ADE7978_REG_NV2RMS		0xE531
+#define ADE7978_REG_CHECKSUM		0xE532
+#define ADE7978_REG_VNOM		0xE533
+#define ADE7978_REG_AFIRMS		0xE537
+#define ADE7978_REG_AFVRMS 		0xE538
+#define ADE7978_REG_BFIRMS		0xE539
+#define ADE7978_REG_BFVRMS		0xE53A
+#define ADE7978_REG_CFIRMS		0xE53B
+#define ADE7978_REG_CFVRMS		0xE53C
+#define ADE7978_REG_LAST_RWDATA32	0xE5FF
+#define ADE7978_REG_PHSTATUS		0xE600
+#define ADE7978_REG_ANGLE0		0xE601
+#define ADE7978_REG_ANGLE1		0xE602
+#define ADE7978_REG_ANGLE2		0xE603
+#define ADE7978_REG_PHNOLOAD		0xE608
+#define ADE7978_REG_LINECYC 		0xE60C
+#define ADE7978_REG_ZXTOUT		0xE60D
+#define ADE7978_REG_COMPMODE		0xE60E
+#define ADE7978_REG_CFMODE      	0xE610
+#define ADE7978_REG_CF1DEN		0xE611
+#define ADE7978_REG_CF2DEN		0xE612
+#define ADE7978_REG_CF3DEN		0xE613
+#define ADE7978_REG_APHCAL		0xE614
+#define ADE7978_REG_BPHCAL		0xE615
+#define ADE7978_REG_CPHCAL		0xE616
+#define ADE7978_REG_PHSIGN		0xE617
+#define ADE7978_REG_CONFIG		0xE618
+#define ADE7978_REG_MMODE		0xE700
+#define ADE7978_REG_ACCMODE		0xE701
+#define ADE7978_REG_LCYCMODE		0xE702
+#define ADE7978_REG_PEAKCYC		0xE703
+#define ADE7978_REG_SAGCYC		0xE704
+#define ADE7978_REG_CFCYC		0xE705
+#define ADE7978_REG_HSDC_CFG		0xE706
+#define ADE7978_REG_VERSION		0xE707
+#define ADE7978_REG_CONFIG3		0xE708
+#define ADE7978_REG_ATEMPOS		0xE709
+#define ADE7978_REG_BTEMPOS		0xE70A
+#define ADE7978_REG_CTEMPOS		0xE70B
+#define ADE7978_REG_NTEMPOS		0xE70C
+#define ADE7978_REG_LAST_RWDATA8    	0xE7FD
+#define ADE7978_REG_APF 		0xE902
+#define ADE7978_REG_BPF 		0xE903
+#define ADE7978_REG_CPF 		0xE904
+#define ADE7978_REG_APERIOD		0xE905
+#define ADE7978_REG_BPERIOD		0xE906
+#define ADE7978_REG_CPERIOD		0xE907
+#define ADE7978_REG_APNOLOAD		0xE908
+#define ADE7978_REG_VARNOLOAD		0xE909
+#define ADE7978_REG_VANOLOAD		0xE90A
+#define ADE7978_REG_LAST_ADD		0xE9FE
+#define ADE7978_REG_LAST_RWDATA16	0xE9FF
+#define ADE7978_REG_CONFIG2		0xEA00
+#define ADE7978_REG_LAST_OP		0xEA01
+#define ADE7978_REG_WTHR		0xEA02
+#define ADE7978_REG_VARTHR		0xEA03
+#define ADE7978_REG_VATHR		0xEA04
+
+/* ADE7978_REG_IPEAK Bit Definition */
+#define ADE7978_IPPHASE2		NO_OS_BIT(26)
+#define ADE7978_IPPHASE1		NO_OS_BIT(25)
+#define ADE7978_IPPHASE0		NO_OS_BIT(24)
+#define ADE7978_IPEAKVAL		NO_OS_GENMASK(23, 0)
+
+/* ADE7978_REG_VPEAK Bit Definition */
+#define ADE7978_VPPHASE2		NO_OS_BIT(26)
+#define ADE7978_VPPHASE1		NO_OS_BIT(25)
+#define ADE7978_VPPHASE0		NO_OS_BIT(24)
+#define ADE7978_VPEAKVAL		NO_OS_GENMASK(23, 0)
+
+/* ADE7978_REG_STATUS0 Bit Definition */
+#define ADE7978_STATUS0_REVPSUM3	NO_OS_BIT(18)
+#define ADE7978_STATUS0_DREADY		NO_OS_BIT(17)
+#define ADE7978_STATUS0_CF3		NO_OS_BIT(16)
+#define ADE7978_STATUS0_CF2		NO_OS_BIT(15)
+#define ADE7978_STATUS0_CF1		NO_OS_BIT(14)
+#define ADE7978_STATUS0_REVPSUM2	NO_OS_BIT(13)
+#define ADE7978_STATUS0_REVRPC		NO_OS_BIT(12)
+#define ADE7978_STATUS0_REVRPB 		NO_OS_BIT(11)
+#define ADE7978_STATUS0_REVRPA 		NO_OS_BIT(10)
+#define ADE7978_STATUS0_REVPSUM1 	NO_OS_BIT(9)
+#define ADE7978_STATUS0_REVAPC 		NO_OS_BIT(8)
+#define ADE7978_STATUS0_REVAPB 		NO_OS_BIT(7)
+#define ADE7978_STATUS0_REVAPA 		NO_OS_BIT(6)
+#define ADE7978_STATUS0_LENERGY 	NO_OS_BIT(5)
+#define ADE7978_STATUS0_VAEHF 		NO_OS_BIT(4)
+#define ADE7978_STATUS0_FREHF 		NO_OS_BIT(3)
+#define ADE7978_STATUS0_FAEHF 		NO_OS_BIT(1)
+#define ADE7978_STATUS0_AEHF 		NO_OS_BIT(0)
+
+/* ADE7978_REG_STATUS1 Bit Definition */
+#define ADE7978_STATUS1_CRC		NO_OS_BIT(25)
+#define ADE7978_STATUS1_PKV		NO_OS_BIT(24)
+#define ADE7978_STATUS1_PKI		NO_OS_BIT(23)
+#define ADE7978_STATUS1_MISMTCH		NO_OS_BIT(20)
+#define ADE7978_STATUS1_SEQERR		NO_OS_BIT(19)
+#define ADE7978_STATUS1_OV		NO_OS_BIT(18)
+#define ADE7978_STATUS1_OI		NO_OS_BIT(17)
+#define ADE7978_STATUS1_SAG		NO_OS_BIT(16)
+#define ADE7978_STATUS1_RSTDONE		NO_OS_BIT(15)
+#define ADE7978_STATUS1_ZXIC		NO_OS_BIT(14)
+#define ADE7978_STATUS1_ZXIB		NO_OS_BIT(13)
+#define ADE7978_STATUS1_ZXIA		NO_OS_BIT(12)
+#define ADE7978_STATUS1_ZXVC		NO_OS_BIT(11)
+#define ADE7978_STATUS1_ZXVB		NO_OS_BIT(10)
+#define ADE7978_STATUS1_ZXVA		NO_OS_BIT(9)
+#define ADE7978_STATUS1_ZXTOIC		NO_OS_BIT(8)
+#define ADE7978_STATUS1_ZXTOIB		NO_OS_BIT(7)
+#define ADE7978_STATUS1_ZXTOIA		NO_OS_BIT(6)
+#define ADE7978_STATUS1_ZXTOVC		NO_OS_BIT(5)
+#define ADE7978_STATUS1_ZXTOVB		NO_OS_BIT(4)
+#define ADE7978_STATUS1_ZXTOVA		NO_OS_BIT(3)
+#define ADE7978_STATUS1_VANLOAD		NO_OS_BIT(2)
+#define ADE7978_STATUS1_FNLOAD		NO_OS_BIT(1)
+#define ADE7978_STATUS1_NLOAD		NO_OS_BIT(0)
+
+/* ADE7978_REG_MASK0 Bit Definition */
+#define ADE7978_MASK0_HREADY		NO_OS_BIT(19)
+#define ADE7978_MASK0_REVPSUM3 		NO_OS_BIT(18)
+#define ADE7978_MASK0_DREADY		NO_OS_BIT(17)
+#define ADE7978_MASK0_CF3		NO_OS_BIT(16)
+#define ADE7978_MASK0_CF2		NO_OS_BIT(15)
+#define ADE7978_MASK0_CF1		NO_OS_BIT(14)
+#define ADE7978_MASK0_REVPSUM2		NO_OS_BIT(13)
+#define ADE7978_MASK0_REVFRPC		NO_OS_BIT(12)
+#define ADE7978_MASK0_REVFRPB		NO_OS_BIT(11)
+#define ADE7978_MASK0_REVFRPA		NO_OS_BIT(10)
+#define ADE7978_MASK0_REVPSUM1	 	NO_OS_BIT(9)
+#define ADE7978_MASK0_REVAPC		NO_OS_BIT(8)
+#define ADE7978_MASK0_REVAPB		NO_OS_BIT(7)
+#define ADE7978_MASK0_REVAPA		NO_OS_BIT(6)
+#define ADE7978_MASK0_LENERGY		NO_OS_BIT(5)
+#define ADE7978_MASK0_VAEHF		NO_OS_BIT(4)
+#define ADE7978_MASK0_FREHF		NO_OS_BIT(3)
+#define ADE7978_MASK0_REHF		NO_OS_BIT(2)
+#define ADE7978_MASK0_FAEHF		NO_OS_BIT(1)
+#define ADE7978_MASK0_AEHF		NO_OS_BIT(0)
+
+/* ADE7978_REG_MASK1 Bit Definition */
+#define ADE7978_MASK1_CRC		NO_OS_BIT(25)
+#define ADE7978_MASK1_PKV		NO_OS_BIT(24)
+#define ADE7978_MASK1_PKI		NO_OS_BIT(23)
+#define ADE7978_MASK1_MISMTCH		NO_OS_BIT(20)
+#define ADE7978_MASK1_SEQERR		NO_OS_BIT(19)
+#define ADE7978_MASK1_OV		NO_OS_BIT(18)
+#define ADE7978_MASK1_OI		NO_OS_BIT(17)
+#define ADE7978_MASK1_SAG		NO_OS_BIT(16)
+#define ADE7978_MASK1_RSTDONE		NO_OS_BIT(15)
+#define ADE7978_MASK1_ZXIC		NO_OS_BIT(14)
+#define ADE7978_MASK1_ZXIB		NO_OS_BIT(13)
+#define ADE7978_MASK1_ZXIA		NO_OS_BIT(12)
+#define ADE7978_MASK1_ZXVC 		NO_OS_BIT(11)
+#define ADE7978_MASK1_ZXVB		NO_OS_BIT(10)
+#define ADE7978_MASK1_ZXVA		NO_OS_BIT(9)
+#define ADE7978_MASK1_ZXTOIC		NO_OS_BIT(8)
+#define ADE7978_MASK1_ZXTOIB		NO_OS_BIT(7)
+#define ADE7978_MASK1_ZXTOIA		NO_OS_BIT(6)
+#define ADE7978_MASK1_ZXTOVC		NO_OS_BIT(5)
+#define ADE7978_MASK1_ZXTOVB		NO_OS_BIT(4)
+#define ADE7978_MASK1_ZXTOVA		NO_OS_BIT(3)
+#define ADE7978_MASK1_VANLOAD		NO_OS_BIT(2)
+#define ADE7978_MASK1_FNLOAD		NO_OS_BIT(1)
+#define ADE7978_MASK1_NLOAD		NO_OS_BIT(0)
+
+/* ADE7978_REG_PHSTATUS Bit Definition */
+#define ADE7978_VSPHASE2		NO_OS_BIT(14)
+#define ADE7978_VSPHASE1		NO_OS_BIT(13)
+#define ADE7978_VSPHASE0		NO_OS_BIT(12)
+#define ADE7978_OVPHASE2		NO_OS_BIT(11)
+#define ADE7978_OVPHASE1		NO_OS_BIT(10)
+#define ADE7978_OVPHASE0		NO_OS_BIT(9)
+#define ADE7978_OIPHASE2		NO_OS_BIT(5)
+#define ADE7978_OIPHASE1		NO_OS_BIT(4)
+#define ADE7978_OIPHASE0		NO_OS_BIT(3)
+
+/* ADE7978_REG_PHNOLOAD Bit Definition */
+#define ADE7978_VANLPHASE2		NO_OS_BIT(8)
+#define ADE7978_VANLPHASE1		NO_OS_BIT(7)
+#define ADE7978_VANLPHASE0		NO_OS_BIT(6)
+#define ADE7978_FNLPHASE2		NO_OS_BIT(5)
+#define ADE7978_FNLPHASE1		NO_OS_BIT(4)
+#define ADE7978_FNLPHASE0		NO_OS_BIT(3)
+#define ADE7978_NLPHASE2		NO_OS_BIT(2)
+#define ADE7978_NLPHASE1		NO_OS_BIT(1)
+#define ADE7978_NLPHASE0		NO_OS_BIT(0)
+
+/* ADE7978_REG_COMPMODE Bit Definition */
+#define ADE7978_SELFREQ			NO_OS_BIT(14)
+#define ADE7978_VNOMCEN			NO_OS_BIT(13)
+#define ADE7978_VNOMBEN			NO_OS_BIT(12)
+#define ADE7978_VNOMAEN			NO_OS_BIT(11)
+#define ADE7978_ANGLESEL		NO_OS_GENMASK(10, 9)
+#define ADE7978_TERMSEL3_2		NO_OS_BIT(8)
+#define ADE7978_TERMSEL3_1		NO_OS_BIT(7)
+#define ADE7978_TERMSEL3_0		NO_OS_BIT(6)
+#define ADE7978_TERMSEL2_2		NO_OS_BIT(5)
+#define ADE7978_TERMSEL2_1		NO_OS_BIT(4)
+#define ADE7978_TERMSEL2_0		NO_OS_BIT(3)
+#define ADE7978_TERMSEL1_2		NO_OS_BIT(2)
+#define ADE7978_TERMSEL1_1		NO_OS_BIT(1)
+#define ADE7978_TERMSEL1_0		NO_OS_BIT(0)
+
+/* ADE7978_REG_CFMODE Bit Definition */
+#define ADE7978_CF3LATCH		NO_OS_BIT(14)
+#define ADE7978_CF2LATCH		NO_OS_BIT(13)
+#define ADE7978_CF1LATCH		NO_OS_BIT(12)
+#define ADE7978_CF3DIS			NO_OS_BIT(11)
+#define ADE7978_CF2DIS			NO_OS_BIT(10)
+#define ADE7978_CF1DIS			NO_OS_BIT(9)
+#define ADE7978_CF3SEL			NO_OS_GENMASK(8, 6)
+#define ADE7978_CF2SEL			NO_OS_GENMASK(5, 3)
+#define ADE7978_CF1SEL			NO_OS_GENMASK(2, 0)
+
+/* ADE7978_REG_APHCAL, ADE7978_REG_BPHCAL,
+ADE7978_REG_CPHCAL, Bit Definition */
+#define ADE7978_PHCALVAL		NO_OS_GENMASK(9, 0)
+
+/* ADE7978_REG_PHSIGN Bit Definition */
+#define ADE7978_SUM3SIGN		NO_OS_BIT(8)
+#define ADE7978_SUM2SIGN		NO_OS_BIT(7)
+#define ADE7978_CVARSIGN		NO_OS_BIT(6)
+#define ADE7978_BVARSIGN		NO_OS_BIT(5)
+#define ADE7978_AVARSIGN		NO_OS_BIT(4)
+#define ADE7978_SUM1SIGN		NO_OS_BIT(3)
+#define ADE7978_CWSIGN			NO_OS_BIT(2)
+#define ADE7978_BWSIGN			NO_OS_BIT(1)
+#define ADE7978_AWSIGN			NO_OS_BIT(0)
+
+/* ADE7978_REG_CONFIG Bit Definition */
+#define ADE7978_INSEL           	NO_OS_BIT(14)
+#define ADE7978_VTOIC			NO_OS_GENMASK(13, 12)
+#define ADE7978_VTOIB			NO_OS_GENMASK(11, 10)
+#define ADE7978_VTOIA			NO_OS_GENMASK(9, 8)
+#define ADE7978_SWRST 			NO_OS_BIT(7)
+#define ADE7978_HSDCEN 			NO_OS_BIT(6)
+#define ADE7978_LPFSEL 		    	NO_OS_BIT(5)
+#define ADE7978_HPFEN 		    	NO_OS_BIT(4)
+#define ADE7978_SWAP 			NO_OS_BIT(3)
+#define ADE7978_ZX_DREADY		NO_OS_GENMASK(1, 0)
+
+/* ADE7978_REG_MMODE Bit Definition */
+#define ADE7978_PEAKSEL2		NO_OS_BIT(4)
+#define ADE7978_PEAKSEL1		NO_OS_BIT(3)
+#define ADE7978_PEAKSEL0		NO_OS_BIT(2)
+#define ADE7978_REVRPSEL        	NO_OS_BIT(1)
+#define ADE7978_REVAPSEL       		NO_OS_BIT(0)
+
+/* ADE7978_REG_ACCMODE Bit Definition */
+#define ADE7978_SAGCFG	 	    	NO_OS_BIT(6)
+#define ADE7978_CONSEL	 		NO_OS_GENMASK(5, 4)
+#define ADE7978_VARACC	 		NO_OS_GENMASK(3, 2)
+#define ADE7978_WATTACC	 		NO_OS_GENMASK(1, 0)
+
+/* ADE7978_REG_LCYCMODE Bit Definition */
+#define ADE7978_PFMODE	 		NO_OS_BIT(7)
+#define ADE7978_RSTREAD	 		NO_OS_BIT(6)
+#define ADE7978_ZXSEL2	 		NO_OS_BIT(5)
+#define ADE7978_ZXSEL1	 		NO_OS_BIT(4)
+#define ADE7978_ZXSEL0	 		NO_OS_BIT(3)
+#define ADE7978_LVA	 		NO_OS_BIT(2)
+#define ADE7978_LVAR	 		NO_OS_BIT(1)
+#define ADE7978_LWATT	 		NO_OS_BIT(0)
+
+/* ADE7978_REG_HSDC_CFG Bit Definition */
+#define ADE7978_HSAPOL			NO_OS_BIT(5)
+#define ADE7978_HXFER	 		NO_OS_GENMASK(4, 3)
+#define ADE7978_HGAP			NO_OS_BIT(2)
+#define ADE7978_HSIZE			NO_OS_BIT(1)
+#define ADE7978_HCLK			NO_OS_BIT(0)
+
+/* ADE7978_REG_CONFIG3 Bit Definition */
+#define ADE7978_ADE7933_SWRST		NO_OS_BIT(7)
+#define ADE7978_CLKOUT_DIS  		NO_OS_BIT(6)
+#define ADE7978_VN2_EN			NO_OS_BIT(3)
+#define ADE7978_VC2_EN			NO_OS_BIT(2)
+#define ADE7978_VB2_EN			NO_OS_BIT(1)
+#define ADE7978_VA2_EN			NO_OS_BIT(0)
+
+/* ADE7978_REG_CONFIG2 Bit Definition */
+#define ADE7978_I2C_LOCK		NO_OS_BIT(0)
+
+/* Miscellaneous Definitions */
+#define IS_8BITS_REG(x) ((x >= ADE7978_REG_MMODE && x <= ADE7978_REG_LAST_RWDATA8) \
+        || (x >= ADE7978_REG_CONFIG2 && x <= ADE7978_SET_SPI_ADDR))
+#define IS_16BITS_REG(x) ((x >= ADE7978_REG_PHSTATUS && x <= ADE7978_REG_CONFIG) \
+        || (x >= ADE7978_REG_APF && x <= ADE7978_REG_LAST_RWDATA16) \
+        || (x == ADE7978_REG_RUN))
+#define ADE7978_CHIP_ID			0x0E88
+#define ADE7978_RESET_RECOVER   	100
+#define ADE7978_SET_SPI_ADDR      	0xEBFF
+#define ADE7978_DUMB_VAL        	0x01
+#define ADE7978_RAM_PROTECTION1 	0xE7FE
+#define ADE7978_RAM_PROTECTION2 	0xE7E3
+#define ADE7978_RAM_PROT_VAL1   	0xAD
+#define ADE7978_RAM_PROT_VAL2   	0x80
+
+/* Constant Definitions */
+/* DSP ON */
+#define ADE7978_RUN_ON 			0x0001
+/* Full scale Codes (FS) referred from Datasheet.*/
+/* Respective digital codes are produced when ADC inputs
+are at full scale. Do not Change. */
+#define ADE7978_WAVE_FS_CODES  		5320000
+#define ADE7978_RMS_FS_CODES  		3761808
+
+/* 0.5V full scale * 0.707 * 10000 for mili units */
+#define ADE7978_FS_VOLTAGE_RMS          3535
+/* 31.25 mV full scale * 0.707 * 1000 for micro units */
+#define ADE7978_FS_CURRENT_RMS          22094
+/* 31.25 mV full scale * 1000 for micro units */
+#define ADE7978_FS_CURRENT              31250
+/* 0.5V full scale * 1000 for mili units */
+#define ADE7978_FS_VOLTAGE           	500
+
+/**
+ * @enum ade7978_cfxsel_e
+ * @brief ADE7978 These bits indicate the value the CFx frequency
+    is proportional to
+ */
+enum ade7978_cfxsel_e {
+	/* the CFx frequency is proportional to the sum of total active powers on
+	each phase */
+	ADE7978_CFXSEL_0,
+	/* the CFx frequency is proportional to the sum of the total reactive
+	powers on each phase */
+	ADE7978_CFXSEL_1,
+	/* the CFx frequency is proportional to the sum of apparent powers
+	on each phase */
+	ADE7978_CFXSEL_2,
+	/* the CFx frequency is proportional to the sum of the fundamental
+	active powers on each phase */
+	ADE7978_CFXSEL_3,
+	/* the CFx frequency is proportional to the sum of the fundamental
+	reactive powers on each phase */
+	ADE7978_CFXSEL_4,
+};
+
+/**
+ * @enum ade7978_zx_dready_e
+ * @brief ADE7978 These bits manage the output signal at the ZX/DREADY pin
+ */
+enum ade7978_zx_dready_e {
+	/* DREADY functionality is enabled */
+	ADE7978_DREADY_EN,
+	/* ZX functionality is generated by the Phase A voltage */
+	ADE7978_ZX_PHASE_A,
+	/* ZX functionality is generated by the Phase B voltage */
+	ADE7978_ZX_PHASE_B,
+	/* ZX functionality is generated by the Phase C voltage */
+	ADE7978_ZX_PHASE_C
+};
+
+/**
+ * @enum ade7978_vtoia_e
+ * @brief ADE7978 These bits decide what phase voltage is considered
+    together with Phase A current in the power path.
+ */
+enum ade7978_vtoia_e {
+	/* Phase A voltage */
+	ADE7978_VTOIA_A,
+	/* Phase B voltage */
+	ADE7978_VTOIA_B,
+	/* Phase C voltage */
+	ADE7978_VTOIA_C
+};
+
+/**
+ * @enum ade7978_vtoib_e
+ * @brief ADE7978 These bits decide what phase voltage is considered
+    together with Phase B current in the power path.
+ */
+enum ade7978_vtoib_e {
+	/* Phase B voltage */
+	ADE7978_VTOIB_B,
+	/* Phase C voltage */
+	ADE7978_VTOIB_C,
+	/* Phase A voltage */
+	ADE7978_VTOIB_A
+};
+
+/**
+ * @enum ade7978_vtoic_e
+ * @brief ADE7978 These bits decide what phase voltage is considered
+    together with Phase C current in the power path.
+ */
+enum ade7978_vtoic_e {
+	/* Phase C voltage */
+	ADE7978_VTOIC_C,
+	/* Phase A voltage */
+	ADE7978_VTOIC_A,
+	/* Phase B voltage */
+	ADE7978_VTOIC_B
+};
+
+/**
+ * @enum ade7978_wattacc_e
+ * @brief ADE7978 These bits decide the accumulation mode of fundamental
+    active powers
+ */
+enum ade7978_wattacc_e {
+	/* Signed accumulation mode of the total and fundamental active
+	powers */
+	ADE7978_WATTACC_SIGNED_ACC,
+	/* Positive only accumulation mode of the total and fundamental
+	active powers */
+	ADE7978_WATTACC_POSITIVE_ACC,
+	/* Reserved. When set, the device behaves like WATTACC[1:0] = 00. */
+	ADE7978_WATTACC_RESERVED,
+	/* Absolute accumulation mode of the total and fundamental
+	active powers */
+	ADE7978_WATTACC_ABSOLUTE_ACC
+};
+
+/**
+ * @enum ade7978_varacc_e
+ * @brief ADE7978 These bits decide the accumulation mode of funamental
+    reactive powers
+ */
+enum ade7978_varacc_e {
+	/* Signed accumulation mode of the fundamental reactive powers */
+	ADE7978_VARACC_SIGNED_ACC,
+	/* reserved. When set, the device behaves like VARACC[1:0] = 00. */
+	ADE7978_VARACC_RESERVED,
+	/* The fundamental reactive power is accumulated, depending on
+	the sign of the fundamental active power */
+	ADE7978_VARACC_SIGN_WATTACC,
+	/* Absolute accumulation mode of the fundamental reactive powers */
+	ADE7978_VARACC_ABSOLUTE_ACC
+};
+
+/**
+ * @enum ade7978_consel_e
+ * @brief ADE7978 These bits select the inputs to the energy
+    accumulation registers.
+    IA’, IB’, and IC’ are IA, IB, and IC shifted respectively by −90°
+ */
+enum ade7978_consel_e {
+	/* 3-phase four wires with three voltage sensors */
+	ADE7978_CONSEL_3P_3W,
+	/* 3-phase three wires delta connection. */
+	ADE7978_CONSEL_3P_3W_DELTA,
+	/* 3-phase four wires delta connection. */
+	ADE7978_CONSEL_3P_4W_DELTA
+};
+
+/**
+ * @enum ade7978_hxfer_e
+ * @brief ADE7978 These bits select the data transmitted on HSDC
+ */
+enum ade7978_hxfer_e {
+	/* HSDC transmits sixteen 32-bit words in the following order:
+	IAWV, VAWV, IBWV, VBWV, ICWV, VCWV, INWV, AVA, BVA, CVA, AWATT,
+	BWATT, CWATT, AVAR, BVAR, and CVAR */
+	ADE7978_HXFER_16,
+	/* HSDC transmits seven instantaneous values of currents and
+	voltages in the following order: IAWV, VAWV, IBWV, VBWV, ICWV,
+	VCWV, and INWV */
+	ADE7978_HXFER_7,
+	/* HSDC transmits nine instantaneous values of phase powers
+	in the following order: AVA, BVA, CVA, AWATT, BWATT, CWATT,
+	AVAR, BVAR, and CVAR */
+	ADE7978_HXFER_9,
+	/* 11 = reserved. If set, the ADE7978 behaves as if
+	HXFER[1:0] = 00. */
+	ADE7978_HXFER_RESERVED
+};
+
+/**
+ * @enum ade7978_freq_sel_e
+ * @brief ADE7978 Freq value
+ */
+enum ade7978_freq_sel_e {
+	/* 50 Hz */
+	ADE7978_SELFREQ_50,
+	/* 60 Hz */
+	ADE7978_SELFREQ_60,
+};
+
+/**
+ * @enum ade7978_phase
+ * @brief ADE7978 available phases.
+ */
+enum ade7978_phase {
+	ADE7978_PHASE_A,
+	ADE7978_PHASE_B,
+	ADE7978_PHASE_C
+};
+
+/**
+ * @struct ade7978_init_param
+ * @brief ADE7978 Device initialization parameters.
+ */
+struct ade7978_init_param {
+	/** Device communication descriptor */
+	struct no_os_spi_init_param 	*spi_init;
+	/* reset descriptor */
+	struct no_os_gpio_desc      	*reset_desc;
+	/* temperature enable */
+	uint8_t             		temp_en;
+};
+
+/**
+ * @struct ade7978_dev
+ * @brief ADE7978 Device structure.
+ */
+struct ade7978_dev {
+	/** Device communication descriptor */
+	struct no_os_spi_desc		*spi_desc;
+	/* reset descriptor */
+	struct no_os_gpio_desc      	*reset_desc;
+	/* Variable storing the IRMS value in ADC code */
+	uint32_t			irms_val;
+	/* Variable storing the VRMS value in ADC code */
+	uint32_t			vrms_val;
+	/* Variable storing the V2RMS value in ADC code */
+	uint32_t			v2rms_val;
+	/* Variable storing the temperature in ADC code */
+	uint32_t            		temperature;
+	/* Variable for enabling the temperature measurement*/
+	uint8_t             		temp_en;
+	/** IRQ device descriptor used to handle interrupt routine */
+	struct no_os_irq_ctrl_desc 	*irq_ctrl;
+};
+
+/* Read device register. */
+int ade7978_read(struct ade7978_dev *dev, uint16_t reg_addr,
+		 uint32_t *reg_data);
+
+/* Write device register. */
+int ade7978_write(struct ade7978_dev *dev, uint16_t reg_addr,
+		  uint32_t reg_data);
+
+/* Update specific register bits. */
+int ade7978_update_bits(struct ade7978_dev *dev, uint16_t reg_addr,
+			uint32_t mask, uint32_t reg_data);
+
+/* Read measurements for specific phase */
+int ade7978_read_data_ph(struct ade7978_dev *dev, enum ade7978_phase phase);
+
+/* Initialize the device. */
+int ade7978_init(struct ade7978_dev **device,
+		 struct ade7978_init_param init_param);
+
+/* Setup the device */
+int ade7978_setup(struct ade7978_dev *dev);
+
+/* Remove the device and release resources. */
+int ade7978_remove(struct ade7978_dev *dev);
+
+/* Get interrupt indicator from STATUS0 register. */
+int ade7978_get_int_status0(struct ade7978_dev *dev, uint32_t msk,
+			    uint8_t *status);
+
+/* Get interrupt indicator from STATUS01 register. */
+int ade7978_get_int_status1(struct ade7978_dev *dev, uint32_t msk,
+			    uint8_t *status);
+
+#endif /* __ADE7978_H__ */

--- a/projects/eval-ade7978/Makefile
+++ b/projects/eval-ade7978/Makefile
@@ -1,0 +1,5 @@
+include ../../tools/scripts/generic_variables.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/eval-ade7978/builds.json
+++ b/projects/eval-ade7978/builds.json
@@ -1,0 +1,7 @@
+{
+    "maxim": {
+      "ade7978_example": {
+        "flags" : "TARGET=max32690"
+      }
+    }
+  }

--- a/projects/eval-ade7978/src.mk
+++ b/projects/eval-ade7978/src.mk
@@ -1,0 +1,43 @@
+
+NO_OS_INC_DIRS += \
+	$(INCLUDE) \
+    $(PLATFORM_DRIVERS) \
+    $(PLATFORM_DRIVERS)/../common/ \
+    $(PROJECT)/src/ \
+    $(DRIVERS)/meter/ade7978
+
+SRCS += $(PROJECT)/src/main.c \
+
+SRCS +=	$(NO-OS)/util/no_os_alloc.c			\
+	$(DRIVERS)/api/no_os_gpio.c 			\
+	$(NO-OS)/util/no_os_mutex.c			\
+	$(NO-OS)/util/no_os_lf256fifo.c			\
+	$(NO-OS)/util/no_os_list.c			\
+	$(NO-OS)/util/no_os_util.c			\
+	$(NO-OS)/util/no_os_crc8.c 			\
+	$(NO-OS)/util/no_os_crc16.c 			\
+	$(DRIVERS)/api/no_os_irq.c			\
+	$(DRIVERS)/api/no_os_uart.c			\
+	$(DRIVERS)/api/no_os_pwm.c			\
+	$(DRIVERS)/api/no_os_spi.c  			\
+	$(DRIVERS)/api/no_os_timer.c  			\
+	$(DRIVERS)/api/no_os_dma.c 			
+
+SRCS +=	$(PLATFORM_DRIVERS)/maxim_irq.c			\
+	$(PLATFORM_DRIVERS)/maxim_gpio_irq.c  		\
+	$(PLATFORM_DRIVERS)/maxim_delay.c     		\
+	$(PLATFORM_DRIVERS)/maxim_init.c      		\
+	$(PLATFORM_DRIVERS)/maxim_uart_stdio.c		\
+	$(PLATFORM_DRIVERS)/maxim_gpio.c      		\
+	$(PLATFORM_DRIVERS)/maxim_spi.c       		\
+	$(PLATFORM_DRIVERS)/maxim_uart.c		\
+	$(PLATFORM_DRIVERS)/maxim_pwm.c
+
+# Application entry point
+SRCS += $(PROJECT)/src/main.c \
+    $(PROJECT)/src/platform/platform.c \
+    $(PROJECT)/src/common/common_data.c \
+    $(PROJECT)/src/interrupt/interrupt.c \
+
+# ADE7978 driver files
+SRCS += $(DRIVERS)/meter/ade7978/ade7978.c

--- a/projects/eval-ade7978/src/common/common_data.c
+++ b/projects/eval-ade7978/src/common/common_data.c
@@ -1,0 +1,95 @@
+/***************************************************************************//**
+ *   @file   common_data.c
+ *   @brief  Defines common data to be used by ADE7978 example project
+ *   @author REtz (radu.etz@analog.com)
+********************************************************************************
+ * Copyright (c) 2024 Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "common_data.h"
+#include "platform.h"
+
+/**
+ * @brief Saves the current and voltage values of device 1 in rms_adc structure
+ * @param dev - device structure
+ * @param value - structure holding the measurements values
+ * @param phase - selects the phase for measurements read
+ * @return 0 in case of success, negative error code otherwise
+ */
+int rms_adc_values_read(struct ade7978_dev *dev, struct measurements *value,
+			enum ade7978_phase phase)
+{
+	int ret;
+	/* variables used to calculate the values of the measurements */
+	float v1_rms, v2_rms, i_rms, temperature;
+
+	if (!dev)
+		return -ENODEV;
+	if (!value)
+		return -EINVAL;
+
+	/* Read the measurements for the selected phase */
+	ret = ade7978_read_data_ph(dev, phase);
+	if (ret)
+		return ret;
+
+	/* Compute v1 value in mV */
+	v1_rms = (float) ADE7978_FS_VOLTAGE_RMS * (float)((int32_t) dev->vrms_val) *
+		 (float) ADE7978_VOLTAGE_TR_FCN / ((float) ADE7978_WAVE_FS_CODES *
+				 (float) 10);
+
+	/* Compute i value in mA */
+	i_rms = (float) ADE7978_FS_CURRENT_RMS * (float)((int32_t) dev->irms_val) *
+		(float) ADE7978_SHUNT_RES / (float) ADE7978_WAVE_FS_CODES;
+
+	/* Save the values in the measurements structure */
+	value->v1_rms = v1_rms;
+	value->v1_rms_adc = dev->vrms_val;
+	value->i_rms = i_rms;
+	value->i_rms_adc = dev->irms_val;
+
+	/* The second voltage channel is multiplexed with the temperature sensor.
+	The channel function is selected by the user through temp_en */
+	if (dev->temp_en) {
+		/* Compute temperature in °C */
+		temperature = 8.72101 * 0.00001 * dev->temperature - 306.47;
+		/* Save the temperature values in the measurements structure */
+		value->temperature_c = temperature;
+		value->temperature  = dev->temperature;
+	} else {
+		/* Compute v2 value */
+		v2_rms = (float) ADE7978_FS_VOLTAGE_RMS * (float)((int32_t) dev->v2rms_val) *
+			 (float) ADE7978_VOLTAGE_TR_FCN / ((float) ADE7978_WAVE_FS_CODES *
+					 (float) 10);
+		/* Save the v2 values in the measurements structure */
+		value->v2_rms = v2_rms;
+		value->v2_rms_adc = dev->v2rms_val;
+	}
+
+	return 0;
+}

--- a/projects/eval-ade7978/src/common/common_data.h
+++ b/projects/eval-ade7978/src/common/common_data.h
@@ -1,0 +1,91 @@
+/***************************************************************************//**
+ *   @file   common_data.h
+ *   @brief  Defines common data to be used by ADE7978 example project
+ *   @author REtz (radu.etz@analog.com)
+********************************************************************************
+ * Copyright (c) 2024 Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __COMMON_DATA_H__
+#define __COMMON_DATA_H__
+
+#include "ade7978.h"
+#include "no_os_uart.h"
+#include "no_os_pwm.h"
+#include "no_os_delay.h"
+#include "no_os_gpio.h"
+#include "no_os_spi.h"
+#include "no_os_print_log.h"
+#include "no_os_units.h"
+#include "no_os_util.h"
+#include "no_os_error.h"
+#include "maxim_uart.h"
+#include "maxim_gpio.h"
+#include "maxim_uart_stdio.h"
+#include "maxim_pwm.h"
+#include "maxim_spi.h"
+#include "maxim_irq.h"
+
+/* Hardware dependent definitions */
+
+/* Current sesing using a shunt */
+/* Value of shunt in mohms */
+#define ADE7978_SHUNT_RES              	1
+
+/* Assuming a voltage divider with Rlow 1k and Rup 990k */
+#define ADE7978_UP_RES                	990000
+#define ADE7978_DOWN_RES		1000
+#define ADE7978_VOLTAGE_TR_FCN		((ADE7978_DOWN_RES + ADE7978_UP_RES) / ADE7978_DOWN_RES)
+
+/**
+ * @struct measurements
+ * @brief measurements structure.
+ */
+struct measurements {
+	/* I rms value */
+	float				i_rms;
+	/* V1 rms value */
+	float				v1_rms;
+	/* V2 rms value */
+	float				v2_rms;
+	/* Temperature °C value */
+	float               		temperature_c;
+	/* I ADC rms value */
+	int32_t				i_rms_adc;
+	/* V1 ADC rms value */
+	int32_t				v1_rms_adc;
+	/* V2 ADC rms value */
+	int32_t				v2_rms_adc;
+	/* Temperature ADC value */
+	int32_t             		temperature;
+};
+
+/* Saves the current and voltage values of device 1 in rms_adc structure */
+int rms_adc_values_read(struct ade7978_dev *dev, struct measurements *value,
+			enum ade7978_phase phase);
+
+#endif /* __COMMON_DATA_H__ */

--- a/projects/eval-ade7978/src/interrupt/interrupt.c
+++ b/projects/eval-ade7978/src/interrupt/interrupt.c
@@ -1,0 +1,159 @@
+/***************************************************************************//**
+ *   @file   inter.c
+ *   @brief  External interrupt implementation file.
+ *   @author REtz (radu.etz@analog.com)
+********************************************************************************
+ * Copyright (c) 2024 Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "no_os_print_log.h"
+#include "common_data.h"
+#include "platform.h"
+#include "interrupt.h"
+
+static volatile uint8_t drdy_flag;
+extern struct no_os_irq_ctrl_desc *ade7978_nvic_desc;
+
+/**
+ * @brief callback function
+ * @param context - context variable
+ * @return none
+ */
+static void interrupt_cb_fn(void *context)
+{
+	struct no_os_irq_ctrl_desc *irq_desc1 = context;
+	int ret;
+
+	drdy_flag++;
+	ret = no_os_irq_disable(irq_desc1, GPIO_RDY_PIN);
+	if (ret)
+		pr_err("ERROR %d \n", ret);
+}
+
+/**
+ * @brief Get data ready flag value
+ *
+ * @return flag value
+ */
+int get_drdy_flag_state(void)
+{
+	return drdy_flag;
+}
+
+/**
+ * @brief Reset data ready low flag value
+ *
+ * @return none
+ */
+void reset_drdy_low_flag_state(void)
+{
+	drdy_flag = 0;
+}
+
+
+/**
+ * @brief Initialize interrupt
+ * @param dev - device structure
+ * @return 0 in case of success, error code otherwise
+ */
+int inter_init(struct ade7978_dev *dev)
+{
+	int ret;
+	struct no_os_gpio_desc *drdy_pin;
+	struct no_os_irq_ctrl_desc *ade7978_gpio_irq_desc;
+
+	if (!dev)
+		return -ENODEV;
+
+	/* Setup GPIO interrupts */
+	struct no_os_callback_desc p2_cb = {
+		/** Callback to be called when the event occurs. */
+		.callback = interrupt_cb_fn,
+		/** Parameter to be passed when the callback is called */
+		.ctx = NULL,
+		/** Event that triggers the calling of the callback. */
+		.event = NO_OS_EVT_GPIO,
+		/** Interrupt source peripheral specifier. */
+		.peripheral = NO_OS_GPIO_IRQ,
+		/** Not used in the case of a GPIO IRQ controller */
+		.handle = NULL
+	};
+
+	/* Initialize GPIO IRQ controller in order to be able to enable GPIO IRQ interrupt */
+	struct no_os_irq_init_param irq_gpio_ip = {
+		.irq_ctrl_id = GPIO_RDY_PORT,
+		.platform_ops = &max_gpio_irq_ops,
+	};
+
+	/* Port 2 drdy */
+	ret = no_os_gpio_get(&drdy_pin, &ade7978_gpio_rdy_ip);
+	if (ret)
+		goto error;
+
+	ret = no_os_gpio_direction_input(drdy_pin);
+	if (ret)
+		goto remove_gpio;
+
+	ret = no_os_irq_ctrl_init(&ade7978_gpio_irq_desc, &irq_gpio_ip);
+	if (ret)
+		goto remove_gpio;
+
+	p2_cb.ctx = ade7978_gpio_irq_desc;
+
+	/* Dready interrupt */
+	ret = no_os_irq_register_callback(ade7978_gpio_irq_desc, GPIO_RDY_PIN,
+					  &p2_cb);
+	if (ret)
+		goto remove_irq;
+
+	ret = no_os_irq_trigger_level_set(ade7978_gpio_irq_desc, GPIO_RDY_PIN,
+					  NO_OS_IRQ_EDGE_FALLING);
+	if (ret)
+		goto remove_irq;
+
+	ret = no_os_irq_set_priority(ade7978_gpio_irq_desc, GPIO_RDY_PIN, 1);
+	if (ret)
+		goto remove_irq;
+
+	ret = no_os_irq_enable(ade7978_gpio_irq_desc, GPIO_RDY_PIN);
+	if (ret)
+		goto remove_irq;
+
+	dev->irq_ctrl = ade7978_gpio_irq_desc;
+
+	return 0;
+
+remove_irq:
+	no_os_irq_ctrl_remove(ade7978_gpio_irq_desc);
+remove_gpio:
+	no_os_gpio_remove(drdy_pin);
+
+error:
+	pr_err("ERROR\n");
+	return ret;
+}

--- a/projects/eval-ade7978/src/interrupt/interrupt.h
+++ b/projects/eval-ade7978/src/interrupt/interrupt.h
@@ -1,0 +1,47 @@
+/***************************************************************************//**
+ *   @file   inter.h
+ *   @brief  Data ready interrupt file.
+ *   @author REtz (radu.etz@analog.com)
+********************************************************************************
+ * Copyright (c) 2024 Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __INTER_H__
+#define __INTER_H__
+
+#include "no_os_irq.h"
+
+/*! Get GPIO flag value. */
+int get_drdy_flag_state(void);
+
+/*! Reset GPIO flag value. */
+void reset_drdy_low_flag_state(void);
+
+/*! Initialize interrupt phase */
+int inter_init(struct ade7978_dev *dev);
+
+#endif /* __INTER__H__ */

--- a/projects/eval-ade7978/src/main.c
+++ b/projects/eval-ade7978/src/main.c
@@ -1,0 +1,233 @@
+/***************************************************************************//**
+ *   @file   main.c
+ *   @brief  Main function of ADE7978 example.
+ *   @author REtz (radu.etz@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include <stdio.h>
+#include "no_os_uart.h"
+#include "no_os_pwm.h"
+#include "no_os_delay.h"
+#include "no_os_gpio.h"
+#include "no_os_spi.h"
+#include "no_os_print_log.h"
+#include "no_os_units.h"
+#include "no_os_util.h"
+#include "no_os_error.h"
+#include "maxim_uart.h"
+#include "maxim_gpio.h"
+#include "maxim_uart_stdio.h"
+#include "maxim_pwm.h"
+#include "maxim_spi.h"
+#include "ade7978.h"
+#include "platform.h"
+#include "common_data.h"
+#include "interrupt.h"
+
+/* nvic descriptor */
+struct no_os_irq_ctrl_desc *ade7978_nvic_desc;
+
+int main(void)
+{
+	int ret;
+	/* print count (multiple of dready) */
+	int32_t print_cnt = 0;
+
+	/* parameters initialization structure */
+	struct ade7978_init_param ade7978_ip;
+	/* device structure */
+	struct ade7978_dev *ade7978_dev;
+	/* read values */
+	struct measurements *vals;
+
+	/* uart descriptor */
+	struct no_os_uart_desc *uart_desc;
+	/* reset descriptor */
+	struct no_os_gpio_desc *gpio_reset_desc;
+	/* gpio descriptor */
+	struct no_os_gpio_desc *gpio_desc;
+
+	ret = no_os_init();
+	if (ret)
+		return ret;
+
+	/* Initialize NVIC IRQ controller in order
+	to be able to enable GPIO IRQ interrupt */
+	struct no_os_irq_init_param ade7978_nvic_ip = {
+		.platform_ops = &max_irq_ops
+	};
+	/* Initialize GPIO IRQ controller */
+	ret = no_os_irq_ctrl_init(&ade7978_nvic_desc,
+				  &ade7978_nvic_ip);
+	if (ret)
+		goto error;
+
+	ret = no_os_irq_set_priority(ade7978_nvic_desc,
+				     GPIO2_IRQn, 1);
+	if (ret)
+		goto remove_irq;
+
+	ret = no_os_irq_enable(ade7978_nvic_desc,
+			       GPIO2_IRQn);
+	if (ret)
+		goto remove_irq;
+
+	/* Initialize UART */
+	ret = no_os_uart_init(&uart_desc, &uart_ip);
+	if (ret)
+		goto remove_irq;
+
+	ret = no_os_gpio_get_optional(&gpio_desc,
+				      &gpio_led1_ip);
+	if (ret)
+		goto remove_uart;
+
+	if (gpio_desc)
+		ret = no_os_gpio_direction_output(gpio_desc,
+						  NO_OS_GPIO_LOW);
+	if (ret)
+		goto remove_led;
+
+	ret = no_os_gpio_get_optional(&gpio_reset_desc,
+				      &gpio_reset_ip);
+	if (ret)
+		goto remove_led;
+
+	if (gpio_reset_desc)
+		ret = no_os_gpio_direction_output(gpio_reset_desc,
+						  NO_OS_GPIO_HIGH);
+	if (ret)
+		goto remove_reset;
+
+	/* Initialize SPI */
+	ade7978_ip.spi_init = &ade7978_spi_ip;
+	/* Initialize Reset */
+	ade7978_ip.reset_desc = gpio_reset_desc;
+	/* Initialize temperature read */
+	/* If temperature read is disabled than the channel
+	is used as the second voltage channel */
+	ade7978_ip.temp_en = ENABLE;
+
+	no_os_uart_stdio(uart_desc);
+
+	pr_info("\n");
+	pr_info("\n");
+	pr_info("ADE7978 SPI example \n\n");
+
+	/* Init ade7978 struct */
+	ade7978_dev = (struct ade7978_dev *)no_os_calloc(1, sizeof(*ade7978_dev));
+	if (!ade7978_dev)
+		return -ENOMEM;
+
+	/* Init measurements struct */
+	vals = (struct vals *)no_os_calloc(1, sizeof(*vals));
+	if (!vals) {
+		ret = -ENOMEM;
+		goto free_dev;
+	}
+
+	/* Initialize the device with the values stored
+	in the initialization structure */
+	ret = ade7978_init(&ade7978_dev, ade7978_ip);
+	if (ret)
+		goto free_dev2;
+	/* setup the ade7978 device */
+	ret = ade7978_setup(ade7978_dev);
+	if (ret)
+		goto free_dev2;
+
+	/* Initialize data ready interrupt */
+	ret = inter_init(ade7978_dev);
+	if (ret)
+		goto free_dev2;
+	/* Clear data ready flag */
+	ret = ade7978_update_bits(ade7978_dev, ADE7978_REG_STATUS0,
+				  ADE7978_STATUS0_DREADY,
+				  no_os_field_prep(ADE7978_STATUS0_DREADY, ENABLE));
+	if (ret)
+		goto free_dev2;
+
+	while (1) {
+		if (print_cnt >= 1000) {
+			/* print the ade7978 rms measured values for PHASE A */
+			pr_info("V1_rms: %3.2f mV\n", vals->v1_rms);
+
+			pr_info("I_rms %3.2f mA\n", vals->i_rms);
+
+			if (ade7978_dev->temp_en)
+				pr_info("Temperature %3.2f °C\n", vals->temperature_c);
+			else
+				pr_info("V2_rms: %3.2f mV\n", vals->v2_rms);
+			print_cnt = 0;
+
+			pr_info("\n");
+			/* toggle the LED on the MCU board */
+			ret = interface_toggle_led(gpio_desc);
+			if (ret)
+				goto free_dev2;
+		}
+
+		if (get_drdy_flag_state() >= 1) {
+			print_cnt++;
+			/* read the ade7978 rms measured values for PHASE A */
+			ret = rms_adc_values_read(ade7978_dev, vals, ADE7978_PHASE_A);
+			if (ret)
+				goto free_dev2;
+			reset_drdy_low_flag_state();
+			/* enable interrupt */
+			ret = no_os_irq_enable(ade7978_dev->irq_ctrl, GPIO_RDY_PIN);
+			if (ret)
+				goto free_dev2;
+			/* clear dready flag */
+			ret = ade7978_update_bits(ade7978_dev, ADE7978_REG_STATUS0,
+						  ADE7978_STATUS0_DREADY,
+						  no_os_field_prep(ADE7978_STATUS0_DREADY, ENABLE));
+			if (ret)
+				goto free_dev2;
+		}
+	}
+
+free_dev2:
+	no_os_free(vals);
+free_dev:
+	no_os_free(ade7978_dev);
+remove_reset:
+	no_os_gpio_remove(gpio_reset_desc);
+remove_led:
+	no_os_gpio_remove(gpio_desc);
+remove_uart:
+	no_os_uart_remove(uart_desc);
+remove_irq:
+	no_os_irq_ctrl_remove(ade7978_nvic_desc);
+
+error:
+	pr_err("ERROR\n");
+	return ret;
+
+}

--- a/projects/eval-ade7978/src/platform/platform.c
+++ b/projects/eval-ade7978/src/platform/platform.c
@@ -1,0 +1,119 @@
+/***************************************************************************//**
+ *   @file   platform.c
+ *   @brief  Defines common data to be used by ADE7978 example project
+ *   @author REtz (radu.etz@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "platform.h"
+
+struct max_uart_init_param max_uart_extra_ip = {
+	.flow = UART_FLOW_DIS
+};
+
+struct max_gpio_init_param gpio_extra_ip = {
+	.vssel = MXC_GPIO_VSSEL_VDDIOH,
+};
+
+struct max_spi_init_param ade7978_spi_extra_ip  = {
+	.num_slaves = SPI_SLAVE_NUM,
+	.polarity = SPI_SS_POL_LOW,
+	.vssel = MXC_GPIO_VSSEL_VDDIOH,
+};
+
+struct no_os_uart_init_param uart_ip = {
+	.device_id = UART_DEV_ID,
+	.baud_rate = UART_BAUD,
+	.size = NO_OS_UART_CS_8,
+	.parity = NO_OS_UART_PAR_NO,
+	.stop = NO_OS_UART_STOP_1_BIT,
+	.platform_ops = &max_uart_ops,
+	.extra = &max_uart_extra_ip,
+};
+
+/* User led gpio init */
+struct no_os_gpio_init_param gpio_led1_ip = {
+	.port = GPIO_LED_PORT,
+	.number = GPIO_LED_PIN,
+	.pull = NO_OS_PULL_UP,
+	.platform_ops = &max_gpio_ops,
+	.extra = &gpio_extra_ip,
+};
+
+/* Reset gpio init */
+struct no_os_gpio_init_param gpio_reset_ip = {
+	.port = GPIO_RESET_PORT,
+	.number = GPIO_RESET_PIN,
+	.pull = NO_OS_PULL_UP,
+	.platform_ops = &max_gpio_ops,
+	.extra = &gpio_extra_ip,
+};
+
+/* data ready pin */
+struct no_os_gpio_init_param ade7978_gpio_rdy_ip = {
+	.port = GPIO_RDY_PORT,
+	.number = GPIO_RDY_PIN,
+	.pull = NO_OS_PULL_UP,
+	.platform_ops = &max_gpio_ops,
+	.extra = &gpio_extra_ip,
+};
+
+/* SPI init params */
+struct no_os_spi_init_param ade7978_spi_ip = {
+	.device_id = SPI_DEVICE_ID,
+	.max_speed_hz = SPI_BAUDRATE,
+	.bit_order = NO_OS_SPI_BIT_ORDER_MSB_FIRST,
+	.mode = NO_OS_SPI_MODE_0,
+	.platform_ops = &max_spi_ops,
+	.chip_select = SPI_CS,
+	.extra = &ade7978_spi_extra_ip,
+};
+
+struct no_os_irq_init_param ade7978_gpio_irq_ip = {
+	.platform_ops = GPIO_IRQ_OPS,
+	.irq_ctrl_id = GPIO_CTRL_IRQ_ID,
+	.extra = GPIO_IRQ_EXTRA,
+};
+
+/**
+ * @brief Toggle Led
+ * @param gpio_led_desc - led descriptor
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int interface_toggle_led(struct no_os_gpio_desc *gpio_led_desc)
+{
+	uint8_t val;
+	int ret;
+
+	ret = no_os_gpio_get_value(gpio_led_desc, &val);
+	if (ret)
+		return ret;
+
+	return no_os_gpio_set_value(gpio_led_desc, !val);
+}

--- a/projects/eval-ade7978/src/platform/platform.h
+++ b/projects/eval-ade7978/src/platform/platform.h
@@ -1,0 +1,101 @@
+/***************************************************************************//**
+ *   @file   platform.h
+ *   @brief  Defines common data to be used by ADE7978 example project
+ *   @author REtz (radu.etz@analog.com)
+********************************************************************************
+ * Copyright 2024(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PLATFORM_H__
+#define __PLATFORM_H__
+
+#include "ade7978.h"
+#include "no_os_uart.h"
+#include "no_os_pwm.h"
+#include "no_os_delay.h"
+#include "no_os_gpio.h"
+#include "no_os_spi.h"
+#include "no_os_print_log.h"
+#include "no_os_units.h"
+#include "no_os_util.h"
+#include "no_os_error.h"
+#include "maxim_uart.h"
+#include "maxim_gpio.h"
+#include "maxim_uart_stdio.h"
+#include "maxim_pwm.h"
+#include "maxim_spi.h"
+#include "maxim_irq.h"
+
+/* UART init params */
+extern struct no_os_uart_init_param uart_ip;
+/* GPIO LED init params */
+extern struct no_os_gpio_init_param gpio_led1_ip;
+/* GPIO Reset init params */
+extern struct no_os_gpio_init_param gpio_reset_ip;
+/* SPI init params */
+extern struct no_os_spi_init_param ade7978_spi_ip ;
+/* GPIO RDY init params */
+extern struct no_os_gpio_init_param ade7978_gpio_rdy_ip;
+/* Interrupt init params */
+extern struct no_os_irq_init_param ade7978_gpio_irq_ip;
+
+/* Configuration for AD-APARD32690-SL */
+/* Port and Pin for user LED */
+#define GPIO_LED_PORT               2
+#define GPIO_LED_PIN                1
+/* Port and Pin for Reset */
+#define GPIO_RESET_PORT             2
+#define GPIO_RESET_PIN              9
+/* Data ready pin */
+#define GPIO_RDY_PORT               2
+#define GPIO_RDY_PIN                7
+
+
+#define GPIO_OPS                    &max_gpio_ops
+#define GPIO_EXTRA                  &gpio_extra_ip
+/* SPI config */
+#define SPI_DEVICE_ID               1
+#define SPI_BAUDRATE                1000000
+#define SPI_CS                      0
+#define SPI_SLAVE_NUM               1
+/* UART config */
+#define UART_DEV_ID                 0
+#define UART_BAUD                   115200
+/* IRQ config */
+#define GPIO_IRQ_OPS                &max_gpio_irq_ops
+#define GPIO_CTRL_IRQ_ID            0
+#define GPIO_IRQ_EXTRA              &gpio_extra_ip
+#define NVIC_GPIO_IRQ               GPIO2_IRQn
+
+#define RESET_TIME                  500
+/* Read data interval in ms */
+#define READ_INTERVAL               3000
+
+/* Led toggle */
+int interface_toggle_led(struct no_os_gpio_desc *gpio_led_desc);
+
+#endif /* __PLATFORM_H__ */


### PR DESCRIPTION
## Pull Request Description

Basic driver for ADE7978 with SPI communication.
The ADE7978 communicates via a digital interface with ADE7933/ADE7932, or ADE7923 forming a
chipset dedicated to measuring 3-phase electrical energy using shunts as current sensors.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
