### PR TITLE
drivers:platform:stm32: Fix PWM free callback resources

### DIFF
--- a/drivers/platform/stm32/stm32_pwm.c
+++ b/drivers/platform/stm32/stm32_pwm.c
@@ -818,7 +818,7 @@ int32_t stm32_pwm_remove(struct no_os_pwm_desc *desc)
 	if (ret)
 		return ret;
 
-	if (desc->irq_id) {
+	if (desc->pwm_callback) {
 		ret = no_os_irq_unregister_callback(extra->nvic_tim, desc->irq_id,
 						    &extra->timer_callback);
 		if (ret)


### PR DESCRIPTION
Fix PWM freeing callback resources in remove API.
Callback is registered based on pwm_callback field but unregistering using irq_id field which returns error.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
