### PR TITLE
tools:scripts:Set the SPI driver version for Maxim

### DIFF
--- a/tools/scripts/maxim.mk
+++ b/tools/scripts/maxim.mk
@@ -43,6 +43,9 @@ TARGET_HARDWARE=TARGET=$(TARGET)
 
 PLATFORM_DRIVERS := $(NO-OS)/drivers/platform/maxim/$(TARGET_LCASE)
 
+# Choose between the v1 and v2 version of the SPI driver for MAX32690 and MAX78002
+MXC_SPI_VERSION ?= v1
+
 ifeq ($(TARGET_LCASE), $(filter $(TARGET_LCASE),max32655 max32690))
 include $(MAXIM_LIBRARIES)/CMSIS/Device/Maxim/$(TARGET_UCASE)/Source/GCC/$(TARGET_LCASE)_memory.mk
 endif


### PR DESCRIPTION
Since commit [1], the user may choose between two versions of the SPI driver for the MAX32690 and MAX78002. Currently, we're not defining this anywhere during the build and as such we get a linker error. Fix this by selecting v1 as a default value. At this time, the No-OS SPI drivers for the Maxim platform are based on the v1 version.

The issue first appeared in the v2024_10 release of msdk.

[1] - https://github.com/analogdevicesinc/msdk/commit/755e6ffa0d4627880fcd053435df295e780a742a

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
