### PR TITLE
doc: sphinx: pin sphinx version to < 9.0

### DIFF
--- a/doc/sphinx/source/requirements.txt
+++ b/doc/sphinx/source/requirements.txt
@@ -1,3 +1,3 @@
-sphinx
+sphinx<9.0
 lxml
 https://github.com/analogdevicesinc/doctools/releases/download/latest/adi-doctools.tar.gz


### PR DESCRIPTION
## Pull Request Description

Pin Sphinx version to < 9.0 to avoid compatibility issues with adi-doctools.

Sphinx 9.0 introduced breaking changes where the 'backrefs' attribute is no longer always present in node attributes, causing a KeyError in adi-doctools directive/node.py:18.

This change ensures compatibility until adi-doctools is updated to handle the Sphinx 9.0 changes.
<img width="817" height="292" alt="image" src="https://github.com/user-attachments/assets/e6226373-ad2e-459f-9284-f1a039278b06" />

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies

