### PR TITLE
drivers: adc_demo: fix function pointer type mismatches

### DIFF
--- a/drivers/adc/adc_demo/iio_adc_demo.c
+++ b/drivers/adc/adc_demo/iio_adc_demo.c
@@ -274,6 +274,47 @@ static struct iio_channel iio_adc_channels[] = {
 	IIO_DEMO_ADC_CHANNEL(15),
 };
 
+/**
+ * @brief Wrapper function for adc_demo_reg_read with correct signature for IIO
+ * @param dev - Device pointer (will be cast to adc_demo_desc)
+ * @param reg - Register address (32-bit)
+ * @param readval - Pointer to store read value (32-bit)
+ * @return 0 on success, negative error code otherwise
+ */
+static int32_t iio_adc_demo_reg_read(void *dev, uint32_t reg, uint32_t *readval)
+{
+	struct adc_demo_desc *desc = (struct adc_demo_desc *)dev;
+	uint8_t val8;
+	int32_t ret;
+
+	if (reg > 0xFF)
+		return -EINVAL;
+
+	ret = adc_demo_reg_read(desc, (uint8_t)reg, &val8);
+	if (ret == 0)
+		*readval = val8;
+
+	return ret;
+}
+
+/**
+ * @brief Wrapper function for adc_demo_reg_write with correct signature for IIO
+ * @param dev - Device pointer (will be cast to adc_demo_desc)
+ * @param reg - Register address (32-bit)
+ * @param writeval - Value to write (32-bit)
+ * @return 0 on success, negative error code otherwise
+ */
+static int32_t iio_adc_demo_reg_write(void *dev, uint32_t reg,
+				      uint32_t writeval)
+{
+	struct adc_demo_desc *desc = (struct adc_demo_desc *)dev;
+
+	if (reg > 0xFF || writeval > 0xFF)
+		return -EINVAL;
+
+	return adc_demo_reg_write(desc, (uint8_t)reg, (uint8_t)writeval);
+}
+
 struct iio_device adc_demo_iio_descriptor = {
 	.num_ch = TOTAL_ADC_CHANNELS,
 	.channels = iio_adc_channels,
@@ -282,9 +323,9 @@ struct iio_device adc_demo_iio_descriptor = {
 	.buffer_attributes = NULL,
 	.pre_enable = update_adc_channels,
 	.post_disable = close_adc_channels,
-	.trigger_handler = (int32_t (*)())adc_demo_trigger_handler,
-	.submit = (int32_t (*)())adc_submit_samples,
-	.debug_reg_read = (int32_t (*)()) adc_demo_reg_read,
-	.debug_reg_write = (int32_t (*)()) adc_demo_reg_write
+	.trigger_handler = adc_demo_trigger_handler,
+	.submit = adc_submit_samples,
+	.debug_reg_read = iio_adc_demo_reg_read,
+	.debug_reg_write = iio_adc_demo_reg_write
 };
 

--- a/drivers/dac/dac_demo/iio_dac_demo.c
+++ b/drivers/dac/dac_demo/iio_dac_demo.c
@@ -270,17 +270,69 @@ static struct iio_channel iio_dac_channels[] = {
 	IIO_DEMO_DAC_CHANNEL(15)
 };
 
+/**
+ * @brief Wrapper function for update_dac_channels with correct signature for IIO
+ * @param dev - Device pointer
+ * @param mask - Channel mask (unsigned)
+ * @return 0 on success, negative error code otherwise
+ */
+static int32_t iio_update_dac_channels(void *dev, uint32_t mask)
+{
+	return update_dac_channels(dev, (int32_t)mask);
+}
+
+/**
+ * @brief Wrapper function for dac_demo_reg_read with correct signature for IIO
+ * @param dev - Device pointer (will be cast to dac_demo_desc)
+ * @param reg - Register address (32-bit)
+ * @param readval - Pointer to store read value (32-bit)
+ * @return 0 on success, negative error code otherwise
+ */
+static int32_t iio_dac_demo_reg_read(void *dev, uint32_t reg, uint32_t *readval)
+{
+	struct dac_demo_desc *desc = (struct dac_demo_desc *)dev;
+	uint8_t val8;
+	int32_t ret;
+
+	if (reg > 0xFF)
+		return -EINVAL;
+
+	ret = dac_demo_reg_read(desc, (uint8_t)reg, &val8);
+	if (ret == 0)
+		*readval = val8;
+
+	return ret;
+}
+
+/**
+ * @brief Wrapper function for dac_demo_reg_write with correct signature for IIO
+ * @param dev - Device pointer (will be cast to dac_demo_desc)
+ * @param reg - Register address (32-bit)
+ * @param writeval - Value to write (32-bit)
+ * @return 0 on success, negative error code otherwise
+ */
+static int32_t iio_dac_demo_reg_write(void *dev, uint32_t reg,
+				      uint32_t writeval)
+{
+	struct dac_demo_desc *desc = (struct dac_demo_desc *)dev;
+
+	if (reg > 0xFF || writeval > 0xFF)
+		return -EINVAL;
+
+	return dac_demo_reg_write(desc, (uint8_t)reg, (uint8_t)writeval);
+}
+
 struct iio_device dac_demo_iio_descriptor = {
 	.num_ch = TOTAL_DAC_CHANNELS,
 	.channels = iio_dac_channels,
 	.attributes = dac_global_attributes,
 	.debug_attributes = NULL,
 	.buffer_attributes = NULL,
-	.pre_enable = (int32_t (*)())update_dac_channels,
+	.pre_enable = iio_update_dac_channels,
 	.post_disable = close_dac_channels,
-	.trigger_handler = (int32_t (*)())dac_demo_trigger_handler,
-	.submit = (int32_t (*)())dac_submit_samples,
-	.debug_reg_read = (int32_t (*)()) dac_demo_reg_read,
-	.debug_reg_write = (int32_t (*)()) dac_demo_reg_write
+	.trigger_handler = dac_demo_trigger_handler,
+	.submit = dac_submit_samples,
+	.debug_reg_read = iio_dac_demo_reg_read,
+	.debug_reg_write = iio_dac_demo_reg_write
 };
 


### PR DESCRIPTION
Description:
Fix compilation errors in iio_adc_demo.c and iio_dac_demo.c caused by incorrect function pointer casting. Modern GCC versions (8+) enforce stricter type checking and reject the previous approach of casting all function pointers to int32_t (*)(void). The fix removes incorrect casts for functions that already match the expected signatures and adds wrapper functions to handle type conversions where needed (converting between uint8_t and uint32_t parameters for register read/write operations).

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
