### PR TITLE
ad9361: do not report a SPI read failure as a calibration timeout

### DIFF
--- a/drivers/rf-transceiver/ad9361/ad9361.c
+++ b/drivers/rf-transceiver/ad9361/ad9361.c
@@ -1298,11 +1298,28 @@ static int32_t ad9361_check_cal_done(struct ad9361_rf_phy *phy, uint32_t reg,
 				     uint32_t mask, uint32_t done_state)
 {
 	uint32_t timeout = 20000; /* RFDC_CAL can take long */
-	uint32_t state;
+	int32_t state;
+	uint32_t polls = 0, spi_err = 0;
+	int32_t first = -1, last = -1;
 
 	while (timeout > 0) {
 		state = ad9361_spi_readf(phy->spi, reg, mask);
-		if (state == done_state)
+		polls++;
+		if (first < 0)
+			first = state;
+		last = state;
+
+		/* A failed read returns a negative errno, which can never
+		 * equal done_state. Treating it as "not done yet" spins the
+		 * whole loop against a dead bus and then blames the
+		 * calibration engine for what was a SPI failure.
+		 */
+		if (state < 0) {
+			spi_err++;
+			return state;
+		}
+
+		if ((uint32_t)state == done_state)
 			return 0;
 
 		if (reg == REG_CALIBRATION_CTRL)
@@ -1312,8 +1329,15 @@ static int32_t ad9361_check_cal_done(struct ad9361_rf_phy *phy, uint32_t reg,
 		timeout--;
 	}
 
-	dev_err(&phy->spi->dev, "Calibration TIMEOUT (0x%"PRIX32", 0x%"PRIX32")", reg,
-		mask);
+	/* Report what happened, not just that time ran out. On a remotely
+	 * attached part every poll is a bus round trip, so the loop cannot
+	 * finish quickly and the counters tell a genuine timeout apart from
+	 * a transport fault after the fact.
+	 */
+	dev_err(&phy->spi->dev,
+		"Calibration TIMEOUT (0x%"PRIX32", 0x%"PRIX32") polls=%"PRIu32
+		" spi_err=%"PRIu32" first=0x%"PRIX32" last=0x%"PRIX32,
+		reg, mask, polls, spi_err, (uint32_t)first, (uint32_t)last);
 
 	return -ETIMEDOUT;
 }


### PR DESCRIPTION
### Problem

`ad9361_check_cal_done()` polls a status register and compares the result against `done_state`:

```c
state = ad9361_spi_readf(phy->spi, reg, mask);
if (state == done_state)
        return 0;
```

`ad9361_spi_readf()` returns a **negative errno** when the read fails. A negative value never equals `done_state`, so a transport failure is indistinguishable from "calibration not finished yet". The loop keeps polling a dead bus for all 20000 iterations and then reports

```
Calibration TIMEOUT (0x247, 0x2)
```

Two things go wrong: the message blames the calibration engine for a SPI fault, and the caller receives `-ETIMEDOUT` with no way to tell which actually happened.

`state` is also declared `uint32_t`, so the negative return is silently converted before the comparison.

### Changes

1. Return the read error immediately when `ad9361_spi_readf()` fails, instead of counting it as a poll.
2. On a genuine timeout, report the loop counters: polls performed, SPI errors seen, first and last value read.

### Why the counters are worth the log line

On a directly attached part a poll is a register access and the loop bound is a time budget. On a remotely attached part it is a bus round trip.

Measured on a bladeRF 2.0 micro xA4, where libbladeRF bundles this driver and each SPI access is a USB round trip of **0.304 ms** (400 iterations):

```
20000 polls x 0.304 ms  =  ~6 s minimum, transport alone
```

That number turned out to matter. I was chasing an intermittent acquisition stall preceded by bursts of `Calibration TIMEOUT (0x247, 0x2)` — 62 identical lines within the same millisecond, twice, minutes apart. Since a single loop cannot emit its timeout in under several seconds, those bursts provably did not come from this loop, but the log alone could not establish that. With `polls=` and `spi_err=` present the question is answered by reading one line.

### Compatibility

All six call sites either propagate the return value or ignore it, and all already treat a negative return as failure, so surfacing `-EIO` instead of `-ETIMEDOUT` does not change control flow for them. Behaviour on the success path is unchanged.

Builds clean as part of libbladeRF (`libbladerf_shared`, which compiles this driver via the `ad936x` target) and is running on hardware here.
