### PR TITLE
drivers projects: fix CodeQL-flagged defects

### DIFF
--- a/drivers/dac/ad5706r/ad5706r.c
+++ b/drivers/dac/ad5706r/ad5706r.c
@@ -60,7 +60,8 @@ static int ad5706r_transfer_with_crc(struct ad5706r_dev *dev,
 	int32_t addr;
 	uint8_t cnt = 0;
 	uint8_t crc_cnt = 0;
-	uint8_t i, crc_seed;
+	uint32_t i;
+	uint8_t crc_seed;
 	uint8_t crc_buf[4] = {0};
 	uint8_t byte_cnt = 0;
 	int inc;

--- a/drivers/dac/ad9144/ad9144.c
+++ b/drivers/dac/ad9144/ad9144.c
@@ -1304,8 +1304,8 @@ int32_t ad9144_short_pattern_test(struct ad9144_dev *dev,
 						      0x01, 0x00);
 			if (ret == -1)
 				printf("%s : short-pattern-test mismatch (%#06lx, %#06lx, %#06lx)!.\n",
-				       __func__, dac, sample,
-				       init_param->stpl_samples[dac][sample]);
+				       __func__, (unsigned long)dac, (unsigned long)sample,
+				       (unsigned long)init_param->stpl_samples[dac][sample]);
 		}
 	}
 	return 0;

--- a/drivers/dac/dac_demo/iio_dac_demo.c
+++ b/drivers/dac/dac_demo/iio_dac_demo.c
@@ -126,7 +126,7 @@ int dac_submit_samples(struct iio_device_data *dev_data)
 
 		while (get_next_ch_idx(desc->active_ch, ch, &ch)) {
 			uint16_t* ch_buffer = (uint16_t*)(desc->loopback_buffers +
-							  (ch * desc->loopback_buffer_len *
+							  ((size_t)ch * desc->loopback_buffer_len *
 							   sizeof(uint16_t) / sizeof(ch_buffer)));
 			ch_buffer[i] = data[k++];
 		}
@@ -169,7 +169,7 @@ int dac_demo_trigger_handler(struct iio_device_data *dev_data)
 	/* Write data to the device one sample/channel at a time */
 	while (get_next_ch_idx(desc->active_ch, ch, &ch)) {
 		uint16_t* ch_buffer = (uint16_t*)(desc->loopback_buffers +
-						  (ch * desc->loopback_buffer_len *
+						  ((size_t)ch * desc->loopback_buffer_len *
 						   sizeof(uint16_t) / sizeof(ch_buffer)));
 		ch_buffer[i] = data[k++];
 	}

--- a/drivers/frequency/ad9517/ad9517.c
+++ b/drivers/frequency/ad9517/ad9517.c
@@ -238,7 +238,7 @@ int32_t ad9517_write(struct ad9517_dev *dev,
 		     uint32_t reg_addr,
 		     uint16_t reg_val)
 {
-	uint8_t i = 0;
+	uint32_t i = 0;
 	int32_t ret = 0;
 	uint16_t reg_address = 0;
 	int8_t reg_value = 0;
@@ -278,7 +278,7 @@ int32_t ad9517_read(struct ad9517_dev *dev,
 	uint32_t reg_address = 0;
 	int32_t ret = 0;
 	uint8_t tx_buffer[3] = {0, 0, 0};
-	uint8_t i = 0;
+	uint32_t i = 0;
 	*reg_value = 0;
 
 	reg_address = AD9517_READ + AD9517_ADDR(reg_addr);

--- a/drivers/frequency/ad9523/ad9523.c
+++ b/drivers/frequency/ad9523/ad9523.c
@@ -57,7 +57,7 @@ int32_t ad9523_spi_read(struct ad9523_dev *dev,
 	uint8_t buf[3];
 
 	int32_t ret = 0;
-	uint8_t index;
+	uint32_t index;
 
 	*reg_data = 0;
 	for (index = 0; index < AD9523_TRANSF_LEN(reg_addr); index++) {
@@ -91,7 +91,7 @@ int32_t ad9523_spi_write(struct ad9523_dev *dev,
 	uint8_t buf[3];
 
 	int32_t ret = 0;
-	uint8_t index;
+	uint32_t index;
 
 	for (index = 0; index < AD9523_TRANSF_LEN(reg_addr); index++) {
 		buf[0] = reg_addr >> 8;
@@ -227,7 +227,8 @@ int32_t ad9523_calibrate(struct ad9523_dev *dev)
 			AD9523_READBACK_1,
 			&reg_data);
 	if ((reg_data & 0x1) != 0x0) {
-		printf("AD9523: VCO calibration failed (%#06lx)!\n", reg_data);
+		printf("AD9523: VCO calibration failed (%#06lx)!\n",
+		       (unsigned long)reg_data);
 		return (-1);
 	}
 
@@ -281,13 +282,15 @@ int32_t ad9523_status(struct ad9523_dev *dev)
 
 	ret = 0;
 	if ((reg_data & AD9523_READBACK_0_STAT_VCXO) != AD9523_READBACK_0_STAT_VCXO) {
-		printf("AD9523: VCXO status errors (%#06lx)!\n", reg_data);
+		printf("AD9523: VCXO status errors (%#06lx)!\n",
+		       (unsigned long)reg_data);
 		ret = -1;
 	}
 
 	if ((reg_data & AD9523_READBACK_0_STAT_PLL2_LD) !=
 	    AD9523_READBACK_0_STAT_PLL2_LD) {
-		printf("AD9523: PLL2 NOT locked (%#06lx)!\n", reg_data);
+		printf("AD9523: PLL2 NOT locked (%#06lx)!\n",
+		       (unsigned long)reg_data);
 		ret = -1;
 	}
 
@@ -477,7 +480,7 @@ int32_t ad9523_setup(struct ad9523_dev **device,
 
 	if (reg_data != 0xAD95) {
 		printf("AD9523: SPI write-verify failed (%#06lX)!\n\r",
-		       reg_data);
+		       (unsigned long)reg_data);
 		return -1;
 	}
 

--- a/drivers/frequency/ad9528/ad9528.c
+++ b/drivers/frequency/ad9528/ad9528.c
@@ -138,7 +138,7 @@ int32_t ad9528_spi_read_n(struct ad9528_dev *dev,
 	uint8_t buf[3];
 
 	int32_t ret = 0;
-	uint8_t index;
+	uint32_t index;
 
 	*reg_data = 0;
 	for (index = 0; index < AD9528_TRANSF_LEN(reg_addr); index++) {
@@ -174,7 +174,7 @@ int32_t ad9528_spi_write_n(struct ad9528_dev *dev,
 	uint8_t buf[3];
 
 	int32_t ret = 0;
-	uint8_t index;
+	uint32_t index;
 
 	for (index = 0; index < AD9528_TRANSF_LEN(reg_addr); index++) {
 		buf[0] = reg_addr >> 8;

--- a/drivers/frequency/ad9545/ad9545.c
+++ b/drivers/frequency/ad9545/ad9545.c
@@ -514,7 +514,7 @@ static uint64_t ad9545_calc_pll_params(struct ad9545_pll_clk *clk,
 	dpll_n_div = no_os_clamp_t(uint32_t, dpll_n_div, min_dpll_n_div,
 				   AD9545_DPLL_MAX_N);
 
-	num = rate - (dpll_n_div * m_div * parent_rate);
+	num = rate - ((uint64_t)dpll_n_div * m_div * parent_rate);
 	den = m_div * parent_rate;
 	no_os_rational_best_approximation_u64(num, den, AD9545_DPLL_MAX_FRAC,
 					      AD9545_DPLL_MAX_MOD, frac, mod);

--- a/drivers/frequency/adf4156/adf4156.c
+++ b/drivers/frequency/adf4156/adf4156.c
@@ -312,8 +312,8 @@ value for the selected spacing. Try with a higher spacing value.\r\n");
 	adf4156_set(dev,
 		    dev->adf4156_st.reg_val[ADF4156_REG3]);
 
-	result = dev->adf4156_st.r0_int * (float)(dev->adf4156_st.fpfd / 1000000);
-	result = result + ((float)dev->adf4156_st.r0_fract / dev->adf4156_st.r2_mod) *\
+	result = dev->adf4156_st.r0_int * (double)(dev->adf4156_st.fpfd / 1000000);
+	result = result + ((double)dev->adf4156_st.r0_fract / dev->adf4156_st.r2_mod) *\
 		 (dev->adf4156_st.fpfd / 1000000);
 
 	return result;

--- a/drivers/frequency/adf4157/adf4157.c
+++ b/drivers/frequency/adf4157/adf4157.c
@@ -296,8 +296,8 @@ double adf4157_set_freq(struct adf4157_dev *dev,
 	adf4157_set(dev,
 		    dev->adf4157_st.reg_val[ADF4157_REG3]);
 
-	result = dev->adf4157_st.r0_int * (float)(dev->adf4157_st.fpfd / 1000000);
-	result = result + ((float)dev->adf4157_st.r0_fract / dev->adf4157_st.r2_mod) *
+	result = dev->adf4157_st.r0_int * (double)(dev->adf4157_st.fpfd / 1000000);
+	result = result + ((double)dev->adf4157_st.r0_fract / dev->adf4157_st.r2_mod) *
 		 (dev->adf4157_st.fpfd / 1000000);
 
 	return result;

--- a/drivers/gmsl/deserializer/camera/max96792/max96792_csi.c
+++ b/drivers/gmsl/deserializer/camera/max96792/max96792_csi.c
@@ -665,7 +665,7 @@ static int max96792_pipe_enable_stream_select(struct gmsl_dev *dev,
 int max96792_csi_update_pipe_remaps(struct gmsl_dev *dev,
 				    struct gmsl_pipe_des_pipe_cfg *pipe)
 {
-	uint8_t vc_id;
+	unsigned int vc_id;
 	struct gmsl_pipe_des_dt_vc_remap *remap;
 	struct gmsl_dev_csi_des_init_param *init_param = (struct
 			gmsl_dev_csi_des_init_param *)dev->dev_config;

--- a/drivers/gnss-gps/nmea_ubx/nmea_ubx.c
+++ b/drivers/gnss-gps/nmea_ubx/nmea_ubx.c
@@ -1545,7 +1545,8 @@ int gnss_configure_baudrate_via_nmea(struct gnss_dev *dev,
 		return -EINVAL;
 
 	/* Build standard baudrate configuration command */
-	snprintf(sentence_content, sizeof(sentence_content), "BRC,%lu", baudrate);
+	snprintf(sentence_content, sizeof(sentence_content), "BRC,%lu",
+		 (unsigned long)baudrate);
 
 	/* Calculate checksum */
 	checksum = gnss_calculate_nmea_checksum(sentence_content);
@@ -1772,7 +1773,7 @@ static int gnss_read_nmea_sentence(struct gnss_dev *dev,
 		return -EINVAL;
 
 	/* Read until we find a complete GPRMC sentence */
-	while (total_read < max_len - 1) {
+	while ((size_t)total_read < max_len - 1) {
 		ret = gnss_read(dev, &byte, 1);
 		if (ret <= 0) {
 			pr_warning("NMEA read timeout at position %d\n", total_read);

--- a/drivers/imu/iio_adis.c
+++ b/drivers/imu/iio_adis.c
@@ -797,7 +797,8 @@ static int adis_iio_read_firm_date(struct adis_dev* adis, char *buf,
 	if (ret)
 		return ret;
 
-	return snprintf(buf, size, "%.2lx-%.2lx-%.4lx", firm_m, firm_d, firm_y);
+	return snprintf(buf, size, "%.2lx-%.2lx-%.4lx", (unsigned long)firm_m,
+			(unsigned long)firm_d, (unsigned long)firm_y);
 }
 
 /**
@@ -818,7 +819,8 @@ static int adis_iio_read_firm_rev(struct adis_dev* adis, char *buf,
 	if (ret)
 		return ret;
 
-	return snprintf(buf, size, "%ld.%ld", firm_rev >> 8, firm_rev & 0xff);
+	return snprintf(buf, size, "%ld.%ld", (long)(firm_rev >> 8),
+			(long)(firm_rev & 0xff));
 }
 
 /**
@@ -839,7 +841,7 @@ static int adis_iio_read_serial_num(struct adis_dev* adis, char *buf,
 	if (ret)
 		return ret;
 
-	return snprintf(buf, size, "0x%.4lx", serial_num);
+	return snprintf(buf, size, "0x%.4lx", (unsigned long)serial_num);
 }
 
 /**
@@ -1735,7 +1737,7 @@ int adis_iio_trigger_handler_with_fifo(struct iio_device_data *dev_data)
 	struct adis_dev *adis;
 	int ret;
 	uint32_t fifo_cnt;
-	uint16_t j;
+	uint32_t j;
 
 	if (!dev_data)
 		return -EINVAL;

--- a/drivers/meter/ade9113/ade9113.c
+++ b/drivers/meter/ade9113/ade9113.c
@@ -173,7 +173,7 @@ int ade9113_read_dc(struct ade9113_dev *dev, uint8_t reg_addr,
 	/* buffer for data read (large enough for a long read) */
 	uint8_t buff[64] = { 0 };
 	/* index */
-	uint8_t i;
+	unsigned int i;
 
 	if (dev->no_devs < 2 || dev->no_devs > 4)
 		return -EINVAL;

--- a/drivers/photo-electronic/adpd410x/adpd410x.c
+++ b/drivers/photo-electronic/adpd410x/adpd410x.c
@@ -74,7 +74,7 @@ int32_t adpd410x_reg_read_bytes(struct adpd410x_dev *dev, uint16_t address,
 				uint8_t *data, uint16_t num_bytes)
 {
 	int32_t ret;
-	uint8_t i;
+	uint16_t i;
 	uint8_t *buff;
 
 	switch (dev->dev_type) {
@@ -552,7 +552,8 @@ int32_t adpd410x_read_fifo(struct adpd410x_dev *dev, uint32_t *data,
 			   uint8_t datawidth)
 {
 	int32_t ret = 0;
-	uint8_t *data_byte_buff, i, j;
+	uint8_t *data_byte_buff;
+	uint16_t i, j;
 	uint16_t next_packet_size, bytes_read = 0,
 				   total_bytes = num_samples * datawidth;
 	if (datawidth > 4 || total_bytes > ADPD410X_FIFO_DEPTH || data == NULL)

--- a/drivers/platform/stm32/stm32_dma.c
+++ b/drivers/platform/stm32/stm32_dma.c
@@ -146,7 +146,7 @@ int stm32_dma_init(struct no_os_dma_desc** desc,
 {
 	struct no_os_dma_desc* descriptor;
 	int ret;
-	uint8_t i;
+	uint32_t i;
 	struct no_os_irq_init_param irq_param = {
 		.irq_ctrl_id = 0,
 		.platform_ops = &stm32_irq_ops,

--- a/drivers/platform/stm32/stm32_gpdma.c
+++ b/drivers/platform/stm32/stm32_gpdma.c
@@ -334,7 +334,7 @@ int stm32_gpdma_init(struct no_os_dma_desc** desc,
 {
 	struct no_os_dma_desc* descriptor;
 	int ret;
-	uint8_t i;
+	uint32_t i;
 	struct no_os_irq_init_param irq_param = {
 		.irq_ctrl_id = 0,
 		.platform_ops = &stm32_irq_ops,

--- a/drivers/platform/stm32/stm32_spi.c
+++ b/drivers/platform/stm32/stm32_spi.c
@@ -497,7 +497,7 @@ int32_t stm32_config_dma_and_start(struct no_os_spi_desc* desc,
 	struct no_os_dma_xfer_desc* tx_ch_xfer;
 	SPI_TypeDef* SPIx = sdesc->hspi->Instance;
 	int ret;
-	uint8_t i;
+	uint32_t i;
 
 	if (!desc || !msgs)
 		return -EINVAL;

--- a/drivers/platform/stm32/stm32_xspi.c
+++ b/drivers/platform/stm32/stm32_xspi.c
@@ -570,7 +570,7 @@ static int32_t stm32_xspi_config_dma_and_start(struct no_os_spi_desc* desc,
 	XSPI_TypeDef* XSPIx = sdesc->hxspi.Instance;
 	struct no_os_dma_xfer_desc* ch_xfer = NULL;
 	int32_t ret;
-	uint8_t i;
+	uint32_t i;
 	bool xfer_tx; // Flag to indicate transmit
 
 	if (!desc || !msgs)

--- a/drivers/sd-card/sd.c
+++ b/drivers/sd-card/sd.c
@@ -183,7 +183,7 @@ static int32_t send_command(struct sd_desc *sd_desc, struct cmd_desc *cmd_desc)
 	/* Read response */
 	if (0 != wait_for_response(sd_desc, cmd_desc->response))
 		return -1;
-	if (cmd_desc->response_len - 1 > 0) {
+	if (cmd_desc->response_len > 1) {
 		memset(cmd_desc->response + 1, 0xFF, cmd_desc->response_len - 1);
 		if (0 != no_os_spi_write_and_read(sd_desc->spi_desc, cmd_desc->response + 1,
 						  cmd_desc->response_len - 1))

--- a/projects/ad413x/src/app/main.c
+++ b/projects/ad413x/src/app/main.c
@@ -141,7 +141,7 @@ int main()
 		return -1;
 
 	for (i = 0; i < 20; i++)
-		printf("DATA[%"PRIi32"], chan %d = %f V \n", i, i % 3, buffer[i],
+		printf("DATA[%"PRIi32"], chan %d = %f V \n", i, i % 3,
 		       (float)buffer[i] / 0xFFFFFF * 2.5);
 
 	return 0;

--- a/projects/ad469x_evb/src/examples/basic/basic_example.c
+++ b/projects/ad469x_evb/src/examples/basic/basic_example.c
@@ -64,7 +64,7 @@ int example_main()
 				goto out;
 			for (j = 0; j <  NUM_SAMPLES; j++) {
 				printf("ch: %ld %ld\r\n",
-				       i,  buf[(i * num_channels) + j]);
+				       (long)i, (long)buf[(i * num_channels) + j]);
 			}
 		}
 	} else {
@@ -76,10 +76,10 @@ int example_main()
 			for (j = 0; j < num_channels; j++) {
 				uint32_t index = (i * num_channels) + j;
 				if (ad469x_is_temp_channel(dev, j)) {
-					printf(" temp: %ld", buf[index]);
+					printf(" temp: %ld", (long)buf[index]);
 					continue;
 				}
-				printf(" ch%ld: %ld", j, buf[index]);
+				printf(" ch%ld: %ld", (long)j, (long)buf[index]);
 			}
 			printf("\r\n");
 		}

--- a/projects/ad713x_fmcz/src/ad713x_fmc.c
+++ b/projects/ad713x_fmcz/src/ad713x_fmc.c
@@ -393,15 +393,15 @@ int main()
 
 	for (i = 0; i < AD7134_FMC_SAMPLE_NO; i++) {
 		j = 0;
-		printf("%lu: ", i);
+		printf("%lu: ", (unsigned long)i);
 		while (j < 8) {
 			adc_buffer[AD7134_FMC_CH_NO * i + j] &= 0xffffff00;
 			adc_buffer[AD7134_FMC_CH_NO * i + j] >>= 8;
 			data = lsb * (int32_t)adc_buffer[AD7134_FMC_CH_NO * i + j];
 			if (data > 4.095)
 				data = data - 8.192;
-			printf("CH%lu: 0x%08lx = %+1.5fV ", j,
-			       adc_buffer[AD7134_FMC_CH_NO * i + j], data);
+			printf("CH%lu: 0x%08lx = %+1.5fV ", (unsigned long)j,
+			       (unsigned long)adc_buffer[AD7134_FMC_CH_NO * i + j], data);
 			if (j == 7)
 				printf("\n");
 			j++;

--- a/projects/ad796x_fmcz/src/examples/basic_example/basic_example.c
+++ b/projects/ad796x_fmcz/src/examples/basic_example/basic_example.c
@@ -63,7 +63,7 @@ int basic_example_main()
 	}
 
 	for (i = 0; i < SAMPLES_PER_CHANNEL; i++, buf++)
-		printf("CH1: %ld\n", *buf);
+		printf("CH1: %ld\n", (long)*buf);
 
 	pr_info("\n Capture done.\n");
 

--- a/projects/ad9656_fmc/src/app/ad9656_fmc.c
+++ b/projects/ad9656_fmc/src/app/ad9656_fmc.c
@@ -278,7 +278,7 @@ int main(void)
 
 	printf("DMA_EXAMPLE: address=%#x samples=%lu channels=%u bits=%u\n",
 	       (uintptr_t)ADC_DDR_BASEADDR,
-	       read_transfer.size / 2,
+	       (unsigned long)(read_transfer.size / 2),
 	       ad9656_core->num_channels, 16);
 
 	ad9656_user_input_test(ad9656_device, AD9656_TEST_OFF, user_input_test_pattern);

--- a/projects/adin1110/src/examples/frame_rx_tx/frame_rx_tx_example.c
+++ b/projects/adin1110/src/examples/frame_rx_tx/frame_rx_tx_example.c
@@ -223,7 +223,8 @@ int example_main()
 			printf("\nSource MAC: %02X:%02X:%02X:%02X:%02X:%02X",
 			       eth_rx.mac_source[0], eth_rx.mac_source[1], eth_rx.mac_source[2],
 			       eth_rx.mac_source[3], eth_rx.mac_source[4], eth_rx.mac_source[5]);
-			printf("\nEthertype: 0x%02X", eth_rx.ethertype);
+			printf("\nEthertype: 0x%02X%02X", eth_rx.ethertype[0],
+			       eth_rx.ethertype[1]);
 			printf("\n\nPayload: \n");
 			for (i = 0; i < eth_rx.len; i++) {
 				printf("0x%02X ", eth_rx.payload[i]);

--- a/projects/aducm3029_flash_demo/src/examples/flash_example/flash_example.c
+++ b/projects/aducm3029_flash_demo/src/examples/flash_example/flash_example.c
@@ -70,9 +70,9 @@ int example_main()
 	printf("UART online.\n");
 
 	no_os_flash_read(flash_dut, 0x3E000, &flash_val, 4);
-	printf("Address 0x3E000: %lX\n", flash_val);
+	printf("Address 0x3E000: %lX\n", (unsigned long)flash_val);
 	no_os_flash_read(flash_dut, 0x3E004, &flash_val, 4);
-	printf("Address 0x3E004: %lX\n", flash_val);
+	printf("Address 0x3E004: %lX\n", (unsigned long)flash_val);
 
 	flash_val = 0xAABBCCDD;
 
@@ -82,9 +82,9 @@ int example_main()
 		return ret;
 
 	no_os_flash_read(flash_dut, 0x3E000, &flash_val, 1);
-	printf("Address 0x3E000: %lX\n", flash_val);
+	printf("Address 0x3E000: %lX\n", (unsigned long)flash_val);
 	no_os_flash_read(flash_dut, 0x3E004, &flash_val, 1);
-	printf("Address 0x3E004: %lX\n", flash_val);
+	printf("Address 0x3E004: %lX\n", (unsigned long)flash_val);
 
 	flash_val = 0xCCDDAABB;
 
@@ -94,9 +94,9 @@ int example_main()
 		return ret;
 
 	no_os_flash_read(flash_dut, 0x3E000, &flash_val, 1);
-	printf("Address 0x3E000: %lX\n", flash_val);
+	printf("Address 0x3E000: %lX\n", (unsigned long)flash_val);
 	no_os_flash_read(flash_dut, 0x3E004, &flash_val, 1);
-	printf("Address 0x3E004: %lX\n", flash_val);
+	printf("Address 0x3E004: %lX\n", (unsigned long)flash_val);
 
 	ret = no_os_irq_global_disable(irq_dut);
 	if (ret < 0)

--- a/projects/adv7511/src/cf_hdmi.c
+++ b/projects/adv7511/src/cf_hdmi.c
@@ -89,12 +89,13 @@ void DDRVideoWr(unsigned short horizontalActiveTime,
 			for (repetition = 0; repetition < ((IMG_DATA[index] >> 24) & 0xff);
 			     repetition++) {
 				backup = pixel;
-				while ((pixel - line * horizontalActiveTime) < horizontalActiveTime) {
+				while ((pixel - (unsigned long)line * horizontalActiveTime) <
+				       horizontalActiveTime) {
 					Xil_Out32((VIDEO_BASEADDR + (pixel * 4)), (IMG_DATA[index] & 0xffffff));
 					pixel += 640;
 				}
 				pixel = backup;
-				if ((pixel - line * horizontalActiveTime) < 639) {
+				if ((pixel - (unsigned long)line * horizontalActiveTime) < 639) {
 					pixel++;
 				} else {
 					line++;
@@ -102,7 +103,7 @@ void DDRVideoWr(unsigned short horizontalActiveTime,
 						Xil_DCacheFlush();
 						return;
 					}
-					pixel = line * horizontalActiveTime;
+					pixel = (unsigned long)line * horizontalActiveTime;
 				}
 			}
 		}

--- a/projects/cn0561/src/cn0561.c
+++ b/projects/cn0561/src/cn0561.c
@@ -315,15 +315,15 @@ int main()
 
 	for (i = 0; i < CN0561_FMC_SAMPLE_NO; i++) {
 		j = 0;
-		printf("%lu: ", i);
+		printf("%lu: ", (unsigned long)i);
 		while (j < CN0561_FMC_CH_NO) {
 			adc_buffer[CN0561_FMC_CH_NO * i + j] &= 0xffffff00;
 			adc_buffer[CN0561_FMC_CH_NO * i + j] >>= 8;
 			data = lsb * (int32_t)adc_buffer[CN0561_FMC_CH_NO * i + j];
 			if (data > 4.095)
 				data = data - 8.192;
-			printf("CH%lu: 0x%08lx = %+1.5fV ", j,
-			       adc_buffer[CN0561_FMC_CH_NO * i + j], data);
+			printf("CH%lu: 0x%08lx = %+1.5fV ", (unsigned long)j,
+			       (unsigned long)adc_buffer[CN0561_FMC_CH_NO * i + j], data);
 			if (j == (CN0561_FMC_CH_NO - 1))
 				printf("\n");
 			j++;

--- a/projects/cn0565/src/examples/eit/app.c
+++ b/projects/cn0565/src/examples/eit/app.c
@@ -106,7 +106,7 @@ void ParseResultMode(struct measurement_config *pMeasCfg)
 	pMeasCfg->bImpedanceReadMode = false; //default
 	if (cmd_ptr) { // If last parameter exists read it
 		strcpy(hex_string_byte_param, cmd_ptr);
-		cmd_ok = sscanf(hex_string_byte_param, "%c", &cTmp);
+		cmd_ok = (sscanf(hex_string_byte_param, "%c", &cTmp) == 1);
 		if (cmd_ok) {
 			if (cTmp == 'Z')
 				pMeasCfg->bImpedanceReadMode = true;
@@ -117,7 +117,7 @@ void ParseResultMode(struct measurement_config *pMeasCfg)
 	pMeasCfg->bMagnitudeMode = false;
 	if (cmd_ptr) { // If parameter exists read it
 		strcpy(hex_string_byte_param, cmd_ptr);
-		cmd_ok = sscanf(hex_string_byte_param, "%c", &cTmp);
+		cmd_ok = (sscanf(hex_string_byte_param, "%c", &cTmp) == 1);
 		if (cmd_ok) {
 			if (cTmp == 'M')
 				pMeasCfg->bMagnitudeMode = true;
@@ -135,27 +135,29 @@ int32_t ParseConfig(char  *pStr,
 	*pStr = 0;
 	cmd_ptr = strtok(pStr + 1, ",");
 	strcpy(hex_string_byte_param, cmd_ptr);
-	cmd_ok = sscanf(hex_string_byte_param, "%hu", &pMeasCfg->nFrequency);
+	cmd_ok = (sscanf(hex_string_byte_param, "%hu", &pMeasCfg->nFrequency) == 1);
 	if (cmd_ok) {
 		cmd_ptr = strtok(NULL, ",");
 		strcpy(hex_string_byte_param, cmd_ptr);
-		cmd_ok = sscanf(hex_string_byte_param, "%hu",
-				&pEitCfg->nElectrodeCnt);
+		cmd_ok = (sscanf(hex_string_byte_param, "%hu",
+				 &pEitCfg->nElectrodeCnt) == 1);
 	}
 	if (cmd_ok) {
 		cmd_ptr = strtok(NULL, ",");
 		strcpy(hex_string_byte_param, cmd_ptr);
-		cmd_ok = sscanf(hex_string_byte_param, "%hu", &pEitCfg->nForceDist);
+		cmd_ok = (sscanf(hex_string_byte_param, "%hu",
+				 &pEitCfg->nForceDist) == 1);
 	}
 	if (cmd_ok) {
 		cmd_ptr = strtok(NULL, ",");
 		strcpy(hex_string_byte_param, cmd_ptr);
-		cmd_ok = sscanf(hex_string_byte_param, "%hu", &pEitCfg->nSenseDist);
+		cmd_ok = (sscanf(hex_string_byte_param, "%hu",
+				 &pEitCfg->nSenseDist) == 1);
 	}
 	if (cmd_ok) {
 		cmd_ptr = strtok(NULL, ",");
 		strcpy(hex_string_byte_param, cmd_ptr);
-		cmd_ok = sscanf(hex_string_byte_param, "%hu", &pEitCfg->nRefEl);
+		cmd_ok = (sscanf(hex_string_byte_param, "%hu", &pEitCfg->nRefEl) == 1);
 	}
 	if (cmd_ok)
 		ParseResultMode(pMeasCfg);
@@ -176,26 +178,26 @@ int32_t ParseQuery(char *pStr,
 	*pStr = 0;
 	cmd_ptr = strtok(pStr + 1, ",");
 	strcpy(hex_string_byte_param, cmd_ptr);
-	cmd_ok = sscanf(hex_string_byte_param, "%hu", &pMeasCfg->nFrequency);
+	cmd_ok = (sscanf(hex_string_byte_param, "%hu", &pMeasCfg->nFrequency) == 1);
 	if (cmd_ok) {
 		cmd_ptr = strtok(NULL, ",");
 		strcpy(hex_string_byte_param, cmd_ptr);
-		cmd_ok = sscanf(hex_string_byte_param, "%hu", &pElCmb->F_plus);
+		cmd_ok = (sscanf(hex_string_byte_param, "%hu", &pElCmb->F_plus) == 1);
 	}
 	if (cmd_ok) {
 		cmd_ptr = strtok(NULL, ",");
 		strcpy(hex_string_byte_param, cmd_ptr);
-		cmd_ok = sscanf(hex_string_byte_param, "%hu", &pElCmb->F_minus);
+		cmd_ok = (sscanf(hex_string_byte_param, "%hu", &pElCmb->F_minus) == 1);
 	}
 	if (cmd_ok) {
 		cmd_ptr = strtok(NULL, ",");
 		strcpy(hex_string_byte_param, cmd_ptr);
-		cmd_ok = sscanf(hex_string_byte_param, "%hu", &pElCmb->S_plus);
+		cmd_ok = (sscanf(hex_string_byte_param, "%hu", &pElCmb->S_plus) == 1);
 	}
 	if (cmd_ok) {
 		cmd_ptr = strtok(NULL, ",");
 		strcpy(hex_string_byte_param, cmd_ptr);
-		cmd_ok = sscanf(hex_string_byte_param, "%hu", &pElCmb->S_minus);
+		cmd_ok = (sscanf(hex_string_byte_param, "%hu", &pElCmb->S_minus) == 1);
 	}
 	if (cmd_ok)
 		ParseResultMode(pMeasCfg);
@@ -211,10 +213,10 @@ void SendResultUint32(uint32_t *pData, uint32_t nDataCount)
 	uint32_t i;
 
 	for (i = 0; i < nDataCount - 1; i++) {
-		printf("%lx,", pData[i]);
+		printf("%lx,", (unsigned long)pData[i]);
 	}
 
-	printf("%lx", pData[i]);
+	printf("%lx", (unsigned long)pData[i]);
 }
 
 void SendResultFloat32(float *data, uint32_t DataCount)
@@ -235,10 +237,10 @@ void SendResultIeee754(float *data, uint32_t DataCount)
 	uint32_t i;
 
 	for (i = 0; i < DataCount - 1; i++) {
-		printf("%lx,", pVal[i]);
+		printf("%lx,", (unsigned long)pVal[i]);
 	}
 
-	printf("%lx", pVal[i]);
+	printf("%lx", (unsigned long)pVal[i]);
 }
 
 void SendResult(uint32_t *pData, uint16_t len,

--- a/projects/eval-adxl367z/src/examples/dummy/dummy_example.c
+++ b/projects/eval-adxl367z/src/examples/dummy/dummy_example.c
@@ -87,7 +87,7 @@ int example_main()
 
 	pr_info("Number of read entries from the FIFO %d \n", entries);
 
-	for (uint8_t i = 0; i < entries / 4; i ++) {
+	for (unsigned int i = 0; i < entries / 4u; i ++) {
 		pr_info("x=%d"".%09u m/s^2\n", (int)x[i].integer, (abs)(x[i].fractional));
 		pr_info("y=%d"".%09u m/s^2\n", (int)y[i].integer, (abs)(y[i].fractional));
 		pr_info("z=%d"".%09u m/s^2\n", (int)z[i].integer, (abs)(z[i].fractional));

--- a/projects/pulsar-adc/src/examples/basic_example/basic_example.c
+++ b/projects/pulsar-adc/src/examples/basic_example/basic_example.c
@@ -68,9 +68,10 @@ int basic_example_main()
 
 	for (i = 0, data = ADC_DDR_BASEADDR; i < SAMPLES_PER_CHANNEL; i++, data++) {
 		if (sign == 's')
-			printf("ADC: %ld\n\r", no_os_sign_extend32(*data, resolution - 1));
+			printf("ADC: %ld\n\r",
+			       (long)no_os_sign_extend32(*data, resolution - 1));
 		else
-			printf("ADC: %ld\n\r", *data);
+			printf("ADC: %ld\n\r", (long)*data);
 	}
 
 	return pulsar_adc_remove(dev);


### PR DESCRIPTION
## Pull Request Description

Resolve static-analysis findings reported by CodeQL across drivers and example projects. All fixes are behavior-preserving except where the previous behavior was itself a bug (sd.c, adin1110 ethertype print).

- sd-card: sd.c: guard against uint32_t underflow when response_len is 0 (compare response_len > 1 instead of response_len - 1 > 0), which previously passed a huge length to memset.

- Widen narrow loop indices compared against wider bounds so the loop cannot wrap: ad5706r, ad9517, ad9523, ad9528, max96792_csi, iio_adis, ade9113, adpd410x, stm32 dma/gpdma/spi/xspi, nmea_ubx, eval-adxl367z dummy_example.

- Match printf/snprintf format specifiers to their argument types (cast uint32_t/int32_t args to (unsigned) long for %l): ad9144, ad9523, nmea_ubx, iio_adis, ad413x, ad469x_evb, ad713x_fmcz, ad796x_fmcz, ad9656_fmc, aducm3029_flash_demo, cn0561, cn0565, pulsar-adc. ad413x dropped a stray argument; adin1110 printed a two-byte ethertype array with a single %02X - now prints both bytes.

- Cast an operand to the wider type before multiplying to avoid overflow before the widening conversion: iio_dac_demo, ad9545, adf4156, adf4157, adv7511 cf_hdmi.

- cn0565 eit: check sscanf return against the expected conversion count (== 1); the uint8_t result stored EOF as 255, so parse failures were treated as success.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
