### PR TITLE
Madura set clkgen rates early in DMA_EXAMPLE

### DIFF
--- a/projects/adrv902x/src/examples/dma_example/dma_example.c
+++ b/projects/adrv902x/src/examples/dma_example/dma_example.c
@@ -387,15 +387,17 @@ int dma_example_main(void)
 		      AXI_ADC_MMCM_RSTN | AXI_ADC_RSTN);
 #endif
 
-	status = adrv9025_post_setup(phy);
-	if (status) {
-		pr_err("error: adrv9025_post_setup() failed\n");
-		goto error_11;
-	}
+	no_os_mdelay(100);
 
 	status = clkgen_setup(&rx_clkgen, &tx_clkgen, &orx_clkgen);
 	if (status)
+		goto error_11;
+
+	status = adrv9025_post_setup(phy);
+	if (status) {
+		pr_err("error: adrv9025_post_setup() failed\n");
 		goto error_12;
+	}
 
 	status = axi_dmac_init(&tx_dmac, &tx_dmac_init);
 	if (status) {


### PR DESCRIPTION
## Pull Request Description

adrv902x: dma_example: Set clkgen rates early

Move clkgen setup earlier in the project flow so that
phy->tx_dac->clock_hz is set correctly in phy->tx_dac->clock_hz.

Add delay before clkgen setup so that clkgen PLL lock.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
