### PR TITLE
Update ad7124_app.c

### DIFF
--- a/projects/ad-ethernetAPLdevice-sl/src/examples/ad7124_app/ad7124_app.c
+++ b/projects/ad-ethernetAPLdevice-sl/src/examples/ad7124_app/ad7124_app.c
@@ -164,10 +164,6 @@ int ad7124_app_main(void)
 	if (ret != 0)
 		return ret;
 
-	ret = ad7124_calibrate(dev);
-	if (ret)
-		printf("ADC calibration failed! (%d)\n", ret);
-
 	/* Enable excitation current 250uA on AIN0 */
 	ret = ad7124_reg_write_msk(dev, AD7124_IOCon1, AD7124_IO_CTRL1_REG_IOUT0(3),
 				   AD7124_IO_CTRL1_REG_IOUT0(0x7));
@@ -190,6 +186,10 @@ int ad7124_app_main(void)
 				   AD7124_IO_CTRL1_REG_PDSW);
 	if (ret != 0)
 		return ret;
+
+	ret = ad7124_calibrate(dev);
+	if (ret)
+		printf("ADC calibration failed! (%d)\n", ret);
 
 	/* Enable saturation error diagnostic */
 	ad7124_regs[AD7124_Error_En].value = 0x10000;


### PR DESCRIPTION
**projects: ad-ethernetAPLdevice-sl: call ad7124 calibration**

This change updates the ad-ethernetAPLdevice-sl project to call ad7124_calibrate() after ADC initialization.

This ensures calibration is performed before temperature acquisition when using the AD7124.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [X ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [X ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [X ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ X] I have performed a self-review of the changes
- [X ] I have commented my code, at least hard-to-understand parts
- [X ] I have build all projects affected by the changes in this PR
- [ X] I have tested in hardware affected projects, at the relevant boards
- [X ] I have signed off all commits from this PR
- [X ] I have updated the documentation (wiki pages, ReadMe etc), if applies
