### PR TITLE
projects: eval-pqmon: add fallback path

### DIFF
--- a/projects/eval-pqmon/src/platform/maxim/platform_src.mk
+++ b/projects/eval-pqmon/src/platform/maxim/platform_src.mk
@@ -36,4 +36,7 @@ INCS +=	$(MAXIM_LIBRARIES)/MAXUSB/include/core/usb.h		\
 	
 SRCS +=	$(MAXIM_LIBRARIES)/MAXUSB/src/core/usb_event.c
 
-EXTRA_MATH_LIB = $(MAXIM_LIBRARIES)/CMSIS/5.9.0/DSP/Lib/libarm_cortexM4l_math.a
+EXTRA_MATH_LIB = $(shell find $(MAXIM_LIBRARIES)/CMSIS -path "*/DSP/*" -name "libarm_cortexM4l_math.a")
+ifeq ($(EXTRA_MATH_LIB),)
+	$(warning CMSIS DSP math library not found. Check MAXIM_LIBRARIES path.)
+endif


### PR DESCRIPTION
Add fallback for new Maxim library path.

## Pull Request Description

The path for libarm_cortexM4l_math.a is now MaximSDK/Libraries/CMSIS/5.9.0/DSP/1.16.2/Lib. Add fallback for this path. Keep old path for compatibility (?).

## PR Type
- [x] Bug fix (change that fixes an issue)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
