### PR TITLE
ad9361: stop reprogramming the RF PLL when the rate is unchanged

### DIFF
--- a/drivers/rf-transceiver/ad9361/ad9361.h
+++ b/drivers/rf-transceiver/ad9361/ad9361.h
@@ -3364,6 +3364,13 @@ struct ad9361_rf_phy {
 	uint8_t			cached_synth_pd[2];
 	int32_t			tx_quad_lpf_tia_match;
 	uint32_t		current_table;
+	/* Last RF PLL rate actually programmed, indexed [0] = RX, [1] = TX.
+	 * clks[]->rate holds the rate read back from the dividers, which
+	 * differs from the request whenever they cannot hit it exactly, so
+	 * the guard in clk_set_rate() cannot use it to detect a no-op
+	 * retune. See clk_set_rate() in ad9361_util.c. */
+	uint32_t		rfpll_requested[2];
+	bool			rfpll_requested_valid[2];
 	struct gain_table_info  *gt_info;
 	bool 			ensm_pin_ctl_en;
 

--- a/drivers/rf-transceiver/ad9361/ad9361_util.c
+++ b/drivers/rf-transceiver/ad9361/ad9361_util.c
@@ -144,8 +144,29 @@ int32_t clk_set_rate(struct ad9361_rf_phy *phy,
 		case TX_RFPLL:
 		case RX_RFPLL:
 			round_rate = ad9361_rfpll_round_rate(clk_priv, rate);
+			/* The guard above compares the request against
+			 * phy->clks[source]->rate, which for these two sources is
+			 * read back from the synthesiser dividers rather than
+			 * remembered from the request. Whenever the dividers cannot
+			 * hit the request exactly the two never match, so the RF PLL
+			 * is reprogrammed on every call - including calls that ask
+			 * for the frequency that is already tuned.
+			 *
+			 * Comparing against round_rate does not help: for the
+			 * internal LO ad9361_rfpll_round_rate() forwards to
+			 * ad9361_rfpll_int_round_rate(), which only range-checks and
+			 * returns the request unchanged. Remember what was actually
+			 * programmed instead and leave the read-back cache alone, so
+			 * clk_get_rate() keeps reporting the achievable rate. */
+			if (phy->rfpll_requested_valid[source == TX_RFPLL] &&
+			    phy->rfpll_requested[source == TX_RFPLL] ==
+			    (uint32_t)round_rate)
+				break;
 			ad9361_rfpll_set_rate(clk_priv, round_rate);
 			phy->clks[source]->rate = ad9361_rfpll_recalc_rate(clk_priv);
+			phy->rfpll_requested[source == TX_RFPLL] =
+				(uint32_t)round_rate;
+			phy->rfpll_requested_valid[source == TX_RFPLL] = true;
 			break;
 		case BBPLL_CLK:
 			round_rate = ad9361_bbpll_round_rate(clk_priv, rate,


### PR DESCRIPTION
`clk_set_rate()` guards the whole switch with

```c
if (phy->clks[source]->rate != rate)
```

but for `TX_RFPLL`/`RX_RFPLL` the cached rate comes from
`ad9361_rfpll_recalc_rate()`, i.e. it is read back from the synthesiser
dividers, while the comparison is against the requested rate. Whenever the
dividers cannot hit the request exactly the two never match and the
synthesiser is reprogrammed on every call, including calls that ask for the
frequency that is already tuned.

## Measurement

bladeRF 2.0 micro xA4 (AD9361, internal LO), 30.72 MSPS, RX channel.
Requesting 2440 MHz reads back 2439999998 Hz — one tick of difference after
the `>> 1` scaling — so the guard is bypassed every time.

Cost of the set-frequency call, 20 calls each, same device session:

| requested frequency | before | after |
|---|---:|---:|
| already tuned | 18988 us | 8204 us |
| different | 14334 us | 13641 us |

Before the change, re-requesting the tuned frequency costs as much as a real
retune (in this sample slightly more); after it, about half.

## Checks

- A sweep over 925 / 2440 / 300 / 925 MHz still programs every step and reads
  back correctly.
- Re-requesting a frequency after visiting another one is not suppressed
  (925 -> 925 -> 2440 -> 925 -> 925 -> 300 -> 925 MHz, all read back within
  10 Hz).
- Sample rate, bandwidth and gain survive the retunes unchanged.

## Note on the approach

Comparing against `ad9361_rfpll_round_rate()` would not help: for the
internal LO it forwards to `ad9361_rfpll_int_round_rate()`, which only
range-checks and returns the request unchanged. The rate that was actually
programmed is remembered separately instead, so `clk_get_rate()` keeps
reporting the achievable rate.