### PR TITLE
util: Remove the inline attribute

### DIFF
--- a/util/no_os_mutex.c
+++ b/util/no_os_mutex.c
@@ -38,26 +38,26 @@
  * @param ptr - Pointer toward the mutex.
  * @return None.
  */
-__attribute__((weak)) inline void no_os_mutex_init(void **mutex) {}
+__attribute__((weak)) void no_os_mutex_init(void **mutex) {}
 
 /**
  * @brief Lock mutex.
  * @param ptr - Pointer toward the mutex.
  * @return None.
  */
-__attribute__((weak)) inline void no_os_mutex_lock(void *mutex) {}
+__attribute__((weak)) void no_os_mutex_lock(void *mutex) {}
 
 /**
  * @brief Unlock mutex.
  * @param ptr - Pointer toward the mutex.
  * @return None.
  */
-__attribute((weak)) inline void no_os_mutex_unlock(void *mutex) {}
+__attribute((weak)) void no_os_mutex_unlock(void *mutex) {}
 
 /**
  * @brief Remove mutex.
  * @param ptr - Pointer toward the mutex.
  * @return None.
  */
-__attribute__((weak)) inline void no_os_mutex_remove(void *mutex) {}
+__attribute__((weak)) void no_os_mutex_remove(void *mutex) {}
 

--- a/util/no_os_semaphore.c
+++ b/util/no_os_semaphore.c
@@ -38,26 +38,26 @@
  * @param ptr - Pointer toward the semaphore.
  * @return None.
  */
-__attribute__((weak)) inline void no_os_semaphore_init(void **semaphore) {}
+__attribute__((weak)) void no_os_semaphore_init(void **semaphore) {}
 
 /**
  * @brief Take token from semaphore.
  * @param ptr - Pointer toward the semaphore.
  * @return None.
  */
-__attribute__((weak)) inline void no_os_semaphore_take(void *semaphore) {}
+__attribute__((weak)) void no_os_semaphore_take(void *semaphore) {}
 
 /**
  * @brief Give token to semaphore
  * @param ptr - Pointer toward the semaphore.
  * @return None.
  */
-__attribute((weak)) inline void no_os_semaphore_give(void *semaphore) {}
+__attribute((weak)) void no_os_semaphore_give(void *semaphore) {}
 
 /**
  * @brief Remove semaphore.
  * @param ptr - Pointer toward the semaphore.
  * @return None.
  */
-__attribute__((weak)) inline void no_os_semaphore_remove(void *semaphore) {}
+__attribute__((weak)) void no_os_semaphore_remove(void *semaphore) {}
 


### PR DESCRIPTION
Adding the inline keyword to a weak function results in the symbol to not actually be defined as weak. Thus, the compilation will fail for platforms which define their own version of those functions (FreeRTOS for example).

__attribute__((weak)) inline:

arm-none-eabi-nm build/objs/iio_demo_freeRTOS/build/app/noos/util/no_os_semaphore.o 00000000 T no_os_semaphore_give
00000000 T no_os_semaphore_init
00000000 T no_os_semaphore_remove
00000000 T no_os_semaphore_take

__attribute__((weak)):

arm-none-eabi-nm build/objs/iio_demo_freeRTOS/build/app/noos/util/no_os_mutex.o 00000000 W no_os_mutex_init
00000000 W no_os_mutex_lock
00000000 W no_os_mutex_remove
00000000 W no_os_mutex_unlock
00000000 n wm4.0.2fb1d36208757ad46d380e25c322250d

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
