### PR TITLE
ad9361: cut gain-table reload cost on remote SPI masters (161 ms -> 63 ms)

### DIFF
--- a/drivers/rf-transceiver/ad9361/ad9361.c
+++ b/drivers/rf-transceiver/ad9361/ad9361.c
@@ -1515,10 +1515,14 @@ static int32_t ad9361_load_gt(struct ad9361_rf_phy *phy, uint64_t freq,
 				 START_GAIN_TABLE_CLOCK |
 				 WRITE_GAIN_TABLE |
 				 RECEIVER_SELECT(dest)); /* Gain Table Index */
-		ad9361_spi_write(spi, REG_GAIN_TABLE_READ_DATA1,
-				 0); /* Dummy Write to delay 3 ADCCLK/16 cycles */
-		ad9361_spi_write(spi, REG_GAIN_TABLE_READ_DATA1,
-				 0); /* Dummy Write to delay ~1u */
+
+		/* Delay 3 ADCCLK/16 cycles and ~1 us before the next row.
+		 * Upstream spent two dummy register writes on this, which is
+		 * free on a directly attached SPI master but costs a full bus
+		 * round trip each on a remote one. no_os_udelay() states the
+		 * same requirement without turning it into bus traffic.
+		 */
+		no_os_udelay(2);
 
 		if ((tab[i][1] & lpf_tia_mask) == 0x20)
 			phy->tx_quad_lpf_tia_match = i;

--- a/drivers/rf-transceiver/ad9361/ad9361.c
+++ b/drivers/rf-transceiver/ad9361/ad9361.c
@@ -1497,13 +1497,20 @@ static int32_t ad9361_load_gt(struct ad9361_rf_phy *phy, uint64_t freq,
 	phy->tx_quad_lpf_tia_match = -EINVAL;
 
 	for (i = 0; i < index_max; i++) {
-		ad9361_spi_write(spi, REG_GAIN_TABLE_ADDRESS, i); /* Gain Table Index */
-		ad9361_spi_write(spi, REG_GAIN_TABLE_WRITE_DATA1,
-				 tab[i][0] | lna); /* Ext LNA, Int LNA, & Mixer Gain Word */
-		ad9361_spi_write(spi, REG_GAIN_TABLE_WRITE_DATA2,
-				 tab[i][1]); /* TIA & LPF Word */
-		ad9361_spi_write(spi, REG_GAIN_TABLE_WRITE_DATA3,
-				 tab[i][2]); /* DC Cal bit & Dig Gain Word */
+		/* The index and the three data words are consecutive
+		 * registers (0x130..0x133), so a single multibyte
+		 * transaction replaces four single-byte writes. Multibyte
+		 * writes address the highest register first and descend,
+		 * hence the DATA3..ADDRESS order.
+		 */
+		uint8_t row[4];
+
+		row[0] = tab[i][2];		/* 0x133 DC Cal bit & Dig Gain Word */
+		row[1] = tab[i][1];		/* 0x132 TIA & LPF Word */
+		row[2] = tab[i][0] | lna;	/* 0x131 Ext LNA, Int LNA, & Mixer */
+		row[3] = i;			/* 0x130 Gain Table Index */
+		ad9361_spi_writem(spi, REG_GAIN_TABLE_WRITE_DATA3, row, 4);
+
 		ad9361_spi_write(spi, REG_GAIN_TABLE_CONFIG,
 				 START_GAIN_TABLE_CLOCK |
 				 WRITE_GAIN_TABLE |


### PR DESCRIPTION
### Problem

`ad9361_load_gt()` issues **7 single-byte SPI writes per row** for a 77-row table, ~539 transactions in total. On a directly attached SPI master that is only bus turnaround. On a master reached over a remote link it is 539 round trips, and the reload happens on **every RX LO move across 1.3 GHz or 4.0 GHz**, because those are the gain-table region boundaries.

Measured on a bladeRF 2.0 micro xA4, where libbladeRF bundles this driver and each `ad9361_spi_write()` is one USB round trip of **0.304 ms** (400 iterations):

```
predicted   539 x 0.304 ms = 163.9 ms
measured    p50 161.3 ms                 <- model accurate to ~2%
```

A retune that stays inside one gain-table region costs 2.4 ms on the same setup, so the reload accounts for essentially the entire crossing cost — a **67x** difference.

### Changes

Two independent commits, both reducing transactions per row without changing what is written:

1. **Multibyte row write.** The index and its three data words are consecutive registers `0x130..0x133`, so one `ad9361_spi_writem()` replaces four single-byte writes. Multibyte writes address the highest register first and descend, hence the `DATA3..ADDRESS` order.

2. **`no_os_udelay(2)` instead of two dummy writes.** The two writes to `REG_GAIN_TABLE_READ_DATA1` after each row commit exist purely as delay — 3 ADCCLK/16 cycles and ~1 us, per their own comments. Expressing that as a delay rather than as bus traffic removes 154 round trips per table while keeping the timing requirement intact for masters that need it.

### Measured effect

15 RX LO moves across the 1.3 and 4.0 GHz boundaries, same hardware and build otherwise:

| | p50 | p90 | min | max |
|---|---:|---:|---:|---:|
| unmodified | 161.3 ms | 185.3 ms | 127.6 ms | 192.6 ms |
| multibyte rows | 107.0 ms | 150.0 ms | 75.1 ms | 154.4 ms |
| + `no_os_udelay(2)` | **63.4 ms** | 85.5 ms | 50.9 ms | 94.7 ms |

### Verification

The written contents are unchanged, checked rather than assumed. All 77 rows of both the 200-1300 MHz and 1300-4000 MHz tables were read back through `REG_GAIN_TABLE_READ_DATA1..3` and compared against the unmodified driver:

- byte-identical dumps at every stage (digest `2cccbf2538c319ba`);
- identical after 15 consecutive boundary crossings, i.e. the shortened row sequence does not drift under repeated reloads;
- readback itself validated first: 25 of 77 rows genuinely differ between the two regions and repeated reads agree, so the comparison is capable of detecting a difference.

### Note on the delay change

Commit 2 assumes the master cannot issue back-to-back SPI transactions faster than ~1 us. That holds for remote masters by construction, and `no_os_udelay(2)` preserves the delay for those that can. It could be gated behind a platform flag instead if a more conservative default is preferred; the multibyte change in commit 1 stands on its own either way.

