### PR TITLE
STM32 CAPI Platform drivers minor fixes

### DIFF
--- a/capi/platform/stm32/stm32_capi_dma.c
+++ b/capi/platform/stm32/stm32_capi_dma.c
@@ -146,7 +146,9 @@ static int stm32_capi_dma_deinit(struct capi_dma_handle *handle)
 	if (dma_priv) {
 		for (i = 0; i < dma_priv->num_chans; i++) {
 			if (dma_priv->chan_privs[i]) {
-				HAL_DMA_DeInit(&dma_priv->chan_privs[i]->hdma);
+
+				if (dma_priv->chan_privs[i]->hdma.Instance)
+					HAL_DMA_DeInit(&dma_priv->chan_privs[i]->hdma);
 				if (handle->init_allocated)
 					capi_free(dma_priv->chan_privs[i]);
 			}
@@ -240,7 +242,9 @@ static int stm32_capi_dma_deinit_chan(struct capi_dma_chan *chan)
 	dma_priv = chan->handle->priv;
 
 	if (chan_priv) {
-		HAL_DMA_DeInit(&chan_priv->hdma);
+
+		if (chan_priv->hdma.Instance)
+			HAL_DMA_DeInit(&chan_priv->hdma);
 
 		if (chan->id < MAX_DMA_CHANNELS)
 			chan_priv_map[chan->id] = NULL;

--- a/capi/platform/stm32/stm32_capi_uart.c
+++ b/capi/platform/stm32/stm32_capi_uart.c
@@ -1315,5 +1315,5 @@ int _fstat(int fd, struct stat *st)
 	}
 
 	errno = EBADF;
-	return 0;
+	return -1;
 }


### PR DESCRIPTION
## Pull Request Description

This PR contains two minor fixes: 
- stm32_capi_uart : correct return value for int _fstat
- stm32_capi_dma:  null guard for HAL deinit

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
