### PR TITLE
drivers: adc: ad7490 : Add support for AD7490

### DIFF
--- a/doc/sphinx/source/drivers/ad7490.rst
+++ b/doc/sphinx/source/drivers/ad7490.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../drivers/adc/ad7490/README.rst

--- a/doc/sphinx/source/drivers_doc.rst
+++ b/doc/sphinx/source/drivers_doc.rst
@@ -20,6 +20,8 @@ ANALOG TO DIGITAL CONVERTERS
 
    drivers/ad405x
 
+   drivers/ad7490
+
    drivers/ad7768
 
    drivers/ad7768-1

--- a/doc/sphinx/source/projects/eval-ad7490sdz.rst
+++ b/doc/sphinx/source/projects/eval-ad7490sdz.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../projects/eval-ad7490sdz/README.rst

--- a/doc/sphinx/source/projects_doc.rst
+++ b/doc/sphinx/source/projects_doc.rst
@@ -29,6 +29,8 @@ ANALOG TO DIGITAL CONVERTERS
 
    projects/ad9208
 
+   projects/eval-ad7490sdz
+
 ADC / DAC
 ==========
 .. toctree::

--- a/drivers/adc/ad7490/README.rst
+++ b/drivers/adc/ad7490/README.rst
@@ -1,0 +1,214 @@
+AD7490 no-OS driver
+===================
+
+.. no-os-doxygen::
+
+Supported Devices
+-----------------
+
+`AD7490 <https://www.analog.com/AD7490>`_
+
+Overview
+--------
+
+The AD7490 is a 12-bit high speed, low power, 16-channel,
+successive approximation ADC. The part operates from a single
+2.7 V to 5.25 V power supply and features throughput rates up
+to 1 MSPS. The part contains a low noise, wide bandwidth
+track-and-hold amplifier that can handle input frequencies in
+excess of 1 MHz.
+
+Applications
+------------
+
+* Multichannel system monitoring
+* Battery-powered equipment
+* Power line monitoring
+* Data acquisition, instrumentation, and process control
+
+AD7490 Device Configuration
+---------------------------
+
+Driver Initialization
+---------------------
+
+In order to be able to use the device, you will have to provide the support for
+the communication protocol (SPI).
+
+The first API to be called is *ad7490_init*. Make sure that it returns 0,
+which means that the driver was initialized correctly.
+
+Operation Mode Configuration
+----------------------------
+
+AD7490 has a total of 4 operation modes:
+
+* Normal Mode
+* Full Shutdown Mode
+* Auto Shutdown Mode
+* Auto Standby Mode
+
+By using the *ad7490_set_op_mode* API, one can configure the AD7490 to
+work using the requested operation mode.
+
+General Configuration
+---------------------
+
+Other configurations such as range can be either REFIN (2.5V) or double 
+the REFIN (5V), and coding wich can be either twos complement or binary can
+be configured by using *ad7490_config* API. Also the state of the DOUT pin
+is also controlled using the same API.
+
+AD7490 Device Measurements
+--------------------------
+
+Single Channel Readings
+-----------------------
+
+By using the *ad7490_read_ch* API, a single channel can be read, and the
+output value is the raw value of the channel.
+
+Multiple Channel Readings
+-------------------------
+
+Multiple channels can be read at once by using the sequencer, which can be
+started by using the *ad7490_start_seq* API, where either a shadow, control
+or consecutive type of sequencer cand be configured. (Please refer to the
+datasheet for each type of sequencer).
+
+More to this, the type of sequencer can be changed without stopping the sequence
+by using *ad7490_change_seq* API, or stopped by using the *ad7490_stop_seq*.
+API.
+
+After starting the sequencer, in order to read the channel values, one should
+use the *ad7490_read_seq* API which handles all the required operations
+related to the sequencer and returning all requested channel values
+in their ascending index order.
+
+AD7490 Driver Initialization Example
+------------------------------------
+
+.. code-block:: bash
+
+	struct ad7490_desc *ad7490;
+	struct ad7490_init_param ad7490_ip = {
+		.spi_param =  {
+			.device_id = 4,
+			.max_speed_hz = 100000,
+			.mode = NO_OS_SPI_MODE_2,
+			.chip_select = 0,
+			.platform_ops = &max_spi_ops,
+			.extra = &max_spi_extra,
+		},
+		.op_mode = AD7490_MODE_NORMAL,
+		.vdd = AD7490_VDD_5V,
+	};
+	int ret, i;
+	int16_t val;
+
+	ret = ad7490_init(&ad7490, &ad7490_ip);
+	if (ret)
+		goto error;
+
+AD7490 no-OS IIO Support
+------------------------
+
+The AD7490 IIO driver comes on top of AD7490 driver and offers support for
+interfacing IIO clients through IIO lib.
+
+IIO AD7490 Device Configuration
+-------------------------------
+
+Device Attributes
+-----------------
+
+AD7490 IIO device has a total of 2 device attributes:
+
+* range - The range can be selected as REFIN (2.5V) or 2x REFIN (5V)
+* polarity - The polarity can be selected as UNIPOLAR or BIPOLAR.
+* sampling_frequency - The sampling frequency for AD7490 (1MSPS).
+
+Device Channels
+---------------
+
+AD7490 IIO device has 16 input channels : 16 voltage channels.
+
+The voltage channels are :
+
+* Channel 0: Voltage
+* Channel 1: Voltage
+* Channel 2: Voltage
+* Channel 3: Voltage
+* Channel 4: Voltage
+* Channel 5: Voltage
+* Channel 6: Voltage
+* Channel 7: Voltage
+* Channel 8: Voltage
+* Channel 9: Voltage
+* Channel 10: Voltage
+* Channel 11: Voltage
+* Channel 12: Voltage
+* Channel 13: Voltage
+* Channel 14: Voltage
+* Channel 15: Voltage
+
+Each voltage channel has 2 attributes:
+
+* raw - the raw voltage value read from the device.
+* scale - is the scale that has to be applied to the raw value in order to obtain the converted real value in Volts. It depends on the selected range and has a specific formula.
+
+In order to obtain the value in the V units, raw has to be scaled by scale:
+
+.. code-block:: bash
+
+	converted_voltage [V] = raw * scale
+	converted_voltage [V] = raw * (range/4096)
+
+Device buffers
+--------------
+
+The AD7490 IIO devices driver supports the usage of a data buffer for reading purposes.
+
+AD7490 IIO Driver Initialization Example
+----------------------------------------
+
+.. code-block:: bash
+
+	#define DATA_BUFFER_SIZE 400
+	uint8_t iio_data_buffer[DATA_BUFFER_SIZE * 16 * sizeof(int16_t)];
+	struct ad7490_iio_desc *ad7490_iio_desc;
+	struct ad7490_iio_init_param ad7490_iio_ip;
+	struct iio_app_desc *app;
+	struct iio_data_buffer voltage_buff = {
+		.buff = (void *)iio_data_buffer,
+		.size = DATA_BUFFER_SIZE * 16 * sizeof(int16_t)
+	};
+	struct iio_app_init_param app_init_param = {0};
+	int ret;
+
+	ad7490_iio_ip.ad7490_init = &ad7490_ip;
+	ad7490_iio_ip.dout_state = AD7490_DOUT_TRISTATE;
+	ad7490_iio_ip.range = AD7490_RANGE_REFIN;
+	ad7490_iio_ip.coding = AD7490_CODING_BINARY;
+	ret = ad7490_iio_init(&ad7490_iio_desc, &ad7490_iio_ip);
+	if (ret)
+		return ret;
+
+	struct iio_app_device iio_devices[] = {
+		{
+			.name = "ad7490",
+			.dev = ad7490_iio_desc,
+			.dev_descriptor = ad7490_iio_desc->iio_dev,
+			.read_buff = &voltage_buff,
+		},
+	};
+
+	app_init_param.devices = iio_devices;
+	app_init_param.nb_devices = NO_OS_ARRAY_SIZE(iio_devices);
+	app_init_param.uart_init_params = uart_ip;
+
+	ret = iio_app_init(&app, app_init_param);
+	if (ret)
+		return ret;
+
+	return iio_app_run(app);

--- a/drivers/adc/ad7490/ad7490.c
+++ b/drivers/adc/ad7490/ad7490.c
@@ -1,0 +1,484 @@
+/***************************************************************************//**
+ *   @file   ad7490.c
+ *   @brief  Source file of AD7490 Driver.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#include "ad7490.h"
+#include "no_os_alloc.h"
+#include "no_os_error.h"
+#include "no_os_delay.h"
+
+#define AD7490_DUMMY_TRANSFER		0xFFFF
+
+/**
+ * @brief AD7490 SPI transfer function
+ * @param desc - AD7490 device descriptor
+ * @param data - Data to be transferred.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+static int ad7490_transfer(struct ad7490_desc *desc, uint16_t *data)
+{
+	struct no_os_spi_msg xfer = {
+		.bytes_number = 2,
+		.cs_delay_first = 1,
+		.cs_delay_last = 1,
+		.cs_change = 1,
+	};
+	uint8_t tx_buff[2];
+	uint8_t rx_buff[2];
+	uint16_t reg_val;
+	int ret;
+
+	reg_val = *data;
+	tx_buff[0] = no_os_field_get(AD7490_HIGH_BYTE_MASK, reg_val);
+	tx_buff[1] = no_os_field_get(AD7490_LOW_BYTE_MASK, reg_val);
+	xfer.rx_buff = rx_buff;
+	xfer.tx_buff = tx_buff;
+
+	ret = no_os_spi_transfer(desc->spi_desc, &xfer, 1);
+	if (ret)
+		return ret;
+
+	*data = no_os_field_prep(AD7490_HIGH_BYTE_MASK, rx_buff[0]) | rx_buff[1];
+
+	return 0;
+}
+
+/**
+ * @brief Set AD7490 operating mode.
+ * @param desc - AD7490 device descriptor
+ * @param op_mode - Selected operating mode.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad7490_set_op_mode(struct ad7490_desc *desc, enum ad7490_op_mode op_mode)
+{
+	uint16_t reg_val;
+	int ret;
+
+	reg_val = no_os_field_prep(AD7490_WRITE_MASK, 1)
+		  | no_os_field_prep(AD7490_ADD_MASK, 0)
+		  | no_os_field_prep(AD7490_PM_MASK, op_mode)
+		  | no_os_field_prep(AD7490_CFG_MASK, desc->cfg);
+
+	reg_val <<= 4;
+	ret = ad7490_transfer(desc, &reg_val);
+	if (ret)
+		return ret;
+
+	switch (op_mode) {
+	case AD7490_MODE_AUTOSTANDBY:
+		reg_val = 0xFFFF;
+		ret = ad7490_transfer(desc, &reg_val);
+		if (ret)
+			return ret;
+
+		break;
+	case AD7490_MODE_AUTOSHUTDOWN:
+		no_os_udelay(1);
+
+		break;
+	case AD7490_MODE_FULLSHUTDOWN:
+		break;
+	case AD7490_MODE_NORMAL:
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	desc->op_mode = op_mode;
+
+	return 0;
+}
+
+/**
+ * @brief Config DOUT state, range and coding of the AD7490.
+ * @param desc - AD7490 device descriptor.
+ * @param dout_state - Selected DOUT state.
+ * @param range - Selected range (REFIN or 2xREFIN)
+ * @param coding - Selected coding style (binary or twos)
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad7490_config(struct ad7490_desc *desc, enum ad7490_dout_state dout_state,
+		  enum ad7490_range range, enum ad7490_coding coding)
+{
+	uint16_t reg_val;
+	uint16_t cfg;
+	int ret;
+
+	if (range == AD7490_RANGE_2XREFIN && desc->vdd == AD7490_VDD_3V3)
+		return -EINVAL;
+
+	cfg = no_os_field_prep(AD7490_WEAKTRI_MASK, dout_state)
+	      | no_os_field_prep(AD7490_RANGE_MASK, range)
+	      | no_os_field_prep(AD7490_CODING_MASK, coding);
+
+	reg_val = no_os_field_prep(AD7490_WRITE_MASK, 1)
+		  | no_os_field_prep(AD7490_ADD_MASK, 0)
+		  | no_os_field_prep(AD7490_PM_MASK, desc->op_mode)
+		  | no_os_field_prep(AD7490_CFG_MASK, desc->cfg);
+
+	reg_val <<= 4;
+	ret = ad7490_transfer(desc, &reg_val);
+	if (ret)
+		return ret;
+
+	desc->cfg = cfg;
+
+	return 0;
+}
+
+/**
+ * @brief Read single cannel raw value.
+ * @param desc - AD7490 device descriptor.
+ * @param channel - Selected channel for value reading.
+ * @param val - Pointer to the selected channel's raw value.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad7490_read_ch(struct ad7490_desc *desc, enum ad7490_address channel,
+		   int16_t *val)
+{
+	uint16_t reg_val;
+	uint16_t tmp;
+	int ret;
+
+	if (desc->seq_op != AD7490_NO_SEQ)
+		return -EINVAL;
+
+	reg_val = no_os_field_prep(AD7490_WRITE_MASK, 1)
+		  | no_os_field_prep(AD7490_SEQ_MASK, 0)
+		  | no_os_field_prep(AD7490_ADD_MASK, channel)
+		  | no_os_field_prep(AD7490_PM_MASK, desc->op_mode)
+		  | no_os_field_prep(AD7490_SHADOW_MASK, 0)
+		  | no_os_field_prep(AD7490_CFG_MASK, desc->cfg);
+
+	tmp = reg_val << 4;
+	reg_val <<= 4;
+	ret = ad7490_transfer(desc, &reg_val);
+	if (ret)
+		return ret;
+
+	ret = ad7490_transfer(desc, &tmp);
+	if (ret)
+		return ret;
+
+	desc->address = channel;
+	tmp = no_os_field_get(AD7490_VAL_MASK, tmp);
+	if (no_os_field_get(AD7490_CODING_MASK, desc->cfg) == AD7490_CODING_TWOS)
+		*val = no_os_sign_extend16(tmp, 11);
+	else
+		*val = tmp;
+
+	return 0;
+}
+
+/**
+ * @brief Start AD7490 SEQUENCER using desired type.
+ * @param desc - AD7490 device descriptor.
+ * @param seq_op - Selected SEQUENCER type.
+ * @param channels - 16 bit channel mask for channel selection (1 = ON, 0 = OFF)
+ * @param last_chan - In case CONSECUTIVE sequencer typee is selected,
+ * 		      last channel is needed for conversion and all channels
+ * 		      until the last one will be then selected.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad7490_start_seq(struct ad7490_desc *desc, enum ad7490_seq_op seq_op,
+		     uint16_t channels, enum ad7490_address last_chan)
+{
+	uint16_t reg_val, tmp;
+	uint8_t msb, lsb;
+	int ret, i, k;
+
+	k = 0;
+	for (i = 0; i < 16; i++) {
+		if (no_os_field_get(NO_OS_BIT(i), channels))
+			k++;
+	}
+
+	if (!k)
+		return -EINVAL;
+
+	desc->nb_channels_seq = k;
+
+	switch (seq_op) {
+	case AD7490_NO_SEQ:
+		return -EINVAL;
+	case AD7490_SHADOW_SEQ:
+	case AD7490_CONTROL_SEQ:
+		reg_val = no_os_field_prep(AD7490_WRITE_MASK, 1)
+			  | no_os_field_prep(AD7490_SEQ_MASK, no_os_field_get(NO_OS_BIT(1), seq_op))
+			  | no_os_field_prep(AD7490_ADD_MASK, desc->address)
+			  | no_os_field_prep(AD7490_PM_MASK, desc->op_mode)
+			  | no_os_field_prep(AD7490_SHADOW_MASK, 1)
+			  | no_os_field_prep(AD7490_CFG_MASK, desc->cfg);
+
+		reg_val <<= 4;
+		tmp = reg_val;
+		ret = ad7490_transfer(desc, &reg_val);
+		if (ret)
+			return ret;
+
+		msb = no_os_field_get(AD7490_HIGH_BYTE_MASK, channels);
+		lsb = no_os_field_get(AD7490_LOW_BYTE_MASK, channels);
+		reg_val = no_os_bit_swap_constant_8(msb);
+		reg_val |= no_os_field_prep(AD7490_HIGH_BYTE_MASK,
+					    no_os_bit_swap_constant_8(lsb));
+		ret = ad7490_transfer(desc, &reg_val);
+		if (ret)
+			return ret;
+
+		break;
+	case AD7490_CONSECUTIVE_SEQ:
+		reg_val = no_os_field_prep(AD7490_WRITE_MASK, 1)
+			  | no_os_field_prep(AD7490_SEQ_MASK, no_os_field_get(NO_OS_BIT(1), seq_op))
+			  | no_os_field_prep(AD7490_ADD_MASK, last_chan)
+			  | no_os_field_prep(AD7490_PM_MASK, desc->op_mode)
+			  | no_os_field_prep(AD7490_SHADOW_MASK, 1)
+			  | no_os_field_prep(AD7490_CFG_MASK, desc->cfg);
+
+		reg_val <<= 4;
+		ret = ad7490_transfer(desc, &reg_val);
+		if (ret)
+			return ret;
+
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	desc->seq_op = seq_op;
+
+	return 0;
+}
+
+/**
+ * @brief Change AD7490 SEQUENCER type while it is active.
+ * @param desc - AD7490 device descriptor.
+ * @param seq_op - Selected SEQUENCER type to change to.
+ * @param coding - If CONTROL sequencer is selected, coding is requested.
+ * @param range -If CONTROL sequencer is selected, range is requested.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad7490_change_seq(struct ad7490_desc *desc, enum ad7490_seq_op seq_op,
+		      enum ad7490_coding coding, enum ad7490_range range)
+{
+	uint16_t reg_val;
+	int ret;
+
+	switch (seq_op) {
+	case AD7490_NO_SEQ:
+		return -EINVAL;
+	case AD7490_SHADOW_SEQ:
+		reg_val = no_os_field_prep(AD7490_WRITE_MASK, 0)
+			  | no_os_field_prep(AD7490_SEQ_MASK, no_os_field_get(NO_OS_BIT(1), seq_op))
+			  | no_os_field_prep(AD7490_ADD_MASK, desc->address)
+			  | no_os_field_prep(AD7490_PM_MASK, desc->op_mode)
+			  | no_os_field_prep(AD7490_SHADOW_MASK, no_os_field_get(NO_OS_BIT(0), seq_op))
+			  | no_os_field_prep(AD7490_CFG_MASK, desc->cfg);
+
+		break;
+	case AD7490_CONTROL_SEQ:
+		reg_val = no_os_field_prep(AD7490_WRITE_MASK, 1)
+			  | no_os_field_prep(AD7490_SEQ_MASK, 1)
+			  | no_os_field_prep(AD7490_ADD_MASK, desc->address)
+			  | no_os_field_prep(AD7490_PM_MASK, desc->op_mode)
+			  | no_os_field_prep(AD7490_SHADOW_MASK, 0)
+			  | no_os_field_prep(AD7490_CFG_MASK, desc->cfg);
+
+		break;
+	case AD7490_CONSECUTIVE_SEQ:
+		return -EINVAL;
+	default:
+		return -EINVAL;
+	}
+
+	reg_val <<= 4;
+	ret = ad7490_transfer(desc, &reg_val);
+	if (ret)
+		return ret;
+
+	desc->seq_op = seq_op;
+
+	return 0;
+}
+
+/**
+ * @brief Stop AD7490 SEQUENCER.
+ * @param desc - AD7490 device descriptor.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad7490_stop_seq(struct ad7490_desc *desc)
+{
+	uint16_t reg_val;
+	int ret;
+
+	reg_val = no_os_field_prep(AD7490_WRITE_MASK, 1)
+		  | no_os_field_prep(AD7490_SEQ_MASK, 0)
+		  | no_os_field_prep(AD7490_ADD_MASK, desc->address)
+		  | no_os_field_prep(AD7490_PM_MASK, desc->op_mode)
+		  | no_os_field_prep(AD7490_SHADOW_MASK, 0)
+		  | no_os_field_prep(AD7490_CFG_MASK, desc->cfg);
+
+	reg_val <<= 4;
+	ret = ad7490_transfer(desc, &reg_val);
+	if (ret)
+		return ret;
+
+	desc->seq_op = AD7490_NO_SEQ;
+
+	return 0;
+}
+
+/**
+ * @brief Read selected channels of the SEQUENCER raw values.
+ * @param desc - AD7490 device descriptor.
+ * @param channels_val - Pointer to selected channels raw values array.
+ * 			 Raw channels values are to be transmitted consecutive
+ * 		         (e.g. if channels 0, 3, and 7 are selected,
+ * 			  channels_val becomes an array with 3 elements, and
+ * 		          index 0 is for channel 0, index 1 for channel 3,
+ * 			  and index 2 for channel 7).
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad7490_read_seq(struct ad7490_desc *desc, int16_t *channels_val)
+{
+	uint16_t reg_val;
+	uint16_t tmp;
+	int ret, i;
+
+	switch (desc->seq_op) {
+	case AD7490_NO_SEQ:
+		return -EINVAL;
+	case AD7490_SHADOW_SEQ:
+		reg_val = no_os_field_prep(AD7490_WRITE_MASK, 0)
+			  | no_os_field_prep(AD7490_SEQ_MASK, no_os_field_get(NO_OS_BIT(1), desc->seq_op))
+			  | no_os_field_prep(AD7490_ADD_MASK, desc->address)
+			  | no_os_field_prep(AD7490_PM_MASK, desc->op_mode)
+			  | no_os_field_prep(AD7490_SHADOW_MASK, no_os_field_get(NO_OS_BIT(0),
+					     desc->seq_op))
+			  | no_os_field_prep(AD7490_CFG_MASK, desc->cfg);
+
+		break;
+	case AD7490_CONTROL_SEQ:
+		reg_val = no_os_field_prep(AD7490_WRITE_MASK, 1)
+			  | no_os_field_prep(AD7490_SEQ_MASK, 1)
+			  | no_os_field_prep(AD7490_ADD_MASK, desc->address)
+			  | no_os_field_prep(AD7490_PM_MASK, desc->op_mode)
+			  | no_os_field_prep(AD7490_SHADOW_MASK, 0)
+			  | no_os_field_prep(AD7490_CFG_MASK, desc->cfg);
+
+		break;
+	case AD7490_CONSECUTIVE_SEQ:
+		return -EINVAL;
+	default:
+		return -EINVAL;
+	}
+
+	reg_val <<= 4;
+	tmp = reg_val;
+
+	for (i = 0; i < desc->nb_channels_seq; i++) {
+		reg_val = tmp;
+
+		ret = ad7490_transfer(desc, &reg_val);
+		if (ret)
+			return ret;
+
+		channels_val[i] = no_os_field_get(AD7490_VAL_MASK, reg_val);
+		if (no_os_field_get(AD7490_CODING_MASK, desc->cfg) == AD7490_CODING_TWOS)
+			channels_val[i] = no_os_sign_extend16(channels_val[i], 11);
+	}
+
+	return 0;
+}
+
+/**
+ * @brief AD7490 Initialization function.
+ * @param desc - AD7490 device descriptor.
+ * @param init_param - AD7490 initialization parameter.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad7490_init(struct ad7490_desc **desc,
+		struct ad7490_init_param *init_param)
+{
+	struct ad7490_desc *descriptor;
+	uint16_t reg_val;
+	int ret;
+
+	descriptor = (struct ad7490_desc *)no_os_calloc(1, sizeof(*descriptor));
+	if (!descriptor)
+		return -ENOMEM;
+
+	ret = no_os_spi_init(&descriptor->spi_desc, init_param->spi_param);
+	if (ret)
+		goto free_desc;
+
+	reg_val = AD7490_DUMMY_TRANSFER;
+	ret = ad7490_transfer(descriptor, &reg_val);
+	if (ret)
+		goto free_spi;
+
+	reg_val = AD7490_DUMMY_TRANSFER;
+	ret = ad7490_transfer(descriptor, &reg_val);
+	if (ret)
+		goto free_spi;
+
+	descriptor->cfg = no_os_field_prep(AD7490_RANGE_MASK, AD7490_RANGE_REFIN);
+	ret = ad7490_set_op_mode(descriptor, init_param->op_mode);
+	if (ret)
+		goto free_spi;
+
+	descriptor->vdd = init_param->vdd;
+
+	*desc = descriptor;
+
+	return 0;
+
+free_spi:
+	no_os_spi_remove(descriptor->spi_desc);
+free_desc:
+	no_os_free(descriptor);
+
+	return ret;
+}
+
+/**
+ * @brief Free the resources allocated by initialization
+ * @param desc - AD7490 device descriptor.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int ad7490_remove(struct ad7490_desc *desc)
+{
+	ad7490_stop_seq(desc);
+	ad7490_set_op_mode(desc, AD7490_MODE_FULLSHUTDOWN);
+	no_os_spi_remove(desc->spi_desc);
+	no_os_free(desc);
+
+	return 0;
+}

--- a/drivers/adc/ad7490/ad7490.h
+++ b/drivers/adc/ad7490/ad7490.h
@@ -1,0 +1,159 @@
+/***************************************************************************//**
+ *   @file   ad7490.h
+ *   @brief  Header file of AD7490 Driver.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef AD7490_H_
+#define AD7490_H_
+
+#include <stdlib.h>
+#include "no_os_spi.h"
+#include "no_os_util.h"
+
+#define AD7490_LOW_BYTE_MASK	NO_OS_GENMASK(7, 0)
+#define AD7490_HIGH_BYTE_MASK	NO_OS_GENMASK(15, 8)
+
+#define AD7490_VAL_MASK		NO_OS_GENMASK(11, 0)
+
+#define AD7490_WRITE_MASK	NO_OS_BIT(11)
+#define AD7490_SEQ_MASK		NO_OS_BIT(10)
+#define AD7490_ADD_MASK		NO_OS_GENMASK(9, 6)
+#define AD7490_PM_MASK		NO_OS_GENMASK(5, 4)
+#define AD7490_SHADOW_MASK	NO_OS_BIT(3)
+#define AD7490_WEAKTRI_MASK	NO_OS_BIT(2)
+#define AD7490_RANGE_MASK	NO_OS_BIT(1)
+#define AD7490_CODING_MASK	NO_OS_BIT(0)
+
+#define AD7490_CFG_MASK		NO_OS_GENMASK(2, 0)
+
+enum ad7490_vdd {
+	AD7490_VDD_3V3,
+	AD7490_VDD_5V,
+};
+
+enum ad7490_address {
+	AD7490_CHAN_ADDR_VIN0,
+	AD7490_CHAN_ADDR_VIN1,
+	AD7490_CHAN_ADDR_VIN2,
+	AD7490_CHAN_ADDR_VIN3,
+	AD7490_CHAN_ADDR_VIN4,
+	AD7490_CHAN_ADDR_VIN5,
+	AD7490_CHAN_ADDR_VIN6,
+	AD7490_CHAN_ADDR_VIN7,
+	AD7490_CHAN_ADDR_VIN8,
+	AD7490_CHAN_ADDR_VIN9,
+	AD7490_CHAN_ADDR_VIN10,
+	AD7490_CHAN_ADDR_VIN11,
+	AD7490_CHAN_ADDR_VIN12,
+	AD7490_CHAN_ADDR_VIN13,
+	AD7490_CHAN_ADDR_VIN14,
+	AD7490_CHAN_ADDR_VIN15,
+	AD7490_CHAN_OFF,
+};
+
+enum ad7490_op_mode {
+	AD7490_MODE_AUTOSTANDBY,
+	AD7490_MODE_AUTOSHUTDOWN,
+	AD7490_MODE_FULLSHUTDOWN,
+	AD7490_MODE_NORMAL,
+};
+
+enum ad7490_dout_state {
+	AD7490_DOUT_TRISTATE,
+	AD7490_DOUT_WEAK,
+};
+
+enum ad7490_range {
+	AD7490_RANGE_2XREFIN,
+	AD7490_RANGE_REFIN,
+};
+
+enum ad7490_coding {
+	AD7490_CODING_TWOS,
+	AD7490_CODING_BINARY,
+};
+
+enum ad7490_seq_op {
+	AD7490_NO_SEQ,
+	AD7490_SHADOW_SEQ,
+	AD7490_CONTROL_SEQ,
+	AD7490_CONSECUTIVE_SEQ,
+};
+
+struct ad7490_init_param {
+	struct no_os_spi_init_param *spi_param;
+	enum ad7490_op_mode op_mode;
+	enum ad7490_vdd vdd;
+};
+
+struct ad7490_desc {
+	struct no_os_spi_desc *spi_desc;
+	enum ad7490_address address;
+	enum ad7490_op_mode op_mode;
+	enum ad7490_seq_op seq_op;
+	enum ad7490_vdd vdd;
+	uint16_t channels;
+	uint8_t nb_channels_seq;
+	uint8_t cfg;
+};
+
+/* Set the operation mode of the AD7490. */
+int ad7490_set_op_mode(struct ad7490_desc *desc, enum ad7490_op_mode op_mode);
+
+/* Configuration of the range, coding and DOUT state. */
+int ad7490_config(struct ad7490_desc *desc, enum ad7490_dout_state dout_state,
+		  enum ad7490_range range, enum ad7490_coding coding);
+
+/* Single channel reading function. */
+int ad7490_read_ch(struct ad7490_desc *desc, enum ad7490_address channel,
+		   int16_t *val);
+
+/* Start SEQUENCER using desired type. */
+int ad7490_start_seq(struct ad7490_desc *desc, enum ad7490_seq_op seq_op,
+		     uint16_t channels, enum ad7490_address last_chan);
+
+/* Change SEQUENCER type while it is running. */
+int ad7490_change_seq(struct ad7490_desc *desc, enum ad7490_seq_op seq_op,
+		      enum ad7490_coding coding, enum ad7490_range range);
+
+/* Stop SEQUENCER. */
+int ad7490_stop_seq(struct ad7490_desc *desc);
+
+/* Read all selected channel values from the SEQUENCER. */
+int ad7490_read_seq(struct ad7490_desc *desc, int16_t *channels_val);
+
+/* Initialize the AD7490. */
+int ad7490_init(struct ad7490_desc **desc,
+		struct ad7490_init_param *init_param);
+
+/* Remove allocated resources of the AD7490 by init function. */
+int ad7490_remove(struct ad7490_desc *desc);
+
+#endif /* AD7490_H_ */

--- a/drivers/adc/ad7490/iio_ad7490.c
+++ b/drivers/adc/ad7490/iio_ad7490.c
@@ -1,0 +1,423 @@
+/**************************************************************************//**
+*   @file   iio_ad7490.c
+*   @brief  Source file of iio_ad7490
+*   @author Radu Sabau (radu.sabau@analog.com)
+*******************************************************************************
+* Copyright 2025(c) Analog Devices, Inc.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* 3. Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived from this
+*    software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+* EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************************************************************/
+#include "iio_ad7490.h"
+#include "no_os_alloc.h"
+#include "no_os_error.h"
+
+#define AD7490_V_FS_2V5		2500
+#define AD7490_V_FS_5V		5000
+
+#define AD7490_CHANNEL(_idx) {			\
+	.ch_type = IIO_VOLTAGE,			\
+	.channel = _idx,			\
+	.indexed = true,			\
+	.attributes = ad7490_iio_attrs,		\
+	.address = _idx,			\
+	.scan_type = &ad7490_iio_scan_type,	\
+	.scan_index = _idx			\
+}
+
+static struct scan_type ad7490_iio_scan_type = {
+	.sign = 'u',
+	.realbits = 12,
+	.storagebits = 16,
+	.shift = 0,
+	.is_big_endian = false,
+};
+
+static const char *const ad7490_range_avail[2] = {
+	[AD7490_RANGE_2XREFIN] = "2X_REF_IN",
+	[AD7490_RANGE_REFIN] = "REF_IN",
+};
+
+static const char *const ad7490_polarity_avail[2] = {
+	[AD7490_CODING_TWOS] = "BIPOLAR",
+	[AD7490_CODING_BINARY] = "UNIPOLAR",
+};
+
+static int ad7490_read_samples(struct ad7490_desc *desc, int16_t *data,
+			       uint32_t samples)
+{
+	uint32_t i, sample_size;
+	int16_t channels_val[16];
+	int ret;
+
+	sample_size = desc->nb_channels_seq * sizeof(int16_t);
+
+	for (i = 0; i < samples; i++) {
+		ret = ad7490_read_seq(desc, data);
+		if (ret)
+			return ret;
+		data += sample_size;
+	}
+
+	return 0;
+}
+
+static int ad7490_iio_read_raw(void *device, char *buf, uint32_t len,
+			       const struct iio_ch_info *channel,
+			       intptr_t priv)
+{
+	struct ad7490_iio_desc *iio_desc = device;
+	int16_t val;
+	int ret;
+
+	ret = ad7490_read_ch(iio_desc->ad7490_desc, channel->address, &val);
+	if (ret)
+		return ret;
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+}
+
+static int ad7490_iio_read_scale(void *device, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel,
+				 intptr_t priv)
+{
+	struct ad7490_iio_desc *iio_desc = device;
+	int32_t vals[2];
+	int16_t val;
+	int ret;
+
+	ret = ad7490_read_ch(iio_desc->ad7490_desc, channel->address, &val);
+	if (ret)
+		return ret;
+
+	if (no_os_field_get(AD7490_RANGE_MASK,
+			    iio_desc->ad7490_desc->cfg) == AD7490_RANGE_2XREFIN)
+		vals[0] = AD7490_V_FS_5V;
+	else
+		vals[0] = AD7490_V_FS_2V5;
+
+	vals[1] = ad7490_iio_scan_type.realbits;
+	ret = ad7490_read_ch(iio_desc->ad7490_desc, channel->address, &val);
+	if (ret)
+		return ret;
+
+	return iio_format_value(buf, len, IIO_VAL_FRACTIONAL_LOG2, 2, vals);
+}
+
+static int ad7490_iio_read_polarity(void *device, char *buf, uint32_t len,
+				    const struct iio_ch_info *channel,
+				    intptr_t priv)
+{
+	struct ad7490_iio_desc *desc = device;
+
+	return sprintf(buf, "%s ",
+		       ad7490_polarity_avail[no_os_field_get(AD7490_CODING_MASK,
+					     desc->ad7490_desc->cfg)]);
+}
+
+static int ad7490_iio_write_polarity(void *device, char *buf, uint32_t len,
+				     const struct iio_ch_info *channel,
+				     intptr_t priv)
+{
+	struct ad7490_iio_desc *desc = device;
+	enum ad7490_range range;
+	enum ad7490_dout_state dout_state;
+	uint32_t i;
+	int ret;
+
+	for (i = 0; i < NO_OS_ARRAY_SIZE(ad7490_polarity_avail); i++)
+		if (!strcmp(buf, ad7490_polarity_avail[i]))
+			break;
+
+	if (i == NO_OS_ARRAY_SIZE(ad7490_polarity_avail))
+		return -EINVAL;
+
+	range = no_os_field_get(AD7490_RANGE_MASK, desc->ad7490_desc->cfg);
+	dout_state = no_os_field_get(AD7490_WEAKTRI_MASK, desc->ad7490_desc->cfg);
+	ret = ad7490_config(desc->ad7490_desc, dout_state, range, i);
+	if (ret)
+		return ret;
+
+	desc->iio_dev->channels->scan_type->sign = (i == AD7490_CODING_BINARY) ? 'u' :
+			's';
+
+	return 0;
+}
+
+static int ad7490_iio_read_polarity_avail(void *device, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	uint32_t avail_size = NO_OS_ARRAY_SIZE(ad7490_polarity_avail);
+	uint32_t length = 0;
+	uint32_t i;
+
+	for (i = 0; i < avail_size; i++)
+		length += sprintf(buf + length, "%s ", ad7490_polarity_avail[i]);
+
+	return length;
+}
+
+static int ad7490_iio_read_range(void *device, char *buf, uint32_t len,
+				 const struct iio_ch_info *channel,
+				 intptr_t priv)
+{
+	struct ad7490_iio_desc *desc = device;
+
+	return sprintf(buf, "%s ", ad7490_range_avail[no_os_field_get(AD7490_RANGE_MASK,
+			desc->ad7490_desc->cfg)]);
+}
+
+static int ad7490_iio_write_range(void *device, char *buf, uint32_t len,
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
+{
+	struct ad7490_iio_desc *desc = device;
+	enum ad7490_coding coding;
+	enum ad7490_dout_state dout_state;
+	uint32_t i;
+
+	for (i = 0; i < NO_OS_ARRAY_SIZE(ad7490_range_avail); i++)
+		if (!strcmp(buf, ad7490_range_avail[i]))
+			break;
+
+	if (i == NO_OS_ARRAY_SIZE(ad7490_range_avail))
+		return -EINVAL;
+
+	coding = no_os_field_get(AD7490_CODING_MASK, desc->ad7490_desc->cfg);
+	dout_state = no_os_field_get(AD7490_WEAKTRI_MASK, desc->ad7490_desc->cfg);
+	return ad7490_config(desc->ad7490_desc, dout_state, i, coding);
+}
+
+static int ad7490_iio_read_range_avail(void *device, char *buf, uint32_t len,
+				       const struct iio_ch_info *channel,
+				       intptr_t priv)
+{
+	uint32_t avail_size = NO_OS_ARRAY_SIZE(ad7490_range_avail);
+	uint32_t length = 0;
+	uint32_t i;
+
+	for (i = 0; i < avail_size; i++)
+		length += sprintf(buf + length, "%s ", ad7490_range_avail[i]);
+
+	return length;
+}
+
+static int ad7490_iio_read_sampling_freq(void *device, char *buf, uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	int32_t val;
+
+	val = 1000000;
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+}
+
+static int ad7490_iio_pre_enable(void *device, uint32_t mask)
+{
+	struct ad7490_iio_desc *desc = device;
+
+	desc->active_channels = mask;
+	desc->no_of_active_channels = no_os_hweight16(mask);
+
+	return ad7490_start_seq(desc->ad7490_desc, AD7490_SHADOW_SEQ, mask, 0);
+}
+
+static int ad7490_iio_post_disable(void *device, uint32_t mask)
+{
+	struct ad7490_iio_desc *desc = device;
+
+	return ad7490_stop_seq(desc->ad7490_desc);
+}
+
+static int iio_ad7490_submit_buffer(struct iio_device_data *iio_dev_data)
+{
+	struct ad7490_iio_desc *iio_desc = iio_dev_data->dev;
+	struct ad7490_desc *desc = iio_desc->ad7490_desc;
+	struct iio_buffer *buffer = iio_dev_data->buffer;
+	uint32_t total_samples;
+	int16_t *push_data, channels_val[16] = {0};
+	uint32_t i = 0, j;
+	int ret;
+	void *buff;
+
+	ret = iio_buffer_get_block(buffer, &buff);
+	if (ret)
+		return ret;
+
+	total_samples = iio_desc->no_of_active_channels * buffer->samples;
+
+	push_data = buff;
+	while (i < total_samples) {
+		ret = ad7490_read_seq(desc, channels_val);
+		if (ret)
+			return ret;
+
+		for (j = 0; j < iio_desc->no_of_active_channels; j++) {
+			push_data[i] = channels_val[j];
+			i++;
+		}
+	}
+
+	return iio_buffer_block_done(buffer);
+}
+
+static int ad7490_iio_read_samples(void *device, int *buff, uint32_t samples)
+{
+	struct ad7490_iio_desc *desc = device;
+	int16_t channels_val[16];
+	uint32_t i = 0, j;
+	int ret;
+
+	while (i < samples * desc->no_of_active_channels) {
+		ret = ad7490_read_seq(desc->ad7490_desc, channels_val);
+		if (ret)
+			return ret;
+
+		for (j = 0; j < desc->no_of_active_channels; j++) {
+			buff[i] = channels_val[j];
+			i++;
+		}
+	}
+
+	return samples;
+}
+
+static struct iio_attribute ad7490_iio_attrs[] = {
+	{
+		.name = "raw",
+		.show = ad7490_iio_read_raw,
+	},
+	{
+		.name = "scale",
+		.show = ad7490_iio_read_scale,
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_attribute ad7490_global_attrs[] = {
+	{
+		.name = "polarity",
+		.show = ad7490_iio_read_polarity,
+		.store = ad7490_iio_write_polarity,
+		.shared = IIO_SHARED_BY_ALL,
+	},
+	{
+		.name = "polarity_available",
+		.show = ad7490_iio_read_polarity_avail,
+		.shared = IIO_SHARED_BY_ALL,
+	},
+	{
+		.name = "range",
+		.show = ad7490_iio_read_range,
+		.store = ad7490_iio_write_range,
+		.shared = IIO_SHARED_BY_ALL,
+	},
+	{
+		.name = "range_available",
+		.show = ad7490_iio_read_range_avail,
+		.shared = IIO_SHARED_BY_ALL,
+	},
+	{
+		.name = "sampling_frequency",
+		.show = ad7490_iio_read_sampling_freq,
+		.shared = IIO_SHARED_BY_ALL,
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+static struct iio_channel ad7490_channels[] = {
+	AD7490_CHANNEL(0),
+	AD7490_CHANNEL(1),
+	AD7490_CHANNEL(2),
+	AD7490_CHANNEL(3),
+	AD7490_CHANNEL(4),
+	AD7490_CHANNEL(5),
+	AD7490_CHANNEL(6),
+	AD7490_CHANNEL(7),
+	AD7490_CHANNEL(8),
+	AD7490_CHANNEL(9),
+	AD7490_CHANNEL(10),
+	AD7490_CHANNEL(11),
+	AD7490_CHANNEL(12),
+	AD7490_CHANNEL(13),
+	AD7490_CHANNEL(14),
+	AD7490_CHANNEL(15),
+};
+
+static struct iio_device ad7490_iio_dev = {
+	.num_ch = NO_OS_ARRAY_SIZE(ad7490_channels),
+	.channels = ad7490_channels,
+	.attributes = ad7490_global_attrs,
+	.read_dev = (int32_t (*)())ad7490_iio_read_samples,
+	.pre_enable = (int32_t (*)())ad7490_iio_pre_enable,
+	.post_disable = (int32_t (*)())ad7490_iio_post_disable,
+	.submit = (int32_t (*)())iio_ad7490_submit_buffer,
+};
+
+int ad7490_iio_init(struct ad7490_iio_desc **iio_desc,
+		    struct ad7490_iio_init_param *init_param)
+{
+	struct ad7490_iio_desc *iio_descriptor;
+	int ret;
+
+	iio_descriptor = (struct ad7490_iio_desc *)no_os_calloc(1,
+			 sizeof(*iio_descriptor));
+	if (!iio_descriptor)
+		return -ENOMEM;
+
+	iio_descriptor->iio_dev = &ad7490_iio_dev;
+	ret = ad7490_init(&iio_descriptor->ad7490_desc, init_param->ad7490_init);
+	if (ret)
+		goto free_desc;
+
+	ret = ad7490_config(iio_descriptor->ad7490_desc, init_param->dout_state,
+			    init_param->range, init_param->coding);
+	if (ret)
+		goto free_ad7490;
+
+	iio_descriptor->iio_dev->channels->scan_type->sign = (init_param->coding ==
+			AD7490_CODING_BINARY) ? 'u' : 's';
+
+	*iio_desc = iio_descriptor;
+
+	return 0;
+
+free_ad7490:
+	ad7490_remove(iio_descriptor->ad7490_desc);
+free_desc:
+	no_os_free(iio_descriptor);
+
+	return 0;
+}
+
+int ad7490_iio_remove(struct ad7490_iio_desc *iio_desc)
+{
+	ad7490_remove(iio_desc->ad7490_desc);
+	no_os_free(iio_desc);
+
+	return 0;
+}

--- a/drivers/adc/ad7490/iio_ad7490.h
+++ b/drivers/adc/ad7490/iio_ad7490.h
@@ -1,0 +1,62 @@
+/**************************************************************************//**
+*   @file   iio_ad7490.h
+*   @brief  Header file of iio_ad7490
+*   @author Radu Sabau (radu.sabau@analog.com)
+*******************************************************************************
+* Copyright 2025(c) Analog Devices, Inc.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* 3. Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived from this
+*    software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+* EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+******************************************************************************/
+
+#ifndef IIO_AD7490_H
+#define IIO_AD7490_H
+
+#include "iio.h"
+#include "iio_types.h"
+#include "ad7490.h"
+
+struct ad7490_iio_desc {
+	struct ad7490_desc *ad7490_desc;
+	struct iio_device *iio_dev;
+
+	uint32_t active_channels;
+	uint8_t no_of_active_channels;
+};
+
+struct ad7490_iio_init_param {
+	struct ad7490_init_param *ad7490_init;
+
+	enum ad7490_dout_state dout_state;
+	enum ad7490_range range;
+	enum ad7490_coding coding;
+};
+
+int ad7490_iio_init(struct ad7490_iio_desc **iio_desc,
+		    struct ad7490_iio_init_param *init_param);
+
+int ad7490_iio_remove(struct ad7490_iio_desc *iio_desc);
+
+#endif /** IIO_AD7490_H */

--- a/projects/eval-ad7490sdz/Makefile
+++ b/projects/eval-ad7490sdz/Makefile
@@ -1,0 +1,10 @@
+# Select the example you want to enable by choosing y for enabling and n for disabling
+EXAMPLE ?= iio_example
+
+include ../../tools/scripts/generic_variables.mk
+
+include ../../tools/scripts/examples.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/eval-ad7490sdz/README.rst
+++ b/projects/eval-ad7490sdz/README.rst
@@ -1,0 +1,165 @@
+EVAL-AD7490SDZ no-OS Example Project
+====================================
+
+.. no-os-doxygen::
+
+.. contents::
+	:depth: 3
+
+Supported Evaluation Boards
+---------------------------
+
+* `EVAL-AD7490SDZ <https://www.analog.com/EVAL-AD7490SDZ>`_
+
+Overview
+--------
+
+The EVAL-AD7490SDZ is a fully featured evaluation kit for the AD7490.
+This board operates in standalone mode or in conjunction with the
+System Development Platform, EVAL-SDP-CB1Z.
+
+Hardware Specifications
+-----------------------
+
+The EVAL-AD7490SDZ device has to be supplied with a 7-9V DC voltage and
+a 3V3/5V VDRIVE voltage from the microcontroller (for the logic level
+voltage of the SPI communication).
+
+**Pin Description**
+
+	Please see the following table for the pin assignments for the
+	interface connector (SPI Test Points).
+
+	+-----+--------+--------------------------------+
+	| Pin |  Name  | Description			|
+	+-----+--------+--------------------------------+
+	| -   |	T_CS   | Chip-Select			|
+	+-----+--------+--------------------------------+
+	| -   | T_DIN  | Master-Out Slave-In (MOSI)	|
+	+-----+--------+--------------------------------+
+	| -   | T_DOUT | Master-In Slave-Out (MISO)	|
+	+-----+--------+--------------------------------+
+	| -   | T_SCLK | Serial Clock			|
+	+-----+--------+--------------------------------+
+
+	Please see the following table for the pin assignments for the
+	power supply connectors (J8 and J700, respectively).
+
+	+-----+--------+--------------------------------+
+	| Pin |  Name  | Description			|
+	+-----+--------+--------------------------------+
+	| 1   |	VDRIVE | 5V/3V3 voltage of the MCU	|
+	+-----+--------+--------------------------------+
+	| 2   |  GND   | Ground				|
+	+-----+--------+--------------------------------+
+
+	+-----+--------+--------------------------------+
+	| Pin |  Name  | Description			|
+	+-----+--------+--------------------------------+
+	| 1   |EXT_PWR | 7V-9V External DC voltage	|
+	+-----+--------+--------------------------------+
+	| 2   |EXT_GND | External Ground		|
+	+-----+--------+--------------------------------+
+
+	Also please refer to the following table for the jumper positions on
+	the board.
+
+	+--------+--------------+
+	| Jumper | Position	|
+	+--------+--------------+
+	| LK701	 | A		|
+	+--------+--------------+
+	| LK101	 | A		|
+	+--------+--------------+
+	| LK102	 | A		|
+	+--------+--------------+
+	| LK19	 | C		|
+	+--------+--------------+
+	| LK17	 | A		|
+	+--------+--------------+
+
+No-OS Build Setup
+-----------------
+
+`Please see: <https://wiki.analog.com/resources/no-os/build>`_
+
+No-OS Supported Examples
+------------------------
+
+The initialization data used in the examples is taken out from:
+`Project Common Data Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/eval-ad7490sdz/src/common>`_
+
+The macros used in Common Data are defined in platform specific files found in:
+`Project Platform Configuration Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/eval-ad7490sdz/src/platform>`_
+
+Basic Example
+^^^^^^^^^^^^^
+
+This is a simple example which initializes the ad7490 and reads a single
+voltage channel continuoussly applying scale to it.
+
+In order to build the basic example make sure you have the following configuration in the Makefile
+`Makefile <https://github.com/analogdevicesinc/no-OS/tree/main/projects/eval-ad7490sdz/Makefile>`_
+
+.. code-block:: bash
+
+	# Select the example you want to enable by choosing y for enabling and n for disabling
+	EXAMPLE ?= basic
+
+IIO example
+^^^^^^^^^^^
+
+This is an example that initializes the ad7490 iio descriptor through which
+an IIO device is initialized as well as it's channels. Then an iio
+application initialization parameter is used for initializing and
+running an IIO app through the IIO lib. Finally the client can
+configure the ad7490 in every way possible througout an IIO
+interface such as IIO oscilloscope.
+
+In order to build the IIO example make sure you have the following configuration in the Makefile
+`Makefile <https://github.com/analogdevicesinc/no-OS/tree/main/projects/eval-ad7490sdz/Makefile>`_
+
+.. code-block:: bash
+
+	# Select the example you want to enable by choosing y for enabling and n for disabling
+	EXAMPLE ?= iio_example
+
+No-OS Supported Platforms
+-------------------------
+
+Maxim Platform
+^^^^^^^^^^^^^^
+
+**Used Hardware**
+
+* `EVAL-AD7490SDZ <https://www.analog.com/EVAL-AD7490SDZ>`_
+* `AD-APARD32690-SL Board <https://www.analog.com/en/resources/evaluation-hardware-and-software/evaluation-boards-kits/ad-apard32690-sl.html>`_
+
+**Connections**:
+
++-------------------------------+----------+---------------------------------+-----------------------------+
+| EVAL-AD7490SDZ Pin Name 	| Mnemonic | Function			     | AD-APARD32690-SL Pin Number |
++-------------------------------+----------+---------------------------------+-----------------------------+
+| T_CS			        | CS       | SPI interface Chip-Select	     | P1_0 		       	   |
++-------------------------------+----------+---------------------------------+-----------------------------+
+| T_DIN				| MOSI     | SPI interface MOSI		     | P1_1		       	   |
++-------------------------------+----------+---------------------------------+-----------------------------+
+| T_DOUT			| MISO     | SPI interface MISO     	     | P1_2		       	   |
++-------------------------------+----------+---------------------------------+-----------------------------+
+| T_SCLK			| SCLK	   | SPI interface Serial Clock Line | P1_3		       	   |
++-------------------------------+----------+---------------------------------+-----------------------------+
+| VDRIVE			| 5V/3V3   | 5V/3.3V DC power supply	     | 5V/3V3		       	   |
++-------------------------------+----------+---------------------------------+-----------------------------+
+| GND				| GND	   | Ground			     | GND		       	   |
++-------------------------------+----------+---------------------------------+-----------------------------+
+
+**Build Command**
+
+.. code-block:: bash
+
+	# to delete current build
+	make reset
+	# to build the project
+	make PLATFORM=maxim TARGET=max32690
+	# to flash the code
+	make run

--- a/projects/eval-ad7490sdz/builds.json
+++ b/projects/eval-ad7490sdz/builds.json
@@ -1,0 +1,10 @@
+{
+  "maxim": {
+    "basic_example": {
+      "flags" : "EXAMPLE=basic TARGET=max32690"
+    },
+    "iio_example": {
+      "flags" : "EXAMPLE=iio_example TARGET=max32690"
+    }
+  }
+}

--- a/projects/eval-ad7490sdz/src.mk
+++ b/projects/eval-ad7490sdz/src.mk
@@ -1,0 +1,28 @@
+INCS += $(INCLUDE)/no_os_delay.h	\
+	$(INCLUDE)/no_os_error.h	\
+	$(INCLUDE)/no_os_gpio.h		\
+	$(INCLUDE)/no_os_print_log.h	\
+	$(INCLUDE)/no_os_spi.h		\
+	$(INCLUDE)/no_os_alloc.h	\
+	$(INCLUDE)/no_os_irq.h		\
+	$(INCLUDE)/no_os_list.h		\
+	$(INCLUDE)/no_os_dma.h		\
+	$(INCLUDE)/no_os_uart.h		\
+	$(INCLUDE)/no_os_lf256fifo.h	\
+	$(INCLUDE)/no_os_util.h		\
+	$(INCLUDE)/no_os_units.h	\
+	$(INCLUDE)/no_os_mutex.h
+
+SRCS += $(DRIVERS)/api/no_os_gpio.c	\
+	$(NO-OS)/util/no_os_lf256fifo.c	\
+	$(DRIVERS)/api/no_os_irq.c	\
+	$(DRIVERS)/api/no_os_spi.c	\
+	$(DRIVERS)/api/no_os_uart.c	\
+	$(DRIVERS)/api/no_os_dma.c	\
+	$(NO-OS)/util/no_os_list.c	\
+	$(NO-OS)/util/no_os_util.c	\
+	$(NO-OS)/util/no_os_alloc.c	\
+	$(NO-OS)/util/no_os_mutex.c
+
+INCS += $(DRIVERS)/adc/ad7490/ad7490.h
+SRCS += $(DRIVERS)/adc/ad7490/ad7490.c

--- a/projects/eval-ad7490sdz/src/common/common_data.c
+++ b/projects/eval-ad7490sdz/src/common/common_data.c
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ *   @file   common_data.c
+ *   @brief  Common data used within the eval-ad7490sdz project.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+ ********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+
+#include "common_data.h"
+#include <stdbool.h>
+
+struct no_os_uart_init_param uart_ip = {
+	.device_id = UART_DEVICE_ID,
+	.baud_rate = UART_BAUDRATE,
+	.asynchronous_rx = true,
+	.size = NO_OS_UART_CS_8,
+	.parity = NO_OS_UART_PAR_NO,
+	.stop = NO_OS_UART_STOP_1_BIT,
+	.platform_ops = UART_OPS,
+	.extra = UART_EXTRA,
+};
+
+struct no_os_spi_init_param ad7490_spi_ip = {
+	.device_id = SPI_DEVICE_ID,
+	.max_speed_hz = SPI_BAUDRATE,
+	.mode = NO_OS_SPI_MODE_2,
+	.chip_select = SPI_CS,
+	.platform_ops = SPI_OPS,
+	.extra = SPI_EXTRA,
+};
+
+struct ad7490_init_param ad7490_ip = {
+	.spi_param = &ad7490_spi_ip,
+	.op_mode = AD7490_MODE_NORMAL,
+	.vdd = AD7490_VDD_5V,
+};

--- a/projects/eval-ad7490sdz/src/common/common_data.h
+++ b/projects/eval-ad7490sdz/src/common/common_data.h
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ *   @file   common_data.h
+ *   @brief  Common data used within the eval-ad7490sdz project.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+ ********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#ifndef __COMMON_DATA_H__
+#define __COMMON_DATA_H__
+
+#include "parameters.h"
+#include "ad7490.h"
+
+#ifdef IIO_SUPPORT
+#include "iio_ad7490.h"
+#endif
+
+extern struct no_os_uart_init_param uart_ip;
+extern struct no_os_spi_init_param ad7490_spi_ip;
+extern struct ad7490_init_param ad7490_ip;
+
+
+#endif /* __COMMON_DATA_H__ */

--- a/projects/eval-ad7490sdz/src/examples/basic/basic_example.c
+++ b/projects/eval-ad7490sdz/src/examples/basic/basic_example.c
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ *   @file   basic_example.c
+ *   @brief  Basic example code for eval-ad7490sdz project
+ *   @author Radu Sabau (radu.sabau@analog.com)
+ ********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#include "ad7490.h"
+#include "common_data.h"
+#include "no_os_delay.h"
+#include "no_os_print_log.h"
+
+#define AD7490_VREF		2.5
+#define AD7490_FULLSCALE	4096
+
+/*****************************************************************************
+ * @brief Basic example main execution.
+ *
+ * @return ret - Result of the example execution. If working correctly, will
+ *               execute continuously the while(1) loop and will not return.
+ *******************************************************************************/
+int example_main()
+{
+	struct ad7490_desc *ad7490;
+	int ret, i;
+	int16_t val;
+
+	ret = ad7490_init(&ad7490, &ad7490_ip);
+	if (ret)
+		goto error;
+
+	ret = ad7490_config(ad7490, AD7490_DOUT_TRISTATE, AD7490_RANGE_REFIN,
+			    AD7490_CODING_BINARY);
+	if (ret)
+		goto free_desc;
+
+	while (1) {
+		for (i = 0; i < AD7490_CHAN_ADDR_VIN15; i++) {
+			ret = ad7490_read_ch(ad7490, (enum ad7490_address)i, &val);
+			if (ret)
+				goto free_desc;
+
+			pr_info("Channel %d RAW Value : %d\n", i, val);
+
+			pr_info("Channel %d Scaled : %0.2f\n", i,
+				((float)val * AD7490_VREF) / AD7490_FULLSCALE);
+		}
+
+		no_os_mdelay(1000);
+	}
+
+	return 0;
+
+free_desc:
+	ad7490_remove(ad7490);
+error:
+	pr_info("Error!\r\n");
+	return ret;
+}

--- a/projects/eval-ad7490sdz/src/examples/iio_example/iio_example.c
+++ b/projects/eval-ad7490sdz/src/examples/iio_example/iio_example.c
@@ -1,0 +1,87 @@
+/********************************************************************************
+ *   @file   iio_example.c
+ *   @brief  IIo example code for eval-ad7490sdz project
+ *   @author Radu Sabau (radu.sabau@analog.com)
+ ********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#include "common_data.h"
+#include "no_os_print_log.h"
+#include "iio_app.h"
+
+#ifndef DATA_BUFFER_SIZE
+#define DATA_BUFFER_SIZE 400
+#endif
+
+uint8_t iio_data_buffer[DATA_BUFFER_SIZE * 16 * sizeof(int)];
+
+/*******************************************************************************
+ * @brief IIO example main execution.
+ *
+ * @return ret - Result of the example execution. If working correctly, will
+ *               execute continuously function iio_app_run and will not return.
+ *******************************************************************************/
+int example_main()
+{
+	int ret;
+	struct ad7490_iio_desc *ad7490_iio_desc;
+	struct ad7490_iio_init_param ad7490_iio_ip;
+	struct iio_app_desc *app;
+	struct iio_data_buffer voltage_buff = {
+		.buff = (void *)iio_data_buffer,
+		.size = DATA_BUFFER_SIZE * 16 * sizeof(int)
+	};
+	struct iio_app_init_param app_init_param = {0};
+
+	ad7490_iio_ip.ad7490_init = &ad7490_ip;
+	ad7490_iio_ip.dout_state = AD7490_DOUT_TRISTATE;
+	ad7490_iio_ip.range = AD7490_RANGE_REFIN;
+	ad7490_iio_ip.coding = AD7490_CODING_BINARY;
+	ret = ad7490_iio_init(&ad7490_iio_desc, &ad7490_iio_ip);
+	if (ret)
+		return ret;
+
+	struct iio_app_device iio_devices[] = {
+		{
+			.name = "ad7490",
+			.dev = ad7490_iio_desc,
+			.dev_descriptor = ad7490_iio_desc->iio_dev,
+			.read_buff = &voltage_buff,
+		},
+	};
+
+	app_init_param.devices = iio_devices;
+	app_init_param.nb_devices = NO_OS_ARRAY_SIZE(iio_devices);
+	app_init_param.uart_init_params = uart_ip;
+
+	ret = iio_app_init(&app, app_init_param);
+	if (ret)
+		return ret;
+
+	return iio_app_run(app);
+}

--- a/projects/eval-ad7490sdz/src/examples/iio_example/iio_example.mk
+++ b/projects/eval-ad7490sdz/src/examples/iio_example/iio_example.mk
@@ -1,0 +1,3 @@
+IIOD = y
+INCS += $(DRIVERS)/adc/ad7490/iio_ad7490.h
+SRCS += $(DRIVERS)/adc/ad7490/iio_ad7490.c

--- a/projects/eval-ad7490sdz/src/platform/maxim/main.c
+++ b/projects/eval-ad7490sdz/src/platform/maxim/main.c
@@ -1,0 +1,53 @@
+/********************************************************************************
+ *   @file   main.c
+ *   @brief  Main file for Maxim platform of eval-ad7490sdz project.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+ ********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#include "common_data.h"
+
+extern int example_main();
+
+int main()
+{
+	struct no_os_uart_desc *uart_desc;
+	int ret;
+
+#ifdef IIO_SUPPORT
+	return example_main();
+#endif
+
+	ret = no_os_uart_init(&uart_desc, &uart_ip);
+	if (ret)
+		return ret;
+
+	no_os_uart_stdio(uart_desc);
+
+	return example_main();
+}

--- a/projects/eval-ad7490sdz/src/platform/maxim/parameters.c
+++ b/projects/eval-ad7490sdz/src/platform/maxim/parameters.c
@@ -1,0 +1,43 @@
+/********************************************************************************
+ *   @file   parameters.c
+ *   @brief  Definition of Maxim platform data used by eval-ad7490sdz project.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+ ********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#include "parameters.h"
+
+struct max_uart_init_param max_uart_extra = {
+	.flow = MAX_UART_FLOW_DIS,
+};
+
+struct max_spi_init_param  max_spi_extra = {
+	.num_slaves = 1,
+	.polarity = SPI_SS_POL_LOW,
+	.vssel = MXC_GPIO_VSSEL_VDDIOH
+};

--- a/projects/eval-ad7490sdz/src/platform/maxim/parameters.h
+++ b/projects/eval-ad7490sdz/src/platform/maxim/parameters.h
@@ -1,0 +1,62 @@
+/********************************************************************************
+ *   @file   parameters.h
+ *   @brief  Definition of Maxim platform data used by eval-ad7490sdz project.
+ *   @author Radu Sabau (radu.sabau@analog.com)
+ ********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************/
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
+
+#include "maxim_gpio.h"
+#include "maxim_spi.h"
+#include "maxim_uart.h"
+#include "maxim_uart_stdio.h"
+
+#ifdef IIO_SUPPORT
+#define INTC_DEVICE_ID	0
+#endif
+
+#define	UART_IRQ_ID	UART0_IRQn
+#define UART_DEVICE_ID	0
+
+#define UART_BAUDRATE	57600
+#define UART_OPS	&max_uart_ops
+#define UART_EXTRA      &max_uart_extra
+
+#define SPI_DEVICE_ID	4
+#define SPI_CS		0
+
+#define SPI_BAUDRATE	2000000
+#define SPI_OPS		&max_spi_ops
+#define SPI_EXTRA	&max_spi_extra
+
+extern struct max_uart_init_param max_uart_extra;
+extern struct max_spi_init_param max_spi_extra;
+
+#endif /* __PARAMETERS_H__ */

--- a/projects/eval-ad7490sdz/src/platform/maxim/platform_src.mk
+++ b/projects/eval-ad7490sdz/src/platform/maxim/platform_src.mk
@@ -1,0 +1,14 @@
+INCS +=	$(PLATFORM_DRIVERS)/maxim_gpio.h      \
+		$(PLATFORM_DRIVERS)/maxim_spi.h       \
+		$(PLATFORM_DRIVERS)/../common/maxim_dma.h       \
+		$(PLATFORM_DRIVERS)/maxim_irq.h      \
+		$(PLATFORM_DRIVERS)/maxim_uart.h      \
+		$(PLATFORM_DRIVERS)/maxim_uart_stdio.h
+
+SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c     \
+		$(PLATFORM_DRIVERS)/maxim_gpio.c      \
+		$(PLATFORM_DRIVERS)/maxim_spi.c       \
+		$(PLATFORM_DRIVERS)/../common/maxim_dma.c       \
+		$(PLATFORM_DRIVERS)/maxim_irq.c      \
+		$(PLATFORM_DRIVERS)/maxim_uart.c      \
+		$(PLATFORM_DRIVERS)/maxim_uart_stdio.c


### PR DESCRIPTION
## Pull Request Description

The AD7490 is a 12-bit high speed, low power, 16-channel, successive
approximation ADC.
The part operates from a single 2.7 V to 5.25 V power supply and
features throughput rates up to 1 MSPS.
The part contains a low noise, wide bandwidth track-and-hold
amplifier that can handle input frequencies in excess of 1 MHz.

This PR includes :
- no-OS driver for AD7490
- no-OS IIO driver for AD7490
- no-OS driver documentation
- no-OS example project (basic and IIO examples) for EVAL-AD7490SDZ (AD7490 evaluation board)
- no-OS example project documentation

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
