### PR TITLE
eval-pqmon: report IIO waveform channels as little endian

### DIFF
--- a/projects/eval-pqmon/src/common/iio_pqm.c
+++ b/projects/eval-pqmon/src/common/iio_pqm.c
@@ -1533,7 +1533,7 @@ struct scan_type pqm_scan_type = {.sign = 's',
 	.storagebits = 16,
 	.shift = 0,
 	.is_big_endian =
-		true
+		false
 }; // generic waveform channel definition
 
 static struct iio_channel iio_pqm_channels[] = {


### PR DESCRIPTION
## Description

The PQMON IIO firmware declares its waveform channels as big endian, but the data actually pushed to the IIO buffer is little endian. Incoming ADE9430 samples are converted big→little endian (`no_os_memswap64`) right after the SPI read and stay little endian all the way out to libIIO, yet `pqm_scan_type` sets `.is_big_endian = true`. libIIO clients therefore byte-swap already-correct data.

This has forced endianness workarounds downstream:
- Scopy: `AcquisitionManager::convertFromHwToHost` ignores libiio channel endianness
- pyadi-iio: analogdevicesinc/pyadi-iio#760

## Change

Set `.is_big_endian = false` in `pqm_scan_type` so the channel format matches the data on the wire. One-line change.

Fixes #3150

## PR Type
- [x] Bug fix (change that fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)