### PR TITLE
drivers:platform:stm32:spi: Fix SPI Abort API

### DIFF
--- a/drivers/platform/stm32/stm32_spi.c
+++ b/drivers/platform/stm32/stm32_spi.c
@@ -601,7 +601,6 @@ void stm32_spi_dma_callback(struct no_os_dma_xfer_desc *old_xfer,
 {
 	struct no_os_spi_desc* desc = ctx;
 	struct stm32_spi_desc* sdesc = desc->extra;
-	SPI_TypeDef * SPIx = sdesc->hspi.Instance;
 
 	/* if more xfers pending dont do anything */
 	if (next_xfer)
@@ -617,13 +616,6 @@ void stm32_spi_dma_callback(struct no_os_dma_xfer_desc *old_xfer,
 
 	/* Perform abort SPI transfers */
 	no_os_spi_transfer_abort(desc);
-
-	/* Free the allocated memory for tx and rx transfers */
-	no_os_free(sdesc->tx_ch_xfer);
-	no_os_free(sdesc->rx_ch_xfer);
-
-	/* put CS pin back into gpio mode */
-	stm32_spi_altrnate_cs_enable(desc, false);
 
 	sdesc->stm32_spi_dma_done = true;
 
@@ -734,6 +726,13 @@ int32_t stm32_spi_transfer_abort(struct no_os_spi_desc* desc)
 #else
 	*(volatile uint8_t *)&SPIx->DR;
 #endif
+
+	/* Free the allocated memory for tx and rx transfers */
+	no_os_free(sdesc->tx_ch_xfer);
+	no_os_free(sdesc->rx_ch_xfer);
+
+	/* put CS pin back into gpio mode */
+	stm32_spi_altrnate_cs_enable(desc, false);
 
 	return 0;
 }


### PR DESCRIPTION
Fix SPI abort API to free the transfer descriptors that are created during transfer configuration.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
