### PR TITLE
Staging/adf4382

### DIFF
--- a/drivers/frequency/adf4382/adf4382.h
+++ b/drivers/frequency/adf4382/adf4382.h
@@ -1,8 +1,8 @@
 /***************************************************************************//**
  *   @file   adf4382.h
  *   @brief  Implementation of adf4382 Driver.
- *   @authors Ciprian Hegbeli (ciprian.hegbeli@analog.com)
- *            Jude Osemene (jude.osemene@analog.com)
+ *   @author Ciprian Hegbeli (ciprian.hegbeli@analog.com)
+ *   @author Jude Osemene (jude.osemene@analog.com)
 ********************************************************************************
  * Copyright 2024(c) Analog Devices, Inc.
  *
@@ -492,17 +492,19 @@
 
 #define ADF4382_VPTAT_CALGEN			46
 #define ADF4382_VCTAT_CALGEN			82
-#define ADF4382_FASTCAL_VPTAT_CALGEN		30
-#define ADF4382_FASTCAL_VCTAT_CALGEN		70
+#define ADF4382_FASTCAL_VPTAT_CALGEN		7
+#define ADF4382_FASTCAL_VCTAT_CALGEN		21
 #define ADF4382_PHASE_BLEED_CNST		2044000
 #define ADF4382_VCO_CAL_CNT			183
 #define ADF4382_VCO_CAL_VTUNE			640
 #define ADF4382_VCO_CAL_ALC			123
 #define ADF4382_POR_DELAY_US			200
-#define ADF4382_LKD_DELAY_US			500
+#define ADF4382_LKD_DELAY_US			1000
 #define ADF4382_COARSE_BLEED_CONST		180U	// 180 microseconds
 #define ADF4382_FINE_BLEED_CONST_1		512U	// 512 microseconds
 #define ADF4382_FINE_BLEED_CONST_2		250U	// 250 microseconds
+#define ADF4382_CAL_VTUNE_TO			124U
+#define ADF4382_FSM_BUSY_LOOP_CNT		100U
 
 #define MHZ					MEGA
 #define S_TO_NS					NANO
@@ -629,12 +631,13 @@ static const struct reg_sequence adf4382_reg_defaults[] = {
 	{ 0x040, 0x00 },
 	{ 0x03f, 0x82 },
 	{ 0x03e, 0x4E },
+	{ 0x03d, 0x20 },
 	{ 0x03c, 0x00 },
 	{ 0x03b, 0x00 },
 	{ 0x03a, 0xFA },
-	{ 0x039, 0x80 },
-	{ 0x038, 0x71 },
-	{ 0x037, 0x82 },
+	{ 0x039, 0x00 },
+	{ 0x038, 0x7C },
+	{ 0x037, 0xCA },
 	{ 0x036, 0xC0 },
 	{ 0x035, 0x00 },
 	{ 0x034, 0x36 },

--- a/drivers/frequency/adf4382/iio_adf4382.c
+++ b/drivers/frequency/adf4382/iio_adf4382.c
@@ -1,8 +1,8 @@
 /***************************************************************************//**
  *   @file   iio_adf4382.c
  *   @brief  Implementation of IIO ADF4382 Driver.
- *   @authors CHegbeli (ciprian.hegbeli@analog.com)
- *            Jude Osemene (jude.osemene@analog.com)
+ *   @author Ciprian Hegbeli (ciprian.hegbeli@analog.com)
+ *   @author Jude Osemene (jude.osemene@analog.com)
 ********************************************************************************
  * Copyright 2024(c) Analog Devices, Inc.
  *

--- a/drivers/frequency/adf4382/iio_adf4382.h
+++ b/drivers/frequency/adf4382/iio_adf4382.h
@@ -1,8 +1,8 @@
 /***************************************************************************//**
  *   @file   iio_adf4382.h
  *   @brief  Implementation of IIO ADF4382 Driver.
- *   @authors Ciprian Hegbeli (ciprian.hegbeli@analog.com)
- *            Jude Osemene (jude.osemene@analog.com)
+ *   @author Ciprian Hegbeli (ciprian.hegbeli@analog.com)
+ *   @author Jude Osemene (jude.osemene@analog.com)
 ********************************************************************************
  * Copyright 2024(c) Analog Devices, Inc.
  *


### PR DESCRIPTION
## Pull Request Description

This pull request is to further optimize fast calibration driver function for faster frequency hop times, also keeping the maximum PFD for Lookup Table generation at 125MHz. 
Also formatted the author section where there are more than one author. 

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
