### PR TITLE
tools: scripts: generic.mk : Fix ftd2xx platform check

### DIFF
--- a/tools/scripts/generic.mk
+++ b/tools/scripts/generic.mk
@@ -144,10 +144,6 @@ ifeq 'mbed' '$(PLATFORM)'
 include $(NO-OS)/tools/scripts/mbed.mk
 endif
 
-ifeq 'ftd2xx' '$(PLATFORM)'
-include $(NO-OS)/tools/scripts/ftd2xx.mk
-endif
-
 #------------------------------------------------------------------------------
 #                            COMMON COMPILER FLAGS                             
 #------------------------------------------------------------------------------


### PR DESCRIPTION
## Pull Request Description

Remove if condition in generic.mk that checks for platform being FTD2XX.

Fix : 08cf3ff ("tools: scripts: ftd2xx.mk : Add FTD2XX as library instead of platform")

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
