### PR TITLE
drivers: gnss-gps: nmea_ubx: fix gnss_ubx_get_val

### DIFF
--- a/drivers/gnss-gps/nmea_ubx/nmea_ubx.c
+++ b/drivers/gnss-gps/nmea_ubx/nmea_ubx.c
@@ -717,16 +717,17 @@ int gnss_ubx_get_val(struct gnss_dev *dev, uint32_t key_id,
 	if (value_size != 1 && value_size != 2 && value_size != 4 && value_size != 8)
 		return -EINVAL;
 
-	/* Convert layer enum to bitfield */
+	/* VALGET encodes the layer as an enum (RAM=0, BBR=1, FLASH=2), unlike
+	 * VALSET which uses a bitmask (RAM=1, BBR=2, FLASH=4).*/
 	switch (layer) {
 	case GNSS_CONFIG_LAYER_RAM:
-		layer_val = VAL_LAYER_RAM;
+		layer_val = VALGET_LAYER_RAM;
 		break;
 	case GNSS_CONFIG_LAYER_BBR:
-		layer_val = VAL_LAYER_BBR;
+		layer_val = VALGET_LAYER_BBR;
 		break;
 	case GNSS_CONFIG_LAYER_FLASH:
-		layer_val = VAL_LAYER_FLASH;
+		layer_val = VALGET_LAYER_FLASH;
 		break;
 	default:
 		return -EINVAL;
@@ -783,6 +784,13 @@ int gnss_ubx_get_val(struct gnss_dev *dev, uint32_t key_id,
 		ret = -EINVAL;
 		goto free_response;
 	}
+
+	/* VALGET is ACKed too: consume the trailing ACK here so it cannot be
+	 * mistaken for the reply of a later poll. */
+	ret = gnss_ubx_wait_for_ack(dev, UBX_CLASS_CFG, UBX_CFG_VALGET);
+
+	if (ret)
+		goto free_payload;
 
 	ret = 0;
 

--- a/drivers/gnss-gps/nmea_ubx/nmea_ubx.h
+++ b/drivers/gnss-gps/nmea_ubx/nmea_ubx.h
@@ -157,6 +157,11 @@
 #define VAL_LAYER_FLASH					0x04
 #define VAL_LAYER_ALL					(VAL_LAYER_RAM | VAL_LAYER_BBR | VAL_LAYER_FLASH)
 
+/* Value layer definitions for UBX-CFG-VALGET */
+#define VALGET_LAYER_RAM					0x00
+#define VALGET_LAYER_BBR					0x01
+#define VALGET_LAYER_FLASH					0x02
+
 /* Value size definitions */
 #define VAL_SIZE_1					0x01
 #define VAL_SIZE_8					0x02


### PR DESCRIPTION
UBX-CFG-VALGET encodes the configuration layer as an enum (RAM=0, BBR=1, FLASH=2), unlike UBX-CFG-VALSET which uses a bitmask (RAM=1, BBR=2, FLASH=4). gnss_ubx_get_val reused the VALSET bitmask values, so it requested the wrong layer. Add dedicated VALGET_LAYER_* constants and use them in the VALGET path.

The module also sends an ACK after the VALGET response. That ACK in gnss_ubx_get_val needs to be consumed so it will not be mistaken as an actual message by the next command.

Fixes: 257c700 ("drivers: gnss-gps: nmea_ubx: initial commit")

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
