### PR TITLE
drivers: adc: ad4080: fix operating mode store mapping

### DIFF
--- a/drivers/adc/ad4080/iio_ad4080.c
+++ b/drivers/adc/ad4080/iio_ad4080.c
@@ -1128,6 +1128,8 @@ static int device_mode_glob_attr_handler(struct iio_ad4080_desc *iio_ad4080,
 	uint8_t reg_val;
 	size_t i;
 	size_t count;
+	/* Normal, Standby, Sleep register encodings */
+	const uint8_t op_mode_reg[] = { 0, 2, 3 };
 
 	ad4080_read(iio_ad4080->ad4080, AD4080_REG_DEVICE_CONFIG, &reg_val);
 	if (show) {
@@ -1147,15 +1149,7 @@ static int device_mode_glob_attr_handler(struct iio_ad4080_desc *iio_ad4080,
 	count = sizeof operating_modes / sizeof operating_modes[0];
 	for (i = 0; i < count; i++) {
 		if (strcmp(buf, operating_modes[i]) == 0) {
-			switch (i) {
-			case 0:
-			case 2:
-			case 3:
-				reg_val = (reg_val & ~AD4080_OP_MODE_MSK) | i;
-				break;
-			default:
-				return -1;
-			}
+			reg_val = (reg_val & ~AD4080_OP_MODE_MSK) | op_mode_reg[i];
 
 			err = ad4080_write(iio_ad4080->ad4080,
 					   AD4080_REG_DEVICE_CONFIG,


### PR DESCRIPTION
The store handler wrote the array index (0,1,2) to the OP_MODE field, but the encodings are 0/2/3. Map the index via a lookup table so "Standby" and "Sleep" program the correct values.

Fixes: f87151885d63 ("drivers: adc: ad4080: Add IIO support to ad4080")

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
