### PR TITLE
platform: stm32: fix SPI DMA timeout underflow

### DIFF
--- a/drivers/platform/stm32/stm32_spi.c
+++ b/drivers/platform/stm32/stm32_spi.c
@@ -672,16 +672,18 @@ int32_t stm32_spi_transfer_dma(struct no_os_spi_desc* desc,
 	sdesc->stm32_spi_dma_done = false;
 	stm32_config_dma_and_start(desc, msgs, len, stm32_spi_dma_callback, desc);
 	timeout = msgs->bytes_number;
-	while (timeout--) {
+	while (timeout > 0) {
 		no_os_mdelay(1);
 		if (sdesc->stm32_spi_dma_done)
 			break;
+		timeout--;
 	};
 
-	/* need some cleanup here? */
-	if (timeout == 0)
+  /* Fix: Check the actual completion flag instead of the counter */
+	if (!sdesc->stm32_spi_dma_done) {
+    /* Optional: Add HAL_DMA_Abort_IT() or similar cleanup here */
 		return -ETIME;
-
+	}
 	return 0;
 }
 

--- a/drivers/platform/stm32/stm32_spi.c
+++ b/drivers/platform/stm32/stm32_spi.c
@@ -679,9 +679,8 @@ int32_t stm32_spi_transfer_dma(struct no_os_spi_desc* desc,
 		timeout--;
 	};
 
-  /* Fix: Check the actual completion flag instead of the counter */
 	if (!sdesc->stm32_spi_dma_done) {
-    /* Optional: Add HAL_DMA_Abort_IT() or similar cleanup here */
+    /* need some cleanup here? */
 		return -ETIME;
 	}
 	return 0;

--- a/drivers/platform/stm32/stm32_xspi.c
+++ b/drivers/platform/stm32/stm32_xspi.c
@@ -693,14 +693,14 @@ static int32_t stm32_xspi_transfer_dma(struct no_os_spi_desc *desc,
 		return ret;
 
 	timeout = msgs->bytes_number;
-	while (timeout--) {
+	while (timeout > 0) {
 		no_os_mdelay(1);
 		if (sdesc->stm32_xspi_dma_done)
 			break;
+		timeout--;
 	};
 
-	/* need some cleanup here? */
-	if (timeout == 0) {
+	if (!sdesc->stm32_xspi_dma_done) {
 		no_os_dma_xfer_abort(sdesc->dma_desc, sdesc->dma_ch);
 		return -ETIME;
 	}


### PR DESCRIPTION
This fixes an issue where an integer underflow in the timeout loop masks DMA failures and creates a race condition that reports false timeouts.

Resolves #3115

## Pull Request Description
### Problem
The loop `while (timeout--)` in `stm32_spi_transfer_dma()` causes two issues:
1. **Integer Underflow:** If DMA stalls, `timeout` decrements past 0 to `0xFFFFFFFF`. The final `if (timeout == 0)` check fails, and the function incorrectly returns `0` (Success).
2. **Race Condition:** If DMA completes during the very last iteration, the loop breaks but `timeout` is already `0`, causing a false `-ETIME` return.

### Solution
- Changed loop condition to `while (timeout > 0)` to prevent underflow.
- Verified completion using the actual hardware flag `!sdesc->stm32_spi_dma_done` instead of the counter.

### Testing
Verified via hardware debugging on STM32 with an ADIN1110 by simulating a DMA stall. The driver now correctly catches the stall and returns `-ETIME`.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
