### PR TITLE
drivers: frequency: ad9545: fix warnings

### DIFF
--- a/drivers/frequency/ad9545/ad9545.c
+++ b/drivers/frequency/ad9545/ad9545.c
@@ -264,7 +264,7 @@ static int32_t ad9545_pll_clk_recalc_rate(struct no_os_clk_desc *hw,
 	uint32_t frac;
 	uint32_t mod;
 	int ret;
-	uint32_t m;
+	uint8_t m;
 	uint32_t n;
 	uint8_t i;
 
@@ -1388,7 +1388,7 @@ static int32_t ad9545_parse_plls(struct ad9545_dev *dev,
 
 		if (init_param->pll_clks[addr].internal_zero_delay_source_rate_hz >=
 		    AD9545_MAX_ZERO_DELAY_RATE) {
-			pr_err("Invalid zero-delay output rate: %llu.\n",
+			pr_err("Invalid zero-delay output rate: %lu.\n",
 			       init_param->pll_clks[addr].internal_zero_delay_source_rate_hz);
 			ret = -EINVAL;
 			goto out_fail;
@@ -2397,7 +2397,8 @@ int32_t ad9545_setup(struct ad9545_dev *dev)
  */
 int32_t ad9545_remove(struct ad9545_dev *dev)
 {
-	int32_t ret, i;
+	int32_t ret;
+	uint32_t i;
 
 	if (!dev)
 		return -EINVAL;


### PR DESCRIPTION
1st warning:

noos/drivers/frequency/ad9545/ad9545.c:272:80: error: passing argument 3 of ‘ad9545_read_reg’ from incompatible pointer type [-Wincompatible-pointer-types]
  272 |         ret = ad9545_read_reg(hw->dev_desc, AD9545_APLLX_M_DIV(hw->hw_ch_num), &m);
      |                                                                                ^~
      |                                                                                |
      |                                                                                uint32_t * {aka unsigned int *}
noos/drivers/frequency/ad9545/ad9545.c:57:34: note: expected ‘uint8_t *’ {aka ‘unsigned char *’} but argument is of type ‘uint32_t *’ {aka ‘unsigned int *’}
   57 |                         uint8_t *reg_data)

2nd warning:
noos/drivers/frequency/ad9545/ad9545.c: In function ‘ad9545_parse_plls’: noos/include/no_os_print_log.h:90:16: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 5 has type ‘uint64_t’ {aka ‘long unsigned int’} [-Wformat=]
   90 |         printf("ERR: %s:%d:%s(): " fmt, __FILE__, __LINE__, __func__, ##args);  \
      |                ^~~~~~~~~~~~~~~~~~~

3rd warning:
noos/drivers/frequency/ad9545/ad9545.c:2412:23: warning: comparison of integer expressions of different signedness: ‘int32_t’ {aka ‘int’} and ‘long unsigned int’ [-Wsign-compare]
 2412 |         for (i = 0; i < NO_OS_ARRAY_SIZE(dev->clks); i++) {
      |                       ^

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
