### PR TITLE
drivers: rtc: max31343: bugs fixes

### DIFF
--- a/drivers/rtc/max31343/max31343.c
+++ b/drivers/rtc/max31343/max31343.c
@@ -34,7 +34,6 @@
 #include <stdlib.h>
 #include <errno.h>
 #include "max31343.h"
-#include "no_os_delay.h"
 #include "no_os_alloc.h"
 
 /**

--- a/drivers/rtc/max31343/max31343.c
+++ b/drivers/rtc/max31343/max31343.c
@@ -85,7 +85,7 @@ int max31343_update_bits(struct max31343_dev *dev, uint8_t reg_addr,
 			 uint8_t mask, uint8_t reg_data)
 {
 	int ret;
-	uint32_t data;
+	uint8_t data;
 
 	ret = max31343_reg_read(dev, reg_addr, &data);
 	if (ret)


### PR DESCRIPTION
## Pull Request Description

The max31343_update_bits() function was using uint32_t for register data, but the          
underlying max31343_reg_read() function expects an 8-bit pointer (uint8_t*). Additionally, 
the no_os_delay.h header is included but never used in the file.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
