### PR TITLE
adxl367: add adxl366 as compatible to the driver

### DIFF
--- a/drivers/accel/adxl367/adxl367.c
+++ b/drivers/accel/adxl367/adxl367.c
@@ -63,6 +63,7 @@ int adxl367_init(struct adxl367_dev **device,
 	if (!dev)
 		return -1;
 
+	dev->id = init_param.id;
 	dev->comm_type = init_param.comm_type;
 	if (dev->comm_type == ADXL367_SPI_COMM) {
 		/* SPI */

--- a/drivers/accel/adxl367/adxl367.h
+++ b/drivers/accel/adxl367/adxl367.h
@@ -278,6 +278,15 @@
 #define ADXL367_SELF_TEST_MAX	270 * 100 / 25
 
 /**
+ * @enum adxl367_id
+ * @brief Compatible device specifier.
+ */
+enum adxl367_id {
+	ADXL367_ID,
+	ADXL366_ID,
+};
+
+/**
  * @enum adxl367_comm_type
  * @brief Enum for communication type.
  */
@@ -411,6 +420,8 @@ struct adxl367_fractional_val {
  * @brief ADXL367 Device structure.
  */
 struct adxl367_dev {
+	/** Compatible device specifier. */
+	enum adxl367_id			id;
 	/** Communication type - I2C or SPI. */
 	enum adxl367_comm_type		comm_type;
 	/** SPI Descriptor */
@@ -438,6 +449,8 @@ struct adxl367_dev {
  * @brief Structure holding the parameters for ADXL367 device initialization.
  */
 struct adxl367_init_param {
+	/** Compatible device specifier. */
+	enum adxl367_id			id;
 	/** Communication type - I2C or SPI. */
 	enum adxl367_comm_type 		comm_type;
 	/** SPI Initialization structure. */


### PR DESCRIPTION
adxl366 is backwards compatible with adxl367. It has a few extra features which will be added later, but simply list it as compatible in the existing driver for now.

## Pull Request Description

adxl366 is backwards compatible with adxl367. It has a few extra features which will be added later, but simply list it as compatible in the existing driver for now.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
