### PR TITLE
drivers:adc:ad738x: Fix build failures for platforms other than xilinx

### DIFF
--- a/drivers/adc/ad738x/ad738x.c
+++ b/drivers/adc/ad738x/ad738x.c
@@ -35,7 +35,9 @@
 #include "stdio.h"
 #include "stdlib.h"
 #include "stdbool.h"
+#ifdef XILINX_PLATFORM
 #include "spi_engine.h"
+#endif
 #include "ad738x.h"
 #include "no_os_delay.h"
 #include "no_os_error.h"
@@ -315,6 +317,7 @@ static int32_t ad738x_read_data_offload(struct ad738x_dev *dev,
 					uint32_t *buf,
 					uint16_t samples)
 {
+#ifdef XILINX_PLATFORM
 	int32_t ret;
 	uint32_t commands_data[2] = {0, 0};
 	struct spi_engine_offload_message msg;
@@ -344,6 +347,7 @@ static int32_t ad738x_read_data_offload(struct ad738x_dev *dev,
 	if (dev->dcache_invalidate_range)
 		dev->dcache_invalidate_range(msg.rx_addr, samples * 4);
 
+#endif
 	return 0;
 }
 
@@ -395,9 +399,11 @@ int32_t ad738x_init(struct ad738x_dev **device,
 	if (!dev)
 		return -1;
 
+	dev->flags = init_param->flags;
+
+#ifdef XILINX_PLATFORM
 	dev->offload_init_param = init_param->offload_init_param;
 	dev->dcache_invalidate_range = init_param->dcache_invalidate_range;
-	dev->flags = init_param->flags;
 
 	ret = axi_clkgen_init(&dev->clkgen, init_param->clkgen_init);
 	if (ret)
@@ -406,6 +412,7 @@ int32_t ad738x_init(struct ad738x_dev **device,
 	ret = axi_clkgen_set_rate(dev->clkgen, init_param->axi_clkgen_rate);
 	if (ret)
 		goto err;
+#endif
 
 	ret = no_os_pwm_init(&dev->pwm_desc, init_param->pwm_init);
 	if (ret)
@@ -456,9 +463,11 @@ int32_t ad738x_remove(struct ad738x_dev *dev)
 	if (ret)
 		goto out;
 
+#ifdef XILINX_PLATFORM
 	ret = axi_clkgen_remove(dev->clkgen);
 	if (ret)
 		goto out;
+#endif
 
 	ret = no_os_pwm_remove(dev->pwm_desc);
 	if (ret)

--- a/drivers/adc/ad738x/ad738x.h
+++ b/drivers/adc/ad738x/ad738x.h
@@ -36,8 +36,10 @@
 #define SRC_AD738X_H_
 
 #include "no_os_util.h"
-#include "clk_axi_clkgen.h"
 #include "no_os_spi.h"
+#ifdef XILINX_PLATFORM
+#include "clk_axi_clkgen.h"
+#endif
 
 /*
  * AD738X registers definition
@@ -140,9 +142,11 @@ enum ad738x_ref_sel {
 struct ad738x_dev {
 	/* SPI */
 	struct no_os_spi_desc		*spi_desc;
+#ifdef XILINX_PLATFORM
 	/** SPI module offload init */
 	struct spi_engine_offload_init_param *offload_init_param;
 	struct axi_clkgen *clkgen;
+#endif
 	struct no_os_pwm_desc *pwm_desc;
 
 	/* Device Settings */
@@ -158,10 +162,12 @@ struct ad738x_dev {
 struct ad738x_init_param {
 	/* SPI */
 	struct no_os_spi_init_param		*spi_param;
+#ifdef XILINX_PLATFORM
 	struct axi_clkgen_init *clkgen_init;
 	uint32_t axi_clkgen_rate;
 	/** SPI module offload init */
 	struct spi_engine_offload_init_param *offload_init_param;
+#endif
 	struct no_os_pwm_init_param *pwm_init;
 
 	/* Device Settings */

--- a/projects/ad738x_fmcz/src/common/common_data.c
+++ b/projects/ad738x_fmcz/src/common/common_data.c
@@ -72,9 +72,11 @@ struct no_os_pwm_init_param trigger_pwm_init_param = {
 
 struct ad738x_init_param ad738x_init_param = {
 	.spi_param = &ad738x_spi_init_param,
+#ifdef XILINX_PLATFORM
 	.clkgen_init = CLKGEN_INIT,
 	.axi_clkgen_rate = 100000000,
 	.offload_init_param = OFFLOAD_INIT,
+#endif
 	.dcache_invalidate_range =
 	(void (*)(uint32_t, uint32_t))DCACHE_INVALIDATE,
 	.pwm_init = &trigger_pwm_init_param,

--- a/projects/ad738x_fmcz/src/platform/xilinx/parameters.c
+++ b/projects/ad738x_fmcz/src/platform/xilinx/parameters.c
@@ -53,6 +53,7 @@ struct spi_engine_init_param spi_eng_init_param  = {
 	.data_width = 32,
 };
 
+#ifdef XILINX_PLATFORM
 struct spi_engine_offload_init_param spi_engine_offload_init_param = {
 	.offload_config = OFFLOAD_RX_EN,
 	.rx_dma_baseaddr = DMA_BASEADDR,
@@ -69,4 +70,5 @@ struct axi_pwm_init_param axi_pwm_init_param = {
 	.ref_clock_Hz = 100000000,
 	.channel = 0
 };
+#endif
 

--- a/projects/ad738x_fmcz/src/platform/xilinx/parameters.h
+++ b/projects/ad738x_fmcz/src/platform/xilinx/parameters.h
@@ -85,7 +85,9 @@
 
 extern struct xil_uart_init_param uart_extra_ip;
 extern struct axi_clkgen_init clkgen_init;
+#ifdef XILINX_PLATFORM
 extern struct spi_engine_offload_init_param spi_engine_offload_init_param;
+#endif
 extern struct spi_engine_init_param spi_eng_init_param;
 extern struct axi_pwm_init_param axi_pwm_init_param;
 


### PR DESCRIPTION
Add compile time checks for AXI function calls and header includes

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
