### PR TITLE
drivers:platform:stm32:irq: Fix IRQ free list when callbacks are not present

### DIFF
--- a/drivers/platform/stm32/stm32_irq.c
+++ b/drivers/platform/stm32/stm32_irq.c
@@ -493,6 +493,7 @@ int stm32_irq_unregister_callback(struct no_os_irq_ctrl_desc *desc,
 	void *discard  = NULL;
 	struct irq_action key;
 	uint32_t hal_event = _events[cb->event].hal_event;
+	uint32_t list_size;
 
 	switch (cb->peripheral) {
 	case NO_OS_UART_IRQ:
@@ -545,6 +546,17 @@ int stm32_irq_unregister_callback(struct no_os_irq_ctrl_desc *desc,
 
 	if (discard)
 		no_os_free(discard);
+
+	/* Get size of the list */
+	ret = no_os_list_get_size(_events[cb->event].actions, &list_size);
+	if (ret)
+		return ret;
+
+	/* If list is empty, remove the list */
+	if (list_size == 0) {
+		no_os_list_remove(_events[cb->event].actions);
+		_events[cb->event].actions = NULL;
+	}
 
 	return ret;
 }


### PR DESCRIPTION
Fix IRQ freeing of list when no callback actions are present. A new list is created when actions are NULL and a callback is registered, but while unregistering, the actions go NULL but list is not freed up.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
