### PR TITLE
drivers: power: Add driver for LTC4284

### DIFF
--- a/doc/sphinx/source/drivers/power/ltc4284.rst
+++ b/doc/sphinx/source/drivers/power/ltc4284.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../../drivers/power/ltc4284/README.rst

--- a/doc/sphinx/source/projects/power/ltc4284.rst
+++ b/doc/sphinx/source/projects/power/ltc4284.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../../projects/ltc4284/README.rst

--- a/drivers/power/ltc4284/README.rst
+++ b/drivers/power/ltc4284/README.rst
@@ -1,0 +1,312 @@
+LTC4284 - High Power Negative Voltage Hot Swap Controller
+==========================================================
+
+Supported Devices
+-----------------
+
+* `LTC4284 <https://www.analog.com/ltc4284>`_
+
+Overview
+--------
+
+The LTC4284 is a high power negative voltage hot swap controller with integrated
+I²C energy monitor and EEPROM. It provides comprehensive protection and monitoring
+for -48V distributed power systems commonly used in telecom infrastructure, data
+centers, and server applications.
+
+The device drives external N-channel MOSFETs to allow a board to be safely
+inserted and removed from a live backplane. The dual-gate, multi-mode drivers
+optimize the MOSFET safe operating area (SOA) for a variety of power levels,
+with an SOA timer limiting MOSFET temperature rise for reliable protection
+against overstresses.
+
+Features
+--------
+
+* Dual-gate N-channel MOSFET driver for high power applications
+* Configurable operating modes: Parallel, Staged Start, or Single modes
+* MOSFET SOA timer protection
+* Programmable 15mV to 30mV current limit sense voltage with <3.3% accuracy
+* Adjustable current limit foldback
+* 8-bit to 16-bit gear-shift ADC with 0.7% accuracy
+* Monitors voltages, currents, power, and energy
+* Nonvolatile configuration and fault recording via EEPROM
+* Floating topology for rugged high voltage operation
+* Selectable inrush control: dV/dt or current limit modes
+* I²C/SMBus or single-wire broadcast interfaces
+* Min/max ADC measurement logging with programmable alerts
+* Reboots on I²C command with programmable delay
+* Adjustable input UV/OV thresholds and hysteresis
+* 44-Pin 5mm × 8mm QFN Package
+
+Applications
+------------
+
+* -48V Telecom and Datacom Infrastructure
+* -48V Distributed Power Systems
+* Hot-swappable Power Supplies
+* Servers and Data Centers
+* Network Equipment
+* Blade Server Systems
+
+LTC4284 Device Configuration
+-----------------------------
+
+Driver Initialization
+^^^^^^^^^^^^^^^^^^^^^
+
+The LTC4284 driver is initialized using the following structure:
+
+.. code-block:: c
+
+	#include "ltc4284.h"
+
+	struct ltc4284_dev *ltc4284_dev;
+	struct ltc4284_init_param init_param = {
+		.i2c_init = {
+			.device_id = 0,
+			.max_speed_hz = 400000,  /* 400kHz I2C */
+			.platform_ops = &max32_i2c_ops,
+			.extra = &i2c_extra
+		},
+		.i2c_addr = LTC4284_I2C_ADDR_2,  /* Default 0x2A */
+		.rsense_mohm = 500,              /* 0.5mΩ sense resistor */
+		.vsense_mv = 25,                 /* 25mV sense voltage */
+		.alert_gpio = NULL               /* Optional ALERT# pin */
+	};
+
+	ret = ltc4284_init(&ltc4284_dev, &init_param);
+
+I²C Address Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The LTC4284 I²C address is configurable via ADR0 and ADR1 pins:
+
+* **0x28**: ADR0=0, ADR1=0
+* **0x29**: ADR0=1, ADR1=0
+* **0x2A**: ADR0=0, ADR1=1 (default)
+* **0x2B**: ADR0=1, ADR1=1
+
+Current Limiting Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The LTC4284 supports programmable current limiting based on external sense
+resistor (RSENSE) and sense voltage (VSENSE):
+
+**Sense Voltage Options**: 15mV, 20mV, 25mV, 30mV
+
+**Current Limit Calculation**:
+
+.. code-block:: c
+
+	/* Current limit = VSENSE / RSENSE
+	 * Example: 25mV / 0.5mΩ = 50A limit
+	 */
+	uint8_t ilim_code = 0x08;  /* Application-specific */
+	ret = ltc4284_set_current_limit(ltc4284_dev, ilim_code);
+
+Monitoring Functions
+^^^^^^^^^^^^^^^^^^^^
+
+The driver provides monitoring functions for voltage, current, power, and energy:
+
+.. code-block:: c
+
+	uint16_t vin_mv, iin_ma, vout_mv;
+	uint32_t power_mw;
+	uint64_t energy_mj;
+
+	/* Read input voltage */
+	ret = ltc4284_read_vin(ltc4284_dev, &vin_mv);
+
+	/* Read input current */
+	ret = ltc4284_read_iin(ltc4284_dev, &iin_ma);
+
+	/* Read output voltage */
+	ret = ltc4284_read_vout(ltc4284_dev, &vout_mv);
+
+	/* Read power consumption */
+	ret = ltc4284_read_power(ltc4284_dev, &power_mw);
+
+	/* Read cumulative energy */
+	ret = ltc4284_read_energy(ltc4284_dev, &energy_mj);
+
+FET Control
+^^^^^^^^^^^
+
+Control MOSFET gate drivers:
+
+.. code-block:: c
+
+	/* Enable FET drivers for hot swap turn-on */
+	ret = ltc4284_enable_fet(ltc4284_dev, true);
+
+	/* Disable FET drivers for turn-off */
+	ret = ltc4284_enable_fet(ltc4284_dev, false);
+
+Fault Management
+^^^^^^^^^^^^^^^^
+
+Read fault status and clear faults:
+
+.. code-block:: c
+
+	uint8_t status, faults;
+
+	/* Read system status */
+	ret = ltc4284_read_status(ltc4284_dev, &status);
+
+	/* Get fault conditions */
+	ret = ltc4284_get_fault(ltc4284_dev, &faults);
+
+	/* Check individual fault bits */
+	if (faults & LTC4284_FAULT_OV_FAULT_BIT)
+		printf("Overvoltage fault detected\\n");
+
+	if (faults & LTC4284_FAULT_OC_FAULT_BIT)
+		printf("Overcurrent fault detected\\n");
+
+	/* Clear all faults */
+	ret = ltc4284_clear_faults(ltc4284_dev);
+
+EEPROM Configuration
+^^^^^^^^^^^^^^^^^^^^
+
+Store and restore configuration to/from EEPROM:
+
+.. code-block:: c
+
+	/* Store current configuration to EEPROM */
+	ret = ltc4284_store_config(ltc4284_dev);
+
+	/* Restore configuration from EEPROM */
+	ret = ltc4284_restore_config(ltc4284_dev);
+
+LTC4284 no-OS IIO Support
+--------------------------
+
+The LTC4284 driver provides comprehensive IIO (Industrial I/O) subsystem
+integration for real-time telemetry and monitoring.
+
+IIO Channels
+^^^^^^^^^^^^
+
+The driver exposes the following IIO channels:
+
+* **vin** (voltage_in channel 0): Input voltage monitoring
+* **iin** (current_in channel 0): Input current monitoring
+* **vout** (voltage_out channel 1): Output voltage monitoring
+* **power** (power channel 0): Power consumption
+* **energy** (energy channel 0): Cumulative energy accumulation
+
+Each channel provides **raw** and **scale** attributes:
+
+* **raw**: Returns integer value in millivolts/milliamps/milliwatts/millijoules
+* **scale**: Returns conversion factor (1/1000) to base units (V/A/W/J)
+
+IIO Initialization
+^^^^^^^^^^^^^^^^^^
+
+.. code-block:: c
+
+	#include "iio_ltc4284.h"
+
+	struct ltc4284_iio_desc *ltc4284_iio_desc;
+	struct ltc4284_iio_init_param iio_init = {
+		.ltc4284_init = &ltc4284_init_param
+	};
+
+	ret = ltc4284_iio_init(&ltc4284_iio_desc, &iio_init);
+
+Using IIO with pyadi-iio
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Remote monitoring via pyadi-iio:
+
+.. code-block:: python
+
+	import adi
+
+	# Connect to IIO device
+	dev = adi.ltc4284(uri="serial:/dev/ttyUSB0,115200")
+
+	# Read telemetry data
+	vin = dev.voltage_in  # Input voltage (V)
+	iin = dev.current_in  # Input current (A)
+	power = dev.power     # Power consumption (W)
+	energy = dev.energy   # Cumulative energy (J)
+
+	print(f"Input: {vin:.2f}V, {iin:.2f}A")
+	print(f"Power: {power:.2f}W, Energy: {energy:.2f}J")
+
+LTC4284 Driver Architecture
+----------------------------
+
+Register Interface
+^^^^^^^^^^^^^^^^^^
+
+The driver provides a complete register map based on the LTC4284 datasheet:
+
+* **System Status Registers** (0x00-0x04): Status, faults, ADC status
+* **Control Registers** (0x0A-0x0F): System control, configuration
+* **GPIO Configuration** (0x10-0x12): GPIO and ADC I/O configuration
+* **ADC Data Registers** (0x40-0x6C): Voltage, current, power, energy readings
+* **Threshold Registers** (0x1E-0x3D): Min/max thresholds for alarm generation
+* **EEPROM Registers** (0xA2-0xDC): Nonvolatile configuration storage
+
+Multi-Mode Operation
+^^^^^^^^^^^^^^^^^^^^^
+
+The LTC4284 supports four operating modes for dual-gate MOSFET control:
+
+1. **Single Driver Mode (Mode 1)**: Single MOSFET for lower power
+2. **Parallel Mode (Mode 2)**: Dual parallel MOSFETs for high power
+3. **High Stress Staged Start (Mode 3)**: Sequential turn-on for stress management
+4. **Low Stress Staged Start (Mode 4)**: Optimized sequential turn-on
+
+Mode selection is configured via CONFIG_1 register and external pin configuration.
+
+Fault Protection
+^^^^^^^^^^^^^^^^
+
+The driver supports comprehensive fault detection and auto-retry:
+
+* **Overcurrent (OC)**: Programmable current limit with foldback
+* **Overvoltage (OV)**: Adjustable OV threshold with hysteresis
+* **Undervoltage (UV)**: Adjustable UV threshold with hysteresis
+* **FET Bad**: MOSFET failure detection
+* **FET Short**: MOSFET short circuit detection
+* **External Fault**: Integration with external fault monitors
+* **Power Failed**: Power good monitoring with timeout
+
+All faults support configurable auto-retry with programmable cooling delays.
+
+LTC4284 Support
+---------------
+
+Hardware Platforms
+^^^^^^^^^^^^^^^^^^
+
+The driver has been tested on:
+
+* **Maxim MAX32665** feather board (primary platform)
+* **DC2470A** evaluation kit (LTC4284 demo board)
+
+Additional platform support can be added by implementing the no-OS I²C platform
+drivers for the target MCU.
+
+Documentation
+^^^^^^^^^^^^^
+
+* **Datasheet**: https://www.analog.com/ltc4284
+* **Evaluation Kit**: https://www.analog.com/DC2470A
+* **Application Note**: Hot Swap Controller Design Guide
+
+Support and Contact
+^^^^^^^^^^^^^^^^^^^
+
+For questions or support:
+
+* **no-OS Repository**: https://github.com/analogdevicesinc/no-OS
+* **IIO Support**: https://wiki.analog.com/resources/tools-software/linux-software/libiio
+* **Technical Support**: https://www.analog.com/support

--- a/drivers/power/ltc4284/iio_ltc4284.c
+++ b/drivers/power/ltc4284/iio_ltc4284.c
@@ -1,0 +1,288 @@
+/***************************************************************************//**
+ *   @file   iio_ltc4284.c
+ *   @brief  Implementation of LTC4284 IIO Driver
+ *   @author Carlos Jones Jr <carlos.jones.jr@analog.com>
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <stdlib.h>
+#include <errno.h>
+#include "iio_ltc4284.h"
+#include "no_os_alloc.h"
+#include "no_os_units.h"
+
+/**
+ * @brief Read raw value from LTC4284 IIO channel
+ * @param dev - IIO device descriptor
+ * @param buf - Output buffer
+ * @param len - Buffer length
+ * @param channel - IIO channel info
+ * @param priv - Private data
+ * @return Number of bytes written, or negative error code
+ */
+static int ltc4284_iio_read_raw(void *dev, char *buf, uint32_t len,
+				const struct iio_ch_info *channel,
+				intptr_t priv)
+{
+	struct ltc4284_iio_desc *iio_ltc4284 = dev;
+	struct ltc4284_dev *ltc4284 = iio_ltc4284->ltc4284_dev;
+	int32_t vals[2];
+	uint16_t value16;
+	uint32_t value32;
+	uint64_t value64;
+	int ret;
+
+	switch (channel->address) {
+	case LTC4284_IIO_VIN_CHAN:
+		ret = ltc4284_read_vin(ltc4284, &value16);
+		vals[0] = (int32_t)value16;
+		break;
+	case LTC4284_IIO_IIN_CHAN:
+		ret = ltc4284_read_iin(ltc4284, &value16);
+		vals[0] = (int32_t)value16;
+		break;
+	case LTC4284_IIO_VOUT_CHAN:
+		ret = ltc4284_read_vout(ltc4284, &value16);
+		vals[0] = (int32_t)value16;
+		break;
+	case LTC4284_IIO_POWER_CHAN:
+		ret = ltc4284_read_power(ltc4284, &value32);
+		vals[0] = (int32_t)value32;
+		break;
+	case LTC4284_IIO_ENERGY_CHAN:
+		ret = ltc4284_read_energy(ltc4284, &value64);
+		vals[0] = (int32_t)value64;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	if (ret)
+		return ret;
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, vals);
+}
+
+/**
+ * @brief Read scale value from LTC4284 IIO channel
+ * @param dev - IIO device descriptor
+ * @param buf - Output buffer
+ * @param len - Buffer length
+ * @param channel - IIO channel info
+ * @param priv - Private data
+ * @return Number of bytes written, or negative error code
+ */
+static int ltc4284_iio_read_scale(void *dev, char *buf, uint32_t len,
+				  const struct iio_ch_info *channel,
+				  intptr_t priv)
+{
+	int32_t vals[2];
+
+	/* Scale factor: raw value (in mV/mA/mW/mJ) to base units (V/A/W/J)
+	 * Scale = 1/1000 for all channels
+	 */
+	vals[0] = 1;
+	vals[1] = (int32_t)MILLI;
+
+	return iio_format_value(buf, len, IIO_VAL_FRACTIONAL, 2, vals);
+}
+
+/**
+ * @brief IIO channel attributes for voltage (input)
+ */
+static struct iio_attribute ltc4284_voltage_input_attrs[] = {
+	{
+		.name = "raw",
+		.show = ltc4284_iio_read_raw,
+	},
+	{
+		.name = "scale",
+		.show = ltc4284_iio_read_scale,
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+/**
+ * @brief IIO channel attributes for current (input)
+ */
+static struct iio_attribute ltc4284_current_input_attrs[] = {
+	{
+		.name = "raw",
+		.show = ltc4284_iio_read_raw,
+	},
+	{
+		.name = "scale",
+		.show = ltc4284_iio_read_scale,
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+/**
+ * @brief IIO channel attributes for power
+ */
+static struct iio_attribute ltc4284_power_attrs[] = {
+	{
+		.name = "raw",
+		.show = ltc4284_iio_read_raw,
+	},
+	{
+		.name = "scale",
+		.show = ltc4284_iio_read_scale,
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+/**
+ * @brief IIO channel attributes for energy
+ */
+static struct iio_attribute ltc4284_energy_attrs[] = {
+	{
+		.name = "raw",
+		.show = ltc4284_iio_read_raw,
+	},
+	{
+		.name = "scale",
+		.show = ltc4284_iio_read_scale,
+	},
+	END_ATTRIBUTES_ARRAY
+};
+
+/**
+ * @brief LTC4284 IIO channels definition
+ */
+static struct iio_channel ltc4284_channels[] = {
+	{
+		.name = "vin",
+		.ch_type = IIO_VOLTAGE,
+		.indexed = 1,
+		.channel = 0,
+		.address = LTC4284_IIO_VIN_CHAN,
+		.attributes = ltc4284_voltage_input_attrs,
+		.ch_out = false
+	},
+	{
+		.name = "iin",
+		.ch_type = IIO_CURRENT,
+		.indexed = 1,
+		.channel = 0,
+		.address = LTC4284_IIO_IIN_CHAN,
+		.attributes = ltc4284_current_input_attrs,
+		.ch_out = false
+	},
+	{
+		.name = "vout",
+		.ch_type = IIO_VOLTAGE,
+		.indexed = 1,
+		.channel = 1,
+		.address = LTC4284_IIO_VOUT_CHAN,
+		.attributes = ltc4284_voltage_input_attrs,
+		.ch_out = false
+	},
+	{
+		.name = "power",
+		.ch_type = IIO_POWER,
+		.indexed = 1,
+		.channel = 0,
+		.address = LTC4284_IIO_POWER_CHAN,
+		.attributes = ltc4284_power_attrs,
+		.ch_out = false
+	},
+	{
+		.name = "energy",
+		.ch_type = IIO_POWER,
+		.indexed = 1,
+		.channel = 0,
+		.address = LTC4284_IIO_ENERGY_CHAN,
+		.attributes = ltc4284_energy_attrs,
+		.ch_out = false
+	}
+};
+
+/**
+ * @brief LTC4284 IIO device structure
+ */
+static struct iio_device ltc4284_iio_dev = {
+	.num_ch = NO_OS_ARRAY_SIZE(ltc4284_channels),
+	.channels = ltc4284_channels,
+};
+
+/**
+ * @brief Initialize LTC4284 IIO interface
+ * @param iio_desc - Pointer to IIO descriptor pointer
+ * @param init_param - Initialization parameters
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltc4284_iio_init(struct ltc4284_iio_desc **iio_desc,
+		     const struct ltc4284_iio_init_param *init_param)
+{
+	struct ltc4284_iio_desc *desc;
+	int ret;
+
+	if (!iio_desc || !init_param || !init_param->ltc4284_init)
+		return -EINVAL;
+
+	desc = (struct ltc4284_iio_desc *)no_os_calloc(1, sizeof(*desc));
+	if (!desc)
+		return -ENOMEM;
+
+	ret = ltc4284_init(&desc->ltc4284_dev, init_param->ltc4284_init);
+	if (ret)
+		goto error_desc;
+
+	desc->iio_dev = &ltc4284_iio_dev;
+
+	*iio_desc = desc;
+
+	return 0;
+
+error_desc:
+	no_os_free(desc);
+	return ret;
+}
+
+/**
+ * @brief Remove LTC4284 IIO interface
+ * @param desc - IIO descriptor
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltc4284_iio_remove(struct ltc4284_iio_desc *desc)
+{
+	int ret;
+
+	if (!desc)
+		return -EINVAL;
+
+	ret = ltc4284_remove(desc->ltc4284_dev);
+	if (ret)
+		return ret;
+
+	no_os_free(desc);
+
+	return 0;
+}

--- a/drivers/power/ltc4284/iio_ltc4284.h
+++ b/drivers/power/ltc4284/iio_ltc4284.h
@@ -1,0 +1,75 @@
+/***************************************************************************//**
+ *   @file   iio_ltc4284.h
+ *   @brief  Header file of LTC4284 IIO Driver
+ *   @author Carlos Jones Jr <carlos.jones.jr@analog.com>
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef __IIO_LTC4284_H__
+#define __IIO_LTC4284_H__
+
+#include "iio.h"
+#include "ltc4284.h"
+
+/**
+ * @struct ltc4284_iio_desc
+ * @brief LTC4284 IIO descriptor
+ */
+struct ltc4284_iio_desc {
+	struct ltc4284_dev *ltc4284_dev;
+	struct iio_device *iio_dev;
+};
+
+/**
+ * @struct ltc4284_iio_init_param
+ * @brief LTC4284 IIO initialization parameters
+ */
+struct ltc4284_iio_init_param {
+	struct ltc4284_init_param *ltc4284_init;
+};
+
+/**
+ * @enum ltc4284_iio_channels
+ * @brief LTC4284 IIO channel enumeration
+ */
+enum ltc4284_iio_channels {
+	LTC4284_IIO_VIN_CHAN,
+	LTC4284_IIO_IIN_CHAN,
+	LTC4284_IIO_VOUT_CHAN,
+	LTC4284_IIO_POWER_CHAN,
+	LTC4284_IIO_ENERGY_CHAN,
+	LTC4284_IIO_NUM_CHANNELS
+};
+
+/* IIO interface functions */
+int ltc4284_iio_init(struct ltc4284_iio_desc **iio_desc,
+		     const struct ltc4284_iio_init_param *init_param);
+int ltc4284_iio_remove(struct ltc4284_iio_desc *desc);
+
+#endif /* __IIO_LTC4284_H__ */

--- a/drivers/power/ltc4284/ltc4284.c
+++ b/drivers/power/ltc4284/ltc4284.c
@@ -1,0 +1,565 @@
+/***************************************************************************//**
+ *   @file   ltc4284.c
+ *   @brief  Implementation of LTC4284 Driver
+ *   @author Carlos Jones Jr <carlos.jones.jr@analog.com>
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include "ltc4284.h"
+#include "no_os_delay.h"
+#include "no_os_units.h"
+#include "no_os_alloc.h"
+
+/**
+ * @brief Read a single byte from LTC4284 register
+ * @param dev - Device descriptor
+ * @param reg - Register address
+ * @param val - Pointer to store read value
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltc4284_read_byte(struct ltc4284_dev *dev, uint8_t reg, uint8_t *val)
+{
+	int ret;
+
+	if (!dev || !val)
+		return -EINVAL;
+
+	ret = no_os_i2c_write(dev->i2c_desc, &reg, 1, 0);
+	if (ret)
+		return ret;
+
+	return no_os_i2c_read(dev->i2c_desc, val, 1, 1);
+}
+
+/**
+ * @brief Write a single byte to LTC4284 register
+ * @param dev - Device descriptor
+ * @param reg - Register address
+ * @param val - Value to write
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltc4284_write_byte(struct ltc4284_dev *dev, uint8_t reg, uint8_t val)
+{
+	uint8_t buf[2];
+
+	if (!dev)
+		return -EINVAL;
+
+	buf[0] = reg;
+	buf[1] = val;
+
+	return no_os_i2c_write(dev->i2c_desc, buf, 2, 1);
+}
+
+/**
+ * @brief Read a 16-bit word from LTC4284 (big-endian)
+ * @param dev - Device descriptor
+ * @param reg - Register address
+ * @param val - Pointer to store read value
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltc4284_read_word(struct ltc4284_dev *dev, uint8_t reg, uint16_t *val)
+{
+	int ret;
+	uint8_t buf[2];
+
+	if (!dev || !val)
+		return -EINVAL;
+
+	ret = no_os_i2c_write(dev->i2c_desc, &reg, 1, 0);
+	if (ret)
+		return ret;
+
+	ret = no_os_i2c_read(dev->i2c_desc, buf, 2, 1);
+	if (ret)
+		return ret;
+
+	/* LTC4284 uses big-endian (MSB first) */
+	*val = ((uint16_t)buf[0] << 8) | buf[1];
+
+	return 0;
+}
+
+/**
+ * @brief Write a 16-bit word to LTC4284 (big-endian)
+ * @param dev - Device descriptor
+ * @param reg - Register address
+ * @param val - Value to write
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltc4284_write_word(struct ltc4284_dev *dev, uint8_t reg, uint16_t val)
+{
+	uint8_t buf[3];
+
+	if (!dev)
+		return -EINVAL;
+
+	buf[0] = reg;
+	buf[1] = (uint8_t)(val >> 8);   /* MSB */
+	buf[2] = (uint8_t)(val & 0xFF); /* LSB */
+
+	return no_os_i2c_write(dev->i2c_desc, buf, 3, 1);
+}
+
+/**
+ * @brief Update register bits with mask
+ * @param dev - Device descriptor
+ * @param reg - Register address
+ * @param mask - Bit mask
+ * @param val - New value for masked bits
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltc4284_update_bits(struct ltc4284_dev *dev, uint8_t reg,
+			uint8_t mask, uint8_t val)
+{
+	int ret;
+	uint8_t reg_val;
+
+	if (!dev)
+		return -EINVAL;
+
+	ret = ltc4284_read_byte(dev, reg, &reg_val);
+	if (ret)
+		return ret;
+
+	reg_val &= ~mask;
+	reg_val |= (val & mask);
+
+	return ltc4284_write_byte(dev, reg, reg_val);
+}
+
+/**
+ * @brief Initialize the LTC4284 device
+ * @param device - Pointer to device descriptor pointer
+ * @param init_param - Initialization parameters
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltc4284_init(struct ltc4284_dev **device,
+		 const struct ltc4284_init_param *init_param)
+{
+	struct ltc4284_dev *dev;
+	uint8_t status;
+	int ret;
+
+	if (!device || !init_param)
+		return -EINVAL;
+
+	if (init_param->i2c_addr < LTC4284_I2C_ADDR_0 ||
+	    init_param->i2c_addr > LTC4284_I2C_ADDR_3)
+		return -EINVAL;
+
+	if (init_param->vsense_mv != 15 && init_param->vsense_mv != 20 &&
+	    init_param->vsense_mv != 25 && init_param->vsense_mv != 30)
+		return -EINVAL;
+
+	dev = (struct ltc4284_dev *)no_os_calloc(1, sizeof(*dev));
+	if (!dev)
+		return -ENOMEM;
+
+	ret = no_os_i2c_init(&dev->i2c_desc, init_param->i2c_init);
+	if (ret)
+		goto error_dev;
+
+	dev->i2c_addr = init_param->i2c_addr;
+	dev->rsense_mohm = init_param->rsense_mohm;
+	dev->vsense_mv = init_param->vsense_mv;
+
+	if (init_param->alert_gpio) {
+		ret = no_os_gpio_get_optional(&dev->alert_gpio, init_param->alert_gpio);
+		if (ret)
+			goto error_i2c;
+
+		if (dev->alert_gpio) {
+			ret = no_os_gpio_direction_input(dev->alert_gpio);
+			if (ret)
+				goto error_gpio;
+		}
+	}
+
+	ret = ltc4284_read_byte(dev, LTC4284_REG_SYSTEM_STATUS, &status);
+	if (ret)
+		goto error_gpio;
+
+	*device = dev;
+
+	return 0;
+
+error_gpio:
+	if (dev->alert_gpio)
+		no_os_gpio_remove(dev->alert_gpio);
+error_i2c:
+	no_os_i2c_remove(dev->i2c_desc);
+error_dev:
+	no_os_free(dev);
+
+	return ret;
+}
+
+/**
+ * @brief Remove the LTC4284 device and free resources
+ * @param dev - Device descriptor
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltc4284_remove(struct ltc4284_dev *dev)
+{
+	int ret;
+
+	if (!dev)
+		return -EINVAL;
+
+	ret = ltc4284_enable_fet(dev, false);
+	if (ret)
+		return ret;
+
+	if (dev->alert_gpio)
+		no_os_gpio_remove(dev->alert_gpio);
+
+	ret = no_os_i2c_remove(dev->i2c_desc);
+	if (ret)
+		return ret;
+
+	no_os_free(dev);
+
+	return 0;
+}
+
+/**
+ * @brief Read input voltage (VPWR)
+ * @param dev - Device descriptor
+ * @param vin_mv - Pointer to store voltage in millivolts
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltc4284_read_vin(struct ltc4284_dev *dev, uint16_t *vin_mv)
+{
+	int ret;
+	uint16_t adc_code;
+
+	if (!dev || !vin_mv)
+		return -EINVAL;
+
+	ret = ltc4284_read_word(dev, LTC4284_REG_VPWR, &adc_code);
+	if (ret)
+		return ret;
+
+	/* Convert ADC code to millivolts
+	 * VIN = ADC_code * LSB (application-specific scaling)
+	 * Default scaling: VIN_LSB = 32mV (32000uV)
+	 */
+	*vin_mv = (uint16_t)((uint32_t)adc_code * LTC4284_VPWR_LSB_UV / MILLI);
+
+	return 0;
+}
+
+/**
+ * @brief Read input current (SENSE)
+ * @param dev - Device descriptor
+ * @param iin_ma - Pointer to store current in milliamps
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltc4284_read_iin(struct ltc4284_dev *dev, uint16_t *iin_ma)
+{
+	int ret;
+	uint16_t adc_code;
+	uint32_t sense_uv;
+
+	if (!dev || !iin_ma)
+		return -EINVAL;
+
+	ret = ltc4284_read_word(dev, LTC4284_REG_SENSE, &adc_code);
+	if (ret)
+		return ret;
+
+	/* Convert ADC code to sense voltage in microvolts
+	 * SENSE_UV = (ADC_code * VSENSE_mV * 1000) / 256 (8-bit mode)
+	 * or / 65536 (16-bit mode)
+	 */
+	sense_uv = ((uint32_t)adc_code * dev->vsense_mv * MILLI) /
+		   LTC4284_ADC_8BIT_LEVELS;
+
+	/* Convert sense voltage to current: I = V_SENSE / R_SENSE
+	 * I_mA = (sense_uV / rsense_mohm)
+	 */
+	if (dev->rsense_mohm == 0)
+		return -EINVAL;
+
+	*iin_ma = (uint16_t)(sense_uv / dev->rsense_mohm);
+
+	return 0;
+}
+
+/**
+ * @brief Read output voltage (DRAIN)
+ * @param dev - Device descriptor
+ * @param vout_mv - Pointer to store voltage in millivolts
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltc4284_read_vout(struct ltc4284_dev *dev, uint16_t *vout_mv)
+{
+	int ret;
+	uint16_t adc_code;
+
+	if (!dev || !vout_mv)
+		return -EINVAL;
+
+	ret = ltc4284_read_word(dev, LTC4284_REG_DRAIN, &adc_code);
+	if (ret)
+		return ret;
+
+	/* Convert ADC code to millivolts
+	 * VOUT = ADC_code * LSB (application-specific scaling)
+	 * Default scaling: DRAIN_LSB = 32mV (32000uV)
+	 */
+	*vout_mv = (uint16_t)((uint32_t)adc_code * LTC4284_DRAIN_LSB_UV / MILLI);
+
+	return 0;
+}
+
+/**
+ * @brief Read power consumption
+ * @param dev - Device descriptor
+ * @param power_mw - Pointer to store power in milliwatts
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltc4284_read_power(struct ltc4284_dev *dev, uint32_t *power_mw)
+{
+	int ret;
+	uint16_t adc_code;
+
+	if (!dev || !power_mw)
+		return -EINVAL;
+
+	ret = ltc4284_read_word(dev, LTC4284_REG_POWER, &adc_code);
+	if (ret)
+		return ret;
+
+	/* Power register contains computed power value
+	 * Power scaling depends on VPWR and SENSE scaling
+	 * For now, return raw ADC code (application-specific scaling needed)
+	 */
+	*power_mw = (uint32_t)adc_code;
+
+	return 0;
+}
+
+/**
+ * @brief Read cumulative energy
+ * @param dev - Device descriptor
+ * @param energy_mj - Pointer to store energy in millijoules
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltc4284_read_energy(struct ltc4284_dev *dev, uint64_t *energy_mj)
+{
+	int ret;
+	uint8_t buf[3];
+	uint32_t energy_code;
+
+	if (!dev || !energy_mj)
+		return -EINVAL;
+
+	/* Energy is a 24-bit value (3 bytes) */
+	ret = no_os_i2c_write(dev->i2c_desc,
+	(uint8_t[]) {
+		LTC4284_REG_ENERGY
+	}, 1, 0);
+	if (ret)
+		return ret;
+
+	ret = no_os_i2c_read(dev->i2c_desc, buf, 3, 1);
+	if (ret)
+		return ret;
+
+	/* Assemble 24-bit value (big-endian) */
+	energy_code = ((uint32_t)buf[0] << 16) |
+		      ((uint32_t)buf[1] << 8) |
+		      buf[2];
+
+	/* Convert to millijoules (application-specific scaling needed) */
+	*energy_mj = (uint64_t)energy_code;
+
+	return 0;
+}
+
+/**
+ * @brief Read temperature
+ * @param dev - Device descriptor
+ * @param temp_mc - Temperature in milli-degrees Celsius
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltc4284_read_temperature(struct ltc4284_dev *dev, int16_t *temp_mc)
+{
+	int ret;
+	uint16_t adc_code;
+
+	if (!dev || !temp_mc)
+		return -EINVAL;
+
+	/* Read temperature from ADIO3 register (2-byte ADC value)
+	 * TODO: Implement proper NTC thermistor conversion formula
+	 * based on datasheet specifications */
+	ret = ltc4284_read_word(dev, LTC4284_REG_ADIO3, &adc_code);
+	if (ret)
+		return ret;
+
+	/* Placeholder conversion - needs proper thermistor formula
+	 * For now, return a nominal room temperature value
+	 * Actual implementation requires NTC beta value and voltage divider specs */
+	*temp_mc = 25000;  /* 25.000 degrees Celsius */
+
+	return 0;
+}
+
+/**
+ * @brief Set current limit
+ * @param dev - Device descriptor
+ * @param ilim_code - Current limit code (0-15)
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltc4284_set_current_limit(struct ltc4284_dev *dev, uint8_t ilim_code)
+{
+	if (!dev)
+		return -EINVAL;
+
+	/* Validate range (4-bit value) */
+	if (ilim_code > 15)
+		return -EINVAL;
+
+	return ltc4284_update_bits(dev, LTC4284_REG_CONFIG_1,
+				   LTC4284_CONFIG_1_ILIM,
+				   ilim_code << 4);
+}
+
+/**
+ * @brief Enable or disable FET drivers
+ * @param dev - Device descriptor
+ * @param enable - True to enable, false to disable
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltc4284_enable_fet(struct ltc4284_dev *dev, bool enable)
+{
+	if (!dev)
+		return -EINVAL;
+
+	return ltc4284_update_bits(dev, LTC4284_REG_CONTROL_1,
+				   LTC4284_CONTROL_1_ON,
+				   enable ? LTC4284_CONTROL_1_ON : 0);
+}
+
+/**
+ * @brief Clear all fault conditions
+ * @param dev - Device descriptor
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltc4284_clear_faults(struct ltc4284_dev *dev)
+{
+	if (!dev)
+		return -EINVAL;
+
+	/* Writing 0x00 to FAULT register clears all faults */
+	return ltc4284_write_byte(dev, LTC4284_REG_FAULT, 0x00);
+}
+
+/**
+ * @brief Read system status register
+ * @param dev - Device descriptor
+ * @param status - Pointer to store status byte
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltc4284_read_status(struct ltc4284_dev *dev, uint8_t *status)
+{
+	if (!dev || !status)
+		return -EINVAL;
+
+	return ltc4284_read_byte(dev, LTC4284_REG_SYSTEM_STATUS, status);
+}
+
+/**
+ * @brief Get current fault conditions
+ * @param dev - Device descriptor
+ * @param faults - Pointer to store fault byte
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltc4284_get_fault(struct ltc4284_dev *dev, uint8_t *faults)
+{
+	if (!dev || !faults)
+		return -EINVAL;
+
+	return ltc4284_read_byte(dev, LTC4284_REG_FAULT, faults);
+}
+
+/**
+ * @brief Store current configuration to EEPROM
+ * @param dev - Device descriptor
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltc4284_store_config(struct ltc4284_dev *dev)
+{
+	int ret;
+	uint8_t status;
+	int timeout = 100; /* 100ms timeout */
+
+	if (!dev)
+		return -EINVAL;
+
+	/* Trigger EEPROM store by writing to SNAPSHOT register */
+	ret = ltc4284_write_byte(dev, LTC4284_REG_SNAPSHOT, 0x01);
+	if (ret)
+		return ret;
+
+	/* Wait for EEPROM write to complete */
+	while (timeout > 0) {
+		ret = ltc4284_read_byte(dev, LTC4284_REG_SYSTEM_STATUS, &status);
+		if (ret)
+			return ret;
+
+		if (!(status & LTC4284_SYSTEM_STATUS_EEPROM_BUSY))
+			return 0;
+
+		no_os_mdelay(1);
+		timeout--;
+	}
+
+	return -ETIMEDOUT;
+}
+
+/**
+ * @brief Restore configuration from EEPROM
+ * @param dev - Device descriptor
+ * @return 0 in case of success, negative error code otherwise
+ */
+int ltc4284_restore_config(struct ltc4284_dev *dev)
+{
+	if (!dev)
+		return -EINVAL;
+
+	/* Restore from EEPROM by triggering a reboot */
+	return ltc4284_write_byte(dev, LTC4284_REG_REBOOT, 0x01);
+}

--- a/drivers/power/ltc4284/ltc4284.h
+++ b/drivers/power/ltc4284/ltc4284.h
@@ -1,0 +1,356 @@
+/***************************************************************************//**
+ *   @file   ltc4284.h
+ *   @brief  Header file of LTC4284 Driver
+ *   @author Carlos Jones Jr <carlos.jones.jr@analog.com>
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef __LTC4284_H__
+#define __LTC4284_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "no_os_util.h"
+#include "no_os_i2c.h"
+#include "no_os_gpio.h"
+
+/******************************************************************************/
+/************************** I2C Address Definitions ***************************/
+/******************************************************************************/
+
+/* I2C 7-bit address range (configurable via ADR0/ADR1 pins) */
+#define LTC4284_I2C_ADDR_0              0x28
+#define LTC4284_I2C_ADDR_1              0x29
+#define LTC4284_I2C_ADDR_2              0x2A  /* Default address */
+#define LTC4284_I2C_ADDR_3              0x2B
+
+/******************************************************************************/
+/*************************** Register Definitions *****************************/
+/******************************************************************************/
+
+/* System Status and Control Registers */
+#define LTC4284_REG_SYSTEM_STATUS       0x00  /* System status information (R) */
+#define LTC4284_REG_ADC_STATUS          0x01  /* ADC conversion status (R) */
+#define LTC4284_REG_INPUT_STATUS        0x02  /* GPIO input status (R) */
+#define LTC4284_REG_FAULT_STATUS        0x03  /* Fault status information (R) */
+#define LTC4284_REG_FAULT               0x04  /* System fault (R/W) */
+#define LTC4284_REG_ADC_ALARM_LOG       0x05  /* ADC alarm log start (R/W, 5 bytes) */
+#define LTC4284_REG_ADC_ALARM_LOG_1     0x05  /* ADC alarm log 1 */
+#define LTC4284_REG_ADC_ALARM_LOG_2     0x06  /* ADC alarm log 2 */
+#define LTC4284_REG_ADC_ALARM_LOG_3     0x07  /* ADC alarm log 3 */
+#define LTC4284_REG_ADC_ALARM_LOG_4     0x08  /* ADC alarm log 4 */
+#define LTC4284_REG_ADC_ALARM_LOG_5     0x09  /* ADC alarm log 5 */
+#define LTC4284_REG_CONTROL             0x0A  /* Control registers start (R/W, 2 bytes) */
+#define LTC4284_REG_CONTROL_1           0x0A  /* Control register 1 */
+#define LTC4284_REG_CONTROL_2           0x0B  /* Control register 2 */
+#define LTC4284_REG_RESERVED_0C         0x0C  /* Reserved (always returns 0) */
+#define LTC4284_REG_CONFIG              0x0D  /* Config registers start (R/W, 3 bytes) */
+#define LTC4284_REG_CONFIG_1            0x0D  /* Config register 1 */
+#define LTC4284_REG_CONFIG_2            0x0E  /* Config register 2 */
+#define LTC4284_REG_CONFIG_3            0x0F  /* Config register 3 */
+#define LTC4284_REG_PGIO_CONFIG         0x10  /* GPIO config start (R/W, 2 bytes) */
+#define LTC4284_REG_PGIO_CONFIG_1       0x10  /* GPIO config 1 */
+#define LTC4284_REG_PGIO_CONFIG_2       0x11  /* GPIO config 2 */
+#define LTC4284_REG_ADIO_CONFIG         0x12  /* ADC I/O config (R/W) */
+#define LTC4284_REG_FAULT_ALERT         0x15  /* Fault alert configuration (R/W) */
+
+/* ADC Threshold Registers (Min/Max) */
+#define LTC4284_REG_SENSE_MIN_TH        0x1E  /* SENSE min threshold */
+#define LTC4284_REG_SENSE_MAX_TH        0x1F  /* SENSE max threshold */
+#define LTC4284_REG_VPWR_MIN_TH         0x20  /* VPWR min threshold */
+#define LTC4284_REG_VPWR_MAX_TH         0x21  /* VPWR max threshold */
+#define LTC4284_REG_POWER_MIN_TH        0x22  /* POWER min threshold (2 bytes) */
+#define LTC4284_REG_POWER_MAX_TH        0x23  /* POWER max threshold (2 bytes) */
+#define LTC4284_REG_ENERGY_TH           0x24  /* ENERGY threshold (3 bytes) */
+#define LTC4284_REG_VPWR_MIN            0x27  /* VPWR minimum */
+#define LTC4284_REG_VPWR_MAX            0x28  /* VPWR maximum */
+#define LTC4284_REG_POWER_MIN           0x29  /* POWER minimum (2 bytes) */
+#define LTC4284_REG_POWER_MAX           0x2A  /* POWER maximum (2 bytes) */
+#define LTC4284_REG_ENERGY              0x2B  /* ENERGY accumulator (3 bytes) */
+
+/* Additional ADC Channel Thresholds */
+#define LTC4284_REG_DRNS_MIN_TH         0x32  /* DRNS min threshold */
+#define LTC4284_REG_DRNS_MAX_TH         0x33  /* DRNS max threshold */
+#define LTC4284_REG_DRAIN_MIN_TH        0x34  /* DRAIN min threshold */
+#define LTC4284_REG_DRAIN_MAX_TH        0x35  /* DRAIN max threshold */
+#define LTC4284_REG_SENSE1_MIN_TH       0x36  /* SENSE1 min threshold */
+#define LTC4284_REG_SENSE1_MAX_TH       0x37  /* SENSE1 max threshold */
+#define LTC4284_REG_SENSE2_MIN_TH       0x38  /* SENSE2 min threshold */
+#define LTC4284_REG_SENSE2_MAX_TH       0x39  /* SENSE2 max threshold */
+#define LTC4284_REG_ADIN12_MIN_TH       0x3A  /* ADIN2-ADIN1 min threshold */
+#define LTC4284_REG_ADIN12_MAX_TH       0x3B  /* ADIN2-ADIN1 max threshold */
+#define LTC4284_REG_ADIN34_MIN_TH       0x3C  /* ADIN4-ADIN3 min threshold */
+#define LTC4284_REG_ADIN34_MAX_TH       0x3D  /* ADIN4-ADIN3 max threshold */
+
+/* ADC Data Registers (16-bit, 2 bytes each) */
+#define LTC4284_REG_SENSE               0x40  /* Current SENSE ADC value */
+#define LTC4284_REG_VPWR                0x41  /* VPWR voltage */
+#define LTC4284_REG_POWER               0x42  /* Power (2 bytes) */
+#define LTC4284_REG_ADIO1               0x55  /* ADIO1 ADC value (2 bytes) */
+#define LTC4284_REG_ADIO1_MIN           0x56  /* ADIO1 minimum (2 bytes) */
+#define LTC4284_REG_ADIO1_MAX           0x57  /* ADIO1 maximum (2 bytes) */
+#define LTC4284_REG_ADIO2               0x58  /* ADIO2 ADC value (2 bytes) */
+#define LTC4284_REG_ADIO2_MIN           0x59  /* ADIO2 minimum (2 bytes) */
+#define LTC4284_REG_ADIO2_MAX           0x5A  /* ADIO2 maximum (2 bytes) */
+#define LTC4284_REG_ADIO3               0x5B  /* ADIO3 ADC value (2 bytes) */
+#define LTC4284_REG_ADIO3_MIN           0x5C  /* ADIO3 minimum (2 bytes) */
+#define LTC4284_REG_ADIO3_MAX           0x5D  /* ADIO3 maximum (2 bytes) */
+#define LTC4284_REG_ADIO4               0x5E  /* ADIO4 ADC value (2 bytes) */
+#define LTC4284_REG_ADIO4_MIN           0x5F  /* ADIO4 minimum (2 bytes) */
+#define LTC4284_REG_ADIO4_MAX           0x60  /* ADIO4 maximum (2 bytes) */
+#define LTC4284_REG_DRNS                0x61  /* DRNS voltage (2 bytes) */
+#define LTC4284_REG_DRNS_MIN            0x62  /* DRNS minimum (2 bytes) */
+#define LTC4284_REG_DRNS_MAX            0x63  /* DRNS maximum (2 bytes) */
+#define LTC4284_REG_DRAIN               0x64  /* DRAIN voltage (2 bytes) */
+#define LTC4284_REG_DRAIN_MIN           0x65  /* DRAIN minimum (2 bytes) */
+#define LTC4284_REG_DRAIN_MAX           0x66  /* DRAIN maximum (2 bytes) */
+#define LTC4284_REG_SENSE1              0x67  /* SENSE1 current (2 bytes) */
+#define LTC4284_REG_SENSE1_MIN          0x68  /* SENSE1 minimum (2 bytes) */
+#define LTC4284_REG_SENSE1_MAX          0x69  /* SENSE1 maximum (2 bytes) */
+#define LTC4284_REG_SENSE2              0x6A  /* SENSE2 current (2 bytes) */
+#define LTC4284_REG_SENSE2_MIN          0x6B  /* SENSE2 minimum (2 bytes) */
+#define LTC4284_REG_SENSE2_MAX          0x6C  /* SENSE2 maximum (2 bytes) */
+
+/* Snapshot and EEPROM Control */
+#define LTC4284_REG_SNAPSHOT            0x84  /* Snapshot control */
+#define LTC4284_REG_SNAPSHOT_1          0x84  /* Snapshot control 1 */
+#define LTC4284_REG_SNAPSHOT_2          0x85  /* Snapshot control 2 */
+#define LTC4284_REG_REBOOT              0xA2  /* Reboot control and status */
+
+/* EEPROM Mirror Registers */
+#define LTC4284_REG_EE_FAULT            0xA4  /* EEPROM fault record */
+#define LTC4284_REG_EE_ADC_ALARM_LOG    0xA5  /* EEPROM alarm log (5 bytes) */
+#define LTC4284_REG_EE_CONTROL          0xAA  /* EEPROM control (2 bytes) */
+#define LTC4284_REG_EE_CONTROL_1        0xAA  /* EEPROM control 1 */
+#define LTC4284_REG_EE_CONTROL_2        0xAB  /* EEPROM control 2 */
+#define LTC4284_REG_RESERVED_AC         0xAC  /* EEPROM busy status */
+#define LTC4284_REG_EE_CONFIG           0xAD  /* EEPROM config (3 bytes) */
+#define LTC4284_REG_EE_CONFIG_1         0xAD  /* EEPROM config 1 */
+#define LTC4284_REG_EE_CONFIG_2         0xAE  /* EEPROM config 2 */
+#define LTC4284_REG_EE_CONFIG_3         0xAF  /* EEPROM config 3 */
+#define LTC4284_REG_EE_PGIO_CONFIG      0xB0  /* EEPROM GPIO config (2 bytes) */
+#define LTC4284_REG_EE_ADIO_CONFIG      0xB2  /* EEPROM ADC I/O config */
+
+/******************************************************************************/
+/*********************** SYSTEM_STATUS Register (0x00) ************************/
+/******************************************************************************/
+
+#define LTC4284_SYSTEM_STATUS_FET_ON_STATUS     NO_OS_BIT(7)  /* GATE commanded on */
+#define LTC4284_SYSTEM_STATUS_EN                NO_OS_BIT(6)  /* EN# pin state */
+#define LTC4284_SYSTEM_STATUS_GATE2_HIGH        NO_OS_BIT(5)  /* GATE2 pin high */
+#define LTC4284_SYSTEM_STATUS_GATE1_HIGH        NO_OS_BIT(4)  /* GATE1 pin high */
+#define LTC4284_SYSTEM_STATUS_TMR_LOW           NO_OS_BIT(3)  /* TMR < 0.1V */
+#define LTC4284_SYSTEM_STATUS_EEPROM_BUSY       NO_OS_BIT(2)  /* EEPROM writing */
+#define LTC4284_SYSTEM_STATUS_PG_STATUS         NO_OS_BIT(1)  /* Power good */
+#define LTC4284_SYSTEM_STATUS_MODE1             NO_OS_BIT(0)  /* Mode 1 enabled */
+
+/******************************************************************************/
+/************************ ADC_STATUS Register (0x01) **************************/
+/******************************************************************************/
+
+#define LTC4284_ADC_STATUS_ADC_READY            NO_OS_BIT(7)  /* ADC conversion done */
+#define LTC4284_ADC_STATUS_ALERT                NO_OS_BIT(6)  /* Alert condition */
+#define LTC4284_ADC_STATUS_ENERGY_OVERFLOW      NO_OS_BIT(5)  /* Energy overflow */
+
+/******************************************************************************/
+/*********************** INPUT_STATUS Register (0x02) *************************/
+/******************************************************************************/
+
+#define LTC4284_INPUT_STATUS_PGIO1_INPUT        NO_OS_BIT(7)  /* PGIO1 pin state */
+#define LTC4284_INPUT_STATUS_PGIO2_INPUT        NO_OS_BIT(6)  /* PGIO2 pin state */
+#define LTC4284_INPUT_STATUS_PGIO3_INPUT        NO_OS_BIT(5)  /* PGIO3 pin state */
+#define LTC4284_INPUT_STATUS_PGIO4_INPUT        NO_OS_BIT(4)  /* PGIO4 pin state */
+#define LTC4284_INPUT_STATUS_ADIO1_INPUT        NO_OS_BIT(3)  /* ADIO1 pin state */
+#define LTC4284_INPUT_STATUS_ADIO2_INPUT        NO_OS_BIT(2)  /* ADIO2 pin state */
+#define LTC4284_INPUT_STATUS_ADIO3_INPUT        NO_OS_BIT(1)  /* ADIO3 pin state */
+#define LTC4284_INPUT_STATUS_ADIO4_INPUT        NO_OS_BIT(0)  /* ADIO4 pin state */
+
+/******************************************************************************/
+/********************** FAULT_STATUS Register (0x03) **************************/
+/******************************************************************************/
+
+#define LTC4284_FAULT_STATUS_EXT_FAULT          NO_OS_BIT(7)  /* External fault */
+#define LTC4284_FAULT_STATUS_POWER_FAULT        NO_OS_BIT(6)  /* Power failed */
+#define LTC4284_FAULT_STATUS_FET_SHORT          NO_OS_BIT(5)  /* FET short */
+#define LTC4284_FAULT_STATUS_UV_STATUS          NO_OS_BIT(4)  /* Undervoltage */
+#define LTC4284_FAULT_STATUS_OV_STATUS          NO_OS_BIT(3)  /* Overvoltage */
+#define LTC4284_FAULT_STATUS_FET_BAD_STATUS     NO_OS_BIT(2)  /* FET bad */
+#define LTC4284_FAULT_STATUS_OC_STATUS          NO_OS_BIT(1)  /* Overcurrent */
+#define LTC4284_FAULT_STATUS_PGI_FAULT          NO_OS_BIT(0)  /* Power good input fault */
+
+/******************************************************************************/
+/************************** FAULT Register (0x04) *****************************/
+/******************************************************************************/
+
+#define LTC4284_FAULT_EXT_FAULT_BIT             NO_OS_BIT(7)  /* External fault bit */
+#define LTC4284_FAULT_POWER_FAULT_BIT           NO_OS_BIT(6)  /* Power failed bit */
+#define LTC4284_FAULT_FET_SHORT_BIT             NO_OS_BIT(5)  /* FET short bit */
+#define LTC4284_FAULT_UV_FAULT_BIT              NO_OS_BIT(4)  /* Undervoltage bit */
+#define LTC4284_FAULT_OV_FAULT_BIT              NO_OS_BIT(3)  /* Overvoltage bit */
+#define LTC4284_FAULT_FET_BAD_FAULT_BIT         NO_OS_BIT(2)  /* FET bad bit */
+#define LTC4284_FAULT_OC_FAULT_BIT              NO_OS_BIT(1)  /* Overcurrent bit */
+#define LTC4284_FAULT_PGI_FAULT_BIT             NO_OS_BIT(0)  /* PGI fault bit */
+
+/* Shorter fault bit aliases for convenience */
+#define LTC4284_FAULT_OV                        LTC4284_FAULT_OV_FAULT_BIT
+#define LTC4284_FAULT_UV                        LTC4284_FAULT_UV_FAULT_BIT
+#define LTC4284_FAULT_OC                        LTC4284_FAULT_OC_FAULT_BIT
+#define LTC4284_FAULT_POWER_BAD                 LTC4284_FAULT_POWER_FAULT_BIT
+#define LTC4284_FAULT_FET                       LTC4284_FAULT_FET_BAD_FAULT_BIT
+#define LTC4284_FAULT_OT                        LTC4284_FAULT_EXT_FAULT_BIT
+
+/******************************************************************************/
+/********************* CONTROL_1 Register (0x0A) ******************************/
+/******************************************************************************/
+
+#define LTC4284_CONTROL_1_ON                    NO_OS_BIT(7)  /* Turn on FET */
+#define LTC4284_CONTROL_1_DVDT                  NO_OS_BIT(6)  /* dV/dt mode */
+#define LTC4284_CONTROL_1_GATE2_ON              NO_OS_BIT(5)  /* Gate2 enable */
+#define LTC4284_CONTROL_1_MASS_WRITE_ENABLE     NO_OS_BIT(4)  /* Mass write enable */
+#define LTC4284_CONTROL_1_PWR_ALARM_MODE        NO_OS_BIT(3)  /* Power alarm mode */
+#define LTC4284_CONTROL_1_PG_RESET_CNTRL        NO_OS_BIT(1)  /* PG reset control */
+#define LTC4284_CONTROL_1_FET_SHORT_PRESENT     NO_OS_BIT(0)  /* FET short present */
+
+/******************************************************************************/
+/********************* CONTROL_2 Register (0x0B) ******************************/
+/******************************************************************************/
+
+#define LTC4284_CONTROL_2_OC_RETRY              NO_OS_GENMASK(7, 6)  /* OC retry */
+#define LTC4284_CONTROL_2_UV_RETRY              NO_OS_GENMASK(5, 4)  /* UV retry */
+#define LTC4284_CONTROL_2_OV_RETRY              NO_OS_GENMASK(3, 2)  /* OV retry */
+#define LTC4284_CONTROL_2_FET_BAD_RETRY         NO_OS_GENMASK(1, 0)  /* FET bad retry */
+
+/******************************************************************************/
+/********************** CONFIG_1 Register (0x0D) ******************************/
+/******************************************************************************/
+
+#define LTC4284_CONFIG_1_ILIM                   NO_OS_GENMASK(7, 4)  /* Current limit */
+#define LTC4284_CONFIG_1_FB                     NO_OS_GENMASK(3, 0)  /* Foldback */
+
+/******************************************************************************/
+/********************** CONFIG_2 Register (0x0E) ******************************/
+/******************************************************************************/
+
+#define LTC4284_CONFIG_2_COOLING_DL             NO_OS_GENMASK(7, 6)  /* Cooling delay */
+#define LTC4284_CONFIG_2_FTBD_DL                NO_OS_GENMASK(5, 4)  /* FET bad delay */
+#define LTC4284_CONFIG_2_REBOOT_DL              NO_OS_GENMASK(3, 2)  /* Reboot delay */
+#define LTC4284_CONFIG_2_ADC_16BIT              NO_OS_BIT(1)  /* 16-bit ADC mode */
+#define LTC4284_CONFIG_2_METER_POWER            NO_OS_BIT(0)  /* Meter power */
+
+/******************************************************************************/
+/********************** CONFIG_3 Register (0x0F) ******************************/
+/******************************************************************************/
+
+#define LTC4284_CONFIG_3_EXTFLT_TURN_OFF        NO_OS_BIT(7)  /* Ext fault turn off */
+#define LTC4284_CONFIG_3_PGI_TURN_OFF           NO_OS_BIT(6)  /* PGI turn off */
+
+/******************************************************************************/
+/******************** ADC Conversion Constants ********************************/
+/******************************************************************************/
+
+/* ADC reference and LSB values (from datasheet specifications) */
+#define LTC4284_ADC_VREF_MV                     2048    /* 2.048V reference */
+#define LTC4284_ADC_8BIT_LEVELS                 256     /* 8-bit resolution */
+#define LTC4284_ADC_16BIT_LEVELS                65536   /* 16-bit resolution */
+
+/* Voltage scaling (depends on resistor dividers - to be calculated per application) */
+#define LTC4284_VPWR_LSB_UV                     32000   /* VPWR LSB in microvolts */
+#define LTC4284_DRAIN_LSB_UV                    32000   /* DRAIN LSB in microvolts */
+
+/* Current sense voltage LSB (programmable 15mV to 30mV) */
+#define LTC4284_SENSE_MIN_MV                    15      /* Minimum sense voltage */
+#define LTC4284_SENSE_MAX_MV                    30      /* Maximum sense voltage */
+
+/******************************************************************************/
+/*************************** Types Declarations *******************************/
+/******************************************************************************/
+
+/**
+ * @struct ltc4284_dev
+ * @brief LTC4284 device descriptor
+ */
+struct ltc4284_dev {
+	struct no_os_i2c_desc *i2c_desc;    /* I2C communication descriptor */
+	uint8_t i2c_addr;                    /* Device I2C address */
+	uint16_t rsense_mohm;                /* Current sense resistor (mΩ) */
+	uint8_t vsense_mv;                   /* Sense voltage threshold (mV) */
+	struct no_os_gpio_desc *alert_gpio;  /* ALERT# pin descriptor (optional) */
+};
+
+/**
+ * @struct ltc4284_init_param
+ * @brief LTC4284 initialization parameters
+ */
+struct ltc4284_init_param {
+	struct no_os_i2c_init_param *i2c_init;     /* I2C initialization parameters */
+	uint8_t i2c_addr;                           /* Device I2C address */
+	uint16_t rsense_mohm;                       /* Sense resistor value (mΩ) */
+	uint8_t vsense_mv;                          /* Sense voltage (15, 20, 25, 30 mV) */
+	struct no_os_gpio_init_param *alert_gpio;   /* ALERT# pin init (optional) */
+};
+
+/******************************************************************************/
+/************************ Functions Declarations ******************************/
+/******************************************************************************/
+
+/* Device initialization and removal */
+int ltc4284_init(struct ltc4284_dev **device,
+		 const struct ltc4284_init_param *init_param);
+int ltc4284_remove(struct ltc4284_dev *dev);
+
+/* Register access functions */
+int ltc4284_read_byte(struct ltc4284_dev *dev, uint8_t reg, uint8_t *val);
+int ltc4284_write_byte(struct ltc4284_dev *dev, uint8_t reg, uint8_t val);
+int ltc4284_read_word(struct ltc4284_dev *dev, uint8_t reg, uint16_t *val);
+int ltc4284_write_word(struct ltc4284_dev *dev, uint8_t reg, uint16_t val);
+int ltc4284_update_bits(struct ltc4284_dev *dev, uint8_t reg,
+			uint8_t mask, uint8_t val);
+
+/* Monitoring functions */
+int ltc4284_read_vin(struct ltc4284_dev *dev, uint16_t *vin_mv);
+int ltc4284_read_iin(struct ltc4284_dev *dev, uint16_t *iin_ma);
+int ltc4284_read_vout(struct ltc4284_dev *dev, uint16_t *vout_mv);
+int ltc4284_read_power(struct ltc4284_dev *dev, uint32_t *power_mw);
+int ltc4284_read_energy(struct ltc4284_dev *dev, uint64_t *energy_mj);
+int ltc4284_read_temperature(struct ltc4284_dev *dev, int16_t *temp_mc);
+
+/* Control functions */
+int ltc4284_set_current_limit(struct ltc4284_dev *dev, uint8_t ilim_code);
+int ltc4284_enable_fet(struct ltc4284_dev *dev, bool enable);
+int ltc4284_clear_faults(struct ltc4284_dev *dev);
+
+/* Status and fault management */
+int ltc4284_read_status(struct ltc4284_dev *dev, uint8_t *status);
+int ltc4284_get_fault(struct ltc4284_dev *dev, uint8_t *faults);
+
+/* EEPROM functions */
+int ltc4284_store_config(struct ltc4284_dev *dev);
+int ltc4284_restore_config(struct ltc4284_dev *dev);
+
+#endif /* __LTC4284_H__ */

--- a/projects/ltc4284/Makefile
+++ b/projects/ltc4284/Makefile
@@ -1,0 +1,9 @@
+EXAMPLE ?= iio
+
+include ../../tools/scripts/generic_variables.mk
+
+include ../../tools/scripts/examples.mk
+
+include src.mk
+
+include ../../tools/scripts/generic.mk

--- a/projects/ltc4284/README.rst
+++ b/projects/ltc4284/README.rst
@@ -1,0 +1,290 @@
+LTC4284 Project
+===============
+
+Overview
+--------
+
+This project demonstrates the LTC4284 High Power Negative Voltage Hot Swap
+Controller driver running on the Maxim MAX32665 platform, interfacing with
+the DC2470A evaluation kit.
+
+The LTC4284 is designed for -48V distributed power systems commonly used in
+telecom infrastructure and data centers. It provides comprehensive hot swap
+control, power monitoring, and fault protection.
+
+Supported Evaluation Boards
+----------------------------
+
+* `DC2470A <https://www.analog.com/DC2470A>`_ - LTC4284 Evaluation Kit
+
+Hardware Setup
+--------------
+
+**Required Hardware:**
+
+* DC2470A Evaluation Kit (LTC4284 demo board)
+* MAX32665 Feather Board (or compatible Maxim MCU)
+* I2C cable/connections
+* -48V power supply (for DC2470A)
+* USB cable for UART console
+
+**Connections:**
+
+=================  =================  ===========================
+DC2470A            MAX32665           Description
+=================  =================  ===========================
+SDA                P0.16 (I2C0_SDA)   I2C data line
+SCL                P0.17 (I2C0_SCL)   I2C clock line
+ALERT# (optional)  GPIO pin           Alert interrupt (optional)
+GND                GND                Common ground
+=================  =================  ===========================
+
+**Power Configuration:**
+
+* DC2470A: Connect -48V input power supply
+* MAX32665: Connect USB for power and UART console
+* Ensure common ground connection between boards
+
+**I2C Address Configuration:**
+
+The LTC4284 I2C address is configured via ADR0 and ADR1 pins:
+
+======  ======  ==============
+ADR0    ADR1    Address
+======  ======  ==============
+GND     GND     0x28
+GND     INTVCC  0x29
+INTVCC  GND     0x2A (default)
+INTVCC  INTVCC  0x2B
+======  ======  ==============
+
+Software Setup
+--------------
+
+**Build Configuration:**
+
+The project supports multiple build configurations defined in ``builds.json``:
+
+.. code-block:: json
+
+   {
+       "maxim": {
+           "basic_max32665": {
+               "flags": "EXAMPLE=basic TARGET=max32665"
+           },
+           "iio_max32665": {
+               "flags": "EXAMPLE=iio TARGET=max32665"
+           }
+       }
+   }
+
+**Build Commands:**
+
+Basic monitoring example:
+
+.. code-block:: bash
+
+   cd projects/ltc4284
+   make EXAMPLE=basic TARGET=max32665
+
+IIO integration example:
+
+.. code-block:: bash
+
+   cd projects/ltc4284
+   make EXAMPLE=iio TARGET=max32665
+
+**Programming the MAX32665:**
+
+Using OpenOCD:
+
+.. code-block:: bash
+
+   openocd -f interface/cmsis-dap.cfg -f target/max32665.cfg \
+       -c "program build/ltc4284.elf verify reset exit"
+
+Using pyOCD:
+
+.. code-block:: bash
+
+   pyocd flash -t max32665 build/ltc4284.elf
+
+Running the Examples
+--------------------
+
+Basic Example
+~~~~~~~~~~~~~
+
+The basic example demonstrates continuous monitoring of the LTC4284:
+
+1. Flash the basic example firmware
+2. Connect UART console (115200 baud, 8N1)
+3. Reset the MAX32665 board
+4. Observe monitoring output
+
+**Expected Output:**
+
+.. code-block:: text
+
+   LTC4284 Basic Example
+   =====================
+
+   LTC4284 initialized successfully
+   I2C Address: 0x2A
+   RSENSE: 500 mohm
+   VSENSE: 25 mV
+
+   Initial Status: 0x00
+   Enabling FET drivers...
+
+   Continuous Monitoring (Ctrl+C to stop):
+   ------------------------------------------
+   VIN: 48120 mV | IIN:  1250 mA | VOUT: 47850 mV | Power:  60150 mW | Energy:  125000000 mJ | Temp: 25.375 C
+   VIN: 48115 mV | IIN:  1248 mA | VOUT: 47845 mV | Power:  60100 mW | Energy:  125060150 mJ | Temp: 25.500 C
+
+**Features:**
+
+* Real-time monitoring of VIN, IIN, VOUT, Power, Energy, Temperature
+* Automatic fault detection and clearing
+* FET enable/disable control
+* 1 Hz update rate
+
+IIO Example
+~~~~~~~~~~~
+
+The IIO example provides network-accessible telemetry via the Industrial I/O
+framework:
+
+1. Flash the IIO example firmware
+2. Connect UART console (115200 baud, 8N1)
+3. Reset the MAX32665 board
+4. Use pyadi-iio or libiio to access telemetry
+
+**Expected Output:**
+
+.. code-block:: text
+
+   LTC4284 IIO Example
+   ===================
+
+   LTC4284 IIO initialized successfully
+   IIO device: ltc4284
+   Channels: VIN, IIN, VOUT, Power, Energy
+
+   IIO app initialized successfully
+
+   Access via:
+     - pyadi-iio: uri='serial:/dev/ttyUSB0,115200'
+     - libiio: iiod -F ttyUSB0,115200
+
+   Running IIO app (Ctrl+C to stop)...
+
+**Using pyadi-iio:**
+
+.. code-block:: python
+
+   import adi
+
+   # Connect to LTC4284 via UART
+   dev = adi.ltc4284(uri="serial:/dev/ttyUSB0,115200")
+
+   # Read voltage measurements
+   vin = dev.voltage_in       # Input voltage in volts
+   vout = dev.voltage_out     # Output voltage in volts
+
+   # Read current
+   iin = dev.current_in       # Input current in amps
+
+   # Read power and energy
+   power = dev.power          # Power in watts
+   energy = dev.energy        # Cumulative energy in joules
+
+   print(f"VIN: {vin:.3f} V, IIN: {iin:.3f} A, Power: {power:.3f} W")
+
+**Using libiio:**
+
+.. code-block:: bash
+
+   # List devices
+   iio_info -u serial:/dev/ttyUSB0,115200
+
+   # Read channel attributes
+   iio_attr -u serial:/dev/ttyUSB0,115200 -d ltc4284 -c voltage0 raw
+   iio_attr -u serial:/dev/ttyUSB0,115200 -d ltc4284 -c current0 raw
+   iio_attr -u serial:/dev/ttyUSB0,115200 -d ltc4284 -c power0 raw
+
+Configuration
+-------------
+
+**Current Sense Resistor (RSENSE):**
+
+The current sensing configuration is defined in ``common_data.c``:
+
+.. code-block:: c
+
+   struct ltc4284_init_param ltc4284_ip = {
+       .rsense_mohm = 500,  // 0.5 mΩ sense resistor
+       .vsense_mv = 25,     // 25 mV sense voltage threshold
+   };
+
+Supported RSENSE values: 100 - 10000 mΩ (0.1 mΩ to 10 mΩ)
+
+**Sense Voltage Threshold (VSENSE):**
+
+Supported values: 15 mV, 20 mV, 25 mV, 30 mV
+
+**Current Limit Calculation:**
+
+.. code-block:: text
+
+   I_LIMIT = V_SENSE / R_SENSE
+
+   Example: 25 mV / 0.5 mΩ = 50 A maximum current
+
+Troubleshooting
+---------------
+
+**I2C Communication Failures:**
+
+* Verify I2C connections (SDA, SCL, GND)
+* Check I2C address configuration (ADR0, ADR1 pins)
+* Ensure pull-up resistors on I2C lines (typically 2.2kΩ to 10kΩ)
+* Verify DC2470A has power applied
+
+**Device Not Responding:**
+
+* Check that DC2470A has -48V power supply connected
+* Verify LTC4284 is not in shutdown mode
+* Check ALERT# pin if fault condition is latched
+* Try power cycling both boards
+
+**Incorrect Measurements:**
+
+* Verify RSENSE value in ``common_data.c`` matches hardware
+* Check VSENSE configuration
+* Ensure load is connected to DC2470A output
+* Verify ADC_CONTROL register configuration
+
+**Build Errors:**
+
+* Ensure correct TARGET specified (max32665)
+* Verify EXAMPLE variable (basic or iio)
+* Check that all dependencies are included in ``src.mk``
+* Review platform-specific includes in ``platform_src.mk``
+
+**UART Console Not Working:**
+
+* Verify baud rate: 115200, 8N1, no flow control
+* Check USB cable connection
+* Ensure correct COM port or /dev/ttyUSB device
+* Verify UART pins on MAX32665 (default UART0)
+
+Support
+-------
+
+For additional support:
+
+* `LTC4284 Product Page <https://www.analog.com/ltc4284>`_
+* `DC2470A Evaluation Kit <https://www.analog.com/DC2470A>`_
+* `LTC4284 Datasheet <https://www.analog.com/media/en/technical-documentation/data-sheets/ltc4284.pdf>`_
+* `no-OS Driver Documentation <https://wiki.analog.com/resources/tools-software/uc-drivers/no-os>`_

--- a/projects/ltc4284/builds.json
+++ b/projects/ltc4284/builds.json
@@ -1,0 +1,10 @@
+{
+	"maxim": {
+		"basic_max32665": {
+			"flags" : "EXAMPLE=basic TARGET=max32665"
+		},
+		"iio_max32665": {
+			"flags" : "EXAMPLE=iio TARGET=max32665"
+		}
+	}
+}

--- a/projects/ltc4284/src.mk
+++ b/projects/ltc4284/src.mk
@@ -1,0 +1,21 @@
+NO_OS_INC_DIRS += \
+	$(INCLUDE) \
+	$(PROJECT)/src/ \
+	$(DRIVERS)/api/
+
+INCS += $(DRIVERS)/power/ltc4284/ltc4284.h
+
+SRCS += $(PROJECT)/src/platform/$(PLATFORM)/main.c \
+	$(PROJECT)/src/common/common_data.c \
+	$(PROJECT)/src/platform/$(PLATFORM)/parameters.c \
+	$(NO-OS)/util/no_os_lf256fifo.c \
+	$(DRIVERS)/api/no_os_i2c.c \
+	$(DRIVERS)/api/no_os_dma.c \
+	$(DRIVERS)/api/no_os_uart.c \
+	$(DRIVERS)/api/no_os_irq.c \
+	$(DRIVERS)/api/no_os_gpio.c \
+	$(DRIVERS)/power/ltc4284/ltc4284.c \
+	$(NO-OS)/util/no_os_util.c \
+	$(NO-OS)/util/no_os_list.c \
+	$(NO-OS)/util/no_os_alloc.c \
+	$(NO-OS)/util/no_os_mutex.c

--- a/projects/ltc4284/src/common/common_data.c
+++ b/projects/ltc4284/src/common/common_data.c
@@ -1,0 +1,60 @@
+/***************************************************************************//**
+ *   @file   common_data.c
+ *   @brief  Common data implementation for LTC4284 project
+ *   @author Carlos Jones Jr <carlos.jones.jr@analog.com>
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "common_data.h"
+#include "parameters.h"
+
+struct no_os_uart_init_param ltc4284_uart_ip = {
+	.device_id = UART_DEVICE_ID,
+	.baud_rate = UART_BAUDRATE,
+	.size = NO_OS_UART_CS_8,
+	.parity = NO_OS_UART_PAR_NO,
+	.stop = NO_OS_UART_STOP_1_BIT,
+	.platform_ops = &max_uart_ops,
+	.extra = &ltc4284_uart_extra_ip
+};
+
+struct no_os_i2c_init_param ltc4284_i2c_ip = {
+	.device_id = I2C_DEVICE_ID,
+	.max_speed_hz = I2C_MAX_SPEED,
+	.platform_ops = &max_i2c_ops,
+	.extra = &ltc4284_i2c_extra_ip
+};
+
+struct ltc4284_init_param ltc4284_ip = {
+	.i2c_init = &ltc4284_i2c_ip,
+	.i2c_addr = LTC4284_I2C_ADDR_2,
+	.rsense_mohm = 500,
+	.vsense_mv = 25,
+	.alert_gpio = NULL
+};

--- a/projects/ltc4284/src/common/common_data.h
+++ b/projects/ltc4284/src/common/common_data.h
@@ -1,0 +1,45 @@
+/***************************************************************************//**
+ *   @file   common_data.h
+ *   @brief  Common data header for LTC4284 project
+ *   @author Carlos Jones Jr <carlos.jones.jr@analog.com>
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef __COMMON_DATA_H__
+#define __COMMON_DATA_H__
+
+#include "no_os_uart.h"
+#include "no_os_i2c.h"
+#include "ltc4284.h"
+
+extern struct no_os_uart_init_param ltc4284_uart_ip;
+extern struct no_os_i2c_init_param ltc4284_i2c_ip;
+extern struct ltc4284_init_param ltc4284_ip;
+
+#endif /* __COMMON_DATA_H__ */

--- a/projects/ltc4284/src/examples/basic/basic_example.c
+++ b/projects/ltc4284/src/examples/basic/basic_example.c
@@ -1,0 +1,174 @@
+/***************************************************************************//**
+ *   @file   basic_example.c
+ *   @brief  Basic example for LTC4284 project
+ *   @author Carlos Jones Jr <carlos.jones.jr@analog.com>
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <stdlib.h>
+#include "common_data.h"
+#include "ltc4284.h"
+#include "no_os_delay.h"
+#include "no_os_print_log.h"
+
+/**
+ * @brief Basic example main execution
+ * @return 0 in case of success, negative error code otherwise
+ */
+int example_main()
+{
+	struct ltc4284_dev *ltc4284_dev;
+	uint16_t vin_mv, iin_ma, vout_mv;
+	uint32_t power_mw;
+	uint64_t energy_mj;
+	int16_t temp_mc;
+	uint8_t status, faults;
+	int ret;
+
+	pr_info("LTC4284 Basic Example\n");
+	pr_info("=====================\n\n");
+
+	ret = ltc4284_init(&ltc4284_dev, &ltc4284_ip);
+	if (ret) {
+		pr_err("LTC4284 initialization failed: %d\n", ret);
+		return ret;
+	}
+
+	pr_info("LTC4284 initialized successfully\n");
+	pr_info("I2C Address: 0x%02X\n", ltc4284_dev->i2c_addr);
+	pr_info("RSENSE: %u mohm\n", ltc4284_dev->rsense_mohm);
+	pr_info("VSENSE: %u mV\n\n", ltc4284_dev->vsense_mv);
+
+	ret = ltc4284_read_status(ltc4284_dev, &status);
+	if (ret) {
+		pr_err("Failed to read status: %d\n", ret);
+		goto cleanup;
+	}
+
+	pr_info("Initial Status: 0x%02X\n", status);
+
+	ret = ltc4284_get_fault(ltc4284_dev, &faults);
+	if (ret == 0 && faults != 0) {
+		pr_info("Initial faults detected: 0x%02X\n", faults);
+		pr_info("Clearing initial faults...\n");
+		ltc4284_clear_faults(ltc4284_dev);
+	}
+
+	pr_info("Enabling FET drivers...\n");
+	ret = ltc4284_enable_fet(ltc4284_dev, true);
+	if (ret) {
+		pr_err("Failed to enable FET: %d\n", ret);
+		goto cleanup;
+	}
+
+	/* Wait for FET to turn on */
+	no_os_mdelay(100);
+
+	pr_info("\nContinuous Monitoring (Ctrl+C to stop):\n");
+	pr_info("------------------------------------------\n");
+
+	while (1) {
+		ret = ltc4284_read_vin(ltc4284_dev, &vin_mv);
+		if (ret) {
+			pr_err("Failed to read VIN: %d\n", ret);
+			goto cleanup;
+		}
+
+		ret = ltc4284_read_vout(ltc4284_dev, &vout_mv);
+		if (ret) {
+			pr_err("Failed to read VOUT: %d\n", ret);
+			goto cleanup;
+		}
+
+		ret = ltc4284_read_iin(ltc4284_dev, &iin_ma);
+		if (ret) {
+			pr_err("Failed to read IIN: %d\n", ret);
+			goto cleanup;
+		}
+
+		ret = ltc4284_read_power(ltc4284_dev, &power_mw);
+		if (ret) {
+			pr_err("Failed to read power: %d\n", ret);
+			goto cleanup;
+		}
+
+		ret = ltc4284_read_energy(ltc4284_dev, &energy_mj);
+		if (ret) {
+			pr_err("Failed to read energy: %d\n", ret);
+			goto cleanup;
+		}
+
+		ret = ltc4284_read_temperature(ltc4284_dev, &temp_mc);
+		if (ret) {
+			pr_err("Failed to read temperature: %d\n", ret);
+			goto cleanup;
+		}
+
+		pr_info("VIN: %5u mV | IIN: %5u mA | VOUT: %5u mV | ",
+			vin_mv, iin_ma, vout_mv);
+		pr_info("Power: %6u mW | Energy: %10llu mJ | ",
+			power_mw, (unsigned long long)energy_mj);
+		pr_info("Temp: %d.%03d C\n",
+			temp_mc / 1000, abs(temp_mc % 1000));
+
+		ret = ltc4284_get_fault(ltc4284_dev, &faults);
+		if (ret == 0 && faults != 0) {
+			pr_err("\n*** FAULT DETECTED: 0x%02X ***\n", faults);
+			if (faults & LTC4284_FAULT_OV)
+				pr_err("  - Overvoltage fault\n");
+			if (faults & LTC4284_FAULT_UV)
+				pr_err("  - Undervoltage fault\n");
+			if (faults & LTC4284_FAULT_OC)
+				pr_err("  - Overcurrent fault\n");
+			if (faults & LTC4284_FAULT_POWER_BAD)
+				pr_err("  - Power bad fault\n");
+			if (faults & LTC4284_FAULT_FET)
+				pr_err("  - FET fault\n");
+			if (faults & LTC4284_FAULT_OT)
+				pr_err("  - Over-temperature fault\n");
+
+			pr_info("Clearing faults...\n\n");
+			ltc4284_clear_faults(ltc4284_dev);
+		}
+
+		/* Update rate: 1 Hz */
+		no_os_mdelay(1000);
+	}
+
+cleanup:
+	ltc4284_enable_fet(ltc4284_dev, false);
+	ltc4284_remove(ltc4284_dev);
+
+	if (ret)
+		pr_err("Example failed: %d\n", ret);
+	else
+		pr_info("Example completed successfully\n");
+
+	return ret;
+}

--- a/projects/ltc4284/src/examples/iio/example.mk
+++ b/projects/ltc4284/src/examples/iio/example.mk
@@ -1,0 +1,4 @@
+IIOD = y
+
+INCS += $(DRIVERS)/power/ltc4284/iio_ltc4284.h
+SRCS += $(DRIVERS)/power/ltc4284/iio_ltc4284.c

--- a/projects/ltc4284/src/examples/iio/iio_example.c
+++ b/projects/ltc4284/src/examples/iio/iio_example.c
@@ -1,0 +1,103 @@
+/***************************************************************************//**
+ *   @file   iio_example.c
+ *   @brief  IIO example for LTC4284 project
+ *   @author Carlos Jones Jr <carlos.jones.jr@analog.com>
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "common_data.h"
+#include "iio_ltc4284.h"
+#include "no_os_print_log.h"
+#include "iio_app.h"
+
+/**
+ * @brief IIO example main execution
+ * @return 0 in case of success, negative error code otherwise
+ */
+int example_main()
+{
+	struct ltc4284_iio_desc *ltc4284_iio_desc;
+	struct ltc4284_iio_init_param ltc4284_iio_ip;
+	struct iio_app_desc *app;
+	struct iio_app_init_param app_init_param = {0};
+	int ret;
+
+	pr_info("LTC4284 IIO Example\n");
+	pr_info("===================\n\n");
+
+	ltc4284_iio_ip.ltc4284_init = &ltc4284_ip;
+
+	ret = ltc4284_iio_init(&ltc4284_iio_desc, &ltc4284_iio_ip);
+	if (ret) {
+		pr_err("LTC4284 IIO initialization failed: %d\n", ret);
+		return ret;
+	}
+
+	pr_info("LTC4284 IIO initialized successfully\n");
+	pr_info("IIO device: ltc4284\n");
+	pr_info("Channels: VIN, IIN, VOUT, Power, Energy\n\n");
+
+	struct iio_app_device iio_devices[] = {
+		{
+			.name = "ltc4284",
+			.dev = ltc4284_iio_desc,
+			.dev_descriptor = ltc4284_iio_desc->iio_dev,
+		}
+	};
+
+	app_init_param.devices = iio_devices;
+	app_init_param.nb_devices = NO_OS_ARRAY_SIZE(iio_devices);
+	app_init_param.uart_init_params = ltc4284_uart_ip;
+
+	ret = iio_app_init(&app, app_init_param);
+	if (ret) {
+		pr_err("IIO app initialization failed: %d\n", ret);
+		goto remove_iio;
+	}
+
+	pr_info("IIO app initialized successfully\n");
+	pr_info("\nAccess via:\n");
+	pr_info("  - pyadi-iio: uri='serial:/dev/ttyUSB0,115200'\n");
+	pr_info("  - libiio: iiod -F ttyUSB0,115200\n\n");
+	pr_info("Running IIO app (Ctrl+C to stop)...\n\n");
+
+	ret = iio_app_run(app);
+
+	iio_app_remove(app);
+
+remove_iio:
+	ltc4284_iio_remove(ltc4284_iio_desc);
+
+	if (ret)
+		pr_err("IIO example failed: %d\n", ret);
+	else
+		pr_info("IIO example completed successfully\n");
+
+	return ret;
+}

--- a/projects/ltc4284/src/platform/maxim/main.c
+++ b/projects/ltc4284/src/platform/maxim/main.c
@@ -1,0 +1,42 @@
+/***************************************************************************//**
+ *   @file   main.c
+ *   @brief  Main entry point for LTC4284 project on Maxim platform
+ *   @author Carlos Jones Jr <carlos.jones.jr@analog.com>
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "parameters.h"
+#include "common_data.h"
+
+extern int example_main();
+
+int main()
+{
+	return example_main();
+}

--- a/projects/ltc4284/src/platform/maxim/parameters.c
+++ b/projects/ltc4284/src/platform/maxim/parameters.c
@@ -1,0 +1,42 @@
+/***************************************************************************//**
+ *   @file   parameters.c
+ *   @brief  Platform parameters for LTC4284 project
+ *   @author Carlos Jones Jr <carlos.jones.jr@analog.com>
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "parameters.h"
+
+struct max_uart_init_param ltc4284_uart_extra_ip = {
+	.flow = MXC_UART_FLOW_DIS
+};
+
+struct max_i2c_init_param ltc4284_i2c_extra_ip = {
+	.vssel = MXC_GPIO_VSSEL_VDDIO
+};

--- a/projects/ltc4284/src/platform/maxim/parameters.h
+++ b/projects/ltc4284/src/platform/maxim/parameters.h
@@ -1,0 +1,50 @@
+/***************************************************************************//**
+ *   @file   parameters.h
+ *   @brief  Platform parameters for LTC4284 project
+ *   @author Carlos Jones Jr <carlos.jones.jr@analog.com>
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef __PARAMETERS_H__
+#define __PARAMETERS_H__
+
+#include "maxim_uart.h"
+#include "maxim_uart_stdio.h"
+#include "maxim_i2c.h"
+
+#define UART_DEVICE_ID  0
+#define UART_BAUDRATE   115200
+#define I2C_DEVICE_ID   0
+#define INTC_DEVICE_ID  0
+#define I2C_MAX_SPEED   400000
+
+extern struct max_uart_init_param ltc4284_uart_extra_ip;
+extern struct max_i2c_init_param ltc4284_i2c_extra_ip;
+
+#endif /* __PARAMETERS_H__ */

--- a/projects/ltc4284/src/platform/maxim/platform_src.mk
+++ b/projects/ltc4284/src/platform/maxim/platform_src.mk
@@ -1,0 +1,12 @@
+NO_OS_INC_DIRS += \
+	$(PLATFORM_DRIVERS) \
+	$(PLATFORM_DRIVERS)/../common/
+
+SRCS += $(PLATFORM_DRIVERS)/maxim_delay.c \
+	$(PLATFORM_DRIVERS)/maxim_gpio.c \
+	$(PLATFORM_DRIVERS)/maxim_gpio_irq.c \
+	$(PLATFORM_DRIVERS)/maxim_irq.c \
+	$(PLATFORM_DRIVERS)/../common/maxim_dma.c \
+	$(PLATFORM_DRIVERS)/maxim_i2c.c \
+	$(PLATFORM_DRIVERS)/maxim_uart.c \
+	$(PLATFORM_DRIVERS)/maxim_uart_stdio.c

--- a/tests/drivers/power/ltc4284/project.yml
+++ b/tests/drivers/power/ltc4284/project.yml
@@ -1,0 +1,86 @@
+---
+:project:
+  :use_exceptions: FALSE
+  :use_test_preprocessor: :all
+  :use_auxiliary_dependencies: TRUE
+  :build_root: build
+  :test_file_prefix: test_
+  :which_ceedling: gem
+  :ceedling_version: 1.0.1
+  :default_tasks:
+    - test:all
+
+:environment:
+
+:extension:
+  :executable: .out
+
+:paths:
+  :test:
+    - test
+  :source:
+    - ../../../../drivers/power/ltc4284/**
+  :support:
+    - test/support
+  :include:
+    - ../../../../include/**
+    - ../../../../drivers/power/ltc4284/**
+
+:defines:
+  :common: &common_defines []
+  :test:
+    - *common_defines
+    - TEST
+  :test_preprocess:
+    - *common_defines
+    - TEST
+
+:cmock:
+  :mock_prefix: mock_
+  :when_no_prototypes: :warn
+  :enforce_strict_ordering: FALSE
+  :plugins:
+    - :ignore
+    - :callback
+    - :return_thru_ptr
+  :treat_as:
+    uint8:    HEX8
+    uint16:   HEX16
+    uint32:   UINT32
+    int8:     INT8
+    bool:     UINT8
+
+:gcov:
+  :reports:
+    - HtmlDetailed
+  :gcovr:
+    :html_medium_threshold: 75
+    :html_high_threshold: 90
+    :report_include: "../../../../drivers/power/ltc4284/.*"
+
+:tools:
+  :release_compiler:
+    :executable: gcc
+    :arguments:
+      - -g
+      - -I"$": COLLECTION_PATHS_SOURCE_INCLUDE_VENDOR
+      - -D$: COLLECTION_DEFINES_RELEASE_AND_VENDOR
+      - -c "${1}"
+      - -o "${2}"
+  :release_linker:
+    :executable: gcc
+    :arguments:
+      - -o "${2}"
+      - "${1}"
+
+:report_tests_log_factory:
+  :reports:
+    - junit
+
+:plugins:
+  :enabled:
+    - report_tests_pretty_stdout
+    - module_generator
+    - report_tests_raw_output_log
+    - gcov
+    - report_tests_log_factory

--- a/tests/drivers/power/ltc4284/test/test_ltc4284.c
+++ b/tests/drivers/power/ltc4284/test/test_ltc4284.c
@@ -1,0 +1,1523 @@
+/***************************************************************************//**
+ *   @file   test_ltc4284.c
+ *   @brief  Unit tests for LTC4284 driver
+ *   @author Carlos Jones Jr <carlos.jones.jr@analog.com>
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include "unity.h"
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+#include "ltc4284.h"
+#include "mock_no_os_i2c.h"
+#include "mock_no_os_gpio.h"
+#include "mock_no_os_alloc.h"
+#include "mock_no_os_delay.h"
+
+/* Test device descriptors */
+static struct ltc4284_dev test_dev_storage;
+static struct ltc4284_dev *test_dev;
+static struct no_os_i2c_desc test_i2c_desc;
+static struct no_os_gpio_desc test_gpio_desc;
+
+/* Mock register storage for simulating hardware */
+static uint8_t mock_reg_value;
+static uint8_t mock_reg_data[8];
+
+/* Test I2C init parameters */
+static struct no_os_i2c_init_param test_i2c_init_param = {
+	.device_id = 0,
+	.max_speed_hz = 400000,
+	.slave_address = LTC4284_I2C_ADDR_2,
+};
+
+/* Test initialization parameters */
+static struct ltc4284_init_param test_init_param = {
+	.i2c_init = &test_i2c_init_param,
+	.i2c_addr = LTC4284_I2C_ADDR_2,
+	.rsense_mohm = 500,
+	.vsense_mv = 25,
+	.alert_gpio = NULL
+};
+
+/**
+ * @brief Custom stub for I2C read to return mock data
+ */
+static int stub_i2c_read(struct no_os_i2c_desc *desc, uint8_t *data,
+			 uint8_t bytes_number, uint8_t stop_bit, int num_calls)
+{
+	if (bytes_number <= sizeof(mock_reg_data)) {
+		memcpy(data, mock_reg_data, bytes_number);
+	}
+	return 0;
+}
+
+/**
+ * @brief Setup function called before each test
+ */
+void setUp(void)
+{
+	test_dev = NULL;
+	memset(&test_dev_storage, 0, sizeof(test_dev_storage));
+	memset(mock_reg_data, 0, sizeof(mock_reg_data));
+	test_dev_storage.i2c_desc = &test_i2c_desc;
+	test_dev_storage.i2c_addr = LTC4284_I2C_ADDR_2;
+	test_dev_storage.rsense_mohm = 500;
+	test_dev_storage.vsense_mv = 25;
+}
+
+/**
+ * @brief Teardown function called after each test
+ */
+void tearDown(void)
+{
+	test_dev = NULL;
+}
+
+/******************************************************************************/
+/************************** Initialization Tests ******************************/
+/******************************************************************************/
+
+/**
+ * @brief Test successful initialization
+ */
+void test_ltc4284_init_success(void)
+{
+	int ret;
+
+	/* Mock memory allocation */
+	no_os_calloc_ExpectAndReturn(1, sizeof(struct ltc4284_dev), &test_dev_storage);
+
+	/* Mock I2C initialization */
+	no_os_i2c_init_IgnoreAndReturn(0);
+
+	/* Mock initial register read for verification */
+	no_os_i2c_write_IgnoreAndReturn(0);
+	no_os_i2c_read_IgnoreAndReturn(0);
+
+	ret = ltc4284_init(&test_dev, &test_init_param);
+
+	TEST_ASSERT_EQUAL(0, ret);
+	TEST_ASSERT_NOT_NULL(test_dev);
+}
+
+/**
+ * @brief Test initialization with NULL device pointer
+ */
+void test_ltc4284_init_null_device(void)
+{
+	int ret;
+
+	ret = ltc4284_init(NULL, &test_init_param);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test initialization with NULL init parameters
+ */
+void test_ltc4284_init_null_params(void)
+{
+	int ret;
+
+	ret = ltc4284_init(&test_dev, NULL);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test initialization with invalid I2C address
+ */
+void test_ltc4284_init_invalid_i2c_addr(void)
+{
+	int ret;
+	struct ltc4284_init_param invalid_param = test_init_param;
+	invalid_param.i2c_addr = 0xFF;
+
+	ret = ltc4284_init(&test_dev, &invalid_param);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test initialization with invalid VSENSE
+ */
+void test_ltc4284_init_invalid_vsense(void)
+{
+	int ret;
+	struct ltc4284_init_param invalid_param = test_init_param;
+	invalid_param.vsense_mv = 35;  /* Invalid value */
+
+	ret = ltc4284_init(&test_dev, &invalid_param);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test initialization with I2C failure
+ */
+void test_ltc4284_init_i2c_fail(void)
+{
+	int ret;
+
+	/* Mock memory allocation */
+	no_os_calloc_ExpectAndReturn(1, sizeof(struct ltc4284_dev), &test_dev_storage);
+
+	/* Mock I2C init failure */
+	no_os_i2c_init_IgnoreAndReturn(-EIO);
+
+	/* Mock cleanup */
+	no_os_free_Expect(&test_dev_storage);
+
+	ret = ltc4284_init(&test_dev, &test_init_param);
+
+	TEST_ASSERT_EQUAL(-EIO, ret);
+}
+
+/**
+ * @brief Test initialization with memory allocation failure
+ */
+void test_ltc4284_init_alloc_fail(void)
+{
+	int ret;
+
+	/* Mock calloc failure */
+	no_os_calloc_ExpectAndReturn(1, sizeof(struct ltc4284_dev), NULL);
+
+	ret = ltc4284_init(&test_dev, &test_init_param);
+
+	TEST_ASSERT_EQUAL(-ENOMEM, ret);
+}
+
+/**
+ * @brief Test driver removal success
+ */
+void test_ltc4284_remove_success(void)
+{
+	int ret;
+
+	/* Mock FET disable (calls update_bits which does read-modify-write) */
+	no_os_i2c_write_IgnoreAndReturn(0);
+	no_os_i2c_read_IgnoreAndReturn(0);  /* For update_bits read */
+
+	/* Mock I2C removal */
+	no_os_i2c_remove_ExpectAndReturn(&test_i2c_desc, 0);
+
+	/* Mock memory free */
+	no_os_free_Expect(&test_dev_storage);
+
+	ret = ltc4284_remove(&test_dev_storage);
+
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+/**
+ * @brief Test driver removal with NULL device
+ */
+void test_ltc4284_remove_null(void)
+{
+	int ret;
+
+	ret = ltc4284_remove(NULL);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/******************************************************************************/
+/*********************** Register Access Tests ********************************/
+/******************************************************************************/
+
+/**
+ * @brief Test read byte success
+ */
+void test_ltc4284_read_byte_success(void)
+{
+	int ret;
+	uint8_t value = 0;
+
+	/* Setup mock data */
+	mock_reg_data[0] = 0x42;
+
+	/* Mock I2C operations */
+	no_os_i2c_write_IgnoreAndReturn(0);
+	no_os_i2c_read_Stub(stub_i2c_read);
+
+	ret = ltc4284_read_byte(&test_dev_storage, LTC4284_REG_SYSTEM_STATUS, &value);
+
+	TEST_ASSERT_EQUAL(0, ret);
+	TEST_ASSERT_EQUAL(0x42, value);
+}
+
+/**
+ * @brief Test read byte with NULL device
+ */
+void test_ltc4284_read_byte_null_dev(void)
+{
+	int ret;
+	uint8_t value;
+
+	ret = ltc4284_read_byte(NULL, LTC4284_REG_SYSTEM_STATUS, &value);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test read byte with NULL value pointer
+ */
+void test_ltc4284_read_byte_null_val(void)
+{
+	int ret;
+
+	ret = ltc4284_read_byte(&test_dev_storage, LTC4284_REG_SYSTEM_STATUS, NULL);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test write byte success
+ */
+void test_ltc4284_write_byte_success(void)
+{
+	int ret;
+	uint8_t value = 0x12;
+
+	/* Mock I2C write */
+	no_os_i2c_write_IgnoreAndReturn(0);
+
+	ret = ltc4284_write_byte(&test_dev_storage, LTC4284_REG_CONTROL_1, value);
+
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+/**
+ * @brief Test write byte with NULL device
+ */
+void test_ltc4284_write_byte_null(void)
+{
+	int ret;
+
+	ret = ltc4284_write_byte(NULL, LTC4284_REG_CONTROL_1, 0x12);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test read word success
+ */
+void test_ltc4284_read_word_success(void)
+{
+	int ret;
+	uint16_t value = 0;
+
+	/* Setup mock data (big-endian) */
+	mock_reg_data[0] = 0x12;
+	mock_reg_data[1] = 0x34;
+
+	/* Mock I2C operations */
+	no_os_i2c_write_IgnoreAndReturn(0);
+	no_os_i2c_read_Stub(stub_i2c_read);
+
+	ret = ltc4284_read_word(&test_dev_storage, LTC4284_REG_SENSE, &value);
+
+	TEST_ASSERT_EQUAL(0, ret);
+	TEST_ASSERT_EQUAL(0x1234, value);
+}
+
+/**
+ * @brief Test read word with NULL device
+ */
+void test_ltc4284_read_word_null_dev(void)
+{
+	int ret;
+	uint16_t value;
+
+	ret = ltc4284_read_word(NULL, LTC4284_REG_SENSE, &value);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test write word success
+ */
+void test_ltc4284_write_word_success(void)
+{
+	int ret;
+	uint16_t value = 0x1234;
+
+	/* Mock I2C write */
+	no_os_i2c_write_IgnoreAndReturn(0);
+
+	ret = ltc4284_write_word(&test_dev_storage, LTC4284_REG_SENSE, value);
+
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+/**
+ * @brief Test update bits success
+ */
+void test_ltc4284_update_bits_success(void)
+{
+	int ret;
+	uint8_t mask = 0x0F;
+	uint8_t new_bits = 0x05;
+
+	/* Setup current register value */
+	mock_reg_data[0] = 0xF0;
+
+	/* Mock read current value */
+	no_os_i2c_write_IgnoreAndReturn(0);
+	no_os_i2c_read_Stub(stub_i2c_read);
+
+	/* Mock write updated value (0xF5) */
+	no_os_i2c_write_IgnoreAndReturn(0);
+
+	ret = ltc4284_update_bits(&test_dev_storage, LTC4284_REG_CONTROL_1, mask,
+				  new_bits);
+
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+/**
+ * @brief Test update bits with NULL device
+ */
+void test_ltc4284_update_bits_null(void)
+{
+	int ret;
+
+	ret = ltc4284_update_bits(NULL, LTC4284_REG_CONTROL_1, 0x0F, 0x05);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/******************************************************************************/
+/*********************** Monitoring Function Tests ****************************/
+/******************************************************************************/
+
+/**
+ * @brief Test read VIN success
+ */
+void test_ltc4284_read_vin_success(void)
+{
+	int ret;
+	uint16_t vin_mv = 0;
+
+	/* Setup mock ADC data */
+	mock_reg_data[0] = 0x0C;
+	mock_reg_data[1] = 0x00;
+
+	/* Mock register read */
+	no_os_i2c_write_IgnoreAndReturn(0);
+	no_os_i2c_read_Stub(stub_i2c_read);
+
+	ret = ltc4284_read_vin(&test_dev_storage, &vin_mv);
+
+	TEST_ASSERT_EQUAL(0, ret);
+	/* Value depends on LTC4284_VPWR_LSB_UV scaling */
+}
+
+/**
+ * @brief Test read VIN with NULL device
+ */
+void test_ltc4284_read_vin_null_dev(void)
+{
+	int ret;
+	uint16_t vin_mv;
+
+	ret = ltc4284_read_vin(NULL, &vin_mv);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test read VIN with NULL output
+ */
+void test_ltc4284_read_vin_null_output(void)
+{
+	int ret;
+
+	ret = ltc4284_read_vin(&test_dev_storage, NULL);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test read IIN success
+ */
+void test_ltc4284_read_iin_success(void)
+{
+	int ret;
+	uint16_t iin_ma = 0;
+
+	/* Setup mock ADC data */
+	mock_reg_data[0] = 0x08;
+	mock_reg_data[1] = 0x00;
+
+	/* Mock register read */
+	no_os_i2c_write_IgnoreAndReturn(0);
+	no_os_i2c_read_Stub(stub_i2c_read);
+
+	ret = ltc4284_read_iin(&test_dev_storage, &iin_ma);
+
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+/**
+ * @brief Test read IIN with NULL device
+ */
+void test_ltc4284_read_iin_null_dev(void)
+{
+	int ret;
+	uint16_t iin_ma;
+
+	ret = ltc4284_read_iin(NULL, &iin_ma);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test read IIN with zero RSENSE (division by zero check)
+ */
+void test_ltc4284_read_iin_zero_rsense(void)
+{
+	int ret;
+	uint16_t iin_ma = 0;
+
+	/* Set RSENSE to 0 */
+	test_dev_storage.rsense_mohm = 0;
+
+	/* Setup mock ADC data */
+	mock_reg_data[0] = 0x08;
+	mock_reg_data[1] = 0x00;
+
+	/* Mock register read */
+	no_os_i2c_write_IgnoreAndReturn(0);
+	no_os_i2c_read_Stub(stub_i2c_read);
+
+	ret = ltc4284_read_iin(&test_dev_storage, &iin_ma);
+
+	/* Driver should catch division by zero */
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test read VOUT success
+ */
+void test_ltc4284_read_vout_success(void)
+{
+	int ret;
+	uint16_t vout_mv = 0;
+
+	/* Setup mock data */
+	mock_reg_data[0] = 0x0A;
+	mock_reg_data[1] = 0x00;
+
+	/* Mock register read */
+	no_os_i2c_write_IgnoreAndReturn(0);
+	no_os_i2c_read_Stub(stub_i2c_read);
+
+	ret = ltc4284_read_vout(&test_dev_storage, &vout_mv);
+
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+/**
+ * @brief Test read VOUT with NULL device
+ */
+void test_ltc4284_read_vout_null_dev(void)
+{
+	int ret;
+	uint16_t vout_mv;
+
+	ret = ltc4284_read_vout(NULL, &vout_mv);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test read power success
+ */
+void test_ltc4284_read_power_success(void)
+{
+	int ret;
+	uint32_t power_mw = 0;
+
+	/* Setup mock data */
+	mock_reg_data[0] = 0x10;
+	mock_reg_data[1] = 0x00;
+
+	/* Mock register read */
+	no_os_i2c_write_IgnoreAndReturn(0);
+	no_os_i2c_read_Stub(stub_i2c_read);
+
+	ret = ltc4284_read_power(&test_dev_storage, &power_mw);
+
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+/**
+ * @brief Test read power with NULL device
+ */
+void test_ltc4284_read_power_null_dev(void)
+{
+	int ret;
+	uint32_t power_mw;
+
+	ret = ltc4284_read_power(NULL, &power_mw);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test read energy success
+ */
+void test_ltc4284_read_energy_success(void)
+{
+	int ret;
+	uint64_t energy_mj = 0;
+
+	/* Setup mock 24-bit data */
+	mock_reg_data[0] = 0x01;
+	mock_reg_data[1] = 0x02;
+	mock_reg_data[2] = 0x03;
+
+	/* Mock register read */
+	no_os_i2c_write_IgnoreAndReturn(0);
+	no_os_i2c_read_Stub(stub_i2c_read);
+
+	ret = ltc4284_read_energy(&test_dev_storage, &energy_mj);
+
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+/**
+ * @brief Test read energy with NULL device
+ */
+void test_ltc4284_read_energy_null_dev(void)
+{
+	int ret;
+	uint64_t energy_mj;
+
+	ret = ltc4284_read_energy(NULL, &energy_mj);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test read temperature success
+ */
+void test_ltc4284_read_temperature_success(void)
+{
+	int ret;
+	int16_t temp_mc = 0;
+
+	/* Setup mock data */
+	mock_reg_data[0] = 0x06;
+	mock_reg_data[1] = 0x40;
+
+	/* Mock register read */
+	no_os_i2c_write_IgnoreAndReturn(0);
+	no_os_i2c_read_Stub(stub_i2c_read);
+
+	ret = ltc4284_read_temperature(&test_dev_storage, &temp_mc);
+
+	TEST_ASSERT_EQUAL(0, ret);
+	/* Placeholder implementation returns 25000 mC */
+	TEST_ASSERT_EQUAL(25000, temp_mc);
+}
+
+/**
+ * @brief Test read temperature with NULL device
+ */
+void test_ltc4284_read_temperature_null_dev(void)
+{
+	int ret;
+	int16_t temp_mc;
+
+	ret = ltc4284_read_temperature(NULL, &temp_mc);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/******************************************************************************/
+/************************** Status and Fault Tests ****************************/
+/******************************************************************************/
+
+/**
+ * @brief Test read status success
+ */
+void test_ltc4284_read_status_success(void)
+{
+	int ret;
+	uint8_t status = 0;
+
+	/* Setup mock status */
+	mock_reg_data[0] = 0x80;
+
+	/* Mock register read */
+	no_os_i2c_write_IgnoreAndReturn(0);
+	no_os_i2c_read_Stub(stub_i2c_read);
+
+	ret = ltc4284_read_status(&test_dev_storage, &status);
+
+	TEST_ASSERT_EQUAL(0, ret);
+	TEST_ASSERT_EQUAL(0x80, status);
+}
+
+/**
+ * @brief Test read status with NULL device
+ */
+void test_ltc4284_read_status_null_dev(void)
+{
+	int ret;
+	uint8_t status;
+
+	ret = ltc4284_read_status(NULL, &status);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test get fault success
+ */
+void test_ltc4284_get_fault_success(void)
+{
+	int ret;
+	uint8_t faults = 0;
+
+	/* Setup mock faults */
+	mock_reg_data[0] = 0x42;
+
+	/* Mock register read */
+	no_os_i2c_write_IgnoreAndReturn(0);
+	no_os_i2c_read_Stub(stub_i2c_read);
+
+	ret = ltc4284_get_fault(&test_dev_storage, &faults);
+
+	TEST_ASSERT_EQUAL(0, ret);
+	TEST_ASSERT_EQUAL(0x42, faults);
+}
+
+/**
+ * @brief Test get fault with NULL device
+ */
+void test_ltc4284_get_fault_null_dev(void)
+{
+	int ret;
+	uint8_t faults;
+
+	ret = ltc4284_get_fault(NULL, &faults);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test clear faults success
+ */
+void test_ltc4284_clear_faults_success(void)
+{
+	int ret;
+
+	/* Mock fault clear write */
+	no_os_i2c_write_IgnoreAndReturn(0);
+
+	ret = ltc4284_clear_faults(&test_dev_storage);
+
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+/**
+ * @brief Test clear faults with NULL device
+ */
+void test_ltc4284_clear_faults_null(void)
+{
+	int ret;
+
+	ret = ltc4284_clear_faults(NULL);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test clear faults with I2C error
+ */
+void test_ltc4284_clear_faults_i2c_error(void)
+{
+	int ret;
+
+	/* Mock I2C write failure */
+	no_os_i2c_write_IgnoreAndReturn(-EIO);
+
+	ret = ltc4284_clear_faults(&test_dev_storage);
+
+	TEST_ASSERT_EQUAL(-EIO, ret);
+}
+
+/******************************************************************************/
+/************************** Control Function Tests ****************************/
+/******************************************************************************/
+
+/**
+ * @brief Test enable FET success
+ */
+void test_ltc4284_enable_fet_success(void)
+{
+	int ret;
+
+	/* Setup mock current control value */
+	mock_reg_data[0] = 0x00;
+
+	/* Mock update_bits operations (read + write) */
+	no_os_i2c_write_IgnoreAndReturn(0);
+	no_os_i2c_read_Stub(stub_i2c_read);
+
+	ret = ltc4284_enable_fet(&test_dev_storage, true);
+
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+/**
+ * @brief Test enable FET with NULL device
+ */
+void test_ltc4284_enable_fet_null(void)
+{
+	int ret;
+
+	ret = ltc4284_enable_fet(NULL, true);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test set current limit success (valid code 0-15)
+ */
+void test_ltc4284_set_current_limit_success(void)
+{
+	int ret;
+
+	/* Setup mock register value */
+	mock_reg_data[0] = 0x00;
+
+	/* Mock update_bits operations (read + write) */
+	no_os_i2c_write_IgnoreAndReturn(0);
+	no_os_i2c_read_Stub(stub_i2c_read);
+
+	/* Use valid ilim_code (0-15) */
+	ret = ltc4284_set_current_limit(&test_dev_storage, 10);
+
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+/**
+ * @brief Test set current limit with NULL device
+ */
+void test_ltc4284_set_current_limit_null(void)
+{
+	int ret;
+
+	ret = ltc4284_set_current_limit(NULL, 10);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test set current limit with invalid code (> 15)
+ */
+void test_ltc4284_set_current_limit_invalid(void)
+{
+	int ret;
+
+	/* Try to set code > 15 (4-bit value) */
+	ret = ltc4284_set_current_limit(&test_dev_storage, 20);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/******************************************************************************/
+/************************** EEPROM Function Tests *****************************/
+/******************************************************************************/
+
+/**
+ * @brief Test store config success
+ */
+void test_ltc4284_store_config_success(void)
+{
+	int ret;
+
+	/* Setup mock: EEPROM not busy */
+	mock_reg_data[0] = 0x00;  /* EEPROM_BUSY bit not set */
+
+	/* Mock write snapshot command */
+	no_os_i2c_write_IgnoreAndReturn(0);
+
+	/* Mock status read (no busy bit) */
+	no_os_i2c_read_Stub(stub_i2c_read);
+
+	ret = ltc4284_store_config(&test_dev_storage);
+
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+/**
+ * @brief Test store config with NULL device
+ */
+void test_ltc4284_store_config_null(void)
+{
+	int ret;
+
+	ret = ltc4284_store_config(NULL);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test restore config success
+ */
+void test_ltc4284_restore_config_success(void)
+{
+	int ret;
+
+	/* Mock reboot command write */
+	no_os_i2c_write_IgnoreAndReturn(0);
+
+	ret = ltc4284_restore_config(&test_dev_storage);
+
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+/**
+ * @brief Test restore config with NULL device
+ */
+void test_ltc4284_restore_config_null(void)
+{
+	int ret;
+
+	ret = ltc4284_restore_config(NULL);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/******************************************************************************/
+/****************** Additional Error Path Coverage Tests *********************/
+/******************************************************************************/
+
+/**
+ * @brief Test read_byte with I2C write failure
+ */
+void test_ltc4284_read_byte_i2c_write_fail(void)
+{
+	int ret;
+	uint8_t value;
+
+	/* Mock I2C write failure */
+	no_os_i2c_write_IgnoreAndReturn(-EIO);
+
+	ret = ltc4284_read_byte(&test_dev_storage, LTC4284_REG_SYSTEM_STATUS, &value);
+
+	TEST_ASSERT_EQUAL(-EIO, ret);
+}
+
+/**
+ * @brief Test read_byte with I2C read failure
+ */
+void test_ltc4284_read_byte_i2c_read_fail(void)
+{
+	int ret;
+	uint8_t value;
+
+	/* Mock I2C write success, read failure */
+	no_os_i2c_write_IgnoreAndReturn(0);
+	no_os_i2c_read_IgnoreAndReturn(-EIO);
+
+	ret = ltc4284_read_byte(&test_dev_storage, LTC4284_REG_SYSTEM_STATUS, &value);
+
+	TEST_ASSERT_EQUAL(-EIO, ret);
+}
+
+/**
+ * @brief Test read_word with I2C write failure
+ */
+void test_ltc4284_read_word_i2c_write_fail(void)
+{
+	int ret;
+	uint16_t value;
+
+	/* Mock I2C write failure */
+	no_os_i2c_write_IgnoreAndReturn(-EIO);
+
+	ret = ltc4284_read_word(&test_dev_storage, LTC4284_REG_SENSE, &value);
+
+	TEST_ASSERT_EQUAL(-EIO, ret);
+}
+
+/**
+ * @brief Test read_word with I2C read failure
+ */
+void test_ltc4284_read_word_i2c_read_fail(void)
+{
+	int ret;
+	uint16_t value;
+
+	/* Mock I2C write success, read failure */
+	no_os_i2c_write_IgnoreAndReturn(0);
+	no_os_i2c_read_IgnoreAndReturn(-EIO);
+
+	ret = ltc4284_read_word(&test_dev_storage, LTC4284_REG_SENSE, &value);
+
+	TEST_ASSERT_EQUAL(-EIO, ret);
+}
+
+/**
+ * @brief Test read_word with NULL value pointer
+ */
+void test_ltc4284_read_word_null_val(void)
+{
+	int ret;
+
+	ret = ltc4284_read_word(&test_dev_storage, LTC4284_REG_SENSE, NULL);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test write_byte with I2C failure
+ */
+void test_ltc4284_write_byte_i2c_fail(void)
+{
+	int ret;
+
+	/* Mock I2C write failure */
+	no_os_i2c_write_IgnoreAndReturn(-EIO);
+
+	ret = ltc4284_write_byte(&test_dev_storage, LTC4284_REG_CONTROL_1, 0x12);
+
+	TEST_ASSERT_EQUAL(-EIO, ret);
+}
+
+/**
+ * @brief Test write_word with NULL device
+ */
+void test_ltc4284_write_word_null(void)
+{
+	int ret;
+
+	ret = ltc4284_write_word(NULL, LTC4284_REG_SENSE, 0x1234);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test write_word with I2C failure
+ */
+void test_ltc4284_write_word_i2c_fail(void)
+{
+	int ret;
+
+	/* Mock I2C write failure */
+	no_os_i2c_write_IgnoreAndReturn(-EIO);
+
+	ret = ltc4284_write_word(&test_dev_storage, LTC4284_REG_SENSE, 0x1234);
+
+	TEST_ASSERT_EQUAL(-EIO, ret);
+}
+
+/**
+ * @brief Test update_bits with read failure
+ */
+void test_ltc4284_update_bits_read_fail(void)
+{
+	int ret;
+
+	/* Mock I2C write success, read failure */
+	no_os_i2c_write_IgnoreAndReturn(0);
+	no_os_i2c_read_IgnoreAndReturn(-EIO);
+
+	ret = ltc4284_update_bits(&test_dev_storage, LTC4284_REG_CONTROL_1, 0x0F, 0x05);
+
+	TEST_ASSERT_EQUAL(-EIO, ret);
+}
+
+/**
+ * @brief Test update_bits with write failure
+ */
+void test_ltc4284_update_bits_write_fail(void)
+{
+	int ret;
+
+	/* Setup mock current value */
+	mock_reg_data[0] = 0xF0;
+
+	/* Mock read success */
+	no_os_i2c_write_IgnoreAndReturn(0);
+	no_os_i2c_read_Stub(stub_i2c_read);
+
+	/* Mock write failure (second write call) */
+	no_os_i2c_write_IgnoreAndReturn(-EIO);
+
+	ret = ltc4284_update_bits(&test_dev_storage, LTC4284_REG_CONTROL_1, 0x0F, 0x05);
+
+	TEST_ASSERT_EQUAL(-EIO, ret);
+}
+
+/**
+ * @brief Test init with GPIO get failure
+ */
+void test_ltc4284_init_gpio_get_fail(void)
+{
+	int ret;
+	struct no_os_gpio_init_param gpio_init = {0};
+	struct ltc4284_init_param param_with_gpio = test_init_param;
+	param_with_gpio.alert_gpio = &gpio_init;
+
+	/* Mock memory allocation */
+	no_os_calloc_ExpectAndReturn(1, sizeof(struct ltc4284_dev), &test_dev_storage);
+
+	/* Mock I2C init success */
+	no_os_i2c_init_IgnoreAndReturn(0);
+
+	/* Mock GPIO get failure */
+	no_os_gpio_get_optional_IgnoreAndReturn(-EIO);
+
+	/* Mock cleanup */
+	no_os_i2c_remove_IgnoreAndReturn(0);
+	no_os_free_Expect(&test_dev_storage);
+
+	ret = ltc4284_init(&test_dev, &param_with_gpio);
+
+	TEST_ASSERT_EQUAL(-EIO, ret);
+}
+
+/**
+ * @brief Test init with GPIO get success (optional GPIO)
+ * This tests the path where GPIO is provided but get_optional returns NULL
+ */
+void test_ltc4284_init_gpio_optional_null(void)
+{
+	int ret;
+	struct no_os_gpio_init_param gpio_init = {0};
+	struct ltc4284_init_param param_with_gpio = test_init_param;
+	param_with_gpio.alert_gpio = &gpio_init;
+
+	/* Mock memory allocation */
+	no_os_calloc_ExpectAndReturn(1, sizeof(struct ltc4284_dev), &test_dev_storage);
+
+	/* Mock I2C init success */
+	no_os_i2c_init_IgnoreAndReturn(0);
+
+	/* Mock GPIO get returning NULL (optional GPIO not available) */
+	no_os_gpio_get_optional_IgnoreAndReturn(0);
+	no_os_gpio_get_optional_ReturnThruPtr_desc(NULL);
+
+	/* Mock status read */
+	no_os_i2c_write_IgnoreAndReturn(0);
+	no_os_i2c_read_IgnoreAndReturn(0);
+
+	ret = ltc4284_init(&test_dev, &param_with_gpio);
+
+	/* Should succeed even without GPIO */
+	TEST_ASSERT_EQUAL(0, ret);
+}
+
+/**
+ * @brief Test init with status read failure
+ */
+void test_ltc4284_init_status_read_fail(void)
+{
+	int ret;
+
+	/* Mock memory allocation */
+	no_os_calloc_ExpectAndReturn(1, sizeof(struct ltc4284_dev), &test_dev_storage);
+
+	/* Mock I2C init success */
+	no_os_i2c_init_IgnoreAndReturn(0);
+
+	/* Mock status read failure */
+	no_os_i2c_write_IgnoreAndReturn(-EIO);
+
+	/* Mock cleanup */
+	no_os_i2c_remove_IgnoreAndReturn(0);
+	no_os_free_Expect(&test_dev_storage);
+
+	ret = ltc4284_init(&test_dev, &test_init_param);
+
+	TEST_ASSERT_EQUAL(-EIO, ret);
+}
+
+/**
+ * @brief Test remove with GPIO allocated
+ */
+void test_ltc4284_remove_with_gpio(void)
+{
+	int ret;
+
+	/* Add GPIO to device */
+	test_dev_storage.alert_gpio = &test_gpio_desc;
+
+	/* Mock FET disable */
+	no_os_i2c_write_IgnoreAndReturn(0);
+	no_os_i2c_read_IgnoreAndReturn(0);
+
+	/* Mock GPIO removal */
+	no_os_gpio_remove_ExpectAndReturn(&test_gpio_desc, 0);
+
+	/* Mock I2C removal */
+	no_os_i2c_remove_ExpectAndReturn(&test_i2c_desc, 0);
+
+	/* Mock memory free */
+	no_os_free_Expect(&test_dev_storage);
+
+	ret = ltc4284_remove(&test_dev_storage);
+
+	TEST_ASSERT_EQUAL(0, ret);
+
+	/* Clean up for next test */
+	test_dev_storage.alert_gpio = NULL;
+}
+
+/**
+ * @brief Test remove with FET disable failure
+ */
+void test_ltc4284_remove_fet_disable_fail(void)
+{
+	int ret;
+
+	/* Mock FET disable failure (update_bits read fails) */
+	no_os_i2c_write_IgnoreAndReturn(0);
+	no_os_i2c_read_IgnoreAndReturn(-EIO);
+
+	ret = ltc4284_remove(&test_dev_storage);
+
+	TEST_ASSERT_EQUAL(-EIO, ret);
+}
+
+/**
+ * @brief Test read_vin with I2C failure
+ */
+void test_ltc4284_read_vin_i2c_fail(void)
+{
+	int ret;
+	uint16_t vin_mv;
+
+	/* Mock I2C failure */
+	no_os_i2c_write_IgnoreAndReturn(-EIO);
+
+	ret = ltc4284_read_vin(&test_dev_storage, &vin_mv);
+
+	TEST_ASSERT_EQUAL(-EIO, ret);
+}
+
+/**
+ * @brief Test read_iin with I2C failure
+ */
+void test_ltc4284_read_iin_i2c_fail(void)
+{
+	int ret;
+	uint16_t iin_ma;
+
+	/* Mock I2C failure */
+	no_os_i2c_write_IgnoreAndReturn(-EIO);
+
+	ret = ltc4284_read_iin(&test_dev_storage, &iin_ma);
+
+	TEST_ASSERT_EQUAL(-EIO, ret);
+}
+
+/**
+ * @brief Test read_iin with NULL output
+ */
+void test_ltc4284_read_iin_null_output(void)
+{
+	int ret;
+
+	ret = ltc4284_read_iin(&test_dev_storage, NULL);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test read_vout with I2C failure
+ */
+void test_ltc4284_read_vout_i2c_fail(void)
+{
+	int ret;
+	uint16_t vout_mv;
+
+	/* Mock I2C failure */
+	no_os_i2c_write_IgnoreAndReturn(-EIO);
+
+	ret = ltc4284_read_vout(&test_dev_storage, &vout_mv);
+
+	TEST_ASSERT_EQUAL(-EIO, ret);
+}
+
+/**
+ * @brief Test read_vout with NULL output
+ */
+void test_ltc4284_read_vout_null_output(void)
+{
+	int ret;
+
+	ret = ltc4284_read_vout(&test_dev_storage, NULL);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test read_power with I2C failure
+ */
+void test_ltc4284_read_power_i2c_fail(void)
+{
+	int ret;
+	uint32_t power_mw;
+
+	/* Mock I2C failure */
+	no_os_i2c_write_IgnoreAndReturn(-EIO);
+
+	ret = ltc4284_read_power(&test_dev_storage, &power_mw);
+
+	TEST_ASSERT_EQUAL(-EIO, ret);
+}
+
+/**
+ * @brief Test read_power with NULL output
+ */
+void test_ltc4284_read_power_null_output(void)
+{
+	int ret;
+
+	ret = ltc4284_read_power(&test_dev_storage, NULL);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test read_energy with I2C write failure
+ */
+void test_ltc4284_read_energy_i2c_write_fail(void)
+{
+	int ret;
+	uint64_t energy_mj;
+
+	/* Mock I2C write failure */
+	no_os_i2c_write_IgnoreAndReturn(-EIO);
+
+	ret = ltc4284_read_energy(&test_dev_storage, &energy_mj);
+
+	TEST_ASSERT_EQUAL(-EIO, ret);
+}
+
+/**
+ * @brief Test read_energy with I2C read failure
+ */
+void test_ltc4284_read_energy_i2c_read_fail(void)
+{
+	int ret;
+	uint64_t energy_mj;
+
+	/* Mock I2C write success, read failure */
+	no_os_i2c_write_IgnoreAndReturn(0);
+	no_os_i2c_read_IgnoreAndReturn(-EIO);
+
+	ret = ltc4284_read_energy(&test_dev_storage, &energy_mj);
+
+	TEST_ASSERT_EQUAL(-EIO, ret);
+}
+
+/**
+ * @brief Test read_energy with NULL output
+ */
+void test_ltc4284_read_energy_null_output(void)
+{
+	int ret;
+
+	ret = ltc4284_read_energy(&test_dev_storage, NULL);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test read_temperature with I2C failure
+ */
+void test_ltc4284_read_temperature_i2c_fail(void)
+{
+	int ret;
+	int16_t temp_mc;
+
+	/* Mock I2C failure */
+	no_os_i2c_write_IgnoreAndReturn(-EIO);
+
+	ret = ltc4284_read_temperature(&test_dev_storage, &temp_mc);
+
+	TEST_ASSERT_EQUAL(-EIO, ret);
+}
+
+/**
+ * @brief Test read_temperature with NULL output
+ */
+void test_ltc4284_read_temperature_null_output(void)
+{
+	int ret;
+
+	ret = ltc4284_read_temperature(&test_dev_storage, NULL);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test read_status with NULL output
+ */
+void test_ltc4284_read_status_null_output(void)
+{
+	int ret;
+
+	ret = ltc4284_read_status(&test_dev_storage, NULL);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test read_status with I2C failure
+ */
+void test_ltc4284_read_status_i2c_fail(void)
+{
+	int ret;
+	uint8_t status;
+
+	/* Mock I2C failure */
+	no_os_i2c_write_IgnoreAndReturn(-EIO);
+
+	ret = ltc4284_read_status(&test_dev_storage, &status);
+
+	TEST_ASSERT_EQUAL(-EIO, ret);
+}
+
+/**
+ * @brief Test get_fault with NULL output
+ */
+void test_ltc4284_get_fault_null_output(void)
+{
+	int ret;
+
+	ret = ltc4284_get_fault(&test_dev_storage, NULL);
+
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+}
+
+/**
+ * @brief Test get_fault with I2C failure
+ */
+void test_ltc4284_get_fault_i2c_fail(void)
+{
+	int ret;
+	uint8_t faults;
+
+	/* Mock I2C failure */
+	no_os_i2c_write_IgnoreAndReturn(-EIO);
+
+	ret = ltc4284_get_fault(&test_dev_storage, &faults);
+
+	TEST_ASSERT_EQUAL(-EIO, ret);
+}
+
+/**
+ * @brief Test enable_fet with I2C failure
+ */
+void test_ltc4284_enable_fet_i2c_fail(void)
+{
+	int ret;
+
+	/* Mock I2C failure */
+	no_os_i2c_write_IgnoreAndReturn(-EIO);
+
+	ret = ltc4284_enable_fet(&test_dev_storage, true);
+
+	TEST_ASSERT_EQUAL(-EIO, ret);
+}
+
+/**
+ * @brief Test set_current_limit with I2C failure
+ */
+void test_ltc4284_set_current_limit_i2c_fail(void)
+{
+	int ret;
+
+	/* Mock I2C failure */
+	no_os_i2c_write_IgnoreAndReturn(-EIO);
+
+	ret = ltc4284_set_current_limit(&test_dev_storage, 10);
+
+	TEST_ASSERT_EQUAL(-EIO, ret);
+}
+
+/**
+ * @brief Test store_config with I2C write failure
+ */
+void test_ltc4284_store_config_i2c_write_fail(void)
+{
+	int ret;
+
+	/* Mock I2C write failure */
+	no_os_i2c_write_IgnoreAndReturn(-EIO);
+
+	ret = ltc4284_store_config(&test_dev_storage);
+
+	TEST_ASSERT_EQUAL(-EIO, ret);
+}
+
+/**
+ * @brief Test store_config with I2C read failure
+ */
+void test_ltc4284_store_config_i2c_read_fail(void)
+{
+	int ret;
+
+	/* Mock write success, read failure */
+	no_os_i2c_write_IgnoreAndReturn(0);
+	no_os_i2c_read_IgnoreAndReturn(-EIO);
+
+	ret = ltc4284_store_config(&test_dev_storage);
+
+	TEST_ASSERT_EQUAL(-EIO, ret);
+}
+
+/**
+ * @brief Test restore_config with I2C failure
+ */
+void test_ltc4284_restore_config_i2c_fail(void)
+{
+	int ret;
+
+	/* Mock I2C write failure */
+	no_os_i2c_write_IgnoreAndReturn(-EIO);
+
+	ret = ltc4284_restore_config(&test_dev_storage);
+
+	TEST_ASSERT_EQUAL(-EIO, ret);
+}


### PR DESCRIPTION
## Pull Request Description

The LTC4284 is a high-power negative voltage hot swap controller with integrated I²C energy monitor and EEPROM.

Key features include:
- Voltage Range: -48V systems (negative voltage hot swap)
- Application: Telecom infrastructure, data centers, server applications
- MOSFET Control: Dual-gate N-channel MOSFET driver for high power applications
- Current Monitoring: Up to 24-bit resolution with external sense resistor
- Power & Energy Monitoring: Real-time power calculation and energy accumulation
- Configurable Protection: Over-current, MOSFET SOA timer, current limit foldback
- Operating Modes: Parallel, Staged Start, or Single modes
- I2C Interface: 100kHz/400kHz with programmable addresses (0x28-0x2B)

The device drives external N-channel MOSFETs to allow a board to be safely inserted and removed from a live backplane, with comprehensive protection against overstresses.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
