### PR TITLE
ad9656_fmc: src: app: ad9656_fmc.c: Add delay

### DIFF
--- a/projects/ad9656_fmc/src/app/ad9656_fmc.c
+++ b/projects/ad9656_fmc/src/app/ad9656_fmc.c
@@ -282,6 +282,8 @@ int main(void)
 
 	printf("ad9656: setup, configuration and test program is done\n");
 
+	no_os_mdelay(10);
+
 #ifdef IIO_SUPPORT
 	struct xil_uart_init_param platform_uart_init_par = {
 #ifdef XPAR_XUARTLITE_NUM_INSTANCES


### PR DESCRIPTION
## Pull Request Description

Add a 10ms delay so that messages have time to be displayed before starting the iio server.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
