### PR TITLE
drivers: digital-io: max14919 : Fix GPIO set value for each channel

### DIFF
--- a/drivers/digital-io/max14919/max14919.c
+++ b/drivers/digital-io/max14919/max14919.c
@@ -51,8 +51,7 @@ int max14919_set_out(struct max14919_desc *desc, enum max14919_out_state *state)
 		return -EINVAL;
 
 	for (i = 0; i < MAX14919_OUT_CHANNELS; i++) {
-		ret = no_os_gpio_set_value(desc->in_desc[i],
-					   state[i] ? NO_OS_GPIO_LOW : NO_OS_GPIO_HIGH);
+		ret = no_os_gpio_set_value(desc->in_desc[i], state[i]);
 		if (ret)
 			return ret;
 


### PR DESCRIPTION
## Pull Request Description

Fix GPIO pin set value function to use the actual value off the state enum (0/1) instead of the inverted one.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
