### PR TITLE
drivers: adc: ad7768: Fix DCLK divider register encoding

### DIFF
--- a/drivers/adc/ad7768/ad7768.h
+++ b/drivers/adc/ad7768/ad7768.h
@@ -102,7 +102,7 @@
 #define AD7768_INTERFACE_CFG_CRC_SEL(x)			(((x) & 0x3) << 2)
 #define AD7768_INTERFACE_CFG_DCLK_DIV(x)		(((x) & 0x3) << 0)
 #define AD7768_INTERFACE_CFG_DCLK_DIV_MSK		NO_OS_GENMASK(1, 0)
-#define AD7768_INTERFACE_CFG_DCLK_DIV_MODE(x)		(4 - no_os_find_first_set_bit(x))
+#define AD7768_INTERFACE_CFG_DCLK_DIV_MODE(x)		(3 - no_os_find_first_set_bit(x))
 #define AD7768_MAX_DCLK_DIV				8
 
 #define AD7768_RESOLUTION				24


### PR DESCRIPTION
## Pull Request Description

Fix off-by-one error in AD7768_INTERFACE_CFG_DCLK_DIV_MODE macro. The macro was incorrectly calculating register values, causing wrong DCLK division settings to be written to hardware.

Corrected mapping:
- Divide by 8 → 0 (bits 00)
- Divide by 4 → 1 (bits 01)
- Divide by 2 → 2 (bits 10)
- Divide by 1 → 3 (bits 11)

Fixes: 5f17a1b0bebb ("drivers: adc: ad7768: Update driver")

Issue: https://github.com/analogdevicesinc/no-OS/issues/2792

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
