### PR TITLE
drivers:platform:stm32:stm32_dma.h: Fixed the trigger and private data

### DIFF
--- a/drivers/platform/stm32/stm32_dma.h
+++ b/drivers/platform/stm32/stm32_dma.h
@@ -58,6 +58,44 @@ enum stm32_dma_mode {
 };
 
 /**
+ * @enum stm32_dma_trig_mode
+ * @brief DMA Trigger Modes
+ */
+enum stm32_dma_trig_mode {
+	/** A Block Transfer is conditioned by trigger */
+	STM32_DMA_BLOCK_XFER_MODE,
+	/** A Repeated Block Transfer is conditioned by trigger */
+	STM32_DMA_REP_BLOCK_XFER_MODE,
+	/** A LLI Link Transfer is conditioned by trigger */
+	STM32_DMA_LLI_LINK_XFER_MODE,
+	/** A Single/Burst Transfer is conditioned by trigger */
+	STM32_DMA_SINGLE_BURST_MODE
+};
+
+/**
+ * @enum stm32_dma_trig_pol
+ * @brief DMA Trigger Polarity
+ */
+enum stm32_dma_trig_pol {
+	STM32_DMA_TRIG_MASKED,
+	STM32_DMA_TRIG_RISING,
+	STM32_DMA_TRIG_FALLING,
+};
+
+/**
+ * @struct stm32_dma_trigger
+ * @brief Trigger descriptor for triggering a DMA transfer
+ */
+struct stm32_dma_trigger {
+	/** Trigger ID */
+	uint32_t id;
+	/** Mode of trigger */
+	enum stm32_dma_trig_mode mode;
+	/** Polarity of trigger */
+	enum stm32_dma_trig_pol polarity;
+};
+
+/**
  * @struct stm32_dma_channel
  * @brief STM32 DMA Channels
  */
@@ -76,12 +114,16 @@ struct stm32_dma_channel {
 	enum stm32_dma_data_alignment per_data_alignment;
 	/* DMA Mode */
 	enum stm32_dma_mode dma_mode;
+	/* Trigger configuration */
+	struct stm32_dma_trigger *trig;
 	/* Source Address for the data */
 	uint8_t* src;
 	/* Destination Address for the data */
 	uint8_t* dst;
 	/* Transfer length in Bytes */
 	uint32_t length;
+	/* Private Channel Data */
+	void *priv_data;
 };
 
 struct stm32_dma_init_param {


### PR DESCRIPTION
## Pull Request Description

The GPDMA code required trigger configuration and private data descriptor to be defined in the stm32_dma_channel structure to work. This definition was missing and has been added here.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
