### PR TITLE
projects: ad74416h: fix builds.json naming

### DIFF
--- a/projects/ad74416h/builds.json
+++ b/projects/ad74416h/builds.json
@@ -26,7 +26,7 @@
     "digital_input_loop": {
       "flags" : "EXAMPLE=digital_input_loop"
     },
-    "basic_example": {
+    "digital_output": {
       "flags" : "EXAMPLE=digital_output"
     },
     "temperature_2wire_rtd": {


### PR DESCRIPTION
## Pull Request Description

Fix build name for the digital output.

Fixes: 10602f926674 ("projects: ad74416h: add digital output example")

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
