### PR TITLE
drivers:platform:stm32:pwm: Add PWM Slave mode

### DIFF
--- a/drivers/platform/stm32/stm32_pwm.c
+++ b/drivers/platform/stm32/stm32_pwm.c
@@ -248,6 +248,9 @@ static int32_t stm32_init_timer(struct stm32_pwm_desc *desc,
 	if (sparam->onepulse_enable) {
 		if (HAL_TIM_OnePulse_Init(htimer, TIM_OPMODE_SINGLE) != HAL_OK)
 			return -EIO;
+	} else {
+		if (HAL_TIM_OnePulse_Init(htimer, TIM_OPMODE_REPETITIVE) != HAL_OK)
+			return -EIO;
 	}
 
 	switch (sparam->trigger_output) {
@@ -743,10 +746,10 @@ int32_t stm32_pwm_remove(struct no_os_pwm_desc *desc)
 	case STM32_PWM_TIMER_TIM:
 		htimer = (TIM_HandleTypeDef *) extra->htimer;
 
-		if (HAL_TIM_Base_DeInit(htimer) != HAL_OK)
+		if (HAL_TIM_PWM_DeInit(htimer) != HAL_OK)
 			return -EIO;
 
-		if (HAL_TIM_PWM_DeInit(htimer) != HAL_OK)
+		if (HAL_TIM_Base_DeInit(htimer) != HAL_OK)
 			return -EIO;
 		break;
 #endif

--- a/drivers/platform/stm32/stm32_pwm.h
+++ b/drivers/platform/stm32/stm32_pwm.h
@@ -51,6 +51,7 @@ enum TimOCMode {
 };
 
 enum stm32_pwm_trigger {
+	PWM_TS_NONE,
 	PWM_TS_ITR0,
 	PWM_TS_ITR1,
 	PWM_TS_ITR2,
@@ -67,6 +68,13 @@ enum stm32_pwm_trigger_out {
 	PWM_TRGO_OC3REF,
 	PWM_TRGO_OC4REF,
 };
+
+enum stm32_pwm_slave_mode {
+	STM32_PWM_SM_DISABLE,
+	STM32_PWM_SM_TRIGGER,
+	STM32_PWM_SM_EXTERNAL1,
+};
+
 /**
  * @struct stm32_pwm_init_param
  * @brief Structure holding the STM32 PWM parameters.
@@ -90,8 +98,8 @@ struct stm32_pwm_init_param {
 	uint32_t (*get_timer_clock)(void);
 	/** Get timer source clock divider */
 	uint32_t clock_divider;
-	/** Enable trigger source */
-	bool trigger_enable;
+	/** Slave mode */
+	enum stm32_pwm_slave_mode slave_mode;
 	/** Trigger source selection */
 	enum stm32_pwm_trigger trigger_source;
 	/** Trigger out selection */

--- a/projects/ad463x_fmcz/src/platform/stm32/parameters.c
+++ b/projects/ad463x_fmcz/src/platform/stm32/parameters.c
@@ -98,7 +98,7 @@ struct stm32_pwm_init_param cs_pwm_extra_init_params = {
 	.get_timer_clock = HAL_RCC_GetPCLK1Freq,
 	.clock_divider = 2,
 	.onepulse_enable = true,
-	.trigger_enable = true,
+	.slave_mode = STM32_PWM_SM_TRIGGER,
 	.trigger_source = PWM_TS_ITR0,
 	.trigger_output = PWM_TRGO_ENABLE,
 };
@@ -125,7 +125,7 @@ struct stm32_pwm_init_param tx_pwm_extra_init_params = {
 	.get_timer_clock = HAL_RCC_GetPCLK2Freq,
 	.clock_divider = 2,
 	.onepulse_enable = true,
-	.trigger_enable = true,
+	.slave_mode = STM32_PWM_SM_TRIGGER,
 	.trigger_source = PWM_TS_ITR0,
 	.dma_enable = true,
 	.repetitions = TX_PWM_REPS,

--- a/projects/ad738x_fmcz/src/platform/stm32/parameters.c
+++ b/projects/ad738x_fmcz/src/platform/stm32/parameters.c
@@ -93,7 +93,7 @@ struct stm32_pwm_init_param cs_pwm_extra_init_params = {
 	.get_timer_clock = HAL_RCC_GetPCLK1Freq,
 	.clock_divider = 2,
 	.onepulse_enable = true,
-	.trigger_enable = true,
+	.slave_mode = STM32_PWM_SM_TRIGGER,
 	.trigger_source = PWM_TS_ITR0,
 	.trigger_output = PWM_TRGO_ENABLE,
 };
@@ -120,7 +120,7 @@ struct stm32_pwm_init_param tx_pwm_extra_init_params = {
 	.get_timer_clock = HAL_RCC_GetPCLK2Freq,
 	.clock_divider = 2,
 	.onepulse_enable = true,
-	.trigger_enable = true,
+	.slave_mode = STM32_PWM_SM_TRIGGER,
 	.trigger_source = PWM_TS_ITR0,
 	.dma_enable = true,
 	.repetitions = TX_PWM_REPS,


### PR DESCRIPTION
## Pull Request Description

Added Slave modes for timers to select trigger, external1 mode and none.
Fixed previous configuration retention in timers. When timers are reinitialized i.e. pwm_remove and then pwm_init called, previous configuration is getting retained for one-pulse mode.

Also Fixes: 9264d8983c4e ("drivers/platform/stm32: stm32 pwm support.")
Also Fixes: 247be2df09cf("platform: stm32: pwm: Add onepulse option")

## PR Type
- [x] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [x] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
