### PR TITLE
xilinx: fix Vitis 2025+ BSP compatibility for fabric IRQ and DDR macros

### DIFF
--- a/cmake/xilinx/xilinx_platform_sdk.cmake
+++ b/cmake/xilinx/xilinx_platform_sdk.cmake
@@ -18,9 +18,23 @@ function(config_xilinx_sdk BUILD_TARGET)
     set(_bsp_lib "${_ws}/bsp/${XILINX_ARCH}/lib")
     set(_lscript "${_ws}/app/src/lscript.ld")
 
-    # Regenerate only when the BSP artifacts are missing (BSP generation is slow;
-    # the .xsa rarely changes within a working tree).
+    # Regenerate when BSP artifacts are missing OR when BSP scripts changed
+    # (indicated by .bsp_regen_needed marker file from build_projects.py).
+    get_filename_component(_hw_dir "${HARDWARE}" DIRECTORY)
+    set(_regen_marker "${_hw_dir}/.bsp_regen_needed")
+    set(_need_regen FALSE)
     if(NOT EXISTS "${_bsp_lib}/libxil.a" OR NOT EXISTS "${_lscript}")
+        message(STATUS "BSP artifacts missing, will regenerate")
+        set(_need_regen TRUE)
+    elseif(EXISTS "${_regen_marker}")
+        message(STATUS "BSP scripts changed (marker file found), will regenerate")
+        set(_need_regen TRUE)
+    endif()
+    if(_need_regen)
+        # Remove stale BSP so Vitis regenerates it
+        if(EXISTS "${_ws}")
+            file(REMOVE_RECURSE "${_ws}")
+        endif()
         file(MAKE_DIRECTORY "${_ws}")
         file(COPY "${HARDWARE}" DESTINATION "${_ws}")
         # create_project reads the CPU from arch.txt (normally written by

--- a/drivers/platform/xilinx/xilinx_compat.h
+++ b/drivers/platform/xilinx/xilinx_compat.h
@@ -118,21 +118,20 @@
 #define XPAR_INTC_SINGLE_DEVICE_ID	0
 #endif
 
-/* Note: XPAR_INTC_MAX_NUM_INTR_INPUTS is intentionally NOT provided here.
- * On Vitis 2025+ the BSP's xintc.h pulls in xintc_drv_config.h, which always
- * defines this macro.  Providing a fallback from xparameters.h (which only
- * exposes XPAR_XINTC_0_NUM_INTR_INPUTS) would be redefined later by
- * xintc_drv_config.h, triggering a redefinition warning.  No no-OS code uses
- * this macro outside the xintc.h include chain, so the BSP definition suffices. */
+/* MicroBlaze interrupt controller: Vitis 2025+ moved XPAR_INTC_MAX_NUM_INTR_INPUTS
+ * to xintc_drv_config.h, but that header is only included when SDT (System Device
+ * Tree) mode is enabled (#ifdef SDT in xintc.h).  In the legacy (non-SDT) BSP flow
+ * that no-OS uses, xintc.h includes xparameters.h instead — which no longer defines
+ * this macro in Vitis 2025+.  Provide the fallback here. */
+#if !defined(XPAR_INTC_MAX_NUM_INTR_INPUTS) && defined(XPAR_XINTC_0_NUM_INTR_INPUTS)
+#define XPAR_INTC_MAX_NUM_INTR_INPUTS	XPAR_XINTC_0_NUM_INTR_INPUTS
+#endif
 
 /* Interrupt ID renames: old XPAR_AXI_INTC_<periph>_INTERRUPT_INTR
- * became XPAR_FABRIC_<periph>_INTR in Vitis 2025+. */
-#if !defined(XPAR_AXI_INTC_AXI_TIMER_INTERRUPT_INTR) && defined(XPAR_FABRIC_AXI_TIMER_INTR)
-#define XPAR_AXI_INTC_AXI_TIMER_INTERRUPT_INTR	XPAR_FABRIC_AXI_TIMER_INTR
-#endif
-#if !defined(XPAR_AXI_INTC_AXI_UART_INTERRUPT_INTR) && defined(XPAR_FABRIC_AXI_UART_INTR)
-#define XPAR_AXI_INTC_AXI_UART_INTERRUPT_INTR	XPAR_FABRIC_AXI_UART_INTR
-#endif
+ * became XPAR_FABRIC_<periph>_INTR in Vitis 2025+.
+ * NOTE: As of the util.py fix that generates XPAR_AXI_INTC_* macros directly
+ * from the XSA for MicroBlaze designs, these fallbacks are no longer needed.
+ * They're removed to avoid redefinition warnings. */
 
 /* SPI device ID and clock frequency renames: Vitis 2025+ uses XPAR_XSPIPS_*
  * instead of the platform-specific XPAR_PS7_SPI_* / XPAR_PSU_SPI_* names,
@@ -169,6 +168,33 @@
 #endif
 #if !defined(XPAR_XUARTPS_1_INTR) && defined(XPAR_XUARTPS_1_INTERRUPTS)
 #define XPAR_XUARTPS_1_INTR			XPAR_XUARTPS_1_INTERRUPTS
+#endif
+
+/* DDR memory base address renames: Vitis 2025+ changed the macro names.
+ * Old: XPAR_PSU_DDR_0_S_AXI_BASEADDR, XPAR_PS7_DDR_0_S_AXI_BASEADDR
+ * New: XPAR_PSU_DDR_0_BASEADDRESS, XPAR_PS7_DDR_0_BASEADDRESS
+ * Also provide XPAR_DDR_MEM_BASEADDR which some projects use as a generic name. */
+#if !defined(XPAR_PSU_DDR_0_S_AXI_BASEADDR) && defined(XPAR_PSU_DDR_0_BASEADDRESS)
+#define XPAR_PSU_DDR_0_S_AXI_BASEADDR		XPAR_PSU_DDR_0_BASEADDRESS
+#endif
+#if !defined(XPAR_PS7_DDR_0_S_AXI_BASEADDR) && defined(XPAR_PS7_DDR_0_BASEADDRESS)
+#define XPAR_PS7_DDR_0_S_AXI_BASEADDR		XPAR_PS7_DDR_0_BASEADDRESS
+#endif
+#if !defined(XPAR_DDR_MEM_BASEADDR)
+#if defined(XPAR_PSU_DDR_0_BASEADDRESS)
+#define XPAR_DDR_MEM_BASEADDR			XPAR_PSU_DDR_0_BASEADDRESS
+#elif defined(XPAR_PS7_DDR_0_BASEADDRESS)
+#define XPAR_DDR_MEM_BASEADDR			XPAR_PS7_DDR_0_BASEADDRESS
+#endif
+#endif
+
+/* MicroBlaze DDR4 memory controller: Vitis 2025+ may use different naming. */
+#if !defined(XPAR_AXI_DDR_CNTRL_C0_DDR4_MEMORY_MAP_BASEADDR)
+#if defined(XPAR_MIG_0_BASEADDR)
+#define XPAR_AXI_DDR_CNTRL_C0_DDR4_MEMORY_MAP_BASEADDR	XPAR_MIG_0_BASEADDR
+#elif defined(XPAR_DDR4_0_BASEADDR)
+#define XPAR_AXI_DDR_CNTRL_C0_DDR4_MEMORY_MAP_BASEADDR	XPAR_DDR4_0_BASEADDR
+#endif
 #endif
 
 #endif /* _XILINX_COMPAT_H_ */

--- a/drivers/platform/xilinx/xilinx_compat.h
+++ b/drivers/platform/xilinx/xilinx_compat.h
@@ -188,9 +188,14 @@
 #endif
 #endif
 
-/* MicroBlaze DDR4 memory controller: Vitis 2025+ may use different naming. */
+/* MicroBlaze DDR4 memory controller: Vitis 2025+ uses different naming.
+ * Old: XPAR_AXI_DDR_CNTRL_C0_DDR4_MEMORY_MAP_BASEADDR (from hsi::generate_bsp)
+ * New: XPAR_DDR4_0_BASEADDRESS (from vitis.create_platform_component)
+ * Note the suffix: BASEADDR vs BASEADDRESS */
 #if !defined(XPAR_AXI_DDR_CNTRL_C0_DDR4_MEMORY_MAP_BASEADDR)
-#if defined(XPAR_MIG_0_BASEADDR)
+#if defined(XPAR_DDR4_0_BASEADDRESS)
+#define XPAR_AXI_DDR_CNTRL_C0_DDR4_MEMORY_MAP_BASEADDR	XPAR_DDR4_0_BASEADDRESS
+#elif defined(XPAR_MIG_0_BASEADDR)
 #define XPAR_AXI_DDR_CNTRL_C0_DDR4_MEMORY_MAP_BASEADDR	XPAR_MIG_0_BASEADDR
 #elif defined(XPAR_DDR4_0_BASEADDR)
 #define XPAR_AXI_DDR_CNTRL_C0_DDR4_MEMORY_MAP_BASEADDR	XPAR_DDR4_0_BASEADDR

--- a/tools/scripts/build_projects.py
+++ b/tools/scripts/build_projects.py
@@ -253,7 +253,29 @@ def configfile_and_download_all_hw(_platform, noos, _builds_dir, hdl_branch):
 			sys.exit(1)
 	return (builds_dir, blacklist)
 
-def get_hardware(hardware, platform, builds_dir):
+# Files that affect BSP generation - changes invalidate the BSP cache
+XILINX_BSP_DEPS = [
+	'tools/scripts/platform/xilinx/util.py',
+	'drivers/platform/xilinx/xilinx_compat.h',
+]
+# Bump this version to force BSP regeneration on all CI runners
+BSP_CACHE_VERSION = 5
+
+
+def _get_bsp_deps_hash(noos_dir):
+	"""Compute combined hash of files that affect BSP generation."""
+	import hashlib
+	combined = hashlib.md5()
+	combined.update(str(BSP_CACHE_VERSION).encode())
+	for relpath in XILINX_BSP_DEPS:
+		filepath = os.path.join(noos_dir, relpath)
+		if os.path.isfile(filepath):
+			with open(filepath, 'rb') as f:
+				combined.update(f.read())
+	return combined.hexdigest()
+
+
+def get_hardware(hardware, platform, builds_dir, noos_dir=None):
 	if platform == 'xilinx':
 		ext = 'xsa'
 		base_name = 'system_top'
@@ -266,12 +288,41 @@ def get_hardware(hardware, platform, builds_dir):
 	old_name = "%s.%s" % (hardware, ext)
 	filename = os.path.join(builds_dir, HW_DIR_NAME, old_name)
 
-	if os.path.isfile(filename):
+	# Check if BSP generation scripts changed (Xilinx only)
+	# Use a marker file to track if we already detected a change this run -
+	# all hardware files must regenerate, not just the first one
+	bsp_scripts_changed = False
+	if platform == 'xilinx' and noos_dir:
+		hash_file = os.path.join(builds_dir, HW_DIR_NAME, '.bsp_deps_hash')
+		regen_marker = os.path.join(builds_dir, HW_DIR_NAME, '.bsp_regen_needed')
+		current_hash = _get_bsp_deps_hash(noos_dir)
+
+		# Check if we already marked this run as needing regeneration
+		if os.path.isfile(regen_marker):
+			bsp_scripts_changed = True
+			log("BSP regeneration in progress (marker file exists)")
+		elif os.path.isfile(hash_file):
+			with open(hash_file, 'r') as f:
+				cached_hash = f.read().strip()
+			if cached_hash != current_hash:
+				bsp_scripts_changed = True
+				log("BSP scripts changed, regenerating all bsps")
+				# Create marker so all subsequent hardware also regenerates
+				with open(regen_marker, 'w') as f:
+					f.write('1')
+		else:
+			# No hash file yet - force regeneration
+			bsp_scripts_changed = True
+			log("No BSP hash file, regenerating all bsps")
+			with open(regen_marker, 'w') as f:
+				f.write('1')
+
+	if os.path.isfile(filename) and not bsp_scripts_changed:
 		#If equal
 		if filecmp.cmp(filename, tmp_filename):
 			log("Same hardware from last build, use existing bsp")
 			return (filename, 0, 0)
-	
+
 	err = run_cmd('cp %s %s' % (tmp_filename, filename))
 	if err != 0:
 		return ('', 1, err)
@@ -359,7 +410,7 @@ def build_cmake_project(noos, project, _platform, _build_name, export_dir,
 				ok = 0
 				os.environ.clear(); os.environ.update(env)
 				continue
-			(hardware_file, new_hdf, hw_err) = get_hardware(hw_name, 'xilinx', builds_dir)
+			(hardware_file, new_hdf, hw_err) = get_hardware(hw_name, 'xilinx', builds_dir, noos)
 			if hw_err != 0 or not hardware_file:
 				log_err("ERROR")
 				log("%s: could not resolve .xsa for hardware '%s' (not downloaded?)" % (
@@ -437,6 +488,21 @@ def build_cmake_project(noos, project, _platform, _build_name, export_dir,
 
 	return ok
 
+def _finalize_bsp_hash(builds_dir, noos_dir):
+	"""Update BSP hash file and remove regeneration marker after build completes."""
+	if not noos_dir:
+		return
+	hash_file = os.path.join(builds_dir, HW_DIR_NAME, '.bsp_deps_hash')
+	regen_marker = os.path.join(builds_dir, HW_DIR_NAME, '.bsp_regen_needed')
+	# Update hash file with current hash
+	current_hash = _get_bsp_deps_hash(noos_dir)
+	with open(hash_file, 'w') as f:
+		f.write(current_hash)
+	# Remove regeneration marker
+	if os.path.isfile(regen_marker):
+		os.remove(regen_marker)
+
+
 def main():
 	(noos, export_dir, log_dir, _project,
 	 _platform, _build_name, _builds_dir, _hw, hdl_branch) = parse_input()
@@ -465,6 +531,10 @@ def main():
 		if cmake_ok is not None:
 			status = 'OK' if cmake_ok == 1 else 'Fail'
 			os.system('echo Project %20s -- %s >> %s' % (project, status, all_status))
+
+	# Finalize BSP hash after all builds complete (Xilinx only)
+	if _platform == 'xilinx':
+		_finalize_bsp_hash(builds_dir, noos)
 
 main()
 

--- a/tools/scripts/platform/xilinx/util.py
+++ b/tools/scripts/platform/xilinx/util.py
@@ -94,6 +94,256 @@ def _build_filter(name_pattern, jtagtarget=None):
 
 
 # ---------------------------------------------------------------------------
+# Fabric interrupt macro generation
+# ---------------------------------------------------------------------------
+
+# GIC IRQ base for PS platforms. The concat output connects to pl_ps_irq,
+# which maps to these GIC IRQ IDs based on the platform.
+# Zynq-7000: sys_concat_intc[15:0] -> IRQ_F2P[15:0] -> GIC 61-68 (0-7), 84-91 (8-15)
+# ZynqMP: sys_concat_intc_0[7:0] -> pl_ps_irq0 -> GIC 121-128
+#         sys_concat_intc_1[7:0] -> pl_ps_irq1 -> GIC 136-143
+# Versal: sys_cips/pl_ps_irq[15:0] -> GIC 116-131
+FABRIC_IRQ_BASE = {
+    "ps7_cortexa9_0": {
+        "sys_concat_intc": lambda idx: 61 + idx if idx < 8 else 84 + (idx - 8),
+    },
+    "psu_cortexa53_0": {
+        "sys_concat_intc_0": lambda idx: 121 + idx,
+        "sys_concat_intc_1": lambda idx: 136 + idx,
+    },
+}
+
+
+def _generate_fabric_irq_macros(xsa_path, cpu):
+    """Extract PL interrupt connections and generate XPAR_FABRIC_* macros.
+
+    The Vitis 2025+ Python API (create_platform_component) does not generate
+    XPAR_FABRIC_*_INTR macros for PL peripherals. This function replicates what
+    the old HSI generate_bsp command did by tracing interrupt signals from
+    peripheral IRQ pins through the concat blocks to the PS interrupt ports.
+
+    For MicroBlaze, generates XPAR_AXI_INTC_*_INTR macros instead.
+
+    Returns a list of C #define lines.
+    """
+    hw_design = HwManager.open_hw_design(xsa_path)
+    defines = []
+
+    # MicroBlaze uses AXI interrupt controller with different naming
+    if cpu == "sys_mb":
+        defines = _generate_mb_irq_macros(hw_design)
+        hw_design.close()
+        return defines
+
+    # Versal has a different interrupt topology (direct pl_ps_irq connections)
+    if "psv_cortexa72" in cpu:
+        defines = _generate_versal_irq_macros(hw_design)
+        hw_design.close()
+        return defines
+
+    # PS platforms (Zynq-7000, ZynqMP): trace through concat blocks
+    irq_base = FABRIC_IRQ_BASE.get(cpu)
+    if not irq_base:
+        hw_design.close()
+        return defines
+
+    # Find all interrupt concat blocks and their input connections
+    cells = hw_design.get_cells(hierarchical='true')
+    concat_map = {}  # concat_name -> {input_idx -> net_name}
+
+    for cell in cells:
+        cell_name = cell.get('NAME')
+        if cell_name not in irq_base:
+            continue
+
+        concat_map[cell_name] = {}
+        pins = hw_design.get_pins(of_objects=cell)
+        if not pins:
+            continue
+
+        for pin in pins:
+            pin_name = pin.get('NAME')
+            if not pin_name.startswith('In'):
+                continue
+            try:
+                idx = int(pin_name[2:])
+            except ValueError:
+                continue
+
+            nets = hw_design.get_nets(of_objects=pin)
+            if nets:
+                concat_map[cell_name][idx] = nets[0].get('NAME')
+
+    # Find all PL peripherals with IRQ outputs and trace to concat inputs
+    for cell in cells:
+        cell_name = cell.get('NAME')
+        pins = hw_design.get_pins(of_objects=cell)
+        if not pins:
+            continue
+
+        for pin in pins:
+            pin_name = pin.get('NAME')
+            # Check if this is an interrupt output (common names)
+            if pin_name.lower() not in ('irq', 'interrupt', 'ip2intc_irpt',
+                                         'mm2s_introut', 's2mm_introut'):
+                continue
+
+            nets = hw_design.get_nets(of_objects=pin)
+            if not nets:
+                continue
+            net_name = nets[0].get('NAME')
+
+            # Find which concat input this net connects to
+            for concat_name, inputs in concat_map.items():
+                for idx, input_net in inputs.items():
+                    if input_net == net_name:
+                        irq_id = irq_base[concat_name](idx)
+                        macro = f"XPAR_FABRIC_{cell_name.upper()}_{pin_name.upper()}_INTR"
+                        defines.append(f"#define {macro} {irq_id}U")
+
+    hw_design.close()
+    return defines
+
+
+def _generate_mb_irq_macros(hw_design):
+    """Generate XPAR_AXI_INTC_*_INTR macros for MicroBlaze designs."""
+    defines = []
+    cells = hw_design.get_cells(hierarchical='true')
+
+    # Find the AXI interrupt controller
+    intc_cell = None
+    for cell in cells:
+        cell_name = cell.get('NAME')
+        if 'axi_intc' in cell_name.lower() or cell_name == 'axi_intc':
+            intc_cell = cell
+            break
+
+    if not intc_cell:
+        return defines
+
+    # Build map of intc inputs to connected nets
+    intc_inputs = {}
+    pins = hw_design.get_pins(of_objects=intc_cell)
+    if pins:
+        for pin in pins:
+            pin_name = pin.get('NAME')
+            if pin_name.lower() == 'intr':
+                # This is the interrupt input vector - trace its sources
+                nets = hw_design.get_nets(of_objects=pin)
+                # The intr pin is typically connected via a concat block
+                # We need to find the concat and trace its inputs
+                break
+
+    # Find interrupt concat block for MicroBlaze (usually sys_concat_intc)
+    concat_map = {}
+    for cell in cells:
+        cell_name = cell.get('NAME')
+        if 'concat_intc' in cell_name.lower():
+            pins = hw_design.get_pins(of_objects=cell)
+            if pins:
+                for pin in pins:
+                    pin_name = pin.get('NAME')
+                    if pin_name.startswith('In'):
+                        try:
+                            idx = int(pin_name[2:])
+                        except ValueError:
+                            continue
+                        nets = hw_design.get_nets(of_objects=pin)
+                        if nets:
+                            concat_map[idx] = nets[0].get('NAME')
+
+    # Find peripherals and match their IRQ nets to concat inputs
+    for cell in cells:
+        cell_name = cell.get('NAME')
+        pins = hw_design.get_pins(of_objects=cell)
+        if not pins:
+            continue
+
+        for pin in pins:
+            pin_name = pin.get('NAME')
+            if pin_name.lower() not in ('irq', 'interrupt', 'ip2intc_irpt',
+                                         'mm2s_introut', 's2mm_introut'):
+                continue
+
+            nets = hw_design.get_nets(of_objects=pin)
+            if not nets:
+                continue
+            net_name = nets[0].get('NAME')
+
+            for idx, input_net in concat_map.items():
+                if input_net == net_name:
+                    macro = f"XPAR_AXI_INTC_{cell_name.upper()}_{pin_name.upper()}_INTR"
+                    defines.append(f"#define {macro} {idx}U")
+
+    return defines
+
+
+def _generate_versal_irq_macros(hw_design):
+    """Generate XPAR_FABRIC_*_INTR macros for Versal designs.
+
+    Versal uses direct pl_ps_irq connections to the CIPS block rather than
+    concat blocks. The GIC mapping is pl_ps_irq[N] -> GIC IRQ 116+N.
+    """
+    defines = []
+
+    # Use non-hierarchical lookup for the top-level CIPS block to get correct
+    # net names. The hierarchical lookup returns internal cells with different
+    # net names that don't match peripheral IRQ outputs.
+    top_cells = hw_design.get_cells()  # Non-hierarchical
+
+    # Find the top-level CIPS block and its pl_ps_irq inputs
+    cips_irq_map = {}  # irq_index -> net_name
+    for cell in top_cells:
+        cell_name = cell.get('NAME')
+        if 'cips' not in cell_name.lower():
+            continue
+
+        pins = hw_design.get_pins(of_objects=cell)
+        if not pins:
+            continue
+
+        for pin in pins:
+            pin_name = pin.get('NAME')
+            if not pin_name.startswith('pl_ps_irq'):
+                continue
+            try:
+                idx = int(pin_name[9:])  # Extract number after 'pl_ps_irq'
+            except ValueError:
+                continue
+
+            nets = hw_design.get_nets(of_objects=pin)
+            if nets:
+                cips_irq_map[idx] = nets[0].get('NAME')
+
+    # Find peripherals (need hierarchical to find all IP) and match IRQs
+    cells = hw_design.get_cells(hierarchical='true')
+    for cell in cells:
+        cell_name = cell.get('NAME')
+        pins = hw_design.get_pins(of_objects=cell)
+        if not pins:
+            continue
+
+        for pin in pins:
+            pin_name = pin.get('NAME')
+            if pin_name.lower() not in ('irq', 'interrupt', 'ip2intc_irpt',
+                                         'mm2s_introut', 's2mm_introut'):
+                continue
+
+            nets = hw_design.get_nets(of_objects=pin)
+            if not nets:
+                continue
+            net_name = nets[0].get('NAME')
+
+            for idx, input_net in cips_irq_map.items():
+                if input_net == net_name:
+                    irq_id = 116 + idx  # Versal GIC mapping
+                    macro = f"XPAR_FABRIC_{cell_name.upper()}_{pin_name.upper()}_INTR"
+                    defines.append(f"#define {macro} {irq_id}U")
+
+    return defines
+
+
+# ---------------------------------------------------------------------------
 # get_arch
 # ---------------------------------------------------------------------------
 
@@ -200,6 +450,18 @@ def create_project(ws, hw_path, hw_file, target):
         with open(xpar_h, "a") as f:
             f.write('\n/* Vitis 2025+ compatibility defines */\n')
             f.write('#include "xilinx_compat.h"\n')
+
+    # Generate XPAR_FABRIC_*_INTR macros for PL interrupts.
+    # Vitis 2025+ create_platform_component does not generate these, but the
+    # old HSI generate_bsp did.  Extract interrupt connections from the XSA
+    # and append the defines to xparameters.h.
+    fabric_irq_defines = _generate_fabric_irq_macros(xsa, cpu)
+    if fabric_irq_defines and os.path.exists(xpar_h):
+        with open(xpar_h, "a") as f:
+            f.write('\n/* Fabric interrupt defines (generated from XSA) */\n')
+            for define in fabric_irq_defines:
+                f.write(define + '\n')
+        print(f"INFO: Generated {len(fabric_irq_defines)} fabric IRQ macros")
 
     print(f"INFO: BSP copied to bsp/{cpu}/")
 

--- a/tools/scripts/platform/xilinx/util.py
+++ b/tools/scripts/platform/xilinx/util.py
@@ -130,7 +130,8 @@ def _generate_fabric_irq_macros(xsa_path, cpu):
     defines = []
 
     # MicroBlaze uses AXI interrupt controller with different naming
-    if cpu == "sys_mb":
+    # Check for any MicroBlaze CPU (sys_mb, or custom names like IOP1_IOP1_mb)
+    if cpu == "sys_mb" or "_mb" in cpu.lower():
         defines = _generate_mb_irq_macros(hw_design)
         hw_design.close()
         return defines
@@ -182,10 +183,15 @@ def _generate_fabric_irq_macros(xsa_path, cpu):
             continue
 
         for pin in pins:
+            # Detect interrupt outputs via TYPE property, with fallback to
+            # common pin names for custom IPs that don't set TYPE properly
+            pin_type = pin.get('TYPE')
+            pin_dir = pin.get('DIRECTION')
             pin_name = pin.get('NAME')
-            # Check if this is an interrupt output (common names)
-            if pin_name.lower() not in ('irq', 'interrupt', 'ip2intc_irpt',
-                                         'mm2s_introut', 's2mm_introut'):
+            is_irq_output = (pin_type == 'INTERRUPT' and pin_dir == 'O')
+            if not is_irq_output and pin_dir == 'O':
+                is_irq_output = pin_name.lower() in ('irq', 'interrupt')
+            if not is_irq_output:
                 continue
 
             nets = hw_design.get_nets(of_objects=pin)
@@ -210,47 +216,63 @@ def _generate_mb_irq_macros(hw_design):
     defines = []
     cells = hw_design.get_cells(hierarchical='true')
 
-    # Find the AXI interrupt controller
+    # Find the AXI interrupt controller by VLNV (more reliable than name)
     intc_cell = None
     for cell in cells:
-        cell_name = cell.get('NAME')
-        if 'axi_intc' in cell_name.lower() or cell_name == 'axi_intc':
+        vlnv = cell.get('VLNV') or ''
+        if 'axi_intc' in vlnv:
             intc_cell = cell
             break
 
     if not intc_cell:
         return defines
 
-    # Build map of intc inputs to connected nets
-    intc_inputs = {}
+    # Trace the intc's intr pin to find the connected concat block
+    intr_net_name = None
     pins = hw_design.get_pins(of_objects=intc_cell)
     if pins:
         for pin in pins:
-            pin_name = pin.get('NAME')
-            if pin_name.lower() == 'intr':
-                # This is the interrupt input vector - trace its sources
+            if pin.get('NAME') == 'intr':
                 nets = hw_design.get_nets(of_objects=pin)
-                # The intr pin is typically connected via a concat block
-                # We need to find the concat and trace its inputs
+                if nets:
+                    intr_net_name = nets[0].get('NAME')
                 break
 
-    # Find interrupt concat block for MicroBlaze (usually sys_concat_intc)
-    concat_map = {}
+    if not intr_net_name:
+        return defines
+
+    # Find the concat block whose dout drives the intc's intr pin
+    concat_cell = None
     for cell in cells:
-        cell_name = cell.get('NAME')
-        if 'concat_intc' in cell_name.lower():
+        vlnv = cell.get('VLNV') or ''
+        if 'xlconcat' in vlnv:
             pins = hw_design.get_pins(of_objects=cell)
-            if pins:
-                for pin in pins:
-                    pin_name = pin.get('NAME')
-                    if pin_name.startswith('In'):
-                        try:
-                            idx = int(pin_name[2:])
-                        except ValueError:
-                            continue
-                        nets = hw_design.get_nets(of_objects=pin)
-                        if nets:
-                            concat_map[idx] = nets[0].get('NAME')
+            for pin in pins:
+                if pin.get('NAME') == 'dout':
+                    nets = hw_design.get_nets(of_objects=pin)
+                    if nets and nets[0].get('NAME') == intr_net_name:
+                        concat_cell = cell
+                        break
+            if concat_cell:
+                break
+
+    if not concat_cell:
+        return defines
+
+    # Build map of concat inputs to connected nets
+    concat_map = {}
+    concat_pins = hw_design.get_pins(of_objects=concat_cell)
+    if concat_pins:
+        for pin in concat_pins:
+            pin_name = pin.get('NAME')
+            if pin_name.startswith('In') and pin.get('DIRECTION') == 'I':
+                try:
+                    idx = int(pin_name[2:])
+                except ValueError:
+                    continue
+                nets = hw_design.get_nets(of_objects=pin)
+                if nets:
+                    concat_map[idx] = nets[0].get('NAME')
 
     # Find peripherals and match their IRQ nets to concat inputs
     for cell in cells:
@@ -260,9 +282,15 @@ def _generate_mb_irq_macros(hw_design):
             continue
 
         for pin in pins:
+            # Detect interrupt outputs via TYPE property, with fallback to
+            # common pin names for custom IPs that don't set TYPE properly
+            pin_type = pin.get('TYPE')
+            pin_dir = pin.get('DIRECTION')
             pin_name = pin.get('NAME')
-            if pin_name.lower() not in ('irq', 'interrupt', 'ip2intc_irpt',
-                                         'mm2s_introut', 's2mm_introut'):
+            is_irq_output = (pin_type == 'INTERRUPT' and pin_dir == 'O')
+            if not is_irq_output and pin_dir == 'O':
+                is_irq_output = pin_name.lower() in ('irq', 'interrupt')
+            if not is_irq_output:
                 continue
 
             nets = hw_design.get_nets(of_objects=pin)
@@ -324,9 +352,15 @@ def _generate_versal_irq_macros(hw_design):
             continue
 
         for pin in pins:
+            # Detect interrupt outputs via TYPE property, with fallback to
+            # common pin names for custom IPs that don't set TYPE properly
+            pin_type = pin.get('TYPE')
+            pin_dir = pin.get('DIRECTION')
             pin_name = pin.get('NAME')
-            if pin_name.lower() not in ('irq', 'interrupt', 'ip2intc_irpt',
-                                         'mm2s_introut', 's2mm_introut'):
+            is_irq_output = (pin_type == 'INTERRUPT' and pin_dir == 'O')
+            if not is_irq_output and pin_dir == 'O':
+                is_irq_output = pin_name.lower() in ('irq', 'interrupt')
+            if not is_irq_output:
                 continue
 
             nets = hw_design.get_nets(of_objects=pin)
@@ -340,6 +374,75 @@ def _generate_versal_irq_macros(hw_design):
                     macro = f"XPAR_FABRIC_{cell_name.upper()}_{pin_name.upper()}_INTR"
                     defines.append(f"#define {macro} {irq_id}U")
 
+    return defines
+
+
+def _generate_ddr_macros(xsa_path, cpu):
+    """Generate DDR memory base address macros for MicroBlaze designs.
+
+    Vitis 2025+ doesn't generate the XPAR_AXI_DDR_CNTRL_* macros that projects
+    expect. This function extracts DDR controller information from the XSA
+    and generates compatible macros.
+
+    Returns a list of C #define lines.
+    """
+    # Check for any MicroBlaze CPU (sys_mb, or custom names like IOP1_IOP1_mb)
+    if cpu != "sys_mb" and "_mb" not in cpu.lower():
+        return []
+
+    hw_design = HwManager.open_hw_design(xsa_path)
+    defines = []
+    seen = set()
+
+    # Find MicroBlaze processor
+    mb_cell = None
+    cells = hw_design.get_cells()
+    for cell in cells:
+        vlnv = cell.get('VLNV') or ''
+        if 'microblaze' in vlnv.lower():
+            mb_cell = cell
+            break
+
+    if not mb_cell:
+        hw_design.close()
+        return defines
+
+    # Get memory ranges from MicroBlaze's perspective
+    mem_ranges = hw_design.get_mem_ranges(of_objects=mb_cell)
+    for mem in mem_ranges:
+        instance_obj = mem.get('INSTANCE')
+        # INSTANCE returns an HwCell object, get its NAME
+        instance = instance_obj.get('NAME') if instance_obj else ''
+        base = mem.get('BASE_VALUE')
+        high = mem.get('HIGH_VALUE')
+
+        if base is None or not instance:
+            continue
+
+        # Check if this is a DDR/MIG controller by looking at the instance name
+        instance_lower = instance.lower()
+        if 'ddr' not in instance_lower and 'mig' not in instance_lower:
+            continue
+
+        # Skip duplicates (same instance can appear multiple times)
+        if instance in seen:
+            continue
+        seen.add(instance)
+
+        # Generate the old-style macro that projects expect
+        # Format: XPAR_AXI_DDR_CNTRL_C0_DDR4_MEMORY_MAP_BASEADDR
+        old_macro = f"XPAR_{instance.upper()}_C0_DDR4_MEMORY_MAP_BASEADDR"
+        defines.append(f"#define {old_macro} {base}")
+
+        # Also generate simpler macros
+        simple_macro = f"XPAR_{instance.upper()}_BASEADDR"
+        defines.append(f"#define {simple_macro} {base}")
+
+        if high is not None:
+            simple_high = f"XPAR_{instance.upper()}_HIGHADDR"
+            defines.append(f"#define {simple_high} {high}")
+
+    hw_design.close()
     return defines
 
 
@@ -462,6 +565,16 @@ def create_project(ws, hw_path, hw_file, target):
             for define in fabric_irq_defines:
                 f.write(define + '\n')
         print(f"INFO: Generated {len(fabric_irq_defines)} fabric IRQ macros")
+
+    # Generate DDR memory base address macros for MicroBlaze.
+    # Vitis 2025+ doesn't generate XPAR_AXI_DDR_CNTRL_* macros.
+    ddr_defines = _generate_ddr_macros(xsa, cpu)
+    if ddr_defines and os.path.exists(xpar_h):
+        with open(xpar_h, "a") as f:
+            f.write('\n/* DDR memory defines (generated from XSA) */\n')
+            for define in ddr_defines:
+                f.write(define + '\n')
+        print(f"INFO: Generated {len(ddr_defines)} DDR macros")
 
     print(f"INFO: BSP copied to bsp/{cpu}/")
 


### PR DESCRIPTION
## Pull Request Description

Vitis 2025+ switched BSP generation from hsi::generate_bsp to vitis.create_platform_component, which doesn't generate several macros that no-OS projects depend on. This broke CI builds for multiple Xilinx projects.

Changes

1. Fabric IRQ macro generation (util.py)
    
    Add Python-based IRQ macro generation that traces interrupt signals from peripheral IRQ pins through concat blocks:
    ZynqMP/Zynq-7000: generates XPAR_FABRIC_*_INTR via sys_concat_intc blocks
    MicroBlaze: generates XPAR_AXI_INTC_*_INTR via AXI interrupt controller
    Versal: generates XPAR_FABRIC_*_INTR via CIPS pl_ps_irq pins

2. DDR macro generation (util.py)

    Generate XPAR_AXI_DDR_CNTRL_* macros for MicroBlaze by tracing memory ranges from the processor.

3. Compatibility fallbacks (xilinx_compat.h)

    Add XPAR_INTC_MAX_NUM_INTR_INPUTS fallback for MicroBlaze
    Add DDR base address renames (BASEADDR vs BASEADDRESS)
    Remove obsolete fallbacks that caused redefinition warnings

4. BSP cache invalidation (build_projects.py, xilinx_platform_sdk.cmake)

    CI runners cache BSPs across runs. When util.py or xilinx_compat.h change, cached BSPs become stale. 
    Add hash-based invalidation:
    Detect changes to BSP generation scripts
    Create marker file to force regeneration for all hardware
    CMake removes stale xsa_work/ when marker exists

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
