### PR TITLE
stm32.mk: use cubemx embedded java

### DIFF
--- a/tools/scripts/stm32.mk
+++ b/tools/scripts/stm32.mk
@@ -89,7 +89,7 @@ $(PLATFORM)_project:
 	@echo SetStructure Advanced >> $(BINARY).cubemx
 	@echo project generate >> $(BINARY).cubemx
 	@echo exit >> $(BINARY).cubemx
-	java -jar $(STM32CUBEMX)/$(MX) -q $(BINARY).cubemx $(HIDE)
+	$(STM32CUBEMX)/jre/bin/java -jar $(STM32CUBEMX)/$(MX) -q $(BINARY).cubemx $(HIDE)
 	$(call remove_file,$(BINARY).cubemx) $(HIDE)
 	$(MAKE) --no-print-directory $(PROJECT)_configure
 


### PR DESCRIPTION


## Pull Request Description

Starting from CubeMX 6.2.0, Java Runtime Environment is embedded in the CubeMX install directory so we should use that one instead.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
