### PR TITLE
drivers: adc: ad4080: add AD408x family chip_info infrastructure

### DIFF
--- a/drivers/adc/ad4080/README.rst
+++ b/drivers/adc/ad4080/README.rst
@@ -4,7 +4,13 @@ AD4080 no-OS Driver
 Supported Devices
 -----------------
 
-`AD4080 <https://www.analog.com/AD4080>`_
+* `AD4080 <https://www.analog.com/AD4080>`_
+* `AD4082 <https://www.analog.com/AD4082>`_
+* `AD4083 <https://www.analog.com/AD4083>`_
+* `AD4085 <https://www.analog.com/AD4085>`_
+* `AD4086 <https://www.analog.com/AD4086>`_
+* `AD4087 <https://www.analog.com/AD4087>`_
+* `AD4088 <https://www.analog.com/AD4088>`_
 
 Overview
 --------
@@ -18,6 +24,12 @@ Simplification of the input anti-alias filter design can be accomplished by
 applying oversampling along with the integrated digital filtering and decimation
 to reduce noise and lower the output data rate for applications that do not
 require the lowest latency of the AD4080.
+
+The driver supports several parts of the AD408x family. These parts are
+register-compatible and differ in ADC resolution: the AD4080 and AD4082 are
+20-bit, the AD4083 and AD4085 are 16-bit, and the AD4086, AD4087 and AD4088
+are 14-bit. The specific part is selected through the ``id`` field of the
+initialization parameter.
 
 Applications
 ------------
@@ -43,11 +55,15 @@ Driver Initialization
 
 The **ad4080_init** function initializes the AD4080 device by allocating memory
 for the device structure, setting up two SPI interfaces (one for configuration
-and one for data), and verifying communication with the chip by reading its ID.
-It performs a software reset, configures SPI settings like 3-wire mode and
-address auto-increment, sets the device's operating mode, and initializes both
-the configuration and data interfaces. Throughout the process, it checks for
-errors at each step and performs cleanup if any initialization fails.
+and one for data), and verifying communication with the chip by reading its
+chip type and product ID. The specific part within the AD408x family is selected
+through the ``id`` field of the initialization parameter, which is used to look
+up the matching entry in the chip information table; the product ID read back
+from the device is checked against the expected value for that part. It performs
+a software reset, configures SPI settings like 3-wire mode and address
+auto-increment, sets the device's operating mode, and initializes both the
+configuration and data interfaces. Throughout the process, it checks for errors
+at each step and performs cleanup if any initialization fails.
 
 SPI Configuration
 -------------------

--- a/drivers/adc/ad4080/ad4080.c
+++ b/drivers/adc/ad4080/ad4080.c
@@ -40,6 +40,51 @@
 
 /******************************************************************************/
 
+const struct ad4080_chip_info ad4080_chip_info_tbl[NUM_AD4080_DEVICES] = {
+	[ID_AD4080] = {
+		.name = "ad4080",
+		.product_id = AD4080_PRODUCT_ID,
+		.num_bits = 20,
+		.lvds_cnv_clk_cnt_max = 7,
+	},
+	[ID_AD4082] = {
+		.name = "ad4082",
+		.product_id = AD4082_PRODUCT_ID,
+		.num_bits = 20,
+		.lvds_cnv_clk_cnt_max = 8,
+	},
+	[ID_AD4083] = {
+		.name = "ad4083",
+		.product_id = AD4083_PRODUCT_ID,
+		.num_bits = 16,
+		.lvds_cnv_clk_cnt_max = 5,
+	},
+	[ID_AD4085] = {
+		.name = "ad4085",
+		.product_id = AD4085_PRODUCT_ID,
+		.num_bits = 16,
+		.lvds_cnv_clk_cnt_max = 8,
+	},
+	[ID_AD4086] = {
+		.name = "ad4086",
+		.product_id = AD4086_PRODUCT_ID,
+		.num_bits = 14,
+		.lvds_cnv_clk_cnt_max = 4,
+	},
+	[ID_AD4087] = {
+		.name = "ad4087",
+		.product_id = AD4087_PRODUCT_ID,
+		.num_bits = 14,
+		.lvds_cnv_clk_cnt_max = 1,
+	},
+	[ID_AD4088] = {
+		.name = "ad4088",
+		.product_id = AD4088_PRODUCT_ID,
+		.num_bits = 14,
+		.lvds_cnv_clk_cnt_max = 8,
+	},
+};
+
 /**
  * @brief Safely select the SPI slave.
  *
@@ -609,6 +654,9 @@ int ad4080_set_lvds_cnv_clk_cnt(struct ad4080_dev *dev,
 	int ret;
 
 	if (!dev)
+		return -EINVAL;
+
+	if (lvds_cnv_clk_cnt > dev->chip_info->lvds_cnv_clk_cnt_max)
 		return -EINVAL;
 
 	ret = ad4080_update_bits(dev, AD4080_REG_DATA_INTF_CONFIG_B,
@@ -1244,12 +1292,18 @@ int ad4080_init(struct ad4080_dev **device,
 		struct ad4080_init_param init_param)
 {
 	struct ad4080_dev *dev;
+	uint16_t product_id;
 	uint8_t data;
 	int ret;
+
+	if (init_param.id >= NUM_AD4080_DEVICES)
+		return -EINVAL;
 
 	dev = (struct ad4080_dev *)calloc(1, sizeof(*dev) + init_param.privdata_len);
 	if (!dev)
 		return -ENOMEM;
+
+	dev->chip_info = &ad4080_chip_info_tbl[init_param.id];
 
 	/* init the config spi */
 	ret = ad4080_init_spi(&dev->cfg, &init_param.cfg);
@@ -1266,6 +1320,22 @@ int ad4080_init(struct ad4080_dev **device,
 		goto error_data_spi;
 
 	if (data != AD4080_CHIP_ID) {
+		ret = -EINVAL;
+		goto error_data_spi;
+	}
+
+	/* Verify the part matches the requested device ID */
+	ret = ad4080_read(dev, AD4080_REG_PRODUCT_ID_L, &data);
+	if (ret)
+		goto error_data_spi;
+	product_id = data;
+
+	ret = ad4080_read(dev, AD4080_REG_PRODUCT_ID_H, &data);
+	if (ret)
+		goto error_data_spi;
+	product_id |= no_os_field_prep(BYTE_ADDR_H, data);
+
+	if (product_id != dev->chip_info->product_id) {
 		ret = -EINVAL;
 		goto error_data_spi;
 	}

--- a/drivers/adc/ad4080/ad4080.h
+++ b/drivers/adc/ad4080/ad4080.h
@@ -158,7 +158,6 @@
 #define AD4080_ADC_GRANULARITY 	20 	/* 20 Bits precision */
 #define ADC_REF_VOLTAGE 	3300 	/* mV granularity */
 #define AD4080_ADC_MAX_RESOLUTION_VAL 	((1 << AD4080_ADC_GRANULARITY) - 1)
-#define AD4080_DEFAULT_SCALE 	(((((double)ADC_REF_VOLTAGE)/1000) / AD4080_ADC_MAX_RESOLUTION_VAL) * 1E3L) /* 1E3 converts volts to millivolts: 1 x 10^3 = 1000. */
 #define OFFSET_CORRECTION_NEGATIVE_LIMIT 	0x800
 
 

--- a/drivers/adc/ad4080/ad4080.h
+++ b/drivers/adc/ad4080/ad4080.h
@@ -142,6 +142,15 @@
 #define BYTE_ADDR_H				NO_OS_GENMASK(15, 8)
 #define BYTE_ADDR_L				NO_OS_GENMASK(7, 0)
 #define AD4080_CHIP_ID				NO_OS_GENMASK(2, 0)
+
+/** AD408x Product IDs (PRODUCT_ID_H:PRODUCT_ID_L) */
+#define AD4080_PRODUCT_ID			0x0050
+#define AD4082_PRODUCT_ID			0x0052
+#define AD4083_PRODUCT_ID			0x0053
+#define AD4085_PRODUCT_ID			0x0055
+#define AD4086_PRODUCT_ID			0x0056
+#define AD4087_PRODUCT_ID			0x0057
+#define AD4088_PRODUCT_ID			0x0058
 #define AD4080_FIFO_SIZE		  NO_OS_BIT(14)
 #define AD4080_FIFO_DEPTH 	16384 	/* AD4080 is 16K deep maximum */
 #define AD4080_MAX_FIFO_WATERMARK 	(AD4080_FIFO_DEPTH)
@@ -271,6 +280,35 @@ enum ad4080_fifo_mode {
 	AD4080_EVENT_TRIGGER,
 };
 
+/** AD408x Supported Device IDs */
+enum ad4080_id {
+	ID_AD4080,
+	ID_AD4082,
+	ID_AD4083,
+	ID_AD4085,
+	ID_AD4086,
+	ID_AD4087,
+	ID_AD4088,
+	NUM_AD4080_DEVICES,
+};
+
+/**
+ * @struct ad4080_chip_info
+ * @brief AD408x part-specific information.
+ */
+struct ad4080_chip_info {
+	/** Device name */
+	const char *name;
+	/** Product ID (PRODUCT_ID_H:PRODUCT_ID_L) */
+	uint16_t product_id;
+	/** ADC resolution in bits */
+	uint8_t num_bits;
+	/** Maximum LVDS interface clock periods from CNV rising edge */
+	uint8_t lvds_cnv_clk_cnt_max;
+};
+
+extern const struct ad4080_chip_info ad4080_chip_info_tbl[NUM_AD4080_DEVICES];
+
 struct ad4080_spi_desc {
 	struct no_os_spi_desc *spi;
 	struct no_os_gpio_desc *ss;
@@ -287,6 +325,8 @@ struct ad4080_gp_desc {
  * @brief ad4080 Device structure.
  */
 struct ad4080_dev {
+	/** Part-specific information */
+	const struct ad4080_chip_info *chip_info;
 	/* SPI */
 	struct ad4080_spi_desc 	cfg;
 	struct ad4080_spi_desc 	data;
@@ -346,6 +386,8 @@ struct ad4080_gp_init_param {
  * @brief ad4080 Device initialization parameters.
  */
 struct ad4080_init_param {
+	/** Device ID (selects the AD408x part) */
+	enum ad4080_id id;
 	/* SPI */
 	struct ad4080_spi_init_param cfg;
 	struct ad4080_spi_init_param data;

--- a/drivers/adc/ad4080/iio_ad4080.c
+++ b/drivers/adc/ad4080/iio_ad4080.c
@@ -154,14 +154,19 @@ static const unsigned long sampling_frequency[] = {
  * @param data - The formatted data to be filled.
  * @param raw_data - The raw data read from the FIFO.
  * @param count - The number of samples to format.
+ * @param bytes_per_sample - Number of raw bytes per conversion sample.
  */
 static void ad4080_format_raw_data(uint32_t *data, uint8_t *raw_data,
-				   size_t count)
+				   size_t count, uint8_t bytes_per_sample)
 {
 	size_t i;
 	for (i = 0; i < count; i++) {
-		uint8_t *p = &raw_data[3 * i + 1];
-		data[i] = no_os_get_unaligned_be24(p);
+		/* skip the leading 0xAA synchro byte */
+		uint8_t *p = &raw_data[bytes_per_sample * i + 1];
+		if (bytes_per_sample == 3)
+			data[i] = no_os_get_unaligned_be24(p);
+		else
+			data[i] = no_os_get_unaligned_be16(p);
 	}
 	return;
 }
@@ -176,6 +181,7 @@ static int iio_ad4080_read_data(struct iio_ad4080_desc *iio_ad4080)
 {
 	struct ad4080_dev *dev = iio_ad4080->ad4080;
 	struct iio_ad4080_fifo_struct *fifo;
+	uint8_t bytes_per_sample;
 	int err;
 
 	/* first read raw fifo data */
@@ -185,8 +191,9 @@ static int iio_ad4080_read_data(struct iio_ad4080_desc *iio_ad4080)
 		return err;
 
 	/* then condition the raw data to make it readable */
+	bytes_per_sample = NO_OS_DIV_ROUND_UP(dev->chip_info->num_bits, 8);
 	ad4080_format_raw_data(fifo->formatted_fifo, fifo->raw_fifo,
-			       fifo->watermark);
+			       fifo->watermark, bytes_per_sample);
 
 	return err;
 }
@@ -300,8 +307,13 @@ static int scale_attr_handler(struct iio_ad4080_desc *iio_ad4080,
 			      const struct iio_ch_info *ch_info,
 			      bool show)
 {
-	const double ad4080_scale = AD4080_DEFAULT_SCALE;
-	return sprintf(buf, "%10f", ad4080_scale);
+	struct ad4080_dev *dev = iio_ad4080->ad4080;
+	int32_t vals[2];
+
+	/* ADC_REF_VOLTAGE is in mV, so the resulting scale is in mV per code */
+	vals[0] = ADC_REF_VOLTAGE;
+	vals[1] = (1UL << dev->chip_info->num_bits) - 1;
+	return iio_format_value(buf, len, IIO_VAL_FRACTIONAL, 1, vals);
 }
 
 /**
@@ -1463,7 +1475,7 @@ int iio_ad4080_fifo_set_watermark(struct iio_ad4080_fifo_struct *fifo,
 
 	iio_ad4080_fifo_unset_watermark(fifo);
 
-	fifo_size = NO_OS_DIV_ROUND_UP(AD4080_ADC_GRANULARITY, 8);
+	fifo_size = NO_OS_DIV_ROUND_UP(fifo->ad4080->chip_info->num_bits, 8);
 	fifo_size = (fifo_size * watermark);
 	fifo_size = fifo_size + 1; /* account for the 0xAA synchro byte */
 
@@ -1615,21 +1627,14 @@ static struct iio_attribute ad4080_global_attr[] = {
 	{0},
 };
 
-static struct scan_type ad4080_scan_type = {
-	.sign = 's',
-	.realbits = AD4080_ADC_GRANULARITY,
-	.storagebits = 32, /* round up to 4 bytes */
-	.shift = 0,
-	.is_big_endian = false
-};
-
-static struct iio_channel ad4080_ch = {
+/* Template copied into each iio_ad4080_desc at init; realbits and the
+ * scan_type back-pointer are filled in per instance. */
+static const struct iio_channel ad4080_ch_template = {
 	.name = "voltage",
 	.ch_type = IIO_VOLTAGE,
 	.channel = 0,
 	.scan_index = 0,
 	.indexed = true,
-	.scan_type = &ad4080_scan_type,
 	.attributes = ad4080_ch_attr,
 	.ch_out = false,
 };
@@ -1661,8 +1666,19 @@ int ad4080_iio_device(struct iio_ad4080_desc *iio_ad4080,
 	if (!iio_ad4080 || !iio_device)
 		return -EINVAL;
 
+	/* Build per-instance channel + scan_type matched to the part */
+	iio_ad4080->scan_type = (struct scan_type) {
+		.sign = 's',
+		.realbits = iio_ad4080->ad4080->chip_info->num_bits,
+		.storagebits = 32, /* round up to 4 bytes */
+		.shift = 0,
+		.is_big_endian = false,
+	};
+	iio_ad4080->ch = ad4080_ch_template;
+	iio_ad4080->ch.scan_type = &iio_ad4080->scan_type;
+
 	iio_device->num_ch = 1;
-	iio_device->channels = &ad4080_ch;
+	iio_device->channels = &iio_ad4080->ch;
 	iio_device->attributes = ad4080_global_attr;
 	iio_device->debug_attributes = NULL;
 	iio_device->buffer_attributes = NULL;

--- a/drivers/adc/ad4080/iio_ad4080.h
+++ b/drivers/adc/ad4080/iio_ad4080.h
@@ -71,6 +71,11 @@ struct iio_ad4080_desc {
 	struct iio_ad4080_fifo_struct fifo;
 	struct no_os_gpio_desc *afe_ctrl;
 
+	/* Per-instance channel/scan_type so two AD408x parts of different
+	 * resolution don't clobber each other's realbits. */
+	struct scan_type scan_type;
+	struct iio_channel ch;
+
 	uint32_t app_device_count;
 	char app_device_name[AD4080_IIO_APP_DEVICE_NAME_LEN];
 	unsigned long sampling_frequency_idx;


### PR DESCRIPTION
## Pull Request Description

The AD4080 driver only supported the 20-bit AD4080. The AD4082, AD4083,
AD4085, AD4086, AD4087 and AD4088 parts are register-compatible but differ
in ADC resolution (20-bit for AD4082, 16-bit for AD4083 and AD4085, 14-bit
for AD4086-AD4088) and in the maximum LVDS interface clock count.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
