### PR TITLE
projects: eval-pqmon: remove inexistent headers

### DIFF
--- a/projects/eval-pqmon/src/platform/maxim/platform_src.mk
+++ b/projects/eval-pqmon/src/platform/maxim/platform_src.mk
@@ -1,7 +1,5 @@
-INCS += $(PLATFORM_DRIVERS)/maxim_delay.h     		\
-        $(PLATFORM_DRIVERS)/maxim_gpio.h      		\
+INCS += $(PLATFORM_DRIVERS)/maxim_gpio.h      		\
         $(PLATFORM_DRIVERS)/maxim_spi.h       		\
-        $(PLATFORM_DRIVERS)/maxim_init.h      		\
         $(PLATFORM_DRIVERS)/maxim_gpio_irq.h  		\
         $(PLATFORM_DRIVERS)/maxim_irq.h       		\
         $(PLATFORM_DRIVERS)/maxim_i2c.h       		\


### PR DESCRIPTION
## Pull Request Description

The header files "maxim_delay.h" and "maxim_init.h" do not exist. In some cases, build errors are generated because of this. This commit removes them from the list of included headers.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
