### PR TITLE
projects: eval-pqmon: Include the OA TC6 files

### DIFF
--- a/projects/eval-pqmon/src.mk
+++ b/projects/eval-pqmon/src.mk
@@ -90,6 +90,9 @@ ifeq ($(INTERFACE), ethernet_t1l)
 		$(DRIVERS)/net/adin1110/adin1110.c					\
 		$(NO-OS)/util/no_os_crc8.c						\
 		$(NO-OS)/network/tcp_socket.c
+
+	INCS += $(DRIVERS)/net/oa_tc6/oa_tc6.h
+	SRCS += $(DRIVERS)/net/oa_tc6/oa_tc6.c
 endif
 
 INCS += $(INCLUDE)/no_os_crc8.h


### PR DESCRIPTION
The eval-pqmon project currently fails to compile because the ADIN1110 driver depends on the oa_tc6 files, which are not included in the build. Fix this by adding them to the source list.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
