### PR TITLE
ci: create shared build workspace and filters

### DIFF
--- a/.github/scripts/build-projects.sh
+++ b/.github/scripts/build-projects.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+echo "Setup cloudsmith helper ..."
+wget https://raw.githubusercontent.com/analogdevicesinc/wiki-scripts/refs/heads/main/utils/cloudsmith_utils/cloudsmith_helper.py \
+    -O ${WORKSPACE}/tools/scripts/cloudsmith_temp.py
+cat ${WORKSPACE}/tools/scripts/cloudsmith_temp.py | sed 's#/usr/bin/python3#/usr/bin/env python3#' > ${WORKSPACE}/tools/scripts/cloudsmith_helper.py
+rm ${WORKSPACE}/tools/scripts/cloudsmith_temp.py
+          
+echo "Running project build ..."
+    ${WORKSPACE}/tools/scripts/build_projects.py \
+    ${WORKSPACE} \
+    -export_dir ${RELEASES_DIR} \
+    -log_dir ${LOGS_DIR} \
+    -builds_dir ${BUILDS_DIR} \
+    -platform ${PLATFORM} \
+    -hdl_branch ${HDL_BRANCH} \
+    -projects ${PROJECTS}

--- a/.github/scripts/get-changed-projects.sh
+++ b/.github/scripts/get-changed-projects.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+projects=""
+for file in ${ALL_CHANGED_FILES}; do
+    if [[ \
+        "$file" == *"board_configs/"* || "$file" == *"capi/"* || "$file" == *"cmake/"* || "$file" == *"drivers/"* \
+        || "$file" == *"iio/"* || "$file" == *"include/"* || "$file" == *"jesd204/"* || "$file" == *"libraries/"* \
+        || "$file" == *"network/"* || "$file" == *"tests/"* || "$file" == *"tools/"* || "$file" == *"util/"* \
+        || "$file" == *"workflows/"* || "$file" == "CMakeLists.txt" || "file" == "CMakePresets.json" || "$file" == "Kconfig" ]]; \
+        then
+              
+        echo "Dependecy paths were modified. Building whole projects."
+        echo "projects=all" >> $GITHUB_OUTPUT
+              
+        break
+    else
+        project=$(echo $file | cut -d "/" -f2)
+        projects="$projects $project" 
+        echo "projects=$projects" >> $GITHUB_OUTPUT
+    fi
+done

--- a/.github/workflows/build-aducm3029-platform.yaml
+++ b/.github/workflows/build-aducm3029-platform.yaml
@@ -90,23 +90,13 @@ jobs:
       - name: Building for platform ADuCM3029
         shell: sh
         run: |
-          echo "Setup cloudsmith helper ..."
-          wget https://raw.githubusercontent.com/analogdevicesinc/wiki-scripts/refs/heads/main/utils/cloudsmith_utils/cloudsmith_helper.py \
-            -O ./tools/scripts/cloudsmith_temp.py
-          cat tools/scripts/cloudsmith_temp.py | sed 's#/usr/bin/python3#/usr/bin/env python3#' > tools/scripts/cloudsmith_helper.py
-          rm tools/scripts/cloudsmith_temp.py
-
-          echo "Running project build ..."
-          ${{ github.workspace }}/tools/scripts/build_projects.py \
-            ${{ github.workspace }} \
-            -export_dir ${{ env.RELEASES_DIR }} \
-            -log_dir ${{ env.LOGS_DIR }} \
-            -builds_dir ${{ env.BUILDS_DIR }} \
-            -platform aducm3029 \
-            -hdl_branch ${{ env.HDL_BRANCH }}
+          ${{ github.workspace }}/.github/scripts/build-projects.sh
         env:
+          WORKSPACE: ${{ github.workspace }}
+          PLATFORM: aducm3029
           CLOUDSMITH_API_KEY: ${{ env.CLOUDSMITH_API_KEY }}
           TOKEN: ${{ secrets.GH_GHDL_TOKEN }}
+          PROJECTS: all
       - name: Upload ADuCM3029 artifacts
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build-aducm3029-platform.yaml
+++ b/.github/workflows/build-aducm3029-platform.yaml
@@ -69,7 +69,7 @@ jobs:
       RELEASES_DIR: ${{ github.workspace }}/latest_build
       LOGS_DIR: ${{ github.workspace }}/logs
       NO_OS_CACHE_DIR: ${{ github.workspace }}/deps_cache
-    runs-on: stm32-runner
+    runs-on: aducm3029-runner
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/build-maxim-platform.yaml
+++ b/.github/workflows/build-maxim-platform.yaml
@@ -80,23 +80,13 @@ jobs:
       - name: Building for platform Maxim
         shell: sh
         run: |
-          echo "Setup cloudsmith helper ..."
-          wget https://raw.githubusercontent.com/analogdevicesinc/wiki-scripts/refs/heads/main/utils/cloudsmith_utils/cloudsmith_helper.py \
-            -O ./tools/scripts/cloudsmith_temp.py
-          cat tools/scripts/cloudsmith_temp.py | sed 's#/usr/bin/python3#/usr/bin/env python3#' > tools/scripts/cloudsmith_helper.py
-          rm tools/scripts/cloudsmith_temp.py
-
-          echo "Running project build ..."
-          ${{ github.workspace }}/tools/scripts/build_projects.py \
-            ${{ github.workspace }} \
-            -export_dir ${{ env.RELEASES_DIR }} \
-            -log_dir ${{ env.LOGS_DIR }} \
-            -builds_dir ${{ env.BUILDS_DIR }} \
-            -platform maxim \
-            -hdl_branch ${{ env.HDL_BRANCH }}
+          ${{ github.workspace }}/.github/scripts/build-projects.sh
         env:
+          WORKSPACE: ${{ github.workspace }}
+          PLATFORM: maxim
           CLOUDSMITH_API_KEY: ${{ env.CLOUDSMITH_API_KEY }}
           TOKEN: ${{ secrets.GH_GHDL_TOKEN }}
+          PROJECTS: all
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build-pico-platform.yaml
+++ b/.github/workflows/build-pico-platform.yaml
@@ -81,23 +81,13 @@ jobs:
       - name: Building for platform Pico
         shell: sh
         run: |
-          echo "Setup cloudsmith helper ..."
-          wget https://raw.githubusercontent.com/analogdevicesinc/wiki-scripts/refs/heads/main/utils/cloudsmith_utils/cloudsmith_helper.py \
-            -O ./tools/scripts/cloudsmith_temp.py
-          cat tools/scripts/cloudsmith_temp.py | sed 's#/usr/bin/python3#/usr/bin/env python3#' > tools/scripts/cloudsmith_helper.py
-          rm tools/scripts/cloudsmith_temp.py
-
-          echo "Running project build ..."
-          ${{ github.workspace }}/tools/scripts/build_projects.py \
-            ${{ github.workspace }} \
-            -export_dir ${{ env.RELEASES_DIR }} \
-            -log_dir ${{ env.LOGS_DIR }} \
-            -builds_dir ${{ env.BUILDS_DIR }} \
-            -platform pico \
-            -hdl_branch ${{ env.HDL_BRANCH }}
+          ${{ github.workspace }}/.github/scripts/build-projects.sh
         env:
+          WORKSPACE: ${{ github.workspace }}
+          PLATFORM: pico
           CLOUDSMITH_API_KEY: ${{ env.CLOUDSMITH_API_KEY }}
           TOKEN: ${{ secrets.GH_GHDL_TOKEN }}
+          PROJECTS: all
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build-stm32-platform.yaml
+++ b/.github/workflows/build-stm32-platform.yaml
@@ -74,26 +74,16 @@ jobs:
         with:
           submodules: false
           clean: false
-      - name: Building for platform STM32 
+      - name: Building for platform STM32
         shell: sh
         run: |
-          echo "Setup cloudsmith helper ..."
-          wget https://raw.githubusercontent.com/analogdevicesinc/wiki-scripts/refs/heads/main/utils/cloudsmith_utils/cloudsmith_helper.py \
-            -O ./tools/scripts/cloudsmith_temp.py
-          cat tools/scripts/cloudsmith_temp.py | sed 's#/usr/bin/python3#/usr/bin/env python3#' > tools/scripts/cloudsmith_helper.py
-          rm tools/scripts/cloudsmith_temp.py
-
-          echo "Running project build ..."
-          ${{ github.workspace }}/tools/scripts/build_projects.py \
-            ${{ github.workspace }} \
-            -export_dir ${{ env.RELEASES_DIR }} \
-            -log_dir ${{ env.LOGS_DIR }} \
-            -builds_dir ${{ env.BUILDS_DIR }} \
-            -platform stm32 \
-            -hdl_branch ${{ env.HDL_BRANCH }}
+          ${{ github.workspace }}/.github/scripts/build-projects.sh
         env:
+          WORKSPACE: ${{ github.workspace }}
+          PLATFORM: stm32
           CLOUDSMITH_API_KEY: ${{ env.CLOUDSMITH_API_KEY }}
           TOKEN: ${{ secrets.GH_GHDL_TOKEN }}
+          PROJECTS: all
       - name: Upload STM32 artifacts
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build-xilinx-platform.yaml
+++ b/.github/workflows/build-xilinx-platform.yaml
@@ -118,8 +118,7 @@ jobs:
         run: |
           rm -rf ${{ env.RELEASES_DIR }} ${{ env.LOGS_DIR }}
           if [[ "${{ job.status }}" == "cancelled" ]]; then
-            lockfile=$(find ${{ github.workspace }}/ -maxdepth 1 | grep ".lock" | sed 's:.*/::')
-            if [[ ! -z "$lockfile" ]]; then
-              rm -rf ${{ env.BUILDS_DIR }}_${{ env.HDL_BRANCH }}_cmake/$lockfile ${{ github.workspace }}/$lockfile
-            fi
+            for lockfile in $(find ${{ github.workspace }}/ -maxdepth 1 -name "*_xilinx.lock" -printf '%f\n'); do
+              rm -f "${{ env.BUILDS_DIR }}_${{ env.HDL_BRANCH }}_cmake/$lockfile" "${{ github.workspace }}/$lockfile"
+            done
           fi

--- a/.github/workflows/build-xilinx-platform.yaml
+++ b/.github/workflows/build-xilinx-platform.yaml
@@ -60,7 +60,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        runs-on: [noos-runner-xilinx-test, noos-runner-xilinx-test, noos-runner-xilinx-test, noos-runner-xilinx-test]
+        runs-on: [noos-runner-xilinx-test, noos-runner-xilinx-test, noos-runner-xilinx-test]
     env:
       CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
       TOOLS_REPO: ${{ secrets.TOOLS_REPO }}

--- a/.github/workflows/build-xilinx-platform.yaml
+++ b/.github/workflows/build-xilinx-platform.yaml
@@ -51,22 +51,28 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build-xilinx-projects:
+    # TEST
+    continue-on-error: true
+    strategy:
+      matrix:
+        runs-on: [noos-runner-xilinx-test, noos-runner-xilinx-test, noos-runner-xilinx-test, noos-runner-xilinx-test]
     env:
       CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
       TOOLS_REPO: ${{ secrets.TOOLS_REPO }}
       BLACKLIST_URL: ${{ secrets.BLACKLIST_URL }}
       HDL_BRANCH: 'main'
       BRANCH: ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }}
-      BUILDS_DIR: ${{ github.workspace }}/builds
+      BUILDS_DIR: ${{ secrets.PRIVATE_WORKSPACE }}/builds
       RELEASES_DIR: ${{ github.workspace }}/latest_build
       LOGS_DIR: ${{ github.workspace }}/logs
       NO_OS_CACHE_DIR: ${{ github.workspace }}/deps_cache
-    runs-on: noos-runner-xilinx
+    # TEST
+    runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 600
     steps:
       - name: Checkout code
@@ -74,26 +80,26 @@ jobs:
         with:
           submodules: false
           clean: false
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+      - name: Get changed projects
+        id: projects-list
+        shell: sh
+        run: |
+          ${{ github.workspace }}/.github/scripts/get-changed-projects.sh
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
       - name: Building for platform Xilinx 
         shell: sh
         run: |
-          echo "Setup cloudsmith helper ..."
-          wget https://raw.githubusercontent.com/analogdevicesinc/wiki-scripts/refs/heads/main/utils/cloudsmith_utils/cloudsmith_helper.py \
-            -O ./tools/scripts/cloudsmith_temp.py
-          cat tools/scripts/cloudsmith_temp.py | sed 's#/usr/bin/python3#/usr/bin/env python3#' > tools/scripts/cloudsmith_helper.py
-          rm tools/scripts/cloudsmith_temp.py
-
-          echo "Running project build ..."
-          ${{ github.workspace }}/tools/scripts/build_projects.py \
-            ${{ github.workspace }} \
-            -export_dir ${{ env.RELEASES_DIR }} \
-            -log_dir ${{ env.LOGS_DIR }} \
-            -builds_dir ${{ env.BUILDS_DIR }} \
-            -platform xilinx \
-            -hdl_branch ${{ env.HDL_BRANCH }}
+          ${{ github.workspace }}/.github/scripts/build-projects.sh
         env:
+          WORKSPACE: ${{ github.workspace }}
+          PLATFORM: xilinx
           CLOUDSMITH_API_KEY: ${{ env.CLOUDSMITH_API_KEY }}
           TOKEN: ${{ secrets.GH_GHDL_TOKEN }}
+          PROJECTS: ${{ steps.projects-list.outputs.projects }}
       - name: Upload Xilinx artifacts
         if: always()
         uses: actions/upload-artifact@v7
@@ -106,8 +112,14 @@ jobs:
         with:
           path: ${{ env.LOGS_DIR }}
           name: ${{ github.job }}-logs
-      - name: Remove logs, new_hardware and release output
+      - name: Remove logs, release output and lockfile
         if: always()
-        shell: sh
+        shell: bash
         run: |
-          rm -rf ${{ env.RELEASES_DIR }} ${{ env.LOGS_DIR }} ${{ env.BUILDS_DIR }}_${{ env.HDL_BRANCH }}/new_hardware
+          rm -rf ${{ env.RELEASES_DIR }} ${{ env.LOGS_DIR }}
+          if [[ "${{ job.status }}" == "cancelled" ]]; then
+            lockfile=$(find ${{ github.workspace }}/ -maxdepth 1 | grep ".lock" | sed 's:.*/::')
+            if [[ ! -z "$lockfile" ]]; then
+              rm -rf ${{ env.BUILDS_DIR }}_${{ env.HDL_BRANCH }}_cmake/$lockfile ${{ github.workspace }}/$lockfile
+            fi
+          fi

--- a/tools/scripts/build_projects.py
+++ b/tools/scripts/build_projects.py
@@ -368,19 +368,6 @@ def build_cmake_project(noos, project, _platform, export_dir, log_dir, cmake_bui
 
 		# Pass an absolute --build-dir: no_os_build anchors a relative one to the
 		# repo root, which would not match the build_dir we clean/probe here.
-<<<<<<< HEAD
-		# Xilinx: keep the cached BSP, clean only objects unless the .xsa changed
-		# or the cache came from a different source path (another CI agent).
-		stale_cache = platform == 'xilinx' and cmake_cache_source_mismatch(str(build_dir), noos)
-		if platform == 'xilinx' and build_dir.exists() and not new_hdf and not stale_cache:
-			# CMAKE, not bare 'cmake': the sourced xilinx env leads PATH with Vitis's broken one.
-			clean_cmd = "%s --build %s --target clean > %s 2>&1" % (CMAKE, build_dir, os.devnull)
-			os.system(clean_cmd)
-			fresh_flag = ""
-		else:
-			fresh_flag = " --fresh"
-		
-=======
 		# Xilinx: reuse cached BSP unless the .xsa changed (new_hdf) or no cache file exists yet. 
 		# Shared build dirs mean CMakeCache paths won't match the current checkout, but the BSP
 		# artifacts don't depend on source paths - only the .xsa matters.
@@ -407,7 +394,6 @@ def build_cmake_project(noos, project, _platform, export_dir, log_dir, cmake_bui
 					os.remove(cmake_cache_file)
 					os.rename(cmake_cache_file_new, cmake_cache_file)
 
->>>>>>> 918617138 (ci: create shared build workspace and filters)
 		build_cmd = ("python3 %s/tools/scripts/no_os_build.py build"
 			     " --project %s --variant %s --board %s"
 			     " --build-dir %s --jobs %d --probe openocd%s%s"
@@ -483,25 +469,28 @@ def build_loop(projects, noos_dir, projects_dir, export_dir, log_dir, builds_dir
 		# None when the current -platform job has nothing to build here.
 		cmake_builds_dir = builds_dir + '_cmake'
 		ensure_dir(cmake_builds_dir)
-
-		lockfile_path = os.path.join(cmake_builds_dir, f"{project}_{platform}.lock")
+	
+		# Check if the projects is currently in another building process or reserve it otherwise
+		lockfile_path = os.path.join(cmake_builds_dir, f"{project}.lock")
 		if not os.path.isfile(lockfile_path):
-			lockfile_validation_path = os.path.join(noos_dir, f"{project}_{platform}.lock")
-			try:
-				open(lockfile_path, "w").close()
-				open(lockfile_validation_path, "w").close()
+			lockfile = open(lockfile_path, "w")
 
-				cmake_ok = build_cmake_project(noos_dir, project, platform, export_dir, log_dir, cmake_builds_dir, builds_dir)
-				if cmake_ok is not None:
-					status = 'OK' if cmake_ok == 1 else 'Fail'
-					os.system('echo Project %20s -- %s >> %s' % (project, status, all_status))
-			finally:
-				if os.path.isfile(lockfile_path):
-					os.remove(lockfile_path)
-				if os.path.isfile(lockfile_validation_path):
-					os.remove(lockfile_validation_path)
-
+			# Store the current building project in the github workspace path for extra validation
+			# This will ensure in case of job cancellation, the lockfile will be deleted as well
+			lockfile_validation_path = os.path.join(noos_dir, f"{project}.lock")
+			lockfile_validation = open(lockfile_validation_path, "w")
+	
+			cmake_ok = build_cmake_project(noos_dir, project, platform, export_dir, log_dir, cmake_builds_dir, builds_dir)
+			if cmake_ok is not None:
+				status = 'OK' if cmake_ok == 1 else 'Fail'
+				os.system('echo Project %20s -- %s >> %s' % (project, status, all_status))
+	
 			new_projects[project] = "done"
+			lockfile_validation.close()
+			lockfile.close()
+
+			os.remove(lockfile_path)
+			os.remove(lockfile_validation_path)
 		else:
 			new_projects[project] = "not_built"
 			log("%s is already in another build process. Skipping and building it later ..." % project)

--- a/tools/scripts/build_projects.py
+++ b/tools/scripts/build_projects.py
@@ -483,28 +483,25 @@ def build_loop(projects, noos_dir, projects_dir, export_dir, log_dir, builds_dir
 		# None when the current -platform job has nothing to build here.
 		cmake_builds_dir = builds_dir + '_cmake'
 		ensure_dir(cmake_builds_dir)
-	
-		# Check if the projects is currently in another building process or reserve it otherwise
-		lockfile_path = os.path.join(cmake_builds_dir, f"{project}.lock")
+
+		lockfile_path = os.path.join(cmake_builds_dir, f"{project}_{platform}.lock")
 		if not os.path.isfile(lockfile_path):
-			lockfile = open(lockfile_path, "w")
+			lockfile_validation_path = os.path.join(noos_dir, f"{project}_{platform}.lock")
+			try:
+				open(lockfile_path, "w").close()
+				open(lockfile_validation_path, "w").close()
 
-			# Store the current building project in the github workspace path for extra validation
-			# This will ensure in case of job cancellation, the lockfile will be deleted as well
-			lockfile_validation_path = os.path.join(noos_dir, f"{project}.lock")
-			lockfile_validation = open(lockfile_validation_path, "w")
-	
-			cmake_ok = build_cmake_project(noos_dir, project, platform, export_dir, log_dir, cmake_builds_dir, builds_dir)
-			if cmake_ok is not None:
-				status = 'OK' if cmake_ok == 1 else 'Fail'
-				os.system('echo Project %20s -- %s >> %s' % (project, status, all_status))
-	
+				cmake_ok = build_cmake_project(noos_dir, project, platform, export_dir, log_dir, cmake_builds_dir, builds_dir)
+				if cmake_ok is not None:
+					status = 'OK' if cmake_ok == 1 else 'Fail'
+					os.system('echo Project %20s -- %s >> %s' % (project, status, all_status))
+			finally:
+				if os.path.isfile(lockfile_path):
+					os.remove(lockfile_path)
+				if os.path.isfile(lockfile_validation_path):
+					os.remove(lockfile_validation_path)
+
 			new_projects[project] = "done"
-			lockfile_validation.close()
-			lockfile.close()
-
-			os.remove(lockfile_path)
-			os.remove(lockfile_validation_path)
 		else:
 			new_projects[project] = "not_built"
 			log("%s is already in another build process. Skipping and building it later ..." % project)

--- a/tools/scripts/build_projects.py
+++ b/tools/scripts/build_projects.py
@@ -8,6 +8,7 @@ import multiprocessing
 import sys
 import filecmp
 import re
+import time
 # This file can be downloaded from the wiki-scripts repository
 # https://raw.githubusercontent.com/analogdevicesinc/wiki-scripts/refs/heads/main/utils/cloudsmith_utils/cloudsmith_helper.py
 from cloudsmith_helper import *
@@ -54,18 +55,20 @@ def parse_input():
 	parser.add_argument('noos_location', help="Path to noos location")
 	parser.add_argument('-export_dir', default=(os.getcwd() + '/exports'), help="Path where to save files")
 	parser.add_argument('-log_dir', default=(os.getcwd() + '/logs'), help="Path where to save log files")
-	parser.add_argument('-project', help="Name of project to be built")
+	parser.add_argument(
+		'-projects',
+		help="List of projects to be built",
+		nargs='+'
+	)
 	parser.add_argument('-platform', help="Name of platform to be built")
-	parser.add_argument('-hardware', help="Name of hardware to be built")
-	parser.add_argument('-build_name', help="Name of built type to be built")
 	parser.add_argument('-builds_dir', default=(os.getcwd() +'/builds'), help="Directory where to build projects")
 	parser.add_argument('-hdl_branch', default='main', help="Name of hdl_branch from which to downlaod hardware or \
 					 we can also specify a timestamp folder from the specific branch but needs to have a specific format, \
 					 of 'branch_name/YYYY_mm_dd-HH_MM_SS' example: main/2023_09_20-06_52_29")
 	args = parser.parse_args()
 
-	return (args.noos_location, args.export_dir, args.log_dir, args.project,
-		args.platform, args.build_name, args.builds_dir, args.hardware, args.hdl_branch)
+	return (args.noos_location, args.export_dir, args.log_dir, 
+		 args.builds_dir, args.platform, args.hdl_branch,args.projects)
 
 ERR = 0
 LOG_START = " -> "
@@ -131,27 +134,6 @@ def run_cmd(cmd):
 def to_blue(str):
 	return TBLUE + str + TWHITE
 
-def cmake_cache_source_mismatch(build_dir, noos):
-	"""True if build_dir's CMakeCache.txt was generated from a different source path.
-
-	CMake refuses to reuse a cache whose CMAKE_HOME_DIRECTORY differs, which
-	happens when CI agents check the repo out under different absolute paths.
-	"""
-	cache = os.path.join(build_dir, 'CMakeCache.txt')
-	if not os.path.isfile(cache):
-		return False
-	want = os.path.realpath(noos)
-	try:
-		with open(cache) as f:
-			for line in f:
-				if line.startswith('CMAKE_HOME_DIRECTORY:'):
-					have = line.split('=', 1)[1].strip()
-					return os.path.realpath(have) != want
-	except OSError:
-		# Unreadable cache: treat as mismatch so --fresh regenerates it cleanly.
-		return True
-	return False
-
 SKIP_DOWNLOAD = None
 key = 'SKIP_DOWNLOAD'
 if key in os.environ:
@@ -200,7 +182,7 @@ def process_blacklist():
 		log('Blacklist file is empty -- no projects excluded')
 	return blacklist
 
-def configfile_and_download_all_hw(_platform, noos, _builds_dir, hdl_branch):
+def configfile_and_download_all_hw(_platform, noos, _builds_dir, hdl_branch, projects = list):
 	server_base_path = "hdl/"
 	hdl_repo = 'sdg-hdl'
 	pattern = r'\d{4}_\d{2}_\d{2}-\d{2}_\d{2}_\d{2}'
@@ -244,9 +226,12 @@ def configfile_and_download_all_hw(_platform, noos, _builds_dir, hdl_branch):
 			blacklist = process_blacklist()
 		new_hardwares = os.path.join(builds_dir, NEW_HW_DIR_NAME)
 		ensure_dir(new_hardwares)
+		
+		projects_list = ','.join(projects)
+
 		download_cmd = [
 			os.path.join(noos, 'tools', 'scripts', 'download_files.py'),
-			noos, builds_dir, server_full_path, str(blacklist)]
+			noos, builds_dir, server_full_path, str(blacklist), projects_list]
 		result = subprocess.run(download_cmd)
 		if result.returncode != 0:
 			log_err("Hardware download failed (exit %d)" % result.returncode)
@@ -283,8 +268,7 @@ def get_hardware(hardware, platform, builds_dir):
 
 	return (filename, 1, err)
 
-def build_cmake_project(noos, project, _platform, _build_name, export_dir,
-			log_dir, cmake_builds_dir, builds_dir):
+def build_cmake_project(noos, project, _platform, export_dir, log_dir, cmake_builds_dir, builds_dir):
 	"""Build the CMake/Kconfig (Maxim/STM32/Pico/Xilinx) side of a project.
 
 	Discovers the project's project/variant/board combinations from the board
@@ -312,8 +296,6 @@ def build_cmake_project(noos, project, _platform, _build_name, export_dir,
 	combos = [c for c in combos if c['platform'] in CMAKE_PLATFORMS]
 	if _platform is not None:
 		combos = [c for c in combos if c['platform'] == _platform]
-	if _build_name is not None:
-		combos = [c for c in combos if c['variant'] == _build_name]
 
 	if not combos:
 		return None
@@ -383,8 +365,10 @@ def build_cmake_project(noos, project, _platform, _build_name, export_dir,
 		# build.log inside the build dir and is copied into dst_log below.
 		dst_log = os.path.join(log_dir, '%s_%s_%s_%s.txt' % (project, platform, variant, board))
 		jobs = int(multiprocessing.cpu_count() / 2) or 1
+
 		# Pass an absolute --build-dir: no_os_build anchors a relative one to the
 		# repo root, which would not match the build_dir we clean/probe here.
+<<<<<<< HEAD
 		# Xilinx: keep the cached BSP, clean only objects unless the .xsa changed
 		# or the cache came from a different source path (another CI agent).
 		stale_cache = platform == 'xilinx' and cmake_cache_source_mismatch(str(build_dir), noos)
@@ -396,6 +380,34 @@ def build_cmake_project(noos, project, _platform, _build_name, export_dir,
 		else:
 			fresh_flag = " --fresh"
 		
+=======
+		# Xilinx: reuse cached BSP unless the .xsa changed (new_hdf) or no cache file exists yet. 
+		# Shared build dirs mean CMakeCache paths won't match the current checkout, but the BSP
+		# artifacts don't depend on source paths - only the .xsa matters.
+		fresh_flag = " --fresh"
+		if _platform == 'xilinx':
+			cmake_cache_file = build_dir / 'CMakeCache.txt'
+			if (not new_hdf and os.path.isfile(cmake_cache_file)): fresh_flag = ""
+
+			# Update cmake cache with current working directory
+			if fresh_flag == "":
+				cmake_cache_file_new = build_dir / 'CMakeCache_new.txt'
+				cmake_toolchain_new = f"CMAKE_TOOLCHAIN_FILE:FILEPATH={noos}/drivers/platform/xilinx/toolchain.cmake\n"
+				with open(cmake_cache_file, "r") as old:
+					lines = old.readlines()
+					with open(cmake_cache_file_new, "w") as new:
+						for line in lines:
+							if "CMAKE_TOOLCHAIN_FILE:FILEPATH=" in line:
+								line = cmake_toolchain_new
+							elif "no-os_SOURCE_DIR:STATIC" in line:
+								line = f"no-os_SOURCE_DIR:STATIC={noos}\n"
+							elif "CMAKE_HOME_DIRECTORY:INTERNAL" in line:
+								line = f"CMAKE_HOME_DIRECTORY:INTERNAL={noos}\n"
+							new.write(line)
+					os.remove(cmake_cache_file)
+					os.rename(cmake_cache_file_new, cmake_cache_file)
+
+>>>>>>> 918617138 (ci: create shared build workspace and filters)
 		build_cmd = ("python3 %s/tools/scripts/no_os_build.py build"
 			     " --project %s --variant %s --board %s"
 			     " --build-dir %s --jobs %d --probe openocd%s%s"
@@ -445,22 +457,25 @@ def build_cmake_project(noos, project, _platform, _build_name, export_dir,
 
 	return ok
 
-def main():
-	(noos, export_dir, log_dir, _project,
-	 _platform, _build_name, _builds_dir, _hw, hdl_branch) = parse_input()
-	projets = os.path.join(noos,'projects')
-	ensure_dir(export_dir)
-	ensure_dir(log_dir)
-	(builds_dir, blacklist) = configfile_and_download_all_hw(_platform, noos, _builds_dir, hdl_branch)
-	for project in os.listdir(projets):
-		if _project is not None:
-			if _project != project:
-				continue
-		project_dir = os.path.join(projets, project)
+def check_built_projects(projects = dict):
+	new_projects = {}
+	for project, status in projects.items():
+		if "not_built" in status:
+			new_projects[project] = status
+	if bool(new_projects):
+		return new_projects
+	
+	return False
+
+def build_loop(projects, noos_dir, projects_dir, export_dir, log_dir, builds_dir, platform):
+	new_projects = {}
+	for project, status in projects.items():
+		project_dir = os.path.join(projects_dir, project)
+
 		# CMake is the only build system; skip projects without a CMakeLists.txt.
 		if not os.path.isfile(os.path.join(project_dir, 'CMakeLists.txt')):
 			continue
-
+	
 		all_status = os.path.join(log_dir, 'all_builds.txt')
 
 		# CMake/Kconfig side: combos discovered from the board presets.
@@ -468,11 +483,74 @@ def main():
 		# None when the current -platform job has nothing to build here.
 		cmake_builds_dir = builds_dir + '_cmake'
 		ensure_dir(cmake_builds_dir)
-		cmake_ok = build_cmake_project(noos, project, _platform, _build_name,
-					 export_dir, log_dir, cmake_builds_dir, builds_dir)
-		if cmake_ok is not None:
-			status = 'OK' if cmake_ok == 1 else 'Fail'
-			os.system('echo Project %20s -- %s >> %s' % (project, status, all_status))
+	
+		# Check if the projects is currently in another building process or reserve it otherwise
+		lockfile_path = os.path.join(cmake_builds_dir, f"{project}.lock")
+		if not os.path.isfile(lockfile_path):
+			lockfile = open(lockfile_path, "w")
+
+			# Store the current building project in the github workspace path for extra validation
+			# This will ensure in case of job cancellation, the lockfile will be deleted as well
+			lockfile_validation_path = os.path.join(noos_dir, f"{project}.lock")
+			lockfile_validation = open(lockfile_validation_path, "w")
+	
+			cmake_ok = build_cmake_project(noos_dir, project, platform, export_dir, log_dir, cmake_builds_dir, builds_dir)
+			if cmake_ok is not None:
+				status = 'OK' if cmake_ok == 1 else 'Fail'
+				os.system('echo Project %20s -- %s >> %s' % (project, status, all_status))
+	
+			new_projects[project] = "done"
+			lockfile_validation.close()
+			lockfile.close()
+
+			os.remove(lockfile_path)
+			os.remove(lockfile_validation_path)
+		else:
+			new_projects[project] = "not_built"
+			log("%s is already in another build process. Skipping and building it later ..." % project)
+
+	return new_projects
+
+def _finalize_bsp_hash(builds_dir, noos_dir):
+	"""Update BSP hash file and remove regeneration marker after build completes."""
+	if not noos_dir:
+		return
+	hash_file = os.path.join(builds_dir, HW_DIR_NAME, '.bsp_deps_hash')
+	regen_marker = os.path.join(builds_dir, HW_DIR_NAME, '.bsp_regen_needed')
+	# Update hash file with current hash
+	current_hash = _get_bsp_deps_hash(noos_dir)
+	with open(hash_file, 'w') as f:
+		f.write(current_hash)
+	# Remove regeneration marker
+	if os.path.isfile(regen_marker):
+		os.remove(regen_marker)
+
+def main():
+	(noos, export_dir, log_dir, _builds_dir, _platform, hdl_branch, _projects) = parse_input()
+	projects_dir = os.path.join(noos,'projects')
+	ensure_dir(export_dir)
+	ensure_dir(log_dir)
+
+	# Create a dictionary for projects to keep the status of currently building projects. If changes are happening
+	# on dependency paths, it'll take the whole projects/ list
+	if 'all' not in _projects:
+		projects = _projects
+	else:
+		projects = os.listdir(projects_dir)
+	projects_dict = {}
+	for project in projects:
+		projects_dict[project] = "not_built"
+
+	(builds_dir, blacklist) = configfile_and_download_all_hw(_platform, noos, _builds_dir, hdl_branch, projects)
+
+	# Build the projects and re-check for non built ones
+	while bool(projects_dict):
+		projects_dict = build_loop(projects_dict, noos, projects_dir, export_dir, log_dir, builds_dir, _platform)
+		projects_dict = check_built_projects(projects_dict)
+		# In case the remaining list on not_build projects is equivalent to the number of currently
+		# building ones, prevent loop spamming.
+		sys.stdout.flush()
+		time.sleep(10)
 
 main()
 

--- a/tools/scripts/download_files.py
+++ b/tools/scripts/download_files.py
@@ -19,12 +19,15 @@ NOOS_PATH = sys.argv[1]
 BUILD_PATH = sys.argv[2]
 HDL_SERVER_BASE_PATH = sys.argv[3]
 blacklist = ast.literal_eval(sys.argv[4])
+PROJECTS = str(sys.argv[5]).split(',')
 NEW_HW_DIR_NAME = 'new_hardware'
 FOLDERS_NR = 30 #number of folders to check for missing hardware file
 
 list_hardware = []
-for dir in os.listdir(NOOS_PATH + '/projects'):
-    file = NOOS_PATH + '/projects/' + str(dir) + '/builds.json'
+if PROJECTS == "all": projects = os.listdir(NOOS_PATH + '/projects')
+else: projects = [ NOOS_PATH + "/projects/" + project for project in PROJECTS ]      # append noos path to every project
+for dir in projects:
+    file = str(dir) + '/builds.json'
     if os.path.exists(file):
         with open(file) as f:
             data = json.load(f)
@@ -65,7 +68,6 @@ except Exception as e:
     log_warn("Could not scan CMake .conf for xilinx hardware: %s" % e)
 
 new_harware_dir= os.path.join(BUILD_PATH, NEW_HW_DIR_NAME)
-os.system("rm -rf %s/*" % (new_harware_dir))
 unique_hardware_list = set(list_hardware)
 for item in blacklist:
     if item in unique_hardware_list:


### PR DESCRIPTION
## Pull Request Description

Implement shared build workspace. Currently, each runner contain an independed build workspace with cache. This results in heavy ocuppied space per runnner workspace. With this implementation, current runners can build in parallel using the same build workspace as well, using project build path .lock file mecahnism and storing non built projects and re-checks.
Another feature is the filtering of projects to build based on paths from the git changes.

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
