### PR TITLE
fix unit-tests build job

### DIFF
--- a/build_projects.yml
+++ b/build_projects.yml
@@ -236,7 +236,7 @@ jobs:
     persistCredentials: true
   - script: |
       sudo apt install ruby-full
-      sudo gem install ceedling -v 0.31.1
+      sudo gem install ceedling
       pip install gcovr==4.1
       cd tests/drivers/imu/
       ceedling test:all

--- a/tests/drivers/imu/project.yml
+++ b/tests/drivers/imu/project.yml
@@ -7,7 +7,7 @@
 
 :project:
   :use_exceptions: FALSE
-  :use_test_preprocessor: TRUE
+  :use_test_preprocessor: :all
   :use_auxiliary_dependencies: TRUE
   :build_root: build
 #  :release_build: TRUE
@@ -35,7 +35,9 @@
     - -:test/support
   :source:
     - ../../../drivers/imu/**
+  :include:
     - ../../../include/**
+    - ../../../drivers/imu/**
   :support:
     - test/support
   :libraries: []
@@ -97,13 +99,10 @@
   :artifact_filename: report_junit.xml
 
 :plugins:
-  :load_paths:
-    - "#{Ceedling.load_path}"
   :enabled:
-    - stdout_pretty_tests_report
+    - report_tests_pretty_stdout
     - module_generator
-    - raw_output_report
+    - report_tests_raw_output_log
     - gcov
-    - xml_tests_report
-    - junit_tests_report
+    - report_tests_log_factory
 ...


### PR DESCRIPTION
## Pull Request Description

Do not force to an older ceedling version, adapt the current test
infrastructure instead.

The new update on the ruby version does not comply with older ceedling
versions, causing the current unit-tests to fail.

Fixes: https://github.com/analogdevicesinc/no-OS/commit/b8e1efd1a3e1836735b9d6c4511d0ebd1843361d ("build_projects.yml: Fix Unit Tests job")

Update the tests configuration file to match the latest ceedling syntax.

See: https://github.com/ThrowTheSwitch/Ceedling/blob/master/docs/BreakingChanges.md

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
