### PR TITLE
ci: publish docs as a GitHub Pages artifact

### DIFF
--- a/.github/scripts/deploy-docs.sh
+++ b/.github/scripts/deploy-docs.sh
@@ -45,8 +45,8 @@ mkdir -p build && cd build
 cmake ..
 cd ../../..
 
-# Run build and upload documentation script
-echo "Uploading the documentation to gh-pages ..."
+# Run documentation validation and build script
+echo "Validating and building the documentation ..."
 . ${TOP_DIR}/.github/scripts/documentation.sh
 
 echo "Finished!"

--- a/.github/scripts/documentation.sh
+++ b/.github/scripts/documentation.sh
@@ -203,53 +203,6 @@ build_sphinx() {
         popd
 }
 
-############################################################################
-# If the current build is not a pull request and it is on main the 
-# documentation will be pushed to the gh-pages branch
-############################################################################
-update_gh_pages() {
-        REPO_SLUG="${REPO_SLUG:-analogdevicesinc/no-OS}"
-
-        git config --global user.email "cse-ci-notifications@analog.com"
-        git config --global user.name "CSE-CI"
-
-        MAIN_COMMIT=$(git rev-parse --short HEAD)
-
-        echo "Running Github docs update on commit '$MAIN_COMMIT'"
-
-        git fetch --depth 1 origin +refs/heads/gh-pages:gh-pages
-        rm -rf ${DEPS_DIR}
-        git checkout gh-pages
-
-        # Clear previous content in the root folder except the doc path which holds new builds
-        find ${TOP_DIR} -mindepth 1 -maxdepth 1 ! \( -name "doc" -o -name ".git" \) -exec rm -r {} \;
-
-        # Create doxygen folder holding new build content
-        mkdir -p ${TOP_DIR}/doxygen
-        rsync -a "${TOP_DIR}/doc/doxygen/build/doxygen_doc/html/" "${TOP_DIR}/doxygen/"
-
-        # Add sphinx build content to root folder
-        cp -R ${TOP_DIR}/doc/sphinx/build/html/* ${TOP_DIR}
-        rm -rf ${TOP_DIR}/doc
-
-        # Create .nojekyll file
-        touch ${TOP_DIR}/.nojekyll
-        git add --all .
-
-        # Only commit and push if there are actual changes
-        if git diff --cached --quiet; then
-                echo "Documentation already up to date - no changes to commit"
-        else
-                git commit -m "Update documentation to ${MAIN_COMMIT:0:7}"
-                if [ -n "$GITHUB_DOC_TOKEN" ] ; then
-                        git push https://${GITHUB_DOC_TOKEN}@github.com/${REPO_SLUG} gh-pages
-                else
-                        git push origin gh-pages
-                fi
-                echo "Documentation updated!"
-        fi
-}
-
 parse_commit_range
 
 check_new_components_readme
@@ -259,9 +212,3 @@ check_sphinx_doc
 build_doxygen
 
 build_sphinx
-
-if [[ "$UPDATE_GH_PAGES" == 'true' ]]; then
-        update_gh_pages
-else
-        echo "Not updating gh-pages ..."
-fi

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -2,10 +2,6 @@ name: Deploy docs for NO-OS
 
 on:
   workflow_dispatch:
-    inputs:
-      update-gh-pages:
-        required: false
-        default: 'false'
 
   pull_request:
     branches:
@@ -23,20 +19,25 @@ on:
       - '.github/workflows/deploy-docs.yaml'
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   NUM_JOBS: 4
 
 jobs:
-  deploy-doxygen:
+  build-docs:
     runs-on: ubuntu-latest
+    outputs:
+      built: ${{ steps.stage.outcome == 'success' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
           submodules: recursive
+          # documentation.sh diffs against the target branch to validate that
+          # new drivers/projects ship a README.rst wired into the toctree.
           fetch-depth: 0
+
       - name: Verify changed files
         id: verify_changed_files
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 #v3
@@ -50,7 +51,9 @@ jobs:
               - '.github/workflows/deploy-docs.yaml'
             drivers:
               - 'drivers/**'
-      - name: Deploy doxygen
+
+      - name: Build documentation
+        id: build
         if: ${{ steps.verify_changed_files.outputs.docs == 'true' || steps.verify_changed_files.outputs.drivers == 'true' }}
         shell: bash
         run: |
@@ -61,5 +64,44 @@ jobs:
           NUM_JOBS: ${{ env.NUM_JOBS }}
           VERSION: '1.13.2'
           TARGET_BRANCH: ${{ github.base_ref }}
-          GITHUB_DOC_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          UPDATE_GH_PAGES: ${{ (github.event_name == 'workflow_dispatch' && inputs.update-gh-pages == 'true') || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
+
+      # Site layout: sphinx html at the root, doxygen under /doxygen/, plus
+      # .nojekyll so that the _sources/ and _static/ directories are served.
+      - name: Stage site
+        id: stage
+        if: ${{ steps.build.outcome == 'success' }}
+        shell: bash
+        run: |
+          set -e
+          rm -rf _site
+          mkdir -p _site/doxygen
+          cp -R doc/sphinx/build/html/. _site/
+          rsync -a doc/doxygen/build/doxygen_doc/html/ _site/doxygen/
+          touch _site/.nojekyll
+
+          # Fail loudly on layout drift rather than publishing a broken site.
+          test -f _site/index.html
+          test -f _site/doxygen/index.html
+          test -f _site/.nojekyll
+          echo "Staged $(du -sh _site | cut -f1) in $(find _site -type f | wc -l) files"
+
+      - name: Upload Pages artifact
+        if: ${{ steps.stage.outcome == 'success' }}
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy-docs:
+    needs: build-docs
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' && needs.build-docs.outputs.built == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Stop using gh-pages for doxygen, it is HUGE and quite likely doubles the git clone time. When this works and gets merged, we can delete that branch from remote.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
