### PR TITLE
drivers: frequency: adf4030 print bug fix

### DIFF
--- a/drivers/frequency/adf4030/adf4030.c
+++ b/drivers/frequency/adf4030/adf4030.c
@@ -784,8 +784,7 @@ int adf4030_set_vco_freq(struct adf4030_dev *dev, uint32_t vco_freq)
 	// Wait for Lock Detect
 	ret = adf4030_poll(dev, 0x90, ADF4030_PLL_LD, true);
 	if (ret)
-		pr_warning("%s:%d PLL failed to lock within the expected time. %x\n", __FILE__,
-			   __LINE__, ret);
+		return ret;
 
 	return adf4030_set_vco_cal(dev, false);
 }
@@ -2097,7 +2096,11 @@ int adf4030_init(struct adf4030_dev **dev,
 		goto error_spi;
 
 	ret = adf4030_set_vco_freq(device, device->vco_freq);
-	if (ret)
+	if (ret == ETIMEDOUT) {
+		pr_warning("%s:%d ADF4030 VCO frequency setting failed. %x\n",
+			   __FILE__,
+			   __LINE__, ret);
+	} else if (ret)
 		goto error_spi;
 
 	// Set BSYNC ODIVA


### PR DESCRIPTION
Removed warning prints for possbile errors on iio interaction errors.

Signed-off-by: Sirac Kucukarabacioglu sirac.kucukarabacioglu@analog.com

## Pull Request Description

Removes noisy warning prints that were emitted on possible errors during IIO interactions with the ADF4030.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
