### PR TITLE
drivers: adc: ad405x: fix GPIO leak in ad405x_init error paths

### DIFF
--- a/drivers/adc/ad405x/ad405x.c
+++ b/drivers/adc/ad405x/ad405x.c
@@ -117,7 +117,7 @@ int ad405x_init(struct ad405x_dev **device,
 				     init_param.comm_init.i3c_init);
 	}
 	if (ret)
-		goto error_dev;
+		goto error_gpio;
 
 	dev->dev_type = init_param.dev_type;
 
@@ -168,6 +168,11 @@ error_com:
 		no_os_spi_remove(dev->com_desc.spi_desc);
 	else
 		no_os_i3c_remove(dev->com_desc.i3c_desc);
+error_gpio:
+	no_os_gpio_remove(dev->gpio_gpio0);
+	no_os_gpio_remove(dev->gpio_gpio1);
+	if (dev->comm_type == AD405X_SPI_COMM)
+		no_os_gpio_remove(dev->extra.spi_extra.gpio_cnv);
 error_dev:
 	no_os_free(dev);
 	return ret;


### PR DESCRIPTION
When ad405x_init_gpios() succeeds but the subsequent SPI/I3C init fails, error_dev only calls no_os_free() without removing the GPIOs. Similarly, error_com only removes the comm interface but not the GPIOs. Add an error_gpio label between them to properly release gpio_gpio0, gpio_gpio1 and gpio_cnv on failure.

Fixes: 0f181cb26f6c ("drivers: ad405x: fix GPIO leak in error paths")

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
