### PR TITLE
drivers: switch: adgm3121: add ADGM3053 support

### DIFF
--- a/drivers/switch/adgm3121/README.rst
+++ b/drivers/switch/adgm3121/README.rst
@@ -1,28 +1,30 @@
-ADGM3144/ADGM3121 MEMS Switch Driver
-====================================
+ADGM3144/ADGM3121/ADGM3053 MEMS Switch Driver
+===============================================
 
 Supported Devices
 -----------------
 
 * `ADGM3144 <https://www.analog.com/ADGM3144>`_ - SP4T Switch
 * `ADGM3121 <https://www.analog.com/ADGM3121>`_ - DPDT Switch
+* `ADGM3053 <https://www.analog.com/ADGM3053>`_ - 4-Channel Crossover Switch
 
 Overview
 --------
 
-The ADGM3144 and ADGM3121 are 3mm x 3mm MEMS switches operating from DC to 23 GHz:
+The ADGM3144, ADGM3121, and ADGM3053 are 3mm x 3mm MEMS switches:
 
-* **ADGM3144**: Single-Pole Four-Throw (SP4T) switch with RF1-4 ports connected to RFC
-* **ADGM3121**: Dual-Pole Dual-Throw (DPDT) switch with RF1A/1B, RF2A/2B ports connected to RFCA/RFCB
+* **ADGM3144**: Single-Pole Four-Throw (SP4T) switch with RF1-4 ports connected to RFC, DC to 23 GHz
+* **ADGM3121**: Dual-Pole Dual-Throw (DPDT) switch with RF1A/1B, RF2A/2B ports connected to RFCA/RFCB, DC to 23 GHz
+* **ADGM3053**: 4-Channel Crossover switch with S1-S4/D1-D4 port switch paths and S-to-S crossover paths, DC to 14 GHz
 
-This driver supports both devices and control modes:
+This driver supports all devices and control modes:
 
 1. **Parallel GPIO Mode**: Direct control via IN1-IN4 GPIO pins
 2. **SPI Mode**: Control via SPI interface with register access
 
 Key Features:
-- DC to 23 GHz frequency range
-- Low insertion loss: -0.5 dB (typical) at 6 GHz  
+- DC to 14/23 GHz frequency range (device dependent)
+- Low insertion loss: -0.5 dB (typical) at 6 GHz
 - High isolation: -22 dB (typical) at 6 GHz
 - Fast switching time: 200 µs (typical)
 - On resistance: 1.9 Ω (typical)
@@ -42,6 +44,7 @@ The driver supports two operating modes, selected via the PIN/SPI control pin:
 
     struct adgm3121_dev *dev;
     struct adgm3121_init_param init_param = {
+        .type = ID_ADGM3144,
         .mode = ADGM3121_MODE_PARALLEL,
         .gpio_pin_spi = {
             .number = PIN_SPI_GPIO_NUM,
@@ -78,6 +81,7 @@ The driver supports two operating modes, selected via the PIN/SPI control pin:
 
     struct adgm3121_dev *dev;
     struct adgm3121_init_param init_param = {
+        .type = ID_ADGM3121,
         .mode = ADGM3121_MODE_SPI,
         .gpio_pin_spi = {
             .number = PIN_SPI_GPIO_NUM,
@@ -105,11 +109,13 @@ Basic Usage
 .. code-block:: c
 
     // ADGM3144: Enable switch 1 (RF1 to RFC)
-    // ADGM3121: Enable switch 1 (RF1A to RFCA) 
+    // ADGM3121: Enable switch 1 (RF1A to RFCA)
+    // ADGM3053: Enable switch 1 (S1 to D1)
     ret = adgm3121_set_switch_state(dev, ADGM3121_SW1, ADGM3121_ENABLE);
-    
+
     // ADGM3144: Disable switch 2 (RF2 to RFC)
-    // ADGM3121: Disable switch 2 (RF1B to RFCA)
+    // ADGM3121: Disable switch 2 (RF2A to RFCA)
+    // ADGM3053: Disable switch 2 (S2 to D2)
     ret = adgm3121_set_switch_state(dev, ADGM3121_SW2, ADGM3121_DISABLE);
     
     // Check switch state
@@ -168,31 +174,31 @@ Hardware Configuration
 
 **Pin Connections:**
 
-+----------+----------------------------------+------------------------------------+
-| Pin      | ADGM3144                         | ADGM3121                           |
-+==========+==================================+====================================+
-| VDD      | 3.0V to 3.6V power supply       | 3.0V to 3.6V power supply           |
-+----------+----------------------------------+------------------------------------+
-| VCP      | 80V charge pump output           | 80V charge pump output             |
-+----------+----------------------------------+------------------------------------+
-| GND      | Ground                           | Ground                             |
-+----------+----------------------------------+------------------------------------+
-| RF Ports | RF1-RF4 (SP4T)                   | RF1A, RF1B, RF2A, RF2B (DPDT)      |
-+----------+----------------------------------+------------------------------------+
-| RFC Port | RFC (common)                     | RFCA, RFCB (dual common)           |
-+----------+----------------------------------+------------------------------------+
-| PIN/SPI  | Mode select (Parallel, SPI)      | Mode select (Parallel, SPI)        |
-+----------+----------------------------------+------------------------------------+
-| IN1-IN4  | Parallel control pins            | Parallel control pins              |
-+----------+----------------------------------+------------------------------------+
-| SDI      | SPI data input                   | SPI data input                     |
-+----------+----------------------------------+------------------------------------+
-| SDO      | SPI data output                  | SPI data output                    |
-+----------+----------------------------------+------------------------------------+
-| SCLK     | SPI clock                        | SPI clock                          |
-+----------+----------------------------------+------------------------------------+
-| CS       | SPI chip select                  | SPI chip select                    |
-+----------+----------------------------------+------------------------------------+
++----------+----------------------------------+------------------------------------+------------------------------------+
+| Pin      | ADGM3144                         | ADGM3121                           | ADGM3053                           |
++==========+==================================+====================================+====================================+
+| VDD      | 3.0V to 3.6V power supply        | 3.0V to 3.6V power supply          | 3.0V to 3.6V power supply          |
++----------+----------------------------------+------------------------------------+------------------------------------+
+| VCP      | 80V charge pump output           | 80V charge pump output             | 80V charge pump output             |
++----------+----------------------------------+------------------------------------+------------------------------------+
+| GND      | Ground                           | Ground                             | AGND, RFGND                        |
++----------+----------------------------------+------------------------------------+------------------------------------+
+| RF Ports | RF1-RF4 (SP4T)                   | RF1A, RF1B, RF2A, RF2B (DPDT)      | S1-S4, D1-D4 (crossover)           |
++----------+----------------------------------+------------------------------------+------------------------------------+
+| RFC Port | RFC (common)                     | RFCA, RFCB (dual common)           | N/A (crossover paths S-to-S)       |
++----------+----------------------------------+------------------------------------+------------------------------------+
+| PIN/SPI  | Mode select (Parallel, SPI)      | Mode select (Parallel, SPI)        | Mode select (Parallel, SPI)        |
++----------+----------------------------------+------------------------------------+------------------------------------+
+| IN1-IN4  | Parallel control pins            | Parallel control pins              | Parallel control pins              |
++----------+----------------------------------+------------------------------------+------------------------------------+
+| SDI      | SPI data input                   | SPI data input                     | SPI data input                     |
++----------+----------------------------------+------------------------------------+------------------------------------+
+| SDO      | SPI data output                  | SPI data output                    | SPI data output                    |
++----------+----------------------------------+------------------------------------+------------------------------------+
+| SCLK     | SPI clock                        | SPI clock                          | SPI clock                          |
++----------+----------------------------------+------------------------------------+------------------------------------+
+| CS       | SPI chip select                  | SPI chip select                    | SPI chip select                    |
++----------+----------------------------------+------------------------------------+------------------------------------+
 
 **External Components:**
 
@@ -203,29 +209,25 @@ Hardware Configuration
 Performance Specifications
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-+---------------------------+------------------+----------+
-| Parameter                 | Typical          | Unit     |
-+===========================+==================+==========+
-| Frequency Range           | DC to 23         | GHz      |
-+---------------------------+------------------+----------+
-| Insertion Loss @ 6GHz     | -0.5             | dB       |
-+---------------------------+------------------+----------+
-| Isolation @ 6GHz          | -22              | dB       |
-+---------------------------+------------------+----------+
-| Return Loss @ 6GHz        | -24.5            | dB       |
-+---------------------------+------------------+----------+
-| On Resistance             | 1.9              | Ω        |
-+---------------------------+------------------+----------+
-| Switching Time            | 200              | µs       |
-+---------------------------+------------------+----------+
-| Power-up Time             | 45               | ms       |
-+---------------------------+------------------+----------+
-| Max RF Power              | 33               | dBm      |
-+---------------------------+------------------+----------+
-| Max DC Current            | 200              | mA       |
-+---------------------------+------------------+----------+
-| Cycle Lifetime            | 100M             | cycles   |
-+---------------------------+------------------+----------+
++---------------------------+---------------------+---------------------+----------+
+| Parameter                 | ADGM3144/ADGM3121   | ADGM3053            | Unit     |
++===========================+=====================+=====================+==========+
+| Frequency Range           | DC to 23            | DC to 14            | GHz      |
++---------------------------+---------------------+---------------------+----------+
+| Insertion Loss            | -0.5 @ 6 GHz        | -0.25 @ 3.2 GHz     | dB       |
++---------------------------+---------------------+---------------------+----------+
+| On Resistance (port)      | 1.9                 | 1.9                 | Ω        |
++---------------------------+---------------------+---------------------+----------+
+| On Resistance (crossover) | N/A                 | 3.8                 | Ω        |
++---------------------------+---------------------+---------------------+----------+
+| Switching Time            | 200                 | 200                 | µs       |
++---------------------------+---------------------+---------------------+----------+
+| Power-up Time             | 45                  | 5                   | ms       |
++---------------------------+---------------------+---------------------+----------+
+| Max RF Power              | 33                  | 33                  | dBm      |
++---------------------------+---------------------+---------------------+----------+
+| Max DC Current            | 200                 | 200                 | mA       |
++---------------------------+---------------------+---------------------+----------+
 
 API Reference
 ~~~~~~~~~~~~~
@@ -255,7 +257,7 @@ Troubleshooting
 
 **Common Issues:**
 
-1. **Switch not responding:** Check VDD supply (3.0-3.6V) and wait 45ms after power-up
+1. **Switch not responding:** Check VDD supply (3.0-3.6V) and wait for power-up (45 ms for ADGM3144/ADGM3121, 5 ms for ADGM3053)
 2. **SPI communication failure:** Verify SPI mode, speed (≤10MHz), and CS timing
 3. **High insertion loss:** Check for proper grounding and 50Ω terminations
 4. **Internal errors:** Use ``adgm3121_check_internal_error()`` to diagnose

--- a/drivers/switch/adgm3121/adgm3121.c
+++ b/drivers/switch/adgm3121/adgm3121.c
@@ -445,6 +445,7 @@ int adgm3121_init(struct adgm3121_dev **device,
 	if (!dev)
 		return -ENOMEM;
 
+	dev->type = init_param->type;
 	dev->mode = init_param->mode;
 	dev->switch_states = 0;
 	dev->daisy_chain_mode = false;
@@ -502,7 +503,10 @@ int adgm3121_init(struct adgm3121_dev **device,
 	}
 
 	/* Wait for power-up time */
-	no_os_mdelay(ADGM3121_POWER_UP_TIME_MS);
+	if (dev->type == ID_ADGM3053)
+		no_os_mdelay(ADGM3053_POWER_UP_TIME_MS);
+	else
+		no_os_mdelay(ADGM3121_POWER_UP_TIME_MS);
 
 	/* Reset all switches to off state */
 	ret = adgm3121_reset_switches(dev);

--- a/drivers/switch/adgm3121/adgm3121.h
+++ b/drivers/switch/adgm3121/adgm3121.h
@@ -59,16 +59,26 @@
 /* Default timeout values */
 #define ADGM3121_SWITCHING_TIME_US	200
 #define ADGM3121_POWER_UP_TIME_MS	45
+#define ADGM3053_POWER_UP_TIME_MS	5
+
+/**
+ * @enum adgm3121_type
+ * @brief Device type enumeration
+ */
+enum adgm3121_type {
+	ID_ADGM3121,
+	ID_ADGM3053,
+};
 
 /**
  * @enum adgm3121_switch
  * @brief Switch enumeration (valid for both devices)
  */
 enum adgm3121_switch {
-	ADGM3121_SW1,
-	ADGM3121_SW2,
-	ADGM3121_SW3,
-	ADGM3121_SW4,
+	ADGM3121_SW1, /* ADGM3121: RF1A-RFCA, ADGM3053: S1-D1 */
+	ADGM3121_SW2, /* ADGM3121: RF2A-RFCA, ADGM3053: S2-D2 */
+	ADGM3121_SW3, /* ADGM3121: RF2B-RFCB, ADGM3053: S3-D3 */
+	ADGM3121_SW4, /* ADGM3121: RF1B-RFCB, ADGM3053: S4-D4 */
 };
 
 /**
@@ -103,6 +113,8 @@ struct adgm3121_dev {
 	struct no_os_gpio_desc *gpio_in4;
 	/* PIN/SPI mode select GPIO */
 	struct no_os_gpio_desc *gpio_pin_spi;
+	/* Device type */
+	enum adgm3121_type type;
 	/* Control mode */
 	enum adgm3121_mode mode;
 	/* Current switch states cache */
@@ -125,6 +137,8 @@ struct adgm3121_init_param {
 	struct no_os_gpio_init_param gpio_in4;
 	/* PIN/SPI mode select GPIO */
 	struct no_os_gpio_init_param gpio_pin_spi;
+	/* Device type */
+	enum adgm3121_type type;
 	/* Control mode */
 	enum adgm3121_mode mode;
 };

--- a/projects/eval-adgm3121/src/common/common_data.c
+++ b/projects/eval-adgm3121/src/common/common_data.c
@@ -45,6 +45,7 @@ struct no_os_uart_init_param adgm3121_uart_ip = {
 };
 
 struct adgm3121_init_param adgm3121_ip = {
+	.type = ID_ADGM3121,
 	.gpio_pin_spi = {
 		.port = GPIO_PIN_SPI_PORT_NUM,
 		.number = GPIO_PIN_SPI_PIN_NUM,


### PR DESCRIPTION
## Pull Request Description

Add support for the ADGM3053 4-channel MEMS crossover switch. Both
devices share the same SPI register interface and control logic, with
the only driver-visible difference being the power-up time (5 ms for
ADGM3053 vs 45 ms for ADGM3121).

Add device type enum (ID_ADGM3121, ID_ADGM3053) to the device and
init_param structures, and select the appropriate power-up delay
in adgm3121_init() based on the device type. Document the per-device
switch-to-RF-port mapping in the switch enum comments.

Existing ADGM3121 users are unaffected since ID_ADGM3121 = 0 matches
the default zero-initialized value.


## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
