### PR TITLE
power: max17851 : Add MAX17851 support

### DIFF
--- a/doc/sphinx/source/drivers/max17851.rst
+++ b/doc/sphinx/source/drivers/max17851.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../drivers/power/max17851/README.rst

--- a/doc/sphinx/source/drivers_doc.rst
+++ b/doc/sphinx/source/drivers_doc.rst
@@ -107,6 +107,7 @@ POWER MANAGEMENT
    drivers/lt8491
    drivers/lt8722
    drivers/ltp8800
+   drivers/max17851
    drivers/max42500
 
 POTENTIOMETER

--- a/drivers/power/max17851/README.rst
+++ b/drivers/power/max17851/README.rst
@@ -1,0 +1,232 @@
+MAX17851 no-OS driver
+=====================
+
+Supported Devices
+-----------------
+
+`MAX17851 <https://www.analog.com/MAX17851>`_
+
+Overview
+--------
+
+The MAX17851 SPI to UART safety monitoring bridge translates communication from
+SPI format to universal asynchronous receiver transmitter (UART) format
+specially designed to interface with Maxim's Battery Management Data
+Acquisition System.
+
+The safety monitoring bridge enables robust communication with baud rates
+extending up to 4Mbps in both single and dual daisy-chain system architectures.
+High throughput, dual UART systems can read 96 cells of battery voltages within
+1173us.
+
+THIS Uart Device is meant to be used alongside devices using Maxim's Battery
+Management System UART Protocol!
+
+Applications
+------------
+* Battery Management Systems (BMS)
+* Electric and Hybrid Electric Vehicles (EV/HEV)
+* Energy Storage Systems (ESS)
+
+Maxim Battery Management System UART Protocol
+---------------------------------------------
+A message is defined as a sequence of UART characters.
+The message starts with a preamble character, followed by
+data characters, and ending with a stop character.
+
+Each character consists of the following 12 bits:
+* One START bit
+* Eight data bits (LSB first)
+* One parity bit (even)
+* Two STOP bits
+
+More than this, every data byte is transmitted and received as two separate
+characters (separated from one byte to two bytes), since every nibble is
+Manchester Encoded. Therefore each  nibble becomes a byte (the bit number
+doubles), so a data byte splits into two characters.
+
+Driver Initialization
+---------------------
+
+In order to be able to use the device, you will have to provide the support for
+the communication protocol (SPI).
+
+The first API to be called is **max17851_init**. Make sure that it returns 0,
+which means that the driver was initialized correctly.
+
+Usually, this function is to be called from **no_os_uart_init** function, since
+max17851 can also be seen as a UART peripheral inside no-OS infrastructure.
+
+For more details regarding UART API, please see
+`No-OS UART API <https://wiki.analog.com/resources/no-os/drivers/uart>`_.
+
+General Configuration
+---------------------
+Baud Rate, Single/Dual UART and Operation Mode are properties that should be set
+at the initialization of the device, therefore they are found in the
+**max17851_init** function, although other configurations can be found there
+such as the :
+* Alert Debounce (**max17851_set_alert_debounce**).
+* GPIO Recovery Delay (**max17851_reg_write** to CONFIG_SAFEMON0 Register).
+* Contact Timer Delay (**max17851_reg_write** to CONFIG_SAFEMON1 Register).
+* Communication Timeout Retry Count (**max17851_set_comm**).
+* Safemon Delay (**max17851_set_safemon_dly**).
+
+But more than this, the MAX17851 no-OS driver also provides access to UART
+related general configuration, that can be performed at run-time, such as :
+* MAX17851_TX_NOPREAMBLE_SEL - Transmits Message with no Preamble Byte.
+* MAX17851_TX_NOSTOP_SEL - Disables Stop Character from UART TX packages.
+* MAX17851_TX_PAUSE_SEL - Puts TX in idle state.
+* MAX17851_TX_ODDPARITY_SEL - Selects ODD parity for UART bits instead of EVEN.
+* MAX17851_TX_QUEUE_SEL - Enables transmission of the message from the queue.
+* MAX17851_TX_PREAMBLES_SEL - Transmits preambles continuously.
+* MAX17851_TX_RAW_DATA_SEL - Disables Manchester encoding from transmitted data.
+* MAX17851_RX_RAW_DATA_SEL - Disables Manchester encoding from received data.
+
+Alert Packet Configuration
+--------------------------
+
+MAX17851 also comes with the Alert Packet feature, therefore ALERT pins can
+be initialized from the Slave BMS chip used alongside MAX17851 and receive
+an alert packet. MAX17851 gives the chance to monitor the specific alerts
+or enable/disable them, so an interrupt inside the MCU host unit can be
+performed in case of failures.
+
+**max17851_set_alrtpckt_time** Sets the time for generating Alert Packets or
+sending keep-alive (stop) characters throughout UART.
+
+**max17851_set_alert** and **max17851_get_alert** enable/disable specific
+alerts, respectively checks if a specific alert is triggered.
+
+Read/Writing Messages Configuration
+-----------------------------------
+
+In order to send/receive UART messages using the MAX17851, a specific routine
+has to be performed for each operation.
+
+Transmitting Messages:
+----------------------
+
+For transmitting messages there are 4 queues, each one of them consisting of 32
+bytes, first byte being the length of the message, rest of them being the
+data bytes need to be sent over UART (can or cannot be encoded, default
+settings require them not to be encoded, since the IC is taking care of
+the Mancheste Encoding).
+
+Therefore the user can select wich queue is to be loaded (written to inside
+the IC memory) and which one to be sent over UART using the
+**max17851_select_queue**, each one being able to be seleted as the
+transmitt/load queue in case of manual message sending.
+
+**max17851_write_msg** handles the whole transmitting of the message, using the
+first queue, therefore in this case the message can not be grater than 31 bytes.
+
+Receving Messages:
+------------------
+**max17851_read_msg** is the API to be used in order to read the received
+buffer over UART.
+
+For both transmitting and receiving messages, the read/write message API's
+handle the buffer clearance after the buffers are properly written/read.
+
+Register Access
+---------------
+
+In case the user wants to use even more specific functionalities of the
+MAX17851 such as using the Continuously Preambles mode, or no STOP
+characters mode, etc. in order for a Hardware-In-The-Loop test or such,
+register access is provided as well as the whole register map being defined
+in the header file.
+
+**max17851_reg_write** - Is to be used for register writing.
+**max17851_reg_read** - Is to be used for register reading.
+
+No-OS platform operations
+-------------------------
+
+Since the MAX17851 is to be used as a UART peripheral in order to communicate
+with other BMS chips, it can be used as such inside the No-OS infrastructure
+and having specific platform ops, therefore a no-OS uart descriptor can be
+used and parsed for initialization in other BMS device drivers.
+
+**max17851_uart_init** - Initializes the UART descriptor.
+**max17851_uart_read** - Reads data over the UART.
+**max17851_uart_write** - Writes data over the UART.
+**max17851_uart_get_errors** - Gets errors from the Alert Loop.
+**max17851_uart_remove** - Removes the UART descriptor.
+
+MAX17851 Driver Initialization Example
+--------------------------------------
+
+.. code-block:: bash
+
+	struct max17851_desc *max17851_desc;
+	struct no_os_spi_init_param max17851_spi_ip = {
+		.device_id = 4,
+		.extra = &max17851_spi_extra,
+		.mode = NO_OS_SPI_MODE_0,
+		.max_speed_hz = 100000,
+		.platform_ops = &max_spi_ops,
+		.chip_select = 0,
+	};
+	struct max17851_init_param max17851_ip = {
+		.spi_param = &max17851_spi_ip,
+		.gpio1_param = NULL,
+		.gpio2_param = NULL,
+		.op_mode = MAX17851_MASTER_DUAL_UART,
+		.baud_rate = MAX17851_UART_BAUD_500K,
+		.no_dev = 1,
+		.single = false,
+		.contact_tmr_dly_4xmin = MAX17851_CONTACT_TIMER_DELAY_INFINITE,
+		.gpio_rec_dly_csec = MAX17851_GPIO_RECOVERY_DELAY_DISABLED,
+		.safemon_dly = MAX17851_SAFEMON_DLY_500MS,
+	};
+
+	ret = max17851_init(&max17851_desc, &max17851_ip);
+	if (ret)
+		return ret;
+
+MAX17851 UART Descriptor Initialization Example
+-----------------------------------------------
+
+.. code-block:: bash
+
+	struct no_os_uart_desc *uart_desc;
+	struct max_spi_init_param max17851_spi_extra = {
+		.num_slaves = 1,
+		.polarity = SPI_SS_POL_LOW,
+		.vssel = MXC_GPIO_VSSEL_VDDIOH
+	};
+	struct no_os_spi_init_param max17851_spi_ip = {
+		.device_id = 4,
+		.extra = &max17851_spi_extra,
+		.mode = NO_OS_SPI_MODE_0,
+		.max_speed_hz = 100000,
+		.platform_ops = &max_spi_ops,
+		.chip_select = 0,
+	};
+	struct max17851_init_param uart_extra = {
+		.spi_param = &max17851_spi_ip,
+		.gpio1_param = NULL,
+		.gpio2_param = NULL,
+		.op_mode = MAX17851_MASTER_DUAL_UART,
+		.baud_rate = MAX17851_UART_BAUD_500K,
+		.no_dev = 1,
+		.single = false,
+		.contact_tmr_dly_4xmin = MAX17851_CONTACT_TIMER_DELAY_INFINITE,
+		.gpio_rec_dly_csec = MAX17851_GPIO_RECOVERY_DELAY_DISABLED,
+		.safemon_dly = MAX17851_SAFEMON_DLY_500MS,
+	};
+	struct no_os_uart_init_param uart_ip = {
+		.device_id = 0,
+		.irq_id = NULL,
+		.baud_rate = 500000,
+		.size = NO_OS_UART_CS_8,
+		.platform_ops = &max17851_uart_ops,
+		.parity = NO_OS_UART_PAR_EVEN,
+		.stop = NO_OS_UART_STOP_2_BIT,
+		.extra = &uart_extra,
+	};
+	ret = no_os_uart_init(&uart_desc, &uart_ip);
+	if (ret)
+		return ret;

--- a/drivers/power/max17851/max17851.c
+++ b/drivers/power/max17851/max17851.c
@@ -1,0 +1,748 @@
+/***************************************************************************//**
+ *   @file   max17851.c
+ *   @brief  Source file of the MAX17851 driver
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "max17851.h"
+#include "no_os_alloc.h"
+#include "no_os_error.h"
+
+/**
+ * @brief Read any UART related errors in case of failures communication wise.
+ * @param desc - Instance of UART
+ * @return Status byte that contains any UART errors that appeared.
+ */
+static uint32_t max17851_uart_get_errors(struct no_os_uart_desc *desc)
+{
+	struct max17851_desc *extra;
+	uint8_t reg_val;
+	int ret;
+
+	extra = desc->extra;
+	ret = max17851_reg_read(extra, MAX17851_STATUS_GEN_REG, &reg_val);
+	if (ret)
+		return ret;
+
+	return reg_val;
+}
+
+/**
+ * @brief Read data from UART device.
+ * @param desc - Instance of UART.
+ * @param data - Pointer to buffer containing data.
+ * @param bytes_number - Number of bytes to read.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+static int32_t max17851_uart_read(struct no_os_uart_desc *desc, uint8_t *data,
+				  uint32_t bytes_number)
+{
+	struct max17851_desc *extra;
+
+	if (!desc || !data || !bytes_number)
+		return -EINVAL;
+
+	if (bytes_number > MAX17851_UART_MAX_BYTES_NB)
+		return -EOPNOTSUPP;
+
+	extra = desc->extra;
+	return max17851_read_msg(extra, data, bytes_number);
+}
+
+/**
+ * @brief Write data to UART device.
+ * @param desc - Instance of UART.
+ * @param data - Pointer to buffer containing data.
+ * @param bytes_number - Number of bytes to read.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+static int32_t max17851_uart_write(struct no_os_uart_desc *desc,
+				   const uint8_t *data,
+				   uint32_t bytes_number)
+{
+	struct max17851_desc *extra;
+
+	if (!desc || !data || !bytes_number)
+		return -EINVAL;
+
+	if (bytes_number > MAX17851_UART_MAX_BYTES_NB)
+		return -EOPNOTSUPP;
+
+	extra = desc->extra;
+	return max17851_write_msg(extra, data, bytes_number);
+}
+
+/**
+ * @brief Initialize the UART communication peripheral.
+ * @param desc - The UART descriptor.
+ * @param param - The structure that contains the UART parameters.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+static int32_t max17851_uart_init(struct no_os_uart_desc **desc,
+				  struct no_os_uart_init_param *param)
+{
+	struct max17851_desc *max17851_uart;
+	struct max17851_init_param *eparam;
+	struct no_os_uart_desc *descriptor;
+	int ret;
+
+	if (!param || !param->extra)
+		return -EINVAL;
+
+	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	eparam = param->extra;
+	switch (param->baud_rate) {
+	case 500000:
+		eparam->baud_rate = MAX17851_UART_BAUD_500K;
+		break;
+	case 1000000:
+		eparam->baud_rate = MAX17851_UART_BAUD_1M;
+		break;
+	case 2000000:
+		eparam->baud_rate = MAX17851_UART_BAUD_2M;
+		break;
+	default:
+		ret = -EINVAL;
+		goto error;
+	}
+	ret = max17851_init(&max17851_uart, eparam);
+	if (ret)
+		goto error;
+
+	descriptor->extra = max17851_uart;
+	descriptor->baud_rate = param->baud_rate;
+	descriptor->device_id = 0;
+
+
+	*desc = descriptor;
+
+	return 0;
+
+error:
+	no_os_free(descriptor);
+
+	return ret;
+}
+
+/**
+ * @brief Free the resources allocated by max_uart_init().
+ * @param desc - The UART descriptor.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+static int32_t max17851_uart_remove(struct no_os_uart_desc *desc)
+{
+	struct max17851_desc *extra;
+
+	if (!desc)
+		return -EINVAL;
+
+	extra = desc->extra;
+
+	max17851_remove(extra);
+	no_os_free(desc);
+
+	return 0;
+}
+
+/**
+ * @brief Send specific device command over SPI.
+ * @param desc - MAX17851 device descriptor.
+ * @param command - Specific command from the command list.
+ * @param enable - Enable/Disable function in case of some commands.
+ * 		   Appropiated value needed only for SWPORT or SLEEP_EN
+ * 		   commands, ohterwise can be left either true or false.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int max17851_send_command(struct max17851_desc *desc,
+			  enum max17851_command command, bool enable)
+{
+	struct no_os_spi_msg xfer = {
+		.tx_buff = desc->buff,
+		.rx_buff = desc->buff,
+		.bytes_number = MAX17851_FRAME_SIZE - 1,
+		.cs_change = 1,
+	};
+
+	switch (command) {
+	case MAX17851_CLR_LSSM:
+	case MAX17851_CLR_ALIVECOUNT_SEED:
+	case MAX17851_VER_CONFIG:
+	case MAX17851_LOAD_CONFIG:
+	case MAX17851_WD_KEY:
+		memset(desc->buff, 0, xfer.bytes_number);
+		desc->buff[0] = command;
+
+		return no_os_spi_transfer(desc->spi_desc, &xfer, 1);
+	case MAX17851_SWPOR:
+	case MAX17851_SLP_EN:
+		xfer.bytes_number++;
+
+		memset(desc->buff, 0, xfer.bytes_number);
+		desc->buff[0] = command;
+		desc->buff[1] = enable;
+
+		return no_os_spi_transfer(desc->spi_desc, &xfer, 1);
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Read message over UART from the MAX17851.
+ * @param desc - MAX17851 device descriptor.
+ * @param data - Pointer to data containing buffer.
+ * @param len - Length of the message in bytes.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int max17851_read_msg(struct max17851_desc *desc, uint8_t *data, uint8_t len)
+{
+	struct no_os_spi_msg xfer = {
+		.tx_buff = desc->buff,
+		.rx_buff = desc->buff,
+		.bytes_number = len + 2,
+		.cs_change = 1,
+	};
+	int ret, i = 0, retries = 0;
+	bool ready = false;
+	bool stop = false;
+	uint8_t reg_val;
+
+	if (len > MAX17851_UART_MAX_BYTES_NB)
+		return -EINVAL;
+
+	while (!stop || !ready) {
+		ret = max17851_reg_read(desc, MAX17851_STATUS_RX_REG, &reg_val);
+		if (ret)
+			return ret;
+
+		stop = no_os_field_get(MAX17851_ALRT_MASK(MAX17851_RX_STOP_ALRT), reg_val);
+
+		ret = max17851_reg_read(desc, MAX17851_STATUS_LSSM_BYTE_REG, &reg_val);
+		if (ret)
+			return ret;
+
+		ready = no_os_field_get(NO_OS_BIT(7), reg_val);
+
+		retries++;
+		if (retries == 100)
+			return -ETIMEDOUT;
+	}
+
+	memset(desc->buff, 0, len + 2);
+	desc->buff[0] = MAX17851_RD_REG(MAX17851_RX_RD_NXT_MSG_REG);
+	ret = no_os_spi_transfer(desc->spi_desc, &xfer, 1);
+	if (ret)
+		return ret;
+
+	memcpy(data, &desc->buff[1], len);
+
+	desc->lssm_byte = desc->buff[i + 1];
+
+	return max17851_clear_buff(desc, false);
+}
+
+/**
+ * @brief Write message over UART using MAX17851.
+ * @param desc - MAX17851 device descriptor.
+ * @param data - Pointer to data containing buffer.
+ * @param len - Length of the message in bytes.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int max17851_write_msg(struct max17851_desc *desc, const uint8_t *data,
+		       uint8_t len)
+{
+	struct no_os_spi_msg xfer = {
+		.tx_buff = desc->buff,
+		.rx_buff = desc->buff,
+		.bytes_number = len + 2,
+		.cs_change = 1,
+	};
+	int ret, i;
+
+	ret = max17851_config_gen2(desc, MAX17851_TX_QUEUE_SEL, true);
+	if (ret)
+		return ret;
+
+	if (len > MAX17851_UART_MAX_BYTES_NB)
+		return -EINVAL;
+
+	memset(desc->buff, 0, len + 2);
+	desc->buff[0] = MAX17851_LDQ_REG;
+	desc->buff[1] = len;
+	memcpy(&desc->buff[2], data, len);
+
+	ret = no_os_spi_transfer(desc->spi_desc, &xfer, 1);
+	if (ret)
+		return ret;
+
+	desc->buff[0] = MAX17851_NXT_LDQ_REG;
+	xfer.bytes_number = 1;
+
+	ret = no_os_spi_transfer(desc->spi_desc, &xfer, 1);
+	if (ret)
+		return ret;
+
+	ret = max17851_config_gen2(desc, MAX17851_TX_QUEUE_SEL, false);
+	if (ret)
+		return ret;
+
+	return max17851_clear_buff(desc, true);
+}
+
+/**
+ * @brief Configure general settings for MAX17851.
+ * @param desc - MAX17851 device descriptor.
+ * @param sel - Specific setting to be changed.
+ * @param enable - Disable/Enable specific setting.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int max17851_config_gen2(struct max17851_desc *desc,
+			 enum max17851_config_gen2_sel sel, bool enable)
+{
+	return max17851_reg_update(desc, MAX17851_CONFIG_GEN2_REG,
+				   MAX17851_CONFIG_GEN2_MASK(sel),
+				   no_os_field_prep(MAX17851_CONFIG_GEN2_MASK(sel), enable));
+}
+
+/**
+ * @brief Set timing for Alert Packets/Keep-Alive Packets.
+ * @param desc - MAX17851 device descriptor.
+ * @param time - Specific pre-defined time value to be set.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int max17851_sel_alrtpckt_time(struct max17851_desc *desc,
+			       enum max17851_alrtpckt_time time)
+{
+	return max17851_reg_update(desc, MAX17851_CONFIG_GEN3_REG,
+				   MAX17851_ALRTPCKT_TIME_MASK,
+				   no_os_field_prep(MAX17851_ALRTPCKT_TIME_MASK,
+						   time));
+}
+
+/**
+ * @brief Select queue for transmitting/loading TX buffer for UART.
+ * @param desc - MAX17851 device descriptor.
+ * @param sel - Specific pre-defined value for either TX or LD queue selection.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int max17851_select_queue(struct max17851_desc *desc,
+			  enum max17851_queue_sel sel)
+{
+	uint8_t mask;
+
+	mask = (sel >= MAX17851_TXQ_0_SEL) ? MAX17851_TXQ_MASK : MAX17851_LOADQ_MASK;
+
+	sel = sel % 4;
+	return max17851_reg_update(desc, MAX17851_TX_QUEUE_SEL_REG, mask,
+				   no_os_field_prep(mask, sel));
+}
+
+/**
+ * @brief Clear RX/TX buffer inside the MAX17851 memory.
+ * @param desc - MAX17851 device descriptor.
+ * @param tx_buf - True - Clear TX buffer.
+ * 		   False - Clear RX buffer.
+ * @return 0 incase of success, negative error code otherwise.
+ */
+int max17851_clear_buff(struct max17851_desc *desc, bool tx_buf)
+{
+	struct no_os_spi_msg xfer = {
+		.tx_buff = desc->buff,
+		.rx_buff = desc->buff,
+		.bytes_number = MAX17851_FRAME_SIZE - 1,
+		.cs_change = 1,
+	};
+
+	memset(desc->buff, 0, xfer.bytes_number);
+	desc->buff[0] = tx_buf ? MAX17851_CLR_TXBUF_REG : MAX17851_CLR_RXBUF_REG;
+
+	return no_os_spi_transfer(desc->spi_desc, &xfer, 1);
+}
+
+/**
+ * @brief Read specific alert state.
+ * @param desc - MAX17851 device descriptor.
+ * @param alert - Specific alert state to be read.
+ * @param enable - Pointer to alert state value to be read.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int max17851_get_alert(struct max17851_desc *desc, enum max17851_alert alert,
+		       bool *enable)
+{
+	uint8_t reg, reg_val;
+	int ret;
+
+	reg = MAX17851_ALERT_RX_REG + (alert / 8) * 2;
+
+	ret = max17851_reg_read(desc, reg, &reg_val);
+	if (ret)
+		return ret;
+
+	*enable = no_os_field_get(MAX17851_ALRT_MASK(alert), reg_val);
+
+	return 0;
+}
+
+/**
+ * @brief Enable/Disable specific alert.
+ * @param desc - MAX17851 device descriptor.
+ * @param alert - Specific alert to be enabled/disabled.
+ * @param enable - true - Enable specific alert.
+ * 		   false - Disable specific alert.
+ * @return 0 in case of success, negative erro code otherwise.
+ */
+int max17851_set_alert(struct max17851_desc *desc, enum max17851_alert alert,
+		       bool enable)
+{
+	uint8_t reg;
+
+	reg = MAX17851_ALERT_RX_REG + (alert / 8) * 2;
+
+	return max17851_reg_update(desc, reg, MAX17851_ALRT_MASK(alert),
+				   no_os_field_prep(MAX17851_ALRT_MASK(alert),
+						   enable));
+}
+
+/**
+ * @brief Select the number of unmasked consecutive Alert Packet status alerts,
+ * 	  which must happen prior to taking action in either Safe Minotring or
+ * 	  Sleep Mode.
+ * @param desc - MAX17851 device descriptor.
+ * @param dbnc - Specific pre-defined value for number of debounces.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int max17851_set_alert_debounce(struct max17851_desc *desc,
+				enum max17851_status_debounce dbnc)
+{
+	return max17851_reg_update(desc, MAX17851_CONFIG_GEN5_REG,
+				   MAX17851_ALRTPCKT_DBNC_MASK,
+				   no_os_field_prep(MAX17851_ALRTPCKT_DBNC_MASK,
+						   dbnc));
+}
+
+/**
+ * @brief Select Safe Monitoring Mode Scan Delay.
+ * @param desc - MAX17851 device descriptor.
+ * @param delay - Specific pre-defined time delay.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int max17851_set_safemon_dly(struct max17851_desc *desc,
+			     enum max17851_safemon_dly delay)
+{
+	return max17851_reg_write(desc, MAX17851_CONFIG_SAFEMON2_REG, delay);
+}
+
+/**
+ * @brief Select which GPIO pins to be configured as SAFEMON output.
+ * @param desc - MAX17851 device descriptor.
+ * @param gpio - Selected GPIO.
+ * @param enable - Enable/Disable the SAFEMON output function of the GPIO.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int max17851_set_safemon_gpio(struct max17851_desc *desc,
+			      enum max17851_safemon_gpio gpio, bool enable)
+{
+	return max17851_reg_update(desc, MAX17851_CONFIG_SAFEMON3_REG,
+				   MAX17851_SAFEMON_GPIO_MASK(gpio),
+				   no_os_field_prep(MAX17851_SAFEMON_GPIO_MASK(gpio), enable));
+}
+
+/**
+ * @brief Set communication retry count and timeout delay.
+ * @param desc - MAX17851 device descriptor.
+ * @param count - Specific pre-defined value for communication retry count.
+ * @param delay - Specific pre-defined value for communication timeout delay.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int max17851_set_comm(struct max17851_desc *desc,
+		      enum max17851_comm_try_count count,
+		      enum max17851_comm_timeout_delay delay)
+{
+	uint8_t reg_val;
+	int ret;
+
+	reg_val = no_os_field_prep(MAX17851_COMM_RETRY_COUNT_MASK, count) |
+		  no_os_field_prep(MAX17851_COMM_TIMEOUT_DELAY_MASK, delay);
+
+	return max17851_reg_write(desc, MAX17851_CONFIG_COMM_REG, reg_val);
+}
+
+/**
+ * @brief MAX17851 register read function.
+ * @param desc - MAX17851 device descriptor.
+ * @param reg - Register Address.
+ * @param data - Data byte to be read.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int max17851_reg_read(struct max17851_desc *desc, uint8_t reg, uint8_t *data)
+{
+	struct no_os_spi_msg xfer = {
+		.tx_buff = desc->buff,
+		.rx_buff = desc->buff,
+		.bytes_number = MAX17851_FRAME_SIZE,
+		.cs_change = 1,
+	};
+	int ret;
+
+	memset(desc->buff, 0, xfer.bytes_number);
+	desc->buff[0] = MAX17851_RD_REG(reg);
+
+	ret = no_os_spi_transfer(desc->spi_desc, &xfer, 1);
+	if (ret)
+		return ret;
+
+	*data = desc->buff[1];
+
+	return 0;
+}
+
+/**
+ * @brief MAX17851 register write function.
+ * @param desc - MAX17851 device descriptor.
+ * @param reg - Register Address.
+ * @param data - Data byte to be written.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int max17851_reg_write(struct max17851_desc *desc, uint8_t reg, uint8_t data)
+{
+	struct no_os_spi_msg xfer = {
+		.tx_buff = desc->buff,
+		.rx_buff = desc->buff,
+		.bytes_number = MAX17851_FRAME_SIZE,
+		.cs_change = 1,
+	};
+
+	desc->buff[0] = reg;
+	desc->buff[1] = data;
+
+	return no_os_spi_transfer(desc->spi_desc, &xfer, 1);
+}
+
+/**
+ * @brief MAX17851 register update function.
+ * @param desc - MAX17851 device descriptor.
+ * @param reg - Register Address.
+ * @param mask - Field mask to be udated inside the register.
+ * @param data - Data byte to be updated.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int max17851_reg_update(struct max17851_desc *desc, uint8_t reg, uint8_t mask,
+			uint8_t data)
+{
+	uint8_t reg_val = 0;
+	int ret;
+
+	ret = max17851_reg_read(desc, reg, &reg_val);
+	if (ret)
+		return ret;
+
+	reg_val &= ~mask;
+	reg_val |= mask & data;
+
+	return max17851_reg_write(desc, reg, reg_val);
+}
+
+/**
+ * @brief MAX17851 device initialization function
+ * @param desc - MAX17851 device descriptor to be intialized.
+ * @param init_param - MAX17851 initialization parameter.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int max17851_init(struct max17851_desc **desc,
+		  struct max17851_init_param *init_param)
+{
+	struct max17851_desc *descriptor;
+	uint8_t reg_val;
+	int ret;
+
+	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	ret = no_os_spi_init(&descriptor->spi_desc, init_param->spi_param);
+	if (ret)
+		goto free_desc;
+
+	ret = no_os_gpio_get_optional(&descriptor->gpio1_desc,
+				      init_param->gpio1_param);
+	if (ret)
+		goto free_spi;
+
+	if (descriptor->gpio1_desc) {
+		ret = no_os_gpio_direction_input(descriptor->gpio1_desc);
+		if (ret)
+			goto free_gpio1;
+	}
+
+	ret = no_os_gpio_get_optional(&descriptor->gpio2_desc,
+				      init_param->gpio2_param);
+	if (ret)
+		goto free_gpio1;
+
+	if (descriptor->gpio2_desc) {
+		ret = no_os_gpio_direction_input(descriptor->gpio2_desc);
+		if (ret)
+			goto free_gpio2;
+	}
+
+	ret = max17851_send_command(descriptor, MAX17851_CLR_LSSM, true);
+	if (ret)
+		goto free_gpio2;
+
+	/* Remaining SPI operation for MAX17851 initialization. */
+	ret = max17851_reg_write(descriptor, MAX17851_CONFIG_GEN0_REG,
+				 init_param->no_dev);
+	if (ret)
+		goto free_gpio2;
+
+	descriptor->no_dev = init_param->no_dev;
+
+	ret = max17851_reg_write(descriptor, MAX17851_CONFIG_GEN1_REG,
+				 no_os_field_prep(MAX17851_SINGLE_MASK, init_param->single) |
+				 no_os_field_prep(MAX17851_BAUD_MASK, init_param->baud_rate));
+	if (ret)
+		goto free_gpio2;
+
+	descriptor->single = init_param->single;
+	descriptor->baud_rate = init_param->baud_rate;
+
+	ret = max17851_reg_update(descriptor, MAX17851_CONFIG_GEN4_REG,
+				  MAX17851_MS_MASK,
+				  no_os_field_prep(MAX17851_MS_MASK, init_param->op_mode));
+	if (ret)
+		goto free_gpio2;
+
+	descriptor->op_mode = init_param->op_mode;
+
+	ret = max17851_set_alert_debounce(descriptor, init_param->dbnc);
+	if (ret)
+		goto free_gpio2;
+
+	descriptor->dbnc = init_param->dbnc;
+
+	ret = max17851_reg_write(descriptor, MAX17851_CONFIG_SAFEMON0_REG,
+				 init_param->gpio_rec_dly_csec);
+	if (ret)
+		goto free_gpio2;
+
+	descriptor->gpio_rec_dly_csec = init_param->gpio_rec_dly_csec;
+
+	ret = max17851_reg_write(descriptor, MAX17851_CONFIG_SAFEMON1_REG,
+				 init_param->contact_tmr_dly_4xmin);
+	if (ret)
+		goto free_gpio2;
+
+	descriptor->contact_tmr_dly_4xmin = init_param->contact_tmr_dly_4xmin;
+
+	ret = max17851_set_safemon_dly(descriptor, init_param->safemon_dly);
+	if (ret)
+		goto free_gpio2;
+
+	descriptor->safemon_dly = init_param->safemon_dly;
+
+	ret = max17851_set_comm(descriptor, MAX17851_RETRY_COUNT_2,
+				init_param->comm_to_delay);
+	if (ret)
+		goto free_gpio2;
+
+	/* Wake up BMS chips in daisy-chain. */
+	ret = max17851_sel_alrtpckt_time(descriptor, MAX17851_ALRTPCKT_INFINITE);
+	if (ret)
+		goto free_gpio2;
+
+	ret = max17851_config_gen2(descriptor, MAX17851_TX_QUEUE_SEL, false);
+	if (ret)
+		goto free_gpio2;
+
+	descriptor->comm_to_delay = init_param->comm_to_delay;
+
+	/* Checking for errors on RX and clearing if necessary*/
+	ret = max17851_reg_read(descriptor, MAX17851_ALERT_GEN_REG, &reg_val);
+	if (ret)
+		goto free_gpio2;
+
+	if (reg_val) {
+		ret = max17851_reg_write(descriptor, MAX17851_ALERT_GEN_REG,
+					 0x00);
+		if (ret)
+			goto free_gpio2;
+	}
+
+	ret = max17851_clear_buff(descriptor, true);
+	if (ret)
+		goto free_gpio2;
+
+	ret = max17851_clear_buff(descriptor, false);
+	if (ret)
+		goto free_gpio2;
+
+	*desc = descriptor;
+
+	return 0;
+
+free_gpio2:
+	no_os_gpio_remove(descriptor->gpio2_desc);
+free_gpio1:
+	no_os_gpio_remove(descriptor->gpio1_desc);
+free_spi:
+	no_os_spi_remove(descriptor->spi_desc);
+free_desc:
+	no_os_free(descriptor);
+
+	return ret;
+}
+
+/**
+ * @brief Deallocate any resources used at the initialization function.
+ * @param desc - MAX17851 device descriptor.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int max17851_remove(struct max17851_desc *desc)
+{
+	no_os_gpio_remove(desc->gpio2_desc);
+	no_os_gpio_remove(desc->gpio1_desc);
+	no_os_spi_remove(desc->spi_desc);
+	no_os_free(desc);
+
+	return 0;
+}
+
+/**
+ * @brief MAX17851 platform specific UART platform ops structure
+ */
+const struct no_os_uart_platform_ops max17851_uart_ops = {
+	.init = &max17851_uart_init,
+	.read = &max17851_uart_read,
+	.write = &max17851_uart_write,
+	.get_errors = &max17851_uart_get_errors,
+	.remove = &max17851_uart_remove
+};

--- a/drivers/power/max17851/max17851.h
+++ b/drivers/power/max17851/max17851.h
@@ -1,0 +1,394 @@
+/***************************************************************************//**
+ *   @file   max17851.h
+ *   @brief  Header file of the MAX17851 driver
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef _MAX17851_H_
+#define _MAX17851_H_
+
+#include <stdint.h>
+#include <string.h>
+#include "no_os_uart.h"
+#include "no_os_gpio.h"
+#include "no_os_spi.h"
+#include "no_os_util.h"
+
+#define MAX17851_UART_MAX_BYTES_NB		31
+
+#define MAX17851_FRAME_SIZE			2
+
+#define MAX17851_RD_REG(reg)			((reg) + 1)
+
+#define MAX17851_GPIO_RECOVERY_DELAY_DISABLED	0xFF
+#define MAX17851_CONTACT_TIMER_DELAY_INFINITE	0xFF
+
+#define MAX17851_CONFIG_GEN2_MASK(sel)		NO_OS_BIT(sel)
+#define MAX17851_ALRTPCKT_TIME_MASK		NO_OS_GENMASK(3, 0)
+#define MAX17851_LOADQ_MASK			NO_OS_GENMASK(1, 0)
+#define MAX17851_TXQ_MASK			NO_OS_GENMASK(3, 2)
+#define MAX17851_ALRT_MASK(alrt)		NO_OS_BIT(((alrt) % 8))
+#define MAX17851_BAUD_MASK			NO_OS_GENMASK(6, 4)
+#define MAX17851_SINGLE_MASK			NO_OS_BIT(7)
+#define MAX17851_MS_MASK			NO_OS_GENMASK(5, 4)
+#define MAX17851_ALRTPCKT_DBNC_MASK		NO_OS_GENMASK(5, 3)
+#define MAX17851_SAFEMON_GPIO_MASK(x)		NO_OS_BIT(x)
+#define MAX17851_COMM_RETRY_COUNT_MASK		NO_OS_GENMASK(5, 4)
+#define MAX17851_COMM_TIMEOUT_DELAY_MASK	NO_OS_GENMASK(2, 0)
+
+#define MAX17851_STATUS_RX_REG			0x00
+#define MAX17851_STATUS_TX_REG			0x02
+#define MAX17851_STATUS_LSSM_BYTE_REG		0x04
+#define MAX17851_STATUS_GEN_REG			0x06
+#define MAX17851_STATUS_OPSTATE_REG		0x08
+#define MAX17851_STATUS_BUF_REG			0x0A
+#define MAX17851_STATUS_WD_REG			0x0C
+#define MAX17851_STATUS_GPIO_REG		0x0E
+
+#define MAX17851_ALERT_RX_REG			0x10
+#define MAX17851_ALERT_TX_REG			0x12
+#define MAX17851_ALERT_LSSM_BYTE_REG		0x14
+#define MAX17851_ALERT_GEN_REG			0x16
+#define MAX17851_ALERT_OPSTATE_REG		0x18
+#define MAX17851_ALERT_BUF_REG			0x1A
+#define MAX17851_ALERT_WD_REG			0x1C
+#define MAX17851_ALERT_GPIO_REG			0x1E
+
+#define MAX17851_ALRTEN_RX_REG			0x20
+#define MAX17851_ALRTEN_TX_REG			0x22
+#define MAX17851_ALRTEN_LSSM_BYTE_REG		0x24
+#define MAX17851_ALRTEN_GEN_REG			0x26
+#define MAX17851_ALRTEN_OPSTATE_REG		0x28
+#define MAX17851_ALRTEN_BUF_REG			0x2A
+#define MAX17851_ALRTEN_WD_REG			0x2C
+#define MAX17851_ALRTEN_GPIO_REG		0x2E
+
+#define MAX17851_CLR_TXBUF_REG			0x40
+#define MAX17851_CLR_RXBUF_REG			0x42
+#define MAX17851_CLR_LSSM_REG			0x44
+#define MAX17851_CLR_ALIVECOUNT_SEED_REG	0x48
+#define MAX17851_SWPOR_REG			0x4A
+#define MAX17851_SLP_EN_REG			0x4C
+#define MAX17851_VER_CONFIG_REG			0x4E
+#define MAX17851_LOAD_CONFIG_REG		0x50
+#define MAX17851_WD_KEY_REG			0x52
+
+#define MAX17851_CONFIG_GEN0_REG		0x60
+#define MAX17851_CONFIG_GEN1_REG		0x62
+#define MAX17851_CONFIG_GEN2_REG		0x64
+#define MAX17851_CONFIG_GEN3_REG		0x66
+#define MAX17851_CONFIG_GEN4_REG		0x68
+#define MAX17851_CONFIG_GEN5_REG		0x6A
+#define MAX17851_CONFIG_SAFEMON0_REG		0x6C
+#define MAX17851_CONFIG_SAFEMON1_REG		0x6E
+#define MAX17851_CONFIG_SAFEMON2_REG		0x70
+#define MAX17851_CONFIG_SAFEMON3_REG		0x72
+#define MAX17851_CONFIG_SLP_REG			0x74
+#define MAX17851_CONFIG_COMM_REG		0x76
+#define MAX17851_STATUS_DBNC_MASK0_REG		0x78
+#define MAX17851_STATUS_DBNC_MASK1_REG		0x7A
+#define MAX17851_STATUS_ERR_MASK0_REG		0x7C
+#define MAX17851_STATUS_ERR_MASK1_REG		0x7E
+#define MAX17851_CONFIG_GPIO12_REG		0x80
+#define MAX17851_CONFIG_GPIO34_REG		0x82
+#define MAX17851_CONFIG_WD0_REG			0x84
+#define MAX17851_CONFIG_WD1_REG			0x86
+#define MAX17851_CONFIG_WD2_REG			0x88
+
+#define MAX17851_ALRTPCKTBUF_RD_PTR_REG		0x8C
+#define MAX17851_ALRTPCKTBUF_RD_MSG_REG		0x8E
+#define MAX17851_RX_RD_MSG_REG			0x90
+#define MAX17851_RX_RD_NXT_MSG_REG		0x92
+#define MAX17851_TX_QUEUE_SEL_REG		0x94
+#define MAX17851_RX_RD_PTR_REG			0x96
+#define MAX17851_RX_WR_PTR_REG			0x98
+#define MAX17851_RX_NXT_MSG_PTR_REG		0x9A
+#define MAX17851_RX_SPACE_REG			0x9C
+#define MAX17851_RX_BYTE_REG			0x9E
+
+#define MAX17851_NXT_LDQ_REG			0xB0
+#define MAX17851_LDQ_REG			0xC0
+#define MAX17851_LDQ_PTR_REG			0xC2
+#define MAX17851_CONFIGQ_REG			0xD0
+#define MAX17851_CONFIG_PTR_REG			0xD2
+
+#define MAX17851_STATE_REG			0xDC
+#define MAX17851_COMM_RTRY_CNT_REG		0xDE
+#define MAX17851_ALRTPCKT_ERR_CNT_REG		0xE0
+#define MAX17851_WD_FAULT_CNT_REG		0xE2
+#define MAX17851_ALIVECOUNT_SEED_REG		0xE4
+#define MAX17851_ALIVECOUNT_RET_REG		0xE6
+#define MAX17851_ALIVECOUNT_Q_REG		0xE8
+#define MAX17851_FAULT_TIMER0_REG		0xEA
+#define MAX17851_FAULT_TIMER1_REG		0xEC
+#define MAX17851_SLP_CBTIMER0_REG		0xEE
+#define MAX17851_SLP_CBTIMER1_REG		0xF0
+#define MAX17851_VERSION_REG			0xF2
+#define MAX17851_MODEL_REG			0xF4
+
+enum max17851_command {
+	MAX17851_CLR_LSSM = MAX17851_CLR_LSSM_REG,
+	MAX17851_CLR_ALIVECOUNT_SEED = MAX17851_CLR_ALIVECOUNT_SEED_REG,
+	MAX17851_SWPOR = MAX17851_SWPOR_REG,
+	MAX17851_SLP_EN = MAX17851_SLP_EN_REG,
+	MAX17851_VER_CONFIG = MAX17851_VER_CONFIG_REG,
+	MAX17851_LOAD_CONFIG = MAX17851_LOAD_CONFIG_REG,
+	MAX17851_WD_KEY = MAX17851_WD_KEY_REG,
+};
+
+enum max17851_alert {
+	MAX17851_RX_EMPTY_ALRT,
+	MAX17851_RX_STOP_ALRT,
+	MAX17851_RX_OVRFLW_ERR_ALRT,
+	MAX17851_RX_IDLE_ALRT,
+	MAX17851_RX_BUSY_ALRT,
+	MAX17851_RX_ERR_ALRT = 7,
+	MAX17851_TX_EMPTY_ALRT,
+	MAX17851_TX_AVAIL_ALRT,
+	MAX17851_TX_FULL_ALRT,
+	MAX17851_TX_OVRFLW_ERR_ALRT,
+	MAX17851_TX_IDLE_ALRT,
+	MAX17851_TX_BUSY_ALRT,
+	MAX17851_TX_HELD_ALRT = 15,
+	MAX17851_HW_ERR_ALRT,
+	MAX17851_ALIVECNT_ERR_ALRT,
+	MAX17851_COMMAND_OP_ALRT,
+	MAX17851_COMM_MSMTCH_ERR_ALRT,
+	MAX17851_ALRTPCKT_ERR_ALRT,
+	MAX17851_COMM_ERR_ALRT,
+	MAX17851_ALRTPCKT_STATUS_ERR_ALRT,
+	MAX17851_RX_READY_ALRT,
+	MAX17851_ALRTPCKTBUF_HW_ERR_ALRT,
+	MAX17851_ALRTPCKT_COMM_ERR_ALRT,
+	MAX17851_SPI_ERR_ALRT,
+	MAX17851_DATAPATH_ERR_ALRT,
+	MAX17851_GPIO_ERR_ALRT,
+	MAX17851_WD_ERR_ALRT,
+	MAX17851_DEV_COUNT_ERR_ALRT,
+	MAX17851_SAFEMON_CFG_ERR_ALRT = 32,
+	MAX17851_SAFEMON_STATUS_ERR_ALRT,
+	MAX17851_SAFEMON_GPIO12_ALRT,
+	MAX17851_SAFEMON_ALRT,
+	MAX17851_SLP_STATUS_ERR_ALRT,
+	MAX17851_SLP_ALRT,
+	MAX17581_LSSM_FULL_ALRT = 43,
+	MAX17851_ALRTPCKTBUF_FULL_ALRT = 47,
+	MAX17851_WD_EXP_ERR_ALRT,
+	MAX17851_WD_RJCT_ERR_ALRT,
+	MAX17851_WD_LFSR_ERR_ALRT,
+	MAX17851_WD_OPEN_ALRT,
+	MAX17851_WD_TO_ERR_ALRT,
+	MAX17851_GPIO1_ERR_ALRT = 56,
+	MAX17851_GPIO2_ERR_ALRT,
+	MAX17851_GPIO3_ERR_ALRT,
+	MAX17851_GPIO4_ERR_ALRT,
+};
+
+enum max17851_queue_sel {
+	MAX17851_LOADQ_0_SEL,
+	MAX17851_LOADQ_1_SEL,
+	MAX17851_LOADQ_2_SEL,
+	MAX17851_LOADQ_3_SEL,
+	MAX17851_TXQ_0_SEL,
+	MAX17851_TXQ_1_SEL,
+	MAX17851_TXQ_2_SEL,
+	MAX17851_TXQ_3_SEL,
+};
+
+enum max17851_config_gen2_sel {
+	MAX17851_TX_NOPREAMBLE_SEL,
+	MAX17851_TX_NOSTOP_SEL,
+	MAX17851_TX_PAUSE_SEL,
+	MAX17851_TX_ODDPARITY_SEL,
+	MAX17851_TX_QUEUE_SEL,
+	MAX17851_TX_PREAMBLES_SEL,
+	MAX17851_TX_RAW_DATA_SEL,
+	MAX17851_RX_RAW_DATA_SEL,
+};
+
+enum max17851_alrtpckt_time {
+	MAX17851_ALRTPCKT_0US,
+	MAX17851_ALRTPCKT_10US,
+	MAX17851_ALRTPCKT_20US,
+	MAX17851_ALRTPCKT_40US,
+	MAX17851_ALRTPCKT_80US,
+	MAX17851_ALRTPCKT_160US,
+	MAX17851_ALRTPCKT_320US,
+	MAX17851_ALRTPCKT_640US,
+	MAX17851_ALRTPCKT_1280US,
+	MAX17851_ALRTPCKT_2560US,
+	MAX17851_ALRTPCKT_5120US,
+	MAX17851_ALRTPCKT_10240US,
+	MAX17851_ALRTPCKT_INFINITE = 15,
+};
+
+enum max17851_baud_rate {
+	MAX17851_UART_BAUD_500K = 1,
+	MAX17851_UART_BAUD_1M,
+	MAX17851_UART_BAUD_2M,
+};
+
+enum max17851_uart_op_mode {
+	MAX17851_SLAVE_DUAL_UART,
+	MAX17851_MASTER_SINGLE_UART = 2,
+	MAX17851_MASTER_DUAL_UART,
+};
+
+enum max17851_status_debounce {
+	MAX17851_ALERTPCKT_DBNC_1,
+	MAX17851_ALERTPCKT_DBNC_2,
+	MAX17851_ALERTPCKT_DBNC_4,
+	MAX17851_ALERTPCKT_DBNC_8,
+	MAX17851_ALERTPCKT_DBNC_16,
+	MAX17851_ALERTPCKT_DBNC_32,
+	MAX17851_ALERTPCKT_DBNC_64,
+	MAX17851_ALERTPCKT_DBNC_128,
+};
+
+enum max17851_safemon_dly {
+	MAX17851_SAFEMON_DLY_500MS,
+	MAX17851_SAFEMON_DLY_1000MS,
+	MAX17851_SAFEMON_DLY_1500MS,
+};
+
+enum max17851_safemon_gpio {
+	MAX17851_SAFEMON_GPIO1,
+	MAX17851_SAFEMON_GPIO2,
+	MAX17851_SAFEMON_GPIO3,
+	MAX17851_SAFEMON_GPIO4,
+};
+
+enum max17851_comm_try_count {
+	MAX17851_RETRY_COUNT_2,
+	MAX17851_RETRY_COUNT_4,
+	MAX17851_RETRY_COUNT_8,
+	MAX17851_RETRY_COUNT_16,
+};
+
+enum max17851_comm_timeout_delay {
+	MAX17851_TIMEOUT_DELAY_276BITS,
+	MAX17851_TIMEOUT_DELAY_516BITS,
+	MAX17851_TIMEOUT_DELAY_996BITS,
+	MAX17851_TIMEOUT_DELAY_1956BITS,
+	MAX17851_TIMEOUT_DELAY_DISABLED,
+};
+
+struct max17851_init_param {
+	struct no_os_spi_init_param *spi_param;
+
+	struct no_os_gpio_init_param *gpio1_param;
+	struct no_os_gpio_init_param *gpio2_param;
+
+	enum max17851_comm_timeout_delay comm_to_delay;
+	enum max17851_safemon_dly safemon_dly;
+	enum max17851_uart_op_mode op_mode;
+	enum max17851_status_debounce dbnc;
+	enum max17851_baud_rate baud_rate;
+
+	uint8_t contact_tmr_dly_4xmin;
+	uint8_t gpio_rec_dly_csec;
+
+	uint8_t no_dev;
+	bool single;
+};
+
+struct max17851_desc {
+	struct no_os_spi_desc *spi_desc;
+
+	struct no_os_gpio_desc *gpio1_desc;
+	struct no_os_gpio_desc *gpio2_desc;
+
+	enum max17851_comm_timeout_delay comm_to_delay;
+	enum max17851_safemon_dly safemon_dly;
+	enum max17851_uart_op_mode op_mode;
+	enum max17851_status_debounce dbnc;
+	enum max17851_baud_rate baud_rate;
+
+	uint8_t contact_tmr_dly_4xmin;
+	uint8_t gpio_rec_dly_csec;
+
+	uint8_t lssm_byte;
+	uint8_t buff[33];
+	uint8_t no_dev;
+	bool single;
+};
+
+int max17851_send_command(struct max17851_desc *desc,
+			  enum max17851_command command, bool enable);
+
+int max17851_read_msg(struct max17851_desc *desc, uint8_t *data, uint8_t len);
+
+int max17851_write_msg(struct max17851_desc *desc, const uint8_t *data,
+		       uint8_t len);
+
+int max17851_config_gen2(struct max17851_desc *desc,
+			 enum max17851_config_gen2_sel sel, bool enable);
+
+int max17851_sel_alrtpckt_time(struct max17851_desc *desc,
+			       enum max17851_alrtpckt_time time);
+
+int max17851_select_queue(struct max17851_desc *desc,
+			  enum max17851_queue_sel sel);
+
+int max17851_clear_buff(struct max17851_desc *desc, bool tx_buf);
+
+int max17851_get_alert(struct max17851_desc *desc, enum max17851_alert alert,
+		       bool *enable);
+
+int max17851_set_alert(struct max17851_desc *desc, enum max17851_alert alert,
+		       bool enable);
+
+int max17851_set_alert_debounce(struct max17851_desc *desc,
+				enum max17851_status_debounce dbnc);
+
+int max17851_set_safemon_dly(struct max17851_desc *desc,
+			     enum max17851_safemon_dly delay);
+
+int max17851_set_safemon_gpio(struct max17851_desc *desc,
+			      enum max17851_safemon_gpio gpio, bool enable);
+
+int max17851_set_comm(struct max17851_desc *desc,
+		      enum max17851_comm_try_count count,
+		      enum max17851_comm_timeout_delay delay);
+
+int max17851_reg_read(struct max17851_desc *desc, uint8_t reg, uint8_t *data);
+
+int max17851_reg_write(struct max17851_desc *desc, uint8_t reg, uint8_t data);
+
+int max17851_reg_update(struct max17851_desc *desc, uint8_t reg, uint8_t mask,
+			uint8_t data);
+
+int max17851_init(struct max17851_desc **desc,
+		  struct max17851_init_param *init_param);
+
+int max17851_remove(struct max17851_desc *desc);
+
+extern const struct no_os_uart_platform_ops max17851_uart_ops;
+
+#endif /* _MAX17851_H_ */


### PR DESCRIPTION
## Pull Request Description

The MAX17851 SPI to UART safety monitoring bridge
translates communication from SPI format to universal
asynchronous receiver transmitter (UART) format special-
ly designed to interface with Maxim's Battery Management
Data Acquisition System. The safety monitoring bridge en-
ables robust communication with baud rates extending up
to 4Mbps in both single and dual daisy-chain system archi-
tectures. High throughput, dual UART systems can read
96 cells of battery voltages within 1173us.

The UART is ISO26262 compliant for automotive safety
integrity level (ASIL) D systems providing detection of
message corruption, delay, loss, and insertion through the
embedded UART communication lock step safety mea-
sure state machine (LSSM). The MAX17851 self verifies
all communication within the message payload to simplify
the software development on the host microcontroller.

This PR implements the MAX17851 no-OS driver,  which although is a device driver, it can
also be used as a platform driver for UART peripheral, in case of usage inside
another BMS device driver.

This PR needs merging before #2429.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies