### PR TITLE
doc: sphinx: conf.py: disable smartquotes

### DIFF
--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -52,3 +52,6 @@ html_theme = 'cosmic'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = []
+
+# Enable/Disable Smart Quotes used to convert quotation marks and dashes.
+smartquotes = False


### PR DESCRIPTION
## Pull Request Description

The documentation we provide contains also examples of commands which take input parameters with the double dash prefix (--). Due to the smartquotes being enabled by default in the sphinx configuration, the double dash is converted to typographical en-dash (–).

Example:
![image](https://github.com/user-attachments/assets/b47879e4-1f07-4c21-a354-3c4bce1cf5ba)


Disable smartquotes such that the commands provided into the documentation can be used properly without any confusion.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
