### PR TITLE
drivers: platform: ftd2xx : Fix FTD2XX GPIO drivers

### DIFF
--- a/drivers/platform/ftd2xx/mpsse/ftd2xx_gpio.h
+++ b/drivers/platform/ftd2xx/mpsse/ftd2xx_gpio.h
@@ -39,14 +39,26 @@
 #include "ftd2xx.h"
 
 #define FTD2XX_GPIO_PIN(x)		NO_OS_BIT(x)
+#define FTD2XX_GPIO_READ_CMD(id)	(0x81 + (id))
 
 #define FTD2XX_MAX_PIN_NB		7
 #define FTD2XX_MAX_PORT_NB		4
+
+extern uint8_t ftd2xx_gpio_pins_dir[FTD2XX_MAX_PORT_NB];
+extern uint8_t ftd2xx_gpio_pins_val[FTD2XX_MAX_PORT_NB];
 
 /**
  * @brief ftd2xx platform specific gpio platform ops structure
  */
 extern const struct no_os_gpio_platform_ops ftd2xx_gpio_ops;
+
+/**
+ * @struct ftd2xx_gpio_init
+ * @brief ftd2xx platform specific initialization parameter
+ */
+struct ftd2xx_gpio_init {
+	uint8_t extra_pins_dir;
+};
 
 /**
  * @struct ftd2xx_gpio_desc

--- a/drivers/platform/ftd2xx/mpsse/ftd2xx_gpio.h
+++ b/drivers/platform/ftd2xx/mpsse/ftd2xx_gpio.h
@@ -49,8 +49,8 @@
 extern const struct no_os_gpio_platform_ops ftd2xx_gpio_ops;
 
 /**
- * @struct stm32_gpio_desc
- * @brief stm32 platform specific gpio descriptor
+ * @struct ftd2xx_gpio_desc
+ * @brief ftd2xx platform specific gpio descriptor
  */
 struct ftd2xx_gpio_desc {
 	/** Specific device handle */

--- a/tools/scripts/ftd2xx.mk
+++ b/tools/scripts/ftd2xx.mk
@@ -9,6 +9,9 @@ ifeq ($(wildcard $(NO-OS)/libraries/ftd2xx/release),)
         endif
 endif
 
+TARGET = mpsse
+EXTRA_LIBS += libmpsse.a, ftd2xx
+
 CFLAGS += -DFT_VER_MAJOR
 CFLAGS += -DFT_VER_MINOR
 CFLAGS += -DFT_VER_BUILD


### PR DESCRIPTION
## Pull Request Description

Instead of making FTD2XX GPIO dependent on either I2C/SPI, it should be independent of those by using the
base D2XX driver device access functions.
Therefore make a PR that adds support for using the mentioned functions, and use the inside the ftd2xx_gpio drivers.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
