### PR TITLE
xilinx: self-validate BSP cache via per-build-dir stamp

### DIFF
--- a/cmake/xilinx/xilinx_platform_sdk.cmake
+++ b/cmake/xilinx/xilinx_platform_sdk.cmake
@@ -17,41 +17,52 @@ function(config_xilinx_sdk BUILD_TARGET)
     set(_bsp_inc "${_ws}/bsp/${XILINX_ARCH}/include")
     set(_bsp_lib "${_ws}/bsp/${XILINX_ARCH}/lib")
     set(_lscript "${_ws}/app/src/lscript.ld")
+    set(_stamp "${_ws}/.bsp_stamp")
+    set(_util_py "${NO_OS_DIR}/tools/scripts/platform/xilinx/util.py")
+    set(_compat_h "${NO_OS_DIR}/drivers/platform/xilinx/xilinx_compat.h")
 
-    # Regenerate when BSP artifacts are missing OR when BSP scripts changed
-    # (indicated by .bsp_regen_needed marker file from build_projects.py).
-    get_filename_component(_hw_dir "${HARDWARE}" DIRECTORY)
-    set(_regen_marker "${_hw_dir}/.bsp_regen_needed")
-    set(_need_regen FALSE)
-    if(NOT EXISTS "${_bsp_lib}/libxil.a" OR NOT EXISTS "${_lscript}")
-        message(STATUS "BSP artifacts missing, will regenerate")
-        set(_need_regen TRUE)
-    elseif(EXISTS "${_regen_marker}")
-        message(STATUS "BSP scripts changed (marker file found), will regenerate")
-        set(_need_regen TRUE)
+    # Vitis install path is version-stamped (.../2025.1/.../vitis) so it
+    # doubles as a toolchain version in the fingerprint below.
+    find_program(VITIS_EXECUTABLE vitis HINTS "$ENV{XILINX_VITIS}/bin")
+
+    # Per-build-dir stamp: regenerate when .xsa, generator scripts, arch or
+    # Vitis change (mirrors the STM32 .cubemx_stamp pattern).
+    file(SHA256 "${HARDWARE}" _xsa_hash)
+    file(SHA256 "${_util_py}" _util_hash)
+    file(SHA256 "${_compat_h}" _compat_hash)
+    set(_fingerprint
+        "${_xsa_hash}:${_util_hash}:${_compat_hash}:${XILINX_ARCH}:${VITIS_EXECUTABLE}")
+
+    set(_need_regen TRUE)
+    if(EXISTS "${_bsp_lib}/libxil.a" AND EXISTS "${_lscript}" AND EXISTS "${_stamp}")
+        file(READ "${_stamp}" _stored)
+        string(STRIP "${_stored}" _stored)
+        if("${_stored}" STREQUAL "${_fingerprint}")
+            set(_need_regen FALSE)
+        else()
+            message(STATUS "Xilinx BSP inputs changed, will regenerate")
+        endif()
+    else()
+        message(STATUS "Xilinx BSP missing or unstamped, will regenerate")
     endif()
+
     if(_need_regen)
-        # Remove stale BSP so Vitis regenerates it
+        if(NOT VITIS_EXECUTABLE)
+            message(FATAL_ERROR "vitis not found under $ENV{XILINX_VITIS}/bin")
+        endif()
         if(EXISTS "${_ws}")
             file(REMOVE_RECURSE "${_ws}")
         endif()
         file(MAKE_DIRECTORY "${_ws}")
         file(COPY "${HARDWARE}" DESTINATION "${_ws}")
-        # create_project reads the CPU from arch.txt (normally written by
-        # get_arch); the arch was already resolved in the toolchain file, so
-        # stage it directly instead of re-running get_arch.
+        # Stage arch.txt so create_project skips the get_arch step.
         file(WRITE "${_ws}/arch.txt" "${XILINX_ARCH}")
-
-        find_program(VITIS_EXECUTABLE vitis HINTS "$ENV{XILINX_VITIS}/bin")
-        if(NOT VITIS_EXECUTABLE)
-            message(FATAL_ERROR "vitis not found under $ENV{XILINX_VITIS}/bin")
-        endif()
 
         message(STATUS "Generating Xilinx BSP + linker script from ${_xsa_file} "
                        "(arch ${XILINX_ARCH})... this can take a few minutes")
         execute_process(
             COMMAND ${VITIS_EXECUTABLE} -s
-                    "${NO_OS_DIR}/tools/scripts/platform/xilinx/util.py"
+                    "${_util_py}"
                     create_project "${_ws}" "${_ws}" "${_xsa_file}"
             RESULT_VARIABLE _rc
             OUTPUT_VARIABLE _out
@@ -61,14 +72,15 @@ function(config_xilinx_sdk BUILD_TARGET)
                 "Xilinx BSP generation failed (rc=${_rc}).\n"
                 "stdout:\n${_out}\nstderr:\n${_err}")
         endif()
+        # Stamp only on success; a failed run is retried next configure.
+        file(WRITE "${_stamp}" "${_fingerprint}")
     endif()
 
     if(NOT EXISTS "${_lscript}")
         message(FATAL_ERROR "Xilinx linker script not found: ${_lscript}")
     endif()
 
-    # BSP headers/libs are shared -> attach to the no-os library (PUBLIC so the
-    # executable inherits the include path for xparameters.h etc.).
+    # BSP headers/libs: PUBLIC on no-os so the executable inherits them.
     target_include_directories(no-os PUBLIC "${_bsp_inc}")
     target_link_directories(${BUILD_TARGET} PUBLIC "${_bsp_lib}")
 
@@ -78,9 +90,8 @@ function(config_xilinx_sdk BUILD_TARGET)
         target_link_options(${BUILD_TARGET} PRIVATE
             -specs=${_ws}/app/src/Xilinx.spec)
     endif()
-    # Vitis 2025 splits the standalone BSP into libxil.a plus libxilstandalone.a
-    # (syscall stubs: _exit/_sbrk/read/write...) and libxiltimer.a. Older layouts
-    # bundle everything into libxil.a, so link the extras only when present.
+    # Vitis 2025 split libxil.a into libxilstandalone.a and libxiltimer.a;
+    # link them when present so older single-lib layouts still work.
     set(_bsp_libs -lxil)
     if(EXISTS "${_bsp_lib}/libxilstandalone.a")
         list(APPEND _bsp_libs -lxilstandalone)

--- a/tools/scripts/build_projects.py
+++ b/tools/scripts/build_projects.py
@@ -253,29 +253,10 @@ def configfile_and_download_all_hw(_platform, noos, _builds_dir, hdl_branch):
 			sys.exit(1)
 	return (builds_dir, blacklist)
 
-# Files that affect BSP generation - changes invalidate the BSP cache
-XILINX_BSP_DEPS = [
-	'tools/scripts/platform/xilinx/util.py',
-	'drivers/platform/xilinx/xilinx_compat.h',
-]
-# Bump this version to force BSP regeneration on all CI runners
-BSP_CACHE_VERSION = 5
+# Xilinx BSP freshness is validated per-build-dir via xsa_work/.bsp_stamp
+# in config_xilinx_sdk (cmake/xilinx/xilinx_platform_sdk.cmake).
 
-
-def _get_bsp_deps_hash(noos_dir):
-	"""Compute combined hash of files that affect BSP generation."""
-	import hashlib
-	combined = hashlib.md5()
-	combined.update(str(BSP_CACHE_VERSION).encode())
-	for relpath in XILINX_BSP_DEPS:
-		filepath = os.path.join(noos_dir, relpath)
-		if os.path.isfile(filepath):
-			with open(filepath, 'rb') as f:
-				combined.update(f.read())
-	return combined.hexdigest()
-
-
-def get_hardware(hardware, platform, builds_dir, noos_dir=None):
+def get_hardware(hardware, platform, builds_dir):
 	if platform == 'xilinx':
 		ext = 'xsa'
 		base_name = 'system_top'
@@ -288,36 +269,7 @@ def get_hardware(hardware, platform, builds_dir, noos_dir=None):
 	old_name = "%s.%s" % (hardware, ext)
 	filename = os.path.join(builds_dir, HW_DIR_NAME, old_name)
 
-	# Check if BSP generation scripts changed (Xilinx only)
-	# Use a marker file to track if we already detected a change this run -
-	# all hardware files must regenerate, not just the first one
-	bsp_scripts_changed = False
-	if platform == 'xilinx' and noos_dir:
-		hash_file = os.path.join(builds_dir, HW_DIR_NAME, '.bsp_deps_hash')
-		regen_marker = os.path.join(builds_dir, HW_DIR_NAME, '.bsp_regen_needed')
-		current_hash = _get_bsp_deps_hash(noos_dir)
-
-		# Check if we already marked this run as needing regeneration
-		if os.path.isfile(regen_marker):
-			bsp_scripts_changed = True
-			log("BSP regeneration in progress (marker file exists)")
-		elif os.path.isfile(hash_file):
-			with open(hash_file, 'r') as f:
-				cached_hash = f.read().strip()
-			if cached_hash != current_hash:
-				bsp_scripts_changed = True
-				log("BSP scripts changed, regenerating all bsps")
-				# Create marker so all subsequent hardware also regenerates
-				with open(regen_marker, 'w') as f:
-					f.write('1')
-		else:
-			# No hash file yet - force regeneration
-			bsp_scripts_changed = True
-			log("No BSP hash file, regenerating all bsps")
-			with open(regen_marker, 'w') as f:
-				f.write('1')
-
-	if os.path.isfile(filename) and not bsp_scripts_changed:
+	if os.path.isfile(filename):
 		#If equal
 		if filecmp.cmp(filename, tmp_filename):
 			log("Same hardware from last build, use existing bsp")
@@ -410,7 +362,7 @@ def build_cmake_project(noos, project, _platform, _build_name, export_dir,
 				ok = 0
 				os.environ.clear(); os.environ.update(env)
 				continue
-			(hardware_file, new_hdf, hw_err) = get_hardware(hw_name, 'xilinx', builds_dir, noos)
+			(hardware_file, new_hdf, hw_err) = get_hardware(hw_name, 'xilinx', builds_dir)
 			if hw_err != 0 or not hardware_file:
 				log_err("ERROR")
 				log("%s: could not resolve .xsa for hardware '%s' (not downloaded?)" % (
@@ -488,21 +440,6 @@ def build_cmake_project(noos, project, _platform, _build_name, export_dir,
 
 	return ok
 
-def _finalize_bsp_hash(builds_dir, noos_dir):
-	"""Update BSP hash file and remove regeneration marker after build completes."""
-	if not noos_dir:
-		return
-	hash_file = os.path.join(builds_dir, HW_DIR_NAME, '.bsp_deps_hash')
-	regen_marker = os.path.join(builds_dir, HW_DIR_NAME, '.bsp_regen_needed')
-	# Update hash file with current hash
-	current_hash = _get_bsp_deps_hash(noos_dir)
-	with open(hash_file, 'w') as f:
-		f.write(current_hash)
-	# Remove regeneration marker
-	if os.path.isfile(regen_marker):
-		os.remove(regen_marker)
-
-
 def main():
 	(noos, export_dir, log_dir, _project,
 	 _platform, _build_name, _builds_dir, _hw, hdl_branch) = parse_input()
@@ -531,10 +468,6 @@ def main():
 		if cmake_ok is not None:
 			status = 'OK' if cmake_ok == 1 else 'Fail'
 			os.system('echo Project %20s -- %s >> %s' % (project, status, all_status))
-
-	# Finalize BSP hash after all builds complete (Xilinx only)
-	if _platform == 'xilinx':
-		_finalize_bsp_hash(builds_dir, noos)
 
 main()
 


### PR DESCRIPTION
Replace the global .bsp_deps_hash / .bsp_regen_needed scheme from ab8762aad8 with a per-build-dir xsa_work/.bsp_stamp, mirroring the STM32 .cubemx_stamp introduced in 7fe1ce5f56.

config_xilinx_sdk fingerprints the BSP inputs (.xsa, util.py, xilinx_compat.h, arch, Vitis path) into the stamp and regenerates only when an artifact is missing or the fingerprint changed. The stamp is written only on success, so a failed run is retried next configure. This also removes BSP_CACHE_VERSION -- input changes are detected automatically from file content.

Offending commit:
  ab8762aad8 ("ci: invalidate BSP cache when generation scripts change")


## Pull Request Description

Please replace this with a detailed description and motivation of the changes. 
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR. 
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
