### PR TITLE
drivers: power: lt3074: add driver for LT3074

### DIFF
--- a/doc/sphinx/source/drivers/lt3074.rst
+++ b/doc/sphinx/source/drivers/lt3074.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../drivers/power/lt3074/README.rst

--- a/doc/sphinx/source/drivers_doc.rst
+++ b/doc/sphinx/source/drivers_doc.rst
@@ -106,6 +106,7 @@ POWER MANAGEMENT
    drivers/ltc7841
    drivers/ltc7871
    drivers/ltm4686
+   drivers/lt3074
    drivers/lt7170
    drivers/lt7182s
    drivers/lt8491

--- a/doc/sphinx/source/projects/lt3074.rst
+++ b/doc/sphinx/source/projects/lt3074.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../projects/lt3074/README.rst

--- a/doc/sphinx/source/projects_doc.rst
+++ b/doc/sphinx/source/projects_doc.rst
@@ -78,6 +78,7 @@ POWER MANAGEMENT
    projects/ltc7841
    projects/ltc7871
    projects/ltm4686
+   projects/lt3074
    projects/lt7170
    projects/lt7182s
    projects/lt8722

--- a/drivers/power/lt3074/README.rst
+++ b/drivers/power/lt3074/README.rst
@@ -1,0 +1,206 @@
+LT3074 no-OS driver
+====================
+
+Supported Devices
+-----------------
+
+`LT3074 <https://www.analog.com/LT3074>`_
+
+Overview
+--------
+
+The LT3074 is a low voltage, ultralow noise, and ultrafast transient response
+linear regulator with a PMBus serial interface. The device supplies up to 3A
+with a typical dropout voltage of 45mV. 
+
+Applications
+------------
+
+LT3074
+-------
+
+* RF Power Supplies: PLLs, VCOs, Mixers, LNAs, PAs
+* High Speed/High Precision Data Converters
+* Low Noise Instrumentation
+* Post-Regulator for Switching Supplies
+* FPGA and DSP Power Supplies
+* Medical Applications
+
+LT3074 Device Configuration
+----------------------------
+
+Driver Initialization
+---------------------
+
+In order to be able to use the device, you will have to provide the support
+for the communication protocol (I2C) alongside other GPIO pins if needed in the
+specific application (depends on the way the device is used).
+
+The first API to be called is **lt3074_init**. Make sure that it return 0,
+which means that the driver was initialized correctly.
+
+The initialization API uses the device descriptor and an initialization
+parameter. The initialization parameter contains the optional GPIO pin
+parameters for interfacing with ALERT and EN pins, and configurations for packet
+error checking.
+
+Status Bytes
+------------
+
+Assertion in the status bytes/words indicates fault/warning in device input/
+output, temperature, and communication, memory and logic. These statuses can be
+accessed via the **lt3074_read_status** API.
+
+Telemetry
+---------
+
+Measurements for each output channel can be read using the
+**lt3074_read_value** API. Some telemetry values includes input/output voltage,
+input/output current, die temperature, and output power.
+
+Overvalue and Undervalue Limits Configuration
+---------------------------------------------
+
+Overvalue and undervalue limits sets the threshold at which the device voltage,
+current, and temperature must meet. When these measurements cross the limits, a
+status bit may be asserted. These limits can be configured using the
+**lt3074_set_limit** API.
+
+VOUT Margin Configuration
+-------------------------
+
+The LT3074 output voltage margin is programmable from 0% to 30%. These can be
+configured using the **lt3074_vout_margin** API.
+
+LT3074 Driver Initialization Example
+-------------------------------------
+
+.. code-block:: bash
+
+	struct lt3074_dev *lt3074_dev;
+	struct no_os_i2c_init_param lt3074_i2c_ip = {
+		.device_id = I2C_DEVICE_ID,
+		.max_speed_hz = 100000,
+		.platform_ops = I2C_OPS,
+		.slave_address = LT3074_PMBUS_ADDRESS,
+		.extra = I2C_EXTRA,
+        };
+
+	struct no_os_gpio_init_param lt3074_enable_ip = {
+		.port = GPIO_EN_PORT,
+		.number = GPIO_EN_NUMBER,
+		.pull = NO_OS_PULL_UP,
+		.platform_ops = GPIO_OPS,
+		.extra = GPIO_EXTRA,
+	};
+
+	struct lt3074_init_param lt3074_ip = {
+		.i2c_init = &lt3074_i2c_ip,
+		.alert_param = NULL,
+		.pg_param = NULL,
+		.en_param = lt3074_enable_ip,
+		.crc_en = false,
+	};
+
+	ret = lt3074_init(&lt3074_dev, &lt3074_ip);
+	if (ret)
+		goto error;
+
+LT3074 no-OS IIO support
+-------------------------
+
+The LT3074 IIO driver comes on top of the LT3074 driver and offers support
+for interfacing IIO clients through libiio.
+
+LT3074 IIO Device Configuration
+--------------------------------
+
+Channels
+--------
+
+The device has a total of 3 input channels and 2 output channels. The input
+consists of the input voltage, bias voltage, and the die temperature. The
+output consists of the output voltage and current.
+
+* ``vout - output voltage``
+* ``iout - output current``
+* ``vin - input voltage``
+* ``vbias - bias voltage``
+* ``temperature - die temperature``
+
+Channel Attributes
+------------------
+
+EAch channels have 2 channel attributes:
+
+* ``raw - the raw value of the channel``
+* ``scale - the scale value of the channel calculated accordingly to each specific channel using a priv``
+
+Global Attributes
+-----------------
+
+The device has a total of 12 global attributes:
+
+* ``vout_margin_low - VOUT margin low limit``
+* ``vout_margin_high - VOUT margin high limit``
+* ``vout_margin_available - Available state of the vout_margin_low and vout_margin_high``
+* ``vout_ov_warn_limit - Output overvoltage warning limit``
+* ``vout_uv_warn_limit - Output undervoltage warning limit``
+* ``iout_oc_fault_limit - Output overcurrent fault limit``
+* ``ot_warn_limit - Overtemperature warning limit``
+* ``vin_ov_warn_limit - Input overvoltage warning limit``
+* ``vin_uv_warn_limit - Input undervoltage warning limit``
+* ``vbias_ov_warn_limit - Bias overvoltage warning limit``
+* ``vbias_uv_warn_limit - Bias undervoltage warning limit``
+* ``iout_min_warn_limit - Output minimum current warning limit``
+
+Debug Attributes
+----------------
+
+The device has a total of 8 debug attributes:
+
+* ``status_byte - Status byte value``
+* ``status_vout - VOUT status byte value``
+* ``status_iout - IOUT status byte value``
+* ``status_input - INPUT status byte value``
+* ``status_mfr_specific - MFR_SPECIFIC status byte value``
+* ``status_word - Status word value``
+* ``status_temperature - TEMPERATURE status byte value of the device``
+* ``status_cml - CML status byte value of the device``
+
+LT3074 IIO Driver Initialization Example
+-----------------------------------------
+
+.. code-block:: bash
+
+	int ret;
+
+	struct lt3074_iio_desc *lt3074_iio_desc;
+	struct lt3074_iio_desc_init_param lt3074_iio_ip = {
+		.lt3074_init_param = &lt3074_ip,
+	};
+
+	struct iio_app_desc *app;
+	struct iio_app_init_param app_init_param = { 0 };
+
+	ret = lt3074_iio_init(&lt3074_iio_desc, &lt3074_iio_ip);
+	if (ret)
+		return ret;
+
+	struct iio_app_device iio_devices[] = {
+		{
+			.name = "lt3074",
+			.dev = lt3074_iio_desc,
+			.dev_descriptor = lt3074_iio_desc->iio_dev,
+		}
+	};
+
+	app_init_param.devices = iio_devices;
+	app_init_param.nb_devices = NO_OS_ARRAY_SIZE(iio_devices);
+	app_init_param.uart_init_params = lt3074_uart_ip;
+
+	ret = iio_app_init(&app, app_init_param);
+	if (ret)
+		return ret;
+
+	return iio_app_run(app);

--- a/drivers/power/lt3074/iio_lt3074.c
+++ b/drivers/power/lt3074/iio_lt3074.c
@@ -1,0 +1,446 @@
+/***************************************************************************//**
+*   @file   iio_lt3074.c
+*   @brief  Source file for the LT3074 IIO Driver
+*   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+* Copyright 2025(c) Analog Devices, Inc.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* 3. Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived from this
+*    software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+* EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include "no_os_alloc.h"
+#include "no_os_error.h"
+#include "no_os_units.h"
+#include "no_os_util.h"
+
+#include "lt3074.h"
+#include "iio_lt3074.h"
+
+static const int32_t lt3074_margin_avail[] = {0, 1, 3, 5, 10, 15, 20, 25, 30};
+
+enum lt3074_iio_chan_type {
+	LT3074_IIO_VIN_CHAN,
+	LT3074_IIO_VOUT_CHAN,
+	LT3074_IIO_IOUT_CHAN,
+	LT3074_IIO_TEMP_CHAN,
+	LT3074_IIO_VBIAS_CHAN,
+};
+
+enum lt3074_iio_attr_id {
+	LT3074_IIO_CHAN_ATTR_RAW,
+	LT3074_IIO_CHAN_ATTR_SCALE,
+	LT3074_IIO_GLOBAL_ATTR_VOUT_MARGIN_LOW,
+	LT3074_IIO_GLOBAL_ATTR_VOUT_MARGIN_HIGH,
+	LT3074_IIO_GLOBAL_ATTR_VOUT_MARGIN_AVAILABLE,
+	LT3074_IIO_GLOBAL_ATTR_VOUT_OV_WARN_LIMIT = LT3074_VOUT_OV_WARN_LIMIT_TYPE,
+	LT3074_IIO_GLOBAL_ATTR_VOUT_UV_WARN_LIMIT = LT3074_VOUT_UV_WARN_LIMIT_TYPE,
+	LT3074_IIO_GLOBAL_ATTR_IOUT_OC_FAULT_LIMIT = LT3074_IOUT_OC_FAULT_LIMIT_TYPE,
+	LT3074_IIO_GLOBAL_ATTR_OT_WARN_LIMIT = LT3074_OT_WARN_LIMIT_TYPE,
+	LT3074_IIO_GLOBAL_ATTR_VIN_OV_WARN_LIMIT = LT3074_VIN_OV_WARN_LIMIT_TYPE,
+	LT3074_IIO_GLOBAL_ATTR_VIN_UV_WARN_LIMIT = LT3074_VIN_UV_WARN_LIMIT_TYPE,
+	LT3074_IIO_GLOBAL_ATTR_VBIAS_OV_WARN_LIMIT = LT3074_VBIAS_OV_WARN_LIMIT_TYPE,
+	LT3074_IIO_GLOBAL_ATTR_VBIAS_UV_WARN_LIMIT = LT3074_VBIAS_UV_WARN_LIMIT_TYPE,
+	LT3074_IIO_GLOBAL_ATTR_IOUT_MIN_WARN_LIMIT = LT3074_IOUT_MIN_WARN_LIMIT_TYPE,
+	LT3074_IIO_DBG_ATTR_STATUS_BYTE = LT3074_STATUS_BYTE,
+	LT3074_IIO_DBG_ATTR_STATUS_VOUT = LT3074_STATUS_VOUT,
+	LT3074_IIO_DBG_ATTR_STATUS_IOUT = LT3074_STATUS_IOUT,
+	LT3074_IIO_DBG_ATTR_STATUS_INPUT = LT3074_STATUS_INPUT,
+	LT3074_IIO_DBG_ATTR_STATUS_TEMPERATURE = LT3074_STATUS_TEMPERATURE,
+	LT3074_IIO_DBG_ATTR_STATUS_CML = LT3074_STATUS_CML,
+	LT3074_IIO_DBG_ATTR_STATUS_MFR_SPECIFIC = LT3074_STATUS_MFR_SPECIFIC,
+	LT3074_IIO_DBG_ATTR_STATUS_WORD = LT3074_STATUS_WORD,
+};
+
+static struct iio_device lt3074_iio_dev;
+
+/**
+ * @brief Handles read request for all attributes.
+ *
+ * @param dev - IIO device structure.
+ * @param buf - Command buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Command attribute id.
+ * @return ret - Result of the reading procedure.
+ */
+static int lt3074_iio_attr_read(void *dev, char *buf, uint32_t len,
+				const struct iio_ch_info *channel,
+				intptr_t priv)
+{
+	struct lt3074_iio_desc *iio_lt3074 = dev;
+	struct lt3074_dev *lt3074 = iio_lt3074->lt3074_dev;
+	int ret, data;
+	int32_t value = 0, vals[2];
+	uint32_t i, regval;
+
+	if (!dev)
+		return -EINVAL;
+
+	if (!lt3074)
+		return -EINVAL;
+
+	switch (priv) {
+	case LT3074_IIO_CHAN_ATTR_RAW:
+		switch (channel->address) {
+		case LT3074_IIO_VIN_CHAN:
+			ret = lt3074_read_value(lt3074, LT3074_VIN, &data);
+			break;
+		case LT3074_IIO_IOUT_CHAN:
+			ret = lt3074_read_value(lt3074, LT3074_IOUT, &data);
+			break;
+		case LT3074_IIO_VOUT_CHAN:
+			ret = lt3074_read_value(lt3074, LT3074_VOUT, &data);
+			break;
+		case LT3074_IIO_TEMP_CHAN:
+			ret = lt3074_read_value(lt3074, LT3074_TEMP, &data);
+			break;
+		case LT3074_IIO_VBIAS_CHAN:
+			ret = lt3074_read_value(lt3074, LT3074_VBIAS, &data);
+			break;
+		default:
+			return -EINVAL;
+		}
+		if (ret)
+			return ret;
+
+		value = data;
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &value);
+
+	case LT3074_IIO_CHAN_ATTR_SCALE:
+		vals[0] = 1;
+		vals[1] = MILLI;
+
+		return iio_format_value(buf, len, IIO_VAL_FRACTIONAL, 2, vals);
+
+	case LT3074_IIO_GLOBAL_ATTR_VOUT_MARGIN_LOW:
+	case LT3074_IIO_GLOBAL_ATTR_VOUT_MARGIN_HIGH:
+		ret = lt3074_reg_read(lt3074, LT3074_MFR_MARGIN, &regval);
+		if (ret)
+			return ret;
+
+		if (priv == LT3074_IIO_GLOBAL_ATTR_VOUT_MARGIN_LOW)
+			regval = no_os_field_get(LT3074_MARGIN_LOW_MSK, regval);
+		else
+			regval = no_os_field_get(LT3074_MARGIN_HIGH_MSK, regval);
+
+		regval = no_os_clamp(regval, 0, 8);
+
+		return sprintf(buf, "%d ", lt3074_margin_avail[regval]);
+
+	case LT3074_IIO_GLOBAL_ATTR_VOUT_MARGIN_AVAILABLE:
+		for (i = 0; i < NO_OS_ARRAY_SIZE(lt3074_margin_avail); i++)
+			value += sprintf(buf + value, "%d ",
+					 lt3074_margin_avail[i]);
+
+		return value;
+
+	case LT3074_IIO_GLOBAL_ATTR_VOUT_OV_WARN_LIMIT:
+	case LT3074_IIO_GLOBAL_ATTR_VOUT_UV_WARN_LIMIT:
+	case LT3074_IIO_GLOBAL_ATTR_IOUT_OC_FAULT_LIMIT:
+	case LT3074_IIO_GLOBAL_ATTR_OT_WARN_LIMIT:
+	case LT3074_IIO_GLOBAL_ATTR_VIN_OV_WARN_LIMIT:
+	case LT3074_IIO_GLOBAL_ATTR_VIN_UV_WARN_LIMIT:
+	case LT3074_IIO_GLOBAL_ATTR_VBIAS_OV_WARN_LIMIT:
+	case LT3074_IIO_GLOBAL_ATTR_VBIAS_UV_WARN_LIMIT:
+	case LT3074_IIO_GLOBAL_ATTR_IOUT_MIN_WARN_LIMIT:
+		ret = lt3074_read_word_data(lt3074, (uint32_t)priv, &data);
+		if (ret)
+			return ret;
+
+		vals[0] = data / MILLI;
+		vals[1] = data * MILLI % MICRO;
+
+		return iio_format_value(buf, len, IIO_VAL_INT_PLUS_MICRO,
+					2, vals);
+
+	case LT3074_IIO_DBG_ATTR_STATUS_BYTE:
+	case LT3074_IIO_DBG_ATTR_STATUS_VOUT:
+	case LT3074_IIO_DBG_ATTR_STATUS_IOUT:
+	case LT3074_IIO_DBG_ATTR_STATUS_INPUT:
+	case LT3074_IIO_DBG_ATTR_STATUS_TEMPERATURE:
+	case LT3074_IIO_DBG_ATTR_STATUS_CML:
+	case LT3074_IIO_DBG_ATTR_STATUS_MFR_SPECIFIC:
+		ret = lt3074_reg_read(lt3074, priv, &regval);
+		if (ret)
+			return ret;
+
+		value = regval;
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &value);
+
+	case LT3074_IIO_DBG_ATTR_STATUS_WORD:
+		ret = lt3074_reg_read(lt3074, LT3074_STATUS_WORD, &regval);
+		if (ret)
+			return ret;
+
+		value = regval;
+
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, &value);
+
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Handles write request for all attributes.
+ *
+ * @param dev - IIO device structure.
+ * @param buf - Command buffer to be filled with requested data.
+ * @param len - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv - Command attribute id.
+ * @return ret - Result of the writing procedure.
+ */
+static int lt3074_iio_attr_write(void *dev, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel,
+				 intptr_t priv)
+{
+	struct lt3074_iio_desc *iio_lt3074 = dev;
+	struct lt3074_dev *lt3074 = iio_lt3074->lt3074_dev;
+	int ret;
+	int32_t val1, val2;
+	uint32_t i;
+	uint8_t byte;
+
+	if (!dev)
+		return -EINVAL;
+
+	if (!lt3074)
+		return -EINVAL;
+
+	switch (priv) {
+	case LT3074_IIO_GLOBAL_ATTR_VOUT_MARGIN_LOW:
+	case LT3074_IIO_GLOBAL_ATTR_VOUT_MARGIN_HIGH:
+		iio_parse_value(buf, IIO_VAL_INT, &val1, NULL);
+
+		for (i = 0; i < NO_OS_ARRAY_SIZE(lt3074_margin_avail); i++)
+			if (val1 == lt3074_margin_avail[i])
+				break;
+
+		if (i == NO_OS_ARRAY_SIZE(lt3074_margin_avail))
+			return -EINVAL;
+
+		ret = lt3074_read_byte(lt3074, LT3074_MFR_MARGIN, &byte);
+		if (ret)
+			return ret;
+
+		if (priv == LT3074_IIO_GLOBAL_ATTR_VOUT_MARGIN_LOW) {
+			byte &= ~LT3074_MARGIN_LOW_MSK;
+			byte |= no_os_field_prep(LT3074_MARGIN_LOW_MSK, i);
+		} else {
+			byte &= ~LT3074_MARGIN_HIGH_MSK;
+			byte |= no_os_field_prep(LT3074_MARGIN_HIGH_MSK, i);
+		}
+
+		return lt3074_write_byte(lt3074, LT3074_MFR_MARGIN, byte);
+
+	case LT3074_IIO_GLOBAL_ATTR_VOUT_OV_WARN_LIMIT:
+	case LT3074_IIO_GLOBAL_ATTR_VOUT_UV_WARN_LIMIT:
+	case LT3074_IIO_GLOBAL_ATTR_IOUT_OC_FAULT_LIMIT:
+	case LT3074_IIO_GLOBAL_ATTR_OT_WARN_LIMIT:
+	case LT3074_IIO_GLOBAL_ATTR_VIN_OV_WARN_LIMIT:
+	case LT3074_IIO_GLOBAL_ATTR_VIN_UV_WARN_LIMIT:
+	case LT3074_IIO_GLOBAL_ATTR_VBIAS_OV_WARN_LIMIT:
+	case LT3074_IIO_GLOBAL_ATTR_VBIAS_UV_WARN_LIMIT:
+	case LT3074_IIO_GLOBAL_ATTR_IOUT_MIN_WARN_LIMIT:
+		iio_parse_value(buf, IIO_VAL_INT_PLUS_MICRO, &val1, &val2);
+
+		val1 = val1 * MILLI + val2 / MILLI;
+
+		return lt3074_set_limit(lt3074, (enum lt3074_limit_type)priv,
+					val1);
+
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Initializes the LT3074 IIO descriptor.
+ * @param iio_desc - The iio device descriptor.
+ * @param init_param - The structure that contains the device initial parameters.
+ * @return 0 in case of success, an error code otherwise.
+ */
+int lt3074_iio_init(struct lt3074_iio_desc **iio_desc,
+		    struct lt3074_iio_desc_init_param *init_param)
+{
+	struct lt3074_iio_desc *descriptor;
+	int ret;
+
+	if (!init_param || !init_param->lt3074_init_param)
+		return -EINVAL;
+
+	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	ret = lt3074_init(&descriptor->lt3074_dev,
+			  init_param->lt3074_init_param);
+	if (ret)
+		goto dev_err;
+
+	descriptor->iio_dev = &lt3074_iio_dev;
+
+	*iio_desc = descriptor;
+
+	return 0;
+
+dev_err:
+	lt3074_iio_remove(descriptor);
+
+	return ret;
+}
+
+/**
+ * @brief Free resources allocated by the init function.
+ * @param iio_desc - The iio device descriptor.
+ * @return 0 in case of success, an error code otherwise.
+ */
+int lt3074_iio_remove(struct lt3074_iio_desc *iio_desc)
+{
+	if (!iio_desc)
+		return -ENODEV;
+
+	lt3074_remove(iio_desc->lt3074_dev);
+	no_os_free(iio_desc);
+
+	return 0;
+}
+
+#define LT3074_IIO_CHAN_ATTR(_name, _value) \
+	{ \
+		.name = #_name, \
+		.show = lt3074_iio_attr_read, \
+		.priv = LT3074_IIO_CHAN_ATTR_##_value, \
+	}
+
+#define LT3074_IIO_GLOBAL_ATTR(_name, _value) \
+	{ \
+		.name = #_name, \
+		.show = lt3074_iio_attr_read, \
+		.store = lt3074_iio_attr_write, \
+		.priv = LT3074_IIO_GLOBAL_ATTR_##_value, \
+	}
+
+#define LT3074_IIO_DBG_ATTR(_name, _value) \
+	{ \
+		.name = #_name, \
+		.show = lt3074_iio_attr_read, \
+		.priv = LT3074_IIO_DBG_ATTR_##_value, \
+	}
+
+static struct iio_attribute lt3074_chan_attrs[] = {
+	LT3074_IIO_CHAN_ATTR(raw, RAW),
+	LT3074_IIO_CHAN_ATTR(scale, SCALE),
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_attribute lt3074_global_attrs[] = {
+	LT3074_IIO_GLOBAL_ATTR(vout_margin_low, VOUT_MARGIN_LOW),
+	LT3074_IIO_GLOBAL_ATTR(vout_margin_high, VOUT_MARGIN_HIGH),
+	LT3074_IIO_GLOBAL_ATTR(vout_margin_available, VOUT_MARGIN_AVAILABLE),
+	LT3074_IIO_GLOBAL_ATTR(vout_ov_warn_limit, VOUT_OV_WARN_LIMIT),
+	LT3074_IIO_GLOBAL_ATTR(vout_uv_warn_limit, VOUT_UV_WARN_LIMIT),
+	LT3074_IIO_GLOBAL_ATTR(iout_oc_fault_limit, IOUT_OC_FAULT_LIMIT),
+	LT3074_IIO_GLOBAL_ATTR(ot_warn_limit, OT_WARN_LIMIT),
+	LT3074_IIO_GLOBAL_ATTR(vin_ov_warn_limit, VIN_OV_WARN_LIMIT),
+	LT3074_IIO_GLOBAL_ATTR(vin_uv_warn_limit, VIN_UV_WARN_LIMIT),
+	LT3074_IIO_GLOBAL_ATTR(vbias_ov_warn_limit, VBIAS_OV_WARN_LIMIT),
+	LT3074_IIO_GLOBAL_ATTR(vbias_uv_warn_limit, VBIAS_UV_WARN_LIMIT),
+	LT3074_IIO_GLOBAL_ATTR(iout_min_warn_limit, IOUT_MIN_WARN_LIMIT),
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_attribute lt3074_debug_attrs[] = {
+	LT3074_IIO_DBG_ATTR(status_byte, STATUS_BYTE),
+	LT3074_IIO_DBG_ATTR(status_vout, STATUS_VOUT),
+	LT3074_IIO_DBG_ATTR(status_iout, STATUS_IOUT),
+	LT3074_IIO_DBG_ATTR(status_input, STATUS_INPUT),
+	LT3074_IIO_DBG_ATTR(status_temperature, STATUS_TEMPERATURE),
+	LT3074_IIO_DBG_ATTR(status_cml, STATUS_CML),
+	LT3074_IIO_DBG_ATTR(status_mfr_specific, STATUS_MFR_SPECIFIC),
+	LT3074_IIO_DBG_ATTR(status_word, STATUS_WORD),
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_channel lt3074_channels[] = {
+	{
+		.name = "vin",
+		.ch_type = IIO_VOLTAGE,
+		.indexed = 1,
+		.channel = LT3074_IIO_VIN_CHAN,
+		.address = LT3074_IIO_VIN_CHAN,
+		.attributes = lt3074_chan_attrs,
+		.ch_out = false
+	},
+	{
+		.name = "vout",
+		.ch_type = IIO_VOLTAGE,
+		.indexed = 1,
+		.channel = LT3074_IIO_VOUT_CHAN,
+		.address = LT3074_IIO_VOUT_CHAN,
+		.attributes = lt3074_chan_attrs,
+		.ch_out = true,
+	},
+	{
+		.name = "iout",
+		.ch_type = IIO_CURRENT,
+		.indexed = 1,
+		.channel = LT3074_IIO_IOUT_CHAN,
+		.address = LT3074_IIO_IOUT_CHAN,
+		.attributes = lt3074_chan_attrs,
+		.ch_out = true,
+	},
+	{
+		.name = "temperature",
+		.ch_type = IIO_TEMP,
+		.indexed = 1,
+		.channel = LT3074_IIO_TEMP_CHAN,
+		.address = LT3074_IIO_TEMP_CHAN,
+		.attributes = lt3074_chan_attrs,
+		.ch_out = false,
+	},
+	{
+		.name = "vbias",
+		.ch_type = IIO_VOLTAGE,
+		.indexed = 1,
+		.channel = LT3074_IIO_VBIAS_CHAN,
+		.address = LT3074_IIO_VBIAS_CHAN,
+		.attributes = lt3074_chan_attrs,
+		.ch_out = false,
+	},
+};
+
+static struct iio_device lt3074_iio_dev = {
+	.num_ch = NO_OS_ARRAY_SIZE(lt3074_channels),
+	.channels = lt3074_channels,
+	.attributes = lt3074_global_attrs,
+	.debug_attributes = lt3074_debug_attrs,
+};

--- a/drivers/power/lt3074/iio_lt3074.h
+++ b/drivers/power/lt3074/iio_lt3074.h
@@ -1,0 +1,62 @@
+/***************************************************************************//**
+*   @file   iio_lt3074.h
+*   @brief  Header file for the LT3074 IIO Driver
+*   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+* Copyright 2025(c) Analog Devices, Inc.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* 3. Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived from this
+*    software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+* EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef IIO_LT3074_H
+#define IIO_LT3074_H
+
+#include <stdbool.h>
+#include "iio.h"
+#include "lt3074.h"
+
+/**
+ * @brief Structure holding the LT3074 IIO device descriptor
+*/
+struct lt3074_iio_desc {
+	struct lt3074_dev *lt3074_dev;
+	struct iio_device *iio_dev;
+};
+
+/**
+ * @brief Structure holding the LT3074 IIO initialization parameter.
+*/
+struct lt3074_iio_desc_init_param {
+	struct lt3074_init_param *lt3074_init_param;
+};
+
+/** Initializes the LT3074 IIO descriptor. */
+int lt3074_iio_init(struct lt3074_iio_desc **,
+		    struct lt3074_iio_desc_init_param *);
+
+/** Free resources allocated by the initialization function. */
+int lt3074_iio_remove(struct lt3074_iio_desc *);
+
+#endif /* IIO_LT3074_H */

--- a/drivers/power/lt3074/lt3074.c
+++ b/drivers/power/lt3074/lt3074.c
@@ -1,0 +1,854 @@
+/*******************************************************************************
+*   @file   lt3074.c
+*   @brief  Source code of the LT3074 Driver
+*   @authors Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+* Copyright 2025(c) Analog Devices, Inc.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* 3. Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived from this
+*    software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+* EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#include "no_os_units.h"
+#include "no_os_util.h"
+#include "no_os_delay.h"
+#include "no_os_alloc.h"
+#include "no_os_i2c.h"
+#include "no_os_gpio.h"
+#include "no_os_crc8.h"
+
+#include "lt3074.h"
+
+/* LINEAR data format params */
+#define LT3074_LIN11_MANTISSA_MAX	1023000L
+#define LT3074_LIN11_MANTISSA_MIN	511000L
+#define LT3074_LIN11_EXPONENT_MAX	15
+#define LT3074_LIN11_EXPONENT_MIN	-15
+#define LT3074_LIN11_MANTISSA_MSK	NO_OS_GENMASK(10,0)
+#define LT3074_LIN11_EXPONENT_MSK	NO_OS_GENMASK(15,11)
+#define LT3074_LIN11_EXPONENT(x)	((int16_t)(x) >> 11)
+#define LT3074_LIN11_MANTISSA(x)	(((int16_t)((x & 0x7FF) << 5)) >> 5)
+#define LT3074_LIN16_EXPONENT		-13
+
+NO_OS_DECLARE_CRC8_TABLE(lt3074_crc_table);
+
+/**
+ * @brief Converts data to LINEAR16 register value.
+ *
+ * @param dev The LT3074 device structure.
+ * @param data The data value to be converted.
+ * @param reg Pointer to store the converted register value.
+ * @return Returns 0 on success, or a negative error code on failure.
+ */
+static int lt3074_data2reg_linear16(struct lt3074_dev *dev, int data,
+				    uint16_t *reg)
+{
+	if (data <= 0)
+		return -EINVAL;
+	data <<= -(dev->lin16_exp);
+
+	data = NO_OS_DIV_ROUND_CLOSEST_ULL(data, MILLI);
+	*reg = (uint16_t)no_os_clamp(data, 0, 0xFFFF);
+
+	return 0;
+}
+
+/**
+ * @brief Converts data to LINEAR11 register value
+ *
+ * @param dev The LT3074 device structure.
+ * @param data The data value to be converted.
+ * @param reg Pointer to store the resulting register value.
+ * @return Returns 0 on success, or a negative error code on failure.
+ */
+static int lt3074_data2reg_linear11(struct lt3074_dev *dev, int data,
+				    uint16_t *reg)
+{
+	int exp = 0, mant = 0;
+	uint8_t negative = 0;
+
+	if (data < 0) {
+		negative = 1;
+		data = -data;
+	}
+
+	/* If value too high, continuously do m/2 until m < 1023. */
+	while (data >= LT3074_LIN11_MANTISSA_MAX &&
+	       exp < LT3074_LIN11_EXPONENT_MAX) {
+		exp++;
+		data >>= 1;
+	}
+
+	/* If value too low, increase mantissa. */
+	while (data < LT3074_LIN11_MANTISSA_MIN &&
+	       exp > LT3074_LIN11_EXPONENT_MIN) {
+		exp--;
+		data <<= 1;
+	}
+
+	mant = no_os_clamp(NO_OS_DIV_ROUND_CLOSEST_ULL(data, MILLI),
+			   0, NO_OS_GENMASK(9, 0));
+	if (negative)
+		mant = -mant;
+
+	*reg = no_os_field_prep(LT3074_LIN11_MANTISSA_MSK, mant) |
+	       no_os_field_prep(LT3074_LIN11_EXPONENT_MSK, exp);
+
+	return 0;
+}
+
+/**
+ * @brief Converts raw LINEAR16 register value to its actual data
+ *
+ * @param dev   Pointer to the lt3074_dev structure.
+ * @param reg   16-bit register value to be converted.
+ * @param data  Pointer to an integer to store the converted linear data.
+ * @return      0 on success, negative error code on failure.
+ */
+static int lt3074_reg2data_linear16(struct lt3074_dev *dev, uint16_t reg,
+				    int *data)
+{
+	int exp = dev->lin16_exp;
+	if (exp < 0)
+		exp = -exp;
+
+	*data = ((int)(reg) * MILLI) >> exp;
+
+	return 0;
+}
+
+/**
+ * @brief Converts raw LINEAR11 register value to its actual data
+ *
+ * @param dev   Pointer to the LT3074 device structure.
+ * @param reg   The register value to be converted.
+ * @param data  Pointer to the variable where the converted data will be stored.
+ * @return      Returns 0 on success, or a negative error code on failure.
+ */
+static int lt3074_reg2data_linear11(struct lt3074_dev *dev, uint16_t reg,
+				    int *data)
+{
+	int val, exp, mant;
+
+	exp = LT3074_LIN11_EXPONENT(reg);
+	mant = LT3074_LIN11_MANTISSA(reg);
+
+	val = mant * MILLI;
+	if (exp >= 0)
+		*data = val << exp;
+	else
+		*data = val >> -exp;
+
+	return 0;
+}
+
+/**
+ * @brief Converts the given data value to a register value.
+ *
+ * @param dev The LT3074 device structure.
+ * @param cmd The command value.
+ * @param data The data value to be converted.
+ * @param reg Pointer to store the converted register value.
+ * @return Returns 0 on success, or a negative error code on failure.
+ */
+static int lt3074_data2reg(struct lt3074_dev *dev, uint32_t cmd,
+			   int data, uint16_t *reg)
+{
+	switch (cmd) {
+	case LT3074_VOUT_OV_WARN_LIMIT:
+	case LT3074_VOUT_UV_WARN_LIMIT:
+	case LT3074_READ_VOUT:
+		return lt3074_data2reg_linear16(dev, data, reg);
+	case LT3074_IOUT_OC_FAULT_LIMIT:
+	case LT3074_OT_WARN_LIMIT:
+	case LT3074_VIN_OV_WARN_LIMIT:
+	case LT3074_VIN_UV_WARN_LIMIT:
+	case LT3074_READ_VIN:
+	case LT3074_READ_IOUT:
+	case LT3074_READ_TEMPERATURE_1:
+	case LT3074_MFR_READ_VBIAS:
+	case LT3074_MFR_BIAS_OV_WARN_LIMIT:
+	case LT3074_MFR_BIAS_UV_WARN_LIMIT:
+	case LT3074_MFR_IOUT_MIN_WARN_LIMIT:
+		return lt3074_data2reg_linear11(dev, data, reg);
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Converts the given register value to its actual data value.
+ *
+ * @param dev The LT3074 device structure.
+ * @param cmd The command value.
+ * @param reg The register value to be converted.
+ * @param data Pointer to store the converted data value.
+ * @return Returns 0 on success, or a negative error code on failure.
+ */
+static int lt3074_reg2data(struct lt3074_dev *dev, uint32_t cmd,
+			   uint16_t reg, int *data)
+{
+	switch (cmd) {
+	case LT3074_VOUT_OV_WARN_LIMIT:
+	case LT3074_VOUT_UV_WARN_LIMIT:
+	case LT3074_READ_VOUT:
+		return lt3074_reg2data_linear16(dev, reg, data);
+	case LT3074_IOUT_OC_FAULT_LIMIT:
+	case LT3074_OT_WARN_LIMIT:
+	case LT3074_VIN_OV_WARN_LIMIT:
+	case LT3074_VIN_UV_WARN_LIMIT:
+	case LT3074_READ_VIN:
+	case LT3074_READ_IOUT:
+	case LT3074_READ_TEMPERATURE_1:
+	case LT3074_MFR_READ_VBIAS:
+	case LT3074_MFR_BIAS_OV_WARN_LIMIT:
+	case LT3074_MFR_BIAS_UV_WARN_LIMIT:
+	case LT3074_MFR_IOUT_MIN_WARN_LIMIT:
+		return lt3074_reg2data_linear11(dev, reg, data);
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Perform packet-error checking via CRC
+ *
+ * @param dev The LT3074 device structure.
+ * @param cmd The command byte.
+ * @param buf Pointer to the data buffer.
+ * @param nbytes Number of bytes in the data buffer.
+ * @param op Operation performed. 0 for write, 1 for read
+ * @return The calculated PEC value.
+ */
+static uint8_t lt3074_pec(struct lt3074_dev *dev, uint8_t cmd, uint8_t *buf,
+			  size_t nbytes, uint8_t op)
+{
+	uint8_t crc_buf[nbytes + op + 2];
+
+	crc_buf[0] = (dev->i2c_desc->slave_address << 1);
+	crc_buf[1] = cmd;
+	if (op)
+		crc_buf[2] = (dev->i2c_desc->slave_address << 1) | 1;
+
+	memcpy(&crc_buf[2 + op], buf, nbytes);
+
+	return no_os_crc8(lt3074_crc_table, crc_buf, nbytes + op + 2, 0);
+}
+
+/**
+ * @brief Initialize the device structure
+ *
+ * @param device - Device structure
+ * @param init_param - Initialization parameters
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt3074_init(struct lt3074_dev **device,
+		struct lt3074_init_param *init_param)
+{
+	struct lt3074_dev *dev;
+	int ret;
+	uint32_t value;
+	uint8_t block[7];
+
+	dev = (struct lt3074_dev *)no_os_calloc(1, sizeof(struct lt3074_dev));
+	if (!dev)
+		return -ENOMEM;
+
+	/* Initialize I2C */
+	ret = no_os_i2c_init(&dev->i2c_desc, init_param->i2c_init);
+	if (ret)
+		goto i2c_err;
+
+	/* Identify device */
+	ret = lt3074_reg_read(dev, LT3074_MFR_SPECIAL_ID, &value);
+	if (ret)
+		goto dev_err;
+	if (value != LT3074_SPECIAL_ID_VALUE) {
+		ret = -EIO;
+		goto dev_err;
+	}
+
+	ret = lt3074_read_block_data(dev, LT3074_IC_DEVICE_ID,
+				     block, 6);
+	if (ret || (strncmp((char *)block, "LT3074", 6))) {
+		ret = -EIO;
+		goto dev_err;
+	}
+
+	/* Set PEC */
+	dev->crc_en = init_param->crc_en;
+	if (dev->crc_en)
+		no_os_crc8_populate_msb(lt3074_crc_table,
+					LT3074_CRC_POLYNOMIAL);
+
+	dev->lin16_exp = LT3074_LIN16_EXPONENT;
+
+	/* Initialize GPIO for PGOOD */
+	ret = no_os_gpio_get_optional(&dev->pg_desc,
+				      init_param->pg_param);
+	if (ret)
+		goto dev_err;
+
+	ret = no_os_gpio_direction_input(dev->pg_desc);
+	if (ret)
+		goto dev_err;
+
+	/* Initialize GPIO for EN */
+	ret = no_os_gpio_get_optional(&dev->en_desc,
+				      init_param->en_param);
+	if (ret)
+		goto dev_err;
+
+	ret = no_os_gpio_direction_output(dev->en_desc, NO_OS_GPIO_HIGH);
+	if (ret)
+		goto dev_err;
+
+	/* Initialize GPIO for ALERT */
+	ret = no_os_gpio_get_optional(&dev->alert_desc,
+				      init_param->alert_param);
+	if (ret)
+		goto dev_err;
+
+	ret = no_os_gpio_direction_input(dev->alert_desc);
+	if (ret)
+		goto dev_err;
+
+	/* Set operation */
+	ret = lt3074_set_operation(dev, LT3074_OPERATION_ON);
+	if (ret)
+		goto dev_err;
+
+	/* Clear faults */
+	ret = lt3074_clear_faults(dev);
+	if (ret)
+		goto dev_err;
+
+	*device = dev;
+
+	return 0;
+
+dev_err:
+	no_os_i2c_remove(dev->i2c_desc);
+i2c_err:
+	no_os_free(dev);
+	return ret;
+}
+
+/**
+ * @brief Free or remove device instance
+ *
+ * @param dev - The device structure
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt3074_remove(struct lt3074_dev *dev)
+{
+	int ret;
+
+	ret = no_os_i2c_remove(dev->i2c_desc);
+	if (ret)
+		return ret;
+
+	ret = no_os_gpio_remove(dev->pg_desc);
+	if (ret)
+		return ret;
+
+	ret = no_os_gpio_remove(dev->en_desc);
+	if (ret)
+		return ret;
+
+	ret = no_os_gpio_remove(dev->alert_desc);
+	if (ret)
+		return ret;
+
+	no_os_free(dev);
+
+	return ret;
+}
+
+/**
+ * @brief Send a PMBus command to the device
+ *
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt3074_send_byte(struct lt3074_dev *dev, uint32_t cmd)
+{
+	uint8_t command = LT3074_CMD(cmd);
+	return no_os_i2c_write(dev->i2c_desc, &command, 1, 1);
+}
+
+/**
+ * @brief Perform a raw PMBus read byte operation
+ *
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @param data - Address of the byte read
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt3074_read_byte(struct lt3074_dev *dev, uint32_t cmd, uint8_t *data)
+{
+	int ret;
+	uint8_t rx_buf[2];
+	uint8_t command = LT3074_CMD(cmd);
+
+	ret = no_os_i2c_write(dev->i2c_desc, &command, 1, 0);
+	if (ret)
+		return ret;
+
+	if (dev->crc_en) {
+		ret = no_os_i2c_read(dev->i2c_desc, rx_buf, 2, 1);
+		if (ret)
+			return ret;
+
+		if (lt3074_pec(dev, command, rx_buf, 1, 1) != rx_buf[1])
+			return -EBADMSG;
+
+		*data = rx_buf[0];
+		return ret;
+	} else
+		return no_os_i2c_read(dev->i2c_desc, data, 1, 1);
+}
+
+/**
+ * @brief Perform a raw PMBus write byte operation
+ *
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @param value - Byte to be written
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt3074_write_byte(struct lt3074_dev *dev, uint32_t cmd, uint8_t value)
+{
+	uint8_t tx_buf[3] = {0};
+
+	tx_buf[0] = LT3074_CMD(cmd);
+	tx_buf[1] = value;
+
+	if (dev->crc_en)
+		tx_buf[2] = lt3074_pec(dev, tx_buf[0], &value, 1, 0);
+
+	return no_os_i2c_write(dev->i2c_desc, tx_buf, dev->crc_en + 2, 1);
+}
+
+/**
+ * @brief Perform a raw PMBus read word operation
+ *
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @param word - Address of the read word
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt3074_read_word(struct lt3074_dev *dev, uint32_t cmd, uint16_t *word)
+{
+	int ret;
+	uint8_t rx_buf[3] = {0};
+	uint8_t command = LT3074_CMD(cmd);
+
+	ret = no_os_i2c_write(dev->i2c_desc, &command, 1, 0);
+	if (ret)
+		return ret;
+
+	if (dev->crc_en) {
+		ret = no_os_i2c_read(dev->i2c_desc, rx_buf, 3, 1);
+		if (ret)
+			return ret;
+
+		if (lt3074_pec(dev, command, rx_buf, 2, 1) != rx_buf[2])
+			return -EBADMSG;
+	} else {
+		ret = no_os_i2c_read(dev->i2c_desc, rx_buf, 2, 1);
+		if (ret)
+			return ret;
+	}
+
+	*word = no_os_get_unaligned_le16(rx_buf);
+	return 0;
+}
+
+/**
+ * @brief Perform a raw PMBus write word operation
+ *
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @param word - Word to write
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt3074_write_word(struct lt3074_dev *dev, uint32_t cmd, uint16_t word)
+{
+	uint8_t tx_buf[4] = {0};
+
+	tx_buf[0] = LT3074_CMD(cmd);
+	no_os_put_unaligned_le16(word, &tx_buf[1]);
+
+	if (dev->crc_en)
+		tx_buf[3] = lt3074_pec(dev, tx_buf[0], &tx_buf[1], 2, 0);
+
+	return no_os_i2c_write(dev->i2c_desc, tx_buf, dev->crc_en + 3, 1);
+}
+
+/**
+ * @brief Perform a PMBus read word operation and converts to actual value
+ *
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @param data - Address of data read
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt3074_read_word_data(struct lt3074_dev *dev, uint32_t cmd, int *data)
+{
+	int ret;
+	uint16_t reg;
+
+	ret = lt3074_read_word(dev, cmd, &reg);
+	if (ret)
+		return ret;
+
+	return lt3074_reg2data(dev, cmd, reg, data);
+}
+
+/**
+ * @brief Converts value to register data and do PMBus write word operation
+ *
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @param data - Value to write
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt3074_write_word_data(struct lt3074_dev *dev, uint32_t cmd, int data)
+{
+	int ret;
+	uint16_t reg;
+
+	ret = lt3074_data2reg(dev, cmd, data, &reg);
+	if (ret)
+		return ret;
+
+	return lt3074_write_word(dev, cmd, reg);
+}
+
+/**
+ * @brief Perform a PMBus read block operation
+ *
+ * @param dev - Device structure
+ * @param cmd - PMBus command
+ * @param data - Address of the read block
+ * @param nbytes - Size of the block in bytes
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt3074_read_block_data(struct lt3074_dev *dev, uint32_t cmd,
+			   uint8_t *data, size_t nbytes)
+{
+	int ret;
+	uint8_t rxbuf[nbytes + 2];
+	uint8_t command = LT3074_CMD(cmd);
+
+	ret = no_os_i2c_write(dev->i2c_desc, &command, 1, 0);
+	if (ret)
+		return ret;
+
+	if (dev->crc_en) {
+		ret = no_os_i2c_read(dev->i2c_desc, rxbuf, nbytes + 2, 1);
+		if (ret)
+			return ret;
+
+		if ((size_t)rxbuf[0] > nbytes)
+			return -EMSGSIZE;
+
+		if (lt3074_pec(dev, command, rxbuf, nbytes + 1, 1) !=
+		    rxbuf[nbytes + 1])
+			return -EBADMSG;
+
+		memcpy(data, &rxbuf[1], nbytes);
+	} else {
+		ret = no_os_i2c_read(dev->i2c_desc, rxbuf, nbytes + 1, 1);
+		if (ret)
+			return ret;
+
+		if ((size_t)rxbuf[0] > nbytes)
+			return -EMSGSIZE;
+
+		memcpy(data, &rxbuf[1], nbytes);
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Generic register read wrapper
+ *
+ * @param dev - Device structure
+ * @param reg - PMBus regiser
+ * @param data - Address of the read data
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt3074_reg_read(struct lt3074_dev *dev, uint32_t reg, uint32_t *data)
+{
+	int ret;
+	int size = LT3074_ADDR_SIZE(reg);
+	uint16_t word;
+	uint8_t byte;
+	uint8_t block[size];
+
+	switch (size) {
+	case LT3074_BYTE:
+		ret = lt3074_read_byte(dev, reg, &byte);
+		if (ret)
+			return ret;
+
+		*data = byte;
+
+		return 0;
+	case LT3074_WORD:
+		ret = lt3074_read_word(dev, reg, &word);
+		if (ret)
+			return ret;
+
+		*data = word;
+
+		return 0;
+	default:
+		ret = lt3074_read_block_data(dev, reg, block, size);
+		if (ret)
+			return ret;
+
+		*data = no_os_get_unaligned_be32(block);
+
+		return 0;
+	}
+}
+
+/**
+ * @brief Generic register write wrapper
+ *
+ * @param dev - Device structure
+ * @param reg - PMBus register
+ * @param val - Value to write
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt3074_reg_write(struct lt3074_dev *dev, uint32_t reg, uint32_t val)
+{
+	switch (LT3074_ADDR_SIZE(reg)) {
+	case LT3074_BYTE:
+		return lt3074_write_byte(dev, LT3074_CMD(reg), (uint8_t)val);
+	case LT3074_WORD:
+		return lt3074_write_word(dev, LT3074_CMD(reg), (uint16_t)val);
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Read a value
+ *
+ * @param dev - Device structure
+ * @param value_type - Value type.
+ * 		       Example values: LT3074_VIN
+ * 				       LT3074_VOUT
+ * 				       LT3074_IOUT
+ * 				       LT3074_TEMP
+ * 				       LT3074_VBIAS
+ * @param value - Address of the read value
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt3074_read_value(struct lt3074_dev *dev,
+		      enum lt3074_value_type value_type,
+		      int *value)
+{
+	return lt3074_read_word_data(dev, value_type, value);
+}
+
+/**
+ * @brief Read statuses
+ *
+ * @param dev - Device structure
+ * @param status_type - Status type.
+ * 			Example values: LT3074_STATUS_BYTE_TYPE
+ * 					LT3074_STATUS_VOUT_TYPE
+ * 					LT3074_STATUS_IOUT_TYPE
+ * 					LT3074_STATUS_INPUT_TYPE
+ * 					LT3074_STATUS_CML_TYPE
+ * @param status - Address of the status structure
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt3074_read_status(struct lt3074_dev *dev,
+		       enum lt3074_status_type status_type,
+		       struct lt3074_status *status)
+{
+	int ret;
+
+	if (status_type & LT3074_STATUS_WORD_TYPE) {
+		ret = lt3074_read_word(dev, LT3074_STATUS_WORD, &status->word);
+		if (ret)
+			return ret;
+	}
+
+	if (status_type & LT3074_STATUS_BYTE_TYPE) {
+		ret = lt3074_read_byte(dev, LT3074_STATUS_BYTE, &status->byte);
+		if (ret)
+			return ret;
+	}
+
+	if (status_type & LT3074_STATUS_VOUT_TYPE) {
+		ret = lt3074_read_byte(dev, LT3074_STATUS_VOUT, &status->vout);
+		if (ret)
+			return ret;
+	}
+
+	if (status_type & LT3074_STATUS_IOUT_TYPE) {
+		ret = lt3074_read_byte(dev, LT3074_STATUS_IOUT, &status->iout);
+		if (ret)
+			return ret;
+	}
+
+	if (status_type & LT3074_STATUS_INPUT_TYPE) {
+		ret = lt3074_read_byte(dev, LT3074_STATUS_INPUT, &status->input);
+		if (ret)
+			return ret;
+	}
+
+	if (status_type & LT3074_STATUS_TEMP_TYPE) {
+		ret = lt3074_read_byte(dev,
+				       LT3074_STATUS_TEMPERATURE,
+				       &status->temp);
+		if (ret)
+			return ret;
+	}
+
+	if (status_type & LT3074_STATUS_CML_TYPE) {
+		ret = lt3074_read_byte(dev, LT3074_STATUS_CML, &status->cml);
+		if (ret)
+			return ret;
+	}
+
+	if (status_type & LT3074_STATUS_MFR_SPECIFIC_TYPE) {
+		ret = lt3074_read_byte(dev,
+				       LT3074_STATUS_MFR_SPECIFIC,
+				       &status->mfr_specific);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Set output voltage margin
+ *
+ * @param dev - Device structure
+ * @param margin_high - Upper margin
+ * @param margin_low - Lower margin
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt3074_vout_margin(struct lt3074_dev *dev, enum lt3074_margin margin_high,
+		       enum lt3074_margin margin_low)
+{
+	uint32_t raw_data;
+
+	raw_data = no_os_field_prep(LT3074_MARGIN_LOW_MSK, margin_high) |
+		   no_os_field_prep(LT3074_MARGIN_HIGH_MSK, margin_low);
+
+	return lt3074_reg_write(dev, LT3074_MFR_MARGIN, raw_data);
+}
+
+/**
+ * @brief Sets the limit value for a specific fault/warning limits.
+ *
+ * @param dev - Device structure
+ * @param limit - The type of limit to set.
+ * @param limit_val - The value to set for the specified limit type.
+ * @return Returns 0 on success, or a negative error code on failure.
+ */
+int lt3074_set_limit(struct lt3074_dev *dev, enum lt3074_limit_type limit,
+		     int limit_val)
+{
+	return lt3074_write_word_data(dev, limit, limit_val);
+}
+
+/**
+ * @brief Set operation.
+ *
+ * @param dev - Device structure
+ * @param operation - Operation.
+ * 		      Accepted values are: LT3074_OPERATION_OFF
+ * 					   LT3074_OPERATION_ON
+ * 					   LT3074_OPERATION_MARGIN_HIGH
+ * 					   LT3074_OPERATION_MARGIN_LOW
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt3074_set_operation(struct lt3074_dev *dev,
+			 enum lt3074_operation_type operation)
+{
+	int ret;
+	uint32_t temp;
+
+	ret = lt3074_reg_read(dev, LT3074_OPERATION, &temp);
+	if (ret)
+		return ret;
+
+	temp &= ~LT3074_OPERATION_ACCESS_MSK;
+	temp |= operation;
+
+	return lt3074_reg_write(dev, LT3074_OPERATION, temp);
+}
+
+/**
+ * @brief Clear status registers.
+ *
+ * @param dev - Device structure
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt3074_clear_faults(struct lt3074_dev *dev)
+{
+	return lt3074_send_byte(dev, LT3074_CLEAR_FAULTS);
+}
+
+/**
+ * @brief Enable/Disable the device using the EN pin.
+ *
+ * @param dev - Device structure
+ * @param state - Enable/Disable state. 0 for disable, 1 for enable.
+ *
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt3074_set_enable_pin(struct lt3074_dev *dev, bool state)
+{
+	return no_os_gpio_direction_output(dev->en_desc, state);
+}
+
+/**
+ * @brief Perform a device software reset
+ *
+ * @param dev - Device structure
+ * @return 0 in case of success, negative error code otherwise
+ */
+int lt3074_software_reset(struct lt3074_dev *dev)
+{
+	return lt3074_send_byte(dev, LT3074_MFR_RESET);
+}

--- a/drivers/power/lt3074/lt3074.h
+++ b/drivers/power/lt3074/lt3074.h
@@ -1,0 +1,264 @@
+/*******************************************************************************
+*   @file   lt3074.h
+*   @brief  Header file of the LT3074 Driver
+*   @authors Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+* Copyright 2025(c) Analog Devices, Inc.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* 3. Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived from this
+*    software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+* EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __LT3074_H__
+#define __LT3074_H__
+
+#include <stdint.h>
+#include <string.h>
+#include "no_os_util.h"
+#include "no_os_i2c.h"
+
+#define LT3074_SEND_BYTE			0 /* Send-only command */
+#define LT3074_BYTE				1 /* Byte */
+#define LT3074_WORD				2 /* Word */
+
+#define LT3074_R0B				(LT3074_SEND_BYTE << 8)
+#define LT3074_R1B				(LT3074_BYTE << 8)
+#define LT3074_R2B				(LT3074_WORD << 8)
+#define LT3074_R6B				(6 << 8) /* Block of size 6*/
+
+#define LT3074_SIZE_MSK				NO_OS_GENMASK(15,8)
+#define LT3074_CMD(x)				((uint8_t)(x & 0xFF))
+#define LT3074_ADDR_SIZE(x)			no_os_field_get(LT3074_SIZE_MSK, x)
+
+/* PMBus registers */
+#define LT3074_PAGE				(LT3074_R1B | 0x00)
+#define LT3074_OPERATION			(LT3074_R1B | 0x01)
+#define LT3074_ON_OFF_CONFIG			(LT3074_R1B | 0x02)
+#define LT3074_CLEAR_FAULTS			(LT3074_R0B | 0x03)
+#define LT3074_WRITE_PROTECT			(LT3074_R1B | 0x10)
+#define LT3074_CAPABILITY			(LT3074_R1B | 0x19)
+#define LT3074_VOUT_MODE			(LT3074_R1B | 0x20)
+#define LT3074_VOUT_OV_WARN_LIMIT		(LT3074_R2B | 0x42)
+#define LT3074_VOUT_UV_WARN_LIMIT		(LT3074_R2B | 0x43)
+#define LT3074_IOUT_OC_FAULT_LIMIT		(LT3074_R2B | 0x46)
+#define LT3074_IOUT_OC_FAULT_RESPONSE		(LT3074_R1B | 0x47)
+#define LT3074_OT_WARN_LIMIT			(LT3074_R2B | 0x51)
+#define LT3074_VIN_OV_WARN_LIMIT		(LT3074_R2B | 0x57)
+#define LT3074_VIN_UV_WARN_LIMIT		(LT3074_R2B | 0x58)
+#define LT3074_STATUS_BYTE			(LT3074_R1B | 0x78)
+#define LT3074_STATUS_WORD			(LT3074_R2B | 0x79)
+#define LT3074_STATUS_VOUT			(LT3074_R1B | 0x7A)
+#define LT3074_STATUS_IOUT			(LT3074_R1B | 0x7B)
+#define LT3074_STATUS_INPUT			(LT3074_R1B | 0x7C)
+#define LT3074_STATUS_TEMPERATURE		(LT3074_R1B | 0x7D)
+#define LT3074_STATUS_CML			(LT3074_R1B | 0x7E)
+#define LT3074_STATUS_MFR_SPECIFIC		(LT3074_R1B | 0x80)
+#define LT3074_READ_VIN				(LT3074_R2B | 0x88)
+#define LT3074_READ_VOUT			(LT3074_R2B | 0x8B)
+#define LT3074_READ_IOUT			(LT3074_R2B | 0x8C)
+#define LT3074_READ_TEMPERATURE_1		(LT3074_R2B | 0x8D)
+#define LT3074_REVISION				(LT3074_R1B | 0x98)
+#define LT3074_IC_DEVICE_ID			(LT3074_R6B | 0xAD)
+#define LT3074_IC_DEVICE_REV			(LT3074_R2B | 0xAE)
+
+/* Manufacturer registers */
+#define LT3074_MFR_MARGIN			(LT3074_R1B | 0xC4)
+#define LT3074_MFR_READ_VBIAS			(LT3074_R2B | 0xC6)
+#define LT3074_MFR_BIAS_OV_WARN_LIMIT		(LT3074_R2B | 0xC7)
+#define LT3074_MFR_BIAS_UV_WARN_LIMIT		(LT3074_R2B | 0xC8)
+#define LT3074_MFR_IOUT_MIN_WARN_LIMIT		(LT3074_R2B | 0xC9)
+#define LT3074_MFR_SPECIAL_ID			(LT3074_R2B | 0xE7)
+#define LT3074_MFR_DEFAULT_CONFIG		(LT3074_R1B | 0xF5)
+#define LT3074_MFR_RAIL_ADDRESS			(LT3074_R1B | 0xFA)
+#define LT3074_MFR_RESET			(LT3074_R0B | 0xFD)
+
+/* PMBus-specific parameters */
+#define LT3074_CRC_POLYNOMIAL			0x7
+#define LT3074_MARGIN_HIGH_MSK			0xF0
+#define LT3074_MARGIN_LOW_MSK			0x0F
+#define LT3074_OPERATION_ACCESS_MSK		(NO_OS_GENMASK(5,4) | NO_OS_BIT(7))
+#define LT3074_SPECIAL_ID_VALUE			0x1C1D
+
+/* Status types masks */
+#define LT3074_STATUS_BYTE_TYPE_MSK		0x01
+#define LT3074_STATUS_VOUT_TYPE_MSK		0x02
+#define LT3074_STATUS_IOUT_TYPE_MSK		0x04
+#define LT3074_STATUS_INPUT_TYPE_MSK		0x08
+#define LT3074_STATUS_TEMP_TYPE_MSK		0x10
+#define LT3074_STATUS_CML_TYPE_MSK		0x20
+#define LT3074_STATUS_MFR_SPECIFIC_TYPE_MSK	0x40
+#define LT3074_STATUS_WORD_TYPE_MSK		0x80
+#define LT3074_STATUS_ALL_TYPE_MSK		0xFF
+
+enum lt3074_operation_type {
+	LT3074_OPERATION_OFF,
+	LT3074_OPERATION_ON = 0x80,
+	LT3074_OPERATION_MARGIN_HIGH = 0xA0,
+	LT3074_OPERATION_MARGIN_LOW = 0x90,
+};
+
+enum lt3074_value_type {
+	LT3074_VIN = LT3074_READ_VIN,
+	LT3074_VOUT = LT3074_READ_VOUT,
+	LT3074_IOUT = LT3074_READ_IOUT,
+	LT3074_TEMP = LT3074_READ_TEMPERATURE_1,
+	LT3074_VBIAS = LT3074_MFR_READ_VBIAS,
+};
+
+enum lt3074_limit_type {
+	LT3074_VOUT_OV_WARN_LIMIT_TYPE = LT3074_VOUT_OV_WARN_LIMIT,
+	LT3074_VOUT_UV_WARN_LIMIT_TYPE = LT3074_VOUT_UV_WARN_LIMIT,
+	LT3074_IOUT_OC_FAULT_LIMIT_TYPE = LT3074_IOUT_OC_FAULT_LIMIT,
+	LT3074_OT_WARN_LIMIT_TYPE = LT3074_OT_WARN_LIMIT,
+	LT3074_VIN_OV_WARN_LIMIT_TYPE = LT3074_VIN_OV_WARN_LIMIT,
+	LT3074_VIN_UV_WARN_LIMIT_TYPE = LT3074_VIN_UV_WARN_LIMIT,
+	LT3074_VBIAS_OV_WARN_LIMIT_TYPE = LT3074_MFR_BIAS_OV_WARN_LIMIT,
+	LT3074_VBIAS_UV_WARN_LIMIT_TYPE = LT3074_MFR_BIAS_UV_WARN_LIMIT,
+	LT3074_IOUT_MIN_WARN_LIMIT_TYPE	= LT3074_MFR_IOUT_MIN_WARN_LIMIT,
+};
+
+enum lt3074_status_type {
+	LT3074_STATUS_BYTE_TYPE = LT3074_STATUS_BYTE_TYPE_MSK,
+	LT3074_STATUS_VOUT_TYPE = LT3074_STATUS_VOUT_TYPE_MSK,
+	LT3074_STATUS_IOUT_TYPE = LT3074_STATUS_IOUT_TYPE_MSK,
+	LT3074_STATUS_INPUT_TYPE = LT3074_STATUS_INPUT_TYPE_MSK,
+	LT3074_STATUS_TEMP_TYPE = LT3074_STATUS_TEMP_TYPE_MSK,
+	LT3074_STATUS_CML_TYPE = LT3074_STATUS_CML_TYPE_MSK,
+	LT3074_STATUS_MFR_SPECIFIC_TYPE = LT3074_STATUS_MFR_SPECIFIC_TYPE_MSK,
+	LT3074_STATUS_WORD_TYPE = LT3074_STATUS_WORD_TYPE_MSK,
+	LT3074_STATUS_ALL_TYPE = LT3074_STATUS_ALL_TYPE_MSK,
+};
+
+enum lt3074_margin {
+	LT3074_MARGIN_PERCENTAGE_0,
+	LT3074_MARGIN_PERCENTAGE_1,
+	LT3074_MARGIN_PERCENTAGE_3,
+	LT3074_MARGIN_PERCENTAGE_5,
+	LT3074_MARGIN_PERCENTAGE_10,
+	LT3074_MARGIN_PERCENTAGE_15,
+	LT3074_MARGIN_PERCENTAGE_20,
+	LT3074_MARGIN_PERCENTAGE_25,
+	LT3074_MARGIN_PERCENTAGE_30,
+};
+
+struct lt3074_dev {
+	struct no_os_i2c_desc *i2c_desc;
+	struct no_os_gpio_desc *pg_desc;
+	struct no_os_gpio_desc *en_desc;
+	struct no_os_gpio_desc *alert_desc;
+
+	int lin16_exp;
+	bool crc_en;
+};
+
+struct lt3074_init_param {
+	struct no_os_i2c_init_param *i2c_init;
+	struct no_os_gpio_init_param *pg_param;
+	struct no_os_gpio_init_param *en_param;
+	struct no_os_gpio_init_param *alert_param;
+
+	bool crc_en;
+};
+
+struct lt3074_status {
+	uint16_t word;
+	uint8_t byte;
+	uint8_t vout;
+	uint8_t iout;
+	uint8_t input;
+	uint8_t temp;
+	uint8_t cml;
+	uint8_t mfr_specific;
+};
+
+/* Initialize the device structure */
+int lt3074_init(struct lt3074_dev **dev,
+		struct lt3074_init_param *init_param);
+
+/* Free or remove device instance */
+int lt3074_remove(struct lt3074_dev *dev);
+
+/* Send a PMBus command to the device */
+int lt3074_send_byte(struct lt3074_dev *dev, uint32_t cmd);
+
+/* Perform a PMBus read_byte operation */
+int lt3074_read_byte(struct lt3074_dev *dev, uint32_t cmd, uint8_t *data);
+
+/*  Perform a PMBus write_byte operation */
+int lt3074_write_byte(struct lt3074_dev *dev, uint32_t cmd, uint8_t value);
+
+/* Perform a PMBus read_word operation */
+int lt3074_read_word(struct lt3074_dev *dev, uint32_t cmd, uint16_t *word);
+
+/* Perform a PMBus write_word operation */
+int lt3074_write_word(struct lt3074_dev *dev, uint32_t cmd, uint16_t word);
+
+/* Perform a PMBus read_word operation then perform conversion*/
+int lt3074_read_word_data(struct lt3074_dev *dev, uint32_t cmd, int *data);
+
+/* Perform conversion then perform a PMBus write_word operation */
+int lt3074_write_word_data(struct lt3074_dev *dev, uint32_t cmd, int data);
+
+/* Read a block of bytes */
+int lt3074_read_block_data(struct lt3074_dev *dev, uint32_t cmd,
+			   uint8_t *data, size_t nbytes);
+
+/* Register read */
+int lt3074_reg_read(struct lt3074_dev *dev, uint32_t reg, uint32_t *data);
+
+/* Register write */
+int lt3074_reg_write(struct lt3074_dev *dev, uint32_t reg, uint32_t val);
+
+/* Read specific value type */
+int lt3074_read_value(struct lt3074_dev *dev,
+		      enum lt3074_value_type value_type,
+		      int *value);
+
+/* Read status */
+int lt3074_read_status(struct lt3074_dev *dev,
+		       enum lt3074_status_type status_type,
+		       struct lt3074_status *status);
+
+/* Set VOUT margins */
+int lt3074_vout_margin(struct lt3074_dev *dev, enum lt3074_margin margin_high,
+		       enum lt3074_margin margin_low);
+
+/* Set fault/warning limit values */
+int lt3074_set_limit(struct lt3074_dev *dev, enum lt3074_limit_type limit,
+		     int limit_val);
+
+/* Set operation */
+int lt3074_set_operation(struct lt3074_dev *dev,
+			 enum lt3074_operation_type operation);
+
+/* Clear status registers */
+int lt3074_clear_faults(struct lt3074_dev *dev);
+
+/* Turn output ON/OFF */
+int lt3074_set_enable_pin(struct lt3074_dev *dev, bool state);
+
+/* Software reset */
+int lt3074_software_reset(struct lt3074_dev *dev);
+
+#endif /* __LT3074_H__ */

--- a/projects/lt3074/Makefile
+++ b/projects/lt3074/Makefile
@@ -1,0 +1,9 @@
+EXAMPLE := iio_example
+
+include ../../tools/scripts/generic_variables.mk
+
+include ../../tools/scripts/examples.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/lt3074/README.rst
+++ b/projects/lt3074/README.rst
@@ -1,0 +1,170 @@
+Evaluating the LT3074
+======================
+
+
+Contents
+--------
+
+.. contents:: Table of Contents
+	:depth: 3
+
+Supported Evaluation Boards
+---------------------------
+
+* `EVAL-LT3074 <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-LT3074.html#eb-documentation>`_
+
+Overview
+--------
+
+The EVAL-LT3074-AZ evaluation board features the LT3074, a 3A, ultralow noise,
+high power-supply rejection ratio (PSRR), 45mV dropout ultrafast linear
+regulator with PMBus capability. The evaluation board allows the LT3074 to be
+configured without the use of external components.
+
+Full performance details are provided in the LT3074 data sheet, which should
+be consulted in conjunction with user guide.
+
+Hardware Specifications
+-----------------------
+
+Power Supply Requirements
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+An external power supply between 2.4V to 5.5V can be used for this project.
+
+**Pin Description**
+
+	J11:
+
+	+-----+----------+-------------------------------------------+
+	| Pin |   Name 	 | Description				     |
+	+-----+----------+-------------------------------------------+
+	| 1   | VDD3P3	 | Do Not Connect			     |
+	+-----+----------+-------------------------------------------+
+	| 2   | GND      | Connect to Ground			     |
+	+-----+----------+-------------------------------------------+
+	| 3   | SDA      | I2C Serial Data			     |
+	+-----+----------+-------------------------------------------+
+	| 4   | SCL 	 | I2C Serial Clock			     |
+	+-----+----------+-------------------------------------------+
+	| 5   | EN	 | Do Not Connect			     |
+	+-----+----------+-------------------------------------------+
+	| 6   | ALERT	 | Do Not Connect			     |
+	+-----+----------+-------------------------------------------+
+
+	Other connections:
+
+	+-----+----------+-------------------------------------------+
+	| Pin |   Name 	 | Description				     |
+	+-----+----------+-------------------------------------------+
+	| 1   | VI+	 | Power Supply, +2.4V - +5.5V		     |
+	+-----+----------+-------------------------------------------+
+	| 2   | GND      | Ground				     |
+	+-----+----------+-------------------------------------------+
+	| 3   | EXTVBIAS | Power Supply, +2.4V - +5.5V		     |
+	+-----+----------+-------------------------------------------+
+	| 4   | VOUT     | Connect to Load			     |
+	+-----+----------+-------------------------------------------+
+	| 5   | POWERGOOD| Do Not Connect			     |
+	+-----+----------+-------------------------------------------+
+	
+
+No-OS Build Setup
+-----------------
+
+Please see: https://wiki.analog.com/resources/no-os/build
+
+No-OS Supported Examples
+------------------------
+
+The initialization data used in the examples is taken out from:
+`Project Common Data Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/lt3074/src/common>`_
+
+The macros used in Common Data are defined in platform specific files found in:
+`Project Platform Configuration Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/lt3074/src/platform>`_
+
+Basic example
+^^^^^^^^^^^^^
+
+This is a simple example that initializes the LT3074, sets the output margin and
+a warning limit, and performs telemetry.
+
+In order to build the basic example:
+
+.. code-block:: bash
+
+	make EXAMPLE=basic
+
+IIO example
+^^^^^^^^^^^
+
+This project is actually a IIOD demo for EVAL-LT3074 evaluation board.
+The project launches a IIOD server on the board so that the user may connect
+to it via an IIO client.
+Using IIO-Oscilloscope, the user can configure the IMU and view the measured data on a plot.
+
+If you are not familiar with ADI IIO Application, please take a look at:
+`IIO No-OS <https://wiki.analog.com/resources/tools-software/no-os-software/iio>`_
+
+If you are not familiar with ADI IIO-Oscilloscope Client, please take a look at:
+`IIO Oscilloscope <https://wiki.analog.com/resources/tools-software/linux-software/iio_oscilloscope>`_
+
+The No-OS IIO Application together with the No-OS IIO LT3074 driver take care of
+all the back-end logic needed to setup the IIO server.
+
+This example initializes the IIO device and calls the IIO app as shown in:
+`IIO Example <https://github.com/analogdevicesinc/no-OS/tree/main/projects/lt3074/src/examples/iio_example>`_
+
+In order to build the IIO project:
+
+.. code-block:: bash
+
+	make EXAMPLE=iio_example
+
+No-OS Supported Platforms
+-------------------------
+
+Maxim Platform
+^^^^^^^^^^^^^^
+
+**Used hardware**
+
+* `EVAL-LT3074 evaluation board <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-LT3074.html#eb-overview>`_
+* `MAX32666EVKIT <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/max32666evkit.html>`_
+
+**Connections**:
+
+J11:
+
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| EVAL-LT3074 Pin Number      |  Mnemonic  | Function					  | MAX32666EVKIT Pin Number	|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 2			      | GND	   | Ground					  | GND			        |
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 3			      | SDA	   | External Power Supply, 12VDC (5mA current)   | P0.15		        |
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 4			      | SCL	   | External Power Supply, 20.1VDC (5mA current) | P0.14			|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 5			      | EN	   | Enable pin					  | Do Not Connect		|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 6			      | ALERT	   | Fault alert pin				  | Do Not Connect		|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+
+Other connection:
+
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| EVAL-LT3074 Pin Number      |  Mnemonic  | Function					  | MAX32666EVKIT Pin Number	|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 5			      | POWERGOOD  | Power Good 				  | Do Not Connect		|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+
+**Build Command**
+
+.. code-block:: bash
+
+	# to delete current build
+	make reset
+	# to build the project
+	make PLATFORM=maxim TARGET=max32665
+	# to flash the code
+	make run

--- a/projects/lt3074/builds.json
+++ b/projects/lt3074/builds.json
@@ -1,0 +1,10 @@
+{
+	"maxim": {
+		"basic_example_max32666": {
+			"flags" : "EXAMPLE=basic TARGET=max32665"
+		},
+		"iio_example_max32666": {
+			"flags" : "EXAMPLE=iio_example TARGET=max32665"
+		}
+	}
+}

--- a/projects/lt3074/src.mk
+++ b/projects/lt3074/src.mk
@@ -1,0 +1,23 @@
+NO_OS_INC_DIRS += \
+	$(INCLUDE) \
+	$(PROJECT)/src/ \
+	$(DRIVERS)/api/
+	
+INCS += $(DRIVERS)/power/lt3074/lt3074.h
+
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/main.c \
+	$(PROJECT)/src/common/common_data.c \
+	$(PROJECT)/src/platform/$(PLATFORM)/parameters.c \
+	$(NO-OS)/util/no_os_lf256fifo.c \
+	$(DRIVERS)/api/no_os_i2c.c \
+	$(DRIVERS)/api/no_os_dma.c \
+	$(DRIVERS)/api/no_os_uart.c \
+	$(DRIVERS)/api/no_os_irq.c \
+	$(DRIVERS)/api/no_os_gpio.c \
+	$(DRIVERS)/api/no_os_pwm.c \
+	$(DRIVERS)/power/lt3074/lt3074.c \
+	$(NO-OS)/util/no_os_util.c \
+	$(NO-OS)/util/no_os_list.c \
+	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c \
+	$(NO-OS)/util/no_os_crc8.c

--- a/projects/lt3074/src/common/common_data.c
+++ b/projects/lt3074/src/common/common_data.c
@@ -1,0 +1,61 @@
+/***************************************************************************//**
+*   @file   common_data.c
+*   @brief  Defines common data to be used by lt3074 examples.
+*   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+* Copyright 2025(c) Analog Devices, Inc.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* 3. Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived from this
+*    software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+* EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "common_data.h"
+
+struct no_os_uart_init_param lt3074_uart_ip = {
+	.device_id = UART_DEVICE_ID,
+	.irq_id = UART_IRQ_ID,
+	.asynchronous_rx = true,
+	.baud_rate = UART_BAUDRATE,
+	.size = NO_OS_UART_CS_8,
+	.parity = NO_OS_UART_PAR_NO,
+	.stop = NO_OS_UART_STOP_1_BIT,
+	.platform_ops = UART_OPS,
+	.extra = UART_EXTRA,
+};
+
+struct no_os_i2c_init_param lt3074_i2c_ip = {
+	.device_id = I2C_DEVICE_ID,
+	.max_speed_hz = 100000,
+	.platform_ops = I2C_OPS,
+	.slave_address = LT3074_PMBUS_59K_261K_ADDRESS,
+	.extra = I2C_EXTRA,
+};
+
+struct lt3074_init_param lt3074_ip = {
+	.i2c_init = &lt3074_i2c_ip,
+	.pg_param = NULL,
+	.en_param = NULL,
+	.alert_param = NULL,
+	.crc_en = true
+};

--- a/projects/lt3074/src/common/common_data.h
+++ b/projects/lt3074/src/common/common_data.h
@@ -1,0 +1,46 @@
+/***************************************************************************//**
+*   @file   common_data.h
+*   @brief  Defines common data to be used by lt3074 examples.
+*   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+* Copyright 2025(c) Analog Devices, Inc.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* 3. Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived from this
+*    software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+* EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __COMMON_DATA_H__
+#define __COMMON_DATA_H__
+
+#include "no_os_i2c.h"
+#include "parameters.h"
+#include "lt3074.h"
+
+#define LT3074_PMBUS_59K_261K_ADDRESS                   0x6E
+
+extern struct no_os_uart_init_param lt3074_uart_ip;
+extern struct no_os_i2c_init_param lt3074_i2c_ip;
+extern struct lt3074_init_param lt3074_ip;
+
+#endif /* __COMMON_DATA_H__ */

--- a/projects/lt3074/src/examples/basic/basic_example.c
+++ b/projects/lt3074/src/examples/basic/basic_example.c
@@ -1,0 +1,112 @@
+/***************************************************************************//**
+*   @file   basic_example.c
+*   @brief  Basic example source file for lt3074 project.
+*   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+* Copyright 2025(c) Analog Devices, Inc.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* 3. Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived from this
+*    software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+* EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "common_data.h"
+#include "no_os_delay.h"
+#include "no_os_print_log.h"
+#include "lt3074.h"
+
+int example_main()
+{
+	struct lt3074_dev *dev;
+	struct lt3074_status status;
+	struct no_os_uart_desc *uart_desc;
+	int ret;
+	int vals[5];
+
+	ret = no_os_uart_init(&uart_desc, &lt3074_uart_ip);
+	if (ret)
+		return ret;
+
+	no_os_uart_stdio(uart_desc);
+
+	pr_info("Running basic example.\n");
+
+	ret = lt3074_init(&dev, &lt3074_ip);
+	if (ret)
+		goto exit;
+
+	ret = lt3074_vout_margin(dev, LT3074_MARGIN_PERCENTAGE_10,
+				 LT3074_MARGIN_PERCENTAGE_10);
+	if (ret)
+		goto exit;
+
+	ret = lt3074_set_limit(dev, LT3074_VIN_OV_WARN_LIMIT_TYPE, 4500);
+	if (ret)
+		goto exit;
+
+	while (1) {
+		ret = lt3074_read_value(dev, LT3074_VIN, &vals[0]);
+		if (ret)
+			goto exit;
+
+		ret = lt3074_read_value(dev, LT3074_VOUT, &vals[1]);
+		if (ret)
+			goto exit;
+
+		ret = lt3074_read_value(dev, LT3074_VBIAS, &vals[2]);
+		if (ret)
+			goto exit;
+
+		ret = lt3074_read_value(dev, LT3074_IOUT, &vals[3]);
+		if (ret)
+			goto exit;
+
+		ret = lt3074_read_value(dev, LT3074_TEMP, &vals[4]);
+		if (ret)
+			goto exit;
+
+		ret = lt3074_read_status(dev, LT3074_STATUS_ALL_TYPE, &status);
+		if (status.vout)
+			pr_info("Status vout asserted.\n");
+		if (status.iout)
+			pr_info("Status iout asserted.\n");
+		if (status.input)
+			pr_info("Status input asserted.\n");
+		if (status.temp)
+			pr_info("Status temp asserted.\n");
+		if (status.cml)
+			pr_info("Status cml asserted.\n");
+		if (status.mfr_specific)
+			pr_info("Status mfr_specific asserted.\n");
+
+		pr_info("vin = %d mV | vout = %d mV | vbias = %d mV | iout = %d mA | temp = %d C\n",
+			vals[0], vals[1], vals[2], vals[3], vals[4] / 1000);
+
+		no_os_mdelay(500);
+	}
+
+exit:
+	pr_err("Error code: %d.\n", ret);
+	lt3074_remove(dev);
+	return ret;
+}

--- a/projects/lt3074/src/examples/iio_example/example.mk
+++ b/projects/lt3074/src/examples/iio_example/example.mk
@@ -1,0 +1,4 @@
+IIOD=y
+
+INCS += $(DRIVERS)/power/lt3074/iio_lt3074.h
+SRCS += $(DRIVERS)/power/lt3074/iio_lt3074.c

--- a/projects/lt3074/src/examples/iio_example/iio_example.c
+++ b/projects/lt3074/src/examples/iio_example/iio_example.c
@@ -1,0 +1,80 @@
+/***************************************************************************//**
+*   @file   iio_example.c
+*   @brief  IIO example source file for lt3074 project.
+*   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+* Copyright 2025(c) Analog Devices, Inc.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* 3. Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived from this
+*    software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+* EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "iio_lt3074.h"
+#include "common_data.h"
+#include "no_os_print_log.h"
+#include "iio_app.h"
+
+int example_main()
+{
+	int ret;
+
+	struct lt3074_iio_desc *lt3074_iio_desc;
+	struct lt3074_iio_desc_init_param lt3074_iio_ip = {
+		.lt3074_init_param = &lt3074_ip,
+	};
+
+	struct iio_app_desc *app;
+	struct iio_app_init_param app_init_param = { 0 };
+
+	ret = lt3074_iio_init(&lt3074_iio_desc, &lt3074_iio_ip);
+	if (ret)
+		goto exit;
+
+	struct iio_app_device iio_devices[] = {
+		{
+			.name = "lt3074",
+			.dev = lt3074_iio_desc,
+			.dev_descriptor = lt3074_iio_desc->iio_dev,
+		}
+	};
+
+	app_init_param.devices = iio_devices;
+	app_init_param.nb_devices = NO_OS_ARRAY_SIZE(iio_devices);
+	app_init_param.uart_init_params = lt3074_uart_ip;
+
+	ret = iio_app_init(&app, app_init_param);
+	if (ret)
+		goto remove_iio_lt3074;
+
+	ret = iio_app_run(app);
+
+	iio_app_remove(app);
+
+remove_iio_lt3074:
+	lt3074_iio_remove(lt3074_iio_desc);
+exit:
+	if (ret)
+		pr_info("Error!\n");
+	return ret;
+}

--- a/projects/lt3074/src/platform/maxim/main.c
+++ b/projects/lt3074/src/platform/maxim/main.c
@@ -1,0 +1,41 @@
+/***************************************************************************//**
+*   @file   main.c
+*   @brief  Main file for Maxim platform of lt3074 project.
+*   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+* Copyright 2025(c) Analog Devices, Inc.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* 3. Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived from this
+*    software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+* EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "parameters.h"
+#include "common_data.h"
+
+extern int example_main();
+
+int main()
+{
+	return example_main();
+}

--- a/projects/lt3074/src/platform/maxim/parameters.c
+++ b/projects/lt3074/src/platform/maxim/parameters.c
@@ -1,0 +1,42 @@
+/***************************************************************************//**
+*   @file   parameters.c
+*   @brief  Definition of Maxim platform data used by lt3074 project.
+*   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+* Copyright 2025(c) Analog Devices, Inc.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* 3. Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived from this
+*    software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+* EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "parameters.h"
+
+struct max_uart_init_param lt3074_uart_extra = {
+	.flow = UART_FLOW_DIS,
+	.map = UART_MAP_A
+};
+
+struct max_i2c_init_param lt3074_i2c_extra = {
+	.vssel = MXC_GPIO_VSSEL_VDDIOH
+};

--- a/projects/lt3074/src/platform/maxim/parameters.h
+++ b/projects/lt3074/src/platform/maxim/parameters.h
@@ -1,0 +1,59 @@
+/***************************************************************************//**
+*   @file   parameters.h
+*   @brief  Definition of Maxim platform data used by lt3074 project.
+*   @author Cedric Justine Encarnacion (cedricjustine.encarnacion@analog.com)
+********************************************************************************
+* Copyright 2025(c) Analog Devices, Inc.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* 3. Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived from this
+*    software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+* EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
+
+#include "maxim_irq.h"
+#include "maxim_i2c.h"
+#include "maxim_gpio.h"
+#include "maxim_uart.h"
+#include "maxim_uart_stdio.h"
+
+#ifdef IIO_SUPPORT
+#define INTC_DEVICE_ID		0
+#endif
+
+#define UART_DEVICE_ID		1
+#define UART_IRQ_ID		UART1_IRQn
+#define UART_BAUDRATE		115200
+#define	UART_OPS		&max_uart_ops
+#define UART_EXTRA		&lt3074_uart_extra
+
+#define I2C_DEVICE_ID		1
+#define I2C_OPS			&max_i2c_ops
+#define I2C_EXTRA		&lt3074_i2c_extra
+
+extern struct max_uart_init_param lt3074_uart_extra;
+extern struct max_i2c_init_param lt3074_i2c_extra;
+
+#endif /* __PARAMETERS_H__ */

--- a/projects/lt3074/src/platform/maxim/platform_src.mk
+++ b/projects/lt3074/src/platform/maxim/platform_src.mk
@@ -1,0 +1,12 @@
+NO_OS_INC_DIRS += \
+        $(PLATFORM_DRIVERS) \
+        $(PLATFORM_DRIVERS)/../common/
+
+SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c \
+        $(PLATFORM_DRIVERS)/maxim_gpio.c \
+        $(PLATFORM_DRIVERS)/maxim_gpio_irq.c \
+        $(PLATFORM_DRIVERS)/maxim_irq.c \
+        $(PLATFORM_DRIVERS)/../common/maxim_dma.c \
+        $(PLATFORM_DRIVERS)/maxim_i2c.c \
+        $(PLATFORM_DRIVERS)/maxim_uart.c \
+        $(PLATFORM_DRIVERS)/maxim_uart_stdio.c


### PR DESCRIPTION
## Pull Request Description

The LT3074 is a low voltage, ultralow noise, and ultrafast transient
response linear regulator with a PMBus serial interface. The device
supplies up to 3A with a typical dropout voltage of 45mV.

This pull request adds the no-OS and IIO driver, as well as examples
and documentations, to quickly evaluate the LT3074.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
