### PR TITLE
drivers:rf-transceiver:ad9361: Fix null pointer dereference in ad9361_rfpll_vco_init

### DIFF
--- a/drivers/rf-transceiver/ad9361/ad9361.c
+++ b/drivers/rf-transceiver/ad9361/ad9361.c
@@ -1746,7 +1746,7 @@ static int32_t ad9361_rfpll_vco_init(struct ad9361_rf_phy *phy,
 				     uint32_t ref_clk)
 {
 	struct no_os_spi_desc *spi = phy->spi;
-	const struct SynthLUT(*tab);
+	const struct SynthLUT(*tab) = NULL;
 	int32_t i = 0;
 	uint32_t range, offs = 0;
 
@@ -1773,6 +1773,12 @@ static int32_t ad9361_rfpll_vco_init(struct ad9361_rf_phy *phy,
 			else
 				phy->current_rx_use_tdd_table = true;
 		}
+	}
+
+	if (tab == NULL) {
+		dev_err(&phy->spi->dev,
+			"%s: Failed to find suitable SynthLUT table", __func__);
+		return -EINVAL;
 	}
 
 	if (tx)


### PR DESCRIPTION
## Pull Request Description

In FDD mode if the Tx and Rx frequencies are the same (as is the case in the example code) then a null pointer is dereferenced as the SynthLUT *tab pointer is not initialised

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
