### PR TITLE
scripts: xilinx: fix platform.build() crash after Quick Build

### DIFF
--- a/tools/scripts/platform/xilinx/util.py
+++ b/tools/scripts/platform/xilinx/util.py
@@ -499,10 +499,16 @@ def create_project(ws, hw_path, hw_file, target):
     client.create_platform_component(
         name="hw0", hw_design=xsa, cpu=vcpu, os="standalone")
 
-    # Build the platform. No need to reconnect - just get the component.
-    print("INFO: Building platform (BSP + FSBL)...")
+    # Build the platform only if Quick Build didn't already produce the BSP.
+    # create_platform_component() sometimes triggers an internal "Quick Build"
+    # that produces libxil.a — calling platform.build() again can crash the
+    # gRPC server with "Application error processing RPC".
     platform = client.get_component(name="hw0")
-    platform.build()
+    libxil_path = os.path.join(out_dir, "hw0", "export", "hw0", "sw",
+                               f"standalone_{vcpu}", "lib", "libxil.a")
+    if not os.path.exists(libxil_path):
+        print("INFO: Building platform (BSP + FSBL)...")
+        platform.build()
 
     # --- Step 2: App component (linker script) ---
     xpfm = os.path.join(out_dir, "hw0", "export", "hw0", "hw0.xpfm")


### PR DESCRIPTION
## Pull Request Description

create_platform_component() sometimes triggers an internal "Quick Build" that produces libxil.a. Calling platform.build() afterwards can crash the Vitis gRPC server with "Application error processing RPC".

Skip platform.build() if libxil.a already exists from Quick Build.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
