### PR TITLE
Extend ad9361 driver to match linux iio implementation

### DIFF
--- a/drivers/rf-transceiver/ad9361/ad9361.c
+++ b/drivers/rf-transceiver/ad9361/ad9361.c
@@ -37,6 +37,7 @@
 #include <string.h>
 #include <inttypes.h>
 #include "ad9361.h"
+#include "ad9361_ext_band_ctrl.h"
 #include "no_os_spi.h"
 #include "no_os_gpio.h"
 #include "no_os_delay.h"
@@ -2417,6 +2418,12 @@ int32_t ad9361_set_gain_ctrl_mode(struct ad9361_rf_phy *phy,
 	else
 		val &= ~SLOW_ATTACK_HYBRID_MODE;
 
+	/* apply digital saturation overrange enable bit (0x101:7) */
+	if (phy->pdata->gain_ctrl.agc_dig_sat_ovrg_en)
+		val |= ENABLE_DIG_SAT_OVRG;
+	else
+		val &= ~ENABLE_DIG_SAT_OVRG;
+
 	rc = ad9361_spi_write(spi, REG_AGC_CONFIG_1, val);
 	if (rc) {
 		dev_err(dev, "Unable to write AGC config1 register: %x",
@@ -4405,6 +4412,17 @@ static int32_t ad9361_bb_clk_change_handler(struct ad9361_rf_phy *phy)
 	ret |= ad9361_auxadc_setup(phy, &phy->pdata->auxadc_ctrl,
 				   clk_get_rate(phy, phy->ref_clk_scale[BBPLL_CLK]));
 
+	/*
+	 * when bb_clk_change_dig_tune_en is set, re-run the digital
+	 * interface tuning every time the baseband clock rate changes, so
+	 * DATA_CLK timing remains valid across dynamic sample-rate switches.
+	 */
+	if (phy->pdata->bb_clk_change_dig_tune_en) {
+#ifndef AXI_ADC_NOT_PRESENT
+		ret |= ad9361_dig_tune(phy, 0, RESTORE_DEFAULT);
+#endif
+	}
+
 	return ret;
 }
 
@@ -5632,6 +5650,20 @@ int32_t ad9361_setup(struct ad9361_rf_phy *phy)
 	ret = ad9361_rssi_setup(phy, &pd->rssi_ctrl, false);
 	if (ret < 0)
 		return ret;
+
+	/* skip live RSSI gain-step calib when pre-loaded tables are present */
+	if (!pd->rssi_skip_calib) {
+		ret = ad9361_rssi_gain_step_calib(phy);
+		if (ret < 0)
+			return ret;
+	} else if (pd->rssi_lna_err_tbl[0] || pd->rssi_mixer_err_tbl[0] ||
+		   pd->rssi_gain_step_calib_reg_val[0]) {
+		/* factory tables present — program them directly */
+		ad9361_ensm_force_state(phy, ENSM_STATE_ALERT);
+		ad9361_rssi_program_lna_gain(phy);
+		ad9361_rssi_write_err_tbl(phy);
+		ad9361_ensm_restore_prev_state(phy);
+	}
 
 	ret = ad9361_clkout_control(phy, pd->ad9361_clkout_mode);
 	if (ret < 0)
@@ -7096,6 +7128,8 @@ int32_t ad9361_rfpll_set_rate(struct refclk_scale *clk_priv, uint32_t rate)
 		ret = ad9361_load_gt(phy, ad9361_from_clk(rate), GT_RX1 + GT_RX2);
 		if (ret < 0)
 			return ret;
+		/* trigger external band switching on RX LO change */
+		ad9361_adjust_rx_ext_band_settings(phy, ad9361_from_clk(rate));
 		break;
 	case TX_RFPLL:
 		if (phy->pdata->use_ext_tx_lo) {
@@ -7119,6 +7153,8 @@ int32_t ad9361_rfpll_set_rate(struct refclk_scale *clk_priv, uint32_t rate)
 						"%s: TX QUAD cal failed", __func__);
 				phy->last_tx_quad_cal_freq = ad9361_from_clk(rate);
 			}
+		/* trigger external band switching on TX LO change */
+		ad9361_adjust_tx_ext_band_settings(phy, ad9361_from_clk(rate));
 		break;
 	default:
 		break;
@@ -7130,7 +7166,7 @@ int32_t ad9361_rfpll_set_rate(struct refclk_scale *clk_priv, uint32_t rate)
 /**
  * Set clock mux parent.
  * @param clk_priv The refclk_scale structure.
- * @param index Index - Enable (1), disable (0) ext lo.
+ * @param index Index - Enable (1) external LO, disable (0) = use internal PLL.
  * @return 0 in case of success, negative error code otherwise.
  */
 int32_t ad9361_clk_mux_set_parent(struct refclk_scale *clk_priv, uint8_t index)
@@ -7145,6 +7181,34 @@ int32_t ad9361_clk_mux_set_parent(struct refclk_scale *clk_priv, uint8_t index)
 	ret = ad9361_trx_ext_lo_control(phy, clk_priv->source == TX_RFPLL, index == 1);
 	if (ret >= 0)
 		clk_priv->mult = index;
+
+	/*
+	 * When switching back from external to internal LO, the dummy
+	 * rate path only updated a software variable — the internal VCO has
+	 * not been programmed.  Re-run the internal RFPLL set_rate at the last
+	 * known frequency so the PLL actually locks.
+	 */
+	if (ret >= 0 && index == 0) {
+		bool tx = (clk_priv->source == TX_RFPLL);
+		uint64_t restore_hz = tx ? phy->current_tx_lo_freq
+				      : phy->current_rx_lo_freq;
+
+		if (restore_hz) {
+			enum ad9361_clocks int_src = tx ? TX_RFPLL_INT : RX_RFPLL_INT;
+			uint32_t restore_rate = ad9361_to_clk(restore_hz);
+
+			ret = ad9361_rfpll_int_set_rate(
+				      phy->ref_clk_scale[int_src],
+				      restore_rate,
+				      phy->clks[phy->ref_clk_scale[int_src]->parent_source]->rate);
+			if (ret < 0)
+				dev_err(&phy->spi->dev,
+					"%s: %s internal PLL re-lock to %"PRIu64
+					" Hz failed: %"PRId32"\n",
+					__func__, tx ? "TX" : "RX",
+					restore_hz, ret);
+		}
+	}
 
 	ad9361_ensm_restore_prev_state(phy);
 
@@ -7492,6 +7556,193 @@ int32_t ad9361_rssi_gain_step_calib(struct ad9361_rf_phy *phy)
 	ad9361_spi_write(phy->spi, REG_CONFIG, 0x00);
 
 	ad9361_ensm_restore_prev_state(phy);
+
+	return 0;
+}
+
+/**
+ * Program the LNA gain step values from pdata->rssi_gain_step_calib_reg_val
+ * into the AD9361 gain-step calibration table.
+ * @param phy The AD9361 state structure.
+ * @return 0 on success, negative error code otherwise.
+ */
+int32_t ad9361_rssi_program_lna_gain(struct ad9361_rf_phy *phy)
+{
+	struct no_os_spi_desc *spi = phy->spi;
+	uint32_t i;
+
+	ad9361_spi_write(spi, REG_LNA_GAIN,
+			 phy->pdata->rssi_gain_step_calib_reg_val[0]);
+
+	ad9361_spi_write(spi, REG_CONFIG,
+			 CALIB_TABLE_SELECT(0x3) | START_CALIB_TABLE_CLOCK);
+
+	for (i = 0; i < 4; i++) {
+		ad9361_spi_write(spi, REG_WORD_ADDRESS, i);
+		ad9361_spi_write(spi, REG_GAIN_DIFF_WORDERROR_WRITE,
+				 phy->pdata->rssi_gain_step_calib_reg_val[i + 1]);
+		ad9361_spi_write(spi, REG_CONFIG,
+				 CALIB_TABLE_SELECT(0x3) | WRITE_LNA_GAIN_DIFF |
+				 START_CALIB_TABLE_CLOCK);
+		no_os_udelay(3);
+	}
+
+	ad9361_spi_write(spi, REG_CONFIG, START_CALIB_TABLE_CLOCK);
+	ad9361_spi_write(spi, REG_CONFIG, 0x00);
+
+	return 0;
+}
+
+/**
+ * Write the pre-loaded LNA and mixer error tables from pdata into hardware.
+ * @param phy The AD9361 state structure.
+ * @return 0 on success, negative error code otherwise.
+ */
+int32_t ad9361_rssi_write_err_tbl(struct ad9361_rf_phy *phy)
+{
+	struct no_os_spi_desc *spi = phy->spi;
+	uint32_t i;
+
+	ad9361_spi_write(spi, REG_CONFIG,
+			 CALIB_TABLE_SELECT(0x3) | START_CALIB_TABLE_CLOCK);
+
+	for (i = 0; i < 4; i++) {
+		ad9361_spi_write(spi, REG_WORD_ADDRESS, i);
+		ad9361_spi_write(spi, REG_GAIN_DIFF_WORDERROR_WRITE,
+				 phy->pdata->rssi_lna_err_tbl[i]);
+		ad9361_spi_write(spi, REG_CONFIG,
+				 CALIB_TABLE_SELECT(0x3) | WRITE_LNA_ERROR_TABLE |
+				 START_CALIB_TABLE_CLOCK);
+	}
+
+	ad9361_spi_write(spi, REG_CONFIG,
+			 CALIB_TABLE_SELECT(0x3) | START_CALIB_TABLE_CLOCK);
+
+	for (i = 0; i < 16; i++) {
+		ad9361_spi_write(spi, REG_WORD_ADDRESS, i);
+		ad9361_spi_write(spi, REG_GAIN_DIFF_WORDERROR_WRITE,
+				 phy->pdata->rssi_mixer_err_tbl[i]);
+		ad9361_spi_write(spi, REG_CONFIG,
+				 CALIB_TABLE_SELECT(0x3) | WRITE_MIXER_ERROR_TABLE |
+				 START_CALIB_TABLE_CLOCK);
+	}
+
+	ad9361_spi_write(spi, REG_CONFIG, 0x00);
+
+	ad9361_spi_write(spi, REG_SETTLE_TIME,
+			 ENABLE_DIG_GAIN_CORR | SETTLE_TIME(0x10));
+
+	return 0;
+}
+
+/**
+ * Read the current RX and TX clock/data delay register values back into pdata.
+ * Call this after ad9361_dig_tune() to persist the tuned values.
+ * @param phy The AD9361 state structure.
+ * @return 0 on success, negative error code otherwise.
+ */
+int32_t ad9361_read_clock_data_delays(struct ad9361_rf_phy *phy)
+{
+	phy->pdata->port_ctrl.rx_clk_data_delay =
+		ad9361_spi_read(phy->spi, REG_RX_CLOCK_DATA_DELAY);
+	phy->pdata->port_ctrl.tx_clk_data_delay =
+		ad9361_spi_read(phy->spi, REG_TX_CLOCK_DATA_DELAY);
+	return 0;
+}
+
+/**
+ * Write the saved RX and TX clock/data delay values from pdata to hardware.
+ * Call this at startup to restore previously tuned values and skip dig_tune.
+ * @param phy The AD9361 state structure.
+ * @return 0 on success, negative error code otherwise.
+ */
+int32_t ad9361_write_clock_data_delays(struct ad9361_rf_phy *phy)
+{
+	ad9361_spi_write(phy->spi, REG_RX_CLOCK_DATA_DELAY,
+			 phy->pdata->port_ctrl.rx_clk_data_delay);
+	ad9361_spi_write(phy->spi, REG_TX_CLOCK_DATA_DELAY,
+			 phy->pdata->port_ctrl.tx_clk_data_delay);
+	return 0;
+}
+
+/**
+ * Return the current digital interface tuning state.
+ * @param phy  The AD9361 state structure.
+ * @param data Output: populated with skip_mode and current delay register values.
+ * @return 0 on success, negative error code otherwise.
+ */
+int32_t ad9361_get_dig_tune_data(struct ad9361_rf_phy *phy,
+				 struct ad9361_dig_tune_data *data)
+{
+	if (!data)
+		return -EINVAL;
+
+	data->skip_mode     = phy->pdata->dig_interface_tune_skipmode;
+	data->rx_clk_delay  = phy->pdata->port_ctrl.rx_clk_data_delay >> 4;
+	data->rx_data_delay = phy->pdata->port_ctrl.rx_clk_data_delay & 0xF;
+	data->tx_clk_delay  = phy->pdata->port_ctrl.tx_clk_data_delay >> 4;
+	data->tx_data_delay = phy->pdata->port_ctrl.tx_clk_data_delay & 0xF;
+
+	return 0;
+}
+
+/**
+ * Write directly to the AD9361 BIST configuration register.
+ * @param phy The AD9361 state structure.
+ * @param val Value to write.
+ * @return 0 on success, negative error code otherwise.
+ */
+int32_t ad9361_write_bist_reg(struct ad9361_rf_phy *phy, uint32_t val)
+{
+	phy->bist_config = val;
+	return ad9361_spi_write(phy->spi, REG_BIST_AND_DATA_PORT_TEST_CONFIG, val);
+}
+
+/**
+ * Temporarily disable ENSM pin control by forcing TDD SPI mode.
+ * Useful before calibration sequences that must use SPI-driven state.
+ * @param phy The AD9361 state structure.
+ * @return 0 on success, negative error code otherwise.
+ */
+int32_t ad9361_ensm_mode_disable_pinctrl(struct ad9361_rf_phy *phy)
+{
+	if (!phy->pdata->fdd)
+		return ad9361_set_ensm_mode(phy, true, false);
+	return 0;
+}
+
+/**
+ * Restore ENSM pin control to the state configured in pdata.
+ * @param phy The AD9361 state structure.
+ * @return 0 on success, negative error code otherwise.
+ */
+int32_t ad9361_ensm_mode_restore_pinctrl(struct ad9361_rf_phy *phy)
+{
+	if (!phy->pdata->fdd)
+		return ad9361_set_ensm_mode(phy, phy->pdata->fdd,
+					    phy->pdata->ensm_pin_ctrl);
+	return 0;
+}
+
+/**
+ * Drive the external calibration switch GPIOs (cal-sw1, cal-sw2).
+ * Bit 0 of @p val controls cal-sw1, bit 1 controls cal-sw2.
+ * These GPIOs route signals for TX quad / LO calibration on boards that
+ * have external calibration switch hardware.
+ * @param phy The AD9361 state structure.
+ * @param val 2-bit value: bit0 = cal_sw1, bit1 = cal_sw2.
+ * @return 0 on success, -ENODEV if GPIOs are not configured.
+ */
+int32_t ad9361_set_cal_sw(struct ad9361_rf_phy *phy, uint32_t val)
+{
+	if (!phy->gpio_desc_cal_sw1 || !phy->gpio_desc_cal_sw2) {
+		dev_err(&phy->spi->dev,
+			"%s: calibration switch GPIOs not configured\n", __func__);
+		return -ENODEV;
+	}
+
+	no_os_gpio_set_value(phy->gpio_desc_cal_sw1, !!(val & NO_OS_BIT(0)));
+	no_os_gpio_set_value(phy->gpio_desc_cal_sw2, !!(val & NO_OS_BIT(1)));
 
 	return 0;
 }

--- a/drivers/rf-transceiver/ad9361/ad9361.h
+++ b/drivers/rf-transceiver/ad9361/ad9361.h
@@ -35,6 +35,7 @@
 #include <stdint.h>
 #include "no_os_gpio.h"
 #include "common.h"
+#include "ad9361_ext_band_ctrl.h"
 
 #define REG_SPI_CONF				 0x000 /* SPI Configuration */
 #define REG_MULTICHIP_SYNC_AND_TX_MON_CTRL	 0x001 /* Multi-Chip Sync and Tx Mon Control */
@@ -2949,6 +2950,7 @@ struct gain_control {
 	uint8_t adc_large_overload_inc_steps; /* 0..15, 0x106 */
 
 	bool adc_lmt_small_overload_prevent_gain_inc; /* 0x120 */
+	bool agc_dig_sat_ovrg_en;  /* 0x101:7 ENABLE_DIG_SAT_OVRG */
 
 	uint8_t lmt_overload_large_exceed_counter; /* 0..15, 0x121 */
 	uint8_t lmt_overload_small_exceed_counter; /* 0..15, 0x121 */
@@ -3173,12 +3175,14 @@ struct ad9361_phy_platform_data {
 	uint8_t			rf_dc_offset_count_high;
 	uint8_t			rf_dc_offset_count_low;
 	uint8_t			dig_interface_tune_skipmode;
-	uint8_t			dig_interface_tune_fir_disable;
+	bool			dig_interface_tune_fir_disable;
 	uint8_t			lo_powerdown_managed_en;
 	uint32_t			dcxo_coarse;
 	uint32_t			dcxo_fine;
 	uint32_t			rf_rx_input_sel;
 	uint32_t			rf_tx_output_sel;
+	bool			rf_rx_input_sel_lock;
+	bool			rf_tx_output_sel_lock;
 	uint32_t		rx1tx1_mode_use_rx_num;
 	uint32_t		rx1tx1_mode_use_tx_num;
 	uint32_t		rx_path_clks[NUM_RX_CLOCKS];
@@ -3193,6 +3197,14 @@ struct ad9361_phy_platform_data {
 	uint32_t			rx_fastlock_delay_ns;
 	uint32_t			tx_fastlock_delay_ns;
 	bool			trx_fastlock_pinctrl_en[2];
+	bool			bb_clk_change_dig_tune_en;
+	bool			axi_half_dac_rate_en;
+
+	/* RSSI gain-step error factory calibration tables */
+	uint32_t		rssi_lna_err_tbl[4];
+	uint32_t		rssi_mixer_err_tbl[16];
+	uint32_t		rssi_gain_step_calib_reg_val[5];
+	bool			rssi_skip_calib; /* skip live RSSI calib if tables pre-loaded */
 
 	enum ad9361_clkout	ad9361_clkout_mode;
 
@@ -3403,6 +3415,7 @@ struct ad9361_rf_phy {
 	uint32_t				bist_tone_level_dB;
 	uint32_t				bist_tone_mask;
 	bool			bbpll_initialized;
+	struct ad9361_ext_band_ctl	*ext_band_ctl;
 };
 
 struct refclk_scale {
@@ -3554,4 +3567,28 @@ int ad9361_synth_lo_powerdown(struct ad9361_rf_phy *phy,
 			      enum synth_pd_ctrl rx,
 			      enum synth_pd_ctrl tx);
 void ad9361_clear_state(struct ad9361_rf_phy *phy);
+
+struct ad9361_dig_tune_data {
+	uint8_t  skip_mode;      /* current dig_interface_tune_skipmode */
+	uint8_t  rx_clk_delay;   /* tuned RX CLK delay value */
+	uint8_t  rx_data_delay;  /* tuned RX DATA delay value */
+	uint8_t  tx_clk_delay;   /* tuned TX CLK delay value */
+	uint8_t  tx_data_delay;  /* tuned TX DATA delay value */
+};
+int32_t ad9361_get_dig_tune_data(struct ad9361_rf_phy *phy,
+				 struct ad9361_dig_tune_data *data);
+
+int32_t ad9361_write_clock_data_delays(struct ad9361_rf_phy *phy);
+int32_t ad9361_read_clock_data_delays(struct ad9361_rf_phy *phy);
+
+int32_t ad9361_write_bist_reg(struct ad9361_rf_phy *phy, uint32_t val);
+
+int32_t ad9361_ensm_mode_disable_pinctrl(struct ad9361_rf_phy *phy);
+int32_t ad9361_ensm_mode_restore_pinctrl(struct ad9361_rf_phy *phy);
+
+int32_t ad9361_rssi_program_lna_gain(struct ad9361_rf_phy *phy);
+int32_t ad9361_rssi_write_err_tbl(struct ad9361_rf_phy *phy);
+
+int32_t ad9361_set_cal_sw(struct ad9361_rf_phy *phy, uint32_t val);
+
 #endif

--- a/drivers/rf-transceiver/ad9361/ad9361_api.h
+++ b/drivers/rf-transceiver/ad9361/ad9361_api.h
@@ -537,4 +537,22 @@ int32_t ad9361_do_dcxo_tune_fine(struct ad9361_rf_phy *phy,
 /* Get the temperature. */
 int32_t ad9361_get_temperature(struct ad9361_rf_phy *phy,
 			       int32_t *temp);
+/* Mute/unmute TX output (also used internally during calibration). */
+int32_t ad9361_tx_mute(struct ad9361_rf_phy *phy, uint32_t state);
+/* Temporarily disable / restore ENSM pin control. */
+int32_t ad9361_ensm_mode_disable_pinctrl(struct ad9361_rf_phy *phy);
+int32_t ad9361_ensm_mode_restore_pinctrl(struct ad9361_rf_phy *phy);
+/* Save / restore digital interface tuning delay registers. */
+int32_t ad9361_write_clock_data_delays(struct ad9361_rf_phy *phy);
+int32_t ad9361_read_clock_data_delays(struct ad9361_rf_phy *phy);
+/* Drive calibration switch GPIOs. */
+int32_t ad9361_set_cal_sw(struct ad9361_rf_phy *phy, uint32_t val);
+/* Direct BIST register write. */
+int32_t ad9361_write_bist_reg(struct ad9361_rf_phy *phy, uint32_t val);
+/* Query current digital tune state. */
+int32_t ad9361_get_dig_tune_data(struct ad9361_rf_phy *phy,
+				 struct ad9361_dig_tune_data *data);
+/* RSSI gain-step error table helpers. */
+int32_t ad9361_rssi_program_lna_gain(struct ad9361_rf_phy *phy);
+int32_t ad9361_rssi_write_err_tbl(struct ad9361_rf_phy *phy);
 #endif

--- a/drivers/rf-transceiver/ad9361/ad9361_conv.c
+++ b/drivers/rf-transceiver/ad9361/ad9361_conv.c
@@ -595,6 +595,7 @@ int32_t ad9361_post_setup(struct ad9361_rf_phy *phy)
 	struct axi_adc *rx_adc = phy->rx_adc;
 	int32_t rx2tx2 = phy->pdata->rx2tx2;
 	uint32_t tmp, num_chan, flags, id, i;
+	uint8_t saved_skipmode = phy->pdata->dig_interface_tune_skipmode;
 	int32_t ret;
 
 	num_chan = ad9361_num_phy_chan(conv);
@@ -602,15 +603,22 @@ int32_t ad9361_post_setup(struct ad9361_rf_phy *phy)
 	axi_adc_write(rx_adc, AXI_ADC_REG_CNTRL, rx2tx2 ? 0 : AXI_ADC_R1_MODE);
 	axi_adc_read(rx_adc, 0x4048, &tmp);
 
+	bool half_rate = phy->pdata->axi_half_dac_rate_en;
+	bool lvds      = !!(phy->pdata->port_ctrl.pp_conf[2] & LVDS_MODE);
+
 	if (!rx2tx2) {
 		axi_adc_write(rx_adc, 0x4048, tmp | NO_OS_BIT(5)); /* R1_MODE */
-		axi_adc_write(rx_adc, 0x404c,
-			      (phy->pdata->port_ctrl.pp_conf[2] & LVDS_MODE) ? 1 : 0); /* RATE */
+		if (!half_rate)
+			axi_adc_write(rx_adc, 0x404c, lvds ? 1 : 0); /* RATE */
+		else
+			axi_adc_write(rx_adc, 0x404c, 0);
 	} else {
 		tmp &= ~NO_OS_BIT(5);
 		axi_adc_write(rx_adc, 0x4048, tmp);
-		axi_adc_write(rx_adc, 0x404c,
-			      (phy->pdata->port_ctrl.pp_conf[2] & LVDS_MODE) ? 3 : 1); /* RATE */
+		if (!half_rate)
+			axi_adc_write(rx_adc, 0x404c, lvds ? 3 : 1); /* RATE */
+		else
+			axi_adc_write(rx_adc, 0x404c, 1);
 	}
 
 #ifdef ALTERA_PLATFORM
@@ -629,16 +637,25 @@ int32_t ad9361_post_setup(struct ad9361_rf_phy *phy)
 
 	flags = 0x0;
 
+	/*
+	 * when bb_clk_change_dig_tune_en is set, force SKIP_ALL during
+	 * post_setup so that the dig_tune call here acts only as an initial
+	 * baseline and the real re-tune happens each time the BB clock changes.
+	 */
+	if (phy->pdata->bb_clk_change_dig_tune_en)
+		phy->pdata->dig_interface_tune_skipmode = 2; /* SKIP_ALL */
+
 	axi_adc_read(rx_adc, ADI_REG_ID, &id);
 	ret = ad9361_dig_tune(phy, 61440000, (id) ? flags | RESTORE_DEFAULT : flags);
 	if (ret < 0)
-		return ret;
+		goto out;
 
 	if (flags & (DO_IDELAY | DO_ODELAY)) {
 		ret = ad9361_dig_tune(phy, 61440000,
-				      (id) ? flags | RESTORE_DEFAULT | BE_VERBOSE : flags | BE_VERBOSE);
+				      (id) ? flags | RESTORE_DEFAULT | BE_VERBOSE
+				      : flags | BE_VERBOSE);
 		if (ret < 0)
-			return ret;
+			goto out;
 	}
 
 	ret = ad9361_set_trx_clock_chain(phy,
@@ -647,6 +664,11 @@ int32_t ad9361_post_setup(struct ad9361_rf_phy *phy)
 
 	ad9361_ensm_force_state(phy, ENSM_STATE_ALERT);
 	ad9361_ensm_restore_prev_state(phy);
+
+out:
+	/* restore skipmode so subsequent BB clock changes tune correctly */
+	if (phy->pdata->bb_clk_change_dig_tune_en)
+		phy->pdata->dig_interface_tune_skipmode = saved_skipmode;
 
 	return ret;
 }

--- a/drivers/rf-transceiver/ad9361/ad9361_ext_band_ctrl.c
+++ b/drivers/rf-transceiver/ad9361/ad9361_ext_band_ctrl.c
@@ -1,0 +1,567 @@
+/*
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <inttypes.h>
+#include "ad9361.h"
+#include "ad9361_util.h"
+#include "ad9361_ext_band_ctrl.h"
+#include "no_os_gpio.h"
+#include "no_os_delay.h"
+#include "no_os_alloc.h"
+#include "no_os_spi.h"
+
+/**
+ * @brief Find the first band setting whose frequency range contains freq.
+ * @param list  - Array of pointers to band settings.
+ * @param count - Number of entries in list.
+ * @param freq  - Frequency to match (Hz).
+ * @return Pointer to the matching setting, or NULL if none matches.
+ */
+static struct ad9361_band_setting *
+find_setting(struct ad9361_band_setting **list, uint32_t count, uint64_t freq)
+{
+	uint32_t i;
+
+	for (i = 0; i < count; i++) {
+		if (list[i]->freq_min <= freq && freq < list[i]->freq_max)
+			return list[i];
+	}
+	return NULL;
+}
+
+/**
+ * @brief Apply GPIO operations for a band setting transition.
+ * @param phy      - AD9361 PHY state.
+ * @param new_sett - Band setting to apply.
+ * @param curr     - Currently active band setting (may be NULL).
+ * @return 0 on success, negative errno on failure.
+ */
+static int apply_gpio_settings(struct ad9361_rf_phy *phy,
+			       const struct ad9361_band_setting *new_sett,
+			       const struct ad9361_band_setting *curr)
+{
+	struct ad9361_ext_band_ctl *ctl = phy->ext_band_ctl;
+	uint32_t i;
+	int ret;
+
+	if (!new_sett->gpio_values || ctl->ngpios == 0)
+		return 0;
+
+	for (i = 0; i < (uint32_t)ctl->ngpios; i++) {
+		uint32_t new_val = new_sett->gpio_values[i];
+		uint32_t cur_val = (curr && curr->gpio_values)
+				   ? curr->gpio_values[i]
+				   : AD9361_EXT_BAND_CTL_OP_NOP;
+
+		if (curr && cur_val == new_val)
+			continue;
+
+		if (new_val == AD9361_EXT_BAND_CTL_OP_NOP)
+			continue;
+
+		if (!ctl->gpios[i]) {
+			dev_err(&phy->spi->dev,
+				"%s: GPIO[%u] is NULL", __func__, (unsigned)i);
+			return -EINVAL;
+		}
+
+		switch (new_val) {
+		case AD9361_EXT_BAND_CTL_OP_LOW:
+			ret = no_os_gpio_direction_output(ctl->gpios[i], 0);
+			break;
+		case AD9361_EXT_BAND_CTL_OP_HIGH:
+			ret = no_os_gpio_direction_output(ctl->gpios[i], 1);
+			break;
+		case AD9361_EXT_BAND_CTL_OP_INPUT:
+			ret = no_os_gpio_direction_input(ctl->gpios[i]);
+			break;
+		default:
+			dev_err(&phy->spi->dev,
+				"%s: unknown op %u on pin %u",
+				__func__, (unsigned)new_val, (unsigned)i);
+			return -EINVAL;
+		}
+
+		if (ret < 0) {
+			dev_err(&phy->spi->dev,
+				"%s: GPIO[%u] op %u failed: %d",
+				__func__, (unsigned)i, (unsigned)new_val, ret);
+			return ret;
+		}
+
+		dev_dbg(&phy->spi->dev,
+			"%s: GPIO[%u] op=%u",
+			__func__, (unsigned)i, (unsigned)new_val);
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Apply a complete band setting (pre-seq, GPIOs, ports, post-seq).
+ * @param phy      - AD9361 PHY state.
+ * @param new_sett - Band setting to apply.
+ * @param curr_ptr - Pointer to the current setting pointer (updated on
+ *                   success). May be NULL for sub-sequence steps.
+ * @return 0 on success, negative errno on failure.
+ */
+static int apply_setting(struct ad9361_rf_phy *phy,
+			 const struct ad9361_band_setting *new_sett,
+			 const struct ad9361_band_setting **curr_ptr)
+{
+	const struct ad9361_band_setting *curr = curr_ptr ? *curr_ptr : NULL;
+	int ret;
+
+	dev_dbg(&phy->spi->dev, "%s: applying '%s'",
+		__func__, new_sett->name ? new_sett->name : "<unnamed>");
+
+	/* Apply pre-sequence steps */
+	if (new_sett->pre_seq && new_sett->pre_seq_len > 0) {
+		uint32_t i;
+		for (i = 0; i < new_sett->pre_seq_len; i++) {
+			ret = apply_setting(phy, &new_sett->pre_seq[i], NULL);
+			if (ret < 0)
+				return ret;
+			if (new_sett->pre_seq[i].delay_us)
+				no_os_udelay(new_sett->pre_seq[i].delay_us);
+		}
+	}
+
+	/* Drive GPIOs */
+	ret = apply_gpio_settings(phy, new_sett, curr);
+	if (ret < 0)
+		return ret;
+
+	/* Switch RX RF port if specified */
+	if (new_sett->rf_rx_input_sel != AD9361_EXT_BAND_NO_PORT_SEL) {
+		if (!curr ||
+		    curr->rf_rx_input_sel != new_sett->rf_rx_input_sel) {
+			ret = ad9361_rf_port_setup(phy, false,
+						   new_sett->rf_rx_input_sel,
+						   0);
+			if (ret < 0) {
+				dev_err(&phy->spi->dev,
+					"%s: RX port %u failed: %d",
+					__func__,
+					(unsigned)new_sett->rf_rx_input_sel,
+					ret);
+				return ret;
+			}
+			dev_dbg(&phy->spi->dev,
+				"%s: RX port -> %u",
+				__func__,
+				(unsigned)new_sett->rf_rx_input_sel);
+		}
+	}
+
+	/* Switch TX RF port if specified */
+	if (new_sett->rf_tx_output_sel != AD9361_EXT_BAND_NO_PORT_SEL) {
+		if (!curr ||
+		    curr->rf_tx_output_sel != new_sett->rf_tx_output_sel) {
+			ret = ad9361_rf_port_setup(phy, true, 0,
+						   new_sett->rf_tx_output_sel);
+			if (ret < 0) {
+				dev_err(&phy->spi->dev,
+					"%s: TX port %u failed: %d",
+					__func__,
+					(unsigned)new_sett->rf_tx_output_sel,
+					ret);
+				return ret;
+			}
+			dev_dbg(&phy->spi->dev,
+				"%s: TX port -> %u",
+				__func__,
+				(unsigned)new_sett->rf_tx_output_sel);
+		}
+	}
+
+	if (curr_ptr)
+		*curr_ptr = new_sett;
+
+	/* Apply post-sequence steps */
+	if (new_sett->post_seq && new_sett->post_seq_len > 0) {
+		uint32_t i;
+		for (i = 0; i < new_sett->post_seq_len; i++) {
+			ret = apply_setting(phy, &new_sett->post_seq[i], NULL);
+			if (ret < 0)
+				return ret;
+			if (new_sett->post_seq[i].delay_us)
+				no_os_udelay(new_sett->post_seq[i].delay_us);
+		}
+	}
+
+	dev_dbg(&phy->spi->dev, "%s: applied '%s'",
+		__func__, new_sett->name ? new_sett->name : "<unnamed>");
+
+	return 0;
+}
+
+/**
+ * @brief Grow a settings array by one element.
+ * @param old_arr  - Existing array (freed on success; may be NULL).
+ * @param old_count - Number of entries in old_arr.
+ * @param new_elem - New element to append.
+ * @return Pointer to the new array, or NULL on allocation failure.
+ */
+static struct ad9361_band_setting **grow_settings_array(
+	struct ad9361_band_setting **old_arr,
+	uint32_t old_count,
+	struct ad9361_band_setting *new_elem)
+{
+	struct ad9361_band_setting **new_arr;
+	uint32_t i;
+
+	new_arr = (struct ad9361_band_setting **)
+		  no_os_calloc(old_count + 1, sizeof(*new_arr));
+	if (!new_arr)
+		return NULL;
+
+	for (i = 0; i < old_count; i++)
+		new_arr[i] = old_arr[i];
+
+	new_arr[old_count] = new_elem;
+
+	no_os_free(old_arr);
+	return new_arr;
+}
+
+/**
+ * @brief Allocate a band setting descriptor.
+ * @param name     - Human-readable name (copied; may be NULL).
+ * @param freq_min - Inclusive lower bound of the frequency range (Hz).
+ * @param freq_max - Exclusive upper bound of the frequency range (Hz).
+ * @param ngpios   - Number of GPIO lines this setting may drive (0 is valid).
+ * @return Pointer to the new setting, or NULL on allocation failure.
+ */
+struct ad9361_band_setting *
+ad9361_band_setting_alloc(const char *name, uint64_t freq_min,
+			  uint64_t freq_max, uint32_t ngpios)
+{
+	struct ad9361_band_setting *s;
+	uint32_t i;
+
+	s = (struct ad9361_band_setting *)
+	    no_os_calloc(1, sizeof(*s));
+	if (!s)
+		return NULL;
+
+	if (name) {
+		char *name_copy = (char *)no_os_calloc(1, strlen(name) + 1);
+		if (!name_copy) {
+			no_os_free(s);
+			return NULL;
+		}
+		strcpy(name_copy, name);
+		s->name = name_copy;
+	}
+
+	s->freq_min         = freq_min;
+	s->freq_max         = freq_max;
+	s->rf_rx_input_sel  = AD9361_EXT_BAND_NO_PORT_SEL;
+	s->rf_tx_output_sel = AD9361_EXT_BAND_NO_PORT_SEL;
+
+	if (ngpios > 0) {
+		s->gpio_values = (uint32_t *)
+				 no_os_calloc(ngpios, sizeof(uint32_t));
+		if (!s->gpio_values) {
+			no_os_free((void *)s->name);
+			no_os_free(s);
+			return NULL;
+		}
+		for (i = 0; i < ngpios; i++)
+			s->gpio_values[i] = AD9361_EXT_BAND_CTL_OP_NOP;
+		s->ngpios = ngpios;
+	}
+
+	return s;
+}
+
+/**
+ * @brief Release a band setting and its sub-sequences.
+ * @param s - Band setting to free (may be NULL).
+ */
+void ad9361_band_setting_free(struct ad9361_band_setting *s)
+{
+	uint32_t i;
+
+	if (!s)
+		return;
+
+	no_os_free((void *)s->name);
+	no_os_free(s->gpio_values);
+
+	if (s->pre_seq) {
+		for (i = 0; i < s->pre_seq_len; i++)
+			no_os_free(s->pre_seq[i].gpio_values);
+		no_os_free(s->pre_seq);
+	}
+
+	if (s->post_seq) {
+		for (i = 0; i < s->post_seq_len; i++)
+			no_os_free(s->post_seq[i].gpio_values);
+		no_os_free(s->post_seq);
+	}
+
+	no_os_free(s);
+}
+
+/**
+ * @brief Set the operation for one GPIO pin.
+ * @param s        - The band setting.
+ * @param gpio_idx - Index in the controller's gpios[] array (0-based).
+ * @param op       - AD9361_EXT_BAND_CTL_OP_LOW/HIGH/INPUT/NOP.
+ * @return 0 on success, -EINVAL if gpio_idx is out of range.
+ */
+int ad9361_band_setting_set_gpio(struct ad9361_band_setting *s,
+				 uint32_t gpio_idx, uint32_t op)
+{
+	if (!s || !s->gpio_values || gpio_idx >= s->ngpios)
+		return -EINVAL;
+	s->gpio_values[gpio_idx] = op;
+	return 0;
+}
+
+/**
+ * @brief Set the RX RF port for this band.
+ * @param s    - The band setting.
+ * @param port - RX RF input port index.
+ */
+void ad9361_band_setting_set_rx_port(struct ad9361_band_setting *s,
+				     uint32_t port)
+{
+	if (s)
+		s->rf_rx_input_sel = port;
+}
+
+/**
+ * @brief Set the TX RF port for this band.
+ * @param s    - The band setting.
+ * @param port - TX RF output port index.
+ */
+void ad9361_band_setting_set_tx_port(struct ad9361_band_setting *s,
+				     uint32_t port)
+{
+	if (s)
+		s->rf_tx_output_sel = port;
+}
+
+/**
+ * @brief Set the post-step delay (microseconds).
+ * @param s        - The band setting.
+ * @param delay_us - Delay in microseconds (0 = no delay).
+ */
+void ad9361_band_setting_set_delay(struct ad9361_band_setting *s,
+				   uint32_t delay_us)
+{
+	if (s)
+		s->delay_us = delay_us;
+}
+
+/**
+ * @brief Allocate an external band controller.
+ * @return Pointer to the zeroed controller, or NULL on failure.
+ */
+struct ad9361_ext_band_ctl *ad9361_ext_band_ctl_alloc(void)
+{
+	return (struct ad9361_ext_band_ctl *)
+	       no_os_calloc(1, sizeof(struct ad9361_ext_band_ctl));
+}
+
+/**
+ * @brief Release a controller and all registered settings.
+ *        GPIO descriptors are NOT freed -- the caller owns them.
+ * @param ctl - Controller to free (may be NULL).
+ */
+void ad9361_ext_band_ctl_free(struct ad9361_ext_band_ctl *ctl)
+{
+	uint32_t i;
+
+	if (!ctl)
+		return;
+
+	for (i = 0; i < ctl->rx_count; i++)
+		ad9361_band_setting_free(ctl->rx_settings[i]);
+
+	for (i = 0; i < ctl->tx_count; i++)
+		ad9361_band_setting_free(ctl->tx_settings[i]);
+
+	no_os_free(ctl->rx_settings);
+	no_os_free(ctl->tx_settings);
+	no_os_free(ctl);
+}
+
+/**
+ * @brief Register a GPIO with the controller.
+ *        GPIOs are referenced by add order (0 = first added).
+ * @param ctl  - The controller.
+ * @param gpio - A configured GPIO descriptor.
+ * @return 0 on success, -EINVAL or -ENOMEM on error.
+ */
+int ad9361_ext_band_ctl_add_gpio(struct ad9361_ext_band_ctl *ctl,
+				 struct no_os_gpio_desc *gpio)
+{
+	if (!ctl || !gpio)
+		return -EINVAL;
+
+	if (ctl->ngpios >= AD9361_EXT_BAND_MAX_GPIOS)
+		return -ENOMEM;
+
+	ctl->gpios[ctl->ngpios] = gpio;
+	ctl->ngpios++;
+	return 0;
+}
+
+/**
+ * @brief Append an RX band setting.
+ *        Settings are matched first-to-last; the first frequency match wins.
+ * @param ctl - The controller.
+ * @param s   - Band setting to add.
+ * @return 0 on success, -EINVAL or -ENOMEM on error.
+ */
+int ad9361_ext_band_ctl_add_rx_setting(struct ad9361_ext_band_ctl *ctl,
+				       struct ad9361_band_setting *s)
+{
+	struct ad9361_band_setting **new_arr;
+
+	if (!ctl || !s)
+		return -EINVAL;
+
+	new_arr = grow_settings_array(ctl->rx_settings, ctl->rx_count, s);
+	if (!new_arr)
+		return -ENOMEM;
+
+	ctl->rx_settings = new_arr;
+	ctl->rx_count++;
+	return 0;
+}
+
+/**
+ * @brief Append a TX band setting.
+ *        Settings are matched first-to-last; the first frequency match wins.
+ * @param ctl - The controller.
+ * @param s   - Band setting to add.
+ * @return 0 on success, -EINVAL or -ENOMEM on error.
+ */
+int ad9361_ext_band_ctl_add_tx_setting(struct ad9361_ext_band_ctl *ctl,
+				       struct ad9361_band_setting *s)
+{
+	struct ad9361_band_setting **new_arr;
+
+	if (!ctl || !s)
+		return -EINVAL;
+
+	new_arr = grow_settings_array(ctl->tx_settings, ctl->tx_count, s);
+	if (!new_arr)
+		return -ENOMEM;
+
+	ctl->tx_settings = new_arr;
+	ctl->tx_count++;
+	return 0;
+}
+
+/**
+ * @brief Attach a controller to a PHY.
+ * @param phy - AD9361 PHY state.
+ * @param ctl - External band controller to register.
+ * @return 0 on success, -EINVAL if either argument is NULL.
+ */
+int32_t ad9361_register_ext_band_control(struct ad9361_rf_phy *phy,
+		struct ad9361_ext_band_ctl *ctl)
+{
+	if (!phy || !ctl)
+		return -EINVAL;
+
+	phy->ext_band_ctl = ctl;
+
+	dev_dbg(&phy->spi->dev,
+		"%s: registered (%u RX / %u TX settings, %d GPIOs)",
+		__func__,
+		(unsigned)ctl->rx_count,
+		(unsigned)ctl->tx_count,
+		ctl->ngpios);
+
+	return 0;
+}
+
+/**
+ * @brief Detach the controller from a PHY. Does not free anything.
+ * @param phy - AD9361 PHY state.
+ */
+void ad9361_unregister_ext_band_control(struct ad9361_rf_phy *phy)
+{
+	if (phy)
+		phy->ext_band_ctl = NULL;
+}
+
+/**
+ * @brief Switch RX band for a new LO frequency.
+ *        Called automatically from ad9361_rfpll_set_rate() on every RX LO
+ *        change. Applications may also call this directly.
+ * @param phy  - AD9361 PHY state.
+ * @param freq - New RX LO frequency in Hz.
+ * @return 0 on success (including no matching setting), or negative errno.
+ */
+int32_t ad9361_adjust_rx_ext_band_settings(struct ad9361_rf_phy *phy,
+		uint64_t freq)
+{
+	struct ad9361_ext_band_ctl *ctl;
+	struct ad9361_band_setting *sett;
+
+	if (!phy)
+		return -EINVAL;
+
+	if (!phy->ext_band_ctl)
+		return 0;
+
+	ctl = phy->ext_band_ctl;
+
+	sett = find_setting(ctl->rx_settings, ctl->rx_count, freq);
+	if (!sett)
+		return 0;
+
+	if (ctl->current_rx_setting == sett)
+		return 0;
+
+	return apply_setting(phy, sett,
+			     (const struct ad9361_band_setting **)
+			     &ctl->current_rx_setting);
+}
+
+/**
+ * @brief Switch TX band for a new LO frequency.
+ * @param phy  - AD9361 PHY state.
+ * @param freq - New TX LO frequency in Hz.
+ * @return 0 on success, or negative errno on hardware failure.
+ */
+int32_t ad9361_adjust_tx_ext_band_settings(struct ad9361_rf_phy *phy,
+		uint64_t freq)
+{
+	struct ad9361_ext_band_ctl *ctl;
+	struct ad9361_band_setting *sett;
+
+	if (!phy)
+		return -EINVAL;
+
+	if (!phy->ext_band_ctl)
+		return 0;
+
+	ctl = phy->ext_band_ctl;
+
+	sett = find_setting(ctl->tx_settings, ctl->tx_count, freq);
+	if (!sett)
+		return 0;
+
+	if (ctl->current_tx_setting == sett)
+		return 0;
+
+	return apply_setting(phy, sett,
+			     (const struct ad9361_band_setting **)
+			     &ctl->current_tx_setting);
+}

--- a/drivers/rf-transceiver/ad9361/ad9361_ext_band_ctrl.h
+++ b/drivers/rf-transceiver/ad9361/ad9361_ext_band_ctrl.h
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef AD9361_EXT_BAND_CTRL_H_
+#define AD9361_EXT_BAND_CTRL_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "no_os_gpio.h"
+
+/* Forward declaration — full definition in ad9361.h */
+struct ad9361_rf_phy;
+
+/* Constants */
+
+/** Maximum number of GPIO lines managed by one controller instance. */
+#define AD9361_EXT_BAND_MAX_GPIOS   32
+
+/** Maximum number of RX or TX band settings per controller. */
+#define AD9361_EXT_BAND_MAX_SETTINGS 64
+
+/**
+ * Sentinel value for rf_rx_input_sel / rf_tx_output_sel meaning
+ * "do not change the current port selection".
+ */
+#define AD9361_EXT_BAND_NO_PORT_SEL  ((uint32_t)-1)
+
+/* GPIO operation codes */
+
+/**
+ * Per-GPIO operation to perform when a band setting becomes active.
+ * Use these as values in ad9361_band_setting.gpio_values[].
+ */
+enum ad9361_ext_band_ctl_op {
+	/** Drive the pin low (output 0). */
+	AD9361_EXT_BAND_CTL_OP_LOW   = 0,
+	/** Drive the pin high (output 1). */
+	AD9361_EXT_BAND_CTL_OP_HIGH  = 1,
+	/** Switch the pin to input (high-Z). */
+	AD9361_EXT_BAND_CTL_OP_INPUT = 2,
+	/** Leave this pin unchanged. */
+	AD9361_EXT_BAND_CTL_OP_NOP   = 3,
+};
+
+/* Band setting descriptor */
+
+/**
+ * struct ad9361_band_setting - Describes a single frequency-band configuration.
+ *
+ * When the LO frequency falls within [freq_min, freq_max), the driver will:
+ *   1. Execute any pre_seq[] steps in order.
+ *   2. Drive GPIOs according to gpio_values[].
+ *   3. Switch the RX/TX port if rf_rx_input_sel / rf_tx_output_sel differ
+ *      from the current selection.
+ *   4. Execute any post_seq[] steps in order.
+ */
+struct ad9361_band_setting {
+	/** Human-readable identifier (optional, used for debug messages). */
+	const char *name;
+
+	/** Inclusive lower bound of the frequency range (Hz). */
+	uint64_t freq_min;
+	/** Exclusive upper bound of the frequency range (Hz). */
+	uint64_t freq_max;
+
+	/**
+	 * GPIO operations for each pin, indexed by GPIO index in the
+	 * controller's gpios[] array.  Must have ngpios entries when non-NULL.
+	 * Use AD9361_EXT_BAND_CTL_OP_NOP for pins that should not change.
+	 */
+	uint32_t *gpio_values;
+	/** Number of valid entries in gpio_values[]. */
+	uint32_t  ngpios;
+
+	/**
+	 * RX RF input port to select.
+	 * Set to AD9361_EXT_BAND_NO_PORT_SEL to leave port unchanged.
+	 */
+	uint32_t rf_rx_input_sel;
+
+	/**
+	 * TX RF output port to select.
+	 * Set to AD9361_EXT_BAND_NO_PORT_SEL to leave port unchanged.
+	 */
+	uint32_t rf_tx_output_sel;
+
+	/**
+	 * Microsecond delay applied after this step when used inside a
+	 * pre_seq[] or post_seq[] sequence.  0 = no delay.
+	 */
+	uint32_t delay_us;
+
+	/** Optional sequenced steps applied before the main setting (may be NULL). */
+	struct ad9361_band_setting *pre_seq;
+	uint32_t pre_seq_len;
+
+	/** Optional sequenced steps applied after the main setting (may be NULL). */
+	struct ad9361_band_setting *post_seq;
+	uint32_t post_seq_len;
+};
+
+/* Controller descriptor */
+
+/**
+ * struct ad9361_ext_band_ctl - External band controller state.
+ *
+ * Holds the GPIO pool and the RX/TX band-setting tables.
+ * Attach to a PHY with ad9361_register_ext_band_control().
+ */
+struct ad9361_ext_band_ctl {
+	/** GPIO descriptors managed by this controller. */
+	struct no_os_gpio_desc *gpios[AD9361_EXT_BAND_MAX_GPIOS];
+	/** Number of valid entries in gpios[]. */
+	int ngpios;
+
+	/** Array of pointers to RX band settings (searched first-match). */
+	struct ad9361_band_setting **rx_settings;
+	uint32_t rx_count;
+
+	/** Array of pointers to TX band settings. */
+	struct ad9361_band_setting **tx_settings;
+	uint32_t tx_count;
+
+	/** Currently active RX setting (NULL if none applied yet). */
+	struct ad9361_band_setting *current_rx_setting;
+	/** Currently active TX setting (NULL if none applied yet). */
+	struct ad9361_band_setting *current_tx_setting;
+};
+
+
+struct ad9361_band_setting *
+ad9361_band_setting_alloc(const char *name, uint64_t freq_min,
+			  uint64_t freq_max, uint32_t ngpios);
+
+void ad9361_band_setting_free(struct ad9361_band_setting *s);
+
+int  ad9361_band_setting_set_gpio(struct ad9361_band_setting *s,
+				  uint32_t gpio_idx, uint32_t op);
+
+void ad9361_band_setting_set_rx_port(struct ad9361_band_setting *s,
+				     uint32_t port);
+
+void ad9361_band_setting_set_tx_port(struct ad9361_band_setting *s,
+				     uint32_t port);
+
+void ad9361_band_setting_set_delay(struct ad9361_band_setting *s,
+				   uint32_t delay_us);
+
+struct ad9361_ext_band_ctl *ad9361_ext_band_ctl_alloc(void);
+void ad9361_ext_band_ctl_free(struct ad9361_ext_band_ctl *ctl);
+
+int ad9361_ext_band_ctl_add_gpio(struct ad9361_ext_band_ctl *ctl,
+				 struct no_os_gpio_desc *gpio);
+
+int ad9361_ext_band_ctl_add_rx_setting(struct ad9361_ext_band_ctl *ctl,
+				       struct ad9361_band_setting *s);
+
+int ad9361_ext_band_ctl_add_tx_setting(struct ad9361_ext_band_ctl *ctl,
+				       struct ad9361_band_setting *s);
+
+
+int32_t ad9361_register_ext_band_control(struct ad9361_rf_phy *phy,
+		struct ad9361_ext_band_ctl *ctl);
+
+void ad9361_unregister_ext_band_control(struct ad9361_rf_phy *phy);
+
+int32_t ad9361_adjust_rx_ext_band_settings(struct ad9361_rf_phy *phy,
+		uint64_t freq);
+
+int32_t ad9361_adjust_tx_ext_band_settings(struct ad9361_rf_phy *phy,
+		uint64_t freq);
+
+#endif /* AD9361_EXT_BAND_CTRL_H_ */

--- a/drivers/rf-transceiver/ad9361/iio_ad9361.c
+++ b/drivers/rf-transceiver/ad9361/iio_ad9361.c
@@ -41,6 +41,14 @@
 #include "ad9361_api.h"
 #include "no_os_util.h"
 #include "no_os_alloc.h"
+#ifndef AXI_ADC_NOT_PRESENT
+#include "axi_adc_core.h"
+#endif
+
+
+#define AXI_ADC_REG_CLOCKS_PER_PPS        0x00C0
+#define AXI_ADC_REG_CLOCKS_PER_PPS_STATUS 0x00C4
+#define AXI_ADC_CLOCKS_PER_PPS_STAT_INVAL NO_OS_BIT(0)
 
 /**
  * Calibration modes.
@@ -757,6 +765,10 @@ static int set_rf_port_select(void *device, char *buf, uint32_t len,
 		}
 		if (i >= NO_OS_ARRAY_SIZE(ad9361_rf_tx_port))
 			return -EINVAL;
+
+		if (ad9361_phy->pdata->rf_tx_output_sel_lock &&
+		    i != ad9361_phy->pdata->rf_tx_output_sel)
+			return -EINVAL;
 		ret = ad9361_set_tx_rf_port_output(ad9361_phy, i);
 		return (ret < 0) ? ret : (int)len;
 	} else {
@@ -764,13 +776,15 @@ static int set_rf_port_select(void *device, char *buf, uint32_t len,
 			if (!strcmp(ad9361_rf_rx_port[i], buf))
 				break;
 		}
-		if (i >= NO_OS_ARRAY_SIZE(ad9361_rf_tx_port))
+		if (i >= NO_OS_ARRAY_SIZE(ad9361_rf_rx_port))
 			return -EINVAL;
 
+		if (ad9361_phy->pdata->rf_rx_input_sel_lock &&
+		    i != ad9361_phy->pdata->rf_rx_input_sel)
+			return -EINVAL;
 		ret = ad9361_set_rx_rf_port_input(ad9361_phy, i);
 		if (ret < 0)
 			return ret;
-
 		return len;
 	}
 }
@@ -1473,7 +1487,6 @@ static int get_ensm_mode_available(void *device, char *buf, uint32_t len,
 				   intptr_t priv)
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
-
 	return (int) snprintf(buf, len, "%s", ad9361_phy->pdata->fdd ?
 			      "sleep wait alert fdd pinctrl pinctrl_fdd_indep" :
 			      "sleep wait alert rx tx pinctrl");
@@ -1496,17 +1509,102 @@ static int get_multichip_sync(void *device, char *buf, uint32_t len,
 
 /**
  * @brief get_rssi_gain_step_error().
- * @param device - Physical instance of a iio_axi_adc device.
- * @param buf - Where value is stored.
- * @param len - Maximum length of value to be stored in buf.
- * @param channel - Channel properties.
- * @return Length of chars written in buf, or negative value on failure.
+ * Returns the current LNA/mixer error tables and gain-step calibration
+ * register values previously stored by a live calibration or written via
+ * the store handler.  Format mirrors the Linux IIO attribute:
+ *   "lna_error: X X X X mixer_error: X…X gain_step_calib_reg_val: X X X X X"
  */
 static int get_rssi_gain_step_error(void *device, char *buf, uint32_t len,
 				    const struct iio_ch_info *channel,
 				    intptr_t priv)
 {
-	return (int) snprintf(buf, len, "%"PRIi16"", 0);  /* dummy */
+	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
+	struct ad9361_phy_platform_data *pd = ad9361_phy->pdata;
+	int n;
+
+	n = snprintf(buf, len,
+		     "lna_error: %"PRIu32" %"PRIu32" %"PRIu32" %"PRIu32" "
+		     "mixer_error: %"PRIu32" %"PRIu32" %"PRIu32" %"PRIu32" "
+		     "%"PRIu32" %"PRIu32" %"PRIu32" %"PRIu32" "
+		     "%"PRIu32" %"PRIu32" %"PRIu32" %"PRIu32" "
+		     "%"PRIu32" %"PRIu32" %"PRIu32" %"PRIu32" "
+		     "gain_step_calib_reg_val: %"PRIu32" %"PRIu32" %"PRIu32" %"PRIu32" %"PRIu32,
+		     pd->rssi_lna_err_tbl[0], pd->rssi_lna_err_tbl[1],
+		     pd->rssi_lna_err_tbl[2], pd->rssi_lna_err_tbl[3],
+		     pd->rssi_mixer_err_tbl[0],  pd->rssi_mixer_err_tbl[1],
+		     pd->rssi_mixer_err_tbl[2],  pd->rssi_mixer_err_tbl[3],
+		     pd->rssi_mixer_err_tbl[4],  pd->rssi_mixer_err_tbl[5],
+		     pd->rssi_mixer_err_tbl[6],  pd->rssi_mixer_err_tbl[7],
+		     pd->rssi_mixer_err_tbl[8],  pd->rssi_mixer_err_tbl[9],
+		     pd->rssi_mixer_err_tbl[10], pd->rssi_mixer_err_tbl[11],
+		     pd->rssi_mixer_err_tbl[12], pd->rssi_mixer_err_tbl[13],
+		     pd->rssi_mixer_err_tbl[14], pd->rssi_mixer_err_tbl[15],
+		     pd->rssi_gain_step_calib_reg_val[0],
+		     pd->rssi_gain_step_calib_reg_val[1],
+		     pd->rssi_gain_step_calib_reg_val[2],
+		     pd->rssi_gain_step_calib_reg_val[3],
+		     pd->rssi_gain_step_calib_reg_val[4]);
+
+	return (n < 0 || (uint32_t)n >= len) ? -ENOMEM : n;
+}
+
+/**
+ * @brief set_rssi_gain_step_error().
+ * Write pre-measured factory calibration tables directly into pdata
+ * and immediately program them into hardware, bypassing a live calibration.
+ *
+ * Expected format (25 space/newline-separated unsigned integers):
+ *   "lna_error: X X X X mixer_error: X…X gain_step_calib_reg_val: X X X X X"
+ *
+ * Alternatively, write the string "rssi_gain_step" to trigger a live
+ * calibration run (equivalent to the calib_mode trigger).
+ */
+static int set_rssi_gain_step_error(void *device, char *buf, uint32_t len,
+				    const struct iio_ch_info *channel,
+				    intptr_t priv)
+{
+	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
+	struct ad9361_phy_platform_data *pd = ad9361_phy->pdata;
+	uint32_t lna[4], mix[16], cal[5];
+	int ret;
+
+	/* Allow a live calibration trigger as a convenience shortcut */
+	if (!strncmp(buf, "rssi_gain_step", 14)) {
+		return ad9361_rssi_gain_step_calib(ad9361_phy) < 0 ? -EIO : (int)len;
+	}
+
+	ret = sscanf(buf,
+		     "lna_error: %"SCNu32" %"SCNu32" %"SCNu32" %"SCNu32" "
+		     "mixer_error: %"SCNu32" %"SCNu32" %"SCNu32" %"SCNu32" "
+		     "%"SCNu32" %"SCNu32" %"SCNu32" %"SCNu32" "
+		     "%"SCNu32" %"SCNu32" %"SCNu32" %"SCNu32" "
+		     "%"SCNu32" %"SCNu32" %"SCNu32" %"SCNu32" "
+		     "gain_step_calib_reg_val: %"SCNu32" %"SCNu32" %"SCNu32" %"SCNu32" %"SCNu32,
+		     &lna[0], &lna[1], &lna[2], &lna[3],
+		     &mix[0],  &mix[1],  &mix[2],  &mix[3],
+		     &mix[4],  &mix[5],  &mix[6],  &mix[7],
+		     &mix[8],  &mix[9],  &mix[10], &mix[11],
+		     &mix[12], &mix[13], &mix[14], &mix[15],
+		     &cal[0], &cal[1], &cal[2], &cal[3], &cal[4]);
+
+	if (ret != 25)
+		return -EINVAL;
+
+	/* Store into pdata */
+	for (ret = 0; ret < 4;  ret++) pd->rssi_lna_err_tbl[ret]  = lna[ret];
+	for (ret = 0; ret < 16; ret++) pd->rssi_mixer_err_tbl[ret] = mix[ret];
+	for (ret = 0; ret < 5;  ret++) pd->rssi_gain_step_calib_reg_val[ret] = cal[ret];
+
+	/* Program immediately into hardware */
+	ad9361_ensm_force_state(ad9361_phy, ENSM_STATE_ALERT);
+	ad9361_rssi_program_lna_gain(ad9361_phy);
+	ad9361_rssi_write_err_tbl(ad9361_phy);
+	ad9361_ensm_restore_prev_state(ad9361_phy);
+
+	/* Mark that tables are pre-loaded so ad9361_setup won't overwrite them */
+	pd->rssi_skip_calib = true;
+
+	return (int)len;
 }
 
 /**
@@ -1644,6 +1742,11 @@ static int get_calib_mode(void *device, char *buf, uint32_t len,
 	return (int) snprintf(buf, len, "%s", en_dis ? "auto" : "manual");
 }
 
+static inline bool ad9361_iio_ensm_sleep_guard(struct ad9361_rf_phy *phy)
+{
+	return phy->curr_ensm_state == ENSM_STATE_SLEEP;
+}
+
 /**
  * @brief set_trx_rate_governor().
  * @param device - Physical instance of a iio_axi_dac device.
@@ -1658,6 +1761,9 @@ static int set_trx_rate_governor(void *device, char *buf, uint32_t len,
 {
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	int ret = 0;
+
+	if (ad9361_iio_ensm_sleep_guard(ad9361_phy))
+		return -EINVAL;
 
 	if (!strcmp(buf, "nominal"))
 		ad9361_set_trx_rate_gov(ad9361_phy, 1);
@@ -1684,6 +1790,9 @@ static int set_dcxo_tune_coarse(void *device, char *buf, uint32_t len,
 	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
 	uint32_t dcxo_coarse = no_os_str_to_uint32(buf);
 	int32_t ret;
+
+	if (ad9361_iio_ensm_sleep_guard(ad9361_phy))
+		return -EINVAL;
 
 	dcxo_coarse = no_os_clamp_t(uint32_t, dcxo_coarse, 0, 63U);
 	ad9361_phy->pdata->dcxo_coarse = dcxo_coarse;
@@ -1737,6 +1846,10 @@ static int set_calib_mode(void *device, char *buf, uint32_t len,
 	int32_t arg = -1;
 	int ret = 0;
 	uint32_t val = 0;
+
+	if (ad9361_iio_ensm_sleep_guard(ad9361_phy))
+		return -EINVAL;
+
 	val = 0;
 
 	if (!strcmp(buf, "auto")) {
@@ -1861,6 +1974,452 @@ static int set_filter_fir_config(void *device, char *buf, uint32_t len,
 		return ret;
 
 	return len;
+}
+
+static int get_in_voltage_rf_bandwidth_available(void *device, char *buf,
+		uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	return snprintf(buf, len, "[200000 1 56000000]");
+}
+
+static int get_out_voltage_rf_bandwidth_available(void *device, char *buf,
+		uint32_t len,
+		const struct iio_ch_info *channel,
+		intptr_t priv)
+{
+	return snprintf(buf, len, "[200000 1 40000000]");
+}
+
+static int get_gain_info(void *device, char *buf, uint32_t len,
+			 const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
+	struct rf_rx_gain rx_gain = {0};
+	int32_t ret;
+
+	rx_gain.ant = ad9361_1rx1tx_channel_map(ad9361_phy, false,
+						channel->ch_num + 1);
+	ret = ad9361_get_rx_gain(ad9361_phy, rx_gain.ant, &rx_gain);
+	if (ret < 0)
+		return ret;
+
+	return snprintf(buf, len,
+			"gain_db: %"PRId32" fgt_lmt_index: %"PRIu32
+			" digital_gain: %"PRIu32" lmt_gain: %"PRIu32
+			" lpf_gain: %"PRIu32" lna_index: %"PRIu32
+			" tia_index: %"PRIu32" mixer_index: %"PRIu32,
+			rx_gain.gain_db, rx_gain.fgt_lmt_index,
+			rx_gain.digital_gain, rx_gain.lmt_gain,
+			rx_gain.lpf_gain, rx_gain.lna_index,
+			rx_gain.tia_index, rx_gain.mixer_index);
+}
+
+static int get_gpo(void *device, char *buf, uint32_t len,
+		   const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
+	return snprintf(buf, len, "%"PRIu32,
+			ad9361_phy->pdata->gpo_ctrl.gpo_manual_mode_enable_mask);
+}
+
+/**
+ * Set GPO manual state at runtime.
+ * Format: "<pin> <value>"  where pin = 0..3, value = 0|1
+ *   or:   "15 <mask>"      where pin = 15 (0xF) sets all 4 pins at once
+ *         mask is a 4-bit nibble (bit0=GPO0 … bit3=GPO3)
+ */
+static int set_gpo(void *device, char *buf, uint32_t len,
+		   const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
+	struct gpo_control *ctrl = &ad9361_phy->pdata->gpo_ctrl;
+	uint32_t pin, val, mask, new_mask;
+
+	if (!ctrl->gpo_manual_mode_en)
+		return -EINVAL;
+
+	if (sscanf(buf, "%"SCNu32" %"SCNu32, &pin, &val) != 2)
+		return -EINVAL;
+
+	if (pin <= 3) {
+		mask = NO_OS_BIT(pin);
+		new_mask = val ? mask : 0;
+	} else if (pin == 0xF) {
+		mask = 0xF;
+		new_mask = val & 0xF;
+	} else {
+		return -EINVAL;
+	}
+
+	ctrl->gpo_manual_mode_enable_mask &= ~mask;
+	ctrl->gpo_manual_mode_enable_mask |= new_mask;
+
+	ad9361_spi_write(ad9361_phy->spi, REG_GPO_FORCE_AND_INIT,
+			 GPO_MANUAL_CTRL(ctrl->gpo_manual_mode_enable_mask) |
+			 GPO_INIT_STATE(ctrl->gpo0_inactive_state_high_en |
+					(ctrl->gpo1_inactive_state_high_en << 1) |
+					(ctrl->gpo2_inactive_state_high_en << 2) |
+					(ctrl->gpo3_inactive_state_high_en << 3)));
+
+	/* Ensure GPO_MANUAL_SELECT is set in the external LNA control register */
+	uint8_t lna_reg = ad9361_spi_read(ad9361_phy->spi, REG_EXTERNAL_LNA_CTRL);
+	if (!(lna_reg & GPO_MANUAL_SELECT))
+		ad9361_spi_write(ad9361_phy->spi, REG_EXTERNAL_LNA_CTRL,
+				 lna_reg | GPO_MANUAL_SELECT);
+
+	return (int)len;
+}
+
+static int get_cal_sw_ctrl(void *device, char *buf, uint32_t len,
+			   const struct iio_ch_info *channel, intptr_t priv)
+{
+	/* Write-only attribute; reading always returns 0 */
+	return snprintf(buf, len, "0");
+}
+
+static int set_cal_sw_ctrl(void *device, char *buf, uint32_t len,
+			   const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
+	uint32_t val = no_os_str_to_uint32(buf);
+	int32_t ret = ad9361_set_cal_sw(ad9361_phy, val);
+	return (ret < 0) ? ret : (int)len;
+}
+
+static int get_bist_timing_analysis(void *device, char *buf, uint32_t len,
+				    const struct iio_ch_info *channel,
+				    intptr_t priv)
+{
+	/*
+	 * Linux returns the last written trigger value (0 when not triggered).
+	 * The verbose timing table is only in the kernel log; IIO exposes a
+	 * simple integer so that the attribute round-trips symmetrically.
+	 */
+	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
+	return snprintf(buf, len, "%"PRIi32, ad9361_phy->bist_config);
+}
+
+static int set_bist_timing_analysis(void *device, char *buf, uint32_t len,
+				    const struct iio_ch_info *channel,
+				    intptr_t priv)
+{
+#ifndef AXI_ADC_NOT_PRESENT
+	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
+	int32_t val = no_os_str_to_int32(buf);
+	ad9361_phy->bist_config = val;
+	if (val)
+		ad9361_dig_interface_timing_analysis(ad9361_phy, buf, (int32_t)len);
+	return (int)len;
+#else
+	return -ENODEV;
+#endif
+}
+
+/* bist_prbs — inject PRBS pattern (0=disable, 1=INJ_TX, 2=INJ_RX) */
+static int get_bist_prbs(void *device, char *buf, uint32_t len,
+			 const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
+	enum ad9361_bist_mode mode;
+	ad9361_get_bist_prbs(ad9361_phy, &mode);
+	return snprintf(buf, len, "%"PRIi32, (int32_t)mode);
+}
+
+static int set_bist_prbs(void *device, char *buf, uint32_t len,
+			 const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
+	int32_t val = no_os_str_to_int32(buf);
+	int32_t ret = ad9361_bist_prbs(ad9361_phy, (enum ad9361_bist_mode)val);
+	return (ret < 0) ? ret : (int)len;
+}
+
+/* bist_tone — inject tone (0=disable, 1=INJ_TX, 2=INJ_RX) */
+static int get_bist_tone(void *device, char *buf, uint32_t len,
+			 const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
+	enum ad9361_bist_mode mode;
+	uint32_t freq_Hz, level_dB, mask;
+	ad9361_get_bist_tone(ad9361_phy, &mode, &freq_Hz, &level_dB, &mask);
+	return snprintf(buf, len, "%"PRIi32, (int32_t)mode);
+}
+
+static int set_bist_tone(void *device, char *buf, uint32_t len,
+			 const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
+	int32_t val = no_os_str_to_int32(buf);
+	int32_t ret = ad9361_bist_tone(ad9361_phy,
+				       (enum ad9361_bist_mode)val,
+				       ad9361_phy->bist_tone_freq_Hz,
+				       ad9361_phy->bist_tone_level_dB,
+				       ad9361_phy->bist_tone_mask);
+	return (ret < 0) ? ret : (int)len;
+}
+
+/* loopback — digital loopback mode (0=disable, 1=digital, 2=RF) */
+static int get_loopback(void *device, char *buf, uint32_t len,
+			const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
+	int32_t mode;
+	ad9361_get_bist_loopback(ad9361_phy, &mode);
+	return snprintf(buf, len, "%"PRIi32, mode);
+}
+
+static int set_loopback(void *device, char *buf, uint32_t len,
+			const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
+	int32_t val = no_os_str_to_int32(buf);
+	int32_t ret = ad9361_bist_loopback(ad9361_phy, val);
+	return (ret < 0) ? ret : (int)len;
+}
+
+static int get_digital_tune(void *device, char *buf, uint32_t len,
+			    const struct iio_ch_info *channel, intptr_t priv)
+{
+	return snprintf(buf, len, "0");
+}
+
+/**
+ * Trigger ad9361_dig_tune at runtime.
+ * Format: "<max_freq_hz> <flags>"  e.g. "61440000 0"
+ */
+static int set_digital_tune(void *device, char *buf, uint32_t len,
+			    const struct iio_ch_info *channel, intptr_t priv)
+{
+#ifndef AXI_ADC_NOT_PRESENT
+	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
+	uint32_t max_freq = 0, flags = 0;
+
+	sscanf(buf, "%"SCNu32" %"SCNu32, &max_freq, &flags);
+	if (!max_freq)
+		max_freq = 61440000;
+
+	int32_t ret = ad9361_dig_tune(ad9361_phy, max_freq,
+				      (enum dig_tune_flags)flags);
+	return (ret < 0) ? ret : (int)len;
+#else
+	return -ENODEV;
+#endif
+}
+
+static int get_initialize(void *device, char *buf, uint32_t len,
+			  const struct iio_ch_info *channel, intptr_t priv)
+{
+	return snprintf(buf, len, "0");
+}
+
+static int set_initialize(void *device, char *buf, uint32_t len,
+			  const struct iio_ch_info *channel, intptr_t priv)
+{
+	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
+	uint32_t val = no_os_str_to_uint32(buf);
+
+	if (val != 1)
+		return -EINVAL;
+
+	ad9361_clear_state(ad9361_phy);
+	int32_t ret = ad9361_setup(ad9361_phy);
+	return (ret < 0) ? ret : (int)len;
+}
+
+/*
+ * samples_pps — samples captured during one GPS 1-PPS interval
+ * Reads ADI_REG_CLOCKS_PER_PPS from the AXI HDL, corrected for
+ * 1rx1tx / 2rx2tx mode and CMOS / LVDS interface mode.
+*/
+static int get_samples_pps(void *device, char *buf, uint32_t len,
+			   const struct iio_ch_info *channel, intptr_t priv)
+{
+#ifndef AXI_ADC_NOT_PRESENT
+	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
+	struct axi_adc *rx_adc = ad9361_phy->rx_adc;
+	uint32_t config, status, mode, val;
+	int ret;
+
+	if (!rx_adc)
+		return -ENODEV;
+
+	/* Check PPS receiver is enabled in the HDL config register */
+	ret = axi_adc_read(rx_adc, AXI_ADC_REG_CONFIG, &config);
+	if (ret < 0)
+		return ret;
+	if (!(config & AXI_ADC_PPS_RECEIVER_ENABLE))
+		return -ENODEV;
+
+	/* Check measurement validity */
+	ret = axi_adc_read(rx_adc, AXI_ADC_REG_CLOCKS_PER_PPS_STATUS, &status);
+	if (ret < 0)
+		return ret;
+	if (status & AXI_ADC_CLOCKS_PER_PPS_STAT_INVAL)
+		return -ETIMEDOUT;
+
+	/* Read the raw DATA_CLK cycle count for one PPS period */
+	ret = axi_adc_read(rx_adc, AXI_ADC_REG_CNTRL, &mode);
+	if (ret < 0)
+		return ret;
+
+	ret = axi_adc_read(rx_adc, AXI_ADC_REG_CLOCKS_PER_PPS, &val);
+	if (ret < 0)
+		return ret;
+
+	/*
+	 * DATA_CLK counts at ADC_CLK rate. Correct for mode:
+	 *  - 2rx2tx: DATA_CLK = ADC_CLK / 2  → multiply count by 2
+	 *  - CMOS:   DATA_CLK = ADC_CLK / 2  → multiply count by 2
+	 *  (the two corrections are independent and additive)
+	 */
+	if (!(mode & AXI_ADC_R1_MODE))
+		val /= 2;  /* 2rx2tx: two samples per DATA_CLK cycle */
+	if (!(config & AXI_ADC_CMOS_OR_LVDS_N))
+		val /= 2;  /* LVDS: DDR so two samples per clock edge */
+
+	return snprintf(buf, len, "%"PRIu32, val);
+#else
+	return snprintf(buf, len, "N/A");
+#endif
+}
+
+/*
+ * IIO calibscale / calibbias / calibphase on AXI DMA channels
+ * These map to per-channel DC-offset and IQ imbalance correction registers
+ * in the AXI ADC HDL core (REG_CHAN_CNTRL_1 / REG_CHAN_CNTRL_2).
+*/
+
+/* --- calibscale --- */
+static int get_calibscale(void *device, char *buf, uint32_t len,
+			  const struct iio_ch_info *channel, intptr_t priv)
+{
+#ifndef AXI_ADC_NOT_PRESENT
+	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
+	int32_t val, val2;
+	int ret;
+
+	if (!ad9361_phy->rx_adc)
+		return -ENODEV;
+
+	ret = axi_adc_get_calib_scale(ad9361_phy->rx_adc,
+				      (uint32_t)channel->ch_num, &val, &val2);
+	if (ret < 0)
+		return ret;
+
+	return snprintf(buf, len, "%"PRId32".%06"PRId32, val, abs(val2));
+#else
+	return snprintf(buf, len, "1.000000");
+#endif
+}
+
+static int set_calibscale(void *device, char *buf, uint32_t len,
+			  const struct iio_ch_info *channel, intptr_t priv)
+{
+#ifndef AXI_ADC_NOT_PRESENT
+	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
+	int32_t val, val2;
+
+	if (!ad9361_phy->rx_adc)
+		return -ENODEV;
+
+	/* Parse fixed-point "X.YYYYYY" */
+	if (sscanf(buf, "%"SCNd32".%"SCNd32, &val, &val2) != 2)
+		return -EINVAL;
+
+	int ret = axi_adc_set_calib_scale(ad9361_phy->rx_adc,
+					  (uint32_t)channel->ch_num, val, val2);
+	return (ret < 0) ? ret : (int)len;
+#else
+	return -ENODEV;
+#endif
+}
+
+/* --- calibbias (DC offset) --- */
+static int get_calibbias(void *device, char *buf, uint32_t len,
+			 const struct iio_ch_info *channel, intptr_t priv)
+{
+#ifndef AXI_ADC_NOT_PRESENT
+	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
+	int32_t val, val2;
+	int ret;
+
+	if (!ad9361_phy->rx_adc)
+		return -ENODEV;
+
+	ret = axi_adc_get_calib_bias(ad9361_phy->rx_adc,
+				     (uint32_t)channel->ch_num, &val, &val2);
+	if (ret < 0)
+		return ret;
+
+	return snprintf(buf, len, "%"PRId32".%06"PRId32, val, abs(val2));
+#else
+	return snprintf(buf, len, "0.000000");
+#endif
+}
+
+static int set_calibbias(void *device, char *buf, uint32_t len,
+			 const struct iio_ch_info *channel, intptr_t priv)
+{
+#ifndef AXI_ADC_NOT_PRESENT
+	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
+	int32_t val, val2 = 0;
+
+	if (!ad9361_phy->rx_adc)
+		return -ENODEV;
+
+	sscanf(buf, "%"SCNd32".%"SCNd32, &val, &val2);
+
+	int ret = axi_adc_set_calib_bias(ad9361_phy->rx_adc,
+					 (uint32_t)channel->ch_num, val, val2);
+	return (ret < 0) ? ret : (int)len;
+#else
+	return -ENODEV;
+#endif
+}
+
+/* --- calibphase (IQ phase correction) --- */
+static int get_calibphase(void *device, char *buf, uint32_t len,
+			  const struct iio_ch_info *channel, intptr_t priv)
+{
+#ifndef AXI_ADC_NOT_PRESENT
+	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
+	int32_t val, val2;
+	int ret;
+
+	if (!ad9361_phy->rx_adc)
+		return -ENODEV;
+
+	ret = axi_adc_get_calib_phase(ad9361_phy->rx_adc,
+				      (uint32_t)channel->ch_num, &val, &val2);
+	if (ret < 0)
+		return ret;
+
+	return snprintf(buf, len, "%"PRId32".%06"PRId32, val, abs(val2));
+#else
+	return snprintf(buf, len, "0.000000");
+#endif
+}
+
+static int set_calibphase(void *device, char *buf, uint32_t len,
+			  const struct iio_ch_info *channel, intptr_t priv)
+{
+#ifndef AXI_ADC_NOT_PRESENT
+	struct ad9361_rf_phy *ad9361_phy = (struct ad9361_rf_phy *)device;
+	int32_t val, val2 = 0;
+
+	if (!ad9361_phy->rx_adc)
+		return -ENODEV;
+
+	sscanf(buf, "%"SCNd32".%"SCNd32, &val, &val2);
+
+	int ret = axi_adc_set_calib_phase(ad9361_phy->rx_adc,
+					  (uint32_t)channel->ch_num, val, val2);
+	return (ret < 0) ? ret : (int)len;
+#else
+	return -ENODEV;
+#endif
 }
 
 struct iio_attribute voltage_output_attributes[] = {
@@ -1993,6 +2552,31 @@ struct iio_attribute voltage_input_attributes[] = {
 		.show = get_bb_dc_offset_tracking_en,
 		.store = set_bb_dc_offset_tracking_en,
 	},
+	{
+		.name = "gain_info",
+		.show = get_gain_info,
+		.store = NULL,
+	},
+	{
+		.name = "samples_pps",
+		.show = get_samples_pps,
+		.store = NULL,
+	},
+	{
+		.name = "calibscale",
+		.show = get_calibscale,
+		.store = set_calibscale,
+	},
+	{
+		.name = "calibbias",
+		.show = get_calibbias,
+		.store = set_calibbias,
+	},
+	{
+		.name = "calibphase",
+		.show = get_calibphase,
+		.store = set_calibphase,
+	},
 	END_ATTRIBUTES_ARRAY
 };
 
@@ -2058,7 +2642,262 @@ struct iio_attribute temp0_attributes[] = {
 	END_ATTRIBUTES_ARRAY,
 };
 
+/* =========================================================================
+ * Device-level (global) handlers with Linux-compatible naming.
+ *
+ * The iio-oscilloscope plugin reads attributes at device scope using the
+ * exact names the Linux kernel IIO driver exposes as IIO_DEVICE_ATTR:
+ *   in_voltage_rf_bandwidth, out_voltage_rf_bandwidth,
+ *   in_voltage_filter_fir_en, out_voltage_filter_fir_en,
+ *   in_out_voltage_filter_fir_en,
+ *   in_voltage_sampling_frequency, out_voltage_sampling_frequency,
+ *   in_voltage_bb_dc_offset_tracking_en,
+ *   in_voltage_rf_dc_offset_tracking_en,
+ *   in_voltage_quadrature_tracking_en
+ *
+ * These global handlers delegate to the same underlying functions used by
+ * the per-channel attributes, using a NULL channel pointer with a fake
+ * ch_info that carries ch_out correctly.
+ * ========================================================================= */
+
+/* Fake channel info stubs used by device-level (global) attribute handlers. */
+static const struct iio_ch_info g_rx_ch = { .ch_out = 0, .ch_num = 0 };
+static const struct iio_ch_info g_tx_ch = { .ch_out = 1, .ch_num = 0 };
+
+/* --- in_voltage_rf_bandwidth ------------------------------------------ */
+static int get_in_voltage_rf_bandwidth(void *dev, char *buf, uint32_t len,
+				       const struct iio_ch_info *ch,
+				       intptr_t priv)
+{
+	return get_rf_bandwidth(dev, buf, len, &g_rx_ch, priv);
+}
+static int set_in_voltage_rf_bandwidth(void *dev, char *buf, uint32_t len,
+				       const struct iio_ch_info *ch,
+				       intptr_t priv)
+{
+	return set_rf_bandwidth(dev, buf, len, &g_rx_ch, priv);
+}
+
+/* --- out_voltage_rf_bandwidth ----------------------------------------- */
+static int get_out_voltage_rf_bandwidth(void *dev, char *buf, uint32_t len,
+					const struct iio_ch_info *ch,
+					intptr_t priv)
+{
+	return get_rf_bandwidth(dev, buf, len, &g_tx_ch, priv);
+}
+static int set_out_voltage_rf_bandwidth(void *dev, char *buf, uint32_t len,
+					const struct iio_ch_info *ch,
+					intptr_t priv)
+{
+	return set_rf_bandwidth(dev, buf, len, &g_tx_ch, priv);
+}
+
+/* --- in_voltage_sampling_frequency ------------------------------------ */
+static int get_in_voltage_sampling_frequency(void *dev, char *buf,
+		uint32_t len,
+		const struct iio_ch_info *ch,
+		intptr_t priv)
+{
+	return get_sampling_frequency(dev, buf, len, &g_rx_ch, priv);
+}
+static int set_in_voltage_sampling_frequency(void *dev, char *buf,
+		uint32_t len,
+		const struct iio_ch_info *ch,
+		intptr_t priv)
+{
+	return set_sampling_frequency(dev, buf, len, &g_rx_ch, priv);
+}
+
+/* --- out_voltage_sampling_frequency ----------------------------------- */
+static int get_out_voltage_sampling_frequency(void *dev, char *buf,
+		uint32_t len,
+		const struct iio_ch_info *ch,
+		intptr_t priv)
+{
+	/* TX sampling rate: read TX_SAMPL_CLK directly */
+	struct ad9361_rf_phy *phy = (struct ad9361_rf_phy *)dev;
+	uint32_t rate;
+	int ret = ad9361_get_tx_sampling_freq(phy, &rate);
+	if (ret < 0)
+		return ret;
+	return snprintf(buf, len, "%"PRIu32, rate);
+}
+static int set_out_voltage_sampling_frequency(void *dev, char *buf,
+		uint32_t len,
+		const struct iio_ch_info *ch,
+		intptr_t priv)
+{
+	struct ad9361_rf_phy *phy = (struct ad9361_rf_phy *)dev;
+	uint32_t rate = no_os_str_to_uint32(buf);
+	int ret = ad9361_set_tx_sampling_freq(phy, rate);
+	if (ret < 0)
+		return ret;
+	return (int)len;
+}
+
+/* --- in_voltage_filter_fir_en ----------------------------------------- */
+static int get_in_voltage_filter_fir_en(void *dev, char *buf, uint32_t len,
+					const struct iio_ch_info *ch,
+					intptr_t priv)
+{
+	return get_filter_fir_en(dev, buf, len, &g_rx_ch, priv);
+}
+static int set_in_voltage_filter_fir_en(void *dev, char *buf, uint32_t len,
+					const struct iio_ch_info *ch,
+					intptr_t priv)
+{
+	return set_filter_fir_en(dev, buf, len, &g_rx_ch, priv);
+}
+
+/* --- out_voltage_filter_fir_en ---------------------------------------- */
+static int get_out_voltage_filter_fir_en(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *ch,
+		intptr_t priv)
+{
+	return get_filter_fir_en(dev, buf, len, &g_tx_ch, priv);
+}
+static int set_out_voltage_filter_fir_en(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *ch,
+		intptr_t priv)
+{
+	return set_filter_fir_en(dev, buf, len, &g_tx_ch, priv);
+}
+
+/* --- in_out_voltage_filter_fir_en ------------------------------------- */
+static int get_in_out_voltage_filter_fir_en(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *ch,
+		intptr_t priv)
+{
+	/* Report RX FIR state (both are always set together) */
+	return get_filter_fir_en(dev, buf, len, &g_rx_ch, priv);
+}
+static int set_in_out_voltage_filter_fir_en(void *dev, char *buf, uint32_t len,
+		const struct iio_ch_info *ch,
+		intptr_t priv)
+{
+	/* Set both RX and TX FIR simultaneously */
+	struct ad9361_rf_phy *phy = (struct ad9361_rf_phy *)dev;
+	int8_t en = (int8_t)no_os_str_to_int32(buf);
+	int ret;
+	ret = ad9361_set_rx_fir_en_dis(phy, en ? 1 : 0);
+	if (ret < 0)
+		return ret;
+	ret = ad9361_set_tx_fir_en_dis(phy, en ? 1 : 0);
+	if (ret < 0)
+		return ret;
+	return (int)len;
+}
+
+/* --- in_voltage_bb_dc_offset_tracking_en ------------------------------ */
+static int get_in_voltage_bb_dc_offset_tracking_en(void *dev, char *buf,
+		uint32_t len,
+		const struct iio_ch_info *ch,
+		intptr_t priv)
+{
+	return get_bb_dc_offset_tracking_en(dev, buf, len, &g_rx_ch, priv);
+}
+static int set_in_voltage_bb_dc_offset_tracking_en(void *dev, char *buf,
+		uint32_t len,
+		const struct iio_ch_info *ch,
+		intptr_t priv)
+{
+	return set_bb_dc_offset_tracking_en(dev, buf, len, &g_rx_ch, priv);
+}
+
+/* --- in_voltage_rf_dc_offset_tracking_en ------------------------------ */
+static int get_in_voltage_rf_dc_offset_tracking_en(void *dev, char *buf,
+		uint32_t len,
+		const struct iio_ch_info *ch,
+		intptr_t priv)
+{
+	return get_rf_dc_offset_tracking_en(dev, buf, len, &g_rx_ch, priv);
+}
+static int set_in_voltage_rf_dc_offset_tracking_en(void *dev, char *buf,
+		uint32_t len,
+		const struct iio_ch_info *ch,
+		intptr_t priv)
+{
+	return set_rf_dc_offset_tracking_en(dev, buf, len, &g_rx_ch, priv);
+}
+
+/* --- in_voltage_quadrature_tracking_en -------------------------------- */
+static int get_in_voltage_quadrature_tracking_en(void *dev, char *buf,
+		uint32_t len,
+		const struct iio_ch_info *ch,
+		intptr_t priv)
+{
+	return get_quadrature_tracking_en(dev, buf, len, &g_rx_ch, priv);
+}
+static int set_in_voltage_quadrature_tracking_en(void *dev, char *buf,
+		uint32_t len,
+		const struct iio_ch_info *ch,
+		intptr_t priv)
+{
+	return set_quadrature_tracking_en(dev, buf, len, &g_rx_ch, priv);
+}
+
 static struct iio_attribute global_attributes[] = {
+
+	{
+		.name = "in_voltage_rf_bandwidth",
+		.show = get_in_voltage_rf_bandwidth,
+		.store = set_in_voltage_rf_bandwidth,
+	},
+	{
+		.name = "in_voltage_rf_bandwidth_available",
+		.show = get_in_voltage_rf_bandwidth_available,
+		.store = NULL,
+	},
+	{
+		.name = "out_voltage_rf_bandwidth",
+		.show = get_out_voltage_rf_bandwidth,
+		.store = set_out_voltage_rf_bandwidth,
+	},
+	{
+		.name = "out_voltage_rf_bandwidth_available",
+		.show = get_out_voltage_rf_bandwidth_available,
+		.store = NULL,
+	},
+	{
+		.name = "in_voltage_sampling_frequency",
+		.show = get_in_voltage_sampling_frequency,
+		.store = set_in_voltage_sampling_frequency,
+	},
+	{
+		.name = "out_voltage_sampling_frequency",
+		.show = get_out_voltage_sampling_frequency,
+		.store = set_out_voltage_sampling_frequency,
+	},
+	{
+		.name = "in_voltage_filter_fir_en",
+		.show = get_in_voltage_filter_fir_en,
+		.store = set_in_voltage_filter_fir_en,
+	},
+	{
+		.name = "out_voltage_filter_fir_en",
+		.show = get_out_voltage_filter_fir_en,
+		.store = set_out_voltage_filter_fir_en,
+	},
+	{
+		.name = "in_out_voltage_filter_fir_en",
+		.show = get_in_out_voltage_filter_fir_en,
+		.store = set_in_out_voltage_filter_fir_en,
+	},
+	{
+		.name = "in_voltage_bb_dc_offset_tracking_en",
+		.show = get_in_voltage_bb_dc_offset_tracking_en,
+		.store = set_in_voltage_bb_dc_offset_tracking_en,
+	},
+	{
+		.name = "in_voltage_rf_dc_offset_tracking_en",
+		.show = get_in_voltage_rf_dc_offset_tracking_en,
+		.store = set_in_voltage_rf_dc_offset_tracking_en,
+	},
+	{
+		.name = "in_voltage_quadrature_tracking_en",
+		.show = get_in_voltage_quadrature_tracking_en,
+		.store = set_in_voltage_quadrature_tracking_en,
+	},
 	{
 		.name = "dcxo_tune_coarse",
 		.show = get_dcxo_tune_coarse,
@@ -2112,7 +2951,7 @@ static struct iio_attribute global_attributes[] = {
 	{
 		.name = "rssi_gain_step_error",
 		.show = get_rssi_gain_step_error,
-		.store = NULL,
+		.store = set_rssi_gain_step_error,
 	},
 	{
 		.name = "dcxo_tune_coarse_available",
@@ -2148,6 +2987,56 @@ static struct iio_attribute global_attributes[] = {
 		.name = "calib_mode",
 		.show = get_calib_mode,
 		.store = set_calib_mode,
+	},
+	END_ATTRIBUTES_ARRAY,
+};
+
+/*
+ * Debug attributes — exposed under the "debug" type in the IIO XML,
+ * matching the Linux kernel ad9361 driver classification.
+ * These are low-level / diagnostic controls that libiio exposes via
+ * iio_device_find_debug_attr() rather than iio_device_find_attr().
+ */
+static struct iio_attribute debug_attributes[] = {
+	{
+		.name = "digital_tune",
+		.show = get_digital_tune,
+		.store = set_digital_tune,
+	},
+	{
+		.name = "calibration_switch_control",
+		.show = get_cal_sw_ctrl,
+		.store = set_cal_sw_ctrl,
+	},
+	{
+		.name = "gpo_set",
+		.show = get_gpo,
+		.store = set_gpo,
+	},
+	{
+		.name = "bist_timing_analysis",
+		.show = get_bist_timing_analysis,
+		.store = set_bist_timing_analysis,
+	},
+	{
+		.name = "bist_prbs",
+		.show = get_bist_prbs,
+		.store = set_bist_prbs,
+	},
+	{
+		.name = "bist_tone",
+		.show = get_bist_tone,
+		.store = set_bist_tone,
+	},
+	{
+		.name = "loopback",
+		.show = get_loopback,
+		.store = set_loopback,
+	},
+	{
+		.name = "initialize",
+		.show = get_initialize,
+		.store = set_initialize,
 	},
 	END_ATTRIBUTES_ARRAY,
 };
@@ -2244,7 +3133,7 @@ int32_t iio_ad9361_init(struct iio_ad9361_desc **desc,
 	iio_ad9361_inst->dev_descriptor.num_ch = NO_OS_ARRAY_SIZE(iio_ad9361_channels);
 	iio_ad9361_inst->dev_descriptor.channels = iio_ad9361_channels;
 	iio_ad9361_inst->dev_descriptor.attributes = global_attributes;
-	iio_ad9361_inst->dev_descriptor.debug_attributes = NULL;
+	iio_ad9361_inst->dev_descriptor.debug_attributes = debug_attributes;
 	iio_ad9361_inst->dev_descriptor.buffer_attributes = NULL;
 	iio_ad9361_inst->dev_descriptor.debug_reg_read = (int32_t (*)())ad9361_reg_read;
 	iio_ad9361_inst->dev_descriptor.debug_reg_write = (int32_t (


### PR DESCRIPTION
## Pull Request Description

Update AD9361 Driver to be as close to the linux implementation as possible. 
This includes : implementing external band control module missing entirely, ensuring clock changes and modifying parameters occurs properly and adding missing functions and iio attributes.


## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
