### PR TITLE
Use no-OS memory allocation functions for memory management

### DIFF
--- a/drivers/net/adin1110/adin1110.c
+++ b/drivers/net/adin1110/adin1110.c
@@ -854,7 +854,7 @@ int adin1110_init(struct adin1110_desc **desc,
 	if (!param->mac_address)
 		return -EINVAL;
 
-	descriptor = calloc(1, sizeof(*descriptor));
+	descriptor = no_os_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -923,7 +923,7 @@ free_spi:
 free_rst_gpio:
 	no_os_gpio_remove(descriptor->reset_gpio);
 free_desc:
-	free(descriptor);
+	no_os_free(descriptor);
 
 	return ret;
 }
@@ -950,7 +950,7 @@ int adin1110_remove(struct adin1110_desc *desc)
 			return ret;
 	}
 
-	free(desc);
+	no_os_free(desc);
 
 	return 0;
 }


### PR DESCRIPTION
## Pull Request Description

no-OS has functions for handling memory allocation, so the adin1110 driver should use these functions for managing memory. 

## PR Type
- [  ] Bug fix (change that fixes an issue)
- [ x ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

