### PR TITLE
Fix axi dmac driver addressing issue

### DIFF
--- a/drivers/axi_core/axi_dmac/axi_dmac.c
+++ b/drivers/axi_core/axi_dmac/axi_dmac.c
@@ -459,8 +459,8 @@ int32_t axi_dmac_transfer_start(struct axi_dmac *dmac,
 			axi_dmac_write(dmac, AXI_DMAC_REG_DEST_STRIDE, 0x0);
 			axi_dmac_write(dmac, AXI_DMAC_REG_SRC_ADDRESS, dmac->next_src_addr);
 			axi_dmac_write(dmac, AXI_DMAC_REG_SRC_STRIDE, 0x0);
-			if ((dmac->transfer.dest_addr % (dmac->width_dst / 8))
-			    || (dmac->transfer.src_addr % (dmac->width_src / 8))) {
+			if ((dmac->transfer.dest_addr % (dmac->width_dst))
+			    || (dmac->transfer.src_addr % (dmac->width_src))) {
 				printf("Source and destination addresses should be aligned with data path widths.\n");
 				return -1;
 			}


### PR DESCRIPTION
## Pull Request Description

There was a divide by 0 in one of the conditions.The divide by 8 doesen't make sense because at this point the width is already in bytes.

Fixes : bd9f1982b799243306f4989515c3db5dd5d6ce26 : ("drivers: axi_dmac.c: Force DMA buffer alignment")

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
