### PR TITLE
drivers: stm32: i2c: Add I2C GPIOs init

### DIFF
--- a/drivers/platform/stm32/stm32_i2c.c
+++ b/drivers/platform/stm32/stm32_i2c.c
@@ -50,6 +50,7 @@ int32_t stm32_i2c_init(struct no_os_i2c_desc **desc,
 	struct no_os_i2c_desc *descriptor;
 	struct stm32_i2c_desc *xdesc;
 	struct stm32_i2c_init_param *i2cinit;
+	struct no_os_gpio_desc *gpio_desc;
 	I2C_TypeDef *base = NULL;
 
 	if (!desc || !param)
@@ -109,6 +110,22 @@ int32_t stm32_i2c_init(struct no_os_i2c_desc **desc,
 		ret = -EIO;
 		goto error_2;
 	}
+
+	/* Initialize the I2C SCL line */
+	ret = no_os_gpio_get_optional(&gpio_desc, i2cinit->scl);
+	if (ret)
+		goto error_2;
+
+	/* Free the resource */
+	no_os_gpio_remove(gpio_desc);
+
+	/* Initialize the I2C SDA line */
+	ret = no_os_gpio_get_optional(&gpio_desc, i2cinit->sda);
+	if (ret)
+		goto error_2;
+
+	/* Free the resource */
+	no_os_gpio_remove(gpio_desc);
 
 	/* copy settings to device descriptor */
 	descriptor->device_id = param->device_id;

--- a/drivers/platform/stm32/stm32_i2c.h
+++ b/drivers/platform/stm32/stm32_i2c.h
@@ -35,6 +35,7 @@
 
 #include <stdint.h>
 #include "no_os_i2c.h"
+#include "no_os_gpio.h"
 #include "stm32_hal.h"
 
 /**
@@ -54,6 +55,10 @@ struct stm32_i2c_desc {
 struct stm32_i2c_init_param {
 	/** I2C Timing */
 	uint32_t i2c_timing;
+	/* SCL GPIO init params */
+	struct no_os_gpio_init_param *scl;
+	/* SDA GPIO init params */
+	struct no_os_gpio_init_param *sda;
 };
 
 /**


### PR DESCRIPTION
Initialize I2C GPIOs (SCL, SDA) using respective init params.

When I2C is selected in a fresh project instance, the gpio configuration is not accurate and requires additional effort to configure them in ioc file. Hence the idea is to consolidate the gpio configuration in driver itself so as to eliminate separate configuration in ioc file. This will be useful in migration of projects among various stm32 series.

## Pull Request Description

Add I2C GPIOs (SCL, SDA) initialization as a part of driver instead of relying on auto generated files from ioc file.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
