### PR TITLE
ADT7420 Linux Support and Linux I2C API Fix

### DIFF
--- a/drivers/platform/linux/linux_i2c.h
+++ b/drivers/platform/linux/linux_i2c.h
@@ -2,8 +2,9 @@
  *   @file   linux/linux_i2c.h
  *   @brief  Header containing extra types used by the I2C driver.
  *   @author Dragos Bogdan (dragos.bogdan@analog.com)
+ *   @author Jamila Macagba (Jamila.Macagba@analog.com)
 ********************************************************************************
- * Copyright 2020(c) Analog Devices, Inc.
+ * Copyright 2020, 2025(c) Analog Devices, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -32,6 +33,8 @@
 *******************************************************************************/
 #ifndef LINUX_I2C_H_
 #define LINUX_I2C_H_
+
+#include <stdint.h>
 
 /**
  * @struct linux_i2c_init_param

--- a/projects/adt7420-pmdz/src/examples/dummy/dummy_example.c
+++ b/projects/adt7420-pmdz/src/examples/dummy/dummy_example.c
@@ -2,8 +2,10 @@
  *   @file   dummy_example.c
  *   @brief  DUMMY example code for adt7420-pmdz project
  *   @author RNechita (ramona.nechita@analog.com)
+ *   @author Jamila Macagba (Jamila.Macagba@analog.com)
+ *   @author Rene Arthur Necesito (Renearthur.Necesito@analog.com)
 ********************************************************************************
- * Copyright 2022(c) Analog Devices, Inc.
+ * Copyright 2022, 2025(c) Analog Devices, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -36,6 +38,14 @@
 #include "no_os_delay.h"
 #include "no_os_print_log.h"
 
+#ifdef LINUX_PLATFORM
+#include <time.h>
+#include <sys/time.h>
+struct timeval tv;
+struct tm *timeinfo;
+char time_string[9];  // hh:mm:ss\0
+#endif  // LINUX_PLATFORM
+
 #define ADT7320_L8		NO_OS_BIT(8)
 #define ADT7320_L16		NO_OS_BIT(16)
 
@@ -62,6 +72,7 @@ int example_main()
 	float temp_now;
 	int ret;
 
+#ifndef LINUX_PLATFORM
 	struct no_os_uart_desc *uart;
 
 	ret = no_os_uart_init(&uart, &uip);
@@ -69,6 +80,7 @@ int example_main()
 		goto error;
 
 	no_os_uart_stdio(uart);
+#endif // LINUX_PLATFORM
 
 	ret = adt7420_init(&adt7420, adt7420_user_init);
 	if (ret)
@@ -130,6 +142,12 @@ int example_main()
 		ret = adt7420_reg_read(adt7420, ADT7420_REG_HIST, &readval);
 		if (ret)
 			goto error_adt7420;
+#ifdef LINUX_PLATFORM
+		gettimeofday(&tv, NULL);
+		timeinfo = localtime(&tv.tv_sec);
+		strftime(time_string, sizeof(time_string), "%H:%M:%S", timeinfo);
+		printf("[%lu.%lu - %s]\n", tv.tv_sec, tv.tv_usec, time_string);
+#endif  // LINUX_PLATFORM
 		printf("The value read from the hist register is %d\n", readval);
 		pr_info("Temp read is %lf\r\n", temp_now);
 		pr_info("Current temp high setpoint is %d\r\n", (int) temp_c_max);

--- a/projects/adt7420-pmdz/src/platform/linux/main.c
+++ b/projects/adt7420-pmdz/src/platform/linux/main.c
@@ -1,10 +1,9 @@
 /***************************************************************************//**
- *   @file   common_data.c
- *   @brief  Defines common data to be used by adt7420-pmdz examples.
- *   @author RNechita (ramona.nechita@analog.com)
+ *   @file   main.c
+ *   @brief  Main file for Linux platform of adt7420-pmdz project.
  *   @author Jamila Macagba (Jamila.Macagba@analog.com)
 ********************************************************************************
- * Copyright 2022, 2025(c) Analog Devices, Inc.
+ * Copyright 2025(c) Analog Devices, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -32,32 +31,17 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 
+#include "parameters.h"
 #include "common_data.h"
 
-#ifndef LINUX_PLATFORM
-struct no_os_uart_init_param uip = {
-	.device_id = UART_DEVICE_ID,
-	.irq_id = UART_IRQ_ID,
-	.asynchronous_rx = true,
-	.baud_rate = UART_BAUDRATE,
-	.size = NO_OS_UART_CS_8,
-	.parity = NO_OS_UART_PAR_NO,
-	.stop = NO_OS_UART_STOP_1_BIT,
-	.platform_ops = UART_OPS,
-	.extra = &xuip,
-};
-#endif // LINUX_PLATFORM
+int example_main();
 
-const struct no_os_i2c_init_param iip = {
-	.device_id = I2C_DEVICE_ID,
-	.max_speed_hz = 100000,
-	.slave_address = 0x48,
-	.extra = NULL,
-	.platform_ops = I2C_OPS,
-	.extra = &adt7420_i2c_extra,
-};
-
-struct adt7420_init_param adt7420_user_init = {
-	.interface_init = iip,
-	.active_device = ID_ADT7420
-};
+/***************************************************************************//**
+ * @brief Main function execution for Linux platform.
+ *
+ * @return ret - Result of the enabled examples execution.
+*******************************************************************************/
+int main()
+{
+	return example_main();
+}

--- a/projects/adt7420-pmdz/src/platform/linux/parameters.c
+++ b/projects/adt7420-pmdz/src/platform/linux/parameters.c
@@ -1,10 +1,9 @@
 /***************************************************************************//**
- *   @file   common_data.c
- *   @brief  Defines common data to be used by adt7420-pmdz examples.
- *   @author RNechita (ramona.nechita@analog.com)
+ *   @file   parameters.c
+ *   @brief  Definition of Linux platform data used by adt7420-pmdz project.
  *   @author Jamila Macagba (Jamila.Macagba@analog.com)
 ********************************************************************************
- * Copyright 2022, 2025(c) Analog Devices, Inc.
+ * Copyright 2025(c) Analog Devices, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -32,32 +31,8 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 
-#include "common_data.h"
+#include "parameters.h"
 
-#ifndef LINUX_PLATFORM
-struct no_os_uart_init_param uip = {
-	.device_id = UART_DEVICE_ID,
-	.irq_id = UART_IRQ_ID,
-	.asynchronous_rx = true,
-	.baud_rate = UART_BAUDRATE,
-	.size = NO_OS_UART_CS_8,
-	.parity = NO_OS_UART_PAR_NO,
-	.stop = NO_OS_UART_STOP_1_BIT,
-	.platform_ops = UART_OPS,
-	.extra = &xuip,
-};
-#endif // LINUX_PLATFORM
-
-const struct no_os_i2c_init_param iip = {
-	.device_id = I2C_DEVICE_ID,
-	.max_speed_hz = 100000,
-	.slave_address = 0x48,
-	.extra = NULL,
-	.platform_ops = I2C_OPS,
-	.extra = &adt7420_i2c_extra,
-};
-
-struct adt7420_init_param adt7420_user_init = {
-	.interface_init = iip,
-	.active_device = ID_ADT7420
+struct linux_i2c_init_param adt7420_i2c_extra = {
+	.device_id = I2C_DEVICE_ID
 };

--- a/projects/adt7420-pmdz/src/platform/linux/parameters.h
+++ b/projects/adt7420-pmdz/src/platform/linux/parameters.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
- *   @file   common_data.c
- *   @brief  Defines common data to be used by adt7420-pmdz examples.
- *   @author RNechita (ramona.nechita@analog.com)
+ *   @file   parameters.h
+ *   @brief  Definitions specific to Linux platform used by adt7420-pmdz
+ *           project.
  *   @author Jamila Macagba (Jamila.Macagba@analog.com)
 ********************************************************************************
- * Copyright 2022, 2025(c) Analog Devices, Inc.
+ * Copyright 2025(c) Analog Devices, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -31,33 +31,15 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
 
-#include "common_data.h"
+#include "linux_i2c.h"
 
-#ifndef LINUX_PLATFORM
-struct no_os_uart_init_param uip = {
-	.device_id = UART_DEVICE_ID,
-	.irq_id = UART_IRQ_ID,
-	.asynchronous_rx = true,
-	.baud_rate = UART_BAUDRATE,
-	.size = NO_OS_UART_CS_8,
-	.parity = NO_OS_UART_PAR_NO,
-	.stop = NO_OS_UART_STOP_1_BIT,
-	.platform_ops = UART_OPS,
-	.extra = &xuip,
-};
-#endif // LINUX_PLATFORM
+#define I2C_DEVICE_ID   1
+#define I2C_EXTRA	&adt7420_i2c_extra
+#define I2C_OPS		&linux_i2c_ops
 
-const struct no_os_i2c_init_param iip = {
-	.device_id = I2C_DEVICE_ID,
-	.max_speed_hz = 100000,
-	.slave_address = 0x48,
-	.extra = NULL,
-	.platform_ops = I2C_OPS,
-	.extra = &adt7420_i2c_extra,
-};
+extern struct linux_i2c_init_param adt7420_i2c_extra;
 
-struct adt7420_init_param adt7420_user_init = {
-	.interface_init = iip,
-	.active_device = ID_ADT7420
-};
+#endif /* __PARAMETERS_H__ */

--- a/projects/adt7420-pmdz/src/platform/linux/platform_src.mk
+++ b/projects/adt7420-pmdz/src/platform/linux/platform_src.mk
@@ -1,0 +1,6 @@
+INCS += $(INCLUDE)/no_os_rtc.h
+
+INCS += $(PLATFORM_DRIVERS)/$(PLATFORM)_i2c.h		\
+
+SRCS += $(PLATFORM_DRIVERS)/$(PLATFORM)_delay.c	\
+	$(PLATFORM_DRIVERS)/$(PLATFORM)_i2c.c		\


### PR DESCRIPTION
## Pull Request Description
Relevant Issue: [2518](https://github.com/analogdevicesinc/no-OS/issues/2518)
- Added ADT7420 Linux platform support
- Re-implementation of Linux I2C read and write APIs for `stop_bit` handling

Tested with the adt7420-pmdz dummy example and an ADT7420 + RPI CM5 (RPI OS) setup.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
