### PR TITLE
Staging/capi xilinx

### DIFF
--- a/capi/inc/capi_gpio.h
+++ b/capi/inc/capi_gpio.h
@@ -170,6 +170,17 @@ int capi_gpio_port_get_raw_value(struct capi_gpio_port_handle *handle,
 				 uint64_t *value_bitmask);
 
 /**
+ * @brief Toggle the output value of the specified pins in a port.
+ *
+ * @param [in] handle The GPIO port.
+ * @param [in] pins_bitmask Bitmask of pins to toggle.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int capi_gpio_port_toggle(struct capi_gpio_port_handle *handle,
+			  uint64_t pins_bitmask);
+
+/**
  * @brief Set the direction of the specified GPIO pin.
  *
  * @param [in] pin The GPIO pin.
@@ -233,6 +244,15 @@ int capi_gpio_pin_set_raw_value(struct capi_gpio_pin *pin, uint8_t value);
 int capi_gpio_pin_get_raw_value(struct capi_gpio_pin *pin, uint8_t *value);
 
 /**
+ * @brief Toggle the output value of the specified GPIO pin.
+ *
+ * @param [in] pin The GPIO pin.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int capi_gpio_pin_toggle(struct capi_gpio_pin *pin);
+
+/**
  * Container for the GPIO specific operations.
  */
 struct capi_gpio_ops {
@@ -259,6 +279,8 @@ struct capi_gpio_ops {
 	/** See capi_gpio_port_get_raw_value() */
 	int (*port_get_raw_value)(struct capi_gpio_port_handle *handle,
 				  uint64_t *value_bitmask);
+	/** See capi_gpio_port_toggle() */
+	int (*port_toggle)(struct capi_gpio_port_handle *handle, uint64_t pins_bitmask);
 	/** See capi_gpio_pin_set_direction() */
 	int (*pin_set_direction)(struct capi_gpio_pin *pin, uint8_t direction);
 	/** See capi_gpio_pin_get_direction() */
@@ -271,6 +293,8 @@ struct capi_gpio_ops {
 	int (*pin_set_raw_value)(struct capi_gpio_pin *pin, uint8_t value);
 	/** See capi_gpio_pin_get_raw_value() */
 	int (*pin_get_raw_value)(struct capi_gpio_pin *pin, uint8_t *value);
+	/** See capi_gpio_pin_toggle() */
+	int (*pin_toggle)(struct capi_gpio_pin *pin);
 };
 
 #ifdef __cplusplus

--- a/capi/inc/capi_platform.h
+++ b/capi/inc/capi_platform.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Common Platform Definitions
+ */
+
+#ifndef _CAPI_PLATFORM_H_
+#define _CAPI_PLATFORM_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/**
+ * @brief Read from the specified memory address and return the
+ *        8 bit read value.
+ *
+ * @param [in] addr The memory address to read from.
+ *
+ * @return The 8 bit read value.
+ */
+#define CAPI_PLATFORM_IO_READ8(addr) UINT8_C(0x00)
+
+/**
+ * @brief Read from the specified memory address and return the
+ *        16 bit read value.
+ *
+ * @param [in] addr The memory address to read from.
+ *
+ * @return The 16 bit read value.
+ */
+#define CAPI_PLATFORM_IO_READ16(addr) UINT16_C(0x0000)
+
+/**
+ * @brief Read from the specified memory address and return the
+ *        32 bit read value.
+ *
+ * @param [in] addr The memory address to read from.
+ *
+ * @return The 32 bit read value.
+ */
+#define CAPI_PLATFORM_IO_READ32(addr) UINT32_C(0x00000000)
+
+/**
+ * @brief Read from the specified memory address and return the
+ *        64 bit read value.
+ *
+ * @param [in] addr The memory address to read from.
+ *
+ * @return The 64 bit read value.
+ */
+#define CAPI_PLATFORM_IO_READ64(addr) UINT64_C(0x0000000000000000)
+
+/**
+ * @brief Write to the specified memory address the specified
+ *        8 bit value.
+ *
+ * @param [in] addr The memory address to write to.
+ * @param [in] val The 8 bit value to write.
+ *
+ * @return None.
+ */
+#define CAPI_PLATFORM_IO_WRITE8(addr, val)
+
+/**
+ * @brief Write to the specified memory address the specified
+ *        16 bit value.
+ *
+ * @param [in] addr The memory address to write to.
+ * @param [in] val The 16 bit value to write.
+ *
+ * @return None.
+ */
+#define CAPI_PLATFORM_IO_WRITE16(addr, val)
+
+/**
+ * @brief Write to the specified memory address the specified
+ *        32 bit value.
+ *
+ * @param [in] addr The memory address to write to.
+ * @param [in] val The 32 bit value to write.
+ *
+ * @return None.
+ */
+#define CAPI_PLATFORM_IO_WRITE32(addr, val)
+
+/**
+ * @brief Write to the specified memory address the specified
+ *        64 bit value.
+ *
+ * @param [in] addr The memory address to write to.
+ * @param [in] val The 64 bit value to write.
+ *
+ * @return None.
+ */
+#define CAPI_PLATFORM_IO_WRITE64(addr, val)
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif

--- a/capi/platform/xilinx/xilinx_capi_alloc.c
+++ b/capi/platform/xilinx/xilinx_capi_alloc.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025-2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "capi_alloc.h"
+#include <stdlib.h>
+
+void *capi_malloc_impl(size_t size)
+{
+	return malloc(size);
+}
+
+void capi_free_impl(void *ptr)
+{
+	free(ptr);
+}
+
+void *capi_calloc_impl(size_t num, size_t size)
+{
+	return calloc(num, size);
+}
+
+void *capi_realloc_impl(void *ptr, size_t size)
+{
+	return realloc(ptr, size);
+}

--- a/capi/platform/xilinx/xilinx_capi_gpio.h
+++ b/capi/platform/xilinx/xilinx_capi_gpio.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Xilinx platform GPIO driver for CAPI
+ *
+ * Supported Xilinx GPIO peripherals:
+ *   - XGpioPs: Zynq PS GPIO (MIO/EMIO)
+ *   - XGpio: AXI GPIO (Programmable Logic)
+ */
+
+#ifndef _XILINX_CAPI_GPIO_H_
+#define _XILINX_CAPI_GPIO_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <capi_gpio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Platform-specific max pins :
+ *   - Zynq-7000 :        118 pins (4 banks)
+ *   - Zynq Ultrascale+ : 174 pins (6 banks)
+ *   - Versal PMC :       116 pins (4 banks)
+ *   - Versal PS :        58 pins  (2 banks)
+ *   - AXI GPIO :         32 pins per channel (max 2 channels)
+ */
+
+/**
+ * @brief Xilinx platform-specific GPIO configuration.
+ *
+ * Passed via config->extra during init. Use the struct matching the backend
+ * selected via config->ops.
+ */
+struct capi_gpio_xilinx_ps_config {
+	/** Starting global XGpioPs pin number. EMIO starts at 54 on Zynq-7000 and 78 on ZynqMP. */
+	uint8_t base_pin;
+};
+
+struct capi_gpio_xilinx_pl_config {
+	/** AXI GPIO channel: 1 or 2 (required) */
+	uint8_t channel;
+};
+
+/**
+ * @brief Xilinx GPIO operations tables. Select one via config->ops.
+ */
+extern const struct capi_gpio_ops capi_gpio_xilinx_ps_ops;
+extern const struct capi_gpio_ops capi_gpio_xilinx_pl_ops;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _XILINX_CAPI_GPIO_H_ */

--- a/capi/platform/xilinx/xilinx_capi_gpio_pl.c
+++ b/capi/platform/xilinx/xilinx_capi_gpio_pl.c
@@ -1,0 +1,697 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Xilinx platform GPIO driver implementation
+ *
+ * Supports XGpio (PL GPIO).
+ */
+#include "capi_gpio.h"
+#include <xilinx_capi_gpio_priv.h>
+#include <capi_alloc.h>
+#include <string.h>
+#include <errno.h>
+#include <stdint.h>
+
+#ifdef XPAR_XGPIO_NUM_INSTANCES
+/* AXI GPIO exposes one 32-bit data/tristate register per channel. */
+#define CAPI_GPIO_PL_MAX_PINS	32U
+
+/* Function prototypes */
+static int capi_gpio_xilinx_port_init(struct capi_gpio_port_handle **handle,
+				      const struct capi_gpio_port_config *config);
+static int capi_gpio_xilinx_port_deinit(struct capi_gpio_port_handle **handle);
+static int capi_gpio_xilinx_port_set_direction(struct capi_gpio_port_handle
+		*handle,
+		uint64_t direction_bitmask);
+static int capi_gpio_xilinx_port_get_direction(struct capi_gpio_port_handle
+		*handle,
+		uint64_t *direction_bitmask);
+static int capi_gpio_xilinx_port_set_value(struct capi_gpio_port_handle *handle,
+		uint64_t value_bitmask);
+static int capi_gpio_xilinx_port_get_value(struct capi_gpio_port_handle *handle,
+		uint64_t *value_bitmask);
+static int capi_gpio_xilinx_port_set_raw_value(struct capi_gpio_port_handle
+		*handle,
+		uint64_t value_bitmask);
+static int capi_gpio_xilinx_port_get_raw_value(struct capi_gpio_port_handle
+		*handle,
+		uint64_t *value_bitmask);
+static int capi_gpio_xilinx_pin_set_direction(struct capi_gpio_pin *pin,
+		uint8_t direction);
+static int capi_gpio_xilinx_pin_get_direction(struct capi_gpio_pin *pin,
+		uint8_t *direction);
+static int capi_gpio_xilinx_pin_set_value(struct capi_gpio_pin *pin,
+		uint8_t value);
+static int capi_gpio_xilinx_pin_get_value(struct capi_gpio_pin *pin,
+		uint8_t *value);
+static int capi_gpio_xilinx_pin_set_raw_value(struct capi_gpio_pin *pin,
+		uint8_t value);
+static int capi_gpio_xilinx_pin_get_raw_value(struct capi_gpio_pin *pin,
+		uint8_t *value);
+static int capi_gpio_xilinx_port_toggle(struct capi_gpio_port_handle *handle,
+					uint64_t pins_bitmask);
+static int capi_gpio_xilinx_pin_toggle(struct capi_gpio_pin *pin);
+
+/* GPIO operations structure. */
+const struct capi_gpio_ops capi_gpio_xilinx_pl_ops = {
+	.port_init = capi_gpio_xilinx_port_init,
+	.port_deinit = capi_gpio_xilinx_port_deinit,
+	.port_set_direction = capi_gpio_xilinx_port_set_direction,
+	.port_get_direction = capi_gpio_xilinx_port_get_direction,
+	.port_set_value = capi_gpio_xilinx_port_set_value,
+	.port_get_value = capi_gpio_xilinx_port_get_value,
+	.port_set_raw_value = capi_gpio_xilinx_port_set_raw_value,
+	.port_get_raw_value = capi_gpio_xilinx_port_get_raw_value,
+	.port_toggle = capi_gpio_xilinx_port_toggle,
+	.pin_set_direction = capi_gpio_xilinx_pin_set_direction,
+	.pin_get_direction = capi_gpio_xilinx_pin_get_direction,
+	.pin_set_value = capi_gpio_xilinx_pin_set_value,
+	.pin_get_value = capi_gpio_xilinx_pin_get_value,
+	.pin_set_raw_value = capi_gpio_xilinx_pin_set_raw_value,
+	.pin_get_raw_value = capi_gpio_xilinx_pin_get_raw_value,
+	.pin_toggle = capi_gpio_xilinx_pin_toggle
+};
+
+static uint64_t logical_to_raw(uint64_t logical_value, uint64_t active_low_mask)
+{
+	return logical_value ^ active_low_mask;
+}
+
+static uint64_t raw_to_logical(uint64_t raw_value, uint64_t active_low_mask)
+{
+	return raw_value ^ active_low_mask;
+}
+
+static uint32_t capi_gpio_get_max_pins(void)
+{
+	return CAPI_GPIO_PL_MAX_PINS;
+}
+
+static void xilinx_gpio_free_allocated_handle(
+	struct capi_gpio_port_handle **handle)
+{
+	if (handle == NULL || *handle == NULL)
+		return;
+
+	capi_free((*handle)->priv);
+	capi_free(*handle);
+	*handle = NULL;
+}
+
+static void xilinx_gpio_clear_app_handle(struct capi_gpio_port_handle *handle)
+{
+	if (handle != NULL)
+		handle->ops = NULL;
+}
+
+/* Dispatcher already checks pin != NULL and port_handle != NULL before calling us */
+static int gpio_validate_pin(const struct capi_gpio_xilinx_port_handle *xhandle,
+			     const struct capi_gpio_pin *pin)
+{
+	if (pin->number >= xhandle->num_pins)
+		return -EINVAL;
+
+	return 0;
+}
+
+static uint32_t gpio_pin_flags(const struct capi_gpio_xilinx_port_handle
+			       *xhandle,
+			       const struct capi_gpio_pin *pin)
+{
+	uint32_t flags = pin->flags;
+
+	if (xhandle->pin_flags != NULL)
+		flags |= xhandle->pin_flags[pin->number];
+
+	return flags;
+}
+
+/**
+ * @brief Initialize a GPIO port.
+ * @note PL: XGpio_Initialize().
+ *
+ * @param[out] handle GPIO port handle pointer.
+ * @param[in] config GPIO port configuration.
+ * @return 0 on success, -EINVAL, -ENODEV, -ENOMEM, or -EIO.
+ */
+static int capi_gpio_xilinx_port_init(struct capi_gpio_port_handle **handle,
+				      const struct capi_gpio_port_config *config)
+{
+	if (handle == NULL || config == NULL) {
+		return -EINVAL;
+	}
+	struct capi_gpio_xilinx_pl_config *xcfg =
+		(struct capi_gpio_xilinx_pl_config *)config->extra;
+	if (xcfg == NULL)
+		return -EINVAL;
+
+	if (xcfg->channel == 0 || xcfg->channel > 2)
+		return -EINVAL;
+
+	if (config->num_pins == 0 ||
+	    config->num_pins > capi_gpio_get_max_pins())
+		return -EINVAL;
+
+	bool alloc_handle = (*handle == NULL);
+	struct capi_gpio_port_handle *h = *handle;
+	struct capi_gpio_xilinx_port_handle *xhandle;
+	XGpio *pl_inst = NULL;
+	int ret;
+
+	if (alloc_handle) {
+		h = capi_malloc(sizeof(*h));
+		if (h == NULL)
+			return -ENOMEM;
+		memset(h, 0, sizeof(*h));
+
+		xhandle = capi_malloc(sizeof(*xhandle));
+		if (xhandle == NULL) {
+			capi_free(h);
+			return -ENOMEM;
+		}
+		h->priv = xhandle;
+		*handle = h;
+	} else {
+		xhandle = h->priv;
+		if (xhandle == NULL)
+			return -EINVAL;
+		if (h->ops != NULL || xhandle->instance != NULL ||
+		    xhandle->pin_flags != NULL)
+			return -EBUSY;
+	}
+
+	memset(xhandle, 0, sizeof(*xhandle));
+	h->init_allocated = alloc_handle;
+	h->ops = config->ops;
+	h->priv = xhandle;
+	xhandle->channel = xcfg->channel;
+	xhandle->num_pins = config->num_pins;
+
+	/* Allocate and copy pin flags */
+	xhandle->pin_flags = capi_malloc(config->num_pins * sizeof(uint32_t));
+	if (xhandle->pin_flags == NULL) {
+		ret = -ENOMEM;
+		goto err_handle;
+	}
+	if (config->flags != NULL)
+		memcpy(xhandle->pin_flags, config->flags,
+		       config->num_pins * sizeof(uint32_t));
+	else
+		memset(xhandle->pin_flags, 0, config->num_pins * sizeof(uint32_t));
+
+	/* Compute active-low mask once at init (eliminates iteration per value call) */
+	xhandle->active_low_mask = 0;
+	for (int i = 0; i < config->num_pins; i++) {
+		if (xhandle->pin_flags[i] & CAPI_GPIO_ACTIVE_LOW)
+			xhandle->active_low_mask |= (1ULL << i);
+	}
+
+	pl_inst = capi_malloc(sizeof(XGpio));
+	if (pl_inst == NULL) {
+		ret = -ENOMEM;
+		goto err_flags;
+	}
+	memset(pl_inst, 0, sizeof(XGpio));
+	if (XGpio_Initialize(pl_inst, (UINTPTR)config->identifier) != XST_SUCCESS) {
+		ret = -EIO;
+		goto err_inst;
+	}
+	xhandle->instance = pl_inst;
+
+	/*
+	 * Reject channel 2 on a single-channel core. XGpio_* assert
+	 * (Channel == 2) && (IsDual == TRUE), so without this guard the first
+	 * op on a non-dual core traps inside embeddedsw.
+	 */
+	if (xhandle->channel == 2 && pl_inst->IsDual == 0) {
+		ret = -ENOTSUP;
+		goto err_inst;
+	}
+
+	/*
+	 * Seed the direction cache from the actual TRI register instead of
+	 * leaving it zeroed. A per-pin direction change rewrites the whole
+	 * channel TRI register from this cache, so a zero seed would silently
+	 * turn every other pin into an output. XGpio TRI polarity (1=input,
+	 * 0=output) matches the CAPI cache convention, so copy it directly.
+	 */
+	xhandle->direction = XGpio_GetDataDirection(pl_inst, xhandle->channel);
+
+	return 0;
+
+err_inst:
+	capi_free(pl_inst);
+	xhandle->instance = NULL;
+err_flags:
+	capi_free(xhandle->pin_flags);
+	xhandle->pin_flags = NULL;
+err_handle:
+	if (alloc_handle)
+		xilinx_gpio_free_allocated_handle(handle);
+	else
+		xilinx_gpio_clear_app_handle(h);
+	return ret;
+}
+
+/**
+ * @brief Deinitialize a GPIO port.
+ * @note PL: Frees XGpio instance.
+ *
+ * @param[in,out] handle GPIO port handle pointer, set to NULL on success.
+ * @return 0 on success, -EINVAL if handle is NULL.
+ */
+static int capi_gpio_xilinx_port_deinit(struct capi_gpio_port_handle **handle)
+{
+	if (handle == NULL || *handle == NULL) {
+		return -EINVAL;
+	}
+	struct capi_gpio_port_handle *h = *handle;
+	struct capi_gpio_xilinx_port_handle *xhandle = h->priv;
+	if (xhandle == NULL)
+		return -EINVAL;
+
+	/* Free the Xilinx driver instance */
+	if (xhandle->instance != NULL) {
+		capi_free(xhandle->instance);
+		xhandle->instance = NULL;
+	}
+	/* Free dynamically allocated pin flags */
+	if (xhandle->pin_flags != NULL) {
+		capi_free(xhandle->pin_flags);
+		xhandle->pin_flags = NULL;
+	}
+	if (h->init_allocated) {
+		capi_free(xhandle);
+		capi_free(h);
+		*handle = NULL;
+	} else {
+		h->ops = NULL;
+	}
+	return 0;
+}
+
+/**
+ * @brief Set GPIO port direction.
+ * @note PL: XGpio_SetDataDirection().
+ *
+ * XGpio_SetDataDirection uses inverted polarity (1=output, 0=input) vs CAPI (1=input, 0=output).
+ *
+ * @param[in] handle GPIO port handle.
+ * @param[in] direction_bitmask 1=input, 0=output per pin.
+ * @return 0 on success, -EINVAL.
+ */
+int capi_gpio_xilinx_port_set_direction(struct capi_gpio_port_handle *handle,
+					uint64_t direction_bitmask)
+{
+	if (handle == NULL)
+		return -EINVAL;
+
+	struct capi_gpio_xilinx_port_handle *xhandle =
+			handle->priv;
+
+	uint64_t mask = (1ULL << xhandle->num_pins) - 1;
+	xhandle->direction = (xhandle->direction & ~mask) |
+			     (direction_bitmask & mask);
+
+	XGpio *inst = (XGpio *)xhandle->instance;
+	XGpio_SetDataDirection(inst, xhandle->channel, (uint32_t)xhandle->direction);
+	return 0;
+}
+
+/**
+ * @brief Get GPIO port direction (cached).
+ * @note PL: Returns cached direction.
+ *
+ * @param[in] handle GPIO port handle.
+ * @param[out] direction_bitmask 1=input, 0=output per pin.
+ * @return 0 on success, -EINVAL if NULL.
+ */
+static int capi_gpio_xilinx_port_get_direction(struct capi_gpio_port_handle
+		*handle,
+		uint64_t *direction_bitmask)
+{
+	if (handle == NULL || direction_bitmask == NULL) {
+		return -EINVAL;
+	}
+	struct capi_gpio_xilinx_port_handle *xhandle =
+			handle->priv;
+
+	uint64_t mask = (1ULL << xhandle->num_pins) - 1;
+	*direction_bitmask = xhandle->direction & mask;
+	return 0;
+}
+/**
+ * @brief Set GPIO port raw output value (no ACTIVE_LOW inversion).
+ *
+ * @note PL: XGpio_DiscreteWrite().
+ *
+ * @param[in] handle GPIO port handle.
+ * @param[in] value_bitmask Raw value per pin.
+ * @return 0 on success, -EINVAL, or -ENOTSUP.
+ */
+static int capi_gpio_xilinx_port_set_raw_value(struct capi_gpio_port_handle
+		*handle,
+		uint64_t value_bitmask)
+{
+	if (handle == NULL) {
+		return -EINVAL;
+	}
+	struct capi_gpio_xilinx_port_handle *xhandle =
+			handle->priv;
+
+	XGpio *inst = (XGpio *)xhandle->instance;
+	uint32_t mask = xhandle->num_pins == 32U ? UINT32_MAX :
+			(1U << xhandle->num_pins) - 1U;
+	uint32_t raw = XGpio_DiscreteRead(inst, xhandle->channel);
+	raw = (raw & ~mask) | ((uint32_t)value_bitmask & mask);
+	XGpio_DiscreteWrite(inst, xhandle->channel, raw);
+	return 0;
+}
+
+/**
+ * @brief Set GPIO port output value (applies ACTIVE_LOW inversion).
+ * @note PL: Active-low map then XGpio_DiscreteWrite().
+ *
+ * @param[in] handle GPIO port handle.
+ * @param[in] value_bitmask Logical value per pin.
+ * @return 0 on success, -EINVAL, or -ENOTSUP.
+ */
+static int capi_gpio_xilinx_port_set_value(struct capi_gpio_port_handle *handle,
+		uint64_t value_bitmask)
+{
+	if (handle == NULL) {
+		return -EINVAL;
+	}
+	struct capi_gpio_xilinx_port_handle *xhandle =
+			handle->priv;
+
+	/* Use cached active-low mask (computed once at init) */
+	uint64_t raw_value = logical_to_raw(value_bitmask, xhandle->active_low_mask);
+
+	return capi_gpio_xilinx_port_set_raw_value(handle, raw_value);
+}
+
+/**
+ * @brief Get GPIO port raw value (no ACTIVE_LOW inversion).
+ * @note PL: XGpio_DiscreteRead().
+ *
+ * Uses XGpio_DiscreteRead() and masks to num_pins.
+ *
+ * @param[in] handle GPIO port handle.
+ * @param[out] value_bitmask Raw value per pin.
+ * @return 0 on success, -EINVAL.
+ */
+static int capi_gpio_xilinx_port_get_raw_value(struct capi_gpio_port_handle
+		*handle,
+		uint64_t *value_bitmask)
+{
+	if (handle == NULL || value_bitmask == NULL)
+		return -EINVAL;
+
+	struct capi_gpio_xilinx_port_handle *xhandle =
+			handle->priv;
+
+	XGpio *inst = (XGpio *)xhandle->instance;
+	uint32_t raw = XGpio_DiscreteRead(inst, xhandle->channel);
+
+	*value_bitmask = (uint64_t)raw & ((1ULL << xhandle->num_pins) - 1);
+	return 0;
+}
+
+/**
+ * @brief Get GPIO port value (applies ACTIVE_LOW inversion).
+ * @note PL: XGpio_DiscreteRead() plus active-low map.
+ *
+ * @param[in] handle GPIO port handle.
+ * @param[out] value_bitmask Logical value per pin.
+ * @return 0 on success, -EINVAL, or -ENOTSUP.
+ */
+static int capi_gpio_xilinx_port_get_value(struct capi_gpio_port_handle *handle,
+		uint64_t *value_bitmask)
+{
+	if (handle == NULL || value_bitmask == NULL) {
+		return -EINVAL;
+	}
+	struct capi_gpio_xilinx_port_handle *xhandle =
+			handle->priv;
+
+	uint64_t raw_value;
+	int ret = capi_gpio_xilinx_port_get_raw_value(handle, &raw_value);
+	if (ret != 0) {
+		return ret;
+	}
+
+	/* Use cached active-low mask (computed once at init) */
+	*value_bitmask = raw_to_logical(raw_value, xhandle->active_low_mask);
+	return 0;
+}
+
+/**
+ * @brief Set GPIO pin direction.
+ * @note PL: Cache then XGpio_SetDataDirection().
+ *
+ * Updates cached direction then writes all pins via XGpio_SetDataDirection().
+ * XGpio polarity is inverted (1=output, 0=input) so cached value is inverted on write.
+ *
+ * @param[in] pin GPIO pin descriptor.
+ * @param[in] direction CAPI_GPIO_INPUT or CAPI_GPIO_OUTPUT.
+ * @return 0 on success, -EINVAL.
+ */
+static int capi_gpio_xilinx_pin_set_direction(struct capi_gpio_pin *pin,
+		uint8_t direction)
+{
+	struct capi_gpio_xilinx_port_handle *xhandle =
+			pin->port_handle->priv;
+
+	if (gpio_validate_pin(xhandle, pin) != 0)
+		return -EINVAL;
+
+	if (direction == CAPI_GPIO_INPUT)
+		xhandle->direction |= (1ULL << pin->number);
+	else
+		xhandle->direction &= ~(1ULL << pin->number);
+
+	XGpio *inst = (XGpio *)xhandle->instance;
+	XGpio_SetDataDirection(inst, xhandle->channel, (uint32_t)xhandle->direction);
+	return 0;
+}
+
+/**
+ * @brief Get GPIO pin direction (cached).
+ * @note PL: Returns cached pin direction.
+ *
+ * @param[in] pin GPIO pin descriptor.
+ * @param[out] direction CAPI_GPIO_INPUT or CAPI_GPIO_OUTPUT.
+ * @return 0 on success, -EINVAL.
+ */
+static int capi_gpio_xilinx_pin_get_direction(struct capi_gpio_pin *pin,
+		uint8_t *direction)
+{
+	if (direction == NULL)
+		return -EINVAL;
+
+	struct capi_gpio_xilinx_port_handle *xhandle =
+			pin->port_handle->priv;
+
+	if (gpio_validate_pin(xhandle, pin) != 0)
+		return -EINVAL;
+
+	*direction = (xhandle->direction >> pin->number) & 1;
+	return 0;
+}
+
+/**
+ * @brief Set GPIO pin value (applies ACTIVE_LOW inversion).
+ * @note PL: XGpio_DiscreteSet()/XGpio_DiscreteClear().
+ *
+ * Uses XGpio_DiscreteSet() / XGpio_DiscreteClear() for atomic single-pin writes.
+ *
+ * @param[in] pin GPIO pin descriptor.
+ * @param[in] value Logical value (0 or 1).
+ * @return 0 on success, -EINVAL.
+ */
+static int capi_gpio_xilinx_pin_set_value(struct capi_gpio_pin *pin,
+		uint8_t value)
+{
+	struct capi_gpio_xilinx_port_handle *xhandle =
+			pin->port_handle->priv;
+	if (gpio_validate_pin(xhandle, pin) != 0)
+		return -EINVAL;
+
+	uint8_t raw_value = value;
+	if (gpio_pin_flags(xhandle, pin) & CAPI_GPIO_ACTIVE_LOW) {
+		raw_value = !value;
+	}
+	XGpio *inst = (XGpio *)xhandle->instance;
+	uint32_t mask = (1U << pin->number);
+
+	/* Use atomic set/clear - faster and safer than read-modify-write */
+	if (raw_value) {
+		XGpio_DiscreteSet(inst, xhandle->channel, mask);
+	} else {
+		XGpio_DiscreteClear(inst, xhandle->channel, mask);
+	}
+	return 0;
+}
+
+/**
+ * @brief Get GPIO pin value (applies ACTIVE_LOW inversion).
+ * @note PL: XGpio_DiscreteRead() plus active-low map.
+ *
+ * Reads via XGpio_DiscreteRead() and applies active-low inversion.
+ *
+ * @param[in] pin GPIO pin descriptor.
+ * @param[out] value Logical value (0 or 1).
+ * @return 0 on success, -EINVAL.
+ */
+static int capi_gpio_xilinx_pin_get_value(struct capi_gpio_pin *pin,
+		uint8_t *value)
+{
+	if (value == NULL)
+		return -EINVAL;
+
+	struct capi_gpio_xilinx_port_handle *xhandle =
+			pin->port_handle->priv;
+	if (gpio_validate_pin(xhandle, pin) != 0)
+		return -EINVAL;
+
+	uint8_t raw_value = 0;
+
+	XGpio *inst = (XGpio *)xhandle->instance;
+	uint32_t reg = XGpio_DiscreteRead(inst, xhandle->channel);
+	raw_value = (reg >> pin->number) & 1;
+
+	/* Apply ACTIVE_LOW inversion */
+	if (gpio_pin_flags(xhandle, pin) & CAPI_GPIO_ACTIVE_LOW) {
+		*value = !raw_value;
+	} else {
+		*value = raw_value;
+	}
+	return 0;
+}
+
+/**
+ * @brief Set GPIO pin raw output value (no ACTIVE_LOW inversion).
+ * @note PL: XGpio_DiscreteSet()/XGpio_DiscreteClear().
+ *
+ * Uses XGpio_DiscreteSet() / XGpio_DiscreteClear() for atomic single-pin writes.
+ *
+ * @param[in] pin GPIO pin descriptor.
+ * @param[in] value Raw value (0 or 1).
+ * @return 0 on success, -EINVAL.
+ */
+static int capi_gpio_xilinx_pin_set_raw_value(struct capi_gpio_pin *pin,
+		uint8_t value)
+{
+	struct capi_gpio_xilinx_port_handle *xhandle =
+			pin->port_handle->priv;
+	if (gpio_validate_pin(xhandle, pin) != 0)
+		return -EINVAL;
+
+	XGpio *inst = (XGpio *)xhandle->instance;
+	uint32_t mask = (1U << pin->number);
+
+	/* Use atomic set/clear - faster and safer than read-modify-write */
+	if (value) {
+		XGpio_DiscreteSet(inst, xhandle->channel, mask);
+	} else {
+		XGpio_DiscreteClear(inst, xhandle->channel, mask);
+	}
+	return 0;
+}
+
+/**
+ * @brief Get GPIO pin raw value (no ACTIVE_LOW inversion).
+ * @note PL: XGpio_DiscreteRead().
+ *
+ * Reads via XGpio_DiscreteRead(), extracts single bit at pin->number.
+ *
+ * @param[in] pin GPIO pin descriptor.
+ * @param[out] value Raw value (0 or 1).
+ * @return 0 on success, -EINVAL.
+ */
+static int capi_gpio_xilinx_pin_get_raw_value(struct capi_gpio_pin *pin,
+		uint8_t *value)
+{
+	if (value == NULL)
+		return -EINVAL;
+
+	struct capi_gpio_xilinx_port_handle *xhandle =
+			pin->port_handle->priv;
+	if (gpio_validate_pin(xhandle, pin) != 0)
+		return -EINVAL;
+
+	XGpio *inst = (XGpio *)xhandle->instance;
+	uint32_t reg = XGpio_DiscreteRead(inst, xhandle->channel);
+	*value = (reg >> pin->number) & 1;
+	return 0;
+}
+
+/**
+ * @brief Toggle specified GPIO pins in a port.
+ * @note PL: XGpio_DiscreteRead()/XGpio_DiscreteWrite() with bits inverted.
+ *
+ * @param[in] handle GPIO port handle.
+ * @param[in] pins_bitmask Bitmask of pins to toggle.
+ * @return 0 on success, -EINVAL.
+ */
+static int capi_gpio_xilinx_port_toggle(struct capi_gpio_port_handle *handle,
+					uint64_t pins_bitmask)
+{
+	if (handle == NULL)
+		return -EINVAL;
+
+	struct capi_gpio_xilinx_port_handle *xhandle = handle->priv;
+	XGpio *inst = (XGpio *)xhandle->instance;
+
+	/*
+	 * Toggling a raw bit is equivalent to toggling the logical value
+	 * regardless of polarity, so no active-low correction is needed here:
+	 * (raw = logical ^ active_low_mask) => (logical ^ 1) ^ active_low_mask
+	 * == raw ^ 1.
+	 */
+	uint32_t current = XGpio_DiscreteRead(inst, xhandle->channel);
+	uint32_t mask = xhandle->num_pins == 32U ? UINT32_MAX :
+			(1U << xhandle->num_pins) - 1U;
+	uint32_t to_toggle = (uint32_t)pins_bitmask & mask;
+	uint32_t raw = current ^ to_toggle;
+
+	XGpio_DiscreteWrite(inst, xhandle->channel, raw);
+	return 0;
+}
+
+/**
+ * @brief Toggle a specified GPIO pin.
+ * @note PL: XGpio_DiscreteRead()/XGpio_DiscreteWrite() with bit inverted.
+ *
+ * @param[in] pin GPIO pin descriptor.
+ * @return 0 on success, -EINVAL.
+ */
+static int capi_gpio_xilinx_pin_toggle(struct capi_gpio_pin *pin)
+{
+	if (pin == NULL)
+		return -EINVAL;
+
+	struct capi_gpio_xilinx_port_handle *xhandle = pin->port_handle->priv;
+
+	if (gpio_validate_pin(xhandle, pin) != 0)
+		return -EINVAL;
+
+	/*
+	 * Toggling a raw bit is equivalent to toggling the logical value
+	 * regardless of polarity, so no active-low correction is needed here.
+	 */
+	XGpio *inst = (XGpio *)xhandle->instance;
+	uint32_t current = XGpio_DiscreteRead(inst, xhandle->channel);
+	uint32_t raw = current ^ (1U << pin->number);
+
+	XGpio_DiscreteWrite(inst, xhandle->channel, raw);
+	return 0;
+}
+
+#endif /* XPAR_XGPIO_NUM_INSTANCES */

--- a/capi/platform/xilinx/xilinx_capi_gpio_priv.h
+++ b/capi/platform/xilinx/xilinx_capi_gpio_priv.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Xilinx platform GPIO private driver contract.
+ */
+
+#ifndef _XILINX_CAPI_GPIO_PRIV_H_
+#define _XILINX_CAPI_GPIO_PRIV_H_
+
+#include <xilinx_capi_gpio.h>
+
+#include "xparameters.h"
+#ifdef XPAR_XGPIOPS_NUM_INSTANCES
+#include "xgpiops.h"
+#endif
+#ifdef XPAR_XGPIO_NUM_INSTANCES
+#include "xgpio.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @struct capi_gpio_xilinx_port_handle
+ * @brief Xilinx GPIO private port state.
+ */
+struct capi_gpio_xilinx_port_handle {
+	/** Xilinx driver instance (XGpioPs* or XGpio*) */
+	void *instance;
+	/** Starting global XGpioPs pin number (PS only) */
+	uint8_t base_pin;
+	/** AXI GPIO channel (PL only: 1 or 2) */
+	uint8_t channel;
+	/** Number of pins in this port */
+	uint8_t num_pins;
+	/** Cached direction bitmask (CAPI: 0=output, 1=input) */
+	uint64_t direction;
+	/** Per-pin flags array (malloc'd to num_pins size) */
+	uint32_t *pin_flags;
+	/** Cached active-low mask (computed once at init from pin_flags) */
+	uint64_t active_low_mask;
+};
+
+/**
+ * @brief Declare a stack-allocated Xilinx GPIO port handle.
+ *
+ * Declares `name` (struct capi_gpio_port_handle) with embedded private
+ * state. Pass &name to capi_gpio_init().
+ */
+#define CAPI_GPIO_PORT_HANDLE_XILINX_DEFINE(name)                      \
+	struct capi_gpio_port_handle name = {                              \
+		.ops = NULL,                                                   \
+		.init_allocated = false,                                       \
+		.priv = &(struct capi_gpio_xilinx_port_handle){0}              \
+	}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _XILINX_CAPI_GPIO_PRIV_H_ */

--- a/capi/platform/xilinx/xilinx_capi_gpio_ps.c
+++ b/capi/platform/xilinx/xilinx_capi_gpio_ps.c
@@ -1,0 +1,706 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Xilinx PS GPIO driver (XGpioPs)
+ *
+ * Supports Zynq-7000, ZynqMP, Versal PS GPIO.
+ * Pin numbering uses global XGpioPs pin IDs. EMIO starts at 54 on Zynq-7000
+ * and at 78 on ZynqMP.
+ * Port operations use base_pin + bit index to map bitmask to physical pins.
+ * Bank boundaries are validated at init via XGpioPs_GetBankPin().
+ */
+#include "capi_gpio.h"
+#include <xilinx_capi_gpio_priv.h>
+#include <capi_alloc.h>
+#include <string.h>
+#include <errno.h>
+#include <stdint.h>
+
+#ifdef XPAR_XGPIOPS_NUM_INSTANCES
+
+static int capi_gpio_xilinx_port_init(struct capi_gpio_port_handle **handle,
+				      const struct capi_gpio_port_config *config);
+static int capi_gpio_xilinx_port_deinit(struct capi_gpio_port_handle **handle);
+static int capi_gpio_xilinx_port_set_direction(struct capi_gpio_port_handle
+		*handle,
+		uint64_t direction_bitmask);
+static int capi_gpio_xilinx_port_get_direction(struct capi_gpio_port_handle
+		*handle,
+		uint64_t *direction_bitmask);
+static int capi_gpio_xilinx_port_set_value(struct capi_gpio_port_handle *handle,
+		uint64_t value_bitmask);
+static int capi_gpio_xilinx_port_get_value(struct capi_gpio_port_handle *handle,
+		uint64_t *value_bitmask);
+static int capi_gpio_xilinx_port_set_raw_value(struct capi_gpio_port_handle
+		*handle,
+		uint64_t value_bitmask);
+static int capi_gpio_xilinx_port_get_raw_value(struct capi_gpio_port_handle
+		*handle,
+		uint64_t *value_bitmask);
+static int capi_gpio_xilinx_pin_set_direction(struct capi_gpio_pin *pin,
+		uint8_t direction);
+static int capi_gpio_xilinx_pin_get_direction(struct capi_gpio_pin *pin,
+		uint8_t *direction);
+static int capi_gpio_xilinx_pin_set_value(struct capi_gpio_pin *pin,
+		uint8_t value);
+static int capi_gpio_xilinx_pin_get_value(struct capi_gpio_pin *pin,
+		uint8_t *value);
+static int capi_gpio_xilinx_pin_set_raw_value(struct capi_gpio_pin *pin,
+		uint8_t value);
+static int capi_gpio_xilinx_pin_get_raw_value(struct capi_gpio_pin *pin,
+		uint8_t *value);
+static int capi_gpio_xilinx_port_toggle(struct capi_gpio_port_handle *handle,
+					uint64_t pins_bitmask);
+static int capi_gpio_xilinx_pin_toggle(struct capi_gpio_pin *pin);
+
+const struct capi_gpio_ops capi_gpio_xilinx_ps_ops = {
+	.port_init = capi_gpio_xilinx_port_init,
+	.port_deinit = capi_gpio_xilinx_port_deinit,
+	.port_set_direction = capi_gpio_xilinx_port_set_direction,
+	.port_get_direction = capi_gpio_xilinx_port_get_direction,
+	.port_set_value = capi_gpio_xilinx_port_set_value,
+	.port_get_value = capi_gpio_xilinx_port_get_value,
+	.port_set_raw_value = capi_gpio_xilinx_port_set_raw_value,
+	.port_get_raw_value = capi_gpio_xilinx_port_get_raw_value,
+	.port_toggle = capi_gpio_xilinx_port_toggle,
+	.pin_set_direction = capi_gpio_xilinx_pin_set_direction,
+	.pin_get_direction = capi_gpio_xilinx_pin_get_direction,
+	.pin_set_value = capi_gpio_xilinx_pin_set_value,
+	.pin_get_value = capi_gpio_xilinx_pin_get_value,
+	.pin_set_raw_value = capi_gpio_xilinx_pin_set_raw_value,
+	.pin_get_raw_value = capi_gpio_xilinx_pin_get_raw_value,
+	.pin_toggle = capi_gpio_xilinx_pin_toggle,
+};
+
+static uint64_t logical_to_raw(uint64_t logical_value, uint64_t active_low_mask)
+{
+	return logical_value ^ active_low_mask;
+}
+
+static uint64_t raw_to_logical(uint64_t raw_value, uint64_t active_low_mask)
+{
+	return raw_value ^ active_low_mask;
+}
+
+static uint32_t capi_gpio_get_max_pins(const XGpioPs *instance)
+{
+	return instance->MaxPinNum;
+}
+
+static uint64_t gpio_pin_mask(uint8_t num_pins)
+{
+	return num_pins == 64U ? UINT64_MAX : (1ULL << num_pins) - 1ULL;
+}
+
+static void xilinx_gpio_free_allocated_handle(
+	struct capi_gpio_port_handle **handle)
+{
+	if (handle == NULL || *handle == NULL)
+		return;
+
+	capi_free((*handle)->priv);
+	capi_free(*handle);
+	*handle = NULL;
+}
+
+static void xilinx_gpio_clear_app_handle(struct capi_gpio_port_handle *handle)
+{
+	if (handle != NULL)
+		handle->ops = NULL;
+}
+
+/* Dispatcher already checks pin != NULL and port_handle != NULL before calling us */
+static int gpio_validate_pin(const struct capi_gpio_xilinx_port_handle *xhandle,
+			     const struct capi_gpio_pin *pin)
+{
+	if (pin->number >= xhandle->num_pins)
+		return -EINVAL;
+
+	return 0;
+}
+
+static uint32_t gpio_pin_flags(const struct capi_gpio_xilinx_port_handle
+			       *xhandle,
+			       const struct capi_gpio_pin *pin)
+{
+	uint32_t flags = pin->flags;
+
+	if (xhandle->pin_flags != NULL)
+		flags |= xhandle->pin_flags[pin->number];
+
+	return flags;
+}
+
+/**
+ * @brief Initialize a PS GPIO port.
+ * @note PS: XGpioPs_LookupConfig()/XGpioPs_CfgInitialize().
+ *
+ * Uses XGpioPs_LookupConfig() and XGpioPs_CfgInitialize().
+ * Validates that base_pin + num_pins stays within one bank boundary.
+ *
+ * @param[out] handle GPIO port handle pointer.
+ * @param[in] config GPIO port configuration.
+ * @return 0 on success, -EINVAL, -ENODEV, -ENOMEM, or -EIO.
+ */
+static int capi_gpio_xilinx_port_init(struct capi_gpio_port_handle **handle,
+				      const struct capi_gpio_port_config *config)
+{
+	if (handle == NULL || config == NULL)
+		return -EINVAL;
+
+	struct capi_gpio_xilinx_ps_config *xcfg =
+		(struct capi_gpio_xilinx_ps_config *)config->extra;
+
+	uint8_t base_pin = xcfg ? xcfg->base_pin : 0;
+
+	/* active_low_mask is uint64_t, so num_pins is bounded to 64. */
+	if (config->num_pins == 0 || config->num_pins > 64)
+		return -EINVAL;
+
+	bool alloc_handle = (*handle == NULL);
+	struct capi_gpio_port_handle *h = *handle;
+	struct capi_gpio_xilinx_port_handle *xhandle;
+	XGpioPs *ps_inst = NULL;
+	int ret;
+
+	if (alloc_handle) {
+		h = capi_malloc(sizeof(*h));
+		if (h == NULL)
+			return -ENOMEM;
+		memset(h, 0, sizeof(*h));
+
+		xhandle = capi_malloc(sizeof(*xhandle));
+		if (xhandle == NULL) {
+			capi_free(h);
+			return -ENOMEM;
+		}
+		h->priv = xhandle;
+		*handle = h;
+	} else {
+		xhandle = h->priv;
+		if (xhandle == NULL)
+			return -EINVAL;
+		if (h->ops != NULL || xhandle->instance != NULL ||
+		    xhandle->pin_flags != NULL)
+			return -EBUSY;
+	}
+
+	memset(xhandle, 0, sizeof(*xhandle));
+	h->init_allocated = alloc_handle;
+	h->ops = config->ops;
+	h->priv = xhandle;
+	xhandle->base_pin = base_pin;
+	xhandle->num_pins = config->num_pins;
+
+	xhandle->pin_flags = capi_malloc(config->num_pins * sizeof(uint32_t));
+	if (xhandle->pin_flags == NULL) {
+		ret = -ENOMEM;
+		goto err_handle;
+	}
+	if (config->flags != NULL)
+		memcpy(xhandle->pin_flags, config->flags, config->num_pins * sizeof(uint32_t));
+	else
+		memset(xhandle->pin_flags, 0, config->num_pins * sizeof(uint32_t));
+
+	for (int i = 0; i < config->num_pins; i++) {
+		if (xhandle->pin_flags[i] & CAPI_GPIO_ACTIVE_LOW)
+			xhandle->active_low_mask |= (1ULL << i);
+	}
+
+	XGpioPs_Config *ps_cfg = XGpioPs_LookupConfig((UINTPTR)config->identifier);
+	if (ps_cfg == NULL) {
+		ret = -ENODEV;
+		goto err_flags;
+	}
+
+	ps_inst = capi_malloc(sizeof(XGpioPs));
+	if (ps_inst == NULL) {
+		ret = -ENOMEM;
+		goto err_flags;
+	}
+	memset(ps_inst, 0, sizeof(XGpioPs));
+	int status = XGpioPs_CfgInitialize(ps_inst, ps_cfg, ps_cfg->BaseAddr);
+	if (status != XST_SUCCESS) {
+		ret = -EIO;
+		goto err_inst;
+	}
+
+	if ((uint32_t)base_pin + config->num_pins >
+	    capi_gpio_get_max_pins(ps_inst)) {
+		ret = -EINVAL;
+		goto err_inst;
+	}
+
+	/* Validate the requested port remains within one physical GPIO bank. */
+	u8 start_bank, start_pin_in_bank;
+	u8 end_bank, end_pin_in_bank;
+	/*
+	 * Versal's XGpioPs_GetBankPin() signature takes the instance pointer;
+	 * Zynq/ZynqMP BSPs expose the older static-helper signature.
+	 */
+#ifdef versal
+	XGpioPs_GetBankPin(ps_inst, (u8)base_pin,
+			   &start_bank, &start_pin_in_bank);
+	XGpioPs_GetBankPin(ps_inst,
+			   (u8)(base_pin + config->num_pins - 1),
+			   &end_bank, &end_pin_in_bank);
+#else
+	XGpioPs_GetBankPin((u8)base_pin, &start_bank, &start_pin_in_bank);
+	XGpioPs_GetBankPin((u8)(base_pin + config->num_pins - 1),
+			   &end_bank, &end_pin_in_bank);
+#endif
+	if (start_bank != end_bank) {
+		ret = -EINVAL;
+		goto err_inst;
+	}
+
+	xhandle->instance = ps_inst;
+	return 0;
+
+err_inst:
+	capi_free(ps_inst);
+err_flags:
+	capi_free(xhandle->pin_flags);
+	xhandle->pin_flags = NULL;
+err_handle:
+	if (alloc_handle)
+		xilinx_gpio_free_allocated_handle(handle);
+	else
+		xilinx_gpio_clear_app_handle(h);
+	return ret;
+}
+
+/**
+ * @brief Deinitialize a PS GPIO port.
+ * @note PS: Frees XGpioPs instance.
+ *
+ * @param[in,out] handle GPIO port handle pointer, set to NULL on success.
+ * @return 0 on success, -EINVAL if handle is NULL.
+ */
+static int capi_gpio_xilinx_port_deinit(struct capi_gpio_port_handle **handle)
+{
+	if (handle == NULL || *handle == NULL)
+		return -EINVAL;
+
+	struct capi_gpio_port_handle *h = *handle;
+	struct capi_gpio_xilinx_port_handle *xhandle = h->priv;
+	if (xhandle == NULL)
+		return -EINVAL;
+
+	if (xhandle->instance != NULL) {
+		capi_free(xhandle->instance);
+		xhandle->instance = NULL;
+	}
+	if (xhandle->pin_flags != NULL) {
+		capi_free(xhandle->pin_flags);
+		xhandle->pin_flags = NULL;
+	}
+	if (h->init_allocated) {
+		capi_free(xhandle);
+		capi_free(h);
+		*handle = NULL;
+	} else {
+		h->ops = NULL;
+	}
+	return 0;
+}
+
+/**
+ * @brief Set PS GPIO port direction.
+ * @note PS: XGpioPs_SetDirectionPin()/XGpioPs_SetOutputEnablePin().
+ *
+ * Iterates pins, maps bitmask bit i to physical pin base_pin+i.
+ * XGpioPs direction polarity (0=input, 1=output) is the inverse of CAPI
+ * (CAPI_GPIO_OUTPUT=0 / CAPI_GPIO_INPUT=1), so the bit is inverted when
+ * calling SetDirectionPin (CAPI input -> 0, CAPI output -> 1).
+ * Output enable is set here once per output pin, not on every value write.
+ *
+ * @param[in] handle GPIO port handle.
+ * @param[in] direction_bitmask 1=input, 0=output per bit.
+ * @return 0 on success, -EINVAL.
+ */
+static int capi_gpio_xilinx_port_set_direction(struct capi_gpio_port_handle
+		*handle,
+		uint64_t direction_bitmask)
+{
+	if (handle == NULL)
+		return -EINVAL;
+
+	struct capi_gpio_xilinx_port_handle *xhandle =
+			handle->priv;
+
+	xhandle->direction = direction_bitmask & gpio_pin_mask(xhandle->num_pins);
+
+	XGpioPs *inst = (XGpioPs *)xhandle->instance;
+	for (int i = 0; i < xhandle->num_pins; i++) {
+		u32 physical_pin = xhandle->base_pin + i;
+		int is_input = (direction_bitmask >> i) & 1; /* CAPI: 1=input */
+		/* XGpioPs: 0=input, 1=output */
+		XGpioPs_SetDirectionPin(inst, physical_pin, is_input ? 0 : 1);
+		/* Enable output buffer only for output pins */
+		XGpioPs_SetOutputEnablePin(inst, physical_pin, is_input ? 0 : 1);
+	}
+	return 0;
+}
+
+/**
+ * @brief Get PS GPIO port direction (cached).
+ * @note PS: Returns cached direction.
+ *
+ * @param[in] handle GPIO port handle.
+ * @param[out] direction_bitmask 1=input, 0=output per bit.
+ * @return 0 on success, -EINVAL.
+ */
+static int capi_gpio_xilinx_port_get_direction(struct capi_gpio_port_handle
+		*handle,
+		uint64_t *direction_bitmask)
+{
+	if (handle == NULL || direction_bitmask == NULL)
+		return -EINVAL;
+
+	struct capi_gpio_xilinx_port_handle *xhandle =
+			handle->priv;
+
+	*direction_bitmask = xhandle->direction;
+	return 0;
+}
+
+/**
+ * @brief Set PS GPIO port raw output value (no ACTIVE_LOW inversion).
+ * @note PS: XGpioPs_WritePin().
+ *
+ * Skips input pins. Uses XGpioPs_WritePin() per output pin.
+ *
+ * @param[in] handle GPIO port handle.
+ * @param[in] value_bitmask Raw value per bit.
+ * @return 0 on success, -EINVAL.
+ */
+static int capi_gpio_xilinx_port_set_raw_value(struct capi_gpio_port_handle
+		*handle,
+		uint64_t value_bitmask)
+{
+	if (handle == NULL)
+		return -EINVAL;
+
+	struct capi_gpio_xilinx_port_handle *xhandle =
+			handle->priv;
+
+	XGpioPs *inst = (XGpioPs *)xhandle->instance;
+	for (int i = 0; i < xhandle->num_pins; i++) {
+		if (xhandle->direction & (1ULL << i))
+			continue; /* skip input pins */
+
+		u32 physical_pin = xhandle->base_pin + i;
+		XGpioPs_WritePin(inst, physical_pin, (value_bitmask >> i) & 1);
+	}
+	return 0;
+}
+
+/**
+ * @brief Set PS GPIO port output value (applies ACTIVE_LOW inversion).
+ * @note PS: Active-low map then XGpioPs_WritePin().
+ *
+ * @param[in] handle GPIO port handle.
+ * @param[in] value_bitmask Logical value per bit.
+ * @return 0 on success, -EINVAL.
+ */
+static int capi_gpio_xilinx_port_set_value(struct capi_gpio_port_handle *handle,
+		uint64_t value_bitmask)
+{
+	if (handle == NULL)
+		return -EINVAL;
+
+	struct capi_gpio_xilinx_port_handle *xhandle =
+			handle->priv;
+
+	return capi_gpio_xilinx_port_set_raw_value(
+		       handle, logical_to_raw(value_bitmask, xhandle->active_low_mask));
+}
+
+/**
+ * @brief Get PS GPIO port raw value (no ACTIVE_LOW inversion).
+ * @note PS: XGpioPs_ReadPin().
+ *
+ * Reads each pin via XGpioPs_ReadPin(), assembles bitmask.
+ *
+ * @param[in] handle GPIO port handle.
+ * @param[out] value_bitmask Raw value per bit.
+ * @return 0 on success, -EINVAL.
+ */
+static int capi_gpio_xilinx_port_get_raw_value(struct capi_gpio_port_handle
+		*handle,
+		uint64_t *value_bitmask)
+{
+	if (handle == NULL || value_bitmask == NULL)
+		return -EINVAL;
+
+	struct capi_gpio_xilinx_port_handle *xhandle =
+			handle->priv;
+
+	XGpioPs *inst = (XGpioPs *)xhandle->instance;
+	*value_bitmask = 0;
+	for (int i = 0; i < xhandle->num_pins; i++) {
+		u32 physical_pin = xhandle->base_pin + i;
+		*value_bitmask |= ((uint64_t)(XGpioPs_ReadPin(inst, physical_pin) & 1) << i);
+	}
+	return 0;
+}
+
+/**
+ * @brief Get PS GPIO port value (applies ACTIVE_LOW inversion).
+ * @note PS: XGpioPs_ReadPin() plus active-low map.
+ *
+ * @param[in] handle GPIO port handle.
+ * @param[out] value_bitmask Logical value per bit.
+ * @return 0 on success, -EINVAL.
+ */
+static int capi_gpio_xilinx_port_get_value(struct capi_gpio_port_handle *handle,
+		uint64_t *value_bitmask)
+{
+	if (handle == NULL || value_bitmask == NULL)
+		return -EINVAL;
+
+	struct capi_gpio_xilinx_port_handle *xhandle =
+			handle->priv;
+
+	uint64_t raw;
+	int ret = capi_gpio_xilinx_port_get_raw_value(handle, &raw);
+	if (ret != 0)
+		return ret;
+
+	*value_bitmask = raw_to_logical(raw, xhandle->active_low_mask);
+	return 0;
+}
+
+/**
+ * @brief Set PS GPIO pin direction.
+ * @note PS: XGpioPs_SetDirectionPin()/XGpioPs_SetOutputEnablePin().
+ *
+ * pin->number is used directly as the absolute XGpioPs global pin ID.
+ * XGpioPs: 0=input, 1=output. Output enable set/cleared here.
+ *
+ * @param[in] pin GPIO pin descriptor.
+ * @param[in] direction CAPI_GPIO_INPUT or CAPI_GPIO_OUTPUT.
+ * @return 0 on success, -EINVAL.
+ */
+static int capi_gpio_xilinx_pin_set_direction(struct capi_gpio_pin *pin,
+		uint8_t direction)
+{
+	struct capi_gpio_xilinx_port_handle *xhandle =
+			pin->port_handle->priv;
+
+	if (gpio_validate_pin(xhandle, pin) != 0)
+		return -EINVAL;
+
+	if (direction == CAPI_GPIO_INPUT)
+		xhandle->direction |= (1ULL << pin->number);
+	else
+		xhandle->direction &= ~(1ULL << pin->number);
+
+	XGpioPs *inst = (XGpioPs *)xhandle->instance;
+	u32 physical_pin = xhandle->base_pin + pin->number;
+	int is_input = (direction == CAPI_GPIO_INPUT);
+	XGpioPs_SetDirectionPin(inst, physical_pin, is_input ? 0 : 1);
+	XGpioPs_SetOutputEnablePin(inst, physical_pin, is_input ? 0 : 1);
+	return 0;
+}
+
+/**
+ * @brief Get PS GPIO pin direction (cached).
+ * @note PS: Returns cached pin direction.
+ *
+ * @param[in] pin GPIO pin descriptor.
+ * @param[out] direction CAPI_GPIO_INPUT or CAPI_GPIO_OUTPUT.
+ * @return 0 on success, -EINVAL.
+ */
+static int capi_gpio_xilinx_pin_get_direction(struct capi_gpio_pin *pin,
+		uint8_t *direction)
+{
+	if (direction == NULL)
+		return -EINVAL;
+
+	struct capi_gpio_xilinx_port_handle *xhandle =
+			pin->port_handle->priv;
+
+	if (gpio_validate_pin(xhandle, pin) != 0)
+		return -EINVAL;
+
+	*direction =
+		(xhandle->direction & (1ULL << pin->number)) ? CAPI_GPIO_INPUT :
+		CAPI_GPIO_OUTPUT;
+	return 0;
+}
+
+/**
+ * @brief Set PS GPIO pin value (applies ACTIVE_LOW inversion).
+ * @note PS: XGpioPs_WritePin().
+ *
+ * Uses XGpioPs_WritePin() with pin->number as absolute global pin ID.
+ *
+ * @param[in] pin GPIO pin descriptor.
+ * @param[in] value Logical value (0 or 1).
+ * @return 0 on success, -EINVAL.
+ */
+static int capi_gpio_xilinx_pin_set_value(struct capi_gpio_pin *pin,
+		uint8_t value)
+{
+	struct capi_gpio_xilinx_port_handle *xhandle =
+			pin->port_handle->priv;
+
+	if (gpio_validate_pin(xhandle, pin) != 0)
+		return -EINVAL;
+
+	uint8_t raw = (gpio_pin_flags(xhandle,
+				      pin) & CAPI_GPIO_ACTIVE_LOW) ? !value : value;
+	XGpioPs_WritePin((XGpioPs *)xhandle->instance, xhandle->base_pin + pin->number,
+			 raw);
+	return 0;
+}
+
+/**
+ * @brief Get PS GPIO pin value (applies ACTIVE_LOW inversion).
+ * @note PS: XGpioPs_ReadPin() plus active-low map.
+ *
+ * Uses XGpioPs_ReadPin() with pin->number as absolute global pin ID.
+ *
+ * @param[in] pin GPIO pin descriptor.
+ * @param[out] value Logical value (0 or 1).
+ * @return 0 on success, -EINVAL.
+ */
+static int capi_gpio_xilinx_pin_get_value(struct capi_gpio_pin *pin,
+		uint8_t *value)
+{
+	if (value == NULL)
+		return -EINVAL;
+
+	struct capi_gpio_xilinx_port_handle *xhandle =
+			pin->port_handle->priv;
+
+	if (gpio_validate_pin(xhandle, pin) != 0)
+		return -EINVAL;
+
+	uint8_t raw =
+		XGpioPs_ReadPin((XGpioPs *)xhandle->instance,
+				xhandle->base_pin + pin->number) & 1;
+	*value = (gpio_pin_flags(xhandle, pin) & CAPI_GPIO_ACTIVE_LOW) ? !raw : raw;
+	return 0;
+}
+
+/**
+ * @brief Set PS GPIO pin raw output value (no ACTIVE_LOW inversion).
+ * @note PS: XGpioPs_WritePin().
+ *
+ * Uses XGpioPs_WritePin() with pin->number as absolute global pin ID.
+ *
+ * @param[in] pin GPIO pin descriptor.
+ * @param[in] value Raw value (0 or 1).
+ * @return 0 on success, -EINVAL.
+ */
+static int capi_gpio_xilinx_pin_set_raw_value(struct capi_gpio_pin *pin,
+		uint8_t value)
+{
+	struct capi_gpio_xilinx_port_handle *xhandle =
+			pin->port_handle->priv;
+
+	if (gpio_validate_pin(xhandle, pin) != 0)
+		return -EINVAL;
+
+	XGpioPs_WritePin((XGpioPs *)xhandle->instance, xhandle->base_pin + pin->number,
+			 value & 1);
+	return 0;
+}
+
+/**
+ * @brief Get PS GPIO pin raw value (no ACTIVE_LOW inversion).
+ * @note PS: XGpioPs_ReadPin().
+ *
+ * Uses XGpioPs_ReadPin() with pin->number as absolute global pin ID.
+ *
+ * @param[in] pin GPIO pin descriptor.
+ * @param[out] value Raw value (0 or 1).
+ * @return 0 on success, -EINVAL.
+ */
+static int capi_gpio_xilinx_pin_get_raw_value(struct capi_gpio_pin *pin,
+		uint8_t *value)
+{
+	if (value == NULL)
+		return -EINVAL;
+
+	struct capi_gpio_xilinx_port_handle *xhandle =
+			pin->port_handle->priv;
+
+	if (gpio_validate_pin(xhandle, pin) != 0)
+		return -EINVAL;
+
+	*value = XGpioPs_ReadPin((XGpioPs *)xhandle->instance,
+				 xhandle->base_pin + pin->number) & 1;
+	return 0;
+}
+
+/**
+ * @brief Toggle specified GPIO pins in a port.
+ * @note PS: XGpioPs_WritePin() with current value inverted.
+ *
+ * @param[in] handle GPIO port handle.
+ * @param[in] pins_bitmask Bitmask of pins to toggle.
+ * @return 0 on success, -EINVAL.
+ */
+static int capi_gpio_xilinx_port_toggle(struct capi_gpio_port_handle *handle,
+					uint64_t pins_bitmask)
+{
+	if (handle == NULL)
+		return -EINVAL;
+
+	struct capi_gpio_xilinx_port_handle *xhandle = handle->priv;
+
+	/*
+	 * XGpioPs_ReadPin()/WritePin() operate on the raw pin level. Toggling
+	 * a raw bit is equivalent to toggling the logical value regardless of
+	 * polarity, so no active-low correction is needed here.
+	 */
+	for (uint8_t i = 0; i < xhandle->num_pins; i++) {
+		if (pins_bitmask & (1ULL << i)) {
+			uint32_t current = XGpioPs_ReadPin((XGpioPs *)xhandle->instance,
+							   xhandle->base_pin + i) & 1;
+			XGpioPs_WritePin((XGpioPs *)xhandle->instance,
+					 xhandle->base_pin + i, current ^ 1);
+		}
+	}
+	return 0;
+}
+
+/**
+ * @brief Toggle a specified GPIO pin.
+ * @note PS: XGpioPs_ReadPin()/XGpioPs_WritePin() with value inverted.
+ *
+ * @param[in] pin GPIO pin descriptor.
+ * @return 0 on success, -EINVAL.
+ */
+static int capi_gpio_xilinx_pin_toggle(struct capi_gpio_pin *pin)
+{
+	if (pin == NULL)
+		return -EINVAL;
+
+	struct capi_gpio_xilinx_port_handle *xhandle = pin->port_handle->priv;
+
+	if (gpio_validate_pin(xhandle, pin) != 0)
+		return -EINVAL;
+
+	/*
+	 * Toggling a raw bit is equivalent to toggling the logical value
+	 * regardless of polarity, so no active-low correction is needed here.
+	 */
+	uint32_t current = XGpioPs_ReadPin((XGpioPs *)xhandle->instance,
+					   xhandle->base_pin + pin->number) & 1;
+
+	XGpioPs_WritePin((XGpioPs *)xhandle->instance,
+			 xhandle->base_pin + pin->number, current ^ 1);
+	return 0;
+}
+
+#endif /* XPAR_XGPIOPS_NUM_INSTANCES */

--- a/capi/platform/xilinx/xilinx_capi_i2c.h
+++ b/capi/platform/xilinx/xilinx_capi_i2c.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Xilinx platform I2C driver for CAPI
+ *
+ * Backends (select via config.ops):
+ *   capi_i2c_xilinx_ps_ops  - XIicPs  (Zynq PS I2C)
+ *   capi_i2c_xilinx_pl_ops  - XIic    (AXI IIC)
+ *
+ * A PS target's SDA sampling window is sized by XIicPs_SetSClk, so it must be
+ * reconfigured to the initiator's speed (a target left at 100k cannot sample a
+ * 400k bus). A PL target oversamples off the fabric clock and needs no such
+ * step. See capi_i2c_{ps,pl}_configure_bus_speed.
+ *
+ * Pass config->extra = NULL for polled mode. To use interrupts, pass
+ * struct capi_i2c_xilinx_config with use_irq=true and the desired irq_id.
+ * IRQ ID 0 is valid for INTC input 0.
+ */
+
+#ifndef _XILINX_CAPI_I2C_H_
+#define _XILINX_CAPI_I2C_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <capi_i2c.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @struct capi_i2c_xilinx_config
+ * @brief Optional Xilinx platform-specific I2C configuration.
+ *
+ * Passed via config->extra during init. use_irq decides whether the driver
+ * connects irq_id through the CAPI IRQ singleton. input_clock_hz optionally
+ * enables PL XIic timing-register writes for designs that expose them.
+ * IRQ ID 0 is valid for an INTC input, so it is passed through unchanged.
+ */
+struct capi_i2c_xilinx_config {
+	/** Enable CAPI IRQ connection during init */
+	bool use_irq;
+	/** Normalized CAPI IRQ ID. Zero is valid for INTC input 0. */
+	uint32_t irq_id;
+	/** Clock feeding optional AXI IIC timing logic. Zero disables timing writes. */
+	uint32_t input_clock_hz;
+	/** Optional SCL-high timing register offset. Zero selects the driver default. */
+	uint32_t thigh_offset;
+	/** Optional SCL-low timing register offset. Zero selects the driver default. */
+	uint32_t tlow_offset;
+	/** Optional init-time bus rate. Zero leaves timing unchanged unless config asks. */
+	uint32_t default_bus_hz;
+	/** Optional init/config duty cycle percent. Zero selects 50%. */
+	uint8_t default_duty_percent;
+};
+
+/**
+ * @brief Xilinx I2C operations tables. Select one via config->ops.
+ */
+extern const struct capi_i2c_ops capi_i2c_xilinx_ps_ops;
+extern const struct capi_i2c_ops capi_i2c_xilinx_pl_ops;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _XILINX_CAPI_I2C_H_ */

--- a/capi/platform/xilinx/xilinx_capi_i2c_pl.c
+++ b/capi/platform/xilinx/xilinx_capi_i2c_pl.c
@@ -1,0 +1,1787 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Xilinx XIic AXI IIC driver
+ *
+ * SDT BSP only. IRQ is explicit via capi_i2c_xilinx_config.
+ * capi_irq_init() must be called before async ops will work.
+ */
+
+#include <capi_i2c.h>
+#include <xilinx_capi_i2c_priv.h>
+#include <capi_irq.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <capi_alloc.h>
+#include <capi_time.h>
+#include <string.h>
+#include "xinterrupt_wrap.h"
+
+#ifdef XPAR_XIIC_NUM_INSTANCES
+
+#define I2C_PL_7BIT_MAX_ADDR		0x7FU
+#define I2C_PL_10BIT_MAX_ADDR		0x3FEU
+#define I2C_PL_BUS_BUSY_TIMEOUT		100000U
+
+/* Bits clocked per byte on the wire: 8 data bits + 1 ACK/NACK. The address
+ * phase costs the same, so we bill it as one extra byte (the "+ 1" below). */
+#define I2C_PL_BITS_PER_BYTE		9U
+/* Safety multiplier over the ideal transfer time: covers START/STOP, repeated
+ * START, ISR latency, and clock stretching by a slow target. */
+#define I2C_PL_TIMEOUT_SAFETY		3U
+/* Fall back to 100 kHz (standard mode) if the handle has no SCL rate. */
+#define I2C_PL_DEFAULT_SCL_HZ		100000U
+
+/* Defaults for designs with nonstandard THIGH/TLOW registers. */
+#define I2C_PL_DEFAULT_THIGH_OFFSET	0x13CU
+#define I2C_PL_DEFAULT_TLOW_OFFSET	0x140U
+#define I2C_PL_DEFAULT_DUTY_PERCENT	50U
+#define I2C_PL_MIN_DUTY_PERCENT		10U
+#define I2C_PL_MAX_DUTY_PERCENT		90U
+
+/*
+ * Frame size a bounced target receive is armed for (see the target branch of
+ * capi_i2c_pl_receive_async). Unlike XIicPs, whose bounce ceiling is the
+ * hardware's own XIICPS_MAX_TRANSFER_SIZE, the AXI IIC imposes no per-frame
+ * limit -- an initiator may clock indefinitely -- so this is a driver-chosen
+ * cap on how much overrun the target will silently absorb, not a hardware
+ * property. An initiator sending MORE than this still gets NO_ACK once the
+ * bounce buffer is exhausted, which is the correct I2C response to a receiver
+ * that is genuinely out of room; the cap only decides where that point is.
+ * 256 covers a byte-length-prefixed frame with room to spare.
+ */
+#define XIIC_TARGET_RX_ABSORB_LEN	256U
+
+static int capi_i2c_pl_init(struct capi_i2c_controller_handle **handle,
+			    const struct capi_i2c_config *config);
+static int capi_i2c_pl_deinit(struct capi_i2c_controller_handle *handle);
+static int capi_i2c_pl_transmit(struct capi_i2c_device *device,
+				struct capi_i2c_transfer *transfer);
+static int capi_i2c_pl_receive(struct capi_i2c_device *device,
+			       struct capi_i2c_transfer *transfer);
+static int capi_i2c_pl_register_callback(struct capi_i2c_controller_handle
+		*handle,
+		capi_i2c_callback const callback,
+		void *const callback_arg);
+static int capi_i2c_pl_configure_bus_speed(struct capi_i2c_controller_handle
+		*handle,
+		enum capi_i2c_speed speed, uint8_t duty_cycle);
+static int capi_i2c_pl_transmit_async(struct capi_i2c_device *device,
+				      struct capi_i2c_transfer *transfer);
+static int capi_i2c_pl_receive_async(struct capi_i2c_device *device,
+				     struct capi_i2c_transfer *transfer);
+static int capi_i2c_pl_recover_bus(struct capi_i2c_controller_handle *handle);
+static int capi_i2c_pl_register_target(struct capi_i2c_controller_handle
+				       *handle, uint16_t addr);
+static int capi_i2c_pl_unregister_target(struct capi_i2c_controller_handle
+		*handle);
+static void capi_i2c_pl_isr(void *handle);
+static void xiic_send_handler(void *ref, int byte_count);
+static void xiic_recv_handler(void *ref, int byte_count);
+static void xiic_status_handler(void *ref, int status_event);
+static void xiic_complete_transfer(struct capi_i2c_xilinx_handle *xh,
+				   int status,
+				   enum capi_i2c_async_event event);
+static int capi_i2c_pl_set_bus_clock(struct capi_i2c_xilinx_handle *xh,
+				     uint32_t bus_hz,
+				     uint8_t duty_percent);
+static int xiic_recv_polled_bounded(struct capi_i2c_xilinx_handle *xh,
+				    u8 addr, uint8_t *buf, uint32_t len);
+
+const struct capi_i2c_ops capi_i2c_xilinx_pl_ops = {
+	.init = capi_i2c_pl_init,
+	.deinit = capi_i2c_pl_deinit,
+	.transmit = capi_i2c_pl_transmit,
+	.receive = capi_i2c_pl_receive,
+	.register_callback = capi_i2c_pl_register_callback,
+	.configure_bus_speed = capi_i2c_pl_configure_bus_speed,
+	.transmit_async = capi_i2c_pl_transmit_async,
+	.receive_async = capi_i2c_pl_receive_async,
+	.recover_bus = capi_i2c_pl_recover_bus,
+	.register_target = capi_i2c_pl_register_target,
+	.unregister_target = capi_i2c_pl_unregister_target,
+	.isr = capi_i2c_pl_isr,
+};
+
+static XIic *inst(struct capi_i2c_xilinx_handle *xh)
+{
+	return (XIic *)xh->instance;
+}
+
+/*
+ * Wall-clock timeout for an I2C transfer. Budget = 3× wire time + 2ms software
+ * margin, floored at 5ms for no-progress detection. Wire time = (len+1)·9 bits
+ * at scl_hz; the 3× covers START/STOP, repeated START, and clock stretching.
+ */
+static uint64_t xiic_transfer_timeout_us(struct capi_i2c_xilinx_handle *xh,
+		uint32_t len)
+{
+	uint32_t scl_hz = xh->clk_freq_hz ? xh->clk_freq_hz :
+			  I2C_PL_DEFAULT_SCL_HZ;
+
+	uint64_t clocks = (uint64_t)(len + 1U) * I2C_PL_BITS_PER_BYTE;
+	uint64_t wire_us = clocks * 1000000ULL / scl_hz;
+	uint64_t timeout_us = wire_us * I2C_PL_TIMEOUT_SAFETY + 2000U;
+
+	return timeout_us < 5000U ? 5000U : timeout_us;
+}
+
+/**
+ * @brief Wall-clock deadline for the busy-wait loops (async completion and the
+ * register-polling bus-state waits: START -> BUS_BUSY, per-byte RX_FULL,
+ * STOP -> BNB, reset -> idle).
+ *
+ * A raw `--count` loop is not a unit of time: it drains faster on a faster CPU,
+ * so a transfer legitimately in flight can be abandoned on a fast core. Poll
+ * capi_uptime() instead. I2C_PL_BUS_BUSY_TIMEOUT is the spin backstop for the
+ * case where no monotonic clock is available -- notably MicroBlaze, whose time
+ * backend returns -ENOTSUP. Without this backstop a missing clock would collapse
+ * to a single check and every wait would give up on its first iteration; with it
+ * the loop still bounds-waits (CPU-relative, imprecise, but non-degenerate)
+ * rather than either hanging forever or timing out immediately.
+ */
+struct xiic_deadline {
+	uint64_t start;
+	uint64_t budget_us;
+	uint32_t spins;
+	bool have_clock;
+};
+
+static void xiic_deadline_init(struct xiic_deadline *d, uint64_t budget_us)
+{
+	d->budget_us = budget_us;
+	d->spins = I2C_PL_BUS_BUSY_TIMEOUT;
+	d->have_clock = (capi_uptime(&d->start) == 0);
+}
+
+/* True while time remains; false once the budget (or spin backstop) expires. */
+static bool xiic_deadline_ok(struct xiic_deadline *d)
+{
+	if (d->have_clock) {
+		uint64_t now;
+
+		if (capi_uptime(&now) == 0)
+			return (now - d->start) < d->budget_us;
+		d->have_clock = false;
+	}
+	return d->spins-- > 0U;
+}
+
+/**
+ * @brief Block until an async transfer completes or the time budget expires.
+ *
+ * Uses the same xiic_deadline mechanism as the polled path, so the no-clock
+ * fallback (MicroBlaze: capi_uptime -> -ENOTSUP) bounds-waits on the spin
+ * backstop instead of doing a single check and reporting an immediate timeout.
+ *
+ * @param xh         Controller handle; xh->xfer_done is set by the ISR.
+ * @param timeout_us Budget from xiic_transfer_timeout_us().
+ * @return true if the transfer completed, false on timeout.
+ */
+static bool xiic_wait_xfer_done(struct capi_i2c_xilinx_handle *xh,
+				uint64_t timeout_us)
+{
+	struct xiic_deadline dl;
+
+	xiic_deadline_init(&dl, timeout_us);
+	while (!xh->xfer_done) {
+		if (!xiic_deadline_ok(&dl))
+			break;
+	}
+
+	return xh->xfer_done;
+}
+
+static void xiic_set_repeated_start(struct capi_i2c_xilinx_handle *xh,
+				    bool enable)
+{
+	u32 options = inst(xh)->Options;
+
+	if (enable)
+		options |= XII_REPEATED_START_OPTION;
+	else
+		options &= ~XII_REPEATED_START_OPTION;
+	XIic_SetOptions(inst(xh), options);
+}
+
+static void xilinx_i2c_free_allocated_handle(
+	struct capi_i2c_controller_handle **handle)
+{
+	if (handle == NULL || *handle == NULL)
+		return;
+
+	capi_free((*handle)->priv);
+	capi_free(*handle);
+	*handle = NULL;
+}
+
+static void xilinx_i2c_clear_app_handle(
+	struct capi_i2c_controller_handle *handle)
+{
+	if (handle != NULL)
+		handle->ops = NULL;
+}
+
+static int xiic_status_to_errno(int status)
+{
+	switch (status) {
+	case XST_SUCCESS:
+		return 0;
+	case XST_IIC_BUS_BUSY:
+		return -EBUSY;
+	case XST_IIC_GENERAL_CALL_ADDRESS:
+		return -EINVAL;
+	case XST_IIC_ARB_LOST:
+		return -EIO;
+	default:
+		return -EIO;
+	}
+}
+
+/* XIic has no transfer-time control for per-device timing fields. */
+static int pl_check_device_fields(const struct capi_i2c_device *device)
+{
+	if (device->duty_cycle != 0)
+		return -ENOTSUP;
+	if (device->clk_stretch != 0)
+		return -ENOTSUP;
+	return 0;
+}
+
+/* XIic_SetAddress asserts unless the address is below 1023. */
+static int pl_check_addr(uint16_t addr, bool b10addr)
+{
+	if (b10addr) {
+		if (addr > I2C_PL_10BIT_MAX_ADDR)
+			return -EINVAL;
+	} else if (addr > I2C_PL_7BIT_MAX_ADDR) {
+		return -EINVAL;
+	}
+	return 0;
+}
+
+/* XIic can prepend a sub-address only with a repeated START. */
+static int i2c_check_read_subaddr(const struct capi_i2c_transfer *transfer)
+{
+	if (transfer->sub_address && transfer->sub_address_len > 0 &&
+	    !transfer->repeated_start)
+		return -ENOTSUP;
+	return 0;
+}
+
+static void xiic_reset_async_state(struct capi_i2c_xilinx_handle *xh)
+{
+	if (xh->async_tx_temp) {
+		capi_free(xh->async_tx_temp);
+		xh->async_tx_temp = NULL;
+	}
+	/* Abandoned before completion: drop the bounce buffer unread. */
+	if (xh->async_rx_bounce) {
+		capi_free(xh->async_rx_bounce);
+		xh->async_rx_bounce = NULL;
+	}
+	xh->async_rx_caller_len = 0;
+
+	xh->xfer_done = true;
+	xh->xfer_status = 0;
+	xh->async_phase = CAPI_I2C_ASYNC_IDLE;
+	xh->async_tx_buf = NULL;
+	xh->async_tx_len = 0;
+	xh->async_rx_buf = NULL;
+	xh->async_rx_len = 0;
+	xh->async_dev_addr = 0;
+	xh->async_no_stop = false;
+	xh->target_request_event = 0;
+	/* Only hardware-release paths clear bus_held. */
+}
+
+static void xiic_cancel_rejected_async_start(struct capi_i2c_xilinx_handle *xh)
+{
+	/* A rejected master start can leave the BNB interrupt enabled. */
+	xiic_reset_async_state(xh);
+	inst(xh)->BNBOnly = FALSE;
+	XIic_WriteIier(inst(xh)->BaseAddress,
+		       XIic_ReadIier(inst(xh)->BaseAddress) & ~XIIC_INTR_BNB_MASK);
+	XIic_ClearIisr(inst(xh)->BaseAddress, XIIC_INTR_BNB_MASK);
+
+	if (XIic_Stop(inst(xh)) != XST_SUCCESS) {
+		XIic_Reset(inst(xh));
+		XIic_IntrGlobalDisable(inst(xh)->BaseAddress);
+		XIic_WriteIier(inst(xh)->BaseAddress, 0);
+		inst(xh)->IsStarted = 0;
+	}
+
+	xh->bus_held = false;
+}
+
+/* Stop hardware before releasing its async buffer. */
+static void xiic_abort_inflight(struct capi_i2c_xilinx_handle *xh)
+{
+	inst(xh)->Options &= ~XII_REPEATED_START_OPTION;
+
+	if (XIic_Stop(inst(xh)) != XST_SUCCESS) {
+		XIic_Reset(inst(xh));
+		XIic_IntrGlobalDisable(inst(xh)->BaseAddress);
+		XIic_WriteIier(inst(xh)->BaseAddress, 0);
+		inst(xh)->IsStarted = 0;
+	}
+
+	xiic_reset_async_state(xh);
+	xh->bus_held = false;
+}
+
+static int capi_i2c_pl_set_bus_clock(struct capi_i2c_xilinx_handle *xh,
+				     uint32_t bus_hz,
+				     uint8_t duty_percent)
+{
+	if (!xh || !inst(xh))
+		return -EINVAL;
+	if (xh->pl_input_clock_hz == 0)
+		return -ENOTSUP;
+	if (bus_hz == 0)
+		return -EINVAL;
+
+	if (duty_percent == 0)
+		duty_percent = xh->pl_default_duty_percent;
+	if (duty_percent == 0)
+		duty_percent = I2C_PL_DEFAULT_DUTY_PERCENT;
+	if (duty_percent < I2C_PL_MIN_DUTY_PERCENT ||
+	    duty_percent > I2C_PL_MAX_DUTY_PERCENT)
+		return -EINVAL;
+	if (XIic_IsIicBusy(inst(xh)) == TRUE)
+		return -EBUSY;
+
+	uint32_t cycles = xh->pl_input_clock_hz / bus_hz;
+	if (cycles < 2U)
+		return -ENOTSUP;
+
+	uint32_t cycles_high = (uint32_t)(((uint64_t)cycles * duty_percent) /
+					  100U);
+	uint32_t cycles_low = cycles - cycles_high;
+	if (cycles_high == 0 || cycles_low == 0)
+		return -ENOTSUP;
+
+	XIic_WriteReg(inst(xh)->BaseAddress, xh->pl_thigh_offset, cycles_high);
+	XIic_WriteReg(inst(xh)->BaseAddress, xh->pl_tlow_offset, cycles_low);
+	xh->clk_freq_hz = bus_hz;
+
+	return 0;
+}
+
+/**
+ * @brief Initialize the CAPI backend instance.
+ * @note PL: XIic_CfgInitialize() plus XIic_Set*Handler().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_i2c_pl_init(struct capi_i2c_controller_handle **handle,
+			    const struct capi_i2c_config *config)
+{
+	if (!handle || !config)
+		return -EINVAL;
+	if (!config->initiator && config->address > I2C_PL_7BIT_MAX_ADDR)
+		return -EINVAL;
+	if (config->dma_handle != NULL)
+		return -ENOTSUP;
+
+	const struct capi_i2c_xilinx_config *xcfg =
+		(const struct capi_i2c_xilinx_config *)config->extra;
+
+	bool alloc = (*handle == NULL);
+	struct capi_i2c_controller_handle *h = *handle;
+	struct capi_i2c_xilinx_handle *xh;
+
+	if (alloc) {
+		h = capi_malloc(sizeof(*h));
+		if (!h)
+			return -ENOMEM;
+		memset(h, 0, sizeof(*h));
+
+		xh = capi_malloc(sizeof(*xh));
+		if (!xh) {
+			capi_free(h);
+			return -ENOMEM;
+		}
+		h->priv = xh;
+		*handle = h;
+	} else {
+		xh = h->priv;
+		if (!xh)
+			return -EINVAL;
+		if (h->ops != NULL || xh->instance != NULL)
+			return -EBUSY;
+	}
+
+	memset(xh, 0, sizeof(*xh));
+	h->init_allocated = alloc;
+	h->ops = config->ops ? config->ops : &capi_i2c_xilinx_pl_ops;
+	h->priv = xh;
+	xh->is_initiator = config->initiator;
+	xh->clk_freq_hz = 0;
+	if (xcfg != NULL && xcfg->input_clock_hz != 0) {
+		xh->pl_input_clock_hz = xcfg->input_clock_hz;
+		xh->pl_thigh_offset = xcfg->thigh_offset != 0 ?
+				      xcfg->thigh_offset :
+				      I2C_PL_DEFAULT_THIGH_OFFSET;
+		xh->pl_tlow_offset = xcfg->tlow_offset != 0 ?
+				     xcfg->tlow_offset :
+				     I2C_PL_DEFAULT_TLOW_OFFSET;
+		xh->pl_default_duty_percent = xcfg->default_duty_percent != 0 ?
+					      xcfg->default_duty_percent :
+					      I2C_PL_DEFAULT_DUTY_PERCENT;
+	}
+
+	XIic_Config *cfg = XIic_LookupConfig((UINTPTR)config->identifier);
+	if (!cfg) {
+		if (alloc)
+			xilinx_i2c_free_allocated_handle(handle);
+		else
+			xilinx_i2c_clear_app_handle(h);
+		return -ENODEV;
+	}
+
+	XIic *iic = capi_malloc(sizeof(XIic));
+	if (!iic) {
+		if (alloc)
+			xilinx_i2c_free_allocated_handle(handle);
+		else
+			xilinx_i2c_clear_app_handle(h);
+		return -ENOMEM;
+	}
+	memset(iic, 0, sizeof(XIic));
+
+	if (XIic_CfgInitialize(iic, cfg, cfg->BaseAddress) != XST_SUCCESS) {
+		capi_free(iic);
+		if (alloc)
+			xilinx_i2c_free_allocated_handle(handle);
+		else
+			xilinx_i2c_clear_app_handle(h);
+		return -EIO;
+	}
+
+	/* Replace the vendor target/arbitration assertion stubs. */
+	XIic_SlaveInclude();
+	XIic_MultiMasterInclude();
+
+	XIic_SetSendHandler(iic, xh, xiic_send_handler);
+	XIic_SetRecvHandler(iic, xh, xiic_recv_handler);
+	XIic_SetStatusHandler(iic, xh, xiic_status_handler);
+	xh->instance = iic;
+
+	uint32_t init_bus_hz = config->clk_freq_hz;
+	if (init_bus_hz == 0 && xcfg != NULL)
+		init_bus_hz = xcfg->default_bus_hz;
+	if (init_bus_hz != 0) {
+		int ret = capi_i2c_pl_set_bus_clock(xh, init_bus_hz,
+						    xh->pl_default_duty_percent);
+		if (ret != 0) {
+			capi_free(iic);
+			xh->instance = NULL;
+			if (alloc)
+				xilinx_i2c_free_allocated_handle(handle);
+			else
+				xilinx_i2c_clear_app_handle(h);
+			return ret;
+		}
+	}
+
+	if (!config->initiator) {
+		if (XIic_SetAddress(iic, XII_ADDR_TO_RESPOND_TYPE,
+				    (int)config->address) != XST_SUCCESS) {
+			capi_free(iic);
+			xh->instance = NULL;
+			if (alloc)
+				xilinx_i2c_free_allocated_handle(handle);
+			else
+				xilinx_i2c_clear_app_handle(h);
+			return -EIO;
+		}
+		xh->target_addr = config->address;
+
+		/*
+		 * Programming the response address is not enough to make the
+		 * controller answer: XIic only drives an ACK once the device is
+		 * enabled, so without this the target is addressed correctly but
+		 * stays deaf and every initiator write NAKs (-EIO / CAPI_I2C_NAKD).
+		 *
+		 * capi_i2c_pl_register_target() already does Stop -> SetAddress ->
+		 * Start for a runtime role switch; a controller opened as a target
+		 * at init must reach the same state without the caller having to
+		 * make a redundant register_target() call.
+		 */
+		if (XIic_Start(iic) != XST_SUCCESS) {
+			capi_free(iic);
+			xh->instance = NULL;
+			if (alloc)
+				xilinx_i2c_free_allocated_handle(handle);
+			else
+				xilinx_i2c_clear_app_handle(h);
+			return -EIO;
+		}
+	}
+
+	if (xcfg != NULL && xcfg->use_irq) {
+		/*
+		 * The caller asked for interrupt-driven operation, so a failure
+		 * to wire up the IRQ is fatal, not a silent downgrade to polled.
+		 * A target in particular cannot answer without its ISR: swallowing
+		 * the error here would defer the failure to the first transfer,
+		 * where it surfaces as an unexplained NAK/timeout instead of a
+		 * clear init error. Unwind (drop the instance and handle) and
+		 * report the failure.
+		 */
+		uint32_t irq_id = xcfg->irq_id;
+		int ret = capi_irq_connect(irq_id, capi_i2c_pl_isr, h);
+		if (ret == 0) {
+			capi_irq_set_level_edge_trigger(irq_id, CAPI_IRQ_LEVEL_HIGH);
+			ret = capi_irq_enable(irq_id);
+		}
+		if (ret != 0) {
+			capi_free(iic);
+			xh->instance = NULL;
+			if (alloc)
+				xilinx_i2c_free_allocated_handle(handle);
+			else
+				xilinx_i2c_clear_app_handle(h);
+			return ret;
+		}
+		xh->irq_id = irq_id;
+		xh->use_irq = true;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Deinitialize the CAPI backend instance.
+ * @note PL: XIic_Stop()/XIic_Reset().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_i2c_pl_deinit(struct capi_i2c_controller_handle *handle)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_i2c_xilinx_handle *xh = handle->priv;
+	if (!xh)
+		return -EINVAL;
+
+	if (xh->use_irq) {
+		capi_irq_disable(xh->irq_id);
+		xh->use_irq = false;
+	}
+
+	if (xh->instance) {
+		XIic_Stop(inst(xh));
+		XIic_IntrGlobalDisable(inst(xh)->BaseAddress);
+		XIic_WriteIier(inst(xh)->BaseAddress, 0);
+		XIic_Reset(inst(xh));
+		XIic_IntrGlobalDisable(inst(xh)->BaseAddress);
+		XIic_WriteIier(inst(xh)->BaseAddress, 0);
+		capi_free(xh->instance);
+		xh->instance = NULL;
+	}
+
+	if (xh->async_tx_temp) {
+		capi_free(xh->async_tx_temp);
+		xh->async_tx_temp = NULL;
+	}
+
+	/*
+	 * Clear the software state too, not just the hardware. A transfer can
+	 * still be armed here (a target listen nothing addressed, or one whose
+	 * peer gave up mid-frame). For an app-allocated handle the struct
+	 * outlives this call, so a stale async_phase would make the next init
+	 * hand back a controller that reports itself busy and rejects every
+	 * transfer with -EBUSY. Mirrors capi_i2c_ps_deinit.
+	 */
+	xiic_reset_async_state(xh);
+	xh->bus_held = false;
+	xh->callback = NULL;
+	xh->callback_arg = NULL;
+	xh->callback_pending = false;
+
+	if (handle->init_allocated) {
+		capi_free(xh);
+		capi_free(handle);
+	} else {
+		handle->ops = NULL;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Run a synchronous transmit operation.
+ * @note PL: XIic_Send()/XIic_SlaveSend().
+ *
+ * Blocking target transfers are not supported because they cannot be armed
+ * safely before the target is addressed.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_i2c_pl_transmit(struct capi_i2c_device *device,
+				struct capi_i2c_transfer *transfer)
+{
+	if (!device || !device->controller || !transfer)
+		return -EINVAL;
+	/*
+	 * A zero-length write is a valid address-only probe (SMBus quick command
+	 * / bus scan): allow len == 0. A data buffer is only required when there
+	 * are data bytes to send.
+	 */
+	if ((transfer->len != 0 && !transfer->buf) ||
+	    (transfer->sub_address_len > 0 && !transfer->sub_address))
+		return -EINVAL;
+
+	int unsup = pl_check_device_fields(device);
+	if (unsup != 0)
+		return unsup;
+
+	struct capi_i2c_xilinx_handle *xh = device->controller->priv;
+	if (xh->async_phase != CAPI_I2C_ASYNC_IDLE)
+		return -EBUSY;
+	if (transfer->len > INT_MAX)
+		return -EINVAL;
+
+	if (!xh->is_initiator)
+		return -ENOTSUP;
+
+	uint16_t addr = transfer->target_addr ? transfer->target_addr :
+			device->address;
+	int addr_ret = pl_check_addr(addr, device->b10addr);
+	if (addr_ret != 0)
+		return addr_ret;
+	uint8_t *tx_buf = transfer->buf;
+	uint32_t tx_len = transfer->len;
+	bool need_free = false;
+	int ret;
+
+	if (device->b10addr) {
+		if (!inst(xh)->Has10BitAddr)
+			return -ENOTSUP;
+		XIic_SetOptions(inst(xh), inst(xh)->Options |
+				XII_SEND_10_BIT_OPTION);
+	} else {
+		inst(xh)->Options &= ~XII_SEND_10_BIT_OPTION;
+	}
+
+	int status = XIic_SetAddress(inst(xh), XII_ADDR_TO_SEND_TYPE, addr);
+	if (status != XST_SUCCESS)
+		return xiic_status_to_errno(status);
+
+	if (transfer->sub_address && transfer->sub_address_len > 0) {
+		if (transfer->len > (uint32_t)INT_MAX - transfer->sub_address_len)
+			return -EINVAL;
+		tx_len = (uint32_t)transfer->sub_address_len + transfer->len;
+		tx_buf = capi_malloc(tx_len);
+		if (!tx_buf)
+			return -ENOMEM;
+		memcpy(tx_buf, transfer->sub_address, transfer->sub_address_len);
+		memcpy(tx_buf + transfer->sub_address_len, transfer->buf,
+		       transfer->len);
+		need_free = true;
+	}
+
+	/*
+	 * Route to the interrupt (MasterSend) path only when the polled
+	 * XIic_Send cannot do the job on an unmodified upstream BSP:
+	 *
+	 *   - 10-bit addressing: XIic_Send formats only a 7-bit header.
+	 *   - held-bus continuation (bus_held): XIic_Send calls
+	 *     XIic_WaitBusFree() unconditionally at its START. A prior no_stop
+	 *     transfer left this controller holding the bus (MSMS asserted), so
+	 *     that entry wait never sees the bus go idle and times out (~1s).
+	 *
+	 * A fresh 7-bit write (bus free), including the FIRST no_stop write of a
+	 * chain, is fine polled: the entry wait passes, and XIIC_REPEATED_START
+	 * leaves the bus held for the continuation below. That covers the common
+	 * write(no_stop) -> read(stop) chain with no IRQ.
+	 */
+	if (device->b10addr || xh->bus_held) {
+		if (!xh->use_irq) {
+			ret = -ENOTSUP;
+			goto out_free;
+		}
+
+		if (transfer->no_stop)
+			xiic_set_repeated_start(xh, true);
+		else
+			xiic_set_repeated_start(xh, false);
+
+		/* XIic_Start would release an existing hold. */
+		if (!xh->bus_held) {
+			status = XIic_Start(inst(xh));
+			if (status != XST_SUCCESS) {
+				ret = xiic_status_to_errno(status);
+				goto out_free;
+			}
+		}
+
+		capi_i2c_callback saved_cb = xh->callback;
+		xh->callback = NULL;
+		xh->async_phase = CAPI_I2C_ASYNC_TX;
+		xh->xfer_done = false;
+		xh->xfer_status = 0;
+		xh->async_no_stop = transfer->no_stop;
+
+		status = XIic_MasterSend(inst(xh), tx_buf, (int)tx_len);
+		if (status != XST_SUCCESS) {
+			xiic_cancel_rejected_async_start(xh);
+			xh->callback = saved_cb;
+			ret = xiic_status_to_errno(status);
+			goto out_free;
+		}
+
+		uint64_t timeout_us = xiic_transfer_timeout_us(xh, tx_len);
+		if (!xiic_wait_xfer_done(xh, timeout_us)) {
+			xiic_abort_inflight(xh);
+			xh->callback = saved_cb;
+			if (need_free)
+				capi_free(tx_buf);
+			return -ETIMEDOUT;
+		}
+		xh->callback = saved_cb;
+		if (need_free)
+			capi_free(tx_buf);
+		return xh->xfer_status;
+	}
+
+	u8 option = transfer->no_stop ? XIIC_REPEATED_START : XIIC_STOP;
+	unsigned sent = XIic_Send(inst(xh)->BaseAddress, addr, tx_buf, tx_len,
+				  option);
+	ret = (sent == tx_len) ? 0 : -EIO;
+
+	/* Mirror the hold left by XIic_Send. */
+	xh->bus_held = (ret == 0) && transfer->no_stop;
+
+out_free:
+	if (need_free)
+		capi_free(tx_buf);
+	return ret;
+}
+
+/**
+ * @brief Bounded polled master receive (replaces XIic_Recv).
+ *
+ * XIic_Recv and its RecvData() helper are correct on their register sequence
+ * but every wait inside them is an unbounded `while` with no timeout:
+ *
+ *   - the post-START spin for SR.BUS_BUSY to assert,
+ *   - RecvData()'s per-byte `while (1)` waiting for IISR.RX_FULL, which for a
+ *     single-byte read does not even watch TX_ERROR,
+ *   - the closing wait for IISR.BNB after the STOP.
+ *
+ * On this board that is not a theoretical risk. The initiator is polled while
+ * the target is interrupt-driven, and both run on the same CPU: if the target
+ * is late producing a byte, the initiator does not slow down, it spins forever
+ * and the CPU never returns to the code that would service the target. The
+ * result is a dead board with no diagnostic.
+ *
+ * This is a transcription of the BSP flow with identical register writes and
+ * bus semantics, differing only in that each wait is bounded and reports where
+ * it gave up. A stalled peer now yields -ETIMEDOUT (or -EIO on a bus error)
+ * instead of wedging, so the caller can recover and the failure is visible.
+ *
+ * Only the 7-bit STOP case reaches here; 10-bit and no_stop are handled on the
+ * interrupt path above.
+ *
+ * @return 0 on success, -ETIMEDOUT if a wait expired, -EIO on a bus error.
+ */
+static int xiic_recv_polled_bounded(struct capi_i2c_xilinx_handle *xh,
+				    u8 addr, uint8_t *buf, uint32_t len)
+{
+	UINTPTR base = inst(xh)->BaseAddress;
+	uint64_t budget_us = xiic_transfer_timeout_us(xh, len);
+	struct xiic_deadline dl;
+	u32 cr;
+
+	XIic_ClearIisr(base, XIIC_INTR_RX_FULL_MASK | XIIC_INTR_TX_ERROR_MASK |
+		       XIIC_INTR_ARB_LOST_MASK);
+
+	/* Receive FIFO occupancy depth of one byte (zero based). */
+	XIic_WriteReg(base, XIIC_RFD_REG_OFFSET, 0);
+
+	cr = XIic_ReadReg(base, XIIC_CR_REG_OFFSET);
+	if ((cr & XIIC_CR_REPEATED_START_MASK) == 0) {
+		XIic_Send7BitAddress(base, addr, XIIC_READ_OPERATION);
+
+		/*
+		 * MSMS is set after the address is in the FIFO. A single-byte
+		 * read must NAK immediately so the target knows to stop.
+		 */
+		cr = XIIC_CR_MSMS_MASK | XIIC_CR_ENABLE_DEVICE_MASK;
+		if (len == 1U)
+			cr |= XIIC_CR_NO_ACK_MASK;
+		XIic_WriteReg(base, XIIC_CR_REG_OFFSET, cr);
+
+		/* BNB must be cleared while the bus is busy, so wait for busy. */
+		xiic_deadline_init(&dl, budget_us);
+		while ((XIic_ReadReg(base, XIIC_SR_REG_OFFSET) &
+			XIIC_SR_BUS_BUSY_MASK) == 0) {
+			if (!xiic_deadline_ok(&dl))
+				goto stall;
+		}
+
+		XIic_ClearIisr(base, XIIC_INTR_BNB_MASK);
+	} else {
+		/* Continuing a held bus: clear TX direction before addressing. */
+		cr &= ~XIIC_CR_DIR_IS_TX_MASK;
+		if (len == 1U)
+			cr |= XIIC_CR_NO_ACK_MASK;
+		XIic_WriteReg(base, XIIC_CR_REG_OFFSET, cr);
+		XIic_Send7BitAddress(base, addr, XIIC_READ_OPERATION);
+	}
+
+	while (len > 0U) {
+		/*
+		 * The final byte is NAKed deliberately, so TX_ERROR is expected
+		 * there and must not be treated as a fault.
+		 */
+		u32 err_mask = (len == 1U) ?
+			       (XIIC_INTR_ARB_LOST_MASK | XIIC_INTR_BNB_MASK) :
+			       (XIIC_INTR_ARB_LOST_MASK | XIIC_INTR_TX_ERROR_MASK |
+				XIIC_INTR_BNB_MASK);
+
+		xiic_deadline_init(&dl, budget_us);
+		for (;;) {
+			u32 isr = XIic_ReadIisr(base);
+
+			if (isr & XIIC_INTR_RX_FULL_MASK)
+				break;
+			if (isr & err_mask)
+				goto bus_error;
+			if (!xiic_deadline_ok(&dl))
+				goto stall;
+		}
+
+		cr = XIic_ReadReg(base, XIIC_CR_REG_OFFSET);
+
+		/*
+		 * Both of these must be programmed BEFORE the byte is read out
+		 * of the FIFO, while the bus is still throttled.
+		 */
+		if (len == 1U) {
+			/* Drop MSMS, stay enabled, so the STOP is issued. */
+			XIic_WriteReg(base, XIIC_CR_REG_OFFSET,
+				      XIIC_CR_ENABLE_DEVICE_MASK);
+		} else if (len == 2U) {
+			/* NAK the byte after this one to mark the end. */
+			XIic_WriteReg(base, XIIC_CR_REG_OFFSET,
+				      cr | XIIC_CR_NO_ACK_MASK);
+		}
+
+		/* Reading DRR unthrottles the bus for the next byte. */
+		*buf++ = (uint8_t)XIic_ReadReg(base, XIIC_DRR_REG_OFFSET);
+
+		XIic_ClearIisr(base, XIIC_INTR_RX_FULL_MASK |
+			       XIIC_INTR_TX_ERROR_MASK |
+			       XIIC_INTR_ARB_LOST_MASK);
+		len--;
+	}
+
+	/* Wait for the STOP to land: MSMS was dropped before the last read. */
+	xiic_deadline_init(&dl, budget_us);
+	while ((XIic_ReadIisr(base) & XIIC_INTR_BNB_MASK) == 0) {
+		if (!xiic_deadline_ok(&dl))
+			goto stall;
+	}
+
+	if ((XIic_ReadReg(base, XIIC_CR_REG_OFFSET) &
+	     XIIC_CR_REPEATED_START_MASK) == 0)
+		XIic_WriteReg(base, XIIC_CR_REG_OFFSET, 0);
+
+	return 0;
+
+bus_error:
+	XIic_WriteReg(base, XIIC_CR_REG_OFFSET, 0);
+	XIic_ClearIisr(base, XIIC_INTR_RX_FULL_MASK | XIIC_INTR_TX_ERROR_MASK |
+		       XIIC_INTR_ARB_LOST_MASK | XIIC_INTR_BNB_MASK);
+	return -EIO;
+
+stall:
+	/*
+	 * Leave the controller disabled and the bus released rather than held,
+	 * so the next transfer starts from a defined state instead of
+	 * inheriting a half-finished frame.
+	 */
+	XIic_WriteReg(base, XIIC_CR_REG_OFFSET, 0);
+	XIic_ClearIisr(base, XIIC_INTR_RX_FULL_MASK | XIIC_INTR_TX_ERROR_MASK |
+		       XIIC_INTR_ARB_LOST_MASK | XIIC_INTR_BNB_MASK);
+	return -ETIMEDOUT;
+}
+
+/**
+ * @brief Run a synchronous receive operation.
+ * @note PL: XIic_Send()/XIic_Recv().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_i2c_pl_receive(struct capi_i2c_device *device,
+			       struct capi_i2c_transfer *transfer)
+{
+	if (!device || !device->controller || !transfer)
+		return -EINVAL;
+	if (!transfer->buf || transfer->len == 0 ||
+	    (transfer->sub_address_len > 0 && !transfer->sub_address))
+		return -EINVAL;
+
+	int unsup = pl_check_device_fields(device);
+	if (unsup != 0)
+		return unsup;
+	unsup = i2c_check_read_subaddr(transfer);
+	if (unsup != 0)
+		return unsup;
+
+	struct capi_i2c_xilinx_handle *xh = device->controller->priv;
+	if (xh->async_phase != CAPI_I2C_ASYNC_IDLE)
+		return -EBUSY;
+	if (transfer->len > INT_MAX)
+		return -EINVAL;
+
+	if (!xh->is_initiator)
+		return -ENOTSUP;
+
+	uint16_t addr = transfer->target_addr ? transfer->target_addr :
+			device->address;
+	int addr_ret = pl_check_addr(addr, device->b10addr);
+	if (addr_ret != 0)
+		return addr_ret;
+	int status;
+
+	if (device->b10addr) {
+		if (!inst(xh)->Has10BitAddr)
+			return -ENOTSUP;
+		XIic_SetOptions(inst(xh), inst(xh)->Options |
+				XII_SEND_10_BIT_OPTION);
+	} else {
+		inst(xh)->Options &= ~XII_SEND_10_BIT_OPTION;
+	}
+
+	status = XIic_SetAddress(inst(xh), XII_ADDR_TO_SEND_TYPE, addr);
+	if (status != XST_SUCCESS)
+		return xiic_status_to_errno(status);
+
+	/*
+	 * Route to the interrupt (MasterRecv) path only when the polled
+	 * XIic_Recv cannot do the job on an unmodified upstream BSP:
+	 *
+	 *   - 10-bit addressing: XIic_Recv formats only a 7-bit header.
+	 *   - no_stop read: XIic_Recv calls XIic_WaitBusFree() unconditionally
+	 *     at its END. When the receive itself holds the bus (RSTA|MSMS left
+	 *     asserted for a repeated START) that wait never sees the bus go
+	 *     idle and times out (~1s). So a receive that must LEAVE the bus
+	 *     held cannot use the polled path here.
+	 *
+	 * A 7-bit read that ENTERS on a held bus but ends with a STOP is fine
+	 * polled: XIic_Recv has no entry bus-free wait, it continues the hold
+	 * with a repeated START (it inspects the CR REPEATED_START bit), and the
+	 * closing STOP frees the bus before the exit wait. That covers the
+	 * common write(no_stop) -> read(stop) register-read chain with no IRQ.
+	 */
+	if (device->b10addr || transfer->no_stop) {
+		if (!xh->use_irq)
+			return -ENOTSUP;
+
+		if (transfer->no_stop)
+			xiic_set_repeated_start(xh, true);
+		else
+			xiic_set_repeated_start(xh, false);
+
+		/* XIic_Start would release an existing hold. */
+		if (!xh->bus_held) {
+			status = XIic_Start(inst(xh));
+			if (status != XST_SUCCESS)
+				return xiic_status_to_errno(status);
+		}
+
+		capi_i2c_callback saved_cb = xh->callback;
+		xh->callback = NULL;
+
+		if (transfer->sub_address && transfer->sub_address_len > 0 &&
+		    transfer->repeated_start) {
+			xh->async_phase = CAPI_I2C_ASYNC_RX_SUBADDR;
+			xh->async_rx_buf = transfer->buf;
+			xh->async_rx_len = transfer->len;
+			xh->async_dev_addr = addr;
+			xh->async_no_stop = transfer->no_stop;
+			xh->async_tx_temp = NULL;
+			xh->xfer_done = false;
+			xh->xfer_status = 0;
+
+			xiic_set_repeated_start(xh, true);
+			status = XIic_MasterSend(inst(xh),
+						 transfer->sub_address,
+						 transfer->sub_address_len);
+		} else {
+			xh->async_phase = CAPI_I2C_ASYNC_RX;
+			xh->xfer_done = false;
+			xh->xfer_status = 0;
+			xh->async_no_stop = transfer->no_stop;
+
+			status = XIic_MasterRecv(inst(xh), transfer->buf,
+						 transfer->len);
+		}
+		if (status != XST_SUCCESS) {
+			xiic_cancel_rejected_async_start(xh);
+			xh->callback = saved_cb;
+			return xiic_status_to_errno(status);
+		}
+
+		uint64_t timeout_us = xiic_transfer_timeout_us(xh,
+				      transfer->len + transfer->sub_address_len);
+		if (!xiic_wait_xfer_done(xh, timeout_us)) {
+			xiic_abort_inflight(xh);
+			xh->callback = saved_cb;
+			return -ETIMEDOUT;
+		}
+		xh->callback = saved_cb;
+		return xh->xfer_status;
+	}
+
+	/*
+	 * Sub-address read: write the register pointer with the bus held, then
+	 * read. XIic_Send here would stall in its entry XIic_WaitBusFree() if a
+	 * prior no_stop transfer already holds the bus, so this chained-write
+	 * form is only valid when the bus is currently free.
+	 */
+	if (transfer->sub_address && transfer->sub_address_len > 0 &&
+	    transfer->repeated_start) {
+		if (xh->bus_held)
+			return -EBUSY;
+		unsigned count = XIic_Send(inst(xh)->BaseAddress, addr,
+					   transfer->sub_address,
+					   transfer->sub_address_len,
+					   XIIC_REPEATED_START);
+		if (count != transfer->sub_address_len)
+			return -EIO;
+	}
+
+	/*
+	 * Polled read, always terminated with a STOP. no_stop reads are handled
+	 * above on the interrupt path (a held receive would hang XIic_Recv's
+	 * unconditional exit XIic_WaitBusFree on the bus it keeps asserted), so
+	 * every read reaching here ends the transaction. XIic_Recv still
+	 * continues an incoming held bus with a repeated START by inspecting the
+	 * CR REPEATED_START bit, so write(no_stop) -> read(stop) chains natively.
+	 */
+	int ret = xiic_recv_polled_bounded(xh, (u8)addr, transfer->buf,
+					   transfer->len);
+	xh->bus_held = false;
+	return ret;
+}
+
+/**
+ * @brief Register the CAPI asynchronous callback.
+ * @note PL: Stores callback for XIic handlers.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_i2c_pl_register_callback(struct capi_i2c_controller_handle
+		*handle,
+		capi_i2c_callback const callback, void *const callback_arg)
+{
+	if (!handle)
+		return -EINVAL;
+	struct capi_i2c_xilinx_handle *xh = handle->priv;
+	xh->callback = callback;
+	xh->callback_arg = callback_arg;
+	return 0;
+}
+
+/**
+ * @brief Configure the I2C bus speed.
+ * @note PL (AXI IIC): rewrites the THIGH/TLOW timing registers from
+ *       pl_input_clock_hz / bus_hz (cycles = fabric_clk / SCL). These registers
+ *       generate the MASTER's SCL only; the slave path oversamples SDA against
+ *       the fixed fabric clock and has no master-speed-derived sampling window.
+ *       So, unlike the PS core, reconfiguring a PL TARGET has nothing to size --
+ *       it is a harmless no-op on the wire, and returns -ENOTSUP when the design
+ *       provides no runtime timing (pl_input_clock_hz == 0), i.e. a stock XIic
+ *       whose SCL ratio is fixed in HDL. Speeds map STANDARD..ULTRA; duty is
+ *       honored via the THIGH/TLOW split. Contrast the PS note, where SetSClk
+ *       sizes a divisor shared by both master and slave.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_i2c_pl_configure_bus_speed(struct capi_i2c_controller_handle
+		*handle,
+		enum capi_i2c_speed speed, uint8_t duty_cycle)
+{
+	static const uint32_t speed_hz[] = {
+		[CAPI_I2C_SPEED_STANDARD] = 100000U,
+		[CAPI_I2C_SPEED_FAST] = 400000U,
+		[CAPI_I2C_SPEED_FAST_PLUS] = 1000000U,
+		[CAPI_I2C_SPEED_HIGH] = 3400000U,
+		[CAPI_I2C_SPEED_ULTRA] = 5000000U,
+	};
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+	if ((unsigned int)speed >= sizeof(speed_hz) / sizeof(speed_hz[0]))
+		return -EINVAL;
+	struct capi_i2c_xilinx_handle *xh = handle->priv;
+	if (xh->async_phase != CAPI_I2C_ASYNC_IDLE || xh->bus_held)
+		return -EBUSY;
+
+	return capi_i2c_pl_set_bus_clock(xh, speed_hz[speed],
+					 duty_cycle);
+}
+
+/**
+ * @brief Start an asynchronous transmit operation.
+ * @note PL: XIic_Start()/XIic_MasterSend().
+ *
+ * Non-blocking: arms the hardware and returns; completion is reported from the
+ * interrupt path (xiic_send_handler -> xiic_complete_transfer).
+ *
+ * Flow, initiator role:
+ *   1. Reject if no IRQ or a transfer is already in flight.
+ *   2. If a sub-address is present, concatenate [sub_address || data] into a
+ *      temp buffer that must outlive this call (freed on completion).
+ *   3. Select 7/10-bit addressing (10-bit rejected if the core lacks it) and
+ *      set the send target address.
+ *   4. Map no_stop to the repeated-start option.
+ *   5. XIic_Start enables the core, then set phase = TX and kick
+ *      XIic_MasterSend.
+ * Rollback differs by how far we got: before the transfer is kicked, use
+ * xiic_reset_async_state; once XIic_MasterSend has been issued, use
+ * xiic_cancel_rejected_async_start to also tear down the pending Xilinx state
+ * so no stray completion interrupt arrives later.
+ * Target role: the request is armed in software. XIic_SlaveSend starts only
+ * after the addressed-as-target event identifies a master read.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_i2c_pl_transmit_async(struct capi_i2c_device *device,
+				      struct capi_i2c_transfer *transfer)
+{
+	if (!device || !device->controller || !transfer)
+		return -EINVAL;
+	/* Zero-length write is a valid address-only probe; buf only needed for data. */
+	if ((transfer->len != 0 && !transfer->buf) ||
+	    (transfer->sub_address_len > 0 && !transfer->sub_address))
+		return -EINVAL;
+
+	int unsup = pl_check_device_fields(device);
+	if (unsup != 0)
+		return unsup;
+
+	struct capi_i2c_xilinx_handle *xh = device->controller->priv;
+	if (!xh->use_irq)
+		return -ENOTSUP;
+	if (xh->async_phase != CAPI_I2C_ASYNC_IDLE)
+		return -EBUSY;
+	if (transfer->len > INT_MAX)
+		return -EINVAL;
+
+	if (xh->is_initiator) {
+		uint16_t addr = transfer->target_addr ? transfer->target_addr :
+				device->address;
+		int addr_ret = pl_check_addr(addr, device->b10addr);
+		if (addr_ret != 0)
+			return addr_ret;
+		uint8_t *tx_buf = transfer->buf;
+		uint32_t tx_len = transfer->len;
+
+		if (transfer->sub_address && transfer->sub_address_len > 0) {
+			if (transfer->len > (uint32_t)INT_MAX - transfer->sub_address_len)
+				return -EINVAL;
+			tx_len = (uint32_t)transfer->sub_address_len + transfer->len;
+			tx_buf = capi_malloc(tx_len);
+			if (!tx_buf)
+				return -ENOMEM;
+			memcpy(tx_buf, transfer->sub_address, transfer->sub_address_len);
+			memcpy(tx_buf + transfer->sub_address_len, transfer->buf, transfer->len);
+			xh->async_tx_temp = tx_buf;
+		} else {
+			xh->async_tx_temp = NULL;
+		}
+
+		if (device->b10addr) {
+			if (!inst(xh)->Has10BitAddr) {
+				xiic_reset_async_state(xh);
+				return -ENOTSUP;
+			}
+			XIic_SetOptions(inst(xh), inst(xh)->Options |
+					XII_SEND_10_BIT_OPTION);
+		} else {
+			inst(xh)->Options &= ~XII_SEND_10_BIT_OPTION;
+		}
+
+		int status = XIic_SetAddress(inst(xh), XII_ADDR_TO_SEND_TYPE,
+					     addr);
+		if (status != XST_SUCCESS) {
+			xiic_reset_async_state(xh);
+			return xiic_status_to_errno(status);
+		}
+
+		if (transfer->no_stop)
+			xiic_set_repeated_start(xh, true);
+		else
+			xiic_set_repeated_start(xh, false);
+
+		/* XIic_Start would release an existing hold. */
+		if (!xh->bus_held) {
+			status = XIic_Start(inst(xh));
+			if (status != XST_SUCCESS) {
+				xiic_reset_async_state(xh);
+				return xiic_status_to_errno(status);
+			}
+		}
+
+		xh->async_phase = CAPI_I2C_ASYNC_TX;
+		xh->xfer_done = false;
+		xh->xfer_status = 0;
+		xh->async_no_stop = transfer->no_stop;
+
+		status = XIic_MasterSend(inst(xh), tx_buf, (int)tx_len);
+		if (status != XST_SUCCESS) {
+			xiic_cancel_rejected_async_start(xh);
+			return xiic_status_to_errno(status);
+		}
+	} else {
+		if (transfer->len > UINT8_MAX)
+			return -ENOTSUP;
+		xh->async_phase = CAPI_I2C_ASYNC_TX;
+		xh->xfer_done = false;
+		xh->xfer_status = 0;
+		xh->async_tx_buf = transfer->buf;
+		xh->async_tx_len = transfer->len;
+		if ((xh->target_request_event & XII_MASTER_READ_EVENT) != 0) {
+			xh->target_request_event = 0;
+			XIic_ClearStats(inst(xh));
+			int status = XIic_SlaveSend(inst(xh), xh->async_tx_buf,
+						    (int)xh->async_tx_len);
+			if (status != XST_SUCCESS) {
+				xiic_reset_async_state(xh);
+				return xiic_status_to_errno(status);
+			}
+		}
+	}
+	return 0;
+}
+
+/**
+ * @brief Start an asynchronous receive operation.
+ * @note PL: XIic_MasterSend()/XIic_MasterRecv().
+ *
+ * Non-blocking: arms the hardware and returns; the interrupt path reports
+ * completion. Two initiator sub-cases:
+ *
+ *   Direct read (no sub-address): XIic_Start, set phase = RX, map no_stop to
+ *   repeated-start, and kick XIic_MasterRecv. The recv handler completes the
+ *   CAPI transfer.
+ *
+ *   Register read (sub_address + repeated_start): a two-phase frame. Phase 1
+ *   sends the sub-address with repeated-start held (bus kept owned) under
+ *   phase = RX_SUBADDR. The send handler then flips to RX and issues phase 2's
+ *   XIic_MasterRecv itself, without completing the CAPI transfer; only phase 2
+ *   completes it. The async_rx_* fields saved here drive phase 2.
+ *
+ * Target role: the request is armed in software. XIic_SlaveRecv starts only
+ * after the addressed-as-target event identifies a master write.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_i2c_pl_receive_async(struct capi_i2c_device *device,
+				     struct capi_i2c_transfer *transfer)
+{
+	if (!device || !device->controller || !transfer)
+		return -EINVAL;
+	if (!transfer->buf || transfer->len == 0 ||
+	    (transfer->sub_address_len > 0 && !transfer->sub_address))
+		return -EINVAL;
+
+	int unsup = pl_check_device_fields(device);
+	if (unsup != 0)
+		return unsup;
+	struct capi_i2c_xilinx_handle *xh = device->controller->priv;
+	if (!xh->use_irq)
+		return -ENOTSUP;
+	if (xh->async_phase != CAPI_I2C_ASYNC_IDLE)
+		return -EBUSY;
+	if (transfer->len > INT_MAX)
+		return -EINVAL;
+	if (xh->is_initiator) {
+		unsup = i2c_check_read_subaddr(transfer);
+		if (unsup != 0)
+			return unsup;
+
+		uint16_t addr = transfer->target_addr ? transfer->target_addr :
+				device->address;
+		int addr_ret = pl_check_addr(addr, device->b10addr);
+		if (addr_ret != 0)
+			return addr_ret;
+
+		if (device->b10addr) {
+			if (!inst(xh)->Has10BitAddr)
+				return -ENOTSUP;
+			XIic_SetOptions(inst(xh), inst(xh)->Options |
+					XII_SEND_10_BIT_OPTION);
+		} else {
+			inst(xh)->Options &= ~XII_SEND_10_BIT_OPTION;
+		}
+
+		int status = XIic_SetAddress(inst(xh), XII_ADDR_TO_SEND_TYPE,
+					     addr);
+		if (status != XST_SUCCESS)
+			return xiic_status_to_errno(status);
+
+		/* XIic_Start would release an existing hold. */
+		if (!xh->bus_held) {
+			status = XIic_Start(inst(xh));
+			if (status != XST_SUCCESS)
+				return xiic_status_to_errno(status);
+		}
+
+		if (transfer->sub_address && transfer->sub_address_len > 0 &&
+		    transfer->repeated_start) {
+			/* The send completion starts the receive phase. */
+			xh->async_phase = CAPI_I2C_ASYNC_RX_SUBADDR;
+			xh->async_rx_buf = transfer->buf;
+			xh->async_rx_len = transfer->len;
+			xh->async_dev_addr = addr;
+			xh->async_no_stop = transfer->no_stop;
+			xh->async_tx_temp = NULL;
+			xh->xfer_done = false;
+			xh->xfer_status = 0;
+
+			xiic_set_repeated_start(xh, true);
+
+			status = XIic_MasterSend(inst(xh), transfer->sub_address,
+						 transfer->sub_address_len);
+			if (status != XST_SUCCESS) {
+				xiic_cancel_rejected_async_start(xh);
+				return xiic_status_to_errno(status);
+			}
+			return 0;
+		}
+
+		xh->async_phase = CAPI_I2C_ASYNC_RX;
+		xh->xfer_done = false;
+		xh->xfer_status = 0;
+		xh->async_no_stop = transfer->no_stop;
+
+		if (transfer->no_stop)
+			xiic_set_repeated_start(xh, true);
+		else
+			xiic_set_repeated_start(xh, false);
+
+		status = XIic_MasterRecv(inst(xh), transfer->buf, transfer->len);
+		if (status != XST_SUCCESS) {
+			xiic_cancel_rejected_async_start(xh);
+			return xiic_status_to_errno(status);
+		}
+	} else {
+		/*
+		 * Target receive. XIic counts the armed ByteCount down and asserts
+		 * NO_ACK the moment it reaches zero (see SlaveRecvData in the BSP's
+		 * xiic_slave.c), so arming the caller's exact length makes an
+		 * initiator that sends more than that get NAKed mid-frame and fail
+		 * its write. Arm a bounce buffer big enough to absorb an over-long
+		 * frame instead, and hand back only the requested length on
+		 * completion; a caller whose buffer is already at least that large
+		 * cannot be over-run and is armed directly.
+		 *
+		 * This mirrors what the PS backend does for the same CAPI contract
+		 * (see capi_i2c_ps_receive_async), so both look identical to a
+		 * caller despite the opposite vendor behaviour.
+		 */
+		uint8_t *rx_buf = transfer->buf;
+
+		xh->async_rx_bounce = NULL;
+		xh->async_rx_caller_len = transfer->len;
+
+		if (transfer->len < XIIC_TARGET_RX_ABSORB_LEN) {
+			xh->async_rx_bounce = capi_malloc(XIIC_TARGET_RX_ABSORB_LEN);
+			if (!xh->async_rx_bounce)
+				return -ENOMEM;
+			rx_buf = xh->async_rx_bounce;
+		}
+
+		xh->async_phase = CAPI_I2C_ASYNC_RX;
+		xh->xfer_done = false;
+		xh->xfer_status = 0;
+		xh->async_rx_buf = transfer->buf;
+		xh->async_rx_len = xh->async_rx_bounce ?
+				   XIIC_TARGET_RX_ABSORB_LEN : transfer->len;
+		if ((xh->target_request_event & XII_MASTER_WRITE_EVENT) != 0) {
+			xh->target_request_event = 0;
+			int status = XIic_SlaveRecv(inst(xh), rx_buf,
+						    (int)xh->async_rx_len);
+			if (status != XST_SUCCESS) {
+				xiic_reset_async_state(xh);
+				return xiic_status_to_errno(status);
+			}
+		}
+	}
+	return 0;
+}
+
+/**
+ * @brief Recover the I2C controller state.
+ * @note PL: XIic_Reset()/XIic_SetAddress().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_i2c_pl_recover_bus(struct capi_i2c_controller_handle *handle)
+{
+	if (!handle)
+		return -EINVAL;
+	struct capi_i2c_xilinx_handle *xh = handle->priv;
+
+	/*
+	 * An in-flight async does not block recovery -- it is the usual reason to
+	 * want it. An armed target receive nothing ever addresses, or a master
+	 * transfer whose peer vanished mid-frame, leave async_phase stuck off IDLE
+	 * with no completion interrupt coming. Refusing -EBUSY there would wedge
+	 * every later recover_bus / register_target / unregister_target on this
+	 * handle. Abandon the transfer as part of recovering; the reset below
+	 * cannot preserve it anyway. Mirrors capi_i2c_ps_recover_bus.
+	 */
+	bool cancelled = xh->async_phase != CAPI_I2C_ASYNC_IDLE;
+	if (cancelled)
+		xiic_abort_inflight(xh);
+
+	XIic_Reset(inst(xh));
+	xh->bus_held = false;
+	inst(xh)->IsStarted = 0;
+	inst(xh)->Options = 0;
+
+	int ret = 0;
+
+	/* Reset cannot clock a target-held SDA, so verify the bus became idle. */
+	struct xiic_deadline dl;
+	bool idle = false;
+
+	xiic_deadline_init(&dl, xiic_transfer_timeout_us(xh, 1U));
+	while (XIic_CheckIsBusBusy(inst(xh)->BaseAddress)) {
+		if (!xiic_deadline_ok(&dl))
+			break;
+	}
+	idle = !XIic_CheckIsBusBusy(inst(xh)->BaseAddress);
+	if (!idle) {
+		ret = -EIO;
+	} else if (!xh->is_initiator) {
+		if (XIic_SetAddress(inst(xh), XII_ADDR_TO_RESPOND_TYPE,
+				    xh->target_addr) != XST_SUCCESS)
+			ret = -EIO;
+		else if (XIic_Start(inst(xh)) != XST_SUCCESS)
+			ret = -EIO;
+	}
+
+	/*
+	 * Notify after the controller work is done, not before: the callback may
+	 * arm a new transfer, and the reset above would destroy one started early.
+	 *
+	 * This fires on the failure paths too. Having cancelled the transfer we
+	 * owe the caller exactly one terminal notification for it, whether or not
+	 * the rest of the recovery succeeded -- skipping it on error would leave
+	 * them waiting on a completion that can never arrive.
+	 */
+	if (cancelled && xh->callback)
+		xh->callback(CAPI_I2C_NONE, xh->callback_arg, -ECANCELED);
+
+	return ret;
+}
+
+/**
+ * @brief Register an I2C target address.
+ * @note PL: XIic_SetAddress()/XIic_Start().
+ *
+ * Stops an idle controller, programs the response address, and restarts it in
+ * target mode. unregister_target() restores initiator mode.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_i2c_pl_register_target(struct capi_i2c_controller_handle
+				       *handle, uint16_t addr)
+{
+	if (!handle)
+		return -EINVAL;
+	if (addr > I2C_PL_7BIT_MAX_ADDR)
+		return -EINVAL;
+
+	struct capi_i2c_xilinx_handle *xh = handle->priv;
+
+	/* Switching role mid-transfer would corrupt the in-flight frame. */
+	if (xh->async_phase != CAPI_I2C_ASYNC_IDLE || xh->bus_held ||
+	    XIic_CheckIsBusBusy(inst(xh)->BaseAddress))
+		return -EBUSY;
+
+	/*
+	 * XIic answers as a slave once a response address is programmed and the
+	 * engine is (re)started; the role is not locked at init. Stop first so
+	 * XIic_SetAddress can write the address register, then switch this
+	 * controller into target mode. Target mode is available on the polled
+	 * (sync) path too, so IRQ is not required here.
+	 */
+	if (XIic_Stop(inst(xh)) != XST_SUCCESS)
+		return -EBUSY;
+	if (XIic_SetAddress(inst(xh), XII_ADDR_TO_RESPOND_TYPE,
+			    (int)addr) != XST_SUCCESS)
+		return -EIO;
+	if (XIic_Start(inst(xh)) != XST_SUCCESS)
+		return -EIO;
+
+	xh->is_initiator = false;
+	xh->target_addr = addr;
+	return 0;
+}
+
+/**
+ * @brief Unregister the I2C target address.
+ * @note PL: XIic_Stop().
+ *
+ * Restores initiator (master) mode so the controller can drive transfers
+ * again, mirroring register_target's runtime role switch.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_i2c_pl_unregister_target(struct capi_i2c_controller_handle
+		*handle)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_i2c_xilinx_handle *xh = handle->priv;
+
+	if (xh->async_phase != CAPI_I2C_ASYNC_IDLE || xh->bus_held ||
+	    XIic_CheckIsBusBusy(inst(xh)->BaseAddress))
+		return -EBUSY;
+
+	if (XIic_Stop(inst(xh)) != XST_SUCCESS)
+		return -EBUSY;
+	XIic_Reset(inst(xh));
+	inst(xh)->Options = 0;
+	xh->is_initiator = true;
+	xh->target_addr = 0;
+	return 0;
+}
+
+/**
+ * @brief Dispatch the I2C interrupt into the Xilinx driver.
+ * @note PL: XIic_InterruptHandler().
+ */
+static void capi_i2c_pl_isr(void *handle)
+{
+	if (!handle)
+		return;
+	struct capi_i2c_xilinx_handle *xh = ((struct capi_i2c_controller_handle *)
+					     handle)->priv;
+	XIic_InterruptHandler(inst(xh));
+
+	if (xh->callback_pending) {
+		capi_i2c_callback callback = xh->callback;
+		void *callback_arg = xh->callback_arg;
+		enum capi_i2c_async_event event = xh->pending_callback_event;
+		int status = xh->pending_callback_status;
+
+		xh->callback_pending = false;
+		if (callback)
+			callback(event, callback_arg, status);
+	}
+}
+
+/* Master callbacks report bytes remaining; target transmit reports bytes
+ * sent. */
+static void xiic_send_handler(void *ref, int byte_count)
+{
+	struct capi_i2c_xilinx_handle *xh = (struct capi_i2c_xilinx_handle *)ref;
+
+	if (xh->async_phase == CAPI_I2C_ASYNC_RX_SUBADDR) {
+		/* Finish the receive phase before notifying CAPI. */
+		xh->async_phase = CAPI_I2C_ASYNC_RX;
+		if (!xh->async_no_stop)
+			inst(xh)->Options &= ~XII_REPEATED_START_OPTION;
+		int status = XIic_MasterRecv(inst(xh), xh->async_rx_buf,
+					     (int)xh->async_rx_len);
+		if (status != XST_SUCCESS)
+			xiic_complete_transfer(xh, -EIO, CAPI_I2C_NONE);
+		return;
+	}
+	if (!xh->is_initiator) {
+		if (xh->async_phase != CAPI_I2C_ASYNC_TX) {
+			xh->target_request_event = 0;
+			return;
+		}
+		int status = byte_count == (int)xh->async_tx_len ? 0 : -EIO;
+
+		xiic_complete_transfer(xh, status,
+				       status == 0 ? CAPI_I2C_XFR_DONE :
+				       CAPI_I2C_NONE);
+		return;
+	}
+
+	xiic_complete_transfer(xh, (byte_count == 0) ? 0 : -EIO,
+			       (byte_count == 0) ? CAPI_I2C_XFR_DONE :
+			       CAPI_I2C_NONE);
+}
+
+static void xiic_recv_handler(void *ref, int byte_count)
+{
+	struct capi_i2c_xilinx_handle *xh = (struct capi_i2c_xilinx_handle *)ref;
+	if (!xh->is_initiator && xh->async_phase != CAPI_I2C_ASYNC_RX) {
+		xh->target_request_event = 0;
+		return;
+	}
+
+	/*
+	 * A bounced target receive is armed for more than the caller asked for,
+	 * so XIic reports the unused remainder as a non-zero byte_count on a
+	 * perfectly good frame. Judge it on the bytes that actually arrived
+	 * instead: short of the caller's length is a genuine truncation, at or
+	 * over it means the request was satisfied and the surplus is discarded.
+	 * XIic counts the armed ByteCount DOWN (unlike XIicPs, which counts up),
+	 * hence armed - remaining.
+	 */
+	if (!xh->is_initiator && xh->async_rx_bounce) {
+		uint32_t got = (byte_count >= 0 &&
+				(uint32_t)byte_count <= xh->async_rx_len) ?
+			       xh->async_rx_len - (uint32_t)byte_count : 0U;
+		bool ok = got >= xh->async_rx_caller_len;
+
+		xiic_complete_transfer(xh, ok ? 0 : -EIO,
+				       ok ? CAPI_I2C_XFR_DONE : CAPI_I2C_NONE);
+		return;
+	}
+
+	xiic_complete_transfer(xh, (byte_count == 0) ? 0 : -EIO,
+			       (byte_count == 0) ? CAPI_I2C_XFR_DONE :
+			       CAPI_I2C_NONE);
+}
+
+static void xiic_complete_transfer(struct capi_i2c_xilinx_handle *xh,
+				   int status,
+				   enum capi_i2c_async_event event)
+{
+	if (status != 0 && xh->is_initiator) {
+		inst(xh)->BNBOnly = FALSE;
+		if (XIic_Stop(inst(xh)) != XST_SUCCESS) {
+			XIic_Reset(inst(xh));
+			XIic_IntrGlobalDisable(inst(xh)->BaseAddress);
+			XIic_WriteIier(inst(xh)->BaseAddress, 0);
+			inst(xh)->IsStarted = 0;
+		}
+		inst(xh)->Options &= ~XII_REPEATED_START_OPTION;
+	}
+
+	xh->bus_held = xh->is_initiator && status == 0 && xh->async_no_stop;
+
+	/*
+	 * Bounced target receive: hand back only what the caller asked for and
+	 * drop the surplus the bounce buffer absorbed. Runs on the failure path
+	 * too, so the buffer is never leaked.
+	 */
+	if (xh->async_rx_bounce) {
+		if (status == 0 && xh->async_rx_buf)
+			memcpy(xh->async_rx_buf, xh->async_rx_bounce,
+			       xh->async_rx_caller_len);
+		capi_free(xh->async_rx_bounce);
+		xh->async_rx_bounce = NULL;
+	}
+	xh->async_rx_caller_len = 0;
+
+	if (xh->async_tx_temp) {
+		capi_free(xh->async_tx_temp);
+		xh->async_tx_temp = NULL;
+	}
+
+	xh->xfer_done = true;
+	xh->xfer_status = status;
+	xh->async_phase = CAPI_I2C_ASYNC_IDLE;
+	xh->async_tx_buf = NULL;
+	xh->async_tx_len = 0;
+	xh->async_rx_buf = NULL;
+	xh->async_rx_len = 0;
+	xh->async_dev_addr = 0;
+	xh->async_no_stop = false;
+	xh->target_request_event = 0;
+
+	if (xh->callback) {
+		xh->pending_callback_event = event;
+		xh->pending_callback_status = status;
+		xh->callback_pending = true;
+	}
+}
+
+static bool xiic_start_target_transfer(struct capi_i2c_xilinx_handle *xh,
+				       int status_event)
+{
+	int ret;
+
+	if (xh->is_initiator)
+		return false;
+	if ((status_event & XII_MASTER_WRITE_EVENT) != 0 &&
+	    xh->async_phase == CAPI_I2C_ASYNC_RX) {
+		xh->target_request_event = 0;
+		/* Arm whatever receive_async chose: bounce buffer, or the
+		 * caller's own buffer when it was already large enough. */
+		ret = XIic_SlaveRecv(inst(xh),
+				     xh->async_rx_bounce ? xh->async_rx_bounce :
+				     xh->async_rx_buf,
+				     (int)xh->async_rx_len);
+	} else if ((status_event & XII_MASTER_READ_EVENT) != 0 &&
+		   xh->async_phase == CAPI_I2C_ASYNC_TX) {
+		xh->target_request_event = 0;
+		XIic_ClearStats(inst(xh));
+		ret = XIic_SlaveSend(inst(xh), xh->async_tx_buf,
+				     (int)xh->async_tx_len);
+	} else {
+		return false;
+	}
+
+	if (ret != XST_SUCCESS)
+		xiic_complete_transfer(xh, xiic_status_to_errno(ret),
+				       CAPI_I2C_NONE);
+	return true;
+}
+
+static void xiic_status_handler(void *ref, int status_event)
+{
+	struct capi_i2c_xilinx_handle *xh = (struct capi_i2c_xilinx_handle *)ref;
+	enum capi_i2c_async_event ev;
+	int status = -EIO;
+
+	if ((status_event & XII_ARB_LOST_EVENT) != 0) {
+		xiic_complete_transfer(xh, -EIO, CAPI_I2C_ALOSS);
+		return;
+	}
+	if ((status_event & XII_SLAVE_NO_ACK_EVENT) != 0) {
+		xiic_complete_transfer(xh, -EIO, CAPI_I2C_NAKD);
+		return;
+	}
+	if (xiic_start_target_transfer(xh, status_event))
+		return;
+	if ((status_event & XII_MASTER_WRITE_EVENT) != 0) {
+		ev = CAPI_I2C_SRXREQ;
+		status = 0;
+	} else if ((status_event & XII_MASTER_READ_EVENT) != 0) {
+		ev = CAPI_I2C_STXREQ;
+		status = 0;
+	} else {
+		ev = CAPI_I2C_NONE;
+	}
+
+	/* Armed target transfers complete through the send/receive handlers. */
+	if (xh->async_phase != CAPI_I2C_ASYNC_IDLE)
+		return;
+
+	xh->target_request_event = status_event;
+	if (xh->callback) {
+		xh->pending_callback_event = ev;
+		xh->pending_callback_status = status;
+		xh->callback_pending = true;
+	}
+}
+
+#endif /* XPAR_XIIC_NUM_INSTANCES */

--- a/capi/platform/xilinx/xilinx_capi_i2c_priv.h
+++ b/capi/platform/xilinx/xilinx_capi_i2c_priv.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Xilinx platform I2C private driver contract.
+ */
+
+#ifndef _XILINX_CAPI_I2C_PRIV_H_
+#define _XILINX_CAPI_I2C_PRIV_H_
+
+#include <xilinx_capi_i2c.h>
+
+#include "xparameters.h"
+#ifdef XPAR_XIICPS_NUM_INSTANCES
+#include "xiicps.h"
+#endif
+#ifdef XPAR_XIIC_NUM_INSTANCES
+#include "xiic.h"
+#include "xiic_l.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @enum capi_i2c_xilinx_async_phase
+ * @brief Internal async operation phase tracking.
+ */
+enum capi_i2c_xilinx_async_phase {
+	CAPI_I2C_ASYNC_IDLE = 0,
+	CAPI_I2C_ASYNC_RX_SUBADDR,
+	CAPI_I2C_ASYNC_TX,
+	CAPI_I2C_ASYNC_RX,
+};
+
+/**
+ * @struct capi_i2c_xilinx_handle
+ * @brief Shared Xilinx I2C private controller state.
+ */
+struct capi_i2c_xilinx_handle {
+	/** Xilinx driver instance (XIicPs* or XIic*) */
+	void *instance;
+	/** True if controller is initiator (master) */
+	bool is_initiator;
+	/** Last-configured SCL rate in Hz */
+	uint32_t clk_freq_hz;
+	/** Clock feeding optional PL timing registers; zero means unsupported */
+	uint32_t pl_input_clock_hz;
+	/** Optional PL SCL-high timing register offset */
+	uint32_t pl_thigh_offset;
+	/** Optional PL SCL-low timing register offset */
+	uint32_t pl_tlow_offset;
+	/** Default PL timing duty cycle percent */
+	uint8_t pl_default_duty_percent;
+	/** IRQ ID (only valid if use_irq is true) */
+	uint32_t irq_id;
+	/** True if IRQ was successfully connected */
+	bool use_irq;
+	/** Target address when in slave mode */
+	uint16_t target_addr;
+	/** User callback for async operations */
+	capi_i2c_callback callback;
+	/** User callback argument */
+	void *callback_arg;
+	/** Async transfer done flag */
+	volatile bool xfer_done;
+	/** Async transfer status (0=success, <0=error) */
+	volatile int xfer_status;
+	/** Temp buffer for async transmit with sub-address (NULL = not allocated) */
+	uint8_t *async_tx_temp;
+	/** Current async operation phase */
+	enum capi_i2c_xilinx_async_phase async_phase;
+	/** Pending receive buffer (for phase 2 of rx with sub_address) */
+	uint8_t *async_rx_buf;
+	/** Pending receive length */
+	uint32_t async_rx_len;
+	/**
+	 * Target role: bounce buffer the slave receive is armed against when the
+	 * caller's own buffer is too short to absorb an over-long frame. NULL
+	 * when the caller's buffer was armed directly.
+	 *
+	 * Both backends need it, for opposite hardware reasons. XIicPs ignores
+	 * ByteCount entirely and drains the RX FIFO for as long as the initiator
+	 * clocks, so an unbounced short buffer is overrun. XIic honours it and
+	 * asserts NO_ACK once it is exhausted, so an unbounced short buffer NAKs
+	 * the initiator mid-frame. Bouncing gives both the same CAPI-visible
+	 * behaviour: the write always completes, the caller gets exactly the
+	 * length it asked for, and the surplus is discarded.
+	 */
+	uint8_t *async_rx_bounce;
+	/** Target role: caller's true requested length behind async_rx_bounce. */
+	uint32_t async_rx_caller_len;
+	/** Device address for pending receive */
+	uint16_t async_dev_addr;
+	/** no_stop flag for pending receive */
+	bool async_no_stop;
+	/** True when a no_stop transfer left the bus held for a repeated START */
+	bool bus_held;
+	/** PL only: callback event pending in ISR tail */
+	bool callback_pending;
+	/** PL only: pending callback event type */
+	enum capi_i2c_async_event pending_callback_event;
+	/** PL only: pending callback status code */
+	int pending_callback_status;
+	/** PL only: target mode event to arm (MASTER_READ/WRITE_EVENT) */
+	u32 target_request_event;
+	/** PL only: async transmit buffer for target slave response */
+	uint8_t *async_tx_buf;
+	/** PL only: async transmit length for target slave response */
+	uint32_t async_tx_len;
+};
+
+/**
+ * @brief Declare a stack-allocated Xilinx I2C controller handle.
+ *
+ * Declares `name` (struct capi_i2c_controller_handle) with embedded
+ * private state. Pass &name to capi_i2c_init().
+ */
+#define CAPI_I2C_HANDLE_XILINX_DEFINE(name)								\
+	struct capi_i2c_controller_handle name = {                          \
+		.ops = NULL,                                                    \
+		.init_allocated = false,                                        \
+		.priv = &(struct capi_i2c_xilinx_handle){0}                     \
+	}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _XILINX_CAPI_I2C_PRIV_H_ */

--- a/capi/platform/xilinx/xilinx_capi_i2c_ps.c
+++ b/capi/platform/xilinx/xilinx_capi_i2c_ps.c
@@ -1,0 +1,1411 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Xilinx XIicPs I2C driver (Zynq PS I2C)
+ *
+ * SDT BSP only. IRQ is explicit via capi_i2c_xilinx_config.
+ * capi_irq_init() must be called before async ops will work.
+ *
+ * Works as initiator or target (100k/400k). As a target the sampling divider
+ * must be sized for the bus it will see -- see capi_i2c_ps_configure_bus_speed.
+ */
+
+#include <capi_i2c.h>
+#include <xilinx_capi_i2c_priv.h>
+#include <capi_irq.h>
+#include <capi_alloc.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include "xinterrupt_wrap.h"
+
+#ifdef XPAR_XIICPS_NUM_INSTANCES
+
+#define I2C_PS_DEFAULT_SCLK_HZ		100000U
+#define I2C_PS_MAX_SCLK_HZ		400000U
+#define I2C_PS_7BIT_MAX_ADDR		0x7FU
+#define I2C_PS_10BIT_MAX_ADDR		0x3FEU
+#define I2C_PS_BUS_BUSY_TIMEOUT		100000U
+
+static int capi_i2c_ps_init(struct capi_i2c_controller_handle **handle,
+			    const struct capi_i2c_config *config);
+static int capi_i2c_ps_deinit(struct capi_i2c_controller_handle *handle);
+static int capi_i2c_ps_transmit(struct capi_i2c_device *device,
+				struct capi_i2c_transfer *transfer);
+static int capi_i2c_ps_receive(struct capi_i2c_device *device,
+			       struct capi_i2c_transfer *transfer);
+static int capi_i2c_ps_register_callback(struct capi_i2c_controller_handle
+		*handle,
+		capi_i2c_callback const callback,
+		void *const callback_arg);
+static int capi_i2c_ps_configure_bus_speed(struct capi_i2c_controller_handle
+		*handle,
+		enum capi_i2c_speed speed, uint8_t duty_cycle);
+static int capi_i2c_ps_transmit_async(struct capi_i2c_device *device,
+				      struct capi_i2c_transfer *transfer);
+static int capi_i2c_ps_receive_async(struct capi_i2c_device *device,
+				     struct capi_i2c_transfer *transfer);
+static int capi_i2c_ps_recover_bus(struct capi_i2c_controller_handle *handle);
+static int capi_i2c_ps_register_target(struct capi_i2c_controller_handle
+				       *handle, uint16_t addr);
+static int capi_i2c_ps_unregister_target(struct capi_i2c_controller_handle
+		*handle);
+static void capi_i2c_ps_isr(void *handle);
+static void xiicps_slave_tx_refill(struct capi_i2c_xilinx_handle *xh);
+static int xiicps_reset_restore(struct capi_i2c_xilinx_handle *xh);
+static void xiicps_status_handler(void *ref, u32 event);
+static void xiicps_async_complete(struct capi_i2c_xilinx_handle *xh, int status,
+				  enum capi_i2c_async_event ev);
+
+const struct capi_i2c_ops capi_i2c_xilinx_ps_ops = {
+	.init = capi_i2c_ps_init,
+	.deinit = capi_i2c_ps_deinit,
+	.transmit = capi_i2c_ps_transmit,
+	.receive = capi_i2c_ps_receive,
+	.register_callback = capi_i2c_ps_register_callback,
+	.configure_bus_speed = capi_i2c_ps_configure_bus_speed,
+	.transmit_async = capi_i2c_ps_transmit_async,
+	.receive_async = capi_i2c_ps_receive_async,
+	.recover_bus = capi_i2c_ps_recover_bus,
+	.register_target = capi_i2c_ps_register_target,
+	.unregister_target = capi_i2c_ps_unregister_target,
+	.isr = capi_i2c_ps_isr,
+};
+
+static XIicPs *inst(struct capi_i2c_xilinx_handle *xh)
+{
+	return (XIicPs *)xh->instance;
+}
+
+static void xilinx_i2c_free_allocated_handle(
+	struct capi_i2c_controller_handle **handle)
+{
+	if (handle == NULL || *handle == NULL)
+		return;
+
+	capi_free((*handle)->priv);
+	capi_free(*handle);
+	*handle = NULL;
+}
+
+static void xilinx_i2c_clear_app_handle(
+	struct capi_i2c_controller_handle *handle)
+{
+	if (handle != NULL)
+		handle->ops = NULL;
+}
+
+static int xiicps_xfer_status_to_errno(s32 status)
+{
+	switch (status) {
+	case XST_SUCCESS:
+		return 0;
+	case XST_IIC_ARB_LOST:
+		return -EIO;
+	case XST_FAILURE:
+		return -EIO;
+	default:
+		return -EIO;
+	}
+}
+
+static int xiicps_wait_bus_free(struct capi_i2c_xilinx_handle *xh)
+{
+	uint32_t timeout = I2C_PS_BUS_BUSY_TIMEOUT;
+
+	while (XIicPs_BusIsBusy(inst(xh)) && --timeout > 0U)
+		;
+
+	return timeout == 0U ? -ETIMEDOUT : 0;
+}
+
+static int xiicps_async_bus_available(struct capi_i2c_xilinx_handle *xh)
+{
+	/* A held bus is available to its current owner. */
+	if (XIicPs_GetOptions(inst(xh)) & XIICPS_REP_START_OPTION)
+		return 0;
+
+	return XIicPs_BusIsBusy(inst(xh)) ? -EBUSY : 0;
+}
+
+static int xiicps_reset_restore(struct capi_i2c_xilinx_handle *xh)
+{
+	uint32_t clk_hz = xh->clk_freq_hz > 0 ? xh->clk_freq_hz :
+			  I2C_PS_DEFAULT_SCLK_HZ;
+
+	XIicPs_Reset(inst(xh));
+	/* SetSClk rejects stale transfer-size state after an error. */
+	XIicPs_WriteReg(inst(xh)->Config.BaseAddress, XIICPS_TRANS_SIZE_OFFSET, 0U);
+	inst(xh)->IsRepeatedStart = 0;
+	if (XIicPs_SetSClk(inst(xh), clk_hz) != XST_SUCCESS)
+		return -EIO;
+	inst(xh)->Options = XIicPs_GetOptions(inst(xh));
+	XIicPs_SetStatusHandler(inst(xh), xh, xiicps_status_handler);
+
+	if (!xh->is_initiator)
+		XIicPs_SetupSlave(inst(xh), xh->target_addr);
+
+	return 0;
+}
+
+/**
+ * @brief Abandon an in-flight async transfer without notifying the caller.
+ *
+ * Silences the hardware first, then drops the software state. Order matters:
+ * clearing async_phase while the interrupt is still unmasked leaves a window
+ * where a late DATA/COMP lands on a transfer that no longer exists and the
+ * status handler runs against freed or reused buffers.
+ *
+ * Does not fire the callback -- the caller decides whether this cancellation is
+ * worth reporting, and when (see capi_i2c_ps_recover_bus, which notifies only
+ * after the controller reset has completed).
+ */
+static void xiicps_cancel_inflight(struct capi_i2c_xilinx_handle *xh)
+{
+	XIicPs_DisableAllInterrupts(inst(xh)->Config.BaseAddress);
+
+	/*
+	 * Drop the BSP's own view of the transfer too. XIicPs tracks Send/Recv
+	 * buffer pointers and counts independently of async_phase; leaving them
+	 * set means the next SlaveSend/SlaveRecv inherits a stale direction latch
+	 * (SlaveInterruptHandler picks send vs recv purely from RecvBufferPtr).
+	 */
+	inst(xh)->SendBufferPtr = NULL;
+	inst(xh)->RecvBufferPtr = NULL;
+	inst(xh)->SendByteCount = 0;
+	inst(xh)->RecvByteCount = 0;
+
+	if (xh->async_tx_temp) {
+		capi_free(xh->async_tx_temp);
+		xh->async_tx_temp = NULL;
+	}
+
+	if (xh->async_rx_bounce) {
+		capi_free(xh->async_rx_bounce);
+		xh->async_rx_bounce = NULL;
+	}
+	xh->async_rx_caller_len = 0;
+
+	xh->xfer_done = true;
+	xh->xfer_status = -ECANCELED;
+	xh->async_phase = CAPI_I2C_ASYNC_IDLE;
+	xh->async_rx_buf = NULL;
+	xh->async_rx_len = 0;
+	xh->async_tx_len = 0;
+	xh->async_dev_addr = 0;
+	xh->async_no_stop = false;
+}
+
+static int xiicps_role_change_allowed(struct capi_i2c_xilinx_handle *xh)
+{
+	/*
+	 * A transfer genuinely in flight cannot be interrupted. But a lingering
+	 * HOLD bit or bus-busy reading after a *completed* transfer (e.g. a NACK
+	 * against a bus with no device, which leaves HOLD asserted) is a
+	 * recoverable leftover, not an active operation - reset it and proceed
+	 * rather than wedging every later role change / reconfigure at -EBUSY.
+	 */
+	if (xh->async_phase != CAPI_I2C_ASYNC_IDLE)
+		return -EBUSY;
+
+	uint32_t control = XIicPs_ReadReg(inst(xh)->Config.BaseAddress,
+					  XIICPS_CR_OFFSET);
+	if ((control & XIICPS_CR_HOLD_MASK) != 0U || XIicPs_BusIsBusy(inst(xh)))
+		return xiicps_reset_restore(xh);
+
+	return 0;
+}
+
+static int ps_check_device_fields(const struct capi_i2c_device *device)
+{
+	if (device->duty_cycle != 0)
+		return -ENOTSUP;
+	if (device->clk_stretch != 0)
+		return -ENOTSUP;
+	return 0;
+}
+
+/* Vendor transfers assert on out-of-range addresses. */
+static int ps_check_addr(uint16_t addr, bool b10addr)
+{
+	if (b10addr) {
+		if (addr > I2C_PS_10BIT_MAX_ADDR)
+			return -EINVAL;
+	} else if (addr > I2C_PS_7BIT_MAX_ADDR) {
+		return -EINVAL;
+	}
+	return 0;
+}
+
+/* XIicPs can prepend a sub-address only with a repeated START. */
+static int ps_check_read_subaddr(const struct capi_i2c_transfer *transfer)
+{
+	if (transfer->sub_address && transfer->sub_address_len > 0 &&
+	    !transfer->repeated_start)
+		return -ENOTSUP;
+	return 0;
+}
+
+/**
+ * @brief Initialize the CAPI backend instance.
+ * @note PS: XIicPs_CfgInitialize()/XIicPs_SetSClk().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_i2c_ps_init(struct capi_i2c_controller_handle **handle,
+			    const struct capi_i2c_config *config)
+{
+	if (!handle || !config)
+		return -EINVAL;
+	if (!config->initiator && config->address > I2C_PS_7BIT_MAX_ADDR)
+		return -EINVAL;
+	if (config->clk_freq_hz > I2C_PS_MAX_SCLK_HZ)
+		return -ENOTSUP;
+	if (config->dma_handle != NULL)
+		return -ENOTSUP;
+
+	bool alloc = (*handle == NULL);
+	struct capi_i2c_controller_handle *h = *handle;
+	struct capi_i2c_xilinx_handle *xh;
+
+	if (alloc) {
+		h = capi_malloc(sizeof(*h));
+		if (!h)
+			return -ENOMEM;
+		memset(h, 0, sizeof(*h));
+		xh = capi_malloc(sizeof(*xh));
+		if (!xh) {
+			capi_free(h);
+			return -ENOMEM;
+		}
+		h->priv = xh;
+		*handle = h;
+	} else {
+		xh = h->priv;
+		if (!xh)
+			return -EINVAL;
+		if (h->ops != NULL || xh->instance != NULL)
+			return -EBUSY;
+	}
+
+	memset(xh, 0, sizeof(*xh));
+	h->init_allocated = alloc;
+	h->ops = config->ops ? config->ops : &capi_i2c_xilinx_ps_ops;
+	h->priv = xh;
+	xh->is_initiator = config->initiator;
+	xh->clk_freq_hz = config->clk_freq_hz;
+
+	XIicPs_Config *cfg = XIicPs_LookupConfig((UINTPTR)config->identifier);
+	if (!cfg) {
+		if (alloc)
+			xilinx_i2c_free_allocated_handle(handle);
+		else
+			xilinx_i2c_clear_app_handle(h);
+		return -ENODEV;
+	}
+
+	XIicPs *ps = capi_malloc(sizeof(XIicPs));
+	if (!ps) {
+		if (alloc)
+			xilinx_i2c_free_allocated_handle(handle);
+		else
+			xilinx_i2c_clear_app_handle(h);
+		return -ENOMEM;
+	}
+	memset(ps, 0, sizeof(XIicPs));
+
+	if (XIicPs_CfgInitialize(ps, cfg, cfg->BaseAddress) != XST_SUCCESS) {
+		capi_free(ps);
+		if (alloc)
+			xilinx_i2c_free_allocated_handle(handle);
+		else
+			xilinx_i2c_clear_app_handle(h);
+		return -EIO;
+	}
+
+	uint32_t target_clk = (config->clk_freq_hz != 0) ? config->clk_freq_hz :
+			      I2C_PS_DEFAULT_SCLK_HZ;
+	if (XIicPs_SetSClk(ps, target_clk) != XST_SUCCESS) {
+		capi_free(ps);
+		if (alloc)
+			xilinx_i2c_free_allocated_handle(handle);
+		else
+			xilinx_i2c_clear_app_handle(h);
+		return -EIO;
+	}
+	xh->clk_freq_hz = target_clk;
+
+	XIicPs_SetStatusHandler(ps, xh, xiicps_status_handler);
+	xh->instance = ps;
+
+	if (!config->initiator) {
+		XIicPs_SetupSlave(ps, (u16)config->address);
+		xh->target_addr = config->address;
+	}
+
+	const struct capi_i2c_xilinx_config *xcfg =
+		(const struct capi_i2c_xilinx_config *)config->extra;
+	if (xcfg != NULL && xcfg->use_irq) {
+		/*
+		 * The caller asked for interrupt-driven operation, so a failure
+		 * to wire up the IRQ is fatal, not a silent downgrade to polled.
+		 * A target in particular cannot answer without its ISR: swallowing
+		 * the error here would defer the failure to the first transfer,
+		 * where it surfaces as an unexplained NAK/timeout instead of a
+		 * clear init error. Unwind (drop the instance and handle) and
+		 * report the failure.
+		 */
+		uint32_t irq_id = xcfg->irq_id;
+		int ret = capi_irq_connect(irq_id, capi_i2c_ps_isr, h);
+		if (ret == 0) {
+			capi_irq_set_level_edge_trigger(irq_id, CAPI_IRQ_LEVEL_HIGH);
+			ret = capi_irq_enable(irq_id);
+		}
+		if (ret != 0) {
+			capi_free(ps);
+			xh->instance = NULL;
+			if (alloc)
+				xilinx_i2c_free_allocated_handle(handle);
+			else
+				xilinx_i2c_clear_app_handle(h);
+			return ret;
+		}
+		xh->irq_id = irq_id;
+		xh->use_irq = true;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Deinitialize the CAPI backend instance.
+ * @note PS: XIicPs_Abort()/XIicPs_Reset().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_i2c_ps_deinit(struct capi_i2c_controller_handle *handle)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_i2c_xilinx_handle *xh = handle->priv;
+	if (!xh)
+		return -EINVAL;
+
+	/*
+	 * Abandon anything still in flight before tearing the hardware down.
+	 *
+	 * A transfer can legitimately be outstanding here: an armed target send
+	 * or receive that no initiator ever addressed, or one whose peer gave up
+	 * mid-frame. Resetting the controller underneath it leaves async_phase
+	 * stuck off IDLE, and for an app-allocated handle (init_allocated false)
+	 * the struct outlives this call -- so the next init inherits a handle that
+	 * reports itself busy and rejects every transfer with -EBUSY.
+	 *
+	 * Cancel first, while the instance is still valid: xiicps_cancel_inflight
+	 * masks the interrupt and clears both our state and the BSP's buffer
+	 * pointers, so the reset below cannot race a late interrupt.
+	 */
+	if (xh->instance && xh->async_phase != CAPI_I2C_ASYNC_IDLE)
+		xiicps_cancel_inflight(xh);
+
+	if (xh->use_irq) {
+		capi_irq_disable(xh->irq_id);
+		xh->use_irq = false;
+	}
+
+	if (xh->instance) {
+		XIicPs_Reset(inst(xh));
+		XIicPs_ResetHw(inst(xh)->Config.BaseAddress);
+		capi_free(xh->instance);
+		xh->instance = NULL;
+	}
+
+	if (xh->async_tx_temp) {
+		capi_free(xh->async_tx_temp);
+		xh->async_tx_temp = NULL;
+	}
+
+	/*
+	 * Reset the software state as well. Only the init_allocated case frees
+	 * the handle; otherwise it is the caller's memory and will be reused.
+	 */
+	xh->async_phase = CAPI_I2C_ASYNC_IDLE;
+	xh->async_tx_len = 0;
+	xh->async_rx_len = 0;
+	xh->xfer_done = true;
+	xh->callback = NULL;
+	xh->callback_arg = NULL;
+
+	if (handle->init_allocated) {
+		capi_free(xh);
+		capi_free(handle);
+	} else {
+		handle->ops = NULL;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Run a synchronous transmit operation.
+ * @note PS: XIicPs_MasterSendPolled()/XIicPs_SlaveSendPolled().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_i2c_ps_transmit(struct capi_i2c_device *device,
+				struct capi_i2c_transfer *transfer)
+{
+	if (!device || !device->controller || !transfer)
+		return -EINVAL;
+	/*
+	 * A zero-length write is a valid address-only probe (SMBus quick command
+	 * / bus scan): allow len == 0. A data buffer is only required when there
+	 * are data bytes to send.
+	 */
+	if ((transfer->len != 0 && !transfer->buf) ||
+	    (transfer->sub_address_len > 0 && !transfer->sub_address))
+		return -EINVAL;
+
+	int unsup = ps_check_device_fields(device);
+	if (unsup != 0)
+		return unsup;
+
+	struct capi_i2c_xilinx_handle *xh = device->controller->priv;
+	if (xh->async_phase != CAPI_I2C_ASYNC_IDLE)
+		return -EBUSY;
+	if (transfer->len > INT32_MAX)
+		return -EINVAL;
+
+	int ret = 0;
+
+	if (xh->is_initiator) {
+		/* Do not wait for a bus this controller intentionally holds. */
+		if (!(XIicPs_GetOptions(inst(xh)) & XIICPS_REP_START_OPTION)) {
+			if (xiicps_wait_bus_free(xh) != 0) {
+				/* Stuck bus / unresponsive target: recover and report
+				 * as an I/O error, not raw -ETIMEDOUT. */
+				(void)xiicps_reset_restore(xh);
+				ret = -EIO;
+				goto done;
+			}
+		}
+
+		uint16_t addr = transfer->target_addr ? transfer->target_addr :
+				device->address;
+		ret = ps_check_addr(addr, device->b10addr);
+		if (ret != 0)
+			goto done;
+
+		if (device->b10addr)
+			XIicPs_SetOptions(inst(xh), XIICPS_10_BIT_ADDR_OPTION);
+		else
+			XIicPs_ClearOptions(inst(xh), XIICPS_10_BIT_ADDR_OPTION);
+
+		uint8_t *tx_buf = transfer->buf;
+		size_t tx_len = transfer->len;
+		bool need_free = false;
+
+		if (transfer->sub_address && transfer->sub_address_len > 0) {
+			if ((uint64_t)transfer->len + transfer->sub_address_len >
+			    INT32_MAX) {
+				ret = -EINVAL;
+				goto done;
+			}
+			tx_len = transfer->sub_address_len + transfer->len;
+			tx_buf = capi_malloc(tx_len);
+			if (!tx_buf) {
+				ret = -ENOMEM;
+				goto done;
+			}
+			memcpy(tx_buf, transfer->sub_address, transfer->sub_address_len);
+			memcpy(tx_buf + transfer->sub_address_len, transfer->buf, transfer->len);
+			need_free = true;
+		}
+
+		if (transfer->no_stop)
+			XIicPs_SetOptions(inst(xh), XIICPS_REP_START_OPTION);
+		else
+			XIicPs_ClearOptions(inst(xh), XIICPS_REP_START_OPTION);
+
+		/*
+		 * XIicPs_MasterSend asserts MsgPtr != NULL even for a zero-length
+		 * (address-only probe) transfer, so pass a valid dummy pointer when
+		 * there is no data buffer. With tx_len == 0 no bytes are read from it.
+		 */
+		static uint8_t ps_zero_len_dummy;
+		if (!tx_buf)
+			tx_buf = &ps_zero_len_dummy;
+
+		/* Polled send returns before STOP reaches the bus. */
+		int status =
+			XIicPs_MasterSendPolled(inst(xh), tx_buf, tx_len, addr);
+		if (need_free)
+			capi_free(tx_buf);
+		if (status != XST_SUCCESS) {
+			ret = xiicps_xfer_status_to_errno(status);
+			(void)xiicps_reset_restore(xh);
+			goto done;
+		}
+
+		if (!transfer->no_stop) {
+			XIicPs_ClearOptions(inst(xh), XIICPS_REP_START_OPTION);
+			if (xiicps_wait_bus_free(xh) != 0) {
+				(void)xiicps_reset_restore(xh);
+				ret = -EIO;
+			}
+		}
+	} else {
+		/* Same-core loopback must use async target transmit. */
+		if (XIicPs_SlaveSendPolled(inst(xh), transfer->buf,
+					   transfer->len) != XST_SUCCESS)
+			ret = -EIO;
+	}
+
+done:
+	xh->xfer_done = true;
+	xh->xfer_status = ret;
+	return ret;
+}
+
+/**
+ * @brief Run a synchronous receive operation.
+ * @note PS: XIicPs_MasterRecvPolled()/XIicPs_SlaveRecvPolled().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_i2c_ps_receive(struct capi_i2c_device *device,
+			       struct capi_i2c_transfer *transfer)
+{
+	if (!device || !device->controller || !transfer)
+		return -EINVAL;
+	if (!transfer->buf || transfer->len == 0 ||
+	    (transfer->sub_address_len > 0 && !transfer->sub_address))
+		return -EINVAL;
+
+	int unsup = ps_check_device_fields(device);
+	if (unsup != 0)
+		return unsup;
+	unsup = ps_check_read_subaddr(transfer);
+	if (unsup != 0)
+		return unsup;
+
+	struct capi_i2c_xilinx_handle *xh = device->controller->priv;
+	if (xh->async_phase != CAPI_I2C_ASYNC_IDLE)
+		return -EBUSY;
+	if (transfer->len > INT32_MAX)
+		return -EINVAL;
+
+	int ret = 0;
+
+	if (xh->is_initiator) {
+		/* Do not wait for a bus this controller intentionally holds. */
+		if (!(XIicPs_GetOptions(inst(xh)) & XIICPS_REP_START_OPTION)) {
+			if (xiicps_wait_bus_free(xh) != 0) {
+				/*
+				 * The bus never went idle - either a genuinely stuck
+				 * bus or a target that is not responding. Recover the
+				 * controller and report it as an I/O error (the
+				 * NACK-equivalent the CAPI contract expects), not a
+				 * raw -ETIMEDOUT.
+				 */
+				(void)xiicps_reset_restore(xh);
+				ret = -EIO;
+				goto done;
+			}
+		}
+
+		if (device->b10addr)
+			XIicPs_SetOptions(inst(xh), XIICPS_10_BIT_ADDR_OPTION);
+		else
+			XIicPs_ClearOptions(inst(xh), XIICPS_10_BIT_ADDR_OPTION);
+
+		uint16_t addr = transfer->target_addr ? transfer->target_addr :
+				device->address;
+		ret = ps_check_addr(addr, device->b10addr);
+		if (ret != 0)
+			goto done;
+
+		if (transfer->sub_address && transfer->sub_address_len > 0 &&
+		    transfer->repeated_start) {
+			XIicPs_SetOptions(inst(xh), XIICPS_REP_START_OPTION);
+			int status = XIicPs_MasterSendPolled(inst(xh), transfer->sub_address,
+							     transfer->sub_address_len,
+							     addr);
+			if (status != XST_SUCCESS) {
+				ret = xiicps_xfer_status_to_errno(status);
+				(void)xiicps_reset_restore(xh);
+				goto done;
+			}
+		}
+
+		if (!transfer->no_stop)
+			XIicPs_ClearOptions(inst(xh), XIICPS_REP_START_OPTION);
+
+		int status = XIicPs_MasterRecvPolled(inst(xh), transfer->buf, transfer->len,
+						     addr);
+		if (status != XST_SUCCESS) {
+			ret = xiicps_xfer_status_to_errno(status);
+			(void)xiicps_reset_restore(xh);
+			goto done;
+		}
+
+		if (!transfer->no_stop) {
+			XIicPs_ClearOptions(inst(xh), XIICPS_REP_START_OPTION);
+			if (xiicps_wait_bus_free(xh) != 0) {
+				(void)xiicps_reset_restore(xh);
+				ret = -EIO;
+			}
+		}
+	} else {
+		ret = -ENOTSUP;
+	}
+
+done:
+	xh->xfer_done = true;
+	xh->xfer_status = ret;
+	return ret;
+}
+
+/**
+ * @brief Register the CAPI asynchronous callback.
+ * @note PS: Stores callback for XIicPs status handler.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_i2c_ps_register_callback(struct capi_i2c_controller_handle
+		*handle,
+		capi_i2c_callback const callback, void *const callback_arg)
+{
+	if (!handle)
+		return -EINVAL;
+	struct capi_i2c_xilinx_handle *xh = handle->priv;
+	xh->callback = callback;
+	xh->callback_arg = callback_arg;
+	return 0;
+}
+
+/**
+ * @brief Configure the I2C bus speed.
+ * @note PS (XIicPs_SetSClk): writes the CR DIV_A/DIV_B divisors. On the Cadence
+ *       PS core those divisors size the clock-enable used by BOTH roles: the
+ *       master's generated SCL AND the slave's SDA sampling/glitch-filter
+ *       window. A target never drives SCL, but it still samples the bus off this
+ *       SetSClk-derived timebase, so a target must be reconfigured to match the
+ *       bus it will see -- a target left at 100k cannot correctly sample a 400k
+ *       initiator. SetupSlave preserves the divisors, so this is the only call
+ *       that sizes them. STANDARD -> 100k, FAST -> 400k (HW clamps to 384.6 kHz
+ *       per CR#779290); FAST_PLUS/HIGH/ULTRA and any non-zero duty are -ENOTSUP.
+ *       Contrast the PL note: XIic has no such shared window.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_i2c_ps_configure_bus_speed(struct capi_i2c_controller_handle
+		*handle,
+		enum capi_i2c_speed speed, uint8_t duty_cycle)
+{
+	if (!handle)
+		return -EINVAL;
+	/* XIicPs cannot set SCL duty cycle. */
+	if (duty_cycle != 0)
+		return -ENOTSUP;
+
+	struct capi_i2c_xilinx_handle *xh = handle->priv;
+	uint32_t speed_hz;
+
+	/*
+	 * A transfer genuinely in flight cannot be reconfigured. A lingering
+	 * HOLD/REP_START or bus-busy from a *completed* (e.g. NACKed) transfer is
+	 * a recoverable leftover - reset it and proceed rather than wedging every
+	 * later reconfigure at -EBUSY (see xiicps_role_change_allowed).
+	 */
+	if (xh->async_phase != CAPI_I2C_ASYNC_IDLE)
+		return -EBUSY;
+
+	switch (speed) {
+	case CAPI_I2C_SPEED_STANDARD:
+		speed_hz = I2C_PS_DEFAULT_SCLK_HZ;
+		break;
+	case CAPI_I2C_SPEED_FAST:
+		speed_hz = I2C_PS_MAX_SCLK_HZ;
+		break;
+	case CAPI_I2C_SPEED_FAST_PLUS:
+	case CAPI_I2C_SPEED_HIGH:
+	case CAPI_I2C_SPEED_ULTRA:
+		return -ENOTSUP;
+	default:
+		return -EINVAL;
+	}
+
+	uint32_t control = XIicPs_ReadReg(inst(xh)->Config.BaseAddress,
+					  XIICPS_CR_OFFSET);
+	if ((control & XIICPS_CR_HOLD_MASK) != 0U ||
+	    (XIicPs_GetOptions(inst(xh)) & XIICPS_REP_START_OPTION) != 0U ||
+	    XIicPs_BusIsBusy(inst(xh))) {
+		/* SetSClk requires an idle controller; clear the leftover state. */
+		if (xiicps_reset_restore(xh) != 0)
+			return -EIO;
+	}
+	if (XIicPs_SetSClk(inst(xh), speed_hz) != XST_SUCCESS)
+		return -EIO;
+
+	xh->clk_freq_hz = speed_hz;
+	return 0;
+}
+
+/**
+ * @brief Start an asynchronous transmit operation.
+ * @note PS: XIicPs_MasterSend()/XIicPs_SlaveSend().
+ *
+ * Non-blocking: this arms the hardware and returns immediately. Completion is
+ * reported later from the interrupt path (xiicps_status_handler ->
+ * xiicps_async_complete), which is where xfer_done/xfer_status are finalized,
+ * any temp buffer is freed, and the CAPI callback fires.
+ *
+ * Flow, initiator role:
+ *   1. Reject if no IRQ (async needs it) or a transfer is already in flight.
+ *   2. Confirm the bus is free (or intentionally held from a no_stop frame).
+ *   3. Select 7/10-bit addressing.
+ *   4. If a sub-address is present, concatenate [sub_address || data] into a
+ *      temp buffer that must outlive this call (freed in the ISR completion).
+ *   5. Map no_stop to the repeated-start/HOLD option.
+ *   6. Set phase = TX and kick XIicPs_MasterSend, then return 0.
+ * Target role: just arm XIicPs_SlaveSend; the ISR completes it when an
+ * initiator clocks the bytes out.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_i2c_ps_transmit_async(struct capi_i2c_device *device,
+				      struct capi_i2c_transfer *transfer)
+{
+	if (!device || !device->controller || !transfer)
+		return -EINVAL;
+	/* Zero-length write is a valid address-only probe; buf only needed for data. */
+	if ((transfer->len != 0 && !transfer->buf) ||
+	    (transfer->sub_address_len > 0 && !transfer->sub_address))
+		return -EINVAL;
+
+	int unsup = ps_check_device_fields(device);
+	if (unsup != 0)
+		return unsup;
+
+	struct capi_i2c_xilinx_handle *xh = device->controller->priv;
+	if (!xh->use_irq)
+		return -ENOTSUP;
+	if (xh->async_phase != CAPI_I2C_ASYNC_IDLE)
+		return -EBUSY;
+	if (transfer->len > INT32_MAX)
+		return -EINVAL;
+
+	if (xh->is_initiator) {
+		uint16_t send_addr = transfer->target_addr ? transfer->target_addr :
+				     device->address;
+		int ret = ps_check_addr(send_addr, device->b10addr);
+		if (ret != 0)
+			return ret;
+
+		ret = xiicps_async_bus_available(xh);
+		if (ret != 0)
+			return ret;
+
+		if (device->b10addr)
+			XIicPs_SetOptions(inst(xh), XIICPS_10_BIT_ADDR_OPTION);
+		else
+			XIicPs_ClearOptions(inst(xh), XIICPS_10_BIT_ADDR_OPTION);
+
+		uint8_t *tx_buf = transfer->buf;
+		size_t tx_len = transfer->len;
+
+		if (transfer->sub_address && transfer->sub_address_len > 0) {
+			if ((uint64_t)transfer->len + transfer->sub_address_len >
+			    INT32_MAX)
+				return -EINVAL;
+			tx_len = transfer->sub_address_len + transfer->len;
+			tx_buf = capi_malloc(tx_len);
+			if (!tx_buf)
+				return -ENOMEM;
+			memcpy(tx_buf, transfer->sub_address, transfer->sub_address_len);
+			memcpy(tx_buf + transfer->sub_address_len, transfer->buf, transfer->len);
+			/* The buffer must outlive the interrupt-driven transfer. */
+			xh->async_tx_temp = tx_buf;
+		} else {
+			xh->async_tx_temp = NULL;
+		}
+
+		if (transfer->no_stop)
+			XIicPs_SetOptions(inst(xh), XIICPS_REP_START_OPTION);
+		else
+			XIicPs_ClearOptions(inst(xh), XIICPS_REP_START_OPTION);
+
+		uint16_t addr = transfer->target_addr ? transfer->target_addr :
+				device->address;
+
+		/*
+		 * XIicPs_MasterSend asserts MsgPtr != NULL even for a zero-length
+		 * (address-only probe) transfer; pass a dummy pointer when there is
+		 * no data buffer. With tx_len == 0 no bytes are read from it.
+		 */
+		static uint8_t ps_async_zero_len_dummy;
+		if (!tx_buf)
+			tx_buf = &ps_async_zero_len_dummy;
+
+		xh->xfer_done = false;
+		xh->xfer_status = 0;
+		xh->async_phase = CAPI_I2C_ASYNC_TX;
+		XIicPs_MasterSend(inst(xh), tx_buf, tx_len, addr);
+	} else {
+		xh->xfer_done = false;
+		xh->xfer_status = 0;
+		xh->async_phase = CAPI_I2C_ASYNC_TX;
+
+		/*
+		 * Clear the TX FIFO before arming the send.
+		 *
+		 * XIicPs_SlaveSend() preloads nothing: it only records the buffer and
+		 * unmasks DATA/COMP, leaving the ISR's TransmitFifoFill() to do every
+		 * write. That helper sizes each burst as
+		 *
+		 *     AvailBytes = XIICPS_FIFO_DEPTH - read(XIICPS_TRANS_SIZE_OFFSET)
+		 *
+		 * but in SLAVE-TRANSMITTER mode TRANS_SIZE is not a live occupancy
+		 * counter -- xiicps_hw.h defines it there as "number of bytes remaining
+		 * in the FIFO after the master terminates the transfer", and only
+		 * CLR_FIFO resets it. A residue N left by the previous transaction
+		 * therefore under-reports free space by N, the first fill falls N bytes
+		 * short, and because SlaveSend never gets a second DATA interrupt once
+		 * the master has drained what was loaded, COMP arrives with
+		 * SendByteCount > 0 -- which xiicps_slave.c reports as
+		 * XIICPS_EVENT_ERROR, with the tail bytes never sent.
+		 *
+		 * A 1-byte send survives any residue 0..15, so short transfers hide the
+		 * bug; XIICPS_FIFO_DEPTH (16) is the first length that needs AvailBytes
+		 * at its maximum and so tolerates no residue at all. Clearing the FIFO
+		 * here forces TRANS_SIZE to 0 and makes every length behave like the
+		 * short ones. This is the same CLR_FIFO that XIicPs_SetupSlave() issues
+		 * at setup -- it is just never re-issued per transfer.
+		 *
+		 * Wait for the bus to go idle first. XIicPs_SlaveInterruptHandler()
+		 * raises COMPLETE_SEND as soon as SendByteCount hits 0 -- that is, when
+		 * the driver has pushed the last byte INTO the FIFO, not when the FIFO
+		 * has drained onto the wire. A caller that re-arms the target the
+		 * instant its completion callback fires can therefore land here while
+		 * the previous transaction is still clocking out, and clearing the FIFO
+		 * underneath it truncates that transfer. The wait is bounded and only
+		 * costs anything when a transfer really is still in flight.
+		 */
+		int busy = xiicps_wait_bus_free(xh);
+		if (busy != 0) {
+			xh->async_phase = CAPI_I2C_ASYNC_IDLE;
+			return busy;
+		}
+
+		XIicPs_WriteReg(inst(xh)->Config.BaseAddress, XIICPS_CR_OFFSET,
+				XIicPs_ReadReg(inst(xh)->Config.BaseAddress,
+					       XIICPS_CR_OFFSET) |
+				XIICPS_CR_CLR_FIFO_MASK);
+
+		/*
+		 * Widen the bus watchdog to its maximum for the duration.
+		 *
+		 * TIME_OUT counts SCL cycles the slave holds the clock low. As an
+		 * interrupt-driven target we stretch the clock every time the ISR
+		 * refills the FIFO, and against a polled initiator sharing this CPU
+		 * that stretch lasts as long as it takes the foreground loop to be
+		 * scheduled again. The narrower the window, the more often the
+		 * watchdog fires on a perfectly healthy transfer. 0xFF is what
+		 * XIicPs_ResetHw() itself programs, so it is the BSP's own default
+		 * rather than an arbitrary loosening.
+		 */
+		XIicPs_WriteReg(inst(xh)->Config.BaseAddress,
+				XIICPS_TIME_OUT_OFFSET, XIICPS_TO_RESET_VALUE);
+
+		/* Length decides whether the ISR needs to top the FIFO up. */
+		xh->async_tx_len = transfer->len;
+
+		XIicPs_SlaveSend(inst(xh), transfer->buf, transfer->len);
+	}
+	return 0;
+}
+
+/**
+ * @brief Start an asynchronous receive operation.
+ * @note PS: XIicPs_MasterSend()/XIicPs_MasterRecv().
+ *
+ * Non-blocking: arms the hardware and returns; the interrupt path reports
+ * completion. Two initiator sub-cases:
+ *
+ *   Direct read (no sub-address): set phase = RX, map no_stop to HOLD, and
+ *   kick XIicPs_MasterRecv. The status handler completes the CAPI transfer on
+ *   COMPLETE_RECV.
+ *
+ *   Register read (sub_address + repeated_start): a two-phase frame. Phase 1
+ *   sends the sub-address with HOLD asserted (bus kept owned) via
+ *   XIicPs_MasterSend under phase = RX_SUBADDR. On COMPLETE_SEND the status
+ *   handler flips phase RX_SUBADDR -> RX and issues the MasterRecv for phase 2
+ *   itself, WITHOUT firing the CAPI callback; only phase 2's COMPLETE_RECV
+ *   completes the transfer. The async_rx_* fields saved here are what the
+ *   handler reads to launch phase 2.
+ *
+ * Target receive is unsupported because XIicPs does not bound slave receive
+ * writes by ByteCount.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_i2c_ps_receive_async(struct capi_i2c_device *device,
+				     struct capi_i2c_transfer *transfer)
+{
+	if (!device || !device->controller || !transfer)
+		return -EINVAL;
+	if (!transfer->buf || transfer->len == 0 ||
+	    (transfer->sub_address_len > 0 && !transfer->sub_address))
+		return -EINVAL;
+
+	int unsup = ps_check_device_fields(device);
+	if (unsup != 0)
+		return unsup;
+	unsup = ps_check_read_subaddr(transfer);
+	if (unsup != 0)
+		return unsup;
+
+	struct capi_i2c_xilinx_handle *xh = device->controller->priv;
+	if (!xh->use_irq)
+		return -ENOTSUP;
+	if (xh->async_phase != CAPI_I2C_ASYNC_IDLE)
+		return -EBUSY;
+	if (transfer->len > INT32_MAX)
+		return -EINVAL;
+
+	/*
+	 * Target (slave) role: arm XIicPs_SlaveRecv and let the ISR complete the
+	 * transfer when an initiator writes to us (status handler fires
+	 * COMPLETE_RECV -> xiicps_async_complete). Mirrors the target branch of
+	 * transmit_async (XIicPs_SlaveSend).
+	 *
+	 * XIicPs_SlaveRecv() takes ByteCount but never uses it -- the vendor
+	 * source discards it with "(void)ByteCount;" -- and SlaveRecvData()
+	 * drains the RX FIFO into RecvBufferPtr for as long as the initiator
+	 * keeps clocking bytes in, with no bound. An initiator sending more
+	 * than transfer->len therefore overruns the caller's buffer.
+	 *
+	 * Work around the missing bound in software: if the caller's buffer is
+	 * smaller than the hardware's own max transfer size (the most an
+	 * initiator could ever clock into one frame), arm the receive against
+	 * an internal bounce buffer sized to that ceiling instead, and copy
+	 * back only the caller's requested length on completion
+	 * (xiicps_async_complete). A buffer already >= the ceiling can never be
+	 * overrun and is armed directly.
+	 */
+	if (!xh->is_initiator) {
+		uint8_t *rx_buf = transfer->buf;
+		xh->async_rx_bounce = NULL;
+		xh->async_rx_caller_len = transfer->len;
+
+		if (transfer->len < XIICPS_MAX_TRANSFER_SIZE) {
+			xh->async_rx_bounce = capi_malloc(XIICPS_MAX_TRANSFER_SIZE);
+			if (!xh->async_rx_bounce)
+				return -ENOMEM;
+			rx_buf = xh->async_rx_bounce;
+		}
+
+		xh->async_rx_buf = transfer->buf;
+		xh->async_phase = CAPI_I2C_ASYNC_RX;
+		xh->xfer_done = false;
+		xh->xfer_status = 0;
+		/*
+		 * RecvByteCount is a free-running up-counter in slave-receive mode
+		 * (RecvByteCount++, xiicps_xfer.c) that no vendor call resets per
+		 * transfer -- neither SlaveRecv nor Reset/Abort touch it. Since
+		 * xiicps_async_complete reads it to size the bounce copy-back, zero
+		 * it here so it counts only this transfer. Without this the second
+		 * and later target receives copy back a stale tail from an earlier
+		 * frame.
+		 */
+		inst(xh)->RecvByteCount = 0;
+		XIicPs_SlaveRecv(inst(xh), rx_buf,
+				 xh->async_rx_bounce ?
+				 (s32)XIICPS_MAX_TRANSFER_SIZE : (s32)transfer->len);
+		return 0;
+	}
+
+	uint16_t addr = transfer->target_addr ? transfer->target_addr :
+			device->address;
+	int ret = ps_check_addr(addr, device->b10addr);
+	if (ret != 0)
+		return ret;
+
+	ret = xiicps_async_bus_available(xh);
+	if (ret != 0)
+		return ret;
+
+	if (device->b10addr)
+		XIicPs_SetOptions(inst(xh), XIICPS_10_BIT_ADDR_OPTION);
+	else
+		XIicPs_ClearOptions(inst(xh), XIICPS_10_BIT_ADDR_OPTION);
+
+	if (transfer->sub_address && transfer->sub_address_len > 0 &&
+	    transfer->repeated_start) {
+		/* The send completion starts the receive phase. */
+		xh->async_phase = CAPI_I2C_ASYNC_RX_SUBADDR;
+		xh->async_rx_buf = transfer->buf;
+		xh->async_rx_len = transfer->len;
+		xh->async_dev_addr = addr;
+		xh->async_no_stop = transfer->no_stop;
+		xh->xfer_done = false;
+		xh->xfer_status = 0;
+
+		XIicPs_SetOptions(inst(xh), XIICPS_REP_START_OPTION);
+		XIicPs_MasterSend(inst(xh), transfer->sub_address,
+				  transfer->sub_address_len, addr);
+		return 0;
+	}
+
+	xh->async_phase = CAPI_I2C_ASYNC_RX;
+	xh->xfer_done = false;
+	xh->xfer_status = 0;
+
+	if (transfer->no_stop)
+		XIicPs_SetOptions(inst(xh), XIICPS_REP_START_OPTION);
+	else
+		XIicPs_ClearOptions(inst(xh), XIICPS_REP_START_OPTION);
+
+	XIicPs_MasterRecv(inst(xh), transfer->buf, transfer->len, addr);
+	return 0;
+}
+
+/**
+ * @brief Recover the I2C controller state.
+ * @note PS: XIicPs_Reset()/XIicPs_SetSClk().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_i2c_ps_recover_bus(struct capi_i2c_controller_handle *handle)
+{
+	if (!handle)
+		return -EINVAL;
+	struct capi_i2c_xilinx_handle *xh = handle->priv;
+
+	/*
+	 * An async transfer still in flight does NOT block recovery -- it is the
+	 * single most common reason recovery is wanted. An armed target receive
+	 * that no initiator ever addresses, or a master transfer whose peer went
+	 * away mid-frame, both leave async_phase stuck off IDLE forever: the
+	 * completion interrupt that would clear it is never going to arrive.
+	 * Refusing with -EBUSY in exactly that situation makes the one call that
+	 * could unwedge the controller unusable, and since CAPI has no separate
+	 * abort/cancel op it leaves the caller with no way out at all -- every
+	 * later recover_bus, register_target, unregister_target and role change
+	 * fails -EBUSY for the lifetime of the handle.
+	 *
+	 * So cancel the in-flight operation as part of recovering. The caller is
+	 * explicitly asking for a controller reset; an outstanding transfer cannot
+	 * survive one, and pretending otherwise only hides the reset from them.
+	 */
+	bool cancelled = xh->async_phase != CAPI_I2C_ASYNC_IDLE;
+	if (cancelled)
+		xiicps_cancel_inflight(xh);
+
+	/*
+	 * XIicPs has no register to drive the standalone 9-clock SDA-release
+	 * sequence (that needs the pins bit-banged as GPIO, which this backend
+	 * does not own), so a controller reset is the strongest recovery
+	 * available. Perform it best-effort and report success: a persistent
+	 * bus-busy reading here often just reflects an idle bus with no external
+	 * activity (common right after init on the INTC/no-IRQ XSAs), not a
+	 * failure of the recovery itself.
+	 */
+	int ret = xiicps_reset_restore(xh);
+
+	/*
+	 * Notify AFTER the reset, not before: the callback is entitled to start a
+	 * new transfer, and resetting on top of one it just armed would silently
+	 * destroy it.
+	 */
+	if (cancelled && xh->callback)
+		xh->callback(CAPI_I2C_NONE, xh->callback_arg, -ECANCELED);
+
+	return ret;
+}
+
+/**
+ * @brief Register an I2C target address.
+ * @note PS: XIicPs_SetupSlave().
+ *
+ * The XIicPs role is not locked at init: XIicPs_SetupSlave clears the
+ * master-mode bit and programs the response address at runtime. This call
+ * therefore switches any initialized controller into target mode and routes
+ * subsequent interrupts to the slave handler (see the ISR dispatch), so a
+ * controller opened as initiator can be turned into a target.
+ *
+ * Fixture note (Cora Z7, coraz7s_gic.xsa): a PS target does NOT inherit the
+ * initiator's SCL rate. Its SDA sampling window is sized by XIicPs_SetSClk
+ * (see capi_i2c_ps_configure_bus_speed), and SetupSlave preserves the divisors,
+ * so a target left at its init-time 100k divider cannot sample a 400k initiator
+ * and short-transfers to -EIO. This is a divider mismatch, not an electrical
+ * limit: reconfigure the target's speed to match the bus (the loopback fixture
+ * calls configure_bus_speed on the target each leg) and 400k runs cleanly over
+ * the same wiring.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_i2c_ps_register_target(struct capi_i2c_controller_handle
+				       *handle, uint16_t addr)
+{
+	if (!handle)
+		return -EINVAL;
+	if (addr > I2C_PS_7BIT_MAX_ADDR)
+		return -EINVAL;
+
+	struct capi_i2c_xilinx_handle *xh = handle->priv;
+
+	int ret = xiicps_role_change_allowed(xh);
+	if (ret != 0)
+		return ret;
+
+	XIicPs_SetupSlave(inst(xh), (u16)addr);
+	xh->is_initiator = false;
+	xh->target_addr = addr;
+	return 0;
+}
+
+/**
+ * @brief Unregister the I2C target address.
+ * @note PS: resets the controller and clears the cached target address.
+ *
+ * Restores initiator (master) mode so the controller can drive transfers
+ * again, mirroring register_target's runtime role switch.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_i2c_ps_unregister_target(struct capi_i2c_controller_handle
+		*handle)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_i2c_xilinx_handle *xh = handle->priv;
+
+	int ret = xiicps_role_change_allowed(xh);
+	if (ret != 0)
+		return ret;
+
+	xh->is_initiator = true;
+	xh->target_addr = 0;
+	return xiicps_reset_restore(xh);
+}
+
+/**
+ * @brief Top up the slave transmit FIFO ahead of the BSP handler.
+ *
+ * XIicPs_SlaveInterruptHandler() refills via TransmitFifoFill(), which sizes
+ * each burst as
+ *
+ *     AvailBytes = XIICPS_FIFO_DEPTH - read(XIICPS_TRANS_SIZE_OFFSET)
+ *
+ * That is only valid where TRANS_SIZE reports live FIFO occupancy. In
+ * SLAVE-TRANSMITTER mode it does not: xiicps_hw.h defines it there as "number
+ * of bytes remaining in the FIFO after the master terminates the transfer".
+ * Reading it mid-transfer under-reports the free space, so the refill comes up
+ * short or writes nothing at all; with no bytes queued the controller raises no
+ * further DATA interrupt and the transfer stalls with the master still clocking.
+ *
+ * Transfers up to XIICPS_FIFO_DEPTH are unaffected because the arming path
+ * clears the FIFO, making the single initial fill exact. Only a transfer long
+ * enough to need a SECOND fill -- i.e. longer than the FIFO -- reaches the bad
+ * arithmetic, which is why the failure starts just past 16 bytes.
+ *
+ * The BSP's own polled path (XIicPs_SlaveSendPolled) sidesteps this by clamping
+ * to XIICPS_FIFO_DEPTH and never consulting TRANS_SIZE. Mirror that here: push
+ * bytes while the hardware reports room, using SR.TXDV (a real FIFO status bit)
+ * rather than TRANS_SIZE. Running before the BSP handler means SendByteCount is
+ * normally already 0 by the time TransmitFifoFill() runs, so its faulty sizing
+ * becomes a no-op rather than something we must fight.
+ */
+static void xiicps_slave_tx_refill(struct capi_i2c_xilinx_handle *xh)
+{
+	XIicPs *iic = inst(xh);
+	UINTPTR base = iic->Config.BaseAddress;
+
+	/* Slave transmit only: SlaveSend() nulls RecvBufferPtr, SlaveRecv sets it. */
+	if (iic->RecvBufferPtr != NULL || iic->SendBufferPtr == NULL)
+		return;
+	if (iic->SendByteCount <= 0)
+		return;
+
+	/*
+	 * Top the FIFO up, without ever waiting.
+	 *
+	 * This runs in interrupt context on a system where the initiator may be a
+	 * POLLED driver on the same CPU. XIic_Recv drains its receive FIFO from a
+	 * foreground loop, and each read is what unthrottles the bus so the target
+	 * can clock out the next byte. Blocking here -- even on a condition as
+	 * seemingly safe as "wait for our TX FIFO to drain" -- deadlocks the
+	 * system: the drain cannot happen until the initiator runs, and the
+	 * initiator cannot run until this ISR returns. So there is no spin, no
+	 * poll, and no wait of any kind below.
+	 *
+	 * Write up to XIICPS_DATA_INTR_DEPTH bytes. The DATA interrupt is the
+	 * hardware saying the initiator has consumed enough that it wants more, so
+	 * that much room is available by construction. The TXDV term is a
+	 * belt-and-braces stop for the case where the FIFO still reports data
+	 * queued once we are past that safe count -- it bounds TX_OVR exposure
+	 * without ever blocking on the flag.
+	 */
+	for (u32 i = 0U; i < (u32)XIICPS_FIFO_DEPTH && iic->SendByteCount > 0; i++) {
+		if (i >= (u32)XIICPS_DATA_INTR_DEPTH &&
+		    (XIicPs_ReadReg(base, XIICPS_SR_OFFSET) &
+		     XIICPS_SR_TXDV_MASK) != 0U)
+			break;
+		XIicPs_SendByte(iic);
+	}
+}
+
+/**
+ * @brief Dispatch the I2C interrupt into the Xilinx driver.
+ * @note PS: XIicPs_MasterInterruptHandler()/SlaveInterruptHandler().
+ */
+static void capi_i2c_ps_isr(void *handle)
+{
+	if (!handle)
+		return;
+	struct capi_i2c_xilinx_handle *xh = ((struct capi_i2c_controller_handle *)
+					     handle)->priv;
+
+	if (xh->is_initiator) {
+		XIicPs_MasterInterruptHandler(inst(xh));
+	} else {
+		xiicps_slave_tx_refill(xh);
+		XIicPs_SlaveInterruptHandler(inst(xh));
+	}
+}
+
+static void xiicps_async_complete(struct capi_i2c_xilinx_handle *xh, int status,
+				  enum capi_i2c_async_event ev)
+{
+	/*
+	 * Target receive via a bounce buffer (see capi_i2c_ps_receive_async):
+	 * judge the frame on how many bytes actually arrived (RecvByteCount, an
+	 * up-counter in slave-receive mode -- see xiicps_slave.c's SlaveRecvData
+	 * -- zeroed per arm in receive_async). At or over the caller's length the
+	 * request is satisfied: hand back exactly that length and drop the
+	 * surplus the bounce buffer absorbed. Short of it is a genuine truncation
+	 * -> -EIO, copy nothing. This mirrors the PL backend (xiic_recv_handler),
+	 * so a short target receive looks identical to a caller on both. Must run
+	 * before xiicps_reset_restore(), which touches the same instance state
+	 * below.
+	 */
+	if (xh->async_rx_bounce) {
+		if (status == 0 && xh->async_rx_buf) {
+			uint32_t got = (uint32_t)inst(xh)->RecvByteCount;
+			if (got >= xh->async_rx_caller_len) {
+				memcpy(xh->async_rx_buf, xh->async_rx_bounce,
+				       xh->async_rx_caller_len);
+			} else {
+				status = -EIO;
+				ev = CAPI_I2C_NONE;
+			}
+		}
+		capi_free(xh->async_rx_bounce);
+		xh->async_rx_bounce = NULL;
+	}
+	xh->async_rx_caller_len = 0;
+
+	if (status != 0)
+		(void)xiicps_reset_restore(xh);
+
+	xh->xfer_done = true;
+	xh->xfer_status = status;
+	xh->async_phase = CAPI_I2C_ASYNC_IDLE;
+	xh->async_rx_buf = NULL;
+	xh->async_rx_len = 0;
+	xh->async_tx_len = 0;
+	xh->async_dev_addr = 0;
+	xh->async_no_stop = false;
+
+	if (xh->async_tx_temp) {
+		capi_free(xh->async_tx_temp);
+		xh->async_tx_temp = NULL;
+	}
+
+	if (xh->callback)
+		xh->callback(ev, xh->callback_arg, status);
+}
+
+static void xiicps_status_handler(void *ref, u32 event)
+{
+	struct capi_i2c_xilinx_handle *xh = (struct capi_i2c_xilinx_handle *)ref;
+	if (xh->async_phase == CAPI_I2C_ASYNC_IDLE)
+		return;
+
+	if (!xh->is_initiator && xh->async_phase == CAPI_I2C_ASYNC_TX &&
+	    (event & XIICPS_EVENT_COMPLETE_SEND)) {
+		xiicps_async_complete(xh, 0, CAPI_I2C_XFR_DONE);
+		return;
+	}
+	if (event & XIICPS_EVENT_NACK) {
+		xiicps_async_complete(xh, -EIO, CAPI_I2C_NAKD);
+		return;
+	}
+	if (event & XIICPS_EVENT_ARB_LOST) {
+		xiicps_async_complete(xh, -EIO, CAPI_I2C_ALOSS);
+		return;
+	}
+	/*
+	 * TIME_OUT is not a target-side failure.
+	 *
+	 * XIICPS_TIME_OUT is a bus watchdog: xiicps_hw.h defines it as firing
+	 * "when the accessed slave holds the sclk line low for longer than the
+	 * time out period", i.e. it exists to stop a MASTER hanging on a stuck
+	 * peer. XIicPs_SlaveSend() enables it regardless of role, so when we are
+	 * the target it reports our own legitimate clock stretching -- which is
+	 * unavoidable here, since an interrupt-driven target necessarily holds SCL
+	 * while its ISR refills the FIFO. Treating that as -EIO fails transfers
+	 * whose data crossed the wire intact.
+	 *
+	 * So ignore it while acting as a target and let the transfer run to its
+	 * COMPLETE_SEND/COMPLETE_RECV. As an initiator it keeps its real meaning
+	 * (the peer is holding the bus hostage) and is still an error.
+	 */
+	if ((event & XIICPS_EVENT_TIME_OUT) && !xh->is_initiator)
+		event &= ~(u32)XIICPS_EVENT_TIME_OUT;
+
+	if (event & (XIICPS_EVENT_ERROR | XIICPS_EVENT_TIME_OUT)) {
+		xiicps_async_complete(xh, -EIO, CAPI_I2C_NONE);
+		return;
+	}
+
+	/* Masking TIME_OUT above may have left nothing to report. */
+	if (event == 0U)
+		return;
+	if (event & XIICPS_EVENT_RX_OVR) {
+		xiicps_async_complete(xh, -EIO, CAPI_I2C_RXOVER);
+		return;
+	}
+	if (event & XIICPS_EVENT_TX_OVR) {
+		xiicps_async_complete(xh, -EIO, CAPI_I2C_TXUNDER);
+		return;
+	}
+
+	if (xh->async_phase == CAPI_I2C_ASYNC_RX_SUBADDR
+	    && (event & XIICPS_EVENT_COMPLETE_SEND)) {
+		/* Finish the receive phase before notifying CAPI. */
+		xh->async_phase = CAPI_I2C_ASYNC_RX;
+		if (xh->async_no_stop)
+			XIicPs_SetOptions(inst(xh), XIICPS_REP_START_OPTION);
+		else
+			XIicPs_ClearOptions(inst(xh), XIICPS_REP_START_OPTION);
+		XIicPs_MasterRecv(inst(xh), xh->async_rx_buf, xh->async_rx_len,
+				  xh->async_dev_addr);
+		return;
+	}
+
+	if (event & (XIICPS_EVENT_COMPLETE_SEND | XIICPS_EVENT_COMPLETE_RECV))
+		xiicps_async_complete(xh, 0, CAPI_I2C_XFR_DONE);
+}
+
+#endif /* XPAR_XIICPS_NUM_INSTANCES */

--- a/capi/platform/xilinx/xilinx_capi_irq.h
+++ b/capi/platform/xilinx/xilinx_capi_irq.h
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Xilinx IRQ driver declarations - shared header for GIC and INTC backends.
+ *
+ * Single source of truth for the Xilinx IRQ id encoding, the cascade
+ * sub-controller interface and the capi_irq_init() extra block. The thin
+ * alias capi_irq_xilinx_driver.h just includes this file.
+ *
+ * Three topologies, two object files (gic.c, intc.c), no weak symbols and no
+ * third dispatcher. "Owns the public API" = defines capi_irq_init() & friends;
+ * exactly one file may, or you get a duplicate-symbol link error (intentional:
+ * one system, one root controller). Which file owns it is picked at compile
+ * time from XPAR_XSCUGIC_NUM_INSTANCES (set by the BSP's xparameters.h):
+ *
+ *   1. GIC-only (Zynq/ZynqMP/Versal):  link gic.c.            extra = NULL
+ *   2. INTC-only root (MicroBlaze):    link intc.c.           extra = NULL
+ *   3. Cascade (PS GIC + PL AXI INTC): link gic.c + intc.c.   extra = &xtra
+ *
+ * In case 3 gic.c owns the API as root and intc.c builds as a sub-controller
+ * (exports only xilinx_capi_irq_intc_subctrl); point config->extra at a
+ * struct capi_irq_xilinx_extra to hand the root that sub-controller.
+ *
+ * config->irq_ctrl_id (platform_ids.h wraps both as IRQ_GIC_ID / IRQ_INTC_ID):
+ *   GIC  - SDT: XPAR_XSCUGIC_0_BASEADDR;  Legacy: XPAR_SCUGIC_SINGLE_DEVICE_ID
+ *   INTC - SDT: XPAR_AXI_INTC_0_BASEADDR; Legacy: XPAR_AXI_INTC_0_DEVICE_ID
+ */
+
+#ifndef _XILINX_CAPI_IRQ_H_
+#define _XILINX_CAPI_IRQ_H_
+
+#include <stdint.h>
+#include <capi_irq.h>
+#include "xparameters.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* --------------------------------------------------------------------------
+ * IRQ id encoding
+ *
+ * One uint32_t carries both *which* controller and *which* input on it:
+ *
+ *   bits [31:16] controller selector (CAPI_IRQ_XILINX_CTRL_*)
+ *   bits [15:0]  controller-local interrupt id
+ *
+ * Example: CAPI_IRQ_XILINX_INTC(5) == 0x0001_0005
+ *          ctrl=1 (INTC), local id=5  ->  INTC input 5.
+ *
+ * Building (CAPI_IRQ_XILINX_GIC/INTC) and decoding (capi_irq_xilinx_ctrl/
+ * _local_id) are exact inverses. A bare id like 5 has a zero high half, so it
+ * decodes to controller 0 = GIC; on a standalone INTC root that selector is
+ * accepted too, which is why plain INTC input numbers work unwrapped there.
+ * -------------------------------------------------------------------------- */
+#define CAPI_IRQ_XILINX_CTRL_SHIFT	16U		/* selector lives in bits [31:16] */
+#define CAPI_IRQ_XILINX_CTRL_MASK	0xFFFF0000U	/* isolates the selector half */
+#define CAPI_IRQ_XILINX_ID_MASK		0x0000FFFFU	/* isolates the local-id half */
+
+#define CAPI_IRQ_XILINX_CTRL_GIC	0U		/* selector value for the GIC  */
+#define CAPI_IRQ_XILINX_CTRL_INTC	1U		/* selector value for the INTC */
+
+/** Encode a GIC input number into a capi_irq id (selector=GIC, low half=id). */
+#define CAPI_IRQ_XILINX_GIC(id) \
+	(((uint32_t)CAPI_IRQ_XILINX_CTRL_GIC << CAPI_IRQ_XILINX_CTRL_SHIFT) | \
+	 ((uint32_t)(id) & CAPI_IRQ_XILINX_ID_MASK))
+
+/** Encode an AXI INTC input number into a capi_irq id (selector=INTC). */
+#define CAPI_IRQ_XILINX_INTC(id) \
+	(((uint32_t)CAPI_IRQ_XILINX_CTRL_INTC << CAPI_IRQ_XILINX_CTRL_SHIFT) | \
+	 ((uint32_t)(id) & CAPI_IRQ_XILINX_ID_MASK))
+
+/** Decode the controller selector (CAPI_IRQ_XILINX_CTRL_*) from a capi_irq id. */
+static inline uint32_t capi_irq_xilinx_ctrl(uint32_t irq)
+{
+	/* keep the high half, then slide it down to bits [15:0] */
+	return (irq & CAPI_IRQ_XILINX_CTRL_MASK) >> CAPI_IRQ_XILINX_CTRL_SHIFT;
+}
+
+/** Decode the controller-local input number from a capi_irq id. */
+static inline uint32_t capi_irq_xilinx_local_id(uint32_t irq)
+{
+	/* just the low half; the selector bits are masked away */
+	return irq & CAPI_IRQ_XILINX_ID_MASK;
+}
+
+/* --------------------------------------------------------------------------
+ * Sub-controller (cascade) interface
+ *
+ * In cascade mode the AXI INTC's aggregated output is a single GIC SPI. The
+ * split of labor keeps each backend touching only its own controller:
+ *
+ *   sub-controller (intc.c): brings up / tears down its own XIntc hardware and
+ *     reports, via struct capi_irq_xilinx_cascade, what the root must wire.
+ *     It never calls any XScuGic_* function - it is pure XIntc.
+ *   root (gic.c): takes that descriptor, decodes the GIC SPI, and does all the
+ *     XScuGic_* wiring (connect dispatch handler, set priority, enable).
+ *
+ * Per-input connect/enable/... are then forwarded to the sub-controller; the
+ * ids passed are controller-local (selector already stripped by the root).
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @brief "Figure out the cascade line yourself" sentinel for cascade_gic_irq.
+ *
+ * Put this in capi_irq_xilinx_extra.cascade_gic_irq and the root derives the
+ * GIC SPI from the descriptor the sub-controller reports (its IntrParent /
+ * IntrId), instead of you hard-coding it. The value is all-ones because no
+ * real interrupt id ever reaches 0xFFFFFFFF, so it can't collide with one.
+ */
+#define CAPI_IRQ_XILINX_CASCADE_AUTO	0xFFFFFFFFU
+
+/**
+ * @struct capi_irq_xilinx_cascade
+ * @brief How the root should wire a sub-controller's cascade line.
+ *
+ * Filled in by the sub-controller's init() and consumed by the root. Carries
+ * only plain integers and a generic handler so the root needs no knowledge of
+ * the sub-controller's BSP driver (no XIntc types cross this boundary).
+ */
+struct capi_irq_xilinx_cascade {
+	/** Raw XIntc_Config.IntrParent: parent controller id + low type-tag bit. */
+	uint32_t intr_parent;
+	/** Raw XIntc_Config.IntrId: encodes the parent's interrupt id + offset. */
+	uint32_t intr_id;
+	/** Dispatch handler the root connects on the cascade line. */
+	capi_isr_callback_t handler;
+	/** Argument passed to @ref handler (the sub-controller's base address). */
+	void *handler_arg;
+};
+
+/**
+ * @struct capi_irq_xilinx_subctrl_ops
+ * @brief Operations a cascaded sub-controller exposes to the root.
+ *
+ * All ids passed to connect/enable/disable/clear_pending/get_status are
+ * controller-local (already stripped of the controller selector by the root).
+ */
+struct capi_irq_xilinx_subctrl_ops {
+	/**
+	 * @brief Bring up the sub-controller's own hardware and report its cascade.
+	 * @param ctrl_id Sub-controller id (irq_ctrl_id form).
+	 * @param out     Filled with the cascade wiring info for the root.
+	 * @return 0 on success, negative errno on failure.
+	 * @note Touches only the sub-controller; the root does the GIC wiring.
+	 */
+	int (*init)(uint32_t ctrl_id, struct capi_irq_xilinx_cascade *out);
+	/**
+	 * @brief Stop the sub-controller's own hardware.
+	 * @return 0 on success, negative errno on failure.
+	 * @note Touches only the sub-controller; the root unwires the GIC line.
+	 */
+	int (*deinit)(void);
+	/** @brief Register an ISR on a controller-local input. */
+	int (*connect)(uint32_t irq, capi_isr_callback_t isr, void *arg);
+	/** @brief Enable a controller-local input. */
+	int (*enable)(uint32_t irq);
+	/** @brief Disable a controller-local input. */
+	int (*disable)(uint32_t irq);
+	/** @brief Acknowledge/clear a controller-local input. */
+	int (*clear_pending)(uint32_t irq);
+	/** @brief Read pending status of a controller-local input. */
+	int (*get_status)(uint32_t irq, uint32_t *pactive);
+};
+
+/**
+ * @struct capi_irq_xilinx_extra
+ * @brief config->extra payload selecting a cascaded sub-controller.
+ *
+ * Set config->extra to point at one of these on a cascade build. Leave
+ * config->extra NULL for a GIC-only or INTC-only root build.
+ */
+struct capi_irq_xilinx_extra {
+	/** Sub-controller ops, e.g. &xilinx_capi_irq_intc_subctrl. */
+	const struct capi_irq_xilinx_subctrl_ops *subctrl;
+	/** Sub-controller controller id (irq_ctrl_id form). */
+	uint32_t subctrl_ctrl_id;
+	/** Root IRQ the cascade drives, or CAPI_IRQ_XILINX_CASCADE_AUTO. */
+	uint32_t cascade_gic_irq;
+};
+
+/**
+ * @brief Sub-controller ops exported by xilinx_capi_irq_intc.c in cascade mode.
+ *
+ * Only defined when the INTC file is compiled as a sub-controller
+ * (XPAR_XSCUGIC_NUM_INSTANCES > 0). The GIC root references this to dispatch
+ * INTC-local IRQs.
+ */
+extern const struct capi_irq_xilinx_subctrl_ops xilinx_capi_irq_intc_subctrl;
+
+/* --------------------------------------------------------------------------
+ * GIC backend
+ * -------------------------------------------------------------------------- */
+#ifdef XPAR_XSCUGIC_NUM_INSTANCES
+#include "xscugic.h"
+
+/**
+ * @brief Return the active XScuGic instance.
+ * @return XScuGic pointer, or NULL if capi_irq_init() has not run.
+ */
+XScuGic *capi_irq_get_scugic_instance(void);
+#endif
+
+/* --------------------------------------------------------------------------
+ * INTC backend
+ * -------------------------------------------------------------------------- */
+#ifdef XPAR_XINTC_NUM_INSTANCES
+#include "xintc.h"
+
+/**
+ * @brief Return the active XIntc instance.
+ * @return XIntc pointer, or NULL if capi_irq_init() has not run.
+ */
+XIntc *capi_irq_get_intc_instance(void);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _XILINX_CAPI_IRQ_H_ */

--- a/capi/platform/xilinx/xilinx_capi_irq_gic.c
+++ b/capi/platform/xilinx/xilinx_capi_irq_gic.c
@@ -1,0 +1,560 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Xilinx PS GIC IRQ driver (XScuGic)
+ *
+ * Singleton: one GIC per system, initialized once via capi_irq_init().
+ * Mirrors no-OS IRQ_PS path: XScuGic_CfgInitialize + exception handler.
+ */
+
+#include <stdbool.h>
+#include <errno.h>
+#include "xilinx_capi_irq.h"
+#ifdef XPAR_XSCUGIC_NUM_INSTANCES
+#include "xscugic.h"
+#include "xil_exception.h"
+#include "xil_io.h"
+
+#include "xinterrupt_wrap.h"
+
+static bool g_initialized = false;
+static XScuGic g_scugic;
+static const struct capi_irq_xilinx_subctrl_ops *g_subctrl;
+/* GIC SPI the sub-controller cascade drives, valid while g_subctrl != NULL. */
+static uint32_t g_cascade_gic_irq;
+
+/*
+ * Trigger types as XScuGic_SetPriorityTriggerType() wants them: the raw 2-bit
+ * GIC ICFGR field, where bit1 selects edge vs level and bit0 must be set.
+ * embeddedsw ships no named constants for these, so we define the two we use.
+ *   0b01 = active-high level   0b11 = rising edge
+ */
+#define CAPI_GIC_TRIGGER_LEVEL_HIGH	0x01U
+#define CAPI_GIC_TRIGGER_EDGE_RISING	0x03U
+/* Priority for the cascade SPI: mid level; lower value = higher priority. */
+#define CAPI_GIC_CASCADE_PRIORITY	0xA0U
+/* GIC pending registers pack 32 inputs per 32-bit word: word = id/32, bit = id%32. */
+#define CAPI_GIC_PENDING_IRQS_PER_REG	32U
+#define CAPI_GIC_PENDING_REG_STRIDE	4U
+
+static int capi_irq_gic_validate(uint32_t irq)
+{
+	return (irq < XSCUGIC_MAX_NUM_INTR_INPUTS) ? 0 : -EINVAL;
+}
+
+static int capi_irq_gic_connect(uint32_t irq, capi_isr_callback_t isr,
+				void *arg)
+{
+	if (capi_irq_gic_validate(irq))
+		return -EINVAL;
+	if (isr == NULL)
+		return -EINVAL;
+
+	int status = XScuGic_Connect(&g_scugic, irq,
+				     (Xil_InterruptHandler)isr, arg);
+	return (status == XST_SUCCESS) ? 0 : -EIO;
+}
+
+static int capi_irq_gic_enable(uint32_t irq)
+{
+	if (capi_irq_gic_validate(irq))
+		return -EINVAL;
+
+	XScuGic_Enable(&g_scugic, irq);
+	return 0;
+}
+
+static int capi_irq_gic_disable(uint32_t irq)
+{
+	if (capi_irq_gic_validate(irq))
+		return -EINVAL;
+
+	XScuGic_Disable(&g_scugic, irq);
+	return 0;
+}
+
+static int capi_irq_gic_clear_pending(uint32_t irq)
+{
+	if (capi_irq_gic_validate(irq))
+		return -EINVAL;
+
+	/* GIC pending registers pack 32 interrupt IDs per 32-bit word. */
+	uint32_t reg = XSCUGIC_PENDING_CLR_OFFSET +
+		       (irq / CAPI_GIC_PENDING_IRQS_PER_REG) *
+		       CAPI_GIC_PENDING_REG_STRIDE;
+	uint32_t bit = 1U << (irq % CAPI_GIC_PENDING_IRQS_PER_REG);
+	Xil_Out32(g_scugic.Config->DistBaseAddress + reg, bit);
+	return 0;
+}
+
+static int capi_irq_gic_get_status(uint32_t irq, uint32_t *pactive)
+{
+	if (pactive == NULL)
+		return -EINVAL;
+	if (capi_irq_gic_validate(irq))
+		return -EINVAL;
+
+	/* GIC pending registers pack 32 interrupt IDs per 32-bit word. */
+	uint32_t reg = XSCUGIC_PENDING_SET_OFFSET +
+		       (irq / CAPI_GIC_PENDING_IRQS_PER_REG) *
+		       CAPI_GIC_PENDING_REG_STRIDE;
+	uint32_t bit = 1U << (irq % CAPI_GIC_PENDING_IRQS_PER_REG);
+	uint32_t val = Xil_In32(g_scugic.Config->DistBaseAddress + reg);
+	*pactive = (val & bit) ? 1U : 0U;
+	return 0;
+}
+
+static int capi_irq_gic_set_priority(uint32_t irq, uint32_t priority)
+{
+	if (capi_irq_gic_validate(irq))
+		return -EINVAL;
+
+	/* XScuGic_SetPriorityTriggerType() asserts above the BSP max. */
+	if (priority > XSCUGIC_MAX_INTR_PRIO_VAL)
+		return -EINVAL;
+
+	uint8_t cur_prio, cur_trig;
+	XScuGic_GetPriorityTriggerType(&g_scugic, irq, &cur_prio, &cur_trig);
+	XScuGic_SetPriorityTriggerType(&g_scugic, irq, (uint8_t)priority,
+				       cur_trig);
+	return 0;
+}
+
+static int capi_irq_gic_get_priority(uint32_t irq, uint32_t *priority)
+{
+	if (priority == NULL)
+		return -EINVAL;
+	if (capi_irq_gic_validate(irq))
+		return -EINVAL;
+
+	uint8_t prio, trig;
+	XScuGic_GetPriorityTriggerType(&g_scugic, irq, &prio, &trig);
+	*priority = prio;
+	return 0;
+}
+
+static int capi_irq_gic_set_level_edge_trigger(uint32_t irq,
+		enum capi_irq_trig_level trigger)
+{
+	if (capi_irq_gic_validate(irq))
+		return -EINVAL;
+
+	uint8_t prio, trig;
+	uint8_t new_trig;
+
+	switch (trigger) {
+	case CAPI_IRQ_LEVEL_HIGH:
+		new_trig = CAPI_GIC_TRIGGER_LEVEL_HIGH;
+		break;
+	case CAPI_IRQ_EDGE_RISING:
+		new_trig = CAPI_GIC_TRIGGER_EDGE_RISING;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	XScuGic_GetPriorityTriggerType(&g_scugic, irq, &prio, &trig);
+	XScuGic_SetPriorityTriggerType(&g_scugic, irq, prio, new_trig);
+	return 0;
+}
+
+/*
+ * Error to report for an INTC-targeted call that the GIC root can't service
+ * itself (priority / trigger config, which the sub-controller ops don't
+ * expose). Distinguish the two failure modes:
+ *   sub-controller present -> -ENOTSUP (INTC inputs lack this feature)
+ *   no sub-controller       -> -ENODEV  (nothing is wired to the INTC selector)
+ */
+static int capi_irq_subctrl_missing(void)
+{
+	return g_subctrl ? -ENOTSUP : -ENODEV;
+}
+
+/*
+ * Resolve the GIC SPI a sub-controller's cascade drives.
+ *
+ * Use @p requested when the caller named one (anything but 0 or the AUTO
+ * sentinel). Otherwise auto-detect from the descriptor the sub-controller
+ * reported: intr_parent must be a GIC, not another INTC (a chained INTC has
+ * no single GIC line); XGet_IntrId strips intr_id's type tag and
+ * XGet_IntrOffset adds the SPI base (e.g. +32), giving the real GIC id.
+ */
+static int capi_irq_resolve_cascade(const struct capi_irq_xilinx_cascade *casc,
+				    uint32_t requested, uint32_t *gic_irq)
+{
+	if (requested != CAPI_IRQ_XILINX_CASCADE_AUTO && requested != 0U) {
+		*gic_irq = requested;
+		return 0;
+	}
+
+	if (casc->intr_parent == 0U ||
+	    XGet_IntcType(casc->intr_parent) == XINTC_TYPE_IS_INTC)
+		return -ENODEV;
+
+	*gic_irq = XGet_IntrId(casc->intr_id) + XGet_IntrOffset(casc->intr_id);
+	return 0;
+}
+
+/*
+ * Wire a sub-controller's already-running cascade onto the GIC: route its
+ * dispatch handler to the SPI, clear any stale pending bit, set the trigger
+ * and priority, and enable the line. All the GIC-side work the sub-controller
+ * deliberately left to us.
+ */
+static int capi_irq_wire_cascade(const struct capi_irq_xilinx_cascade *casc,
+				 uint32_t gic_irq)
+{
+	int status = XScuGic_Connect(&g_scugic, gic_irq,
+				     (Xil_InterruptHandler)casc->handler,
+				     casc->handler_arg);
+	if (status != XST_SUCCESS)
+		return -EIO;
+
+	XScuGic_DistWriteReg(&g_scugic,
+			     XSCUGIC_PENDING_CLR_OFFSET +
+			     (gic_irq / CAPI_GIC_PENDING_IRQS_PER_REG) *
+			     CAPI_GIC_PENDING_REG_STRIDE,
+			     1U << (gic_irq % CAPI_GIC_PENDING_IRQS_PER_REG));
+
+	XScuGic_SetPriorityTriggerType(&g_scugic, gic_irq,
+				       CAPI_GIC_CASCADE_PRIORITY,
+				       CAPI_GIC_TRIGGER_LEVEL_HIGH);
+	XScuGic_Enable(&g_scugic, gic_irq);
+	return 0;
+}
+
+/**
+ * @brief Initialize the CAPI backend instance.
+ * @note PS: XScuGic_LookupConfig()/XScuGic_CfgInitialize().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int capi_irq_init(struct capi_irq_config *config)
+{
+	int ret;
+
+	if (config == NULL)
+		return -EINVAL;
+
+	if (g_initialized)
+		return -EBUSY;
+
+	XScuGic_Config *cfg = XScuGic_LookupConfig((UINTPTR)config->irq_ctrl_id);
+	if (cfg == NULL)
+		return -ENODEV;
+
+	int status = XScuGic_CfgInitialize(&g_scugic, cfg, cfg->CpuBaseAddress);
+	if (status != XST_SUCCESS)
+		return -EIO;
+
+	Xil_ExceptionInit();
+	Xil_ExceptionRegisterHandler(XIL_EXCEPTION_ID_INT,
+				     (Xil_ExceptionHandler)XScuGic_InterruptHandler, &g_scugic);
+
+	g_subctrl = NULL;
+	struct capi_irq_xilinx_extra *extra = config->extra;
+	if (extra != NULL && extra->subctrl != NULL) {
+		struct capi_irq_xilinx_cascade casc;
+
+		/* Sub-controller brings up its own hardware and tells us... */
+		ret = extra->subctrl->init(extra->subctrl_ctrl_id, &casc);
+		if (ret)
+			return ret;
+
+		/* ...which GIC line to wire, then we do the GIC-side work. */
+		ret = capi_irq_resolve_cascade(&casc, extra->cascade_gic_irq,
+					       &g_cascade_gic_irq);
+		if (ret == 0)
+			ret = capi_irq_wire_cascade(&casc, g_cascade_gic_irq);
+		if (ret) {
+			extra->subctrl->deinit();
+			return ret;
+		}
+
+		g_subctrl = extra->subctrl;
+	}
+
+	g_initialized = true;
+	return 0;
+}
+
+/**
+ * @brief Deinitialize the CAPI backend instance.
+ * @note PS: XScuGic_Disable()/XScuGic_Disconnect().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int capi_irq_deinit(void)
+{
+	if (!g_initialized)
+		return -EINVAL;
+
+	Xil_ExceptionDisable();
+
+	if (g_subctrl != NULL) {
+		/* Stop the sub-controller, then tear down its GIC cascade line. */
+		if (g_subctrl->deinit != NULL) {
+			int ret = g_subctrl->deinit();
+			if (ret)
+				return ret;
+		}
+		XScuGic_Disable(&g_scugic, g_cascade_gic_irq);
+		XScuGic_Disconnect(&g_scugic, g_cascade_gic_irq);
+		g_cascade_gic_irq = 0U;
+	}
+
+	for (uint32_t i = 0; i < XSCUGIC_MAX_NUM_INTR_INPUTS; i++) {
+		XScuGic_Disable(&g_scugic, i);
+		XScuGic_Disconnect(&g_scugic, i);
+	}
+
+	Xil_ExceptionRemoveHandler(XIL_EXCEPTION_ID_INT);
+	g_subctrl = NULL;
+	g_initialized = false;
+	return 0;
+}
+
+/**
+ * @brief Enable global interrupt delivery.
+ * @note PS: Xil_ExceptionEnable().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int capi_irq_global_enable(void)
+{
+	if (!g_initialized)
+		return -EINVAL;
+
+	Xil_ExceptionEnable();
+	return 0;
+}
+
+/**
+ * @brief Disable global interrupt delivery.
+ * @note PS: Xil_ExceptionDisable().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int capi_irq_global_disable(void)
+{
+	if (!g_initialized)
+		return -EINVAL;
+
+	Xil_ExceptionDisable();
+	return 0;
+}
+
+/**
+ * @brief Connect an ISR to an interrupt line.
+ * @note PS: XScuGic_Connect().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int capi_irq_connect(uint32_t irq, capi_isr_callback_t isr, void *arg)
+{
+	if (!g_initialized)
+		return -EINVAL;
+	if (isr == NULL)
+		return -EINVAL;
+
+	switch (capi_irq_xilinx_ctrl(irq)) {
+	case CAPI_IRQ_XILINX_CTRL_GIC:
+		return capi_irq_gic_connect(capi_irq_xilinx_local_id(irq), isr, arg);
+	case CAPI_IRQ_XILINX_CTRL_INTC:
+		if (g_subctrl == NULL)
+			return -ENODEV;
+		if (g_subctrl->connect == NULL)
+			return -ENOTSUP;
+		return g_subctrl->connect(capi_irq_xilinx_local_id(irq), isr, arg);
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Enable an interrupt line.
+ * @note PS: XScuGic_Enable().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int capi_irq_enable(uint32_t irq)
+{
+	if (!g_initialized)
+		return -EINVAL;
+
+	switch (capi_irq_xilinx_ctrl(irq)) {
+	case CAPI_IRQ_XILINX_CTRL_GIC:
+		return capi_irq_gic_enable(capi_irq_xilinx_local_id(irq));
+	case CAPI_IRQ_XILINX_CTRL_INTC:
+		if (g_subctrl == NULL)
+			return -ENODEV;
+		if (g_subctrl->enable == NULL)
+			return -ENOTSUP;
+		return g_subctrl->enable(capi_irq_xilinx_local_id(irq));
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Disable an interrupt line.
+ * @note PS: XScuGic_Disable().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int capi_irq_disable(uint32_t irq)
+{
+	if (!g_initialized)
+		return -EINVAL;
+
+	switch (capi_irq_xilinx_ctrl(irq)) {
+	case CAPI_IRQ_XILINX_CTRL_GIC:
+		return capi_irq_gic_disable(capi_irq_xilinx_local_id(irq));
+	case CAPI_IRQ_XILINX_CTRL_INTC:
+		if (g_subctrl == NULL)
+			return -ENODEV;
+		if (g_subctrl->disable == NULL)
+			return -ENOTSUP;
+		return g_subctrl->disable(capi_irq_xilinx_local_id(irq));
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Clear an interrupt pending bit.
+ * @note PS: Xil_Out32() to GIC pending-clear register.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int capi_irq_clear_pending(uint32_t irq)
+{
+	if (!g_initialized)
+		return -EINVAL;
+
+	switch (capi_irq_xilinx_ctrl(irq)) {
+	case CAPI_IRQ_XILINX_CTRL_GIC:
+		return capi_irq_gic_clear_pending(capi_irq_xilinx_local_id(irq));
+	case CAPI_IRQ_XILINX_CTRL_INTC:
+		if (g_subctrl == NULL)
+			return -ENODEV;
+		if (g_subctrl->clear_pending == NULL)
+			return -ENOTSUP;
+		return g_subctrl->clear_pending(capi_irq_xilinx_local_id(irq));
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Read interrupt pending status.
+ * @note PS: Xil_In32() from GIC pending-set register.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int capi_irq_get_status(uint32_t irq, uint32_t *pactive)
+{
+	if (!g_initialized || pactive == NULL)
+		return -EINVAL;
+
+	switch (capi_irq_xilinx_ctrl(irq)) {
+	case CAPI_IRQ_XILINX_CTRL_GIC:
+		return capi_irq_gic_get_status(capi_irq_xilinx_local_id(irq),
+					       pactive);
+	case CAPI_IRQ_XILINX_CTRL_INTC:
+		if (g_subctrl == NULL)
+			return -ENODEV;
+		if (g_subctrl->get_status == NULL)
+			return -ENOTSUP;
+		return g_subctrl->get_status(capi_irq_xilinx_local_id(irq),
+					     pactive);
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Set interrupt priority.
+ * @note PS: XScuGic_Get/SetPriorityTriggerType().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int capi_irq_set_priority(uint32_t irq, uint32_t priority)
+{
+	if (!g_initialized)
+		return -EINVAL;
+
+	switch (capi_irq_xilinx_ctrl(irq)) {
+	case CAPI_IRQ_XILINX_CTRL_GIC:
+		return capi_irq_gic_set_priority(capi_irq_xilinx_local_id(irq),
+						 priority);
+	case CAPI_IRQ_XILINX_CTRL_INTC:
+		return capi_irq_subctrl_missing();
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Get interrupt priority.
+ * @note PS: XScuGic_GetPriorityTriggerType().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int capi_irq_get_priority(uint32_t irq, uint32_t *priority)
+{
+	if (!g_initialized)
+		return -EINVAL;
+	if (priority == NULL)
+		return -EINVAL;
+
+	switch (capi_irq_xilinx_ctrl(irq)) {
+	case CAPI_IRQ_XILINX_CTRL_GIC:
+		return capi_irq_gic_get_priority(capi_irq_xilinx_local_id(irq),
+						 priority);
+	case CAPI_IRQ_XILINX_CTRL_INTC:
+		return capi_irq_subctrl_missing();
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Configure interrupt trigger type.
+ * @note PS: XScuGic_SetPriorityTriggerType().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int capi_irq_set_level_edge_trigger(uint32_t irq,
+				    enum capi_irq_trig_level trigger)
+{
+	if (!g_initialized)
+		return -EINVAL;
+
+	switch (capi_irq_xilinx_ctrl(irq)) {
+	case CAPI_IRQ_XILINX_CTRL_GIC:
+		return capi_irq_gic_set_level_edge_trigger(
+			       capi_irq_xilinx_local_id(irq), trigger);
+	case CAPI_IRQ_XILINX_CTRL_INTC:
+		return capi_irq_subctrl_missing();
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Return the active XScuGic instance.
+ * @note PS: Returns active XScuGic instance.
+ *
+ * @return XScuGic instance pointer, or NULL if not initialized.
+ */
+XScuGic *capi_irq_get_scugic_instance(void)
+{
+	return g_initialized ? &g_scugic : NULL;
+}
+#endif /* XPAR_XSCUGIC_NUM_INSTANCES */

--- a/capi/platform/xilinx/xilinx_capi_irq_intc.c
+++ b/capi/platform/xilinx/xilinx_capi_irq_intc.c
@@ -1,0 +1,464 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Xilinx AXI INTC IRQ driver (XIntc).
+ *
+ * This file supports two link modes:
+ *   - linked alone on MicroBlaze: XIntc owns the public capi_irq_* API;
+ *   - linked with xilinx_capi_irq_gic.c on Zynq/ZynqMP: XIntc exports only
+ *     xilinx_capi_irq_intc_subctrl and the GIC owns the public capi_irq_* API.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <errno.h>
+
+#include "xilinx_capi_irq.h"
+
+#ifdef XPAR_XINTC_NUM_INSTANCES
+
+#include "xintc.h"
+#include "xintc_l.h"
+#include "xil_exception.h"
+
+/*
+ * Pick this file's role at compile time. A GIC in the BSP means we are the PL
+ * sub-controller cascaded into it (case 3); no GIC means we are the standalone
+ * MicroBlaze root (case 2). The two are mutually exclusive (SUBCTRL == !ROOT),
+ * so the public capi_irq_* API below is compiled in exactly one build.
+ *
+ * Either way this file is pure XIntc: it includes no xscugic.h and calls no
+ * XScuGic_* function. In cascade mode the root (gic.c) owns all GIC wiring;
+ * we only report what to wire (see struct capi_irq_xilinx_cascade).
+ *
+ * Note: an undefined XPAR_XSCUGIC_NUM_INSTANCES evaluates to 0 in #if, so the
+ * MicroBlaze case takes the #else cleanly without needing the macro defined.
+ */
+#if XPAR_XSCUGIC_NUM_INSTANCES > 0
+#define CAPI_IRQ_XILINX_INTC_SUBCTRL	1
+#define CAPI_IRQ_XILINX_INTC_ROOT	0
+#else
+#define CAPI_IRQ_XILINX_INTC_SUBCTRL	0
+#define CAPI_IRQ_XILINX_INTC_ROOT	1
+#endif
+
+/* Write-1-to-clear every input in the INTC's Acknowledge register at once. */
+#define CAPI_INTC_ACK_ALL_PENDING	0xFFFFFFFFU
+
+static bool g_initialized = false;
+static XIntc g_intc;
+
+#if CAPI_IRQ_XILINX_INTC_SUBCTRL
+static bool g_cascaded = false;
+#endif
+
+static int capi_irq_intc_validate(uint32_t irq)
+{
+	/*
+	 * Bound against the input count the BSP reports for this instance
+	 * rather than a compile-time macro: XIntc carries it at runtime and
+	 * the spelling of the XPAR_*_NUM_INTR_INPUTS macro varies by BSP era.
+	 * Only ever called after init, so CfgPtr is valid.
+	 */
+	return (irq < (uint32_t)g_intc.CfgPtr->NumberofIntrs) ? 0 : -EINVAL;
+}
+
+#if CAPI_IRQ_XILINX_INTC_ROOT
+/*
+ * Map a public capi_irq id to a bare INTC input number for the root path.
+ *
+ * On a standalone INTC root there is only one controller, so both selectors
+ * mean the same thing: GIC accepts bare ids (high half 0), INTC accepts ids
+ * built with CAPI_IRQ_XILINX_INTC(). Either way the input is the low half.
+ * Range is left to the leaf op, the single point both modes funnel through.
+ */
+static int capi_irq_intc_decode_root_irq(uint32_t irq, uint32_t *local_irq)
+{
+	if (local_irq == NULL)
+		return -EINVAL;
+
+	switch (capi_irq_xilinx_ctrl(irq)) {
+	case CAPI_IRQ_XILINX_CTRL_GIC:
+	case CAPI_IRQ_XILINX_CTRL_INTC:
+		*local_irq = capi_irq_xilinx_local_id(irq);
+		return 0;
+	default:
+		return -EINVAL;
+	}
+}
+#endif
+
+static int capi_irq_intc_initialize(uint32_t ctrl_id)
+{
+	int status;
+
+	status = XIntc_Initialize(&g_intc, (UINTPTR)ctrl_id);
+	if (status != XST_SUCCESS)
+		return -ENODEV;
+
+	status = XIntc_Start(&g_intc, XIN_REAL_MODE);
+	return (status == XST_SUCCESS) ? 0 : -EIO;
+}
+
+/**
+ * @brief Connect an ISR to an AXI INTC input.
+ * @note INTC: XIntc_Connect().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_irq_intc_connect(uint32_t irq, capi_isr_callback_t isr,
+				 void *arg)
+{
+	if (capi_irq_intc_validate(irq))
+		return -EINVAL;
+	if (isr == NULL)
+		return -EINVAL;
+
+	int status = XIntc_Connect(&g_intc, (u8)irq, (XInterruptHandler)isr, arg);
+	return (status == XST_SUCCESS) ? 0 : -EIO;
+}
+
+/**
+ * @brief Enable an AXI INTC input.
+ * @note INTC: XIntc_Enable().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_irq_intc_enable(uint32_t irq)
+{
+	if (capi_irq_intc_validate(irq))
+		return -EINVAL;
+
+	XIntc_Enable(&g_intc, (u8)irq);
+	return 0;
+}
+
+/**
+ * @brief Disable an AXI INTC input.
+ * @note INTC: XIntc_Disable().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_irq_intc_disable(uint32_t irq)
+{
+	if (capi_irq_intc_validate(irq))
+		return -EINVAL;
+
+	XIntc_Disable(&g_intc, (u8)irq);
+	return 0;
+}
+
+/**
+ * @brief Clear a pending AXI INTC input.
+ * @note INTC: XIntc_Acknowledge().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_irq_intc_clear_pending(uint32_t irq)
+{
+	if (capi_irq_intc_validate(irq))
+		return -EINVAL;
+
+	XIntc_Acknowledge(&g_intc, (u8)irq);
+	return 0;
+}
+
+/**
+ * @brief Read whether an AXI INTC input is pending.
+ * @note INTC: XIntc_GetIntrStatus().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_irq_intc_get_status(uint32_t irq, uint32_t *pactive)
+{
+	if (pactive == NULL)
+		return -EINVAL;
+	if (capi_irq_intc_validate(irq))
+		return -EINVAL;
+
+	uint32_t isr = XIntc_GetIntrStatus(g_intc.BaseAddress);
+	*pactive = (isr & (1U << irq)) ? 1U : 0U;
+	return 0;
+}
+
+#if CAPI_IRQ_XILINX_INTC_SUBCTRL
+/**
+ * @brief Initialize AXI INTC as a cascaded sub-controller.
+ * @note INTC: XIntc_Initialize()/XIntc_Start().
+ *
+ * We stop at the INTC boundary: start the controller, ack any stale inputs,
+ * and hand back the raw IntrParent/IntrId from the SDT config plus the
+ * device interrupt handler and its arg (our base address). The root (gic.c)
+ * decodes the GIC SPI from IntrParent/IntrId and does the XScuGic_* wiring.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_irq_intc_subctrl_init(uint32_t ctrl_id,
+				      struct capi_irq_xilinx_cascade *out)
+{
+	int ret;
+
+	if (out == NULL)
+		return -EINVAL;
+	if (g_initialized)
+		return -EBUSY;
+
+	ret = capi_irq_intc_initialize(ctrl_id);
+	if (ret)
+		return ret;
+
+	/* Acknowledge any stale inputs so the cascade starts quiet. */
+	XIntc_Out32(g_intc.CfgPtr->BaseAddress + XIN_IAR_OFFSET,
+		    CAPI_INTC_ACK_ALL_PENDING);
+
+	out->intr_parent = g_intc.CfgPtr->IntrParent;
+	out->intr_id = g_intc.CfgPtr->IntrId;
+	out->handler = (capi_isr_callback_t)XIntc_DeviceInterruptHandler;
+	out->handler_arg = (void *)(uintptr_t)g_intc.CfgPtr->BaseAddress;
+
+	g_initialized = true;
+	g_cascaded = true;
+	return 0;
+}
+
+/**
+ * @brief Deinitialize the cascaded AXI INTC sub-controller.
+ * @note INTC: XIntc_Stop().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_irq_intc_subctrl_deinit(void)
+{
+	if (!g_initialized || !g_cascaded)
+		return -EINVAL;
+
+	XIntc_Stop(&g_intc);
+
+	g_cascaded = false;
+	g_initialized = false;
+	return 0;
+}
+
+const struct capi_irq_xilinx_subctrl_ops xilinx_capi_irq_intc_subctrl = {
+	.init = capi_irq_intc_subctrl_init,
+	.deinit = capi_irq_intc_subctrl_deinit,
+	.connect = capi_irq_intc_connect,
+	.enable = capi_irq_intc_enable,
+	.disable = capi_irq_intc_disable,
+	.clear_pending = capi_irq_intc_clear_pending,
+	.get_status = capi_irq_intc_get_status,
+};
+#endif /* CAPI_IRQ_XILINX_INTC_SUBCTRL */
+
+#if CAPI_IRQ_XILINX_INTC_ROOT
+
+/**
+ * @brief Initialize the CAPI INTC backend as a root controller.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int capi_irq_init(struct capi_irq_config *config)
+{
+	int ret;
+
+	if (!config)
+		return -EINVAL;
+	if (g_initialized)
+		return -EBUSY;
+
+	Xil_ExceptionInit();
+
+	ret = capi_irq_intc_initialize(config->irq_ctrl_id);
+	if (ret)
+		return ret;
+
+	/* Route the INTC's aggregated output to the MicroBlaze IRQ exception. */
+	Xil_ExceptionRegisterHandler(XIL_EXCEPTION_ID_INT,
+				     (Xil_ExceptionHandler)XIntc_InterruptHandler,
+				     &g_intc);
+
+	g_initialized = true;
+	return 0;
+}
+
+/**
+ * @brief Deinitialize the CAPI INTC root backend.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+int capi_irq_deinit(void)
+{
+	if (!g_initialized)
+		return -EINVAL;
+
+	Xil_ExceptionDisable();
+	XIntc_Stop(&g_intc);
+	Xil_ExceptionRemoveHandler(XIL_EXCEPTION_ID_INT);
+
+	g_initialized = false;
+	return 0;
+}
+
+int capi_irq_global_enable(void)
+{
+	if (!g_initialized)
+		return -EINVAL;
+
+	Xil_ExceptionEnable();
+	return 0;
+}
+
+int capi_irq_global_disable(void)
+{
+	if (!g_initialized)
+		return -EINVAL;
+
+	Xil_ExceptionDisable();
+	return 0;
+}
+
+int capi_irq_connect(uint32_t irq, capi_isr_callback_t isr, void *arg)
+{
+	uint32_t local_irq;
+	int ret;
+
+	if (!g_initialized)
+		return -EINVAL;
+
+	ret = capi_irq_intc_decode_root_irq(irq, &local_irq);
+	if (ret)
+		return ret;
+
+	return capi_irq_intc_connect(local_irq, isr, arg);
+}
+
+int capi_irq_enable(uint32_t irq)
+{
+	uint32_t local_irq;
+	int ret;
+
+	if (!g_initialized)
+		return -EINVAL;
+
+	ret = capi_irq_intc_decode_root_irq(irq, &local_irq);
+	if (ret)
+		return ret;
+
+	return capi_irq_intc_enable(local_irq);
+}
+
+int capi_irq_disable(uint32_t irq)
+{
+	uint32_t local_irq;
+	int ret;
+
+	if (!g_initialized)
+		return -EINVAL;
+
+	ret = capi_irq_intc_decode_root_irq(irq, &local_irq);
+	if (ret)
+		return ret;
+
+	return capi_irq_intc_disable(local_irq);
+}
+
+int capi_irq_clear_pending(uint32_t irq)
+{
+	uint32_t local_irq;
+	int ret;
+
+	if (!g_initialized)
+		return -EINVAL;
+
+	ret = capi_irq_intc_decode_root_irq(irq, &local_irq);
+	if (ret)
+		return ret;
+
+	return capi_irq_intc_clear_pending(local_irq);
+}
+
+int capi_irq_get_status(uint32_t irq, uint32_t *pactive)
+{
+	uint32_t local_irq;
+	int ret;
+
+	if (!g_initialized || pactive == NULL)
+		return -EINVAL;
+
+	ret = capi_irq_intc_decode_root_irq(irq, &local_irq);
+	if (ret)
+		return ret;
+
+	return capi_irq_intc_get_status(local_irq, pactive);
+}
+
+int capi_irq_set_priority(uint32_t irq, uint32_t priority)
+{
+	uint32_t local_irq;
+	int ret;
+
+	(void)priority;
+
+	if (!g_initialized)
+		return -EINVAL;
+
+	ret = capi_irq_intc_decode_root_irq(irq, &local_irq);
+	if (ret)
+		return ret;
+
+	return -ENOTSUP;
+}
+
+int capi_irq_get_priority(uint32_t irq, uint32_t *priority)
+{
+	uint32_t local_irq;
+	int ret;
+
+	if (!g_initialized)
+		return -EINVAL;
+	if (priority == NULL)
+		return -EINVAL;
+
+	ret = capi_irq_intc_decode_root_irq(irq, &local_irq);
+	if (ret)
+		return ret;
+
+	return -ENOTSUP;
+}
+
+int capi_irq_set_level_edge_trigger(uint32_t irq,
+				    enum capi_irq_trig_level trigger)
+{
+	uint32_t local_irq;
+	int ret;
+
+	(void)trigger;
+
+	if (!g_initialized)
+		return -EINVAL;
+
+	ret = capi_irq_intc_decode_root_irq(irq, &local_irq);
+	if (ret)
+		return ret;
+
+	return -ENOTSUP;
+}
+
+#endif /* CAPI_IRQ_XILINX_INTC_ROOT */
+
+/**
+ * @brief Return the active XIntc instance.
+ *
+ * @return XIntc instance pointer, or NULL if not initialized.
+ */
+XIntc *capi_irq_get_intc_instance(void)
+{
+	return g_initialized ? &g_intc : NULL;
+}
+
+#endif /* XPAR_XINTC_NUM_INSTANCES */

--- a/capi/platform/xilinx/xilinx_capi_platform.h
+++ b/capi/platform/xilinx/xilinx_capi_platform.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Xilinx platform I/O macro definitions for CAPI.
+ *
+ * Provides the Xilinx-backed implementations of the CAPI_PLATFORM_IO_*
+ * read/write macros, mapping them onto the BSP Xil_In / Xil_Out primitives.
+ */
+
+#ifndef _XILINX_CAPI_PLATFORM_H_
+#define _XILINX_CAPI_PLATFORM_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "xil_io.h"
+#include "xil_types.h"
+#include <stdint.h>
+
+#define CAPI_PLATFORM_IO_READ8(addr)  Xil_In8((UINTPTR)(addr))
+#define CAPI_PLATFORM_IO_READ16(addr) Xil_In16((UINTPTR)(addr))
+#define CAPI_PLATFORM_IO_READ32(addr) Xil_In32((UINTPTR)(addr))
+#define CAPI_PLATFORM_IO_READ64(addr) Xil_In64((UINTPTR)(addr))
+
+#define CAPI_PLATFORM_IO_WRITE8(addr, val)  Xil_Out8((UINTPTR)(addr), (u8)(val))
+#define CAPI_PLATFORM_IO_WRITE16(addr, val) Xil_Out16((UINTPTR)(addr), (u16)(val))
+#define CAPI_PLATFORM_IO_WRITE32(addr, val) Xil_Out32((UINTPTR)(addr), (u32)(val))
+#define CAPI_PLATFORM_IO_WRITE64(addr, val) Xil_Out64((UINTPTR)(addr), (u64)(val))
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _XILINX_CAPI_PLATFORM_H_ */

--- a/capi/platform/xilinx/xilinx_capi_spi.h
+++ b/capi/platform/xilinx/xilinx_capi_spi.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Xilinx platform SPI driver for CAPI
+ *
+ * Backends (select via config.ops):
+ *   capi_spi_xilinx_ps_ops  - XSpiPs  (Zynq PS SPI)
+ *   capi_spi_xilinx_pl_ops  - XSpi    (AXI Quad SPI)
+ *
+ * Both backends operate in master mode only.
+ */
+
+#ifndef _XILINX_CAPI_SPI_H_
+#define _XILINX_CAPI_SPI_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <capi_spi.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Pass config->extra = NULL for polled mode. To use interrupts, pass
+ * struct capi_spi_xilinx_config with use_irq=true and the desired irq_id.
+ * IRQ ID 0 is valid for INTC input 0. XSpiPs clock freq comes from
+ * config->clk_freq_hz; XSpi loopback comes from config->loopback.
+ */
+
+/**
+ * @struct capi_spi_xilinx_config
+ * @brief Optional Xilinx platform-specific SPI configuration.
+ *
+ * Passed via config->extra during init. use_irq decides whether the driver
+ * connects irq_id through the CAPI IRQ singleton. IRQ ID 0 is valid for an
+ * INTC input, so it is passed through unchanged.
+ */
+struct capi_spi_xilinx_config {
+	/** Enable CAPI IRQ connection during init */
+	bool use_irq;
+	/** Normalized CAPI IRQ ID. Zero is valid for INTC input 0. */
+	uint32_t irq_id;
+};
+
+/**
+ * @brief Xilinx SPI operations tables. Select one via config->ops.
+ */
+extern const struct capi_spi_ops capi_spi_xilinx_ps_ops;
+extern const struct capi_spi_ops capi_spi_xilinx_pl_ops;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _XILINX_CAPI_SPI_H_ */

--- a/capi/platform/xilinx/xilinx_capi_spi_pl.c
+++ b/capi/platform/xilinx/xilinx_capi_spi_pl.c
@@ -1,0 +1,1059 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Xilinx XSpi AXI Quad SPI driver (master mode only)
+ *
+ * SDT BSP only. IRQ is explicit via capi_spi_xilinx_config.
+ * capi_irq_init() must be called before async ops will work.
+ */
+
+#include <capi_alloc.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <errno.h>
+#include <string.h>
+#include <capi_spi.h>
+#include <xilinx_capi_spi_priv.h>
+#include <capi_gpio.h>
+#include "capi_irq.h"
+#include "xinterrupt_wrap.h"
+
+#ifdef XPAR_XSPI_NUM_INSTANCES
+
+/* native_cs == 0 selects CS0. */
+#define XSPI_CAPI_DEFAULT_NATIVE_CS_MASK	1U
+#define XSPI_CAPI_DESELECT_ALL_NATIVE		0U
+#define XSPI_CAPI_SINGLE_BYTE_TRANSFER		1U
+#define XSPI_CAPI_MAX_TRANSFER_SIZE		UINT16_MAX
+
+static int capi_spi_pl_init(struct capi_spi_controller_handle **handle,
+			    const struct capi_spi_config *config);
+static int capi_spi_pl_deinit(struct capi_spi_controller_handle *handle);
+static int capi_spi_pl_transceive(struct capi_spi_device *device,
+				  struct capi_spi_transfer *transfer);
+static int capi_spi_pl_transceive_async(struct capi_spi_device *device,
+					struct capi_spi_transfer *transfer, int timeout);
+static int capi_spi_pl_read_command(struct capi_spi_device *device,
+				    struct capi_spi_transfer *transfer);
+static int capi_spi_pl_read_command_async(struct capi_spi_device *device,
+		struct capi_spi_transfer *transfer);
+static int capi_spi_pl_abort_async(struct capi_spi_device *device);
+static int capi_spi_pl_register_callback(struct capi_spi_controller_handle
+		*handle,
+		capi_spi_callback_t const callback, void *callback_arg);
+static int capi_spi_pl_set_cs(struct capi_spi_device *device,
+			      enum capi_spi_cs_control cs);
+static void capi_spi_pl_isr(void *handle);
+static void spi_status_handler(void *callback_ref, u32 status_event,
+			       unsigned int byte_count);
+static void spi_finish_irq(struct capi_spi_xilinx_handle *xh);
+
+const struct capi_spi_ops capi_spi_xilinx_pl_ops = {
+	.init = capi_spi_pl_init,
+	.deinit = capi_spi_pl_deinit,
+	.transceive = capi_spi_pl_transceive,
+	.transceive_async = capi_spi_pl_transceive_async,
+	.read_command = capi_spi_pl_read_command,
+	.read_command_async = capi_spi_pl_read_command_async,
+	.abort_async = capi_spi_pl_abort_async,
+	.register_callback = capi_spi_pl_register_callback,
+	.set_cs = capi_spi_pl_set_cs,
+	.isr = capi_spi_pl_isr,
+};
+
+static XSpi *inst(struct capi_spi_xilinx_handle *xh)
+{
+	return (XSpi *)xh->instance;
+}
+
+static void xilinx_spi_free_allocated_handle(
+	struct capi_spi_controller_handle **handle)
+{
+	if (handle == NULL || *handle == NULL)
+		return;
+
+	capi_free((*handle)->priv);
+	capi_free(*handle);
+	*handle = NULL;
+}
+
+static void xilinx_spi_clear_app_handle(
+	struct capi_spi_controller_handle *handle)
+{
+	if (handle != NULL)
+		handle->ops = NULL;
+}
+
+static int xspi_status_to_errno(int status)
+{
+	if (status == XST_SUCCESS || status == XST_DEVICE_IS_STARTED)
+		return 0;
+
+	if (status == XST_DEVICE_BUSY)
+		return -EBUSY;
+
+	if (status == XST_DEVICE_NOT_FOUND)
+		return -ENODEV;
+
+	if (status == XST_DEVICE_IS_STOPPED)
+		return -EIO;
+
+	if (status == XST_SPI_NO_SLAVE || status == XST_SPI_TOO_MANY_SLAVES)
+		return -EINVAL;
+
+	if (status == XST_SPI_NOT_MASTER || status == XST_SPI_SLAVE_ONLY)
+		return -ENOTSUP;
+
+	return -EIO;
+}
+
+static int gpio_cs_assert(const struct capi_spi_device *device);
+static int gpio_cs_deassert(const struct capi_spi_device *device);
+
+static int pl_async_cleanup(struct capi_spi_xilinx_handle *xh, bool copy_rx)
+{
+	int cs_ret = 0;
+
+	if (copy_rx && xh->async.rx_buffer != NULL &&
+	    xh->async.transfer.rx_buf != NULL && xh->async.transfer.rx_size > 0) {
+		memcpy(xh->async.transfer.rx_buf,
+		       xh->async.rx_buffer + xh->async.rx_offset,
+		       xh->async.transfer.rx_size);
+	}
+	capi_free(xh->async.tx_buffer);
+	capi_free(xh->async.rx_buffer);
+	if (xh->async.gpio_cs_device != NULL) {
+		cs_ret = gpio_cs_deassert(xh->async.gpio_cs_device);
+		xh->async.gpio_cs_device = NULL;
+	} else if (xh->instance != NULL) {
+		(void)XSpi_SetSlaveSelect(inst(xh), XSPI_CAPI_DESELECT_ALL_NATIVE);
+		XSpi_SetSlaveSelectReg(inst(xh), inst(xh)->SlaveSelectReg);
+	}
+	memset(&xh->async, 0, sizeof(xh->async));
+	xh->async_in_progress = false;
+	return cs_ret;
+}
+
+static void spi_status_handler(void *callback_ref, u32 status_event,
+			       unsigned int byte_count)
+{
+	struct capi_spi_xilinx_handle *xh = (struct capi_spi_xilinx_handle *)
+					    callback_ref;
+	(void)byte_count;
+
+	if (xh == NULL)
+		return;
+
+	if (status_event == XST_SPI_RECEIVE_NOT_EMPTY ||
+	    status_event == XST_SPI_SLAVE_MODE)
+		return;
+
+	if (!xh->async_in_progress)
+		return;
+
+	/* An error supersedes a completion reported earlier by the same ISR. */
+	if (!xh->terminal_pending ||
+	    xh->pending_status == XST_SPI_TRANSFER_DONE) {
+		xh->pending_status = status_event;
+		xh->terminal_pending = true;
+	}
+}
+
+static void spi_finish_irq(struct capi_spi_xilinx_handle *xh)
+{
+	if (!xh->terminal_pending)
+		return;
+
+	u32 status_event = xh->pending_status;
+	xh->pending_status = 0;
+	xh->terminal_pending = false;
+
+	if (status_event != XST_SPI_TRANSFER_DONE) {
+		XSpi_IntrGlobalDisable(inst(xh));
+		XSpi_Reset(inst(xh));
+		(void)pl_async_cleanup(xh, false);
+		if (XSpi_Start(inst(xh)) == XST_SUCCESS && !xh->use_irq)
+			XSpi_IntrGlobalDisable(inst(xh));
+		enum capi_async_event evt = CAPI_SPI_EVENT_ERROR;
+		if (status_event == XST_SPI_TRANSMIT_UNDERRUN)
+			evt = CAPI_SPI_EVENT_TX_FIFO_UNDERFLOW;
+		else if (status_event == XST_SPI_RECEIVE_OVERRUN)
+			evt = CAPI_SPI_EVENT_RX_FIFO_OVERFLOW;
+		else if (status_event == XST_SPI_MODE_FAULT ||
+			 status_event == XST_SPI_SLAVE_MODE_FAULT)
+			evt = CAPI_SPI_EVENT_TX_COLLISION;
+
+		if (xh->callback != NULL)
+			xh->callback(evt, xh->callback_arg, status_event);
+		return;
+	}
+
+	int ret = pl_async_cleanup(xh, true);
+	if (xh->callback != NULL) {
+		enum capi_async_event event = (ret == 0) ?
+					      CAPI_SPI_EVENT_XFR_DONE :
+					      CAPI_SPI_EVENT_ERROR;
+		xh->callback(event, xh->callback_arg, ret);
+	}
+}
+
+static int gpio_cs_assert(const struct capi_spi_device *device)
+{
+	for (uint8_t i = 0; i < device->cs_gpio_num; i++) {
+		int ret = capi_gpio_pin_set_value(&device->cs_gpio[i], CAPI_GPIO_HIGH);
+		if (ret != 0) {
+			while (i > 0) {
+				i--;
+				(void)capi_gpio_pin_set_value(&device->cs_gpio[i],
+							      CAPI_GPIO_LOW);
+			}
+			return ret;
+		}
+	}
+	return 0;
+}
+
+static int gpio_cs_deassert(const struct capi_spi_device *device)
+{
+	int first_error = 0;
+
+	for (uint8_t i = 0; i < device->cs_gpio_num; i++) {
+		int ret = capi_gpio_pin_set_value(&device->cs_gpio[i], CAPI_GPIO_LOW);
+		if (ret != 0 && first_error == 0)
+			first_error = ret;
+	}
+	return first_error;
+}
+
+static u32 pl_build_options(struct capi_spi_device *device, bool loopback)
+{
+	u32 options = XSP_MASTER_OPTION | XSP_MANUAL_SSELECT_OPTION;
+	if (device->mode & CAPI_SPI_CPHA)
+		options |= XSP_CLK_PHASE_1_OPTION;
+	if (device->mode & CAPI_SPI_CPOL)
+		options |= XSP_CLK_ACTIVE_LOW_OPTION;
+	if (loopback)
+		options |= XSP_LOOPBACK_OPTION;
+	return options;
+}
+
+static int pl_validate_data_width(struct capi_spi_xilinx_handle *xh)
+{
+	/* CAPI buffers are byte-oriented. */
+	return (inst(xh)->DataWidth == XSP_DATAWIDTH_BYTE) ? 0 : -ENOTSUP;
+}
+
+static int pl_validate_transfer(const struct capi_spi_device *device,
+				const struct capi_spi_transfer *transfer,
+				bool async, bool read_command)
+{
+	if ((device->mode & ~(CAPI_SPI_CPHA | CAPI_SPI_CPOL)) != 0)
+		return -EINVAL;
+	if (device->flow_ctl_param.mode != CAPI_SPI_FLOW_CTL_DISABLE)
+		return -ENOTSUP;
+	if ((device->cs_gpio == NULL) != (device->cs_gpio_num == 0))
+		return -EINVAL;
+	if (device->cs_gpio_num > 0 && device->native_cs != 0)
+		return -EINVAL;
+	if (device->non_continuous_mode) {
+		if (async || read_command || device->cs_gpio_num == 0)
+			return -ENOTSUP;
+	}
+	/* AXI SPI has no runtime SCLK divider. */
+	if (device->max_speed_hz != 0)
+		return -ENOTSUP;
+	if (device->cs_gpio_num == 0) {
+		uint16_t mask = device->native_cs;
+		if (mask == 0U)
+			mask = XSPI_CAPI_DEFAULT_NATIVE_CS_MASK;
+		if ((mask & (mask - 1U)) != 0U)
+			return -EINVAL;
+	}
+	if (transfer->timeout > 0 || transfer->xfer_delay_clk_cycles != 0)
+		return -ENOTSUP;
+	return 0;
+}
+
+static int pl_select_device(struct capi_spi_xilinx_handle *xh,
+			    const struct capi_spi_device *device)
+{
+	u32 mask = XSPI_CAPI_DESELECT_ALL_NATIVE;
+	if (device->cs_gpio_num == 0) {
+		mask = device->native_cs;
+		if (mask == 0U)
+			mask = XSPI_CAPI_DEFAULT_NATIVE_CS_MASK;
+		if ((mask & ~inst(xh)->SlaveSelectMask) != 0U ||
+		    (mask & (mask - 1U)) != 0U)
+			return -EINVAL;
+	}
+	return xspi_status_to_errno(XSpi_SetSlaveSelect(inst(xh), mask));
+}
+
+static int pl_drive_native_cs(struct capi_spi_xilinx_handle *xh,
+			      uint16_t native_cs, bool assert)
+{
+	u32 selected = native_cs;
+	if (selected == 0U)
+		selected = XSPI_CAPI_DEFAULT_NATIVE_CS_MASK;
+	if ((selected & ~inst(xh)->SlaveSelectMask) != 0U ||
+	    (selected & (selected - 1U)) != 0U)
+		return -EINVAL;
+
+	u32 mask = assert ? selected : XSPI_CAPI_DESELECT_ALL_NATIVE;
+	int ret = xspi_status_to_errno(XSpi_SetSlaveSelect(inst(xh), mask));
+	if (ret != 0)
+		return ret;
+	/* XSpi_SetSlaveSelect only updates the cached SSR value. */
+	XSpi_SetSlaveSelectReg(inst(xh), inst(xh)->SlaveSelectReg);
+	return 0;
+}
+
+/* XSpi_SetOptions clears the raw CR; reapply LSB bit after every SetOptions call. */
+static void pl_apply_lsb(XSpi *spi, bool lsb_first)
+{
+	u32 ctrl = XSpi_GetControlReg(spi);
+	if (lsb_first)
+		ctrl |= XSP_CR_LSB_MSB_FIRST_MASK;
+	else
+		ctrl &= ~XSP_CR_LSB_MSB_FIRST_MASK;
+	XSpi_SetControlReg(spi, ctrl);
+}
+
+/**
+ * @brief Initialize the CAPI backend instance.
+ * @note PL: XSpi_Initialize()/XSpi_Start().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_spi_pl_init(struct capi_spi_controller_handle **handle,
+			    const struct capi_spi_config *config)
+{
+	if (handle == NULL || config == NULL)
+		return -EINVAL;
+	if (*handle != NULL &&
+	    ((*handle)->ops != NULL ||
+	     ((*handle)->priv != NULL &&
+	      ((struct capi_spi_xilinx_handle *)(*handle)->priv)->instance != NULL)))
+		return -EBUSY;
+	if (config->three_pin_mode || config->dma_handle != NULL ||
+	    config->clk_freq_hz != 0)
+		return -ENOTSUP;
+
+	bool alloc = (*handle == NULL);
+	struct capi_spi_controller_handle *h = *handle;
+	struct capi_spi_xilinx_handle *xh;
+	XSpi *spi = NULL;
+	int ret;
+
+	if (alloc) {
+		h = capi_malloc(sizeof(*h));
+		if (h == NULL)
+			return -ENOMEM;
+		memset(h, 0, sizeof(*h));
+
+		xh = capi_malloc(sizeof(*xh));
+		if (xh == NULL) {
+			capi_free(h);
+			return -ENOMEM;
+		}
+		h->priv = xh;
+		*handle = h;
+	} else {
+		xh = h->priv;
+		if (xh == NULL)
+			return -EINVAL;
+	}
+
+	memset(xh, 0, sizeof(*xh));
+	h->init_allocated = alloc;
+	h->ops = config->ops ? config->ops : &capi_spi_xilinx_pl_ops;
+	h->priv = xh;
+	xh->loopback = config->loopback;
+
+	spi = capi_malloc(sizeof(XSpi));
+	if (!spi) {
+		ret = -ENOMEM;
+		goto err_handle;
+	}
+	memset(spi, 0, sizeof(XSpi));
+
+	ret = xspi_status_to_errno(XSpi_Initialize(spi,
+				   (UINTPTR)config->identifier));
+	if (ret != 0)
+		goto err_inst;
+
+	XSpi_Reset(spi);
+	xh->instance = spi;
+
+	ret = pl_validate_data_width(xh);
+	if (ret != 0)
+		goto err_inst;
+
+	u32 options = XSP_MASTER_OPTION | XSP_MANUAL_SSELECT_OPTION;
+	if (config->loopback)
+		options |= XSP_LOOPBACK_OPTION;
+	ret = xspi_status_to_errno(XSpi_SetOptions(spi, options));
+	if (ret != 0)
+		goto err_inst;
+
+	XSpi_SetStatusHandler(spi, xh, spi_status_handler);
+	ret = xspi_status_to_errno(XSpi_Start(spi));
+	if (ret != 0)
+		goto err_start;
+	/* XSpi_Start enables DGIER; initialization starts in polled mode. */
+	XSpi_IntrGlobalDisable(spi);
+
+	const struct capi_spi_xilinx_config *xcfg =
+		(const struct capi_spi_xilinx_config *)config->extra;
+	if (xcfg != NULL && xcfg->use_irq) {
+		uint32_t irq_id = xcfg->irq_id;
+		ret = capi_irq_connect(irq_id, capi_spi_pl_isr, h);
+		if (ret == 0) {
+			capi_irq_set_level_edge_trigger(irq_id, CAPI_IRQ_LEVEL_HIGH);
+			ret = capi_irq_enable(irq_id);
+			if (ret == 0) {
+				xh->irq_id = irq_id;
+				xh->use_irq = true;
+				XSpi_IntrGlobalEnable(spi);
+			}
+		}
+	}
+
+	return 0;
+
+err_start:
+	XSpi_IntrGlobalDisable(spi);
+	XSpi_Reset(spi);
+	/* SRR reset does not clear DGIER. */
+	XSpi_WriteReg(spi->BaseAddr, XSP_DGIER_OFFSET, 0);
+err_inst:
+	capi_free(spi);
+	xh->instance = NULL;
+err_handle:
+	if (alloc)
+		xilinx_spi_free_allocated_handle(handle);
+	else
+		xilinx_spi_clear_app_handle(h);
+	return ret;
+}
+
+/**
+ * @brief Deinitialize the CAPI backend instance.
+ * @note PL: XSpi_Reset().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_spi_pl_deinit(struct capi_spi_controller_handle *handle)
+{
+	if (handle == NULL)
+		return -EINVAL;
+
+	struct capi_spi_xilinx_handle *xh = handle->priv;
+	if (xh == NULL)
+		return -EINVAL;
+
+	if (xh->use_irq) {
+		capi_irq_disable(xh->irq_id);
+		xh->use_irq = false;
+	}
+
+	if (xh->instance != NULL) {
+		XSpi_IntrGlobalDisable(inst(xh));
+		XSpi_Reset(inst(xh));
+		(void)pl_async_cleanup(xh, false);
+		XSpi_WriteReg(inst(xh)->BaseAddr, XSP_DGIER_OFFSET, 0);
+		capi_free(xh->instance);
+		xh->instance = NULL;
+	} else {
+		(void)pl_async_cleanup(xh, false);
+	}
+
+	if (handle->init_allocated) {
+		capi_free(xh);
+		capi_free(handle);
+	} else {
+		handle->ops = NULL;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Run a synchronous SPI transceive operation.
+ * @note PL: XSpi_SetSlaveSelect()/XSpi_Transfer().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_spi_pl_transceive(struct capi_spi_device *device,
+				  struct capi_spi_transfer *transfer)
+{
+	if (device == NULL || device->controller == NULL || transfer == NULL)
+		return -EINVAL;
+
+	int ret = pl_validate_transfer(device, transfer, false, false);
+	if (ret != 0)
+		return ret;
+
+	struct capi_spi_xilinx_handle *xh = device->controller->priv;
+	if (xh->async_in_progress || inst(xh)->IsBusy)
+		return -EBUSY;
+
+	ret = pl_validate_data_width(xh);
+	if (ret != 0)
+		return ret;
+
+	uint16_t len =
+		(transfer->tx_size > transfer->rx_size) ? transfer->tx_size : transfer->rx_size;
+	if (len == 0)
+		return -EINVAL;
+
+	bool need_rx_temp = (transfer->rx_buf == NULL) || (transfer->rx_size < len);
+
+	uint8_t *tx = capi_malloc(len);
+	if (!tx)
+		return -ENOMEM;
+	memset(tx, 0, len);
+	if (transfer->tx_buf && transfer->tx_size > 0)
+		memcpy(tx, transfer->tx_buf, transfer->tx_size);
+
+	uint8_t *rx = transfer->rx_buf;
+	if (need_rx_temp) {
+		rx = capi_malloc(len);
+		if (!rx) {
+			capi_free(tx);
+			return -ENOMEM;
+		}
+	}
+
+	ret = xspi_status_to_errno(XSpi_SetOptions(inst(xh),
+				   pl_build_options(device, xh->loopback)));
+	if (ret != 0) {
+		capi_free(tx);
+		if (need_rx_temp)
+			capi_free(rx);
+		return ret;
+	}
+
+	pl_apply_lsb(inst(xh), device->lsb_first);
+
+	bool use_gpio_cs = device->cs_gpio_num > 0;
+	ret = pl_select_device(xh, device);
+	if (ret != 0) {
+		capi_free(tx);
+		if (need_rx_temp)
+			capi_free(rx);
+		return ret;
+	}
+
+	/* DGIER selects the interrupt-driven XSpi_Transfer path. */
+	XSpi_IntrGlobalDisable(inst(xh));
+
+	int status;
+	int gpio_error = 0;
+	if (use_gpio_cs && device->non_continuous_mode) {
+		status = XST_SUCCESS;
+		for (uint16_t i = 0; i < len && status == XST_SUCCESS; i++) {
+			ret = gpio_cs_assert(device);
+			if (ret != 0) {
+				gpio_error = ret;
+				status = XST_FAILURE;
+				break;
+			}
+			status = XSpi_Transfer(inst(xh), tx + i, rx ? rx + i : NULL,
+					       XSPI_CAPI_SINGLE_BYTE_TRANSFER);
+			ret = gpio_cs_deassert(device);
+			if (ret != 0 && status == XST_SUCCESS) {
+				gpio_error = ret;
+				status = XST_FAILURE;
+			}
+		}
+	} else {
+		if (use_gpio_cs) {
+			ret = gpio_cs_assert(device);
+			if (ret != 0) {
+				gpio_error = ret;
+				status = XST_FAILURE;
+			} else {
+				status = XSpi_Transfer(inst(xh), tx, rx, len);
+			}
+			ret = gpio_cs_deassert(device);
+			if (ret != 0 && status == XST_SUCCESS) {
+				gpio_error = ret;
+				status = XST_FAILURE;
+			}
+		} else {
+			status = XSpi_Transfer(inst(xh), tx, rx, len);
+		}
+	}
+
+	/* MANUAL_SSELECT leaves native CS asserted. */
+	if (!use_gpio_cs) {
+		(void)XSpi_SetSlaveSelect(inst(xh), XSPI_CAPI_DESELECT_ALL_NATIVE);
+		XSpi_SetSlaveSelectReg(inst(xh), inst(xh)->SlaveSelectReg);
+	}
+
+	if (xh->use_irq)
+		XSpi_IntrGlobalEnable(inst(xh));
+
+	/* Failed transfers may leave the temporary RX buffer incomplete. */
+	if (status == XST_SUCCESS && need_rx_temp && transfer->rx_buf &&
+	    transfer->rx_size > 0)
+		memcpy(transfer->rx_buf, rx, transfer->rx_size);
+
+	capi_free(tx);
+	if (need_rx_temp)
+		capi_free(rx);
+
+	return (gpio_error != 0) ? gpio_error :
+	       xspi_status_to_errno(status);
+}
+
+/**
+ * @brief Start an asynchronous SPI transceive operation.
+ * @note PL: XSpi_Transfer() in interrupt mode.
+ *
+ * Non-blocking: this arms the hardware and returns immediately. Completion is
+ * reported later from the interrupt path (spi_status_handler ->
+ * pl_async_cleanup), which frees the temp buffers, copies RX back out, and
+ * fires the CAPI callback with XFR_DONE or an error event.
+ *
+ * Flow:
+ *   1. Reject if no IRQ (async needs it) or a transfer is already in flight.
+ *   2. Compute the framed length (max of TX/RX; NULL TX means zeroes) and mark
+ *      async_in_progress so every later error path unwinds via pl_async_cleanup.
+ *   3. Allocate the TX copy (XSpi needs a non-const buffer) and, when the
+ *      caller's RX is absent/too small, a temp RX; both must outlive this call
+ *      and are freed in the ISR completion. rx_offset = 0 (no command prefix).
+ *   4. Apply CAPI mode options (then reapply bit order, which SetOptions clears)
+ *      and select the target (native CS, or assert GPIO CS held until done).
+ *   5. XSpi_IntrGlobalEnable then XSpi_Transfer, which returns after arming
+ *      interrupts; return 0.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_spi_pl_transceive_async(struct capi_spi_device *device,
+					struct capi_spi_transfer *transfer, int timeout)
+{
+	if (device == NULL || device->controller == NULL || transfer == NULL)
+		return -EINVAL;
+
+	int ret = pl_validate_transfer(device, transfer, true, false);
+	if (ret != 0)
+		return ret;
+	if (timeout != 0)
+		return -ENOTSUP;
+
+	struct capi_spi_xilinx_handle *xh = device->controller->priv;
+	if (!xh->use_irq)
+		return -ENOTSUP;
+	if (xh->async_in_progress || inst(xh)->IsBusy)
+		return -EBUSY;
+
+	ret = pl_validate_data_width(xh);
+	if (ret != 0)
+		return ret;
+
+	uint16_t len =
+		(transfer->tx_size > transfer->rx_size) ? transfer->tx_size : transfer->rx_size;
+	if (len == 0)
+		return -EINVAL;
+
+	xh->async_in_progress = true;
+
+	bool need_rx_temp = (transfer->rx_buf == NULL) || (transfer->rx_size < len);
+
+	uint8_t *tx = capi_malloc(len);
+	if (!tx) {
+		xh->async_in_progress = false;
+		return -ENOMEM;
+	}
+	memset(tx, 0, len);
+	if (transfer->tx_buf && transfer->tx_size > 0)
+		memcpy(tx, transfer->tx_buf, transfer->tx_size);
+	xh->async.tx_buffer = tx;
+
+	uint8_t *rx = transfer->rx_buf;
+	if (need_rx_temp) {
+		rx = capi_malloc(len);
+		if (!rx) {
+			capi_free(tx);
+			xh->async.tx_buffer = NULL;
+			xh->async_in_progress = false;
+			return -ENOMEM;
+		}
+		xh->async.rx_buffer = rx;
+		xh->async.transfer.rx_buf = transfer->rx_buf;
+		xh->async.transfer.rx_size = transfer->rx_size;
+	} else {
+		xh->async.rx_buffer = NULL;
+		xh->async.transfer.rx_buf = NULL;
+	}
+	xh->async.rx_offset = 0;
+	xh->async.transfer.rx_size = transfer->rx_size;
+
+	ret = xspi_status_to_errno(XSpi_SetOptions(inst(xh),
+				   pl_build_options(device, xh->loopback)));
+	if (ret != 0) {
+		(void)pl_async_cleanup(xh, false);
+		return ret;
+	}
+
+	pl_apply_lsb(inst(xh), device->lsb_first);
+
+	ret = pl_select_device(xh, device);
+	if (ret != 0) {
+		(void)pl_async_cleanup(xh, false);
+		return ret;
+	}
+
+	if (device->cs_gpio_num > 0) {
+		xh->async.gpio_cs_device = device;
+		ret = gpio_cs_assert(device);
+		if (ret != 0) {
+			(void)pl_async_cleanup(xh, false);
+			return ret;
+		}
+	}
+
+	XSpi_IntrGlobalEnable(inst(xh));
+	ret = xspi_status_to_errno(XSpi_Transfer(inst(xh), tx, rx, len));
+	if (ret != 0) {
+		(void)pl_async_cleanup(xh, false);
+		return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Run a synchronous SPI command-read operation.
+ * @note PL: Command+RX via XSpi_Transfer().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_spi_pl_read_command(struct capi_spi_device *device,
+				    struct capi_spi_transfer *transfer)
+{
+	if (device == NULL || device->controller == NULL || transfer == NULL)
+		return -EINVAL;
+
+	int ret = pl_validate_transfer(device, transfer, false, true);
+	if (ret != 0)
+		return ret;
+
+	struct capi_spi_xilinx_handle *xh = device->controller->priv;
+	if (xh->async_in_progress || inst(xh)->IsBusy)
+		return -EBUSY;
+
+	ret = pl_validate_data_width(xh);
+	if (ret != 0)
+		return ret;
+
+	uint32_t total = (uint32_t)transfer->tx_size + transfer->rx_size;
+	if (total == 0)
+		return 0;	/* Zero-length read command is a successful no-op. */
+	if (total > XSPI_CAPI_MAX_TRANSFER_SIZE)
+		return -EINVAL;
+
+	uint8_t *tx = capi_malloc(total);
+	uint8_t *rx = capi_malloc(total);
+	if (!tx || !rx) {
+		capi_free(tx);
+		capi_free(rx);
+		return -ENOMEM;
+	}
+
+	memset(tx, 0, total);
+	if (transfer->tx_buf && transfer->tx_size > 0)
+		memcpy(tx, transfer->tx_buf, transfer->tx_size);
+
+	ret = xspi_status_to_errno(XSpi_SetOptions(inst(xh),
+				   pl_build_options(device, xh->loopback)));
+	if (ret != 0) {
+		capi_free(tx);
+		capi_free(rx);
+		return ret;
+	}
+
+	pl_apply_lsb(inst(xh), device->lsb_first);
+
+	ret = pl_select_device(xh, device);
+	if (ret != 0) {
+		capi_free(tx);
+		capi_free(rx);
+		return ret;
+	}
+
+	XSpi_IntrGlobalDisable(inst(xh));
+
+	int status;
+	int gpio_error = 0;
+	if (device->cs_gpio_num > 0) {
+		ret = gpio_cs_assert(device);
+		if (ret != 0) {
+			gpio_error = ret;
+			status = XST_FAILURE;
+		} else {
+			status = XSpi_Transfer(inst(xh), tx, rx, total);
+		}
+		ret = gpio_cs_deassert(device);
+		if (ret != 0 && status == XST_SUCCESS) {
+			gpio_error = ret;
+			status = XST_FAILURE;
+		}
+	} else {
+		status = XSpi_Transfer(inst(xh), tx, rx, total);
+	}
+
+	if (device->cs_gpio_num == 0) {
+		(void)XSpi_SetSlaveSelect(inst(xh), XSPI_CAPI_DESELECT_ALL_NATIVE);
+		XSpi_SetSlaveSelectReg(inst(xh), inst(xh)->SlaveSelectReg);
+	}
+
+	if (xh->use_irq)
+		XSpi_IntrGlobalEnable(inst(xh));
+
+	if (status == XST_SUCCESS && transfer->rx_buf && transfer->rx_size > 0)
+		memcpy(transfer->rx_buf, rx + transfer->tx_size, transfer->rx_size);
+
+	capi_free(tx);
+	capi_free(rx);
+	return (gpio_error != 0) ? gpio_error :
+	       xspi_status_to_errno(status);
+}
+
+/**
+ * @brief Start an asynchronous SPI command-read operation.
+ * @note PL: Async command+RX via XSpi_Transfer().
+ *
+ * Non-blocking, same completion path as capi_spi_pl_transceive_async. The only
+ * difference is framing: command/address TX bytes and RX data share one CS
+ * frame, so it builds a single full-duplex buffer of length tx_size + rx_size
+ * (dummy TX clocks the read phase).
+ *
+ * SPI is full-duplex: the controller shifts out one TX byte and latches one RX
+ * byte per clock, so the RX buffer fills for the whole frame, including while
+ * the command bytes are being sent. Those first tx_size RX bytes are just the
+ * bus echo during the command and must be discarded. The temporary buffers and
+ * the offset that does this are held in xh->async (see the async_transfer
+ * struct) so the ISR can finish the copy after this call returns:
+ *
+ *   tx (heap, tx_size+rx_size):  [ cmd bytes | 0 0 0 ... ]  (dummy TX clocks read)
+ *   rx (heap, tx_size+rx_size):  [ echo bytes | real data ]
+ *                                  \_ discard _/ \__ copied out __/
+ *                                  rx_offset = tx_size
+ *
+ * On completion pl_async_cleanup copies rx[rx_offset .. rx_offset+rx_size) into
+ * the caller's transfer->rx_buf, skipping the command-echo bytes. Both heap
+ * buffers must outlive this call (the transfer is interrupt-driven) and are
+ * freed by that same cleanup.
+ *
+ * Flow:
+ *   1. Reject if no IRQ or a transfer is already in flight.
+ *   2. Allocate the combined TX/RX buffers and copy the command bytes into the
+ *      TX prefix (rest of TX stays zero as dummy read clocks).
+ *   3. Save async state (rx_offset = tx_size) and mark async_in_progress so
+ *      every later error path unwinds via pl_async_cleanup.
+ *   4. Apply CAPI mode options (then reapply bit order, which SetOptions clears)
+ *      and select the target (native CS, or assert GPIO CS held until done).
+ *   5. XSpi_IntrGlobalEnable then XSpi_Transfer, which returns after arming
+ *      interrupts; return 0.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_spi_pl_read_command_async(struct capi_spi_device *device,
+		struct capi_spi_transfer *transfer)
+{
+	if (device == NULL || device->controller == NULL || transfer == NULL)
+		return -EINVAL;
+
+	int ret = pl_validate_transfer(device, transfer, true, true);
+	if (ret != 0)
+		return ret;
+
+	uint32_t total32 = (uint32_t)transfer->tx_size + transfer->rx_size;
+	if (total32 > XSPI_CAPI_MAX_TRANSFER_SIZE)
+		return -EINVAL;
+	uint16_t total = (uint16_t)total32;
+	if (total == 0)
+		return -EINVAL;
+
+	struct capi_spi_xilinx_handle *xh = device->controller->priv;
+	if (!xh->use_irq)
+		return -ENOTSUP;
+	if (xh->async_in_progress || inst(xh)->IsBusy)
+		return -EBUSY;
+
+	ret = pl_validate_data_width(xh);
+	if (ret != 0)
+		return ret;
+
+	uint8_t *tx = capi_malloc(total);
+	uint8_t *rx = capi_malloc(total);
+	if (!tx || !rx) {
+		capi_free(tx);
+		capi_free(rx);
+		return -ENOMEM;
+	}
+
+	memset(tx, 0, total);
+	memset(rx, 0, total);
+	if (transfer->tx_buf && transfer->tx_size > 0)
+		memcpy(tx, transfer->tx_buf, transfer->tx_size);
+
+	xh->async.tx_buffer = tx;
+	xh->async.rx_buffer = rx;
+	xh->async.transfer.rx_buf = transfer->rx_buf;
+	xh->async.rx_offset = transfer->tx_size;
+	xh->async.transfer.rx_size = transfer->rx_size;
+	xh->async_in_progress = true;
+
+	ret = xspi_status_to_errno(XSpi_SetOptions(inst(xh),
+				   pl_build_options(device, xh->loopback)));
+	if (ret != 0) {
+		(void)pl_async_cleanup(xh, false);
+		return ret;
+	}
+
+	pl_apply_lsb(inst(xh), device->lsb_first);
+
+	ret = pl_select_device(xh, device);
+	if (ret != 0) {
+		(void)pl_async_cleanup(xh, false);
+		return ret;
+	}
+
+	if (device->cs_gpio_num > 0) {
+		xh->async.gpio_cs_device = device;
+		ret = gpio_cs_assert(device);
+		if (ret != 0) {
+			(void)pl_async_cleanup(xh, false);
+			return ret;
+		}
+	}
+
+	XSpi_IntrGlobalEnable(inst(xh));
+	ret = xspi_status_to_errno(XSpi_Transfer(inst(xh), tx, rx, total));
+	if (ret != 0) {
+		(void)pl_async_cleanup(xh, false);
+		return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Abort an in-progress asynchronous operation.
+ * @note PL: XSpi_Reset()/XSpi_Start().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_spi_pl_abort_async(struct capi_spi_device *device)
+{
+	if (device == NULL || device->controller == NULL)
+		return -EINVAL;
+
+	struct capi_spi_xilinx_handle *xh = device->controller->priv;
+	if (!xh->async_in_progress)
+		return 0;
+
+	XSpi_IntrGlobalDisable(inst(xh));
+	XSpi_Reset(inst(xh));
+	(void)pl_async_cleanup(xh, false);
+	int ret = xspi_status_to_errno(XSpi_Start(inst(xh)));
+	if (ret == XST_SUCCESS && !xh->use_irq)
+		XSpi_IntrGlobalDisable(inst(xh));
+
+	if (xh->callback)
+		xh->callback(CAPI_SPI_EVENT_ERROR, xh->callback_arg, 0);
+
+	return ret;
+}
+
+/**
+ * @brief Register the CAPI asynchronous callback.
+ * @note PL: stores the CAPI callback used by the XSpi event path.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_spi_pl_register_callback(struct capi_spi_controller_handle
+		*handle,
+		capi_spi_callback_t const callback, void *callback_arg)
+{
+	if (handle == NULL)
+		return -EINVAL;
+	struct capi_spi_xilinx_handle *xh = handle->priv;
+	xh->callback = callback;
+	xh->callback_arg = callback_arg;
+	return 0;
+}
+
+/**
+ * @brief Control the SPI chip select line.
+ * @note PL: Manual controls drive GPIO CS logically or the native SSR
+ *       directly; automatic CS is left to the per-transfer path.
+ *
+ * Supports the three CAPI CS controls:
+ *   CAPI_SPI_CS_AUTO           - the transfer functions already assert CS at
+ *                                the start of each frame and release it at the
+ *                                end, so automatic CS needs no standing action
+ *                                here; accepted as a no-op.
+ *   CAPI_SPI_CS_MANUAL_ASSERT  - drive CS active outside of a transfer.
+ *   CAPI_SPI_CS_MANUAL_DEASSERT- drive CS inactive outside of a transfer.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_spi_pl_set_cs(struct capi_spi_device *device,
+			      enum capi_spi_cs_control cs)
+{
+	if (device == NULL || device->controller == NULL)
+		return -EINVAL;
+	struct capi_spi_xilinx_handle *xh = device->controller->priv;
+	if (xh->async_in_progress || inst(xh)->IsBusy)
+		return -EBUSY;
+
+	if ((device->cs_gpio == NULL) != (device->cs_gpio_num == 0))
+		return -EINVAL;
+	if (device->cs_gpio_num > 0 && device->native_cs != 0)
+		return -EINVAL;
+
+	if (cs == CAPI_SPI_CS_AUTO)
+		return 0;
+
+	if (device->cs_gpio_num > 0) {
+		if (cs == CAPI_SPI_CS_MANUAL_ASSERT)
+			return gpio_cs_assert(device);
+		else if (cs == CAPI_SPI_CS_MANUAL_DEASSERT)
+			return gpio_cs_deassert(device);
+		else
+			return -EINVAL;
+	}
+
+	if (cs == CAPI_SPI_CS_MANUAL_ASSERT)
+		return pl_drive_native_cs(xh, device->native_cs, true);
+	else if (cs == CAPI_SPI_CS_MANUAL_DEASSERT)
+		return pl_drive_native_cs(xh, device->native_cs, false);
+	return -EINVAL;
+}
+
+/**
+ * @brief Dispatch the backend interrupt handler.
+ * @note PL: XSpi_InterruptHandler().
+ *
+ */
+static void capi_spi_pl_isr(void *handle)
+{
+	if (handle == NULL)
+		return;
+	struct capi_spi_xilinx_handle *xh = ((struct capi_spi_controller_handle *)
+					     handle)->priv;
+	XSpi_InterruptHandler(inst(xh));
+	spi_finish_irq(xh);
+}
+
+#endif /* XPAR_XSPI_NUM_INSTANCES */

--- a/capi/platform/xilinx/xilinx_capi_spi_priv.h
+++ b/capi/platform/xilinx/xilinx_capi_spi_priv.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Xilinx platform SPI private driver contract.
+ */
+
+#ifndef _XILINX_CAPI_SPI_PRIV_H_
+#define _XILINX_CAPI_SPI_PRIV_H_
+
+#include <xilinx_capi_spi.h>
+
+#include "xparameters.h"
+#ifdef XPAR_XSPIPS_NUM_INSTANCES
+#include "xspips.h"
+#include "xspips_hw.h"
+#endif
+#ifdef XPAR_XSPI_NUM_INSTANCES
+#include "xspi.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @struct capi_spi_xilinx_async_transfer
+ * @brief In-flight async state retained between the API call and the ISR.
+ */
+struct capi_spi_xilinx_async_transfer {
+	/** Heap-allocated TX buffer kept alive until the ISR fires */
+	uint8_t *tx_buffer;
+	/** Heap-allocated RX buffer kept alive until the ISR fires */
+	uint8_t *rx_buffer;
+	/** Byte offset into rx_buffer where real data starts */
+	uint16_t rx_offset;
+	/** Device pointer held for GPIO CS deassert in the ISR or on abort */
+	const struct capi_spi_device *gpio_cs_device;
+	/** Copy of the caller's transfer descriptor for ISR-side completion */
+	struct capi_spi_transfer transfer;
+};
+
+/**
+ * @struct capi_spi_xilinx_handle
+ * @brief Shared Xilinx SPI private controller state.
+ */
+struct capi_spi_xilinx_handle {
+	/** Xilinx driver instance (XSpiPs* or XSpi*) */
+	void *instance;
+	/** Loopback mode enabled (PL only; used when rebuilding options per transfer) */
+	bool loopback;
+	/** User callback for async operations */
+	capi_spi_callback_t callback;
+	/** User callback argument */
+	void *callback_arg;
+	/** IRQ ID (only valid if use_irq is true) */
+	uint32_t irq_id;
+	/** True if IRQ was successfully connected during init */
+	bool use_irq;
+	/** True while an async transfer is in flight */
+	volatile bool async_in_progress;
+	/** Terminal Xilinx status collected during the current ISR dispatch */
+	uint32_t pending_status;
+	/** True when pending_status must be completed after the vendor ISR returns */
+	bool terminal_pending;
+	/** Resources held between the async API call and ISR completion */
+	struct capi_spi_xilinx_async_transfer async;
+};
+
+/**
+ * @brief Declare a stack-allocated Xilinx SPI controller handle.
+ *
+ * Declares `name` (struct capi_spi_controller_handle) with embedded
+ * private state. Pass &name to capi_spi_init().
+ */
+#define CAPI_SPI_HANDLE_XILINX_DEFINE(name)                            \
+	struct capi_spi_controller_handle name = {                         \
+		.ops = NULL,                                                   \
+		.init_allocated = false,                                       \
+		.priv = &(struct capi_spi_xilinx_handle){0}                    \
+	}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _XILINX_CAPI_SPI_PRIV_H_ */

--- a/capi/platform/xilinx/xilinx_capi_spi_ps.c
+++ b/capi/platform/xilinx/xilinx_capi_spi_ps.c
@@ -1,0 +1,1097 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Xilinx XSpiPs SPI driver (Zynq PS SPI, master mode only)
+ *
+ * SDT BSP only. IRQ is explicit via capi_spi_xilinx_config.
+ * capi_irq_init() must be called before async ops will work.
+ */
+
+#include <capi_alloc.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <errno.h>
+#include <string.h>
+#include <capi_spi.h>
+#include <xilinx_capi_spi_priv.h>
+#include <capi_gpio.h>
+#include "capi_irq.h"
+#include "xinterrupt_wrap.h"
+
+#ifdef XPAR_XSPIPS_NUM_INSTANCES
+
+/* native_cs == 0 selects CS0. */
+#define XSPIPS_CAPI_DEFAULT_NATIVE_CS_MASK	1U
+#define XSPIPS_CAPI_LAST_NATIVE_CS_MASK		0x04U
+#define XSPIPS_CAPI_DESELECT_ALL_NATIVE		0x0FU
+#define XSPIPS_CAPI_SINGLE_BYTE_TRANSFER	1U
+#define XSPIPS_CAPI_RX_DRAIN_LIMIT		128U
+#define XSPIPS_CAPI_MAX_TRANSFER_SIZE		UINT16_MAX
+#define XSPIPS_CAPI_PRESCALER_EXP_OFFSET	1U
+
+static int capi_spi_ps_init(struct capi_spi_controller_handle **handle,
+			    const struct capi_spi_config *config);
+static int capi_spi_ps_deinit(struct capi_spi_controller_handle *handle);
+static int capi_spi_ps_transceive(struct capi_spi_device *device,
+				  struct capi_spi_transfer *transfer);
+static int capi_spi_ps_transceive_async(struct capi_spi_device *device,
+					struct capi_spi_transfer *transfer, int timeout);
+static int capi_spi_ps_read_command(struct capi_spi_device *device,
+				    struct capi_spi_transfer *transfer);
+static int capi_spi_ps_read_command_async(struct capi_spi_device *device,
+		struct capi_spi_transfer *transfer);
+static int capi_spi_ps_abort_async(struct capi_spi_device *device);
+static int capi_spi_ps_register_callback(struct capi_spi_controller_handle
+		*handle,
+		capi_spi_callback_t const callback, void *callback_arg);
+static int capi_spi_ps_set_cs(struct capi_spi_device *device,
+			      enum capi_spi_cs_control cs);
+static void capi_spi_ps_isr(void *handle);
+static void spips_status_handler(const void *callback_ref, u32 status_event,
+				 u32 byte_count);
+static void spips_finish_irq(struct capi_spi_xilinx_handle *xh);
+
+const struct capi_spi_ops capi_spi_xilinx_ps_ops = {
+	.init = capi_spi_ps_init,
+	.deinit = capi_spi_ps_deinit,
+	.transceive = capi_spi_ps_transceive,
+	.transceive_async = capi_spi_ps_transceive_async,
+	.read_command = capi_spi_ps_read_command,
+	.read_command_async = capi_spi_ps_read_command_async,
+	.abort_async = capi_spi_ps_abort_async,
+	.register_callback = capi_spi_ps_register_callback,
+	.set_cs = capi_spi_ps_set_cs,
+	.isr = capi_spi_ps_isr,
+};
+
+static XSpiPs *inst(struct capi_spi_xilinx_handle *xh)
+{
+	return (XSpiPs *)xh->instance;
+}
+
+static void xilinx_spi_free_allocated_handle(
+	struct capi_spi_controller_handle **handle)
+{
+	if (handle == NULL || *handle == NULL)
+		return;
+
+	capi_free((*handle)->priv);
+	capi_free(*handle);
+	*handle = NULL;
+}
+
+static void xilinx_spi_clear_app_handle(
+	struct capi_spi_controller_handle *handle)
+{
+	if (handle != NULL)
+		handle->ops = NULL;
+}
+
+static int spips_status_to_errno(int status)
+{
+	if (status == XST_SUCCESS)
+		return 0;
+
+	if (status == XST_DEVICE_BUSY)
+		return -EBUSY;
+
+	if (status == XST_DEVICE_NOT_FOUND)
+		return -ENODEV;
+
+	if (status == XST_SPI_NO_SLAVE || status == XST_SPI_TOO_MANY_SLAVES)
+		return -EINVAL;
+
+	if (status == XST_SPI_NOT_MASTER || status == XST_SPI_SLAVE_ONLY)
+		return -ENOTSUP;
+
+	return -EIO;
+}
+
+static int gpio_cs_assert(const struct capi_spi_device *device)
+{
+	for (uint8_t i = 0; i < device->cs_gpio_num; i++) {
+		int ret = capi_gpio_pin_set_value(&device->cs_gpio[i], CAPI_GPIO_HIGH);
+		if (ret != 0) {
+			while (i > 0) {
+				i--;
+				(void)capi_gpio_pin_set_value(&device->cs_gpio[i],
+							      CAPI_GPIO_LOW);
+			}
+			return ret;
+		}
+	}
+	return 0;
+}
+
+static int gpio_cs_deassert(const struct capi_spi_device *device)
+{
+	int first_error = 0;
+
+	for (uint8_t i = 0; i < device->cs_gpio_num; i++) {
+		int ret = capi_gpio_pin_set_value(&device->cs_gpio[i], CAPI_GPIO_LOW);
+		if (ret != 0 && first_error == 0)
+			first_error = ret;
+	}
+	return first_error;
+}
+
+static u8 spips_calc_prescaler(u32 input_clk_hz, u32 desired_hz)
+{
+	if (desired_hz == 0 || input_clk_hz == 0)
+		return XSPIPS_CLK_PRESCALE_64;
+
+	u8 prescale;
+	for (prescale = XSPIPS_CLK_PRESCALE_4; prescale <= XSPIPS_CLK_PRESCALE_256;
+	     prescale++) {
+		u32 actual_hz =
+			input_clk_hz / (1U << (prescale + XSPIPS_CAPI_PRESCALER_EXP_OFFSET));
+		if (actual_hz <= desired_hz)
+			return prescale;
+	}
+	return XSPIPS_CLK_PRESCALE_256;
+}
+
+static int spips_set_frequency(XSpiPs *spi, u32 desired_hz)
+{
+	if (desired_hz == 0)
+		return 0;
+	if (spi->Config.InputClockHz == 0)
+		return -ENOTSUP;
+
+	u8 prescale = spips_calc_prescaler(spi->Config.InputClockHz, desired_hz);
+	u32 actual_hz =
+		spi->Config.InputClockHz /
+		(1U << (prescale + XSPIPS_CAPI_PRESCALER_EXP_OFFSET));
+	if (actual_hz > desired_hz)
+		return -ENOTSUP;
+
+	return spips_status_to_errno(XSpiPs_SetClkPrescaler(spi, prescale));
+}
+
+static int ps_cs_to_index(uint16_t native_cs, u8 *index)
+{
+	uint16_t mask = native_cs;
+	if (mask == 0U)
+		mask = XSPIPS_CAPI_DEFAULT_NATIVE_CS_MASK;
+
+	if (index == NULL || mask > XSPIPS_CAPI_LAST_NATIVE_CS_MASK ||
+	    (mask & (mask - 1U)) != 0U)
+		return -EINVAL;
+
+	u8 idx = 0;
+	while (mask > XSPIPS_CAPI_DEFAULT_NATIVE_CS_MASK) {
+		mask >>= 1;
+		idx++;
+	}
+	*index = idx;
+	return 0;
+}
+
+static int ps_validate_transfer(const struct capi_spi_device *device,
+				const struct capi_spi_transfer *transfer,
+				bool async, bool read_command)
+{
+	if (device->lsb_first)
+		return -ENOTSUP;
+	if ((device->mode & ~(CAPI_SPI_CPHA | CAPI_SPI_CPOL)) != 0)
+		return -EINVAL;
+	if (device->flow_ctl_param.mode != CAPI_SPI_FLOW_CTL_DISABLE)
+		return -ENOTSUP;
+	if ((device->cs_gpio == NULL) != (device->cs_gpio_num == 0))
+		return -EINVAL;
+	if (device->cs_gpio_num > 0 && device->native_cs != 0)
+		return -EINVAL;
+	if (device->non_continuous_mode) {
+		if (async || read_command || device->cs_gpio_num == 0)
+			return -ENOTSUP;
+	}
+	if (device->cs_gpio_num == 0) {
+		u8 index;
+		int ret = ps_cs_to_index(device->native_cs, &index);
+		if (ret != 0)
+			return ret;
+	}
+	if (transfer->timeout > 0 || transfer->xfer_delay_clk_cycles != 0)
+		return -ENOTSUP;
+	return 0;
+}
+
+static int ps_select_device(struct capi_spi_xilinx_handle *xh,
+			    const struct capi_spi_device *device)
+{
+	u8 index = XSPIPS_CAPI_DESELECT_ALL_NATIVE;
+	if (device->cs_gpio_num == 0) {
+		int ret = ps_cs_to_index(device->native_cs, &index);
+		if (ret != 0)
+			return ret;
+	}
+	return spips_status_to_errno(XSpiPs_SetSlaveSelect(inst(xh), index));
+}
+
+static int ps_drive_native_cs(struct capi_spi_xilinx_handle *xh,
+			      uint16_t native_cs, bool assert)
+{
+	u8 selected;
+	int ret = ps_cs_to_index(native_cs, &selected);
+	if (ret != 0)
+		return ret;
+
+	u8 index = assert ? selected : XSPIPS_CAPI_DESELECT_ALL_NATIVE;
+	ret = spips_status_to_errno(XSpiPs_SetSlaveSelect(inst(xh), index));
+	if (ret != 0)
+		return ret;
+
+	u32 config = XSpiPs_ReadReg(inst(xh)->Config.BaseAddress, XSPIPS_CR_OFFSET);
+	config &= ~XSPIPS_CR_SSCTRL_MASK;
+	config |= inst(xh)->SlaveSelect;
+	XSpiPs_WriteReg(inst(xh)->Config.BaseAddress, XSPIPS_CR_OFFSET, config);
+	if (assert)
+		XSpiPs_Enable(inst(xh));
+	else
+		XSpiPs_Disable(inst(xh));
+	return 0;
+}
+
+static void ps_deselect_native(struct capi_spi_xilinx_handle *xh)
+{
+	(void)XSpiPs_SetSlaveSelect(inst(xh), XSPIPS_CAPI_DESELECT_ALL_NATIVE);
+	u32 config = XSpiPs_ReadReg(inst(xh)->Config.BaseAddress, XSPIPS_CR_OFFSET);
+	config |= XSPIPS_CR_SSCTRL_MASK;
+	XSpiPs_WriteReg(inst(xh)->Config.BaseAddress, XSPIPS_CR_OFFSET, config);
+	XSpiPs_Disable(inst(xh));
+}
+
+static int ps_async_cleanup(struct capi_spi_xilinx_handle *xh, bool copy_rx)
+{
+	int cs_ret = 0;
+
+	if (copy_rx && xh->async.rx_buffer != NULL &&
+	    xh->async.transfer.rx_buf != NULL && xh->async.transfer.rx_size > 0) {
+		memcpy(xh->async.transfer.rx_buf,
+		       xh->async.rx_buffer + xh->async.rx_offset,
+		       xh->async.transfer.rx_size);
+	}
+	capi_free(xh->async.tx_buffer);
+	capi_free(xh->async.rx_buffer);
+	if (xh->async.gpio_cs_device != NULL) {
+		cs_ret = gpio_cs_deassert(xh->async.gpio_cs_device);
+		xh->async.gpio_cs_device = NULL;
+	} else if (xh->instance != NULL) {
+		ps_deselect_native(xh);
+	}
+	memset(&xh->async, 0, sizeof(xh->async));
+	xh->async_in_progress = false;
+	return cs_ret;
+}
+
+static void spips_status_handler(const void *callback_ref, u32 status_event,
+				 u32 byte_count)
+{
+	struct capi_spi_xilinx_handle *xh =
+		(struct capi_spi_xilinx_handle *)(uintptr_t)callback_ref;
+	(void)byte_count;
+
+	if (xh == NULL)
+		return;
+
+	if (!xh->async_in_progress)
+		return;
+
+	/* An error supersedes a completion reported earlier by the same ISR. */
+	if (!xh->terminal_pending ||
+	    xh->pending_status == XST_SPI_TRANSFER_DONE) {
+		xh->pending_status = status_event;
+		xh->terminal_pending = true;
+	}
+}
+
+static void spips_finish_irq(struct capi_spi_xilinx_handle *xh)
+{
+	if (!xh->terminal_pending)
+		return;
+
+	u32 status_event = xh->pending_status;
+	xh->pending_status = 0;
+	xh->terminal_pending = false;
+
+	if (status_event != XST_SPI_TRANSFER_DONE) {
+		XSpiPs_WriteReg(inst(xh)->Config.BaseAddress, XSPIPS_IDR_OFFSET,
+				XSPIPS_IXR_DISABLE_ALL_MASK);
+		XSpiPs_Abort(inst(xh));
+		(void)ps_async_cleanup(xh, false);
+		enum capi_async_event evt = CAPI_SPI_EVENT_ERROR;
+		if (status_event == XST_SPI_TRANSMIT_UNDERRUN)
+			evt = CAPI_SPI_EVENT_TX_FIFO_UNDERFLOW;
+		else if (status_event == XST_SPI_RECEIVE_OVERRUN)
+			evt = CAPI_SPI_EVENT_RX_FIFO_OVERFLOW;
+		else if (status_event == XST_SPI_MODE_FAULT ||
+			 status_event == XST_SPI_SLAVE_MODE_FAULT)
+			evt = CAPI_SPI_EVENT_TX_COLLISION;
+
+		if (xh->callback != NULL)
+			xh->callback(evt, xh->callback_arg, status_event);
+		return;
+	}
+
+	int ret = ps_async_cleanup(xh, true);
+	if (xh->callback != NULL) {
+		enum capi_async_event event = (ret == 0) ?
+					      CAPI_SPI_EVENT_XFR_DONE :
+					      CAPI_SPI_EVENT_ERROR;
+		xh->callback(event, xh->callback_arg, ret);
+	}
+}
+
+/**
+ * @brief Initialize the CAPI backend instance.
+ * @note PS: XSpiPs_LookupConfig()/XSpiPs_CfgInitialize().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_spi_ps_init(struct capi_spi_controller_handle **handle,
+			    const struct capi_spi_config *config)
+{
+	if (handle == NULL || config == NULL)
+		return -EINVAL;
+	if (*handle != NULL &&
+	    ((*handle)->ops != NULL ||
+	     ((*handle)->priv != NULL &&
+	      ((struct capi_spi_xilinx_handle *)(*handle)->priv)->instance != NULL)))
+		return -EBUSY;
+	if (config->three_pin_mode || config->loopback ||
+	    config->dma_handle != NULL)
+		return -ENOTSUP;
+
+	bool alloc = (*handle == NULL);
+	struct capi_spi_controller_handle *h = *handle;
+	struct capi_spi_xilinx_handle *xh;
+	XSpiPs *ps = NULL;
+	int ret;
+
+	if (alloc) {
+		h = capi_malloc(sizeof(*h));
+		if (h == NULL)
+			return -ENOMEM;
+		memset(h, 0, sizeof(*h));
+
+		xh = capi_malloc(sizeof(*xh));
+		if (xh == NULL) {
+			capi_free(h);
+			return -ENOMEM;
+		}
+		h->priv = xh;
+		*handle = h;
+	} else {
+		xh = h->priv;
+		if (xh == NULL)
+			return -EINVAL;
+	}
+
+	memset(xh, 0, sizeof(*xh));
+	h->init_allocated = alloc;
+	h->ops = config->ops ? config->ops : &capi_spi_xilinx_ps_ops;
+	h->priv = xh;
+	xh->loopback = config->loopback;
+
+	XSpiPs_Config *cfg = XSpiPs_LookupConfig((UINTPTR)config->identifier);
+	if (cfg == NULL) {
+		ret = -ENODEV;
+		goto err_handle;
+	}
+
+	ps = capi_malloc(sizeof(XSpiPs));
+	if (ps == NULL) {
+		ret = -ENOMEM;
+		goto err_handle;
+	}
+	memset(ps, 0, sizeof(XSpiPs));
+
+	ret = spips_status_to_errno(XSpiPs_CfgInitialize(ps, cfg,
+				    cfg->BaseAddress));
+	if (ret != 0)
+		goto err_inst;
+
+	XSpiPs_Reset(ps);
+	xh->instance = ps;
+
+	u32 options = XSPIPS_MASTER_OPTION | XSPIPS_FORCE_SSELECT_OPTION;
+	ret = spips_status_to_errno(XSpiPs_SetOptions(ps, options));
+	if (ret != 0)
+		goto err_inst;
+
+	/* clk_freq_hz is the reference clock; max_speed_hz selects SCLK. */
+	if (config->clk_freq_hz != 0)
+		ps->Config.InputClockHz = config->clk_freq_hz;
+	ret = spips_status_to_errno(XSpiPs_SetClkPrescaler(ps,
+				    XSPIPS_CLK_PRESCALE_64));
+	if (ret != 0)
+		goto err_inst;
+
+	XSpiPs_SetStatusHandler(ps, xh, spips_status_handler);
+
+	const struct capi_spi_xilinx_config *xcfg =
+		(const struct capi_spi_xilinx_config *)config->extra;
+	if (xcfg != NULL && xcfg->use_irq) {
+		uint32_t irq_id = xcfg->irq_id;
+		ret = capi_irq_connect(irq_id, capi_spi_ps_isr, h);
+		if (ret == 0) {
+			capi_irq_set_level_edge_trigger(irq_id, CAPI_IRQ_LEVEL_HIGH);
+			ret = capi_irq_enable(irq_id);
+			if (ret == 0) {
+				xh->irq_id = irq_id;
+				xh->use_irq = true;
+			}
+		}
+	}
+
+	return 0;
+
+err_inst:
+	capi_free(ps);
+	xh->instance = NULL;
+err_handle:
+	if (alloc)
+		xilinx_spi_free_allocated_handle(handle);
+	else
+		xilinx_spi_clear_app_handle(h);
+	return ret;
+}
+
+/**
+ * @brief Deinitialize the CAPI backend instance.
+ * @note PS: XSpiPs_Abort()/XSpiPs_Disable().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_spi_ps_deinit(struct capi_spi_controller_handle *handle)
+{
+	if (handle == NULL)
+		return -EINVAL;
+
+	struct capi_spi_xilinx_handle *xh = handle->priv;
+	if (xh == NULL)
+		return -EINVAL;
+
+	if (xh->use_irq) {
+		capi_irq_disable(xh->irq_id);
+		xh->use_irq = false;
+	}
+
+	if (xh->instance != NULL) {
+		if (xh->async_in_progress || inst(xh)->IsBusy)
+			XSpiPs_Abort(inst(xh));
+		(void)ps_async_cleanup(xh, false);
+		XSpiPs_Disable(inst(xh));
+		XSpiPs_WriteReg(inst(xh)->Config.BaseAddress, XSPIPS_IDR_OFFSET,
+				XSPIPS_IXR_DISABLE_ALL_MASK);
+		XSpiPs_WriteReg(inst(xh)->Config.BaseAddress, XSPIPS_SR_OFFSET,
+				XSPIPS_IXR_WR_TO_CLR_MASK);
+		for (uint32_t i = 0; i < XSPIPS_CAPI_RX_DRAIN_LIMIT; i++) {
+			if (!(XSpiPs_ReadReg(inst(xh)->Config.BaseAddress, XSPIPS_SR_OFFSET) &
+			      XSPIPS_IXR_RXNEMPTY_MASK))
+				break;
+			(void)XSpiPs_ReadReg(inst(xh)->Config.BaseAddress, XSPIPS_RXD_OFFSET);
+		}
+		XSpiPs_Reset(inst(xh));
+		capi_free(xh->instance);
+		xh->instance = NULL;
+	} else {
+		(void)ps_async_cleanup(xh, false);
+	}
+
+	if (handle->init_allocated) {
+		capi_free(xh);
+		capi_free(handle);
+	} else {
+		handle->ops = NULL;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Run a synchronous SPI transceive operation.
+ * @note PS: XSpiPs_SetSlaveSelect()/XSpiPs_PolledTransfer().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_spi_ps_transceive(struct capi_spi_device *device,
+				  struct capi_spi_transfer *transfer)
+{
+	if (device == NULL || device->controller == NULL || transfer == NULL)
+		return -EINVAL;
+
+	int ret = ps_validate_transfer(device, transfer, false, false);
+	if (ret != 0)
+		return ret;
+
+	struct capi_spi_xilinx_handle *xh = device->controller->priv;
+	if (xh->async_in_progress || inst(xh)->IsBusy)
+		return -EBUSY;
+
+	uint16_t len =
+		(transfer->tx_size > transfer->rx_size) ? transfer->tx_size : transfer->rx_size;
+	if (len == 0)
+		return -EINVAL;
+
+	bool need_rx_temp = (transfer->rx_buf == NULL) || (transfer->rx_size < len);
+
+	uint8_t *tx = capi_malloc(len);
+	if (!tx)
+		return -ENOMEM;
+	memset(tx, 0, len);
+	if (transfer->tx_buf && transfer->tx_size > 0)
+		memcpy(tx, transfer->tx_buf, transfer->tx_size);
+
+	uint8_t *rx = transfer->rx_buf;
+	if (need_rx_temp) {
+		rx = capi_malloc(len);
+		if (!rx) {
+			capi_free(tx);
+			return -ENOMEM;
+		}
+	}
+
+	u32 options = XSPIPS_MASTER_OPTION | XSPIPS_FORCE_SSELECT_OPTION;
+	if (device->mode & CAPI_SPI_CPHA)
+		options |= XSPIPS_CLK_PHASE_1_OPTION;
+	if (device->mode & CAPI_SPI_CPOL)
+		options |= XSPIPS_CLK_ACTIVE_LOW_OPTION;
+	ret = spips_status_to_errno(XSpiPs_SetOptions(inst(xh), options));
+	if (ret != 0) {
+		capi_free(tx);
+		if (need_rx_temp)
+			capi_free(rx);
+		return ret;
+	}
+
+	ret = spips_set_frequency(inst(xh), device->max_speed_hz);
+	if (ret != 0) {
+		capi_free(tx);
+		if (need_rx_temp)
+			capi_free(rx);
+		return ret;
+	}
+
+	bool use_gpio_cs = device->cs_gpio_num > 0;
+	ret = ps_select_device(xh, device);
+	if (ret != 0) {
+		capi_free(tx);
+		if (need_rx_temp)
+			capi_free(rx);
+		return ret;
+	}
+
+	XSpiPs_WriteReg(inst(xh)->Config.BaseAddress, XSPIPS_IDR_OFFSET,
+			XSPIPS_IXR_DISABLE_ALL_MASK);
+
+	int status;
+	int gpio_error = 0;
+	if (use_gpio_cs && device->non_continuous_mode) {
+		status = XST_SUCCESS;
+		for (uint16_t i = 0; i < len && status == XST_SUCCESS; i++) {
+			ret = gpio_cs_assert(device);
+			if (ret != 0) {
+				gpio_error = ret;
+				status = XST_FAILURE;
+				break;
+			}
+			status = XSpiPs_PolledTransfer(inst(xh), tx + i, rx ? rx + i : NULL,
+						       XSPIPS_CAPI_SINGLE_BYTE_TRANSFER);
+			ret = gpio_cs_deassert(device);
+			if (ret != 0 && status == XST_SUCCESS) {
+				gpio_error = ret;
+				status = XST_FAILURE;
+			}
+		}
+	} else {
+		if (use_gpio_cs) {
+			ret = gpio_cs_assert(device);
+			if (ret != 0) {
+				gpio_error = ret;
+				status = XST_FAILURE;
+			} else {
+				status = XSpiPs_PolledTransfer(inst(xh), tx, rx, len);
+			}
+			ret = gpio_cs_deassert(device);
+			if (ret != 0 && status == XST_SUCCESS) {
+				gpio_error = ret;
+				status = XST_FAILURE;
+			}
+		} else {
+			status = XSpiPs_PolledTransfer(inst(xh), tx, rx, len);
+		}
+	}
+
+	if (status != XST_SUCCESS)
+		XSpiPs_Abort(inst(xh));
+	if (!use_gpio_cs)
+		ps_deselect_native(xh);
+
+	/* Failed transfers may leave the temporary RX buffer incomplete. */
+	if (status == XST_SUCCESS && need_rx_temp && transfer->rx_buf &&
+	    transfer->rx_size > 0)
+		memcpy(transfer->rx_buf, rx, transfer->rx_size);
+
+	capi_free(tx);
+	if (need_rx_temp)
+		capi_free(rx);
+
+	return (gpio_error != 0) ? gpio_error :
+	       spips_status_to_errno(status);
+}
+
+/**
+ * @brief Start an asynchronous SPI transceive operation.
+ * @note PS: XSpiPs_Transfer() plus IRQ enable.
+ *
+ * Non-blocking: this arms the hardware and returns immediately. Completion is
+ * reported later from the interrupt path (spips_status_handler ->
+ * ps_async_cleanup), which frees the temp buffers, copies RX back out, and
+ * fires the CAPI callback with XFR_DONE or an error event.
+ *
+ * Flow:
+ *   1. Reject if no IRQ (async needs it) or a transfer is already in flight.
+ *   2. Compute the framed length (max of TX/RX; NULL TX means zeroes) and mark
+ *      async_in_progress so every later error path unwinds via ps_async_cleanup.
+ *   3. Allocate the TX copy (XSpiPs needs a non-const buffer) and, when the
+ *      caller's RX is absent/too small, a temp RX; both must outlive this call
+ *      and are freed in the ISR completion.
+ *   4. Apply CAPI mode options and per-device speed, then select the target
+ *      (native CS, or assert GPIO CS and keep it held until completion).
+ *   5. Kick XSpiPs_Transfer, which arms interrupts and returns; return 0.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_spi_ps_transceive_async(struct capi_spi_device *device,
+					struct capi_spi_transfer *transfer, int timeout)
+{
+	if (device == NULL || device->controller == NULL || transfer == NULL)
+		return -EINVAL;
+
+	int ret = ps_validate_transfer(device, transfer, true, false);
+	if (ret != 0)
+		return ret;
+	if (timeout != 0)
+		return -ENOTSUP;
+
+	struct capi_spi_xilinx_handle *xh = device->controller->priv;
+	if (!xh->use_irq)
+		return -ENOTSUP;
+	if (xh->async_in_progress || inst(xh)->IsBusy)
+		return -EBUSY;
+
+	uint16_t len =
+		(transfer->tx_size > transfer->rx_size) ? transfer->tx_size : transfer->rx_size;
+	if (len == 0)
+		return -EINVAL;
+
+	xh->async_in_progress = true;
+
+	bool need_rx_temp = (transfer->rx_buf == NULL) || (transfer->rx_size < len);
+
+	uint8_t *tx = capi_malloc(len);
+	if (!tx) {
+		xh->async_in_progress = false;
+		return -ENOMEM;
+	}
+	memset(tx, 0, len);
+	if (transfer->tx_buf && transfer->tx_size > 0)
+		memcpy(tx, transfer->tx_buf, transfer->tx_size);
+	xh->async.tx_buffer = tx;
+
+	uint8_t *rx = transfer->rx_buf;
+	if (need_rx_temp) {
+		rx = capi_malloc(len);
+		if (!rx) {
+			capi_free(tx);
+			xh->async.tx_buffer = NULL;
+			xh->async_in_progress = false;
+			return -ENOMEM;
+		}
+		xh->async.rx_buffer = rx;
+		xh->async.transfer.rx_buf = transfer->rx_buf;
+		xh->async.transfer.rx_size = transfer->rx_size;
+	} else {
+		xh->async.rx_buffer = NULL;
+		xh->async.transfer.rx_buf = NULL;
+	}
+	xh->async.rx_offset = 0;
+	xh->async.transfer.rx_size = transfer->rx_size;
+
+	u32 options = XSPIPS_MASTER_OPTION | XSPIPS_FORCE_SSELECT_OPTION;
+	if (device->mode & CAPI_SPI_CPHA)
+		options |= XSPIPS_CLK_PHASE_1_OPTION;
+	if (device->mode & CAPI_SPI_CPOL)
+		options |= XSPIPS_CLK_ACTIVE_LOW_OPTION;
+	ret = spips_status_to_errno(XSpiPs_SetOptions(inst(xh), options));
+	if (ret != 0) {
+		(void)ps_async_cleanup(xh, false);
+		return ret;
+	}
+
+	ret = spips_set_frequency(inst(xh), device->max_speed_hz);
+	if (ret != 0) {
+		(void)ps_async_cleanup(xh, false);
+		return ret;
+	}
+
+	ret = ps_select_device(xh, device);
+	if (ret != 0) {
+		(void)ps_async_cleanup(xh, false);
+		return ret;
+	}
+
+	if (device->cs_gpio_num > 0) {
+		xh->async.gpio_cs_device = device;
+		ret = gpio_cs_assert(device);
+		if (ret != 0) {
+			(void)ps_async_cleanup(xh, false);
+			return ret;
+		}
+	}
+
+	ret = spips_status_to_errno(XSpiPs_Transfer(inst(xh), tx, rx, len));
+	if (ret != 0) {
+		(void)ps_async_cleanup(xh, false);
+		return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Run a synchronous SPI command-read operation.
+ * @note PS: Command+RX via XSpiPs_PolledTransfer().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_spi_ps_read_command(struct capi_spi_device *device,
+				    struct capi_spi_transfer *transfer)
+{
+	if (device == NULL || device->controller == NULL || transfer == NULL)
+		return -EINVAL;
+
+	int ret = ps_validate_transfer(device, transfer, false, true);
+	if (ret != 0)
+		return ret;
+
+	struct capi_spi_xilinx_handle *xh = device->controller->priv;
+	if (xh->async_in_progress || inst(xh)->IsBusy)
+		return -EBUSY;
+
+	uint32_t total = (uint32_t)transfer->tx_size + transfer->rx_size;
+	if (total == 0)
+		return 0;	/* Zero-length read command is a successful no-op. */
+	if (total > XSPIPS_CAPI_MAX_TRANSFER_SIZE)
+		return -EINVAL;
+
+	uint8_t *tx = capi_malloc(total);
+	uint8_t *rx = capi_malloc(total);
+	if (!tx || !rx) {
+		capi_free(tx);
+		capi_free(rx);
+		return -ENOMEM;
+	}
+
+	memset(tx, 0, total);
+	if (transfer->tx_buf && transfer->tx_size > 0)
+		memcpy(tx, transfer->tx_buf, transfer->tx_size);
+
+	XSpiPs_WriteReg(inst(xh)->Config.BaseAddress, XSPIPS_IDR_OFFSET,
+			XSPIPS_IXR_DISABLE_ALL_MASK);
+
+	u32 options = XSPIPS_MASTER_OPTION | XSPIPS_FORCE_SSELECT_OPTION;
+	if (device->mode & CAPI_SPI_CPHA)
+		options |= XSPIPS_CLK_PHASE_1_OPTION;
+	if (device->mode & CAPI_SPI_CPOL)
+		options |= XSPIPS_CLK_ACTIVE_LOW_OPTION;
+	ret = spips_status_to_errno(XSpiPs_SetOptions(inst(xh), options));
+	if (ret != 0) {
+		capi_free(tx);
+		capi_free(rx);
+		return ret;
+	}
+
+	ret = spips_set_frequency(inst(xh), device->max_speed_hz);
+	if (ret != 0) {
+		capi_free(tx);
+		capi_free(rx);
+		return ret;
+	}
+
+	bool use_gpio_cs = device->cs_gpio_num > 0;
+	ret = ps_select_device(xh, device);
+	if (ret != 0) {
+		capi_free(tx);
+		capi_free(rx);
+		return ret;
+	}
+
+	int status;
+	int gpio_error = 0;
+	if (use_gpio_cs) {
+		ret = gpio_cs_assert(device);
+		if (ret != 0) {
+			gpio_error = ret;
+			status = XST_FAILURE;
+		} else {
+			status = XSpiPs_PolledTransfer(inst(xh), tx, rx, total);
+		}
+		ret = gpio_cs_deassert(device);
+		if (ret != 0 && status == XST_SUCCESS) {
+			gpio_error = ret;
+			status = XST_FAILURE;
+		}
+	} else {
+		status = XSpiPs_PolledTransfer(inst(xh), tx, rx, total);
+	}
+	if (status != XST_SUCCESS)
+		XSpiPs_Abort(inst(xh));
+	if (!use_gpio_cs)
+		ps_deselect_native(xh);
+
+	if (status == XST_SUCCESS && transfer->rx_buf && transfer->rx_size > 0)
+		memcpy(transfer->rx_buf, rx + transfer->tx_size, transfer->rx_size);
+
+	capi_free(tx);
+	capi_free(rx);
+	return (gpio_error != 0) ? gpio_error :
+	       spips_status_to_errno(status);
+}
+
+/**
+ * @brief Start an asynchronous SPI command-read operation.
+ * @note PS: Async command+RX via XSpiPs_Transfer().
+ *
+ * Non-blocking, same completion path as capi_spi_ps_transceive_async. The only
+ * difference is framing: command/address TX bytes and RX data share one CS
+ * frame, so it builds a single full-duplex buffer of length tx_size + rx_size
+ * (dummy TX clocks the read phase).
+ *
+ * SPI is full-duplex: the controller shifts out one TX byte and latches one RX
+ * byte per clock, so the RX buffer fills for the whole frame, including while
+ * the command bytes are being sent. Those first tx_size RX bytes are just the
+ * bus echo during the command and must be discarded. The temporary buffers and
+ * the offset that does this are held in xh->async (see the async_transfer
+ * struct) so the ISR can finish the copy after this call returns:
+ *
+ *   tx (heap, tx_size+rx_size):  [ cmd bytes | 0 0 0 ... ]  (dummy TX clocks read)
+ *   rx (heap, tx_size+rx_size):  [ echo bytes | real data ]
+ *                                  \_ discard _/ \__ copied out __/
+ *                                  rx_offset = tx_size
+ *
+ * On completion ps_async_cleanup copies rx[rx_offset .. rx_offset+rx_size) into
+ * the caller's transfer->rx_buf, skipping the command-echo bytes. Both heap
+ * buffers must outlive this call (the transfer is interrupt-driven) and are
+ * freed by that same cleanup.
+ *
+ * Flow:
+ *   1. Reject if no IRQ or a transfer is already in flight.
+ *   2. Allocate the combined TX/RX buffers and copy the command bytes into the
+ *      TX prefix (rest of TX stays zero as dummy read clocks).
+ *   3. Save async state (rx_offset = tx_size) and mark async_in_progress so
+ *      every later error path unwinds via ps_async_cleanup.
+ *   4. Apply CAPI mode options and per-device speed, then select the target
+ *      (native CS, or assert GPIO CS and keep it held until completion).
+ *   5. Kick XSpiPs_Transfer, which arms interrupts and returns; return 0.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_spi_ps_read_command_async(struct capi_spi_device *device,
+		struct capi_spi_transfer *transfer)
+{
+	if (device == NULL || device->controller == NULL || transfer == NULL)
+		return -EINVAL;
+
+	int ret = ps_validate_transfer(device, transfer, true, true);
+	if (ret != 0)
+		return ret;
+
+	uint32_t total32 = (uint32_t)transfer->tx_size + transfer->rx_size;
+	if (total32 > XSPIPS_CAPI_MAX_TRANSFER_SIZE)
+		return -EINVAL;
+	uint16_t total = (uint16_t)total32;
+	if (total == 0)
+		return -EINVAL;
+
+	struct capi_spi_xilinx_handle *xh = device->controller->priv;
+	if (!xh->use_irq)
+		return -ENOTSUP;
+	if (xh->async_in_progress || inst(xh)->IsBusy)
+		return -EBUSY;
+
+	uint8_t *tx = capi_malloc(total);
+	uint8_t *rx = capi_malloc(total);
+	if (!tx || !rx) {
+		capi_free(tx);
+		capi_free(rx);
+		return -ENOMEM;
+	}
+
+	memset(tx, 0, total);
+	memset(rx, 0, total);
+	if (transfer->tx_buf && transfer->tx_size > 0)
+		memcpy(tx, transfer->tx_buf, transfer->tx_size);
+
+	xh->async.tx_buffer = tx;
+	xh->async.rx_buffer = rx;
+	xh->async.transfer.rx_buf = transfer->rx_buf;
+	xh->async.rx_offset = transfer->tx_size;
+	xh->async.transfer.rx_size = transfer->rx_size;
+	xh->async_in_progress = true;
+
+	u32 options = XSPIPS_MASTER_OPTION | XSPIPS_FORCE_SSELECT_OPTION;
+	if (device->mode & CAPI_SPI_CPHA)
+		options |= XSPIPS_CLK_PHASE_1_OPTION;
+	if (device->mode & CAPI_SPI_CPOL)
+		options |= XSPIPS_CLK_ACTIVE_LOW_OPTION;
+	ret = spips_status_to_errno(XSpiPs_SetOptions(inst(xh), options));
+	if (ret != 0) {
+		(void)ps_async_cleanup(xh, false);
+		return ret;
+	}
+
+	ret = spips_set_frequency(inst(xh), device->max_speed_hz);
+	if (ret != 0) {
+		(void)ps_async_cleanup(xh, false);
+		return ret;
+	}
+
+	ret = ps_select_device(xh, device);
+	if (ret != 0) {
+		(void)ps_async_cleanup(xh, false);
+		return ret;
+	}
+
+	if (device->cs_gpio_num > 0) {
+		xh->async.gpio_cs_device = device;
+		ret = gpio_cs_assert(device);
+		if (ret != 0) {
+			(void)ps_async_cleanup(xh, false);
+			return ret;
+		}
+	}
+
+	ret = spips_status_to_errno(XSpiPs_Transfer(inst(xh), tx, rx, total));
+	if (ret != 0) {
+		(void)ps_async_cleanup(xh, false);
+		return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Abort an in-progress asynchronous operation.
+ * @note PS: XSpiPs_Abort().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_spi_ps_abort_async(struct capi_spi_device *device)
+{
+	if (device == NULL || device->controller == NULL)
+		return -EINVAL;
+
+	struct capi_spi_xilinx_handle *xh = device->controller->priv;
+	if (!xh->async_in_progress)
+		return 0;
+
+	XSpiPs_WriteReg(inst(xh)->Config.BaseAddress, XSPIPS_IDR_OFFSET,
+			XSPIPS_IXR_DISABLE_ALL_MASK);
+	XSpiPs_Abort(inst(xh));
+	(void)ps_async_cleanup(xh, false);
+
+	if (xh->callback)
+		xh->callback(CAPI_SPI_EVENT_ERROR, xh->callback_arg, 0);
+
+	return 0;
+}
+
+/**
+ * @brief Register the CAPI asynchronous callback.
+ * @note PS: stores the CAPI callback used by the XSpiPs event path.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_spi_ps_register_callback(struct capi_spi_controller_handle
+		*handle,
+		capi_spi_callback_t const callback, void *callback_arg)
+{
+	if (handle == NULL)
+		return -EINVAL;
+	struct capi_spi_xilinx_handle *xh = handle->priv;
+	xh->callback = callback;
+	xh->callback_arg = callback_arg;
+	return 0;
+}
+
+/**
+ * @brief Control the SPI chip select line.
+ * @note PS: Manual controls drive GPIO CS logically or the native SSCTRL field
+ *       directly; automatic CS is left to the per-transfer path.
+ *
+ * Supports the three CAPI CS controls:
+ *   CAPI_SPI_CS_AUTO           - the transfer functions already assert CS at
+ *                                the start of each frame and release it at the
+ *                                end, so automatic CS needs no standing action
+ *                                here; accepted as a no-op.
+ *   CAPI_SPI_CS_MANUAL_ASSERT  - drive CS active outside of a transfer.
+ *   CAPI_SPI_CS_MANUAL_DEASSERT- drive CS inactive outside of a transfer.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_spi_ps_set_cs(struct capi_spi_device *device,
+			      enum capi_spi_cs_control cs)
+{
+	if (device == NULL || device->controller == NULL)
+		return -EINVAL;
+	struct capi_spi_xilinx_handle *xh = device->controller->priv;
+	if (xh->async_in_progress || inst(xh)->IsBusy)
+		return -EBUSY;
+
+	if ((device->cs_gpio == NULL) != (device->cs_gpio_num == 0))
+		return -EINVAL;
+	if (device->cs_gpio_num > 0 && device->native_cs != 0)
+		return -EINVAL;
+
+	if (cs == CAPI_SPI_CS_AUTO)
+		return 0;
+
+	if (device->cs_gpio_num > 0) {
+		if (cs == CAPI_SPI_CS_MANUAL_ASSERT)
+			return gpio_cs_assert(device);
+		else if (cs == CAPI_SPI_CS_MANUAL_DEASSERT)
+			return gpio_cs_deassert(device);
+		else
+			return -EINVAL;
+	}
+
+	if (cs == CAPI_SPI_CS_MANUAL_ASSERT)
+		return ps_drive_native_cs(xh, device->native_cs, true);
+	else if (cs == CAPI_SPI_CS_MANUAL_DEASSERT)
+		return ps_drive_native_cs(xh, device->native_cs, false);
+	return -EINVAL;
+}
+
+/**
+ * @brief Dispatch the backend interrupt handler.
+ * @note PS: XSpiPs_InterruptHandler().
+ *
+ */
+static void capi_spi_ps_isr(void *handle)
+{
+	if (handle == NULL)
+		return;
+	struct capi_spi_xilinx_handle *xh = ((struct capi_spi_controller_handle *)
+					     handle)->priv;
+	XSpiPs_InterruptHandler(inst(xh));
+	spips_finish_irq(xh);
+}
+
+#endif /* XPAR_XSPIPS_NUM_INSTANCES */

--- a/capi/platform/xilinx/xilinx_capi_time.c
+++ b/capi/platform/xilinx/xilinx_capi_time.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Xilinx strong implementations of capi_time weak hooks.
+ *
+ * These override the __attribute__((weak)) stubs in capi/src/capi_time.c at
+ * link time.
+ *
+ * capi_wait_us_impl / capi_wait_ms_impl:
+ *   Cortex-A9/A53/R5 targets expose usleep() from xil_sleep.h (BSP sleep.h).
+ *   MicroBlaze uses usleep_MB().  _XPARAMETERS_PS_H_ distinguishes the two.
+ *
+ * capi_uptime_impl:
+ *   Reads the 64-bit Cortex-A9 global timer via XTime_GetTime() from xtime_l.h.
+ *   COUNTS_PER_SECOND is CPU_FREQ/2 on Zynq-7000 (667 MHz → 333 MHz counter).
+ *   Division is integer: precision is ~3 µs at 333 MHz, fine for test/benchmark.
+ *   Only compiled on PS targets (_XPARAMETERS_PS_H_).
+ */
+
+#include "capi_time.h"
+#include "sleep.h"
+#include <errno.h>
+#include "xparameters.h"
+
+/*
+ * SDT BSP (Vitis 2025.2+): xiltimer.h replaces xtime_l.h. The compiler is
+ * invoked with -DSDT for SDT builds. Legacy BSP: xtime_l.h on PS targets.
+ */
+#ifdef _XPARAMETERS_PS_H_
+
+#include "xiltimer.h"
+#include "xtimer_config.h"
+
+#endif /* _XPARAMETERS_PS_H_ */
+
+void capi_wait_us_impl(uint32_t us)
+{
+#ifdef _XPARAMETERS_PS_H_
+	usleep(us);
+#else
+	usleep_MB(us);
+#endif
+}
+
+void capi_wait_ms_impl(uint32_t ms)
+{
+#ifdef _XPARAMETERS_PS_H_
+	usleep((uint32_t)(ms * 1000U));
+#else
+	usleep_MB((uint32_t)(ms * 1000U));
+#endif
+}
+
+int capi_uptime_impl(uint64_t *us)
+{
+#ifdef _XPARAMETERS_PS_H_
+	XTime ticks;
+
+	XTime_GetTime(&ticks);
+	*us = (uint64_t)ticks * 1000000ULL / (uint64_t)(COUNTS_PER_SECOND);
+	return 0;
+#else
+	return -ENOTSUP;
+#endif
+}

--- a/capi/platform/xilinx/xilinx_capi_timer.h
+++ b/capi/platform/xilinx/xilinx_capi_timer.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Xilinx platform Timer driver for CAPI
+ *
+ * Backends (select via config.ops):
+ *   capi_timer_xilinx_pl_ops     - XTmrCtr  (AXI Timer, 2 channels)
+ *   capi_timer_xilinx_ps_ttc_ops - XTtcPs   (Zynq PS TTC, 1 channel per instance)
+ *   capi_timer_xilinx_ps_scu_ops - XScuTimer (PS SCU Private Timer, 1 channel)
+ *
+ * Pass config->extra = NULL for polled mode. To use interrupts, pass
+ * struct capi_timer_xilinx_config with use_irq=true and the desired irq_id.
+ * IRQ ID 0 is valid for INTC input 0.
+ */
+
+#ifndef _XILINX_CAPI_TIMER_H_
+#define _XILINX_CAPI_TIMER_H_
+
+#include <xparameters.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <capi_timer.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @struct capi_timer_xilinx_config
+ * @brief Optional Xilinx platform-specific Timer configuration.
+ *
+ * Passed via config->extra during init. use_irq decides whether the driver
+ * connects irq_id through the CAPI IRQ singleton. IRQ ID 0 is valid for an
+ * INTC input, so it is passed through unchanged.
+ */
+struct capi_timer_xilinx_config {
+	/** Enable CAPI IRQ connection during init */
+	bool use_irq;
+	/** Normalized CAPI IRQ ID. Zero is valid for INTC input 0. */
+	uint32_t irq_id;
+};
+
+/**
+ * @brief Xilinx timer operations tables. Select one via config->ops.
+ */
+extern const struct capi_timer_ops capi_timer_xilinx_ps_ttc_ops;
+extern const struct capi_timer_ops capi_timer_xilinx_ps_scu_ops;
+extern const struct capi_timer_ops capi_timer_xilinx_pl_ops;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _XILINX_CAPI_TIMER_H_ */

--- a/capi/platform/xilinx/xilinx_capi_timer_pl.c
+++ b/capi/platform/xilinx/xilinx_capi_timer_pl.c
@@ -1,0 +1,1155 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Xilinx AXI Timer (XTmrCtr) driver for CAPI
+ *
+ * Two channels per instance.
+ * capi_irq_init() must be called before IRQ-driven async ops will work.
+ *
+ * Each XTmrCtr channel has one terminal-count interrupt and no separate compare
+ * register, so on channel 0 the compare match and the global counter overflow
+ * are the same physical event. They cannot be armed together (the second
+ * returns -EBUSY) so a single expiry never fires both callbacks.
+ */
+
+#include <capi_alloc.h>
+#include <string.h>
+#include <errno.h>
+#include <capi_timer.h>
+#include <capi_irq.h>
+#include <xilinx_capi_timer_priv.h>
+#include "xinterrupt_wrap.h"
+
+#ifdef XPAR_XTMRCTR_NUM_INSTANCES
+
+#define CAPI_TIMER_NSEC_PER_SEC	1000000000ULL
+
+static int capi_timer_pl_init(struct capi_timer_handle **handle,
+			      const struct capi_timer_config *config);
+static int capi_timer_pl_deinit(struct capi_timer_handle *handle);
+static int capi_timer_pl_start(struct capi_timer_handle *handle);
+static int capi_timer_pl_stop(struct capi_timer_handle *handle);
+static int capi_timer_pl_counter_config(struct capi_timer_handle *handle,
+					const struct capi_timer_counter_config *config);
+static int capi_timer_pl_counter_get(struct capi_timer_handle *handle,
+				     uint32_t *counter);
+static int capi_timer_pl_event_irq_enable(struct capi_timer_handle *handle,
+		uint32_t event);
+static int capi_timer_pl_event_irq_disable(struct capi_timer_handle *handle,
+		uint32_t event);
+static int capi_timer_pl_register_event_callback(struct capi_timer_handle
+		*handle,
+		capi_timer_event_callback callback,
+		void *callback_arg);
+static int capi_timer_pl_channel_init(struct capi_timer_handle *handle,
+				      uint32_t chan);
+static int capi_timer_pl_channel_deinit(struct capi_timer_handle *handle,
+					uint32_t chan);
+static int capi_timer_pl_channel_config(struct capi_timer_handle *handle,
+					uint32_t chan,
+					const struct capi_timer_channel_config *ch_config);
+static int capi_timer_pl_channel_enable(struct capi_timer_handle *handle,
+					uint32_t chan);
+static int capi_timer_pl_channel_disable(struct capi_timer_handle *handle,
+		uint32_t chan);
+static int capi_timer_pl_channel_compare_set(struct capi_timer_handle *handle,
+		uint32_t chan,
+		uint32_t compare);
+static int capi_timer_pl_channel_compare_get(struct capi_timer_handle *handle,
+		uint32_t chan,
+		uint32_t *compare);
+static int capi_timer_pl_channel_capture_get(struct capi_timer_handle *handle,
+		uint32_t chan,
+		uint32_t *capture);
+static int capi_timer_pl_channel_irq_enable(struct capi_timer_handle *handle,
+		uint32_t chan,
+		uint32_t event);
+static int capi_timer_pl_channel_irq_disable(struct capi_timer_handle *handle,
+		uint32_t chan,
+		uint32_t event);
+static int capi_timer_pl_channel_register_callback(struct capi_timer_handle
+		*handle, uint32_t chan,
+		capi_timer_channel_callback callback,
+		void *callback_arg);
+static int capi_timer_pl_is_irq_pending(struct capi_timer_handle *handle,
+					bool *pending);
+static void capi_timer_pl_isr(struct capi_timer_handle *handle);
+static int capi_timer_pl_nsec_to_ticks(const struct capi_timer_handle *handle,
+				       uint64_t duration_ns,
+				       uint32_t *ticks);
+static int capi_timer_pl_ticks_to_nsec(const struct capi_timer_handle *handle,
+				       uint64_t ticks,
+				       uint32_t *duration_ns);
+
+#define PL_TIMER_NUM_CHANNELS 2
+
+const struct capi_timer_ops capi_timer_xilinx_pl_ops = {
+	.init = capi_timer_pl_init,
+	.deinit = capi_timer_pl_deinit,
+	.start = capi_timer_pl_start,
+	.stop = capi_timer_pl_stop,
+	.counter_config = capi_timer_pl_counter_config,
+	.counter_get = capi_timer_pl_counter_get,
+	.event_irq_enable = capi_timer_pl_event_irq_enable,
+	.event_irq_disable = capi_timer_pl_event_irq_disable,
+	.register_event_callback = capi_timer_pl_register_event_callback,
+	.channel_init = capi_timer_pl_channel_init,
+	.channel_deinit = capi_timer_pl_channel_deinit,
+	.channel_config = capi_timer_pl_channel_config,
+	.channel_enable = capi_timer_pl_channel_enable,
+	.channel_disable = capi_timer_pl_channel_disable,
+	.channel_compare_set = capi_timer_pl_channel_compare_set,
+	.channel_compare_get = capi_timer_pl_channel_compare_get,
+	.channel_capture_get = capi_timer_pl_channel_capture_get,
+	.channel_irq_enable = capi_timer_pl_channel_irq_enable,
+	.channel_irq_disable = capi_timer_pl_channel_irq_disable,
+	.channel_register_callback = capi_timer_pl_channel_register_callback,
+	.is_irq_pending = capi_timer_pl_is_irq_pending,
+	.isr = capi_timer_pl_isr,
+	.nsec_to_ticks = capi_timer_pl_nsec_to_ticks,
+	.ticks_to_nsec = capi_timer_pl_ticks_to_nsec,
+};
+
+static XTmrCtr *inst(struct capi_timer_xilinx_handle *xh)
+{
+	return (XTmrCtr *)xh->instance;
+}
+
+static void xilinx_timer_free_allocated_handle(struct capi_timer_handle
+		**handle)
+{
+	if (handle == NULL || *handle == NULL)
+		return;
+
+	capi_free((*handle)->priv);
+	capi_free(*handle);
+	*handle = NULL;
+}
+
+static void xilinx_timer_clear_app_handle(struct capi_timer_handle *handle)
+{
+	if (handle != NULL)
+		handle->ops = NULL;
+}
+
+static int check_timer_config(const struct capi_timer_config *config)
+{
+	if (config->input_clock_identifier != 0)
+		return -ENOTSUP;
+	if (config->input_clock_hz > UINT32_MAX ||
+	    config->output_freq_hz > UINT32_MAX)
+		return -ENOTSUP;
+
+	return 0;
+}
+
+static int check_compare_config(const struct capi_timer_compare_config *config)
+{
+	if (config->generate_pulse_on_match || config->output_identifier != 0 ||
+	    config->polarity != CAPI_TIMER_ON_COMPARE_KEEP || config->stop_enabled ||
+	    config->extra != NULL)
+		return -ENOTSUP;
+
+	return 0;
+}
+
+static int check_capture_config(const struct capi_timer_capture_config *config)
+{
+	if (config->input_identifier != 0 || config->edge != CAPI_TIMER_CAPTURE_BOTH ||
+	    config->extra != NULL)
+		return -ENOTSUP;
+
+	return 0;
+}
+
+static int check_pwm_config(const struct capi_timer_pwm_config *config)
+{
+	if (config->output_identifier != 0 || config->inverted_polarity
+	    || config->offset_ns != 0 ||
+	    config->extra != NULL)
+		return -ENOTSUP;
+
+	return 0;
+}
+
+static void axi_timer_isr_handler(void *ref, u8 timer_number)
+{
+	struct capi_timer_xilinx_handle *xh = (struct capi_timer_xilinx_handle *)ref;
+
+	if (timer_number < xh->num_channels && xh->channels[timer_number].use_irq &&
+	    xh->channels[timer_number].callback) {
+		uint32_t event = xh->channels[timer_number].mode ==
+				 CAPI_TIMER_CAPTURE_MODE ? CAPI_TIMER_CHANNEL_EVENT_CAPTURE :
+				 CAPI_TIMER_CHANNEL_EVENT_COMPARE;
+		xh->channels[timer_number].callback(event,
+						    timer_number,
+						    xh->channels[timer_number].callback_arg, 0);
+	}
+
+	if (timer_number == 0 &&
+	    xh->channels[0].mode != CAPI_TIMER_CAPTURE_MODE &&
+	    xh->event_irq_enabled && xh->event_callback) {
+		xh->event_callback(CAPI_TIMER_GLOBAL_EVENT_COUNTER_OVERFLOW,
+				   xh->event_callback_arg,
+				   0);
+	}
+}
+
+static void irq_handler(void *ref)
+{
+	capi_timer_pl_isr((struct capi_timer_handle *)ref);
+}
+
+/**
+ * @brief Initialize the CAPI timer backend instance.
+ * @note PL: XTmrCtr_CfgInitialize()/XTmrCtr_InitHw().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_pl_init(struct capi_timer_handle **handle,
+			      const struct capi_timer_config *config)
+{
+	if (!handle || !config)
+		return -EINVAL;
+	if (check_timer_config(config) != 0)
+		return -ENOTSUP;
+
+	bool alloc_handle = (*handle == NULL);
+	struct capi_timer_handle *h = *handle;
+	struct capi_timer_xilinx_handle *xh;
+
+	if (alloc_handle) {
+		h = capi_malloc(sizeof(*h));
+		if (!h)
+			return -ENOMEM;
+		memset(h, 0, sizeof(*h));
+
+		xh = capi_malloc(sizeof(*xh));
+		if (!xh) {
+			capi_free(h);
+			return -ENOMEM;
+		}
+		h->priv = xh;
+		*handle = h;
+	} else {
+		xh = h->priv;
+		if (!xh)
+			return -EINVAL;
+		if (h->ops != NULL || xh->instance != NULL)
+			return -EBUSY;
+	}
+
+	memset(xh, 0, sizeof(*xh));
+	h->init_allocated = alloc_handle;
+	h->ops = config->ops ? config->ops : &capi_timer_xilinx_pl_ops;
+	h->priv = xh;
+	xh->input_clock_hz = (uint32_t)config->input_clock_hz;
+
+	XTmrCtr *xi = capi_malloc(sizeof(XTmrCtr));
+	if (!xi) {
+		if (alloc_handle)
+			xilinx_timer_free_allocated_handle(handle);
+		else
+			xilinx_timer_clear_app_handle(h);
+		return -ENOMEM;
+	}
+	memset(xi, 0, sizeof(XTmrCtr));
+
+	XTmrCtr_Config *cfg = XTmrCtr_LookupConfig((UINTPTR)config->identifier);
+	if (!cfg) {
+		capi_free(xi);
+		if (alloc_handle)
+			xilinx_timer_free_allocated_handle(handle);
+		else
+			xilinx_timer_clear_app_handle(h);
+		return -ENODEV;
+	}
+
+	/*
+	 * output_freq_hz is the desired tick/event rate, expressed via the
+	 * compare/PWM reload values at channel-config time - it is NOT the input
+	 * clock and must not be compared against it. The AXI timer counts at its
+	 * input clock; there is no init-time output divider to validate here.
+	 */
+	uint32_t actual_clock = cfg->SysClockFreqHz ? cfg->SysClockFreqHz :
+				(uint32_t)config->input_clock_hz;
+
+	XTmrCtr_CfgInitialize(xi, cfg, cfg->BaseAddress);
+
+	int status = XTmrCtr_InitHw(xi);
+	if (status != XST_SUCCESS) {
+		capi_free(xi);
+		if (alloc_handle)
+			xilinx_timer_free_allocated_handle(handle);
+		else
+			xilinx_timer_clear_app_handle(h);
+		return -EIO;
+	}
+
+	/* XTmrCtr_InitHw leaves stale write-one-to-clear IRQ flags intact. */
+	for (u8 n = 0; n < 2; n++) {
+		u32 csr = XTmrCtr_ReadReg(cfg->BaseAddress, n, XTC_TCSR_OFFSET);
+		if (csr & XTC_CSR_INT_OCCURED_MASK)
+			XTmrCtr_WriteReg(cfg->BaseAddress, n, XTC_TCSR_OFFSET,
+					 csr | XTC_CSR_INT_OCCURED_MASK);
+	}
+
+	XTmrCtr_SetHandler(xi, axi_timer_isr_handler, xh);
+
+	xh->instance = xi;
+	xh->input_clock_hz = actual_clock;
+	if (cfg->SysClockFreqHz == 0 && actual_clock != 0)
+		xi->Config.SysClockFreqHz = xh->input_clock_hz;
+	xh->num_channels = PL_TIMER_NUM_CHANNELS;
+
+	const struct capi_timer_xilinx_config *xcfg =
+		(const struct capi_timer_xilinx_config *)config->extra;
+	if (xcfg != NULL && xcfg->use_irq) {
+		uint32_t irq_id = xcfg->irq_id;
+		int ret = capi_irq_connect(irq_id, irq_handler, h);
+		if (ret == 0) {
+			capi_irq_set_level_edge_trigger(irq_id, CAPI_IRQ_LEVEL_HIGH);
+			ret = capi_irq_enable(irq_id);
+			if (ret == 0) {
+				xh->irq_id = irq_id;
+				xh->use_irq = true;
+			}
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Deinitialize the CAPI timer backend instance.
+ * @note PL: XTmrCtr_PwmDisable()/XTmrCtr_Stop() then capi_free.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_pl_deinit(struct capi_timer_handle *handle)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+	if (!xh)
+		return -EINVAL;
+
+	if (xh->use_irq) {
+		capi_irq_disable(xh->irq_id);
+		xh->use_irq = false;
+	}
+
+	if (xh->instance) {
+		XTmrCtr_PwmDisable(inst(xh));
+		XTmrCtr_Stop(inst(xh), 0);
+		XTmrCtr_Stop(inst(xh), 1);
+		for (u8 chan = 0; chan < PL_TIMER_NUM_CHANNELS; chan++) {
+			u32 options = XTmrCtr_GetOptions(inst(xh), chan);
+			XTmrCtr_SetOptions(inst(xh), chan,
+					   options & ~XTC_INT_MODE_OPTION);
+			u32 csr = XTmrCtr_ReadReg(inst(xh)->BaseAddress, chan,
+						  XTC_TCSR_OFFSET);
+			if (csr & XTC_CSR_INT_OCCURED_MASK)
+				XTmrCtr_WriteReg(inst(xh)->BaseAddress, chan,
+						 XTC_TCSR_OFFSET,
+						 csr | XTC_CSR_INT_OCCURED_MASK);
+		}
+		capi_free(xh->instance);
+		xh->instance = NULL;
+	}
+
+	if (handle->init_allocated) {
+		capi_free(xh);
+		capi_free(handle);
+	} else {
+		handle->ops = NULL;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Start the timer counter.
+ * @note PL: XTmrCtr_PwmEnable() for PWM, XTmrCtr_Start() otherwise.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_pl_start(struct capi_timer_handle *handle)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (xh->channels[0].mode == CAPI_TIMER_PWM_MODE && xh->channels[0].enabled) {
+		XTmrCtr_PwmEnable(inst(xh));
+		return 0;
+	}
+
+	for (uint8_t i = 0; i < xh->num_channels; i++) {
+		if (xh->channels[i].initialized && xh->channels[i].enabled)
+			XTmrCtr_Start(inst(xh), i);
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Stop the timer counter.
+ * @note PL: XTmrCtr_PwmDisable() for PWM, XTmrCtr_Stop() otherwise.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_pl_stop(struct capi_timer_handle *handle)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (xh->channels[0].mode == CAPI_TIMER_PWM_MODE) {
+		XTmrCtr_PwmDisable(inst(xh));
+		return 0;
+	}
+
+	for (uint8_t i = 0; i < xh->num_channels; i++)
+		XTmrCtr_Stop(inst(xh), i);
+
+	return 0;
+}
+
+/**
+ * @brief Configure the timer counter.
+ * @note PL: XTmrCtr_SetResetValue()/XTmrCtr_Reset().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_pl_counter_config(struct capi_timer_handle *handle,
+					const struct capi_timer_counter_config *config)
+{
+	if (!handle || !config)
+		return -EINVAL;
+	if (config->extra != NULL)
+		return -ENOTSUP;
+
+	if (config->min != 0)
+		return -ENOTSUP;
+	if (!config->rollover)
+		return -ENOTSUP;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	u32 options = XTC_AUTO_RELOAD_OPTION;
+	u32 reset_value;
+
+	switch (config->direction) {
+	case CAPI_TIMER_COUNT_UP:
+		/*
+		 * For an up-counter TLR is the count FLOOR loaded on start and on
+		 * every rollover, so the period is 2^32 - TLR ticks. Preloading the
+		 * two's complement of `max` therefore yields exactly `max` ticks
+		 * between overflows - the counter still ends at 2^32, it just starts
+		 * high enough to get there in `max` steps.
+		 *
+		 * A full-span request (0 or the 32-bit max, i.e. "just roll over")
+		 * keeps TLR = 0. Note -max is computed in uint32_t, so max == 0 would
+		 * wrap to 0 anyway; it is spelled out to keep the intent readable.
+		 */
+		reset_value = (config->max == 0U || config->max == UINT32_MAX)
+			      ? 0U : (u32)(0U - config->max);
+		break;
+	case CAPI_TIMER_COUNT_DOWN:
+		if (config->max == 0)
+			return -EINVAL;
+		options |= XTC_DOWN_COUNT_OPTION;
+		reset_value = config->max;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	XTmrCtr_SetOptions(inst(xh), 0, options);
+	XTmrCtr_SetResetValue(inst(xh), 0, reset_value);
+	XTmrCtr_Reset(inst(xh), 0);
+
+	/* start() only runs initialized and enabled channels. */
+	xh->channels[0].initialized = true;
+	xh->channels[0].enabled = true;
+	xh->channels[0].mode = CAPI_TIMER_COMPARE_MODE;
+
+	return 0;
+}
+
+/**
+ * @brief Read the timer counter value.
+ * @note PL: XTmrCtr_GetValue().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_pl_counter_get(struct capi_timer_handle *handle,
+				     uint32_t *counter)
+{
+	if (!handle || !counter)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	*counter = XTmrCtr_GetValue(inst(xh), 0);
+
+	return 0;
+}
+
+/**
+ * @brief Enable timer global event interrupts.
+ * @note PL: Enables XTC_INT_MODE_OPTION.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_pl_event_irq_enable(struct capi_timer_handle *handle,
+		uint32_t event)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (event != CAPI_TIMER_GLOBAL_EVENT_COUNTER_OVERFLOW)
+		return -EINVAL;
+
+	if (!xh->use_irq)
+		return -ENOTSUP;
+
+	/*
+	 * XTmrCtr timer 0 has a single terminal-count interrupt with no separate
+	 * compare register, so overflow and channel-0 compare are the same event.
+	 * Refuse to arm overflow while channel 0 compare is armed so one expiry
+	 * cannot fire both callbacks.
+	 */
+	if (xh->channels[0].use_irq)
+		return -EBUSY;
+
+	u32 options = XTmrCtr_GetOptions(inst(xh), 0);
+	options |= XTC_INT_MODE_OPTION;
+	XTmrCtr_SetOptions(inst(xh), 0, options);
+	xh->event_irq_enabled = true;
+
+	return 0;
+}
+
+/**
+ * @brief Disable timer global event interrupts.
+ * @note PL: Clears XTC_INT_MODE_OPTION.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_pl_event_irq_disable(struct capi_timer_handle *handle,
+		uint32_t event)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (event != CAPI_TIMER_GLOBAL_EVENT_COUNTER_OVERFLOW)
+		return -EINVAL;
+
+	xh->event_irq_enabled = false;
+	if (!xh->channels[0].use_irq) {
+		u32 options = XTmrCtr_GetOptions(inst(xh), 0);
+		options &= ~XTC_INT_MODE_OPTION;
+		XTmrCtr_SetOptions(inst(xh), 0, options);
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Register the timer global event callback.
+ * @note PL: Stores overflow callback.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_pl_register_event_callback(struct capi_timer_handle
+		*handle,
+		capi_timer_event_callback callback,
+		void *callback_arg)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	xh->event_callback = callback;
+	xh->event_callback_arg = callback_arg;
+
+	return 0;
+}
+
+/**
+ * @brief Initialize the CAPI timer backend instance.
+ * @note PL: Marks channel initialized.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_pl_channel_init(struct capi_timer_handle *handle,
+				      uint32_t chan)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+
+	/*
+	 * No double-init guard: the simple counter API (counter_config) pre-flags
+	 * channel 0 as initialized so start() runs it, and callers may still call
+	 * channel_init(0) explicitly afterwards. channel_init just (re)establishes
+	 * the channel's known state, so allow it unconditionally.
+	 */
+	xh->channels[chan].initialized = true;
+	xh->channels[chan].enabled = false;
+	xh->channels[chan].mode = CAPI_TIMER_COMPARE_MODE;
+
+	return 0;
+}
+
+/**
+ * @brief Deinitialize the CAPI timer backend instance.
+ * @note PL: Disables and clears channel state.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_pl_channel_deinit(struct capi_timer_handle *handle,
+					uint32_t chan)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+
+	if (xh->channels[chan].mode == CAPI_TIMER_PWM_MODE) {
+		if (chan != 0)
+			return -EINVAL;
+		capi_timer_pl_channel_disable(handle, chan);
+		capi_timer_pl_channel_irq_disable(handle, 0,
+						  CAPI_TIMER_CHANNEL_EVENT_COMPARE);
+		capi_timer_pl_channel_irq_disable(handle, 1,
+						  CAPI_TIMER_CHANNEL_EVENT_COMPARE);
+		memset(&xh->channels[0], 0, sizeof(struct capi_timer_xilinx_channel));
+		memset(&xh->channels[1], 0, sizeof(struct capi_timer_xilinx_channel));
+		return 0;
+	}
+
+	capi_timer_pl_channel_disable(handle, chan);
+	uint32_t event = xh->channels[chan].mode == CAPI_TIMER_CAPTURE_MODE ?
+			 CAPI_TIMER_CHANNEL_EVENT_CAPTURE :
+			 CAPI_TIMER_CHANNEL_EVENT_COMPARE;
+	capi_timer_pl_channel_irq_disable(handle, chan, event);
+	memset(&xh->channels[chan], 0, sizeof(struct capi_timer_xilinx_channel));
+
+	return 0;
+}
+
+/**
+ * @brief Configure a timer channel.
+ * @note PL: XTmrCtr_PwmConfigure() for PWM, XTmrCtr_SetOptions()/SetResetValue()
+ * otherwise.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_pl_channel_config(struct capi_timer_handle *handle,
+					uint32_t chan,
+					const struct capi_timer_channel_config *ch_config)
+{
+	if (!handle || !ch_config)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+	/*
+	 * PWM drives both timers as one unit and is only valid on channel 0; a
+	 * PWM request on channel 1 is fundamentally invalid regardless of whether
+	 * that channel was initialized, so reject it (EINVAL) before the
+	 * not-initialized (ENODEV) check.
+	 */
+	if (ch_config->mode == CAPI_TIMER_PWM_MODE && chan != 0)
+		return -EINVAL;
+	if (!xh->channels[chan].initialized)
+		return -ENODEV;
+	if (ch_config->extra != NULL)
+		return -ENOTSUP;
+
+	u32 options = 0;
+
+	switch (ch_config->mode) {
+	case CAPI_TIMER_COMPARE_MODE:
+		if (check_compare_config(&ch_config->config.compare) != 0)
+			return -ENOTSUP;
+		if (ch_config->config.compare.match_value == 0)
+			return -EINVAL;
+		options = XTC_DOWN_COUNT_OPTION | XTC_AUTO_RELOAD_OPTION;
+		break;
+
+	case CAPI_TIMER_CAPTURE_MODE:
+		if (check_capture_config(&ch_config->config.capture) != 0)
+			return -ENOTSUP;
+		options = XTC_CAPTURE_MODE_OPTION | XTC_AUTO_RELOAD_OPTION;
+		break;
+
+	case CAPI_TIMER_PWM_MODE: {
+		if (check_pwm_config(&ch_config->config.pwm) != 0)
+			return -ENOTSUP;
+		if (chan != 0)
+			return -EINVAL;
+
+		if (ch_config->config.pwm.active_ns > ch_config->config.pwm.period_ns)
+			return -EINVAL;
+		if (ch_config->config.pwm.period_ns > UINT32_MAX ||
+		    ch_config->config.pwm.active_ns > UINT32_MAX)
+			return -EINVAL;
+		if (inst(xh)->Config.SysClockFreqHz == 0)
+			return -EINVAL;
+
+		uint64_t clock_period_ns =
+			(CAPI_TIMER_NSEC_PER_SEC +
+			 (inst(xh)->Config.SysClockFreqHz / 2U)) /
+			inst(xh)->Config.SysClockFreqHz;
+		/* PwmConfigure's two-clock adjustment must not underflow. */
+		if (clock_period_ns == 0 ||
+		    ch_config->config.pwm.period_ns < (2ULL * clock_period_ns) ||
+		    ch_config->config.pwm.active_ns < (2ULL * clock_period_ns))
+			return -EINVAL;
+
+		/* Embeddedsw programs rounded_ticks - 2. */
+		uint64_t period_load =
+			((ch_config->config.pwm.period_ns + (clock_period_ns / 2ULL)) /
+			 clock_period_ns) -
+			2ULL;
+		if (period_load > XTC_MAX_LOAD_VALUE)
+			return -EINVAL;
+
+		XTmrCtr_PwmDisable(inst(xh));
+		(void)XTmrCtr_PwmConfigure(inst(xh), (u32)ch_config->config.pwm.period_ns,
+					   (u32)ch_config->config.pwm.active_ns);
+
+		xh->channels[0].mode = CAPI_TIMER_PWM_MODE;
+		xh->channels[1].mode = CAPI_TIMER_PWM_MODE;
+		return 0;
+	}
+
+	default:
+		return -EINVAL;
+	}
+
+	if (xh->channels[chan].use_irq || (chan == 0 && xh->event_irq_enabled))
+		options |= XTC_INT_MODE_OPTION;
+	XTmrCtr_SetOptions(inst(xh), (u8)chan, options);
+
+	if (ch_config->mode == CAPI_TIMER_COMPARE_MODE) {
+		XTmrCtr_SetResetValue(inst(xh), (u8)chan,
+				      ch_config->config.compare.match_value);
+		XTmrCtr_Reset(inst(xh), (u8)chan);
+	} else if (ch_config->mode == CAPI_TIMER_CAPTURE_MODE) {
+		XTmrCtr_SetResetValue(inst(xh), (u8)chan, 0);
+		XTmrCtr_Reset(inst(xh), (u8)chan);
+	}
+
+	xh->channels[chan].mode = ch_config->mode;
+
+	return 0;
+}
+
+/**
+ * @brief Enable a timer channel.
+ * @note PL: XTmrCtr_PwmEnable() for PWM, XTmrCtr_Start() otherwise.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_pl_channel_enable(struct capi_timer_handle *handle,
+					uint32_t chan)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+	/*
+	 * XTmrCtr_PwmConfigure programs BOTH timers (Timer 0 = period, Timer 1 =
+	 * high-time), so a PWM configured on channel 0 owns channel 1. Channel 1
+	 * therefore cannot be enabled on its own while PWM is active - reject it
+	 * (EINVAL) ahead of the not-initialized check.
+	 */
+	if (chan == 1 && xh->channels[0].mode == CAPI_TIMER_PWM_MODE)
+		return -EINVAL;
+	if (!xh->channels[chan].initialized)
+		return -ENODEV;
+
+	if (xh->channels[chan].mode == CAPI_TIMER_PWM_MODE) {
+		if (chan != 0)
+			return -EINVAL;
+		xh->channels[0].enabled = true;
+		xh->channels[1].enabled = true;
+		XTmrCtr_PwmEnable(inst(xh));
+		return 0;
+	}
+
+	xh->channels[chan].enabled = true;
+	XTmrCtr_Start(inst(xh), (u8)chan);
+
+	return 0;
+}
+
+/**
+ * @brief Disable a timer channel.
+ * @note PL: XTmrCtr_PwmDisable() for PWM, XTmrCtr_Stop() otherwise.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_pl_channel_disable(struct capi_timer_handle *handle,
+		uint32_t chan)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+	if (!xh->channels[chan].initialized)
+		return -ENODEV;
+
+	if (xh->channels[chan].mode == CAPI_TIMER_PWM_MODE) {
+		if (chan != 0)
+			return -EINVAL;
+		xh->channels[0].enabled = false;
+		xh->channels[1].enabled = false;
+		XTmrCtr_PwmDisable(inst(xh));
+		return 0;
+	}
+
+	xh->channels[chan].enabled = false;
+	XTmrCtr_Stop(inst(xh), (u8)chan);
+
+	return 0;
+}
+
+/**
+ * @brief Set a timer channel compare value.
+ * @note PL: XTmrCtr_SetResetValue()/SetOptions().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_pl_channel_compare_set(struct capi_timer_handle *handle,
+		uint32_t chan,
+		uint32_t compare)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+	if (!xh->channels[chan].initialized)
+		return -ENODEV;
+	if (compare == 0)
+		return -EINVAL;
+
+	XTmrCtr_SetResetValue(inst(xh), (u8)chan, compare);
+
+	u32 options = XTmrCtr_GetOptions(inst(xh), (u8)chan);
+	options |= XTC_AUTO_RELOAD_OPTION | XTC_DOWN_COUNT_OPTION;
+	XTmrCtr_SetOptions(inst(xh), (u8)chan, options);
+	XTmrCtr_Reset(inst(xh), (u8)chan);
+
+	return 0;
+}
+
+/**
+ * @brief Get a timer channel compare value.
+ * @note PL: XTmrCtr_ReadReg(XTC_TLR_OFFSET).
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_pl_channel_compare_get(struct capi_timer_handle *handle,
+		uint32_t chan,
+		uint32_t *compare)
+{
+	if (!handle || !compare)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+	if (!xh->channels[chan].initialized)
+		return -ENODEV;
+
+	*compare = XTmrCtr_ReadReg(inst(xh)->BaseAddress, (u8)chan, XTC_TLR_OFFSET);
+
+	return 0;
+}
+
+/**
+ * @brief Get a timer channel capture value.
+ * @note PL: XTmrCtr_GetCaptureValue().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_pl_channel_capture_get(struct capi_timer_handle *handle,
+		uint32_t chan,
+		uint32_t *capture)
+{
+	if (!handle || !capture)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+	if (!xh->channels[chan].initialized)
+		return -ENODEV;
+
+	*capture = XTmrCtr_GetCaptureValue(inst(xh), (u8)chan);
+
+	return 0;
+}
+
+/**
+ * @brief Enable timer channel interrupts.
+ * @note PL: Enables XTC_INT_MODE_OPTION.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_pl_channel_irq_enable(struct capi_timer_handle *handle,
+		uint32_t chan,
+		uint32_t event)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+	if (!xh->channels[chan].initialized)
+		return -ENODEV;
+
+	if ((xh->channels[chan].mode == CAPI_TIMER_CAPTURE_MODE &&
+	     event != CAPI_TIMER_CHANNEL_EVENT_CAPTURE) ||
+	    (xh->channels[chan].mode != CAPI_TIMER_CAPTURE_MODE &&
+	     event != CAPI_TIMER_CHANNEL_EVENT_COMPARE))
+		return -ENOTSUP;
+
+	if (!xh->use_irq)
+		return -ENOTSUP;
+
+	/*
+	 * On channel 0 the terminal-count interrupt is shared with the global
+	 * overflow event (see event_irq_enable). Refuse compare while overflow is
+	 * armed so one expiry drives only one callback. Other channels have no
+	 * overflow event, so they are unaffected.
+	 */
+	if (chan == 0 && xh->event_irq_enabled)
+		return -EBUSY;
+
+	xh->channels[chan].use_irq = true;
+
+	u32 options = XTmrCtr_GetOptions(inst(xh), (u8)chan);
+	options |= XTC_INT_MODE_OPTION;
+	XTmrCtr_SetOptions(inst(xh), (u8)chan, options);
+
+	return 0;
+}
+
+/**
+ * @brief Disable timer channel interrupts.
+ * @note PL: Clears XTC_INT_MODE_OPTION.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_pl_channel_irq_disable(struct capi_timer_handle *handle,
+		uint32_t chan,
+		uint32_t event)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+	if (!xh->channels[chan].initialized)
+		return -ENODEV;
+
+	if ((xh->channels[chan].mode == CAPI_TIMER_CAPTURE_MODE &&
+	     event != CAPI_TIMER_CHANNEL_EVENT_CAPTURE) ||
+	    (xh->channels[chan].mode != CAPI_TIMER_CAPTURE_MODE &&
+	     event != CAPI_TIMER_CHANNEL_EVENT_COMPARE))
+		return -ENOTSUP;
+
+	xh->channels[chan].use_irq = false;
+
+	if (chan != 0 || !xh->event_irq_enabled) {
+		u32 options = XTmrCtr_GetOptions(inst(xh), (u8)chan);
+		options &= ~XTC_INT_MODE_OPTION;
+		XTmrCtr_SetOptions(inst(xh), (u8)chan, options);
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Register a timer channel callback.
+ * @note PL: Stores channel callback.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_pl_channel_register_callback(struct capi_timer_handle
+		*handle, uint32_t chan,
+		capi_timer_channel_callback callback,
+		void *callback_arg)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+
+	if (xh->use_irq)
+		capi_irq_disable(xh->irq_id);
+	xh->channels[chan].callback = callback;
+	xh->channels[chan].callback_arg = callback_arg;
+	if (xh->use_irq)
+		capi_irq_enable(xh->irq_id);
+
+	return 0;
+}
+
+/**
+ * @brief Check whether a timer interrupt is pending.
+ * @note PL: XTmrCtr_IsExpired().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_pl_is_irq_pending(struct capi_timer_handle *handle,
+					bool *pending)
+{
+	if (!handle || !pending)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	*pending = (XTmrCtr_IsExpired(inst(xh), 0) != 0) ||
+		   (XTmrCtr_IsExpired(inst(xh), 1) != 0);
+
+	return 0;
+}
+
+/**
+ * @brief Dispatch the timer interrupt handler.
+ * @note PL: XTmrCtr_InterruptHandler().
+ *
+ */
+static void capi_timer_pl_isr(struct capi_timer_handle *handle)
+{
+	if (!handle)
+		return;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	XTmrCtr_InterruptHandler(inst(xh));
+}
+
+/**
+ * @brief Convert nanoseconds to timer ticks.
+ * @note PL: Converts ns using input clock.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_pl_nsec_to_ticks(const struct capi_timer_handle *handle,
+				       uint64_t duration_ns,
+				       uint32_t *ticks)
+{
+	if (!handle || !ticks)
+		return -EINVAL;
+
+	const struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (xh->input_clock_hz == 0)
+		return -EINVAL;
+
+	/* Split before multiplying to avoid 64-bit overflow. */
+	uint64_t whole = duration_ns / CAPI_TIMER_NSEC_PER_SEC;
+	uint64_t remainder = duration_ns % CAPI_TIMER_NSEC_PER_SEC;
+
+	if (whole > UINT32_MAX / xh->input_clock_hz)
+		return -EOVERFLOW;
+
+	uint64_t result = whole * xh->input_clock_hz;
+	uint64_t fraction = (remainder * xh->input_clock_hz) /
+			    CAPI_TIMER_NSEC_PER_SEC;
+
+	if (fraction > UINT32_MAX - result)
+		return -EOVERFLOW;
+
+	result += fraction;
+	*ticks = (uint32_t)result;
+	return 0;
+}
+
+/**
+ * @brief Convert timer ticks to nanoseconds.
+ * @note PL: Converts ticks using input clock.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_pl_ticks_to_nsec(const struct capi_timer_handle *handle,
+				       uint64_t ticks,
+				       uint32_t *duration_ns)
+{
+	if (!handle || !duration_ns)
+		return -EINVAL;
+
+	const struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (xh->input_clock_hz == 0)
+		return -EINVAL;
+
+	/* Split before multiplying to avoid 64-bit overflow. */
+	uint64_t whole = ticks / xh->input_clock_hz;
+	uint64_t remainder = ticks % xh->input_clock_hz;
+
+	if (whole > UINT32_MAX / CAPI_TIMER_NSEC_PER_SEC)
+		return -EOVERFLOW;
+
+	uint64_t result = whole * CAPI_TIMER_NSEC_PER_SEC;
+	uint64_t fraction = (remainder * CAPI_TIMER_NSEC_PER_SEC) /
+			    xh->input_clock_hz;
+
+	if (fraction > UINT32_MAX - result)
+		return -EOVERFLOW;
+
+	result += fraction;
+	*duration_ns = (uint32_t)result;
+	return 0;
+}
+
+#endif /* XPAR_XTMRCTR_NUM_INSTANCES */

--- a/capi/platform/xilinx/xilinx_capi_timer_priv.h
+++ b/capi/platform/xilinx/xilinx_capi_timer_priv.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Xilinx platform Timer private driver contract.
+ */
+
+#ifndef _XILINX_CAPI_TIMER_PRIV_H_
+#define _XILINX_CAPI_TIMER_PRIV_H_
+
+#include <xilinx_capi_timer.h>
+
+#include "xparameters.h"
+#ifdef XPAR_XSCUTIMER_NUM_INSTANCES
+#include "xscutimer.h"
+#endif
+#ifdef XPAR_XTTCPS_NUM_INSTANCES
+#include "xttcps.h"
+#endif
+#ifdef XPAR_XTMRCTR_NUM_INSTANCES
+#include "xtmrctr.h"
+#include "xtmrctr_l.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @struct capi_timer_xilinx_channel
+ * @brief Per-channel state tracking.
+ */
+struct capi_timer_xilinx_channel {
+	/** Channel has been initialized */
+	bool initialized;
+	/** Channel is running */
+	bool enabled;
+	/** Current mode */
+	enum capi_timer_channel_mode mode;
+	/** User callback */
+	capi_timer_channel_callback callback;
+	/** Callback argument */
+	void *callback_arg;
+	/** IRQ enabled for this channel */
+	bool use_irq;
+};
+
+/**
+ * @struct capi_timer_xilinx_handle
+ * @brief Shared Xilinx timer private state.
+ */
+struct capi_timer_xilinx_handle {
+	/** XTmrCtr*, XTtcPs*, or XScuTimer* instance */
+	void *instance;
+	/** Input clock frequency in Hz */
+	uint32_t input_clock_hz;
+	/** IRQ ID (only valid if use_irq is true) */
+	uint32_t irq_id;
+	/** True if IRQ was successfully connected during init */
+	bool use_irq;
+	/** Global timer event IRQ is logically enabled */
+	bool event_irq_enabled;
+	/** Number of channels actually used by this backend (set at init) */
+	uint8_t num_channels;
+	/** Per-channel state - sized for the widest backend (AXI: 2 channels) */
+	struct capi_timer_xilinx_channel channels[2];
+	/** Global timer event callback */
+	capi_timer_event_callback event_callback;
+	/** Event callback argument */
+	void *event_callback_arg;
+};
+
+/**
+ * @brief Declare a stack-allocated Xilinx Timer handle.
+ *
+ * Declares `name` (struct capi_timer_handle) with embedded private state.
+ * Pass &name to capi_timer_init().
+ */
+#define CAPI_TIMER_HANDLE_XILINX_DEFINE(name)                          \
+	struct capi_timer_handle name = {                                  \
+		.ops = NULL,                                                   \
+		.init_allocated = false,                                       \
+		.priv = &(struct capi_timer_xilinx_handle){0}                  \
+	}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _XILINX_CAPI_TIMER_PRIV_H_ */

--- a/capi/platform/xilinx/xilinx_capi_timer_ps_scu.c
+++ b/capi/platform/xilinx/xilinx_capi_timer_ps_scu.c
@@ -1,0 +1,925 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Xilinx PS SCU Private Timer (XScuTimer) driver for CAPI
+ *
+ * Single channel, 32-bit down-counting timer private to Cortex-A9 CPU.
+ * Supports compare/auto-reload mode only (no capture, no PWM).
+ * capi_irq_init() must be called before IRQ-driven async ops will work.
+ *
+ * The HW has ONE "counter expired" interrupt and NO separate compare register:
+ * the compare value is the reload/period, so a channel compare match and a
+ * global counter overflow are the same physical event. The two events cannot
+ * be armed at the same time (the second returns -EBUSY) so a single expiry
+ * never fires both callbacks.
+ */
+
+#include <capi_alloc.h>
+#include <string.h>
+#include <errno.h>
+#include <capi_timer.h>
+#include <capi_irq.h>
+#include <xilinx_capi_timer_priv.h>
+#include "xinterrupt_wrap.h"
+
+#ifdef XPAR_XSCUTIMER_NUM_INSTANCES
+
+#define CAPI_TIMER_NSEC_PER_SEC	1000000000ULL
+
+static int capi_timer_ps_scu_init(struct capi_timer_handle **handle,
+				  const struct capi_timer_config *config);
+static int capi_timer_ps_scu_deinit(struct capi_timer_handle *handle);
+static int capi_timer_ps_scu_start(struct capi_timer_handle *handle);
+static int capi_timer_ps_scu_stop(struct capi_timer_handle *handle);
+static int capi_timer_ps_scu_counter_config(struct capi_timer_handle *handle,
+		const struct capi_timer_counter_config *config);
+static int capi_timer_ps_scu_counter_get(struct capi_timer_handle *handle,
+		uint32_t *counter);
+static int capi_timer_ps_scu_event_irq_enable(struct capi_timer_handle *handle,
+		uint32_t event);
+static int capi_timer_ps_scu_event_irq_disable(struct capi_timer_handle *handle,
+		uint32_t event);
+static int capi_timer_ps_scu_register_event_callback(struct capi_timer_handle
+		*handle,
+		capi_timer_event_callback callback,
+		void *callback_arg);
+static int capi_timer_ps_scu_channel_init(struct capi_timer_handle *handle,
+		uint32_t chan);
+static int capi_timer_ps_scu_channel_deinit(struct capi_timer_handle *handle,
+		uint32_t chan);
+static int capi_timer_ps_scu_channel_config(struct capi_timer_handle *handle,
+		uint32_t chan,
+		const struct capi_timer_channel_config *ch_config);
+static int capi_timer_ps_scu_channel_enable(struct capi_timer_handle *handle,
+		uint32_t chan);
+static int capi_timer_ps_scu_channel_disable(struct capi_timer_handle *handle,
+		uint32_t chan);
+static int capi_timer_ps_scu_channel_compare_set(struct capi_timer_handle
+		*handle, uint32_t chan,
+		uint32_t compare);
+static int capi_timer_ps_scu_channel_compare_get(struct capi_timer_handle
+		*handle, uint32_t chan,
+		uint32_t *compare);
+static int capi_timer_ps_scu_channel_capture_get(struct capi_timer_handle
+		*handle, uint32_t chan,
+		uint32_t *capture);
+static int capi_timer_ps_scu_channel_irq_enable(struct capi_timer_handle
+		*handle, uint32_t chan,
+		uint32_t event);
+static int capi_timer_ps_scu_channel_irq_disable(struct capi_timer_handle
+		*handle, uint32_t chan,
+		uint32_t event);
+static int capi_timer_ps_scu_channel_register_callback(struct capi_timer_handle
+		*handle,
+		uint32_t chan,
+		capi_timer_channel_callback callback,
+		void *callback_arg);
+static int capi_timer_ps_scu_is_irq_pending(struct capi_timer_handle *handle,
+		bool *pending);
+static void capi_timer_ps_scu_isr(struct capi_timer_handle *handle);
+static int capi_timer_ps_scu_nsec_to_ticks(const struct capi_timer_handle
+		*handle,
+		uint64_t duration_ns, uint32_t *ticks);
+static int capi_timer_ps_scu_ticks_to_nsec(const struct capi_timer_handle
+		*handle, uint64_t ticks,
+		uint32_t *duration_ns);
+
+#define PS_SCU_NUM_CHANNELS 1
+
+const struct capi_timer_ops capi_timer_xilinx_ps_scu_ops = {
+	.init = capi_timer_ps_scu_init,
+	.deinit = capi_timer_ps_scu_deinit,
+	.start = capi_timer_ps_scu_start,
+	.stop = capi_timer_ps_scu_stop,
+	.counter_config = capi_timer_ps_scu_counter_config,
+	.counter_get = capi_timer_ps_scu_counter_get,
+	.event_irq_enable = capi_timer_ps_scu_event_irq_enable,
+	.event_irq_disable = capi_timer_ps_scu_event_irq_disable,
+	.register_event_callback = capi_timer_ps_scu_register_event_callback,
+	.channel_init = capi_timer_ps_scu_channel_init,
+	.channel_deinit = capi_timer_ps_scu_channel_deinit,
+	.channel_config = capi_timer_ps_scu_channel_config,
+	.channel_enable = capi_timer_ps_scu_channel_enable,
+	.channel_disable = capi_timer_ps_scu_channel_disable,
+	.channel_compare_set = capi_timer_ps_scu_channel_compare_set,
+	.channel_compare_get = capi_timer_ps_scu_channel_compare_get,
+	.channel_capture_get = capi_timer_ps_scu_channel_capture_get,
+	.channel_irq_enable = capi_timer_ps_scu_channel_irq_enable,
+	.channel_irq_disable = capi_timer_ps_scu_channel_irq_disable,
+	.channel_register_callback = capi_timer_ps_scu_channel_register_callback,
+	.is_irq_pending = capi_timer_ps_scu_is_irq_pending,
+	.isr = capi_timer_ps_scu_isr,
+	.nsec_to_ticks = capi_timer_ps_scu_nsec_to_ticks,
+	.ticks_to_nsec = capi_timer_ps_scu_ticks_to_nsec,
+};
+
+static XScuTimer *inst(struct capi_timer_xilinx_handle *xh)
+{
+	return (XScuTimer *)xh->instance;
+}
+
+static void xilinx_timer_free_allocated_handle(struct capi_timer_handle
+		**handle)
+{
+	if (handle == NULL || *handle == NULL)
+		return;
+
+	capi_free((*handle)->priv);
+	capi_free(*handle);
+	*handle = NULL;
+}
+
+static void xilinx_timer_clear_app_handle(struct capi_timer_handle *handle)
+{
+	if (handle != NULL)
+		handle->ops = NULL;
+}
+
+static int check_timer_config(const struct capi_timer_config *config)
+{
+	if (config->input_clock_identifier != 0)
+		return -ENOTSUP;
+
+	/*
+	 * input_clock_hz is 64-bit but the SCU prescaler math and the ns<->ticks
+	 * conversions use a 32-bit clock. A value that does not fit in 32 bits
+	 * would truncate - potentially to zero - and then be used as a divisor
+	 * (src_clk / (prescaler + 1), and input_clock_hz in the conversions).
+	 * Reject an out-of-range clock up front rather than divide by a bogus or
+	 * zero value.
+	 */
+	if (config->input_clock_hz > UINT32_MAX ||
+	    config->output_freq_hz > UINT32_MAX)
+		return -ENOTSUP;
+
+	return 0;
+}
+
+static int check_compare_config(const struct capi_timer_compare_config *config)
+{
+	if (config->generate_pulse_on_match || config->output_identifier != 0 ||
+	    config->polarity != CAPI_TIMER_ON_COMPARE_KEEP || config->stop_enabled ||
+	    config->extra != NULL)
+		return -ENOTSUP;
+
+	return 0;
+}
+
+static void irq_handler(void *ref)
+{
+	capi_timer_ps_scu_isr((struct capi_timer_handle *)ref);
+}
+
+/**
+ * @brief Initialize the CAPI timer backend instance.
+ * @note PS: XScuTimer_LookupConfig()/XScuTimer_CfgInitialize().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_scu_init(struct capi_timer_handle **handle,
+				  const struct capi_timer_config *config)
+{
+	if (!handle || !config)
+		return -EINVAL;
+	if (check_timer_config(config) != 0)
+		return -ENOTSUP;
+
+	bool alloc_handle = (*handle == NULL);
+	struct capi_timer_handle *h = *handle;
+	struct capi_timer_xilinx_handle *xh;
+
+	if (alloc_handle) {
+		h = capi_malloc(sizeof(*h));
+		if (!h)
+			return -ENOMEM;
+		memset(h, 0, sizeof(*h));
+
+		xh = capi_malloc(sizeof(*xh));
+		if (!xh) {
+			capi_free(h);
+			return -ENOMEM;
+		}
+		h->priv = xh;
+		*handle = h;
+	} else {
+		xh = h->priv;
+		if (!xh)
+			return -EINVAL;
+		if (h->ops != NULL || xh->instance != NULL)
+			return -EBUSY;
+	}
+
+	memset(xh, 0, sizeof(*xh));
+	h->init_allocated = alloc_handle;
+	h->ops = config->ops ? config->ops : &capi_timer_xilinx_ps_scu_ops;
+	h->priv = xh;
+	xh->input_clock_hz = (uint32_t)config->input_clock_hz;
+
+	XScuTimer *xi = capi_malloc(sizeof(XScuTimer));
+	if (!xi) {
+		if (alloc_handle)
+			xilinx_timer_free_allocated_handle(handle);
+		else
+			xilinx_timer_clear_app_handle(h);
+		return -ENOMEM;
+	}
+	memset(xi, 0, sizeof(XScuTimer));
+
+	XScuTimer_Config *cfg = XScuTimer_LookupConfig((UINTPTR)config->identifier);
+	if (!cfg) {
+		capi_free(xi);
+		if (alloc_handle)
+			xilinx_timer_free_allocated_handle(handle);
+		else
+			xilinx_timer_clear_app_handle(h);
+		return -ENODEV;
+	}
+
+	int status = XScuTimer_CfgInitialize(xi, cfg, cfg->BaseAddr);
+	if (status != XST_SUCCESS) {
+		capi_free(xi);
+		if (alloc_handle)
+			xilinx_timer_free_allocated_handle(handle);
+		else
+			xilinx_timer_clear_app_handle(h);
+		return -EIO;
+	}
+
+	XScuTimer_EnableAutoReload(xi);
+
+	/*
+	 * Configure prescaler: SCU prescaler value N divides by N+1 (0..255).
+	 * If output_freq_hz is requested, compute the closest prescaler.
+	 */
+	uint32_t src_clk = (uint32_t)config->input_clock_hz;
+	if (config->output_freq_hz > 0) {
+		if (src_clk == 0) {
+			XScuTimer_Stop(xi);
+			capi_free(xi);
+			if (alloc_handle)
+				xilinx_timer_free_allocated_handle(handle);
+			else
+				xilinx_timer_clear_app_handle(h);
+			return -EINVAL;
+		}
+		uint32_t target = (uint32_t)config->output_freq_hz;
+		if (target >= src_clk) {
+			XScuTimer_SetPrescaler(xi, 0);
+			xh->input_clock_hz = src_clk;
+		} else {
+			uint32_t prescaler =
+				(uint32_t)(((uint64_t)src_clk + target / 2U) /
+					   target - 1U);
+			if (prescaler > 255)
+				prescaler = 255;
+			XScuTimer_SetPrescaler(xi, (u8)prescaler);
+			xh->input_clock_hz = src_clk / (prescaler + 1);
+		}
+	}
+
+	xh->instance = xi;
+	xh->num_channels = PS_SCU_NUM_CHANNELS;
+
+	const struct capi_timer_xilinx_config *xcfg =
+		(const struct capi_timer_xilinx_config *)config->extra;
+	if (xcfg != NULL && xcfg->use_irq) {
+		uint32_t irq_id = xcfg->irq_id;
+		XScuTimer_ClearInterruptStatus(xi);
+		int ret = capi_irq_connect(irq_id, irq_handler, h);
+		if (ret == 0) {
+			capi_irq_set_level_edge_trigger(irq_id, CAPI_IRQ_LEVEL_HIGH);
+			ret = capi_irq_enable(irq_id);
+			if (ret == 0) {
+				xh->irq_id = irq_id;
+				xh->use_irq = true;
+			}
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Deinitialize the CAPI timer backend instance.
+ * @note PS: XScuTimer_Stop() then capi_free.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_scu_deinit(struct capi_timer_handle *handle)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+	if (!xh)
+		return -EINVAL;
+
+	if (xh->use_irq) {
+		capi_irq_disable(xh->irq_id);
+		xh->use_irq = false;
+	}
+
+	if (xh->instance) {
+		XScuTimer_Stop(inst(xh));
+		XScuTimer_DisableInterrupt(inst(xh));
+		XScuTimer_ClearInterruptStatus(inst(xh));
+		capi_free(xh->instance);
+		xh->instance = NULL;
+	}
+
+	if (handle->init_allocated) {
+		capi_free(xh);
+		capi_free(handle);
+	} else {
+		handle->ops = NULL;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Start the timer counter.
+ * @note PS: XScuTimer_Start().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_scu_start(struct capi_timer_handle *handle)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+	XScuTimer_Start(inst(xh));
+
+	return 0;
+}
+
+/**
+ * @brief Stop the timer counter.
+ * @note PS: XScuTimer_Stop().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_scu_stop(struct capi_timer_handle *handle)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+	XScuTimer_Stop(inst(xh));
+
+	return 0;
+}
+
+/**
+ * @brief Configure the timer counter.
+ * @note PS: XScuTimer_LoadTimer().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_scu_counter_config(struct capi_timer_handle *handle,
+		const struct capi_timer_counter_config *config)
+{
+	if (!handle || !config)
+		return -EINVAL;
+	if (config->extra != NULL)
+		return -ENOTSUP;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (config->direction != CAPI_TIMER_COUNT_DOWN)
+		return -ENOTSUP;
+	if (config->min != 0)
+		return -ENOTSUP;
+	if (!config->rollover)
+		return -ENOTSUP;
+	if (config->max == 0)
+		return -EINVAL;
+	/*
+	 * The SCU private timer counts N+1 cycles for a load value of N (it
+	 * expires when the count rolls from 0 past the reload), so program
+	 * max-1 to get exactly max ticks per period.
+	 */
+	XScuTimer_LoadTimer(inst(xh), config->max - 1);
+
+	return 0;
+}
+
+/**
+ * @brief Read the timer counter value.
+ * @note PS: XScuTimer_GetCounterValue().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_scu_counter_get(struct capi_timer_handle *handle,
+		uint32_t *counter)
+{
+	if (!handle || !counter)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	*counter = XScuTimer_GetCounterValue(inst(xh));
+
+	return 0;
+}
+
+/**
+ * @brief Enable timer global event interrupts.
+ * @note PS: XScuTimer_EnableInterrupt().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_scu_event_irq_enable(struct capi_timer_handle *handle,
+		uint32_t event)
+{
+	if (!handle)
+		return -EINVAL;
+
+	if (event != CAPI_TIMER_GLOBAL_EVENT_COUNTER_OVERFLOW)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+	if (!xh->use_irq)
+		return -ENOTSUP;
+
+	/*
+	 * The SCU private timer has a single "counter expired" interrupt and no
+	 * separate compare register, so overflow and channel compare are the same
+	 * physical event. Refuse to arm overflow while compare is armed: one
+	 * expiry must not silently fire both callbacks. Callers pick one.
+	 */
+	if (xh->channels[0].use_irq)
+		return -EBUSY;
+
+	XScuTimer_EnableInterrupt(inst(xh));
+	xh->event_irq_enabled = true;
+
+	return 0;
+}
+
+/**
+ * @brief Disable timer global event interrupts.
+ * @note PS: XScuTimer_DisableInterrupt().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_scu_event_irq_disable(struct capi_timer_handle *handle,
+		uint32_t event)
+{
+	if (!handle)
+		return -EINVAL;
+
+	if (event != CAPI_TIMER_GLOBAL_EVENT_COUNTER_OVERFLOW)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	xh->event_irq_enabled = false;
+	if (!xh->channels[0].use_irq)
+		XScuTimer_DisableInterrupt(inst(xh));
+
+	return 0;
+}
+
+/**
+ * @brief Register the timer global event callback.
+ * @note PS: Stores overflow callback.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_scu_register_event_callback(struct capi_timer_handle
+		*handle,
+		capi_timer_event_callback callback,
+		void *callback_arg)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	xh->event_callback = callback;
+	xh->event_callback_arg = callback_arg;
+
+	return 0;
+}
+
+/**
+ * @brief Initialize the CAPI timer backend instance.
+ * @note PS: Marks channel initialized.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_scu_channel_init(struct capi_timer_handle *handle,
+		uint32_t chan)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+
+	xh->channels[0].initialized = true;
+	xh->channels[0].enabled = false;
+	xh->channels[0].mode = CAPI_TIMER_COMPARE_MODE;
+
+	return 0;
+}
+
+/**
+ * @brief Deinitialize the CAPI timer backend instance.
+ * @note PS: Disables and clears channel state.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_scu_channel_deinit(struct capi_timer_handle *handle,
+		uint32_t chan)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+
+	capi_timer_ps_scu_channel_disable(handle, 0);
+	xh->channels[0].use_irq = false;
+	if (!xh->event_irq_enabled) {
+		XScuTimer_DisableInterrupt(inst(xh));
+		XScuTimer_ClearInterruptStatus(inst(xh));
+	}
+	memset(&xh->channels[0], 0, sizeof(struct capi_timer_xilinx_channel));
+
+	return 0;
+}
+
+/**
+ * @brief Configure a timer channel.
+ * @note PS: XScuTimer_LoadTimer().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_scu_channel_config(struct capi_timer_handle *handle,
+		uint32_t chan,
+		const struct capi_timer_channel_config *ch_config)
+{
+	if (!handle || !ch_config)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+	if (ch_config->extra != NULL)
+		return -ENOTSUP;
+
+	if (ch_config->mode != CAPI_TIMER_COMPARE_MODE)
+		return -ENOTSUP;
+	if (check_compare_config(&ch_config->config.compare) != 0)
+		return -ENOTSUP;
+
+	if (ch_config->config.compare.match_value == 0)
+		return -EINVAL;
+	XScuTimer_LoadTimer(inst(xh), ch_config->config.compare.match_value - 1);
+
+	xh->channels[0].mode = CAPI_TIMER_COMPARE_MODE;
+
+	return 0;
+}
+
+/**
+ * @brief Enable a timer channel.
+ * @note PS: XScuTimer_Start().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_scu_channel_enable(struct capi_timer_handle *handle,
+		uint32_t chan)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+
+	xh->channels[0].enabled = true;
+	XScuTimer_Start(inst(xh));
+
+	return 0;
+}
+
+/**
+ * @brief Disable a timer channel.
+ * @note PS: XScuTimer_Stop().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_scu_channel_disable(struct capi_timer_handle *handle,
+		uint32_t chan)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+
+	xh->channels[0].enabled = false;
+	XScuTimer_Stop(inst(xh));
+
+	return 0;
+}
+
+/**
+ * @brief Set a timer channel compare value.
+ * @note PS: XScuTimer_LoadTimer().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_scu_channel_compare_set(struct capi_timer_handle
+		*handle, uint32_t chan,
+		uint32_t compare)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+
+	if (compare == 0)
+		return -EINVAL;
+	XScuTimer_LoadTimer(inst(xh), compare - 1);
+
+	return 0;
+}
+
+/**
+ * @brief Get a timer channel compare value.
+ * @note PS: XScuTimer_ReadReg(XSCUTIMER_LOAD_OFFSET).
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_scu_channel_compare_get(struct capi_timer_handle
+		*handle, uint32_t chan,
+		uint32_t *compare)
+{
+	if (!handle || !compare)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+
+	/* HW load register holds match_value-1; add 1 to return user-facing value. */
+	*compare = XScuTimer_ReadReg(inst(xh)->Config.BaseAddr,
+				     XSCUTIMER_LOAD_OFFSET) + 1U;
+
+	return 0;
+}
+
+/**
+ * @brief Get a timer channel capture value.
+ * @note PS: Returns -ENOTSUP.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_scu_channel_capture_get(struct capi_timer_handle
+		*handle, uint32_t chan,
+		uint32_t *capture)
+{
+	(void)handle;
+	(void)chan;
+	(void)capture;
+	return -ENOTSUP;
+}
+
+/**
+ * @brief Enable timer channel interrupts.
+ * @note PS: XScuTimer_EnableInterrupt().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_scu_channel_irq_enable(struct capi_timer_handle
+		*handle, uint32_t chan,
+		uint32_t event)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+
+	if (event != CAPI_TIMER_CHANNEL_EVENT_COMPARE)
+		return -EINVAL;
+
+	if (!xh->use_irq)
+		return -ENOTSUP;
+
+	/*
+	 * Single shared "expired" interrupt (see event_irq_enable): refuse compare
+	 * while the global overflow event is armed so one expiry drives only one
+	 * callback.
+	 */
+	if (xh->event_irq_enabled)
+		return -EBUSY;
+
+	xh->channels[0].use_irq = true;
+	XScuTimer_EnableInterrupt(inst(xh));
+
+	return 0;
+}
+
+/**
+ * @brief Disable timer channel interrupts.
+ * @note PS: XScuTimer_DisableInterrupt().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_scu_channel_irq_disable(struct capi_timer_handle
+		*handle, uint32_t chan,
+		uint32_t event)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+
+	if (event != CAPI_TIMER_CHANNEL_EVENT_COMPARE)
+		return -EINVAL;
+
+	xh->channels[0].use_irq = false;
+	if (!xh->event_irq_enabled)
+		XScuTimer_DisableInterrupt(inst(xh));
+
+	return 0;
+}
+
+/**
+ * @brief Register a timer channel callback.
+ * @note PS: Stores channel callback.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_scu_channel_register_callback(struct capi_timer_handle
+		*handle,
+		uint32_t chan,
+		capi_timer_channel_callback callback,
+		void *callback_arg)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+
+	xh->channels[0].callback = callback;
+	xh->channels[0].callback_arg = callback_arg;
+
+	return 0;
+}
+
+/**
+ * @brief Check whether a timer interrupt is pending.
+ * @note PS: XScuTimer_IsExpired().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_scu_is_irq_pending(struct capi_timer_handle *handle,
+		bool *pending)
+{
+	if (!handle || !pending)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	*pending = (XScuTimer_IsExpired(inst(xh)) != 0);
+
+	return 0;
+}
+
+/**
+ * @brief Dispatch the timer interrupt handler.
+ * @note PS: XScuTimer_ClearInterruptStatus().
+ *
+ */
+static void capi_timer_ps_scu_isr(struct capi_timer_handle *handle)
+{
+	if (!handle)
+		return;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	XScuTimer_ClearInterruptStatus(inst(xh));
+
+	if (xh->channels[0].use_irq && xh->channels[0].callback) {
+		xh->channels[0].callback(CAPI_TIMER_CHANNEL_EVENT_COMPARE, 0,
+					 xh->channels[0].callback_arg, 0);
+	}
+
+	if (xh->event_irq_enabled && xh->event_callback) {
+		xh->event_callback(CAPI_TIMER_GLOBAL_EVENT_COUNTER_OVERFLOW,
+				   xh->event_callback_arg,
+				   0);
+	}
+}
+
+/**
+ * @brief Convert nanoseconds to timer ticks.
+ * @note PS: Converts ns using input clock.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_scu_nsec_to_ticks(const struct capi_timer_handle
+		*handle,
+		uint64_t duration_ns, uint32_t *ticks)
+{
+	if (!handle || !ticks)
+		return -EINVAL;
+
+	const struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (xh->input_clock_hz == 0)
+		return -EINVAL;
+
+	/* Split ns into whole seconds and sub-second remainder to avoid 64-bit overflow. */
+	uint64_t whole = duration_ns / CAPI_TIMER_NSEC_PER_SEC;
+	uint64_t remainder = duration_ns % CAPI_TIMER_NSEC_PER_SEC;
+
+	/* ticks from whole seconds: whole_sec * clock_hz */
+	if (whole > UINT32_MAX / xh->input_clock_hz)
+		return -EOVERFLOW;
+
+	uint64_t result = whole * xh->input_clock_hz;
+	/* ticks from sub-second part: (remainder_ns * clock_hz) / 1e9 */
+	uint64_t fraction = (remainder * xh->input_clock_hz) /
+			    CAPI_TIMER_NSEC_PER_SEC;
+
+	if (fraction > UINT32_MAX - result)
+		return -EOVERFLOW;
+
+	result += fraction;
+	*ticks = (uint32_t)result;
+	return 0;
+}
+
+/**
+ * @brief Convert timer ticks to nanoseconds.
+ * @note PS: Converts ticks using input clock.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_scu_ticks_to_nsec(const struct capi_timer_handle
+		*handle, uint64_t ticks,
+		uint32_t *duration_ns)
+{
+	if (!handle || !duration_ns)
+		return -EINVAL;
+
+	const struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (xh->input_clock_hz == 0)
+		return -EINVAL;
+
+	/* Split ticks into whole seconds and sub-second remainder to avoid overflow. */
+	uint64_t whole = ticks / xh->input_clock_hz;
+	uint64_t remainder = ticks % xh->input_clock_hz;
+
+	/* ns from whole seconds: whole_sec * 1e9 */
+	if (whole > UINT32_MAX / CAPI_TIMER_NSEC_PER_SEC)
+		return -EOVERFLOW;
+
+	uint64_t result = whole * CAPI_TIMER_NSEC_PER_SEC;
+	/* ns from sub-second part: (remainder_ticks * 1e9) / clock_hz */
+	uint64_t fraction = (remainder * CAPI_TIMER_NSEC_PER_SEC) /
+			    xh->input_clock_hz;
+
+	if (fraction > UINT32_MAX - result)
+		return -EOVERFLOW;
+
+	result += fraction;
+	*duration_ns = (uint32_t)result;
+	return 0;
+}
+
+#endif /* XPAR_XSCUTIMER_NUM_INSTANCES */

--- a/capi/platform/xilinx/xilinx_capi_timer_ps_ttc.c
+++ b/capi/platform/xilinx/xilinx_capi_timer_ps_ttc.c
@@ -1,0 +1,1019 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Xilinx PS TTC (XTtcPs) driver for CAPI
+ *
+ * One channel per TTC instance (three TTC units per TTC block on Zynq-7000).
+ * capi_irq_init() must be called before IRQ-driven async ops will work.
+ */
+
+#include <capi_alloc.h>
+#include <string.h>
+#include <errno.h>
+#include <capi_timer.h>
+#include <capi_irq.h>
+#include <xilinx_capi_timer_priv.h>
+#include "xinterrupt_wrap.h"
+
+#ifdef XPAR_XTTCPS_NUM_INSTANCES
+
+#define CAPI_TIMER_NSEC_PER_SEC	1000000000ULL
+
+static int capi_timer_ps_ttc_init(struct capi_timer_handle **handle,
+				  const struct capi_timer_config *config);
+static int capi_timer_ps_ttc_deinit(struct capi_timer_handle *handle);
+static int capi_timer_ps_ttc_start(struct capi_timer_handle *handle);
+static int capi_timer_ps_ttc_stop(struct capi_timer_handle *handle);
+static int capi_timer_ps_ttc_counter_config(struct capi_timer_handle *handle,
+		const struct capi_timer_counter_config *config);
+static int capi_timer_ps_ttc_counter_get(struct capi_timer_handle *handle,
+		uint32_t *counter);
+static int capi_timer_ps_ttc_event_irq_enable(struct capi_timer_handle *handle,
+		uint32_t event);
+static int capi_timer_ps_ttc_event_irq_disable(struct capi_timer_handle *handle,
+		uint32_t event);
+static int capi_timer_ps_ttc_register_event_callback(struct capi_timer_handle
+		*handle,
+		capi_timer_event_callback callback,
+		void *callback_arg);
+static int capi_timer_ps_ttc_channel_init(struct capi_timer_handle *handle,
+		uint32_t chan);
+static int capi_timer_ps_ttc_channel_deinit(struct capi_timer_handle *handle,
+		uint32_t chan);
+static int capi_timer_ps_ttc_channel_config(struct capi_timer_handle *handle,
+		uint32_t chan,
+		const struct capi_timer_channel_config *ch_config);
+static int capi_timer_ps_ttc_channel_enable(struct capi_timer_handle *handle,
+		uint32_t chan);
+static int capi_timer_ps_ttc_channel_disable(struct capi_timer_handle *handle,
+		uint32_t chan);
+static int capi_timer_ps_ttc_channel_compare_set(struct capi_timer_handle
+		*handle, uint32_t chan,
+		uint32_t compare);
+static int capi_timer_ps_ttc_channel_compare_get(struct capi_timer_handle
+		*handle, uint32_t chan,
+		uint32_t *compare);
+static int capi_timer_ps_ttc_channel_capture_get(struct capi_timer_handle
+		*handle, uint32_t chan,
+		uint32_t *capture);
+static int capi_timer_ps_ttc_channel_irq_enable(struct capi_timer_handle
+		*handle, uint32_t chan,
+		uint32_t event);
+static int capi_timer_ps_ttc_channel_irq_disable(struct capi_timer_handle
+		*handle, uint32_t chan,
+		uint32_t event);
+static int capi_timer_ps_ttc_channel_register_callback(struct capi_timer_handle
+		*handle,
+		uint32_t chan,
+		capi_timer_channel_callback callback,
+		void *callback_arg);
+static int capi_timer_ps_ttc_is_irq_pending(struct capi_timer_handle *handle,
+		bool *pending);
+static void capi_timer_ps_ttc_isr(struct capi_timer_handle *handle);
+static int capi_timer_ps_ttc_nsec_to_ticks(const struct capi_timer_handle
+		*handle,
+		uint64_t duration_ns, uint32_t *ticks);
+static int capi_timer_ps_ttc_ticks_to_nsec(const struct capi_timer_handle
+		*handle, uint64_t ticks,
+		uint32_t *duration_ns);
+
+#define PS_TTC_NUM_CHANNELS 1
+/*
+ * When the TTC prescaler is enabled it divides the source clock by
+ * 2^(prescaler+1), so a register value P yields a divisor of 2 << P. We use
+ * a fixed prescaler here and pre-divide the reported input clock to match, so
+ * the ns<->ticks conversions see the actual counter tick rate.
+ */
+#define PS_TTC_PRESCALER 0U
+#define PS_TTC_CLOCK_DIVISOR (2U << PS_TTC_PRESCALER)
+
+static bool ttc_interval_fits(uint32_t value)
+{
+#if defined(ARMA9)
+	return value <= XTTCPS_MAX_INTERVAL_COUNT;
+#else
+	(void)value;
+	return true;
+#endif
+}
+
+const struct capi_timer_ops capi_timer_xilinx_ps_ttc_ops = {
+	.init = capi_timer_ps_ttc_init,
+	.deinit = capi_timer_ps_ttc_deinit,
+	.start = capi_timer_ps_ttc_start,
+	.stop = capi_timer_ps_ttc_stop,
+	.counter_config = capi_timer_ps_ttc_counter_config,
+	.counter_get = capi_timer_ps_ttc_counter_get,
+	.event_irq_enable = capi_timer_ps_ttc_event_irq_enable,
+	.event_irq_disable = capi_timer_ps_ttc_event_irq_disable,
+	.register_event_callback = capi_timer_ps_ttc_register_event_callback,
+	.channel_init = capi_timer_ps_ttc_channel_init,
+	.channel_deinit = capi_timer_ps_ttc_channel_deinit,
+	.channel_config = capi_timer_ps_ttc_channel_config,
+	.channel_enable = capi_timer_ps_ttc_channel_enable,
+	.channel_disable = capi_timer_ps_ttc_channel_disable,
+	.channel_compare_set = capi_timer_ps_ttc_channel_compare_set,
+	.channel_compare_get = capi_timer_ps_ttc_channel_compare_get,
+	.channel_capture_get = capi_timer_ps_ttc_channel_capture_get,
+	.channel_irq_enable = capi_timer_ps_ttc_channel_irq_enable,
+	.channel_irq_disable = capi_timer_ps_ttc_channel_irq_disable,
+	.channel_register_callback = capi_timer_ps_ttc_channel_register_callback,
+	.is_irq_pending = capi_timer_ps_ttc_is_irq_pending,
+	.isr = capi_timer_ps_ttc_isr,
+	.nsec_to_ticks = capi_timer_ps_ttc_nsec_to_ticks,
+	.ticks_to_nsec = capi_timer_ps_ttc_ticks_to_nsec,
+};
+
+static XTtcPs *inst(struct capi_timer_xilinx_handle *xh)
+{
+	return (XTtcPs *)xh->instance;
+}
+
+static void xilinx_timer_free_allocated_handle(struct capi_timer_handle
+		**handle)
+{
+	if (handle == NULL || *handle == NULL)
+		return;
+
+	capi_free((*handle)->priv);
+	capi_free(*handle);
+	*handle = NULL;
+}
+
+static void xilinx_timer_clear_app_handle(struct capi_timer_handle *handle)
+{
+	if (handle != NULL)
+		handle->ops = NULL;
+}
+
+static int check_timer_config(const struct capi_timer_config *config)
+{
+	if (config->input_clock_identifier != 0)
+		return -ENOTSUP;
+
+	return 0;
+}
+
+static int check_compare_config(const struct capi_timer_compare_config *config)
+{
+	if (config->generate_pulse_on_match || config->output_identifier != 0 ||
+	    config->polarity != CAPI_TIMER_ON_COMPARE_KEEP || config->stop_enabled ||
+	    config->extra != NULL)
+		return -ENOTSUP;
+
+	return 0;
+}
+
+static int check_pwm_config(const struct capi_timer_pwm_config *config)
+{
+	if (config->output_identifier != 0 || config->offset_ns != 0
+	    || config->extra != NULL)
+		return -ENOTSUP;
+
+	return 0;
+}
+
+static void irq_handler(void *ref)
+{
+	capi_timer_ps_ttc_isr((struct capi_timer_handle *)ref);
+}
+
+/**
+ * @brief Initialize the CAPI timer backend instance.
+ * @note PS: XTtcPs_LookupConfig()/XTtcPs_CfgInitialize().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_ttc_init(struct capi_timer_handle **handle,
+				  const struct capi_timer_config *config)
+{
+	if (!handle || !config)
+		return -EINVAL;
+	if (check_timer_config(config) != 0)
+		return -ENOTSUP;
+
+	bool alloc_handle = (*handle == NULL);
+	struct capi_timer_handle *h = *handle;
+	struct capi_timer_xilinx_handle *xh;
+
+	if (alloc_handle) {
+		h = capi_malloc(sizeof(*h));
+		if (!h)
+			return -ENOMEM;
+		memset(h, 0, sizeof(*h));
+
+		xh = capi_malloc(sizeof(*xh));
+		if (!xh) {
+			capi_free(h);
+			return -ENOMEM;
+		}
+		h->priv = xh;
+		*handle = h;
+	} else {
+		xh = h->priv;
+		if (!xh)
+			return -EINVAL;
+		if (h->ops != NULL || xh->instance != NULL)
+			return -EBUSY;
+	}
+
+	memset(xh, 0, sizeof(*xh));
+	h->init_allocated = alloc_handle;
+	h->ops = config->ops ? config->ops : &capi_timer_xilinx_ps_ttc_ops;
+	h->priv = xh;
+	/*
+	 * Provisional; the effective input clock is taken from the BSP config
+	 * (cfg->InputClockHz) after prescaling below, which overrides this.
+	 */
+	xh->input_clock_hz = (uint32_t)config->input_clock_hz;
+
+	XTtcPs *xi = capi_malloc(sizeof(XTtcPs));
+	if (!xi) {
+		if (alloc_handle)
+			xilinx_timer_free_allocated_handle(handle);
+		else
+			xilinx_timer_clear_app_handle(h);
+		return -ENOMEM;
+	}
+	memset(xi, 0, sizeof(XTtcPs));
+
+	/*
+	 * Unified lookup: the (UINTPTR) cast holds both a base address (SDT) and a
+	 * device ID (legacy/hsi), so no SDT branch is needed. A bad id/address is
+	 * rejected flow-agnostically by the NULL check below.
+	 */
+	XTtcPs_Config *cfg = XTtcPs_LookupConfig((UINTPTR)config->identifier);
+	if (!cfg) {
+		capi_free(xi);
+		if (alloc_handle)
+			xilinx_timer_free_allocated_handle(handle);
+		else
+			xilinx_timer_clear_app_handle(h);
+		return -ENODEV;
+	}
+
+	int status = XTtcPs_CfgInitialize(xi, cfg, cfg->BaseAddress);
+	if (status != XST_SUCCESS) {
+		capi_free(xi);
+		if (alloc_handle)
+			xilinx_timer_free_allocated_handle(handle);
+		else
+			xilinx_timer_clear_app_handle(h);
+		return -EIO;
+	}
+
+	XTtcPs_Stop(xi);
+
+	/*
+	 * Configure prescaler: if output_freq_hz is requested, find the best
+	 * power-of-2 divisor (2^(P+1), P=0..15). Otherwise use default.
+	 */
+	uint32_t src_clk = cfg->InputClockHz;
+	if (config->output_freq_hz > 0 && config->output_freq_hz < src_clk) {
+		/* Find smallest power-of-2 divisor that does not exceed target. */
+		uint32_t target = (uint32_t)config->output_freq_hz;
+		uint8_t best_p = 15;
+		for (uint8_t p = 0; p < 16; p++) {
+			if (src_clk / (2U << p) <= target) {
+				best_p = p;
+				break;
+			}
+		}
+		uint32_t best_div = 2U << best_p;
+		XTtcPs_SetPrescaler(xi, best_p);
+		xh->instance = xi;
+		xh->input_clock_hz = src_clk / best_div;
+	} else if (config->output_freq_hz > 0) {
+		/* output_freq_hz >= src_clk: no prescaling needed */
+		XTtcPs_SetPrescaler(xi, XTTCPS_CLK_CNTRL_PS_DISABLE);
+		xh->instance = xi;
+		xh->input_clock_hz = src_clk;
+	} else {
+		XTtcPs_SetPrescaler(xi, PS_TTC_PRESCALER);
+		xh->instance = xi;
+		xh->input_clock_hz = src_clk / PS_TTC_CLOCK_DIVISOR;
+	}
+	xh->num_channels = PS_TTC_NUM_CHANNELS;
+
+	const struct capi_timer_xilinx_config *xcfg =
+		(const struct capi_timer_xilinx_config *)config->extra;
+	if (xcfg != NULL && xcfg->use_irq) {
+		uint32_t irq_id = xcfg->irq_id;
+		XTtcPs_ClearInterruptStatus(xi, XTtcPs_GetInterruptStatus(xi));
+		int ret = capi_irq_connect(irq_id, irq_handler, h);
+		if (ret == 0) {
+			capi_irq_set_level_edge_trigger(irq_id, CAPI_IRQ_LEVEL_HIGH);
+			ret = capi_irq_enable(irq_id);
+			if (ret == 0) {
+				xh->irq_id = irq_id;
+				xh->use_irq = true;
+			}
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Deinitialize the CAPI timer backend instance.
+ * @note PS: XTtcPs_Stop() then capi_free.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_ttc_deinit(struct capi_timer_handle *handle)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+	if (!xh)
+		return -EINVAL;
+
+	if (xh->use_irq) {
+		capi_irq_disable(xh->irq_id);
+		xh->use_irq = false;
+	}
+
+	if (xh->instance) {
+		XTtcPs_Stop(inst(xh));
+		XTtcPs_DisableInterrupts(inst(xh), XTTCPS_IXR_ALL_MASK);
+		XTtcPs_ClearInterruptStatus(inst(xh),
+					    XTtcPs_GetInterruptStatus(inst(xh)));
+		capi_free(xh->instance);
+		xh->instance = NULL;
+	}
+
+	if (handle->init_allocated) {
+		capi_free(xh);
+		capi_free(handle);
+	} else {
+		handle->ops = NULL;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Start the timer counter.
+ * @note PS: XTtcPs_Start().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_ttc_start(struct capi_timer_handle *handle)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+	XTtcPs_Start(inst(xh));
+
+	return 0;
+}
+
+/**
+ * @brief Stop the timer counter.
+ * @note PS: XTtcPs_Stop().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_ttc_stop(struct capi_timer_handle *handle)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+	XTtcPs_Stop(inst(xh));
+
+	return 0;
+}
+
+/**
+ * @brief Configure the timer counter.
+ * @note PS: XTtcPs_SetInterval()/XTtcPs_ResetCounterValue().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_ttc_counter_config(struct capi_timer_handle *handle,
+		const struct capi_timer_counter_config *config)
+{
+	if (!handle || !config)
+		return -EINVAL;
+	if (config->extra != NULL)
+		return -ENOTSUP;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (config->direction != CAPI_TIMER_COUNT_UP)
+		return -ENOTSUP;
+	if (config->min != 0)
+		return -ENOTSUP;
+	if (!config->rollover)
+		return -ENOTSUP;
+	if (config->max == 0 || !ttc_interval_fits(config->max))
+		return -EINVAL;
+	/*
+	 * Enable interval mode so the interval register is honored: the counter
+	 * counts up and rolls over at 'max' (not at the full 16/32-bit range).
+	 * Without INTERVAL_MODE the interval register is ignored and the counter
+	 * free-runs to full rollover, silently discarding 'max'. WAVE_DISABLE
+	 * keeps the waveform output off (counter-only use).
+	 */
+	XTtcPs_SetOptions(inst(xh),
+			  XTTCPS_OPTION_INTERVAL_MODE | XTTCPS_OPTION_WAVE_DISABLE);
+	XTtcPs_SetInterval(inst(xh), (XInterval)config->max);
+	XTtcPs_ResetCounterValue(inst(xh));
+
+	return 0;
+}
+
+/**
+ * @brief Read the timer counter value.
+ * @note PS: XTtcPs_GetCounterValue().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_ttc_counter_get(struct capi_timer_handle *handle,
+		uint32_t *counter)
+{
+	if (!handle || !counter)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	*counter = XTtcPs_GetCounterValue(inst(xh));
+
+	return 0;
+}
+
+/**
+ * @brief Enable timer global event interrupts.
+ * @note PS: XTtcPs_EnableInterrupts().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_ttc_event_irq_enable(struct capi_timer_handle *handle,
+		uint32_t event)
+{
+	if (!handle)
+		return -EINVAL;
+
+	if (event != CAPI_TIMER_GLOBAL_EVENT_COUNTER_OVERFLOW)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+	if (!xh->use_irq)
+		return -ENOTSUP;
+
+	XTtcPs_EnableInterrupts(inst(xh), XTTCPS_IXR_INTERVAL_MASK);
+	xh->event_irq_enabled = true;
+
+	return 0;
+}
+
+/**
+ * @brief Disable timer global event interrupts.
+ * @note PS: XTtcPs_DisableInterrupts().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_ttc_event_irq_disable(struct capi_timer_handle *handle,
+		uint32_t event)
+{
+	if (!handle)
+		return -EINVAL;
+
+	if (event != CAPI_TIMER_GLOBAL_EVENT_COUNTER_OVERFLOW)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	/*
+	 * Overflow owns the interval interrupt exclusively (compare is on the
+	 * match bit), so it can be torn down without checking the channel.
+	 */
+	xh->event_irq_enabled = false;
+	XTtcPs_DisableInterrupts(inst(xh), XTTCPS_IXR_INTERVAL_MASK);
+
+	return 0;
+}
+
+/**
+ * @brief Register the timer global event callback.
+ * @note PS: Stores overflow callback.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_ttc_register_event_callback(struct capi_timer_handle
+		*handle,
+		capi_timer_event_callback callback,
+		void *callback_arg)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	xh->event_callback = callback;
+	xh->event_callback_arg = callback_arg;
+
+	return 0;
+}
+
+/**
+ * @brief Initialize the CAPI timer backend instance.
+ * @note PS: Marks channel initialized.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_ttc_channel_init(struct capi_timer_handle *handle,
+		uint32_t chan)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+
+	xh->channels[0].initialized = true;
+	xh->channels[0].enabled = false;
+	xh->channels[0].mode = CAPI_TIMER_COMPARE_MODE;
+
+	return 0;
+}
+
+/**
+ * @brief Deinitialize the CAPI timer backend instance.
+ * @note PS: Disables and clears channel state.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_ttc_channel_deinit(struct capi_timer_handle *handle,
+		uint32_t chan)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+
+	capi_timer_ps_ttc_channel_disable(handle, 0);
+	xh->channels[0].use_irq = false;
+	/* Channel owns the match-0 interrupt; overflow (interval) is untouched. */
+	XTtcPs_DisableInterrupts(inst(xh), XTTCPS_IXR_MATCH_0_MASK);
+	XTtcPs_ClearInterruptStatus(inst(xh), XTTCPS_IXR_MATCH_0_MASK);
+	memset(&xh->channels[0], 0, sizeof(struct capi_timer_xilinx_channel));
+
+	return 0;
+}
+
+/**
+ * @brief Configure a timer channel.
+ * @note PS: XTtcPs_SetOptions()/XTtcPs_SetInterval().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_ttc_channel_config(struct capi_timer_handle *handle,
+		uint32_t chan,
+		const struct capi_timer_channel_config *ch_config)
+{
+	if (!handle || !ch_config)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+	if (ch_config->extra != NULL)
+		return -ENOTSUP;
+
+	u32 options = XTTCPS_OPTION_WAVE_DISABLE;
+
+	switch (ch_config->mode) {
+	case CAPI_TIMER_COMPARE_MODE:
+		if (check_compare_config(&ch_config->config.compare) != 0)
+			return -ENOTSUP;
+		if (ch_config->config.compare.match_value == 0 ||
+		    !ttc_interval_fits(ch_config->config.compare.match_value))
+			return -EINVAL;
+		/*
+		 * Compare uses MATCH mode + a match register, NOT interval mode.
+		 * This keeps the compare event (match interrupt) on its own bit,
+		 * separate from the interval/overflow interrupt, so the two events
+		 * cannot alias. The counter free-runs to full range, so any match
+		 * value is always reached.
+		 */
+		options |= XTTCPS_OPTION_MATCH_MODE;
+		break;
+
+	case CAPI_TIMER_PWM_MODE: {
+		if (check_pwm_config(&ch_config->config.pwm) != 0)
+			return -ENOTSUP;
+		if (ch_config->config.pwm.period_ns == 0)
+			return -EINVAL;
+		if (ch_config->config.pwm.active_ns > ch_config->config.pwm.period_ns)
+			return -EINVAL;
+		if (xh->input_clock_hz > 0) {
+			uint32_t period_ticks;
+			uint32_t duty_ticks;
+			int ret = capi_timer_ps_ttc_nsec_to_ticks(handle,
+					ch_config->config.pwm.period_ns, &period_ticks);
+			if (ret != 0)
+				return -EINVAL;
+			ret = capi_timer_ps_ttc_nsec_to_ticks(handle,
+							      ch_config->config.pwm.active_ns, &duty_ticks);
+			if (ret != 0)
+				return -EINVAL;
+			if (period_ticks == 0 || !ttc_interval_fits(period_ticks) ||
+			    !ttc_interval_fits(duty_ticks))
+				return -EINVAL;
+			/*
+			 * PWM needs BOTH interval mode (period, loaded via
+			 * SetInterval) and match mode (duty, loaded via
+			 * SetMatchValue) enabled; the official ttcps PWM example
+			 * sets INTERVAL_MODE | MATCH_MODE together. Omitting
+			 * INTERVAL_MODE leaves the period register ignored and
+			 * the counter free-running to full rollover.
+			 */
+			options = XTTCPS_OPTION_INTERVAL_MODE | XTTCPS_OPTION_MATCH_MODE;
+			if (ch_config->config.pwm.inverted_polarity)
+				options |= XTTCPS_OPTION_WAVE_POLARITY;
+			XTtcPs_SetOptions(inst(xh), options);
+			XTtcPs_SetInterval(inst(xh), (XInterval)period_ticks);
+			XTtcPs_SetMatchValue(inst(xh), 0, (XMatchRegValue)duty_ticks);
+			xh->channels[0].mode = CAPI_TIMER_PWM_MODE;
+			return 0;
+		}
+		options = XTTCPS_OPTION_INTERVAL_MODE | XTTCPS_OPTION_MATCH_MODE;
+		if (ch_config->config.pwm.inverted_polarity)
+			options |= XTTCPS_OPTION_WAVE_POLARITY;
+		break;
+	}
+
+	case CAPI_TIMER_CAPTURE_MODE:
+		return -ENOTSUP;
+
+	default:
+		return -EINVAL;
+	}
+
+	XTtcPs_SetOptions(inst(xh), options);
+
+	/* Compare threshold goes into match register 0, not the interval register. */
+	if (ch_config->mode == CAPI_TIMER_COMPARE_MODE)
+		XTtcPs_SetMatchValue(inst(xh), 0,
+				     (XMatchRegValue)ch_config->config.compare.match_value);
+
+	xh->channels[0].mode = ch_config->mode;
+
+	return 0;
+}
+
+/**
+ * @brief Enable a timer channel.
+ * @note PS: XTtcPs_Start().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_ttc_channel_enable(struct capi_timer_handle *handle,
+		uint32_t chan)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+
+	xh->channels[0].enabled = true;
+	XTtcPs_Start(inst(xh));
+
+	return 0;
+}
+
+/**
+ * @brief Disable a timer channel.
+ * @note PS: XTtcPs_Stop().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_ttc_channel_disable(struct capi_timer_handle *handle,
+		uint32_t chan)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+
+	xh->channels[0].enabled = false;
+	XTtcPs_Stop(inst(xh));
+
+	return 0;
+}
+
+/**
+ * @brief Set a timer channel compare value.
+ * @note PS: XTtcPs_SetOptions()/XTtcPs_SetMatchValue().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_ttc_channel_compare_set(struct capi_timer_handle
+		*handle, uint32_t chan,
+		uint32_t compare)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+	if (compare == 0 || !ttc_interval_fits(compare))
+		return -EINVAL;
+
+	/*
+	 * Program the compare threshold into match register 0 under MATCH mode.
+	 * Using the match register (not the interval register) keeps the compare
+	 * event distinct from the counter-overflow event at the hardware level.
+	 */
+	u32 options = XTTCPS_OPTION_MATCH_MODE | XTTCPS_OPTION_WAVE_DISABLE;
+	XTtcPs_SetOptions(inst(xh), options);
+	XTtcPs_SetMatchValue(inst(xh), 0, (XMatchRegValue)compare);
+
+	return 0;
+}
+
+/**
+ * @brief Get a timer channel compare value.
+ * @note PS: XTtcPs_GetMatchValue().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_ttc_channel_compare_get(struct capi_timer_handle
+		*handle, uint32_t chan,
+		uint32_t *compare)
+{
+	if (!handle || !compare)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+
+	/* Read back match register 0 (the compare threshold set above). */
+	*compare = (uint32_t)XTtcPs_GetMatchValue(inst(xh), 0);
+
+	return 0;
+}
+
+/**
+ * @brief Get a timer channel capture value.
+ * @note PS: Returns -ENOTSUP.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_ttc_channel_capture_get(struct capi_timer_handle
+		*handle, uint32_t chan,
+		uint32_t *capture)
+{
+	(void)handle;
+	(void)chan;
+	(void)capture;
+	return -ENOTSUP;
+}
+
+/**
+ * @brief Enable timer channel interrupts.
+ * @note PS: XTtcPs_EnableInterrupts().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_ttc_channel_irq_enable(struct capi_timer_handle
+		*handle, uint32_t chan,
+		uint32_t event)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+
+	if (event != CAPI_TIMER_CHANNEL_EVENT_COMPARE)
+		return -EINVAL;
+
+	if (!xh->use_irq)
+		return -ENOTSUP;
+
+	/* Compare event rides the match-0 interrupt, independent of overflow. */
+	xh->channels[0].use_irq = true;
+	XTtcPs_EnableInterrupts(inst(xh), XTTCPS_IXR_MATCH_0_MASK);
+
+	return 0;
+}
+
+/**
+ * @brief Disable timer channel interrupts.
+ * @note PS: XTtcPs_DisableInterrupts().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_ttc_channel_irq_disable(struct capi_timer_handle
+		*handle, uint32_t chan,
+		uint32_t event)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+
+	if (event != CAPI_TIMER_CHANNEL_EVENT_COMPARE)
+		return -EINVAL;
+
+	/*
+	 * Compare and overflow now own separate interrupt bits, so disabling the
+	 * match interrupt no longer risks tearing down the overflow interrupt.
+	 */
+	xh->channels[0].use_irq = false;
+	XTtcPs_DisableInterrupts(inst(xh), XTTCPS_IXR_MATCH_0_MASK);
+
+	return 0;
+}
+
+/**
+ * @brief Register a timer channel callback.
+ * @note PS: Stores channel callback.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_ttc_channel_register_callback(struct capi_timer_handle
+		*handle,
+		uint32_t chan,
+		capi_timer_channel_callback callback,
+		void *callback_arg)
+{
+	if (!handle)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (chan >= xh->num_channels)
+		return -EINVAL;
+
+	xh->channels[0].callback = callback;
+	xh->channels[0].callback_arg = callback_arg;
+
+	return 0;
+}
+
+/**
+ * @brief Check whether a timer interrupt is pending.
+ * @note PS: XTtcPs_GetInterruptStatus().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_ttc_is_irq_pending(struct capi_timer_handle *handle,
+		bool *pending)
+{
+	if (!handle || !pending)
+		return -EINVAL;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	u32 status = XTtcPs_GetInterruptStatus(inst(xh));
+	*pending = (status != 0);
+
+	return 0;
+}
+
+/**
+ * @brief Dispatch the timer interrupt handler.
+ * @note PS: XTtcPs_Get/ClearInterruptStatus().
+ *
+ */
+static void capi_timer_ps_ttc_isr(struct capi_timer_handle *handle)
+{
+	if (!handle)
+		return;
+
+	struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	uint32_t status = XTtcPs_GetInterruptStatus(inst(xh));
+	XTtcPs_ClearInterruptStatus(inst(xh), status);
+
+	/*
+	 * Compare and overflow are dispatched off distinct status bits: the
+	 * match-0 bit fires the channel compare callback, the interval bit fires
+	 * the global overflow callback. A lone match no longer fires overflow and
+	 * vice versa, so each callback runs exactly for its own hardware event.
+	 */
+	if ((status & XTTCPS_IXR_MATCH_0_MASK) && xh->channels[0].use_irq &&
+	    xh->channels[0].callback) {
+		xh->channels[0].callback(CAPI_TIMER_CHANNEL_EVENT_COMPARE, 0,
+					 xh->channels[0].callback_arg, 0);
+	}
+
+	if ((status & XTTCPS_IXR_INTERVAL_MASK) && xh->event_irq_enabled &&
+	    xh->event_callback) {
+		xh->event_callback(CAPI_TIMER_GLOBAL_EVENT_COUNTER_OVERFLOW,
+				   xh->event_callback_arg,
+				   0);
+	}
+}
+
+/**
+ * @brief Convert nanoseconds to timer ticks.
+ * @note PS: Converts ns using input clock.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_ttc_nsec_to_ticks(const struct capi_timer_handle
+		*handle,
+		uint64_t duration_ns, uint32_t *ticks)
+{
+	if (!handle || !ticks)
+		return -EINVAL;
+
+	const struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (xh->input_clock_hz == 0)
+		return -EINVAL;
+
+	/* Split ns into whole seconds and sub-second remainder to avoid 64-bit overflow. */
+	uint64_t whole = duration_ns / CAPI_TIMER_NSEC_PER_SEC;
+	uint64_t remainder = duration_ns % CAPI_TIMER_NSEC_PER_SEC;
+
+	/* ticks from whole seconds: whole_sec * clock_hz */
+	if (whole > UINT32_MAX / xh->input_clock_hz)
+		return -EOVERFLOW;
+
+	uint64_t result = whole * xh->input_clock_hz;
+	/* ticks from sub-second part: (remainder_ns * clock_hz) / 1e9 */
+	uint64_t fraction = (remainder * xh->input_clock_hz) /
+			    CAPI_TIMER_NSEC_PER_SEC;
+
+	if (fraction > UINT32_MAX - result)
+		return -EOVERFLOW;
+
+	result += fraction;
+	*ticks = (uint32_t)result;
+	return 0;
+}
+
+/**
+ * @brief Convert timer ticks to nanoseconds.
+ * @note PS: Converts ticks using input clock.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_timer_ps_ttc_ticks_to_nsec(const struct capi_timer_handle
+		*handle, uint64_t ticks,
+		uint32_t *duration_ns)
+{
+	if (!handle || !duration_ns)
+		return -EINVAL;
+
+	const struct capi_timer_xilinx_handle *xh = handle->priv;
+
+	if (xh->input_clock_hz == 0)
+		return -EINVAL;
+
+	/* Split ticks into whole seconds and sub-second remainder to avoid overflow. */
+	uint64_t whole = ticks / xh->input_clock_hz;
+	uint64_t remainder = ticks % xh->input_clock_hz;
+
+	/* ns from whole seconds: whole_sec * 1e9 */
+	if (whole > UINT32_MAX / CAPI_TIMER_NSEC_PER_SEC)
+		return -EOVERFLOW;
+
+	uint64_t result = whole * CAPI_TIMER_NSEC_PER_SEC;
+	/* ns from sub-second part: (remainder_ticks * 1e9) / clock_hz */
+	uint64_t fraction = (remainder * CAPI_TIMER_NSEC_PER_SEC) /
+			    xh->input_clock_hz;
+
+	if (fraction > UINT32_MAX - result)
+		return -EOVERFLOW;
+
+	result += fraction;
+	*duration_ns = (uint32_t)result;
+	return 0;
+}
+
+#endif /* XPAR_XTTCPS_NUM_INSTANCES */

--- a/capi/platform/xilinx/xilinx_capi_uart.h
+++ b/capi/platform/xilinx/xilinx_capi_uart.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Xilinx platform UART driver for CAPI
+ *
+ * Backends are selected via config.ops. Platform driver code and tests that
+ * need backend ops symbols or private handle storage should include
+ * xilinx_capi_uart_priv.h.
+ */
+
+#ifndef _XILINX_CAPI_UART_H_
+#define _XILINX_CAPI_UART_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <capi_uart.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @struct capi_uart_xilinx_config
+ * @brief Optional Xilinx platform-specific UART configuration.
+ *
+ * Passed via config->extra during init. use_irq decides whether the driver
+ * connects irq_id through the CAPI IRQ singleton. IRQ ID 0 is valid for an
+ * INTC input, so it is passed through unchanged.
+ */
+struct capi_uart_xilinx_config {
+	/** Enable CAPI IRQ connection during init */
+	bool use_irq;
+	/** Normalized CAPI IRQ ID. Zero is valid for INTC input 0. */
+	uint32_t irq_id;
+};
+
+/**
+ * @brief Xilinx UART operations tables. Select one via config->ops.
+ */
+extern const struct capi_uart_ops capi_uart_xilinx_ps_ops;
+extern const struct capi_uart_ops capi_uart_xilinx_pl_lite_ops;
+extern const struct capi_uart_ops capi_uart_xilinx_pl_ns550_ops;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _XILINX_CAPI_UART_H_ */

--- a/capi/platform/xilinx/xilinx_capi_uart_pl_lite.c
+++ b/capi/platform/xilinx/xilinx_capi_uart_pl_lite.c
@@ -1,0 +1,914 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Xilinx XUartLite UART driver (AXI UartLite)
+ *
+ * Fixed 8N1. Baud rate, word length, parity and stop bits are set at
+ * synthesis time and cannot be changed at runtime. set_line_config() is
+ * accepted but only the loopback field has any effect.
+ *
+ * SDT BSP only. IRQ is explicit via capi_uart_xilinx_config.
+ * capi_irq_init() must be called before async ops will work.
+ */
+
+#include <capi_uart.h>
+#include <xilinx_capi_uart_priv.h>
+#include <capi_alloc.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <errno.h>
+#include <string.h>
+#include "capi_irq.h"
+#include "xinterrupt_wrap.h"
+
+#ifdef XPAR_XUARTLITE_NUM_INSTANCES
+
+
+/*
+ * UartLite baud rate is fixed in hardware at synthesis time. Cache the common
+ * Vivado default for get_line_config() because embeddedsw cannot read it back.
+ */
+#define CAPI_UART_LITE_DEFAULT_BAUDRATE	9600U
+
+static int capi_uart_pl_lite_init(struct capi_uart_handle **handle,
+				  const struct capi_uart_config *config);
+static int capi_uart_pl_lite_deinit(struct capi_uart_handle *handle);
+static int capi_uart_pl_lite_get_line_config(struct capi_uart_handle *handle,
+		struct capi_uart_line_config *line_config);
+static int capi_uart_pl_lite_set_line_config(struct capi_uart_handle *handle,
+		struct capi_uart_line_config *line_config);
+static int capi_uart_pl_lite_enable_fifo(struct capi_uart_handle *handle,
+		bool enable);
+static int capi_uart_pl_lite_flush_tx_fifo(struct capi_uart_handle *handle);
+static int capi_uart_pl_lite_flush_rx_fifo(struct capi_uart_handle *handle);
+static int capi_uart_pl_lite_get_rx_fifo_count(struct capi_uart_handle *handle,
+		uint16_t *count);
+static int capi_uart_pl_lite_get_tx_fifo_count(struct capi_uart_handle *handle,
+		uint16_t *count);
+static int capi_uart_pl_lite_transmit(struct capi_uart_handle *handle,
+				      uint8_t *buf, uint32_t len);
+static int capi_uart_pl_lite_receive(struct capi_uart_handle *handle,
+				     uint8_t *buf, uint32_t len);
+static int capi_uart_pl_lite_register_callback(struct capi_uart_handle *handle,
+		capi_uart_callback const callback,
+		void *const callback_arg);
+static int capi_uart_pl_lite_transmit_async(struct capi_uart_handle *handle,
+		uint8_t *buf,
+		uint32_t len);
+static int capi_uart_pl_lite_receive_async(struct capi_uart_handle *handle,
+		uint8_t *buf,
+		uint32_t len);
+static int capi_uart_pl_lite_get_interrupt_reason(struct capi_uart_handle
+		*handle,
+		enum capi_uart_interrupt_reason *reason);
+static int capi_uart_pl_lite_get_line_status(struct capi_uart_handle *handle,
+		uint32_t *status_flags);
+static int capi_uart_pl_lite_set_irq_tx(struct capi_uart_handle *handle,
+					bool enable);
+static int capi_uart_pl_lite_irq_tx_ready(struct capi_uart_handle *handle,
+		bool *ready);
+static int capi_uart_pl_lite_irq_tx_complete(struct capi_uart_handle *handle,
+		bool *complete);
+static int capi_uart_pl_lite_set_irq_rx(struct capi_uart_handle *handle,
+					bool enable);
+static int capi_uart_pl_lite_irq_rx_ready(struct capi_uart_handle *handle,
+		bool *ready);
+static int capi_uart_pl_lite_set_irq_err(struct capi_uart_handle *handle,
+		bool enable);
+static int capi_uart_pl_lite_is_irq_pending(struct capi_uart_handle *handle,
+		bool *pending);
+static void capi_uart_pl_lite_isr(void *handle);
+static uint32_t capi_uart_pl_lite_read_byte(struct capi_uart_handle *handle,
+		uint8_t *byte);
+
+static void lite_tx_done(struct capi_uart_xilinx_handle *xh,
+			 unsigned int event_data);
+static void lite_rx_done(struct capi_uart_xilinx_handle *xh,
+			 unsigned int event_data);
+static void lite_send_handler(void *callback_ref, unsigned int event_data);
+static void lite_recv_handler(void *callback_ref, unsigned int event_data);
+
+const struct capi_uart_ops capi_uart_xilinx_pl_lite_ops = {
+	.init = capi_uart_pl_lite_init,
+	.deinit = capi_uart_pl_lite_deinit,
+	.get_line_config = capi_uart_pl_lite_get_line_config,
+	.set_line_config = capi_uart_pl_lite_set_line_config,
+	.enable_fifo = capi_uart_pl_lite_enable_fifo,
+	.flush_tx_fifo = capi_uart_pl_lite_flush_tx_fifo,
+	.flush_rx_fifo = capi_uart_pl_lite_flush_rx_fifo,
+	.get_rx_fifo_count = capi_uart_pl_lite_get_rx_fifo_count,
+	.get_tx_fifo_count = capi_uart_pl_lite_get_tx_fifo_count,
+	.transmit = capi_uart_pl_lite_transmit,
+	.receive = capi_uart_pl_lite_receive,
+	.register_callback = capi_uart_pl_lite_register_callback,
+	.transmit_async = capi_uart_pl_lite_transmit_async,
+	.receive_async = capi_uart_pl_lite_receive_async,
+	.get_interrupt_reason = capi_uart_pl_lite_get_interrupt_reason,
+	.get_line_status = capi_uart_pl_lite_get_line_status,
+	.transmit_9bit = NULL,
+	.receive_9bit = NULL,
+	.set_flow_control_state = NULL,
+	.get_flow_control_state = NULL,
+	.isr = capi_uart_pl_lite_isr,
+	.read_byte = capi_uart_pl_lite_read_byte,
+	.write_byte = NULL,
+	.set_irq_tx = capi_uart_pl_lite_set_irq_tx,
+	.irq_tx_ready = capi_uart_pl_lite_irq_tx_ready,
+	.irq_tx_complete = capi_uart_pl_lite_irq_tx_complete,
+	.set_irq_rx = capi_uart_pl_lite_set_irq_rx,
+	.irq_rx_ready = capi_uart_pl_lite_irq_rx_ready,
+	.set_irq_err = capi_uart_pl_lite_set_irq_err,
+	.is_irq_pending = capi_uart_pl_lite_is_irq_pending,
+};
+
+static XUartLite *inst(struct capi_uart_xilinx_handle *xh)
+{
+	return (XUartLite *)xh->instance;
+}
+
+/*
+ * True while either direction still owns a caller buffer. RequestedBytes is the
+ * flag that spans a whole transfer: RemainingBytes only counts what has yet to
+ * be handed to the FIFO and so clears early on transmit, leaving the tail of a
+ * send looking idle. See lite_disable_irq_if_idle() for why that distinction
+ * matters on this core.
+ */
+static bool lite_xfer_busy(struct capi_uart_xilinx_handle *xh)
+{
+	return inst(xh)->SendBuffer.RequestedBytes > 0 ||
+	       inst(xh)->ReceiveBuffer.RequestedBytes > 0;
+}
+
+static void xilinx_uart_free_allocated_handle(struct capi_uart_handle **handle)
+{
+	if (handle == NULL || *handle == NULL)
+		return;
+
+	capi_free((*handle)->priv);
+	capi_free(*handle);
+	*handle = NULL;
+}
+
+/**
+ * @brief Initialize the CAPI backend instance.
+ * @note PL: XUartLite_Initialize().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_pl_lite_init(struct capi_uart_handle **handle,
+				  const struct capi_uart_config *config)
+{
+	if (handle == NULL || config == NULL)
+		return -EINVAL;
+
+	if (config->dma_handle != NULL)
+		return -ENOTSUP;
+
+	bool alloc = (*handle == NULL);
+	struct capi_uart_handle *h = *handle;
+	struct capi_uart_xilinx_handle *xh;
+
+	if (alloc) {
+		h = capi_malloc(sizeof(*h));
+		if (h == NULL)
+			return -ENOMEM;
+		memset(h, 0, sizeof(*h));
+
+		xh = capi_malloc(sizeof(*xh));
+		if (xh == NULL) {
+			capi_free(h);
+			return -ENOMEM;
+		}
+		h->priv = xh;
+		*handle = h;
+	} else {
+		xh = h->priv;
+		if (xh == NULL)
+			return -EINVAL;
+	}
+
+	memset(xh, 0, sizeof(*xh));
+	h->init_allocated = alloc;
+	h->ops = config->ops ? config->ops : &capi_uart_xilinx_pl_lite_ops;
+	h->priv = xh;
+
+	/* Fixed 8N1; cache the known fields because hardware cannot report them. */
+	xh->line_config.baudrate = CAPI_UART_LITE_DEFAULT_BAUDRATE;
+	xh->line_config.size = CAPI_UART_DATA_BITS_8;
+	xh->line_config.parity = CAPI_UART_PARITY_NONE;
+	xh->line_config.stop_bits = CAPI_UART_STOP_1_BIT;
+	xh->line_config.flow_control = CAPI_UART_FLOW_CONTROL_NONE;
+
+	XUartLite *ul = capi_malloc(sizeof(XUartLite));
+	if (ul == NULL) {
+		if (alloc)
+			xilinx_uart_free_allocated_handle(handle);
+		return -ENOMEM;
+	}
+	memset(ul, 0, sizeof(XUartLite));
+
+	if (XUartLite_Initialize(ul, (UINTPTR)config->identifier) != XST_SUCCESS) {
+		capi_free(ul);
+		if (alloc)
+			xilinx_uart_free_allocated_handle(handle);
+		return -EIO;
+	}
+
+	xh->instance = ul;
+
+	XUartLite_ResetFifos(ul);
+	XUartLite_SetSendHandler(ul, lite_send_handler, xh);
+	XUartLite_SetRecvHandler(ul, lite_recv_handler, xh);
+
+	const struct capi_uart_xilinx_config *xcfg =
+		(const struct capi_uart_xilinx_config *)config->extra;
+	if (xcfg != NULL && xcfg->use_irq) {
+		uint32_t irq_id = xcfg->irq_id;
+
+		int ret = capi_irq_connect(irq_id, capi_uart_pl_lite_isr, h);
+		if (ret == 0) {
+			capi_irq_set_level_edge_trigger(irq_id, CAPI_IRQ_EDGE_RISING);
+			ret = capi_irq_enable(irq_id);
+			if (ret == 0) {
+				xh->irq_id = irq_id;
+				xh->use_irq = true;
+			}
+			/* IRQ enable failure is not init failure; stay polled on async */
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Deinitialize the CAPI backend instance.
+ * @note PL: XUartLite_DisableInterrupt()/XUartLite_ResetFifos().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_pl_lite_deinit(struct capi_uart_handle *handle)
+{
+	if (handle == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	if (xh == NULL)
+		return -EINVAL;
+
+	if (lite_xfer_busy(xh))
+		return -EBUSY;
+
+	if (xh->use_irq) {
+		capi_irq_disable(xh->irq_id);
+		xh->use_irq = false;
+	}
+
+	XUartLite_DisableInterrupt(inst(xh));
+	XUartLite_ResetFifos(inst(xh));
+
+	capi_free(xh->instance);
+	xh->instance = NULL;
+
+	if (handle->init_allocated) {
+		capi_free(xh);
+		capi_free(handle);
+	} else {
+		handle->ops = NULL;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Get the UART line configuration.
+ * @note PL: Returns cached fixed 8N1.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_pl_lite_get_line_config(struct capi_uart_handle *handle,
+		struct capi_uart_line_config *line_config)
+{
+	if (handle == NULL || line_config == NULL)
+		return -EINVAL;
+
+	/* Fixed at synthesis; return cached. */
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	memcpy(line_config, &xh->line_config, sizeof(*line_config));
+	return 0;
+}
+
+/**
+ * @brief Set the UART line configuration.
+ * @note PL: Fixed 8N1; returns -ENOTSUP.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_pl_lite_set_line_config(struct capi_uart_handle *handle,
+		struct capi_uart_line_config *line_config)
+{
+	if (handle == NULL || line_config == NULL)
+		return -EINVAL;
+
+	/* XUartLite line format is fixed in the IP. */
+	(void)handle;
+	(void)line_config;
+	return -ENOTSUP;
+}
+
+/**
+ * @brief Enable or disable UART FIFO behavior.
+ * @note PL: FIFOs are always on.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_pl_lite_enable_fifo(struct capi_uart_handle *handle,
+		bool enable)
+{
+	(void)handle;
+	(void)enable;
+	return 0; /* XUartLite always uses FIFOs */
+}
+
+/**
+ * @brief Flush the UART TX FIFO.
+ * @note PL: XUartLite_ResetFifos().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_pl_lite_flush_tx_fifo(struct capi_uart_handle *handle)
+{
+	if (handle == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	XUartLite_ResetFifos(inst(xh));
+	return 0;
+}
+
+/**
+ * @brief Flush the UART RX FIFO.
+ * @note PL: XUartLite_ResetFifos().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_pl_lite_flush_rx_fifo(struct capi_uart_handle *handle)
+{
+	if (handle == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	XUartLite_ResetFifos(inst(xh));
+	return 0;
+}
+
+/**
+ * @brief Get the UART RX FIFO occupancy.
+ * @note PL: Reads XUL_STATUS_REG_OFFSET.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_pl_lite_get_rx_fifo_count(struct capi_uart_handle *handle,
+		uint16_t *count)
+{
+	if (handle == NULL || count == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	UINTPTR base = inst(xh)->RegBaseAddress;
+	u32 sr = XUartLite_ReadReg(base, XUL_STATUS_REG_OFFSET);
+	*count = (sr & XUL_SR_RX_FIFO_VALID_DATA) ? 1 : 0;
+	return 0;
+}
+
+/**
+ * @brief Get the UART TX FIFO occupancy.
+ * @note PL: Reads XUL_STATUS_REG_OFFSET.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_pl_lite_get_tx_fifo_count(struct capi_uart_handle *handle,
+		uint16_t *count)
+{
+	if (handle == NULL || count == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	UINTPTR base = inst(xh)->RegBaseAddress;
+	u32 sr = XUartLite_ReadReg(base, XUL_STATUS_REG_OFFSET);
+	*count = (sr & XUL_SR_TX_FIFO_EMPTY) ? 0 : 1;
+	return 0;
+}
+
+/**
+ * @brief Run a synchronous transmit operation.
+ * @note PL: XUartLite_Send().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_pl_lite_transmit(struct capi_uart_handle *handle,
+				      uint8_t *buf, uint32_t len)
+{
+	if (handle == NULL || buf == NULL)
+		return -EINVAL;
+	if (len == 0)
+		return 0;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	if (lite_xfer_busy(xh))
+		return -EBUSY;
+
+	uint32_t total = 0;
+	while (total < len) {
+		uint32_t sent = XUartLite_Send(inst(xh), buf + total, len - total);
+		total += sent;
+		/* Spin until FIFO has space if we couldn't send all */
+		if (total < len) {
+			UINTPTR base = inst(xh)->RegBaseAddress;
+			while (!(XUartLite_ReadReg(base, XUL_STATUS_REG_OFFSET) &
+				 XUL_SR_TX_FIFO_EMPTY))
+				;
+		}
+	}
+	/* Wait until TX FIFO drains */
+	UINTPTR base = inst(xh)->RegBaseAddress;
+	while (!(XUartLite_ReadReg(base, XUL_STATUS_REG_OFFSET) & XUL_SR_TX_FIFO_EMPTY))
+		;
+
+	/*
+	 * XUartLite_Send() loaded RequestedBytes and only the interrupt path ever
+	 * clears it, which never runs here. Left set, it reads as a transmit still
+	 * in flight: the next interrupt of any kind would be taken as this one
+	 * completing and fire a spurious TX_DONE, and lite_disable_irq_if_idle()
+	 * would never let the controller go quiet again.
+	 */
+	inst(xh)->SendBuffer.RequestedBytes = 0;
+	return 0;
+}
+
+/**
+ * @brief Run a synchronous receive operation.
+ * @note PL: XUartLite_Recv().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_pl_lite_receive(struct capi_uart_handle *handle,
+				     uint8_t *buf, uint32_t len)
+{
+	if (handle == NULL || buf == NULL)
+		return -EINVAL;
+	if (len == 0)
+		return 0;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	if (lite_xfer_busy(xh))
+		return -EBUSY;
+
+	uint32_t total = 0;
+	while (total < len)
+		total += XUartLite_Recv(inst(xh), buf + total, len - total);
+
+	/* Same as the polled transmit above: nothing else clears RequestedBytes
+	 * on this path, and a stale one looks like a receive still outstanding. */
+	inst(xh)->ReceiveBuffer.RequestedBytes = 0;
+	return 0;
+}
+
+/**
+ * @brief Register the CAPI asynchronous callback.
+ * @note PL: Stores callback for handlers.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_pl_lite_register_callback(struct capi_uart_handle *handle,
+		capi_uart_callback const callback,
+		void *const callback_arg)
+{
+	if (handle == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	xh->callback = callback;
+	xh->callback_arg = callback_arg;
+	return 0;
+}
+
+/**
+ * @brief Start an asynchronous transmit operation.
+ * @note PL: XUartLite_Send()+XUartLite_EnableInterrupt().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_pl_lite_transmit_async(struct capi_uart_handle *handle,
+		uint8_t *buf,
+		uint32_t len)
+{
+	if (handle == NULL || buf == NULL)
+		return -EINVAL;
+	if (len == 0)
+		return 0;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	if (!xh->use_irq)
+		return -ENOTSUP;
+	/* RequestedBytes, not RemainingBytes: the previous send still owns the
+	 * caller's buffer while its tail drains out of the FIFO. */
+	if (inst(xh)->SendBuffer.RequestedBytes > 0)
+		return -EBUSY;
+
+	/* Only disable interrupts if no async receive is pending. The shared
+	 * interrupt enable bit must stay active to service a concurrent RX. */
+	if (inst(xh)->ReceiveBuffer.RequestedBytes == 0)
+		XUartLite_DisableInterrupt(inst(xh));
+	XUartLite_Send(inst(xh), buf, len);
+	if (inst(xh)->SendBuffer.RemainingBytes == 0) {
+		/*
+		 * TX fit entirely in the FIFO and completed synchronously here.
+		 * lite_tx_done() only clears the single shared interrupt-enable
+		 * bit when NO direction is still busy; if an async receive is
+		 * pending it deliberately leaves it untouched.
+		 */
+		lite_tx_done(xh, inst(xh)->SendBuffer.RequestedBytes);
+		return 0;
+	}
+
+	/* TX is still draining; re-enable interrupts if they were disabled. */
+	if (inst(xh)->ReceiveBuffer.RequestedBytes == 0)
+		XUartLite_EnableInterrupt(inst(xh));
+	return 0;
+}
+
+/**
+ * @brief Start an asynchronous receive operation.
+ * @note PL: XUartLite_EnableInterrupt()+XUartLite_Recv().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_pl_lite_receive_async(struct capi_uart_handle *handle,
+		uint8_t *buf,
+		uint32_t len)
+{
+	if (handle == NULL || buf == NULL)
+		return -EINVAL;
+	if (len == 0)
+		return 0;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	if (!xh->use_irq)
+		return -ENOTSUP;
+	if (inst(xh)->ReceiveBuffer.RequestedBytes > 0)
+		return -EBUSY;
+
+	XUartLite_EnableInterrupt(inst(xh));
+	XUartLite_Recv(inst(xh), buf, len);
+
+	/*
+	 * XUartLite_Recv() drains whatever is already sitting in the RX FIFO
+	 * synchronously before returning (XUartLite_ReceiveBuffer() runs
+	 * inline, not from the ISR). If the caller pre-buffered the full
+	 * transfer with a blocking transmit before arming this receive, len
+	 * bytes are already in the FIFO and RemainingBytes hits 0 right here --
+	 * no RX interrupt is coming to complete it, since there is no new edge
+	 * on an already-idle line. Mirrors the same synchronous-completion
+	 * check in transmit_async() for the equivalent TX case.
+	 */
+	if (inst(xh)->ReceiveBuffer.RemainingBytes == 0)
+		lite_rx_done(xh, inst(xh)->ReceiveBuffer.RequestedBytes);
+
+	return 0;
+}
+
+/**
+ * @brief Get the last UART interrupt reason.
+ * @note PL: Returns cached ISR reason.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_pl_lite_get_interrupt_reason(struct capi_uart_handle
+		*handle,
+		enum capi_uart_interrupt_reason *reason)
+{
+	if (handle == NULL || reason == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	*reason = xh->last_interrupt_reason;
+	return 0;
+}
+
+/**
+ * @brief Get UART line status flags.
+ * @note PL: XUartLite_GetStatusReg().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_pl_lite_get_line_status(struct capi_uart_handle *handle,
+		uint32_t *status_flags)
+{
+	if (handle == NULL || status_flags == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	UINTPTR base = inst(xh)->RegBaseAddress;
+	u32 sr = XUartLite_GetStatusReg(base);
+	*status_flags = 0;
+
+	if (sr & XUL_SR_FRAMING_ERROR)
+		*status_flags |= CAPI_UART_LINE_STAT_FRAMING_ERROR;
+	if (sr & XUL_SR_PARITY_ERROR)
+		*status_flags |= CAPI_UART_LINE_STAT_PARITY_ERROR;
+	if (sr & XUL_SR_OVERRUN_ERROR)
+		*status_flags |= CAPI_UART_LINE_STAT_OVERRUN_ERROR;
+
+	return 0;
+}
+
+/*
+ * Cap on the re-service loop below. Every pass either drains the RX FIFO,
+ * refills the TX FIFO or retires a transfer, so a handful is always enough to
+ * reach a quiet status register; the bound only stops a device streaming data
+ * faster than it can be read from pinning the CPU inside the ISR.
+ */
+#define CAPI_UART_LITE_ISR_MAX_PASSES	8U
+
+/**
+ * @brief Dispatch the backend interrupt handler.
+ * @note PL: XUartLite_InterruptHandler().
+ *
+ */
+static void capi_uart_pl_lite_isr(void *handle)
+{
+	if (handle == NULL)
+		return;
+
+	struct capi_uart_xilinx_handle *xh = ((struct capi_uart_handle *)handle)->priv;
+	UINTPTR base = inst(xh)->RegBaseAddress;
+
+	/*
+	 * Re-service until the status register is quiet rather than handling one
+	 * condition per interrupt. Both directions are OR-ed onto a single
+	 * edge-triggered pin, so a source that rises while the other is already
+	 * holding the line high produces no edge of its own and would otherwise
+	 * never be seen. XUartLite_InterruptHandler() samples the status register
+	 * once on entry, so a TX FIFO that empties (or an RX byte that lands) just
+	 * after that read is missed by the pass that was already running.
+	 *
+	 * Looping here costs nothing when there is no second condition -- the
+	 * first re-read breaks straight out -- and is what makes concurrent
+	 * transmit and receive reliable instead of timing-dependent.
+	 */
+	for (unsigned int pass = 0U; pass < CAPI_UART_LITE_ISR_MAX_PASSES;
+	     pass++) {
+		XUartLite_InterruptHandler(inst(xh));
+
+		u32 sr = XUartLite_GetStatusReg(base);
+		bool rx_pending = (sr & (XUL_SR_RX_FIFO_FULL |
+					 XUL_SR_RX_FIFO_VALID_DATA)) != 0;
+		bool tx_pending = ((sr & XUL_SR_TX_FIFO_EMPTY) != 0) &&
+				  inst(xh)->SendBuffer.RequestedBytes > 0;
+
+		if (!rx_pending && !tx_pending)
+			break;
+	}
+}
+/**
+ * @brief Poll for and read one byte from the receive FIFO.
+ * @note PL: XUartLite_ReadReg().
+ *
+ * @return 1 if a byte was read, 0 if no byte is available.
+ */
+static uint32_t capi_uart_pl_lite_read_byte(
+	struct capi_uart_handle *handle,
+	uint8_t *byte)
+{
+	if (handle == NULL || byte == NULL || handle->priv == NULL)
+		return 0U;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+
+	if (xh->instance == NULL || lite_xfer_busy(xh))
+		return 0U;
+
+	UINTPTR base = inst(xh)->RegBaseAddress;
+
+	if (XUartLite_IsReceiveEmpty(base))
+		return 0U;
+
+	*byte = (uint8_t)XUartLite_ReadReg(base, XUL_RX_FIFO_OFFSET);
+
+	return 1U;
+}
+/*
+ * UART Lite has a single interrupt-enable bit (XUL_CR_ENABLE_INTR) shared by
+ * both directions, so a completing transfer must only disable interrupts when
+ * the opposite direction has no async operation still in flight; otherwise the
+ * still-pending direction would stop receiving interrupts and never complete.
+ *
+ * "In flight" is RequestedBytes, not RemainingBytes. RemainingBytes counts what
+ * is left to hand to the FIFO, so a transmit clears it one FIFO-depth before the
+ * wire is actually drained, while RequestedBytes survives until the completion
+ * handler zeroes it. Gating on RemainingBytes therefore blinds the controller
+ * during the tail of a transmit -- fatal in external loopback, where the receive
+ * cannot finish until the transmit has, so the receive-side completion is always
+ * the one that runs first and pulls the enable out from under the pending TX.
+ * The line is edge-triggered (see the INTERRUPTS trigger nibble in the BSP), so
+ * the TX-empty edge that arrives while the output is gated is lost outright, not
+ * merely delayed, and no later edge is ever produced from an idle FIFO.
+ */
+static void lite_disable_irq_if_idle(struct capi_uart_xilinx_handle *xh)
+{
+	if (inst(xh)->SendBuffer.RequestedBytes == 0 &&
+	    inst(xh)->ReceiveBuffer.RequestedBytes == 0)
+		XUartLite_DisableInterrupt(inst(xh));
+}
+
+static void lite_tx_done(struct capi_uart_xilinx_handle *xh,
+			 unsigned int event_data)
+{
+	if (xh == NULL || xh->instance == NULL)
+		return;
+
+	if (inst(xh)->SendBuffer.RequestedBytes == 0 && event_data == 0)
+		return;
+	if (event_data == 0)
+		event_data = inst(xh)->SendBuffer.RequestedBytes;
+
+	xh->last_interrupt_reason = CAPI_UART_INTR_TX_BUFFER_EMPTY;
+	inst(xh)->SendBuffer.RequestedBytes = 0;
+	lite_disable_irq_if_idle(xh);
+	if (xh->callback)
+		xh->callback(CAPI_UART_EVENT_TX_DONE, xh->callback_arg, event_data);
+}
+
+static void lite_send_handler(void *callback_ref, unsigned int event_data)
+{
+	struct capi_uart_xilinx_handle *xh = (struct capi_uart_xilinx_handle *)
+					     callback_ref;
+
+	if (xh == NULL || xh->instance == NULL)
+		return;
+
+	if (inst(xh)->SendBuffer.RemainingBytes > 0)
+		return; /* Partial; wait for next TX empty interrupt. */
+
+	lite_tx_done(xh, event_data);
+}
+
+static void lite_rx_done(struct capi_uart_xilinx_handle *xh,
+			 unsigned int event_data)
+{
+	xh->last_interrupt_reason = CAPI_UART_INTR_RX_BUFFER_FULL;
+	inst(xh)->ReceiveBuffer.RequestedBytes = 0;
+	lite_disable_irq_if_idle(xh);
+
+	if (xh->callback)
+		xh->callback(CAPI_UART_EVENT_RX_DONE, xh->callback_arg, event_data);
+}
+
+static void lite_recv_handler(void *callback_ref, unsigned int event_data)
+{
+	struct capi_uart_xilinx_handle *xh = (struct capi_uart_xilinx_handle *)
+					     callback_ref;
+
+	if (xh == NULL || xh->instance == NULL)
+		return;
+
+	xh->last_interrupt_reason = CAPI_UART_INTR_RX_BUFFER_FULL;
+
+	/* No receive_async pending; drain RX FIFO to clear the interrupt source,
+	 * but do NOT disable interrupts (TX async may still be in progress). */
+	if (inst(xh)->ReceiveBuffer.RequestedBytes == 0) {
+		UINTPTR base = inst(xh)->RegBaseAddress;
+		while (XUartLite_ReadReg(base,
+					 XUL_STATUS_REG_OFFSET) & XUL_SR_RX_FIFO_VALID_DATA)
+			(void)XUartLite_ReadReg(base, XUL_RX_FIFO_OFFSET);
+		return;
+	}
+
+	if (inst(xh)->ReceiveBuffer.RemainingBytes > 0)
+		return; /* Partial; wait for more data. */
+
+	lite_rx_done(xh, event_data);
+}
+
+/**
+ * @brief Enable or disable TX interrupt.
+ * @note PL Lite: Unsupported; UartLite has a single global interrupt.
+ *
+ * @return -ENOTSUP unconditionally.
+ */
+static int capi_uart_pl_lite_set_irq_tx(struct capi_uart_handle *handle,
+					bool enable)
+{
+	(void)handle;
+	(void)enable;
+	return -ENOTSUP;
+}
+
+/**
+ * @brief Check if TX buffer is ready for more data.
+ * @note PL Lite: XUartLite_IsTransmitFull().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_pl_lite_irq_tx_ready(struct capi_uart_handle *handle,
+		bool *ready)
+{
+	if (handle == NULL || ready == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	UINTPTR base = inst(xh)->RegBaseAddress;
+	*ready = XUartLite_IsTransmitFull(base) ? false : true;
+	return 0;
+}
+
+/**
+ * @brief Check if transmission is complete.
+ * @note PL Lite: XUartLite_GetStatusReg() & XUL_SR_TX_FIFO_EMPTY.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_pl_lite_irq_tx_complete(struct capi_uart_handle *handle,
+		bool *complete)
+{
+	if (handle == NULL || complete == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	UINTPTR base = inst(xh)->RegBaseAddress;
+	u32 sr = XUartLite_GetStatusReg(base);
+	*complete = (sr & XUL_SR_TX_FIFO_EMPTY) ? true : false;
+	return 0;
+}
+
+/**
+ * @brief Enable or disable RX interrupt.
+ * @note PL Lite: Unsupported; UartLite has a single global interrupt.
+ *
+ * @return -ENOTSUP unconditionally.
+ */
+static int capi_uart_pl_lite_set_irq_rx(struct capi_uart_handle *handle,
+					bool enable)
+{
+	(void)handle;
+	(void)enable;
+	return -ENOTSUP;
+}
+
+/**
+ * @brief Check if RX data is ready.
+ * @note PL Lite: XUartLite_IsReceiveEmpty().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_pl_lite_irq_rx_ready(struct capi_uart_handle *handle,
+		bool *ready)
+{
+	if (handle == NULL || ready == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	UINTPTR base = inst(xh)->RegBaseAddress;
+	*ready = XUartLite_IsReceiveEmpty(base) ? false : true;
+	return 0;
+}
+
+/**
+ * @brief Enable or disable error/status interrupt.
+ * @note PL Lite: Unsupported; UartLite has a single global interrupt.
+ *
+ * @return -ENOTSUP unconditionally.
+ */
+static int capi_uart_pl_lite_set_irq_err(struct capi_uart_handle *handle,
+		bool enable)
+{
+	(void)handle;
+	(void)enable;
+	return -ENOTSUP;
+}
+
+/**
+ * @brief Check if any UART interrupt is pending.
+ * @note PL Lite: XUartLite_GetStatusReg() & (RX_FIFO_FULL | TX_FIFO_EMPTY).
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_pl_lite_is_irq_pending(struct capi_uart_handle *handle,
+		bool *pending)
+{
+	if (handle == NULL || pending == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	UINTPTR base = inst(xh)->RegBaseAddress;
+	u32 sr = XUartLite_GetStatusReg(base);
+	*pending = (sr & (XUL_SR_RX_FIFO_FULL | XUL_SR_TX_FIFO_EMPTY)) ? true : false;
+	return 0;
+}
+
+#endif /* XPAR_XUARTLITE_NUM_INSTANCES */

--- a/capi/platform/xilinx/xilinx_capi_uart_pl_ns550.c
+++ b/capi/platform/xilinx/xilinx_capi_uart_pl_ns550.c
@@ -1,0 +1,994 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Xilinx XUartNs550 UART driver (AXI UART 16550)
+ *
+ * Full 16550 UART: runtime baud, data bits, parity, stop bits, loopback.
+ * OUT2 must be asserted for interrupts to propagate to the GIC.
+ * Level-triggered: IRQ must be enabled per-operation and disabled after
+ * completion to prevent interrupt storms.
+ *
+ * SDT BSP only. IRQ is explicit via capi_uart_xilinx_config.
+ * capi_irq_init() must be called before async ops will work.
+ */
+
+#include <capi_uart.h>
+#include <xilinx_capi_uart_priv.h>
+#include <capi_alloc.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <errno.h>
+#include <string.h>
+#include "capi_irq.h"
+#include "xinterrupt_wrap.h"
+
+#ifdef XPAR_XUARTNS550_NUM_INSTANCES
+
+/* Common UART reset/default line coding used when the caller does not provide one. */
+#define CAPI_UART_NS550_DEFAULT_BAUDRATE	115200U
+
+/* embeddedsw has no named "FIFO disabled" value for the 16550 FCR register. */
+#define CAPI_UART_NS550_FCR_DISABLE		0x00U
+
+static int capi_uart_ns550_init(struct capi_uart_handle **handle,
+				const struct capi_uart_config *config);
+static int capi_uart_ns550_deinit(struct capi_uart_handle *handle);
+static int capi_uart_ns550_get_line_config(struct capi_uart_handle *handle,
+		struct capi_uart_line_config *line_config);
+static int capi_uart_ns550_set_line_config(struct capi_uart_handle *handle,
+		struct capi_uart_line_config *line_config);
+static int capi_uart_ns550_enable_fifo(struct capi_uart_handle *handle,
+				       bool enable);
+static int capi_uart_ns550_flush_tx_fifo(struct capi_uart_handle *handle);
+static int capi_uart_ns550_flush_rx_fifo(struct capi_uart_handle *handle);
+static int capi_uart_ns550_get_rx_fifo_count(struct capi_uart_handle *handle,
+		uint16_t *count);
+static int capi_uart_ns550_get_tx_fifo_count(struct capi_uart_handle *handle,
+		uint16_t *count);
+static int capi_uart_ns550_transmit(struct capi_uart_handle *handle,
+				    uint8_t *buf, uint32_t len);
+static int capi_uart_ns550_receive(struct capi_uart_handle *handle,
+				   uint8_t *buf, uint32_t len);
+static int capi_uart_ns550_register_callback(struct capi_uart_handle *handle,
+		capi_uart_callback const callback,
+		void *const callback_arg);
+static int capi_uart_ns550_transmit_async(struct capi_uart_handle *handle,
+		uint8_t *buf,
+		uint32_t len);
+static int capi_uart_ns550_receive_async(struct capi_uart_handle *handle,
+		uint8_t *buf,
+		uint32_t len);
+static int capi_uart_ns550_get_interrupt_reason(struct capi_uart_handle *handle,
+		enum capi_uart_interrupt_reason *reason);
+static int capi_uart_ns550_get_line_status(struct capi_uart_handle *handle,
+		uint32_t *status_flags);
+static int capi_uart_ns550_set_irq_tx(struct capi_uart_handle *handle,
+				      bool enable);
+static int capi_uart_ns550_irq_tx_ready(struct capi_uart_handle *handle,
+					bool *ready);
+static int capi_uart_ns550_irq_tx_complete(struct capi_uart_handle *handle,
+		bool *complete);
+static int capi_uart_ns550_set_irq_rx(struct capi_uart_handle *handle,
+				      bool enable);
+static int capi_uart_ns550_irq_rx_ready(struct capi_uart_handle *handle,
+					bool *ready);
+static int capi_uart_ns550_set_irq_err(struct capi_uart_handle *handle,
+				       bool enable);
+static int capi_uart_ns550_is_irq_pending(struct capi_uart_handle *handle,
+		bool *pending);
+static void capi_uart_ns550_isr(void *handle);
+static void ns550_event_handler(void *callback_ref, u32 event,
+				unsigned int event_data);
+static void ns550_rx_done(struct capi_uart_xilinx_handle *xh,
+			  unsigned int event_data);
+
+const struct capi_uart_ops capi_uart_xilinx_pl_ns550_ops = {
+	.init = capi_uart_ns550_init,
+	.deinit = capi_uart_ns550_deinit,
+	.get_line_config = capi_uart_ns550_get_line_config,
+	.set_line_config = capi_uart_ns550_set_line_config,
+	.enable_fifo = capi_uart_ns550_enable_fifo,
+	.flush_tx_fifo = capi_uart_ns550_flush_tx_fifo,
+	.flush_rx_fifo = capi_uart_ns550_flush_rx_fifo,
+	.get_rx_fifo_count = capi_uart_ns550_get_rx_fifo_count,
+	.get_tx_fifo_count = capi_uart_ns550_get_tx_fifo_count,
+	.transmit = capi_uart_ns550_transmit,
+	.receive = capi_uart_ns550_receive,
+	.register_callback = capi_uart_ns550_register_callback,
+	.transmit_async = capi_uart_ns550_transmit_async,
+	.receive_async = capi_uart_ns550_receive_async,
+	.get_interrupt_reason = capi_uart_ns550_get_interrupt_reason,
+	.get_line_status = capi_uart_ns550_get_line_status,
+	.transmit_9bit = NULL,
+	.receive_9bit = NULL,
+	.set_flow_control_state = NULL,
+	.get_flow_control_state = NULL,
+	.isr = capi_uart_ns550_isr,
+	.read_byte = NULL,
+	.write_byte = NULL,
+	.set_irq_tx = capi_uart_ns550_set_irq_tx,
+	.irq_tx_ready = capi_uart_ns550_irq_tx_ready,
+	.irq_tx_complete = capi_uart_ns550_irq_tx_complete,
+	.set_irq_rx = capi_uart_ns550_set_irq_rx,
+	.irq_rx_ready = capi_uart_ns550_irq_rx_ready,
+	.set_irq_err = capi_uart_ns550_set_irq_err,
+	.is_irq_pending = capi_uart_ns550_is_irq_pending,
+};
+
+static XUartNs550 *inst(struct capi_uart_xilinx_handle *xh)
+{
+	return (XUartNs550 *)xh->instance;
+}
+
+static bool ns550_tx_busy(struct capi_uart_xilinx_handle *xh)
+{
+	return inst(xh)->SendBuffer.RemainingBytes > 0;
+}
+
+static bool ns550_rx_busy(struct capi_uart_xilinx_handle *xh)
+{
+	return inst(xh)->ReceiveBuffer.RemainingBytes > 0;
+}
+
+static void xilinx_uart_free_allocated_handle(struct capi_uart_handle **handle)
+{
+	if (handle == NULL || *handle == NULL)
+		return;
+
+	capi_free((*handle)->priv);
+	capi_free(*handle);
+	*handle = NULL;
+}
+
+/**
+ * @brief Initialize the CAPI backend instance.
+ * @note PL: XUartNs550_LookupConfig()/XUartNs550_CfgInitialize().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ns550_init(struct capi_uart_handle **handle,
+				const struct capi_uart_config *config)
+{
+	if (handle == NULL || config == NULL)
+		return -EINVAL;
+
+	if (config->dma_handle != NULL)
+		return -ENOTSUP;
+
+	int ret;
+	bool alloc = (*handle == NULL);
+	struct capi_uart_handle *h = *handle;
+	struct capi_uart_xilinx_handle *xh;
+
+	if (alloc) {
+		h = capi_malloc(sizeof(*h));
+		if (h == NULL)
+			return -ENOMEM;
+		memset(h, 0, sizeof(*h));
+
+		xh = capi_malloc(sizeof(*xh));
+		if (xh == NULL) {
+			capi_free(h);
+			return -ENOMEM;
+		}
+		h->priv = xh;
+		*handle = h;
+	} else {
+		xh = h->priv;
+		if (xh == NULL)
+			return -EINVAL;
+	}
+
+	memset(xh, 0, sizeof(*xh));
+	h->init_allocated = alloc;
+	h->ops = config->ops ? config->ops : &capi_uart_xilinx_pl_ns550_ops;
+	h->priv = xh;
+
+	xh->line_config.baudrate = CAPI_UART_NS550_DEFAULT_BAUDRATE;
+	xh->line_config.size = CAPI_UART_DATA_BITS_8;
+	xh->line_config.parity = CAPI_UART_PARITY_NONE;
+	xh->line_config.stop_bits = CAPI_UART_STOP_1_BIT;
+	xh->line_config.flow_control = CAPI_UART_FLOW_CONTROL_NONE;
+	if (config->line_config != NULL)
+		memcpy(&xh->line_config, config->line_config, sizeof(xh->line_config));
+
+	XUartNs550_Config *cfg = XUartNs550_LookupConfig((UINTPTR)config->identifier);
+	if (cfg == NULL) {
+		if (alloc)
+			xilinx_uart_free_allocated_handle(handle);
+		return -ENODEV;
+	}
+
+	XUartNs550 *ns = capi_malloc(sizeof(XUartNs550));
+	if (ns == NULL) {
+		if (alloc)
+			xilinx_uart_free_allocated_handle(handle);
+		return -ENOMEM;
+	}
+	memset(ns, 0, sizeof(XUartNs550));
+
+	if (XUartNs550_CfgInitialize(ns, cfg, cfg->BaseAddress) != XST_SUCCESS) {
+		capi_free(ns);
+		if (alloc)
+			xilinx_uart_free_allocated_handle(handle);
+		return -EIO;
+	}
+
+	xh->instance = ns;
+
+	if (config->clk_freq_hz != 0) {
+		ns->InputClockHz = config->clk_freq_hz;
+	} else {
+	}
+
+	u16 options = XUN_OPTION_FIFOS_ENABLE | XUN_OPTION_RESET_TX_FIFO |
+		      XUN_OPTION_RESET_RX_FIFO | XUN_OPTION_ASSERT_OUT2;
+	XUartNs550_SetOptions(ns, options);
+
+	ret = capi_uart_ns550_set_line_config(h, &xh->line_config);
+	if (ret) {
+		capi_free(ns);
+		if (alloc)
+			xilinx_uart_free_allocated_handle(handle);
+		return ret;
+	}
+
+	XUartNs550_SetHandler(ns, ns550_event_handler, xh);
+
+	const struct capi_uart_xilinx_config *xcfg =
+		(const struct capi_uart_xilinx_config *)config->extra;
+	if (xcfg != NULL && xcfg->use_irq) {
+		uint32_t irq_id = xcfg->irq_id;
+		int ret = capi_irq_connect(irq_id, capi_uart_ns550_isr, h);
+		if (ret == 0) {
+			capi_irq_set_level_edge_trigger(irq_id, CAPI_IRQ_LEVEL_HIGH);
+			ret = capi_irq_enable(irq_id);
+			if (ret == 0) {
+				xh->irq_id = irq_id;
+				xh->use_irq = true;
+			}
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Deinitialize the CAPI backend instance.
+ * @note PL: Clears IER/FCR/MCR.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ns550_deinit(struct capi_uart_handle *handle)
+{
+	if (handle == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	if (xh == NULL)
+		return -EINVAL;
+
+	if (inst(xh)->SendBuffer.RemainingBytes > 0
+	    || inst(xh)->ReceiveBuffer.RemainingBytes > 0)
+		return -EBUSY;
+
+	if (xh->use_irq) {
+		capi_irq_disable(xh->irq_id);
+		xh->use_irq = false;
+	}
+
+	UINTPTR base = inst(xh)->BaseAddress;
+	XUartNs550_WriteReg(base, XUN_IER_OFFSET, 0);
+	XUartNs550_WriteReg(base, XUN_FCR_OFFSET,
+			    XUN_FIFO_TX_RESET | XUN_FIFO_RX_RESET);
+	XUartNs550_WriteReg(base, XUN_MCR_OFFSET,
+			    XUartNs550_ReadReg(base, XUN_MCR_OFFSET) & ~XUN_MCR_LOOP);
+
+	capi_free(xh->instance);
+	xh->instance = NULL;
+
+	if (handle->init_allocated) {
+		capi_free(xh);
+		capi_free(handle);
+	} else {
+		handle->ops = NULL;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Get the UART line configuration.
+ * @note PL: Reads LCR/MCR.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ns550_get_line_config(struct capi_uart_handle *handle,
+		struct capi_uart_line_config *line_config)
+{
+	if (handle == NULL || line_config == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	UINTPTR base = inst(xh)->BaseAddress;
+
+	u8 lcr = XUartNs550_GetLineControlReg(base);
+
+	/* Data bits: LCR[1:0] */
+	u8 db = lcr & XUN_LCR_LENGTH_MASK;
+	line_config->size = (db == 0)   ? CAPI_UART_DATA_BITS_5
+			    : (db == 1) ? CAPI_UART_DATA_BITS_6
+			    : (db == 2) ? CAPI_UART_DATA_BITS_7
+			    : CAPI_UART_DATA_BITS_8;
+
+	line_config->stop_bits =
+		(lcr & XUN_LCR_2_STOP_BITS) ? CAPI_UART_STOP_2_BIT : CAPI_UART_STOP_1_BIT;
+
+	/* MARK/SPACE parity needs cached config. */
+	line_config->parity = xh->line_config.parity;
+	line_config->sticky_parity = xh->line_config.sticky_parity;
+
+	/* Baud: XUartNs550_SetBaud does not update BaudRate; use cached. */
+	line_config->baudrate = xh->line_config.baudrate;
+
+	u8 mcr = XUartNs550_ReadReg(base, XUN_MCR_OFFSET);
+	line_config->loopback = (mcr & XUN_MCR_LOOP) ? true : false;
+
+	line_config->flow_control = CAPI_UART_FLOW_CONTROL_NONE;
+	line_config->address_mode = CAPI_UART_ADDRESS_MODE_DISABLED;
+	line_config->device_address = 0;
+
+	return 0;
+}
+
+/**
+ * @brief Set the UART line configuration.
+ * @note PL: XUartNs550_SetBaud()/SetLineControlReg().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ns550_set_line_config(struct capi_uart_handle *handle,
+		struct capi_uart_line_config *line_config)
+{
+	if (handle == NULL || line_config == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	UINTPTR base = inst(xh)->BaseAddress;
+
+	if (line_config->flow_control != CAPI_UART_FLOW_CONTROL_NONE)
+		return -ENOTSUP;
+	if (line_config->address_mode != CAPI_UART_ADDRESS_MODE_DISABLED)
+		return -ENOTSUP;
+	if (line_config->device_address != 0)
+		return -ENOTSUP;
+
+	if (line_config->baudrate == 0)
+		return -EINVAL;
+
+	XUartNs550_SetBaud(base, inst(xh)->InputClockHz, line_config->baudrate);
+	/* SetBaud does not update the BaudRate field; track it manually. */
+	inst(xh)->BaudRate = line_config->baudrate;
+
+	u8 lcr = 0;
+
+	switch (line_config->size) {
+	case CAPI_UART_DATA_BITS_5:
+		break;
+	case CAPI_UART_DATA_BITS_6:
+		lcr |= XUN_LCR_6_DATA_BITS;
+		break;
+	case CAPI_UART_DATA_BITS_7:
+		lcr |= XUN_LCR_7_DATA_BITS;
+		break;
+	case CAPI_UART_DATA_BITS_8:
+		lcr |= XUN_LCR_8_DATA_BITS;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	switch (line_config->stop_bits) {
+	case CAPI_UART_STOP_1_BIT:
+		break;
+	case CAPI_UART_STOP_2_BIT:
+		lcr |= XUN_LCR_2_STOP_BITS;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	if (line_config->parity != CAPI_UART_PARITY_NONE) {
+		lcr |= XUN_LCR_ENABLE_PARITY;
+		/*
+		 * MARK/SPACE (stuck) parity is encoded in the 16550 LCR via the
+		 * stick-parity bit combined with the even-parity bit, not as its
+		 * own value: STICK alone forces the parity bit to 1 (MARK), while
+		 * EVEN|STICK forces it to 0 (SPACE). For ODD/EVEN, STICK is only
+		 * applied when the caller explicitly asked for sticky parity.
+		 */
+		switch (line_config->parity) {
+		case CAPI_UART_PARITY_ODD:
+			if (line_config->sticky_parity)
+				lcr |= XUN_LCR_STICK_PARITY;
+			break;
+		case CAPI_UART_PARITY_EVEN:
+			lcr |= XUN_LCR_EVEN_PARITY;
+			if (line_config->sticky_parity)
+				lcr |= XUN_LCR_STICK_PARITY;
+			break;
+		case CAPI_UART_PARITY_MARK:
+			lcr |= XUN_LCR_STICK_PARITY;
+			break;
+		case CAPI_UART_PARITY_SPACE:
+			lcr |= XUN_LCR_EVEN_PARITY | XUN_LCR_STICK_PARITY;
+			break;
+		default:
+			return -ENOTSUP;
+		}
+	}
+
+	XUartNs550_SetLineControlReg(base, lcr);
+
+	u8 mcr = XUartNs550_ReadReg(base, XUN_MCR_OFFSET);
+	if (line_config->loopback)
+		mcr |= XUN_MCR_LOOP;
+	else
+		mcr &= ~XUN_MCR_LOOP;
+	XUartNs550_WriteReg(base, XUN_MCR_OFFSET, mcr);
+
+	memcpy(&xh->line_config, line_config, sizeof(*line_config));
+	return 0;
+}
+
+/**
+ * @brief Enable or disable UART FIFO behavior.
+ * @note PL: Writes XUN_FCR_OFFSET.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ns550_enable_fifo(struct capi_uart_handle *handle,
+				       bool enable)
+{
+	if (handle == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	UINTPTR base = inst(xh)->BaseAddress;
+
+	if (enable)
+		XUartNs550_WriteReg(base, XUN_FCR_OFFSET,
+				    XUN_FIFO_ENABLE | XUN_FIFO_TX_RESET | XUN_FIFO_RX_RESET |
+				    XUN_FIFO_TRIGGER_08);
+	else
+		XUartNs550_WriteReg(base, XUN_FCR_OFFSET,
+				    CAPI_UART_NS550_FCR_DISABLE);
+
+	return 0;
+}
+
+/**
+ * @brief Flush the UART TX FIFO.
+ * @note PL: Resets TX FIFO.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ns550_flush_tx_fifo(struct capi_uart_handle *handle)
+{
+	if (handle == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	UINTPTR base = inst(xh)->BaseAddress;
+	XUartNs550_WriteReg(base, XUN_FCR_OFFSET,
+			    XUN_FIFO_ENABLE | XUN_FIFO_TX_RESET | XUN_FIFO_TRIGGER_08);
+	return 0;
+}
+
+/**
+ * @brief Flush the UART RX FIFO.
+ * @note PL: Resets RX FIFO.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ns550_flush_rx_fifo(struct capi_uart_handle *handle)
+{
+	if (handle == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	UINTPTR base = inst(xh)->BaseAddress;
+	XUartNs550_WriteReg(base, XUN_FCR_OFFSET,
+			    XUN_FIFO_ENABLE | XUN_FIFO_RX_RESET | XUN_FIFO_TRIGGER_08);
+	return 0;
+}
+
+/**
+ * @brief Get the UART RX FIFO occupancy.
+ * @note PL: Reads XUN_LSR_OFFSET.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ns550_get_rx_fifo_count(struct capi_uart_handle *handle,
+		uint16_t *count)
+{
+	if (handle == NULL || count == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	u8 lsr = XUartNs550_ReadReg(inst(xh)->BaseAddress, XUN_LSR_OFFSET);
+	*count = (lsr & XUN_LSR_DATA_READY) ? 1 : 0;
+	return 0;
+}
+
+/**
+ * @brief Get the UART TX FIFO occupancy.
+ * @note PL: Reads XUN_LSR_OFFSET.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ns550_get_tx_fifo_count(struct capi_uart_handle *handle,
+		uint16_t *count)
+{
+	if (handle == NULL || count == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	u8 lsr = XUartNs550_ReadReg(inst(xh)->BaseAddress, XUN_LSR_OFFSET);
+	*count = (lsr & XUN_LSR_TX_BUFFER_EMPTY) ? 0 : 1;
+	return 0;
+}
+
+/**
+ * @brief Run a synchronous transmit operation.
+ * @note PL: XUartNs550_Send().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ns550_transmit(struct capi_uart_handle *handle,
+				    uint8_t *buf, uint32_t len)
+{
+	if (handle == NULL || buf == NULL)
+		return -EINVAL;
+	if (len == 0)
+		return 0;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	if (ns550_tx_busy(xh))
+		return -EBUSY;
+
+	/*
+	 * XUartNs550_SendBuffer() auto-arms the TX-empty interrupt whenever
+	 * IER already has RX_DATA set. A blocking transmit must clear that bit
+	 * after every Send() call so the TX ISR cannot advance SendBuffer in
+	 * parallel with this polling loop. Only mask the controller IRQ around
+	 * that shared-state update: RX must remain serviceable while the FIFO
+	 * drains or a concurrent async receive can overflow its hardware FIFO.
+	 */
+	uint32_t total = 0;
+	while (total < len) {
+		if (xh->use_irq)
+			capi_irq_disable(xh->irq_id);
+
+		uint32_t sent = XUartNs550_Send(inst(xh), buf + total, len - total);
+		u8 ier = XUartNs550_ReadReg(inst(xh)->BaseAddress, XUN_IER_OFFSET);
+		XUartNs550_WriteReg(inst(xh)->BaseAddress, XUN_IER_OFFSET,
+				    ier & ~XUN_IER_TX_EMPTY);
+
+		if (xh->use_irq)
+			capi_irq_enable(xh->irq_id);
+
+		total += sent;
+		if (total < len) {
+			/* Wait for TX FIFO to drain before sending more */
+			while (!(XUartNs550_ReadReg(inst(xh)->BaseAddress, XUN_LSR_OFFSET) &
+				 XUN_LSR_TX_BUFFER_EMPTY))
+				;
+		}
+	}
+	while (!(XUartNs550_ReadReg(inst(xh)->BaseAddress, XUN_LSR_OFFSET) &
+		 XUN_LSR_TX_EMPTY))
+		;
+
+	return 0;
+}
+
+/**
+ * @brief Run a synchronous receive operation.
+ * @note PL: XUartNs550_Recv().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ns550_receive(struct capi_uart_handle *handle,
+				   uint8_t *buf, uint32_t len)
+{
+	if (handle == NULL || buf == NULL)
+		return -EINVAL;
+	if (len == 0)
+		return 0;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	if (ns550_rx_busy(xh))
+		return -EBUSY;
+
+	uint32_t total = 0;
+	while (total < len)
+		total += XUartNs550_Recv(inst(xh), buf + total, len - total);
+	return 0;
+}
+
+/**
+ * @brief Register the CAPI asynchronous callback.
+ * @note PL: Stores callback for events.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ns550_register_callback(struct capi_uart_handle *handle,
+		capi_uart_callback const callback,
+		void *const callback_arg)
+{
+	if (handle == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	xh->callback = callback;
+	xh->callback_arg = callback_arg;
+	return 0;
+}
+
+/**
+ * @brief Start an asynchronous transmit operation.
+ * @note PL: XUartNs550_Send() then enables TX IRQ.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ns550_transmit_async(struct capi_uart_handle *handle,
+		uint8_t *buf,
+		uint32_t len)
+{
+	if (handle == NULL || buf == NULL)
+		return -EINVAL;
+	if (len == 0)
+		return 0;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	if (!xh->use_irq)
+		return -ENOTSUP;
+	if (inst(xh)->SendBuffer.RemainingBytes > 0)
+		return -EBUSY;
+
+	/*
+	 * XUartNs550_Send() does an unprotected read-modify-write of IER to
+	 * clear the TX-empty bit, and the enable below does the same to set
+	 * it -- neither is safe against a concurrent RX ISR update. Unlike
+	 * capi_uart_ns550_transmit(), there's no polling drain loop afterward
+	 * to race against, so disabling just around this setup is sufficient.
+	 */
+	capi_irq_disable(xh->irq_id);
+	XUartNs550_Send(inst(xh), buf, len);
+	/* Enable TX empty interrupt only after Send to prevent an early ISR. */
+	u8 ier = XUartNs550_ReadReg(inst(xh)->BaseAddress, XUN_IER_OFFSET);
+	XUartNs550_WriteReg(inst(xh)->BaseAddress, XUN_IER_OFFSET,
+			    ier | XUN_IER_TX_EMPTY);
+	capi_irq_enable(xh->irq_id);
+	return 0;
+}
+
+/**
+ * @brief Start an asynchronous receive operation.
+ * @note PL: Enables RX IRQ then XUartNs550_Recv().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ns550_receive_async(struct capi_uart_handle *handle,
+		uint8_t *buf,
+		uint32_t len)
+{
+	if (handle == NULL || buf == NULL)
+		return -EINVAL;
+	if (len == 0)
+		return 0;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	if (!xh->use_irq)
+		return -ENOTSUP;
+	if (inst(xh)->ReceiveBuffer.RemainingBytes > 0)
+		return -EBUSY;
+
+	/* Enable RX interrupt before Recv */
+	u8 ier = XUartNs550_ReadReg(inst(xh)->BaseAddress, XUN_IER_OFFSET);
+	XUartNs550_WriteReg(inst(xh)->BaseAddress, XUN_IER_OFFSET,
+			    ier | XUN_IER_RX_DATA);
+	XUartNs550_Recv(inst(xh), buf, len);
+
+	/*
+	 * XUartNs550_Recv() drains whatever is already sitting in the RX FIFO
+	 * synchronously before returning (XUartNs550_ReceiveBuffer() runs
+	 * inline, not from the ISR). If the caller pre-buffered the full
+	 * transfer with a blocking transmit before arming this receive, len
+	 * bytes are already in the FIFO and RemainingBytes hits 0 right here --
+	 * no RX interrupt is coming to complete it, since there is no new edge
+	 * on an already-idle line. Mirrors the equivalent lite-UART fix.
+	 */
+	if (inst(xh)->ReceiveBuffer.RemainingBytes == 0)
+		ns550_rx_done(xh, inst(xh)->ReceiveBuffer.RequestedBytes);
+
+	return 0;
+}
+
+/**
+ * @brief Get the last UART interrupt reason.
+ * @note PL: Returns cached ISR reason.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ns550_get_interrupt_reason(struct capi_uart_handle *handle,
+		enum capi_uart_interrupt_reason *reason)
+{
+	if (handle == NULL || reason == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	*reason = xh->last_interrupt_reason;
+	return 0;
+}
+
+/**
+ * @brief Get UART line status flags.
+ * @note PL: Reads XUN_LSR_OFFSET.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ns550_get_line_status(struct capi_uart_handle *handle,
+		uint32_t *status_flags)
+{
+	if (handle == NULL || status_flags == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	u32 lsr = XUartNs550_ReadReg(inst(xh)->BaseAddress, XUN_LSR_OFFSET);
+	*status_flags = 0;
+
+	if (lsr & XUN_LSR_BREAK_INT)
+		*status_flags |= CAPI_UART_LINE_STAT_BREAK_IND;
+
+	if (lsr & XUN_LSR_FRAMING_ERROR)
+		*status_flags |= CAPI_UART_LINE_STAT_FRAMING_ERROR;
+
+	if (lsr & XUN_LSR_PARITY_ERROR)
+		*status_flags |= CAPI_UART_LINE_STAT_PARITY_ERROR;
+
+	if (lsr & XUN_LSR_OVERRUN_ERROR)
+		*status_flags |= CAPI_UART_LINE_STAT_OVERRUN_ERROR;
+
+	return 0;
+}
+
+/**
+ * @brief Dispatch the backend interrupt handler.
+ * @note PL: XUartNs550_InterruptHandler().
+ *
+ */
+static void capi_uart_ns550_isr(void *handle)
+{
+	if (handle == NULL)
+		return;
+
+	struct capi_uart_xilinx_handle *xh = ((struct capi_uart_handle *)handle)->priv;
+	XUartNs550_InterruptHandler(inst(xh));
+}
+
+static void ns550_rx_done(struct capi_uart_xilinx_handle *xh,
+			  unsigned int event_data)
+{
+	UINTPTR base = inst(xh)->BaseAddress;
+	u8 ier = XUartNs550_ReadReg(base, XUN_IER_OFFSET);
+
+	xh->last_interrupt_reason = CAPI_UART_INTR_RX_BUFFER_FULL;
+	XUartNs550_WriteReg(base, XUN_IER_OFFSET, ier & ~XUN_IER_RX_DATA);
+	if (xh->callback)
+		xh->callback(CAPI_UART_EVENT_RX_DONE, xh->callback_arg, event_data);
+}
+
+static void ns550_event_handler(void *callback_ref, u32 event,
+				unsigned int event_data)
+{
+	struct capi_uart_xilinx_handle *xh = (struct capi_uart_xilinx_handle *)
+					     callback_ref;
+
+	if (xh == NULL || xh->instance == NULL)
+		return;
+
+	UINTPTR base = inst(xh)->BaseAddress;
+	u8 ier;
+
+	switch (event) {
+	case XUN_EVENT_SENT_DATA:
+		xh->last_interrupt_reason = CAPI_UART_INTR_TX_BUFFER_EMPTY;
+		ier = XUartNs550_ReadReg(base, XUN_IER_OFFSET);
+		XUartNs550_WriteReg(base, XUN_IER_OFFSET, ier & ~XUN_IER_TX_EMPTY);
+		if (xh->callback)
+			xh->callback(CAPI_UART_EVENT_TX_DONE, xh->callback_arg, event_data);
+		break;
+
+	case XUN_EVENT_RECV_DATA:
+		xh->last_interrupt_reason = CAPI_UART_INTR_RX_BUFFER_FULL;
+		if (inst(xh)->ReceiveBuffer.RemainingBytes > 0)
+			return; /* Partial; keep interrupt enabled. */
+		ns550_rx_done(xh, event_data);
+		break;
+
+	case XUN_EVENT_RECV_TIMEOUT:
+		xh->last_interrupt_reason = CAPI_UART_INTR_RX_BUFFER_FULL;
+		if (inst(xh)->ReceiveBuffer.RemainingBytes == 0) {
+			ns550_rx_done(xh, event_data);
+		} else {
+			if (xh->callback)
+				xh->callback(CAPI_UART_EVENT_RX_TIMEOUT, xh->callback_arg,
+					     event_data);
+		}
+		break;
+
+	case XUN_EVENT_RECV_ERROR:
+		xh->last_interrupt_reason = CAPI_UART_INTR_RX_LINE_STATUS;
+		if (xh->callback)
+			xh->callback(CAPI_UART_EVENT_INTERRUPT, xh->callback_arg, event_data);
+		break;
+
+	case XUN_EVENT_MODEM:
+		xh->last_interrupt_reason = CAPI_UART_INTR_MODEM_STATUS;
+		if (xh->callback)
+			xh->callback(CAPI_UART_EVENT_INTERRUPT, xh->callback_arg, event_data);
+		break;
+
+	default:
+		if (xh->callback)
+			xh->callback(CAPI_UART_EVENT_INTERRUPT, xh->callback_arg, event_data);
+		break;
+	}
+}
+
+/**
+ * @brief Enable or disable TX interrupt.
+ * @note PL: XUartNs550_WriteReg() with IER_TX_EMPTY.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ns550_set_irq_tx(struct capi_uart_handle *handle,
+				      bool enable)
+{
+	if (handle == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	u8 ier = XUartNs550_ReadReg(inst(xh)->BaseAddress, XUN_IER_OFFSET);
+	if (enable)
+		ier |= XUN_IER_TX_EMPTY;
+	else
+		ier &= ~XUN_IER_TX_EMPTY;
+	XUartNs550_WriteReg(inst(xh)->BaseAddress, XUN_IER_OFFSET, ier);
+	return 0;
+}
+
+/**
+ * @brief Check if TX buffer is ready for more data.
+ * @note PL: XUartNs550_ReadReg(LSR) & XUN_LSR_TX_EMPTY.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ns550_irq_tx_ready(struct capi_uart_handle *handle,
+					bool *ready)
+{
+	if (handle == NULL || ready == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	u32 lsr = XUartNs550_ReadReg(inst(xh)->BaseAddress, XUN_LSR_OFFSET);
+	*ready = (lsr & XUN_LSR_TX_EMPTY) ? true : false;
+	return 0;
+}
+
+/**
+ * @brief Check if transmission is complete.
+ * @note PL: XUartNs550_ReadReg(LSR) & XUN_LSR_TX_EMPTY.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ns550_irq_tx_complete(struct capi_uart_handle *handle,
+		bool *complete)
+{
+	if (handle == NULL || complete == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	u32 lsr = XUartNs550_ReadReg(inst(xh)->BaseAddress, XUN_LSR_OFFSET);
+	*complete = (lsr & XUN_LSR_TX_EMPTY) ? true : false;
+	return 0;
+}
+
+/**
+ * @brief Enable or disable RX interrupt.
+ * @note PL: XUartNs550_WriteReg() with IER_RX_DATA.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ns550_set_irq_rx(struct capi_uart_handle *handle,
+				      bool enable)
+{
+	if (handle == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	u8 ier = XUartNs550_ReadReg(inst(xh)->BaseAddress, XUN_IER_OFFSET);
+	if (enable)
+		ier |= XUN_IER_RX_DATA;
+	else
+		ier &= ~XUN_IER_RX_DATA;
+	XUartNs550_WriteReg(inst(xh)->BaseAddress, XUN_IER_OFFSET, ier);
+	return 0;
+}
+
+/**
+ * @brief Check if RX data is ready.
+ * @note PL: XUartNs550_ReadReg(LSR) & XUN_LSR_DATA_READY.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ns550_irq_rx_ready(struct capi_uart_handle *handle,
+					bool *ready)
+{
+	if (handle == NULL || ready == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	u32 lsr = XUartNs550_ReadReg(inst(xh)->BaseAddress, XUN_LSR_OFFSET);
+	*ready = (lsr & XUN_LSR_DATA_READY) ? true : false;
+	return 0;
+}
+
+/**
+ * @brief Enable or disable error/status interrupt.
+ * @note PL: XUartNs550_WriteReg() with IER_RX_LINE.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ns550_set_irq_err(struct capi_uart_handle *handle,
+				       bool enable)
+{
+	if (handle == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	u8 ier = XUartNs550_ReadReg(inst(xh)->BaseAddress, XUN_IER_OFFSET);
+	if (enable)
+		ier |= XUN_IER_RX_LINE;
+	else
+		ier &= ~XUN_IER_RX_LINE;
+	XUartNs550_WriteReg(inst(xh)->BaseAddress, XUN_IER_OFFSET, ier);
+	return 0;
+}
+
+/**
+ * @brief Check if any UART interrupt is pending.
+ * @note PL: XUartNs550_ReadReg(IIR); bit 0 is 1 when no interrupt pending.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ns550_is_irq_pending(struct capi_uart_handle *handle,
+		bool *pending)
+{
+	if (handle == NULL || pending == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	u32 iir = XUartNs550_ReadReg(inst(xh)->BaseAddress, XUN_IIR_OFFSET);
+	*pending = (iir & 0x01) ? false : true;
+	return 0;
+}
+
+#endif /* XPAR_XUARTNS550_NUM_INSTANCES */

--- a/capi/platform/xilinx/xilinx_capi_uart_priv.h
+++ b/capi/platform/xilinx/xilinx_capi_uart_priv.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Xilinx platform UART private driver contract.
+ *
+ * Include this from Xilinx UART backend sources and tests that intentionally
+ * inspect Xilinx-private state or preallocate Xilinx UART storage.
+ */
+
+#ifndef _XILINX_CAPI_UART_PRIV_H_
+#define _XILINX_CAPI_UART_PRIV_H_
+
+#include <xilinx_capi_uart.h>
+
+#include "xparameters.h"
+#ifdef XPAR_XUARTPS_NUM_INSTANCES
+#include "xuartps.h"
+#endif
+#ifdef XPAR_XUARTLITE_NUM_INSTANCES
+#include "xuartlite.h"
+#include "xuartlite_l.h"
+#endif
+#ifdef XPAR_XUARTNS550_NUM_INSTANCES
+#include "xuartns550.h"
+#include "xuartns550_l.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @struct capi_uart_xilinx_handle
+ * @brief Xilinx UART private handle.
+ */
+struct capi_uart_xilinx_handle {
+	/** Xilinx driver instance (XUartPs*, XUartPsv*, XUartLite*, XUartNs550*) */
+	void *instance;
+	/** Cached line configuration */
+	struct capi_uart_line_config line_config;
+	/** User callback for async operations */
+	capi_uart_callback callback;
+	/** User callback argument */
+	void *callback_arg;
+	/** IRQ ID (only valid if use_irq is true) */
+	uint32_t irq_id;
+	/** True if IRQ was successfully connected during init */
+	bool use_irq;
+	/** Last interrupt reason (captured in ISR) */
+	enum capi_uart_interrupt_reason last_interrupt_reason;
+};
+
+/**
+ * @brief Declare a stack-allocated Xilinx UART handle.
+ *
+ * Declares `name` (struct capi_uart_handle) with embedded private state.
+ * Pass &name to capi_uart_init(). The backend skips allocation and sets
+ * init_allocated to false.
+ */
+#define CAPI_UART_HANDLE_XILINX_DEFINE(name)                           \
+	struct capi_uart_handle name = {                                   \
+		.ops = NULL,                                                   \
+		.init_allocated = false,                                       \
+		.priv = &(struct capi_uart_xilinx_handle){0}                   \
+	}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _XILINX_CAPI_UART_PRIV_H_ */

--- a/capi/platform/xilinx/xilinx_capi_uart_ps.c
+++ b/capi/platform/xilinx/xilinx_capi_uart_ps.c
@@ -1,0 +1,969 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Xilinx XUartPs UART driver (Zynq-7000 / ZynqMP PS UART)
+ *
+ * SDT BSP only. IRQ is explicit via capi_uart_xilinx_config.
+ * capi_irq_init() must be called before async ops will work.
+ */
+
+#include <capi_uart.h>
+#include <xilinx_capi_uart_priv.h>
+#include <capi_alloc.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <errno.h>
+#include <string.h>
+#include "capi_irq.h"
+#include "xinterrupt_wrap.h"
+
+#ifdef XPAR_XUARTPS_NUM_INSTANCES
+
+/* Common UART reset/default line coding used when the caller does not provide one. */
+#define CAPI_UART_PS_DEFAULT_BAUDRATE	115200U
+
+static int capi_uart_ps_init(struct capi_uart_handle **handle,
+			     const struct capi_uart_config *config);
+static int capi_uart_ps_deinit(struct capi_uart_handle *handle);
+static int capi_uart_ps_get_line_config(struct capi_uart_handle *handle,
+					struct capi_uart_line_config *line_config);
+static int capi_uart_ps_set_line_config(struct capi_uart_handle *handle,
+					struct capi_uart_line_config *line_config);
+static int capi_uart_ps_enable_fifo(struct capi_uart_handle *handle,
+				    bool enable);
+static int capi_uart_ps_flush_tx_fifo(struct capi_uart_handle *handle);
+static int capi_uart_ps_flush_rx_fifo(struct capi_uart_handle *handle);
+static int capi_uart_ps_get_rx_fifo_count(struct capi_uart_handle *handle,
+		uint16_t *count);
+static int capi_uart_ps_get_tx_fifo_count(struct capi_uart_handle *handle,
+		uint16_t *count);
+static int capi_uart_ps_transmit(struct capi_uart_handle *handle, uint8_t *buf,
+				 uint32_t len);
+static int capi_uart_ps_receive(struct capi_uart_handle *handle, uint8_t *buf,
+				uint32_t len);
+static int capi_uart_ps_register_callback(struct capi_uart_handle *handle,
+		capi_uart_callback const callback,
+		void *const callback_arg);
+static int capi_uart_ps_transmit_async(struct capi_uart_handle *handle,
+				       uint8_t *buf, uint32_t len);
+static int capi_uart_ps_receive_async(struct capi_uart_handle *handle,
+				      uint8_t *buf, uint32_t len);
+static int capi_uart_ps_get_interrupt_reason(struct capi_uart_handle *handle,
+		enum capi_uart_interrupt_reason *reason);
+static int capi_uart_ps_get_line_status(struct capi_uart_handle *handle,
+					uint32_t *status_flags);
+static int capi_uart_ps_set_irq_tx(struct capi_uart_handle *handle,
+				   bool enable);
+static int capi_uart_ps_irq_tx_ready(struct capi_uart_handle *handle,
+				     bool *ready);
+static int capi_uart_ps_irq_tx_complete(struct capi_uart_handle *handle,
+					bool *complete);
+static int capi_uart_ps_set_irq_rx(struct capi_uart_handle *handle,
+				   bool enable);
+static int capi_uart_ps_irq_rx_ready(struct capi_uart_handle *handle,
+				     bool *ready);
+static int capi_uart_ps_set_irq_err(struct capi_uart_handle *handle,
+				    bool enable);
+static int capi_uart_ps_is_irq_pending(struct capi_uart_handle *handle,
+				       bool *pending);
+static void capi_uart_ps_isr(void *handle);
+static void ps_tx_done(struct capi_uart_xilinx_handle *xh, u32 event_data);
+static void ps_rx_done(struct capi_uart_xilinx_handle *xh, u32 event_data);
+static void ps_event_handler(void *callback_ref, u32 event, u32 event_data);
+
+const struct capi_uart_ops capi_uart_xilinx_ps_ops = {
+	.init = capi_uart_ps_init,
+	.deinit = capi_uart_ps_deinit,
+	.get_line_config = capi_uart_ps_get_line_config,
+	.set_line_config = capi_uart_ps_set_line_config,
+	.enable_fifo = capi_uart_ps_enable_fifo,
+	.flush_tx_fifo = capi_uart_ps_flush_tx_fifo,
+	.flush_rx_fifo = capi_uart_ps_flush_rx_fifo,
+	.get_rx_fifo_count = capi_uart_ps_get_rx_fifo_count,
+	.get_tx_fifo_count = capi_uart_ps_get_tx_fifo_count,
+	.transmit = capi_uart_ps_transmit,
+	.receive = capi_uart_ps_receive,
+	.register_callback = capi_uart_ps_register_callback,
+	.transmit_async = capi_uart_ps_transmit_async,
+	.receive_async = capi_uart_ps_receive_async,
+	.get_interrupt_reason = capi_uart_ps_get_interrupt_reason,
+	.get_line_status = capi_uart_ps_get_line_status,
+	.transmit_9bit = NULL,
+	.receive_9bit = NULL,
+	.set_flow_control_state = NULL,
+	.get_flow_control_state = NULL,
+	.isr = capi_uart_ps_isr,
+	.read_byte = NULL,
+	.write_byte = NULL,
+	.set_irq_tx = capi_uart_ps_set_irq_tx,
+	.irq_tx_ready = capi_uart_ps_irq_tx_ready,
+	.irq_tx_complete = capi_uart_ps_irq_tx_complete,
+	.set_irq_rx = capi_uart_ps_set_irq_rx,
+	.irq_rx_ready = capi_uart_ps_irq_rx_ready,
+	.set_irq_err = capi_uart_ps_set_irq_err,
+	.is_irq_pending = capi_uart_ps_is_irq_pending,
+};
+
+static XUartPs *inst(struct capi_uart_xilinx_handle *xh)
+{
+	return (XUartPs *)xh->instance;
+}
+
+/*
+ * Busy checks are PER DIRECTION. TX and RX are independent on a UART, and the
+ * async API is explicitly built around holding a receive armed while traffic
+ * moves the other way, so a pending receive must not block a transmit (or the
+ * reverse). A combined check refuses exactly the arm-RX-then-send-TX sequence
+ * that full-duplex callers rely on.
+ */
+static bool ps_tx_busy(struct capi_uart_xilinx_handle *xh)
+{
+	return inst(xh)->SendBuffer.RemainingBytes > 0;
+}
+
+static bool ps_rx_busy(struct capi_uart_xilinx_handle *xh)
+{
+	return inst(xh)->ReceiveBuffer.RemainingBytes > 0;
+}
+
+static void xilinx_uart_free_allocated_handle(struct capi_uart_handle **handle)
+{
+	if (handle == NULL || *handle == NULL)
+		return;
+
+	capi_free((*handle)->priv);
+	capi_free(*handle);
+	*handle = NULL;
+}
+
+/**
+ * @brief Initialize the CAPI backend instance.
+ * @note PS: XUartPs_LookupConfig()/XUartPs_CfgInitialize().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ps_init(struct capi_uart_handle **handle,
+			     const struct capi_uart_config *config)
+{
+	if (handle == NULL || config == NULL)
+		return -EINVAL;
+	/* XUartPs async support is IRQ-only. */
+	if (config->dma_handle != NULL)
+		return -ENOTSUP;
+
+	int ret;
+	bool alloc = (*handle == NULL);
+	struct capi_uart_handle *h = *handle;
+	struct capi_uart_xilinx_handle *xh;
+
+	if (alloc) {
+		h = capi_malloc(sizeof(*h));
+		if (h == NULL)
+			return -ENOMEM;
+		memset(h, 0, sizeof(*h));
+
+		xh = capi_malloc(sizeof(*xh));
+		if (xh == NULL) {
+			capi_free(h);
+			return -ENOMEM;
+		}
+		h->priv = xh;
+		*handle = h;
+	} else {
+		xh = h->priv;
+		if (xh == NULL)
+			return -EINVAL;
+	}
+
+	memset(xh, 0, sizeof(*xh));
+	h->init_allocated = alloc;
+	h->ops = config->ops ? config->ops : &capi_uart_xilinx_ps_ops;
+	h->priv = xh;
+
+	xh->line_config.baudrate = CAPI_UART_PS_DEFAULT_BAUDRATE;
+	xh->line_config.size = CAPI_UART_DATA_BITS_8;
+	xh->line_config.parity = CAPI_UART_PARITY_NONE;
+	xh->line_config.stop_bits = CAPI_UART_STOP_1_BIT;
+	xh->line_config.flow_control = CAPI_UART_FLOW_CONTROL_NONE;
+	if (config->line_config != NULL)
+		memcpy(&xh->line_config, config->line_config, sizeof(xh->line_config));
+
+	XUartPs_Config *cfg = XUartPs_LookupConfig((UINTPTR)config->identifier);
+	if (cfg == NULL) {
+		if (alloc)
+			xilinx_uart_free_allocated_handle(handle);
+		return -ENODEV;
+	}
+
+	XUartPs *ps = capi_malloc(sizeof(XUartPs));
+	if (ps == NULL) {
+		if (alloc)
+			xilinx_uart_free_allocated_handle(handle);
+		return -ENOMEM;
+	}
+	memset(ps, 0, sizeof(XUartPs));
+
+	if (XUartPs_CfgInitialize(ps, cfg, cfg->BaseAddress) != XST_SUCCESS) {
+		capi_free(ps);
+		if (alloc)
+			xilinx_uart_free_allocated_handle(handle);
+		return -EIO;
+	}
+
+	xh->instance = ps;
+
+	ret = capi_uart_ps_set_line_config(h, &xh->line_config);
+	if (ret) {
+		capi_free(ps);
+		if (alloc)
+			xilinx_uart_free_allocated_handle(handle);
+		return ret;
+	}
+	XUartPs_SetHandler(ps, ps_event_handler, xh);
+	XUartPs_SetRecvTimeout(ps, 8);
+
+	const struct capi_uart_xilinx_config *xcfg =
+		(const struct capi_uart_xilinx_config *)config->extra;
+	if (xcfg != NULL && xcfg->use_irq) {
+		uint32_t irq_id = xcfg->irq_id;
+		int ret = capi_irq_connect(irq_id, capi_uart_ps_isr, h);
+		if (ret == 0) {
+			capi_irq_set_level_edge_trigger(irq_id, CAPI_IRQ_LEVEL_HIGH);
+			ret = capi_irq_enable(irq_id);
+			if (ret == 0) {
+				xh->irq_id = irq_id;
+				xh->use_irq = true;
+			}
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Deinitialize the CAPI backend instance.
+ * @note PS: XUartPs_DisableUart()/XUartPs_SetInterruptMask(0).
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ps_deinit(struct capi_uart_handle *handle)
+{
+	if (handle == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	if (xh == NULL)
+		return -EINVAL;
+
+	if (inst(xh)->SendBuffer.RemainingBytes > 0
+	    || inst(xh)->ReceiveBuffer.RemainingBytes > 0)
+		return -EBUSY;
+
+	if (xh->use_irq) {
+		capi_irq_disable(xh->irq_id);
+		xh->use_irq = false;
+	}
+
+	XUartPs_DisableUart(inst(xh));
+	XUartPs_SetOperMode(inst(xh), 0);
+	XUartPs_SetInterruptMask(inst(xh), 0);
+
+	capi_free(xh->instance);
+	xh->instance = NULL;
+
+	if (handle->init_allocated) {
+		capi_free(xh);
+		capi_free(handle);
+	} else {
+		handle->ops = NULL;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Get the UART line configuration.
+ * @note PS: XUartPs_GetDataFormat()/XUartPs_ReadReg().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ps_get_line_config(struct capi_uart_handle *handle,
+					struct capi_uart_line_config *line_config)
+{
+	if (handle == NULL || line_config == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	XUartPsFormat fmt;
+	XUartPs_GetDataFormat(inst(xh), &fmt);
+
+	line_config->baudrate = fmt.BaudRate;
+
+	switch (fmt.DataBits) {
+	case XUARTPS_FORMAT_6_BITS:
+		line_config->size = CAPI_UART_DATA_BITS_6;
+		break;
+	case XUARTPS_FORMAT_7_BITS:
+		line_config->size = CAPI_UART_DATA_BITS_7;
+		break;
+	default:
+		line_config->size = CAPI_UART_DATA_BITS_8;
+		break;
+	}
+
+	switch (fmt.Parity) {
+	case XUARTPS_FORMAT_ODD_PARITY:
+		line_config->parity = CAPI_UART_PARITY_ODD;
+		break;
+	case XUARTPS_FORMAT_EVEN_PARITY:
+		line_config->parity = CAPI_UART_PARITY_EVEN;
+		break;
+	default:
+		line_config->parity = CAPI_UART_PARITY_NONE;
+		break;
+	}
+
+	line_config->stop_bits = (fmt.StopBits == XUARTPS_FORMAT_2_STOP_BIT) ?
+				 CAPI_UART_STOP_2_BIT
+				 : CAPI_UART_STOP_1_BIT;
+
+	u32 mode = XUartPs_ReadReg(inst(xh)->Config.BaseAddress, XUARTPS_MR_OFFSET);
+	line_config->loopback = (mode & XUARTPS_MR_CHMODE_L_LOOP) ? true : false;
+
+	/* XUartPs has no hardware registers for these fields; return safe defaults. */
+	line_config->flow_control = CAPI_UART_FLOW_CONTROL_NONE;
+	line_config->address_mode = CAPI_UART_ADDRESS_MODE_DISABLED;
+	line_config->device_address = 0;
+	line_config->sticky_parity = false;
+
+	return 0;
+}
+
+/**
+ * @brief Set the UART line configuration.
+ * @note PS: XUartPs_SetBaudRate()/XUartPs_SetDataFormat().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ps_set_line_config(struct capi_uart_handle *handle,
+					struct capi_uart_line_config *line_config)
+{
+	if (handle == NULL || line_config == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+
+	/* Reject line-config fields not supported by XUartPs. */
+	if (line_config->flow_control != CAPI_UART_FLOW_CONTROL_NONE)
+		return -ENOTSUP;
+	if (line_config->address_mode != CAPI_UART_ADDRESS_MODE_DISABLED)
+		return -ENOTSUP;
+	if (line_config->device_address != 0)
+		return -ENOTSUP;
+	if (line_config->sticky_parity)
+		return -ENOTSUP;
+	if (line_config->parity == CAPI_UART_PARITY_MARK ||
+	    line_config->parity == CAPI_UART_PARITY_SPACE)
+		return -ENOTSUP;
+
+	XUartPsFormat fmt;
+	fmt.BaudRate = line_config->baudrate;
+
+	switch (line_config->size) {
+	case CAPI_UART_DATA_BITS_6:
+		fmt.DataBits = XUARTPS_FORMAT_6_BITS;
+		break;
+	case CAPI_UART_DATA_BITS_7:
+		fmt.DataBits = XUARTPS_FORMAT_7_BITS;
+		break;
+	case CAPI_UART_DATA_BITS_8:
+		fmt.DataBits = XUARTPS_FORMAT_8_BITS;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	switch (line_config->parity) {
+	case CAPI_UART_PARITY_NONE:
+		fmt.Parity = XUARTPS_FORMAT_NO_PARITY;
+		break;
+	case CAPI_UART_PARITY_ODD:
+		fmt.Parity = XUARTPS_FORMAT_ODD_PARITY;
+		break;
+	case CAPI_UART_PARITY_EVEN:
+		fmt.Parity = XUARTPS_FORMAT_EVEN_PARITY;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	switch (line_config->stop_bits) {
+	case CAPI_UART_STOP_1_BIT:
+		fmt.StopBits = XUARTPS_FORMAT_1_STOP_BIT;
+		break;
+	case CAPI_UART_STOP_2_BIT:
+		fmt.StopBits = XUARTPS_FORMAT_2_STOP_BIT;
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	if (XUartPs_SetBaudRate(inst(xh), fmt.BaudRate) != XST_SUCCESS)
+		return -EINVAL;
+
+	if (XUartPs_SetDataFormat(inst(xh), &fmt) != XST_SUCCESS)
+		return -EINVAL;
+
+	u8 oper = line_config->loopback ? XUARTPS_OPER_MODE_LOCAL_LOOP :
+		  XUARTPS_OPER_MODE_NORMAL;
+	XUartPs_SetOperMode(inst(xh), oper);
+
+	memcpy(&xh->line_config, line_config, sizeof(*line_config));
+	return 0;
+}
+
+/**
+ * @brief Enable or disable UART FIFO behavior.
+ * @note PS: FIFOs are always on.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ps_enable_fifo(struct capi_uart_handle *handle,
+				    bool enable)
+{
+	(void)handle;
+	(void)enable;
+	return 0; /* XUartPs always uses FIFO */
+}
+
+/**
+ * @brief Flush the UART TX FIFO.
+ * @note PS: XUartPs_IsTransmitEmpty().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ps_flush_tx_fifo(struct capi_uart_handle *handle)
+{
+	if (handle == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	while (!XUartPs_IsTransmitEmpty(inst(xh)))
+		;
+	return 0;
+}
+
+/**
+ * @brief Flush the UART RX FIFO.
+ * @note PS: XUartPs_IsReceiveData()/XUartPs_RecvByte().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ps_flush_rx_fifo(struct capi_uart_handle *handle)
+{
+	if (handle == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	UINTPTR base = inst(xh)->Config.BaseAddress;
+	while (XUartPs_IsReceiveData(base))
+		(void)XUartPs_RecvByte(base);
+	return 0;
+}
+
+/**
+ * @brief Get the UART RX FIFO occupancy.
+ * @note PS: XUartPs_IsReceiveData().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ps_get_rx_fifo_count(struct capi_uart_handle *handle,
+		uint16_t *count)
+{
+	if (handle == NULL || count == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	*count = XUartPs_IsReceiveData(inst(xh)->Config.BaseAddress) ? 1 : 0;
+	return 0;
+}
+
+/**
+ * @brief Get the UART TX FIFO occupancy.
+ * @note PS: XUartPs_IsTransmitEmpty().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ps_get_tx_fifo_count(struct capi_uart_handle *handle,
+		uint16_t *count)
+{
+	if (handle == NULL || count == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	*count = XUartPs_IsTransmitEmpty(inst(xh)) ? 0 : 1;
+	return 0;
+}
+
+/**
+ * @brief Run a synchronous transmit operation.
+ * @note PS: XUartPs_Send()/XUartPs_IsSending().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ps_transmit(struct capi_uart_handle *handle, uint8_t *buf,
+				 uint32_t len)
+{
+	if (handle == NULL || buf == NULL)
+		return -EINVAL;
+	if (len == 0)
+		return 0;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	if (ps_tx_busy(xh))
+		return -EBUSY;
+
+	/* XUartPs_Send only pushes what fits in the TX FIFO and relies on the
+	 * interrupt handler to feed the rest. In this polled path nothing drains
+	 * the remainder, so loop until the whole buffer is queued, waiting for
+	 * the FIFO to drain between chunks. */
+	uint32_t total = 0;
+	while (total < len) {
+		total += XUartPs_Send(inst(xh), buf + total, len - total);
+		while (XUartPs_IsSending(inst(xh)))
+			;
+	}
+	return 0;
+}
+
+/**
+ * @brief Run a synchronous receive operation.
+ * @note PS: XUartPs_Recv().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ps_receive(struct capi_uart_handle *handle, uint8_t *buf,
+				uint32_t len)
+{
+	if (handle == NULL || buf == NULL)
+		return -EINVAL;
+	if (len == 0)
+		return 0;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	if (ps_rx_busy(xh))
+		return -EBUSY;
+
+	uint32_t total = 0;
+	while (total < len)
+		total += XUartPs_Recv(inst(xh), buf + total, len - total);
+	return 0;
+}
+
+/**
+ * @brief Register the CAPI asynchronous callback.
+ * @note PS: Stores callback for XUartPs events.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ps_register_callback(struct capi_uart_handle *handle,
+		capi_uart_callback const callback,
+		void *const callback_arg)
+{
+	if (handle == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	if (xh->use_irq)
+		capi_irq_disable(xh->irq_id);
+	xh->callback = callback;
+	xh->callback_arg = callback_arg;
+	if (xh->use_irq)
+		capi_irq_enable(xh->irq_id);
+	return 0;
+}
+
+/**
+ * @brief Start an asynchronous transmit operation.
+ * @note PS: XUartPs_Send()/XUartPs_SetInterruptMask().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ps_transmit_async(struct capi_uart_handle *handle,
+				       uint8_t *buf, uint32_t len)
+{
+	if (handle == NULL || buf == NULL)
+		return -EINVAL;
+	if (len == 0)
+		return 0;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	if (!xh->use_irq)
+		return -ENOTSUP;
+	if (inst(xh)->SendBuffer.RemainingBytes > 0)
+		return -EBUSY;
+
+	/* Clear stale TX status before starting this transfer. */
+	XUartPs_WriteReg(inst(xh)->Config.BaseAddress, XUARTPS_ISR_OFFSET,
+			 XUARTPS_IXR_TXEMPTY | XUARTPS_IXR_TXFULL);
+
+	/* Send first; XUartPs_Send disables TX interrupts internally. Arm
+	 * TXEMPTY only if more bytes remain in the software buffer. */
+	XUartPs_Send(inst(xh), buf, len);
+	if (inst(xh)->SendBuffer.RemainingBytes == 0) {
+		ps_tx_done(xh, inst(xh)->SendBuffer.RequestedBytes);
+		return 0;
+	}
+
+	u32 mask = XUartPs_GetInterruptMask(inst(xh));
+	XUartPs_SetInterruptMask(inst(xh), mask | XUARTPS_IXR_TXEMPTY);
+
+	return 0;
+}
+
+/**
+ * @brief Start an asynchronous receive operation.
+ * @note PS: XUartPs_SetInterruptMask()/XUartPs_Recv().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ps_receive_async(struct capi_uart_handle *handle,
+				      uint8_t *buf, uint32_t len)
+{
+	if (handle == NULL || buf == NULL)
+		return -EINVAL;
+	if (len == 0)
+		return 0;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	if (!xh->use_irq)
+		return -ENOTSUP;
+	if (inst(xh)->ReceiveBuffer.RemainingBytes > 0)
+		return -EBUSY;
+
+	/* OR in RX bits; preserve any active TX mask bits from transmit_async. */
+	u32 mask = XUartPs_GetInterruptMask(inst(xh));
+	XUartPs_SetInterruptMask(inst(xh),
+				 mask | XUARTPS_IXR_RXOVR | XUARTPS_IXR_RXFULL |
+				 XUARTPS_IXR_TOUT | XUARTPS_IXR_PARITY |
+				 XUARTPS_IXR_FRAMING | XUARTPS_IXR_OVER);
+	XUartPs_Recv(inst(xh), buf, len);
+
+	/*
+	 * XUartPs_Recv() drains whatever is already sitting in the RX FIFO
+	 * synchronously before returning (XUartPs_ReceiveBuffer() runs inline,
+	 * not from the ISR). If the caller pre-buffered the full transfer with
+	 * a blocking transmit before arming this receive, len bytes are
+	 * already in the FIFO and RemainingBytes hits 0 right here -- no RX
+	 * interrupt is coming to complete it, since there is no new edge on an
+	 * already-idle line. Mirrors the equivalent lite/NS550 UART fixes.
+	 */
+	if (inst(xh)->ReceiveBuffer.RemainingBytes == 0)
+		ps_rx_done(xh, inst(xh)->ReceiveBuffer.RequestedBytes);
+
+	return 0;
+}
+
+/**
+ * @brief Get the last UART interrupt reason.
+ * @note PS: Returns cached ISR reason.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ps_get_interrupt_reason(struct capi_uart_handle *handle,
+		enum capi_uart_interrupt_reason *reason)
+{
+	if (handle == NULL || reason == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	*reason = xh->last_interrupt_reason;
+	return 0;
+}
+
+/**
+ * @brief Get UART line status flags.
+ * @note PS: XUartPs_ReadReg(ISR/RXBS).
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ps_get_line_status(struct capi_uart_handle *handle,
+					uint32_t *status_flags)
+{
+	if (handle == NULL || status_flags == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	UINTPTR base = inst(xh)->Config.BaseAddress;
+	*status_flags = 0;
+
+	u32 isr = XUartPs_ReadReg(base, XUARTPS_ISR_OFFSET);
+	u32 rxbs = XUartPs_ReadReg(base, XUARTPS_RXBS_OFFSET);
+
+	if ((isr & XUARTPS_IXR_RBRK) ||
+	    (rxbs & (XUARTPS_RXBS_BYTE0_BRKE | XUARTPS_RXBS_BYTE1_BRKE |
+		     XUARTPS_RXBS_BYTE2_BRKE |
+		     XUARTPS_RXBS_BYTE3_BRKE)))
+		*status_flags |= CAPI_UART_LINE_STAT_BREAK_IND;
+
+	if ((isr & XUARTPS_IXR_FRAMING) ||
+	    (rxbs & (XUARTPS_RXBS_BYTE0_FRME | XUARTPS_RXBS_BYTE1_FRME |
+		     XUARTPS_RXBS_BYTE2_FRME |
+		     XUARTPS_RXBS_BYTE3_FRME)))
+		*status_flags |= CAPI_UART_LINE_STAT_FRAMING_ERROR;
+
+	if ((isr & XUARTPS_IXR_PARITY) ||
+	    (rxbs & (XUARTPS_RXBS_BYTE0_PARE | XUARTPS_RXBS_BYTE1_PARE |
+		     XUARTPS_RXBS_BYTE2_PARE |
+		     XUARTPS_RXBS_BYTE3_PARE)))
+		*status_flags |= CAPI_UART_LINE_STAT_PARITY_ERROR;
+
+	if (isr & XUARTPS_IXR_OVER)
+		*status_flags |= CAPI_UART_LINE_STAT_OVERRUN_ERROR;
+
+	return 0;
+}
+
+/**
+ * @brief Dispatch the backend interrupt handler.
+ * @note PS: XUartPs_InterruptHandler().
+ *
+ */
+static void capi_uart_ps_isr(void *handle)
+{
+	if (handle == NULL)
+		return;
+
+	struct capi_uart_xilinx_handle *xh = ((struct capi_uart_handle *)handle)->priv;
+	XUartPs_InterruptHandler(inst(xh));
+}
+
+static void ps_tx_done(struct capi_uart_xilinx_handle *xh, u32 event_data)
+{
+	if (xh == NULL || xh->instance == NULL)
+		return;
+
+	if (inst(xh)->SendBuffer.RequestedBytes == 0 && event_data == 0)
+		return;
+	if (event_data == 0)
+		event_data = inst(xh)->SendBuffer.RequestedBytes;
+
+	xh->last_interrupt_reason = CAPI_UART_INTR_TX_BUFFER_EMPTY;
+	XUartPs_SetInterruptMask(inst(xh), XUartPs_GetInterruptMask(inst(xh)) &
+				 ~(XUARTPS_IXR_TXEMPTY | XUARTPS_IXR_TXFULL));
+	inst(xh)->SendBuffer.RequestedBytes = 0;
+	if (xh->callback)
+		xh->callback(CAPI_UART_EVENT_TX_DONE, xh->callback_arg, event_data);
+}
+
+static void ps_rx_done(struct capi_uart_xilinx_handle *xh, u32 event_data)
+{
+	xh->last_interrupt_reason = CAPI_UART_INTR_RX_BUFFER_FULL;
+	XUartPs_SetInterruptMask(inst(xh),
+				 XUartPs_GetInterruptMask(inst(xh)) &
+				 ~(XUARTPS_IXR_RXOVR | XUARTPS_IXR_RXFULL |
+				   XUARTPS_IXR_TOUT));
+	if (xh->callback)
+		xh->callback(CAPI_UART_EVENT_RX_DONE, xh->callback_arg, event_data);
+}
+
+static void ps_event_handler(void *callback_ref, u32 event, u32 event_data)
+{
+	struct capi_uart_xilinx_handle *xh = (struct capi_uart_xilinx_handle *)
+					     callback_ref;
+
+	if (xh == NULL || xh->instance == NULL)
+		return;
+
+	u32 rx_remaining = inst(xh)->ReceiveBuffer.RemainingBytes;
+
+	switch (event) {
+	case XUARTPS_EVENT_SENT_DATA: /* 3 */
+		ps_tx_done(xh, event_data);
+		break;
+
+	case XUARTPS_EVENT_RECV_DATA: /* 1 */
+		xh->last_interrupt_reason = CAPI_UART_INTR_RX_BUFFER_FULL;
+		if (rx_remaining == 0)
+			ps_rx_done(xh, event_data);
+		break;
+
+	case XUARTPS_EVENT_RECV_TOUT: /* 2 */
+		xh->last_interrupt_reason = CAPI_UART_INTR_RX_BUFFER_FULL;
+		/*
+		 * A receive timeout is only terminal when the request is actually
+		 * satisfied. With bytes still outstanding it means the wire went
+		 * briefly idle mid-transfer -- report RX_TIMEOUT as progress and
+		 * leave the receive armed so the rest still completes. Masking here
+		 * instead would disable the very interrupt the remaining bytes need,
+		 * so RX_DONE could never follow and the transfer would stall
+		 * forever. Only ps_rx_done() masks, and only on completion; the
+		 * NS550 and lite backends keep the same invariant.
+		 */
+		if (rx_remaining == 0) {
+			ps_rx_done(xh, event_data);
+		} else if (xh->callback) {
+			xh->callback(CAPI_UART_EVENT_RX_TIMEOUT, xh->callback_arg,
+				     event_data);
+		}
+		break;
+
+	case XUARTPS_EVENT_RECV_ERROR:      /* 4 */
+	case XUARTPS_EVENT_PARE_FRAME_BRKE: /* 6 */
+	case XUARTPS_EVENT_RECV_ORERR:      /* 7 */
+		xh->last_interrupt_reason = CAPI_UART_INTR_RX_LINE_STATUS;
+		if (xh->callback)
+			xh->callback(CAPI_UART_EVENT_INTERRUPT, xh->callback_arg, event_data);
+		break;
+
+	default:
+		xh->last_interrupt_reason = CAPI_UART_INTR_MODEM_STATUS;
+		if (xh->callback)
+			xh->callback(CAPI_UART_EVENT_INTERRUPT, xh->callback_arg, event_data);
+		break;
+	}
+}
+
+/**
+ * @brief Enable or disable TX interrupt.
+ * @note PS: XUartPs_SetInterruptMask() with TXEMPTY/TXFULL.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ps_set_irq_tx(struct capi_uart_handle *handle, bool enable)
+{
+	if (handle == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	u32 mask = XUartPs_GetInterruptMask(inst(xh));
+	if (enable)
+		mask |= XUARTPS_IXR_TXEMPTY | XUARTPS_IXR_TXFULL;
+	else
+		mask &= ~(XUARTPS_IXR_TXEMPTY | XUARTPS_IXR_TXFULL);
+	XUartPs_SetInterruptMask(inst(xh), mask);
+	return 0;
+}
+
+/**
+ * @brief Check if TX buffer is ready for more data.
+ * @note PS: XUartPs_IsTransmitEmpty().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ps_irq_tx_ready(struct capi_uart_handle *handle,
+				     bool *ready)
+{
+	if (handle == NULL || ready == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	*ready = XUartPs_IsTransmitEmpty(inst(xh)) ? true : false;
+	return 0;
+}
+
+/**
+ * @brief Check if transmission is complete.
+ * @note PS: XUartPs_IsTransmitEmpty().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ps_irq_tx_complete(struct capi_uart_handle *handle,
+					bool *complete)
+{
+	if (handle == NULL || complete == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	*complete = XUartPs_IsTransmitEmpty(inst(xh)) ? true : false;
+	return 0;
+}
+
+/**
+ * @brief Enable or disable RX interrupt.
+ * @note PS: XUartPs_SetInterruptMask() with RXFULL/RXOVR/TOUT.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ps_set_irq_rx(struct capi_uart_handle *handle, bool enable)
+{
+	if (handle == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	u32 mask = XUartPs_GetInterruptMask(inst(xh));
+	if (enable)
+		mask |= XUARTPS_IXR_RXFULL | XUARTPS_IXR_RXOVR | XUARTPS_IXR_TOUT;
+	else
+		mask &= ~(XUARTPS_IXR_RXFULL | XUARTPS_IXR_RXOVR | XUARTPS_IXR_TOUT);
+	XUartPs_SetInterruptMask(inst(xh), mask);
+	return 0;
+}
+
+/**
+ * @brief Check if RX data is ready.
+ * @note PS: XUartPs_IsReceiveData().
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ps_irq_rx_ready(struct capi_uart_handle *handle,
+				     bool *ready)
+{
+	if (handle == NULL || ready == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	UINTPTR base = inst(xh)->Config.BaseAddress;
+	*ready = XUartPs_IsReceiveData(base) ? true : false;
+	return 0;
+}
+
+/**
+ * @brief Enable or disable error/status interrupt.
+ * @note PS: XUartPs_SetInterruptMask() with error flags.
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ps_set_irq_err(struct capi_uart_handle *handle,
+				    bool enable)
+{
+	if (handle == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	u32 mask = XUartPs_GetInterruptMask(inst(xh));
+	if (enable)
+		mask |= XUARTPS_IXR_PARITY | XUARTPS_IXR_FRAMING | XUARTPS_IXR_OVER |
+			XUARTPS_IXR_RBRK;
+	else
+		mask &= ~(XUARTPS_IXR_PARITY | XUARTPS_IXR_FRAMING | XUARTPS_IXR_OVER |
+			  XUARTPS_IXR_RBRK);
+	XUartPs_SetInterruptMask(inst(xh), mask);
+	return 0;
+}
+
+/**
+ * @brief Check if any UART interrupt is pending.
+ * @note PS: XUartPs_ReadReg(ISR).
+ *
+ * @return 0 on success, negative errno on failure.
+ */
+static int capi_uart_ps_is_irq_pending(struct capi_uart_handle *handle,
+				       bool *pending)
+{
+	if (handle == NULL || pending == NULL)
+		return -EINVAL;
+
+	struct capi_uart_xilinx_handle *xh = handle->priv;
+	UINTPTR base = inst(xh)->Config.BaseAddress;
+	u32 isr = XUartPs_ReadReg(base, XUARTPS_ISR_OFFSET);
+	*pending = (isr != 0) ? true : false;
+	return 0;
+}
+
+#endif /* XPAR_XUARTPS_NUM_INSTANCES */

--- a/capi/src/capi_gpio.c
+++ b/capi/src/capi_gpio.c
@@ -90,6 +90,15 @@ int capi_gpio_port_get_raw_value(struct capi_gpio_port_handle *handle,
 	return handle->ops->port_get_raw_value(handle, value_bitmask);
 }
 
+int capi_gpio_port_toggle(struct capi_gpio_port_handle *handle,
+			  uint64_t pins_bitmask)
+{
+	if (!handle || !handle->ops || !handle->ops->port_toggle) {
+		return -EINVAL;
+	}
+	return handle->ops->port_toggle(handle, pins_bitmask);
+}
+
 int capi_gpio_pin_set_direction(struct capi_gpio_pin *pin, uint8_t direction)
 {
 	if (!pin || !pin->port_handle || !pin->port_handle->ops ||
@@ -142,4 +151,13 @@ int capi_gpio_pin_get_raw_value(struct capi_gpio_pin *pin, uint8_t *value)
 		return -EINVAL;
 	}
 	return pin->port_handle->ops->pin_get_raw_value(pin, value);
+}
+
+int capi_gpio_pin_toggle(struct capi_gpio_pin *pin)
+{
+	if (!pin || !pin->port_handle || !pin->port_handle->ops ||
+	    !pin->port_handle->ops->pin_toggle) {
+		return -EINVAL;
+	}
+	return pin->port_handle->ops->pin_toggle(pin);
 }

--- a/capi/src/capi_uart.c
+++ b/capi/src/capi_uart.c
@@ -160,6 +160,24 @@ int capi_uart_get_line_status(struct capi_uart_handle *handle,
 	return handle->ops->get_line_status(handle, status_flags);
 }
 
+int capi_uart_set_flow_control_state(struct capi_uart_handle *handle,
+				     bool rts_state, bool cts_state)
+{
+	if (!handle || !handle->ops || !handle->ops->set_flow_control_state) {
+		return -EINVAL;
+	}
+	return handle->ops->set_flow_control_state(handle, rts_state, cts_state);
+}
+
+int capi_uart_get_flow_control_state(struct capi_uart_handle *handle,
+				     bool *rts_state, bool *cts_state)
+{
+	if (!handle || !handle->ops || !handle->ops->get_flow_control_state) {
+		return -EINVAL;
+	}
+	return handle->ops->get_flow_control_state(handle, rts_state, cts_state);
+}
+
 void capi_uart_isr(void *handle)
 {
 	struct capi_uart_handle *ch = (struct capi_uart_handle *)handle;


### PR DESCRIPTION
## Pull Request Description

Adds the Xilinx platform implementation of the Common API (CAPI) under `drivers/platform/xilinx/`, providing board-agnostic backends for the core peripheral classes on PS-controlled ARM targets and MicroBlaze designs.

The drivers are SDT-only and use base-address `LookupConfig`. Interrupts route through the IRQ controller singleton via `capi_irq_connect()`, with a soft fallback to polled operation when no IRQ is wired in the XSA.

Each backend has its own `.c` file and exports its own operations table. The configuration structures do not use a type enum.

## Drivers Added

- **GPIO**
  - `XGpioPs` (PS): global pin IDs, with an EMIO offset of 54 on Zynq-7000 and 78 on ZynqMP. Bank boundaries are validated during initialization.
  - `XGpio` (PL): per-channel, 32-bit operation.
  - Both drivers account for the inverted direction polarity relative to the CAPI convention.

- **UART**
  - `XUartPs` (PS)
  - `XUartNs550` (AXI 16550)
  - `XUartLite` (AXI, fixed 8N1)

- **SPI**
  - `XSpiPs` (PS): master mode, with native CS0/1/2 represented as one-hot masks.
  - `XSpi` (AXI Quad SPI): master mode.

- **I2C**
  - `XIicPs` (PS): 7-bit and 10-bit addressing with repeated-start support.
  - `XIic` (AXI IIC).

- **Timer**
  - `XTtcPs`: up-counting.
  - `XScuTimer`: 32-bit down-counting, A9-private.
  - `XTmrCtr`: AXI timer with two channels.

- **IRQ**
  - `XScuGic` (GIC).
  - `XIntc` (AXI INTC), either as a root controller or cascaded to a GIC SPI line.
  - IRQ IDs are bit-packed: controller in the upper half, input in the lower half.

- **Time / Platform**
  - Strong `capi_time` hooks:
    - Uptime via the A9 global timer.
    - Delays via `usleep()` / `usleep_MB()`.
  - `CAPI_PLATFORM_IO_*` macros implemented using `Xil_In*` / `Xil_Out*`.

## What Was Tested

Validated on:

- ZedBoard (Zynq-7000), across GIC, INTC, and no-IRQ XSA variants.
- ZCU102 (ZynqMP).
- Cora Z7 (MicroBlaze).

Testing used a structured hardware test environment and covered:

- Initialization verified through a real follow-up operation.
- Deinitialization verified by reading hardware registers back, including confirmation that interrupts were disabled.
- Functional and loopback paths:
  - SPI internal loopback (`rx == tx`).
  - UART loopback.
  - Real timer counter movement in both up-counting and down-counting modes.
  - IRQ delivery through GIC, INTC cascade, INTC root, and no-IRQ `-ENOTSUP`.
- Asynchronous and interrupt-driven paths:
  - PS and PL SPI.
  - UART asynchronous TX completion.
  - No-IRQ polled fallback.
- Applied-configuration round trips:
  - Bus speed.
  - Line configuration.
  - Initialization clock frequency.
  - Channel configuration matching.
  - Runtime UART settings: baud rate, data bits, parity, and stop bits.
- Contract and error paths:
  - Per-backend contracts.
  - Null configuration and null handle.
  - Null and zero-length TX/RX buffers.
  - Reinitialization stress.
- Real-device smoke tests where hardware was wired, including the ADXL355 over I2C.

## Known Limitations

The following features are not hardware-dependent and are explicitly asserted to return `-ENOTSUP`:

- **DMA**
  - DMA is not supported yet.
  - A non-null `dma_handle` is rejected during initialization.

- **I2C**
  - Duty-cycle configuration.
  - Clock stretching.
  - 10-bit addressing on PL.

- **SPI PS**
  - LSB-first operation.
  - Per-transfer counter fields.

- **UART**
  - RTS and RTS/CTS flow control.
  - 9-bit and multidrop addressing.
  - Sticky, mark, and space parity.
  - `UartLite` is fixed at 8N1, with baud rate, word length, parity, and stop bits configured at synthesis time. Non-default line configurations are rejected.

- **Timer**
  - Non-rollover configuration.
  - Non-zero minimum values.

- **IRQ**
  - Priority and trigger configuration apply only to GIC inputs; INTC inputs reject these settings.

## PR Type

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## PR Checklist

- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have built all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards:
  - ZedBoard (Zynq-7000: GIC, INTC, and no-IRQ)
  - ZCU102 (ZynqMP)
  - Cora Z7 (MicroBlaze)
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applicable (N/A, driver-only change)