### PR TITLE
drivers:platform:stm32: Fix GPIO clear pending interrupt

### DIFF
--- a/drivers/platform/stm32/stm32_gpio_irq.c
+++ b/drivers/platform/stm32/stm32_gpio_irq.c
@@ -436,11 +436,20 @@ static int stm32_gpio_irq_set_priority(struct no_os_irq_ctrl_desc *desc,
 static int stm32_irq_clear_pending(struct no_os_irq_ctrl_desc* desc,
 				   uint32_t irq_id)
 {
+	IRQn_Type nvic_irq_id;
+	int ret;
+
 	if (!desc || !desc->extra || !IS_EXTI_GPIO_PIN(desc->irq_ctrl_id))
 		return -EINVAL;
 
 	if (__HAL_GPIO_EXTI_GET_IT(1 << (desc->irq_ctrl_id)))
 		__HAL_GPIO_EXTI_CLEAR_IT(1 << (desc->irq_ctrl_id));
+
+	ret = stm32_get_exti_irq_id_from_pin(desc->irq_ctrl_id, &nvic_irq_id);
+	if (ret)
+		return ret;
+
+	HAL_NVIC_ClearPendingIRQ(nvic_irq_id);
 
 	return 0;
 }


### PR DESCRIPTION
Fix GPIO IRQ clear pending interrupt to clear interrupt in both EXTI and NVIC.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
