### PR TITLE
util: Add missing no_os_find_last_set_bit_u64 function

### DIFF
--- a/include/no_os_util.h
+++ b/include/no_os_util.h
@@ -137,6 +137,7 @@ uint32_t no_os_find_first_set_bit(uint32_t word);
 uint64_t no_os_find_first_set_bit_u64(uint64_t word);
 /* Find last set bit in word. */
 uint32_t no_os_find_last_set_bit(uint32_t word);
+uint64_t no_os_find_last_set_bit_u64(uint64_t word);
 /* Locate the closest element in an array. */
 uint32_t no_os_find_closest(int32_t val,
 			    const int32_t *array,

--- a/util/no_os_util.c
+++ b/util/no_os_util.c
@@ -90,6 +90,24 @@ uint32_t no_os_find_last_set_bit(uint32_t word)
 }
 
 /**
+ * Find last set bit in word.
+ */
+uint64_t no_os_find_last_set_bit_u64(uint64_t word)
+{
+	uint64_t bit = 0;
+	uint64_t last_set_bit = 64;
+
+	while (word) {
+		if (word & 0x1)
+			last_set_bit = bit;
+		word >>= 1;
+		bit ++;
+	}
+
+	return last_set_bit;
+}
+
+/**
  * Locate the closest element in an array.
  */
 uint32_t no_os_find_closest(int32_t val,


### PR DESCRIPTION
## Pull Request Description

Add the missing 64-bit version of no_os_find_last_set_bit to provide complete coverage for bit manipulation operations.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
