### PR TITLE
drivers: power: add max22216

### DIFF
--- a/drivers/power/max22216/max22216.c
+++ b/drivers/power/max22216/max22216.c
@@ -1,0 +1,402 @@
+/***************************************************************************//**
+ *   @file   max22216.c
+ *   @brief  Current control
+ *   @author Robert Budai (robert.budai@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "max22216.h"
+
+int max22216_write_reg(struct max22216_desc *desc, uint8_t reg_addr,
+		       uint16_t data)
+{
+	int ret;
+
+	if (!desc || !desc->spi_desc) {
+		return -1;
+	}
+	uint8_t tx[3] = { reg_addr | 0x80, (data >> 8) & 0xFF, data & 0xFF};  // Register address, high byte, low byte
+
+	ret =  no_os_spi_write_and_read(desc->spi_desc, tx, 3);
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
+
+int max22216_read_reg(struct max22216_desc *desc, uint8_t reg_addr,
+		      uint16_t *data)
+{
+	int ret;
+
+	if (!desc || !desc->spi_desc) {
+		return -1;
+	}
+
+	uint8_t tx[3] = { reg_addr, 0x00, 0x00};  // Assuming MSB=1 for read
+	ret = no_os_spi_write_and_read(desc->spi_desc, tx, 3);
+	if (ret) {
+		return ret;
+	}
+	ret = no_os_spi_write_and_read(desc->spi_desc, tx, 3);
+	if (ret) {
+		return ret;
+	}
+	desc->status_reg = tx[0];
+
+	*data = (tx[1] << 8) | tx[2]; // or rx[1], dependtesing on your SPI driver
+
+	return 0;
+}
+
+int max22216_write_reg_list(struct max22216_desc *desc,
+			    max22216_reg_setting_t* list, uint8_t elem_nr)
+{
+	int ret;
+	uint8_t i;
+
+	if (!desc || !desc->spi_desc || !list) {
+		return -1;
+	}
+
+	for (i = 0; i < elem_nr; i++) {
+		ret = max22216_write_reg(desc, list[i].reg_addr, list[i].data);
+		if (ret) {
+			return ret;
+		}
+	}
+	return 0;
+}
+
+int erase_fault_reg(struct max22216_desc *desc)
+{
+	int ret;
+	uint16_t data = 0;
+
+	ret = max22216_write_reg(desc, MAX22216_FAULT1, 0xFFFF);
+	if (ret) {
+		return ret;
+	}
+	ret = max22216_read_reg(desc, MAX22216_FAULT0, &data);
+	if (ret) {
+		return ret;
+	}
+	ret = max22216_read_reg(desc, MAX22216_FAULT1, &data);
+	if (ret) {
+		return ret;
+	}
+
+	return 0;
+}
+
+int max22216_set_enable_pin(struct max22216_desc *desc, bool value)
+{
+	int ret;
+
+	if (!desc || !desc->drv_en_gpio) {
+		return -1;
+	}
+
+	ret = no_os_gpio_set_value(desc->drv_en_gpio,
+				   value ? NO_OS_GPIO_HIGH : NO_OS_GPIO_LOW);
+	if (ret) {
+		return ret;
+	}
+
+	return 0;
+}
+
+int max22216_check_fault_pin(struct max22216_desc *desc, bool *fault_status)
+{
+	int ret;
+	uint8_t value;
+
+	if (!desc || !desc->fault_gpio || !fault_status) {
+		return -1;
+	}
+
+	ret = no_os_gpio_get_value(desc->fault_gpio, &value);
+	if (ret) {
+		return ret;
+	}
+
+	*fault_status = (value == NO_OS_GPIO_LOW); // Assuming LOW indicates a fault
+	return 0;
+}
+
+int max22216_current_reg_control(struct max22216_desc *desc, uint8_t channel_nr,
+				 uint16_t value)
+{
+	int ret;
+	uint16_t test_value;
+	max22216_reg_setting_t reg_setting;
+	// Prepare register settings for current control
+	uint8_t reg_addr = MAX22216_CFG_DC_H_0 + (channel_nr *
+			   MAX22216_CHANNEL_CONFIG_REG_SHIFT);
+
+	if (!desc || !desc->spi_desc) {
+		return -1;
+	}
+
+	if (channel_nr >= MAX22216_NR_OF_CHANNELS) {
+		return -1;
+	}
+
+	// Write the register settings
+	ret = max22216_write_reg(desc, reg_addr, value);
+	if (ret) {
+		return ret;
+	}
+
+	ret = max22216_read_reg(desc, reg_addr, &test_value);
+	if (ret) {
+		return ret;
+	}
+
+	if (test_value != value) {
+		return -1;
+	}
+
+	return 0;
+}
+
+int max22216_turn_on(struct max22216_desc *desc, uint8_t channel_nr)
+{
+	int ret;
+	uint16_t data;
+
+	if (!desc || !desc->spi_desc) {
+		return -1;
+	}
+
+	if (channel_nr >= MAX22216_NR_OF_CHANNELS) {
+		return -1;
+	}
+
+	ret = max22216_read_reg(desc,
+				MAX22216_CFG_IND_0_0 + (channel_nr * MAX22216_CHANNEL_CONFIG_REG_SHIFT), &data);
+	if (ret) {
+		return ret;
+	}
+	ret = max22216_write_reg(desc,
+				 MAX22216_CFG_IND_0_0 + (channel_nr * MAX22216_CHANNEL_CONFIG_REG_SHIFT),
+				 data | 0x0800);
+	if (ret) {
+		return ret;
+	}
+	ret = max22216_read_reg(desc,
+				MAX22216_CFG_IND_0_0 + (channel_nr * MAX22216_CHANNEL_CONFIG_REG_SHIFT), &data);
+	if (ret) {
+		return ret;
+	}
+	if (!(data | 0x0800)) {
+		return -1;
+	}
+
+	ret = max22216_read_reg(desc, MAX22216_GLOBAL_CTRL, &data);
+	if (ret) {
+		return ret;
+	}
+	ret = max22216_write_reg(desc, MAX22216_GLOBAL_CTRL,
+				 data | (0x00C0 | (1 << channel_nr)));
+	if (ret) {
+		return ret;
+	}
+	ret = max22216_read_reg(desc, MAX22216_GLOBAL_CTRL, &data);
+	if (ret) {
+		return ret;
+	}
+	if (!(data | (0x00C0 | (1 << channel_nr)))) {
+		// This indicates that the channel was not successfully turned on
+		return -1;
+	}
+
+	return 0;
+
+}
+
+int max22216_turn_off(struct max22216_desc *desc, uint8_t channel_nr)
+{
+	int ret;
+	uint16_t data;
+
+	if (!desc || !desc->spi_desc) {
+		return -1;
+	}
+
+	if (channel_nr >= MAX22216_NR_OF_CHANNELS) {
+		return -1;
+	}
+
+
+	ret = max22216_read_reg(desc, MAX22216_GLOBAL_CTRL, &data);
+	if (ret) {
+		return ret;
+	}
+	ret = max22216_write_reg(desc, MAX22216_GLOBAL_CTRL,
+				 data & ~(0x00C0 | (1 << channel_nr)));
+	if (ret) {
+		return ret;
+	}
+	ret = max22216_read_reg(desc, MAX22216_GLOBAL_CTRL, &data);
+	if (ret) {
+		return ret;
+	}
+	if (data & ~(0x00C0 | (1 << channel_nr))) {
+		// This indicates that the channel was not successfully turned off
+		return -1;
+	}
+
+
+	ret = max22216_read_reg(desc,
+				MAX22216_CFG_IND_0_0 + (channel_nr * MAX22216_CHANNEL_CONFIG_REG_SHIFT), &data);
+	if (ret) {
+		return ret;
+	}
+	ret = max22216_write_reg(desc,
+				 MAX22216_CFG_IND_0_0 + (channel_nr * MAX22216_CHANNEL_CONFIG_REG_SHIFT),
+				 data & ~0x0800);
+	if (ret) {
+		return ret;
+	}
+	ret = max22216_read_reg(desc,
+				MAX22216_CFG_IND_0_0 + (channel_nr * MAX22216_CHANNEL_CONFIG_REG_SHIFT), &data);
+	if (ret) {
+		return ret;
+	}
+	if (data & ~0x0800) {
+		return -1;
+	}
+
+	return 0;
+}
+
+int max22216_set_current_mA(struct max22216_desc *desc, uint8_t channel_nr,
+			    uint16_t current_mA)
+{
+	int ret;
+	uint16_t read_value;
+	// Convert mA to the appropriate register value
+	uint16_t reg_value = (uint16_t)(current_mA / (MAX22216_K_CDR * MAX22216_GAIN *
+					MAX22216_SNSF));
+
+	if (!desc) {
+		return -1;
+	}
+
+	ret = max22216_current_reg_control(desc, channel_nr, reg_value);
+	if (ret) {
+		return ret;
+	}
+
+	return 0;
+}
+
+int max22216_init(struct max22216_desc **desc,
+		  struct max22216_init_param *param)
+{
+	int ret;
+
+	if (!desc || !param || !param->spi_ip) {
+		return -1;
+	}
+
+	struct max22216_desc *dev = calloc(1, sizeof(*dev));
+
+	if (!dev) {
+		return -1;
+	}
+	struct no_os_gpio_desc *max22216_drv_en_desc = calloc(1,
+			sizeof(*max22216_drv_en_desc));
+	if (!max22216_drv_en_desc) {
+		goto error1;
+	}
+	struct no_os_gpio_desc *max22216_fault_desc = calloc(1,
+			sizeof(*max22216_fault_desc));
+	if (!max22216_fault_desc) {
+		goto error2;
+	}
+	ret = no_os_spi_init(&dev->spi_desc, param->spi_ip);
+	if (ret) {
+		goto error1;
+	}
+	// Setup for enable pin
+	ret = no_os_gpio_get(&max22216_drv_en_desc, param->drv_en_gpio_ip);
+	if (ret) {
+		goto error1;
+	}
+	dev->drv_en_gpio = max22216_drv_en_desc;
+	ret = no_os_gpio_direction_output(max22216_drv_en_desc, NO_OS_GPIO_HIGH);
+	if (ret) {
+		goto error1;
+	}
+	ret = no_os_gpio_set_value(max22216_drv_en_desc, NO_OS_GPIO_HIGH);
+	if (ret) {
+		goto error1;
+	}
+
+	// Setup for fault pin polling
+	ret = no_os_gpio_get(&max22216_fault_desc, param->fault_gpio_ip);
+	if (ret) {
+		goto error1;
+	}
+	dev->fault_gpio = max22216_fault_desc;
+
+	ret = no_os_gpio_direction_input(max22216_fault_desc);
+	if (ret) {
+		goto error1;
+	}
+
+	dev->status_reg = 0;
+	*desc = dev;
+	return 0;
+
+error1:
+	free(max22216_fault_desc);
+error2:
+	free(max22216_drv_en_desc);
+error3:
+	free(dev);
+	return ret;
+}
+
+int max22216_remove(struct max22216_desc *desc)
+{
+	if (!desc)
+		return -1;
+	if (desc->spi_desc)
+		no_os_spi_remove(desc->spi_desc);
+	if (desc->drv_en_gpio)
+		no_os_gpio_remove(desc->drv_en_gpio);
+	if (desc->fault_gpio)
+		no_os_gpio_remove(desc->fault_gpio);
+	free(desc);
+	return 0;
+}

--- a/drivers/power/max22216/max22216.h
+++ b/drivers/power/max22216/max22216.h
@@ -1,0 +1,100 @@
+/***************************************************************************//**
+ *   @file   max22216.h
+ *   @brief  Current control
+ *   @author Robert Budai (robert.budai@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef MAX22216_H
+#define MAX22216_H
+
+#include <stdbool.h>
+#include "no_os_gpio.h"
+#include "no_os_spi.h"
+#include "no_os_alloc.h"
+
+#define MAX22216_NR_OF_CHANNELS         4 // Number of channels supported by MAX22216
+
+#define MAX22216_K_CDR                  1.017
+#define MAX22216_GAIN                   0.25
+#define MAX22216_SNSF                   1
+#define MAX22216_GLOBAL_CTRL            0x00
+#define MAX22216_GLOBAL_CFG             0x01
+#define MAX22216_F_AC                   0x07
+#define MAX22216_U_AC_SCAN              0x08
+#define MAX22216_CFG_DC_L2H_0           0x09
+#define MAX22216_CFG_DC_H_0             0x0A
+#define MAX22216_CFG_L2H_TIME_0         0x0C
+#define MAX22216_CFG_CTRL0_0            0x0D
+#define MAX22216_CFG_CTRL1_0            0x0E
+#define MAX22216_CFG_IND_0_0            0x13
+#define MAX22216_CFG_P_0                0x15
+#define MAX22216_DIAG_CURR_MON_0        0x45 // Diagnostics current monitor register for channel 0
+#define MAX22216_CFG_I_0                0x16
+#define MAX22216_FAULT0                 0x65
+#define MAX22216_FAULT1                 0x66
+
+#define MAX22216_CHANNEL_CONFIG_REG_SHIFT   0x14 // Channel configuration registers start at 0x14
+#define MAX22216_DIAGNOSTICS_REG_SHIFT      0x09
+
+typedef struct {
+	uint8_t reg_addr; // Register address
+	int16_t data; // Data to write
+} max22216_reg_setting_t;
+
+struct max22216_init_param {
+	struct no_os_spi_init_param *spi_ip;
+	struct no_os_gpio_init_param *drv_en_gpio_ip; // GPIO for driver enable
+	struct no_os_gpio_init_param *fault_gpio_ip; // GPIO for fault indication
+};
+
+struct max22216_desc {
+	struct no_os_spi_desc *spi_desc;
+	struct no_os_gpio_desc *drv_en_gpio; // GPIO for driver enable
+	struct no_os_gpio_desc *fault_gpio; // GPIO for fault indication
+	uint16_t status_reg; // Status register value
+};
+
+int max22216_init(struct max22216_desc **desc,
+		  struct max22216_init_param *param);
+int max22216_remove(struct max22216_desc *desc);
+int max22216_write_reg(struct max22216_desc *desc, uint8_t, uint16_t);
+int max22216_read_reg(struct max22216_desc *desc, uint8_t, uint16_t*);
+int max22216_write_reg_list(struct max22216_desc *desc,
+			    max22216_reg_setting_t* list, uint8_t elem_nr);
+int max22216_set_enable_pin(struct max22216_desc *desc, bool value);
+int max22216_check_fault_pin(struct max22216_desc *desc, bool *fault_status);
+int max22216_current_reg_control(struct max22216_desc *desc, uint8_t channel_nr,
+				 uint16_t value);
+int max22216_set_current_mA(struct max22216_desc *desc, uint8_t channel_nr,
+			    uint16_t current_mA);
+int max22216_turn_on(struct max22216_desc *desc, uint8_t channel_nr);
+int max22216_turn_off(struct max22216_desc *desc, uint8_t channel_nr);
+
+#endif // MAX22216_H


### PR DESCRIPTION
The MAX22216 integrate four programmable 36V half-bridges. It is primarily intended to drive inductive loads such as on-off solenoid valves, DC motors, proportional valves, bi-stable valves, relays, etc.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
