### PR TITLE
adxl355 - read FIFO as multiples of 3

### DIFF
--- a/drivers/accel/adxl355/adxl355.c
+++ b/drivers/accel/adxl355/adxl355.c
@@ -731,6 +731,8 @@ int adxl355_get_raw_fifo_data(struct adxl355_dev *dev, uint8_t *fifo_entries,
 	if (ret)
 		return ret;
 
+	*fifo_entries = (*fifo_entries / 3) * 3;
+
 	if (*fifo_entries > 0) {
 
 		ret = adxl355_read_device_data(dev, ADXL355_ADDR(ADXL355_FIFO_DATA),


### PR DESCRIPTION
Data gets stored in the FIFO as locations and 3 locations pertain to the same measurement (x, y, z). However, it may be that one interrogates the number of filled locations in the FIFO and this number is not a multiple of 3 at that moment (most likely due to locations being filled sequentially). In this case, the correct approach is to read only multiples of 3 and leave the remaining 1 or 2 locations in the FIFO. This commit does that.

Closes #2431

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
