### PR TITLE
drivers: temperature: max31865: fix read mask not applied to SPI buffer

### DIFF
--- a/drivers/temperature/max31865pmb1/max31865.c
+++ b/drivers/temperature/max31865pmb1/max31865.c
@@ -152,14 +152,14 @@ int max31865_read(struct max31865_dev *device, uint8_t reg_addr,
 		.cs_change = 1,
 	};
 
-	raw_array[0] = reg_addr;
-	raw_array[1] = reg_addr;
-
 	if ((reg_addr & MAX31865_READ_MASK) != reg_addr)
 		reg_addr &= MAX31865_READ_MASK;
 
 	if (reg_addr < MAX31865_CONFIG_REG || reg_addr > MAX31865_FAULTSTAT_REG)
 		return -EINVAL;
+
+	raw_array[0] = reg_addr;
+	raw_array[1] = reg_addr;
 
 	ret = no_os_spi_transfer(device->comm_desc, &temp_xfer, 1);
 	if (ret)


### PR DESCRIPTION
The raw_array[] was being assigned the register address before the MAX31865_READ_MASK correction was applied, making the mask check ineffective. Move the raw_array[] assignment after the mask correction so the corrected address is used in the SPI transfer.

Fixes: 3aada09a8622 ("driver:temperature: Added support for max31865pmb1")

Grabbed from #3058

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
