### PR TITLE
ci: documentation.sh: Fix unary operator

### DIFF
--- a/ci/documentation.sh
+++ b/ci/documentation.sh
@@ -70,16 +70,16 @@ check_sphinx_doc() {
                         if ! [ -f "$sphinx_path/$top_dir/$fn_dir.rst" ];
                         then
                                 echo_red "Missing $fn_dir.rst file at $sphinx_path/$top_dir"
-                                erros_found=1
+                                errors_found=1
                         fi
 
                         if ! grep -q "$top_dir/$fn_dir" "$sphinx_path/${top_dir}_doc.rst"
                         then
                                 echo_red "Missing $top_dir/$fn_dir link inside $sphinx_path/${top_dir}_doc.rst"
-                                erros_found=1
+                                errors_found=1
                         fi
 
-                        if [ $erros_found -eq 1 ]
+                        if [ "$errors_found" -eq "1" ]
                         then
                                 exit 1
                         fi


### PR DESCRIPTION
## Pull Request Description

Due to a misspelling, errors_found didn't exist if no error was caught. Still, double quote to ensure bash never expands into an invalid `if [ -eq 1 ]`, instead, ensure `if [ "" -eq "1" ]`

Fixes cluttering the log with 
```
./ci/documentation.sh: line 82: [: -eq: unary operator expected
```

## PR Type
- [X] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
