### PR TITLE
projects: aducm3029_flash_demo: fix missing irq ops

### DIFF
--- a/projects/aducm3029_flash_demo/src/main.c
+++ b/projects/aducm3029_flash_demo/src/main.c
@@ -41,6 +41,7 @@
 #include "no_os_uart.h"
 #include "aducm3029_uart.h"
 #include "aducm3029_uart_stdio.h"
+#include "aducm3029_irq.h"
 
 /***************************************************************************//**
  * @brief main
@@ -72,6 +73,7 @@ int main(int argc, char *argv[])
 	struct no_os_irq_ctrl_desc *irq_dut;
 	struct no_os_irq_init_param irq_init = {
 		.irq_ctrl_id = 0,
+		.platform_ops = &aducm_irq_ops,
 		.extra = NULL
 	};
 


### PR DESCRIPTION
Fix a runtime bug where the ops were not initialized.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
