### PR TITLE
platform: stm32: fix SPI DMA timeout underflow

### DIFF
--- a/drivers/platform/stm32/stm32_spi.c
+++ b/drivers/platform/stm32/stm32_spi.c
@@ -672,16 +672,17 @@ int32_t stm32_spi_transfer_dma(struct no_os_spi_desc* desc,
 	sdesc->stm32_spi_dma_done = false;
 	stm32_config_dma_and_start(desc, msgs, len, stm32_spi_dma_callback, desc);
 	timeout = msgs->bytes_number;
-	while (timeout--) {
+	while (timeout > 0) {
 		no_os_mdelay(1);
 		if (sdesc->stm32_spi_dma_done)
 			break;
+		timeout--;
 	};
 
-	/* need some cleanup here? */
-	if (timeout == 0)
+	if (!sdesc->stm32_spi_dma_done) {
+		/* need some cleanup here? */
 		return -ETIME;
-
+	}
 	return 0;
 }
 

--- a/drivers/platform/stm32/stm32_xspi.c
+++ b/drivers/platform/stm32/stm32_xspi.c
@@ -693,14 +693,14 @@ static int32_t stm32_xspi_transfer_dma(struct no_os_spi_desc *desc,
 		return ret;
 
 	timeout = msgs->bytes_number;
-	while (timeout--) {
+	while (timeout > 0) {
 		no_os_mdelay(1);
 		if (sdesc->stm32_xspi_dma_done)
 			break;
+		timeout--;
 	};
 
-	/* need some cleanup here? */
-	if (timeout == 0) {
+	if (!sdesc->stm32_xspi_dma_done) {
 		no_os_dma_xfer_abort(sdesc->dma_desc, sdesc->dma_ch);
 		return -ETIME;
 	}


### PR DESCRIPTION
This fixes an issue where an integer underflow in the timeout loop masks DMA failures and creates a race condition that reports false timeouts.

Resolves #3115

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
