### PR TITLE
drivers: platform: maxim: max32650: Fix spi config

### DIFF
--- a/drivers/platform/maxim/max32650/maxim_spi.c
+++ b/drivers/platform/maxim/max32650/maxim_spi.c
@@ -209,13 +209,13 @@ static int32_t _max_spi_config_pins(struct no_os_spi_desc *desc)
 
 		switch (desc->chip_select) {
 		case 0:
-			cs = gpio_cfg_spi2_ss0;
+			cs = gpio_cfg_spi3_ss0;
 			break;
 		case 1:
-			cs = gpio_cfg_spi2_ss1;
+			cs = gpio_cfg_spi3_ss1;
 			break;
 		case 2:
-			cs = gpio_cfg_spi2_ss2;
+			cs = gpio_cfg_spi3_ss2;
 			break;
 		case 3:
 			cs = gpio_cfg_spi3_ss3;


### PR DESCRIPTION
Fix spi chip select configuration for MAX32650.

## Pull Request Description

For device_id==3 use spi3 configuration.

## PR Type
- [x] Bug fix (change that fixes an issue)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
