### PR TITLE
projects: ad9361: add getter for TX sampling frequency

### DIFF
--- a/drivers/axi_core/iio_axi_dac/iio_axi_dac.c
+++ b/drivers/axi_core/iio_axi_dac/iio_axi_dac.c
@@ -114,10 +114,23 @@ static int get_voltage_sampling_frequency(void *device, char *buf,
 		const struct iio_ch_info *channel,
 		intptr_t priv)
 {
-	/* This function doesn't have an equivalent function in axi_dac_core,
-	 * and it should be implemented there first */
+	uint64_t sampling_freq_hz;
+	int ret;
+	struct iio_axi_dac_desc *iio_dac = (struct iio_axi_dac_desc *)device;
 
-	return -ENOENT;
+	if (iio_dac->get_sampling_frequency)
+		ret = iio_dac->get_sampling_frequency(iio_dac->dac,
+						      channel->ch_num,
+						      &sampling_freq_hz);
+	else
+		/* This function doesn't have an equivalent function in
+		 * axi_dac_core, and it should be implemented there first */
+		return -ENOSYS;
+
+	if (ret < 0)
+		return ret;
+
+	return snprintf(buf, len, "%"PRIi64"", sampling_freq_hz);
 }
 
 /**
@@ -215,10 +228,23 @@ static int get_altvoltage_sampling_frequency(void *device, char *buf,
 		const struct iio_ch_info *channel,
 		intptr_t priv)
 {
-	/* This function doesn't have an equivalent function in axi_dac_core,
-	 * and it should be implemented there first */
+	uint64_t sampling_freq_hz;
+	int ret;
+	struct iio_axi_dac_desc *iio_dac = (struct iio_axi_dac_desc *)device;
 
-	return -ENOENT;
+	if (iio_dac->get_sampling_frequency)
+		ret = iio_dac->get_sampling_frequency(iio_dac->dac,
+						      channel->ch_num,
+						      &sampling_freq_hz);
+	else
+		/* This function doesn't have an equivalent function in
+		 * axi_dac_core, and it should be implemented there first */
+		return -ENOSYS;
+
+	if (ret < 0)
+		return ret;
+
+	return snprintf(buf, len, "%"PRIi64"", sampling_freq_hz);
 }
 
 /**
@@ -670,6 +696,7 @@ int32_t iio_axi_dac_init(struct iio_axi_dac_desc **desc,
 		iio_axi_dac_inst->dmac = init->tx_dmac;
 		iio_axi_dac_inst->dcache_flush_range = init->dcache_flush_range;
 	}
+	iio_axi_dac_inst->get_sampling_frequency = init->get_sampling_frequency;
 
 	status = iio_axi_dac_create_device_descriptor(iio_axi_dac_inst,
 			&iio_axi_dac_inst->dev_descriptor);

--- a/drivers/axi_core/iio_axi_dac/iio_axi_dac.h
+++ b/drivers/axi_core/iio_axi_dac/iio_axi_dac.h
@@ -50,6 +50,9 @@ struct iio_axi_dac_desc {
 	uint32_t mask;
 	/** flush contents of instruction and/or data cache */
 	void (*dcache_flush_range)(uint32_t address, uint32_t bytes_count);
+	/** Custom implementation for get sampling frequency */
+	int (*get_sampling_frequency)(struct axi_dac *dev, uint32_t chan,
+				      uint64_t *sampling_freq_hz);
 	/** iio device descriptor */
 	struct iio_device dev_descriptor;
 	/** Channel names */
@@ -67,7 +70,11 @@ struct iio_axi_dac_init_param {
 	struct axi_dmac *tx_dmac;
 	/** Function pointer to flush the data cache for the given address range */
 	void (*dcache_flush_range)(uint32_t address, uint32_t bytes_count);
+	/** Custom sampling frequency getter */
+	int (*get_sampling_frequency)(struct axi_dac *dev, uint32_t chan,
+				      uint64_t *sampling_freq_hz);
 };
+
 
 /* Init application. */
 int32_t iio_axi_dac_init(struct iio_axi_dac_desc **desc,

--- a/drivers/rf-transceiver/ad9361/ad9361_api.c
+++ b/drivers/rf-transceiver/ad9361/ad9361_api.c
@@ -1501,8 +1501,17 @@ int32_t ad9361_set_tx_sampling_freq(struct ad9361_rf_phy *phy,
 int32_t ad9361_get_tx_sampling_freq(struct ad9361_rf_phy *phy,
 				    uint32_t *sampling_freq_hz)
 {
-	*sampling_freq_hz = (uint32_t)clk_get_rate(phy,
-			    phy->ref_clk_scale[TX_SAMPL_CLK]);
+	uint32_t freq;
+
+	if (!phy || !sampling_freq_hz)
+		return -EINVAL;
+
+	freq = clk_get_rate(phy, phy->ref_clk_scale[TX_SAMPL_CLK]);
+
+	if (freq == 0)
+		return -ENODEV;
+
+	*sampling_freq_hz = freq;
 
 	return 0;
 }

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -540,6 +540,40 @@ static int ad9361_iio_axi_adc_get_sampling_freq(struct axi_adc *dev,
 	return 0;
 }
 
+/**
+ * @brief Get TX sampling frequency callback for iio_axi_dac.
+ * @param dev - The AXI DAC device (unused, uses global ad9361_phy).
+ * @param chan - Channel number (unused, AD9361 has single TX sample rate).
+ * @param sampling_freq_hz - Output sampling frequency in Hz.
+ * @return 0 in case of success, negative error code otherwise.
+ */
+static int ad9361_iio_axi_dac_get_sampling_freq(struct axi_dac *dev,
+		uint32_t chan,
+		uint64_t *sampling_freq_hz)
+{
+	uint32_t freq;
+	struct ad9361_rf_phy *phy;
+	int ret;
+
+	if (!dev || !sampling_freq_hz)
+		return -EINVAL;
+
+#ifdef FMCOMMS5
+	if (dev == ad9361_phy_b->tx_dac)
+		phy = ad9361_phy_b;
+	else
+#endif
+		phy = ad9361_phy;
+
+	ret = ad9361_get_tx_sampling_freq(phy, &freq);
+
+	if (ret < 0)
+		return ret;
+
+	*sampling_freq_hz = freq;
+	return 0;
+}
+
 #endif /* IIO_SUPPORT */
 
 /***************************************************************************//**
@@ -990,6 +1024,7 @@ int main(void)
 	iio_axi_dac_init_par = (struct iio_axi_dac_init_param) {
 		.tx_dac = ad9361_phy->tx_dac,
 		.tx_dmac = tx_dmac,
+		.get_sampling_frequency = ad9361_iio_axi_dac_get_sampling_freq,
 #ifndef PLATFORM_MB
 		.dcache_flush_range = (void (*)(uint32_t, uint32_t))Xil_DCacheFlushRange,
 #endif
@@ -1008,6 +1043,7 @@ int main(void)
 #ifdef FMCOMMS5
 	iio_axi_dac_b_init_par = (struct iio_axi_dac_init_param) {
 		.tx_dac = ad9361_phy_b->tx_dac,
+		.get_sampling_frequency = ad9361_iio_axi_dac_get_sampling_freq,
 	};
 
 	status = iio_axi_dac_init(&iio_axi_dac_b_desc, &iio_axi_dac_b_init_par);


### PR DESCRIPTION
## Pull Request Description

This ensures that the correct value for sampling frequency is read by tx_dac devices.
## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
