### PR TITLE
drivers:dac:ltc2672: Add support for LTC2662 devices

### DIFF
--- a/projects/dc2903a/src.mk
+++ b/projects/dc2903a/src.mk
@@ -17,6 +17,7 @@ SRCS += $(DRIVERS)/dac/ltc2672/ltc2672.c
 INCS += $(INCLUDE)/no_os_delay.h        \
         $(INCLUDE)/no_os_error.h        \
         $(INCLUDE)/no_os_print_log.h    \
+        $(INCLUDE)/no_os_gpio.h         \
         $(INCLUDE)/no_os_spi.h          \
         $(INCLUDE)/no_os_irq.h          \
         $(INCLUDE)/no_os_list.h         \
@@ -32,6 +33,7 @@ INCS += $(INCLUDE)/no_os_delay.h        \
 SRCS += $(NO-OS)/util/no_os_lf256fifo.c \
         $(DRIVERS)/api/no_os_irq.c      \
         $(DRIVERS)/api/no_os_timer.c    \
+        $(DRIVERS)/api/no_os_gpio.c     \
         $(DRIVERS)/api/no_os_spi.c      \
         $(DRIVERS)/api/no_os_dma.c      \
         $(DRIVERS)/api/no_os_uart.c     \


### PR DESCRIPTION
1. Add support for LTC2662_12 and LTC2662_16 devices
2. Add support for functions ltc2672_remove_gpio(), ltc2672_cfg_reset(), ltc2672_reset(), ltc2672_write_input_register_channel(), ltc2672_write_input_register_all_channels(), ltc2672_update_channel(), ltc2672_update_all_channels(), ltc2672_hw_ldac_update()
3. Generate 32 bits command instead of 24 bits

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
