### PR TITLE
Add ethernet support to eval-pqmon

### DIFF
--- a/drivers/net/w5500/w5500.c
+++ b/drivers/net/w5500/w5500.c
@@ -1,0 +1,1118 @@
+/***************************************************************************//**
+*   @file   w5500.c
+*   @brief  Implementation of W5500 Driver
+*   @author Alisa-Dariana Roman (alisa.roman@analog.com)
+********************************************************************************
+* Copyright 2025(c) Analog Devices, Inc.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* 3. Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived from this
+*    software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+* EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "w5500.h"
+
+/***************************************************************************//**
+ * @brief Write data to a W5500 register
+ *
+ * @param dev   - The device descriptor
+ * @param block - The block select bits (common registers, socket registers, etc.)
+ * @param addr  - The register address
+ * @param data  - The data buffer to write
+ * @param len   - The data length
+ *
+ * @return 0 in case of success, negative error code otherwise
+*******************************************************************************/
+int w5500_reg_write(struct w5500_dev *dev, uint8_t block,
+		    uint16_t addr, const uint8_t *data, uint16_t len)
+{
+	uint8_t spi_tx[3 + len];
+
+	spi_tx[0] = W5500_BYTE_HIGH(addr);
+	spi_tx[1] = W5500_BYTE_LOW(addr);
+
+	spi_tx[2] = W5500_BSB(block) | W5500_RWB_WRITE | W5500_OM_VDM;
+
+	memcpy(&spi_tx[3], data, len);
+
+	struct no_os_spi_msg xfer = {
+		.tx_buff = spi_tx,
+		.rx_buff = NULL,
+		.bytes_number = 3 + len,
+		.cs_change = 1,
+	};
+
+	return no_os_spi_transfer(dev->spi, &xfer, 1);
+}
+
+/***************************************************************************//**
+ * @brief Read data from a W5500 register
+ *
+ * @param dev   - The device descriptor
+ * @param block - The block select bits (common registers, socket registers, etc.)
+ * @param addr  - The register address
+ * @param data  - The buffer to store read data
+ * @param len   - The data length to read
+ *
+ * @return 0 in case of success, negative error code otherwise
+*******************************************************************************/
+int w5500_reg_read(struct w5500_dev *dev, uint8_t block,
+		   uint16_t addr, uint8_t *data, uint16_t len)
+{
+	uint8_t spi_tx[3];
+	uint8_t spi_rx[3 + len];
+	int ret;
+
+	spi_tx[0] = W5500_BYTE_HIGH(addr);
+	spi_tx[1] = W5500_BYTE_LOW(addr);
+
+	spi_tx[2] = W5500_BSB(block) | W5500_RWB_READ | W5500_OM_VDM;
+
+	struct no_os_spi_msg xfer = {
+		.tx_buff = spi_tx,
+		.rx_buff = spi_rx,
+		.bytes_number = 3 + len,
+		.cs_change = 1,
+	};
+
+	ret = no_os_spi_transfer(dev->spi, &xfer, 1);
+	if (ret)
+		return ret;
+
+	memcpy(data, &spi_rx[3], len);
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * @brief Read a 16-bit register reliably by reading until consecutive values match
+ *
+ * @param dev   - The device descriptor
+ * @param block - The block select bits (common registers, socket registers, etc.)
+ * @param addr  - The register address
+ * @param value - Pointer to store the 16-bit value
+ *
+ * @return 0 in case of success, negative error code otherwise
+*******************************************************************************/
+int w5500_read_16bit_reg(struct w5500_dev *dev, uint8_t block,
+			 uint16_t addr, uint16_t *value)
+{
+	int ret;
+	uint8_t data[2];
+	uint16_t val1, val2;
+	int attempts = 0;
+	const int max_attempts = 5;
+
+	do {
+		ret = w5500_reg_read(dev, block, addr, data, 2);
+		if (ret)
+			return ret;
+		val1 = (data[0] << 8) | data[1];
+
+		ret = w5500_reg_read(dev, block, addr, data, 2);
+		if (ret)
+			return ret;
+		val2 = (data[0] << 8) | data[1];
+
+		attempts++;
+	} while (val1 != val2 && attempts < max_attempts);
+
+	if (attempts >= max_attempts)
+		return -EIO;
+
+	*value = val1;
+	return 0;
+}
+
+/***************************************************************************//**
+ * @brief Set MAC address
+ *
+ * @param dev - The device descriptor
+ * @param mac - 6-byte MAC address array
+ *
+ * @return 0 in case of success, negative error code otherwise
+*******************************************************************************/
+int w5500_set_mac(struct w5500_dev *dev, const uint8_t mac[6])
+{
+	return w5500_reg_write(dev, W5500_COMMON_REG, W5500_SHAR, mac, 6);
+}
+
+/***************************************************************************//**
+ * @brief Set IP address
+ *
+ * @param dev - The device descriptor
+ * @param ip  - 4-byte IP address array
+ *
+ * @return 0 in case of success, negative error code otherwise
+*******************************************************************************/
+int w5500_set_ip(struct w5500_dev *dev, const uint8_t ip[4])
+{
+	return w5500_reg_write(dev, W5500_COMMON_REG, W5500_SIPR, ip, 4);
+}
+
+/***************************************************************************//**
+ * @brief Set subnet mask
+ *
+ * @param dev    - The device descriptor
+ * @param subnet - 4-byte subnet mask array
+ *
+ * @return 0 in case of success, negative error code otherwise
+*******************************************************************************/
+int w5500_set_subnet(struct w5500_dev *dev, const uint8_t subnet[4])
+{
+	return w5500_reg_write(dev, W5500_COMMON_REG, W5500_SUBR, subnet, 4);
+}
+
+/***************************************************************************//**
+ * @brief Set gateway address
+ *
+ * @param dev     - The device descriptor
+ * @param gateway - 4-byte gateway address array
+ *
+ * @return 0 in case of success, negative error code otherwise
+*******************************************************************************/
+int w5500_set_gateway(struct w5500_dev *dev, const uint8_t gateway[4])
+{
+	return w5500_reg_write(dev, W5500_COMMON_REG, W5500_GAR, gateway, 4);
+}
+
+/***************************************************************************//**
+ * @brief Get MAC address
+ *
+ * @param dev - The device descriptor
+ * @param mac - Buffer to store the 6-byte MAC address
+ *
+ * @return 0 in case of success, negative error code otherwise
+*******************************************************************************/
+int w5500_get_mac(struct w5500_dev *dev, uint8_t mac[6])
+{
+	return w5500_reg_read(dev, W5500_COMMON_REG, W5500_SHAR, mac, 6);
+}
+
+/***************************************************************************//**
+ * @brief Get IP address
+ *
+ * @param dev - The device descriptor
+ * @param ip  - Buffer to store the 4-byte IP address
+ *
+ * @return 0 in case of success, negative error code otherwise
+*******************************************************************************/
+int w5500_get_ip(struct w5500_dev *dev, uint8_t ip[4])
+{
+	return w5500_reg_read(dev, W5500_COMMON_REG, W5500_SIPR, ip, 4);
+}
+
+/***************************************************************************//**
+ * @brief Get subnet mask
+ *
+ * @param dev    - The device descriptor
+ * @param subnet - Buffer to store the 4-byte subnet mask
+ *
+ * @return 0 in case of success, negative error code otherwise
+*******************************************************************************/
+int w5500_get_subnet(struct w5500_dev *dev, uint8_t subnet[4])
+{
+	return w5500_reg_read(dev, W5500_COMMON_REG, W5500_SUBR, subnet, 4);
+}
+
+/***************************************************************************//**
+ * @brief Get gateway address
+ *
+ * @param dev     - The device descriptor
+ * @param gateway - Buffer to store the 4-byte gateway address
+ *
+ * @return 0 in case of success, negative error code otherwise
+*******************************************************************************/
+int w5500_get_gateway(struct w5500_dev *dev, uint8_t gateway[4])
+{
+	return w5500_reg_read(dev, W5500_COMMON_REG, W5500_GAR, gateway, 4);
+}
+
+/***************************************************************************//**
+ * @brief Check the Ethernet link status
+ *
+ * @param dev - The device descriptor
+ *
+ * @return 0 if link is up, -ENETDOWN if link is down, other negative codes on error
+*******************************************************************************/
+int w5500_check_link_status(struct w5500_dev *dev)
+{
+	int ret;
+	uint8_t phycfgr;
+
+	ret = w5500_reg_read(dev, W5500_COMMON_REG, W5500_PHYCFGR, &phycfgr, 1);
+	if (ret)
+		return ret;
+
+	if (!no_os_field_get(W5500_PHYCFGR_LNK, phycfgr))
+		return -ENETDOWN;
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * @brief Configure W5500 TCP parameters (RTR and RCR)
+ *
+ * @param dev         - The device descriptor
+ * @param retry_time  - Retry timeout value in 100μs units (default: 2000 = 200ms)
+ * @param retry_count - Maximum retry count (default: 8)
+ *
+ * @return 0 on success, negative error code otherwise
+*******************************************************************************/
+int w5500_tcp_config(struct w5500_dev *dev, uint16_t retry_time,
+		     uint8_t retry_count)
+{
+	int ret;
+	uint8_t rtr_buf[2];
+
+	rtr_buf[0] = W5500_BYTE_HIGH(retry_time);
+	rtr_buf[1] = W5500_BYTE_LOW(retry_time);
+
+	ret = w5500_reg_write(dev, W5500_COMMON_REG, W5500_RTR, rtr_buf, 2);
+	if (ret)
+		return ret;
+
+	ret = w5500_reg_write(dev, W5500_COMMON_REG, W5500_RCR, &retry_count, 1);
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * @brief Write to a socket register
+ *
+ * @param dev        - The device descriptor
+ * @param sock_id    - Socket number (0-7)
+ * @param reg_offset - Register offset
+ * @param data       - Data to write
+ * @param len        - Data length
+ *
+ * @return 0 on success, negative error code otherwise
+*******************************************************************************/
+static int w5500_socket_reg_write(struct w5500_dev *dev, uint8_t sock_id,
+				  uint16_t reg_offset, const uint8_t *data,
+				  uint16_t len)
+{
+	if (sock_id > W5500_MAX_SOCK_NUMBER)
+		return -EINVAL;
+
+	return w5500_reg_write(dev, W5500_SOCKET_REG_BLOCK(sock_id),
+			       reg_offset, data, len);
+}
+
+/***************************************************************************//**
+ * @brief Read from a socket register
+ *
+ * @param dev        - The device descriptor
+ * @param sock_id    - Socket number (0-7)
+ * @param reg_offset - Register offset
+ * @param data       - Buffer to store data
+ * @param len        - Data length to read
+ *
+ * @return 0 on success, negative error code otherwise
+*******************************************************************************/
+static int w5500_socket_reg_read(struct w5500_dev *dev, uint8_t sock_id,
+				 uint16_t reg_offset, uint8_t *data,
+				 uint16_t len)
+{
+	if (sock_id > W5500_MAX_SOCK_NUMBER)
+		return -EINVAL;
+
+	return w5500_reg_read(dev, W5500_SOCKET_REG_BLOCK(sock_id),
+			      reg_offset, data, len);
+}
+
+/***************************************************************************//**
+ * @brief Read status of a socket
+ *
+ * @param dev     - The device descriptor
+ * @param sock_id - Socket number (0-7)
+ * @param status  - Variable to store status
+ *
+ * @return 0 on success, negative error code otherwise
+*******************************************************************************/
+int w5500_socket_read_status(struct w5500_dev *dev, uint8_t sock_id,
+			     uint8_t *status)
+{
+	return w5500_socket_reg_read(dev, sock_id, W5500_Sn_SR, status, 1);
+}
+
+/***************************************************************************//**
+ * @brief Write a command to a socket's command register
+ *
+ * @param dev     - The device descriptor
+ * @param sock_id - Socket number (0-7)
+ * @param val     - Command value to write
+ *
+ * @return 0 on success, negative error code otherwise
+*******************************************************************************/
+int w5500_socket_command_write(struct w5500_dev *dev, uint8_t sock_id,
+			       uint8_t val)
+{
+	uint8_t cmd = val;
+
+	return w5500_socket_reg_write(dev, sock_id, W5500_Sn_CR, &cmd, 1);
+}
+
+/***************************************************************************//**
+ * @brief Clear specific socket interrupt flags
+ *
+ * @param dev     - Device descriptor
+ * @param sock_id - Socket number (0-7)
+ * @param flags   - Interrupt flags to clear
+ *
+ * @return 0 on success, negative error code otherwise
+*******************************************************************************/
+int w5500_socket_clear_interrupt(struct w5500_dev *dev, uint8_t sock_id,
+				 uint8_t flags)
+{
+	return w5500_socket_reg_write(dev, sock_id, W5500_Sn_IR, &flags, 1);
+}
+
+/***************************************************************************//**
+ * @brief Initialize socket data structures
+ *
+ * @param dev - The device descriptor
+ *
+ * @note Internal function, no return value
+*******************************************************************************/
+static void w5500_sockets_init(struct w5500_dev *dev)
+{
+	for (int i = 0; i <= W5500_MAX_SOCK_NUMBER; i++) {
+		dev->sockets[i].protocol = W5500_Sn_MR_CLOSE;
+		dev->sockets[i].mss = 1460;
+		dev->sockets[i].tx_buf_size = 2;
+		dev->sockets[i].rx_buf_size = 2;
+	}
+}
+
+/***************************************************************************//**
+ * @brief Initialize a socket
+ *
+ * @param dev     - Device descriptor
+ * @param sock_id - Socket number (0-7)
+ *
+ * @return 0 on success, negative error code otherwise
+*******************************************************************************/
+int w5500_socket_init(struct w5500_dev *dev, uint8_t sock_id)
+{
+	int ret;
+	uint8_t mss_buf[2];
+	struct w5500_socket *sock = &dev->sockets[sock_id];
+
+	mss_buf[0] = W5500_BYTE_HIGH(sock->mss);
+	mss_buf[1] = W5500_BYTE_LOW(sock->mss);
+
+	if (sock_id > W5500_MAX_SOCK_NUMBER)
+		return -EINVAL;
+
+	ret = w5500_socket_reg_write(dev, sock_id, W5500_Sn_MR, &sock->protocol, 1);
+	if (ret)
+		return ret;
+
+	if (sock->protocol == W5500_Sn_MR_TCP) {
+		ret = w5500_socket_reg_write(dev, sock_id, W5500_Sn_MSSR, mss_buf, 2);
+		if (ret)
+			return ret;
+	}
+
+	ret = w5500_socket_reg_write(dev, sock_id, W5500_Sn_RXBUF_SIZE,
+				     &sock->rx_buf_size, 1);
+	if (ret)
+		return ret;
+
+	ret = w5500_socket_reg_write(dev, sock_id, W5500_Sn_TXBUF_SIZE,
+				     &sock->tx_buf_size, 1);
+	if (ret)
+		return ret;
+
+	return w5500_socket_command_write(dev, sock_id, W5500_Sn_CR_OPEN);
+}
+
+/***************************************************************************//**
+ * @brief Open a socket with specified protocol
+ *
+ * @param dev       - The device descriptor
+ * @param sock_id   - Socket ID to use (0-7)
+ * @param proto     - Protocol type (TCP, UDP)
+ * @param buff_size - Buffer size (1, 2, 4, 8, 16 KB)
+ *
+ * @return 0 on success, negative error code otherwise
+*******************************************************************************/
+int w5500_socket_open(struct w5500_dev *dev, uint8_t sock_id,
+		      enum socket_protocol proto, uint8_t buff_size)
+{
+	struct w5500_socket *sock;
+	uint8_t protocol;
+	int ret;
+
+	switch (proto) {
+	case PROTOCOL_TCP:
+		protocol = W5500_Sn_MR_TCP;
+		break;
+	case PROTOCOL_UDP:
+		protocol = W5500_Sn_MR_UDP;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	sock = &dev->sockets[sock_id];
+
+	sock->protocol = protocol;
+	sock->tx_buf_size = 2;
+	sock->rx_buf_size = 2;
+
+	ret = w5500_socket_init(dev, sock_id);
+	if (ret) {
+		sock->protocol = W5500_Sn_MR_CLOSE;
+		return ret;
+	}
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * @brief Close a socket
+ *
+ * @param dev     - Device descriptor
+ * @param sock_id - Socket number (0-7)
+ *
+ * @return 0 on success, negative error code otherwise
+*******************************************************************************/
+int w5500_socket_close(struct w5500_dev *dev, uint8_t sock_id)
+{
+	int ret;
+
+	if (sock_id > W5500_MAX_SOCK_NUMBER)
+		return -EINVAL;
+
+	return w5500_socket_command_write(dev, sock_id, W5500_Sn_CR_CLOSE);
+}
+
+/***************************************************************************//**
+ * @brief Connect to a remote host (TCP client mode)
+ *
+ * @param dev     - Device descriptor
+ * @param sock_id - Socket number (0-7)
+ * @param addr    - Socket address structure containing remote IP and port
+ *
+ * @return 0 on success, negative error code otherwise
+*******************************************************************************/
+int w5500_socket_connect(struct w5500_dev *dev, uint8_t sock_id,
+			 struct socket_address *addr)
+{
+	int ret;
+	uint8_t status;
+	uint8_t ip_addr[4];
+	uint8_t port_buf[2];
+
+	if (sock_id > W5500_MAX_SOCK_NUMBER)
+		return -EINVAL;
+
+	if (!addr || !addr->addr)
+		return -EINVAL;
+
+	ret = w5500_socket_reg_read(dev, sock_id, W5500_Sn_SR, &status, 1);
+	if (ret)
+		return ret;
+
+	if (status != W5500_Sn_SR_INIT)
+		return -EINVAL;
+
+	if (sscanf(addr->addr, "%hhu.%hhu.%hhu.%hhu", &ip_addr[0], &ip_addr[1],
+		   &ip_addr[2], &ip_addr[3]) != 4)
+		return -EINVAL;
+
+	port_buf[0] = W5500_BYTE_HIGH(addr->port);
+	port_buf[1] = W5500_BYTE_LOW(addr->port);
+
+	ret = w5500_socket_reg_write(dev, sock_id, W5500_Sn_DIPR, ip_addr, 4);
+	if (ret)
+		return ret;
+
+	ret = w5500_socket_reg_write(dev, sock_id, W5500_Sn_DPORT, port_buf, 2);
+	if (ret)
+		return ret;
+
+	return w5500_socket_command_write(dev, sock_id, W5500_Sn_CR_CONNECT);
+}
+
+/***************************************************************************//**
+ * @brief Disconnect a TCP connection
+ *
+ * @param dev     - Device descriptor
+ * @param sock_id - Socket number (0-7)
+ *
+ * @return 0 on success, -ENOTCONN if not connected, other negative error codes
+*******************************************************************************/
+int w5500_socket_disconnect(struct w5500_dev *dev, uint8_t sock_id)
+{
+	int ret;
+	uint8_t status;
+
+	if (sock_id > W5500_MAX_SOCK_NUMBER)
+		return -EINVAL;
+
+	ret = w5500_socket_reg_read(dev, sock_id, W5500_Sn_SR, &status, 1);
+	if (ret)
+		return ret;
+
+	if (status != W5500_Sn_SR_ESTABLISHED &&
+	    status != W5500_Sn_SR_CLOSE_WAIT)
+		return -ENOTCONN;
+
+	return w5500_socket_command_write(dev, sock_id, W5500_Sn_CR_DISCON);
+}
+
+/***************************************************************************//**
+ * @brief Send data through a socket
+ *
+ * @param dev     - Device descriptor
+ * @param sock_id - Socket number (0-7)
+ * @param buf     - Data buffer to send
+ * @param len     - Data length
+ *
+ * @return Number of bytes sent on success, negative error code otherwise
+*******************************************************************************/
+int w5500_socket_send(struct w5500_dev *dev, uint8_t sock_id, const void *buf,
+		      uint16_t len)
+{
+	int ret;
+	uint16_t free_size = 0;
+	uint16_t wr_ptr;
+	uint8_t wr_ptr_buf[2];
+	uint8_t status;
+	uint16_t total_sent = 0;
+	uint16_t chunk_size;
+	const uint8_t *data = (const uint8_t *)buf;
+
+	if (sock_id > W5500_MAX_SOCK_NUMBER)
+		return -EINVAL;
+
+	ret = w5500_socket_reg_read(dev, sock_id, W5500_Sn_SR, &status, 1);
+	if (ret)
+		return ret;
+
+	if (status != W5500_Sn_SR_ESTABLISHED &&
+	    status != W5500_Sn_SR_UDP &&
+	    status != W5500_Sn_SR_MACRAW)
+		return -ENOTCONN;
+
+	while (total_sent < len) {
+		ret = w5500_read_16bit_reg(dev, W5500_SOCKET_REG_BLOCK(sock_id),
+					   W5500_Sn_TX_FSR, &free_size);
+		if (ret)
+			return ret;
+
+		if (free_size == 0) {
+			no_os_mdelay(1);
+			continue;
+		}
+
+		chunk_size = (len - total_sent) < free_size ? (len - total_sent) : free_size;
+
+		ret = w5500_read_16bit_reg(dev, W5500_SOCKET_REG_BLOCK(sock_id),
+					   W5500_Sn_TX_WR, &wr_ptr);
+		if (ret)
+			return ret;
+
+		ret = w5500_reg_write(dev, W5500_SOCKET_TX_BUF_BLOCK(sock_id),
+				      wr_ptr, data + total_sent, chunk_size);
+		if (ret)
+			return ret;
+
+		wr_ptr += chunk_size;
+
+		wr_ptr_buf[0] = W5500_BYTE_HIGH(wr_ptr);
+		wr_ptr_buf[1] = W5500_BYTE_LOW(wr_ptr);
+
+		ret = w5500_socket_reg_write(dev, sock_id, W5500_Sn_TX_WR,
+					     wr_ptr_buf, 2);
+		if (ret)
+			return ret;
+
+		ret = w5500_socket_command_write(dev, sock_id, W5500_Sn_CR_SEND);
+		if (ret)
+			return ret;
+
+		total_sent += chunk_size;
+	}
+
+	return len;
+}
+
+/***************************************************************************//**
+ * @brief Receive data from a socket
+ *
+ * @param dev     - Device descriptor
+ * @param sock_id - Socket number (0-7)
+ * @param buf     - Buffer to store received data
+ * @param len     - Maximum length to receive
+ *
+ * @return Number of bytes received on success, negative error code otherwise
+*******************************************************************************/
+int w5500_socket_recv(struct w5500_dev *dev, uint8_t sock_id, void *buf,
+		      uint16_t len)
+{
+	int ret;
+	uint16_t rx_size = 0;
+	uint16_t rd_ptr;
+	uint8_t rd_ptr_buf[2];
+	uint8_t status;
+
+	if (sock_id > W5500_MAX_SOCK_NUMBER)
+		return -EINVAL;
+
+	ret = w5500_socket_reg_read(dev, sock_id, W5500_Sn_SR, &status, 1);
+	if (ret)
+		return ret;
+
+	if (status != W5500_Sn_SR_ESTABLISHED &&
+	    status != W5500_Sn_SR_UDP &&
+	    status != W5500_Sn_SR_MACRAW)
+		return -ENOTCONN;
+
+	ret = w5500_read_16bit_reg(dev, W5500_SOCKET_REG_BLOCK(sock_id),
+				   W5500_Sn_RX_RSR, &rx_size);
+	if (ret)
+		return ret;
+
+	if (rx_size == 0)
+		return 0;
+
+	if (len > rx_size)
+		len = rx_size;
+
+	ret = w5500_read_16bit_reg(dev, W5500_SOCKET_REG_BLOCK(sock_id),
+				   W5500_Sn_RX_RD, &rd_ptr);
+	if (ret)
+		return ret;
+
+	ret = w5500_reg_read(dev, W5500_SOCKET_RX_BUF_BLOCK(sock_id),
+			     rd_ptr, buf, len);
+	if (ret)
+		return ret;
+
+	rd_ptr += len;
+
+	rd_ptr_buf[0] = W5500_BYTE_HIGH(rd_ptr);
+	rd_ptr_buf[1] = W5500_BYTE_LOW(rd_ptr);
+
+	ret = w5500_socket_reg_write(dev, sock_id, W5500_Sn_RX_RD, rd_ptr_buf, 2);
+	if (ret)
+		return ret;
+
+	ret = w5500_socket_command_write(dev, sock_id, W5500_Sn_CR_RECV);
+	if (ret)
+		return ret;
+
+	ret = w5500_socket_clear_interrupt(dev, sock_id, W5500_Sn_IR_RECV);
+	if (ret)
+		return ret;
+
+	return len;
+}
+
+/***************************************************************************//**
+ * @brief Send data to a specific destination (UDP)
+ *
+ * @param dev     - Device descriptor
+ * @param sock_id - Socket number (0-7)
+ * @param buf     - Data buffer to send
+ * @param len     - Data length
+ * @param to      - Destination address (IP and port)
+ *
+ * @return 0 on success, negative error code otherwise
+*******************************************************************************/
+int w5500_socket_sendto(struct w5500_dev *dev, uint8_t sock_id, const void *buf,
+			uint16_t len, struct socket_address *to)
+{
+	int ret;
+	uint8_t status;
+	uint8_t ip_addr[4];
+	uint8_t port_buf[2];
+	uint16_t free_size = 0;
+	uint16_t wr_ptr;
+	uint8_t wr_ptr_buf[2];
+
+	if (sock_id > W5500_MAX_SOCK_NUMBER || !buf || !to || !to->addr)
+		return -EINVAL;
+
+	ret = w5500_socket_reg_read(dev, sock_id, W5500_Sn_SR, &status, 1);
+	if (ret)
+		return ret;
+
+	if (status != W5500_Sn_SR_UDP)
+		return -EPROTOTYPE;
+
+	if (sscanf(to->addr, "%hhu.%hhu.%hhu.%hhu", &ip_addr[0], &ip_addr[1],
+		   &ip_addr[2], &ip_addr[3]) != 4)
+		return -EINVAL;
+
+	port_buf[0] = W5500_BYTE_HIGH(to->port);
+	port_buf[1] = W5500_BYTE_LOW(to->port);
+
+	ret = w5500_socket_reg_write(dev, sock_id, W5500_Sn_DIPR, ip_addr, 4);
+	if (ret)
+		return ret;
+
+	ret = w5500_socket_reg_write(dev, sock_id, W5500_Sn_DPORT, port_buf, 2);
+	if (ret)
+		return ret;
+
+	ret = w5500_read_16bit_reg(dev, W5500_SOCKET_REG_BLOCK(sock_id),
+				   W5500_Sn_TX_FSR, &free_size);
+	if (ret)
+		return ret;
+
+	if (free_size < len)
+		return -ENOBUFS;
+
+	ret = w5500_read_16bit_reg(dev, W5500_SOCKET_REG_BLOCK(sock_id),
+				   W5500_Sn_TX_WR, &wr_ptr);
+	if (ret)
+		return ret;
+
+	ret = w5500_reg_write(dev, W5500_SOCKET_TX_BUF_BLOCK(sock_id),
+			      wr_ptr, buf, len);
+	if (ret)
+		return ret;
+
+	wr_ptr += len;
+
+	wr_ptr_buf[0] = W5500_BYTE_HIGH(wr_ptr);
+	wr_ptr_buf[1] = W5500_BYTE_LOW(wr_ptr);
+
+	ret = w5500_socket_reg_write(dev, sock_id, W5500_Sn_TX_WR,
+				     wr_ptr_buf, 2);
+	if (ret)
+		return ret;
+
+	return w5500_socket_command_write(dev, sock_id, W5500_Sn_CR_SEND);
+}
+
+/***************************************************************************//**
+ * @brief Receive data from a socket with source address information (UDP)
+ *
+ * @param dev     - Device descriptor
+ * @param sock_id - Socket number (0-7)
+ * @param buf     - Buffer to store received data
+ * @param len     - Maximum length to receive
+ * @param from    - Buffer to store source address information
+ *
+ * @return Number of bytes received on success, negative error code otherwise
+*******************************************************************************/
+int w5500_socket_recvfrom(struct w5500_dev *dev, uint8_t sock_id,
+			  void *buf, uint16_t len,
+			  struct socket_address *from)
+{
+	int ret;
+	uint16_t rx_size = 0;
+	uint16_t rd_ptr;
+	uint8_t rd_ptr_buf[2];
+	uint8_t status;
+	uint8_t header[8];
+	static char ip_str[16];
+	uint16_t data_len;
+
+	if (sock_id > W5500_MAX_SOCK_NUMBER || !buf)
+		return -EINVAL;
+
+	ret = w5500_socket_reg_read(dev, sock_id, W5500_Sn_SR, &status, 1);
+	if (ret)
+		return ret;
+
+	if (status != W5500_Sn_SR_UDP)
+		return -EPROTOTYPE;
+
+	ret = w5500_read_16bit_reg(dev, W5500_SOCKET_REG_BLOCK(sock_id),
+				   W5500_Sn_RX_RSR, &rx_size);
+	if (ret)
+		return ret;
+
+	if (rx_size < 8)
+		return 0;
+
+	ret = w5500_read_16bit_reg(dev, W5500_SOCKET_REG_BLOCK(sock_id),
+				   W5500_Sn_RX_RD, &rd_ptr);
+	if (ret)
+		return ret;
+
+	ret = w5500_reg_read(dev, W5500_SOCKET_RX_BUF_BLOCK(sock_id),
+			     rd_ptr, header, 8);
+	if (ret)
+		return ret;
+
+	data_len = (header[6] << 8) | header[7];
+
+	if (len > data_len)
+		len = data_len;
+
+	ret = w5500_reg_read(dev, W5500_SOCKET_RX_BUF_BLOCK(sock_id),
+			     rd_ptr + 8, buf, len);
+	if (ret)
+		return ret;
+
+	if (from) {
+		snprintf(ip_str, sizeof(ip_str), "%d.%d.%d.%d",
+			 header[0], header[1], header[2], header[3]);
+		from->addr = ip_str;
+		from->port = (header[4] << 8) | header[5];
+	}
+
+	rd_ptr += data_len + 8;
+
+	rd_ptr_buf[0] = W5500_BYTE_HIGH(rd_ptr);
+	rd_ptr_buf[1] = W5500_BYTE_LOW(rd_ptr);
+
+	ret = w5500_socket_reg_write(dev, sock_id, W5500_Sn_RX_RD,
+				     rd_ptr_buf, 2);
+	if (ret)
+		return ret;
+
+	ret = w5500_socket_command_write(dev, sock_id, W5500_Sn_CR_RECV);
+	if (ret)
+		return ret;
+
+	return len;
+}
+
+/***************************************************************************//**
+ * @brief Bind a socket to a specific port (server mode)
+ *
+ * @param dev     - Device descriptor
+ * @param sock_id - Socket number (0-7)
+ * @param port    - Local port number
+ *
+ * @return 0 on success, negative error code otherwise
+*******************************************************************************/
+int w5500_socket_bind(struct w5500_dev *dev, uint8_t sock_id, uint16_t port)
+{
+	uint8_t port_buf[2];
+
+	if (sock_id > W5500_MAX_SOCK_NUMBER)
+		return -EINVAL;
+
+	port_buf[0] = W5500_BYTE_HIGH(port);
+	port_buf[1] = W5500_BYTE_LOW(port);
+
+	return w5500_socket_reg_write(dev, sock_id, W5500_Sn_PORT, port_buf, 2);
+}
+
+/***************************************************************************//**
+ * @brief Set socket to listen mode (TCP server)
+ *
+ * @param dev     - Device descriptor
+ * @param sock_id - Socket number (0-7)
+ *
+ * @return 0 on success, negative error code otherwise
+*******************************************************************************/
+int w5500_socket_listen(struct w5500_dev *dev, uint8_t sock_id)
+{
+	int ret;
+	uint8_t status;
+
+	if (sock_id > W5500_MAX_SOCK_NUMBER)
+		return -EINVAL;
+
+	ret = w5500_socket_reg_read(dev, sock_id, W5500_Sn_SR, &status, 1);
+	if (ret)
+		return ret;
+
+	if (status != W5500_Sn_SR_INIT)
+		return -EINVAL;
+
+	return w5500_socket_command_write(dev, sock_id, W5500_Sn_CR_LISTEN);
+}
+
+/***************************************************************************//**
+ * @brief Reset the W5500 chip using hardware or software method
+ *
+ * @param dev - The device descriptor
+ *
+ * @return 0 in case of success, negative error code otherwise
+*******************************************************************************/
+int w5500_reset(struct w5500_dev *dev)
+{
+	int ret;
+	uint8_t mr;
+	uint8_t ver;
+
+	if (dev->gpio_reset) {
+		ret = no_os_gpio_set_value(dev->gpio_reset, 0);
+		if (ret)
+			return ret;
+
+		/* Hold reset low for at least 500us per datasheet */
+		no_os_udelay(500);
+
+		ret = no_os_gpio_set_value(dev->gpio_reset, 1);
+		if (ret)
+			return ret;
+	} else {
+		mr = W5500_MR_RST;
+		ret = w5500_reg_write(dev, W5500_COMMON_REG, W5500_MR, &mr, 1);
+		if (ret)
+			return ret;
+	}
+
+	/* Wait for reset to complete */
+	no_os_mdelay(1);
+
+	ret = w5500_reg_read(dev, W5500_COMMON_REG, W5500_MR, &mr, 1);
+	if (ret)
+		return ret;
+
+	if (mr & W5500_MR_RST)
+		return -ETIMEDOUT;
+
+	ret = w5500_reg_read(dev, W5500_COMMON_REG, W5500_VERSIONR, &ver, 1);
+	if (ret)
+		return ret;
+
+	if (ver != W5500_CHIP_VERSION)
+		return -EINVAL;
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * @brief Setup the W5500 chip with basic configuration
+ *
+ * @param dev - The device descriptor
+ *
+ * @return 0 in case of success, negative error code otherwise
+*******************************************************************************/
+int w5500_setup(struct w5500_dev *dev)
+{
+	int ret;
+
+	ret = w5500_reset(dev);
+	if (ret)
+		return ret;
+
+	ret = w5500_set_mac(dev, dev->mac_addr);
+	if (ret)
+		return ret;
+
+	ret = w5500_set_ip(dev, dev->ip_addr);
+	if (ret)
+		return ret;
+
+	ret = w5500_set_subnet(dev, dev->subnet_mask);
+	if (ret)
+		return ret;
+
+	ret = w5500_set_gateway(dev, dev->gateway);
+	if (ret)
+		return ret;
+
+	ret = w5500_tcp_config(dev, dev->retry_time, dev->retry_count);
+	if (ret)
+		return ret;
+
+	return w5500_check_link_status(dev);
+}
+
+/***************************************************************************//**
+ * @brief Initialize the device
+ *
+ * @param device     - Pointer to the device descriptor to be initialized
+ * @param init_param - The device's initialization parameters
+ *
+ * @return 0 in case of success, negative error code otherwise
+*******************************************************************************/
+int w5500_init(struct w5500_dev **device,
+	       struct w5500_init_param *init_param)
+{
+	struct w5500_dev *dev;
+	int ret;
+
+	dev = (struct w5500_dev *)malloc(sizeof(*dev));
+	if (!dev)
+		return -ENOMEM;
+
+	ret = no_os_gpio_get_optional(&dev->gpio_reset, &init_param->gpio_reset);
+	if (ret)
+		goto free_dev;
+
+	ret = no_os_gpio_get_optional(&dev->gpio_int, &init_param->gpio_int);
+	if (ret)
+		goto free_gpio_reset;
+
+	ret = no_os_spi_init(&dev->spi, &init_param->spi_init);
+	if (ret)
+		goto free_gpio_int;
+
+	memcpy(dev->mac_addr, init_param->mac_addr, 6);
+	memcpy(dev->ip_addr, init_param->ip_addr, 4);
+	memcpy(dev->subnet_mask, init_param->subnet_mask, 4);
+	memcpy(dev->gateway, init_param->gateway, 4);
+
+	memcpy(&dev->retry_time, &init_param->retry_time, 1);
+	memcpy(&dev->retry_count, &init_param->retry_count, 1);
+
+	w5500_sockets_init(dev);
+
+	ret = w5500_setup(dev);
+	if (ret)
+		goto free_spi;
+
+	*device = dev;
+
+	return 0;
+
+free_spi:
+	no_os_spi_remove(dev->spi);
+free_gpio_int:
+	no_os_gpio_remove(dev->gpio_int);
+free_gpio_reset:
+	no_os_gpio_remove(dev->gpio_reset);
+free_dev:
+	no_os_free(dev);
+
+	return ret;
+}
+
+/***************************************************************************//**
+ * @brief Free a device descriptor and release resources
+ *
+ * @param dev - The device descriptor to be removed
+ *
+ * @return 0 in case of success, negative error code otherwise
+*******************************************************************************/
+int w5500_remove(struct w5500_dev *dev)
+{
+	int ret;
+
+	ret = no_os_spi_remove(dev->spi);
+	ret |= no_os_gpio_remove(dev->gpio_reset);
+	ret |= no_os_gpio_remove(dev->gpio_int);
+
+	no_os_free(dev);
+
+	return ret;
+}

--- a/drivers/net/w5500/w5500.h
+++ b/drivers/net/w5500/w5500.h
@@ -1,0 +1,352 @@
+/***************************************************************************//**
+*   @file   w5500.h
+*   @brief  Header file W5500 Driver
+*   @author Alisa-Dariana Roman (alisa.roman@analog.com)
+********************************************************************************
+* Copyright 2025(c) Analog Devices, Inc.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* 3. Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived from this
+*    software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+* EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef __W5500_H__
+#define __W5500_H__
+
+#include "network_interface.h"
+
+#include <errno.h>
+#include <string.h>
+#include "no_os_alloc.h"
+#include "no_os_delay.h"
+#include "no_os_spi.h"
+#include "no_os_gpio.h"
+#include "no_os_util.h"
+
+#define W5500_CHIP_VERSION   0x04
+
+/* Byte manipulation helpers */
+#define W5500_BYTE_HIGH(value)       (((value) >> 8) & 0xFF)
+#define W5500_BYTE_LOW(value)        ((value) & 0xFF)
+
+/* SPI Frame Structure Masks */
+#define W5500_BSB_MASK               NO_OS_GENMASK(7, 3)   /* Block Select Bits */
+#define W5500_RWB_MASK               NO_OS_BIT(2)          /* Read/Write Bit */
+#define W5500_OM_MASK                NO_OS_GENMASK(1, 0)   /* Operation Mode Bits */
+
+/* Control Byte Construction Helpers */
+#define W5500_BSB(block)             no_os_field_prep(W5500_BSB_MASK, block)
+#define W5500_RWB_READ               0x00
+#define W5500_RWB_WRITE              NO_OS_BIT(2)
+#define W5500_OM_VDM                 0x00    /* Variable Data Length Mode */
+#define W5500_OM_FDM_1               0x01    /* Fixed Data Length Mode 1 byte */
+#define W5500_OM_FDM_2               0x02    /* Fixed Data Length Mode 2 bytes */
+#define W5500_OM_FDM_4               0x03    /* Fixed Data Length Mode 4 bytes */
+
+/* Block Select Bit values */
+#define W5500_COMMON_REG             0x00    /* Common Register Block */
+#define W5500_SOCKET_REG_BLOCK(n)    (0x01 + (n) * 4)  /* Socket n Register Block */
+#define W5500_SOCKET_TX_BUF_BLOCK(n) (0x02 + (n) * 4)  /* Socket n TX Buffer Block */
+#define W5500_SOCKET_RX_BUF_BLOCK(n) (0x03 + (n) * 4)  /* Socket n RX Buffer Block */
+
+/* Common Register Offsets */
+#define W5500_MR             0x0000  /* Mode Register */
+#define W5500_GAR            0x0001  /* Gateway Address Register (4 bytes) */
+#define W5500_SUBR           0x0005  /* Subnet Mask Register (4 bytes) */
+#define W5500_SHAR           0x0009  /* Source Hardware Address Register (6 bytes) */
+#define W5500_SIPR           0x000F  /* Source IP Address Register (4 bytes) */
+#define W5500_INTLEVEL       0x0013  /* Interrupt Low Level Timer Register (2 bytes) */
+#define W5500_IR             0x0015  /* Interrupt Register */
+#define W5500_IMR            0x0016  /* Interrupt Mask Register */
+#define W5500_SIR            0x0017  /* Socket Interrupt Register */
+#define W5500_SIMR           0x0018  /* Socket Interrupt Mask Register */
+#define W5500_RTR            0x0019  /* Retry Time Register (2 bytes) */
+#define W5500_RCR            0x001B  /* Retry Count Register */
+#define W5500_PTIMER         0x001C  /* PPP LCP Request Timer Register */
+#define W5500_PMAGIC         0x001D  /* PPP LCP Magic Number Register */
+#define W5500_PHAR           0x001E  /* PPP Destination MAC Register (6 bytes) */
+#define W5500_PSID           0x0024  /* PPP Session ID Register (2 bytes) */
+#define W5500_PMRU           0x0026  /* PPP Maximum Segment Size (2 bytes) */
+#define W5500_UIPR           0x0028  /* Unreachable IP Address Register (4 bytes) */
+#define W5500_UPORTR         0x002C  /* Unreachable Port Register (2 bytes) */
+#define W5500_PHYCFGR        0x002E  /* PHY Configuration Register */
+#define W5500_VERSIONR       0x0039  /* Chip Version Register */
+
+/* Mode Register (MR) bit values */
+#define W5500_MR_RST         NO_OS_BIT(7)    /* Reset */
+#define W5500_MR_WOL         NO_OS_BIT(5)    /* Wake on LAN */
+#define W5500_MR_PB          NO_OS_BIT(4)    /* Ping Block */
+#define W5500_MR_PPPOE       NO_OS_BIT(3)    /* PPPoE Mode */
+#define W5500_MR_FARP        NO_OS_BIT(1)    /* Force ARP */
+
+/* Socket Register Offsets */
+#define W5500_Sn_MR          0x0000  /* Socket n Mode Register */
+#define W5500_Sn_CR          0x0001  /* Socket n Command Register */
+#define W5500_Sn_IR          0x0002  /* Socket n Interrupt Register */
+#define W5500_Sn_SR          0x0003  /* Socket n Status Register */
+#define W5500_Sn_PORT        0x0004  /* Socket n Source Port Register (2 bytes) */
+#define W5500_Sn_DHAR        0x0006  /* Socket n Destination Hardware Address Register (6 bytes) */
+#define W5500_Sn_DIPR        0x000C  /* Socket n Destination IP Address Register (4 bytes) */
+#define W5500_Sn_DPORT       0x0010  /* Socket n Destination Port Register (2 bytes) */
+#define W5500_Sn_MSSR        0x0012  /* Socket n Maximum Segment Size Register (2 bytes) */
+#define W5500_Sn_TOS         0x0015  /* Socket n Type of Service Register */
+#define W5500_Sn_TTL         0x0016  /* Socket n Time to Live Register */
+#define W5500_Sn_RXBUF_SIZE  0x001E  /* Socket n RX Buffer Size Register */
+#define W5500_Sn_TXBUF_SIZE  0x001F  /* Socket n TX Buffer Size Register */
+#define W5500_Sn_TX_FSR      0x0020  /* Socket n TX Free Size Register (2 bytes) */
+#define W5500_Sn_TX_RD       0x0022  /* Socket n TX Read Pointer Register (2 bytes) */
+#define W5500_Sn_TX_WR       0x0024  /* Socket n TX Write Pointer Register (2 bytes) */
+#define W5500_Sn_RX_RSR      0x0026  /* Socket n RX Received Size Register (2 bytes) */
+#define W5500_Sn_RX_RD       0x0028  /* Socket n RX Read Pointer Register (2 bytes) */
+#define W5500_Sn_RX_WR       0x002A  /* Socket n RX Write Pointer Register (2 bytes) */
+#define W5500_Sn_IMR         0x002C  /* Socket n Interrupt Mask Register */
+#define W5500_Sn_FRAG        0x002D  /* Socket n Fragment Offset in IP Header (2 bytes) */
+#define W5500_Sn_KPALVTR     0x002F  /* Socket n Keep Alive Timer Register */
+
+/* Socket Mode Register (Sn_MR) values */
+#define W5500_Sn_MR_CLOSE    0x00    /* Closed */
+#define W5500_Sn_MR_TCP      0x01    /* TCP */
+#define W5500_Sn_MR_UDP      0x02    /* UDP */
+#define W5500_Sn_MR_MACRAW   0x04    /* MAC Raw mode */
+#define W5500_Sn_MR_NDMC     NO_OS_BIT(5)    /* No Delayed ACK */
+#define W5500_Sn_MR_MULTI    NO_OS_BIT(7)    /* Multicasting */
+#define W5500_Sn_MR_BCASTB   NO_OS_BIT(6)    /* Broadcast Blocking */
+#define W5500_Sn_MR_UCASTB   NO_OS_BIT(4)    /* Unicast Blocking (UDP mode) */
+#define W5500_Sn_MR_MIP6B    NO_OS_BIT(4)    /* IPv6 Blocking (MACRAW mode) */
+
+/* Socket Command Register (Sn_CR) values */
+#define W5500_Sn_CR_OPEN             0x01    /* Initialize and open socket */
+#define W5500_Sn_CR_LISTEN           0x02    /* Wait connection request in TCP mode (Server mode) */
+#define W5500_Sn_CR_CONNECT          0x04    /* Send connection request in TCP mode (Client mode) */
+#define W5500_Sn_CR_DISCON           0x08    /* Send closing request in TCP mode */
+#define W5500_Sn_CR_CLOSE            0x10    /* Close socket */
+#define W5500_Sn_CR_SEND             0x20    /* Send data */
+#define W5500_Sn_CR_SEND_MAC         0x21    /* Send data with MAC address (UDP mode) */
+#define W5500_Sn_CR_SEND_KEEP        0x22    /* Send keep-alive packet (TCP mode) */
+#define W5500_Sn_CR_RECV             0x40    /* Receive data */
+
+/* Socket Status Register (Sn_SR) values */
+#define W5500_Sn_SR_CLOSED           0x00    /* Socket is closed */
+#define W5500_Sn_SR_INIT             0x13    /* Socket is initialized */
+#define W5500_Sn_SR_LISTEN           0x14    /* Socket is in listen state */
+#define W5500_Sn_SR_ESTABLISHED      0x17    /* Connection is established */
+#define W5500_Sn_SR_CLOSE_WAIT       0x1C    /* Closing state */
+#define W5500_Sn_SR_UDP              0x22    /* Socket is in UDP mode */
+#define W5500_Sn_SR_MACRAW           0x42    /* Socket is in MACRAW mode */
+#define W5500_Sn_SR_SYNSENT          0x15    /* SYN packet sent (TCP client) */
+#define W5500_Sn_SR_SYNRECV          0x16    /* SYN packet received (TCP server) */
+#define W5500_Sn_SR_FIN_WAIT         0x18    /* Socket closing (FIN sent) */
+#define W5500_Sn_SR_CLOSING          0x1A    /* Socket closing (FIN exchanged) */
+#define W5500_Sn_SR_TIME_WAIT        0x1B    /* Socket closing (2MSL timer active) */
+#define W5500_Sn_SR_LAST_ACK         0x1D    /* Socket closing (Last ACK) */
+
+/* Socket Interrupt Register (Sn_IR) values */
+#define W5500_Sn_IR_SEND_OK          NO_OS_BIT(4)    /* Send operation completed */
+#define W5500_Sn_IR_TIMEOUT          NO_OS_BIT(3)    /* Timeout occurred */
+#define W5500_Sn_IR_RECV             NO_OS_BIT(2)    /* Data received */
+#define W5500_Sn_IR_DISCON           NO_OS_BIT(1)    /* Connection termination requested/completed */
+#define W5500_Sn_IR_CON              NO_OS_BIT(0)    /* Connection established */
+
+/* Interrupt Register (IR) values */
+#define W5500_IR_CONFLICT            NO_OS_BIT(7)    /* IP address conflict */
+#define W5500_IR_UNREACH             NO_OS_BIT(6)    /* Destination unreachable */
+#define W5500_IR_PPPOE               NO_OS_BIT(5)    /* PPPoE connection closed */
+#define W5500_IR_MP                  NO_OS_BIT(4)    /* Magic packet received */
+
+/* PHY Configuration Register (PHYCFGR) values */
+#define W5500_PHYCFGR_RST            NO_OS_BIT(7)    /* PHY Reset */
+#define W5500_PHYCFGR_OPMD           NO_OS_BIT(6)    /* Operation Mode Select */
+#define W5500_PHYCFGR_OPMDC          NO_OS_GENMASK(5, 3)    /* Operation Mode Configuration */
+#define W5500_PHYCFGR_DPX            NO_OS_BIT(2)    /* Duplex Status (1=Full, 0=Half) */
+#define W5500_PHYCFGR_SPD            NO_OS_BIT(1)    /* Speed Status (1=100Mbps, 0=10Mbps) */
+#define W5500_PHYCFGR_LNK            NO_OS_BIT(0)    /* Link Status (1=Up, 0=Down) */
+
+/* PHYCFGR Operation Mode Configuration values */
+#define W5500_PHYCFGR_OPMDC_10BT_HD      no_os_field_prep(W5500_PHYCFGR_OPMDC, 0)
+/* 10BT Half-duplex, no auto-nego */
+#define W5500_PHYCFGR_OPMDC_10BT_FD      no_os_field_prep(W5500_PHYCFGR_OPMDC, 1)
+/* 10BT Full-duplex, no auto-nego */
+#define W5500_PHYCFGR_OPMDC_100BT_HD     no_os_field_prep(W5500_PHYCFGR_OPMDC, 2)
+/* 100BT Half-duplex, no auto-nego */
+#define W5500_PHYCFGR_OPMDC_100BT_FD     no_os_field_prep(W5500_PHYCFGR_OPMDC, 3)
+/* 100BT Full-duplex, no auto-nego */
+#define W5500_PHYCFGR_OPMDC_100BT_HD_AN  no_os_field_prep(W5500_PHYCFGR_OPMDC, 4)
+/* 100BT Half-duplex, with auto-nego */
+#define W5500_PHYCFGR_OPMDC_POWER_DOWN   no_os_field_prep(W5500_PHYCFGR_OPMDC, 6)
+/* Power down mode */
+#define W5500_PHYCFGR_OPMDC_ALL_AN       no_os_field_prep(W5500_PHYCFGR_OPMDC, 7)
+/* All capable, with auto-nego */
+
+/* Socket Buffer Size values (2^n KB) */
+#define W5500_SOCK_BUF_SIZE_0K       0x00    /* 0KB buffer size */
+#define W5500_SOCK_BUF_SIZE_1K       0x01    /* 1KB buffer size */
+#define W5500_SOCK_BUF_SIZE_2K       0x02    /* 2KB buffer size (default) */
+#define W5500_SOCK_BUF_SIZE_4K       0x04    /* 4KB buffer size */
+#define W5500_SOCK_BUF_SIZE_8K       0x08    /* 8KB buffer size */
+#define W5500_SOCK_BUF_SIZE_16K      0x10    /* 16KB buffer size */
+
+/* Maximum socket number */
+#define W5500_MAX_SOCK_NUMBER        7       /* 8 sockets (0-7) */
+
+struct w5500_socket {
+	uint8_t protocol;
+	uint16_t mss;
+	uint8_t tx_buf_size;
+	uint8_t rx_buf_size;
+};
+
+struct w5500_dev {
+	struct no_os_gpio_desc *gpio_reset;
+	struct no_os_gpio_desc *gpio_int;
+	struct no_os_spi_desc *spi;
+	uint8_t mac_addr[6];
+	uint8_t ip_addr[4];
+	uint8_t subnet_mask[4];
+	uint8_t gateway[4];
+	uint16_t retry_time;
+	uint8_t retry_count;
+	struct w5500_socket sockets[W5500_MAX_SOCK_NUMBER + 1];
+};
+
+struct w5500_init_param {
+	struct no_os_gpio_init_param gpio_reset;
+	struct no_os_gpio_init_param gpio_int;
+	struct no_os_spi_init_param spi_init;
+	uint8_t mac_addr[6];
+	uint8_t ip_addr[4];
+	uint8_t subnet_mask[4];
+	uint8_t gateway[4];
+	uint16_t retry_time;
+	uint8_t retry_count;
+};
+
+/*! Write data to a W5500 register */
+int w5500_reg_write(struct w5500_dev *dev, uint8_t block,
+		    uint16_t addr, const uint8_t *data, uint16_t len);
+
+/*! Read data from a W5500 register */
+int w5500_reg_read(struct w5500_dev *dev, uint8_t block,
+		   uint16_t addr, uint8_t *data, uint16_t len);
+
+/*! Read a 16-bit register reliably by reading until consecutive values match */
+int w5500_read_16bit_reg(struct w5500_dev *dev, uint8_t block,
+			 uint16_t addr, uint16_t *value);
+
+/*! Set MAC address */
+int w5500_set_mac(struct w5500_dev *dev, const uint8_t mac[6]);
+
+/*! Set IP address */
+int w5500_set_ip(struct w5500_dev *dev, const uint8_t ip[4]);
+
+/*! Set subnet mask */
+int w5500_set_subnet(struct w5500_dev *dev, const uint8_t subnet[4]);
+
+/*! Set gateway address */
+int w5500_set_gateway(struct w5500_dev *dev, const uint8_t gateway[4]);
+
+/*! Get MAC address */
+int w5500_get_mac(struct w5500_dev *dev, uint8_t mac[6]);
+
+/*! Get IP address */
+int w5500_get_ip(struct w5500_dev *dev, uint8_t ip[4]);
+
+/*! Get subnet mask */
+int w5500_get_subnet(struct w5500_dev *dev, uint8_t subnet[4]);
+
+/*! Get gateway address */
+int w5500_get_gateway(struct w5500_dev *dev, uint8_t gateway[4]);
+
+/*! Check the Ethernet link status */
+int w5500_check_link_status(struct w5500_dev *dev);
+
+/*! Configure W5500 TCP parameters (RTR and RCR) */
+int w5500_tcp_config(struct w5500_dev *dev, uint16_t retry_time,
+		     uint8_t retry_count);
+
+/*! Read status of a socket */
+int w5500_socket_read_status(struct w5500_dev *dev, uint8_t sock_id,
+			     uint8_t *status);
+
+/*! Write a command to a socket's command register */
+int w5500_socket_command_write(struct w5500_dev *dev, uint8_t sock_id,
+			       uint8_t val);
+
+/*! Clear specific socket interrupt flags */
+int w5500_socket_clear_interrupt(struct w5500_dev *dev, uint8_t sock_id,
+				 uint8_t flags);
+
+/*! Initialize a socket */
+int w5500_socket_init(struct w5500_dev *dev, uint8_t sock_id);
+
+/*! Open a socket with specified protocol */
+int w5500_socket_open(struct w5500_dev *dev, uint8_t sock_id,
+		      enum socket_protocol proto, uint8_t buff_size);
+
+/*! Close a socket */
+int w5500_socket_close(struct w5500_dev *dev, uint8_t sock_id);
+
+/*! Connect to a remote host (TCP client mode) */
+int w5500_socket_connect(struct w5500_dev *dev, uint8_t sock_id,
+			 struct socket_address *addr);
+
+/*! Disconnect a TCP connection */
+int w5500_socket_disconnect(struct w5500_dev *dev, uint8_t sock_id);
+
+/*! Send data through a socket */
+int w5500_socket_send(struct w5500_dev *dev, uint8_t sock_id, const void *buf,
+		      uint16_t len);
+
+/*! Receive data from a socket */
+int w5500_socket_recv(struct w5500_dev *dev, uint8_t sock_id, void *buf,
+		      uint16_t len);
+
+/*! Send data to a specific destination (UDP) */
+int w5500_socket_sendto(struct w5500_dev *dev, uint8_t sock_id, const void *buf,
+			uint16_t len, struct socket_address *to);
+
+/*! Receive data from a socket with source address information (UDP) */
+int w5500_socket_recvfrom(struct w5500_dev *dev, uint8_t sock_id,
+			  void *buf, uint16_t len,
+			  struct socket_address *from);
+
+/*! Bind a socket to a specific port (server mode) */
+int w5500_socket_bind(struct w5500_dev *dev, uint8_t sock_id, uint16_t port);
+
+/*! Set socket to listen mode (TCP server) */
+int w5500_socket_listen(struct w5500_dev *dev, uint8_t sock_id);
+
+/*! Reset the W5500 chip using hardware or software method */
+int w5500_reset(struct w5500_dev *dev);
+
+/*! Setup the W5500 chip with basic configuration */
+int w5500_setup(struct w5500_dev *dev);
+
+/*! Initialize the device */
+int w5500_init(struct w5500_dev **device,
+	       struct w5500_init_param *init_param);
+
+/*! Free a device descriptor and release resources */
+int w5500_remove(struct w5500_dev *dev);
+
+#endif

--- a/iio/iio.c
+++ b/iio/iio.c
@@ -206,7 +206,7 @@ struct iio_desc {
 	int (*send)(void *conn, uint8_t *buf, uint32_t len);
 	/* FIFO for socket descriptors */
 	struct no_os_circular_buffer	*conns;
-#if defined(NO_OS_NETWORKING) || defined(NO_OS_LWIP_NETWORKING)
+#if defined(NO_OS_NETWORKING) || defined(NO_OS_LWIP_NETWORKING) || defined(NO_OS_W5500_NETWORKING)
 	struct tcp_socket_desc	*current_sock;
 	/* Instance of server socket */
 	struct tcp_socket_desc	*server;
@@ -1441,7 +1441,7 @@ int iio_buffer_pop_scan(struct iio_buffer *buffer, void *data)
 	return ret;
 }
 
-#if defined(NO_OS_NETWORKING) || defined(NO_OS_LWIP_NETWORKING)
+#if defined(NO_OS_NETWORKING) || defined(NO_OS_LWIP_NETWORKING) || defined(NO_OS_W5500_NETWORKING)
 
 static int32_t accept_network_clients(struct iio_desc *desc)
 {
@@ -1499,7 +1499,7 @@ int iio_step(struct iio_desc *desc)
 
 	iio_process_async_triggers(desc);
 
-#if defined(NO_OS_NETWORKING) || defined(NO_OS_LWIP_NETWORKING)
+#if defined(NO_OS_NETWORKING) || defined(NO_OS_LWIP_NETWORKING) || defined(NO_OS_W5500_NETWORKING)
 	if (desc->server) {
 		ret = accept_network_clients(desc);
 		if (NO_OS_IS_ERR_VALUE(ret) && ret != -EAGAIN)
@@ -1516,7 +1516,7 @@ int iio_step(struct iio_desc *desc)
 
 	ret = iiod_conn_step(desc->iiod, conn_id);
 	if (ret == -ENOTCONN) {
-#if defined(NO_OS_NETWORKING) || defined(NO_OS_LWIP_NETWORKING)
+#if defined(NO_OS_NETWORKING) || defined(NO_OS_LWIP_NETWORKING) || defined(NO_OS_W5500_NETWORKING)
 		iiod_conn_remove(desc->iiod, conn_id, &data);
 		socket_remove(data.conn);
 		no_os_free(data.buf);
@@ -1947,7 +1947,7 @@ int iio_init(struct iio_desc **desc, struct iio_init_param *init_param)
 			goto free_conns;
 		_push_conn(ldesc, conn_id);
 	}
-#if defined(NO_OS_NETWORKING) || defined(NO_OS_LWIP_NETWORKING)
+#if defined(NO_OS_NETWORKING) || defined(NO_OS_LWIP_NETWORKING) || defined(NO_OS_W5500_NETWORKING)
 	else if (init_param->phy_type == USE_NETWORK) {
 		ldesc->send = (int (*)())socket_send;
 		ldesc->recv = (int (*)())socket_recv;
@@ -1986,7 +1986,7 @@ int iio_init(struct iio_desc **desc, struct iio_init_param *init_param)
 	return 0;
 
 free_pylink:
-#if defined(NO_OS_NETWORKING) || defined(NO_OS_LWIP_NETWORKING)
+#if defined(NO_OS_NETWORKING) || defined(NO_OS_LWIP_NETWORKING) || defined(NO_OS_W5500_NETWORKING)
 	socket_remove(ldesc->server);
 #endif
 free_conns:
@@ -2018,7 +2018,7 @@ int iio_remove(struct iio_desc *desc)
 	if (!desc)
 		return -EINVAL;
 
-#if defined(NO_OS_NETWORKING) || defined(NO_OS_LWIP_NETWORKING)
+#if defined(NO_OS_NETWORKING) || defined(NO_OS_LWIP_NETWORKING) || defined(NO_OS_W5500_NETWORKING)
 	for (int i = 0; i < IIOD_MAX_CONNECTIONS; i++) {
 		ret = iiod_conn_remove(desc->iiod, i, &data);
 		if (!ret) {

--- a/iio/iio.h
+++ b/iio/iio.h
@@ -37,7 +37,7 @@
 
 #include "iio_types.h"
 #include "no_os_uart.h"
-#if defined(NO_OS_NETWORKING) || defined(NO_OS_LWIP_NETWORKING)
+#if defined(NO_OS_NETWORKING) || defined(NO_OS_LWIP_NETWORKING) || defined(NO_OS_W5500_NETWORKING)
 #include "tcp_socket.h"
 #endif
 
@@ -97,7 +97,7 @@ struct iio_init_param {
 	enum physical_link_type	phy_type;
 	union {
 		struct no_os_uart_desc *uart_desc;
-#if defined(NO_OS_NETWORKING) || defined(NO_OS_LWIP_NETWORKING)
+#if defined(NO_OS_NETWORKING) || defined(NO_OS_LWIP_NETWORKING) || defined(NO_OS_W5500_NETWORKING)
 		struct tcp_socket_init_param *tcp_socket_init_param;
 #endif
 	};

--- a/iio/iio_app/iio_app.c
+++ b/iio/iio_app/iio_app.c
@@ -348,6 +348,14 @@ int iio_app_init(struct iio_app_desc **app,
 	status = network_setup(&iio_init_param, uart_desc, application->irq_desc);
 	if (status < 0)
 		goto error;
+#elif defined(NO_OS_W5500_NETWORKING)
+	static struct tcp_socket_init_param socket_param;
+
+	socket_param.net = &app_init_param.net_dev->net_if;
+	socket_param.max_buff_size = 0;
+
+	iio_init_param.phy_type = USE_NETWORK;
+	iio_init_param.tcp_socket_init_param = &socket_param;
 #else
 	iio_init_param.phy_type = USE_UART;
 	iio_init_param.uart_desc = uart_desc;

--- a/iio/iio_app/iio_app.h
+++ b/iio/iio_app/iio_app.h
@@ -44,6 +44,11 @@
 #include "lwip_socket.h"
 #endif
 
+#if defined(NO_OS_W5500_NETWORKING)
+#include "tcp_socket.h"
+#include "w5500_network.h"
+#endif
+
 #define IIO_APP_DEVICE(_name, _dev, _dev_descriptor, _read_buff, _write_buff, _default_trigger_id) {\
 	.name = _name,\
 	.dev = _dev,\
@@ -122,6 +127,10 @@ struct iio_app_init_param {
 
 #ifdef NO_OS_LWIP_NETWORKING
 	struct lwip_network_param lwip_param;
+#endif
+
+#ifdef NO_OS_W5500_NETWORKING
+	struct w5500_network_dev *net_dev;
 #endif
 };
 

--- a/network/w5500_network/w5500_network.c
+++ b/network/w5500_network/w5500_network.c
@@ -1,0 +1,548 @@
+/***************************************************************************/ /**
+*   @file   w5500_network.c
+*   @brief  W5500 Network Interface Implementation
+*   @author Alisa-Dariana Roman (alisa.roman@analog.com)
+********************************************************************************
+* Copyright 2025(c) Analog Devices, Inc.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* 3. Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived from this
+*    software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+* EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "w5500_network.h"
+#include "tcp_socket.h"
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+/***************************************************************************//**
+ * @brief Initialize the socket mapping table
+ *
+ * @param dev - The W5500 network device descriptor
+ *
+ * @return 0 in case of success, negative error code otherwise
+*******************************************************************************/
+static int w5500_net_sockets_init(struct w5500_network_dev *dev)
+{
+	uint8_t i;
+
+	for (i = 0; i <= W5500_MAX_SOCK_NUMBER; i++) {
+		dev->sockets[i].in_use = 0;
+		dev->sockets[i].physical_id = i;
+		dev->sockets[i].local_port = 0;
+		dev->sockets[i].remote_port = 0;
+		memset(dev->sockets[i].remote_ip, 0, 4);
+	}
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * @brief Find an available socket in the socket mapping table
+ *
+ * @param dev         - The W5500 network device descriptor
+ * @param physical_id - Pointer to store the found physical socket ID
+ *
+ * @return 0 in case of success, -ENOENT if no free socket found
+*******************************************************************************/
+static int w5500_net_find_free_socket(struct w5500_network_dev *dev,
+				      uint8_t *physical_id)
+{
+	uint8_t i;
+
+	for (i = 0; i <= W5500_MAX_SOCK_NUMBER; i++) {
+		if (!dev->sockets[i].in_use) {
+			*physical_id = i;
+			return 0;
+		}
+	}
+	return -ENOENT;
+}
+
+/***************************************************************************//**
+ * @brief Map a virtual socket ID to its physical counterpart
+ *
+ * @param dev         - The W5500 network device descriptor
+ * @param sock_id     - The virtual socket ID to map
+ * @param physical_id - Pointer to store the mapped physical socket ID
+ *
+ * @return 0 in case of success, -ENOENT if mapping not found
+*******************************************************************************/
+static int w5500_net_map(struct w5500_network_dev *dev, uint32_t sock_id,
+			 uint8_t *physical_id)
+{
+	uint8_t i;
+
+	for (i = 0; i <= W5500_MAX_SOCK_NUMBER; i++) {
+		if (dev->sockets[i].sock_id == sock_id) {
+			*physical_id = dev->sockets[i].physical_id;
+			return 0;
+		}
+	}
+	return -ENOENT;
+}
+
+/***************************************************************************//**
+ * @brief Open a socket through the network interface
+ *
+ * @param net       - The network interface
+ * @param sock_id   - Pointer to store the assigned socket ID
+ * @param proto     - Protocol to use (TCP, UDP)
+ * @param buff_size - Buffer size for the socket
+ *
+ * @return 0 in case of success, negative error code otherwise
+*******************************************************************************/
+static int32_t w5500_net_socket_open(void *net, uint32_t *sock_id,
+				     enum socket_protocol proto,
+				     uint32_t buff_size)
+{
+	struct w5500_network_dev *net_dev = net;
+	uint8_t buff_kb;
+	uint8_t physical_id;
+	struct w5500_socket_map *socket;
+	int ret;
+
+	if (buff_size <= 1024)
+		buff_kb = 1;
+	else if (buff_size <= 2048)
+		buff_kb = 2;
+	else if (buff_size <= 4096)
+		buff_kb = 4;
+	else if (buff_size <= 8192)
+		buff_kb = 8;
+	else
+		buff_kb = 16;
+
+	ret = w5500_net_find_free_socket(net_dev, &physical_id);
+	if (ret)
+		return ret;
+
+	ret = w5500_socket_open(net_dev->mac_dev, physical_id, proto, buff_kb);
+	if (ret)
+		return ret;
+
+	socket = &net_dev->sockets[physical_id];
+
+	socket->role = (proto == PROTOCOL_TCP) ? W5500_ROLE_CLIENT : W5500_ROLE_UNUSED;
+	socket->in_use = 1;
+	socket->sock_id = net_dev->next_virtual_id;
+
+	net_dev->next_virtual_id++;
+
+	*sock_id = socket->sock_id;
+	return 0;
+}
+
+/***************************************************************************//**
+ * @brief Close a socket
+ *
+ * @param net     - The network interface
+ * @param sock_id - The socket ID to close
+ *
+ * @return 0 in case of success, negative error code otherwise
+*******************************************************************************/
+static int32_t w5500_net_socket_close(void *net, uint32_t sock_id)
+{
+	struct w5500_network_dev *net_dev = net;
+	struct w5500_socket_map *socket;
+	uint8_t physical_id;
+	int ret;
+
+	ret = w5500_net_map(net_dev, sock_id, &physical_id);
+	if (ret)
+		return ret;
+
+	ret = w5500_socket_close(net_dev->mac_dev, physical_id);
+	if (ret) {
+		return ret;
+	}
+
+	socket = &net_dev->sockets[physical_id];
+	socket->in_use = 0;
+	socket->role = W5500_ROLE_UNUSED;
+
+	return 0;
+
+}
+
+/***************************************************************************//**
+ * @brief Connect a socket to a remote host
+ *
+ * @param net     - The network interface
+ * @param sock_id - The socket ID to connect
+ * @param addr    - The remote address to connect to
+ *
+ * @return 0 in case of success, negative error code otherwise
+*******************************************************************************/
+static int32_t w5500_net_socket_connect(void *net, uint32_t sock_id,
+					struct socket_address *addr)
+{
+	struct w5500_network_dev *net_dev = net;
+	struct socket_address w5500_addr;
+	uint8_t physical_id;
+	int ret;
+
+	if (!addr || !addr->addr)
+		return -EINVAL;
+
+	ret = w5500_net_map(net_dev, sock_id, &physical_id);
+	if (ret)
+		return ret;
+
+	w5500_addr.addr = addr->addr;
+	w5500_addr.port = addr->port;
+
+	return w5500_socket_connect(net_dev->mac_dev, physical_id, &w5500_addr);
+}
+
+/***************************************************************************//**
+ * @brief Disconnect a connected socket
+ *
+ * @param net     - The network interface
+ * @param sock_id - The socket ID to disconnect
+ *
+ * @return 0 in case of success, negative error code otherwise
+*******************************************************************************/
+static int32_t w5500_net_socket_disconnect(void *net, uint32_t sock_id)
+{
+	struct w5500_network_dev *net_dev = net;
+	uint8_t physical_id;
+	int ret;
+
+	ret = w5500_net_map(net_dev, sock_id, &physical_id);
+	if (ret)
+		return ret;
+
+	return w5500_socket_disconnect(net_dev->mac_dev, physical_id);
+}
+
+/***************************************************************************//**
+ * @brief Send data through a socket
+ *
+ * @param net     - The network interface
+ * @param sock_id - The socket ID to send data through
+ * @param data    - Pointer to the data buffer to send
+ * @param size    - Size of the data to send
+ *
+ * @return Number of bytes sent on success, negative error code otherwise
+*******************************************************************************/
+static int32_t w5500_net_socket_send(void *net, uint32_t sock_id,
+				     const void *data, uint32_t size)
+{
+	struct w5500_network_dev *net_dev = net;
+	uint8_t physical_id;
+	int ret;
+
+	if (!data)
+		return -EINVAL;
+
+	ret = w5500_net_map(net_dev, sock_id, &physical_id);
+	if (ret)
+		return ret;
+
+	return w5500_socket_send(net_dev->mac_dev, physical_id, data, size);
+}
+
+/***************************************************************************//**
+ * @brief Receive data from a socket
+ *
+ * @param net     - The network interface
+ * @param sock_id - The socket ID to receive data from
+ * @param data    - Buffer to store received data
+ * @param size    - Maximum size of data to receive
+ *
+ * @return Number of bytes received on success, negative error code otherwise
+*******************************************************************************/
+static int32_t w5500_net_socket_recv(void *net, uint32_t sock_id,
+				     void *data, uint32_t size)
+{
+	struct w5500_network_dev *net_dev = net;
+	uint8_t physical_id;
+	int ret;
+
+	if (!data)
+		return -EINVAL;
+
+	ret = w5500_net_map(net_dev, sock_id, &physical_id);
+	if (ret)
+		return ret;
+
+	return w5500_socket_recv(net_dev->mac_dev, physical_id, data, size);
+}
+
+/***************************************************************************//**
+ * @brief Send data to a specific destination (UDP)
+ *
+ * @param net     - The network interface
+ * @param sock_id - The socket ID to send data through
+ * @param data    - Pointer to the data buffer to send
+ * @param size    - Size of the data to send
+ * @param to      - Destination address information
+ *
+ * @return Number of bytes sent on success, negative error code otherwise
+*******************************************************************************/
+static int32_t w5500_net_socket_sendto(void *net, uint32_t sock_id,
+				       const void *data, uint32_t size,
+				       const struct socket_address *to)
+{
+	struct w5500_network_dev *net_dev = net;
+	struct socket_address w5500_addr;
+	uint8_t physical_id;
+	int ret;
+
+	if (!data || !to || !to->addr)
+		return -EINVAL;
+
+	ret = w5500_net_map(net_dev, sock_id, &physical_id);
+	if (ret)
+		return ret;
+
+	/* Copy the address structure for W5500 */
+	w5500_addr.addr = to->addr;
+	w5500_addr.port = to->port;
+
+	return w5500_socket_sendto(net_dev->mac_dev, physical_id, data, size,
+				   &w5500_addr);
+}
+
+/***************************************************************************//**
+ * @brief Receive data from a socket with source address information (UDP)
+ *
+ * @param net     - The network interface
+ * @param sock_id - The socket ID to receive data from
+ * @param data    - Buffer to store received data
+ * @param size    - Maximum size of data to receive
+ * @param from    - Buffer to store source address information
+ *
+ * @return Number of bytes received on success, negative error code otherwise
+*******************************************************************************/
+static int32_t w5500_net_socket_recvfrom(void *net, uint32_t sock_id,
+		void *data, uint32_t size,
+		struct socket_address *from)
+{
+	struct w5500_network_dev *net_dev = net;
+	uint8_t physical_id;
+	int ret;
+
+	if (!data)
+		return -EINVAL;
+
+	ret = w5500_net_map(net_dev, sock_id, &physical_id);
+	if (ret)
+		return ret;
+
+	return w5500_socket_recvfrom(net_dev->mac_dev, physical_id, data, size, from);
+}
+
+/***************************************************************************//**
+ * @brief Bind a socket to a specific port
+ *
+ * @param net     - The network interface
+ * @param sock_id - The socket ID to bind
+ * @param port    - The port number to bind to
+ *
+ * @return 0 in case of success, negative error code otherwise
+*******************************************************************************/
+static int32_t w5500_net_socket_bind(void *net, uint32_t sock_id, uint16_t port)
+{
+	struct w5500_network_dev *net_dev = net;
+	struct w5500_socket_map *socket;
+	uint8_t physical_id;
+	int ret;
+
+	ret = w5500_net_map(net_dev, sock_id, &physical_id);
+	if (ret)
+		return ret;
+
+	ret = w5500_socket_bind(net_dev->mac_dev, physical_id, port);
+	if (ret)
+		return ret;
+
+	socket = &net_dev->sockets[physical_id];
+	socket->local_port = port;
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * @brief Set a socket to listen mode (TCP server)
+ *
+ * @param net      - The network interface
+ * @param sock_id  - The socket ID to set in listen mode
+ * @param back_log - Maximum connection backlog (not used by W5500)
+ *
+ * @return 0 in case of success, negative error code otherwise
+*******************************************************************************/
+static int32_t w5500_net_socket_listen(void *net, uint32_t sock_id,
+				       uint32_t back_log)
+{
+	struct w5500_network_dev *net_dev = net;
+	struct w5500_socket_map *socket;
+	uint8_t physical_id;
+	int ret;
+
+	ret = w5500_net_map(net_dev, sock_id, &physical_id);
+	if (ret)
+		return ret;
+
+	ret = w5500_socket_listen(net_dev->mac_dev, physical_id);
+	if (ret)
+		return ret;
+
+	socket = &net_dev->sockets[physical_id];
+	socket->role = W5500_ROLE_SERVER;
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * @brief Accept an incoming connection on a listening socket
+ *
+ * @param net            - The network interface
+ * @param sock_id        - The listening socket ID
+ * @param client_sock_id - Pointer to store the new client socket ID
+ *
+ * @return 0 in case of success, -EAGAIN if no connection pending, other negative error code otherwise
+*******************************************************************************/
+static int32_t w5500_net_socket_accept(void *net, uint32_t sock_id,
+				       uint32_t *client_sock_id)
+{
+	struct w5500_network_dev *net_dev = net;
+	struct w5500_socket_map *server_socket;
+	struct w5500_socket_map *new_socket;
+	uint8_t status;
+	uint8_t physical_id;
+	uint8_t new_physical_id;
+	int ret;
+
+	if (!client_sock_id)
+		return -EINVAL;
+
+	ret = w5500_net_map(net_dev, sock_id, &physical_id);
+	if (ret)
+		return ret;
+
+	server_socket = &net_dev->sockets[physical_id];
+
+	if (server_socket->role != W5500_ROLE_SERVER)
+		return -EINVAL;
+
+	ret = w5500_socket_read_status(net_dev->mac_dev, physical_id, &status);
+	if (ret)
+		return ret;
+
+	if (status != W5500_Sn_SR_ESTABLISHED)
+		return -EAGAIN;
+
+	ret = w5500_net_find_free_socket(net_dev, &new_physical_id);
+	if (ret)
+		return ret;
+
+	ret = w5500_socket_open(net_dev->mac_dev, new_physical_id, PROTOCOL_TCP, 2);
+	if (ret)
+		return ret;
+
+	ret = w5500_socket_bind(net_dev->mac_dev, new_physical_id,
+				server_socket->local_port);
+	if (ret)
+		return ret;
+
+	ret = w5500_socket_listen(net_dev->mac_dev, new_physical_id);
+	if (ret)
+		return ret;
+
+	new_socket = &net_dev->sockets[new_physical_id];
+	new_socket->sock_id = sock_id;
+	new_socket->local_port = server_socket->local_port;
+	new_socket->in_use = 1;
+	new_socket->role = W5500_ROLE_SERVER;
+
+	server_socket->sock_id = net_dev->next_virtual_id++;
+	server_socket->role = W5500_ROLE_CLIENT;
+
+	*client_sock_id = server_socket->sock_id;
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * @brief Initialize the W5500 network interface
+ *
+ * @param net_dev    - Double pointer to store the created network device
+ * @param init_param - Initialization parameters
+ *
+ * @return 0 in case of success, negative error code otherwise
+*******************************************************************************/
+int w5500_network_init(struct w5500_network_dev **net_dev,
+		       struct w5500_network_init_param *init_param)
+{
+	struct w5500_network_dev *dev;
+	int32_t ret;
+
+	dev = (struct w5500_network_dev *)no_os_calloc(1, sizeof(*dev));
+	if (!dev)
+		return -ENOMEM;
+
+	dev->net_if.net = dev;
+
+	dev->net_if.socket_open = w5500_net_socket_open;
+	dev->net_if.socket_close = w5500_net_socket_close;
+	dev->net_if.socket_connect = w5500_net_socket_connect;
+	dev->net_if.socket_disconnect = w5500_net_socket_disconnect;
+	dev->net_if.socket_send = w5500_net_socket_send;
+	dev->net_if.socket_recv = w5500_net_socket_recv;
+	dev->net_if.socket_sendto = w5500_net_socket_sendto;
+	dev->net_if.socket_recvfrom = w5500_net_socket_recvfrom;
+	dev->net_if.socket_bind = w5500_net_socket_bind;
+	dev->net_if.socket_listen = w5500_net_socket_listen;
+	dev->net_if.socket_accept = w5500_net_socket_accept;
+
+	ret = w5500_net_sockets_init(dev);
+	if (ret)
+		return ret;
+
+	dev->next_virtual_id = W5500_MAX_SOCK_NUMBER + 1;
+
+	*net_dev = dev;
+
+	return 0;
+}
+
+/***************************************************************************//**
+ * @brief Remove a W5500 network device and free resources
+ *
+ * @param dev - The device descriptor to remove
+ *
+ * @return 0 in case of success, negative error code otherwise
+*******************************************************************************/
+int w5500_network_remove(struct w5500_network_dev *dev)
+{
+	if (!dev)
+		return -EINVAL;
+
+	no_os_free(dev);
+
+	return 0;
+}

--- a/network/w5500_network/w5500_network.h
+++ b/network/w5500_network/w5500_network.h
@@ -1,0 +1,75 @@
+/***************************************************************************//**
+*   @file   w5500_network.h
+*   @brief  W5500 Network Interface
+*   @author Alisa-Dariana Roman (alisa.roman@analog.com)
+********************************************************************************
+* Copyright 2025(c) Analog Devices, Inc.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* 3. Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived from this
+*    software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+* EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef W5500_NETWORK_H
+#define W5500_NETWORK_H
+
+#include "network_interface.h"
+#include "w5500.h"
+
+enum w5500_socket_role {
+	W5500_ROLE_UNUSED,
+	W5500_ROLE_SERVER,
+	W5500_ROLE_CLIENT
+};
+
+struct w5500_socket_map {
+	uint8_t physical_id;
+	uint32_t sock_id;
+	uint8_t in_use;
+	enum w5500_socket_role role;
+	uint16_t local_port;
+	uint16_t remote_port;
+	uint8_t remote_ip[4];
+};
+
+
+struct w5500_network_dev {
+	struct w5500_dev *mac_dev;
+	struct network_interface net_if;
+	struct w5500_socket_map sockets[W5500_MAX_SOCK_NUMBER + 1];
+	uint32_t next_virtual_id;
+};
+
+struct w5500_network_init_param {
+	void *mac_dev;
+};
+
+/*! Initialize the device */
+int w5500_network_init(struct w5500_network_dev **net_dev,
+		       struct w5500_network_init_param *init_param);
+
+/*! Free a device descriptor and release resources */
+int w5500_network_remove(struct w5500_network_dev *dev);
+
+#endif /* W5500_NETWORK_H */

--- a/projects/eval-pqmon/Makefile
+++ b/projects/eval-pqmon/Makefile
@@ -17,8 +17,8 @@ $(info Using SERIAL as interface for IIO communication)
 CFLAGS += -DPQM_CONN_SERIAL
 endif
 
-ifeq ($(INTERFACE), ethernet)
-$(info Using ETHERNET as interface for IIO communication)
+ifeq ($(INTERFACE), ethernet_t1l)
+$(info Using ETHERNET T1L as interface for IIO communication)
 CFLAGS += -DPQM_CONN_T1L
 CFLAGS += -DNO_OS_LWIP_NETWORKING
 CFLAGS += -DNO_OS_LWIP_INIT_ONETIME=1

--- a/projects/eval-pqmon/Makefile
+++ b/projects/eval-pqmon/Makefile
@@ -17,6 +17,14 @@ $(info Using SERIAL as interface for IIO communication)
 CFLAGS += -DPQM_CONN_SERIAL
 endif
 
+ifeq ($(INTERFACE), ethernet)
+$(info Using ETHERNET as interface for IIO communication)
+CFLAGS += -DPQM_CONN_USB
+CFLAGS += -DNO_OS_USB_UART
+CFLAGS += -DPQM_CONN_ETH
+CFLAGS += -DNO_OS_W5500_NETWORKING
+endif
+
 ifeq ($(INTERFACE), ethernet_t1l)
 $(info Using ETHERNET T1L as interface for IIO communication)
 CFLAGS += -DPQM_CONN_T1L

--- a/projects/eval-pqmon/README.md
+++ b/projects/eval-pqmon/README.md
@@ -36,7 +36,7 @@ The firmware application can communicate with clients via several interfaces. In
 
 * ```INTERFACE=usb``` (Default value)
 * ```INTERFACE=serial``` (Used for 485 communication. Half-duplex communication must be handled by user)
-* ```INTERFACE=ethernet``` (Used for communication over T1L)
+* ```INTERFACE=ethernet_t1l``` (Used for communication over T1L)
 
 NOTE: In case one builds firmware multiple times with different interfaces, make sure to delete the `build` directory before the new  compilation.
 

--- a/projects/eval-pqmon/src.mk
+++ b/projects/eval-pqmon/src.mk
@@ -66,6 +66,17 @@ endif
 ifeq ($(INTERFACE), serial)
 endif
 
+ifeq ($(INTERFACE), ethernet)
+	INCS += $(DRIVERS)/net/w5500/w5500.h
+	INCS += $(NO-OS)/network/w5500_network/w5500_network.h
+	INCS += $(NO-OS)/network/network_interface.h
+	INCS += $(NO-OS)/network/tcp_socket.h
+
+	SRCS += $(DRIVERS)/net/w5500/w5500.c
+	SRCS += $(NO-OS)/network/w5500_network/w5500_network.c
+	SRCS += $(NO-OS)/network/tcp_socket.c
+endif
+
 ifeq ($(INTERFACE), ethernet_t1l)
 	LIBRARIES += lwip
 	INCS += $(NO-OS)/network/tcp_socket.h			\

--- a/projects/eval-pqmon/src.mk
+++ b/projects/eval-pqmon/src.mk
@@ -66,7 +66,7 @@ endif
 ifeq ($(INTERFACE), serial)
 endif
 
-ifeq ($(INTERFACE), ethernet)
+ifeq ($(INTERFACE), ethernet_t1l)
 	LIBRARIES += lwip
 	INCS += $(NO-OS)/network/tcp_socket.h			\
 		$(NO-OS)/network/noos_mbedtls_config.h		\

--- a/projects/eval-pqmon/src/common/common_data.c
+++ b/projects/eval-pqmon/src/common/common_data.c
@@ -33,6 +33,47 @@
 
 #include "common_data.h"
 
+#if defined(PQM_CONN_ETH)
+
+const struct no_os_gpio_init_param w5500_rst_gpio_ip = {
+	.port = 0,
+	.number = 14,
+	.pull = NO_OS_PULL_UP,
+	.platform_ops = GPIO_OPS,
+	.extra = GPIO_EXTRA,
+};
+
+const struct no_os_gpio_init_param w5500_int_gpio_ip = {
+	.port = 0,
+	.number = 13,
+	.pull = NO_OS_PULL_NONE,
+	.platform_ops = GPIO_OPS,
+	.extra = GPIO_EXTRA,
+};
+
+const struct no_os_spi_init_param w5500_spi_init_params = {
+	.device_id = 3,
+	.max_speed_hz = 15000000,
+	.bit_order = NO_OS_SPI_BIT_ORDER_MSB_FIRST,
+	.mode = NO_OS_SPI_MODE_0,
+	.platform_ops = SPI_OPS,
+	.chip_select = 0,
+	.extra = WIZ_SPI_EXTRA,
+};
+
+struct w5500_init_param w5500_ip = {
+	.spi_init = w5500_spi_init_params,
+	.gpio_reset = w5500_rst_gpio_ip,
+	.gpio_int = w5500_int_gpio_ip,
+	.mac_addr = {0x00, 0x08, 0xDC, 0x01, 0x02, 0x03},
+	.ip_addr = {192, 168, 1, 110},
+	.subnet_mask = {255, 255, 255, 0},
+	.gateway = {192, 168, 1, 1},
+	.retry_time = 2000,
+	.retry_count = 3,
+};
+#endif
+
 #if defined(PQM_CONN_USB)
 struct no_os_uart_init_param iio_demo_usb_ip = {
 	.device_id = UART_DEVICE_ID,

--- a/projects/eval-pqmon/src/common/common_data.h
+++ b/projects/eval-pqmon/src/common/common_data.h
@@ -34,6 +34,10 @@
 #ifndef __COMMON_DATA_H__
 #define __COMMON_DATA_H__
 
+#if defined(PQM_CONN_ETH)
+#include "w5500.h"
+#endif
+
 #if defined(PQM_CONN_T1L)
 #include "lwip_socket.h"
 #include "lwip_adin1110.h"
@@ -69,6 +73,12 @@
 #define MAX_EVENT_NUMBER 6
 
 extern IIO_BUFF_TYPE iio_data_buffer_loc[MAX_SIZE_BASE_ADDR];
+
+#if defined(PQM_CONN_ETH)
+extern const struct no_os_spi_init_param w5500_spi_init_params;
+
+extern struct w5500_init_param w5500_ip;
+#endif
 
 #if defined(PQM_CONN_USB)
 extern struct no_os_uart_init_param iio_demo_usb_ip;

--- a/projects/eval-pqmon/src/examples/basic/basic_example.c
+++ b/projects/eval-pqmon/src/examples/basic/basic_example.c
@@ -225,6 +225,23 @@ int basic_pqm_firmware()
 	app_init_param.lwip_param.extra = NULL;
 #endif
 
+#if defined(PQM_CONN_ETH)
+	struct w5500_dev *mac_dev;
+	struct w5500_network_dev *net_dev;
+
+	status = w5500_init(&mac_dev, &w5500_ip);
+	if (status)
+		return status;
+
+	status = w5500_network_init(&net_dev, NULL);
+	if (status)
+		return status;
+
+	net_dev->mac_dev = mac_dev;
+
+	app_init_param.net_dev = net_dev;
+#endif
+
 	app_init_param.post_step_callback = &(pqm_one_cycle);
 	status = iio_app_init(&app, app_init_param);
 

--- a/projects/eval-pqmon/src/platform/maxim/parameters.h
+++ b/projects/eval-pqmon/src/platform/maxim/parameters.h
@@ -49,6 +49,10 @@
 #define UART_IRQ_ID USB_IRQn
 #define UART_OPS &max_usb_uart_ops
 
+#if defined(PQM_CONN_ETH)
+#define WIZ_SPI_EXTRA &spi_extra_ip
+#endif
+
 #if defined(PQM_CONN_USB)
 #define UART_EXTRA &iio_demo_usb_uart_extra_ip
 #elif defined(PQM_CONN_SERIAL)


### PR DESCRIPTION
## Pull Request Description

This PR adds support for the W5500 Ethernet controller chip, providing standard Ethernet connectivity for no-os projects. The implementation includes:

- Core W5500 driver with SPI interface and socket management
- Network interface adapter to integrate with the no-os network_interface API
- IIO subsystem support for W5500-based network communications
- Integration with the eval-pqmon project, adding a new "ethernet" build option

## PR Type
- [x] New feature (change that adds new functionality)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
