### PR TITLE
gitignore: update for CMake, STM32cubeide, and .no_os_venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .metadata
+.no_os_venv
+.cubeide
+no-os.code-workspace
 SDK.log
 bsp
 hw
@@ -10,6 +13,7 @@ RemoteSystemsTempFiles
 build
 BUILD
 builds
+build-*
 exports
 logs
 log.txt


### PR DESCRIPTION
Ignore files generated by cmake build using tools/scripts/no_os_build.py with default build directory option
Ignore files generated at .no_os_venv
Ignore files generated by stm32cubeide

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
