### PR TITLE
jesd204: add optional GT reset GPIO support (Versal)

### DIFF
--- a/drivers/axi_core/jesd204/axi_jesd204_rx.c
+++ b/drivers/axi_core/jesd204/axi_jesd204_rx.c
@@ -143,6 +143,38 @@ struct axi_jesd204_rx_jesd204_priv {
 };
 
 /**
+ * @brief Perform an optional external GT reset using GPIO signals.
+ * @param reset - GPIO descriptor for the reset pin (active high).
+ * @param done - GPIO descriptor for the reset-done pin.
+ * @return 0 on success, negative error code otherwise.
+ *
+ * Ported from Linux: analogdevicesinc/linux commit 719c71b.
+ */
+static int axi_jesd_ext_reset(struct no_os_gpio_desc *reset,
+			      struct no_os_gpio_desc *done)
+{
+	uint8_t val;
+	int count;
+
+	if (!reset || !done)
+		return 0;
+
+	no_os_gpio_set_value(reset, NO_OS_GPIO_HIGH);
+	no_os_udelay(20);
+	no_os_gpio_set_value(reset, NO_OS_GPIO_LOW);
+
+	for (count = 0; count < 32; count++) {
+		no_os_mdelay(1);
+		no_os_gpio_get_value(done, &val);
+		if (val)
+			return 0;
+	}
+
+	pr_err("GT reset-done timeout\n");
+	return -ETIMEDOUT;
+}
+
+/**
  * @brief JESD204 RX AXI Data Write.
  * @param jesd - The device structure.
  * @param reg_addr - The register address.
@@ -700,6 +732,8 @@ static int axi_jesd204_rx_jesd204_clks_enable(struct jesd204_dev *jdev,
 		enum jesd204_state_op_reason reason,
 		struct jesd204_link *lnk)
 {
+	struct axi_jesd204_rx_jesd204_priv *priv = jesd204_dev_priv(jdev);
+	struct axi_jesd204_rx *jesd = priv->jesd;
 
 	pr_debug("%s:%d link_num %u reason %s\n", __func__, __LINE__,
 		 lnk->link_id, jesd204_state_op_reason_str(reason));
@@ -712,6 +746,10 @@ static int axi_jesd204_rx_jesd204_clks_enable(struct jesd204_dev *jdev,
 	default:
 		return JESD204_STATE_CHANGE_DONE;
 	}
+
+	if (jesd->gt_reset_pll)
+		axi_jesd_ext_reset(jesd->gt_reset_pll, jesd->gt_reset_done);
+
 	return JESD204_STATE_CHANGE_DONE;
 }
 
@@ -744,6 +782,9 @@ static int axi_jesd204_rx_jesd204_link_enable(struct jesd204_dev *jdev,
 	default:
 		return JESD204_STATE_CHANGE_DONE;
 	}
+
+	if (jesd->gt_reset_dp)
+		axi_jesd_ext_reset(jesd->gt_reset_dp, jesd->gt_reset_done);
 
 	ret = no_os_clk_enable(jesd->lane_clk);
 	if (ret) {
@@ -955,6 +996,21 @@ int32_t axi_jesd204_rx_init(struct axi_jesd204_rx **jesd204,
 	jesd->config.subclass_version = init->subclass;
 
 	jesd->lane_clk = init->lane_clk;
+
+	/* Optional GT reset GPIOs (Versal) */
+	if (init->gt_reset_pll)
+		no_os_gpio_get_optional(&jesd->gt_reset_pll, init->gt_reset_pll);
+	if (init->gt_reset_dp)
+		no_os_gpio_get_optional(&jesd->gt_reset_dp, init->gt_reset_dp);
+	if (init->gt_reset_done)
+		no_os_gpio_get_optional(&jesd->gt_reset_done, init->gt_reset_done);
+
+	if (jesd->gt_reset_pll)
+		no_os_gpio_direction_output(jesd->gt_reset_pll, NO_OS_GPIO_LOW);
+	if (jesd->gt_reset_dp)
+		no_os_gpio_direction_output(jesd->gt_reset_dp, NO_OS_GPIO_LOW);
+	if (jesd->gt_reset_done)
+		no_os_gpio_direction_input(jesd->gt_reset_done);
 
 	ret = jesd204_dev_register(&jesd->jdev, &jesd204_axi_jesd204_rx_init);
 	if (ret)

--- a/drivers/axi_core/jesd204/axi_jesd204_rx.h
+++ b/drivers/axi_core/jesd204/axi_jesd204_rx.h
@@ -37,6 +37,7 @@
 #include <stdbool.h>
 #include "jesd204.h"
 #include "no_os_clk.h"
+#include "no_os_gpio.h"
 
 struct jesd204_rx_config {
 	uint8_t octets_per_frame;
@@ -73,6 +74,10 @@ struct axi_jesd204_rx {
 	struct no_os_clk_desc *lane_clk;
 	/** JESD204 FSM device */
 	struct jesd204_dev *jdev;
+	/** Optional GT reset GPIOs (Versal) */
+	struct no_os_gpio_desc *gt_reset_pll;
+	struct no_os_gpio_desc *gt_reset_dp;
+	struct no_os_gpio_desc *gt_reset_done;
 };
 
 /**
@@ -96,6 +101,10 @@ struct jesd204_rx_init {
 	uint32_t lane_clk_khz;
 	/** Lane Clock */
 	struct no_os_clk_desc *lane_clk;
+	/** Optional GT reset GPIO init params (Versal) */
+	struct no_os_gpio_init_param *gt_reset_pll;
+	struct no_os_gpio_init_param *gt_reset_dp;
+	struct no_os_gpio_init_param *gt_reset_done;
 };
 
 /** JESD204 RX Lane Clock Enable */

--- a/drivers/axi_core/jesd204/axi_jesd204_tx.c
+++ b/drivers/axi_core/jesd204/axi_jesd204_tx.c
@@ -100,6 +100,38 @@ struct axi_jesd204_tx_jesd204_priv {
 };
 
 /**
+ * @brief Perform an optional external GT reset using GPIO signals.
+ * @param reset - GPIO descriptor for the reset pin (active high).
+ * @param done - GPIO descriptor for the reset-done pin.
+ * @return 0 on success, negative error code otherwise.
+ *
+ * Ported from Linux: analogdevicesinc/linux commit 719c71b.
+ */
+static int axi_jesd_ext_reset(struct no_os_gpio_desc *reset,
+			      struct no_os_gpio_desc *done)
+{
+	uint8_t val;
+	int count;
+
+	if (!reset || !done)
+		return 0;
+
+	no_os_gpio_set_value(reset, NO_OS_GPIO_HIGH);
+	no_os_udelay(20);
+	no_os_gpio_set_value(reset, NO_OS_GPIO_LOW);
+
+	for (count = 0; count < 32; count++) {
+		no_os_mdelay(1);
+		no_os_gpio_get_value(done, &val);
+		if (val)
+			return 0;
+	}
+
+	pr_err("GT reset-done timeout\n");
+	return -ETIMEDOUT;
+}
+
+/**
  * @brief JESD204 TX AXI Data Write.
  * @param jesd - The device structure.
  * @param reg_addr - The register address.
@@ -595,6 +627,9 @@ static int axi_jesd204_tx_jesd204_link_setup(struct jesd204_dev *jdev,
 	pr_debug("%s:%d link_num %u reason %s\n", __func__, __LINE__,
 		 lnk->link_id, jesd204_state_op_reason_str(reason));
 
+	if (jesd->gt_reset_pll)
+		axi_jesd_ext_reset(jesd->gt_reset_pll, jesd->gt_reset_done);
+
 	if (jesd->num_lanes != lnk->num_lanes)
 		pr_debug("Possible instantiation for multiple chips; HDL lanes %u, Link[%u] lanes %u\n",
 			 jesd->num_lanes, lnk->link_id, lnk->num_lanes);
@@ -628,6 +663,9 @@ static int axi_jesd204_tx_jesd204_clks_enable(struct jesd204_dev *jdev,
 
 	if (reason != JESD204_STATE_OP_REASON_INIT)
 		return JESD204_STATE_CHANGE_DONE;
+
+	if (jesd->gt_reset_dp)
+		axi_jesd_ext_reset(jesd->gt_reset_dp, jesd->gt_reset_done);
 
 	axi_jesd204_tx_write(jesd, JESD204_TX_REG_LINK_DISABLE, 0x1);
 	no_os_udelay(1);
@@ -876,6 +914,21 @@ int32_t axi_jesd204_tx_init(struct axi_jesd204_tx **jesd204,
 	jesd->config.subclass_version = init->subclass;
 
 	jesd->lane_clk = init->lane_clk;
+
+	/* Optional GT reset GPIOs (Versal) */
+	if (init->gt_reset_pll)
+		no_os_gpio_get_optional(&jesd->gt_reset_pll, init->gt_reset_pll);
+	if (init->gt_reset_dp)
+		no_os_gpio_get_optional(&jesd->gt_reset_dp, init->gt_reset_dp);
+	if (init->gt_reset_done)
+		no_os_gpio_get_optional(&jesd->gt_reset_done, init->gt_reset_done);
+
+	if (jesd->gt_reset_pll)
+		no_os_gpio_direction_output(jesd->gt_reset_pll, NO_OS_GPIO_LOW);
+	if (jesd->gt_reset_dp)
+		no_os_gpio_direction_output(jesd->gt_reset_dp, NO_OS_GPIO_LOW);
+	if (jesd->gt_reset_done)
+		no_os_gpio_direction_input(jesd->gt_reset_done);
 
 	ret = jesd204_dev_register(&jesd->jdev, &jesd204_axi_jesd204_tx_init);
 	if (ret)

--- a/drivers/axi_core/jesd204/axi_jesd204_tx.h
+++ b/drivers/axi_core/jesd204/axi_jesd204_tx.h
@@ -37,6 +37,7 @@
 #include <stdbool.h>
 #include "jesd204.h"
 #include "no_os_clk.h"
+#include "no_os_gpio.h"
 
 struct jesd204_tx_config {
 	uint8_t device_id;
@@ -84,6 +85,10 @@ struct axi_jesd204_tx {
 	struct no_os_clk_desc *lane_clk;
 	/** JESD204 FSM device */
 	struct jesd204_dev *jdev;
+	/** Optional GT reset GPIOs (Versal) */
+	struct no_os_gpio_desc *gt_reset_pll;
+	struct no_os_gpio_desc *gt_reset_dp;
+	struct no_os_gpio_desc *gt_reset_done;
 };
 
 /**
@@ -117,6 +122,10 @@ struct jesd204_tx_init {
 	uint32_t lane_clk_khz;
 	/** Lane Clock */
 	struct no_os_clk_desc *lane_clk;
+	/** Optional GT reset GPIO init params (Versal) */
+	struct no_os_gpio_init_param *gt_reset_pll;
+	struct no_os_gpio_init_param *gt_reset_dp;
+	struct no_os_gpio_init_param *gt_reset_done;
 };
 
 /** JESD204 TX Lane Clock Enable */

--- a/projects/ad9656_fmc/src.mk
+++ b/projects/ad9656_fmc/src.mk
@@ -28,6 +28,7 @@ SRCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.c \
         $(DRIVERS)/frequency/ad9553/ad9553.c \
         $(DRIVERS)/frequency/ad9508/ad9508.c \
         $(DRIVERS)/api/no_os_spi.c \
+	$(DRIVERS)/api/no_os_gpio.c \
         $(NO-OS)/util/no_os_clk.c \
         $(NO-OS)/util/no_os_util.c \
         $(NO-OS)/util/no_os_alloc.c \
@@ -63,6 +64,7 @@ INCS += $(DRIVERS)/axi_core/axi_adc_core/axi_adc_core.h \
 INCS +=	$(PLATFORM_DRIVERS)/$(PLATFORM)_spi.h
 INCS +=	$(INCLUDE)/no_os_axi_io.h \
         $(INCLUDE)/no_os_spi.h \
+	$(INCLUDE)/no_os_gpio.h \
         $(INCLUDE)/no_os_error.h \
         $(INCLUDE)/no_os_delay.h \
         $(INCLUDE)/no_os_clk.h \


### PR DESCRIPTION
## Pull Request Description
Port GT transceiver reset handling from the Linux JESD204 driver (analogdevicesinc/linux commit 719c71b) to no-OS.

On Versal platforms, the GT PLL and datapath resets are exposed as GPIO signals rather than being handled by the XCVR driver.  Add optional GPIO fields to the TX/RX init and device structs, and perform the resets at the correct points in the JESD204 FSM:

  TX: PLL reset in link_setup, DP reset in clks_enable
  RX: PLL reset in clks_enable, DP reset in link_enable

When the GPIO descriptors are NULL (non-Versal platforms), the reset is silently skipped.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
