### PR TITLE
projects: ad9081: fix bug in app_clock

### DIFF
--- a/projects/ad9081/src/app_clock.c
+++ b/projects/ad9081/src/app_clock.c
@@ -332,7 +332,7 @@ int32_t app_clock_init(struct no_os_clk dev_refclk[MULTIDEVICE_INSTANCE_COUNT])
 
 		adf4371_hw[i].dev = adf4371_dev[i];
 		adf4371_hw[i].dev_clk_recalc_rate = adf4371_clk_recalc_rate_chan;
-		adf4371_hw[i].dev_clk_round_rate = adf4371_clk_round_rate_chan;
+		adf4371_hw[i].dev_clk_round_rate = adf4371_clk_round_rate_dev;
 		adf4371_hw[i].dev_clk_set_rate = adf4371_clk_set_rate_chan;
 
 		dev_refclk[i].hw = &adf4371_hw[i];


### PR DESCRIPTION
## Pull Request Description

The name of the round rate function changed
and it wasn't updated in app_clock. Fixed naming issue.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
