### PR TITLE
include: Add ohm unit conversion macros

### DIFF
--- a/include/no_os_units.h
+++ b/include/no_os_units.h
@@ -65,6 +65,10 @@
 #define MICROWATT_PER_MILLIWATT	1000UL
 #define MICROWATT_PER_WATT	1000000UL
 
+#define MILLIOHM_PER_OHM	1000UL
+#define MICROOHM_PER_MILLIOHM	1000UL
+#define MICROOHM_PER_OHM	1000000UL
+
 #define MILLIDEGREE_PER_DEGREE	1000UL
 
 /* Returns the given value converted from degree to rad */


### PR DESCRIPTION
## Pull Request Description

Add resistance unit conversion macros (milliohm, microohm) to no_os_units.h, following the existing pattern used for voltage, current, and power conversions.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
