### PR TITLE
drivers: maxim platform drivers: reset actions array to NULL.

### DIFF
--- a/drivers/platform/maxim/max32650/maxim_gpio_irq.c
+++ b/drivers/platform/maxim/max32650/maxim_gpio_irq.c
@@ -150,6 +150,7 @@ static int max_gpio_irq_ctrl_remove(struct no_os_irq_ctrl_desc *desc)
 		no_os_free(discard);
 
 	no_os_list_remove(actions[desc->irq_ctrl_id]);
+	actions[desc->irq_ctrl_id] = NULL;
 	no_os_free(desc);
 
 	return 0;

--- a/drivers/platform/maxim/max32655/maxim_gpio_irq.c
+++ b/drivers/platform/maxim/max32655/maxim_gpio_irq.c
@@ -143,6 +143,7 @@ static int max_gpio_irq_ctrl_remove(struct no_os_irq_ctrl_desc *desc)
 		no_os_free(discard);
 
 	no_os_list_remove(actions[desc->irq_ctrl_id]);
+	actions[desc->irq_ctrl_id] = NULL;
 	no_os_free(desc);
 
 	return 0;

--- a/drivers/platform/maxim/max32660/maxim_gpio_irq.c
+++ b/drivers/platform/maxim/max32660/maxim_gpio_irq.c
@@ -143,6 +143,7 @@ static int max_gpio_irq_ctrl_remove(struct no_os_irq_ctrl_desc *desc)
 		no_os_free(discard);
 
 	no_os_list_remove(actions[desc->irq_ctrl_id]);
+	actions[desc->irq_ctrl_id] = NULL;
 	no_os_free(desc);
 
 	return 0;

--- a/drivers/platform/maxim/max32662/maxim_gpio_irq.c
+++ b/drivers/platform/maxim/max32662/maxim_gpio_irq.c
@@ -143,6 +143,7 @@ static int max_gpio_irq_ctrl_remove(struct no_os_irq_ctrl_desc *desc)
 		no_os_free(discard);
 
 	no_os_list_remove(actions[desc->irq_ctrl_id]);
+	actions[desc->irq_ctrl_id] = NULL;
 	no_os_free(desc);
 
 	return 0;

--- a/drivers/platform/maxim/max32665/maxim_gpio_irq.c
+++ b/drivers/platform/maxim/max32665/maxim_gpio_irq.c
@@ -143,6 +143,7 @@ static int max_gpio_irq_ctrl_remove(struct no_os_irq_ctrl_desc *desc)
 		no_os_free(discard);
 
 	no_os_list_remove(actions[desc->irq_ctrl_id]);
+	actions[desc->irq_ctrl_id] = NULL;
 	no_os_free(desc);
 
 	return 0;

--- a/drivers/platform/maxim/max32670/maxim_gpio_irq.c
+++ b/drivers/platform/maxim/max32670/maxim_gpio_irq.c
@@ -143,6 +143,7 @@ static int max_gpio_irq_ctrl_remove(struct no_os_irq_ctrl_desc *desc)
 		no_os_free(discard);
 
 	no_os_list_remove(actions[desc->irq_ctrl_id]);
+	actions[desc->irq_ctrl_id] = NULL;
 	no_os_free(desc);
 
 	return 0;

--- a/drivers/platform/maxim/max32672/maxim_gpio_irq.c
+++ b/drivers/platform/maxim/max32672/maxim_gpio_irq.c
@@ -143,6 +143,7 @@ static int max_gpio_irq_ctrl_remove(struct no_os_irq_ctrl_desc *desc)
 		no_os_free(discard);
 
 	no_os_list_remove(actions[desc->irq_ctrl_id]);
+	actions[desc->irq_ctrl_id] = NULL;
 	no_os_free(desc);
 
 	return 0;

--- a/drivers/platform/maxim/max32690/maxim_gpio_irq.c
+++ b/drivers/platform/maxim/max32690/maxim_gpio_irq.c
@@ -156,6 +156,7 @@ static int max_gpio_irq_ctrl_remove(struct no_os_irq_ctrl_desc *desc)
 		no_os_free(discard);
 
 	no_os_list_remove(actions[desc->irq_ctrl_id]);
+	actions[desc->irq_ctrl_id] = NULL;
 	no_os_free(desc);
 
 	return 0;

--- a/drivers/platform/maxim/max78000/maxim_gpio_irq.c
+++ b/drivers/platform/maxim/max78000/maxim_gpio_irq.c
@@ -143,6 +143,7 @@ static int max_gpio_irq_ctrl_remove(struct no_os_irq_ctrl_desc *desc)
 		no_os_free(discard);
 
 	no_os_list_remove(actions[desc->irq_ctrl_id]);
+	actions[desc->irq_ctrl_id] = NULL;
 	no_os_free(desc);
 
 	return 0;


### PR DESCRIPTION
During initialization of gpio irq control inside max_gpio_irq_ctrl_init(), actions[param->irq_ctrl_id] is checked for NULL before it is assigned a new list. max_gpio_irq_ctrl_remove() should initialize the actions[] array index back to NULL after freeing the list assigned to the array index so future calls to max_gpio_irq_ctrl_init() will not skip over the list creation and actions[] array assignment.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [X] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [X] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [X] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [X] I have performed a self-review of the changes
- [X] I have commented my code, at least hard-to-understand parts
- [X] I have build all projects affected by the changes in this PR
- [X] I have tested in hardware affected projects, at the relevant boards
- [X] I have signed off all commits from this PR
- [X] I have updated the documentation (wiki pages, ReadMe etc), if applies
