### PR TITLE
Dev/adhv4711

### DIFF
--- a/doc/sphinx/source/projects/eval/eval-adhv4710.rst
+++ b/doc/sphinx/source/projects/eval/eval-adhv4710.rst
@@ -1,0 +1,1 @@
+.. include:: ../../../../../projects/eval-adhv4710/README.rst

--- a/drivers/amplifiers/adhv4710/adhv4710.c
+++ b/drivers/amplifiers/adhv4710/adhv4710.c
@@ -48,6 +48,12 @@
 #include <errno.h>
 #include <math.h>
 
+/* Per-variant constants, indexed by enum adhv4710_type */
+static const struct adhv4710_chip_info chip_info[] = {
+	[ID_ADHV4710] = { .version_product = ADHV4710_VERSION_PRODUCT },
+	[ID_ADHV4711] = { .version_product = ADHV4711_VERSION_PRODUCT },
+};
+
 /**
  * @brief Initialize the device.
  * @param device - The device structure.
@@ -69,6 +75,8 @@ int adhv4710_init(struct adhv4710_dev **device,
 	if (!dev)
 		return -ENOMEM;
 
+	dev->id = init_param.id;
+
 	/* SPI Initialization */
 	ret = no_os_spi_init(&dev->spi_desc,
 			     init_param.spi_init);
@@ -85,7 +93,7 @@ int adhv4710_init(struct adhv4710_dev **device,
 	if (ret)
 		goto error_spi;
 
-	if (reg_val != ADHV4710_VERSION_PRODUCT) {
+	if (reg_val != chip_info[dev->id].version_product) {
 		ret = -ENXIO;
 		goto error_spi;
 	}

--- a/drivers/amplifiers/adhv4710/adhv4710.h
+++ b/drivers/amplifiers/adhv4710/adhv4710.h
@@ -55,6 +55,7 @@
 /* Version product */
 #define ADHV4710_SILICON_REV					0x4
 #define ADHV4710_VERSION_PRODUCT     				0x46
+#define ADHV4711_VERSION_PRODUCT					0x47
 
 /* ADHV4710 Register Map */
 /* 8 BIT REGISTERS */
@@ -128,6 +129,26 @@
 #define ADHV4710_DECREASE_I 					0
 
 /**
+* @enum adhv4710_type
+* @brief Supported device variants.
+*/
+enum adhv4710_type {
+	/** ADHV4710 */
+	ID_ADHV4710,
+	/** ADHV4711 */
+	ID_ADHV4711,
+};
+
+/**
+* @struct adhv4710_chip_info
+* @brief Per-variant constants.
+*/
+struct adhv4710_chip_info {
+	/** Expected value of the CTRL_REG_26 chip-id register */
+	uint8_t version_product;
+};
+
+/**
 * @struct adhv4710_init_param
 * @brief ADHV4710 Device initialization parameters.
 */
@@ -136,6 +157,8 @@ struct adhv4710_init_param {
 	struct no_os_spi_init_param 	*spi_init;
 	/** GPIO RESET descriptor used to reset device (HW reset) */
 	struct no_os_gpio_init_param  	*gpio_reset;
+	/** Device variant */
+	enum adhv4710_type		id;
 };
 
 /**
@@ -147,6 +170,8 @@ struct adhv4710_dev {
 	struct no_os_spi_desc		*spi_desc;
 	/** GPIO RESET descriptor used to reset device (HW reset) */
 	struct no_os_gpio_desc  	*gpio_reset;
+	/** Device variant */
+	enum adhv4710_type		id;
 };
 
 /* Initialize the device. */

--- a/projects/eval-adhv4710/README.rst
+++ b/projects/eval-adhv4710/README.rst
@@ -1,0 +1,138 @@
+EVAL-ADHV4710 no-OS Example Project
+===================================
+
+.. no-os-doxygen::
+
+.. contents:: Table of Contents
+    :depth: 3
+
+Supported Evaluation Boards
+----------------------------
+
+* `EVAL-ADHV4710 <https://www.analog.com/ADHV4710>`_
+* `EVAL-ADHV4711 <https://www.analog.com/ADHV4711>`_
+
+Overview
+--------
+
+The ADHV4710 and ADHV4711 are high voltage, high precision amplifiers
+controlled over an SPI interface. The two parts are variants of the same
+device and share the same register map and control logic; they differ
+only in the value reported by the product-version (chip-id) register
+(``CTRL_REG_26``): ``0x46`` for the ADHV4710 and ``0x47`` for the
+ADHV4711. A single no-OS driver (``drivers/amplifiers/adhv4710``)
+supports both variants, selected at initialization time.
+
+The firmware initializes the amplifier, configures its overcurrent
+(source and sink), overvoltage (positive and negative) and
+overtemperature protection limits, and then periodically polls the alarm
+status register, reporting any triggered protection over UART and
+re-enabling the amplifier from a latched shutdown.
+
+Applications
+------------
+
+* High voltage signal conditioning
+* Piezoelectric transducer and MEMS driving
+* Programmable power supplies
+* Automated test equipment (ATE)
+
+Selecting the Device Variant
+----------------------------
+
+The driver distinguishes the two parts through the ``id`` field of
+``struct adhv4710_init_param``, using ``enum adhv4710_type``:
+
+.. code-block:: c
+
+   enum adhv4710_type {
+           ID_ADHV4710,
+           ID_ADHV4711,
+   };
+
+At initialization the driver reads ``CTRL_REG_26`` and validates it
+against the expected product-version value for the selected variant
+(returning ``-ENXIO`` on mismatch). The variant used by the example is
+controlled by the ``ADHV4710_DEV_ID`` macro in the
+`Project Common Data Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/eval-adhv4710/src/common>`__:
+
+.. code-block:: c
+
+   /* Device variant: ID_ADHV4710 or ID_ADHV4711 */
+   #define ADHV4710_DEV_ID                 ID_ADHV4710
+
+Set this to ``ID_ADHV4711`` when running against an ADHV4711 board.
+
+Hardware Specifications
+------------------------
+
+Board Connections
+~~~~~~~~~~~~~~~~~~~
+
+The evaluation board is controlled over a 4-wire SPI interface plus a
+GPIO used for hardware reset. The example also toggles a user LED to
+indicate liveness. The SPI, reset and LED pins are defined in the
+`Project Platform Configuration Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/eval-adhv4710/src/platform>`__.
+
+No-OS Build Setup
+-----------------
+
+Please see: `No-OS Build Guide <https://wiki.analog.com/resources/no-os/build>`_
+
+No-OS Supported Examples
+------------------------
+
+The initialization data used in the example is taken out from the
+`Project Common Data Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/eval-adhv4710/src/common>`__.
+
+The macros used in Common Data are defined in platform specific files
+found in the
+`Project Platform Configuration Path <https://github.com/analogdevicesinc/no-OS/tree/main/projects/eval-adhv4710/src/platform>`__.
+
+ADHV4710 example
+~~~~~~~~~~~~~~~~~
+
+The ``adhv4710_example`` initializes the UART console and the SPI
+interface, performs a hardware reset of the amplifier, and initializes
+the device for the variant selected by ``ADHV4710_DEV_ID``. It then
+clears the shutdown latch, enables all alarm latches, programs the
+nominal quiescent current, and configures the overcurrent (source and
+sink), overvoltage (positive and negative) and overtemperature
+protection limits from the user-defined values in ``common_data.h``.
+
+In its main loop the example periodically reads the alarm status
+register (``CTRL_REG_14``), prints any triggered protection over UART,
+clears the latched alarm flags, and re-enables the amplifier from
+shutdown when required, toggling the user LED each cycle.
+
+No-OS Supported Platforms
+-------------------------
+
+Maxim Platform
+~~~~~~~~~~~~~~
+
+Used Hardware
+^^^^^^^^^^^^^
+
+* `EVAL-ADHV4710 <https://www.analog.com/ADHV4710>`_ or
+  `EVAL-ADHV4711 <https://www.analog.com/ADHV4711>`_
+* `MAX32690EVKIT <https://www.analog.com/MAX32690>`_
+
+Connections
+^^^^^^^^^^^
+
+Connect the evaluation board to the MAX32690 SPI pins (CS, MOSI, MISO,
+SCLK), the reset GPIO and ground/power as configured in the platform
+files.
+
+Build Command
+^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   # to delete current build
+   make reset
+   # to build the project
+   make PLATFORM=maxim TARGET=max32690
+   # to flash the code
+   make run

--- a/projects/eval-adhv4710/src/common/common_data.h
+++ b/projects/eval-adhv4710/src/common/common_data.h
@@ -62,6 +62,9 @@ extern struct no_os_gpio_init_param gpio_reset_ip;
 /* check for triggered alarms interval */
 #define READ_INTERVAL                   2000000
 
+/* Device variant: ID_ADHV4710 or ID_ADHV4711 */
+#define ADHV4710_DEV_ID                 ID_ADHV4710
+
 /* Setup values for ADHV4710 */
 /* Current resolution */
 #define ADHV4710_CURRENT_RESOLUTION     15.625

--- a/projects/eval-adhv4710/src/main.c
+++ b/projects/eval-adhv4710/src/main.c
@@ -106,6 +106,9 @@ int main(void)
 	/* Init the reset */
 	adhv4710_ip.gpio_reset = &gpio_reset_ip;
 
+	/* Select the device variant */
+	adhv4710_ip.id = ADHV4710_DEV_ID;
+
 	no_os_uart_stdio(uart_desc);
 
 	pr_info("\n");


### PR DESCRIPTION
## Pull Request Description

Add ADHV4711 variant support via chip-info table:
The ADHV4710 and ADHV4711 are variants of the same device, sharing the
register map and control logic and differing only in the product-version
(chip-id) register CTRL_REG_26 (0x46 vs 0x47). Support both from the
single driver instead of duplicating it.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
