### PR TITLE
Add STM32 CAPI peripherals implementation

### DIFF
--- a/capi/inc/capi_alloc.h
+++ b/capi/inc/capi_alloc.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2025 Analog Devices, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Common API Memory Allocation
+ *
+ * Overrideable allocation suite for CAPI drivers.
+ * Provides malloc/free/calloc/realloc functions that can be overridden
+ * at link time by providing strong implementations.
+ */
+
+#pragma once
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Allocate memory block
+ *
+ * Weak implementation uses standard malloc(). Can be overridden by
+ * providing a strong implementation of capi_malloc_impl().
+ *
+ * @param size Number of bytes to allocate
+ * @return Pointer to allocated memory, or NULL on failure
+ */
+void *capi_malloc(size_t size);
+
+/**
+ * @brief Free memory block
+ *
+ * Weak implementation uses standard free(). Can be overridden by
+ * providing a strong implementation of capi_free_impl().
+ *
+ * @param ptr Pointer to memory block to free
+ */
+void capi_free(void *ptr);
+
+/**
+ * @brief Allocate and zero-initialize memory block
+ *
+ * Weak implementation uses standard calloc(). Can be overridden by
+ * providing a strong implementation of capi_calloc_impl().
+ *
+ * @param num Number of elements
+ * @param size Size of each element in bytes
+ * @return Pointer to allocated and zero-initialized memory, or NULL on failure
+ */
+void *capi_calloc(size_t num, size_t size);
+
+/**
+ * @brief Reallocate memory block
+ *
+ * Weak implementation uses standard realloc(). Can be overridden by
+ * providing a strong implementation of capi_realloc_impl().
+ *
+ * @param ptr Pointer to existing memory block (or NULL)
+ * @param size New size in bytes
+ * @return Pointer to reallocated memory, or NULL on failure
+ */
+void *capi_realloc(void *ptr, size_t size);
+
+/* Weak hook symbols to be overridden by the platform/app (don't call directly). */
+void *capi_malloc_impl(size_t size);
+void capi_free_impl(void *ptr);
+void *capi_calloc_impl(size_t num, size_t size);
+void *capi_realloc_impl(void *ptr, size_t size);
+
+#ifdef __cplusplus
+}
+#endif

--- a/capi/inc/capi_dma.h
+++ b/capi/inc/capi_dma.h
@@ -1,0 +1,430 @@
+/*
+ * Copyright (c) 2024-2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Common HAL DMA
+ */
+
+#ifndef _CAPI_DMA_H_
+#define _CAPI_DMA_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * @enum capi_dma_xfer_type
+ * @brief Supported transfer directions
+ */
+enum capi_dma_xfer_type {
+	CAPI_DMA_MEM_TO_MEM,
+	CAPI_DMA_MEM_TO_DEV,
+	CAPI_DMA_DEV_TO_MEM,
+};
+
+/**
+ * @enum capi_dma_addr_inc
+ * @brief DMA address increment options.
+ */
+enum capi_dma_addr_inc {
+	CAPI_DMA_BYTE_INCREMENT,     /**< Increment address by byte */
+	CAPI_DMA_HALFWORD_INCREMENT, /**< Increment address by halfword */
+	CAPI_DMA_WORD_INCREMENT,     /**< Increment address by word */
+	CAPI_DMA_NO_INCREMENT        /**< No address increment */
+};
+
+/**
+ * @enum capi_dma_xfer_size
+ * @brief DMA transfer size options.
+ */
+enum capi_dma_xfer_size {
+	CAPI_DMA_XFER_SIZE_1_BYTE = 0x0U,   /**< 1 Byte */
+	CAPI_DMA_XFER_SIZE_2_BYTES = 0x1U,  /**< 2 Bytes */
+	CAPI_DMA_XFER_SIZE_4_BYTES = 0x2U,  /**< 4 Bytes */
+	CAPI_DMA_XFER_SIZE_8_BYTES = 0x3U,  /**< 8 Bytes */
+	CAPI_DMA_XFER_SIZE_16_BYTES = 0x4U, /**< 16 Bytes */
+	CAPI_DMA_XFER_SIZE_32_BYTES = 0x5U  /**< 32 Bytes */
+};
+
+/**
+ * @enum capi_dma_sg_mode
+ * @brief Scatter-gather descriptor organization modes
+ */
+enum capi_dma_sg_mode {
+	CAPI_DMA_SG_MODE_ARRAY, /**< Array mode: contiguous descriptor array (DMA, DDE array) */
+	CAPI_DMA_SG_MODE_LIST,  /**< List mode: linked list descriptors (DDE list only) */
+};
+
+// Forward declaration of structures
+struct capi_dma_ops;
+struct capi_irq_handle;
+
+/**
+ * @typedef capi_dma_glbl_addr_t
+ * @brief Global address type for DMA operations.
+ */
+typedef uintptr_t capi_dma_glbl_addr_t;
+
+/**
+ * @typedef capi_dma_xfer_complete_cb
+ * @brief Callback function type for DMA transfer completion.
+ * @param event Event type indicating the completion status
+ * @param xfer_complete_ctx Context data passed to the callback
+ */
+typedef void (*capi_dma_xfer_complete_cb)(uint32_t event,
+		void *xfer_complete_ctx);
+
+/**
+ * @typedef capi_dma_error_cb
+ * @brief Callback function type for DMA error events.
+ * @param event Event type indicating the error status
+ * @param error_ctx Context data passed to the callback
+ */
+typedef void (*capi_dma_error_cb)(uint32_t event, void *error_ctx);
+
+/**
+ * @struct capi_dma_transfer
+ * @brief Represents a generic DMA transfer configuration.
+ */
+struct capi_dma_transfer {
+	/** Source address of the data */
+	capi_dma_glbl_addr_t src;
+	/** Destination address of the data */
+	capi_dma_glbl_addr_t dst;
+	/** Length of the transfer in bytes */
+	size_t length;
+	/** Direction of the transfer */
+	enum capi_dma_xfer_type xfer_type;
+	/** Source address increment mode for each transfer. */
+	enum capi_dma_addr_inc src_inc;
+	/** Destination address increment mode for each transfer. */
+	enum capi_dma_addr_inc dst_inc;
+	/** Source data size for each transfer. */
+	enum capi_dma_xfer_size src_size;
+	/** Destination data size for each transfer. */
+	enum capi_dma_xfer_size dst_size;
+	uint32_t irq_priority;
+	/** Optional user-defined data */
+	void *user_data;
+	/** Optional platform-specific data. Set to NULL if unused */
+	void *extra;
+};
+
+/**
+ * @struct capi_dma_chan
+ * @brief Represents the state and configuration of a DMA channel.
+ */
+struct capi_dma_chan {
+	/** Indicates whether this structure is owned by the application or the
+	 * driver. Set by capi_dma_init_chan(); used by capi_dma_deinit_chan(). */
+	bool owned_by_app;
+	/** Pointer to the associated DMA controller handle. Set by
+	 * capi_dma_init_chan(). */
+	struct capi_dma_handle *handle;
+	/** Channel ID. Set by capi_dma_init_chan(). */
+	uint32_t id;
+	/** Interrupt number for this channel. Set by capi_dma_init_chan(). */
+	uint32_t irq_num;
+	/** Callback function invoked on transfer completion. Set by
+	 * capi_dma_config_xfer(). */
+	capi_dma_xfer_complete_cb xfer_complete_cb;
+	/** Context data for transfer completion callback */
+	void *xfer_complete_ctx;
+	/** Callback function invoked on DMA errors. Set by
+	 * capi_dma_register_error_callback(). */
+	capi_dma_error_cb error_cb;
+	/** Context data for error callback */
+	void *error_ctx;
+	/** Pointer to the capi_dma_transfer object associated with the ongoing
+	 * transfer. This is also passed as the context to the transfer completion
+	 * callback. Set by capi_dma_config_xfer().
+	 */
+	struct capi_dma_transfer *xfer;
+	/** Optional user-defined data */
+	void *user_data;
+	/** Optional platform-specific data. Set by capi_dma_init_chan(). Set to NULL
+	 * if unused. */
+	void *extra;
+};
+
+/**
+ * @struct capi_dma_handle
+ * @brief DMA handle type
+ */
+struct capi_dma_handle {
+	const struct capi_dma_ops
+		*ops; /**< Function pointers that implement the DMA CAPI */
+	bool init_allocated;            /**< If true, the driver is owner of handle memory. */
+	void *priv;                     /**< Pointer to driver-specific handle extension. */
+};
+
+/**
+ * @struct capi_dma_config
+ * @brief Configuration structure for a DMA controller.
+ */
+struct capi_dma_config {
+	/** Unique identifier for the DMA controller */
+	uint64_t id;
+	/** Number of DMA channels available in the controller */
+	uint32_t num_chans;
+	/** Pointer to platform-specific DMA function implementations */
+	const struct capi_dma_ops *ops;
+	/** Handle of IRQ driver. Set to NULL if unused */
+	struct capi_irq_handle *irq_handle;
+	/** Optional platform-specific data. Set to NULL if unused */
+	void *extra;
+};
+
+/**
+ * @struct capi_dma_sg_config
+ * @brief Scatter-gather transfer configuration
+ *
+ * This structure supports both array and list scatter-gather modes.
+ * - For array mode: blocks must be a contiguous array
+ * - For list mode: each block's extra field can contain next-descriptor pointer
+ */
+struct capi_dma_sg_config {
+	/** Number of blocks in the array/list */
+	uint32_t num_blocks;
+	/** Scatter-gather mode */
+	enum capi_dma_sg_mode mode;
+	/** Direction of the transfer (applies to all blocks) */
+	enum capi_dma_xfer_type xfer_type;
+	/** Optional user-defined data */
+	void *user_data;
+	/** Optional platform-specific data. Set to NULL if unused */
+	void *extra;
+};
+
+/**
+ * @brief Initializes an instance of the DMA controller.
+ *
+ * @param [in,out] handle Points to a pointer to the DMA controller context
+ * structure. If set to NULL, the driver allocates the context and takes
+ * ownership. If not NULL, the application provides the structure and retains
+ * ownership.
+ * @param [in] config     Points to the configuration for the DMA controller.
+ *
+ * @return 0 on success, or an error code.
+ */
+int capi_dma_init(struct capi_dma_handle **handle,
+		  const struct capi_dma_config *config);
+
+/**
+ * @brief Frees the resources allocated by the DMA layer and disables the DMA
+ * controller.
+ *
+ * @param [in] handle Points to the DMA controller context.
+ *
+ * @return 0 on success, or an error code.
+ */
+int capi_dma_deinit(struct capi_dma_handle *handle);
+
+/**
+ * @brief Initializes a DMA channel.
+ *
+ * @param [in]  handle Points to the DMA controller context.
+ * @param [in,out] chan_ptr Points to a pointer to the DMA channel structure.
+ *                        If set to NULL, the driver allocates the structure and
+ * takes ownership. If not NULL, the application provides the structure and
+ * retains ownership.
+ * @param [in]  id     Identifier for the DMA channel to initialize.
+ *
+ * @return 0 on success, or an error code.
+ */
+int capi_dma_init_chan(struct capi_dma_handle *handle,
+		       struct capi_dma_chan **chan_ptr,
+		       uint32_t id);
+
+/**
+ * @brief Deinitializes a DMA channel and releases associated resources.
+ *
+ * @param [in] chan Points to the DMA channel to be deinitialized.
+ *
+ * @return 0 on success, or an error code.
+ */
+int capi_dma_deinit_chan(struct capi_dma_chan *chan);
+
+/**
+ * @brief Configures platform-specific settings for a DMA transfer.
+ *
+ * @param [in] chan Points to the DMA channel to be configured.
+ * @param [in] xfer Points to the DMA transfer configuration. This should be valid until the
+ * transfer is completed.
+ *
+ * @return 0 on success, or an error code.
+ */
+int capi_dma_config_xfer(struct capi_dma_chan *chan,
+			 struct capi_dma_transfer *xfer);
+
+/**
+ * @brief Starts a DMA transfer on the specified channel.
+ *
+ * @param [in] chan Points to the DMA channel on which the transfer will start.
+ *
+ * @return 0 on success, or an error code.
+ */
+int capi_dma_xfer_start(struct capi_dma_chan *chan);
+
+/**
+ * @brief Aborts an ongoing DMA transfer and removes pending transfers from the
+ * SG list.
+ *
+ * @param [in] chan Points to the DMA channel whose transfer should be aborted.
+ *
+ * @return 0 on success, or an error code.
+ */
+int capi_dma_xfer_abort(struct capi_dma_chan *chan);
+
+/**
+ * @brief Checks whether the DMA channel has completed its transfer.
+ *
+ * @param [in] chan Points to the DMA channel to check.
+ *
+ * @return true if the transfer is complete; false otherwise.
+ */
+bool capi_dma_chan_is_completed(const struct capi_dma_chan *chan);
+
+/**
+ * @brief DMA Driver Interrupt handler. If interrupt vectors are managed and
+ * implemented by user, then user shall call this function in the relevant
+ * interrupt vector function.
+ *
+ * @param [in] handle Points to the DMA controller context
+ *
+ * @return 0 on success, or an error code.
+ */
+int capi_dma_isr(struct capi_dma_handle *handle);
+
+/**
+ * @brief DMA Channel Interrupt handler. If interrupt vectors are managed and
+ * implemented by user, then user shall call this function in the relevant
+ * interrupt vector function.
+ *
+ * @param [in] chan Points to the DMA channel.
+ *
+ * @return 0 on success, or an error code.
+ */
+int capi_dma_isr_chan(struct capi_dma_chan *chan);
+
+/**
+ * @brief Registers a callback function for DMA channel interrupts.
+ *
+ * @param [in] chan Points to the DMA channel.
+ * @param [in] callback Callback function to be invoked on DMA interrupts.
+ *                     The callback receives the channel and interrupt status.
+ * @param [in] xfer_complete_ctx Context data to be passed to the complete callback.
+ *
+ * @return 0 on success, or an error code.
+ */
+int capi_dma_register_complete_callback(struct capi_dma_chan *chan,
+					capi_dma_xfer_complete_cb callback,
+					void *xfer_complete_ctx);
+
+/**
+ * @brief Registers a callback function for DMA error events.
+ *
+ * @param [in] chan Points to the DMA channel.
+ * @param [in] callback Callback function to be invoked on DMA errors.
+ *                      The callback receives the channel, error status, and context.
+ * @param [in] error_ctx Context data to be passed to the error callback.
+ *
+ * @return 0 on success, or an error code.
+ */
+int capi_dma_register_error_callback(struct capi_dma_chan *chan,
+				     capi_dma_error_cb callback,
+				     void *error_ctx);
+
+/**
+ * @brief Configures a single scatter-gather descriptor
+ *
+ * This function builds one hardware descriptor in a scatter-gather chain.
+ * Call this function once for each block in the scatter-gather transfer.
+ * The descriptors are stored in the array provided in sg_config->extra.
+ *
+ * @param [in] chan Points to the DMA channel
+ * @param [in] sg_config Points to scatter-gather configuration containing the descriptor array
+ * @param [in] block Points to the transfer parameters for this descriptor
+ * @param [in] index Index of this descriptor in the array (0 to num_blocks-1)
+ *
+ * @return 0 on success, or an error code.
+ */
+int capi_dma_config_scattergather_xfer(struct capi_dma_chan *chan,
+				       const struct capi_dma_sg_config *sg_config,
+				       struct capi_dma_transfer *block, uint32_t index);
+
+/**
+ * @brief Starts a scatter-gather DMA transfer
+ *
+ * This function configures the primary descriptor and starts the scatter-gather
+ * DMA operation. All descriptors must be configured using
+ * capi_dma_config_scattergather_xfer() before calling this function.
+ *
+ * @param [in] chan Points to the DMA channel on which the transfer will start
+ * @param [in] sg_config Points to scatter-gather configuration containing the descriptor array
+ *
+ * @return 0 on success, or an error code.
+ */
+int capi_dma_start_scattergather_xfer(struct capi_dma_chan *chan,
+				      const struct capi_dma_sg_config *sg_config);
+
+/**
+ * @struct capi_dma_ops
+ * @brief Structure holding function pointers to platform-specific DMA
+ * operations.
+ *
+ * These are used internally by the DMA thin layer. The public API (above) wraps
+ * these operations to provide a consistent interface.
+ */
+struct capi_dma_ops {
+	/** See capi_dma_init() */
+	int (*init)(struct capi_dma_handle **, const struct capi_dma_config *);
+	/** See capi_dma_deinit() */
+	int (*deinit)(struct capi_dma_handle *);
+	/** See capi_dma_init_chan() */
+	int (*init_chan)(struct capi_dma_handle *, struct capi_dma_chan **,
+			 uint32_t id);
+	/** See capi_dma_deinit_chan() */
+	int (*deinit_chan)(struct capi_dma_chan *);
+	/** See capi_dma_config_xfer() */
+	int (*config_xfer)(struct capi_dma_chan *, struct capi_dma_transfer *);
+	/** See capi_dma_xfer_start() */
+	int (*xfer_start)(struct capi_dma_chan *);
+	/** See capi_dma_xfer_abort() */
+	int (*xfer_abort)(struct capi_dma_chan *);
+	/** See capi_dma_chan_is_completed() */
+	bool (*chan_is_completed)(const struct capi_dma_chan *);
+	/** See capi_dma_isr() */
+	int (*isr)(struct capi_dma_handle *);
+	/** See capi_dma_isr_chan() */
+	int (*isr_chan)(struct capi_dma_chan *);
+	/** Register callback function for channel interrupts */
+	int (*register_complete_callback)(struct capi_dma_chan *,
+					  capi_dma_xfer_complete_cb callback,
+					  void *xfer_complete_ctx);
+	/** Register callback function for error events */
+	int (*register_error_callback)(struct capi_dma_chan *,
+				       capi_dma_error_cb callback,
+				       void *error_ctx);
+	/** See capi_dma_config_scattergather_xfer() */
+	int (*config_scattergather_xfer)(struct capi_dma_chan *,
+					 const struct capi_dma_sg_config *,
+					 struct capi_dma_transfer *, uint32_t);
+	/** See capi_dma_start_scattergather_xfer() */
+	int (*start_scattergather_xfer)(struct capi_dma_chan *,
+					const struct capi_dma_sg_config *);
+};
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/capi/inc/capi_gpio.h
+++ b/capi/inc/capi_gpio.h
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _CAPI_GPIO_H_
+#define _CAPI_GPIO_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/**
+ * GPIO direction options.
+ */
+#define CAPI_GPIO_OUTPUT 0x0
+#define CAPI_GPIO_INPUT  0x1
+
+/**
+ * GPIO pin value options.
+ */
+#define CAPI_GPIO_LOW  0x0
+#define CAPI_GPIO_HIGH 0x1
+
+/**
+ * GPIO pin flags options.
+ */
+#define CAPI_GPIO_ACTIVE_HIGH 0x00
+#define CAPI_GPIO_ACTIVE_LOW  0x01
+
+/**
+ * GPIO port handle type
+ */
+struct capi_gpio_port_handle {
+	const struct capi_gpio_ops *ops; /**< set and used by capi thin layer */
+	bool init_allocated;             /**< If true, the driver is owner of handle memory. */
+	void *lock;                      /**< set and used by capi thin layer if mux is available */
+	void *priv;                      /**< set and used by user optionally */
+};
+
+/**
+ * GPIO port configuration.
+ */
+struct capi_gpio_port_config {
+	/** GPIO port specific operations. */
+	const struct capi_gpio_ops *ops;
+	/** GPIO port identifier:
+	 * - Base address for internal GPIO controllers.
+	 * - Device specific address for external GPIO controllers (e.g., GPIO
+	 *   expanders).
+	 */
+	uint64_t identifier;
+	/** Number of GPIO pins. */
+	uint8_t num_pins;
+	/** GPIO pins flags. */
+	uint32_t *flags;
+	/** This is intended to store GPIO specific configurations. */
+	void *extra;
+};
+
+/**
+ * GPIO pin configuration/descriptor.
+ */
+struct capi_gpio_pin {
+	/** Corresponding GPIO port handle. */
+	struct capi_gpio_port_handle *port_handle;
+	/** GPIO pin number. */
+	uint32_t number;
+	/** GPIO pin flags. */
+	uint32_t flags;
+};
+
+/**
+ * @brief Initialize the GPIO port.
+ *
+ * @param [in,out] handle If NULL, the function must allocate the required
+ *                        memory. Otherwise, init() will use the preallocated
+ *                        structure pointed to by the handle.
+ * @param [in] config The GPIO port configuration.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int capi_gpio_port_init(struct capi_gpio_port_handle **handle,
+			const struct capi_gpio_port_config *config);
+
+/**
+ * @brief Deinitialize the GPIO port.
+ *
+ * @param [in] handle The GPIO port handle. If allocated by the init()
+ *                    function, deinit() must free the memory.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int capi_gpio_port_deinit(struct capi_gpio_port_handle **handle);
+
+/**
+ * @brief Set the direction of all the pins belonging to the specified port.
+ *
+ * @param [in] handle The GPIO port.
+ * @param [in] direction_bitmask The direction (bitmask) to be set for the
+ *                               GPIO pins.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int capi_gpio_port_set_direction(struct capi_gpio_port_handle *handle,
+				 uint64_t direction_bitmask);
+
+/**
+ * @brief Get the current direction of all the pins belonging to the
+ *        specified port.
+ *
+ * @param [in] handle The GPIO port.
+ * @param [out] direction_bitmask The current direction (bitmask) of the
+ *                                GPIO pins.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int capi_gpio_port_get_direction(struct capi_gpio_port_handle *handle,
+				 uint64_t *direction_bitmask);
+
+/**
+ * @brief Set the value of all the pins belonging to the specified port.
+ *
+ * @param [in] handle The GPIO port.
+ * @param [in] value_bitmask The value (bitmask) to be set for the GPIO pins.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int capi_gpio_port_set_value(struct capi_gpio_port_handle *handle,
+			     uint64_t value_bitmask);
+
+/**
+ * @brief Get the current value of all the pins belonging to the
+ *        specified port.
+ *
+ * @param [in] handle The GPIO port.
+ * @param [out] value_bitmask The current value (bitmask) of the GPIO pins.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int capi_gpio_port_get_value(struct capi_gpio_port_handle *handle,
+			     uint64_t *value_bitmask);
+
+/**
+ * @brief Set the raw value of all the pins belonging to the specified port.
+ *
+ * @param [in] handle The GPIO port.
+ * @param [in] value_bitmask The raw value (bitmask) to be set for the GPIO
+ *                           pins, regardless of the ACTIVE_LOW flag.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int capi_gpio_port_set_raw_value(struct capi_gpio_port_handle *handle,
+				 uint64_t value_bitmask);
+
+/**
+ * @brief Get the current raw value of all the pins belonging to the
+ *        specified port.
+ *
+ * @param [in] handle The GPIO port.
+ * @param [out] value_bitmask The current raw value (bitmask) of the GPIO pins,
+ *                            regardless of the ACTIVE_LOW flag.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int capi_gpio_port_get_raw_value(struct capi_gpio_port_handle *handle,
+				 uint64_t *value_bitmask);
+
+/**
+ * @brief Set the direction of the specified GPIO pin.
+ *
+ * @param [in] pin The GPIO pin.
+ * @param [in] direction The direction to be set for the GPIO pin.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int capi_gpio_pin_set_direction(struct capi_gpio_pin *pin, uint8_t direction);
+
+/**
+ * @brief Get the current direction of the specified GPIO pin.
+ *
+ * @param [in] pin The GPIO pin.
+ * @param [out] direction The current direction of the GPIO pin.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int capi_gpio_pin_get_direction(struct capi_gpio_pin *pin, uint8_t *direction);
+
+/**
+ * @brief Set the value of the specified GPIO pin.
+ *
+ * @param [in] pin The GPIO pin.
+ * @param [in] value The value to be set for the GPIO pin.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int capi_gpio_pin_set_value(struct capi_gpio_pin *pin, uint8_t value);
+
+/**
+ * @brief Get the current value of the specified GPIO pin.
+ *
+ * @param [in] pin The GPIO pin.
+ * @param [out] value The current value of the GPIO pin.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int capi_gpio_pin_get_value(struct capi_gpio_pin *pin, uint8_t *value);
+
+/**
+ * @brief Set the raw value of the specified GPIO pin.
+ *
+ * @param [in] pin The GPIO pin.
+ * @param [in] value The raw value to be set for the GPIO pin,
+ *                   regardless of the ACTIVE_LOW flag.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int capi_gpio_pin_set_raw_value(struct capi_gpio_pin *pin, uint8_t value);
+
+/**
+ * @brief Get the current raw value of all the pins belonging to the
+ *        specified port.
+ *
+ * @param [in] pin The GPIO pin.
+ * @param [out] value The current raw value of the GPIO pin,
+ *                    regardless of the ACTIVE_LOW flag.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int capi_gpio_pin_get_raw_value(struct capi_gpio_pin *pin, uint8_t *value);
+
+/**
+ * Container for the GPIO specific operations.
+ */
+struct capi_gpio_ops {
+	/** See capi_gpio_port_init() */
+	int (*port_init)(struct capi_gpio_port_handle **handle,
+			 const struct capi_gpio_port_config *config);
+	/** See capi_gpio_port_deinit() */
+	int (*port_deinit)(struct capi_gpio_port_handle **handle);
+	/** See capi_gpio_port_set_direction() */
+	int (*port_set_direction)(struct capi_gpio_port_handle *handle,
+				  uint64_t direction_bitmask);
+	/** See capi_gpio_port_get_direction() */
+	int (*port_get_direction)(struct capi_gpio_port_handle *handle,
+				  uint64_t *direction_bitmask);
+	/** See capi_gpio_port_set_value() */
+	int (*port_set_value)(struct capi_gpio_port_handle *handle,
+			      uint64_t value_bitmask);
+	/** See capi_gpio_port_get_value() */
+	int (*port_get_value)(struct capi_gpio_port_handle *handle,
+			      uint64_t *value_bitmask);
+	/** See capi_gpio_port_set_raw_value() */
+	int (*port_set_raw_value)(struct capi_gpio_port_handle *handle,
+				  uint64_t value_bitmask);
+	/** See capi_gpio_port_get_raw_value() */
+	int (*port_get_raw_value)(struct capi_gpio_port_handle *handle,
+				  uint64_t *value_bitmask);
+	/** See capi_gpio_pin_set_direction() */
+	int (*pin_set_direction)(struct capi_gpio_pin *pin, uint8_t direction);
+	/** See capi_gpio_pin_get_direction() */
+	int (*pin_get_direction)(struct capi_gpio_pin *pin, uint8_t *direction);
+	/** See capi_gpio_pin_set_value() */
+	int (*pin_set_value)(struct capi_gpio_pin *pin, uint8_t value);
+	/** See capi_gpio_pin_get_value() */
+	int (*pin_get_value)(struct capi_gpio_pin *pin, uint8_t *value);
+	/** See capi_gpio_pin_set_raw_value() */
+	int (*pin_set_raw_value)(struct capi_gpio_pin *pin, uint8_t value);
+	/** See capi_gpio_pin_get_raw_value() */
+	int (*pin_get_raw_value)(struct capi_gpio_pin *pin, uint8_t *value);
+};
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* _CAPI_GPIO_H_ */

--- a/capi/inc/capi_i2c.h
+++ b/capi/inc/capi_i2c.h
@@ -1,0 +1,333 @@
+/*
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Common HAL I2C
+ */
+
+#ifndef _CAPI_I2C_H_
+#define _CAPI_I2C_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+/** Forward Declarations */
+
+/**
+ * @brief forward declaration of common hal DMA controller handle
+ */
+struct capi_dma_handle;
+
+/**
+ * @brief I2C bus speed mode.
+ */
+enum capi_i2c_speed {
+	CAPI_I2C_SPEED_STANDARD,  /**< I2C Standard Speed: 100 kbps */
+	CAPI_I2C_SPEED_FAST,      /**< I2C Fast Speed: 400 kbps */
+	CAPI_I2C_SPEED_FAST_PLUS, /**< I2C Fast Plus Speed: 1 Mbps */
+	CAPI_I2C_SPEED_HIGH,      /**< I2C High Speed: 3.4 Mbps */
+	CAPI_I2C_SPEED_ULTRA      /**< I2C Fast Plus Speed: 5 Mbps */
+};
+
+/**
+ * @brief async event types
+ */
+enum capi_i2c_async_event {
+	CAPI_I2C_NONE,     /**< No event from I2C controller */
+	CAPI_I2C_XFR_DONE, /**< I2C transfer has completed */
+	CAPI_I2C_TXUNDER,  /**< There has been a HW Error: TX Underflow */
+	CAPI_I2C_RXOVER,   /**< There has been a HW Error:  RX Overflow */
+	CAPI_I2C_ALOSS,    /**< There has been an Arbitration Loss */
+	CAPI_I2C_NAKD,     /**< There has been a NAK detected */
+	CAPI_I2C_REPEAT,   /**< There has been a Repeated Start detected. */
+	CAPI_I2C_STXREQ,   /**< There has been a Target Tx Request. */
+	CAPI_I2C_SRXREQ    /**< There has been a Target Rx Request. */
+};
+
+/**
+ * @brief I2C controller configuration
+ */
+struct capi_i2c_config {
+	/** I2C controller identifier:
+	 * - Base address for internal controllers.
+	 * - Device address on I2C bus for external controllers
+	 *   (e.g., I2C Multiplexers, I2C Repeaters).
+	 */
+	uint64_t identifier;
+	/** Frequency of peripheral clock in Hz, if zero driver sets to default of platform */
+	uint32_t clk_freq_hz;
+	/** Specifies whether controller acts as I2C Initiator or I2C Target. */
+	bool initiator;
+	/** Device address when it acts as a target */
+	uint16_t address;
+	/** Device descriptor (e.g., capi_i2c_device, capi_spi_device).
+	 * Populated only when this controller acts as a device for another
+	 * controller (e.g., I2C Multiplexers, I2C Repeaters).
+	 */
+	void *device;
+	/** optional - user shall pass common hal dma handle to enable dma for async transfers */
+	struct capi_dma_handle *dma_handle;
+	/** Optional platform specific extra configuration. */
+	void *extra;
+	/** Platform specific implementation of the API. (Mandatory field, but can be NULL and we'll
+	 * make sure it gets auto populated when using our build system.) */
+	const struct capi_i2c_ops *ops;
+};
+
+/**
+ * @brief I2C controller handle
+ *
+ * Drivers may need own handle type to handle internals.
+ * Driver developer shall declare this as the first field of private handle structure.
+ */
+struct capi_i2c_controller_handle {
+	const struct capi_i2c_ops *ops; /**< set and used by capi thin layer */
+	bool init_allocated;            /**< If true, the driver is owner of handle memory. */
+	void *lock;                     /**< set and used by capi thin layer if mux is available */
+	void *priv;                     /**< set and used by user optionally */
+};
+
+/**
+ * @brief I2C device descriptor
+ */
+struct capi_i2c_device {
+	/** I2C controller this device is connected to. */
+	struct capi_i2c_controller_handle *controller;
+	/** When device acts as target, I2C address of the device on the bus (as specified, not
+	 * shifted). */
+	uint16_t address;
+	/** Specifies whether device works with 10-bit or 7-bit addressing. */
+	bool b10addr;
+	/** I2C speed mode supported by the device. */
+	enum capi_i2c_speed speed;
+	/** I2C SCLK duty cycle required by device, expressed as the numerator in the fraction
+	 * duty_cycle / 256. */
+	uint8_t duty_cycle;
+	/* TODO: discuss clock stretching, per device? */
+	/** clock stretching, 0:none, -1:infinite, [1,n]:bit times where n depends to platform
+	 * support */
+	int clk_stretch;
+	/** Optional platform specific extra configuration. */
+	void *extra;
+};
+
+/**
+ * @brief  I2C transfer
+ */
+struct capi_i2c_transfer {
+	/** Issue a repeated start condition prior to sending the sub-address. */
+	bool repeated_start;
+	/** Sub-address (register) buffer, input, ignored when the other device is an initiator. */
+	uint8_t *sub_address;
+	/** Length of sub-address buffer in bytes, ignored when the other device is an initiator. */
+	uint8_t sub_address_len;
+	/** Data buffer, in/out direction depending on write/read. */
+	uint8_t *buf;
+	/** I2C target device address on the bus (as specified, not shifted). */
+	uint16_t target_addr;
+	/** Length of data buffer in bytes. */
+	uint32_t len;
+	/** Don't issue a stop condition after the data transfer. */
+	bool no_stop;
+};
+
+/**
+ * @brief  I2C Driver Call Back type
+ * @param[in] event I2C event type
+ * @param[in] arg Pointer to user specific data.
+ * @param[in] event_extra optional, platform/driver specific extra information for event
+ */
+typedef void (*capi_i2c_callback)(enum capi_i2c_async_event event, void *arg,
+				  int event_extra);
+
+/**
+ * @brief Initialize an instance of the I2C controller.
+ *
+ * @param [in out] handle Points to a pointer of the context structure. If this
+ *                 pointer is set to NULL, then the controller will allocate
+ *	               the context structure and be the owner. If the pointer
+ *	               is not NULL, the application has allocated the structure and is
+ *	               the owner.
+ * @param [in] config Points to the configuration for the I2C controller.
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_i2c_init(struct capi_i2c_controller_handle **handle,
+		  const struct capi_i2c_config *config);
+
+/**
+ * @brief Deinitialize the I2C controller, disable, and bring to default settings.
+ *
+ * @param [in] handle Points to the I2C controller context.
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_i2c_deinit(struct capi_i2c_controller_handle *handle);
+
+/**
+ * @brief Sync/Blocking transmit function.
+ *
+ * @param [in] device Points to the I2C target-device configuration/descriptor
+ * @param [in] transfer Points to the I2C transfer
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_i2c_transmit(struct capi_i2c_device *device,
+		      struct capi_i2c_transfer *transfer);
+
+/**
+ * @brief Sync/Blocking receive function.
+ *
+ * @param [in] device Points to the I2C target-device configuration/descriptor
+ * @param [in] transfer Points to the I2C transfer
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_i2c_receive(struct capi_i2c_device *device,
+		     struct capi_i2c_transfer *transfer);
+
+/**
+ * @brief Register callback to get async events
+ *
+ * @param [in] handle Points to the I2C controller context.
+ * @param [in] callback User callback function
+ * @param [in] callback_arg User callback arg
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_i2c_register_callback(struct capi_i2c_controller_handle *handle,
+			       capi_i2c_callback const callback, void *const callback_arg);
+
+/**
+ * @brief Configure I2C bus speed
+ *
+ * @param [in] handle Points to the I2C controller context.
+ * @param [in] speed Desired I2C bus speed
+ * @param [in] duty_cycle Desired I2C SCLK duty cycle percentage (10-90%)
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_i2c_configure_bus_speed(struct capi_i2c_controller_handle *handle,
+				 enum capi_i2c_speed speed, uint8_t duty_cycle);
+
+/**
+ * @brief Async/Non-blocking transmit function.
+ *
+ * @param [in] device Points to the I2C target-device configuration/descriptor
+ * @param [in] transfer Points to the I2C transfer
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_i2c_transmit_async(struct capi_i2c_device *device,
+			    struct capi_i2c_transfer *transfer);
+
+/**
+ * @brief Async/Non-blocking receive function.
+ *
+ * @param [in] device Points to the I2C target-device configuration/descriptor
+ * @param [in] transfer Points to the I2C transfer
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_i2c_receive_async(struct capi_i2c_device *device,
+			   struct capi_i2c_transfer *transfer);
+
+/**
+ * @brief Recover I2C bus by releasing SDA line if held low by a slave device.
+ *
+ * This function attempts to recover the I2C bus by enabling the bus clear mechanism
+ * and waiting for the SDA line to be released (go high). It performs multiple
+ * recovery cycles, checking the SDA line state after each cycle.
+ *
+ * @param[in] handle Pointer to the I2C controller handle.
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_i2c_recover_bus(struct capi_i2c_controller_handle *handle);
+
+/**
+ * @brief Register I2C controller in target mode.
+ *
+ * Configures the I2C controller to operate in target mode with the specified
+ * target address. Disables initiator mode when registered as a target.
+ *
+ * @param[in] handle Pointer to the I2C controller handle.
+ * @param[in] addr The target device address (7-bit or 10-bit).
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_i2c_register_target(struct capi_i2c_controller_handle *handle,
+			     uint16_t addr);
+
+/**
+ * @brief Unregister I2C controller from target mode.
+ *
+ * Disables target mode operation and clears the target address configuration.
+ * Re-enables initiator mode after unregistration.
+ *
+ * @param[in] handle Pointer to the I2C controller handle.
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_i2c_unregister_target(struct capi_i2c_controller_handle *handle);
+
+/**
+ * @brief I2C Driver Interrupt handler. If interrupt vectors are managed and implemented by user,
+ * then user shall call this function in the relevant interrupt vector function.
+ *
+ * @param [in] handle Points to the I2C controller context
+ */
+void capi_i2c_isr(void *handle);
+
+/**
+ * @brief Structure holding I2C function pointers that point to the platform
+ * specific function. See API functions for relevant descriptions.
+ */
+struct capi_i2c_ops {
+	/** See capi_i2c_init() */
+	int (*init)(struct capi_i2c_controller_handle **handle,
+		    const struct capi_i2c_config *config);
+	/** See capi_i2c_deinit() */
+	int (*deinit)(struct capi_i2c_controller_handle *handle);
+	/** See capi_i2c_transmit() */
+	int (*transmit)(struct capi_i2c_device *device,
+			struct capi_i2c_transfer *transfer);
+	/** See capi_i2c_receive() */
+	int (*receive)(struct capi_i2c_device *device,
+		       struct capi_i2c_transfer *transfer);
+	/** See capi_i2c_register_callback() */
+	int (*register_callback)(struct capi_i2c_controller_handle *handle,
+				 capi_i2c_callback const callback, void *const callback_arg);
+	/** See capi_i2c_configure_bus_speed() */
+	int (*configure_bus_speed)(struct capi_i2c_controller_handle *handle,
+				   enum capi_i2c_speed speed, uint8_t duty_cycle);
+	/** See capi_i2c_transmit_async() */
+	int (*transmit_async)(struct capi_i2c_device *device,
+			      struct capi_i2c_transfer *transfer);
+	/** See capi_i2c_receive_async() */
+	int (*receive_async)(struct capi_i2c_device *device,
+			     struct capi_i2c_transfer *transfer);
+	/** See capi_i2c_recover_bus() */
+	int (*recover_bus)(struct capi_i2c_controller_handle *handle);
+	/** See capi_i2c_register_target() */
+	int (*register_target)(struct capi_i2c_controller_handle *handle,
+			       uint16_t addr);
+	/** See capi_i2c_unregister_target() */
+	int (*unregister_target)(struct capi_i2c_controller_handle *handle);
+	/** See capi_i2c_isr() */
+	void (*isr)(void *handle);
+};
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/capi/inc/capi_irq.h
+++ b/capi/inc/capi_irq.h
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2024-2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Common HAL Interrupt Controller.
+ */
+
+#ifndef _CAPI_IRQ_H_
+#define _CAPI_IRQ_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * @brief Enumerated type that defines the trigger type.
+ */
+enum capi_irq_trig_level {
+	CAPI_IRQ_LEVEL_LOW,    /**< Trigger when signal is low. */
+	CAPI_IRQ_LEVEL_HIGH,   /**< Trigger when signal is high. */
+	CAPI_IRQ_EDGE_FALLING, /**< Trigger on falling edge. */
+	CAPI_IRQ_EDGE_RISING,  /**< Trigger on rising edge. */
+	CAPI_IRQ_EDGE_BOTH     /**< Trigger on rising and falling edge. */
+};
+
+/**
+ * @brief Interrupt Service Routine.
+ *
+ * @param [in] arg Points to application defined argument.
+ */
+typedef void (*capi_isr_callback_t)(void *arg);
+
+/**
+ * @struct capi_irq_config
+ * @brief Structure that holds the IRQ Controller configuration.
+ */
+struct capi_irq_config {
+	/** Interrupt request controller ID. */
+	uint32_t irq_ctrl_id;
+	/**
+	 * This is intended to store irq controller specific configurations,
+	 * it should not be a reference to any peripheral descriptor.
+	 */
+	void *extra;
+};
+
+/**
+ * @brief Initialize an instance of the IRQ controller.
+ *
+ * @param [in] config Points to the configuration for the IRQ controller.
+ * @return int 0 for success or error code.
+ */
+int capi_irq_init(struct capi_irq_config *config);
+
+/**
+ * @brief Deinitialize the IRQ controller, disable, and bring to default settings.
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_irq_deinit(void);
+
+/**
+ * @brief Enable the interrupt controller.
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_irq_global_enable(void);
+
+/**
+ * @brief Disable the interrupt controller.
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_irq_global_disable(void);
+
+/**
+ * @brief Enable specific irq.
+ *
+ * @param [in] irq Defines the IRQ number.
+ * @return int 0 for success or error code.
+ */
+int capi_irq_enable(uint32_t irq);
+
+/**
+ * @brief Disable specific irq.
+ *
+ * @param [in] irq Defines the IRQ number.
+ * @return int 0 for success or error code.
+ */
+int capi_irq_disable(uint32_t irq);
+
+/**
+ * @brief Set isr for the irq
+ *
+ * @param [in] irq Defines the IRQ number.
+ * @param [in] isr function pointer to isr that needs to be registered.
+ * @param [in] arg A pointer to application defined argument returned when ISR is called.
+ * @return int 0 for success or error code.
+ */
+int capi_irq_connect(uint32_t irq, capi_isr_callback_t isr, void *arg);
+
+/**
+ * @brief Clear a specific pending irq.
+ *
+ * @param [in] irq Defines the IRQ number.
+ * @return int 0 for success or error code.
+ */
+int capi_irq_clear_pending(uint32_t irq);
+
+/**
+ * @brief Get status of a specific irq.
+ *
+ * @param [in] irq Defines the IRQ number.
+ * @param [out] pactive Pointer to irq status update.
+ * @return int 0 for success or error code.
+ */
+int capi_irq_get_status(uint32_t irq, uint32_t *pactive);
+
+/**
+ * @brief Set irq priority.
+ *
+ * @param [in] irq Defines the IRQ number.
+ * @param [in] priority  Priority to set.
+ * @return int 0 for success or error code.
+ */
+int capi_irq_set_priority(uint32_t irq, uint32_t priority);
+
+/**
+ * @brief Get irq priority.
+ *
+ * @param [in] irq Defines the IRQ number.
+ * @param [out] priority irq priority retrieved.
+ * @return int 0 for success or error code.
+ */
+int capi_irq_get_priority(uint32_t irq, uint32_t *priority);
+
+/**
+ * @brief Set the IRQ to fire when defined level or edge is detected based on the given
+ * configuration.
+ *
+ * @param [in] irq Defines the IRQ number.
+ * @param [in] trigger The defined state for IRQ trigger which can be level or edge.
+ * @return int 0 for success or error code.
+ */
+int capi_irq_set_level_edge_trigger(uint32_t irq,
+				    enum capi_irq_trig_level trigger);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif // CAPI_IRQ_H_

--- a/capi/inc/capi_spi.h
+++ b/capi/inc/capi_spi.h
@@ -1,0 +1,378 @@
+/*
+ * Copyright (c) 2024-2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Common API SPI
+ */
+
+#ifndef _CAPI_SPI_H_
+#define _CAPI_SPI_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+/** Forward Declarations */
+
+/**
+ * @brief forward declaration of common hal GPIO pin desc
+ */
+struct capi_gpio_pin;
+
+/**
+ * @brief forward declaration of common hal DMA controller handle
+ */
+struct capi_dma_handle;
+
+/**
+ * @brief SPI controller configuration
+ */
+struct capi_spi_config {
+	/** ops - optional. if NULL, API selects driver from static mapping based on
+	 * identifier */
+	const struct capi_spi_ops *ops;
+	/** SPI controller identifier:
+	 * - Base address for internal controllers.
+	 * - Device specific address for external controllers (e.g., SPI
+	 *   expanders, SPI bridges).
+	 */
+	uint64_t identifier;
+	/** optional - user shall pass common hal dma handle to enable dma for async transfers */
+	struct capi_dma_handle *dma_handle;
+	/** Enables 3 pin mode of operation */
+	bool three_pin_mode;
+	/** Loopback enable, connects MISO to MOSI during configuration */
+	bool loopback;
+	/** Frequency of peripheral clock in Hz, if zero, driver sets to default of platform */
+	uint32_t clk_freq_hz;
+	/** Optional platform specific extra configuration */
+	void *extra;
+};
+
+/**
+ * @brief SPI controller handle
+ *
+ * Drivers may need own handle type to handle internals.
+ * Driver developer shall declare this as the first field of private handle structure.
+ */
+struct capi_spi_controller_handle {
+	const struct capi_spi_ops *ops; /**< set and used by capi thin layer */
+	bool init_allocated;            /**< If true, the driver is owner of handle memory. */
+	void *lock;                     /**< set and used by capi thin layer if mux is available */
+	void *priv;                     /**< set and used by user optionally */
+};
+
+/**
+ * @name SPI modes
+ * @{
+ */
+
+/** The CPHA bit selects the clock phase. */
+#define CAPI_SPI_CPHA 0x01
+
+/** The CPOL bit sets the polarity of the clock signal during the idle state. */
+#define CAPI_SPI_CPOL 0x02
+
+/**
+ * @enum capi_spi_mode
+ * @brief SPI communication modes defining clock polarity and phase.
+ */
+enum capi_spi_mode {
+	/** Data sampled on rising edge and shifted out on the falling edge. */
+	CAPI_SPI_MODE_0 = (0 | 0),
+	/** Data sampled on the falling edge and shifted out on the rising edge. */
+	CAPI_SPI_MODE_1 = (0 | CAPI_SPI_CPHA),
+	/** Data sampled on the falling edge and shifted out on the rising edge. */
+	CAPI_SPI_MODE_2 = (CAPI_SPI_CPOL | 0),
+	/** Data sampled on the rising edge and shifted out on the falling edge. */
+	CAPI_SPI_MODE_3 = (CAPI_SPI_CPOL | CAPI_SPI_CPHA)
+};
+
+/** @} */
+
+/**
+ * @brief SPI polarity of RDY/MISO line for flow control
+ */
+enum capi_spi_rdy_pol {
+	CAPI_SPI_RDY_POL_HIGH,
+	CAPI_SPI_RDY_POL_LOW,
+};
+
+/**
+ * @brief SPI flow control mode
+ */
+enum capi_spi_flow_ctl {
+	CAPI_SPI_FLOW_CTL_DISABLE, /**< No flow control */
+	CAPI_SPI_FLOW_CTL_TIMER, /**< Timer based flow control. Time unit is number of clock cycles.
+				  * If read burst size is less than transfer count, initiator enters
+				  * wait state after transferring burst size of bytes.
+				  */
+	CAPI_SPI_FLOW_CTL_RDY,   /** Ready pin based flow control
+				  * In this mode, the initiator waits for an active level on the RDYIN
+				  * pin.   Once it detects the transition, it transfers burts size of
+				  * bytes   and then goes back to wait state until another active
+				  * level   is detected. */
+	CAPI_SPI_FLOW_CTL_MISO,  /** In this mode, the initiator waits for an active level on the
+				  * MISO pin.  Once it detects the transition, it transfers burts
+				  * size  of bytes  and then goes back to wait state until another
+				  * active  level is detected. */
+};
+
+/**
+ * @brief Flow control configuration for data reads
+ */
+struct capi_spi_flow_ctl_params {
+	enum capi_spi_flow_ctl mode; /**< Flow coontrol mode */
+	uint16_t burts_size;         /**< if non-zero, specifies the limit of number of bytes to be
+				      * transferred at once.
+				      * See flow control mode descriptions for further information. */
+	enum capi_spi_rdy_pol
+	rdy_pol;   /**< Polarity of the Readt Pin, used when ready pin based flow ctrl */
+	uint16_t wait_tmr; /**< number of clock cycles to wait, used when timer based flow ctrl.
+			    * See flow control mode descriptions for further information */
+};
+
+/**
+ * @brief SPI target-device configuration/descriptor
+ */
+struct capi_spi_device {
+	/** SPI controller this device is connected to. */
+	struct capi_spi_controller_handle *controller;
+	/** Maximum transfer speed supported by the device. */
+	uint32_t max_speed_hz;
+	/** SPI mode (e.g., phase, polarity). */
+	enum capi_spi_mode mode;
+	/** Native chip-selects bitmask (multiple CSs selection is allowed). */
+	uint16_t native_cs;
+	/** GPIO chip-selects descriptors (multiple GPIO CSs are allowed).
+	 *  user shall include "capi_gpio.h" to reach gpio api */
+	struct capi_gpio_pin *cs_gpio;
+	/** Number of GPIO chip-selects. */
+	uint8_t cs_gpio_num;
+	/** flow control parameters */
+	struct capi_spi_flow_ctl_params flow_ctl_param;
+	/** sets byte based CS assert/de-assert transaction */
+	bool non_continuous_mode;
+	/** LSB First Transfer; true: LSB first, false: MSB first */
+	bool lsb_first;
+	/** Optional platform specific extra configuration */
+	void *extra;
+};
+
+/**
+ * @brief CS control
+ */
+enum capi_spi_cs_control {
+	CAPI_SPI_CS_AUTO,            /**< default setting for supported HW */
+	CAPI_SPI_CS_MANUAL_ASSERT,   /**< User controlled CS assert state */
+	CAPI_SPI_CS_MANUAL_DEASSERT, /**< User controlled CS de-assert state */
+};
+
+/**
+ * @brief  SPI transfer
+ */
+struct capi_spi_transfer {
+	const uint8_t
+	*tx_buf; /**< transmit buffer, if NULL zeroes will be transmitted */
+	uint8_t *rx_buf;       /**< receive buffer, if NULL rx bytes will be discarded */
+	uint16_t tx_size;      /**< tx size */
+	uint16_t rx_size;      /**< rx size, rx size can be different from tx
+				*   for read command operations */
+	int timeout;           /**< if supported, timeout in milliseconds. 0 or -1 means infinite */
+	uint8_t xfer_delay_clk_cycles; /**< Transfer Delay time in clock cycles */
+};
+
+/** @brief spi async events */
+enum capi_async_event {
+	CAPI_SPI_EVENT_XFR_DONE = 1,      /**< transfer complete */
+	CAPI_SPI_EVENT_XFR_TIMEOUT,       /**< Transfer timeout */
+	CAPI_SPI_EVENT_TX_IRQ,            /**< required number of bytes transmitted
+					   * see capi_spi_set_transfer_irq_trig_level()
+					   */
+	CAPI_SPI_EVENT_TX_FIFO_UNDERFLOW, /**< Tx FIFO underflow event */
+	CAPI_SPI_EVENT_RX_FIFO_OVERFLOW,  /**< Rx FIFO overflow event */
+	CAPI_SPI_EVENT_ERROR,             /**< Generic error event,
+					   * details may be provided by driver in extra
+					   */
+	CAPI_SPI_EVENT_TX_COLLISION,      /**< There has been a HW Error: TX Collision */
+	CAPI_SPI_EVENT_OTHER              /**< Other events,
+					   * details may be provided by driver in extra
+					   */
+};
+
+/**
+ * @brief  SPI Driver Call Back type
+ * @param[in] event SPI event type
+ * @param[in] arg Pointer to user specific data.
+ * @param[in] event_extra optional, platform/driver specific extra information for event
+ */
+typedef void (*capi_spi_callback_t)(enum capi_async_event event, void *arg,
+				    int event_extra);
+
+/**
+ * @brief Initialize an instance of the SPI controller.
+ *
+ * @param [in out] handle Points to a pointer of the context structure. If this
+ *                 pointer is set to NULL, then the controller will allocate
+ *	               the context structure and be the owner. If the pointer
+ *	               is not NULL, the application has allocated the structure and is
+ *	               the owner.
+ * @param [in] config Points to the configuration for the SPI controller.
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_spi_init(struct capi_spi_controller_handle **handle,
+		  const struct capi_spi_config *config);
+
+/**
+ * @brief Deinitialize the SPI controller, disable, and bring to default settings.
+ *
+ * @param [in] handle Points to the SPI controller context.
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_spi_deinit(struct capi_spi_controller_handle *handle);
+
+/**
+ * @brief Sync/Blocking transceive function.
+ *
+ * @param [in] device Points to the SPI target-device configuration/descriptor
+ * @param [in] transfer Points to the SPI transfer
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_spi_transceive(struct capi_spi_device *device,
+			struct capi_spi_transfer *transfer);
+
+/**
+ * @brief Async/Non-Blocking transceive function.
+ *
+ * @param [in] device Points to the SPI target-device configuration/descriptor
+ * @param [in] transfer Points to the SPI transfer
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_spi_transceive_async(struct capi_spi_device *device,
+			      struct capi_spi_transfer *transfer);
+
+/**
+ * @brief Sync/Blocking read command style transceive function.
+ * Although the SPI transfers are usually full-duplex, in many cases, the target works on a protocol
+ * which has a “Command + Address + Read/Write-data” sequence. The write command is always
+ * unidirectional. However, the read command needs a Tx transfer followed by an Rx transfer in a
+ * single CS frame.
+ *
+ * Example-1: Tx 2 bytes (instruction, address) Rx 1 byte
+ *            MOSI ____<instruction><  address  >______________
+ *            MISO ______________________________<  data_byte  >
+ *
+ * Example-2: Write-only, Tx 3 bytes (instruction, address, data), Rx size 0
+ *            MOSI ____<instruction><  address  ><  data_byte  >
+ *            MISO ____________________________________________
+ *
+ * @param [in] device Points to the SPI target-device configuration/descriptor
+ * @param [in] transfer Points to the SPI transfer
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_spi_read_command(struct capi_spi_device *device,
+			  struct capi_spi_transfer *transfer);
+
+/**
+ * @brief Async/Non-Blocking read command style transceive function.
+ * See blocking version of this function for description
+ *
+ * @param [in] device Points to the SPI target-device configuration/descriptor
+ * @param [in] transfer Points to the SPI transfer
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_spi_read_command_async(struct capi_spi_device *device,
+				struct capi_spi_transfer *transfer);
+
+/**
+ * @brief Abort recent async transfer operation
+ *
+ * @param [in] device Points to the SPI target-device configuration/descriptor
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_spi_abort_async(struct capi_spi_device *device);
+
+/**
+ * @brief Register callback to get async events
+ *
+ * @param [in] handle Points to the SPI controller context.
+ * @param [in] callback User callback function
+ * @param [in] callback_arg User callback arg
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_spi_register_callback(struct capi_spi_controller_handle *handle,
+			       capi_spi_callback_t const callback, void *callback_arg);
+
+/**
+ * @brief Set chip select mode/state.
+ *
+ * @param [in] device Points to the SPI target-device configuration/descriptor
+ * @param [in] cs_control chip select mode/level
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_spi_set_cs(struct capi_spi_device *device,
+		    enum capi_spi_cs_control cs_control);
+
+/**
+ * @brief SPI Driver Interrupt handler. If interrupt vectors are managed and implemented by user,
+ * then user shall call this function in the relevant interrupt vector function.
+ *
+ * @param [in] handle Points to the SPI controller context
+ */
+void capi_spi_isr(struct capi_spi_controller_handle *handle);
+
+/**
+ * @brief Structure holding SPI function pointers that point to the platform
+ * specific function. See API functions for relevant descriptions.
+ */
+struct capi_spi_ops {
+	/** See capi_spi_init() */
+	int (*init)(struct capi_spi_controller_handle **handle,
+		    const struct capi_spi_config *config);
+	/** See capi_spi_deinit() */
+	int (*deinit)(struct capi_spi_controller_handle *handle);
+	/** See capi_spi_transceive() */
+	int (*transceive)(struct capi_spi_device *device,
+			  struct capi_spi_transfer *transfer);
+	/** See capi_spi_transceive_async() */
+	int (*transceive_async)(struct capi_spi_device *device,
+				struct capi_spi_transfer *transfer,
+				int timeout);
+	/** See capi_spi_read_command() */
+	int (*read_command)(struct capi_spi_device *device,
+			    struct capi_spi_transfer *transfer);
+	/** See capi_spi_read_command_async() */
+	int (*read_command_async)(struct capi_spi_device *device,
+				  struct capi_spi_transfer *transfer);
+	/** See capi_spi_abort_async() */
+	int (*abort_async)(struct capi_spi_device *device);
+	/** See capi_spi_register_callback() */
+	int (*register_callback)(struct capi_spi_controller_handle *handle,
+				 capi_spi_callback_t const callback, void *callback_arg);
+	/** See capi_spi_set_cs() */
+	int (*set_cs)(struct capi_spi_device *device, enum capi_spi_cs_control cs);
+	/** See capi_spi_isr() */
+	void (*isr)(void *handle);
+};
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/capi/inc/capi_time.h
+++ b/capi/inc/capi_time.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Common API time and delay services
+ *
+ * Singleton system services for blocking delays and monotonic uptime. There is
+ * no device instance to manage, so (like capi_alloc / capi_log) these are plain
+ * functions that forward to a weak *_impl symbol. The platform provides a strong
+ * implementation at link time; the weak defaults keep the API linkable on
+ * platforms that have not yet wired up a time source.
+ */
+
+#ifndef _CAPI_TIME_H_
+#define _CAPI_TIME_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * @brief Busy-wait for at least the given number of microseconds.
+ *
+ * Blocks the calling CPU in a tight loop. Intended for short, precise delays
+ * (e.g. device timing requirements) where giving up the CPU is undesirable or
+ * the requested delay is shorter than one scheduler/SysTick period. For longer,
+ * coarse delays prefer capi_wait_ms(), which may yield.
+ *
+ * @param [in] us Minimum number of microseconds to wait.
+ */
+void capi_wait_us(uint32_t us);
+
+/**
+ * @brief Delay for at least the given number of milliseconds.
+ *
+ * Coarse delay. On an RTOS this may sleep the calling thread and yield the CPU
+ * to other work; on bare metal it typically falls back to a tick-based busy
+ * wait. Use capi_wait_us() when you need sub-millisecond precision or must not
+ * yield.
+ *
+ * @param [in] ms Minimum number of milliseconds to wait.
+ */
+void capi_wait_ms(uint32_t ms);
+
+/**
+ * @brief Get the monotonic time elapsed since boot, in microseconds.
+ *
+ * The returned value increases monotonically and is intended for measuring
+ * elapsed time by subtracting two readings. It is not wall-clock time.
+ *
+ * @param [out] us Receives the microseconds since boot. Must not be NULL.
+ *
+ * @return 0 on success, -EINVAL if @p us is NULL, -ENOSYS if the platform
+ *         provides no time source.
+ */
+int capi_uptime(uint64_t *us);
+
+/*
+ * Weak hook symbols overridden by the platform/app (don't call directly).
+ *
+ * A platform that implements only capi_wait_us_impl() gets a working
+ * capi_wait_ms() for free: the default capi_wait_ms_impl() delegates to it.
+ */
+void capi_wait_us_impl(uint32_t us);
+void capi_wait_ms_impl(uint32_t ms);
+int capi_uptime_impl(uint64_t *us);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* _CAPI_TIME_H_ */

--- a/capi/inc/capi_timer.h
+++ b/capi/inc/capi_timer.h
@@ -1,0 +1,529 @@
+/*
+ * Copyright (c) 2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Common API TIMER
+ */
+
+#ifndef _CAPI_TIMER_H_
+#define _CAPI_TIMER_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * @brief TIMER counter direction
+ */
+enum capi_timer_counter_direction {
+	/** Timer counts up from min to max. */
+	CAPI_TIMER_COUNT_UP,
+	/** Timer counts down from max to min. */
+	CAPI_TIMER_COUNT_DOWN,
+	/** Can be used as a starting point to augment implementation specific directions */
+	CAPI_TIMER_COUNTER_DIRECTION_LIMIT
+};
+
+/**
+ * @brief TIMER counter configuration
+ * @note Structure used to pass counter configuration parameters to Driver
+ */
+struct capi_timer_counter_config {
+	/** Counter direction: up, down. See: enum capi_timer_counter_direction */
+	uint32_t direction;
+	/** Minimum value for the counter. */
+	uint32_t min;
+	/** Maximum value for the counter. */
+	uint32_t max;
+	/** If true, rollover to min after reaching max (or to max after reaching min if counting
+	 * down). */
+	bool rollover;
+	/** Optional platform specific extra configuration. */
+	const void *extra;
+};
+
+/**
+ * @brief TIMER channel operation modes
+ */
+enum capi_timer_channel_mode {
+	CAPI_TIMER_COMPARE_MODE,
+	CAPI_TIMER_CAPTURE_MODE,
+	CAPI_TIMER_PWM_MODE,
+	/** Can be used as a starting point to augment implementation specific modes */
+	CAPI_TIMER_CHANNEL_MODE_LIMIT
+};
+
+/**
+ * @brief TIMER output compare polarity on match
+ */
+enum capi_timer_on_compare_polarity {
+	/** On match, keep the output compare as is. */
+	CAPI_TIMER_ON_COMPARE_KEEP,
+	/** On match, set the output compare pin as active. */
+	CAPI_TIMER_ON_COMPARE_ACTIVE,
+	/** On match, set the output compare pin as inactive. */
+	CAPI_TIMER_ON_COMPARE_INACTIVE,
+	/** On match, toggle the output compare pin. */
+	CAPI_TIMER_ON_COMPARE_TOGGLE,
+	/** On match, generate a 1-cycle pulse. */
+	CAPI_TIMER_ON_COMPARE_PULSE,
+	/** Can be used as a starting point to augment implementation specific polarities */
+	CAPI_TIMER_ON_COMPARE_POLARITY_LIMIT
+};
+
+/**
+ * @brief Compare channel mode parameters
+ * @note Structure used to pass compare mode parameters to Driver
+ */
+struct capi_timer_compare_config {
+	/** If true, generates a platform specific pulse (duration, polarity, etc.) on output
+	 * compare match using the output port defined by output_identifier. */
+	bool generate_pulse_on_match;
+	/** Platform specific output compare port or pin identifier used for pulse generation. */
+	uint64_t output_identifier;
+	/** Output compare polarity on match. See: enum capi_timer_on_compare_polarity */
+	uint32_t polarity;
+	/** Stop timer in case of a match in this channel */
+	bool stop_enabled;
+	/** Match value for the compare channel */
+	uint32_t match_value;
+	/** Optional platform specific extra configuration. */
+	const void *extra;
+};
+
+/**
+ * @brief TIMER input capture edge sensitivity
+ */
+enum capi_timer_capture_edge {
+	/** Capture on both rising and falling edges of the input capture pin. */
+	CAPI_TIMER_CAPTURE_BOTH,
+	/** Capture only the rising edge of the input capture pin. */
+	CAPI_TIMER_CAPTURE_RISING,
+	/** Capture only the falling edge of the input capture pin. */
+	CAPI_TIMER_CAPTURE_FALLING,
+	/** Can be used as a starting point to augment implementation specific edges */
+	CAPI_TIMER_CAPTURE_EDGE_LIMIT
+};
+
+/**
+ * @brief Capture channel mode parameters
+ * @note Structure used to pass capture mode parameters to Driver
+ */
+struct capi_timer_capture_config {
+	/** Platform specific input capture port or pin identifier used to trigger capture. */
+	uint64_t input_identifier;
+	/** Specify which input capture pin edge to capture on. See: enum capi_timer_capture_edge */
+	uint8_t edge;
+	/** Optional platform specific extra configuration. */
+	const void *extra;
+};
+
+/**
+ * @brief PWM mode parameters
+ * @note Structure used to pass PWM(Pulse-Width modulation) mode parameters to Driver
+ */
+struct capi_timer_pwm_config {
+	/** Platform specific PWM output port or pin identifier used to generate PWM output. */
+	uint64_t output_identifier;
+	/** PWM Polarity, normal or inverted. */
+	bool inverted_polarity;
+	/** Period of the PWM signal in nanoseconds. */
+	uint64_t period_ns;
+	/** Pulse (active part of the period) duration in nanoseconds, always smaller than
+	 * period_ns. */
+	uint64_t active_ns;
+	/** Offset of the active part of the period from the period start. */
+	uint64_t offset_ns;
+	/** Optional platform specific extra configuration. */
+	const void *extra;
+};
+
+/**
+ * @brief TIMER channel configuration
+ */
+struct capi_timer_channel_config {
+	/** The timer channel mode. See: enum capi_timer_channel_mode */
+	uint32_t mode;
+	union {
+		struct capi_timer_compare_config compare;
+		struct capi_timer_capture_config capture;
+		struct capi_timer_pwm_config pwm;
+	} config;
+	const void *extra; /**< Optional platform specific extra configuration. */
+};
+
+/**
+ * @brief TIMER configuration
+ */
+struct capi_timer_config {
+	/** platform ops - optional. if NULL, API selects driver from static mapping based on
+	 * identifier. */
+	const struct capi_timer_ops *ops;
+	/** Platform specific identifier of device instance (base address, index, etc.). */
+	uint64_t identifier;
+	/** Platform specific identifier for the input clock source (e.g., address, index, etc.). */
+	uint64_t input_clock_identifier;
+	/** Input source frequency in Hz. */
+	uint64_t input_clock_hz;
+	/** Desired operation frequency in Hz, implementation will try to find optimal prescaler
+	 * values to obtain it. */
+	uint64_t output_freq_hz;
+	/** Optional platform specific extra configuration. */
+	const void *extra;
+};
+
+/**
+ * @brief TIMER handle type
+ */
+struct capi_timer_handle {
+	const struct capi_timer_ops
+		*ops; /**< Function pointers that implement the Timer CAPI */
+	bool init_allocated;              /**< If true, the driver is owner of handle memory. */
+	void *priv;                       /**< Pointer to driver-specific handle extension. */
+};
+
+/** @brief TIMER global (non-channel) events */
+enum capi_timer_global_event {
+	/** Timer counter overflowed event (TIMER event, not a TIMER channel event). */
+	CAPI_TIMER_GLOBAL_EVENT_COUNTER_OVERFLOW,
+	/** Can be used as a starting point to augment implementation specific event types */
+	CAPI_TIMER_GLOBAL_EVENT_LIMIT
+};
+
+/** @brief TIMER channel events */
+enum capi_timer_channel_event {
+	/** Compare match event. */
+	CAPI_TIMER_CHANNEL_EVENT_COMPARE,
+	/** Input capture event. */
+	CAPI_TIMER_CHANNEL_EVENT_CAPTURE,
+	/** Can be used as a starting point to augment implementation specific event types */
+	CAPI_TIMER_CHANNEL_EVENT_LIMIT
+};
+
+/**
+ * @brief TIMER event callback type (non-channel/global)
+ * @param[in] event TIMER async event type. See: enum capi_timer_global_event
+ * @param[in] arg Pointer to user specific data.
+ * @param[in] event_extra optional, platform/driver specific extra information for event
+ */
+typedef void (*capi_timer_event_callback)(uint32_t event, void *arg,
+		int event_extra);
+
+/**
+ * @brief TIMER channel callback type
+ * @param[in] event TIMER async event type. See: enum capi_timer_channel_event
+ * @param[in] chan TIMER channel.
+ * @param[in] arg Pointer to user specific data.
+ * @param[in] event_extra optional, platform/driver specific extra information for event
+ */
+typedef void (*capi_timer_channel_callback)(uint32_t event, uint32_t chan,
+		void *arg,
+		int event_extra);
+
+/**
+ * @struct capi_timer_ops
+ * @brief Structure that contains the timer operations function pointers.
+ */
+struct capi_timer_ops {
+	/** See capi_timer_init() */
+	int (*init)(struct capi_timer_handle **handle,
+		    const struct capi_timer_config *config);
+	/** See capi_timer_deinit() */
+	int (*deinit)(struct capi_timer_handle *handle);
+	/** See capi_timer_start() */
+	int (*start)(struct capi_timer_handle *handle);
+	/** See capi_timer_stop() */
+	int (*stop)(struct capi_timer_handle *handle);
+	/** See capi_timer_counter_config() */
+	int (*counter_config)(struct capi_timer_handle *handle,
+			      const struct capi_timer_counter_config *config);
+	/** See capi_timer_counter_get() */
+	int (*counter_get)(struct capi_timer_handle *handle, uint32_t *counter);
+	/** See capi_timer_event_irq_enable() */
+	int (*event_irq_enable)(struct capi_timer_handle *handle, uint32_t event);
+	/** See capi_timer_event_irq_disable() */
+	int (*event_irq_disable)(struct capi_timer_handle *handle, uint32_t event);
+	/** See capi_timer_register_event_callback() */
+	int (*register_event_callback)(struct capi_timer_handle *handle,
+				       capi_timer_event_callback callback, void *callback_arg);
+
+	/** See capi_timer_channel_init() */
+	int (*channel_init)(struct capi_timer_handle *handle, uint32_t chan);
+	/** See capi_timer_channel_deinit() */
+	int (*channel_deinit)(struct capi_timer_handle *handle, uint32_t chan);
+	/** See capi_timer_channel_config() */
+	int (*channel_config)(struct capi_timer_handle *handle, uint32_t chan,
+			      const struct capi_timer_channel_config *ch_config);
+	/** See capi_timer_channel_enable() */
+	int (*channel_enable)(struct capi_timer_handle *handle, uint32_t chan);
+	/** See capi_timer_channel_disable() */
+	int (*channel_disable)(struct capi_timer_handle *handle, uint32_t chan);
+	/** See capi_timer_channel_compare_set() */
+	int (*channel_compare_set)(struct capi_timer_handle *handle, uint32_t chan,
+				   uint32_t compare);
+	/** See capi_timer_channel_compare_get() */
+	int (*channel_compare_get)(struct capi_timer_handle *handle, uint32_t chan,
+				   uint32_t *compare);
+	/** See capi_timer_channel_capture_get() */
+	int (*channel_capture_get)(struct capi_timer_handle *handle, uint32_t chan,
+				   uint32_t *capture);
+	/** See capi_timer_channel_irq_enable() */
+	int (*channel_irq_enable)(struct capi_timer_handle *handle, uint32_t chan,
+				  uint32_t event);
+	/** See capi_timer_channel_irq_disable() */
+	int (*channel_irq_disable)(struct capi_timer_handle *handle, uint32_t chan,
+				   uint32_t event);
+	/** See capi_timer_channel_register_callback() */
+	int (*channel_register_callback)(struct capi_timer_handle *handle,
+					 uint32_t chan,
+					 capi_timer_channel_callback callback, void *callback_arg);
+	/** See capi_timer_is_irq_pending() */
+	int (*is_irq_pending)(struct capi_timer_handle *handle, bool *pending);
+	/** See capi_timer_isr() */
+	void (*isr)(struct capi_timer_handle *handle);
+
+	/** See capi_timer_nsec_to_ticks() */
+	int (*nsec_to_ticks)(const struct capi_timer_handle *handle,
+			     uint64_t duration_ns,
+			     uint32_t *ticks);
+	/** See capi_timer_ticks_to_nsec() */
+	int (*ticks_to_nsec)(const struct capi_timer_handle *handle, uint64_t ticks,
+			     uint32_t *duration_ns);
+};
+
+/**
+ * @brief Timer init function, allocates the handle and configures the timer.
+ * @param[in] handle Double pointer to a timer handle structure. Allocated by implementation when
+ * *handle is NULL.
+ * @param[in] config Pointer to a timer configuration structure.
+ * @return int 0 for success, negative error code otherwise.
+ */
+int capi_timer_init(struct capi_timer_handle **handle,
+		    const struct capi_timer_config *config);
+
+/**
+ * @brief Deallocate resources allocated by capi_timer_init and put the timer in an idle state.
+ * @param[in] handle Pointer to a timer handle structure.
+ * @return int 0 for success, negative error code otherwise.
+ */
+int capi_timer_deinit(struct capi_timer_handle *handle);
+
+/**
+ * @brief Start counting using the timer counter.
+ * @param[in] handle Pointer to a timer handle structure.
+ * @return int 0 for success, negative error code otherwise.
+ */
+int capi_timer_start(struct capi_timer_handle *handle);
+
+/**
+ * @brief Stop the timer counter from counting.
+ * @param[in] handle Pointer to a timer handle structure.
+ * @return int 0 for success, negative error code otherwise.
+ */
+int capi_timer_stop(struct capi_timer_handle *handle);
+
+/**
+ * @brief Configure the timer counter.
+ * @param[in] handle Pointer to a timer handle structure.
+ * @param[in] config Pointer to the counter configuration structure.
+ * @return int 0 for success, negative error code otherwise.
+ */
+int capi_timer_counter_config(struct capi_timer_handle *handle,
+			      const struct capi_timer_counter_config *config);
+
+/**
+ * @brief Get the timer counter value.
+ * @param[in] handle Pointer to a timer handle structure.
+ * @param[out] counter The value the counter is at.
+ * @return int 0 for success, negative error code otherwise.
+ */
+int capi_timer_counter_get(struct capi_timer_handle *handle, uint32_t *counter);
+
+/**
+ * @brief Enable interrupt for TIMER event (non-channel) specific events.
+ * @param[in] handle Pointer to a timer handle structure.
+ * @param[in] event The event identifier.
+ * @return int 0 for success, negative error code otherwise.
+ */
+int capi_timer_event_irq_enable(struct capi_timer_handle *handle,
+				uint32_t event);
+
+/**
+ * @brief Disable interrupt for TIMER event (non-channel) specific events.
+ * @param[in] handle Pointer to a timer handle structure.
+ * @param[in] event The event identifier.
+ * @return int 0 for success, negative error code otherwise.
+ */
+int capi_timer_event_irq_disable(struct capi_timer_handle *handle,
+				 uint32_t event);
+
+/**
+ * @brief Register a user provided callback for TIMER event (non-channel) specific events.
+ * @param[in] handle Pointer to a timer handle structure.
+ * @param[in] callback Callback function pointer.
+ * @param[in] callback_arg Arguments that the interrupt passes to the callback function.
+ * @return int 0 for success, negative error code otherwise.
+ */
+int capi_timer_register_event_callback(struct capi_timer_handle *handle,
+				       capi_timer_event_callback callback, void *callback_arg);
+
+/**
+ * @brief Initialize a timer channel by allocating the resources required for it.
+ * @param[in] handle Pointer to a timer handle structure.
+ * @param[in] chan The channel number.
+ * @return int 0 for success, negative error code otherwise.
+ */
+int capi_timer_channel_init(struct capi_timer_handle *handle, uint32_t chan);
+
+/**
+ * @brief Deinitialize a timer channel by deallocating the resources it required and by putting the
+ * channel in an idle state.
+ * @param[in] handle Pointer to a timer handle structure.
+ * @param[in] chan The channel number.
+ * @return int 0 for success, negative error code otherwise.
+ */
+int capi_timer_channel_deinit(struct capi_timer_handle *handle, uint32_t chan);
+
+/**
+ * @brief Configure the timer channel without allocating/deallocating resources.
+ * @param[in] handle Pointer to a timer handle structure.
+ * @param[in] chan The channel number.
+ * @param[in] ch_config Pointer to the channel configuration structure (void *, because there are
+ * multiple channel types).
+ * @return int 0 for success, negative error code otherwise.
+ */
+int capi_timer_channel_config(struct capi_timer_handle *handle, uint32_t chan,
+			      const struct capi_timer_channel_config *ch_config);
+
+/**
+ * @brief Enable the specified channel.
+ * @param[in] handle Pointer to a timer handle structure.
+ * @param[in] chan The channel number.
+ * @return int 0 for success, negative error code otherwise.
+ */
+int capi_timer_channel_enable(struct capi_timer_handle *handle, uint32_t chan);
+
+/**
+ * @brief Disable the specified channel.
+ * @param[in] handle Pointer to a timer handle structure.
+ * @param[in] chan The channel number.
+ * @return int 0 for success, negative error code otherwise.
+ */
+int capi_timer_channel_disable(struct capi_timer_handle *handle, uint32_t chan);
+
+/**
+ * @brief Set the compare value for an output compare channel.
+ * @param[in] handle Pointer to a timer handle structure.
+ * @param[in] chan The channel number.
+ * @param[in] compare The compare value.
+ * @return int 0 for success, negative error code otherwise.
+ */
+int capi_timer_channel_compare_set(struct capi_timer_handle *handle,
+				   uint32_t chan,
+				   uint32_t compare);
+
+/**
+ * @brief Get the compare value for an output compare channel.
+ * @param[in] handle Pointer to a timer handle structure.
+ * @param[in] chan The channel number.
+ * @param[out] compare The compare value.
+ * @return int 0 for success, negative error code otherwise.
+ */
+int capi_timer_channel_compare_get(struct capi_timer_handle *handle,
+				   uint32_t chan,
+				   uint32_t *compare);
+/**
+ * @brief Get the capture value of an input capture channel.
+ * @param[in] handle Pointer to a timer handle structure.
+ * @param[in] chan The channel number.
+ * @param[out] capture The input capture value.
+ * @return int 0 for success, negative error code otherwise.
+ */
+int capi_timer_channel_capture_get(struct capi_timer_handle *handle,
+				   uint32_t chan,
+				   uint32_t *capture);
+
+/**
+ * @brief Enable interrupt when the specified event occurs on the specified channel.
+ * @param[in] handle Pointer to a timer handle structure.
+ * @param[in] chan The channel number.
+ * @param[in] event The event identifier.
+ * @return int 0 for success, negative error code otherwise.
+ */
+int capi_timer_channel_irq_enable(struct capi_timer_handle *handle,
+				  uint32_t chan, uint32_t event);
+
+/**
+ * @brief Disable interrupt for the specified event on the specified channel.
+ * @param[in] handle Pointer to a timer handle structure.
+ * @param[in] chan The channel number.
+ * @param[in] event The event identifier.
+ * @return int 0 for success, negative error code otherwise.
+ */
+int capi_timer_channel_irq_disable(struct capi_timer_handle *handle,
+				   uint32_t chan, uint32_t event);
+
+/**
+ * @brief Register a user provided callback on TIMER channel specific events.
+ * @param[in] handle Pointer to a timer handle structure.
+ * @param[in] chan The channel number.
+ * @param[in] callback Callback function pointer.
+ * @param[in] callback_arg Arguments that the interrupt passes to the callback function.
+ * @return int 0 for success, negative error code otherwise.
+ */
+int capi_timer_channel_register_callback(struct capi_timer_handle *handle,
+		uint32_t chan,
+		capi_timer_channel_callback callback, void *callback_arg);
+
+/**
+ * @brief Check if the specified timer has any pending interrupts.
+ * @param[in] handle Pointer to a timer handle structure.
+ * @param[out] pending Boolean indicating if there are any pending interrupts.
+ * @return int 0 for success, negative error code otherwise.
+ */
+int capi_timer_is_irq_pending(struct capi_timer_handle *handle, bool *pending);
+
+/**
+ * @brief Convert nanoseconds to timer ticks (convenience function).
+ * @param[in] handle Pointer to a timer handle structure.
+ * @param[in] duration_ns Duration in nanoseconds.
+ * @param[out] ticks Timer tick count for given duration_ns.
+ * @return int 0 for success, negative error code otherwise.
+ */
+int capi_timer_nsec_to_ticks(const struct capi_timer_handle *handle,
+			     uint64_t duration_ns,
+			     uint32_t *ticks);
+
+/**
+ * @brief Convert timer ticks to nanoseconds (convenience function).
+ * @param[in] handle Pointer to a timer handle structure.
+ * @param[in] ticks Timer tick count.
+ * @param[out] duration_ns Duration in nanoseconds for given ticks.
+ * @return int 0 for success, negative error code otherwise.
+ */
+int capi_timer_ticks_to_nsec(const struct capi_timer_handle *handle,
+			     uint64_t ticks,
+			     uint32_t *duration_ns);
+
+/**
+ * @brief Timer interrupt service routine (ISR)
+ *
+ * This function should be called from the actual hardware interrupt handler.
+ * It handles timer events and calls registered callbacks as needed.
+ *
+ * @param [in] handle Timer controller handle
+ */
+void capi_timer_isr(struct capi_timer_handle *handle);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/capi/inc/capi_uart.h
+++ b/capi/inc/capi_uart.h
@@ -1,0 +1,598 @@
+/*
+ * Copyright (c) 2024-2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Common HAL UART API
+ */
+
+#ifndef _CAPI_UART_H_
+#define _CAPI_UART_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+/** Forward Declarations */
+
+/**
+ * @brief forward declaration of common hal DMA controller handle
+ */
+struct capi_dma_handle;
+
+/**
+ * @brief uart line status flags
+ */
+enum capi_uart_line_status_flags {
+	CAPI_UART_LINE_STAT_BREAK_IND = 1U,     /**< Break indicator (data line was held low for
+						 * longer than a full character transmission time) */
+	CAPI_UART_LINE_STAT_FRAMING_ERROR = 2U, /**< Framing error (invalid stop bit is found) */
+	CAPI_UART_LINE_STAT_PARITY_ERROR = 4U,  /**< Parity error */
+	CAPI_UART_LINE_STAT_OVERRUN_ERROR = 8U, /**< The receive buffer was full, and a new byte
+						 * arrived before the previous one was read */
+};
+
+/**
+ * @brief uart interrupt reasons
+ */
+enum capi_uart_interrupt_reason {
+	CAPI_UART_INTR_MODEM_STATUS,    /**< Modem status interrupt */
+	CAPI_UART_INTR_TX_BUFFER_EMPTY, /**< Transmit buffer empty interrupt */
+	CAPI_UART_INTR_RX_BUFFER_FULL,  /**< Receive buffer full interrupt */
+	CAPI_UART_INTR_RX_LINE_STATUS,  /**< Receive line status interrupt,
+					 * Details can be get by calling capi_uart_get_line_status()
+					 */
+	CAPI_UART_INTR_RX_TIMEOUT,      /**< Receive timeout interrupt */
+	CAPI_UART_INTR_NONE,            /**< No interrupt reason */
+};
+
+/**
+ * @brief uart async events
+ */
+enum capi_uart_async_event {
+	CAPI_UART_EVENT_TX_DONE,    /**< Transfer completed */
+	CAPI_UART_EVENT_TX_ABORTED, /**< Transfer aborted */
+	CAPI_UART_EVENT_RX_DONE,    /**< Rx completed */
+	CAPI_UART_EVENT_RX_TIMEOUT, /**< Rx timeout */
+	CAPI_UART_EVENT_INTERRUPT,  /**< UART interrupt,
+				     * reason can be get by calling capi_uart_get_interrupt_reason()
+				     */
+};
+
+/**
+ * @brief number of data bits
+ */
+enum capi_uart_data_bits {
+	CAPI_UART_DATA_BITS_8, /**< 8 data bits */
+	CAPI_UART_DATA_BITS_7, /**< 7 data bits */
+	CAPI_UART_DATA_BITS_6, /**< 6 data bits */
+	CAPI_UART_DATA_BITS_5, /**< 5 data bits */
+};
+
+/**
+ * @brief uart parity options
+ */
+enum capi_uart_parity {
+	CAPI_UART_PARITY_NONE,  /**< no parity */
+	CAPI_UART_PARITY_MARK,  /**< mark parity */
+	CAPI_UART_PARITY_SPACE, /**< space parity */
+	CAPI_UART_PARITY_ODD,   /**< odd parity */
+	CAPI_UART_PARITY_EVEN   /**< even parity */
+};
+
+/**
+ * @brief uart number of stop bits options
+ */
+enum capi_uart_stop_bits {
+	CAPI_UART_STOP_1_BIT, /**< one stop bit */
+	CAPI_UART_STOP_2_BIT  /**< two stop bits */
+};
+
+/**
+ * @brief uart flow control options
+ */
+enum capi_uart_flow_control {
+	CAPI_UART_FLOW_CONTROL_NONE,  /**< no flow control */
+	CAPI_UART_FLOW_CONTROL_RTS,   /**< RTS flow control */
+	CAPI_UART_FLOW_CONTROL_CTS,   /**< CTS flow control */
+	CAPI_UART_FLOW_CONTROL_RTSCTS /**< RTS/CTS flow control */
+};
+
+/**
+ * @brief uart address mode for multi-drop communication
+ */
+enum capi_uart_address_mode {
+	CAPI_UART_ADDRESS_MODE_DISABLED, /**< normal 8-bit mode */
+	CAPI_UART_ADDRESS_MODE_9BIT,     /**< 9-bit address mode */
+	CAPI_UART_ADDRESS_MODE_MULTIDROP /**< multi-drop mode with address detection */
+};
+
+/**
+ * @brief UART line configuration
+ */
+struct capi_uart_line_config {
+	/** UART baudrate in bps. Valid range: 300 - 4000000 */
+	uint32_t baudrate;
+	/** UART number of data bits. */
+	enum capi_uart_data_bits size;
+	/** UART parity */
+	enum capi_uart_parity parity;
+	/** UART number of stop bits */
+	enum capi_uart_stop_bits stop_bits;
+	/** Flow control configuration */
+	enum capi_uart_flow_control flow_control;
+	/** Address mode for multi-drop communication */
+	enum capi_uart_address_mode address_mode;
+	/** Device address for multi-drop mode (0-255) */
+	uint8_t device_address;
+	/** Sticky parity enable/disable */
+	bool sticky_parity;
+	/** Loopback mode enable/disable */
+	bool loopback;
+};
+
+/**
+ * @brief UART controller configuration
+ */
+struct capi_uart_config {
+	/** UART controller identifier:
+	 * - Base address for internal controllers.
+	 * - Device address on uart bus for external controllers
+	 *   (e.g.,  UART Mux, UART to I2C Bridge).
+	 */
+	uint32_t identifier;
+	/** optional - user shall pass common hal dma handle to enable dma for async transfers */
+	struct capi_dma_handle *dma_handle;
+	/** Frequency of peripheral clock in Hz, if zero, driver sets to default of platform */
+	uint32_t clk_freq_hz;
+	/** Pointer to UART line configuration. If NULL, HW defaults will be active */
+	struct capi_uart_line_config *line_config;
+	/** Optional platform specific extra configuration. */
+	void *extra;
+	/** Platform specific implementation of the API. (Mandatory field, but can be NULL and we'll
+	 * make sure it gets auto populated when using our build system.) */
+	const struct capi_uart_ops *ops;
+};
+
+/**
+ * @brief UART handle type
+ */
+struct capi_uart_handle {
+	const struct capi_uart_ops *ops; /**< set and used by capi thin layer */
+	bool init_allocated;             /**< If true, the driver is owner of handle memory. */
+	void *lock; /**< set and used by capi thin layer if locking is available */
+	void *priv; /**< set and used by user optionally */
+};
+
+/**
+ * @brief  UART Driver Call Back type
+ * @param[in] event UART async event type
+ * @param[in] arg Pointer to user specific data.
+ * @param[in] event_extra optional, platform/driver specific extra information for event
+ */
+typedef void (*capi_uart_callback)(enum capi_uart_async_event event, void *arg,
+				   int event_extra);
+
+/**
+ * @brief Initialize an instance of the UART controller.
+ *
+ * @param [in out] handle Points to a pointer of the context structure. If this
+ *                 pointer is set to NULL, then the controller will allocate
+ *	               the context structure and be the owner. If the pointer
+ *	               is not NULL, the application has allocated the structure and is
+ *	               the owner.
+ * @param [in] config Points to the configuration for the UART controller.
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_uart_init(struct capi_uart_handle **handle,
+		   const struct capi_uart_config *config);
+
+/**
+ * @brief Deinitialize the UART controller, disable, and bring to default settings.
+ *
+ * @param [in] handle Points to the UART controller context.
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_uart_deinit(struct capi_uart_handle *handle);
+
+/**
+ * @brief Get line config of UART.
+ * If not set before, this function shall return startup/default config.
+ * User may need to get defaults from HW and change individual settings.
+ *
+ * @param [in] handle Points to the UART controller context.
+ * @param [out] line_config returns the line config.
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_uart_get_line_config(struct capi_uart_handle *handle,
+			      struct capi_uart_line_config *line_config);
+
+/**
+ * @brief Set line config of UART.
+ *
+ * @param [in] handle Points to the UART controller context.
+ * @param [in] line_config Points to the UART line config.
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_uart_set_line_config(struct capi_uart_handle *handle,
+			      struct capi_uart_line_config *line_config);
+
+/* HW fifo related functions */
+
+/**
+ * @brief Enable/Disable HW fifo of UART controller
+ *
+ * @param [in] handle Points to the UART controller context.
+ * @param [in] enable enabled state of UART FIFO
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_uart_enable_fifo(struct capi_uart_handle *handle, bool enable);
+
+/**
+ * @brief Flush Tx fifo of UART controller
+ *
+ * @param [in] handle Points to the UART controller context.
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_uart_flush_tx_fifo(struct capi_uart_handle *handle);
+
+/**
+ * @brief Flush Rx fifo of UART controller
+ *
+ * @param [in] handle Points to the UART controller context.
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_uart_flush_rx_fifo(struct capi_uart_handle *handle);
+
+/**
+ * @brief Get available bytes on Rx fifo of UART controller
+ *
+ * @param [in] handle Points to the UART controller context.
+ * @param [out] count returns number of bytes in UART Rx FIFO
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_uart_get_rx_fifo_count(struct capi_uart_handle *handle,
+				uint16_t *count);
+
+/**
+ * @brief Get available bytes on Tx fifo of UART controller
+ *
+ * @param [in] handle Points to the UART controller context.
+ * @param [out] count returns number of bytes in UART Tx FIFO
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_uart_get_tx_fifo_count(struct capi_uart_handle *handle,
+				uint16_t *count);
+
+/**
+ * @brief Sync/Blocking transmit function.
+ *
+ * @param [in] handle Points to the UART controller context.
+ * @param [in] buf Points to the user buffer holding data
+ * @param [in] len number of bytes to be transmitted
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_uart_transmit(struct capi_uart_handle *handle, uint8_t *buf,
+		       uint32_t len);
+
+/**
+ * @brief Sync/Blocking receive function.
+ *
+ * @param [in] handle Points to the UART controller context.
+ * @param [out] buf Points to the user buffer for incoming data
+ * @param [in] len number of bytes to be received
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_uart_receive(struct capi_uart_handle *handle, uint8_t *buf,
+		      uint32_t len);
+
+/**
+ * @brief Register callback to get async events
+ *
+ * @param [in] handle Points to the UART controller context.
+ * @param [in] callback User callback function
+ * @param [in] callback_arg User callback arg
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_uart_register_callback(struct capi_uart_handle *handle,
+				capi_uart_callback const callback,
+				void *const callback_arg);
+
+/**
+ * @brief Async/Non-Blocking transmit function.
+ *
+ * @param [in] handle Points to the UART controller context.
+ * @param [in] buf Points to the user buffer holding data
+ * @param [in] len number of bytes to be transmitted
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_uart_transmit_async(struct capi_uart_handle *handle, uint8_t *buf,
+			     uint32_t len);
+
+/**
+ * @brief Async/Non-Blocking receive function.
+ *
+ * @param [in] handle Points to the UART controller context.
+ * @param [out] buf Points to the user buffer for incoming data
+ * @param [in] len number of bytes to be received
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_uart_receive_async(struct capi_uart_handle *handle, uint8_t *buf,
+			    uint32_t len);
+
+/**
+ * @brief Get UART interrupt reason.
+ * if CAPI_UART_EVENT_INTERRUPT event occurs, user can get the reason with this api
+ *
+ * @param [in] handle Points to the UART controller context.
+ * @param [out] reason returns interrupt reason
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_uart_get_interrupt_reason(struct capi_uart_handle *handle,
+				   enum capi_uart_interrupt_reason *reason);
+
+/**
+ * @brief Get UART line status flags
+ * if the interrupt reason is CAPI_UART_INTR_RX_LINE_STATUS,
+ * user can get the line status flags with this api
+ *
+ * @param [in] handle Points to the UART controller context.
+ * @param [out] status_flags returns status flags. Check enum capi_uart_line_status_flags
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_uart_get_line_status(struct capi_uart_handle *handle,
+			      uint32_t *status_flags);
+
+/**
+ * @brief Send 9-bit data for multi-drop communication
+ *
+ * @param [in] handle Points to the UART controller context.
+ * @param [in] data 9-bit data to transmit (only lower 9 bits used)
+ * @param [in] is_address true if this is an address byte, false for data
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_uart_transmit_9bit(struct capi_uart_handle *handle, uint16_t data,
+			    bool is_address);
+
+/**
+ * @brief Receive 9-bit data for multi-drop communication
+ *
+ * @param [in] handle Points to the UART controller context.
+ * @param [out] data received 9-bit data (only lower 9 bits valid)
+ * @param [out] is_address true if this is an address byte, false for data
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_uart_receive_9bit(struct capi_uart_handle *handle, uint16_t *data,
+			   bool *is_address);
+
+/**
+ * @brief Set flow control state manually
+ *
+ * @param [in] handle Points to the UART controller context.
+ * @param [in] rts_state RTS signal state (true = asserted, false = deasserted)
+ * @param [in] cts_state CTS signal state (true = asserted, false = deasserted)
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_uart_set_flow_control_state(struct capi_uart_handle *handle,
+				     bool rts_state,
+				     bool cts_state);
+
+/**
+ * @brief Get flow control state
+ *
+ * @param [in] handle Points to the UART controller context.
+ * @param [out] rts_state RTS signal state (true = asserted, false = deasserted)
+ * @param [out] cts_state CTS signal state (true = asserted, false = deasserted)
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_uart_get_flow_control_state(struct capi_uart_handle *handle,
+				     bool *rts_state,
+				     bool *cts_state);
+
+/**
+ * @brief UART Driver Interrupt handler. If interrupt vectors are managed and implemented by user,
+ * then user shall call this function in the relevant interrupt vector function.
+ *
+ * @param [in] handle Points to the UART controller context
+ */
+void capi_uart_isr(void *handle);
+
+/**
+ * @brief Read a single byte from the UART
+ * @param [in] handle Points to the UART controller context.
+ * @param [out] byte Pointer to store the received byte
+ *
+ * @return uint32_t Number of bytes read (0 if no data available, 1 if byte was read)
+ */
+uint32_t capi_uart_read_byte(struct capi_uart_handle *handle, uint8_t *byte);
+
+/**
+ * @brief Write a single byte to the UART
+ *
+ * @param [in] handle Points to the UART controller context.
+ * @param [in] byte Byte to transmit
+ *
+ * @return uint32_t Number of bytes written (0 on failure, 1 on success)
+ */
+uint32_t capi_uart_write_byte(struct capi_uart_handle *handle, uint8_t byte);
+
+/**
+ * @brief Enable or disable TX interrupt
+ *
+ * @param [in] handle Points to the UART controller context.
+ * @param [in] enable Boolean to enable (true) or disable (false) the TX interrupt
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_uart_set_irq_tx(struct capi_uart_handle *handle, bool enable);
+
+/**
+ * @brief Check if UART TX buffer can accept bytes
+ *
+ * @param [in] handle Points to the UART controller context.
+ * @param [out] ready Pointer to store TX buffer ready status
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_uart_irq_tx_ready(struct capi_uart_handle *handle, bool *ready);
+
+/**
+ * @brief Check if transmission is complete
+ *
+ * @param [in] handle Points to the UART controller context.
+ * @param [out] complete Pointer to store completion status
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_uart_irq_tx_complete(struct capi_uart_handle *handle, bool *complete);
+
+/**
+ * @brief Enable or disable RX interrupt
+ *
+ * @param [in] handle Points to the UART controller context.
+ * @param [in] enable Boolean to enable (true) or disable (false) the RX interrupt
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_uart_set_irq_rx(struct capi_uart_handle *handle, bool enable);
+
+/**
+ * @brief Check if RX data is ready
+ *
+ * @param [in] handle Points to the UART controller context.
+ * @param [out] ready Pointer to store data ready status
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_uart_irq_rx_ready(struct capi_uart_handle *handle, bool *ready);
+
+/**
+ * @brief Enable or disable status/error interrupt
+ *
+ * @param [in] handle Points to the UART controller context.
+ * @param [in] enable Boolean to enable (true) or disable (false) the status interrupt
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_uart_set_irq_err(struct capi_uart_handle *handle, bool enable);
+
+/**
+ * @brief Check if any interrupt is pending
+ *
+ * @param [in] handle Points to the UART controller context.
+ * @param [out] pending Pointer to store interrupt pending status
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_uart_is_irq_pending(struct capi_uart_handle *handle, bool *pending);
+
+/**
+ * @brief Structure holding UART function pointers that point to the platform
+ * specific function. See API functions for relevant descriptions.
+ */
+struct capi_uart_ops {
+	/** See capi_uart_init() */
+	int (*init)(struct capi_uart_handle **handle,
+		    const struct capi_uart_config *config);
+	/** See capi_uart_deinit() */
+	int (*deinit)(struct capi_uart_handle *handle);
+	/** See capi_uart_get_line_config() */
+	int (*get_line_config)(struct capi_uart_handle *handle,
+			       struct capi_uart_line_config *line_config);
+	/** See capi_uart_set_line_config() */
+	int (*set_line_config)(struct capi_uart_handle *handle,
+			       struct capi_uart_line_config *line_config);
+	/** See capi_uart_enable_fifo() */
+	int (*enable_fifo)(struct capi_uart_handle *handle, bool enable);
+	/** See capi_uart_flush_tx_fifo() */
+	int (*flush_tx_fifo)(struct capi_uart_handle *handle);
+	/** See capi_uart_flush_rx_fifo() */
+	int (*flush_rx_fifo)(struct capi_uart_handle *handle);
+	/** See capi_uart_get_rx_fifo_count() */
+	int (*get_rx_fifo_count)(struct capi_uart_handle *handle, uint16_t *count);
+	/** See capi_uart_get_tx_fifo_count() */
+	int (*get_tx_fifo_count)(struct capi_uart_handle *handle, uint16_t *count);
+	/** See capi_uart_transmit() */
+	int (*transmit)(struct capi_uart_handle *handle, uint8_t *buf, uint32_t len);
+	/** See capi_uart_receive() */
+	int (*receive)(struct capi_uart_handle *handle, uint8_t *buf, uint32_t len);
+	/** See capi_uart_register_callback() */
+	int (*register_callback)(struct capi_uart_handle *handle,
+				 capi_uart_callback const callback,
+				 void *const callback_arg);
+	/** See capi_uart_transmit_async() */
+	int (*transmit_async)(struct capi_uart_handle *handle, uint8_t *buf,
+			      uint32_t len);
+	/** See capi_uart_receive_async() */
+	int (*receive_async)(struct capi_uart_handle *handle, uint8_t *buf,
+			     uint32_t len);
+	/** See capi_uart_get_interrupt_reason() */
+	int (*get_interrupt_reason)(struct capi_uart_handle *handle,
+				    enum capi_uart_interrupt_reason *reason);
+	/** See capi_uart_get_line_status() */
+	int (*get_line_status)(struct capi_uart_handle *handle, uint32_t *status_flags);
+	/** See capi_uart_transmit_9bit() */
+	int (*transmit_9bit)(struct capi_uart_handle *handle, uint16_t data,
+			     bool is_address);
+	/** See capi_uart_receive_9bit() */
+	int (*receive_9bit)(struct capi_uart_handle *handle, uint16_t *data,
+			    bool *is_address);
+	/** See capi_uart_set_flow_control_state() */
+	int (*set_flow_control_state)(struct capi_uart_handle *handle, bool rts_state,
+				      bool cts_state);
+	/** See capi_uart_get_flow_control_state() */
+	int (*get_flow_control_state)(struct capi_uart_handle *handle, bool *rts_state,
+				      bool *cts_state);
+	/** See capi_uart_isr() */
+	void (*isr)(void *handle);
+	/** See capi_uart_read_byte() */
+	uint32_t (*read_byte)(struct capi_uart_handle *handle, uint8_t *byte);
+	/** See capi_uart_write_byte() */
+	uint32_t (*write_byte)(struct capi_uart_handle *handle, uint8_t byte);
+	/** See capi_uart_set_irq_tx() */
+	int (*set_irq_tx)(struct capi_uart_handle *handle, bool enable);
+	/** See capi_uart_irq_tx_ready() */
+	int (*irq_tx_ready)(struct capi_uart_handle *handle, bool *ready);
+	/** See capi_uart_irq_tx_complete() */
+	int (*irq_tx_complete)(struct capi_uart_handle *handle, bool *complete);
+	/** See capi_uart_set_irq_rx() */
+	int (*set_irq_rx)(struct capi_uart_handle *handle, bool enable);
+	/** See capi_uart_irq_rx_ready() */
+	int (*irq_rx_ready)(struct capi_uart_handle *handle, bool *ready);
+	/** See capi_uart_set_irq_err() */
+	int (*set_irq_err)(struct capi_uart_handle *handle, bool enable);
+	/** See capi_uart_is_irq_pending() */
+	int (*is_irq_pending)(struct capi_uart_handle *handle, bool *pending);
+};
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/capi/platform/stm32/stm32_capi_alloc.c
+++ b/capi/platform/stm32/stm32_capi_alloc.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "capi_alloc.h"
+#include <stdlib.h>
+
+void *capi_malloc_impl(size_t size)
+{
+	return malloc(size);
+}
+
+void capi_free_impl(void *ptr)
+{
+	free(ptr);
+}
+
+void *capi_calloc_impl(size_t num, size_t size)
+{
+	return calloc(num, size);
+}
+
+void *capi_realloc_impl(void *ptr, size_t size)
+{
+	return realloc(ptr, size);
+}

--- a/capi/platform/stm32/stm32_capi_dma.c
+++ b/capi/platform/stm32/stm32_capi_dma.c
@@ -1,0 +1,511 @@
+/*
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "stm32_capi_dma_priv.h"
+#include "capi_alloc.h"
+#include <errno.h>
+#include <string.h>
+
+#define MAX_DMA_CHANNELS 16
+
+static struct capi_dma_handle *dma_handle_singleton = NULL;
+static struct stm32_dma_chan_priv *chan_priv_map[MAX_DMA_CHANNELS];
+
+/**
+ * @brief Find channel private data by HAL DMA handle.
+ * @param hdma - Pointer to the HAL DMA handle.
+ * @return Pointer to the matching channel private data, or NULL if not found.
+ */
+static struct stm32_dma_chan_priv *find_chan_priv_by_hdma(
+	DMA_HandleTypeDef *hdma)
+{
+	uint32_t i;
+
+	for (i = 0; i < MAX_DMA_CHANNELS; i++) {
+		if (chan_priv_map[i] && &chan_priv_map[i]->hdma == hdma)
+			return chan_priv_map[i];
+	}
+
+	return NULL;
+}
+
+/**
+ * @brief HAL DMA transfer complete callback.
+ * @param hdma - Pointer to the HAL DMA handle that completed.
+ */
+static void stm32_capi_dma_xfer_cplt_callback(DMA_HandleTypeDef *hdma)
+{
+	struct stm32_dma_chan_priv *chan_priv;
+
+	chan_priv = find_chan_priv_by_hdma(hdma);
+	if (!chan_priv || !chan_priv->capi_chan)
+		return;
+
+	chan_priv->completed = true;
+
+	if (chan_priv->capi_chan->xfer_complete_cb)
+		chan_priv->capi_chan->xfer_complete_cb(0,
+						       chan_priv->capi_chan->xfer_complete_ctx);
+}
+
+/**
+ * @brief HAL DMA transfer error callback.
+ * @param hdma - Pointer to the HAL DMA handle that errored.
+ */
+static void stm32_capi_dma_xfer_error_callback(DMA_HandleTypeDef *hdma)
+{
+	struct stm32_dma_chan_priv *chan_priv;
+
+	chan_priv = find_chan_priv_by_hdma(hdma);
+	if (!chan_priv)
+		return;
+
+	chan_priv->completed = true;
+}
+
+/**
+ * @brief Initialize the STM32 DMA controller.
+ * @param handle - Pointer to the DMA handle pointer to be allocated.
+ * @param config - Pointer to the DMA configuration structure.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_dma_init(struct capi_dma_handle **handle,
+			       const struct capi_dma_config *config)
+{
+	struct capi_dma_handle *dma_handle;
+	struct stm32_dma_priv_handle *dma_priv;
+
+	if (!handle || !config)
+		return -EINVAL;
+
+	if (dma_handle_singleton) {
+		*handle = dma_handle_singleton;
+		return 0;
+	}
+
+	if (*handle == NULL) {
+		dma_handle = (struct capi_dma_handle *)capi_calloc(1, sizeof(*dma_handle));
+		if (!dma_handle)
+			return -ENOMEM;
+
+		dma_priv = (struct stm32_dma_priv_handle *)capi_calloc(1, sizeof(*dma_priv));
+		if (!dma_priv) {
+			capi_free(dma_handle);
+			return -ENOMEM;
+		}
+
+		dma_handle->priv = dma_priv;
+		dma_handle->init_allocated = true;
+	} else {
+		dma_handle = *handle;
+		dma_handle->init_allocated = false;
+
+		if (!dma_handle->priv)
+			return -EINVAL;
+
+		dma_priv = dma_handle->priv;
+	}
+
+	dma_priv->num_chans = config->num_chans;
+	dma_priv->chan_privs = (struct stm32_dma_chan_priv **)capi_calloc(
+				       config->num_chans, sizeof(struct stm32_dma_chan_priv *));
+	if (!dma_priv->chan_privs) {
+		if (dma_handle->init_allocated) {
+			capi_free(dma_priv);
+			capi_free(dma_handle);
+		}
+		return -ENOMEM;
+	}
+
+	dma_handle->ops = config->ops;
+
+	dma_handle_singleton = dma_handle;
+	*handle = dma_handle;
+
+	return 0;
+}
+
+/**
+ * @brief Deinitialize the STM32 DMA controller.
+ * @param handle - Pointer to the DMA handle to deinitialize.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_dma_deinit(struct capi_dma_handle *handle)
+{
+	struct stm32_dma_priv_handle *dma_priv;
+	uint32_t i;
+
+	if (!handle)
+		return -EINVAL;
+
+	dma_priv = handle->priv;
+
+	if (dma_priv) {
+		for (i = 0; i < dma_priv->num_chans; i++) {
+			if (dma_priv->chan_privs[i]) {
+				HAL_DMA_DeInit(&dma_priv->chan_privs[i]->hdma);
+				if (handle->init_allocated)
+					capi_free(dma_priv->chan_privs[i]);
+			}
+		}
+		if (handle->init_allocated)
+			capi_free(dma_priv->chan_privs);
+	}
+
+	memset(chan_priv_map, 0, sizeof(chan_priv_map));
+
+	if (handle->init_allocated) {
+		capi_free(dma_priv);
+		capi_free(handle);
+	}
+
+	dma_handle_singleton = NULL;
+
+	return 0;
+}
+
+/**
+ * @brief Initialize a DMA channel.
+ * @param handle - Pointer to the DMA handle.
+ * @param chan_ptr - Pointer to the channel pointer to be allocated.
+ * @param id - Channel identifier.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_dma_init_chan(struct capi_dma_handle *handle,
+				    struct capi_dma_chan **chan_ptr,
+				    uint32_t id)
+{
+	struct capi_dma_chan *chan;
+	struct stm32_dma_chan_priv *chan_priv;
+	struct stm32_dma_priv_handle *dma_priv;
+
+	if (!handle || !chan_ptr)
+		return -EINVAL;
+
+	dma_priv = handle->priv;
+	if (!dma_priv)
+		return -EINVAL;
+
+	if (id >= dma_priv->num_chans)
+		return -EINVAL;
+
+	if (dma_priv->chan_privs[id])
+		return -EBUSY;
+
+	chan = (struct capi_dma_chan *)capi_calloc(1, sizeof(*chan));
+	if (!chan)
+		return -ENOMEM;
+
+	chan_priv = (struct stm32_dma_chan_priv *)capi_calloc(1, sizeof(*chan_priv));
+	if (!chan_priv) {
+		capi_free(chan);
+		return -ENOMEM;
+	}
+
+	chan->owned_by_app = false;
+	chan->handle = handle;
+	chan->id = id;
+	chan->extra = chan_priv;
+
+	chan_priv->capi_chan = chan;
+	chan_priv->completed = true;
+
+	dma_priv->chan_privs[id] = chan_priv;
+
+	if (id < MAX_DMA_CHANNELS)
+		chan_priv_map[id] = chan_priv;
+
+	*chan_ptr = chan;
+
+	return 0;
+}
+
+/**
+ * @brief Deinitialize a DMA channel.
+ * @param chan - Pointer to the DMA channel to deinitialize.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_dma_deinit_chan(struct capi_dma_chan *chan)
+{
+	struct stm32_dma_chan_priv *chan_priv;
+	struct stm32_dma_priv_handle *dma_priv;
+
+	if (!chan || !chan->handle)
+		return -EINVAL;
+
+	chan_priv = chan->extra;
+	dma_priv = chan->handle->priv;
+
+	if (chan_priv) {
+		HAL_DMA_DeInit(&chan_priv->hdma);
+
+		if (chan->id < MAX_DMA_CHANNELS)
+			chan_priv_map[chan->id] = NULL;
+
+		if (dma_priv && chan->id < dma_priv->num_chans)
+			dma_priv->chan_privs[chan->id] = NULL;
+
+		capi_free(chan_priv);
+	}
+
+	if (!chan->owned_by_app)
+		capi_free(chan);
+
+	return 0;
+}
+
+/**
+ * @brief Configure a DMA transfer.
+ * @param chan - Pointer to the DMA channel.
+ * @param xfer - Pointer to the DMA transfer descriptor.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_dma_config_xfer(struct capi_dma_chan *chan,
+				      struct capi_dma_transfer *xfer)
+{
+	struct stm32_dma_chan_priv *chan_priv;
+	struct stm32_dma_chan_extra_config *chan_extra;
+	int ret;
+
+	if (!chan || !xfer || !chan->extra)
+		return -EINVAL;
+
+	chan_priv = chan->extra;
+	chan_extra = xfer->extra;
+
+	if (chan_extra) {
+		chan_priv->ch_num = chan_extra->ch_num;
+		chan_priv->mem_increment = chan_extra->mem_increment;
+		chan_priv->per_increment = chan_extra->per_increment;
+		chan_priv->mem_data_alignment = chan_extra->mem_data_alignment;
+		chan_priv->per_data_alignment = chan_extra->per_data_alignment;
+		chan_priv->dma_mode = chan_extra->dma_mode;
+		chan_priv->trig = chan_extra->trig;
+
+		if (chan_extra->hdma)
+			memcpy(&chan_priv->hdma, chan_extra->hdma, sizeof(DMA_HandleTypeDef));
+	}
+
+#if defined(STM32F2) || defined(STM32F4) || defined(STM32F7)
+	chan_priv->hdma.Init.Channel = chan_priv->ch_num;
+#else
+	chan_priv->hdma.Init.Request = chan_priv->ch_num;
+#endif
+
+	if (!chan_priv->hdma.Instance)
+		return -EINVAL;
+
+	switch (chan_priv->dma_mode) {
+	case CAPI_DMA_NORMAL_MODE:
+		chan_priv->hdma.Init.Mode = DMA_NORMAL;
+		break;
+	case CAPI_DMA_CIRCULAR_MODE:
+		chan_priv->hdma.Init.Mode = DMA_CIRCULAR;
+		break;
+	default:
+		chan_priv->hdma.Init.Mode = DMA_NORMAL;
+		break;
+	}
+
+	switch (xfer->xfer_type) {
+	case CAPI_DMA_MEM_TO_MEM:
+		chan_priv->hdma.Init.Direction = DMA_MEMORY_TO_MEMORY;
+		chan_priv->hdma.Init.MemInc = (xfer->dst_inc == CAPI_DMA_BYTE_INCREMENT) ?
+					      DMA_MINC_ENABLE : DMA_MINC_DISABLE;
+		chan_priv->hdma.Init.PeriphInc = (xfer->src_inc == CAPI_DMA_BYTE_INCREMENT) ?
+						 DMA_PINC_ENABLE : DMA_PINC_DISABLE;
+		break;
+	case CAPI_DMA_MEM_TO_DEV:
+		chan_priv->hdma.Init.Direction = DMA_MEMORY_TO_PERIPH;
+		chan_priv->hdma.Init.MemInc = (xfer->src_inc == CAPI_DMA_BYTE_INCREMENT) ?
+					      DMA_MINC_ENABLE : DMA_MINC_DISABLE;
+		chan_priv->hdma.Init.PeriphInc = (xfer->dst_inc == CAPI_DMA_BYTE_INCREMENT) ?
+						 DMA_PINC_ENABLE : DMA_PINC_DISABLE;
+		break;
+	case CAPI_DMA_DEV_TO_MEM:
+		chan_priv->hdma.Init.Direction = DMA_PERIPH_TO_MEMORY;
+		chan_priv->hdma.Init.MemInc = (xfer->dst_inc == CAPI_DMA_BYTE_INCREMENT) ?
+					      DMA_MINC_ENABLE : DMA_MINC_DISABLE;
+		chan_priv->hdma.Init.PeriphInc = (xfer->src_inc == CAPI_DMA_BYTE_INCREMENT) ?
+						 DMA_PINC_ENABLE : DMA_PINC_DISABLE;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	switch (chan_priv->mem_data_alignment) {
+	case CAPI_DMA_DATA_ALIGN_BYTE:
+		chan_priv->hdma.Init.MemDataAlignment = DMA_MDATAALIGN_BYTE;
+		break;
+	case CAPI_DMA_DATA_ALIGN_HALF_WORD:
+		chan_priv->hdma.Init.MemDataAlignment = DMA_MDATAALIGN_HALFWORD;
+		break;
+	case CAPI_DMA_DATA_ALIGN_WORD:
+		chan_priv->hdma.Init.MemDataAlignment = DMA_MDATAALIGN_WORD;
+		break;
+	default:
+		chan_priv->hdma.Init.MemDataAlignment = DMA_MDATAALIGN_BYTE;
+		break;
+	}
+
+	switch (chan_priv->per_data_alignment) {
+	case CAPI_DMA_DATA_ALIGN_BYTE:
+		chan_priv->hdma.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
+		break;
+	case CAPI_DMA_DATA_ALIGN_HALF_WORD:
+		chan_priv->hdma.Init.PeriphDataAlignment = DMA_PDATAALIGN_HALFWORD;
+		break;
+	case CAPI_DMA_DATA_ALIGN_WORD:
+		chan_priv->hdma.Init.PeriphDataAlignment = DMA_PDATAALIGN_WORD;
+		break;
+	default:
+		chan_priv->hdma.Init.PeriphDataAlignment = DMA_PDATAALIGN_BYTE;
+		break;
+	}
+
+	chan_priv->src = xfer->src;
+	chan_priv->dst = xfer->dst;
+	chan_priv->length = xfer->length;
+	chan_priv->completed = false;
+
+	chan->xfer = xfer;
+
+	chan_priv->hdma.XferCpltCallback = stm32_capi_dma_xfer_cplt_callback;
+	chan_priv->hdma.XferErrorCallback = stm32_capi_dma_xfer_error_callback;
+
+	ret = HAL_DMA_Init(&chan_priv->hdma);
+	if (ret != HAL_OK)
+		return -EIO;
+
+	return 0;
+}
+
+/**
+ * @brief Start a DMA transfer.
+ * @param chan - Pointer to the DMA channel.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_dma_xfer_start(struct capi_dma_chan *chan)
+{
+	struct stm32_dma_chan_priv *chan_priv;
+	int ret;
+
+	if (!chan || !chan->extra)
+		return -EINVAL;
+
+	chan_priv = chan->extra;
+	chan_priv->completed = false;
+
+	if (chan->irq_num) {
+		ret = HAL_DMA_Start_IT(&chan_priv->hdma,
+				       (uint32_t)chan_priv->src,
+				       (uint32_t)chan_priv->dst,
+				       chan_priv->length);
+	} else {
+		ret = HAL_DMA_Start(&chan_priv->hdma,
+				    (uint32_t)chan_priv->src,
+				    (uint32_t)chan_priv->dst,
+				    chan_priv->length);
+		if (ret == HAL_OK) {
+			ret = HAL_DMA_PollForTransfer(&chan_priv->hdma,
+						      HAL_DMA_FULL_TRANSFER,
+						      1000);
+			if (ret == HAL_OK)
+				chan_priv->completed = true;
+		}
+	}
+
+	if (ret != HAL_OK)
+		return -EIO;
+
+	return 0;
+}
+
+/**
+ * @brief Abort an ongoing DMA transfer.
+ * @param chan - Pointer to the DMA channel.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_dma_xfer_abort(struct capi_dma_chan *chan)
+{
+	struct stm32_dma_chan_priv *chan_priv;
+	int ret;
+
+	if (!chan || !chan->extra)
+		return -EINVAL;
+
+	chan_priv = chan->extra;
+
+	ret = HAL_DMA_Abort(&chan_priv->hdma);
+
+	if ((ret != HAL_OK) &&
+	    (chan_priv->hdma.ErrorCode != HAL_DMA_ERROR_NO_XFER))
+		return -EIO;
+
+	chan_priv->completed = true;
+
+	return 0;
+}
+
+/**
+ * @brief Check if a DMA channel transfer is completed.
+ * @param chan - Pointer to the DMA channel.
+ * @return true if the transfer is completed, false otherwise.
+ */
+static bool stm32_capi_dma_chan_is_completed(const struct capi_dma_chan *chan)
+{
+	struct stm32_dma_chan_priv *chan_priv;
+
+	if (!chan || !chan->extra)
+		return true;
+
+	chan_priv = chan->extra;
+
+	return chan_priv->completed;
+}
+
+/**
+ * @brief DMA controller interrupt handler.
+ * @param handle - Pointer to the DMA handle.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_dma_isr(struct capi_dma_handle *handle)
+{
+	(void)handle;
+	return 0;
+}
+
+/**
+ * @brief DMA channel interrupt handler.
+ * @param chan - Pointer to the DMA channel.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_dma_isr_chan(struct capi_dma_chan *chan)
+{
+	struct stm32_dma_chan_priv *chan_priv;
+
+	if (!chan || !chan->extra)
+		return -EINVAL;
+
+	chan_priv = chan->extra;
+
+	HAL_DMA_IRQHandler(&chan_priv->hdma);
+
+	return 0;
+}
+
+const struct capi_dma_ops stm32_capi_dma_ops = {
+	.init = stm32_capi_dma_init,
+	.deinit = stm32_capi_dma_deinit,
+	.init_chan = stm32_capi_dma_init_chan,
+	.deinit_chan = stm32_capi_dma_deinit_chan,
+	.config_xfer = stm32_capi_dma_config_xfer,
+	.xfer_start = stm32_capi_dma_xfer_start,
+	.xfer_abort = stm32_capi_dma_xfer_abort,
+	.chan_is_completed = stm32_capi_dma_chan_is_completed,
+	.isr = stm32_capi_dma_isr,
+	.isr_chan = stm32_capi_dma_isr_chan,
+};

--- a/capi/platform/stm32/stm32_capi_dma.h
+++ b/capi/platform/stm32/stm32_capi_dma.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef STM32_CAPI_DMA_H_
+#define STM32_CAPI_DMA_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "stm32_hal.h"
+#include "capi_dma.h"
+
+/**
+ * @enum stm32_capi_dma_data_alignment
+ * @brief DMA Data alignment
+ */
+enum stm32_capi_dma_data_alignment {
+	CAPI_DMA_DATA_ALIGN_BYTE = 0,
+	CAPI_DMA_DATA_ALIGN_HALF_WORD = 1,
+	CAPI_DMA_DATA_ALIGN_WORD = 2
+};
+
+/**
+ * @enum stm32_capi_dma_mode
+ * @brief DMA Data Modes
+ */
+enum stm32_capi_dma_mode {
+	CAPI_DMA_NORMAL_MODE = 0,
+	CAPI_DMA_CIRCULAR_MODE = 1
+};
+
+/**
+ * @enum stm32_capi_dma_trig_mode
+ * @brief DMA Trigger Modes
+ */
+enum stm32_capi_dma_trig_mode {
+	STM32_CAPI_DMA_BLOCK_XFER_MODE,
+	STM32_CAPI_DMA_REP_BLOCK_XFER_MODE,
+	STM32_CAPI_DMA_LLI_LINK_XFER_MODE,
+	STM32_CAPI_DMA_SINGLE_BURST_MODE
+};
+
+/**
+ * @enum stm32_capi_dma_trig_pol
+ * @brief DMA Trigger Polarity
+ */
+enum stm32_capi_dma_trig_pol {
+	STM32_CAPI_DMA_TRIG_MASKED,
+	STM32_CAPI_DMA_TRIG_RISING,
+	STM32_CAPI_DMA_TRIG_FALLING,
+};
+
+/**
+ * @struct stm32_capi_dma_trigger
+ * @brief Trigger descriptor for triggering a DMA transfer
+ */
+struct stm32_capi_dma_trigger {
+	uint32_t id;
+	enum stm32_capi_dma_trig_mode mode;
+	enum stm32_capi_dma_trig_pol polarity;
+};
+
+/**
+ * @struct stm32_dma_extra_config
+ * @brief STM32 platform specific DMA configuration for CAPI interface
+ */
+struct stm32_dma_extra_config {
+	/** DMA Handle - can be NULL for auto-init */
+	DMA_HandleTypeDef *hdma;
+	/** On F2/F4/F7: DMA_CHANNEL_x (channel selector); on others: DMA request number */
+	uint32_t ch_num;
+	/** Memory Increment */
+	bool mem_increment;
+	/** Peripheral Increment */
+	bool per_increment;
+	/** Memory Data Alignment */
+	enum stm32_capi_dma_data_alignment mem_data_alignment;
+	/** Peripheral Data Alignment */
+	enum stm32_capi_dma_data_alignment per_data_alignment;
+	/** DMA Mode */
+	enum stm32_capi_dma_mode dma_mode;
+	/** Trigger configuration (optional) */
+	struct stm32_capi_dma_trigger *trig;
+};
+
+/**
+ * @struct stm32_dma_chan_extra_config
+ * @brief STM32 platform specific DMA channel configuration
+ */
+struct stm32_dma_chan_extra_config {
+	/** DMA Handle */
+	DMA_HandleTypeDef *hdma;
+	/** Channel Number */
+	uint32_t ch_num;
+	/** Memory Increment */
+	bool mem_increment;
+	/** Peripheral Increment */
+	bool per_increment;
+	/** Memory Data Alignment */
+	enum stm32_capi_dma_data_alignment mem_data_alignment;
+	/** Peripheral Data Alignment */
+	enum stm32_capi_dma_data_alignment per_data_alignment;
+	/** DMA Mode */
+	enum stm32_capi_dma_mode dma_mode;
+	/** Trigger configuration (optional) */
+	struct stm32_capi_dma_trigger *trig;
+};
+
+/**
+ * @brief STM32 CAPI DMA operations structure
+ */
+extern const struct capi_dma_ops stm32_capi_dma_ops;
+
+#endif /* STM32_CAPI_DMA_H_ */

--- a/capi/platform/stm32/stm32_capi_dma_priv.h
+++ b/capi/platform/stm32/stm32_capi_dma_priv.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _STM32_CAPI_DMA_PRIV_H_
+#define _STM32_CAPI_DMA_PRIV_H_
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+#include "stm32_capi_dma.h"
+
+/**
+ * @brief STM32 platform specific DMA private handle
+ */
+struct stm32_dma_priv_handle {
+	/** Number of channels */
+	uint32_t num_chans;
+	/** Array of channel private data pointers */
+	struct stm32_dma_chan_priv **chan_privs;
+};
+
+/**
+ * @brief STM32 platform specific DMA channel private data
+ */
+struct stm32_dma_chan_priv {
+	/** DMA HAL Handle */
+	DMA_HandleTypeDef hdma;
+	/** Channel Number */
+	uint32_t ch_num;
+	/** Memory Increment */
+	bool mem_increment;
+	/** Peripheral Increment */
+	bool per_increment;
+	/** Memory Data Alignment */
+	enum stm32_capi_dma_data_alignment mem_data_alignment;
+	/** Peripheral Data Alignment */
+	enum stm32_capi_dma_data_alignment per_data_alignment;
+	/** DMA Mode */
+	enum stm32_capi_dma_mode dma_mode;
+	/** Trigger configuration */
+	struct stm32_capi_dma_trigger *trig;
+	/** Source Address for the data */
+	capi_dma_glbl_addr_t src;
+	/** Destination Address for the data */
+	capi_dma_glbl_addr_t dst;
+	/** Transfer length in Bytes */
+	size_t length;
+	/** Transfer completed flag */
+	volatile bool completed;
+	/** Back-reference to the CAPI channel */
+	struct capi_dma_chan *capi_chan;
+};
+
+#define CAPI_DMA_HANDLE_STM32_INIT() \
+	(&(struct capi_dma_handle){ \
+		.ops = NULL, \
+		.init_allocated = false, \
+		.priv = &(struct stm32_dma_priv_handle){0}})
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
+
+#endif /* _STM32_CAPI_DMA_PRIV_H_ */

--- a/capi/platform/stm32/stm32_capi_gpio.c
+++ b/capi/platform/stm32/stm32_capi_gpio.c
@@ -1,0 +1,690 @@
+/*
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdlib.h>
+#include <errno.h>
+#include "capi_alloc.h"
+#include "stm32_capi_gpio_priv.h"
+
+/** Maximum number of pins per STM32 GPIO port */
+#define STM32_GPIO_PINS_PER_PORT 16
+
+/** Bit shift to access the reset bits in the BSRR register */
+#define STM32_BSRR_RESET_SHIFT  16
+
+/** Default direction mask - all pins configured as inputs */
+#define STM32_GPIO_ALL_INPUTS    0xFFFF
+
+
+static int stm32_capi_gpio_port_set_raw_value(struct capi_gpio_port_handle
+		*handle,
+		uint64_t value_bitmask);
+static int stm32_capi_gpio_port_get_raw_value(struct capi_gpio_port_handle
+		*handle,
+		uint64_t *value_bitmask);
+static int stm32_capi_gpio_pin_set_raw_value(struct capi_gpio_pin *pin,
+		uint8_t value);
+static int stm32_capi_gpio_pin_get_raw_value(struct capi_gpio_pin *pin,
+		uint8_t *value);
+
+/**
+ * @brief Get STM32 GPIO port from identifier.
+ * @param identifier - Port identifier (0=GPIOA, 1=GPIOB, etc. or base address).
+ * @return Pointer to the GPIO port peripheral, or NULL if invalid.
+ */
+static GPIO_TypeDef *get_gpio_port_from_identifier(uint64_t identifier)
+{
+	/* If identifier is a valid GPIO peripheral base address, use it directly */
+	if (IS_GPIO_ALL_INSTANCE((GPIO_TypeDef *)(uintptr_t)identifier))
+		return (GPIO_TypeDef *)(uintptr_t)identifier;
+
+	/* Otherwise, map port number to GPIO peripheral */
+	switch (identifier) {
+	case 0:
+		return GPIOA;
+#ifdef GPIOB
+	case 1:
+		return GPIOB;
+#endif
+#ifdef GPIOC
+	case 2:
+		return GPIOC;
+#endif
+#ifdef GPIOD
+	case 3:
+		return GPIOD;
+#endif
+#ifdef GPIOE
+	case 4:
+		return GPIOE;
+#endif
+#ifdef GPIOF
+	case 5:
+		return GPIOF;
+#endif
+#ifdef GPIOG
+	case 6:
+		return GPIOG;
+#endif
+#ifdef GPIOH
+	case 7:
+		return GPIOH;
+#endif
+#ifdef GPIOI
+	case 8:
+		return GPIOI;
+#endif
+#ifdef GPIOJ
+	case 9:
+		return GPIOJ;
+#endif
+#ifdef GPIOK
+	case 10:
+		return GPIOK;
+#endif
+	default:
+		return NULL;
+	}
+}
+
+/**
+ * @brief Enable GPIO port clock in RCC.
+ * @param identifier - Port identifier (number or base address).
+ * @return 0 on success, negative error code otherwise.
+ */
+static int enable_gpio_port_clock(uint64_t identifier)
+{
+	/* Handle base address case */
+	if (IS_GPIO_ALL_INSTANCE((GPIO_TypeDef *)(uintptr_t)identifier)) {
+		GPIO_TypeDef *port = (GPIO_TypeDef *)(uintptr_t)identifier;
+
+		if (port == GPIOA) {
+			__HAL_RCC_GPIOA_CLK_ENABLE();
+			return 0;
+		}
+#ifdef GPIOB
+		if (port == GPIOB) {
+			__HAL_RCC_GPIOB_CLK_ENABLE();
+			return 0;
+		}
+#endif
+#ifdef GPIOC
+		if (port == GPIOC) {
+			__HAL_RCC_GPIOC_CLK_ENABLE();
+			return 0;
+		}
+#endif
+#ifdef GPIOD
+		if (port == GPIOD) {
+			__HAL_RCC_GPIOD_CLK_ENABLE();
+			return 0;
+		}
+#endif
+#ifdef GPIOE
+		if (port == GPIOE) {
+			__HAL_RCC_GPIOE_CLK_ENABLE();
+			return 0;
+		}
+#endif
+#ifdef GPIOF
+		if (port == GPIOF) {
+			__HAL_RCC_GPIOF_CLK_ENABLE();
+			return 0;
+		}
+#endif
+#ifdef GPIOG
+		if (port == GPIOG) {
+			__HAL_RCC_GPIOG_CLK_ENABLE();
+			return 0;
+		}
+#endif
+#ifdef GPIOH
+		if (port == GPIOH) {
+			__HAL_RCC_GPIOH_CLK_ENABLE();
+			return 0;
+		}
+#endif
+#ifdef GPIOI
+		if (port == GPIOI) {
+			__HAL_RCC_GPIOI_CLK_ENABLE();
+			return 0;
+		}
+#endif
+#ifdef GPIOJ
+		if (port == GPIOJ) {
+			__HAL_RCC_GPIOJ_CLK_ENABLE();
+			return 0;
+		}
+#endif
+#ifdef GPIOK
+		if (port == GPIOK) {
+			__HAL_RCC_GPIOK_CLK_ENABLE();
+			return 0;
+		}
+#endif
+		return -EINVAL;
+	}
+
+	/* Handle port number case */
+	switch (identifier) {
+	case 0:
+		__HAL_RCC_GPIOA_CLK_ENABLE();
+		break;
+#ifdef GPIOB
+	case 1:
+		__HAL_RCC_GPIOB_CLK_ENABLE();
+		break;
+#endif
+#ifdef GPIOC
+	case 2:
+		__HAL_RCC_GPIOC_CLK_ENABLE();
+		break;
+#endif
+#ifdef GPIOD
+	case 3:
+		__HAL_RCC_GPIOD_CLK_ENABLE();
+		break;
+#endif
+#ifdef GPIOE
+	case 4:
+		__HAL_RCC_GPIOE_CLK_ENABLE();
+		break;
+#endif
+#ifdef GPIOF
+	case 5:
+		__HAL_RCC_GPIOF_CLK_ENABLE();
+		break;
+#endif
+#ifdef GPIOG
+	case 6:
+		__HAL_RCC_GPIOG_CLK_ENABLE();
+		break;
+#endif
+#ifdef GPIOH
+	case 7:
+		__HAL_RCC_GPIOH_CLK_ENABLE();
+		break;
+#endif
+#ifdef GPIOI
+	case 8:
+		__HAL_RCC_GPIOI_CLK_ENABLE();
+		break;
+#endif
+#ifdef GPIOJ
+	case 9:
+		__HAL_RCC_GPIOJ_CLK_ENABLE();
+		break;
+#endif
+#ifdef GPIOK
+	case 10:
+		__HAL_RCC_GPIOK_CLK_ENABLE();
+		break;
+#endif
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Apply logical value considering ACTIVE_LOW flag.
+ * @param raw_value - Raw hardware value.
+ * @param flags - Pin flags.
+ * @return Logical value after applying ACTIVE_LOW inversion.
+ */
+static inline uint8_t apply_active_low(uint8_t raw_value, uint32_t flags)
+{
+	if (flags & CAPI_GPIO_ACTIVE_LOW)
+		return raw_value ? CAPI_GPIO_LOW : CAPI_GPIO_HIGH;
+	return raw_value;
+}
+
+/**
+ * @brief Convert logical value to raw considering ACTIVE_LOW flag.
+ * @param logical_value - Logical value.
+ * @param flags - Pin flags.
+ * @return Raw hardware value after applying ACTIVE_LOW inversion.
+ */
+static inline uint8_t to_raw_value(uint8_t logical_value, uint32_t flags)
+{
+	if (flags & CAPI_GPIO_ACTIVE_LOW)
+		return logical_value ? CAPI_GPIO_LOW : CAPI_GPIO_HIGH;
+	return logical_value;
+}
+
+/**
+ * @brief Initialize a GPIO port.
+ * @param handle - Pointer to port handle pointer. If *handle is NULL, memory
+ *                 is allocated by the driver.
+ * @param config - Pointer to the GPIO port configuration.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_gpio_port_init(struct capi_gpio_port_handle **handle,
+				     const struct capi_gpio_port_config *config)
+{
+	struct capi_gpio_port_handle *port_handle;
+	struct stm32_capi_gpio_port_priv *priv;
+	struct stm32_capi_gpio_port_config *extra_config;
+	GPIO_TypeDef *port;
+	int ret;
+
+	if (!handle || !config)
+		return -EINVAL;
+
+	/* Get GPIO port from identifier */
+	port = get_gpio_port_from_identifier(config->identifier);
+	if (!port)
+		return -EINVAL;
+
+	/* Enable port clock */
+	ret = enable_gpio_port_clock(config->identifier);
+	if (ret)
+		return ret;
+
+	if (*handle == NULL) {
+		port_handle = capi_calloc(1, sizeof(*port_handle));
+		if (!port_handle)
+			return -ENOMEM;
+
+		priv = capi_calloc(1, sizeof(*priv));
+		if (!priv) {
+			capi_free(port_handle);
+			return -ENOMEM;
+		}
+
+		port_handle->priv = priv;
+		port_handle->init_allocated = true;
+	} else {
+		port_handle = *handle;
+		port_handle->init_allocated = false;
+
+		if (!port_handle->priv)
+			return -EINVAL;
+
+		priv = port_handle->priv;
+	}
+
+	port_handle->ops = config->ops;
+
+	/* Initialize private data */
+	priv->port = port;
+	priv->num_pins = config->num_pins ? config->num_pins : STM32_GPIO_PINS_PER_PORT;
+	priv->direction_mask = STM32_GPIO_ALL_INPUTS;
+
+	/* Apply extra configuration if provided */
+	if (config->extra) {
+		extra_config = (struct stm32_capi_gpio_port_config *)config->extra;
+		priv->default_config.mode = extra_config->mode;
+		priv->default_config.speed = extra_config->speed;
+		priv->default_config.alternate = extra_config->alternate;
+		priv->default_config.pull = extra_config->pull;
+	} else {
+		/* Default configuration */
+		priv->default_config.mode = GPIO_MODE_INPUT;
+		priv->default_config.speed = GPIO_SPEED_FREQ_LOW;
+		priv->default_config.alternate = 0;
+		priv->default_config.pull = GPIO_NOPULL;
+	}
+
+	*handle = port_handle;
+	return 0;
+}
+
+/**
+ * @brief Deinitialize a GPIO port.
+ * @param handle - Pointer to port handle pointer. Set to NULL on return.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_gpio_port_deinit(struct capi_gpio_port_handle **handle)
+{
+	struct capi_gpio_port_handle *port_handle;
+
+	if (!handle || !*handle)
+		return -EINVAL;
+
+	port_handle = *handle;
+
+	if (port_handle->init_allocated) {
+		capi_free(port_handle->priv);
+		capi_free(port_handle);
+	}
+
+	*handle = NULL;
+	return 0;
+}
+
+/**
+ * @brief Set direction for all pins in the port.
+ * @param handle - Pointer to the GPIO port handle.
+ * @param direction_bitmask - Direction bitmask (1=input, 0=output per pin).
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_gpio_port_set_direction(struct capi_gpio_port_handle
+		*handle,
+		uint64_t direction_bitmask)
+{
+	struct stm32_capi_gpio_port_priv *priv;
+	GPIO_InitTypeDef gpio_config;
+	uint16_t i;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	priv = handle->priv;
+
+	/* Configure each pin according to direction bitmask */
+	for (i = 0; i < priv->num_pins; i++) {
+		gpio_config.Pin = (1U << (i));
+		gpio_config.Pull = priv->default_config.pull;
+		gpio_config.Speed = priv->default_config.speed;
+
+		if (direction_bitmask & (1U << (i))) {
+			/* Input */
+			gpio_config.Mode = GPIO_MODE_INPUT;
+		} else {
+			/* Output */
+			gpio_config.Mode = GPIO_MODE_OUTPUT_PP;
+		}
+
+		HAL_GPIO_Init(priv->port, &gpio_config);
+	}
+
+	priv->direction_mask = (uint16_t)direction_bitmask;
+	return 0;
+}
+
+/**
+ * @brief Get direction of all pins in the port.
+ * @param handle - Pointer to the GPIO port handle.
+ * @param direction_bitmask - Pointer to store direction bitmask.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_gpio_port_get_direction(struct capi_gpio_port_handle
+		*handle,
+		uint64_t *direction_bitmask)
+{
+	struct stm32_capi_gpio_port_priv *priv;
+
+	if (!handle || !handle->priv || !direction_bitmask)
+		return -EINVAL;
+
+	priv = handle->priv;
+	*direction_bitmask = priv->direction_mask;
+	return 0;
+}
+
+/**
+ * @brief Set value for all pins in the port (considering ACTIVE_LOW flags).
+ * @param handle - Pointer to the GPIO port handle.
+ * @param value_bitmask - Value bitmask to set.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_gpio_port_set_value(struct capi_gpio_port_handle *handle,
+		uint64_t value_bitmask)
+{
+	/* For port-level operations without per-pin flags, use raw value */
+	return stm32_capi_gpio_port_set_raw_value(handle, value_bitmask);
+}
+
+/**
+ * @brief Get value of all pins in the port (considering ACTIVE_LOW flags).
+ * @param handle - Pointer to the GPIO port handle.
+ * @param value_bitmask - Pointer to store value bitmask.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_gpio_port_get_value(struct capi_gpio_port_handle *handle,
+		uint64_t *value_bitmask)
+{
+	/* For port-level operations without per-pin flags, use raw value */
+	return stm32_capi_gpio_port_get_raw_value(handle, value_bitmask);
+}
+
+/**
+ * @brief Set raw value for all pins (ignoring ACTIVE_LOW flag).
+ * @param handle - Pointer to the GPIO port handle.
+ * @param value_bitmask - Raw value bitmask to set.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_gpio_port_set_raw_value(struct capi_gpio_port_handle
+		*handle,
+		uint64_t value_bitmask)
+{
+	struct stm32_capi_gpio_port_priv *priv;
+	uint16_t set_pins;
+	uint16_t reset_pins;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	priv = handle->priv;
+
+	/* Calculate which pins to set and reset */
+	set_pins = (uint16_t)value_bitmask;
+	reset_pins = (uint16_t)(~value_bitmask);
+
+	/* Use BSRR register for atomic set/reset */
+	priv->port->BSRR = ((uint32_t)reset_pins << STM32_BSRR_RESET_SHIFT) | set_pins;
+
+	return 0;
+}
+
+/**
+ * @brief Get raw value of all pins (ignoring ACTIVE_LOW flag).
+ * @param handle - Pointer to the GPIO port handle.
+ * @param value_bitmask - Pointer to store raw value bitmask.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_gpio_port_get_raw_value(struct capi_gpio_port_handle
+		*handle,
+		uint64_t *value_bitmask)
+{
+	struct stm32_capi_gpio_port_priv *priv;
+
+	if (!handle || !handle->priv || !value_bitmask)
+		return -EINVAL;
+
+	priv = handle->priv;
+
+	/* Read input data register */
+	*value_bitmask = priv->port->IDR & GPIO_PIN_All;
+
+	return 0;
+}
+
+/**
+ * @brief Set direction for a single pin.
+ * @param pin - Pointer to the GPIO pin descriptor.
+ * @param direction - Direction (CAPI_GPIO_INPUT or CAPI_GPIO_OUTPUT).
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_gpio_pin_set_direction(struct capi_gpio_pin *pin,
+		uint8_t direction)
+{
+	struct stm32_capi_gpio_port_priv *priv;
+	GPIO_InitTypeDef gpio_config;
+	uint8_t current_value;
+
+	if (!pin || !pin->port_handle || !pin->port_handle->priv)
+		return -EINVAL;
+
+	if (pin->number >= STM32_GPIO_PINS_PER_PORT)
+		return -EINVAL;
+
+	priv = pin->port_handle->priv;
+
+	gpio_config.Pin = (1U << (pin->number));
+	gpio_config.Pull = priv->default_config.pull;
+	gpio_config.Speed = priv->default_config.speed;
+
+	if (direction == CAPI_GPIO_INPUT) {
+		gpio_config.Mode = GPIO_MODE_INPUT;
+		priv->direction_mask |= (1U << (pin->number));
+	} else {
+		/* Read current pin state and set output value before configuring
+		 * direction to avoid glitches on the pin */
+		current_value = (priv->port->IDR & (1U << (pin->number))) ? 1 : 0;
+		HAL_GPIO_WritePin(priv->port, (1U << (pin->number)),
+				  (GPIO_PinState)current_value);
+
+		/* Use open-drain or push-pull based on pin flags */
+		if (pin->flags & STM32_GPIO_OPEN_DRAIN)
+			gpio_config.Mode = GPIO_MODE_OUTPUT_OD;
+		else
+			gpio_config.Mode = GPIO_MODE_OUTPUT_PP;
+		priv->direction_mask &= ~(1U << (pin->number));
+	}
+
+	HAL_GPIO_Init(priv->port, &gpio_config);
+
+	return 0;
+}
+
+/**
+ * @brief Get direction of a single pin.
+ * @param pin - Pointer to the GPIO pin descriptor.
+ * @param direction - Pointer to store the direction.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_gpio_pin_get_direction(struct capi_gpio_pin *pin,
+		uint8_t *direction)
+{
+	struct stm32_capi_gpio_port_priv *priv;
+
+	if (!pin || !pin->port_handle || !pin->port_handle->priv || !direction)
+		return -EINVAL;
+
+	if (pin->number >= STM32_GPIO_PINS_PER_PORT)
+		return -EINVAL;
+
+	priv = pin->port_handle->priv;
+
+	if (priv->direction_mask & (1U << (pin->number)))
+		*direction = CAPI_GPIO_INPUT;
+	else
+		*direction = CAPI_GPIO_OUTPUT;
+
+	return 0;
+}
+
+/**
+ * @brief Set value for a single pin (considering ACTIVE_LOW flag).
+ * @param pin - Pointer to the GPIO pin descriptor.
+ * @param value - Logical value (CAPI_GPIO_HIGH or CAPI_GPIO_LOW).
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_gpio_pin_set_value(struct capi_gpio_pin *pin,
+		uint8_t value)
+{
+	uint8_t raw_value;
+
+	if (!pin)
+		return -EINVAL;
+
+	/* Apply ACTIVE_LOW flag */
+	raw_value = to_raw_value(value, pin->flags);
+
+	return stm32_capi_gpio_pin_set_raw_value(pin, raw_value);
+}
+
+/**
+ * @brief Get value of a single pin (considering ACTIVE_LOW flag).
+ * @param pin - Pointer to the GPIO pin descriptor.
+ * @param value - Pointer to store the logical value.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_gpio_pin_get_value(struct capi_gpio_pin *pin,
+		uint8_t *value)
+{
+	uint8_t raw_value;
+	int ret;
+
+	if (!pin || !value)
+		return -EINVAL;
+
+	ret = stm32_capi_gpio_pin_get_raw_value(pin, &raw_value);
+	if (ret)
+		return ret;
+
+	/* Apply ACTIVE_LOW flag */
+	*value = apply_active_low(raw_value, pin->flags);
+
+	return 0;
+}
+
+/**
+ * @brief Set raw value for a single pin (ignoring ACTIVE_LOW flag).
+ * @param pin - Pointer to the GPIO pin descriptor.
+ * @param value - Raw value to set.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_gpio_pin_set_raw_value(struct capi_gpio_pin *pin,
+		uint8_t value)
+{
+	struct stm32_capi_gpio_port_priv *priv;
+
+	if (!pin || !pin->port_handle || !pin->port_handle->priv)
+		return -EINVAL;
+
+	if (pin->number >= STM32_GPIO_PINS_PER_PORT)
+		return -EINVAL;
+
+	priv = pin->port_handle->priv;
+
+	/* Use BSRR for atomic set/reset */
+	if (value)
+		priv->port->BSRR = (1U << (pin->number));
+	else
+		priv->port->BSRR = (1U << (pin->number)) << STM32_BSRR_RESET_SHIFT;
+
+	return 0;
+}
+
+/**
+ * @brief Get raw value of a single pin (ignoring ACTIVE_LOW flag).
+ * @param pin - Pointer to the GPIO pin descriptor.
+ * @param value - Pointer to store the raw value.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_gpio_pin_get_raw_value(struct capi_gpio_pin *pin,
+		uint8_t *value)
+{
+	struct stm32_capi_gpio_port_priv *priv;
+
+	if (!pin || !pin->port_handle || !pin->port_handle->priv || !value)
+		return -EINVAL;
+
+	if (pin->number >= STM32_GPIO_PINS_PER_PORT)
+		return -EINVAL;
+
+	priv = pin->port_handle->priv;
+
+	/* Read from input data register */
+	*value = (priv->port->IDR & (1U << (pin->number))) ? CAPI_GPIO_HIGH :
+		 CAPI_GPIO_LOW;
+
+	return 0;
+}
+
+/**
+ * @brief STM32 platform specific GPIO operations for CAPI
+ */
+const struct capi_gpio_ops stm32_capi_gpio_ops = {
+	.port_init = stm32_capi_gpio_port_init,
+	.port_deinit = stm32_capi_gpio_port_deinit,
+	.port_set_direction = stm32_capi_gpio_port_set_direction,
+	.port_get_direction = stm32_capi_gpio_port_get_direction,
+	.port_set_value = stm32_capi_gpio_port_set_value,
+	.port_get_value = stm32_capi_gpio_port_get_value,
+	.port_set_raw_value = stm32_capi_gpio_port_set_raw_value,
+	.port_get_raw_value = stm32_capi_gpio_port_get_raw_value,
+	.pin_set_direction = stm32_capi_gpio_pin_set_direction,
+	.pin_get_direction = stm32_capi_gpio_pin_get_direction,
+	.pin_set_value = stm32_capi_gpio_pin_set_value,
+	.pin_get_value = stm32_capi_gpio_pin_get_value,
+	.pin_set_raw_value = stm32_capi_gpio_pin_set_raw_value,
+	.pin_get_raw_value = stm32_capi_gpio_pin_get_raw_value,
+};

--- a/capi/platform/stm32/stm32_capi_gpio.h
+++ b/capi/platform/stm32/stm32_capi_gpio.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef STM32_CAPI_GPIO_H_
+#define STM32_CAPI_GPIO_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "stm32_hal.h"
+#include "capi_gpio.h"
+
+/**
+ * STM32-specific GPIO pin flags (can be OR'd with CAPI_GPIO_* flags)
+ */
+#define STM32_GPIO_OPEN_DRAIN  0x02
+
+/**
+ * @struct stm32_capi_gpio_port_config
+ * @brief STM32-specific GPIO port configuration for CAPI interface
+ */
+struct stm32_capi_gpio_port_config {
+	/** Default output mode for pins (GPIO_MODE_INPUT, GPIO_MODE_OUTPUT_PP, etc.) */
+	uint32_t mode;
+	/** Default speed grade for pins */
+	uint32_t speed;
+	/** Default alternate functionality (for AF modes) */
+	uint32_t alternate;
+	/** Default pull configuration (GPIO_NOPULL, GPIO_PULLUP, GPIO_PULLDOWN) */
+	uint32_t pull;
+};
+
+/**
+ * @brief STM32 platform specific GPIO operations for CAPI
+ */
+extern const struct capi_gpio_ops stm32_capi_gpio_ops;
+
+#endif /* STM32_CAPI_GPIO_H_ */

--- a/capi/platform/stm32/stm32_capi_gpio_priv.h
+++ b/capi/platform/stm32/stm32_capi_gpio_priv.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _STM32_CAPI_GPIO_PRIV_H_
+#define _STM32_CAPI_GPIO_PRIV_H_
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+#include "stm32_capi_gpio.h"
+
+/**
+ * @brief STM32 platform specific GPIO port private data
+ */
+struct stm32_capi_gpio_port_priv {
+	/** STM32 GPIO port peripheral (GPIOA, GPIOB, etc.) */
+	GPIO_TypeDef *port;
+	/** Number of pins in this port */
+	uint8_t num_pins;
+	/** Current direction configuration for all pins (1=input, 0=output) */
+	uint16_t direction_mask;
+	/** Default configuration */
+	struct stm32_capi_gpio_port_config default_config;
+};
+
+#define CAPI_GPIO_PORT_HANDLE_STM32_INIT() \
+	(&(struct capi_gpio_port_handle){ \
+		.ops = NULL, \
+		.init_allocated = false, \
+		.priv = &(struct stm32_capi_gpio_port_priv){0}})
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
+
+#endif /* _STM32_CAPI_GPIO_PRIV_H_ */

--- a/capi/platform/stm32/stm32_capi_i2c.c
+++ b/capi/platform/stm32/stm32_capi_i2c.c
@@ -1,0 +1,798 @@
+/*
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdlib.h>
+#include <errno.h>
+#include "stm32_capi_i2c_priv.h"
+#include "capi_alloc.h"
+
+#define MAX_I2C_INSTANCES		4
+#define STM32_I2C_DEFAULT_CLOCK_HZ	100000
+#define STM32_I2C_DEFAULT_TIMING	0x10909CECU
+#define STM32_I2C_SEQ_TIMEOUT_MS	1000
+
+/* Lookup table for mapping HAL handles to private handles */
+static struct {
+	I2C_HandleTypeDef *hi2c;
+	struct stm32_i2c_priv_handle *priv_handle;
+} i2c_handle_lookup[MAX_I2C_INSTANCES];
+static uint8_t i2c_handle_count = 0;
+
+/**
+ * @brief Find the private handle associated with a HAL I2C handle.
+ * @param hi2c - Pointer to the HAL I2C handle.
+ * @return Pointer to the private handle, or NULL if not found.
+ */
+static struct stm32_i2c_priv_handle *find_priv_handle(I2C_HandleTypeDef *hi2c)
+{
+	for (uint8_t i = 0; i < i2c_handle_count; i++) {
+		if (i2c_handle_lookup[i].hi2c == hi2c)
+			return i2c_handle_lookup[i].priv_handle;
+	}
+	return NULL;
+}
+
+/**
+ * @brief Register a mapping between a HAL I2C handle and a private handle.
+ * @param hi2c - Pointer to the HAL I2C handle.
+ * @param priv_handle - Pointer to the private handle.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int register_handle_mapping(I2C_HandleTypeDef *hi2c,
+				   struct stm32_i2c_priv_handle *priv_handle)
+{
+	if (i2c_handle_count >= MAX_I2C_INSTANCES)
+		return -ENOMEM;
+
+	i2c_handle_lookup[i2c_handle_count].hi2c = hi2c;
+	i2c_handle_lookup[i2c_handle_count].priv_handle = priv_handle;
+	i2c_handle_count++;
+	return 0;
+}
+
+/**
+ * @brief Unregister the mapping for a HAL I2C handle.
+ * @param hi2c - Pointer to the HAL I2C handle.
+ */
+static void unregister_handle_mapping(I2C_HandleTypeDef *hi2c)
+{
+	for (uint8_t i = 0; i < i2c_handle_count; i++) {
+		if (i2c_handle_lookup[i].hi2c == hi2c) {
+			/* Move last entry to this position */
+			if (i < i2c_handle_count - 1)
+				i2c_handle_lookup[i] = i2c_handle_lookup[i2c_handle_count - 1];
+			i2c_handle_count--;
+			break;
+		}
+	}
+}
+
+/**
+ * @brief Get I2C base address from identifier.
+ * @param identifier - I2C peripheral identifier or base address.
+ * @return Pointer to the I2C peripheral, or NULL if invalid.
+ */
+static I2C_TypeDef *get_i2c_base_from_identifier(uint64_t identifier)
+{
+	if (identifier >= PERIPH_BASE)
+		return (I2C_TypeDef *)identifier;
+
+	switch (identifier) {
+#if defined(I2C1)
+	case 1:
+		return I2C1;
+#endif
+#if defined(I2C2)
+	case 2:
+		return I2C2;
+#endif
+#if defined(I2C3)
+	case 3:
+		return I2C3;
+#endif
+#if defined(I2C4)
+	case 4:
+		return I2C4;
+#endif
+	default:
+		return NULL;
+	}
+}
+
+/**
+ * @brief Initialize the STM32 I2C controller.
+ * @param handle - Pointer to a pointer of the I2C controller handle.
+ * @param config - Pointer to the I2C configuration.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_i2c_init(struct capi_i2c_controller_handle **handle,
+			       const struct capi_i2c_config *config)
+{
+	struct capi_i2c_controller_handle *i2c_handle;
+	struct stm32_i2c_priv_handle *priv_handle;
+	struct stm32_i2c_extra_config *extra_config;
+	I2C_TypeDef *base;
+	int ret;
+
+	if (!handle || !config || !config->extra)
+		return -EINVAL;
+
+	if (*handle == NULL) {
+		i2c_handle = capi_calloc(1, sizeof(*i2c_handle));
+		if (!i2c_handle)
+			return -ENOMEM;
+
+		priv_handle = capi_calloc(1, sizeof(*priv_handle));
+		if (!priv_handle) {
+			capi_free(i2c_handle);
+			return -ENOMEM;
+		}
+
+		i2c_handle->priv = priv_handle;
+		i2c_handle->init_allocated = true;
+	} else {
+		i2c_handle = *handle;
+		i2c_handle->init_allocated = false;
+
+		if (!i2c_handle->priv)
+			return -EINVAL;
+
+		priv_handle = i2c_handle->priv;
+	}
+	i2c_handle->ops = config->ops;
+
+	extra_config = config->extra;
+
+	if (extra_config && extra_config->hi2c) {
+		priv_handle->hi2c = *extra_config->hi2c;
+	} else {
+		base = get_i2c_base_from_identifier(config->identifier);
+		if (!base) {
+			ret = -EINVAL;
+			goto error;
+		}
+		priv_handle->hi2c.Instance = base;
+	}
+
+#if defined(STM32F4) || defined(STM32F1) || defined(STM32F2) || defined(STM32L1)
+	priv_handle->hi2c.Init.ClockSpeed = config->clk_freq_hz ?
+					    config->clk_freq_hz :
+					    STM32_I2C_DEFAULT_CLOCK_HZ;
+	priv_handle->hi2c.Init.DutyCycle = I2C_DUTYCYCLE_2;
+#else
+	if (extra_config)
+		priv_handle->hi2c.Init.Timing = extra_config->i2c_timing;
+	else
+		priv_handle->hi2c.Init.Timing = STM32_I2C_DEFAULT_TIMING;
+#endif
+	priv_handle->hi2c.Init.OwnAddress1 = config->address;
+	priv_handle->hi2c.Init.AddressingMode = I2C_ADDRESSINGMODE_7BIT;
+	priv_handle->hi2c.Init.DualAddressMode = I2C_DUALADDRESS_DISABLE;
+	priv_handle->hi2c.Init.OwnAddress2 = 0;
+	priv_handle->hi2c.Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
+	priv_handle->hi2c.Init.NoStretchMode = I2C_NOSTRETCH_DISABLE;
+
+	ret = HAL_I2C_Init(&priv_handle->hi2c);
+	if (ret != HAL_OK) {
+		ret = -EIO;
+		goto error;
+	}
+
+	ret = register_handle_mapping(&priv_handle->hi2c, priv_handle);
+	if (ret)
+		goto error_deinit;
+
+	priv_handle->callback = NULL;
+	priv_handle->callback_arg = NULL;
+	priv_handle->async_in_progress = false;
+
+	*handle = i2c_handle;
+	return 0;
+
+error_deinit:
+	HAL_I2C_DeInit(&priv_handle->hi2c);
+error:
+	if (i2c_handle->init_allocated) {
+		capi_free(priv_handle);
+		capi_free(i2c_handle);
+	}
+	return ret;
+}
+
+/**
+ * @brief Deinitialize the STM32 I2C controller.
+ * @param handle - Pointer to the I2C controller handle.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_i2c_deinit(struct capi_i2c_controller_handle *handle)
+{
+	struct stm32_i2c_priv_handle *priv_handle;
+
+	if (!handle)
+		return -EINVAL;
+
+	priv_handle = handle->priv;
+
+	if (priv_handle) {
+		unregister_handle_mapping(&priv_handle->hi2c);
+		HAL_I2C_DeInit(&priv_handle->hi2c);
+	}
+
+	if (handle->init_allocated) {
+		capi_free(priv_handle);
+		capi_free(handle);
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Synchronous I2C transmit operation.
+ * @param device - Pointer to the I2C device descriptor.
+ * @param transfer - Pointer to the I2C transfer descriptor.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_i2c_transmit(struct capi_i2c_device *device,
+				   struct capi_i2c_transfer *transfer)
+{
+	struct stm32_i2c_priv_handle *priv_handle;
+	HAL_StatusTypeDef hal_ret;
+	uint16_t dev_addr;
+
+	if (!device || !device->controller || !transfer)
+		return -EINVAL;
+
+	if (!transfer->buf && transfer->len > 0)
+		return -EINVAL;
+
+	priv_handle = device->controller->priv;
+	if (!priv_handle)
+		return -EINVAL;
+
+	dev_addr = (transfer->target_addr ? transfer->target_addr : device->address) <<
+		   1;
+
+	if (transfer->sub_address && transfer->sub_address_len > 0) {
+		hal_ret = HAL_I2C_Mem_Write(&priv_handle->hi2c,
+					    dev_addr,
+					    transfer->sub_address[0],
+					    transfer->sub_address_len == 1 ?
+					    I2C_MEMADD_SIZE_8BIT : I2C_MEMADD_SIZE_16BIT,
+					    transfer->buf,
+					    transfer->len,
+					    HAL_MAX_DELAY);
+	} else if (transfer->no_stop) {
+		hal_ret = HAL_I2C_Master_Seq_Transmit_IT(&priv_handle->hi2c,
+				dev_addr,
+				transfer->buf,
+				transfer->len,
+				I2C_FIRST_FRAME);
+		if (hal_ret == HAL_OK) {
+			uint32_t start = HAL_GetTick();
+			while (HAL_I2C_GetState(&priv_handle->hi2c) != HAL_I2C_STATE_READY) {
+				if (HAL_GetTick() - start > STM32_I2C_SEQ_TIMEOUT_MS)
+					return -ETIMEDOUT;
+			}
+		}
+	} else {
+		hal_ret = HAL_I2C_Master_Transmit(&priv_handle->hi2c,
+						  dev_addr,
+						  transfer->buf,
+						  transfer->len,
+						  HAL_MAX_DELAY);
+	}
+
+	switch (hal_ret) {
+	case HAL_OK:
+		return 0;
+	case HAL_BUSY:
+		return -EBUSY;
+	case HAL_TIMEOUT:
+		return -ETIMEDOUT;
+	default:
+		return -EIO;
+	}
+}
+
+/**
+ * @brief Synchronous I2C receive operation.
+ * @param device - Pointer to the I2C device descriptor.
+ * @param transfer - Pointer to the I2C transfer descriptor.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_i2c_receive(struct capi_i2c_device *device,
+				  struct capi_i2c_transfer *transfer)
+{
+	struct stm32_i2c_priv_handle *priv_handle;
+	HAL_StatusTypeDef hal_ret;
+	uint16_t dev_addr;
+
+	if (!device || !device->controller || !transfer)
+		return -EINVAL;
+
+	if (!transfer->buf && transfer->len > 0)
+		return -EINVAL;
+
+	priv_handle = device->controller->priv;
+	if (!priv_handle)
+		return -EINVAL;
+
+	dev_addr = (transfer->target_addr ? transfer->target_addr : device->address) <<
+		   1;
+
+	if (transfer->sub_address && transfer->sub_address_len > 0) {
+		hal_ret = HAL_I2C_Mem_Read(&priv_handle->hi2c,
+					   dev_addr,
+					   transfer->sub_address[0],
+					   transfer->sub_address_len == 1 ?
+					   I2C_MEMADD_SIZE_8BIT : I2C_MEMADD_SIZE_16BIT,
+					   transfer->buf,
+					   transfer->len,
+					   HAL_MAX_DELAY);
+	} else if (transfer->no_stop) {
+		hal_ret = HAL_I2C_Master_Seq_Receive_IT(&priv_handle->hi2c,
+							dev_addr,
+							transfer->buf,
+							transfer->len,
+							I2C_LAST_FRAME);
+		if (hal_ret == HAL_OK) {
+			uint32_t start = HAL_GetTick();
+			while (HAL_I2C_GetState(&priv_handle->hi2c) != HAL_I2C_STATE_READY) {
+				if (HAL_GetTick() - start > STM32_I2C_SEQ_TIMEOUT_MS)
+					return -ETIMEDOUT;
+			}
+		}
+	} else {
+		hal_ret = HAL_I2C_Master_Receive(&priv_handle->hi2c,
+						 dev_addr,
+						 transfer->buf,
+						 transfer->len,
+						 HAL_MAX_DELAY);
+	}
+
+	switch (hal_ret) {
+	case HAL_OK:
+		return 0;
+	case HAL_BUSY:
+		return -EBUSY;
+	case HAL_TIMEOUT:
+		return -ETIMEDOUT;
+	default:
+		return -EIO;
+	}
+}
+
+/**
+ * @brief Register an async event callback for I2C operations.
+ * @param handle - Pointer to the I2C controller handle.
+ * @param callback - User callback function.
+ * @param callback_arg - User callback argument.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_i2c_register_callback(struct capi_i2c_controller_handle
+		*handle,
+		capi_i2c_callback const callback,
+		void *const callback_arg)
+{
+	struct stm32_i2c_priv_handle *priv_handle;
+
+	if (!handle)
+		return -EINVAL;
+
+	priv_handle = handle->priv;
+	priv_handle->callback = callback;
+	priv_handle->callback_arg = callback_arg;
+
+	return 0;
+}
+
+/**
+ * @brief Configure I2C bus speed.
+ * @param handle - Pointer to the I2C controller handle.
+ * @param speed - Desired I2C bus speed mode.
+ * @param duty_cycle - Desired I2C SCLK duty cycle percentage.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_i2c_configure_bus_speed(struct capi_i2c_controller_handle
+		*handle,
+		enum capi_i2c_speed speed,
+		uint8_t duty_cycle)
+{
+	struct stm32_i2c_priv_handle *priv_handle;
+	uint32_t clock_speed;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	priv_handle = handle->priv;
+
+	switch (speed) {
+	case CAPI_I2C_SPEED_STANDARD:
+		clock_speed = STM32_I2C_DEFAULT_CLOCK_HZ;
+		break;
+	case CAPI_I2C_SPEED_FAST:
+		clock_speed = 400000;
+		break;
+	case CAPI_I2C_SPEED_FAST_PLUS:
+		clock_speed = 1000000;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	HAL_I2C_DeInit(&priv_handle->hi2c);
+
+#if defined(STM32F4) || defined(STM32F1) || defined(STM32F2) || defined(STM32L1)
+	priv_handle->hi2c.Init.ClockSpeed = clock_speed;
+	if (duty_cycle > 50)
+		priv_handle->hi2c.Init.DutyCycle = I2C_DUTYCYCLE_16_9;
+	else
+		priv_handle->hi2c.Init.DutyCycle = I2C_DUTYCYCLE_2;
+#else
+	(void)clock_speed;
+	(void)duty_cycle;
+#endif
+
+	if (HAL_I2C_Init(&priv_handle->hi2c) != HAL_OK)
+		return -EIO;
+
+	return 0;
+}
+
+/**
+ * @brief Asynchronous I2C transmit operation.
+ * @param device - Pointer to the I2C device descriptor.
+ * @param transfer - Pointer to the I2C transfer descriptor.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_i2c_transmit_async(struct capi_i2c_device *device,
+		struct capi_i2c_transfer *transfer)
+{
+	struct stm32_i2c_priv_handle *priv_handle;
+	HAL_StatusTypeDef hal_ret;
+	uint16_t dev_addr;
+
+	if (!device || !device->controller || !transfer)
+		return -EINVAL;
+
+	if (!transfer->buf && transfer->len > 0)
+		return -EINVAL;
+
+	priv_handle = device->controller->priv;
+	if (!priv_handle)
+		return -EINVAL;
+
+	if (priv_handle->async_in_progress)
+		return -EBUSY;
+
+	priv_handle->async_in_progress = true;
+	priv_handle->current_transfer = transfer;
+
+	dev_addr = (transfer->target_addr ? transfer->target_addr : device->address) <<
+		   1;
+
+	if (transfer->sub_address && transfer->sub_address_len > 0) {
+		hal_ret = HAL_I2C_Mem_Write_IT(&priv_handle->hi2c,
+					       dev_addr,
+					       transfer->sub_address[0],
+					       transfer->sub_address_len == 1 ?
+					       I2C_MEMADD_SIZE_8BIT : I2C_MEMADD_SIZE_16BIT,
+					       transfer->buf,
+					       transfer->len);
+	} else {
+		hal_ret = HAL_I2C_Master_Transmit_IT(&priv_handle->hi2c,
+						     dev_addr,
+						     transfer->buf,
+						     transfer->len);
+	}
+
+	if (hal_ret != HAL_OK) {
+		priv_handle->async_in_progress = false;
+		priv_handle->current_transfer = NULL;
+		switch (hal_ret) {
+		case HAL_BUSY:
+			return -EBUSY;
+		default:
+			return -EIO;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Asynchronous I2C receive operation.
+ * @param device - Pointer to the I2C device descriptor.
+ * @param transfer - Pointer to the I2C transfer descriptor.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_i2c_receive_async(struct capi_i2c_device *device,
+					struct capi_i2c_transfer *transfer)
+{
+	struct stm32_i2c_priv_handle *priv_handle;
+	HAL_StatusTypeDef hal_ret;
+	uint16_t dev_addr;
+
+	if (!device || !device->controller || !transfer)
+		return -EINVAL;
+
+	if (!transfer->buf && transfer->len > 0)
+		return -EINVAL;
+
+	priv_handle = device->controller->priv;
+	if (!priv_handle)
+		return -EINVAL;
+
+	if (priv_handle->async_in_progress)
+		return -EBUSY;
+
+	priv_handle->async_in_progress = true;
+	priv_handle->current_transfer = transfer;
+
+	dev_addr = (transfer->target_addr ? transfer->target_addr : device->address) <<
+		   1;
+
+	if (transfer->sub_address && transfer->sub_address_len > 0) {
+		hal_ret = HAL_I2C_Mem_Read_IT(&priv_handle->hi2c,
+					      dev_addr,
+					      transfer->sub_address[0],
+					      transfer->sub_address_len == 1 ?
+					      I2C_MEMADD_SIZE_8BIT : I2C_MEMADD_SIZE_16BIT,
+					      transfer->buf,
+					      transfer->len);
+	} else {
+		hal_ret = HAL_I2C_Master_Receive_IT(&priv_handle->hi2c,
+						    dev_addr,
+						    transfer->buf,
+						    transfer->len);
+	}
+
+	if (hal_ret != HAL_OK) {
+		priv_handle->async_in_progress = false;
+		priv_handle->current_transfer = NULL;
+		switch (hal_ret) {
+		case HAL_BUSY:
+			return -EBUSY;
+		default:
+			return -EIO;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Recover the I2C bus by reinitializing the peripheral.
+ * @param handle - Pointer to the I2C controller handle.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_i2c_recover_bus(struct capi_i2c_controller_handle *handle)
+{
+	struct stm32_i2c_priv_handle *priv_handle;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	priv_handle = handle->priv;
+
+	HAL_I2C_DeInit(&priv_handle->hi2c);
+
+	if (HAL_I2C_Init(&priv_handle->hi2c) != HAL_OK)
+		return -EIO;
+
+	return 0;
+}
+
+/**
+ * @brief Register the I2C controller as a target device.
+ * @param handle - Pointer to the I2C controller handle.
+ * @param addr - Target device address (7-bit or 10-bit).
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_i2c_register_target(struct capi_i2c_controller_handle
+		*handle,
+		uint16_t addr)
+{
+	struct stm32_i2c_priv_handle *priv_handle;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	priv_handle = handle->priv;
+
+	HAL_I2C_DeInit(&priv_handle->hi2c);
+
+	priv_handle->hi2c.Init.OwnAddress1 = addr << 1;
+
+	if (HAL_I2C_Init(&priv_handle->hi2c) != HAL_OK)
+		return -EIO;
+
+	return 0;
+}
+
+/**
+ * @brief Unregister the I2C controller from target mode.
+ * @param handle - Pointer to the I2C controller handle.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_i2c_unregister_target(struct capi_i2c_controller_handle
+		*handle)
+{
+	struct stm32_i2c_priv_handle *priv_handle;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	priv_handle = handle->priv;
+
+	HAL_I2C_DeInit(&priv_handle->hi2c);
+
+	priv_handle->hi2c.Init.OwnAddress1 = 0;
+
+	if (HAL_I2C_Init(&priv_handle->hi2c) != HAL_OK)
+		return -EIO;
+
+	return 0;
+}
+
+/**
+ * @brief I2C interrupt service routine handler.
+ * @param handle - Pointer to the I2C controller handle.
+ */
+static void stm32_capi_i2c_isr(void *handle)
+{
+	struct capi_i2c_controller_handle *ctrl_handle;
+	struct stm32_i2c_priv_handle *priv_handle;
+
+	if (!handle)
+		return;
+
+	ctrl_handle = (struct capi_i2c_controller_handle *)handle;
+	priv_handle = ctrl_handle->priv;
+
+	HAL_I2C_EV_IRQHandler(&priv_handle->hi2c);
+	HAL_I2C_ER_IRQHandler(&priv_handle->hi2c);
+}
+
+/**
+ * @brief HAL I2C master transmit complete callback.
+ * @param hi2c - Pointer to the HAL I2C handle.
+ */
+void HAL_I2C_MasterTxCpltCallback(I2C_HandleTypeDef *hi2c)
+{
+	struct stm32_i2c_priv_handle *priv_handle;
+
+	priv_handle = find_priv_handle(hi2c);
+	if (!priv_handle)
+		return;
+
+	priv_handle->async_in_progress = false;
+	priv_handle->current_transfer = NULL;
+
+	if (priv_handle->callback)
+		priv_handle->callback(CAPI_I2C_XFR_DONE, priv_handle->callback_arg, 0);
+}
+
+/**
+ * @brief HAL I2C master receive complete callback.
+ * @param hi2c - Pointer to the HAL I2C handle.
+ */
+void HAL_I2C_MasterRxCpltCallback(I2C_HandleTypeDef *hi2c)
+{
+	struct stm32_i2c_priv_handle *priv_handle;
+
+	priv_handle = find_priv_handle(hi2c);
+	if (!priv_handle)
+		return;
+
+	priv_handle->async_in_progress = false;
+	priv_handle->current_transfer = NULL;
+
+	if (priv_handle->callback)
+		priv_handle->callback(CAPI_I2C_XFR_DONE, priv_handle->callback_arg, 0);
+}
+
+/**
+ * @brief HAL I2C memory transmit complete callback.
+ * @param hi2c - Pointer to the HAL I2C handle.
+ */
+void HAL_I2C_MemTxCpltCallback(I2C_HandleTypeDef *hi2c)
+{
+	struct stm32_i2c_priv_handle *priv_handle;
+
+	priv_handle = find_priv_handle(hi2c);
+	if (!priv_handle)
+		return;
+
+	priv_handle->async_in_progress = false;
+	priv_handle->current_transfer = NULL;
+
+	if (priv_handle->callback)
+		priv_handle->callback(CAPI_I2C_XFR_DONE, priv_handle->callback_arg, 0);
+}
+
+/**
+ * @brief HAL I2C memory receive complete callback.
+ * @param hi2c - Pointer to the HAL I2C handle.
+ */
+void HAL_I2C_MemRxCpltCallback(I2C_HandleTypeDef *hi2c)
+{
+	struct stm32_i2c_priv_handle *priv_handle;
+
+	priv_handle = find_priv_handle(hi2c);
+	if (!priv_handle)
+		return;
+
+	priv_handle->async_in_progress = false;
+	priv_handle->current_transfer = NULL;
+
+	if (priv_handle->callback)
+		priv_handle->callback(CAPI_I2C_XFR_DONE, priv_handle->callback_arg, 0);
+}
+
+/**
+ * @brief HAL I2C error callback.
+ * @param hi2c - Pointer to the HAL I2C handle.
+ */
+void HAL_I2C_ErrorCallback(I2C_HandleTypeDef *hi2c)
+{
+	struct stm32_i2c_priv_handle *priv_handle;
+	enum capi_i2c_async_event event = CAPI_I2C_NAKD;
+	uint32_t error;
+
+	priv_handle = find_priv_handle(hi2c);
+	if (!priv_handle)
+		return;
+
+	priv_handle->async_in_progress = false;
+	priv_handle->current_transfer = NULL;
+
+	error = HAL_I2C_GetError(hi2c);
+
+	if (error & HAL_I2C_ERROR_AF)
+		event = CAPI_I2C_NAKD;
+	else if (error & HAL_I2C_ERROR_ARLO)
+		event = CAPI_I2C_ALOSS;
+	else if (error & HAL_I2C_ERROR_OVR)
+		event = CAPI_I2C_RXOVER;
+
+	if (priv_handle->callback)
+		priv_handle->callback(event, priv_handle->callback_arg, (int)error);
+}
+
+/**
+ * @brief HAL I2C abort complete callback.
+ * @param hi2c - Pointer to the HAL I2C handle.
+ */
+void HAL_I2C_AbortCpltCallback(I2C_HandleTypeDef *hi2c)
+{
+	struct stm32_i2c_priv_handle *priv_handle;
+
+	priv_handle = find_priv_handle(hi2c);
+	if (!priv_handle)
+		return;
+
+	priv_handle->async_in_progress = false;
+	priv_handle->current_transfer = NULL;
+
+	if (priv_handle->callback)
+		priv_handle->callback(CAPI_I2C_NAKD, priv_handle->callback_arg, -ECANCELED);
+}
+
+const struct capi_i2c_ops stm32_capi_i2c_ops = {
+	.init = stm32_capi_i2c_init,
+	.deinit = stm32_capi_i2c_deinit,
+	.transmit = stm32_capi_i2c_transmit,
+	.receive = stm32_capi_i2c_receive,
+	.register_callback = stm32_capi_i2c_register_callback,
+	.configure_bus_speed = stm32_capi_i2c_configure_bus_speed,
+	.transmit_async = stm32_capi_i2c_transmit_async,
+	.receive_async = stm32_capi_i2c_receive_async,
+	.recover_bus = stm32_capi_i2c_recover_bus,
+	.register_target = stm32_capi_i2c_register_target,
+	.unregister_target = stm32_capi_i2c_unregister_target,
+	.isr = stm32_capi_i2c_isr,
+};

--- a/capi/platform/stm32/stm32_capi_i2c.h
+++ b/capi/platform/stm32/stm32_capi_i2c.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef STM32_CAPI_I2C_H_
+#define STM32_CAPI_I2C_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "stm32_hal.h"
+#include "capi_i2c.h"
+
+/**
+ * @struct stm32_i2c_extra_config
+ * @brief STM32 platform specific I2C configuration for CAPI interface
+ */
+struct stm32_i2c_extra_config {
+	/** I2C Handle - can be NULL for auto-init based on identifier */
+	I2C_HandleTypeDef *hi2c;
+	/** I2C Timing (for STM32 families that use timing register) */
+	uint32_t i2c_timing;
+};
+
+/**
+ * @brief STM32 CAPI I2C operations structure
+ */
+extern const struct capi_i2c_ops stm32_capi_i2c_ops;
+
+#endif /* STM32_CAPI_I2C_H_ */

--- a/capi/platform/stm32/stm32_capi_i2c_priv.h
+++ b/capi/platform/stm32/stm32_capi_i2c_priv.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _STM32_CAPI_I2C_PRIV_H_
+#define _STM32_CAPI_I2C_PRIV_H_
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+#include "stm32_capi_i2c.h"
+
+/**
+ * @brief STM32 platform specific I2C private handle
+ */
+struct stm32_i2c_priv_handle {
+	/** I2C HAL Handle */
+	I2C_HandleTypeDef hi2c;
+	/** CAPI callback */
+	capi_i2c_callback callback;
+	/** CAPI callback argument */
+	void *callback_arg;
+	/** Async transfer in progress flag */
+	bool async_in_progress;
+	/** Current transfer for async operations */
+	struct capi_i2c_transfer *current_transfer;
+};
+
+#define CAPI_I2C_CONTROLLER_HANDLE_STM32_INIT() \
+	(&(struct capi_i2c_controller_handle){ \
+		.ops = NULL, \
+		.init_allocated = false, \
+		.priv = &(struct stm32_i2c_priv_handle){0}})
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
+
+#endif /* _STM32_CAPI_I2C_PRIV_H_ */

--- a/capi/platform/stm32/stm32_capi_irq.c
+++ b/capi/platform/stm32/stm32_capi_irq.c
@@ -1,0 +1,691 @@
+/*
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <string.h>
+#include <errno.h>
+#include "stm32_capi_irq.h"
+
+#define STM32_CAPI_IRQ_INVALID	((IRQn_Type)(-1))
+
+/**
+ * @struct stm32_capi_irq_entry
+ * @brief IRQ callback entry
+ */
+struct stm32_capi_irq_entry {
+	/** Callback function */
+	capi_isr_callback_t callback;
+	/** Callback argument */
+	void *arg;
+	/** IRQ enabled flag */
+	bool enabled;
+};
+
+/** IRQ callback table */
+static struct stm32_capi_irq_entry irq_table[STM32_CAPI_IRQ_MAX_IRQS];
+
+/** EXTI line to IRQn mapping */
+static IRQn_Type exti_irq_map[STM32_CAPI_EXTI_MAX_LINES];
+
+/** Controller initialized flag */
+static bool irq_initialized = false;
+
+/** Current priority grouping */
+static uint32_t current_priority_grouping;
+
+/** Default preemption priority */
+static uint32_t default_preempt_priority = 0;
+
+/** Default sub-priority */
+static uint32_t default_sub_priority = 0;
+
+/**
+ * @brief Map GPIO pin number to EXTI IRQn.
+ * @param pin - GPIO pin number (0-15).
+ * @return IRQn_Type for the EXTI line.
+ */
+static IRQn_Type get_exti_irqn(uint16_t pin)
+{
+	if (pin >= STM32_CAPI_EXTI_MAX_LINES)
+		return STM32_CAPI_IRQ_INVALID;
+
+#if defined(STM32F0) || defined(STM32L0) || defined(STM32G0)
+	/* Some STM32 families have combined EXTI handlers */
+	if (pin <= 1)
+		return EXTI0_1_IRQn;
+	else if (pin <= 3)
+		return EXTI2_3_IRQn;
+	else
+		return EXTI4_15_IRQn;
+#elif defined(STM32F1) || defined(STM32F2) || defined(STM32F3) || \
+      defined(STM32F4) || defined(STM32F7) || defined(STM32L1) || \
+      defined(STM32L4) || defined(STM32L5) || defined(STM32H7) || \
+      defined(STM32G4) || defined(STM32WB) || defined(STM32WL) || \
+      defined(STM32U5) || defined(STM32H5)
+	/* Most STM32 families have individual handlers for EXTI0-4 */
+	switch (pin) {
+	case 0:
+		return EXTI0_IRQn;
+	case 1:
+		return EXTI1_IRQn;
+	case 2:
+		return EXTI2_IRQn;
+	case 3:
+		return EXTI3_IRQn;
+	case 4:
+		return EXTI4_IRQn;
+	case 5:
+	case 6:
+	case 7:
+	case 8:
+	case 9:
+		return EXTI9_5_IRQn;
+	default:
+		return EXTI15_10_IRQn;
+	}
+#else
+	/* Fallback for unknown families */
+	return EXTI0_IRQn;
+#endif
+}
+
+/**
+ * @brief Initialize EXTI IRQ mapping table.
+ */
+static void init_exti_irq_map(void)
+{
+	uint16_t i;
+
+	for (i = 0; i < STM32_CAPI_EXTI_MAX_LINES; i++)
+		exti_irq_map[i] = get_exti_irqn(i);
+}
+
+/**
+ * @brief Check if IRQ number is valid.
+ * @param irq - IRQ number.
+ * @return true if valid, false otherwise.
+ */
+static inline bool is_valid_irq(uint32_t irq)
+{
+	return irq < STM32_CAPI_IRQ_MAX_IRQS;
+}
+
+/**
+ * @brief Check if IRQ is an EXTI GPIO interrupt.
+ * @param irq - IRQ number.
+ * @param pin - Pointer to store GPIO pin (0-15) if EXTI.
+ * @return true if EXTI GPIO interrupt, false otherwise.
+ */
+static bool is_exti_gpio_irq(uint32_t irq, uint16_t *pin)
+{
+	uint16_t i;
+
+	for (i = 0; i < STM32_CAPI_EXTI_MAX_LINES; i++) {
+		if ((uint32_t)exti_irq_map[i] == irq) {
+			if (pin)
+				*pin = i;
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * @brief Initialize the STM32 IRQ controller.
+ * @param config - Pointer to the IRQ configuration.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_irq_init(struct capi_irq_config *config)
+{
+	struct stm32_capi_irq_extra_config *extra;
+
+	if (irq_initialized)
+		return 0;
+
+	/* Clear callback table */
+	memset(irq_table, 0, sizeof(irq_table));
+
+	/* Initialize EXTI mapping */
+	init_exti_irq_map();
+
+	/* Apply extra configuration if provided */
+	if (config && config->extra) {
+		extra = (struct stm32_capi_irq_extra_config *)config->extra;
+		current_priority_grouping = extra->priority_grouping;
+		default_preempt_priority = extra->default_preempt_priority;
+		default_sub_priority = extra->default_sub_priority;
+
+		/* Configure NVIC priority grouping */
+		HAL_NVIC_SetPriorityGrouping(current_priority_grouping);
+	} else {
+		/* Use default priority grouping (4 bits preemption, 0 bits sub) */
+		current_priority_grouping = NVIC_PRIORITYGROUP_4;
+		HAL_NVIC_SetPriorityGrouping(current_priority_grouping);
+	}
+
+	irq_initialized = true;
+
+	return 0;
+}
+
+/**
+ * @brief Deinitialize the STM32 IRQ controller.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_irq_deinit(void)
+{
+	uint32_t i;
+
+	if (!irq_initialized)
+		return 0;
+
+	/* Disable all registered IRQs */
+	for (i = 0; i < STM32_CAPI_IRQ_MAX_IRQS; i++) {
+		if (irq_table[i].enabled) {
+			NVIC_DisableIRQ((IRQn_Type)i);
+			irq_table[i].enabled = false;
+		}
+		irq_table[i].callback = NULL;
+		irq_table[i].arg = NULL;
+	}
+
+	irq_initialized = false;
+
+	return 0;
+}
+
+/**
+ * @brief Enable global interrupts.
+ * @return 0 on success.
+ */
+static int stm32_capi_irq_global_enable(void)
+{
+	__enable_irq();
+	return 0;
+}
+
+/**
+ * @brief Disable global interrupts.
+ * @return 0 on success.
+ */
+static int stm32_capi_irq_global_disable(void)
+{
+	__disable_irq();
+	return 0;
+}
+
+/**
+ * @brief Enable a specific IRQ.
+ * @param irq - IRQ number.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_irq_enable(uint32_t irq)
+{
+	if (!irq_initialized)
+		return -ENODEV;
+
+	if (!is_valid_irq(irq))
+		return -EINVAL;
+
+	/* Set default priority if not already configured */
+	if (!irq_table[irq].enabled && !NVIC_GetEnableIRQ((IRQn_Type)irq))
+		HAL_NVIC_SetPriority((IRQn_Type)irq, default_preempt_priority,
+				     default_sub_priority);
+
+	NVIC_EnableIRQ((IRQn_Type)irq);
+	irq_table[irq].enabled = true;
+
+	return 0;
+}
+
+/**
+ * @brief Disable a specific IRQ.
+ * @param irq - IRQ number.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_irq_disable(uint32_t irq)
+{
+	if (!irq_initialized)
+		return -ENODEV;
+
+	if (!is_valid_irq(irq))
+		return -EINVAL;
+
+	NVIC_DisableIRQ((IRQn_Type)irq);
+	irq_table[irq].enabled = false;
+
+	return 0;
+}
+
+/**
+ * @brief Connect an ISR to an IRQ.
+ * @param irq - IRQ number.
+ * @param isr - ISR callback function.
+ * @param arg - Argument passed to ISR.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_irq_connect(uint32_t irq, capi_isr_callback_t isr,
+				  void *arg)
+{
+	if (!irq_initialized)
+		return -ENODEV;
+
+	if (!is_valid_irq(irq))
+		return -EINVAL;
+
+	if (!isr)
+		return -EINVAL;
+
+	/* Store callback info */
+	irq_table[irq].callback = isr;
+	irq_table[irq].arg = arg;
+
+	return 0;
+}
+
+/**
+ * @brief Disconnect an ISR from an IRQ.
+ * @param irq - IRQ number.
+ * @return 0 on success, negative error code otherwise.
+ */
+int stm32_capi_irq_disconnect(uint32_t irq)
+{
+	if (!irq_initialized)
+		return -ENODEV;
+
+	if (!is_valid_irq(irq))
+		return -EINVAL;
+
+	/* Disable IRQ before disconnecting */
+	if (irq_table[irq].enabled) {
+		NVIC_DisableIRQ((IRQn_Type)irq);
+		irq_table[irq].enabled = false;
+	}
+
+	/* Clear callback info */
+	irq_table[irq].callback = NULL;
+	irq_table[irq].arg = NULL;
+
+	return 0;
+}
+
+/**
+ * @brief Clear pending interrupt flag.
+ * @param irq - IRQ number.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_irq_clear_pending(uint32_t irq)
+{
+	if (!irq_initialized)
+		return -ENODEV;
+
+	if (!is_valid_irq(irq))
+		return -EINVAL;
+
+	NVIC_ClearPendingIRQ((IRQn_Type)irq);
+
+	return 0;
+}
+
+/**
+ * @brief Set pending interrupt flag.
+ * @param irq - IRQ number.
+ * @return 0 on success, negative error code otherwise.
+ */
+int stm32_capi_irq_set_pending(uint32_t irq)
+{
+	if (!irq_initialized)
+		return -ENODEV;
+
+	if (!is_valid_irq(irq))
+		return -EINVAL;
+
+	NVIC_SetPendingIRQ((IRQn_Type)irq);
+
+	return 0;
+}
+
+/**
+ * @brief Get IRQ status (active/pending).
+ * @param irq - IRQ number.
+ * @param pactive - Pointer to store status (1=active/pending, 0=inactive).
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_irq_get_status(uint32_t irq, uint32_t *pactive)
+{
+	if (!irq_initialized)
+		return -ENODEV;
+
+	if (!is_valid_irq(irq) || !pactive)
+		return -EINVAL;
+
+	/* Check if IRQ is active or pending */
+	*pactive = NVIC_GetPendingIRQ((IRQn_Type)irq) ||
+		   NVIC_GetActive((IRQn_Type)irq);
+
+	return 0;
+}
+
+/**
+ * @brief Set IRQ priority.
+ * @param irq - IRQ number.
+ * @param priority - Priority value (used as preemption priority).
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_irq_set_priority(uint32_t irq, uint32_t priority)
+{
+	uint32_t preempt_priority;
+	uint32_t sub_priority;
+
+	if (!irq_initialized)
+		return -ENODEV;
+
+	if (!is_valid_irq(irq))
+		return -EINVAL;
+
+	/*
+	 * Priority encoding: upper bits = preemption priority,
+	 * lower bits = sub-priority. The split depends on priority grouping.
+	 * For simplicity, we use priority as preemption priority with 0 sub.
+	 */
+	preempt_priority = priority;
+	sub_priority = 0;
+
+	HAL_NVIC_SetPriority((IRQn_Type)irq, preempt_priority, sub_priority);
+
+	return 0;
+}
+
+/**
+ * @brief Get IRQ priority.
+ * @param irq - IRQ number.
+ * @param priority - Pointer to store priority value.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_irq_get_priority(uint32_t irq, uint32_t *priority)
+{
+	uint32_t preempt_priority;
+	uint32_t sub_priority;
+
+	if (!irq_initialized)
+		return -ENODEV;
+
+	if (!is_valid_irq(irq) || !priority)
+		return -EINVAL;
+
+	HAL_NVIC_GetPriority((IRQn_Type)irq, current_priority_grouping,
+			     &preempt_priority, &sub_priority);
+
+	/* Return preemption priority as the main priority value */
+	*priority = preempt_priority;
+
+	return 0;
+}
+
+/**
+ * @brief Set IRQ trigger level/edge for EXTI lines.
+ * @param irq - IRQ number (must be an EXTI IRQ).
+ * @param trigger - Trigger type.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_irq_set_level_edge_trigger(uint32_t irq,
+		enum capi_irq_trig_level trigger)
+{
+	uint16_t pin;
+	uint32_t line_mask;
+
+	if (!irq_initialized)
+		return -ENODEV;
+
+	if (!is_valid_irq(irq))
+		return -EINVAL;
+
+	/* Check if this is an EXTI GPIO interrupt */
+	if (!is_exti_gpio_irq(irq, &pin))
+		return -ENOTSUP;
+
+	/* Map CAPI trigger level to STM32 GPIO EXTI mode */
+	switch (trigger) {
+	case CAPI_IRQ_EDGE_RISING:
+	case CAPI_IRQ_EDGE_FALLING:
+	case CAPI_IRQ_EDGE_BOTH:
+		break;
+	case CAPI_IRQ_LEVEL_LOW:
+	case CAPI_IRQ_LEVEL_HIGH:
+		/* Level-triggered interrupts not supported on STM32 EXTI */
+		return -ENOTSUP;
+	default:
+		return -EINVAL;
+	}
+
+	line_mask = (1UL << pin);
+
+	/* Configure EXTI trigger through EXTI registers directly */
+#if defined(STM32H7) || defined(STM32L5) || defined(STM32U5) || defined(STM32H5)
+	/* New EXTI architecture with separate registers */
+	EXTI->RTSR1 &= ~line_mask;
+	EXTI->FTSR1 &= ~line_mask;
+
+	if (trigger == CAPI_IRQ_EDGE_RISING || trigger == CAPI_IRQ_EDGE_BOTH)
+		EXTI->RTSR1 |= line_mask;
+
+	if (trigger == CAPI_IRQ_EDGE_FALLING || trigger == CAPI_IRQ_EDGE_BOTH)
+		EXTI->FTSR1 |= line_mask;
+#else
+	/* Legacy EXTI architecture */
+	EXTI->RTSR &= ~line_mask;
+	EXTI->FTSR &= ~line_mask;
+
+	if (trigger == CAPI_IRQ_EDGE_RISING || trigger == CAPI_IRQ_EDGE_BOTH)
+		EXTI->RTSR |= line_mask;
+
+	if (trigger == CAPI_IRQ_EDGE_FALLING || trigger == CAPI_IRQ_EDGE_BOTH)
+		EXTI->FTSR |= line_mask;
+#endif
+
+	return 0;
+}
+
+/**
+ * @brief Check if IRQ is enabled.
+ * @param irq - IRQ number.
+ * @param enabled - Pointer to store enabled status.
+ * @return 0 on success, negative error code otherwise.
+ */
+int stm32_capi_irq_is_enabled(uint32_t irq, bool *enabled)
+{
+	if (!irq_initialized)
+		return -ENODEV;
+
+	if (!is_valid_irq(irq) || !enabled)
+		return -EINVAL;
+
+	*enabled = NVIC_GetEnableIRQ((IRQn_Type)irq) != 0;
+
+	return 0;
+}
+
+/**
+ * @brief Generic IRQ handler that dispatches to registered callbacks.
+ * @param irq - IRQ number.
+ */
+void stm32_capi_irq_handler(uint32_t irq)
+{
+	const struct stm32_capi_irq_entry *entry;
+
+	if (!is_valid_irq(irq))
+		return;
+
+	entry = &irq_table[irq];
+
+	if (entry->callback)
+		entry->callback(entry->arg);
+}
+
+/**
+ * @brief EXTI callback handler for GPIO interrupts.
+ * @param gpio_pin - GPIO pin number (0-15).
+ */
+void stm32_capi_exti_handler(uint16_t gpio_pin)
+{
+	IRQn_Type irq;
+
+	if (gpio_pin >= STM32_CAPI_EXTI_MAX_LINES)
+		return;
+
+	irq = exti_irq_map[gpio_pin];
+	stm32_capi_irq_handler((uint32_t)irq);
+}
+
+/**
+ * @brief HAL GPIO EXTI Callback (weak override).
+ * @param GPIO_Pin - GPIO pin bitmask that triggered the interrupt.
+ *
+ * This overrides the weak HAL_GPIO_EXTI_Callback to dispatch to
+ * registered CAPI callbacks.
+ */
+void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin)
+{
+	uint16_t pin = 0;
+
+	/* Find which pin triggered (GPIO_Pin is a bitmask) */
+	while (GPIO_Pin > 1) {
+		GPIO_Pin >>= 1;
+		pin++;
+	}
+
+	stm32_capi_exti_handler(pin);
+}
+
+/*
+ * CAPI IRQ interface implementation.
+ * These functions are called directly by application code via the
+ * capi_irq.h API. The capi_irq.c wrapper is only used for stub builds.
+ */
+
+/**
+ * @brief Initialize the IRQ controller (CAPI interface).
+ * @param config - Pointer to the IRQ configuration.
+ * @return 0 on success, negative error code otherwise.
+ */
+int capi_irq_init(struct capi_irq_config *config)
+{
+	return stm32_capi_irq_init(config);
+}
+
+/**
+ * @brief Deinitialize the IRQ controller (CAPI interface).
+ * @return 0 on success, negative error code otherwise.
+ */
+int capi_irq_deinit(void)
+{
+	return stm32_capi_irq_deinit();
+}
+
+/**
+ * @brief Enable global interrupts (CAPI interface).
+ * @return 0 on success.
+ */
+int capi_irq_global_enable(void)
+{
+	return stm32_capi_irq_global_enable();
+}
+
+/**
+ * @brief Disable global interrupts (CAPI interface).
+ * @return 0 on success.
+ */
+int capi_irq_global_disable(void)
+{
+	return stm32_capi_irq_global_disable();
+}
+
+/**
+ * @brief Enable a specific IRQ (CAPI interface).
+ * @param irq - IRQ number.
+ * @return 0 on success, negative error code otherwise.
+ */
+int capi_irq_enable(uint32_t irq)
+{
+	return stm32_capi_irq_enable(irq);
+}
+
+/**
+ * @brief Disable a specific IRQ (CAPI interface).
+ * @param irq - IRQ number.
+ * @return 0 on success, negative error code otherwise.
+ */
+int capi_irq_disable(uint32_t irq)
+{
+	return stm32_capi_irq_disable(irq);
+}
+
+/**
+ * @brief Connect an ISR to an IRQ (CAPI interface).
+ * @param irq - IRQ number.
+ * @param isr - ISR callback function.
+ * @param arg - Argument passed to ISR.
+ * @return 0 on success, negative error code otherwise.
+ */
+int capi_irq_connect(uint32_t irq, capi_isr_callback_t isr, void *arg)
+{
+	return stm32_capi_irq_connect(irq, isr, arg);
+}
+
+/**
+ * @brief Clear pending interrupt flag (CAPI interface).
+ * @param irq - IRQ number.
+ * @return 0 on success, negative error code otherwise.
+ */
+int capi_irq_clear_pending(uint32_t irq)
+{
+	return stm32_capi_irq_clear_pending(irq);
+}
+
+/**
+ * @brief Get IRQ status (CAPI interface).
+ * @param irq - IRQ number.
+ * @param pactive - Pointer to store status.
+ * @return 0 on success, negative error code otherwise.
+ */
+int capi_irq_get_status(uint32_t irq, uint32_t *pactive)
+{
+	return stm32_capi_irq_get_status(irq, pactive);
+}
+
+/**
+ * @brief Set IRQ priority (CAPI interface).
+ * @param irq - IRQ number.
+ * @param priority - Priority value.
+ * @return 0 on success, negative error code otherwise.
+ */
+int capi_irq_set_priority(uint32_t irq, uint32_t priority)
+{
+	return stm32_capi_irq_set_priority(irq, priority);
+}
+
+/**
+ * @brief Get IRQ priority (CAPI interface).
+ * @param irq - IRQ number.
+ * @param priority - Pointer to store priority value.
+ * @return 0 on success, negative error code otherwise.
+ */
+int capi_irq_get_priority(uint32_t irq, uint32_t *priority)
+{
+	return stm32_capi_irq_get_priority(irq, priority);
+}
+
+/**
+ * @brief Set IRQ trigger level/edge (CAPI interface).
+ * @param irq - IRQ number.
+ * @param trigger - Trigger type.
+ * @return 0 on success, negative error code otherwise.
+ */
+int capi_irq_set_level_edge_trigger(uint32_t irq,
+				    enum capi_irq_trig_level trigger)
+{
+	return stm32_capi_irq_set_level_edge_trigger(irq, trigger);
+}

--- a/capi/platform/stm32/stm32_capi_irq.h
+++ b/capi/platform/stm32/stm32_capi_irq.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef STM32_CAPI_IRQ_H_
+#define STM32_CAPI_IRQ_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "stm32_hal.h"
+#include "capi_irq.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * @brief Maximum number of external interrupts supported.
+ *
+ * This value should cover all NVIC IRQs for the target MCU.
+ * Most STM32 devices have fewer than 128 interrupts.
+ */
+#ifndef STM32_CAPI_IRQ_MAX_IRQS
+#define STM32_CAPI_IRQ_MAX_IRQS		128
+#endif
+
+/**
+ * @brief Maximum number of EXTI lines supported.
+ *
+ * STM32 devices typically have 16 GPIO EXTI lines (0-15).
+ */
+#define STM32_CAPI_EXTI_MAX_LINES	16
+
+/**
+ * @struct stm32_capi_irq_extra_config
+ * @brief STM32-specific IRQ controller configuration for CAPI interface
+ */
+struct stm32_capi_irq_extra_config {
+	/** Priority group configuration (0-7, see NVIC_SetPriorityGrouping) */
+	uint32_t priority_grouping;
+	/** Default preemption priority for new IRQs */
+	uint32_t default_preempt_priority;
+	/** Default sub-priority for new IRQs */
+	uint32_t default_sub_priority;
+};
+
+/**
+ * @brief Disconnect an ISR from an IRQ.
+ * @param irq - IRQ number.
+ * @return 0 on success, negative error code otherwise.
+ */
+int stm32_capi_irq_disconnect(uint32_t irq);
+
+/**
+ * @brief Set pending interrupt flag.
+ * @param irq - IRQ number.
+ * @return 0 on success, negative error code otherwise.
+ */
+int stm32_capi_irq_set_pending(uint32_t irq);
+
+/**
+ * @brief Check if IRQ is enabled.
+ * @param irq - IRQ number.
+ * @param enabled - Pointer to store enabled status.
+ * @return 0 on success, negative error code otherwise.
+ */
+int stm32_capi_irq_is_enabled(uint32_t irq, bool *enabled);
+
+/**
+ * @brief Generic IRQ handler that dispatches to registered callbacks.
+ * @param irq - IRQ number.
+ *
+ * This can be called from the actual ISR handlers (e.g., EXTI0_IRQHandler)
+ * to dispatch to the registered callback.
+ */
+void stm32_capi_irq_handler(uint32_t irq);
+
+/**
+ * @brief EXTI callback handler for GPIO interrupts.
+ * @param gpio_pin - GPIO pin number (0-15).
+ *
+ * This should be called from HAL_GPIO_EXTI_Callback or directly from
+ * EXTI IRQ handlers.
+ */
+void stm32_capi_exti_handler(uint16_t gpio_pin);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* STM32_CAPI_IRQ_H_ */

--- a/capi/platform/stm32/stm32_capi_pwm.c
+++ b/capi/platform/stm32/stm32_capi_pwm.c
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdlib.h>
+#include <errno.h>
+#include "capi_alloc.h"
+#include "stm32_capi_pwm.h"
+#include "stm32_capi_timer.h"
+
+#ifdef HAL_TIM_MODULE_ENABLED
+
+static int apply_pwm_config(struct stm32_capi_pwm_desc *desc)
+{
+	struct capi_timer_channel_config ch_cfg = {0};
+
+	ch_cfg.mode = CAPI_TIMER_PWM_MODE;
+	ch_cfg.config.pwm.period_ns = desc->period_ns;
+	ch_cfg.config.pwm.active_ns = desc->duty_cycle_ns;
+	ch_cfg.config.pwm.inverted_polarity = desc->inverted_polarity;
+
+	return capi_timer_channel_config(desc->timer, desc->channel, &ch_cfg);
+}
+
+int stm32_capi_pwm_init(struct stm32_capi_pwm_desc **desc,
+			const struct stm32_capi_pwm_config *config)
+{
+	struct stm32_capi_pwm_desc *pwm;
+	struct stm32_capi_timer_extra_config extra = {0};
+	struct capi_timer_config tim_cfg = {0};
+	struct capi_timer_handle *timer = NULL;
+	int ret;
+
+	if (!desc || !config)
+		return -EINVAL;
+
+	if (*desc) {
+		pwm = *desc;
+		pwm->init_allocated = false;
+	} else {
+		pwm = capi_calloc(1, sizeof(*pwm));
+		if (!pwm)
+			return -ENOMEM;
+		pwm->init_allocated = true;
+	}
+
+	if (config->get_input_clock)
+		extra.get_input_clock = config->get_input_clock;
+
+	tim_cfg.ops = &stm32_capi_timer_ops;
+	tim_cfg.identifier = config->timer_id;
+	tim_cfg.input_clock_hz = config->input_clock_hz;
+	tim_cfg.extra = &extra;
+
+	ret = capi_timer_init(&timer, &tim_cfg);
+	if (ret)
+		goto err_free;
+
+	ret = capi_timer_channel_init(timer, config->channel);
+	if (ret)
+		goto err_timer;
+
+	pwm->timer = timer;
+	pwm->channel = config->channel;
+	pwm->period_ns = config->period_ns;
+	pwm->duty_cycle_ns = config->duty_cycle_ns;
+	pwm->inverted_polarity = config->inverted_polarity;
+	pwm->enabled = false;
+
+	ret = apply_pwm_config(pwm);
+	if (ret)
+		goto err_channel;
+
+	*desc = pwm;
+	return 0;
+
+err_channel:
+	capi_timer_channel_deinit(timer, config->channel);
+err_timer:
+	capi_timer_deinit(timer);
+err_free:
+	if (pwm->init_allocated)
+		capi_free(pwm);
+	return ret;
+}
+
+int stm32_capi_pwm_remove(struct stm32_capi_pwm_desc *desc)
+{
+	if (!desc)
+		return -EINVAL;
+
+	if (desc->enabled)
+		capi_timer_channel_disable(desc->timer, desc->channel);
+
+	capi_timer_channel_deinit(desc->timer, desc->channel);
+	capi_timer_stop(desc->timer);
+	capi_timer_deinit(desc->timer);
+	if (desc->init_allocated)
+		capi_free(desc);
+
+	return 0;
+}
+
+int stm32_capi_pwm_enable(struct stm32_capi_pwm_desc *desc)
+{
+	int ret;
+
+	if (!desc)
+		return -EINVAL;
+
+	ret = capi_timer_channel_enable(desc->timer, desc->channel);
+	if (ret)
+		return ret;
+
+	ret = capi_timer_start(desc->timer);
+	if (ret) {
+		capi_timer_channel_disable(desc->timer, desc->channel);
+		return ret;
+	}
+
+	desc->enabled = true;
+	return 0;
+}
+
+int stm32_capi_pwm_disable(struct stm32_capi_pwm_desc *desc)
+{
+	int ret;
+
+	if (!desc)
+		return -EINVAL;
+
+	ret = capi_timer_channel_disable(desc->timer, desc->channel);
+	if (ret)
+		return ret;
+
+	desc->enabled = false;
+	return 0;
+}
+
+int stm32_capi_pwm_set_period(struct stm32_capi_pwm_desc *desc,
+			      uint64_t period_ns)
+{
+	bool was_enabled;
+	int ret;
+
+	if (!desc)
+		return -EINVAL;
+
+	was_enabled = desc->enabled;
+	if (was_enabled) {
+		ret = stm32_capi_pwm_disable(desc);
+		if (ret)
+			return ret;
+	}
+
+	desc->period_ns = period_ns;
+	ret = apply_pwm_config(desc);
+
+	if (was_enabled && !ret)
+		ret = stm32_capi_pwm_enable(desc);
+
+	return ret;
+}
+
+int stm32_capi_pwm_get_period(struct stm32_capi_pwm_desc *desc,
+			      uint64_t *period_ns)
+{
+	if (!desc || !period_ns)
+		return -EINVAL;
+
+	*period_ns = desc->period_ns;
+	return 0;
+}
+
+int stm32_capi_pwm_set_duty_cycle(struct stm32_capi_pwm_desc *desc,
+				  uint64_t duty_cycle_ns)
+{
+	bool was_enabled;
+	int ret;
+
+	if (!desc)
+		return -EINVAL;
+
+	was_enabled = desc->enabled;
+	if (was_enabled) {
+		ret = stm32_capi_pwm_disable(desc);
+		if (ret)
+			return ret;
+	}
+
+	desc->duty_cycle_ns = duty_cycle_ns;
+	ret = apply_pwm_config(desc);
+
+	if (was_enabled && !ret)
+		ret = stm32_capi_pwm_enable(desc);
+
+	return ret;
+}
+
+int stm32_capi_pwm_get_duty_cycle(struct stm32_capi_pwm_desc *desc,
+				  uint64_t *duty_cycle_ns)
+{
+	if (!desc || !duty_cycle_ns)
+		return -EINVAL;
+
+	*duty_cycle_ns = desc->duty_cycle_ns;
+	return 0;
+}
+
+int stm32_capi_pwm_set_polarity(struct stm32_capi_pwm_desc *desc,
+				bool inverted)
+{
+	bool was_enabled;
+	int ret;
+
+	if (!desc)
+		return -EINVAL;
+
+	was_enabled = desc->enabled;
+	if (was_enabled) {
+		ret = stm32_capi_pwm_disable(desc);
+		if (ret)
+			return ret;
+	}
+
+	desc->inverted_polarity = inverted;
+	ret = apply_pwm_config(desc);
+
+	if (was_enabled && !ret)
+		ret = stm32_capi_pwm_enable(desc);
+
+	return ret;
+}
+
+int stm32_capi_pwm_get_polarity(struct stm32_capi_pwm_desc *desc,
+				bool *inverted)
+{
+	if (!desc || !inverted)
+		return -EINVAL;
+
+	*inverted = desc->inverted_polarity;
+	return 0;
+}
+
+#endif /* HAL_TIM_MODULE_ENABLED */

--- a/capi/platform/stm32/stm32_capi_pwm.h
+++ b/capi/platform/stm32/stm32_capi_pwm.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef STM32_CAPI_PWM_H_
+#define STM32_CAPI_PWM_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "stm32_hal.h"
+#include "capi_timer.h"
+
+#ifdef HAL_TIM_MODULE_ENABLED
+
+/**
+ * @struct stm32_capi_pwm_config
+ * @brief Configuration for STM32 CAPI PWM driver
+ *
+ * This driver supports basic TIM-based PWM. Advanced features such as LPTIM,
+ * slave/master timer modes, DMA-driven PWM, complementary channels, and
+ * one-pulse mode are not supported.
+ */
+struct stm32_capi_pwm_config {
+	/** TIM peripheral number (1-17) or base address */
+	uint32_t timer_id;
+	/** Channel index 0-3 (maps to TIM_CHANNEL_1 through TIM_CHANNEL_4) */
+	uint32_t channel;
+	/** PWM period in nanoseconds */
+	uint64_t period_ns;
+	/** Active (high) time in nanoseconds */
+	uint64_t duty_cycle_ns;
+	/** true = idle high / active low, false = idle low / active high */
+	bool inverted_polarity;
+	/** Input clock frequency in Hz (0 = auto-detect from RCC) */
+	uint64_t input_clock_hz;
+	/** Optional function returning the timer input clock (overrides input_clock_hz) */
+	uint32_t (*get_input_clock)(void);
+};
+
+/**
+ * @struct stm32_capi_pwm_desc
+ * @brief Runtime descriptor for an active PWM instance
+ */
+struct stm32_capi_pwm_desc {
+	/** Underlying CAPI timer handle */
+	struct capi_timer_handle *timer;
+	/** Channel index (0-3) */
+	uint32_t channel;
+	/** True if the descriptor was allocated by init */
+	bool init_allocated;
+	/** Current period in nanoseconds */
+	uint64_t period_ns;
+	/** Current duty cycle (active time) in nanoseconds */
+	uint64_t duty_cycle_ns;
+	/** Current polarity setting */
+	bool inverted_polarity;
+	/** Whether the PWM output is currently enabled */
+	bool enabled;
+};
+
+int stm32_capi_pwm_init(struct stm32_capi_pwm_desc **desc,
+			const struct stm32_capi_pwm_config *config);
+
+int stm32_capi_pwm_remove(struct stm32_capi_pwm_desc *desc);
+
+int stm32_capi_pwm_enable(struct stm32_capi_pwm_desc *desc);
+
+int stm32_capi_pwm_disable(struct stm32_capi_pwm_desc *desc);
+
+int stm32_capi_pwm_set_period(struct stm32_capi_pwm_desc *desc,
+			      uint64_t period_ns);
+
+int stm32_capi_pwm_get_period(struct stm32_capi_pwm_desc *desc,
+			      uint64_t *period_ns);
+
+int stm32_capi_pwm_set_duty_cycle(struct stm32_capi_pwm_desc *desc,
+				  uint64_t duty_cycle_ns);
+
+int stm32_capi_pwm_get_duty_cycle(struct stm32_capi_pwm_desc *desc,
+				  uint64_t *duty_cycle_ns);
+
+int stm32_capi_pwm_set_polarity(struct stm32_capi_pwm_desc *desc,
+				bool inverted);
+
+int stm32_capi_pwm_get_polarity(struct stm32_capi_pwm_desc *desc,
+				bool *inverted);
+
+#endif /* HAL_TIM_MODULE_ENABLED */
+
+#endif /* STM32_CAPI_PWM_H_ */

--- a/capi/platform/stm32/stm32_capi_spi.c
+++ b/capi/platform/stm32/stm32_capi_spi.c
@@ -1,0 +1,1633 @@
+/*
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include "stm32_capi_spi_priv.h"
+#include "stm32_capi_gpio_priv.h"
+#include "capi_alloc.h"
+#include "capi_time.h"
+#ifdef HAL_TIM_MODULE_ENABLED
+#include "capi_timer.h"
+#endif
+
+#ifndef max
+#define max(a, b) (((a) > (b)) ? (a) : (b))
+#endif
+
+#define STM32_SPI_CRC_POLYNOMIAL		10
+#define STM32_SPI_DMA_DEFAULT_TIMEOUT_MS	1000
+#define STM32_SPI_GPIO_PINS_PER_PORT		16
+
+/* Forward declarations */
+static int stm32_capi_spi_dma_abort(struct capi_spi_device *device);
+
+/* lookup table for mapping HAL handles to private handles */
+#define MAX_SPI_INSTANCES 8
+static struct {
+	SPI_HandleTypeDef *hspi;
+	struct stm32_spi_priv_handle *priv_handle;
+} spi_handle_lookup[MAX_SPI_INSTANCES];
+static uint8_t spi_handle_count = 0;
+
+/**
+ * @brief Find the private handle associated with a HAL SPI handle.
+ * @param hspi - Pointer to the HAL SPI handle.
+ * @return Pointer to the private handle, or NULL if not found.
+ */
+static struct stm32_spi_priv_handle *find_priv_handle(SPI_HandleTypeDef *hspi)
+{
+	for (uint8_t i = 0; i < spi_handle_count; i++) {
+		if (spi_handle_lookup[i].hspi == hspi) {
+			return spi_handle_lookup[i].priv_handle;
+		}
+	}
+	return NULL;
+}
+
+/**
+ * @brief Register a mapping between a HAL SPI handle and a private handle.
+ * @param hspi - Pointer to the HAL SPI handle.
+ * @param priv_handle - Pointer to the private handle.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int register_handle_mapping(SPI_HandleTypeDef *hspi,
+				   struct stm32_spi_priv_handle *priv_handle)
+{
+	if (spi_handle_count >= MAX_SPI_INSTANCES) {
+		return -ENOMEM;
+	}
+
+	spi_handle_lookup[spi_handle_count].hspi = hspi;
+	spi_handle_lookup[spi_handle_count].priv_handle = priv_handle;
+	spi_handle_count++;
+	return 0;
+}
+
+/**
+ * @brief Unregister the mapping for a HAL SPI handle.
+ * @param hspi - Pointer to the HAL SPI handle.
+ */
+static void unregister_handle_mapping(SPI_HandleTypeDef *hspi)
+{
+	for (uint8_t i = 0; i < spi_handle_count; i++) {
+		if (spi_handle_lookup[i].hspi == hspi) {
+			/* Move last entry to this position */
+			if (i < spi_handle_count - 1) {
+				spi_handle_lookup[i] = spi_handle_lookup[spi_handle_count - 1];
+			}
+			spi_handle_count--;
+			break;
+		}
+	}
+}
+
+/**
+ * @brief Configure SPI peripheral based on device settings.
+ * @param priv_handle - Pointer to the STM32 SPI private handle.
+ * @param device - Pointer to the SPI device descriptor.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_spi_config_peripheral(struct stm32_spi_priv_handle
+		*priv_handle,
+		struct capi_spi_device *device)
+{
+	uint32_t prescaler = 0u;
+	int ret = 0;
+
+	/* Verify SPI instance is configured */
+	if (!priv_handle->hspi.Instance)
+		return -EINVAL;
+
+	/* automatically select prescaler based on max_speed_hz */
+	if (device->max_speed_hz != 0u) {
+		uint32_t div = priv_handle->input_clock / device->max_speed_hz;
+
+		switch (div) {
+		case 0 ... 2:
+			prescaler = SPI_BAUDRATEPRESCALER_2;
+			break;
+		case 3 ... 4:
+			prescaler = SPI_BAUDRATEPRESCALER_4;
+			break;
+		case 5 ... 8:
+			prescaler = SPI_BAUDRATEPRESCALER_8;
+			break;
+		case 9 ... 16:
+			prescaler = SPI_BAUDRATEPRESCALER_16;
+			break;
+		case 17 ... 32:
+			prescaler = SPI_BAUDRATEPRESCALER_32;
+			break;
+		case 33 ... 64:
+			prescaler = SPI_BAUDRATEPRESCALER_64;
+			break;
+		case 65 ... 128:
+			prescaler = SPI_BAUDRATEPRESCALER_128;
+			break;
+		default:
+			prescaler = SPI_BAUDRATEPRESCALER_256;
+			break;
+		}
+	} else {
+		prescaler = SPI_BAUDRATEPRESCALER_64;
+	}
+
+	/* Use the SPI instance that was set during init */
+	priv_handle->hspi.Init.Mode = SPI_MODE_MASTER;
+	priv_handle->hspi.Init.Direction = SPI_DIRECTION_2LINES;
+	priv_handle->hspi.Init.DataSize = SPI_DATASIZE_8BIT;
+	priv_handle->hspi.Init.CLKPolarity = device->mode & CAPI_SPI_CPOL ?
+					     SPI_POLARITY_HIGH :
+					     SPI_POLARITY_LOW;
+	priv_handle->hspi.Init.CLKPhase = device->mode & CAPI_SPI_CPHA ?
+					  SPI_PHASE_2EDGE :
+					  SPI_PHASE_1EDGE;
+	priv_handle->hspi.Init.NSS = SPI_NSS_SOFT;
+	priv_handle->hspi.Init.BaudRatePrescaler = prescaler;
+	priv_handle->hspi.Init.FirstBit = device->lsb_first ?
+					  SPI_FIRSTBIT_LSB :
+					  SPI_FIRSTBIT_MSB;
+	priv_handle->hspi.Init.TIMode = SPI_TIMODE_DISABLE;
+	priv_handle->hspi.Init.CRCCalculation = SPI_CRCCALCULATION_DISABLE;
+	priv_handle->hspi.Init.CRCPolynomial = STM32_SPI_CRC_POLYNOMIAL;
+
+	ret = HAL_SPI_Init(&priv_handle->hspi);
+	if (ret != HAL_OK) {
+		return -EIO;
+	}
+
+#ifdef SPI_SR_TXE
+	__HAL_SPI_ENABLE(&priv_handle->hspi);
+#endif
+
+	return 0;
+}
+
+/**
+ * @brief Get SPI base address from identifier.
+ * @param identifier - SPI peripheral identifier or base address.
+ * @return Pointer to the SPI peripheral, or NULL if invalid.
+ */
+static SPI_TypeDef *get_spi_base_from_identifier(uint64_t identifier)
+{
+	/* If identifier is a base address, use it directly */
+	if (identifier >= PERIPH_BASE) {
+		return (SPI_TypeDef *)identifier;
+	}
+
+	/* Otherwise, map device ID to base address */
+	switch (identifier) {
+#if defined(SPI1)
+	case 1:
+		return SPI1;
+#endif
+#if defined(SPI2)
+	case 2:
+		return SPI2;
+#endif
+#if defined(SPI3)
+	case 3:
+		return SPI3;
+#endif
+#if defined(SPI4)
+	case 4:
+		return SPI4;
+#endif
+#if defined(SPI5)
+	case 5:
+		return SPI5;
+#endif
+#if defined(SPI6)
+	case 6:
+		return SPI6;
+#endif
+	default:
+		return NULL;
+	}
+}
+
+/**
+ * @brief Initialize the STM32 SPI controller.
+ * @param handle - Pointer to store the allocated SPI controller handle.
+ * @param config - Pointer to the SPI configuration.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_spi_init(struct capi_spi_controller_handle **handle,
+			       const struct capi_spi_config *config)
+{
+	struct capi_spi_controller_handle *spi_handle;
+	struct stm32_spi_priv_handle *spi_priv_handle;
+	struct stm32_spi_extra_config *spi_extra_config;
+	SPI_TypeDef *base;
+	int ret = 0;
+
+	if (!handle || !config || !config->extra)
+		return -EINVAL;
+
+	if (*handle == NULL) {
+		spi_handle = (struct capi_spi_controller_handle *)capi_calloc(1,
+				sizeof(*spi_handle));
+		if (!spi_handle)
+			return -ENOMEM;
+
+		spi_priv_handle = (struct stm32_spi_priv_handle *)capi_calloc(1,
+				  sizeof(*spi_priv_handle));
+		if (!spi_priv_handle) {
+			capi_free(spi_handle);
+			return -ENOMEM;
+		}
+
+		spi_handle->priv = spi_priv_handle;
+		spi_handle->init_allocated = true;
+	} else {
+		spi_handle = *handle;
+		spi_handle->init_allocated = false;
+
+		if (!spi_handle->priv)
+			return -EINVAL;
+
+		spi_priv_handle = spi_handle->priv;
+	}
+
+	spi_handle->ops = config->ops;
+
+	spi_extra_config = config->extra;
+
+	/* Set up SPI instance */
+	if (spi_extra_config && spi_extra_config->hspi) {
+		spi_priv_handle->hspi = *spi_extra_config->hspi;
+	} else {
+		/* Auto-configure based on identifier */
+		base = get_spi_base_from_identifier(config->identifier);
+		if (!base) {
+			ret = -EINVAL;
+			goto error;
+		}
+		spi_priv_handle->hspi.Instance = base;
+	}
+
+	/* Initialize other fields */
+	spi_priv_handle->callback = NULL;
+	spi_priv_handle->callback_arg = NULL;
+	spi_priv_handle->current_transfer = NULL;
+	spi_priv_handle->async_in_progress = false;
+	spi_priv_handle->dma_done = false;
+
+	if (spi_extra_config) {
+		if (spi_extra_config->get_input_clock)
+			spi_priv_handle->input_clock = spi_extra_config->get_input_clock();
+		else
+			spi_priv_handle->input_clock = config->clk_freq_hz;
+
+		spi_priv_handle->alternate = spi_extra_config->alternate;
+
+		/* Set up DMA if provided */
+		if (spi_extra_config->dma_handle) {
+			spi_priv_handle->dma_handle = spi_extra_config->dma_handle;
+
+			/* Initialize DMA channels if configured */
+			if (spi_extra_config->rxdma_ch_id != 0) {
+				ret = capi_dma_init_chan(spi_priv_handle->dma_handle,
+							 &spi_priv_handle->rxdma_ch,
+							 spi_extra_config->rxdma_ch_id);
+				if (ret)
+					goto error;
+			}
+
+			if (spi_extra_config->txdma_ch_id != 0) {
+				ret = capi_dma_init_chan(spi_priv_handle->dma_handle,
+							 &spi_priv_handle->txdma_ch,
+							 spi_extra_config->txdma_ch_id);
+				if (ret)
+					goto error;
+			}
+		}
+
+#ifdef HAL_TIM_MODULE_ENABLED
+		/* Store timer handles for PWM-based CS/TX control */
+		if (spi_extra_config->cs_timer) {
+			spi_priv_handle->cs_timer = spi_extra_config->cs_timer;
+			spi_priv_handle->cs_timer_channel = spi_extra_config->cs_timer_channel;
+
+			ret = capi_timer_channel_disable(spi_priv_handle->cs_timer,
+							 spi_priv_handle->cs_timer_channel);
+			if (ret)
+				goto error;
+		}
+		if (spi_extra_config->tx_timer) {
+			spi_priv_handle->tx_timer = spi_extra_config->tx_timer;
+			spi_priv_handle->tx_timer_channel = spi_extra_config->tx_timer_channel;
+
+			ret = capi_timer_channel_disable(spi_priv_handle->tx_timer,
+							 spi_priv_handle->tx_timer_channel);
+			if (ret)
+				goto error;
+		}
+#endif
+	} else {
+		spi_priv_handle->input_clock = config->clk_freq_hz;
+	}
+
+	/* Register handle mapping for callbacks */
+	ret = register_handle_mapping(&spi_priv_handle->hspi, spi_priv_handle);
+	if (ret != 0) {
+		goto error;
+	}
+
+	*handle = spi_handle;
+	return 0;
+
+error:
+	if (spi_handle->init_allocated) {
+		capi_free(spi_priv_handle);
+		capi_free(spi_handle);
+	}
+	return ret;
+}
+
+/**
+ * @brief Deinitialize the STM32 SPI controller and free resources.
+ * @param handle - Pointer to the SPI controller handle.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_spi_deinit(struct capi_spi_controller_handle *handle)
+{
+	struct stm32_spi_priv_handle *spi_priv_handle;
+
+	if (!handle)
+		return -EINVAL;
+
+	spi_priv_handle = handle->priv;
+
+	if (spi_priv_handle) {
+#ifdef HAL_TIM_MODULE_ENABLED
+		if (spi_priv_handle->cs_timer)
+			capi_timer_channel_disable(spi_priv_handle->cs_timer,
+						   spi_priv_handle->cs_timer_channel);
+		if (spi_priv_handle->tx_timer)
+			capi_timer_channel_disable(spi_priv_handle->tx_timer,
+						   spi_priv_handle->tx_timer_channel);
+#endif
+
+		/* Clean up DMA channels */
+		if (spi_priv_handle->rxdma_ch) {
+			capi_dma_deinit_chan(spi_priv_handle->rxdma_ch);
+			spi_priv_handle->rxdma_ch = NULL;
+		}
+		if (spi_priv_handle->txdma_ch) {
+			capi_dma_deinit_chan(spi_priv_handle->txdma_ch);
+			spi_priv_handle->txdma_ch = NULL;
+		}
+
+#ifdef SPI_SR_TXE
+		__HAL_SPI_DISABLE(&spi_priv_handle->hspi);
+#endif
+		HAL_SPI_DeInit(&spi_priv_handle->hspi);
+
+		/* Unregister handle mapping */
+		unregister_handle_mapping(&spi_priv_handle->hspi);
+
+		/* Clean up CAPI GPIO for CS */
+		if (spi_priv_handle->cs_initialized) {
+			capi_gpio_port_deinit(&spi_priv_handle->cs_port_handle);
+			spi_priv_handle->cs_initialized = false;
+		}
+	}
+
+	if (handle->init_allocated) {
+		capi_free(handle->priv);
+		capi_free(handle);
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Setup GPIO CS pin for the device using CAPI GPIO.
+ * @param priv_handle - Pointer to the STM32 SPI private handle.
+ * @param device - Pointer to the SPI device descriptor.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int setup_cs_gpio(struct stm32_spi_priv_handle *priv_handle,
+			 struct capi_spi_device *device)
+{
+	struct stm32_spi_device_extra *dev_extra = device->extra;
+	struct capi_gpio_port_config port_config;
+	int ret;
+
+	if (!dev_extra || !dev_extra->chip_select_port)
+		return 0; /* No CS setup needed */
+
+	/* Skip if already initialized */
+	if (priv_handle->cs_initialized)
+		return 0;
+
+	/* Configure GPIO port for CS pin */
+	priv_handle->cs_gpio_config.mode = GPIO_MODE_OUTPUT_PP;
+	priv_handle->cs_gpio_config.speed = GPIO_SPEED_FREQ_LOW;
+	priv_handle->cs_gpio_config.pull = GPIO_NOPULL;
+	priv_handle->cs_gpio_config.alternate = 0;
+
+	/* Initialize GPIO port */
+	port_config.ops = &stm32_capi_gpio_ops;
+	port_config.identifier = dev_extra->chip_select_port;
+	port_config.num_pins = STM32_SPI_GPIO_PINS_PER_PORT;
+	port_config.flags = NULL;
+	port_config.extra = &priv_handle->cs_gpio_config;
+
+	ret = capi_gpio_port_init(&priv_handle->cs_port_handle, &port_config);
+	if (ret)
+		return ret;
+
+	/* Configure chip select pin */
+	priv_handle->chip_select.port_handle = priv_handle->cs_port_handle;
+	priv_handle->chip_select.number = dev_extra->chip_select_pin;
+	priv_handle->chip_select.flags = CAPI_GPIO_ACTIVE_LOW; /* CS is active low */
+
+	/* Set CS as output */
+	ret = capi_gpio_pin_set_direction(&priv_handle->chip_select, CAPI_GPIO_OUTPUT);
+	if (ret) {
+		capi_gpio_port_deinit(&priv_handle->cs_port_handle);
+		return ret;
+	}
+
+	/* Set CS high (inactive) - using raw value since ACTIVE_LOW flag is set */
+	ret = capi_gpio_pin_set_raw_value(&priv_handle->chip_select, CAPI_GPIO_HIGH);
+	if (ret) {
+		capi_gpio_port_deinit(&priv_handle->cs_port_handle);
+		return ret;
+	}
+
+	priv_handle->cs_initialized = true;
+	return 0;
+}
+
+/**
+ * @brief Perform SPI transfer with proper CS control and timing.
+ * @param priv_handle - Pointer to the STM32 SPI private handle.
+ * @param device - Pointer to the SPI device descriptor.
+ * @param transfer - Pointer to the transfer descriptor.
+ * @param assert_cs - Whether to assert CS before transfer.
+ * @param deassert_cs - Whether to deassert CS after transfer.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int perform_spi_transfer_with_cs(struct stm32_spi_priv_handle
+					*priv_handle,
+					struct capi_spi_device *device,
+					struct capi_spi_transfer *transfer,
+					bool assert_cs, bool deassert_cs)
+{
+	struct stm32_spi_device_extra *dev_extra = device->extra;
+	uint64_t slave_id;
+	static uint64_t last_slave_id = 0;
+	int ret = 0;
+	HAL_StatusTypeDef hal_ret;
+
+	/* Compute slave ID for configuration optimization */
+	slave_id = ((uint64_t)(uintptr_t)priv_handle->hspi.Instance << 32) |
+		   (device->cs_gpio ? device->cs_gpio->number : device->native_cs);
+
+	if (slave_id != last_slave_id) {
+		last_slave_id = slave_id;
+		ret = stm32_capi_spi_config_peripheral(priv_handle, device);
+		if (ret)
+			return ret;
+	}
+
+	/* Assert CS if requested (drive low for active-low CS) */
+	if (assert_cs && priv_handle->cs_initialized) {
+		capi_gpio_pin_set_raw_value(&priv_handle->chip_select, CAPI_GPIO_LOW);
+	}
+
+	/* CS delay first */
+	if (dev_extra && dev_extra->cs_delay_first) {
+		capi_wait_us(dev_extra->cs_delay_first);
+	}
+
+	/* Use HAL functions for reliable operation */
+	if (transfer->tx_buf && transfer->rx_buf) {
+		uint32_t xfer_len = max(transfer->tx_size, transfer->rx_size);
+		uint32_t timeout_val = transfer->timeout > 0 ?
+				       transfer->timeout : HAL_MAX_DELAY;
+
+		if (transfer->tx_size == transfer->rx_size) {
+			hal_ret = HAL_SPI_TransmitReceive(&priv_handle->hspi,
+							  (uint8_t *)transfer->tx_buf,
+							  transfer->rx_buf,
+							  xfer_len, timeout_val);
+		} else {
+			uint8_t *tmp_tx = capi_calloc(1, xfer_len);
+			uint8_t *tmp_rx = capi_calloc(1, xfer_len);
+
+			if (!tmp_tx || !tmp_rx) {
+				capi_free(tmp_tx);
+				capi_free(tmp_rx);
+				ret = -ENOMEM;
+				goto cs_deassert;
+			}
+			memcpy(tmp_tx, transfer->tx_buf, transfer->tx_size);
+			hal_ret = HAL_SPI_TransmitReceive(&priv_handle->hspi,
+							  tmp_tx, tmp_rx,
+							  xfer_len, timeout_val);
+			if (hal_ret == HAL_OK)
+				memcpy(transfer->rx_buf, tmp_rx, transfer->rx_size);
+			capi_free(tmp_tx);
+			capi_free(tmp_rx);
+		}
+	} else if (transfer->tx_buf) {
+		hal_ret = HAL_SPI_Transmit(&priv_handle->hspi,
+					   (uint8_t *)transfer->tx_buf,
+					   transfer->tx_size,
+					   transfer->timeout > 0 ? transfer->timeout : HAL_MAX_DELAY);
+	} else {
+		uint8_t *zero_tx = capi_calloc(1, transfer->rx_size);
+
+		if (!zero_tx) {
+			ret = -ENOMEM;
+			goto cs_deassert;
+		}
+		hal_ret = HAL_SPI_TransmitReceive(&priv_handle->hspi,
+						  zero_tx, transfer->rx_buf,
+						  transfer->rx_size,
+						  transfer->timeout > 0 ? transfer->timeout : HAL_MAX_DELAY);
+		capi_free(zero_tx);
+	}
+
+	if (hal_ret != HAL_OK) {
+		if (hal_ret == HAL_TIMEOUT)
+			ret = -ETIMEDOUT;
+		else
+			ret = -EIO;
+	}
+
+cs_deassert:
+	/* CS delay last */
+	if (dev_extra && dev_extra->cs_delay_last) {
+		capi_wait_us(dev_extra->cs_delay_last);
+	}
+
+	/* Deassert CS if requested (drive high for active-low CS) */
+	if (deassert_cs && priv_handle->cs_initialized) {
+		capi_gpio_pin_set_raw_value(&priv_handle->chip_select, CAPI_GPIO_HIGH);
+	}
+
+	/* CS change delay */
+	if (dev_extra && dev_extra->cs_change_delay) {
+		capi_wait_us(dev_extra->cs_change_delay);
+	}
+
+	return ret;
+}
+
+/**
+ * @brief Perform a synchronous SPI transceive operation.
+ * @param device - Pointer to the SPI device descriptor.
+ * @param transfer - Pointer to the transfer descriptor.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_spi_transceive(struct capi_spi_device *device,
+				     struct capi_spi_transfer *transfer)
+{
+	struct stm32_spi_priv_handle *priv_handle;
+	int ret;
+
+	if (!device || !device->controller || !transfer)
+		return -EINVAL;
+
+	priv_handle = device->controller->priv;
+
+	/* Set up CS GPIO if needed */
+	ret = setup_cs_gpio(priv_handle, device);
+	if (ret)
+		return ret;
+
+	/* Perform the transfer with CS control */
+	return perform_spi_transfer_with_cs(priv_handle, device, transfer, true, true);
+}
+
+/**
+ * @brief Perform an asynchronous SPI transceive operation using interrupts.
+ * @param device - Pointer to the SPI device descriptor.
+ * @param transfer - Pointer to the transfer descriptor.
+ * @param timeout - Timeout value in milliseconds.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_spi_transceive_async(struct capi_spi_device *device,
+		struct capi_spi_transfer *transfer,
+		int timeout)
+{
+	struct stm32_spi_priv_handle *priv_handle;
+	struct stm32_spi_device_extra *dev_extra;
+	HAL_StatusTypeDef hal_ret;
+	int ret;
+
+	if (!device || !device->controller || !transfer)
+		return -EINVAL;
+
+	priv_handle = device->controller->priv;
+	dev_extra = device->extra;
+
+	if (priv_handle->async_in_progress)
+		return -EBUSY;
+
+	/* Set up CS GPIO if needed */
+	ret = setup_cs_gpio(priv_handle, device);
+	if (ret)
+		return ret;
+
+	/* Configure SPI for this device */
+	ret = stm32_capi_spi_config_peripheral(priv_handle, device);
+	if (ret)
+		return ret;
+
+	priv_handle->current_transfer = transfer;
+	priv_handle->async_in_progress = true;
+
+	/* Assert CS (drive low for active-low CS) */
+	if (priv_handle->cs_initialized)
+		capi_gpio_pin_set_raw_value(&priv_handle->chip_select, CAPI_GPIO_LOW);
+
+	/* CS delay first */
+	if (dev_extra && dev_extra->cs_delay_first)
+		capi_wait_us(dev_extra->cs_delay_first);
+
+	if (transfer->tx_buf && transfer->rx_buf) {
+		hal_ret = HAL_SPI_TransmitReceive_IT(&priv_handle->hspi,
+						     (uint8_t *)transfer->tx_buf,
+						     transfer->rx_buf,
+						     max(transfer->tx_size, transfer->rx_size));
+	} else if (transfer->tx_buf) {
+		hal_ret = HAL_SPI_Transmit_IT(&priv_handle->hspi,
+					      (uint8_t *)transfer->tx_buf,
+					      transfer->tx_size);
+	} else if (transfer->rx_buf) {
+		hal_ret = HAL_SPI_Receive_IT(&priv_handle->hspi,
+					     transfer->rx_buf,
+					     transfer->rx_size);
+	} else {
+		priv_handle->async_in_progress = false;
+		/* Deassert CS on error */
+		if (priv_handle->cs_initialized)
+			capi_gpio_pin_set_raw_value(&priv_handle->chip_select, CAPI_GPIO_HIGH);
+		return -EINVAL;
+	}
+
+	if (hal_ret != HAL_OK) {
+		priv_handle->async_in_progress = false;
+		priv_handle->current_transfer = NULL;
+		/* Deassert CS on error */
+		if (priv_handle->cs_initialized)
+			capi_gpio_pin_set_raw_value(&priv_handle->chip_select, CAPI_GPIO_HIGH);
+		switch (hal_ret) {
+		case HAL_BUSY:
+			return -EBUSY;
+		case HAL_ERROR:
+			return -EIO;
+		default:
+			return -EIO;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Perform a synchronous SPI read command (TX then RX).
+ * @param device - Pointer to the SPI device descriptor.
+ * @param transfer - Pointer to the transfer descriptor.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_spi_read_command(struct capi_spi_device *device,
+				       struct capi_spi_transfer *transfer)
+{
+	struct stm32_spi_priv_handle *priv_handle;
+	struct stm32_spi_device_extra *dev_extra;
+	HAL_StatusTypeDef hal_ret;
+	int ret = 0;
+
+	if (!device || !device->controller || !transfer)
+		return -EINVAL;
+
+	priv_handle = device->controller->priv;
+	dev_extra = device->extra;
+
+	/* Set up CS GPIO if needed */
+	ret = setup_cs_gpio(priv_handle, device);
+	if (ret)
+		return ret;
+
+	/* Configure SPI for this device */
+	ret = stm32_capi_spi_config_peripheral(priv_handle, device);
+	if (ret)
+		return ret;
+
+	/* Assert CS (drive low for active-low CS) */
+	if (priv_handle->cs_initialized)
+		capi_gpio_pin_set_raw_value(&priv_handle->chip_select, CAPI_GPIO_LOW);
+
+	/* CS delay first */
+	if (dev_extra && dev_extra->cs_delay_first)
+		capi_wait_us(dev_extra->cs_delay_first);
+
+	/* First transmit command/address */
+	if (transfer->tx_buf && transfer->tx_size > 0) {
+		hal_ret = HAL_SPI_Transmit(&priv_handle->hspi,
+					   (uint8_t *)transfer->tx_buf,
+					   transfer->tx_size,
+					   transfer->timeout > 0 ? transfer->timeout : HAL_MAX_DELAY);
+		if (hal_ret != HAL_OK) {
+			switch (hal_ret) {
+			case HAL_BUSY:
+				ret = -EBUSY;
+				break;
+			case HAL_TIMEOUT:
+				ret = -ETIMEDOUT;
+				break;
+			default:
+				ret = -EIO;
+				break;
+			}
+			goto deassert_cs;
+		}
+	}
+
+	/* Then receive data */
+	if (transfer->rx_buf && transfer->rx_size > 0) {
+		hal_ret = HAL_SPI_Receive(&priv_handle->hspi,
+					  transfer->rx_buf,
+					  transfer->rx_size,
+					  transfer->timeout > 0 ? transfer->timeout : HAL_MAX_DELAY);
+		switch (hal_ret) {
+		case HAL_OK:
+			break;
+		case HAL_BUSY:
+			ret = -EBUSY;
+			break;
+		case HAL_TIMEOUT:
+			ret = -ETIMEDOUT;
+			break;
+		default:
+			ret = -EIO;
+			break;
+		}
+	}
+
+deassert_cs:
+	/* CS delay last */
+	if (dev_extra && dev_extra->cs_delay_last)
+		capi_wait_us(dev_extra->cs_delay_last);
+
+	/* Deassert CS (drive high for active-low CS) */
+	if (priv_handle->cs_initialized)
+		capi_gpio_pin_set_raw_value(&priv_handle->chip_select, CAPI_GPIO_HIGH);
+
+	/* CS change delay */
+	if (dev_extra && dev_extra->cs_change_delay)
+		capi_wait_us(dev_extra->cs_change_delay);
+
+	return ret;
+}
+
+/**
+ * @brief Perform an asynchronous SPI read command using interrupts.
+ * @param device - Pointer to the SPI device descriptor.
+ * @param transfer - Pointer to the transfer descriptor.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_spi_read_command_async(struct capi_spi_device *device,
+		struct capi_spi_transfer *transfer)
+{
+	struct stm32_spi_priv_handle *priv_handle;
+	struct stm32_spi_device_extra *dev_extra;
+	HAL_StatusTypeDef hal_ret;
+	int ret;
+
+	if (!device || !device->controller || !transfer)
+		return -EINVAL;
+
+	priv_handle = device->controller->priv;
+	dev_extra = device->extra;
+
+	if (priv_handle->async_in_progress)
+		return -EBUSY;
+
+	/* Set up CS GPIO if needed */
+	ret = setup_cs_gpio(priv_handle, device);
+	if (ret)
+		return ret;
+
+	/* Configure SPI for this device */
+	ret = stm32_capi_spi_config_peripheral(priv_handle, device);
+	if (ret)
+		return ret;
+
+	priv_handle->current_transfer = transfer;
+	priv_handle->async_in_progress = true;
+
+	/* Assert CS (drive low for active-low CS) */
+	if (priv_handle->cs_initialized)
+		capi_gpio_pin_set_raw_value(&priv_handle->chip_select, CAPI_GPIO_LOW);
+
+	/* CS delay first */
+	if (dev_extra && dev_extra->cs_delay_first)
+		capi_wait_us(dev_extra->cs_delay_first);
+
+	if (transfer->tx_buf && transfer->tx_size > 0) {
+		hal_ret = HAL_SPI_Transmit_IT(&priv_handle->hspi,
+					      (uint8_t *)transfer->tx_buf,
+					      transfer->tx_size);
+	} else if (transfer->rx_buf && transfer->rx_size > 0) {
+		hal_ret = HAL_SPI_Receive_IT(&priv_handle->hspi,
+					     transfer->rx_buf,
+					     transfer->rx_size);
+	} else {
+		priv_handle->async_in_progress = false;
+		/* Deassert CS on error */
+		if (priv_handle->cs_initialized)
+			capi_gpio_pin_set_raw_value(&priv_handle->chip_select, CAPI_GPIO_HIGH);
+		return -EINVAL;
+	}
+
+	if (hal_ret != HAL_OK) {
+		priv_handle->async_in_progress = false;
+		priv_handle->current_transfer = NULL;
+		/* Deassert CS on error */
+		if (priv_handle->cs_initialized)
+			capi_gpio_pin_set_raw_value(&priv_handle->chip_select, CAPI_GPIO_HIGH);
+		switch (hal_ret) {
+		case HAL_BUSY:
+			return -EBUSY;
+		case HAL_ERROR:
+			return -EIO;
+		default:
+			return -EIO;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Abort an ongoing asynchronous SPI operation.
+ * @param device - Pointer to the SPI device descriptor.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_spi_abort_async(struct capi_spi_device *device)
+{
+	struct stm32_spi_priv_handle *priv_handle;
+	HAL_StatusTypeDef hal_ret;
+	int ret = 0;
+
+	if (!device || !device->controller)
+		return -EINVAL;
+
+	priv_handle = device->controller->priv;
+
+	if (!priv_handle->async_in_progress)
+		return 0;
+
+	/* Abort DMA transfers if they are active */
+	if (priv_handle->dma_handle && (priv_handle->rxdma_ch
+					|| priv_handle->txdma_ch)) {
+		ret = stm32_capi_spi_dma_abort(device);
+		if (ret)
+			return ret;
+	}
+
+	hal_ret = HAL_SPI_Abort_IT(&priv_handle->hspi);
+
+	if (hal_ret != HAL_OK) {
+		/*
+		 * HAL_SPI_Abort_IT failed — HAL_SPI_AbortCpltCallback was NOT
+		 * called, so clean up and fire the callback.
+		 */
+		if (priv_handle->cs_initialized)
+			capi_gpio_pin_set_raw_value(&priv_handle->chip_select,
+						    CAPI_GPIO_HIGH);
+		priv_handle->async_in_progress = false;
+		priv_handle->current_transfer = NULL;
+
+		if (priv_handle->callback)
+			priv_handle->callback(CAPI_SPI_EVENT_ERROR,
+					      priv_handle->callback_arg,
+					      -ECANCELED);
+		return -EIO;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Register a callback for SPI events.
+ * @param handle - Pointer to the SPI controller handle.
+ * @param callback - Callback function to register.
+ * @param callback_arg - User context passed to the callback.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_spi_register_callback(struct capi_spi_controller_handle
+		*handle,
+		capi_spi_callback_t const callback,
+		void *callback_arg)
+{
+	struct stm32_spi_priv_handle *priv_handle;
+
+	if (!handle)
+		return -EINVAL;
+
+	priv_handle = handle->priv;
+	priv_handle->callback = callback;
+	priv_handle->callback_arg = callback_arg;
+
+	return 0;
+}
+
+/**
+ * @brief Manually control the chip select line.
+ * @param device - Pointer to the SPI device descriptor.
+ * @param cs_control - CS control mode (auto, assert, deassert).
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_spi_set_cs(struct capi_spi_device *device,
+				 enum capi_spi_cs_control cs_control)
+{
+	struct stm32_spi_priv_handle *priv_handle;
+
+	if (!device || !device->controller)
+		return -EINVAL;
+
+	priv_handle = device->controller->priv;
+
+	if (!priv_handle->cs_initialized)
+		return -ENOSYS;
+
+	switch (cs_control) {
+	case CAPI_SPI_CS_AUTO:
+		/* HAL handles CS automatically - nothing to do */
+		break;
+	case CAPI_SPI_CS_MANUAL_ASSERT:
+		/* Assert CS (drive low for active-low CS) */
+		capi_gpio_pin_set_raw_value(&priv_handle->chip_select, CAPI_GPIO_LOW);
+		break;
+	case CAPI_SPI_CS_MANUAL_DEASSERT:
+		/* Deassert CS (drive high for active-low CS) */
+		capi_gpio_pin_set_raw_value(&priv_handle->chip_select, CAPI_GPIO_HIGH);
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief SPI interrupt service routine handler.
+ * @param handle - Pointer to the SPI controller handle.
+ */
+static void stm32_capi_spi_isr(void *handle)
+{
+	struct capi_spi_controller_handle *controller_handle = (struct
+			capi_spi_controller_handle *)handle;
+	struct stm32_spi_priv_handle *priv_handle;
+
+	if (!controller_handle)
+		return;
+
+	priv_handle = controller_handle->priv;
+	HAL_SPI_IRQHandler(&priv_handle->hspi);
+}
+
+/**
+ * @brief Transfer multiple SPI messages in sequence.
+ * @param device - Pointer to the SPI device descriptor.
+ * @param transfers - Array of transfer descriptors.
+ * @param transfer_count - Number of transfers.
+ * @return 0 on success, negative error code otherwise.
+ */
+int stm32_capi_spi_transfer_multiple(struct capi_spi_device *device,
+				     struct capi_spi_transfer *transfers,
+				     uint32_t transfer_count)
+{
+	struct stm32_spi_priv_handle *priv_handle;
+	int ret;
+
+	if (!device || !device->controller || !transfers || !transfer_count)
+		return -EINVAL;
+
+	priv_handle = device->controller->priv;
+
+	/* Set up CS GPIO if needed */
+	ret = setup_cs_gpio(priv_handle, device);
+	if (ret)
+		return ret;
+
+	for (uint32_t i = 0; i < transfer_count; i++) {
+		bool assert_cs = (i == 0);
+		bool deassert_cs = (i == transfer_count - 1);
+
+		ret = perform_spi_transfer_with_cs(priv_handle, device, &transfers[i],
+						   assert_cs, deassert_cs);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Enable or disable alternate function mode for the CS pin.
+ * @param device - Pointer to the SPI device descriptor.
+ * @param enable - true for alternate function, false for GPIO mode.
+ * @return 0 on success, negative error code otherwise.
+ */
+int stm32_capi_spi_alternate_cs_enable(struct capi_spi_device *device,
+				       bool enable)
+{
+	struct stm32_spi_priv_handle *priv_handle;
+	struct stm32_capi_gpio_port_priv *gpio_priv;
+	struct stm32_spi_device_extra *dev_extra;
+	GPIO_InitTypeDef gpio_config;
+	int ret;
+
+	if (!device || !device->controller)
+		return -EINVAL;
+
+	priv_handle = device->controller->priv;
+	dev_extra = device->extra;
+
+	if (!priv_handle->cs_initialized)
+		return -ENOSYS;
+
+	if (!dev_extra)
+		return -EINVAL;
+
+	/* Get GPIO port private data for direct HAL access */
+	gpio_priv = priv_handle->cs_port_handle->priv;
+
+	/* Configure GPIO for alternate function or regular output */
+	gpio_config.Pin = (1 << (priv_handle->chip_select.number));
+	gpio_config.Pull = GPIO_NOPULL;
+	gpio_config.Speed = GPIO_SPEED_FREQ_LOW;
+
+	if (enable) {
+		gpio_config.Mode = GPIO_MODE_AF_PP;
+		gpio_config.Alternate = priv_handle->alternate;
+	} else {
+		gpio_config.Mode = GPIO_MODE_OUTPUT_PP;
+		gpio_config.Alternate = 0;
+	}
+
+	HAL_GPIO_Init(gpio_priv->port, &gpio_config);
+
+	/* Set CS high (inactive) when in GPIO mode */
+	if (!enable) {
+		ret = capi_gpio_pin_set_raw_value(&priv_handle->chip_select, CAPI_GPIO_HIGH);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief DMA completion callback for SPI transfers.
+ * @param event - DMA event identifier.
+ * @param ctx - User context (pointer to the SPI device).
+ */
+static void stm32_capi_spi_dma_callback(uint32_t event, void *ctx)
+{
+	struct capi_spi_device *device = (struct capi_spi_device *)ctx;
+	struct stm32_spi_priv_handle *priv_handle = device->controller->priv;
+
+	/* if more xfers pending dont do anything */
+	if (priv_handle->current_transfer_index < priv_handle->transfer_count - 1)
+		return;
+
+#ifdef HAL_TIM_MODULE_ENABLED
+	if (priv_handle->cs_timer)
+		capi_timer_channel_disable(priv_handle->cs_timer,
+					   priv_handle->cs_timer_channel);
+
+	if (priv_handle->tx_timer)
+		capi_timer_channel_disable(priv_handle->tx_timer,
+					   priv_handle->tx_timer_channel);
+#endif
+
+	/* Perform abort SPI transfers */
+	stm32_capi_spi_abort_async(device);
+
+	priv_handle->dma_done = true;
+
+	if (priv_handle->dma_user_cb)
+		priv_handle->dma_user_cb(priv_handle->dma_user_ctx);
+}
+
+/**
+ * @brief Configure and start DMA transfers.
+ * @param device - Pointer to the SPI device descriptor.
+ * @param transfers - Array of transfer descriptors.
+ * @param transfer_count - Number of transfers.
+ * @param completion_callback - Callback invoked on DMA completion.
+ * @param callback_ctx - User context passed to the callback.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_config_dma_and_start(struct capi_spi_device *device,
+		struct capi_spi_transfer *transfers,
+		uint32_t transfer_count,
+		capi_dma_xfer_complete_cb completion_callback,
+		void *callback_ctx)
+{
+	struct stm32_spi_priv_handle *priv_handle = device->controller->priv;
+	struct capi_dma_transfer *rx_ch_xfer;
+	struct capi_dma_transfer *tx_ch_xfer;
+	SPI_TypeDef *SPIx = priv_handle->hspi.Instance;
+	int ret;
+	uint32_t i;
+
+	if (!device || !transfers || !priv_handle->dma_handle)
+		return -EINVAL;
+
+	if (!priv_handle->rxdma_ch || !priv_handle->txdma_ch)
+		return -EINVAL;
+
+	rx_ch_xfer = capi_calloc(transfer_count, sizeof(*rx_ch_xfer));
+	if (!rx_ch_xfer)
+		return -ENOMEM;
+
+	tx_ch_xfer = capi_calloc(transfer_count, sizeof(*tx_ch_xfer));
+	if (!tx_ch_xfer) {
+		ret = -ENOMEM;
+		goto free_rx_ch_xfer;
+	}
+
+	for (i = 0; i < transfer_count; i++) {
+		/* Configure TX DMA transfer */
+		tx_ch_xfer[i].src = (capi_dma_glbl_addr_t)transfers[i].tx_buf;
+#ifndef SPI_SR_TXE
+		tx_ch_xfer[i].dst = (capi_dma_glbl_addr_t) & (SPIx->TXDR);
+#else
+		tx_ch_xfer[i].dst = (capi_dma_glbl_addr_t) & (SPIx->DR);
+#endif
+		tx_ch_xfer[i].xfer_type = CAPI_DMA_MEM_TO_DEV;
+		tx_ch_xfer[i].src_inc = CAPI_DMA_BYTE_INCREMENT;
+		tx_ch_xfer[i].dst_inc = CAPI_DMA_NO_INCREMENT;
+		tx_ch_xfer[i].length = transfers[i].tx_size;
+
+		/* Configure RX DMA transfer */
+		rx_ch_xfer[i].dst = (capi_dma_glbl_addr_t)transfers[i].rx_buf;
+#ifndef SPI_SR_RXNE
+		rx_ch_xfer[i].src = (capi_dma_glbl_addr_t) & (SPIx->RXDR);
+#else
+		rx_ch_xfer[i].src = (capi_dma_glbl_addr_t) & (SPIx->DR);
+#endif
+		rx_ch_xfer[i].xfer_type = CAPI_DMA_DEV_TO_MEM;
+		rx_ch_xfer[i].src_inc = CAPI_DMA_NO_INCREMENT;
+		rx_ch_xfer[i].dst_inc = CAPI_DMA_BYTE_INCREMENT;
+		rx_ch_xfer[i].length = transfers[i].rx_size;
+	}
+
+	priv_handle->tx_ch_xfer = tx_ch_xfer;
+	priv_handle->rx_ch_xfer = rx_ch_xfer;
+	priv_handle->transfer_count = transfer_count;
+	priv_handle->current_transfer_index = 0;
+
+	/* Register completion callback on the RX DMA channel */
+	if (completion_callback) {
+		ret = capi_dma_register_complete_callback(priv_handle->rxdma_ch,
+				completion_callback,
+				callback_ctx);
+		if (ret)
+			goto cleanup_dma;
+	}
+
+	/* Configure RX DMA channel */
+	ret = capi_dma_config_xfer(priv_handle->rxdma_ch, &rx_ch_xfer[0]);
+	if (ret)
+		goto cleanup_dma;
+
+	/* Configure TX DMA channel */
+	ret = capi_dma_config_xfer(priv_handle->txdma_ch, &tx_ch_xfer[0]);
+	if (ret)
+		goto cleanup_dma;
+
+	/* Start TX DMA transfer */
+	ret = capi_dma_xfer_start(priv_handle->txdma_ch);
+	if (ret)
+		goto abort_transfer;
+
+	/* Start RX DMA transfer */
+	ret = capi_dma_xfer_start(priv_handle->rxdma_ch);
+	if (ret)
+		goto abort_transfer;
+
+	/* Enable SPI DMA requests */
+	if (priv_handle->txdma_ch) {
+#if defined (STM32H5)
+		SET_BIT(priv_handle->hspi.Instance->CFG1, SPI_CFG1_TXDMAEN);
+#else
+		SET_BIT(priv_handle->hspi.Instance->CR2, SPI_CR2_TXDMAEN);
+#endif
+	}
+
+	if (priv_handle->rxdma_ch) {
+#if defined (STM32H5)
+		SET_BIT(priv_handle->hspi.Instance->CFG1, SPI_CFG1_RXDMAEN);
+#else
+		SET_BIT(priv_handle->hspi.Instance->CR2, SPI_CR2_RXDMAEN);
+#endif
+	}
+
+#ifdef HAL_TIM_MODULE_ENABLED
+	if (priv_handle->cs_timer) {
+		stm32_capi_spi_alternate_cs_enable(device, true);
+		ret = capi_timer_channel_enable(priv_handle->cs_timer,
+						priv_handle->cs_timer_channel);
+		if (ret)
+			goto abort_transfer;
+		ret = capi_timer_start(priv_handle->cs_timer);
+		if (ret)
+			goto abort_transfer;
+	}
+	if (priv_handle->tx_timer) {
+		ret = capi_timer_channel_enable(priv_handle->tx_timer,
+						priv_handle->tx_timer_channel);
+		if (ret)
+			goto abort_transfer;
+		ret = capi_timer_start(priv_handle->tx_timer);
+		if (ret)
+			goto abort_transfer;
+	}
+#endif
+
+	return 0;
+
+abort_transfer:
+	capi_dma_xfer_abort(priv_handle->txdma_ch);
+	capi_dma_xfer_abort(priv_handle->rxdma_ch);
+cleanup_dma:
+	capi_free(tx_ch_xfer);
+	priv_handle->tx_ch_xfer = NULL;
+free_rx_ch_xfer:
+	capi_free(rx_ch_xfer);
+	priv_handle->rx_ch_xfer = NULL;
+	return ret;
+}
+
+/**
+ * @brief Abort DMA transfers and free associated resources.
+ * @param device - Pointer to the SPI device descriptor.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_spi_dma_abort(struct capi_spi_device *device)
+{
+	struct stm32_spi_priv_handle *priv_handle;
+	SPI_TypeDef *SPIx;
+	int ret = 0;
+
+	if (!device || !device->controller)
+		return -EINVAL;
+
+	priv_handle = device->controller->priv;
+	if (!priv_handle)
+		return -EINVAL;
+
+	SPIx = priv_handle->hspi.Instance;
+
+	if (priv_handle->rxdma_ch) {
+		ret = capi_dma_xfer_abort(priv_handle->rxdma_ch);
+		if (ret)
+			return ret;
+
+#if defined (STM32H5)
+		CLEAR_BIT(SPIx->CFG1, SPI_CFG1_RXDMAEN);
+#else
+		CLEAR_BIT(SPIx->CR2, SPI_CR2_RXDMAEN);
+#endif
+	}
+
+	if (priv_handle->txdma_ch) {
+		ret = capi_dma_xfer_abort(priv_handle->txdma_ch);
+		if (ret)
+			return ret;
+
+#if defined (STM32H5)
+		CLEAR_BIT(SPIx->CFG1, SPI_CFG1_TXDMAEN);
+#else
+		CLEAR_BIT(SPIx->CR2, SPI_CR2_TXDMAEN);
+#endif
+	}
+
+	/* Dummy read to clear any pending read on SPI */
+#ifndef SPI_SR_RXNE
+	*(volatile uint8_t *)&SPIx->RXDR;
+#else
+	*(volatile uint8_t *)&SPIx->DR;
+#endif
+
+	/* Free the allocated memory for tx and rx transfers */
+	capi_free(priv_handle->tx_ch_xfer);
+	capi_free(priv_handle->rx_ch_xfer);
+	priv_handle->tx_ch_xfer = NULL;
+	priv_handle->rx_ch_xfer = NULL;
+
+	/* put CS pin back into gpio mode */
+	stm32_capi_spi_alternate_cs_enable(device, false);
+
+	return 0;
+}
+
+/**
+ * @brief Perform an asynchronous single DMA transfer.
+ * @param device - Pointer to the SPI device descriptor.
+ * @param transfer - Pointer to the transfer descriptor.
+ * @param callback - Completion callback.
+ * @param callback_arg - Callback argument.
+ * @return 0 on success, negative error code otherwise.
+ */
+int stm32_capi_spi_transfer_dma_async(struct capi_spi_device *device,
+				      struct capi_spi_transfer *transfer,
+				      void (*callback)(void*),
+				      void* callback_arg)
+{
+	return stm32_capi_spi_transfer_multiple_dma_async(device, transfer, 1, callback,
+			callback_arg);
+}
+
+/**
+ * @brief Perform a synchronous single DMA transfer.
+ * @param device - Pointer to the SPI device descriptor.
+ * @param transfer - Pointer to the transfer descriptor.
+ * @return 0 on success, negative error code otherwise.
+ */
+int stm32_capi_spi_transfer_dma(struct capi_spi_device *device,
+				struct capi_spi_transfer *transfer)
+{
+	return stm32_capi_spi_transfer_multiple_dma(device, transfer, 1);
+}
+
+/**
+ * @brief Perform an asynchronous multi-transfer DMA operation.
+ * @param device - Pointer to the SPI device descriptor.
+ * @param transfers - Array of transfer descriptors.
+ * @param transfer_count - Number of transfers.
+ * @param callback - Completion callback.
+ * @param callback_arg - Callback argument.
+ * @return 0 on success, negative error code otherwise.
+ */
+int stm32_capi_spi_transfer_multiple_dma_async(struct capi_spi_device *device,
+		struct capi_spi_transfer *transfers,
+		uint32_t transfer_count,
+		void (*callback)(void*),
+		void* callback_arg)
+{
+	struct stm32_spi_priv_handle *priv_handle;
+
+	if (!device || !device->controller || !transfers || !transfer_count)
+		return -EINVAL;
+
+	priv_handle = device->controller->priv;
+
+	priv_handle->dma_user_cb = callback;
+	priv_handle->dma_user_ctx = callback_arg;
+
+	return stm32_capi_config_dma_and_start(device, transfers, transfer_count,
+					       stm32_capi_spi_dma_callback, device);
+}
+
+/**
+ * @brief Perform a synchronous multi-transfer DMA operation.
+ * @param device - Pointer to the SPI device descriptor.
+ * @param transfers - Array of transfer descriptors.
+ * @param transfer_count - Number of transfers.
+ * @return 0 on success, negative error code otherwise.
+ */
+int stm32_capi_spi_transfer_multiple_dma(struct capi_spi_device *device,
+		struct capi_spi_transfer *transfers,
+		uint32_t transfer_count)
+{
+	struct stm32_spi_priv_handle *priv_handle;
+	uint32_t timeout;
+	int ret;
+
+	if (!device || !device->controller || !transfers || !transfer_count)
+		return -EINVAL;
+
+	priv_handle = device->controller->priv;
+
+	priv_handle->dma_done = false;
+	ret = stm32_capi_config_dma_and_start(device, transfers, transfer_count,
+					      stm32_capi_spi_dma_callback, device);
+	if (ret)
+		return ret;
+
+	/* Wait for completion with timeout */
+	timeout = transfers[0].tx_size + transfers[0].rx_size;
+	if (timeout == 0)
+		timeout = STM32_SPI_DMA_DEFAULT_TIMEOUT_MS;
+
+	while (timeout) {
+		timeout--;
+		capi_wait_ms(1);
+		if (priv_handle->dma_done)
+			break;
+	}
+
+	if (!timeout) {
+		stm32_capi_spi_dma_abort(device);
+		return -ETIMEDOUT;
+	}
+
+	return 0;
+}
+
+const struct capi_spi_ops stm32_capi_spi_ops = {
+	.init = stm32_capi_spi_init,
+	.deinit = stm32_capi_spi_deinit,
+	.transceive = stm32_capi_spi_transceive,
+	.transceive_async = stm32_capi_spi_transceive_async,
+	.read_command = stm32_capi_spi_read_command,
+	.read_command_async = stm32_capi_spi_read_command_async,
+	.abort_async = stm32_capi_spi_abort_async,
+	.register_callback = stm32_capi_spi_register_callback,
+	.set_cs = stm32_capi_spi_set_cs,
+	.isr = stm32_capi_spi_isr,
+};
+
+const struct stm32_capi_spi_extended_ops stm32_capi_spi_extended_ops = {
+	.base_ops = {
+		.init = stm32_capi_spi_init,
+		.deinit = stm32_capi_spi_deinit,
+		.transceive = stm32_capi_spi_transceive,
+		.transceive_async = stm32_capi_spi_transceive_async,
+		.read_command = stm32_capi_spi_read_command,
+		.read_command_async = stm32_capi_spi_read_command_async,
+		.abort_async = stm32_capi_spi_abort_async,
+		.register_callback = stm32_capi_spi_register_callback,
+		.set_cs = stm32_capi_spi_set_cs,
+		.isr = stm32_capi_spi_isr,
+	},
+	.transfer_dma = stm32_capi_spi_transfer_dma,
+	.transfer_dma_async = stm32_capi_spi_transfer_dma_async,
+	.transfer_multiple_dma = stm32_capi_spi_transfer_multiple_dma,
+	.transfer_multiple_dma_async = stm32_capi_spi_transfer_multiple_dma_async,
+	.alternate_cs_enable = stm32_capi_spi_alternate_cs_enable,
+};
+
+/**
+ * @brief HAL SPI TX complete callback.
+ * @param hspi - Pointer to the HAL SPI handle.
+ */
+void HAL_SPI_TxCpltCallback(SPI_HandleTypeDef *hspi)
+{
+	struct stm32_spi_priv_handle *priv_handle;
+	struct capi_spi_transfer *transfer;
+
+	priv_handle = find_priv_handle(hspi);
+	if (!priv_handle) {
+		return;
+	}
+
+	transfer = priv_handle->current_transfer;
+
+	/* For read command async, check if we need to start RX phase */
+	if (transfer && transfer->rx_buf && transfer->rx_size > 0
+	    && transfer->tx_size > 0) {
+		/* Start RX phase for read command */
+		HAL_StatusTypeDef hal_ret = HAL_SPI_Receive_IT(hspi, transfer->rx_buf,
+					    transfer->rx_size);
+		if (hal_ret != HAL_OK) {
+			/* Error in RX phase - deassert CS */
+			if (priv_handle->cs_initialized)
+				capi_gpio_pin_set_raw_value(&priv_handle->chip_select, CAPI_GPIO_HIGH);
+			priv_handle->async_in_progress = false;
+			priv_handle->current_transfer = NULL;
+			if (priv_handle->callback) {
+				priv_handle->callback(CAPI_SPI_EVENT_ERROR,
+						      priv_handle->callback_arg,
+						      -EIO);
+			}
+		}
+		return;
+	}
+
+	/* TX complete - deassert CS */
+	if (priv_handle->cs_initialized)
+		capi_gpio_pin_set_raw_value(&priv_handle->chip_select, CAPI_GPIO_HIGH);
+
+	priv_handle->async_in_progress = false;
+	priv_handle->current_transfer = NULL;
+
+	if (priv_handle->callback) {
+		priv_handle->callback(CAPI_SPI_EVENT_XFR_DONE,
+				      priv_handle->callback_arg,
+				      0);
+	}
+}
+
+/**
+ * @brief HAL SPI RX complete callback.
+ * @param hspi - Pointer to the HAL SPI handle.
+ */
+void HAL_SPI_RxCpltCallback(SPI_HandleTypeDef *hspi)
+{
+	struct stm32_spi_priv_handle *priv_handle;
+
+	priv_handle = find_priv_handle(hspi);
+	if (!priv_handle) {
+		return;
+	}
+
+	/* RX complete - deassert CS */
+	if (priv_handle->cs_initialized)
+		capi_gpio_pin_set_raw_value(&priv_handle->chip_select, CAPI_GPIO_HIGH);
+
+	priv_handle->async_in_progress = false;
+	priv_handle->current_transfer = NULL;
+
+	if (priv_handle->callback) {
+		priv_handle->callback(CAPI_SPI_EVENT_XFR_DONE,
+				      priv_handle->callback_arg,
+				      0);
+	}
+}
+
+/**
+ * @brief HAL SPI TX/RX complete callback.
+ * @param hspi - Pointer to the HAL SPI handle.
+ */
+void HAL_SPI_TxRxCpltCallback(SPI_HandleTypeDef *hspi)
+{
+	struct stm32_spi_priv_handle *priv_handle;
+
+	priv_handle = find_priv_handle(hspi);
+	if (!priv_handle) {
+		return;
+	}
+
+	/* TxRx complete - deassert CS */
+	if (priv_handle->cs_initialized)
+		capi_gpio_pin_set_raw_value(&priv_handle->chip_select, CAPI_GPIO_HIGH);
+
+	priv_handle->async_in_progress = false;
+	priv_handle->current_transfer = NULL;
+
+	if (priv_handle->callback) {
+		priv_handle->callback(CAPI_SPI_EVENT_XFR_DONE,
+				      priv_handle->callback_arg,
+				      0);
+	}
+}
+
+/**
+ * @brief HAL SPI error callback.
+ * @param hspi - Pointer to the HAL SPI handle.
+ */
+void HAL_SPI_ErrorCallback(SPI_HandleTypeDef *hspi)
+{
+	struct stm32_spi_priv_handle *priv_handle;
+
+	priv_handle = find_priv_handle(hspi);
+	if (!priv_handle) {
+		return;
+	}
+
+	/* Error - deassert CS */
+	if (priv_handle->cs_initialized)
+		capi_gpio_pin_set_raw_value(&priv_handle->chip_select, CAPI_GPIO_HIGH);
+
+	priv_handle->async_in_progress = false;
+	priv_handle->current_transfer = NULL;
+
+	if (priv_handle->callback) {
+		priv_handle->callback(CAPI_SPI_EVENT_ERROR,
+				      priv_handle->callback_arg,
+				      -EIO);
+	}
+}
+
+/**
+ * @brief HAL SPI abort complete callback.
+ * @param hspi - Pointer to the HAL SPI handle.
+ */
+void HAL_SPI_AbortCpltCallback(SPI_HandleTypeDef *hspi)
+{
+	struct stm32_spi_priv_handle *priv_handle;
+
+	priv_handle = find_priv_handle(hspi);
+	if (!priv_handle)
+		return;
+
+	if (priv_handle->cs_initialized)
+		capi_gpio_pin_set_raw_value(&priv_handle->chip_select, CAPI_GPIO_HIGH);
+
+	priv_handle->async_in_progress = false;
+	priv_handle->current_transfer = NULL;
+
+	if (priv_handle->callback)
+		priv_handle->callback(CAPI_SPI_EVENT_ERROR,
+				      priv_handle->callback_arg, 0);
+}

--- a/capi/platform/stm32/stm32_capi_spi.h
+++ b/capi/platform/stm32/stm32_capi_spi.h
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _STM32_CAPI_SPI_H_
+#define _STM32_CAPI_SPI_H_
+
+#include "stm32_hal.h"
+#include "capi_spi.h"
+#include "capi_dma.h"
+#include "capi_gpio.h"
+#include "stm32_capi_gpio.h"
+#ifdef HAL_TIM_MODULE_ENABLED
+#include "capi_timer.h"
+#endif
+
+/**
+ * @brief STM32 SPI extra configuration for CAPI interface
+ */
+struct stm32_spi_extra_config {
+	/** SPI Handle - can be NULL for auto-init based on identifier */
+	SPI_HandleTypeDef *hspi;
+	/** Chip select port */
+	uint32_t chip_select_port;
+	/** Get peripheral source clock function */
+	uint32_t (*get_input_clock)(void);
+	/** Chip select alternate function */
+	uint32_t alternate;
+	/** DMA Handle for async operations */
+	struct capi_dma_handle *dma_handle;
+	/** RX DMA Channel ID */
+	uint32_t rxdma_ch_id;
+	/** TX DMA Channel ID */
+	uint32_t txdma_ch_id;
+	/** SPI interrupt number */
+	uint32_t irq_num;
+#ifdef HAL_TIM_MODULE_ENABLED
+	/** CS timer handle for PWM-based CS control */
+	struct capi_timer_handle *cs_timer;
+	/** CS timer channel number */
+	uint32_t cs_timer_channel;
+	/** TX timer handle for PWM-based TX clocking */
+	struct capi_timer_handle *tx_timer;
+	/** TX timer channel number */
+	uint32_t tx_timer_channel;
+#endif
+};
+
+/**
+ * @brief STM32 SPI device extra configuration for device-specific settings
+ */
+struct stm32_spi_device_extra {
+	/** GPIO CS port for manual CS control */
+	uint32_t chip_select_port;
+	/** GPIO CS pin number */
+	uint32_t chip_select_pin;
+	/** CS delay timings */
+	uint16_t cs_delay_first;
+	uint16_t cs_delay_last;
+	uint16_t cs_change_delay;
+};
+
+extern const struct capi_spi_ops stm32_capi_spi_ops;
+
+/**
+ * @brief Extended STM32 SPI operations structure with DMA support
+ */
+struct stm32_capi_spi_extended_ops {
+	struct capi_spi_ops base_ops;
+	int (*transfer_dma)(struct capi_spi_device *device,
+			    struct capi_spi_transfer *transfer);
+	int (*transfer_dma_async)(struct capi_spi_device *device,
+				  struct capi_spi_transfer *transfer,
+				  void (*callback)(void*),
+				  void* callback_arg);
+	int (*transfer_multiple_dma)(struct capi_spi_device *device,
+				     struct capi_spi_transfer *transfers,
+				     uint32_t transfer_count);
+	int (*transfer_multiple_dma_async)(struct capi_spi_device *device,
+					   struct capi_spi_transfer *transfers,
+					   uint32_t transfer_count,
+					   void (*callback)(void*),
+					   void* callback_arg);
+	int (*alternate_cs_enable)(struct capi_spi_device *device, bool enable);
+};
+
+extern const struct stm32_capi_spi_extended_ops stm32_capi_spi_extended_ops;
+
+/* Extended CAPI functions for STM32-specific features */
+
+/**
+ * @brief Transfer multiple messages in sequence (like stm32_spi_transfer)
+ * @param device - The SPI device descriptor
+ * @param transfers - Array of transfer descriptors
+ * @param transfer_count - Number of transfers
+ * @return 0 in case of success, error codes otherwise
+ */
+int stm32_capi_spi_transfer_multiple(struct capi_spi_device *device,
+				     struct capi_spi_transfer *transfers,
+				     uint32_t transfer_count);
+
+/**
+ * @brief Async transfer single message using DMA
+ * @param device - The SPI device descriptor
+ * @param transfer - Transfer descriptor
+ * @param callback - Completion callback
+ * @param callback_arg - Callback argument
+ * @return 0 in case of success, error codes otherwise
+ */
+int stm32_capi_spi_transfer_dma_async(struct capi_spi_device *device,
+				      struct capi_spi_transfer *transfer,
+				      void (*callback)(void*),
+				      void* callback_arg);
+
+/**
+ * @brief Sync transfer single message using DMA
+ * @param device - The SPI device descriptor
+ * @param transfer - Transfer descriptor
+ * @return 0 in case of success, error codes otherwise
+ */
+int stm32_capi_spi_transfer_dma(struct capi_spi_device *device,
+				struct capi_spi_transfer *transfer);
+
+/**
+ * @brief Async transfer multiple messages using DMA
+ * @param device - The SPI device descriptor
+ * @param transfers - Array of transfer descriptors
+ * @param transfer_count - Number of transfers
+ * @param callback - Completion callback
+ * @param callback_arg - Callback argument
+ * @return 0 in case of success, error codes otherwise
+ */
+int stm32_capi_spi_transfer_multiple_dma_async(struct capi_spi_device *device,
+		struct capi_spi_transfer *transfers,
+		uint32_t transfer_count,
+		void (*callback)(void*),
+		void* callback_arg);
+
+/**
+ * @brief Sync transfer multiple messages using DMA
+ * @param device - The SPI device descriptor
+ * @param transfers - Array of transfer descriptors
+ * @param transfer_count - Number of transfers
+ * @return 0 in case of success, error codes otherwise
+ */
+int stm32_capi_spi_transfer_multiple_dma(struct capi_spi_device *device,
+		struct capi_spi_transfer *transfers,
+		uint32_t transfer_count);
+
+/**
+ * @brief Enable/disable alternate function for CS pin
+ * @param device - The SPI device descriptor
+ * @param enable - true for alternate function, false for GPIO mode
+ * @return 0 in case of success, error codes otherwise
+ */
+int stm32_capi_spi_alternate_cs_enable(struct capi_spi_device *device,
+				       bool enable);
+
+#endif /* _STM32_CAPI_SPI_H_ */

--- a/capi/platform/stm32/stm32_capi_spi_priv.h
+++ b/capi/platform/stm32/stm32_capi_spi_priv.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _STM32_CAPI_SPI_PRIV_H_
+#define _STM32_CAPI_SPI_PRIV_H_
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+#include "stm32_capi_spi.h"
+
+/**
+ * @brief STM32 SPI private handle with full feature support
+ */
+struct stm32_spi_priv_handle {
+	/** SPI HAL Handle */
+	SPI_HandleTypeDef hspi;
+	/** SPI input clock frequency */
+	uint32_t input_clock;
+	/** Chip select alternate function */
+	uint32_t alternate;
+	/** Chip select GPIO port handle */
+	struct capi_gpio_port_handle *cs_port_handle;
+	/** Chip select GPIO pin descriptor */
+	struct capi_gpio_pin chip_select;
+	/** DMA handle for async operations */
+	struct capi_dma_handle *dma_handle;
+	/** RX DMA Channel */
+	struct capi_dma_chan *rxdma_ch;
+	/** TX DMA Channel */
+	struct capi_dma_chan *txdma_ch;
+	/** CAPI callback */
+	capi_spi_callback_t callback;
+	/** CAPI callback argument */
+	void *callback_arg;
+	/** Current transfer */
+	struct capi_spi_transfer *current_transfer;
+	/** Transfer queue */
+	struct capi_spi_transfer *transfer_queue;
+	/** Number of transfers */
+	uint32_t transfer_count;
+	/** Current transfer index */
+	uint32_t current_transfer_index;
+	/** Async transfer in progress flag */
+	bool async_in_progress;
+	/** DMA completion flag */
+	bool dma_done;
+	/** DMA user callback */
+	void (*dma_user_cb)(void *ctx);
+	/** DMA user callback context */
+	void *dma_user_ctx;
+	/** TX DMA transfer descriptors */
+	struct capi_dma_transfer *tx_ch_xfer;
+	/** RX DMA transfer descriptors */
+	struct capi_dma_transfer *rx_ch_xfer;
+#ifdef HAL_TIM_MODULE_ENABLED
+	/** Timer handle for PWM-based CS control */
+	struct capi_timer_handle *cs_timer;
+	/** CS timer channel number */
+	uint32_t cs_timer_channel;
+	/** Timer handle for PWM-based TX clocking */
+	struct capi_timer_handle *tx_timer;
+	/** TX timer channel number */
+	uint32_t tx_timer_channel;
+#endif
+	/** GPIO CS configuration */
+	struct stm32_capi_gpio_port_config cs_gpio_config;
+	/** Flag indicating if CS GPIO is initialized */
+	bool cs_initialized;
+};
+
+#define CAPI_SPI_CONTROLLER_HANDLE_STM32_INIT() \
+	(&(struct capi_spi_controller_handle){ \
+		.ops = NULL, \
+		.init_allocated = false, \
+		.priv = &(struct stm32_spi_priv_handle){ .hspi = { 0 } }})
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
+
+#endif /* _STM32_CAPI_SPI_PRIV_H_ */

--- a/capi/platform/stm32/stm32_capi_time.c
+++ b/capi/platform/stm32/stm32_capi_time.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "stm32_hal.h"
+#include "capi_time.h"
+
+/**
+ * @brief Busy-wait for at least the given number of microseconds.
+ *
+ * On cores with a DWT cycle counter (Cortex-M3/M4/M7) this uses the hardware
+ * cycle counter for precise sub-microsecond resolution.  On cores without DWT
+ * it falls back to the coarsest available HAL delay (1 ms).
+ *
+ * @param us Minimum number of microseconds to wait.
+ */
+#if defined(DWT)
+#pragma GCC push_options
+#pragma GCC optimize ("O3")
+void capi_wait_us_impl(uint32_t us)
+{
+	static bool dwt_initialised = false;
+	volatile uint32_t cycles = (SystemCoreClock / 1000000U) * us;
+	volatile uint32_t start;
+
+	if (!dwt_initialised) {
+		CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+#ifdef STM32F7
+		DWT->LAR = 0xC5ACCE55;
+#endif
+		DWT->CTRL |= 1;
+		dwt_initialised = true;
+	}
+
+	start = DWT->CYCCNT;
+	while (DWT->CYCCNT - start < cycles)
+		;
+}
+#pragma GCC pop_options
+#else
+void capi_wait_us_impl(uint32_t us)
+{
+	if (us)
+		HAL_Delay((us - 1) / 1000 + 1);
+}
+#endif
+
+/**
+ * @brief Delay for at least the given number of milliseconds.
+ *
+ * Uses the SysTick-based HAL_Delay which is accurate to +/- 1 ms.
+ *
+ * @param ms Minimum number of milliseconds to wait.
+ */
+void capi_wait_ms_impl(uint32_t ms)
+{
+	HAL_Delay(ms);
+}
+
+/**
+ * @brief Return monotonic uptime in microseconds since boot.
+ *
+ * The millisecond portion comes from HAL_GetTick() (SysTick).  On cores with
+ * the DWT cycle counter the sub-millisecond fraction is derived from CYCCNT
+ * for microsecond-level resolution; otherwise the fractional part is zero.
+ *
+ * @param[out] us Receives uptime in microseconds.
+ * @return 0 on success.
+ */
+int capi_uptime_impl(uint64_t *us)
+{
+	uint32_t ms = HAL_GetTick();
+	uint64_t result = (uint64_t)ms * 1000U;
+
+#if defined(DWT)
+	{
+		uint32_t cycles_per_ms = SystemCoreClock / 1000U;
+		uint32_t cyccnt = DWT->CYCCNT;
+		uint32_t frac_us = (cyccnt % cycles_per_ms) / (SystemCoreClock / 1000000U);
+
+		result += frac_us;
+	}
+#endif
+
+	*us = result;
+
+	return 0;
+}

--- a/capi/platform/stm32/stm32_capi_timer.c
+++ b/capi/platform/stm32/stm32_capi_timer.c
@@ -1,0 +1,1214 @@
+/*
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdlib.h>
+#include <errno.h>
+#include "capi_alloc.h"
+#include "stm32_capi_timer_priv.h"
+
+#ifdef HAL_TIM_MODULE_ENABLED
+
+#define NSEC_PER_SEC			1000000000ULL
+#define STM32_TIMER_DEFAULT_FREQ_HZ	1000000
+#define STM32_TIMER_DEFAULT_PERIOD	0xFFFFFFFFU
+#define STM32_TIMER_INVALID_CHANNEL	0xFFFFFFFFU
+
+#define MAX_TIMER_INSTANCES		16
+
+/* Lookup table for mapping HAL handles to private handles */
+static struct {
+	TIM_HandleTypeDef *htim;
+	struct stm32_capi_timer_priv *priv;
+} timer_handle_lookup[MAX_TIMER_INSTANCES];
+static uint8_t timer_handle_count = 0;
+
+/**
+ * @brief Find the private handle associated with a HAL timer handle.
+ * @param htim - Pointer to the HAL timer handle.
+ * @return Pointer to the private handle, or NULL if not found.
+ */
+static struct stm32_capi_timer_priv *find_priv_from_htim(
+	TIM_HandleTypeDef *htim)
+{
+	for (uint8_t i = 0; i < timer_handle_count; i++) {
+		if (timer_handle_lookup[i].htim->Instance == htim->Instance)
+			return timer_handle_lookup[i].priv;
+	}
+	return NULL;
+}
+
+/**
+ * @brief Register a mapping between a HAL timer handle and a private handle.
+ * @param htim - Pointer to the HAL timer handle.
+ * @param priv - Pointer to the private handle.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int register_timer_handle(TIM_HandleTypeDef *htim,
+				 struct stm32_capi_timer_priv *priv)
+{
+	if (timer_handle_count >= MAX_TIMER_INSTANCES)
+		return -ENOMEM;
+
+	timer_handle_lookup[timer_handle_count].htim = htim;
+	timer_handle_lookup[timer_handle_count].priv = priv;
+	timer_handle_count++;
+	return 0;
+}
+
+/**
+ * @brief Unregister the mapping for a HAL timer handle.
+ * @param htim - Pointer to the HAL timer handle.
+ */
+static void unregister_timer_handle(TIM_HandleTypeDef *htim)
+{
+	for (uint8_t i = 0; i < timer_handle_count; i++) {
+		if (timer_handle_lookup[i].htim->Instance == htim->Instance) {
+			if (i < timer_handle_count - 1)
+				timer_handle_lookup[i] =
+					timer_handle_lookup[timer_handle_count - 1];
+			timer_handle_count--;
+			break;
+		}
+	}
+}
+
+/**
+ * @brief Get timer base address from identifier.
+ * @param identifier - Timer peripheral identifier or base address.
+ * @param clk_freq - Pointer to store the clock frequency for the timer.
+ * @return Pointer to the timer peripheral, or NULL if invalid.
+ */
+static uint32_t get_apb_timer_clk(uint32_t pclk)
+{
+	uint32_t hclk = HAL_RCC_GetHCLKFreq();
+
+	if (pclk == hclk)
+		return pclk;
+	return pclk * 2U;
+}
+
+static TIM_TypeDef *get_timer_base_from_identifier(uint64_t identifier,
+		uint32_t *clk_freq)
+{
+	uint32_t apb1_tim_clk = get_apb_timer_clk(HAL_RCC_GetPCLK1Freq());
+	uint32_t apb2_tim_clk = get_apb_timer_clk(HAL_RCC_GetPCLK2Freq());
+
+	*clk_freq = apb1_tim_clk;
+
+	if (identifier >= PERIPH_BASE)
+		return (TIM_TypeDef *)identifier;
+
+	switch (identifier) {
+#if defined(TIM1)
+	case 1:
+		*clk_freq = apb2_tim_clk;
+		return TIM1;
+#endif
+#if defined(TIM2)
+	case 2:
+		return TIM2;
+#endif
+#if defined(TIM3)
+	case 3:
+		return TIM3;
+#endif
+#if defined(TIM4)
+	case 4:
+		return TIM4;
+#endif
+#if defined(TIM5)
+	case 5:
+		return TIM5;
+#endif
+#if defined(TIM6)
+	case 6:
+		return TIM6;
+#endif
+#if defined(TIM7)
+	case 7:
+		return TIM7;
+#endif
+#if defined(TIM8)
+	case 8:
+		*clk_freq = apb2_tim_clk;
+		return TIM8;
+#endif
+#if defined(TIM9)
+	case 9:
+		return TIM9;
+#endif
+#if defined(TIM10)
+	case 10:
+		return TIM10;
+#endif
+#if defined(TIM11)
+	case 11:
+		return TIM11;
+#endif
+#if defined(TIM12)
+	case 12:
+		return TIM12;
+#endif
+#if defined(TIM13)
+	case 13:
+		return TIM13;
+#endif
+#if defined(TIM14)
+	case 14:
+		return TIM14;
+#endif
+#if defined(TIM15)
+	case 15:
+		return TIM15;
+#endif
+#if defined(TIM16)
+	case 16:
+		return TIM16;
+#endif
+#if defined(TIM17)
+	case 17:
+		return TIM17;
+#endif
+	default:
+		return NULL;
+	}
+}
+
+/**
+ * @brief Map CAPI channel index to HAL timer channel constant.
+ * @param chan - CAPI channel index (0-3).
+ * @return HAL timer channel constant, or STM32_TIMER_INVALID_CHANNEL if invalid.
+ */
+static uint32_t get_hal_channel(uint32_t chan)
+{
+	switch (chan) {
+	case 0:
+		return TIM_CHANNEL_1;
+	case 1:
+		return TIM_CHANNEL_2;
+	case 2:
+		return TIM_CHANNEL_3;
+	case 3:
+		return TIM_CHANNEL_4;
+	default:
+		return STM32_TIMER_INVALID_CHANNEL;
+	}
+}
+
+/**
+ * @brief Map CAPI channel index to HAL timer interrupt flag.
+ * @param chan - CAPI channel index (0-3).
+ * @return HAL timer interrupt flag, or 0 if invalid.
+ */
+static uint32_t get_hal_it_flag(uint32_t chan)
+{
+	switch (chan) {
+	case 0:
+		return TIM_IT_CC1;
+	case 1:
+		return TIM_IT_CC2;
+	case 2:
+		return TIM_IT_CC3;
+	case 3:
+		return TIM_IT_CC4;
+	default:
+		return 0;
+	}
+}
+
+/**
+ * @brief Initialize the STM32 timer.
+ * @param handle - Pointer to a pointer of the timer handle.
+ * @param config - Pointer to the timer configuration.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_timer_init(struct capi_timer_handle **handle,
+				 const struct capi_timer_config *config)
+{
+	struct capi_timer_handle *tim_handle;
+	struct stm32_capi_timer_priv *priv;
+	struct stm32_capi_timer_extra_config *extra;
+	TIM_TypeDef *base;
+	uint32_t src_clk_freq;
+	uint32_t prescaler;
+	int ret;
+
+	if (!handle || !config || !config->extra)
+		return -EINVAL;
+
+	base = get_timer_base_from_identifier(config->identifier, &src_clk_freq);
+	if (!base)
+		return -EINVAL;
+
+	if (*handle == NULL) {
+		tim_handle = capi_calloc(1, sizeof(*tim_handle));
+		if (!tim_handle)
+			return -ENOMEM;
+
+		priv = capi_calloc(1, sizeof(*priv));
+		if (!priv) {
+			capi_free(tim_handle);
+			return -ENOMEM;
+		}
+
+		tim_handle->priv = priv;
+		tim_handle->init_allocated = true;
+	} else {
+		tim_handle = *handle;
+		tim_handle->init_allocated = false;
+
+		if (!tim_handle->priv)
+			return -EINVAL;
+
+		priv = tim_handle->priv;
+	}
+
+	tim_handle->ops = config->ops;
+
+	extra = (struct stm32_capi_timer_extra_config *)config->extra;
+
+	if (extra && extra->htim) {
+		priv->htim = *extra->htim;
+	} else {
+		priv->htim.Instance = base;
+	}
+
+	if (extra && extra->get_input_clock)
+		priv->input_clock_hz = extra->get_input_clock();
+	else if (config->input_clock_hz)
+		priv->input_clock_hz = config->input_clock_hz;
+	else
+		priv->input_clock_hz = src_clk_freq;
+
+	if (extra)
+		priv->irq_num = extra->irq_num;
+
+	priv->output_freq_hz = config->output_freq_hz;
+	if (priv->output_freq_hz == 0)
+		priv->output_freq_hz = STM32_TIMER_DEFAULT_FREQ_HZ;
+
+	if (priv->input_clock_hz < priv->output_freq_hz) {
+		ret = -EINVAL;
+		goto error;
+	}
+
+	prescaler = (priv->input_clock_hz / priv->output_freq_hz) - 1;
+
+	priv->htim.Init.Prescaler = prescaler;
+	priv->htim.Init.CounterMode = TIM_COUNTERMODE_UP;
+	priv->htim.Init.Period = STM32_TIMER_DEFAULT_PERIOD;
+	priv->htim.Init.ClockDivision = TIM_CLOCKDIVISION_DIV1;
+	priv->htim.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
+
+	ret = HAL_TIM_Base_Init(&priv->htim);
+	if (ret != HAL_OK) {
+		ret = -EIO;
+		goto error;
+	}
+
+	priv->direction = CAPI_TIMER_COUNT_UP;
+	priv->counter_min = 0;
+	priv->counter_max = priv->htim.Init.Period;
+	priv->rollover = true;
+
+	ret = register_timer_handle(&priv->htim, priv);
+	if (ret)
+		goto error_deinit;
+
+	*handle = tim_handle;
+	return 0;
+
+error_deinit:
+	HAL_TIM_Base_DeInit(&priv->htim);
+error:
+	if (tim_handle->init_allocated) {
+		capi_free(priv);
+		capi_free(tim_handle);
+	}
+	return ret;
+}
+
+/**
+ * @brief Deinitialize the STM32 timer.
+ * @param handle - Pointer to the timer handle.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_timer_deinit(struct capi_timer_handle *handle)
+{
+	struct stm32_capi_timer_priv *priv;
+
+	if (!handle)
+		return -EINVAL;
+
+	priv = handle->priv;
+	if (priv) {
+		HAL_TIM_Base_Stop_IT(&priv->htim);
+		HAL_TIM_Base_DeInit(&priv->htim);
+		unregister_timer_handle(&priv->htim);
+	}
+
+	if (handle->init_allocated) {
+		capi_free(priv);
+		capi_free(handle);
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Start the timer counter.
+ * @param handle - Pointer to the timer handle.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_timer_start(struct capi_timer_handle *handle)
+{
+	struct stm32_capi_timer_priv *priv;
+	HAL_StatusTypeDef ret;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	priv = handle->priv;
+
+	if (priv->irq_num)
+		ret = HAL_TIM_Base_Start_IT(&priv->htim);
+	else
+		ret = HAL_TIM_Base_Start(&priv->htim);
+
+	return (ret == HAL_OK) ? 0 : -EIO;
+}
+
+/**
+ * @brief Stop the timer counter.
+ * @param handle - Pointer to the timer handle.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_timer_stop(struct capi_timer_handle *handle)
+{
+	struct stm32_capi_timer_priv *priv;
+	HAL_StatusTypeDef ret;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	priv = handle->priv;
+
+	if (priv->irq_num)
+		ret = HAL_TIM_Base_Stop_IT(&priv->htim);
+	else
+		ret = HAL_TIM_Base_Stop(&priv->htim);
+
+	return (ret == HAL_OK) ? 0 : -EIO;
+}
+
+/**
+ * @brief Configure the timer counter.
+ * @param handle - Pointer to the timer handle.
+ * @param config - Pointer to the counter configuration.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_timer_counter_config(struct capi_timer_handle *handle,
+		const struct capi_timer_counter_config *config)
+{
+	struct stm32_capi_timer_priv *priv;
+	HAL_StatusTypeDef ret;
+
+	if (!handle || !handle->priv || !config)
+		return -EINVAL;
+
+	priv = handle->priv;
+
+	priv->direction = config->direction;
+	priv->counter_min = config->min;
+	priv->counter_max = config->max;
+	priv->rollover = config->rollover;
+
+	if (config->direction == CAPI_TIMER_COUNT_DOWN)
+		priv->htim.Init.CounterMode = TIM_COUNTERMODE_DOWN;
+	else
+		priv->htim.Init.CounterMode = TIM_COUNTERMODE_UP;
+
+	priv->htim.Init.Period = config->max - config->min;
+
+	ret = HAL_TIM_Base_Init(&priv->htim);
+	if (ret != HAL_OK)
+		return -EIO;
+
+	__HAL_TIM_SET_COUNTER(&priv->htim, config->min);
+
+	return 0;
+}
+
+/**
+ * @brief Get the current counter value.
+ * @param handle - Pointer to the timer handle.
+ * @param counter - Pointer to store the counter value.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_timer_counter_get(struct capi_timer_handle *handle,
+					uint32_t *counter)
+{
+	struct stm32_capi_timer_priv *priv;
+
+	if (!handle || !handle->priv || !counter)
+		return -EINVAL;
+
+	priv = handle->priv;
+	*counter = __HAL_TIM_GET_COUNTER(&priv->htim) + priv->counter_min;
+
+	return 0;
+}
+
+/**
+ * @brief Enable timer event IRQ.
+ * @param handle - Pointer to the timer handle.
+ * @param event - Event type identifier.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_timer_event_irq_enable(struct capi_timer_handle *handle,
+		uint32_t event)
+{
+	struct stm32_capi_timer_priv *priv;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	priv = handle->priv;
+
+	switch (event) {
+	case CAPI_TIMER_GLOBAL_EVENT_COUNTER_OVERFLOW:
+		__HAL_TIM_ENABLE_IT(&priv->htim, TIM_IT_UPDATE);
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Disable timer event IRQ.
+ * @param handle - Pointer to the timer handle.
+ * @param event - Event type identifier.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_timer_event_irq_disable(struct capi_timer_handle *handle,
+		uint32_t event)
+{
+	struct stm32_capi_timer_priv *priv;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	priv = handle->priv;
+
+	switch (event) {
+	case CAPI_TIMER_GLOBAL_EVENT_COUNTER_OVERFLOW:
+		__HAL_TIM_DISABLE_IT(&priv->htim, TIM_IT_UPDATE);
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Register a global timer event callback.
+ * @param handle - Pointer to the timer handle.
+ * @param callback - Callback function.
+ * @param callback_arg - Callback argument.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_timer_register_event_callback(
+	struct capi_timer_handle *handle,
+	capi_timer_event_callback callback,
+	void *callback_arg)
+{
+	struct stm32_capi_timer_priv *priv;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	priv = handle->priv;
+	priv->event_callback = callback;
+	priv->event_callback_arg = callback_arg;
+
+	return 0;
+}
+
+/**
+ * @brief Initialize a timer channel.
+ * @param handle - Pointer to the timer handle.
+ * @param chan - Channel number (0-3).
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_timer_channel_init(struct capi_timer_handle *handle,
+		uint32_t chan)
+{
+	struct stm32_capi_timer_priv *priv;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	if (chan >= STM32_TIMER_MAX_CHANNELS)
+		return -EINVAL;
+
+	priv = handle->priv;
+	priv->channels[chan].enabled = false;
+	priv->channels[chan].mode = CAPI_TIMER_COMPARE_MODE;
+	priv->channels[chan].callback = NULL;
+	priv->channels[chan].callback_arg = NULL;
+
+	return 0;
+}
+
+/**
+ * @brief Deinitialize a timer channel.
+ * @param handle - Pointer to the timer handle.
+ * @param chan - Channel number (0-3).
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_timer_channel_deinit(struct capi_timer_handle *handle,
+		uint32_t chan)
+{
+	struct stm32_capi_timer_priv *priv;
+	uint32_t hal_chan;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	if (chan >= STM32_TIMER_MAX_CHANNELS)
+		return -EINVAL;
+
+	priv = handle->priv;
+	hal_chan = get_hal_channel(chan);
+
+	switch (priv->channels[chan].mode) {
+	case CAPI_TIMER_COMPARE_MODE:
+		HAL_TIM_OC_Stop(&priv->htim, hal_chan);
+		break;
+	case CAPI_TIMER_CAPTURE_MODE:
+		HAL_TIM_IC_Stop(&priv->htim, hal_chan);
+		break;
+	case CAPI_TIMER_PWM_MODE:
+		HAL_TIM_PWM_Stop(&priv->htim, hal_chan);
+		break;
+	default:
+		break;
+	}
+
+	priv->channels[chan].enabled = false;
+	priv->channels[chan].callback = NULL;
+	priv->channels[chan].callback_arg = NULL;
+
+	return 0;
+}
+
+/**
+ * @brief Configure a timer channel.
+ * @param handle - Pointer to the timer handle.
+ * @param chan - Channel number (0-3).
+ * @param ch_config - Pointer to the channel configuration.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_timer_channel_config(
+	struct capi_timer_handle *handle,
+	uint32_t chan,
+	const struct capi_timer_channel_config *ch_config)
+{
+	struct stm32_capi_timer_priv *priv;
+	TIM_OC_InitTypeDef oc_config = {0};
+	TIM_IC_InitTypeDef ic_config = {0};
+	uint32_t hal_chan;
+	HAL_StatusTypeDef ret;
+
+	if (!handle || !handle->priv || !ch_config)
+		return -EINVAL;
+
+	if (chan >= STM32_TIMER_MAX_CHANNELS)
+		return -EINVAL;
+
+	priv = handle->priv;
+	hal_chan = get_hal_channel(chan);
+	priv->channels[chan].mode = ch_config->mode;
+
+	switch (ch_config->mode) {
+	case CAPI_TIMER_COMPARE_MODE:
+		switch (ch_config->config.compare.polarity) {
+		case CAPI_TIMER_ON_COMPARE_TOGGLE:
+			oc_config.OCMode = TIM_OCMODE_TOGGLE;
+			break;
+		case CAPI_TIMER_ON_COMPARE_ACTIVE:
+			oc_config.OCMode = TIM_OCMODE_ACTIVE;
+			break;
+		case CAPI_TIMER_ON_COMPARE_INACTIVE:
+			oc_config.OCMode = TIM_OCMODE_INACTIVE;
+			break;
+		case CAPI_TIMER_ON_COMPARE_PULSE:
+			oc_config.OCMode = TIM_OCMODE_PWM1;
+			break;
+		case CAPI_TIMER_ON_COMPARE_KEEP:
+		default:
+			oc_config.OCMode = TIM_OCMODE_TIMING;
+			break;
+		}
+		oc_config.Pulse = ch_config->config.compare.match_value;
+		oc_config.OCPolarity = TIM_OCPOLARITY_HIGH;
+		oc_config.OCFastMode = TIM_OCFAST_DISABLE;
+
+		ret = HAL_TIM_OC_ConfigChannel(&priv->htim, &oc_config, hal_chan);
+		if (ret != HAL_OK)
+			return -EIO;
+		break;
+
+	case CAPI_TIMER_CAPTURE_MODE:
+		switch (ch_config->config.capture.edge) {
+		case CAPI_TIMER_CAPTURE_RISING:
+			ic_config.ICPolarity = TIM_INPUTCHANNELPOLARITY_RISING;
+			break;
+		case CAPI_TIMER_CAPTURE_FALLING:
+			ic_config.ICPolarity = TIM_INPUTCHANNELPOLARITY_FALLING;
+			break;
+		case CAPI_TIMER_CAPTURE_BOTH:
+			ic_config.ICPolarity = TIM_INPUTCHANNELPOLARITY_BOTHEDGE;
+			break;
+		default:
+			ic_config.ICPolarity = TIM_INPUTCHANNELPOLARITY_RISING;
+			break;
+		}
+		ic_config.ICSelection = TIM_ICSELECTION_DIRECTTI;
+		ic_config.ICPrescaler = TIM_ICPSC_DIV1;
+		ic_config.ICFilter = 0;
+
+		ret = HAL_TIM_IC_ConfigChannel(&priv->htim, &ic_config, hal_chan);
+		if (ret != HAL_OK)
+			return -EIO;
+		break;
+
+	case CAPI_TIMER_PWM_MODE:
+		oc_config.OCMode = TIM_OCMODE_PWM1;
+		if (ch_config->config.pwm.period_ns > 0) {
+			uint64_t period_ticks = (priv->output_freq_hz *
+						 ch_config->config.pwm.period_ns) / NSEC_PER_SEC;
+			uint64_t active_ticks = (priv->output_freq_hz *
+						 ch_config->config.pwm.active_ns) / NSEC_PER_SEC;
+
+			priv->htim.Init.Period = (uint32_t)period_ticks;
+			HAL_TIM_Base_Init(&priv->htim);
+			oc_config.Pulse = (uint32_t)active_ticks;
+		} else {
+			oc_config.Pulse = 0;
+		}
+
+		if (ch_config->config.pwm.inverted_polarity)
+			oc_config.OCPolarity = TIM_OCPOLARITY_LOW;
+		else
+			oc_config.OCPolarity = TIM_OCPOLARITY_HIGH;
+		oc_config.OCFastMode = TIM_OCFAST_DISABLE;
+
+		ret = HAL_TIM_PWM_ConfigChannel(&priv->htim, &oc_config, hal_chan);
+		if (ret != HAL_OK)
+			return -EIO;
+		break;
+
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Enable a timer channel.
+ * @param handle - Pointer to the timer handle.
+ * @param chan - Channel number (0-3).
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_timer_channel_enable(struct capi_timer_handle *handle,
+		uint32_t chan)
+{
+	struct stm32_capi_timer_priv *priv;
+	uint32_t hal_chan;
+	HAL_StatusTypeDef ret;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	if (chan >= STM32_TIMER_MAX_CHANNELS)
+		return -EINVAL;
+
+	priv = handle->priv;
+	hal_chan = get_hal_channel(chan);
+
+	switch (priv->channels[chan].mode) {
+	case CAPI_TIMER_COMPARE_MODE:
+		ret = HAL_TIM_OC_Start(&priv->htim, hal_chan);
+		break;
+	case CAPI_TIMER_CAPTURE_MODE:
+		ret = HAL_TIM_IC_Start(&priv->htim, hal_chan);
+		break;
+	case CAPI_TIMER_PWM_MODE:
+		ret = HAL_TIM_PWM_Start(&priv->htim, hal_chan);
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	if (ret != HAL_OK)
+		return -EIO;
+
+	priv->channels[chan].enabled = true;
+	return 0;
+}
+
+/**
+ * @brief Disable a timer channel.
+ * @param handle - Pointer to the timer handle.
+ * @param chan - Channel number (0-3).
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_timer_channel_disable(struct capi_timer_handle *handle,
+		uint32_t chan)
+{
+	struct stm32_capi_timer_priv *priv;
+	uint32_t hal_chan;
+	HAL_StatusTypeDef ret;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	if (chan >= STM32_TIMER_MAX_CHANNELS)
+		return -EINVAL;
+
+	priv = handle->priv;
+	hal_chan = get_hal_channel(chan);
+
+	switch (priv->channels[chan].mode) {
+	case CAPI_TIMER_COMPARE_MODE:
+		ret = HAL_TIM_OC_Stop(&priv->htim, hal_chan);
+		break;
+	case CAPI_TIMER_CAPTURE_MODE:
+		ret = HAL_TIM_IC_Stop(&priv->htim, hal_chan);
+		break;
+	case CAPI_TIMER_PWM_MODE:
+		ret = HAL_TIM_PWM_Stop(&priv->htim, hal_chan);
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	if (ret != HAL_OK)
+		return -EIO;
+
+	priv->channels[chan].enabled = false;
+	return 0;
+}
+
+/**
+ * @brief Set compare value for a timer channel.
+ * @param handle - Pointer to the timer handle.
+ * @param chan - Channel number (0-3).
+ * @param compare - Compare value to set.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_timer_channel_compare_set(struct capi_timer_handle
+		*handle,
+		uint32_t chan, uint32_t compare)
+{
+	struct stm32_capi_timer_priv *priv;
+	uint32_t hal_chan;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	if (chan >= STM32_TIMER_MAX_CHANNELS)
+		return -EINVAL;
+
+	priv = handle->priv;
+	hal_chan = get_hal_channel(chan);
+
+	__HAL_TIM_SET_COMPARE(&priv->htim, hal_chan, compare);
+
+	return 0;
+}
+
+/**
+ * @brief Get compare value from a timer channel.
+ * @param handle - Pointer to the timer handle.
+ * @param chan - Channel number (0-3).
+ * @param compare - Pointer to store compare value.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_timer_channel_compare_get(struct capi_timer_handle
+		*handle,
+		uint32_t chan, uint32_t *compare)
+{
+	struct stm32_capi_timer_priv *priv;
+	uint32_t hal_chan;
+
+	if (!handle || !handle->priv || !compare)
+		return -EINVAL;
+
+	if (chan >= STM32_TIMER_MAX_CHANNELS)
+		return -EINVAL;
+
+	priv = handle->priv;
+	hal_chan = get_hal_channel(chan);
+
+	*compare = __HAL_TIM_GET_COMPARE(&priv->htim, hal_chan);
+
+	return 0;
+}
+
+/**
+ * @brief Get capture value from a timer channel.
+ * @param handle - Pointer to the timer handle.
+ * @param chan - Channel number (0-3).
+ * @param capture - Pointer to store capture value.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_timer_channel_capture_get(struct capi_timer_handle
+		*handle,
+		uint32_t chan, uint32_t *capture)
+{
+	struct stm32_capi_timer_priv *priv;
+	uint32_t hal_chan;
+
+	if (!handle || !handle->priv || !capture)
+		return -EINVAL;
+
+	if (chan >= STM32_TIMER_MAX_CHANNELS)
+		return -EINVAL;
+
+	priv = handle->priv;
+	hal_chan = get_hal_channel(chan);
+
+	*capture = HAL_TIM_ReadCapturedValue(&priv->htim, hal_chan);
+
+	return 0;
+}
+
+/**
+ * @brief Enable channel IRQ.
+ * @param handle - Pointer to the timer handle.
+ * @param chan - Channel number (0-3).
+ * @param event - Event type identifier.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_timer_channel_irq_enable(struct capi_timer_handle *handle,
+		uint32_t chan, uint32_t event)
+{
+	struct stm32_capi_timer_priv *priv;
+	uint32_t it_flag;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	if (chan >= STM32_TIMER_MAX_CHANNELS)
+		return -EINVAL;
+
+	priv = handle->priv;
+	it_flag = get_hal_it_flag(chan);
+
+	__HAL_TIM_ENABLE_IT(&priv->htim, it_flag);
+
+	return 0;
+}
+
+/**
+ * @brief Disable channel IRQ.
+ * @param handle - Pointer to the timer handle.
+ * @param chan - Channel number (0-3).
+ * @param event - Event type identifier.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_timer_channel_irq_disable(struct capi_timer_handle
+		*handle,
+		uint32_t chan, uint32_t event)
+{
+	struct stm32_capi_timer_priv *priv;
+	uint32_t it_flag;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	if (chan >= STM32_TIMER_MAX_CHANNELS)
+		return -EINVAL;
+
+	priv = handle->priv;
+	it_flag = get_hal_it_flag(chan);
+
+	__HAL_TIM_DISABLE_IT(&priv->htim, it_flag);
+
+	return 0;
+}
+
+/**
+ * @brief Register a channel-specific callback.
+ * @param handle - Pointer to the timer handle.
+ * @param chan - Channel number (0-3).
+ * @param callback - Callback function.
+ * @param callback_arg - Callback argument.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_timer_channel_register_callback(
+	struct capi_timer_handle *handle,
+	uint32_t chan,
+	capi_timer_channel_callback callback,
+	void *callback_arg)
+{
+	struct stm32_capi_timer_priv *priv;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	if (chan >= STM32_TIMER_MAX_CHANNELS)
+		return -EINVAL;
+
+	priv = handle->priv;
+	priv->channels[chan].callback = callback;
+	priv->channels[chan].callback_arg = callback_arg;
+
+	return 0;
+}
+
+/**
+ * @brief Check if any timer IRQ is pending.
+ * @param handle - Pointer to the timer handle.
+ * @param pending - Pointer to store pending status.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_timer_is_irq_pending(struct capi_timer_handle *handle,
+		bool *pending)
+{
+	struct stm32_capi_timer_priv *priv;
+	uint32_t sr;
+
+	if (!handle || !handle->priv || !pending)
+		return -EINVAL;
+
+	priv = handle->priv;
+	sr = priv->htim.Instance->SR;
+
+	*pending = (sr & (TIM_SR_UIF | TIM_SR_CC1IF | TIM_SR_CC2IF |
+			  TIM_SR_CC3IF | TIM_SR_CC4IF)) != 0;
+
+	return 0;
+}
+
+/**
+ * @brief Timer interrupt service routine.
+ * @param handle - Pointer to the timer handle.
+ */
+static void stm32_capi_timer_isr(struct capi_timer_handle *handle)
+{
+	struct stm32_capi_timer_priv *priv;
+	uint32_t sr;
+	uint32_t i;
+
+	if (!handle || !handle->priv)
+		return;
+
+	priv = handle->priv;
+	sr = priv->htim.Instance->SR;
+
+	if (sr & TIM_SR_UIF) {
+		__HAL_TIM_CLEAR_FLAG(&priv->htim, TIM_FLAG_UPDATE);
+		if (priv->event_callback) {
+			priv->event_callback(CAPI_TIMER_GLOBAL_EVENT_COUNTER_OVERFLOW,
+					     priv->event_callback_arg, 0);
+		}
+	}
+
+	for (i = 0; i < STM32_TIMER_MAX_CHANNELS; i++) {
+		uint32_t cc_flag = TIM_SR_CC1IF << i;
+		if (sr & cc_flag) {
+			__HAL_TIM_CLEAR_FLAG(&priv->htim, TIM_FLAG_CC1 << i);
+			if (priv->channels[i].callback) {
+				uint32_t event =
+					(priv->channels[i].mode == CAPI_TIMER_CAPTURE_MODE) ?
+					CAPI_TIMER_CHANNEL_EVENT_CAPTURE :
+					CAPI_TIMER_CHANNEL_EVENT_COMPARE;
+				priv->channels[i].callback(event, i,
+							   priv->channels[i].callback_arg, 0);
+			}
+		}
+	}
+}
+
+/**
+ * @brief Convert nanoseconds to timer ticks.
+ * @param handle - Pointer to the timer handle.
+ * @param duration_ns - Duration in nanoseconds.
+ * @param ticks - Pointer to store tick count.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_timer_nsec_to_ticks(const struct capi_timer_handle
+		*handle,
+		uint64_t duration_ns, uint32_t *ticks)
+{
+	struct stm32_capi_timer_priv *priv;
+
+	if (!handle || !handle->priv || !ticks)
+		return -EINVAL;
+
+	priv = handle->priv;
+
+	*ticks = (uint32_t)((priv->output_freq_hz * duration_ns) / NSEC_PER_SEC);
+
+	return 0;
+}
+
+/**
+ * @brief Convert timer ticks to nanoseconds.
+ * @param handle - Pointer to the timer handle.
+ * @param ticks - Tick count.
+ * @param duration_ns - Pointer to store duration in nanoseconds.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_timer_ticks_to_nsec(const struct capi_timer_handle
+		*handle,
+		uint64_t ticks, uint32_t *duration_ns)
+{
+	struct stm32_capi_timer_priv *priv;
+
+	if (!handle || !handle->priv || !duration_ns)
+		return -EINVAL;
+
+	priv = handle->priv;
+
+	if (priv->output_freq_hz == 0)
+		return -EINVAL;
+
+	*duration_ns = (uint32_t)((ticks * NSEC_PER_SEC) / priv->output_freq_hz);
+
+	return 0;
+}
+
+const struct capi_timer_ops stm32_capi_timer_ops = {
+	.init = stm32_capi_timer_init,
+	.deinit = stm32_capi_timer_deinit,
+	.start = stm32_capi_timer_start,
+	.stop = stm32_capi_timer_stop,
+	.counter_config = stm32_capi_timer_counter_config,
+	.counter_get = stm32_capi_timer_counter_get,
+	.event_irq_enable = stm32_capi_timer_event_irq_enable,
+	.event_irq_disable = stm32_capi_timer_event_irq_disable,
+	.register_event_callback = stm32_capi_timer_register_event_callback,
+	.channel_init = stm32_capi_timer_channel_init,
+	.channel_deinit = stm32_capi_timer_channel_deinit,
+	.channel_config = stm32_capi_timer_channel_config,
+	.channel_enable = stm32_capi_timer_channel_enable,
+	.channel_disable = stm32_capi_timer_channel_disable,
+	.channel_compare_set = stm32_capi_timer_channel_compare_set,
+	.channel_compare_get = stm32_capi_timer_channel_compare_get,
+	.channel_capture_get = stm32_capi_timer_channel_capture_get,
+	.channel_irq_enable = stm32_capi_timer_channel_irq_enable,
+	.channel_irq_disable = stm32_capi_timer_channel_irq_disable,
+	.channel_register_callback = stm32_capi_timer_channel_register_callback,
+	.is_irq_pending = stm32_capi_timer_is_irq_pending,
+	.isr = stm32_capi_timer_isr,
+	.nsec_to_ticks = stm32_capi_timer_nsec_to_ticks,
+	.ticks_to_nsec = stm32_capi_timer_ticks_to_nsec,
+};
+
+/**
+ * @brief HAL timer period elapsed callback (overflow).
+ * @param htim - Pointer to the HAL timer handle.
+ */
+void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
+{
+	struct stm32_capi_timer_priv *priv;
+
+	priv = find_priv_from_htim(htim);
+	if (!priv)
+		return;
+
+	if (priv->event_callback) {
+		priv->event_callback(CAPI_TIMER_GLOBAL_EVENT_COUNTER_OVERFLOW,
+				     priv->event_callback_arg, 0);
+	}
+}
+
+/**
+ * @brief HAL timer output compare delay elapsed callback.
+ * @param htim - Pointer to the HAL timer handle.
+ */
+void HAL_TIM_OC_DelayElapsedCallback(TIM_HandleTypeDef *htim)
+{
+	struct stm32_capi_timer_priv *priv;
+	uint32_t chan;
+
+	priv = find_priv_from_htim(htim);
+	if (!priv)
+		return;
+
+	for (chan = 0; chan < STM32_TIMER_MAX_CHANNELS; chan++) {
+		if (priv->channels[chan].callback &&
+		    priv->channels[chan].mode == CAPI_TIMER_COMPARE_MODE) {
+			priv->channels[chan].callback(CAPI_TIMER_CHANNEL_EVENT_COMPARE,
+						      chan,
+						      priv->channels[chan].callback_arg,
+						      0);
+		}
+	}
+}
+
+/**
+ * @brief HAL timer input capture callback.
+ * @param htim - Pointer to the HAL timer handle.
+ */
+void HAL_TIM_IC_CaptureCallback(TIM_HandleTypeDef *htim)
+{
+	struct stm32_capi_timer_priv *priv;
+	uint32_t chan;
+
+	priv = find_priv_from_htim(htim);
+	if (!priv)
+		return;
+
+	for (chan = 0; chan < STM32_TIMER_MAX_CHANNELS; chan++) {
+		uint32_t hal_chan = get_hal_channel(chan);
+		if (htim->Channel == (1 << (hal_chan / 4))) {
+			if (priv->channels[chan].callback &&
+			    priv->channels[chan].mode == CAPI_TIMER_CAPTURE_MODE) {
+				priv->channels[chan].callback(
+					CAPI_TIMER_CHANNEL_EVENT_CAPTURE,
+					chan,
+					priv->channels[chan].callback_arg,
+					0);
+			}
+			break;
+		}
+	}
+}
+
+/**
+ * @brief HAL timer PWM pulse finished callback.
+ * @param htim - Pointer to the HAL timer handle.
+ */
+void HAL_TIM_PWM_PulseFinishedCallback(TIM_HandleTypeDef *htim)
+{
+	struct stm32_capi_timer_priv *priv;
+	uint32_t chan;
+
+	priv = find_priv_from_htim(htim);
+	if (!priv)
+		return;
+
+	for (chan = 0; chan < STM32_TIMER_MAX_CHANNELS; chan++) {
+		if (priv->channels[chan].callback &&
+		    priv->channels[chan].mode == CAPI_TIMER_PWM_MODE) {
+			priv->channels[chan].callback(CAPI_TIMER_CHANNEL_EVENT_COMPARE,
+						      chan,
+						      priv->channels[chan].callback_arg,
+						      0);
+		}
+	}
+}
+
+#endif /* HAL_TIM_MODULE_ENABLED */

--- a/capi/platform/stm32/stm32_capi_timer.h
+++ b/capi/platform/stm32/stm32_capi_timer.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef STM32_CAPI_TIMER_H_
+#define STM32_CAPI_TIMER_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "stm32_hal.h"
+#include "capi_timer.h"
+
+#ifdef HAL_TIM_MODULE_ENABLED
+
+/** Maximum number of timer channels */
+#define STM32_TIMER_MAX_CHANNELS	4
+
+/**
+ * @struct stm32_capi_timer_extra_config
+ * @brief STM32-specific timer configuration for CAPI interface
+ */
+struct stm32_capi_timer_extra_config {
+	/** Pre-initialized TIM handle (optional - if NULL, driver will init) */
+	TIM_HandleTypeDef *htim;
+	/** Get input clock frequency function (optional) */
+	uint32_t (*get_input_clock)(void);
+	/** IRQ number for the timer (0 to disable IRQ) */
+	uint32_t irq_num;
+};
+
+/**
+ * @brief STM32 platform specific timer operations for CAPI
+ */
+extern const struct capi_timer_ops stm32_capi_timer_ops;
+
+#endif /* HAL_TIM_MODULE_ENABLED */
+
+#endif /* STM32_CAPI_TIMER_H_ */

--- a/capi/platform/stm32/stm32_capi_timer_priv.h
+++ b/capi/platform/stm32/stm32_capi_timer_priv.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _STM32_CAPI_TIMER_PRIV_H_
+#define _STM32_CAPI_TIMER_PRIV_H_
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+#include "stm32_capi_timer.h"
+
+#ifdef HAL_TIM_MODULE_ENABLED
+
+/**
+ * @brief Per-channel state for STM32 timer
+ */
+struct stm32_capi_timer_channel_state {
+	/** Channel mode */
+	uint32_t mode;
+	/** Channel enabled flag */
+	bool enabled;
+	/** Channel-specific callback */
+	capi_timer_channel_callback callback;
+	/** Callback argument */
+	void *callback_arg;
+};
+
+/**
+ * @brief STM32 platform specific timer private data
+ */
+struct stm32_capi_timer_priv {
+	/** STM32 HAL timer handle */
+	TIM_HandleTypeDef htim;
+	/** Timer input clock frequency in Hz */
+	uint64_t input_clock_hz;
+	/** Timer output/counting frequency in Hz */
+	uint64_t output_freq_hz;
+	/** Counter direction */
+	uint32_t direction;
+	/** Counter minimum value */
+	uint32_t counter_min;
+	/** Counter maximum value */
+	uint32_t counter_max;
+	/** Rollover enabled */
+	bool rollover;
+	/** IRQ number */
+	uint32_t irq_num;
+	/** Global event callback */
+	capi_timer_event_callback event_callback;
+	/** Global event callback argument */
+	void *event_callback_arg;
+	/** Channel states */
+	struct stm32_capi_timer_channel_state channels[STM32_TIMER_MAX_CHANNELS];
+};
+
+#define CAPI_TIMER_HANDLE_STM32_INIT() \
+	(&(struct capi_timer_handle){ \
+		.ops = NULL, \
+		.init_allocated = false, \
+		.priv = &(struct stm32_capi_timer_priv){0}})
+
+#endif /* HAL_TIM_MODULE_ENABLED */
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
+
+#endif /* _STM32_CAPI_TIMER_PRIV_H_ */

--- a/capi/platform/stm32/stm32_capi_uart.c
+++ b/capi/platform/stm32/stm32_capi_uart.c
@@ -1,0 +1,780 @@
+/*
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "stm32_capi_uart_priv.h"
+#include "capi_alloc.h"
+#include <errno.h>
+#include <sys/stat.h>
+#include <stdio.h>
+
+/** Maximum number of UART instances tracked for HAL callback routing.
+ * 12 covers all known STM32 families (up to 10 on H7/H5, plus headroom). */
+#define STM32_CAPI_UART_MAX_INSTANCES 12
+
+/** Lookup table: maps HAL UART handle → CAPI handle for ISR dispatch */
+static struct capi_uart_handle *uart_handle_map[STM32_CAPI_UART_MAX_INSTANCES];
+static UART_HandleTypeDef *uart_hal_map[STM32_CAPI_UART_MAX_INSTANCES];
+
+static void uart_map_register(UART_HandleTypeDef *huart,
+			      struct capi_uart_handle *handle)
+{
+	unsigned int i;
+
+	for (i = 0; i < STM32_CAPI_UART_MAX_INSTANCES; i++) {
+		if (!uart_hal_map[i] || uart_hal_map[i] == huart) {
+			uart_hal_map[i] = huart;
+			uart_handle_map[i] = handle;
+			return;
+		}
+	}
+}
+
+static void uart_map_unregister(UART_HandleTypeDef *huart)
+{
+	unsigned int i;
+
+	for (i = 0; i < STM32_CAPI_UART_MAX_INSTANCES; i++) {
+		if (uart_hal_map[i] == huart) {
+			uart_hal_map[i] = NULL;
+			uart_handle_map[i] = NULL;
+			return;
+		}
+	}
+}
+
+static struct capi_uart_handle *uart_map_lookup(UART_HandleTypeDef *huart)
+{
+	unsigned int i;
+
+	for (i = 0; i < STM32_CAPI_UART_MAX_INSTANCES; i++) {
+		if (uart_hal_map[i] == huart)
+			return uart_handle_map[i];
+	}
+	return NULL;
+}
+
+/**
+ * @brief Initialize the STM32 UART peripheral.
+ * @param handle - Pointer to the UART handle to be allocated and initialized.
+ * @param config - Pointer to the UART configuration structure.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_uart_init(struct capi_uart_handle **handle,
+				const struct capi_uart_config *config)
+{
+	struct capi_uart_handle *uart_handle;
+	struct stm32_uart_priv_handle *uart_priv_handle;
+	struct stm32_uart_extra_config *uart_extra_config;
+	int ret = 0;
+
+	if (!handle || !config || !config->extra)
+		return -EINVAL;
+
+	if (*handle == NULL) {
+		uart_handle = (struct capi_uart_handle *)capi_calloc(1, sizeof(*uart_handle));
+		if (!uart_handle)
+			return -ENOMEM;
+
+		uart_priv_handle = (struct stm32_uart_priv_handle *)capi_calloc(1,
+				   sizeof(*uart_priv_handle));
+		if (!uart_priv_handle) {
+			capi_free(uart_handle);
+			return -ENOMEM;
+		}
+
+		uart_handle->priv = uart_priv_handle;
+		uart_handle->init_allocated = true;
+	} else {
+		uart_handle = *handle;
+		uart_handle->init_allocated = false;
+
+		if (!uart_handle->priv)
+			return -EINVAL;
+
+		uart_priv_handle = uart_handle->priv;
+	}
+	uart_handle->ops = config->ops;
+
+	uart_extra_config = config->extra;
+
+	uart_priv_handle->huart = uart_extra_config->huart;
+
+	uart_priv_handle->huart->Init.BaudRate = config->line_config->baudrate;
+
+	switch (config->line_config->size) {
+#ifdef UART_WORDLENGTH_7B
+	case CAPI_UART_DATA_BITS_7:
+		uart_priv_handle->huart->Init.WordLength = UART_WORDLENGTH_7B;
+		break;
+#endif
+	case CAPI_UART_DATA_BITS_8:
+		uart_priv_handle->huart->Init.WordLength = UART_WORDLENGTH_8B;
+		break;
+	/* TODO: add 9 bits option to CAPI */
+	/* case CAPI_UART_DATA_BITS_9:
+		uart_priv_handle->huart->Init.WordLength = UART_WORDLENGTH_9B;
+		break; */
+	default:
+		ret = -EINVAL;
+		goto error;
+	};
+
+	switch (config->line_config->parity) {
+	case CAPI_UART_PARITY_NONE:
+		uart_priv_handle->huart->Init.Parity = UART_PARITY_NONE;
+		break;
+	case CAPI_UART_PARITY_ODD:
+		uart_priv_handle->huart->Init.Parity = UART_PARITY_ODD;
+		break;
+	case CAPI_UART_PARITY_EVEN:
+		uart_priv_handle->huart->Init.Parity = UART_PARITY_EVEN;
+		break;
+	default:
+		ret = -EINVAL;
+		goto error;
+	};
+
+	uart_priv_handle->huart->Init.StopBits =
+		config->line_config->stop_bits == CAPI_UART_STOP_1_BIT ?
+		UART_STOPBITS_1 : UART_STOPBITS_2;
+
+	uart_priv_handle->huart->Init.Mode = uart_extra_config->huart->Init.Mode;
+	uart_priv_handle->huart->Init.HwFlowCtl =
+		uart_extra_config->huart->Init.HwFlowCtl;
+	uart_priv_handle->huart->Init.OverSampling =
+		uart_extra_config->huart->Init.OverSampling;
+
+	ret = HAL_UART_Init(uart_priv_handle->huart);
+	if (ret != HAL_OK) {
+		ret = -EIO;
+		goto error;
+	}
+
+	*handle = uart_handle;
+
+	uart_map_register(uart_priv_handle->huart, uart_handle);
+
+	return 0;
+error:
+	if (uart_handle->init_allocated) {
+		capi_free(uart_priv_handle);
+		capi_free(uart_handle);
+	}
+
+	return ret;
+}
+
+/**
+ * @brief Deinitialize the STM32 UART peripheral and free resources.
+ * @param handle - Pointer to the UART handle.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_uart_deinit(struct capi_uart_handle *handle)
+{
+	struct stm32_uart_priv_handle *uart_priv_handle;
+
+	if (!handle)
+		return -EINVAL;
+
+	uart_priv_handle = handle->priv;
+
+	if (uart_priv_handle) {
+		uart_map_unregister(uart_priv_handle->huart);
+		HAL_UART_DeInit(uart_priv_handle->huart);
+	}
+
+	if (handle->init_allocated) {
+		capi_free(uart_priv_handle);
+		capi_free(handle);
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Get the current UART line configuration from the STM32 HAL handle.
+ * @param handle - Pointer to the UART handle.
+ * @param line_config - Pointer to the structure to fill with current config.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_uart_get_line_config(struct capi_uart_handle *handle,
+		struct capi_uart_line_config *line_config)
+{
+	struct stm32_uart_priv_handle *priv;
+
+	if (!handle || !handle->priv || !line_config)
+		return -EINVAL;
+
+	priv = handle->priv;
+
+	line_config->baudrate = priv->huart->Init.BaudRate;
+
+	switch (priv->huart->Init.WordLength) {
+#ifdef UART_WORDLENGTH_7B
+	case UART_WORDLENGTH_7B:
+		line_config->size = CAPI_UART_DATA_BITS_7;
+		break;
+#endif
+	case UART_WORDLENGTH_8B:
+		line_config->size = CAPI_UART_DATA_BITS_8;
+		break;
+	default:
+		line_config->size = CAPI_UART_DATA_BITS_8;
+		break;
+	}
+
+	switch (priv->huart->Init.Parity) {
+	case UART_PARITY_ODD:
+		line_config->parity = CAPI_UART_PARITY_ODD;
+		break;
+	case UART_PARITY_EVEN:
+		line_config->parity = CAPI_UART_PARITY_EVEN;
+		break;
+	default:
+		line_config->parity = CAPI_UART_PARITY_NONE;
+		break;
+	}
+
+	line_config->stop_bits = (priv->huart->Init.StopBits == UART_STOPBITS_2) ?
+				 CAPI_UART_STOP_2_BIT : CAPI_UART_STOP_1_BIT;
+
+	switch (priv->huart->Init.HwFlowCtl) {
+	case UART_HWCONTROL_RTS:
+		line_config->flow_control = CAPI_UART_FLOW_CONTROL_RTS;
+		break;
+	case UART_HWCONTROL_CTS:
+		line_config->flow_control = CAPI_UART_FLOW_CONTROL_CTS;
+		break;
+	case UART_HWCONTROL_RTS_CTS:
+		line_config->flow_control = CAPI_UART_FLOW_CONTROL_RTSCTS;
+		break;
+	default:
+		line_config->flow_control = CAPI_UART_FLOW_CONTROL_NONE;
+		break;
+	}
+
+	line_config->address_mode = CAPI_UART_ADDRESS_MODE_DISABLED;
+	line_config->device_address = 0;
+	line_config->sticky_parity = false;
+	line_config->loopback = false;
+
+	return 0;
+}
+
+/**
+ * @brief Set a new UART line configuration on the STM32 peripheral.
+ * @param handle - Pointer to the UART handle.
+ * @param line_config - Pointer to the new line configuration to apply.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_uart_set_line_config(struct capi_uart_handle *handle,
+		struct capi_uart_line_config *line_config)
+{
+	struct stm32_uart_priv_handle *priv;
+	int ret;
+
+	if (!handle || !handle->priv || !line_config)
+		return -EINVAL;
+
+	priv = handle->priv;
+
+	priv->huart->Init.BaudRate = line_config->baudrate;
+
+	switch (line_config->size) {
+#ifdef UART_WORDLENGTH_7B
+	case CAPI_UART_DATA_BITS_7:
+		priv->huart->Init.WordLength = UART_WORDLENGTH_7B;
+		break;
+#endif
+	case CAPI_UART_DATA_BITS_8:
+		priv->huart->Init.WordLength = UART_WORDLENGTH_8B;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	switch (line_config->parity) {
+	case CAPI_UART_PARITY_NONE:
+		priv->huart->Init.Parity = UART_PARITY_NONE;
+		break;
+	case CAPI_UART_PARITY_ODD:
+		priv->huart->Init.Parity = UART_PARITY_ODD;
+		break;
+	case CAPI_UART_PARITY_EVEN:
+		priv->huart->Init.Parity = UART_PARITY_EVEN;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	priv->huart->Init.StopBits = (line_config->stop_bits == CAPI_UART_STOP_2_BIT) ?
+				     UART_STOPBITS_2 : UART_STOPBITS_1;
+
+	switch (line_config->flow_control) {
+	case CAPI_UART_FLOW_CONTROL_NONE:
+		priv->huart->Init.HwFlowCtl = UART_HWCONTROL_NONE;
+		break;
+	case CAPI_UART_FLOW_CONTROL_RTS:
+		priv->huart->Init.HwFlowCtl = UART_HWCONTROL_RTS;
+		break;
+	case CAPI_UART_FLOW_CONTROL_CTS:
+		priv->huart->Init.HwFlowCtl = UART_HWCONTROL_CTS;
+		break;
+	case CAPI_UART_FLOW_CONTROL_RTSCTS:
+		priv->huart->Init.HwFlowCtl = UART_HWCONTROL_RTS_CTS;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	ret = HAL_UART_Init(priv->huart);
+	if (ret != HAL_OK)
+		return -EIO;
+
+	return 0;
+}
+
+/**
+ * @brief Transmit data over the STM32 UART peripheral.
+ * @param handle - Pointer to the UART handle.
+ * @param buf - Pointer to the data buffer to transmit.
+ * @param len - Number of bytes to transmit.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_uart_transmit(struct capi_uart_handle *handle,
+				    uint8_t *buf, uint32_t len)
+{
+	struct stm32_uart_priv_handle *uart_priv_handle;
+	int ret;
+
+	if (!handle || !handle->priv || !buf)
+		return -EINVAL;
+
+	if (!len)
+		return 0;
+
+	uart_priv_handle = handle->priv;
+
+	ret = HAL_UART_Transmit(uart_priv_handle->huart, buf, len, HAL_MAX_DELAY);
+	switch (ret) {
+	case HAL_OK:
+		break;
+	case HAL_BUSY:
+		return -EBUSY;
+	case HAL_TIMEOUT:
+		return -ETIMEDOUT;
+	default:
+		return -EIO;
+	};
+
+	return 0;
+}
+
+/**
+ * @brief Receive data from the STM32 UART peripheral.
+ * @param handle - Pointer to the UART handle.
+ * @param buf - Pointer to the buffer to store received data.
+ * @param len - Number of bytes to receive.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_uart_receive(struct capi_uart_handle *handle,
+				   uint8_t *buf, uint32_t len)
+{
+	struct stm32_uart_priv_handle *uart_priv_handle;
+	int ret;
+
+	if (!handle || !handle->priv || !buf)
+		return -EINVAL;
+
+	if (!len)
+		return 0;
+
+	uart_priv_handle = handle->priv;
+
+	ret = HAL_UART_Receive(uart_priv_handle->huart, buf, len, HAL_MAX_DELAY);
+	switch (ret) {
+	case HAL_OK:
+		break;
+	case HAL_BUSY:
+		return -EBUSY;
+	case HAL_TIMEOUT:
+		return -ETIMEDOUT;
+	default:
+		return -EIO;
+	};
+
+	return 0;
+}
+
+/**
+ * @brief Register a user callback for UART async events.
+ * @param handle - Pointer to the UART handle.
+ * @param callback - User callback function.
+ * @param callback_arg - User-provided argument forwarded to the callback.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_uart_register_callback(struct capi_uart_handle *handle,
+		capi_uart_callback const callback,
+		void *const callback_arg)
+{
+	struct stm32_uart_priv_handle *priv;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	priv = handle->priv;
+	priv->callback = callback;
+	priv->callback_arg = callback_arg;
+
+	return 0;
+}
+
+/**
+ * @brief Transmit data asynchronously (interrupt-driven).
+ * @param handle - Pointer to the UART handle.
+ * @param buf - Pointer to the data buffer to transmit.
+ * @param len - Number of bytes to transmit.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_uart_transmit_async(struct capi_uart_handle *handle,
+		uint8_t *buf, uint32_t len)
+{
+	struct stm32_uart_priv_handle *priv;
+	int ret;
+
+	if (!handle || !handle->priv || !buf)
+		return -EINVAL;
+
+	if (!len)
+		return 0;
+
+	priv = handle->priv;
+
+	ret = HAL_UART_Transmit_IT(priv->huart, buf, (uint16_t)len);
+	switch (ret) {
+	case HAL_OK:
+		return 0;
+	case HAL_BUSY:
+		return -EBUSY;
+	default:
+		return -EIO;
+	}
+}
+
+/**
+ * @brief Receive data asynchronously (interrupt-driven).
+ * @param handle - Pointer to the UART handle.
+ * @param buf - Pointer to the buffer for incoming data.
+ * @param len - Number of bytes to receive.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_uart_receive_async(struct capi_uart_handle *handle,
+		uint8_t *buf, uint32_t len)
+{
+	struct stm32_uart_priv_handle *priv;
+	int ret;
+
+	if (!handle || !handle->priv || !buf)
+		return -EINVAL;
+
+	if (!len)
+		return 0;
+
+	priv = handle->priv;
+
+	ret = HAL_UART_Receive_IT(priv->huart, buf, (uint16_t)len);
+	switch (ret) {
+	case HAL_OK:
+		return 0;
+	case HAL_BUSY:
+		return -EBUSY;
+	default:
+		return -EIO;
+	}
+}
+
+/**
+ * @brief Get the reason for the most recent UART interrupt.
+ * @param handle - Pointer to the UART handle.
+ * @param reason - Output: the interrupt reason.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_uart_get_interrupt_reason(
+	struct capi_uart_handle *handle,
+	enum capi_uart_interrupt_reason *reason)
+{
+	struct stm32_uart_priv_handle *priv;
+
+	if (!handle || !handle->priv || !reason)
+		return -EINVAL;
+
+	priv = handle->priv;
+	*reason = priv->last_interrupt_reason;
+
+	return 0;
+}
+
+/**
+ * @brief Get accumulated line status flags.
+ * @param handle - Pointer to the UART handle.
+ * @param status_flags - Output: bitmask of capi_uart_line_status_flags.
+ * @return 0 on success, negative error code otherwise.
+ */
+static int stm32_capi_uart_get_line_status(struct capi_uart_handle *handle,
+		uint32_t *status_flags)
+{
+	struct stm32_uart_priv_handle *priv;
+
+	if (!handle || !handle->priv || !status_flags)
+		return -EINVAL;
+
+	priv = handle->priv;
+	*status_flags = priv->last_line_status;
+	priv->last_line_status = 0;
+
+	return 0;
+}
+
+/**
+ * @brief UART ISR entry point — delegates to HAL_UART_IRQHandler.
+ * @param handle - Pointer to the UART handle (cast from void *).
+ */
+static void stm32_capi_uart_isr(void *handle)
+{
+	struct capi_uart_handle *uart_handle = (struct capi_uart_handle *)handle;
+	struct stm32_uart_priv_handle *priv;
+
+	if (!uart_handle || !uart_handle->priv)
+		return;
+
+	priv = uart_handle->priv;
+
+	HAL_UART_IRQHandler(priv->huart);
+}
+
+/*
+ * STM32 HAL weak-override callbacks.
+ *
+ * The HAL calls these from HAL_UART_IRQHandler().  We look up the CAPI
+ * handle via the mapping table and forward the event to the user callback.
+ */
+
+void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart)
+{
+	struct capi_uart_handle *handle = uart_map_lookup(huart);
+	struct stm32_uart_priv_handle *priv;
+
+	if (!handle)
+		return;
+
+	priv = handle->priv;
+	if (priv->callback)
+		priv->callback(CAPI_UART_EVENT_TX_DONE, priv->callback_arg, 0);
+}
+
+void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart)
+{
+	struct capi_uart_handle *handle = uart_map_lookup(huart);
+	struct stm32_uart_priv_handle *priv;
+
+	if (!handle)
+		return;
+
+	priv = handle->priv;
+	if (priv->callback)
+		priv->callback(CAPI_UART_EVENT_RX_DONE, priv->callback_arg, 0);
+}
+
+void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart)
+{
+	struct capi_uart_handle *handle = uart_map_lookup(huart);
+	struct stm32_uart_priv_handle *priv;
+	uint32_t error;
+
+	if (!handle)
+		return;
+
+	priv = handle->priv;
+	error = huart->ErrorCode;
+
+	/* Map HAL error bits to CAPI line status flags */
+	if (error & HAL_UART_ERROR_PE)
+		priv->last_line_status |= CAPI_UART_LINE_STAT_PARITY_ERROR;
+	if (error & HAL_UART_ERROR_FE)
+		priv->last_line_status |= CAPI_UART_LINE_STAT_FRAMING_ERROR;
+	if (error & HAL_UART_ERROR_ORE)
+		priv->last_line_status |= CAPI_UART_LINE_STAT_OVERRUN_ERROR;
+
+	priv->last_interrupt_reason = CAPI_UART_INTR_RX_LINE_STATUS;
+
+	if (priv->callback)
+		priv->callback(CAPI_UART_EVENT_INTERRUPT, priv->callback_arg,
+			       (int)error);
+}
+
+void HAL_UART_AbortCpltCallback(UART_HandleTypeDef *huart)
+{
+	struct capi_uart_handle *handle = uart_map_lookup(huart);
+	struct stm32_uart_priv_handle *priv;
+
+	if (!handle)
+		return;
+
+	priv = handle->priv;
+	if (priv->callback)
+		priv->callback(CAPI_UART_EVENT_TX_ABORTED, priv->callback_arg,
+			       0);
+}
+
+const struct capi_uart_ops stm32_capi_uart_ops = {
+	.init = stm32_capi_uart_init,
+	.deinit = stm32_capi_uart_deinit,
+	.get_line_config = stm32_capi_uart_get_line_config,
+	.set_line_config = stm32_capi_uart_set_line_config,
+	.transmit = stm32_capi_uart_transmit,
+	.receive = stm32_capi_uart_receive,
+	.register_callback = stm32_capi_uart_register_callback,
+	.transmit_async = stm32_capi_uart_transmit_async,
+	.receive_async = stm32_capi_uart_receive_async,
+	.get_interrupt_reason = stm32_capi_uart_get_interrupt_reason,
+	.get_line_status = stm32_capi_uart_get_line_status,
+	.isr = stm32_capi_uart_isr,
+};
+
+static struct capi_uart_handle *uart_stdio_handle = NULL;
+
+/**
+ * @brief Enable stdio redirection over the STM32 UART peripheral.
+ * @param handle - Pointer to an initialized UART handle.
+ * @return 0 on success, negative error code otherwise.
+ */
+int stm32_uart_stdio_enable(struct capi_uart_handle *handle)
+{
+	if (!handle)
+		return -EINVAL;
+
+	uart_stdio_handle = handle;
+
+	/* Disable I/O buffering for STDOUT stream, so that
+	* chars are sent out as soon as they are printed. */
+	setvbuf(stdout, NULL, _IONBF, 0);
+
+	return 0;
+}
+
+#define STDIN_FILENO  0
+#define STDOUT_FILENO 1
+#define STDERR_FILENO 2
+
+/**
+ * @brief Check if a file descriptor refers to a terminal.
+ * @param fd - File descriptor to check.
+ * @return 1 if the descriptor is a terminal, 0 otherwise.
+ */
+int _isatty(int fd)
+{
+	if (fd >= STDIN_FILENO && fd <= STDERR_FILENO)
+		return 1;
+
+	errno = EBADF;
+	return 0;
+}
+
+/**
+ * @brief Write data to a file descriptor.
+ * @param fd - File descriptor to write to.
+ * @param ptr - Pointer to the data buffer.
+ * @param len - Number of bytes to write.
+ * @return Number of bytes written on success, -1 on error.
+ */
+int _write(int fd, char *ptr, int len)
+{
+	int ret;
+
+	if (fd == STDOUT_FILENO || fd == STDERR_FILENO) {
+		ret = stm32_capi_uart_transmit(uart_stdio_handle, (uint8_t *)ptr, len);
+		if (ret < 0) {
+			errno = -ret;
+			return -1;
+		}
+
+		return len;
+	}
+	errno = EBADF;
+	return -1;
+}
+
+/**
+ * @brief Close a file descriptor.
+ * @param fd - File descriptor to close.
+ * @return 0 on success, -1 on error.
+ */
+int _close(int fd)
+{
+	if (fd >= STDIN_FILENO && fd <= STDERR_FILENO)
+		return 0;
+
+	errno = EBADF;
+	return -1;
+}
+
+/**
+ * @brief Reposition file descriptor offset.
+ * @param fd - File descriptor.
+ * @param ptr - Offset value.
+ * @param dir - Seek direction.
+ * @return -1 always, seeking is not supported.
+ */
+int _lseek(int fd, int ptr, int dir)
+{
+	(void) fd;
+	(void) ptr;
+	(void) dir;
+
+	errno = EBADF;
+	return -1;
+}
+
+/**
+ * @brief Read data from a file descriptor.
+ * @param fd - File descriptor to read from.
+ * @param ptr - Pointer to the buffer for incoming data.
+ * @param len - Number of bytes to read.
+ * @return Number of bytes read on success, -1 on error.
+ */
+int _read(int fd, char *ptr, int len)
+{
+	int ret;
+
+	if (fd == STDIN_FILENO) {
+		ret = stm32_capi_uart_receive(uart_stdio_handle, (uint8_t *)ptr, 1);
+		if (ret < 0) {
+			errno = -ret;
+			return -1;
+		}
+
+		return 1;
+	}
+	errno = EBADF;
+	return -1;
+}
+
+/**
+ * @brief Get file status.
+ * @param fd - File descriptor.
+ * @param st - Pointer to the stat structure to fill.
+ * @return 0 on success, -1 on error.
+ */
+int _fstat(int fd, struct stat *st)
+{
+	if (fd >= STDIN_FILENO && fd <= STDERR_FILENO) {
+		st->st_mode = S_IFCHR;
+		return 0;
+	}
+
+	errno = EBADF;
+	return 0;
+}

--- a/capi/platform/stm32/stm32_capi_uart.h
+++ b/capi/platform/stm32/stm32_capi_uart.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef STM32_CAPI_UART_H_
+#define STM32_CAPI_UART_H_
+
+#include "stm32_hal.h"
+#include "capi_uart.h"
+
+/**
+ * @brief STM32-specific UART extra configuration
+ */
+struct stm32_uart_extra_config {
+	/** Pointer to the STM32 HAL UART handle */
+	UART_HandleTypeDef *huart;
+};
+
+/**
+ * @brief STM32 platform specific UART operations for CAPI
+ */
+extern const struct capi_uart_ops stm32_capi_uart_ops;
+
+/**
+ * @brief Enable stdio redirection over the STM32 UART peripheral.
+ * @param handle - Pointer to an initialized UART handle.
+ * @return 0 on success, negative error code otherwise.
+ */
+int stm32_uart_stdio_enable(struct capi_uart_handle *handle);
+
+#endif /* STM32_CAPI_UART_H_ */

--- a/capi/platform/stm32/stm32_capi_uart_priv.h
+++ b/capi/platform/stm32/stm32_capi_uart_priv.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _STM32_CAPI_UART_PRIV_H_
+#define _STM32_CAPI_UART_PRIV_H_
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+#include "stm32_capi_uart.h"
+
+/**
+ * @brief STM32-specific UART private handle data
+ */
+struct stm32_uart_priv_handle {
+	/** Pointer to the STM32 HAL UART handle */
+	UART_HandleTypeDef *huart;
+	/** User-registered CAPI async callback */
+	capi_uart_callback callback;
+	/** User-provided argument passed to callback */
+	void *callback_arg;
+	/** Cached interrupt reason for get_interrupt_reason */
+	enum capi_uart_interrupt_reason last_interrupt_reason;
+	/** Cached line status flags for get_line_status */
+	uint32_t last_line_status;
+};
+
+#define CAPI_UART_HANDLE_STM32_INIT() \
+	(&(struct capi_uart_handle){ \
+		.ops = NULL, \
+		.init_allocated = false, \
+		.priv = &(struct stm32_uart_priv_handle){0}})
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
+
+#endif /* _STM32_CAPI_UART_PRIV_H_ */

--- a/capi/src/capi_alloc.c
+++ b/capi/src/capi_alloc.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025 Analog Devices, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "capi_alloc.h"
+
+/* Default weak implementations: no-op implementations that return NULL/do nothing */
+
+__attribute__((weak)) void *capi_malloc_impl(size_t size)
+{
+	(void)size;
+	return NULL;
+}
+
+__attribute__((weak)) void capi_free_impl(void *ptr)
+{
+	(void)ptr;
+}
+
+__attribute__((weak)) void *capi_calloc_impl(size_t num, size_t size)
+{
+	(void)num;
+	(void)size;
+	return NULL;
+}
+
+__attribute__((weak)) void *capi_realloc_impl(void *ptr, size_t size)
+{
+	(void)ptr;
+	(void)size;
+	return NULL;
+}
+
+/* Strong wrapper functions that call the (possibly overridden) implementations */
+
+void *capi_malloc(size_t size)
+{
+	return capi_malloc_impl(size);
+}
+
+void capi_free(void *ptr)
+{
+	capi_free_impl(ptr);
+}
+
+void *capi_calloc(size_t num, size_t size)
+{
+	return capi_calloc_impl(num, size);
+}
+
+void *capi_realloc(void *ptr, size_t size)
+{
+	return capi_realloc_impl(ptr, size);
+}

--- a/capi/src/capi_dma.c
+++ b/capi/src/capi_dma.c
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2024-2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file capi_dma.c
+ * @brief This file contains a set of small wrapper functions that can be used to access
+ *        the DMA driver via its ops pointer structure. Note, it does not
+ *        implement any thread safety such as mutually excluding calls to the DMA functions.
+ *        If this is needed, it is suggested that this file and all of the other driver
+ *        wrappers be copied and enhanced in your project.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <capi_dma.h>
+
+int capi_dma_init(struct capi_dma_handle **handle,
+		  const struct capi_dma_config *config)
+{
+	if (!handle || !config || !config->ops || !config->ops->init) {
+		return -EINVAL;
+	}
+	return config->ops->init(handle, config);
+}
+
+int capi_dma_deinit(struct capi_dma_handle *handle)
+{
+	if (!handle || !handle->ops || !handle->ops->deinit) {
+		return -EINVAL;
+	}
+	return handle->ops->deinit(handle);
+}
+
+int capi_dma_init_chan(struct capi_dma_handle *handle,
+		       struct capi_dma_chan **chan_ptr, uint32_t id)
+{
+	if (!handle || !handle->ops || !handle->ops->init_chan) {
+		return -EINVAL;
+	}
+	return handle->ops->init_chan(handle, chan_ptr, id);
+}
+
+int capi_dma_deinit_chan(struct capi_dma_chan *chan)
+{
+	if (!chan || !chan->handle || !chan->handle->ops
+	    || !chan->handle->ops->deinit_chan) {
+		return -EINVAL;
+	}
+	return chan->handle->ops->deinit_chan(chan);
+}
+
+int capi_dma_config_xfer(struct capi_dma_chan *chan,
+			 struct capi_dma_transfer *xfer)
+{
+	if (!chan || !chan->handle || !chan->handle->ops
+	    || !chan->handle->ops->config_xfer) {
+		return -EINVAL;
+	}
+	return chan->handle->ops->config_xfer(chan, xfer);
+}
+
+int capi_dma_xfer_start(struct capi_dma_chan *chan)
+{
+	if (!chan || !chan->handle || !chan->handle->ops
+	    || !chan->handle->ops->xfer_start) {
+		return -EINVAL;
+	}
+	return chan->handle->ops->xfer_start(chan);
+}
+
+int capi_dma_xfer_abort(struct capi_dma_chan *chan)
+{
+	if (!chan || !chan->handle || !chan->handle->ops
+	    || !chan->handle->ops->xfer_abort) {
+		return -EINVAL;
+	}
+	return chan->handle->ops->xfer_abort(chan);
+}
+
+bool capi_dma_chan_is_completed(const struct capi_dma_chan *chan)
+{
+	if (!chan || !chan->handle || !chan->handle->ops
+	    || !chan->handle->ops->chan_is_completed) {
+		return false;
+	}
+	return chan->handle->ops->chan_is_completed(chan);
+}
+
+int capi_dma_isr(struct capi_dma_handle *handle)
+{
+	if (!handle || !handle->ops || !handle->ops->isr) {
+		return -EINVAL;
+	}
+	return handle->ops->isr(handle);
+}
+
+int capi_dma_isr_chan(struct capi_dma_chan *chan)
+{
+	if (!chan || !chan->handle || !chan->handle->ops
+	    || !chan->handle->ops->isr_chan) {
+		return -EINVAL;
+	}
+	return chan->handle->ops->isr_chan(chan);
+}
+
+int capi_dma_register_complete_callback(struct capi_dma_chan *chan,
+					capi_dma_xfer_complete_cb callback, void *xfer_complete_ctx)
+{
+	if (!chan || !chan->handle || !chan->handle->ops ||
+	    !chan->handle->ops->register_complete_callback) {
+		return -EINVAL;
+	}
+
+	return chan->handle->ops->register_complete_callback(chan, callback,
+			xfer_complete_ctx);
+}
+
+int capi_dma_register_error_callback(struct capi_dma_chan *chan,
+				     capi_dma_error_cb callback,
+				     void *error_ctx)
+{
+	if (!chan || !chan->handle || !chan->handle->ops ||
+	    !chan->handle->ops->register_error_callback) {
+		return -EINVAL;
+	}
+
+	return chan->handle->ops->register_error_callback(chan, callback, error_ctx);
+}
+
+int capi_dma_config_scattergather_xfer(struct capi_dma_chan *chan,
+				       const struct capi_dma_sg_config *sg_config,
+				       struct capi_dma_transfer *block, uint32_t index)
+{
+	if (!chan || !chan->handle || !chan->handle->ops ||
+	    !chan->handle->ops->config_scattergather_xfer || !sg_config || !block) {
+		return -EINVAL;
+	}
+	return chan->handle->ops->config_scattergather_xfer(chan, sg_config, block,
+			index);
+}
+
+int capi_dma_start_scattergather_xfer(struct capi_dma_chan *chan,
+				      const struct capi_dma_sg_config *sg_config)
+{
+	if (!chan || !chan->handle || !chan->handle->ops ||
+	    !chan->handle->ops->start_scattergather_xfer) {
+		return -EINVAL;
+	}
+	return chan->handle->ops->start_scattergather_xfer(chan, sg_config);
+}

--- a/capi/src/capi_gpio.c
+++ b/capi/src/capi_gpio.c
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2024-2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file capi_gpio.c
+ * @brief This file contains a set of small wrapper functions that can be used to access
+ *        the GPIO driver via its ops pointer structure. Note, it does not
+ *        implement any thread safety such as mutually excluding calls to the GPIO functions.
+ *        If this is needed, it is suggested that this file and all of the other driver
+ *        wrappers be copied and enhanced in your project.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <capi_gpio.h>
+
+int capi_gpio_port_init(struct capi_gpio_port_handle **handle,
+			const struct capi_gpio_port_config *config)
+{
+	if (!handle || !config || !config->ops || !config->ops->port_init) {
+		return -EINVAL;
+	}
+	return config->ops->port_init(handle, config);
+}
+
+int capi_gpio_port_deinit(struct capi_gpio_port_handle **handle)
+{
+	if (!handle || !*handle || !(*handle)->ops || !(*handle)->ops->port_deinit) {
+		return -EINVAL;
+	}
+	return (*handle)->ops->port_deinit(handle);
+}
+
+int capi_gpio_port_set_direction(struct capi_gpio_port_handle *handle,
+				 uint64_t direction_bitmask)
+{
+	if (!handle || !handle->ops || !handle->ops->port_set_direction) {
+		return -EINVAL;
+	}
+	return handle->ops->port_set_direction(handle, direction_bitmask);
+}
+
+int capi_gpio_port_get_direction(struct capi_gpio_port_handle *handle,
+				 uint64_t *direction_bitmask)
+{
+	if (!handle || !handle->ops || !handle->ops->port_get_direction) {
+		return -EINVAL;
+	}
+	return handle->ops->port_get_direction(handle, direction_bitmask);
+}
+
+int capi_gpio_port_set_value(struct capi_gpio_port_handle *handle,
+			     uint64_t value_bitmask)
+{
+	if (!handle || !handle->ops || !handle->ops->port_set_value) {
+		return -EINVAL;
+	}
+	return handle->ops->port_set_value(handle, value_bitmask);
+}
+
+int capi_gpio_port_get_value(struct capi_gpio_port_handle *handle,
+			     uint64_t *value_bitmask)
+{
+	if (!handle || !handle->ops || !handle->ops->port_get_value) {
+		return -EINVAL;
+	}
+	return handle->ops->port_get_value(handle, value_bitmask);
+}
+
+int capi_gpio_port_set_raw_value(struct capi_gpio_port_handle *handle,
+				 uint64_t value_bitmask)
+{
+	if (!handle || !handle->ops || !handle->ops->port_set_raw_value) {
+		return -EINVAL;
+	}
+	return handle->ops->port_set_raw_value(handle, value_bitmask);
+}
+
+int capi_gpio_port_get_raw_value(struct capi_gpio_port_handle *handle,
+				 uint64_t *value_bitmask)
+{
+	if (!handle || !handle->ops || !handle->ops->port_get_raw_value) {
+		return -EINVAL;
+	}
+	return handle->ops->port_get_raw_value(handle, value_bitmask);
+}
+
+int capi_gpio_pin_set_direction(struct capi_gpio_pin *pin, uint8_t direction)
+{
+	if (!pin || !pin->port_handle || !pin->port_handle->ops ||
+	    !pin->port_handle->ops->pin_set_direction) {
+		return -EINVAL;
+	}
+	return pin->port_handle->ops->pin_set_direction(pin, direction);
+}
+
+int capi_gpio_pin_get_direction(struct capi_gpio_pin *pin, uint8_t *direction)
+{
+	if (!pin || !pin->port_handle || !pin->port_handle->ops ||
+	    !pin->port_handle->ops->pin_get_direction) {
+		return -EINVAL;
+	}
+	return pin->port_handle->ops->pin_get_direction(pin, direction);
+}
+
+int capi_gpio_pin_set_value(struct capi_gpio_pin *pin, uint8_t value)
+{
+	if (!pin || !pin->port_handle || !pin->port_handle->ops ||
+	    !pin->port_handle->ops->pin_set_value) {
+		return -EINVAL;
+	}
+	return pin->port_handle->ops->pin_set_value(pin, value);
+}
+
+int capi_gpio_pin_get_value(struct capi_gpio_pin *pin, uint8_t *value)
+{
+	if (!pin || !pin->port_handle || !pin->port_handle->ops ||
+	    !pin->port_handle->ops->pin_get_value) {
+		return -EINVAL;
+	}
+	return pin->port_handle->ops->pin_get_value(pin, value);
+}
+
+int capi_gpio_pin_set_raw_value(struct capi_gpio_pin *pin, uint8_t value)
+{
+	if (!pin || !pin->port_handle || !pin->port_handle->ops ||
+	    !pin->port_handle->ops->pin_set_raw_value) {
+		return -EINVAL;
+	}
+	return pin->port_handle->ops->pin_set_raw_value(pin, value);
+}
+
+int capi_gpio_pin_get_raw_value(struct capi_gpio_pin *pin, uint8_t *value)
+{
+	if (!pin || !pin->port_handle || !pin->port_handle->ops ||
+	    !pin->port_handle->ops->pin_get_raw_value) {
+		return -EINVAL;
+	}
+	return pin->port_handle->ops->pin_get_raw_value(pin, value);
+}

--- a/capi/src/capi_i2c.c
+++ b/capi/src/capi_i2c.c
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2024-2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file capi_i2c.c
+ * @brief This file contains a set of small wrapper functions that can be used to access
+ *        the I2C driver via its ops pointer structure. Note, it does not
+ *        implement any thread safety such as mutually excluding calls to the I2C functions.
+ *        If this is needed, it is suggested that this file and all of the other driver
+ *        wrappers be copied and enhanced in your project.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <capi_i2c.h>
+
+int capi_i2c_init(struct capi_i2c_controller_handle **handle,
+		  const struct capi_i2c_config *config)
+{
+	if (!handle || !config || !config->ops || !config->ops->init) {
+		return -EINVAL;
+	}
+	return config->ops->init(handle, config);
+}
+
+int capi_i2c_deinit(struct capi_i2c_controller_handle *handle)
+{
+	if (!handle || !handle->ops || !handle->ops->deinit) {
+		return -EINVAL;
+	}
+	return handle->ops->deinit(handle);
+}
+
+int capi_i2c_transmit(struct capi_i2c_device *device,
+		      struct capi_i2c_transfer *transfer)
+{
+	if (!device || !device->controller || !device->controller->ops ||
+	    !device->controller->ops->transmit) {
+		return -EINVAL;
+	}
+	return device->controller->ops->transmit(device, transfer);
+}
+
+int capi_i2c_receive(struct capi_i2c_device *device,
+		     struct capi_i2c_transfer *transfer)
+{
+	if (!device || !device->controller || !device->controller->ops ||
+	    !device->controller->ops->receive) {
+		return -EINVAL;
+	}
+	return device->controller->ops->receive(device, transfer);
+}
+
+int capi_i2c_configure_bus_speed(struct capi_i2c_controller_handle *handle,
+				 enum capi_i2c_speed speed, uint8_t duty_cycle)
+{
+	if (!handle || !handle->ops || !handle->ops->configure_bus_speed) {
+		return -EINVAL;
+	}
+	return handle->ops->configure_bus_speed(handle, speed, duty_cycle);
+}
+
+int capi_i2c_register_callback(struct capi_i2c_controller_handle *handle,
+			       capi_i2c_callback const callback, void *const callback_arg)
+{
+	if (!handle || !handle->ops || !handle->ops->register_callback) {
+		return -EINVAL;
+	}
+	return handle->ops->register_callback(handle, callback, callback_arg);
+}
+
+int capi_i2c_transmit_async(struct capi_i2c_device *device,
+			    struct capi_i2c_transfer *transfer)
+{
+	if (!device || !device->controller || !device->controller->ops ||
+	    !device->controller->ops->transmit_async) {
+		return -EINVAL;
+	}
+	return device->controller->ops->transmit_async(device, transfer);
+}
+
+int capi_i2c_receive_async(struct capi_i2c_device *device,
+			   struct capi_i2c_transfer *transfer)
+{
+	if (!device || !device->controller || !device->controller->ops ||
+	    !device->controller->ops->receive_async) {
+		return -EINVAL;
+	}
+	return device->controller->ops->receive_async(device, transfer);
+}
+
+int capi_i2c_recover_bus(struct capi_i2c_controller_handle *handle)
+{
+	if (!handle || !handle->ops || !handle->ops->recover_bus) {
+		return -EINVAL;
+	}
+	return handle->ops->recover_bus(handle);
+}
+
+int capi_i2c_register_target(struct capi_i2c_controller_handle *handle,
+			     uint16_t addr)
+{
+	if (!handle || !handle->ops || !handle->ops->register_target) {
+		return -EINVAL;
+	}
+	return handle->ops->register_target(handle, addr);
+}
+
+int capi_i2c_unregister_target(struct capi_i2c_controller_handle *handle)
+{
+	if (!handle || !handle->ops || !handle->ops->unregister_target) {
+		return -EINVAL;
+	}
+	return handle->ops->unregister_target(handle);
+}
+
+void capi_i2c_isr(void *handle)
+{
+	if (!handle) {
+		return;
+	}
+	struct capi_i2c_controller_handle *ctrl_handle =
+		(struct capi_i2c_controller_handle *)handle;
+	if (!ctrl_handle->ops || !ctrl_handle->ops->isr) {
+		return;
+	}
+	ctrl_handle->ops->isr(handle);
+}

--- a/capi/src/capi_irq.c
+++ b/capi/src/capi_irq.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2024-2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file capi_irq.c
+ * @brief This file contains a set of small wrapper functions that can be used to access
+ *        the IRQ driver via its ops pointer structure. Note, it does not
+ *        contain the actual driver implementation.
+ */
+
+#include "capi_irq.h"
+
+// For stub implementation, we directly call the stub functions
+#ifdef CAPI_STUB_IMPLEMENTATION
+#include "capi_irq_stub_driver.h"
+
+int capi_irq_init(struct capi_irq_config *config)
+{
+	return capi_irq_stub_init(config);
+}
+
+int capi_irq_deinit(void)
+{
+	return capi_irq_stub_deinit();
+}
+
+int capi_irq_global_enable(void)
+{
+	return capi_irq_stub_global_enable();
+}
+
+int capi_irq_global_disable(void)
+{
+	return capi_irq_stub_global_disable();
+}
+
+int capi_irq_enable(uint32_t irq)
+{
+	return capi_irq_stub_enable(irq);
+}
+
+int capi_irq_disable(uint32_t irq)
+{
+	return capi_irq_stub_disable(irq);
+}
+
+int capi_irq_connect(uint32_t irq, capi_isr_callback_t isr, void *arg)
+{
+	return capi_irq_stub_connect(irq, isr, arg);
+}
+
+int capi_irq_clear_pending(uint32_t irq)
+{
+	return capi_irq_stub_clear_pending(irq);
+}
+
+int capi_irq_get_status(uint32_t irq, uint32_t *pactive)
+{
+	return capi_irq_stub_get_status(irq, pactive);
+}
+
+int capi_irq_set_priority(uint32_t irq, uint32_t priority)
+{
+	return capi_irq_stub_set_priority(irq, priority);
+}
+
+int capi_irq_get_priority(uint32_t irq, uint32_t *priority)
+{
+	return capi_irq_stub_get_priority(irq, priority);
+}
+
+int capi_irq_set_level_edge_trigger(uint32_t irq,
+				    enum capi_irq_trig_level trigger)
+{
+	return capi_irq_stub_set_level_edge_trigger(irq, trigger);
+}
+
+#endif /* CAPI_STUB_IMPLEMENTATION */

--- a/capi/src/capi_spi.c
+++ b/capi/src/capi_spi.c
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2024-2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file capi_spi.c
+ * @brief This file contains a set of small wrapper functions that can be used to access
+ *        the SPI driver via its ops pointer structure. Note, it does not
+ *        implement any thread safety such as mutually excluding calls to the SPI functions.
+ *        If this is needed, it is suggested that this file and all of the other driver
+ *        wrappers be copied and enhanced in your project.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <capi_spi.h>
+
+int capi_spi_init(struct capi_spi_controller_handle **handle,
+		  const struct capi_spi_config *config)
+{
+	if (!handle || !config || !config->ops || !config->ops->init) {
+		return -EINVAL;
+	}
+	return config->ops->init(handle, config);
+}
+
+int capi_spi_deinit(struct capi_spi_controller_handle *handle)
+{
+	if (!handle || !handle->ops || !handle->ops->deinit) {
+		return -EINVAL;
+	}
+	return handle->ops->deinit(handle);
+}
+
+int capi_spi_transceive(struct capi_spi_device *device,
+			struct capi_spi_transfer *transfer)
+{
+	if (!device || !device->controller || !device->controller->ops ||
+	    !device->controller->ops->transceive) {
+		return -EINVAL;
+	}
+	return device->controller->ops->transceive(device, transfer);
+}
+
+int capi_spi_transceive_async(struct capi_spi_device *device,
+			      struct capi_spi_transfer *transfer)
+{
+	if (!device || !device->controller || !device->controller->ops ||
+	    !device->controller->ops->transceive_async) {
+		return -EINVAL;
+	}
+	return device->controller->ops->transceive_async(device, transfer, 0);
+}
+
+int capi_spi_read_command(struct capi_spi_device *device,
+			  struct capi_spi_transfer *transfer)
+{
+	if (!device || !device->controller || !device->controller->ops ||
+	    !device->controller->ops->read_command) {
+		return -EINVAL;
+	}
+	return device->controller->ops->read_command(device, transfer);
+}
+
+int capi_spi_read_command_async(struct capi_spi_device *device,
+				struct capi_spi_transfer *transfer)
+{
+	if (!device || !device->controller || !device->controller->ops ||
+	    !device->controller->ops->read_command_async) {
+		return -EINVAL;
+	}
+	return device->controller->ops->read_command_async(device, transfer);
+}
+
+int capi_spi_abort_async(struct capi_spi_device *device)
+{
+	if (!device || !device->controller || !device->controller->ops ||
+	    !device->controller->ops->abort_async) {
+		return -EINVAL;
+	}
+	return device->controller->ops->abort_async(device);
+}
+
+int capi_spi_register_callback(struct capi_spi_controller_handle *handle,
+			       capi_spi_callback_t const callback, void *callback_arg)
+{
+	if (!handle || !handle->ops || !handle->ops->register_callback) {
+		return -EINVAL;
+	}
+	return handle->ops->register_callback(handle, callback, callback_arg);
+}
+
+int capi_spi_set_cs(struct capi_spi_device *device,
+		    enum capi_spi_cs_control cs_control)
+{
+	if (!device || !device->controller || !device->controller->ops ||
+	    !device->controller->ops->set_cs) {
+		return -EINVAL;
+	}
+	return device->controller->ops->set_cs(device, cs_control);
+}
+
+void capi_spi_isr(struct capi_spi_controller_handle *handle)
+{
+	if (!handle || !handle->ops || !handle->ops->isr) {
+		return;
+	}
+	handle->ops->isr(handle);
+}

--- a/capi/src/capi_time.c
+++ b/capi/src/capi_time.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2025 Analog Devices, Inc.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file capi_time.c
+ * @brief Strong wrappers over the weak time/delay hooks.
+ *
+ * The wrappers do the API-level argument checking and forward to the weak
+ * *_impl symbols, which the platform overrides at link time. The weak defaults
+ * keep the API linkable and give sensible behaviour even on a partially-ported
+ * platform: capi_wait_ms_impl() is built on top of capi_wait_us_impl(), so a
+ * platform only needs to provide a microsecond busy-wait to get both delays.
+ */
+
+#include "capi_time.h"
+
+#include <errno.h>
+#include <stddef.h>
+
+/* --- Weak default implementations (overridden by the platform) --- */
+
+/* No time source by default: do nothing rather than guess at a delay. */
+__attribute__((weak)) void capi_wait_us_impl(uint32_t us)
+{
+	(void)us;
+}
+
+/*
+ * Default millisecond delay built from the microsecond busy-wait.
+ */
+__attribute__((weak)) void capi_wait_ms_impl(uint32_t ms)
+{
+	while (ms-- > 0) {
+		capi_wait_us_impl(1000);
+	}
+}
+
+/* No time source by default. */
+__attribute__((weak)) int capi_uptime_impl(uint64_t *us)
+{
+	(void)us;
+	return -ENOSYS;
+}
+
+/* --- Strong public wrappers --- */
+
+void capi_wait_us(uint32_t us)
+{
+	capi_wait_us_impl(us);
+}
+
+void capi_wait_ms(uint32_t ms)
+{
+	capi_wait_ms_impl(ms);
+}
+
+int capi_uptime(uint64_t *us)
+{
+	if (us == NULL) {
+		return -EINVAL;
+	}
+
+	return capi_uptime_impl(us);
+}

--- a/capi/src/capi_timer.c
+++ b/capi/src/capi_timer.c
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2024-2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file capi_timer.c
+ * @brief This file contains a set of small wrapper functions that can be used to access
+ *        the TIMER driver via its ops pointer structure. Note, it does not
+ *        implement any thread safety such as mutually excluding calls to the TIMER functions.
+ *        If this is needed, it is suggested that this file and all of the other driver
+ *        wrappers be copied and enhanced in your project.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <capi_timer.h>
+
+int capi_timer_init(struct capi_timer_handle **handle,
+		    const struct capi_timer_config *config)
+{
+	if (config != NULL && config->ops != NULL && config->ops->init != NULL) {
+		return config->ops->init(handle, config);
+	}
+
+	return -EINVAL;
+}
+
+int capi_timer_deinit(struct capi_timer_handle *handle)
+{
+	if (handle != NULL && handle->ops != NULL && handle->ops->deinit != NULL) {
+		return handle->ops->deinit(handle);
+	}
+
+	return -EINVAL;
+}
+
+int capi_timer_start(struct capi_timer_handle *handle)
+{
+	if (handle != NULL && handle->ops != NULL && handle->ops->start != NULL) {
+		return handle->ops->start(handle);
+	}
+
+	return -EINVAL;
+}
+
+int capi_timer_stop(struct capi_timer_handle *handle)
+{
+	if (handle != NULL && handle->ops != NULL && handle->ops->stop != NULL) {
+		return handle->ops->stop(handle);
+	}
+
+	return -EINVAL;
+}
+
+int capi_timer_counter_config(struct capi_timer_handle *handle,
+			      const struct capi_timer_counter_config *config)
+{
+	if (handle != NULL && handle->ops != NULL
+	    && handle->ops->counter_config != NULL) {
+		return handle->ops->counter_config(handle, config);
+	}
+
+	return -EINVAL;
+}
+
+int capi_timer_counter_get(struct capi_timer_handle *handle, uint32_t *counter)
+{
+	if (handle != NULL && handle->ops != NULL && handle->ops->counter_get != NULL) {
+		return handle->ops->counter_get(handle, counter);
+	}
+
+	return -EINVAL;
+}
+
+int capi_timer_event_irq_enable(struct capi_timer_handle *handle,
+				uint32_t event)
+{
+	if (handle != NULL && handle->ops != NULL
+	    && handle->ops->event_irq_enable != NULL) {
+		return handle->ops->event_irq_enable(handle, event);
+	}
+
+	return -EINVAL;
+}
+
+int capi_timer_event_irq_disable(struct capi_timer_handle *handle,
+				 uint32_t event)
+{
+	if (handle != NULL && handle->ops != NULL
+	    && handle->ops->event_irq_disable != NULL) {
+		return handle->ops->event_irq_disable(handle, event);
+	}
+
+	return -EINVAL;
+}
+
+int capi_timer_register_event_callback(struct capi_timer_handle *handle,
+				       capi_timer_event_callback callback, void *callback_arg)
+{
+	if (handle != NULL && handle->ops != NULL &&
+	    handle->ops->register_event_callback != NULL) {
+		return handle->ops->register_event_callback(handle, callback, callback_arg);
+	}
+
+	return -EINVAL;
+}
+
+int capi_timer_channel_init(struct capi_timer_handle *handle, uint32_t chan)
+{
+	if (handle != NULL && handle->ops != NULL
+	    && handle->ops->channel_init != NULL) {
+		return handle->ops->channel_init(handle, chan);
+	}
+
+	return -EINVAL;
+}
+
+int capi_timer_channel_deinit(struct capi_timer_handle *handle, uint32_t chan)
+{
+	if (handle != NULL && handle->ops != NULL
+	    && handle->ops->channel_deinit != NULL) {
+		return handle->ops->channel_deinit(handle, chan);
+	}
+
+	return -EINVAL;
+}
+
+int capi_timer_channel_config(struct capi_timer_handle *handle, uint32_t chan,
+			      const struct capi_timer_channel_config *ch_config)
+{
+	if (handle != NULL && handle->ops != NULL
+	    && handle->ops->channel_config != NULL) {
+		return handle->ops->channel_config(handle, chan, ch_config);
+	}
+
+	return -EINVAL;
+}
+
+int capi_timer_channel_enable(struct capi_timer_handle *handle, uint32_t chan)
+{
+	if (handle != NULL && handle->ops != NULL
+	    && handle->ops->channel_enable != NULL) {
+		return handle->ops->channel_enable(handle, chan);
+	}
+
+	return -EINVAL;
+}
+
+int capi_timer_channel_disable(struct capi_timer_handle *handle, uint32_t chan)
+{
+	if (handle != NULL && handle->ops != NULL
+	    && handle->ops->channel_disable != NULL) {
+		return handle->ops->channel_disable(handle, chan);
+	}
+
+	return -EINVAL;
+}
+
+int capi_timer_channel_compare_set(struct capi_timer_handle *handle,
+				   uint32_t chan,
+				   uint32_t compare)
+{
+	if (handle != NULL && handle->ops != NULL
+	    && handle->ops->channel_compare_set != NULL) {
+		return handle->ops->channel_compare_set(handle, chan, compare);
+	}
+
+	return -EINVAL;
+}
+
+int capi_timer_channel_compare_get(struct capi_timer_handle *handle,
+				   uint32_t chan,
+				   uint32_t *compare)
+{
+	if (handle != NULL && handle->ops != NULL
+	    && handle->ops->channel_compare_get != NULL) {
+		return handle->ops->channel_compare_get(handle, chan, compare);
+	}
+
+	return -EINVAL;
+}
+
+int capi_timer_channel_capture_get(struct capi_timer_handle *handle,
+				   uint32_t chan,
+				   uint32_t *capture)
+{
+	if (handle != NULL && handle->ops != NULL
+	    && handle->ops->channel_capture_get != NULL) {
+		return handle->ops->channel_capture_get(handle, chan, capture);
+	}
+
+	return -EINVAL;
+}
+
+int capi_timer_channel_irq_enable(struct capi_timer_handle *handle,
+				  uint32_t chan, uint32_t event)
+{
+	if (handle != NULL && handle->ops != NULL
+	    && handle->ops->channel_irq_enable != NULL) {
+		return handle->ops->channel_irq_enable(handle, chan, event);
+	}
+
+	return -EINVAL;
+}
+
+int capi_timer_channel_irq_disable(struct capi_timer_handle *handle,
+				   uint32_t chan, uint32_t event)
+{
+	if (handle != NULL && handle->ops != NULL
+	    && handle->ops->channel_irq_disable != NULL) {
+		return handle->ops->channel_irq_disable(handle, chan, event);
+	}
+
+	return -EINVAL;
+}
+
+int capi_timer_channel_register_callback(struct capi_timer_handle *handle,
+		uint32_t chan,
+		capi_timer_channel_callback callback, void *callback_arg)
+{
+	if (handle != NULL && handle->ops != NULL &&
+	    handle->ops->channel_register_callback != NULL) {
+		return handle->ops->channel_register_callback(handle, chan, callback,
+				callback_arg);
+	}
+
+	return -EINVAL;
+}
+
+int capi_timer_is_irq_pending(struct capi_timer_handle *handle, bool *pending)
+{
+	if (handle != NULL && handle->ops != NULL
+	    && handle->ops->is_irq_pending != NULL) {
+		return handle->ops->is_irq_pending(handle, pending);
+	}
+
+	return -EINVAL;
+}
+
+void capi_timer_isr(struct capi_timer_handle *handle)
+{
+	if (handle != NULL && handle->ops != NULL && handle->ops->isr != NULL) {
+		handle->ops->isr(handle);
+	}
+}
+
+int capi_timer_nsec_to_ticks(const struct capi_timer_handle *handle,
+			     uint64_t duration_ns,
+			     uint32_t *ticks)
+{
+	if (handle != NULL && handle->ops != NULL
+	    && handle->ops->nsec_to_ticks != NULL) {
+		return handle->ops->nsec_to_ticks(handle, duration_ns, ticks);
+	}
+
+	return -EINVAL;
+}
+
+int capi_timer_ticks_to_nsec(const struct capi_timer_handle *handle,
+			     uint64_t ticks,
+			     uint32_t *duration_ns)
+{
+	if (handle != NULL && handle->ops != NULL
+	    && handle->ops->ticks_to_nsec != NULL) {
+		return handle->ops->ticks_to_nsec(handle, ticks, duration_ns);
+	}
+
+	return -EINVAL;
+}

--- a/capi/src/capi_uart.c
+++ b/capi/src/capi_uart.c
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2024-2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file capi_uart.c
+ * @brief This file contains a set of small wrapper functions that can be used to access
+ *        the UART driver via its ops pointer structure. Note, it does not
+ *        implement any thread safety such as mutually excluding calls to the UART functions.
+ *        If this is needed, it is suggested that this file and all of the other driver
+ *        wrappers be copied and enhanced in your project.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <capi_uart.h>
+
+int capi_uart_init(struct capi_uart_handle **handle,
+		   const struct capi_uart_config *config)
+{
+	if (!handle || !config || !config->ops || !config->ops->init) {
+		return -EINVAL;
+	}
+	return config->ops->init(handle, config);
+}
+
+int capi_uart_deinit(struct capi_uart_handle *handle)
+{
+	if (!handle || !handle->ops || !handle->ops->deinit) {
+		return -EINVAL;
+	}
+	return handle->ops->deinit(handle);
+}
+
+int capi_uart_get_line_config(struct capi_uart_handle *handle,
+			      struct capi_uart_line_config *line_config)
+{
+	if (!handle || !handle->ops || !handle->ops->get_line_config) {
+		return -EINVAL;
+	}
+	return handle->ops->get_line_config(handle, line_config);
+}
+
+int capi_uart_set_line_config(struct capi_uart_handle *handle,
+			      struct capi_uart_line_config *line_config)
+{
+	if (!handle || !handle->ops || !handle->ops->set_line_config) {
+		return -EINVAL;
+	}
+	return handle->ops->set_line_config(handle, line_config);
+}
+
+int capi_uart_enable_fifo(struct capi_uart_handle *handle, bool enable)
+{
+	if (!handle || !handle->ops || !handle->ops->enable_fifo) {
+		return -EINVAL;
+	}
+	return handle->ops->enable_fifo(handle, enable);
+}
+
+int capi_uart_flush_tx_fifo(struct capi_uart_handle *handle)
+{
+	if (!handle || !handle->ops || !handle->ops->flush_tx_fifo) {
+		return -EINVAL;
+	}
+	return handle->ops->flush_tx_fifo(handle);
+}
+
+int capi_uart_flush_rx_fifo(struct capi_uart_handle *handle)
+{
+	if (!handle || !handle->ops || !handle->ops->flush_rx_fifo) {
+		return -EINVAL;
+	}
+	return handle->ops->flush_rx_fifo(handle);
+}
+
+int capi_uart_get_rx_fifo_count(struct capi_uart_handle *handle,
+				uint16_t *count)
+{
+	if (!handle || !handle->ops || !handle->ops->get_rx_fifo_count) {
+		return -EINVAL;
+	}
+	return handle->ops->get_rx_fifo_count(handle, count);
+}
+
+int capi_uart_get_tx_fifo_count(struct capi_uart_handle *handle,
+				uint16_t *count)
+{
+	if (!handle || !handle->ops || !handle->ops->get_tx_fifo_count) {
+		return -EINVAL;
+	}
+	return handle->ops->get_tx_fifo_count(handle, count);
+}
+
+int capi_uart_transmit(struct capi_uart_handle *handle, uint8_t *buf,
+		       uint32_t len)
+{
+	if (!handle || !handle->ops || !handle->ops->transmit) {
+		return -EINVAL;
+	}
+	return handle->ops->transmit(handle, buf, len);
+}
+
+int capi_uart_receive(struct capi_uart_handle *handle, uint8_t *buf,
+		      uint32_t len)
+{
+	if (!handle || !handle->ops || !handle->ops->receive) {
+		return -EINVAL;
+	}
+	return handle->ops->receive(handle, buf, len);
+}
+
+int capi_uart_register_callback(struct capi_uart_handle *handle,
+				capi_uart_callback const callback,
+				void *const callback_arg)
+{
+	if (!handle || !handle->ops || !handle->ops->register_callback) {
+		return -EINVAL;
+	}
+	return handle->ops->register_callback(handle, callback, callback_arg);
+}
+
+int capi_uart_transmit_async(struct capi_uart_handle *handle, uint8_t *buf,
+			     uint32_t len)
+{
+	if (!handle || !handle->ops || !handle->ops->transmit_async) {
+		return -EINVAL;
+	}
+	return handle->ops->transmit_async(handle, buf, len);
+}
+
+int capi_uart_receive_async(struct capi_uart_handle *handle, uint8_t *buf,
+			    uint32_t len)
+{
+	if (!handle || !handle->ops || !handle->ops->receive_async) {
+		return -EINVAL;
+	}
+	return handle->ops->receive_async(handle, buf, len);
+}
+
+int capi_uart_get_interrupt_reason(struct capi_uart_handle *handle,
+				   enum capi_uart_interrupt_reason *reason)
+{
+	if (!handle || !handle->ops || !handle->ops->get_interrupt_reason) {
+		return -EINVAL;
+	}
+	return handle->ops->get_interrupt_reason(handle, reason);
+}
+
+int capi_uart_get_line_status(struct capi_uart_handle *handle,
+			      uint32_t *status_flags)
+{
+	if (!handle || !handle->ops || !handle->ops->get_line_status) {
+		return -EINVAL;
+	}
+	return handle->ops->get_line_status(handle, status_flags);
+}
+
+void capi_uart_isr(void *handle)
+{
+	struct capi_uart_handle *ch = (struct capi_uart_handle *)handle;
+
+	if (!handle || !ch->ops || !ch->ops->isr) {
+		return;
+	}
+	ch->ops->isr(handle);
+}
+
+uint32_t capi_uart_read_byte(struct capi_uart_handle *handle, uint8_t *byte)
+{
+	if (!handle || !handle->ops || !handle->ops->read_byte) {
+		return 0U;
+	}
+	return handle->ops->read_byte(handle, byte);
+}
+
+uint32_t capi_uart_write_byte(struct capi_uart_handle *handle, uint8_t byte)
+{
+	if (!handle || !handle->ops || !handle->ops->write_byte) {
+		return 0U;
+	}
+	return handle->ops->write_byte(handle, byte);
+}
+
+int capi_uart_set_irq_tx(struct capi_uart_handle *handle, bool enable)
+{
+	if (!handle || !handle->ops || !handle->ops->set_irq_tx) {
+		return -EINVAL;
+	}
+	return handle->ops->set_irq_tx(handle, enable);
+}
+
+int capi_uart_irq_tx_ready(struct capi_uart_handle *handle, bool *ready)
+{
+	if (!handle || !handle->ops || !handle->ops->irq_tx_ready) {
+		return -EINVAL;
+	}
+	return handle->ops->irq_tx_ready(handle, ready);
+}
+
+int capi_uart_irq_tx_complete(struct capi_uart_handle *handle, bool *complete)
+{
+	if (!handle || !handle->ops || !handle->ops->irq_tx_complete) {
+		return -EINVAL;
+	}
+	return handle->ops->irq_tx_complete(handle, complete);
+}
+
+int capi_uart_set_irq_rx(struct capi_uart_handle *handle, bool enable)
+{
+	if (!handle || !handle->ops || !handle->ops->set_irq_rx) {
+		return -EINVAL;
+	}
+	return handle->ops->set_irq_rx(handle, enable);
+}
+
+int capi_uart_irq_rx_ready(struct capi_uart_handle *handle, bool *ready)
+{
+	if (!handle || !handle->ops || !handle->ops->irq_rx_ready) {
+		return -EINVAL;
+	}
+	return handle->ops->irq_rx_ready(handle, ready);
+}
+
+int capi_uart_set_irq_err(struct capi_uart_handle *handle, bool enable)
+{
+	if (!handle || !handle->ops || !handle->ops->set_irq_err) {
+		return -EINVAL;
+	}
+	return handle->ops->set_irq_err(handle, enable);
+}
+
+int capi_uart_is_irq_pending(struct capi_uart_handle *handle, bool *pending)
+{
+	if (!handle || !handle->ops || !handle->ops->is_irq_pending) {
+		return -EINVAL;
+	}
+	return handle->ops->is_irq_pending(handle, pending);
+}


### PR DESCRIPTION
## Pull Request Description

This PR adds CAPI based implementations to several STM32 platform drivers: GPIO, DMA, IRQ, I2C, SPI, UART and TIMER.
## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
