### PR TITLE
adc: ad4080: add support for ad4081

### DIFF
--- a/drivers/adc/ad4080/README.rst
+++ b/drivers/adc/ad4080/README.rst
@@ -5,6 +5,7 @@ Supported Devices
 -----------------
 
 * `AD4080 <https://www.analog.com/AD4080>`_
+* `AD4081 <https://www.analog.com/AD4081>`_
 * `AD4082 <https://www.analog.com/AD4082>`_
 * `AD4083 <https://www.analog.com/AD4083>`_
 * `AD4085 <https://www.analog.com/AD4085>`_
@@ -26,8 +27,8 @@ to reduce noise and lower the output data rate for applications that do not
 require the lowest latency of the AD4080.
 
 The driver supports several parts of the AD408x family. These parts are
-register-compatible and differ in ADC resolution: the AD4080 and AD4082 are
-20-bit, the AD4083 and AD4085 are 16-bit, and the AD4086, AD4087 and AD4088
+register-compatible and differ in ADC resolution: the AD4080, AD4081 and AD4082
+are 20-bit, the AD4083 and AD4085 are 16-bit, and the AD4086, AD4087 and AD4088
 are 14-bit. The specific part is selected through the ``id`` field of the
 initialization parameter.
 

--- a/drivers/adc/ad4080/ad4080.c
+++ b/drivers/adc/ad4080/ad4080.c
@@ -47,6 +47,12 @@ const struct ad4080_chip_info ad4080_chip_info_tbl[NUM_AD4080_DEVICES] = {
 		.num_bits = 20,
 		.lvds_cnv_clk_cnt_max = 7,
 	},
+	[ID_AD4081] = {
+		.name = "ad4081",
+		.product_id = AD4081_PRODUCT_ID,
+		.num_bits = 20,
+		.lvds_cnv_clk_cnt_max = 2,
+	},
 	[ID_AD4082] = {
 		.name = "ad4082",
 		.product_id = AD4082_PRODUCT_ID,

--- a/drivers/adc/ad4080/ad4080.h
+++ b/drivers/adc/ad4080/ad4080.h
@@ -145,6 +145,7 @@
 
 /** AD408x Product IDs (PRODUCT_ID_H:PRODUCT_ID_L) */
 #define AD4080_PRODUCT_ID			0x0050
+#define AD4081_PRODUCT_ID			0x0051
 #define AD4082_PRODUCT_ID			0x0052
 #define AD4083_PRODUCT_ID			0x0053
 #define AD4085_PRODUCT_ID			0x0055
@@ -282,6 +283,7 @@ enum ad4080_fifo_mode {
 /** AD408x Supported Device IDs */
 enum ad4080_id {
 	ID_AD4080,
+	ID_AD4081,
 	ID_AD4082,
 	ID_AD4083,
 	ID_AD4085,


### PR DESCRIPTION
## Pull Request Description

Add the AD4081 to the AD408x chip information table. The AD4081 is
register-compatible with the AD4080, providing 20-bit resolution and a
maximum LVDS interface clock count of 2. Values match the mainline Linux
driver (product ID 0x0051).

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
