### PR TITLE
drivers: dma: Fix DMA remove API

### DIFF
--- a/drivers/api/no_os_dma.c
+++ b/drivers/api/no_os_dma.c
@@ -152,7 +152,7 @@ int no_os_dma_remove(struct no_os_dma_desc *desc)
 		return 0;
 
 	for (i = 0; i < desc->num_ch; i++) {
-		ret = no_os_list_remove(desc->channels->sg_list);
+		ret = no_os_list_remove(desc->channels[i].sg_list);
 		if (ret)
 			return ret;
 


### PR DESCRIPTION
## Pull Request Description

Fix to deallocate memory for list descriptors of all channels in remove API.

Fixes: db62b45db6a5 ("Add a generic DMA API")

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
