### PR TITLE
projects: eval-ade9430: reset temperature status

### DIFF
--- a/projects/eval-ade9430/src/examples/basic_example/basic_example.c
+++ b/projects/eval-ade9430/src/examples/basic_example/basic_example.c
@@ -88,6 +88,12 @@ static int basic_read_temp(struct ade9430_dev *dev)
 			return -ENODATA;
 	}
 
+	/* if conversion succeeded clear the staus bit */
+	ret = ade9430_update_bits(dev, ADE9430_REG_STATUS0, ADE9430_STATUS0_TEMP_RDY,
+				  no_os_field_prep(ADE9430_STATUS0_TEMP_RDY, 1));
+	if (ret)
+		return ret;
+
 	/* if conversion succeeded compute the temperature */
 	ret = ade9430_read(dev, ADE9430_REG_TEMP_RSLT, &temp_raw);
 	if (ret)


### PR DESCRIPTION
After a temperature reading the temperature status bit in STATUS0 is cleared, so that the next reading will be valid.

## Pull Request Description

Bug fix: the TEMP_RDY bit in STATUS0 is W1C.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
