### PR TITLE
drivers:irq: support to get the interrupt priority 

### DIFF
--- a/drivers/api/no_os_irq.c
+++ b/drivers/api/no_os_irq.c
@@ -227,6 +227,26 @@ int no_os_irq_set_priority(struct no_os_irq_ctrl_desc *desc,
 }
 
 /**
+ * @brief Get the priority for an interrupt.
+ * @param desc - The IRQ controller descriptor.
+ * @param irq_id - Interrupt identifier.
+ * @param priority_level - The priority level of the interrupt.
+ * @return 0 in case of success, negative errno error codes.
+ */
+int no_os_irq_get_priority(struct no_os_irq_ctrl_desc *desc,
+			   uint32_t irq_id,
+			   uint32_t *priority_level)
+{
+	if (!desc || !desc->platform_ops)
+		return -EINVAL;
+
+	if (!desc->platform_ops->get_priority)
+		return -ENOSYS;
+
+	return desc->platform_ops->get_priority(desc, irq_id, priority_level);
+}
+
+/**
  * @brief Clear the pending interrupt.
  * @param desc - The IRQ controller descriptor.
  * @param irq_id - Interrupt identifier.

--- a/drivers/platform/stm32/stm32_irq.c
+++ b/drivers/platform/stm32/stm32_irq.c
@@ -577,6 +577,24 @@ static int stm32_irq_set_priority(struct no_os_irq_ctrl_desc *desc,
 }
 
 /**
+ * @brief Get a priority level for an interrupt
+ * @param desc - Interrupt controller descriptor.
+ * @param irq_id - The interrupt vector entry id of the peripheral.
+ * @param priority_level - The interrupt priority level
+ * @return 0
+ */
+static int stm32_irq_get_priority(struct no_os_irq_ctrl_desc *desc,
+				  uint32_t irq_id,
+				  uint32_t *priority_level)
+{
+	uint32_t priority_group, sub_priority;
+	priority_group = HAL_NVIC_GetPriorityGrouping();
+	HAL_NVIC_GetPriority(irq_id, priority_group, priority_level, &sub_priority);
+
+	return 0;
+}
+
+/**
  * @brief stm32 specific IRQ platform ops structure
  */
 const struct no_os_irq_platform_ops stm32_irq_ops = {
@@ -589,5 +607,6 @@ const struct no_os_irq_platform_ops stm32_irq_ops = {
 	.enable = &stm32_irq_enable,
 	.disable = &stm32_irq_disable,
 	.set_priority = &stm32_irq_set_priority,
+	.get_priority = &stm32_irq_get_priority,
 	.remove = &stm32_irq_ctrl_remove
 };

--- a/include/no_os_irq.h
+++ b/include/no_os_irq.h
@@ -182,6 +182,9 @@ struct no_os_irq_platform_ops {
 	/** Set the priority level for a specific interrupt */
 	int (*set_priority)(struct no_os_irq_ctrl_desc *desc, uint32_t irq_id,
 			    uint32_t priority_level);
+	/** Get the priority level for a specific interrupt */
+	int (*get_priority)(struct no_os_irq_ctrl_desc *desc, uint32_t irq_id,
+			    uint32_t *priority_level);
 	/** IRQ remove function pointer */
 	int (*remove)(struct no_os_irq_ctrl_desc *desc);
 	/** Clear pending interrupt */
@@ -230,6 +233,11 @@ int no_os_irq_disable(struct no_os_irq_ctrl_desc *desc, uint32_t irq_id);
 int no_os_irq_set_priority(struct no_os_irq_ctrl_desc *desc,
 			   uint32_t irq_id,
 			   uint32_t priority_level);
+
+/** Get the priority level for a specific interrupt */
+int no_os_irq_get_priority(struct no_os_irq_ctrl_desc *desc,
+			   uint32_t irq_id,
+			   uint32_t *priority_level);
 
 /* Clear the pending interrupts */
 int no_os_irq_clear_pending(struct no_os_irq_ctrl_desc* desc,


### PR DESCRIPTION
## Pull Request Description

Added a function to get the priority of an interrupt into STM32 platform api. This will provide better visibility of the already set interrupt priority and will provide the ability to dynamically adjust the priorities, if needed.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
