### PR TITLE
drivers: adc: ad7091: Fix ADC reset behavior

### DIFF
--- a/drivers/adc/ad7091r5/ad7091r5.c
+++ b/drivers/adc/ad7091r5/ad7091r5.c
@@ -468,12 +468,12 @@ static int32_t ad7091r5_init_gpio(struct ad7091r5_dev *dev,
 	if (ret < 0)
 		return ret;
 
-	ret = no_os_gpio_direction_output(dev->gpio_resetn, NO_OS_GPIO_LOW);
+	ret = no_os_gpio_direction_output(dev->gpio_resetn, NO_OS_GPIO_HIGH);
 	if (ret < 0)
 		return ret;
 
 	/** Reset to configure pins */
-	return ad7091r5_reset(dev, init_param->gpio_resetn);
+	return ad7091r5_reset(dev, false);
 }
 
 /**


### PR DESCRIPTION
During ADC initialization, the reset GPIO is active-low and must remain high after setup. The reset function, invoked from GPIO initialization, must trigger a hardware reset accordingly to ensure correct ADC startup.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
