### PR TITLE
drivers: adc: ad9656: Fixed PN mismatch error

### DIFF
--- a/drivers/adc/ad9656/ad9656.c
+++ b/drivers/adc/ad9656/ad9656.c
@@ -103,20 +103,26 @@ int32_t ad9656_reg_write(struct ad9656_dev *dev,
  * @param dev - The device handler for the ad9656 chip
  * @param test_mode - The type of test that is to be performed or OFF if the testing
  * 					  process is to be stopped
+ * @param link_mode - Used for link control, it also specifies what type of test is
+ * 					  is going to be performed, OFF if no testing is done
  * @return 0 if the ad9656 chip could be successfully set for JESD204 link testing,
  * 		   -1 otherwise
  */
 int32_t ad9656_JESD204_test(struct ad9656_dev *dev,
-			    uint32_t test_mode)
+			    uint32_t test_mode, uint32_t link_mode)
 {
 	uint8_t format;
 	int32_t ret;
+
+	ret = ad9656_reg_write(dev, AD9656_REG_LINK_MODE, link_mode);
+	if (ret != 0)
+		return ret;
 
 	ret = ad9656_reg_write(dev, AD9656_REG_ADC_TEST_MODE, test_mode);
 	if (ret != 0)
 		return ret;
 
-	if (test_mode == AD9656_TEST_OFF)
+	if (test_mode != AD9656_TEST_OFF)
 		format = AD9656_FORMAT_OFFSET_BINARY;
 	else
 		format = AD9656_FORMAT_2S_COMPLEMENT;

--- a/drivers/adc/ad9656/ad9656.h
+++ b/drivers/adc/ad9656/ad9656.h
@@ -45,6 +45,7 @@
 #define AD9656_REG_USER_TEST_PATTERN_2_LSB 			0x1B
 #define AD9656_REG_USER_TEST_PATTERN_2_MSB			0x1C
 #define AD9656_REG_LINK_CONTROL					0x05F
+#define AD9656_REG_LINK_MODE					0x61
 #define AD9656_REG_JESD204B_LANE_RATE_CTRL			0x021
 #define AD9656_REG_JESD204B_PLL_LOCK_STATUS			0x00A
 #define AD9656_REG_JESD204B_QUICK_CONFIG			0x05E
@@ -60,6 +61,9 @@
 #define AD9656_TEST_OFF						0x000
 #define AD9656_TEST_PN9						0x006
 #define AD9656_TEST_PN23					0x005
+#define AD9656_LINK_OFF						0x000
+#define AD9656_LINK_PN9						0x004
+#define AD9656_LINK_PN23					0x003
 #define AD9656_TEST_USER_INPUT					0x048
 #define AD9656_FORMAT_2S_COMPLEMENT				0x001
 #define AD9656_FORMAT_OFFSET_BINARY				0x000
@@ -97,7 +101,7 @@ int32_t ad9656_setup(struct ad9656_dev **device,
 int32_t ad9656_remove(struct ad9656_dev *dev);
 
 int32_t ad9656_JESD204_test(struct ad9656_dev *dev,
-			    uint32_t test_mode);
+			    uint32_t test_mode, uint32_t link_mode);
 
 int32_t ad9656_user_input_test(struct ad9656_dev *dev, uint32_t test_mode,
 			       struct ad9656_user_input_test_pattern user_input_test_pattern);

--- a/projects/ad9656_fmc/src/app/ad9656_fmc.c
+++ b/projects/ad9656_fmc/src/app/ad9656_fmc.c
@@ -225,20 +225,20 @@ int main(void)
 //******************************************************************************
 
 	/* receive path testing */
-	ad9656_JESD204_test(ad9656_device, AD9656_TEST_PN9);
+	ad9656_JESD204_test(ad9656_device, AD9656_TEST_PN9, AD9656_LINK_PN9);
 	if (axi_adc_pn_mon(ad9656_core, AXI_ADC_PN9, 10) == -1) {
 		printf("%s ad9656 - PN9 sequence mismatch!\n", __func__);
 	} else {
 		printf("%s ad9656 - PN9 sequence checked!\n", __func__);
 	}
-	ad9656_JESD204_test(ad9656_device, AD9656_TEST_PN23);
+	ad9656_JESD204_test(ad9656_device, AD9656_TEST_PN23, AD9656_LINK_PN23);
 	if (axi_adc_pn_mon(ad9656_core, AXI_ADC_PN23A, 10) == -1) {
 		printf("%s ad9656 - PN23 sequence mismatch!\n", __func__);
 	} else {
 		printf("%s ad9656 - PN23 sequence checked!\n", __func__);
 	}
 
-	ad9656_JESD204_test(ad9656_device, AD9656_TEST_OFF);
+	ad9656_JESD204_test(ad9656_device, AD9656_TEST_OFF, AD9656_LINK_OFF);
 
 //******************************************************************************
 // generate user input in place of real ADC data and capture data with DMA


### PR DESCRIPTION
Fixed an issue which would throw a message that said that the PN9 and PN23 check sequences don't match. The issue was present because the chip has two registers which need to be written with the desired PN sequence in order to test the PN mechanism. Only one register was written, thus prompting the mismatch error. The changes affect the driver & the project.

HDL PR regarding AD9656: https://github.com/analogdevicesinc/hdl/pull/1622

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
