### PR TITLE
AD4630-20 support

### DIFF
--- a/drivers/adc/ad463x/ad463x.c
+++ b/drivers/adc/ad463x/ad463x.c
@@ -46,6 +46,24 @@
 
 #define ADAQ4224_GAIN_MAX_NANO 6670000000ULL
 
+/**
+ * Lookup table for amount of precison bits on default output mode.
+ */
+static const uint8_t ad463x_chip_precision[] = {
+	[ID_AD4630_24] = 24,
+	[ID_AD4630_20] = 20,
+	[ID_AD4630_16] = 16,
+	[ID_AD4631_24] = 24,
+	[ID_AD4631_20] = 20,
+	[ID_AD4631_16] = 16,
+	[ID_AD4632_24] = 24,
+	[ID_AD4632_20] = 20,
+	[ID_AD4632_16] = 16,
+	[ID_AD4030] = 24,
+	[ID_ADAQ4216] = 16,
+	[ID_ADAQ4224] = 24,
+};
+
 /*
  * Gains computed as fractions of 1000 so they can be expressed by integers.
  */
@@ -759,13 +777,10 @@ int32_t ad463x_init(struct ad463x_dev **device,
 
 	switch (dev->output_mode) {
 	case AD463X_24_DIFF:
-		switch (dev->device_id) {
-		case ID_ADAQ4216:
-			dev->real_bits_precision = 16;
-			break;
-		default:
+		if (dev->device_id >= NO_OS_ARRAY_SIZE(ad463x_chip_precision))
 			dev->real_bits_precision = 24;
-		}
+		else
+			dev->real_bits_precision = ad463x_chip_precision[dev->device_id];
 		break;
 
 	case AD463X_16_DIFF_8_COM:

--- a/drivers/adc/ad463x/iio_ad463x.c
+++ b/drivers/adc/ad463x/iio_ad463x.c
@@ -324,10 +324,17 @@ int32_t iio_ad463x_init(struct iio_ad463x **desc,
 
 	iio_ad463x->ad463x_desc = dev;
 
-	if (dev->device_id <= ID_AD4632_16)
+	if (dev->device_id <= ID_AD4632_16) {
 		iio_ad463x->iio_dev_desc = ad463x_iio_desc_two_chn;
-	else
+		iio_ad463x->iio_dev_desc.channels[0].scan_type->realbits =
+			dev->real_bits_precision;
+		iio_ad463x->iio_dev_desc.channels[1].scan_type->realbits =
+			dev->real_bits_precision;
+	} else {
 		iio_ad463x->iio_dev_desc = ad463x_iio_desc_one_chn;
+		iio_ad463x->iio_dev_desc.channels[0].scan_type->realbits =
+			dev->real_bits_precision;
+	}
 
 	*desc = iio_ad463x;
 

--- a/projects/ad463x_fmcz/Makefile
+++ b/projects/ad463x_fmcz/Makefile
@@ -4,7 +4,7 @@
 
 EXAMPLE ?= iio
 
-# AD4630 Family = 0 | AD4030 Family = 1 | ADAQ4224 = 2 | ADAQ4216 = 3
+# AD4630 Family = 0 | AD4030 Family = 1 | ADAQ4224 = 2 | ADAQ4216 = 3 | AD4630-20 Family = 4
 AD463X_ID=0
 
 include ../../tools/scripts/generic_variables.mk

--- a/projects/ad463x_fmcz/README.rst
+++ b/projects/ad463x_fmcz/README.rst
@@ -11,6 +11,7 @@ Supported Evaluation Boards
 
 * `EVAL-AD4030-24FMCZ <https://www.analog.com/EVAL-AD4030-24>`_
 * `EVAL-AD4630-16FMCZ <https://www.analog.com/EVAL-AD4630-16>`_
+* `EVAL-AD4630-20FMCZ <https://www.analog.com/EVAL-AD4630-20>`_
 * `EVAL-AD4630-24FMCZ <https://www.analog.com/EVAL-AD4630-24>`_
 * `EVAL-ADAQ4224-FMCZ <https://www.analog.com/ADAQ4224>`_
 * `EV-ISO-4224-FMCZ <https://www.analog.com/ADAQ4224>`_

--- a/projects/ad463x_fmcz/src.mk
+++ b/projects/ad463x_fmcz/src.mk
@@ -60,7 +60,9 @@ INCS += $(DRIVERS)/axi_core/axi_dmac/axi_dmac.h \
 INCS += $(DRIVERS)/adc/ad463x/ad463x.h
 SRCS += $(DRIVERS)/adc/ad463x/ad463x.c
 
-ifeq (3,$(strip $(AD463X_ID)))
+ifeq (4,$(strip $(AD463X_ID)))
+CFLAGS += -DAD4630_20_DEV
+else ifeq (3,$(strip $(AD463X_ID)))
 CFLAGS += -DADAQ4216_DEV
 else ifeq (2,$(strip $(AD463X_ID)))
 CFLAGS += -DADAQ4224_DEV

--- a/projects/ad463x_fmcz/src/common/common_data.c
+++ b/projects/ad463x_fmcz/src/common/common_data.c
@@ -153,6 +153,9 @@ struct ad463x_init_param ad463x_init_param = {
 #elif AD4030_DEV
 	.vref = 5000 * 1000UL,
 	.device_id = ID_AD4030, /* dev_id */
+#elif AD4630_20_DEV
+	.vref = 5000 * 1000UL,
+	.device_id = ID_AD4630_20, /* dev_id */
 #else
 	.vref = 5000 * 1000UL,
 	.device_id = ID_AD4630_24, /* dev_id */


### PR DESCRIPTION
## Pull Request Description

Extend AD463x device driver and project to also support AD4630-20 and similar 20-bit precision ADCs.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
