### PR TITLE
Add option to support AD4195-4

### DIFF
--- a/drivers/adc/ad4170/ad4170.c
+++ b/drivers/adc/ad4170/ad4170.c
@@ -1804,6 +1804,7 @@ int ad4170_init(struct ad4170_dev **device,
 		break;
 
 	case ID_AD4190:
+	case ID_AD4195:
 		prod_id_l_expected = AD4190_PRODUCT_ID_L_VALUE;
 		prod_id_h_expected = AD4190_PRODUCT_ID_H_VALUE;
 		break;

--- a/drivers/adc/ad4170/ad4170.h
+++ b/drivers/adc/ad4170/ad4170.h
@@ -990,7 +990,8 @@ enum ad4170_id {
 	ID_AD4170,
 	ID_AD4171,
 	ID_AD4172,
-	ID_AD4190
+	ID_AD4190,
+	ID_AD4195
 };
 
 /**


### PR DESCRIPTION
## Pull Request Description

According to a software support request, AD4190-4 and AD4195-4 have the same functionality/features.
Since AD4190 is already supported, add an option to indicate AD4195 is also supported.
## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
