### PR TITLE
drivers: digital-io : Fix reg_write function for spi_transfer usage

### DIFF
--- a/drivers/dac/max22017/max22017.c
+++ b/drivers/dac/max22017/max22017.c
@@ -514,6 +514,7 @@ int max22017_reg_write(struct max22017_desc *desc, uint32_t addr, uint32_t val)
 {
 	struct no_os_spi_msg xfer = {
 		.tx_buff = desc->buff,
+		.rx_buff = desc->buff,
 		.bytes_number = MAX22017_FRAME_SIZE,
 		.cs_change = 1,
 	};

--- a/drivers/digital-io/max149x6/max149x6-base.c
+++ b/drivers/digital-io/max149x6/max149x6-base.c
@@ -99,6 +99,7 @@ int max149x6_reg_write(struct max149x6_desc *desc, uint32_t addr, uint32_t val)
 {
 	struct no_os_spi_msg xfer = {
 		.tx_buff = desc->buff,
+		.rx_buff = desc->buff,
 		.bytes_number = MAX149X6_FRAME_SIZE,
 		.cs_change = 1,
 	};

--- a/drivers/digital-io/max22190/max22190.c
+++ b/drivers/digital-io/max22190/max22190.c
@@ -376,6 +376,7 @@ int max22190_reg_write(struct max22190_desc *desc, uint32_t addr, uint32_t val)
 {
 	struct no_os_spi_msg xfer = {
 		.tx_buff = desc->buff,
+		.rx_buff = desc->buff,
 		.bytes_number = MAX22190_FRAME_SIZE,
 		.cs_change = 1,
 	};

--- a/drivers/digital-io/max22196/max22196.c
+++ b/drivers/digital-io/max22196/max22196.c
@@ -94,6 +94,7 @@ int max22196_reg_write(struct max22196_desc *desc, uint32_t reg, uint32_t val)
 {
 	struct no_os_spi_msg xfer = {
 		.tx_buff = desc->buff,
+		.rx_buff = desc->buff,
 		.bytes_number = MAX22196_FRAME_SIZE,
 		.cs_change = 1,
 	};


### PR DESCRIPTION
## Pull Request Description

Some platforms have an spi_transfer function in their platform ops, and some don't.
In case of those who don't, noOS calls no_os_spi_write_then_read for each message,
and one condition is for the rx_buff to be equal to tx_buff, which for these specific
drivers was not true as for the reg_write functions.

This PR fixes this problem by allocating the buffer pointer to both rx_buff and tx_buff,
although for a reg_write the rx_buff, doesn't really matter.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
