### PR TITLE
scripts: xilinx: wait for Vitis Quick Build to complete

### DIFF
--- a/tools/scripts/platform/xilinx/util.py
+++ b/tools/scripts/platform/xilinx/util.py
@@ -499,11 +499,25 @@ def create_project(ws, hw_path, hw_file, target):
     client.create_platform_component(
         name="hw0", hw_design=xsa, cpu=vcpu, os="standalone")
 
-    # Build the platform only if Quick Build didn't already produce the BSP.
-    # create_platform_component() sometimes triggers an internal "Quick Build"
-    # that produces libxil.a — calling platform.build() again can crash the
-    # gRPC server with "Application error processing RPC".
+    # Wait for any async Quick Build to complete before proceeding.
+    # create_platform_component() sometimes triggers an async build; calling
+    # platform.build() while it's running crashes with "Application error
+    # processing RPC".
+    from vitis import _build
+    build_svc = _build.Build(client._serverObj)
+
+    print("INFO: Waiting for platform build to complete...")
+    for _ in range(90):
+        running = build_svc.listRunningBuilds()
+        if not running:
+            break
+        time.sleep(1)
+    else:
+        raise RuntimeError(f"Platform build timed out. Running: {running}")
+
+    # Build explicitly if Quick Build didn't produce the BSP
     platform = client.get_component(name="hw0")
+    xpfm = os.path.join(out_dir, "hw0", "export", "hw0", "hw0.xpfm")
     libxil_path = os.path.join(out_dir, "hw0", "export", "hw0", "sw",
                                f"standalone_{vcpu}", "lib", "libxil.a")
     if not os.path.exists(libxil_path):
@@ -511,7 +525,6 @@ def create_project(ws, hw_path, hw_file, target):
         platform.build()
 
     # --- Step 2: App component (linker script) ---
-    xpfm = os.path.join(out_dir, "hw0", "export", "hw0", "hw0.xpfm")
     print("INFO: Creating app component for linker script...")
     app = client.create_app_component(
         name="app", platform=xpfm, template="empty_application")


### PR DESCRIPTION
## Pull Request Description

create_platform_component() triggers an asynchronous "Quick Build" that compiles the BSP. Checking for libxil.a immediately after the call may find it missing and call platform.build(), which crashes with "Application error processing RPC" because the build is already running.

Replace the immediate check with polling that waits up to 90 seconds for both libxil.a and hw0.xpfm to appear.

Fixes: 8e26bd94f4 ("scripts: add Vitis 2025 BSP gen using Unified IDE Python API")

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
