### PR TITLE
drivers:platform:stm32:stm32_pwm.c: PWM related bugfixes

### DIFF
--- a/drivers/platform/stm32/stm32_pwm.c
+++ b/drivers/platform/stm32/stm32_pwm.c
@@ -307,7 +307,7 @@ static int32_t stm32_init_timer(struct stm32_pwm_desc *desc,
 		sparam->timer_callback.ctx = desc;
 		sparam->timer_callback.event = NO_OS_EVT_TIM_PWM_PULSE_FINISHED;
 		sparam->timer_callback.peripheral = NO_OS_TIM_IRQ;
-		sparam->timer_callback.handle = &desc->htimer;
+		sparam->timer_callback.handle = htimer;
 
 		ret = no_os_irq_register_callback(desc->nvic_tim, param->irq_id,
 						  &sparam->timer_callback);


### PR DESCRIPTION
## Pull Request Description

The PWM implementation had two issues:

1. The handle assigned to the timer_callback structure for the timer was incorrect.
2. The usage of the prescaler for the LPTimer was flawed. The prescaler in the Timer and LPTimer functions differently: in the Timer, the prescaler is incremented by 1 before dividing the clock, whereas in the LPTimer, the prescaler is used directly as specified in the register.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
