### PR TITLE
Frequency PLLs mod2 fix

### DIFF
--- a/drivers/frequency/adf4368/adf4368.c
+++ b/drivers/frequency/adf4368/adf4368.c
@@ -1098,8 +1098,12 @@ int adf4368_get_rfout(struct adf4368_dev *dev, uint64_t *val)
 		return ret;
 	mod2 |= tmp;
 
-	freq = frac2 * pfd;
-	freq = no_os_div_u64(freq, mod2);
+	if (mod2) {
+		freq = frac2 * pfd;
+		freq = no_os_div_u64(freq, mod2);
+	} else {
+		freq = 0;
+	}
 	freq = freq + (frac1 * pfd);
 	freq = no_os_div_u64(freq, ADF4368_MOD1WORD);
 	freq = freq + (n_value * pfd);
@@ -1633,7 +1637,7 @@ int adf4368_set_freq(struct adf4368_dev *dev)
 {
 	uint32_t frac2_word = 0;
 	uint32_t frac1_word = 0;
-	uint32_t mod2_word = 0;
+	uint32_t mod2_word = 1;
 	uint8_t ldwin_pw = 0;
 	uint8_t clkout_div;
 	uint8_t dclk_div1;

--- a/drivers/frequency/adf4382/adf4382.c
+++ b/drivers/frequency/adf4382/adf4382.c
@@ -650,8 +650,12 @@ int adf4382_get_rfout(struct adf4382_dev *dev, uint64_t *val)
 		return ret;
 	mod2 |= tmp;
 
-	freq = frac2 * pfd;
-	freq = no_os_div_u64(freq, mod2);
+	if (mod2) {
+		freq = frac2 * pfd;
+		freq = no_os_div_u64(freq, mod2);
+	} else {
+		freq = 0;
+	}
 	freq = freq + (frac1 * pfd);
 	freq = no_os_div_u64(freq, ADF4382_MOD1WORD);
 	freq = freq + (n * pfd);
@@ -753,7 +757,7 @@ static int adf4382_pll_fract_n_compute(struct adf4382_dev *dev, uint64_t freq,
 	*frac1_word = (uint32_t)no_os_div64_u64_rem(res, pfd_freq, &rem);
 
 	*frac2_word = 0;
-	*mod2_word = 0;
+	*mod2_word = 1;
 
 	if (rem > 0)
 		return adf4382_frac2_compute(dev, rem, pfd_freq, frac2_word,

--- a/drivers/frequency/adf5611/adf5611.c
+++ b/drivers/frequency/adf5611/adf5611.c
@@ -588,8 +588,12 @@ int adf5611_get_rfout(struct adf5611_dev *dev, uint64_t *val)
 		return ret;
 	mod2 |= tmp;
 
-	freq = frac2 * pfd;
-	freq = no_os_div_u64(freq, mod2);
+	if (mod2) {
+		freq = frac2 * pfd;
+		freq = no_os_div_u64(freq, mod2);
+	} else {
+		freq = 0;
+	}
 	freq = freq + (frac1 * pfd);
 	freq = no_os_div_u64(freq, ADF5611_MOD1WORD);
 	freq = (freq + (n * pfd)) * ADF5611_OUTPUT_DOUBLER;
@@ -643,7 +647,7 @@ static int adf5611_frac_compute(uint64_t f_vco, uint64_t pfd_freq,
 	res = rem * ADF5611_MOD1WORD;
 	*frac1_word = (uint32_t)no_os_div64_u64_rem(res, pfd_freq, &rem);
 	*frac2_word = 0;
-	*mod2_word = 0;
+	*mod2_word = 1;
 
 	if (rem > 0) {
 		mod2_wd *= NO_OS_DIV_U64(mod2_max, mod2_wd);


### PR DESCRIPTION
## Pull Request Description

Issue : #3025 
Fix MOD2 handling for ADF5611, ADF4368, and ADF4382 frequency drivers to avoid invalid fractional computation paths.

This PR updates three drivers so MOD2 is initialized to 1 (instead of 0) in default/non-fractional paths, and adds a guard in RF output readback to prevent division by zero when MOD2 is 0.
When MOD2 is 0, FRACT2 contribution is treated as 0 and the calculation continues safely.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
