### PR TITLE
drivers: frequency: admv1014: Fix Q channel gain assignment

### DIFF
--- a/drivers/frequency/admv1014/admv1014.c
+++ b/drivers/frequency/admv1014/admv1014.c
@@ -284,7 +284,7 @@ int admv1014_get_if_amp_gain(struct admv1014_dev *dev, uint8_t *i_coarse_gain,
 	if (ret)
 		return ret;
 
-	*i_coarse_gain = no_os_field_get(ADMV1014_IF_AMP_COARSE_GAIN_Q_MSK, data);
+	*q_coarse_gain = no_os_field_get(ADMV1014_IF_AMP_COARSE_GAIN_Q_MSK, data);
 
 	return 0;
 }


### PR DESCRIPTION
## Pull Request Description

Fix incorrect variable assignment in admv1014_get_if_amp_gain function where the Q channel coarse gain was being assigned to the I channel gain pointer instead of the Q channel gain pointer.

Fixes: 101b911cbbd3 ("drivers: frequency: admv1014: Add support for ADMV1014")

Issue: https://github.com/analogdevicesinc/no-OS/issues/2731

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
