### PR TITLE
build_projects.yml: Fix Unit Tests job

### DIFF
--- a/build_projects.yml
+++ b/build_projects.yml
@@ -236,7 +236,7 @@ jobs:
     persistCredentials: true
   - script: |
       sudo apt install ruby-full
-      sudo gem install ceedling
+      sudo gem install ceedling -v 0.31.1
       pip install gcovr==4.1
       cd tests/drivers/imu/
       ceedling test:all


### PR DESCRIPTION
## Pull Request Description

The ceedling framework used inside the Unit Tests job has released a new version (>1.0.0) which isn't backwards compatible. This is a hot fix that sets the version to 0.31.1 (latest working version). 
This issue was also reported to the Ceedling repo
(ThrowTheSwitch/Ceedling#939) where porting to the latest versions is explained.

I don't have the expertise to *correctly* update Ceedling to latest, but I recommend that it should be done in the future. This fix was done to make the CIs for unit tests pass.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
