### PR TITLE
drivers: power: adp1055: add support for adp1055

### DIFF
--- a/doc/sphinx/source/drivers/adp1055.rst
+++ b/doc/sphinx/source/drivers/adp1055.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../drivers/power/adp1055/README.rst

--- a/doc/sphinx/source/drivers_doc.rst
+++ b/doc/sphinx/source/drivers_doc.rst
@@ -101,6 +101,7 @@ POWER MANAGEMENT
 
    drivers/ades1754
    drivers/adp1050
+   drivers/adp1055
    drivers/adp5055
    drivers/ltc2992
    drivers/ltc4162l

--- a/doc/sphinx/source/projects/adp1055.rst
+++ b/doc/sphinx/source/projects/adp1055.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../projects/adp1055/README.rst

--- a/doc/sphinx/source/projects_doc.rst
+++ b/doc/sphinx/source/projects_doc.rst
@@ -73,6 +73,7 @@ POWER MANAGEMENT
 
    projects/ades1754
    projects/adp1050
+   projects/adp1055
    projects/adp5055
    projects/dc2703a
    projects/ltc4162l

--- a/drivers/power/adp1055/README.rst
+++ b/drivers/power/adp1055/README.rst
@@ -1,0 +1,227 @@
+ADP1055 no-OS driver
+====================
+
+Supported Devices
+-----------------
+
+`ADP1055 <https://www.analog.com/ADP1055>`_
+
+Overview
+--------
+
+The ADP1055 is an advanced digital controller with a PMBus™ interface targeting
+high density, high efficiency dc-to-dc power conversion.
+This controller implements voltage mode control with high speed, input voltage
+feedforward operation for enhanced transient and noise performance.
+The ADP1055 has four programmable pulse-width modulation (PWM) outputs capable
+of controlling most high efficiency power supply topologies,
+with the added control of synchronous rectification (SR).
+
+Applications
+------------
+
+ADP1055
+-------
+
+* High density, isolated dc-to-dc power supplies
+* Intermediate bus converters
+* High availability parallel power systems
+* Server, storage, industrial, networking, and communications infrastructure
+
+ADP1055 Device Configuration
+----------------------------
+
+Driver Initialization
+---------------------
+
+In order to be able to use the device, you will have to provide the support
+for the communication protocol (I2C) alongside other GPIO pins if needed in the
+specific application (depends on the way the device is used).
+
+The first API to be called is **adp1055_init**. Make sure that it return 0,
+which means that the driver was initialized correctly.
+
+The initialization API uses the device descriptor and an initialization
+parameter, which contains an unsigned 8-bit integer variable on_off_config
+containing the information to be sent to the ON_OFF_CONFIG command in the
+PMBus commands which tells the device how it will be started-up, default
+configuration for this can be found in the header file of the driver.
+
+VOUT Configuration
+------------------
+
+Since the device is to be connected in parallel to other circuit, VOUT is
+referring to the VS pins which are actually Voltage Input pins to which a
+resistor divider is applied in orde to have the VS differential voltage at 1V. 
+Depending on the resistor divider information a scale is to be set for the
+VOUT using the **adp1055_vout_scale** API.
+
+The VOUT_COMMAND sets the output voltage referrence which commands the PWMs
+(actual outputs of the ADP1055), if the voltage sensed by the VS pins is greater
+than VOUT_COMMAND, the PWMs will be set off, regarding the state set by the user.
+Also the VOUT_MAX value can be changed with the same API, and this applies a
+limit to the previous mentioned VOUT_COMMAND. The API used for setting these
+two values is **adp1055_vout_value**.
+
+VOUT also has an offset that can be set in order to correctly sense the voltage
+output of the parallel-connected circuit using **adp1055_vout_offset** API, and
+also a transition rate using **adp1055_vout_tr** API.
+
+For VOUT margins can also be set for the case where at the start-up of the
+device margin low/high values will be used for the voltage output value using
+**adp1055_vout_margin** API.
+
+Voltage value sensed on the VS pins can be read using **adp1055_read_vsense**
+API, correct values will be returned only if vout scale is set using the
+previous mentioned API.
+
+VIN Configuration
+-----------------
+
+VIN_ON and VIN_OFF command values can be set using **adp1055_set_vin** API and
+they refer to the input voltage at which the unit starts, respectively stops the
+power conversion.
+
+More than that the value of the input voltage(value read at the VF pin) can be
+read using **adp1055_read_value** API, and correct values will be returned only
+if VIN_SCALE_MONITOR command value is written accordingly to the datasheet using
+**adp1055_write** API.
+
+Status Configuration
+--------------------
+
+Statuses bytes/words of the device can be read using **adp1055_read_status**
+API.
+
+PWM configuration
+-----------------
+
+PWMs duty-cycle and modulation can be set using the **adp1055_pwm_config** 
+API but also each PWM can be enabled using **adp1055_set_pwm** API which
+also selects the frequency of the specific set PWM channel.
+
+Frequency Synchronization
+-------------------------
+
+Frequency Synchronization can be disabled or enabled using **adp1055_freq_sync**
+API.
+
+ADP1055 Driver Initialization Example
+-------------------------------------
+
+.. code-block:: bash
+
+	struct adp1055_desc *adp1055_desc;
+	struct no_os_i2c_init_param adp1055_i2c_ip = {
+		.device_id = 0,
+		.max_speed_hz = 100000,
+		.platform_ops = &max_i2c_ops,
+		.slave_address = ADP1055_PMBUS_DEFAULT_ADDRESS,
+		.extra = &adp1055_i2c_extra,
+	};
+	struct no_os_gpio_init_param adp1055_pg_alt_ip = {
+		.port = 0,
+		.number = 24,
+		.pull = NO_OS_PULL_NONE,
+		.platform_ops = &max_gpio_ops,
+		.extra = *&adp1055_gpio_extra_ip,
+	};
+	struct adp1055_init_param adp1055_ip = {
+		.i2c_param = &adp1055_i2c_ip,
+		.pg_alt_param = &adp1055_pg_alt_ip,
+		.flgi_param = NULL,
+		.syni_param = NULL,
+		.on_off_config = ADP1055_ON_OFF_DEFAULT_CFG,
+	};
+	ret = adp1055_init(&adp1055_desc, &adp1055_ip);
+	if (ret)
+		goto error;
+
+ADP1055 no-OS IIO support
+-------------------------
+
+The ADP1055 IIO driver comes on top of the ADP1055 driver and offers support
+for interfacing IIO clients through libiio.
+
+ADP1055 IIO Device Configuration
+--------------------------------
+
+Input Channel Attributes
+------------------------
+
+VOUT/VIN/IIN/TEMP channels are the input channels of the ADP1055 IIO device
+and each of them has a total of 2 channel attributes:
+
+* ``raw - the raw value of the channel``
+* ``scale - the scale value of the channel calculated accordingly to each specific channel using a priv``
+
+Output Channel Attributes
+-------------------------
+
+OUTA/OUTB/OUTC/OUTD/SR1/SR2 channels are six output channels of the ADP1055 IIO device
+and each of them has a total of 3 channel attributes:
+
+* ``enable - state of the channel``
+* ``frequency - frequency of the channel, all channels share the same frequency``
+* ``frequency_available - list of available frequency for the output channels``
+
+Global Attributes
+-----------------
+
+The device has a total of 3 global attributes:
+
+* ``vout_command - VOUT_COMMAND value of the device``
+* ``vout_scale_monitor - VOUT_SCALE_MONITOR value of the device``
+* ``vout_offset - VOUT_OFFSET value of the device``
+
+Debug Attributes
+----------------
+
+* ``status_vout - VOUT status byte value of the device``
+* ``staus_iout - IOUT status byte value of the device``
+* ``status_input - INPUT status byte value of the device``
+* ``status_temperature - TEMPERATURE status byte value of the device``
+* ``status_cml - CML status byte value of the device``
+* ``status_other - OTHER status byte value of the device``
+* ``status_word - status WORD value of the device``
+* ``status_mfr - MRF status value of the device``
+
+ADP1055 IIO Driver Initialization Example
+-----------------------------------------
+
+.. code-block:: bash
+
+	int ret;
+
+	struct adp1055_iio_desc *adp1055_iio_desc;
+	struct adp1055_iio_desc_init_param adp1055_iio_ip = {
+		.adp1055_init_param = &adp1055_ip,
+		.vout_scale_monitor = 0xA155,
+		.vin_scale_monitor = 0xB033,
+		.iin_scale_monitor = 0x01,
+	};
+
+	struct iio_app_desc *app;
+	struct iio_app_init_param app_init_param = { 0 };
+
+	ret = adp1055_iio_init(&adp1055_iio_desc, &adp1055_iio_ip);
+	if (ret)
+		goto exit;
+
+	struct iio_app_device iio_devices[] = {
+		{
+			.name = "adp1055",
+			.dev = adp1055_iio_desc,
+			.dev_descriptor = adp1055_iio_desc->iio_dev,
+		}
+	};
+
+	app_init_param.devices = iio_devices;
+	app_init_param.nb_devices = NO_OS_ARRAY_SIZE(iio_devices);
+	app_init_param.uart_init_params = adp1055_uart_ip;
+
+	ret = iio_app_init(&app, app_init_param);
+	if (ret)
+		goto remove_iio_adp1055;
+
+	return iio_app_run(app);

--- a/drivers/power/adp1055/adp1055.c
+++ b/drivers/power/adp1055/adp1055.c
@@ -1,0 +1,761 @@
+/***************************************************************************//**
+ *   @file   adp1055.c
+ *   @brief  Source file for the ADP1055 Driver
+ *   @author Ivangil Mercano (Ivangil.mercano@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "adp1055.h"
+#include "no_os_error.h"
+#include "no_os_util.h"
+#include "no_os_alloc.h"
+
+/**
+ * @brief Send command byte/word to ADP1055
+ * @param desc - ADP1055 device descriptor
+ * @param command - Value of the command
+ * @return 0 in case of sucess, negative error code otherwise
+ */
+int adp1055_send_command(struct adp1055_desc *desc, uint16_t command)
+{
+	uint8_t data[2];
+	uint8_t command_val;
+
+	if (!desc)
+		return -EINVAL;
+
+	if (command > ADP1055_EXTENDED_COMMAND) {
+		data[0] = no_os_field_get(ADP1055_LSB_MASK, command);
+		data[1] = no_os_field_get(ADP1055_MSB_MASK, command);
+
+		return no_os_i2c_write(desc->i2c_desc, data, 2, 1);
+	}
+
+	command_val = no_os_field_get(ADP1055_LSB_MASK, command);
+
+	return no_os_i2c_write(desc->i2c_desc, &command_val, 1, 1);
+}
+
+/**
+ * @brief - Write data to ADP1055
+ * @param desc - ADP1055 device structure
+ * @param command - Command value
+ * @param data - Data value to write in ADP1055
+ * @param byte_num - Number of bytes to write.
+ * @return 0 in case of success, negative error code otherwise
+ */
+int adp1055_write(struct adp1055_desc *desc, uint16_t command, uint16_t data,
+		  uint8_t byte_num)
+{
+	uint8_t val[4];
+
+	if (!desc)
+		return -EINVAL;
+
+	if (command > ADP1055_EXTENDED_COMMAND) {
+		val[0] = no_os_field_get(ADP1055_MSB_MASK, command);
+		val[1] = no_os_field_get(ADP1055_LSB_MASK, command);
+		if (byte_num > 1) {
+			val[2] = no_os_field_get(ADP1055_LSB_MASK, data);
+			val[3] = no_os_field_get(ADP1055_MSB_MASK, data);
+		} else
+			val[2] = no_os_field_get(ADP1055_LSB_MASK, data);
+
+		return no_os_i2c_write(desc->i2c_desc, val, byte_num + 2, 1);
+	} else {
+		val[0] = no_os_field_get(ADP1055_LSB_MASK, command);
+		if (byte_num > 1) {
+			val[1] = no_os_field_get(ADP1055_LSB_MASK, data);
+			val[2] = no_os_field_get(ADP1055_MSB_MASK, data);
+		} else
+			val[1] = no_os_field_get(ADP1055_LSB_MASK, data);
+
+		return no_os_i2c_write(desc->i2c_desc, val, byte_num + 1, 1);
+	}
+}
+
+/**
+ * @brief Read data from ADP1055
+ * @param desc - ADP1055 device descriptor
+ * @param command - Command value
+ * @param data - Buffer with received data
+ * @param byte_num - Number of bytes of received data
+ * @return 0 if success, negative error otherwise
+ */
+int adp1055_read(struct adp1055_desc *desc, uint16_t command, uint8_t *data,
+		 uint8_t byte_num)
+{
+	int ret;
+	uint8_t command_val[2];
+	uint8_t write_bytes;
+
+	if (!desc)
+		return -EINVAL;
+
+	if (command > ADP1055_EXTENDED_COMMAND) {
+		command_val[1] = no_os_field_get(ADP1055_LSB_MASK, command);
+		command_val[0] = no_os_field_get(ADP1055_MSB_MASK, command);
+		write_bytes = 2;
+	} else {
+		command_val[0] = no_os_field_get(ADP1055_LSB_MASK, command);
+		write_bytes = 1;
+	}
+	ret = no_os_i2c_write(desc->i2c_desc, command_val, write_bytes, 0);
+	if (ret)
+		return ret;
+
+	return no_os_i2c_read(desc->i2c_desc, data, byte_num, 1);
+}
+
+/**
+ * @brief Initialize the ADP1055 device.
+ * @param desc - ADP1055 device descriptor
+ * @param init_param - Initialization parameter containing information about the
+ * 		       ADP1055 device to be initialized.
+ * @return 0 in case of succes, negative error code otherwise
+*/
+int adp1055_init(struct adp1055_desc **desc,
+		 struct adp1055_init_param *init_param)
+{
+	struct adp1055_desc *descriptor;
+	int ret;
+	uint8_t val;
+
+	descriptor = (struct adp1055_desc *)no_os_calloc(sizeof(*descriptor), 1);
+	if (!descriptor)
+		return -ENOMEM;
+
+	ret = no_os_i2c_init(&descriptor->i2c_desc, init_param->i2c_param);
+	if (ret)
+		goto free_desc;
+
+	ret = no_os_gpio_get_optional(&descriptor->pg_alt_desc,
+				      init_param->pg_alt_param);
+	if (ret)
+		goto free_desc;
+
+	ret = no_os_gpio_direction_input(descriptor->pg_alt_desc);
+	if (ret)
+		goto free_desc;
+
+	if (init_param->ext_syni) {
+		ret = no_os_pwm_init(&descriptor->syni_desc,
+				     init_param->syni_param);
+		if (ret)
+			goto free_desc;
+
+		descriptor->flgi_desc = NULL;
+	} else {
+		ret = no_os_gpio_get_optional(&descriptor->flgi_desc,
+					      init_param->flgi_param);
+		if (ret)
+			goto free_desc;
+
+		ret = no_os_gpio_direction_output(descriptor->flgi_desc,
+						  NO_OS_GPIO_LOW);
+		if (ret)
+			goto free_desc;
+
+		descriptor->syni_desc = NULL;
+	}
+
+	ret = no_os_gpio_get_optional(&descriptor->ctrl_desc,
+				      init_param->ctrl_param);
+	if (ret)
+		goto free_desc;
+
+	if (descriptor->ctrl_desc
+	    && !no_os_field_get(ADP1055_CTRL_PIN_ENABLE, init_param->on_off_config))
+		goto free_desc;
+
+	ret = adp1055_write(descriptor, ADP1055_ON_OFF_CONFIG,
+			    (uint16_t)init_param->on_off_config, 1);
+	if (ret)
+		goto free_desc;
+
+	val = no_os_field_get(ADP1055_ON_OFF_MASK, ADP1055_OPERATION_ON);
+
+	ret = adp1055_write(descriptor, ADP1055_OPERATION, val, 1);
+	if (ret)
+		goto free_desc;
+
+	/* Time needed for the adp1055 to power-up. */
+	no_os_mdelay(52);
+
+	ret = adp1055_send_command(descriptor, ADP1055_CLEAR_FAULTS);
+	if (ret)
+		goto free_desc;
+
+	descriptor->freq_exp = no_os_field_prep(ADP1055_EXP_MASK,
+						ADP1055_DEFAULT_FREQ_EXP);
+	descriptor->freq_mant = no_os_field_prep(ADP1055_MANT_MASK,
+				ADP1055_DEFAULT_FREQ_MANT);
+
+	*desc = descriptor;
+
+	return 0;
+
+free_desc:
+	adp1055_remove(descriptor);
+
+	return ret;
+}
+
+/**
+ * @brief Free the resources allocated by the adp1055_init()
+ * @param desc - ADP1055 device descriptor
+ * @return 0 in case of success, negative error otherwise
+ */
+int adp1055_remove(struct adp1055_desc *desc)
+{
+	int ret;
+	uint8_t val;
+
+	if (!desc)
+		return -ENODEV;
+
+	if (desc->i2c_desc) {
+		val = no_os_field_get(ADP1055_ON_OFF_MASK, ADP1055_OPERATION_ON);
+		ret = adp1055_write(desc, ADP1055_OPERATION, val, 1);
+		if (ret)
+			return ret;
+	}
+
+	no_os_gpio_remove(desc->ctrl_desc);
+	no_os_gpio_remove(desc->flgi_desc);
+	no_os_pwm_remove(desc->syni_desc);
+	no_os_gpio_remove(desc->pg_alt_desc);
+	no_os_i2c_remove(desc->i2c_desc);
+	no_os_free(desc);
+
+	return 0;
+}
+
+/**
+ * @brief Send statuses
+ * @param desc - ADP1055 device descriptor
+ * @param status - Status type
+ * @param status_val - Status value to be returned
+ * @return 0 in case of success, negative error otherwise
+ */
+int adp1055_read_status(struct adp1055_desc *desc,
+			enum adp1055_status_type status,
+			uint16_t *status_val)
+{
+	uint8_t read_byte;
+	uint8_t data[2];
+	int ret;
+
+	switch (status) {
+	case ADP1055_STATUS_VOUT_TYPE:
+	case ADP1055_STATUS_IOUT_TYPE:
+	case ADP1055_STATUS_INPUT_TYPE:
+	case ADP1055_STATUS_TEMP_TYPE:
+	case ADP1055_STATUS_CML_TYPE:
+		ret = adp1055_read(desc, (uint16_t)status, &read_byte, 1);
+		if (ret)
+			return ret;
+
+		*status_val = read_byte;
+
+		return 0;
+	case ADP1055_STATUS_WORD_TYPE:
+		ret = adp1055_read(desc, (uint16_t)status, data, 2);
+		if (ret)
+			return ret;
+
+		*status_val = no_os_get_unaligned_le16(data);
+
+		return 0;
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Read VIN/IIN/VOUT/TEMP2/TEMP3/DUTY_CYCLE_FREQ/POUT raw value from the ADP1055
+ * @param desc - AP1055 device descriptor
+ * @param value - value type
+ * @param mant - Raw mantissa value to be received
+ * @param exp - Raw exponent value to be received
+ * @return 0 in case of success, negative error otherwise
+ */
+int adp1055_read_value(struct adp1055_desc *desc, enum adp1055_value_type value,
+		       uint16_t *mant, uint8_t *exp)
+{
+	int ret;
+	uint8_t data[2];
+
+	ret = adp1055_read(desc, value, data, 2);
+	if (ret)
+		return ret;
+
+	*mant = no_os_field_get(ADP1055_MANT_MASK,
+				no_os_get_unaligned_le16(data));
+	*exp = no_os_field_get(ADP1055_EXP_MASK,
+			       no_os_get_unaligned_le16(data));
+
+	return 0;
+}
+
+/**
+ * @brief Read Voltage Sense output raw value from the ADP1055
+ * @param desc - ADP1055 device descriptor
+ * @param vsense - VS(VOUT) raw value to be received of the parallel circuit.
+ * @return 0 in case of succes, negative error code otherwise
+*/
+int adp1055_read_vsense(struct adp1055_desc *desc, uint16_t *vsense)
+{
+	int ret;
+	uint8_t data[2];
+
+	ret = adp1055_read(desc, ADP1055_READ_VOUT, data, 2);
+	if (ret)
+		return ret;
+
+	*vsense = no_os_get_unaligned_le16(data);
+
+	return 0;
+}
+
+/**
+ * @brief Set VOUT_COMMAND and VOUT_MAX values
+ * @param desc - ADP1055 descriptor
+ * @param vout_command - VOUT_COMMAND value
+ * @param vout_max - VOUT_MAX value
+ * @return 0 in case of success, negative error code otherwise
+*/
+int adp1055_vout_value(struct adp1055_desc *desc, uint16_t vout_command,
+		       uint16_t vout_max)
+{
+	int ret;
+
+	ret = adp1055_write(desc, ADP1055_VOUT_COMMAND, vout_command, 2);
+	if (ret)
+		return ret;
+
+	ret = adp1055_write(desc, ADP1055_GO_CMD, ADP1055_VOLT_REF_GO, 1);
+	if (ret)
+		return ret;
+
+	return adp1055_write(desc, ADP1055_VOUT_MAX, vout_max, 2);
+}
+
+/**
+ * @brief Set output voltage offset
+ * @param desc - ADP1055 device descriptor
+ * @param vout_offset - VOUT offset value.
+ * @return 0 in case of succes, negative error code otherwise
+*/
+int adp1055_vout_offset(struct adp1055_desc *desc, int16_t vout_offset)
+{
+	return adp1055_write(desc, ADP1055_VOUT_CAL_OFFSET, vout_offset, 2);
+}
+
+/**
+ * @brief Set ADP1055 VOUT transition rate
+ * @param desc - ADP1055 device descriptor
+ * @param exp - Exponent - 5-bit twos complement
+ * @param mant - Mantissa - 11-bit twos complement
+ * @return 0 in case of succes, negative error code otherwise
+*/
+int adp1055_vout_tr(struct adp1055_desc *desc, uint8_t exp, uint16_t mant)
+{
+	uint16_t val;
+
+	val = no_os_field_prep(ADP1055_EXP_MASK, exp) | mant;
+
+	return adp1055_write(desc, ADP1055_VOUT_TRANSITION_RATE, val, 2);
+}
+
+/**
+ * @brief Set ADP1055 Vout Droop
+ * @param desc - ADP1055 device descriptor
+ * @param exp - Exponent 5-bit two's compliment
+ * @param mant - Mantissa 11-bit two's compliment
+ * @return 0 in case of success, negative error code otherwise
+ */
+int adp1055_vout_droop(struct adp1055_desc *desc, uint8_t exp, uint16_t mant)
+{
+	uint16_t val;
+
+	val = no_os_field_prep(ADP1055_EXP_MASK, exp) | mant;
+
+	return adp1055_write(desc, ADP1055_VOUT_DROOP, val, 2);
+}
+
+/**
+ * @brief Set ADP1055 vout scale loop
+ * @param desc - ADP1055 device descriptor
+ * @param exp - Exponent 5-bit two's compliment
+ * @param mant - Mantissa 11-bit two's compliment
+ * @return 0 in case of success, negative error code otherwise
+ */
+int adp1055_vout_scale_loop(struct adp1055_desc *desc, uint8_t exp,
+			    uint16_t mant)
+{
+	uint16_t val;
+
+	val = no_os_field_prep(ADP1055_EXP_MASK, exp) | mant;
+
+	return adp1055_write(desc, ADP1055_VOUT_SCALE_LOOP, val, 2);
+}
+
+/**
+ * @brief Set ADP1055 VOUT_SCALE_MONITOR
+ * @param desc - ADP1055 device descriptor
+ * @param exp - Exponent - 5-bit twos complement
+ * @param mant - Mantissa - 11-bit twos complement
+ * @return 0 in case of succes, negative error code otherwise
+*/
+int adp1055_vout_scale(struct adp1055_desc *desc, uint8_t exp, uint16_t mant)
+{
+	uint16_t val;
+
+	val = no_os_field_prep(ADP1055_EXP_MASK, exp) | mant;
+
+	return adp1055_write(desc, ADP1055_VOUT_SCALE_MONITOR, val, 2);
+}
+
+/**
+ * @brief Set ADP1055 VIN on/off raw value for input voltage limiting.
+ * @param desc - ADP1055 device descriptor
+ * @param mant - Mantissa value to be transmitted, 11 bit twos complement.
+ * @param exp - Exponent value to be transmitted, 5 bit twos complement.
+ * @param state_on - true - Set VIN_ON.
+ * 		     false - Set VIN_OFF.
+ * @return 0 in case of succes, negative error code otherwise
+*/
+int adp1055_set_vin(struct adp1055_desc *desc, int16_t mant, int8_t exp,
+		    bool state_on)
+{
+	uint16_t val;
+
+	val = no_os_field_prep(ADP1055_EXP_MASK, exp) | mant;
+
+	return adp1055_write(desc, state_on ? ADP1055_VIN_ON : ADP1055_VIN_OFF,
+			     val, 2);
+}
+
+/**
+ * @brief Set ADP1055 IOUT calibration gain
+ * @param desc - ADP1055 deveice descriptor
+ * @param mant - Mantissa value to be transmitted, 11-bit twos compliment
+ * @param exp - Exponent value to be transmitted, 5-bit twos compliment
+ * @return 0 in case of success, negative error otherwise
+ */
+int adp1055_iout_cal_gain(struct adp1055_desc *desc, int16_t mant, int8_t exp)
+{
+	int16_t val;
+
+	val = no_os_field_prep(ADP1055_EXP_MASK, exp) | mant;
+
+	return adp1055_write(desc, ADP1055_IOUT_CAL_GAIN, val, 2);
+}
+
+/**
+ * @brief Set ADP1055 IOUT calibration offset
+ * @param desc - ADP1055 deveice descriptor
+ * @param mant - Mantissa value to be transmitted, 11-bit twos compliment
+ * @param exp - Exponent value to be transmitted, 5-bit twos compliment
+ * @return 0 in case of success, negative error otherwise
+ */
+int adp1055_iout_cal_offset(struct adp1055_desc *desc, int16_t mant, int8_t exp)
+{
+	int16_t val;
+
+	val = no_os_field_prep(ADP1055_EXP_MASK, exp) | mant;
+
+	return adp1055_write(desc, ADP1055_IOUT_CAL_OFFSET, val, 2);
+}
+
+/**
+ * @brief Set ADP1055 Normal Mode Digital Filter
+ * @param desc - ADP1055 device descriptor
+ * @param zero - light mode zero settings.
+ * @param pole - light mode pole settings.
+ * @param lf - light mode low filter gain settings.
+ * @param hf - light mode high filter gain settings.
+ * @return 0 in case of success, negative error otherwise
+ */
+int adp1055_normal_mode_df(struct adp1055_desc *desc, uint8_t zero,
+			   uint8_t pole,
+			   uint8_t lf, uint8_t hf)
+{
+	int ret;
+
+	ret = adp1055_write(desc, ADP1055_NM_DIGFILT_LF_GAIN_SETTING, lf, 1);
+	if (ret)
+		return ret;
+
+	ret = adp1055_write(desc, ADP1055_NM_DIGFILT_ZERO_SETTING, zero, 1);
+	if (ret)
+		return ret;
+
+	ret = adp1055_write(desc, ADP1055_NM_DIGFILT_POLE_SETTING, pole, 1);
+	if (ret)
+		return ret;
+
+	ret =  adp1055_write(desc, ADP1055_NM_DIGFILT_POLE_SETTING, hf, 1);
+	if (ret)
+		return ret;
+
+	return adp1055_write(desc, ADP1055_GO_CMD, ADP1055_FILTER_GO, 1);
+
+}
+
+/**
+ * @brief Set ADP1055 Light Load Mode Digital Filter
+ * @param desc - ADP1055 device descriptor
+ * @param zero - light mode zero settings.
+ * @param pole - light mode pole settings.
+ * @param lf - light mode low filter gain settings.
+ * @param hf - light mode high filter gain settings.
+ * @return 0 in case of success, negative error otherwise
+ */
+int adp1055_lightload_mode_df(struct adp1055_desc *desc, uint8_t zero,
+			      uint8_t pole,
+			      uint8_t lf, uint8_t hf)
+{
+	int ret;
+
+	ret = adp1055_write(desc, ADP1055_LLM_DIGFILT_LF_GAIN_SETTING, lf, 1);
+	if (ret)
+		return ret;
+
+	ret = adp1055_write(desc, ADP1055_LLM_DIGFILT_ZERO_SETTING, zero, 1);
+	if (ret)
+		return ret;
+
+	ret = adp1055_write(desc, ADP1055_LLM_DIGFILT_POLE_SETTING, pole, 1);
+	if (ret)
+		return ret;
+
+	ret =  adp1055_write(desc, ADP1055_LLM_DIGFILT_POLE_SETTING, hf, 1);
+	if (ret)
+		return ret;
+
+	return adp1055_write(desc, ADP1055_GO_CMD, ADP1055_FILTER_GO, 1);
+}
+
+/**
+ * @brief Set ADP1055 Single Shot Digital Filter
+ * @param desc - ADP1055 device descriptor
+ * @param zero - light mode zero settings.
+ * @param pole - light mode pole settings.
+ * @param lf - light mode low filter gain settings.
+ * @param hf - light mode high filter gain settings.
+ * @return 0 in case of success, negative error otherwise
+ */
+int adp1055_singleshot_mode_df(struct adp1055_desc *desc, uint8_t zero,
+			       uint8_t pole,
+			       uint8_t lf, uint8_t hf)
+{
+	int ret;
+
+	ret = adp1055_write(desc, ADP1055_SS_DIGFILT_LF_GAIN_SETTING, lf, 1);
+	if (ret)
+		return ret;
+
+	ret = adp1055_write(desc, ADP1055_SS_DIGFILT_ZERO_SETTING, zero, 1);
+	if (ret)
+		return ret;
+
+	ret = adp1055_write(desc, ADP1055_SS_DIGFILT_POLE_SETTING, pole, 1);
+	if (ret)
+		return ret;
+
+	ret =  adp1055_write(desc, ADP1055_SS_DIGFILT_POLE_SETTING, hf, 1);
+	if (ret)
+		return ret;
+
+	return adp1055_write(desc, ADP1055_GO_CMD, ADP1055_FILTER_GO, 1);
+}
+
+/**
+ * @brief PWM modulation configuration for the ADP1055
+ * @param desc - ADP1055 device descriptor
+ * @param pulse_width - Width of the pulse wanted for the signal (used for
+ * 			calculation of the 12-bit rising and falling edge
+ * 			timings for the requested channels, it depends on each
+ * 			channel how the falling and rising edges are calculated
+ * 			using this value). Each LSB corresponds to a 5ns
+ * 			resolution.
+ * @param pulse_start - Start of the pulse wanted for the signal (used for
+ * 			calculation of the 12-bit rising and falling edge
+ * 			timings for the requested channels, it depends on each
+ * 			channel how the falling and rising edges are calculated
+ * 			using this value). Each LSB corresponds to a 5ns
+ * 			resolution.
+ * @param mod_en - boolian for modulation enable
+ * @param mod_sign - bolian for modulation sign
+ * @param chan - requested channel
+ * @return 0 in case of success, negative error otherwise
+ */
+int adp1055_pwm_config(struct adp1055_desc * desc, uint16_t pulse_width,
+		       uint16_t pulse_start, bool mod_en, bool mod_sign, enum adp1055_channel chan)
+{
+	int ret;
+	uint8_t redge, fedge;
+	uint16_t reg_redge, reg_fedge;
+	uint8_t pwm_disable = 0x3f;
+
+	ret = adp1055_write(desc, ADP1055_PWM_DISABLE_SETTING, pwm_disable, 1);
+	if (ret)
+		return ret;
+
+	fedge = no_os_field_get(ADP1055_PWM_TIMING_MASK, pulse_width + pulse_start);
+	redge = no_os_field_get(ADP1055_PWM_TIMING_MASK, pulse_start);
+
+	switch (chan) {
+	case ADP1055_OUTA:
+		reg_redge = ADP1055_OUTA_REDGE_SETTING;
+		reg_fedge = ADP1055_OUTA_FEDGE_SETTING;
+		break;
+	case ADP1055_OUTB:
+		reg_redge = ADP1055_OUTB_REDGE_SETTING;
+		reg_fedge = ADP1055_OUTB_FEDGE_SETTING;
+		break;
+	case ADP1055_OUTC:
+		reg_redge = ADP1055_OUTC_REDGE_SETTING;
+		reg_fedge = ADP1055_OUTC_FEDGE_SETTING;
+		break;
+	case ADP1055_OUTD:
+		reg_redge = ADP1055_OUTD_REDGE_SETTING;
+		reg_fedge = ADP1055_OUTD_FEDGE_SETTING;
+		break;
+	case ADP1055_SR1:
+		reg_redge = ADP1055_SR1_REDGE_SETTING;
+		reg_fedge = ADP1055_SR1_FEDGE_SETTING;
+		break;
+	case ADP1055_SR2:
+		reg_redge = ADP1055_SR2_REDGE_SETTING;
+		reg_fedge = ADP1055_SR2_FEDGE_SETTING;
+		break;
+
+	default:
+		return -EINVAL;
+	}
+
+	fedge = fedge | no_os_field_get(ADP1055_PWM_MODEN_MASK, (uint8_t)mod_en) |
+		no_os_field_get(ADP1055_PWM_SIGN_MASK, (uint8_t)mod_sign);
+
+	redge = redge | no_os_field_get(ADP1055_PWM_MODEN_MASK, (uint8_t)mod_en) |
+		no_os_field_get(ADP1055_PWM_SIGN_MASK, (uint8_t)mod_sign);
+
+	ret = adp1055_write(desc, reg_fedge, fedge, 2);
+	if (ret)
+		return ret;
+
+	ret = adp1055_write(desc, reg_redge, redge, 2);
+	if (ret)
+		return ret;
+
+	return adp1055_write(desc, ADP1055_GO_CMD, ADP1055_PWM_GO, 1);
+}
+
+/**
+ * @brief Set PWM channel and frequency
+ * @param desc - ADP1055 device descriptor
+ * @param chan - Selected channel
+ * @param exp - 5-bit twos compliment (-4 to 0)
+ * @param mant - 11-bit twos compliment
+ * @return 0 in case of success, negative error otherwise
+ */
+int adp1055_set_pwm(struct adp1055_desc * desc, enum adp1055_channel chan,
+		    int8_t exp, uint16_t mant)
+{
+	int ret;
+	uint8_t reg_val;
+	uint16_t freq;
+
+	freq = no_os_field_prep(ADP1055_EXP_MASK, exp) | mant;
+
+	ret = adp1055_write(desc, ADP1055_FREQUENCY_SWITCH, freq, 2);
+	if (ret)
+		return ret;
+
+	desc->freq_mant = no_os_field_prep(ADP1055_MANT_MASK, mant);
+	desc->freq_exp = no_os_field_prep(ADP1055_EXP_MASK, exp);
+
+	ret = adp1055_write(desc, ADP1055_GO_CMD, ADP1055_FREQ_GO, 1);
+	if (ret)
+		return ret;
+
+	switch (chan) {
+	case ADP1055_OUTA:
+		reg_val = ADP1055_OUTA_ON;
+		break;
+	case ADP1055_OUTB:
+		reg_val = ADP1055_OUTA_ON;
+		break;
+	case ADP1055_OUTC:
+		reg_val = ADP1055_OUTA_ON;
+		break;
+	case ADP1055_OUTD:
+		reg_val = ADP1055_OUTA_ON;
+		break;
+	case ADP1055_SR1:
+		reg_val = ADP1055_OUTA_ON;
+		break;
+	case ADP1055_SR2:
+		reg_val = ADP1055_OUTA_ON;
+		break;
+	case ADP1055_DISABLE_ALL:
+		reg_val = ADP1055_PWM_OFF;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return adp1055_write(desc, ADP1055_PWM_DISABLE_SETTING, reg_val, 1);
+}
+
+/**
+ * @brief Frequency synchronization of the PWM clock with an external clock
+ * 	  Requires syni_desc to be initialized.
+ * @param desc - ADP1055 device descriptor
+ * @param pll - pll disable and enable
+ * @param reso - 5ns resolution enable
+ * @return 0 in case of success, negative error otherwise
+ */
+int adp1055_freq_sync(struct adp1055_desc * desc, bool pll, bool reso)
+{
+	uint8_t val;
+	int ret;
+
+	val = no_os_field_prep(ADP1055_FREQ_PLL_MASK, (uint8_t)pll) |
+	      no_os_field_prep(ADP1055_FREQ_JITT_MASK, ADP1055_FREQ_JITT_VAL) |
+	      no_os_field_prep(ADP1055_FREQ_RESO_MASK, (uint8_t)reso);
+
+	ret = adp1055_write(desc, ADP1055_SYNC, val, 1);
+	if (ret)
+		return -EINVAL;
+
+	return adp1055_write(desc,  ADP1055_GO_CMD, ADP1055_SYNC_GO, 1);
+}

--- a/drivers/power/adp1055/adp1055.h
+++ b/drivers/power/adp1055/adp1055.h
@@ -1,0 +1,609 @@
+/***************************************************************************//**
+ *   @file   adp1055.h
+ *   @brief  Header file for the ADP1055 Driver
+ *   @author Ivangil Mercano (Ivangil.mercano@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __ADP_1055_H__
+#define __ADP_1055_H__
+
+
+/******************************************************************************/
+/***************************** Include Files **********************************/
+/******************************************************************************/
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include "no_os_gpio.h"
+#include "no_os_i2c.h"
+#include "no_os_pwm.h"
+#include "no_os_util.h"
+#include "no_os_units.h"
+
+/*****************************************************************************/
+/************************** ADP1055 Constants ********************************/
+/*****************************************************************************/
+#define ADP1055_WR_FRAME_SIZE			4
+#define ADP1055_RD_FRAME_SIZE			5
+#define ADP1055_SC_FRAME_SIZE			3
+#define ADP1055_LSB_MASK			NO_OS_GENMASK(7, 0)
+#define ADP1055_MSB_MASK			NO_OS_GENMASK(15, 8)
+#define ADP1055_EXTENDED_COMMAND		0xFF
+
+#define ADP1055_OPERATION_ON			0x80
+#define ADP1055_OPERATION_OFF			0x00
+#define ADP1055_OPERATION_SOFT_OFF		0x40
+
+#define ADP1055_EXP_MASK			NO_OS_GENMASK(15, 11)
+#define ADP1055_MANT_MASK			NO_OS_GENMASK(10, 0)
+
+#define ADP1055_VOUT_MODE_MASK			NO_OS_GENMASK(4, 0)
+
+#define ADP1055_PWM_TIMING_MASK			NO_OS_GENMASK(15, 4)
+#define ADP1055_PWM_MODEN_MASK			3
+#define ADP1055_PWM_SIGN_MASK			2
+
+#define ADP1055_OUTA_ON				0x3E
+#define ADP1055_OUTB_ON 			0x3D
+#define ADP1055_OUTC_ON				0x3B
+#define ADP1055_OUTD_ON 			0x37
+#define ADP1055_SR1_ON 				0x2F
+#define ADP1055_SR2_ON 				0x1F
+#define ADP1055_PWM_OFF				0x3F
+
+#define ADP1055_ON_OFF_DEFAULT_CFG		0x00
+#define ADP1055_DEFAULT_FREQ_MANT		-4
+#define ADP1055_DEFAULT_FREQ_EXP		782
+#define ADP1055_CTRL_PIN_ENABLE			NO_OS_BIT(4)
+
+/** CMD GO */
+#define ADP1055_VOLT_REF_GO            		0x01
+#define ADP1055_PWM_GO                  	0x02
+#define ADP1055_FREQ_GO                 	0x04
+#define ADP1055_FILTER_GO               	0x08
+#define ADP1055_VS_BAL_GO               	0x10
+#define ADP1055_VFF_GO                  	0x20
+#define ADP1055_SYNC_GO                 	0x40
+
+# define ADP1055_ON_OFF_MASK			NO_OS_GENMASK(7, 6)
+
+#define ADP1055_FREQ_PLL_MASK			NO_OS_BIT(6)
+#define ADP1055_FREQ_JITT_MASK			NO_OS_BIT(1)
+#define ADP1055_FREQ_RESO_MASK			NO_OS_BIT(0)
+#define ADP1055_FREQ_JITT_VAL			0x02
+
+/* PMBus COMMAND SET */
+/*****************************************************************************/
+/************************** adp1055 Registers ********************************/
+/*****************************************************************************/
+#define ADP1055_OPERATION			0x01
+#define ADP1055_ON_OFF_CONFIG			0x02
+#define ADP1055_CLEAR_FAULTS			0x03
+#define ADP1055_WRITE_PROTECT			0x10
+#define ADP1055_RESTORE_DEFAULT_ALL		0x12
+#define ADP1055_STORE_USER_ALL			0x15
+#define ADP1055_RESTORE_USER_ALL		0x16
+#define ADP1055_CAPABILITY			0x19
+
+#define ADP1055_SMBALERT_MASK			0x1B
+#define ADP1055_VOUT_MODE			0x20
+#define ADP1055_VOUT_COMMAND			0x21
+#define ADP1055_VOUT_TRIM			0x22
+#define ADP1055_VOUT_CAL_OFFSET			0x23
+#define ADP1055_VOUT_MAX			0x24
+#define ADP1055_VOUT_TRANSITION_RATE		0x27
+#define ADP1055_VOUT_DROOP			0x28
+#define ADP1055_VOUT_SCALE_LOOP			0x29
+#define ADP1055_VOUT_SCALE_MONITOR		0x2A
+#define ADP1055_FREQUENCY_SWITCH		0x33
+
+/** VIN ON OFF */
+#define ADP1055_VIN_ON				0x35
+#define ADP1055_VIN_OFF				0x36
+
+#define ADP1055_INTERLEAVE			0x37
+#define ADP1055_IOUT_CAL_GAIN			0x38
+#define ADP1055_IOUT_CAL_OFFSET			0x39
+
+/** Fault, Reponse, Limit, and Warn */
+#define ADP1055_VOUT_OV_FAULT_LIMIT		0x40
+#define ADP1055_VOUT_OV_FAULT_RESPONSE		0x41
+#define ADP1055_VOUT_OV_WARN_LIMIT		0x42
+#define ADP1055_VOUT_UV_WARN_LIMIT		0x43
+#define ADP1055_VOUT_UV_FAULT_LIMIT		0x44
+#define ADP1055_VOUT_UV_FAULT_RESPONSE		0x45
+#define ADP1055_IOUT_OC_FAULT_LIMIT		0x46
+#define ADP1055_IOUT_OC_FAULT_RES		0x47
+#define ADP1055_IOUT_OC_LV_FAULT_LIMIT		0x48
+#define ADP1055_IOUT_OC_LV_FAULT_RESPONSE	0x49
+#define ADP1055_IOUT_OC_WARN_LIMIT		0x4A
+#define ADP1055_IOUT_UC_FAULT_LIMIT		0x4B
+#define ADP1055_IOUT_UC_FAULT_RESPONSE		0x4C
+#define ADP1055_OT_FAULT_LIMIT			0x4F
+#define ADP1055_OT_FAULT_RESPONSE		0x50
+#define ADP1055_OT_WARN_LIMIT			0x51
+#define ADP1055_VIN_OV_FAULT_LIMIT		0x55
+#define ADP1055_VIN_OV_FAULT_RESPONSE		0x56
+#define ADP1055_VIN_UV_FAULT_LIMIT		0x59
+#define ADP1055_VIN_UV_FAULT_RESPONSE		0x5A
+#define ADP1055_IIN_OC_FAULT_LIMIT		0x5B
+#define ADP1055_IIN_OC_FAULT_RESPOSNE		0x5C
+
+#define ADP1055_POWER_GOOD_ON			0x5E
+#define ADP1055_POWER_GOOD_OFF			0x5F
+#define ADP1055_TON_DELAY			0x60
+#define ADP1055_TON_RISE			0x61
+#define ADP1055_TON_MAX_FAULT_LIMIT		0x62
+#define	ADP1055_TON_MAX_FAULT_RESPOSNE		0x63
+#define ADP1055_TOFF_DELAY			0x64
+#define ADP1055_TOFF_FALL			0x65
+#define ADP1055_TOFF_MAX_WARN_LIMIT		0x66
+#define ADP1055_POUT_OP_FAULT_LIMIT		0x68
+#define ADP1055_POUT_OP_FAULT_RESPONSE		0x69
+
+/** STATUS */
+#define ADP1055_STATUS_BYTE			0x78
+#define ADP1055_STATUS_WORD			0x79
+#define ADP1055_STATUS_VOUT			0x7A
+#define ADP1055_STATUS_IOUT			0x7B
+#define ADP1055_STATUS_INPUT			0x7C
+#define ADP1055_STATUS_TEMPERATURE		0x7D
+#define ADP1055_STATUS_CML			0x7E
+#define ADP1055_STATUS_OTHER			0x7F
+#define ADP1055_STATUS_MFR_SPECIFIC		0x80
+
+/** READ */
+#define ADP1055_READ_VIN			0x88
+#define ADP1055_READ_IIN			0x89
+#define ADP1055_READ_VOUT			0x8B
+#define ADP1055_READ_IOUT			0x8C
+#define ADP1055_READ_TEMPERATURE_2		0x8E
+#define ADP1055_READ_TEMPERATURE_3		0x8F
+#define ADP1055_READ_DUTY_CYCLE			0x94
+#define ADP1055_READ_FREQUENCY			0x95
+#define ADP1055_READ_POUT			0x96
+
+#define ADP1055_READ_PMBUS_REVISION		0x98
+#define ADP1055_MFR_ID				0x99
+#define ADP1055_MFR_MODEL			0x9A
+#define ADP1055_MFR_REVISION			0x9B
+#define ADP1055_MFR_LOCATION			0x9C
+#define ADP1055_MFR_DATE			0x9D
+#define ADP1055_IC_DEVICE_ID			0xAD
+#define ADP1055_IC_DEVICE_REV			0xAE
+#define ADP1055_EEPROM_DATA_00			0xB0
+#define ADP1055_EEPROM_DATA_01			0xB1
+#define ADP1055_EEPROM_DATA_02			0xB2
+#define ADP1055_EEPROM_DATA_03			0xB3
+#define ADP1055_EEPROM_DATA_04			0xB4
+#define ADP1055_EEPROM_DATA_05			0xB5
+#define ADP1055_EEPROM_DATA_06			0xB6
+#define ADP1055_EEPROM_DATA_07			0xB7
+#define ADP1055_EEPROM_DATA_08			0xB8
+#define ADP1055_EEPROM_DATA_09			0xB9
+#define ADP1055_EEPROM_DATA_10			0xBA
+#define ADP1055_EEPROM_DATA_11			0xBB
+#define ADP1055_EEPROM_DATA_12			0xBC
+#define ADP1055_EEPROM_DATA_13			0xBD
+#define ADP1055_EEPROM_DATA_14			0xBE
+#define ADP1055_EEPROM_DATA_15			0xBF
+#define ADP1055_EEPROM_CRC_CHKSUM		0xD1
+#define ADP1055_EEPROM_NUM_RD_BYTES		0xD2
+#define ADP1055_EEPROM_ADDR_OFFSET		0xD3
+#define ADP1055_EEPROM_PAGE_ERASE		0xD4
+#define ADP1055_EEPROM_PASSWORD			0xD5
+#define ADP1055_TRIM_PASSWORD			0xD6
+#define ADP1055_CHIP_PASSWORD			0xD7
+#define ADP1055_IIN_SCALE_MONITOR		0xD9
+#define ADP1055_EEPROM_INFO			0xF1
+#define ADP1055_READ_BLACKBOX_CURR		0xF2
+#define ADP1055_READ_BLACKBOX_PREV		0xF3
+#define ADP1055_CMD_MASK			0xF4
+#define ADP1055_EXTCMD_MASK			0xF5
+#define ADP1055_MFR_SPECIFIC_1			0xFA
+#define ADP1055_MFR_SPECIFIC_2			0xFB
+
+/* MANUFACTURER SPECIFIC EXTENDED COMMAND LIST */
+
+/** Go Command */
+#define ADP1055_GO_CMD				0xFE00
+
+/** NM LLM and SS Digfilt */
+#define ADP1055_NM_DIGFILT_LF_GAIN_SETTING 	0xFE01
+#define ADP1055_NM_DIGFILT_ZERO_SETTING 	0xFE02
+#define ADP1055_NM_DIGFILT_POLE_SETTING  	0xFE03
+#define ADP1055_NM_DIGFILT_HF_GAIN_SETTING	0xFE04
+
+#define ADP1055_LLM_DIGFILT_LF_GAIN_SETTING 	0xFE05
+#define ADP1055_LLM_DIGFILT_ZERO_SETTING	0xFE06
+#define ADP1055_LLM_DIGFILT_POLE_SETTING 	0xFE07
+#define ADP1055_LLM_DIGFILT_HF_GAIN_SETTING	0xFE08
+
+#define ADP1055_SS_DIGFILT_LF_GAIN_SETTING 	0xFE09
+#define ADP1055_SS_DIGFILT_ZERO_SETTING 	0xFE0A
+#define ADP1055_SS_DIGFILT_POLE_SETTING 	0xFE0B
+#define ADP1055_SS_DIGFILT_HF_GAIN_SETTING 	0xFE0C
+
+/** OUTA, OUTB, OUTC, OUTC, SR1, and SR2 Settings */
+#define ADP1055_OUTA_REDGE_SETTING		0xFE0D
+#define ADP1055_OUTA_FEDGE_SETTING 		0xFE0E
+#define ADP1055_OUTB_REDGE_SETTING 		0xFE0F
+#define ADP1055_OUTB_FEDGE_SETTING 		0xFE10
+#define ADP1055_OUTC_REDGE_SETTING		0xFE11
+#define ADP1055_OUTC_FEDGE_SETTING		0xFE12
+#define ADP1055_OUTD_REDGE_SETTING 		0xFE13
+#define ADP1055_OUTD_FEDGE_SETTING 		0xFE14
+#define ADP1055_SR1_REDGE_SETTING 		0xFE15
+#define ADP1055_SR1_FEDGE_SETTING		0xFE16
+#define ADP1055_SR2_REDGE_SETTING 		0xFE17
+#define ADP1055_SR2_FEDGE_SETTING 		0xFE18
+#define ADP1055_SR1_REDGE_LLM_SETTING 		0xFE19
+#define ADP1055_SR1_FEDGE_LLM_SETTING		0xFE1A
+#define ADP1055_SR2_REDGE_LLM_SETTING 		0xFE1B
+#define ADP1055_SR2_FEDGE_LLM_SETTING 		0xFE1C
+
+/** ADT Setting */
+#define ADP1055_ADT_CONFIG 			0xFE1D
+#define ADP1055_ADT_THRESHOLD			0xFE1E
+
+/** PWM Output Dead Time */
+#define ADP1055_OUTA_DEAD_TIME 			0xFE1F
+#define ADP1055_OUTB_DEAD_TIME			0xFE20
+#define ADP1055_OUTC_DEAD_TIME			0xFE21
+#define ADP1055_OUTD_DEAD_TIME			0xFE22
+#define ADP1055_SR1_DEAD_TIME 			0xFE23
+#define ADP1055_SR2_DEAD_TIME 			0xFE24
+
+/** VSBAL Settings */
+#define ADP1055_VSBAL_SETTING			0xFE25
+#define ADP1055_VSBAL_OUTA_B 			0xFE26
+#define ADP1055_VSBAL_OUTC_D			0xFE27
+#define ADP1055_VSBAL_SR1_2			0xFE28
+
+/** FFWD Setting */
+#define ADP1055_FFWD_SETTING			0xFE29
+
+/* ISHARE Setting */
+#define ADP1055_ISHARE_SETTING			0xFE2A
+#define ADP1055_ISHARE_BANDWIDTH 		0xFE2B
+
+/** Fast Setting */
+#define ADP1055_IIN_OC_FAST_SETTING		0xFE2C
+#define ADP1055_IOUT_OC_FAST_SETTING 		0xFE2D
+#define ADP1055_IOUT_UC_FAST_SETTING		0xFE2E
+#define ADP1055_VOUT_OV_FAST_SETTING		0xFE2F
+
+/* Debounce Settings */
+#define ADP1055_DEBOUNCE_SETTING_1		0xFE30
+#define ADP1055_DEBOUNCE_SETTING_2		0xFE31
+#define ADP1055_DEBOUNCE_SETTING_3 		0xFE32
+#define ADP1055_DEBOUNCE_SETTING_4 		0xFE33
+
+/** Fault Response  */
+#define ADP1055_VOUT_OV_FAST_FAULT_RESPONSE	0xFE34
+#define ADP1055_IOUT_OC_FAST_FAULT_RESPONSE	0xFE35
+#define ADP1055_IOUT_UC_FAST_FAULT_RESPONSE	0xFE36
+#define ADP1055_IIN_OC_FAST_FAULT_RESPONSE 	0xFE37
+#define ADP1055ISHARE_FAULT_RESPONSE 		0xFE38
+#define ADP1055_GPIO1_FAULT_RESPONSE		0xFE39
+#define ADP1055_GPIO2_FAULT_RESPONSE 		0xFE3A
+#define ADP1055_GPIO3_FAULT_RESPONSE 		0xFE3B
+#define ADP1055_GPIO4_FAULT_RESPONSE		0xFE3C
+
+/** PWM Fault Mask */
+#define ADP1055_PWM_FAULT_MASK			0xFE3D
+
+/** Delay Time Unit */
+#define ADP1055_DELAY_TIME_UNIT 		0xFE3E
+
+/** WDT Setting */
+#define ADP1055_WDT_SETTING			0xFE3F
+
+/** GPIO Setting */
+#define ADP1055_GPIO_SETTING			0xFE40
+#define ADP1055GPIO1_2_KARNAUGH_MAP		0xFE41
+#define ADP1055_GPIO3_4_KARNAUGH_MAP		0xFE42
+
+/** PGOOD Fault Setting */
+#define ADP1055_PGOOD_FAULT_DEB			0xFE43
+#define ADP1055_PGOOD1_FAULT_SELECT		0xFE44
+#define ADP1055_PGOOD2_FAULT_SELECT		0xFE45
+
+/** Soft Start */
+#define ADP1055_SOFT_START_BLANKING		0xFE46
+#define ADP1055_SOFT_STOP_BLANKING		0xFE47
+
+/** Blackbox Setting */
+#define ADP1055_BLACKBOX_SETTING		0xFE48
+
+/** PWM Disable Setting */
+#define ADP1055_PWM_DISABLE_SETTING		0xFE49
+
+/** Filter Transition */
+#define ADP1055_FILTER_TRANSITION		0xFE4A
+
+/** Deep Light Load Mode Setting */
+#define ADP1055_DEEP_LLM_SETTING		0xFE4B
+#define ADP1055_DEEP_LLM_DISABLE_SETTING	0xFE4C
+
+/** OVP Fault Config */
+#define ADP1055_OVP_FAULT_CONFIG		0xFE4D
+
+/** CS1 and CS2 */
+#define ADP1055_CS1_SETTING			0xFE4E
+#define ADP1055_CS2_SETTING			0xFE4F
+
+/** Pulse Skiping and Shutdown */
+#define ADP1055_PULSE_SKIP_AND_SHUTDOWN		0xFE50
+
+/** Soft Start Setting */
+#define ADP1055_SOFT_START_SETTING		0xFE51
+
+/** SR Delay */
+#define ADP1055_SR_DELAY			0xFE52
+
+/** Modulation Limit */
+#define ADP1055_MODULATION_LIMIT		0xFE53
+
+/** SYNC */
+#define ADP1055_SYNC				0xFE55
+
+/** Duty Balance Edgesel */
+#define ADP1055_DUTY_BAL_EDGESEL		0xFE56
+
+/** Double UPD Rate */
+#define ADP1055_DOUBLE_UPD_RATE			0xFE57
+
+/** Vin Scale Monitor */
+#define ADP1055_VIN_SCALE_MONITOR		0xFE58
+
+/* IIN Cal Gain */
+#define ADP1055_IIN_CAL_GAIN			0xFE59
+
+/** TSNS Setting */
+#define ADP1055_TSNS_SETTING			0xFE5A
+
+/* Auto go CMD */
+#define ADP1055_AUTO_GO_CMD			0xFE5B
+
+/** Diode Emulation */
+#define ADP1055_DIODE_EMULATION			0xFE5C
+
+/** CS2 Constant Current Mode */
+#define ADP1055_CS2_CONST_CUR_MODE		0xFE5D
+
+/** NL ERR Gain Factor */
+#define ADP1055_NL_ERR_GAIN_FACTOR		0xFE5E
+
+/** SR Setting */
+#define ADP1055_SR_SETTING			0xFE5F
+
+/** Temperature Polarity */
+#define ADP1055_NOMINAL_TEMP_POLE		0xFE60
+#define ADP1055_LOW_TEMP_POLE			0xFE61
+#define ADP1055_LOW_TEMP_SETTING		0xFE62
+
+/** GPIO3 Snubber */
+#define ADP1055_GPIO3_4_SNUBBER_ON_TIME		0xFE63
+#define ADP1055_GPIO3_4_SNUBBER_DELAY		0xFE64
+
+/** VOUT Droop Setting */
+#define ADP1055_VOUT_DROOP_SETTING		0xFE65
+
+/** NL Burst Mode */
+#define ADP1055_NL_BURST_MODE			0xFE66
+
+/** HF ADC Config */
+#define ADP1055_HF_ADC_CONFIG			0xFE67
+
+/** VS Trim */
+#define ADP1055_VS_TRIM				0xFE80
+
+/** VFF Gain Trim */
+#define ADP1055_VFF_GAIN_TRIM			0xFE81
+
+/** CS1 Gain Trim */
+#define ADP1055_CS1_GAIN_TRIM			0xFE82
+
+/** TSNS Settings */
+#define ADP1055_TSNS_EXTFWD_GAIN_TRIM		0xFE86
+#define ADP1055_TSNS_EXTFWD_OFFSET_TRIM		0xFE87
+#define ADP1055_TSNS_EXTREV_GAIN_TRIM		0xFE88
+#define ADP1055_TSNS_EXTREV_OFFSET_TRIM		0xFE89
+
+/** Faults */
+#define ADP1055_FAULT_VOUT			0xFE8C
+#define ADP1055_FAULT_IOUT			0xFE8D
+#define ADP1055_FAULT_INPUT			0xFE8E
+#define ADP1055_FAULT_TEMPERATURE		0xFE8F
+#define ADP1055_FAULT_CML			0xFE90
+#define ADP1055_FAULT_OTHER			0xFE91
+#define ADP1055_FAULT_MFR_SPECIFIC		0xFE92
+#define ADP1055_FAULT_UNKNOWN			0xFE93
+#define ADP1055_STATUS_UNKNOWN			0xFE94
+#define ADP1055_FIRST_FAULT_ID			0xFE95
+
+/** Values */
+#define ADP1055_VFF_VALUE			0xFE96
+#define ADP1055_VS_VALUE			0xFE97
+#define ADP1055_CS1_VALUE			0xFE98
+#define ADP1055_CS2_VALUE			0xFE99
+#define ADP1055_POUT_VALUE			0xFE9A
+#define ADP1055_TSNS_EXTFWD_VALUE		0xFE9C
+#define ADP1055_TSNS_EXTREV_VALUE		0xFE9D
+#define ADP1055_MODULATION_VALUE		0xFE9F
+#define ADP1055_ISHARE_VALUE			0xFEA0
+#define ADP1055_ADD_ADC_VALUE			0xFEA3
+
+enum adp1055_status_type {
+	ADP1055_STATUS_VOUT_TYPE = ADP1055_STATUS_VOUT,
+	ADP1055_STATUS_IOUT_TYPE = ADP1055_STATUS_IOUT,
+	ADP1055_STATUS_INPUT_TYPE = ADP1055_STATUS_INPUT,
+	ADP1055_STATUS_TEMP_TYPE = ADP1055_STATUS_TEMPERATURE,
+	ADP1055_STATUS_CML_TYPE = ADP1055_STATUS_CML,
+	ADP1055_STATUS_OTHER_TYPE = ADP1055_STATUS_OTHER,
+	ADP1055_STATUS_WORD_TYPE = ADP1055_STATUS_WORD,
+	ADP1055_STATUS_MFR_TYPE = ADP1055_STATUS_MFR_SPECIFIC,
+};
+
+enum adp1055_value_type {
+	ADP1055_VALUE_VIN = ADP1055_READ_VIN,
+	ADP1055_VALUE_IIN = ADP1055_READ_IIN,
+	ADP1055_VALUE_IOUT = ADP1055_READ_IOUT,
+	ADP1055_VALUE_TEMP2 = ADP1055_READ_TEMPERATURE_2,
+	ADP1055_VALUE_TEMP3 = ADP1055_READ_TEMPERATURE_3,
+	ADP1055_VALUE_DUTY_CYCLE = ADP1055_READ_DUTY_CYCLE,
+	ADP1055_VALUE_FREQUENCY = ADP1055_READ_FREQUENCY,
+	ADP1055_VALUE_POUT = ADP1055_READ_POUT,
+};
+
+enum adp1055_channel {
+	ADP1055_OUTA,
+	ADP1055_OUTB,
+	ADP1055_OUTC,
+	ADP1055_OUTD,
+	ADP1055_SR1,
+	ADP1055_SR2,
+	ADP1055_DISABLE_ALL,
+};
+
+/**
+ * @brief Initialization parameter for the ADP1055 device.
+*/
+struct adp1055_init_param {
+	struct no_os_i2c_init_param *i2c_param;
+	struct no_os_gpio_init_param *pg_alt_param;
+	struct no_os_pwm_init_param *syni_param;
+	struct no_os_gpio_init_param *flgi_param;
+	struct no_os_gpio_init_param *ctrl_param;
+	uint8_t on_off_config;
+	bool ext_syni;
+};
+
+/**
+ * @brief Device descriptor for ADP1055.
+*/
+struct adp1055_desc {
+	struct no_os_i2c_desc *i2c_desc;
+	struct no_os_gpio_desc *pg_alt_desc;
+	struct no_os_pwm_desc *syni_desc;
+	struct no_os_gpio_desc *flgi_desc;
+	struct no_os_gpio_desc *ctrl_desc;
+	uint16_t freq_mant;
+	uint8_t freq_exp;
+};
+
+/** Send command byte/word to ADP1055 */
+int adp1055_send_command(struct adp1055_desc *desc, uint16_t command);
+
+/** Write data to ADP1055 */
+int adp1055_write(struct adp1055_desc *desc, uint16_t command, uint16_t data,
+		  uint8_t byte_num);
+
+/** Read data from ADP1055 */
+int adp1055_read(struct adp1055_desc *desc, uint16_t command, uint8_t *data,
+		 uint8_t bytes_number);
+
+/** Initialize the ADP1055 device. */
+int adp1055_init(struct adp1055_desc **desc,
+		 struct adp1055_init_param *init_param);
+
+/** Free the resources allocated by the adp1055_init() */
+int adp1055_remove(struct adp1055_desc *desc);
+
+/** Send statuses  */
+int adp1055_read_status(struct adp1055_desc *desc,
+			enum adp1055_status_type status,
+			uint16_t *status_val);
+
+/** Read VIN/IIN/VOUT/TEMP2/TEMP3/DUTY_CYCLE_FREQ/POUT raw value from the ADP1055 */
+int adp1055_read_value(struct adp1055_desc *desc, enum adp1055_value_type value,
+		       uint16_t *mant, uint8_t *exp);
+
+/** Read Voltage Sense output raw value from the ADP1055 */
+int adp1055_read_vsense(struct adp1055_desc *desc, uint16_t *vsense);
+
+/** Set VOUT_COMMAND and VOUT_MAX values */
+int adp1055_vout_value(struct adp1055_desc *desc, uint16_t vout_command,
+		       uint16_t vout_max);
+
+/** Set output voltage offset */
+int adp1055_vout_offset(struct adp1055_desc *desc, int16_t vout_offset);
+
+/** Set ADP1055 VOUT transition rate */
+int adp1055_vout_tr(struct adp1055_desc *desc, uint8_t exp, uint16_t mant);
+
+/** Set ADP1055 Vout Droop */
+int adp1055_vout_droop(struct adp1055_desc *desc, uint8_t exp, uint16_t mant);
+
+/** Set ADP1055 vout scale loop */
+int adp1055_vout_scale_loop(struct adp1055_desc *desc, uint8_t exp,
+			    uint16_t mant);
+
+/** Set ADP1055 VOUT_SCALE_MONITOR */
+int adp1055_vout_scale(struct adp1055_desc *desc, uint8_t exp, uint16_t mant);
+
+/** Set ADP1055 VIN on/off raw value for input voltage limiting. */
+int adp1055_set_vin(struct adp1055_desc *desc, int16_t mant, int8_t exp,
+		    bool state_on);
+
+/** Set ADP1055 IOUT calibration gain */
+int adp1055_iout_cal_gain(struct adp1055_desc *desc, int16_t mant, int8_t exp);
+
+/** Set ADP1055 IOUT calibration offset */
+int adp1055_iout_cal_offset(struct adp1055_desc *desc, int16_t mant,
+			    int8_t exp);
+
+/** Set ADP1055 Normal Mode Digital Filter */
+int adp1055_normal_mode_df(struct adp1055_desc *desc, uint8_t zero,
+			   uint8_t pole,
+			   uint8_t lf, uint8_t hf);
+
+/** Set ADP1055 Light Load Mode Digital Filter */
+int adp1055_lightload_mode_df(struct adp1055_desc *desc, uint8_t zero,
+			      uint8_t pole,
+			      uint8_t lf, uint8_t hf);
+
+/** Set ADP1055 Single Shot Digital Filter */
+int adp1055_singleshot_mode_df(struct adp1055_desc *desc, uint8_t zero,
+			       uint8_t pole,
+			       uint8_t lf, uint8_t hf);
+
+/** PWM modulation configuration for the ADP1055 */
+int adp1055_pwm_config(struct adp1055_desc * desc, uint16_t pulse_width,
+		       uint16_t pulse_start, bool mod_en, bool mod_sign, enum adp1055_channel chan);
+
+/** Set PWM channel and frequency */
+int adp1055_set_pwm(struct adp1055_desc * desc, enum adp1055_channel chan,
+		    int8_t exp, uint16_t mant);
+
+/** Set Frequency Synchronization */
+int adp1055_freq_sync(struct adp1055_desc * desc, bool pll, bool reso);
+
+#endif /** __ADP_1050_H__ */

--- a/drivers/power/adp1055/iio_adp1055.c
+++ b/drivers/power/adp1055/iio_adp1055.c
@@ -1,0 +1,863 @@
+/***************************************************************************//**
+ *   @file   iio_adp1055.c
+ *   @brief  Source file for the ADP1055 IIO Driver
+ *   @author Ivan Gil Mercano (IvanGil.Mercano@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include "no_os_alloc.h"
+#include "no_os_error.h"
+#include "no_os_units.h"
+#include "no_os_util.h"
+
+#include "adp1055.h"
+#include "iio_adp1055.h"
+
+#define ADP1055_IIO_OUTPUT_CHANNEL(x)		((x) - 6)
+#define ADP1055_IIO_OUTPUT_OUTCHAN_MASK		NO_OS_GENMASK(3, 0)
+#define ADP1055_IIO_OUTPUT_SRCHAN_MASK		NO_OS_GENMASK(5, 4)
+#define ADP1055_IIO_OUT_MASK 				NO_OS_GENMASK(5, 0)
+#define ADP1055_IIO_ENABLE_MASK(x)			NO_OS_BIT(x)
+#define ADP1055_IIO_FREQ_MANT(x)		((x) > 48 && (x) < 64  ? -4 : \
+                       				(x) > 64 && (x) < 128 ? -3 : \
+                        			(x) > 128 && (x) < 256 ? -2 : \
+                        			(x) > 256 && (x) < 510 ? -1 : 0)
+
+static const char *const adp1055_enable_avail[2] = {
+	"Disabled", "Enabled"
+};
+
+static const char *const adp1055_freq_avail[] = {
+	"49KHz",
+	"59KHz",
+	"60KHz",
+	"65KHz",
+	"71KHz",
+	"78KHz",
+	"87KHz",
+	"104KHz",
+	"120KHz",
+	"130KHz",
+	"136KHz",
+	"142KHz",
+	"149KHz",
+	"184KHz",
+	"223KHz",
+	"250KHz",
+	"284KHz",
+	"329KHz",
+	"338KHz",
+	"347KHz",
+	"357KHz",
+	"379KHz",
+	"397KHz",
+	"403KHz",
+	"410KHz",
+	"97.5KHz",
+	"111.5KHz",
+	"156.5KHz",
+	"164.5KHz",
+	"173.5KHz",
+	"195.5KHz",
+	"201.5KHz",
+	"208.5KHz",
+	"215.5KHz",
+	"231.5KHz",
+	"240.5KHz",
+	"260.5KHz",
+	"271.5KHz",
+	"297.5KHz",
+	"312.5KHz",
+	"320.5KHz",
+	"367.5KHz",
+	"390.5KHz"
+};
+
+static const uint32_t adp1055_freq2_avail[] = {
+	49,
+	59,
+	60,
+	65,
+	71,
+	78,
+	87,
+	104,
+	120,
+	130,
+	136,
+	142,
+	149,
+	184,
+	223,
+	250,
+	284,
+	329,
+	338,
+	347,
+	357,
+	379,
+	397,
+	403,
+	410,
+	97,
+	111,
+	156,
+	164,
+	173,
+	195,
+	201,
+	208,
+	215,
+	231,
+	240,
+	260,
+	271,
+	297,
+	312,
+	320,
+	367,
+	390,
+};
+
+enum adp1055_iio_enable_type {
+	ADP1055_IIO_OUT_ENABLE,
+	ADP1055_IIO_FEEDFORWARD_ENABLE,
+	ADP1055_IIO_PULSE_ENABLE,
+	ADP1055_IIO_FREQ_SYNC_ENABLE
+};
+
+enum ADP1055_iio_input_chan_type {
+	ADP1055_IIO_VIN_CHAN,
+	ADP1055_IIO_IIN_CHAN,
+	ADP1055_IIO_VOUT_CHAN,
+	ADP1055_IIO_IOUT_CHAN,
+	ADP1055_IIO_TEMP2_CHAN,
+	ADP1055_IIO_TEMP3_CHAN
+};
+
+enum ADP1055_iio_output_chan_type {
+	ADP1055_IIO_OUTA_CHAN = 0x6,
+	ADP1055_IIO_OUTB_CHAN = 0x7,
+	ADP1055_IIO_OUTC_CHAN = 0x8,
+	ADP1055_IIO_OUTD_CHAN = 0x9,
+	ADP1055_IIO_SR1_CHAN = 0xA,
+	ADP1055_IIO_SR2_CHAN = 0xB
+};
+
+enum ADP1055_iio_vout_value_type {
+	ADP1055_IIO_VOUT_COMMAND_VALUE = ADP1055_VOUT_COMMAND,
+	ADP1055_IIO_VOUT_SCALE_MONITOR_VALUE = ADP1055_VOUT_SCALE_MONITOR,
+	ADP1055_IIO_VOUT_OFFSET_VALUE = ADP1055_VOUT_CAL_OFFSET,
+};
+
+static int adp1055_iio_read_raw(void *dev, char *buf, uint32_t len,
+				const struct iio_ch_info *channel,
+				intptr_t priv);
+
+static int adp1055_iio_read_scale(void *dev, char *buf, uint32_t len,
+				  const struct iio_ch_info *channel,
+				  intptr_t priv);
+
+static int adp1055_iio_read_status(void *dev, char *buf, uint32_t len,
+				   const struct iio_ch_info *channel,
+				   intptr_t priv);
+
+static int adp1055_iio_read_vout(void *dev, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel,
+				 intptr_t priv);
+
+static int adp1055_iio_write_vout(void *dev, char *buf, uint32_t len,
+				  const struct iio_ch_info *channel,
+				  intptr_t priv);
+
+static int adp1055_iio_read_freq(void *dev, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel,
+				 intptr_t priv);
+
+static int adp1055_iio_read_freq_available(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv);
+
+static int adp1055_iio_write_freq(void *dev, char *buf, uint32_t len,
+				  const struct iio_ch_info *channel,
+				  intptr_t priv);
+
+static int adp1055_iio_read_enable(void *dev, char *buf, uint32_t len,
+				   const struct iio_ch_info *channel,
+				   intptr_t priv);
+
+static int adp1055_iio_write_enable(void *dev, char *buf, uint32_t len,
+				    const struct iio_ch_info *channel,
+				    intptr_t priv);
+
+static struct iio_attribute adp1055_input_attrs[] = {
+	{
+		.name = "raw",
+		.show = adp1055_iio_read_raw,
+	},
+	{
+		.name = "scale",
+		.show = adp1055_iio_read_scale,
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_attribute adp1055_output_attrs[] = {
+	{
+		.name = "enable",
+		.show = adp1055_iio_read_enable,
+		.store = adp1055_iio_write_enable,
+		.priv = ADP1055_IIO_OUT_ENABLE
+	},
+	{
+		.name = "frequency",
+		.show = adp1055_iio_read_freq,
+		.store = adp1055_iio_write_freq,
+		.shared = IIO_SHARED_BY_ALL
+	},
+	{
+		.name = "freqyency_available",
+		.show = adp1055_iio_read_freq_available,
+		.shared = IIO_SHARED_BY_ALL,
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_attribute adp1055_global_attrs[] = {
+	{
+		.name = "vout_command",
+		.show = adp1055_iio_read_vout,
+		.store = adp1055_iio_write_vout,
+		.priv = ADP1055_IIO_VOUT_COMMAND_VALUE
+	},
+	{
+		.name = "vout_scale_monitor",
+		.show = adp1055_iio_read_vout,
+		.store = adp1055_iio_write_vout,
+		.priv = ADP1055_IIO_VOUT_SCALE_MONITOR_VALUE
+	},
+	{
+		.name = "vout_offset",
+		.show = adp1055_iio_read_vout,
+		.store = adp1055_iio_write_vout,
+		.priv = ADP1055_IIO_VOUT_OFFSET_VALUE
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_attribute adp1055_debug_attrs[] = {
+	{
+		.name = "status_vout",
+		.show = adp1055_iio_read_status,
+		.priv = ADP1055_STATUS_VOUT_TYPE
+	},
+	{
+		.name = "status_iout",
+		.show = adp1055_iio_read_status,
+		.priv = ADP1055_STATUS_IOUT_TYPE
+	},
+	{
+		.name = "status_input",
+		.show = adp1055_iio_read_status,
+		.priv = ADP1055_STATUS_INPUT_TYPE
+	},
+	{
+		.name = "status_temp",
+		.show = adp1055_iio_read_status,
+		.priv = ADP1055_STATUS_TEMP_TYPE
+	},
+	{
+		.name = "status_cml",
+		.show = adp1055_iio_read_status,
+		.priv = ADP1055_STATUS_CML_TYPE
+	},
+	{
+		.name = "status_other",
+		.show = adp1055_iio_read_status,
+		.priv = ADP1055_STATUS_OTHER_TYPE
+	},
+	{
+		.name = "status_word",
+		.show = adp1055_iio_read_status,
+		.priv = ADP1055_STATUS_WORD_TYPE
+	},
+	{
+		.name = "status_mfr",
+		.show = adp1055_iio_read_status,
+		.priv = ADP1055_STATUS_MFR_TYPE
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_channel adp1055_channels[] = {
+	{
+		.name = "vin",
+		.ch_type = IIO_VOLTAGE,
+		.indexed = 1,
+		.channel = ADP1055_IIO_VIN_CHAN,
+		.address = ADP1055_IIO_VIN_CHAN,
+		.attributes = adp1055_input_attrs,
+		.ch_out = false
+	},
+	{
+		.name = "iin",
+		.ch_type = IIO_CURRENT,
+		.indexed = 1,
+		.channel = ADP1055_IIO_IIN_CHAN,
+		.address = ADP1055_IIO_IIN_CHAN,
+		.attributes = adp1055_input_attrs,
+		.ch_out = false
+	},
+	{
+		.name = "vout",
+		.ch_type = IIO_VOLTAGE,
+		.indexed = 1,
+		.channel = ADP1055_IIO_VOUT_CHAN,
+		.address = ADP1055_IIO_VOUT_CHAN,
+		.attributes = adp1055_input_attrs,
+		.ch_out = false
+	},
+	{
+		.name = "iout",
+		.ch_type = IIO_CURRENT,
+		.indexed = 1,
+		.channel = ADP1055_IIO_IOUT_CHAN,
+		.address = ADP1055_IIO_IOUT_CHAN,
+		.attributes = adp1055_input_attrs,
+		.ch_out = false
+	},
+	{
+		.name = "temp2",
+		.ch_type = IIO_TEMP,
+		.indexed = 1,
+		.channel = ADP1055_IIO_TEMP2_CHAN,
+		.address = ADP1055_IIO_TEMP2_CHAN,
+		.attributes = adp1055_input_attrs,
+		.ch_out = false
+	},
+	{
+		.name = "temp3",
+		.ch_type = IIO_TEMP,
+		.indexed = 1,
+		.channel = ADP1055_IIO_TEMP3_CHAN,
+		.address = ADP1055_IIO_TEMP3_CHAN,
+		.attributes = adp1055_input_attrs,
+		.ch_out = false
+	},
+	{
+		.name = "outa",
+		.ch_type = IIO_VOLTAGE,
+		.indexed = 1,
+		.channel = ADP1055_IIO_OUTA_CHAN,
+		.address = ADP1055_IIO_OUTA_CHAN,
+		.attributes = adp1055_output_attrs,
+		.ch_out = true,
+	},
+	{
+		.name = "outb",
+		.ch_type = IIO_VOLTAGE,
+		.indexed = 1,
+		.channel = ADP1055_IIO_OUTB_CHAN,
+		.address = ADP1055_IIO_OUTB_CHAN,
+		.attributes = adp1055_output_attrs,
+		.ch_out = true,
+	},
+	{
+		.name = "outc",
+		.ch_type = IIO_VOLTAGE,
+		.indexed = 1,
+		.channel = ADP1055_IIO_OUTA_CHAN,
+		.address = ADP1055_IIO_OUTA_CHAN,
+		.attributes = adp1055_output_attrs,
+		.ch_out = true,
+	},
+	{
+		.name = "outd",
+		.ch_type = IIO_VOLTAGE,
+		.indexed = 1,
+		.channel = ADP1055_IIO_OUTB_CHAN,
+		.address = ADP1055_IIO_OUTB_CHAN,
+		.attributes = adp1055_output_attrs,
+		.ch_out = true,
+	},
+	{
+		.name = "sr1",
+		.ch_type = IIO_VOLTAGE,
+		.indexed = 1,
+		.channel = ADP1055_IIO_SR1_CHAN,
+		.address = ADP1055_IIO_SR1_CHAN,
+		.attributes = adp1055_output_attrs,
+		.ch_out = true,
+	},
+	{
+		.name = "sr2",
+		.ch_type = IIO_VOLTAGE,
+		.indexed = 1,
+		.channel = ADP1055_IIO_SR2_CHAN,
+		.address = ADP1055_IIO_SR2_CHAN,
+		.attributes = adp1055_output_attrs,
+		.ch_out = true,
+	}
+};
+
+static struct iio_device adp1055_iio_dev = {
+	.num_ch = NO_OS_ARRAY_SIZE(adp1055_channels),
+	.channels = adp1055_channels,
+	.attributes = adp1055_global_attrs,
+	.debug_attributes = adp1055_debug_attrs
+};
+
+/**
+ * @brief Handles the read request for the raw attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ *
+ */
+static int adp1055_iio_read_raw(void *dev, char *buf, uint32_t len,
+				const struct iio_ch_info *channel,
+				intptr_t priv)
+{
+	int ret;
+	uint16_t mant, val;
+	uint8_t exp;
+	struct adp1055_iio_desc *iio_adp1055 = dev;
+	struct adp1055_desc *adp1055 = iio_adp1055->adp1055_desc;
+
+	switch (channel->address) {
+	case ADP1055_IIO_VIN_CHAN:
+		ret = adp1055_read_value(adp1055, ADP1055_VALUE_VIN, &mant, &exp);
+		break;
+	case ADP1055_IIO_IIN_CHAN:
+		ret = adp1055_read_value(adp1055, ADP1055_VALUE_IIN, &mant, &exp);
+		break;
+	case ADP1055_IIO_TEMP2_CHAN:
+		ret = adp1055_read_value(adp1055, ADP1055_VALUE_TEMP2, &mant, &exp);
+		break;
+	case ADP1055_IIO_TEMP3_CHAN:
+		ret = adp1055_read_value(adp1055, ADP1055_VALUE_TEMP3, &mant, &exp);
+		break;
+	case ADP1055_IIO_IOUT_CHAN:
+		ret = adp1055_read_value(adp1055, ADP1055_VALUE_IOUT, &mant, &exp);
+		break;
+	case ADP1055_IIO_VOUT_CHAN:
+		ret = adp1055_read_vsense(adp1055, &mant);
+		if (ret)
+			return ret;
+		return iio_format_value(buf, len, IIO_VAL_INT, 1, (int32_t *)&mant);
+	default:
+		return -EINVAL;
+	}
+
+	if (ret)
+		return ret;
+
+	val = no_os_field_get(ADP1055_EXP_MASK, exp) |
+	      no_os_field_get(ADP1055_MANT_MASK, mant);
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, (int32_t *)&val);
+}
+
+/**
+ * @brief Handles the read request for scale attribute
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int adp1055_iio_read_scale(void *dev, char *buf, uint32_t len,
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
+{
+	int vals[2], ret;
+	uint16_t mant, exp;
+	struct adp1055_iio_desc *iio_adp1055 = dev;
+	struct adp1055_desc *adp1055 = iio_adp1055->adp1055_desc;
+
+	switch (channel->address) {
+	case ADP1055_IIO_VIN_CHAN:
+		ret = adp1055_read_value(adp1055, ADP1055_VALUE_VIN, &mant, (uint8_t *)&exp);
+		break;
+	case ADP1055_IIO_IIN_CHAN:
+		ret = adp1055_read_value(adp1055, ADP1055_VALUE_IIN, &mant, (uint8_t *)&exp);
+		break;
+	case ADP1055_IIO_TEMP2_CHAN:
+		ret = adp1055_read_value(adp1055, ADP1055_VALUE_TEMP2, &mant, (uint8_t *)&exp);
+		break;
+	case ADP1055_IIO_TEMP3_CHAN:
+		ret = adp1055_read_value(adp1055, ADP1055_VALUE_TEMP3, &mant, (uint8_t *)&exp);
+		break;
+	case ADP1055_IIO_VOUT_CHAN:
+		ret = adp1055_read_vsense(adp1055, &mant);
+
+		vals[0] = mant;
+		vals[1] = 10;
+
+		return iio_format_value(buf, len, IIO_VAL_FRACTIONAL_LOG2, 2,
+					(int32_t *)vals);
+	}
+	if (ret)
+		return ret;
+
+	vals[0] = no_os_sign_extend16(mant, 10);
+	vals[1] = no_os_sign_extend16(exp, 4) * (-1);
+
+	return iio_format_value(buf, len, IIO_VAL_FRACTIONAL_LOG2, 2, (int32_t *)vals);
+}
+
+/**
+ * @brief Handles the read request for status debug attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ */
+static int adp1055_iio_read_status(void *dev, char *buf, uint32_t len,
+				   const struct iio_ch_info *channel,
+				   intptr_t priv)
+{
+	int ret;
+	uint16_t status;
+	struct  adp1055_iio_desc *iio_adp1055 = dev;
+	struct adp1055_desc *adp1055 = iio_adp1055->adp1055_desc;
+
+	ret = adp1055_read_status(adp1055, priv, &status);
+	if (ret)
+		return ret;
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, (int32_t *)&status);
+
+}
+
+/**
+ * @brief handles the read request for vout global attributes
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int adp1055_iio_read_vout(void *dev, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel,
+				 intptr_t priv)
+{
+	int ret;
+	uint16_t val;
+	uint8_t data[2];
+	struct adp1055_iio_desc *iio_adp1055 = dev;
+	struct adp1055_desc *adp1055 = iio_adp1055->adp1055_desc;
+
+	if (!dev)
+		return -EINVAL;
+
+	iio_adp1055 = dev;
+
+	if (!iio_adp1055->adp1055_desc)
+		return -EINVAL;
+
+	ret = adp1055_read(adp1055, priv, data, 2);
+	if (ret)
+		return ret;
+
+	val = no_os_get_unaligned_le16(data);
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, (int32_t *)&val);
+}
+
+/**
+ * @brief Handles the write request for vout global attributes.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int adp1055_iio_write_vout(void *dev, char *buf, uint32_t len,
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
+{
+	uint16_t val;
+	struct adp1055_iio_desc *iio_adp1055 = dev;
+	struct adp1055_desc *adp1055 = iio_adp1055->adp1055_desc;
+
+	iio_parse_value(buf, IIO_VAL_INT, (int32_t *)&val, NULL);
+
+	switch (priv) {
+	case ADP1055_IIO_VOUT_COMMAND_VALUE:
+		return adp1055_vout_value(adp1055, val, val + 1);
+	case ADP1055_IIO_VOUT_OFFSET_VALUE:
+		return adp1055_vout_offset(adp1055, val);
+	case ADP1055_IIO_VOUT_SCALE_MONITOR_VALUE:
+		return adp1055_vout_scale(adp1055, no_os_field_get(ADP1055_EXP_MASK, val),
+					  no_os_field_get(ADP1055_MANT_MASK, val));
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Handles the read request for freq attribute
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int adp1055_iio_read_freq(void *dev, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel,
+				 intptr_t priv)
+{
+	int ret;
+	uint16_t val;
+	uint8_t data[2];
+	struct adp1055_iio_desc *iio_adp1055 = dev;
+	struct adp1055_desc *adp1055 = iio_adp1055->adp1055_desc;
+
+	if (!dev)
+		return -EINVAL;
+
+	iio_adp1055 = dev;
+
+	if (!iio_adp1055->adp1055_desc)
+		return -EINVAL;
+
+	ret = adp1055_read(adp1055, priv, data, 2);
+	if (ret)
+		return ret;
+
+	val = no_os_get_unaligned_le16(data);
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, (int32_t *)&val);
+}
+
+/**
+ * @brief Handles the read request for freq_available attribute.
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int adp1055_iio_read_freq_available(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	int length = 0;
+	uint32_t i;
+
+	for (i = 0; i < NO_OS_ARRAY_SIZE(adp1055_freq_avail); i++)
+		length += sprintf(buf + length, "%s ", adp1055_freq_avail[i]);
+
+	return length;
+}
+
+/**
+ * @brief Handles the write request for freq attribute
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int adp1055_iio_write_freq(void *dev, char *buf, uint32_t len,
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
+{
+	struct adp1055_iio_desc *iio_adp1055 = dev;
+	struct adp1055_desc *adp1055 = iio_adp1055->adp1055_desc;
+	int16_t mant, exp;
+	uint32_t i;
+
+	for (i = 0; i < NO_OS_ARRAY_SIZE(adp1055_freq_avail); i++)
+		if (!strcmp(buf, adp1055_freq_avail[i]))
+			break;
+
+	if (i == NO_OS_ARRAY_SIZE(adp1055_freq_avail))
+		return -EINVAL;
+
+	exp = ADP1055_IIO_FREQ_MANT(adp1055_freq2_avail[i]);
+
+	mant = (int16_t)(adp1055_freq2_avail[i] / (1 << exp));
+
+	return adp1055_set_pwm(adp1055, ADP1055_IIO_OUTPUT_CHANNEL(channel->address),
+			       exp, mant);
+}
+
+/**
+ * @brief Handles the read request for enable attribute
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int adp1055_iio_read_enable(void *dev, char *buf, uint32_t len,
+				   const struct iio_ch_info *channel,
+				   intptr_t priv)
+{
+	struct adp1055_iio_desc *iio_adp1055 = dev;
+	struct adp1055_desc *adp1055 = iio_adp1055->adp1055_desc;
+	int ret;
+	uint8_t val;
+
+	ret = adp1055_read(adp1055, ADP1055_PWM_DISABLE_SETTING, &val, 1);
+	if (ret)
+		return ret;
+
+	val = no_os_field_prep(ADP1055_IIO_OUT_MASK,
+			       no_os_field_get(ADP1055_IIO_OUTPUT_OUTCHAN_MASK, val) |
+			       no_os_field_get(ADP1055_IIO_OUTPUT_SRCHAN_MASK, val));
+
+	if (no_os_field_get(ADP1055_IIO_ENABLE_MASK(ADP1055_IIO_OUTPUT_CHANNEL(
+				    channel->address)), val))
+		return sprintf(buf, "%s ", adp1055_enable_avail[1]);
+
+	return sprintf(buf, "%s ", adp1055_enable_avail[0]);
+}
+
+/**
+ * @brief Handles the write request for enable attribute
+ * @param dev     - The iio device structure.
+ * @param buf	  - Command buffer to be filled with requested data.
+ * @param len     - Length of the received command buffer in bytes.
+ * @param channel - Command channel info.
+ * @param priv    - Command attribute id.
+ * @return ret    - Result of the reading procedure.
+ * 		    In case of success, the size of the read data is returned.
+*/
+static int adp1055_iio_write_enable(void *dev, char *buf, uint32_t len,
+				    const struct iio_ch_info *channel,
+				    intptr_t priv)
+{
+	struct adp1055_iio_desc *iio_adp1055 = dev;
+	struct adp1055_desc *adp1055 = iio_adp1055->adp1055_desc;
+	uint32_t i;
+
+
+	for (i = 0; i < NO_OS_ARRAY_SIZE(adp1055_enable_avail); i++)
+		if (!strcmp(buf, adp1055_enable_avail[i]))
+			break;
+
+	if (i == NO_OS_ARRAY_SIZE(adp1055_enable_avail))
+		return -EINVAL;
+
+	return adp1055_set_pwm(adp1055,
+			       i ? ADP1055_IIO_OUTPUT_CHANNEL(channel->address) : ADP1055_DISABLE_ALL,
+			       adp1055->freq_exp, adp1055->freq_mant);
+}
+
+/**
+ * @brief Initializes the ADP1050 IIO descriptor.
+ * @param iio_desc - The iio device descriptor.
+ * @param init_param - The structure that contains the device initial parameters.
+ * @return 0 in case of success, an error code otherwise.
+ */
+int adp1055_iio_init(struct adp1055_iio_desc **iio_desc,
+		     struct adp1055_iio_desc_init_param *init_param)
+{
+	struct adp1055_iio_desc *descriptor;
+	int ret;
+
+	if (!init_param || !init_param->adp1055_init_param)
+		return -EINVAL;
+
+	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	ret = adp1055_init(&descriptor->adp1055_desc,
+			   init_param->adp1055_init_param);
+	if (ret)
+		goto free_desc;
+
+	ret = adp1055_vout_scale(descriptor->adp1055_desc,
+				 no_os_field_get(ADP1055_EXP_MASK, init_param->vout_scale_monitor),
+				 no_os_field_get(ADP1055_MANT_MASK, init_param->vout_scale_monitor));
+	if (ret)
+		goto free_desc;
+
+	ret = adp1055_write(descriptor->adp1055_desc, ADP1055_VIN_SCALE_MONITOR,
+			    init_param->vin_scale_monitor, 2);
+	if (ret)
+		goto free_desc;
+
+	ret = adp1055_write(descriptor->adp1055_desc, ADP1055_IIN_SCALE_MONITOR,
+			    init_param->iin_scale_monitor, 2);
+	if (ret)
+		goto free_desc;
+
+	descriptor->iio_dev = &adp1055_iio_dev;
+
+	*iio_desc = descriptor;
+
+	return 0;
+
+free_desc:
+	adp1055_iio_remove(descriptor);
+
+	return ret;
+}
+
+/**
+ * @brief Free resources allocated by the init function.
+ * @param iio_desc - The iio device descriptor.
+ * @return 0 in case of success, an error code otherwise.
+ */
+int adp1055_iio_remove(struct adp1055_iio_desc *iio_desc)
+{
+	if (!iio_desc)
+		return -ENODEV;
+
+	adp1055_remove(iio_desc->adp1055_desc);
+	no_os_free(iio_desc);
+
+	return 0;
+}

--- a/drivers/power/adp1055/iio_adp1055.h
+++ b/drivers/power/adp1055/iio_adp1055.h
@@ -1,0 +1,65 @@
+/***************************************************************************//**
+ *   @file   iio_adp1055.h
+ *   @brief  Header file for the ADP1055 IIO Driver
+ *   @author Ivan Gil Mercano (IvanGil.Mercano@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef IIO_ADP1055_H
+#define IIO_ADP1055_H
+
+#include <stdbool.h>
+#include "iio.h"
+#include "adp1055.h"
+
+/**
+ * @brief Structure holding the adp1055 IIO device descriptor
+*/
+struct adp1055_iio_desc {
+	struct adp1055_desc *adp1055_desc;
+	struct iio_device *iio_dev;
+};
+
+/**
+ * @brief Structure holding the adp1055 IIO initalization parameter.
+*/
+struct adp1055_iio_desc_init_param {
+	struct adp1055_init_param *adp1055_init_param;
+	uint16_t vout_scale_monitor;
+	uint16_t vin_scale_monitor;
+	uint16_t iin_scale_monitor;
+};
+
+/** Initializes the adp1055 IIO descriptor. */
+int adp1055_iio_init(struct adp1055_iio_desc **,
+		     struct adp1055_iio_desc_init_param *);
+
+/** Free resources allocated by the initialization function. */
+int adp1055_iio_remove(struct adp1055_iio_desc *);
+
+#endif /* IIO_adp1055_H */

--- a/projects/adp1055/Makefile
+++ b/projects/adp1055/Makefile
@@ -1,0 +1,10 @@
+# Select the example you want to enable by choosing y for enabling and n for disabling
+EXAMPLE ?= iio_example
+
+include ../../tools/scripts/generic_variables.mk
+
+include ../../tools/scripts/examples.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/adp1055/README.rst
+++ b/projects/adp1055/README.rst
@@ -1,0 +1,247 @@
+ADP1055 no-OS Example Project
+=============================
+
+.. contents::
+	:depth: 3
+
+Supported Evaluation Boards
+---------------------------
+
+* `ADP1055DC1-EVALZ <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-adp1055.html#eb-documentation>`_
+
+Overview
+--------
+
+The evaluation board allows the ADP1055 to be exercised without the need for
+external components. The board is set up to act as an isolated PSU,
+outputting a rated load of 12 V, 20 A from a 36 V dc to 75 V dc source.
+
+Full performance details are provided in the ADP1055 data sheet, which should
+be consulted in conjunction with user guide.
+
+Hadrware Specifications
+-----------------------
+
+Power Supply Requirments
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+For this specific project an external power supply is used to provide a 20.1V
+and 12V voltages for the ADP1055DC1-EVALZ daughter board to simulate a parallel
+circuit to the ADP1055 as well as a +5V Power Supply for the PMBUS/I2C
+interface.
+
+**Pin Description**
+
+	Please see the following table for the pin assignments for the interface
+	connectors (J1 and J2).
+
+	J1:
+
+	+-----+----------+-------------------------------------------+
+	| Pin |   Name 	 | Description				     |
+	+-----+----------+-------------------------------------------+
+	| 1   | 10V_VCC  | Do Not Connect			     |
+	+-----+----------+-------------------------------------------+
+	| 2   | VS+      | Power Supply, +12V DC 		     |
+	+-----+----------+-------------------------------------------+
+	| 3   | VS-      | Connect to Ground		     	     |
+	+-----+----------+-------------------------------------------+
+	| 4   | CS2+     | Do Not Connect			     |
+	+-----+----------+-------------------------------------------+
+	| 5   | CS2-	 | Do Not Connect			     |
+	+-----+----------+-------------------------------------------+
+    	| 6   | NC  	 | Do Not Connect			     |
+	+-----+----------+-------------------------------------------+
+	| 7   | VFF	 | Power Supply, +20.1V DC		     |
+	+-----+----------+-------------------------------------------+
+	| 8   | CS1	 | Connect to Ground			     |
+	+-----+----------+-------------------------------------------+
+	| 9   | SR1	 | Connect to Oscilloscope (Scopy)	     |
+	+-----+----------+-------------------------------------------+
+	| 10  | SR2	 | Connect to Oscilloscope (Scopy)	     |
+	+-----+----------+-------------------------------------------+
+	| 11  | OUTA     | Connect to Oscilloscope (Scopy)	     |
+	+-----+----------+-------------------------------------------+
+	| 12  | OUTB	 | Connect to Oscilloscope (Scopy)	     |
+	+-----+----------+-------------------------------------------+
+	| 13  | OUTC     | Do Not Connect			     |
+	+-----+----------+-------------------------------------------+
+	| 14  | OUTD	 | Do Not Connect			     |
+	+-----+----------+-------------------------------------------+
+        | 15  | SYNC	 | Do Not Connect	             	     |
+	+-----+----------+-------------------------------------------+
+	| 16  | GPIO4	 | Do Not Connect                            |
+	+-----+----------+-------------------------------------------+
+	| 17  | GPIO3	 |  Do Not Connect                           |
+	+-----+----------+-------------------------------------------+
+	| 18  | GPIO2	 | Do Not Connect			     |
+	+-----+----------+-------------------------------------------+
+	| 19  | GPIO1    | Power-Good Signal (GPIO)		     |
+	+-----+----------+-------------------------------------------+
+	| 20  | CTRL     | Do Not Connect			     |
+	+-----+----------+-------------------------------------------+
+	| 21  | SCL	 | I2C Serial Clock (Connect to J2 instead)  |
+	+-----+----------+-------------------------------------------+
+	| 22  | SDA      | I2C Serial Data (Connect to J2 instead)   |
+	+-----+----------+-------------------------------------------+
+	| 23  | ISHARE	 | Do Not Connect			     |
+	+-----+----------+-------------------------------------------+
+	| 24  | VCORE    | Do Not Connect			     |
+	+-----+----------+-------------------------------------------+
+	| 25  | VDD      | Do Not Connect			     |
+	+-----+----------+-------------------------------------------+
+	| 26  | OVP      | Do Not Connect			     |
+	+-----+----------+-------------------------------------------+
+	| 27  | DGND     | Do Not Connect			     |
+	+-----+----------+-------------------------------------------+
+	| 28  | AGND     |  Connect to Ground		     	     |
+	+-----+----------+-------------------------------------------+
+	| 29  | JRTN     | Do Not Connect			     |
+	+-----+----------+-------------------------------------------+
+	| 30  | RES      | Do Not Connect			     |
+	+-----+----------+-------------------------------------------+
+	| 31  | JTD      | Do Not Connect			     |
+	+-----+----------+-------------------------------------------+
+	| 32  | OVP      | Do Not Connect			     |
+	+-----+----------+-------------------------------------------+
+
+	J2:
+
+	+-----+----------+-------------------------------------------+
+	| Pin |   Name 	 | Description				     |
+	+-----+----------+-------------------------------------------+
+	| 1   | 10V_VDD  | Power Supply, +5V			     |
+	+-----+----------+-------------------------------------------+
+	| 2   | SCL      | I2C Serial Clock			     |
+	+-----+----------+-------------------------------------------+
+	| 3   | SDA      | I2C Serial Data			     |
+	+-----+----------+-------------------------------------------+
+	| 4   | GND      | Connect to Ground			     |
+	+-----+----------+-------------------------------------------+
+
+No-OS Build Setup
+-----------------
+
+Please see: https://wiki.analog.com/resources/no-os/build
+
+No-OS Supported Examples
+------------------------
+
+The initialization data used in the examples is taken out from:
+`Project Common Data Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/adp1055/src/common>`_
+
+The macros used in Common Data are defined in platform specific files found in:
+`Project Platform Configuration Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/adp1055/src/platform>`_
+
+Basic example
+^^^^^^^^^^^^^
+
+This is a simple example that initializes the ADP1055, unlock its CHIP, EEPROM
+and TRIM registers, sets the device in a closed loop state, and then : sets the
+VOUT transition rate, VOUT scale and value of the VOUT_COMMAND and VOUT_MAX.
+
+For the PWM it sets the duty cycle on the OUTA channel and then enables the OUTA
+channel with a 49KHz frequency, then the DUTY_CYCLE data is read as well as all
+the statuses.
+
+In order to build the basic example make sure you have the following configuration in the Makefile
+`Makefile <https://github.com/analogdevicesinc/no-OS/tree/main/projects/adp1055/Makefile>`_
+
+.. code-block:: bash
+
+	# Select the example you want to enable by choosing y for enabling and n for disabling
+	BASIC_EXAMPLE = y
+	IIO_EXAMPLE = n
+
+IIO example
+^^^^^^^^^^^
+
+This project is actually a IIOD demo for ADP1055DC1-EVALZ evaluation board.
+The project launches a IIOD server on the board so that the user may connect
+to it via an IIO client.
+Using IIO-Oscilloscope, the user can configure the IMU and view the measured data on a plot.
+
+If you are not familiar with ADI IIO Application, please take a look at:
+`IIO No-OS <https://wiki.analog.com/resources/tools-software/no-os-software/iio>`_
+
+If you are not familiar with ADI IIO-Oscilloscope Client, please take a look at:
+`IIO Oscilloscope <https://wiki.analog.com/resources/tools-software/linux-software/iio_oscilloscope>`_
+
+The No-OS IIO Application together with the No-OS IIO ADP1055 driver take care of
+all the back-end logic needed to setup the IIO server.
+
+This example initializes the IIO device and calls the IIO app as shown in:
+`IIO Example <https://github.com/analogdevicesinc/no-OS/tree/main/projects/adp1055/src/examples/iio_example>`_
+
+In order to build the IIO project make sure you have the following configuration in the
+`Makefile <https://github.com/analogdevicesinc/no-OS/tree/main/projects/adp1055/Makefile>`_
+
+.. code-block:: bash
+
+        # Select the example you want to enable by choosing y for enabling and n for disabling
+        BASIC_EXAMPLE = n
+        IIO__EXAMPLE = y
+
+No-OS Supported Platforms
+-------------------------
+
+Maxim Platform
+^^^^^^^^^^^^^^
+
+**Used hardware**
+
+* `ADP1055DC1-EVALZ daughter board <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-adp1055.html#eb-overview>`_
+* `AD-APARD32690-SL <https://www.analog.com/en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/ad-apard32690-sl.html>`_
+
+**Connections**:
+
+J1:
+
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| ADP1055DC1-EVALZ Pin Number |  Mnemonic  | Function					  | AD-APARD32690-SL Pin Number |
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 2			      | VS+	   | External Power Supply, 12VDC (5mA current)   | GND			        |
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 3			      | VS-	   |  Connect to Ground                           | Do Not Connect	        |
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 7			      | VF	   | External Power Supply, 20.1VDC (5mA current) | Do Not Connect		|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 8			      | CS1	   | Ground					  | GND				|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 9			      | SR1	   | SR1 channel output (May connect to Scopy)	  | Do Not Connect		|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 10			      | SR2	   | SR2 channel output (May connect to Scopy)	  | Do Not Connect		|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 11			      | OUTA	   | OUTA channel output (May connect to Scopy)	  | Do Not Connect		|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 12			      | OUTB	   | OUTB channel output (May connect to Scopy)	  | Do Not Connect		|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 19			      | PG/ALT#    | Power-Good Signal Logic OUTPUT		  | P0_24			|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 28			      | AGND	   | Ground					  | GND				|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+
+J2:
+
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| ADP1055DC1-EVALZ Pin Number |  Mnemonic  | Function					  | AD-APARD32690-SL Pin Number |
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 1			      | 10V_VDD	   | Power Supply, +5VDC			  | 5V0			        |
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 2			      | SCL	   | I2C Serial Clock				  | I2C0_SCL		        |
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 3			      | SDA	   | I2C Serial Data				  | I2C0_SDA			|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+| 4			      | GND	   | Ground					  | GND				|
++-----------------------------+------------+----------------------------------------------+-----------------------------+
+
+**Build Command**
+
+.. code-block:: bash
+
+	# to delete current build
+	make reset
+	# to build the project
+	make PLATFORM=maxim TARGET=max32690
+	# to flash the code
+	make run

--- a/projects/adp1055/builds.json
+++ b/projects/adp1055/builds.json
@@ -1,0 +1,10 @@
+{
+	"maxim": {
+		"basic_example_max32690": {
+			"flags" : "EXAMPLE=basic"
+		},
+		"iio_example_max32690": {
+			"flags" : "EXAMPLE=iio_example"
+		}
+	}
+}

--- a/projects/adp1055/src.mk
+++ b/projects/adp1055/src.mk
@@ -1,0 +1,31 @@
+INCS += $(INCLUDE)/no_os_delay.h     		\
+		$(INCLUDE)/no_os_error.h     	\
+		$(INCLUDE)/no_os_list.h     	\
+		$(INCLUDE)/no_os_gpio.h      	\
+		$(INCLUDE)/no_os_dma.h      	\
+		$(INCLUDE)/no_os_print_log.h 	\
+		$(INCLUDE)/no_os_i2c.h       	\
+		$(INCLUDE)/no_os_irq.h		\
+		$(INCLUDE)/no_os_pwm.h       	\
+		$(INCLUDE)/no_os_rtc.h       	\
+		$(INCLUDE)/no_os_uart.h      	\
+		$(INCLUDE)/no_os_lf256fifo.h 	\
+		$(INCLUDE)/no_os_util.h 	\
+		$(INCLUDE)/no_os_units.h        \
+		$(INCLUDE)/no_os_alloc.h        \
+                $(INCLUDE)/no_os_mutex.h	
+
+SRCS += $(NO-OS)/util/no_os_lf256fifo.c 	\
+		$(DRIVERS)/api/no_os_i2c.c  	\
+		$(DRIVERS)/api/no_os_dma.c  	\
+		$(DRIVERS)/api/no_os_uart.c  	\
+		$(DRIVERS)/api/no_os_irq.c  	\
+		$(DRIVERS)/api/no_os_gpio.c  	\
+		$(DRIVERS)/api/no_os_pwm.c	\
+		$(NO-OS)/util/no_os_util.c	\
+		$(NO-OS)/util/no_os_list.c      \
+		$(NO-OS)/util/no_os_alloc.c 	\
+		$(NO-OS)/util/no_os_mutex.c	
+
+INCS += $(DRIVERS)/power/adp1055/adp1055.h
+SRCS += $(DRIVERS)/power/adp1055/adp1055.c

--- a/projects/adp1055/src/common/common_data.c
+++ b/projects/adp1055/src/common/common_data.c
@@ -1,0 +1,67 @@
+/***************************************************************************//**
+ *   @file   common_data.c
+ *   @brief  Defines common data to be used by adp1055 examples.
+ *   @author Ivan Gil Mercano (ivangil.mercano@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "common_data.h"
+
+struct no_os_uart_init_param adp1055_uart_ip = {
+	.device_id = UART_DEVICE_ID,
+	.baud_rate = UART_BAUDRATE,
+	.size = NO_OS_UART_CS_8,
+	.parity = NO_OS_UART_PAR_NO,
+	.stop = NO_OS_UART_STOP_1_BIT,
+	.platform_ops = UART_OPS,
+	.extra = UART_EXTRA,
+};
+
+struct no_os_i2c_init_param adp1055_i2c_ip = {
+	.device_id = I2C_DEVICE_ID,
+	.max_speed_hz = 100000,
+	.platform_ops = I2C_OPS,
+	.slave_address = ADP1055_PMBUS_DEFAULT_ADDRESS,
+	.extra = I2C_EXTRA,
+};
+
+struct no_os_gpio_init_param adp1055_pg_alt_ip = {
+	.port = GPIO_PG_ALT_PORT,
+	.number = GPIO_PG_ALT_PIN,
+	.pull = NO_OS_PULL_NONE,
+	.platform_ops = GPIO_OPS,
+	.extra = GPIO_EXTRA,
+};
+
+struct adp1055_init_param adp1055_ip = {
+	.i2c_param = &adp1055_i2c_ip,
+	.pg_alt_param = &adp1055_pg_alt_ip,
+	.flgi_param = NULL,
+	.syni_param = NULL,
+	.on_off_config = ADP1055_ON_OFF_DEFAULT_CFG,
+};

--- a/projects/adp1055/src/common/common_data.h
+++ b/projects/adp1055/src/common/common_data.h
@@ -1,0 +1,49 @@
+/***************************************************************************//**
+ *   @file   common_data.h
+ *   @brief  Defines common data to be used by adp1055 examples.
+ *   @author Ivan Gil Mercano (ivangil.mercano@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __COMMON_DATA_H__
+#define __COMMON_DATA_H__
+
+#include "parameters.h"
+#include "no_os_i2c.h"
+#include "no_os_gpio.h"
+#include "no_os_pwm.h"
+#include "adp1055.h"
+
+#define ADP1055_PMBUS_DEFAULT_ADDRESS   0x4B
+
+extern struct no_os_uart_init_param adp1055_uart_ip;
+extern struct no_os_i2c_init_param adp1055_i2c_ip;
+extern struct no_os_gpio_init_param adp1055_pg_alt_ip;
+extern struct adp1055_init_param adp1055_ip;
+
+#endif /* __COMMON_DATA_H__ */

--- a/projects/adp1055/src/examples/basic/basic_example.c
+++ b/projects/adp1055/src/examples/basic/basic_example.c
@@ -1,0 +1,127 @@
+/***************************************************************************//**
+ *   @file   basic_example.c
+ *   @brief  Basic example source file for adp1055 project.
+ *   @author Ivan Gil Mercano (Ivangil.mercano@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "common_data.h"
+#include "no_os_delay.h"
+#include "no_os_i2c.h"
+#include "no_os_print_log.h"
+#include "no_os_util.h"
+#include "no_os_pwm.h"
+#include "adp1055.h"
+
+int example_main()
+{
+	int ret;
+
+	struct adp1055_desc *adp1055_desc;
+	uint8_t data = 120;
+	uint8_t data2[2];
+	uint16_t vout;
+	int16_t val;
+
+	pr_info("INIT: ");
+	ret = adp1055_init(&adp1055_desc, &adp1055_ip);
+	if (ret)
+		pr_info("Fail \n");
+	else
+		pr_info("Pass \n");
+
+	pr_info("VOUT SCALE: ");
+	ret = adp1055_vout_scale(adp1055_desc, -12, 341);
+	if (ret)
+		pr_info("Fail \n");
+	else
+		pr_info("Pass \n");
+
+	pr_info("VOUT VALUE: ");
+	ret = adp1055_vout_value(adp1055_desc, 0x3000, 0x5000);
+	if (ret)
+		pr_info("Fail \n");
+	else
+		pr_info("Pass \n");
+
+	pr_info("PWM CONFIG: ");
+	ret = adp1055_pwm_config(adp1055_desc, 0x00DE, 0x000E, 0, 0, ADP1055_OUTA);
+	if (ret)
+		pr_info("Fail \n");
+	else
+		pr_info("Pass \n");
+
+	pr_info("SET PWM: ");
+	ret = adp1055_set_pwm(adp1055_desc, ADP1055_OUTA, -4, 782);
+	if (ret)
+		pr_info("Fail \n");
+	else
+		pr_info("Pass \n");
+
+	pr_info("READ VALUE: ");
+	ret = adp1055_read_value(adp1055_desc, ADP1055_VALUE_DUTY_CYCLE, &vout, &data);
+	if (ret)
+		pr_info("Fail \n");
+	else
+		pr_info("Pass \n");
+
+	/* Checking statuses. */
+	pr_info("READ STAT VOUT: ");
+	ret = adp1055_read(adp1055_desc, ADP1055_STATUS_VOUT, &data, 1);
+	if (ret)
+		pr_info("Fail \n");
+	else
+		pr_info("Pass \n");
+
+	pr_info("READ STAT INPUT: ");
+	ret = adp1055_read(adp1055_desc, ADP1055_STATUS_INPUT, &data, 1);
+	if (ret)
+		pr_info("Fail \n");
+	else
+		pr_info("Pass \n");
+
+	pr_info("READ STAT CML: ");
+	ret = adp1055_read(adp1055_desc, ADP1055_STATUS_CML, &data, 1);
+	if (ret)
+		pr_info("Fail \n");
+	else
+		pr_info("Pass \n");
+
+	pr_info("READ STAT WORD: ");
+	ret = adp1055_read(adp1055_desc, ADP1055_STATUS_WORD, data2, 2);
+	if (ret)
+		pr_info("Fail \n");
+	else
+		pr_info("Pass \n");
+
+exit:
+	if (ret)
+		pr_info("Error!\n");
+	adp1055_remove(adp1055_desc);
+	return ret;
+}

--- a/projects/adp1055/src/examples/iio_example/example.mk
+++ b/projects/adp1055/src/examples/iio_example/example.mk
@@ -1,0 +1,3 @@
+IIOD=y
+INCS += $(DRIVERS)/power/adp1055/iio_adp1055.h
+SRCS += $(DRIVERS)/power/adp1055/iio_adp1055.c

--- a/projects/adp1055/src/examples/iio_example/iio_example.c
+++ b/projects/adp1055/src/examples/iio_example/iio_example.c
@@ -1,0 +1,83 @@
+/***************************************************************************//**
+ *   @file   iio_example.c
+ *   @brief  IIO example source file for adp1055 project.
+ *   @author Ivan Gil Mercano (Ivangil.mercano@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "iio_adp1055.h"
+#include "common_data.h"
+#include "no_os_print_log.h"
+#include "iio_app.h"
+
+int example_main()
+{
+	int ret;
+
+	struct adp1055_iio_desc *adp1055_iio_desc;
+	struct adp1055_iio_desc_init_param adp1055_iio_ip = {
+		.adp1055_init_param = &adp1055_ip,
+		.vout_scale_monitor = 0xA155,
+		.vin_scale_monitor = 0xB033,
+		.iin_scale_monitor = 0x01,
+	};
+
+	struct iio_app_desc *app;
+	struct iio_app_init_param app_init_param = { 0 };
+
+	ret = adp1055_iio_init(&adp1055_iio_desc, &adp1055_iio_ip);
+	if (ret)
+		goto exit;
+
+	struct iio_app_device iio_devices[] = {
+		{
+			.name = "adp1055",
+			.dev = adp1055_iio_desc,
+			.dev_descriptor = adp1055_iio_desc->iio_dev,
+		}
+	};
+
+	app_init_param.devices = iio_devices;
+	app_init_param.nb_devices = NO_OS_ARRAY_SIZE(iio_devices);
+	app_init_param.uart_init_params = adp1055_uart_ip;
+
+	ret = iio_app_init(&app, app_init_param);
+	if (ret)
+		goto remove_iio_adp1055;
+
+	ret = iio_app_run(app);
+
+	iio_app_remove(app);
+
+remove_iio_adp1055:
+	adp1055_iio_remove(adp1055_iio_desc);
+exit:
+	if (ret)
+		pr_info("Error!\n");
+	return ret;
+}

--- a/projects/adp1055/src/platform/maxim/main.c
+++ b/projects/adp1055/src/platform/maxim/main.c
@@ -1,0 +1,57 @@
+/***************************************************************************//**
+ *   @file   main.c
+ *   @brief  Main file for Maxim platform of adp1055 project.
+ *   @author Ivan Gil Mercano (ivangil.mercano@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "parameters.h"
+#include "common_data.h"
+#include "no_os_error.h"
+
+extern int example_main();
+
+int main()
+{
+	int ret = -EINVAL;
+
+	struct no_os_uart_desc *uart_desc;
+
+	/** Initialize UART interface */
+	ret = no_os_uart_init(&uart_desc, &adp1055_uart_ip);
+	if (ret)
+		return ret;
+
+	no_os_uart_stdio(uart_desc);
+
+	ret = example_main();
+	if (ret)
+		return ret;
+
+	return ret;
+}

--- a/projects/adp1055/src/platform/maxim/parameters.c
+++ b/projects/adp1055/src/platform/maxim/parameters.c
@@ -1,0 +1,45 @@
+/***************************************************************************//**
+ *   @file   parameters.c
+ *   @brief  Definition of Maxim platform data used by adp1055 project.
+ *   @author Ivan Gil Mercano (ivangil.mercano@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "parameters.h"
+
+struct max_uart_init_param adp1055_uart_extra = {
+	.flow = UART_FLOW_DIS,
+};
+
+struct max_i2c_init_param adp1055_i2c_extra = {
+	.vssel = MXC_GPIO_VSSEL_VDDIOH
+};
+
+struct max_gpio_init_param adp1055_pg_alt_extra = {
+	.vssel = MXC_GPIO_VSSEL_VDDIOH
+};

--- a/projects/adp1055/src/platform/maxim/parameters.h
+++ b/projects/adp1055/src/platform/maxim/parameters.h
@@ -1,0 +1,64 @@
+/***************************************************************************//**
+ *   @file   parameters.h
+ *   @brief  Definition of Maxim platform data used by adp1055 project.
+ *   @author Ivan Gil Mercano (ivangil.mercano@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
+
+#include "maxim_irq.h"
+#include "maxim_i2c.h"
+#include "maxim_gpio.h"
+#include "maxim_uart.h"
+#include "maxim_uart_stdio.h"
+
+#ifdef IIO_SUPPORT
+#define INTC_DEVICE_ID		0
+#endif
+
+#define UART_DEVICE_ID		2
+#define UART_BAUDRATE		57600
+#define	UART_OPS		&max_uart_ops
+#define UART_EXTRA		&adp1055_uart_extra
+
+#define GPIO_PG_ALT_PORT	0
+#define GPIO_PG_ALT_PIN		9
+#define GPIO_OPS		&max_gpio_ops
+#define GPIO_EXTRA		&adp1055_pg_alt_extra
+
+#define I2C_DEVICE_ID		0
+#define I2C_OPS			&max_i2c_ops
+#define I2C_EXTRA		&adp1055_i2c_extra
+
+extern struct max_uart_init_param adp1055_uart_extra;
+extern struct max_i2c_init_param adp1055_i2c_extra;
+extern struct max_gpio_init_param adp1055_pg_alt_extra;
+
+#endif /* __PARAMETERS_H__ */

--- a/projects/adp1055/src/platform/maxim/platform_src.mk
+++ b/projects/adp1055/src/platform/maxim/platform_src.mk
@@ -1,0 +1,16 @@
+INCS += $(PLATFORM_DRIVERS)/maxim_gpio.h      \
+        $(PLATFORM_DRIVERS)/maxim_gpio_irq.h  \
+        $(PLATFORM_DRIVERS)/maxim_irq.h       \
+        $(PLATFORM_DRIVERS)/../common/maxim_dma.h       \
+        $(PLATFORM_DRIVERS)/maxim_i2c.h       \
+        $(PLATFORM_DRIVERS)/maxim_uart.h      \
+        $(PLATFORM_DRIVERS)/maxim_uart_stdio.h
+
+SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c     \
+        $(PLATFORM_DRIVERS)/maxim_gpio.c      \
+        $(PLATFORM_DRIVERS)/maxim_gpio_irq.c  \
+        $(PLATFORM_DRIVERS)/maxim_irq.c       \
+        $(PLATFORM_DRIVERS)/../common/maxim_dma.c       \
+        $(PLATFORM_DRIVERS)/maxim_i2c.c       \
+        $(PLATFORM_DRIVERS)/maxim_uart.c      \
+        $(PLATFORM_DRIVERS)/maxim_uart_stdio.c


### PR DESCRIPTION
## Pull Request Description

The ADP1055 is a flexible, feature-rich digital secondary side controller that targets ac-to-dc and isolated dc-to-dc secondary side applications. The ADP1055 is optimized for minimal component count, maximum flexibility, and minimum design time. Features include differential remote voltage sense, primary and secondary side current sense, pulse-width modulation (PWM) generation, frequency synchronization, redundant OVP, and current sharing.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
