### PR TITLE
drivers: AD9528 SPI register-address MSB encoding

### DIFF
--- a/drivers/frequency/ad9528/ad9528.c
+++ b/drivers/frequency/ad9528/ad9528.c
@@ -110,9 +110,9 @@ int32_t ad9528_spi_write(struct ad9528_dev *dev,
 
 	int32_t ret = 0;
 
-	buf[0] = (uint8_t) reg_addr >> 8;
-	buf[1] = (uint8_t) reg_addr & 0xFF;
-	buf[2] = (uint8_t) reg_data;
+	buf[0] = reg_addr >> 8;
+	buf[1] = reg_addr & 0xFF;
+	buf[2] = reg_data;
 	ret |= no_os_spi_write_and_read(dev->spi_desc,
 					buf,
 					3);


### PR DESCRIPTION
Fix ad9528_spi_write(): shift must be before casting to uint8_t. 

## Pull Request Description

Correct the register-address byte packing in ad9528_spi_write(): shift reg_addr before casting to uint8_t. The previous expression cast first, causing the high address byte to always be zero.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
