### PR TITLE
drivers:adc:ad7779: Bug fixes to ad7779_set_dec_rate()

### DIFF
--- a/drivers/adc/ad7779/ad7779.c
+++ b/drivers/adc/ad7779/ad7779.c
@@ -595,7 +595,7 @@ int32_t ad7779_set_dec_rate(ad7779_dev *dev,
 			return -1;
 		}
 		dev->dec_rate_int = int_val;
-		dev->dec_rate_int = dec_val;
+		dev->dec_rate_dec = dec_val;
 		ret = ad7779_do_update_mode_pins(dev);
 	} else {
 		msb = (int_val & 0x0F00) >> 8;
@@ -616,7 +616,7 @@ int32_t ad7779_set_dec_rate(ad7779_dev *dev,
 						AD7779_REG_SRC_IF_LSB,
 						lsb);
 		dev->dec_rate_int = int_val;
-		dev->dec_rate_int = dec_val;
+		dev->dec_rate_dec = dec_val;
 	}
 
 	return ret;


### PR DESCRIPTION
Cached memory update fixed for dec_rate_dec member

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
