### PR TITLE
tools: xilinx: fix Versal A72 target filter for xsdb Python API

### DIFF
--- a/tools/scripts/platform/xilinx/util.py
+++ b/tools/scripts/platform/xilinx/util.py
@@ -490,8 +490,8 @@ def _init_ps_cortexr5(session, hw_path, hw_file, jtagtarget):
 
 def _init_ps_versal(session, jtagtarget):
     """Initialize PS for Versal (cortexa72) after PDI programming."""
-    session.targets('-s', '--nocase',
-                    filter=_build_filter('*A72*#0', jtagtarget))
+    filt = _build_filter('Cortex-A72*0', jtagtarget)
+    session.targets('-s', filter=filt)
     session.rst('-c', type='processor')
     time.sleep(2)
     session.configparams('force-mem-accesses', 1)


### PR DESCRIPTION
## Pull Request Description

The xsdb Python API filter parser in Vitis 2025+ does not handle the pattern '*A72*#0' correctly - the '#' character combined with '--nocase' flag causes a filter parse error.

Change the filter pattern from '*A72*#0' to 'Cortex-A72*0' which matches the exact target name 'Cortex-A72 #0' shown in the target list. The '--nocase' flag is no longer needed since we use the exact case.

This was not caught earlier because the Versal upload path in util.py was never tested on real hardware - previous Versal work used the Tcl path (util.tcl) which has a different filter syntax.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
