### PR TITLE
drivers: platform: maxim: Use generic name for enum elements

### DIFF
--- a/drivers/platform/maxim/max32650/maxim_uart.c
+++ b/drivers/platform/maxim/max32650/maxim_uart.c
@@ -318,10 +318,10 @@ static int32_t max_uart_init(struct no_os_uart_desc **desc,
 	case MAX_UART_FLOW_DIS:
 		flow = MXC_UART_FLOW_DIS;
 		break;
-	case UART_FLOW_LOW:
+	case MAX_UART_FLOW_LOW:
 		flow = MXC_UART_FLOW_EN_LOW;
 		break;
-	case UART_FLOW_HIGH:
+	case MAX_UART_FLOW_HIGH:
 		flow = MXC_UART_FLOW_EN_HIGH;
 		break;
 	default:

--- a/drivers/platform/maxim/max32650/maxim_uart.h
+++ b/drivers/platform/maxim/max32650/maxim_uart.h
@@ -45,8 +45,8 @@
  */
 enum max_uart_flow_ctrl {
 	MAX_UART_FLOW_DIS,
-	UART_FLOW_LOW,
-	UART_FLOW_HIGH
+	MAX_UART_FLOW_LOW,
+	MAX_UART_FLOW_HIGH
 };
 
 /**

--- a/drivers/platform/maxim/max32655/maxim_uart.c
+++ b/drivers/platform/maxim/max32655/maxim_uart.c
@@ -322,8 +322,8 @@ static int32_t max_uart_init(struct no_os_uart_desc **desc,
 	case MAX_UART_FLOW_DIS:
 		flow = MXC_UART_FLOW_DIS;
 		break;
-	case UART_FLOW_LOW:
-	case UART_FLOW_HIGH:
+	case MAX_UART_FLOW_LOW:
+	case MAX_UART_FLOW_HIGH:
 		flow = MXC_UART_FLOW_EN;
 		break;
 	default:

--- a/drivers/platform/maxim/max32655/maxim_uart.h
+++ b/drivers/platform/maxim/max32655/maxim_uart.h
@@ -45,8 +45,8 @@
  */
 enum max_uart_flow_ctrl {
 	MAX_UART_FLOW_DIS,
-	UART_FLOW_LOW,
-	UART_FLOW_HIGH
+	MAX_UART_FLOW_LOW,
+	MAX_UART_FLOW_HIGH
 };
 
 /**

--- a/drivers/platform/maxim/max32660/maxim_uart.c
+++ b/drivers/platform/maxim/max32660/maxim_uart.c
@@ -316,10 +316,10 @@ static int32_t max_uart_init(struct no_os_uart_desc **desc,
 	case MAX_UART_FLOW_DIS:
 		flow = MXC_UART_FLOW_DIS;
 		break;
-	case UART_FLOW_LOW:
+	case MAX_UART_FLOW_LOW:
 		flow = MXC_UART_FLOW_EN_LOW;
 		break;
-	case UART_FLOW_HIGH:
+	case MAX_UART_FLOW_HIGH:
 		flow = MXC_UART_FLOW_EN_HIGH;
 		break;
 	default:
@@ -328,13 +328,13 @@ static int32_t max_uart_init(struct no_os_uart_desc **desc,
 	}
 
 	switch (eparam->map) {
-	case UART_MAP_A:
+	case MAX_UART_MAP_A:
 		map = MAP_A;
 		break;
-	case UART_MAP_B:
+	case MAX_UART_MAP_B:
 		map = MAP_B;
 		break;
-	case UART_MAP_C:
+	case MAX_UART_MAP_C:
 		map = MAP_C;
 		break;
 	default:

--- a/drivers/platform/maxim/max32660/maxim_uart.h
+++ b/drivers/platform/maxim/max32660/maxim_uart.h
@@ -45,17 +45,17 @@
  */
 enum max_uart_flow_ctrl {
 	MAX_UART_FLOW_DIS,
-	UART_FLOW_LOW,
-	UART_FLOW_HIGH
+	MAX_UART_FLOW_LOW,
+	MAX_UART_FLOW_HIGH
 };
 
 /**
  * @brief UART pin mapping select
  */
 enum max_uart_map {
-	UART_MAP_A,
-	UART_MAP_B,
-	UART_MAP_C,
+	MAX_UART_MAP_A,
+	MAX_UART_MAP_B,
+	MAX_UART_MAP_C,
 };
 
 /**

--- a/drivers/platform/maxim/max32662/maxim_uart.c
+++ b/drivers/platform/maxim/max32662/maxim_uart.c
@@ -311,7 +311,7 @@ static int32_t max_uart_init(struct no_os_uart_desc **desc,
 	case MAX_UART_FLOW_DIS:
 		flow = MXC_UART_FLOW_DIS;
 		break;
-	case UART_FLOW_EN:
+	case MAX_UART_FLOW_EN:
 		flow = MXC_UART_FLOW_EN;
 		break;
 	default:
@@ -320,13 +320,13 @@ static int32_t max_uart_init(struct no_os_uart_desc **desc,
 	}
 
 	switch (eparam->map) {
-	case UART_MAP_A:
+	case MAX_UART_MAP_A:
 		map = MAP_A;
 		break;
-	case UART_MAP_B:
+	case MAX_UART_MAP_B:
 		map = MAP_B;
 		break;
-	case UART_MAP_C:
+	case MAX_UART_MAP_C:
 		map = MAP_C;
 		break;
 	default:

--- a/drivers/platform/maxim/max32662/maxim_uart.h
+++ b/drivers/platform/maxim/max32662/maxim_uart.h
@@ -45,16 +45,16 @@
  */
 enum max_uart_flow_ctrl {
 	MAX_UART_FLOW_DIS,
-	UART_FLOW_EN
+	MAX_UART_FLOW_EN
 };
 
 /**
  * @brief UART pin mapping select
  */
 enum max_uart_map {
-	UART_MAP_A,
-	UART_MAP_B,
-	UART_MAP_C,
+	MAX_UART_MAP_A,
+	MAX_UART_MAP_B,
+	MAX_UART_MAP_C,
 };
 
 /**

--- a/drivers/platform/maxim/max32665/maxim_uart.c
+++ b/drivers/platform/maxim/max32665/maxim_uart.c
@@ -329,10 +329,10 @@ static int32_t max_uart_init(struct no_os_uart_desc **desc,
 	case MAX_UART_FLOW_DIS:
 		flow = MXC_UART_FLOW_DIS;
 		break;
-	case UART_FLOW_LOW:
+	case MAX_UART_FLOW_LOW:
 		flow = MXC_UART_FLOW_EN_LOW;
 		break;
-	case UART_FLOW_HIGH:
+	case MAX_UART_FLOW_HIGH:
 		flow = MXC_UART_FLOW_EN_HIGH;
 		break;
 	default:
@@ -341,10 +341,10 @@ static int32_t max_uart_init(struct no_os_uart_desc **desc,
 	}
 
 	switch (eparam->map) {
-	case UART_MAP_A:
+	case MAX_UART_MAP_A:
 		map = MAP_A;
 		break;
-	case UART_MAP_B:
+	case MAX_UART_MAP_B:
 		map = MAP_B;
 		break;
 	default:

--- a/drivers/platform/maxim/max32665/maxim_uart.h
+++ b/drivers/platform/maxim/max32665/maxim_uart.h
@@ -45,16 +45,16 @@
  */
 enum max_uart_flow_ctrl {
 	MAX_UART_FLOW_DIS,
-	UART_FLOW_LOW,
-	UART_FLOW_HIGH
+	MAX_UART_FLOW_LOW,
+	MAX_UART_FLOW_HIGH
 };
 
 /**
  * @brief UART pin mapping select
  */
 enum max_uart_map {
-	UART_MAP_B,
-	UART_MAP_A,
+	MAX_UART_MAP_B,
+	MAX_UART_MAP_A,
 };
 
 /**

--- a/drivers/platform/maxim/max32690/maxim_uart.c
+++ b/drivers/platform/maxim/max32690/maxim_uart.c
@@ -331,10 +331,10 @@ static int32_t max_uart_init(struct no_os_uart_desc **desc,
 	case MAX_UART_FLOW_DIS:
 		flow = MXC_UART_FLOW_DIS;
 		break;
-	case UART_FLOW_LOW:
+	case MAX_UART_FLOW_LOW:
 		flow = MXC_UART_FLOW_EN;
 		break;
-	case UART_FLOW_HIGH:
+	case MAX_UART_FLOW_HIGH:
 		flow = MXC_UART_FLOW_EN;
 		break;
 	default:

--- a/drivers/platform/maxim/max32690/maxim_uart.h
+++ b/drivers/platform/maxim/max32690/maxim_uart.h
@@ -45,8 +45,8 @@
  */
 enum max_uart_flow_ctrl {
 	MAX_UART_FLOW_DIS,
-	UART_FLOW_LOW,
-	UART_FLOW_HIGH
+	MAX_UART_FLOW_LOW,
+	MAX_UART_FLOW_HIGH
 };
 
 /**

--- a/drivers/platform/maxim/max78000/maxim_uart.c
+++ b/drivers/platform/maxim/max78000/maxim_uart.c
@@ -338,10 +338,10 @@ static int32_t max_uart_init(struct no_os_uart_desc **desc,
 	case MAX_UART_FLOW_DIS:
 		flow = MXC_UART_FLOW_DIS;
 		break;
-	case UART_FLOW_LOW:
+	case MAX_UART_FLOW_LOW:
 		flow = MXC_UART_FLOW_EN;
 		break;
-	case UART_FLOW_HIGH:
+	case MAX_UART_FLOW_HIGH:
 		flow = MXC_UART_FLOW_EN;
 		break;
 	default:

--- a/drivers/platform/maxim/max78000/maxim_uart.h
+++ b/drivers/platform/maxim/max78000/maxim_uart.h
@@ -45,8 +45,8 @@
  */
 enum max_uart_flow_ctrl {
 	MAX_UART_FLOW_DIS,
-	UART_FLOW_LOW,
-	UART_FLOW_HIGH
+	MAX_UART_FLOW_LOW,
+	MAX_UART_FLOW_HIGH
 };
 
 /**

--- a/projects/lt3074/src/platform/maxim/parameters.c
+++ b/projects/lt3074/src/platform/maxim/parameters.c
@@ -34,7 +34,7 @@
 
 struct max_uart_init_param lt3074_uart_extra = {
 	.flow = MAX_UART_FLOW_DIS,
-	.map = UART_MAP_A
+	.map = MAX_UART_MAP_A
 };
 
 struct max_i2c_init_param lt3074_i2c_extra = {


### PR DESCRIPTION
The max32670 and max32672 platforms use different enum element names for the UART flow control. Rename them to match the naming convention used by the rest of the maxim platforms.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
