### PR TITLE
drivers: afe: ad413x: fix resource leak in ad413x_init error paths

### DIFF
--- a/drivers/afe/ad413x/ad413x.c
+++ b/drivers/afe/ad413x/ad413x.c
@@ -923,22 +923,22 @@ int32_t ad413x_init(struct ad413x_dev **device,
 	/* RDY pin */
 	ret = no_os_gpio_get(&dev->rdy_pin_desc, init_param.rdy_pin_init);
 	if (ret)
-		goto err_dev;
+		goto err_spi;
 
 	/* Enable the input direction of the specified GPIO. */
 	ret = no_os_gpio_direction_input(dev->rdy_pin_desc);
 	if (ret)
-		goto err_dev;
+		goto err_gpio;
 
 	/* Device Settings */
 	ret = ad413x_do_soft_reset(dev);
 	if (ret)
-		goto err_spi;
+		goto err_gpio;
 
 	/* Reset POR flag */
 	ret = ad413x_reg_read(dev, AD413X_REG_STATUS, &reg_data);
 	if (ret)
-		goto err_spi;
+		goto err_gpio;
 
 	/* Change SPI to 4 wire*/
 	ret = ad413x_reg_write_msk(dev,
@@ -946,25 +946,25 @@ int32_t ad413x_init(struct ad413x_dev **device,
 				   AD413X_ADC_CSB_EN,
 				   AD413X_ADC_CSB_EN);
 	if (ret)
-		goto err_spi;
+		goto err_gpio;
 
 	ret = ad413x_reg_read(dev, AD413X_REG_ID, &reg_data);
 	if (ret)
-		goto err_spi;
+		goto err_gpio;
 
 	switch (dev->chip_id) {
 	case AD4130_8:
 		if (reg_data != AD4130_8) {
-			goto err_spi;
+			goto err_gpio;
 		}
 		break;
 	default:
-		goto err_spi;
+		goto err_gpio;
 	}
 
 	ret = ad413x_set_adc_mode(dev, AD413X_STANDBY_MODE);
 	if (ret)
-		goto err_spi;
+		goto err_gpio;
 
 	if (init_param.spi_crc_en) {
 		ret = ad413x_reg_write_msk(dev,
@@ -972,7 +972,7 @@ int32_t ad413x_init(struct ad413x_dev **device,
 					   AD413X_SPI_CRC_ERR_EN,
 					   AD413X_SPI_CRC_ERR_EN);
 		if (ret)
-			goto err_spi;
+			goto err_gpio;
 		dev->spi_crc_en = init_param.spi_crc_en;
 	}
 
@@ -980,21 +980,21 @@ int32_t ad413x_init(struct ad413x_dev **device,
 	for (i = 0; i < 8; i++) {
 		ret = ad413x_preset_store(dev, init_param.preset[i], i);
 		if (ret)
-			goto err_spi;
+			goto err_gpio;
 	}
 
 	/* Channel setup */
 	for (i = 0; i < 16; i++) {
 		ret = ad413x_set_ch_preset(dev, i, init_param.ch[i].preset);
 		if (ret)
-			goto err_spi;
+			goto err_gpio;
 
 		ret = ad413x_reg_write_msk(dev,
 					   AD413X_REG_CHN(i),
 					   AD413X_AINP_M(init_param.ch[i].ain_p),
 					   AD413X_AINP_M(0xFF));
 		if (ret)
-			goto err_spi;
+			goto err_gpio;
 		dev->ch[i].ain_p = init_param.ch[i].ain_p;
 
 		ret = ad413x_reg_write_msk(dev,
@@ -1002,52 +1002,54 @@ int32_t ad413x_init(struct ad413x_dev **device,
 					   AD413X_AINM_M(init_param.ch[i].ain_m),
 					   AD413X_AINM_M(0xFF));
 		if (ret)
-			goto err_spi;
+			goto err_gpio;
 		dev->ch[i].ain_m = init_param.ch[i].ain_m;
 
 		ret = ad413x_ch_exc_input(dev, i, init_param.ch[i].iout0_exc_input,
 					  init_param.ch[i].iout1_exc_input);
 		if (ret)
-			goto err_spi;
+			goto err_gpio;
 
 		ret = ad413x_pdsw_en(dev, i, init_param.ch[i].pdsw_en);
 		if (ret)
-			goto err_spi;
+			goto err_gpio;
 
 		ret = ad413x_ch_en(dev, i, init_param.ch[i].enable);
 		if (ret)
-			goto err_spi;
+			goto err_gpio;
 	}
 
 	ret = ad413x_set_int_ref(dev, init_param.int_ref);
 	if (ret)
-		goto err_spi;
+		goto err_gpio;
 
 	ret = ad413x_adc_bipolar(dev, init_param.bipolar);
 	if (ret)
-		goto err_spi;
+		goto err_gpio;
 
 	ret = ad413x_set_v_bias(dev, init_param.v_bias);
 	if (ret)
-		goto err_spi;
+		goto err_gpio;
 
 	ret = ad413x_set_standby_ctrl(dev, init_param.standby_ctrl);
 	if (ret)
-		goto err_spi;
+		goto err_gpio;
 
 	ret = ad413x_set_mclk(dev, init_param.mclk);
 	if (ret)
-		goto err_spi;
+		goto err_gpio;
 
 	ret = ad413x_data_stat_en(dev, init_param.data_stat);
 	if (ret)
-		goto err_spi;
+		goto err_gpio;
 
 	*device = dev;
 
 	pr_info("AD413X successfully initialized\n");
 	return 0;
 
+err_gpio:
+	no_os_gpio_remove(dev->rdy_pin_desc);
 err_spi:
 	no_os_spi_remove(dev->spi_dev);
 err_dev:


### PR DESCRIPTION
The error cleanup labels do not account for the GPIO resource. After rdy_pin_desc is initialized, all error paths jump to err_spi which only removes the SPI interface, leaking the GPIO descriptor. Also, GPIO init failures jump to err_dev which skips SPI cleanup.

Add an err_gpio label that removes rdy_pin_desc and falls through to err_spi. Route all post-GPIO error paths through err_gpio and fix the GPIO init failure paths to jump to err_spi.

Fixes: ae341da459aa ("ad413x: Fix resource leak on error path")

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
