### PR TITLE
filter: admv8818: force initialization of SDO

### DIFF
--- a/drivers/filter/admv8818/admv8818.c
+++ b/drivers/filter/admv8818/admv8818.c
@@ -346,19 +346,15 @@ int admv8818_init(struct admv8818_dev **device,
 	if (ret)
 		goto error_dev;
 
-	ret = admv8818_spi_update_bits(dev, ADMV8818_REG_SPI_CONFIG_A,
-				       ADMV8818_SOFTRESET_N_MSK |
-				       ADMV8818_SOFTRESET_MSK,
-				       no_os_field_prep(ADMV8818_SOFTRESET_N_MSK, 1) |
-				       no_os_field_prep(ADMV8818_SOFTRESET_MSK, 1));
+	ret = admv8818_spi_write(dev, ADMV8818_REG_SPI_CONFIG_A,
+				 no_os_field_prep(ADMV8818_SOFTRESET_N_MSK, 1) |
+				 no_os_field_prep(ADMV8818_SOFTRESET_MSK, 1));
 	if (ret)
 		goto error_spi;
 
-	ret = admv8818_spi_update_bits(dev, ADMV8818_REG_SPI_CONFIG_A,
-				       ADMV8818_SDOACTIVE_N_MSK |
-				       ADMV8818_SDOACTIVE_MSK,
-				       no_os_field_prep(ADMV8818_SDOACTIVE_N_MSK, 1) |
-				       no_os_field_prep(ADMV8818_SDOACTIVE_MSK, 1));
+	ret = admv8818_spi_write(dev, ADMV8818_REG_SPI_CONFIG_A,
+				 no_os_field_prep(ADMV8818_SDOACTIVE_N_MSK, 1) |
+				 no_os_field_prep(ADMV8818_SDOACTIVE_MSK, 1));
 	if (ret)
 		goto error_spi;
 


### PR DESCRIPTION
## Pull Request Description

When a weak pull-up is present on the SDO line, spi_update_bits fails to write both the SOFTRESET and SDOACTIVE bits because it incorrectly reads them as already set.

Since the soft reset disables the SDO line, performing a read-modify-write operation on ADI_SPI_CONFIG_A to enable the SDO line doesn't make sense. This change directly writes to the register instead of using spi_update_bits.

Fixes: 3755205246724f658a89eae985266bcc0185ae48 ("drivers:filter: add admv8818 support")

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
