### PR TITLE
drivers: xilinx: fix XUartPsv recv to request 1 byte

### DIFF
--- a/drivers/platform/xilinx/xilinx_uart.c
+++ b/drivers/platform/xilinx/xilinx_uart.c
@@ -53,7 +53,8 @@ typedef XUartPsv_Config XUartPs_Config;
 #define XUartPs_SetInterruptMask  XUartPsv_SetInterruptMask
 #define XUartPs_InterruptHandler  XUartPsv_InterruptHandler
 #define XUartPs_Send              XUartPsv_Send
-#define XUartPs_Recv(inst, buf, num) XUartPsv_Recv((inst), (buf), (num))
+/* PL011 BSP only fires callback when all requested bytes arrive; request 1 */
+#define XUartPs_Recv(inst, buf, num) XUartPsv_Recv((inst), (buf), 1)
 #define XUARTPS_OPER_MODE_NORMAL  XUARTPSV_OPER_MODE_NORMAL
 #define XUARTPS_EVENT_RECV_DATA       XUARTPSV_EVENT_RECV_DATA
 #define XUARTPS_EVENT_RECV_TOUT       XUARTPSV_EVENT_RECV_TOUT


### PR DESCRIPTION
## Pull Request Description

The XUartPsv BSP driver (Versal PL011) only fires the receive callback when all requested bytes arrive. Unlike XUartPs (ZynqMP Cadence UART), it has no separate timeout handler for partial data delivery — RTRIS and RXRIS both route to ReceiveDataHandler which requires RemainingBytes to reach zero before calling back.

Requesting UART_BUFF_LENGTH bytes causes the callback to never fire for short messages (e.g. IIO commands), hanging the receiver. Request 1 byte at a time so every received byte triggers the callback immediately.

Fixes: acf8d14dae ("drivers: xilinx: add Versal PSV UART support")

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
