### PR TITLE
projects: add ad74414h support

### DIFF
--- a/doc/sphinx/source/projects/adc-dac/ad74414h.rst
+++ b/doc/sphinx/source/projects/adc-dac/ad74414h.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../../projects/ad74414h/README.rst

--- a/projects/ad74414h/Makefile
+++ b/projects/ad74414h/Makefile
@@ -1,0 +1,9 @@
+EXAMPLE ?= basic
+
+include ../../tools/scripts/generic_variables.mk
+
+include ../../tools/scripts/examples.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/ad74414h/README.rst
+++ b/projects/ad74414h/README.rst
@@ -1,0 +1,169 @@
+AD74414H no-OS Project
+======================
+
+Supported Evaluation Boards
+---------------------------
+
+- :adi:`EVAL-AD74414H`
+
+Overview
+---------
+
+The AD74414H is a quad-channel, software-configurable device designed
+for robust industrial control applications. It offers versatile analog
+and digital I/O capabilities for measuring voltage, current, RTD, and
+thermocouples while incorporating a 16-bit DAC and a 24-bit sigma-delta
+ADC with optional 50Hz/60Hz rejection. Each channel features an
+integrated HART modem that provides both HART and SPI communications
+using configurable pin assignments that support multiple operation
+modes. This is complemented by adaptive power switching, built-in
+diagnostics for open-circuit/short-circuit detection, a high-accuracy
+2.5V reference, and auxiliary channels for sensing and power supply
+measurements.
+
+Applications
+------------
+
+- Industrial control systems
+- Process control
+- Factory automation
+
+No-OS Build Setup
+-----------------
+
+Please see: :dokuwiki:`No-OS Build Setup </resources/no-os/build>`
+
+No-OS Supported Examples
+------------------------
+
+The initialization data used in the examples is taken from the
+:git-no-OS:`Project Common Data Path </projects/ad74414h/src/common>`.
+The macros used in Common Data are defined in platform-specific files found in:
+:git-no-OS:`Platform Configuration Path </projects/ad74414h/src/platform>`.
+
+Basic Example
+~~~~~~~~~~~~~
+
+The Basic Example demonstrates the fundamental initialization and
+configuration of the AD74414H device by setting up communication
+interfaces such as UART and SPI using common data structures in a
+no-OS environment. To enable the Basic Example and disable other
+examples, update the :git-no-OS:`Makefile </projects/ad74414h/Makefile>`
+with the following settings:
+
+.. code-block:: bash
+
+    # Enable Basic Example
+    EXAMPLE = basic
+
+Current Input External Power Example
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Current Input External Power Example demonstrates channel
+configuration in externally powered current input mode. It reads the
+ADC value and computes the input current. To enable this example, update
+the :git-no-OS:`Makefile </projects/ad74414h/Makefile>` with the
+following settings:
+
+.. code-block:: bash
+
+    # Enable Current Input External Power Example
+    EXAMPLE = current_input_ext
+
+Current Input Loop Power Example
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Current Input Loop Power Example demonstrates channel configuration
+in loop-powered current input mode. It reads the ADC value and computes
+the input current. To enable this example, update the
+:git-no-OS:`Makefile </projects/ad74414h/Makefile>` with the following
+settings:
+
+.. code-block:: bash
+
+    # Enable Current Input Loop Power Example
+    EXAMPLE = current_input_loop
+
+Current Output Example
+~~~~~~~~~~~~~~~~~~~~~~
+
+The Current Output Example demonstrates channel configuration in
+current output mode. It sets a DAC code to drive a specified output
+current on the configured channel. To enable this example, update the
+:git-no-OS:`Makefile </projects/ad74414h/Makefile>` with the following
+settings:
+
+.. code-block:: bash
+
+    # Enable Current Output Example
+    EXAMPLE = current_output
+
+Digital Input Logic Example
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Digital Input Logic Example demonstrates channel configuration in
+digital input mode with a fixed comparator threshold for logic-level
+detection. To enable this example, update the
+:git-no-OS:`Makefile </projects/ad74414h/Makefile>` with the following
+settings:
+
+.. code-block:: bash
+
+    # Enable Digital Input Logic Example
+    EXAMPLE = digital_input_logic
+
+Digital Input Loop Example
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Digital Input Loop Example demonstrates channel configuration in
+digital input mode with loop-powered operation. To enable this example,
+update the :git-no-OS:`Makefile </projects/ad74414h/Makefile>` with the
+following settings:
+
+.. code-block:: bash
+
+    # Enable Digital Input Loop Example
+    EXAMPLE = digital_input_loop
+
+Digital Output Example
+~~~~~~~~~~~~~~~~~~~~~~
+
+The Digital Output Example demonstrates channel configuration in
+digital output mode with GPIO-based control of the output state. To
+enable this example, update the
+:git-no-OS:`Makefile </projects/ad74414h/Makefile>` with the following
+settings:
+
+.. code-block:: bash
+
+    # Enable Digital Output Example
+    EXAMPLE = digital_output
+
+No-OS Supported Platforms
+-------------------------
+
+Mbed Platform
+~~~~~~~~~~~~~
+
+Used Hardware
+^^^^^^^^^^^^^
+
+- :adi:`EVAL-AD74414H`
+- :adi:`EVAL-SDP-CK1Z`
+
+Build Command
+^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+    # Clean previous build artifacts
+    make clean
+
+    # Build the project for the Mbed platform
+    make PLATFORM=mbed
+
+    # Flash the firmware
+    make flash
+
+    # Start a debugging session
+    make debug

--- a/projects/ad74414h/builds.json
+++ b/projects/ad74414h/builds.json
@@ -1,0 +1,25 @@
+{
+  "mbed": {
+    "basic_example": {
+      "flags" : "EXAMPLE=basic"
+    },
+    "current_input_ext": {
+      "flags" : "EXAMPLE=current_input_ext"
+    },
+    "current_input_loop": {
+      "flags" : "EXAMPLE=current_input_loop"
+    },
+    "current_output": {
+      "flags" : "EXAMPLE=current_output"
+    },
+    "digital_input_logic": {
+      "flags" : "EXAMPLE=digital_input_logic"
+    },
+    "digital_input_loop": {
+      "flags" : "EXAMPLE=digital_input_loop"
+    },
+    "digital_output": {
+      "flags" : "EXAMPLE=digital_output"
+    }
+  }
+}

--- a/projects/ad74414h/src.mk
+++ b/projects/ad74414h/src.mk
@@ -1,0 +1,33 @@
+INCS += $(INCLUDE)/no_os_delay.h     \
+		$(INCLUDE)/no_os_error.h     \
+		$(INCLUDE)/no_os_gpio.h      \
+		$(INCLUDE)/no_os_print_log.h \
+		$(INCLUDE)/no_os_spi.h       \
+		$(INCLUDE)/no_os_irq.h      \
+		$(INCLUDE)/no_os_list.h      \
+		$(INCLUDE)/no_os_timer.h      \
+		$(INCLUDE)/no_os_uart.h      \
+		$(INCLUDE)/no_os_lf256fifo.h \
+		$(INCLUDE)/no_os_util.h \
+		$(INCLUDE)/no_os_units.h \
+		$(INCLUDE)/no_os_init.h \
+		$(INCLUDE)/no_os_crc8.h \
+		$(INCLUDE)/no_os_alloc.h \
+		$(INCLUDE)/no_os_mutex.h \
+		$(INCLUDE)/no_os_dma.h
+
+SRCS += $(DRIVERS)/api/no_os_gpio.c \
+		$(NO-OS)/util/no_os_lf256fifo.c \
+		$(DRIVERS)/api/no_os_irq.c  \
+		$(DRIVERS)/api/no_os_spi.c  \
+		$(DRIVERS)/api/no_os_timer.c  \
+		$(DRIVERS)/api/no_os_uart.c \
+		$(NO-OS)/util/no_os_list.c \
+		$(NO-OS)/util/no_os_util.c \
+		$(NO-OS)/util/no_os_crc8.c \
+		$(NO-OS)/util/no_os_alloc.c \
+		$(NO-OS)/util/no_os_mutex.c \
+		$(DRIVERS)/api/no_os_dma.c
+
+INCS += $(DRIVERS)/adc-dac/ad74416h/ad74416h.h
+SRCS += $(DRIVERS)/adc-dac/ad74416h/ad74416h.c

--- a/projects/ad74414h/src/common/common_data.c
+++ b/projects/ad74414h/src/common/common_data.c
@@ -1,0 +1,61 @@
+/***************************************************************************//**
+ *   @file   common_data.c
+ *   @brief  Defines common data to be used by eval-ad74414h examples.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "common_data.h"
+
+struct no_os_uart_init_param ad74414h_uart_ip = {
+	.device_id = UART_DEVICE_ID,
+	.irq_id = UART_IRQ_ID,
+	.asynchronous_rx = true,
+	.baud_rate = UART_BAUDRATE,
+	.size = NO_OS_UART_CS_8,
+	.parity = NO_OS_UART_PAR_NO,
+	.stop = NO_OS_UART_STOP_1_BIT,
+	.extra = UART_EXTRA,
+	.platform_ops = UART_OPS,
+};
+
+struct no_os_spi_init_param ad74414h_spi_ip = {
+	.device_id = SPI_DEVICE_ID,
+	.max_speed_hz = SPI_BAUDRATE,
+	.bit_order = NO_OS_SPI_BIT_ORDER_MSB_FIRST,
+	.mode = NO_OS_SPI_MODE_2,
+	.platform_ops = SPI_OPS,
+	.chip_select = SPI_CS,
+	.extra = SPI_EXTRA,
+};
+
+struct ad74416h_init_param ad74414h_ip = {
+	.id = ID_AD74414H,
+	.dev_addr = 0,
+};

--- a/projects/ad74414h/src/common/common_data.h
+++ b/projects/ad74414h/src/common/common_data.h
@@ -1,0 +1,43 @@
+/***************************************************************************//**
+ *   @file   ad74414h/src/common/common_data.h
+ *   @brief  Defines common data to be used by eval-ad74414h examples.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __COMMON_DATA_H__
+#define __COMMON_DATA_H__
+
+#include "parameters.h"
+#include "ad74416h.h"
+
+extern struct no_os_uart_init_param ad74414h_uart_ip;
+extern struct no_os_spi_init_param ad74414h_spi_ip;
+extern struct ad74416h_init_param ad74414h_ip;
+
+#endif /* __COMMON_DATA_H__ */

--- a/projects/ad74414h/src/examples/basic/basic_example.c
+++ b/projects/ad74414h/src/examples/basic/basic_example.c
@@ -1,0 +1,70 @@
+/***************************************************************************//**
+ *   @file   basic_example.c
+ *   @brief  Basic example header for eval-ad74414h project
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "common_data.h"
+#include "ad74416h.h"
+#include "no_os_delay.h"
+#include "no_os_gpio.h"
+#include "no_os_print_log.h"
+
+/***************************************************************************//**
+ * @brief Basic example main execution.
+ *
+ * @return ret - Result of the example execution. If working correctly, will
+ *               execute continuously the while(1) loop and will not return.
+*******************************************************************************/
+int example_main()
+{
+	struct ad74416h_desc *ad74414h_desc;
+	int ret;
+
+	ret = ad74416h_init(&ad74414h_desc, &ad74414h_ip);
+	if (ret)
+		goto error;
+
+	pr_info("ad74414h successfully initialized!\r\n");
+
+	ret = ad74416h_gpio_set(ad74414h_desc, AD74416H_CH_C, NO_OS_GPIO_HIGH);
+	if (ret)
+		goto error_ad74414h;
+
+	pr_info("ad74414h GPO2 set to HIGH\r\n");
+
+	return 0;
+
+error_ad74414h:
+	ad74416h_remove(ad74414h_desc);
+error:
+	pr_info("Error!\r\n");
+	return ret;
+}

--- a/projects/ad74414h/src/examples/current_input_ext/current_input_ext.c
+++ b/projects/ad74414h/src/examples/current_input_ext/current_input_ext.c
@@ -1,0 +1,114 @@
+/***************************************************************************//**
+ *   @file   current_input_ext.c
+ *   @brief  Current input in External power mode example for ad74414h-pmdz
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "common_data.h"
+#include "ad74416h.h"
+#include "no_os_delay.h"
+#include "no_os_print_log.h"
+#include "math.h"
+
+/***************************************************************************//**
+ * @brief Current input External power example main execution.
+ *
+ * @return ret - Result of the example execution. If working correctly, will
+ *               execute continuously the while(1) loop and will not return.
+*******************************************************************************/
+int example_main()
+{
+	struct ad74416h_desc *ad74414h_desc;
+	int ret;
+
+	union ad74416h_live_status status;
+	uint32_t adc_value = 0;
+	double calculated_current = 0;
+
+	ret = ad74416h_init(&ad74414h_desc, &ad74414h_ip);
+	if (ret)
+		goto error;
+
+	pr_info("ad74414h successfully initialized!\r\n");
+
+	//Configure Channel A as Current Input externally powered
+	ret = ad74416h_set_channel_function(ad74414h_desc, 0, AD74416H_CURRENT_IN_EXT);
+	if (ret) {
+		pr_info("Error setting Channel 0 as current input ext powered\r\n");
+		goto error_ad74414h;
+	}
+
+	//Configure the ADC sample rate
+	ret = ad74416h_set_adc_rate(ad74414h_desc, 0, AD74416H_20SPS_50_60HZ_REJECTION);
+	if (ret) {
+		pr_info("Error setting sampling rate to 20SPS\r\n");
+		goto error_ad74414h;
+	}
+
+	//Enable ADC A
+	ret = ad74416h_set_adc_channel_enable(ad74414h_desc, 0, 1);
+	if (ret) {
+		pr_info("Error enabling ADC A\r\n");
+		goto error_ad74414h;
+	}
+	//Set ADC A to continuous conversion
+	ret = ad74416h_set_adc_conv_seq(ad74414h_desc, AD74416H_START_CONT);
+	if (ret) {
+		pr_info("Error enabling continuous conversions in ADC A\r\n");
+		goto error_ad74414h;
+	}
+
+	while (1) {
+		//Check if there is data ready in the ADC
+		ret = ad74416h_get_live(ad74414h_desc, &status);
+		if (ret) {
+			pr_info("Error reading the live status register\r\n");
+			goto error_ad74414h;
+		}
+		//If data is ready, read the ADC result
+		if (status.status_bits.ADC_DATA_RDY == 1) {
+			ret = ad74416h_get_raw_adc_result(ad74414h_desc, 0, &adc_value);
+			if (ret) {
+				pr_info("Error getting raw adc result in ADC A\r\n");
+				goto error_ad74414h;
+			}
+			pr_info("The ADC input value is %0x\r\n", adc_value);
+			calculated_current = (adc_value / pow(2, 24)) * 0.3125 / 12;
+			pr_info("Calculated current = %.6f mA\r\n", calculated_current * 1000);
+		}
+	}
+
+error_ad74414h:
+	ad74416h_remove(ad74414h_desc);
+	return ret;
+error:
+	pr_info("Error %d !\r\n", ret);
+	return ret;
+}

--- a/projects/ad74414h/src/examples/current_input_loop/current_input_loop.c
+++ b/projects/ad74414h/src/examples/current_input_loop/current_input_loop.c
@@ -1,0 +1,127 @@
+/***************************************************************************//**
+ *   @file   current_input_loop.c
+ *   @brief  Current input in Loop power mode example code for ad74414h-pmdz
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "common_data.h"
+#include "ad74416h.h"
+#include "no_os_delay.h"
+#include "no_os_print_log.h"
+#include <math.h>
+
+/***************************************************************************//**
+ * @brief Current input Loop power example main execution.
+ *
+ * @return ret - Result of the example execution. If working correctly, will
+ *               execute continuously the while(1) loop and will not return.
+*******************************************************************************/
+int example_main()
+{
+	struct ad74416h_desc *ad74414h_desc;
+	int ret;
+
+	union ad74416h_live_status status;
+	uint32_t adc_value = 0;
+	uint16_t current_code = 0;
+	double current_input = 0.0;
+
+	ret = ad74416h_init(&ad74414h_desc, &ad74414h_ip);
+	if (ret)
+		goto error;
+
+	pr_info("ad74414h successfully initialized!\r\n");
+
+	//Configure Channel A as Current Input loop powered
+	ret = ad74416h_set_channel_function(ad74414h_desc, 0, AD74416H_CURRENT_IN_LOOP);
+	if (ret) {
+		pr_info("Error setting Channel 0 as current input loop powered\r\n");
+		goto error_ad74414h;
+	}
+
+	//Configure the current output limit
+	ret = ad74416h_dac_current_to_code(ad74414h_desc, 22000, &current_code);
+	if (ret) {
+		pr_info("Error calculating DAC code for desired current\r\n");
+		goto error_ad74414h;
+	}
+	ret = ad74416h_set_channel_dac_code(ad74414h_desc, 0, current_code);
+	if (ret) {
+		pr_info("Error loading current limit into DAC A\r\n");
+		goto error_ad74414h;
+	}
+
+	//Configure the ADC sample rate
+	ret = ad74416h_set_adc_rate(ad74414h_desc, 0, AD74416H_20SPS_50_60HZ_REJECTION);
+	if (ret) {
+		pr_info("Error setting sampling rate to 20SPS\r\n");
+		goto error_ad74414h;
+	}
+
+	//Enable ADC A
+	ret = ad74416h_set_adc_channel_enable(ad74414h_desc, 0, 1);
+	if (ret) {
+		pr_info("Error enabling ADC A\r\n");
+		goto error_ad74414h;
+	}
+	//Set ADC A to continuous conversion
+	ret = ad74416h_set_adc_conv_seq(ad74414h_desc, AD74416H_START_CONT);
+	if (ret) {
+		pr_info("Error enabling continuous conversions in ADC A\r\n");
+		goto error_ad74414h;
+	}
+
+	while (1) {
+		//Check if there is data ready in the ADC
+		ret = ad74416h_get_live(ad74414h_desc, &status);
+		if (ret) {
+			pr_info("Error reading the live status register\r\n");
+			goto error_ad74414h;
+		}
+		//If data is ready, read the ADC result
+		if (status.status_bits.ADC_DATA_RDY == 1) {
+			ret = ad74416h_get_raw_adc_result(ad74414h_desc, 0, &adc_value);
+			if (ret) {
+				pr_info("Error getting raw adc result in ADC A\r\n");
+				goto error_ad74414h;
+			}
+			pr_info("The ADC input value is %0x\r\n", adc_value);
+			current_input = (((double)adc_value / pow(2, 24)) * 0.3125) / 12;
+			pr_info("Calculated input current = %.6f\r\n", current_input * 1000);
+		}
+	}
+
+error_ad74414h:
+	ad74416h_remove(ad74414h_desc);
+	return ret;
+error:
+	pr_info("Error %d !\r\n", ret);
+	return ret;
+}

--- a/projects/ad74414h/src/examples/current_output/current_output.c
+++ b/projects/ad74414h/src/examples/current_output/current_output.c
@@ -1,0 +1,86 @@
+/***************************************************************************//**
+ *   @file   current_output.c
+ *   @brief  Current Output example code for ad74414h-pmdz project
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "common_data.h"
+#include "ad74416h.h"
+#include "no_os_delay.h"
+#include "no_os_print_log.h"
+
+/***************************************************************************//**
+ * @brief Current output example main execution.
+ *
+ * @return ret - Result of the example execution. If working correctly, will
+ *               execute continuously the while(1) loop and will not return.
+*******************************************************************************/
+int example_main()
+{
+	struct ad74416h_desc *ad74414h_desc;
+	int ret;
+	uint16_t dac_code;
+
+	ret = ad74416h_init(&ad74414h_desc, &ad74414h_ip);
+	if (ret)
+		goto error;
+
+	pr_info("ad74414h successfully initialized!\r\n");
+
+	//Configure Channel A as Current Output
+	ret = ad74416h_set_channel_function(ad74414h_desc, 0, AD74416H_CURRENT_OUT);
+	if (ret) {
+		pr_info("Error setting Channel 0 as current output\r\n");
+		goto error_ad74414h;
+	}
+
+	//Calculate the code for the DAC
+	ret = ad74416h_dac_current_to_code(ad74414h_desc, 10000, &dac_code);
+	if (ret) {
+		pr_info("Error calculating the code for the DAC\r\n");
+		goto error_ad74414h;
+	}
+
+	pr_info("The code for the dac for 10mA is %0x\r\n", dac_code);
+
+	//Configure Channel A code to middle range
+	ret = ad74416h_set_channel_dac_code(ad74414h_desc, 0, dac_code);
+	if (ret) {
+		pr_info("Error setting the dac code\r\n");
+		goto error_ad74414h;
+	}
+
+error_ad74414h:
+	ad74416h_remove(ad74414h_desc);
+	return ret;
+error:
+	pr_info("Error %d!\r\n", ret);
+	return ret;
+}

--- a/projects/ad74414h/src/examples/digital_input_logic/digital_input_logic.c
+++ b/projects/ad74414h/src/examples/digital_input_logic/digital_input_logic.c
@@ -1,0 +1,162 @@
+/***************************************************************************//**
+ *   @file   digital_input_logic.c
+ *   @brief  Digital Input Logic example code for ad74414h-pmdz project
+ *           This example configures Channel A as a Digital Input.
+ *           It prints in terminal the DIN value in Channel A
+ *           GPIO_A LED is used as a representation of the DIN value in channel A
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "common_data.h"
+#include "ad74416h.h"
+#include "no_os_delay.h"
+#include "no_os_print_log.h"
+#include "no_os_util.h"
+
+/*******************************************************************************
+ * @brief This function configures the digital input as a Type1/Type3 Digital
+ *        input
+ * @param desc - The device structure
+ * @return ret - Result of the execution.
+*******************************************************************************/
+int configure_di_type1_3(struct ad74416h_desc *desc, uint32_t ch)
+{
+	int ret;
+	//Set a fixed threshold mode
+	ret = ad74416h_reg_update(desc, AD74416H_DIN_CONFIG1(ch),
+				  AD74416H_DIN_THRESH_MODE_MSK, 1);
+	if (ret)
+		return ret;
+	//Set the threshold to 8.5V
+	ret = ad74416h_reg_update(desc, AD74416H_DIN_CONFIG1(ch),
+				  AD74416H_COMP_THRESH_MSK, 0x37);
+	if (ret)
+		return ret;
+	//Configure the current sink to 2.4mA
+	ret = ad74416h_reg_update(desc, AD74416H_DIN_CONFIG0(ch),
+				  AD74416H_DIN_SINK_RANGE_MSK, 0);
+	if (ret)
+		return ret;
+	ret = ad74416h_reg_update(desc, AD74416H_DIN_CONFIG0(ch), AD74416H_DIN_SINK_MSK,
+				  0x14);
+	if (ret)
+		return ret;
+	return 0;
+}
+
+/*******************************************************************************
+ * @brief This function configures the digital input as a Type2 Digital input
+ * @param desc - The device structure
+ * @return ret - Result of the execution.
+*******************************************************************************/
+int configure_di_type2(struct ad74416h_desc *desc, uint32_t ch)
+{
+	int ret;
+	//Set a fixed threshold mode
+	ret = ad74416h_reg_update(desc, AD74416H_DIN_CONFIG1(ch),
+				  AD74416H_DIN_THRESH_MODE_MSK, 1);
+	if (ret)
+		return ret;
+	//Set the threshold to 8.5V
+	ret = ad74416h_reg_update(desc, AD74416H_DIN_CONFIG1(ch),
+				  AD74416H_COMP_THRESH_MSK, 0x37);
+	if (ret)
+		return ret;
+	//Configure the current sink to 6.96mA
+	ret = ad74416h_reg_update(desc, AD74416H_DIN_CONFIG0(ch),
+				  AD74416H_DIN_SINK_RANGE_MSK, 1);
+	if (ret)
+		return ret;
+	ret = ad74416h_reg_update(desc, AD74416H_DIN_CONFIG0(ch), AD74416H_DIN_SINK_MSK,
+				  0x1D);
+	if (ret)
+		return ret;
+	return 0;
+}
+
+/***************************************************************************//**
+ * @brief Digital Input Logic example main execution.
+ *
+ * @return ret - Result of the example execution. If working correctly, will
+ *               execute continuously the while(1) loop and will not return.
+*******************************************************************************/
+int example_main()
+{
+	struct ad74416h_desc *ad74414h_desc;
+	int ret;
+
+	uint8_t dig_input = 0;
+
+	ret = ad74416h_init(&ad74414h_desc, &ad74414h_ip);
+	if (ret)
+		goto error;
+
+	pr_info("ad74414h successfully initialized!\r\n");
+
+	//Configure Channel A as Digital Input Logic mode
+	ret = ad74416h_set_channel_function(ad74414h_desc, 0, AD74416H_DIGITAL_INPUT);
+	if (ret) {
+		pr_info("Error setting Channel 0 as digital input logic mode\r\n");
+		goto error_ad74414h;
+	}
+
+	//Link GPIO_A to DIN0
+	ret = ad74416h_set_gpio_config(ad74414h_desc, 0, AD74416H_GPIO_CONFIG_COMP);
+	if (ret) {
+		pr_info("Error configuring GPIO_A as the output of the DIN comparator\r\n");
+		goto error_ad74414h;
+	}
+
+	//Uncomment the desired function depending on which type of DI is desired
+	ret = configure_di_type1_3(ad74414h_desc, 0);
+	//ret = configure_di_type2(ad74414h_desc, 0);
+	if (ret) {
+		pr_info("Error configuring the DI type\r\n");
+		goto error_ad74414h;
+	}
+
+	while (1) {
+		no_os_mdelay(1000);
+		ret = ad74416h_gpio_get(ad74414h_desc, 0, &dig_input);
+		if (ret) {
+			pr_info("Error getting DIN value\r\n");
+			goto error_ad74414h;
+		}
+		pr_info("DIN Value = %d\r\n", dig_input);
+	}
+
+
+error_ad74414h:
+	ad74416h_remove(ad74414h_desc);
+	return ret;
+error:
+	pr_info("Error %d !\r\n", ret);
+	return ret;
+}

--- a/projects/ad74414h/src/examples/digital_input_loop/digital_input_loop.c
+++ b/projects/ad74414h/src/examples/digital_input_loop/digital_input_loop.c
@@ -1,0 +1,176 @@
+/***************************************************************************//**
+ *   @file   digital_input_loop.c
+ *   @brief  Digital Input Loop Powered example code for ad74414h-pmdz project
+ *	     This example configures Channel A as a Digital Input.
+ *	     It prints in terminal the DIN value in Channel A
+ *	     GPIO_A LED is used as a representation of the DIN value in channel A
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "common_data.h"
+#include "ad74416h.h"
+#include "no_os_delay.h"
+#include "no_os_print_log.h"
+#include "no_os_util.h"
+
+/*******************************************************************************
+ * @brief This function configures the digital input as a Type1/Type3 Digital
+ *        input
+ * @param desc - The device structure
+ * @return ret - Result of the execution.
+*******************************************************************************/
+int configure_di_type1_3(struct ad74416h_desc *desc, uint32_t ch)
+{
+	int ret;
+	//Set a fixed threshold mode
+	ret = ad74416h_reg_update(desc, AD74416H_DIN_CONFIG1(ch),
+				  AD74416H_DIN_THRESH_MODE_MSK, 1);
+	if (ret)
+		return ret;
+	//Set the threshold to 8.5V
+	ret = ad74416h_reg_update(desc, AD74416H_DIN_CONFIG1(ch),
+				  AD74416H_COMP_THRESH_MSK, 0x37);
+	if (ret)
+		return ret;
+	//Configure the current sink to 2.4mA
+	ret = ad74416h_reg_update(desc, AD74416H_DIN_CONFIG0(ch),
+				  AD74416H_DIN_SINK_RANGE_MSK, 0);
+	if (ret)
+		return ret;
+	ret = ad74416h_reg_update(desc, AD74416H_DIN_CONFIG0(ch), AD74416H_DIN_SINK_MSK,
+				  0x14);
+	if (ret)
+		return ret;
+	return 0;
+}
+
+/*******************************************************************************
+ * @brief This function configures the digital input as a Type2 Digital input
+ * @param desc - The device structure
+ * @return ret - Result of the execution.
+*******************************************************************************/
+int configure_di_type2(struct ad74416h_desc *desc, uint32_t ch)
+{
+	int ret;
+	//Set a fixed threshold mode
+	ret = ad74416h_reg_update(desc, AD74416H_DIN_CONFIG1(ch),
+				  AD74416H_DIN_THRESH_MODE_MSK, 1);
+	if (ret)
+		return ret;
+	//Set the threshold to 8.5V
+	ret = ad74416h_reg_update(desc, AD74416H_DIN_CONFIG1(ch),
+				  AD74416H_COMP_THRESH_MSK, 0x37);
+	if (ret)
+		return ret;
+	//Configure the current sink to 6.96mA
+	ret = ad74416h_reg_update(desc, AD74416H_DIN_CONFIG0(ch),
+				  AD74416H_DIN_SINK_RANGE_MSK, 1);
+	if (ret)
+		return ret;
+	ret = ad74416h_reg_update(desc, AD74416H_DIN_CONFIG0(ch), AD74416H_DIN_SINK_MSK,
+				  0x1D);
+	if (ret)
+		return ret;
+	return 0;
+}
+
+/***************************************************************************//**
+ * @brief Digital Input Loop example main execution.
+ *
+ * @return ret - Result of the example execution. If working correctly, will
+ *               execute continuously the while(1) loop and will not return.
+*******************************************************************************/
+int example_main()
+{
+	struct ad74416h_desc *ad74414h_desc;
+	int ret;
+
+	uint16_t current_code = 0;
+	uint8_t dig_input = 0;
+
+	ret = ad74416h_init(&ad74414h_desc, &ad74414h_ip);
+	if (ret)
+		goto error;
+
+	pr_info("ad74414h successfully initialized!\r\n");
+
+	//Configure Channel A as Digital Input Loop mode
+	ret = ad74416h_set_channel_function(ad74414h_desc, 0,
+					    AD74416H_DIGITAL_INPUT_LOOP);
+	if (ret) {
+		pr_info("Error setting Channel 0 as digital input logic mode\r\n");
+		goto error_ad74414h;
+	}
+
+	//Configure the current output limit
+	ret = ad74416h_dac_current_to_code(ad74414h_desc, 9000, &current_code);
+	if (ret) {
+		pr_info("Error calculating DAC code for desired current\r\n");
+		goto error_ad74414h;
+	}
+	ret = ad74416h_set_channel_dac_code(ad74414h_desc, 0, current_code);
+	if (ret) {
+		pr_info("Error loading current limit into DAC A\r\n");
+		goto error_ad74414h;
+	}
+
+	//Link GPIO_A to DIN0
+	ret = ad74416h_set_gpio_config(ad74414h_desc, 0, AD74416H_GPIO_CONFIG_COMP);
+	if (ret) {
+		pr_info("Error configuring GPIO_A as the output of the DIN comparator\r\n");
+		goto error_ad74414h;
+	}
+
+	//Uncomment the desired function depending on which type of DI is desired
+	ret = configure_di_type1_3(ad74414h_desc, 0);
+	//ret = configure_di_type2(ad74414h_desc, 0);
+	if (ret) {
+		pr_info("Error configuring the DI type\r\n");
+		goto error_ad74414h;
+	}
+
+
+	while (1) {
+		no_os_mdelay(1000);
+		ret = ad74416h_gpio_get(ad74414h_desc, 0, &dig_input);
+		if (ret) {
+			pr_info("Error getting DIN value\r\n");
+			goto error_ad74414h;
+		}
+		pr_info("DIN Value = %d\r\n", dig_input);
+	}
+
+error_ad74414h:
+	ad74416h_remove(ad74414h_desc);
+	return ret;
+error:
+	pr_info("Error %d !\r\n", ret);
+	return ret;
+}

--- a/projects/ad74414h/src/examples/digital_output/digital_output.c
+++ b/projects/ad74414h/src/examples/digital_output/digital_output.c
@@ -1,0 +1,107 @@
+/***************************************************************************//**
+ *   @file   digital_output.c
+ *   @brief  Digital Output example code for ad74414h-pmdz project
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "common_data.h"
+#include "ad74416h.h"
+#include "no_os_delay.h"
+#include "no_os_print_log.h"
+#include "no_os_util.h"
+
+int control_doutput_with_gpio(struct ad74416h_desc *desc)
+{
+	int ret;
+	//Configure GPIO_SELECT as DO
+	ret = ad74416h_set_gpio_config(desc, 0, AD74416H_GPIO_CONFIG_DO);
+	if (ret)
+		return ret;
+	//Configure GPIO as the DO source
+	ret = ad74416h_reg_update(desc, AD74416H_DO_EXT_CONFIG(0),
+				  AD74416H_DO_SRC_SEL_MSK, 1);
+	if (ret)
+		return ret;
+	return 0;
+}
+
+/***************************************************************************//**
+ * @brief Digital Output example main execution.
+ *
+ * @return ret - Result of the example execution. If working correctly, will
+ *               execute continuously the while(1) loop and will not return.
+*******************************************************************************/
+int example_main()
+{
+	struct ad74416h_desc *ad74414h_desc;
+	int ret;
+
+	ret = ad74416h_init(&ad74414h_desc, &ad74414h_ip);
+	if (ret)
+		goto error;
+
+	pr_info("ad74414h successfully initialized!\r\n");
+
+	//Configure Channel A as High Impedance
+	ret = ad74416h_set_channel_function(ad74414h_desc, 0, AD74416H_HIGH_Z);
+	if (ret) {
+		pr_info("Error setting Channel 0 as high impedance\r\n");
+		goto error_ad74414h;
+	}
+
+	//Select source capability by setting the DO_MODE bit
+	ret = ad74416h_reg_update(ad74414h_desc, AD74416H_DO_EXT_CONFIG(0),
+				  AD74416H_DO_MODE_MSK, 1);
+	if (ret) {
+		pr_info("Error setting DO Source mode\r\n");
+		goto error_ad74414h;
+	}
+
+	ret = control_doutput_with_gpio(ad74414h_desc);
+	if (ret) {
+		pr_info("Error setting the GPIO as source for the DO\r\n");
+		goto error_ad74414h;
+	}
+
+	//Enable the FET in channel 1. Comment the next block if the user wants to control the DO with the GPIO.
+	ret = ad74416h_reg_update(ad74414h_desc, AD74416H_DO_EXT_CONFIG(0),
+				  AD74416H_DO_DATA_MSK, 1);
+	if (ret) {
+		pr_info("Error enabling the FET in Channel 1\r\n");
+		goto error_ad74414h;
+	}
+
+error_ad74414h:
+	ad74416h_remove(ad74414h_desc);
+	return ret;
+error:
+	pr_info("Error %d !\r\n", ret);
+	return ret;
+}

--- a/projects/ad74414h/src/platform/mbed/main.c
+++ b/projects/ad74414h/src/platform/mbed/main.c
@@ -1,0 +1,65 @@
+/***************************************************************************//**
+ *   @file   main.c
+ *   @brief  Main file for Mbed platform of ad74414h project.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "parameters.h"
+#include "common_data.h"
+
+extern int example_main();
+
+/***************************************************************************//**
+ * @brief Main function for Mbed platform.
+ *
+ * @return ret - Result of the enabled examples.
+*******************************************************************************/
+
+int main()
+{
+	int ret;
+	struct no_os_uart_desc *uart_desc;
+
+	ad74414h_ip.spi_ip = ad74414h_spi_ip;
+
+	ret = no_os_uart_init(&uart_desc, &ad74414h_uart_ip);
+	if (ret)
+		return ret;
+
+	no_os_uart_stdio(uart_desc);
+
+	ret = example_main();
+	if (ret) {
+		no_os_uart_remove(uart_desc);
+		return ret;
+	}
+
+	return 0;
+}

--- a/projects/ad74414h/src/platform/mbed/parameters.c
+++ b/projects/ad74414h/src/platform/mbed/parameters.c
@@ -1,0 +1,71 @@
+/***************************************************************************//**
+ *   @file   parameters.c
+ *   @brief  Definition of Mbed platform data used by ad74414h project.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "parameters.h"
+
+struct mbed_uart_init_param ad74414h_uart_extra_ip = {
+	.uart_tx_pin = UART_TX_PIN,
+	.uart_rx_pin = UART_RX_PIN
+};
+
+struct mbed_spi_init_param ad74414h_spi_extra = {
+	.spi_miso_pin = ARDUINO_UNO_D12,
+	.spi_mosi_pin = ARDUINO_UNO_D11,
+	.spi_clk_pin = ARDUINO_UNO_D13,
+	.use_sw_csb = false
+};
+
+/* ADC_RDY GPIO parameters*/
+struct no_os_gpio_init_param adc_rdy_gpio_ip = {
+	.port = 0,
+	.pull = NO_OS_PULL_NONE,
+	.number = GPIO_ADC_RDY,
+	.platform_ops = GPIO_OPS,
+	.extra = GPIO_EXTRA
+};
+
+/* ADC_RDY GPIO IRQ parameters */
+struct no_os_irq_init_param adc_rdy_gpio_irq_ip = {
+	.irq_ctrl_id = GPIO_IRQ_ADC_ID,
+	.platform_ops = GPIO_IRQ_OPS,
+	.extra = GPIO_IRQ_ADC_EXTRA
+};
+
+struct mbed_gpio_init_param ad74414h_gpio_extra = {
+	.pin_mode = 0 //NA
+};
+
+/*ADC_RDY interrupt Mbed platform specific parameters */
+struct mbed_gpio_irq_init_param mbed_adc_rdy_gpio_irq_extra = {
+	.gpio_irq_pin = ARDUINO_UNO_D2,
+};

--- a/projects/ad74414h/src/platform/mbed/parameters.h
+++ b/projects/ad74414h/src/platform/mbed/parameters.h
@@ -1,0 +1,76 @@
+/***************************************************************************//**
+ *   @file   parameters.h
+ *   @brief  Definitions specific to Mbed platform used by ad74414h
+ *           project.
+ *   @author Antoniu Miclaus (antoniu.miclaus@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
+
+#include <PinNames.h>
+#include "mbed_uart.h"
+#include "mbed_spi.h"
+#include "no_os_uart.h"
+#include "no_os_gpio.h"
+#include "mbed_gpio.h"
+#include "no_os_irq.h"
+#include "mbed_irq.h"
+#include "mbed_gpio_irq.h"
+
+#define UART_TX_PIN	    CONSOLE_TX
+#define	UART_RX_PIN	    CONSOLE_RX
+#define UART_DEVICE_ID  0
+#define UART_IRQ_ID     0
+#define UART_BAUDRATE   115200
+#define UART_EXTRA	&ad74414h_uart_extra_ip
+#define UART_OPS        &mbed_uart_ops
+
+#define SPI_BAUDRATE    1000000
+#define SPI_OPS         &mbed_spi_ops
+#define SPI_EXTRA       &ad74414h_spi_extra
+#define SPI_DEVICE_ID   0
+#define SPI_CS          ARDUINO_UNO_D10
+
+#define GPIO_OPS	&mbed_gpio_ops
+#define GPIO_ADC_RDY	ARDUINO_UNO_D2
+#define GPIO_EXTRA 	&ad74414h_gpio_extra
+
+#define GPIO_IRQ_ADC_ID		0
+#define GPIO_IRQ_OPS		&mbed_gpio_irq_ops
+#define GPIO_IRQ_ADC_EXTRA	&mbed_adc_rdy_gpio_irq_extra
+
+extern struct mbed_uart_init_param ad74414h_uart_extra_ip;
+extern struct mbed_spi_init_param ad74414h_spi_extra;
+extern struct no_os_gpio_init_param adc_rdy_gpio_ip;
+extern struct no_os_irq_init_param adc_rdy_gpio_irq_ip;
+extern struct mbed_gpio_init_param ad74414h_gpio_extra;
+extern struct mbed_gpio_irq_init_param mbed_adc_rdy_gpio_irq_extra;
+
+#endif /* __PARAMETERS_H__ */

--- a/projects/ad74414h/src/platform/mbed/platform_src.mk
+++ b/projects/ad74414h/src/platform/mbed/platform_src.mk
@@ -1,0 +1,12 @@
+INCS += $(PLATFORM_DRIVERS)/mbed_uart.h      \
+		$(PLATFORM_DRIVERS)/mbed_gpio.h      \
+		$(PLATFORM_DRIVERS)/mbed_irq.h       \
+		$(PLATFORM_DRIVERS)/mbed_gpio_irq.h  \
+		$(PLATFORM_DRIVERS)/mbed_spi.h
+
+SRCS += $(PLATFORM_DRIVERS)/mbed_uart.cpp       \
+		$(PLATFORM_DRIVERS)/mbed_gpio.cpp       \
+		$(PLATFORM_DRIVERS)/mbed_irq.cpp        \
+		$(PLATFORM_DRIVERS)/mbed_gpio_irq.cpp   \
+		$(PLATFORM_DRIVERS)/mbed_spi.cpp        \
+		$(PLATFORM_DRIVERS)/mbed_delay.cpp


### PR DESCRIPTION
## Pull Request Description

Add AD74414H project with MBED platform support and examples for all
supported channel modes: basic, current output, current input (external
and loop powered), digital input (logic and loop powered), and digital
output.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
