### PR TITLE
ci: tests: fix JUnit XML report generation

### DIFF
--- a/tests/drivers/imu/project.yml
+++ b/tests/drivers/imu/project.yml
@@ -95,8 +95,9 @@
   :test: []
   :release: []
 
-:junit_tests_report:
-  :artifact_filename: report_junit.xml
+:report_tests_log_factory:
+  :reports:
+    - junit
 
 :plugins:
   :enabled:

--- a/tests/drivers/led/project.yml
+++ b/tests/drivers/led/project.yml
@@ -94,8 +94,9 @@
   :test: []
   :release: []
 
-:junit_tests_report:
-  :artifact_filename: report_junit_original.xml
+:report_tests_log_factory:
+  :reports:
+    - junit
 
 :plugins:
   :enabled:


### PR DESCRIPTION
## Pull Request Description

Update test configurations to use correct Ceedling format for JUnit XML report generation. Replace deprecated :junit_tests_report section with :report_tests_log_factory configuration.

This fixes the CI warning "No test result files matching 'tests/drivers/**/build/artifacts/test/*.xml' were found" by enabling proper XML output generation.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
