### PR TITLE
drivers:adf4368: fix voltage level configuration

### DIFF
--- a/drivers/frequency/adf4368/adf4368.c
+++ b/drivers/frequency/adf4368/adf4368.c
@@ -1924,13 +1924,13 @@ int adf4368_init(struct adf4368_dev **dev,
 	if (ret)
 		goto error_spi;
 
-	ret = adf4368_check_scratchpad(device);
+	ret = adf4368_spi_write(device, 0x15,
+				no_os_field_prep(ADF4368_CMOS_OV_MSK,
+						device->cmos_3v3));
 	if (ret)
 		goto error_spi;
 
-	ret = adf4368_spi_write(device, 0x3D,
-				no_os_field_prep(ADF4368_CMOS_OV_MSK,
-						device->cmos_3v3));
+	ret = adf4368_check_scratchpad(device);
 	if (ret)
 		goto error_spi;
 


### PR DESCRIPTION




## Pull Request Description

- fix the register from 0x3d to 0x15
- fix the sequence so that the level is configured prior to the scratchpad test

Closes #2718

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
