### PR TITLE
drivers: pwm: Fix PWM remove API

### DIFF
--- a/drivers/platform/stm32/stm32_pwm.c
+++ b/drivers/platform/stm32/stm32_pwm.c
@@ -793,7 +793,7 @@ int32_t stm32_pwm_remove(struct no_os_pwm_desc *desc)
 		return -EINVAL;
 	}
 
-	ret = no_os_gpio_remove(extra->gpio);
+	ret = no_os_gpio_remove(desc->pwm_gpio);
 	if (ret)
 		return ret;
 

--- a/drivers/platform/stm32/stm32_pwm.h
+++ b/drivers/platform/stm32/stm32_pwm.h
@@ -34,9 +34,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "no_os_gpio.h"
 #include "no_os_irq.h"
-#include "stm32_gpio.h"
 #include "stm32_hal.h"
 
 enum stm32_pwm_timer {
@@ -123,8 +121,6 @@ struct stm32_pwm_desc {
 	void *htimer;
 	/** Type of timer used for PWM */
 	enum stm32_pwm_timer pwm_timer;
-	/** Timer GPIO instance */
-	struct no_os_gpio_desc *gpio;
 	/** Timer prescaler */
 	uint32_t prescaler;
 	/** Timer autoreload enable */


### PR DESCRIPTION
Fix to deallocate memory for GPIO in remove API.
Remove unused gpio structure member.

Fixes: 9264d8983c4e ("drivers/platform/stm32: stm32 pwm support.")

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
