### PR TITLE
drivers: spi: Add SPI Abort API

### DIFF
--- a/drivers/adc/ad463x/ad463x.c
+++ b/drivers/adc/ad463x/ad463x.c
@@ -598,7 +598,7 @@ static int32_t ad463x_read_data_dma(struct ad463x_dev *dev,
 	if (ret != 0)
 		goto out;
 
-	ret = no_os_spi_transfer_dma_sync(dev->spi_desc, &spi_msg, 1);
+	ret = no_os_spi_transfer_dma(dev->spi_desc, &spi_msg, 1);
 	if (ret)
 		goto out;
 

--- a/drivers/adc/ad738x/ad738x.c
+++ b/drivers/adc/ad738x/ad738x.c
@@ -292,7 +292,7 @@ static int32_t ad738x_read_data_dma(struct ad738x_dev *dev,
 	if (ret != 0)
 		goto out;
 
-	ret = no_os_spi_transfer_dma_sync(dev->spi_desc, &spi_msg, 1);
+	ret = no_os_spi_transfer_dma(dev->spi_desc, &spi_msg, 1);
 	if (ret)
 		goto out;
 

--- a/drivers/api/no_os_spi.c
+++ b/drivers/api/no_os_spi.c
@@ -221,9 +221,9 @@ out:
  * @param len - Number of messages in the array.
  * @return 0 in case of success, negativ error code otherwise.
  */
-int32_t no_os_spi_transfer_dma_sync(struct no_os_spi_desc *desc,
-				    struct no_os_spi_msg *msgs,
-				    uint32_t len)
+int32_t no_os_spi_transfer_dma(struct no_os_spi_desc *desc,
+			       struct no_os_spi_msg *msgs,
+			       uint32_t len)
 {
 	if (!desc || !desc->platform_ops || !msgs || !len)
 		return -EINVAL;

--- a/drivers/api/no_os_spi.c
+++ b/drivers/api/no_os_spi.c
@@ -228,8 +228,8 @@ int32_t no_os_spi_transfer_dma(struct no_os_spi_desc *desc,
 	if (!desc || !desc->platform_ops || !msgs || !len)
 		return -EINVAL;
 
-	if (desc->platform_ops->dma_transfer_sync)
-		return desc->platform_ops->dma_transfer_sync(desc, msgs, len);
+	if (desc->platform_ops->transfer_dma)
+		return desc->platform_ops->transfer_dma(desc, msgs, len);
 
 	return -ENOSYS;
 }
@@ -254,8 +254,8 @@ int32_t no_os_spi_transfer_dma_async(struct no_os_spi_desc *desc,
 	if (!desc || !desc->platform_ops || !msgs || !len)
 		return -EINVAL;
 
-	if (desc->platform_ops->dma_transfer_async)
-		return desc->platform_ops->dma_transfer_async(desc, msgs, len,
+	if (desc->platform_ops->transfer_dma_async)
+		return desc->platform_ops->transfer_dma_async(desc, msgs, len,
 				callback, ctx);
 
 	return -ENOSYS;

--- a/drivers/api/no_os_spi.c
+++ b/drivers/api/no_os_spi.c
@@ -260,3 +260,19 @@ int32_t no_os_spi_transfer_dma_async(struct no_os_spi_desc *desc,
 
 	return -ENOSYS;
 }
+
+/**
+ * @brief Abort SPI transfers.
+ * @param desc - The SPI descriptor.
+ * @return 0 in case of success, -1 otherwise.
+ */
+int32_t no_os_spi_transfer_abort(struct no_os_spi_desc *desc)
+{
+	if (!desc || !desc->platform_ops)
+		return -EINVAL;
+
+	if (!desc->platform_ops->transfer_abort)
+		return -ENOSYS;
+
+	return desc->platform_ops->transfer_abort(desc);
+}

--- a/drivers/platform/maxim/max32650/maxim_spi.c
+++ b/drivers/platform/maxim/max32650/maxim_spi.c
@@ -637,9 +637,9 @@ free_rx_ch_xfer:
  * @param len - Number of messages.
  * @return 0 in case of success, errno codes otherwise.
  */
-static int32_t max_spi_dma_transfer_sync(struct no_os_spi_desc *desc,
-		struct no_os_spi_msg *msgs,
-		uint32_t len)
+static int32_t max_spi_transfer_dma(struct no_os_spi_desc *desc,
+				    struct no_os_spi_msg *msgs,
+				    uint32_t len)
 {
 	return max_config_dma_and_start(desc, msgs, len, NULL, NULL, false);
 }
@@ -654,7 +654,7 @@ static int32_t max_spi_dma_transfer_sync(struct no_os_spi_desc *desc,
  * @param ctx - User defined parameter for the callback function.
  * @return 0 in case of success, errno codes otherwise.
  */
-static int32_t max_spi_dma_transfer_async(struct no_os_spi_desc *desc,
+static int32_t max_spi_transfer_dma_async(struct no_os_spi_desc *desc,
 		struct no_os_spi_msg *msgs,
 		uint32_t len,
 		void (*callback)(void *),
@@ -796,7 +796,7 @@ const struct no_os_spi_platform_ops max_spi_ops = {
 	.init = &max_spi_init,
 	.write_and_read = &max_spi_write_and_read,
 	.transfer = &max_spi_transfer,
-	.dma_transfer_sync = &max_spi_dma_transfer_sync,
-	.dma_transfer_async = &max_spi_dma_transfer_async,
+	.transfer_dma = &max_spi_transfer_dma,
+	.transfer_dma_async = &max_spi_transfer_dma_async,
 	.remove = &max_spi_remove
 };

--- a/drivers/platform/maxim/max32655/maxim_spi.c
+++ b/drivers/platform/maxim/max32655/maxim_spi.c
@@ -537,9 +537,9 @@ free_rx_ch_xfer:
  * @param len - Number of messages.
  * @return 0 in case of success, errno codes otherwise.
  */
-static int32_t max_spi_dma_transfer_sync(struct no_os_spi_desc *desc,
-		struct no_os_spi_msg *msgs,
-		uint32_t len)
+static int32_t max_spi_transfer_dma(struct no_os_spi_desc *desc,
+				    struct no_os_spi_msg *msgs,
+				    uint32_t len)
 {
 	return max_config_dma_and_start(desc, msgs, len, NULL, NULL, false);
 }
@@ -554,7 +554,7 @@ static int32_t max_spi_dma_transfer_sync(struct no_os_spi_desc *desc,
  * @param ctx - User defined parameter for the callback function.
  * @return 0 in case of success, errno codes otherwise.
  */
-static int32_t max_spi_dma_transfer_async(struct no_os_spi_desc *desc,
+static int32_t max_spi_transfer_dma_async(struct no_os_spi_desc *desc,
 		struct no_os_spi_msg *msgs,
 		uint32_t len,
 		void (*callback)(void *),
@@ -696,7 +696,7 @@ const struct no_os_spi_platform_ops max_spi_ops = {
 	.init = &max_spi_init,
 	.write_and_read = &max_spi_write_and_read,
 	.transfer = &max_spi_transfer,
-	.dma_transfer_sync = &max_spi_dma_transfer_sync,
-	.dma_transfer_async = &max_spi_dma_transfer_async,
+	.transfer_dma = &max_spi_transfer_dma,
+	.transfer_dma_async = &max_spi_transfer_dma_async,
 	.remove = &max_spi_remove
 };

--- a/drivers/platform/maxim/max32660/maxim_spi.c
+++ b/drivers/platform/maxim/max32660/maxim_spi.c
@@ -530,9 +530,9 @@ free_rx_ch_xfer:
  * @param len - Number of messages.
  * @return 0 in case of success, errno codes otherwise.
  */
-static int32_t max_spi_dma_transfer_sync(struct no_os_spi_desc *desc,
-		struct no_os_spi_msg *msgs,
-		uint32_t len)
+static int32_t max_spi_transfer_dma(struct no_os_spi_desc *desc,
+				    struct no_os_spi_msg *msgs,
+				    uint32_t len)
 {
 	return max_config_dma_and_start(desc, msgs, len, NULL, NULL, false);
 }
@@ -547,7 +547,7 @@ static int32_t max_spi_dma_transfer_sync(struct no_os_spi_desc *desc,
  * @param ctx - User defined parameter for the callback function.
  * @return 0 in case of success, errno codes otherwise.
  */
-static int32_t max_spi_dma_transfer_async(struct no_os_spi_desc *desc,
+static int32_t max_spi_transfer_dma_async(struct no_os_spi_desc *desc,
 		struct no_os_spi_msg *msgs,
 		uint32_t len,
 		void (*callback)(void *),
@@ -689,7 +689,7 @@ const struct no_os_spi_platform_ops max_spi_ops = {
 	.init = &max_spi_init,
 	.write_and_read = &max_spi_write_and_read,
 	.transfer = &max_spi_transfer,
-	.dma_transfer_sync = &max_spi_dma_transfer_sync,
-	.dma_transfer_async = &max_spi_dma_transfer_async,
+	.transfer_dma = &max_spi_transfer_dma,
+	.transfer_dma_async = &max_spi_transfer_dma_async,
 	.remove = &max_spi_remove
 };

--- a/drivers/platform/maxim/max32665/maxim_spi.c
+++ b/drivers/platform/maxim/max32665/maxim_spi.c
@@ -626,9 +626,9 @@ free_rx_ch_xfer:
  * @param len - Number of messages.
  * @return 0 in case of success, errno codes otherwise.
  */
-static int32_t max_spi_dma_transfer_sync(struct no_os_spi_desc *desc,
-		struct no_os_spi_msg *msgs,
-		uint32_t len)
+static int32_t max_spi_transfer_dma(struct no_os_spi_desc *desc,
+				    struct no_os_spi_msg *msgs,
+				    uint32_t len)
 {
 	return max_config_dma_and_start(desc, msgs, len, NULL, NULL, false);
 }
@@ -643,7 +643,7 @@ static int32_t max_spi_dma_transfer_sync(struct no_os_spi_desc *desc,
  * @param ctx - User defined parameter for the callback function.
  * @return 0 in case of success, errno codes otherwise.
  */
-static int32_t max_spi_dma_transfer_async(struct no_os_spi_desc *desc,
+static int32_t max_spi_transfer_dma_async(struct no_os_spi_desc *desc,
 		struct no_os_spi_msg *msgs,
 		uint32_t len,
 		void (*callback)(void *),
@@ -785,7 +785,7 @@ const struct no_os_spi_platform_ops max_spi_ops = {
 	.init = &max_spi_init,
 	.write_and_read = &max_spi_write_and_read,
 	.transfer = &max_spi_transfer,
-	.dma_transfer_sync = &max_spi_dma_transfer_sync,
-	.dma_transfer_async = &max_spi_dma_transfer_async,
+	.transfer_dma = &max_spi_transfer_dma,
+	.transfer_dma_async = &max_spi_transfer_dma_async,
 	.remove = &max_spi_remove
 };

--- a/drivers/platform/maxim/max32690/maxim_spi.c
+++ b/drivers/platform/maxim/max32690/maxim_spi.c
@@ -652,9 +652,9 @@ free_rx_ch_xfer:
  * @param len - Number of messages.
  * @return 0 in case of success, errno codes otherwise.
  */
-static int32_t max_spi_dma_transfer_sync(struct no_os_spi_desc *desc,
-		struct no_os_spi_msg *msgs,
-		uint32_t len)
+static int32_t max_spi_transfer_dma(struct no_os_spi_desc *desc,
+				    struct no_os_spi_msg *msgs,
+				    uint32_t len)
 {
 	return max_config_dma_and_start(desc, msgs, len, NULL, NULL, false);
 }
@@ -669,7 +669,7 @@ static int32_t max_spi_dma_transfer_sync(struct no_os_spi_desc *desc,
  * @param ctx - User defined parameter for the callback function.
  * @return 0 in case of success, errno codes otherwise.
  */
-static int32_t max_spi_dma_transfer_async(struct no_os_spi_desc *desc,
+static int32_t max_spi_transfer_dma_async(struct no_os_spi_desc *desc,
 		struct no_os_spi_msg *msgs,
 		uint32_t len,
 		void (*callback)(void *),
@@ -811,7 +811,7 @@ const struct no_os_spi_platform_ops max_spi_ops = {
 	.init = &max_spi_init,
 	.write_and_read = &max_spi_write_and_read,
 	.transfer = &max_spi_transfer,
-	.dma_transfer_sync = &max_spi_dma_transfer_sync,
-	.dma_transfer_async = &max_spi_dma_transfer_async,
+	.transfer_dma = &max_spi_transfer_dma,
+	.transfer_dma_async = &max_spi_transfer_dma_async,
 	.remove = &max_spi_remove
 };

--- a/drivers/platform/maxim/max78000/maxim_spi.c
+++ b/drivers/platform/maxim/max78000/maxim_spi.c
@@ -536,9 +536,9 @@ free_rx_ch_xfer:
  * @param len - Number of messages.
  * @return 0 in case of success, errno codes otherwise.
  */
-static int32_t max_spi_dma_transfer_sync(struct no_os_spi_desc *desc,
-		struct no_os_spi_msg *msgs,
-		uint32_t len)
+static int32_t max_spi_transfer_dma(struct no_os_spi_desc *desc,
+				    struct no_os_spi_msg *msgs,
+				    uint32_t len)
 {
 	return max_config_dma_and_start(desc, msgs, len, NULL, NULL, false);
 }
@@ -553,7 +553,7 @@ static int32_t max_spi_dma_transfer_sync(struct no_os_spi_desc *desc,
  * @param ctx - User defined parameter for the callback function.
  * @return 0 in case of success, errno codes otherwise.
  */
-static int32_t max_spi_dma_transfer_async(struct no_os_spi_desc *desc,
+static int32_t max_spi_transfer_dma_async(struct no_os_spi_desc *desc,
 		struct no_os_spi_msg *msgs,
 		uint32_t len,
 		void (*callback)(void *),
@@ -695,7 +695,7 @@ const struct no_os_spi_platform_ops max_spi_ops = {
 	.init = &max_spi_init,
 	.write_and_read = &max_spi_write_and_read,
 	.transfer = &max_spi_transfer,
-	.dma_transfer_sync = &max_spi_dma_transfer_sync,
-	.dma_transfer_async = &max_spi_dma_transfer_async,
+	.transfer_dma = &max_spi_transfer_dma,
+	.transfer_dma_async = &max_spi_transfer_dma_async,
 	.remove = &max_spi_remove
 };

--- a/drivers/platform/stm32/stm32_spi.c
+++ b/drivers/platform/stm32/stm32_spi.c
@@ -641,7 +641,7 @@ void stm32_spi_dma_callback(struct no_os_dma_xfer_desc *old_xfer,
  * @param ctx - User defined parameter for the callback function.
  * @return 0 in case of success, errno codes otherwise.
  */
-int32_t stm32_spi_dma_transfer_async(struct no_os_spi_desc* desc,
+int32_t stm32_spi_transfer_dma_async(struct no_os_spi_desc* desc,
 				     struct no_os_spi_msg* msgs,
 				     uint32_t len,
 				     void (*callback)(void*),
@@ -663,9 +663,9 @@ int32_t stm32_spi_dma_transfer_async(struct no_os_spi_desc* desc,
  * @param len - Number of messages.
  * @return 0 in case of success, errno codes otherwise.
  */
-int32_t stm32_spi_dma_transfer_sync(struct no_os_spi_desc* desc,
-				    struct no_os_spi_msg* msgs,
-				    uint32_t len)
+int32_t stm32_spi_transfer_dma(struct no_os_spi_desc* desc,
+			       struct no_os_spi_msg* msgs,
+			       uint32_t len)
 {
 	uint32_t timeout;
 	struct stm32_spi_desc* sdesc = desc->extra;
@@ -746,7 +746,7 @@ const struct no_os_spi_platform_ops stm32_spi_ops = {
 	.write_and_read = &stm32_spi_write_and_read,
 	.remove = &stm32_spi_remove,
 	.transfer = &stm32_spi_transfer,
-	.dma_transfer_async = &stm32_spi_dma_transfer_async,
-	.dma_transfer_sync = &stm32_spi_dma_transfer_sync,
+	.transfer_dma_async = &stm32_spi_transfer_dma_async,
+	.transfer_dma = &stm32_spi_transfer_dma,
 	.transfer_abort = &stm32_spi_transfer_abort
 };

--- a/drivers/platform/stm32/stm32_xspi.c
+++ b/drivers/platform/stm32/stm32_xspi.c
@@ -648,7 +648,7 @@ free_ch_xfer:
  * @param ctx - User specific data which should be passed to the callback function.
  * @return 0 in case of success, negative code otherwise.
  */
-static int32_t stm32_xspi_dma_transfer_async(struct no_os_spi_desc *desc,
+static int32_t stm32_xspi_transfer_dma_async(struct no_os_spi_desc *desc,
 		struct no_os_spi_msg *msgs,
 		uint32_t len,
 		void (*callback)(void *),
@@ -674,9 +674,9 @@ static int32_t stm32_xspi_dma_transfer_async(struct no_os_spi_desc *desc,
  * @param len - Number of messages.
  * @return 0 in case of success, negative code otherwise.
  */
-static int32_t stm32_xspi_dma_transfer_sync(struct no_os_spi_desc *desc,
-		struct no_os_spi_msg *msgs,
-		uint32_t len)
+static int32_t stm32_xspi_transfer_dma(struct no_os_spi_desc *desc,
+				       struct no_os_spi_msg *msgs,
+				       uint32_t len)
 {
 	int32_t ret;
 	uint32_t timeout;
@@ -716,6 +716,6 @@ const struct no_os_spi_platform_ops stm32_xspi_ops = {
 	.remove = &stm32_xspi_remove,
 	.transfer = &stm32_xspi_transfer,
 	.write_and_read = &stm32_xspi_write_and_read,
-	.dma_transfer_sync = stm32_xspi_dma_transfer_sync,
-	.dma_transfer_async = stm32_xspi_dma_transfer_async,
+	.transfer_dma = stm32_xspi_transfer_dma,
+	.transfer_dma_async = stm32_xspi_transfer_dma_async,
 };

--- a/include/no_os_spi.h
+++ b/include/no_os_spi.h
@@ -265,9 +265,9 @@ int32_t no_os_spi_transfer(struct no_os_spi_desc *desc,
 			   uint32_t len);
 
 /* Transfer a list of messages using DMA. Wait until all transfers are done */
-int32_t no_os_spi_transfer_dma_sync(struct no_os_spi_desc *desc,
-				    struct no_os_spi_msg *msgs,
-				    uint32_t len);
+int32_t no_os_spi_transfer_dma(struct no_os_spi_desc *desc,
+			       struct no_os_spi_msg *msgs,
+			       uint32_t len);
 /*
  * Transfer a list of messages using DMA. Return once the first one started and
  * invoke a callback when they are done.

--- a/include/no_os_spi.h
+++ b/include/no_os_spi.h
@@ -239,6 +239,8 @@ struct no_os_spi_platform_ops {
 				      uint32_t, void (*)(void *), void *);
 	/** SPI remove function pointer */
 	int32_t (*remove)(struct no_os_spi_desc *);
+	/** SPI abort function pointer */
+	int32_t (*transfer_abort)(struct no_os_spi_desc *);
 };
 
 /******************************************************************************/
@@ -275,6 +277,9 @@ int32_t no_os_spi_transfer_dma_async(struct no_os_spi_desc *desc,
 				     uint32_t len,
 				     void (*callback)(void *),
 				     void *ctx);
+
+/* Abort SPI transfers. */
+int32_t no_os_spi_transfer_abort(struct no_os_spi_desc *desc);
 
 /* Initialize SPI bus descriptor*/
 int32_t no_os_spibus_init(const struct no_os_spi_init_param *param);

--- a/include/no_os_spi.h
+++ b/include/no_os_spi.h
@@ -229,13 +229,13 @@ struct no_os_spi_platform_ops {
 	/** Iterate over the spi_msg array and send all messages using DMA.
 	 * Blocks until the transfer is completed.
 	 */
-	int32_t (*dma_transfer_sync)(struct no_os_spi_desc *, struct no_os_spi_msg *,
-				     uint32_t);
+	int32_t (*transfer_dma)(struct no_os_spi_desc *, struct no_os_spi_msg *,
+				uint32_t);
 	/** Iterate over the spi_msg array and send all messages using DMA.
 	 * Returns immediately after the transfer is started and invokes a
 	 * callback once all the messages have been transfered.
 	 */
-	int32_t (*dma_transfer_async)(struct no_os_spi_desc *, struct no_os_spi_msg *,
+	int32_t (*transfer_dma_async)(struct no_os_spi_desc *, struct no_os_spi_msg *,
 				      uint32_t, void (*)(void *), void *);
 	/** SPI remove function pointer */
 	int32_t (*remove)(struct no_os_spi_desc *);


### PR DESCRIPTION
## Pull Request Description

Add SPI Abort API to abort the SPI transactions.

This is useful when user has to terminate the SPI transactions in the application, especially when circular DMA is used.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
