### PR TITLE
drivers:adc-dac:ad5592r: Driver Enhancement

### DIFF
--- a/drivers/adc-dac/ad5592r/ad5592r-base.h
+++ b/drivers/adc-dac/ad5592r/ad5592r-base.h
@@ -3,7 +3,7 @@
  *   @brief  Header file of AD5592R Base Driver.
  *   @author Mircea Caprioru (mircea.caprioru@analog.com)
 ********************************************************************************
- * Copyright 2018, 2020(c) Analog Devices, Inc.
+ * Copyright 2018, 2020, 2025(c) Analog Devices, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -38,6 +38,7 @@
 #include "no_os_spi.h"
 #include "no_os_i2c.h"
 #include "no_os_util.h"
+#include "no_os_alloc.h"
 #include <stdbool.h>
 
 #define CH_MODE_UNUSED			0
@@ -92,6 +93,8 @@ enum ad5592r_registers {
 
 #define INTERNAL_VREF_VOLTAGE			    2.5
 
+#define NUM_OF_CHANNELS 8
+
 struct ad5592r_dev;
 
 struct ad5592r_rw_ops {
@@ -108,8 +111,21 @@ struct ad5592r_rw_ops {
 	int32_t (*gpio_read)(struct ad5592r_dev *dev, uint8_t *value);
 };
 
+enum ad559xr_range {
+	ZERO_TO_VREF,
+	ZERO_TO_2VREF
+};
+
 struct ad5592r_init_param {
 	bool int_ref;
+	struct no_os_spi_init_param *spi_init;
+	struct no_os_i2c_init_param *i2c_init;
+	uint8_t channel_modes[8];
+	uint8_t channel_offstate[8];
+	enum ad559xr_range adc_range;
+	enum ad559xr_range dac_range;
+	bool adc_buf;
+	uint8_t power_down[8];
 };
 
 struct ad5592r_dev {
@@ -126,6 +142,11 @@ struct ad5592r_dev {
 	uint8_t gpio_in;
 	uint8_t gpio_val;
 	uint8_t ldac_mode;
+	enum ad559xr_range adc_range;
+	enum ad559xr_range dac_range;
+	bool int_ref;
+	uint8_t power_down[8];
+	bool adc_buf;
 };
 
 int32_t ad5592r_base_reg_write(struct ad5592r_dev *dev, uint8_t reg,
@@ -141,5 +162,14 @@ int32_t ad5592r_gpio_direction_output(struct ad5592r_dev *dev,
 int32_t ad5592r_software_reset(struct ad5592r_dev *dev);
 int32_t ad5592r_set_channel_modes(struct ad5592r_dev *dev);
 int32_t ad5592r_reset_channel_modes(struct ad5592r_dev *dev);
+int32_t ad5592r_set_adc_range(struct ad5592r_dev *dev,
+			      enum ad559xr_range adc_range);
+int32_t ad5592r_set_dac_range(struct ad5592r_dev *dev,
+			      enum ad559xr_range dac_range);
+int32_t ad5592r_power_down(struct ad5592r_dev *dev, uint8_t chan, bool enable);
+int32_t ad5592r_set_int_ref(struct ad5592r_dev *dev, bool enable);
+int32_t ad5592r_set_adc_buffer(struct ad5592r_dev *dev, bool enable);
+int32_t ad5592r_base_reg_update(struct ad5592r_dev* dev, uint16_t reg_addr,
+				uint16_t data, uint16_t mask);
 
 #endif /* AD5592R_BASE_H_ */

--- a/drivers/adc-dac/ad5592r/ad5592r.h
+++ b/drivers/adc-dac/ad5592r/ad5592r.h
@@ -3,7 +3,7 @@
  *   @brief  Header file of AD5592R driver.
  *   @author Mircea Caprioru (mircea.caprioru@analog.com)
 ********************************************************************************
- * Copyright 2018, 2020(c) Analog Devices, Inc.
+ * Copyright 2018, 2020, 2025(c) Analog Devices, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -19,7 +19,7 @@
  *    contributors may be used to endorse or promote products derived from this
  *    software without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. ‚ÄúAS IS‚Äù AND ANY EXPRESS OR
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. ìAS ISî AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
  * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
@@ -54,7 +54,9 @@ int32_t ad5592r_reg_write(struct ad5592r_dev *dev, uint8_t reg,
 int32_t ad5592r_reg_read(struct ad5592r_dev *dev, uint8_t reg,
 			 uint16_t *value);
 int32_t ad5592r_gpio_read(struct ad5592r_dev *dev, uint8_t *value);
-int32_t ad5592r_init(struct ad5592r_dev *dev,
+int32_t ad5592r_init(struct ad5592r_dev **dev,
 		     struct ad5592r_init_param *init_param);
+int32_t ad5592r_enable_busy(struct ad5592r_dev *dev, bool enable);
+int32_t ad5592r_spi_wnop_r16(struct ad5592r_dev *dev, uint16_t *buf);
 
 #endif /* AD5592R_H_ */

--- a/drivers/adc-dac/ad5592r/ad5593r.h
+++ b/drivers/adc-dac/ad5592r/ad5593r.h
@@ -3,7 +3,7 @@
  *   @brief  Header file of AD5593R driver.
  *   @author Mircea Caprioru (mircea.caprioru@analog.com)
 ********************************************************************************
- * Copyright 2018, 2020(c) Analog Devices, Inc.
+ * Copyright 2018, 2020, 2025(c) Analog Devices, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -19,7 +19,7 @@
  *    contributors may be used to endorse or promote products derived from this
  *    software without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. ‚ÄúAS IS‚Äù AND ANY EXPRESS OR
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. ìAS ISî AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
  * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
@@ -36,6 +36,17 @@
 #include "stdint.h"
 #include "ad5592r-base.h"
 
+#define AD5593R_MODE_CONF		(0 << 4)
+#define AD5593R_MODE_DAC_WRITE		(1 << 4)
+#define AD5593R_MODE_ADC_READBACK	(4 << 4)
+#define AD5593R_MODE_DAC_READBACK	(5 << 4)
+#define AD5593R_MODE_GPIO_READBACK	(6 << 4)
+#define AD5593R_MODE_REG_READBACK	(7 << 4)
+
+#define AD5593R_STOP_BIT	1
+#define AD5593R_RESTART_BIT	0
+#define AD5593R_ADC_VALUES_BUFF_SIZE	    18
+
 int32_t ad5593r_write_dac(struct ad5592r_dev *dev, uint8_t chan,
 			  uint16_t value);
 int32_t ad5593r_read_adc(struct ad5592r_dev *dev, uint8_t chan,
@@ -47,7 +58,7 @@ int32_t ad5593r_reg_write(struct ad5592r_dev *dev, uint8_t reg,
 int32_t ad5593r_reg_read(struct ad5592r_dev *dev, uint8_t reg,
 			 uint16_t *value);
 int32_t ad5593r_gpio_read(struct ad5592r_dev *dev, uint8_t *value);
-int32_t ad5593r_init(struct ad5592r_dev *dev,
+int32_t ad5593r_init(struct ad5592r_dev **dev,
 		     struct ad5592r_init_param *init_param);
 
 #endif /* AD5593R_H_ */


### PR DESCRIPTION
1. Added driver apis for adc range, dac range, power down,set internal reference and set adc buffer to the base driver.
2. Added API to enable busy indicatir on AD5592r
3. Removed static for spi nop API for visibilty.
4. Moved some macros from ad5593.c to header file for visibility.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
