### PR TITLE
drivers: afe: ad413x: add channel bounds check to public API functions

### DIFF
--- a/drivers/afe/ad413x/ad413x.c
+++ b/drivers/afe/ad413x/ad413x.c
@@ -400,6 +400,9 @@ int32_t ad413x_set_ch_preset(struct ad413x_dev *dev, uint8_t ch_nb,
 {
 	int32_t ret;
 
+	if (ch_nb >= NO_OS_ARRAY_SIZE(dev->ch))
+		return -EINVAL;
+
 	ret = ad413x_reg_write_msk(dev,
 				   AD413X_REG_CHN(ch_nb),
 				   AD413X_SETUP_M(preset_nb),
@@ -428,6 +431,9 @@ int32_t ad413x_ch_exc_input(struct ad413x_dev *dev, uint8_t ch_nb,
 {
 	int32_t ret;
 
+	if (ch_nb >= NO_OS_ARRAY_SIZE(dev->ch))
+		return -EINVAL;
+
 	ret = ad413x_reg_write_msk(dev,
 				   AD413X_REG_CHN(ch_nb),
 				   AD413X_I_OUT0_CH_M(iout0_exc_inp) |
@@ -455,6 +461,9 @@ int32_t ad413x_ch_en(struct ad413x_dev *dev, uint8_t ch_nb, uint8_t enable)
 {
 	int32_t ret;
 
+	if (ch_nb >= NO_OS_ARRAY_SIZE(dev->ch))
+		return -EINVAL;
+
 	ret = ad413x_reg_write_msk(dev,
 				   AD413X_REG_CHN(ch_nb),
 				   enable ? AD413X_ENABLE_M : 0x0U,
@@ -479,6 +488,9 @@ int32_t ad413x_ch_en(struct ad413x_dev *dev, uint8_t ch_nb, uint8_t enable)
 int32_t ad413x_pdsw_en(struct ad413x_dev *dev, uint8_t ch_nb, bool pdsw_en)
 {
 	int32_t ret;
+
+	if (ch_nb >= NO_OS_ARRAY_SIZE(dev->ch))
+		return -EINVAL;
 
 	ret = ad413x_reg_write_msk(dev,
 				   AD413X_REG_CHN(ch_nb),


### PR DESCRIPTION
ad413x_set_ch_preset(), ad413x_ch_exc_input(), ad413x_ch_en() and ad413x_pdsw_en() accept a uint8_t ch_nb parameter and use it to index dev->ch[16] without bounds checking. Passing ch_nb >= 16 writes beyond the array, corrupting adjacent memory.

Add a bounds check at the top of each function.

Fixes: 562506ea2a14 ("drivers: afe: add support for ad413x")

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
