### PR TITLE
drivers:platform:stm32:stm32:stm32_gpdma.c: Removed List De-Init

### DIFF
--- a/drivers/platform/stm32/stm32_gpdma.c
+++ b/drivers/platform/stm32/stm32_gpdma.c
@@ -115,8 +115,6 @@ static int stm32_gpdma_llist_config(struct stm32_dma_channel *sdma_ch,
 		if (ch_priv_data->llist) {
 			if (HAL_DMAEx_List_ResetQ(ch_priv_data->llist) != HAL_OK)
 				return -EINVAL;
-			if (HAL_DMAEx_List_DeInit(sdma_ch->hdma) != HAL_OK)
-				return -EINVAL;
 
 			no_os_free(ch_priv_data->llist);
 			ch_priv_data->llist = NULL;


### PR DESCRIPTION
## Pull Request Description

Re-configuration of the DMA and the List should only configure the list with the new nodes but should not de-initialize the DMA. 

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
