### PR TITLE
iio: make XML header strings const

### DIFF
--- a/iio/iio.c
+++ b/iio/iio.c
@@ -69,7 +69,7 @@
 
 static char uart_buff[IIOD_CONN_BUFFER_SIZE];
 
-static char header[] =
+static const char header[] =
 	"<?xml version=\"1.0\" encoding=\"utf-8\"?>"
 	"<!DOCTYPE context ["
 	"<!ELEMENT context (device | context-attribute)*>"
@@ -94,7 +94,7 @@ static char header[] =
 	"<context name=\"xml\" description=\"no-OS/projects/"
 	NO_OS_TOSTRING(NO_OS_PROJECT)" "
 	NO_OS_TOSTRING(NO_OS_VERSION)"\" >";
-static char header_end[] = "</context>";
+static const char header_end[] = "</context>";
 
 static const char * const iio_chan_type_string[] = {
 	[IIO_VOLTAGE] = "voltage",


### PR DESCRIPTION
Mark header[] and header_end[] as const so they are placed in .rodata (flash) instead of .data (SRAM). These strings are never modified, and keeping them in SRAM wastes ~700 bytes that compete with .bss for the same memory region.

This fixes the iio_aducm3029 build where .bss overflows DSRAM_B by 596 bytes on the ADuCM3029 platform.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
