### PR TITLE
Fix vitis 2025 sdt

### DIFF
--- a/drivers/platform/xilinx/xilinx_compat.h
+++ b/drivers/platform/xilinx/xilinx_compat.h
@@ -118,11 +118,12 @@
 #define XPAR_INTC_SINGLE_DEVICE_ID	0
 #endif
 
-/* AXI Interrupt Controller renames: Vitis 2025+ changed the INTC array
- * size macro and the interrupt ID naming convention. */
-#if !defined(XPAR_INTC_MAX_NUM_INTR_INPUTS) && defined(XPAR_XINTC_0_NUM_INTR_INPUTS)
-#define XPAR_INTC_MAX_NUM_INTR_INPUTS	XPAR_XINTC_0_NUM_INTR_INPUTS
-#endif
+/* Note: XPAR_INTC_MAX_NUM_INTR_INPUTS is intentionally NOT provided here.
+ * On Vitis 2025+ the BSP's xintc.h pulls in xintc_drv_config.h, which always
+ * defines this macro.  Providing a fallback from xparameters.h (which only
+ * exposes XPAR_XINTC_0_NUM_INTR_INPUTS) would be redefined later by
+ * xintc_drv_config.h, triggering a redefinition warning.  No no-OS code uses
+ * this macro outside the xintc.h include chain, so the BSP definition suffices. */
 
 /* Interrupt ID renames: old XPAR_AXI_INTC_<periph>_INTERRUPT_INTR
  * became XPAR_FABRIC_<periph>_INTR in Vitis 2025+. */
@@ -144,6 +145,11 @@
 #ifndef XPAR_XSPIPS_1_DEVICE_ID
 #define XPAR_XSPIPS_1_DEVICE_ID			1
 #endif
+
+/* GPIO PS device ID: Vitis 2025+ removed this macro. */
+#ifndef XPAR_XGPIOPS_0_DEVICE_ID
+#define XPAR_XGPIOPS_0_DEVICE_ID		0
+#endif
 #if !defined(XPAR_PS7_SPI_0_SPI_CLK_FREQ_HZ) && defined(XPAR_XSPIPS_0_SPI_CLK_FREQ_HZ)
 #define XPAR_PS7_SPI_0_SPI_CLK_FREQ_HZ		XPAR_XSPIPS_0_SPI_CLK_FREQ_HZ
 #endif
@@ -155,6 +161,14 @@
 #endif
 #if !defined(XPAR_PSU_SPI_1_SPI_CLK_FREQ_HZ) && defined(XPAR_XSPIPS_1_SPI_CLK_FREQ_HZ)
 #define XPAR_PSU_SPI_1_SPI_CLK_FREQ_HZ		XPAR_XSPIPS_1_SPI_CLK_FREQ_HZ
+#endif
+
+/* UART PS interrupt ID renames: Vitis 2025+ changed _INTR to _INTERRUPTS. */
+#if !defined(XPAR_XUARTPS_0_INTR) && defined(XPAR_XUARTPS_0_INTERRUPTS)
+#define XPAR_XUARTPS_0_INTR			XPAR_XUARTPS_0_INTERRUPTS
+#endif
+#if !defined(XPAR_XUARTPS_1_INTR) && defined(XPAR_XUARTPS_1_INTERRUPTS)
+#define XPAR_XUARTPS_1_INTR			XPAR_XUARTPS_1_INTERRUPTS
 #endif
 
 #endif /* _XILINX_COMPAT_H_ */

--- a/drivers/platform/xilinx/xilinx_delay.c
+++ b/drivers/platform/xilinx/xilinx_delay.c
@@ -64,11 +64,11 @@ struct no_os_time no_os_get_time(void)
 {
 	struct no_os_time t = {0, 0};
 #ifdef _XPARAMETERS_PS_H_
-	unsigned long long Xtime_Global;
+	XTime Xtime_Global;
 	uint32_t rem;
 
 	XTime_GetTime(&Xtime_Global);
-	t.s = no_os_div_u64_rem(Xtime_Global, COUNTS_PER_SECOND, &rem);
+	t.s = no_os_div_u64_rem((uint64_t)Xtime_Global, COUNTS_PER_SECOND, &rem);
 	t.us = no_os_div_u64((uint64_t)rem * 1000000, COUNTS_PER_SECOND);
 #endif
 

--- a/drivers/platform/xilinx/xilinx_gpio.c
+++ b/drivers/platform/xilinx/xilinx_gpio.c
@@ -74,7 +74,11 @@ int32_t _gpio_init(struct no_os_gpio_desc *desc,
 		if (!xdesc->instance)
 			goto pl_error;
 
+#ifdef SDT
+		xdesc->config = XGpio_LookupConfig(xinit->base_addr);
+#else
 		xdesc->config = XGpio_LookupConfig(xinit->device_id);
+#endif
 		if (xdesc->config == NULL)
 			goto pl_error;
 
@@ -96,7 +100,11 @@ pl_error:
 		if (!xdesc->instance)
 			goto ps_error;
 
+#ifdef SDT
+		xdesc->config = XGpioPs_LookupConfig(xinit->base_addr);
+#else
 		xdesc->config = XGpioPs_LookupConfig(xinit->device_id);
+#endif
 		if (xdesc->config == NULL)
 			goto ps_error;
 

--- a/drivers/platform/xilinx/xilinx_gpio.h
+++ b/drivers/platform/xilinx/xilinx_gpio.h
@@ -58,6 +58,8 @@ struct xil_gpio_init_param {
 	enum xil_gpio_type	type;
 	/** Device ID */
 	uint32_t		device_id;
+	/** Device base address (used for SDT flow) */
+	uint32_t		base_addr;
 };
 
 /**

--- a/drivers/platform/xilinx/xilinx_gpio_irq.c
+++ b/drivers/platform/xilinx/xilinx_gpio_irq.c
@@ -144,7 +144,11 @@ int xil_gpio_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 	}
 
 	xil_ip = param->extra;
+#ifdef SDT
+	GPIO_Config = XGpioPs_LookupConfig(xil_ip->base_addr);
+#else
 	GPIO_Config = XGpioPs_LookupConfig(xil_ip->gpio_device_id);
+#endif
 	status = XGpioPs_CfgInitialize(&xil_desc->my_Gpio, GPIO_Config,
 				       GPIO_Config->BaseAddr);
 	if (status)

--- a/drivers/platform/xilinx/xilinx_gpio_irq.h
+++ b/drivers/platform/xilinx/xilinx_gpio_irq.h
@@ -58,6 +58,8 @@ struct xil_callback_desc {
 struct xil_gpio_irq_init_param {
 	struct no_os_irq_ctrl_desc *parent_desc;
 	int32_t gpio_device_id;
+	/** Device base address (used for SDT flow) */
+	uint32_t base_addr;
 };
 
 /**

--- a/drivers/platform/xilinx/xilinx_i2c.c
+++ b/drivers/platform/xilinx/xilinx_i2c.c
@@ -186,7 +186,11 @@ int32_t xil_i2c_init(struct no_os_i2c_desc **desc,
 		if (!xdesc->instance)
 			goto pl_error;
 
+#ifdef SDT
+		xdesc->config = XIic_LookupConfig(xinit->base_addr);
+#else
 		xdesc->config = XIic_LookupConfig(xinit->device_id);
+#endif
 		if (xdesc->config == NULL)
 			goto pl_error;
 
@@ -251,7 +255,11 @@ pl_error:
 		if (!xdesc->instance)
 			goto ps_error;
 
+#ifdef SDT
+		xdesc->config = XIicPs_LookupConfig(xinit->base_addr);
+#else
 		xdesc->config = XIicPs_LookupConfig(xinit->device_id);
+#endif
 		if (xdesc->config == NULL)
 			goto ps_error;
 

--- a/drivers/platform/xilinx/xilinx_i2c.h
+++ b/drivers/platform/xilinx/xilinx_i2c.h
@@ -57,6 +57,8 @@ struct xil_i2c_init_param {
 	enum xil_i2c_type	type;
 	/** Device ID */
 	uint32_t		device_id;
+	/** Device base address (used for SDT flow) */
+	uint32_t		base_addr;
 };
 
 /**

--- a/drivers/platform/xilinx/xilinx_irq.c
+++ b/drivers/platform/xilinx/xilinx_irq.c
@@ -85,7 +85,12 @@ int xil_irq_ctrl_init(struct no_os_irq_ctrl_desc **desc,
 		if (!xil_dev->instance)
 			goto error;
 
+#ifdef SDT
+		config = XScuGic_LookupConfig(
+				 ((struct xil_irq_init_param *)param->extra)->base_addr);
+#else
 		config = XScuGic_LookupConfig(descriptor->irq_ctrl_id);
+#endif
 		if (!config)
 			goto ps_error;
 

--- a/drivers/platform/xilinx/xilinx_irq.h
+++ b/drivers/platform/xilinx/xilinx_irq.h
@@ -56,6 +56,8 @@ enum xil_irq_type {
 struct xil_irq_init_param {
 	/** Xilinx architecture */
 	enum xil_irq_type	type;
+	/** Device base address (used for SDT flow) */
+	uint32_t		base_addr;
 };
 
 /**

--- a/drivers/platform/xilinx/xilinx_spi.c
+++ b/drivers/platform/xilinx/xilinx_spi.c
@@ -46,16 +46,6 @@
 #include "no_os_alloc.h"
 #include "xilinx_spi.h"
 
-#if defined(PLATFORM_ZYNQ)
-#define SPI_CLK_FREQ_HZ(dev)	(XPAR_PS7_SPI_ ## dev ## _SPI_CLK_FREQ_HZ)
-#define SPI_NUM_INSTANCES	XPAR_XSPIPS_NUM_INSTANCES
-#elif defined(PLATFORM_ZYNQMP)
-#define SPI_CLK_FREQ_HZ(dev)	(XPAR_PSU_SPI_ ## dev ## _SPI_CLK_FREQ_HZ)
-#define SPI_NUM_INSTANCES	XPAR_XSPIPS_NUM_INSTANCES
-#else
-#define SPI_NUM_INSTANCES	0
-#endif
-
 #warning SPI delays are not supported on the xilinx platform
 
 /**
@@ -88,7 +78,11 @@ static int32_t spi_init_pl(struct no_os_spi_desc *desc,
 	if (!xdesc->instance)
 		goto pl_error;
 
+#ifdef SDT
+	xdesc->config = XSpi_LookupConfig(xinit->base_addr);
+#else
 	xdesc->config = XSpi_LookupConfig(param->device_id);
+#endif
 	if (xdesc->config == NULL)
 		goto pl_error;
 
@@ -99,7 +93,11 @@ static int32_t spi_init_pl(struct no_os_spi_desc *desc,
 	if (ret != 0)
 		goto pl_error;
 
+#ifdef SDT
+	ret = XSpi_Initialize(xdesc->instance, xinit->base_addr);
+#else
 	ret = XSpi_Initialize(xdesc->instance, param->device_id);
+#endif
 	if (ret != 0)
 		goto pl_error;
 
@@ -162,7 +160,11 @@ static int32_t spi_init_ps(struct no_os_spi_desc *desc,
 	if (!xdesc->instance)
 		goto ps_error;
 
+#ifdef SDT
+	xdesc->config = XSpiPs_LookupConfig(xinit->base_addr);
+#else
 	xdesc->config = XSpiPs_LookupConfig(param->device_id);
+#endif
 	if (xdesc->config == NULL)
 		goto ps_error;
 
@@ -173,20 +175,7 @@ static int32_t spi_init_ps(struct no_os_spi_desc *desc,
 	if (ret != 0)
 		goto ps_error;
 
-	switch (param->device_id) {
-#if (SPI_NUM_INSTANCES >= 1)
-	case 0:
-		input_clock = SPI_CLK_FREQ_HZ(0);
-		break;
-#endif
-#if (SPI_NUM_INSTANCES >= 2)
-	case 1:
-		input_clock = SPI_CLK_FREQ_HZ(1);
-		break;
-#endif
-	default:
-		goto ps_error;
-	};
+	input_clock = ((XSpiPs_Config*)xdesc->config)->InputClockHz;
 
 	if (desc->max_speed_hz != 0u) {
 		uint32_t div = input_clock / desc->max_speed_hz;

--- a/drivers/platform/xilinx/xilinx_spi.h
+++ b/drivers/platform/xilinx/xilinx_spi.h
@@ -62,6 +62,8 @@ struct xil_spi_init_param {
 	enum xil_spi_type	type;
 	/** SPI flags */
 	uint32_t		flags;
+	/** Device base address (used for SDT flow) */
+	uint32_t		base_addr;
 };
 
 /**

--- a/drivers/platform/xilinx/xilinx_spi_pl.c
+++ b/drivers/platform/xilinx/xilinx_spi_pl.c
@@ -169,7 +169,12 @@ static int32_t xil_spi_init_pl(struct no_os_spi_desc **desc,
 	if (!desc || !param || param->device_id >= XPAR_XSPI_NUM_INSTANCES)
 		return -EINVAL;
 
+#ifdef SDT
+	cfg = XSpi_LookupConfig(
+		      ((struct xil_spi_init_param *)param->extra)->base_addr);
+#else
 	cfg = XSpi_LookupConfig(param->device_id);
+#endif
 	if (!cfg)
 		return -EINVAL;
 

--- a/drivers/platform/xilinx/xilinx_timer.c
+++ b/drivers/platform/xilinx/xilinx_timer.c
@@ -313,7 +313,11 @@ int32_t xilinx_timer_init(struct no_os_timer_desc **desc,
 	switch (xdesc->type) {
 	case TIMER_PS:
 #ifdef XSCUTIMER_H
+#ifdef SDT
+		xdesc->config = XScuTimer_LookupConfig(xinit->base_addr);
+#else
 		xdesc->config = XScuTimer_LookupConfig(dev->id);
+#endif
 		xdesc->instance = no_os_calloc(1, sizeof(XScuTimer));
 		if (!xdesc->instance)
 			goto error_xdesc;
@@ -342,7 +346,11 @@ int32_t xilinx_timer_init(struct no_os_timer_desc **desc,
 		if (!xdesc->instance)
 			return -1;
 
+#ifdef SDT
+		xdesc->config = XTmrCtr_LookupConfig(xinit->base_addr);
+#else
 		xdesc->config = XTmrCtr_LookupConfig(dev->id);
+#endif
 		if (!xdesc->config) {
 			no_os_free(xdesc->instance);
 			goto error_desc;

--- a/drivers/platform/xilinx/xilinx_timer.h
+++ b/drivers/platform/xilinx/xilinx_timer.h
@@ -77,6 +77,8 @@ struct xil_timer_init_param {
 	uint8_t active_tmr;
 	/** Platform selection parameter */
 	enum xil_timer_type type;
+	/** Device base address (used for SDT flow) */
+	uint32_t base_addr;
 };
 
 /**

--- a/drivers/platform/xilinx/xilinx_uart.c
+++ b/drivers/platform/xilinx/xilinx_uart.c
@@ -374,6 +374,7 @@ static int32_t xil_uart_init(struct no_os_uart_desc **desc,
 	xil_uart_desc = descriptor->extra;
 	xil_uart_desc->irq_id = xil_uart_init_param->irq_id;
 	xil_uart_desc->type = xil_uart_init_param->type;
+	xil_uart_desc->base_addr = xil_uart_init_param->base_addr;
 
 #ifdef _XPARAMETERS_PS_H_
 	status = irq_setup((struct no_os_irq_ctrl_desc **)&xil_uart_desc->irq_desc);
@@ -391,7 +392,11 @@ static int32_t xil_uart_init(struct no_os_uart_desc **desc,
 		 * Initialize the UART driver so that it's ready to use
 		 * Look up the configuration in the config table, then initialize it.
 		 */
+#ifdef SDT
+		config = XUartPs_LookupConfig(xil_uart_desc->base_addr);
+#else
 		config = XUartPs_LookupConfig(descriptor->device_id);
+#endif
 		if (!config)
 			goto error_free_instance;
 
@@ -434,7 +439,11 @@ static int32_t xil_uart_init(struct no_os_uart_desc **desc,
 		if (!(xil_uart_desc->instance))
 			goto error_free_xil_uart_desc;
 
+#ifdef SDT
+		config = XUartLite_LookupConfig(xil_uart_desc->base_addr);
+#else
 		config = XUartLite_LookupConfig(descriptor->device_id);
+#endif
 		if (!config)
 			goto error_free_instance;
 

--- a/drivers/platform/xilinx/xilinx_uart.h
+++ b/drivers/platform/xilinx/xilinx_uart.h
@@ -60,6 +60,8 @@ struct xil_uart_init_param {
 	uint32_t			irq_id;
 	/** Interrupt Request Descriptor */
 	struct no_os_irq_ctrl_desc *irq_desc;
+	/** Device base address (used for SDT flow) */
+	uint32_t			base_addr;
 };
 
 /**
@@ -73,6 +75,8 @@ struct xil_uart_desc {
 	uint32_t			irq_id;
 	/** Interrupt Request Descriptor */
 	struct no_os_irq_ctrl_desc *irq_desc;
+	/** Device base address (used for SDT flow) */
+	uint32_t			base_addr;
 	/** FIFO */
 	struct no_os_fifo_element	*fifo;
 	/** FIFO read offset */

--- a/projects/ad3552r_fmcz/src/platform/xilinx/parameters.c
+++ b/projects/ad3552r_fmcz/src/platform/xilinx/parameters.c
@@ -42,16 +42,25 @@
 struct xil_gpio_init_param xil_gpio_param = {
 	.device_id = GPIO_DEVICE_ID,
 	.type = GPIO_PS,
+#ifdef SDT
+	.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 };
 
 struct xil_spi_init_param xil_spi_param = {
 	.type = SPI_PS,
-	.flags = 0
+	.flags = 0,
+#ifdef SDT
+	.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 };
 
 #ifdef IIO_SUPPORT
 struct xil_uart_init_param platform_uart_param = {
 	.type = UART_PS,
-	.irq_id = UART_IRQ_ID
+	.irq_id = UART_IRQ_ID,
+#ifdef SDT
+	.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 };
 #endif

--- a/projects/ad4110/src/app/main.c
+++ b/projects/ad4110/src/app/main.c
@@ -57,6 +57,9 @@ int main()
 
 	struct xil_spi_init_param spi_extra = {
 		.type = SPI_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 		.flags = 0U
 	};
 	struct no_os_spi_init_param spi_ip = {
@@ -77,7 +80,10 @@ int main()
 	/* IRQ instance. */
 	struct no_os_irq_ctrl_desc *irq_desc;
 	struct xil_irq_init_param irq_extra = {
-		.type = IRQ_PS
+		.type = IRQ_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSCUGIC_0_BASEADDR,
+#endif
 	};
 	struct no_os_irq_init_param irq_ip = {
 		.irq_ctrl_id = 0U,

--- a/projects/ad413x/src/app/main.c
+++ b/projects/ad413x/src/app/main.c
@@ -70,6 +70,9 @@ int main()
 	/* SPI instance */
 	struct xil_spi_init_param spi_extra = {
 		.type = SPI_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 		.flags = 0U
 	};
 	struct no_os_spi_init_param spi_ip = {
@@ -84,6 +87,9 @@ int main()
 
 	struct xil_gpio_init_param xil_gpio_param = {
 		.type = GPIO_PS,
+#ifdef SDT
+		.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 		.device_id = XPAR_PS7_GPIO_0_DEVICE_ID
 	};
 
@@ -149,6 +155,9 @@ int main()
 
 	struct xil_uart_init_param platform_uart_init_par = {
 		.type = UART_PS,
+#ifdef SDT
+		.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 		.irq_id = UART_IRQ_ID
 	};
 

--- a/projects/ad463x_fmcz/src/platform/xilinx/parameters.c
+++ b/projects/ad463x_fmcz/src/platform/xilinx/parameters.c
@@ -37,16 +37,22 @@
 struct xil_uart_init_param uart_extra_ip = {
 #ifdef XPAR_XUARTLITE_NUM_INSTANCES
 	.type = UART_PL,
+#ifdef SDT
+	.base_addr = XPAR_XUARTLITE_0_BASEADDR,
+#endif
 #else
 	.type = UART_PS,
-	.irq_id = UART_IRQ_ID
+	.irq_id = UART_IRQ_ID,
+#ifdef SDT
+	.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 #endif
 };
 
 struct axi_pwm_init_param ad4630_axi_pwm_init = {
 	.base_addr = AXI_PWMGEN_BASEADDR,
 	.ref_clock_Hz = 100000000,
-	.channel = 0
+	.channel = 0,
 };
 
 struct spi_engine_init_param spi_eng_init_param  = {
@@ -59,4 +65,7 @@ struct spi_engine_init_param spi_eng_init_param  = {
 struct xil_gpio_init_param gpio_extra_param = {
 	.device_id = GPIO_DEVICE_ID,
 	.type = GPIO_PS,
+#ifdef SDT
+	.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 };

--- a/projects/ad469x_evb/src/platform/xilinx/parameters.c
+++ b/projects/ad469x_evb/src/platform/xilinx/parameters.c
@@ -36,9 +36,15 @@
 struct xil_uart_init_param uart_extra_ip = {
 #ifdef XPAR_XUARTLITE_NUM_INSTANCES
 	.type = UART_PL,
+#ifdef SDT
+	.base_addr = XPAR_XUARTLITE_0_BASEADDR,
+#endif
 #else
 	.type = UART_PS,
-	.irq_id = UART_IRQ_ID
+	.irq_id = UART_IRQ_ID,
+#ifdef SDT
+	.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 #endif
 };
 struct axi_pwm_init_param pwm_extra_ip = {
@@ -56,4 +62,7 @@ struct spi_engine_init_param spi_eng_extra_ip = {
 struct xil_gpio_init_param gpio_extra_ip = {
 	.device_id = GPIO_DEVICE_ID,
 	.type = GPIO_PS,
+#ifdef SDT
+	.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 };

--- a/projects/ad5758-sdz/src/app/ad5758_sdz.c
+++ b/projects/ad5758-sdz/src/app/ad5758_sdz.c
@@ -48,6 +48,9 @@
 
 const struct xil_spi_init_param spi_extra = {
 	.type = SPI_PS,
+#ifdef SDT
+	.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 	.flags = NULL
 };
 const struct no_os_spi_init_param spi_ip = {
@@ -62,6 +65,9 @@ const struct no_os_spi_init_param spi_ip = {
 
 const struct xil_gpio_init_param gpio_extra = {
 	.type = GPIO_PS,
+#ifdef SDT
+	.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 	.device_id = GPIO_DEVICE_ID
 };
 const struct no_os_gpio_init_param reset_ip = {

--- a/projects/ad5766-sdz/src/ad5766_sdz.c
+++ b/projects/ad5766-sdz/src/ad5766_sdz.c
@@ -64,6 +64,9 @@ int main(void)
 	struct xil_gpio_init_param gpio_extra_param = {
 		.device_id = GPIO_DEVICE_ID,
 		.type = GPIO_PS,
+#ifdef SDT
+		.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 	};
 
 	struct no_os_gpio_init_param ad5766_gpio_reset_param = {

--- a/projects/ad6676-ebz/src/ad6676_ebz.c
+++ b/projects/ad6676-ebz/src/ad6676_ebz.c
@@ -69,8 +69,14 @@ int32_t ad6676_gpio_config(struct ad6676_init_param init_param)
 	struct xil_gpio_init_param xil_gpio_param = {
 #ifdef PLATFORM_MB
 		.type = GPIO_PL,
+#ifdef SDT
+		.base_addr = XPAR_XGPIO_0_BASEADDR,
+#endif
 #else
 		.type = GPIO_PS,
+#ifdef SDT
+		.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 #endif
 		.device_id = GPIO_DEVICE_ID
 	};
@@ -252,8 +258,14 @@ int main(void)
 	struct xil_gpio_init_param xil_gpio_param = {
 #ifdef PLATFORM_MB
 		.type = GPIO_PL,
+#ifdef SDT
+		.base_addr = XPAR_XGPIO_0_BASEADDR,
+#endif
 #else
 		.type = GPIO_PS,
+#ifdef SDT
+		.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 #endif
 		.device_id = GPIO_DEVICE_ID
 	};
@@ -268,8 +280,14 @@ int main(void)
 	struct xil_spi_init_param xil_spi_param = {
 #ifdef PLATFORM_MB
 		.type = SPI_PL,
+#ifdef SDT
+		.base_addr = XPAR_XSPI_0_BASEADDR,
+#endif
 #else
 		.type = SPI_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 #endif
 	};
 
@@ -479,8 +497,14 @@ int main(void)
 	struct xil_uart_init_param platform_uart_init_par = {
 #ifdef XPAR_XUARTLITE_NUM_INSTANCES
 		.type = UART_PL,
+#ifdef SDT
+		.base_addr = XPAR_XUARTLITE_0_BASEADDR,
+#endif
 #else
 		.type = UART_PS,
+#ifdef SDT
+		.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 		.irq_id = UART_IRQ_ID
 #endif
 	};

--- a/projects/ad7124-4sdz/src/ad7124-4sdz.c
+++ b/projects/ad7124-4sdz/src/ad7124-4sdz.c
@@ -48,6 +48,9 @@ int main(void)
 
 	static struct xil_spi_init_param xil_spi_init_params = {
 		.type = SPI_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 	};
 
 	struct no_os_spi_init_param spi_init = {

--- a/projects/ad7124-8pmdz/src/main.c
+++ b/projects/ad7124-8pmdz/src/main.c
@@ -98,8 +98,14 @@ int main(void)
 	struct xil_uart_init_param platform_uart_init_par = {
 #ifdef XPAR_XUARTLITE_NUM_INSTANCES
 		.type = UART_PL,
+#ifdef SDT
+		.base_addr = XPAR_XUARTLITE_0_BASEADDR,
+#endif
 #else
 		.type = UART_PS,
+#ifdef SDT
+		.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 		.irq_id = UART_IRQ_ID
 #endif
 	};

--- a/projects/ad713x_fmcz/src/ad713x_fmc.c
+++ b/projects/ad713x_fmcz/src/ad713x_fmc.c
@@ -92,6 +92,9 @@ int main()
 	uint32_t spi_eng_msg_cmds[1];
 	static struct xil_spi_init_param spi_engine_init_params = {
 		.type = SPI_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 	};
 	struct xil_gpio_init_param gpio_extra_param;
 	struct no_os_gpio_init_param ad7134_1_dclkio = {
@@ -198,6 +201,9 @@ int main()
 
 	gpio_extra_param.device_id = GPIO_DEVICE_ID;
 	gpio_extra_param.type = GPIO_PS;
+#ifdef SDT
+	gpio_extra_param.base_addr = XPAR_XGPIOPS_0_BASEADDR;
+#endif
 
 	ad713x_init_param_1.adc_data_len = ADC_24_BIT_DATA;
 	ad713x_init_param_1.clk_delay_en = false;
@@ -313,8 +319,14 @@ int main()
 	struct xil_uart_init_param platform_uart_init_par = {
 #ifdef XPAR_XUARTLITE_NUM_INSTANCES
 		.type = UART_PL,
+#ifdef SDT
+		.base_addr = XPAR_XUARTLITE_0_BASEADDR,
+#endif
 #else
 		.type = UART_PS,
+#ifdef SDT
+		.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 		.irq_id = UART_IRQ_ID
 #endif
 	};

--- a/projects/ad719x/src/platform/xilinx/parameters.c
+++ b/projects/ad719x/src/platform/xilinx/parameters.c
@@ -35,10 +35,16 @@
 
 struct xil_spi_init_param spi_extra = {
 	.type = SPI_PS,
-	.flags = 0U
+	.flags = 0U,
+#ifdef SDT
+	.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 };
 
 struct xil_gpio_init_param gpio_extra = {
 	.type = GPIO_PS,
-	.device_id = GPIO_DEVICE_ID
+	.device_id = GPIO_DEVICE_ID,
+#ifdef SDT
+	.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 };

--- a/projects/ad738x_fmcz/src/platform/xilinx/parameters.c
+++ b/projects/ad738x_fmcz/src/platform/xilinx/parameters.c
@@ -39,9 +39,15 @@
 struct xil_uart_init_param uart_extra_ip = {
 #ifdef XPAR_XUARTLITE_NUM_INSTANCES
 	.type = UART_PL,
+#ifdef SDT
+	.base_addr = XPAR_XUARTLITE_0_BASEADDR,
+#endif
 #else
 	.type = UART_PS,
-	.irq_id = UART_IRQ_ID
+	.irq_id = UART_IRQ_ID,
+#ifdef SDT
+	.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 #endif
 };
 

--- a/projects/ad7606x-fmc/src/common_data.c
+++ b/projects/ad7606x-fmc/src/common_data.c
@@ -80,6 +80,9 @@ static struct no_os_pwm_init_param trigger_pwm_init = {
 static struct xil_gpio_init_param xil_gpio_param = {
 	.device_id = GPIO_DEVICE_ID,
 	.type = GPIO_PS,
+#ifdef SDT
+	.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 };
 
 static struct no_os_gpio_init_param ad7606x_gpio_reset = {

--- a/projects/ad7606x-fmc/src/iio_example.c
+++ b/projects/ad7606x-fmc/src/iio_example.c
@@ -56,8 +56,14 @@
 static struct xil_uart_init_param uart_extra_ip = {
 #ifdef XPAR_XUARTLITE_NUM_INSTANCES
 	.type = UART_PL,
+#ifdef SDT
+	.base_addr = XPAR_XUARTLITE_0_BASEADDR,
+#endif
 #else
 	.type = UART_PS,
+#ifdef SDT
+	.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 	.irq_id = UART_IRQ_ID
 #endif
 };

--- a/projects/ad7616-sdz/src/ad7616_sdz.c
+++ b/projects/ad7616-sdz/src/ad7616_sdz.c
@@ -96,6 +96,9 @@ struct no_os_spi_init_param ad7616_spi_init = {
 struct xil_gpio_init_param xil_gpio_param = {
 	.device_id = GPIO_DEVICE_ID,
 	.type = GPIO_PS,
+#ifdef SDT
+	.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 };
 struct no_os_gpio_init_param ad7616_gpio_reset = {
 	.number = GPIO_ADC_RESET_N,

--- a/projects/ad7768-evb/src/ad7768_evb.c
+++ b/projects/ad7768-evb/src/ad7768_evb.c
@@ -77,12 +77,18 @@ int main(void)
 
 	struct xil_spi_init_param xil_spi_initial = {
 		.flags = 0,
-		.type = SPI_PS
+		.type = SPI_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 	};
 
 	struct xil_gpio_init_param xil_gpio_initial = {
 		.device_id = GPIO_DEVICE_ID,
-		.type = GPIO_PS
+		.type = GPIO_PS,
+#ifdef SDT
+		.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 	};
 
 	ad7768_init_param default_init_param = {
@@ -219,6 +225,9 @@ int main(void)
 
 	struct xil_uart_init_param platform_uart_init_par = {
 		.type = UART_PS,
+#ifdef SDT
+		.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 		.irq_id = UART_IRQ_ID
 	};
 

--- a/projects/ad796x_fmcz/src/common/common_data.c
+++ b/projects/ad796x_fmcz/src/common/common_data.c
@@ -102,7 +102,10 @@ struct no_os_pwm_init_param axi_pwm_1_ip = {
 
 struct xil_gpio_init_param xil_gpio_init = {
 	.device_id = GPIO_DEVICE_ID,
-	.type = GPIO_PS
+	.type = GPIO_PS,
+#ifdef SDT
+	.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 };
 
 struct no_os_gpio_init_param gpio_adc_en3_fmc_ip = {

--- a/projects/ad796x_fmcz/src/platform/xilinx/parameters.c
+++ b/projects/ad796x_fmcz/src/platform/xilinx/parameters.c
@@ -36,8 +36,14 @@
 struct xil_uart_init_param iio_uart_extra_ip = {
 #ifdef XPAR_XUARTLITE_NUM_INSTANCES
 	.type = UART_PL,
+#ifdef SDT
+	.base_addr = XPAR_XUARTLITE_0_BASEADDR,
+#endif
 #else
 	.type = UART_PS,
-	.irq_id = UART_IRQ_ID
+	.irq_id = UART_IRQ_ID,
+#ifdef SDT
+	.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 #endif
 };

--- a/projects/ad9081/src/app.c
+++ b/projects/ad9081/src/app.c
@@ -79,8 +79,14 @@ int main(void)
 	struct xil_gpio_init_param  xil_gpio_param = {
 #ifdef PLATFORM_MB
 		.type = GPIO_PL,
+#ifdef SDT
+		.base_addr = XPAR_XGPIO_0_BASEADDR,
+#endif
 #else
 		.type = GPIO_PS,
+#ifdef SDT
+		.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 #endif
 		.device_id = GPIO_DEVICE_ID
 	};
@@ -114,8 +120,14 @@ int main(void)
 	struct xil_spi_init_param xil_spi_param = {
 #ifdef PLATFORM_MB
 		.type = SPI_PL,
+#ifdef SDT
+		.base_addr = XPAR_XSPI_0_BASEADDR,
+#endif
 #else
 		.type = SPI_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 #endif
 	};
 	struct no_os_spi_init_param phy_spi_init_param = {
@@ -286,8 +298,14 @@ int main(void)
 	struct xil_gpio_init_param  xil_gpio_param_2 = {
 #ifdef PLATFORM_MB
 		.type = GPIO_PL,
+#ifdef SDT
+		.base_addr = XPAR_XGPIO_0_BASEADDR,
+#endif
 #else
 		.type = GPIO_PS,
+#ifdef SDT
+		.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 #endif
 		.device_id = GPIO_2_DEVICE_ID
 	};
@@ -458,8 +476,14 @@ int main(void)
 	struct xil_uart_init_param platform_uart_init_par = {
 #ifdef XPAR_XUARTLITE_NUM_INSTANCES
 		.type = UART_PL,
+#ifdef SDT
+		.base_addr = XPAR_XUARTLITE_0_BASEADDR,
+#endif
 #else
 		.type = UART_PS,
+#ifdef SDT
+		.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 		.irq_id = UART_IRQ_ID
 #endif
 	};

--- a/projects/ad9081/src/app_clock.c
+++ b/projects/ad9081/src/app_clock.c
@@ -64,8 +64,18 @@ int32_t app_clock_init(struct no_os_clk dev_refclk[MULTIDEVICE_INSTANCE_COUNT])
 	struct xil_spi_init_param xil_spi_param = {
 #ifdef PLATFORM_MB
 		.type = SPI_PL,
+#ifdef SDT
+		.base_addr = XPAR_XSPI_0_BASEADDR,
+#endif
 #else
 		.type = SPI_PS,
+#ifdef SDT
+#ifdef QUAD_MXFE
+		.base_addr = XPAR_XSPIPS_2_BASEADDR,
+#else
+		.base_addr = XPAR_XSPIPS_1_BASEADDR,
+#endif
+#endif
 #endif
 	};
 
@@ -162,8 +172,14 @@ int32_t app_clock_init(struct no_os_clk dev_refclk[MULTIDEVICE_INSTANCE_COUNT])
 	struct xil_gpio_init_param xil_gpio_param = {
 #ifdef PLATFORM_MB
 		.type = GPIO_PL,
+#ifdef SDT
+		.base_addr = XPAR_XGPIO_0_BASEADDR,
+#endif
 #else
 		.type = GPIO_PS,
+#ifdef SDT
+		.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 #endif
 		.device_id = GPIO_DEVICE_ID
 	};

--- a/projects/ad9083/src/app.c
+++ b/projects/ad9083/src/app.c
@@ -172,8 +172,14 @@ int main(void)
 	struct xil_uart_init_param platform_uart_init_par = {
 #ifdef XPAR_XUARTLITE_NUM_INSTANCES
 		.type = UART_PL,
+#ifdef SDT
+		.base_addr = XPAR_XUARTLITE_0_BASEADDR,
+#endif
 #else
 		.type = UART_PS,
+#ifdef SDT
+		.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 		.irq_id = UART_IRQ_ID
 #endif
 	};

--- a/projects/ad9083/src/app_ad9083.c
+++ b/projects/ad9083/src/app_ad9083.c
@@ -138,6 +138,9 @@ int32_t app_ad9083_init(struct app_ad9083 **app,
 	struct app_ad9083 *app_ad9083;
 	struct xil_spi_init_param xil_spi_param = {
 		.type = SPI_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 	};
 
 	// clock chip spi settings
@@ -152,6 +155,9 @@ int32_t app_ad9083_init(struct app_ad9083 **app,
 	};
 	struct xil_gpio_init_param  xil_gpio_param = {
 		.type = GPIO_PS,
+#ifdef SDT
+		.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 		.device_id = GPIO_DEVICE_ID
 	};
 	struct no_os_gpio_init_param	gpio_phy_resetb = {

--- a/projects/ad9083/src/app_clocking.c
+++ b/projects/ad9083/src/app_clocking.c
@@ -156,6 +156,9 @@ int32_t app_clocking_init(struct app_clocking **app,
 
 	struct xil_spi_init_param xil_spi_param = {
 		.type = SPI_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 	};
 
 	/* clock chip spi settings */

--- a/projects/ad9172/src/main.c
+++ b/projects/ad9172/src/main.c
@@ -62,6 +62,9 @@ int main(void)
 {
 	struct xil_spi_init_param xil_spi_param = {
 		.type = SPI_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 		.flags = 0
 	};
 
@@ -134,6 +137,9 @@ int main(void)
 
 	struct xil_gpio_init_param xilinx_gpio_init_param = {
 		.type = GPIO_PS,
+#ifdef SDT
+		.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 		.device_id = GPIO_DEVICE_ID
 	};
 	struct ad9172_init_param ad9172_param = {
@@ -371,8 +377,14 @@ int main(void)
 	struct xil_uart_init_param platform_uart_init_par = {
 #ifdef XPAR_XUARTLITE_NUM_INSTANCES
 		.type = UART_PL,
+#ifdef SDT
+		.base_addr = XPAR_XUARTLITE_0_BASEADDR,
+#endif
 #else
 		.type = UART_PS,
+#ifdef SDT
+		.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 		.irq_id = UART_IRQ_ID
 #endif
 	};

--- a/projects/ad9208/src/main.c
+++ b/projects/ad9208/src/main.c
@@ -78,8 +78,14 @@ int32_t start_iiod(struct axi_adc *rx_0_adc, struct axi_adc *rx_1_adc,
 	struct xil_uart_init_param platform_uart_init_par = {
 #ifdef XPAR_XUARTLITE_NUM_INSTANCES
 		.type = UART_PL,
+#ifdef SDT
+		.base_addr = XPAR_XUARTLITE_0_BASEADDR,
+#endif
 #else
 		.type = UART_PS,
+#ifdef SDT
+		.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 		.irq_id = UART_IRQ_ID
 #endif
 	};
@@ -151,6 +157,9 @@ int main(void)
 {
 	struct xil_spi_init_param xil_spi_param = {
 		.type = SPI_PL,
+#ifdef SDT
+		.base_addr = XPAR_XSPI_0_BASEADDR,
+#endif
 		.flags = 0
 	};
 
@@ -344,6 +353,9 @@ int main(void)
 
 	struct xil_gpio_init_param xilinx_gpio_init_param = {
 		.type = GPIO_PL,
+#ifdef SDT
+		.base_addr = XPAR_XGPIO_0_BASEADDR,
+#endif
 		.device_id = GPIO_DEVICE_ID
 	};
 

--- a/projects/ad9265-fmc-125ebz/src/ad9265_fmc_125ebz.c
+++ b/projects/ad9265-fmc-125ebz/src/ad9265_fmc_125ebz.c
@@ -60,6 +60,9 @@ int main(void)
 	/* Initialize SPI structures */
 	struct xil_spi_init_param xil_spi_param = {
 		.type = SPI_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 	};
 
 	struct no_os_spi_init_param ad9265_spi_param = {
@@ -176,6 +179,9 @@ int main(void)
 
 	struct xil_uart_init_param platform_uart_init_par = {
 		.type = UART_PS,
+#ifdef SDT
+		.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 		.irq_id = UART_IRQ_ID
 	};
 

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -98,8 +98,14 @@ uint16_t adc_buffer[ADC_BUFFER_SAMPLES * ADC_CHANNELS] __attribute__((
 struct xil_spi_init_param xil_spi_param = {
 #ifdef PLATFORM_MB
 	.type = SPI_PL,
+#ifdef SDT
+	.base_addr = XPAR_XSPI_0_BASEADDR,
+#endif
 #else
 	.type = SPI_PS,
+#ifdef SDT
+	.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 #endif
 	.flags = 0
 };
@@ -107,8 +113,14 @@ struct xil_spi_init_param xil_spi_param = {
 struct xil_gpio_init_param xil_gpio_param = {
 #ifdef PLATFORM_MB
 	.type = GPIO_PL,
+#ifdef SDT
+	.base_addr = XPAR_XGPIO_0_BASEADDR,
+#endif
 #else
 	.type = GPIO_PS,
+#ifdef SDT
+	.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 #endif
 	.device_id = GPIO_DEVICE_ID
 };
@@ -694,6 +706,9 @@ int main(void)
 	 */
 	struct xil_irq_init_param xil_irq_init_par = {
 		.type = IRQ_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSCUGIC_0_BASEADDR,
+#endif
 	};
 
 	/**
@@ -861,8 +876,14 @@ int main(void)
 	struct xil_uart_init_param platform_uart_init_par = {
 #ifdef XPAR_XUARTLITE_NUM_INSTANCES
 		.type = UART_PL,
+#ifdef SDT
+		.base_addr = XPAR_XUARTLITE_0_BASEADDR,
+#endif
 #else
 		.type = UART_PS,
+#ifdef SDT
+		.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 		.irq_id = UART_IRQ_ID
 #endif
 	};

--- a/projects/ad9371/src/app/headless.c
+++ b/projects/ad9371/src/app/headless.c
@@ -988,8 +988,14 @@ int main(void)
 	struct xil_uart_init_param platform_uart_init_par = {
 #ifdef XPAR_XUARTLITE_NUM_INSTANCES
 		.type = UART_PL,
+#ifdef SDT
+		.base_addr = XPAR_XUARTLITE_0_BASEADDR,
+#endif
 #else
 		.type = UART_PS,
+#ifdef SDT
+		.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 		.irq_id = UART_IRQ_ID
 #endif
 	};

--- a/projects/ad9371/src/devices/adi_hal/common.c
+++ b/projects/ad9371/src/devices/adi_hal/common.c
@@ -55,8 +55,14 @@ int32_t platform_init(void)
 	struct xil_spi_init_param xilinx_spi_param = {
 #ifdef PLATFORM_MB
 		.type = SPI_PL,
+#ifdef SDT
+		.base_addr = XPAR_XSPI_0_BASEADDR,
+#endif
 #else
 		.type = SPI_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 #endif
 		.flags = SPI_CS_DECODE
 	};
@@ -64,8 +70,14 @@ int32_t platform_init(void)
 	struct xil_gpio_init_param xilinx_gpio_param = {
 #ifdef PLATFORM_MB
 		.type = GPIO_PL,
+#ifdef SDT
+		.base_addr = XPAR_XGPIO_0_BASEADDR,
+#endif
 #else
 		.type = GPIO_PS,
+#ifdef SDT
+		.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 #endif
 		.device_id = GPIO_DEVICE_ID
 	};

--- a/projects/ad9434-fmc-500ebz/src/ad9434_fmc_500ebz.c
+++ b/projects/ad9434-fmc-500ebz/src/ad9434_fmc_500ebz.c
@@ -62,6 +62,9 @@ int main(void)
 	/* Initialize SPI structures */
 	struct xil_spi_init_param xil_spi_param = {
 		.type = SPI_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 	};
 
 	struct no_os_spi_init_param ad9434_spi_param = {
@@ -170,6 +173,9 @@ int main(void)
 #ifdef IIO_SUPPORT
 	struct xil_uart_init_param platform_uart_init_par = {
 		.type = UART_PS,
+#ifdef SDT
+		.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 		.irq_id = UART_IRQ_ID
 	};
 

--- a/projects/ad9467/src/app/ad9467_fmc.c
+++ b/projects/ad9467/src/app/ad9467_fmc.c
@@ -198,8 +198,14 @@ int main()
 	struct xil_spi_init_param xil_spi_param = {
 #ifdef PLATFORM_MB
 		.type = SPI_PL,
+#ifdef SDT
+		.base_addr = XPAR_XSPI_0_BASEADDR,
+#endif
 #else
 		.type = SPI_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 #endif
 	};
 	ad9467_spi_param.device_id = SPI_DEVICE_ID;
@@ -421,8 +427,14 @@ int main()
 	struct xil_uart_init_param platform_uart_init_par = {
 #ifdef XPAR_XUARTLITE_NUM_INSTANCES
 		.type = UART_PL,
+#ifdef SDT
+		.base_addr = XPAR_XUARTLITE_0_BASEADDR,
+#endif
 #else
 		.type = UART_PS,
+#ifdef SDT
+		.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 		.irq_id = UART_IRQ_ID
 #endif
 	};

--- a/projects/ad9656_fmc/src/app/ad9656_fmc.c
+++ b/projects/ad9656_fmc/src/app/ad9656_fmc.c
@@ -62,6 +62,9 @@ int main(void)
 
 	struct xil_spi_init_param xil_spi_param = {
 		.type = SPI_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 		.flags = 0U
 	};
 
@@ -288,8 +291,14 @@ int main(void)
 	struct xil_uart_init_param platform_uart_init_par = {
 #ifdef XPAR_XUARTLITE_NUM_INSTANCES
 		.type = UART_PL,
+#ifdef SDT
+		.base_addr = XPAR_XUARTLITE_0_BASEADDR,
+#endif
 #else
 		.type = UART_PS,
+#ifdef SDT
+		.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 		.irq_id = UART_IRQ_ID
 #endif
 	};

--- a/projects/adaq7980_sdz/src/adaq7980_sdz.c
+++ b/projects/adaq7980_sdz/src/adaq7980_sdz.c
@@ -81,6 +81,9 @@ int main()
 	struct xil_gpio_init_param gpio_extra_param = {
 		.device_id = GPIO_DEVICE_ID,
 		.type = GPIO_PS,
+#ifdef SDT
+		.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 	};
 
 	struct no_os_gpio_init_param adaq7980_pd_ldo = {

--- a/projects/adaq8092_fmc/src/adaq8092_fmc.c
+++ b/projects/adaq8092_fmc/src/adaq8092_fmc.c
@@ -65,7 +65,10 @@ int main(void)
 
 	struct xil_spi_init_param xil_spi_init = {
 		.flags = 0,
-		.type = SPI_PS
+		.type = SPI_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 	};
 
 	/* SPI */
@@ -81,7 +84,10 @@ int main(void)
 	/* GPIO */
 	struct xil_gpio_init_param xil_gpio_init = {
 		.device_id = GPIO_DEVICE_ID,
-		.type = GPIO_PS
+		.type = GPIO_PS,
+#ifdef SDT
+		.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 	};
 
 	struct no_os_gpio_init_param gpio_par_ser_init_param = {
@@ -200,6 +206,9 @@ int main(void)
 #ifdef IIO_SUPPORT
 	struct xil_uart_init_param platform_uart_init_par = {
 		.type = UART_PS,
+#ifdef SDT
+		.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 		.irq_id = UART_IRQ_ID
 	};
 

--- a/projects/adf4377_sdz/src/platform/xilinx/parameters.c
+++ b/projects/adf4377_sdz/src/platform/xilinx/parameters.c
@@ -36,10 +36,16 @@
 
 struct xil_spi_init_param spi_extra = {
 	.type = SPI_PS,
-	.flags = 0U
+	.flags = 0U,
+#ifdef SDT
+	.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 };
 
 struct xil_gpio_init_param xil_gpio_init = {
 	.device_id = GPIO_DEVICE_ID,
-	.type = GPIO_PS
+	.type = GPIO_PS,
+#ifdef SDT
+	.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 };

--- a/projects/adf5902_sdz/src/adf5902_sdz.c
+++ b/projects/adf5902_sdz/src/adf5902_sdz.c
@@ -59,12 +59,18 @@ int main(void)
 
 	struct xil_spi_init_param xil_spi_init = {
 		.flags = 0,
-		.type = SPI_PS
+		.type = SPI_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 	};
 
 	struct xil_gpio_init_param xil_gpio_init = {
 		.device_id = GPIO_DEVICE_ID,
-		.type = GPIO_PS
+		.type = GPIO_PS,
+#ifdef SDT
+		.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 	};
 
 	struct no_os_gpio_init_param gpio_ce_param = {

--- a/projects/adrv9001/src/app/headless.c
+++ b/projects/adrv9001/src/app/headless.c
@@ -208,6 +208,9 @@ static int32_t iio_run(struct iio_axi_adc_init_param *adc_pars,
 	struct iio_app_device app_devices[IIO_DEV_COUNT * 2] = {0};
 	struct xil_uart_init_param platform_uart_init_par = {
 		.type = UART_PS,
+#ifdef SDT
+		.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 		.irq_id = UART_IRQ_ID
 	};
 

--- a/projects/adrv9001/src/hal/no_os_platform.c
+++ b/projects/adrv9001/src/hal/no_os_platform.c
@@ -73,16 +73,28 @@ int32_t no_os_hw_open(void *devHalCfg)
 	struct xil_gpio_init_param gip_extra = {
 #ifdef PLATFORM_MB
 		.type = GPIO_PL,
+#ifdef SDT
+		.base_addr = XPAR_XGPIO_0_BASEADDR,
+#endif
 #else
 		.type = GPIO_PS,
+#ifdef SDT
+		.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 #endif
 		.device_id = GPIO_DEVICE_ID
 	};
 	struct xil_spi_init_param sip_extra = {
 #ifdef PLATFORM_MB
 		.type = SPI_PL,
+#ifdef SDT
+		.base_addr = XPAR_XSPI_0_BASEADDR,
+#endif
 #else
 		.type = SPI_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 #endif
 		.flags = 0
 	};

--- a/projects/adrv9009/src/app/app_clocking.c
+++ b/projects/adrv9009/src/app/app_clocking.c
@@ -359,8 +359,14 @@ adiHalErr_t clocking_init(uint32_t rx_div40_rate_hz,
 	struct xil_spi_init_param xil_spi_param = {
 #ifdef PLATFORM_MB
 		.type = SPI_PL,
+#ifdef SDT
+		.base_addr = XPAR_XSPI_0_BASEADDR,
+#endif
 #else
 		.type = SPI_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 #endif
 #if defined(ZU11EG) || defined(FMCOMMS8_ZCU102)
 		.flags = SPI_CS_DECODE
@@ -370,8 +376,14 @@ adiHalErr_t clocking_init(uint32_t rx_div40_rate_hz,
 	struct xil_gpio_init_param xil_gpio_param = {
 #ifdef PLATFORM_MB
 		.type = GPIO_PL,
+#ifdef SDT
+		.base_addr = XPAR_XGPIO_0_BASEADDR,
+#endif
 #else
 		.type = GPIO_PS,
+#ifdef SDT
+		.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 #endif
 		.device_id = GPIO_DEVICE_ID,
 	};

--- a/projects/adrv9009/src/app/headless_arm.c
+++ b/projects/adrv9009/src/app/headless_arm.c
@@ -64,8 +64,14 @@ int32_t start_iiod(struct axi_dmac *rx_dmac, struct axi_dmac *tx_dmac,
 	struct xil_uart_init_param platform_uart_init_par = {
 #ifdef XPAR_XUARTLITE_NUM_INSTANCES
 		.type = UART_PL,
+#ifdef SDT
+		.base_addr = XPAR_XUARTLITE_0_BASEADDR,
+#endif
 #else
 		.type = UART_PS,
+#ifdef SDT
+		.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 		.irq_id = UART_IRQ_ID
 #endif
 	};
@@ -240,16 +246,28 @@ int main(void)
 	struct xil_spi_init_param hal_spi_param = {
 #ifdef PLATFORM_MB
 		.type = SPI_PL,
+#ifdef SDT
+		.base_addr = XPAR_XSPI_0_BASEADDR,
+#endif
 #else
 		.type = SPI_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 #endif
 		.flags = SPI_CS_DECODE
 	};
 	struct xil_gpio_init_param hal_gpio_param = {
 #ifdef PLATFORM_MB
 		.type = GPIO_PL,
+#ifdef SDT
+		.base_addr = XPAR_XGPIO_0_BASEADDR,
+#endif
 #else
 		.type = GPIO_PS,
+#ifdef SDT
+		.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 #endif
 		.device_id = GPIO_DEVICE_ID
 	};

--- a/projects/adrv9009/src/app/headless_mb.c
+++ b/projects/adrv9009/src/app/headless_mb.c
@@ -60,8 +60,14 @@ int32_t start_iiod(struct axi_dmac *rx_dmac, struct axi_dmac *tx_dmac,
 	struct xil_uart_init_param platform_uart_init_par = {
 #ifdef XPAR_XUARTLITE_NUM_INSTANCES
 		.type = UART_PL,
+#ifdef SDT
+		.base_addr = XPAR_XUARTLITE_0_BASEADDR,
+#endif
 #else
 		.type = UART_PS,
+#ifdef SDT
+		.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 		.irq_id = UART_IRQ_ID
 #endif
 	};
@@ -230,16 +236,28 @@ int main(void)
 	struct xil_spi_init_param hal_spi_param = {
 #ifdef PLATFORM_MB
 		.type = SPI_PL,
+#ifdef SDT
+		.base_addr = XPAR_XSPI_0_BASEADDR,
+#endif
 #else
 		.type = SPI_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 #endif
 		.flags = SPI_CS_DECODE
 	};
 	struct xil_gpio_init_param hal_gpio_param = {
 #ifdef PLATFORM_MB
 		.type = GPIO_PL,
+#ifdef SDT
+		.base_addr = XPAR_XGPIO_0_BASEADDR,
+#endif
 #else
 		.type = GPIO_PS,
+#ifdef SDT
+		.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 #endif
 		.device_id = GPIO_DEVICE_ID
 	};
@@ -334,8 +352,14 @@ int main(void)
 	struct xil_spi_init_param xil_spi_param = {
 #ifdef PLATFORM_MB
 		.type = SPI_PL,
+#ifdef SDT
+		.base_addr = XPAR_XSPI_0_BASEADDR,
+#endif
 #else
 		.type = SPI_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 #endif
 #if defined(ZU11EG) || defined(FMCOMMS8_ZCU102)
 		.flags = SPI_CS_DECODE
@@ -358,8 +382,14 @@ int main(void)
 	struct xil_gpio_init_param xil_gpio_param = {
 #ifdef PLATFORM_MB
 		.type = GPIO_PL,
+#ifdef SDT
+		.base_addr = XPAR_XGPIO_0_BASEADDR,
+#endif
 #else
 		.type = GPIO_PS,
+#ifdef SDT
+		.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 #endif
 		.device_id = GPIO_DEVICE_ID,
 	};

--- a/projects/adrv9009/src/app/headless_zu.c
+++ b/projects/adrv9009/src/app/headless_zu.c
@@ -120,10 +120,16 @@ int main(void)
 
 	struct xil_spi_init_param hal_spi_param = {
 		.type = SPI_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 		.flags = SPI_CS_DECODE
 	};
 	struct xil_gpio_init_param hal_gpio_param = {
 		.type = GPIO_PS,
+#ifdef SDT
+		.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 		.device_id = GPIO_DEVICE_ID
 	};
 
@@ -260,6 +266,9 @@ int main(void)
 
 	struct xil_spi_init_param xil_spi_param = {
 		.type = SPI_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 		.flags = SPI_CS_DECODE
 	};
 

--- a/projects/adrv902x/src/examples/iio_example/iio_example.c
+++ b/projects/adrv902x/src/examples/iio_example/iio_example.c
@@ -558,8 +558,14 @@ int iio_example_main(void)
 	struct xil_uart_init_param platform_uart_init_par = {
 #ifdef XPAR_XUARTLITE_NUM_INSTANCES
 		.type = UART_PL,
+#ifdef SDT
+		.base_addr = XPAR_XUARTLITE_0_BASEADDR,
+#endif
 #else
 		.type = UART_PS,
+#ifdef SDT
+		.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 		.irq_id = UART_IRQ_ID
 #endif
 	};

--- a/projects/adrv902x/src/platform/xilinx/parameters.c
+++ b/projects/adrv902x/src/platform/xilinx/parameters.c
@@ -36,17 +36,29 @@
 struct xil_spi_init_param spi_extra = {
 #ifdef PLATFORM_MB
 	.type = SPI_PL,
+#ifdef SDT
+	.base_addr = XPAR_XSPI_0_BASEADDR,
+#endif
 #else
 	.type = SPI_PS,
+#ifdef SDT
+	.base_addr = XPAR_XSPIPS_0_BASEADDR,
 #endif
-	.flags = 0
+#endif
+	.flags = 0,
 };
 
 struct xil_gpio_init_param xil_gpio_param = {
 #ifdef PLATFORM_MB
 	.type = GPIO_PL,
+#ifdef SDT
+	.base_addr = XPAR_XGPIO_0_BASEADDR,
+#endif
 #else
 	.type = GPIO_PS,
+#ifdef SDT
+	.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 #endif
 	.device_id = GPIO_DEVICE_ID,
 };

--- a/projects/adrv903x/src/examples/iio_example/iio_example.c
+++ b/projects/adrv903x/src/examples/iio_example/iio_example.c
@@ -541,8 +541,14 @@ int example_main()
 	struct xil_uart_init_param platform_uart_init_par = {
 #ifdef XPAR_XUARTLITE_NUM_INSTANCES
 		.type = UART_PL,
+#ifdef SDT
+		.base_addr = XPAR_XUARTLITE_0_BASEADDR,
+#endif
 #else
 		.type = UART_PS,
+#ifdef SDT
+		.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 		.irq_id = UART_IRQ_ID
 #endif
 	};

--- a/projects/adrv903x/src/platform/xilinx/parameters.c
+++ b/projects/adrv903x/src/platform/xilinx/parameters.c
@@ -38,8 +38,14 @@
 struct xil_spi_init_param spi_extra = {
 #ifdef PLATFORM_MB
 	.type = SPI_PL,
+#ifdef SDT
+	.base_addr = XPAR_XSPI_0_BASEADDR,
+#endif
 #else
 	.type = SPI_PS,
+#ifdef SDT
+	.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 #endif
 	.flags = 0
 };
@@ -47,8 +53,14 @@ struct xil_spi_init_param spi_extra = {
 struct xil_gpio_init_param xil_gpio_param = {
 #ifdef PLATFORM_MB
 	.type = GPIO_PL,
+#ifdef SDT
+	.base_addr = XPAR_XGPIO_0_BASEADDR,
+#endif
 #else
 	.type = GPIO_PS,
+#ifdef SDT
+	.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 #endif
 	.device_id = GPIO_DEVICE_ID,
 };

--- a/projects/adrv904x/src/examples/iio_example/iio_example.c
+++ b/projects/adrv904x/src/examples/iio_example/iio_example.c
@@ -401,8 +401,14 @@ int iio_example_main(void)
 	struct xil_uart_init_param platform_uart_init_par = {
 #ifdef XPAR_XUARTLITE_NUM_INSTANCES
 		.type = UART_PL,
+#ifdef SDT
+		.base_addr = XPAR_XUARTLITE_0_BASEADDR,
+#endif
 #else
 		.type = UART_PS,
+#ifdef SDT
+		.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 		.irq_id = UART_IRQ_ID
 #endif
 	};

--- a/projects/adrv904x/src/platform/xilinx/parameters.c
+++ b/projects/adrv904x/src/platform/xilinx/parameters.c
@@ -49,17 +49,29 @@
 struct xil_spi_init_param spi_extra = {
 #ifdef PLATFORM_MB
 	.type = SPI_PL,
+#ifdef SDT
+	.base_addr = XPAR_XSPI_0_BASEADDR,
+#endif
 #else
 	.type = SPI_PS,
+#ifdef SDT
+	.base_addr = XPAR_XSPIPS_0_BASEADDR,
 #endif
-	.flags = 0
+#endif
+	.flags = 0,
 };
 
 struct xil_gpio_init_param xil_gpio_param = {
 #ifdef PLATFORM_MB
 	.type = GPIO_PL,
+#ifdef SDT
+	.base_addr = XPAR_XGPIO_0_BASEADDR,
+#endif
 #else
 	.type = GPIO_PS,
+#ifdef SDT
+	.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 #endif
 	.device_id = GPIO_DEVICE_ID,
 };

--- a/projects/adv7511/src/main.c
+++ b/projects/adv7511/src/main.c
@@ -186,6 +186,9 @@ static int32_t app_set_i2c_mux(struct no_os_i2c_desc *adv7511_i2c)
 
 	i2c_mux_init_extra.device_id = XPAR_AXI_IIC_MAIN_DEVICE_ID;
 	i2c_mux_init_extra.type = IIC_PL;
+#ifdef SDT
+	i2c_mux_init_extra.base_addr = XPAR_XIIC_0_BASEADDR;
+#endif
 	i2c_mux_init.max_speed_hz = 400000;
 	i2c_mux_init.slave_address = mux_addr;
 	i2c_mux_init.platform_ops = &xil_i2c_ops;
@@ -326,6 +329,9 @@ int main()
 
 	adv7511_extra_i2c_init.device_id = XPAR_AXI_IIC_MAIN_DEVICE_ID;
 	adv7511_extra_i2c_init.type = IIC_PL;
+#ifdef SDT
+	adv7511_extra_i2c_init.base_addr = XPAR_XIIC_0_BASEADDR;
+#endif
 	adv7511_i2c_init.device_id = XPAR_AXI_IIC_MAIN_DEVICE_ID;
 	adv7511_i2c_init.max_speed_hz = 400000;
 	adv7511_i2c_init.slave_address = 0x39;
@@ -334,6 +340,9 @@ int main()
 #if defined(_XPARAMETERS_PS_H_)
 	xil_timer_init.active_tmr = 0;
 	xil_timer_init.type = TIMER_PS;
+#ifdef SDT
+	xil_timer_init.base_addr = XPAR_XSCUTIMER_0_BASEADDR;
+#endif
 	timer_init.id = XPAR_XSCUTIMER_0_DEVICE_ID;
 	timer_init.freq_hz = XPAR_CPU_CORTEXA9_CORE_CLOCK_FREQ_HZ / 2;
 	timer_init.ticks_count = timer_init.freq_hz / 1000;
@@ -342,6 +351,9 @@ int main()
 #else
 	xil_timer_init.active_tmr = 0;
 	xil_timer_init.type = TIMER_PL;
+#ifdef SDT
+	xil_timer_init.base_addr = XPAR_XTMRCTR_0_BASEADDR;
+#endif
 	timer_init.id = XPAR_AXI_TIMER_DEVICE_ID;
 	timer_init.freq_hz = XPAR_AXI_TIMER_CLOCK_FREQ_HZ;
 	timer_init.ticks_count = timer_init.freq_hz / 1000;
@@ -350,6 +362,9 @@ int main()
 #endif
 #if defined(_XPARAMETERS_PS_H_)
 	gic_init_extra.type = IRQ_PS;
+#ifdef SDT
+	gic_init_extra.base_addr = XPAR_XSCUGIC_0_BASEADDR;
+#endif
 	gic_init.irq_ctrl_id = XPAR_SCUGIC_0_DEVICE_ID;
 #else
 	gic_init_extra.type = IRQ_PL;

--- a/projects/cn0561/src/cn0561.c
+++ b/projects/cn0561/src/cn0561.c
@@ -90,6 +90,9 @@ int main()
 	uint32_t spi_eng_msg_cmds[1];
 	static struct xil_spi_init_param spi_engine_init_params = {
 		.type = SPI_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 	};
 	struct xil_gpio_init_param gpio_extra_param;
 	struct no_os_gpio_init_param cn0561_pnd = {
@@ -153,6 +156,9 @@ int main()
 
 	gpio_extra_param.device_id = GPIO_DEVICE_ID;
 	gpio_extra_param.type = GPIO_PS;
+#ifdef SDT
+	gpio_extra_param.base_addr = XPAR_XGPIOPS_0_BASEADDR;
+#endif
 
 	cn0561_init_param.adc_data_len = ADC_24_BIT_DATA;
 	cn0561_init_param.clk_delay_en = false;
@@ -257,6 +263,9 @@ int main()
 	};
 	struct xil_uart_init_param platform_uart_init_par = {
 		.type = UART_PS,
+#ifdef SDT
+		.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 		.irq_id = UART_IRQ_ID
 	};
 

--- a/projects/display_demo/src/app/main.c
+++ b/projects/display_demo/src/app/main.c
@@ -54,6 +54,9 @@ int main(void)
 
 	struct xil_spi_init_param spi_extra = {
 		.type = SPI_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 		.flags = 0U
 	};
 
@@ -69,6 +72,9 @@ int main(void)
 
 	struct xil_gpio_init_param extra = {
 		.type = GPIO_PS,
+#ifdef SDT
+		.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 		.device_id = XPAR_PS7_GPIO_0_DEVICE_ID
 	};
 

--- a/projects/eval-adxl367z/src/platform/xilinx/parameters.c
+++ b/projects/eval-adxl367z/src/platform/xilinx/parameters.c
@@ -35,5 +35,8 @@
 
 struct xil_spi_init_param spi_extra = {
 	.type = SPI_PS,
-	.flags = 0U
+	.flags = 0U,
+#ifdef SDT
+	.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 };

--- a/projects/fmcdaq2/src/app/fmcdaq2.c
+++ b/projects/fmcdaq2/src/app/fmcdaq2.c
@@ -173,8 +173,14 @@ static int fmcdaq2_gpio_init(struct fmcdaq2_dev *dev)
 	struct xil_gpio_init_param xil_gpio_param = {
 #ifdef PLATFORM_MB
 		.type = GPIO_PL,
+#ifdef SDT
+		.base_addr = XPAR_XGPIO_0_BASEADDR,
+#endif
 #else
 		.type = GPIO_PS,
+#ifdef SDT
+		.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 #endif
 		.device_id = GPIO_DEVICE_ID
 	};
@@ -270,8 +276,14 @@ static int fmcdaq2_spi_init(struct fmcdaq2_init_param *dev_init)
 	static struct xil_spi_init_param xil_spi_param = {
 #ifdef PLATFORM_MB
 		.type = SPI_PL,
+#ifdef SDT
+		.base_addr = XPAR_XSPI_0_BASEADDR,
+#endif
 #else
 		.type = SPI_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 #endif
 	};
 	ad9523_spi_param.platform_ops = &xil_spi_ops;
@@ -694,8 +706,14 @@ static int fmcdaq2_iio_init(struct fmcdaq2_dev *dev,
 	struct xil_uart_init_param platform_uart_init_par = {
 #ifdef XPAR_XUARTLITE_NUM_INSTANCES
 		.type = UART_PL,
+#ifdef SDT
+		.base_addr = XPAR_XUARTLITE_0_BASEADDR,
+#endif
 #else
 		.type = UART_PS,
+#ifdef SDT
+		.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 		.irq_id = UART_IRQ_ID
 #endif
 	};

--- a/projects/fmcdaq3/src/app/fmcdaq3.c
+++ b/projects/fmcdaq3/src/app/fmcdaq3.c
@@ -152,8 +152,14 @@ int main(void)
 	struct xil_spi_init_param xil_spi_param = {
 #ifdef PLATFORM_MB
 		.type = SPI_PL,
+#ifdef SDT
+		.base_addr = XPAR_XSPI_0_BASEADDR,
+#endif
 #else
 		.type = SPI_PS,
+#ifdef SDT
+		.base_addr = XPAR_XSPIPS_0_BASEADDR,
+#endif
 #endif
 	};
 	ad9528_spi_param.platform_ops = &xil_spi_ops;
@@ -188,8 +194,14 @@ int main(void)
 	struct xil_gpio_init_param xil_gpio_param = {
 #ifdef PLATFORM_MB
 		.type = GPIO_PL,
+#ifdef SDT
+		.base_addr = XPAR_XGPIO_0_BASEADDR,
+#endif
 #else
 		.type = GPIO_PS,
+#ifdef SDT
+		.base_addr = XPAR_XGPIOPS_0_BASEADDR,
+#endif
 #endif
 		.device_id = GPIO_DEVICE_ID
 	};
@@ -645,8 +657,14 @@ int main(void)
 	struct xil_uart_init_param platform_uart_init_par = {
 #ifdef XPAR_XUARTLITE_NUM_INSTANCES
 		.type = UART_PL,
+#ifdef SDT
+		.base_addr = XPAR_XUARTLITE_0_BASEADDR,
+#endif
 #else
 		.type = UART_PS,
+#ifdef SDT
+		.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 		.irq_id = UART_IRQ_ID
 #endif
 	};

--- a/projects/hello_world/src/platform/xilinx/parameters.c
+++ b/projects/hello_world/src/platform/xilinx/parameters.c
@@ -43,8 +43,14 @@
 struct xil_uart_init_param hello_world_uart_extra_ip = {
 #ifdef XPAR_XUARTLITE_NUM_INSTANCES
 	.type = UART_PL,
+#ifdef SDT
+	.base_addr = XPAR_XUARTLITE_0_BASEADDR,
+#endif
 #else
 	.type = UART_PS,
+#ifdef SDT
+	.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 	.irq_id = UART_IRQ_ID,
 #endif
 };

--- a/projects/iio_demo/src/platform/xilinx/parameters.c
+++ b/projects/iio_demo/src/platform/xilinx/parameters.c
@@ -36,8 +36,14 @@
 struct xil_uart_init_param iio_demo_uart_extra_ip = {
 #ifdef XPAR_XUARTLITE_NUM_INSTANCES
 	.type = UART_PL,
+#ifdef SDT
+	.base_addr = XPAR_XUARTLITE_0_BASEADDR,
+#endif
 #else
 	.type = UART_PS,
-	.irq_id = UART_IRQ_ID
+	.irq_id = UART_IRQ_ID,
+#ifdef SDT
+	.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 #endif
 };

--- a/projects/pulsar-adc/src/platform/xilinx/parameters.c
+++ b/projects/pulsar-adc/src/platform/xilinx/parameters.c
@@ -36,9 +36,15 @@
 struct xil_uart_init_param uart_extra_ip = {
 #ifdef XPAR_XUARTLITE_NUM_INSTANCES
 	.type = UART_PL,
+#ifdef SDT
+	.base_addr = XPAR_XUARTLITE_0_BASEADDR,
+#endif
 #else
 	.type = UART_PS,
-	.irq_id = UART_IRQ_ID
+	.irq_id = UART_IRQ_ID,
+#ifdef SDT
+	.base_addr = XPAR_XUARTPS_0_BASEADDR,
+#endif
 #endif
 };
 

--- a/tools/scripts/platform/xilinx/util.py
+++ b/tools/scripts/platform/xilinx/util.py
@@ -145,13 +145,9 @@ def create_project(ws, hw_path, hw_file, target):
     client = vitis.create_client(workspace=out_dir)
     client.create_platform_component(
         name="hw0", hw_design=xsa, cpu=vcpu, os="standalone")
-    vitis.dispose()
 
-    # Reconnect: building immediately after create_platform_component on
-    # the same gRPC session fails with "Application error processing RPC".
-    # A fresh client session avoids this.
+    # Build the platform. No need to reconnect - just get the component.
     print("INFO: Building platform (BSP + FSBL)...")
-    client = vitis.create_client(workspace=out_dir)
     platform = client.get_component(name="hw0")
     platform.build()
 

--- a/tools/scripts/xilinx.mk
+++ b/tools/scripts/xilinx.mk
@@ -183,6 +183,13 @@ else
 LIB_FLAGS += -Wl,--start-group,-lxil,-lgcc,-lc,-lm,--end-group
 endif
 
+# SDT (System Device Tree) mode for Vitis 2025+.  The BSP is compiled with
+# -DSDT, which changes struct layouts and API signatures.  App code must use
+# the same define so ABI matches.
+ifeq ($(shell test $(VITIS_YEAR) -ge 2025 && echo y),y)
+CFLAGS += -DSDT
+endif
+
 # Add the common include paths
 CFLAGS += -I$(BUILD_DIR)/app/src
 # Xilinx's bsp include path


### PR DESCRIPTION
## Pull Request Description

Vitis 2025+ uses SDT (System Device Tree) mode, which breaks the existing Xilinx platform drivers in several ways:

- BSP is compiled with -DSDT, changing config struct layouts (e.g. XSpiPs_Config uses char *Name instead of u16 DeviceId)
- LookupConfig() APIs now take a BaseAddress instead of a DeviceId
- XPAR_*_DEVICE_ID macros are no longer generated; some interrupt macros were renamed (_INTR → _INTERRUPTS)

This PR restores Xilinx builds on Vitis 2025+ while remaining backward compatible with Vitis 2023/2024:

- Adds a base_addr field to the Xilinx platform init_param structs; in SDT mode the drivers pass it to LookupConfig(). All new code is #ifdef SDT-guarded, so older toolchains compile unchanged.
- Reads the SPI input clock from config->InputClockHz instead of the removed XPAR_*_SPI_CLK_FREQ_HZ macros (byte-identical value, works on PS7/PSU/Versal).
- Extends xilinx_compat.h with fallback DEVICE_ID/INTR defines so projects need no per-file macro churn.
- Updates 12 project parameters.c files to set base_addr under #ifdef SDT

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
