### PR TITLE
DMA support for max32670 and max32672

### DIFF
--- a/drivers/platform/maxim/common/maxim_dma.h
+++ b/drivers/platform/maxim/common/maxim_dma.h
@@ -47,6 +47,8 @@
 #include "max32665.h"
 #elif TARGET_NUM == 32670
 #include "max32670.h"
+#elif TARGET_NUM == 32672
+#include "max32672.h"
 #elif TARGET_NUM == 32690
 #include "max32690.h"
 #elif TARGET_NUM == 78000

--- a/drivers/platform/maxim/common/maxim_dma.h
+++ b/drivers/platform/maxim/common/maxim_dma.h
@@ -45,6 +45,8 @@
 #include "max32660.h"
 #elif TARGET_NUM == 32665
 #include "max32665.h"
+#elif TARGET_NUM == 32670
+#include "max32670.h"
 #elif TARGET_NUM == 32690
 #include "max32690.h"
 #elif TARGET_NUM == 78000

--- a/drivers/platform/maxim/max32670/maxim_irq.c
+++ b/drivers/platform/maxim/max32670/maxim_irq.c
@@ -39,6 +39,7 @@
 #include "uart.h"
 #include "tmr.h"
 #include "maxim_irq.h"
+#include "maxim_dma.h"
 #include "max32670.h"
 #include "no_os_uart.h"
 #include "no_os_util.h"
@@ -51,6 +52,8 @@ static struct event_list _events[] = {
 	[NO_OS_EVT_UART_ERROR] = {.event = NO_OS_EVT_UART_ERROR},
 	[NO_OS_EVT_RTC] = {.event = NO_OS_EVT_RTC},
 	[NO_OS_EVT_TIM_ELAPSED] = {.event = NO_OS_EVT_TIM_ELAPSED},
+	[NO_OS_EVT_DMA_RX_COMPLETE] = {.event = NO_OS_EVT_DMA_RX_COMPLETE},
+	[NO_OS_EVT_DMA_TX_COMPLETE] = {.event = NO_OS_EVT_DMA_TX_COMPLETE},
 };
 
 static struct no_os_irq_ctrl_desc *nvic;
@@ -172,6 +175,74 @@ void TMR2_IRQHandler()
 	_timer_common_callback(MXC_TMR2);
 }
 #endif
+
+/**
+ * @brief DMA interupt callback
+ * @param ch_num - The DMA channel number for which the interrupt occured
+ */
+static void max_dma_handler(uint32_t ch_num)
+{
+	struct event_list *rx_evt_list = &_events[NO_OS_EVT_DMA_RX_COMPLETE];
+	struct event_list *tx_evt_list = &_events[NO_OS_EVT_DMA_TX_COMPLETE];
+	struct irq_action *rx_action, *tx_action;
+	struct irq_action key = {.irq_id = max_dma_get_irq(0, ch_num)};
+	int ret;
+
+	/* Clear the DMA interrupt flag */
+	MAX_DMA->ch[ch_num].st |= NO_OS_BIT(2);
+
+	if (rx_evt_list->actions) {
+		ret = no_os_list_read_find(rx_evt_list->actions, (void **)&rx_action, &key);
+		if (!ret && rx_action->callback)
+			rx_action->callback(rx_action->ctx);
+	}
+
+	if (tx_evt_list->actions) {
+		ret = no_os_list_read_find(tx_evt_list->actions, (void **)&tx_action, &key);
+		if (!ret && tx_action->callback)
+			tx_action->callback(tx_action->ctx);
+	}
+}
+
+void DMA0_IRQHandler()
+{
+	max_dma_handler(0);
+}
+
+void DMA1_IRQHandler()
+{
+	max_dma_handler(1);
+}
+
+void DMA2_IRQHandler()
+{
+	max_dma_handler(2);
+}
+
+void DMA3_IRQHandler()
+{
+	max_dma_handler(3);
+}
+
+void DMA4_IRQHandler()
+{
+	max_dma_handler(4);
+}
+
+void DMA5_IRQHandler()
+{
+	max_dma_handler(5);
+}
+
+void DMA6_IRQHandler()
+{
+	max_dma_handler(6);
+}
+
+void DMA7_IRQHandler()
+{
+	max_dma_handler(7);
+}
 
 void RTC_IRQHandler()
 {
@@ -295,133 +366,84 @@ int max_irq_register_callback(struct no_os_irq_ctrl_desc *desc,
 			      struct no_os_callback_desc *callback_desc)
 {
 	int ret;
+	void *discard;
+	bool new_action = false;
 	struct irq_action *action;
 	struct irq_action action_key = {.irq_id = irq_id};
 
 	if (is_gpio_irq_id(irq_id))
 		return -ENOSYS;
 
-	if (!desc || !callback_desc)
+	if (!desc || !callback_desc
+	    || callback_desc->event >= NO_OS_ARRAY_SIZE(_events))
 		return -EINVAL;
 
+	if (_events[callback_desc->event].actions == NULL) {
+		ret = no_os_list_init(&_events[callback_desc->event].actions,
+				      NO_OS_LIST_PRIORITY_LIST,
+				      irq_action_cmp);
+		if (ret)
+			return ret;
+	}
+
+	ret = no_os_list_read_find(_events[callback_desc->event].actions,
+				   (void **)&action,
+				   &action_key);
+	/*
+	 * If an action with the same irq_id as the function parameter does not exists, insert a new one,
+	 * otherwise update
+	 */
+	if (ret) {
+		action = no_os_calloc(1, sizeof(*action));
+		if (!action)
+			return -ENOMEM;
+
+		action->irq_id = irq_id;
+		action->handle = callback_desc->handle;
+		action->callback = callback_desc->callback;
+		action->ctx = callback_desc->ctx;
+
+		ret = no_os_list_add_last(_events[callback_desc->event].actions, action);
+		if (ret)
+			goto free_action;
+
+		new_action = true;
+	}
+
 	switch (callback_desc->peripheral) {
+	case NO_OS_SPI_DMA_IRQ:
+	case NO_OS_DMA_IRQ:
 	case NO_OS_UART_IRQ:
-		if (_events[callback_desc->event].actions == NULL) {
-			ret = no_os_list_init(&_events[callback_desc->event].actions,
-					      NO_OS_LIST_PRIORITY_LIST,
-					      irq_action_cmp);
-			if (ret)
-				return ret;
-		}
-
-		ret = no_os_list_read_find(_events[callback_desc->event].actions,
-					   (void **)&action,
-					   &action_key);
-		/*
-		 * If an action with the same irq_id as the function parameter does not exists, insert a new one,
-		 * otherwise update
-		 */
-		if (ret) {
-			action = no_os_calloc(1, sizeof(*action));
-			if (!action)
-				return -ENOMEM;
-
-			action->irq_id = irq_id;
-			action->handle = callback_desc->handle;
-			action->callback = callback_desc->callback;
-			action->ctx = callback_desc->ctx;
-
-			ret = no_os_list_add_last(_events[callback_desc->event].actions, action);
-			if (ret)
-				goto free_action;
-		} else {
-			action->irq_id = irq_id;
-			action->handle = callback_desc->handle;
-			action->callback = callback_desc->callback;
-			action->ctx = callback_desc->ctx;
-		}
+	case NO_OS_TIM_IRQ:
 		break;
+
 	case NO_OS_RTC_IRQ:
-		if (_events[NO_OS_EVT_RTC].actions == NULL) {
-			ret = no_os_list_init(&_events[NO_OS_EVT_RTC].actions, NO_OS_LIST_PRIORITY_LIST,
-					      irq_action_cmp);
-			if (ret)
-				return ret;
-		}
-
-		/*
-		 * This is a special case for RTC on Maxim platform. Since there is only 1 RTC peripheral, there should
-		 * be only 1 registered callback at a time.
-		 */
-		ret = no_os_list_read_first(_events[NO_OS_EVT_RTC].actions, (void **)&action);
-		if (ret) {
-			action = no_os_calloc(1, sizeof(*action));
-			if (!action)
-				return -ENOMEM;
-
-			action->irq_id = irq_id;
-			action->handle = callback_desc->handle;
-			action->callback = callback_desc->callback;
-			action->ctx = callback_desc->ctx;
-
-			ret = no_os_list_add_first(_events[NO_OS_EVT_RTC].actions, action);
-			if (ret)
-				goto free_action;
-
-		} else {
-			action->irq_id = irq_id;
-			action->handle = callback_desc->handle;
-			action->callback = callback_desc->callback;
-			action->ctx = callback_desc->ctx;
-		}
-
 		ret = MXC_RTC_EnableInt(MXC_RTC_INT_EN_LONG);
 		if (ret)
 			return -EBUSY;
+
 		break;
-	case NO_OS_TIM_IRQ:
-		if (_events[NO_OS_EVT_TIM_ELAPSED].actions == NULL) {
-			ret = no_os_list_init(&_events[NO_OS_EVT_TIM_ELAPSED].actions,
-					      NO_OS_LIST_PRIORITY_LIST,
-					      irq_action_cmp);
-			if (ret)
-				return ret;
-		}
 
-		ret = no_os_list_read_find(_events[callback_desc->event].actions,
-					   (void **)&action,
-					   &action_key);
-		/*
-		 * If an action with the same irq_id as the function parameter does not exists, insert a new one,
-		 * otherwise update
-		 */
-		if (ret) {
-			action = no_os_calloc(1, sizeof(*action));
-			if (!action)
-				return -ENOMEM;
-
-			action->irq_id = irq_id;
-			action->handle = callback_desc->handle;
-			action->callback = callback_desc->callback;
-			action->ctx = callback_desc->ctx;
-
-			ret = no_os_list_add_last(_events[callback_desc->event].actions, action);
-			if (ret)
-				goto free_action;
-
-		} else {
-			action->irq_id = irq_id;
-			action->handle = callback_desc->handle;
-			action->callback = callback_desc->callback;
-			action->ctx = callback_desc->ctx;
-		}
-		break;
 	default:
+		if (new_action) {
+			ret = -EINVAL;
+			goto remove_new_action;
+		}
+
 		return -EINVAL;
+	}
+
+	if (!new_action) {
+		action->irq_id = irq_id;
+		action->handle = callback_desc->handle;
+		action->callback = callback_desc->callback;
+		action->ctx = callback_desc->ctx;
 	}
 
 	return 0;
 
+remove_new_action:
+	no_os_list_get_last(_events[callback_desc->event].actions, &discard);
 free_action:
 	no_os_free(action);
 	return ret;

--- a/drivers/platform/maxim/max32670/maxim_spi.c
+++ b/drivers/platform/maxim/max32670/maxim_spi.c
@@ -37,18 +37,188 @@
 #include "mxc_errors.h"
 #include "mxc_pins.h"
 #include "maxim_spi.h"
+#include "maxim_dma.h"
+#include "no_os_delay.h"
+#include "no_os_print_log.h"
 #include "no_os_util.h"
 #include "no_os_alloc.h"
+#include "no_os_units.h"
+#include "no_os_dma.h"
 
 #define SPI_MASTER_MODE	1
 #define SPI_SINGLE_MODE	0
 
+#define MAX_DELAY_SCLK	255
+#define NS_PER_US	1000
+
+struct max_dma_spi_xfer_data {
+	struct no_os_spi_desc *spi;
+	struct no_os_dma_ch *tx_ch;
+	struct no_os_dma_ch *rx_ch;
+
+	/* Used in order to free the memory allocated for the DMA transfer structs */
+	struct no_os_dma_xfer_desc *first_xfer_tx;
+	struct no_os_dma_xfer_desc *first_xfer_rx;
+
+	/* The callback provided as a parameter in the async transfer case. */
+	void (*cb)(void *);
+	void *ctx;
+};
+
+/**
+ * @brief Configure the SPI peripheral for the next DMA transfer.
+ * @param old_xfer - The last completed transfer.
+ * @param next_xfer - The next transfer in the SG list.
+ * @param ctx - .
+ */
+static void max_dma_xfer_cycle(struct no_os_dma_xfer_desc *old_xfer,
+			       struct no_os_dma_xfer_desc *next_xfer,
+			       void *ctx)
+{
+	struct max_dma_spi_xfer_data *data = ctx;
+	struct max_spi_state *max_spi_state = data->spi->extra;
+	mxc_spi_regs_t *spi = MXC_SPI_GET_SPI(data->spi->device_id);
+
+	/*
+	 * Since this callback is shared, waait for both the RX and TX
+	 * channels to finish the current transfer.
+	 */
+	while (no_os_dma_in_progress(max_spi_state->dma, data->rx_ch) &&
+	       no_os_dma_in_progress(max_spi_state->dma, data->tx_ch));
+
+	/* Wait for the SPI transfer to finish. */
+	while (spi->stat & 1);
+
+	if (!next_xfer) {
+		if (data->cb)
+			data->cb(data->ctx);
+
+		no_os_dma_chan_unlock(data->tx_ch);
+		no_os_dma_chan_unlock(data->rx_ch);
+		no_os_free(data->first_xfer_tx);
+		no_os_free(data->first_xfer_rx);
+		no_os_free(data);
+
+		return;
+	}
+
+	spi->ctrl1 |= next_xfer->length;
+	spi->ctrl1 |= no_os_field_prep(MXC_F_SPI_CTRL1_RX_NUM_CHAR,
+				       next_xfer->length);
+
+	spi->ctrl0 |= MXC_F_SPI_CTRL0_START;
+}
+
+/**
+ * @brief Set the reqsel field of the cfg (DMA channel specific) register
+ * @param desc - SPI descriptor
+ */
+static void _max_dma_set_req(struct no_os_spi_desc *desc)
+{
+	struct max_spi_state *st = desc->extra;
+
+	switch (desc->device_id) {
+	case 0:
+		st->dma_req_tx = MXC_V_DMA_CTRL_REQUEST_SPI0TX;
+		st->dma_req_rx = MXC_V_DMA_CTRL_REQUEST_SPI0RX;
+		break;
+	case 1:
+		st->dma_req_tx = MXC_V_DMA_CTRL_REQUEST_SPI1TX;
+		st->dma_req_rx = MXC_V_DMA_CTRL_REQUEST_SPI1RX;
+		break;
+	case 2:
+		st->dma_req_tx = MXC_V_DMA_CTRL_REQUEST_SPI2TX;
+		st->dma_req_rx = MXC_V_DMA_CTRL_REQUEST_SPI2RX;
+		break;
+	default:
+		return;
+	}
+}
+
+/**
+ * @brief Set the closest first and last SCLK delays to what was requested
+ * @param desc - SPI descriptor
+ * @param msg - The message for which the delays will be set
+ */
+static void _max_delay_config(struct no_os_spi_desc *desc,
+			      struct no_os_spi_msg *msg)
+{
+	struct max_spi_state *st = desc->extra;
+	uint32_t sstime_cache;
+	uint32_t ticks_delay;
+	mxc_spi_regs_t *spi;
+	uint32_t clk_rate;
+	uint32_t ticks_ns;
+	uint32_t delay_first_ns;
+	uint32_t delay_last_ns;
+
+	delay_first_ns = msg->cs_delay_first * 1000 +
+			 desc->platform_delays.cs_delay_first;
+	delay_last_ns = msg->cs_delay_last * 1000 + desc->platform_delays.cs_delay_last;
+
+	if (delay_first_ns == st->cs_delay_first &&
+	    delay_last_ns == st->cs_delay_last)
+		return;
+
+	spi = MXC_SPI_GET_SPI(desc->device_id);
+	sstime_cache = spi->sstime;
+	clk_rate = MXC_SPI_GetPeripheralClock(spi);
+	ticks_ns = NO_OS_DIV_ROUND_CLOSEST(NANO, clk_rate);
+
+	if (delay_first_ns != st->cs_delay_first) {
+		/**
+		 * The minimum number of delay ticks is 1. If 0 is written to the
+		 * sstime register, there would be a delay of 256 ticks.
+		 */
+		if (delay_first_ns == 0)
+			ticks_delay = 1;
+		else
+			ticks_delay = delay_first_ns / ticks_ns;
+
+		if (ticks_delay > MAX_DELAY_SCLK) {
+			pr_warning("cs_delay_first value is too high\n");
+			goto error;
+		}
+
+		spi->sstime &= ~MXC_F_SPI_SSTIME_PRE;
+		spi->sstime |= no_os_field_prep(MXC_F_SPI_SSTIME_PRE, ticks_delay);
+	}
+	if (delay_last_ns != st->cs_delay_last) {
+		/**
+		 * The minimum number of delay ticks is 1. If 0 is written to the
+		 * sstime register, there would be a delay of 256 ticks.
+		 */
+		if (delay_last_ns == 0)
+			ticks_delay = 1;
+		else
+			ticks_delay = delay_last_ns / ticks_ns;
+
+		if (ticks_delay > MAX_DELAY_SCLK) {
+			pr_warning("cs_delay_last value is too high\n");
+			goto error;
+		}
+
+		spi->sstime &= ~MXC_F_SPI_SSTIME_POST;
+		spi->sstime |= no_os_field_prep(MXC_F_SPI_SSTIME_POST, ticks_delay);
+	}
+
+	st->cs_delay_first = delay_first_ns;
+	st->cs_delay_last = delay_last_ns;
+
+	return;
+
+error:
+	spi->sstime = sstime_cache;
+}
+
 static int _max_spi_config(struct no_os_spi_desc *desc)
 {
-	int32_t ret;
 	struct max_spi_init_param *eparam;
+	struct max_spi_state *st;
+	int32_t ret;
 
-	eparam = desc->extra;
+	st = desc->extra;
+	eparam = st->init_param;
 
 	ret = MXC_SPI_Init(MXC_SPI_GET_SPI(desc->device_id), SPI_MASTER_MODE,
 			   SPI_SINGLE_MODE,
@@ -96,14 +266,20 @@ int32_t max_spi_init(struct no_os_spi_desc **desc,
 	int32_t ret;
 	struct no_os_spi_desc *descriptor;
 	struct max_spi_init_param *eparam;
+	struct max_spi_state *st;
 
 	if (!param || !param->extra)
 		return -EINVAL;
 
 	descriptor = no_os_calloc(1, sizeof(*descriptor));
-
 	if (!descriptor)
 		return -ENOMEM;
+
+	st = no_os_calloc(1, sizeof(*st));
+	if (!st) {
+		ret = -ENOMEM;
+		goto err;
+	}
 
 	eparam = param->extra;
 	descriptor->device_id = param->device_id;
@@ -111,7 +287,9 @@ int32_t max_spi_init(struct no_os_spi_desc **desc,
 	descriptor->chip_select = param->chip_select;
 	descriptor->mode = param->mode;
 	descriptor->bit_order = param->bit_order;
-	descriptor->extra = eparam;
+
+	st->init_param = eparam;
+	descriptor->extra = st;
 
 	if (descriptor->device_id >= MXC_SPI_INSTANCES) {
 		ret = -EINVAL;
@@ -120,14 +298,32 @@ int32_t max_spi_init(struct no_os_spi_desc **desc,
 
 	ret = _max_spi_config(descriptor);
 	if (ret)
-		return ret;
+		goto err;
+
+	if (eparam->dma_param) {
+		/*
+		 * The RX complete interrupt needs to have higher priority,
+		 * otherwise there is race condition, since for short transfers, the TX
+		 * channel will start a transfer which will finish before the RX has chance
+		 * to start.
+		 */
+		if (eparam->dma_rx_priority >= eparam->dma_tx_priority) {
+			ret = -EINVAL;
+			goto err;
+		}
+
+		ret = no_os_dma_init(&st->dma, eparam->dma_param);
+		if (ret)
+			goto err;
+
+		_max_dma_set_req(descriptor);
+	}
 
 	*desc = descriptor;
 
 	return 0;
-err_init:
-	MXC_SPI_Shutdown(MXC_SPI_GET_SPI(descriptor->device_id));
 err:
+	no_os_free(st);
 	no_os_free(descriptor);
 
 	return ret;
@@ -144,9 +340,209 @@ int32_t max_spi_remove(struct no_os_spi_desc *desc)
 		return -EINVAL;
 
 	MXC_SPI_Shutdown(MXC_SPI_GET_SPI(desc->device_id));
+	no_os_free(desc->extra);
 	no_os_free(desc);
 
 	return 0;
+}
+
+/**
+ * @brief Configure and start a series of transfers using DMA.
+ * @param desc - The SPI descriptor.
+ * @param msgs - The messages array.
+ * @param len - Number of messages.
+ * @param callback - Function to be invoked once the transfers are done.
+ * @param ctx - User defined parameter for the callback function.
+ * @param is_async - Whether or not the function should wait for the completion.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+static int32_t max_config_dma_and_start(struct no_os_spi_desc *desc,
+					struct no_os_spi_msg *msgs,
+					uint32_t len,
+					void (*callback)(void *),
+					void *ctx, bool is_async)
+{
+	mxc_spi_regs_t *spi = MXC_SPI_GET_SPI(desc->device_id);
+	static uint32_t last_slave_id[MXC_SPI_INSTANCES];
+	struct max_dma_spi_xfer_data *sync_xfer_data;
+	struct max_spi_state *max_spi = desc->extra;
+	struct no_os_dma_xfer_desc *rx_ch_xfer;
+	struct no_os_dma_xfer_desc *tx_ch_xfer;
+	struct no_os_dma_ch *tx_ch;
+	struct no_os_dma_ch *rx_ch;
+	uint32_t slave_id;
+	size_t i = 0;
+	int32_t ret;
+
+	slave_id = desc->chip_select;
+	if (slave_id != last_slave_id[desc->device_id]) {
+		ret = _max_spi_config(desc);
+		if (ret)
+			return ret;
+
+		last_slave_id[desc->device_id] = slave_id;
+	}
+
+	/* Assert CS desc->chip_select when the SPI transaction is started */
+	spi->ctrl0 &= ~MXC_F_SPI_CTRL0_SS_ACTIVE;
+	spi->ctrl0 |= no_os_field_prep(MXC_F_SPI_CTRL0_SS_ACTIVE,
+				       NO_OS_BIT(desc->chip_select));
+
+	rx_ch_xfer = no_os_calloc(len, sizeof(*rx_ch_xfer));
+	if (!rx_ch_xfer)
+		return -ENOMEM;
+
+	tx_ch_xfer = no_os_calloc(len, sizeof(*tx_ch_xfer));
+	if (!tx_ch_xfer) {
+		ret = -ENOMEM;
+		goto free_rx_ch_xfer;
+	}
+
+	sync_xfer_data = no_os_calloc(1, sizeof(*sync_xfer_data));
+	if (!sync_xfer_data) {
+		ret = -ENOMEM;
+		goto free_tx_ch_xfer;
+	}
+
+	/* Flush the RX and TX FIFOs */
+	spi->dma |= MXC_F_SPI_DMA_RX_FLUSH | MXC_F_SPI_DMA_TX_FLUSH;
+	/* Enable SPI */
+	spi->intfl |= MXC_F_SPI_INTFL_MST_DONE;
+
+	if (msgs[0].cs_change)
+		spi->ctrl0 &= ~MXC_F_SPI_CTRL0_SS_CTRL;
+	else
+		spi->ctrl0 |= MXC_F_SPI_CTRL0_SS_CTRL;
+
+	spi->ctrl1 = msgs[0].bytes_number;
+	/* Enable the TX FIFO */
+	spi->dma |= MXC_F_SPI_DMA_TX_FIFO_EN;
+	spi->ctrl1 |= no_os_field_prep(MXC_F_SPI_CTRL1_RX_NUM_CHAR,
+				       msgs[0].bytes_number);
+	/* Enable the RX FIFO */
+	spi->dma |= MXC_F_SPI_DMA_RX_FIFO_EN;
+
+	/* Allow DMA transfers for RX and TX SPI FIFOs */
+	spi->dma |= MXC_F_SPI_DMA_DMA_RX_EN | MXC_F_SPI_DMA_DMA_TX_EN;
+
+	ret = no_os_dma_acquire_channel(max_spi->dma, &tx_ch);
+	if (ret)
+		goto free_sync_xfer_data;
+
+	ret = no_os_dma_acquire_channel(max_spi->dma, &rx_ch);
+	if (ret)
+		goto release_tx_ch;
+
+	sync_xfer_data->spi = desc;
+	sync_xfer_data->rx_ch = rx_ch;
+	sync_xfer_data->tx_ch = tx_ch;
+	sync_xfer_data->first_xfer_tx = tx_ch_xfer;
+	sync_xfer_data->first_xfer_rx = rx_ch_xfer;
+
+	if (is_async) {
+		sync_xfer_data->cb = callback;
+		sync_xfer_data->ctx = ctx;
+	}
+
+	for (i = 0; i < len; i++) {
+		tx_ch_xfer[i].src = msgs[i].tx_buff;
+		tx_ch_xfer[i].dst = (uint8_t *)max_spi->dma_req_tx;
+		tx_ch_xfer[i].length = msgs[i].bytes_number;
+		tx_ch_xfer[i].periph = NO_OS_DMA_IRQ;
+		tx_ch_xfer[i].xfer_complete_cb = max_dma_xfer_cycle;
+		tx_ch_xfer[i].xfer_complete_ctx = sync_xfer_data;
+		tx_ch_xfer[i].xfer_type = MEM_TO_DEV;
+		tx_ch_xfer[i].irq_priority = max_spi->init_param->dma_tx_priority;
+
+		rx_ch_xfer[i].dst = msgs[i].rx_buff;
+		rx_ch_xfer[i].src = (uint8_t *)max_spi->dma_req_rx;
+		rx_ch_xfer[i].length = msgs[i].bytes_number;
+		rx_ch_xfer[i].periph = NO_OS_DMA_IRQ;
+		rx_ch_xfer[i].xfer_type = DEV_TO_MEM;
+		rx_ch_xfer[i].irq_priority = max_spi->init_param->dma_rx_priority;
+	}
+
+	ret = no_os_dma_config_xfer(max_spi->dma, tx_ch_xfer, len, tx_ch);
+	if (ret)
+		goto release_rx_ch;
+
+	ret = no_os_dma_config_xfer(max_spi->dma, rx_ch_xfer, len, rx_ch);
+	if (ret)
+		goto abort_rx_tx;
+
+	/* Start the transaction */
+	spi->ctrl0 |= MXC_F_SPI_CTRL0_START;
+
+	ret = no_os_dma_xfer_start(max_spi->dma, rx_ch);
+	if (ret)
+		goto abort_rx_tx;
+
+	ret = no_os_dma_xfer_start(max_spi->dma, tx_ch);
+	if (ret)
+		goto abort_rx_tx;
+
+	if (!is_async) {
+		while (!no_os_dma_is_completed(max_spi->dma, rx_ch) ||
+		       !no_os_dma_is_completed(max_spi->dma, tx_ch));
+
+		while (spi->stat & 1);
+		/* End the transaction */
+		spi->ctrl0 &= ~MXC_F_SPI_CTRL0_START;
+		/* Disable the RX and TX FIFOs */
+		spi->dma &= ~(MXC_F_SPI_DMA_TX_FIFO_EN | MXC_F_SPI_DMA_RX_FIFO_EN);
+	}
+
+	return 0;
+
+abort_rx_tx:
+	no_os_dma_xfer_abort(max_spi->dma, tx_ch);
+	no_os_dma_xfer_abort(max_spi->dma, rx_ch);
+release_rx_ch:
+	no_os_dma_release_channel(max_spi->dma, rx_ch);
+release_tx_ch:
+	no_os_dma_release_channel(max_spi->dma, tx_ch);
+free_sync_xfer_data:
+	no_os_free(sync_xfer_data);
+free_tx_ch_xfer:
+	no_os_free(tx_ch_xfer);
+free_rx_ch_xfer:
+	no_os_free(rx_ch_xfer);
+
+	return ret;
+}
+
+/**
+ * @brief Configure and start a series of transfers using DMA. Wait for the
+ * 	  completion before returning.
+ * @param desc - The SPI descriptor.
+ * @param msgs - The messages array.
+ * @param len - Number of messages.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+static int32_t max_spi_transfer_dma(struct no_os_spi_desc *desc,
+				    struct no_os_spi_msg *msgs,
+				    uint32_t len)
+{
+	return max_config_dma_and_start(desc, msgs, len, NULL, NULL, false);
+}
+
+/**
+ * @brief Configure and start a series of transfers using DMA.
+ * 	  Return immediately, and invoke a callback once they're completed.
+ * @param desc - The SPI descriptor.
+ * @param msgs - The messages array.
+ * @param len - Number of messages.
+ * @param callback - Function to be invoked once the transfers are done.
+ * @param ctx - User defined parameter for the callback function.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+static int32_t max_spi_transfer_dma_async(struct no_os_spi_desc *desc,
+		struct no_os_spi_msg *msgs,
+		uint32_t len,
+		void (*callback)(void *),
+		void *ctx)
+{
+	return max_config_dma_and_start(desc, msgs, len, callback, ctx, true);
 }
 
 /**
@@ -160,9 +556,14 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 			 struct no_os_spi_msg *msgs,
 			 uint32_t len)
 {
+	mxc_spi_regs_t *spi = MXC_SPI_GET_SPI(desc->device_id);
 	static uint32_t last_slave_id[MXC_SPI_INSTANCES];
-	mxc_spi_req_t req;
+	uint32_t tx_cnt;
+	uint32_t rx_cnt;
+	bool rx_done = true;
+	bool tx_done = true;
 	uint32_t slave_id;
+	size_t i = 0;
 	int32_t ret;
 
 	if (!desc || !msgs)
@@ -177,23 +578,73 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 		last_slave_id[desc->device_id] = slave_id;
 	}
 
-	req.spi = MXC_SPI_GET_SPI(desc->device_id);
-	req.ssIdx = desc->chip_select;
-	for (uint32_t i = 0; i < len; i++) {
-		req.txData = msgs[i].tx_buff;
-		req.rxData = msgs[i].rx_buff;
-		req.txCnt = 0;
-		req.rxCnt = 0;
-		req.ssDeassert = msgs[i].cs_change;
-		req.txLen = req.txData ? msgs[i].bytes_number : 0;
-		req.rxLen = req.rxData ? msgs[i].bytes_number : 0;
+	/* Assert CS desc->chip_select when the SPI transaction is started */
+	spi->ctrl0 &= ~MXC_F_SPI_CTRL0_SS_ACTIVE;
+	spi->ctrl0 |= no_os_field_prep(MXC_F_SPI_CTRL0_SS_ACTIVE,
+				       NO_OS_BIT(desc->chip_select));
 
-		ret = MXC_SPI_MasterTransaction(&req);
+	for (i = 0; i < len; i++) {
+		/* Flush the RX and TX FIFOs */
+		spi->dma |= MXC_F_SPI_DMA_RX_FLUSH | MXC_F_SPI_DMA_TX_FLUSH;
+		/* Enable SPI */
+		spi->intfl |= MXC_F_SPI_INTFL_MST_DONE;
+		spi->ctrl1 = 0;
 
-		if (ret == E_BAD_PARAM)
-			return -EINVAL;
-		if (ret == E_BAD_STATE)
-			return -EBUSY;
+		rx_cnt = 0;
+		tx_cnt = 0;
+
+		if (msgs[i].cs_change)
+			spi->ctrl0 &= ~MXC_F_SPI_CTRL0_SS_CTRL;
+		else
+			spi->ctrl0 |= MXC_F_SPI_CTRL0_SS_CTRL;
+
+		_max_delay_config(desc, &msgs[i]);
+
+		if (msgs[i].tx_buff) {
+			/* Set the transfer size in the TX direction */
+			spi->ctrl1 = msgs[i].bytes_number;
+			tx_done = false;
+			/* Enable the TX FIFO */
+			spi->dma |= MXC_F_SPI_DMA_TX_FIFO_EN;
+			tx_cnt += MXC_SPI_WriteTXFIFO(spi, &msgs[i].tx_buff[tx_cnt],
+						      msgs[i].bytes_number - tx_cnt);
+			tx_done = (tx_cnt == msgs[i].bytes_number) ? true : false;
+		}
+		if (msgs[i].rx_buff) {
+			/* Set the transfer size in the RX direction */
+			spi->ctrl1 |= no_os_field_prep(MXC_F_SPI_CTRL1_RX_NUM_CHAR,
+						       msgs[i].bytes_number);
+			/* Enable the RX FIFO */
+			spi->dma |= MXC_F_SPI_DMA_RX_FIFO_EN;
+			rx_done = false;
+		}
+
+		/* Start the transaction */
+		spi->ctrl0 |= MXC_F_SPI_CTRL0_START;
+
+		while (!(rx_done && tx_done)) {
+			if (msgs[i].tx_buff && tx_cnt < msgs[i].bytes_number) {
+				tx_cnt += MXC_SPI_WriteTXFIFO(spi, &msgs[i].tx_buff[tx_cnt],
+							      msgs[i].bytes_number - tx_cnt);
+				tx_done = (tx_cnt == msgs[i].bytes_number) ? true : false;
+			}
+			if (msgs[i].rx_buff && rx_cnt < msgs[i].bytes_number) {
+				rx_cnt += MXC_SPI_ReadRXFIFO(spi, &msgs[i].rx_buff[rx_cnt],
+							     msgs[i].bytes_number - rx_cnt);
+				rx_done = (rx_cnt == msgs[i].bytes_number) ? true : false;
+			}
+		}
+
+		/* Wait for the RX and TX FIFOs to empty */
+		while (!(spi->intfl & MXC_F_SPI_INTFL_MST_DONE));
+
+		/* End the transaction */
+		spi->ctrl0 &= ~MXC_F_SPI_CTRL0_START;
+
+		/* Disable the RX and TX FIFOs */
+		spi->dma &= ~(MXC_F_SPI_DMA_TX_FIFO_EN | MXC_F_SPI_DMA_RX_FIFO_EN);
+
+		no_os_udelay(msgs[i].cs_change_delay);
 	}
 
 	return 0;
@@ -227,5 +678,7 @@ const struct no_os_spi_platform_ops max_spi_ops = {
 	.init = &max_spi_init,
 	.write_and_read = &max_spi_write_and_read,
 	.transfer = &max_spi_transfer,
+	.transfer_dma = &max_spi_transfer_dma,
+	.transfer_dma_async = &max_spi_transfer_dma_async,
 	.remove = &max_spi_remove
 };

--- a/drivers/platform/maxim/max32670/maxim_spi.h
+++ b/drivers/platform/maxim/max32670/maxim_spi.h
@@ -35,7 +35,10 @@
 #define MAXIM_SPI_H_
 
 #include <stdint.h>
+#include "max32670.h"
+#include "gpio.h"
 #include "no_os_spi.h"
+#include "no_os_dma.h"
 
 /**
  * @brief maxim specific SPI platform ops structure
@@ -56,6 +59,19 @@ enum spi_ss_polarity {
 struct max_spi_init_param {
 	uint32_t num_slaves;
 	enum spi_ss_polarity polarity;
+	mxc_gpio_vssel_t vssel;
+	struct no_os_dma_init_param *dma_param;
+	uint32_t dma_rx_priority;
+	uint32_t dma_tx_priority;
+};
+
+struct max_spi_state {
+	struct max_spi_init_param *init_param;
+	uint32_t cs_delay_first;
+	uint32_t cs_delay_last;
+	struct no_os_dma_desc *dma;
+	uint32_t dma_req_rx;
+	uint32_t dma_req_tx;
 };
 
 #endif

--- a/drivers/platform/maxim/max32672/maxim_irq.c
+++ b/drivers/platform/maxim/max32672/maxim_irq.c
@@ -39,6 +39,7 @@
 #include "uart.h"
 #include "tmr.h"
 #include "maxim_irq.h"
+#include "maxim_dma.h"
 #include "max32672.h"
 #include "no_os_uart.h"
 #include "no_os_util.h"
@@ -51,6 +52,8 @@ static struct event_list _events[] = {
 	[NO_OS_EVT_UART_ERROR] = {.event = NO_OS_EVT_UART_ERROR},
 	[NO_OS_EVT_RTC] = {.event = NO_OS_EVT_RTC},
 	[NO_OS_EVT_TIM_ELAPSED] = {.event = NO_OS_EVT_TIM_ELAPSED},
+	[NO_OS_EVT_DMA_RX_COMPLETE] = {.event = NO_OS_EVT_DMA_RX_COMPLETE},
+	[NO_OS_EVT_DMA_TX_COMPLETE] = {.event = NO_OS_EVT_DMA_TX_COMPLETE},
 };
 
 static struct no_os_irq_ctrl_desc *nvic;
@@ -172,6 +175,94 @@ void TMR2_IRQHandler()
 	_timer_common_callback(MXC_TMR2);
 }
 #endif
+
+/**
+ * @brief DMA interupt callback
+ * @param ch_num - The DMA channel number for which the interrupt occured
+ */
+static void max_dma_handler(uint32_t ch_num)
+{
+	struct event_list *rx_evt_list = &_events[NO_OS_EVT_DMA_RX_COMPLETE];
+	struct event_list *tx_evt_list = &_events[NO_OS_EVT_DMA_TX_COMPLETE];
+	struct irq_action *rx_action, *tx_action;
+	struct irq_action key = {.irq_id = max_dma_get_irq(0, ch_num)};
+	int ret;
+
+	/* Clear the DMA interrupt flag */
+	MAX_DMA->ch[ch_num].st |= NO_OS_BIT(2);
+
+	if (rx_evt_list->actions) {
+		ret = no_os_list_read_find(rx_evt_list->actions, (void **)&rx_action, &key);
+		if (!ret && rx_action->callback)
+			rx_action->callback(rx_action->ctx);
+	}
+
+	if (tx_evt_list->actions) {
+		ret = no_os_list_read_find(tx_evt_list->actions, (void **)&tx_action, &key);
+		if (!ret && tx_action->callback)
+			tx_action->callback(tx_action->ctx);
+	}
+}
+
+void DMA0_IRQHandler()
+{
+	max_dma_handler(0);
+}
+
+void DMA1_IRQHandler()
+{
+	max_dma_handler(1);
+}
+
+void DMA2_IRQHandler()
+{
+	max_dma_handler(2);
+}
+
+void DMA3_IRQHandler()
+{
+	max_dma_handler(3);
+}
+
+void DMA4_IRQHandler()
+{
+	max_dma_handler(4);
+}
+
+void DMA5_IRQHandler()
+{
+	max_dma_handler(5);
+}
+
+void DMA6_IRQHandler()
+{
+	max_dma_handler(6);
+}
+
+void DMA7_IRQHandler()
+{
+	max_dma_handler(7);
+}
+
+void DMA8_IRQHandler()
+{
+	max_dma_handler(8);
+}
+
+void DMA9_IRQHandler()
+{
+	max_dma_handler(9);
+}
+
+void DMA10_IRQHandler()
+{
+	max_dma_handler(10);
+}
+
+void DMA11_IRQHandler()
+{
+	max_dma_handler(11);
+}
 
 void RTC_IRQHandler()
 {
@@ -295,133 +386,84 @@ int max_irq_register_callback(struct no_os_irq_ctrl_desc *desc,
 			      struct no_os_callback_desc *callback_desc)
 {
 	int ret;
+	void *discard;
+	bool new_action = false;
 	struct irq_action *action;
 	struct irq_action action_key = {.irq_id = irq_id};
 
 	if (is_gpio_irq_id(irq_id))
 		return -ENOSYS;
 
-	if (!desc || !callback_desc)
+	if (!desc || !callback_desc
+	    || callback_desc->event >= NO_OS_ARRAY_SIZE(_events))
 		return -EINVAL;
 
+	if (_events[callback_desc->event].actions == NULL) {
+		ret = no_os_list_init(&_events[callback_desc->event].actions,
+				      NO_OS_LIST_PRIORITY_LIST,
+				      irq_action_cmp);
+		if (ret)
+			return ret;
+	}
+
+	ret = no_os_list_read_find(_events[callback_desc->event].actions,
+				   (void **)&action,
+				   &action_key);
+	/*
+	 * If an action with the same irq_id as the function parameter does not exists, insert a new one,
+	 * otherwise update
+	 */
+	if (ret) {
+		action = no_os_calloc(1, sizeof(*action));
+		if (!action)
+			return -ENOMEM;
+
+		action->irq_id = irq_id;
+		action->handle = callback_desc->handle;
+		action->callback = callback_desc->callback;
+		action->ctx = callback_desc->ctx;
+
+		ret = no_os_list_add_last(_events[callback_desc->event].actions, action);
+		if (ret)
+			goto free_action;
+
+		new_action = true;
+	}
+
 	switch (callback_desc->peripheral) {
+	case NO_OS_SPI_DMA_IRQ:
+	case NO_OS_DMA_IRQ:
 	case NO_OS_UART_IRQ:
-		if (_events[callback_desc->event].actions == NULL) {
-			ret = no_os_list_init(&_events[callback_desc->event].actions,
-					      NO_OS_LIST_PRIORITY_LIST,
-					      irq_action_cmp);
-			if (ret)
-				return ret;
-		}
-
-		ret = no_os_list_read_find(_events[callback_desc->event].actions,
-					   (void **)&action,
-					   &action_key);
-		/*
-		 * If an action with the same irq_id as the function parameter does not exists, insert a new one,
-		 * otherwise update
-		 */
-		if (ret) {
-			action = no_os_calloc(1, sizeof(*action));
-			if (!action)
-				return -ENOMEM;
-
-			action->irq_id = irq_id;
-			action->handle = callback_desc->handle;
-			action->callback = callback_desc->callback;
-			action->ctx = callback_desc->ctx;
-
-			ret = no_os_list_add_last(_events[callback_desc->event].actions, action);
-			if (ret)
-				goto free_action;
-		} else {
-			action->irq_id = irq_id;
-			action->handle = callback_desc->handle;
-			action->callback = callback_desc->callback;
-			action->ctx = callback_desc->ctx;
-		}
+	case NO_OS_TIM_IRQ:
 		break;
+
 	case NO_OS_RTC_IRQ:
-		if (_events[NO_OS_EVT_RTC].actions == NULL) {
-			ret = no_os_list_init(&_events[NO_OS_EVT_RTC].actions, NO_OS_LIST_PRIORITY_LIST,
-					      irq_action_cmp);
-			if (ret)
-				return ret;
-		}
-
-		/*
-		 * This is a special case for RTC on Maxim platform. Since there is only 1 RTC peripheral, there should
-		 * be only 1 registered callback at a time.
-		 */
-		ret = no_os_list_read_first(_events[NO_OS_EVT_RTC].actions, (void **)&action);
-		if (ret) {
-			action = no_os_calloc(1, sizeof(*action));
-			if (!action)
-				return -ENOMEM;
-
-			action->irq_id = irq_id;
-			action->handle = callback_desc->handle;
-			action->callback = callback_desc->callback;
-			action->ctx = callback_desc->ctx;
-
-			ret = no_os_list_add_first(_events[NO_OS_EVT_RTC].actions, action);
-			if (ret)
-				goto free_action;
-
-		} else {
-			action->irq_id = irq_id;
-			action->handle = callback_desc->handle;
-			action->callback = callback_desc->callback;
-			action->ctx = callback_desc->ctx;
-		}
-
 		ret = MXC_RTC_EnableInt(MXC_RTC_INT_EN_LONG);
 		if (ret)
 			return -EBUSY;
+
 		break;
-	case NO_OS_TIM_IRQ:
-		if (_events[NO_OS_EVT_TIM_ELAPSED].actions == NULL) {
-			ret = no_os_list_init(&_events[NO_OS_EVT_TIM_ELAPSED].actions,
-					      NO_OS_LIST_PRIORITY_LIST,
-					      irq_action_cmp);
-			if (ret)
-				return ret;
-		}
 
-		ret = no_os_list_read_find(_events[callback_desc->event].actions,
-					   (void **)&action,
-					   &action_key);
-		/*
-		 * If an action with the same irq_id as the function parameter does not exists, insert a new one,
-		 * otherwise update
-		 */
-		if (ret) {
-			action = no_os_calloc(1, sizeof(*action));
-			if (!action)
-				return -ENOMEM;
-
-			action->irq_id = irq_id;
-			action->handle = callback_desc->handle;
-			action->callback = callback_desc->callback;
-			action->ctx = callback_desc->ctx;
-
-			ret = no_os_list_add_last(_events[callback_desc->event].actions, action);
-			if (ret)
-				goto free_action;
-
-		} else {
-			action->irq_id = irq_id;
-			action->handle = callback_desc->handle;
-			action->callback = callback_desc->callback;
-			action->ctx = callback_desc->ctx;
-		}
-		break;
 	default:
+		if (new_action) {
+			ret = -EINVAL;
+			goto remove_new_action;
+		}
+
 		return -EINVAL;
+	}
+
+	if (!new_action) {
+		action->irq_id = irq_id;
+		action->handle = callback_desc->handle;
+		action->callback = callback_desc->callback;
+		action->ctx = callback_desc->ctx;
 	}
 
 	return 0;
 
+remove_new_action:
+	no_os_list_get_last(_events[callback_desc->event].actions, &discard);
 free_action:
 	no_os_free(action);
 	return ret;

--- a/drivers/platform/maxim/max32672/maxim_spi.c
+++ b/drivers/platform/maxim/max32672/maxim_spi.c
@@ -37,18 +37,188 @@
 #include "mxc_errors.h"
 #include "mxc_pins.h"
 #include "maxim_spi.h"
+#include "maxim_dma.h"
+#include "no_os_delay.h"
+#include "no_os_print_log.h"
 #include "no_os_util.h"
 #include "no_os_alloc.h"
+#include "no_os_units.h"
+#include "no_os_dma.h"
 
 #define SPI_MASTER_MODE	1
 #define SPI_SINGLE_MODE	0
 
+#define MAX_DELAY_SCLK	255
+#define NS_PER_US	1000
+
+struct max_dma_spi_xfer_data {
+	struct no_os_spi_desc *spi;
+	struct no_os_dma_ch *tx_ch;
+	struct no_os_dma_ch *rx_ch;
+
+	/* Used in order to free the memory allocated for the DMA transfer structs */
+	struct no_os_dma_xfer_desc *first_xfer_tx;
+	struct no_os_dma_xfer_desc *first_xfer_rx;
+
+	/* The callback provided as a parameter in the async transfer case. */
+	void (*cb)(void *);
+	void *ctx;
+};
+
+/**
+ * @brief Configure the SPI peripheral for the next DMA transfer.
+ * @param old_xfer - The last completed transfer.
+ * @param next_xfer - The next transfer in the SG list.
+ * @param ctx - .
+ */
+static void max_dma_xfer_cycle(struct no_os_dma_xfer_desc *old_xfer,
+			       struct no_os_dma_xfer_desc *next_xfer,
+			       void *ctx)
+{
+	struct max_dma_spi_xfer_data *data = ctx;
+	struct max_spi_state *max_spi_state = data->spi->extra;
+	mxc_spi_regs_t *spi = MXC_SPI_GET_SPI(data->spi->device_id);
+
+	/*
+	 * Since this callback is shared, waait for both the RX and TX
+	 * channels to finish the current transfer.
+	 */
+	while (no_os_dma_in_progress(max_spi_state->dma, data->rx_ch) &&
+	       no_os_dma_in_progress(max_spi_state->dma, data->tx_ch));
+
+	/* Wait for the SPI transfer to finish. */
+	while (spi->stat & 1);
+
+	if (!next_xfer) {
+		if (data->cb)
+			data->cb(data->ctx);
+
+		no_os_dma_chan_unlock(data->tx_ch);
+		no_os_dma_chan_unlock(data->rx_ch);
+		no_os_free(data->first_xfer_tx);
+		no_os_free(data->first_xfer_rx);
+		no_os_free(data);
+
+		return;
+	}
+
+	spi->ctrl1 |= next_xfer->length;
+	spi->ctrl1 |= no_os_field_prep(MXC_F_SPI_CTRL1_RX_NUM_CHAR,
+				       next_xfer->length);
+
+	spi->ctrl0 |= MXC_F_SPI_CTRL0_START;
+}
+
+/**
+ * @brief Set the reqsel field of the cfg (DMA channel specific) register
+ * @param desc - SPI descriptor
+ */
+static void _max_dma_set_req(struct no_os_spi_desc *desc)
+{
+	struct max_spi_state *st = desc->extra;
+
+	switch (desc->device_id) {
+	case 0:
+		st->dma_req_tx = MXC_V_DMA_CTRL_REQUEST_SPI0TX;
+		st->dma_req_rx = MXC_V_DMA_CTRL_REQUEST_SPI0RX;
+		break;
+	case 1:
+		st->dma_req_tx = MXC_V_DMA_CTRL_REQUEST_SPI1TX;
+		st->dma_req_rx = MXC_V_DMA_CTRL_REQUEST_SPI1RX;
+		break;
+	case 2:
+		st->dma_req_tx = MXC_V_DMA_CTRL_REQUEST_SPI2TX;
+		st->dma_req_rx = MXC_V_DMA_CTRL_REQUEST_SPI2RX;
+		break;
+	default:
+		return;
+	}
+}
+
+/**
+ * @brief Set the closest first and last SCLK delays to what was requested
+ * @param desc - SPI descriptor
+ * @param msg - The message for which the delays will be set
+ */
+static void _max_delay_config(struct no_os_spi_desc *desc,
+			      struct no_os_spi_msg *msg)
+{
+	struct max_spi_state *st = desc->extra;
+	uint32_t sstime_cache;
+	uint32_t ticks_delay;
+	mxc_spi_regs_t *spi;
+	uint32_t clk_rate;
+	uint32_t ticks_ns;
+	uint32_t delay_first_ns;
+	uint32_t delay_last_ns;
+
+	delay_first_ns = msg->cs_delay_first * 1000 +
+			 desc->platform_delays.cs_delay_first;
+	delay_last_ns = msg->cs_delay_last * 1000 + desc->platform_delays.cs_delay_last;
+
+	if (delay_first_ns == st->cs_delay_first &&
+	    delay_last_ns == st->cs_delay_last)
+		return;
+
+	spi = MXC_SPI_GET_SPI(desc->device_id);
+	sstime_cache = spi->sstime;
+	clk_rate = MXC_SPI_GetPeripheralClock(spi);
+	ticks_ns = NO_OS_DIV_ROUND_CLOSEST(NANO, clk_rate);
+
+	if (delay_first_ns != st->cs_delay_first) {
+		/**
+		 * The minimum number of delay ticks is 1. If 0 is written to the
+		 * sstime register, there would be a delay of 256 ticks.
+		 */
+		if (delay_first_ns == 0)
+			ticks_delay = 1;
+		else
+			ticks_delay = delay_first_ns / ticks_ns;
+
+		if (ticks_delay > MAX_DELAY_SCLK) {
+			pr_warning("cs_delay_first value is too high\n");
+			goto error;
+		}
+
+		spi->sstime &= ~MXC_F_SPI_SSTIME_PRE;
+		spi->sstime |= no_os_field_prep(MXC_F_SPI_SSTIME_PRE, ticks_delay);
+	}
+	if (delay_last_ns != st->cs_delay_last) {
+		/**
+		 * The minimum number of delay ticks is 1. If 0 is written to the
+		 * sstime register, there would be a delay of 256 ticks.
+		 */
+		if (delay_last_ns == 0)
+			ticks_delay = 1;
+		else
+			ticks_delay = delay_last_ns / ticks_ns;
+
+		if (ticks_delay > MAX_DELAY_SCLK) {
+			pr_warning("cs_delay_last value is too high\n");
+			goto error;
+		}
+
+		spi->sstime &= ~MXC_F_SPI_SSTIME_POST;
+		spi->sstime |= no_os_field_prep(MXC_F_SPI_SSTIME_POST, ticks_delay);
+	}
+
+	st->cs_delay_first = delay_first_ns;
+	st->cs_delay_last = delay_last_ns;
+
+	return;
+
+error:
+	spi->sstime = sstime_cache;
+}
+
 static int _max_spi_config(struct no_os_spi_desc *desc)
 {
-	int32_t ret;
 	struct max_spi_init_param *eparam;
+	struct max_spi_state *st;
+	int32_t ret;
 
-	eparam = desc->extra;
+	st = desc->extra;
+	eparam = st->init_param;
 
 	ret = MXC_SPI_Init(MXC_SPI_GET_SPI(desc->device_id), SPI_MASTER_MODE,
 			   SPI_SINGLE_MODE,
@@ -96,14 +266,20 @@ int32_t max_spi_init(struct no_os_spi_desc **desc,
 	int32_t ret;
 	struct no_os_spi_desc *descriptor;
 	struct max_spi_init_param *eparam;
+	struct max_spi_state *st;
 
 	if (!param || !param->extra)
 		return -EINVAL;
 
 	descriptor = no_os_calloc(1, sizeof(*descriptor));
-
 	if (!descriptor)
 		return -ENOMEM;
+
+	st = no_os_calloc(1, sizeof(*st));
+	if (!st) {
+		ret = -ENOMEM;
+		goto err;
+	}
 
 	eparam = param->extra;
 	descriptor->device_id = param->device_id;
@@ -111,7 +287,9 @@ int32_t max_spi_init(struct no_os_spi_desc **desc,
 	descriptor->chip_select = param->chip_select;
 	descriptor->mode = param->mode;
 	descriptor->bit_order = param->bit_order;
-	descriptor->extra = eparam;
+
+	st->init_param = eparam;
+	descriptor->extra = st;
 
 	if (descriptor->device_id >= MXC_SPI_INSTANCES) {
 		ret = -EINVAL;
@@ -120,14 +298,32 @@ int32_t max_spi_init(struct no_os_spi_desc **desc,
 
 	ret = _max_spi_config(descriptor);
 	if (ret)
-		return ret;
+		goto err;
+
+	if (eparam->dma_param) {
+		/*
+		 * The RX complete interrupt needs to have higher priority,
+		 * otherwise there is race condition, since for short transfers, the TX
+		 * channel will start a transfer which will finish before the RX has chance
+		 * to start.
+		 */
+		if (eparam->dma_rx_priority >= eparam->dma_tx_priority) {
+			ret = -EINVAL;
+			goto err;
+		}
+
+		ret = no_os_dma_init(&st->dma, eparam->dma_param);
+		if (ret)
+			goto err;
+
+		_max_dma_set_req(descriptor);
+	}
 
 	*desc = descriptor;
 
 	return 0;
-err_init:
-	MXC_SPI_Shutdown(MXC_SPI_GET_SPI(descriptor->device_id));
 err:
+	no_os_free(st);
 	no_os_free(descriptor);
 
 	return ret;
@@ -144,9 +340,209 @@ int32_t max_spi_remove(struct no_os_spi_desc *desc)
 		return -EINVAL;
 
 	MXC_SPI_Shutdown(MXC_SPI_GET_SPI(desc->device_id));
+	no_os_free(desc->extra);
 	no_os_free(desc);
 
 	return 0;
+}
+
+/**
+ * @brief Configure and start a series of transfers using DMA.
+ * @param desc - The SPI descriptor.
+ * @param msgs - The messages array.
+ * @param len - Number of messages.
+ * @param callback - Function to be invoked once the transfers are done.
+ * @param ctx - User defined parameter for the callback function.
+ * @param is_async - Whether or not the function should wait for the completion.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+static int32_t max_config_dma_and_start(struct no_os_spi_desc *desc,
+					struct no_os_spi_msg *msgs,
+					uint32_t len,
+					void (*callback)(void *),
+					void *ctx, bool is_async)
+{
+	mxc_spi_regs_t *spi = MXC_SPI_GET_SPI(desc->device_id);
+	static uint32_t last_slave_id[MXC_SPI_INSTANCES];
+	struct max_dma_spi_xfer_data *sync_xfer_data;
+	struct max_spi_state *max_spi = desc->extra;
+	struct no_os_dma_xfer_desc *rx_ch_xfer;
+	struct no_os_dma_xfer_desc *tx_ch_xfer;
+	struct no_os_dma_ch *tx_ch;
+	struct no_os_dma_ch *rx_ch;
+	uint32_t slave_id;
+	size_t i = 0;
+	int32_t ret;
+
+	slave_id = desc->chip_select;
+	if (slave_id != last_slave_id[desc->device_id]) {
+		ret = _max_spi_config(desc);
+		if (ret)
+			return ret;
+
+		last_slave_id[desc->device_id] = slave_id;
+	}
+
+	/* Assert CS desc->chip_select when the SPI transaction is started */
+	spi->ctrl0 &= ~MXC_F_SPI_CTRL0_SS_ACTIVE;
+	spi->ctrl0 |= no_os_field_prep(MXC_F_SPI_CTRL0_SS_ACTIVE,
+				       NO_OS_BIT(desc->chip_select));
+
+	rx_ch_xfer = no_os_calloc(len, sizeof(*rx_ch_xfer));
+	if (!rx_ch_xfer)
+		return -ENOMEM;
+
+	tx_ch_xfer = no_os_calloc(len, sizeof(*tx_ch_xfer));
+	if (!tx_ch_xfer) {
+		ret = -ENOMEM;
+		goto free_rx_ch_xfer;
+	}
+
+	sync_xfer_data = no_os_calloc(1, sizeof(*sync_xfer_data));
+	if (!sync_xfer_data) {
+		ret = -ENOMEM;
+		goto free_tx_ch_xfer;
+	}
+
+	/* Flush the RX and TX FIFOs */
+	spi->dma |= MXC_F_SPI_DMA_RX_FLUSH | MXC_F_SPI_DMA_TX_FLUSH;
+	/* Enable SPI */
+	spi->intfl |= MXC_F_SPI_INTFL_MST_DONE;
+
+	if (msgs[0].cs_change)
+		spi->ctrl0 &= ~MXC_F_SPI_CTRL0_SS_CTRL;
+	else
+		spi->ctrl0 |= MXC_F_SPI_CTRL0_SS_CTRL;
+
+	spi->ctrl1 = msgs[0].bytes_number;
+	/* Enable the TX FIFO */
+	spi->dma |= MXC_F_SPI_DMA_TX_FIFO_EN;
+	spi->ctrl1 |= no_os_field_prep(MXC_F_SPI_CTRL1_RX_NUM_CHAR,
+				       msgs[0].bytes_number);
+	/* Enable the RX FIFO */
+	spi->dma |= MXC_F_SPI_DMA_RX_FIFO_EN;
+
+	/* Allow DMA transfers for RX and TX SPI FIFOs */
+	spi->dma |= MXC_F_SPI_DMA_DMA_RX_EN | MXC_F_SPI_DMA_DMA_TX_EN;
+
+	ret = no_os_dma_acquire_channel(max_spi->dma, &tx_ch);
+	if (ret)
+		goto free_sync_xfer_data;
+
+	ret = no_os_dma_acquire_channel(max_spi->dma, &rx_ch);
+	if (ret)
+		goto release_tx_ch;
+
+	sync_xfer_data->spi = desc;
+	sync_xfer_data->rx_ch = rx_ch;
+	sync_xfer_data->tx_ch = tx_ch;
+	sync_xfer_data->first_xfer_tx = tx_ch_xfer;
+	sync_xfer_data->first_xfer_rx = rx_ch_xfer;
+
+	if (is_async) {
+		sync_xfer_data->cb = callback;
+		sync_xfer_data->ctx = ctx;
+	}
+
+	for (i = 0; i < len; i++) {
+		tx_ch_xfer[i].src = msgs[i].tx_buff;
+		tx_ch_xfer[i].dst = (uint8_t *)max_spi->dma_req_tx;
+		tx_ch_xfer[i].length = msgs[i].bytes_number;
+		tx_ch_xfer[i].periph = NO_OS_DMA_IRQ;
+		tx_ch_xfer[i].xfer_complete_cb = max_dma_xfer_cycle;
+		tx_ch_xfer[i].xfer_complete_ctx = sync_xfer_data;
+		tx_ch_xfer[i].xfer_type = MEM_TO_DEV;
+		tx_ch_xfer[i].irq_priority = max_spi->init_param->dma_tx_priority;
+
+		rx_ch_xfer[i].dst = msgs[i].rx_buff;
+		rx_ch_xfer[i].src = (uint8_t *)max_spi->dma_req_rx;
+		rx_ch_xfer[i].length = msgs[i].bytes_number;
+		rx_ch_xfer[i].periph = NO_OS_DMA_IRQ;
+		rx_ch_xfer[i].xfer_type = DEV_TO_MEM;
+		rx_ch_xfer[i].irq_priority = max_spi->init_param->dma_rx_priority;
+	}
+
+	ret = no_os_dma_config_xfer(max_spi->dma, tx_ch_xfer, len, tx_ch);
+	if (ret)
+		goto release_rx_ch;
+
+	ret = no_os_dma_config_xfer(max_spi->dma, rx_ch_xfer, len, rx_ch);
+	if (ret)
+		goto abort_rx_tx;
+
+	/* Start the transaction */
+	spi->ctrl0 |= MXC_F_SPI_CTRL0_START;
+
+	ret = no_os_dma_xfer_start(max_spi->dma, rx_ch);
+	if (ret)
+		goto abort_rx_tx;
+
+	ret = no_os_dma_xfer_start(max_spi->dma, tx_ch);
+	if (ret)
+		goto abort_rx_tx;
+
+	if (!is_async) {
+		while (!no_os_dma_is_completed(max_spi->dma, rx_ch) ||
+		       !no_os_dma_is_completed(max_spi->dma, tx_ch));
+
+		while (spi->stat & 1);
+		/* End the transaction */
+		spi->ctrl0 &= ~MXC_F_SPI_CTRL0_START;
+		/* Disable the RX and TX FIFOs */
+		spi->dma &= ~(MXC_F_SPI_DMA_TX_FIFO_EN | MXC_F_SPI_DMA_RX_FIFO_EN);
+	}
+
+	return 0;
+
+abort_rx_tx:
+	no_os_dma_xfer_abort(max_spi->dma, tx_ch);
+	no_os_dma_xfer_abort(max_spi->dma, rx_ch);
+release_rx_ch:
+	no_os_dma_release_channel(max_spi->dma, rx_ch);
+release_tx_ch:
+	no_os_dma_release_channel(max_spi->dma, tx_ch);
+free_sync_xfer_data:
+	no_os_free(sync_xfer_data);
+free_tx_ch_xfer:
+	no_os_free(tx_ch_xfer);
+free_rx_ch_xfer:
+	no_os_free(rx_ch_xfer);
+
+	return ret;
+}
+
+/**
+ * @brief Configure and start a series of transfers using DMA. Wait for the
+ * 	  completion before returning.
+ * @param desc - The SPI descriptor.
+ * @param msgs - The messages array.
+ * @param len - Number of messages.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+static int32_t max_spi_transfer_dma(struct no_os_spi_desc *desc,
+				    struct no_os_spi_msg *msgs,
+				    uint32_t len)
+{
+	return max_config_dma_and_start(desc, msgs, len, NULL, NULL, false);
+}
+
+/**
+ * @brief Configure and start a series of transfers using DMA.
+ * 	  Return immediately, and invoke a callback once they're completed.
+ * @param desc - The SPI descriptor.
+ * @param msgs - The messages array.
+ * @param len - Number of messages.
+ * @param callback - Function to be invoked once the transfers are done.
+ * @param ctx - User defined parameter for the callback function.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+static int32_t max_spi_transfer_dma_async(struct no_os_spi_desc *desc,
+		struct no_os_spi_msg *msgs,
+		uint32_t len,
+		void (*callback)(void *),
+		void *ctx)
+{
+	return max_config_dma_and_start(desc, msgs, len, callback, ctx, true);
 }
 
 /**
@@ -160,9 +556,14 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 			 struct no_os_spi_msg *msgs,
 			 uint32_t len)
 {
+	mxc_spi_regs_t *spi = MXC_SPI_GET_SPI(desc->device_id);
 	static uint32_t last_slave_id[MXC_SPI_INSTANCES];
-	mxc_spi_req_t req;
+	uint32_t tx_cnt;
+	uint32_t rx_cnt;
+	bool rx_done = true;
+	bool tx_done = true;
 	uint32_t slave_id;
+	size_t i = 0;
 	int32_t ret;
 
 	if (!desc || !msgs)
@@ -177,23 +578,73 @@ int32_t max_spi_transfer(struct no_os_spi_desc *desc,
 		last_slave_id[desc->device_id] = slave_id;
 	}
 
-	req.spi = MXC_SPI_GET_SPI(desc->device_id);
-	req.ssIdx = desc->chip_select;
-	for (uint32_t i = 0; i < len; i++) {
-		req.txData = msgs[i].tx_buff;
-		req.rxData = msgs[i].rx_buff;
-		req.txCnt = 0;
-		req.rxCnt = 0;
-		req.ssDeassert = msgs[i].cs_change;
-		req.txLen = req.txData ? msgs[i].bytes_number : 0;
-		req.rxLen = req.rxData ? msgs[i].bytes_number : 0;
+	/* Assert CS desc->chip_select when the SPI transaction is started */
+	spi->ctrl0 &= ~MXC_F_SPI_CTRL0_SS_ACTIVE;
+	spi->ctrl0 |= no_os_field_prep(MXC_F_SPI_CTRL0_SS_ACTIVE,
+				       NO_OS_BIT(desc->chip_select));
 
-		ret = MXC_SPI_MasterTransaction(&req);
+	for (i = 0; i < len; i++) {
+		/* Flush the RX and TX FIFOs */
+		spi->dma |= MXC_F_SPI_DMA_RX_FLUSH | MXC_F_SPI_DMA_TX_FLUSH;
+		/* Enable SPI */
+		spi->intfl |= MXC_F_SPI_INTFL_MST_DONE;
+		spi->ctrl1 = 0;
 
-		if (ret == E_BAD_PARAM)
-			return -EINVAL;
-		if (ret == E_BAD_STATE)
-			return -EBUSY;
+		rx_cnt = 0;
+		tx_cnt = 0;
+
+		if (msgs[i].cs_change)
+			spi->ctrl0 &= ~MXC_F_SPI_CTRL0_SS_CTRL;
+		else
+			spi->ctrl0 |= MXC_F_SPI_CTRL0_SS_CTRL;
+
+		_max_delay_config(desc, &msgs[i]);
+
+		if (msgs[i].tx_buff) {
+			/* Set the transfer size in the TX direction */
+			spi->ctrl1 = msgs[i].bytes_number;
+			tx_done = false;
+			/* Enable the TX FIFO */
+			spi->dma |= MXC_F_SPI_DMA_TX_FIFO_EN;
+			tx_cnt += MXC_SPI_WriteTXFIFO(spi, &msgs[i].tx_buff[tx_cnt],
+						      msgs[i].bytes_number - tx_cnt);
+			tx_done = (tx_cnt == msgs[i].bytes_number) ? true : false;
+		}
+		if (msgs[i].rx_buff) {
+			/* Set the transfer size in the RX direction */
+			spi->ctrl1 |= no_os_field_prep(MXC_F_SPI_CTRL1_RX_NUM_CHAR,
+						       msgs[i].bytes_number);
+			/* Enable the RX FIFO */
+			spi->dma |= MXC_F_SPI_DMA_RX_FIFO_EN;
+			rx_done = false;
+		}
+
+		/* Start the transaction */
+		spi->ctrl0 |= MXC_F_SPI_CTRL0_START;
+
+		while (!(rx_done && tx_done)) {
+			if (msgs[i].tx_buff && tx_cnt < msgs[i].bytes_number) {
+				tx_cnt += MXC_SPI_WriteTXFIFO(spi, &msgs[i].tx_buff[tx_cnt],
+							      msgs[i].bytes_number - tx_cnt);
+				tx_done = (tx_cnt == msgs[i].bytes_number) ? true : false;
+			}
+			if (msgs[i].rx_buff && rx_cnt < msgs[i].bytes_number) {
+				rx_cnt += MXC_SPI_ReadRXFIFO(spi, &msgs[i].rx_buff[rx_cnt],
+							     msgs[i].bytes_number - rx_cnt);
+				rx_done = (rx_cnt == msgs[i].bytes_number) ? true : false;
+			}
+		}
+
+		/* Wait for the RX and TX FIFOs to empty */
+		while (!(spi->int_fl & MXC_F_SPI_INT_FL_M_DONE));
+
+		/* End the transaction */
+		spi->ctrl0 &= ~MXC_F_SPI_CTRL0_START;
+
+		/* Disable the RX and TX FIFOs */
+		spi->dma &= ~(MXC_F_SPI_DMA_TX_FIFO_EN | MXC_F_SPI_DMA_RX_FIFO_EN);
+
+		no_os_udelay(msgs[i].cs_change_delay);
 	}
 
 	return 0;
@@ -227,5 +678,7 @@ const struct no_os_spi_platform_ops max_spi_ops = {
 	.init = &max_spi_init,
 	.write_and_read = &max_spi_write_and_read,
 	.transfer = &max_spi_transfer,
+	.transfer_dma = &max_spi_transfer_dma,
+	.transfer_dma_async = &max_spi_transfer_dma_async,
 	.remove = &max_spi_remove
 };

--- a/drivers/platform/maxim/max32672/maxim_spi.h
+++ b/drivers/platform/maxim/max32672/maxim_spi.h
@@ -19,7 +19,7 @@
  *    contributors may be used to endorse or promote products derived from this
  *    software without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
  * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
@@ -35,7 +35,10 @@
 #define MAXIM_SPI_H_
 
 #include <stdint.h>
+#include "max32672.h"
+#include "gpio.h"
 #include "no_os_spi.h"
+#include "no_os_dma.h"
 
 /**
  * @brief maxim specific SPI platform ops structure
@@ -56,6 +59,19 @@ enum spi_ss_polarity {
 struct max_spi_init_param {
 	uint32_t num_slaves;
 	enum spi_ss_polarity polarity;
+	mxc_gpio_vssel_t vssel;
+	struct no_os_dma_init_param *dma_param;
+	uint32_t dma_rx_priority;
+	uint32_t dma_tx_priority;
+};
+
+struct max_spi_state {
+	struct max_spi_init_param *init_param;
+	uint32_t cs_delay_first;
+	uint32_t cs_delay_last;
+	struct no_os_dma_desc *dma;
+	uint32_t dma_req_rx;
+	uint32_t dma_req_tx;
 };
 
 #endif


### PR DESCRIPTION
## Pull Request Description

Register MAX32670/MAX32672 in the shared DMA header, add DMA IRQ handlers
to the IRQ driver, and upgrade the SPI driver to support DMA
transfers following the same patterns used by other Maxim platforms.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
