### PR TITLE
drivers: switch: adg1736: add ADG2736 support

### DIFF
--- a/drivers/switch/adg1736/README.rst
+++ b/drivers/switch/adg1736/README.rst
@@ -1,11 +1,12 @@
-ADG736/ADG1736 no-OS driver
-===========================
+ADG736/ADG1736/ADG2736 no-OS driver
+====================================
 
 Supported Devices
 -----------------
 
 - `ADG736 <https://www.analog.com/en/products/adg736.html>`_
 - `ADG1736 <https://www.analog.com/en/products/adg1736.html>`_
+- `ADG2736 <https://www.analog.com/en/products/adg2736.html>`_
 
 Overview
 --------
@@ -14,25 +15,29 @@ The ADG736 and ADG1736 are monolithic devices comprising two independently
 selectable CMOS single pole, double throw (SPDT) switches. Each switch can
 connect its input to one of two outputs (A or B) based on the control signal.
 
-The devices operate from 1.8 V to 5.5 V single supply and feature:
-- Low on resistance (2.5 Ω typical)
-- Fast switching times (tON: 16 ns, tOFF: 8 ns)
+The ADG2736 is a pin-compatible ultra-low leakage variant with picoamp-level
+leakage currents. It shares the same GPIO-based control interface, pinout,
+and truth table as the ADG1736, including EN pin support.
+
+All devices operate from 1.8 V to 5.5 V single supply and feature:
+- Low on resistance
+- Fast switching times
 - Break-before-make switching action
 - TTL-/CMOS-compatible control inputs
 
 **Key Difference:**
 
 - **ADG736**: Control via IN1 and IN2 pins only
-- **ADG1736**: Adds optional EN pin for enabling/disabling the mux logic
+- **ADG1736/ADG2736**: Adds optional EN pin for enabling/disabling the mux logic
 
 Applications
 ------------
 
 - Audio and video switching
-- USB 1.1 signal switching
+- Data acquisition systems
 - Sample-and-hold systems
 - Communications systems
-- Mechanical reed relay replacement
+- Instrumentation
 
 Device Configuration
 --------------------
@@ -43,8 +48,8 @@ Driver Initialization
 In order to be able to use the device, you will have to provide the support
 for the communication protocol (GPIO for the control pins IN1 and IN2).
 
-For **ADG1736**, you can optionally provide an EN pin to enable/disable the
-mux logic. If not provided, the EN pin is assumed to be tied high externally.
+For **ADG1736/ADG2736**, you can optionally provide an EN pin to enable/disable
+the mux logic. If not provided, the EN pin is assumed to be tied high externally.
 
 For **ADG736**, the EN pin is not available and must not be specified.
 
@@ -54,16 +59,17 @@ which means that the driver was initialized correctly.
 Switch Control
 ~~~~~~~~~~~~~~
 
-Use **adg1736_set_switch_state()** to control which output each switch connects to:
+The driver provides functions to control which output each switch connects to:
 - ADG1736_CONNECT_A: Connect to output A (IN = HIGH)
 - ADG1736_CONNECT_B: Connect to output B (IN = LOW)
 
-Use **adg1736_get_switch_state()** to read the current switch position.
+Use **adg1736_set_switch_state()** and **adg1736_get_switch_state()** to
+control and read the current switch position.
 
-Enable/Disable Control (ADG1736 only)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Enable/Disable Control (ADG1736/ADG2736 only)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If using ADG1736 with EN pin configured, use:
+If using ADG1736 or ADG2736 with EN pin configured, use:
 - **adg1736_enable()**: Enable the mux logic (EN = HIGH)
 - **adg1736_disable()**: Disable the mux logic (EN = LOW)
 

--- a/drivers/switch/adg1736/adg1736.c
+++ b/drivers/switch/adg1736/adg1736.c
@@ -1,6 +1,6 @@
 /***************************************************************************//**
  *   @file   adg1736.c
- *   @brief  Implementation of ADG1736 Driver.
+ *   @brief  Implementation of ADG1736/ADG2736 Driver.
  *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
 ********************************************************************************
  * Copyright 2025(c) Analog Devices, Inc.
@@ -128,7 +128,8 @@ int adg1736_init(struct adg1736_dev **device,
 	if (!device || !init_param)
 		return -EINVAL;
 
-	if (init_param->type == ADG736 && init_param->gpio_en)
+	if (init_param->type != ADG1736 && init_param->type != ADG2736 &&
+	    init_param->gpio_en)
 		return -EINVAL;
 
 	dev = no_os_calloc(1, sizeof(*dev));
@@ -153,7 +154,7 @@ int adg1736_init(struct adg1736_dev **device,
 	if (ret)
 		goto error_gpio2;
 
-	if (dev->type == ADG1736) {
+	if (dev->type == ADG1736 || dev->type == ADG2736) {
 		ret = no_os_gpio_get_optional(&dev->gpio_en, init_param->gpio_en);
 		if (ret)
 			goto error_gpio2;
@@ -193,7 +194,7 @@ int adg1736_remove(struct adg1736_dev *dev)
 
 	no_os_gpio_remove(dev->gpio_in1);
 	no_os_gpio_remove(dev->gpio_in2);
-	if (dev->type == ADG1736 && dev->gpio_en)
+	if ((dev->type == ADG1736 || dev->type == ADG2736) && dev->gpio_en)
 		no_os_gpio_remove(dev->gpio_en);
 	no_os_free(dev);
 
@@ -201,7 +202,7 @@ int adg1736_remove(struct adg1736_dev *dev)
 }
 
 /**
- * @brief Enable the mux (ADG1736 only, requires EN pin).
+ * @brief Enable the mux (ADG1736/ADG2736 only, requires EN pin).
  * @param dev - The device structure.
  * @return 0 in case of success, negative error code otherwise.
  */
@@ -210,7 +211,7 @@ int adg1736_enable(struct adg1736_dev *dev)
 	if (!dev)
 		return -EINVAL;
 
-	if (dev->type != ADG1736)
+	if (dev->type != ADG1736 && dev->type != ADG2736)
 		return -ENOTSUP;
 
 	if (!dev->gpio_en)
@@ -220,7 +221,7 @@ int adg1736_enable(struct adg1736_dev *dev)
 }
 
 /**
- * @brief Disable the mux (ADG1736 only, requires EN pin).
+ * @brief Disable the mux (ADG1736/ADG2736 only, requires EN pin).
  * @param dev - The device structure.
  * @return 0 in case of success, negative error code otherwise.
  */
@@ -229,7 +230,7 @@ int adg1736_disable(struct adg1736_dev *dev)
 	if (!dev)
 		return -EINVAL;
 
-	if (dev->type != ADG1736)
+	if (dev->type != ADG1736 && dev->type != ADG2736)
 		return -ENOTSUP;
 
 	if (!dev->gpio_en)

--- a/drivers/switch/adg1736/adg1736.h
+++ b/drivers/switch/adg1736/adg1736.h
@@ -1,6 +1,6 @@
 /***************************************************************************//**
  *   @file   adg1736.h
- *   @brief  Header file of ADG1736 Driver.
+ *   @brief  Header file of ADG1736/ADG2736 Driver.
  *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
 ********************************************************************************
  * Copyright 2025(c) Analog Devices, Inc.
@@ -40,6 +40,7 @@
 enum adg1736_type {
 	ADG736,
 	ADG1736,
+	ADG2736,
 };
 
 enum adg1736_switch {
@@ -83,10 +84,10 @@ int adg1736_init(struct adg1736_dev **device,
 /** Free resources allocated by adg1736_init(). */
 int adg1736_remove(struct adg1736_dev *dev);
 
-/** Enable the mux (ADG1736 only, requires EN pin). */
+/** Enable the mux (ADG1736/ADG2736 only, requires EN pin). */
 int adg1736_enable(struct adg1736_dev *dev);
 
-/** Disable the mux (ADG1736 only, requires EN pin). */
+/** Disable the mux (ADG1736/ADG2736 only, requires EN pin). */
 int adg1736_disable(struct adg1736_dev *dev);
 
 #endif // ADG1736_H_


### PR DESCRIPTION
## Pull Request Description

The ADG2736 is a pin-compatible ultra-low leakage variant of the
ADG1736 dual SPDT switch. Both devices share the same GPIO-based
control interface, pinout, and truth table, including EN pin support.

Add ADG2736 to the existing type enum and update the EN pin logic
to handle both ADG1736 and ADG2736 devices.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
