### PR TITLE
drivers:platform:stm32:dma: Fix DMA Abort API

### DIFF
--- a/drivers/platform/stm32/stm32_dma.c
+++ b/drivers/platform/stm32/stm32_dma.c
@@ -247,7 +247,10 @@ int stm32_dma_xfer_abort(struct no_os_dma_desc* desc,
 
 	ret = HAL_DMA_Abort(sdma_chan->hdma);
 
-	if (ret != HAL_OK)
+	/* If transfer already completed, the state changes to READY
+	 * and hence aborting again would lead to error from HAL */
+	if ((ret != HAL_OK) &&
+	    (sdma_chan->hdma->ErrorCode != HAL_DMA_ERROR_NO_XFER))
 		return -EINVAL;
 
 	return 0;

--- a/drivers/platform/stm32/stm32_dma.c
+++ b/drivers/platform/stm32/stm32_dma.c
@@ -245,10 +245,7 @@ int stm32_dma_xfer_abort(struct no_os_dma_desc* desc,
 
 	sdma_chan = chan->extra;
 
-	if (chan->irq_num)
-		ret = HAL_DMA_Abort_IT(sdma_chan->hdma);
-	else
-		ret = HAL_DMA_Abort(sdma_chan->hdma);
+	ret = HAL_DMA_Abort(sdma_chan->hdma);
 
 	if (ret != HAL_OK)
 		return -EINVAL;


### PR DESCRIPTION
The DMA_Abort_IT disables the DMA and rest of the flags are cleared in the ISR. At this point, the execution do not reach ISR since the IRQ is disabled in no_os_dma_abort platform's abort is called. Hence abort needs to be done without ISR branch.

HAL returns an error when application tries to abort an already completed DMA transaction.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
