### PR TITLE
drivers: platform/maxim/max32655: Add UART3 with IBRO clock

### DIFF
--- a/drivers/platform/maxim/max32655/maxim_uart.c
+++ b/drivers/platform/maxim/max32655/maxim_uart.c
@@ -82,6 +82,9 @@ static int32_t _max_uart_pins_config(uint32_t device_id, mxc_gpio_vssel_t vssel)
 	case 2:
 		uart_pins = gpio_cfg_uart2;
 		break;
+	case 3:
+		uart_pins = gpio_cfg_uart3;
+		break;
 	default:
 		return -EINVAL;
 	}
@@ -331,7 +334,11 @@ static int32_t max_uart_init(struct no_os_uart_desc **desc,
 		goto error;
 	}
 
-	ret = MXC_UART_Init(uart_regs, descriptor->baud_rate, MXC_UART_APB_CLK);
+	if (descriptor->device_id == 3) {
+		ret = MXC_UART_Init(uart_regs, descriptor->baud_rate, MXC_UART_IBRO_CLK);
+	} else {
+		ret = MXC_UART_Init(uart_regs, descriptor->baud_rate, MXC_UART_APB_CLK);
+	}
 	if (ret != E_NO_ERROR) {
 		ret = -EINVAL;
 		goto error;
@@ -359,10 +366,12 @@ static int32_t max_uart_init(struct no_os_uart_desc **desc,
 		goto error;
 	}
 
-	ret = MXC_UART_SetFlowCtrl(uart_regs, flow, 8);
-	if (ret != E_NO_ERROR) {
-		ret = -EINVAL;
-		goto error;
+	if (descriptor->device_id != 3) {
+		ret = MXC_UART_SetFlowCtrl(uart_regs, flow, 8);
+		if (ret != E_NO_ERROR) {
+			ret = -EINVAL;
+			goto error;
+		}
 	}
 
 	*desc = descriptor;


### PR DESCRIPTION
Extend UART support from UART0-2 to include UART3 for MAX32655.

UART3 uses IBRO_CLK instead of APB_CLK and has no hardware flow control support, requiring special initialization handling.

## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
