### PR TITLE
doc: sphinx: Fix warning formatting, add name no-os-doxygen directive

### DIFF
--- a/doc/sphinx/ext/ext_no_os.py
+++ b/doc/sphinx/ext/ext_no_os.py
@@ -30,7 +30,7 @@ def manage_no_os_doxygen_links(env):
 
     def get_exclusions(file):
         if not path.isfile(file):
-            logger.warning(f"'{file}' does not exist!")
+            logger.warning(f"no-os-doxygen: '{file}' does not exist!")
             return
 
         ctime = path.getctime(file)
@@ -56,7 +56,7 @@ def manage_no_os_doxygen_links(env):
         file = path.join(doxypath, f"{p}_page.html")
         if not path.isfile(file):
             if dxy[p]['warn']:
-                logger.warning(f"'{file}' does not exist!")
+                logger.warning(f"no-os-doxygen: '{file}' does not exist!")
                 dxy[p]['warn'] = False
             continue
 
@@ -75,7 +75,8 @@ def manage_no_os_doxygen_links(env):
                 if prev.tag == "h1":
                     title = ''.join(prev.itertext()).strip().lower()
                 else:
-                    logger.warning(f"List in '{file}' missing title h1.")
+                    logger.warning(f"no-os-doxygen: List in '{file}'"
+                                   " missing title h1.")
                     continue
 
                 links = le.xpath("./li/a")
@@ -84,8 +85,8 @@ def manage_no_os_doxygen_links(env):
                 dxy[p]['list'][title] = dict(links_)
         else:
             if len(link_elements) != 1:
-                logger.warning(f"number of lists for '{p}' is 1, "
-                               f"got {len(link_elements)}.")
+                logger.warning(f"no-os-doxygen: number of lists for '{p}'"
+                               f" is 1, got {len(link_elements)}.")
                 continue
 
             links = link_elements[0].xpath("./li/a")
@@ -136,8 +137,8 @@ class directive_no_os_doxygen(Directive):
             lf = [k, *lk]
 
         if lf[0] not in env.no_os_doxygen:
-            logger.warning(f"Entry '{lf[0]}' from doc '{env.docname}' "
-                           "doesn't exist.")
+            logger.warning(f"no-os-doxygen: Entry '{lf[0]}' from doc"
+                           " '{env.docname}' doesn't exist.")
             return []
 
         if env.no_os_doxygen[lf[0]]['list'] is None:
@@ -145,15 +146,15 @@ class directive_no_os_doxygen(Directive):
 
         if lf[1] not in env.no_os_doxygen[lf[0]]['list']:
             if lf[1] not in env.no_os_doxygen[lf[0]]['exclude']:
-                logger.warning(f"Entry '{lf[1]}' doesn't exist in "
-                               "'{lf[0]}'")
+                logger.warning(f"no-os-doxygen: Entry '{lf[1]}' doesn't exist"
+                               f" in '{lf[0]}'")
             return []
 
         elif (len(lf) == 3 and
               lf[2] not in env.no_os_doxygen[lf[0]]['list'][lf[1]]):
             if lf[2] not in env.no_os_doxygen[lf[0]]['exclude']:
-                logger.warning(f"Entry '{lf[2]}' doesn't exist in "
-                               f"'{lf[0]}/{lf[1]}'")
+                logger.warning(f"no-os-doxygen: Entry '{lf[2]}' doesn't exist"
+                               f" in '{lf[0]}/{lf[1]}'")
             return []
 
         if lf[0] == "drivers":


### PR DESCRIPTION


## Pull Request Description

Prefix warnings with no-os-doxygen, to make it clear the source of the warning.
```
reading sources... [100%] projects_doc
WARNING: no-os-doxygen: Entry 'ad405x' doesn't exist in 'drivers/adc'
WARNING: no-os-doxygen: Entry 'ad5293' doesn't exist in 'drivers/potentiometer'
WARNING: no-os-doxygen: Entry 'ad7768' doesn't exist in 'drivers/adc'
WARNING: no-os-doxygen: Entry 'ad7768-1' doesn't exist in 'drivers/adc'
WARNING: no-os-doxygen: Entry 'ad796x' doesn't exist in 'drivers/adc'
....
```

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
