### PR TITLE
switch: adgm3121: fix power-up time

### DIFF
--- a/drivers/switch/adgm3121/adgm3121.h
+++ b/drivers/switch/adgm3121/adgm3121.h
@@ -58,7 +58,7 @@
 
 /* Default timeout values */
 #define ADGM3121_SWITCHING_TIME_US	200
-#define ADGM3121_POWER_UP_TIME_MS	45
+#define ADGM3121_POWER_UP_TIME_MS	5
 #define ADGM3053_POWER_UP_TIME_MS	5
 
 /**


### PR DESCRIPTION
## Pull Request Description

The datasheet specifies a maximum power-up time of 5 ms for the ADGM3121 (V_CP cap = 100 pF, -40C to +85C), but the driver waited 45 ms. Correct the define to match the datasheet.

Fixes: 71b48d858f24 ("switch: adgm3121: add driver support")

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
