### PR TITLE
tools: scripts: no_os_build.py default build dir to build/

### DIFF
--- a/doc/sphinx/source/build_guides/build_aducm3029_cmake.rst
+++ b/doc/sphinx/source/build_guides/build_aducm3029_cmake.rst
@@ -142,7 +142,7 @@ Useful options:
     - ``--dry-run`` — print the ``cmake`` commands without running them.
 
 Each combination is built into its own directory named
-``build-<project>-<variant>-<board>`` at the repo root (override the location
+``build/<project>-<variant>-<board>`` at the repo root (override the location
 with ``--build-dir``). The build artifacts (``.elf``, ``.hex``, ``.bin``) are
 placed in ``<build-dir>/build``.
 

--- a/doc/sphinx/source/build_guides/build_maxim_cmake.rst
+++ b/doc/sphinx/source/build_guides/build_maxim_cmake.rst
@@ -149,7 +149,7 @@ Useful options:
     - ``--dry-run`` — print the ``cmake`` commands without running them.
 
 Each combination is built into its own directory named
-``build-<project>-<variant>-<board>`` at the repo root (override the location
+``build/<project>-<variant>-<board>`` at the repo root (override the location
 with ``--build-dir``). The build artifacts (``.elf``, ``.hex``, ``.bin``) are placed
 in ``<build-dir>/build``.
 

--- a/doc/sphinx/source/build_guides/build_pico_cmake.rst
+++ b/doc/sphinx/source/build_guides/build_pico_cmake.rst
@@ -155,7 +155,7 @@ Useful options:
     - ``--dry-run`` — print the ``cmake`` commands without running them.
 
 Each combination is built into its own directory named
-``build-<project>-<variant>-<board>`` at the repo root (override the location
+``build/<project>-<variant>-<board>`` at the repo root (override the location
 with ``--build-dir``). The build artifacts (``.elf``, ``.hex``, ``.bin`` and,
 when picotool is available, ``.uf2``) are placed in ``<build-dir>/build``.
 

--- a/doc/sphinx/source/build_guides/build_stm32_cmake.rst
+++ b/doc/sphinx/source/build_guides/build_stm32_cmake.rst
@@ -147,7 +147,7 @@ Useful options:
     - ``--dry-run`` — print the ``cmake`` commands without running them.
 
 Each combination is built into its own directory named
-``build-<project>-<variant>-<board>`` at the repo root (override the location
+``build/<project>-<variant>-<board>`` at the repo root (override the location
 with ``--build-dir``). The build artifacts (``.elf``, ``.hex``, ``.bin``) are placed
 in ``<build-dir>/build``.
 

--- a/doc/sphinx/source/build_guides/build_xilinx.rst
+++ b/doc/sphinx/source/build_guides/build_xilinx.rst
@@ -51,7 +51,9 @@ Or, in one step with the helper (pass the ``.xsa`` via ``--hardware``):
           --hardware path/to/system_top.xsa
 
 The firmware (``build/<project>.elf``) and the intermediate Vitis BSP/FSBL work
-directories are created under ``build-<project>/``. See the
+directories are created under the configured build directory — the one passed to
+``cmake -B`` above, or ``build/<project>-<variant>-<board>/`` when using the
+helper. See the
 :doc:`../cmake_cheatsheet` for the full set of build, configure and cleanup
 commands.
 

--- a/tools/scripts/no_os_build.py
+++ b/tools/scripts/no_os_build.py
@@ -52,7 +52,7 @@ CMAKE = _resolve_cmake()
 
 def combo_build_dir(build_dir_base, combo):
     """Return the build directory path for a given combination."""
-    name = f"build-{combo['project']}-{combo['variant']}-{combo['board']}"
+    name = f"{combo['project']}-{combo['variant']}-{combo['board']}"
     return build_dir_base / name
 
 
@@ -513,7 +513,7 @@ def cmd_build(args, repo_root, presets):
         if not build_dir_base.is_absolute():
             build_dir_base = repo_root / build_dir_base
     else:
-        build_dir_base = repo_root
+        build_dir_base = repo_root / "build"
     total = len(filtered)
 
     if args.dry_run:
@@ -745,7 +745,7 @@ def main():
     build_parser.add_argument("--variant", help="Variant to build")
     build_parser.add_argument("--board", help="Board to build for")
     build_parser.add_argument(
-        "--build-dir", help="Base directory where build-<project>-<variant>-<board> directories are created (default: repo root)"
+        "--build-dir", help="Base directory where <project>-<variant>-<board> directories are created (default: build/ at the repo root)"
     )
     build_parser.add_argument(
         "--jobs", "-j", type=int, help="Parallel jobs for cmake --build"


### PR DESCRIPTION
Nests all build-* directories under build/ instead of spraying them across the repo root. Keeps ls clean it's also .gitignore-ed.

## Pull Request Description

Nests all build-* directories under build/ instead of spraying them across the repo root. Keeps ls clean it's also .gitignore-ed.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
