### PR TITLE
drivers:stm32:pwm: Change pwm_frequency in _compute_period_ticks() from float to double

### DIFF
--- a/drivers/platform/stm32/stm32_pwm.c
+++ b/drivers/platform/stm32/stm32_pwm.c
@@ -56,7 +56,7 @@ static uint32_t _compute_period_ticks(uint32_t (*get_timer_clock)(void),
 				      uint32_t prescaler,
 				      uint32_t period_ns)
 {
-	float pwm_frequency;
+	double pwm_frequency;
 	uint32_t timer_frequency_hz;
 	uint32_t period;
 


### PR DESCRIPTION
Change the datatype of pwm_frequency for improved precision in period tick computation

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
