### PR TITLE
Fix/gcc14 maxim builds

### DIFF
--- a/drivers/adc/ad7490/iio_ad7490.c
+++ b/drivers/adc/ad7490/iio_ad7490.c
@@ -90,6 +90,7 @@ static int ad7490_iio_read_raw(void *device, char *buf, uint32_t len,
 			       intptr_t priv)
 {
 	struct ad7490_iio_desc *iio_desc = device;
+	int32_t val32;
 	int16_t val;
 	int ret;
 
@@ -97,7 +98,9 @@ static int ad7490_iio_read_raw(void *device, char *buf, uint32_t len,
 	if (ret)
 		return ret;
 
-	return iio_format_value(buf, len, IIO_VAL_INT, 1, &val);
+	val32 = val;
+
+	return iio_format_value(buf, len, IIO_VAL_INT, 1, &val32);
 }
 
 static int ad7490_iio_read_scale(void *device, char *buf, uint32_t len,

--- a/drivers/amplifiers/adhv4710/adhv4710.c
+++ b/drivers/amplifiers/adhv4710/adhv4710.c
@@ -76,7 +76,9 @@ int adhv4710_init(struct adhv4710_dev **device,
 		goto error_dev;
 
 	/* reset gpio */
-	dev->gpio_reset = init_param.gpio_reset;
+	ret = no_os_gpio_get_optional(&dev->gpio_reset, init_param.gpio_reset);
+	if (ret)
+		goto error_spi;
 
 	/* Read version product */
 	ret = adhv4710_version_product(dev, &reg_val);
@@ -204,7 +206,7 @@ int adhv4710_get_status(struct adhv4710_dev *dev, uint8_t reg_addr, uint8_t msk,
 {
 	int ret;
 	/* register value read */
-	uint32_t reg_val;
+	int8_t reg_val;
 
 	if (!status)
 		return -EINVAL;

--- a/drivers/dac/max22017/iio_max22017.c
+++ b/drivers/dac/max22017/iio_max22017.c
@@ -390,7 +390,7 @@ static struct iio_channel max22017_iio_channels[] = {
 };
 
 static struct iio_device max22017_iio_dev = {
-	.channels = &max22017_iio_channels,
+	.channels = max22017_iio_channels,
 	.num_ch = NO_OS_ARRAY_SIZE(max22017_iio_channels),
 	.debug_reg_read = (int32_t (*)())max22017_iio_reg_read,
 	.debug_reg_write = (int32_t (*)())max22017_iio_reg_write,

--- a/drivers/meter/ade7753/ade7753.c
+++ b/drivers/meter/ade7753/ade7753.c
@@ -64,6 +64,8 @@ int ade7753_init(struct ade7753_dev **device,
 	struct ade7753_dev *dev;
 	/* value read from register */
 	uint32_t reg_val;
+	/* interrupt status value */
+	uint8_t int_status;
 	/* timeout value */
 	uint16_t timeout = 1000;
 
@@ -80,7 +82,9 @@ int ade7753_init(struct ade7753_dev **device,
 	/* interrupt */
 	dev->irq_ctrl = init_param.irq_ctrl;
 	/* reset gpio */
-	dev->gpio_reset = init_param.gpio_reset;
+	ret = no_os_gpio_get_optional(&dev->gpio_reset, init_param.gpio_reset);
+	if (ret)
+		goto error_spi;
 
 	/* reset the device */
 	if (dev->gpio_reset) {
@@ -94,11 +98,11 @@ int ade7753_init(struct ade7753_dev **device,
 	}
 	/* wait for reset ack */
 	do {
-		ret = ade7753_get_int_status(dev, ADE7753_RESET_MSK, &reg_val);
+		ret = ade7753_get_int_status(dev, ADE7753_RESET_MSK, &int_status);
 		if (ret)
 			goto error_spi;
 		timeout--;
-	} while ((!reg_val) && (timeout > 0));
+	} while ((!int_status) && (timeout > 0));
 	if (timeout <= 0) {
 		ret = -ETIMEDOUT;
 		goto error_spi;

--- a/drivers/meter/ade7754/ade7754.c
+++ b/drivers/meter/ade7754/ade7754.c
@@ -63,6 +63,8 @@ int ade7754_init(struct ade7754_dev **device,
 	struct ade7754_dev *dev;
 	/* value read from register */
 	uint32_t reg_val;
+	/* interrupt status indicator */
+	uint8_t int_status;
 	/* timeout value */
 	uint16_t timeout = 1000;
 
@@ -79,7 +81,15 @@ int ade7754_init(struct ade7754_dev **device,
 	/* interrupt */
 	dev->irq_ctrl = init_param.irq_ctrl;
 	/* reset gpio */
-	dev->gpio_reset = init_param.gpio_reset;
+	ret = no_os_gpio_get_optional(&dev->gpio_reset, init_param.gpio_reset);
+	if (ret)
+		goto error_spi;
+
+	if (dev->gpio_reset) {
+		ret = no_os_gpio_direction_output(dev->gpio_reset, NO_OS_GPIO_HIGH);
+		if (ret)
+			goto error_spi;
+	}
 	/* reset the device */
 	if (dev->gpio_reset) {
 		ret = ade7754_hw_reset(dev);
@@ -92,10 +102,10 @@ int ade7754_init(struct ade7754_dev **device,
 	}
 	/* wait for reset ack */
 	do {
-		ret = ade7754_get_int_status(dev, ADE7754_RESET_MSK, &reg_val);
+		ret = ade7754_get_int_status(dev, ADE7754_RESET_MSK, &int_status);
 		if (ret)
 			goto error_spi;
-	} while ((!reg_val) && (timeout--));
+	} while ((!int_status) && (timeout--));
 	if (!timeout) {
 		ret = -ETIMEDOUT;
 		goto error_spi;

--- a/drivers/meter/ade7758/ade7758.c
+++ b/drivers/meter/ade7758/ade7758.c
@@ -64,6 +64,10 @@ int ade7758_init(struct ade7758_dev **device,
 	struct ade7758_dev *dev;
 	/* value read from register */
 	uint32_t reg_val;
+	/* interrupt status indicator */
+	uint8_t int_status;
+	/* status register dump for irq clear */
+	int32_t rstatus;
 	/* timeout value */
 	uint16_t timeout = 1000;
 
@@ -85,16 +89,16 @@ int ade7758_init(struct ade7758_dev **device,
 		goto error_spi;
 	/* wait for reset ack */
 	do {
-		ret = ade7758_get_int_status(dev, ADE7758_RESET_MSK, &reg_val);
+		ret = ade7758_get_int_status(dev, ADE7758_RESET_MSK, &int_status);
 		if (ret)
 			goto error_spi;
-	} while ((!reg_val) && (timeout--));
+	} while ((!int_status) && (timeout--));
 	if (!timeout) {
 		ret = -ETIMEDOUT;
 		goto error_spi;
 	}
 	/* reset the status register */
-	ret = ade7758_clear_irq_status(dev, &reg_val);
+	ret = ade7758_clear_irq_status(dev, &rstatus);
 	if (ret)
 		goto error_spi;
 	/* Read version product */

--- a/drivers/meter/ade7816/ade7816.c
+++ b/drivers/meter/ade7816/ade7816.c
@@ -1378,7 +1378,7 @@ static int ade7816_irq_config(struct no_os_gpio_desc *gpio_irq,
 		return ret;
 
 	ret = no_os_irq_register_callback(init_param->irq_ctrl,
-					  gpio_irq->number, &irq_cb);
+					  gpio_irq->number, irq_cb);
 	if (ret)
 		return ret;
 

--- a/drivers/meter/ade7913/ade7913.c
+++ b/drivers/meter/ade7913/ade7913.c
@@ -151,7 +151,7 @@ int ade7913_read_waveforms(struct ade7913_dev *dev, uint8_t reg_addr,
 		// third device
 		dev->spi_desc = dev->spi_desc2;
 		ret = ade7913_read(dev, reg_addr,
-				   &reg_data);
+				   reg_data);
 		if (ret)
 			return ret;
 		dev->i_wav_m[2] = dev->i_wav;
@@ -160,7 +160,7 @@ int ade7913_read_waveforms(struct ade7913_dev *dev, uint8_t reg_addr,
 		// second device
 		dev->spi_desc = dev->spi_desc1;
 		ret = ade7913_read(dev, reg_addr,
-				   &reg_data);
+				   reg_data);
 		if (ret)
 			return ret;
 		dev->i_wav_m[1] = dev->i_wav;
@@ -169,7 +169,7 @@ int ade7913_read_waveforms(struct ade7913_dev *dev, uint8_t reg_addr,
 		// first device
 		dev->spi_desc = dev->spi_desc0;
 		ret = ade7913_read(dev, reg_addr,
-				   &reg_data);
+				   reg_data);
 		if (ret)
 			return ret;
 		dev->i_wav_m[0] = dev->i_wav;
@@ -180,7 +180,7 @@ int ade7913_read_waveforms(struct ade7913_dev *dev, uint8_t reg_addr,
 		// second device
 		dev->spi_desc = dev->spi_desc1;
 		ret = ade7913_read(dev, reg_addr,
-				   &reg_data);
+				   reg_data);
 		if (ret)
 			return ret;
 		dev->i_wav_m[1] = dev->i_wav;
@@ -189,7 +189,7 @@ int ade7913_read_waveforms(struct ade7913_dev *dev, uint8_t reg_addr,
 		// first device
 		dev->spi_desc = dev->spi_desc0;
 		ret = ade7913_read(dev, reg_addr,
-				   &reg_data);
+				   reg_data);
 		if (ret)
 			return ret;
 		dev->i_wav_m[0] = dev->i_wav;
@@ -200,7 +200,7 @@ int ade7913_read_waveforms(struct ade7913_dev *dev, uint8_t reg_addr,
 		// single device
 		dev->spi_desc = dev->spi_desc0;
 		ret = ade7913_read(dev, reg_addr,
-				   &reg_data);
+				   reg_data);
 		if (ret)
 			return ret;
 		dev->i_wav_m[0] = dev->i_wav;
@@ -263,29 +263,29 @@ int ade7913_write_broadcast(struct ade7913_dev *dev, uint8_t reg_addr,
 	case 3 :
 		// third device
 		dev->spi_desc = dev->spi_desc2;
-		ret = ade7913_write(dev, reg_addr, reg_data);
+		ret = ade7913_write(dev, reg_addr, *reg_data);
 		if (ret)
 			return ret;
 		// second device
 		dev->spi_desc = dev->spi_desc1;
-		ret = ade7913_write(dev, reg_addr, reg_data);
+		ret = ade7913_write(dev, reg_addr, *reg_data);
 		if (ret)
 			return ret;
 		// first device
 		dev->spi_desc = dev->spi_desc0;
-		ret = ade7913_write(dev, reg_addr, reg_data);
+		ret = ade7913_write(dev, reg_addr, *reg_data);
 		if (ret)
 			return ret;
 		break;
 	case 2 :
 		// second device
 		dev->spi_desc = dev->spi_desc1;
-		ret = ade7913_write(dev, reg_addr, reg_data);
+		ret = ade7913_write(dev, reg_addr, *reg_data);
 		if (ret)
 			return ret;
 		// first device
 		dev->spi_desc = dev->spi_desc0;
-		ret = ade7913_write(dev, reg_addr, reg_data);
+		ret = ade7913_write(dev, reg_addr, *reg_data);
 		if (ret)
 			return ret;
 		break;
@@ -586,7 +586,7 @@ int ade7913_remove(struct ade7913_dev *dev)
 int ade7913_sw_reset(struct ade7913_dev *dev)
 {
 	int ret;
-	uint8_t *ver_product;
+	uint8_t ver_product;
 	// reset on variable must be 0 after reset
 	uint8_t reset_on;
 
@@ -609,7 +609,7 @@ int ade7913_sw_reset(struct ade7913_dev *dev)
 	if (ret)
 		return ret;
 
-	dev->ver_product = ver_product;
+	dev->ver_product[0] = ver_product;
 
 	return 0;
 }
@@ -795,7 +795,7 @@ int ade7913_crc_status(struct ade7913_dev *dev, uint8_t *status)
 {
 	int ret;
 	/* register value read */
-	uint32_t reg_val;
+	uint8_t reg_val;
 
 	if (!dev)
 		return -ENODEV;
@@ -822,7 +822,7 @@ int ade7913_ic_prot_status(struct ade7913_dev *dev, uint8_t *status)
 {
 	int ret;
 	/* register value read */
-	uint32_t reg_val;
+	uint8_t reg_val;
 
 	if (!dev)
 		return -ENODEV;
@@ -833,8 +833,8 @@ int ade7913_ic_prot_status(struct ade7913_dev *dev, uint8_t *status)
 	if (ret)
 		return ret;
 
-	status = no_os_test_bit(no_os_find_first_set_bit(ADE7913_IC_PROT_MSK),
-				&reg_val);
+	*status = no_os_test_bit(no_os_find_first_set_bit(ADE7913_IC_PROT_MSK),
+				 &reg_val);
 
 	return 0;
 }
@@ -866,7 +866,7 @@ int ade7913_adc_na_status(struct ade7913_dev *dev, uint8_t *status)
 {
 	int ret;
 	/* register value read */
-	uint32_t reg_val;
+	uint8_t reg_val;
 
 	if (!dev)
 		return -ENODEV;
@@ -893,7 +893,7 @@ int ade7913_cnt_snapshot_val(struct ade7913_dev *dev, uint16_t *val)
 {
 	int ret;
 	/* register value read */
-	uint16_t reg_val;
+	uint8_t reg_val;
 
 	if (!dev)
 		return -ENODEV;

--- a/drivers/meter/ade7913/ade7913.h
+++ b/drivers/meter/ade7913/ade7913.h
@@ -162,11 +162,11 @@ struct ade7913_dev {
 	/* Version product */
 	uint8_t 			*ver_product;
 	/* I_WAV */
-	int32_t				*i_wav;
+	int32_t				i_wav;
 	/* V1_WAV */
-	int32_t				*v1_wav;
+	int32_t				v1_wav;
 	/* V2_WAV */
-	int32_t				*v2_wav;
+	int32_t				v2_wav;
 	/* I_WAV multiple devices */
 	int32_t				*i_wav_m;
 	/* V1_WAV multiple devices */
@@ -174,11 +174,11 @@ struct ade7913_dev {
 	/* V2_WAV multiple devices */
 	int32_t				*v2_wav_m;
 	/* ADC_CRC */
-	uint16_t            		*adc_crc;
+	uint16_t            		adc_crc;
 	/* Status 0 */
-	uint8_t             		*status0;
+	uint8_t             		status0;
 	/* CNT_SNAPSHOT */
-	uint16_t            		*cnt_snapshot;
+	uint16_t            		cnt_snapshot;
 	/* number of devices */
 	uint8_t 			no_devs;
 	/* burst mode */

--- a/drivers/meter/ade7953/ade7953.c
+++ b/drivers/meter/ade7953/ade7953.c
@@ -81,7 +81,9 @@ int ade7953_init(struct ade7953_dev **device,
 	/* interrupt */
 	dev->irq_ctrl = init_param.irq_ctrl;
 	/* reset gpio */
-	dev->gpio_reset = init_param.gpio_reset;
+	ret = no_os_gpio_get(&dev->gpio_reset, init_param.gpio_reset);
+	if (ret)
+		goto error_spi;
 
 	/* Lock the communication interface after autoidentification */
 	ret = ade7953_update_bits(dev, ADE7953_REG_CONFIG, ADE7953_COMM_LOCK_MSK,
@@ -143,7 +145,7 @@ int ade7953_read(struct ade7953_dev *dev, uint16_t reg_addr,
 	if (!reg_data)
 		return -EINVAL;
 
-	no_os_put_unaligned_be16(reg_addr, &buff);
+	no_os_put_unaligned_be16(reg_addr, buff);
 	buff[2] = ADE7953_SPI_READ;
 
 	/* 8 bits registers */
@@ -212,7 +214,7 @@ int ade7953_write(struct ade7953_dev *dev, uint16_t reg_addr,
 	if (!dev)
 		return -ENODEV;
 
-	no_os_put_unaligned_be16(reg_addr, &buff);
+	no_os_put_unaligned_be16(reg_addr, buff);
 	buff[2] = 0x00;
 
 	/* 8 bits registers */

--- a/drivers/meter/ade7978/ade7978.c
+++ b/drivers/meter/ade7978/ade7978.c
@@ -304,7 +304,7 @@ int ade7978_init(struct ade7978_dev **device,
 	/* chip id read value */
 	uint32_t chip_id;
 	/* data read */
-	uint32_t data;
+	uint8_t data;
 
 	dev = (struct ade7978_dev *)no_os_calloc(1, sizeof(*dev));
 	if (!dev)

--- a/drivers/meter/ade9000/ade9000.c
+++ b/drivers/meter/ade9000/ade9000.c
@@ -61,7 +61,7 @@ int ade9000_read(struct ade9000_dev *dev, uint16_t reg_addr, uint32_t *reg_data)
 		return -EINVAL;
 
 	addr = (uint16_t) no_os_field_prep(NO_OS_GENMASK(16, 4), reg_addr);
-	no_os_put_unaligned_be16(addr, &buff);
+	no_os_put_unaligned_be16(addr, buff);
 	buff[1] = buff[1] | ADE9000_SPI_READ;
 
 	/* 16 bits registers */
@@ -185,7 +185,7 @@ int ade9000_read_temp(struct ade9000_dev *dev)
 	/* temperature offset */
 	uint32_t offset;
 	/* status of temperature ready */
-	uint8_t *status = 0;
+	uint8_t status = 0;
 	/* timeout for temperature read */
 	uint16_t timeout = 0;
 

--- a/drivers/meter/ade9078/ade9078.c
+++ b/drivers/meter/ade9078/ade9078.c
@@ -59,7 +59,7 @@ int ade9078_read(struct ade9078_dev *dev, uint16_t reg_addr, uint32_t *reg_data)
 		return -EINVAL;
 
 	addr = (uint16_t) no_os_field_prep(NO_OS_GENMASK(15, 4), reg_addr);
-	no_os_put_unaligned_be16(addr, &buff);
+	no_os_put_unaligned_be16(addr, buff);
 	buff[1] = buff[1] | ADE9078_SPI_READ;
 
 	/* 16 bits registers */

--- a/drivers/meter/ade9153a/ade9153a.c
+++ b/drivers/meter/ade9153a/ade9153a.c
@@ -388,7 +388,7 @@ int ade9153a_read(struct ade9153a_dev *dev, uint16_t reg_addr,
 		buff[i] = 0;
 
 	addr = (uint16_t) no_os_field_prep(NO_OS_GENMASK(16, 4), reg_addr);
-	no_os_put_unaligned_be16(addr, &buff);
+	no_os_put_unaligned_be16(addr, buff);
 	buff[1] = buff[1] | ADE9153A_SPI_READ;
 
 	if ((reg_addr > ADE9153A_START_16ADDR) & (reg_addr < ADE9153A_END_16ADDR)) {
@@ -453,7 +453,7 @@ int ade9153a_write(struct ade9153a_dev *dev, uint16_t reg_addr,
 		return -ENODEV;
 
 	addr = (uint16_t) no_os_field_prep(NO_OS_GENMASK(16, 4), reg_addr);
-	no_os_put_unaligned_be16(addr, &buff);
+	no_os_put_unaligned_be16(addr, buff);
 
 	if ((reg_addr > ADE9153A_START_16ADDR) & (reg_addr < ADE9153A_END_16ADDR)) {
 		no_os_put_unaligned_be16(reg_data, &buff[data_byte_offset]);
@@ -1009,7 +1009,7 @@ int ade9153a_ipk_val(struct ade9153a_dev *dev, uint32_t *val)
 	ret = ade9153a_read(dev, ADE9153A_REG_IPEAK, &reg_val);
 	if (ret)
 		return ret;
-	*val = no_os_get_unaligned_be24(&reg_val);
+	*val = reg_val & (uint32_t)(ADE9153A_IPEAKVAL_MSK);
 
 	return 0;
 }
@@ -1034,7 +1034,7 @@ int ade9153a_vpk_val(struct ade9153a_dev *dev, uint32_t *val)
 	ret = ade9153a_read(dev, ADE9153A_REG_VPEAK, &reg_val);
 	if (ret)
 		return ret;
-	*val = no_os_get_unaligned_be24(&reg_val);
+	*val = reg_val & (uint32_t)(ADE9153A_VPEAKVAL_MSK);
 
 	return 0;
 }
@@ -1729,7 +1729,7 @@ int ade9153a_clear_chip_stat(struct ade9153a_dev *dev, uint32_t *reg_val)
 	if (!dev)
 		return -ENODEV;
 
-	return ade9153a_read(dev, ADE9153A_REG_CHIP_STATUS, &reg_val);
+	return ade9153a_read(dev, ADE9153A_REG_CHIP_STATUS, reg_val);
 }
 
 /**
@@ -1757,7 +1757,7 @@ int ade9153a_clear_event_stat(struct ade9153a_dev *dev, uint32_t *reg_val)
 	if (!dev)
 		return -ENODEV;
 
-	return ade9153a_read(dev, ADE9153A_REG_EVENT_STATUS, &reg_val);
+	return ade9153a_read(dev, ADE9153A_REG_EVENT_STATUS, reg_val);
 }
 
 /**
@@ -1785,7 +1785,7 @@ int ade9153a_clear_ms_stat(struct ade9153a_dev *dev, uint32_t *reg_val)
 	if (!dev)
 		return -ENODEV;
 
-	return ade9153a_read(dev, ADE9153A_REG_MS_STATUS_IRQ, &reg_val);
+	return ade9153a_read(dev, ADE9153A_REG_MS_STATUS_IRQ, reg_val);
 }
 
 /**
@@ -2638,7 +2638,7 @@ int ade9153a_get_phnoload_status(struct ade9153a_dev *dev, uint8_t *status)
 {
 	int ret;
 	/* register value read */
-	uint8_t reg_val;
+	uint32_t reg_val;
 
 	if (!dev)
 		return -ENODEV;
@@ -3977,7 +3977,7 @@ int ade9153a_temp_val(struct ade9153a_dev *dev,
 	/* temperature gain value read*/
 	uint32_t gain;
 	/* temperature value read */
-	uint32_t temp;
+	uint16_t temp;
 	/* status of temperature ready */
 	uint8_t status = 0;
 	/* timeout for temperature read */

--- a/drivers/meter/ade9153a/ade9153a.h
+++ b/drivers/meter/ade9153a/ade9153a.h
@@ -666,9 +666,9 @@ struct ade9153a_init_param {
 	/** GPIO RESET descriptor used to reset device (HW reset) */
 	struct no_os_gpio_init_param  	*gpio_reset;
 	/** GPIO ss descriptor used to config comms */
-	struct no_os_spi_init_param 	*gpio_ss;
+	struct no_os_gpio_init_param 	*gpio_ss;
 	/** GPIO sck descriptor used to config comms */
-	struct no_os_spi_init_param	*gpio_sck;
+	struct no_os_gpio_init_param	*gpio_sck;
 	/** Enable SPI interface */
 	uint8_t				spi_en;
 	/** IRQ device descriptor used to handle interrupt routine for GPIO RDY */
@@ -932,7 +932,7 @@ int ade9153a_get_zxbi(struct ade9153a_dev *dev, uint8_t *status);
 int ade9153a_get_zxai(struct ade9153a_dev *dev, uint8_t *status);
 
 // Get zero crossing detect on V ch indicator.
-ade9153a_get_zxav(struct ade9153a_dev *dev, uint8_t *status);
+int ade9153a_get_zxav(struct ade9153a_dev *dev, uint8_t *status);
 
 // Get reset done indicator.
 int ade9153a_get_rstdone(struct ade9153a_dev *dev, uint8_t *status);
@@ -1031,7 +1031,7 @@ int ade9153a_clear_egyrdy(struct ade9153a_dev *dev);
 int ade9153a_clear_cf2(struct ade9153a_dev *dev);
 
 // Clear CF1 pulse issued int mask.
-ade9153a_clear_cf1(struct ade9153a_dev *dev);
+int ade9153a_clear_cf1(struct ade9153a_dev *dev);
 
 // Clear CF2 polarity change int mask.
 int ade9153a_clear_cf2_chg(struct ade9153a_dev *dev);

--- a/drivers/net/mdio_spi/mdio_spi.c
+++ b/drivers/net/mdio_spi/mdio_spi.c
@@ -52,7 +52,7 @@ struct mdio_spi_extra {
  * @return 0 in case of success, negative code otherwise
  */
 int mdio_spi_init(struct no_os_mdio_desc **dev,
-		  struct no_os_mdio_init_param *ip)
+		  const struct no_os_mdio_init_param *ip)
 {
 	int ret;
 	struct mdio_spi_init_param *msip;

--- a/drivers/platform/maxim/max32665/maxim_i2c.c
+++ b/drivers/platform/maxim/max32665/maxim_i2c.c
@@ -62,13 +62,13 @@ void I2C0_IRQHandler(void)
  */
 void I2C1_IRQHandler(void)
 {
-	MXC_I2C_AsyncHandler(MXC_BASE_I2C1_BUS0);
+	MXC_I2C_AsyncHandler(MXC_I2C1_BUS0);
 }
 
 #ifdef MXC_I2C2
 void I2C2_IRQHandler(void)
 {
-	MXC_I2C_AsyncHandler(MXC_BASE_I2C2_BUS0);
+	MXC_I2C_AsyncHandler(MXC_I2C2_BUS0);
 }
 #endif
 

--- a/drivers/platform/maxim/max32690/maxim_rtc.c
+++ b/drivers/platform/maxim/max32690/maxim_rtc.c
@@ -103,7 +103,7 @@ int32_t no_os_rtc_remove(struct no_os_rtc_desc *dev)
  */
 int32_t no_os_rtc_start(struct no_os_rtc_desc *dev)
 {
-	MXC_RTC_Wait_BusyToClear();
+	while (MXC_RTC_GetBusyFlag());
 	MXC_RTC_Start();
 
 	return 0;
@@ -116,7 +116,7 @@ int32_t no_os_rtc_start(struct no_os_rtc_desc *dev)
  */
 int32_t no_os_rtc_stop(struct no_os_rtc_desc *dev)
 {
-	MXC_RTC_Wait_BusyToClear();
+	while (MXC_RTC_GetBusyFlag());
 	MXC_RTC_Stop();
 
 	return 0;
@@ -150,19 +150,19 @@ int32_t no_os_rtc_set_cnt(struct no_os_rtc_desc *dev, uint32_t tmr_cnt)
 
 	rtc_regs = MXC_RTC;
 
-	MXC_RTC_Wait_BusyToClear();
+	while (MXC_RTC_GetBusyFlag());
 	rtc_regs->ctrl |= MXC_F_RTC_REVA_CTRL_WR_EN;
 
-	MXC_RTC_Wait_BusyToClear();
+	while (MXC_RTC_GetBusyFlag());
 	no_os_rtc_stop(dev);
 
-	MXC_RTC_Wait_BusyToClear();
+	while (MXC_RTC_GetBusyFlag());
 	rtc_regs->sec = tmr_cnt;
 
-	MXC_RTC_Wait_BusyToClear();
+	while (MXC_RTC_GetBusyFlag());
 	no_os_rtc_start(dev);
 
-	MXC_RTC_Wait_BusyToClear();
+	while (MXC_RTC_GetBusyFlag());
 	rtc_regs->ctrl &= ~MXC_F_RTC_REVA_CTRL_WR_EN;
 
 	return 0;

--- a/drivers/power/lt8722/iio_lt8722.c
+++ b/drivers/power/lt8722/iio_lt8722.c
@@ -1189,6 +1189,7 @@ static int lt8722_iio_read_dac_ilimn(void *dev, char *buf, uint32_t len,
 				     const struct iio_ch_info *channel, intptr_t priv)
 {
 	int ret;
+	uint16_t reg_value;
 	uint32_t value;
 	struct lt8722_iio_dev *iio_lt8722;
 	struct lt8722_dev *lt8722;
@@ -1199,9 +1200,11 @@ static int lt8722_iio_read_dac_ilimn(void *dev, char *buf, uint32_t len,
 	iio_lt8722 = (struct lt8722_iio_dev *)dev;
 	lt8722 = iio_lt8722->lt8722_dev;
 
-	ret = lt8722_get_spis_dac_ilimn(lt8722, &value);
+	ret = lt8722_get_spis_dac_ilimn(lt8722, &reg_value);
 	if (ret)
 		return ret;
+
+	value = reg_value;
 
 	return iio_format_value(buf, len, IIO_VAL_INT, 1, (int32_t *)&value);
 }
@@ -1251,6 +1254,7 @@ static int lt8722_iio_read_dac_ilimp(void *dev, char *buf, uint32_t len,
 				     const struct iio_ch_info *channel, intptr_t priv)
 {
 	int ret;
+	uint16_t reg_value;
 	uint32_t value;
 	struct lt8722_iio_dev *iio_lt8722;
 	struct lt8722_dev *lt8722;
@@ -1261,9 +1265,11 @@ static int lt8722_iio_read_dac_ilimp(void *dev, char *buf, uint32_t len,
 	iio_lt8722 = (struct lt8722_iio_dev *)dev;
 	lt8722 = iio_lt8722->lt8722_dev;
 
-	ret = lt8722_get_spis_dac_ilimp(lt8722, &value);
+	ret = lt8722_get_spis_dac_ilimp(lt8722, &reg_value);
 	if (ret)
 		return ret;
+
+	value = reg_value;
 
 	return iio_format_value(buf, len, IIO_VAL_INT, 1, (int32_t *)&value);
 }

--- a/drivers/power/ltc4162l/iio_ltc4162l.c
+++ b/drivers/power/ltc4162l/iio_ltc4162l.c
@@ -131,7 +131,7 @@ static int ltc4162l_ch_attr_show(void *ddev, char *buf,
 	struct ltc4162l_iio_device *dev = ddev;
 	int ret;
 	int32_t val;
-	uint32_t uval;
+	uint16_t uval;
 
 	switch (priv) {
 	case LTC4162L_BATTERY_COUNT:
@@ -216,7 +216,7 @@ static int ltc4162l_ch_attr_store(void *ddev, char *buf,
 				  intptr_t priv)
 {
 	struct ltc4162l_iio_device *dev = ddev;
-	int16_t val;
+	int32_t val;
 	int ret;
 
 	switch (priv) {
@@ -296,7 +296,7 @@ static int ltc4162l_read_raw(void *ddev, char *buf, uint32_t len,
 	struct ltc4162l_iio_device *dev = ddev;
 	int ret;
 	int32_t val;
-	uint32_t uval;
+	uint16_t uval;
 
 	switch (priv) {
 	case LTC4162L_VBAT_VAL:

--- a/drivers/power/ltc4296/ltc4296.c
+++ b/drivers/power/ltc4296/ltc4296.c
@@ -1054,7 +1054,7 @@ int ltc4296_init(struct ltc4296_dev **device,
 	return 0;
 
 err_spi:
-	no_os_spi_remove(dev);
+	no_os_spi_remove(dev->spi_desc);
 err:
 	no_os_free(dev);
 

--- a/drivers/power/ltc7841/iio_ltc7841.c
+++ b/drivers/power/ltc7841/iio_ltc7841.c
@@ -59,7 +59,7 @@ enum ltc7841_iio_chan_type {
  * @return ret    - Result of the reading procedure.
  * 		    In case of success, the size of the read data is returned.
 */
-static int ltc7841_iio_reg_read(void *dev, uint32_t reg, uint32_t *readval)
+static int32_t ltc7841_iio_reg_read(void *dev, uint32_t reg, uint32_t *readval)
 {
 	uint8_t register_value[2];
 	int ret;
@@ -81,7 +81,7 @@ static int ltc7841_iio_reg_read(void *dev, uint32_t reg, uint32_t *readval)
  * @param writeval - Value to write.
  * @return ret    - Result of the writing procedure.
 */
-static int ltc7841_iio_reg_write(void *dev, uint32_t reg, uint32_t writeval)
+static int32_t ltc7841_iio_reg_write(void *dev, uint32_t reg, uint32_t writeval)
 {
 	struct ltc7841_iio_desc *iio_ltc7841 = dev;
 	struct ltc7841_desc *ltc7841 = iio_ltc7841->ltc7841_desc;

--- a/drivers/power/ltc7871/iio_ltc7871.c
+++ b/drivers/power/ltc7871/iio_ltc7871.c
@@ -245,9 +245,9 @@ static int ltc7871_iio_get_mod_freq(void *dev, char *buf, uint32_t len,
 static int ltc7871_iio_set_mod_freq(void *dev, char *buf, uint32_t len,
 				    const struct iio_ch_info *channel, intptr_t priv);
 static int ltc7871_iio_get_pwmen_pin(void *dev, char *buf, uint32_t len,
-				     const struct iio_ch_info *channel);
+				     const struct iio_ch_info *channel, intptr_t priv);
 static int ltc7871_iio_set_pwmen_pin(void *dev, char *buf, uint32_t len,
-				     const struct iio_ch_info *channel);
+				     const struct iio_ch_info *channel, intptr_t priv);
 
 static struct iio_channel const ltc7871_channels[] = {
 	//no available channel
@@ -638,6 +638,8 @@ uint32_t ltc7871_iio_get_mask_mfr_chip_ctrl(enum ltc7871_iio_mfr_chip_ctrl_attrs
  */
 static int ltc7871_iio_reg_read(void *dev, uint32_t reg, uint32_t *readval)
 {
+	int ret;
+	uint8_t reg_val;
 	struct ltc7871_iio_dev *iio_ltc7871;
 	struct ltc7871_dev *ltc7871;
 
@@ -647,7 +649,13 @@ static int ltc7871_iio_reg_read(void *dev, uint32_t reg, uint32_t *readval)
 	iio_ltc7871 = (struct ltc7871_iio_dev *)dev;
 	ltc7871 = iio_ltc7871->ltc7871_dev;
 
-	return ltc7871_reg_read(ltc7871, reg, readval);
+	ret = ltc7871_reg_read(ltc7871, reg, &reg_val);
+	if (ret)
+		return ret;
+
+	*readval = reg_val;
+
+	return 0;
 }
 
 /**
@@ -685,7 +693,7 @@ static int ltc7871_iio_read_mfr_fault(void *dev, char *buf, uint32_t len,
 				      const struct iio_ch_info *channel, intptr_t priv)
 {
 	int ret;
-	uint8_t value;
+	bool value;
 	uint8_t reg_data;
 	uint32_t mask = ltc7871_iio_get_mask_mfr_fault(priv);
 	struct ltc7871_iio_dev *iio_ltc7871;
@@ -718,7 +726,7 @@ static int ltc7871_iio_read_mfr_oc_fault(void *dev, char *buf, uint32_t len,
 		const struct iio_ch_info *channel, intptr_t priv)
 {
 	int ret;
-	uint8_t value;
+	bool value;
 	uint8_t reg_data;
 	uint32_t mask = ltc7871_iio_get_mask_mfr_oc_fault(priv);
 	struct ltc7871_iio_dev *iio_ltc7871;
@@ -751,7 +759,7 @@ static int ltc7871_iio_read_mfr_noc_fault(void *dev, char *buf, uint32_t len,
 		const struct iio_ch_info *channel, intptr_t priv)
 {
 	int ret;
-	uint8_t value;
+	bool value;
 	uint8_t reg_data;
 	uint32_t mask = ltc7871_iio_get_mask_mfr_noc_fault(priv);
 	struct ltc7871_iio_dev *iio_ltc7871;
@@ -784,7 +792,7 @@ static int ltc7871_iio_read_mfr_status(void *dev, char *buf, uint32_t len,
 				       const struct iio_ch_info *channel, intptr_t priv)
 {
 	int ret;
-	uint8_t value;
+	bool value;
 	uint8_t reg_data;
 	uint32_t mask = ltc7871_iio_get_mask_mfr_status(priv);
 	struct ltc7871_iio_dev *iio_ltc7871;
@@ -961,7 +969,7 @@ static int ltc7871_iio_read_pec_fault(void *dev, char *buf, uint32_t len,
 				      const struct iio_ch_info *channel, intptr_t priv)
 {
 	int ret;
-	uint8_t value;
+	bool value;
 	uint8_t reg_data;
 	uint32_t mask = ltc7871_iio_get_mask_mfr_chip_ctrl(priv);
 	struct ltc7871_iio_dev *iio_ltc7871;
@@ -994,7 +1002,7 @@ static int ltc7871_iio_set_write_protect(void *dev, char *buf, uint32_t len,
 		const struct iio_ch_info *channel, intptr_t priv)
 {
 	int ret;
-	uint8_t value;
+	int32_t value;
 	uint8_t mask = ltc7871_iio_get_mask_mfr_chip_ctrl(priv);
 	struct ltc7871_iio_dev *iio_ltc7871;
 	struct ltc7871_dev *ltc7871;
@@ -1026,7 +1034,7 @@ static int ltc7871_iio_read_write_protect(void *dev, char *buf, uint32_t len,
 		const struct iio_ch_info *channel, intptr_t priv)
 {
 	int ret;
-	uint8_t value;
+	bool value;
 
 	struct ltc7871_iio_dev *iio_ltc7871;
 	struct ltc7871_dev *ltc7871;
@@ -1091,7 +1099,7 @@ static int ltc7871_iio_write_mfr_idac_vlow(void *dev, char *buf, uint32_t len,
 		const struct iio_ch_info *channel, intptr_t priv)
 {
 	int ret;
-	int8_t value;
+	int32_t value;
 	struct ltc7871_iio_dev *iio_ltc7871;
 	struct ltc7871_dev *ltc7871;
 
@@ -1155,7 +1163,7 @@ static int ltc7871_iio_write_mfr_idac_vhigh(void *dev, char *buf, uint32_t len,
 		const struct iio_ch_info *channel, intptr_t priv)
 {
 	int ret;
-	int8_t value;
+	int32_t value;
 	struct ltc7871_iio_dev *iio_ltc7871;
 	struct ltc7871_dev *ltc7871;
 
@@ -1219,7 +1227,7 @@ static int ltc7871_iio_write_mfr_idac_setcur(void *dev, char *buf, uint32_t len,
 		const struct iio_ch_info *channel, intptr_t priv)
 {
 	int ret;
-	int8_t value;
+	int32_t value;
 	struct ltc7871_iio_dev *iio_ltc7871;
 	struct ltc7871_dev *ltc7871;
 
@@ -1347,7 +1355,7 @@ static int ltc7871_iio_set_mod_freq(void *dev, char *buf, uint32_t len,
 				    const struct iio_ch_info *channel, intptr_t priv)
 {
 	int ret;
-	int8_t value;
+	int32_t value;
 	struct ltc7871_iio_dev *iio_ltc7871;
 	struct ltc7871_dev *ltc7871;
 
@@ -1374,7 +1382,7 @@ static int ltc7871_iio_set_mod_freq(void *dev, char *buf, uint32_t len,
  * 		    In case of success, the size of the read data is returned.
 */
 static int ltc7871_iio_get_pwmen_pin(void *dev, char *buf, uint32_t len,
-				     const struct iio_ch_info *channel)
+				     const struct iio_ch_info *channel, intptr_t priv)
 {
 	int ret;
 	struct ltc7871_iio_dev *iio_ltc7871;
@@ -1405,7 +1413,7 @@ static int ltc7871_iio_get_pwmen_pin(void *dev, char *buf, uint32_t len,
  * 		    In case of success, the size of the read data is returned.
  */
 static int ltc7871_iio_set_pwmen_pin(void *dev, char *buf, uint32_t len,
-				     const struct iio_ch_info *channel)
+				     const struct iio_ch_info *channel, intptr_t priv)
 {
 	int ret;
 	uint8_t value;

--- a/drivers/rtc/pcf85263/pcf85263.c
+++ b/drivers/rtc/pcf85263/pcf85263.c
@@ -84,7 +84,7 @@ int pcf85263_update_bits(struct pcf85263_dev *dev, uint8_t reg_addr,
 			 uint8_t mask, uint8_t reg_data)
 {
 	int ret;
-	uint32_t data;
+	uint8_t data;
 
 	ret = pcf85263_read(dev, reg_addr, &data);
 	if (ret)

--- a/drivers/temperature/adt7420/adt7420.c
+++ b/drivers/temperature/adt7420/adt7420.c
@@ -445,13 +445,14 @@ int adt7420_i2c_reg_read(struct adt7420_dev *dev, uint16_t register_address,
 {
 	uint8_t data_buffer[3] = { 0, 0 };
 	uint8_t num_bytes;
+	uint8_t reg_addr = register_address;
 
 	if (no_os_field_get(ADT7320_L16, register_address))
 		num_bytes = 2;
 	else
 		num_bytes = 1;
 
-	if (no_os_i2c_write(dev->i2c_desc, &register_address, 1,
+	if (no_os_i2c_write(dev->i2c_desc, &reg_addr, 1,
 			    0)) //add a repeat start
 		return -1;
 	if (no_os_i2c_read(dev->i2c_desc, data_buffer, num_bytes, 1))

--- a/drivers/temperature/adt7420/iio_adt7420.c
+++ b/drivers/temperature/adt7420/iio_adt7420.c
@@ -42,15 +42,15 @@
 #include "adt7420.h"
 
 static int adt7420_iio_read_temp(void *dev, char *buf, uint32_t len,
-				 const struct iio_ch_info *channel, intptr_t *priv);
+				 const struct iio_ch_info *channel, intptr_t priv);
 static int adt7420_iio_read_max(void *dev, char *buf, uint32_t len,
-				const struct iio_ch_info *channel, intptr_t *priv);
+				const struct iio_ch_info *channel, intptr_t priv);
 static int adt7420_iio_read_min(void *dev, char *buf, uint32_t len,
-				const struct iio_ch_info *channel, intptr_t *priv);
+				const struct iio_ch_info *channel, intptr_t priv);
 static int adt7420_iio_read_crit(void *dev, char *buf, uint32_t len,
-				 const struct iio_ch_info *channel, intptr_t *priv);
+				 const struct iio_ch_info *channel, intptr_t priv);
 static int adt7420_iio_read_hyst(void *dev, char *buf, uint32_t len,
-				 const struct iio_ch_info *channel, intptr_t *priv);
+				 const struct iio_ch_info *channel, intptr_t priv);
 static int adt7420_iio_reg_read(struct adt7420_iio_dev *dev, uint32_t reg,
 				uint32_t *readval);
 static int adt7420_iio_reg_write(struct adt7420_iio_dev *dev, uint32_t reg,
@@ -181,10 +181,19 @@ int adt7420_iio_remove(struct adt7420_iio_dev *desc)
 static int adt7420_iio_reg_read(struct adt7420_iio_dev *dev, uint32_t reg,
 				uint32_t *readval)
 {
+	uint16_t val;
+	int ret;
+
 	if (reg > __UINT8_MAX__)
 		return -EINVAL;
 
-	return adt7420_reg_read(dev->adt7420_dev, reg, readval);
+	ret = adt7420_reg_read(dev->adt7420_dev, reg, &val);
+	if (ret)
+		return ret;
+
+	*readval = val;
+
+	return 0;
 }
 
 /**
@@ -220,7 +229,7 @@ static int adt7420_iio_reg_write(struct adt7420_iio_dev *dev, uint32_t reg,
  * @return ret    - 0 in case of success, errno errors otherwise
 */
 static int adt7420_iio_read_temp(void *dev, char *buf, uint32_t len,
-				 const struct iio_ch_info *channel, intptr_t *priv)
+				 const struct iio_ch_info *channel, intptr_t priv)
 {
 	struct adt7420_iio_dev *iio_adt7420;
 	struct adt7420_dev *adt7420;
@@ -254,7 +263,7 @@ static int adt7420_iio_read_temp(void *dev, char *buf, uint32_t len,
  * @return ret    - 0 in case of success, errno errors otherwise
 */
 static int adt7420_iio_read_max(void *dev, char *buf, uint32_t len,
-				const struct iio_ch_info *channel, intptr_t *priv)
+				const struct iio_ch_info *channel, intptr_t priv)
 {
 	struct adt7420_iio_dev *iio_adt7420;
 	struct adt7420_dev *adt7420;
@@ -311,7 +320,7 @@ static int adt7420_iio_read_max(void *dev, char *buf, uint32_t len,
  * @return ret    - 0 in case of success, errno errors otherwise
 */
 static int adt7420_iio_read_min(void *dev, char *buf, uint32_t len,
-				const struct iio_ch_info *channel, intptr_t *priv)
+				const struct iio_ch_info *channel, intptr_t priv)
 {
 	struct adt7420_iio_dev *iio_adt7420;
 	struct adt7420_dev *adt7420;
@@ -368,7 +377,7 @@ static int adt7420_iio_read_min(void *dev, char *buf, uint32_t len,
  * @return ret    - 0 in case of success, errno errors otherwise
 */
 static int adt7420_iio_read_crit(void *dev, char *buf, uint32_t len,
-				 const struct iio_ch_info *channel, intptr_t *priv)
+				 const struct iio_ch_info *channel, intptr_t priv)
 {
 	struct adt7420_iio_dev *iio_adt7420;
 	struct adt7420_dev *adt7420;
@@ -425,12 +434,12 @@ static int adt7420_iio_read_crit(void *dev, char *buf, uint32_t len,
  * @return ret    - 0 in case of success, errno errors otherwise
 */
 static int adt7420_iio_read_hyst(void *dev, char *buf, uint32_t len,
-				 const struct iio_ch_info *channel, intptr_t *priv)
+				 const struct iio_ch_info *channel, intptr_t priv)
 {
 	struct adt7420_iio_dev *iio_adt7420;
 	struct adt7420_dev *adt7420;
 
-	int16_t temp = 0;
+	uint16_t temp = 0;
 	int32_t temp_c = 0;
 	iio_adt7420 = (struct adt7420_iio_dev *)dev;
 	adt7420 = iio_adt7420->adt7420_dev;

--- a/drivers/temperature/adt7420/iio_adt7420.h
+++ b/drivers/temperature/adt7420/iio_adt7420.h
@@ -43,7 +43,7 @@
  */
 struct adt7420_iio_dev {
 	struct adt7420_dev *adt7420_dev;
-	struct iio_dev *iio_dev;
+	struct iio_device *iio_dev;
 	uint32_t active_channels;
 	uint8_t no_active_channels;
 };

--- a/projects/ad-acevsecrdset-sl/src/pilot/pilot.c
+++ b/projects/ad-acevsecrdset-sl/src/pilot/pilot.c
@@ -39,6 +39,7 @@
 #include "gpio.h"
 #include "tmr.h"
 #include "adc.h"
+#include "nvic_table.h"
 
 // Flag indicating PWM values have been acquired
 static volatile int flag_pwm_low;
@@ -306,7 +307,8 @@ int pilot_setup_adc(void)
 unsigned int pilot_read_val(void)
 {
 	//clear ADC done interrupt flag
-	MXC_ADC_RevA_ClearFlags(MXC_ADC, MXC_F_ADC_REVA_INTR_DONE_IF);
+	MXC_ADC_RevA_ClearFlags((mxc_adc_reva_regs_t *)MXC_ADC,
+				MXC_F_ADC_REVA_INTR_DONE_IF);
 
 	//set start bit
 	MXC_ADC->ctrl |= MXC_F_ADC_REVA_CTRL_START;

--- a/projects/ad-acevsecrdset-sl/src/self_test/self_test.c
+++ b/projects/ad-acevsecrdset-sl/src/self_test/self_test.c
@@ -40,7 +40,12 @@
 #include "interface.h"
 #if defined(REV_D)
 #include "inter.h"
+/* Declared here because inter.h exposes the opto flag getters under
+ * different names; the implementations live in inter.c. */
+int get_gpio_opto_out1_flag_state(void);
+int get_gpio_opto_out2_flag_state(void);
 #endif
+#include "rcd.h"
 #include "supply.h"
 #include "pilot.h"
 #include "relay.h"

--- a/projects/ad-acevsecrdset-sl/src/state_machine/state_machine.c
+++ b/projects/ad-acevsecrdset-sl/src/state_machine/state_machine.c
@@ -388,11 +388,13 @@ int state_machine()
 
 		// ----------------------------- READ TEMPERATURE----------------------------------------
 		if (TEMPERATURE_READ_RATE <= multiple_20ms_adt75) {
-			ret = adt75_reg_read(adt75_desc, 0, &adt75_value);
+			uint16_t adt75_raw = 0;
+
+			ret = adt75_reg_read(adt75_desc, 0, &adt75_raw);
 			if (ret)
 				goto error;
 
-			adt75_value = no_os_field_get(ADT75_TEMP_MASK, adt75_value);
+			adt75_value = no_os_field_get(ADT75_TEMP_MASK, adt75_raw);
 			stout->temperature = no_os_sign_extend32(adt75_value, ADT75_SIGN_BIT);
 			stout->temperature *= MILLIDEGREE_PER_DEGREE / ADT75_TEMP_DIV;
 			pr_debug("Temperature: %.03f C\n", (double)stout->temperature / 1000);

--- a/projects/ad-acevsecrdset-sl/src/supply/supply.c
+++ b/projects/ad-acevsecrdset-sl/src/supply/supply.c
@@ -238,7 +238,7 @@ int supply_init(struct ade9113_dev **device)
 	return 0;
 
 error:
-	ade9113_remove(device);
+	ade9113_remove(*device);
 ade9113_init_err:
 	no_os_irq_ctrl_remove(ade9113_gpio_irq_desc);
 	ade9113_gpio_irq_desc = NULL;

--- a/projects/ad7091r8-sdz/src/common/common_data.c
+++ b/projects/ad7091r8-sdz/src/common/common_data.c
@@ -67,35 +67,3 @@ struct ad7091r8_init_param ad7091r8_ip = {
 	.device_id = AD7091R8,
 #endif
 };
-
-#ifdef IIO_TIMER_TRIGGER_EXAMPLE
-/* AD7091R-8 timer init parameter */
-struct no_os_timer_init_param ad7091r8_timer_ip = {
-	.id = AD7091R8_TIMER_DEVICE_ID,
-	.freq_hz = AD7091R8_TIMER_FREQ_HZ,
-	.ticks_count = AD7091R8_TIMER_TICKS_COUNT,
-	.platform_ops = TIMER_OPS,
-	.extra = AD7091R8_TIMER_EXTRA,
-};
-
-/* AD7091R-8 timer irq init parameter */
-struct no_os_irq_init_param ad7091r8_timer_irq_ip = {
-	.irq_ctrl_id = 0,
-	.platform_ops = TIMER_IRQ_OPS,
-	.extra = AD7091R8_TIMER_IRQ_EXTRA,
-};
-
-/* AD7091R-8 timer trigger callback info */
-const struct iio_hw_trig_cb_info ad7091r8_timer_cb_info = {
-	.event = NO_OS_EVT_TIM_ELAPSED,
-	.peripheral = NO_OS_TIM_IRQ,
-	.handle = AD7091R8_TIMER_CB_HANDLE,
-};
-
-/* AD7091R-8 timer trigger init parameter */
-struct iio_hw_trig_init_param ad7091r8_timer_trig_ip = {
-	.irq_id = AD7091R8_TIMER_TRIG_IRQ_ID,
-	.cb_info = ad7091r8_timer_cb_info,
-	.name = AD7091R8_TIMER_TRIG_NAME,
-};
-#endif

--- a/projects/ad7091r8-sdz/src/examples/iio_timer_trigger/iio_timer_trigger_example.c
+++ b/projects/ad7091r8-sdz/src/examples/iio_timer_trigger/iio_timer_trigger_example.c
@@ -50,6 +50,36 @@
 
 uint8_t ad7091r8_data_buffer[IIO_DATA_BUFFER_SIZE];
 
+/* AD7091R-8 timer init parameter */
+struct no_os_timer_init_param ad7091r8_timer_ip = {
+	.id = AD7091R8_TIMER_DEVICE_ID,
+	.freq_hz = AD7091R8_TIMER_FREQ_HZ,
+	.ticks_count = AD7091R8_TIMER_TICKS_COUNT,
+	.platform_ops = TIMER_OPS,
+	.extra = AD7091R8_TIMER_EXTRA,
+};
+
+/* AD7091R-8 timer irq init parameter */
+struct no_os_irq_init_param ad7091r8_timer_irq_ip = {
+	.irq_ctrl_id = 0,
+	.platform_ops = TIMER_IRQ_OPS,
+	.extra = AD7091R8_TIMER_IRQ_EXTRA,
+};
+
+/* AD7091R-8 timer trigger callback info */
+const struct iio_hw_trig_cb_info ad7091r8_timer_cb_info = {
+	.event = NO_OS_EVT_TIM_ELAPSED,
+	.peripheral = NO_OS_TIM_IRQ,
+	.handle = AD7091R8_TIMER_CB_HANDLE,
+};
+
+/* AD7091R-8 timer trigger init parameter */
+struct iio_hw_trig_init_param ad7091r8_timer_trig_ip = {
+	.irq_id = AD7091R8_TIMER_TRIG_IRQ_ID,
+	.cb_info = ad7091r8_timer_cb_info,
+	.name = AD7091R8_TIMER_TRIG_NAME,
+};
+
 /***************************************************************************//**
  * @brief IIO trigger example main execution.
  *

--- a/projects/adalm-lsmspg/src/examples/curvetrace_example/curvetrace_example.c
+++ b/projects/adalm-lsmspg/src/examples/curvetrace_example/curvetrace_example.c
@@ -719,7 +719,7 @@ int lm75_example(struct no_os_uart_desc *uart_desc)
 		.i2c_ip = &lm75_i2c_ip,
 	};
 	int ret;
-	uint32_t temp_raw;
+	uint16_t temp_raw;
 	uint32_t temp;
 
 

--- a/projects/adp1055/builds.json
+++ b/projects/adp1055/builds.json
@@ -1,10 +1,10 @@
 {
 	"maxim": {
 		"basic_example_max32690": {
-			"flags" : "EXAMPLE=basic"
+			"flags" : "EXAMPLE=basic TARGET=max32690"
 		},
 		"iio_example_max32690": {
-			"flags" : "EXAMPLE=iio_example"
+			"flags" : "EXAMPLE=iio_example TARGET=max32690"
 		}
 	}
 }

--- a/projects/adt7420-pmdz/src/examples/dummy/dummy_example.c
+++ b/projects/adt7420-pmdz/src/examples/dummy/dummy_example.c
@@ -138,7 +138,7 @@ int example_main()
 		ret = adt7420_reg_write(adt7420, ADT7420_REG_HIST, hyst);
 		if (ret)
 			goto error_adt7420;
-		uint32_t readval = 0;
+		uint16_t readval = 0;
 		ret = adt7420_reg_read(adt7420, ADT7420_REG_HIST, &readval);
 		if (ret)
 			goto error_adt7420;

--- a/projects/demo_esp/src/examples/basic/basic_example.c
+++ b/projects/demo_esp/src/examples/basic/basic_example.c
@@ -31,6 +31,7 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 
+#include <string.h>
 #include "common_data.h"
 #include "no_os_delay.h"
 #include "no_os_error.h"
@@ -114,7 +115,7 @@ int32_t init_and_connect_wifi(struct wifi_desc **wifi)
 	return 0;
 
 error_wifi:
-	wifi_remove(wifi);
+	wifi_remove(*wifi);
 error_uart:
 	no_os_uart_remove(udesc);
 error_irq:
@@ -228,7 +229,7 @@ int init_and_connect_to_mqtt_broker(struct mqtt_desc **mqtt,
 error_wifi:
 	wifi_remove(wifi);
 error_mqtt:
-	mqtt_remove(mqtt);
+	mqtt_remove(*mqtt);
 error_sock:
 	socket_remove(sock);
 

--- a/projects/eval-ade7753/src/common/common_data.c
+++ b/projects/eval-ade7753/src/common/common_data.c
@@ -48,7 +48,8 @@ int read_measurements(struct ade7753_dev *dev)
 	float current_rms_val, voltage_rms_val;
 	float frequency_val;
 	float temperature_C;
-	int32_t status, temperature;
+	uint8_t status;
+	int32_t temperature;
 
 	/* read energy values */
 	ret = ade7753_energy_vals(dev, &energy_vals);
@@ -75,7 +76,7 @@ int read_measurements(struct ade7753_dev *dev)
 	pr_info("V rms: %.2f mV \n", voltage_rms_val);
 
 	/* read temperature */
-	ret = ade7753_get_int_status(dev, ADE7753_TEMP_MSK, status);
+	ret = ade7753_get_int_status(dev, ADE7753_TEMP_MSK, &status);
 	if (ret)
 		return ret;
 	if (status) {

--- a/projects/eval-ade7753/src/main.c
+++ b/projects/eval-ade7753/src/main.c
@@ -125,7 +125,7 @@ int main(void)
 	ade7753_ip.spi_init = &ade7753_spi_ip;
 
 	/* Init the reset */
-	ade7753_ip.gpio_reset = reset_desc;
+	ade7753_ip.gpio_reset = &gpio_reset_ip;
 
 	no_os_uart_stdio(uart_desc);
 

--- a/projects/eval-ade7754/src/common/common_data.c
+++ b/projects/eval-ade7754/src/common/common_data.c
@@ -46,17 +46,17 @@ int read_rms_measurements(struct ade7754_dev *dev)
 
 	/* read rms values */
 	if (no_os_test_bit(no_os_find_first_set_bit(ADE7754_ZXA_MSK),
-			   dev->irq_status)) {
+			   &dev->irq_status)) {
 		ret = ade7754_rms_vals_phase_a(dev, &rms_vals);
 		if (ret)
 			return ret;
 	} else if (no_os_test_bit(no_os_find_first_set_bit(ADE7754_ZXB_MSK),
-				  dev->irq_status)) {
+				  &dev->irq_status)) {
 		ret = ade7754_rms_vals_phase_b(dev, &rms_vals);
 		if (ret)
 			return ret;
 	} else if (no_os_test_bit(no_os_find_first_set_bit(ADE7754_ZXC_MSK),
-				  dev->irq_status)) {
+				  &dev->irq_status)) {
 		ret = ade7754_rms_vals_phase_c(dev, &rms_vals);
 		if (ret)
 			return ret;

--- a/projects/eval-ade7754/src/main.c
+++ b/projects/eval-ade7754/src/main.c
@@ -58,7 +58,7 @@ int main(void)
 	/* counter for display values interval */
 	uint16_t cnt;
 	/* data value read */
-	uint32_t data;
+	int32_t data;
 
 	/* parameters initialization structure */
 	struct ade7754_init_param ade7754_ip;
@@ -128,7 +128,7 @@ int main(void)
 	ade7754_ip.spi_init = &ade7754_spi_ip;
 
 	/* Init the reset */
-	ade7754_ip.gpio_reset = reset_desc;
+	ade7754_ip.gpio_reset = &gpio_reset_ip;
 
 	no_os_uart_stdio(uart_desc);
 

--- a/projects/eval-ade7758/src/common/common_data.c
+++ b/projects/eval-ade7758/src/common/common_data.c
@@ -48,7 +48,7 @@ int read_measurements(struct ade7758_dev *dev)
 
 	/* read energy values */
 	if (no_os_test_bit(no_os_find_first_set_bit(ADE7758_ZXA_MSK),
-			   dev->irq_status)) {
+			   &dev->irq_status)) {
 		ret = ade7758_energy_vals_phase_a(dev, &energy_vals);
 		if (ret)
 			return ret;
@@ -56,7 +56,7 @@ int read_measurements(struct ade7758_dev *dev)
 		if (ret)
 			return ret;
 	} else if (no_os_test_bit(no_os_find_first_set_bit(ADE7758_ZXB_MSK),
-				  dev->irq_status)) {
+				  &dev->irq_status)) {
 		ret = ade7758_energy_vals_phase_b(dev, &energy_vals);
 		if (ret)
 			return ret;
@@ -64,7 +64,7 @@ int read_measurements(struct ade7758_dev *dev)
 		if (ret)
 			return ret;
 	} else if (no_os_test_bit(no_os_find_first_set_bit(ADE7758_ZXC_MSK),
-				  dev->irq_status)) {
+				  &dev->irq_status)) {
 		ret = ade7758_energy_vals_phase_c(dev, &energy_vals);
 		if (ret)
 			return ret;

--- a/projects/eval-ade7758/src/common/common_data.h
+++ b/projects/eval-ade7758/src/common/common_data.h
@@ -90,4 +90,7 @@ and sense circuit */
 /* Read measurements */
 int read_measurements(struct ade7758_dev *dev);
 
+/* Print measurements */
+int print_measurements(struct ade7758_dev *dev);
+
 #endif /* __COMMON_DATA_H__ */

--- a/projects/eval-ade7880/src/main.c
+++ b/projects/eval-ade7880/src/main.c
@@ -40,6 +40,7 @@
 #include "no_os_units.h"
 #include "no_os_util.h"
 #include "no_os_error.h"
+#include "no_os_alloc.h"
 #include "maxim_uart.h"
 #include "maxim_gpio.h"
 #include "maxim_uart_stdio.h"
@@ -47,6 +48,9 @@
 #include "maxim_spi.h"
 #include "ade7880.h"
 #include "platform.h"
+
+/* Defined in platform.c */
+int interface_toggle_led(struct no_os_gpio_desc *gpio_led_desc);
 
 int main(void)
 {

--- a/projects/eval-ade7913/src/main.c
+++ b/projects/eval-ade7913/src/main.c
@@ -39,6 +39,7 @@
 #include "no_os_print_log.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
+#include "no_os_alloc.h"
 #include "no_os_error.h"
 #include "maxim_uart.h"
 #include "maxim_gpio.h"
@@ -53,12 +54,18 @@
 // nvic descriptor
 struct no_os_irq_ctrl_desc *ade7913_nvic_desc;
 
+// data ready flag accessors (defined in interrupt.c)
+int get_drdy_flag_state(void);
+void reset_drdy_low_flag_state(void);
+
 int main(void)
 {
 	int ret;
 	uint8_t i = 0;
 	// data read
 	uint8_t reg_val;
+	// value broadcast to the SYNC_SNAP register
+	uint8_t sync_snap_en = ENABLE;
 	uint16_t cnt;
 	// structure for the rms values
 	struct rms_adc_values rms_values;
@@ -214,7 +221,7 @@ int main(void)
 		if (ret)
 			goto free_dev;
 		ret = ade7913_write_broadcast(ade7913_dev,
-					      ADE7913_REG_SYNC_SNAP, ENABLE);
+					      ADE7913_REG_SYNC_SNAP, &sync_snap_en);
 		if (ret)
 			goto free_dev;
 		ade7913_dev->spi_desc = ade7913_dev->spi_desc0;
@@ -240,7 +247,7 @@ int main(void)
 		if (ret)
 			goto free_dev;
 		ret = ade7913_write_broadcast(ade7913_dev,
-					      ADE7913_REG_SYNC_SNAP, ENABLE);
+					      ADE7913_REG_SYNC_SNAP, &sync_snap_en);
 		if (ret)
 			goto free_dev;
 		ade7913_dev->spi_desc = ade7913_dev->spi_desc0;

--- a/projects/eval-ade7913/src/platform/platform.c
+++ b/projects/eval-ade7913/src/platform/platform.c
@@ -121,10 +121,10 @@ struct no_os_irq_init_param ade7913_gpio_irq_ip = {
 
 /**
  * @brief Init NVIC
- * @param ade7913_nvic_desc - irq nvic descriptor
+ * @param ade7913_nvic_desc - pointer to the irq nvic descriptor to allocate
  * @return 0 in case of success, negative error code otherwise.
  */
-int init_nvic(struct no_os_irq_ctrl_desc *ade7913_nvic_desc)
+int init_nvic(struct no_os_irq_ctrl_desc **ade7913_nvic_desc)
 {
 	int ret;
 
@@ -137,23 +137,23 @@ int init_nvic(struct no_os_irq_ctrl_desc *ade7913_nvic_desc)
 		.platform_ops = &max_irq_ops,
 	};
 	/* Initialize GPIO IRQ controller */
-	ret = no_os_irq_ctrl_init(&ade7913_nvic_desc,
+	ret = no_os_irq_ctrl_init(ade7913_nvic_desc,
 				  &ade7913_nvic_ip);
 	if (ret)
 		goto error;
-	ret = no_os_irq_set_priority(ade7913_nvic_desc,
+	ret = no_os_irq_set_priority(*ade7913_nvic_desc,
 				     GPIO2_IRQn, 1);
 	if (ret)
 		goto remove_irq;
 
-	ret = no_os_irq_enable(ade7913_nvic_desc, GPIO2_IRQn);
+	ret = no_os_irq_enable(*ade7913_nvic_desc, GPIO2_IRQn);
 	if (ret)
 		goto remove_irq;
 
 	return 0;
 
 remove_irq:
-	no_os_irq_ctrl_remove(ade7913_nvic_desc);
+	no_os_irq_ctrl_remove(*ade7913_nvic_desc);
 
 error:
 	pr_err("ERROR\n");

--- a/projects/eval-ade7913/src/platform/platform.h
+++ b/projects/eval-ade7913/src/platform/platform.h
@@ -76,6 +76,6 @@
 #define NVIC_GPIO_IRQ               GPIO2_IRQn
 
 // Init NVIC
-int init_nvic(struct no_os_irq_ctrl_desc *ade7913_nvic_desc);
+int init_nvic(struct no_os_irq_ctrl_desc **ade7913_nvic_desc);
 
 #endif /* __PLATFORM_H__ */

--- a/projects/eval-ade7953/src/main.c
+++ b/projects/eval-ade7953/src/main.c
@@ -126,7 +126,7 @@ int main(void)
 	ade7953_ip.en_24_bit = ENABLE;
 
 	/* Init the reset */
-	ade7953_ip.gpio_reset = reset_desc;
+	ade7953_ip.gpio_reset = &gpio_reset_ip;
 
 	no_os_uart_stdio(uart_desc);
 
@@ -145,7 +145,7 @@ int main(void)
 		goto free_dev;
 
 	/* Hard reset the ADE */
-	ade7953_dev->gpio_reset = ade7953_ip.gpio_reset;
+	ade7953_dev->gpio_reset = reset_desc;
 	ret = ade7953_hw_reset(ade7953_dev);
 	if (ret)
 		goto free_dev;

--- a/projects/eval-ade7978/src/main.c
+++ b/projects/eval-ade7978/src/main.c
@@ -40,6 +40,8 @@
 #include "no_os_units.h"
 #include "no_os_util.h"
 #include "no_os_error.h"
+#include "no_os_alloc.h"
+#include "no_os_init.h"
 #include "maxim_uart.h"
 #include "maxim_gpio.h"
 #include "maxim_uart_stdio.h"
@@ -146,7 +148,7 @@ int main(void)
 		return -ENOMEM;
 
 	/* Init measurements struct */
-	vals = (struct vals *)no_os_calloc(1, sizeof(*vals));
+	vals = (struct measurements *)no_os_calloc(1, sizeof(*vals));
 	if (!vals) {
 		ret = -ENOMEM;
 		goto free_dev;

--- a/projects/eval-ade9000/src/main.c
+++ b/projects/eval-ade9000/src/main.c
@@ -40,6 +40,7 @@
 #include "no_os_units.h"
 #include "no_os_util.h"
 #include "no_os_error.h"
+#include "no_os_alloc.h"
 #include "maxim_uart.h"
 #include "maxim_gpio.h"
 #include "maxim_uart_stdio.h"

--- a/projects/eval-ade9000/src/platform/platform.h
+++ b/projects/eval-ade9000/src/platform/platform.h
@@ -57,6 +57,8 @@ extern struct no_os_gpio_init_param gpio_led1_ip;
 // SPI init params
 extern struct no_os_spi_init_param ade9000_spi_ip ;
 
+int interface_toggle_led(struct no_os_gpio_desc *gpio_led_desc);
+
 /* Configuration for AD-APARD32690-SL */
 // Port and Pin for user LED
 #define GPIO_LED_PORT               2

--- a/projects/eval-ade9078/src/main.c
+++ b/projects/eval-ade9078/src/main.c
@@ -39,6 +39,7 @@
 #include "no_os_print_log.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
+#include "no_os_alloc.h"
 #include "no_os_error.h"
 #include "maxim_uart.h"
 #include "maxim_gpio.h"

--- a/projects/eval-ade9078/src/platform/platform.h
+++ b/projects/eval-ade9078/src/platform/platform.h
@@ -63,6 +63,9 @@ extern struct no_os_gpio_init_param gpio_reset_ip;
 // SPI init params
 extern struct no_os_spi_init_param ade9078_spi_ip ;
 
+// Toggle Led
+int interface_toggle_led(struct no_os_gpio_desc *gpio_led_desc);
+
 /* Configuration for AD-APARD32690-SL */
 // Port and Pin for user LED
 #define GPIO_LED_PORT               2

--- a/projects/eval-adhv4710/src/main.c
+++ b/projects/eval-adhv4710/src/main.c
@@ -56,7 +56,7 @@ int main(void)
 	/* counter for display values interval */
 	uint32_t cnt;
 	/* value read from the adhv registers */
-	uint8_t value;
+	int8_t value;
 	/* used to set the alarm levels */
 	uint8_t level;
 
@@ -104,7 +104,7 @@ int main(void)
 	adhv4710_ip.spi_init = &adhv4710_spi_ip;
 
 	/* Init the reset */
-	adhv4710_ip.gpio_reset = reset_desc;
+	adhv4710_ip.gpio_reset = &gpio_reset_ip;
 
 	no_os_uart_stdio(uart_desc);
 
@@ -118,7 +118,7 @@ int main(void)
 		return -ENOMEM;
 
 	/* Hard reset the ADE */
-	adhv4710_dev->gpio_reset = adhv4710_ip.gpio_reset;
+	adhv4710_dev->gpio_reset = reset_desc;
 	ret = adhv4710_hw_reset(adhv4710_dev);
 	if (ret)
 		goto free_dev;

--- a/projects/lt8722/src/examples/basic/basic_example.c
+++ b/projects/lt8722/src/examples/basic/basic_example.c
@@ -47,7 +47,7 @@ int example_main()
 	no_os_uart_stdio(uart_desc);
 
 	int ret;
-	double voltage;
+	int64_t voltage;
 	struct lt8722_dev *lt8722_dev;
 
 	pr_info("\nBasic example");

--- a/projects/max17616/src/platform/maxim/main.c
+++ b/projects/max17616/src/platform/maxim/main.c
@@ -34,6 +34,8 @@
 #include "common_data.h"
 #include "no_os_error.h"
 
+extern int example_main();
+
 int main()
 {
 	return example_main();

--- a/projects/wethlink/src/app/led.c
+++ b/projects/wethlink/src/app/led.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include "no_os_gpio.h"
+#include "no_os_delay.h"
 #include "parameters.h"
 #include "led.h"
 

--- a/projects/wethlink/src/app/main.c
+++ b/projects/wethlink/src/app/main.c
@@ -247,7 +247,7 @@ post_eeprom:
 		.rx_tolerance = nvmp->data.rx_tolerance,
 		.tx_auto_ifvga = nvmp->data.tx_auto_ifvga,
 		.rx_auto_ifvga_rflna = nvmp->data.rx_auto_ifvga_rflna,
-		.temp_correlation = &nvmp->data.temp_correlation[hbtx],
+		.temp_correlation = nvmp->data.temp_correlation[hbtx],
 		.id = id,
 		.hbtx = hbtx,
 		.crc8 = crc8,


### PR DESCRIPTION
## Pull Request Description
In order to integrate no-OS with cim, we need to fix no-OS builds with gcc 14+ versions. This covers projects built for maxim and their used drivers. Expect more patches like this one when cim will be able to build for other targets too.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
