### PR TITLE
Versal vitis support

### DIFF
--- a/doc/sphinx/source/build_guides/build_xilinx_vitis2025.rst
+++ b/doc/sphinx/source/build_guides/build_xilinx_vitis2025.rst
@@ -442,6 +442,14 @@ Troubleshooting
 
 **Solution:** Install xsdb WSL2 fix (see above)
 
+Variables/Locals show "N/A" on Versal
+--------------------------------------
+
+When debugging on Versal (Cortex-A72) with Vitis 2025.1, the Variables and Locals
+views may show "N/A" instead of actual values. This is a known Vitis 2025.1 bug
+affecting Versal targets. Breakpoints, stepping, and continue all work normally.
+This does not affect Zynq or ZynqMP targets.
+
 Summary
 =======
 

--- a/tools/scripts/platform/xilinx/generate_vitis_launch.py
+++ b/tools/scripts/platform/xilinx/generate_vitis_launch.py
@@ -119,22 +119,30 @@ def generate_mb_init():
 
 
 def generate_versal_init():
-    """Generate Versal initialization section (uses PLM, not FSBL)."""
+    """Generate Versal-specific targetSetup fields (zuTraceOptions only)."""
     return {
-        "versalInitialization": {
-            "usePLM": True,
-            "plmFile": ""  # Typically extracted from PDI
+        "zuTraceOptions": {
+            "isSelected": False,
+            "scratchAddress": "0xfffc0000",
+            "scratchSize": "0x40000",
+            "traceOutputPath": ""
         }
     }
 
 
-def generate_download_elf(target_cpu, elf_path):
+def generate_download_elf(target_cpu, elf_path, project_dir):
     """Generate downloadElf section."""
+    # Make ELF path workspace-relative if possible
+    try:
+        rel = os.path.relpath(elf_path, project_dir)
+        ws_elf = f"${{workspaceFolder}}/{rel}"
+    except ValueError:
+        ws_elf = elf_path
     return [
         {
             "core": target_cpu,
-            "resetProcessor": False,
-            "elfFile": elf_path,
+            "resetProcessor": True,
+            "elfFile": ws_elf,
             "stopAtEntry": False,
             "isSelfRelocatingApp": False,
             "relativeAddress": ""
@@ -151,8 +159,20 @@ def generate_launch_json(args):
     # Extract XSA basename (e.g., "system_top" from "system_top.xsa")
     xsa_basename = Path(args.xsa_path).stem
 
-    # Generate bitstream path
-    bitstream_path = f"_ide/{xsa_basename}/{xsa_basename}.bit"
+    # Generate bitstream/PDI path.
+    # For Versal the PDI inside the XSA may not match the XSA filename,
+    # so search for the extracted .pdi file.
+    if arch_config['initType'] == 'versal':
+        # Match Vitis expected PDI location
+        ide_dir = Path(args.project_dir) / '_ide' / xsa_basename
+        pdi_files = list(ide_dir.glob('*.pdi')) if ide_dir.exists() else []
+        if pdi_files:
+            pdi_name = pdi_files[0].name
+        else:
+            pdi_name = "system_top.pdi"
+        bitstream_path = f"_ide/{xsa_basename}/{pdi_name}"
+    else:
+        bitstream_path = f"_ide/{xsa_basename}/{xsa_basename}.bit"
 
     # Generate configuration name
     config_name = f"{args.project_name}_app_hw_1"
@@ -169,51 +189,70 @@ def generate_launch_json(args):
     else:
         init_section = {}
 
-    # Build the complete configuration
+    is_versal = arch_config['initType'] == 'versal'
+
+    # Build the base configuration entry
+    launch_entry = {
+        "type": "tcf-debug",
+        "request": "launch",
+        "name": config_name,
+        "debugType": arch_config['debugType'],
+    }
+
+    launch_entry["xsaPath"] = f"${{workspaceFolder}}/{args.xsa_path}"
+
+    setup_mode = "standalone"
+    exec_script = True
+    script_path = ""
+    launch_entry.update({
+        "attachToRunningTargetOptions": {
+            "targetSetupMode": setup_mode,
+            "executeScript": exec_script,
+            "scriptPath": script_path
+        },
+        "autoAttachProcessChildren": False,
+        "target": {
+            "targetConnectionId": "Local",
+            "peersIniPath": ".peers.ini",
+            "context": "Versal" if is_versal else "Device"
+        },
+        "pathMap": [],
+    })
+
+    # Build targetSetup
+    target_setup = {
+        "resetSystem": True,
+        "programDevice": True,
+        "partialBitstream": False,
+        "skipRevisionCheck": False,
+        "device": {
+            "plDevice": "Auto Detect",
+            "psDevice": "Auto Detect"
+        },
+        "enableRPUSplitMode": False,
+    }
+    if is_versal:
+        target_setup["pdiFile"] = f"${{workspaceFolder}}/{bitstream_path}"
+        target_setup["supportsSegPdi"] = False
+    else:
+        target_setup["resetAPU"] = False
+        target_setup["resetRPU"] = False
+        target_setup["bitstreamFile"] = f"${{workspaceFolder}}/{bitstream_path}"
+
+    target_setup.update(init_section)
+    target_setup["downloadElf"] = generate_download_elf(
+        arch_config['targetCpu'], args.elf_path, args.project_dir)
+    target_setup["crossTriggerBreakpoints"] = {
+        "isSelected": False,
+        "breakpoints": []
+    }
+
+    launch_entry["targetSetup"] = target_setup
+    launch_entry["internalConsoleOptions"] = "openOnSessionStart"
+
     config = {
         "version": "0.2.0",
-        "configurations": [
-            {
-                "type": "tcf-debug",
-                "request": "launch",
-                "name": config_name,
-                "debugType": arch_config['debugType'],
-                "xsaPath": f"${{workspaceFolder}}/{args.xsa_path}",
-                "attachToRunningTargetOptions": {
-                    "targetSetupMode": "standalone",
-                    "executeScript": True,
-                    "scriptPath": ""
-                },
-                "autoAttachProcessChildren": False,
-                "target": {
-                    "targetConnectionId": "Local",
-                    "peersIniPath": "../_ide/.peers.ini",
-                    "context": "Device"
-                },
-                "pathMap": [],
-                "targetSetup": {
-                    "resetSystem": True,
-                    "programDevice": True,
-                    "partialBitstream": False,
-                    "skipRevisionCheck": False,
-                    "device": {
-                        "plDevice": "Auto Detect",
-                        "psDevice": "Auto Detect"
-                    },
-                    "enableRPUSplitMode": False,
-                    "resetAPU": False,
-                    "resetRPU": False,
-                    "bitstreamFile": f"${{workspaceFolder}}/{bitstream_path}",
-                    **init_section,
-                    "downloadElf": generate_download_elf(arch_config['targetCpu'], args.elf_path),
-                    "crossTriggerBreakpoints": {
-                        "isSelected": False,
-                        "breakpoints": []
-                    }
-                },
-                "internalConsoleOptions": "openOnSessionStart"
-            }
-        ]
+        "configurations": [launch_entry]
     }
 
     return config
@@ -288,8 +327,8 @@ def main():
         json.dump(launch_config, f, indent='\t')
         f.write('\n')  # Add trailing newline
 
-    print(f"Generated Vitis launch configuration: {output_path}")
     arch_config = detect_arch_config(args.arch)
+    print(f"Generated Vitis launch configuration: {output_path}")
     print(f"  Architecture: {args.arch}")
     print(f"  Debug type: {arch_config['debugType']}")
     print(f"  Target CPU: {arch_config['targetCpu']}")

--- a/tools/scripts/platform/xilinx/util.tcl
+++ b/tools/scripts/platform/xilinx/util.tcl
@@ -272,15 +272,21 @@ proc clean_build {} {
 set pl_dict [dict create					\
 	"ps7_cortexa9_0" "xc7z*"				\
 	"psu_cortexa53_0" "PSU"					\
+	"sys_cips_pspmc_0_psv_cortexa72_0" "Versal*"		\
 	"sys_mb" "xc*"]
 
 set ps_dict [dict create					\
 	"ps7_cortexa9_0" "*Cortex-A9 MPCore #0*"		\
 	"psu_cortexa53_0" "*Cortex-A53 #0*"			\
+	"sys_cips_pspmc_0_psv_cortexa72_0" "*Cortex-A72 #0*"	\
 	"sys_mb" "*MicroBlaze #*"]
 
 proc _cpu_reset {cpu} {
 	if {$cpu == "sys_mb"} {
+		return
+	}
+	if {$cpu == "sys_cips_pspmc_0_psv_cortexa72_0"} {
+		# Versal: PLM handles reset; just select the A72 core
 		return
 	}
 	targets -set -filter {name =~ "APU*" && jtag_cable_name =~ "*$::jtagtarget*"}
@@ -292,7 +298,40 @@ proc _cpu_reset {cpu} {
 	}
 }
 
+proc _write_pl_versal {pdi_path} {
+	# Versal PDI programming requires Vivado hardware manager (cs_server).
+	# xsct + hw_server alone cannot program Versal devices.
+	set pdi [file normalize $pdi_path]
+	set tmp_script "/tmp/_noos_versal_pdi_[pid].tcl"
+	set fd [open $tmp_script w]
+	puts $fd "open_hw_manager"
+	puts $fd "connect_hw_server -url TCP:localhost:3121"
+	puts $fd "open_hw_target"
+	puts $fd "current_hw_device \[lindex \[get_hw_devices xcv*\] 0\]"
+	puts $fd "set_property PROGRAM.FILE \{$pdi\} \[current_hw_device\]"
+	puts $fd "program_hw_devices \[current_hw_device\]"
+	puts $fd "close_hw_manager"
+	puts $fd "exit"
+	close $fd
+
+	puts "INFO: Programming Versal PDI via Vivado..."
+	set result ""
+	if {[catch {set result [exec vivado -mode tcl -nolog -nojournal -source $tmp_script 2>@1]} err]} {
+		set result $err
+	}
+	file delete -force $tmp_script
+	if {[string first "Successfully programmed PDI" $result] == -1} {
+		error "ERROR: Vivado PDI programming failed:\n$result"
+	}
+	puts "INFO: PDI programmed successfully. Waiting for PLM..."
+	after 5000
+}
+
 proc _write_pl {cpu {bitstream}} {
+	if {$cpu == "sys_cips_pspmc_0_psv_cortexa72_0"} {
+		# Versal: handled separately in upload via _write_pl_versal
+		return
+	}
 	set name [dict get $::pl_dict $cpu]
 	targets -set -filter {name =~ "$name" && jtag_cable_name =~ "*$::jtagtarget*"}
 	fpga -file [file normalize $bitstream]
@@ -325,6 +364,15 @@ proc _init_ps {cpu} {
 			psu_ps_pl_reset_config
 			targets -set -filter {name =~ "Cortex-R5 #0" && jtag_cable_name =~ "*$::jtagtarget*"}
 		}
+		"sys_cips_pspmc_0_psv_cortexa72_0" {
+			# Versal: release the A72 from reset after PDI programming.
+			targets -set -nocase -filter {name =~ "*A72*#0" && jtag_cable_name =~ "*$::jtagtarget*"}
+			rst -processor -clear-registers
+			after 2000
+			# Versal requires forced memory access for dow since
+			# the XSA memory map may not reflect the PDI runtime state.
+			configparams force-mem-accesses 1
+		}
 		"sys_mb" {
 			set name [dict get $::pl_dict $cpu]
 			targets -set -filter {name =~ "$name" && jtag_cable_name =~ "*$::jtagtarget*"}
@@ -344,26 +392,62 @@ proc _write_ps {cpu} {
 
 proc upload {} {
 	openhw $::hw
-	set bitstream [file rootname $::hw]
-	append bitstream ".bit"
 	set cpu [_get_processor]
 
-	# Connect to the fpga
-  if { [info exists ::env(XSCT_REMOTE_HOST)] && [info exists ::env(XSCT_REMOTE_PORT)] } {
-    connect -host "$::env(XSCT_REMOTE_HOST)" -port "$::env(XSCT_REMOTE_PORT)"
-  } else {
-    connect
-  }
+	if {$cpu == "sys_cips_pspmc_0_psv_cortexa72_0"} {
+		# Versal flow: PDI via Vivado (requires cs_server), then
+		# ELF download via xsct.
+		set xsa_dir [file dirname [file normalize $::hw]]
+		set pdi_path [file join $xsa_dir "system_top.pdi"]
+		if {![file exists $pdi_path]} {
+			exec unzip -o -q [file normalize $::hw] "*.pdi" -d $xsa_dir
+		}
 
-	# Reset and stop the ARM CPU before we re-program the FPGA if we are on a ZYNQ.
-	# Otherwise undefined behavior can occur.
-	_cpu_reset $cpu
+		# 1. Start hw_server (Vivado and xsct will both connect to it)
+		catch {exec pkill -x hw_server}
+		catch {exec pkill -x cs_server}
+		after 2000
+		exec hw_server &
+		after 3000
 
-	_write_pl $cpu $bitstream
+		# 2. Program PDI via Vivado (auto-launches cs_server)
+		_write_pl_versal $pdi_path
 
-	_init_ps $cpu
+		# 3. Ensure cs_server is running for debug target enumeration
+		if {[catch {exec pgrep -x cs_server}]} {
+			puts "INFO: Starting cs_server..."
+			exec cs_server &
+			after 3000
+		}
 
-	_write_ps $cpu
+		# 4. Connect xsct to the running hw_server
+		if { [info exists ::env(XSCT_REMOTE_HOST)] && [info exists ::env(XSCT_REMOTE_PORT)] } {
+			connect -host "$::env(XSCT_REMOTE_HOST)" -port "$::env(XSCT_REMOTE_PORT)"
+		} else {
+			connect -host localhost -port 3121
+		}
+		after 5000
+
+		# 5. Init PS and download ELF
+		_init_ps $cpu
+		_write_ps $cpu
+	} else {
+		set bitstream [file rootname $::hw]
+		append bitstream ".bit"
+
+		# Connect to the fpga
+		if { [info exists ::env(XSCT_REMOTE_HOST)] && [info exists ::env(XSCT_REMOTE_PORT)] } {
+			connect -host "$::env(XSCT_REMOTE_HOST)" -port "$::env(XSCT_REMOTE_PORT)"
+		} else {
+			connect
+		}
+
+		# Reset and stop the ARM CPU before we re-program the FPGA
+		_cpu_reset $cpu
+		_write_pl $cpu $bitstream
+		_init_ps $cpu
+		_write_ps $cpu
+	}
 }
 
 set function	[lindex $argv 0]

--- a/tools/scripts/xilinx.mk
+++ b/tools/scripts/xilinx.mk
@@ -261,7 +261,8 @@ vitis_launch_config: $(TEMP_DIR)/arch.txt
 	@mkdir -p $(PROJECT)/_ide
 	@echo "Extracting bitstream and initialization files from XSA..."
 	@mkdir -p $(PROJECT)/_ide/$(basename $(notdir $(HARDWARE)))
-	@unzip -q -o $(HARDWARE) '*.bit' -d $(PROJECT)/_ide/$(basename $(notdir $(HARDWARE)))/
+	@unzip -q -o $(HARDWARE) '*.bit' -d $(PROJECT)/_ide/$(basename $(notdir $(HARDWARE)))/ 2>/dev/null; \
+	 unzip -q -o $(HARDWARE) '*.pdi' -d $(PROJECT)/_ide/$(basename $(notdir $(HARDWARE)))/ 2>/dev/null; true
 	@unzip -q -o $(HARDWARE) 'psu_init.tcl' -d $(PROJECT)/_ide/$(basename $(notdir $(HARDWARE)))/ 2>/dev/null || \
 	 unzip -q -o $(HARDWARE) 'ps7_init.tcl' -d $(PROJECT)/_ide/$(basename $(notdir $(HARDWARE)))/ 2>/dev/null || \
 	 unzip -q -o $(HARDWARE) 'ps_init.tcl' -d $(PROJECT)/_ide/$(basename $(notdir $(HARDWARE)))/ 2>/dev/null || true


### PR DESCRIPTION
## Pull Request Description

Add Versal (psv_cortexa72) architecture support to the Xilinx build and debug tooling for Vitis 2025.x Unified IDE:

generate_vitis_launch.py:
- Add Versal arch detection (cortexa72/psv_cortexa72)
- Generate baremetal-versal debug config with PDI path
- Use relative peersIniPath (TCF adapter limitation)
- Set Versal target context for debug enumeration

util.tcl:
- Add _write_pl_versal: PDI programming via Vivado hardware manager (xsct device program fails on Versal with PLM error 0x302)
- Add Versal flow in upload: hw_server/cs_server management
- Add Versal _init_ps: rst -processor -clear-registers + force-mem-accesses
- Add Versal entries to pl_dict/ps_dict CPU mappings

xilinx.mk:
- Extract both .bit and .pdi from XSA in vitis_launch_config target

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
