### PR TITLE
drivers: imu: adis : Fix reset delay

### DIFF
--- a/drivers/imu/adis.c
+++ b/drivers/imu/adis.c
@@ -116,7 +116,7 @@ int adis_init(struct adis_dev **adis, const struct adis_init_param *ip)
 						  NO_OS_GPIO_LOW);
 		if (ret)
 			goto error;
-		no_os_mdelay(dev->info->timeouts->reset_ms);
+		no_os_mdelay(ip->info->timeouts->reset_ms);
 	}
 
 	dev->info = ip->info;


### PR DESCRIPTION
## Pull Request Description

Fix delay for the RESET pin, so that the value from the initialization parameter is used instead of the device descriptor, since at that specific initialization, the device descriptor's information is not correct yet and that may result in incorrect behavior such as a longer than expected/needed delay.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
