### PR TITLE
projects: ad405x: Fixup Makefile default and dangling header

### DIFF
--- a/projects/ad405x/Makefile
+++ b/projects/ad405x/Makefile
@@ -1,4 +1,4 @@
-EXAMPLE ?= basic
+EXAMPLE ?= basic_example
 
 # Select the device you want to enable, the following are supported:
 # AD4050, AD4052, AD4056, AD4058, AD4060, AD4062

--- a/projects/ad405x/src/examples/basic_example/basic_example.c
+++ b/projects/ad405x/src/examples/basic_example/basic_example.c
@@ -40,7 +40,6 @@
 #include "common_data.h"
 #include "no_os_print_log.h"
 #include "ad405x.h"
-#include "basic_example.h"
 
 /***************************************************************************//**
  * @brief Basic example main executiont.


### PR DESCRIPTION
## Pull Request Description

The makefile EXAMPLE value must match the directory, not file name.
The example header doesn't exist in the new directory format.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
