### PR TITLE
drivers:stm32:irq: Add DMA Half transfer interrupt complete

### DIFF
--- a/drivers/platform/stm32/stm32_irq.c
+++ b/drivers/platform/stm32/stm32_irq.c
@@ -425,6 +425,14 @@ int stm32_irq_register_callback(struct no_os_irq_ctrl_desc *desc,
 
 			break;
 
+		case HAL_DMA_XFER_HALFCPLT_CB_ID:
+			pDmaCallback.XferHalfCpltCallback = _DMA_HalfCpltCallback;
+			ret = HAL_DMA_RegisterCallback(cb->handle, hal_event,
+						       pDmaCallback.XferHalfCpltCallback);
+			if (ret != HAL_OK)
+				return -EFAULT;
+			break;
+
 		default:
 			return -EINVAL;
 		};


### PR DESCRIPTION
Added support for DMA half transfer interrupt complete for DMA IRQ.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [X] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
