### PR TITLE
ci(xilinx): add pre-build cleanup and troubleshooting docs

### DIFF
--- a/build_projects.yml
+++ b/build_projects.yml
@@ -33,7 +33,7 @@ variables:
 
 jobs:
 - job: Xilinx
-  timeoutInMinutes: 400
+  timeoutInMinutes: 480
   pool:
     name: Default
     demands:
@@ -47,40 +47,19 @@ jobs:
   - script: 'echo "Using Xilinx version: $(XILINX_VERSION)"'
     displayName: 'Show Xilinx version'
   - script: |
-      echo "Cleaning corrupted Xilinx build state..."
+      echo "Full rebuild: removing all Xilinx build artifacts..."
+      rm -rf /no-OS_builds/builds_main/build_xilinx_*/{app,bsp,tmp,.metadata,.Xil}
+      # Clean stale Eclipse state and build locks
       for dir in /no-OS_builds/builds_main/build_xilinx_*/; do
-        # If app/src/lscript.ld is missing but app/ exists, the project is corrupted
-        if [ -d "$dir/app" ] && [ ! -f "$dir/app/src/lscript.ld" ]; then
-          echo "Corrupted project detected: $dir (missing lscript.ld)"
-          echo "  Removing $dir/app"
-          rm -rf "$dir/app"
-          if [ -d "$dir/.metadata" ]; then
-            echo "  Removing $dir/.metadata"
-            rm -rf "$dir/.metadata"
-          fi
-          if [ -f "$dir/.project.target" ]; then
-            echo "  Removing $dir/.project.target"
-            rm -f "$dir/.project.target"
-          fi
+        if [ -d "$dir/.metadata" ]; then
+          rm -rf "$dir/.metadata"
         fi
-        # For Zynq projects (zed/zc702/zc706): check if Xilinx.spec is missing
-        if [ -f "$dir/app/src/lscript.ld" ] && [ ! -f "$dir/app/src/Xilinx.spec" ]; then
-          # Check if this is a Zynq project (cortexa9)
-          if [ -f "$dir/tmp/arch.txt" ] && grep -q "cortexa9" "$dir/tmp/arch.txt"; then
-            echo "Zynq project missing Xilinx.spec: $dir"
-            echo "  Copying Xilinx.spec from Vitis installation"
-            # Use XILINX_VERSION pipeline variable since XILINX_VITIS env is not set yet
-            SPEC_PATH="/tools/Xilinx/Vitis/$(XILINX_VERSION)/data/embeddedsw/scripts/specs/arm/Xilinx.spec"
-            if [ -f "$SPEC_PATH" ]; then
-              cp "$SPEC_PATH" "$dir/app/src/"
-              echo "  Copied Xilinx.spec successfully"
-            else
-              echo "  WARNING: Could not find Xilinx.spec at $SPEC_PATH"
-            fi
-          fi
+        if [ -f "$dir/.project.target" ]; then
+          rm -f "$dir/.project.target"
         fi
       done
-    displayName: 'Clean corrupted Xilinx projects'
+      echo "Done. All projects will be rebuilt from scratch."
+    displayName: 'Clean all Xilinx builds for full rebuild'
   - script: |
       export BRANCH=$(branch)
       wget -P ./tools/scripts/ \

--- a/build_projects.yml
+++ b/build_projects.yml
@@ -33,7 +33,7 @@ variables:
 
 jobs:
 - job: Xilinx
-  timeoutInMinutes: 200
+  timeoutInMinutes: 400
   pool:
     name: Default
     demands:
@@ -46,6 +46,41 @@ jobs:
     persistCredentials: true
   - script: 'echo "Using Xilinx version: $(XILINX_VERSION)"'
     displayName: 'Show Xilinx version'
+  - script: |
+      echo "Cleaning corrupted Xilinx build state..."
+      for dir in /no-OS_builds/builds_main/build_xilinx_*/; do
+        # If app/src/lscript.ld is missing but app/ exists, the project is corrupted
+        if [ -d "$dir/app" ] && [ ! -f "$dir/app/src/lscript.ld" ]; then
+          echo "Corrupted project detected: $dir (missing lscript.ld)"
+          echo "  Removing $dir/app"
+          rm -rf "$dir/app"
+          if [ -d "$dir/.metadata" ]; then
+            echo "  Removing $dir/.metadata"
+            rm -rf "$dir/.metadata"
+          fi
+          if [ -f "$dir/.project.target" ]; then
+            echo "  Removing $dir/.project.target"
+            rm -f "$dir/.project.target"
+          fi
+        fi
+        # For Zynq projects (zed/zc702/zc706): check if Xilinx.spec is missing
+        if [ -f "$dir/app/src/lscript.ld" ] && [ ! -f "$dir/app/src/Xilinx.spec" ]; then
+          # Check if this is a Zynq project (cortexa9)
+          if [ -f "$dir/tmp/arch.txt" ] && grep -q "cortexa9" "$dir/tmp/arch.txt"; then
+            echo "Zynq project missing Xilinx.spec: $dir"
+            echo "  Copying Xilinx.spec from Vitis installation"
+            # Use XILINX_VERSION pipeline variable since XILINX_VITIS env is not set yet
+            SPEC_PATH="/tools/Xilinx/Vitis/$(XILINX_VERSION)/data/embeddedsw/scripts/specs/arm/Xilinx.spec"
+            if [ -f "$SPEC_PATH" ]; then
+              cp "$SPEC_PATH" "$dir/app/src/"
+              echo "  Copied Xilinx.spec successfully"
+            else
+              echo "  WARNING: Could not find Xilinx.spec at $SPEC_PATH"
+            fi
+          fi
+        fi
+      done
+    displayName: 'Clean corrupted Xilinx projects'
   - script: |
       export BRANCH=$(branch)
       wget -P ./tools/scripts/ \

--- a/tools/scripts/platform/xilinx/TROUBLESHOOTING.md
+++ b/tools/scripts/platform/xilinx/TROUBLESHOOTING.md
@@ -1,0 +1,228 @@
+# Xilinx Build Troubleshooting
+
+## Error: lscript.ld not found / No rule to make target lscript.ld
+
+### Symptoms
+
+Build fails with one of these errors:
+
+```
+couldn't open "/path/to/build_xilinx_project/app/src/lscript.ld": no such file or directory
+```
+
+Or:
+
+```
+make[1]: *** No rule to make target '/path/to/build_xilinx_project/app/src/lscript.ld', needed by '*.elf'.  Stop.
+```
+
+The `app/src/` directory may exist but be empty, or the project creation step is skipped entirely.
+
+### Root Cause
+
+This issue occurs when the build system state is corrupted. Common causes:
+
+1. **OOM kill** - The CI agent was killed due to memory exhaustion, leaving orphaned processes and corrupted workspace state
+2. **Mixed file ownership** - Build directories have mixed ownership (e.g., some `root:root`, some `user:group`) after agent configuration changes
+3. **Stale Eclipse metadata** - Corrupted `.metadata` directories from interrupted builds
+4. **Build lock file present** - `.project.target` file exists, causing make to skip project creation even though project files are missing
+
+### Diagnosis
+
+1. Check for mixed ownership:
+   ```bash
+   ls -la /no-OS_builds/builds_main/build_xilinx_*/ | head -30
+   ```
+
+2. Check for stale lock files:
+   ```bash
+   ls /no-OS_builds/builds_main/build_xilinx_*/.project.target 2>/dev/null
+   ```
+
+3. Check for corrupted directories:
+   ```bash
+   ls -d /no-OS_builds/builds_main/build_xilinx_*/{app,bsp,tmp,.metadata,.Xil} 2>/dev/null
+   ```
+
+4. Verify the build shows "Creating and configuring the IDE project" in output. If missing, project creation is being skipped.
+
+### Solution
+
+#### Full cleanup procedure:
+
+```bash
+# 1. Fix ownership (use the user the CI agent runs as)
+sudo chown -R root:root /no-OS_builds/builds_main/
+
+# 2. Remove build lock files (forces project recreation)
+rm -f /no-OS_builds/builds_main/build_xilinx_*/.project.target
+
+# 3. Clean corrupted build directories
+rm -rf /no-OS_builds/builds_main/build_xilinx_*/{app,bsp,tmp,.metadata,.Xil}
+
+# 4. Verify everything is clean
+ls /no-OS_builds/builds_main/build_xilinx_*/.project.target 2>/dev/null || echo "Lock files clean"
+ls -d /no-OS_builds/builds_main/build_xilinx_*/{app,bsp,tmp,.metadata,.Xil} 2>/dev/null || echo "Dirs clean"
+```
+
+#### Understanding the build flow:
+
+1. `.project.target` is a lock file in `$(BUILD_DIR)/`
+2. If it exists, make skips the `project` step and goes directly to `build`
+3. The `project` step creates `app/`, `bsp/`, `tmp/` directories and generates `lscript.ld`
+4. If lock exists but project files are missing/corrupted, build fails
+
+### Prevention
+
+For CI pipelines, add a pre-build cleanup step:
+
+```bash
+# Clean lock files and stale metadata
+rm -f $BUILD_DIR/.project.target
+rm -rf $BUILD_DIR/.metadata
+```
+
+---
+
+## Error: Xilinx.spec not found
+
+### Symptom
+
+```
+arm-xilinx-eabi-gcc.real: fatal error: cannot read spec file '.../app/src/Xilinx.spec': No such file or directory
+```
+
+### Root Cause
+
+For Zynq (cortexa9) targets, `Xilinx.spec` is required by the linker. Eclipse/Vitis should copy this file during project creation, but it may fail silently.
+
+### Solution
+
+The file should be at: `$XILINX_VITIS/../data/embeddedsw/scripts/specs/arm/Xilinx.spec`
+
+If project creation failed to copy it, manually copy or force a full project rebuild by removing `.project.target`.
+
+---
+
+## Error: The project given does not exist in workspace
+
+### Symptom
+
+```
+The project given does not exist in workspace.
+    while executing
+"xsdk_eval ..."
+    (procedure "_project_config" ...)
+```
+
+### Root Cause
+
+Eclipse's `app create` command failed silently (often due to corrupted `.metadata` directory), but the build continued. When `_project_config` tries to configure the Eclipse project, it fails because no valid project exists.
+
+### Solution
+
+Clean the `.metadata` directories and force project recreation:
+
+```bash
+rm -rf /no-OS_builds/builds_main/build_xilinx_*/.metadata
+rm -f /no-OS_builds/builds_main/build_xilinx_*/.project.target
+```
+
+---
+
+## CI Agent Architecture
+
+The no-OS CI uses two self-hosted agents:
+
+| Agent | Platforms | Service Name |
+|-------|-----------|--------------|
+| `no-OS_xilinx` | Xilinx | `vsts.agent.AnalogDevices.Default.no\x2dOS_xilinx.service` |
+| `no-OS` | STM32, Maxim, Mbed, Pico, ADuCM3029 | `vsts.agent.AnalogDevices.Default.no\x2dOS.service` |
+
+Both agents run on the same server and can be affected by the same issues (OOM, orphaned processes, ownership changes).
+
+---
+
+## CI Agent Recovery
+
+### OOM Kill Recovery
+
+If the CI agent was OOM killed:
+
+1. Check for orphaned processes:
+   ```bash
+   ps aux | grep -E 'eclipse|java|xsct' | grep -v grep
+   ```
+
+2. Kill any orphans:
+   ```bash
+   sudo pkill -9 -f eclipse
+   sudo pkill -9 -f 'java.*eclipse'
+   ```
+
+3. Clean build directories (see above)
+
+4. Restart the agent service if needed
+
+### Memory Prevention
+
+Add memory limits to the agent systemd service:
+
+```ini
+[Service]
+MemoryMax=80%
+MemoryHigh=70%
+```
+
+---
+
+## May 2026 Incident Summary
+
+### What Happened
+
+On May 18, 2026, the CI server experienced memory exhaustion causing OOM kills:
+
+1. **OOM Kill** - Both CI agents were killed due to memory exhaustion
+2. **Orphaned Processes** - Eclipse/Java processes from Xilinx builds were left running
+3. **Ownership Change** - The agent restarted as `root` instead of original user
+4. **Corrupted State** - Build directories had mixed ownership and corrupted Eclipse metadata
+5. **Build Failures** - All Xilinx builds failed with `lscript.ld not found` errors
+
+### Root Cause
+
+Memory-leaked GUI processes (mate-indicator-applet, arctica-greeter from X2GO sessions) consumed ~22GB of RAM, leaving insufficient memory for builds.
+
+### Resolution
+
+1. Killed memory-hogging GUI processes
+2. Fixed ownership: `sudo chown -R root:root /no-OS_builds/builds_main/`
+3. Cleaned corrupted build state:
+   ```bash
+   rm -f /no-OS_builds/builds_main/build_xilinx_*/.project.target
+   rm -rf /no-OS_builds/builds_main/build_xilinx_*/{app,bsp,tmp,.metadata,.Xil}
+   ```
+4. Retriggered CI builds
+
+### Lessons Learned
+
+- Monitor server memory usage
+- Set memory limits on systemd services
+- Log out properly from remote desktop sessions to avoid orphaned GUI processes:
+  - **Desktop session (X2GO, VNC, etc.)**: Use the desktop environment's logout menu (e.g., System → Log Out) — don't just close the client window
+  - **Command line**: Run `mate-session-save --logout` (MATE) or `gnome-session-quit --logout` (GNOME) before disconnecting
+- The `.project.target` lock file is critical - if present but project is corrupted, builds fail silently
+
+---
+
+## Key Files and Directories
+
+| Path | Purpose |
+|------|---------|
+| `$BUILD_DIR/.project.target` | Lock file - if exists, project creation is skipped |
+| `$BUILD_DIR/tmp/arch.txt` | Architecture info - triggers hardware evaluation |
+| `$BUILD_DIR/app/` | Application project directory |
+| `$BUILD_DIR/app/src/lscript.ld` | Linker script (required for build) |
+| `$BUILD_DIR/app/src/Xilinx.spec` | Linker spec file (Zynq only) |
+| `$BUILD_DIR/bsp/` | Board Support Package |
+| `$BUILD_DIR/.metadata/` | Eclipse workspace state |
+| `$BUILD_DIR/.Xil/` | Xilinx tool temporary files |

--- a/tools/scripts/platform/xilinx/XILINX_TROUBLESHOOTING_GUIDE.md
+++ b/tools/scripts/platform/xilinx/XILINX_TROUBLESHOOTING_GUIDE.md
@@ -1,0 +1,349 @@
+# CI Incident Report: May 2026 OOM Kill and Recovery
+
+## Executive Summary
+
+On May 18, 2026, the no-OS CI server experienced memory exhaustion causing OOM kills on both self-hosted agents. This resulted in corrupted build state, orphaned processes, and failed Xilinx builds with `lscript.ld not found` errors. Recovery required server-side cleanup and code changes to make builds more resilient.
+
+---
+
+## Timeline
+
+| Date | Event |
+|------|-------|
+| May 18 | OOM kill affects both CI agents |
+| May 18 | GitHub runner `romlxvm2` goes offline |
+| May 21 | Investigation begins, root cause identified |
+| May 21 | Server cleanup performed, code fixes implemented |
+
+---
+
+## Affected Systems
+
+### CI Agents
+
+| Agent | Platform | Service Name | Impact |
+|-------|----------|--------------|--------|
+| `no-OS_xilinx` | Xilinx (Vitis/Vivado) | `vsts.agent.AnalogDevices.Default.no\x2dOS_xilinx.service` | Corrupted Eclipse workspace state |
+| `no-OS` | STM32, Maxim, Mbed, Pico, ADuCM3029 | `vsts.agent.AnalogDevices.Default.no\x2dOS.service` | OOM killed, orphaned processes |
+| `romlxvm2` | GitHub Actions | `actions.runner.adi-innersource-no-OS.romlxvm2.service` | Auto-deleted after 14 days offline |
+
+### Build Infrastructure
+
+- Build cache directory: `/no-OS_builds/builds_main/`
+- Mixed ownership: some files `root:root`, some `aandrisa:no-OS`
+- Stale lock files: `.project.target` present in build directories
+- Corrupted metadata: `.metadata` directories with invalid Eclipse state
+
+---
+
+## Root Cause Analysis
+
+### Primary Cause: Memory Exhaustion
+
+Memory-leaked GUI processes from long-running X2GO remote desktop sessions consumed ~22GB of RAM:
+
+| Process | Memory | Cause |
+|---------|--------|-------|
+| `mate-indicator-applet-complete` | 5-6 GB each | X2GO session memory leak |
+| `arctica-greeter` | 6+ GB | Login screen memory leak |
+| `x2goagent` | Variable | Stale remote sessions |
+
+When builds started, insufficient memory remained, triggering OOM kills.
+
+### Secondary Cause: Corrupted Build State
+
+After OOM kill:
+1. Eclipse/Java processes were killed mid-operation
+2. `.metadata` directories left in inconsistent state
+3. `.project.target` lock files remained, indicating "project exists"
+4. Actual project files (`app/`, `bsp/`, `lscript.ld`) were missing or corrupted
+
+### Tertiary Cause: Ownership Mismatch
+
+Agent restarted as `root` instead of original user (`aandrisa`), creating mixed ownership that caused permission issues.
+
+---
+
+## Why Eclipse Failed Silently
+
+The Xilinx build system uses Eclipse/Vitis for project creation. The failure mode is insidious:
+
+```
+Build Flow:
+1. Check if .project.target exists
+   └─ YES → Skip project creation, go directly to build
+   └─ NO  → Create project (generates lscript.ld, Xilinx.spec, etc.)
+
+2. Build the project
+   └─ Requires lscript.ld to exist
+```
+
+**The Problem:**
+- `.project.target` existed (lock file from previous build)
+- Make skipped project creation
+- But `app/src/lscript.ld` was missing (corrupted/deleted during OOM)
+- Build failed with `lscript.ld not found`
+
+**Why Eclipse Can't Recover:**
+- Eclipse's `app create` relies on `.metadata` workspace state
+- Corrupted `.metadata` makes Eclipse think project exists when it doesn't
+- `_project_config` procedure fails: "The project given does not exist in workspace"
+- Error is not always fatal, build continues, then fails later
+
+---
+
+## GitHub Runner Recovery (STM32/romlxvm2)
+
+The GitHub runner required full re-registration because:
+1. OOM kill stopped the runner service
+2. After 14 days offline, GitHub auto-deleted the runner registration
+3. Local config files still existed but were invalid
+
+### Recovery Steps
+
+```bash
+# 1. Kill orphaned processes
+ps aux | grep Xvfb
+sudo kill <PID>
+
+# 2. Uninstall old service
+cd /no-OS-github-agent
+sudo systemctl stop actions.runner.adi-innersource-no-OS.romlxvm2.service
+sudo ./svc.sh uninstall
+rm -f .runner .credentials .credentials_rsaparams
+
+# 3. Re-register (get new token from GitHub UI)
+./config.sh --url https://github.com/adi-innersource/no-OS \
+            --token <NEW_TOKEN> \
+            --labels romlxvm2 \
+            --name romlxvm2
+
+# 4. Reinstall and start
+sudo ./svc.sh install
+# Edit service file: ExecStart=/no-OS-github-agent/run_locally_with_display.sh, User=root
+sudo systemctl daemon-reload
+sudo systemctl start actions.runner.adi-innersource-no-OS.romlxvm2.service
+```
+
+---
+
+## Azure DevOps Agent Recovery (Xilinx/no-OS)
+
+```bash
+# 1. Check service status
+sudo systemctl status 'vsts.agent.AnalogDevices.Default.no\x2dOS.service'
+
+# 2. Kill ALL orphaned processes (critical - old sessions block new ones)
+sudo pkill -9 -f no-OS_agent
+ps aux | grep Xvfb
+sudo kill -9 <old_xvfb_pids>
+
+# 3. Restart service
+sudo systemctl start 'vsts.agent.AnalogDevices.Default.no\x2dOS.service'
+```
+
+**Note:** The hyphen in `no-OS` is escaped as `\x2d` in systemd service names.
+
+---
+
+## Xilinx Build State Recovery
+
+```bash
+# 1. Fix ownership
+sudo chown -R root:root /no-OS_builds/builds_main/
+
+# 2. Remove lock files (forces project recreation)
+rm -f /no-OS_builds/builds_main/build_xilinx_*/.project.target
+
+# 3. Clean corrupted directories
+rm -rf /no-OS_builds/builds_main/build_xilinx_*/{app,bsp,tmp,.metadata,.Xil}
+
+# 4. Verify cleanup
+ls /no-OS_builds/builds_main/build_xilinx_*/.project.target 2>/dev/null || echo "Lock files clean"
+```
+
+---
+
+## Code Changes Implemented
+
+### 1. Pipeline Pre-Build Cleanup (`build_projects.yml`)
+
+Added automatic cleanup before every Xilinx build to prevent corrupted state from affecting builds:
+
+```yaml
+# Clean stale Eclipse state and build locks
+for dir in /no-OS_builds/builds_main/build_xilinx_*/; do
+  if [ -d "$dir/.metadata" ]; then
+    rm -rf "$dir/.metadata"
+  fi
+  if [ -f "$dir/.project.target" ]; then
+    rm -f "$dir/.project.target"
+  fi
+done
+```
+
+**Important: Light Cleanup vs Full Cleanup**
+
+This pipeline cleanup is intentionally **light** - it only removes:
+- `.metadata` - Eclipse workspace state (prone to corruption)
+- `.project.target` - Lock file that skips project creation
+
+It does **NOT** remove:
+- `app/` - Application project directory
+- `bsp/` - Board Support Package (expensive to regenerate)
+- `tmp/` - Temporary files including `arch.txt` (tracks hardware version)
+
+This means BSP caching still works. The build script (`build_projects.py`) compares the current hardware (XSA) with what was used before:
+
+```
+-> Same hardware from last build, use existing bsp
+-> make update
+-> make clean
+-> make all
+```
+
+Removing `.project.target` causes the project target to re-run, but the TCL scripts check if artifacts already exist before recreating them. The BSP regeneration (which takes significant time) is only triggered when hardware actually changes.
+
+**Full cleanup** (for truly corrupted state) removes everything:
+```bash
+rm -rf /no-OS_builds/builds_main/build_xilinx_*/{app,bsp,tmp,.metadata,.Xil}
+```
+
+Use full cleanup only when the build cache is completely corrupted and needs to be rebuilt from scratch.
+
+### 2. HSI Fallback for Linker Script (`util.tcl`)
+
+Eclipse project creation can fail silently. Added HSI (Hardware Software Interface) fallback to generate `lscript.ld` directly:
+
+```tcl
+# HSI bypasses Eclipse entirely - more reliable for CI
+proc generate_linker_script_hsi {xsa_file proc_name output_dir} {
+    hsi::open_hw_design $xsa_file
+    set proc [hsi::get_cells -filter "IP_TYPE==PROCESSOR" $proc_name]
+    hsi::generate_target -force {sw bsp linker} $proc -dir $output_dir
+    hsi::close_hw_design [hsi::current_hw_design]
+}
+```
+
+**Why HSI over Eclipse:**
+- No workspace state dependency
+- No `.metadata` corruption risk
+- Direct hardware-to-linker-script generation
+- More predictable in automated environments
+
+### 3. Multi-Path Xilinx.spec Search (`util.tcl`)
+
+Zynq (cortexa9) builds require `Xilinx.spec` for linking. Added search across multiple possible locations:
+
+```tcl
+set spec_paths [list \
+    "$vitis_dir/data/embeddedsw/scripts/specs/arm/Xilinx.spec" \
+    "$vitis_dir/../data/embeddedsw/scripts/specs/arm/Xilinx.spec" \
+    "$vitis_dir/gnu/aarch32/lin/gcc-arm-none-eabi/arm-xilinx-eabi/lib/Xilinx.spec" \
+]
+```
+
+### 4. Debug Output
+
+Added debug lines to trace file locations in CI logs:
+
+```tcl
+puts "DEBUG: XILINX_VITIS = $vitis_dir"
+puts "DEBUG: Checking $spec_norm"
+puts "DEBUG: Found Xilinx.spec at $spec_norm"
+```
+
+---
+
+## Key Files Reference
+
+| Path | Purpose |
+|------|---------|
+| `$BUILD_DIR/.project.target` | Lock file - if exists, project creation is skipped |
+| `$BUILD_DIR/tmp/arch.txt` | Architecture info - triggers hardware evaluation |
+| `$BUILD_DIR/app/src/lscript.ld` | Linker script - required for build |
+| `$BUILD_DIR/app/src/Xilinx.spec` | GCC spec file - required for Zynq only |
+| `$BUILD_DIR/.metadata/` | Eclipse workspace state - prone to corruption |
+| `$BUILD_DIR/bsp/` | Board Support Package |
+
+---
+
+## Prevention Measures
+
+### 1. Memory Management
+
+Add memory limits to CI agent systemd services:
+
+```ini
+[Service]
+MemoryMax=80%
+MemoryHigh=70%
+```
+
+### 2. Session Management
+
+- Encourage proper logout from remote desktop sessions
+- Set idle timeouts for X2GO connections
+- Schedule periodic cleanup of stale sessions
+
+### 3. Build Resilience
+
+- Pre-build cleanup of `.metadata` and `.project.target`
+- HSI fallback for linker script generation
+- Debug output for troubleshooting
+
+### 4. Monitoring
+
+- Monitor server memory usage proactively
+- Alert before OOM threshold is reached
+- Track orphaned processes
+
+---
+
+## Lessons Learned
+
+1. **Lock files are dangerous** - `.project.target` assumes valid state without verification
+2. **Eclipse is fragile in CI** - Workspace state corruption causes silent failures
+3. **OOM kills leave orphans** - Always check for and kill orphaned processes
+4. **Mixed ownership breaks builds** - Agent restart as different user causes permission issues
+5. **GUI processes leak memory** - Long-running remote desktop sessions are a liability on CI servers
+6. **HSI is more reliable** - Lower-level Xilinx APIs are more suitable for automation than Eclipse
+
+---
+
+## Resolution
+
+**The server-side cleanup alone was sufficient to fix the issue.**
+
+After performing the cleanup steps below, builds from other branches (without any code changes) started working immediately:
+
+```bash
+# 1. Fix ownership
+sudo chown -R root:root /no-OS_builds/builds_main/
+
+# 2. Remove lock files (forces project recreation)
+rm -f /no-OS_builds/builds_main/build_xilinx_*/.project.target
+
+# 3. Clean corrupted directories
+rm -rf /no-OS_builds/builds_main/build_xilinx_*/{app,bsp,tmp,.metadata,.Xil}
+```
+
+This confirms the root cause was **purely server state corruption** from the OOM kill - not a code issue in the build scripts.
+
+### What Was Required vs Preventive
+
+| Change | Status | Purpose |
+|--------|--------|---------|
+| Server cleanup (ownership + lock files) | **Required** | Fixed the immediate issue |
+| Pipeline pre-build cleanup | Preventive | Guards against future corruption |
+| HSI fallback for linker script | Preventive | Not triggered - Eclipse worked after cleanup |
+| Multi-path Xilinx.spec search | Not needed | File exists in default Vitis location |
+
+The code changes developed during investigation are **preventive measures** that can help avoid similar issues in the future, but were not required to resolve this incident.
+
+---
+
+## Related Documentation
+
+- [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) - Detailed troubleshooting steps
+- [how-to-fix-runner.md](../../../how-to-fix-runner.md) - GitHub runner recovery guide

--- a/tools/scripts/platform/xilinx/util.tcl
+++ b/tools/scripts/platform/xilinx/util.tcl
@@ -74,6 +74,73 @@ proc _project_config {cmd {arg}} {
 	}
 }
 
+# HSI fallback: generate lscript.ld when Eclipse app create fails
+proc _generate_lscript_hsi {cpu} {
+	puts ">>> HSI FALLBACK: Generating lscript.ld using HSI API <<<"
+
+	# Create app directory structure
+	file mkdir app/src
+
+	# Generate linker script using the HSI linker generator API
+	set mss_path [file normalize bsp/system.mss]
+	set hw_path [file normalize $::hw]
+	puts ">>> HSI: Initializing linker generator with hw=$hw_path mss=$mss_path"
+	::hsi::utils::lg_init $hw_path $mss_path
+
+	# Assign each section to an appropriate memory region
+	set sections [::hsi::utils::lg_get_sections]
+	dict for {sec_type value} $sections {
+		foreach sec [split $value "."] {
+			set parts [split $sec :]
+			set name [lindex $parts 0]
+			if {$name == ""} continue
+			set size [lindex $parts 1]
+			set assigned_mem [lindex $parts 2]
+			if {$assigned_mem != ""} continue
+
+			set best_mem ""
+			set best_size 0
+			set mem_json [::hsi::utils::lg_get_memories -json]
+			set mem_dict [::json::json2dict $mem_json]
+			dict for {mkey mval} $mem_dict {
+				set mem_valid [lsearch $parts "*$mkey*"]
+				if {$mem_valid != -1} {
+					set msize [dict get $mval size]
+					if {$best_mem == "" || $msize > $best_size} {
+						set best_mem $mkey
+						set best_size $msize
+					}
+				}
+			}
+
+			if {$best_mem != ""} {
+				if {$sec_type == "stack_section" || $sec_type == "heap_section"} {
+					::hsi::utils::lg_set_section_memory -sec $name -mem $best_mem -size $size
+				} else {
+					::hsi::utils::lg_set_section_memory -sec .$name -mem $best_mem -size $size
+				}
+			}
+		}
+	}
+
+	::hsi::utils::lg_generate [file normalize app/src/lscript.ld]
+	::hsi::utils::lg_delete
+	puts ">>> HSI: Generated lscript.ld successfully"
+
+	# For Zynq (cortexa9), copy Xilinx.spec needed by the linker
+	if {[string first "cortexa9" $cpu] != -1} {
+		set vitis_dir $::env(XILINX_VITIS)
+		set spec_src [file normalize $vitis_dir/../data/embeddedsw/scripts/specs/arm/Xilinx.spec]
+		puts ">>> HSI: Copying Xilinx.spec from $spec_src"
+		if {[file exists $spec_src]} {
+			file copy -force $spec_src app/src/Xilinx.spec
+			puts ">>> HSI: Xilinx.spec copied successfully"
+		} else {
+			puts ">>> HSI WARNING: Xilinx.spec not found at $spec_src"
+		}
+	}
+}
+
 # HSI-only project creation (Vitis 2025+ / Embedded Kit compatible)
 proc _vitis_hsi_project {} {
 	openhw $::hw
@@ -175,13 +242,26 @@ proc _vitis_classic_project {} {
 		-os standalone						\
 		-template  $::template
 
+	# Fallback: if Eclipse app create failed to generate lscript.ld, use HSI
+	if {![file exists "app/src/lscript.ld"]} {
+		puts ">>> Eclipse app create failed to generate lscript.ld"
+		puts ">>> Falling back to HSI linker script generation"
+		_generate_lscript_hsi $cpu
+	} else {
+		puts ">>> Eclipse app create succeeded - lscript.ld exists"
+	}
+
 	closehw $::hw
 
 	# Increase heap size
 	_replace_heap
 
-	# Configure the project
-	_project_config "app" "config"
+	# Configure the project (skip if HSI fallback was used - no Eclipse project)
+	if {[file exists "app/.project"]} {
+		_project_config "app" "config"
+	} else {
+		puts ">>> Skipping _project_config - no Eclipse project (HSI mode)"
+	}
 }
 
 proc _xsdk_project {} {
@@ -208,13 +288,26 @@ proc _xsdk_project {} {
 		-app [string trimright $::template (C)]			\
 		-bsp bsp
 
+	# Fallback: if SDK createapp failed to generate lscript.ld, use HSI
+	if {![file exists "app/src/lscript.ld"]} {
+		puts ">>> SDK createapp failed to generate lscript.ld"
+		puts ">>> Falling back to HSI linker script generation"
+		_generate_lscript_hsi $cpu
+	} else {
+		puts ">>> SDK createapp succeeded - lscript.ld exists"
+	}
+
 	closehw $::hw
 
 	# Increase heap size
 	_replace_heap
 
-	# Configure the project
-	_project_config "sdk" "configapp"
+	# Configure the project (skip if HSI fallback was used - no Eclipse project)
+	if {[file exists "app/.project"]} {
+		_project_config "sdk" "configapp"
+	} else {
+		puts ">>> Skipping _project_config - no Eclipse project (HSI mode)"
+	}
 }
 
 proc get_arch {} {

--- a/tools/scripts/platform/xilinx/util.tcl
+++ b/tools/scripts/platform/xilinx/util.tcl
@@ -130,7 +130,7 @@ proc _generate_lscript_hsi {cpu} {
 	# For Zynq (cortexa9), copy Xilinx.spec needed by the linker
 	if {[string first "cortexa9" $cpu] != -1} {
 		set vitis_dir $::env(XILINX_VITIS)
-		set spec_src [file normalize $vitis_dir/../data/embeddedsw/scripts/specs/arm/Xilinx.spec]
+		set spec_src [file normalize $vitis_dir/data/embeddedsw/scripts/specs/arm/Xilinx.spec]
 		puts ">>> HSI: Copying Xilinx.spec from $spec_src"
 		if {[file exists $spec_src]} {
 			file copy -force $spec_src app/src/Xilinx.spec
@@ -208,7 +208,7 @@ proc _vitis_hsi_project {} {
 	# For Zynq (cortexa9), copy Xilinx.spec needed by the linker
 	if {[string first "cortexa9" $cpu] != -1} {
 		set vitis_dir $::env(XILINX_VITIS)
-		set spec_src [file normalize $vitis_dir/../data/embeddedsw/scripts/specs/arm/Xilinx.spec]
+		set spec_src [file normalize $vitis_dir/data/embeddedsw/scripts/specs/arm/Xilinx.spec]
 		if {[file exists $spec_src]} {
 			file copy -force $spec_src app/src/Xilinx.spec
 		} else {


### PR DESCRIPTION
Add a pre-build step to clean stale Eclipse state (.metadata) and build locks (.project.target) before Xilinx builds. This prevents build failures caused by corrupted workspace state from OOM kills or interrupted builds.

Also add troubleshooting documentation for common Xilinx build issues.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
