### PR TITLE
cmake: aducm3029: fix CCES headless RTE generation on CI runners

### DIFF
--- a/cmake/aducm3029/aducm3029_platform_sdk.cmake
+++ b/cmake/aducm3029/aducm3029_platform_sdk.cmake
@@ -99,6 +99,25 @@ function(config_aducm3029_sdk BUILD_TARGET)
 		set(_max_attempts 5)
 		set(_generated FALSE)
 
+		# CCES is Eclipse-based and needs two things the CI runner may lack:
+		#  1. A writable Eclipse configuration area (defaults to ~/.eclipse,
+		#     which may not exist or be read-only on containerised runners).
+		#  2. An X display for SWT/GTK initialisation even in headless mode.
+		# Fix (1) by pointing -configuration at a temp dir inside the build
+		# tree, and (2) by prefixing the command with xvfb-run on Linux.
+		set(_cces_config_dir "${CCES_WORKSPACE}/.eclipse_config")
+
+		if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
+			find_program(_xvfb_run xvfb-run)
+			if(_xvfb_run)
+				set(_cces_prefix ${_xvfb_run} -a)
+			else()
+				set(_cces_prefix)
+			endif()
+		else()
+			set(_cces_prefix)
+		endif()
+
 		foreach(_attempt RANGE 1 ${_max_attempts})
 			# Full workspace cleanup each attempt: stale CCES metadata (which
 			# tracks the imported project by name) would otherwise make a repeat
@@ -108,8 +127,9 @@ function(config_aducm3029_sdk BUILD_TARGET)
 
 			message(STATUS "Generating ADuCM3029 CCES project (attempt ${_attempt}/${_max_attempts})...")
 			execute_process(
-				COMMAND ${CCES_LAUNCHER} -nosplash
+				COMMAND ${_cces_prefix} ${CCES_LAUNCHER} -nosplash
 					-application com.analog.crosscore.headlesstools
+					-configuration ${_cces_config_dir}
 					-command projectcreate
 					-data ${CCES_WORKSPACE}
 					-project ${CCES_PROJECT_DIR}
@@ -132,8 +152,9 @@ function(config_aducm3029_sdk BUILD_TARGET)
 			)
 
 			execute_process(
-				COMMAND ${CCES_LAUNCHER} -nosplash
+				COMMAND ${_cces_prefix} ${CCES_LAUNCHER} -nosplash
 					-application com.analog.crosscore.headlesstools
+					-configuration ${_cces_config_dir}
 					-command addaddin
 					-data ${CCES_WORKSPACE}
 					-project ${CCES_PROJECT_NAME}


### PR DESCRIPTION
## Pull Request Description

CCES is Eclipse-based and requires a writable configuration area (~/.eclipse) and an X display for SWT/GTK initialisation, even in headless mode. On CI runners the project generation step fails silently, producing no RTE sources.

Fix by redirecting the Eclipse configuration area to a temporary directory inside the build tree (-configuration flag) and wrapping the CCES launcher with xvfb-run on Linux to provide a virtual X display.

Without this fix, a successful CCES generation is only possible when the build cache from a previous run is still present on the runner. Once that cache is evicted, the stamp-gated regeneration triggers and the build fails again. This fix ensures CCES headless generation succeeds unconditionally, regardless of runner state.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
