### PR TITLE
drivers: adc: AD9208: fixed readme

### DIFF
--- a/drivers/adc/ad9208/README.rst
+++ b/drivers/adc/ad9208/README.rst
@@ -198,7 +198,7 @@ application requirements.
 Device Initialization Example
 -----------------------------
 
-.. code-block::C
+.. code-block:: C
 
     #include "no_os_spi.h"
     #include "xilinx_spi.h"


### PR DESCRIPTION
Modified AD9208 readme to reflect missing driver init example code.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
