### PR TITLE
drivers: platform: ftd2xx : Fix typo in FTD2XX GPIO driver

### DIFF
--- a/drivers/platform/ftd2xx/mpsse/ftd2xx_gpio.c
+++ b/drivers/platform/ftd2xx/mpsse/ftd2xx_gpio.c
@@ -305,20 +305,13 @@ int32_t ftd2xx_gpio_get_value(struct no_os_gpio_desc *desc, uint8_t *value)
 			return ret;
 		}
 
-		status = FT_Read(extra_desc->ftHandle, &val, val, &bytesRead);
+		status = FT_Read(extra_desc->ftHandle, &val, 1, &bytesRead);
 		if (status != FT_OK) {
 			ret = status;
 			return ret;
 		}
 
-		if (bytesRead == 1) {
-			*value = no_os_field_get(FTD2XX_GPIO_PIN(desc->number), val);
-
-			return 0;
-		} else {
-			ret = -EIO;
-			pr_err("Failed to read GPIO input\n");
-		}
+		*value = no_os_field_get(FTD2XX_GPIO_PIN(desc->number), val);
 	} else
 		return -EINVAL;
 


### PR DESCRIPTION
## Pull Request Description

In FTD2XX gpio_get_value the number of bytes to read should be 1, but instead is also the "val" number, which is a typo. Also, the number of bytes read is irrelevant to the code, since FTD2XX will always return 1 byte for the sent command.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
