### PR TITLE
Cmake xilinx open

### DIFF
--- a/cmake/ide/backends/vitis.cmake
+++ b/cmake/ide/backends/vitis.cmake
@@ -1,22 +1,84 @@
 # --- Vitis IDE Backend (Xilinx) ---
 #
-# Minimal backend for the CMake-driven Xilinx flow. The heavy lifting (BSP +
-# linker script generation) happens in config_xilinx_sdk()
-# (cmake/xilinx/xilinx_platform_sdk.cmake), not here. This backend is a
-# placeholder for future Vitis launch.json / debug-config generation via
-# tools/scripts/platform/xilinx/generate_vitis_launch.py (which needs the built
-# ELF + FSBL, so it belongs in a post-build step once boot/flash is wired up).
+# Generates the artifacts the Vitis 2025+ Unified IDE needs to debug the
+# project, mirroring the legacy `make sdkopen` (which ran `vitis_launch_config`
+# then opened the GUI):
+#
+#   <ws>/_ide/<xsa>/*.bit|*.pdi|ps7_init.tcl|psu_init.tcl   (extracted from XSA)
+#   <ws>/_ide/launch.json                                   (debug config)
+#
+# where <ws> is the Vitis workspace `--open` opens and populates:
+#   <proj_bin>/xsa_work/ide/workspace
+# (see open_vitis_workspace / util.py create_ide_workspace). launch.json's
+# ${workspaceFolder} resolves to <ws>, so the ELF (build/<t>.elf), FSBL
+# (xsa_run/...) and staged XSA (xsa_work/<xsa>) are referenced relative to it.
+#
+# The heavy lifting (BSP + linker script) happens in config_xilinx_sdk()
+# (cmake/xilinx/xilinx_platform_sdk.cmake); this backend only wires up the IDE.
 
 function(ide_vitis_configure PROJECT_TARGET)
     if(NOT PLATFORM STREQUAL "xilinx")
         return()
     endif()
-    # No configure-time IDE artifacts yet.
+
+    find_package(Python3 COMPONENTS Interpreter QUIET)
+    if(NOT Python3_Interpreter_FOUND)
+        message(STATUS "python3 not found; skipping Vitis launch.json generation")
+        return()
+    endif()
+    # The workspace root `--open` opens (create_ide_workspace builds hw0/app
+    # here). launch.json's ${workspaceFolder} resolves to this dir, so all paths
+    # are computed relative to it.
+    set(_ws "${CMAKE_CURRENT_BINARY_DIR}/xsa_work/ide/workspace")
+    # Stage the debug artifacts in a sibling dir, NOT the workspace itself: a
+    # pre-existing _ide/ makes Vitis reject create_client ("cannot recognize the
+    # workspace version"). create_ide_workspace copies staging/_ide into the
+    # workspace after Vitis initializes it.
+    get_filename_component(_xsa_file "${HARDWARE}" NAME)
+    get_filename_component(_xsa_base "${HARDWARE}" NAME_WE)
+    set(_ide_dir "${CMAKE_CURRENT_BINARY_DIR}/xsa_work/ide/staging/_ide")
+    set(_hw_ide "${_ide_dir}/${_xsa_base}")
+
+    # Extract the bitstream / PDI and PS init script from the XSA (a zip),
+    # mirroring the legacy vitis_launch_config recipe. Best-effort: a given XSA
+    # contains only the members relevant to its architecture.
+    include(${NO_OS_DIR}/cmake/xilinx/xilinx_hw.cmake)
+    extract_xsa_members("${HARDWARE}" "${_hw_ide}")
+
+    # A copy of the XSA lives in xsa_work (staged by config_xilinx_sdk); the FSBL
+    # is produced by the flash target under xsa_run. Express both relative to the
+    # workspace root so the generated config is portable.
+    file(RELATIVE_PATH _xsa_rel "${_ws}"
+        "${CMAKE_CURRENT_BINARY_DIR}/xsa_work/${_xsa_file}")
+    file(RELATIVE_PATH _fsbl_rel "${_ws}"
+        "${CMAKE_CURRENT_BINARY_DIR}/xsa_run/tmp/output/hw0/export/hw0/sw/hw0/boot/fsbl.elf")
+    # The ELF the launch config downloads (built as <t>.elf under build/).
+    set(_elf "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_TARGET}.elf")
+
+    execute_process(
+        COMMAND ${Python3_EXECUTABLE}
+                "${NO_OS_DIR}/tools/scripts/platform/xilinx/generate_vitis_launch.py"
+                --arch "${XILINX_ARCH}"
+                --project-name "${PROJECT_TARGET}"
+                --xsa-path "${_xsa_rel}"
+                --elf-path "${_elf}"
+                --fsbl-path "${_fsbl_rel}"
+                --project-dir "${_ws}"
+                --output "${_ide_dir}/launch.json"
+        RESULT_VARIABLE _rc OUTPUT_QUIET)
+    if(NOT _rc EQUAL 0)
+        message(STATUS "Vitis launch.json generation failed (rc=${_rc}); "
+                       "the IDE can still be opened, debug config must be set up manually")
+        return()
+    endif()
+
+    message(STATUS "Generated Vitis IDE config: ${_ide_dir}/launch.json")
+    message(STATUS "Open the Vitis IDE with: no_os_build.py build ... --open")
 endfunction()
 
 function(ide_vitis_post_build PROJECT_TARGET)
     if(NOT PLATFORM STREQUAL "xilinx")
         return()
     endif()
-    # No post-build IDE artifacts yet.
+    # launch.json paths are static; nothing to resolve post-build.
 endfunction()

--- a/cmake/xilinx/xilinx_flash.cmake
+++ b/cmake/xilinx/xilinx_flash.cmake
@@ -86,4 +86,29 @@ function(add_xilinx_flash_target TARGET_NAME)
         COMMENT "Programming bitstream and running ${TARGET_NAME}.elf on target (Xilinx JTAG)..."
         USES_TERMINAL
         VERBATIM)
+
+    # erase / debug / debug_server exist on OpenOCD/J-Link platforms but have no
+    # Xilinx equivalent in this flow:
+    #   - Bare-metal Zynq/ZynqMP/MicroBlaze run the ELF straight into DDR/OCM over
+    #     JTAG; there is no on-chip flash to erase (a power cycle clears it).
+    #   - Interactive debugging is done from the Vitis GUI. `--open` populates a
+    #     Vitis workspace with the no-OS sources and the generated
+    #     _ide/launch.json debug config, then opens it.
+    # Define them anyway so `--target erase/debug/debug_server` prints guidance
+    # instead of failing with "No rule to make target".
+    add_custom_target(erase
+        COMMAND ${CMAKE_COMMAND} -E echo
+            "'erase' is not applicable to Xilinx: the application runs from RAM over JTAG; a power cycle clears it."
+        VERBATIM)
+
+    # `--open` materializes the Vitis workspace on demand (under
+    # xsa_work/ide/workspace) and launches the GUI; point users there rather
+    # than at a raw path that may not exist until --open has run.
+    set(_vitis_hint "Use the Vitis IDE to debug: 'no_os_build.py build ... --open' then launch the generated debug configuration.")
+    add_custom_target(debug
+        COMMAND ${CMAKE_COMMAND} -E echo "${_vitis_hint}"
+        VERBATIM)
+    add_custom_target(debug_server
+        COMMAND ${CMAKE_COMMAND} -E echo "${_vitis_hint}"
+        VERBATIM)
 endfunction()

--- a/projects/adrv903x/CMakeLists.txt
+++ b/projects/adrv903x/CMakeLists.txt
@@ -54,3 +54,6 @@ config_platform_sdk(adrv903x)
 add_flash_target(adrv903x)
 post_build_config(adrv903x)
 target_link_libraries(adrv903x no-os)
+
+# Wrap fseek/fclose so the custom implementations in no_os_platform.c are used
+target_link_options(adrv903x PRIVATE -Wl,--wrap=fseek -Wl,--wrap=fclose)

--- a/projects/adrv904x/CMakeLists.txt
+++ b/projects/adrv904x/CMakeLists.txt
@@ -57,3 +57,6 @@ config_platform_sdk(adrv904x)
 add_flash_target(adrv904x)
 post_build_config(adrv904x)
 target_link_libraries(adrv904x no-os)
+
+# Wrap fseek/fclose so the custom implementations in no_os_platform.c are used
+target_link_options(adrv904x PRIVATE -Wl,--wrap=fseek -Wl,--wrap=fclose)

--- a/tools/scripts/no_os_build.py
+++ b/tools/scripts/no_os_build.py
@@ -100,13 +100,13 @@ def harvest_compile_manifest(build_dir):
     CMake writes compile_commands.json (CMAKE_EXPORT_COMPILE_COMMANDS) at the
     build-dir root with one entry per compiled translation unit. It is the
     ground truth for what the no-OS ELF is built from: the union of the project
-    target and the `no-os` OBJECT library. We parse the -I/-D flags out of each
-    command so the Vitis app component indexes headers and macros exactly as
-    ninja did.
+    target and the `no-os` OBJECT library. We parse the -I/-D/-include flags
+    out of each command so the Vitis app component indexes headers and macros
+    exactly as ninja did.
 
-    Returns a dict {"sources": [...], "includes": [...], "defines": [...]} with
-    duplicates removed and insertion order preserved, or None if the compile
-    database is missing.
+    Returns a dict {"sources": [...], "includes": [...], "defines": [...],
+    "force_includes": [...]} with duplicates removed and insertion order
+    preserved, or None if the compile database is missing.
     """
     cc = build_dir / "compile_commands.json"
     if not cc.exists():
@@ -114,8 +114,8 @@ def harvest_compile_manifest(build_dir):
     with open(cc) as f:
         entries = json.load(f)
 
-    sources, includes, defines = [], [], []
-    seen_src, seen_inc, seen_def = set(), set(), set()
+    sources, includes, defines, force_includes = [], [], [], []
+    seen_src, seen_inc, seen_def, seen_finc = set(), set(), set(), set()
     for e in entries:
         src = e.get("file")
         if src and src not in seen_src:
@@ -139,8 +139,16 @@ def harvest_compile_manifest(build_dir):
                 if val and val not in seen_def:
                     seen_def.add(val)
                     defines.append(val)
+            elif tok == "-include":
+                i += 1
+                if i < len(tokens):
+                    val = tokens[i]
+                    if val and val not in seen_finc:
+                        seen_finc.add(val)
+                        force_includes.append(val)
             i += 1
-    return {"sources": sources, "includes": includes, "defines": defines}
+    return {"sources": sources, "includes": includes, "defines": defines,
+            "force_includes": force_includes}
 
 
 def open_vitis_workspace(repo_root, build_dir, combo):

--- a/tools/scripts/no_os_build.py
+++ b/tools/scripts/no_os_build.py
@@ -14,6 +14,7 @@ import argparse
 import itertools
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -78,6 +79,141 @@ def open_vscode_workspace(repo_root):
         subprocess.run([editor, str(workspace)], check=True)
     except subprocess.CalledProcessError as e:
         print(f"--open: failed to launch '{editor}': {e}", file=sys.stderr)
+
+
+def read_cmake_cache_value(build_dir, key):
+    """Return the value of a CMakeCache.txt entry (KEY:TYPE=VALUE), or None."""
+    cache = build_dir / "CMakeCache.txt"
+    if not cache.exists():
+        return None
+    prefix = f"{key}:"
+    with open(cache) as f:
+        for line in f:
+            if line.startswith(prefix) and "=" in line:
+                return line.split("=", 1)[1].strip()
+    return None
+
+
+def harvest_compile_manifest(build_dir):
+    """Extract the source/include/define set from compile_commands.json.
+
+    CMake writes compile_commands.json (CMAKE_EXPORT_COMPILE_COMMANDS) at the
+    build-dir root with one entry per compiled translation unit. It is the
+    ground truth for what the no-OS ELF is built from: the union of the project
+    target and the `no-os` OBJECT library. We parse the -I/-D flags out of each
+    command so the Vitis app component indexes headers and macros exactly as
+    ninja did.
+
+    Returns a dict {"sources": [...], "includes": [...], "defines": [...]} with
+    duplicates removed and insertion order preserved, or None if the compile
+    database is missing.
+    """
+    cc = build_dir / "compile_commands.json"
+    if not cc.exists():
+        return None
+    with open(cc) as f:
+        entries = json.load(f)
+
+    sources, includes, defines = [], [], []
+    seen_src, seen_inc, seen_def = set(), set(), set()
+    for e in entries:
+        src = e.get("file")
+        if src and src not in seen_src:
+            seen_src.add(src)
+            sources.append(src)
+        tokens = shlex.split(e.get("command", ""))
+        i = 0
+        while i < len(tokens):
+            tok = tokens[i]
+            if tok.startswith("-I"):
+                val = tok[2:] or (tokens[i + 1] if tok == "-I" else "")
+                if tok == "-I":
+                    i += 1
+                if val and val not in seen_inc:
+                    seen_inc.add(val)
+                    includes.append(val)
+            elif tok.startswith("-D"):
+                val = tok[2:] or (tokens[i + 1] if tok == "-D" else "")
+                if tok == "-D":
+                    i += 1
+                if val and val not in seen_def:
+                    seen_def.add(val)
+                    defines.append(val)
+            i += 1
+    return {"sources": sources, "includes": includes, "defines": defines}
+
+
+def open_vitis_workspace(repo_root, build_dir, combo):
+    """Populate and open a Vitis Unified IDE workspace for a Xilinx project.
+
+    Xilinx debugging/browsing happens in the Vitis GUI, not VS Code + OpenOCD.
+    Unlike the BSP-only xsa_work that config_xilinx_sdk leaves behind, this
+    materializes a real, openable workspace under
+    <build>/projects/<project>/xsa_work/ide/workspace containing:
+
+      - the hw0 platform (BSP), and
+      - an 'app' component whose sources are the no-OS files CMake actually
+        compiled, referenced in place (import_files is_skip_copy_sources) with
+        the include paths and -D defines harvested from compile_commands.json.
+
+    This mirrors the intent of the legacy `make` flow (which symlinked the
+    required no-OS sources under build/app so they showed up in Vitis), adapted
+    to the CMake build: CMake still owns the flashed ELF; Vitis gets a browsable
+    /buildable view of the same sources. Then launches `vitis -w <workspace>`.
+    """
+    proj_bin = build_dir / "projects" / combo["project"]
+    xsa_work = proj_bin / "xsa_work"
+    workspace = xsa_work / "ide" / "workspace"
+    if not xsa_work.exists():
+        print(f"--open: BSP work dir not found at {xsa_work} "
+              "(build the project first).", file=sys.stderr)
+        return
+    vitis = shutil.which("vitis")
+    if not vitis:
+        print("--open: 'vitis' not found on PATH. Source settings64.sh from "
+              f"your Vitis install, then re-run --open.", file=sys.stderr)
+        return
+
+    manifest = harvest_compile_manifest(build_dir)
+    if manifest is None:
+        print(f"--open: compile_commands.json not found in {build_dir} "
+              "(configure/build the project first).", file=sys.stderr)
+        return
+    # The BSP CPU/arch is resolved by the toolchain and cached; pass it through
+    # so util.py need not depend on a freshly staged arch.txt.
+    arch = read_cmake_cache_value(build_dir, "XILINX_ARCH")
+    if arch:
+        manifest["arch"] = arch
+    manifest_path = xsa_work / "ide_manifest.json"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(manifest_path, "w") as f:
+        json.dump(manifest, f, indent="\t")
+
+    # xsa_work holds a copy of the .xsa and arch.txt (staged by
+    # config_xilinx_sdk); util.py reads both from hw_path.
+    xsa_files = list(xsa_work.glob("*.xsa"))
+    if not xsa_files:
+        print(f"--open: no .xsa found in {xsa_work}.", file=sys.stderr)
+        return
+    util_py = repo_root / "tools" / "scripts" / "platform" / "xilinx" / "util.py"
+
+    print(f"Populating Vitis workspace ({len(manifest['sources'])} sources)...")
+    try:
+        subprocess.run(
+            [vitis, "-s", str(util_py), "create_ide_workspace",
+             str(xsa_work), str(xsa_work), xsa_files[0].name,
+             str(manifest_path)],
+            check=True, cwd=str(repo_root))
+    except subprocess.CalledProcessError as e:
+        print(f"--open: failed to populate Vitis workspace: {e}",
+              file=sys.stderr)
+        return
+
+    print(f"Opening Vitis IDE workspace: {workspace}")
+    try:
+        subprocess.run([vitis, "-w", str(workspace)], check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"--open: failed to launch 'vitis': {e}", file=sys.stderr)
 
 
 class Spinner:
@@ -723,7 +859,18 @@ def cmd_build(args, repo_root, presets):
         sys.exit(1)
 
     if args.open:
-        open_vscode_workspace(repo_root)
+        # --open targets a single project's IDE. When the filter matched exactly
+        # one combination, open that; otherwise fall back to the repo-root VS
+        # Code workspace (the multi-project view).
+        if len(filtered) == 1:
+            combo = filtered[0]
+            build_dir = combo_build_dir(build_dir_base, combo)
+            if combo["platform"] == "xilinx":
+                open_vitis_workspace(repo_root, build_dir, combo)
+            else:
+                open_vscode_workspace(repo_root)
+        else:
+            open_vscode_workspace(repo_root)
 
 
 def main():

--- a/tools/scripts/platform/xilinx/generate_vitis_launch.py
+++ b/tools/scripts/platform/xilinx/generate_vitis_launch.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""
+Generate Vitis 2025.1+ launch.json configuration for no-OS projects.
+
+This script automatically creates debug configurations for the Vitis Unified IDE,
+eliminating the need for manual configuration steps.
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def detect_arch_config(arch):
+    """
+    Detect architecture-specific configuration based on ARCH string.
+
+    Returns: dict with debugType, targetCpu, useFsbl, initType
+    """
+    arch_lower = arch.lower()
+
+    if 'cortexa53' in arch_lower or 'psu_cortexa53' in arch_lower:
+        return {
+            'debugType': 'baremetal-zu',
+            'targetCpu': 'psu_cortexa53_0',
+            'useFsbl': True,
+            'initType': 'zu'
+        }
+    elif 'cortexr5' in arch_lower or 'psu_cortexr5' in arch_lower:
+        return {
+            'debugType': 'baremetal-zu',
+            'targetCpu': 'psu_cortexr5_0',
+            'useFsbl': True,
+            'initType': 'zu'
+        }
+    elif 'cortexa9' in arch_lower or 'ps7_cortexa9' in arch_lower:
+        return {
+            'debugType': 'baremetal-zynq',
+            'targetCpu': 'ps7_cortexa9_0',
+            'useFsbl': True,
+            'initType': 'zynq'
+        }
+    elif 'microblaze' in arch_lower or 'sys_mb' in arch_lower:
+        return {
+            'debugType': 'baremetal-fpga',
+            'targetCpu': arch,
+            'useFsbl': False,
+            'initType': 'mb'
+        }
+    elif 'cortexa72' in arch_lower or 'psv_cortexa72' in arch_lower:
+        return {
+            'debugType': 'baremetal-versal',
+            'targetCpu': 'psv_cortexa72_0',
+            'useFsbl': False,
+            'initType': 'versal'
+        }
+    else:
+        print(f"Warning: Unknown architecture '{arch}'. Using default ZynqMP settings.", file=sys.stderr)
+        return {
+            'debugType': 'baremetal-zu',
+            'targetCpu': 'psu_cortexa53_0',
+            'useFsbl': True,
+            'initType': 'zu'
+        }
+
+
+def generate_zu_init(fsbl_path, xsa_basename):
+    """Generate ZynqMP (Zynq Ultrascale+) initialization section."""
+    return {
+        "zuInitialization": {
+            "isFsbl": True,
+            "usingFSBL": {
+                "initWithFSBL": True,
+                "fsblExitSymbol": "XFsbl_Exit",
+                "fsblFile": f"${{workspaceFolder}}/{fsbl_path}"
+            },
+            "usingPsuInit": {
+                "runPsuInit": True,
+                "plPowerup": True,
+                "psuInitTclFile": f"${{workspaceFolder}}/_ide/{xsa_basename}/psu_init.tcl"
+            }
+        },
+        "zuTraceOptions": {
+            "isSelected": False,
+            "scratchAddress": "0x60000",
+            "scratchSize": "0x60000",
+            "traceOutputPath": ""
+        }
+    }
+
+
+def generate_zynq_init(fsbl_path, xsa_basename):
+    """Generate Zynq-7000 initialization section."""
+    return {
+        "zynqInitialization": {
+            "isFsbl": True,
+            "usingFSBL": {
+                "initWithFSBL": True,
+                "fsblExitSymbol": "FsblHandoffJtagExit",
+                "fsblFile": f"${{workspaceFolder}}/{fsbl_path}"
+            },
+            "usingPs7Init": {
+                "runPs7Init": True,
+                "ps7InitTclFile": f"${{workspaceFolder}}/_ide/{xsa_basename}/ps7_init.tcl"
+            }
+        }
+    }
+
+
+def generate_versal_init():
+    """Generate Versal-specific targetSetup fields (zuTraceOptions only)."""
+    return {
+        "zuTraceOptions": {
+            "isSelected": False,
+            "scratchAddress": "0xfffc0000",
+            "scratchSize": "0x40000",
+            "traceOutputPath": ""
+        }
+    }
+
+
+def generate_download_elf(target_cpu, elf_path, project_dir):
+    """Generate downloadElf section."""
+    # Make ELF path workspace-relative if possible
+    try:
+        rel = os.path.relpath(elf_path, project_dir)
+        ws_elf = f"${{workspaceFolder}}/{rel}"
+    except ValueError:
+        ws_elf = elf_path
+    return [
+        {
+            "core": target_cpu,
+            "resetProcessor": True,
+            "elfFile": ws_elf,
+            "stopAtEntry": False,
+            "isSelfRelocatingApp": False,
+            "relativeAddress": ""
+        }
+    ]
+
+
+def generate_launch_json(args):
+    """Generate the complete launch.json file."""
+
+    # Detect architecture configuration
+    arch_config = detect_arch_config(args.arch)
+
+    # Extract XSA basename (e.g., "system_top" from "system_top.xsa")
+    xsa_basename = Path(args.xsa_path).stem
+
+    # Generate bitstream/PDI path.
+    # The filename inside the XSA may not match the XSA filename
+    # (e.g., system_top.bit inside system_top_vcu118.xsa), so search
+    # for the extracted file rather than assuming a name.
+    ide_dir = Path(args.project_dir) / '_ide' / xsa_basename
+    if arch_config['initType'] == 'versal':
+        pdi_files = list(ide_dir.glob('*.pdi')) if ide_dir.exists() else []
+        hw_name = pdi_files[0].name if pdi_files else "system_top.pdi"
+        bitstream_path = f"_ide/{xsa_basename}/{hw_name}"
+    else:
+        bit_files = list(ide_dir.glob('*.bit')) if ide_dir.exists() else []
+        hw_name = bit_files[0].name if bit_files else f"{xsa_basename}.bit"
+        bitstream_path = f"_ide/{xsa_basename}/{hw_name}"
+
+    # Generate configuration name
+    config_name = f"{args.project_name}_app_hw_1"
+
+    # Generate architecture-specific initialization section
+    if arch_config['initType'] == 'zu':
+        init_section = generate_zu_init(args.fsbl_path, xsa_basename)
+    elif arch_config['initType'] == 'zynq':
+        init_section = generate_zynq_init(args.fsbl_path, xsa_basename)
+    elif arch_config['initType'] == 'versal':
+        init_section = generate_versal_init()
+    else:
+        init_section = {}
+
+    is_versal = arch_config['initType'] == 'versal'
+    is_mb = arch_config['initType'] == 'mb'
+
+    # Build the base configuration entry
+    launch_entry = {
+        "type": "tcf-debug",
+        "request": "launch",
+        "name": config_name,
+        "debugType": arch_config['debugType'],
+    }
+
+    launch_entry["xsaPath"] = f"${{workspaceFolder}}/{args.xsa_path}"
+
+    setup_mode = "standalone"
+    exec_script = True
+    script_path = ""
+    launch_entry.update({
+        "attachToRunningTargetOptions": {
+            "targetSetupMode": setup_mode,
+            "executeScript": exec_script,
+            "scriptPath": script_path
+        },
+        "autoAttachProcessChildren": False,
+        "target": {
+            "targetConnectionId": "Local",
+            "peersIniPath": ".peers.ini",
+            "context": "Versal" if is_versal else ("fpga" if is_mb else "Device")
+        },
+        "pathMap": [],
+    })
+
+    # Build targetSetup
+    target_setup = {
+        "resetSystem": True,
+        "programDevice": True,
+        "partialBitstream": False,
+        "skipRevisionCheck": False,
+        "device": {
+            "plDevice": "Auto Detect",
+            "psDevice": "Auto Detect"
+        },
+    }
+    if is_versal:
+        target_setup["pdiFile"] = f"${{workspaceFolder}}/{bitstream_path}"
+        target_setup["supportsSegPdi"] = False
+    elif is_mb:
+        target_setup["bitstreamFile"] = f"${{workspaceFolder}}/{bitstream_path}"
+    else:
+        target_setup["enableRPUSplitMode"] = False
+        target_setup["resetAPU"] = False
+        target_setup["resetRPU"] = False
+        target_setup["bitstreamFile"] = f"${{workspaceFolder}}/{bitstream_path}"
+
+    target_setup.update(init_section)
+    target_setup["downloadElf"] = generate_download_elf(
+        arch_config['targetCpu'], args.elf_path, args.project_dir)
+
+    launch_entry["targetSetup"] = target_setup
+    launch_entry["internalConsoleOptions"] = "openOnSessionStart"
+
+    config = {
+        "version": "0.2.0",
+        "configurations": [launch_entry]
+    }
+
+    return config
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Generate Vitis 2025.1+ launch.json for no-OS projects'
+    )
+    parser.add_argument('--arch', required=True,
+                        help='Architecture string (e.g., psu_cortexa53_0, ps7_cortexa9_0)')
+    parser.add_argument('--project-name', required=True,
+                        help='Project name (e.g., adrv904x)')
+    parser.add_argument('--xsa-path', required=True,
+                        help='XSA file path relative to project (e.g., system_top.xsa)')
+    parser.add_argument('--elf-path', required=True,
+                        help='Absolute path to ELF file')
+    parser.add_argument('--fsbl-path', required=True,
+                        help='FSBL path relative to project (e.g., build/tmp/output/hw0/export/hw0/sw/hw0/boot/fsbl.elf)')
+    parser.add_argument('--project-dir', required=True,
+                        help='Project directory (absolute path)')
+    parser.add_argument('--output', required=True,
+                        help='Output path for launch.json')
+
+    args = parser.parse_args()
+
+    # Generate the launch configuration
+    launch_config = generate_launch_json(args)
+
+    # Ensure output directory exists
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Write the JSON file
+    with open(output_path, 'w') as f:
+        json.dump(launch_config, f, indent='\t')
+        f.write('\n')  # Add trailing newline
+
+    arch_config = detect_arch_config(args.arch)
+    print(f"Generated Vitis launch configuration: {output_path}")
+    print(f"  Architecture: {args.arch}")
+    print(f"  Debug type: {arch_config['debugType']}")
+    print(f"  Target CPU: {arch_config['targetCpu']}")
+    print(f"  Uses FSBL: {arch_config['useFsbl']}")
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/scripts/platform/xilinx/util.py
+++ b/tools/scripts/platform/xilinx/util.py
@@ -350,6 +350,9 @@ def create_ide_workspace(ws, hw_path, hw_file, manifest_path):
     if defines:
         app.set_app_config(key="USER_COMPILE_DEFINITIONS", values=defines)
 
+    # Link math library (-lm) for projects that use log10, pow, etc.
+    app.set_app_config(key="USER_LINK_LIBRARIES", values=["m"])
+
     ld = app.get_ld_script()
     ld.set_heap_size('0x100000')
 

--- a/tools/scripts/platform/xilinx/util.py
+++ b/tools/scripts/platform/xilinx/util.py
@@ -8,12 +8,12 @@ Drives BSP/FSBL generation and JTAG programming via the Vitis 2025+ Python
 API (xsdb/hsi). Invoked via: vitis -s util.py <function> <args...>
 
 Arguments (positional):
-  function  - Function to call: get_arch, create_project, create_fsbl,
-               clean_build, upload
+  function  - Function to call: get_arch, create_project, create_ide_workspace,
+               create_fsbl, clean_build, upload
   ws        - Workspace/project path
   hw_path   - Hardware definition directory
   hw_file   - Hardware file name (e.g. system_top.xsa)
-  binary    - ELF binary path
+  binary    - ELF binary path (for create_ide_workspace: the manifest JSON path)
   target    - Target CPU filter (empty or "0" for auto-select)
   template  - App template name (unused in 2025+ flow)
   fsbl_file - FSBL ELF path (optional, for upload)
@@ -246,6 +246,127 @@ def create_project(ws, hw_path, hw_file, target):
 
     vitis.dispose()
     print("INFO: Project created successfully")
+
+
+# ---------------------------------------------------------------------------
+# create_ide_workspace
+# ---------------------------------------------------------------------------
+
+def create_ide_workspace(ws, hw_path, hw_file, manifest_path):
+    """Build a persistent Vitis workspace populated with the no-OS sources.
+
+    Unlike create_project (which builds into a throwaway tmp/output and copies
+    only the BSP + linker script out), this materializes a workspace that Vitis
+    can open directly with `vitis -w <workspace>`:
+
+      - an 'hw0' platform component (BSP), and
+      - an 'app' application component whose sources are the no-OS files the
+        CMake build actually compiled, referenced in place (not copied) via
+        import_files(is_skip_copy_sources=True) -- the modern equivalent of the
+        legacy `make` symlink mirror under build/app.
+
+    The include paths and compile definitions are taken from the CMake build so
+    Vitis's indexer resolves headers/macros exactly as ninja did. CMake still
+    owns the real build (the flashed ELF); this component exists for browsing
+    and (optionally) building inside the GUI.
+
+    manifest_path points at a JSON file written by no_os_build.py:
+        {"sources": [...abs paths...],
+         "includes": [...abs dirs...],
+         "defines": ["NAME=VAL", "NAME", ...]}
+    """
+    import json
+    import vitis
+
+    with open(manifest_path, "r") as f:
+        manifest = json.load(f)
+    sources = manifest.get("sources", [])
+    includes = manifest.get("includes", [])
+    defines = manifest.get("defines", [])
+
+    # Arch comes from the manifest (no_os_build reads XILINX_ARCH from the CMake
+    # cache); fall back to a staged arch.txt if present. Unlike create_project,
+    # this path may run long after the BSP was generated, so we don't rely on
+    # config_xilinx_sdk having just written arch.txt into hw_path.
+    cpu = manifest.get("arch")
+    if not cpu:
+        arch_file = os.path.join(hw_path, "arch.txt")
+        with open(arch_file, "r") as f:
+            cpu = f.read().strip()
+    vcpu = _vitis_cpu_name(cpu)
+
+    xsa = os.path.join(hw_path, hw_file)
+    # Persistent workspace: sibling of tmp/ so it survives after this run and a
+    # subsequent create_project (which only wipes tmp/output) leaves it intact.
+    out_dir = os.path.join(ws, "ide", "workspace")
+
+    xpfm = os.path.join(out_dir, "hw0", "export", "hw0", "hw0.xpfm")
+
+    # --- Step 1: Platform (BSP). Skip the slow rebuild if it already exists. ---
+    if not os.path.exists(xpfm):
+        print(f"INFO: Creating IDE platform component (cpu={vcpu})...")
+        client = vitis.create_client(workspace=out_dir)
+        client.create_platform_component(
+            name="hw0", hw_design=xsa, cpu=vcpu, os="standalone")
+        vitis.dispose()
+
+        print("INFO: Building IDE platform (BSP)...")
+        client = vitis.create_client(workspace=out_dir)
+        platform = client.get_component(name="hw0")
+        platform.build()
+        vitis.dispose()
+    else:
+        print("INFO: IDE platform component already present; reusing.")
+
+    # --- Step 2: App component populated with the no-OS sources ---
+    # Recreate the app component every run so a re-run of --open picks up source
+    # or flag changes from a refreshed manifest. The app references sources in
+    # place (no compile here), so this is cheap; the slow platform build above
+    # is what we preserve. Vitis refuses create_app_component if the component
+    # dir already exists, so remove it first.
+    import shutil
+    app_dir = os.path.join(out_dir, "app")
+    if os.path.exists(app_dir):
+        shutil.rmtree(app_dir)
+    print("INFO: Creating app component and importing no-OS sources...")
+    client = vitis.create_client(workspace=out_dir)
+    app = client.create_app_component(
+        name="app", platform=xpfm, template="empty_application")
+
+    # Reference each source in place (no copy). import_files takes a common
+    # from_loc + file list, so group by containing directory to keep paths
+    # absolute and avoid copying the whole tree.
+    from collections import defaultdict
+    by_dir = defaultdict(list)
+    for src in sources:
+        if os.path.exists(src):
+            by_dir[os.path.dirname(src)].append(os.path.basename(src))
+    for from_loc, files in by_dir.items():
+        app.import_files(from_loc=from_loc, files=files,
+                         is_skip_copy_sources=True)
+
+    if includes:
+        app.set_app_config(key="USER_INCLUDE_DIRECTORIES", values=includes)
+    if defines:
+        app.set_app_config(key="USER_COMPILE_DEFINITIONS", values=defines)
+
+    ld = app.get_ld_script()
+    ld.set_heap_size('0x100000')
+
+    vitis.dispose()
+
+    # Copy the pre-staged debug artifacts (launch.json + extracted bitstream /
+    # ps7_init.tcl) into the workspace now that Vitis has initialized it. They
+    # must NOT be present before create_client, or Vitis refuses the workspace
+    # ("cannot recognize the workspace version"). Staged by ide_vitis_configure
+    # at <ws>/ide/staging/_ide.
+    staged_ide = os.path.join(ws, "ide", "staging", "_ide")
+    if os.path.isdir(staged_ide):
+        shutil.copytree(staged_ide, os.path.join(out_dir, "_ide"),
+                        dirs_exist_ok=True)
+        print("INFO: Debug configuration (_ide/launch.json) staged in workspace.")
+
+    print(f"INFO: IDE workspace ready: {out_dir}")
 
 
 # ---------------------------------------------------------------------------
@@ -771,6 +892,8 @@ def main():
     dispatch = {
         "get_arch": lambda: get_arch(hw_path, hw_file, target),
         "create_project": lambda: create_project(ws, hw_path, hw_file, target),
+        "create_ide_workspace": lambda: create_ide_workspace(
+            ws, hw_path, hw_file, binary),
         "create_fsbl": lambda: create_fsbl(ws, hw_path, hw_file, target),
         "upload": lambda: upload(hw_path, hw_file, binary, target,
                                  fsbl_file, jtagtarget),

--- a/tools/scripts/platform/xilinx/util.py
+++ b/tools/scripts/platform/xilinx/util.py
@@ -283,6 +283,7 @@ def create_ide_workspace(ws, hw_path, hw_file, manifest_path):
     sources = manifest.get("sources", [])
     includes = manifest.get("includes", [])
     defines = manifest.get("defines", [])
+    force_includes = manifest.get("force_includes", [])
 
     # Arch comes from the manifest (no_os_build reads XILINX_ARCH from the CMake
     # cache); fall back to a staged arch.txt if present. Unlike create_project,
@@ -357,6 +358,23 @@ def create_ide_workspace(ws, hw_path, hw_file, manifest_path):
     ld.set_heap_size('0x100000')
 
     vitis.dispose()
+
+    # Patch UserConfig.cmake to add force-include flags for Kconfig-generated
+    # headers (e.g., -include no_os_config.h). The Vitis API doesn't support
+    # arbitrary compiler flags, so we edit the file directly after Vitis
+    # creates it.
+    if force_includes:
+        user_config = os.path.join(out_dir, "app", "src", "UserConfig.cmake")
+        if os.path.exists(user_config):
+            with open(user_config, "r") as f:
+                content = f.read()
+            flags = " ".join(f"-include {h}" for h in force_includes)
+            # Replace empty USER_COMPILE_OTHER_FLAGS with the force-include flags
+            content = content.replace(
+                "set(USER_COMPILE_OTHER_FLAGS )",
+                f"set(USER_COMPILE_OTHER_FLAGS {flags})")
+            with open(user_config, "w") as f:
+                f.write(content)
 
     # Copy the pre-staged debug artifacts (launch.json + extracted bitstream /
     # ps7_init.tcl) into the workspace now that Vitis has initialized it. They


### PR DESCRIPTION
## Pull Request Description

Add --open command to the CMake build system for Xilinx platforms. This creates a Vitis IDE workspace from a CMake build and opens it in the Vitis GUI, enabling developers to use the IDE for debugging and development.

Changes:

no_os_build.py: Add open command that creates the IDE workspace and launches Vitis
util.py: Add open_ide_workspace() function and link math library (-lm) in workspace configuration
adrv903x/adrv904x CMakeLists.txt: Add --wrap=fseek and --wrap=fclose linker options so the custom file I/O implementations in no_os_platform.c are used (required for in-memory firmware file emulation)

Usage:

python tools/scripts/no_os_build.py build adrv904x zcu102 basic_example
python tools/scripts/no_os_build.py open adrv904x zcu102 basic_example

Tested on ZCU102 with adrv904x project - builds and runs successfully in Vitis IDE.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
