### PR TITLE
ad9361: do not leave the part in ALERT when update_rf_bandwidth fails

### DIFF
--- a/drivers/rf-transceiver/ad9361/ad9361.c
+++ b/drivers/rf-transceiver/ad9361/ad9361.c
@@ -5743,27 +5743,36 @@ int32_t ad9361_update_rf_bandwidth(struct ad9361_rf_phy *phy,
 
 	ad9361_ensm_force_state(phy, ENSM_STATE_ALERT);
 
+	/* Returning early from here would leave the part in ALERT with
+	 * tracking disabled, so every subsequent calibration runs against a
+	 * corrupted state. Collect the result instead and always restore,
+	 * the way ad9361_do_calib_run() already does.
+	 */
 	ret = __ad9361_update_rf_bandwidth(phy, rf_rx_bw, rf_tx_bw);
-	if (ret < 0)
-		return ret;
+	if (ret == 0) {
+		phy->current_rx_bw_Hz = rf_rx_bw;
+		phy->current_tx_bw_Hz = rf_tx_bw;
 
-	phy->current_rx_bw_Hz = rf_rx_bw;
-	phy->current_tx_bw_Hz = rf_tx_bw;
-
-	if (phy->manual_tx_quad_cal_en == false) {
-		ret = ad9361_tx_quad_calib(phy, rf_rx_bw / 2, rf_tx_bw / 2, -1);
-		if (ret < 0)
-			return ret;
+		if (phy->manual_tx_quad_cal_en == false)
+			ret = ad9361_tx_quad_calib(phy, rf_rx_bw / 2,
+						   rf_tx_bw / 2, -1);
 	}
 
-	ret = ad9361_tracking_control(phy, phy->bbdc_track_en,
-				      phy->rfdc_track_en, phy->quad_track_en);
-	if (ret < 0)
-		return ret;
+	/* Restore unconditionally, but keep the first error: a successful
+	 * restore must not mask the failure that got us here.
+	 */
+	if (ret == 0)
+		ret = ad9361_tracking_control(phy, phy->bbdc_track_en,
+					      phy->rfdc_track_en,
+					      phy->quad_track_en);
+	else
+		(void)ad9361_tracking_control(phy, phy->bbdc_track_en,
+					      phy->rfdc_track_en,
+					      phy->quad_track_en);
 
 	ad9361_ensm_restore_prev_state(phy);
 
-	return 0;
+	return ret;
 }
 
 /**


### PR DESCRIPTION
### Problem

`ad9361_update_rf_bandwidth()` forces `ENSM_STATE_ALERT` and disables tracking, then returns early on three failure paths, each of which skips `ad9361_ensm_restore_prev_state()` and the tracking restore:

```c
ad9361_ensm_force_state(phy, ENSM_STATE_ALERT);

ret = __ad9361_update_rf_bandwidth(phy, rf_rx_bw, rf_tx_bw);
if (ret < 0)
        return ret;                     /* <- ALERT, tracking off */
...
        if (ret < 0)
                return ret;             /* <- ALERT, tracking off */
...
if (ret < 0)
        return ret;                     /* <- ALERT, tracking off */

ad9361_ensm_restore_prev_state(phy);
```

The part is then left in ALERT with tracking disabled. Calibrations issued afterwards run against that state and keep failing, so a single transient fault turns into an unbounded stream of

```
Calibration TIMEOUT (0x247, 0x2)
```

rather than one reported error. `0x247` is the RX RF DC calibration status register and `0x2` its done bit, so the message is a symptom of the corrupted state rather than of a genuine calibration problem.

### How it was found

On a bladeRF 2.0 micro xA4, which bundles this driver via libbladeRF: one initial failure was followed by **124 timeouts over 8.7 minutes**, and the device did not recover until it was closed and reopened. The failure had no effect on the caller's return code either, so the host had no way to tell that the part had been left in a bad state.

### Fix

`ad9361_do_calib_run()` in this same file already has the right shape: it keeps the outcome in `ret` and restores tracking and the previous ENSM state unconditionally. This applies that shape to `ad9361_update_rf_bandwidth()`, while still returning the original error, so that a successful restore does not mask the failure that caused it.

The other five `ad9361_ensm_force_state(phy, ENSM_STATE_ALERT)` call sites in the file were checked: two already restore correctly, and the remaining three are straight-line SPI sequences with no early return, so they are unaffected.

### Testing

Builds clean as part of libbladeRF (`libbladerf_shared`, which compiles this driver via the `ad936x` target). No functional change on the success path: the state updates, the quad calibration and the tracking restore run in the same order as before.
