### PR TITLE
drivers: net: oa_tc6: Fix RTSA/RTSP handling

### DIFF
--- a/drivers/net/oa_tc6/oa_tc6.c
+++ b/drivers/net/oa_tc6/oa_tc6.c
@@ -499,8 +499,6 @@ static int oa_tc6_rx_chunk_to_frame(struct oa_tc6_desc *desc, uint8_t *chunks,
 
 				/* Flags valid when EV=1 Only */
 				frame_buffer->frame_drop = !!(footer & OA_DATA_FOOTER_FD_MASK);
-				frame_buffer->rtsa = !!(footer & OA_DATA_FOOTER_RTSA_MASK);
-				frame_buffer->rtsp = !!(footer & OA_DATA_FOOTER_RTSP_MASK);
 
 				/* Now get a new buffer for the second frame */
 				ret = oa_tc6_get_empty_rx_buff(desc, &frame_buffer, true);
@@ -529,6 +527,11 @@ static int oa_tc6_rx_chunk_to_frame(struct oa_tc6_desc *desc, uint8_t *chunks,
 			       ebo - sbo + 1);
 			frame_buffer->index += ebo - sbo + 1;
 			frame_buffer->len = frame_buffer->index;
+
+			//Flags valid when SV=1
+			frame_buffer->rtsa = !!(footer & OA_DATA_FOOTER_RTSA_MASK);
+			frame_buffer->rtsp = !!(footer & OA_DATA_FOOTER_RTSP_MASK);
+
 			frame_buffer->vs = no_os_field_get(OA_DATA_FOOTER_VS_MASK, footer);
 
 			if (frame_buffer->state == OA_BUFF_RX_COMPLETE) {
@@ -552,8 +555,6 @@ static int oa_tc6_rx_chunk_to_frame(struct oa_tc6_desc *desc, uint8_t *chunks,
 
 			/* Flags valid when EV=1 Only */
 			frame_buffer->frame_drop = !!(footer & OA_DATA_FOOTER_FD_MASK);
-			frame_buffer->rtsa = !!(footer & OA_DATA_FOOTER_RTSA_MASK);
-			frame_buffer->rtsp = !!(footer & OA_DATA_FOOTER_RTSP_MASK);
 
 			/* Get a new buffer for the next iteration */
 			ret = oa_tc6_get_empty_rx_buff(desc, &frame_buffer, true);
@@ -574,6 +575,11 @@ static int oa_tc6_rx_chunk_to_frame(struct oa_tc6_desc *desc, uint8_t *chunks,
 			frame_buffer->index += OA_CHUNK_SIZE - sbo;
 			frame_buffer->len = frame_buffer->index;
 			frame_buffer->state = OA_BUFF_RX_IN_PROGRESS;
+
+			//Flags valid when SV=1
+			frame_buffer->rtsa = !!(footer & OA_DATA_FOOTER_RTSA_MASK);
+			frame_buffer->rtsp = !!(footer & OA_DATA_FOOTER_RTSP_MASK);
+
 			frame_buffer->vs = no_os_field_get(OA_DATA_FOOTER_VS_MASK, footer);
 			chunks += OA_CHUNK_SIZE + OA_FOOTER_LEN;
 			continue;

--- a/drivers/net/oa_tc6/oa_tc6.c
+++ b/drivers/net/oa_tc6/oa_tc6.c
@@ -397,8 +397,10 @@ static int oa_tc6_tx_frame_to_chunks(struct oa_tc6_desc *desc,
 			header |= no_os_field_prep(OA_DATA_HEADER_DV_MASK, 1);
 			header |= no_os_field_prep(OA_DATA_HEADER_VS_MASK, frame_buffer->vs);
 
-			if (!i)
-				header |= no_os_field_prep(OA_DATA_FOOTER_SV_MASK, 1);
+			if (!i) {
+				header |= no_os_field_prep(OA_DATA_HEADER_SV_MASK, 1);
+				header |= no_os_field_prep(OA_DATA_HEADER_TSC_MASK, frame_buffer->tsc);
+			}
 
 			if (i == tx_frame_num_chunks - 1) {
 				header |= no_os_field_prep(OA_DATA_HEADER_EV_MASK, 1);

--- a/drivers/net/oa_tc6/oa_tc6.h
+++ b/drivers/net/oa_tc6/oa_tc6.h
@@ -107,6 +107,7 @@
 #define OA_DATA_HEADER_SWO_MASK		NO_OS_GENMASK(19, 16)
 #define OA_DATA_HEADER_EV_MASK		NO_OS_BIT(14)
 #define OA_DATA_HEADER_EBO_MASK		NO_OS_GENMASK(13, 8)
+#define OA_DATA_HEADER_TSC_MASK		NO_OS_GENMASK(7, 6)
 #define OA_DATA_HEADER_P_MASK		NO_OS_BIT(0)
 
 /* Standard control and status registers (MMS 0) */
@@ -187,8 +188,8 @@ struct oa_tc6_frame_buffer {
 	uint32_t len;
 	uint8_t data[CONFIG_OA_CHUNK_BUFFER_SIZE];
 	enum oa_tc6_user_buffer_state state;
-	uint8_t vs;
-
+	uint8_t vs;      /**< Vendor Specific. Tx or Rx */
+	uint8_t tsc;     /**< Timestamp capture. 2-bits. Tx Only */
 	bool frame_drop; /**< Frame should be dropped (is invalid). Rx Only */
 	bool rtsa;       /**< Timestamp added. Rx Only */
 	bool rtsp;       /**< Timestamp parity. Rx Only */


### PR DESCRIPTION
## Pull Request Description

Corrects the handling of the RTSA and RTSP flags. They are valid when SV=1.  The implementation was setting them based on the EV=1 bit instead.  This only has an impact if RX timestamping is enabled on the OASPI interface. 

Adds support for the TSC flags in the transmit header to enable Tx timestamping. Also corrects a minor constant usage issue which has no functional impact since the values were the same.

## PR Type
- [X] Bug fix (change that fixes an issue)
- [X] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [X] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [X] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [X] I have performed a self-review of the changes
- [X] I have commented my code, at least hard-to-understand parts
- [X] I have build all projects affected by the changes in this PR
- [X] I have tested in hardware affected projects, at the relevant boards
- [X] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
