### PR TITLE
drivers: platform: ftd2xx : Fix GPIO driver

### DIFF
--- a/drivers/platform/ftd2xx/mpsse/ftd2xx_gpio.c
+++ b/drivers/platform/ftd2xx/mpsse/ftd2xx_gpio.c
@@ -259,20 +259,20 @@ int32_t ftd2xx_gpio_get_value(struct no_os_gpio_desc *desc, uint8_t *value)
 {
 	struct ftd2xx_gpio_desc *extra_desc;
 	FT_STATUS status;
-	UCHAR value = 0;
+	UCHAR val = 0;
 	int32_t ret;
 
 	extra_desc = desc->extra;
 	if (no_os_field_get(NO_OS_BIT(desc->number),
 			    extra_desc->pins_dir) == NO_OS_GPIO_IN) {
-		status = FT_ReadGPIO(extra_desc->ftHandle, &value);
+		status = FT_ReadGPIO(extra_desc->ftHandle, &val);
 		if (status != FT_OK) {
 			ret = status;
 			return ret;
 		}
 		extra_desc->pins_val &= ~NO_OS_BIT(desc->number);
 		extra_desc->pins_val |= NO_OS_BIT(desc->number) & no_os_field_prep(NO_OS_BIT(
-						desc->number), no_os_field_get(NO_OS_BIT(desc->number), value));
+						desc->number), no_os_field_get(NO_OS_BIT(desc->number), val));
 	}
 
 	*value = no_os_field_get(NO_OS_BIT(desc->number), extra_desc->pins_val);

--- a/drivers/platform/ftd2xx/mpsse/ftd2xx_gpio.c
+++ b/drivers/platform/ftd2xx/mpsse/ftd2xx_gpio.c
@@ -108,7 +108,7 @@ error:
 int32_t ftd2xx_gpio_get_optional(struct no_os_gpio_desc **desc,
 				 const struct no_os_gpio_init_param *param)
 {
-	if (param = NULL) {
+	if (!param) {
 		*desc = NULL;
 		return 0;
 	}


### PR DESCRIPTION
## Pull Request Description

Fix same variable name for different variables in GPIO driver.
Fix syntax error in gpio function.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
