### PR TITLE
ci: increase timeout for xilinx builds

### DIFF
--- a/.github/scripts/astyle.sh
+++ b/.github/scripts/astyle.sh
@@ -37,10 +37,10 @@ get_script_path() {
 
 	[ -n "$script" ] || return 1
 
-	if [ -f ".github/scripts/$script" ] ; then
+	if [ -f "${WORKSPACE}/.github/scripts/$script" ] ; then
 		echo ".github/scripts/$script"
-	elif [ -f "build/$script" ] ; then
-		echo "build/$script"
+	elif [ -f "${WORKSPACE}/build/$script" ] ; then
+		echo "${WORKSPACE}/build/$script"
 	else
 		return 1
 	fi
@@ -111,7 +111,7 @@ run_astyle() {
 	git diff --name-only --diff-filter=d $COMMIT_RANGE | while read -r file; do
 		if is_source_file "$file" && is_valid_file "$file"
 		then
-			./build/astyle/build/gcc/bin/astyle --options="$(get_script_path .github/config/astyle_config)" "$file"
+			${WORKSPACE}/./build/astyle/build/gcc/bin/astyle --options="${WORKSPACE}/.github/config/astyle_config" "$file"
 		fi
 	done;
 

--- a/.github/workflows/build-xilinx-platform.yaml
+++ b/.github/workflows/build-xilinx-platform.yaml
@@ -91,6 +91,7 @@ jobs:
           CLOUDSMITH_API_KEY: ${{ env.CLOUDSMITH_API_KEY }}
           TOKEN: ${{ secrets.GH_GHDL_TOKEN }}
       - name: Upload Xilinx artifacts
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           path: ${{ env.RELEASES_DIR }}

--- a/.github/workflows/build-xilinx-platform.yaml
+++ b/.github/workflows/build-xilinx-platform.yaml
@@ -63,6 +63,7 @@ jobs:
       LOGS_DIR: ${{ github.workspace }}/logs
       NO_OS_CACHE_DIR: ${{ github.workspace }}/deps_cache
     runs-on: noos-runner-xilinx
+    timeout-minutes: 600
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -101,6 +102,7 @@ jobs:
           path: ${{ env.LOGS_DIR }}
           name: logs_xilinx_${{ github.job }}
       - name: Remove logs, new_hardware and release output
+        if: always()
         shell: sh
         run: |
           rm -rf ${{ env.RELEASES_DIR }} ${{ env.LOGS_DIR }} ${{ env.BUILDS_DIR }}_${{ env.HDL_BRANCH }}/new_hardware

--- a/tools/scripts/build_projects.py
+++ b/tools/scripts/build_projects.py
@@ -415,7 +415,6 @@ def build_cmake_project(noos, project, _platform, _build_name, export_dir,
 		if not success:
 			log_err("ERROR")
 			log("See log %s" % dst_log)
-			os.system("cat %s" % dst_log)
 			ERR = 1
 
 		# The final link + .hex/.bin runs as a cmake custom command whose failure


### PR DESCRIPTION
## Pull Request Description

Increase the default timeout for xilinx builds to 600 minutes.
Remove exesive verbosity from CI.
Always remove the output after are uploaded as artifacts on CI.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
