### PR TITLE
drivers: power: lt7182s: Add support for LT7184S

### DIFF
--- a/drivers/power/lt7182s/lt7182s.c
+++ b/drivers/power/lt7182s/lt7182s.c
@@ -53,6 +53,9 @@ static const struct lt7182s_chip_info lt7182s_info[] = {
 	[ID_LT7182S] = {
 		.name = "LT7182S",
 	},
+	[ID_LT7184S] = {
+		.name = "LT7184S",
+	},
 };
 
 /**

--- a/drivers/power/lt7182s/lt7182s.h
+++ b/drivers/power/lt7182s/lt7182s.h
@@ -226,6 +226,7 @@
 
 enum lt7182s_chip_id {
 	ID_LT7182S,
+	ID_LT7184S,
 };
 
 enum lt7182s_output_channel {


### PR DESCRIPTION
## Pull Request Description

The LT7184S is a dual-output monolithic PolyPhase DC/DC synchronous step-down 
regulator that delivers up to 7A of continuous current from both channels
simultaneously and supports loads from -8A to +9A in either channel. LT7184S
contains the same set of registers with the LT7182S. Current and voltage ratings 
are the major differences.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
