### PR TITLE
Add driver for AD8460

### DIFF
--- a/doc/sphinx/source/drivers/ad8460.rst
+++ b/doc/sphinx/source/drivers/ad8460.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../drivers/dac/ad8460/README.rst

--- a/doc/sphinx/source/drivers_doc.rst
+++ b/doc/sphinx/source/drivers_doc.rst
@@ -45,6 +45,7 @@ DIGITAL TO ANALOG CONVERTERS
 .. toctree::
    :maxdepth: 1
 
+   drivers/ad8460
    drivers/max22017
 
 FREQUENCY GENERATORS

--- a/doc/sphinx/source/projects/eval-ad8460.rst
+++ b/doc/sphinx/source/projects/eval-ad8460.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../projects/eval-ad8460/README.rst

--- a/doc/sphinx/source/projects_doc.rst
+++ b/doc/sphinx/source/projects_doc.rst
@@ -86,6 +86,7 @@ DAC
 .. toctree::
    :maxdepth: 1
 
+   projects/eval-ad8460
    projects/max22017
 
 TEMPERATURE

--- a/drivers/dac/ad8460/README.rst
+++ b/drivers/dac/ad8460/README.rst
@@ -1,0 +1,208 @@
+AD8460 no-OS driver
+=====================
+
+Supported Devices
+-----------------
+
+`AD8460 <https://www.analog.com/AD8460>`_
+
+Overview
+--------
+
+The AD8460 is a “bits in, power out” high voltage, high-power, high-speed driver
+optimized for large output current (up to ±1 A) and high slew rate (up to ±1800
+V/μs) at high voltage (up to ±40 V) into capacitive loads. Combining a 14-bit
+high-speed DAC, a high voltage, high output current (HV-HI) analog driver, and
+fault monitoring and protection circuits, the AD8460 is ideally suited for high
+power applications such as arbitrary waveform generation (AWG), programmable
+power supplies, and high voltage automated test equipment (ATE).
+
+A proprietary high-voltage BCDMOS process, novel high voltage architecture, and
+thermally enhanced package from Analog Devices Inc. enable this high-performance
+driver. A digital engine implements user-configurable features: modes for
+digital input, programmable supply current, and fault monitoring and
+programmable protection settings for output current, output voltage, and
+junction temperature. Analog features extend functionality: external
+compensation enables unlimited capacitive load drive, programmable shutdown
+delay, and full-scale adjustment. The AD8460 operates on high voltage dual
+supplies up to ±55 V and a single low voltage supply of 5 V.
+
+Applications
+------------
+
+AD8460
+--------
+
+* Automatic test equipment (ATE)
+* Display panel formation and testing
+* Piezo drivers
+* Programmable power supplies
+
+AD8460 Device Configuration
+-----------------------------
+
+Driver Initialization
+---------------------
+
+In order to be able to use the device, you will have to provide the support
+for the communication protocol (SPI).
+
+The first API to be called is **ad8460_init**. Make sure that it returns 0,
+which means that the driver was initialized correctly.
+
+Reseting AD8460
+---------------
+
+Manual POR can be achieved by pulling RESETB LOW and then HIGH, which resets all
+the digital registers to default. Also, reset to defaults can also be commanded
+at any time through the SOFT_RESET register bit. These are done using the API
+**ad8460_reset**.
+
+Reading and Writing HVDAC Values
+--------------------------------
+
+Reading and writing HVDAC values is done using **ad8460_get_hvdac_word** and
+**ad8460_set_hvdac_word** APIs, respectively.
+
+Switching between APG and AWG Modes
+-----------------------------------
+
+The AD8460 can be switched between APG and AWG modes using
+**ad8460_enable_apg_mode** API. If 1 is passed as a parameter, the device will
+be switched to APG mode; otherwise, it will be switched to AWG mode.
+
+Shutdown Flag
+-------------
+
+The shutdown flag can be read using **ad8460_read_shutdown_flag** API. If the
+value read is 1, the device is in shutdown mode; otherwise, it is not.
+
+Resetting HV Driver
+-------------------
+
+The HV driver can be reset using **ad8460_hv_reset** API.
+
+Setting a Sample
+----------------
+
+A single sample can be set in APG mode using **ad8460_set_sample** API.
+
+AD8460 Driver Initialization Example
+--------------------------------------
+
+.. code-block:: bash
+
+	struct ad8460_device *dev;
+
+	struct no_os_uart_init_param uip = {
+		.device_id = UART_DEVICE_ID,
+		.baud_rate = UART_BAUDRATE,
+		.size = NO_OS_UART_CS_8,
+		.parity = NO_OS_UART_PAR_NO,
+		.stop = NO_OS_UART_STOP_1_BIT,
+		.platform_ops = UART_OPS,
+		.extra = UART_EXTRA,
+	};
+
+	const struct no_os_spi_init_param ad8460_spi_ip = {
+		.device_id = SPI_DEVICE_ID,
+		.max_speed_hz = SPI_MAX_SPEED,
+		.chip_select = SPI_CS,
+		.mode = NO_OS_SPI_MODE_0,
+		.bit_order = NO_OS_SPI_BIT_ORDER_MSB_FIRST,
+		.platform_ops = SPI_OPS,
+		.extra = SPI_EXTRA,
+		.parent = NULL,
+	};
+
+	const struct no_os_gpio_init_param ad8460_gpio_rstn = {
+		.port = GPIO_RSTN_PORT_NUM,
+		.number = GPIO_RSTN_PIN_NUM,
+		.platform_ops = GPIO_OPS,
+		.extra = GPIO_EXTRA,
+	};
+
+	struct ad8460_init_param ad8460_ip = {
+		.spi_init_param = ad8460_spi_ip,
+		.gpio_rstn = ad8460_gpio_rstn,
+		.refio_1p2v_mv = 1200,
+		.ext_resistor_ohms = 2000,
+	};
+
+	ret = ad8460_init(&dev, &ad8460_ip);
+	if (ret)
+		goto error;
+
+AD8460 no-OS IIO support
+--------------------------
+
+The AD8460 IIO driver comes on top of the AD8460 driver and offers support
+for interfacing IIO clients through libiio.
+
+AD8460 IIO Device Configuration
+---------------------------------
+
+Channel Attributes
+------------------
+
+AD8460 has a total of 22 channel attributes:
+
+* ``out_voltage_raw - raw single HVDAC data``
+* ``out_voltage_scale - scale that has to be applied to the raw value in order to obtain the voltage value in mV``
+* ``out_voltage_raw0 - raw HVDAC data word 0``
+* ``out_voltage_raw1 - raw HVDAC data word 1``
+* ``out_voltage_raw2 - raw HVDAC data word 2``
+* ``out_voltage_raw3 - raw HVDAC data word 3``
+* ``out_voltage_raw4 - raw HVDAC data word 4``
+* ``out_voltage_raw5 - raw HVDAC data word 5``
+* ``out_voltage_raw6 - raw HVDAC data word 6``
+* ``out_voltage_raw7 - raw HVDAC data word 7``
+* ``out_voltage_raw8 - raw HVDAC data word 8``
+* ``out_voltage_raw9 - raw HVDAC data word 9``
+* ``out_voltage_raw10 - raw HVDAC data word 10``
+* ``out_voltage_raw11 - raw HVDAC data word 11``
+* ``out_voltage_raw12 - raw HVDAC data word 12``
+* ``out_voltage_raw13 - raw HVDAC data word 13``
+* ``out_voltage_raw14 - raw HVDAC data word 14``
+* ``out_voltage_raw15 - raw HVDAC data word 15``
+* ``out_voltage_toggle_en - enable or disable APG mode``
+* ``out_voltage_symbol - how many symbols of HVDAC data to be used``
+* ``out_voltage_powerdown - power down the HV driver``
+* ``out_current_raw - raw quiescent current value of HV driver``
+
+AD8460 IIO Driver Initialization Example
+------------------------------------------
+
+.. code-block:: bash
+
+	int ret;
+
+	struct ad8460_iio_device *ad8460_iio_dev;
+	struct ad8460_iio_init_param ad8460_iio_ip = {
+		.ad8460_init_param = &ad8460_ip,
+	};
+
+	struct iio_app_desc *app;
+	struct iio_app_init_param app_init_param = {0};
+
+	ret = ad8460_iio_init(&ad8460_iio_dev, &ad8460_iio_ip);
+	if (ret)
+		goto exit;
+
+	struct iio_app_device iio_devices[] = {
+		{
+			.name = "ad8460",
+			.dev = ad8460_iio_dev,
+			.dev_descriptor = ad8460_iio_dev->iio_dev,
+		},
+	};
+
+	app_init_param.devices = iio_devices;
+	app_init_param.nb_devices = NO_OS_ARRAY_SIZE(iio_devices);
+	app_init_param.uart_init_params = uip;
+
+	ret = iio_app_init(&app, app_init_param);
+	if (ret)
+		goto remove_iio_ad8460;
+
+	return iio_app_run(app);

--- a/drivers/dac/ad8460/ad8460.c
+++ b/drivers/dac/ad8460/ad8460.c
@@ -1,0 +1,327 @@
+/***************************************************************************//**
+ *   @file   ad8460.c
+ *   @brief  Implementation of AD8460 Driver.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include "ad8460.h"
+#include "no_os_alloc.h"
+#include "no_os_delay.h"
+#include "no_os_error.h"
+#include "no_os_spi.h"
+#include "no_os_print_log.h"
+#include "no_os_util.h"
+
+/******************************************************************************/
+/************************ Functions Definitions *******************************/
+/******************************************************************************/
+/******************************************************************************/
+
+/**
+ * @brief Read a register value
+ * @param dev - AD8460 descriptor
+ * @param addr - register address
+ * @param val - register value
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ad8460_reg_read(struct ad8460_device *dev, uint8_t addr, uint8_t *val)
+{
+	int ret;
+	uint8_t buf[2];
+
+	buf[0] = 0x80 | addr;
+	buf[1] = 0x00;
+
+	ret = no_os_spi_write_and_read(dev->spi_desc, buf, 2);
+	if (ret)
+		return ret;
+
+	*val = buf[1];
+
+	return 0;
+}
+
+/**
+ * @brief Write a register value
+ * @param dev - AD8460 descriptor
+ * @param addr - register address
+ * @param val - register value
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ad8460_reg_write(struct ad8460_device *dev, uint8_t addr, uint8_t val)
+{
+	uint8_t buf[2];
+
+	buf[0] = addr;
+	buf[1] = val;
+
+	return no_os_spi_write_and_read(dev->spi_desc, buf, 2);
+}
+
+/**
+ * @brief Read-modify-write operation
+ * @param dev - AD8460 descriptor
+ * @param addr - register address
+ * @param mask - Mask for specific register bits to be updated
+ * @param val - register value
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ad8460_reg_update_bits(struct ad8460_device *dev, uint8_t addr,
+			   uint8_t mask, uint8_t val)
+{
+	int ret;
+	uint8_t regval;
+
+	ret = ad8460_reg_read(dev, addr, &regval);
+	if (ret)
+		return ret;
+
+	regval &= ~mask;
+	regval |= no_os_field_prep(mask, val);
+
+	return ad8460_reg_write(dev, addr, regval);
+}
+
+/**
+ * @brief Device and comm init function
+ * @param dev - AD8460 descriptor to be initialized
+ * @param init_param - Init parameter for descriptor
+ * @return 0 in case of success, errno errors otherwise
+ */
+int ad8460_init(struct ad8460_device **dev,
+		struct ad8460_init_param *init_param)
+{
+	struct ad8460_device *temp_dev;
+	int ret;
+
+	temp_dev = no_os_calloc(1, sizeof(*temp_dev));
+	if (!temp_dev)
+		return -ENOMEM;
+
+	ret = no_os_spi_init(&temp_dev->spi_desc, &init_param->spi_init_param);
+	if (ret) {
+		pr_err("Failed to initialize SPI descriptor\r\n");
+		goto free_dev;
+	}
+
+	ret = no_os_gpio_get_optional(&temp_dev->gpio_rstn, &init_param->gpio_rstn);
+	if (ret) {
+		pr_err("Failed to get reset gpio\r\n");
+		goto remove_spi;
+	}
+
+	temp_dev->refio_1p2v_mv = init_param->refio_1p2v_mv;
+	temp_dev->ext_resistor_ohms = init_param->ext_resistor_ohms;
+
+	*dev = temp_dev;
+
+	return 0;
+
+remove_spi:
+	ret = no_os_spi_remove(temp_dev->spi_desc);
+	if (ret)
+		pr_err("Failed to remove SPI descriptor\r\n");
+
+free_dev:
+	no_os_free(temp_dev);
+
+	return ret;
+}
+
+/**
+ * @brief Free resources allocated by the init function
+ * @param dev - AD8460 descriptor
+ * @return 0 in case of success, errno errors otherwise
+ */
+int ad8460_remove(struct ad8460_device *dev)
+{
+	int ret;
+
+	if (!dev)
+		return -ENODEV;
+
+	ret = no_os_spi_remove(dev->spi_desc);
+	if (ret)
+		return ret;
+
+	no_os_free(dev);
+
+	return 0;
+}
+
+/**
+ * @brief Reset the AD8460 device
+ * @param dev - AD8460 descriptor
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ad8460_reset(struct ad8460_device *dev)
+{
+	int ret;
+
+	ret = no_os_gpio_direction_output(dev->gpio_rstn, NO_OS_GPIO_LOW);
+	if (ret)
+		return ret;
+
+	/* minimum duration of 10ns */
+	no_os_udelay(1);
+
+	ret = no_os_gpio_set_value(dev->gpio_rstn, NO_OS_GPIO_HIGH);
+	if (ret)
+		return ret;
+
+	/* bring all registers to their default state */
+	return ad8460_reg_write(dev, 0x03, 1);
+}
+
+/**
+ * @brief Get the value of a high voltage DAC word
+ * @param dev - AD8460 descriptor
+ * @param index - index of the word to be read
+ * @param val - value of the word
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ad8460_get_hvdac_word(struct ad8460_device *dev, int8_t index,
+			  uint16_t *val)
+{
+	int ret;
+	uint8_t buf[3];
+
+	buf[0] = 0x80 | AD8460_HVDAC_DATA_WORD(index);
+	buf[1] = 0x00;
+	buf[2] = 0x00;
+
+	ret = no_os_spi_write_and_read(dev->spi_desc, buf, 3);
+	if (ret)
+		return ret;
+
+	*val = no_os_get_unaligned_le16(buf + 1);
+
+	return 0;
+}
+
+/**
+ * @brief Set the value of a high voltage DAC word
+ * @param dev - AD8460 descriptor
+ * @param index - index of the word to be set
+ * @param val - value of the word
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ad8460_set_hvdac_word(struct ad8460_device *dev, int8_t index, uint16_t val)
+{
+	uint8_t buf[3];
+
+	buf[0] = AD8460_HVDAC_DATA_WORD(index);
+
+	val = no_os_field_prep(AD8460_DATA_BYTE_FULL_MSK, val);
+
+	no_os_put_unaligned_le16(val, buf + 1);
+
+	return no_os_spi_write_and_read(dev->spi_desc, buf, 3);
+}
+
+/**
+ * @brief Enable or disable the APG mode
+ * @param dev - AD8460 descriptor
+ * @param val - enable or disable APG mode
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ad8460_enable_apg_mode(struct ad8460_device *dev, int val)
+{
+	int ret;
+
+	ret = ad8460_reg_update_bits(dev, 0x02, AD8460_APG_MODE_ENABLE_MSK, val);
+	if (ret)
+		return ret;
+
+	return ad8460_reg_update_bits(dev, 0x00, AD8460_WAVE_GEN_MODE_MSK, val);
+}
+
+/**
+ * @brief Read the shutdown flag
+ * @param dev - AD8460 descriptor
+ * @param flag - shutdown flag
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ad8460_read_shutdown_flag(struct ad8460_device *dev, uint8_t *flag)
+{
+	uint8_t val;
+	int ret;
+
+	ret = ad8460_reg_read(dev, 0x0E, &val);
+	if (ret)
+		return ret;
+
+	*flag = !!no_os_field_get(AD8460_SHUTDOWN_FLAG_MSK, val);
+
+	return 0;
+}
+
+/**
+ * @brief Reset the high voltage driver
+ * @param dev - AD8460 descriptor
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ad8460_hv_reset(struct ad8460_device *dev)
+{
+	int ret;
+
+	ret = ad8460_reg_update_bits(dev, 0x00, AD8460_HV_RESET_MSK, 1);
+	if (ret)
+		return ret;
+
+	no_os_udelay(20);
+
+	return ad8460_reg_update_bits(dev, 0x00, AD8460_HV_RESET_MSK, 0);
+}
+
+/**
+ * @brief Set the sample value
+ * @param dev - AD8460 descriptor
+ * @param val - sample value
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ad8460_set_sample(struct ad8460_device *dev, uint16_t val)
+{
+	int ret;
+
+	ret = ad8460_enable_apg_mode(dev, 1);
+	if (ret)
+		return ret;
+
+	ret = ad8460_set_hvdac_word(dev, 0, val);
+	if (ret)
+		return ret;
+
+	return ad8460_reg_update_bits(dev, 0x02, AD8460_PATTERN_DEPTH_MSK, 0);
+}

--- a/drivers/dac/ad8460/ad8460.h
+++ b/drivers/dac/ad8460/ad8460.h
@@ -1,0 +1,147 @@
+/***************************************************************************//**
+ *   @file   ad8460.h
+ *   @brief  Implementation of AD8460 Driver.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef __AD8460_H__
+#define __AD8460_H__
+
+#include "no_os_gpio.h"
+#include "no_os_spi.h"
+#include "no_os_util.h"
+
+#define AD8460_HVDAC_DATA_WORD(x)		(0x60 + (2 * (x)))
+
+#define AD8460_HV_RESET_MSK			NO_OS_BIT(7)
+#define AD8460_HV_SLEEP_MSK			NO_OS_BIT(4)
+#define AD8460_WAVE_GEN_MODE_MSK		NO_OS_BIT(0)
+
+#define AD8460_HVDAC_SLEEP_MSK			NO_OS_BIT(3)
+
+#define AD8460_FAULT_ARM_MSK			NO_OS_BIT(7)
+#define AD8460_FAULT_LIMIT_MSK			NO_OS_GENMASK(6, 0)
+
+#define AD8460_APG_MODE_ENABLE_MSK		NO_OS_BIT(5)
+#define AD8460_PATTERN_DEPTH_MSK		NO_OS_GENMASK(3, 0)
+
+#define AD8460_QUIESCENT_CURRENT_MSK		NO_OS_GENMASK(7, 0)
+
+#define AD8460_SHUTDOWN_FLAG_MSK		NO_OS_BIT(7)
+
+#define AD8460_DATA_BYTE_LOW_MSK		NO_OS_GENMASK(7, 0)
+#define AD8460_DATA_BYTE_HIGH_MSK		NO_OS_GENMASK(5, 0)
+#define AD8460_DATA_BYTE_FULL_MSK		NO_OS_GENMASK(13, 0)
+
+#define AD8460_DEFAULT_FAULT_PROTECT		0x00
+#define AD8460_DATA_BYTE_WORD_LENGTH		2
+#define AD8460_NUM_DATA_WORDS			16
+#define AD8460_NOMINAL_VOLTAGE_SPAN		80
+#define AD8460_MIN_EXT_RESISTOR_OHMS		2000
+#define AD8460_MAX_EXT_RESISTOR_OHMS		20000
+#define AD8460_MIN_VREFIO_UV			120000
+#define AD8460_MAX_VREFIO_UV			1200000
+#define AD8460_ABS_MAX_OVERVOLTAGE_UV		55000000
+#define AD8460_ABS_MAX_OVERCURRENT_UA		1000000
+#define AD8460_MAX_OVERTEMPERATURE_MC		150000
+#define AD8460_MIN_OVERTEMPERATURE_MC		20000
+#define AD8460_CURRENT_LIMIT_CONV(x)		((x) / 15625)
+#define AD8460_VOLTAGE_LIMIT_CONV(x)		((x) / 1953000)
+#define AD8460_TEMP_LIMIT_CONV(x)		(((x) + 266640) / 6510)
+
+/**
+ * @brief AD8460 descriptor
+ */
+struct ad8460_device {
+	/** SPI Descriptor */
+	struct no_os_spi_desc *spi_desc;
+	/** Reset GPIO descriptor */
+	struct no_os_gpio_desc *gpio_rstn;
+	/** REFIO drive voltage in millivolts */
+	int refio_1p2v_mv;
+	/** External resistor connected to FS_ADJ in ohms */
+	uint32_t ext_resistor_ohms;
+};
+
+/**
+ * @brief AD8460 init param
+ */
+struct ad8460_init_param {
+	/** Host processor SPI configuration */
+	struct no_os_spi_init_param spi_init_param;
+	/** Reset GPIO configuration */
+	struct no_os_gpio_init_param gpio_rstn;
+	/** REFIO drive voltage in millivolts */
+	int refio_1p2v_mv;
+	/** External resistor connected to FS_ADJ in ohms */
+	uint32_t ext_resistor_ohms;
+};
+
+/** Read a register value */
+int ad8460_reg_read(struct ad8460_device *dev, uint8_t addr, uint8_t *val);
+
+/** Write a register value */
+int ad8460_reg_write(struct ad8460_device *dev, uint8_t addr, uint8_t val);
+
+/** Read-modify-write operation */
+int ad8460_reg_update_bits(struct ad8460_device *dev, uint8_t addr,
+			   uint8_t mask, uint8_t val);
+
+/** Device and comm init function */
+int ad8460_init(struct ad8460_device **dev,
+		struct ad8460_init_param *init_param);
+
+/** Free resources allocated by the init function */
+int ad8460_remove(struct ad8460_device *dev);
+
+/** Reset the AD8460 device */
+int ad8460_reset(struct ad8460_device *dev);
+
+/** Get the value of a high voltage DAC word */
+int ad8460_get_hvdac_word(struct ad8460_device *dev, int8_t index,
+			  uint16_t *val);
+
+/** Set the value of a high voltage DAC word */
+int ad8460_set_hvdac_word(struct ad8460_device *dev, int8_t index,
+			  uint16_t val);
+
+/** Enable or disable the APG mode */
+int ad8460_enable_apg_mode(struct ad8460_device *dev, int val);
+
+/** Read the shutdown flag */
+int ad8460_read_shutdown_flag(struct ad8460_device *dev, uint8_t *flag);
+
+/** Reset the high voltage driver */
+int ad8460_hv_reset(struct ad8460_device *dev);
+
+/** Set the sample value */
+int ad8460_set_sample(struct ad8460_device *dev, uint16_t val);
+
+#endif	/* __AD8460_H__ */

--- a/drivers/dac/ad8460/iio_ad8460.c
+++ b/drivers/dac/ad8460/iio_ad8460.c
@@ -1,0 +1,467 @@
+/***************************************************************************//**
+ *   @file   iio_ad8460.c
+ *   @brief  Implementation of IIO AD8460 Driver.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <errno.h>
+#include "iio_ad8460.h"
+#include "ad8460.h"
+#include "no_os_alloc.h"
+#include "no_os_error.h"
+
+#define AD8460_CHAN_EXT_INFO(_name, _what, _read, _write) {	\
+	.name = (_name),					\
+	.show = (int (*)()) (_read),				\
+	.store = (int (*)()) (_write),				\
+	.priv = (_what),					\
+	.shared = IIO_SEPARATE,					\
+}
+
+#define AD8460_VOLTAGE_CHAN {					\
+	.ch_type = IIO_VOLTAGE,					\
+	.ch_out = 1,						\
+	.indexed = 1,						\
+	.channel = 0,						\
+	.scan_index = 0,					\
+	.scan_type = &ad8460_iio_scan_type,			\
+	.attributes = ad8460_voltage_attrs,			\
+}
+
+#define AD8460_CURRENT_CHAN {					\
+	.ch_type = IIO_CURRENT,					\
+	.ch_out = 1,						\
+	.indexed = 1,						\
+	.channel = 0,						\
+	.scan_index = -1,					\
+	.attributes = ad8460_current_attrs,			\
+}
+
+static int ad8460_iio_reg_read(struct ad8460_iio_device *dev, uint32_t reg,
+			       uint32_t *readval)
+{
+	return ad8460_reg_read(dev->dev, (uint8_t)reg, (uint8_t*)readval);
+}
+
+static int ad8460_iio_reg_write(struct ad8460_iio_device *dev, uint32_t reg,
+				uint32_t writeval)
+{
+	return ad8460_reg_write(dev->dev, (uint8_t)reg, (uint8_t)writeval);
+}
+
+static int ad8460_iio_reg_update_bits(struct ad8460_iio_device *dev,
+				      uint32_t reg, uint32_t mask, uint32_t val)
+{
+	return ad8460_reg_update_bits(dev->dev, (uint8_t)reg, (uint8_t)mask,
+				      (uint8_t)val);
+}
+
+static int ad8460_buffer_preenable(void *dev, uint32_t mask)
+{
+	struct ad8460_iio_device *iio_dev = dev;
+
+	return ad8460_enable_apg_mode(iio_dev->dev, 0);
+}
+
+static int ad8460_buffer_postdisable(void *dev)
+{
+	struct ad8460_iio_device *iio_dev = dev;
+
+	return ad8460_enable_apg_mode(iio_dev->dev, 1);
+}
+
+static int ad8460_read_raw(void *ddev, char *buf, uint32_t len,
+			   const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct ad8460_iio_device *dev = ddev;
+	uint32_t uval32;
+	uint16_t uval16;
+	int32_t val;
+	int ret;
+
+	switch (channel->type) {
+	case IIO_VOLTAGE:
+		ret = ad8460_get_hvdac_word(dev->dev, priv, &uval16);
+		if (ret)
+			return ret;
+
+		val = uval16;
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	case IIO_CURRENT:
+		ret = ad8460_iio_reg_read(dev, 0x04, &uval32);
+		if (ret)
+			return ret;
+
+		val = uval32;
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	default:
+		return -EINVAL;
+	}
+}
+
+static int ad8460_write_raw(void *ddev, char *buf, uint32_t len,
+			    const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct ad8460_iio_device *dev = ddev;
+	uint16_t data;
+	int32_t val;
+	int ret;
+
+	switch (channel->type) {
+	case IIO_VOLTAGE:
+		ret = iio_parse_value(buf, IIO_VAL_INT, &val, NULL);
+		if (ret < 0)
+			return ret;
+
+		data = val;
+
+		return ad8460_set_sample(dev->dev, data);
+	case IIO_CURRENT:
+		ret = iio_parse_value(buf, IIO_VAL_INT, &val, NULL);
+		if (ret < 0)
+			return ret;
+
+		data = no_os_field_prep(AD8460_QUIESCENT_CURRENT_MSK, val);
+
+		return ad8460_iio_reg_write(dev, 0x04, data);
+	default:
+		return -EINVAL;
+	}
+}
+
+static int ad8460_read_scale(void *ddev, char *buf, uint32_t len,
+			     const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct ad8460_iio_device *dev = ddev;
+	int32_t val[2];
+
+	/*
+	* vCONV = vNOMINAL_SPAN * (DAC_CODE / 2**14) - 40V
+	* vMAX  = vNOMINAL_SPAN * (2**14 / 2**14) - 40V
+	* vMIN  = vNOMINAL_SPAN * (0 / 2**14) - 40V
+	* vADJ  = vCONV * (2000 / rSET) * (vREF / 1.2)
+	* vSPAN = vADJ_MAX - vADJ_MIN
+	* See datasheet page 49, section FULL-SCALE REDUCTION
+	*/
+	val[0] = AD8460_NOMINAL_VOLTAGE_SPAN * 2000 * dev->dev->refio_1p2v_mv;
+	val[1] = dev->dev->ext_resistor_ohms * 1200;
+
+	return iio_format_value(buf, len, IIO_VAL_FRACTIONAL, 2, val);
+}
+
+static int ad8460_dac_input_read(void *ddev, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct ad8460_iio_device *dev = ddev;
+	uint16_t reg;
+	int32_t val;
+	int ret;
+
+	ret = ad8460_get_hvdac_word(dev->dev, priv, &reg);
+	if (ret)
+		return ret;
+
+	val = reg;
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+}
+
+static int ad8460_dac_input_write(void *ddev, char *buf, uint32_t len,
+				  const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct ad8460_iio_device *dev = ddev;
+	uint16_t reg;
+	int32_t val;
+	int ret;
+
+	ret = iio_parse_value(buf, IIO_VAL_INT, &val, NULL);
+	if (ret < 0)
+		return ret;
+
+	reg = val;
+
+	return ad8460_set_hvdac_word(dev->dev, priv, reg);
+}
+
+static int ad8460_read_toggle_en(void *ddev, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct ad8460_iio_device *dev = ddev;
+	uint32_t reg;
+	int32_t val;
+	int ret;
+
+	ret = ad8460_iio_reg_read(dev, 0x02, &reg);
+	if (ret)
+		return ret;
+
+	val = no_os_field_get(AD8460_APG_MODE_ENABLE_MSK, reg);
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+}
+
+static int ad8460_write_toggle_en(void *ddev, char *buf, uint32_t len,
+				  const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct ad8460_iio_device *dev = ddev;
+	bool toggle_en;
+	int32_t val;
+	int ret;
+
+	ret = iio_parse_value(buf, IIO_VAL_INT, &val, NULL);
+	if (ret < 0)
+		return ret;
+
+	toggle_en = !!val;
+
+	return ad8460_enable_apg_mode(dev->dev, toggle_en);
+}
+
+static int ad8460_read_symbol(void *ddev, char *buf, uint32_t len,
+			      const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct ad8460_iio_device *dev = ddev;
+	uint32_t reg;
+	int32_t val;
+	int ret;
+
+	ret = ad8460_iio_reg_read(dev, 0x02, &reg);
+	if (ret)
+		return ret;
+
+	val = no_os_field_get(AD8460_PATTERN_DEPTH_MSK, reg);
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+}
+
+static int ad8460_write_symbol(void *ddev, char *buf, uint32_t len,
+			       const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct ad8460_iio_device *dev = ddev;
+	uint8_t sym;
+	int32_t val;
+	int ret;
+
+	ret = iio_parse_value(buf, IIO_VAL_INT, &val, NULL);
+	if (ret < 0)
+		return ret;
+
+	sym = val;
+
+	return ad8460_iio_reg_update_bits(dev, 0x02, AD8460_PATTERN_DEPTH_MSK, sym);
+}
+
+static int ad8460_read_powerdown(void *ddev, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct ad8460_iio_device *dev = ddev;
+	uint32_t reg;
+	int32_t val;
+	int ret;
+
+	ret = ad8460_iio_reg_read(dev, 0x01, &reg);
+	if (ret)
+		return ret;
+
+	val = no_os_field_get(AD8460_HVDAC_SLEEP_MSK, reg);
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+}
+
+static int ad8460_write_powerdown(void *ddev, char *buf, uint32_t len,
+				  const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct ad8460_iio_device *dev = ddev;
+	bool pwr_down;
+	uint8_t sdn_flag;
+	int32_t val;
+	int ret;
+
+	ret = iio_parse_value(buf, IIO_VAL_INT, &val, NULL);
+	if (ret < 0)
+		return ret;
+
+	pwr_down = !!val;
+
+	/*
+	 * If powerdown is set, HVDAC is enabled and the HV driver is
+	 * enabled via HV_RESET in case it is in shutdown mode,
+	 * If powerdown is cleared, HVDAC is set to shutdown state
+	 * as well as the HV driver. Quiescent current decreases and ouput is
+	 * floating (high impedance).
+	 */
+
+	ret = ad8460_iio_reg_update_bits(dev, 0x01, AD8460_HVDAC_SLEEP_MSK, pwr_down);
+	if (ret)
+		return ret;
+
+	if (!pwr_down) {
+		ret = ad8460_read_shutdown_flag(dev->dev, &sdn_flag);
+		if (ret)
+			return ret;
+
+		if (sdn_flag) {
+			ret = ad8460_hv_reset(dev->dev);
+			if (ret)
+				return ret;
+		}
+	}
+
+	return ad8460_iio_reg_update_bits(dev, 0x00, AD8460_HV_SLEEP_MSK, !pwr_down);
+}
+
+static struct iio_attribute ad8460_voltage_attrs[] = {
+	AD8460_CHAN_EXT_INFO("raw", 0, ad8460_read_raw, ad8460_write_raw),
+	AD8460_CHAN_EXT_INFO("scale", 0, ad8460_read_scale, NULL),
+	AD8460_CHAN_EXT_INFO("raw0", 0, ad8460_dac_input_read,
+			     ad8460_dac_input_write),
+	AD8460_CHAN_EXT_INFO("raw1", 1, ad8460_dac_input_read,
+			     ad8460_dac_input_write),
+	AD8460_CHAN_EXT_INFO("raw2", 2, ad8460_dac_input_read,
+			     ad8460_dac_input_write),
+	AD8460_CHAN_EXT_INFO("raw3", 3, ad8460_dac_input_read,
+			     ad8460_dac_input_write),
+	AD8460_CHAN_EXT_INFO("raw4", 4, ad8460_dac_input_read,
+			     ad8460_dac_input_write),
+	AD8460_CHAN_EXT_INFO("raw5", 5, ad8460_dac_input_read,
+			     ad8460_dac_input_write),
+	AD8460_CHAN_EXT_INFO("raw6", 6, ad8460_dac_input_read,
+			     ad8460_dac_input_write),
+	AD8460_CHAN_EXT_INFO("raw7", 7, ad8460_dac_input_read,
+			     ad8460_dac_input_write),
+	AD8460_CHAN_EXT_INFO("raw8", 8, ad8460_dac_input_read,
+			     ad8460_dac_input_write),
+	AD8460_CHAN_EXT_INFO("raw9", 9, ad8460_dac_input_read,
+			     ad8460_dac_input_write),
+	AD8460_CHAN_EXT_INFO("raw10", 10, ad8460_dac_input_read,
+			     ad8460_dac_input_write),
+	AD8460_CHAN_EXT_INFO("raw11", 11, ad8460_dac_input_read,
+			     ad8460_dac_input_write),
+	AD8460_CHAN_EXT_INFO("raw12", 12, ad8460_dac_input_read,
+			     ad8460_dac_input_write),
+	AD8460_CHAN_EXT_INFO("raw13", 13, ad8460_dac_input_read,
+			     ad8460_dac_input_write),
+	AD8460_CHAN_EXT_INFO("raw14", 14, ad8460_dac_input_read,
+			     ad8460_dac_input_write),
+	AD8460_CHAN_EXT_INFO("raw15", 15, ad8460_dac_input_read,
+			     ad8460_dac_input_write),
+	AD8460_CHAN_EXT_INFO("toggle_en", 0, ad8460_read_toggle_en,
+			     ad8460_write_toggle_en),
+	AD8460_CHAN_EXT_INFO("symbol", 0, ad8460_read_symbol,
+			     ad8460_write_symbol),
+	AD8460_CHAN_EXT_INFO("powerdown", 0, ad8460_read_powerdown,
+			     ad8460_write_powerdown),
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_attribute ad8460_current_attrs[] = {
+	AD8460_CHAN_EXT_INFO("raw", 0, ad8460_read_raw, ad8460_write_raw),
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct scan_type ad8460_iio_scan_type = {
+	.sign = 'u',
+	.realbits = 14,
+	.storagebits = 16,
+};
+
+static struct iio_channel ad8460_channels[] = {
+	AD8460_VOLTAGE_CHAN,
+	AD8460_CURRENT_CHAN,
+};
+
+static struct iio_device ad8460_iio_dev = {
+	.num_ch = NO_OS_ARRAY_SIZE(ad8460_channels),
+	.channels = ad8460_channels,
+	.debug_reg_read = (int32_t (*)()) ad8460_iio_reg_read,
+	.debug_reg_write = (int32_t (*)()) ad8460_iio_reg_write,
+	.pre_enable = (int32_t (*)()) ad8460_buffer_preenable,
+	.post_disable = (int32_t (*)()) ad8460_buffer_postdisable,
+};
+
+/**
+ * @brief Initializes the AD8460 IIO driver
+ * @param iio_device - The iio device structure.
+ * @param iio_init_param - Parameters for the initialization of iio_dev
+ * @return 0 in case of success, errno errors otherwise
+ */
+int ad8460_iio_init(struct ad8460_iio_device **iio_device,
+		    struct ad8460_iio_init_param *iio_init_param)
+{
+	struct ad8460_iio_device *iio_device_temp;
+	int ret;
+
+	if (!iio_init_param || !iio_init_param->init_param)
+		return -EINVAL;
+
+	iio_device_temp = no_os_calloc(1, sizeof(*iio_device_temp));
+	if (!iio_device_temp)
+		return -ENOMEM;
+
+	ret = ad8460_init(&iio_device_temp->dev, iio_init_param->init_param);
+	if (ret) {
+		no_os_free(iio_device_temp);
+		return ret;
+	}
+
+	iio_device_temp->iio_dev = &ad8460_iio_dev;
+
+	ret = ad8460_reset(iio_device_temp->dev);
+
+	/* Enables DAC by default */
+	ret = ad8460_iio_reg_update_bits(iio_device_temp, 0x01, AD8460_HVDAC_SLEEP_MSK,
+					 0);
+	if (ret)
+		return ret;
+
+	*iio_device = iio_device_temp;
+
+	return 0;
+}
+
+/**
+ * @brief Free resources allocated by the init function
+ * @param iio_device - The iio device structure.
+ * @return 0 in case of success, errno errors otherwise
+ */
+int ad8460_iio_remove(struct ad8460_iio_device *iio_device)
+{
+	int ret;
+
+	ret = ad8460_remove(iio_device->dev);
+	if (ret)
+		return ret;
+
+	no_os_free(iio_device);
+
+	return 0;
+}

--- a/drivers/dac/ad8460/iio_ad8460.h
+++ b/drivers/dac/ad8460/iio_ad8460.h
@@ -1,0 +1,67 @@
+/***************************************************************************//**
+ *   @file   iio_ad8460.h
+ *   @brief  Implementation of IIO AD8460 Driver.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef __IIO_AD8460_H__
+#define __IIO_AD8460_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+
+#include "iio.h"
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+
+struct ad8460_iio_device {
+	struct ad8460_device *dev;
+	struct iio_device *iio_dev;
+	uint32_t active_channels;
+	uint8_t no_active_channels;
+};
+
+struct ad8460_iio_init_param {
+	struct ad8460_init_param *init_param;
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+int ad8460_iio_init(struct ad8460_iio_device **iio_device,
+		    struct ad8460_iio_init_param *iio_init_param);
+
+int ad8460_iio_remove(struct ad8460_iio_device *iio_device);
+
+#endif	/* __IIO_AD8460_H__ */

--- a/projects/eval-ad8460/Makefile
+++ b/projects/eval-ad8460/Makefile
@@ -1,0 +1,9 @@
+# Select the example you want to enable by choosing y for enabling and n for disabling
+BASIC_EXAMPLE = n
+IIO_EXAMPLE = y
+
+include ../../tools/scripts/generic_variables.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/eval-ad8460/README.rst
+++ b/projects/eval-ad8460/README.rst
@@ -1,0 +1,166 @@
+Evaluating the EVAL-AD8460
+===========================
+
+.. contents::
+	:depth: 3
+
+Supported Evaluation Boards
+---------------------------
+
+* `EVAL-AD8460 <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-ad8460.html>`_
+
+Overview
+--------
+
+The EVAL-AD8460SDZ board enables easy evaluation of the AD8460, offered in a 12
+mm x 12 mm, 80-lead thin quad flat package (TQFP) with an exposed pad at the top
+for a mountable heat sink. The evaluation board provides a platform for quick
+and easy evaluation of the AD8460 for various user-defined configurations.
+
+The AD8460 is ideally suited for demanding applications such as high-speed
+arbitrary waveform generation, programmable power supplies, and LCD/OLED panel
+formation.
+
+The evaluation board hardware and software enable full operation of the AD8460
+analog pattern generation (APG) and arbitrary waveform generation (AWG) modes.
+The AD8460 data sheet provides the full specifications of the AD8460 and details
+on the device operation. Consult it in conjunction with the user guide.
+
+Hardware Specifications
+-----------------------
+
+Power Supply Requirments
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+For this specific project, an external 5V supply is connected to the VCC_5V pin
+to supply the SPI communication block of EVAL-AD8460.
+
+Board Connector and Jumper Settings
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Pin Description**
+
+	Please see the following table for the pin assignments:
+
+	+----------+-------------------------------------------+
+	| Name     | Description			       |
+	+----------+-------------------------------------------+
+	| VCC_5V   | Connect to 5V supply		       |
+	+----------+-------------------------------------------+
+	| GND      | Connect to Ground			       |
+	+----------+-------------------------------------------+
+	| SCK      | Connect to SPI Clock (SCK)		       |
+	+----------+-------------------------------------------+
+	| SDO      | Connect to SPI Master In Slave Out (MISO) |
+	+----------+-------------------------------------------+
+	| CS       | Connect to SPI Chip Select (CS)	       |
+	+----------+-------------------------------------------+
+	| SDI      | Connect to SPI Master Out Slave In (MOSI) |
+	+----------+-------------------------------------------+
+	| RESETB   | Connect to GPIO pin (RESET)	       |
+	+----------+-------------------------------------------+
+
+No-OS Build Setup
+-----------------
+
+Please see: https://wiki.analog.com/resources/no-os/build
+
+No-OS Supported Examples
+------------------------
+
+The initialization data used in the examples is taken out from:
+`Project Common Data Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/eval-ad8460/src/common>`_
+
+The macros used in Common Data are defined in platform specific files found in:
+`Project Platform Configuration Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/eval-ad8460/src/platform>`_
+
+Basic example
+^^^^^^^^^^^^^
+
+This is a simple example that:
+
+* initializes the AD8460
+* resets the AD8460
+* switches modes between APG and AWG
+* writes then reads HVDAC registers
+* and reads the shutdown flag
+
+In order to build the basic example make sure you have the following
+configuration in the
+`Makefile <https://github.com/analogdevicesinc/no-OS/tree/main/projects/eval-ad8460/Makefile>`_
+
+.. code-block:: bash
+
+	# Select the example you want to enable by choosing y for enabling and n for disabling
+	BASIC_EXAMPLE = y
+	IIO_EXAMPLE = n
+
+IIO example
+^^^^^^^^^^^
+
+This project is actually a IIOD demo for EVAL-AD8460. The project launches a IIOD
+server on the board so that the user may connect to it via an IIO client.
+
+Using IIO-Oscilloscope, the user can configure the device.
+
+If you are not familiar with ADI IIO Application, please take a look at:
+`IIO No-OS <https://wiki.analog.com/resources/tools-software/no-os-software/iio>`_
+
+If you are not familiar with ADI IIO-Oscilloscope Client, please take a look at:
+`IIO Oscilloscope <https://wiki.analog.com/resources/tools-software/linux-software/iio_oscilloscope>`_
+
+The No-OS IIO Application together with the No-OS IIO AD8460 driver take care
+of all the back-end logic needed to setup the IIO server.
+
+This example initializes the IIO device and calls the IIO app as shown in:
+`IIO Example <https://github.com/analogdevicesinc/no-OS/tree/main/projects/eval-ad8460/src/examples/iio_example>`_
+
+In order to build the IIO project make sure you have the following configuration
+in the
+`Makefile <https://github.com/analogdevicesinc/no-OS/tree/main/projects/eval-ad8460/Makefile>`_
+
+.. code-block:: bash
+
+        # Select the example you want to enable by choosing y for enabling and n for disabling
+        BASIC_EXAMPLE = n
+        IIO__EXAMPLE = y
+
+No-OS Supported Platforms
+-------------------------
+
+Maxim Platform
+^^^^^^^^^^^^^^
+
+**Used hardware**
+
+* `EVAL-AD8460 <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-ad8460.html>`_
+* `MAX32666FTHR <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/max32666fthr.html>`_
+
+**Connections**:
+
++-----------------+---------------------------------+-------------------------+
+| EVAL-AD8460 Pin | Function			    | MAX32666FTHR Pin        |
++-----------------+---------------------------------+-------------------------+
+| VCC_5V          | Low Voltage Power Supply	    | 5V Supply (External)    |
++-----------------+---------------------------------+-------------------------+
+| SCK             | SPI Clock (SCK)		    | AIN3 (SPI1_SCK)	      |
++-----------------+---------------------------------+-------------------------+
+| SDO             | SPI Master In Slave Out (MISO)  | AIN2 (SPI1_MISO)	      |
++-----------------+---------------------------------+-------------------------+
+| CS              | SPI Chip Select (CS)	    | AIN0 (SPI1_SS0)	      |
++-----------------+---------------------------------+-------------------------+
+| SDI             | SPI Master Out Slave In (MOSI)  | AIN1 (SPI1_MOSI)        |
++-----------------+---------------------------------+-------------------------+
+| RESETB          | GPIO (RESET Pin)		    | AIN4 (P0_27)	      |
++-----------------+---------------------------------+-------------------------+
+| GND             | Ground (GND) 		    | GND		      |
++-----------------+---------------------------------+-------------------------+
+
+**Build Command**
+
+.. code-block:: bash
+
+	# to delete current build
+	make PLATFORM=maxim TARGET=max32665 reset
+	# to build the project and flash the code
+	make PLATFORM=maxim TARGET=max32665 run

--- a/projects/eval-ad8460/builds.json
+++ b/projects/eval-ad8460/builds.json
@@ -1,0 +1,10 @@
+{
+    "maxim": {
+      "basic_example_max32665": {
+        "flags" : "BASIC_EXAMPLE=y IIO_EXAMPLE=n TARGET=max32665"
+      },
+      "iio_example_max32665": {
+        "flags" : "BASIC_EXAMPLE=n IIO_EXAMPLE=y TARGET=max32665"
+      }
+    }
+  }

--- a/projects/eval-ad8460/src.mk
+++ b/projects/eval-ad8460/src.mk
@@ -1,0 +1,41 @@
+include $(PROJECT)/src/platform/$(PLATFORM)/platform_src.mk
+include $(PROJECT)/src/examples/examples_src.mk
+
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/main.c
+
+INCS += $(PROJECT)/src/common/common_data.h
+SRCS += $(PROJECT)/src/common/common_data.c
+
+INCS += $(PROJECT)/src/platform/platform_includes.h
+
+INCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.h
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/parameters.c
+
+INCS += $(INCLUDE)/no_os_delay.h     \
+		$(INCLUDE)/no_os_error.h     \
+		$(INCLUDE)/no_os_gpio.h      \
+		$(INCLUDE)/no_os_print_log.h \
+		$(INCLUDE)/no_os_spi.h       \
+		$(INCLUDE)/no_os_alloc.h       \
+		$(INCLUDE)/no_os_irq.h      \
+		$(INCLUDE)/no_os_list.h      \
+		$(INCLUDE)/no_os_dma.h      \
+		$(INCLUDE)/no_os_uart.h      \
+		$(INCLUDE)/no_os_lf256fifo.h \
+		$(INCLUDE)/no_os_util.h 	\
+		$(INCLUDE)/no_os_units.h	\
+		$(INCLUDE)/no_os_mutex.h
+
+SRCS += $(DRIVERS)/api/no_os_gpio.c \
+		$(NO-OS)/util/no_os_lf256fifo.c \
+		$(DRIVERS)/api/no_os_irq.c  \
+		$(DRIVERS)/api/no_os_spi.c  \
+		$(DRIVERS)/api/no_os_uart.c \
+		$(DRIVERS)/api/no_os_dma.c \
+		$(NO-OS)/util/no_os_list.c \
+		$(NO-OS)/util/no_os_util.c \
+		$(NO-OS)/util/no_os_alloc.c \
+		$(NO-OS)/util/no_os_mutex.c
+
+INCS += $(DRIVERS)/dac/ad8460/ad8460.h
+SRCS += $(DRIVERS)/dac/ad8460/ad8460.c

--- a/projects/eval-ad8460/src/common/common_data.c
+++ b/projects/eval-ad8460/src/common/common_data.c
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ *   @file   common_data.c
+ *   @brief  Defines common data to be used by ad8460 examples.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+#include "common_data.h"
+#include <stdbool.h>
+
+struct no_os_uart_init_param uip = {
+	.device_id = UART_DEVICE_ID,
+	.baud_rate = UART_BAUDRATE,
+	.size = NO_OS_UART_CS_8,
+	.parity = NO_OS_UART_PAR_NO,
+	.stop = NO_OS_UART_STOP_1_BIT,
+	.platform_ops = UART_OPS,
+	.extra = UART_EXTRA,
+};
+
+const struct no_os_spi_init_param ad8460_spi_ip = {
+	.device_id = SPI_DEVICE_ID,
+	.max_speed_hz = SPI_MAX_SPEED,
+	.chip_select = SPI_CS,
+	.mode = NO_OS_SPI_MODE_0,
+	.bit_order = NO_OS_SPI_BIT_ORDER_MSB_FIRST,
+	.platform_ops = SPI_OPS,
+	.extra = SPI_EXTRA,
+	.parent = NULL,
+};
+
+const struct no_os_gpio_init_param ad8460_gpio_rstn = {
+	.port = GPIO_RSTN_PORT_NUM,
+	.number = GPIO_RSTN_PIN_NUM,
+	.platform_ops = GPIO_OPS,
+	.extra = GPIO_EXTRA,
+};
+
+struct ad8460_init_param ad8460_ip = {
+	.spi_init_param = ad8460_spi_ip,
+	.gpio_rstn = ad8460_gpio_rstn,
+	.refio_1p2v_mv = 1200,
+	.ext_resistor_ohms = 2000,
+};

--- a/projects/eval-ad8460/src/common/common_data.h
+++ b/projects/eval-ad8460/src/common/common_data.h
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ *   @file   common_data.h
+ *   @brief  Defines common data to be used by ad8460 examples.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#ifndef __COMMON_DATA_H__
+#define __COMMON_DATA_H__
+
+#include "platform_includes.h"
+#include "ad8460.h"
+#ifdef IIO_SUPPORT
+#include "iio_ad8460.h"
+#endif
+
+extern struct no_os_uart_init_param uip;
+
+extern const struct no_os_spi_init_param ad8460_spi_ip;
+extern const struct no_os_gpio_init_param ad8460_gpio_rstn;
+extern struct ad8460_init_param ad8460_ip;
+
+#endif /* __COMMON_DATA_H__ */

--- a/projects/eval-ad8460/src/examples/basic/basic_example.c
+++ b/projects/eval-ad8460/src/examples/basic/basic_example.c
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ *   @file   basic_example.c
+ *   @brief  Basic example code for ad8460 project
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+#include "basic_example.h"
+#include "common_data.h"
+#include "ad8460.h"
+#include "no_os_print_log.h"
+
+/*****************************************************************************
+ * @brief Basic example main execution.
+ *
+ * @return ret - Result of the example execution. If working correctly, will
+ *               execute continuously the while(1) loop and will not return.
+ *******************************************************************************/
+int basic_example_main()
+{
+	struct ad8460_device *dev;
+	int ret, i;
+	uint16_t val;
+	uint8_t flag;
+
+	pr_info("\r\nRunning AD8460 Basic Example\r\n");
+
+	ret = ad8460_init(&dev, &ad8460_ip);
+	if (ret)
+		goto error;
+
+	ret = ad8460_reset(dev);
+	if (ret)
+		goto free_dev;
+
+	/** Switch to APG mode */
+	ret = ad8460_enable_apg_mode(dev, 1);
+	if (ret)
+		goto free_dev;
+
+	/** Switch to AWG mode */
+	ret = ad8460_enable_apg_mode(dev, 0);
+
+	for (i = 0; i < 16; i++) {
+		ret = ad8460_set_hvdac_word(dev, i, i);
+		if (ret)
+			goto free_dev;
+
+		ret = ad8460_get_hvdac_word(dev, i, &val);
+		if (ret)
+			goto free_dev;
+
+		pr_info("HVDAC[%d]: 0x%04X\r\n", i, val);
+	}
+
+	ret = ad8460_read_shutdown_flag(dev, &flag);
+	if (ret)
+		goto free_dev;
+
+	pr_info("Shutdown flag: %d\r\n", flag);
+
+	if (flag) {
+		ret = ad8460_hv_reset(dev);
+		if (ret)
+			goto free_dev;
+	}
+
+	pr_info("AD8460 Basic Example Done\r\n");
+
+	return 0;
+
+free_dev:
+	ad8460_remove(dev);
+error:
+	pr_info("Error!\r\n");
+	return ret;
+}

--- a/projects/eval-ad8460/src/examples/basic/basic_example.h
+++ b/projects/eval-ad8460/src/examples/basic/basic_example.h
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ *   @file   basic_example.h
+ *   @brief  Basic example header for ad8460 project
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#ifndef __BASIC_EXAMPLE_H__
+#define __BASIC_EXAMPLE_H__
+
+int basic_example_main();
+
+#endif /* __BASIC_EXAMPLE_H__ */

--- a/projects/eval-ad8460/src/examples/examples_src.mk
+++ b/projects/eval-ad8460/src/examples/examples_src.mk
@@ -1,0 +1,21 @@
+ifeq (y,$(strip $(IIO_EXAMPLE)))
+IIOD=y
+CFLAGS += -DIIO_EXAMPLE=1
+SRCS += $(PROJECT)/src/examples/iio_example/iio_example.c
+INCS += $(PROJECT)/src/examples/iio_example/iio_example.h
+endif
+
+ifeq (y,$(strip $(BASIC_EXAMPLE)))
+CFLAGS += -DBASIC_EXAMPLE=1
+SRCS += $(PROJECT)/src/examples/basic/basic_example.c
+INCS += $(PROJECT)/src/examples/basic/basic_example.h
+endif
+
+ifeq (y,$(strip $(IIOD)))
+SRC_DIRS += $(NO-OS)/iio/iio_app
+INCS += $(DRIVERS)/dac/ad8460/iio_ad8460.h
+SRCS += $(DRIVERS)/dac/ad8460/iio_ad8460.c
+
+INCS += $(INCLUDE)/no_os_list.h \
+		$(PLATFORM_DRIVERS)/$(PLATFORM)_uart.h
+endif

--- a/projects/eval-ad8460/src/examples/iio_example/iio_example.c
+++ b/projects/eval-ad8460/src/examples/iio_example/iio_example.c
@@ -1,0 +1,81 @@
+/********************************************************************************
+ *   @file   iio_example.c
+ *   @brief  IIO example code for the ad8460 project
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+#include "iio_example.h"
+#include "common_data.h"
+#include "no_os_print_log.h"
+
+/*******************************************************************************
+ * @brief IIO example main execution.
+ *
+ * @return ret - Result of the example execution. If working correctly, will
+ *               execute continuously function iio_app_run and will not return.
+ *******************************************************************************/
+int iio_example_main()
+{
+	int ret;
+	struct ad8460_iio_device *ad8460_iio_dev;
+	struct ad8460_iio_init_param ad8460_iio_ip;
+	struct iio_app_desc *app;
+	struct iio_app_init_param app_init_param = {0};
+
+	ad8460_iio_ip.init_param = &ad8460_ip;
+	ret = ad8460_iio_init(&ad8460_iio_dev, &ad8460_iio_ip);
+	if (ret)
+		return ret;
+
+	struct iio_app_device iio_devices[] = {
+		{
+			.name = "ad8460",
+			.dev = ad8460_iio_dev,
+			.dev_descriptor = ad8460_iio_dev->iio_dev,
+		},
+	};
+
+	app_init_param.devices = iio_devices;
+	app_init_param.nb_devices = NO_OS_ARRAY_SIZE(iio_devices);
+	app_init_param.uart_init_params = uip;
+
+	ret = iio_app_init(&app, app_init_param);
+	if (ret)
+		goto error;
+
+	ret = iio_app_run(app);
+	if (ret)
+		pr_err("Error: iio_app_run: %d\r\n", ret);
+
+	iio_app_remove(app);
+error:
+	ad8460_iio_remove(ad8460_iio_dev);
+	return ret;
+}

--- a/projects/eval-ad8460/src/examples/iio_example/iio_example.h
+++ b/projects/eval-ad8460/src/examples/iio_example/iio_example.h
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ *   @file   iio_example.h
+ *   @brief  IIO example header for ad8460 project
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#ifndef __IIO_EXAMPLE_H__
+#define __IIO_EXAMPLE_H__
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+int iio_example_main();
+
+#endif /* __IIO_EXAMPLE_H__ */

--- a/projects/eval-ad8460/src/platform/maxim/main.c
+++ b/projects/eval-ad8460/src/platform/maxim/main.c
@@ -1,0 +1,80 @@
+/********************************************************************************
+ *   @file   main.c
+ *   @brief  Main file for Maxim platform of ad8460 project.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+#include "platform_includes.h"
+#include "common_data.h"
+
+#ifdef IIO_EXAMPLE
+#include "iio_example.h"
+#endif
+
+#ifdef BASIC_EXAMPLE
+#include "basic_example.h"
+#endif
+
+/*******************************************************************************
+ * @brief Main function execution for AD8460 platform.
+ *
+ * @return ret - Result of the enabled examples execution.
+ *******************************************************************************/
+int main()
+{
+#ifdef BASIC_EXAMPLE
+	int ret;
+	struct no_os_uart_desc *uart;
+
+	ret = no_os_uart_init(&uart, &uip);
+	if (ret)
+		goto error;
+
+	no_os_uart_stdio(uart);
+	ret = basic_example_main();
+	if (ret)
+		goto error;
+#endif
+
+#ifdef IIO_EXAMPLE
+	return iio_example_main();
+#endif
+
+#if (IIO_EXAMPLE + BASIC_EXAMPLE != 1)
+#error Selected example projects cannot be enabled at the same time. \
+Please enable only one example and re - build the project.
+#endif
+
+#ifdef BASIC_EXAMPLE
+error:
+	no_os_uart_remove(uart);
+#endif
+	return 0;
+}

--- a/projects/eval-ad8460/src/platform/maxim/parameters.c
+++ b/projects/eval-ad8460/src/platform/maxim/parameters.c
@@ -1,0 +1,48 @@
+/********************************************************************************
+ *   @file   parameters.c
+ *   @brief  Definition of maxim platform data used by ad8460 project.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#include "parameters.h"
+
+struct max_uart_init_param max_uart_extra = {
+	.flow = UART_FLOW_DIS,
+	.vssel = MXC_GPIO_VSSEL_VDDIOH
+};
+
+struct max_spi_init_param  max_spi_extra = {
+	.num_slaves = 1,
+	.polarity = SPI_SS_POL_LOW,
+	.vssel = MXC_GPIO_VSSEL_VDDIOH
+};
+
+struct max_gpio_init_param max_gpio_extra = {
+	.vssel = MXC_GPIO_VSSEL_VDDIOH
+};

--- a/projects/eval-ad8460/src/platform/maxim/parameters.h
+++ b/projects/eval-ad8460/src/platform/maxim/parameters.h
@@ -1,0 +1,83 @@
+/********************************************************************************
+ *   @brief  Definitions specific to Maxim platform used by ad8460 project.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
+
+#include "maxim_gpio.h"
+#include "maxim_spi.h"
+#include "maxim_uart.h"
+#include "maxim_uart_stdio.h"
+
+#ifdef IIO_SUPPORT
+#define INTC_DEVICE_ID	0
+#endif
+
+#if (TARGET_NUM == 32690)
+#define	UART_IRQ_ID	UART0_IRQn
+#define UART_DEVICE_ID	0
+#elif (TARGET_NUM == 32665)
+#define UART_IRQ_ID	UART1_IRQn
+#define UART_DEVICE_ID	1
+#endif
+
+#define UART_BAUDRATE	115200
+#define UART_OPS	&max_uart_ops
+#define UART_EXTRA      &max_uart_extra
+
+#if (TARGET_NUM == 32650)
+#define SPI_DEVICE_ID	1
+#define SPI_CS		0
+#elif (TARGET_NUM == 32660) || (TARGET_NUM == 32655)
+#define SPI_DEVICE_ID	0
+#define SPI_CS		0
+#elif (TARGET_NUM == 32665)
+#define SPI_DEVICE_ID	1
+#define SPI_CS		0
+#elif (TARGET_NUM == 78000)
+#define SPI_DEVICE_ID	1
+#define SPI_CS		1
+#endif
+
+#define SPI_MAX_SPEED	1000000
+#define SPI_OPS		&max_spi_ops
+#define SPI_EXTRA	&max_spi_extra
+
+#define GPIO_RSTN_PORT_NUM	0
+#define GPIO_RSTN_PIN_NUM	27
+#define GPIO_OPS	&max_gpio_ops
+#define GPIO_EXTRA 	&max_gpio_extra
+
+extern struct max_uart_init_param max_uart_extra;
+extern struct max_spi_init_param max_spi_extra;
+extern struct max_gpio_init_param max_gpio_extra;
+
+#endif /* __PARAMETERS_H__ */

--- a/projects/eval-ad8460/src/platform/maxim/platform_src.mk
+++ b/projects/eval-ad8460/src/platform/maxim/platform_src.mk
@@ -1,0 +1,14 @@
+INCS +=	$(PLATFORM_DRIVERS)/maxim_gpio.h      \
+		$(PLATFORM_DRIVERS)/maxim_spi.h       \
+		$(PLATFORM_DRIVERS)/../common/maxim_dma.h       \
+		$(PLATFORM_DRIVERS)/maxim_irq.h      \
+		$(PLATFORM_DRIVERS)/maxim_uart.h      \
+		$(PLATFORM_DRIVERS)/maxim_uart_stdio.h
+
+SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c     \
+		$(PLATFORM_DRIVERS)/maxim_gpio.c      \
+		$(PLATFORM_DRIVERS)/maxim_spi.c       \
+		$(PLATFORM_DRIVERS)/../common/maxim_dma.c       \
+		$(PLATFORM_DRIVERS)/maxim_irq.c      \
+		$(PLATFORM_DRIVERS)/maxim_uart.c      \
+		$(PLATFORM_DRIVERS)/maxim_uart_stdio.c

--- a/projects/eval-ad8460/src/platform/platform_includes.h
+++ b/projects/eval-ad8460/src/platform/platform_includes.h
@@ -1,0 +1,47 @@
+/********************************************************************************
+ *   @file   platform_includes.h
+ *   @brief  Includes for used platforms used by the ad8460 project.
+ *   @author John Erasmus Mari Geronimo (johnerasmusmari.geronimo@analog.com)
+ ********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#ifndef __PLATFORM_INCLUDES_H__
+#define __PLATFORM_INCLUDES_H__
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#ifdef MAXIM_PLATFORM
+#include "maxim/parameters.h"
+#endif
+
+#ifdef IIO_SUPPORT
+#include "iio_app.h"
+#endif
+
+#endif /* __PLATFORM_INCLUDES_H__ */


### PR DESCRIPTION
## Pull Request Description

Note: IIO Driver was patterned to the mainline AD8460 Linux driver

The AD8460 is a “bits in, power out” high voltage, high-power, high-speed driver optimized for large output current (up to ±1 A) and high slew rate (up to ±1800 V/μs) at high voltage (up to ±40 V) into capacitive loads. Combining a 14-bit high-speed DAC, a high voltage, high output current (HV-HI) analog driver, and fault monitoring and protection circuits, the AD8460 is ideally suited for high power applications such as arbitrary waveform generation (AWG), programmable power supplies, and high voltage automated test equipment (ATE).

A proprietary high-voltage BCDMOS process, novel high voltage architecture, and thermally enhanced package from Analog Devices Inc. enable this high-performance driver. A digital engine implements user-configurable features: modes for digital input, programmable supply current, and fault monitoring and programmable protection settings for output current, output voltage, and junction temperature. Analog features extend functionality: external compensation enables unlimited capacitive load drive, programmable shutdown delay, and full-scale adjustment. The AD8460 operates on high voltage dual supplies up to ±55 V and a single low voltage supply of 5 V.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
