### PR TITLE
VSC tasks and extensions

### DIFF
--- a/cmake/ide/backends/vscode.cmake
+++ b/cmake/ide/backends/vscode.cmake
@@ -95,6 +95,18 @@ function(ide_vscode_configure PROJECT_TARGET)
         @ONLY
     )
 
+    # --- Generate tasks.json (Ctrl+Shift+B build tasks) ---
+    # The build/clean/flash tasks just drive `cmake --build <build-dir>`; the
+    # toolchain and target are baked into the cache at configure time, so the
+    # tasks are platform-agnostic and need no environment setup at build time.
+    # PROJECT_TARGET is the executable target; expose it for the template.
+    set(PROJECT_TARGET_NAME "${PROJECT_TARGET}")
+    configure_file(
+        "${VSCODE_TEMPLATES_DIR}/tasks.json.in"
+        "${VSCODE_DIR}/tasks.json"
+        @ONLY
+    )
+
     # --- Generate launch.json via two-pass rendering ---
     # Pass 1: configure_file() resolves @VAR@ placeholders → intermediate file
     # Pass 2: file(GENERATE) resolves $<GENEX> → final output

--- a/cmake/ide/backends/vscode.cmake
+++ b/cmake/ide/backends/vscode.cmake
@@ -95,6 +95,15 @@ function(ide_vscode_configure PROJECT_TARGET)
         @ONLY
     )
 
+    # --- Generate extensions.json ---
+    # no-OS drives builds via tasks.json (cmake --build) and debugging via
+    # cortex-debug, so recommend the C/C++ and cortex-debug extensions.
+    configure_file(
+        "${VSCODE_TEMPLATES_DIR}/extensions.json.in"
+        "${VSCODE_DIR}/extensions.json"
+        @ONLY
+    )
+
     # --- Generate tasks.json (Ctrl+Shift+B build tasks) ---
     # The build/clean/flash tasks just drive `cmake --build <build-dir>`; the
     # toolchain and target are baked into the cache at configure time, so the

--- a/cmake/ide/templates/vscode/extensions.json.in
+++ b/cmake/ide/templates/vscode/extensions.json.in
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "ms-vscode.cpptools",
+        "marus25.cortex-debug"
+    ]
+}

--- a/cmake/ide/templates/vscode/tasks.json.in
+++ b/cmake/ide/templates/vscode/tasks.json.in
@@ -1,0 +1,45 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "no-OS: Build (@NO_OS_PROJECT_NAME@ / @PLATFORM@ / @TARGET@)",
+            "type": "shell",
+            "command": "cmake",
+            "args": [
+                "--build",
+                "@CMAKE_BINARY_DIR@",
+                "--target",
+                "@PROJECT_TARGET_NAME@"
+            ],
+            "problemMatcher": "$gcc",
+            "group": "build"
+        },
+        {
+            "label": "no-OS: Clean rebuild (@NO_OS_PROJECT_NAME@ / @PLATFORM@ / @TARGET@)",
+            "type": "shell",
+            "command": "cmake",
+            "args": [
+                "--build",
+                "@CMAKE_BINARY_DIR@",
+                "--target",
+                "@PROJECT_TARGET_NAME@",
+                "--clean-first"
+            ],
+            "problemMatcher": "$gcc",
+            "group": "build"
+        },
+        {
+            "label": "no-OS: Flash (@NO_OS_PROJECT_NAME@ / @PLATFORM@ / @TARGET@)",
+            "type": "shell",
+            "command": "cmake",
+            "args": [
+                "--build",
+                "@CMAKE_BINARY_DIR@",
+                "--target",
+                "flash"
+            ],
+            "problemMatcher": "$gcc",
+            "group": "build"
+        }
+    ]
+}

--- a/drivers/platform/aducm3029/toolchain.cmake
+++ b/drivers/platform/aducm3029/toolchain.cmake
@@ -138,10 +138,13 @@ set(CMAKE_CXX_FLAGS "${COMMON_CPU_FLAGS} ${ADUCM_DEFS} -ffunction-sections -fdat
 # Requires the code cache to stay disabled (default); see system_ADuCM3029.c.
 set(CMAKE_ASM_FLAGS "${COMMON_CPU_FLAGS} ${ADUCM_DEFS} -DADI_DISABLE_INSTRUCTION_SRAM -x assembler-with-cpp" CACHE STRING "ASM compiler flags" FORCE)
 
-# Debug build flags - Full debug info, no optimization
-set(CMAKE_C_FLAGS_DEBUG "-g -gdwarf-2 -O0 -D_DEBUG" CACHE STRING "C compiler flags for Debug" FORCE)
-set(CMAKE_CXX_FLAGS_DEBUG "-g -gdwarf-2 -O0 -D_DEBUG" CACHE STRING "C++ compiler flags for Debug" FORCE)
-set(CMAKE_ASM_FLAGS_DEBUG "-g -gdwarf-2 -D_DEBUG" CACHE STRING "ASM compiler flags for Debug" FORCE)
+# Debug build flags - Full debug info, no optimization.
+# Use GCC's default DWARF version (4 for this toolchain) rather than forcing
+# -gdwarf-2: the older format lacks the location lists cortex-debug/GDB need to
+# render source and locals, which broke source-level debugging on this platform.
+set(CMAKE_C_FLAGS_DEBUG "-g -O0 -D_DEBUG" CACHE STRING "C compiler flags for Debug" FORCE)
+set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -D_DEBUG" CACHE STRING "C++ compiler flags for Debug" FORCE)
+set(CMAKE_ASM_FLAGS_DEBUG "-g -D_DEBUG" CACHE STRING "ASM compiler flags for Debug" FORCE)
 
 # Release build flags - Optimize for speed, disable assertions
 set(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG" CACHE STRING "C compiler flags for Release" FORCE)
@@ -149,9 +152,9 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG" CACHE STRING "C++ compiler flags for 
 set(CMAKE_ASM_FLAGS_RELEASE "-DNDEBUG" CACHE STRING "ASM compiler flags for Release" FORCE)
 
 # RelWithDebInfo build flags - Optimize with debug info
-set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O2 -g -gdwarf-2 -DNDEBUG" CACHE STRING "C compiler flags for RelWithDebInfo" FORCE)
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -gdwarf-2 -DNDEBUG" CACHE STRING "C++ compiler flags for RelWithDebInfo" FORCE)
-set(CMAKE_ASM_FLAGS_RELWITHDEBINFO "-g -gdwarf-2 -DNDEBUG" CACHE STRING "ASM compiler flags for RelWithDebInfo" FORCE)
+set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O2 -g -DNDEBUG" CACHE STRING "C compiler flags for RelWithDebInfo" FORCE)
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -DNDEBUG" CACHE STRING "C++ compiler flags for RelWithDebInfo" FORCE)
+set(CMAKE_ASM_FLAGS_RELWITHDEBINFO "-g -DNDEBUG" CACHE STRING "ASM compiler flags for RelWithDebInfo" FORCE)
 
 # MinSizeRel build flags - Optimize for size
 set(CMAKE_C_FLAGS_MINSIZEREL "-Os -DNDEBUG" CACHE STRING "C compiler flags for MinSizeRel" FORCE)


### PR DESCRIPTION
## Pull Request Description

Generate a .vscode/tasks.json alongside the other VS Code config files so Ctrl+Shift+B builds work out of the box for any project on any platform.
Generate a .vscode/extensions.json alongside the other VS Code config files, recommending the extensions no-OS actually relies on: the C/C++ extension for IntelliSense (fed by compile_commands.json) and cortex-debug for on-target debugging via launch.json.
Drop -gdwarf-2 debug flag for aducm

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
