### PR TITLE
ci: fix astyle checker paths

### DIFF
--- a/.github/scripts/astyle.sh
+++ b/.github/scripts/astyle.sh
@@ -111,7 +111,7 @@ run_astyle() {
 	git diff --name-only --diff-filter=d $COMMIT_RANGE | while read -r file; do
 		if is_source_file "$file" && is_valid_file "$file"
 		then
-			${WORKSPACE}/./build/astyle/build/gcc/bin/astyle --options="${WORKSPACE}/.github/config/astyle_config" "$file"
+			${WORKSPACE}/build/astyle/build/gcc/bin/astyle --options="${WORKSPACE}/.github/config/astyle_config" "$file"
 		fi
 	done;
 

--- a/.github/workflows/build-common.yaml
+++ b/.github/workflows/build-common.yaml
@@ -33,6 +33,7 @@ jobs:
         env:
           NUM_JOBS: ${{ env.NUM_JOBS }}
           TARGET_BRANCH: ${{ github.base_ref }}
+          WORKSPACE: ${{ github.workspace }}
       - name: Check-cpp format
         shell: sh
         run: |


### PR DESCRIPTION
## Pull Request Description

Fix astyle script checker paths. Currently errors are prompted of wrong paths.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
