### PR TITLE
drivers: dac: ad5460: fix wrong range constant in current_to_code

### DIFF
--- a/drivers/dac/ad5460/ad5460.c
+++ b/drivers/dac/ad5460/ad5460.c
@@ -100,7 +100,7 @@ int ad5460_dac_current_to_code(struct ad5460_desc *desc, uint32_t uamps,
 		offset = 0;
 		break;
 	case AD5460_IOUT_RANGE_0_20MA:
-		if (uamps > AD5460_DAC_RANGE || uamps < -AD5460_DAC_RANGE)
+		if (uamps > AD5460_DAC_CURRENT_RANGE_20MA)
 			return -EINVAL;
 		range = AD5460_DAC_CURRENT_RANGE_20MA;
 		offset = 0;


### PR DESCRIPTION
The IOUT_RANGE_0_20MA case uses AD5460_DAC_RANGE (12000, a voltage constant in mV) instead of AD5460_DAC_CURRENT_RANGE_20MA (20000). This accepts current values up to only 12000 uA instead of 20000 uA. Also remove the dead lower-bound check against a negative constant since uamps is uint32_t.

Fixes: 8cb0e8bf483f ("dac: ad5460: add initial support")

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
