### PR TITLE
projects: hello_world: add xilinx hardware to builds.json

### DIFF
--- a/projects/hello_world/builds.json
+++ b/projects/hello_world/builds.json
@@ -1,10 +1,16 @@
 {
   "xilinx": {
     "zynq": {
-      "flags": ""
+      "flags": "",
+      "hardware": [
+        "adv7511_zed"
+      ]
     },
     "zynqmp": {
-      "flags": ""
+      "flags": "",
+      "hardware": [
+        "adv7511_zed"
+      ]
     }
   }
 }


### PR DESCRIPTION
The xilinx build entries were missing the hardware field, causing CI to fail with 'No HARDWARE for xilinx found'.

Fixes: ef32cb2f05 ("projects: hello_world: Add Hello World example project")

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
