### PR TITLE
power: ades1754 : Add support for ADES1754

### DIFF
--- a/doc/sphinx/source/drivers/ades1754.rst
+++ b/doc/sphinx/source/drivers/ades1754.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../drivers/power/ades1754/README.rst

--- a/doc/sphinx/source/drivers_doc.rst
+++ b/doc/sphinx/source/drivers_doc.rst
@@ -97,6 +97,7 @@ POWER MANAGEMENT
 .. toctree::
    :maxdepth: 1
 
+   drivers/ades1754
    drivers/adp1050
    drivers/ltc2992
    drivers/ltc4162l

--- a/doc/sphinx/source/projects/ades1754.rst
+++ b/doc/sphinx/source/projects/ades1754.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../projects/ades1754/README.rst

--- a/doc/sphinx/source/projects_doc.rst
+++ b/doc/sphinx/source/projects_doc.rst
@@ -70,6 +70,7 @@ POWER MANAGEMENT
 .. toctree::
    :maxdepth: 1
 
+   projects/ades1754
    projects/adp1050
    projects/dc2703a
    projects/ltc4162l

--- a/drivers/power/ades1754/README.rst
+++ b/drivers/power/ades1754/README.rst
@@ -1,0 +1,136 @@
+ADES1754 no-OS driver
+=====================
+
+Supported Devices
+-----------------
+
+`ADES1754 <https://www.analog.com/ADES1754>`_
+
+Overview
+--------
+
+The ADES1754/ADES1755/ADES1756 are flexible
+data-acquisition systems for the management of high-
+voltage and low-voltage battery modules. The systems
+can measure 14 cell voltages and a combination of six
+temperatures or system voltage measurements with fully
+redundant measurement engines in 162μs, or perform
+all inputs solely with the ADC measurement engine in
+99μs. Fourteen internal balancing switches rated
+for >300mA for cell-balancing current support extensive
+built-in diagnostics.
+
+Cell and bus-bar voltages ranging from -2.5V to +5V are
+measured differentially over a 65V common-mode
+range, with a typical accuracy of 100μV. If oversampling
+is enabled, up to 128 measurements per channel can be
+averaged internally with 14-bit resolution and combined
+with digital post-processing IIR filtering for increased
+noise immunity.
+
+Applications
+------------
+
+* Residential Battery Storage Systems
+* High-Voltage Battery Stacks
+* Battery-Backup Systems (UPS)
+* Super-Cap Systems
+* Battery-Powered Tools
+* EV Charging
+
+Driver Initialization
+---------------------
+
+In order to be able to use the device, you will have to provide support
+for the communication protocol (UART) which can be done either using the
+host UNIT UART peripheral, or by using MAX17851 SPI-to-UART bridge as
+an UART peripheral (see MAX17851 device driver and documentation for it).
+
+The first API to be called is **ades1754_init**. Make sure it return 0,
+which means that the driver was intialized correctly.
+
+Scan Configuration
+------------------
+
+One can set the ADC scaning method by calling **ades1754_set_adc_method**
+function, or switching the used scan mode by calling the
+**ades1754_switch_scan_mode** function.
+
+More than this the user can trigger the scanning, or stop it by using
+**ades1754_start_scan** function.
+
+Cell Configuration
+------------------
+
+Cell polarity can be changed by using the **ades1754_set_cell_poll**
+function.
+
+Cell voltage can be read back from the accumulator registers after or before
+triggering a scan by calling **ades1754_get_cell_data** function.
+
+IIR Configuration
+-----------------
+
+ADES1754 also comes along with an integrated IIR filter to be used for
+acquisition.
+
+IIR filter coefficient can be set with **ades1754_set_iir** function.
+IIR settings such as Alert Issuance to be based on IIR filter results,
+IIR data to be stored inside the accumulators or output data to
+take or not the IIR data in consideration can be set by using
+**ades175_set_iir_ctrl** function.
+
+Buffer Configuration
+--------------------
+
+Buffer can be set to be normall sized, or double sized based on the
+**ades1754_set_buffer_mode** function that sets the mode.
+
+Alert Configration
+------------------
+
+User can set the alert threshold values by using **ades1754_set_alert_thr**
+function, and read alert status of specific alerts by suing
+**ades1754_get_alert** function.
+
+Cell-Balancing Configuration
+----------------------------
+
+Cell-Balancing mode is to be set by using **ades1754_set_balancing_mode**
+function.
+Cell-Balancing measurement is to be set by using **ades1754_set_balancing_meas**
+function.
+Cell-Balancing calibration is to be performed by using
+**ades1754_set_balancing_calib** function.
+
+ADES1754 Driver Initialization Example
+--------------------------------------
+
+.. code-block:: bash
+
+	struct ades1754_desc *ades1754_desc;
+	struct no_os_uart_init_param ades1754_comm_ip = {
+		.device_id = 1,
+		.baud_rate = 500000,
+		.asynchronous_rx = false,
+		.size = NO_OS_UART_CS_8,
+		.platform_ops = &max_uart_ops,
+		.parity = NO_OS_UART_PAR_ODD,
+		.stop = NO_OS_UART_STOP_2_BIT,
+		.extra = &ades1754_comm_extra,
+	};
+	struct ades1754_init_param ades1754_ip = {
+		.uart_param = &ades1754_comm_ip,
+		.id = ID_ADES1754,
+		.uart_bridge = true,
+		.dev_addr = 0,
+		.no_dev = 1,
+	};
+
+	ret = ades1754_init(&ades1754_desc, &ades1754_ip);
+	if (ret)
+		return ret;
+
+	ret = ades1754_set_cell_polarity(ades1754, ADES1754_UNIPOLAR);
+	if (ret)
+		goto error;

--- a/drivers/power/ades1754/ades1754.c
+++ b/drivers/power/ades1754/ades1754.c
@@ -1,0 +1,1237 @@
+/***************************************************************************//**
+ *   @file   ades1754.c
+ *   @brief  Source file for the ADES1754 Driver
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "ades1754.h"
+#include "no_os_alloc.h"
+#include "no_os_crc8.h"
+#include "no_os_delay.h"
+#include "no_os_error.h"
+
+NO_OS_DECLARE_CRC8_TABLE(crc_table);
+
+/**
+ * @brief Manchester encoding/decoding function for ADES1754
+ * @param nibble - Encoding - Only 4 LSb are considered (a nibble).
+ * 		   Decoding - Data byte to be decoded.
+ * @param encode - true - Encode
+ * 		   false - Decode
+ * @return A byte of data in case of encoding (the encoded nibble that turn into
+ * 	   a byte amid encoding) or a nibble of data (4 MSb have a value of 0).
+ */
+static uint8_t ades1754_manchester(uint8_t nibble, bool encode)
+{
+	bool bit0, bit1, bit2, bit3;
+	if (encode) {
+		bit0 = no_os_field_get(NO_OS_BIT(0), nibble);
+		bit1 = no_os_field_get(NO_OS_BIT(1), nibble);
+		bit2 = no_os_field_get(NO_OS_BIT(2), nibble);
+		bit3 = no_os_field_get(NO_OS_BIT(3), nibble);
+
+		nibble = no_os_field_prep(NO_OS_BIT(0), bit0) |
+			 no_os_field_prep(NO_OS_BIT(2), bit1) |
+			 no_os_field_prep(NO_OS_BIT(4), bit2) |
+			 no_os_field_prep(NO_OS_BIT(6), bit3);
+		nibble |= no_os_field_prep(NO_OS_BIT(1), !bit0) |
+			  no_os_field_prep(NO_OS_BIT(3), !bit1) |
+			  no_os_field_prep(NO_OS_BIT(5), !bit2) |
+			  no_os_field_prep(NO_OS_BIT(7), !bit3);
+
+		return nibble;
+	} else {
+		nibble = no_os_field_prep(NO_OS_BIT(1), no_os_field_get(NO_OS_BIT(2), nibble)) |
+			 no_os_field_prep(NO_OS_BIT(2), no_os_field_get(NO_OS_BIT(4), nibble)) |
+			 no_os_field_prep(NO_OS_BIT(3), no_os_field_get(NO_OS_BIT(6), nibble)) |
+			 no_os_field_get(NO_OS_BIT(0), nibble);
+
+		return nibble;
+	}
+}
+
+/**
+ * @brief ADES1754 HELLO ALL specific command message to wake-up devices
+ * 	  alongside daisy-chain.
+ * @param desc - ADES1754 device descriptor.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ades1754_hello_all(struct ades1754_desc *desc)
+{
+	uint8_t tx_data[8];
+	uint8_t rx_data[16];
+	int ret;
+
+	if (desc->uart_bridge) {
+		tx_data[0] = ADES1754_HELLO_ALL_BYTE;
+		tx_data[1] = 0x00;
+		tx_data[2] = desc->no_dev;
+
+		ret = no_os_uart_write(desc->uart_desc, tx_data, 3);
+		if (ret < 0)
+			return ret;
+
+		return no_os_uart_read(desc->uart_desc, rx_data, 3);
+	} else {
+		tx_data[0] = ADES1754_PREAMBLE_BYTE;
+		tx_data[1] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+						 ADES1754_HELLO_ALL_BYTE), true);
+		tx_data[2] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						 ADES1754_HELLO_ALL_BYTE), true);
+		tx_data[3] = ades1754_manchester(0x00, true);
+		tx_data[4] = ades1754_manchester(0x00, true);
+		tx_data[5] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						 desc->no_dev), true);
+		tx_data[6] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						 desc->no_dev), true);
+		tx_data[7] = ADES1754_STOP_BYTE;
+
+		ret = no_os_uart_write(desc->uart_desc, tx_data, 8);
+		if (ret < 0)
+			return ret;
+
+		return no_os_uart_read(desc->uart_desc, rx_data, 8);
+	}
+}
+
+/**
+ * @brief ADES1754 write device command message.
+ * @param desc - ADES1754 device descriptor.
+ * @param reg - Register Address.
+ * @param data - Data to be written.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ades1754_write_dev(struct ades1754_desc *desc, uint8_t reg, uint16_t data)
+{
+	uint8_t tx_data[12];
+	uint8_t crc[4];
+	uint8_t pec;
+	int ret;
+
+	if (desc->uart_bridge) {
+		tx_data[0] = no_os_field_prep(ADES1754_RW_ADDR_MASK,
+					      desc->dev_addr) | ADES1754_WR_MASK;
+		tx_data[1] = reg;
+		tx_data[2] = no_os_field_get(ADES1754_LSB_MASK, data);
+		tx_data[3] = no_os_field_get(ADES1754_MSB_MASK, data);
+
+		crc[0] = no_os_bit_swap_constant_8(tx_data[0]);
+		crc[1] = no_os_bit_swap_constant_8(tx_data[1]);
+		crc[2] = no_os_bit_swap_constant_8(tx_data[2]);
+		crc[3] = no_os_bit_swap_constant_8(tx_data[3]);
+
+		pec = no_os_crc8(crc_table, crc, 4, 0x00);
+
+		tx_data[4] = no_os_bit_swap_constant_8(pec);
+
+		return no_os_uart_write(desc->uart_desc, tx_data, 5);
+	} else {
+		tx_data[0] = ADES1754_PREAMBLE_BYTE;
+		tx_data[1] = no_os_field_prep(ADES1754_RW_ADDR_MASK,
+					      desc->dev_addr) | ADES1754_WR_MASK;
+		tx_data[2] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						 tx_data[1]), true);
+		tx_data[1] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+						 tx_data[1]), true);
+		tx_data[3] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+						 reg), true);
+		tx_data[4] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						 reg), true);
+		tx_data[5] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+						 no_os_field_get(ADES1754_LSB_MASK, data)), true);
+		tx_data[6] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						 no_os_field_get(ADES1754_LSB_MASK, data)), true);
+		tx_data[7] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+						 no_os_field_get(ADES1754_MSB_MASK, data)), true);
+		tx_data[8] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						 no_os_field_get(ADES1754_MSB_MASK, data)), true);
+
+		crc[0] = no_os_field_prep(ADES1754_RW_ADDR_MASK,
+					  desc->dev_addr) | ADES1754_WR_MASK;
+		crc[1] = reg;
+		crc[2] = no_os_field_get(ADES1754_LSB_MASK, data);
+		crc[3] = no_os_field_get(ADES1754_MSB_MASK, data);
+
+		crc[0] = no_os_bit_swap_constant_8(crc[0]);
+		crc[1] = no_os_bit_swap_constant_8(crc[1]);
+		crc[2] = no_os_bit_swap_constant_8(crc[2]);
+		crc[3] = no_os_bit_swap_constant_8(crc[3]);
+
+		pec = no_os_crc8(crc_table, crc, 4, 0x00);
+
+		tx_data[9] = no_os_bit_swap_constant_8(pec);
+		tx_data[10] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						  tx_data[9]), true);
+		tx_data[9] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+						 tx_data[9]), true);
+
+		tx_data[11] = ADES1754_STOP_BYTE;
+
+		ret = no_os_uart_write(desc->uart_desc, tx_data, 12);
+		if (ret < 0)
+			return ret;
+
+		return 0;
+	}
+}
+
+/**
+ * @brief ADES1754 write all command message.
+ * @param desc - ADES1754 device descriptor.
+ * @param reg - Register Address.
+ * @param data - Data to be written.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ades1754_write_all(struct ades1754_desc *desc, uint8_t reg, uint16_t data)
+{
+	uint8_t tx_data[12];
+	uint8_t crc[4];
+	uint8_t pec;
+
+	if (desc->uart_bridge) {
+		tx_data[0] = ADES1754_WR_ALL;
+		tx_data[1] = reg;
+		tx_data[2] = no_os_field_get(ADES1754_LSB_MASK, data);
+		tx_data[3] = no_os_field_get(ADES1754_MSB_MASK, data);
+
+		crc[0] = no_os_bit_swap_constant_8(tx_data[0]);
+		crc[1] = no_os_bit_swap_constant_8(tx_data[1]);
+		crc[2] = no_os_bit_swap_constant_8(tx_data[2]);
+		crc[3] = no_os_bit_swap_constant_8(tx_data[3]);
+
+		pec = no_os_crc8(crc_table, crc, 4, 0x00);
+
+		tx_data[4] = no_os_bit_swap_constant_8(pec);
+
+		return no_os_uart_write(desc->uart_desc, tx_data, 5);
+	} else {
+		tx_data[0] = ADES1754_PREAMBLE_BYTE;
+		tx_data[1] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+						 ADES1754_WR_ALL), true);
+		tx_data[2] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						 ADES1754_WR_ALL), true);
+		tx_data[3] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+						 reg), true);
+		tx_data[4] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						 reg), true);
+		tx_data[5] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+						 no_os_field_get(ADES1754_LSB_MASK, data)), true);
+		tx_data[6] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						 no_os_field_get(ADES1754_LSB_MASK, data)), true);
+		tx_data[7] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+						 no_os_field_get(ADES1754_MSB_MASK, data)), true);
+		tx_data[8] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						 no_os_field_get(ADES1754_MSB_MASK, data)), true);
+
+		crc[0] = ADES1754_WR_ALL;
+		crc[1] = reg;
+		crc[2] = no_os_field_get(ADES1754_LSB_MASK, data);
+		crc[3] = no_os_field_get(ADES1754_MSB_MASK, data);
+
+		crc[0] = no_os_bit_swap_constant_8(crc[0]);
+		crc[1] = no_os_bit_swap_constant_8(crc[1]);
+		crc[2] = no_os_bit_swap_constant_8(crc[2]);
+		crc[3] = no_os_bit_swap_constant_8(crc[3]);
+
+		pec = no_os_crc8(crc_table, crc, 4, 0x00);
+
+		tx_data[9] = no_os_bit_swap_constant_8(pec);
+		tx_data[10] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						  tx_data[9]), true);
+		tx_data[9] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+						 tx_data[9]), true);
+
+		tx_data[11] = ADES1754_STOP_BYTE;
+
+		return no_os_uart_write(desc->uart_desc, tx_data, 12);
+	}
+}
+
+/**
+ * @brief ADES1754 read device command message.
+ * @param desc - ADES1754 device descriptor.
+ * @param reg - Register Address.
+ * @param data - Data to be read.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ades1754_read_dev(struct ades1754_desc *desc, uint8_t reg, uint16_t *data)
+{
+	int ret, read_b = 0, retries = 0;
+	uint8_t rx_data[14] = { 0 };
+	uint8_t tx_data[14];
+	uint8_t crc[6];
+	uint8_t pec;
+
+	if (desc->uart_bridge) {
+		tx_data[0] = no_os_field_prep(ADES1754_RW_ADDR_MASK,
+					      desc->dev_addr) | ADES1754_RD_MASK;
+		tx_data[1] = reg;
+		tx_data[2] = ADES1754_DEFAULT_DC_BYTE_SEED;
+
+		crc[0] = no_os_bit_swap_constant_8(tx_data[0]);
+		crc[1] = no_os_bit_swap_constant_8(tx_data[1]);
+		crc[2] = no_os_bit_swap_constant_8(tx_data[2]);
+
+		pec = no_os_crc8(crc_table, crc, 3, 0x00);
+
+		tx_data[3] = no_os_bit_swap_constant_8(pec);
+		tx_data[4] = ADES1754_FILL_BYTE_C2;
+		tx_data[5] = ADES1754_FILL_BYTE_D3;
+
+		ret = no_os_uart_write(desc->uart_desc, tx_data, 6);
+		if (ret < 0)
+			return ret;
+
+		ret = no_os_uart_read(desc->uart_desc, rx_data, 7);
+		if (ret < 0)
+			return ret;
+
+		crc[0] = no_os_bit_swap_constant_8(rx_data[0]);
+		crc[1] = no_os_bit_swap_constant_8(rx_data[1]);
+		crc[2] = no_os_bit_swap_constant_8(rx_data[2]);
+		crc[3] = no_os_bit_swap_constant_8(rx_data[3]);
+		crc[4] = no_os_bit_swap_constant_8(rx_data[4]);
+		crc[5] = no_os_bit_swap_constant_8(rx_data[5]);
+
+		pec = no_os_crc8(crc_table, crc, 6, 0x00);
+		pec = no_os_bit_swap_constant_8(pec);
+		if (pec != rx_data[6])
+			return -EINVAL;
+
+		*data = no_os_field_prep(ADES1754_MSB_MASK, rx_data[3]) | rx_data[2];
+	} else {
+		tx_data[0] = ADES1754_PREAMBLE_BYTE;
+		tx_data[1] = no_os_field_prep(ADES1754_RW_ADDR_MASK,
+					      desc->dev_addr) | ADES1754_RD_MASK;
+		tx_data[2] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						 tx_data[1]), true);
+		tx_data[1] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+						 tx_data[1]), true);
+		tx_data[3] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+						 reg), true);
+		tx_data[4] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						 reg), true);
+		tx_data[5] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+						 ADES1754_DEFAULT_DC_BYTE_SEED), true);
+		tx_data[6] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						 ADES1754_DEFAULT_DC_BYTE_SEED), true);
+
+		crc[0] = ADES1754_PREAMBLE_BYTE;
+		crc[1] = no_os_field_prep(ADES1754_RW_ADDR_MASK,
+					  desc->dev_addr) | ADES1754_RD_MASK;
+		crc[2] = reg;
+		crc[3] = ADES1754_DEFAULT_DC_BYTE_SEED;
+
+		crc[0] = no_os_bit_swap_constant_8(crc[0]);
+		crc[1] = no_os_bit_swap_constant_8(crc[1]);
+		crc[2] = no_os_bit_swap_constant_8(crc[2]);
+		crc[3] = no_os_bit_swap_constant_8(crc[3]);
+
+		pec = no_os_crc8(crc_table, crc, 4, 0x00);
+		pec = no_os_bit_swap_constant_8(pec);
+		tx_data[7] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+						 pec), true);
+		tx_data[8] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						 pec), true);
+		tx_data[9] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						 ADES1754_FILL_BYTE_C2), true);
+		tx_data[10] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+						  ADES1754_FILL_BYTE_C2), true);
+		tx_data[11] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						  ADES1754_FILL_BYTE_D3), true);
+		tx_data[12] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+						  ADES1754_FILL_BYTE_D3), true);
+		tx_data[13] = ADES1754_STOP_BYTE;
+
+		ret = no_os_uart_write(desc->uart_desc, tx_data, 14);
+		if (ret < 0)
+			return ret;
+
+		while (read_b < 14) {
+			ret = no_os_uart_read(desc->uart_desc, &rx_data[read_b],
+					      14 - read_b);
+			if (ret >= 0)
+				read_b += ret;
+
+			retries++;
+			if (retries == 100)
+				return -ETIMEDOUT;
+		}
+
+		crc[0] = no_os_field_prep(ADES1754_UPPER_NIBBLE_MASK,
+					  ades1754_manchester(rx_data[2], false)) | ades1754_manchester(rx_data[1],
+							  false);
+		crc[1] = no_os_field_prep(ADES1754_UPPER_NIBBLE_MASK,
+					  ades1754_manchester(rx_data[4], false)) | ades1754_manchester(rx_data[3],
+							  false);
+		crc[2] = no_os_field_prep(ADES1754_UPPER_NIBBLE_MASK,
+					  ades1754_manchester(rx_data[6], false)) | ades1754_manchester(rx_data[5],
+							  false);
+		crc[3] = no_os_field_prep(ADES1754_UPPER_NIBBLE_MASK,
+					  ades1754_manchester(rx_data[8], false)) | ades1754_manchester(rx_data[7],
+							  false);
+		crc[4] = no_os_field_prep(ADES1754_UPPER_NIBBLE_MASK,
+					  ades1754_manchester(rx_data[10], false)) | ades1754_manchester(rx_data[9],
+							  false);
+		crc[5] = no_os_field_prep(ADES1754_UPPER_NIBBLE_MASK,
+					  ades1754_manchester(rx_data[12], false)) | ades1754_manchester(rx_data[11],
+							  false);
+
+		crc[0] = no_os_bit_swap_constant_8(crc[0]);
+		crc[1] = no_os_bit_swap_constant_8(crc[1]);
+		crc[2] = no_os_bit_swap_constant_8(crc[2]);
+		crc[3] = no_os_bit_swap_constant_8(crc[3]);
+		crc[4] = no_os_bit_swap_constant_8(crc[4]);
+
+		pec = no_os_crc8(crc_table, crc, 5, 0x00);
+		pec = no_os_bit_swap_constant_8(pec);
+
+		if (pec != crc[5] && rx_data[13] == ADES1754_STOP_BYTE)
+			return -EINVAL;
+
+		*data = no_os_field_prep(ADES1754_MSB_MASK, crc[4]) | crc[3];
+	}
+
+	return 0;
+}
+
+/**
+ * @brief ADES1754 read all command message.
+ * @param desc - ADES1754 device descriptor.
+ * @param reg - Register Address.
+ * @param data - Data to be read.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ades1754_read_all(struct ades1754_desc *desc, uint8_t reg, uint16_t *data)
+{
+	int ret, i, j, read_b = 0, retries = 0;
+	uint8_t tx_data[10 + 4 * desc->no_dev];
+	uint8_t rx_data[10 + 4 * desc->no_dev];
+	uint8_t crc[9 + 4 * desc->no_dev];
+	uint8_t pec;
+
+	if (desc->uart_bridge) {
+		tx_data[0] = ADES1754_RD_ALL;
+		tx_data[1] = reg;
+		tx_data[2] = ADES1754_DEFAULT_DC_BYTE_SEED;
+
+		crc[0] = no_os_bit_swap_constant_8(tx_data[0]);
+		crc[1] = no_os_bit_swap_constant_8(tx_data[1]);
+		crc[2] = no_os_bit_swap_constant_8(tx_data[2]);
+
+		pec = no_os_crc8(crc_table, crc, 4, 0x00);
+		tx_data[3] = no_os_bit_swap_constant_8(pec);
+
+		for (i = 0; i < 2 * desc->no_dev; i++) {
+			if (i % 2)
+				tx_data[i + 4] = ADES1754_FILL_BYTE_C2;
+			else
+				tx_data[i + 4] = ADES1754_FILL_BYTE_D3;
+		}
+
+		ret = no_os_uart_write(desc->uart_desc, tx_data,
+				       4 + 2 * desc->no_dev);
+		if (ret < 0)
+			return ret;
+
+		ret = no_os_uart_read(desc->uart_desc, rx_data,
+				      5 + 2 * desc->no_dev);
+		if (ret < 0)
+			return ret;
+
+		crc[0] = no_os_bit_swap_constant_8(rx_data[0]);
+		crc[1] = no_os_bit_swap_constant_8(rx_data[1]);
+		for (i = 0; i < 2 * desc->no_dev; i++)
+			crc[i + 2] = no_os_bit_swap_constant_8(rx_data[i + 2]);
+
+		crc[i + 2] = no_os_bit_swap_constant_8(rx_data[i + 2]);
+		crc[i + 3] = no_os_bit_swap_constant_8(rx_data[i + 3]);
+		pec = no_os_crc8(crc_table, crc, 4 + 2 * desc->no_dev, 0x00);
+		pec = no_os_bit_swap_constant_8(pec);
+		if (pec != rx_data[i + 4])
+			return -EINVAL;
+
+		for (j = 0; j < desc->no_dev; j++)
+			data[j] = no_os_field_prep(ADES1754_MSB_MASK,
+						   rx_data[3 + 2 * j]) | rx_data[2 + 2 * j];
+	} else {
+		tx_data[0] = ADES1754_PREAMBLE_BYTE;
+		tx_data[1] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+						 ADES1754_RD_ALL), true);
+		tx_data[2] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						 ADES1754_RD_ALL), true);
+		tx_data[3] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+						 reg), true);
+		tx_data[4] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						 reg), true);
+		tx_data[5] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+						 ADES1754_DEFAULT_DC_BYTE_SEED), true);
+		tx_data[6] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						 ADES1754_DEFAULT_DC_BYTE_SEED), true);
+
+		crc[0] = ADES1754_RD_ALL;
+		crc[1] = reg;
+		crc[2] = ADES1754_DEFAULT_DC_BYTE_SEED;
+
+		crc[0] = no_os_bit_swap_constant_8(crc[0]);
+		crc[1] = no_os_bit_swap_constant_8(crc[1]);
+		crc[2] = no_os_bit_swap_constant_8(crc[2]);
+
+		pec = no_os_crc8(crc_table, crc, 4, 0x00);
+		pec = no_os_bit_swap_constant_8(pec);
+
+		tx_data[7] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+						 pec), true);
+		tx_data[8] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						 pec), true);
+
+		for (i = 0; i < 4 * desc->no_dev; i++) {
+			switch (i % 4) {
+			case 0:
+				tx_data[i + 9] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+								     ADES1754_FILL_BYTE_C2), true);
+				break;
+			case 1:
+				tx_data[i + 9] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+								     ADES1754_FILL_BYTE_C2), true);
+				break;
+			case 2:
+				tx_data[i + 9] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+								     ADES1754_FILL_BYTE_D3), true);
+				break;
+			case 3:
+				tx_data[i + 9] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+								     ADES1754_FILL_BYTE_D3), true);
+				break;
+			default:
+				return -EINVAL;
+			}
+		}
+		tx_data[i + 9] = ADES1754_STOP_BYTE;
+
+		ret = no_os_uart_write(desc->uart_desc, tx_data, i + 10);
+		if (ret < 0)
+			return ret;
+
+		while (read_b < 10 + 4 * desc->no_dev) {
+			ret = no_os_uart_read(desc->uart_desc, &rx_data[read_b],
+					      (10 + 4 * desc->no_dev) - read_b);
+			if (ret >= 0)
+				read_b += ret;
+			else {
+				retries++;
+				if (retries > 100)
+					return -ETIMEDOUT;
+			}
+		}
+
+		crc[0] = no_os_field_prep(ADES1754_UPPER_NIBBLE_MASK,
+					  ades1754_manchester(rx_data[2], false)) | ades1754_manchester(rx_data[1],
+							  false);
+		crc[1] = no_os_field_prep(ADES1754_UPPER_NIBBLE_MASK,
+					  ades1754_manchester(rx_data[4], false)) | ades1754_manchester(rx_data[3],
+							  false);
+
+		for (i = 0; i < 2 * desc->no_dev; i++)
+			crc[i + 2] = no_os_field_prep(ADES1754_UPPER_NIBBLE_MASK,
+						      ades1754_manchester(rx_data[2 * (i + 2)],
+								      false)) | ades1754_manchester(rx_data[2 * (i + 2) - 1], false);
+
+		crc[i + 2] = no_os_field_prep(ADES1754_UPPER_NIBBLE_MASK,
+					      ades1754_manchester(rx_data[2 * (i + 2)],
+							      false)) | ades1754_manchester(rx_data[2 * (i + 2) - 1], false);
+		crc[i + 3] = no_os_field_prep(ADES1754_UPPER_NIBBLE_MASK,
+					      ades1754_manchester(rx_data[2 * (i + 3)],
+							      false)) | ades1754_manchester(rx_data[2 * (i + 3) - 1], false);
+
+		for (j = 0; j < i + 3; i++)
+			crc[j] = no_os_bit_swap_constant_8(crc[j]);
+
+		pec = no_os_crc8(crc_table, crc, 3 + 2 * desc->no_dev, 0x00);
+		pec = no_os_bit_swap_constant_8(pec);
+		if (pec != crc[i + 3] && rx_data[11 + (4 * desc->no_dev)] == ADES1754_STOP_BYTE)
+			return -EINVAL;
+
+		j = 0;
+		for (i = 3; i < 3 + 2 * desc->no_dev; i += 4) {
+			data[j] = no_os_field_prep(ADES1754_MSB_MASK,
+						   no_os_bit_swap_constant_8(crc[i + 1])) | no_os_bit_swap_constant_8(crc[i]);
+			j++;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief ADES1754 read block command message.
+ * @param desc - ADES1754 device descriptor.
+ * @param block - Block number.
+ * @param reg - Register Address.
+ * @param data - Data to be read.
+ * @param double_size - true - Block is double sized (16 bits).
+ * 			false - Block is single sized (8 bits).
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ades1754_read_block(struct ades1754_desc *desc, uint8_t block, uint8_t reg,
+			uint16_t *data, bool double_size)
+{
+	int ret, read_b = 0, retries = 0;
+	uint8_t tx_data[20];
+	uint8_t rx_data[20];
+	uint8_t crc[9];
+	uint8_t pec;
+
+	if (desc->uart_bridge) {
+		tx_data[0] = no_os_field_prep(ADES1754_RW_ADDR_MASK, block) | ADES1754_BL_MASK;
+		tx_data[1] = desc->dev_addr;
+		tx_data[2] = reg;
+		tx_data[3] = ADES1754_DEFAULT_DC_BYTE_SEED;
+
+		crc[0] = no_os_bit_swap_constant_8(tx_data[0]);
+		crc[1] = no_os_bit_swap_constant_8(tx_data[1]);
+		crc[2] = no_os_bit_swap_constant_8(tx_data[2]);
+		crc[3] = no_os_bit_swap_constant_8(tx_data[3]);
+
+		pec = no_os_crc8(crc_table, crc, 4, 0x00);
+		tx_data[4] = no_os_bit_swap_constant_8(pec);
+		tx_data[5] = ADES1754_FILL_BYTE_C2;
+		tx_data[6] = ADES1754_FILL_BYTE_D3;
+
+		if (double_size) {
+			tx_data[7] = ADES1754_FILL_BYTE_C2;
+			tx_data[8] = ADES1754_FILL_BYTE_D3;
+
+			ret = no_os_uart_write(desc->uart_desc, tx_data, 9);
+			if (ret < 0)
+				return ret;
+
+			ret = no_os_uart_read(desc->uart_desc, rx_data, 10);
+			if (ret < 0)
+				return ret;
+		} else {
+			ret = no_os_uart_write(desc->uart_desc, tx_data, 7);
+			if (ret < 0)
+				return ret;
+
+			ret = no_os_uart_read(desc->uart_desc, rx_data, 8);
+			if (ret < 0)
+				return ret;
+		}
+
+		crc[0] = no_os_bit_swap_constant_8(rx_data[0]);
+		crc[1] = no_os_bit_swap_constant_8(rx_data[1]);
+		crc[2] = no_os_bit_swap_constant_8(rx_data[2]);
+		crc[3] = no_os_bit_swap_constant_8(rx_data[3]);
+		crc[4] = no_os_bit_swap_constant_8(rx_data[4]);
+		crc[5] = no_os_bit_swap_constant_8(rx_data[5]);
+		crc[6] = no_os_bit_swap_constant_8(rx_data[6]);
+
+		if (double_size) {
+			crc[6] = no_os_bit_swap_constant_8(rx_data[6]);
+			crc[7] = no_os_bit_swap_constant_8(rx_data[7]);
+			crc[8] = no_os_bit_swap_constant_8(rx_data[8]);
+
+			pec = no_os_crc8(crc_table, crc, 9, 0x00);
+			pec = no_os_bit_swap_constant_8(pec);
+			if (pec != rx_data[9])
+				return -EINVAL;
+
+			data[0] = no_os_field_prep(ADES1754_MSB_MASK, rx_data[5]) | rx_data[4];
+			data[1] = no_os_field_prep(ADES1754_MSB_MASK, rx_data[7]) | rx_data[5];
+		} else {
+			pec = no_os_crc8(crc_table, crc, 7, 0x00);
+			pec = no_os_bit_swap_constant_8(pec);
+			if (pec != rx_data[7])
+				return -EINVAL;
+
+			*data = no_os_field_prep(ADES1754_MSB_MASK, rx_data[5]) | rx_data[4];
+		}
+	} else {
+		tx_data[0] = ADES1754_PREAMBLE_BYTE;
+		tx_data[1] = no_os_field_prep(ADES1754_RW_ADDR_MASK, block) | ADES1754_BL_MASK;
+		tx_data[2] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						 tx_data[1]), true);
+		tx_data[1] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+						 tx_data[1]), true);
+		tx_data[3] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+						 desc->dev_addr), true);
+		tx_data[4] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						 desc->dev_addr), true);
+		tx_data[5] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+						 reg), true);
+		tx_data[6] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						 reg), true);
+		tx_data[7] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+						 ADES1754_DEFAULT_DC_BYTE_SEED), true);
+		tx_data[8] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						 ADES1754_DEFAULT_DC_BYTE_SEED), true);
+
+		crc[0] = ADES1754_PREAMBLE_BYTE;
+		crc[1] = no_os_field_prep(ADES1754_RW_ADDR_MASK, block) | ADES1754_BL_MASK;
+		crc[2] = desc->dev_addr;
+		crc[3] = reg;
+		crc[4] = ADES1754_DEFAULT_DC_BYTE_SEED;
+
+		crc[0] = no_os_bit_swap_constant_8(crc[0]);
+		crc[1] = no_os_bit_swap_constant_8(crc[1]);
+		crc[2] = no_os_bit_swap_constant_8(crc[2]);
+		crc[3] = no_os_bit_swap_constant_8(crc[3]);
+		crc[4] = no_os_bit_swap_constant_8(crc[4]);
+
+		pec = no_os_crc8(crc_table, crc, 5, 0x00);
+		pec = no_os_bit_swap_constant_8(pec);
+		tx_data[9] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+						 pec), true);
+		tx_data[10] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						  pec), true);
+		tx_data[11] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+						  ADES1754_FILL_BYTE_C2), true);
+		tx_data[12] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						  ADES1754_FILL_BYTE_C2), true);
+		tx_data[13] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+						  ADES1754_FILL_BYTE_D3), true);
+		tx_data[14] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+						  ADES1754_FILL_BYTE_D3), true);
+		tx_data[15] = ADES1754_STOP_BYTE;
+
+		if (double_size) {
+			tx_data[15] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+							  ADES1754_FILL_BYTE_C2), true);
+			tx_data[16] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+							  ADES1754_FILL_BYTE_C2), true);
+			tx_data[17] = ades1754_manchester(no_os_field_get(ADES1754_LOWER_NIBBLE_MASK,
+							  ADES1754_FILL_BYTE_D3), true);
+			tx_data[18] = ades1754_manchester(no_os_field_get(ADES1754_UPPER_NIBBLE_MASK,
+							  ADES1754_FILL_BYTE_D3), true);
+
+			tx_data[19] = ADES1754_STOP_BYTE;
+
+			ret = no_os_uart_write(desc->uart_desc, tx_data, 20);
+			if (ret < 0)
+				return ret;
+
+			while (read_b < 20) {
+				ret = no_os_uart_read(desc->uart_desc, &rx_data[read_b], 20 - read_b);
+				if (ret >= 0)
+					read_b += ret;
+				else {
+					retries++;
+					if (retries > 100)
+						return -ETIMEDOUT;
+				}
+			}
+		} else {
+			ret = no_os_uart_write(desc->uart_desc, tx_data, 16);
+			if (ret < 0)
+				return ret;
+
+			while (read_b < 16) {
+				ret = no_os_uart_read(desc->uart_desc, &rx_data[read_b], 16 - read_b);
+				if (ret >= 0)
+					read_b += ret;
+				else {
+					retries++;
+					if (retries > 100)
+						return -ETIMEDOUT;
+				}
+			}
+		}
+
+		crc[0] = no_os_field_prep(ADES1754_UPPER_NIBBLE_MASK,
+					  ades1754_manchester(rx_data[2], false)) | ades1754_manchester(rx_data[1],
+							  false);
+		crc[1] = no_os_field_prep(ADES1754_UPPER_NIBBLE_MASK,
+					  ades1754_manchester(rx_data[4], false)) | ades1754_manchester(rx_data[3],
+							  false);
+		crc[2] = no_os_field_prep(ADES1754_UPPER_NIBBLE_MASK,
+					  ades1754_manchester(rx_data[6], false)) | ades1754_manchester(rx_data[5],
+							  false);
+		crc[3] = no_os_field_prep(ADES1754_UPPER_NIBBLE_MASK,
+					  ades1754_manchester(rx_data[8], false)) | ades1754_manchester(rx_data[7],
+							  false);
+		crc[4] = no_os_field_prep(ADES1754_UPPER_NIBBLE_MASK,
+					  ades1754_manchester(rx_data[10], false)) | ades1754_manchester(rx_data[9],
+							  false);
+		crc[5] = no_os_field_prep(ADES1754_UPPER_NIBBLE_MASK,
+					  ades1754_manchester(rx_data[12], false)) | ades1754_manchester(rx_data[11],
+							  false);
+		crc[6] = no_os_field_prep(ADES1754_UPPER_NIBBLE_MASK,
+					  ades1754_manchester(rx_data[14], false)) | ades1754_manchester(rx_data[13],
+							  false);
+
+		if (double_size) {
+			crc[7] = no_os_field_prep(ADES1754_UPPER_NIBBLE_MASK,
+						  ades1754_manchester(rx_data[16], false)) | ades1754_manchester(rx_data[15],
+								  false);
+			crc[8] = no_os_field_prep(ADES1754_UPPER_NIBBLE_MASK,
+						  ades1754_manchester(rx_data[18], false)) | ades1754_manchester(rx_data[17],
+								  false);
+
+			crc[0] = no_os_bit_swap_constant_8(crc[0]);
+			crc[1] = no_os_bit_swap_constant_8(crc[1]);
+			crc[2] = no_os_bit_swap_constant_8(crc[2]);
+			crc[3] = no_os_bit_swap_constant_8(crc[3]);
+			crc[4] = no_os_bit_swap_constant_8(crc[4]);
+			crc[5] = no_os_bit_swap_constant_8(crc[5]);
+			crc[6] = no_os_bit_swap_constant_8(crc[6]);
+			crc[7] = no_os_bit_swap_constant_8(crc[7]);
+
+			pec = no_os_crc8(crc_table, crc, 8, 0x00);
+			pec = no_os_bit_swap_constant_8(pec);
+			if (pec != crc[8] && rx_data[19] == ADES1754_STOP_BYTE)
+				return -EINVAL;
+
+			data[0] = no_os_field_prep(ADES1754_MSB_MASK, crc[5]) | crc[4];
+			data[1] = no_os_field_prep(ADES1754_MSB_MASK, crc[7]) | crc[6];
+		} else {
+			pec = no_os_crc8(crc_table, crc, 6, 0x00);
+			pec = no_os_bit_swap_constant_8(pec);
+			if (pec != crc[6] && rx_data[15] == ADES1754_STOP_BYTE)
+				return -EINVAL;
+
+			*data = no_os_field_prep(ADES1754_MSB_MASK, crc[5]) | crc[4];
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief ADES1754 update device command message.
+ * @param desc - ADES1754 device descriptor.
+ * @param reg - Register Address.
+ * @param mask - Mask of field to be updated.
+ * @param val - Data to be updated.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ades1754_update_dev(struct ades1754_desc *desc, uint8_t reg, uint16_t mask,
+			uint16_t val)
+{
+	uint16_t reg_val;
+	int ret;
+
+	ret = ades1754_read_dev(desc, reg, &reg_val);
+	if (ret < 0)
+		return ret;
+
+	reg_val &= ~mask;
+	reg_val |= no_os_field_prep(mask, val);
+
+	return ades1754_write_dev(desc, reg, reg_val);
+}
+
+/**
+ * @brief Set ADC scan method.
+ * @param desc - ADES1754 device descriptor.
+ * @param scan_method - Specific pre-defined value for the Scan Method.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ades1754_set_adc_method(struct ades1754_desc *desc,
+			    enum ades1754_scan_method scan_method)
+{
+	return ades1754_update_dev(desc, ADES1754_SCANCTRL_REG,
+				   ADES1754_ADC_METHOD_MASK, scan_method);
+}
+
+/**
+ * @brief Select Scan Mode of the cells.
+ * @param desc - ADES1754 device descriptor.
+ * @param mode - Specific pre-defined value for the Cell Scan Mode.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ades1754_switch_scan_mode(struct ades1754_desc *desc,
+			      enum ades1754_scan_mode mode)
+{
+	int ret;
+
+	ret = ades1754_update_dev(desc, ADES1754_SCANCTRL_REG,
+				  ADES1754_SCAN_MODE_MASK, mode);
+	if (ret < 0)
+		return ret;
+
+	desc->scan_mode = mode;
+
+	return 0;
+}
+
+/**
+ * @brief Set Cell Polarity.
+ * @param desc - ADES1754 device descriptor.
+ * @param cell_polarity - Specific pre-defined value for cell polarity.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ades1754_set_cell_pol(struct ades1754_desc *desc,
+			  enum ades1754_cell_polarity cell_polarity)
+{
+	uint16_t reg_val = 0;
+	unsigned int i;
+	int ret;
+
+	reg_val = cell_polarity | no_os_field_prep(ADES1754_CELL_POLARITY_MASK,
+			cell_polarity);
+
+	ret = ades1754_write_dev(desc, ADES1754_POLARITYCTRL_REG, reg_val);
+	if (ret < 0)
+		return ret;
+
+	desc->cell_polarity = cell_polarity;
+
+	return 0;
+}
+
+/**
+ * @brief ADES1754 Start/Stop Scanning function.
+ * @param desc - ADES1754 device descriptor.
+ * @param meas - true - Starts scan.
+ * 		 false - Stops scan.
+ * @param cell_mask - Specific Cell Mask word (each bit set means the cell
+ * 		      is selected for measurement).
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ades1754_start_scan(struct ades1754_desc *desc, bool meas,
+			uint16_t cell_mask)
+{
+	int ret;
+
+	if (cell_mask > NO_OS_GENMASK(14, 1))
+		return -EINVAL;
+
+	ret = ades1754_write_dev(desc, ADES1754_MEASUREEN1_REG, cell_mask);
+	if (ret < 0)
+		return ret;
+
+	return ades1754_update_dev(desc, ADES1754_SCANCTRL_REG,
+				   ADES1754_SCAN_REQUEST_MASK, meas);
+}
+
+/**
+ * @brief ADES1754 read cell data.
+ * @param desc - ADES1754 device descriptor.
+ * @param cell_nb - Selected Cell Number (0 to 15).
+ * @param cell_voltage - Raw Cell Voltage data.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ades1754_get_cell_data(struct ades1754_desc *desc, uint8_t cell_nb,
+			   int32_t *cell_voltage)
+{
+	uint16_t reg_val;
+	int ret;
+
+	ret = ades1754_read_dev(desc, ADES1754_CELLN_REG(cell_nb), &reg_val);
+	if (ret < 0)
+		return ret;
+
+	*cell_voltage = reg_val;
+
+	if (no_os_field_get(NO_OS_BIT(cell_nb), desc->cell_polarity))
+		*cell_voltage = no_os_sign_extend32(reg_val, 13);
+
+	return 0;
+}
+
+/**
+ * @brief Set IIR filter coefficient.
+ * @param desc - ADES1754 device descriptor.
+ * @param coef - Specific pre-defined IIR coefficient value.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ades1754_set_iir(struct ades1754_desc *desc,
+		     enum ades1754_iir_filter_coef coef)
+{
+	return ades1754_update_dev(desc, ADES1754_DEVCFG2_REG,
+				   ADES1754_IIR_MASK, coef);
+}
+
+/**
+ * @brief Set speciic IIR filter settings.
+ * @param desc - ADES1754 device descriptor.
+ * @param alrtfilt - true - Alert Issuance Based on IIR Filter Results.
+ * 		     false - Alert Issuance Based on Raw Sequencer Results.
+ * @param acc - true - ADC result is included in the IIR accumulator.
+ * 		false - ADC result is not included in the IIR accumulator.
+ * @param output - true - IIR Filtered ADC data is loaded into the output data
+ * 		          registers.
+ * 		   false - Unfiltered ADC data is loaded into the output data
+ * 			   registers.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ades1754_set_iir_ctrl(struct ades1754_desc *desc, bool alrtfilt, bool acc,
+			  bool output)
+{
+	uint16_t val;
+
+	val = no_os_field_prep(ADES1754_ALRTFILT_MASK, alrtfilt);
+	val |= no_os_field_prep(ADES1754_AMENDFILT_MASK, acc);
+	val |= no_os_field_prep(ADES1754_RDFILT_MASK, output);
+
+	return ades1754_update_dev(desc, ADES1754_SCANCTRL_REG,
+				   ADES1754_IIR_SCAN_MASK, val);
+}
+
+/**
+ * @brief Set Buffer mode for data acquisition.
+ * @param desc - ADES1754 device descriptor.
+ * @param mode - Specific pre-defined value for Buffer mode.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ades1754_set_buffer_mode(struct ades1754_desc *desc,
+			     enum ades1754_buffer_mode mode)
+{
+	return ades1754_update_dev(desc, ADES1754_DEVCFG_REG,
+				   ADES1754_DBLBUFEN_MASK, mode);
+}
+
+/**
+ * @brief Set specific alert thershold value.
+ * @param desc - ADES1754 device descriptor.
+ * @param alert - Specific pre-defined Alert selection.
+ * @param thr - Threshold value.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ades1754_set_alert_thr(struct ades1754_desc *desc,
+			   enum ades1754_alert alert,
+			   uint16_t thr)
+{
+	uint8_t reg, reg2;
+	uint16_t mask;
+	int ret;
+
+	switch (alert) {
+	case ADES1754_CELL_OV:
+		mask = NO_OS_GENMASK(15, 2);
+		reg = ADES1754_OVTHCLR_REG;
+		reg2 = ADES1754_OVTHSET_REG;
+		break;
+	case ADES1754_CELL_UV:
+		mask = NO_OS_GENMASK(15, 2);
+		reg = ADES1754_UVTHCLR_REG;
+		reg2 = ADES1754_UVTHSET_REG;
+		break;
+	case ADES1754_BIPOLAR_OV:
+		mask = NO_OS_GENMASK(15, 2);
+		reg = ADES1754_BIPOVTHCLR_REG;
+		reg2 = ADES1754_BIPOVTHSET_REG;
+		break;
+	case ADES1754_BIPOLAR_UV:
+		mask = NO_OS_GENMASK(15, 2);
+		reg = ADES1754_BIPUVTHCLR_REG;
+		reg2 = ADES1754_BIPUVTHSET_REG;
+		break;
+	case ADES1754_BLOCK_OV:
+		mask = NO_OS_GENMASK(15, 2);
+		reg = ADES1754_BLKOVTHCLR_REG;
+		reg2 = ADES1754_BLKOVTHSET_REG;
+		break;
+	case ADES1754_BLOCK_UV:
+		mask = NO_OS_GENMASK(15, 2);
+		reg = ADES1754_BLKUVTHCLR_REG;
+		reg2 = ADES1754_BLKUVTHSET_REG;
+		break;
+	case ADES1754_CELL_MISMATCH:
+		mask = NO_OS_GENMASK(15, 2);
+
+		return ades1754_write_dev(desc, ADES1754_MSMTCH_REG,
+					  no_os_field_prep(mask, thr));
+	case ADES1754_AUXIN_OV:
+		mask = NO_OS_GENMASK(15, 2);
+		reg = ADES1754_AUXAOVTHCLR_REG;
+		reg2 = ADES1754_AUXAOVTHSET_REG;
+		break;
+	case ADES1754_AUXIN_UV:
+		mask = NO_OS_GENMASK(15, 2);
+		reg = ADES1754_AUXAUVTHCLR_REG;
+		reg2 = ADES1754_AUXAUVTHSET_REG;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	ret = ades1754_write_dev(desc, reg, no_os_field_prep(mask, thr));
+	if (ret < 0)
+		return ret;
+
+	return ades1754_write_dev(desc, reg2, no_os_field_prep(mask, thr));
+}
+
+/**
+ * @brief Read specific alert state.
+ * @param desc - ADES1754 device descriptor.
+ * @param alert - Specific pre-defined Alert selection.
+ * @param enable - true - Specific alert has triggered.
+ * 		   false - Specific alert didn't trigger.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ades1754_get_alert(struct ades1754_desc *desc, enum ades1754_alert alert,
+		       bool *enable)
+{
+	uint16_t mask, reg_val;
+	int ret;
+
+	switch (alert) {
+	case ADES1754_CELL_OV:
+	case ADES1754_BIPOLAR_OV:
+		mask = NO_OS_BIT(12);
+		break;
+	case ADES1754_CELL_UV:
+	case ADES1754_BIPOLAR_UV:
+		mask = NO_OS_BIT(11);
+		break;
+	case ADES1754_BLOCK_OV:
+		mask = NO_OS_BIT(10);
+		break;
+	case ADES1754_BLOCK_UV:
+		mask = NO_OS_BIT(9);
+		break;
+	case ADES1754_CELL_MISMATCH:
+		mask = NO_OS_BIT(13);
+		break;
+	case ADES1754_AUXIN_OV:
+		mask = NO_OS_BIT(8);
+		break;
+	case ADES1754_AUXIN_UV:
+		mask = NO_OS_BIT(7);
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	ret = ades1754_read_dev(desc, ADES1754_STATUS1_REG, &reg_val);
+	if (ret < 0)
+		return ret;
+
+	*enable = no_os_field_get(mask, reg_val);
+
+	return 0;
+}
+
+/**
+ * @brief Set Cell Balancing mode.
+ * @param desc - ADES1754 device descriptor.
+ * @param mode - Specfic pre-defined value for Cell Balancing mode.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ades1754_set_balancing_mode(struct ades1754_desc *desc,
+				enum ades1754_bal_mode mode)
+{
+	return ades1754_update_dev(desc, ADES1754_BALCTRL_REG,
+				   ADES1754_CBMODE_MASK, mode);
+}
+
+/**
+ * @brief Cell-Ballancing Measurement Enable/Disable.
+ * @param desc - ADES1754 device descriptor.
+ * @param meas - Specific pre-defined value for Cell-Balancing Measurement
+ * 		 state.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ades1754_set_balancing_meas(struct ades1754_desc *desc,
+				enum ades1754_bal_meas meas)
+{
+	return ades1754_update_dev(desc, ADES1754_BALCTRL_REG,
+				   ADES1754_CBMEASEN_MASK, meas);
+}
+
+/**
+ * @brief Cell-Balancing Calibration Period Selection
+ * @param desc - ADES1754 device descriptor.
+ * @param calib - Specific pre-defined value for Cell-Balancing Calibration
+ * 		  Period number.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ades1754_set_balancing_calib(struct ades1754_desc *desc,
+				 enum ades1754_bal_calib calib)
+{
+	return ades1754_update_dev(desc, ADES1754_BALDLYCTRL_REG,
+				   ADES1754_CBCALDLY_MASK, calib);
+}
+
+/**
+ * @brief ADES1754 device intialization function.
+ * @param desc - ADES1754 device descriptor.
+ * @param init_param - ADES1754 initialization parameter.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ades1754_init(struct ades1754_desc **desc,
+		  struct ades1754_init_param *init_param)
+{
+	struct ades1754_desc *descriptor;
+	int ret;
+
+	if (init_param->dev_addr > ADES1754_DEV_ADDR_MAX)
+		return -EINVAL;
+
+	descriptor = (struct ades1754_desc *)no_os_calloc(sizeof(*descriptor),
+			1);
+	if (!descriptor)
+		return -ENOMEM;
+
+	ret = no_os_uart_init(&descriptor->uart_desc,
+			      init_param->uart_param);
+	if (ret)
+		goto free_desc;
+
+	no_os_crc8_populate_msb(crc_table, 0x4D); // 0xB2 if 0xA6 doesn't work
+
+	descriptor->uart_bridge = init_param->uart_bridge;
+	descriptor->dev_addr = init_param->dev_addr;
+	descriptor->no_dev = init_param->no_dev;
+
+	ret = ades1754_hello_all(descriptor);
+	if (ret < 0)
+		goto free_comm;
+
+	descriptor->alive = false;
+	descriptor->id = init_param->id;
+
+	*desc = descriptor;
+
+	return 0;
+
+free_comm:
+	no_os_uart_remove(descriptor->uart_desc);
+free_desc:
+	no_os_free(descriptor);
+
+	return ret;
+}
+
+/**
+ * @brief Deallocate any resources used by the initialization function.@
+ * @param desc - ADES1754 device descriptor.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ades1754_remove(struct ades1754_desc *desc)
+{
+	no_os_mdelay(10);
+	no_os_uart_remove(desc->uart_desc);
+	no_os_free(desc);
+
+	return 0;
+}

--- a/drivers/power/ades1754/ades1754.h
+++ b/drivers/power/ades1754/ades1754.h
@@ -1,0 +1,388 @@
+/***************************************************************************//**
+ *   @file   ades1754.h
+ *   @brief  Header file for the ADES1754 Driver
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __ADES1754_H__
+#define __ADES1754_H__
+
+#include "no_os_spi.h"
+#include "no_os_uart.h"
+#include "no_os_util.h"
+#include "no_os_units.h"
+
+#define ADES1754_VERSION_REG			0x00
+#define ADES1754_ADDRESS_REG			0x01
+#define ADES1754_STATUS1_REG			0x02
+#define ADES1754_STATUS2_REG			0x03
+#define ADES1754_STATUS3_REG			0x04
+#define ADES1754_FMEA1_REG			0x05
+#define ADES1754_FMEA2_REG			0x06
+#define ADES1754_ALRTSUM_REG			0x07
+#define ADES1754_ALRTOVCELL_REG			0x08
+#define ADES1754_ALRTUVCELL_REG			0x09
+#define ADES1754_MINMAXCELL_REG			0x0A
+#define ADES1754_ALRTAUXPRTCT_REG		0x0B
+#define ADES1754_ALRTUAUXOV_REG			0x0C
+#define ADES1754_ALRTAUXUV_REG			0x0D
+#define ADES1754_ALRTCOMPOVR_REG		0x0E
+#define ADES1754_ALRTCOMPUVR_REG		0x0F
+#define ADES1754_ALRTCOMPAUXOVR_REG		0x10
+#define ADES1754_ALRTCOMPAUXUV_REG		0x11
+#define ADES1754_ALRTBALSWRE_REG		0x12
+#define ADES1754_SWACTION_REG			0x13
+#define ADES1754_DEVCFG_REG			0x14
+#define ADES1754_DEVCFG2_REG			0x15
+#define ADES1754_AUXGPIOCFG_REG			0x16
+#define ADES1754_GPIOCFG_REG			0x17
+#define ADES1754_PACKCFG_REG			0x18
+
+#define ADES1754_ALRTIRQEN_REG			0x19
+#define ADES1754_ALRTOVEN_REG			0x1A
+#define ADES1754_ALRTUVEN_REG			0x1B
+#define ADES1754_ALRTAUXOVEN_REG		0x1C
+#define ADES1754_ALRTAUXUVEN_REG		0x1D
+#define ADES1754_ALRTCALTST_REG			0x1E
+
+#define ADES1754_OVTHCLR_REG			0x1F
+#define ADES1754_OVTHSET_REG			0x20
+#define ADES1754_UVTHCLR_REG			0x21
+#define ADES1754_UVTHSET_REG			0x22
+#define ADES1754_MSMTCH_REG			0x23
+#define ADES1754_BIPOVTHCLR_REG			0x24
+#define ADES1754_BIPOVTHSET_REG			0x25
+#define ADES1754_BIPUVTHCLR_REG			0x26
+#define ADES1754_BIPUVTHSET_REG			0x27
+#define ADES1754_BLKOVTHCLR_REG			0x28
+#define ADES1754_BLKOVTHSET_REG			0x29
+#define ADES1754_BLKUVTHCLR_REG			0x2A
+#define ADES1754_BLKUVTHSET_REG			0x2B
+#define ADES1754_AUXROVTHCLR_REG		0x30
+#define ADES1754_AUXROVTHSET_REG		0x31
+#define ADES1754_AUXRUVTHCLR_REG		0x32
+#define ADES1754_AUXRUVTHSET_REG		0x33
+#define ADES1754_AUXAOVTHCLR_REG		0x34
+#define ADES1754_AUXAOVTHSET_REG		0x35
+#define ADES1754_AUXAUVTHCLR_REG		0x36
+#define ADES1754_AUXAUVTHSET_REG		0x37
+#define ADES1754_COMPOVTH_REG			0x38
+#define ADES1754_COMPUVTH_REG			0x39
+#define ADES1754_COMPAUXROVTH_REG		0x3A
+#define ADES1754_COMPAUXRUVTH_REG		0x3B
+#define ADES1754_COMPAUXAOVTH_REG		0x3C
+#define ADES1754_COMPAUXAUVTH_REG		0x3D
+
+#define ADES1754_COMPOPNTH_REG			0x3E
+#define ADES1754_COMPAUXROPNTH_REG		0x3F
+#define ADES1754_COMPAUXOPNTH_REG		0x40
+#define ADES1754_COMPACCOVTH_REG		0x41
+#define ADES1754_COMPACCUVTH_REG		0x42
+#define ADES1754_BALSHRTTHR_REG			0x43
+#define ADES1754_BALLOWTHR_REG			0x44
+#define ADES1754_BALHIGHTHR_REG			0x45
+
+#define ADES1754_CELLN_REG(n)			(0x47 + (n))
+#define ADES1754_BLOCK_REG			0x55
+
+#define ADES1754_TOTAL_REG			0x56
+#define ADES1754_DIAG1_REG			0x57
+#define ADES1754_DIAG2_REG			0x58
+#define ADES1754_AUX0_REG			0x59
+#define ADES1754_AUX1_REG			0x5A
+#define ADES1754_AUX2_REG			0x5B
+#define ADES1754_AUX3_REG			0x5C
+#define ADES1754_AUX4_REG			0x5D
+#define ADES1754_AUX5_REG			0x5E
+
+#define ADES1754_POLARITYCTRL_REG		0x5F
+#define ADES1754_AUXREFCTRL_REG			0x60
+#define ADES1754_AUXTIME_REG			0x61
+#define ADES1754_ACQCFG_REG			0x62
+#define ADES1754_BALSWDLY_REG			0x63
+
+#define ADES1754_MEASUREEN1_REG			0x64
+#define ADES1754_MEASUREEN2_REG			0x65
+#define ADES1754_SCANCTRL_REG			0x66
+
+#define ADES1754_ADCTEST1A_REG			0x67
+#define ADES1754_ADCTEST1B_REG			0x68
+#define ADES1754_ADCTEST2A_REG			0x69
+#define ADES1754_ADCTEST2B_REG			0x6A
+#define ADES1754_DIAGCFG_REG			0x6B
+#define ADES1754_CTSTCFG_REG			0x6C
+#define ADES1754_AUXTSTCFG_REG			0x6D
+#define ADES1754_DIAGGENCFG_REG			0x6E
+
+#define ADES1754_BALSWCTRL_REG			0x6F
+#define ADES1754_BALEXP1_REG			0x70
+#define ADES1754_BALEXP2_REG			0x71
+#define ADES1754_BALEXP3_REG			0x72
+#define ADES1754_BALEXP4_REG			0x73
+#define ADES1754_BALEXP5_REG			0x74
+#define ADES1754_BALEXP6_REG			0x75
+#define ADES1754_BALEXP7_REG			0x76
+#define ADES1754_BALEXP8_REG			0x77
+#define ADES1754_BALEXP9_REG			0x78
+#define ADES1754_BALEXP10_REG			0x79
+#define ADES1754_BALEXP11_REG			0x7A
+#define ADES1754_BALEXP12_REG			0x7B
+#define ADES1754_BALEXP13_REG			0x7C
+#define ADES1754_BALEXP14_REG			0x7D
+#define ADES1754_BALAUTOUVTH_REG		0x7E
+#define ADES1754_BALDLYCTRL_REG			0x7F
+#define ADES1754_BALCTRL_REG			0x80
+#define ADES1754_BALSTAT_REG			0x81
+#define ADES1754_BALUVSTAT_REG			0x82
+#define ADES1754_BALDATA_REG			0x83
+
+#define ADES1754_I2CPNTR_REG			0x84
+#define ADES1754_I2CWDATA1_REG			0x85
+#define ADES1754_I2CWDATA2_REG			0x86
+#define ADES1754_I2CRDATA1_REG			0x87
+#define ADES1754_I2CRDATA2_REG			0x88
+#define ADES1754_I2CCFG_REG			0x89
+#define ADES1754_I2CSTAT_REG			0x8A
+#define ADES1754_I2CSEND_REG			0x8B
+
+#define ADES1754_ID1_REG			0x8C
+#define ADES1754_ID2_REG			0x8D
+#define ADES1754_ID3_REG			0x8E
+#define ADES1754_OTP3_REG			0x8F
+#define ADES1754_OTP4_REG			0x90
+#define ADES1754_OTP5_REG			0x91
+#define ADES1754_OTP6_REG			0x92
+#define ADES1754_OTP7_REG			0x93
+#define ADES1754_OTP8_REG			0x94
+#define ADES1754_OTP9_REG			0x95
+#define ADES1754_OTP10_REG			0x96
+#define ADES1754_OTP11_REG			0x97
+#define ADES1754_OTP12_REG			0x98
+
+#define ADES1754_PREAMBLE_BYTE			0x15
+#define ADES1754_STOP_BYTE			0x54
+#define ADES1754_HELLO_ALL_BYTE			0x57
+
+#define ADES1754_DEV_ADDR_MAX			0x1F
+#define ADES1754_WR_ALL				0x02
+#define ADES1754_RD_ALL				0x03
+#define ADES1754_DEFAULT_DC_BYTE_SEED		0x00
+#define ADES1754_FILL_BYTE_C2			0xC2
+#define ADES1754_FILL_BYTE_D3			0xD3
+
+#define ADES1754_WR_MASK			NO_OS_BIT(2)
+#define ADES1754_RD_MASK			ADES1754_WR_MASK | NO_OS_BIT(0)
+#define ADES1754_BL_MASK			NO_OS_GENMASK(2, 1)
+#define ADES1754_RW_ADDR_MASK			NO_OS_GENMASK(7, 3)
+
+#define ADES1754_LSB_MASK			NO_OS_GENMASK(7, 0)
+#define ADES1754_MSB_MASK			NO_OS_GENMASK(15, 8)
+#define ADES1754_LOWER_NIBBLE_MASK		NO_OS_GENMASK(3, 0)
+#define ADES1754_UPPER_NIBBLE_MASK		NO_OS_GENMASK(7, 4)
+
+#define ADES1754_ADC_METHOD_MASK		NO_OS_BIT(1)
+#define ADES1754_SCAN_MODE_MASK			NO_OS_GENMASK(8, 6)
+#define ADES1754_SCAN_REQUEST_MASK		NO_OS_BIT(0)
+#define ADES1754_IIR_MASK			NO_OS_GENMASK(15, 13)
+#define ADES1754_ALRTFILT_MASK			NO_OS_BIT(2)
+#define ADES1754_AMENDFILT_MASK			NO_OS_BIT(1)
+#define ADES1754_RDFILT_MASK			NO_OS_BIT(0)
+#define ADES1754_IIR_SCAN_MASK			NO_OS_GENMASK(11, 9)
+#define ADES1754_DBLBUFEN_MASK			NO_OS_BIT(0)
+#define ADES1754_CBMODE_MASK			NO_OS_GENMASK(13, 11)
+#define ADES1754_CBMEASEN_MASK			NO_OS_GENMASK(1, 0)
+#define ADES1754_CBCALDLY_MASK			NO_OS_GENMASK(2, 0)
+#define ADES1754_UARTCFG_MASK			NO_OS_GENMASK(15, 14)
+#define ADES1754_CELL_POLARITY_MASK		NO_OS_BIT(15)
+
+enum ades1754_id {
+	ID_ADES1754,
+	ID_ADES1755,
+	ID_ADES1756,
+	ID_ADES1751,
+	ID_ADES1752,
+};
+
+enum ades1754_scan_method {
+	ADES1754_PYRAMID_METHOD,
+	ADES1754_RAMP_METHOD,
+};
+
+enum ades1754_scan_mode {
+	ADES1754_SCAN_ADC,
+	ADES1754_SCAN_COMP,
+	ADES1754_SCAN_ADC_COMP,
+	ADES1754_ON_DEMAND_CALIB,
+	ADES1754_BALANCING_SW_SHRT,
+	ADES1754_BALANCING_SW_OPEN,
+	ADES1754_CELL_SENSE_OPEN_ODDS,
+	ADES1754_CELL_SENSE_OPEN_EVENS
+};
+
+enum ades1754_cell_polarity {
+	ADES1754_UNIPOLAR,
+	ADES1754_BIPOLAR,
+};
+
+enum ades1754_iir_filter_coef {
+	ADES1754_IIR_0_125,
+	ADES1754_IIR_0_250,
+	ADES1754_IIR_0_375,
+	ADES1754_IIR_0_500,
+	ADES1754_IIR_0_625,
+	ADES1754_IIR_0_750,
+	ADES1754_IIR_0_875,
+	ADES1754_IIR_1_000_OFF,
+};
+
+enum ades1754_buffer_mode {
+	ADES1754_SINGLE_BUFF,
+	ADES1754_DOUBLE_BUFF,
+};
+
+enum ades1754_alert {
+	ADES1754_CELL_OV,
+	ADES1754_CELL_UV,
+	ADES1754_BIPOLAR_OV,
+	ADES1754_BIPOLAR_UV,
+	ADES1754_BLOCK_OV,
+	ADES1754_BLOCK_UV,
+	ADES1754_CELL_MISMATCH,
+	ADES1754_AUXIN_OV,
+	ADES1754_AUXIN_UV,
+};
+
+enum ades1754_bal_mode {
+	ADES1754_BAL_DISABLED,
+	ADES1754_BAL_EMERGENCY,
+	ADES1754_BAL_MANUAL_SEC,
+	ADES1754_BAL_MANUAL_MIN,
+	ADES1754_BAL_AUTO_SEC,
+	ADES1754_BAL_AUTO_MIN,
+	ADES1754_BAL_AUTO_GROUP_SEC,
+	ADES1754_BAL_AUTO_GROUP_MIN,
+};
+
+enum ades1754_bal_meas {
+	ADES1754_ALL_MEAS_DISABLED = 1,
+	ADES1754_ADC_CAL_ON_CBUVTHR_OFF,
+	ADES1754_ALL_MEAS_ENABLED,
+};
+
+enum ades1754_bal_calib {
+	ADES1754_BAL_CALIB_DISABLED,
+	ADES1754_BAL_2_CYCLE,
+	ADES1754_BAL_4_CYCLE,
+	ADES1754_BAL_8_CYCLE,
+	ADES1754_BAL_12_CYCLE,
+	ADES1754_BAL_16_CYCLE,
+	ADES1754_BAL_24_CYCLE,
+};
+
+struct ades1754_init_param {
+	struct no_os_uart_init_param *uart_param;
+	enum ades1754_id id;
+	bool uart_bridge;
+	uint8_t dev_addr;
+	uint8_t no_dev;
+};
+
+struct ades1754_desc {
+	struct no_os_uart_desc *uart_desc;
+	enum ades1754_id id;
+	bool uart_bridge;
+	enum ades1754_scan_mode scan_mode;
+	enum ades1754_cell_polarity cell_polarity;
+	uint8_t dev_addr;
+	uint8_t no_dev;
+	bool alive;
+};
+
+int ades1754_hello_all(struct ades1754_desc *desc);
+
+int ades1754_write_dev(struct ades1754_desc *desc, uint8_t reg, uint16_t data);
+
+int ades1754_write_all(struct ades1754_desc *desc, uint8_t reg, uint16_t data);
+
+int ades1754_read_dev(struct ades1754_desc *desc, uint8_t reg, uint16_t *data);
+
+int ades1754_read_all(struct ades1754_desc *desc, uint8_t reg, uint16_t *data);
+
+int ades1754_read_block(struct ades1754_desc *desc, uint8_t block, uint8_t reg,
+			uint16_t *data, bool double_size);
+
+int ades1754_update_dev(struct ades1754_desc *desc, uint8_t reg, uint16_t mask,
+			uint16_t val);
+
+int ades1754_set_adc_method(struct ades1754_desc *desc,
+			    enum ades1754_scan_method scan_method);
+
+int ades1754_switch_scan_mode(struct ades1754_desc *desc,
+			      enum ades1754_scan_mode mode);
+
+int ades1754_set_cell_pol(struct ades1754_desc *desc,
+			  enum ades1754_cell_polarity cell_polarity);
+
+int ades1754_start_scan(struct ades1754_desc *desc, bool meas,
+			uint16_t cell_mask);
+
+int ades1754_get_cell_data(struct ades1754_desc *desc, uint8_t cell_nb,
+			   int32_t *cell_voltage);
+
+int ades1754_set_iir(struct ades1754_desc *desc,
+		     enum ades1754_iir_filter_coef coef);
+
+int ades1754_set_iir_ctrl(struct ades1754_desc *desc, bool alrtfilt, bool acc,
+			  bool output);
+
+int ades1754_set_buffer_mode(struct ades1754_desc *desc,
+			     enum ades1754_buffer_mode mode);
+
+int ades1754_set_alert_thr(struct ades1754_desc *desc,
+			   enum ades1754_alert alert,
+			   uint16_t thr);
+
+int ades1754_get_alert(struct ades1754_desc *desc, enum ades1754_alert alert,
+		       bool *enable);
+
+int ades1754_set_balancing_mode(struct ades1754_desc *desc,
+				enum ades1754_bal_mode mode);
+
+int ades1754_set_balancing_meas(struct ades1754_desc *desc,
+				enum ades1754_bal_meas meas);
+
+int ades1754_set_balancing_calib(struct ades1754_desc *desc,
+				 enum ades1754_bal_calib calib);
+
+int ades1754_init(struct ades1754_desc **desc,
+		  struct ades1754_init_param *init_param);
+
+int ades1754_remove(struct ades1754_desc *desc);
+
+#endif /* __ADES1754_H__ */

--- a/projects/ades1754/Makefile
+++ b/projects/ades1754/Makefile
@@ -1,0 +1,8 @@
+include ../../tools/scripts/generic_variables.mk
+
+EXAMPLE ?= spi_uart_bridge
+include ../../tools/scripts/examples.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/ades1754/README.rst
+++ b/projects/ades1754/README.rst
@@ -1,0 +1,244 @@
+Evaluating the EVAL-ADES1754
+============================
+
+.. contents::
+	:depth: 3
+
+Supported Evaluation Boards
+---------------------------
+
+`EVAL-ADES1754 <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-ades1754.html>`_
+
+Overview
+--------
+
+The ADES1754 evaluation kit (EV kit) is used to
+demonstrate the features and capabilities of the
+ADES1754/ADES1755/ADES1756 14-channel, high-
+voltage, smart sensor, data-acquisition interface ICs. The
+ADES1754 EV kit is coupled with a MAX17851 EV kit to
+establish communication with a host MCU.
+
+Hardware Specifications
+-----------------------
+
+MAX17851EVKIT
+-------------
+
+In case the SPI-to-UART bridge example is to be run, an external
+MAX17851EVKIT board is also needed.
+
+`MAX17851EVKIT <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/max17851evkit.html>`_
+
+Power Supply Requirments
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+For this specific project, an external 12V PSU is needed in order
+to simulate the voltage over the voltage cells.
+
+A 3V3 supply is needed for the SHDNL pin of the ADES1754.
+
+Also a 5V supply and a 3V3 supply are needed for UART and SPI communication,
+in case the MAX17851EVKIT board, or only a 3V3 supply in case of the
+default UART communication.
+
+Board Connector
+^^^^^^^^^^^^^^^
+
+Default UART
+------------
+
+**Pin Description**
+
+	Please see the following table for the pin assignments for
+	the Hex Inverter and the EVAL-ADES1754, respectively:
+
+	+-----------+-------------------------------------------------+
+	|   Name    |	Description				      |
+	+-----------+-------------------------------------------------+
+	|  VCC_3V3  |   Connect to VCC pin of Hex Inverter	      |
+	+-----------+-------------------------------------------------+
+	|  GND      |   Connect to GND pin			      |
+	+-----------+-------------------------------------------------+
+	|  IN1+     |   Connect to TX Host Signal and RXP	      |
+	+-----------+-------------------------------------------------+
+	|  IN1-	    |   Connect to RXN	      			      |
+	+-----------+-------------------------------------------------+
+	|  IN2+	    |   Connect to RX Host Signal and TXP	      |
+	+-----------+-------------------------------------------------+
+	|  IN2-	    |   Float or Connected to TXN 	      	      |
+	+-----------+-------------------------------------------------+
+
+	+-----------+-------------------------------------------------+
+	|   Name    |	Description				      |
+	+-----------+-------------------------------------------------+
+	|  VCC_3V3  |   Connect to SHDNL pin			      |
+	+-----------+-------------------------------------------------+
+	|  GND      |   Connect to AGND pin			      |
+	+-----------+-------------------------------------------------+
+	|  RXN      |   Connect to inverted TX Host Signal	      |
+	+-----------+-------------------------------------------------+
+	|  RXP	    |   Connect to positive TX Host Signal	      |
+	+-----------+-------------------------------------------------+
+	|  TXN	    |   Float or connectec to IN2-		      |
+	+-----------+-------------------------------------------------+
+	|  TXP	    |   Connect to positive RX Host Signal	      |
+	+-----------+-------------------------------------------------+
+
+SPI-to-UART
+-----------
+
+	**Pin Description**
+
+	Please see the following table for the pin assignments for
+	the MAX17851EVKIT and the EVAL-ADES1754, respectively:
+
+	+-----------+-------------------------------------------------+
+	|   Name    |	Description				      |
+	+-----------+-------------------------------------------------+
+	|  VCC_3V3  |   Connect to DCIN2 pin of MAX17851EVKIT	      |
+	+-----------+-------------------------------------------------+
+	|  VCC_5V   |   Connect to DCIN1 pin of MAX17851EVKIT	      |
+	+-----------+-------------------------------------------------+
+	|  GND      |   Connect to GND pin of MAX17851EVKIT	      |
+	+-----------+-------------------------------------------------+
+	|  CS	    |   Connect to SPI Chip Select(CS) 		      |
+	+-----------+-------------------------------------------------+
+	|  MOSI	    |   Connect to SPI Master-Out-Slave-In(MOSI)      |
+	+-----------+-------------------------------------------------+
+	|  MISO	    |   Connect to SPI Master-In-Slave-Out(MISO)      |
+	+-----------+-------------------------------------------------+
+	|  SCK	    |   Connect to SPI Clock(SCK) 	      	      |
+	+-----------+-------------------------------------------------+
+
+	+-----------+-------------------------------------------------+
+	|   Name    |	Description				      |
+	+-----------+-------------------------------------------------+
+	|  VCC_3V3  |   Connect to SHDNL pin			      |
+	+-----------+-------------------------------------------------+
+	|  GND      |   Connect to AGND pin			      |
+	+-----------+-------------------------------------------------+
+	|  RXN      |   Connect to TXN signal of MAX17851EVKIT	      |
+	+-----------+-------------------------------------------------+
+	|  RXP	    |   Connect to TXP signal of MAX17851EVKIT	      |
+	+-----------+-------------------------------------------------+
+	|  TXN	    |   Connect to RXN signal of MAX17851EVKIT        |
+	+-----------+-------------------------------------------------+
+	|  TXP	    |   Connect to RXP signal of MAX17851EVKIT	      |
+	+-----------+-------------------------------------------------+
+
+No-OS Build Setup
+-----------------
+
+Please see: `No-OS Build Wiki <https://wiki.analog.com/resources/no-os/build>`_
+
+No-OS Supported Examples
+------------------------
+
+The initialization data used in the examples is taken out from:
+`Project Common Data Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ades1754/src/common>`_
+
+The macros used for Common Data structures are defined in platform specific files found at:
+`Project Platform Configuration Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ades1754/src/platform>`_
+
+BASIC Example
+^^^^^^^^^^^^^
+
+Steps of the examples:
+
+* Initializes the ADES1754
+* Reads Cell Voltage for each Cell.
+* Scans for Alerts.
+* In case any alerts are detected the example is stopped.
+* If the example is stopped a specific message is shown on the Std I/O UART.
+
+In order to build the default uart example make sure you have the following
+configuration in the Makefile:
+`Makefile <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ades1754/Makefile>`_
+
+.. code-block:: bash
+
+	EXAMPLE ?= def_uart_example
+
+SPI-to-UART Bridge Example
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Steps of the examples:
+
+* Specific structures for the example are defined.
+* MAX17851 then the ADES1754 are intialized.
+* Reads Cell Voltage for each Cell.
+* Scans for Alerts.
+* In case any alerts are detected the example is stopped.
+* If the example is stopped a specific message is shown on the Std I/O UART.
+
+In order to build the spi uart example make sure you have the following
+configuration in the Makefile:
+`Makefile <https://github.com/analogdevicesinc/no-OS/tree/main/projects/ades1754/Makefile>`_
+
+.. code-block:: bash
+
+	EXAMPLE ?= spi_uart_example
+
+No-OS Supported Platforms
+-------------------------
+
+Maxim Platform
+^^^^^^^^^^^^^^
+
+**Used Hardware**
+
+* `EVAL-ADES1754 <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/eval-ades1754.html>`_
+* `AD-APARD32690-SL <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/ad-apard32690-sl.html>`_
+* `Standard Industry Hex Inverter (Default UART Example)`
+* `MAX17851EVKIT (SPI UART Example) <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/max17851evkit.html>`_
+
++--------------+---------------------------------+-------------------+------------------+----------------------+
+| ADES1754 Pin | Function			 | Hex Inverter	     | MAX17851 Pin	| AD-APARD32690-SL Pin |
++--------------+---------------------------------+-------------------+------------------+----------------------+
+| -	       | Low Voltage Power Supply	 | -		     | DCIN1		| 5V0 Supply	       |
++--------------+---------------------------------+-------------------+------------------+----------------------+
+| -	       | Low Voltage Power Supply	 | VCC		     | DCIN2		| 3V3 Supply	       |
++--------------+---------------------------------+-------------------+------------------+----------------------+
+| SHDNL	       | Low Voltage Power Supply	 | -                 | -                | 3V3 Supply           |
++--------------+---------------------------------+-------------------+------------------+----------------------+
+| AGND         | Ground				 | GND		     | GND		| GND		       |
++--------------+---------------------------------+-------------------+------------------+----------------------+
+| RXP          | Receive Line(+) for UART slave  | IN1+		     | TXP (Master)     | P2_14                |
++--------------+---------------------------------+-------------------+------------------+----------------------+
+| RXN          | Receive Line(-) for UART slave  | IN1-              | TXN (Master)     | -                    |
++--------------+---------------------------------+-------------------+------------------+----------------------+
+| TXP          | Transmit Line(+) for UART slave | IN2+              | RXP (Master)     | P2_16		       |
++--------------+---------------------------------+-------------------+------------------+----------------------+
+| TXN          | Transmit Line(-) for UART slave | IN2-              | RXN (Master)     | -                    |
++--------------+---------------------------------+-------------------+------------------+----------------------+
+| -            | SPI Chip-Select                 | -                 | SPI-CS (PORT0)   | P1_0		       |
++--------------+---------------------------------+-------------------+------------------+----------------------+
+| -            | SPI Master-Out-Slave-In         | -                 | SPI-MOSI (PORT0) | P1_1                 |
++--------------+---------------------------------+-------------------+------------------+----------------------+
+| -            | SPI Master-In-Slave-Out         | -           	     | SPI_MISO (PORT0) | P1_2                 |
++--------------+---------------------------------+-------------------+------------------+----------------------+
+| -            | SPI Clock                       | -                 | SPI-SCK (PORT0)  | P1_3                 |
++--------------+---------------------------------+-------------------+------------------+----------------------+
+
+**Build Command**
+
+Default UART Example
+--------------------
+
+.. code-block:: bash
+
+	# to delete current build
+	make PLATFORM=maxim TARGET=max32690 EXAMPLE=def_uart_example reset
+	# to build the project and flash the code
+	make PLATFORM=maxim TARGET=max32690 EXAMPLE=def_uart_example run
+
+SPI UART Example
+----------------
+
+.. code-block:: bash
+
+	# to delete current build
+	make PLATFORM=maxim TARGET=max32690 EXAMPLE=spi_uart_example reset
+	# to build the project and flash the code
+	make PLATFORM=maxim TARGET=max32690 EXAMPLE=spi_uart_example run

--- a/projects/ades1754/builds.json
+++ b/projects/ades1754/builds.json
@@ -1,0 +1,10 @@
+{
+	"maxim": {
+		"basic_example_max32690_ades1754": {
+			"flags" : "EXAMPLE=basic TARGET=max32690"
+		},
+		"spi_uart_example_max32690_ades1754_max17851": {
+			"flags" : "EXAMPLE=spi_uart_bridge TARGET=max32690"
+		}
+	}
+}

--- a/projects/ades1754/src.mk
+++ b/projects/ades1754/src.mk
@@ -1,0 +1,30 @@
+INCS += $(INCLUDE)/no_os_delay.h		\
+	$(INCLUDE)/no_os_error.h		\
+	$(INCLUDE)/no_os_print_log.h		\
+	$(INCLUDE)/no_os_gpio.h			\
+	$(INCLUDE)/no_os_alloc.h		\
+	$(INCLUDE)/no_os_irq.h			\
+	$(INCLUDE)/no_os_list.h			\
+	$(INCLUDE)/no_os_dma.h			\
+	$(INCLUDE)/no_os_uart.h			\
+	$(INCLUDE)/no_os_lf256fifo.h		\
+	$(INCLUDE)/no_os_util.h			\
+	$(INCLUDE)/no_os_units.h		\
+	$(INCLUDE)/no_os_crc8.h			\
+	$(INCLUDE)/no_os_spi.h			\
+	$(INCLUDE)/no_os_mutex.h
+
+SRCS += $(DRIVERS)/api/no_os_uart.c		\
+	$(DRIVERS)/api/no_os_irq.c		\
+	$(DRIVERS)/api/no_os_gpio.c		\
+	$(DRIVERS)/api/no_os_spi.c		\
+	$(DRIVERS)/api/no_os_dma.c		\
+	$(NO-OS)/util/no_os_list.c		\
+	$(NO-OS)/util/no_os_alloc.c		\
+	$(NO-OS)/util/no_os_lf256fifo.c		\
+	$(NO-OS)/util/no_os_mutex.c		\
+	$(NO-OS)/util/no_os_crc8.c		\
+	$(NO-OS)/util/no_os_util.c
+
+INCS += $(DRIVERS)/power/ades1754/ades1754.h
+SRCS += $(DRIVERS)/power/ades1754/ades1754.c

--- a/projects/ades1754/src/common/common_data.c
+++ b/projects/ades1754/src/common/common_data.c
@@ -1,0 +1,63 @@
+/***************************************************************************//**
+ *   @file   common_data.c
+ *   @brief  Defines common data to be used by ades1754 examples.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "common_data.h"
+
+struct no_os_uart_init_param ades1754_uart_ip = {
+	.device_id = UART_DEVICE_ID,
+	.irq_id = UART_IRQ_ID,
+	.baud_rate = UART_BAUDRATE,
+	.size = NO_OS_UART_CS_8,
+	.platform_ops = UART_OPS,
+	.parity = NO_OS_UART_PAR_NO,
+	.stop = NO_OS_UART_STOP_1_BIT,
+	.extra = UART_EXTRA,
+};
+
+struct no_os_uart_init_param ades1754_comm_ip = {
+	.device_id = COMM_DEVICE_ID,
+	.baud_rate = COMM_BAUDRATE,
+	.asynchronous_rx = false,
+	.size = NO_OS_UART_CS_8,
+	.platform_ops = COMM_OPS,
+	.parity = NO_OS_UART_PAR_ODD,
+	.stop = NO_OS_UART_STOP_2_BIT,
+	.extra = COMM_EXTRA,
+};
+
+struct ades1754_init_param ades1754_ip = {
+	.uart_param = &ades1754_comm_ip,
+	.id = ID_ADES1754,
+	.uart_bridge = true,
+	.dev_addr = 0,
+	.no_dev = 1,
+};

--- a/projects/ades1754/src/common/common_data.h
+++ b/projects/ades1754/src/common/common_data.h
@@ -1,0 +1,43 @@
+/***************************************************************************//**
+ *   @file   common_data.h
+ *   @brief  Defines common data to be used by ades1754 examples.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __COMMON_DATA_H__
+#define __COMMON_DATA_H__
+
+#include "parameters.h"
+#include "ades1754.h"
+
+extern struct no_os_uart_init_param ades1754_uart_ip;
+extern struct no_os_uart_init_param ades1754_comm_ip;
+extern struct ades1754_init_param ades1754_ip;
+
+#endif /* __COMMON_DATA_H__ */

--- a/projects/ades1754/src/examples/basic/basic_example.c
+++ b/projects/ades1754/src/examples/basic/basic_example.c
@@ -1,0 +1,104 @@
+/***************************************************************************//**
+ *   @file   basic_example.c
+ *   @brief  Basic example sources file for ades1754.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "common_data.h"
+#include "no_os_delay.h"
+#include "no_os_print_log.h"
+
+#define ADES1754_CELL_RESOLUTION		16383.0f
+
+static const char* const ades1754_alert_msg[] = {
+	[ADES1754_CELL_OV] = "Cell Overvoltage Alert!\n",
+	[ADES1754_CELL_UV] = "Cell Undervoltage Alert!\n",
+	[ADES1754_BIPOLAR_OV] = "Bipolar Overvoltage Alert!\n",
+	[ADES1754_BIPOLAR_UV] = "Bipolar Undervoltage Alert!\n",
+	[ADES1754_BLOCK_OV] = "Block Overvoltage Alert!\n",
+	[ADES1754_BLOCK_UV] = "Block Undervoltage Alert!\n",
+	[ADES1754_CELL_MISMATCH] = "Cell Mismatch Alert!\n",
+	[ADES1754_AUXIN_OV] = "Aux IN Overvoltage Alert!\n",
+	[ADES1754_AUXIN_UV] = "Aux IN Undervoltage Alert!\n"
+};
+
+/**
+ * @brief Basic example main execution
+ * @return ret - Result of the example execution.
+*/
+int example_main()
+{
+	struct ades1754_desc *ades1754_desc;
+	bool alert = false, enable;
+	int32_t cell_voltage;
+	float real_voltage;
+	int ret, i;
+
+	ret = ades1754_init(&ades1754_desc, &ades1754_ip);
+	if (ret)
+		goto exit;
+
+	/* Continous CELL Voltage reading, and checkings for ALERT. */
+	while (!alert) {
+		for (i = 0; i < 15; i++) {
+			ret = ades1754_get_cell_data(ades1754_desc, i,
+						     &cell_voltage);
+			if (ret)
+				goto remove_ades1754;
+
+			real_voltage = cell_voltage;
+			real_voltage = real_voltage * 5.0f / ADES1754_CELL_RESOLUTION;
+			pr_info("Cell %d Voltage : %0.5fV\n", i, real_voltage);
+		}
+
+		for (i = 0; i < 9; i++) {
+			ret = ades1754_get_alert(ades1754_desc, i, &enable);
+			if (ret)
+				goto remove_ades1754;
+
+			if (enable) {
+				pr_info("%s", ades1754_alert_msg[i]);
+				alert = true;
+			}
+
+		}
+
+		if (alert)
+			pr_info("Alert detected, solve alert related failures and start again!\n");
+		else
+			no_os_mdelay(500);
+	}
+
+remove_ades1754:
+	ades1754_remove(ades1754_desc);
+exit:
+	if (ret)
+		pr_info("Error!\n");
+	return ret;
+}

--- a/projects/ades1754/src/examples/spi_uart_bridge/example.mk
+++ b/projects/ades1754/src/examples/spi_uart_bridge/example.mk
@@ -1,0 +1,2 @@
+INCS += $(DRIVERS)/power/max17851/max17851.h
+SRCS += $(DRIVERS)/power/max17851/max17851.c

--- a/projects/ades1754/src/examples/spi_uart_bridge/spi_uart_bridge_example.c
+++ b/projects/ades1754/src/examples/spi_uart_bridge/spi_uart_bridge_example.c
@@ -1,0 +1,138 @@
+/***************************************************************************//**
+ *   @file   spi_uart_bridge_example.c
+ *   @brief  SPI-to-UART example source file for ades1754.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "common_data.h"
+#include "max17851.h"
+#include "no_os_delay.h"
+#include "no_os_print_log.h"
+
+#define ADES1754_CELL_RESOLUTION		16383.0f
+
+static const char* const ades1754_alert_msg[] = {
+	[ADES1754_CELL_OV] = "Cell Overvoltage Alert!\n",
+	[ADES1754_CELL_UV] = "Cell Undervoltage Alert!\n",
+	[ADES1754_BIPOLAR_OV] = "Bipolar Overvoltage Alert!\n",
+	[ADES1754_BIPOLAR_UV] = "Bipolar Undervoltage Alert!\n",
+	[ADES1754_BLOCK_OV] = "Block Overvoltage Alert!\n",
+	[ADES1754_BLOCK_UV] = "Block Undervoltage Alert!\n",
+	[ADES1754_CELL_MISMATCH] = "Cell Mismatch Alert!\n",
+	[ADES1754_AUXIN_OV] = "Aux IN Overvoltage Alert!\n",
+	[ADES1754_AUXIN_UV] = "Aux IN Undervoltage Alert!\n"
+};
+
+/**
+ * @brief SPI-to-UART example main execution
+ * @return ret - Result of the example execution.
+*/
+int example_main()
+{
+	struct ades1754_desc *ades1754_desc;
+	bool alert = false, enable;
+	int32_t cell_voltage;
+	float real_voltage;
+	int ret, i;
+
+
+	struct max_spi_init_param max17851_spi_extra = {
+		.num_slaves = 1,
+		.polarity = SPI_SS_POL_LOW,
+		.vssel = MXC_GPIO_VSSEL_VDDIOH
+	};
+
+	struct no_os_spi_init_param max17851_spi_ip = {
+		.device_id = 4,
+		.extra = &max17851_spi_extra,
+		.mode = NO_OS_SPI_MODE_0,
+		.max_speed_hz = 100000,
+		.platform_ops = &max_spi_ops,
+		.chip_select = 0,
+	};
+
+	struct max17851_init_param ades1754_comm_extra = {
+		.spi_param = &max17851_spi_ip,
+		.gpio1_param = NULL,
+		.gpio2_param = NULL,
+		.op_mode = MAX17851_MASTER_DUAL_UART,
+		.baud_rate = MAX17851_UART_BAUD_500K,
+		.no_dev = 1,
+		.single = false,
+		.contact_tmr_dly_4xmin = MAX17851_CONTACT_TIMER_DELAY_INFINITE,
+		.gpio_rec_dly_csec = MAX17851_GPIO_RECOVERY_DELAY_DISABLED,
+		.safemon_dly = MAX17851_SAFEMON_DLY_500MS,
+	};
+
+	ades1754_comm_ip.platform_ops = &max17851_uart_ops;
+	ades1754_comm_ip.extra = &ades1754_comm_extra;
+	ades1754_ip.uart_bridge = true;
+
+	ret = ades1754_init(&ades1754_desc, &ades1754_ip);
+	if (ret)
+		goto exit;
+
+	/* Continous CELL Voltage reading, and checkings for ALERT. */
+	while (!alert) {
+		for (i = 0; i < 15; i++) {
+			ret = ades1754_get_cell_data(ades1754_desc, i,
+						     &cell_voltage);
+			if (ret)
+				goto remove_ades1754;
+
+			real_voltage = cell_voltage;
+			real_voltage = real_voltage * 5.0f / ADES1754_CELL_RESOLUTION;
+			pr_info("Cell %d Voltage : %0.5fV\n", i, real_voltage);
+		}
+
+		for (i = 0; i < 9; i++) {
+			ret = ades1754_get_alert(ades1754_desc, i, &enable);
+			if (ret)
+				goto remove_ades1754;
+
+			if (enable) {
+				pr_info("%s", ades1754_alert_msg[i]);
+				alert = true;
+			}
+
+		}
+
+		if (alert)
+			pr_info("Alert detected, solve alert related failures and start again!\n");
+		else
+			no_os_mdelay(500);
+	}
+
+remove_ades1754:
+	ades1754_remove(ades1754_desc);
+exit:
+	if (ret)
+		pr_info("Error!\n");
+	return ret;
+}

--- a/projects/ades1754/src/platform/maxim/main.c
+++ b/projects/ades1754/src/platform/maxim/main.c
@@ -1,0 +1,56 @@
+/***************************************************************************//**
+ *   @file   main.c
+ *   @brief  Main file for Maxim platform of ades1754 project.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "common_data.h"
+#include "no_os_error.h"
+#include "no_os_print_log.h"
+
+extern int example_main();
+
+int main()
+{
+	int ret = -EINVAL;
+
+	struct no_os_uart_desc *uart_desc;
+
+	ret = no_os_uart_init(&uart_desc, &ades1754_uart_ip);
+	if (ret)
+		return ret;
+
+	no_os_uart_stdio(uart_desc);
+
+	ret = example_main();
+
+	no_os_uart_remove(uart_desc);
+
+	return ret;
+}

--- a/projects/ades1754/src/platform/maxim/parameters.c
+++ b/projects/ades1754/src/platform/maxim/parameters.c
@@ -1,0 +1,44 @@
+/***************************************************************************//**
+ *   @file   parameters.c
+ *   @brief  Definition of Maxim platform data used by ades1754 project.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "parameters.h"
+#include "no_os_gpio.h"
+#include "no_os_spi.h"
+
+struct max_uart_init_param ades1754_uart_extra = {
+	.flow = UART_FLOW_DIS,
+};
+
+struct max_uart_init_param ades1754_comm_extra = {
+	.flow = UART_FLOW_DIS,
+	.vssel = MXC_GPIO_VSSEL_VDDIO,
+};

--- a/projects/ades1754/src/platform/maxim/parameters.h
+++ b/projects/ades1754/src/platform/maxim/parameters.h
@@ -1,0 +1,57 @@
+/***************************************************************************//**
+ *   @file   parameters.h
+ *   @brief  Definition of Maxim platform data used by ades1754 project.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
+
+#include "maxim_spi.h"
+#include "maxim_irq.h"
+#include "maxim_uart.h"
+#include "maxim_uart_stdio.h"
+
+#define UART_IRQ_ID	UART0_IRQn
+#define UART_DEVICE_ID	0
+#define UART_BAUDRATE	57600
+
+#define COMM_DEVICE_ID	1
+#define COMM_BAUDRATE	500000
+
+#define COMM_EXTRA	&ades1754_comm_extra
+#define COMM_OPS	&max_uart_ops
+
+#define UART_EXTRA	&ades1754_uart_extra
+#define UART_OPS	&max_uart_ops
+
+extern struct max_uart_init_param ades1754_uart_extra;
+extern struct max_uart_init_param ades1754_comm_extra;
+
+#endif /* __PARAMATERS_H__ */

--- a/projects/ades1754/src/platform/maxim/platform_src.mk
+++ b/projects/ades1754/src/platform/maxim/platform_src.mk
@@ -1,0 +1,12 @@
+INCS += $(PLATFORM_DRIVERS)/../common/maxim_dma.h	\
+	$(PLATFORM_DRIVERS)/maxim_uart.h		\
+	$(PLATFORM_DRIVERS)/maxim_uart_stdio.h		\
+	$(PLATFORM_DRIVERS)/maxim_spi.h			\
+	$(PLATFORM_DRIVERS)/maxim_irq.h
+
+SRCS += $(PLATFORM_DRIVERS)/../common/maxim_dma.c	\
+	$(PLATFORM_DRIVERS)/maxim_uart.c		\
+	$(PLATFORM_DRIVERS)/maxim_uart_stdio.c		\
+	$(PLATFORM_DRIVERS)/maxim_irq.c			\
+	$(PLATFORM_DRIVERS)/maxim_spi.c			\
+	$(PLATFORM_DRIVERS)/maxim_delay.c


### PR DESCRIPTION
## Pull Request Description

The ADES1754/ADES1755/ADES1756 are flexible
data-acquisition systems for the management of high-
voltage and low-voltage battery modules. The systems
can measure 14 cell voltages and a combination of six
temperatures or system voltage measurements with fully
redundant measurement engines in 162μs, or perform
all inputs solely with the ADC measurement engine in
99μs. Fourteen internal balancing switches rated
for >300mA for cell-balancing current support extensive
built-in diagnostics. Up to 32 devices can be daisy-
chained to manage 448 cells and monitor 192
temperatures.

This PR includes examples that use other device drivers, therefore it needs to be merged after #2428 

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
