### PR TITLE
drivers: rf-transceiver: ad9361: fix icp_val exceeding 6 bits

### DIFF
--- a/drivers/rf-transceiver/ad9361/ad9361.c
+++ b/drivers/rf-transceiver/ad9361/ad9361.c
@@ -6646,7 +6646,7 @@ int32_t ad9361_bbpll_set_rate(struct refclk_scale *clk_priv, uint32_t rate,
 	/* 25uA/LSB, Offset 25uA */
 	icp_val = NO_OS_DIV_ROUND_CLOSEST((uint32_t)tmp, 25U) - 1;
 
-	icp_val = no_os_clamp(icp_val, 1, 64);
+	icp_val = no_os_clamp(icp_val, 1, 63);
 
 	ad9361_spi_write(spi, REG_CP_CURRENT, icp_val);
 	ad9361_spi_writem(spi, REG_LOOP_FILTER_3, lf_defaults,


### PR DESCRIPTION
## Pull Request Description

Currently the icp_val is clamped to 64. This is 7 bits and bleeds into the "Must be 0" section violating the datasheet, this change clamps it correctly to 63

<img width="1103" height="70" alt="image" src="https://github.com/user-attachments/assets/bee0b1f7-441b-4dff-8a86-747ae5277fac" />

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
