### PR TITLE
fix the timeout underflow bugs across the codebase

### DIFF
--- a/drivers/afe/ad5940/iio_ad5940.c
+++ b/drivers/afe/ad5940/iio_ad5940.c
@@ -75,15 +75,15 @@ static int ad5940_iio_read_chan_raw(void *device, char *buf, uint32_t len,
 
 	AppBiaCtrl(iiodev->ad5940, BIACTRL_START, 0);
 
-	while (timeout--) {
+	while (timeout > 0) {
 		no_os_gpio_get_value(iiodev->ad5940->gp0_gpio, &gpio);
-		if (gpio)
-			no_os_mdelay(1);
-		else
+		if (!gpio)
 			break;
+		no_os_mdelay(1);
+		timeout--;
 	}
 
-	if (!timeout) {
+	if (gpio) {
 		AppBiaCtrl(iiodev->ad5940, BIACTRL_STOPNOW, 0);
 		return -ETIMEDOUT;
 	}

--- a/drivers/amplifiers/ada4250/ada4250.c
+++ b/drivers/amplifiers/ada4250/ada4250.c
@@ -163,7 +163,7 @@ int32_t ada4250_soft_reset(struct ada4250_dev *dev)
 	ret = ada4250_update(dev, ADA4250_REG_RESET, ADA4250_RESET_MSK,
 			     ADA4250_RESET(ADA4250_RESET_ENABLE));
 
-	while (timeout--) {
+	while (timeout > 0) {
 		ret = ada4250_read(dev, ADA4250_REG_RESET, &data);
 		if (ret != 0)
 			return ret;
@@ -175,9 +175,10 @@ int32_t ada4250_soft_reset(struct ada4250_dev *dev)
 			else
 				break;
 		}
+		timeout--;
 	}
 
-	if (timeout < 1)
+	if (data & ADA4250_RESET(ADA4250_RESET_ENABLE))
 		ret = -ETIME;
 
 	return ret;

--- a/drivers/axi_core/jesd204/altera_adxcvr.c
+++ b/drivers/axi_core/jesd204/altera_adxcvr.c
@@ -355,14 +355,15 @@ void adxcvr_finalize_lane_rate_change(struct adxcvr *xcvr)
 		return;
 
 	adxcvr_write(xcvr, ADXCVR_REG_RESETN, ADXCVR_RESETN);
-	do {
+	while (timeout > 0) {
 		adxcvr_read(xcvr, ADXCVR_REG_STATUS, &status);
 		if (status == ADXCVR_STATUS)
 			break;
 		no_os_mdelay(1);
-	} while (timeout--);
+		timeout--;
+	}
 
-	if (timeout < 0) {
+	if (status != ADXCVR_STATUS) {
 		adxcvr_read(xcvr, ADXCVR_REG_STATUS2, &status);
 		printf("%s: Link activation error:\n", xcvr->name);
 		printf("\tLink PLL %slocked\n",

--- a/drivers/axi_core/jesd204/axi_adxcvr.c
+++ b/drivers/axi_core/jesd204/axi_adxcvr.c
@@ -134,13 +134,14 @@ int32_t adxcvr_drp_wait_idle(struct adxcvr *xcvr,
 	uint32_t val;
 	int32_t timeout = 20;
 
-	do {
+	while (timeout > 0) {
 		adxcvr_read(xcvr, ADXCVR_REG_DRP_STATUS(drp_addr), &val);
 		if (!(val & ADXCVR_DRP_STATUS_BUSY))
 			return ADXCVR_DRP_STATUS_RDATA(val);
 
 		no_os_mdelay(1);
-	} while (timeout--);
+		timeout--;
+	}
 
 	printf("%s: %s: Timeout!", xcvr->name, __func__);
 

--- a/drivers/rf-transceiver/ad9361/ad9361.c
+++ b/drivers/rf-transceiver/ad9361/ad9361.c
@@ -1299,7 +1299,7 @@ static int32_t ad9361_check_cal_done(struct ad9361_rf_phy *phy, uint32_t reg,
 	uint32_t timeout = 20000; /* RFDC_CAL can take long */
 	uint32_t state;
 
-	do {
+	while (timeout > 0) {
 		state = ad9361_spi_readf(phy->spi, reg, mask);
 		if (state == done_state)
 			return 0;
@@ -1308,7 +1308,8 @@ static int32_t ad9361_check_cal_done(struct ad9361_rf_phy *phy, uint32_t reg,
 			no_os_udelay(1200);
 		else
 			no_os_udelay(120);
-	} while (timeout--);
+		timeout--;
+	}
 
 	dev_err(&phy->spi->dev, "Calibration TIMEOUT (0x%"PRIX32", 0x%"PRIX32")", reg,
 		mask);

--- a/network/wifi/at_parser.c
+++ b/network/wifi/at_parser.c
@@ -519,12 +519,13 @@ static int32_t send_cmd(struct at_desc *desc, enum at_cmd cmd,
 		if (0 != wait_for_response(desc))
 			return -1;
 		/* Wait until '>' is received */
-		while (timeout--) {
+		while (timeout > 0) {
 			if (WAITING_SEND != desc->callback_operation)
 				break;
 			no_os_mdelay(1);
+			timeout--;
 		}
-		if (timeout == 0)
+		if (WAITING_SEND == desc->callback_operation)
 			return -1;
 		/* Write payload */
 		no_os_uart_write(desc->uart_desc, in_param->send_data.data.buff,
@@ -532,13 +533,14 @@ static int32_t send_cmd(struct at_desc *desc, enum at_cmd cmd,
 	} else if (cmd == AT_DISCONNECT_NETWORK) {
 		if (desc->is_wifi_connected) {
 			/* Wait for WIFI_DISCONNECT */
-			do {
+			while (timeout > 0) {
 				if (desc->is_wifi_connected == 0)
 					break;
 				no_os_mdelay(1);
-			} while (timeout--);
+				timeout--;
+			}
 
-			if (timeout == 0)
+			if (desc->is_wifi_connected)
 				return -1;
 
 			return 0;


### PR DESCRIPTION
## Pull Request Description
A few individual patches and commits to fix the timeout underflow bugs across the codebase (excluding the stm32 platform drivers already addressed in PR #3116):

  Files Fixed:

  1. drivers/amplifiers/ada4250/ada4250.c - Fixed underflow in soft reset timeout
  2. drivers/afe/ad5940/iio_ad5940.c - Fixed underflow in GPIO wait loop
  3. network/wifi/at_parser.c - Fixed 2 underflow bugs in AT command timeouts
  4. drivers/rf-transceiver/ad9361/ad9361.c - Fixed underflow in calibration check
  5. drivers/axi_core/jesd204/axi_adxcvr.c - Improved timeout handling (was using signed int)
  6. drivers/axi_core/jesd204/altera_adxcvr.c - Improved for consistency (was already correct)

  Key Changes Applied:

  - Replaced while (timeout--) with while (timeout > 0) and explicit decrement
  - Changed timeout checks from counter value to actual hardware/status flags
  - Eliminated unsigned integer underflow from 0 to 0xFFFFFFFF
  - Removed race conditions where success on last iteration was misreported as timeout

  All commits reference issue #3115 and follow the same fix pattern as PR #3116. The fixes ensure that:
  1. Timeouts are properly detected when operations fail
  2. Successful operations aren't incorrectly reported as timeouts
  3. The code is consistent and maintainable across the codebase

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
