### PR TITLE
capi: platform: maxim: max32657: Add MAX32657 CAPI drivers

### DIFF
--- a/capi/platform/maxim/max32657/maxim_capi_alloc.c
+++ b/capi/platform/maxim/max32657/maxim_capi_alloc.c
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ *   @file   maxim_capi_alloc.c
+ *   @brief  Override of weak CAPI alloc functions
+ *   @author Ramon Miguel Imbao (ramonmiguel.imbao@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <stdlib.h>
+#include "capi_alloc.h"
+
+void *capi_malloc_impl(size_t size)
+{
+	return malloc(size);
+}
+
+void *capi_calloc_impl(size_t num, size_t size)
+{
+	return calloc(num, size);
+}
+
+void capi_free_impl(void *ptr)
+{
+	free(ptr);
+}

--- a/capi/platform/maxim/max32657/maxim_capi_dma.c
+++ b/capi/platform/maxim/max32657/maxim_capi_dma.c
@@ -1,0 +1,587 @@
+/*******************************************************************************
+ *   @file   maxim_capi_dma.c
+ *   @brief  Implementation of DMA functions with CAPI
+ *   @author Ramon Miguel Imbao (ramonmiguel.imbao@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <stdint.h>
+#include <errno.h>
+#include "dma.h"
+#include "spc.h"
+#include "max32657.h"
+#include "maxim_capi_dma.h"
+#include "maxim_capi_irq.h"
+#include "capi_irq.h"
+
+static struct capi_dma_handle *dma;
+
+/** Forward declaration *******************************************************/
+
+static void max_capi_dma_isr_callback(void *ctx);
+
+/** Helper functions **********************************************************/
+
+/**
+ * @brief Convert CAPI DMA transfer size to msdk DMA data transfer width
+ */
+static int _max_capi_dma_get_width(enum capi_dma_xfer_size size,
+				   mxc_dma_width_t *width)
+{
+	switch (size) {
+	case CAPI_DMA_XFER_SIZE_1_BYTE:
+		*width = MXC_DMA_WIDTH_BYTE;
+		break;
+	case CAPI_DMA_XFER_SIZE_2_BYTES:
+		*width = MXC_DMA_WIDTH_HALFWORD;
+		break;
+	case CAPI_DMA_XFER_SIZE_4_BYTES:
+		*width = MXC_DMA_WIDTH_WORD;
+		break;
+	case CAPI_DMA_XFER_SIZE_8_BYTES:
+	case CAPI_DMA_XFER_SIZE_16_BYTES:
+	case CAPI_DMA_XFER_SIZE_32_BYTES:
+		return -ENOTSUP;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+/** DMA functions implementation **********************************************/
+
+/**
+ * @brief Initialize the DMA
+ * @param handle The DMA handle
+ * @param config The config struct
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_dma_init(struct capi_dma_handle **handle,
+		      const struct capi_dma_config *config)
+{
+	int ret;
+	struct capi_dma_handle *dma_handle;
+	struct max_capi_dma_priv *dma_priv;
+	struct capi_irq_config irq_config;
+	uint8_t num_channels = MXC_DMA_CHANNELS;
+
+	if (!handle || !config)
+		return -EINVAL;
+
+	if (config->num_chans > MXC_DMA_CHANNELS)
+		return -EINVAL;
+
+	if (dma) {
+		*handle = dma;
+		return 0;
+	}
+
+	if (config->num_chans > 0)
+		num_channels = config->num_chans;
+
+	if (*handle == NULL) {
+		dma_handle = capi_calloc(1, sizeof(*dma_handle));
+		if (!dma_handle)
+			return -ENOMEM;
+		dma_handle->init_allocated = true;
+	} else {
+		dma_handle = *handle;
+		dma_handle->init_allocated = false;
+	}
+
+	dma_priv = capi_calloc(1, sizeof(*dma_priv));
+	if (!dma_priv) {
+		ret = -ENOMEM;
+		goto free_handle;
+	}
+	dma_priv->channels = capi_calloc(num_channels,
+					 sizeof(struct capi_dma_chan *));
+	if (!dma_priv->channels) {
+		ret = -ENOMEM;
+		goto free_priv;
+	}
+
+	ret = MXC_DMA_Init(MXC_DMA1_S);
+	if (ret != E_NO_ERROR) {
+		ret = -EIO;
+		goto free_channels;
+	}
+
+	dma_priv->id = config->id;
+	dma_handle->ops = config->ops;
+	dma_handle->priv = dma_priv;
+
+	irq_config = (struct capi_irq_config) {
+		.irq_ctrl_id = 0,
+	};
+	ret = capi_irq_init(&irq_config);
+	if (ret && ret != -EBUSY) {
+		/* -EBUSY means IRQ already initialized, which is fine since
+		   it uses a singleton pattern. */
+		goto deinit_dma;
+	}
+
+	dma = dma_handle;
+	*handle = dma_handle;
+
+	return 0;
+deinit_dma:
+	MXC_DMA_DeInit(MXC_DMA1_S);
+	MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_DMA1);
+free_channels:
+	capi_free(dma_priv->channels);
+free_priv:
+	capi_free(dma_priv);
+free_handle:
+	if (dma_handle->init_allocated)
+		capi_free(dma_handle);
+
+	dma = NULL;
+
+	return ret;
+}
+
+/**
+ * @brief Deinitialize the DMA
+ * @param handle The DMA handle
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_dma_deinit(struct capi_dma_handle *handle)
+{
+	struct max_capi_dma_priv *dma_priv;
+	uint8_t i;
+	IRQn_Type irq;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	dma_priv = handle->priv;
+
+	MXC_DMA_DeInit(MXC_DMA1_S);
+	MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_DMA1);
+
+	MXC_DMA1_S->inten &= ~((1 << MXC_DMA_CHANNELS) - 1);
+
+	for (i = 0; i < MXC_DMA_CHANNELS; i++) {
+		irq = MXC_DMA_CH_GET_IRQ(MXC_DMA1_S, i);
+		capi_irq_disable(irq);
+	}
+
+	capi_free(dma_priv->channels);
+	capi_free(dma_priv);
+	if (handle->init_allocated)
+		capi_free(handle);
+
+	dma = NULL;
+
+	return 0;
+}
+
+/**
+ * @brief Initialize a DMA channel
+ * @param handle The DMA handle
+ * @param chan_prt Pointer to a channel
+ * @param id ID of the DMA channel
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_dma_init_chan(struct capi_dma_handle *handle,
+			   struct capi_dma_chan **chan_ptr, uint32_t id)
+{
+	int hw_id, ret;
+	struct max_capi_dma_priv *dma_priv;
+	struct max_capi_dma_ch_priv *ch_priv;
+	struct capi_dma_chan *chan;
+
+	if (!handle || !handle->priv || !chan_ptr)
+		return -EINVAL;
+
+	dma_priv = handle->priv;
+
+	if (id > dma_priv->num_channels)
+		return -EINVAL;
+
+	if (dma_priv->channels[id] != NULL) {
+		/* Channel already initialized */
+		*chan_ptr = dma_priv->channels[id];
+		return 0;
+	}
+
+	if (*chan_ptr == NULL) {
+		chan = capi_calloc(1, sizeof(*chan));
+		if (!chan)
+			return -ENOMEM;
+		chan->owned_by_app = false;
+	} else {
+		chan = *chan_ptr;
+		chan->owned_by_app = true;
+	}
+
+	hw_id = MXC_DMA_AcquireChannel(MXC_DMA1_S);
+	if (hw_id < 0) {
+		ret = -EBUSY;
+		goto free_channel;
+	}
+	ch_priv = capi_calloc(1, sizeof(*ch_priv));
+	if (!ch_priv) {
+		MXC_DMA_ReleaseChannel(hw_id);
+		ret = -ENOMEM;
+		goto free_channel;
+	}
+	ch_priv->hw_channel_id = hw_id; /* MSDK-assigned */
+	chan->handle = handle;
+	chan->id = id; /* User-assigned */
+	chan->irq_num = MXC_DMA_CH_GET_IRQ(MXC_DMA1_S, hw_id);
+	chan->extra = ch_priv;
+
+	ret = capi_irq_connect(chan->irq_num,
+			       max_capi_dma_isr_callback, chan);
+	if (ret)
+		goto free_channel_priv;
+
+	ret = capi_irq_enable(chan->irq_num);
+	if (ret)
+		goto free_channel_priv;
+
+	dma_priv->channels[id] = chan;
+	*chan_ptr = chan;
+
+	return 0;
+
+free_channel_priv:
+	capi_free(ch_priv);
+	MXC_DMA_ReleaseChannel(hw_id);
+free_channel:
+	if (!chan->owned_by_app)
+		capi_free(chan);
+	return ret;
+}
+
+/**
+ * @brief Deinitialize a DMA channel
+ * @param chan The DMA channel
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_dma_deinit_chan(struct capi_dma_chan *chan)
+{
+	int ret = 0;
+	struct max_capi_dma_priv *dma_priv;
+	struct max_capi_dma_ch_priv *ch_priv;
+
+	if (!chan || !chan->handle || !chan->handle->priv)
+		return -EINVAL;
+
+	dma_priv = chan->handle->priv;
+	ch_priv = chan->extra;
+
+	capi_irq_disable(chan->irq_num);
+
+	ret = MXC_DMA_ReleaseChannel(ch_priv->hw_channel_id);
+
+	dma_priv->channels[chan->id] = NULL;
+
+	capi_free(ch_priv);
+	if (!chan->owned_by_app)
+		capi_free(chan);
+
+	if (ret != E_NO_ERROR)
+		return -EIO;
+
+	return 0;
+}
+
+/**
+ * @brief Configure a DMA channel transfer
+ * @param chan The DMA channel
+ * @param xfer The transfer configuration struct
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_dma_config_xfer(struct capi_dma_chan *chan,
+			     struct capi_dma_transfer *xfer)
+{
+	int ret;
+	struct max_capi_dma_ch_priv *ch_priv;
+	struct max_capi_dma_xfer_extra *xfer_extra;
+	mxc_dma_config_t dma_config;
+	mxc_dma_reqsel_t reqsel = MXC_DMA_REQUEST_MEMTOMEM;
+	mxc_dma_srcdst_t srcdst;
+	mxc_dma_width_t srcwd, dstwd;
+
+	if (!chan || !xfer || !xfer->extra)
+		return -EINVAL;
+
+	xfer_extra = xfer->extra;
+	ch_priv = chan->extra;
+
+	/* Determine request select based on transfer type */
+	if (xfer->xfer_type != CAPI_DMA_MEM_TO_MEM) {
+		reqsel = (mxc_dma_reqsel_t)xfer_extra->reqsel;
+		/* Validate that reqsel direction matches transfer type */
+		if (xfer->xfer_type == CAPI_DMA_MEM_TO_DEV) {
+			/* MEM_TO_DEV should use TX request selects */
+			if (reqsel == MXC_DMA_REQUEST_SPIRX ||
+			    reqsel == MXC_DMA_REQUEST_UARTRX ||
+			    reqsel == MXC_DMA_REQUEST_I3CRX_CONT ||
+			    reqsel == MXC_DMA_REQUEST_I3CRX_TARG ||
+			    reqsel == MXC_DMA_REQUEST_AESRX)
+				return -EINVAL;
+		} else if (xfer->xfer_type == CAPI_DMA_DEV_TO_MEM) {
+			/* DEV_TO_MEM should use RX request selects */
+			if (reqsel == MXC_DMA_REQUEST_SPITX ||
+			    reqsel == MXC_DMA_REQUEST_UARTTX ||
+			    reqsel == MXC_DMA_REQUEST_I3CTX_CONT ||
+			    reqsel == MXC_DMA_REQUEST_I3CTX_TARG ||
+			    reqsel == MXC_DMA_REQUEST_CRCTX ||
+			    reqsel == MXC_DMA_REQUEST_AESTX)
+				return -EINVAL;
+		}
+	}
+
+	ret = _max_capi_dma_get_width(xfer->src_size, &srcwd);
+	if (ret)
+		return ret;
+	ret = _max_capi_dma_get_width(xfer->dst_size, &dstwd);
+	if (ret)
+		return ret;
+
+	dma_config = (mxc_dma_config_t) {
+		.ch = ch_priv->hw_channel_id,
+		.reqsel = reqsel,
+		.srcwd = srcwd,
+		.dstwd = dstwd,
+		.srcinc_en = (xfer->src_inc != CAPI_DMA_NO_INCREMENT),
+		.dstinc_en = (xfer->dst_inc != CAPI_DMA_NO_INCREMENT),
+	};
+
+	srcdst = (mxc_dma_srcdst_t) {
+		.ch = ch_priv->hw_channel_id,
+		.source = (void *)xfer->src,
+		.dest = (void *)xfer->dst,
+		.len = xfer->length,
+	};
+
+	ret = MXC_DMA_ConfigChannel(dma_config, srcdst);
+	if (ret != E_NO_ERROR)
+		return -EIO;
+
+	ch_priv->completed = false;
+
+	/*  MXC_DMA_ConfigChannel explicitly sets the CTRL register for a
+	    channel. We have to call MXC_DMA_ChannelEnableInt again to add the
+	    MXC_F_DMA_CTRL_CTZ_IE flag. */
+	MXC_DMA_EnableInt(MXC_DMA1_S, ch_priv->hw_channel_id);
+	MXC_DMA_ChannelEnableInt(ch_priv->hw_channel_id, MXC_F_DMA_CTRL_CTZ_IE);
+
+	chan->xfer = xfer;
+
+	return 0;
+}
+
+/**
+ * @brief Start a DMA transfer on a channel
+ * @param chan The DMA channel
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_dma_xfer_start(struct capi_dma_chan *chan)
+{
+	int ret;
+	struct max_capi_dma_ch_priv *ch_priv;
+
+	if (!chan || !chan->extra)
+		return -EINVAL;
+
+	ch_priv = chan->extra;
+
+	ch_priv->completed = false;
+
+	ret = MXC_DMA_Start(ch_priv->hw_channel_id);
+	if (ret)
+		return -EIO;
+
+	return 0;
+}
+
+/**
+ * @brief Stop a DMA transfer on a channel
+ * @param chan The DMA channel
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_dma_xfer_abort(struct capi_dma_chan *chan)
+{
+	int ret;
+	struct max_capi_dma_ch_priv *ch_priv;
+
+	if (!chan || !chan->extra)
+		return -EINVAL;
+
+	ch_priv = chan->extra;
+
+	ret = MXC_DMA_Stop(ch_priv->hw_channel_id);
+	if (ret)
+		return -EIO;
+
+	return 0;
+}
+
+/**
+ * @brief Check if a DMA channel has completed its transfer
+ * @param chan The DMA channel
+ * @return true if the transfer is complete, false otherwise
+ */
+bool max_capi_dma_chan_is_completed(const struct capi_dma_chan *chan)
+{
+	struct max_capi_dma_ch_priv *ch_priv;
+
+	if (!chan || !chan->extra)
+		return false;
+
+	ch_priv = chan->extra;
+
+	return ch_priv->completed;
+}
+
+/**
+ * @brief DMA controller interrupt handler
+ * @param handle The DMA handle
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_dma_isr(struct capi_dma_handle *handle)
+{
+	if (!handle)
+		return -EINVAL;
+
+	/* Call MSDK DMA interrupt handler for the controller */
+	MXC_DMA_Handler(MXC_DMA1_S);
+
+	return 0;
+}
+
+/**
+ * @brief DMA channel interrupt handler
+ * @param chan The DMA channel
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_dma_isr_chan(struct capi_dma_chan *chan)
+{
+	struct max_capi_dma_ch_priv *ch_priv;
+	int flags;
+
+	if (!chan || !chan->extra)
+		return -EINVAL;
+
+	ch_priv = chan->extra;
+
+	/* Get the interrupt flags for this channel */
+	flags = MXC_DMA_ChannelGetFlags(ch_priv->hw_channel_id);
+	if (flags < 0)
+		return flags;
+
+	/* Clear the interrupt flags */
+	MXC_DMA_ChannelClearFlags(ch_priv->hw_channel_id, flags);
+
+	/* Check if the transfer completed (CTZ interrupt or bus error) */
+	if (flags & MXC_F_DMA_STATUS_CTZ_IF) {
+		if (chan->xfer_complete_cb)
+			chan->xfer_complete_cb(0, chan->xfer_complete_ctx);
+	} else if (flags & MXC_F_DMA_STATUS_BUS_ERR) {
+		if (chan->error_cb)
+			chan->error_cb(0, chan->error_ctx);
+	}
+
+	ch_priv->completed = true;
+
+	return 0;
+}
+
+/**
+ * @brief Register callback function for DMA channel interrupts
+ * @param chan The DMA channel
+ * @param callback The callback function to be called when an interrupt occurs
+ * @param xfer_complete_ctx Context data to be passed to the function
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_dma_register_complete_callback(struct capi_dma_chan *chan,
+		capi_dma_xfer_complete_cb callback,
+		void *xfer_complete_ctx)
+{
+	if (!chan)
+		return -EINVAL;
+
+	chan->xfer_complete_cb = callback;
+	chan->xfer_complete_ctx = xfer_complete_ctx;
+
+	return 0;
+}
+
+/**
+ * @brief Register callback function for DMA error events
+ * @param chan The DMA channel
+ * @param callback The callback function to be called when an error occurs
+ * @param error_ctx Context data to be passed to the function
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_dma_register_error_callback(struct capi_dma_chan *chan,
+		capi_dma_error_cb callback,
+		void *error_ctx)
+{
+	if (!chan)
+		return -EINVAL;
+
+	chan->error_cb = callback;
+	chan->error_ctx = error_ctx;
+
+	return 0;
+}
+
+const struct capi_dma_ops max_capi_dma_ops = {
+	.init = max_capi_dma_init,
+	.deinit = max_capi_dma_deinit,
+	.init_chan = max_capi_dma_init_chan,
+	.deinit_chan = max_capi_dma_deinit_chan,
+	.config_xfer = max_capi_dma_config_xfer,
+	.xfer_start = max_capi_dma_xfer_start,
+	.xfer_abort = max_capi_dma_xfer_abort,
+	.chan_is_completed = max_capi_dma_chan_is_completed,
+	.isr = max_capi_dma_isr,
+	.isr_chan = max_capi_dma_isr_chan,
+	.register_complete_callback = max_capi_dma_register_complete_callback,
+	.register_error_callback = max_capi_dma_register_error_callback,
+};
+
+/**
+ * @brief IRQ callback wrapper that bridges CAPI IRQ to CAPI DMA
+ * @param ctx - Context pointer (capi_dma_chan)
+ */
+static void max_capi_dma_isr_callback(void *ctx)
+{
+	struct capi_dma_chan *chan = (struct capi_dma_chan *)ctx;
+
+	if (chan)
+		max_capi_dma_isr_chan(chan);
+}

--- a/capi/platform/maxim/max32657/maxim_capi_dma.h
+++ b/capi/platform/maxim/max32657/maxim_capi_dma.h
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ *   @file   maxim_capi_dma.h
+ *   @brief  Header file for DMA functions with CAPI
+ *   @author Ramon Miguel Imbao (ramonmiguel.imbao@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef MAXIM_CAPI_DMA_H_
+#define MAXIM_CAPI_DMA_H_
+
+#include "dma.h"
+#include "capi_dma.h"
+#include "capi_alloc.h"
+
+#if !defined(CONFIG_TRUSTED_EXECUTION_SECURE) || (CONFIG_TRUSTED_EXECUTION_SECURE != 1)
+#error "CONFIG_TRUSTED_EXECUTION_SECURE must be defined and set to 1."
+#endif
+
+enum max_capi_dma_request {
+	MAX_CAPI_DMA_REQUEST_MEMTOMEM = MXC_DMA_REQUEST_MEMTOMEM,
+	MAX_CAPI_DMA_REQUEST_SPI_RX = MXC_DMA_REQUEST_SPIRX,
+	MAX_CAPI_DMA_REQUEST_SPI_TX = MXC_DMA_REQUEST_SPITX,
+	MAX_CAPI_DMA_REQUEST_UART_RX = MXC_DMA_REQUEST_UARTRX,
+	MAX_CAPI_DMA_REQUEST_UART_TX = MXC_DMA_REQUEST_UARTTX,
+	MAX_CAPI_DMA_REQUEST_I3C_RX_CONTROLLER = MXC_DMA_REQUEST_I3CRX_CONT,
+	MAX_CAPI_DMA_REQUEST_I3C_TX_CONTROLLER = MXC_DMA_REQUEST_I3CTX_CONT,
+	MAX_CAPI_DMA_REQUEST_I3C_RX_TARGET = MXC_DMA_REQUEST_I3CRX_TARG,
+	MAX_CAPI_DMA_REQUEST_I3C_TX_TARGET = MXC_DMA_REQUEST_I3CTX_TARG,
+	MAX_CAPI_DMA_REQUEST_AES_RX = MXC_DMA_REQUEST_AESRX,
+	MAX_CAPI_DMA_REQUEST_AES_TX = MXC_DMA_REQUEST_AESTX,
+	MAX_CAPI_DMA_REQUEST_CRC_TX = MXC_DMA_REQUEST_CRCTX,
+};
+
+struct max_capi_dma_priv {
+	/** Identifier */
+	uint64_t id;
+	/** Array of pointers to channels */
+	struct capi_dma_chan **channels;
+	/** Number of channels storage */
+	uint8_t num_channels;
+};
+
+struct max_capi_dma_ch_priv {
+	/* MXC_DMA_AcquireChannel returns a channel ID and is stored here */
+	uint32_t hw_channel_id;
+	/* DMA completion flag */
+	volatile bool completed;
+};
+
+struct max_capi_dma_xfer_extra {
+	/** DMA request type */
+	enum max_capi_dma_request reqsel;
+};
+
+extern const struct capi_dma_ops max_capi_dma_ops;
+
+#endif /* MAXIM_CAPI_DMA_H_ */

--- a/capi/platform/maxim/max32657/maxim_capi_gpio.c
+++ b/capi/platform/maxim/max32657/maxim_capi_gpio.c
@@ -1,0 +1,570 @@
+/***************************************************************************/ /*
+*   @file   maxim_capi_gpio.c
+*   @brief  Implementation of GPIO functions with CAPI.
+*   @author Ramon Miguel Imbao (ramonmiguel.imbao@analog.com)
+********************************************************************************
+* Copyright 2026(c) Analog Devices, Inc.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* 3. Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived from this
+*    software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+* EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <errno.h>
+#include "gpio.h"
+#include "maxim_capi_gpio.h"
+#include "mxc_errors.h"
+#include "max32657.h"
+#include "capi_alloc.h"
+
+/** Static variables **********************************************************/
+
+static struct capi_gpio_port_handle *gpio[MXC_CFG_GPIO_INSTANCES] = {NULL};
+
+/** GPIO functions implemenation **********************************************/
+/**
+ * @brief Initialize a GPIO port
+ * @param handle - the GPIO port handle
+ * @param config - the GPIO port configuration
+ * @return 0 if successful, negative error code otherwise
+ */
+int max_capi_gpio_port_init(struct capi_gpio_port_handle **handle,
+			    const struct capi_gpio_port_config *config)
+{
+	int ret;
+	struct capi_gpio_port_handle *port_handle;
+	struct max_capi_gpio_port_priv *priv;
+
+	if (!handle || !config)
+		return -EINVAL;
+
+	if (config->identifier >= MXC_CFG_GPIO_INSTANCES)
+		return -EINVAL;
+
+	if (config->num_pins == 0 || config->num_pins > MXC_CFG_GPIO_PINS_PORT)
+		return -EINVAL;
+
+	// if (gpio[config->identifier] != NULL) {
+	// 	*handle = gpio[config->identifier];
+	// 	return 0;
+	// }
+
+	if (*handle == NULL) {
+		port_handle = capi_calloc(1, sizeof(*port_handle));
+		if (!port_handle)
+			return -ENOMEM;
+		port_handle->init_allocated = true;
+	} else {
+		port_handle = *handle;
+		port_handle->init_allocated = false;
+	}
+
+	priv = capi_calloc(1, sizeof(*priv));
+	if (!priv) {
+		ret = -ENOMEM;
+		goto free_handle;
+	}
+
+	port_handle->priv = priv;
+	port_handle->ops = config->ops;
+
+	priv->id = config->identifier;
+	priv->port = MXC_GPIO_GET_GPIO(config->identifier);
+	priv->num_pins = config->num_pins;
+	priv->pin_mask = (1U << config->num_pins) - 1;
+	priv->direction_mask = priv->pin_mask; /* All inputs by default */
+
+	/* Copy user config or set defaults */
+	if (config->extra) {
+		priv->extra = *(struct max_capi_gpio_extra_config *)config->extra;
+	} else {
+		priv->extra.vssel = MAX_CAPI_GPIO_VSSEL_VDDIO;
+		priv->extra.func = MAX_CAPI_GPIO_FUNC_IN;
+		priv->extra.pad = MAX_CAPI_GPIO_PAD_NONE;
+		priv->extra.drvstr = MAX_CAPI_GPIO_DRVSTR_0;
+	}
+
+	ret = MXC_GPIO_Init(config->identifier);
+	if (ret != E_NO_ERROR)
+		goto free_priv;
+
+	gpio[config->identifier] = port_handle;
+	*handle = port_handle;
+
+	return 0;
+
+free_priv:
+	capi_free(priv);
+free_handle:
+	if (port_handle->init_allocated)
+		capi_free(port_handle);
+
+	gpio[config->identifier] = NULL;
+
+	return ret;
+}
+
+/**
+ * @brief Deinitialize a GPIO port
+ * @param handle - the GPIO port handle
+ * @return 0 if successful, negative error code otherwise
+ */
+int max_capi_gpio_port_deinit(struct capi_gpio_port_handle **handle)
+{
+	const struct max_capi_gpio_port_priv *gpio_priv;
+	uint8_t id;
+
+	if (!handle || !*handle || !(*handle)->priv)
+		return -EINVAL;
+
+	gpio_priv = (*handle)->priv;
+	id = gpio_priv->id;
+
+	capi_free((*handle)->priv);
+
+	if ((*handle)->init_allocated)
+		capi_free(*handle);
+
+	gpio[id] = NULL;
+	*handle = NULL;
+
+	return 0;
+}
+
+static void set_enable(mxc_gpio_regs_t *regs, uint32_t mask, uint8_t is_enabled)
+{
+	if (is_enabled)
+		regs->en0 |= mask;
+	else
+		regs->en0 &= ~mask;
+}
+
+/**
+ * @brief Set direction for all pins in the port
+ * @param handle - the GPIO handle
+ * @param direction_bitmask - Direction bitmask (1=input, 0=output)
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_gpio_port_set_direction(struct capi_gpio_port_handle *handle,
+				     uint64_t direction_bitmask)
+{
+	struct max_capi_gpio_port_priv *priv;
+	mxc_gpio_cfg_t gpio_config;
+
+	if (!handle)
+		return -EINVAL;
+
+	priv = handle->priv;
+
+	/* Common configuration */
+	gpio_config = (mxc_gpio_cfg_t) {
+		.port = priv->port,
+		.drvstr = (mxc_gpio_drvstr_t)priv->extra.drvstr,
+		.pad = (mxc_gpio_pad_t)priv->extra.pad,
+		.vssel = (mxc_gpio_vssel_t)priv->extra.vssel,
+	};
+
+	/* Set the output pins */
+	gpio_config.func = MXC_GPIO_FUNC_OUT;
+	gpio_config.mask = ~direction_bitmask & priv->pin_mask;
+	MXC_GPIO_Config(&gpio_config);
+	set_enable(priv->port, ~direction_bitmask & priv->pin_mask, true);
+	MXC_GPIO_OutClr(priv->port, ~direction_bitmask & priv->pin_mask);
+
+	/* Set the input pins */
+	gpio_config.func = MXC_GPIO_FUNC_IN;
+	gpio_config.mask = direction_bitmask & priv->pin_mask;
+	MXC_GPIO_Config(&gpio_config);
+
+	priv->direction_mask = (uint32_t)direction_bitmask & priv->pin_mask;
+	return 0;
+}
+
+/**
+ * @brief Get direction for all pins in the port
+ * @param handle - the GPIO handle
+ * @param direction_bitmask - pointer to where the bitmask will be stored
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_gpio_port_get_direction(struct capi_gpio_port_handle *handle,
+				     uint64_t *direction_bitmask)
+{
+	const struct max_capi_gpio_port_priv *priv;
+
+	if (!handle || !handle->priv || !direction_bitmask)
+		return -EINVAL;
+
+	priv = handle->priv;
+
+	*direction_bitmask = priv->direction_mask;
+
+	return 0;
+}
+
+/**
+ * @brief Set raw value for all pins in the port (ignoring ACTIVE_LOW flag)
+ * @param handle - the GPIO handle
+ * @param value_bitmask - the value bitmask
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_gpio_port_set_raw_value(struct capi_gpio_port_handle *handle,
+				     uint64_t value_bitmask)
+{
+	struct max_capi_gpio_port_priv *priv;
+	uint32_t set_pins, reset_pins;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	priv = handle->priv;
+
+	set_pins = (uint32_t)value_bitmask & priv->pin_mask;
+	reset_pins = (uint32_t)~value_bitmask & priv->pin_mask;
+
+	set_enable(priv->port, priv->pin_mask, true);
+	MXC_GPIO_OutSet(priv->port, set_pins);
+	MXC_GPIO_OutClr(priv->port, reset_pins);
+
+	return 0;
+}
+
+/**
+ * @brief Get raw value for all pins in the port (ignoring ACTIVE_LOW flag)
+ * @param handle - the GPIO handle
+ * @param value_bitmask - pointer to where the value bitmask will be stored
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_gpio_port_get_raw_value(struct capi_gpio_port_handle *handle,
+				     uint64_t *value_bitmask)
+{
+	struct max_capi_gpio_port_priv *priv;
+	uint32_t in_pins, out_pins;
+
+	if (!handle || !handle->priv || !value_bitmask)
+		return -EINVAL;
+
+	priv = handle->priv;
+
+	in_pins = MXC_GPIO_InGet(priv->port, priv->pin_mask);
+	out_pins = MXC_GPIO_OutGet(priv->port, priv->pin_mask);
+	*value_bitmask = in_pins | out_pins;
+
+	return 0;
+}
+
+/**
+ * @brief Set value for all pins in the port
+ * @param handle - the GPIO handle
+ * @param value_bitmask - the value bitmask
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_gpio_port_set_value(struct capi_gpio_port_handle *handle,
+				 uint64_t value_bitmask)
+{
+	return max_capi_gpio_port_set_raw_value(handle, value_bitmask);
+}
+
+/**
+ * @brief Get value for all pins in the port
+ * @param handle - the GPIO handle
+ * @param value_bitmask - pointer to where the value bitmask will be stored
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_gpio_port_get_value(struct capi_gpio_port_handle *handle,
+				 uint64_t *value_bitmask)
+{
+	return max_capi_gpio_port_get_raw_value(handle, value_bitmask);
+}
+
+/**
+ * @brief Set direction for a single pin
+ * @param pin - the pin handle
+ * @param direction - the direction to set the pin to
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_gpio_pin_set_direction(struct capi_gpio_pin *pin,
+				    uint8_t direction)
+{
+	struct max_capi_gpio_port_priv *priv;
+	mxc_gpio_cfg_t gpio_config;
+
+	if (!pin || !pin->port_handle || !pin->port_handle->priv)
+		return -EINVAL;
+
+	priv = pin->port_handle->priv;
+
+	if (pin->number >= priv->num_pins)
+		return -EINVAL;
+
+	gpio_config = (mxc_gpio_cfg_t) {
+		.port = priv->port,
+		.mask = (1U << pin->number),
+		.pad = (mxc_gpio_pad_t)priv->extra.pad,
+		.vssel = (mxc_gpio_vssel_t)priv->extra.vssel,
+		.drvstr = (mxc_gpio_drvstr_t)priv->extra.drvstr,
+	};
+
+	switch (direction) {
+	case CAPI_GPIO_OUTPUT:
+		gpio_config.func = MXC_GPIO_FUNC_OUT;
+		MXC_GPIO_Config(&gpio_config);
+		priv->direction_mask &= ~(1 << pin->number);
+		break;
+	case CAPI_GPIO_INPUT:
+		gpio_config.func = MXC_GPIO_FUNC_IN;
+		MXC_GPIO_Config(&gpio_config);
+		priv->direction_mask |= (1 << pin->number);
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Get direction for a single pin
+ * @param pin - the pin handle
+ * @param direction - pointer to where the direction will be stored
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_gpio_pin_get_direction(struct capi_gpio_pin *pin,
+				    uint8_t *direction)
+{
+	const struct max_capi_gpio_port_priv *priv;
+
+	if (!pin || !pin->port_handle || !pin->port_handle->priv || !direction)
+		return -EINVAL;
+
+	priv = pin->port_handle->priv;
+
+	if (pin->number >= priv->num_pins)
+		return -EINVAL;
+
+	if (priv->direction_mask & ((uint32_t)(1 << pin->number)))
+		*direction = CAPI_GPIO_INPUT;
+	else
+		*direction = CAPI_GPIO_OUTPUT;
+
+	return 0;
+}
+
+/**
+ * @brief Set the raw value of a single pin (ignoring the ACITVE_LOW flag)
+ * @param pin - the pin handle
+ * @param value - the value (CAPI_GPIO_LOW or CAPI_GPIO_HIGH)
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_gpio_pin_set_raw_value(struct capi_gpio_pin *pin, uint8_t value)
+{
+	struct max_capi_gpio_port_priv *priv;
+
+	if (!pin || !pin->port_handle || !pin->port_handle->priv)
+		return -EINVAL;
+
+	priv = pin->port_handle->priv;
+
+	if (pin->number >= priv->num_pins)
+		return -EINVAL;
+
+	set_enable(priv->port, (1 << pin->number), true);
+	switch (value) {
+	case CAPI_GPIO_LOW:
+		MXC_GPIO_OutClr(priv->port, (1 << pin->number));
+		break;
+	case CAPI_GPIO_HIGH:
+		MXC_GPIO_OutSet(priv->port, (1 << pin->number));
+		break;
+	/**
+	 * In the maxim_gpio implementation, there is a HIGH_Z option that seems to
+	 * be missing from CAPI. See: capi/capi_gpio.h.
+	 */
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Get the raw value of a single pin (ignoring the ACTIVE_LOW flag)
+ * @param pin - the pin handle
+ * @param value - pointer to where value will be stored
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_gpio_pin_get_raw_value(struct capi_gpio_pin *pin, uint8_t *value)
+{
+	struct max_capi_gpio_port_priv *priv;
+
+	if (!pin || !pin->port_handle || !pin->port_handle->priv || !value)
+		return -EINVAL;
+
+	priv = pin->port_handle->priv;
+
+	if (pin->number >= priv->num_pins)
+		return -EINVAL;
+
+	set_enable(priv->port, (1 << pin->number), true);
+	if (priv->extra.func == MAX_CAPI_GPIO_FUNC_IN)
+		*value = MXC_GPIO_InGet(priv->port,
+					(1U << pin->number)) >> pin->number;
+	else
+		*value = MXC_GPIO_OutGet(priv->port,
+					 (1U << pin->number)) >> pin->number;
+
+	return 0;
+}
+
+/**
+ * @brief Apply logical value considering ACTIVE_LOW flag
+ * @param raw_value - Raw hardware value
+ * @param flags - Pin flags
+ * @return Logical value
+ */
+static inline uint8_t apply_active_low(uint8_t raw_value, uint32_t flags)
+{
+	if (flags & CAPI_GPIO_ACTIVE_LOW)
+		return raw_value ? CAPI_GPIO_LOW : CAPI_GPIO_HIGH;
+	return raw_value;
+}
+
+/**
+ * @brief Convert logical value to raw considering ACTIVE_LOW flag
+ * @param logical_value - Logical value
+ * @param flags - Pin flags
+ * @return Raw hardware value
+ */
+static inline uint8_t to_raw_value(uint8_t logical_value, uint32_t flags)
+{
+	if (flags & CAPI_GPIO_ACTIVE_LOW)
+		return logical_value ? CAPI_GPIO_LOW : CAPI_GPIO_HIGH;
+	return logical_value;
+}
+
+/**
+ * @brief Set the value of a single pin (considering the ACTIVE_LOW flag)
+ * @param pin - the pin handle
+ * @param value - the value (CAPI_GPIO_LOW or CAPI_GPIO_HIGH)
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_gpio_pin_set_value(struct capi_gpio_pin *pin, uint8_t value)
+{
+	uint8_t raw_value;
+
+	if (!pin)
+		return -EINVAL;
+
+	raw_value = to_raw_value(value, pin->flags);
+
+	return max_capi_gpio_pin_set_raw_value(pin, raw_value);
+}
+
+/**
+ * @brief Get the value of a single pin (considering the ACTIVE_LOW flag)
+ * @param pin - the pin handle
+ * @param value - pointer where to store the value
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_gpio_pin_get_value(struct capi_gpio_pin *pin, uint8_t *value)
+{
+	uint8_t raw_value;
+	int ret;
+
+	if (!pin || !value)
+		return -EINVAL;
+
+	ret = max_capi_gpio_pin_get_raw_value(pin, &raw_value);
+	if (ret)
+		return ret;
+
+	*value = apply_active_low(raw_value, pin->flags);
+
+	return 0;
+}
+
+/**
+ * @brief Toggle the value of the specified pins in a port
+ * @param handle - the GPIO port handle
+ * @param pins_bitmask - bitmask of pins to toggle
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_gpio_port_toggle(struct capi_gpio_port_handle *handle,
+			      uint64_t pins_bitmask)
+{
+	struct max_capi_gpio_port_priv *priv;
+	uint32_t masked_pins;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	priv = handle->priv;
+	masked_pins = (uint32_t)pins_bitmask & priv->pin_mask;
+
+	set_enable(priv->port, masked_pins, true);
+	MXC_GPIO_OutToggle(priv->port, masked_pins);
+
+	return 0;
+}
+
+/**
+ * @brief Toggle the output value of the specified GPIO pin
+ * @param pin - the GPIO pin
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_gpio_pin_toggle(struct capi_gpio_pin *pin)
+{
+	struct max_capi_gpio_port_priv *priv;
+
+	if (!pin || !pin->port_handle || !pin->port_handle->priv)
+		return -EINVAL;
+
+	priv = pin->port_handle->priv;
+
+	if (pin->number > priv->num_pins)
+		return -EINVAL;
+
+	set_enable(priv->port, (1U << pin->number), true);
+	MXC_GPIO_OutToggle(priv->port, (1U << pin->number));
+
+	return 0;
+}
+
+const struct capi_gpio_ops max_capi_gpio_ops = {
+	.port_init = &max_capi_gpio_port_init,
+	.port_deinit = &max_capi_gpio_port_deinit,
+	.port_set_direction = &max_capi_gpio_port_set_direction,
+	.port_get_direction = &max_capi_gpio_port_get_direction,
+	.port_set_value = &max_capi_gpio_port_set_value,
+	.port_get_value = &max_capi_gpio_port_get_value,
+	.port_set_raw_value = &max_capi_gpio_port_set_raw_value,
+	.port_get_raw_value = &max_capi_gpio_port_get_raw_value,
+	.pin_set_direction = &max_capi_gpio_pin_set_direction,
+	.pin_get_direction = &max_capi_gpio_pin_get_direction,
+	.pin_set_value = &max_capi_gpio_pin_set_value,
+	.pin_get_value = &max_capi_gpio_pin_get_value,
+	.pin_set_raw_value = &max_capi_gpio_pin_set_raw_value,
+	.pin_get_raw_value = &max_capi_gpio_pin_get_raw_value,
+	.port_toggle = &max_capi_gpio_port_toggle,
+	.pin_toggle = &max_capi_gpio_pin_toggle,
+};

--- a/capi/platform/maxim/max32657/maxim_capi_gpio.h
+++ b/capi/platform/maxim/max32657/maxim_capi_gpio.h
@@ -1,0 +1,85 @@
+/***************************************************************************//**
+ *   @file   maxim_capi_gpio.h
+ *   @brief  Header file for GPIO functions with CAPI.
+ *   @author Ramon Miguel Imbao (ramonmiguel.imbao@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef MAXIM_CAPI_GPIO_H_
+#define MAXIM_CAPI_GPIO_H_
+
+#include "gpio.h"
+#include "capi_gpio.h"
+
+enum max_capi_gpio_vssel {
+	MAX_CAPI_GPIO_VSSEL_VDDIO = MXC_GPIO_VSSEL_VDDIO,
+	MAX_CAPI_GPIO_VSSEL_VDDIOH = MXC_GPIO_VSSEL_VDDIOH,
+};
+
+enum max_capi_gpio_func {
+	MAX_CAPI_GPIO_FUNC_IN = MXC_GPIO_FUNC_IN,
+	MAX_CAPI_GPIO_FUNC_OUT = MXC_GPIO_FUNC_OUT,
+	MAX_CAPI_GPIO_FUNC_ALT_1 = MXC_GPIO_FUNC_ALT1,
+	MAX_CAPI_GPIO_FUNC_ALT_2 = MXC_GPIO_FUNC_ALT2,
+	MAX_CAPI_GPIO_FUNC_ALT_3 = MXC_GPIO_FUNC_ALT3,
+	MAX_CAPI_GPIO_FUNC_ALT_4 = MXC_GPIO_FUNC_ALT4,
+};
+
+enum max_capi_gpio_pad {
+	MAX_CAPI_GPIO_PAD_NONE = MXC_GPIO_PAD_NONE,
+	MAX_CAPI_GPIO_PAD_PULL_UP = MXC_GPIO_PAD_WEAK_PULL_UP,
+	MAX_CAPI_GPIO_PAD_PULL_DOWN = MXC_GPIO_PAD_WEAK_PULL_DOWN,
+};
+
+enum max_capi_gpio_drvstr {
+	MAX_CAPI_GPIO_DRVSTR_0 = MXC_GPIO_DRVSTR_0,
+	MAX_CAPI_GPIO_DRVSTR_1 = MXC_GPIO_DRVSTR_1,
+	MAX_CAPI_GPIO_DRVSTR_2 = MXC_GPIO_DRVSTR_2,
+	MAX_CAPI_GPIO_DRVSTR_3 = MXC_GPIO_DRVSTR_3,
+};
+
+struct max_capi_gpio_extra_config {
+	enum max_capi_gpio_vssel vssel;
+	enum max_capi_gpio_func func;
+	enum max_capi_gpio_pad pad;
+	enum max_capi_gpio_drvstr drvstr;
+};
+
+struct max_capi_gpio_port_priv {
+	uint32_t id;
+	mxc_gpio_regs_t *port;
+	uint8_t num_pins;
+	uint32_t pin_mask;
+	uint32_t direction_mask;
+	struct max_capi_gpio_extra_config extra;
+};
+
+extern const struct capi_gpio_ops max_capi_gpio_ops;
+
+#endif /* MAXIM_CAPI_GPIO_H_ */

--- a/capi/platform/maxim/max32657/maxim_capi_i2c.c
+++ b/capi/platform/maxim/max32657/maxim_capi_i2c.c
@@ -1,0 +1,1631 @@
+/*******************************************************************************
+ *   @file   maxim_capi_i2c.c
+ *   @brief  Implementation of I2C functions with CAPI
+ *   @author Ramon Miguel Imbao (ramonmiguel.imbao@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <errno.h>
+#include <string.h>
+#include "capi_i2c.h"
+#include "capi_dma.h"
+#include "capi_irq.h"
+#include "maxim_capi_i2c.h"
+#include "maxim_capi_dma.h"
+#include "maxim_capi_irq.h"
+#include "i3c.h"
+
+/** Static variables **********************************************************/
+
+static struct capi_i2c_controller_handle *i2c[MXC_CFG_I3C_INSTANCES] = {NULL};
+static volatile bool dma_completed[MXC_CFG_I3C_INSTANCES] = {false};
+static struct capi_dma_chan *dma_channel_rx[MXC_CFG_I3C_INSTANCES];
+static struct capi_dma_chan *dma_channel_tx[MXC_CFG_I3C_INSTANCES];
+static bool async_transfer_in_progress[MXC_CFG_I3C_INSTANCES] = {false};
+
+/** Forward declarations ******************************************************/
+
+void max_capi_i2c_isr(void *handle);
+int max_capi_i2c_configure_bus_speed(struct capi_i2c_controller_handle *handle,
+				     enum capi_i2c_speed speed,
+				     uint8_t duty_cycle);
+
+/** Helper functions **********************************************************/
+
+/**
+ * @brief Set TX data for target mode
+ * @param i2c_priv The I2C private data
+ * @param data Pointer to TX data buffer
+ * @param length Number of bytes to transmit
+ */
+static void _max_capi_i2c_target_set_tx_data(struct max_capi_i2c_priv *i2c_priv,
+		const uint8_t *data, uint16_t length)
+{
+	mxc_i3c_regs_t *i3c = MXC_I3C_GET_I3C(i2c_priv->identifier);
+
+	i2c_priv->target->tx_buffer = data;
+	i2c_priv->target->tx_length = length;
+	i2c_priv->target->tx_count = 0;
+
+	MXC_I3C_Target_EnableInt(i3c, MXC_F_I3C_TARG_INTEN_TX_NFULL);
+}
+
+/**
+ * @brief Get RX data for target mode
+ * @param i2c_priv The I2C private data
+ * @param[out] data Pointer to RX data buffer
+ * @param[out] length Number of bytes received
+ */
+static void _max_capi_i2c_target_get_rx_data(struct max_capi_i2c_priv *i2c_priv,
+		uint8_t **data, uint16_t *length)
+{
+	*data = i2c_priv->target->rx_buffer;
+	*length = i2c_priv->target->rx_count;
+}
+
+
+/**
+ * @brief Get PP/OD frequencies for a given I2C speed
+ * @param[in] i2c_freq Desired I2C frequency
+ * @param[out] pp_freq PP frequency
+ * @param[out] od_freq OD frequency
+ * @return 0 on success, -EINVAL if unsupported frequency
+ */
+static int _max_capi_i2c_get_frequencies(uint32_t i2c_freq, uint32_t *pp_freq,
+		uint32_t *od_freq)
+{
+	if (!pp_freq || !od_freq)
+		return -EINVAL;
+
+	/** Values obtained through trial-and-error by sweeping through
+	    PP and OD frequencies and getting the I2C frequency.
+	    Lowest frequencies chosen for power efficiency. */
+	switch (i2c_freq) {
+	case MAX_CAPI_I2C_SPEED_STANDARD:
+		*pp_freq = 2500000;
+		*od_freq =  500000;
+		break;
+	case MAX_CAPI_I2C_SPEED_FAST:
+		*pp_freq = 12500000;
+		*od_freq =  1390000;
+		break;
+	case MAX_CAPI_I2C_SPEED_FAST_PLUS:
+		*pp_freq = 2500000;
+		*od_freq = 2500000;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Configure I3C peripheral in I2C mode
+ * @param i2c_priv The private handle
+ * @param target_mode Target mode: true,
+ * 		      Controller mode: false
+ * @param addr_or_freq Address if target mode,
+ * 		       Frequency if controller mode
+ * @return 0 on success, negative error code otherwise
+ */
+static int _max_capi_i2c_configure_hardware(struct max_capi_i2c_priv *i2c_priv,
+		bool target_mode,
+		uint32_t addr_or_freq)
+{
+	struct max_capi_i2c_extra *i2c_extra = i2c_priv->extra;
+	struct max_capi_i2c_target_state *target = i2c_priv->target;
+	uint8_t i2c_id = i2c_priv->identifier;
+	mxc_i3c_config_t i3c_config;
+	mxc_gpio_cfg_t i3c_pins;
+	int ret;
+	bool target_allocated = false;
+
+	ret = MXC_I3C_Shutdown(MXC_I3C_GET_I3C(i2c_id));
+	if (ret != E_NO_ERROR)
+		return -EINVAL;
+
+	if (target_mode) {
+		i3c_config = (mxc_i3c_config_t) {
+			.target_mode = true,
+			.static_addr = addr_or_freq,
+			.i2c_hz = 0, /* These values are ignored in target mode */
+			.od_hz = 0,
+			.pp_hz = 0,
+		};
+
+		if (!target) {
+			target = capi_calloc(1, sizeof(*target));
+			if (!target)
+				return -ENOMEM;
+			i2c_priv->target = target;
+			target_allocated = true;
+		}
+	} else {
+		i3c_config = (mxc_i3c_config_t) {
+			.target_mode = false,
+			.static_addr = 0, /* This value is ignored in controller mode */
+			.i2c_hz = addr_or_freq,
+		};
+		ret = _max_capi_i2c_get_frequencies(addr_or_freq,
+						    &i3c_config.pp_hz,
+						    &i3c_config.od_hz);
+		if (ret)
+			return ret;
+
+		i2c_priv->freq = addr_or_freq;
+	}
+
+	ret = MXC_I3C_Init(MXC_I3C_GET_I3C(i2c_id), &i3c_config);
+	if (ret != E_NO_ERROR) {
+		ret = -EIO;
+		if (target_mode && target_allocated)
+			goto free_target;
+
+		return ret;
+	}
+
+	i3c_pins = gpio_cfg_i3c;
+	i3c_pins.vssel = (mxc_gpio_vssel_t)i2c_extra->vssel;
+	MXC_GPIO_Config(&i3c_pins);
+
+	return 0;
+
+free_target:
+	if (i2c_priv->target) {
+		capi_free(target);
+		i2c_priv->target = NULL;
+	}
+
+	return ret;
+}
+
+/**
+ * @brief Handle target mode interrupts
+ *
+ * IMPORTANT: The callback is invoked from interrupt context and must:
+ * - Execute quickly without blocking
+ * - For CAPI_I2C_STXREQ event: Set target->tx_buffer and target->tx_length
+ *   before returning, or set tx_buffer to NULL for underrun
+ * - For CAPI_I2C_SRXREQ event: Prepare to receive data
+ * - Return immediately
+ * @param i2c_priv I2C private data
+ * @param i3c I3C peripheral
+ */
+static void _max_capi_i2c_target_isr(struct max_capi_i2c_priv *i2c_priv,
+				     mxc_i3c_regs_t *i3c)
+{
+	struct max_capi_i2c_target_state *target = i2c_priv->target;
+	uint32_t flags = MXC_I3C_Target_GetFlags(i3c);
+	capi_i2c_callback callback = i2c_priv->callback;
+	void *callback_arg = i2c_priv->callback_arg;
+
+	if (!target)
+		return;
+
+	/* START */
+	if (flags & MXC_F_I3C_TARG_INTFL_START) {
+		target->rx_count = 0;
+		target->tx_count = 0;
+
+		MXC_I3C_ClearRXFIFO(i3c);
+		MXC_I3C_ClearTXFIFO(i3c);
+
+		MXC_I3C_Target_ClearFlags(i3c, MXC_F_I3C_TARG_INTFL_START);
+	}
+
+	/* Address match */
+	if (flags & MXC_F_I3C_TARG_INTFL_ADDRMATCH) {
+		uint32_t status = i3c->targ_status;
+
+		if (status & MXC_F_I3C_TARG_STATUS_RX_SDR) {
+			/* Controller wants to write to us */
+			target->state = MAX_CAPI_I2C_TARGET_STATE_RX;
+
+			if (callback)
+				callback(CAPI_I2C_SRXREQ, callback_arg, 0);
+
+		} else if (status & MXC_F_I3C_TARG_STATUS_TX_SDR) {
+			/* Controller wants to read from us */
+			target->state = MAX_CAPI_I2C_TARGET_STATE_TX;
+
+			if (callback)
+				callback(CAPI_I2C_STXREQ, callback_arg, 0);
+		}
+
+		MXC_I3C_Target_ClearFlags(i3c, MXC_F_I3C_TARG_INTFL_ADDRMATCH);
+	}
+
+	/* RX ready - controller is writing data to us */
+	if (flags & MXC_F_I3C_TARG_INTFL_RX_RDY) {
+		if (target->state == MAX_CAPI_I2C_TARGET_STATE_RX) {
+			while (i3c->targ_status & MXC_F_I3C_TARG_STATUS_RX_RDY) {
+				if (target->rx_count < MAX_CAPI_I2C_TARGET_RX_BUFFER_SIZE) {
+					uint8_t byte = (uint8_t)(i3c->targ_rxfifo8 & 0xFF);
+					target->rx_buffer[target->rx_count++] = byte;
+				} else {
+					/* Buffer overflow - read and discard */
+					(void)i3c->targ_rxfifo8;
+
+					if (callback)
+						callback(CAPI_I2C_RXOVER, callback_arg, 0);
+				}
+			}
+		}
+
+		MXC_I3C_Target_ClearFlags(i3c, MXC_F_I3C_TARG_INTFL_RX_RDY);
+	}
+
+	/* TX not full - controller is reading from us */
+	if (flags & MXC_F_I3C_TARG_INTFL_TX_NFULL) {
+		if (target->state == MAX_CAPI_I2C_TARGET_STATE_TX) {
+			if (target->tx_buffer == NULL) {
+				/* TX underrun */
+				MXC_I3C_Target_DisableInt(i3c, MXC_F_I3C_TARG_INTCLR_TX_NFULL);
+
+				if (callback)
+					callback(CAPI_I2C_TXUNDER, callback_arg, 0);
+			} else {
+				while ((i3c->targ_status & MXC_F_I3C_TARG_STATUS_TX_NFULL) &&
+				       (target->tx_count < target->tx_length)) {
+					uint8_t byte = target->tx_buffer[target->tx_count++];
+					i3c->targ_txfifo8 = byte;
+				}
+
+				/* Check if we've sent all data */
+				if (target->tx_count >= target->tx_length)
+					MXC_I3C_Target_DisableInt(i3c, MXC_F_I3C_TARG_INTCLR_TX_NFULL);
+			}
+		}
+
+		MXC_I3C_Target_ClearFlags(i3c, MXC_F_I3C_TARG_INTFL_TX_NFULL);
+	}
+
+
+
+	/* STOP */
+	if (flags & MXC_F_I3C_TARG_INTFL_STOP) {
+		int event_extra = 0;
+
+		if (target->state == MAX_CAPI_I2C_TARGET_STATE_RX) {
+			/* Application should handle rx_buffer and rx_count
+			   in callback */
+			event_extra = target->rx_count;
+		}
+
+		target->state = MAX_CAPI_I2C_TARGET_STATE_IDLE;
+		target->tx_buffer = NULL;
+		target->tx_length = 0;
+
+		if (callback)
+			callback(CAPI_I2C_XFR_DONE, callback_arg, event_extra);
+
+		MXC_I3C_Target_ClearFlags(i3c, MXC_F_I3C_TARG_INTFL_STOP);
+	}
+
+	/* Errors/warnings */
+	if (flags & MXC_F_I3C_TARG_INTFL_ERRWARN) {
+		uint32_t errwarn = i3c->targ_errwarn;
+
+		/* Clear error */
+		i3c->targ_errwarn = errwarn;
+		MXC_I3C_Target_ClearFlags(i3c, MXC_F_I3C_TARG_INTFL_ERRWARN);
+
+		if (callback)
+			callback(CAPI_I2C_NAKD, callback_arg, errwarn);
+	}
+}
+
+/**
+ * @brief Reset async state to IDLE
+ * @param i2c_priv I2C private data
+ */
+static void _max_capi_i2c_reset_async_state(struct max_capi_i2c_priv *i2c_priv)
+{
+	if (!i2c_priv->async)
+		return;
+
+	i2c_priv->async->state = MAX_CAPI_I2C_ASYNC_STATE_IDLE;
+	i2c_priv->async->target_addr = 0;
+	i2c_priv->async->subaddr_buf = NULL;
+	i2c_priv->async->subaddr_len = 0;
+	i2c_priv->async->subaddr_idx = 0;
+	i2c_priv->async->data_buf = NULL;
+	i2c_priv->async->data_len = 0;
+	i2c_priv->async->data_idx = 0;
+	i2c_priv->async->send_stop = false;
+	i2c_priv->async->result = 0;
+	i2c_priv->async->is_transmit = false;
+}
+
+/**
+ * @brief Write bytes from buffer to TX FIFO
+ * @param i3c I3C peripheral registers
+ * @param buf Source buffer
+ * @param len Number of bytes to write
+ * @param idx Pointer to current index
+ * @param is_last_chunk True if this is the last data chunk
+ * @return Number of bytes actually written
+ */
+static uint16_t _max_capi_i2c_write_tx_fifo(mxc_i3c_regs_t *i3c,
+		const uint8_t *buf, uint16_t len,
+		uint16_t *idx, bool is_last_chunk)
+{
+	uint16_t written = 0;
+
+	while ((*idx < len) &&
+	       (MXC_I3C_Controller_GetTXCount(i3c) < MAX_CAPI_I2C_FIFO_DEPTH)) {
+		bool is_last = (is_last_chunk && (*idx == (len - 1)));
+		int ret = MXC_I3C_WriteTXFIFO(i3c, &buf[*idx], 1, is_last, 0);
+		if (ret <= 0)
+			break;
+		(*idx)++;
+		written++;
+	}
+
+	return written;
+}
+
+/**
+ * @brief Read available bytes from RX FIFO to buffer
+ * @param i3c I3C peripheral registers
+ * @param buf Destination buffer
+ * @param len Total buffer length
+ * @param idx Pointer to current index
+ * @return Number of bytes read
+ */
+static uint16_t _max_capi_i2c_read_rx_fifo(mxc_i3c_regs_t *i3c,
+		uint8_t *buf, uint16_t len,
+		uint16_t *idx)
+{
+	uint16_t available = MXC_I3C_Controller_GetRXCount(i3c);
+	uint16_t to_read = (available < len - (*idx)) ? available : (len - (*idx));
+
+	if (to_read > 0) {
+		int ret = MXC_I3C_ReadRXFIFO(i3c, &buf[*idx], to_read, 0);
+		if (ret > 0)
+			*idx += ret;
+		return ret > 0 ? ret : 0;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Perform I2C transmit using FIFO (interrupt-driven)
+ * @param i3c I3C peripheral registers
+ * @param async Async state
+ * @return 0 on success, negative error code otherwise
+ */
+static int _max_capi_i2c_transmit_fifo(mxc_i3c_regs_t *i3c,
+				       struct max_capi_i2c_async_state *async)
+{
+	int ret;
+
+	async->is_transmit = true;
+
+	if (async->subaddr_buf)
+		async->state = MAX_CAPI_I2C_ASYNC_STATE_TX_SUBADDR;
+	else
+		async->state = MAX_CAPI_I2C_ASYNC_STATE_TX_DATA;
+
+	ret = MXC_I3C_EmitStart(i3c, true, MXC_I3C_TRANSFER_TYPE_WRITE,
+				async->target_addr, 0);
+	if (ret != E_SUCCESS)
+		return (ret == E_BUSY) ? -EBUSY : -EIO;
+
+	if (async->state == MAX_CAPI_I2C_ASYNC_STATE_TX_SUBADDR) {
+		_max_capi_i2c_write_tx_fifo(i3c, async->subaddr_buf,
+					    async->subaddr_len,
+					    &async->subaddr_idx,
+					    false);
+		if (async->subaddr_idx >= async->subaddr_len)
+			async->state = MAX_CAPI_I2C_ASYNC_STATE_TX_DATA;
+	}
+
+	if (async->state == MAX_CAPI_I2C_ASYNC_STATE_TX_DATA) {
+		_max_capi_i2c_write_tx_fifo(i3c, async->data_buf,
+					    async->data_len,
+					    &async->data_idx,
+					    true);
+	}
+
+	MXC_I3C_Controller_ClearFlags(i3c, 0xFFFFFFFF);
+	MXC_I3C_Controller_EnableInt(i3c, MXC_F_I3C_CONT_INTEN_TX_NFULL |
+				     MXC_F_I3C_CONT_INTEN_DONE |
+				     MXC_F_I3C_CONT_INTEN_ERRWARN);
+
+	return 0;
+}
+
+/**
+ * @brief Perform I2C receive using FIFO (interrupt-driven)
+ * @param i3c I3C peripheral registers
+ * @param async Async state
+ * @return 0 on success, negative error code otherwise
+ */
+static int _max_capi_i2c_receive_fifo(mxc_i3c_regs_t *i3c,
+				      struct max_capi_i2c_async_state *async)
+{
+	int ret;
+	uint32_t int_mask;
+
+	async->is_transmit = false;
+
+	if (async->subaddr_buf) {
+		async->state = MAX_CAPI_I2C_ASYNC_STATE_TX_SUBADDR;
+
+		ret = MXC_I3C_EmitStart(i3c, true, MXC_I3C_TRANSFER_TYPE_WRITE,
+					async->target_addr, 0);
+		if (ret != E_SUCCESS)
+			return (ret == E_BUSY) ? -EBUSY : -EIO;
+
+		_max_capi_i2c_write_tx_fifo(i3c, async->subaddr_buf,
+					    async->subaddr_len,
+					    &async->subaddr_idx,
+					    true);
+
+		int_mask = MXC_F_I3C_CONT_INTEN_TX_NFULL |
+			   MXC_F_I3C_CONT_INTEN_DONE |
+			   MXC_F_I3C_CONT_INTEN_ERRWARN;
+	} else {
+		async->state = MAX_CAPI_I2C_ASYNC_STATE_RX_DATA;
+
+		ret = MXC_I3C_EmitStart(i3c, true, MXC_I3C_TRANSFER_TYPE_READ,
+					async->target_addr, async->data_len);
+		if (ret != E_SUCCESS)
+			return (ret == E_BUSY) ? -EBUSY : -EIO;
+
+		int_mask = MXC_F_I3C_CONT_INTEN_RX_RDY |
+			   MXC_F_I3C_CONT_INTEN_DONE |
+			   MXC_F_I3C_CONT_INTEN_ERRWARN;
+	}
+
+	MXC_I3C_Controller_ClearFlags(i3c, 0xFFFFFFFF);
+	MXC_I3C_Controller_EnableInt(i3c, int_mask);
+
+	return 0;
+}
+
+/**
+ * @brief Cleanup and deinit a DMA channel
+ * @param channel The DMA channel
+ */
+void _max_capi_i2c_dma_cleanup_channel(struct capi_dma_chan **channel)
+{
+	if (channel && *channel) {
+		capi_dma_xfer_abort(*channel);
+		capi_dma_deinit_chan(*channel);
+		*channel = NULL;
+	}
+}
+
+/**
+ * @brief DMA transfer completion callback
+ * @param event The event indicating completion status
+ * @param ctx The user data passed (struct max_capi_i2c_priv)
+ */
+static void _max_capi_i2c_dma_complete_callback(uint32_t event, void *ctx)
+{
+	struct max_capi_i2c_priv *i2c_priv = ctx;
+
+	if (!i2c_priv || !i2c_priv->async)
+		return;
+
+	i2c_priv->callback_active = true;
+
+	uint8_t i2c_id = i2c_priv->identifier;
+	mxc_i3c_regs_t *i3c = MXC_I3C_GET_I3C(i2c_id);
+	capi_i2c_callback callback;
+	void *callback_arg;
+
+	callback = i2c_priv->callback;
+	callback_arg = i2c_priv->callback_arg;
+
+	dma_completed[i2c_id] = true;
+	MXC_I3C_Controller_EnableInt(i3c, MXC_F_I3C_CONT_INTEN_DONE);
+
+	if (i2c_priv->async->send_stop)
+		MXC_I3C_EmitI2CStop(i3c);
+
+	_max_capi_i2c_dma_cleanup_channel(&dma_channel_rx[i2c_id]);
+	_max_capi_i2c_dma_cleanup_channel(&dma_channel_tx[i2c_id]);
+
+	dma_completed[i2c_id] = false;
+	async_transfer_in_progress[i2c_id] = false;
+
+	if (i2c_priv->async->dma_allocated_buffer) {
+		capi_free(i2c_priv->async->dma_allocated_buffer);
+		i2c_priv->async->dma_allocated_buffer = NULL;
+	}
+
+	_max_capi_i2c_reset_async_state(i2c_priv);
+
+	if (callback)
+		callback(event, callback_arg, 0);
+
+	i2c_priv->callback_active = false;
+}
+
+/**
+ * @brief Perform I2C transmit using DMA
+ * @param i2c_priv I2C private data
+ * @param i3c I3C peripheral registers
+ * @param async Async state
+ * @return 0 on success, negative error code otherwise
+ */
+static int _max_capi_i2c_transmit_dma(struct max_capi_i2c_priv *i2c_priv,
+				      mxc_i3c_regs_t *i3c,
+				      struct max_capi_i2c_async_state *async)
+{
+	int ret;
+	struct capi_dma_handle *dma_handle = i2c_priv->dma_handle;
+	uint8_t i2c_id = i2c_priv->identifier;
+	uint8_t *tx_buffer;
+	uint16_t tx_len;
+	struct max_capi_dma_xfer_extra dma_tx_extra;
+	struct capi_dma_transfer dma_tx_xfer;
+
+	if (async_transfer_in_progress[i2c_id])
+		return -EBUSY;
+
+	async_transfer_in_progress[i2c_id] = true;
+
+	if (async->subaddr_buf) {
+		tx_len = async->subaddr_len + async->data_len;
+		tx_buffer = capi_malloc(tx_len);
+		if (!tx_buffer) {
+			async_transfer_in_progress[i2c_id] = false;
+			return -ENOMEM;
+		}
+		memcpy(tx_buffer, async->subaddr_buf, async->subaddr_len);
+		memcpy(tx_buffer + async->subaddr_len, async->data_buf, async->data_len);
+		i2c_priv->async->dma_allocated_buffer = tx_buffer;
+	} else {
+		tx_buffer = async->data_buf;
+		tx_len = async->data_len;
+		i2c_priv->async->dma_allocated_buffer = NULL;
+	}
+
+	async->state = MAX_CAPI_I2C_ASYNC_STATE_TX_DATA;
+
+	ret = MXC_I3C_EmitStart(i3c, true, MXC_I3C_TRANSFER_TYPE_WRITE,
+				async->target_addr, 0);
+	if (ret != E_SUCCESS) {
+		if (tx_buffer != async->data_buf)
+			capi_free(tx_buffer);
+		async_transfer_in_progress[i2c_id] = false;
+		return -EIO;
+	}
+
+	i3c->cont_dmactrl = MXC_S_I3C_CONT_DMACTRL_TX_EN_EN;
+
+	ret = capi_dma_init_chan(dma_handle, &dma_channel_tx[i2c_id], 0);
+	if (ret)
+		goto error_cleanup;
+
+	dma_tx_extra = (struct max_capi_dma_xfer_extra) {
+		.reqsel = MAX_CAPI_DMA_REQUEST_I3C_TX_CONTROLLER,
+	};
+
+	dma_tx_xfer = (struct capi_dma_transfer) {
+		.src = (capi_dma_glbl_addr_t)tx_buffer,
+		.dst = (capi_dma_glbl_addr_t)&i3c->cont_txfifo8,
+		.src_inc = CAPI_DMA_BYTE_INCREMENT,
+		.dst_inc = CAPI_DMA_NO_INCREMENT,
+		.src_size = CAPI_DMA_XFER_SIZE_1_BYTE,
+		.dst_size = CAPI_DMA_XFER_SIZE_1_BYTE,
+		.length = tx_len,
+		.extra = &dma_tx_extra,
+		.xfer_type = CAPI_DMA_MEM_TO_DEV,
+		.user_data = i2c_priv,
+	};
+
+	ret = capi_dma_config_xfer(dma_channel_tx[i2c_id], &dma_tx_xfer);
+	if (ret)
+		goto error_deinit_tx;
+
+	ret = capi_dma_register_complete_callback(dma_channel_tx[i2c_id],
+			_max_capi_i2c_dma_complete_callback,
+			i2c_priv);
+
+	dma_completed[i2c_id] = false;
+
+	ret = capi_dma_xfer_start(dma_channel_tx[i2c_id]);
+	if (ret)
+		goto error_deinit_tx;
+
+	return 0;
+
+error_deinit_tx:
+	capi_dma_deinit_chan(dma_channel_tx[i2c_id]);
+error_cleanup:
+	if (tx_buffer != async->data_buf)
+		capi_free(tx_buffer);
+	async_transfer_in_progress[i2c_id] = false;
+
+	return ret;
+}
+
+/**
+ * @brief Perform I2C receive using DMA
+ * @param i2c_priv I2C private data
+ * @param i3c I3C peripheral registers
+ * @param async Async state
+ * @return 0 on success, negative error code otherwise
+ */
+static int _max_capi_i2c_receive_dma(struct max_capi_i2c_priv *i2c_priv,
+				     mxc_i3c_regs_t *i3c,
+				     struct max_capi_i2c_async_state *async)
+{
+	int ret;
+	struct capi_dma_handle *dma_handle = i2c_priv->dma_handle;
+	uint8_t i2c_id = i2c_priv->identifier;
+	struct max_capi_dma_xfer_extra dma_rx_extra;
+	struct capi_dma_transfer dma_rx_xfer;
+	uint16_t i;
+	bool is_last;
+	uint32_t timeout = MAX_CAPI_I2C_DMA_TIMEOUT;
+
+	if (async_transfer_in_progress[i2c_id])
+		return -EBUSY;
+
+	async->state = MAX_CAPI_I2C_ASYNC_STATE_RX_DATA;
+
+	if (async->subaddr_buf) {
+		ret = MXC_I3C_EmitStart(i3c, true, MXC_I3C_TRANSFER_TYPE_WRITE,
+					async->target_addr, 0);
+		if (ret != E_SUCCESS) {
+			async_transfer_in_progress[i2c_id] = false;
+			return -EIO;
+		}
+
+		for (i = 0; i < async->subaddr_len; i++) {
+			is_last = (i == (async->subaddr_len - 1));
+			ret = MXC_I3C_WriteTXFIFO(i3c, &async->subaddr_buf[i],
+						  1, is_last, 0);
+			if (ret <= 0) {
+				async_transfer_in_progress[i2c_id] = false;
+				return -EIO;
+			}
+		}
+		while (!(MXC_I3C_Controller_GetFlags(i3c) & MXC_F_I3C_CONT_INTFL_DONE)) {
+			if (--timeout == 0)
+				return -ETIMEDOUT;
+		}
+		MXC_I3C_Controller_ClearFlags(i3c, MXC_F_I3C_CONT_INTFL_DONE);
+	}
+
+	ret = MXC_I3C_EmitStart(i3c, true, MXC_I3C_TRANSFER_TYPE_READ,
+				async->target_addr, async->data_len);
+	if (ret != E_SUCCESS) {
+		async_transfer_in_progress[i2c_id] = false;
+		return -EIO;
+	}
+
+	i3c->cont_dmactrl = MXC_S_I3C_CONT_DMACTRL_RX_EN_EN;
+
+	ret = capi_dma_init_chan(dma_handle, &dma_channel_rx[i2c_id], 0);
+	if (ret)
+		goto error_cleanup;
+
+	dma_rx_extra = (struct max_capi_dma_xfer_extra) {
+		.reqsel = MAX_CAPI_DMA_REQUEST_I3C_RX_CONTROLLER,
+	};
+
+	dma_rx_xfer = (struct capi_dma_transfer) {
+		.src = (capi_dma_glbl_addr_t)&i3c->cont_rxfifo8,
+		.dst = (capi_dma_glbl_addr_t)async->data_buf,
+		.src_inc = CAPI_DMA_NO_INCREMENT,
+		.dst_inc = CAPI_DMA_BYTE_INCREMENT,
+		.src_size = CAPI_DMA_XFER_SIZE_1_BYTE,
+		.dst_size = CAPI_DMA_XFER_SIZE_1_BYTE,
+		.length = async->data_len,
+		.extra = &dma_rx_extra,
+		.xfer_type = CAPI_DMA_DEV_TO_MEM,
+		.user_data = i2c_priv,
+	};
+
+	ret = capi_dma_config_xfer(dma_channel_rx[i2c_id], &dma_rx_xfer);
+	if (ret)
+		goto error_deinit_rx;
+
+	ret = capi_dma_register_complete_callback(dma_channel_rx[i2c_id],
+			_max_capi_i2c_dma_complete_callback,
+			i2c_priv);
+	if (ret)
+		goto error_deinit_rx;
+
+	dma_completed[i2c_id] = false;
+
+	ret = capi_dma_xfer_start(dma_channel_rx[i2c_id]);
+	if (ret)
+		goto error_deinit_rx;
+
+	return 0;
+
+error_deinit_rx:
+	capi_dma_deinit_chan(dma_channel_rx[i2c_id]);
+error_cleanup:
+	async_transfer_in_progress[i2c_id] = false;
+
+	return ret;
+}
+
+/**
+ * @brief Handle controller mode interrupts
+ * @param i2c_priv I2C private data
+ * @param i3c I3C peripheral
+ */
+static void _max_capi_i2c_controller_isr(struct max_capi_i2c_priv *i2c_priv,
+		mxc_i3c_regs_t *i3c)
+{
+	uint32_t flags;
+	int ret, result;
+	bool operation_complete;
+	capi_i2c_callback callback;
+	void *callback_arg;
+
+	if (!i2c_priv->async || i2c_priv->async->state == MAX_CAPI_I2C_ASYNC_STATE_IDLE)
+		return;
+
+	operation_complete = false;
+	flags = MXC_I3C_Controller_GetFlags(i3c);
+
+	if (flags & MXC_F_I3C_CONT_INTFL_ERRWARN) {
+		uint32_t errwarn = i3c->cont_errwarn;
+		i3c->cont_errwarn = errwarn;
+
+		i2c_priv->async->result = -EIO;
+		i2c_priv->async->state = MAX_CAPI_I2C_ASYNC_STATE_ERROR;
+
+		if (i2c_priv->async->send_stop)
+			MXC_I3C_EmitI2CStop(i3c);
+
+		operation_complete = true;
+		goto invoke_callback;
+	}
+
+	switch (i2c_priv->async->state) {
+	case MAX_CAPI_I2C_ASYNC_STATE_TX_SUBADDR:
+		if (flags & MXC_F_I3C_CONT_INTFL_TX_NFULL) {
+			_max_capi_i2c_write_tx_fifo(i3c,
+						    i2c_priv->async->subaddr_buf,
+						    i2c_priv->async->subaddr_len,
+						    &i2c_priv->async->subaddr_idx,
+						    false);
+
+			if (i2c_priv->async->subaddr_idx >= i2c_priv->async->subaddr_len) {
+				if (i2c_priv->async->is_transmit) {
+					i2c_priv->async->state = MAX_CAPI_I2C_ASYNC_STATE_TX_DATA;
+				} else {
+					ret = MXC_I3C_EmitStart(i3c, true,
+								MXC_I3C_TRANSFER_TYPE_READ,
+								i2c_priv->async->target_addr,
+								i2c_priv->async->data_len);
+					if (ret != E_SUCCESS) {
+						i2c_priv->async->result = -EIO;
+						i2c_priv->async->state = MAX_CAPI_I2C_ASYNC_STATE_ERROR;
+						operation_complete = true;
+						break;
+					}
+
+					MXC_I3C_Controller_DisableInt(i3c, MXC_F_I3C_CONT_INTEN_TX_NFULL);
+					MXC_I3C_Controller_EnableInt(i3c, MXC_F_I3C_CONT_INTEN_RX_RDY);
+
+					i2c_priv->async->state = MAX_CAPI_I2C_ASYNC_STATE_RX_DATA;
+				}
+			}
+		}
+		break;
+
+	case MAX_CAPI_I2C_ASYNC_STATE_TX_DATA:
+		if (flags & MXC_F_I3C_CONT_INTFL_TX_NFULL) {
+			_max_capi_i2c_write_tx_fifo(i3c,
+						    i2c_priv->async->data_buf,
+						    i2c_priv->async->data_len,
+						    &i2c_priv->async->data_idx,
+						    true);
+
+			if (i2c_priv->async->data_idx >= i2c_priv->async->data_len) {
+				i2c_priv->async->state = MAX_CAPI_I2C_ASYNC_STATE_WAIT_DONE;
+				MXC_I3C_Controller_DisableInt(i3c, MXC_F_I3C_CONT_INTEN_TX_NFULL);
+			}
+		}
+		break;
+
+	case MAX_CAPI_I2C_ASYNC_STATE_RX_DATA:
+		if (flags & MXC_F_I3C_CONT_INTFL_RX_RDY) {
+			_max_capi_i2c_read_rx_fifo(i3c,
+						   i2c_priv->async->data_buf,
+						   i2c_priv->async->data_len,
+						   &i2c_priv->async->data_idx);
+
+			if (i2c_priv->async->data_idx >= i2c_priv->async->data_len) {
+				i2c_priv->async->state = MAX_CAPI_I2C_ASYNC_STATE_WAIT_DONE;
+				MXC_I3C_Controller_DisableInt(i3c, MXC_F_I3C_CONT_INTEN_RX_RDY);
+			}
+		}
+		break;
+
+	case MAX_CAPI_I2C_ASYNC_STATE_WAIT_DONE:
+		if (flags & MXC_F_I3C_CONT_INTFL_DONE) {
+			i2c_priv->async->result = 0;
+			operation_complete = true;
+
+			if (i2c_priv->async->send_stop)
+				MXC_I3C_EmitI2CStop(i3c);
+		}
+		break;
+
+	default:
+		break;
+	}
+
+invoke_callback:
+	if (operation_complete) {
+		MXC_I3C_Controller_DisableInt(i3c, 0xFFFFFFFF);
+		MXC_I3C_Controller_ClearFlags(i3c, 0xFFFFFFFF);
+
+		result = i2c_priv->async->result;
+		callback = i2c_priv->callback;
+		callback_arg = i2c_priv->callback_arg;
+
+		_max_capi_i2c_reset_async_state(i2c_priv);
+
+		if (callback) {
+			callback(CAPI_I2C_XFR_DONE, callback_arg, result);
+		}
+	}
+}
+
+/**
+ * @brief Setup before an async transmit/receive function
+ * @param device The I2C device
+ * @param transfer The I2C transfer
+ * @return 0 on success, negative error code otherwise
+ */
+int _max_capi_i2c_setup_async(struct capi_i2c_device *device,
+			      struct capi_i2c_transfer *transfer)
+{
+	struct max_capi_i2c_priv *i2c_priv;
+	mxc_i3c_regs_t *i3c;
+	uint8_t i2c_id;
+	int ret;
+
+	if (!device || !device->controller || !device->controller->priv || !transfer)
+		return -EINVAL;
+
+	if (!transfer->buf || transfer->len == 0)
+		return -EINVAL;
+
+	i2c_priv = device->controller->priv;
+	i2c_id = i2c_priv->identifier;
+	i3c = MXC_I3C_GET_I3C(i2c_id);
+
+	/* Allocate async state on first use */
+	if (!i2c_priv->async) {
+		i2c_priv->async = capi_calloc(1, sizeof(*i2c_priv->async));
+		if (!i2c_priv->async)
+			return -ENOMEM;
+	}
+
+	if (i2c_priv->target && i2c_priv->target->enabled)
+		return -ENOTSUP;
+
+	if (i2c_priv->async->state != MAX_CAPI_I2C_ASYNC_STATE_IDLE)
+		return -EBUSY;
+
+	i2c_priv->async->target_addr = transfer->target_addr;
+	i2c_priv->async->send_stop = !transfer->no_stop;
+	i2c_priv->async->result = 0;
+
+	if (transfer->sub_address && transfer->sub_address_len > 0) {
+		i2c_priv->async->subaddr_buf = transfer->sub_address;
+		i2c_priv->async->subaddr_len = transfer->sub_address_len;
+		i2c_priv->async->subaddr_idx = 0;
+	} else {
+		i2c_priv->async->subaddr_buf = NULL;
+		i2c_priv->async->subaddr_len = 0;
+	}
+
+	i2c_priv->async->data_buf = transfer->buf;
+	i2c_priv->async->data_len = transfer->len;
+	i2c_priv->async->data_idx = 0;
+
+	MXC_I3C_ClearRXFIFO(i3c);
+	MXC_I3C_ClearTXFIFO(i3c);
+
+	ret = MXC_I3C_SetRXTXThreshold(i3c, MXC_I3C_RX_TH_NOT_EMPTY,
+				       MXC_I3C_TX_TH_HALF_FULL);
+	if (ret != E_SUCCESS) {
+		_max_capi_i2c_reset_async_state(i2c_priv);
+		return -EIO;
+	}
+
+	return 0;
+}
+
+/** I2C functions implementation **********************************************/
+
+/**
+ * @brief Initialize the I3C peripheral in I2C mode
+ * @param handle The I2C handle
+ * @param config The I2C initialization config
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_i2c_init(struct capi_i2c_controller_handle **handle,
+		      const struct capi_i2c_config *config)
+{
+	int ret;
+	struct capi_i2c_controller_handle *i2c_handle;
+	struct max_capi_i2c_priv *i2c_priv;
+	struct max_capi_i2c_extra *i2c_extra;
+	uint8_t i2c_id;
+
+	if (!handle || !config || !config->extra)
+		return -EINVAL;
+
+	if (config->identifier >= MXC_CFG_I3C_INSTANCES)
+		return -EINVAL;
+
+	if (i2c[config->identifier] != NULL) {
+		*handle = i2c[config->identifier];
+		return 0;
+	}
+
+	if (*handle == NULL) {
+		i2c_handle = capi_calloc(1, sizeof(*i2c_handle));
+		if (!i2c_handle)
+			return -ENOMEM;
+		i2c_handle->init_allocated = true;
+	} else {
+		i2c_handle = *handle;
+		i2c_handle->init_allocated = false;
+	}
+
+	i2c_priv = capi_calloc(1, sizeof(*i2c_priv));
+	if (!i2c_priv) {
+		ret = -ENOMEM;
+		goto free_handle;
+	}
+
+	i2c_handle->ops = config->ops;
+	i2c_extra = config->extra;
+	i2c_priv->identifier = config->identifier;
+	i2c_priv->extra = i2c_extra;
+	i2c_handle->priv = i2c_priv;
+	i2c_id = i2c_priv->identifier;
+
+	if (config->clk_freq_hz <= MAX_CAPI_I2C_SPEED_STANDARD) {
+		i2c_priv->freq = MAX_CAPI_I2C_SPEED_STANDARD;
+	} else if (config->clk_freq_hz <= MAX_CAPI_I2C_SPEED_FAST) {
+		i2c_priv->freq = MAX_CAPI_I2C_SPEED_FAST;
+	} else if (config->clk_freq_hz <= MAX_CAPI_I2C_SPEED_FAST_PLUS) {
+		i2c_priv->freq = MAX_CAPI_I2C_SPEED_FAST_PLUS;
+	} else {
+		ret = -EINVAL;
+		goto free_priv;
+	}
+
+	ret = _max_capi_i2c_configure_hardware(i2c_priv, !config->initiator,
+					       config->initiator ? i2c_priv->freq : config->address);
+	if (ret)
+		goto shutdown_i2c;
+
+	if (config->dma_handle && i2c_extra->dma_config) {
+		i2c_priv->dma_handle = config->dma_handle;
+
+		ret = capi_dma_init(&i2c_priv->dma_handle,
+				    i2c_extra->dma_config);
+		if (ret)
+			goto shutdown_i2c;
+	}
+
+	struct capi_irq_config irq_config = {
+		.irq_ctrl_id = 0,
+	};
+	ret = capi_irq_init(&irq_config);
+	if (ret && ret != -EBUSY) {
+		/* -EBUSY means IRQ already initialized, which is fine since
+		   it uses a singleton pattern. */
+		goto shutdown_i2c;
+	}
+
+	IRQn_Type i2c_irq = MXC_I3C_GET_IRQ(i2c_id);
+	ret = capi_irq_connect(i2c_irq, max_capi_i2c_isr, i2c_handle);
+	if (ret)
+		goto shutdown_i2c;
+
+	ret = capi_irq_enable(i2c_irq);
+	if (ret)
+		goto shutdown_i2c;
+
+	i2c[config->identifier] = i2c_handle;
+	*handle = i2c_handle;
+	i2c_priv->i2c_handle = i2c_handle;
+
+	return 0;
+
+shutdown_i2c:
+	MXC_I3C_Shutdown(MXC_I3C_GET_I3C(i2c_id));
+	if (i2c_priv->target) {
+		capi_free(i2c_priv->target);
+		i2c_priv->target = NULL;
+	}
+free_priv:
+	capi_free(i2c_priv);
+free_handle:
+	if (i2c_handle->init_allocated)
+		capi_free(i2c_handle);
+
+	i2c[config->identifier] = NULL;
+
+	return ret;
+}
+
+/**
+ * @brief Deinitialize the I3C peripheral
+ * @param handle The I2C handle
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_i2c_deinit(struct capi_i2c_controller_handle *handle)
+{
+	int ret;
+	struct max_capi_i2c_priv *i2c_priv;
+	uint8_t i2c_id;
+	mxc_i3c_regs_t *i3c;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	i2c_priv = handle->priv;
+	i2c_id = i2c_priv->identifier;
+	i3c = MXC_I3C_GET_I3C(i2c_id);
+
+	MXC_I3C_Controller_DisableInt(i3c, 0xFFFFFFFF);
+	MXC_I3C_Controller_ClearFlags(i3c, 0xFFFFFFFF);
+	MXC_I3C_Target_DisableInt(i3c, 0xFFFFFFFF);
+	MXC_I3C_Target_ClearFlags(i3c, 0xFFFFFFFF);
+
+	if (i2c_priv->async) {
+		if (i2c_priv->async->state != MAX_CAPI_I2C_ASYNC_STATE_IDLE) {
+			if (dma_channel_rx[i2c_id])
+				capi_dma_xfer_abort(dma_channel_rx[i2c_id]);
+			if (dma_channel_tx[i2c_id])
+				capi_dma_xfer_abort(dma_channel_tx[i2c_id]);
+
+			uint32_t timeout = MAX_CAPI_I2C_DMA_CALLBACK_CLEANUP_TIMEOUT;
+			while (i2c_priv->callback_active && --timeout);
+
+			if (!timeout)
+				i2c_priv->callback_active = false;
+
+			MXC_I3C_EmitI2CStop(i3c);
+		}
+
+		capi_free(i2c_priv->async);
+		i2c_priv->async = NULL;
+	}
+
+	if (i2c_priv->dma_handle) {
+		_max_capi_i2c_dma_cleanup_channel(&dma_channel_rx[i2c_id]);
+		_max_capi_i2c_dma_cleanup_channel(&dma_channel_tx[i2c_id]);
+		dma_completed[i2c_id] = false;
+		async_transfer_in_progress[i2c_id] = false;
+	}
+
+	capi_irq_disable(MXC_I3C_GET_IRQ(i2c_id));
+
+	ret = MXC_I3C_Shutdown(i3c);
+
+	if (i2c_priv->target) {
+		capi_free(i2c_priv->target);
+		i2c_priv->target = NULL;
+	}
+
+	capi_free(i2c_priv);
+	if (handle->init_allocated)
+		capi_free(handle);
+
+	i2c[i2c_id] = NULL;
+
+	if (ret != E_NO_ERROR)
+		return (ret == E_TIME_OUT ? -ETIMEDOUT : -EIO);
+
+	return 0;
+}
+
+/**
+ * @brief Transmit function
+ * @param device The I2C device
+ * @param transfer The I2C transfer
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_i2c_transmit(struct capi_i2c_device *device,
+			  struct capi_i2c_transfer *transfer)
+{
+	struct max_capi_i2c_priv *i2c_priv;
+	uint8_t i2c_id;
+
+	if (!device || !device->controller || !device->controller->priv || !transfer
+	    || !transfer->buf)
+		return -EINVAL;
+
+	i2c_priv = device->controller->priv;
+	i2c_id = i2c_priv->identifier;
+
+	if (i2c_priv->target != NULL && i2c_priv->target->enabled) {
+		/* Target mode - set TX data*/
+		_max_capi_i2c_target_set_tx_data(i2c_priv, transfer->buf, transfer->len);
+
+		return 0;
+	} else {
+		/* Controller mode - do the transmit */
+		uint8_t *combined_buf = NULL;
+
+		if (transfer->sub_address_len > 0 && !transfer->sub_address)
+			return -EINVAL;
+
+		mxc_i3c_req_t i2c_req = (mxc_i3c_req_t) {
+			.is_i2c = true,
+			.rx_buf = NULL,
+			.rx_len = 0,
+			.stop = !transfer->no_stop,
+			.target_addr = transfer->target_addr ? transfer->target_addr : device->address,
+		};
+
+		/* If sub_address is filled, concatenate with data buffer */
+		if (transfer->sub_address && transfer->sub_address_len > 0) {
+			combined_buf = capi_malloc(transfer->sub_address_len + transfer->len);
+			if (!combined_buf)
+				return -ENOMEM;
+
+			memcpy(combined_buf, transfer->sub_address, transfer->sub_address_len);
+			memcpy(combined_buf + transfer->sub_address_len, transfer->buf, transfer->len);
+
+			i2c_req.tx_buf = combined_buf;
+			i2c_req.tx_len = transfer->sub_address_len + transfer->len;
+		} else {
+			i2c_req.tx_buf = transfer->buf;
+			i2c_req.tx_len = transfer->len;
+		}
+
+		int ret = MXC_I3C_Controller_Transaction(MXC_I3C_GET_I3C(i2c_id), &i2c_req);
+
+		if (combined_buf)
+			capi_free(combined_buf);
+
+		if (ret)
+			return (ret == E_TIME_OUT ? -ETIMEDOUT : -EIO);
+
+		return 0;
+	}
+}
+
+
+/**
+ * @brief Receive function
+ * @param device The I2C device
+ * @param transfer The I2C transfer
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_i2c_receive(struct capi_i2c_device *device,
+			 struct capi_i2c_transfer *transfer)
+{
+	struct max_capi_i2c_priv *i2c_priv;
+	mxc_i3c_req_t i2c_req;
+	uint8_t i2c_id;
+
+	if (!device || !device->controller || !device->controller->priv || !transfer
+	    || !transfer->buf)
+		return -EINVAL;
+
+	i2c_priv = device->controller->priv;
+	i2c_id = i2c_priv->identifier;
+
+	if (i2c_priv->target != NULL && i2c_priv->target->enabled) {
+		/* Target mode - get RX data */
+		uint8_t *rx_data;
+		uint16_t rx_len;
+
+		_max_capi_i2c_target_get_rx_data(i2c_priv, &rx_data, &rx_len);
+
+		if (rx_len > transfer->len)
+			return -EOVERFLOW;
+
+		memcpy(transfer->buf, rx_data, rx_len);
+		transfer->len = rx_len;
+
+		return 0;
+	} else {
+		if (transfer->sub_address_len > 0 && !transfer->sub_address)
+			return -EINVAL;
+
+		i2c_req = (mxc_i3c_req_t) {
+			.is_i2c = true,
+			.rx_buf = transfer->buf,
+			.rx_len = transfer->len,
+			.stop = !transfer->no_stop,
+			.target_addr = transfer->target_addr ? transfer->target_addr : device->address,
+		};
+
+		if (transfer->sub_address && transfer->sub_address_len > 0) {
+			i2c_req.tx_buf = transfer->sub_address;
+			i2c_req.tx_len = transfer->sub_address_len;
+		}
+
+		int ret =  MXC_I3C_Controller_Transaction(MXC_I3C_GET_I3C(i2c_id), &i2c_req);
+		if (ret != E_NO_ERROR)
+			return (ret == E_TIME_OUT ? -ETIMEDOUT : -EIO);
+
+		return 0;
+	}
+}
+
+/**
+ * @brief Register a callback
+ * @param handle The I2C controller handle
+ * @param callback The callback function
+ * @param callback_arg Argument for the callback function
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_i2c_register_callback(struct capi_i2c_controller_handle *handle,
+				   capi_i2c_callback const callback,
+				   void *const callback_arg)
+{
+	struct max_capi_i2c_priv *i2c_priv;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	i2c_priv = handle->priv;
+	i2c_priv->callback = callback;
+	i2c_priv->callback_arg = callback_arg;
+
+	return 0;
+}
+
+/**
+ * @brief Configures the I2C bus speed
+ * @param handle The I2C controller handle
+ * @param speed The clock speed
+ * @param duty_cycle Ignored - automatically determined by hardware
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_i2c_configure_bus_speed(struct capi_i2c_controller_handle *handle,
+				     enum capi_i2c_speed speed,
+				     uint8_t duty_cycle)
+{
+	int ret;
+	uint32_t pp_freq, od_freq, i2c_freq;
+	struct max_capi_i2c_priv *i2c_priv;
+	mxc_i3c_regs_t *i3c;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	i2c_priv = handle->priv;
+	i3c = MXC_I3C_GET_I3C(i2c_priv->identifier);
+
+	switch (speed) {
+	case CAPI_I2C_SPEED_STANDARD:
+		i2c_freq = MAX_CAPI_I2C_SPEED_STANDARD;
+		break;
+	case CAPI_I2C_SPEED_FAST:
+		i2c_freq = MAX_CAPI_I2C_SPEED_FAST;
+		break;
+	case CAPI_I2C_SPEED_FAST_PLUS:
+		i2c_freq = MAX_CAPI_I2C_SPEED_FAST_PLUS;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	ret = _max_capi_i2c_get_frequencies(i2c_freq, &pp_freq, &od_freq);
+	if (ret)
+		return ret;
+
+	i2c_priv->freq = i2c_freq;
+	ret = MXC_I3C_SetPPFrequency(i3c, pp_freq);
+	if (ret < 0)
+		return -EINVAL;
+	ret = MXC_I3C_SetODFrequency(i3c, od_freq, false);
+	if (ret < 0)
+		return -EINVAL;
+	ret = MXC_I3C_SetI2CFrequency(i3c, i2c_freq);
+	if (ret < 0)
+		return -EINVAL;
+
+	return 0;
+}
+
+/**
+ * @brief Async transmit function
+ * @param device The I2C device
+ * @param transfer The I2C transfer
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_i2c_transmit_async(struct capi_i2c_device *device,
+				struct capi_i2c_transfer *transfer)
+{
+	struct max_capi_i2c_priv *i2c_priv;
+
+	if (!device || !device->controller || !device->controller->priv || !transfer)
+		return -EINVAL;
+
+	i2c_priv = device->controller->priv;
+
+	if (i2c_priv->target != NULL && i2c_priv->target->enabled) {
+		/* Target mode - set TX data */
+		_max_capi_i2c_target_set_tx_data(i2c_priv, transfer->buf, transfer->len);
+
+		return 0;
+	} else {
+		/* Controller mode - do the transmit async */
+		int ret = _max_capi_i2c_setup_async(device, transfer);
+		if (ret)
+			return ret;
+
+		mxc_i3c_regs_t *i3c = MXC_I3C_GET_I3C(i2c_priv->identifier);
+
+		if (i2c_priv->dma_handle)
+			ret = _max_capi_i2c_transmit_dma(i2c_priv, i3c, i2c_priv->async);
+		else
+			ret = _max_capi_i2c_transmit_fifo(i3c, i2c_priv->async);
+
+		if (ret)
+			_max_capi_i2c_reset_async_state(i2c_priv);
+
+		return ret;
+	}
+}
+
+/**
+ * @brief Async receive function
+ * @param device The I2C device
+ * @param transfer The I2C transfer
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_i2c_receive_async(struct capi_i2c_device *device,
+			       struct capi_i2c_transfer *transfer)
+{
+	struct max_capi_i2c_priv *i2c_priv;
+
+	if (!device || !device->controller || !device->controller->priv || !transfer)
+		return -EINVAL;
+
+	i2c_priv = device->controller->priv;
+
+	if (i2c_priv->target != NULL && i2c_priv->target->enabled) {
+		/* Target mode - get RX data */
+		uint8_t *rx_data;
+		uint16_t rx_len;
+
+		_max_capi_i2c_target_get_rx_data(i2c_priv, &rx_data, &rx_len);
+
+		if (rx_len > transfer->len)
+			return -EOVERFLOW;
+
+		memcpy(transfer->buf, rx_data, rx_len);
+		transfer->len = rx_len;
+
+		return 0;
+	} else {
+		/* Controller mode - do the receive async */
+		int ret = _max_capi_i2c_setup_async(device, transfer);
+		if (ret)
+			return ret;
+
+		mxc_i3c_regs_t *i3c = MXC_I3C_GET_I3C(i2c_priv->identifier);
+
+		if (i2c_priv->dma_handle)
+			ret = _max_capi_i2c_receive_dma(i2c_priv, i3c, i2c_priv->async);
+		else
+			ret = _max_capi_i2c_receive_fifo(i3c, i2c_priv->async);
+
+		if (ret)
+			_max_capi_i2c_reset_async_state(i2c_priv);
+
+		return ret;
+	}
+}
+
+/**
+ * @brief Attempt to recover the I2C bus
+ * @param handle The I2C controller handle
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_i2c_recover_bus(struct capi_i2c_controller_handle *handle)
+{
+	const struct max_capi_i2c_priv *i2c_priv;
+	uint8_t i2c_id;
+	int ret;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	i2c_priv = handle->priv;
+	i2c_id = i2c_priv->identifier;
+
+	ret = MXC_I3C_Recover(MXC_I3C_GET_I3C(i2c_id));
+	if (ret != E_NO_ERROR)
+		return -EIO;
+
+	return 0;
+}
+
+/**
+ * @brief Register the I2C controller in target mode
+ * @param handle The I2C controller handle
+ * @param addr Valid 7-bit or 10-bit I2C address
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_i2c_register_target(struct capi_i2c_controller_handle *handle,
+				 uint16_t addr)
+{
+	struct max_capi_i2c_priv *i2c_priv;
+	mxc_i3c_regs_t *i3c;
+	uint8_t i2c_id;
+	int ret;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	/* Validate address */
+	if (addr > 0x3FF)
+		return -EINVAL;
+	if (addr <= 0x7F) {
+		if (addr <= 0x07 || addr >= 0x78)
+			return -EINVAL;
+	}
+
+	i2c_priv = handle->priv;
+	i2c_id = i2c_priv->identifier;
+
+	if (i2c_priv->target != NULL && i2c_priv->target->enabled)
+		return -EBUSY;
+
+	ret = _max_capi_i2c_configure_hardware(i2c_priv, true, addr);
+	if (ret)
+		return ret;
+
+	if (!i2c_priv->target)
+		return -ENOMEM;
+
+	i2c_priv->target->enabled = true;
+	i2c_priv->target->address = addr;
+	i2c_priv->target->b10addr = (addr > 0x7F);
+	i2c_priv->target->state = MAX_CAPI_I2C_TARGET_STATE_IDLE;
+	i2c_priv->target->rx_count = 0;
+	i2c_priv->target->tx_count = 0;
+	i2c_priv->target->tx_buffer = NULL;
+	i2c_priv->target->tx_length = 0;
+
+	i3c = MXC_I3C_GET_I3C(i2c_id);
+	MXC_I3C_Target_ClearFlags(i3c, 0xFFFFFFFF);
+	MXC_I3C_Target_EnableInt(i3c, MXC_F_I3C_TARG_INTEN_START |
+				 MXC_F_I3C_TARG_INTEN_ADDRMATCH |
+				 MXC_F_I3C_TARG_INTEN_STOP |
+				 MXC_F_I3C_TARG_INTEN_RX_RDY |
+				 MXC_F_I3C_TARG_INTEN_ERRWARN);
+
+	return 0;
+}
+
+/**
+ * @brief Unregister the I2C controller from target mode
+ * @param handle The I2C controller handle
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_i2c_unregister_target(struct capi_i2c_controller_handle *handle)
+{
+	struct max_capi_i2c_priv *i2c_priv;
+	mxc_i3c_regs_t *i3c;
+	uint8_t i2c_id;
+	int ret;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	i2c_priv = handle->priv;
+
+	if (i2c_priv->target == NULL || !i2c_priv->target->enabled)
+		return -EINVAL;
+
+	i2c_id = i2c_priv->identifier;
+	i3c = MXC_I3C_GET_I3C(i2c_id);
+
+	MXC_I3C_Target_DisableInt(i3c, MXC_F_I3C_TARG_INTCLR_START |
+				  MXC_F_I3C_TARG_INTCLR_ADDRMATCH |
+				  MXC_F_I3C_TARG_INTCLR_STOP |
+				  MXC_F_I3C_TARG_INTCLR_RX_RDY |
+				  MXC_F_I3C_TARG_INTCLR_TX_NFULL |
+				  MXC_F_I3C_TARG_INTCLR_ERRWARN);
+
+	i2c_priv->target->enabled = false;
+
+	ret = _max_capi_i2c_configure_hardware(i2c_priv, false, i2c_priv->freq);
+	if (ret)
+		return ret;
+
+	return 0;
+}
+
+/**
+ * @brief The function called during an interrupt
+ * @param handle The I2C handle
+ */
+void max_capi_i2c_isr(void *handle)
+{
+	struct capi_i2c_controller_handle *i2c_handle;
+	struct max_capi_i2c_priv *i2c_priv;
+	mxc_i3c_regs_t *i3c;
+	uint8_t i2c_id;
+
+	if (!handle)
+		return;
+
+	i2c_handle = (struct capi_i2c_controller_handle *)handle;
+	if (!i2c_handle->priv)
+		return;
+
+	i2c_priv = i2c_handle->priv;
+	i2c_id = i2c_priv->identifier;
+	i3c = MXC_I3C_GET_I3C(i2c_id);
+
+	if (i2c_priv->target && (MXC_I3C_Target_GetFlags(i3c) != 0)) {
+		_max_capi_i2c_target_isr(i2c_priv, i3c);
+	} else if (MXC_I3C_Controller_GetFlags(i3c) != 0) {
+		_max_capi_i2c_controller_isr(i2c_priv, i3c);
+	} else {
+		uint32_t target_flags = MXC_I3C_Target_GetFlags(i3c);
+		uint32_t controller_flags = MXC_I3C_Controller_GetFlags(i3c);
+
+		if (target_flags)
+			MXC_I3C_Target_ClearFlags(i3c, target_flags);
+		if (controller_flags)
+			MXC_I3C_Controller_ClearFlags(i3c, controller_flags);
+	}
+}
+
+const struct capi_i2c_ops max_capi_i2c_ops = {
+	.init = max_capi_i2c_init,
+	.deinit = max_capi_i2c_deinit,
+	.transmit = max_capi_i2c_transmit,
+	.receive = max_capi_i2c_receive,
+	.register_callback = max_capi_i2c_register_callback,
+	.configure_bus_speed = max_capi_i2c_configure_bus_speed,
+	.transmit_async = max_capi_i2c_transmit_async,
+	.receive_async = max_capi_i2c_receive_async,
+	.recover_bus = max_capi_i2c_recover_bus,
+	.register_target = max_capi_i2c_register_target,
+	.unregister_target = max_capi_i2c_unregister_target,
+	.isr = max_capi_i2c_isr,
+};

--- a/capi/platform/maxim/max32657/maxim_capi_i2c.h
+++ b/capi/platform/maxim/max32657/maxim_capi_i2c.h
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ *   @file   maxim_capi_i2c.h
+ *   @brief  Header file for I2C functions with CAPI
+ *   @author Ramon Miguel Imbao (ramonmiguel.imbao@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef MAXIM_CAPI_I2C_H_
+#define MAXIM_CAPI_I2C_H_
+
+#include "maxim_capi_gpio.h"
+#include "capi_i2c.h"
+
+#define MAX_CAPI_I2C_TARGET_RX_BUFFER_SIZE	256
+#define MAX_CAPI_I2C_FIFO_DEPTH			32
+
+#define MAX_CAPI_I2C_DMA_TIMEOUT			1000
+#define MAX_CAPI_I2C_DMA_CALLBACK_CLEANUP_TIMEOUT	10000
+
+enum max_capi_i2c_speed {
+	/** 100 kHz */
+	MAX_CAPI_I2C_SPEED_STANDARD =	 100000,
+	/** 400 kHz */
+	MAX_CAPI_I2C_SPEED_FAST = 	 400000,
+	/** 1 MHz */
+	MAX_CAPI_I2C_SPEED_FAST_PLUS =	1000000,
+	/** 3.4 MHz - NOT SUPPORTED */
+	MAX_CAPI_I2C_SPEED_HIGH =	3400000,
+	/** 5 MHz - NOT SUPPORTED */
+	MAX_CAPI_I2C_SPEED_ULTRA =	5000000,
+};
+
+enum max_capi_i2c_target_state_enum {
+	/** Listening for address */
+	MAX_CAPI_I2C_TARGET_STATE_IDLE,
+	/** Receiving from controller */
+	MAX_CAPI_I2C_TARGET_STATE_RX,
+	/** Transmitting to controller */
+	MAX_CAPI_I2C_TARGET_STATE_TX,
+};
+
+struct max_capi_i2c_target_state {
+	/** Target mode active */
+	bool enabled;
+	/** Target address */
+	uint16_t address;
+	/** 10-bit address */
+	bool b10addr;
+	/** State enum */
+	enum max_capi_i2c_target_state_enum state;
+	/** Temporary RX buffer */
+	uint8_t rx_buffer[MAX_CAPI_I2C_TARGET_RX_BUFFER_SIZE];
+	/** Bytes received */
+	uint16_t rx_count;
+	/** TX data from callback */
+	const uint8_t *tx_buffer;
+	/** Bytes transmitted */
+	uint16_t tx_count;
+	/** Total TX length */
+	uint16_t tx_length;
+};
+
+enum max_capi_i2c_async_state_enum {
+	/** No async in progress */
+	MAX_CAPI_I2C_ASYNC_STATE_IDLE,
+	/** Transmitting sub-address */
+	MAX_CAPI_I2C_ASYNC_STATE_TX_SUBADDR,
+	/** Transmitting data */
+	MAX_CAPI_I2C_ASYNC_STATE_TX_DATA,
+	/** Receiving data */
+	MAX_CAPI_I2C_ASYNC_STATE_RX_DATA,
+	/** Waiting for transaction completion */
+	MAX_CAPI_I2C_ASYNC_STATE_WAIT_DONE,
+	/** Error occurred */
+	MAX_CAPI_I2C_ASYNC_STATE_ERROR,
+};
+
+struct max_capi_i2c_async_state {
+	/** Async state */
+	volatile enum max_capi_i2c_async_state_enum state;
+	/** Target I2C address */
+	uint16_t target_addr;
+	/** Sub-address buffer */
+	uint8_t *subaddr_buf;
+	/** Sub-address length remaining */
+	uint16_t subaddr_len;
+	/** Sub-address write index */
+	uint16_t subaddr_idx;
+	/** Data buffer */
+	uint8_t *data_buf;
+	/** Data length remaining */
+	uint16_t data_len;
+	/** Data read/write index */
+	uint16_t data_idx;
+	/** Send STOP condition */
+	bool send_stop;
+	/** Operation result (0 on success, negative error code otherwise) */
+	int result;
+	/** Transmit (true), or Receive (false) */
+	bool is_transmit;
+	/** DMA allocated buffer storage */
+	uint8_t *dma_allocated_buffer;
+};
+
+struct max_capi_i2c_priv {
+	/** I2C controller handle */
+	struct capi_i2c_controller_handle *i2c_handle;
+	/** I2C device ID; only 0 is valid for MAX32657 */
+	uint32_t identifier;
+	/** DMA controller handle */
+	struct capi_dma_handle *dma_handle;
+	/** For storing the platform-specific config */
+	struct max_capi_i2c_extra *extra;
+	/** DMA callback function */
+	capi_i2c_callback callback;
+	/** DMA callback arg */
+	void *callback_arg;
+	/** Flag to prevent DMA race condition */
+	volatile bool callback_active;
+	/** Clock frequency in Hz */
+	uint32_t freq;
+	/** Target mode state */
+	struct max_capi_i2c_target_state *target;
+	/** Async state */
+	struct max_capi_i2c_async_state *async;
+};
+
+struct max_capi_i2c_extra {
+	/** Voltage level of the I3C peripheral */
+	enum max_capi_gpio_vssel vssel;
+	/** OPTIONAL - DMA config parameters */
+	struct capi_dma_config *dma_config;
+};
+
+extern const struct capi_i2c_ops max_capi_i2c_ops;
+
+#endif /* MAXIM_CAPI_I2C_H_ */

--- a/capi/platform/maxim/max32657/maxim_capi_irq.c
+++ b/capi/platform/maxim/max32657/maxim_capi_irq.c
@@ -1,0 +1,836 @@
+/***************************************************************************/ /*
+*   @file   maxim_capi_irq.c
+*   @brief  Implementation of IRQ functions with CAPI.
+*   @author Ramon Miguel Imbao (ramonmiguel.imbao@analog.com)
+********************************************************************************
+* Copyright 2026(c) Analog Devices, Inc.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+*
+* 3. Neither the name of Analog Devices, Inc. nor the names of its
+*    contributors may be used to endorse or promote products derived from this
+*    software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+* EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+* OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+* LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+* NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+* EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <string.h>
+#include <errno.h>
+#include "maxim_capi_gpio.h"
+#include "maxim_capi_irq.h"
+#include "max32657.h"
+#include "gpio.h"
+#include "uart.h"
+#include "rtc.h"
+#include "tmr.h"
+#include "dma.h"
+#include "spi.h"
+#include "wdt.h"
+#include "i3c.h"
+
+/** Static variables **********************************************************/
+
+static bool irq_initialized = false;
+static struct max_capi_irq_entry irq_table[MXC_IRQ_COUNT];
+static struct max_capi_irq_entry gpio_irq_table[MXC_CFG_GPIO_PINS_PORT];
+static uint32_t default_priority = 0;
+
+/** Helper functions ***********************************************************/
+
+/**
+ * @brief Check if IRQ is valid
+ * @param irq - the IRQ to check
+ * @return true if valid, false if not
+ */
+static inline bool _max_capi_irq_is_valid_irq(uint32_t irq)
+{
+	return irq < MXC_IRQ_COUNT;
+}
+
+/**
+ * @brief Check if IRQ is GPIO0 port interrupt
+ * @param irq - the IRQ to check
+ * @return true if GPIO0_IRQn, false if not
+ */
+static inline bool _max_capi_irq_is_gpio_irq(uint32_t irq)
+{
+	return irq == (uint32_t)GPIO0_IRQn;
+}
+
+/** Function implementations **************************************************/
+
+/**
+ * @brief Initialize the IRQ
+ * @param config - IRQ configuration struct
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_irq_init(struct capi_irq_config *config)
+{
+	const struct max_capi_irq_extra_config *extra;
+
+	if (!config)
+		return -EINVAL;
+
+	if (irq_initialized)
+		return -EBUSY;
+
+	/* Clear callback tables */
+	memset(irq_table, 0, sizeof(irq_table));
+	memset(gpio_irq_table, 0, sizeof(gpio_irq_table));
+
+	if (config->extra) {
+		extra = config->extra;
+		default_priority = extra->default_priority;
+	}
+
+	irq_initialized = true;
+
+	return 0;
+}
+
+/**
+ * @brief Deinitialize the IRQ
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_irq_deinit(void)
+{
+	uint32_t i;
+
+	if (!irq_initialized)
+		return -EINVAL;
+
+	for (i = 0; i < MXC_IRQ_COUNT; i++) {
+		if (irq_table[i].enabled) {
+			NVIC_DisableIRQ((IRQn_Type)i);
+			irq_table[i].enabled = false;
+		}
+		irq_table[i].callback = NULL;
+		irq_table[i].arg = NULL;
+	}
+
+	for (i = 0; i < MXC_CFG_GPIO_PINS_PORT; i++) {
+		gpio_irq_table[i].callback = NULL;
+		gpio_irq_table[i].arg = NULL;
+	}
+
+	irq_initialized = false;
+
+	return 0;
+}
+
+/**
+ * @brief Enable the IRQ globally
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_irq_global_enable(void)
+{
+	if (!irq_initialized)
+		return -EINVAL;
+
+	__enable_irq();
+	return 0;
+}
+
+/**
+ * @brief Disable the IRQ globally
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_irq_global_disable(void)
+{
+	if (!irq_initialized)
+		return -EINVAL;
+
+	__disable_irq();
+	return 0;
+}
+
+/**
+ * @brief Enable an IRQ
+ * @param irq - the IRQ number to enable
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_irq_enable(uint32_t irq)
+{
+	if (!irq_initialized)
+		return -EINVAL;
+
+	if (!_max_capi_irq_is_valid_irq(irq))
+		return -EINVAL;
+
+	if (!irq_table[irq].enabled && !NVIC_GetEnableIRQ(irq))
+		NVIC_SetPriority(irq, default_priority);
+
+	NVIC_EnableIRQ(irq);
+	irq_table[irq].enabled = true;
+
+	return 0;
+}
+
+/**
+ * @brief Disable an IRQ
+ * @param irq - the IRQ to disable
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_irq_disable(uint32_t irq)
+{
+	if (!irq_initialized)
+		return -EINVAL;
+
+	if (!_max_capi_irq_is_valid_irq(irq))
+		return -EINVAL;
+
+	NVIC_DisableIRQ(irq);
+	irq_table[irq].enabled = false;
+
+	return 0;
+}
+
+/**
+ * @brief Connect an IRQ to a callback. Does not automatically enable it.
+ * @param irq - the IRQ to connect to
+ * @param isr - the callback function to connect to the IRQ
+ * @param arg - the arguments to pass to the callback function
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_irq_connect(uint32_t irq, capi_isr_callback_t isr, void *arg)
+{
+	int ret;
+
+	if (!irq_initialized)
+		return -EINVAL;
+
+	if (!isr)
+		return -EINVAL;
+
+	if (!_max_capi_irq_is_valid_irq(irq))
+		return -EINVAL;
+
+	irq_table[irq].callback = isr;
+	irq_table[irq].arg = arg;
+
+	switch (irq) {
+	case RTC_IRQn:
+		ret = MXC_RTC_EnableInt(MXC_RTC_INT_FL_LONG |
+					MXC_RTC_INT_FL_SHORT |
+					MXC_RTC_INT_FL_READY);
+		if (ret)
+			return -EBUSY;
+		break;
+	case TMR0_IRQn:
+		MXC_TMR_EnableInt(MXC_TMR0);
+		break;
+	case TMR1_IRQn:
+		MXC_TMR_EnableInt(MXC_TMR1);
+		break;
+	case TMR2_IRQn:
+		MXC_TMR_EnableInt(MXC_TMR2);
+		break;
+	case TMR3_IRQn:
+		MXC_TMR_EnableInt(MXC_TMR3);
+		break;
+	case TMR4_IRQn:
+		MXC_TMR_EnableInt(MXC_TMR4);
+		break;
+	case TMR5_IRQn:
+		MXC_TMR_EnableInt(MXC_TMR5);
+		break;
+	default:
+		break;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Clear a pending IRQ
+ * @param irq - the IRQ to clear
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_irq_clear_pending(uint32_t irq)
+{
+	if (!irq_initialized)
+		return -EINVAL;
+
+	if (!_max_capi_irq_is_valid_irq(irq))
+		return -EINVAL;
+
+	NVIC_ClearPendingIRQ(irq);
+
+	return 0;
+}
+
+/**
+ * @brief Get the status of an IRQ
+ * @param irq - the IRQ
+ * @param pactive - pointer to where the status will be stored
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_irq_get_status(uint32_t irq, uint32_t *pactive)
+{
+	if (!irq_initialized)
+		return -EINVAL;
+
+	if (!_max_capi_irq_is_valid_irq(irq) || !pactive)
+		return -EINVAL;
+
+	*pactive = NVIC_GetPendingIRQ(irq) || NVIC_GetActive(irq);
+
+	return 0;
+}
+
+/**
+ * @brief Set the priority of an IRQ
+ * @param irq - the IRQ
+ * @param priority - the priority
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_irq_set_priority(uint32_t irq, uint32_t priority)
+{
+	if (!irq_initialized)
+		return -EINVAL;
+
+	if (!_max_capi_irq_is_valid_irq(irq))
+		return -EINVAL;
+
+	NVIC_SetPriority(irq, priority);
+
+	return 0;
+}
+
+/**
+ * @brief Get the priority of an IRQ
+ * @param irq - the IRQ
+ * @param priority - pointer to where the priority will be stored
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_irq_get_priority(uint32_t irq, uint32_t *priority)
+{
+	if (!irq_initialized)
+		return -EINVAL;
+
+	if (!_max_capi_irq_is_valid_irq(irq))
+		return -EINVAL;
+
+	*priority = NVIC_GetPriority(irq);
+
+	return 0;
+}
+
+/**
+ * @brief Set the level/edge trigger for all pins on the GPIO IRQ. If other IRQs
+ * 	  are specified, the function will return -ENOTSUP.
+ * @param irq - the IRQ
+ * @param trigger - the level/edge trigger
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_irq_set_level_edge_trigger(uint32_t irq,
+					enum capi_irq_trig_level trigger)
+{
+	mxc_gpio_cfg_t config;
+	int32_t trig;
+
+	if (!irq_initialized)
+		return -EINVAL;
+
+	if (!_max_capi_irq_is_valid_irq(irq))
+		return -EINVAL;
+
+	if (!_max_capi_irq_is_gpio_irq(irq))
+		return -ENOTSUP;
+
+	switch (trigger) {
+	case CAPI_IRQ_EDGE_RISING:
+		trig = MXC_GPIO_INT_RISING;
+		break;
+	case CAPI_IRQ_EDGE_FALLING:
+		trig = MXC_GPIO_INT_FALLING;
+		break;
+	case CAPI_IRQ_EDGE_BOTH:
+		trig = MXC_GPIO_INT_BOTH;
+		break;
+	case CAPI_IRQ_LEVEL_LOW:
+		trig = MXC_GPIO_INT_LOW;
+		break;
+	case CAPI_IRQ_LEVEL_HIGH:
+		trig = MXC_GPIO_INT_HIGH;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	config = (mxc_gpio_cfg_t) {
+		.port = MXC_GPIO_GET_GPIO(0),
+		/**
+		 * Let's set the trigger for all the pins for now since there is
+		 * no mechanism to select the pin with capi_irq_set_level_edge_trigger
+		 **/
+		.mask = 0xFFFFFFFF,
+		.func = MXC_GPIO_FUNC_IN,
+	};
+	MXC_GPIO_IntConfig(&config, trig);
+
+	return 0;
+}
+
+/** Platform-specific functions ***********************************************/
+
+/**
+ * @brief Callback for DMA
+ * @param ch DMA channel
+ * @param reason Not used
+ */
+void max_capi_dma_callback(int ch, int reason)
+{
+	IRQn_Type irq;
+
+	switch (ch) {
+	case 0:
+		irq = DMA1_CH0_IRQn;
+		break;
+	case 1:
+		irq = DMA1_CH1_IRQn;
+		break;
+	case 2:
+		irq = DMA1_CH2_IRQn;
+		break;
+	case 3:
+		irq = DMA1_CH3_IRQn;
+		break;
+	default:
+		return;
+	}
+
+	if (irq_table[irq].callback)
+		irq_table[irq].callback(irq_table[irq].arg);
+}
+
+/**
+ * @brief Connect a GPIO pin to a callback
+ * @param pin - the GPIO pin
+ * @param isr - the callback function to connect to the IRQ
+ * @param arg - the arguments to pass to the callback function
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_gpio_irq_connect(struct capi_gpio_pin *pin,
+			      capi_isr_callback_t isr, void *arg)
+{
+	mxc_gpio_cfg_t config;
+	struct max_capi_gpio_port_priv *gpio_priv;
+
+	if (!irq_initialized)
+		return -EINVAL;
+
+	if (!pin || !pin->port_handle || !pin->port_handle->priv || !isr)
+		return -EINVAL;
+
+	if (pin->number >= MXC_CFG_GPIO_PINS_PORT)
+		return -EINVAL;
+
+	gpio_priv = pin->port_handle->priv;
+
+	config = (mxc_gpio_cfg_t) {
+		.port = MXC_GPIO_GET_GPIO(gpio_priv->id),
+		.mask = (1U << pin->number),
+	};
+
+	gpio_irq_table[pin->number].callback = isr;
+	gpio_irq_table[pin->number].arg = arg;
+
+	MXC_GPIO_RegisterCallback(&config, gpio_irq_table[pin->number].callback,
+				  gpio_irq_table[pin->number].arg);
+
+	return 0;
+}
+
+/**
+ * @brief Disconnect a GPIO from a callback
+ * @param pin - the GPIO pin
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_gpio_irq_disconnect(const struct capi_gpio_pin *pin)
+{
+	if (!irq_initialized)
+		return -EINVAL;
+
+	if (!pin)
+		return -EINVAL;
+
+	if (pin->number >= MXC_CFG_GPIO_PINS_PORT)
+		return -EINVAL;
+
+	if (gpio_irq_table[pin->number].enabled)
+		gpio_irq_table[pin->number].enabled = false;
+
+	gpio_irq_table[pin->number].callback = NULL;
+	gpio_irq_table[pin->number].arg = NULL;
+
+	return 0;
+}
+
+/**
+ * @brief Enable an interrupt on a specific pin
+ * @param pin - the GPIO pin
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_gpio_irq_enable(struct capi_gpio_pin *pin)
+{
+	struct max_capi_gpio_port_priv *gpio_priv;
+
+	if (!irq_initialized)
+		return -EINVAL;
+
+	if (!pin || !pin->port_handle || !pin->port_handle->priv)
+		return -EINVAL;
+
+	if (pin->number >= MXC_CFG_GPIO_PINS_PORT)
+		return -EINVAL;
+
+	gpio_priv = pin->port_handle->priv;
+
+	MXC_GPIO_EnableInt(MXC_GPIO_GET_GPIO(gpio_priv->id),
+			   (1U << pin->number));
+	gpio_irq_table[pin->number].enabled = true;
+
+	return 0;
+}
+
+/**
+ * @brief Disable an interrupt on a specific pin
+ * @param pin - the GPIO pin
+ * @return 0 on success, negative error code oherwise
+ */
+int max_capi_gpio_irq_disable(struct capi_gpio_pin *pin)
+{
+	struct max_capi_gpio_port_priv *gpio_priv;
+
+	if (!irq_initialized)
+		return -EINVAL;
+
+	if (!pin || !pin->port_handle || !pin->port_handle->priv)
+		return -EINVAL;
+
+	if (pin->number >= MXC_CFG_GPIO_PINS_PORT)
+		return -EINVAL;
+
+	gpio_priv = pin->port_handle->priv;
+
+	MXC_GPIO_DisableInt(MXC_GPIO_GET_GPIO(gpio_priv->id),
+			    (1U << pin->number));
+	gpio_irq_table[pin->number].enabled = false;
+
+	return 0;
+}
+
+/**
+ * @brief Set level/edge trigger for a specific pin
+ * @param pin - the GPIO pin
+ * @param trigger  - the trigger to set the pin to
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_gpio_irq_set_level_edge_trigger(struct capi_gpio_pin *pin,
+		enum capi_irq_trig_level trigger)
+{
+	mxc_gpio_cfg_t config;
+	mxc_gpio_int_pol_t trig;
+	struct max_capi_gpio_port_priv *gpio_priv;
+
+	if (!irq_initialized)
+		return -EINVAL;
+
+	if (!pin || !pin->port_handle || !pin->port_handle->priv)
+		return -EINVAL;
+
+	if (pin->number >= MXC_CFG_GPIO_PINS_PORT)
+		return -EINVAL;
+
+	switch (trigger) {
+	case CAPI_IRQ_LEVEL_LOW:
+		trig = MXC_GPIO_INT_LOW;
+		break;
+	case CAPI_IRQ_LEVEL_HIGH:
+		trig = MXC_GPIO_INT_HIGH;
+		break;
+	case CAPI_IRQ_EDGE_FALLING:
+		trig = MXC_GPIO_INT_FALLING;
+		break;
+	case CAPI_IRQ_EDGE_RISING:
+		trig = MXC_GPIO_INT_RISING;
+		break;
+	case CAPI_IRQ_EDGE_BOTH:
+		trig = MXC_GPIO_INT_BOTH;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	gpio_priv = pin->port_handle->priv;
+
+	config = (mxc_gpio_cfg_t) {
+		.port = MXC_GPIO_GET_GPIO(gpio_priv->id),
+		.mask = (1U << pin->number),
+	};
+
+	MXC_GPIO_IntConfig(&config, trig);
+
+	return 0;
+}
+
+/**
+ * @brief Enable interrupts on all pins
+ * @return 0
+ */
+int max_capi_gpio_irq_global_enable(void)
+{
+	MXC_GPIO_EnableInt(MXC_GPIO_GET_GPIO(0), 0xFFFFFFFF);
+
+	return 0;
+}
+
+/**
+ * @brief Disable interrupts on all pins
+ * @return 0
+ */
+int max_capi_gpio_irq_global_disable(void)
+{
+	MXC_GPIO_DisableInt(MXC_GPIO_GET_GPIO(0), 0xFFFFFFFF);
+
+	return 0;
+}
+
+/** Peripheral IRQ Handlers ***************************************************/
+
+void UART_IRQHandler()
+{
+	if (irq_table[UART_IRQn].callback)
+		irq_table[UART_IRQn].callback(irq_table[UART_IRQn].arg);
+	else
+		MXC_UART_AsyncHandler(MXC_UART);
+}
+
+void _dma_handler(mxc_dma_regs_t *dma, uint32_t channel)
+{
+	IRQn_Type irq;
+
+	switch (channel) {
+	case 0:
+		irq = DMA1_CH0_IRQn;
+		break;
+	case 1:
+		irq = DMA1_CH1_IRQn;
+		break;
+	case 2:
+		irq = DMA1_CH2_IRQn;
+		break;
+	case 3:
+		irq = DMA1_CH3_IRQn;
+		break;
+	default:
+		return;
+	}
+
+	if (irq_table[irq].callback)
+		irq_table[irq].callback(irq_table[irq].arg);
+
+	MXC_DMA_Handler(dma);
+}
+
+void DMA1_CH0_IRQHandler()
+{
+	_dma_handler(MXC_DMA1_S, 0);
+}
+
+void DMA1_CH1_IRQHandler()
+{
+	_dma_handler(MXC_DMA1_S, 1);
+}
+
+void DMA1_CH2_IRQHandler()
+{
+	_dma_handler(MXC_DMA1_S, 2);
+}
+
+void DMA1_CH3_IRQHandler()
+{
+	_dma_handler(MXC_DMA1_S, 3);
+}
+
+void RTC_IRQHandler()
+{
+	if (irq_table[RTC_IRQn].callback)
+		irq_table[RTC_IRQn].callback(irq_table[RTC_IRQn].arg);
+
+	MXC_RTC_ClearFlags(MXC_RTC_INT_FL_LONG |
+			   MXC_RTC_INT_FL_SHORT |
+			   MXC_RTC_INT_FL_READY);
+}
+
+void _timer_handler(mxc_tmr_regs_t *tmr)
+{
+	uint32_t irq = MXC_TMR_GET_IRQ(MXC_TMR_GET_IDX(tmr));
+	if (irq_table[irq].callback)
+		irq_table[irq].callback(irq_table[irq].arg);
+
+	MXC_TMR_ClearFlags(tmr);
+}
+
+#ifdef MXC_TMR0
+void TMR0_IRQHandler()
+{
+	_timer_handler(MXC_TMR0);
+}
+#endif /* MXC_TMR0 */
+
+#ifdef MXC_TMR1
+void TMR1_IRQHandler()
+{
+	_timer_handler(MXC_TMR1);
+}
+#endif /* MXC_TMR1 */
+
+#ifdef MXC_TMR2
+void TMR2_IRQHandler()
+{
+	_timer_handler(MXC_TMR2);
+}
+#endif /* MXC_TMR2 */
+
+#ifdef MXC_TMR3
+void TMR3_IRQHandler()
+{
+	_timer_handler(MXC_TMR3);
+}
+#endif /* MXC_TMR3 */
+
+#ifdef MXC_TMR4
+void TMR4_IRQHandler()
+{
+	_timer_handler(MXC_TMR4);
+}
+#endif /* MXC_TMR4 */
+
+#ifdef MXC_TMR5
+void TMR5_IRQHandler()
+{
+	_timer_handler(MXC_TMR5);
+}
+#endif /* MXC_TMR5 */
+
+void GPIO0_IRQHandler()
+{
+	MXC_GPIO_Handler(0);
+
+	if (irq_table[GPIO0_IRQn].callback)
+		irq_table[GPIO0_IRQn].callback(irq_table[GPIO0_IRQn].arg);
+}
+
+void SPI_IRQHandler()
+{
+	if (irq_table[SPI_IRQn].callback)
+		irq_table[SPI_IRQn].callback(irq_table[SPI_IRQn].arg);
+	else
+		MXC_SPI_ClearFlags(MXC_SPI_GET_SPI(0));
+}
+
+void WDT_IRQHandler()
+{
+	if (MXC_WDT->ctrl & (MXC_F_WDT_CTRL_CLKRDY_IE | MXC_F_WDT_CTRL_CLKRDY))
+		MXC_WDT->ctrl &= ~MXC_F_WDT_CTRL_CLKRDY_IE;
+
+	MXC_WDT_ClearIntFlag(MXC_WDT);
+	MXC_WDT_ClearResetFlag(MXC_WDT);
+
+	if (irq_table[WDT_IRQn].callback)
+		irq_table[WDT_IRQn].callback(irq_table[WDT_IRQn].arg);
+}
+
+void TRNG_IRQHandler()
+{
+	if (irq_table[TRNG_IRQn].callback)
+		irq_table[TRNG_IRQn].callback(irq_table[TRNG_IRQn].arg);
+}
+
+void I3C_IRQHandler()
+{
+	if (irq_table[I3C_IRQn].callback)
+		irq_table[I3C_IRQn].callback(irq_table[I3C_IRQn].arg);
+}
+
+/** CAPI functions implementation **********************************************/
+
+int capi_irq_init(struct capi_irq_config *config)
+{
+	return max_capi_irq_init(config);
+}
+
+int capi_irq_deinit(void)
+{
+	return max_capi_irq_deinit();
+}
+
+int capi_irq_global_enable(void)
+{
+	return max_capi_irq_global_enable();
+}
+
+int capi_irq_global_disable(void)
+{
+	return max_capi_irq_global_disable();
+}
+
+int capi_irq_enable(uint32_t irq)
+{
+	return max_capi_irq_enable(irq);
+}
+
+int capi_irq_disable(uint32_t irq)
+{
+	return max_capi_irq_disable(irq);
+}
+
+int capi_irq_connect(uint32_t irq, capi_isr_callback_t isr, void *arg)
+{
+	return max_capi_irq_connect(irq, isr, arg);
+}
+
+int capi_irq_clear_pending(uint32_t irq)
+{
+	return max_capi_irq_clear_pending(irq);
+}
+
+int capi_irq_get_status(uint32_t irq, uint32_t *pactive)
+{
+	return max_capi_irq_get_status(irq, pactive);
+}
+
+int capi_irq_set_priority(uint32_t irq, uint32_t priority)
+{
+	return max_capi_irq_set_priority(irq, priority);
+}
+
+int capi_irq_get_priority(uint32_t irq, uint32_t *priority)
+{
+	return max_capi_irq_get_priority(irq, priority);
+}
+
+int capi_irq_set_level_edge_trigger(uint32_t irq,
+				    enum capi_irq_trig_level trigger)
+{
+	return max_capi_irq_set_level_edge_trigger(irq, trigger);
+}

--- a/capi/platform/maxim/max32657/maxim_capi_irq.h
+++ b/capi/platform/maxim/max32657/maxim_capi_irq.h
@@ -1,0 +1,68 @@
+/***************************************************************************//**
+ *   @file   maxim_capi_irq.h
+ *   @brief  Header file for IRQ functions with CAPI.
+ *   @author Ramon Miguel Imbao (ramonmiguel.imbao@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef MAXIM_CAPI_IRQ_H_
+#define MAXIM_CAPI_IRQ_H_
+
+#include "uart.h"
+#include "capi_gpio.h"
+#include "capi_irq.h"
+
+struct max_capi_irq_entry {
+	/** Callback function */
+	capi_isr_callback_t callback;
+	/** Callback argument */
+	void *arg;
+	/* IRQ enabled flag */
+	bool enabled;
+};
+
+struct max_capi_irq_extra_config {
+	uint32_t default_priority;
+};
+
+extern const struct capi_irq_ops max_capi_irq_ops;
+
+void max_capi_dma_callback(int ch, int reason);
+
+int max_capi_gpio_irq_connect(struct capi_gpio_pin *pin,
+			      capi_isr_callback_t isr, void *arg);
+int max_capi_gpio_irq_disconnect(const struct capi_gpio_pin *pin);
+int max_capi_gpio_irq_enable(struct capi_gpio_pin *pin);
+int max_capi_gpio_irq_disable(struct capi_gpio_pin *pin);
+int max_capi_gpio_irq_set_level_edge_trigger(struct capi_gpio_pin *pin,
+		enum capi_irq_trig_level trigger);
+int max_capi_gpio_irq_global_enable(void);
+int max_capi_gpio_irq_global_disable(void);
+
+#endif /* MAXIM_CAPI_IRQ_H_ */

--- a/capi/platform/maxim/max32657/maxim_capi_rtc.c
+++ b/capi/platform/maxim/max32657/maxim_capi_rtc.c
@@ -1,0 +1,649 @@
+/*******************************************************************************
+ *   @file   maxim_capi_rtc.c
+ *   @brief  Implementation of RTC functions
+ *   @author Ramon Miguel Imbao (ramonmiguel.imbao@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <errno.h>
+#include "maxim_capi_irq.h"
+#include "maxim_capi_rtc.h"
+#include "rtc.h"
+
+/** Static variables **********************************************************/
+
+static struct capi_rtc_handle *rtc = NULL;
+
+/** Forward declarations ******************************************************/
+
+void max_capi_rtc_isr(void *handle);
+
+/** Function implementations **************************************************/
+
+/**
+ * @brief Initialize the RTC peripheral
+ * @param handle Pointer to RTC handle pointer
+ * @param config RTC configuration
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_rtc_init(struct capi_rtc_handle **handle,
+		      struct capi_rtc_config *config)
+{
+	int ret;
+	struct capi_rtc_handle *rtc_handle;
+	struct max_capi_rtc_priv *rtc_priv;
+	const struct max_capi_rtc_extra *rtc_extra;
+	uint32_t actual_freq;
+
+	if (!handle || !config)
+		return -EINVAL;
+
+	if (rtc != NULL) {
+		*handle = rtc;
+		return 0;
+	}
+
+	if (config->initial_subsec >= MXC_RTC_MAX_SSEC)
+		return -EINVAL;
+
+	if (*handle == NULL) {
+		rtc_handle = capi_calloc(1, sizeof(*rtc_handle));
+		if (!rtc_handle)
+			return -ENOMEM;
+		rtc_handle->init_allocated = true;
+	} else {
+		rtc_handle = *handle;
+		rtc_handle->init_allocated = false;
+	}
+
+	rtc_priv = capi_calloc(1, sizeof(*rtc_priv));
+	if (!rtc_priv) {
+		ret = -ENOMEM;
+		goto free_handle;
+	}
+
+	ret = MXC_RTC_Init(config->initial_sec, config->initial_subsec);
+	if (ret) {
+		ret = -EIO;
+		goto free_priv;
+	}
+
+	rtc_priv->freq = config->freq ? config->freq : 32768;
+	rtc_priv->measure_freq = false;
+	rtc_priv->callback = NULL;
+	rtc_priv->event_ctx = NULL;
+	rtc_priv->events_enabled = 0;
+	rtc_priv->is_running = false;
+
+	if (config->extra) {
+		rtc_extra = config->extra;
+		rtc_priv->measure_freq = rtc_extra->measure_freq;
+	}
+
+	if (rtc_priv->measure_freq) {
+		actual_freq = MXC_RTC_TrimCrystal();
+		if (actual_freq > 0)
+			rtc_priv->freq = actual_freq;
+	}
+
+	rtc_handle->ops = config->ops;
+	rtc_handle->priv = rtc_priv;
+
+	struct capi_irq_config irq_config = {
+		.irq_ctrl_id = 0,
+	};
+
+	ret = capi_irq_init(&irq_config);
+	if (ret && ret != -EBUSY) {
+		/* -EBUSY means IRQ already initialized, which is fine since
+		   it uses a singleton pattern. */
+		goto free_priv;
+	}
+
+	ret = capi_irq_connect(RTC_IRQn, max_capi_rtc_isr, rtc_handle);
+	if (ret)
+		goto free_priv;
+
+	ret = capi_irq_set_priority(RTC_IRQn, config->irq_priority);
+	if (ret)
+		goto free_priv;
+
+	ret = capi_irq_enable(RTC_IRQn);
+	if (ret)
+		goto free_priv;
+
+	rtc = rtc_handle;
+	*handle = rtc_handle;
+
+	return 0;
+
+free_priv:
+	capi_free(rtc_priv);
+free_handle:
+	if (rtc_handle->init_allocated)
+		capi_free(rtc_handle);
+
+	rtc = NULL;
+
+	return ret;
+}
+
+/**
+ * @brief Deinitialize the RTC peripheral
+ * @param handle The RTC handle
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_rtc_deinit(struct capi_rtc_handle *handle)
+{
+	int ret;
+	struct max_capi_rtc_priv *rtc_priv;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	if (handle != rtc)
+		return -EINVAL;
+
+	rtc_priv = handle->priv;
+
+	MXC_RTC_DisableInt(MXC_RTC_INT_EN_LONG |
+			   MXC_RTC_INT_EN_SHORT |
+			   MXC_RTC_INT_EN_READY);
+	capi_irq_disable(RTC_IRQn);
+
+	ret = MXC_RTC_Stop();
+
+	capi_free(rtc_priv);
+
+	if (handle->init_allocated)
+		capi_free(handle);
+
+	rtc = NULL;
+
+	return ret;
+}
+
+/**
+ * @brief Start the RTC
+ * @param handle The RTC handle
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_rtc_start(struct capi_rtc_handle *handle)
+{
+	int ret;
+	struct max_capi_rtc_priv *rtc_priv;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	rtc_priv = handle->priv;
+
+	ret = MXC_RTC_Start();
+	if (ret != E_NO_ERROR)
+		return -EIO;
+
+	rtc_priv->is_running = true;
+
+	return 0;
+}
+
+/**
+ * @brief Stop the RTC
+ * @param handle The RTC handle
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_rtc_stop(struct capi_rtc_handle *handle)
+{
+	int ret;
+	struct max_capi_rtc_priv *rtc_priv;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	rtc_priv = handle->priv;
+
+	ret = MXC_RTC_Stop();
+	if (ret != E_NO_ERROR)
+		return -EIO;
+
+	rtc_priv->is_running = false;
+
+	return 0;
+}
+
+/**
+ * @brief Get the current time
+ * @param handle The RTC handle
+ * @param time Where to store the current time
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_rtc_get_time(struct capi_rtc_handle *handle,
+			  struct capi_rtc_time *time)
+{
+	int ret;
+	uint32_t sec, subsec;
+
+	if (!handle || !time)
+		return -EINVAL;
+
+	ret = MXC_RTC_GetTime(&sec, &subsec);
+	if (ret != E_NO_ERROR)
+		return (ret == E_BUSY) ? -EBUSY : -EIO;
+
+	time->sec = sec;
+	time->subsec = subsec;
+	time->subsec_resolution = MXC_RTC_MAX_SSEC;
+
+	return 0;
+}
+
+/**
+ * @brief Set the current time
+ * @param handle The RTC handle
+ * @param time The time struct
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_rtc_set_time(struct capi_rtc_handle *handle,
+			  const struct capi_rtc_time *time)
+{
+	int ret;
+	const struct max_capi_rtc_priv *rtc_priv;
+
+	if (!handle || !handle->priv || !time)
+		return -EINVAL;
+
+	if (time->subsec >= MXC_RTC_MAX_SSEC)
+		return -EINVAL;
+
+	rtc_priv = handle->priv;
+
+	ret = MXC_RTC_Stop();
+	if (ret != E_NO_ERROR)
+		return -EIO;
+
+	ret = MXC_RTC_Init(time->sec, time->subsec);
+	if (ret != E_NO_ERROR)
+		return -EIO;
+
+	if (rtc_priv->is_running) {
+		ret = MXC_RTC_Start();
+		if (ret != E_NO_ERROR)
+			return -EIO;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Get the current datetime - not supported since the MAX32657 does not
+ * 	  have calendar-related functions
+ * @param handle The RTC handle
+ * @param datetime Where to store the datetime
+ * @return -ENOSYS
+ */
+int max_capi_rtc_get_datetime(struct capi_rtc_handle *handle,
+			      struct capi_rtc_datetime *datetime)
+{
+	return -ENOSYS;
+}
+
+/**
+ * @brief Set the current datetime - not supported since the MAX32657 does not
+ * 	  have calendar-related functions
+ * @param handle The RTC handle
+ * @param datetime The datetime struct
+ * @return -ENOSYS
+ */
+int max_capi_rtc_set_datetime(struct capi_rtc_handle *handle,
+			      const struct capi_rtc_datetime *datetime)
+{
+	return -ENOSYS;
+}
+
+/**
+ * @brief Set an alarm
+ * @param handle The RTC handle
+ * @param type Alarm type
+ * @param alarm_value Pointer to alarm value
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_rtc_set_alarm(struct capi_rtc_handle *handle,
+			   enum capi_rtc_alarm_type type,
+			   const void *alarm_value)
+{
+	int ret;
+
+	if (!handle || !alarm_value)
+		return -EINVAL;
+
+	switch (type) {
+	case CAPI_RTC_ALARM_TIME:
+		const struct capi_rtc_time *alarm = alarm_value;
+
+		if (alarm->sec > MXC_F_RTC_TODA_TOD_ALARM)
+			return -EINVAL;
+
+		ret = MXC_RTC_SetTimeofdayAlarm(alarm->sec);
+		if (ret != E_NO_ERROR)
+			return -EIO;
+
+		return 0;
+
+	case CAPI_RTC_ALARM_SUBSEC:
+		const uint32_t *subsec = alarm_value;
+
+		ret = MXC_RTC_SetSubsecondAlarm(subsec);
+		if (ret != E_NO_ERROR)
+			return -EIO;
+
+		return 0;
+
+	case CAPI_RTC_ALARM_DATETIME:
+		return -ENOTSUP;
+
+	default:
+		return -EINVAL;
+	}
+}
+
+/**
+ * @brief Disable an alarm
+ * @param handle The RTC handle
+ * @param type Alarm type
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_rtc_disable_alarm(struct capi_rtc_handle *handle,
+			       enum capi_rtc_alarm_type type)
+{
+	int ret;
+
+	if (!handle)
+		return -EINVAL;
+
+	switch (type) {
+	case CAPI_RTC_ALARM_TIME:
+		ret = MXC_RTC_DisableInt(MXC_RTC_INT_EN_LONG);
+		break;
+	case CAPI_RTC_ALARM_SUBSEC:
+		ret = MXC_RTC_DisableInt(MXC_RTC_INT_EN_SHORT);
+		break;
+	case CAPI_RTC_ALARM_DATETIME:
+		return -ENOTSUP;
+	default:
+		return -EINVAL;
+	}
+
+	if (ret != E_NO_ERROR)
+		return -EIO;
+
+	return 0;
+}
+
+/**
+ * @brief Enable square wave output
+ * @param handle The RTC handle
+ * @param freq The square wave frequency
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_rtc_sqwave_enable(struct capi_rtc_handle *handle,
+			       enum capi_rtc_sqwave_freq freq)
+{
+	int ret;
+	mxc_rtc_freq_sel_t msdk_freq;
+
+	if (!handle)
+		return -EINVAL;
+
+	switch (freq) {
+	case CAPI_RTC_SQWAVE_1HZ:
+		msdk_freq = MXC_RTC_F_1HZ;
+		break;
+	case CAPI_RTC_SQWAVE_512HZ:
+		msdk_freq = MXC_RTC_F_512HZ;
+		break;
+	case CAPI_RTC_SQWAVE_4KHZ:
+		msdk_freq = MXC_RTC_F_4KHZ;
+		break;
+	case CAPI_RTC_SQWAVE_32KHZ:
+		msdk_freq = MXC_RTC_F_32KHZ;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	ret = MXC_RTC_SquareWaveStart(msdk_freq);
+	if (ret != E_NO_ERROR)
+		return -EIO;
+
+	return 0;
+}
+
+/**
+ * @brief Disable square wave output
+ * @param handle The RTC handle
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_rtc_sqwave_disable(struct capi_rtc_handle *handle)
+{
+	int ret;
+
+	if (!handle)
+		return -EINVAL;
+
+	ret = MXC_RTC_SquareWaveStop();
+	if (ret != E_NO_ERROR)
+		return -EIO;
+
+	return 0;
+}
+
+/**
+ * @brief Trim/calibrate the RTC frequency
+ * @param handle The RTC handle
+ * @param trim Trim value
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_rtc_trim(struct capi_rtc_handle *handle, int8_t trim)
+{
+	int ret;
+	struct max_capi_rtc_priv *rtc_priv;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	rtc_priv = handle->priv;
+
+	ret = MXC_RTC_Trim(trim);
+	if (ret != E_NO_ERROR)
+		return -EIO;
+
+	if (rtc_priv->measure_freq) {
+		uint32_t actual_freq = MXC_RTC_TrimCrystal();
+		if (actual_freq > 0)
+			rtc_priv->freq = actual_freq;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Register event callback
+ * @param handle The RTC handle
+ * @param callback Callback function
+ * @param event_ctx Context pointer for callback
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_rtc_register_callback(struct capi_rtc_handle *handle,
+				   capi_rtc_event_callback_t callback,
+				   void *event_ctx)
+{
+	struct max_capi_rtc_priv *rtc_priv;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	rtc_priv = handle->priv;
+	rtc_priv->callback = callback;
+	rtc_priv->event_ctx = event_ctx;
+
+	return 0;
+}
+
+/**
+ * @brief Enable RTC events
+ * @param handle The RTC handle
+ * @param events_mask Bitmask of events to enable
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_rtc_enable_events(struct capi_rtc_handle *handle,
+			       uint32_t events_mask)
+{
+	int ret;
+	struct max_capi_rtc_priv *rtc_priv;
+	uint32_t msdk_mask = 0;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	rtc_priv = handle->priv;
+
+	if (events_mask & (1 << CAPI_RTC_EVENT_ALARM))
+		msdk_mask |= MXC_RTC_INT_EN_LONG;
+	if (events_mask & (1 << CAPI_RTC_EVENT_SUBSEC_ALARM))
+		msdk_mask |= MXC_RTC_INT_EN_SHORT;
+	if (events_mask & (1 << CAPI_RTC_EVENT_READY))
+		msdk_mask |= MXC_RTC_INT_EN_READY;
+
+	ret = MXC_RTC_EnableInt(msdk_mask);
+	if (ret != E_NO_ERROR)
+		return -EIO;
+
+	rtc_priv->events_enabled |= events_mask;
+
+	return 0;
+}
+
+/**
+ * @brief Disable RTC events
+ * @param handle The RTC handle
+ * @param events_mask Bitmask of events to disable
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_rtc_disable_events(struct capi_rtc_handle *handle,
+				uint32_t events_mask)
+{
+	int ret;
+	struct max_capi_rtc_priv *rtc_priv;
+	uint32_t msdk_mask = 0;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	rtc_priv = handle->priv;
+
+	if (events_mask & (1 << CAPI_RTC_EVENT_ALARM))
+		msdk_mask |= MXC_RTC_INT_EN_LONG;
+	if (events_mask & (1 << CAPI_RTC_EVENT_SUBSEC_ALARM))
+		msdk_mask |= MXC_RTC_INT_EN_SHORT;
+	if (events_mask & (1 << CAPI_RTC_EVENT_READY))
+		msdk_mask |= MXC_RTC_INT_EN_READY;
+
+	ret = MXC_RTC_DisableInt(msdk_mask);
+	if (ret != E_NO_ERROR)
+		return -EIO;
+
+	rtc_priv->events_enabled &= ~events_mask;
+
+	return 0;
+}
+
+/**
+ * @brief RTC interrupt handler
+ * @param handle The RTC handle
+ */
+void max_capi_rtc_isr(void *handle)
+{
+	struct capi_rtc_handle *rtc_handle = (struct capi_rtc_handle *)handle;
+	struct max_capi_rtc_priv *rtc_priv;
+	int flags;
+
+	if (!rtc_handle || !rtc_handle->priv)
+		return;
+
+	rtc_priv = rtc_handle->priv;
+
+	flags = MXC_RTC_GetFlags();
+
+	if (flags & MXC_RTC_INT_FL_LONG) {
+		MXC_RTC_ClearFlags(MXC_RTC_INT_FL_LONG);
+
+		if (rtc_priv->callback
+		    && (rtc_priv->events_enabled & (1 << CAPI_RTC_EVENT_ALARM)))
+			rtc_priv->callback(rtc_handle, CAPI_RTC_EVENT_ALARM, rtc_priv->event_ctx);
+	}
+
+	if (flags & MXC_RTC_INT_FL_SHORT) {
+		MXC_RTC_ClearFlags(MXC_RTC_INT_FL_SHORT);
+
+		if (rtc_priv->callback
+		    && (rtc_priv->events_enabled & (1 << CAPI_RTC_EVENT_SUBSEC_ALARM)))
+			rtc_priv->callback(rtc_handle, CAPI_RTC_EVENT_SUBSEC_ALARM,
+					   rtc_priv->event_ctx);
+	}
+
+	if (flags & MXC_RTC_INT_FL_READY) {
+		MXC_RTC_ClearFlags(MXC_RTC_INT_FL_READY);
+
+		if (rtc_priv->callback
+		    && (rtc_priv->events_enabled & (1 << CAPI_RTC_EVENT_READY)))
+			rtc_priv->callback(rtc_handle, CAPI_RTC_EVENT_READY, rtc_priv->event_ctx);
+	}
+}
+
+struct capi_rtc_ops max_capi_rtc_ops = {
+	.init = max_capi_rtc_init,
+	.deinit = max_capi_rtc_deinit,
+	.start = max_capi_rtc_start,
+	.stop = max_capi_rtc_stop,
+	.get_time = max_capi_rtc_get_time,
+	.set_time = max_capi_rtc_set_time,
+	.get_datetime = max_capi_rtc_get_datetime,
+	.set_datetime = max_capi_rtc_set_datetime,
+	.set_alarm = max_capi_rtc_set_alarm,
+	.disable_alarm = max_capi_rtc_disable_alarm,
+	.sqwave_enable = max_capi_rtc_sqwave_enable,
+	.sqwave_disable = max_capi_rtc_sqwave_disable,
+	.trim = max_capi_rtc_trim,
+	.register_callback = max_capi_rtc_register_callback,
+	.enable_events = max_capi_rtc_enable_events,
+	.disable_events = max_capi_rtc_disable_events,
+	.isr = max_capi_rtc_isr,
+};

--- a/capi/platform/maxim/max32657/maxim_capi_rtc.h
+++ b/capi/platform/maxim/max32657/maxim_capi_rtc.h
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ *   @file   maxim_capi_rtc.h
+ *   @brief  Header file for RTC functions
+ *   @author Ramon Miguel Imbao (ramonmiguel.imbao@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef MAXIM_CAPI_RTC_H_
+#define MAXIM_CAPI_RTC_H_
+
+#include "capi_irq.h"
+#include "capi_rtc.h"
+
+struct max_capi_rtc_extra {
+	/** Whether to measure the crystal frequency on startup and during trim */
+	bool measure_freq;
+};
+
+struct max_capi_rtc_priv {
+	/** Frequency in Hz (measured, typically 32768) */
+	uint32_t freq;
+	/** Whether to measure the crystal frequency on startup and during trim */
+	bool measure_freq;
+	/** Event callback function */
+	capi_rtc_event_callback_t callback;
+	/** Context pointer for callback */
+	void *event_ctx;
+	/** Enabled events mask */
+	uint32_t events_enabled;
+	/** RTC running state */
+	bool is_running;
+};
+
+extern const struct capi_rtc_ops max_capi_rtc_ops;
+
+#endif /* MAXIM_CAPI_RTC_H_ */

--- a/capi/platform/maxim/max32657/maxim_capi_spi.c
+++ b/capi/platform/maxim/max32657/maxim_capi_spi.c
@@ -1,0 +1,1233 @@
+/*******************************************************************************
+ *   @file   maxim_capi_spi.c
+ *   @brief  Implementation of SPI functions
+ *   @author Ramon Miguel Imbao (ramonmiguel.imbao@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <stdio.h>
+#include <errno.h>
+#include "capi_spi.h"
+#include "capi_time.h"
+#include "maxim_capi_dma.h"
+#include "maxim_capi_irq.h"
+#include "maxim_capi_spi.h"
+#include "maxim_capi_gpio.h"
+#include "spi.h"
+
+/** Forward declarations ******************************************************/
+
+void max_capi_spi_isr(void *handle);
+
+/** Static variables **********************************************************/
+
+static struct capi_spi_controller_handle *spi[MXC_SPI_INSTANCES] = {NULL};
+static volatile uint8_t dma_completed_count[MXC_SPI_INSTANCES] = {0};
+static struct capi_dma_chan *dma_channel_rx[MXC_SPI_INSTANCES] = {NULL};
+static struct capi_dma_chan *dma_channel_tx[MXC_SPI_INSTANCES] = {NULL};
+/* In capi_spi_transfer, if the transmit buffer is NULL, zeroes will be
+   transmitted and if the receive buffer is NULL, the data is discarded */
+static uint8_t zero_tx[1] = {0};
+static uint8_t zero_rx[1];
+static bool transfer_in_progress[MXC_SPI_INSTANCES] = {false};
+static bool async_transfer_in_progress[MXC_SPI_INSTANCES] = {false};
+
+/** Helper functions **********************************************************/
+
+/**
+ * @brief Configure a SPI peripheral
+ * @param handle The SPI handle
+ * @return 0 in case of success, negative error code otherwise
+ */
+int _max_capi_spi_config(struct capi_spi_controller_handle *handle)
+{
+	int ret;
+	struct max_capi_spi_priv *spi_priv;
+
+	spi_priv = handle->priv;
+	uint8_t spi_id = spi_priv->identifier;
+
+	mxc_spi_pins_t spi_pins_config = {
+		.clock = true,
+		.ss0 = (spi_priv->extra.chip_select & (1 << 0)) ? true : false,
+		.ss1 = (spi_priv->extra.chip_select & (1 << 1)) ? true : false,
+		.ss2 = (spi_priv->extra.chip_select & (1 << 2)) ? true : false,
+		.miso = true,
+		.mosi = true,
+		.sdio2 = false, /* sdio2 and sdio3 are ignored in spi_me30.c */
+		.sdio3 = false,
+		.vddioh = (spi_priv->extra.vssel == MAX_CAPI_GPIO_VSSEL_VDDIOH),
+	};
+
+	ret = MXC_SPI_Init(MXC_SPI_GET_SPI(spi_id),
+			   spi_priv->extra.device_role,
+			   (spi_priv->extra.bus_width == MAX_CAPI_SPI_BUS_WIDTH_QUAD) ? 1 : 0,
+			   spi_priv->extra.num_targets,
+			   spi_priv->extra.polarity_mask,
+			   spi_priv->clock_freq,
+			   spi_pins_config);
+	if (ret < 0) {
+		ret = -EINVAL;
+		goto error;
+	}
+
+	mxc_spi_mode_t spi_mode;
+	if (spi_priv->extra.clock_phase == MAX_CAPI_SPI_CLOCK_PHASE_0) {
+		if (spi_priv->extra.clock_polarity == MAX_CAPI_SPI_CLOCK_POLARITY_0) {
+			spi_mode = SPI_MODE_0;
+		} else if (spi_priv->extra.clock_polarity == MAX_CAPI_SPI_CLOCK_POLARITY_1) {
+			spi_mode = SPI_MODE_1;
+		} else {
+			ret = -EINVAL;
+			goto error;
+		}
+	} else if (spi_priv->extra.clock_phase == MAX_CAPI_SPI_CLOCK_PHASE_1) {
+		if (spi_priv->extra.clock_polarity == MAX_CAPI_SPI_CLOCK_POLARITY_0) {
+			spi_mode = SPI_MODE_2;
+		} else if (spi_priv->extra.clock_polarity == MAX_CAPI_SPI_CLOCK_POLARITY_1) {
+			spi_mode = SPI_MODE_3;
+		} else {
+			ret = -EINVAL;
+			goto error;
+		}
+	} else {
+		ret = -EINVAL;
+		goto error;
+	}
+	ret = MXC_SPI_SetMode(MXC_SPI_GET_SPI(spi_id), spi_mode);
+	if (ret) {
+		ret = -EINVAL;
+		goto error;
+	}
+
+	ret = MXC_SPI_SetWidth(MXC_SPI_GET_SPI(spi_id),
+			       (mxc_spi_width_t)spi_priv->extra.bus_width);
+	if (ret) {
+		ret = -EINVAL;
+		goto error;
+	}
+
+	ret = MXC_SPI_SetDataSize(MXC_SPI_GET_SPI(spi_id), 8);
+	if (ret) {
+		ret = -EINVAL;
+		goto error;
+	}
+
+	return 0;
+
+error:
+	MXC_SPI_Shutdown(MXC_SPI_GET_SPI(spi_id));
+
+	return ret;
+}
+
+/**
+ * @brief Set the closest first and last SCLK delays to what was requested
+ * @param device The SPI device
+ * @param transfer The SPI transfer
+ */
+void _max_capi_delay_config(struct capi_spi_device *device,
+			    struct capi_spi_transfer *transfer)
+{
+	struct capi_spi_controller_handle *spi_handle;
+	struct max_capi_spi_priv *spi_priv;
+	mxc_spi_regs_t *spi_reg;
+	uint32_t spi_freq, ns_per_tick, tstime_cache;
+	uint32_t delay_first_ns, delay_last_ns;
+	uint32_t delay_first_ticks, delay_last_ticks;
+
+	spi_handle = device->controller;
+	spi_priv = spi_handle->priv;
+
+	spi_reg = MXC_SPI_GET_SPI(spi_priv->identifier);
+	tstime_cache = spi_reg->tstime;
+
+	spi_freq = MXC_SPI_GetPeripheralClock(spi_reg);
+	ns_per_tick = (1000000000UL / spi_freq);
+
+	delay_first_ns = spi_priv->extra.platform_delays.cs_delay_first;
+	delay_last_ns = spi_priv->extra.platform_delays.cs_delay_last;
+
+	// TODO: Add transfer->xfer_delay_clk_cycles to these?
+	delay_first_ticks = (delay_first_ns / ns_per_tick);
+	delay_last_ticks = (delay_last_ns / ns_per_tick);
+
+	/** The minimum number of delay ticks is 1. If 0 is written to the
+	 *  tstime register, there would be a delay of 256 ticks.
+	 */
+	if (delay_first_ticks == 0)
+		delay_first_ticks = 1;
+	if (delay_first_ticks > MAX_DELAY_SCLK)
+		goto error;
+	spi_reg->tstime &= ~MXC_F_SPI_TSTIME_PRE;
+	spi_reg->tstime |= (delay_first_ticks << MXC_F_SPI_TSTIME_PRE_POS);
+
+	if (delay_last_ticks == 0)
+		delay_last_ticks = 1;
+	if (delay_last_ticks > MAX_DELAY_SCLK)
+		goto error;
+	spi_reg->tstime &= ~MXC_F_SPI_TSTIME_POST;
+	spi_reg->tstime |= (delay_last_ticks << MXC_F_SPI_TSTIME_POST_POS);
+
+	return;
+error:
+	spi_reg->tstime = tstime_cache;
+}
+
+/**
+ * @brief Get chip select index based on bitmask
+ * @param chip_select Bitmask for chip select from capi_spi_device
+ * @return 0, 1, or 2 on success, negative error code otherwise
+ */
+int _max_capi_spi_get_cs_index(uint16_t chip_select)
+{
+	int cs_index;
+
+	if (chip_select == 0 ||
+	    (chip_select & (chip_select - 1)) != 0) {
+		return -EINVAL;
+	}
+
+	cs_index = __builtin_ctz(chip_select);
+	if (cs_index > 2) {
+		return -EINVAL;
+	}
+
+	return cs_index;
+}
+
+/**
+ * @brief Queues as many bytes as the TX FIFO allows, up to clk_len
+ * @param spi_priv The private structure
+ * @return
+ */
+static bool _max_capi_spi_fifo_fill_tx(struct max_capi_spi_priv *spi_priv)
+{
+	struct max_capi_spi_fifo_async *fifo_async = &spi_priv->fifo_async;
+	mxc_spi_regs_t *spi_reg = MXC_SPI_GET_SPI(spi_priv->identifier);
+	uint32_t written;
+
+	while (fifo_async->tx_cnt < fifo_async->clk_len) {
+		const uint8_t *src;
+		size_t len;
+
+		if (fifo_async->tx_buf && (fifo_async->tx_cnt < fifo_async->tx_size)) {
+			src = &fifo_async->tx_buf[fifo_async->tx_cnt];
+			len = fifo_async->tx_size - fifo_async->tx_cnt;
+		} else {
+			src = zero_tx;
+			len = 1;
+		}
+
+		written = MXC_SPI_WriteTXFIFO(spi_reg, (uint8_t *)src, len);
+		if (written == 0)
+			break;
+
+		fifo_async->tx_cnt += written;
+	}
+
+	return (fifo_async->tx_cnt >= fifo_async->clk_len);
+}
+
+/**
+ * @brief Reads whatever is available in the RX FIFO into rx_buf
+ * @param spi_priv The private structure
+ * @return True when all expected RX bytes have been received (or when there is
+ * 	   no RX buffer), False otherwise
+ */
+static bool _max_capi_spi_fifo_drain_rx(struct max_capi_spi_priv *spi_priv)
+{
+	struct max_capi_spi_fifo_async *fifo_async = &spi_priv->fifo_async;
+	mxc_spi_regs_t *spi_reg = MXC_SPI_GET_SPI(spi_priv->identifier);
+	uint32_t total = fifo_async->rx_skip + fifo_async->rx_size;
+
+	if (!fifo_async->rx_buf)
+		return true;
+
+	while (fifo_async->rx_cnt < total) {
+		uint32_t n;
+
+		if (fifo_async->rx_cnt < fifo_async->rx_skip) {
+			/* Discard RX */
+			n = MXC_SPI_ReadRXFIFO(spi_reg, zero_rx, 1);
+		} else  {
+			uint32_t off = fifo_async->rx_cnt - fifo_async->rx_skip;
+
+			n = MXC_SPI_ReadRXFIFO(spi_reg,
+					       &fifo_async->rx_buf[off],
+					       (total - fifo_async->rx_cnt));
+		}
+
+		if (n == 0)
+			break; /* RX FIFO empty for now */
+
+		fifo_async->rx_cnt += n;
+	}
+
+	return (fifo_async->rx_cnt >= total);
+}
+
+/**
+ * @brief Do a SPI transfer using FIFO
+ * @param device The SPI device
+ * @param transfer The transfer
+ * @param is_async Whether it's async or not
+ * @param read_cmd Whether it's a read command or not
+ * @return 0 on success, negative error code otherwise
+ */
+int _max_capi_spi_transceive_fifo(struct capi_spi_device *device,
+				  struct capi_spi_transfer *transfer,
+				  bool is_async, bool read_cmd)
+{
+	int32_t target_id;
+	int ret;
+	struct capi_spi_controller_handle *spi_handle;
+	struct max_capi_spi_priv *spi_priv;
+	struct max_capi_spi_fifo_async *fifo_async;
+	mxc_spi_regs_t *spi_reg;
+	uint8_t spi_id;
+	uint32_t tx_effective, rx_effective, clk_len;
+	uint32_t target_speed;
+	uint32_t inten;
+	int timeout;
+	bool rx_done, tx_done;
+
+	spi_handle = device->controller;
+	spi_priv = spi_handle->priv;
+	spi_reg = MXC_SPI_GET_SPI(spi_priv->identifier);
+	spi_id = spi_priv->identifier;
+	fifo_async = &spi_priv->fifo_async;
+	timeout = transfer->timeout;
+
+	if (is_async) {
+		if (transfer_in_progress[spi_id])
+			return -EBUSY;
+	} else if (timeout == 0 || timeout == -1) {
+		while (transfer_in_progress[spi_id]);
+	} else {
+		while (transfer_in_progress[spi_id]) {
+			timeout--;
+			if (timeout == 0) {
+				return -ETIMEDOUT;
+			}
+			capi_wait_ms(1);
+		}
+	}
+	transfer_in_progress[spi_id] = true;
+
+	/* Validate only one CS is chosen */
+	target_id = _max_capi_spi_get_cs_index(device->native_cs);
+	if (target_id < 0) {
+		transfer_in_progress[spi_id] = false;
+		return target_id;
+	}
+
+	if (device->max_speed_hz > spi_priv->clock_freq) {
+		transfer_in_progress[spi_id] = false;
+		return -EINVAL;
+	}
+
+	target_speed = device->max_speed_hz
+		       ? device->max_speed_hz
+		       : spi_priv->clock_freq;
+
+	if (target_speed != spi_priv->clock_freq) {
+		ret = MXC_SPI_SetFrequency(spi_reg, target_speed);
+		if (ret < 0) {
+			transfer_in_progress[spi_id] = false;
+			return -EIO;
+		}
+	} else {
+		ret = MXC_SPI_SetFrequency(spi_reg, spi_priv->clock_freq);
+		if (ret < 0) {
+			transfer_in_progress[spi_id] = false;
+			return -EIO;
+		}
+	}
+
+	/* Assert CS when the SPI transaction is started */
+	MXC_SPI_SetSlave(spi_reg, target_id);
+
+	/* Flush the RX and TX FIFOs */
+	spi_reg->dma |= MXC_F_SPI_DMA_RX_FLUSH | MXC_F_SPI_DMA_TX_FLUSH;
+	/* Enable SPI */
+	spi_reg->intfl |= MXC_F_SPI_INTFL_CONT_DONE;
+	spi_reg->ctrl1 = 0;
+
+	if (device->non_continuous_mode)
+		spi_reg->ctrl0 &= ~MXC_F_SPI_CTRL0_TS_CTRL;
+	else
+		spi_reg->ctrl0 |= MXC_F_SPI_CTRL0_TS_CTRL;
+
+	_max_capi_delay_config(device, transfer);
+
+	/*
+	 * In standard full-duplex mode, the number of SCLK characters that are
+	 * clocked out is governed by TX_NUM_CHAR. To receive more bytes than
+	 * are transmitted (rx_size > tx_size), TX_NUM_CHAR must be extended to
+	 * the larger of the two lengths and dummy bytes shifted out to generate
+	 * the additional clocks.
+	 */
+	tx_effective = transfer->tx_buf ? transfer->tx_size : 0;
+	rx_effective = transfer->rx_buf ? transfer->rx_size : 0;
+
+	if (read_cmd) {
+		/* Half duplex */
+		clk_len = tx_effective + rx_effective;
+		fifo_async->rx_skip = transfer->tx_size;
+	} else {
+		clk_len = (rx_effective > tx_effective) ? rx_effective : tx_effective;
+		fifo_async->rx_skip = 0;
+	}
+
+	/* Populate shared transfer state */
+	fifo_async->tx_buf = transfer->tx_buf;
+	fifo_async->rx_buf = transfer->rx_buf;
+	fifo_async->tx_size = transfer->tx_size;
+	fifo_async->rx_size = transfer->rx_size;
+	fifo_async->clk_len = clk_len;
+	fifo_async->tx_cnt = 0;
+	fifo_async->rx_cnt = 0;
+
+	if (clk_len == 0) {
+		if (is_async && spi_priv->callback)
+			spi_priv->callback(CAPI_SPI_EVENT_XFR_DONE,
+					   spi_priv->callback_arg, 0);
+		transfer_in_progress[spi_id] = false;
+		return 0;
+	}
+
+	if (is_async) {
+		async_transfer_in_progress[spi_id] = true;
+		fifo_async->active = true;
+	}
+
+	/* Set the number of characters to clock out (TX direction) */
+	spi_reg->ctrl1 = clk_len;
+	/* Enable the TX FIFO */
+	spi_reg->dma |= MXC_F_SPI_DMA_TX_FIFO_EN;
+
+	if (transfer->rx_buf) {
+		uint32_t rx_num_char = read_cmd ? clk_len : transfer->rx_size;
+
+		/* Set the transfer size in the RX direction */
+		spi_reg->ctrl1 |= (rx_num_char << MXC_F_SPI_CTRL1_RX_NUM_CHAR_POS);
+		/* Enable the RX FIFO */
+		spi_reg->dma |= MXC_F_SPI_DMA_RX_FIFO_EN;
+	}
+
+	if (is_async) {
+		MXC_SETFIELD(spi_reg->dma, MXC_F_SPI_DMA_TX_THD_VAL,
+			     (1U << MXC_F_SPI_DMA_TX_THD_VAL_POS));
+		MXC_SETFIELD(spi_reg->dma, MXC_F_SPI_DMA_RX_THD_VAL,
+			     (0U << MXC_F_SPI_DMA_RX_THD_VAL_POS));
+	}
+
+	/* Prime the TX FIFO with the first bytes before starting */
+	_max_capi_spi_fifo_fill_tx(spi_priv);
+
+	if (is_async) {
+		inten = MXC_F_SPI_INTEN_CONT_DONE |
+			MXC_F_SPI_INTEN_TX_OV |
+			MXC_F_SPI_INTEN_RX_OV |
+			MXC_F_SPI_INTEN_ABORT;
+		if (transfer->rx_buf)
+			inten |= MXC_F_SPI_INTEN_RX_THD;
+		if (fifo_async->tx_cnt < clk_len)
+			inten |= MXC_F_SPI_INTEN_TX_THD;
+
+		spi_reg->inten = inten;
+
+		MXC_SPI_StartTransmission(spi_reg);
+		return 0;
+	}
+
+	/* Start the transaction */
+	MXC_SPI_StartTransmission(spi_reg);
+
+	tx_done = false;
+	rx_done = false;
+	while (!(rx_done && tx_done)) {
+		tx_done = _max_capi_spi_fifo_fill_tx(spi_priv);
+		rx_done = _max_capi_spi_fifo_drain_rx(spi_priv);
+	}
+
+	/* Wait for the RX and TX FIFOs to be empty */
+	while (!(spi_reg->intfl & MXC_F_SPI_INTFL_CONT_DONE));
+
+	/* End the transaction */
+	spi_reg->ctrl0 &= ~MXC_F_SPI_CTRL0_START;
+
+	/* Disable the RX and TX FIFOs */
+	spi_reg->dma &= ~(MXC_F_SPI_DMA_RX_FIFO_EN | MXC_F_SPI_DMA_TX_FIFO_EN);
+
+	transfer_in_progress[spi_id] = false;
+
+	return 0;
+}
+
+/**
+ * @brief Cleanup a DMA channel
+ * @param channel The DMA channel
+ */
+void _max_capi_spi_dma_cleanup_channel(struct capi_dma_chan **channel)
+{
+	if (channel && *channel) {
+		capi_dma_xfer_abort(*channel);
+		capi_dma_deinit_chan(*channel);
+		*channel = NULL;
+	}
+}
+
+/**
+ * @brief The callback called when a transfer is completed
+ * @param transfer The DMA transfer
+ * @param ctx The user data passed (struct max_capi_spi_priv)
+ */
+void _max_capi_spi_dma_complete_callback(uint32_t event, void *ctx)
+{
+	struct max_capi_spi_priv *priv = ctx;
+	uint8_t spi_id = priv->identifier;
+
+	dma_completed_count[spi_id]++;
+	if (dma_completed_count[spi_id] == 2) {
+		if (priv->callback) {
+			priv->callback(CAPI_SPI_EVENT_XFR_DONE,
+				       priv->callback_arg, 0);
+		}
+
+		dma_completed_count[spi_id] = 0;
+		async_transfer_in_progress[spi_id] = false;
+		transfer_in_progress[spi_id] = false;
+
+		// _max_capi_spi_dma_cleanup_channel(&dma_channel_rx[spi_id]);
+		// _max_capi_spi_dma_cleanup_channel(&dma_channel_tx[spi_id]);
+	}
+}
+
+/**
+ * @brief Do a SPI transfer using DMA
+ * @param device The SPI device
+ * @param transfer The SPI transfer
+ * @param is_async Whether it's async or not
+ * @return 0 on success, negative error code otherwise
+ */
+int _max_capi_spi_transceive_dma(struct capi_spi_device *device,
+				 struct capi_spi_transfer *transfer,
+				 bool is_async)
+{
+	int32_t target_id;
+	int ret;
+	struct capi_spi_controller_handle *spi_handle;
+	struct max_capi_spi_priv *spi_priv;
+	struct capi_dma_handle *dma_handle;
+	struct max_capi_dma_xfer_extra dma_transfer_tx_extra, dma_transfer_rx_extra;
+	struct capi_dma_transfer dma_transfer_tx, dma_transfer_rx;
+	mxc_spi_regs_t *spi_reg;
+	uint8_t spi_id;
+	uint32_t target_speed;
+	uint32_t rx_id, tx_id;
+	int timeout;
+
+	spi_handle = device->controller;
+	spi_priv = spi_handle->priv;
+	spi_reg = MXC_SPI_GET_SPI(spi_priv->identifier);
+	dma_handle = spi_priv->dma_handle;
+	spi_id = spi_priv->identifier;
+	timeout = transfer->timeout;
+
+	if (timeout == 0 || timeout == -1) {
+		while (transfer_in_progress[spi_id]);
+	} else {
+		while (transfer_in_progress[spi_id]) {
+			timeout--;
+			if (timeout == 0) {
+				return -ETIMEDOUT;
+			}
+			capi_wait_ms(1);
+		}
+	}
+	transfer_in_progress[spi_id] = true;
+
+	/* Validate only one CS is chosen */
+	target_id = _max_capi_spi_get_cs_index(device->native_cs);
+	if (target_id < 0) {
+		transfer_in_progress[spi_id] = false;
+		return target_id;
+	}
+
+	if (device->max_speed_hz > spi_priv->clock_freq)
+		return -EINVAL;
+	target_speed = device->max_speed_hz ? device->max_speed_hz :
+		       spi_priv->clock_freq;
+	if (target_speed != spi_priv->clock_freq) {
+		ret = MXC_SPI_SetFrequency(spi_reg, target_speed);
+		if (ret < 0) {
+			transfer_in_progress[spi_id] = false;
+			return -EIO;
+		}
+	} else {
+		ret = MXC_SPI_SetFrequency(spi_reg, spi_priv->clock_freq);
+		if (ret < 0) {
+			transfer_in_progress[spi_id] = false;
+			return -EIO;
+		}
+	}
+
+	/* Assert CS spi_extra->chip_select when the SPI transaction is started */
+	MXC_SPI_SetSlave(spi_reg, (int)target_id);
+
+	/* Flush the RX and TX FIFOs */
+	MXC_SPI_ClearRXFIFO(spi_reg);
+	MXC_SPI_ClearTXFIFO(spi_reg);
+	/* Enable SPI */
+	spi_reg->intfl |= MXC_F_SPI_INTFL_CONT_DONE;
+
+	if (device->non_continuous_mode)
+		spi_reg->ctrl0 &= ~MXC_F_SPI_CTRL0_TS_CTRL;
+	else
+		spi_reg->ctrl0 |= MXC_F_SPI_CTRL0_TS_CTRL;
+
+	/* Enable the TX and RX FIFO */
+	spi_reg->ctrl1 = transfer->tx_size;
+	spi_reg->ctrl1 |= (transfer->rx_size << MXC_F_SPI_CTRL1_RX_NUM_CHAR_POS);
+	spi_reg->dma |= MXC_F_SPI_DMA_TX_FIFO_EN | MXC_F_SPI_DMA_RX_FIFO_EN;
+
+	_max_capi_delay_config(device, transfer);
+
+	/* Allow DMA transfer for RX and TX SPI FIFOs */
+	spi_reg->dma |= MXC_F_SPI_DMA_RX_EN | MXC_F_SPI_DMA_TX_EN;
+
+	if (!dma_channel_rx[spi_id]) {
+		ret = _max_capi_spi_get_cs_index(device->native_cs);
+		if (ret < 0) {
+			transfer_in_progress[spi_id] = false;
+			return ret;
+		}
+		rx_id = ret;
+		ret = capi_dma_init_chan(dma_handle, &dma_channel_rx[spi_id], rx_id * 2);
+		if (ret) {
+			transfer_in_progress[spi_id] = false;
+			return ret;
+		}
+	}
+	if (!dma_channel_tx[spi_id]) {
+		ret = _max_capi_spi_get_cs_index(device->native_cs);
+		if (ret < 0) {
+			transfer_in_progress[spi_id] = false;
+			return ret;
+		}
+		tx_id = ret;
+		ret = capi_dma_init_chan(dma_handle, &dma_channel_tx[spi_id], tx_id * 2 + 1);
+		if (ret)
+			goto deinit_rx_chan;
+	}
+
+	dma_transfer_rx_extra = (struct max_capi_dma_xfer_extra) {
+		.reqsel = MAX_CAPI_DMA_REQUEST_SPI_RX,
+	};
+	dma_transfer_rx = (struct capi_dma_transfer) {
+		.src = (capi_dma_glbl_addr_t)&spi_reg->fifo8,
+		.dst = transfer->rx_buf ?
+		       (capi_dma_glbl_addr_t)transfer->rx_buf :
+		       (capi_dma_glbl_addr_t)zero_rx,
+		       .src_size = CAPI_DMA_XFER_SIZE_1_BYTE,
+		       .dst_size = CAPI_DMA_XFER_SIZE_1_BYTE,
+		       .src_inc = CAPI_DMA_NO_INCREMENT,
+		       .dst_inc = transfer->rx_buf ?
+				  CAPI_DMA_BYTE_INCREMENT :
+				  CAPI_DMA_NO_INCREMENT,
+				  .length = transfer->rx_size,
+				  .extra = &dma_transfer_rx_extra,
+				  .xfer_type = CAPI_DMA_DEV_TO_MEM,
+	};
+	dma_transfer_tx_extra = (struct max_capi_dma_xfer_extra) {
+		.reqsel = MAX_CAPI_DMA_REQUEST_SPI_TX,
+	};
+	dma_transfer_tx = (struct capi_dma_transfer) {
+		.src = transfer->tx_buf ?
+		       (capi_dma_glbl_addr_t)transfer->tx_buf :
+		       (capi_dma_glbl_addr_t)zero_tx,
+		       .dst = (capi_dma_glbl_addr_t)&spi_reg->fifo8,
+		       .src_size = CAPI_DMA_XFER_SIZE_1_BYTE,
+		       .dst_size = CAPI_DMA_XFER_SIZE_1_BYTE,
+		       .src_inc = transfer->tx_buf ?
+				  CAPI_DMA_BYTE_INCREMENT : CAPI_DMA_NO_INCREMENT,
+				  .dst_inc = CAPI_DMA_NO_INCREMENT,
+				  .length = transfer->tx_size,
+				  .extra = &dma_transfer_tx_extra,
+				  .xfer_type = CAPI_DMA_MEM_TO_DEV,
+	};
+
+	dma_completed_count[spi_id] = 0;
+
+	ret = capi_dma_config_xfer(dma_channel_rx[spi_id], &dma_transfer_rx);
+	if (ret)
+		goto deinit_tx_chan;
+	ret = capi_dma_config_xfer(dma_channel_tx[spi_id], &dma_transfer_tx);
+	if (ret)
+		goto abort_transfer;
+
+	if (is_async) {
+		async_transfer_in_progress[spi_id] = true;
+		ret = capi_dma_register_complete_callback(dma_channel_rx[spi_id],
+				_max_capi_spi_dma_complete_callback,
+				spi_priv);
+		if (ret)
+			goto abort_transfer;
+		ret = capi_dma_register_complete_callback(dma_channel_tx[spi_id],
+				_max_capi_spi_dma_complete_callback,
+				spi_priv);
+		if (ret)
+			goto abort_transfer;
+	}
+
+	ret = capi_dma_xfer_start(dma_channel_rx[spi_id]);
+	if (ret)
+		goto abort_transfer;
+	ret = capi_dma_xfer_start(dma_channel_tx[spi_id]);
+	if (ret)
+		goto abort_transfer;
+
+	/* Start the transaction */
+	MXC_SPI_StartTransmission(spi_reg);
+
+	if (!is_async) {
+		while (!capi_dma_chan_is_completed(dma_channel_rx[spi_id]) ||
+		       !capi_dma_chan_is_completed(dma_channel_tx[spi_id]));
+
+		while (spi_reg->status & MXC_F_SPI_STATUS_BUSY);
+		/* End the transaction */
+		spi_reg->ctrl0 &= ~MXC_F_SPI_CTRL0_START;
+		/* Disable the RX and TX FIFOs */
+		spi_reg->dma &= ~(MXC_F_SPI_DMA_TX_FIFO_EN | MXC_F_SPI_DMA_RX_FIFO_EN);
+
+		transfer_in_progress[spi_id] = false;
+	}
+
+	return 0;
+
+abort_transfer:
+	if (is_async)
+		async_transfer_in_progress[spi_id] = false;
+	capi_dma_xfer_abort(dma_channel_tx[spi_id]);
+	capi_dma_xfer_abort(dma_channel_rx[spi_id]);
+deinit_tx_chan:
+	capi_dma_deinit_chan(dma_channel_tx[spi_id]);
+	dma_channel_tx[spi_id] = NULL;
+deinit_rx_chan:
+	capi_dma_deinit_chan(dma_channel_rx[spi_id]);
+	dma_channel_rx[spi_id] = NULL;
+
+	transfer_in_progress[spi_id] = false;
+
+	return ret;
+}
+
+/** SPI functions implementation **********************************************/
+/**
+ * @brief Initialize the SPI peripheral
+ * @param handle The SPI controller handle
+ * @param config The SPI initialization config
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_spi_init(struct capi_spi_controller_handle **handle,
+		      const struct capi_spi_config *config)
+{
+	int ret;
+	struct capi_spi_controller_handle *spi_handle;
+	struct max_capi_spi_priv *spi_priv;
+	uint8_t spi_id;
+
+	if (!handle || !config)
+		return -EINVAL;
+
+	if (config->identifier >= MXC_SPI_INSTANCES)
+		return -EINVAL;
+
+	if (spi[config->identifier] != NULL) {
+		*handle = spi[config->identifier];
+		return 0;
+	}
+
+	if (*handle == NULL) {
+		spi_handle = capi_calloc(1, sizeof(*spi_handle));
+		if (!spi_handle)
+			return -ENOMEM;
+		spi_handle->init_allocated = true;
+	} else {
+		spi_handle = *handle;
+		spi_handle->init_allocated = false;
+	}
+
+	spi_priv = capi_calloc(1, sizeof(*spi_priv));
+	if (!spi_priv) {
+		ret = -ENOMEM;
+		goto free_handle;
+	}
+
+	spi_handle->ops = config->ops;
+	spi_priv->identifier = config->identifier;
+	spi_priv->clock_freq = config->clk_freq_hz;
+	spi_handle->priv = spi_priv;
+	spi_id = spi_priv->identifier;
+
+	/* Copy user config or set defaults */
+	if (config->extra) {
+		spi_priv->extra = *(struct max_capi_spi_extra *)config->extra;
+	} else {
+		spi_priv->extra.device_role = MAX_CAPI_SPI_DEVICE_ROLE_CONTROLLER;
+		spi_priv->extra.bus_width = MAX_CAPI_SPI_BUS_WIDTH_STANDARD;
+		spi_priv->extra.num_targets = 1;
+		spi_priv->extra.polarity_mask = 0;
+		spi_priv->extra.chip_select = MAX_CAPI_SPI_CS0;
+		spi_priv->extra.vssel = MAX_CAPI_GPIO_VSSEL_VDDIO;
+		spi_priv->extra.clock_phase = MAX_CAPI_SPI_CLOCK_PHASE_0;
+		spi_priv->extra.clock_polarity = MAX_CAPI_SPI_CLOCK_POLARITY_0;
+		spi_priv->extra.platform_delays.cs_delay_first = 0;
+		spi_priv->extra.platform_delays.cs_delay_last = 0;
+		spi_priv->extra.dma_config = NULL;
+	}
+
+	ret = _max_capi_spi_config(spi_handle);
+	if (ret)
+		goto shutdown_spi;
+
+	if (config->dma_handle && spi_priv->extra.dma_config) {
+		spi_priv->dma_handle = config->dma_handle;
+
+		ret = capi_dma_init(&spi_priv->dma_handle,
+				    spi_priv->extra.dma_config);
+		if (ret)
+			goto shutdown_spi;
+	}
+
+	struct capi_irq_config irq_config = {
+		.irq_ctrl_id = 0,
+	};
+	ret = capi_irq_init(&irq_config);
+	if (ret && ret != -EBUSY) {
+		/* -EBUSY means IRQ already initialized, which is fine since
+		   it uses a singleton pattern. */
+		goto deinit_dma;
+	}
+
+	IRQn_Type spi_irq = MXC_SPI_GET_IRQ(spi_id);
+	ret = capi_irq_connect(spi_irq, max_capi_spi_isr, spi_handle);
+	if (ret)
+		goto deinit_dma;
+
+	ret = capi_irq_enable(spi_irq);
+	if (ret)
+		goto deinit_dma;
+
+	spi[config->identifier] = spi_handle;
+	*handle = spi_handle;
+	spi_priv->spi_handle = spi_handle;
+
+	return 0;
+
+deinit_dma:
+	_max_capi_spi_dma_cleanup_channel(&dma_channel_rx[spi_id]);
+	_max_capi_spi_dma_cleanup_channel(&dma_channel_tx[spi_id]);
+shutdown_spi:
+	MXC_SPI_Shutdown(MXC_SPI_GET_SPI(spi_id));
+	capi_free(spi_priv);
+free_handle:
+	if (spi_handle->init_allocated)
+		capi_free(spi_handle);
+
+	spi[config->identifier] = NULL;
+	dma_completed_count[config->identifier] = 0;
+	async_transfer_in_progress[config->identifier] = false;
+	transfer_in_progress[config->identifier] = false;
+
+	return ret;
+}
+
+/**
+ * @brief Deinitialize the SPI peripheral
+ * @param handle The SPI controller handle
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_spi_deinit(struct capi_spi_controller_handle *handle)
+{
+	int ret;
+	struct max_capi_spi_priv *spi_priv;
+	uint8_t spi_id;
+
+	if (!handle)
+		return -EINVAL;
+
+	spi_priv = handle->priv;
+	spi_id = spi_priv->identifier;
+
+	ret = MXC_SPI_Shutdown(MXC_SPI_GET_SPI(spi_priv->identifier));
+	if (ret != E_NO_ERROR)
+		return -EIO;
+
+	dma_completed_count[spi_id] = 0;
+	async_transfer_in_progress[spi_id] = false;
+	transfer_in_progress[spi_id] = false;
+
+	_max_capi_spi_dma_cleanup_channel(&dma_channel_rx[spi_id]);
+	_max_capi_spi_dma_cleanup_channel(&dma_channel_tx[spi_id]);
+
+	capi_irq_disable(MXC_SPI_GET_IRQ(spi_id));
+
+	capi_free(spi_priv);
+	if (handle->init_allocated) {
+		capi_free(handle);
+	}
+
+	spi[spi_id] = NULL;
+
+	return 0;
+}
+
+/**
+ * @brief Perform blocking SPI transfer
+ * @param device The SPI device
+ * @param transfer The SPI transfer
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_spi_transceive(struct capi_spi_device *device,
+			    struct capi_spi_transfer *transfer)
+{
+	const struct max_capi_spi_priv *spi_priv;
+
+	if (!device || !device->controller || !transfer)
+		return -EINVAL;
+
+	spi_priv = device->controller->priv;
+	if (spi_priv->dma_handle)
+		return _max_capi_spi_transceive_dma(device, transfer, false);
+	else
+		return _max_capi_spi_transceive_fifo(device, transfer, false, false);
+}
+
+/**
+ * @brief Perform non-blocking SPI transfer
+ * @param device The SPI device
+ * @param transfer The SPI transfer
+ * @param timeout timeout - not used
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_spi_transceive_async(struct capi_spi_device *device,
+				  struct capi_spi_transfer *transfer,
+				  int timeout)
+{
+	const struct max_capi_spi_priv *spi_priv;
+
+	if (!device || !device->controller || !transfer)
+		return -EINVAL;
+
+	spi_priv = device->controller->priv;
+	if (spi_priv->dma_handle)
+		return _max_capi_spi_transceive_dma(device, transfer, true);
+	else
+		return _max_capi_spi_transceive_fifo(device, transfer, true, false);
+}
+
+/**
+ * @brief Register a callback for async transactions
+ * @param handle The SPI controller handle
+ * @param callback The callback function to register
+ * @param callback_arg The argument for the callback function
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_spi_register_callback(struct capi_spi_controller_handle *handle,
+				   capi_spi_callback_t const callback,
+				   void *callback_arg)
+{
+	struct max_capi_spi_priv *priv;
+
+	if (!handle)
+		return -EINVAL;
+
+	priv = handle->priv;
+	priv->callback = callback;
+	priv->callback_arg = callback_arg;
+
+	return 0;
+}
+
+/**
+ * @brief Send a command/address, then reads data - all in one CS assertion,
+ * 	  blocking
+ * @param device The SPI device
+ * @param transfer The SPI transfer
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_spi_read_command(struct capi_spi_device *device,
+			      struct capi_spi_transfer *transfer)
+{
+	const struct max_capi_spi_priv *spi_priv;
+
+	if (!device || !device->controller || !transfer)
+		return -EINVAL;
+
+	spi_priv = device->controller->priv;
+	if (spi_priv->dma_handle)
+		return -ENOTSUP;
+	else
+		return _max_capi_spi_transceive_fifo(device, transfer, false, true);
+}
+
+/**
+ * @brief Send a command/address, then reads data - all in one CS assertion,
+ * 	  non-blocking
+ * @param device The SPI device
+ * @param transfer The SPI transfer
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_spi_read_command_async(struct capi_spi_device *device,
+				    struct capi_spi_transfer *transfer)
+{
+	const struct max_capi_spi_priv *spi_priv;
+
+	if (!device || !device->controller || !transfer)
+		return -EINVAL;
+
+	spi_priv = device->controller->priv;
+	if (spi_priv->dma_handle)
+		return -ENOTSUP;
+	else
+		return _max_capi_spi_transceive_fifo(device, transfer, true, true);
+}
+
+/**
+ * @brief Abort an async transaction
+ * @param device The SPI device
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_spi_abort_async(struct capi_spi_device *device)
+{
+	const struct max_capi_spi_priv *spi_priv;
+	struct max_capi_spi_fifo_async *fifo_async;
+	uint8_t spi_id;
+	mxc_spi_regs_t *spi_reg;
+
+	if (!device || !device->controller)
+		return -EINVAL;
+
+	spi_priv = device->controller->priv;
+	spi_id = spi_priv->identifier;
+	spi_reg = MXC_SPI_GET_SPI(spi_id);
+	fifo_async = &((struct max_capi_spi_priv *)spi_priv)->fifo_async;
+
+	_max_capi_spi_dma_cleanup_channel(&dma_channel_rx[spi_id]);
+	_max_capi_spi_dma_cleanup_channel(&dma_channel_tx[spi_id]);
+
+	spi_reg->inten &= ~(MXC_F_SPI_INTEN_TX_THD |
+			    MXC_F_SPI_INTEN_RX_THD |
+			    MXC_F_SPI_INTEN_CONT_DONE);
+	fifo_async->active = false;
+
+	spi_reg->ctrl0 &= ~MXC_F_SPI_CTRL0_START;
+	spi_reg->dma &= ~(MXC_F_SPI_DMA_RX_FIFO_EN | MXC_F_SPI_DMA_TX_FIFO_EN);
+	spi_reg->dma &= ~(MXC_F_SPI_DMA_RX_EN | MXC_F_SPI_DMA_TX_EN);
+
+	dma_completed_count[spi_id] = 0;
+	async_transfer_in_progress[spi_id] = false;
+	transfer_in_progress[spi_id] = false;
+
+	if (spi_priv->callback)
+		spi_priv->callback(CAPI_SPI_EVENT_ERROR,
+				   spi_priv->callback_arg, 0);
+
+	return 0;
+}
+
+/**
+ * @brief Manually assert/deassert chip select, or restore to auto mode
+ * @param device The SPI device
+ * @param cs_control The chip select mode
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_spi_set_cs(struct capi_spi_device *device,
+			enum capi_spi_cs_control cs_control)
+{
+	struct max_capi_spi_priv *spi_priv;
+	mxc_spi_regs_t *spi_reg;
+	uint8_t spi_id;
+
+	if (!device || !device->controller)
+		return -EINVAL;
+
+	spi_priv = device->controller->priv;
+	spi_id = spi_priv->identifier;
+	spi_reg = MXC_SPI_GET_SPI(spi_id);
+
+	switch (cs_control) {
+	case CAPI_SPI_CS_AUTO:
+		/* Hardware controls CS */
+		spi_reg->ctrl0 |= MXC_F_SPI_CTRL0_TS_CTRL;
+		break;
+
+	case CAPI_SPI_CS_MANUAL_ASSERT:
+		spi_reg->ctrl0 &= ~MXC_F_SPI_CTRL0_TS_CTRL;
+		MXC_SPI_SetSlave(spi_reg, spi_priv->extra.chip_select);
+		spi_reg->ctrl0 |= MXC_F_SPI_CTRL0_START;
+		break;
+
+	case CAPI_SPI_CS_MANUAL_DEASSERT:
+		spi_reg->ctrl0 &= ~MXC_F_SPI_CTRL0_TS_CTRL;
+		spi_reg->ctrl0 &= ~MXC_F_SPI_CTRL0_START;
+		break;
+
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+void max_capi_spi_isr(void *handle)
+{
+	struct capi_spi_controller_handle *spi_handle;
+	struct max_capi_spi_priv *spi_priv;
+	mxc_spi_regs_t *spi_reg;
+	uint32_t interrupt_flags;
+	uint8_t spi_id;
+	bool has_error = false;
+
+	if (!handle)
+		return;
+
+	spi_handle = (struct capi_spi_controller_handle *)handle;
+	spi_priv = spi_handle->priv;
+	spi_id = spi_priv->identifier;
+	spi_reg = MXC_SPI_GET_SPI(spi_id);
+
+	interrupt_flags = MXC_SPI_GetFlags(spi_reg);
+	if (!interrupt_flags)
+		return;
+
+	/* RX FIFO overflow */
+	if (interrupt_flags & MXC_F_SPI_INTFL_RX_OV) {
+		has_error = true;
+		if (spi_priv->callback) {
+			spi_priv->callback(CAPI_SPI_EVENT_RX_FIFO_OVERFLOW,
+					   spi_priv->callback_arg, 0);
+		}
+	}
+
+	/* TX FIFO underflow */
+	if (interrupt_flags & MXC_F_SPI_INTFL_TX_OV) {
+		has_error = true;
+		if (spi_priv->callback) {
+			spi_priv->callback(CAPI_SPI_EVENT_TX_FIFO_UNDERFLOW,
+					   spi_priv->callback_arg, 0);
+		}
+	}
+
+	/* Check async */
+	if (spi_priv->fifo_async.active) {
+		struct max_capi_spi_fifo_async *fifo_async = &spi_priv->fifo_async;
+
+		_max_capi_spi_fifo_drain_rx(spi_priv);
+		_max_capi_spi_fifo_fill_tx(spi_priv);
+
+		bool tx_complete = (fifo_async->tx_cnt >= fifo_async->clk_len);
+		bool rx_complete = (!fifo_async->rx_buf) ||
+				   (fifo_async->rx_cnt >=
+				    (fifo_async->rx_skip + fifo_async->rx_size));
+
+		if (tx_complete)
+			spi_reg->inten &= ~MXC_F_SPI_INTEN_TX_THD;
+		if (rx_complete)
+			spi_reg->inten &= ~MXC_F_SPI_INTEN_RX_THD;
+
+		if (tx_complete && rx_complete &&
+		    (interrupt_flags & MXC_F_SPI_INTFL_CONT_DONE)) {
+			spi_reg->inten &= ~(MXC_F_SPI_INTEN_TX_THD |
+					    MXC_F_SPI_INTEN_RX_THD |
+					    MXC_F_SPI_INTEN_CONT_DONE);
+			spi_reg->ctrl0 &= ~MXC_F_SPI_CTRL0_START;
+			spi_reg->dma &= ~(MXC_F_SPI_DMA_RX_FIFO_EN |
+					  MXC_F_SPI_DMA_TX_FIFO_EN);
+			fifo_async->active = false;
+			async_transfer_in_progress[spi_id] = false;
+			transfer_in_progress[spi_id] = false;
+			if (spi_priv->callback)
+				spi_priv->callback(CAPI_SPI_EVENT_XFR_DONE,
+						   spi_priv->callback_arg, 0);
+		}
+
+		spi_reg->intfl = interrupt_flags;
+		return;
+	}
+
+	/* Transfer complete */
+	if (interrupt_flags & MXC_F_SPI_INTFL_CONT_DONE) {
+		if (spi_priv->callback) {
+			spi_priv->callback(CAPI_SPI_EVENT_XFR_DONE,
+					   spi_priv->callback_arg, 0);
+		}
+	}
+
+	/* Other errors */
+	if (interrupt_flags & MXC_F_SPI_INTFL_ABORT) {
+		has_error = true;
+		if (spi_priv->callback) {
+			spi_priv->callback(CAPI_SPI_EVENT_ERROR,
+					   spi_priv->callback_arg, -ECANCELED);
+		}
+	}
+
+	if (has_error && async_transfer_in_progress[spi_id]) {
+		_max_capi_spi_dma_cleanup_channel(&dma_channel_rx[spi_id]);
+		_max_capi_spi_dma_cleanup_channel(&dma_channel_tx[spi_id]);
+
+		dma_completed_count[spi_id] = 0;
+		async_transfer_in_progress[spi_id] = false;
+		transfer_in_progress[spi_id] = false;
+
+		spi_reg->ctrl0 &= ~MXC_F_SPI_CTRL0_START;
+		spi_reg->dma &= ~(MXC_F_SPI_DMA_RX_FIFO_EN | MXC_F_SPI_DMA_TX_FIFO_EN);
+		spi_reg->dma &= ~(MXC_F_SPI_DMA_RX_EN | MXC_F_SPI_DMA_TX_EN);
+	}
+
+	/* Clear all interrupt flags that were handled */
+	spi_reg->intfl = interrupt_flags;
+}
+
+const struct capi_spi_ops max_capi_spi_ops = {
+	.init = max_capi_spi_init,
+	.deinit = max_capi_spi_deinit,
+	.transceive = max_capi_spi_transceive,
+	.transceive_async = max_capi_spi_transceive_async,
+	.register_callback = max_capi_spi_register_callback,
+	.read_command = max_capi_spi_read_command,
+	.read_command_async = max_capi_spi_read_command_async,
+	.abort_async = max_capi_spi_abort_async,
+	.set_cs = max_capi_spi_set_cs,
+	.isr = max_capi_spi_isr,
+};

--- a/capi/platform/maxim/max32657/maxim_capi_spi.h
+++ b/capi/platform/maxim/max32657/maxim_capi_spi.h
@@ -1,0 +1,150 @@
+/*******************************************************************************
+ *   @file   maxim_capi_spi.h
+ *   @brief  Header file for SPI functions
+ *   @author Ramon Miguel Imbao (ramonmiguel.imbao@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef MAXIM_CAPI_SPI_H_
+#define MAXIM_CAPI_SPI_H_
+
+#include "capi_spi.h"
+#include "maxim_capi_gpio.h"
+
+#define MAX_DELAY_SCLK 255
+
+enum max_capi_spi_device_role {
+	MAX_CAPI_SPI_DEVICE_ROLE_TARGET,
+	MAX_CAPI_SPI_DEVICE_ROLE_CONTROLLER,
+};
+
+enum max_capi_spi_bus_width {
+	/** 1 Data line, half duplex */
+	MAX_CAPI_SPI_BUS_WIDTH_3WIRE,
+	/** CITO/COTI, full duplex */
+	MAX_CAPI_SPI_BUS_WIDTH_STANDARD,
+	/** 2 data lines, half duplex */
+	MAX_CAPI_SPI_BUS_WIDTH_DUAL,
+	/** 4 data lines, half duplex */
+	MAX_CAPI_SPI_BUS_WIDTH_QUAD,
+};
+
+enum max_capi_spi_clock_phase {
+	MAX_CAPI_SPI_CLOCK_PHASE_0,
+	MAX_CAPI_SPI_CLOCK_PHASE_1,
+};
+
+enum max_capi_spi_clock_polarity {
+	MAX_CAPI_SPI_CLOCK_POLARITY_0,
+	MAX_CAPI_SPI_CLOCK_POLARITY_1,
+};
+
+enum max_capi_spi_chip_select {
+	MAX_CAPI_SPI_CS0 = (1 << 0),
+	MAX_CAPI_SPI_CS1 = (1 << 1),
+	MAX_CAPI_SPI_CS2 = (1 << 2),
+};
+
+struct max_capi_spi_fifo_async {
+	/* TX buffer */
+	const uint8_t *tx_buf;
+	/* RX buffer */
+	uint8_t *rx_buf;
+	/* TX bytes to send */
+	uint32_t tx_size;
+	/* RX bytes to receive */
+	uint32_t rx_size;
+	/* max(tx_effective, rx_effective) */
+	uint32_t clk_len;
+	/* chars queued to TX FIFO so far */
+	uint32_t tx_cnt;
+	/* chars drained from RX FIFO so far */
+	uint32_t rx_cnt;
+	/* RX bytes to discard before rx_buf */
+	uint32_t rx_skip;
+	/* FIFO async in progress */
+	bool active;
+};
+
+/**
+ * @struct max_spi_delays
+ * @brief Delays in nanoseconds
+ */
+struct max_capi_spi_delays {
+	/** Delay between the CS assert and first SCLK edge */
+	uint32_t cs_delay_first;
+	/** Delay between the last SCLK edge and the CS deassert */
+	uint32_t cs_delay_last;
+};
+
+struct max_capi_spi_extra {
+	/** Controller or Peripheral */
+	enum max_capi_spi_device_role device_role;
+	/** Bus width */
+	enum max_capi_spi_bus_width bus_width;
+	/** Number of targets */
+	uint32_t num_targets;
+	/** Bitmask for chip select pins polarity */
+	uint8_t polarity_mask;
+	/** Choose which chip select(s) gets enabled */
+	uint8_t chip_select;
+	/** Voltage level of the SPI peripheral */
+	enum max_capi_gpio_vssel vssel;
+	/** Clock phase; used for setting SPI mode */
+	enum max_capi_spi_clock_phase clock_phase;
+	/** Clock polarity; used for setting SPI mode */
+	enum max_capi_spi_clock_polarity clock_polarity;
+	/** SPI delays */
+	struct max_capi_spi_delays platform_delays;
+	/** OPTIONAL - DMA config parameters */
+	struct capi_dma_config *dma_config;
+};
+
+struct max_capi_spi_priv {
+	/** SPI controller handle */
+	struct capi_spi_controller_handle *spi_handle;
+	/** SPI device ID; only 0 is valid for MAX32657 */
+	uint32_t identifier;
+	/** DMA controller handle */
+	struct capi_dma_handle *dma_handle;
+	/** For storing the platform-specific config */
+	struct max_capi_spi_extra extra;
+	/** Clock frequency */
+	uint32_t clock_freq;
+	/** DMA callback function */
+	capi_spi_callback_t callback;
+	/** DMA callback arg */
+	void *callback_arg;
+	/** FIFO async */
+	struct max_capi_spi_fifo_async fifo_async;
+};
+
+extern const struct capi_spi_ops max_capi_spi_ops;
+
+#endif /* MAXIM_CAPI_SPI_H_ */

--- a/capi/platform/maxim/max32657/maxim_capi_time.c
+++ b/capi/platform/maxim/max32657/maxim_capi_time.c
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ *   @file   maxim_capi_time.c
+ *   @brief  Implementation of Time functions with CAPI
+ *   @author Ramon Miguel Imbao (ramonmiguel.imbao@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <errno.h>
+#include "capi_time.h"
+#include "mxc_delay.h"
+#include "mxc_sys.h"
+
+/** Static variables **********************************************************/
+
+static volatile unsigned long long _system_ticks = 0;
+
+/** Function implementations **************************************************/
+
+/**
+ * @brief Delay for at least the given number of microseconds
+ * @param us Minimum number of microseconds to wait
+ */
+void capi_wait_us_impl(uint32_t us)
+{
+	MXC_Delay(MXC_DELAY_USEC(us));
+}
+
+/**
+ * @brief Delay for at least the given number of milliseconds
+ * @param ms Minimum number of milliseconds to wait
+ */
+void capi_wait_ms_impl(uint32_t ms)
+{
+	MXC_Delay(MXC_DELAY_MSEC(ms));
+}
+
+/**
+ * @brief Get the uptime in microseconds since boot
+ * @param[out] us Uptime in microseconds
+ */
+int capi_uptime_impl(uint64_t *us)
+{
+	uint64_t ticks_start, ticks_end, sub_us;
+	uint32_t systick_val;
+	uint64_t reload;
+
+	if (!us)
+		return -EINVAL;
+
+	reload = (uint64_t)SysTick->LOAD + 1ULL;
+
+	do {
+		ticks_start = _system_ticks;
+		systick_val = SysTick->VAL;
+		ticks_end = _system_ticks;
+	} while (ticks_start != ticks_end);
+
+	if (systick_val >= reload)
+		systick_val = (uint32_t)(reload - 1ULL);
+
+	sub_us = (((reload - 1ULL) - systick_val) * 1000ULL) / reload;
+
+	*us = (ticks_start * 1000ULL) + sub_us;
+
+	return 0;
+}
+
+/** Platform-specific functions ***********************************************/
+
+extern void SysTick_Handler(void);
+
+void SysTick_Handler(void)
+{
+	MXC_DelayHandler();
+	_system_ticks++;
+}

--- a/capi/platform/maxim/max32657/maxim_capi_timer.c
+++ b/capi/platform/maxim/max32657/maxim_capi_timer.c
@@ -1,0 +1,1444 @@
+/*******************************************************************************
+ *   @file   maxim_capi_timer.c
+ *   @brief  Implementation of Timer and PWM functions
+ *   @author Ramon Miguel Imbao (ramonmiguel.imbao@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <errno.h>
+#include <stdint.h>
+#include "maxim_capi_irq.h"
+#include "maxim_capi_timer.h"
+#include "tmr.h"
+
+/** Static variables **********************************************************/
+
+static struct capi_timer_handle *timer[MXC_CFG_TMR_INSTANCES] = {NULL};
+
+/** Forward declarations ******************************************************/
+
+void max_capi_timer_isr(void *handle);
+
+/** Helper functions **********************************************************/
+
+/**
+ * @brief Get the prescaler for PWM mode
+ * @param div Clock division value (this should be a power of 2)
+ * @param prescaler enum value to be provided
+ * @return 0 on success, negative error code otherwise
+ */
+static int _max_capi_timer_get_prescaler_for_pwm(uint32_t div,
+		mxc_tmr_pres_t *prescaler)
+{
+	int i;
+
+	if (!prescaler)
+		return -EINVAL;
+
+	i = 1;
+
+	while (div / MAX_CAPI_PWM_GET_PRESCALER(i) > MAX_CAPI_PWM_TMR_MAX_VAL) {
+		i++;
+		if (i > MAX_CAPI_MAX_PRESCALER_INDEX)
+			return -ERANGE;
+	}
+
+	*prescaler = MAX_CAPI_PWM_PRESCALER_VAL(i);
+
+	return 0;
+}
+
+/**
+ * @brief Get the prescaler for counter/compare modes
+ * @param div Clock division value needed to achieve target frequency
+ * @param prescaler enum value to be provided
+ * @return 0 on success, negative error code otherwise
+ */
+static int _max_capi_timer_get_prescaler_for_counter(uint32_t div,
+		mxc_tmr_pres_t *prescaler)
+{
+	int i;
+
+	if (!prescaler)
+		return -EINVAL;
+
+	for (i = 1; i <= MAX_CAPI_MAX_PRESCALER_INDEX; i++) {
+		if (MAX_CAPI_PWM_GET_PRESCALER(i) >= div) {
+			*prescaler = MAX_CAPI_PWM_PRESCALER_VAL(i);
+			return 0;
+		}
+	}
+
+	return -ERANGE;
+}
+
+/**
+ * @brief Configure a GPIO pin based on the identifier and channel
+ * @param identifier Timer ID
+ * @param use_alternate_pin Whether to use the alternate pin or not
+ * @param vssel Voltage for the GPIO pin
+ * @return 0 on success, negative error code otherwise
+ */
+static int _max_capi_timer_configure_gpio(uint32_t identifier,
+		bool use_alternate_pin,
+		enum max_capi_gpio_vssel vssel)
+{
+	mxc_gpio_cfg_t gpio_config;
+
+	if (!use_alternate_pin) {
+		if (identifier == 0)
+			gpio_config = gpio_cfg_tmr0;
+		else if (identifier == 1)
+			gpio_config = gpio_cfg_tmr1;
+		else if (identifier == 2)
+			gpio_config = gpio_cfg_tmr2;
+		else if (identifier == 3)
+			gpio_config = gpio_cfg_tmr3;
+		else if (identifier == 4)
+			gpio_config = gpio_cfg_tmr4;
+		else if (identifier == 5)
+			gpio_config = gpio_cfg_tmr5;
+		else
+			return -EINVAL;
+	} else {
+		if (identifier == 0)
+			gpio_config = gpio_cfg_tmr0b;
+		else if (identifier == 2)
+			return -ENOTSUP;
+		else if (identifier == 1)
+			gpio_config = gpio_cfg_tmr1b;
+		else if (identifier == 3)
+			gpio_config = gpio_cfg_tmr3b;
+		else if (identifier == 4)
+			gpio_config = gpio_cfg_tmr4b;
+		else if (identifier == 5)
+			gpio_config = gpio_cfg_tmr5b;
+		else
+			return -EINVAL;
+	}
+
+	gpio_config.vssel = (mxc_gpio_vssel_t)vssel;
+
+	return MXC_GPIO_Config(&gpio_config);
+}
+
+/**
+ * @brief Get clock frequency given a clock source
+ * @param clock_source The clock source (from enum max_capi_timer_clock_source)
+ * @param freq_hz Where to store the frequency
+ * @param msdk_clock Where to store the msdk clock identifier
+ * @return 0 on success, negative error code otherwise
+ */
+static int _max_capi_timer_get_clock_frequency(enum max_capi_timer_clock_source
+		clock_source,
+		uint32_t *freq_hz, mxc_tmr_clock_t *msdk_clock)
+{
+	if (!freq_hz || !msdk_clock)
+		return -EINVAL;
+
+	switch (clock_source) {
+	case MAX_CAPI_TIMER_CLOCK_APB:
+		*freq_hz = PeripheralClock;
+		*msdk_clock = MXC_TMR_APB_CLK;
+		return 0;
+
+	case MAX_CAPI_TIMER_CLOCK_IBRO:
+		*freq_hz = IBRO_FREQ;
+		*msdk_clock = MXC_TMR_IBRO_CLK;
+		return 0;
+
+	case MAX_CAPI_TIMER_CLOCK_ERTCO:
+		*freq_hz = ERTCO_FREQ;
+		*msdk_clock = MXC_TMR_ERTCO_CLK;
+		return 0;
+
+	case MAX_CAPI_TIMER_CLOCK_EXTERNAL:
+	case MAX_CAPI_TIMER_CLOCK_INRO:
+	case MAX_CAPI_TIMER_CLOCK_IBRO_DIV8:
+		return -ENOTSUP;
+
+	default:
+		return -EINVAL;
+	}
+}
+
+/** Timer functions implementation ********************************************/
+
+/**
+ * @brief Initialize the timer peripheral. Defaults to 32-bit mode if not
+ * 	  specified in the extra init params.
+ * @param handle The timer handle
+ * @param config The timer config
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_timer_init(struct capi_timer_handle **handle,
+			const struct capi_timer_config *config)
+{
+	int ret;
+	struct capi_timer_handle *timer_handle;
+	struct max_capi_timer_priv *timer_priv;
+	const struct max_capi_timer_extra *timer_extra;
+	enum max_capi_timer_bit_mode bit_mode = MAX_CAPI_TIMER_BIT_MODE_32BIT;
+	enum max_capi_timer_clock_source clock_source = MAX_CAPI_TIMER_CLOCK_APB;
+	mxc_tmr_clock_t msdk_clock;
+	uint32_t clock_hz;
+	uint32_t prescaler_div;
+	mxc_tmr_pres_t prescaler;
+
+	if (!handle || !config)
+		return -EINVAL;
+
+	if (config->identifier >= MXC_CFG_TMR_INSTANCES)
+		return -EINVAL;
+
+	if (timer[config->identifier] != NULL) {
+		*handle = timer[config->identifier];
+		return 0;
+	}
+
+	if (config->output_freq_hz == 0)
+		return -EINVAL;
+
+	if (*handle == NULL) {
+		timer_handle = capi_calloc(1, sizeof(*timer_handle));
+		if (!timer_handle)
+			return -ENOMEM;
+		timer_handle->init_allocated = true;
+	} else {
+		timer_handle = *handle;
+		timer_handle->init_allocated = false;
+	}
+
+	timer_priv = capi_calloc(1, sizeof(*timer_priv));
+	if (!timer_priv) {
+		ret = -ENOMEM;
+		goto free_handle;
+	}
+
+	timer_handle->priv = timer_priv;
+	timer_handle->ops = config->ops;
+
+	if (config->input_clock_identifier)
+		clock_source = config->input_clock_identifier;
+
+	ret = _max_capi_timer_get_clock_frequency(clock_source, &clock_hz, &msdk_clock);
+	if (ret)
+		goto free_priv;
+
+	timer_priv->clock_source = clock_source;
+	timer_priv->clock_freq_hz = clock_hz;
+	timer_priv->msdk_clock = msdk_clock;
+
+	timer_priv->identifier = config->identifier;
+	prescaler_div = clock_hz / config->output_freq_hz;
+	ret = _max_capi_timer_get_prescaler_for_counter(prescaler_div, &prescaler);
+	if (ret)
+		goto free_priv;
+	timer_priv->frequency = clock_hz / MAX_CAPI_PWM_PRESCALER_TRUE(prescaler);
+
+	if (config->extra) {
+		timer_extra = config->extra;
+		bit_mode = timer_extra->bit_mode;
+		if (bit_mode != MAX_CAPI_TIMER_BIT_MODE_32BIT &&
+		    bit_mode != MAX_CAPI_TIMER_BIT_MODE_16BIT_DUAL) {
+			ret = -EINVAL;
+			goto free_priv;
+		}
+	}
+
+	struct capi_irq_config irq_config = {
+		.irq_ctrl_id = 0,
+	};
+
+	ret = capi_irq_init(&irq_config);
+	if (ret && ret != -EBUSY) {
+		/* -EBUSY means IRQ already initialized, which is fine since
+		   it uses a singleton pattern. */
+		goto free_priv;
+	}
+
+	IRQn_Type timer_irq = MXC_TMR_GET_IRQ(timer_priv->identifier);
+	ret = capi_irq_connect(timer_irq, max_capi_timer_isr, timer_handle);
+	if (ret)
+		goto free_priv;
+
+	ret = capi_irq_enable(timer_irq);
+	if (ret)
+		goto free_priv;
+
+	timer_priv->bit_mode = bit_mode;
+
+	timer_priv->global_callback = NULL;
+	timer_priv->global_callback_arg = NULL;
+	timer_priv->global_events_enabled = 0;
+
+	timer_priv->channel[0] = NULL;
+	timer_priv->channel[1] = NULL;
+
+	timer[config->identifier] = timer_handle;
+	*handle = timer_handle;
+
+	return 0;
+
+free_priv:
+	capi_free(timer_priv);
+free_handle:
+	if (timer_handle->init_allocated)
+		capi_free(timer_handle);
+
+	timer[config->identifier] = NULL;
+
+	return ret;
+}
+
+/**
+ * @brief Deinitialize the timer peripheral
+ * @param handle The timer handle
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_timer_deinit(struct capi_timer_handle *handle)
+{
+	struct max_capi_timer_priv *timer_priv;
+	mxc_tmr_regs_t *tmr_reg;
+	uint8_t id;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	timer_priv = handle->priv;
+	tmr_reg = MXC_TMR_GET_TMR(timer_priv->identifier);
+	id = timer_priv->identifier;
+
+	MXC_TMR_Stop(tmr_reg);
+	MXC_TMR_DisableInt(tmr_reg);
+	MXC_TMR_Shutdown(tmr_reg);
+
+	if (timer_priv->channel[0]) {
+		capi_free(timer_priv->channel[0]);
+		timer_priv->channel[0] = NULL;
+	}
+	if (timer_priv->channel[1]) {
+		capi_free(timer_priv->channel[1]);
+		timer_priv->channel[1] = NULL;
+	}
+
+	capi_irq_disable(MXC_TMR_GET_IRQ(timer_priv->identifier));
+
+	capi_free(handle->priv);
+
+	if (handle->init_allocated)
+		capi_free(handle);
+
+	timer[id] = NULL;
+
+	return 0;
+}
+
+/**
+ * @brief Timer start function
+ * @param handle The timer handle
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_timer_start(struct capi_timer_handle *handle)
+{
+	struct max_capi_timer_priv *timer_priv;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	timer_priv = handle->priv;
+
+	MXC_TMR_Start(MXC_TMR_GET_TMR(timer_priv->identifier));
+
+	return 0;
+}
+
+/**
+ * @brief Timer stop function
+ * @param handle The timer handle
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_timer_stop(struct capi_timer_handle *handle)
+{
+	struct max_capi_timer_priv *timer_priv;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	timer_priv = handle->priv;
+
+	MXC_TMR_Stop(MXC_TMR_GET_TMR(timer_priv->identifier));
+
+	return 0;
+}
+
+/**
+ * @brief Configure the counter for a timer
+ * @param handle The timer handle
+ * @param config The timer counter config
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_timer_counter_config(struct capi_timer_handle *handle,
+				  const struct capi_timer_counter_config *config)
+{
+	int ret;
+	struct max_capi_timer_priv *timer_priv;
+	const struct max_capi_timer_counter_extra *extra = NULL;
+
+	if (!handle || !handle->priv || !config)
+		return -EINVAL;
+
+	timer_priv = handle->priv;
+
+	if (config->direction == CAPI_TIMER_COUNT_DOWN)
+		return -ENOTSUP;
+
+	if (!timer_priv->channel[0]) {
+		ret = capi_timer_channel_init(handle, 0);
+		if (ret)
+			return ret;
+	}
+
+	if (config->rollover)
+		timer_priv->channel[0]->config.mode = MXC_TMR_MODE_CONTINUOUS;
+	else
+		timer_priv->channel[0]->config.mode = MXC_TMR_MODE_ONESHOT;
+
+	if (config->max > 0) {
+		if (timer_priv->bit_mode == MAX_CAPI_TIMER_BIT_MODE_16BIT_DUAL
+		    && config->max > UINT16_MAX)
+			return -EINVAL;
+
+		timer_priv->channel[0]->config.cmp_cnt = config->max;
+		timer_priv->channel[0]->compare.value = config->max;
+	}
+
+	if (config->extra) {
+		extra = (const struct max_capi_timer_counter_extra *)config->extra;
+		timer_priv->channel[0]->init_pin = extra->init_pin;
+		timer_priv->channel[0]->use_alternate_pin = extra->use_alternate_pin;
+		timer_priv->channel[0]->vssel = extra->vssel;
+	}
+
+	if (!timer_priv->channel[0]->enabled) {
+		ret = capi_timer_channel_enable(handle, 0);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Get the value of a timer counter
+ * @param handle The timer handle
+ * @param counter Pointer to where the value will be stored
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_timer_counter_get(struct capi_timer_handle *handle,
+			       uint32_t *counter)
+{
+	struct max_capi_timer_priv *timer_priv;
+
+	if (!handle || !handle->priv || !counter)
+		return -EINVAL;
+
+	timer_priv = handle->priv;
+
+	*counter = MXC_TMR_GetCount(MXC_TMR_GET_TMR(timer_priv->identifier));
+
+	return 0;
+}
+
+/**
+ * @brief Initialize a channel - allocates memory and sets defaults
+ * @param handle The timer handle
+ * @param chan The channel (0 = Timer A, 1 = Timer B)
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_timer_channel_init(struct capi_timer_handle *handle, uint32_t chan)
+{
+	int ret;
+	struct max_capi_timer_priv *timer_priv;
+	uint32_t prescaler_div;
+	mxc_tmr_pres_t prescaler;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	timer_priv = handle->priv;
+
+	if (timer_priv->bit_mode == MAX_CAPI_TIMER_BIT_MODE_32BIT) {
+		if (chan != 0)
+			return -EINVAL;
+	} else {
+		if (chan > 1)
+			return -EINVAL;
+	}
+
+	if (timer_priv->channel[chan]) {
+		capi_free(timer_priv->channel[chan]);
+		timer_priv->channel[chan] = NULL;
+	}
+
+	timer_priv->channel[chan] = capi_calloc(1,
+						sizeof(struct max_capi_timer_channel_state));
+	if (!timer_priv->channel[chan])
+		return -ENOMEM;
+
+	prescaler_div = timer_priv->clock_freq_hz / timer_priv->frequency;
+	ret = _max_capi_timer_get_prescaler_for_counter(prescaler_div, &prescaler);
+	if (ret)
+		goto free_channel;
+
+	timer_priv->frequency = timer_priv->clock_freq_hz /
+				MAX_CAPI_PWM_PRESCALER_TRUE(prescaler);
+
+	timer_priv->channel[chan]->config.pres = prescaler;
+	timer_priv->channel[chan]->config.mode = MXC_TMR_MODE_CONTINUOUS;
+	timer_priv->channel[chan]->config.clock = timer_priv->msdk_clock;
+	timer_priv->channel[chan]->config.cmp_cnt = 1;
+	timer_priv->channel[chan]->config.pol = 0;
+	timer_priv->channel[chan]->vssel = MAX_CAPI_GPIO_VSSEL_VDDIO;
+	timer_priv->channel[chan]->enabled = false;
+
+	return 0;
+
+free_channel:
+	capi_free(timer_priv->channel[chan]);
+	timer_priv->channel[chan] = NULL;
+
+	return ret;
+}
+
+/**
+ * @brief Deinitialize a channel - frees allocated memory
+ * @param handle The timer handle
+ * @param chan The channel (0 = Timer A, 1 = Timer B)
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_timer_channel_deinit(struct capi_timer_handle *handle,
+				  uint32_t chan)
+{
+	struct max_capi_timer_priv *timer_priv;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	timer_priv = handle->priv;
+
+	if (timer_priv->bit_mode == MAX_CAPI_TIMER_BIT_MODE_32BIT) {
+		if (chan != 0)
+			return -EINVAL;
+	} else {
+		if (chan > 1)
+			return -EINVAL;
+	}
+
+	if (!timer_priv->channel[chan])
+		return 0;
+
+	if (timer_priv->channel[chan]->enabled) {
+		mxc_tmr_regs_t *tmr_reg = MXC_TMR_GET_TMR(timer_priv->identifier);
+		if (chan == 0) {
+			tmr_reg->ctrl0 &= ~MXC_F_TMR_CTRL0_EN_A;
+			tmr_reg->ctrl1 &= ~MXC_F_TMR_CTRL1_IE_A;
+		} else {
+			tmr_reg->ctrl0 &= ~MXC_F_TMR_CTRL0_EN_B;
+			tmr_reg->ctrl1 &= ~MXC_F_TMR_CTRL1_IE_B;
+		}
+
+		timer_priv->channel[chan]->enabled = false;
+	}
+
+	capi_free(timer_priv->channel[chan]);
+	timer_priv->channel[chan] = NULL;
+
+	return 0;
+}
+
+/**
+ * @brief Configure a channel - stores configuration in memory without applying
+ * 	  to hardware yet.
+ * @param handle The timer handle
+ * @param chan The channel (0 = Timer A, 1 = Timer B)
+ * @param ch_config The configuration for the channel
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_timer_channel_config(struct capi_timer_handle *handle,
+				  uint32_t chan,
+				  const struct capi_timer_channel_config *ch_config)
+{
+	int ret;
+	struct max_capi_timer_priv *timer_priv;
+	const struct max_capi_timer_channel_extra *channel_extra;
+	enum max_capi_gpio_vssel vssel;
+	mxc_tmr_regs_t *tmr_reg;
+	uint32_t freq_period, low_time, freq_duty, prescaler_div;
+	uint32_t period_ticks, duty_ticks;
+	mxc_tmr_pres_t prescaler;
+
+	if (!handle || !handle->priv || !ch_config)
+		return -EINVAL;
+
+	timer_priv = handle->priv;
+	tmr_reg = MXC_TMR_GET_TMR(timer_priv->identifier);
+
+	if (timer_priv->bit_mode == MAX_CAPI_TIMER_BIT_MODE_32BIT) {
+		if (chan != 0)
+			return -EINVAL;
+	} else {
+		if (chan > 1)
+			return -EINVAL;
+	}
+
+	if (!timer_priv->channel[chan])
+		return -EINVAL;
+
+	if (timer_priv->bit_mode == MAX_CAPI_TIMER_BIT_MODE_32BIT) {
+		timer_priv->channel[chan]->config.bitMode = MXC_TMR_BIT_MODE_32;
+	} else {
+		if (chan == 0) {
+			timer_priv->channel[chan]->config.bitMode = MXC_TMR_BIT_MODE_16A;
+		} else {
+			if (ch_config->mode != CAPI_TIMER_COMPARE_MODE &&
+			    ch_config->mode != MAX_CAPI_TIMER_MODE_ONESHOT &&
+			    ch_config->mode != MAX_CAPI_TIMER_MODE_CONTINUOUS) {
+				return -ENOTSUP;
+			}
+
+			timer_priv->channel[chan]->config.bitMode = MXC_TMR_BIT_MODE_16B;
+		}
+	}
+
+	timer_priv->channel[chan]->init_pin = false;
+	timer_priv->channel[chan]->use_alternate_pin = false;
+
+	switch (ch_config->mode) {
+	case CAPI_TIMER_COMPARE_MODE:
+		timer_priv->channel[chan]->config.mode = MXC_TMR_MODE_COMPARE;
+		timer_priv->channel[chan]->compare.value =
+			ch_config->config.compare.match_value;
+		timer_priv->channel[chan]->init_pin =
+			ch_config->config.compare.generate_pulse_on_match;
+
+		/* Polarity validation only matters when actually generating output */
+		if (ch_config->config.compare.generate_pulse_on_match &&
+		    ch_config->config.compare.polarity != CAPI_TIMER_ON_COMPARE_TOGGLE)
+			return -EINVAL;
+		break;
+
+	case CAPI_TIMER_PWM_MODE:
+		timer_priv->channel[chan]->config.mode = MXC_TMR_MODE_PWM;
+
+		if (ch_config->config.pwm.period_ns == 0)
+			return -EINVAL;
+		if (ch_config->config.pwm.active_ns > ch_config->config.pwm.period_ns)
+			return -EINVAL;
+
+		freq_period = (1000000000UL / ch_config->config.pwm.period_ns);
+		if (freq_period == 0)
+			return -EINVAL;
+
+		prescaler_div = timer_priv->clock_freq_hz / freq_period;
+		ret = _max_capi_timer_get_prescaler_for_pwm(prescaler_div, &prescaler);
+		if (ret)
+			return ret;
+
+		period_ticks = MXC_TMR_GetPeriod(tmr_reg,
+						 timer_priv->msdk_clock,
+						 MAX_CAPI_PWM_PRESCALER_TRUE(prescaler),
+						 freq_period);
+
+		if (ch_config->config.pwm.active_ns == ch_config->config.pwm.period_ns) {
+			/* 100% duty cycle */
+			duty_ticks = period_ticks;
+		} else {
+			low_time = ch_config->config.pwm.period_ns - ch_config->config.pwm.active_ns;
+			freq_duty = (1000000000UL / low_time);
+			duty_ticks = MXC_TMR_GetPeriod(tmr_reg,
+						       timer_priv->msdk_clock,
+						       MAX_CAPI_PWM_PRESCALER_TRUE(prescaler),
+						       freq_duty);
+		}
+
+		timer_priv->channel[chan]->pwm.period_ticks = period_ticks;
+		timer_priv->channel[chan]->pwm.duty_cycle_ticks = duty_ticks;
+
+		timer_priv->channel[chan]->config.pres = prescaler;
+		timer_priv->channel[chan]->config.cmp_cnt = period_ticks;
+		timer_priv->channel[chan]->config.pol = ch_config->config.pwm.inverted_polarity;
+
+		timer_priv->channel[chan]->init_pin = true;
+		break;
+
+	case MAX_CAPI_TIMER_MODE_ONESHOT:
+		timer_priv->channel[chan]->config.mode = MXC_TMR_MODE_ONESHOT;
+		timer_priv->channel[chan]->compare.value =
+			ch_config->config.compare.match_value;
+		timer_priv->channel[chan]->init_pin =
+			ch_config->config.compare.generate_pulse_on_match;
+		break;
+
+	case MAX_CAPI_TIMER_MODE_CONTINUOUS:
+		timer_priv->channel[chan]->config.mode = MXC_TMR_MODE_CONTINUOUS;
+		timer_priv->channel[chan]->compare.value =
+			ch_config->config.compare.match_value;
+		timer_priv->channel[chan]->init_pin =
+			ch_config->config.compare.generate_pulse_on_match;
+		break;
+
+	/**
+	 * These timer modes require a timer input pin, but there
+	 * doesn't seem to be documentation regarding this. Perhaps
+	 * there aren't timer input pins on the MAX32657?
+	 */
+	case CAPI_TIMER_CAPTURE_MODE:
+	case MAX_CAPI_TIMER_MODE_DUAL_EDGE:
+	case MAX_CAPI_TIMER_MODE_GATED:
+	case MAX_CAPI_TIMER_MODE_CAPTURE_COMPARE:
+	case MAX_CAPI_TIMER_MODE_COUNTER:
+		return -ENOTSUP;
+
+	default:
+		return -EINVAL;
+	}
+
+	vssel = MAX_CAPI_GPIO_VSSEL_VDDIO;
+	if (ch_config->extra) {
+		channel_extra = ch_config->extra;
+		vssel = channel_extra->vssel;
+		timer_priv->channel[chan]->init_pin = channel_extra->init_pin;
+		timer_priv->channel[chan]->use_alternate_pin = channel_extra->use_alternate_pin;
+	}
+	timer_priv->channel[chan]->vssel = vssel;
+
+	if (chan == 1 && timer_priv->channel[chan]->init_pin)
+		return -ENOTSUP;
+
+	return 0;
+}
+
+/**
+ * @brief Enable a channel - applies stored configuration
+ * @param handle The timer handle
+ * @param chan The channel (0 = Timer A, 1 = Timer B)
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_timer_channel_enable(struct capi_timer_handle *handle,
+				  uint32_t chan)
+{
+	int ret;
+	struct max_capi_timer_priv *timer_priv;
+	mxc_tmr_regs_t *tmr_reg;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	timer_priv = handle->priv;
+	tmr_reg = MXC_TMR_GET_TMR(timer_priv->identifier);
+
+	if (!timer_priv->channel[chan])
+		return -EINVAL;
+
+	if (timer_priv->bit_mode == MAX_CAPI_TIMER_BIT_MODE_32BIT) {
+		if (chan != 0)
+			return -EINVAL;
+	} else {
+		if (chan > 1)
+			return -EINVAL;
+
+		if (chan == 1) {
+			if (timer_priv->channel[chan]->config.mode != MXC_TMR_MODE_COMPARE &&
+			    timer_priv->channel[chan]->config.mode != MXC_TMR_MODE_ONESHOT &&
+			    timer_priv->channel[chan]->config.mode != MXC_TMR_MODE_CONTINUOUS) {
+				return -ENOTSUP;
+			}
+		}
+	}
+
+	if (timer_priv->bit_mode == MAX_CAPI_TIMER_BIT_MODE_32BIT) {
+		ret = MXC_TMR_Init(tmr_reg, &timer_priv->channel[chan]->config, false);
+		if (ret)
+			return ret;
+	} else {
+		uint32_t other_channel = (chan == 0) ? 1 : 0;
+		bool other_enabled = (timer_priv->channel[other_channel] &&
+				      timer_priv->channel[other_channel]->enabled);
+
+		if (!other_enabled) {
+			ret = MXC_TMR_Init(tmr_reg, &timer_priv->channel[chan]->config, false);
+			if (ret)
+				return ret;
+		} else {
+			uint32_t mask = (other_channel == 0) ? 0x0000FFFF : 0xFFFF0000;
+			uint32_t ctrl0 = tmr_reg->ctrl0 & mask;
+			uint32_t ctrl1 = tmr_reg->ctrl1 & mask;
+			uint32_t cmp = tmr_reg->cmp & mask;
+			uint32_t cnt = tmr_reg->cnt & mask;
+
+			ret = MXC_TMR_Init(tmr_reg, &timer_priv->channel[chan]->config, false);
+			if (ret)
+				return ret;
+
+			tmr_reg->ctrl0 = (tmr_reg->ctrl0 & ~mask) | ctrl0;
+			tmr_reg->ctrl1 = (tmr_reg->ctrl1 & ~mask) | ctrl1;
+			tmr_reg->cmp = (tmr_reg->cmp & ~mask) | cmp;
+			tmr_reg->cnt = (tmr_reg->cnt & ~mask) | cnt;
+		}
+	}
+
+	switch (timer_priv->channel[chan]->config.mode) {
+	case MXC_TMR_MODE_PWM:
+		ret = MXC_TMR_SetPWM(tmr_reg, timer_priv->channel[chan]->pwm.duty_cycle_ticks);
+		if (ret)
+			return ret;
+		break;
+
+	case MXC_TMR_MODE_COMPARE:
+	case MXC_TMR_MODE_ONESHOT:
+	case MXC_TMR_MODE_CONTINUOUS:
+		if (timer_priv->bit_mode == MAX_CAPI_TIMER_BIT_MODE_32BIT) {
+			MXC_TMR_SetCompare(tmr_reg, timer_priv->channel[chan]->compare.value);
+		} else {
+			uint32_t compare = timer_priv->channel[chan]->compare.value;
+			if (compare > UINT16_MAX)
+				return -EINVAL;
+
+			uint32_t cmp_reg = MXC_TMR_GetCompare(tmr_reg);
+			if (chan == 0) {
+				cmp_reg &= ~0x0000FFFF;
+				cmp_reg |= compare;
+			} else {
+				cmp_reg &= ~0xFFFF0000;
+				cmp_reg |= compare << 16;
+			}
+			MXC_TMR_SetCompare(tmr_reg, cmp_reg);
+		}
+		break;
+
+	case MXC_TMR_MODE_CAPTURE:
+	case MXC_TMR_MODE_CAPTURE_COMPARE:
+	case MXC_TMR_MODE_DUAL_EDGE:
+	case MXC_TMR_MODE_GATED:
+	case MXC_TMR_MODE_COUNTER:
+		return -ENOTSUP;
+
+	default:
+		break;
+	}
+
+	if (timer_priv->channel[chan]->init_pin
+	    && !timer_priv->channel[chan]->gpio_initialized) {
+		ret = _max_capi_timer_configure_gpio(timer_priv->identifier,
+						     timer_priv->channel[chan]->use_alternate_pin,
+						     timer_priv->channel[chan]->vssel);
+		if (ret)
+			return ret;
+
+		timer_priv->channel[chan]->gpio_initialized = true;
+	}
+
+	timer_priv->channel[chan]->enabled = true;
+
+	return 0;
+}
+
+/**
+ * @brief Disable a channel - stops the specific timer
+ * @param handle The timer handle
+ * @param chan The channel (0 = Timer A, 1 = Timer B)
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_timer_channel_disable(struct capi_timer_handle *handle,
+				   uint32_t chan)
+{
+	struct max_capi_timer_priv *timer_priv;
+	mxc_tmr_regs_t *tmr_reg;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	timer_priv = handle->priv;
+	tmr_reg = MXC_TMR_GET_TMR(timer_priv->identifier);
+
+	if (timer_priv->bit_mode == MAX_CAPI_TIMER_BIT_MODE_32BIT) {
+		if (chan != 0)
+			return -EINVAL;
+	} else {
+		if (chan > 1)
+			return -EINVAL;
+	}
+
+	if (!timer_priv->channel[chan])
+		return -EINVAL;
+
+	if (chan == 0)
+		tmr_reg->ctrl0 &= ~MXC_F_TMR_CTRL0_CLKEN_A;
+	else
+		tmr_reg->ctrl0 &= ~MXC_F_TMR_CTRL0_CLKEN_B;
+
+	timer_priv->channel[chan]->enabled = false;
+
+	return 0;
+}
+
+/**
+ * @brief Set the compare value for a channel
+ * @param handle The timer handle
+ * @param chan The channel (0 = Timer A, 1 = Timer B)
+ * @param compare The compare value
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_timer_channel_compare_set(struct capi_timer_handle *handle,
+				       uint32_t chan, uint32_t compare)
+{
+	struct max_capi_timer_priv *timer_priv;
+	mxc_tmr_regs_t *tmr_reg;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	timer_priv = handle->priv;
+	tmr_reg = MXC_TMR_GET_TMR(timer_priv->identifier);
+
+	if (timer_priv->bit_mode == MAX_CAPI_TIMER_BIT_MODE_32BIT) {
+		if (chan != 0)
+			return -EINVAL;
+	} else {
+		if (chan > 1)
+			return -EINVAL;
+		if (compare > UINT16_MAX)
+			return -EINVAL;
+	}
+
+	if (!timer_priv->channel[chan])
+		return -EINVAL;
+
+	timer_priv->channel[chan]->compare.value = compare;
+
+	if (timer_priv->channel[chan]->enabled) {
+		if (timer_priv->bit_mode == MAX_CAPI_TIMER_BIT_MODE_32BIT) {
+			MXC_TMR_SetCompare(tmr_reg, compare);
+		} else {
+			uint32_t cmp_reg = MXC_TMR_GetCompare(tmr_reg);
+			if (chan == 0) {
+				cmp_reg &= ~0x0000FFFF;
+				cmp_reg |= compare;
+			} else {
+				cmp_reg &= ~0xFFFF0000;
+				cmp_reg |= compare << 16;
+			}
+			MXC_TMR_SetCompare(tmr_reg, cmp_reg);
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Get the compare value for a channel
+ * @param handle The timer handle
+ * @param chan The channel (0 = Timer A, 1 = Timer B)
+ * @param compare Where to store the compare value
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_timer_channel_compare_get(struct capi_timer_handle *handle,
+				       uint32_t chan, uint32_t *compare)
+{
+	struct max_capi_timer_priv *timer_priv;
+
+	if (!handle || !handle->priv || !compare)
+		return -EINVAL;
+
+	timer_priv = handle->priv;
+
+	if (timer_priv->bit_mode == MAX_CAPI_TIMER_BIT_MODE_32BIT) {
+		if (chan != 0)
+			return -EINVAL;
+	} else {
+		if (chan > 1)
+			return -EINVAL;
+	}
+
+	if (!timer_priv->channel[chan])
+		return -EINVAL;
+
+	*compare = timer_priv->channel[chan]->compare.value;
+
+	return 0;
+}
+
+/**
+ * @brief Get the capture value for a channel.
+ * 	  Since capture mode is not supported because it requires an input pin,
+ * 	  this returns -ENOTSUP instead.
+ * @param handle The timer handle
+ * @param chan The channel (0 = Timer A, 1 = Timer B)
+ * @param capture Where to store the capture value
+ * @return -ENOTSUP
+ */
+int max_capi_timer_channel_capture_get(struct capi_timer_handle *handle,
+				       uint32_t chan, uint32_t *capture)
+{
+	return -ENOTSUP;
+}
+
+/**
+ * @brief Convert nsec to ticks
+ * @param handle The timer handle
+ * @param duration_ns The duration in nanoseconds
+ * @param ticks Where to store the ticks for given duration_ns
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_timer_nsec_to_ticks(const struct capi_timer_handle *handle,
+				 uint64_t duration_ns, uint32_t *ticks)
+{
+	const struct max_capi_timer_priv *timer_priv;
+	uint64_t result;
+	const uint64_t one_billion = 1000000000ULL;
+
+	if (!handle || !handle->priv || !ticks)
+		return -EINVAL;
+
+	timer_priv = handle->priv;
+	if (timer_priv->frequency == 0)
+		return -EINVAL;
+
+	if (duration_ns > ((UINT64_MAX - (one_billion / 2ULL)) /
+		    timer_priv->frequency))
+		return -EOVERFLOW;
+
+	result = ((duration_ns * timer_priv->frequency) +
+		  (one_billion / 2ULL)) / one_billion;
+
+	if (result > UINT32_MAX)
+		return -EOVERFLOW;
+
+	*ticks = (uint32_t)result;
+
+	return 0;
+}
+
+/**
+ * @brief Convert ticks to nsec
+ * @param handle The timer handle
+ * @param ticks The number of ticks
+ * @param duration_ns Where to store the nanoseconds for given number of ticks
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_timer_ticks_to_nsec(const struct capi_timer_handle *handle,
+				 uint64_t ticks, uint32_t *duration_ns)
+{
+	const struct max_capi_timer_priv *timer_priv;
+	uint64_t result;
+	const uint64_t one_billion = 1000000000ULL;
+
+	if (!handle || !handle->priv || !duration_ns)
+		return -EINVAL;
+
+	timer_priv = handle->priv;
+	if (timer_priv->frequency == 0)
+		return -EINVAL;
+
+	if (ticks > ((UINT64_MAX - (timer_priv->frequency / 2ULL)) /
+	    one_billion))
+		return -EOVERFLOW;
+
+	result = ((ticks * one_billion) + (timer_priv->frequency / 2ULL)) /
+		 timer_priv->frequency;
+
+	if (result > UINT32_MAX)
+		return -EOVERFLOW;
+
+	*duration_ns = (uint32_t)result;
+
+	return 0;
+}
+
+/**
+ * @brief Enable an event
+ * @param handle The timer handle
+ * @param event The event to enable
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_timer_event_irq_enable(struct capi_timer_handle *handle,
+				    uint32_t event)
+{
+	struct max_capi_timer_priv *timer_priv;
+	mxc_tmr_regs_t *tmr_reg;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	timer_priv = handle->priv;
+	tmr_reg = MXC_TMR_GET_TMR(timer_priv->identifier);
+
+	if (event >= CAPI_TIMER_GLOBAL_EVENT_LIMIT)
+		return -EINVAL;
+
+	switch (event) {
+	case CAPI_TIMER_GLOBAL_EVENT_COUNTER_OVERFLOW:
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	tmr_reg->ctrl1 |= MXC_F_TMR_CTRL1_IE_A;
+	if (timer_priv->bit_mode == MAX_CAPI_TIMER_BIT_MODE_16BIT_DUAL)
+		tmr_reg->ctrl1 |= MXC_F_TMR_CTRL1_IE_B;
+
+	timer_priv->global_events_enabled |= (1 << event);
+
+	return 0;
+}
+
+/**
+ * @brief Disable an event
+ * @param handle The timer handle
+ * @param event The event to disable
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_timer_event_irq_disable(struct capi_timer_handle *handle,
+				     uint32_t event)
+{
+	struct max_capi_timer_priv *timer_priv;
+	mxc_tmr_regs_t *tmr_reg;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	timer_priv = handle->priv;
+	tmr_reg = MXC_TMR_GET_TMR(timer_priv->identifier);
+
+	if (event >= CAPI_TIMER_GLOBAL_EVENT_LIMIT)
+		return -EINVAL;
+
+	switch (event) {
+	case CAPI_TIMER_GLOBAL_EVENT_COUNTER_OVERFLOW:
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	timer_priv->global_events_enabled &= ~(1 << event);
+
+	if (timer_priv->global_events_enabled == 0) {
+		bool has_channel_events = false;
+		if (timer_priv->channel[0] && timer_priv->channel[0]->events_enabled)
+			has_channel_events = true;
+		if (timer_priv->channel[1] && timer_priv->channel[1]->events_enabled)
+			has_channel_events = true;
+
+		if (!has_channel_events) {
+			tmr_reg->ctrl1 &= ~MXC_F_TMR_CTRL1_IE_A;
+			if (timer_priv->bit_mode == MAX_CAPI_TIMER_BIT_MODE_16BIT_DUAL)
+				tmr_reg->ctrl1 &= ~MXC_F_TMR_CTRL1_IE_B;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Register a callback for global events
+ * @param handle The timer handle
+ * @param callback The callback to register
+ * @param callback_arg Argument to pass to the callback
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_timer_register_event_callback(struct capi_timer_handle *handle,
+		capi_timer_event_callback callback,
+		void *callback_arg)
+{
+	struct max_capi_timer_priv *timer_priv;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	timer_priv = handle->priv;
+
+	timer_priv->global_callback = callback;
+	timer_priv->global_callback_arg = callback_arg;
+
+	return 0;
+}
+
+/**
+ * @brief Enable interrupts for a specific channel
+ * @param handle The timer handle
+ * @param chan The channel (0 = Timer A, 1 = Timer B)
+ * @param event The event to enable
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_timer_channel_irq_enable(struct capi_timer_handle *handle,
+				      uint32_t chan, uint32_t event)
+{
+	struct max_capi_timer_priv *timer_priv;
+	mxc_tmr_regs_t *tmr_reg;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	timer_priv = handle->priv;
+	tmr_reg = MXC_TMR_GET_TMR(timer_priv->identifier);
+
+	if (timer_priv->bit_mode == MAX_CAPI_TIMER_BIT_MODE_32BIT) {
+		if (chan != 0)
+			return -EINVAL;
+	} else {
+		if (chan > 1)
+			return -EINVAL;
+	}
+
+	if (!timer_priv->channel[chan])
+		return -EINVAL;
+
+	if (event >= CAPI_TIMER_CHANNEL_EVENT_LIMIT)
+		return -EINVAL;
+
+	switch (event) {
+	case CAPI_TIMER_CHANNEL_EVENT_COMPARE:
+		break;
+	case CAPI_TIMER_CHANNEL_EVENT_CAPTURE:
+		return -ENOTSUP;
+	default:
+		return -EINVAL;
+	}
+
+	timer_priv->channel[chan]->events_enabled |= (1 << event);
+
+	if (chan == 0)
+		tmr_reg->ctrl1 |= MXC_F_TMR_CTRL1_IE_A;
+	else
+		tmr_reg->ctrl1 |= MXC_F_TMR_CTRL1_IE_B;
+
+	return 0;
+}
+
+/**
+ * @brief Disable interrupts for a specific channel
+ * @param handle The timer handle
+ * @param chan The channel (0 = Timer A, 1 = Timer B)
+ * @param event The event to disable
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_timer_channel_irq_disable(struct capi_timer_handle *handle,
+				       uint32_t chan, uint32_t event)
+{
+	struct max_capi_timer_priv *timer_priv;
+	mxc_tmr_regs_t *tmr_reg;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	timer_priv = handle->priv;
+	tmr_reg = MXC_TMR_GET_TMR(timer_priv->identifier);
+
+	if (timer_priv->bit_mode == MAX_CAPI_TIMER_BIT_MODE_32BIT) {
+		if (chan != 0)
+			return -EINVAL;
+	} else {
+		if (chan > 1)
+			return -EINVAL;
+	}
+
+	if (!timer_priv->channel[chan])
+		return -EINVAL;
+
+	if (event >= CAPI_TIMER_CHANNEL_EVENT_LIMIT)
+		return -EINVAL;
+
+	switch (event) {
+	case CAPI_TIMER_CHANNEL_EVENT_COMPARE:
+		break;
+	case CAPI_TIMER_CHANNEL_EVENT_CAPTURE:
+		return -ENOTSUP;
+	default:
+		return -EINVAL;
+	}
+
+	timer_priv->channel[chan]->events_enabled &= ~(1 << event);
+
+	if (timer_priv->channel[chan]->events_enabled == 0) {
+		if (chan == 0)
+			tmr_reg->ctrl1 &= ~MXC_F_TMR_CTRL1_IE_A;
+		else
+			tmr_reg->ctrl1 &= ~MXC_F_TMR_CTRL1_IE_B;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Register a callback for a specific channel
+ * @param handle The timer handle
+ * @param chan The channel (0 = Timer A, 1 = Timer B)
+ * @param callback The callback to register
+ * @param callback_arg Argument to pass to the callback
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_timer_channel_register_callback(struct capi_timer_handle *handle,
+		uint32_t chan,
+		capi_timer_channel_callback callback,
+		void *callback_arg)
+{
+	struct max_capi_timer_priv *timer_priv;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	timer_priv = handle->priv;
+
+	if (timer_priv->bit_mode == MAX_CAPI_TIMER_BIT_MODE_32BIT) {
+		if (chan != 0)
+			return -EINVAL;
+	} else {
+		if (chan > 1)
+			return -EINVAL;
+	}
+
+	if (!timer_priv->channel[chan])
+		return -EINVAL;
+
+	timer_priv->channel[chan]->callback = callback;
+	timer_priv->channel[chan]->callback_arg = callback_arg;
+
+	return 0;
+}
+
+/**
+ * @brief Check if an IRQ is pending
+ * @param handle The timer handle
+ * @param pending Where to store if pending or not
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_timer_is_irq_pending(struct capi_timer_handle *handle,
+				  bool *pending)
+{
+	struct max_capi_timer_priv *timer_priv;
+	uint32_t flags;
+
+	if (!handle || !handle->priv || !pending)
+		return -EINVAL;
+
+	timer_priv = handle->priv;
+
+	flags = MXC_TMR_GetFlags(MXC_TMR_GET_TMR(timer_priv->identifier));
+
+	*pending = (flags & (MXC_F_TMR_INTFL_IRQ_A | MXC_F_TMR_INTFL_IRQ_B));
+
+	return 0;
+}
+
+/**
+ * @brief The ISR for the timer peripheral
+ * @param handle The timer handle
+ */
+void max_capi_timer_isr(void *handle)
+{
+	struct capi_timer_handle *timer_handle = (struct capi_timer_handle *)handle;
+	struct max_capi_timer_priv *timer_priv;
+	uint32_t flags;
+
+	if (!handle || !timer_handle->priv)
+		return;
+
+	timer_priv = timer_handle->priv;
+	flags = MXC_TMR_GetFlags(MXC_TMR_GET_TMR(timer_priv->identifier));
+
+	if (flags & MXC_F_TMR_INTFL_IRQ_A) {
+		if ((timer_priv->global_events_enabled & (1 <<
+				CAPI_TIMER_GLOBAL_EVENT_COUNTER_OVERFLOW))
+		    && timer_priv->global_callback) {
+			timer_priv->global_callback(CAPI_TIMER_GLOBAL_EVENT_COUNTER_OVERFLOW,
+						    timer_priv->global_callback_arg,
+						    0);
+		}
+
+		if (timer_priv->channel[0]
+		    && (timer_priv->channel[0]->events_enabled) & (1 <<
+				    CAPI_TIMER_CHANNEL_EVENT_COMPARE)
+		    && timer_priv->channel[0]->callback) {
+			timer_priv->channel[0]->callback(CAPI_TIMER_CHANNEL_EVENT_COMPARE,
+							 0,
+							 timer_priv->channel[0]->callback_arg,
+							 0);
+		}
+	}
+
+	if (flags & MXC_F_TMR_INTFL_IRQ_B) {
+		if ((timer_priv->global_events_enabled & (1 <<
+				CAPI_TIMER_GLOBAL_EVENT_COUNTER_OVERFLOW))
+		    && timer_priv->global_callback) {
+			timer_priv->global_callback(CAPI_TIMER_GLOBAL_EVENT_COUNTER_OVERFLOW,
+						    timer_priv->global_callback_arg,
+						    1);
+		}
+
+		if (timer_priv->channel[1]
+		    && (timer_priv->channel[1]->events_enabled & (1 <<
+				    CAPI_TIMER_CHANNEL_EVENT_COMPARE))
+		    && timer_priv->channel[1]->callback) {
+			timer_priv->channel[1]->callback(CAPI_TIMER_CHANNEL_EVENT_COMPARE,
+							 1,
+							 timer_priv->channel[1]->callback_arg,
+							 0);
+		}
+	}
+
+	MXC_TMR_ClearFlags(MXC_TMR_GET_TMR(timer_priv->identifier));
+}
+
+struct capi_timer_ops max_capi_timer_ops = {
+	.init = max_capi_timer_init,
+	.deinit = max_capi_timer_deinit,
+	.start = max_capi_timer_start,
+	.stop = max_capi_timer_stop,
+	.counter_config = max_capi_timer_counter_config,
+	.counter_get = max_capi_timer_counter_get,
+	.event_irq_enable = max_capi_timer_event_irq_enable,
+	.event_irq_disable = max_capi_timer_event_irq_disable,
+	.register_event_callback = max_capi_timer_register_event_callback,
+	.channel_init = max_capi_timer_channel_init,
+	.channel_deinit = max_capi_timer_channel_deinit,
+	.channel_config = max_capi_timer_channel_config,
+	.channel_enable = max_capi_timer_channel_enable,
+	.channel_disable = max_capi_timer_channel_disable,
+	.channel_compare_set = max_capi_timer_channel_compare_set,
+	.channel_compare_get = max_capi_timer_channel_compare_get,
+	.channel_capture_get = max_capi_timer_channel_capture_get,
+	.channel_irq_enable = max_capi_timer_channel_irq_enable,
+	.channel_irq_disable = max_capi_timer_channel_irq_disable,
+	.channel_register_callback = max_capi_timer_channel_register_callback,
+	.is_irq_pending = max_capi_timer_is_irq_pending,
+	.isr = max_capi_timer_isr,
+	.nsec_to_ticks = max_capi_timer_nsec_to_ticks,
+	.ticks_to_nsec = max_capi_timer_ticks_to_nsec,
+};

--- a/capi/platform/maxim/max32657/maxim_capi_timer.h
+++ b/capi/platform/maxim/max32657/maxim_capi_timer.h
@@ -1,0 +1,160 @@
+/*******************************************************************************
+ *   @file   maxim_capi_timer.h
+ *   @brief  Header file for Timer and PWM functions
+ *   @author Ramon Miguel Imbao (ramonmiguel.imbao@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef MAXIM_CAPI_TIMER_H_
+#define MAXIM_CAPI_TIMER_H_
+
+#include "capi_timer.h"
+#include "tmr.h"
+#include "maxim_capi_gpio.h"
+#include "capi_alloc.h"
+
+#define MAX_CAPI_PWM_TMR_MAX_VAL	0x0000FFFF
+#define MAX_CAPI_PWM_PRESCALER_VAL(n)	((n - 1U) * 16)
+#define MAX_CAPI_PWM_PRESCALER_TRUE(n)	(1U << ((n) / 16))
+#define MAX_CAPI_PWM_GET_PRESCALER(n)	(1U << ((n) - 1))
+#define MAX_CAPI_MAX_PRESCALER_INDEX	13U	/* 2^(13 - 1) = 4096 */
+
+enum max_capi_timer_clock_source {
+	/** Peripheral clock */
+	MAX_CAPI_TIMER_CLOCK_APB,
+	/** External clock input */
+	MAX_CAPI_TIMER_CLOCK_EXTERNAL,
+	/** Internal baud rate oscillator (7.3728 MHz) */
+	MAX_CAPI_TIMER_CLOCK_IBRO,
+	/** External RTC oscillator (32.768 kHz) */
+	MAX_CAPI_TIMER_CLOCK_ERTCO,
+	/** Internal nano-ring oscillator */
+	MAX_CAPI_TIMER_CLOCK_INRO,
+	/** IBRO divided by 8 (921.6 kHz) */
+	MAX_CAPI_TIMER_CLOCK_IBRO_DIV8,
+};
+
+enum max_capi_timer_bit_mode {
+	/** 32-bit timer mode */
+	MAX_CAPI_TIMER_BIT_MODE_32BIT,
+	/** 16-bit timer mode */
+	MAX_CAPI_TIMER_BIT_MODE_16BIT_DUAL,
+};
+
+enum max_capi_timer_channel_mode {
+	MAX_CAPI_TIMER_MODE_ONESHOT = CAPI_TIMER_CHANNEL_MODE_LIMIT,
+	MAX_CAPI_TIMER_MODE_CONTINUOUS,
+	MAX_CAPI_TIMER_MODE_COUNTER,
+	MAX_CAPI_TIMER_MODE_GATED,
+	MAX_CAPI_TIMER_MODE_CAPTURE_COMPARE,
+	MAX_CAPI_TIMER_MODE_DUAL_EDGE,
+};
+
+struct max_capi_timer_extra {
+	/** Timer bit mode (32-bit or 16-bit dual) */
+	enum max_capi_timer_bit_mode bit_mode;
+};
+
+struct max_capi_timer_channel_extra {
+	/** GPIO voltage selection */
+	enum max_capi_gpio_vssel vssel;
+	/** GPIO initialization flag */
+	bool init_pin;
+	/** Alternate pin selection */
+	bool use_alternate_pin;
+};
+
+struct max_capi_timer_counter_extra {
+	/** GPIO voltage selection */
+	enum max_capi_gpio_vssel vssel;
+	/** GPIO initialization flag */
+	bool init_pin;
+	/** Alternate pin selection */
+	bool use_alternate_pin;
+};
+
+struct max_capi_timer_channel_state {
+	/** Timer config */
+	mxc_tmr_cfg_t config;
+	/** PWM mode parameters */
+	struct {
+		/** PWM period in ticks */
+		uint32_t period_ticks;
+		/** Duty cycle in ticks */
+		uint32_t duty_cycle_ticks;
+	} pwm;
+	/** Compare mode parameters */
+	struct {
+		/** Compare match value */
+		uint32_t value;
+	} compare;
+	/** GPIO initialization flag */
+	bool init_pin;
+	/** Alternate pin selection */
+	bool use_alternate_pin;
+	/** GPIO voltage selection */
+	enum max_capi_gpio_vssel vssel;
+	/** GPIO already initialized flag */
+	bool gpio_initialized;
+	/** Channel-specific event callback */
+	capi_timer_channel_callback callback;
+	/** Event callback arg */
+	void *callback_arg;
+	/** Channel event enable mask */
+	uint32_t events_enabled;
+	/** Timer enabled */
+	bool enabled;
+};
+
+struct max_capi_timer_priv {
+	/** Timer ID */
+	uint32_t identifier;
+	/** Timer frequency */
+	uint32_t frequency;
+	/** 32-bit or dual 16-bit mode */
+	enum max_capi_timer_bit_mode bit_mode;
+	/** Timer A/B state */
+	struct max_capi_timer_channel_state *channel[2];
+	/** Global timer event callback */
+	capi_timer_event_callback global_callback;
+	/** Global timer event callback arg */
+	void *global_callback_arg;
+	/** Bitmask for enabled global events */
+	uint32_t global_events_enabled;
+	/** Clock source */
+	enum max_capi_timer_clock_source clock_source;
+	/** Clock source frequency */
+	uint32_t clock_freq_hz;
+	/** MSDK clock storage */
+	mxc_tmr_clock_t msdk_clock;
+};
+
+extern struct capi_timer_ops max_capi_timer_ops;
+
+#endif /* MAXIM_CAPI_TIMER_H_ */

--- a/capi/platform/maxim/max32657/maxim_capi_trng.c
+++ b/capi/platform/maxim/max32657/maxim_capi_trng.c
@@ -1,0 +1,322 @@
+/*******************************************************************************
+ *   @file   maxim_capi_trng.c
+ *   @brief  Implementation of TRNG functions
+ *   @author Ramon Miguel Imbao (ramonmiguel.imbao@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <stdlib.h>
+#include <errno.h>
+#include "capi_trng.h"
+#include "maxim_capi_trng.h"
+#include "maxim_capi_irq.h"
+#include "trng.h"
+#include "max32657.h"
+
+/** Static variables **********************************************************/
+
+static struct capi_trng_handle *trng = NULL;
+
+/** Forward declarations ******************************************************/
+
+void max_capi_trng_isr(void *handle);
+
+/** Helper functions **********************************************************/
+
+/**
+ * @brief Callback function to pass to MXC_TRNG_RandomAsync
+ * @param req MSDK-managed parameter (not used)
+ * @param result The result of the callback
+ */
+static void _max_capi_trng_msdk_callback(void *req, int result)
+{
+	struct max_capi_trng_priv *trng_priv;
+	enum capi_trng_async_event event;
+
+	if (!trng || !trng->priv)
+		return;
+
+	trng_priv = trng->priv;
+
+	if (trng_priv->callback) {
+		event = (result == E_NO_ERROR)
+			? CAPI_TRNG_EVENT_GENERATION_COMPLETE
+			: CAPI_TRNG_EVENT_ERROR;
+		trng_priv->callback(event, trng_priv->callback_arg, result);
+	}
+}
+
+/** Function implementations **************************************************/
+
+/**
+ * @brief Initialize the TRNG peripheral
+ * @param handle Pointer to the TRNG handle
+ * @param config Configuration struct
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_trng_init(struct capi_trng_handle **handle,
+		       const struct capi_trng_config *config)
+{
+	int ret;
+	struct capi_trng_handle *trng_handle;
+	struct max_capi_trng_priv *trng_priv;
+
+	if (!handle || !config)
+		return -EINVAL;
+
+	if (config->identifier != 0)
+		return -EINVAL;
+
+	if (trng != NULL) {
+		*handle = trng;
+		return 0;
+	}
+
+	if (*handle == NULL) {
+		trng_handle = capi_calloc(1, sizeof(*trng_handle));
+		if (!trng_handle)
+			return -ENOMEM;
+		trng_handle->init_allocated = true;
+	} else {
+		trng_handle = *handle;
+		trng_handle->init_allocated = false;
+	}
+
+	trng_priv = capi_calloc(1, sizeof(*trng_priv));
+	if (!trng_priv) {
+		ret = -ENOMEM;
+		goto free_handle;
+	}
+
+	trng_handle->priv = trng_priv;
+	trng_handle->ops = config->ops;
+
+	ret = MXC_TRNG_Init();
+	if (ret)
+		goto free_priv;
+
+	struct capi_irq_config irq_config = {
+		.irq_ctrl_id = 0,
+	};
+
+	ret = capi_irq_init(&irq_config);
+	if (ret && ret != -EBUSY) {
+		/* -EBUSY means IRQ already initialized, which is fine since
+		   it uses a singleton pattern. */
+		goto free_priv;
+	}
+
+	ret = capi_irq_connect(TRNG_IRQn, max_capi_trng_isr, trng_handle);
+	if (ret)
+		goto free_priv;
+
+	ret = capi_irq_set_priority(TRNG_IRQn, config->irq_priority);
+	if (ret)
+		goto free_priv;
+
+	ret = capi_irq_enable(TRNG_IRQn);
+	if (ret)
+		goto free_priv;
+
+	trng = trng_handle;
+	*handle = trng_handle;
+
+	return 0;
+
+free_priv:
+	MXC_TRNG_Shutdown();
+	capi_free(trng_priv);
+free_handle:
+	if (trng_handle->init_allocated)
+		capi_free(trng_handle);
+
+	trng = NULL;
+
+	return ret;
+}
+
+/**
+ * @brief Deinitialize the TRNG peripheral
+ * @param handle The TRNG handle
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_trng_deinit(struct capi_trng_handle *handle)
+{
+	int ret;
+	struct max_capi_trng_priv *trng_priv;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	trng_priv = handle->priv;
+
+	capi_irq_disable(TRNG_IRQn);
+
+	ret = MXC_TRNG_Shutdown();
+
+	capi_free(handle->priv);
+
+	if (handle->init_allocated)
+		capi_free(handle);
+
+	trng = NULL;
+
+	return ret;
+}
+
+/**
+ * @brief Generate an unsigned 32-bit number (blocking)
+ * @param handle The TRNG handle
+ * @param value Where to store the unsigned 32-bit number
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_trng_generate_u32(struct capi_trng_handle *handle, uint32_t *value)
+{
+	if (!handle || !handle->priv || !value)
+		return -EINVAL;
+
+	*value = (uint32_t)MXC_TRNG_RandomInt();
+
+	return 0;
+}
+
+/**
+ * @brief Fill a buffer with random bytes (blocking)
+ * @param handle The TRNG handle
+ * @param buffer The data buffer to store bytes to
+ * @param length The length of the buffer
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_trng_fill_buffer(struct capi_trng_handle *handle, uint8_t *buffer,
+			      uint32_t length)
+{
+	int ret;
+
+	if (!handle || !handle->priv || !buffer)
+		return -EINVAL;
+
+	if (length == 0)
+		return -EINVAL;
+
+	ret = MXC_TRNG_Random(buffer, length);
+	if (ret != E_NO_ERROR)
+		return -EINVAL;
+
+	return 0;
+}
+
+/**
+ * @brief Fill a buffer with random bytes (non-blocking)
+ * @param handle The TRNG handle
+ * @param buffer The data buffer to store bytes to
+ * @param length The length of the buffer
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_trng_fill_buffer_async(struct capi_trng_handle *handle,
+				    uint8_t *buffer, uint32_t length)
+{
+	if (!handle || !handle->priv || !buffer)
+		return -EINVAL;
+
+	if (length == 0)
+		return -EINVAL;
+
+	MXC_TRNG_RandomAsync(buffer, length, _max_capi_trng_msdk_callback);
+
+	return 0;
+}
+
+/**
+ * @brief Register a callback
+ * @param handle The TRNG handle
+ * @param callback The callback function
+ * @param callback_arg The callback function argument
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_trng_register_callback(struct capi_trng_handle *handle,
+				    capi_trng_callback_t callback,
+				    void *callback_arg)
+{
+	struct max_capi_trng_priv *trng_priv;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	trng_priv = handle->priv;
+
+	trng_priv->callback = callback;
+	trng_priv->callback_arg = callback_arg;
+
+	return 0;
+}
+
+/**
+ * @brief Perform entropy source health test
+ * @param handle The TRNG handle
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_trng_health_test(struct capi_trng_handle *handle)
+{
+	int ret;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	ret = MXC_TRNG_HealthTest();
+	if (ret != E_NO_ERROR)
+		return -EINVAL;
+
+	return 0;
+}
+
+/**
+ * @brief Interrupt handler for the TRNG peripheral
+ * @param handle The TRNG handle
+ */
+void max_capi_trng_isr(void *handle)
+{
+	struct capi_trng_handle *trng_handle = (struct capi_trng_handle *)handle;
+
+	if (!trng_handle || !trng_handle->priv)
+		return;
+
+	MXC_TRNG_Handler();
+}
+
+const struct capi_trng_ops max_capi_trng_ops = {
+	.init = max_capi_trng_init,
+	.deinit = max_capi_trng_deinit,
+	.generate_u32 = max_capi_trng_generate_u32,
+	.fill_buffer = max_capi_trng_fill_buffer,
+	.fill_buffer_async = max_capi_trng_fill_buffer_async,
+	.register_callback = max_capi_trng_register_callback,
+	.health_test = max_capi_trng_health_test,
+	.isr = max_capi_trng_isr,
+};
+

--- a/capi/platform/maxim/max32657/maxim_capi_trng.h
+++ b/capi/platform/maxim/max32657/maxim_capi_trng.h
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ *   @file   maxim_capi_trng.h
+ *   @brief  Header file for TRNG functions
+ *   @author Ramon Miguel Imbao (ramonmiguel.imbao@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef MAXIM_CAPI_TRNG_H_
+#define MAXIM_CAPI_TRNG_H_
+
+#include "capi_trng.h"
+#include "capi_irq.h"
+
+struct max_capi_trng_priv {
+	/** Callback function for async */
+	capi_trng_callback_t callback;
+	/** Callback argument for async */
+	void *callback_arg;
+};
+
+extern const struct capi_trng_ops max_capi_trng_ops;
+
+#endif /* MAXIM_CAPI_TRNG_H_ */

--- a/capi/platform/maxim/max32657/maxim_capi_uart.c
+++ b/capi/platform/maxim/max32657/maxim_capi_uart.c
@@ -1,0 +1,1152 @@
+/*******************************************************************************
+ *   @file   maxim_capi_uart.c
+ *   @brief  Implementation of UART functions with CAPI.
+ *   @author Ramon Miguel Imbao (ramonmiguel.imbao@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <errno.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "capi_dma.h"
+#include "capi_irq.h"
+#include "capi_uart.h"
+#include "maxim_capi_irq.h"
+#include "maxim_capi_uart.h"
+#include <sys/stat.h>
+
+/** Static declarations *******************************************************/
+
+static struct capi_uart_handle *uart[MXC_UART_INSTANCES] = {NULL};
+static int8_t stdio_index = -1;
+static bool async_transfer_in_progress[MXC_UART_INSTANCES] = {false};
+static volatile bool dma_completed[MXC_UART_INSTANCES] = {false};
+static struct capi_dma_chan *dma_channel_tx[MXC_UART_INSTANCES] = {NULL};
+static struct capi_dma_chan *dma_channel_rx[MXC_UART_INSTANCES] = {NULL};
+
+/** Forward declarations ******************************************************/
+
+void max_capi_uart_isr(void *handle);
+
+/** Helper functions **********************************************************/
+
+/**
+ * @brief Configure the VDDIO for the UART pins.
+ * @param vssel - the voltage level of the interface.
+ * @return 0 in case of success, errno codes otherwise.
+ */
+static int32_t _max_uart_pins_config(enum max_capi_gpio_vssel vssel)
+{
+	mxc_gpio_cfg_t uart_pins = gpio_cfg_uart;
+	int ret;
+
+	uart_pins = gpio_cfg_uart;
+
+	uart_pins.vssel = (mxc_gpio_vssel_t)vssel;
+	ret = MXC_GPIO_Config(&uart_pins);
+
+	return ret;
+}
+
+/**
+ * @brief Release a DMA channel
+ * @param channel Pointer to a channel pointer
+ */
+static void _max_capi_uart_dma_cleanup_channel(struct capi_dma_chan **channel)
+{
+	if (channel && *channel) {
+		capi_dma_xfer_abort(*channel);
+		capi_dma_deinit_chan(*channel);
+		*channel = NULL;
+	}
+}
+
+/**
+ * @brief MSDK completion callback function
+ * @param req The UART
+ * @param result Result
+ */
+static void _max_capi_uart_msdk_callback(mxc_uart_req_t *req, int result)
+{
+	uint32_t id = MXC_UART_GET_IDX(req->uart);
+	struct capi_uart_handle *handle = uart[id];
+	struct max_capi_uart_priv *uart_priv;
+	enum capi_uart_async_event event;
+	bool is_tx;
+
+	if (!handle || !handle->priv)
+		return;
+
+	uart_priv = handle->priv;
+	is_tx = (req->txData != NULL);
+
+	if (result == E_NO_ERROR)
+		event = is_tx ? CAPI_UART_EVENT_TX_DONE : CAPI_UART_EVENT_RX_DONE;
+	else if (result == E_ABORT && is_tx)
+		event = CAPI_UART_EVENT_TX_ABORTED;
+	else
+		event = CAPI_UART_EVENT_INTERRUPT;
+
+	async_transfer_in_progress[id] = false;
+
+	if (uart_priv->callback)
+		uart_priv->callback(event, uart_priv->callback_arg, result);
+}
+
+/**
+ * @brief DMA transfer complete callback function
+ * @param event The event indicating completion status
+ * @param ctx The private struct passed into the callback
+ */
+static void _max_capi_uart_dma_complete(uint32_t event, void *ctx)
+{
+	struct max_capi_uart_priv *uart_priv = (struct max_capi_uart_priv *)ctx;
+	uint32_t id;
+	capi_uart_callback callback;
+	void *callback_arg;
+
+	if (!uart_priv)
+		return;
+
+	id = uart_priv->id;
+
+	callback = uart_priv->callback;
+	callback_arg = uart_priv->callback_arg;
+
+	dma_completed[id] = true;
+
+	uart_priv->uart->dma &= ~(MXC_F_UART_DMA_TX_EN | MXC_F_UART_DMA_RX_EN);
+	_max_capi_uart_dma_cleanup_channel(&dma_channel_rx[id]);
+	_max_capi_uart_dma_cleanup_channel(&dma_channel_tx[id]);
+
+	async_transfer_in_progress[id] = false;
+
+	if (callback)
+		callback(event, callback_arg, 0);
+}
+
+/**
+ * @brief Receive with DMA
+ * @param priv The private structure
+ * @param buf The buffer to store the data to
+ * @param len The length of the data
+ */
+static int _max_capi_uart_receive_dma(struct max_capi_uart_priv *priv,
+				      uint8_t *buf, uint32_t len)
+{
+	int ret;
+
+	ret = capi_dma_init_chan(priv->dma_handle, &dma_channel_rx[priv->id], 0);
+	if (ret)
+		goto error;
+
+	priv->dma_xfer_extra = (struct max_capi_dma_xfer_extra) {
+		.reqsel = MAX_CAPI_DMA_REQUEST_UART_RX,
+	};
+	priv->dma_xfer = (struct capi_dma_transfer) {
+		.src = (capi_dma_glbl_addr_t)&priv->uart->fifo,
+		.dst = (capi_dma_glbl_addr_t)buf,
+		.src_inc = CAPI_DMA_NO_INCREMENT,
+		.dst_inc = CAPI_DMA_BYTE_INCREMENT,
+		.src_size = CAPI_DMA_XFER_SIZE_1_BYTE,
+		.dst_size = CAPI_DMA_XFER_SIZE_1_BYTE,
+		.length = len,
+		.xfer_type = CAPI_DMA_DEV_TO_MEM,
+		.user_data = priv,
+	};
+
+	priv->uart->dma |= MXC_F_UART_DMA_RX_EN;
+
+	ret = capi_dma_config_xfer(dma_channel_rx[priv->id], &priv->dma_xfer);
+	if (ret)
+		goto error_deinit;
+
+	ret = capi_dma_register_complete_callback(dma_channel_rx[priv->id],
+			_max_capi_uart_dma_complete,
+			priv);
+	if (ret)
+		goto error_deinit;
+
+	dma_completed[priv->id] = false;
+	async_transfer_in_progress[priv->id] = true;
+
+	ret = capi_dma_xfer_start(dma_channel_rx[priv->id]);
+	if (ret)
+		goto error_deinit;
+
+	return 0;
+
+error_deinit:
+	priv->uart->dma &= ~MXC_F_UART_DMA_RX_EN;
+	_max_capi_uart_dma_cleanup_channel(&dma_channel_rx[priv->id]);
+error:
+	async_transfer_in_progress[priv->id] = false;
+
+	return ret;
+}
+
+/**
+ * @brief Transmit with DMA
+ * @brief priv The private structure
+ * @param buf The buffer to get data from
+ * @param len The length of the data
+ */
+static int _max_capi_uart_transmit_dma(struct max_capi_uart_priv *priv,
+				       uint8_t *buf, uint32_t len)
+{
+	int ret;
+
+	ret = capi_dma_init_chan(priv->dma_handle, &dma_channel_tx[priv->id], 0);
+	if (ret)
+		goto error;
+
+	priv->dma_xfer_extra = (struct max_capi_dma_xfer_extra) {
+		.reqsel = MAX_CAPI_DMA_REQUEST_UART_TX,
+	};
+	priv->dma_xfer = (struct capi_dma_transfer) {
+		.src = (capi_dma_glbl_addr_t)buf,
+		.dst = (capi_dma_glbl_addr_t)&priv->uart->fifo,
+		.src_inc = CAPI_DMA_BYTE_INCREMENT,
+		.dst_inc = CAPI_DMA_NO_INCREMENT,
+		.src_size = CAPI_DMA_XFER_SIZE_1_BYTE,
+		.dst_size = CAPI_DMA_XFER_SIZE_1_BYTE,
+		.length = len,
+		.xfer_type = CAPI_DMA_MEM_TO_DEV,
+		.user_data = priv,
+	};
+
+	priv->uart->dma |= MXC_F_UART_DMA_TX_EN;
+
+	ret = capi_dma_config_xfer(dma_channel_tx[priv->id], &priv->dma_xfer);
+	if (ret)
+		goto error_deinit;
+
+	ret = capi_dma_register_complete_callback(dma_channel_tx[priv->id],
+			_max_capi_uart_dma_complete,
+			priv);
+	if (ret)
+		goto error_deinit;
+
+	dma_completed[priv->id] = false;
+	async_transfer_in_progress[priv->id] = true;
+
+	ret = capi_dma_xfer_start(dma_channel_tx[priv->id]);
+	if (ret)
+		goto error_deinit;
+
+	return 0;
+
+error_deinit:
+	priv->uart->dma &= ~MXC_F_UART_DMA_TX_EN;
+	_max_capi_uart_dma_cleanup_channel(&dma_channel_tx[priv->id]);
+error:
+	async_transfer_in_progress[priv->id] = false;
+
+	return ret;
+}
+
+/**
+ * @brief Converts CAPI enum values to msdk values for line config
+ * @param line_config The line config
+ * @param[out] size Number of data bits
+ * @param[out] parity Parity
+ * @param[out] stop Stop bits
+ * @return 0 on success, negative error code otherwise
+ */
+static int _max_capi_uart_map_line_config(const struct capi_uart_line_config
+		*line_config,
+		uint32_t *size,
+		mxc_uart_parity_t *parity,
+		mxc_uart_stop_t *stop)
+{
+	switch (line_config->size) {
+	case CAPI_UART_DATA_BITS_5:
+		*size = 5;
+		break;
+	case CAPI_UART_DATA_BITS_6:
+		*size = 6;
+		break;
+	case CAPI_UART_DATA_BITS_7:
+		*size = 7;
+		break;
+	case CAPI_UART_DATA_BITS_8:
+		*size = 8;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	switch (line_config->parity) {
+	case CAPI_UART_PARITY_NONE:
+		*parity = MXC_UART_PARITY_DISABLE;
+		break;
+	case CAPI_UART_PARITY_ODD:
+		*parity = MXC_UART_PARITY_ODD_1;
+		break;
+	case CAPI_UART_PARITY_EVEN:
+		*parity = MXC_UART_PARITY_EVEN_1;
+		break;
+	case CAPI_UART_PARITY_MARK:
+	case CAPI_UART_PARITY_SPACE:
+		return -ENOTSUP;
+	default:
+		return -EINVAL;
+	}
+
+	switch (line_config->stop_bits) {
+	case CAPI_UART_STOP_1_BIT:
+		*stop = MXC_UART_STOP_1;
+		break;
+	case CAPI_UART_STOP_2_BIT:
+		*stop = MXC_UART_STOP_2;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+/** UART implementation *******************************************************/
+
+/**
+ * @brief Initialize the UART peripheral
+ * @param handle Pointer to a UART handle pointer
+ * @param config UART config struct
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_uart_init(struct capi_uart_handle **handle,
+		       const struct capi_uart_config *config)
+{
+	int ret;
+
+	struct capi_uart_handle *uart_handle;
+	struct max_capi_uart_priv *uart_priv;
+	struct max_capi_uart_extra *uart_extra;
+	mxc_uart_clock_t clk_src;
+	uint32_t baud_rate, size;
+	mxc_uart_parity_t parity;
+	mxc_uart_stop_t stop;
+	struct capi_uart_line_config line_cfg;
+
+	if (!handle || !config || !config->extra)
+		return -EINVAL;
+
+	if (config->identifier >= MXC_UART_INSTANCES)
+		return -EINVAL;
+
+	if (uart[config->identifier] != NULL) {
+		*handle = uart[config->identifier];
+		return 0;
+	}
+
+	if (*handle == NULL) {
+		uart_handle = capi_calloc(1, sizeof(*uart_handle));
+		if (!uart_handle)
+			return -ENOMEM;
+		uart_handle->init_allocated = true;
+	} else {
+		uart_handle = *handle;
+		uart_handle->init_allocated = false;
+	}
+
+	uart_priv = capi_calloc(1, sizeof(*uart_priv));
+	if (!uart_priv) {
+		ret = -ENOMEM;
+		goto free_handle;
+	}
+
+	uart_handle->priv = uart_priv;
+	uart_handle->ops = config->ops;
+
+	uart_extra = config->extra;
+
+	uart_priv->uart = MXC_UART_GET_UART(config->identifier);
+	uart_priv->id = config->identifier;
+
+	if (config->clk_freq_hz == 0) {
+		/** Default */
+		clk_src = MXC_UART_APB_CLK;
+	} else if (config->clk_freq_hz == PeripheralClock) {
+		/** APB clock */
+		clk_src = MXC_UART_APB_CLK;
+	} else if (config->clk_freq_hz == IBRO_FREQ) {
+		/** IBRO = 7.3728 MHz */
+		clk_src = MXC_UART_IBRO_CLK;
+	} else {
+		ret = -ENOTSUP;
+		goto free_priv;
+	}
+	uart_priv->clk_src = clk_src;
+
+	baud_rate = MAX_CAPI_UART_DEFAULT_BAUD;
+	if (config->line_config) {
+		line_cfg = *config->line_config;
+		baud_rate = config->line_config->baudrate;
+	} else {
+		line_cfg = (struct capi_uart_line_config) {
+			.baudrate = MAX_CAPI_UART_DEFAULT_BAUD,
+			.size = CAPI_UART_DATA_BITS_8,
+			.parity = CAPI_UART_PARITY_NONE,
+			.stop_bits = CAPI_UART_STOP_1_BIT,
+		};
+	}
+
+	ret = _max_capi_uart_map_line_config(&line_cfg, &size, &parity, &stop);
+	if (ret)
+		goto free_priv;
+
+	uart_priv->line_config = line_cfg;
+
+	ret = MXC_UART_Init(uart_priv->uart, baud_rate, clk_src);
+	if (ret != E_NO_ERROR) {
+		ret = -EINVAL;
+		goto free_priv;
+	}
+
+	ret = _max_uart_pins_config(uart_extra->vssel);
+	if (ret)
+		goto free_priv;
+
+	ret = MXC_UART_SetDataSize(uart_priv->uart, size);
+	if (ret != E_NO_ERROR) {
+		ret = -EINVAL;
+		goto free_priv;
+	}
+
+	ret = MXC_UART_SetParity(uart_priv->uart, parity);
+	if (ret != E_NO_ERROR) {
+		ret = -EINVAL;
+		goto free_priv;
+	}
+
+	ret = MXC_UART_SetStopBits(uart_priv->uart, stop);
+	if (ret != E_NO_ERROR) {
+		ret = -EINVAL;
+		goto free_priv;
+	}
+
+	if (config->dma_handle && uart_extra->dma_config) {
+		uart_priv->dma_handle = config->dma_handle;
+		ret = capi_dma_init(&uart_priv->dma_handle,
+				    uart_extra->dma_config);
+		if (ret)
+			goto shutdown_uart;
+	}
+
+	struct capi_irq_config irq_config = {
+		.irq_ctrl_id = 0,
+	};
+	ret = capi_irq_init(&irq_config);
+	if (ret && ret != -EBUSY) {
+		/* -EBUSY means IRQ already initialized, which is fine since
+		   it uses a singleton pattern. */
+		goto cleanup_channels;
+	}
+
+
+	IRQn_Type irq = MXC_UART_GET_IRQ(config->identifier);
+	ret = capi_irq_connect(irq, max_capi_uart_isr, uart_handle);
+	if (ret)
+		goto cleanup_channels;
+
+	ret = capi_irq_enable(irq);
+	if (ret)
+		goto cleanup_channels;
+
+	uart[config->identifier] = uart_handle;
+	*handle = uart_handle;
+
+	return 0;
+
+cleanup_channels:
+	_max_capi_uart_dma_cleanup_channel(&dma_channel_tx[config->identifier]);
+	_max_capi_uart_dma_cleanup_channel(&dma_channel_rx[config->identifier]);
+shutdown_uart:
+	MXC_UART_Shutdown(uart_priv->uart);
+free_priv:
+	capi_free(uart_priv);
+free_handle:
+	if (uart_handle->init_allocated)
+		capi_free(uart_handle);
+
+	uart[config->identifier] = NULL;
+
+	return ret;
+}
+
+/**
+ * @brief Deinitialize the UART peripheral
+ * @param handle The UART handle
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_uart_deinit(struct capi_uart_handle *handle)
+{
+	struct max_capi_uart_priv *uart_priv;
+	uint8_t id;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	uart_priv = handle->priv;
+	id = uart_priv->id;
+
+	_max_capi_uart_dma_cleanup_channel(&dma_channel_rx[id]);
+	_max_capi_uart_dma_cleanup_channel(&dma_channel_tx[id]);
+	uart_priv->uart->dma &= ~(MXC_F_UART_DMA_RX_EN | MXC_F_UART_DMA_TX_EN);
+	async_transfer_in_progress[id] = false;
+	dma_completed[id] = false;
+
+	capi_irq_disable(MXC_UART_GET_IRQ(id));
+
+	MXC_UART_Shutdown(uart_priv->uart);
+	capi_free(handle->priv);
+	if (handle->init_allocated)
+		capi_free(handle);
+
+	if (stdio_index == id)
+		stdio_index = -1;
+
+	uart[id] = NULL;
+
+	return 0;
+}
+
+/**
+ * @brief Read data from the UART device. Blocking function.
+ * @param handle - UART handle.
+ * @param buf - Pointer to buffer containing data.
+ * @param len - Number of bytes to read.
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_uart_receive(struct capi_uart_handle *handle, uint8_t *buf,
+			  uint32_t len)
+{
+	int ret, n;
+	struct max_capi_uart_priv *uart_priv;
+
+	if (!handle || !handle->priv ||  !buf || !len)
+		return -EINVAL;
+
+	uart_priv = handle->priv;
+
+	n = (int)len;
+
+	ret = MXC_UART_Read(uart_priv->uart, buf, &n);
+	if (ret != E_SUCCESS)
+		return -EIO;
+
+	return 0;
+}
+
+/**
+ * @brief Write data to the UART device. Blocking function.
+ * @param handle - UART handle.
+ * @param buf - Pointer to buffer containing data.
+ * @param len - Number of bytes to write.
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_uart_transmit(struct capi_uart_handle *handle, uint8_t *buf,
+			   uint32_t len)
+{
+	struct max_capi_uart_priv *uart_priv;
+	int32_t transferred = 0;
+	int block_size, ret;
+
+	if (!handle || !handle->priv || !buf || !len)
+		return -EINVAL;
+
+	uart_priv = handle->priv;
+
+	while (len) {
+		block_size = (MXC_UART_FIFO_DEPTH < len ? MXC_UART_FIFO_DEPTH : len);
+		while (!(MXC_UART_GetStatus(uart_priv->uart) &
+			 MXC_F_UART_STATUS_TX_EM));
+		ret = MXC_UART_Write(uart_priv->uart,
+				     (uint8_t *)(buf + transferred),
+				     &block_size);
+		transferred += block_size;
+		len -= block_size;
+
+		if (ret != E_SUCCESS)
+			return -EIO;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Read data from the UART device. Nonblocking function.
+ * @param handle - UART handle.
+ * @param buf - Pointer to buffer containing data.
+ * @param len - Number of bytes to read.
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_uart_receive_async(struct capi_uart_handle *handle, uint8_t *buf,
+				uint32_t len)
+{
+	int ret;
+	uint32_t id;
+	struct max_capi_uart_priv *uart_priv;
+
+	if (!handle || !handle->priv || !buf || !len)
+		return -EINVAL;
+
+	uart_priv = handle->priv;
+	id = uart_priv->id;
+
+	if (async_transfer_in_progress[id])
+		return -EBUSY;
+
+	if (uart_priv->dma_handle)
+		return _max_capi_uart_receive_dma(uart_priv, buf, len);
+
+	uart_priv->async_req = (mxc_uart_req_t) {
+		.uart = uart_priv->uart,
+		.rxData = buf,
+		.rxLen = len,
+		.rxCnt = 0,
+		.txData = NULL,
+		.txLen = 0,
+		.txCnt = 0,
+		.callback = _max_capi_uart_msdk_callback,
+	};
+
+	async_transfer_in_progress[id] = true;
+
+	ret = MXC_UART_TransactionAsync(&uart_priv->async_req);
+	if (ret != E_NO_ERROR) {
+		async_transfer_in_progress[id] = false;
+		return (ret == E_BUSY ? -EBUSY : -EIO);
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Write data from the UART device. Nonblocking function.
+ * @param handle - UART handle.
+ * @param buf - Pointer to buffer to store the data.
+ * @param len - Number of bytes to write.
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_uart_transmit_async(struct capi_uart_handle *handle,
+				 uint8_t *buf, uint32_t len)
+{
+	int ret;
+	uint32_t id;
+	struct max_capi_uart_priv *uart_priv;
+
+	if (!handle || !handle->priv || !buf || !len)
+		return -EINVAL;
+
+	uart_priv = handle->priv;
+	id = uart_priv->id;
+
+	if (async_transfer_in_progress[id])
+		return -EBUSY;
+
+	if (uart_priv->dma_handle)
+		return _max_capi_uart_transmit_dma(uart_priv, buf, len);
+
+	uart_priv->async_req = (mxc_uart_req_t) {
+		.uart = uart_priv->uart,
+		.txData = buf,
+		.txLen = len,
+		.txCnt = 0,
+		.rxData = NULL,
+		.rxLen = 0,
+		.rxCnt = 0,
+		.callback = _max_capi_uart_msdk_callback,
+	};
+
+	async_transfer_in_progress[id] = true;
+
+	ret = MXC_UART_TransactionAsync(&uart_priv->async_req);
+	if (ret != E_NO_ERROR) {
+		async_transfer_in_progress[id] = false;
+		return (ret == E_BUSY ? -EBUSY : -EIO);
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Register a callback
+ * @param handle The UART handle
+ * @param callback The callback function
+ * @param callback_arg Callback arg
+ */
+int max_capi_uart_register_callback(struct capi_uart_handle *handle,
+				    capi_uart_callback const callback,
+				    void *const callback_arg)
+{
+	struct max_capi_uart_priv *uart_priv;
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	uart_priv = handle->priv;
+
+	uart_priv->callback = callback;
+	uart_priv->callback_arg = callback_arg;
+
+	return 0;
+}
+
+/**
+ * @brief Interrupt function for UART
+ * @param handle The UART handle
+ */
+void max_capi_uart_isr(void *handle)
+{
+	struct capi_uart_handle *uart_handle = (struct capi_uart_handle *)handle;
+	struct max_capi_uart_priv *uart_priv;
+
+	if (!uart_handle || !uart_handle->priv)
+		return;
+
+	uart_priv = uart_handle->priv;
+
+	MXC_UART_AsyncHandler(uart_priv->uart);
+}
+
+/**
+ * @brief Set the line config for UART
+ * @param handle The UART handle
+ * @param line_config The line config
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_uart_set_line_config(struct capi_uart_handle *handle,
+				  struct capi_uart_line_config *line_config)
+{
+	struct max_capi_uart_priv *uart_priv;
+	mxc_uart_parity_t parity;
+	mxc_uart_stop_t stop;
+	int ret;
+	uint32_t size;
+
+	if (!handle || !handle->priv || !line_config)
+		return -EINVAL;
+
+	uart_priv = handle->priv;
+
+	ret = _max_capi_uart_map_line_config(line_config, &size, &parity, &stop);
+	if (ret)
+		return ret;
+
+	ret = MXC_UART_SetFrequency(uart_priv->uart, line_config->baudrate,
+				    uart_priv->clk_src);
+	if (ret < 0)
+		return -EINVAL;
+
+	ret = MXC_UART_SetDataSize(uart_priv->uart, size);
+	if (ret != E_NO_ERROR)
+		return -EINVAL;
+
+	ret = MXC_UART_SetParity(uart_priv->uart, parity);
+	if (ret != E_NO_ERROR)
+		return -EINVAL;
+
+	ret = MXC_UART_SetStopBits(uart_priv->uart, stop);
+	if (ret != E_NO_ERROR)
+		return -EINVAL;
+
+	uart_priv->line_config = *line_config;
+
+	return 0;
+}
+
+/**
+ * @brief Get the line config for UART
+ * @param handle The UART handle
+ * @param line_config Where to store the line config
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_uart_get_line_config(struct capi_uart_handle *handle,
+				  struct capi_uart_line_config *line_config)
+{
+	struct max_capi_uart_priv *uart_priv;
+
+	if (!handle || !handle->priv || !line_config)
+		return -EINVAL;
+
+	uart_priv = handle->priv;
+
+	*line_config = uart_priv->line_config;
+	line_config->baudrate = MXC_UART_GetFrequency(uart_priv->uart);
+
+	return 0;
+}
+
+/**
+ * @brief Flush the RX FIFO
+ * @param handle The UART handle
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_uart_flush_rx_fifo(struct capi_uart_handle *handle)
+{
+	struct max_capi_uart_priv *uart_priv;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	uart_priv = handle->priv;
+
+	return MXC_UART_ClearRXFIFO(uart_priv->uart) == E_NO_ERROR ? 0 : -EIO;
+}
+
+/**
+ * @brief Flush the TX FIFO
+ * @param handle The UART handle
+ * @return 0 on succes, negative error code otherwise
+ */
+int max_capi_uart_flush_tx_fifo(struct capi_uart_handle *handle)
+{
+	struct max_capi_uart_priv *uart_priv;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	uart_priv = handle->priv;
+
+	return MXC_UART_ClearTXFIFO(uart_priv->uart) == E_NO_ERROR ? 0 : -EIO;
+}
+
+/**
+ * @brief Get the number of bytes available in the RX FIFO
+ * @param handle The UART handle
+ * @param count Where to store the number of bytes
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_uart_get_rx_fifo_count(struct capi_uart_handle *handle,
+				    uint16_t *count)
+{
+	struct max_capi_uart_priv *uart_priv;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	uart_priv = handle->priv;
+
+	*count = MXC_UART_GetRXFIFOAvailable(uart_priv->uart);
+
+	return 0;
+}
+
+/**
+ * @brief Get the number of queued bytes in the TX FIFO
+ * @param handle The UART handle
+ * @param count Where to store the number of bytes
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_uart_get_tx_fifo_count(struct capi_uart_handle *handle,
+				    uint16_t *count)
+{
+	struct max_capi_uart_priv *uart_priv;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	uart_priv = handle->priv;
+
+	*count = MXC_UART_FIFO_DEPTH - MXC_UART_GetTXFIFOAvailable(uart_priv->uart);
+
+	return 0;
+}
+
+/**
+ * @brief Get the reason for the interrupt
+ * @param handle The UART handle
+ * @param reason Where to store the interrupt reason
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_uart_get_interrupt_reason(struct capi_uart_handle *handle,
+				       enum capi_uart_interrupt_reason *reason)
+{
+	struct max_capi_uart_priv *uart_priv;
+	uint32_t flags;
+
+	if (!handle || !handle->priv || !reason)
+		return -EINVAL;
+
+	uart_priv = handle->priv;
+
+	flags = MXC_UART_GetFlags(uart_priv->uart) & uart_priv->uart->inten;
+
+	if (flags & (MXC_F_UART_INTFL_RX_FERR | MXC_F_UART_INTFL_RX_PAR |
+		     MXC_F_UART_INTFL_RX_OV))
+		*reason = CAPI_UART_INTR_RX_LINE_STATUS;
+	else if (flags & (MXC_F_UART_INTFL_RX_THD | MXC_F_UART_INTFL_RX_FULL))
+		*reason = CAPI_UART_INTR_RX_BUFFER_FULL;
+	else if (flags & (MXC_F_UART_INTFL_TX_THD | MXC_F_UART_INTFL_TX_OB))
+		*reason = CAPI_UART_INTR_TX_BUFFER_EMPTY;
+	else if (flags & MXC_F_UART_INTFL_CTS_EV)
+		*reason = CAPI_UART_INTR_MODEM_STATUS;
+	else
+		return -ENODATA;
+
+	return 0;
+}
+
+/**
+ * @brief Get UART line status flags
+ * @param handle The UART handle
+ * @param status_flags Where to store the status flags
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_uart_get_line_status(struct capi_uart_handle *handle,
+				  uint32_t *status_flags)
+{
+	struct max_capi_uart_priv *uart_priv;
+	uint32_t flags;
+	uint32_t clear = 0;
+	uint32_t status = 0;
+
+	if (!handle || !handle->priv || !status_flags)
+		return -EINVAL;
+
+	uart_priv = handle->priv;
+
+	flags = MXC_UART_GetFlags(uart_priv->uart);
+
+	if (flags & MXC_F_UART_INTFL_RX_FERR) {
+		status |= CAPI_UART_LINE_STAT_FRAMING_ERROR;
+		clear |= MXC_F_UART_INTFL_RX_FERR;
+	}
+	if (flags & MXC_F_UART_INTFL_RX_PAR) {
+		status |= CAPI_UART_LINE_STAT_PARITY_ERROR;
+		clear |= MXC_F_UART_INTFL_RX_PAR;
+	}
+	if (flags & MXC_F_UART_INTFL_RX_OV) {
+		status |= CAPI_UART_LINE_STAT_OVERRUN_ERROR;
+		clear |= MXC_F_UART_INTFL_RX_OV;
+	}
+	/* MAX32657 has no break-detect flag. BREAK_IND is never reported. */
+
+	if (clear)
+		MXC_UART_ClearFlags(uart_priv->uart, clear);
+
+	*status_flags = status;
+
+	return 0;
+}
+
+/**
+ * @brief Enable/disable FIFO - not supported. UART FIFOs are always on
+ * @param handle The UART handle
+ * @param enable Whether to enable or disable
+ * @return -ENOSYS
+ */
+int max_capi_uart_enable_fifo(struct capi_uart_handle *handle, bool enable)
+{
+	return -ENOSYS;
+}
+
+/**
+ * @brief Transmit 9-bit data - not supported. 9-bit mode is not supported.
+ * @param handle The UART handle
+ * @param data The data to transmit
+ * @param is_address Whether it is an address or data byte
+ * @return -ENOSYS
+ */
+int max_capi_uart_transmit_9bit(struct capi_uart_handle *handle, uint16_t data,
+				bool is_address)
+{
+	return -ENOSYS;
+}
+
+/**
+ * @brief Receive 9-bit data - not supported. 9-bit mode is not supported.
+ * @param handle The UART handle
+ * @param data Where to store the data
+ * @param is_address Whether it is an address or data byte
+ * @return -ENOSYS
+ */
+int max_capi_uart_receive_9bit(struct capi_uart_handle *handle, uint16_t *data,
+			       bool *is_address)
+{
+	return -ENOSYS;
+}
+
+/**
+ * @brief Set flow control state - not supported. Flow control is not supported.
+ * @param handle The UART handle
+ * @param rts_state RTS signal state
+ * @param cts_state CTS signal state
+ * @return -ENOSYS
+ */
+int max_capi_uart_set_flow_control_state(struct capi_uart_handle *handle,
+		bool rts_state, bool cts_state)
+{
+	return -ENOSYS;
+}
+
+/**
+ * @brief Get flow control state - not supported. Flow control is not supported.
+ * @param handle The UART handle
+ * @param rts_state Where to store the RTS signal state
+ * @param cts_state Where to store the CTS signal state
+ * @return -ENOSYS
+ */
+int max_capi_uart_get_flow_control_state(struct capi_uart_handle *handle,
+		bool *rts_state, bool *cts_state)
+{
+	return -ENOSYS;
+}
+
+struct capi_uart_ops max_capi_uart_ops = {
+	.init = max_capi_uart_init,
+	.deinit = max_capi_uart_deinit,
+	.transmit = max_capi_uart_transmit,
+	.receive = max_capi_uart_receive,
+	.transmit_async = max_capi_uart_transmit_async,
+	.receive_async = max_capi_uart_receive_async,
+	.register_callback = max_capi_uart_register_callback,
+	.isr = max_capi_uart_isr,
+	.set_line_config = max_capi_uart_set_line_config,
+	.get_line_config = max_capi_uart_get_line_config,
+	.flush_rx_fifo = max_capi_uart_flush_rx_fifo,
+	.flush_tx_fifo = max_capi_uart_flush_tx_fifo,
+	.get_rx_fifo_count = max_capi_uart_get_rx_fifo_count,
+	.get_tx_fifo_count = max_capi_uart_get_tx_fifo_count,
+	.get_interrupt_reason = max_capi_uart_get_interrupt_reason,
+	.get_line_status = max_capi_uart_get_line_status,
+	/* Everything below cannot be implemented; returns -ENOSYS */
+	.enable_fifo = max_capi_uart_enable_fifo,
+	.transmit_9bit = max_capi_uart_transmit_9bit,
+	.receive_9bit = max_capi_uart_receive_9bit,
+	.set_flow_control_state = max_capi_uart_set_flow_control_state,
+	.get_flow_control_state = max_capi_uart_get_flow_control_state,
+};
+
+/** Platform-specific functions ***********************************************/
+
+int max_capi_uart_stdio_enable(struct capi_uart_handle *handle)
+{
+	struct max_capi_uart_priv *uart_priv;
+
+	if (!handle)
+		return -EINVAL;
+
+	uart_priv = handle->priv;
+	stdio_index = uart_priv->id;
+
+	if (handle != uart[uart_priv->id])
+		return -EINVAL;
+
+	setvbuf(stdout, NULL, _IONBF, 0);
+
+	return 0;
+}
+
+/** stdio Redirect implementation *********************************************/
+
+#define STDIN_FILENO	0   /**> Definition of stdin */
+#define STDOUT_FILENO   1   /**> Definition of stdout */
+#define STDERR_FILENO   2   /**> Definition of stderr */
+
+int _isatty(int file)
+{
+	if (file >= STDIN_FILENO && file <= STDERR_FILENO)
+		return 1;
+
+	errno = EBADF;
+	return 0;
+}
+
+int _write(int file, char *ptr, int len)
+{
+	int ret;
+
+	if (stdio_index == -1)
+		return -1;
+
+	if (file == STDOUT_FILENO || file == STDERR_FILENO) {
+		ret = max_capi_uart_transmit(uart[stdio_index], (uint8_t *)ptr, len);
+		if (ret < 0) {
+
+			errno = -ret;
+			return -1;
+		}
+
+		return len;
+	}
+	errno = EBADF;
+	return -1;
+}
+
+int _close(int file)
+{
+	if (file >= STDIN_FILENO && file <= STDERR_FILENO)
+		return 0;
+
+	errno = EBADF;
+	return -1;
+}
+
+int _lseek(int file, off_t offset, int whence)
+{
+	(void) file;
+	(void) offset;
+	(void) whence;
+
+	errno = EBADF;
+	return -1;
+}
+
+int _read(int file, char *ptr, int len)
+{
+	int ret;
+
+	if (stdio_index == -1)
+		return -1;
+
+	if (file == STDIN_FILENO) {
+		ret = max_capi_uart_receive(uart[stdio_index], (uint8_t *)ptr, 1);
+		if (ret < 0) {
+			errno = -ret;
+			return -1;
+		}
+
+		return ret;
+	}
+	errno = EBADF;
+	return -1;
+}
+
+int _fstat(int file, struct stat *st)
+{
+	if (file >= STDIN_FILENO && file <= STDERR_FILENO) {
+		st->st_mode = S_IFCHR;
+		return 0;
+	}
+
+	errno = EBADF;
+	return 0;
+}

--- a/capi/platform/maxim/max32657/maxim_capi_uart.h
+++ b/capi/platform/maxim/max32657/maxim_capi_uart.h
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ *   @file   maxim_capi_uart.h
+ *   @brief  Header file for UART functions with CAPI
+ *   @author Ramon Miguel Imbao (ramonmiguel.imbao@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef MAXIM_CAPI_UART_H_
+#define MAXIM_CAPI_UART_H_
+
+#include "uart.h"
+#include "capi_dma.h"
+#include "capi_uart.h"
+#include "maxim_capi_dma.h"
+#include "maxim_capi_irq.h"
+#include "maxim_capi_gpio.h"
+
+#define MAX_CAPI_UART_DEFAULT_BAUD 115200
+
+struct max_capi_uart_extra {
+	/** GPIO voltage selection */
+	enum max_capi_gpio_vssel vssel;
+	/** OPTIONAL - DMA config */
+	struct capi_dma_config *dma_config;
+};
+
+struct max_capi_uart_priv {
+	/** Identifier */
+	uint32_t id;
+	/** UART registers */
+	mxc_uart_regs_t *uart;
+	/** Clock source storage */
+	mxc_uart_clock_t clk_src;
+	/** Line config storage */
+	struct capi_uart_line_config line_config;
+	/** DMA handle */
+	struct capi_dma_handle *dma_handle;
+	/** Async callback */
+	capi_uart_callback callback;
+	/** Callback arg */
+	void *callback_arg;
+	/** UART request storage for async */
+	mxc_uart_req_t async_req;
+	/** DMA transfer storage for async */
+	struct capi_dma_transfer dma_xfer;
+	/** DMA transfer extra struct storage for async */
+	struct max_capi_dma_xfer_extra dma_xfer_extra;
+};
+
+extern struct capi_uart_ops max_capi_uart_ops;
+
+int max_capi_uart_stdio_enable(struct capi_uart_handle *handle);
+
+#endif /* MAXIM_CAPI_UART_H_ */

--- a/capi/platform/maxim/max32657/maxim_capi_wdt.c
+++ b/capi/platform/maxim/max32657/maxim_capi_wdt.c
@@ -1,0 +1,512 @@
+/*******************************************************************************
+ *   @file   maxim_capi_wdt.c
+ *   @brief  Implementation of WDT functions
+ *   @author Ramon Miguel Imbao (ramonmiguel.imbao@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#include <errno.h>
+#include <string.h>
+#include "maxim_capi_irq.h"
+#include "maxim_capi_wdt.h"
+#include "capi_wdt.h"
+#include "capi_irq.h"
+#include "max32657.h"
+
+/** Static variables **********************************************************/
+
+static struct capi_wdt_handle *wdt[MXC_CFG_WDT_INSTANCES] = {NULL};
+
+/** Forward declarations ******************************************************/
+
+void max_capi_wdt_isr(void *handle);
+
+/** Helper functions **********************************************************/
+
+/**
+ * @brief Get clock frequency for a given source
+ * @param clock_source Clock source
+ * @return Clock frequency in Hz on success, 0 on error
+ */
+static uint32_t _max_capi_wdt_get_clock_freq(enum max_capi_wdt_clock
+		clock_source)
+{
+	switch (clock_source) {
+	case MAX_CAPI_WDT_CLOCK_PCLK:
+		return PeripheralClock;
+	case MAX_CAPI_WDT_CLOCK_IBRO:
+		return IBRO_FREQ;
+	default:
+		return 0;
+	}
+}
+
+/**
+ * @brief Convert microseconds to period (enum max_capi_wdt_period)
+ * @param timeout_us Timeout in microseconds
+ * @param clock_freq_hz Clock frequency in Hz
+ * @param period Period
+ * @return 0 on success, negative error code otherwise
+ */
+static int _max_capi_wdt_us_to_period(uint64_t timeout_us,
+				      uint32_t clock_freq_hz,
+				      enum max_capi_wdt_period *period)
+{
+	uint64_t required_ticks;
+	int power;
+
+	if (!period)
+		return -EINVAL;
+
+	required_ticks = (timeout_us * clock_freq_hz) / 1000000ULL;
+
+	for (power = 16; power <= 31; power++) {
+		if ((1ULL << power) >= required_ticks) {
+			*period = (enum max_capi_wdt_period)(31 - power);
+			return 0;
+		}
+	}
+
+	return -ERANGE;
+}
+
+/** WDT functions implementations *********************************************/
+
+/**
+ * @brief Initialize the WDT peripheral. Does not start the WDT.
+ * 	  WDT starts with the first feed.
+ * @param handle The WDT handle
+ * @param config The config struct
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_wdt_init(struct capi_wdt_handle **handle,
+		      const struct capi_wdt_config *config)
+{
+	int ret;
+	struct capi_wdt_handle *wdt_handle;
+	struct max_capi_wdt_priv *wdt_priv;
+	struct max_capi_wdt_extra *wdt_extra;
+	enum max_capi_wdt_clock clock_source;
+	mxc_wdt_cfg_t wdt_config;
+	uint32_t rst_flags;
+
+	if (!handle || !config)
+		return -EINVAL;
+
+	if (config->identifier >= MXC_CFG_WDT_INSTANCES)
+		return -EINVAL;
+
+	if (wdt[config->identifier] != NULL) {
+		*handle = wdt[config->identifier];
+		return 0;
+	}
+
+	if (*handle == NULL) {
+		wdt_handle = capi_calloc(1, sizeof(*wdt_handle));
+		if (!wdt_handle)
+			return -ENOMEM;
+		wdt_handle->init_allocated = true;
+	} else {
+		wdt_handle = *handle;
+		wdt_handle->init_allocated = false;
+	}
+
+	wdt_priv = capi_calloc(1, sizeof(*wdt_priv));
+	if (!wdt_priv) {
+		ret = -ENOMEM;
+		goto free_handle;
+	}
+
+	clock_source = MAX_CAPI_WDT_CLOCK_PCLK;
+	if (config->extra) {
+		wdt_extra = config->extra;
+		clock_source = wdt_extra->clock_source;
+	}
+
+	wdt_priv->id = config->identifier;
+	wdt_priv->callback = config->callback;
+	wdt_priv->clock_source = clock_source;
+	wdt_priv->clock_freq_hz = _max_capi_wdt_get_clock_freq(clock_source);
+	if (wdt_priv->clock_freq_hz == 0) {
+		ret = -EINVAL;
+		goto free_priv;
+	}
+
+	rst_flags = MXC_WDT_GetResetFlag(MXC_WDT);
+
+	memset(&wdt_config, 0, sizeof(wdt_config));
+	ret = MXC_WDT_Init(MXC_WDT, &wdt_config);
+	MXC_WDT_SetIntPeriod(MXC_WDT, MXC_WDT_PERIOD_2_31);
+	MXC_WDT_SetResetPeriod(MXC_WDT, MXC_WDT_PERIOD_2_31);
+	MXC_WDT_DisableInt(MXC_WDT);
+	MXC_WDT_DisableReset(MXC_WDT);
+	MXC_WDT_Disable(MXC_WDT);
+	MXC_WDT_ClearResetFlag(MXC_WDT);
+	if (ret)
+		goto free_priv;
+
+	/** Execute the WDT feed sequence and disable the WDT */
+	__disable_irq();
+	MXC_WDT_Disable(MXC_WDT);
+
+	/** Set WDTn_CTRL.clk_rdy_ie = 1 to generate a
+	 * WDT-enabled interrupt event */
+	MXC_WDT->ctrl |= MXC_F_WDT_CTRL_CLKRDY_IE;
+
+	/** Re-enable global interrupts */
+	__enable_irq();
+
+	/** Configure WDTn_CLKSEL.source to select the clock source */
+	ret = MXC_WDT_SetClockSource(MXC_WDT, (mxc_wdt_clock_t)clock_source);
+	if (ret)
+		goto free_priv;
+
+	struct capi_irq_config irq_config = {
+		.irq_ctrl_id = 0,
+	};
+
+	ret = capi_irq_init(&irq_config);
+	if (ret && ret != -EBUSY) {
+		/* -EBUSY means IRQ already initialized, which is fine since
+		   it uses a singleton pattern. */
+		goto free_priv;
+	}
+
+	ret = capi_irq_connect(WDT_IRQn, max_capi_wdt_isr, wdt_handle);
+	if (ret)
+		goto free_priv;
+
+	ret = capi_irq_enable(WDT_IRQn);
+	if (ret)
+		goto free_priv;
+
+	/** Restore reset flags */
+	MXC_WDT->ctrl |= rst_flags;
+
+	wdt_priv->configured = false;
+	wdt_priv->enabled = false;
+
+	wdt_handle->priv = wdt_priv;
+	wdt_handle->ops = config->ops;
+
+	wdt[config->identifier] = wdt_handle;
+	*handle = wdt_handle;
+
+	return 0;
+
+free_priv:
+	capi_free(wdt_priv);
+free_handle:
+	if (wdt_handle->init_allocated)
+		capi_free(wdt_handle);
+
+	wdt[config->identifier] = NULL;
+
+	return ret;
+}
+
+/**
+ * @brief Deinitialize the WDT peripheral
+ * @param handle The WDT handle
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_wdt_deinit(struct capi_wdt_handle *handle)
+{
+	const struct max_capi_wdt_priv *wdt_priv;
+	uint8_t id;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	wdt_priv = handle->priv;
+	id = wdt_priv->id;
+
+	capi_irq_disable(WDT_IRQn);
+
+	capi_free(handle->priv);
+	if (handle->init_allocated)
+		capi_free(handle);
+
+	wdt[id] = NULL;
+
+	return MXC_WDT_Shutdown(MXC_WDT);
+}
+
+/**
+ * @brief Get available channels for WDT. In the case of MAX32657, it is single
+ * 	  channel, and will return 1 as per CAPI.
+ * @param handle The WDT handle
+ * @param channels Where to store the number of channels.
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_get_chan_count(struct capi_wdt_handle *handle, int *channels)
+{
+	if (!handle || !channels)
+		return -EINVAL;
+
+	*channels = 1;
+
+	return 0;
+}
+
+/**
+ * @brief Set up a WDT channel. Does not start the WDT.
+ * 	  WDT starts with the first feed.
+ * @param handle The WDT handle
+ * @param chan_id The channel ID - must be 0
+ * @param chan_config The configuration struct
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_wdt_setup_chan(struct capi_wdt_handle *handle, int chan_id,
+			    const struct capi_wdt_chan_config *chan_config)
+{
+	int ret;
+	struct max_capi_wdt_priv *wdt_priv;
+	struct max_capi_wdt_chan_extra *wdt_chan_extra;
+	enum max_capi_wdt_period late_period;
+	enum max_capi_wdt_mode mode = MAX_CAPI_WDT_MODE_COMPATIBILITY;
+	mxc_wdt_cfg_t wdt_config;
+
+	if (!handle || !handle->priv || !chan_config)
+		return -EINVAL;
+
+	if (chan_id != 0)
+		return -EINVAL;
+
+	wdt_priv = handle->priv;
+
+	/**
+	 * Configure the standard thresholds
+	 * If using the optional windowed WDT feature...
+	 */
+	memset(&wdt_config, 0, sizeof(wdt_config));
+	if (chan_config->extra) {
+		wdt_chan_extra = chan_config->extra;
+		wdt_config.upperIntPeriod = (mxc_wdt_period_t)wdt_chan_extra->late_interrupt;
+		wdt_config.upperResetPeriod = (mxc_wdt_period_t)wdt_chan_extra->late_reset;
+		wdt_config.lowerIntPeriod = (mxc_wdt_period_t)wdt_chan_extra->early_interrupt;
+		wdt_config.lowerResetPeriod = (mxc_wdt_period_t)wdt_chan_extra->early_reset;
+		mode = wdt_chan_extra->mode;
+	} else if (chan_config->timeout_us > 0) {
+		ret = _max_capi_wdt_us_to_period(chan_config->timeout_us,
+						 wdt_priv->clock_freq_hz,
+						 &late_period);
+		if (ret)
+			return ret;
+
+		wdt_config.upperIntPeriod = (mxc_wdt_period_t)late_period;
+		wdt_config.upperResetPeriod = (mxc_wdt_period_t)late_period;
+	} else {
+		return -EINVAL;
+	}
+
+	MXC_WDT_SetIntPeriod(MXC_WDT, &wdt_config);
+	MXC_WDT_SetResetPeriod(MXC_WDT, &wdt_config);
+	if (mode == MAX_CAPI_WDT_MODE_WINDOWED)
+		MXC_WDT->ctrl |= MXC_F_WDT_CTRL_WIN_EN;
+	else
+		MXC_WDT->ctrl &= ~MXC_F_WDT_CTRL_WIN_EN;
+
+	if (chan_config->irq_mode) {
+		/**
+		 * Set WDTn_CTRL.wdt_int_en to generate an interrupt when a
+		 * WDT late interrupt event occurs...
+		 */
+		MXC_WDT_EnableInt(MXC_WDT);
+		MXC_WDT_DisableReset(MXC_WDT);
+	} else {
+		/**
+		 * Set WDTn_CTRL.wdt_rst_en to generate an interrupt when a
+		 * WDT late reset event occurs...
+		 */
+		MXC_WDT_EnableReset(MXC_WDT);
+		MXC_WDT_DisableInt(MXC_WDT);
+	}
+
+	wdt_priv->configured = true;
+	wdt_priv->enabled = false;
+
+	return 0;
+}
+
+/**
+ * @brief Disable a channel. Feed is required to restart.
+ * @param handle The WDT handle
+ * @param chan_id The channel ID - must be 0
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_wdt_disable_chan(struct capi_wdt_handle *handle, int chan_id)
+{
+	struct max_capi_wdt_priv *wdt_priv;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	if (chan_id != 0)
+		return -EINVAL;
+
+	wdt_priv = handle->priv;
+
+	if (wdt_priv->enabled) {
+		MXC_WDT_Disable(MXC_WDT);
+		wdt_priv->enabled = false;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief Feed (restart) a channel
+ * @param handle The WDT handle
+ * @param chan_id The channel ID - must be 0
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_wdt_feed_chan(struct capi_wdt_handle *handle, int chan_id)
+{
+	struct max_capi_wdt_priv *wdt_priv;
+
+	if (!handle || !handle->priv)
+		return -EINVAL;
+
+	if (chan_id != 0)
+		return -EINVAL;
+
+	wdt_priv = handle->priv;
+
+	if (!wdt_priv->configured)
+		return -EAGAIN;
+
+	if (wdt_priv->enabled) {
+		MXC_WDT_ResetTimer(MXC_WDT);
+	} else {
+		/** Execute the WDT feed sequence and enable the WDT */
+		__disable_irq();
+		MXC_WDT_Enable(MXC_WDT);
+
+		/** Verify the peripheral is enabled before proceeding */
+		while (!(MXC_WDT->ctrl & MXC_F_WDT_CTRL_CLKRDY));
+
+		/**
+		 * Set WDTn_CTRL.clkrdy_ie = 1 to generate WDT-enabled
+		 * event interrupt
+		 */
+		MXC_WDT->ctrl |= MXC_F_WDT_CTRL_CLKRDY_IE;
+
+		/** Re-enable global interrupts */
+		__enable_irq();
+
+		wdt_priv->enabled = true;
+	}
+
+	return 0;
+}
+
+/**
+ * @brief The ISR for the WDT peripheral
+ * @param handle The WDT handle
+ */
+void max_capi_wdt_isr(void *handle)
+{
+	struct capi_wdt_handle *wdt_handle = handle;
+	struct max_capi_wdt_priv *wdt_priv;
+	uint32_t flags;
+	bool windowed_mode;
+
+	if (!wdt_handle || !wdt_handle->priv)
+		return;
+
+	wdt_priv = wdt_handle->priv;
+
+	windowed_mode = MXC_WDT->ctrl & MXC_F_WDT_CTRL_WIN_EN;
+	flags = 0;
+	if (windowed_mode) {
+		if (MXC_WDT->ctrl & MXC_F_WDT_CTRL_INT_EARLY)
+			flags |= MAX_CAPI_WDT_FLAG_INT_EARLY;
+		if (MXC_WDT->ctrl & MXC_F_WDT_CTRL_RST_EARLY)
+			flags |= MAX_CAPI_WDT_FLAG_RST_EARLY;
+	}
+	if (MXC_WDT->ctrl & MXC_F_WDT_CTRL_INT_LATE)
+		flags |= MAX_CAPI_WDT_FLAG_INT_LATE;
+	if (MXC_WDT->ctrl & MXC_F_WDT_CTRL_RST_LATE)
+		flags |= MAX_CAPI_WDT_FLAG_RST_LATE;
+
+	if (flags && wdt_priv->callback)
+		wdt_priv->callback(0, handle, flags);
+}
+
+struct capi_wdt_ops max_capi_wdt_ops = {
+	.init = max_capi_wdt_init,
+	.deinit = max_capi_wdt_deinit,
+	.get_chan_count = max_capi_get_chan_count,
+	.setup_chan = max_capi_wdt_setup_chan,
+	.disable_chan = max_capi_wdt_disable_chan,
+	.feed_chan = max_capi_wdt_feed_chan,
+	.isr = max_capi_wdt_isr,
+};
+
+/** Platform-specific functions ***********************************************/
+
+/**
+ * @brief Get the interrupt and reset flags from the WDT peripheral
+ * @param handle The WDT handle
+ * @param flags Where to store the flags
+ * @return 0 on success, negative error code otherwise
+ */
+int max_capi_wdt_get_flags(struct capi_wdt_handle *handle, uint32_t *flags)
+{
+	if (!handle || !flags)
+		return -EINVAL;
+
+	*flags = 0;
+
+	if (MXC_WDT->ctrl & MXC_F_WDT_CTRL_INT_LATE)
+		*flags |= MAX_CAPI_WDT_FLAG_INT_LATE;
+
+	if (MXC_WDT->ctrl & MXC_F_WDT_CTRL_INT_EARLY)
+		*flags |= MAX_CAPI_WDT_FLAG_INT_EARLY;
+
+	if (MXC_WDT->ctrl & MXC_F_WDT_CTRL_RST_LATE)
+		*flags |= MAX_CAPI_WDT_FLAG_RST_LATE;
+
+	if (MXC_WDT->ctrl & MXC_F_WDT_CTRL_RST_EARLY)
+		*flags |= MAX_CAPI_WDT_FLAG_RST_EARLY;
+
+	return 0;
+}
+
+int max_capi_wdt_clear_flags(struct capi_wdt_handle *handle)
+{
+	if (!handle)
+		return -EINVAL;
+
+	MXC_WDT_ClearIntFlag(MXC_WDT);
+	MXC_WDT_ClearResetFlag(MXC_WDT);
+
+	return 0;
+}

--- a/capi/platform/maxim/max32657/maxim_capi_wdt.h
+++ b/capi/platform/maxim/max32657/maxim_capi_wdt.h
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ *   @file   maxim_capi_wdt.h
+ *   @brief  Header file for WDT functions
+ *   @author Ramon Miguel Imbao (ramonmiguel.imbao@analog.com)
+********************************************************************************
+ * Copyright 2026(c) Analog Devices, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Analog Devices, Inc. nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ANALOG DEVICES, INC. “AS IS” AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+ * EVENT SHALL ANALOG DEVICES, INC. BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************/
+
+#ifndef MAXIM_CAPI_WDT_H_
+#define MAXIM_CAPI_WDT_H_
+
+#include "capi_wdt.h"
+#include "wdt.h"
+#include <stdbool.h>
+
+enum max_capi_wdt_flag {
+	MAX_CAPI_WDT_FLAG_INT_LATE =	(1 << 0),
+	MAX_CAPI_WDT_FLAG_INT_EARLY =	(1 << 1),
+	MAX_CAPI_WDT_FLAG_RST_LATE =	(1 << 2),
+	MAX_CAPI_WDT_FLAG_RST_EARLY =	(1 << 3),
+};
+
+enum max_capi_wdt_period {
+	MAX_CAPI_WDT_PERIOD_2_31 = MXC_WDT_PERIOD_2_31,
+	MAX_CAPI_WDT_PERIOD_2_30 = MXC_WDT_PERIOD_2_30,
+	MAX_CAPI_WDT_PERIOD_2_29 = MXC_WDT_PERIOD_2_29,
+	MAX_CAPI_WDT_PERIOD_2_28 = MXC_WDT_PERIOD_2_28,
+	MAX_CAPI_WDT_PERIOD_2_27 = MXC_WDT_PERIOD_2_27,
+	MAX_CAPI_WDT_PERIOD_2_26 = MXC_WDT_PERIOD_2_26,
+	MAX_CAPI_WDT_PERIOD_2_25 = MXC_WDT_PERIOD_2_25,
+	MAX_CAPI_WDT_PERIOD_2_24 = MXC_WDT_PERIOD_2_24,
+	MAX_CAPI_WDT_PERIOD_2_23 = MXC_WDT_PERIOD_2_23,
+	MAX_CAPI_WDT_PERIOD_2_22 = MXC_WDT_PERIOD_2_22,
+	MAX_CAPI_WDT_PERIOD_2_21 = MXC_WDT_PERIOD_2_21,
+	MAX_CAPI_WDT_PERIOD_2_20 = MXC_WDT_PERIOD_2_20,
+	MAX_CAPI_WDT_PERIOD_2_19 = MXC_WDT_PERIOD_2_19,
+	MAX_CAPI_WDT_PERIOD_2_18 = MXC_WDT_PERIOD_2_18,
+	MAX_CAPI_WDT_PERIOD_2_17 = MXC_WDT_PERIOD_2_17,
+	MAX_CAPI_WDT_PERIOD_2_16 = MXC_WDT_PERIOD_2_16,
+};
+
+enum max_capi_wdt_clock {
+	MAX_CAPI_WDT_CLOCK_PCLK = MXC_WDT_PCLK,
+	MAX_CAPI_WDT_CLOCK_IBRO = MXC_WDT_IBRO_CLK,
+};
+
+enum max_capi_wdt_mode {
+	MAX_CAPI_WDT_MODE_COMPATIBILITY = MXC_WDT_COMPATIBILITY,
+	MAX_CAPI_WDT_MODE_WINDOWED = MXC_WDT_WINDOWED,
+};
+
+struct max_capi_wdt_extra {
+	/** Clock source */
+	enum max_capi_wdt_clock clock_source;
+};
+
+struct max_capi_wdt_priv {
+	/** WDT ID */
+	uint32_t id;
+	/** Clock source */
+	enum max_capi_wdt_clock clock_source;
+	/** Clock frequency in Hz */
+	uint32_t clock_freq_hz;
+	/** Configured or not */
+	bool configured;
+	/** Enabled or not */
+	bool enabled;
+	/** Callback */
+	capi_wdt_callback_t callback;
+};
+
+struct max_capi_wdt_chan_extra {
+	/** Late interrupt event threshold */
+	enum max_capi_wdt_period late_interrupt;
+	/** Late reset event threshold */
+	enum max_capi_wdt_period late_reset;
+	/** Compatibility or windowed mode */
+	enum max_capi_wdt_mode mode;
+	/** Early interrupt event threshold (for windowed mode) */
+	enum max_capi_wdt_period early_interrupt;
+	/** Early reset event threshold (for windowed mode) */
+	enum max_capi_wdt_period early_reset;
+};
+
+extern struct capi_wdt_ops max_capi_wdt_ops;
+
+int max_capi_wdt_get_flags(struct capi_wdt_handle *handle, uint32_t *flags);
+int max_capi_wdt_clear_flags(struct capi_wdt_handle *handle);
+
+#endif /* MAXIM_CAPI_WDT_H_ */


### PR DESCRIPTION
## Pull Request Description

This PR adds implementations of CAPI-based drivers for the MAX32657:
- UART
- GPIO
- DMA
- Timer
- SPI
- I2C
- IRQ
- WDT
- RTC
- TRNG

## Testing

Testing was done with a MAX32657EVKIT. Examples were created to test out peripherals:
- `blinky`
    - Toggles LED on P0.13 every 100ms
- `uart`
    - Sends "Hello CAPI" with `capi_uart_transmit()`, then initializes stdio redirection
    - Prints 10 messages via `printf()`, then echoes received characters back
    - Deinitializes when user types `exit`
- `button_polling`
    - Polls button state on P0.12 and prints to UART on press and on release
- `button_irq`
    - Toggles LED on P0.13 while waiting for falling-edge interrupt on a button on P0.12
    - Interrupt triggers a callback that prints to UART
- `dma`
    - Performs 64-byte memory-to-memory transfer with DMA completion callback that prints to UART
    - Validates buffer contents post-transfer
- `i2c`
    - Tests I3C peripheral in I2C mode
    - Initializes I2C bus in fast mode and attempts to write transactions to two devices
    - Tests bus speed changed (from 400kHz to 100kHz)
    - Verified I2C signals with ADALM2000
- `spi`
    - Performed loopback test with SPI configured with two 'devices' and two different speeds (400kHz and 100kHz)
    - Validated buffer contents post-transfer
- `timer`
    - TMR0 set up in dual 16-bit mode, both counter modes. TMR0A at 10kHz, TMR0B at 5kHz.
    - TMR1 set up as 32-bit PWM mode, at 10kHz with 10% duty cycle. 
    - TMR4 set up as 32-bit compare mode, with match value at 1 ms.
    - TMR3 set up as 32-bit one-shot mode, firing after 50 us. Example loops to restart TMR3 every 1 s.
    - All signals verified with ADALM2000
- `trng`
    - Generates 10 random 32-bit values, then fills a 256-byte buffer with random data, and prints all values to UART
- `wdt`
    - First configured with watchdog reset enabled, and shortest period
    - System resets, detects it, then reconfigures to interrupt only, and windowed mode with 21.5 s to 85.9 s window
    - 30-second feed intervals for the watchdog

## Not Tested

- I2C and SPI with actual devices
- RTC due to no external crystal on the MAX32657EVKIT

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
