### PR TITLE
drivers: net: oa_tc6: Support protected mode

### DIFF
--- a/drivers/net/oa_tc6/oa_tc6.h
+++ b/drivers/net/oa_tc6/oa_tc6.h
@@ -49,6 +49,10 @@
 #define CONFIG_OA_CHUNK_BUFFER_SIZE	1514
 #endif
 
+#ifndef CONFIG_OA_TC6_PROTECTION
+#define CONFIG_OA_TC6_PROTECTION	0
+#endif
+
 #define OA_TX_FRAME_BUFF_NUM		CONFIG_OA_TX_FRAME_BUFF_NUM
 #define OA_RX_FRAME_BUFF_NUM		CONFIG_OA_RX_FRAME_BUFF_NUM
 
@@ -180,7 +184,7 @@ struct oa_tc6_frame_buffer {
  */
 struct oa_tc6_desc {
 	struct no_os_spi_desc *comm_desc;
-	uint8_t ctrl_chunks[12];
+	uint8_t ctrl_chunks[16];
 	uint8_t data_chunks[OA_SPI_BUFF_LEN];
 
 	struct oa_tc6_frame_buffer user_rx_frame_buffer[OA_RX_FRAME_BUFF_NUM];


### PR DESCRIPTION
Implement the protected mode for the oa_tc6 driver. In this mode, control transactions include the register's value in 1's complement in order to verify the data integrity.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
