### PR TITLE
rf-transceiver: ad9361: ad9361.c: Return calib err

### DIFF
--- a/drivers/rf-transceiver/ad9361/ad9361.c
+++ b/drivers/rf-transceiver/ad9361/ad9361.c
@@ -5671,7 +5671,7 @@ int32_t ad9361_setup(struct ad9361_rf_phy *phy)
 int32_t ad9361_do_calib_run(struct ad9361_rf_phy *phy, uint32_t cal,
 			    int32_t arg)
 {
-	int32_t ret;
+	int32_t ret, ret2;
 
 	dev_dbg(&phy->spi->dev, "%s: CAL %"PRIu32" ARG %"PRId32, __func__, cal, arg);
 
@@ -5695,11 +5695,11 @@ int32_t ad9361_do_calib_run(struct ad9361_rf_phy *phy, uint32_t cal,
 		break;
 	}
 
-	ret = ad9361_tracking_control(phy, phy->bbdc_track_en,
-				      phy->rfdc_track_en, phy->quad_track_en);
+	ret2 = ad9361_tracking_control(phy, phy->bbdc_track_en,
+				       phy->rfdc_track_en, phy->quad_track_en);
 	ad9361_ensm_restore_prev_state(phy);
 
-	return ret;
+	return ret ? ret : ret2;
 }
 
 /**


### PR DESCRIPTION
## Pull Request Description

Return error in case TX_QUAD_CAL or RFDC_CAL fail.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
