### PR TITLE
Selective builds proof of concept

### DIFF
--- a/build_projects.yml
+++ b/build_projects.yml
@@ -46,6 +46,7 @@ jobs:
     persistCredentials: true
   - script: 'echo "Using Xilinx version: $(XILINX_VERSION)"'
     displayName: 'Show Xilinx version'
+  - template: ci/steps-select-builds.yml
   - script: |
       export BRANCH=$(branch)
       wget -P ./tools/scripts/ \
@@ -55,7 +56,8 @@ jobs:
         -log_dir $(LOG_DIR) \
         -builds_dir /no-OS_builds/builds \
         -platform xilinx \
-        -hdl_branch $(HDL_BRANCH)
+        -hdl_branch $(HDL_BRANCH) \
+        -combos_file $(COMBOS_FILE)
     env:
       CLOUDSMITH_API_KEY: $(CLOUDSMITH_API_KEY)
       TOKEN: $(TOKEN)
@@ -108,6 +110,7 @@ jobs:
       echo "Bundled toolchain: ${GCC:-not found}"
       [ -n "$GCC" ] && "$GCC" -dumpfullversion 2>/dev/null | sed 's/^/Bundled arm-none-eabi-gcc version: /'
     displayName: 'Show SDK versions'
+  - template: ci/steps-select-builds.yml
   - script: |
       wget -P ./tools/scripts/ \
         https://raw.githubusercontent.com/analogdevicesinc/wiki-scripts/refs/heads/main/utils/cloudsmith_utils/cloudsmith_helper.py && \
@@ -116,7 +119,8 @@ jobs:
         -log_dir $(LOG_DIR) \
         -builds_dir /no-OS_builds/builds \
         -platform stm32 \
-        -hdl_branch $(HDL_BRANCH)
+        -hdl_branch $(HDL_BRANCH) \
+        -combos_file $(COMBOS_FILE)
     env:
       CLOUDSMITH_API_KEY: $(CLOUDSMITH_API_KEY)
       TOKEN: $(TOKEN)
@@ -149,6 +153,7 @@ jobs:
     persistCredentials: true
   - script: 'echo "Using Maxim SDK version: $(MAXIM_SDK_VERSION)"'
     displayName: 'Show Maxim SDK version'
+  - template: ci/steps-select-builds.yml
   - script: |
       wget -P ./tools/scripts/ \
         https://raw.githubusercontent.com/analogdevicesinc/wiki-scripts/refs/heads/main/utils/cloudsmith_utils/cloudsmith_helper.py && \
@@ -157,7 +162,8 @@ jobs:
         -log_dir $(LOG_DIR) \
         -builds_dir /no-OS_builds/builds \
         -platform maxim \
-        -hdl_branch $(HDL_BRANCH)
+        -hdl_branch $(HDL_BRANCH) \
+        -combos_file $(COMBOS_FILE)
     env:
       CLOUDSMITH_API_KEY: $(CLOUDSMITH_API_KEY)
       TOKEN: $(TOKEN)
@@ -190,6 +196,7 @@ jobs:
     persistCredentials: true
   - script: 'echo "Using Pico SDK version: $(PICO_SDK_VERSION)"'
     displayName: 'Show Pico SDK version'
+  - template: ci/steps-select-builds.yml
   - script: |
       wget -P ./tools/scripts/ \
         https://raw.githubusercontent.com/analogdevicesinc/wiki-scripts/refs/heads/main/utils/cloudsmith_utils/cloudsmith_helper.py && \
@@ -198,7 +205,8 @@ jobs:
         -log_dir $(LOG_DIR) \
         -builds_dir /no-OS_builds/builds \
         -platform pico \
-        -hdl_branch $(HDL_BRANCH)
+        -hdl_branch $(HDL_BRANCH) \
+        -combos_file $(COMBOS_FILE)
     env:
       CLOUDSMITH_API_KEY: $(CLOUDSMITH_API_KEY)
       TOKEN: $(TOKEN)
@@ -234,6 +242,7 @@ jobs:
       echo "Using CCES IDE version: $(CCES_VERSION)"
       echo "Using ARM CMSIS version: $(ARM_CMSIS_VERSION)"
     displayName: 'Show SDK versions'
+  - template: ci/steps-select-builds.yml
   - script: |
       wget -P ./tools/scripts/ \
         https://raw.githubusercontent.com/analogdevicesinc/wiki-scripts/refs/heads/main/utils/cloudsmith_utils/cloudsmith_helper.py && \
@@ -242,7 +251,8 @@ jobs:
         -log_dir $(LOG_DIR) \
         -builds_dir /no-OS_builds/builds \
         -platform aducm3029 \
-        -hdl_branch $(HDL_BRANCH)
+        -hdl_branch $(HDL_BRANCH) \
+        -combos_file $(COMBOS_FILE)
     env:
       CLOUDSMITH_API_KEY: $(CLOUDSMITH_API_KEY)
       TOKEN: $(TOKEN)
@@ -270,6 +280,7 @@ jobs:
     submodules: true
     clean: true
     persistCredentials: true
+  - template: ci/steps-select-builds.yml
   - script: |
       sudo apt install ruby-full
       sudo gem install ceedling
@@ -279,7 +290,9 @@ jobs:
         cd "$dir" && ceedling test:all && cd -
       done
     displayName: 'Run unit tests'
+    condition: eq(variables.RUN_TESTS, 'true')
   - task: PublishTestResults@2
+    condition: eq(variables.RUN_TESTS, 'true')
     inputs:
       testResultsFormat: 'JUnit'
       testResultsFiles: 'tests/drivers/**/build/artifacts/test/*.xml'

--- a/ci/steps-select-builds.yml
+++ b/ci/steps-select-builds.yml
@@ -1,0 +1,50 @@
+# Reusable step: compute the change-based build filter for the current run.
+#
+# Writes a JSON filter (see tools/scripts/ci_select_builds.py) to
+# $(Build.ArtifactStagingDirectory)/ci_builds.json and exposes its location as
+# the pipeline variable COMBOS_FILE, consumed by build_projects.py -combos_file.
+#
+# On a pull request, the filter is derived from the diff against the merge base
+# with the target branch. On any other trigger (push to main / next_stable /
+# release), or if the merge base cannot be resolved, it falls back to building
+# everything - the safe default that matches the previous always-build-all CI.
+steps:
+- script: |
+    set -e
+    FILTER="$(Build.ArtifactStagingDirectory)/ci_builds.json"
+    echo "##vso[task.setvariable variable=COMBOS_FILE]$FILTER"
+
+    emit_flags() {
+      # Export RUN_TESTS / BUILD_ALL pipeline variables from the filter so job
+      # steps (e.g. unit tests) can gate on them via condition:.
+      eval "$(python3 tools/scripts/ci_select_builds.py --flags "$FILTER")"
+      echo "##vso[task.setvariable variable=BUILD_ALL]${BUILD_ALL}"
+      echo "##vso[task.setvariable variable=RUN_TESTS]${RUN_TESTS}"
+    }
+
+    if [ "$(Build.Reason)" != "PullRequest" ]; then
+      echo "Not a PR ($(Build.Reason)); building everything."
+      echo '{"build_all": true, "build_docs": true, "run_tests": true}' > "$FILTER"
+      emit_flags
+      exit 0
+    fi
+
+    # Resolve the merge base against the PR target. The checkout is shallow
+    # (fetchDepth: 50), so fetch the target branch first.
+    TARGET="$(System.PullRequest.TargetBranch)"
+    TARGET="${TARGET#refs/heads/}"
+    git fetch --no-tags --depth=50 origin "$TARGET" || true
+    BASE=$(git merge-base HEAD FETCH_HEAD 2>/dev/null || true)
+
+    if [ -z "$BASE" ]; then
+      echo "Could not resolve merge base with '$TARGET'; building everything."
+      echo '{"build_all": true, "build_docs": true, "run_tests": true}' > "$FILTER"
+      emit_flags
+      exit 0
+    fi
+
+    echo "Selecting builds for $BASE...HEAD"
+    python3 tools/scripts/ci_select_builds.py \
+      --base "$BASE" --head HEAD --output "$FILTER" --print
+    emit_flags
+  displayName: 'Select builds from change set'

--- a/tools/scripts/build_projects.py
+++ b/tools/scripts/build_projects.py
@@ -62,10 +62,15 @@ def parse_input():
 	parser.add_argument('-hdl_branch', default='main', help="Name of hdl_branch from which to downlaod hardware or \
 					 we can also specify a timestamp folder from the specific branch but needs to have a specific format, \
 					 of 'branch_name/YYYY_mm_dd-HH_MM_SS' example: main/2023_09_20-06_52_29")
+	parser.add_argument('-combos_file', help="Path to a JSON filter produced by "
+					 "ci_select_builds.py. When given, only the listed "
+					 "(project, variant, board) combinations are built (unless "
+					 "the filter has build_all=true, which builds everything).")
 	args = parser.parse_args()
 
 	return (args.noos_location, args.export_dir, args.log_dir, args.project,
-		args.platform, args.build_name, args.builds_dir, args.hardware, args.hdl_branch)
+		args.platform, args.build_name, args.builds_dir, args.hardware, args.hdl_branch,
+		args.combos_file)
 
 ERR = 0
 LOG_START = " -> "
@@ -250,8 +255,27 @@ def get_hardware(hardware, platform, builds_dir):
 
 	return (filename, 1, err)
 
+def load_combos_filter(combos_file):
+	"""Load a ci_select_builds.py filter.
+
+	Returns None to mean "no restriction, build everything" (either no filter
+	was given or the filter has build_all=true). Otherwise returns a set of
+	(project, variant, board) tuples to restrict the build to.
+	"""
+	if not combos_file:
+		return None
+	with open(combos_file) as f:
+		data = json.load(f)
+	if data.get("build_all"):
+		return None
+	return {
+		(c["project"], c["variant"], c["board"])
+		for c in data.get("combos", [])
+	}
+
+
 def build_cmake_project(noos, project, _platform, _build_name, export_dir,
-			log_dir, cmake_builds_dir, builds_dir):
+			log_dir, cmake_builds_dir, builds_dir, combos_allow=None):
 	"""Build the CMake/Kconfig (Maxim/STM32/Pico/Xilinx) side of a project.
 
 	Discovers the project's project/variant/board combinations from the board
@@ -281,6 +305,11 @@ def build_cmake_project(noos, project, _platform, _build_name, export_dir,
 		combos = [c for c in combos if c['platform'] == _platform]
 	if _build_name is not None:
 		combos = [c for c in combos if c['variant'] == _build_name]
+	# CI change-based selection: keep only the combinations the selector chose.
+	# combos_allow is None when no filter applies (build everything).
+	if combos_allow is not None:
+		combos = [c for c in combos
+			  if (c['project'], c['variant'], c['board']) in combos_allow]
 
 	if not combos:
 		return None
@@ -409,15 +438,23 @@ def build_cmake_project(noos, project, _platform, _build_name, export_dir,
 
 def main():
 	(noos, export_dir, log_dir, _project,
-	 _platform, _build_name, _builds_dir, _hw, hdl_branch) = parse_input()
+	 _platform, _build_name, _builds_dir, _hw, hdl_branch, combos_file) = parse_input()
 	projets = os.path.join(noos,'projects')
 	ensure_dir(export_dir)
 	ensure_dir(log_dir)
+	combos_allow = load_combos_filter(combos_file)
+	# Projects with at least one selected combo; lets us skip the rest (and
+	# their hardware download) outright when a filter is active.
+	selected_projects = (
+		None if combos_allow is None
+		else {p for (p, _v, _b) in combos_allow})
 	(builds_dir, blacklist) = configfile_and_download_all_hw(_platform, noos, _builds_dir, hdl_branch)
 	for project in os.listdir(projets):
 		if _project is not None:
 			if _project != project:
 				continue
+		if selected_projects is not None and project not in selected_projects:
+			continue
 		project_dir = os.path.join(projets, project)
 		# CMake is the only build system; skip projects without a CMakeLists.txt.
 		if not os.path.isfile(os.path.join(project_dir, 'CMakeLists.txt')):
@@ -431,7 +468,8 @@ def main():
 		cmake_builds_dir = builds_dir + '_cmake'
 		ensure_dir(cmake_builds_dir)
 		cmake_ok = build_cmake_project(noos, project, _platform, _build_name,
-					 export_dir, log_dir, cmake_builds_dir, builds_dir)
+					 export_dir, log_dir, cmake_builds_dir, builds_dir,
+					 combos_allow=combos_allow)
 		if cmake_ok is not None:
 			status = 'OK' if cmake_ok == 1 else 'Fail'
 			os.system('echo Project %20s -- %s >> %s' % (project, status, all_status))

--- a/tools/scripts/ci_select_builds.py
+++ b/tools/scripts/ci_select_builds.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+# Copyright 2026(c) Analog Devices, Inc.
+#
+# SPDX short identifier: BSD-1-Clause
+"""Select the minimal set of CI builds for a change set.
+
+CI builds every (project, variant, board) combination on every push, which is
+wasteful for a PR that only touches one project or one driver. This script maps
+the changed files to the combinations that actually need rebuilding and writes a
+filter file that build_projects.py consumes to restrict its work.
+
+The mapping is entirely static (no CMake configure needed):
+
+  * A build's driver manifest is its project/<variant>.conf: the CONFIG_*=y
+    symbols it enables. This is the source of truth for "which build uses which
+    driver".
+  * A driver source file maps to a CONFIG symbol via the
+    no_os_sources_ifdef(CONFIG_X <path>) calls in each driver CMakeLists.txt.
+  * Kconfig `select` edges close the gap where a conf enables a high-level
+    symbol (e.g. CONFIG_MOTOR_IIO_TMC5240) that selects the one a changed file
+    is gated on (CONFIG_MOTOR_TMC5240) without naming it.
+
+Classification of a changed path, first match wins:
+
+  doc/**, **/*.md, **/*.rst          -> docs build only, no project builds
+  tests/**                           -> unit tests only
+  projects/<P>/**                    -> all builds of project <P>
+  drivers/platform/<plat>/**         -> all builds whose platform is <plat>
+  drivers|iio|network|jesd204/**     -> builds enabling that dir's CONFIG symbols
+  libraries/**, cmake/libraries/**   -> builds enabling that library's symbol
+  include/**, capi/**, util/**       -> BUILD ALL (linked into every target)
+  cmake/**, CMakeLists.txt, Kconfig, -> BUILD ALL (build-system change)
+    CMakePresets.json, tools/scripts/no_os_build.py, ci/**
+  anything else                      -> BUILD ALL (fail-safe)
+
+Every ambiguity resolves to *more* building, never less: an unknown path, a
+parse failure, or an empty result set builds everything. A missed build breaks
+the merge; an extra build only costs time.
+
+Output is a JSON filter file:
+
+  {
+    "build_all": false,
+    "build_docs": true,
+    "run_tests": false,
+    "combos": [{"project": "admt4000", "variant": "basic", "board": "sdp-ck1z"},
+               ...]
+  }
+
+When build_all is true, "combos" is omitted and consumers build the full set.
+"""
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# no_os_build.py guards its CLI behind __main__, so importing it here is safe
+# and reuses the exact combo-discovery the builder uses.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from no_os_build import (
+    find_repo_root,
+    load_presets,
+    discover_all_combinations,
+)
+
+# Source subtrees whose files are gated on CONFIG symbols via
+# no_os_sources_ifdef, so a change maps to specific builds.
+GATED_TREES = ("drivers", "iio", "network", "jesd204")
+
+# libraries/<dir> -> the CONFIG symbol whose confs pull that library in.
+# pico-sdk is fetched by the toolchain for every pico build, so it maps to the
+# platform rather than a CONFIG symbol (handled separately).
+LIB_DIR_TO_SYMBOL = {
+    "azure": "CONFIG_AZURE",
+    "esh": "CONFIG_ESH",
+    "free_rtos": "CONFIG_FREERTOS",
+    "lvgl": "CONFIG_LVGL",
+    "lwip": "CONFIG_LWIP",
+    "mbedtls": "CONFIG_MBEDTLS",
+    "mqtt": "CONFIG_MQTT",
+    "fatfs": "CONFIG_FATFS",
+    # precision-converters-library and tmc have no top-level enable symbol;
+    # they are pulled in by driver/example symbols, so a change to them is
+    # matched through the driver CMakeLists that references their path.
+}
+
+# no_os_sources_ifdef(CONFIG_X path...) / no_os_sources_dir_ifdef(CONFIG_X dir)
+_IFDEF_RE = re.compile(
+    r"no_os_(?:sources|sources_dir|sources_dir_recurse|include_dir"
+    r"|include_dir_recurse)_ifdef\s*\(\s*(CONFIG_[A-Z0-9_]+)(.*?)\)",
+    re.DOTALL,
+)
+# ${CMAKE_CURRENT_SOURCE_DIR}/foo/bar.c  or  ${CMAKE_SOURCE_DIR}/libraries/...
+_PATH_TOKEN_RE = re.compile(r"\$\{(CMAKE_CURRENT_SOURCE_DIR|CMAKE_SOURCE_DIR)\}/([^\s\)]+)")
+
+
+def git_changed_files(repo_root, base, head):
+    """Return the list of paths changed between base and head (repo-relative)."""
+    rng = f"{base}...{head}" if base and head else "HEAD~1...HEAD"
+    out = subprocess.run(
+        ["git", "-C", str(repo_root), "diff", "--name-only", rng],
+        capture_output=True, text=True, check=True,
+    )
+    return [line.strip() for line in out.stdout.splitlines() if line.strip()]
+
+
+def build_conf_symbol_index(repo_root, combos):
+    """symbol -> set of combo keys, from every combo's <variant>.conf.
+
+    A combo's driver manifest is projects/<project>/<variant>.conf; the board
+    .conf only adds platform wiring (bus instances) and never a driver, so it
+    is not indexed for driver mapping.
+    """
+    index = {}
+    conf_cache = {}
+    for combo in combos:
+        conf = repo_root / "projects" / combo["project"] / f"{combo['variant']}.conf"
+        if conf not in conf_cache:
+            conf_cache[conf] = _read_enabled_symbols(conf)
+        key = _combo_key(combo)
+        for sym in conf_cache[conf]:
+            index.setdefault(sym, set()).add(key)
+    return index
+
+
+def _read_enabled_symbols(conf_path):
+    """Return the set of CONFIG_* symbols set to y in a .conf file."""
+    syms = set()
+    if not conf_path.is_file():
+        return syms
+    for line in conf_path.read_text().splitlines():
+        line = line.strip()
+        m = re.match(r"(CONFIG_[A-Z0-9_]+)\s*=\s*y\b", line)
+        if m:
+            syms.add(m.group(1))
+    return syms
+
+
+def build_path_symbol_index(repo_root):
+    """Map each gated source directory to the CONFIG symbols compiled from it.
+
+    Directory-granular by design: a changed file is attributed to every symbol
+    referenced from files under the same driver leaf directory. This slightly
+    over-selects within a single driver dir (safe) and is robust to path
+    spelling, globs, and multi-source ifdef calls.
+
+    Each CMakeLists.txt's own directory is also indexed with the union of every
+    symbol it references. This keeps an aggregating file that lists many drivers
+    (e.g. drivers/afe/CMakeLists.txt, or its sibling Kconfig, which resolves to
+    the same dir via nearest-ancestor lookup) mapped to just that subtree's
+    symbols rather than falling back to build-all. A change to a leaf source
+    still resolves to the more specific leaf dir, since the lookup walks up to
+    the nearest indexed directory.
+
+    Returns dict: repo-relative dir (posix str) -> set(symbols).
+    """
+    dir_to_syms = {}
+    for tree in GATED_TREES:
+        tree_root = repo_root / tree
+        if not tree_root.is_dir():
+            continue
+        for cml in tree_root.rglob("CMakeLists.txt"):
+            cml_dir = cml.parent
+            try:
+                cml_key = cml_dir.relative_to(repo_root).as_posix()
+            except ValueError:
+                cml_key = None
+            text = cml.read_text()
+            for m in _IFDEF_RE.finditer(text):
+                symbol = m.group(1)
+                # The CMakeLists (and its sibling Kconfig) belongs to every
+                # symbol it gates: a change to it may affect any of them.
+                if cml_key is not None:
+                    dir_to_syms.setdefault(cml_key, set()).add(symbol)
+                for pm in _PATH_TOKEN_RE.finditer(m.group(2)):
+                    anchor, rel = pm.group(1), pm.group(2)
+                    base = cml_dir if anchor == "CMAKE_CURRENT_SOURCE_DIR" else repo_root
+                    target = (base / rel).resolve()
+                    # Attribute the enclosing directory of the referenced path.
+                    src_dir = target.parent if target.suffix else target
+                    try:
+                        key = src_dir.relative_to(repo_root).as_posix()
+                    except ValueError:
+                        continue
+                    dir_to_syms.setdefault(key, set()).add(symbol)
+    return dir_to_syms
+
+
+def build_select_closure(repo_root):
+    """Map each symbol S to the set of symbols that (transitively) select S.
+
+    A conf may enable only a high-level symbol that `select`s the one a changed
+    file is gated on. To rebuild that combo, when file->S we must also match
+    confs enabling any symbol that reaches S through select edges.
+
+    Returns dict: symbol -> set(symbols that pull it in, including itself).
+    """
+    # Parse `config NAME` blocks and their `select TARGET` lines across all
+    # Kconfig files.
+    selects = {}  # selector -> set(selected)
+    for kconfig in repo_root.rglob("Kconfig"):
+        # Skip fetched dependency trees and worktrees.
+        parts = kconfig.relative_to(repo_root).parts
+        if parts[0] in ("libraries", ".claude", "build") or "build" in parts:
+            # libraries/*/Kconfig belong to vendored deps; no-OS never sources
+            # them for project config.
+            if parts[0] == "libraries":
+                continue
+        current = None
+        try:
+            lines = kconfig.read_text().splitlines()
+        except (OSError, UnicodeDecodeError):
+            continue
+        for line in lines:
+            cm = re.match(r"\s*(?:menuconfig|config)\s+([A-Z0-9_]+)", line)
+            if cm:
+                current = "CONFIG_" + cm.group(1)
+                continue
+            sm = re.match(r"\s*select\s+([A-Z0-9_]+)", line)
+            if sm and current:
+                selects.setdefault(current, set()).add("CONFIG_" + sm.group(1))
+
+    # Invert and transitively close: for each target, who reaches it?
+    reachers = {}  # target -> set(selectors reaching it)
+    for selector, targets in selects.items():
+        for t in targets:
+            reachers.setdefault(t, set()).add(selector)
+
+    def closure(target):
+        seen = {target}
+        stack = list(reachers.get(target, ()))
+        while stack:
+            s = stack.pop()
+            if s in seen:
+                continue
+            seen.add(s)
+            stack.extend(reachers.get(s, ()))
+        return seen
+
+    return {sym: closure(sym) for sym in set(reachers)}
+
+
+def _combo_key(combo):
+    return (combo["project"], combo["variant"], combo["board"])
+
+
+def classify(repo_root, changed, combos, conf_index, path_index, select_closure):
+    """Return (build_all, build_docs, run_tests, set-of-combo-keys)."""
+    build_docs = False
+    run_tests = False
+    selected = set()
+
+    platforms = {c["platform"] for c in combos}
+    combos_by_project = {}
+    combos_by_platform = {}
+    for c in combos:
+        combos_by_project.setdefault(c["project"], []).append(c)
+        combos_by_platform.setdefault(c["platform"], []).append(c)
+
+    def symbols_to_combos(symbols):
+        keys = set()
+        for sym in symbols:
+            # Expand through select-closure: any symbol that pulls sym in.
+            for reacher in select_closure.get(sym, {sym}):
+                keys |= conf_index.get(reacher, set())
+            keys |= conf_index.get(sym, set())
+        return keys
+
+    for path in changed:
+        p = path.replace("\\", "/")
+        parts = p.split("/")
+
+        # --- docs: build docs only, contributes no project builds ---
+        if p.startswith("doc/") or p.endswith(".md") or p.endswith(".rst"):
+            build_docs = True
+            continue
+
+        # --- unit tests ---
+        if p.startswith("tests/"):
+            run_tests = True
+            continue
+
+        # --- a specific project ---
+        if p.startswith("projects/") and len(parts) >= 2:
+            proj = parts[1]
+            for c in combos_by_project.get(proj, []):
+                selected.add(_combo_key(c))
+            continue
+
+        # --- a platform: every build on that platform ---
+        if p.startswith("drivers/platform/") and len(parts) >= 3:
+            plat = parts[2]
+            # Kconfig platform dir names don't always equal preset PLATFORM
+            # strings (e.g. free_rtos). Match known platforms; unknown -> all.
+            if plat in platforms:
+                for c in combos_by_platform.get(plat, []):
+                    selected.add(_combo_key(c))
+                continue
+            return True, build_docs, run_tests, set()
+
+        # --- a gated driver / subsystem source tree ---
+        if parts[0] in GATED_TREES:
+            # Directory-granular: find the nearest indexed dir at or above the
+            # changed file.
+            syms = _lookup_dir_symbols(p, path_index)
+            if syms:
+                selected |= symbols_to_combos(syms)
+                continue
+            # A file in a gated tree we couldn't map (e.g. a shared header) is
+            # too risky to drop.
+            return True, build_docs, run_tests, set()
+
+        # --- a bundled library ---
+        if p.startswith("libraries/") and len(parts) >= 2:
+            libdir = parts[1]
+            sym = LIB_DIR_TO_SYMBOL.get(libdir)
+            if sym:
+                selected |= symbols_to_combos({sym})
+                continue
+            if libdir == "pico-sdk":
+                for c in combos_by_platform.get("pico", []):
+                    selected.add(_combo_key(c))
+                continue
+            # precision-converters-library / tmc have no enable symbol; a driver
+            # CMakeLists references their path directly (e.g. TMC-API sources
+            # gated on CONFIG_MOTOR_TMC5240), so path_index may attribute them.
+            syms = _lookup_dir_symbols(p, path_index)
+            if syms:
+                selected |= symbols_to_combos(syms)
+                continue
+            # Unattributable library change: build everywhere to be safe.
+            return True, build_docs, run_tests, set()
+
+        # --- cmake/libraries/<lib>.cmake: same mapping as the lib dir ---
+        if p.startswith("cmake/libraries/") and p.endswith(".cmake"):
+            stem = Path(p).stem.lower()
+            alias = {"freertos": "free_rtos", "pcl": None, "tmc": None}
+            libdir = alias.get(stem, stem)
+            sym = LIB_DIR_TO_SYMBOL.get(libdir) if libdir else None
+            if sym:
+                selected |= symbols_to_combos({sym})
+                continue
+            return True, build_docs, run_tests, set()
+
+        # --- everything else that is core / build-system -> BUILD ALL ---
+        return True, build_docs, run_tests, set()
+
+    return False, build_docs, run_tests, selected
+
+
+def _lookup_dir_symbols(path, path_index):
+    """Symbols for the changed file's nearest indexed ancestor directory."""
+    d = Path(path).parent
+    while True:
+        key = d.as_posix()
+        if key in path_index:
+            return path_index[key]
+        if d == Path("."):
+            return set()
+        parent = d.parent
+        if parent == d:
+            return set()
+        d = parent
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--flags", metavar="FILTER",
+                    help="Read an existing filter JSON and print shell "
+                    "assignments (BUILD_ALL / RUN_TESTS) to stdout, then exit. "
+                    "Used by CI to gate steps; ignores all other arguments.")
+    ap.add_argument("--base", help="Base git ref (PR merge base)")
+    ap.add_argument("--head", help="Head git ref (PR tip)")
+    ap.add_argument("--changed-file", help="Read changed paths from this file "
+                    "(one per line) instead of running git diff")
+    ap.add_argument("--output", "-o", help="Path to write the JSON filter")
+    ap.add_argument("--print", dest="do_print", action="store_true",
+                    help="Also print a human summary to stderr")
+    args = ap.parse_args()
+
+    # --flags: read an existing filter and emit shell variable assignments.
+    if args.flags:
+        data = json.loads(Path(args.flags).read_text())
+        build_all = bool(data.get("build_all"))
+        run_tests = bool(data.get("run_tests")) or build_all
+        print(f"BUILD_ALL={'true' if build_all else 'false'}")
+        print(f"RUN_TESTS={'true' if run_tests else 'false'}")
+        return
+
+    if not args.output:
+        ap.error("--output is required unless --flags is given")
+
+    repo_root = find_repo_root()
+
+    if args.changed_file:
+        changed = [l.strip() for l in Path(args.changed_file).read_text().splitlines()
+                   if l.strip()]
+    else:
+        changed = git_changed_files(repo_root, args.base, args.head)
+
+    presets = load_presets(repo_root)
+    combos = discover_all_combinations(repo_root, presets)
+
+    if not changed:
+        # No changed files resolved: build nothing but stay safe on docs/tests.
+        result = {"build_all": False, "build_docs": False, "run_tests": False,
+                  "combos": []}
+        Path(args.output).write_text(json.dumps(result, indent=2))
+        if args.do_print:
+            print("No changed files; selecting no builds.", file=sys.stderr)
+        return
+
+    conf_index = build_conf_symbol_index(repo_root, combos)
+    path_index = build_path_symbol_index(repo_root)
+    select_closure = build_select_closure(repo_root)
+
+    build_all, build_docs, run_tests, keys = classify(
+        repo_root, changed, combos, conf_index, path_index, select_closure)
+
+    if build_all:
+        result = {"build_all": True, "build_docs": build_docs, "run_tests": run_tests}
+    else:
+        selected_combos = [
+            {"project": p, "variant": v, "board": b}
+            for (p, v, b) in sorted(keys)
+        ]
+        result = {"build_all": False, "build_docs": build_docs,
+                  "run_tests": run_tests, "combos": selected_combos}
+
+    Path(args.output).write_text(json.dumps(result, indent=2))
+
+    if args.do_print:
+        if build_all:
+            print(f"BUILD ALL (docs={build_docs}, tests={run_tests})", file=sys.stderr)
+        else:
+            print(f"{len(keys)} build(s) selected "
+                  f"(docs={build_docs}, tests={run_tests})", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/scripts/test_ci_select_builds.py
+++ b/tools/scripts/test_ci_select_builds.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# Copyright 2026(c) Analog Devices, Inc.
+#
+# SPDX short identifier: BSD-1-Clause
+"""Tests for ci_select_builds.py, run against the real repository tree.
+
+These are integration tests: they build the actual conf/path/select indices
+from the checked-out source and assert the selector's classification of
+representative change sets. Run with:
+
+    python3 tools/scripts/test_ci_select_builds.py
+"""
+import unittest
+
+import ci_select_builds as sel
+from no_os_build import find_repo_root, load_presets, discover_all_combinations
+
+
+class SelectorTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.repo = find_repo_root()
+        presets = load_presets(cls.repo)
+        cls.combos = discover_all_combinations(cls.repo, presets)
+        cls.conf_index = sel.build_conf_symbol_index(cls.repo, cls.combos)
+        cls.path_index = sel.build_path_symbol_index(cls.repo)
+        cls.select_closure = sel.build_select_closure(cls.repo)
+        cls.all_projects = {c["project"] for c in cls.combos}
+
+    def classify(self, changed):
+        return sel.classify(self.repo, changed, self.combos, self.conf_index,
+                            self.path_index, self.select_closure)
+
+    def test_doc_only_no_builds(self):
+        ba, docs, tests, keys = self.classify(["doc/sphinx/source/x.rst", "README.md"])
+        self.assertFalse(ba)
+        self.assertTrue(docs)
+        self.assertFalse(tests)
+        self.assertEqual(keys, set())
+
+    def test_tests_only(self):
+        ba, docs, tests, keys = self.classify(["tests/drivers/foo/test_foo.c"])
+        self.assertFalse(ba)
+        self.assertTrue(tests)
+        self.assertEqual(keys, set())
+
+    def test_project_scopes_to_that_project(self):
+        ba, _, _, keys = self.classify(["projects/admt4000/src/common/common_data.c"])
+        self.assertFalse(ba)
+        self.assertTrue(keys)
+        self.assertEqual({p for (p, _v, _b) in keys}, {"admt4000"})
+
+    def test_include_builds_all(self):
+        ba, _, _, _ = self.classify(["include/no_os_spi.h"])
+        self.assertTrue(ba)
+
+    def test_build_system_builds_all(self):
+        for path in ("CMakeLists.txt", "CMakePresets.json", "Kconfig",
+                     "tools/scripts/no_os_build.py", "cmake/source_util.cmake",
+                     "capi/foo.c"):
+            ba, _, _, _ = self.classify([path])
+            self.assertTrue(ba, f"{path} should build all")
+
+    def test_platform_scopes_to_platform(self):
+        ba, _, _, keys = self.classify(["drivers/platform/stm32/stm32_spi.c"])
+        self.assertFalse(ba)
+        self.assertTrue(keys)
+        platforms = {c["platform"] for c in self.combos
+                     if (c["project"], c["variant"], c["board"]) in keys}
+        self.assertEqual(platforms, {"stm32"})
+
+    def test_select_closure_narrows_gated_driver(self):
+        # tmc5240.c is gated on CONFIG_MOTOR_TMC5240, which is select-ed by
+        # CONFIG_MOTOR_IIO_TMC5240. The only conf enabling it is admt4000's
+        # iio_trigger_tmc5240 variant, so exactly that combo must be selected.
+        ba, _, _, keys = self.classify(["drivers/motor/tmc5240/tmc5240.c"])
+        self.assertFalse(ba)
+        self.assertTrue(keys, "expected at least the tmc5240 variant")
+        for (proj, variant, _b) in keys:
+            self.assertEqual(proj, "admt4000")
+            self.assertIn("tmc5240", variant)
+
+    def test_library_scopes_to_symbol(self):
+        ba, _, _, keys = self.classify(["libraries/mbedtls/library/ssl_tls.c"])
+        self.assertFalse(ba)
+        # Every selected combo must actually enable mbedtls.
+        for key in keys:
+            proj, variant, _b = key
+            conf = self.repo / "projects" / proj / f"{variant}.conf"
+            self.assertIn("CONFIG_MBEDTLS", sel._read_enabled_symbols(conf))
+
+    def test_unknown_gated_file_builds_all(self):
+        # A file in a gated tree that no CMakeLists attributes is too risky to
+        # drop -> build all.
+        ba, _, _, _ = self.classify(["drivers/some_new_dir/mystery.c"])
+        self.assertTrue(ba)
+
+    def test_mixed_doc_and_project(self):
+        ba, docs, _, keys = self.classify(
+            ["doc/x.rst", "projects/admt4000/src/common/common_data.c"])
+        self.assertFalse(ba)
+        self.assertTrue(docs)
+        self.assertEqual({p for (p, _v, _b) in keys}, {"admt4000"})
+
+    def test_any_build_all_path_short_circuits(self):
+        # A build-all path anywhere in the set forces build_all regardless of
+        # the other (narrower) paths.
+        ba, _, _, _ = self.classify(
+            ["projects/admt4000/x.c", "include/no_os_spi.h"])
+        self.assertTrue(ba)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
This is more like a discussion starter not a serious PR at this point, the idea is that if a PR edits a particular driver under driver/adc/[name], only projects that include and build this driver should be built by CI. If a new driver is added to drivers/afe/Kconfig, build all projects that include drivers in drivers/afe because of that Kconfig change. If a project is edited, only build that project. And so on.

This is hooked into existing Azure CI but I don't expect this to be merged before we finish the Github CI migration so that's already one thing that needs to be changed.

Is the json filter okay or should we somehow implement it directly in no_os_builds.py ? 
Do you have ideas for other rules or ideas for implementing this in a simpler way ? 
Perhaps the test script should be hooked to unit tests really and run by CI always on some historical commits.


