### PR TITLE
drivers: platform: maxim: max32655: Fix TRNG Compilation

### DIFF
--- a/drivers/platform/maxim/max32655/maxim_trng.c
+++ b/drivers/platform/maxim/max32655/maxim_trng.c
@@ -33,6 +33,7 @@
 *******************************************************************************/
 
 #include "trng.h"
+#include "maxim_trng.h"
 #include "no_os_util.h"
 #include "no_os_alloc.h"
 #include "no_os_error.h"


### PR DESCRIPTION
Add maxim_trng.h to MAX32655 TRNG source file. Breaks compilation otherwise.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
