### PR TITLE
i3c: Remove bus in case no device is attached on the bus

### DIFF
--- a/drivers/api/no_os_i3c.c
+++ b/drivers/api/no_os_i3c.c
@@ -286,6 +286,8 @@ int no_os_i3c_remove(struct no_os_i3c_desc *desc)
 		it++;
 	}
 
+	no_os_i3c_remove_bus(bus_desc);
+
 	/* Only error case is !desc */
 	desc->platform_ops->i3c_ops_remove(desc);
 	no_os_free(desc);
@@ -295,7 +297,7 @@ int no_os_i3c_remove(struct no_os_i3c_desc *desc)
 
 /**
  * @brief Free the resources allocated by no_os_i3c_init_bus.
- * Must remove all devices first, if not, -EFAULT is returned.
+ * Must remove all devices first, if not, -EBUSY is returned.
  * @param desc - The I3C bus descriptor.
  * @return 0 in case of success, error code otherwise.
  */
@@ -312,7 +314,7 @@ int no_os_i3c_remove_bus(struct no_os_i3c_bus_desc *desc)
 	/* Verify if all devices are removed */
 	for (it = desc->devs; it < desc->devs + NO_OS_I3C_MAX_DEV_NUMBER; it++) {
 		if (*it)
-			return -EFAULT;
+			return -EBUSY;
 	}
 
 	no_os_mutex_remove(desc->mutex);


### PR DESCRIPTION
## Pull Request Description

Harmonize the behavior with the i2c abstraction of removing the bus if no device is attached anymore.

Since the specification foresees hot-join events,
the original thought was that it made sense to keep bus allocated during the execution life-time, even if no device is attached. Revisiting it, for a hot-join implementation would make more sense to have a device attached with a "may_join" flag, and have some sort of init defer mechanism on the part drivers.

Change error code from -EFAULT to -EBUSY as in "the bus is busy because there are devices attached please remove them first and try again later"

Slightly related to #2460 and discussed with @SwaroopPKADI

## PR Type
- [X] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [X] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [X] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [X] I have performed a self-review of the changes
- [X] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
