### PR TITLE
drivers: adc: ad463x: fix resource leak in ad463x_init error paths

### DIFF
--- a/drivers/adc/ad463x/ad463x.c
+++ b/drivers/adc/ad463x/ad463x.c
@@ -825,22 +825,22 @@ int32_t ad463x_init(struct ad463x_dev **device,
 	ret = ad463x_spi_reg_write_masked(dev, AD463X_REG_MODES, AD463X_LANE_MODE_MSK,
 					  dev->lane_mode);
 	if (ret != 0)
-		return ret;
+		goto error_spi;
 
 	ret = ad463x_spi_reg_write_masked(dev, AD463X_REG_MODES, AD463X_CLK_MODE_MSK,
 					  dev->clock_mode);
 	if (ret != 0)
-		return ret;
+		goto error_spi;
 
 	ret = ad463x_spi_reg_write_masked(dev, AD463X_REG_MODES, AD463X_DDR_MODE_MSK,
 					  dev->data_rate);
 	if (ret != 0)
-		return ret;
+		goto error_spi;
 
 	ret = ad463x_spi_reg_write_masked(dev, AD463X_REG_MODES,
 					  AD463X_OUT_DATA_MODE_MSK, dev->output_mode);
 	if (ret != 0)
-		return ret;
+		goto error_spi;
 
 	if (dev->spi_dma_enable || dev->offload_enable) {
 		ret = no_os_pwm_init(&dev->trigger_pwm_desc,


### PR DESCRIPTION
Four ad463x_spi_reg_write_masked() calls for mode configuration use bare return statements instead of goto error_spi, bypassing cleanup of the SPI descriptor, clock generator, GPIOs and device descriptor. Replace return with goto error_spi to use the existing cleanup chain.

Fixes: fe417e15292b ("adc: ad463x: initial commit")

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
