### PR TITLE
Fixed bug in setting imaginary component of measured Rtia while running loops for ad5940

### DIFF
--- a/drivers/afe/ad5940/ad5940.h
+++ b/drivers/afe/ad5940/ad5940.h
@@ -2598,98 +2598,102 @@ enum ad5940_afe_result {
  *    @defgroup SWD_Const
  *    @brief Switch D set. This is bitmask for register DSWFULLCON.
  *    @details
+ *        Connects the D-node of the excitation amplifier
  *        It's used to initialize structure @ref SWMatrixCfg_Type
  *        The bitmasks can be OR'ed together. For example
  *          - `SWD_AIN1|SWD_RCAL0` means close SWD_AIN1 and SWD_RCAL0 in same time, and open all other D switches.
  *          - `SWD_AIN2` means close SWD_AIN2 and open all other D switches.
  *    @{
 */
-#define SWD_OPEN                    (0<<0)
-#define SWD_RCAL0                   (1<<0)
-#define SWD_AIN1                    (1<<1)
-#define SWD_AIN2                    (1<<2)
-#define SWD_AIN3                    (1<<3)
-#define SWD_CE0                     (1<<4)
-//#define SWD_CE1                     (1<<5)  /** @todo add Switch D configuration for new added pins */
-#define SWD_SE0                     (1<<6)
-//#define SWD_SE1                     (1<<7)
+#define SWD_OPEN                    (0<<0)  // open all D switches
+#define SWD_RCAL0                   (1<<0)  // DR0
+#define SWD_AIN1                    (1<<1)  // D2
+#define SWD_AIN2                    (1<<2)  // D3
+#define SWD_AIN3                    (1<<3)  // D4
+#define SWD_CE0                     (1<<4)  // D5
+#define SWD_CE1                     (1<<5)  // D6 (reserved?)
+#define SWD_SE0                     (1<<6)  // D7
+#define SWD_SE1                     (1<<7)  // D8 AFE3
 /** @} */
 
 /**
  * @defgroup SWP_Const
  * @brief Switch P set. This is bitmask for register PSWFULLCON.
  * @details
+ *        Positive nodes of the excitation amplifier
  *        It's used to initialize structure @ref SWMatrixCfg_Type.
  *        The bitmasks can be OR'ed together. For example
  *          - `SWP_RCAL0|SWP_AIN1` means close SWP_RCAL0 and SWP_AIN1 in same time, and open all other P switches.
  *          - `SWP_SE0` means close SWP_SE0 and open all other P switches.
  * @{
 */
-#define SWP_OPEN                    0       /* Open all P switches */
-#define SWP_RCAL0                   (1<<0)
-#define SWP_AIN1                    (1<<1)
-#define SWP_AIN2                    (1<<2)
-#define SWP_AIN3                    (1<<3)
-#define SWP_RE0                     (1<<4)
-#define SWP_RE1                     (1<<5)
-#define SWP_SE0                     (1<<6)
-#define SWP_DE0                     (1<<7)
-//#define SWP_SE1                     (1<<8)
-//#define SWP_DE1                     (1<<9)
-#define SWP_CE0                     (1<<10)
-//#define SWP_CE1                     (1<<11)
-#define SWP_PL                      (1<<13)
-#define SWP_PL2                     (1<<14)
+#define SWP_OPEN                    0         // Open all P switches 
+#define SWP_RCAL0                   (1<<0)    // PR0
+#define SWP_AIN1                    (1<<1)    // P2
+#define SWP_AIN2                    (1<<2)    // P3
+#define SWP_AIN3                    (1<<3)    // P4
+#define SWP_RE0                     (1<<4)    // P5
+#define SWP_RE1                     (1<<5)    // P6  AFE2 pin
+#define SWP_SE0                     (1<<6)    // P7
+#define SWP_DE0                     (1<<7)    // P8
+#define SWP_SE1                     (1<<8)    // P9  AFE3 pin
+#define SWP_DE1                     (1<<9)    // P10 reserved
+#define SWP_CE0                     (1<<10)   // P11 
+#define SWP_CE1                     (1<<11)   // P12 reserved
+#define SWP_PL                      (1<<13)   // PL
+#define SWP_PL2                     (1<<14)   // PL2
 /** @} */
 
 /**
  * @defgroup SWN_Const
  * @brief Switch N set. This is bitmask for register NSWFULLCON.
  * @details
+ *        Negative node of the excitation amplifier
  *        It's used to initialize structure @ref SWMatrixCfg_Type.
  *        The bitmasks can be OR'ed together. For example
  *          - `SWN_RCAL0|SWN_AIN1` means close SWN_RCAL0 and SWN_AIN1 in same time, and open all other N switches.
  *          - `SWN_SE0` means close SWN_SE0 and open all other N switches.
  * @{
 */
-#define SWN_OPEN                    0       /**< Open all N switches */
-#define SWN_RCAL1                   (1<<9)
-#define SWN_AIN0                    (1<<0)
-#define SWN_AIN1                    (1<<1)
-#define SWN_AIN2                    (1<<2)
-#define SWN_AIN3                    (1<<3)
-#define SWN_SE0LOAD                 (1<<4)  /**< SE0_LOAD is different from PIN SE0. It's the point after 100Ohm load resistor */
-#define SWN_DE0LOAD                 (1<<5)
-#define SWN_SE1LOAD                 (1<<6)
-#define SWN_DE1LOAD                 (1<<7)
-#define SWN_SE0                     (1<<8)  /**< SE0 here means the PIN SE0. */
-#define SWN_NL                      (1<<10)
-#define SWN_NL2                     (1<<11)
+#define SWN_OPEN                    0         // Open all N switches 
+#define SWN_RCAL1                   (1<<9)    // NR1
+#define SWN_AIN0                    (1<<0)    // N1
+#define SWN_AIN1                    (1<<1)    // N2
+#define SWN_AIN2                    (1<<2)    // N3
+#define SWN_AIN3                    (1<<3)    // N4
+#define SWN_SE0LOAD                 (1<<4)    // N5 SE0 pin via RLOAD_SE0.
+#define SWN_DE0LOAD                 (1<<5)    // N6 SE0 <<-- BUG in AD5940/AD5941 Datasheet?
+#define SWN_SE1LOAD                 (1<<6)    // N7 AFE3 pin via the RLOAD_AFE3 resistor.
+#define SWN_DE1LOAD                 (1<<7)    // N8 reserved
+#define SWN_SE0                     (1<<8)    // N9 SE0 pin, bypassing the RLOAD_SE0 resistor.
+#define SWN_NL                      (1<<10)   // NL
+#define SWN_NL2                     (1<<11)   // NL2
 /** @} */
 
 /**
  * @defgroup SWT_Const
  * @brief Switch T set. This is bitmask for register TSWFULLCON.
  * @details
+ *        Inverting input of the high speed TIA.
  *        It's used to initialize structure @ref SWMatrixCfg_Type.
  *        The bitmasks can be OR'ed together. For example
  *          - SWT_RCAL0|SWT_AIN1 means close SWT_RCAL0 and SWT_AIN1 in same time, and open all other T switches.
  *          - SWT_SE0LOAD means close SWT_SE0LOAD and open all other T switches.
  * @{
 */
-#define SWT_OPEN                    0         /**< Open all T switches */
-#define SWT_RCAL1                   (1<<11)
-#define SWT_AIN0                    (1<<0)
-#define SWT_AIN1                    (1<<1)
-#define SWT_AIN2                    (1<<2)
-#define SWT_AIN3                    (1<<3)
-#define SWT_SE0LOAD                 (1<<4)    /**< SE0_LOAD is different from PIN SE0. It's the point after 100Ohm load resistor */
-#define SWT_DE0                     (1<<5)    /**< Metal edit */
-#define SWT_SE1LOAD                 (1<<6)
-#define SWT_DE1                     (1<<7)    /**< Metal edit */
-#define SWT_TRTIA                   (1<<8)    /**< T9 switch. Connect RTIA to T matrix */
-#define SWT_DE0LOAD                 (1<<9)
-#define SWT_DE1LOAD                 (1<<10)
+#define SWT_OPEN                    0         // Open all T switches 
+#define SWT_RCAL1                   (1<<11)   // TR1
+#define SWT_AIN0                    (1<<0)    // T1 AIN0 pin via the T9 switch
+#define SWT_AIN1                    (1<<1)    // T2 AIN1 pin via the T9 switch
+#define SWT_AIN2                    (1<<2)    // T3 AIN2 pin via the T9 switch
+#define SWT_AIN3                    (1<<3)    // T4 AIN3 pin via the T9 switch.
+#define SWT_SE0LOAD                 (1<<4)    // T5 SE0 pin thru RLOAD_SE0 via the T9 switch
+#define SWT_DE0                     (1<<5)    // T6 RCALx path to the DE0 input to calibrate the RLOAD_DE0 and RTIA_DE0
+#define SWT_SE1LOAD                 (1<<6)    // T7 
+#define SWT_DE1                     (1<<7)    // T8 reserved
+#define SWT_TRTIA                   (1<<8)    // T9 used along with T1, T2, T3, T4, T5, and T6.
+#define SWT_DE0LOAD                 (1<<9)    // T10 DE0 pin
+#define SWT_DE1LOAD                 (1<<10)   // T11 reserved
 /** @} */
 
 /** @} Switch_Matrix_Block_Const */
@@ -2993,32 +2997,39 @@ enum ad5940_afe_result {
  * @brief ADC Channel P Configuration
  * @{
 */
-#define ADCMUXP_FLOAT               0x0
-#define ADCMUXP_HSTIA_P             0x1
-#define ADCMUXP_AIN0                0x4
-#define ADCMUXP_AIN1                0x5
-#define ADCMUXP_AIN2                0x6
-#define ADCMUXP_AIN3                0x7
-#define ADCMUXP_AVDD_2              0x8
-#define ADCMUXP_DVDD_2              0x9
-#define ADCMUXP_AVDDREG             0xA     /**< AVDD internal regulator output. It's around 1.8V */
-#define ADCMUXP_TEMP                0xB     /**< Internal temperature output */
-#define ADCMUXP_VSET1P1             0xC     /**< Internal 1.1V bias voltage */
-#define ADCMUXP_VDE0                0xD     /**< Voltage of DE0 pin  */
-#define ADCMUXP_VSE0                0xE     /**< Voltage of SE0 pin  */
-#define ADCMUXP_VREF2P5             0x10    /**< The internal 2.5V reference buffer output. */
-#define ADCMUXP_VREF1P8DAC          0x12    /**< HSDAC 1.8V internal reference. It's only available when both AFECON.BIT20 and AFECON.BIT6 are set. */
-#define ADCMUXP_TEMPN               0x13    /**< Internal temperature output */
-#define ADCMUXP_AIN4                0x14    /**< Voltage of AIN4/LPF0 pin  */
-#define ADCMUXP_AIN6                0x16    /**< Voltage of AIN6 pin, not available on AD5941  */
-#define ADCMUXP_VZERO0              0x17    /**< Voltage of Vzero0 pin  */
-#define ADCMUXP_VBIAS0              0x18    /**< Voltage of Vbias0 pin  */
-#define ADCMUXP_VCE0                0x19
-#define ADCMUXP_VRE0                0x1A
-#define ADCMUXP_VCE0_2              0x1F    /**< VCE0 divide by 2 */
-#define ADCMUXP_LPTIA0_P            0x21
-#define ADCMUXP_AGND                0x23
-#define ADCMUXP_P_NODE              0x24    /**< Buffered voltage of excitation buffer P node.  */
+
+#define ADCMUXP_FLOAT        0x0   // Floating input.
+#define ADCMUXP_HSTIA_P      0x1   // High speed TIA positive signal.
+#define ADCMUXP_AIN0         0x4   // External analog input AIN0.
+#define ADCMUXP_AIN1         0x5   // External analog input AIN1.
+#define ADCMUXP_AIN2         0x6   // External analog input AIN2.
+#define ADCMUXP_AIN3         0x7   // External analog input AIN3 / BUF_VREF1V8.
+#define ADCMUXP_AVDD_2       0x8   // AVDD/2.
+#define ADCMUXP_DVDD_2       0x9   // DVDD/2.
+#define ADCMUXP_AVDDREG_2    0xA   // AVDD_REG/2 (~1.8 V).
+#define ADCMUXP_TEMP         0xB   // Internal temperature sensor (positive).
+#define ADCMUXP_VSET1P1      0xC   // VBIAS_CAP (~1.1 V bias capacitor node).
+#define ADCMUXP_VDE0         0xD   // Voltage at DE0 pin.
+#define ADCMUXP_VSE0         0xE   // Voltage at SE0 pin.
+#define ADCMUXP_AFE3         0xF   // Voltage at AFE3 pin.
+#define ADCMUXP_VREF1P25     0x10  // 1.25 V (internal 2.5 V reference / 2).
+#define ADCMUXP_VREF1P8DAC   0x12  // HSDAC 1.8 V internal reference.
+#define ADCMUXP_TEMPN        0x13  // Negative terminal of internal temp sensor (TEMPSEN_N).
+#define ADCMUXP_AIN4         0x14  // AIN4 / LPF0 pin.
+#define ADCMUXP_AIN6         0x16  // AIN6 (AD5940 only).
+#define ADCMUXP_VZERO0       0x17  // VZERO0 pin.
+#define ADCMUXP_VBIAS0       0x18  // VBIAS0 pin.
+#define ADCMUXP_VCE0         0x19  // Voltage on CE0 pin.
+#define ADCMUXP_VRE0         0x1A  // Voltage on RE0 pin.
+#define ADCMUXP_AFE4         0x1B  // Voltage of AFE4 pin.
+#define ADCMUXP_RESERVED1C   0x1C  // Reserved.
+#define ADCMUXP_AFE1         0x1D  // Voltage of AFE1 pin.
+#define ADCMUXP_AFE2         0x1E  // Voltage of AFE2 pin.
+#define ADCMUXP_VCE0_2       0x1F  // VCE0 / 2.
+#define ADCMUXP_LPTIA0_P     0x21  // Low power TIA positive output (LPTIA_P).
+#define ADCMUXP_AGND_REF     0x23  // AGND_REF.
+#define ADCMUXP_P_NODE       0x24  // Buffered voltage of excitation buffer P node.
+
 /**@}*/
 
 /**
@@ -3026,20 +3037,23 @@ enum ad5940_afe_result {
  * @brief ADC Channel N Configuration
  * @{
 */
-#define ADCMUXN_FLOAT               0x0
-#define ADCMUXN_HSTIA_N             0x1
-#define ADCMUXN_LPTIA0_N            0x2
-#define ADCMUXN_AIN0                0x4
-#define ADCMUXN_AIN1                0x5
-#define ADCMUXN_AIN2                0x6
-#define ADCMUXN_AIN3                0x7
-#define ADCMUXN_VSET1P1             0x8
-#define ADCMUXN_TEMPN               0xB
-#define ADCMUXN_AIN4                0xC
-#define ADCMUXN_AIN6                0xE
-#define ADCMUXN_VZERO0              0x10
-#define ADCMUXN_VBIAS0              0x11
-#define ADCMUXN_N_NODE              0x14    /**< Buffered voltage of excitation buffer N node.  */
+#define ADCMUXN_FLOAT        0x0   // Floating input.
+#define ADCMUXN_HSTIA_N      0x1   // High speed TIA negative input.
+#define ADCMUXN_LPTIA0_N     0x2   // Low power TIA negative input.
+#define ADCMUXN_AIN0         0x4   // External analog input AIN0.
+#define ADCMUXN_AIN1         0x5   // External analog input AIN1.
+#define ADCMUXN_AIN2         0x6   // External analog input AIN2.
+#define ADCMUXN_AIN3         0x7   // External analog input AIN3 / BUF_VREF1V8.
+#define ADCMUXN_VSET1P1      0x8   // VBIAS_CAP (1.1 V bias capacitor node).
+#define ADCMUXN_TEMPN        0xB   // Temperature sensor negative output (TEMPSEN_N).
+#define ADCMUXN_AIN4         0xC   // External analog input AIN4 / LPF0.
+#define ADCMUXN_AIN6         0xE   // External analog input AIN6 (AD5940 only).
+#define ADCMUXN_VZERO0       0x10  // VZERO0 pin.
+#define ADCMUXN_VBIAS0       0x11  // VBIAS0 pin.
+#define ADCMUXN_N_NODE       0x14  // Negative node of excitation amplifier.
+#define ADCMUXN_RESERVED15   0x15  // Reserved.
+#define ADCMUXN_RESERVED16   0x16  // Reserved.
+                                   
 /** @} */
 
 /**

--- a/drivers/afe/ad5940/bia_measurement.c
+++ b/drivers/afe/ad5940/bia_measurement.c
@@ -515,8 +515,8 @@ static int AppBiaRtiaCal(struct ad5940_dev *dev)
 		}
 		AppBiaCfg.RtiaCurrValue[AppBiaCfg.SweepCfg.SweepIndex] =
 			AppBiaCfg.RtiaCalTable[i][0];
-		AppBiaCfg.RtiaCurrValue[AppBiaCfg.SweepCfg.SweepIndex] =
-			AppBiaCfg.RtiaCalTable[i][0];
+		AppBiaCfg.RtiaCurrValue[AppBiaCfg.SweepCfg.SweepIndex+1] =
+			AppBiaCfg.RtiaCalTable[i][1];
 		AppBiaCfg.SweepCfg.SweepIndex = 0; /* Reset index */
 	} else {
 		hsrtia_cal.fFreq = AppBiaCfg.SinFreq;


### PR DESCRIPTION
## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [ x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ x] I have performed a self-review of the changes
- [ x] I have commented my code, at least hard-to-understand parts
- [ x] I have build all projects affected by the changes in this PR
- [x ] I have tested in hardware affected projects, at the relevant boards
- [ x] I have signed off all commits from this PR
- [x ] I have updated the documentation (wiki pages, ReadMe etc), if applies
