### PR TITLE
i2c write repeated start for maxim/aducm3029 platforms

### DIFF
--- a/drivers/platform/aducm3029/aducm3029_i2c.c
+++ b/drivers/platform/aducm3029/aducm3029_i2c.c
@@ -232,7 +232,7 @@ static int32_t aducm3029_i2c_write(struct no_os_i2c_desc *desc,
 		return 0;
 	}
 
-	trans->bRepeatStart = false;
+	trans->bRepeatStart = stop_bit ? false : true;
 	trans->pPrologue = 0;
 	trans->nPrologueSize = 0;
 	trans->pData = data;

--- a/drivers/platform/maxim/max32650/maxim_i2c.c
+++ b/drivers/platform/maxim/max32650/maxim_i2c.c
@@ -258,7 +258,7 @@ static int32_t max_i2c_write(struct no_os_i2c_desc *desc,
 	/** Write transaction */
 	req.rx_len = 0;
 	req.rx_buf = data;
-	req.restart = 0;
+	req.restart = stop_bit ? 0 : 1;
 
 	return MXC_I2C_MasterTransaction(&req);
 }

--- a/drivers/platform/maxim/max32655/maxim_i2c.c
+++ b/drivers/platform/maxim/max32655/maxim_i2c.c
@@ -261,7 +261,7 @@ static int32_t max_i2c_write(struct no_os_i2c_desc *desc,
 	/** Write transaction */
 	req.rx_len = 0;
 	req.rx_buf = data;
-	req.restart = 0;
+	req.restart = stop_bit ? 0 : 1;
 
 	return MXC_I2C_MasterTransaction(&req);
 }

--- a/drivers/platform/maxim/max32660/maxim_i2c.c
+++ b/drivers/platform/maxim/max32660/maxim_i2c.c
@@ -260,7 +260,7 @@ static int32_t max_i2c_write(struct no_os_i2c_desc *desc,
 	/** Write transaction */
 	req.rx_len = 0;
 	req.rx_buf = data;
-	req.restart = 0;
+	req.restart = stop_bit ? 0 : 1;
 
 	return MXC_I2C_MasterTransaction(&req);
 }

--- a/drivers/platform/maxim/max32662/maxim_i2c.c
+++ b/drivers/platform/maxim/max32662/maxim_i2c.c
@@ -260,7 +260,7 @@ static int32_t max_i2c_write(struct no_os_i2c_desc *desc,
 	/** Write transaction */
 	req.rx_len = 0;
 	req.rx_buf = data;
-	req.restart = 0;
+	req.restart = stop_bit ? 0 : 1;
 
 	return MXC_I2C_MasterTransaction(&req);
 }

--- a/drivers/platform/maxim/max32665/maxim_i2c.c
+++ b/drivers/platform/maxim/max32665/maxim_i2c.c
@@ -261,7 +261,7 @@ static int32_t max_i2c_write(struct no_os_i2c_desc *desc,
 	/** Write transaction */
 	req.rx_len = 0;
 	req.rx_buf = data;
-	req.restart = 0;
+	req.restart = stop_bit ? 0 : 1;
 
 	return MXC_I2C_MasterTransaction(&req);
 }

--- a/drivers/platform/maxim/max32670/maxim_i2c.c
+++ b/drivers/platform/maxim/max32670/maxim_i2c.c
@@ -261,7 +261,7 @@ static int32_t max_i2c_write(struct no_os_i2c_desc *desc,
 	/** Write transaction */
 	req.rx_len = 0;
 	req.rx_buf = data;
-	req.restart = 0;
+	req.restart = stop_bit ? 0 : 1;
 
 	return MXC_I2C_MasterTransaction(&req);
 }

--- a/drivers/platform/maxim/max32672/maxim_i2c.c
+++ b/drivers/platform/maxim/max32672/maxim_i2c.c
@@ -261,7 +261,7 @@ static int32_t max_i2c_write(struct no_os_i2c_desc *desc,
 	/** Write transaction */
 	req.rx_len = 0;
 	req.rx_buf = data;
-	req.restart = 0;
+	req.restart = stop_bit ? 0 : 1;
 
 	return MXC_I2C_MasterTransaction(&req);
 }

--- a/drivers/platform/maxim/max32690/maxim_i2c.c
+++ b/drivers/platform/maxim/max32690/maxim_i2c.c
@@ -259,7 +259,7 @@ static int32_t max_i2c_write(struct no_os_i2c_desc *desc,
 	/** Write transaction */
 	req.rx_len = 0;
 	req.rx_buf = data;
-	req.restart = 0;
+	req.restart = stop_bit ? 0 : 1;
 
 	return MXC_I2C_MasterTransaction(&req);
 }

--- a/drivers/platform/maxim/max78000/maxim_i2c.c
+++ b/drivers/platform/maxim/max78000/maxim_i2c.c
@@ -260,7 +260,7 @@ static int32_t max_i2c_write(struct no_os_i2c_desc *desc,
 	/** Write transaction */
 	req.rx_len = 0;
 	req.rx_buf = data;
-	req.restart = 0;
+	req.restart = stop_bit ? 0 : 1;
 
 	return MXC_I2C_MasterTransaction(&req);
 }


### PR DESCRIPTION
## Pull Request Description

The i2c_write function implementations on maxim and aducm3029 take a stop_bit parameter which is ignored, fix that.

Most likely fixes #2826 or is at least part of the problem

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
