### PR TITLE
build_projects.yml: skip projects build if it's a documentation PR

### DIFF
--- a/build_projects.yml
+++ b/build_projects.yml
@@ -25,7 +25,24 @@ variables:
     value: $(Build.SourceBranchName)
 
 jobs:
+- job: CheckLabel
+  pool:
+    vmImage: ubuntu-latest
+  steps:
+  - bash: |
+      sudo apt install curl
+      if curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | grep '"name": "documentation"'
+      then
+        echo "##vso[task.setvariable variable=prHasLabel;isOutput=true]true"
+        echo "[INFO] documentation label found, skipping build!"
+      fi
+    displayName: Check for documentation label on PR
+    condition: eq(variables['Build.Reason'], 'PullRequest')
+    name: checkPrLabel
+
 - job: Xilinx
+  dependsOn: CheckLabel
+  condition: or(not(eq(variables['Build.Reason'], 'PullRequest')), not(eq(dependencies.build_and_static_validation.outputs['checkPrLabel.prHasLabel'], true)))
   timeoutInMinutes: 200
   pool:
     name: Default
@@ -61,6 +78,8 @@ jobs:
       publishLocation: 'pipeline'
 
 - job: STM32
+  dependsOn: CheckLabel
+  condition: or(not(eq(variables['Build.Reason'], 'PullRequest')), not(eq(dependencies.build_and_static_validation.outputs['checkPrLabel.prHasLabel'], true)))
   timeoutInMinutes: 200
   pool:
     name: Default
@@ -94,6 +113,8 @@ jobs:
       publishLocation: 'pipeline'
 
 - job: Maxim
+  dependsOn: CheckLabel
+  condition: or(not(eq(variables['Build.Reason'], 'PullRequest')), not(eq(dependencies.build_and_static_validation.outputs['checkPrLabel.prHasLabel'], true)))
   timeoutInMinutes: 200
   pool:
     name: Default
@@ -127,6 +148,8 @@ jobs:
       publishLocation: 'pipeline'
 
 - job: Mbed
+  dependsOn: CheckLabel
+  condition: or(not(eq(variables['Build.Reason'], 'PullRequest')), not(eq(dependencies.build_and_static_validation.outputs['checkPrLabel.prHasLabel'], true)))
   timeoutInMinutes: 200
   pool:
     name: Default
@@ -160,6 +183,8 @@ jobs:
       publishLocation: 'pipeline'
 
 - job: Pico
+  dependsOn: CheckLabel
+  condition: or(not(eq(variables['Build.Reason'], 'PullRequest')), not(eq(dependencies.build_and_static_validation.outputs['checkPrLabel.prHasLabel'], true)))
   timeoutInMinutes: 200
   pool:
     name: Default
@@ -193,6 +218,8 @@ jobs:
       publishLocation: 'pipeline'
 
 - job: ADuCM3029
+  dependsOn: CheckLabel
+  condition: or(not(eq(variables['Build.Reason'], 'PullRequest')), not(eq(dependencies.build_and_static_validation.outputs['checkPrLabel.prHasLabel'], true)))
   timeoutInMinutes: 200
   pool:
     name: Default
@@ -226,6 +253,8 @@ jobs:
       publishLocation: 'pipeline'
 
 - job: Unit_tests
+  dependsOn: CheckLabel
+  condition: or(not(eq(variables['Build.Reason'], 'PullRequest')), not(eq(dependencies.build_and_static_validation.outputs['checkPrLabel.prHasLabel'], true)))
   pool:
     vmImage: ubuntu-latest
   steps:


### PR DESCRIPTION
## Pull Request Description

If the documentation label is set to the opened PR then we skip the projects building jobs.
The condition on the jobs is: if the build reason is different from PR build anyway, and if it's a PR, build just if the documentation label is not found.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [x] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
