### PR TITLE
Fix Readme Links: driver: frequency: adf4030, adf4368, adf4382, adf5611

### DIFF
--- a/drivers/frequency/adf4030/README.rst
+++ b/drivers/frequency/adf4030/README.rst
@@ -4,31 +4,31 @@ ADF4030 no-OS driver
 Supported Devices
 -----------------
 
-`ADF4030 <www.analog.com/en/products/adf4030.html>`_
+`ADF4030 <https://www.analog.com/en/products/adf4030.html>`_
 
 Overview
 --------
 
-The `ADF4030 <www.analog.com/en/products/adf4030.html>`_ provides for 10 bidirectional synchronized clock
+The `ADF4030 <https://www.analog.com/en/products/adf4030.html>`_ provides for 10 bidirectional synchronized clock
 (BSYNC) channels and accepts a reference clock input (REFIN)
 signal as a frequency reference for generating an output clock
 on any BSYNC channels that are configured as an output. The
-hallmark feature of the `ADF4030 <www.analog.com/en/products/adf4030.html>`_ is the ability to time align the clock
+hallmark feature of the `ADF4030 <https://www.analog.com/en/products/adf4030.html>`_ is the ability to time align the clock
 edges of any one or more BSYNC channels to <5 ps (at the device
 pins) with respect to the BSYNC channel selected as the reference
 BSYNC channel.
-The `ADF4030 <www.analog.com/en/products/adf4030.html>`_  is well adapted for multiple connections with other
-`ADF4030 <www.analog.com/en/products/adf4030.html>`_  devices for synchronizing clock signals in a system. Each
+The `ADF4030 <https://www.analog.com/en/products/adf4030.html>`_  is well adapted for multiple connections with other
+`ADF4030 <https://www.analog.com/en/products/adf4030.html>`_  devices for synchronizing clock signals in a system. Each
 BSYNC is bidirectional, allowing for reversing the direction of the
 clock signal to measure the propagation delay of the transmission
 medium. Round trip constructions that use replica paths are also
 supported. The bidirectional nature of the round trip delay measurement greatly reduces the error in determining the propagation delay
 through the BSYNC transmission medium as compared to using
-a replica path. This feature makes the `ADF4030 <www.analog.com/en/products/adf4030.html>`_  capable to time
-align the clock edges of BSYNC channels across multiple `ADF4030 <www.analog.com/en/products/adf4030.html>`_ 
+a replica path. This feature makes the `ADF4030 <https://www.analog.com/en/products/adf4030.html>`_  capable to time
+align the clock edges of BSYNC channels across multiple `ADF4030 <https://www.analog.com/en/products/adf4030.html>`_ 
 devices, independent of the tree or cascade architecture in which
-the `ADF4030 <www.analog.com/en/products/adf4030.html>`_  system is designed. The benefits of bidirectional
-clocking extend to devices other than the `ADF4030 <www.analog.com/en/products/adf4030.html>`_  (assuming
+the `ADF4030 <https://www.analog.com/en/products/adf4030.html>`_  system is designed. The benefits of bidirectional
+clocking extend to devices other than the `ADF4030 <https://www.analog.com/en/products/adf4030.html>`_  (assuming
 those devices support bidirectional clock exchanges).
 
 

--- a/drivers/frequency/adf4368/README.rst
+++ b/drivers/frequency/adf4368/README.rst
@@ -6,20 +6,20 @@ ADF4368 no-OS driver
 Supported Devices
 -----------------
 
-`ADF4368 <www.analog.com/en/products/adf4368.html>`_
+`ADF4368 <https://www.analog.com/en/products/adf4368.html>`_
 
 Overview
 --------
 
 
-The `ADF4368 <www.analog.com/en/products/adf4368.html>`_ is a 
+The `ADF4368 <https://www.analog.com/en/products/adf4368.html>`_ is a 
 high performance, ultra-low jitter, integer-N and
 fractional-N phase-locked loop (PLL) with integrated VCO ideally
 suited for frequency conversion applications.
 The high performance PLL has a figure of merit of -239 dBc/Hz,
 very low 1/f noise of normalized -287 dBc/Hz and high PFD
 frequency that can achieve ultra-low in-band noise and integrated
-jitter. The `ADF4368 <www.analog.com/en/products/adf4368.html>`_ 
+jitter. The `ADF4368 <https://www.analog.com/en/products/adf4368.html>`_ 
 can generate any frequency from 800 MHz to 12.8 GHz without an 
 internal doubler, which eliminates the need for sub-harmonic filters. 
 The Σ-Δ modulator includes a 25-bit fixed modulus that allows 
@@ -31,7 +31,7 @@ useful for any application.
 
 For multiple frequency conversion applications, such as phase
 array radar or massive MIMO systems, the outputs of multiple
-`ADF4368 <www.analog.com/en/products/adf4368.html>`_ can 
+`ADF4368 <https://www.analog.com/en/products/adf4368.html>`_ can 
 be aligned by using the SYNC input or EZSync™. The EZSync method is 
 used when it is difficult to distribute the SYNC signal to all 
 devices precisely. For applications that require deterministic 
@@ -107,7 +107,7 @@ the value in the same range.
 
 In order to determine which value corresponds to your design charge pump
 current, please refer to the datasheet
-`ADF4368 <www.analog.com/en/products/adf4368.html>`_ in the register details
+`ADF4368 <https://www.analog.com/en/products/adf4368.html>`_ in the register details
 section for register REG001F.
 
 Bleed Current Configuration

--- a/drivers/frequency/adf4382/README.rst
+++ b/drivers/frequency/adf4382/README.rst
@@ -6,14 +6,14 @@ ADF4382 no-OS driver
 Supported Devices
 -----------------
 
-* `ADF4382 <www.analog.com/en/products/adf4382.html>`_
-* `ADF4382A <www.analog.com/en/products/adf4382a.html>`_
-* `ADF43823 <www.analog.com/en/products/adf43823.html>`_
+* `ADF4382 <https://www.analog.com/en/products/adf4382.html>`_
+* `ADF4382A <https://www.analog.com/en/products/adf4382a.html>`_
+* `ADF43823 <https://www.analog.com/en/products/adf43823.html>`_
 
 Overview
 --------
 
-The `ADF4382 <www.analog.com/en/products/adf4382.html>`_ is a high performance,
+The `ADF4382 <https://www.analog.com/en/products/adf4382.html>`_ is a high performance,
 ultralow jitter, Frac-N PLL with integrated VCO ideally suited for LO generation
 for 5G applications or data converter clock applications. The high performance
 PLL has a figure of merit of -238 dBc/Hz, low 1/f Noise and high PFD frequency
@@ -23,7 +23,7 @@ integrated jitter. The ADF4382 can generate frequencies from 687.5 MHz to
 sub-harmonic filters.
 
 For multiple data converter clock applications, the
-`ADF4382 <www.analog.com/en/products/adf4382.html>`_ automatically aligns its
+`ADF4382 <https://www.analog.com/en/products/adf4382.html>`_ automatically aligns its
 output to the input reference edge by including the output divider in the PLL
 feedback loop. For applications that require deterministic delay or delay
 adjustment capability, a programmable reference to output delay with <1ps
@@ -96,7 +96,7 @@ the value in the same range.
 
 In order to determine which value corresponds to your design charge pump
 current, please refer to the datasheet
-`ADF4382 <www.analog.com/en/products/adf4382.html>`_ in the register details
+`ADF4382 <https://www.analog.com/en/products/adf4382.html>`_ in the register details
 section for register REG001F.
 
 Bleed Current Configuration

--- a/drivers/frequency/adf5611/README.rst
+++ b/drivers/frequency/adf5611/README.rst
@@ -6,24 +6,24 @@ ADF5611 no-OS driver
 Supported Devices
 -----------------
 
-* `ADF5611 <www.analog.com/en/products/adf5611.html>`_
-* `ADF5612 <www.analog.com/en/products/adf5612.html>`_
+* `ADF5611 <https://www.analog.com/en/products/adf5611.html>`_
+* `ADF5612 <https://www.analog.com/en/products/adf5612.html>`_
 
 Overview
 --------
 
-The `ADF5611 <www.analog.com/en/products/adf5611.html>`_ and `ADF5612 <www.analog.com/en/products/adf5612.html>`_ 
+The `ADF5611 <https://www.analog.com/en/products/adf5611.html>`_ and `ADF5612 <https://www.analog.com/en/products/adf5612.html>`_ 
 allows implementation of fractional-N or Integer N phase-locked loop (PLL) frequency 
 synthesizers when used with an external loop filter and an external reference source. 
 The wideband microwave voltage controlled oscillator (VCO) design permits frequency operation 
-from 7300 MHz to 14600 MHz for `ADF5611 <www.analog.com/en/products/adf5611.html>`_ and from 7300 
-MHz to 8500 MHz for `ADF5612 <www.analog.com/en/products/adf5612.html>`_ at a single radio 
+from 7300 MHz to 14600 MHz for `ADF5611 <https://www.analog.com/en/products/adf5611.html>`_ and from 7300 
+MHz to 8500 MHz for `ADF5612 <https://www.analog.com/en/products/adf5612.html>`_ at a single radio 
 frequency (RF) output. A series of frequency dividers with a differential frequency output 
-allows operation from 57 MHz to 14600MHz for `ADF5611 <www.analog.com/en/products/adf5611.html>`_, 
-while `ADF5612 <www.analog.com/en/products/adf5612.html>`_ is limited to 57MHz to 8500MHz. 
+allows operation from 57 MHz to 14600MHz for `ADF5611 <https://www.analog.com/en/products/adf5611.html>`_, 
+while `ADF5612 <https://www.analog.com/en/products/adf5612.html>`_ is limited to 57MHz to 8500MHz. 
 Analog and digital power supplies for the PLL circuitry range from 3.15 V to 3.45 V, and 
 the VCO supplies are between 4.75 V and 5.25 V.
-Both `ADF5611 <www.analog.com/en/products/adf5611.html>`_ and `ADF5612 <www.analog.com/en/products/adf5612.html>`_ 
+Both `ADF5611 <https://www.analog.com/en/products/adf5611.html>`_ and `ADF5612 <https://www.analog.com/en/products/adf5612.html>`_ 
 has an integrated VCO with a fundamental frequency of 3650 MHz to 7300 MHz. These frequencies 
 are internally doubled and routed to the RFOUT pin. An additional differential output allows 
 the doubled VCO frequency to be divided by 1, 2, 4, 8, 16, 32, 64, or 128, allowing the user 
@@ -91,18 +91,18 @@ configuration can be read out using **adf5611_get_cp_i**, which will also return
 the value in the same range.
 
 In order to determine which value corresponds to your design charge pump
-current, please refer to the datasheet `ADF5611 <www.analog.com/en/products/adf5611.html>`_ 
+current, please refer to the datasheet `ADF5611 <https://www.analog.com/en/products/adf5611.html>`_ 
 in the register details section for register REG0021h.
 
 
 Output Frequency Configuration
 ------------------------------
 
-The `ADF5611 <www.analog.com/en/products/adf5611.html>`_ and `ADF5612 <www.analog.com/en/products/adf5612.html>`_ 
+The `ADF5611 <https://www.analog.com/en/products/adf5611.html>`_ and `ADF5612 <https://www.analog.com/en/products/adf5612.html>`_ 
 each has a main RF output and a differential divider RF output.
 The main RF output range from 7300MHz to 14600MHz, and the differential divided 
-output is between 57MHz to 14600MHz for `ADF5611 <www.analog.com/en/products/adf5611.html>`_,
-while `ADF5612 <www.analog.com/en/products/adf5612.html>`_ has a similar minimum main RF output 
+output is between 57MHz to 14600MHz for `ADF5611 <https://www.analog.com/en/products/adf5611.html>`_,
+while `ADF5612 <https://www.analog.com/en/products/adf5612.html>`_ has a similar minimum main RF output 
 frequency but has maximum main RF output as well as divided output of 8500MHz.
 The main RF output can be reconfigured by using the **adf5611_set_rfout** API. 
 The output frequency set by the API is expressed in Hz. The previously configured output 


### PR DESCRIPTION
Broken Links in the Drivers Readme files fixed.

## Pull Request Description

Updated product page links in the ReadMe file.
Issue link : https://github.com/analogdevicesinc/no-OS/issues/2609

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
