### PR TITLE
driver: Add network support for Xilinx boards

### DIFF
--- a/doc/sphinx/source/drivers/net/xemacps.rst
+++ b/doc/sphinx/source/drivers/net/xemacps.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../../drivers/net/xemacps/README.rst

--- a/doc/sphinx/source/drivers_doc.rst
+++ b/doc/sphinx/source/drivers_doc.rst
@@ -202,6 +202,7 @@ ETHERNET
    :glob:
 
    drivers/ethernet/*
+   drivers/net/*
 
 GYROSCOPES
 ============

--- a/doc/sphinx/source/projects/net/xilinx_lwip.rst
+++ b/doc/sphinx/source/projects/net/xilinx_lwip.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../../projects/xilinx_lwip/README.rst

--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -8,7 +8,8 @@ SKIPDIR = -path ./platform -prune -o \
 	-path ./rf-transceiver/koror -prune -o	\
 	-path ./rf-transceiver/palma -prune -o	\
 	-path ./net/oa_tc6 -prune -o \
-	-path ./motor/tmc5240 -prune -o
+	-path ./motor/tmc5240 -prune -o \
+	-path ./net/xemacps -prune -o
 
 INCLUDES = -I../include/ \
 	 -I../projects/drivers/util/ \

--- a/drivers/net/xemacps/README.rst
+++ b/drivers/net/xemacps/README.rst
@@ -1,0 +1,207 @@
+XEmacPs no-OS Driver
+=====================
+
+Supported Devices
+-----------------
+
+- Xilinx Zynq-7000 SoC (GEM v2)
+- Xilinx ZynqMP / Versal (GEM v3+)
+
+Overview
+--------
+
+The XEmacPs driver is a standalone, bare-metal MAC driver for the
+Processing System Gigabit Ethernet MAC (PS GEM) found in the Xilinx
+Zynq-7000 and ZynqMP SoC families. It uses polling (no IRQs) and
+copy-mode DMA to send and receive raw Ethernet frames, with no
+dependency on any network stack. An upper layer such as the no-OS lwIP
+glue (``lwip_xemacps``) can be used to connect this driver to a TCP/IP
+stack.
+
+Buffer descriptor memory is placed in a dedicated 1 MB uncached region
+marked as ``DEVICE_MEMORY`` via ``Xil_SetTlbAttributes()``, eliminating
+cache-coherency races between the CPU and the GEM DMA engine. Frame data
+buffers are cache-line aligned and use explicit cache maintenance
+(flush before TX, invalidate after RX).
+
+PHY Handling
+~~~~~~~~~~~~
+
+During initialization the driver scans all 32 MDIO addresses (0-31)
+by reading the PHY ID registers (registers 2 and 3). The first address
+that returns valid, non-zero, non-0xFFFF values for both registers is
+selected as the active PHY. This means the ``phy_addr`` field in the
+initialization parameters is unused - the driver always auto-detects
+the PHY address.
+
+If the detected PHY is a Marvell 88E151x (matched by OUI), the driver
+automatically configures RGMII TX/RX timing delays via page-2 register
+21 and issues a soft-reset so the new timing takes effect. Non-Marvell
+PHYs skip this step.
+
+After PHY detection and configuration, the driver starts
+auto-negotiation. The ``xemacps_poll()`` function monitors the PHY link
+state via BMSR: when the link comes up it reads the negotiated speed
+(10/100/1000 Mbps) and programs the MAC accordingly. When the link
+drops, it restarts auto-negotiation so the PHY re-negotiates
+automatically when the cable is reconnected.
+
+GEM v2 Errata Workaround
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The driver includes an automatic workaround for the Zynq-7000 GEM v2
+silicon errata (`AR# 52028
+<https://adaptivesupport.amd.com/s/article/52028>`_), where the RX data
+path can lock up under heavy traffic of small frames. The workaround
+flushes the RX packet buffer on every resource error and resets the RX
+path when inactivity is detected. It is gated on runtime GEM version
+detection and only activates on GEM v2.
+
+GEM v3+ Queue Parking
+~~~~~~~~~~~~~~~~~~~~~~
+
+On ZynqMP (GEM v3+), the MAC exposes multiple priority queues. This
+driver uses only queue 0 for RX and queue 1 for TX. Unused queues are
+parked with terminated buffer descriptors (WRAP + NEW for RX, WRAP +
+USED for TX) so the DMA engine does not access uninitialized memory.
+
+Applications
+------------
+
+- Industrial Ethernet networking on Zynq-based boards
+- IIO data acquisition over Ethernet
+- TCP/UDP server applications
+- Bare-metal network connectivity for sensor and control systems
+
+Device Configuration
+--------------------
+
+The driver exposes a small public API for initialization, data transfer,
+and polling. All functions are declared in ``no_os_xemacps.h``.
+
+Initialization and Resource Management
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``xemacps_init()`` function allocates the driver descriptor,
+configures the GEM controller registers (network configuration, DMA
+configuration, buffer descriptors), scans the MDIO bus for a PHY,
+configures Marvell RGMII delays if applicable, starts auto-negotiation,
+and starts the MAC. The ``xemacps_remove()`` function stops the MAC and
+frees the descriptor.
+
+Data Transfer
+~~~~~~~~~~~~~
+
+The ``xemacps_send()`` function copies an Ethernet frame into a static
+TX buffer, flushes the D-cache, programs the TX buffer descriptor, and
+polls until the GEM sets the TxUsed bit. The ``xemacps_recv()`` function
+harvests a single completed RX buffer descriptor, copies the frame into
+the caller's buffer, and reposts the descriptor to hardware.
+
+Polling and Link State
+~~~~~~~~~~~~~~~~~~~~~~
+
+The ``xemacps_poll()`` function must be called once per polling cycle
+before the ``xemacps_recv()`` loop. It monitors the PHY link state via
+BMSR and configures the MAC operating speed when the link transitions
+up. When the link drops, it restarts auto-negotiation. If the link is
+down, RX processing is skipped entirely.
+
+On Zynq-7000 (``PLATFORM_ZYNQ``), ``xemacps_poll()`` also runs the
+AR# 52028 errata workaround and clears RX status error flags.
+
+The ``xemacps_get_link_state()`` function returns the current link
+state without polling the PHY - it returns the cached value from the
+last ``xemacps_poll()`` call.
+
+Multicast Filtering
+~~~~~~~~~~~~~~~~~~~
+
+The ``xemacps_set_mcast_hash()`` function adds a multicast MAC address
+to the GEM hash filter, enabling reception of frames destined for that
+multicast group (e.g. mDNS at ``01:00:5E:00:00:FB``).
+
+Build-time Feature Flags
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following defines can be set at build time (e.g. via
+``CFLAGS=-DGEM_PROMISC``) to toggle GEM features in the network
+configuration register:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Define
+     - Default
+     - Effect
+   * - ``GEM_PROMISC``
+     - off
+     - Receive all frames regardless of destination address
+   * - ``GEM_HALF_DUPLEX``
+     - off (full duplex)
+     - Disable full-duplex mode
+   * - ``GEM_NO_BROADCAST``
+     - off
+     - Reject broadcast frames
+   * - ``GEM_STRIP_FCS``
+     - off
+     - Strip FCS from received frames
+   * - ``GEM_NO_RX_CHKSUM``
+     - off (checksum on)
+     - Disable RX checksum offload
+   * - ``GEM_NO_PAUSE``
+     - off (pause on)
+     - Disable pause frame support
+   * - ``GEM_NO_MCAST_HASH``
+     - off (hash on)
+     - Disable multicast hash filter
+   * - ``GEM_UCAST_HASH``
+     - off
+     - Enable unicast hash filter
+   * - ``GEM_SGMII``
+     - off
+     - Enable SGMII / PCS mode (for PS GTR serial Ethernet)
+
+Driver Initialization Example
+------------------------------
+
+.. code-block:: C
+
+    #include <stdint.h>
+    #include "no_os_xemacps.h"
+
+    int main(void)
+    {
+        struct xemacps_init_param param = {
+            .device_id = 0,
+            .hwaddr    = {0x00, 0x0A, 0x35, 0x00, 0x01, 0x02},
+        };
+
+        struct xemacps_desc *desc;
+        uint8_t buf[XEMACPS_MAX_FRAME_SIZE];
+        uint32_t len;
+        int ret;
+
+        ret = xemacps_init(&desc, &param);
+        if (ret)
+            return ret;
+
+        /* Main polling loop */
+        while (1) {
+            xemacps_poll(desc);
+
+            if (!xemacps_get_link_state(desc))
+                continue;
+
+            ret = xemacps_recv(desc, buf, &len);
+            if (ret)
+                break;
+
+            if (len > 0) {
+                /* Process received frame in buf[0..len-1] */
+            }
+        }
+
+        xemacps_remove(desc);
+        return ret;
+    }

--- a/drivers/net/xemacps/README.rst
+++ b/drivers/net/xemacps/README.rst
@@ -24,31 +24,6 @@ cache-coherency races between the CPU and the GEM DMA engine. Frame data
 buffers are cache-line aligned and use explicit cache maintenance
 (flush before TX, invalidate after RX).
 
-PHY Handling
-~~~~~~~~~~~~
-
-During initialization the driver scans all 32 MDIO addresses (0-31)
-by reading the PHY ID registers (registers 2 and 3). The first address
-that returns valid, non-zero, non-0xFFFF values for both registers is
-selected as the active PHY. This means the ``phy_addr`` field in the
-initialization parameters is unused - the driver always auto-detects
-the PHY address.
-
-If the detected PHY is a Marvell 88E151x (matched by OUI), the driver
-automatically configures RGMII TX/RX timing delays via page-2 register
-21 and issues a soft-reset so the new timing takes effect. Non-Marvell
-PHYs skip this step.
-
-After PHY detection and configuration, the driver starts
-auto-negotiation. The ``xemacps_poll()`` function monitors the PHY link
-state via BMSR: when the link comes up it reads the negotiated speed
-(10/100/1000 Mbps) and programs the MAC accordingly. When the link
-drops, it restarts auto-negotiation so the PHY re-negotiates
-automatically when the cable is reconnected.
-
-GEM v2 Errata Workaround
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
 The driver includes an automatic workaround for the Zynq-7000 GEM v2
 silicon errata (`AR# 52028
 <https://adaptivesupport.amd.com/s/article/52028>`_), where the RX data
@@ -56,14 +31,6 @@ path can lock up under heavy traffic of small frames. The workaround
 flushes the RX packet buffer on every resource error and resets the RX
 path when inactivity is detected. It is gated on runtime GEM version
 detection and only activates on GEM v2.
-
-GEM v3+ Queue Parking
-~~~~~~~~~~~~~~~~~~~~~~
-
-On ZynqMP (GEM v3+), the MAC exposes multiple priority queues. This
-driver uses only queue 0 for RX and queue 1 for TX. Unused queues are
-parked with terminated buffer descriptors (WRAP + NEW for RX, WRAP +
-USED for TX) so the DMA engine does not access uninitialized memory.
 
 Applications
 ------------
@@ -84,10 +51,12 @@ Initialization and Resource Management
 
 The ``xemacps_init()`` function allocates the driver descriptor,
 configures the GEM controller registers (network configuration, DMA
-configuration, buffer descriptors), scans the MDIO bus for a PHY,
-configures Marvell RGMII delays if applicable, starts auto-negotiation,
-and starts the MAC. The ``xemacps_remove()`` function stops the MAC and
-frees the descriptor.
+configuration, buffer descriptors), starts PHY auto-negotiation, and
+starts the MAC. Initialization succeeds regardless of whether a PHY
+link is present - if no cable is connected, the driver starts with
+link down and ``xemacps_poll()`` will detect the link once it comes up.
+The ``xemacps_remove()`` function stops the MAC and frees the
+descriptor.
 
 Data Transfer
 ~~~~~~~~~~~~~
@@ -98,21 +67,18 @@ polls until the GEM sets the TxUsed bit. The ``xemacps_recv()`` function
 harvests a single completed RX buffer descriptor, copies the frame into
 the caller's buffer, and reposts the descriptor to hardware.
 
-Polling and Link State
-~~~~~~~~~~~~~~~~~~~~~~
+Polling, Link State, and Errata Handling
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``xemacps_poll()`` function must be called once per polling cycle
-before the ``xemacps_recv()`` loop. It monitors the PHY link state via
-BMSR and configures the MAC operating speed when the link transitions
-up. When the link drops, it restarts auto-negotiation. If the link is
-down, RX processing is skipped entirely.
+before the ``xemacps_recv()`` loop. It polls the PHY link state via
+BMSR, and when the link transitions up it reads the negotiated speed
+and configures the MAC accordingly. When the link drops, it restarts
+auto-negotiation so the PHY re-negotiates when the cable is
+reconnected. If the link is down, RX processing is skipped entirely.
 
 On Zynq-7000 (``PLATFORM_ZYNQ``), ``xemacps_poll()`` also runs the
 AR# 52028 errata workaround and clears RX status error flags.
-
-The ``xemacps_get_link_state()`` function returns the current link
-state without polling the PHY - it returns the cached value from the
-last ``xemacps_poll()`` call.
 
 Multicast Filtering
 ~~~~~~~~~~~~~~~~~~~
@@ -120,47 +86,6 @@ Multicast Filtering
 The ``xemacps_set_mcast_hash()`` function adds a multicast MAC address
 to the GEM hash filter, enabling reception of frames destined for that
 multicast group (e.g. mDNS at ``01:00:5E:00:00:FB``).
-
-Build-time Feature Flags
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The following defines can be set at build time (e.g. via
-``CFLAGS=-DGEM_PROMISC``) to toggle GEM features in the network
-configuration register:
-
-.. list-table::
-   :header-rows: 1
-
-   * - Define
-     - Default
-     - Effect
-   * - ``GEM_PROMISC``
-     - off
-     - Receive all frames regardless of destination address
-   * - ``GEM_HALF_DUPLEX``
-     - off (full duplex)
-     - Disable full-duplex mode
-   * - ``GEM_NO_BROADCAST``
-     - off
-     - Reject broadcast frames
-   * - ``GEM_STRIP_FCS``
-     - off
-     - Strip FCS from received frames
-   * - ``GEM_NO_RX_CHKSUM``
-     - off (checksum on)
-     - Disable RX checksum offload
-   * - ``GEM_NO_PAUSE``
-     - off (pause on)
-     - Disable pause frame support
-   * - ``GEM_NO_MCAST_HASH``
-     - off (hash on)
-     - Disable multicast hash filter
-   * - ``GEM_UCAST_HASH``
-     - off
-     - Enable unicast hash filter
-   * - ``GEM_SGMII``
-     - off
-     - Enable SGMII / PCS mode (for PS GTR serial Ethernet)
 
 Driver Initialization Example
 ------------------------------
@@ -174,6 +99,7 @@ Driver Initialization Example
     {
         struct xemacps_init_param param = {
             .device_id = 0,
+            .phy_addr  = 1,
             .hwaddr    = {0x00, 0x0A, 0x35, 0x00, 0x01, 0x02},
         };
 
@@ -189,9 +115,6 @@ Driver Initialization Example
         /* Main polling loop */
         while (1) {
             xemacps_poll(desc);
-
-            if (!xemacps_get_link_state(desc))
-                continue;
 
             ret = xemacps_recv(desc, buf, &len);
             if (ret)

--- a/drivers/net/xemacps/no_os_xemacps.c
+++ b/drivers/net/xemacps/no_os_xemacps.c
@@ -441,10 +441,14 @@ int xemacps_init(struct xemacps_desc **desc, struct xemacps_init_param *param)
 #endif
 #endif
 
-	cfg = XEmacPs_LookupConfig(param->device_id);
+#ifdef SDT
+	cfg = XEmacPs_LookupConfig((UINTPTR)param->device_id);
+#else
+	cfg = XEmacPs_LookupConfig((uint16_t)param->device_id);
+#endif
 	if (!cfg) {
-		printf("xemacps: LookupConfig failed for device %u\n",
-		       param->device_id);
+		printf("xemacps: LookupConfig failed for identifier 0x%lx\n",
+		       (unsigned long)param->device_id);
 		ret = -ENODEV;
 		goto free_desc;
 	}

--- a/drivers/net/xemacps/no_os_xemacps.c
+++ b/drivers/net/xemacps/no_os_xemacps.c
@@ -1,0 +1,814 @@
+/***************************************************************************//**
+ *   @file   no_os_xemacps.c
+ *   @brief  Standalone MAC driver for the Xilinx PS GEM (XEmacPs).
+ *
+ *   Provides init/remove/send/recv/poll for the Zynq-7000 / ZynqMP PS
+ *   Gigabit Ethernet MAC. Uses polling (no IRQs) and copy-mode DMA.
+ *   No network stack dependency - the upper layer (e.g. lwIP glue)
+ *   calls xemacps_send/recv with raw Ethernet frame buffers.
+ *
+ *   BD (buffer descriptor) memory is placed in a dedicated uncached region
+ *   following the Xilinx reference implementation (xemacpsif_dma.c).
+ *   Xil_SetTlbAttributes() only works with L1 page entries (1MB),
+ *   so a 1 MB static array is reserved and marked DEVICE_MEMORY.
+ *
+ *   This driver is limited to a single instance due to the static buffer
+ *   arrays (bd_space, tx_buf, rx_buf).
+ *
+ *   @author Nicolae-Daniel Deaconescu (Nicolae-daniel.Deaconescu@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <string.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+#include <xparameters.h>
+#include <xemacps.h>
+#include <xil_cache.h>
+#include <xil_mmu.h>
+
+#include "no_os_xemacps.h"
+#include "no_os_delay.h"
+#include "no_os_alloc.h"
+
+#define XGEM_BD_TO_INDEX(ringptr, bdptr) \
+	(((UINTPTR)(bdptr) - (UINTPTR)(ringptr)->BaseBdAddr) / (ringptr)->Separation)
+
+/* Uncached memory region for DMA buffer descriptors */
+static uint8_t bd_space[0x100000] __attribute__((aligned(0x100000)));
+static volatile uint32_t bd_space_index;
+
+/* DMA frame data buffers - static, cache-line aligned */
+static uint8_t tx_buf[XGEM_BUFF_SIZE]
+__attribute__((aligned(XGEM_CACHE_LINE_SIZE)));
+static uint8_t rx_buf[XGEM_RX_BD_COUNT][XGEM_BUFF_SIZE]
+__attribute__((aligned(XGEM_CACHE_LINE_SIZE)));
+
+/**
+ * @struct xemacps_desc
+ * @brief  Internal driver state for the XEmacPs MAC driver.
+ */
+struct xemacps_desc {
+	XEmacPs emac;
+
+	uint8_t *tx_bd_space;
+	uint32_t tx_bd_len;
+
+	uint8_t *rx_bd_space;
+	uint32_t rx_bd_len;
+
+	uint32_t last_rx_frms_cntr;
+	uint8_t phy_addr;
+	bool     link_up;
+};
+
+/**
+ * @brief Detect PHY address by scanning MDIO addresses 0-31.
+ *
+ * Reads PHY ID registers 2 and 3 at each address. A valid PHY returns
+ * non-zero, non-0xFFFF values for both registers.
+ *
+ * @param emac - XEmacPs instance.
+ * @return PHY address (0-31) on success, negative error code if not found.
+ */
+static int8_t xgem_detect_phy(XEmacPs *emac)
+{
+	uint16_t phyreg1, phyreg2;
+	uint8_t addr;
+	int ret;
+
+	for (addr = 0; addr <= 31; addr++) {
+		ret = XEmacPs_PhyRead(emac, addr,
+				      PHY_REG_PHYID1, &phyreg1);
+		ret |= XEmacPs_PhyRead(emac, addr,
+				       PHY_REG_PHYID2, &phyreg2);
+
+		if ((ret == XST_SUCCESS) &&
+		    (phyreg1 > 0x0000) && (phyreg1 < 0xFFFF) &&
+		    (phyreg2 > 0x0000) && (phyreg2 < 0xFFFF)) {
+			printf("xemacps: PHY found at addr %u "
+			       "(ID=0x%04x%04x)\n",
+			       addr, phyreg1, phyreg2);
+			return addr;
+		}
+	}
+
+	return -ENODEV;
+}
+
+/**
+ * @brief Configure RGMII TX/RX delays on a Marvell 88E151x PHY.
+ *
+ * @param emac     - XEmacPs instance.
+ * @param phy_addr - MDIO address of the PHY.
+ * @return 0 on success, negative error code on MDIO failure.
+ */
+static int32_t xgem_marvell_rgmii_delays(XEmacPs *emac, uint8_t phy_addr)
+{
+	uint16_t phyid1, phyid2, bmcr;
+	uint32_t oui;
+	int ret;
+
+	/* Verify this is a Marvell PHY */
+	ret = XEmacPs_PhyRead(emac, phy_addr, PHY_REG_PHYID1, &phyid1);
+	if (ret != XST_SUCCESS)
+		return -EIO;
+	ret = XEmacPs_PhyRead(emac, phy_addr, PHY_REG_PHYID2, &phyid2);
+	if (ret != XST_SUCCESS)
+		return -EIO;
+
+	oui = ((uint32_t)phyid1 << 6) | ((phyid2 >> 10) & 0x3F);
+	if (oui != MARVELL_PHY_ID) {
+		printf("xemacps: PHY OUI 0x%06x is not Marvell, "
+		       "skipping RGMII delay config\n", oui);
+		return 0;
+	}
+
+	printf("xemacps: Found Marvell OUI 0x%06x, "
+	       "model: 0X%02X\n", oui, (phyid2 >> 4) & 0x3F);
+
+	/* Switch to page 2 */
+	ret = XEmacPs_PhyWrite(emac, phy_addr, PHY_REG_PAGE, 0x02);
+	if (ret != XST_SUCCESS)
+		return -EIO;
+
+	ret = XEmacPs_PhyWrite(emac, phy_addr, MRVL_PAGE2_RGMII_CTRL,
+			       0x0030);
+	if (ret != XST_SUCCESS)
+		return -EIO;
+
+	/* Switch back to page 0 */
+	ret = XEmacPs_PhyWrite(emac, phy_addr, PHY_REG_PAGE, 0x00);
+	if (ret != XST_SUCCESS)
+		return -EIO;
+
+	/* Soft-reset the PHY so new timing takes effect */
+	ret = XEmacPs_PhyRead(emac, phy_addr, PHY_REG_BMCR, &bmcr);
+	if (ret != XST_SUCCESS)
+		return -EIO;
+
+	bmcr |= PHY_REG_BMCR_RESET;
+	ret = XEmacPs_PhyWrite(emac, phy_addr, PHY_REG_BMCR, bmcr);
+	if (ret != XST_SUCCESS)
+		return -EIO;
+
+	/* Wait for reset to complete (bit self-clears) */
+	no_os_mdelay(100);
+
+	printf("xemacps: Marvell PHY RGMII delays configured\n");
+	return 0;
+}
+
+/**
+ * @brief Restart auto-negotiation on the PHY.
+ * @param emac     - XEmacPs instance.
+ * @param phy_addr - MDIO address of the PHY.
+ * @return 0 on success, negative error code on MDIO failure.
+ */
+static int32_t xgem_phy_start_autonegotiation(XEmacPs *emac, uint8_t phy_addr)
+{
+	uint16_t bmcr;
+	int32_t ret;
+
+	ret = XEmacPs_PhyRead(emac, phy_addr, PHY_REG_BMCR, &bmcr);
+	if (ret != XST_SUCCESS)
+		return -EIO;
+
+	bmcr |= PHY_REG_BMCR_ANEGEN | PHY_REG_BMCR_RSTANEG;
+	ret = XEmacPs_PhyWrite(emac, phy_addr, PHY_REG_BMCR, bmcr);
+	if (ret != XST_SUCCESS)
+		return -EIO;
+
+	return 0;
+}
+
+/**
+ * @brief Read the negotiated link speed from PHY registers.
+ *
+ * Must only be called after auto-negotiation has completed.
+ *
+ * @param emac     - XEmacPs instance.
+ * @param phy_addr - MDIO address of the PHY.
+ * @return Link speed in Mbps (10, 100, or 1000).
+ */
+static int16_t xgem_phy_get_speed(XEmacPs *emac, uint8_t phy_addr)
+{
+	uint16_t stat1000, anlpar;
+
+	XEmacPs_PhyRead(emac, phy_addr, PHY_REG_1000STAT, &stat1000);
+	if (stat1000 & (PHY_REG_1000STAT_LP_FD | PHY_REG_1000STAT_LP_HD))
+		return 1000;
+
+	XEmacPs_PhyRead(emac, phy_addr, PHY_REG_ANLPAR, &anlpar);
+	if (anlpar & (PHY_REG_ANLPAR_100FD | PHY_REG_ANLPAR_100HD))
+		return 100;
+
+	return 10;
+}
+
+/**
+ * @brief Re-post RX BDs to hardware after harvesting completed frames.
+ * @param d     - Driver descriptor.
+ * @param count - Number of BDs to re-submit.
+ * @param bd    - First BD of the set (from a prior BdRingAlloc).
+ * @return 0 on success, negative error code otherwise.
+ */
+static int32_t xgem_rx_submit(struct xemacps_desc *d, uint32_t count,
+			      XEmacPs_Bd *bd)
+{
+	XEmacPs_BdRing *rx_ring = &XEmacPs_GetRxRing(&d->emac);
+	XEmacPs_Bd *cur_bd = bd;
+	uint8_t *buf;
+	uint32_t i;
+
+	for (i = 0; i < count; i++) {
+		buf = (uint8_t *)(uintptr_t)(XEmacPs_BdRead(cur_bd, 0U) & ~0x3UL);
+		Xil_DCacheInvalidateRange((uintptr_t)buf, XGEM_BUFF_SIZE);
+
+		XEmacPs_BdWrite(cur_bd, XEMACPS_BD_STAT_OFFSET, 0);
+		dsb();
+
+		XEmacPs_BdClearRxNew(cur_bd);
+
+		if (i < count - 1)
+			cur_bd = XEmacPs_BdRingNext(rx_ring, cur_bd);
+	}
+
+	dsb();
+
+	return XEmacPs_BdRingToHw(rx_ring, count, bd);
+}
+
+/**
+ * @brief Zynq-7000 GEM v2 silicon errata workaround (AR# 52028).
+ *
+ * Under heavy traffic of small frames the GEM v2 RX path can lock up
+ * when the controller encounters a large number of resource errors.
+ * @param d    - Driver descriptor.
+ * @param rxsr - Current value of RXSR (already read by the caller).
+ */
+static void xgem_resetrx_on_no_rxdata(struct xemacps_desc *d, uint32_t rxsr)
+{
+#ifndef PLATFORM_ZYNQ
+	(void)d;
+	(void)rxsr;
+	return;
+#else
+	uint32_t rxcnt, regctrl;
+
+	/*
+	 * Flush RX packet on every resource error to free
+	 * space in the packet buffer
+	 */
+	if (rxsr & XEMACPS_RXSR_BUFFNA_MASK) {
+		regctrl = XEmacPs_ReadReg(d->emac.Config.BaseAddress,
+					  XEMACPS_NWCTRL_OFFSET);
+		XEmacPs_WriteReg(d->emac.Config.BaseAddress,
+				 XEMACPS_NWCTRL_OFFSET,
+				 regctrl |
+				 XEMACPS_NWCTRL_FLUSH_DPRAM_MASK);
+	}
+
+	/*
+	 * Monitor the frame counter for inactivity. If
+	 * BUFFNA is set and the counter has not incremented for two
+	 * consecutive reads, the RX data path is locked. Toggle
+	 * RXEN to reset it.
+	 */
+	rxcnt = XEmacPs_ReadReg(d->emac.Config.BaseAddress,
+				XEMACPS_RXCNT_OFFSET);
+
+	if (!(rxsr & XEMACPS_RXSR_BUFFNA_MASK) || rxcnt ||
+	    d->last_rx_frms_cntr)
+		goto out;
+
+	regctrl = XEmacPs_ReadReg(d->emac.Config.BaseAddress,
+				  XEMACPS_NWCTRL_OFFSET);
+	regctrl &= ~XEMACPS_NWCTRL_RXEN_MASK;
+	XEmacPs_WriteReg(d->emac.Config.BaseAddress,
+			 XEMACPS_NWCTRL_OFFSET, regctrl);
+
+	dsb();
+	(void)XEmacPs_ReadReg(d->emac.Config.BaseAddress,
+			      XEMACPS_NWCTRL_OFFSET);
+
+	regctrl |= XEMACPS_NWCTRL_RXEN_MASK;
+	XEmacPs_WriteReg(d->emac.Config.BaseAddress,
+			 XEMACPS_NWCTRL_OFFSET, regctrl);
+	dsb();
+
+out:
+	d->last_rx_frms_cntr = rxcnt;
+#endif /* PLATFORM_ZYNQ */
+}
+
+
+void xgem_init_controller(XEmacPs_Config* cfg)
+{
+	XEmacPs_WriteReg(cfg->BaseAddress,
+			 XEMACPS_NWCTRL_OFFSET, 0x00);
+
+	XEmacPs_WriteReg(cfg->BaseAddress,
+			 XEMACPS_NWCTRL_OFFSET, XEMACPS_NWCTRL_STATCLR_MASK);
+
+	XEmacPs_WriteReg(cfg->BaseAddress, XEMACPS_RXSR_OFFSET, 0x0F);
+	XEmacPs_WriteReg(cfg->BaseAddress, XEMACPS_TXSR_OFFSET, 0xFF);
+
+	XEmacPs_WriteReg(cfg->BaseAddress, XEMACPS_IDR_OFFSET, 0x7FFFEFF);
+
+	XEmacPs_WriteReg(cfg->BaseAddress, XEMACPS_RXQBASE_OFFSET, 0x0);
+	XEmacPs_WriteReg(cfg->BaseAddress, XEMACPS_TXQBASE_OFFSET, 0x0);
+
+	XEmacPs_WriteReg(cfg->BaseAddress, XEMACPS_RXQ1BASE_OFFSET, 0x0);
+	XEmacPs_WriteReg(cfg->BaseAddress, XEMACPS_TXQ1BASE_OFFSET, 0x0);
+}
+
+void xgem_config_controller(struct xemacps_desc* d, XEmacPs_Config* cfg)
+{
+	/* Program NWCFG */
+	{
+		uint32_t nwcfg;
+
+		nwcfg = XEmacPs_ReadReg(cfg->BaseAddress,
+					XEMACPS_NWCFG_OFFSET);
+		nwcfg |= GEM_NWCFG_FEATURES;
+
+		/* SGMII/PCS only valid on GEM v3+ (ZynqMP) */
+		nwcfg &= ~(XEMACPS_NWCFG_SGMIIEN_MASK |
+			   XEMACPS_NWCFG_PCSSEL_MASK);
+
+		XEmacPs_WriteReg(cfg->BaseAddress,
+				 XEMACPS_NWCFG_OFFSET, nwcfg);
+	}
+
+	/* Program DMACR */
+	{
+		uint32_t dmacr;
+
+		dmacr = XEmacPs_ReadReg(cfg->BaseAddress,
+					XEMACPS_DMACR_OFFSET);
+
+		/* RX buffer size in 64-byte units */
+		dmacr = (dmacr & ~XEMACPS_DMACR_RXBUF_MASK) |
+			(((XGEM_BUFF_SIZE / 64U) << XEMACPS_DMACR_RXBUF_SHIFT)
+			 & XEMACPS_DMACR_RXBUF_MASK);
+
+		dmacr |= XEMACPS_DMACR_TCPCKSUM_MASK
+			 | XEMACPS_DMACR_TXSIZE_MASK
+			 | XEMACPS_DMACR_RXSIZE_MASK;
+
+		dmacr &= ~(XEMACPS_DMACR_ENDIAN_MASK);
+		dmacr = (dmacr & ~XEMACPS_DMACR_BLENGTH_MASK)
+			| XEMACPS_DMACR_INCR16_AHB_BURST;
+
+#ifdef __aarch64__
+		dmacr |= XEMACPS_DMACR_ADDR_WIDTH_64;
+#endif
+
+		XEmacPs_WriteReg(cfg->BaseAddress,
+				 XEMACPS_DMACR_OFFSET, dmacr);
+	}
+
+	{
+		uint32_t nwctrl;
+
+		nwctrl = XEmacPs_ReadReg(cfg->BaseAddress,
+					 XEMACPS_NWCTRL_OFFSET);
+
+		nwctrl |= XEMACPS_NWCTRL_MDEN_MASK;
+
+		XEmacPs_WriteReg(cfg->BaseAddress, XEMACPS_NWCTRL_OFFSET, nwctrl);
+	}
+
+	no_os_mdelay(1);
+}
+
+
+/**
+ * @brief Initialize the XEmacPs GEM and bring the PHY link up.
+ * @param desc  - Set to newly allocated descriptor on success.
+ * @param param - Initialization parameters.
+ * @return 0 on success, negative error code otherwise.
+ */
+int xemacps_init(struct xemacps_desc **desc, struct xemacps_init_param *param)
+{
+	XEmacPs_BdRing *tx_ring, *rx_ring;
+	struct xemacps_desc *d;
+	XEmacPs_Config *cfg;
+	int ret;
+
+	printf("xemacps: init start\n");
+
+	d = no_os_calloc(1, sizeof(*d));
+	if (!d)
+		return -ENOMEM;
+
+#if defined (ARMR5)
+	Xil_SetTlbAttributes((int32_t)bd_space, STRONG_ORDERD_SHARED | PRIV_RW_USER_RW);
+#else
+#if defined __aarch64__
+	Xil_SetTlbAttributes((uint64_t)bd_space, NORM_NONCACHE | INNER_SHAREABLE);
+#else
+	Xil_SetTlbAttributes((int32_t)bd_space, DEVICE_MEMORY);
+#endif
+#endif
+
+	cfg = XEmacPs_LookupConfig(param->device_id);
+	if (!cfg) {
+		printf("xemacps: LookupConfig failed for device %u\n",
+		       param->device_id);
+		ret = -ENODEV;
+		goto free_desc;
+	}
+
+	ret = XEmacPs_CfgInitialize(&d->emac, cfg, cfg->BaseAddress);
+	if (ret != XST_SUCCESS) {
+		printf("xemacps: CfgInitialize failed (%d)\n", ret);
+		ret = -EIO;
+		goto free_desc;
+	}
+	xgem_init_controller(cfg);
+
+	xgem_config_controller(d, cfg);
+
+	XEmacPs_SetMacAddress(&d->emac, param->hwaddr, 1);
+	XEmacPs_SetMdioDivisor(&d->emac, MDC_DIV_224);
+
+	int8_t phy = xgem_detect_phy(&d->emac);
+
+	if (phy < 0) {
+		printf("xemacps: no PHY found on GEM 0x%lx\n",
+		       (unsigned long)cfg->BaseAddress);
+		ret = -ENODEV;
+		goto free_desc;
+	}
+	d->phy_addr = phy;
+
+	/* Configure RGMII delays on the PHY before starting autoneg */
+	ret = xgem_marvell_rgmii_delays(&d->emac, d->phy_addr);
+	if (ret) {
+		printf("xemacps: RGMII delay config failed (%d)\n", ret);
+		goto free_desc;
+	}
+
+	/* Allocate BD space */
+	d->rx_bd_len = XEmacPs_BdRingMemCalc(XEMACPS_DMABD_MINIMUM_ALIGNMENT,
+					     XGEM_RX_BD_COUNT);
+	bd_space_index = no_os_align(bd_space_index,
+				     XEMACPS_DMABD_MINIMUM_ALIGNMENT);
+	d->rx_bd_space = &bd_space[bd_space_index];
+	bd_space_index += d->rx_bd_len;
+
+	d->tx_bd_len = XEmacPs_BdRingMemCalc(XEMACPS_DMABD_MINIMUM_ALIGNMENT,
+					     XGEM_TX_BD_COUNT);
+	bd_space_index = no_os_align(bd_space_index,
+				     XEMACPS_DMABD_MINIMUM_ALIGNMENT);
+	d->tx_bd_space = &bd_space[bd_space_index];
+	bd_space_index += d->tx_bd_len;
+
+	XEmacPs_Bd *bdrxterminate = NULL;
+	XEmacPs_Bd *bdtxterminate = NULL;
+	if (d->emac.Version > 2) {
+		bdrxterminate = (XEmacPs_Bd *)&bd_space[bd_space_index];
+		bd_space_index += 0x10000;
+		bdtxterminate = (XEmacPs_Bd *)&bd_space[bd_space_index];
+		bd_space_index += 0x10000;
+	}
+
+	/* RX BD ring */
+	XEmacPs_Bd bd_template;
+
+	rx_ring = &XEmacPs_GetRxRing(&d->emac);
+	ret = XEmacPs_BdRingCreate(rx_ring, (UINTPTR)d->rx_bd_space,
+				   (UINTPTR)d->rx_bd_space,
+				   XEMACPS_DMABD_MINIMUM_ALIGNMENT,
+				   XGEM_RX_BD_COUNT);
+	if (ret != XST_SUCCESS) {
+		printf("xemacps: RX BdRingCreate failed (%d)\n", ret);
+		ret = -EIO;
+		goto free_desc;
+	}
+
+	XEmacPs_BdClear(&bd_template);
+	ret = XEmacPs_BdRingClone(rx_ring, &bd_template, XEMACPS_RECV);
+	if (ret != XST_SUCCESS) {
+		ret = -EIO;
+		goto free_desc;
+	}
+
+	/* Allocate and write buffer address to RX BDs */
+	{
+		XEmacPs_Bd *rxbd;
+		uint32_t bdindex;
+		uint32_t *temp;
+
+		for (uint32_t i = 0; i < XGEM_RX_BD_COUNT; i++) {
+			ret = XEmacPs_BdRingAlloc(rx_ring, 1, &rxbd);
+			if (ret != XST_SUCCESS) {
+				ret = -EIO;
+				goto free_desc;
+			}
+
+			ret = XEmacPs_BdRingToHw(rx_ring, 1, rxbd);
+			if (ret != XST_SUCCESS) {
+				ret = -EIO;
+				goto free_desc;
+			}
+
+			bdindex = XGEM_BD_TO_INDEX(rx_ring, rxbd);
+			temp = (uint32_t *)rxbd;
+			*temp = 0;
+			if (bdindex == (XGEM_RX_BD_COUNT - 1))
+				*temp = XEMACPS_RXBUF_WRAP_MASK;
+			temp++;
+			*temp = 0;
+			dsb();
+
+			Xil_DCacheInvalidateRange((UINTPTR)rx_buf[bdindex],
+						  XGEM_BUFF_SIZE);
+			XEmacPs_BdSetAddressRx(rxbd, (UINTPTR)rx_buf[bdindex]);
+		}
+	}
+
+	/* TX BD ring */
+	XEmacPs_BdClear(&bd_template);
+	XEmacPs_BdSetStatus(&bd_template, XEMACPS_TXBUF_USED_MASK);
+
+	tx_ring = &XEmacPs_GetTxRing(&d->emac);
+	ret = XEmacPs_BdRingCreate(tx_ring, (UINTPTR)d->tx_bd_space,
+				   (UINTPTR)d->tx_bd_space,
+				   XEMACPS_DMABD_MINIMUM_ALIGNMENT,
+				   XGEM_TX_BD_COUNT);
+	if (ret != XST_SUCCESS) {
+		printf("xemacps: TX BdRingCreate failed (%d)\n", ret);
+		ret = -EIO;
+		goto free_desc;
+	}
+
+	ret = XEmacPs_BdRingClone(tx_ring, &bd_template, XEMACPS_SEND);
+	if (ret != XST_SUCCESS) {
+		ret = -EIO;
+		goto free_desc;
+	}
+
+	/* Program queue base registers */
+	XEmacPs_SetQueuePtr(&d->emac, d->emac.RxBdRing.BaseBdAddr, 0, XEMACPS_RECV);
+	if (d->emac.Version > 2) {
+		XEmacPs_SetQueuePtr(&d->emac, d->emac.TxBdRing.BaseBdAddr, 1, XEMACPS_SEND);
+	} else {
+		XEmacPs_SetQueuePtr(&d->emac, d->emac.TxBdRing.BaseBdAddr, 0, XEMACPS_SEND);
+	}
+
+	/* Park unused queues on GEM v3+ (ZynqMP) */
+	if (d->emac.Version > 2) {
+		XEmacPs_BdClear(bdrxterminate);
+		XEmacPs_BdSetAddressRx(bdrxterminate,
+				       (XEMACPS_RXBUF_NEW_MASK |
+					XEMACPS_RXBUF_WRAP_MASK));
+		XEmacPs_Out32(cfg->BaseAddress + XEMACPS_RXQ1BASE_OFFSET,
+			      (UINTPTR)bdrxterminate);
+
+		XEmacPs_BdClear(bdtxterminate);
+		XEmacPs_BdSetStatus(bdtxterminate,
+				    (XEMACPS_TXBUF_USED_MASK |
+				     XEMACPS_TXBUF_WRAP_MASK));
+		XEmacPs_Out32(cfg->BaseAddress + XEMACPS_TXQBASE_OFFSET,
+			      (UINTPTR)bdtxterminate);
+	}
+	dsb();
+
+	printf("xemacps: starting autonegotiation\n");
+	xgem_phy_start_autonegotiation(&d->emac, d->phy_addr);
+
+	XEmacPs_Start(&d->emac);
+
+	printf("xemacps: init complete, MAC started\n");
+	*desc = d;
+	return 0;
+
+free_desc:
+	no_os_free(d);
+	return ret;
+}
+
+/**
+ * @brief Stop the GEM and release the driver descriptor.
+ * @param desc - Descriptor returned by xemacps_init.
+ * @return 0 on success.
+ */
+int xemacps_remove(struct xemacps_desc *desc)
+{
+	XEmacPs_Stop(&desc->emac);
+	no_os_free(desc);
+
+	return 0;
+}
+
+/**
+ * @brief Transmit a raw Ethernet frame.
+ * @param desc - Driver descriptor.
+ * @param buf  - Frame data (Ethernet header + payload).
+ * @param len  - Frame length in bytes.
+ * @return 0 on success, negative error code otherwise.
+ */
+int xemacps_send(struct xemacps_desc *desc, uint8_t *buf, uint32_t len)
+{
+	XEmacPs_Bd *bd = (XEmacPs_Bd *)(void *)desc->tx_bd_space;
+	uint32_t timeout;
+
+	memcpy(tx_buf, buf, len);
+	Xil_DCacheFlushRange((uintptr_t)tx_buf, len);
+
+	XEmacPs_WriteReg(desc->emac.Config.BaseAddress, XEMACPS_TXSR_OFFSET,
+			 XEMACPS_TXSR_USEDREAD_MASK | XEMACPS_TXSR_TXCOMPL_MASK);
+
+	XEmacPs_BdSetAddressTx(bd, (UINTPTR)tx_buf);
+	XEmacPs_BdWrite(bd, XEMACPS_BD_STAT_OFFSET,
+			XEMACPS_TXBUF_WRAP_MASK | XEMACPS_TXBUF_LAST_MASK |
+			(len & XEMACPS_TXBUF_LEN_MASK));
+	dsb();
+
+	XEmacPs_Transmit(&desc->emac);
+
+	timeout = 200000U;
+	do {
+		dsb();
+		if (XEmacPs_BdRead(bd, XEMACPS_BD_STAT_OFFSET) &
+		    XEMACPS_TXBUF_USED_MASK)
+			break;
+	} while (--timeout);
+
+	if (!timeout)
+		return -ETIMEDOUT;
+
+	return 0;
+}
+
+/**
+ * @brief Receive a single Ethernet frame.
+ *
+ * Harvests at most one completed RX BD, copies the frame data into
+ * the caller's buffer, and reposts the BD to hardware. If no frame
+ * is available, returns 0 with *len set to 0.
+ *
+ * @param desc - Driver descriptor.
+ * @param buf  - Buffer to receive frame data (must be >= XEMACPS_MAX_FRAME_SIZE).
+ * @param len  - Set to the received frame length, or 0 if no frame available.
+ * @return 0 on success, negative error code on BD ring error.
+ */
+int xemacps_recv(struct xemacps_desc *desc, uint8_t *buf, uint32_t *len)
+{
+	XEmacPs_BdRing *rx_ring = &XEmacPs_GetRxRing(&desc->emac);
+	XEmacPs_Bd *bd;
+	uint8_t *frame;
+	int ret;
+
+	*len = 0;
+
+	if (XEmacPs_BdRingFromHwRx(rx_ring, 1, &bd) == 0)
+		return 0;
+
+	frame = (uint8_t *)(uintptr_t)(XEmacPs_BdRead(bd, 0U) & ~0x3UL);
+	*len = XEmacPs_BdGetLength(bd);
+
+	Xil_DCacheInvalidateRange((uintptr_t)frame, *len);
+
+	memcpy(buf, frame, *len);
+
+	/* Return this BD to hardware immediately */
+	XEmacPs_BdClearRxNew(bd);
+	XEmacPs_BdRingFree(rx_ring, 1, bd);
+
+	ret = XEmacPs_BdRingAlloc(rx_ring, 1, &bd);
+	if (ret != XST_SUCCESS)
+		return -ENOMEM;
+
+	ret = xgem_rx_submit(desc, 1, bd);
+	if (ret != XST_SUCCESS)
+		return -EIO;
+
+	return 0;
+}
+
+/**
+ * @brief Poll PHY link state via BMSR.
+ *
+ * @param d - Driver descriptor.
+ */
+static int xgem_poll_link(struct xemacps_desc *d)
+{
+	uint16_t bmsr;
+	int32_t speed;
+	bool was_up = d->link_up, is_up;
+	int ret;
+
+	ret = XEmacPs_PhyRead(&d->emac, d->phy_addr, PHY_REG_BMSR, &bmsr);
+	if (ret != XST_SUCCESS || bmsr == 0xFFFF)
+		return -ENODEV;
+
+	is_up = (bmsr & PHY_REG_BMSR_LSTATUS) && (bmsr & PHY_REG_BMSR_ANEGCMPL);
+
+	if (is_up == was_up)
+		return 0;
+
+	if (is_up) {
+		speed = xgem_phy_get_speed(&d->emac, d->phy_addr);
+		if (speed < 0)
+			return speed;
+		printf("xemacps: PHY link up at %dMbps\n", speed);
+		XEmacPs_SetOperatingSpeed(&d->emac, (uint16_t)speed);
+	} else {
+		printf("xemacps: PHY link down\n");
+		ret = xgem_phy_start_autonegotiation(&d->emac, d->phy_addr);
+		if (ret)
+			return ret;
+	}
+
+	d->link_up = is_up;
+
+	return 0;
+}
+
+/**
+ * @brief Poll the RX status and run the errata workaround.
+ *
+ * Must be called once per polling cycle, before the xemacps_recv() loop.
+ * Reads RXSR, runs the AR# 52028 errata check, and clears any error flags.
+ *
+ * @param desc - Driver descriptor.
+ * @return 0 on success.
+ */
+int xemacps_poll(struct xemacps_desc *desc)
+{
+	uint32_t rxsr;
+	int ret;
+
+	ret = xgem_poll_link(desc);
+	if (ret)
+		return ret;
+
+	if (!desc->link_up)
+		return 0;
+
+	rxsr = XEmacPs_ReadReg(desc->emac.Config.BaseAddress,
+			       XEMACPS_RXSR_OFFSET);
+
+	xgem_resetrx_on_no_rxdata(desc, rxsr);
+
+	if (rxsr)
+		XEmacPs_WriteReg(desc->emac.Config.BaseAddress,
+				 XEMACPS_RXSR_OFFSET, rxsr);
+
+	return 0;
+}
+
+/**
+ * @brief Add a multicast MAC address to the GEM hash filter.
+ * @param desc - Driver descriptor.
+ * @param addr - 6-byte multicast MAC address.
+ * @return 0 on success.
+ */
+int xemacps_set_mcast_hash(struct xemacps_desc *desc, uint8_t *addr)
+{
+	XEmacPs_SetHash(&desc->emac, addr);
+
+	return 0;
+}
+
+/**
+ * @brief Return the current PHY link state.
+ * @param desc - Driver descriptor.
+ * @return true if link is up, false otherwise.
+ */
+bool xemacps_get_link_state(struct xemacps_desc *desc)
+{
+	return desc->link_up;
+}

--- a/drivers/net/xemacps/no_os_xemacps.h
+++ b/drivers/net/xemacps/no_os_xemacps.h
@@ -174,8 +174,10 @@ struct xemacps_desc;
  * @brief  Initialization parameters for the XEmacPs MAC driver.
  */
 struct xemacps_init_param {
-	/** XEmacPs device ID from xparameters.h (e.g. XPAR_XEMACPS_0_DEVICE_ID) */
-	uint16_t device_id;
+	/**
+	 * XEmacPs identifier from xparameters.h.
+	 */
+	uintptr_t device_id;
 	/** MDIO address of the on-board PHY */
 	uint8_t phy_addr;
 	/** Ethernet MAC address for this interface */

--- a/drivers/net/xemacps/no_os_xemacps.h
+++ b/drivers/net/xemacps/no_os_xemacps.h
@@ -1,0 +1,193 @@
+/***************************************************************************//**
+ *   @file   no_os_xemacps.h
+ *   @brief  Public API for the Xilinx PS GEM (XEmacPs) MAC driver.
+ *
+ *   Standalone Ethernet MAC driver for the Zynq-7000 / ZynqMP Processing
+ *   System Gigabit Ethernet MAC.
+ *
+ *   @author Nicolae-Daniel Deaconescu (Nicolae-daniel.Deaconescu@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef __XEMACPS_DRV_H__
+#define __XEMACPS_DRV_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "no_os_util.h"
+
+/* Number of RX buffer descriptors pre-posted to hardware */
+#define XGEM_RX_BD_COUNT		64
+#define XGEM_TX_BD_COUNT		1
+
+#if defined(__aarch64__)
+#define XGEM_CACHE_LINE_SIZE	64
+#else
+#define XGEM_CACHE_LINE_SIZE	32
+#endif
+
+/* Frame buffer size, aligned to the next cache-line size. */
+#define XGEM_BUFF_SIZE	no_os_align(XEMACPS_MAX_FRAME_SIZE, XGEM_CACHE_LINE_SIZE)
+
+
+/* PHY register definitions (IEEE 802.3) */
+#define PHY_REG_BMCR				0x00
+#define PHY_REG_BMSR				0x01
+#define PHY_REG_PHYID1				0x02
+#define PHY_REG_PHYID2				0x03
+#define PHY_REG_BMSR_LSTATUS		NO_OS_BIT(2)
+#define PHY_REG_BMSR_ANEGCMPL		NO_OS_BIT(5)
+#define PHY_REG_BMCR_RESET			NO_OS_BIT(15)
+#define PHY_REG_BMCR_ANEGEN			NO_OS_BIT(12)
+#define PHY_REG_BMCR_RSTANEG		NO_OS_BIT(9)
+#define PHY_REG_ANLPAR				0x05
+#define PHY_REG_ANLPAR_100FD		NO_OS_BIT(8)
+#define PHY_REG_ANLPAR_100HD		NO_OS_BIT(7)
+#define PHY_REG_1000STAT			0x0A
+#define PHY_REG_1000STAT_LP_FD		NO_OS_BIT(11)
+#define PHY_REG_1000STAT_LP_HD		NO_OS_BIT(10)
+
+/* Marvell 88E1510/88E1512 page and register definitions */
+#define MARVELL_PHY_ID				0x005043
+#define PHY_REG_PAGE				22
+#define MRVL_PAGE2_RGMII_CTRL			21
+/* Page 2 Reg 21 values: enable RGMII TX and RX delays per speed */
+#define MRVL_RGMII_1000_DELAYS			0x0070
+#define MRVL_RGMII_100_DELAYS			0x2030
+#define MRVL_RGMII_10_DELAYS			0x0030
+
+/* Maximum Ethernet frame size, rounded up to a 32-byte cache-line multiple. */
+#ifndef XEMACPS_MAX_FRAME_SIZE
+#define XEMACPS_MAX_FRAME_SIZE	1536
+#endif
+
+/* MAC address length */
+#define XEMACPS_ETH_ALEN	6
+
+/* GEM feature flags. Override at build time, e.g. -DGEM_PROMISC */
+
+/* Promiscuous mode — receive all frames regardless of address */
+#ifdef GEM_PROMISC
+#define GEM_NWCFG_PROMISC	XEMACPS_NWCFG_COPYALLEN_MASK
+#else
+#define GEM_NWCFG_PROMISC	0
+#endif
+
+/* Full duplex (enabled by default) */
+#ifndef GEM_HALF_DUPLEX
+#define GEM_NWCFG_DUPLEX	XEMACPS_NWCFG_FDEN_MASK
+#else
+#define GEM_NWCFG_DUPLEX	0
+#endif
+
+/* Reject broadcast frames */
+#ifdef GEM_NO_BROADCAST
+#define GEM_NWCFG_BCAST		XEMACPS_NWCFG_BCASTDI_MASK
+#else
+#define GEM_NWCFG_BCAST		0
+#endif
+
+/* Strip FCS from received frames */
+#ifdef GEM_STRIP_FCS
+#define GEM_NWCFG_FCS		XEMACPS_NWCFG_FCSREM_MASK
+#else
+#define GEM_NWCFG_FCS		0
+#endif
+
+/* RX checksum offload (enabled by default) */
+#ifndef GEM_NO_RX_CHKSUM
+#define GEM_NWCFG_RXCHKSUM	XEMACPS_NWCFG_RXCHKSUMEN_MASK
+#else
+#define GEM_NWCFG_RXCHKSUM	0
+#endif
+
+/* Pause frame support (enabled by default) */
+#ifndef GEM_NO_PAUSE
+#define GEM_NWCFG_PAUSE		XEMACPS_NWCFG_PAUSEEN_MASK
+#else
+#define GEM_NWCFG_PAUSE		0
+#endif
+
+/* Multicast hash filter (enabled by default) */
+#ifndef GEM_NO_MCAST_HASH
+#define GEM_NWCFG_MCAST		XEMACPS_NWCFG_MCASTHASHEN_MASK
+#else
+#define GEM_NWCFG_MCAST		0
+#endif
+
+/* Unicast hash filter */
+#ifdef GEM_UCAST_HASH
+#define GEM_NWCFG_UCAST		XEMACPS_NWCFG_UCASTHASHEN_MASK
+#else
+#define GEM_NWCFG_UCAST		0
+#endif
+
+/* SGMII / PCS mode — enable for boards using PS GTR serial Ethernet
+ * Not needed for MIO/RGMII boards. */
+#ifdef GEM_SGMII
+#define GEM_NWCFG_SGMII		(XEMACPS_NWCFG_SGMIIEN_MASK | \
+				 XEMACPS_NWCFG_PCSSEL_MASK)
+#else
+#define GEM_NWCFG_SGMII		0
+#endif
+
+/* Combined feature mask */
+#define GEM_NWCFG_FEATURES	(GEM_NWCFG_PROMISC | GEM_NWCFG_DUPLEX | \
+				 GEM_NWCFG_BCAST | GEM_NWCFG_FCS | \
+				 GEM_NWCFG_RXCHKSUM | GEM_NWCFG_PAUSE | \
+				 GEM_NWCFG_MCAST | GEM_NWCFG_UCAST | \
+				 GEM_NWCFG_SGMII)
+
+
+
+/* Opaque driver descriptor - full definition in xemacps.c */
+struct xemacps_desc;
+
+/**
+ * @struct xemacps_init_param
+ * @brief  Initialization parameters for the XEmacPs MAC driver.
+ */
+struct xemacps_init_param {
+	/** XEmacPs device ID from xparameters.h (e.g. XPAR_XEMACPS_0_DEVICE_ID) */
+	uint16_t device_id;
+	/** MDIO address of the on-board PHY */
+	uint8_t phy_addr;
+	/** Ethernet MAC address for this interface */
+	uint8_t hwaddr[XEMACPS_ETH_ALEN];
+};
+
+int xemacps_init(struct xemacps_desc **desc, struct xemacps_init_param *param);
+int xemacps_remove(struct xemacps_desc *desc);
+int xemacps_send(struct xemacps_desc *desc, uint8_t *buf, uint32_t len);
+int xemacps_recv(struct xemacps_desc *desc, uint8_t *buf, uint32_t *len);
+int xemacps_poll(struct xemacps_desc *desc);
+int xemacps_set_mcast_hash(struct xemacps_desc *desc, uint8_t *addr);
+bool xemacps_get_link_state(struct xemacps_desc *desc);
+
+#endif /* __XEMACPS_DRV_H__ */

--- a/network/lwip_raw_socket/lwip_socket.c
+++ b/network/lwip_raw_socket/lwip_socket.c
@@ -63,9 +63,8 @@
 
 #include "no_os_delay.h"
 #include "no_os_alloc.h"
+#include "no_os_util.h"
 #include "tcp_socket.h"
-
-#include "adin1110.h"
 
 static bool mdns_result;
 static bool mdns_is_conflict;
@@ -276,7 +275,6 @@ static int _lwip_start_mdns(struct lwip_network_desc *desc, struct netif *netif)
 int32_t no_os_lwip_init(struct lwip_network_desc **desc,
 			struct lwip_network_param *param)
 {
-	struct network_interface *network_descriptor;
 	struct lwip_network_desc *descriptor;
 	struct netif *netif_descriptor;
 	ip4_addr_t ipaddr, netmask, gw;
@@ -287,17 +285,11 @@ int32_t no_os_lwip_init(struct lwip_network_desc **desc,
 #endif
 	int ret;
 
-	network_descriptor = calloc(1, sizeof(*network_descriptor));
-	if (!network_descriptor)
+	netif_descriptor = no_os_calloc(1, sizeof(*netif_descriptor));
+	if (!netif_descriptor)
 		return -ENOMEM;
 
-	netif_descriptor = calloc(1, sizeof(*netif_descriptor));
-	if (!netif_descriptor) {
-		ret = -ENOMEM;
-		goto free_network_descriptor;
-	}
-
-	descriptor = calloc(1, sizeof(*descriptor));
+	descriptor = no_os_calloc(1, sizeof(*descriptor));
 	if (!descriptor) {
 		ret = -ENOMEM;
 		goto free_netif_descriptor;
@@ -392,11 +384,9 @@ platform_remove:
 	param->platform_ops->remove(descriptor->mac_desc);
 free_netif:
 	netif_remove(netif_descriptor);
-	free(descriptor);
+	no_os_free(descriptor);
 free_netif_descriptor:
-	free(netif_descriptor);
-free_network_descriptor:
-	free(network_descriptor);
+	no_os_free(netif_descriptor);
 
 	return ret;
 }
@@ -457,9 +447,9 @@ static int32_t lwip_socket_close(void *net, uint32_t sock_id)
 		pbuf_free(sock->p);
 	}
 
-	tcp_close(sock->pcb);
 	tcp_recv(sock->pcb, NULL);
 	tcp_err(sock->pcb, NULL);
+	tcp_close(sock->pcb);
 
 	sock->p_idx = 0;
 	sock->pcb = NULL;

--- a/network/lwip_raw_socket/netdevs/xemacps/lwip_xemacps.c
+++ b/network/lwip_raw_socket/netdevs/xemacps/lwip_xemacps.c
@@ -1,0 +1,163 @@
+/***************************************************************************//**
+ *   @file   lwip_xemacps.c
+ *   @brief  lwIP glue layer for the XEmacPs MAC driver.
+ *   @author Nicolae-Daniel Deaconescu (Nicolae-daniel.Deaconescu@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifdef NO_OS_LWIP_NETWORKING
+
+#include <string.h>
+#include <errno.h>
+
+#include "lwip/pbuf.h"
+#include "lwip/stats.h"
+#include "netif/ethernet.h"
+
+#include "lwip_socket.h"
+#include "lwip_xemacps.h"
+
+static uint8_t lwip_buf[XEMACPS_MAX_FRAME_SIZE];
+
+/**
+ * @brief Initialize the XEmacPs MAC and configure multicast filters.
+ * @param desc - Set to MAC descriptor on success.
+ * @param param - Pointer to xemacps_init_param.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int32_t xemacps_lwip_init(void **desc, void *param)
+{
+	struct xemacps_init_param *ip = param;
+	struct xemacps_desc *d;
+	uint8_t mdns_mcast[6] = {0x01, 0x00, 0x5E, 0x00, 0x00, 0xFB};
+	int ret;
+
+	ret = xemacps_init(&d, ip);
+	if (ret)
+		return ret;
+
+	ret = xemacps_set_mcast_hash(d, mdns_mcast);
+	if (ret) {
+		xemacps_remove(d);
+		return ret;
+	}
+
+	*desc = d;
+	return 0;
+}
+
+/**
+ * @brief Remove the XEmacPs MAC descriptor.
+ * @param desc - MAC descriptor.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int32_t xemacps_lwip_remove(void *desc)
+{
+	return xemacps_remove(desc);
+}
+
+/**
+ * @brief Transmit a pbuf chain via the XEmacPs MAC.
+ * @param netif - lwIP network interface.
+ * @param p     - pbuf chain to transmit.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int32_t xemacps_netif_output(struct netif *netif, struct pbuf *p)
+{
+	struct lwip_network_desc *lwip_desc = netif->state;
+	struct xemacps_desc *d = lwip_desc->mac_desc;
+	uint32_t len;
+
+	LINK_STATS_INC(link.xmit);
+
+	len = pbuf_copy_partial(p, lwip_buf, p->tot_len, 0);
+
+	return xemacps_send(d, lwip_buf, len);
+}
+
+/**
+ * @brief Poll for received frames and deliver them to lwIP.
+ * @param desc - lwIP network descriptor.
+ * @param data - Unused.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int32_t xemacps_step(struct lwip_network_desc *desc, void *data)
+{
+	struct xemacps_desc *d = desc->mac_desc;
+	struct netif *netif = desc->lwip_netif;
+	struct pbuf *p;
+	uint32_t len;
+	int ret;
+
+	ret = xemacps_poll(d);
+	if (ret)
+		return ret;
+
+	if (xemacps_get_link_state(d)) {
+		if (!netif_is_link_up(netif))
+			netif_set_link_up(netif);
+	} else {
+		if (netif_is_link_up(netif))
+			netif_set_link_down(netif);
+	}
+
+	do {
+		ret = xemacps_recv(d, lwip_buf, &len);
+		if (ret)
+			return ret;
+
+		if (!len)
+			break;
+
+		LINK_STATS_INC(link.recv);
+
+		p = pbuf_alloc(PBUF_RAW, len, PBUF_POOL);
+		if (p) {
+			pbuf_take(p, lwip_buf, len);
+			if (desc->lwip_netif->input(p, desc->lwip_netif) != ERR_OK) {
+				LINK_STATS_INC(link.drop);
+				pbuf_free(p);
+			}
+		} else {
+			LINK_STATS_INC(link.memerr);
+			LINK_STATS_INC(link.drop);
+		}
+	} while (1);
+
+	return 0;
+}
+
+const struct no_os_lwip_ops xemacps_lwip_ops = {
+	.init          = xemacps_lwip_init,
+	.remove        = xemacps_lwip_remove,
+	.netif_output  = xemacps_netif_output,
+	.step          = xemacps_step,
+};
+
+#endif /* NO_OS_LWIP_NETWORKING */

--- a/network/lwip_raw_socket/netdevs/xemacps/lwip_xemacps.h
+++ b/network/lwip_raw_socket/netdevs/xemacps/lwip_xemacps.h
@@ -1,0 +1,45 @@
+/***************************************************************************//**
+ *   @file   lwip_xemacps.h
+ *   @brief  Header for the XEmacPs lwIP glue layer.
+ *   @author Nicolae-Daniel Deaconescu (Nicolae-daniel.Deaconescu@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef _LWIP_XEMACPS_H_
+#define _LWIP_XEMACPS_H_
+
+#ifdef NO_OS_LWIP_NETWORKING
+
+#include "lwip_socket.h"
+#include "no_os_xemacps.h"
+
+extern const struct no_os_lwip_ops xemacps_lwip_ops;
+
+#endif /* NO_OS_LWIP_NETWORKING */
+#endif /* _LWIP_XEMACPS_H_ */

--- a/projects/xilinx_lwip/Makefile
+++ b/projects/xilinx_lwip/Makefile
@@ -1,0 +1,10 @@
+PLATFORM = xilinx
+CFLAGS += -DNO_OS_LWIP_NETWORKING
+CFLAGS += -DNO_OS_LWIP_INIT_ONETIME=1
+CFLAGS += -Wall -Wextra
+
+include ../../tools/scripts/generic_variables.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/xilinx_lwip/README.rst
+++ b/projects/xilinx_lwip/README.rst
@@ -1,0 +1,186 @@
+Xilinx Zynq lwIP Ethernet Demo
+===============================
+
+Overview
+--------
+
+This project demonstrates bare-metal Ethernet networking on Xilinx
+Zynq-7000 and ZynqMP boards using the PS GEM (XEmacPs) and the lwIP
+raw API (NO_SYS=1). Two example applications are available:
+
+- **IIO example** (default) - exposes virtual ADC/DAC devices over the
+  iiod TCP protocol on port 30431.
+- **Echo server example** - runs a TCP echo server on port 7
+
+Board Compatibility
+-------------------
+
+The project is generic for any Xilinx board with a PS GEM. The driver
+automatically scans MDIO addresses 0-31 to find the on-board PHY, so
+no board-specific PHY address configuration is required.
+
+If the detected PHY is a Marvell 88E151x, the driver configures RGMII
+TX/RX timing delays automatically.
+
+Known Errata
+------------
+
+The Zynq-7000 GEM v2 has a silicon bug (`AR# 52028
+<https://adaptivesupport.amd.com/s/article/52028>`_) where the RX data
+path can lock up under heavy traffic of small frames when a large number
+of receive resource errors are generated.
+
+The XEmacPs driver includes an automatic workaround that:
+
+1. Flushes a packet from the RX buffer on every resource error to reduce
+   the error rate.
+2. Monitors the received-frame counter - if it stops incrementing for
+   two consecutive polling cycles while resource errors are present, the
+   driver toggles the RX enable bit to reset the receive path.
+
+This workaround only activates on GEM v2 (Zynq-7000) and is skipped on
+GEM v3+ (ZynqMP / Versal).
+
+Prerequisites
+-------------
+
+- Xilinx Vitis / Vivado (``xsct`` and ``vitis`` must be in PATH)
+- A hardware description file (``*.xsa``) generated from a Vivado project
+  targeting your board
+- ``libiio`` installed on the host (for the IIO example)
+- ``netcat`` / ``nc`` installed on the host (for the echo example)
+
+Building
+--------
+
+Place the ``.xsa`` file inside ``projects/xilinx_lwip/`` before building.
+The build system detects it automatically and generates the BSP.
+
+**IIO example (default):**
+
+.. code-block:: bash
+
+   cd projects/xilinx_lwip
+   make PLATFORM=xilinx
+
+**Echo server example:**
+
+.. code-block:: bash
+
+   cd projects/xilinx_lwip
+   make PLATFORM=xilinx ECHO_EXAMPLE=y
+
+Build outputs are written to ``projects/xilinx_lwip/build/``.
+
+Flashing
+--------
+
+.. code-block:: bash
+
+   make run
+
+This calls ``xsct`` to program the bitstream and ELF over JTAG.
+
+Build Flags
+-----------
+
+The following flags can be passed to ``make`` or set in the Makefile:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Flag
+     - Default
+     - Description
+   * - ``ECHO_EXAMPLE=y``
+     - unset (IIO example)
+     - Build the TCP echo server instead of the IIO server
+   * - ``NO_OS_IP``
+     - unset (DHCP/AutoIP)
+     - Static IP address, e.g. ``192.168.1.100``
+   * - ``NO_OS_NETMASK``
+     - unset
+     - Subnet mask, e.g. ``255.255.255.0`` (required with ``NO_OS_IP``)
+   * - ``NO_OS_GATEWAY``
+     - unset
+     - Default gateway, e.g. ``192.168.1.1`` (required with ``NO_OS_IP``)
+   * - ``DEBUG=1``
+     - unset
+     - Disable ``-O2``, enable ``-O0 -g3`` for debugging
+   * - ``VERBOSE=y``
+     - unset
+     - Print each compiler and linker invocation
+
+GEM Feature Flags
+~~~~~~~~~~~~~~~~~~
+
+The following defines toggle GEM hardware features via
+``CFLAGS=-D<flag>``:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Define
+     - Default
+     - Effect
+   * - ``GEM_PROMISC``
+     - off
+     - Receive all frames regardless of destination address
+   * - ``GEM_HALF_DUPLEX``
+     - off (full duplex)
+     - Disable full-duplex mode
+   * - ``GEM_NO_BROADCAST``
+     - off
+     - Reject broadcast frames
+   * - ``GEM_STRIP_FCS``
+     - off
+     - Strip FCS from received frames
+   * - ``GEM_NO_RX_CHKSUM``
+     - off (RX checksum on)
+     - Disable RX checksum offload
+   * - ``GEM_NO_PAUSE``
+     - off (pause on)
+     - Disable pause frame support
+   * - ``GEM_NO_MCAST_HASH``
+     - off (hash on)
+     - Disable multicast hash filter
+   * - ``GEM_UCAST_HASH``
+     - off
+     - Enable unicast hash filter
+   * - ``GEM_SGMII``
+     - off
+     - Enable SGMII / PCS mode (for boards using PS GTR serial Ethernet)
+
+Example with static IP and promiscuous mode:
+
+.. code-block:: bash
+
+   make PLATFORM=xilinx NO_OS_IP=169.254.3.1 NO_OS_NETMASK=255.255.0.0 NO_OS_GATEWAY=0.0.0.0 CFLAGS="-DGEM_PROMISC"
+
+Network Configuration
+---------------------
+
+By default the board uses DHCP, falling back to AutoIP (``169.254.x.x``)
+if no DHCP server is present. The assigned IP address and gateway are
+printed over the UART console at startup (115200 baud, 8N1).
+
+The MAC address is set in the example source files
+(``src/examples/iio_lwip/iio_lwip_example.c`` and
+``src/examples/echo_lwip/echo_lwip_example.c``). Change the last three
+bytes to ensure uniqueness on your network:
+
+.. code-block:: c
+
+   static uint8_t mac_addr[6] = {0x00, 0x0A, 0x35, 0x00, 0x01, 0x02};
+
+Connecting - IIO Example
+------------------------
+
+The board exposes two virtual devices: ``adc_demo`` (input) and
+``dac_demo`` (output), served over the iiod protocol on **TCP port 30431**.
+
+Connecting - Echo Example
+--------------------------
+
+The echo server listens on **TCP port 7** and reflects every byte back
+to the sender.

--- a/projects/xilinx_lwip/src.mk
+++ b/projects/xilinx_lwip/src.mk
@@ -1,0 +1,81 @@
+LIBRARIES += lwip
+
+# slipif.c requires sio_* functions which we don't implement.
+ALL_IGNORED_FILES += $(NO-OS)/libraries/lwip/lwip/src/netif/slipif.c
+
+CFLAGS += -DGEM_INSTANCE=0
+CFLAGS += -DSSIZE_MAX=INT_MAX
+
+SRCS += $(PROJECT)/src/platform/xilinx/main.c
+SRCS += $(PROJECT)/src/platform/xilinx/parameters.c
+SRCS += $(PROJECT)/src/common/common_data.c
+
+INCS += $(PROJECT)/src/common/app_config.h
+INCS += $(PROJECT)/src/common/common_data.h
+INCS += $(PROJECT)/src/platform/platform_includes.h
+INCS += $(PROJECT)/src/platform/xilinx/parameters.h
+
+ifeq ($(ECHO_EXAMPLE),y)
+CFLAGS += -DECHO_EXAMPLE
+SRCS += $(PROJECT)/src/examples/echo_lwip/echo_lwip_example.c
+INCS += $(PROJECT)/src/examples/echo_lwip/echo_lwip_example.h
+# lwIP TCP echo server
+SRCS += $(NO-OS)/libraries/lwip/lwip/contrib/apps/tcpecho_raw/tcpecho_raw.c
+INCS += $(NO-OS)/libraries/lwip/lwip/contrib/apps/tcpecho_raw/tcpecho_raw.h
+else
+IIOD = y
+SRCS += $(PROJECT)/src/examples/iio_lwip/iio_lwip_example.c
+INCS += $(PROJECT)/src/examples/iio_lwip/iio_lwip_example.h
+# Virtual IIO demo devices
+SRCS += $(DRIVERS)/adc/adc_demo/adc_demo.c \
+        $(DRIVERS)/adc/adc_demo/iio_adc_demo.c \
+        $(DRIVERS)/dac/dac_demo/dac_demo.c \
+        $(DRIVERS)/dac/dac_demo/iio_dac_demo.c
+INCS += $(DRIVERS)/adc/adc_demo/adc_demo.h \
+        $(DRIVERS)/adc/adc_demo/iio_adc_demo.h \
+        $(DRIVERS)/dac/dac_demo/dac_demo.h \
+        $(DRIVERS)/dac/dac_demo/iio_dac_demo.h
+endif
+
+# XEmacPs MAC driver (PS GEM)
+INCS += $(DRIVERS)/net/xemacps/no_os_xemacps.h
+SRCS += $(DRIVERS)/net/xemacps/no_os_xemacps.c
+
+# # XAxiEmac MAC driver (PL AXI Ethernet) - stubs
+# INCS += $(DRIVERS)/net/xaxiemac/no_os_xaxiemac.h
+# SRCS += $(DRIVERS)/net/xaxiemac/no_os_xaxiemac.c
+
+# Generic Xilinx lwIP glue
+INCS += $(NO-OS)/network/lwip_raw_socket/netdevs/xemacps/lwip_xemacps.h
+SRCS += $(NO-OS)/network/lwip_raw_socket/netdevs/xemacps/lwip_xemacps.c
+
+# HAL
+SRCS += $(DRIVERS)/api/no_os_uart.c \
+        $(DRIVERS)/api/no_os_irq.c \
+        $(NO-OS)/util/no_os_lf256fifo.c \
+        $(NO-OS)/util/no_os_list.c \
+        $(NO-OS)/util/no_os_util.c \
+        $(NO-OS)/util/no_os_alloc.c \
+        $(NO-OS)/util/no_os_mutex.c \
+        $(NO-OS)/util/no_os_fifo.c
+
+INCS += $(INCLUDE)/no_os_delay.h \
+        $(INCLUDE)/no_os_error.h \
+        $(INCLUDE)/no_os_irq.h \
+        $(INCLUDE)/no_os_uart.h \
+        $(INCLUDE)/no_os_lf256fifo.h \
+        $(INCLUDE)/no_os_list.h \
+        $(INCLUDE)/no_os_util.h \
+        $(INCLUDE)/no_os_alloc.h \
+        $(INCLUDE)/no_os_mutex.h \
+        $(INCLUDE)/no_os_print_log.h
+
+# Xilinx platform drivers
+SRCS += $(PLATFORM_DRIVERS)/xilinx_uart.c \
+        $(PLATFORM_DRIVERS)/xilinx_gpio.c \
+        $(PLATFORM_DRIVERS)/xilinx_irq.c \
+        $(PLATFORM_DRIVERS)/xilinx_delay.c
+
+INCS += $(PLATFORM_DRIVERS)/xilinx_uart.h \
+        $(PLATFORM_DRIVERS)/xilinx_gpio.h \
+        $(PLATFORM_DRIVERS)/xilinx_irq.h

--- a/projects/xilinx_lwip/src/common/app_config.h
+++ b/projects/xilinx_lwip/src/common/app_config.h
@@ -1,0 +1,38 @@
+/***************************************************************************//**
+ *   @file   app_config.h
+ *   @brief  Config file for the Xilinx IIO lwIP demo project.
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __APP_CONFIG_H__
+#define __APP_CONFIG_H__
+
+#undef ENABLE_LOOPBACK
+#define ENABLE_LOOPBACK
+
+#endif /* __APP_CONFIG_H__ */

--- a/projects/xilinx_lwip/src/common/common_data.c
+++ b/projects/xilinx_lwip/src/common/common_data.c
@@ -1,0 +1,70 @@
+/***************************************************************************//**
+ *   @file   common_data.c
+ *   @brief  Definitions of common init params for the xilinx_lwip project.
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "common_data.h"
+
+struct no_os_uart_init_param xilinx_lwip_uart_ip = {
+	.device_id = UART_DEVICE_ID,
+	.irq_id    = UART_IRQ_ID,
+	.asynchronous_rx = true,
+	.baud_rate = UART_BAUDRATE,
+	.size      = NO_OS_UART_CS_8,
+	.parity    = NO_OS_UART_PAR_NO,
+	.stop      = NO_OS_UART_STOP_1_BIT,
+	.extra     = UART_EXTRA,
+	.platform_ops = UART_OPS,
+};
+
+#ifndef ECHO_EXAMPLE
+
+#ifdef ENABLE_LOOPBACK
+static uint16_t loopback_buffs[DEMO_CHANNELS][SAMPLES_PER_CHANNEL];
+#endif
+
+struct adc_demo_init_param adc_init_par = {
+	.ext_buff_len = SAMPLES_PER_CHANNEL,
+	.ext_buff = (uint16_t **)loopback_buffs,
+	.dev_global_attr = 3333,
+	.dev_ch_attr = {1111, 1112, 1113, 1114},
+};
+
+struct dac_demo_init_param dac_init_par = {
+	.loopback_buffer_len = SAMPLES_PER_CHANNEL,
+	.loopback_buffers = (uint16_t **)loopback_buffs,
+	.dev_global_attr = 4444,
+	.dev_ch_attr = {1111, 1112, 1113, 1114},
+};
+
+uint8_t in_buff[MAX_SIZE_BASE_ADDR];
+uint8_t out_buff[MAX_SIZE_BASE_ADDR];
+
+#endif /* ECHO_EXAMPLE */

--- a/projects/xilinx_lwip/src/common/common_data.h
+++ b/projects/xilinx_lwip/src/common/common_data.h
@@ -1,0 +1,77 @@
+/***************************************************************************//**
+ *   @file   common_data.h
+ *   @brief  Common init params shared across the xilinx_lwip project.
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __COMMON_DATA_H__
+#define __COMMON_DATA_H__
+
+#include <stdint.h>
+#include "platform_includes.h"
+#include "app_config.h"
+#include "no_os_uart.h"
+#include "no_os_util.h"
+
+/* UART init params - not used for IIO under NO_OS_LWIP_NETWORKING but still
+ * required as a field in iio_app_init_param. */
+extern struct no_os_uart_init_param xilinx_lwip_uart_ip;
+
+#ifndef ECHO_EXAMPLE
+
+#include "adc_demo.h"
+#include "dac_demo.h"
+
+/* Number of virtual channels in each demo device */
+#undef TOTAL_ADC_CHANNELS
+#define TOTAL_ADC_CHANNELS	4
+#undef TOTAL_DAC_CHANNELS
+#define TOTAL_DAC_CHANNELS	4
+#define DEMO_CHANNELS		no_os_max(TOTAL_ADC_CHANNELS, TOTAL_DAC_CHANNELS)
+
+#ifdef ENABLE_LOOPBACK
+#define SAMPLES_PER_CHANNEL	SAMPLES_PER_CHANNEL_PLATFORM
+#else
+#define SAMPLES_PER_CHANNEL	0
+#define loopback_buffs		NULL
+#endif
+
+#define MAX_SIZE_BASE_ADDR	(SAMPLES_PER_CHANNEL * DEMO_CHANNELS * sizeof(uint16_t))
+
+extern uint8_t in_buff[];
+extern uint8_t out_buff[];
+
+#define ADC_DDR_BASEADDR	in_buff
+#define DAC_DDR_BASEADDR	out_buff
+
+extern struct adc_demo_init_param adc_init_par;
+extern struct dac_demo_init_param dac_init_par;
+
+#endif /* ECHO_EXAMPLE */
+
+#endif /* __COMMON_DATA_H__ */

--- a/projects/xilinx_lwip/src/examples/echo_lwip/echo_lwip_example.c
+++ b/projects/xilinx_lwip/src/examples/echo_lwip/echo_lwip_example.c
@@ -1,0 +1,83 @@
+/***************************************************************************//**
+ *   @file   echo_lwip_example.c
+ *   @brief  TCP echo server over Ethernet (lwIP / XEmacPs) for Xilinx boards.
+ *   @author Nicolae-Daniel Deaconescu (Nicolae-daniel.Deaconescu@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <string.h>
+#include <stdio.h>
+#include "no_os_error.h"
+#include "lwip_socket.h"
+#include "lwip_xemacps.h"
+#include "tcpecho_raw.h"
+#include "parameters.h"
+#include "echo_lwip_example.h"
+
+/* MAC address - must be unique on the local network */
+static uint8_t mac_addr[6] = {0x00, 0x0A, 0x35, 0x00, 0x01, 0x02};
+
+/***************************************************************************//**
+ * @brief Run the TCP echo server on the board.
+ *
+ * Initialises the XEmacPs MAC, brings up the lwIP stack, starts the
+ * tcpecho_raw server on port 7, and polls indefinitely.
+ *
+ * @return 0 on success, negative error code on failure.
+*******************************************************************************/
+int echo_lwip_example_main(void)
+{
+	struct lwip_network_desc *lwip_desc;
+	struct xemacps_init_param gem_ip = {
+		.device_id = GEM_DEVICE_ID,
+	};
+	struct lwip_network_param lwip_param = {
+		.platform_ops = &xemacps_lwip_ops,
+		.mac_param    = &gem_ip,
+	};
+	int ret;
+
+	memcpy(gem_ip.hwaddr, mac_addr, sizeof(mac_addr));
+	memcpy(lwip_param.hwaddr, mac_addr, sizeof(mac_addr));
+
+	ret = no_os_lwip_init(&lwip_desc, &lwip_param);
+	if (ret)
+		return ret;
+
+	tcpecho_raw_init();
+
+	printf("echo: listening on port 7\n");
+
+	while (1)
+		no_os_lwip_step(lwip_desc, lwip_desc);
+
+	no_os_lwip_remove(lwip_desc);
+
+	return 0;
+}

--- a/projects/xilinx_lwip/src/examples/echo_lwip/echo_lwip_example.h
+++ b/projects/xilinx_lwip/src/examples/echo_lwip/echo_lwip_example.h
@@ -1,0 +1,39 @@
+/***************************************************************************//**
+ *   @file   echo_lwip_example.h
+ *   @brief  Header for the TCP echo server example.
+ *   @author Nicolae-Daniel Deaconescu (Nicolae-daniel.Deaconescu@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef __ECHO_LWIP_EXAMPLE_H__
+#define __ECHO_LWIP_EXAMPLE_H__
+
+int echo_lwip_example_main(void);
+
+#endif /* __ECHO_LWIP_EXAMPLE_H__ */

--- a/projects/xilinx_lwip/src/examples/iio_lwip/iio_lwip_example.c
+++ b/projects/xilinx_lwip/src/examples/iio_lwip/iio_lwip_example.c
@@ -1,0 +1,140 @@
+/***************************************************************************//**
+ *   @file   iio_lwip_example.c
+ *   @brief  IIO over Ethernet (lwIP / XEmacPs) example for Xilinx Zynq boards.
+ *
+ *   Exposes virtual ADC and DAC demo devices over the iiod TCP protocol
+ *   on port 30431. Connect from a host running libiio:
+ *
+ *     iio_info -n ip:<board-ip>
+ *
+ *   @author Nicolae-Daniel Deaconescu (Nicolae-daniel.Deaconescu@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <string.h>
+#include "no_os_error.h"
+#include "no_os_util.h"
+#include "iio_app.h"
+#include "lwip_xemacps.h"
+#include "adc_demo.h"
+#include "iio_adc_demo.h"
+#include "dac_demo.h"
+#include "iio_dac_demo.h"
+#include "common_data.h"
+#include "parameters.h"
+#include "iio_lwip_example.h"
+
+/*
+ * MAC address for this board. Must be unique on the local network.
+ * Change the last three bytes (OUI 00:0A:35 is assigned to Xilinx/AMD).
+ */
+static uint8_t mac_addr[6] = {0x00, 0x0A, 0x35, 0x00, 0x01, 0x02};
+
+/* IIO data buffers */
+#define DATA_BUFFER_SAMPLES	SAMPLES_PER_CHANNEL_PLATFORM
+static uint8_t adc_data_buffer[DATA_BUFFER_SAMPLES * TOTAL_ADC_CHANNELS *
+						   sizeof(uint16_t)];
+static uint8_t dac_data_buffer[DATA_BUFFER_SAMPLES * TOTAL_DAC_CHANNELS *
+						   sizeof(uint16_t)];
+
+/***************************************************************************//**
+ * @brief Run the IIO over Ethernet demo.
+ *
+ * Initialises the virtual ADC/DAC IIO demo devices, configures the XEmacPs
+ * MAC driver as the lwIP network backend, and enters the iio_app_run() loop.
+ * This function does not return under normal operation.
+ *
+ * @return 0 on success, negative error code on initialisation failure.
+*******************************************************************************/
+int iio_lwip_example_main(void)
+{
+	struct adc_demo_desc *adc_desc;
+	struct dac_demo_desc *dac_desc;
+	struct iio_app_desc *app;
+	int ret;
+
+	/* --- Initialise virtual IIO devices --- */
+	ret = adc_demo_init(&adc_desc, &adc_init_par);
+	if (ret)
+		return ret;
+
+	ret = dac_demo_init(&dac_desc, &dac_init_par);
+	if (ret)
+		goto remove_adc;
+
+	/* --- IIO device + buffer descriptors --- */
+	struct iio_data_buffer adc_buff = {
+		.buff = adc_data_buffer,
+		.size = sizeof(adc_data_buffer),
+	};
+
+	struct iio_data_buffer dac_buff = {
+		.buff = dac_data_buffer,
+		.size = sizeof(dac_data_buffer),
+	};
+
+	struct iio_app_device iio_devices[] = {
+		IIO_APP_DEVICE("adc_demo", adc_desc,
+			       &adc_demo_iio_descriptor, &adc_buff, NULL, NULL),
+		IIO_APP_DEVICE("dac_demo", dac_desc,
+			       &dac_demo_iio_descriptor, NULL, &dac_buff, NULL),
+	};
+
+	/* --- XEmacPs GEM init params --- */
+	struct xemacps_init_param gem_ip = {
+		.device_id = GEM_DEVICE_ID,
+	};
+	memcpy(gem_ip.hwaddr, mac_addr, sizeof(mac_addr));
+
+	/* --- iio_app init --- */
+	struct iio_app_init_param app_init_param = {0};
+
+	app_init_param.devices = iio_devices;
+	app_init_param.nb_devices = NO_OS_ARRAY_SIZE(iio_devices);
+	app_init_param.uart_init_params = xilinx_lwip_uart_ip;
+	app_init_param.lwip_param.platform_ops = &xemacps_lwip_ops;
+	app_init_param.lwip_param.mac_param    = &gem_ip;
+	memcpy(app_init_param.lwip_param.hwaddr, mac_addr, sizeof(mac_addr));
+
+	ret = iio_app_init(&app, app_init_param);
+	if (ret)
+		goto remove_dac;
+
+	/* Loops indefinitely, serving iiod connections on TCP port 30431 */
+	ret = iio_app_run(app);
+
+	iio_app_remove(app);
+
+remove_dac:
+	dac_demo_remove(dac_desc);
+remove_adc:
+	adc_demo_remove(adc_desc);
+
+	return ret;
+}

--- a/projects/xilinx_lwip/src/examples/iio_lwip/iio_lwip_example.h
+++ b/projects/xilinx_lwip/src/examples/iio_lwip/iio_lwip_example.h
@@ -1,0 +1,38 @@
+/***************************************************************************//**
+ *   @file   iio_lwip_example.h
+ *   @brief  IIO lwIP example header for the cora_z7 project.
+ *   @author Nicolae-Daniel Deaconescu (Nicolae-daniel.Deaconescu@analog.com)
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __IIO_LWIP_EXAMPLE_H__
+#define __IIO_LWIP_EXAMPLE_H__
+
+int iio_lwip_example_main(void);
+
+#endif /* __IIO_LWIP_EXAMPLE_H__ */

--- a/projects/xilinx_lwip/src/platform/platform_includes.h
+++ b/projects/xilinx_lwip/src/platform/platform_includes.h
@@ -1,0 +1,43 @@
+/***************************************************************************//**
+ *   @file   platform_includes.h
+ *   @brief  Platform-specific includes for the cora_z7 project.
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PLATFORM_INCLUDES_H__
+#define __PLATFORM_INCLUDES_H__
+
+#ifdef XILINX_PLATFORM
+#include "xilinx/parameters.h"
+#endif
+
+#ifdef IIO_SUPPORT
+#include "iio_app.h"
+#endif
+
+#endif /* __PLATFORM_INCLUDES_H__ */

--- a/projects/xilinx_lwip/src/platform/xilinx/main.c
+++ b/projects/xilinx_lwip/src/platform/xilinx/main.c
@@ -1,0 +1,66 @@
+/***************************************************************************//**
+ *   @file   main.c
+ *   @brief  Main entry point for the Xilinx IIO lwIP demo.
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <stdio.h>
+#include <xil_cache.h>
+#include "no_os_error.h"
+
+#if defined(ECHO_EXAMPLE)
+#include "echo_lwip_example.h"
+#else
+#include "iio_lwip_example.h"
+#endif
+
+int main(void)
+{
+	int ret;
+
+	/*
+	 * On Cortex-A53 (ZynqMP) the BSP boot code (boot.S / translation_table.S)
+	 * already enables caches and the MMU before main(). Calling the enable
+	 * functions again is harmless but unnecessary.
+	 * On Cortex-A9 (Zynq-7000) caches are off at reset and must be enabled here.
+	 */
+	Xil_ICacheEnable();
+	Xil_DCacheEnable();
+
+	printf("main: caches enabled\n");
+
+#if defined(ECHO_EXAMPLE)
+	ret = echo_lwip_example_main();
+#else
+	ret = iio_lwip_example_main();
+#endif
+
+	printf("main: example exited with %d\n", ret);
+	return ret;
+}

--- a/projects/xilinx_lwip/src/platform/xilinx/parameters.c
+++ b/projects/xilinx_lwip/src/platform/xilinx/parameters.c
@@ -1,0 +1,42 @@
+/***************************************************************************//**
+ *   @file   parameters.c
+ *   @brief  Xilinx platform-specific data definitions for the xilinx_lwip project.
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "parameters.h"
+
+struct xil_uart_init_param xilinx_lwip_uart_extra_ip = {
+#ifdef XPAR_XUARTLITE_NUM_INSTANCES
+	.type = UART_PL,
+#else
+	.type = UART_PS,
+	.irq_id = UART_IRQ_ID,
+#endif
+};

--- a/projects/xilinx_lwip/src/platform/xilinx/parameters.h
+++ b/projects/xilinx_lwip/src/platform/xilinx/parameters.h
@@ -1,0 +1,79 @@
+/***************************************************************************//**
+ *   @file   parameters.h
+ *   @brief  Xilinx platform-specific definitions for the xilinx_lwip project.
+********************************************************************************
+ * Copyright 2025(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
+
+#include <xparameters.h>
+#include <xil_cache.h>
+#include "xilinx_uart.h"
+
+/* PS (Zynq-7000 / ZynqMP) peripheral IDs */
+#ifdef _XPARAMETERS_PS_H_
+#define UART_DEVICE_ID		XPAR_XUARTPS_0_DEVICE_ID
+#define INTC_DEVICE_ID		XPAR_SCUGIC_SINGLE_DEVICE_ID
+#define UART_IRQ_ID		XPAR_XUARTPS_1_INTR
+#else
+/* Fallback for MicroBlaze / PL UART */
+#define UART_DEVICE_ID		XPAR_AXI_UART_DEVICE_ID
+#define INTC_DEVICE_ID		XPAR_INTC_SINGLE_DEVICE_ID
+#define UART_IRQ_ID		XPAR_AXI_INTC_AXI_UART_INTERRUPT_INTR
+#endif
+
+#define UART_EXTRA		&xilinx_lwip_uart_extra_ip
+#define UART_OPS		&xil_uart_ops
+
+/* Buffer depth for virtual IIO demo devices */
+#define SAMPLES_PER_CHANNEL_PLATFORM	2000
+#define UART_BAUDRATE			        115200
+
+/*
+ * GEM instance selection. Override at build time with -DGEM_INSTANCE=1
+ */
+#ifndef GEM_INSTANCE
+#define GEM_INSTANCE	0
+#endif
+
+#if GEM_INSTANCE == 0 && defined(XPAR_XEMACPS_0_DEVICE_ID)
+#define GEM_DEVICE_ID	XPAR_XEMACPS_0_DEVICE_ID
+#elif GEM_INSTANCE == 1 && defined(XPAR_XEMACPS_1_DEVICE_ID)
+#define GEM_DEVICE_ID	XPAR_XEMACPS_1_DEVICE_ID
+#elif GEM_INSTANCE == 2 && defined(XPAR_XEMACPS_2_DEVICE_ID)
+#define GEM_DEVICE_ID	XPAR_XEMACPS_2_DEVICE_ID
+#elif GEM_INSTANCE == 3 && defined(XPAR_XEMACPS_3_DEVICE_ID)
+#define GEM_DEVICE_ID	XPAR_XEMACPS_3_DEVICE_ID
+#else
+#error "GEM_INSTANCE not available - check your .xsa / BSP configuration"
+#endif
+
+extern struct xil_uart_init_param xilinx_lwip_uart_extra_ip;
+
+#endif /* __PARAMETERS_H__ */

--- a/projects/xilinx_lwip/src/platform/xilinx/parameters.h
+++ b/projects/xilinx_lwip/src/platform/xilinx/parameters.h
@@ -57,11 +57,25 @@
 
 /*
  * GEM instance selection. Override at build time with -DGEM_INSTANCE=1
+ *
  */
 #ifndef GEM_INSTANCE
 #define GEM_INSTANCE	0
 #endif
 
+#ifdef SDT
+#if GEM_INSTANCE == 0 && defined(XPAR_XEMACPS_0_BASEADDR)
+#define GEM_DEVICE_ID	XPAR_XEMACPS_0_BASEADDR
+#elif GEM_INSTANCE == 1 && defined(XPAR_XEMACPS_1_BASEADDR)
+#define GEM_DEVICE_ID	XPAR_XEMACPS_1_BASEADDR
+#elif GEM_INSTANCE == 2 && defined(XPAR_XEMACPS_2_BASEADDR)
+#define GEM_DEVICE_ID	XPAR_XEMACPS_2_BASEADDR
+#elif GEM_INSTANCE == 3 && defined(XPAR_XEMACPS_3_BASEADDR)
+#define GEM_DEVICE_ID	XPAR_XEMACPS_3_BASEADDR
+#else
+#error "GEM_INSTANCE not available - check your .xsa / BSP configuration"
+#endif
+#else /* legacy non-SDT BSP */
 #if GEM_INSTANCE == 0 && defined(XPAR_XEMACPS_0_DEVICE_ID)
 #define GEM_DEVICE_ID	XPAR_XEMACPS_0_DEVICE_ID
 #elif GEM_INSTANCE == 1 && defined(XPAR_XEMACPS_1_DEVICE_ID)
@@ -73,6 +87,7 @@
 #else
 #error "GEM_INSTANCE not available - check your .xsa / BSP configuration"
 #endif
+#endif /* SDT */
 
 extern struct xil_uart_init_param xilinx_lwip_uart_extra_ip;
 


### PR DESCRIPTION
## Pull Request Description

Added ethernet support for xilinx boards using the XEMacPs driver, following the [AMD Programming Guide](https://docs.amd.com/r/en-US/ug585-zynq-7000-SoC-TRM/Programming-Guide?tocId=dp5v~GxO_gy4dRHC6sYxjQ).

## Components:

- Standalone XEmacPs MAC driver(drivers/net/xemacps/): Includes PHY registration, autonegotiation, and init/remove, send/recv/poll functionality. Note: Zynq-7000 processors have a [hardware bug](https://adaptivesupport.amd.com/s/article/52028?language=en_US) that causes the RX data path to lock up under heavy traffic, requiring resets. 
- LwIP integration layer(network/lwip_raw_socket/netdevs/xemacps/): Integration layer for LwIP that calls the driver code, similar to the adin1110 driver
- LwIP raw socket updates (network/lwip_raw_socket/lwip_socket.c): removed dependency on adin1110 driver, updated heap allocations, removed unused variables.
- Project examples (projects/xilinx_lwip/) : an LwIP TCP echo server and an IIO server over ethernet.
- README file detailing build commands, pre-requisites and usages

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
