### PR TITLE
Add burnout current and PGA gain functionality to ad7124 driver

### DIFF
--- a/drivers/adc/ad7124/ad7124.c
+++ b/drivers/adc/ad7124/ad7124.c
@@ -857,6 +857,32 @@ int ad7124_set_polarity(struct ad7124_dev* device,
 	return 0;
 }
 
+/***************************************************************************//**
+ * @brief Set the Magnitude of the Burnout Detect Current Source
+ * @param device - AD7124 Device Descriptor.
+ * @param burnout - Burnout current.
+ * @param setup_id - Setup ID (number).
+ * @return Returns 0 for success or negative error code otherwise.
+*****************************************************************************/
+int ad7124_set_burnout(struct ad7124_dev* device,
+		       enum ad7124_burnout burnout,
+		       uint8_t setup_id)
+{
+	int ret;
+
+	ret = ad7124_reg_write_msk(device,
+				   AD7124_CFG0_REG + setup_id,
+				   no_os_field_prep(AD7124_SETUP_CONF_REG_BURNOUT_MSK, burnout),
+				   AD7124_SETUP_CONF_REG_BURNOUT_MSK);
+
+	if (ret)
+		return ret;
+
+	device->setups[setup_id].burnout = burnout;
+
+	return 0;
+}
+
 /***************************************************************************//*
  * @brief Select the reference source.
  * @param device - AD7124 Device Descriptor.
@@ -1082,6 +1108,13 @@ int32_t ad7124_setup(struct ad7124_dev **device,
 		ret = ad7124_set_polarity(dev,
 					  init_param->setups[setup_index].bi_unipolar,
 					  setup_index);
+		if (ret)
+			goto error_spi;
+
+		ret = ad7124_set_burnout(dev,
+					 init_param->setups[setup_index].burnout,
+					 setup_index);
+
 		if (ret)
 			goto error_spi;
 

--- a/drivers/adc/ad7124/ad7124.c
+++ b/drivers/adc/ad7124/ad7124.c
@@ -955,6 +955,32 @@ int ad7124_enable_buffers(struct ad7124_dev* device,
 }
 
 /***************************************************************************//**
+ * @brief Select the PGA Gain.
+ * @param device - AD7124 Device Descriptor.
+ * @param pga - PGA gain.
+ * @param setup_id - Setup ID (Number).
+ * @return Returns 0 for success or negative error code otherwise.
+******************************************************************************/
+int ad7124_set_pga(struct ad7124_dev* device,
+		   enum ad7124_pga pga,
+		   uint8_t setup_id)
+{
+	int ret;
+
+	ret = ad7124_reg_write_msk(device,
+				   AD7124_CFG0_REG + setup_id,
+				   no_os_field_prep(AD7124_SETUP_CONF_REG_PGA_MSK, pga),
+				   AD7124_SETUP_CONF_REG_PGA_MSK);
+
+	if (ret)
+		return ret;
+
+	device->setups[setup_id].pga = pga;
+
+	return 0;
+}
+
+/***************************************************************************//**
  * @brief Select the Power Mode.
  * @param device - AD7124 Device Descriptor.
  * @param mode - ADC Power Mode.
@@ -1070,6 +1096,13 @@ int32_t ad7124_setup(struct ad7124_dev **device,
 					    init_param->setups[setup_index].ain_buff,
 					    init_param->setups[setup_index].ref_buff,
 					    setup_index);
+		if (ret)
+			goto error_spi;
+
+		ret = ad7124_set_pga(dev,
+				     init_param->setups[setup_index].pga,
+				     setup_index);
+
 		if (ret)
 			goto error_spi;
 	}

--- a/drivers/adc/ad7124/ad7124.h
+++ b/drivers/adc/ad7124/ad7124.h
@@ -270,6 +270,7 @@
 #define AD7124_CHMAP_REG_AINPOS_MSK    		NO_OS_GENMASK(9,5)
 #define AD7124_CHMAP_REG_AINNEG_MSK    		NO_OS_GENMASK(4,0)
 #define AD7124_ADC_CTRL_REG_MODE_MSK   		NO_OS_GENMASK(5,2)
+#define AD7124_SETUP_CONF_REG_BURNOUT_MSK	NO_OS_GENMASK(10,9)
 #define AD7124_SETUP_CONF_REG_REF_SEL_MSK	NO_OS_GENMASK(4,3)
 #define AD7124_SETUP_CONF_REG_PGA_MSK       NO_OS_GENMASK(2,0)
 #define AD7124_REF_BUF_MSK                  NO_OS_GENMASK(8,7)
@@ -359,6 +360,21 @@ struct ad7124_channel_map {
 };
 
 /**
+ * @enum ad7124_burnout
+ * @brief Burnout current values
+ */
+enum ad7124_burnout {
+	/* Off */
+	AD7124_BURNOUT_OFF,
+	/* 500nA */
+	AD7124_BURNOUT_500N,
+	/* 2 uA */
+	AD7124_BURNOUT_2U,
+	/* 4 uA */
+	AD7124_BURNOUT_4U,
+};
+
+/**
  * @enum ad7124_reference_source
  * @brief Type of ADC Reference
 **/
@@ -396,6 +412,7 @@ enum ad7124_pga {
 **/
 struct ad7124_channel_setup {
 	bool bi_unipolar;
+	enum ad7124_burnout burnout;
 	bool ref_buff;
 	bool  ain_buff;
 	enum ad7124_reference_source ref_source;
@@ -634,6 +651,11 @@ int ad7124_assign_setup(struct ad7124_dev *device,
 int ad7124_set_polarity(struct ad7124_dev* device,
 			bool bipolar,
 			uint8_t setup_id);
+
+/* Assign magnitude of burnout current source to setup */
+int ad7124_set_burnout(struct ad7124_dev* device,
+		       enum ad7124_burnout burnout,
+		       uint8_t setup_id);
 
 /* Assign reference source to setup */
 int ad7124_set_reference_source(struct ad7124_dev* device,

--- a/drivers/adc/ad7124/ad7124.h
+++ b/drivers/adc/ad7124/ad7124.h
@@ -271,6 +271,7 @@
 #define AD7124_CHMAP_REG_AINNEG_MSK    		NO_OS_GENMASK(4,0)
 #define AD7124_ADC_CTRL_REG_MODE_MSK   		NO_OS_GENMASK(5,2)
 #define AD7124_SETUP_CONF_REG_REF_SEL_MSK	NO_OS_GENMASK(4,3)
+#define AD7124_SETUP_CONF_REG_PGA_MSK       NO_OS_GENMASK(2,0)
 #define AD7124_REF_BUF_MSK                  NO_OS_GENMASK(8,7)
 #define AD7124_AIN_BUF_MSK                  NO_OS_GENMASK(6,5)
 #define AD7124_POWER_MODE_MSK			    NO_OS_GENMASK(7,6)
@@ -375,6 +376,21 @@ enum ad7124_reference_source {
 };
 
 /**
+ * @enum ad7124_pga
+ * @brief PGA gains
+ */
+enum ad7124_pga {
+	AD7124_PGA_1,
+	AD7124_PGA_2,
+	AD7124_PGA_4,
+	AD7124_PGA_8,
+	AD7124_PGA_16,
+	AD7124_PGA_32,
+	AD7124_PGA_64,
+	AD7124_PGA_128
+};
+
+/**
   * @struct ad7124_channel_setup
   * @brief Channel setup
 **/
@@ -383,6 +399,7 @@ struct ad7124_channel_setup {
 	bool ref_buff;
 	bool  ain_buff;
 	enum ad7124_reference_source ref_source;
+	enum ad7124_pga pga;
 };
 
 /**
@@ -629,6 +646,11 @@ int ad7124_enable_buffers(struct ad7124_dev* device,
 			  bool ain_buff,
 			  bool ref_buff,
 			  uint8_t setup_id);
+
+/* Assign PGA gain to setup */
+int ad7124_set_pga(struct ad7124_dev* device,
+		   enum ad7124_pga pga,
+		   uint8_t setup_id);
 
 /* Select the power mode */
 int ad7124_set_power_mode(struct ad7124_dev *device,


### PR DESCRIPTION
## Pull Request Description

I noticed that all functions and structs were implemented to be able to set all the fields in the "CHANNEL_x" and "CONFIG_x" registers, apart from the "PGA" and "Burnout" fields of the "CONFIG_x" registers. The aim of this PR is to add functions which allow the user to set those bit fields, and to initialise them in the `ad7124_setup()` function by adding to the `ad7124_init_param` struct.

I have tested these changes on a custom board with a AD7124_8 chip.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
