### PR TITLE
adrv9009: app_talise.c: Do not enable ORx, Tx

### DIFF
--- a/projects/adrv9009/Makefile
+++ b/projects/adrv9009/Makefile
@@ -3,9 +3,9 @@ MB ?= n
 include ../../tools/scripts/generic_variables.mk
 
 # Uncomment to select the profile:
-#PROFILE = tx_bw100_ir122p88_rx_bw100_or122p88_orx_bw100_or122p88_dc122p88
+PROFILE = tx_bw100_ir122p88_rx_bw100_or122p88_orx_bw100_or122p88_dc122p88
 #PROFILE = tx_bw200_ir245p76_rx_bw200_or245p76_orx_bw200_or245p76_dc245p76
-PROFILE = tx_bw400_ir491p52_rx_bw200_or245p76_orx_bw400_or491p52_dc245p76
+#PROFILE = tx_bw400_ir491p52_rx_bw200_or245p76_orx_bw400_or491p52_dc245p76
 
 ifeq (n,$(strip $(MB)))
 include arm_src.mk

--- a/projects/adrv9009/src/app/app_talise.c
+++ b/projects/adrv9009/src/app/app_talise.c
@@ -381,6 +381,7 @@ adiHalErr_t talise_setup(taliseDevice_t * const pd, taliseInit_t * const pi)
 		axi_jesd204_rx_lane_clk_enable(rx_jesd);
 #endif
 
+#ifndef ADRV9008_1
 	if (talInit.obsRx.obsRxChannelsEnable != TAL_RXOFF)
 		axi_jesd204_rx_lane_clk_enable(rx_os_jesd);
 
@@ -396,6 +397,7 @@ adiHalErr_t talise_setup(taliseDevice_t * const pd, taliseInit_t * const pi)
 		ADIHAL_spiWriteByte(pd->devHalInfo, TALISE_ADDR_DES_PHY_GENERAL_CTL_1,
 				    phy_ctrl);
 	}
+#endif
 
 	ADIHAL_sysrefReq(pd->devHalInfo, SYSREF_CONT_OFF);
 


### PR DESCRIPTION
## Pull Request Description

Do not enable lane clock for ORx and Tx paths in case of an ADRV9008-1 device.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
