### PR TITLE
include: no_os_aout: fix typo for init function

### DIFF
--- a/include/no_os_aout.h
+++ b/include/no_os_aout.h
@@ -69,7 +69,7 @@ struct no_os_aout_desc {
 int32_t no_os_aout_set_voltage(struct no_os_aout_desc *desc, float value);
 
 /* Initialize the analog output peripheral */
-int32_t no_so_aout_init(struct no_os_aout_desc **desc,
+int32_t no_os_aout_init(struct no_os_aout_desc **desc,
 			const struct no_os_aout_init_param *param);
 
 /* Free the resources allocated by no_os_aout_init() */


### PR DESCRIPTION
## Pull Request Description

Init function name was accidentally no_so_aout_init, changed it to no_os_aout_init().

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
