### PR TITLE
drivers: amplifiers: ada4250: fix resource leak in ada4250_init

### DIFF
--- a/drivers/amplifiers/ada4250/ada4250.c
+++ b/drivers/amplifiers/ada4250/ada4250.c
@@ -551,7 +551,7 @@ int32_t ada4250_init(struct ada4250_dev **device,
 		/* SPI */
 		ret = no_os_spi_init(&dev->spi_desc, init_param->spi_init);
 		if (ret != 0)
-			goto error_dev;
+			goto error_slp;
 
 		ret = ada4250_read(dev, ADA4250_REG_CHIP_ID2, &data);
 		if (ret != 0)
@@ -572,11 +572,11 @@ int32_t ada4250_init(struct ada4250_dev **device,
 
 		ret = ada4250_soft_reset(dev);
 		if (ret != 0)
-			return -1;
+			goto error_spi;
 	} else {
 		ret = no_os_gpio_get(&dev->gpio_g2, init_param->gpio_g2_param);
 		if (ret != 0)
-			goto error_dev;
+			goto error_slp;
 
 		ret = no_os_gpio_direction_output(dev->gpio_g2, NO_OS_GPIO_LOW);
 		if (ret != 0)
@@ -609,23 +609,29 @@ int32_t ada4250_init(struct ada4250_dev **device,
 	/* Initialize gpio bandwidth and pull it to high */
 	ret = no_os_gpio_get_optional(&dev->gpio_bw, init_param->gpio_bw_param);
 	if (ret != 0)
-		return -1;
+		goto error_config;
 
 	ret = no_os_gpio_direction_output(dev->gpio_bw, NO_OS_GPIO_HIGH);
 	if (ret != 0)
-		return -1;
+		goto error_bw;
 
 	ret = ada4250_set_config(dev);
 	if (ret != 0)
-		return -1;
+		goto error_bw;
 
 	*device = dev;
 
 	return ret;
 
+error_bw:
+	no_os_gpio_remove(dev->gpio_bw);
+error_config:
+	if (dev->device_id == ADA4250)
+		goto error_spi;
+	goto error_bufen;
 error_spi:
 	no_os_spi_remove(dev->spi_desc);
-	goto error_dev;
+	goto error_slp;
 error_bufen:
 	no_os_gpio_remove(dev->gpio_bufen);
 error_g0:


### PR DESCRIPTION
Several error paths in ada4250_init() either return directly or jump to error_dev, bypassing cleanup of already-initialized GPIOs and SPI resources. Route all error paths through the appropriate cleanup labels to ensure proper resource release on failure.

Fixes: 014488c6ff24 ("drivers: amplifiers: add ada4230 support")

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
