### PR TITLE
Feature/sdgsw-1295: use capi alloc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,6 +327,11 @@ add_custom_command(
 
 include(${KCONFIG_VARS_FILE})
 
+# add capi dir into `no-os` before projects are added
+# capi_alloc_add_link_guard() is defined when a project's
+# post_build_config() calls it.
+add_subdirectory(capi)
+
 if(NATIVE_BUILD)
     add_subdirectory(projects)
 endif()

--- a/capi/CMakeLists.txt
+++ b/capi/CMakeLists.txt
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026 Analog Devices, Inc.
+#
+# Generic wiring for capi_alloc
+# Will become generic wiring for entire CAPI
+
+# 1. Header path (always on -- harmless where capi is unused).
+target_include_directories(no-os PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/inc)
+
+# 2. Generic wrapper (always compiled).
+target_sources(no-os PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/capi_alloc.c)
+
+# 3. Platform backend, only if this PLATFORM provides one.
+set(_capi_backend
+    ${CMAKE_CURRENT_SOURCE_DIR}/platform/${PLATFORM}/${PLATFORM}_capi_alloc.c)
+if(EXISTS "${_capi_backend}")
+    target_sources(no-os PRIVATE ${_capi_backend})
+    message(STATUS "capi_alloc: using ${PLATFORM} backend")
+else()
+    message(STATUS "capi_alloc: no ${PLATFORM} backend -- weak no-op defaults "
+                   "in effect (a link guard fails any project that uses capi_alloc)")
+endif()
+
+# Resolve an 'nm' matching the toolchain for the post-link guard, and stash the
+# results in cache/global scope so capi_alloc_add_link_guard() -- which is
+# called from another directory (cmake/project_utils.cmake) -- can see them.
+if(CMAKE_NM)
+    set(_capi_nm "${CMAKE_NM}")
+else()
+    get_filename_component(_cc "${CMAKE_C_COMPILER}" NAME)
+    get_filename_component(_cc_dir "${CMAKE_C_COMPILER}" DIRECTORY)
+    string(REGEX REPLACE "(gcc|cc|clang)(\\.exe)?$" "nm" _nm_name "${_cc}")
+    find_program(_capi_nm NAMES "${_nm_name}" nm HINTS "${_cc_dir}")
+endif()
+set(CAPI_ALLOC_NM "${_capi_nm}" CACHE INTERNAL "nm used by the capi_alloc link guard")
+set(CAPI_ALLOC_GUARD_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/capi_alloc_guard.cmake"
+    CACHE INTERNAL "path to the capi_alloc post-link guard script")
+
+# Attach the post-link weak-symbol guard to an executable target. Safe to call
+# on every project: it passes silently unless capi_*_impl is referenced but
+# resolves to the weak no-op default (no strong backend linked).
+function(capi_alloc_add_link_guard _target)
+    if(NOT CAPI_ALLOC_NM)
+        message(WARNING "capi_alloc: no 'nm' found; skipping weak-symbol link "
+                        "guard for ${_target} (allocation backend not verified)")
+        return()
+    endif()
+    add_custom_command(
+        TARGET ${_target} POST_BUILD
+        COMMAND ${CMAKE_COMMAND}
+                -DELF=$<TARGET_FILE:${_target}>
+                -DNM=${CAPI_ALLOC_NM}
+                -DPLATFORM=${PLATFORM}
+                -P ${CAPI_ALLOC_GUARD_SCRIPT}
+        VERBATIM
+        COMMENT "capi_alloc: verifying strong allocation backend for ${_target}")
+endfunction()

--- a/capi/capi_alloc_guard.cmake
+++ b/capi/capi_alloc_guard.cmake
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026 Analog Devices, Inc.
+#
+# Post-link guard for the capi_alloc allocation backend.
+#
+# Run as a POST_BUILD step on a final executable:
+#   cmake -DELF=<file> -DNM=<nm> -DPLATFORM=<plat> -P capi_alloc_guard.cmake
+#
+# It fails the build if any capi_*_impl allocation hook is present in the
+# linked executable as a WEAK symbol. Because the whole capi allocation suite
+# is compiled with -ffunction-sections and linked with --gc-sections, a
+# capi_*_impl symbol survives into the ELF only when it is actually referenced
+# (i.e. some code calls capi_malloc/calloc/free/realloc). If such a reference
+# resolves to the weak no-op default from capi/src/capi_alloc.c instead of a
+# strong platform backend, every allocation would silently return NULL at
+# runtime. This turns that silent runtime failure into a loud build failure.
+#
+# Symbols that are never used are removed by the linker and never reach this
+# check, so projects that do not use capi_alloc are unaffected.
+# This is a temporary guard. Eventually all platform will have their drivers 
+# ported to CAPI. This will become redundant.
+
+if(NOT EXISTS "${ELF}")
+    message(FATAL_ERROR "capi_alloc guard: executable not found: ${ELF}")
+endif()
+
+execute_process(
+    COMMAND "${NM}" "${ELF}"
+    OUTPUT_VARIABLE _nm_out
+    RESULT_VARIABLE _nm_rc
+    ERROR_VARIABLE  _nm_err
+)
+if(NOT _nm_rc EQUAL 0)
+    message(FATAL_ERROR "capi_alloc guard: '${NM} ${ELF}' failed: ${_nm_err}")
+endif()
+
+set(_impls capi_malloc_impl capi_calloc_impl capi_free_impl capi_realloc_impl)
+set(_weak "")
+
+# nm line for a defined symbol: "<hexvalue> <type> <name>"
+# nm line for an undefined symbol: "<spaces> <type> <name>"
+# Weak types: V/W (defined weak), v/w (undefined weak). Any of these for a
+# capi_*_impl means no strong backend won the link.
+string(REPLACE "\n" ";" _lines "${_nm_out}")
+foreach(_line IN LISTS _lines)
+    if(_line MATCHES "^[0-9a-fA-F]* +([VWvw]) +([A-Za-z0-9_]+)$")
+        set(_type "${CMAKE_MATCH_1}")
+        set(_name "${CMAKE_MATCH_2}")
+        list(FIND _impls "${_name}" _idx)
+        if(NOT _idx EQUAL -1)
+            list(APPEND _weak "${_name} (weak '${_type}')")
+        endif()
+    endif()
+endforeach()
+
+if(_weak)
+    string(REPLACE ";" "\n    " _weak_str "${_weak}")
+    message(FATAL_ERROR
+        "capi_alloc: the following allocation hooks resolved to the WEAK "
+        "no-op default in\n  ${ELF}:\n    ${_weak_str}\n\n"
+        "capi_malloc/calloc/free/realloc are used, but no strong platform "
+        "backend was linked for PLATFORM=${PLATFORM}, so every allocation "
+        "would return NULL at runtime.\n"
+        "Provide capi/platform/${PLATFORM}/${PLATFORM}_capi_alloc.c (defining "
+        "capi_malloc_impl, capi_calloc_impl, capi_free_impl and "
+        "capi_realloc_impl), or do not use capi_alloc on this platform yet.")
+endif()

--- a/cmake/project_utils.cmake
+++ b/cmake/project_utils.cmake
@@ -51,6 +51,13 @@ function(post_build_config PROJECT_TARGET)
                 )
         endif()
 
+        # Fail the build if this executable uses capi_alloc but no strong
+        # platform backend was linked (weak no-op would return NULL at runtime).
+        # Passes silently for projects that do not use capi_alloc.
+        if(COMMAND capi_alloc_add_link_guard)
+                capi_alloc_add_link_guard(${PROJECT_TARGET})
+        endif()
+
         # IDE project file generation (replaces cmake -P vscode_config.cmake
         # and generate_stm32cubeide_project calls)
         ide_generate(${PROJECT_TARGET})

--- a/drivers/accel/adxl313/adxl313.c
+++ b/drivers/accel/adxl313/adxl313.c
@@ -38,7 +38,7 @@
 #include "no_os_print_log.h"
 #include "no_os_util.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 static int64_t adxl313_accel_conv(struct adxl313_dev *dev, int16_t raw_accel);
 static void adxl313_compute_multiplier(struct adxl313_dev *dev);
@@ -158,7 +158,7 @@ int adxl313_init(struct adxl313_dev **device,
 	uint8_t reg_value = 0;
 
 
-	dev = (struct adxl313_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct adxl313_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -326,10 +326,10 @@ error_com:
 		no_os_spi_remove(dev->com_desc.spi_desc);
 	else
 		no_os_i2c_remove(dev->com_desc.i2c_desc);
-	no_os_free(dev);
+	capi_free(dev);
 	return -EPIPE;
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 	return -ENODEV;
 }
 
@@ -349,7 +349,7 @@ int adxl313_remove(struct adxl313_dev *dev)
 	else
 		ret = no_os_i2c_remove(dev->com_desc.i2c_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/accel/adxl313/iio_adxl313.c
+++ b/drivers/accel/adxl313/iio_adxl313.c
@@ -35,7 +35,7 @@
 #include <stdio.h>
 #include "no_os_error.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "iio_adxl313.h"
 #include "adxl313.h"
 
@@ -1022,7 +1022,7 @@ int adxl313_iio_init(struct adxl313_iio_dev **iio_dev,
 	int ret;
 	struct adxl313_iio_dev *desc;
 
-	desc = (struct adxl313_iio_dev *)no_os_calloc(1, sizeof(*desc));
+	desc = (struct adxl313_iio_dev *)capi_calloc(1, sizeof(*desc));
 	if (!desc)
 		return -ENOMEM;
 
@@ -1068,11 +1068,11 @@ int adxl313_iio_init(struct adxl313_iio_dev **iio_dev,
 	return 0;
 
 error_adxl313_init:
-	no_os_free(desc);
+	capi_free(desc);
 	return ret;
 error_config:
 	adxl313_remove(desc->adxl313_dev);
-	no_os_free(desc);
+	capi_free(desc);
 	return ret;
 }
 
@@ -1091,7 +1091,7 @@ int adxl313_iio_remove(struct adxl313_iio_dev *desc)
 	if (ret)
 		return ret;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/accel/adxl345/adxl345.c
+++ b/drivers/accel/adxl345/adxl345.c
@@ -33,7 +33,7 @@
 
 #include <stdlib.h>
 #include "adxl345.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 
 static const uint8_t adxl345_part_id[] = {
@@ -125,7 +125,7 @@ int32_t adxl345_init(struct adxl345_dev **device,
 	struct adxl345_dev *dev;
 	int32_t status = 0;
 
-	dev = (struct adxl345_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct adxl345_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -164,7 +164,7 @@ int32_t adxl345_remove(struct adxl345_dev *dev)
 	else
 		ret = no_os_i2c_remove(dev->i2c_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/accel/adxl355/adxl355.c
+++ b/drivers/accel/adxl355/adxl355.c
@@ -35,7 +35,7 @@
 #include <errno.h>
 #include "adxl355.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 static uint8_t shadow_reg_val[5] = {0, 0, 0, 0, 0};
 static const uint8_t adxl355_scale_mul[4] = {0, 1, 2, 4};
@@ -138,7 +138,7 @@ int adxl355_init(struct adxl355_dev **device,
 		return -EINVAL;
 	}
 
-	dev = (struct adxl355_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct adxl355_dev *)capi_calloc(1, sizeof(*dev));
 
 	if (!dev)
 		return -ENOMEM;
@@ -212,10 +212,10 @@ error_com:
 		no_os_spi_remove(dev->com_desc.spi_desc);
 	else
 		no_os_i2c_remove(dev->com_desc.i2c_desc);
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -235,7 +235,7 @@ int adxl355_remove(struct adxl355_dev *dev)
 	else
 		ret = no_os_i2c_remove(dev->com_desc.i2c_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/accel/adxl355/iio_adxl355.c
+++ b/drivers/accel/adxl355/iio_adxl355.c
@@ -38,7 +38,7 @@
 #include "iio_adxl355.h"
 #include "adxl355.h"
 #include "no_os_units.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 #define ACCEL_AXIS_X (uint32_t) 0
 #define ACCEL_AXIS_Y (uint32_t) 1
@@ -1031,7 +1031,7 @@ int adxl355_iio_init(struct adxl355_iio_dev **iio_dev,
 	int ret;
 	struct adxl355_iio_dev *desc;
 
-	desc = (struct adxl355_iio_dev *)no_os_calloc(1, sizeof(*desc));
+	desc = (struct adxl355_iio_dev *)capi_calloc(1, sizeof(*desc));
 	if (!desc)
 		return -ENOMEM;
 
@@ -1064,11 +1064,11 @@ int adxl355_iio_init(struct adxl355_iio_dev **iio_dev,
 	return 0;
 
 error_adxl355_init:
-	no_os_free(desc);
+	capi_free(desc);
 	return ret;
 error_config:
 	adxl355_remove(desc->adxl355_dev);
-	no_os_free(desc);
+	capi_free(desc);
 	return ret;
 }
 
@@ -1087,7 +1087,7 @@ int adxl355_iio_remove(struct adxl355_iio_dev *desc)
 	if (ret)
 		return ret;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/accel/adxl362/adxl362.c
+++ b/drivers/accel/adxl362/adxl362.c
@@ -33,7 +33,7 @@
 
 #include <stdlib.h>
 #include "adxl362.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /***************************************************************************//**
  * @brief Initializes communication with the device and checks if the part is
@@ -53,7 +53,7 @@ int32_t adxl362_init(struct adxl362_dev **device,
 	uint8_t reg_value = 0;
 	int32_t status = -1;
 
-	dev = (struct adxl362_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct adxl362_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -84,7 +84,7 @@ int32_t adxl362_remove(struct adxl362_dev *dev)
 
 	ret = no_os_spi_remove(dev->spi_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/accel/adxl367/adxl367.c
+++ b/drivers/accel/adxl367/adxl367.c
@@ -36,7 +36,7 @@
 #include "no_os_delay.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_print_log.h"
 
 static const uint8_t adxl367_scale_mul[3] = {1, 2, 4};
@@ -59,7 +59,7 @@ int adxl367_init(struct adxl367_dev **device,
 	uint8_t reg_value;
 	int status;
 
-	dev = (struct adxl367_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct adxl367_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -122,7 +122,7 @@ err:
 	else
 		no_os_i2c_remove(dev->i2c_desc);
 comm_err:
-	no_os_free(dev);
+	capi_free(dev);
 	return status;
 }
 
@@ -142,7 +142,7 @@ int adxl367_remove(struct adxl367_dev *dev)
 	else
 		ret = no_os_i2c_remove(dev->i2c_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/accel/adxl367/iio_adxl367.c
+++ b/drivers/accel/adxl367/iio_adxl367.c
@@ -35,7 +35,7 @@
 #include <stdio.h>
 #include "no_os_error.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "iio_adxl367.h"
 #include "adxl367.h"
 #include <string.h>
@@ -714,7 +714,7 @@ int adxl367_iio_init(struct adxl367_iio_dev **iio_dev,
 	int ret;
 	struct adxl367_iio_dev *desc;
 
-	desc = (struct adxl367_iio_dev *)no_os_calloc(1, sizeof(*desc));
+	desc = (struct adxl367_iio_dev *)capi_calloc(1, sizeof(*desc));
 	if (!desc)
 		return -ENOMEM;
 
@@ -745,11 +745,11 @@ int adxl367_iio_init(struct adxl367_iio_dev **iio_dev,
 	return 0;
 
 error_adxl367_init:
-	no_os_free(desc);
+	capi_free(desc);
 	return ret;
 error_config:
 	adxl367_remove(desc->adxl367_dev);
-	no_os_free(desc);
+	capi_free(desc);
 	return ret;
 }
 
@@ -768,7 +768,7 @@ int adxl367_iio_remove(struct adxl367_iio_dev *desc)
 	if (ret)
 		return ret;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/accel/adxl372/adxl372.c
+++ b/drivers/accel/adxl372/adxl372.c
@@ -36,7 +36,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include "adxl372.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 
 /**
@@ -692,7 +692,7 @@ int32_t adxl372_init(struct adxl372_dev **device,
 	uint8_t dev_id, part_id, rev_id;
 	int32_t ret;
 
-	dev = (struct adxl372_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct adxl372_dev *)capi_malloc(sizeof(*dev));
 	if (!dev) {
 		ret = -ENOMEM;
 		goto error;
@@ -834,7 +834,7 @@ int32_t adxl372_init(struct adxl372_dev **device,
 
 error:
 	printf("adxl372 initialization error (%d)\n", ret);
-	no_os_free(dev);
+	capi_free(dev);
 	no_os_mdelay(1000);
 	return ret;
 }

--- a/drivers/accel/adxl38x/adxl38x.c
+++ b/drivers/accel/adxl38x/adxl38x.c
@@ -35,7 +35,7 @@
 #include <errno.h>
 #include "adxl38x.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_util.h"
 
 static const uint8_t adxl38x_scale_mul[3] = {1, 2, 4};
@@ -160,7 +160,7 @@ int adxl38x_init(struct adxl38x_dev **device,
 	int ret;
 	uint8_t reg_value;
 
-	dev = (struct adxl38x_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct adxl38x_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -234,10 +234,10 @@ error_com:
 		no_os_spi_remove(dev->com_desc.spi_desc);
 	else
 		no_os_i2c_remove(dev->com_desc.i2c_desc);
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -256,7 +256,7 @@ int adxl38x_remove(struct adxl38x_dev *dev)
 		ret = no_os_spi_remove(dev->com_desc.spi_desc);
 	else
 		ret = no_os_i2c_remove(dev->com_desc.i2c_desc);
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/adc-dac/ad5592r/ad5592r-base.h
+++ b/drivers/adc-dac/ad5592r/ad5592r-base.h
@@ -40,7 +40,7 @@
 #include "no_os_i2c.h"
 #include "no_os_gpio.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include <stdbool.h>
 
 #define CH_MODE_UNUSED			0

--- a/drivers/adc-dac/ad5592r/ad5592r.c
+++ b/drivers/adc-dac/ad5592r/ad5592r.c
@@ -32,6 +32,7 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 #include "no_os_error.h"
+#include "capi_alloc.h"
 #include "ad5592r-base.h"
 #include "ad5592r.h"
 
@@ -343,7 +344,7 @@ int32_t ad5592r_init(struct ad5592r_dev **device,
 	struct ad5592r_dev *dev;
 	uint8_t i;
 
-	dev = (struct ad5592r_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ad5592r_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -415,7 +416,7 @@ err_remove_spi_ss:
 err_remove_spi:
 	no_os_spi_remove(dev->spi);
 err_free_device:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -451,7 +452,7 @@ int32_t ad5592r_remove(struct ad5592r_dev *dev)
 		return err;
 
 	/* finally we can remove our descriptor object */
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/adc-dac/ad5592r/ad5593r.c
+++ b/drivers/adc-dac/ad5592r/ad5593r.c
@@ -34,6 +34,7 @@
 
 #include "ad5592r-base.h"
 #include "no_os_error.h"
+#include "capi_alloc.h"
 #include "ad5593r.h"
 
 const struct ad5592r_rw_ops ad5593r_rw_ops = {
@@ -266,7 +267,7 @@ int32_t ad5593r_init(struct ad5592r_dev **device,
 	uint8_t i;
 	struct ad5592r_dev *dev;
 
-	dev = (struct ad5592r_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ad5592r_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -324,7 +325,7 @@ int32_t ad5593r_init(struct ad5592r_dev **device,
 err_remove_i2c:
 	no_os_i2c_remove(dev->i2c);
 err_free_device:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -353,7 +354,7 @@ int32_t ad5593r_remove(struct ad5592r_dev *dev)
 		return err;
 
 	/* finally we can remove our descriptor object */
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/adc-dac/ad5592r/iio_ad559xr.c
+++ b/drivers/adc-dac/ad5592r/iio_ad559xr.c
@@ -34,7 +34,7 @@
 #include <errno.h>
 #include <assert.h>
 #include <string.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_list.h"
 #include "iio_ad559xr.h"
 #include "ad5592r.h"
@@ -370,7 +370,7 @@ static int new_ad559xr_add_port(struct iio_ad559xr_desc *desc,
 	if (!name)
 		return -EINVAL;
 
-	port = no_os_calloc(1, sizeof * port);
+	port = capi_calloc(1, sizeof * port);
 	if (port) {
 		snprintf(port->name, AD559XR_MAX_PORT_NAMELEN, "%s%d", name, number);
 		port->mode = mode;
@@ -380,7 +380,7 @@ static int new_ad559xr_add_port(struct iio_ad559xr_desc *desc,
 
 		err = no_os_list_add_last(desc->aio_ports, port);
 		if (err)
-			no_os_free(port);
+			capi_free(port);
 	}
 	return err;
 }
@@ -609,7 +609,7 @@ static int populate_iio_channels(struct iio_ad559xr_desc *desc, bool analog)
 	if (err)
 		return err;
 
-	iio_chptr = no_os_calloc(port_count, sizeof(struct iio_channel));
+	iio_chptr = capi_calloc(port_count, sizeof(struct iio_channel));
 	if (!iio_chptr)
 		return -ENOMEM;
 
@@ -682,7 +682,7 @@ int iio_ad559xr_aio_init(struct iio_ad559xr_desc **desc,
 	if (!ad5592r)
 		return -ENODEV;
 
-	ldesc = no_os_calloc(1, sizeof * ldesc);
+	ldesc = capi_calloc(1, sizeof * ldesc);
 	if (!ldesc)
 		return -ENOMEM;
 
@@ -721,7 +721,7 @@ int iio_ad559xr_aio_init(struct iio_ad559xr_desc **desc,
 
 	scan_size = (ldesc->port_count * AD559XR_STORAGE_BYTES)
 		    * AD5599XR_MAX_SAMPLE_SIZE;
-	ldesc->raw_buffer = no_os_malloc(scan_size);
+	ldesc->raw_buffer = capi_malloc(scan_size);
 	if (!ldesc->raw_buffer)
 		goto err_free_channels;
 	ldesc->raw_buffer_size = scan_size;
@@ -735,11 +735,11 @@ int iio_ad559xr_aio_init(struct iio_ad559xr_desc **desc,
 
 	return 0;
 err_free_channels:
-	no_os_free(ldesc->channels);
+	capi_free(ldesc->channels);
 err_free_list:
 	ad559xr_list_free(ldesc);
 err_free_ldesc:
-	no_os_free(ldesc);
+	capi_free(ldesc);
 	return err;
 }
 
@@ -774,7 +774,7 @@ int iio_ad559xr_gpio_init(struct iio_ad559xr_desc **desc,
 	if (!gpio_map)
 		return -EINVAL;
 
-	ldesc = no_os_calloc(1, sizeof * ldesc);
+	ldesc = capi_calloc(1, sizeof * ldesc);
 	if (!ldesc)
 		return -ENOMEM;
 
@@ -831,7 +831,7 @@ int iio_ad559xr_gpio_init(struct iio_ad559xr_desc **desc,
 err_free_list:
 	ad559xr_list_free(ldesc);
 err_free_ldesc:
-	no_os_free(ldesc);
+	capi_free(ldesc);
 	return err;
 }
 
@@ -850,13 +850,13 @@ int iio_ad559xr_remove(struct iio_ad559xr_desc *desc)
 	if (!desc)
 		return -EINVAL;
 	if (desc->channels)
-		no_os_free(desc->channels);
+		capi_free(desc->channels);
 	if (desc->raw_buffer)
-		no_os_free(desc->raw_buffer);
+		capi_free(desc->raw_buffer);
 
 	err = ad559xr_list_free(desc);
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return err;
 }

--- a/drivers/adc-dac/ad74413r/ad74413r.c
+++ b/drivers/adc-dac/ad74413r/ad74413r.c
@@ -36,7 +36,7 @@
 #include "no_os_delay.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 #define AD74413R_FRAME_SIZE 		4
 #define AD74413R_CRC_POLYNOMIAL 	0x7
@@ -1171,7 +1171,7 @@ int ad74413r_init(struct ad74413r_desc **desc,
 	if (!init_param)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -1209,7 +1209,7 @@ free_reset:
 comm_err:
 	no_os_spi_remove(descriptor->comm_desc);
 err:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -1241,7 +1241,7 @@ int ad74413r_remove(struct ad74413r_desc *desc)
 	if (ret)
 		return ret;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/adc-dac/ad74413r/iio_ad74413r.c
+++ b/drivers/adc-dac/ad74413r/iio_ad74413r.c
@@ -37,7 +37,7 @@
 #include "no_os_error.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "ad74413r.h"
 #include "iio_ad74413r.h"
 
@@ -1253,7 +1253,7 @@ static int ad74413r_iio_setup_channels(struct ad74413r_iio_desc *iio_desc)
 		channel_buff_cnt++;
 	}
 
-	chan_buffer = no_os_calloc(channel_buff_cnt, sizeof(*chan_buffer));
+	chan_buffer = capi_calloc(channel_buff_cnt, sizeof(*chan_buffer));
 	if (!chan_buffer)
 		return -ENOMEM;
 
@@ -1332,7 +1332,7 @@ static int ad74413r_iio_setup_channels(struct ad74413r_iio_desc *iio_desc)
 	return 0;
 
 free_channels:
-	no_os_free(chan_buffer);
+	capi_free(chan_buffer);
 
 	return ret;
 }
@@ -1524,7 +1524,7 @@ int ad74413r_iio_init(struct ad74413r_iio_desc **iio_desc,
 	if (!init_param || !init_param->ad74413r_init_param)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -1556,7 +1556,7 @@ int ad74413r_iio_init(struct ad74413r_iio_desc **iio_desc,
 	return 0;
 err:
 	ad74413r_remove(descriptor->ad74413r_desc);
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -1574,8 +1574,8 @@ int ad74413r_iio_remove(struct ad74413r_iio_desc *desc)
 	if (ret)
 		return ret;
 
-	no_os_free(desc->iio_dev->channels);
-	no_os_free(desc);
+	capi_free(desc->iio_dev->channels);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/adc-dac/ad74416h/ad74416h.c
+++ b/drivers/adc-dac/ad74416h/ad74416h.c
@@ -36,7 +36,7 @@
 #include "no_os_delay.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 #define AD74416H_CRC_POLYNOMIAL 	0x7
 #define AD74416H_DIN_DEBOUNCE_LEN 	NO_OS_BIT(5)
@@ -977,7 +977,7 @@ int ad74416h_init(struct ad74416h_desc **desc,
 	if (!init_param)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -1012,7 +1012,7 @@ gpio_err:
 comm_err:
 	no_os_spi_remove(descriptor->spi_desc);
 err:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -1043,7 +1043,7 @@ int ad74416h_remove(struct ad74416h_desc *desc)
 
 	desc->spi_desc = NULL;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/adc/ad405x/ad405x.c
+++ b/drivers/adc/ad405x/ad405x.c
@@ -38,7 +38,7 @@
 #include <string.h>
 #include "ad405x.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 static const uint8_t reset_pattern_buff[18] = {
 	0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE,
@@ -93,7 +93,7 @@ int ad405x_init(struct ad405x_dev **device,
 		return -EINVAL;
 	}
 
-	dev = (struct ad405x_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ad405x_dev *)capi_calloc(1, sizeof(*dev));
 
 	if (!dev)
 		return -ENOMEM;
@@ -174,7 +174,7 @@ error_gpio:
 	if (dev->comm_type == AD405X_SPI_COMM)
 		no_os_gpio_remove(dev->extra.spi_extra.gpio_cnv);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -207,7 +207,7 @@ int ad405x_remove(struct ad405x_dev *dev)
 	} else
 		ret = no_os_i3c_remove(dev->com_desc.i3c_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/adc/ad4080/iio_ad4080.c
+++ b/drivers/adc/ad4080/iio_ad4080.c
@@ -37,7 +37,7 @@
 #include <string.h>
 #include <assert.h>
 
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 #include "iio_ad4080.h"
 
@@ -1431,13 +1431,13 @@ void iio_ad4080_fifo_unset_watermark(struct iio_ad4080_fifo_struct *fifo)
 			     AD4080_FIFO_DISABLE);
 
 	if (fifo->formatted_fifo) {
-		no_os_free(fifo->formatted_fifo);
+		capi_free(fifo->formatted_fifo);
 		fifo->formatted_fifo = NULL;
 		fifo->formatted_bufsize = 0;
 	}
 
 	if (fifo->raw_fifo) {
-		no_os_free(fifo->raw_fifo);
+		capi_free(fifo->raw_fifo);
 		fifo->raw_fifo = NULL;
 		fifo->bufsize = 0;
 	}
@@ -1473,7 +1473,7 @@ int iio_ad4080_fifo_set_watermark(struct iio_ad4080_fifo_struct *fifo,
 	fifo_size = (fifo_size * watermark);
 	fifo_size = fifo_size + 1; /* account for the 0xAA synchro byte */
 
-	raw_fifo = no_os_malloc(fifo_size);
+	raw_fifo = capi_malloc(fifo_size);
 	if (!raw_fifo) {
 		return -ENOMEM;
 	}
@@ -1482,7 +1482,7 @@ int iio_ad4080_fifo_set_watermark(struct iio_ad4080_fifo_struct *fifo,
 	fifo->bufsize = fifo_size;
 
 	formatted_bufsize = watermark * sizeof(uint32_t);
-	formatted_fifo = no_os_malloc(formatted_bufsize);
+	formatted_fifo = capi_malloc(formatted_bufsize);
 	if (!formatted_fifo)
 		goto err_malloc_formatted_fifo;
 	fifo->formatted_fifo = formatted_fifo;
@@ -1495,9 +1495,9 @@ int iio_ad4080_fifo_set_watermark(struct iio_ad4080_fifo_struct *fifo,
 
 	return 0;
 err_set_fifo_watermark:
-	no_os_free(formatted_fifo);
+	capi_free(formatted_fifo);
 err_malloc_formatted_fifo:
-	no_os_free(raw_fifo);
+	capi_free(raw_fifo);
 	return err;
 }
 

--- a/drivers/adc/ad463x/ad463x.c
+++ b/drivers/adc/ad463x/ad463x.c
@@ -39,7 +39,7 @@
 #include "no_os_units.h"
 #include "ad463x.h"
 #include "no_os_print_log.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_spi.h"
 
 #define AD463x_TEST_DATA 0xAA
@@ -595,7 +595,7 @@ static int32_t ad463x_read_data_dma(struct ad463x_dev *dev,
 	if (!dev)
 		return -EINVAL;
 
-	rx_buf = no_os_calloc(1, samples * dev->read_bytes_no);
+	rx_buf = capi_calloc(1, samples * dev->read_bytes_no);
 	if (!rx_buf)
 		return -ENOMEM;
 
@@ -622,7 +622,7 @@ static int32_t ad463x_read_data_dma(struct ad463x_dev *dev,
 		p_buf += 2;
 	}
 out:
-	no_os_free(rx_buf);
+	capi_free(rx_buf);
 	return ret;
 }
 
@@ -706,7 +706,7 @@ int32_t ad463x_init(struct ad463x_dev **device,
 		return -1;
 	}
 
-	dev = (struct ad463x_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ad463x_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -879,7 +879,7 @@ error_gpio:
 	no_os_gpio_remove(dev->gpio_pgia_a0);
 	no_os_gpio_remove(dev->gpio_pgia_a1);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return -1;
 }
@@ -988,7 +988,7 @@ int32_t ad463x_remove(struct ad463x_dev *dev)
 			return ret;
 	}
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/adc/ad463x/iio_ad463x.c
+++ b/drivers/adc/ad463x/iio_ad463x.c
@@ -37,7 +37,7 @@
 #include "iio.h"
 #include "iio_ad463x.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 static int ad463x_iio_read_raw(void *dev, char *buf, uint32_t len,
 			       const struct iio_ch_info *channel, intptr_t priv);
@@ -322,7 +322,7 @@ int32_t iio_ad463x_init(struct iio_ad463x **desc,
 {
 	struct iio_ad463x *iio_ad463x;
 
-	iio_ad463x = (struct iio_ad463x *)no_os_calloc(1, sizeof(struct iio_ad463x));
+	iio_ad463x = (struct iio_ad463x *)capi_calloc(1, sizeof(struct iio_ad463x));
 	if (!iio_ad463x)
 		return -1;
 
@@ -355,7 +355,7 @@ int32_t iio_ad463x_remove(struct iio_ad463x *desc)
 	if (!desc)
 		return -1;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/adc/ad4692/ad4692.c
+++ b/drivers/adc/ad4692/ad4692.c
@@ -38,7 +38,7 @@
 #include "no_os_delay.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_units.h"
 
 const int ad4692_int_osc_val[16] = {
@@ -693,7 +693,7 @@ int ad4692_init(struct ad4692_desc **desc, struct ad4692_init_param *init_param)
 	struct ad4692_desc *descriptor;
 	int ret;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -776,7 +776,7 @@ reset_err:
 spi_err:
 	no_os_spi_remove(descriptor->comm_desc);
 err:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -795,7 +795,7 @@ int ad4692_remove(struct ad4692_desc *desc)
 	no_os_pwm_remove(desc->conv_desc);
 	no_os_gpio_remove(desc->reset_desc);
 	no_os_spi_remove(desc->comm_desc);
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/adc/ad4692/iio_ad4692.c
+++ b/drivers/adc/ad4692/iio_ad4692.c
@@ -33,7 +33,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
@@ -770,12 +770,12 @@ int ad4692_iio_init(struct ad4692_iio_desc **iio_desc,
 	struct iio_device *iio_dev;
 	int ret;
 
-	descriptor = (struct ad4692_iio_desc *)no_os_calloc(1, sizeof(*descriptor));
+	descriptor = (struct ad4692_iio_desc *)capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
 	/* Allocate a copy of the iio_device to avoid modifying the shared static */
-	iio_dev = (struct iio_device *)no_os_calloc(1, sizeof(*iio_dev));
+	iio_dev = (struct iio_device *)capi_calloc(1, sizeof(*iio_dev));
 	if (!iio_dev) {
 		ret = -ENOMEM;
 		goto error;
@@ -807,9 +807,9 @@ int ad4692_iio_init(struct ad4692_iio_desc **iio_desc,
 	return 0;
 
 iio_dev_error:
-	no_os_free(iio_dev);
+	capi_free(iio_dev);
 error:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 	return ret;
 }
 
@@ -821,8 +821,8 @@ int ad4692_iio_remove(struct ad4692_iio_desc *iio_desc)
 	if (ret)
 		return ret;
 
-	no_os_free(iio_desc->iio_dev);
-	no_os_free(iio_desc);
+	capi_free(iio_desc->iio_dev);
+	capi_free(iio_desc);
 
 	return 0;
 }

--- a/drivers/adc/ad469x/ad469x.c
+++ b/drivers/adc/ad469x/ad469x.c
@@ -41,7 +41,7 @@
 #include "no_os_delay.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 #define AD469x_TEST_DATA 0xEA
 
@@ -1061,7 +1061,7 @@ int32_t ad469x_init(struct ad469x_dev **device,
 	uint8_t max_data_ch;
 	uint32_t sample_frequncy_ksps;
 
-	dev = (struct ad469x_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad469x_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -1171,7 +1171,7 @@ error_clkgen:
 	axi_clkgen_remove(dev->clkgen);
 #endif
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -1216,7 +1216,7 @@ int32_t ad469x_remove(struct ad469x_dev *dev)
 		return ret;
 #endif
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/adc/ad6673/ad6673.c
+++ b/drivers/adc/ad6673/ad6673.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include "ad6673.h"
 #include "ad6673_cfg.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 static const int32_t shadow_regs[SHADOW_REGISTER_COUNT] = {
 	0,
@@ -79,7 +79,7 @@ int32_t ad6673_setup(struct ad6673_dev **device,
 	int32_t ret = 0;
 	int8_t i = 0;
 
-	dev = (struct ad6673_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad6673_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -178,7 +178,7 @@ int32_t ad6673_remove(struct ad6673_dev *dev)
 
 	ret = no_os_spi_remove(dev->spi_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/adc/ad6676/ad6676.c
+++ b/drivers/adc/ad6676/ad6676.c
@@ -35,7 +35,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "ad6676.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 
 /***************************************************************************//**
@@ -637,7 +637,7 @@ int32_t ad6676_setup(struct ad6676_dev **device,
 	uint8_t scale;
 	struct ad6676_dev *dev;
 
-	dev = (struct ad6676_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad6676_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 

--- a/drivers/adc/ad7091r/ad7091r.c
+++ b/drivers/adc/ad7091r/ad7091r.c
@@ -33,7 +33,7 @@
 
 #include <stdlib.h>
 #include "ad7091r.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 
 /***************************************************************************//**
@@ -57,7 +57,7 @@ int8_t ad7091r_init(struct ad7091r_dev **device,
 	uint8_t status = 0;
 	uint8_t tmp_val = 0xFF;
 
-	dev = (struct ad7091r_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad7091r_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -87,7 +87,7 @@ int32_t ad7091r_remove(struct ad7091r_dev *dev)
 
 	ret = no_os_spi_remove(dev->spi_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/adc/ad7091r5/ad7091r5.c
+++ b/drivers/adc/ad7091r5/ad7091r5.c
@@ -38,7 +38,7 @@
 #include "no_os_error.h"
 #include "no_os_delay.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * Read from device.
@@ -533,7 +533,7 @@ int32_t ad7091r5_init(struct ad7091r5_dev **device,
 	if (!device || !init_param)
 		return -EINVAL;
 
-	dev = (struct ad7091r5_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad7091r5_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -560,7 +560,7 @@ error_i2c:
 error_gpio:
 	no_os_gpio_remove(dev->gpio_resetn);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -585,7 +585,7 @@ int32_t ad7091r5_remove(struct ad7091r5_dev *dev)
 	if (ret < 0)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/adc/ad7091r8/ad7091r8.c
+++ b/drivers/adc/ad7091r8/ad7091r8.c
@@ -35,7 +35,7 @@
 #include <errno.h>
 
 #include "ad7091r8.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
 #include "no_os_delay.h"
@@ -386,7 +386,7 @@ int ad7091r8_init(struct ad7091r8_dev **device,
 	if (!device)
 		return -EINVAL;
 
-	dev = (struct ad7091r8_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ad7091r8_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -444,7 +444,7 @@ err_release_spi:
 	no_os_spi_remove(dev->spi_desc);
 
 err_free_dev:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -471,7 +471,7 @@ int ad7091r8_remove(struct ad7091r8_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 	return 0;
 }
 

--- a/drivers/adc/ad7091r8/iio_ad7091r8.c
+++ b/drivers/adc/ad7091r8/iio_ad7091r8.c
@@ -38,7 +38,7 @@
 #include "iio_ad7091r8.h"
 #include "ad7091r8.h"
 #include "no_os_units.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 static int ad7091r8_iio_read_reg(void *dev, uint32_t reg,
 				 uint32_t *readval);
@@ -298,7 +298,7 @@ int ad7091r8_iio_init(struct ad7091r8_iio_dev **iio_dev,
 	if (!init_param || !init_param->ad7091r8_dev_init)
 		return -EINVAL;
 
-	desc = (struct ad7091r8_iio_dev *)no_os_calloc(1, sizeof(*desc));
+	desc = (struct ad7091r8_iio_dev *)capi_calloc(1, sizeof(*desc));
 	if (!desc)
 		return -ENOMEM;
 
@@ -327,7 +327,7 @@ int ad7091r8_iio_init(struct ad7091r8_iio_dev **iio_dev,
 	return 0;
 
 error_ad7091r8_init:
-	no_os_free(desc);
+	capi_free(desc);
 	return ret;
 }
 
@@ -346,7 +346,7 @@ int ad7091r8_iio_remove(struct ad7091r8_iio_dev *desc)
 	if (ret)
 		return ret;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/adc/ad7124/ad7124.c
+++ b/drivers/adc/ad7124/ad7124.c
@@ -35,7 +35,7 @@
 #include <stdbool.h>
 #include "ad7124.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 
 /*
@@ -1484,7 +1484,7 @@ int32_t ad7124_setup(struct ad7124_dev **device,
 	uint8_t setup_index;
 	uint8_t ch_index;
 
-	dev = (struct ad7124_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad7124_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -1640,7 +1640,7 @@ int32_t ad7124_remove(struct ad7124_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/adc/ad713x/ad713x.c
+++ b/drivers/adc/ad713x/ad713x.c
@@ -42,7 +42,7 @@
 #include "ad713x.h"
 #include "no_os_delay.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 static const int ad713x_output_data_frame[4][9][2] = {
 	{
@@ -543,7 +543,7 @@ int32_t ad713x_init(struct ad713x_dev **device,
 	int32_t ret;
 	uint8_t data;
 
-	dev = (struct ad713x_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ad713x_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -552,7 +552,7 @@ int32_t ad713x_init(struct ad713x_dev **device,
 		if (NO_OS_IS_ERR_VALUE(ret))
 			goto error_dev;
 	} else {
-		dev->spi_desc = no_os_calloc(1, sizeof * dev->spi_desc);
+		dev->spi_desc = capi_calloc(1, sizeof * dev->spi_desc);
 		if (!dev->spi_desc)
 			goto error_dev;
 		dev->spi_desc->chip_select = init_param->spi_init_prm.chip_select;
@@ -640,7 +640,7 @@ int32_t ad713x_remove(struct ad713x_dev *dev)
 	if (NO_OS_IS_ERR_VALUE(ret))
 		return -1;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/adc/ad713x/iio_ad713x.c
+++ b/drivers/adc/ad713x/iio_ad713x.c
@@ -41,7 +41,7 @@
 #include "iio_ad713x.h"
 #include "iio_types.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "spi_engine.h"
 
 #define MEGA 1000000UL
@@ -483,7 +483,7 @@ int iio_ad713x_init(struct ad713x_iio **desc,
 	if (!param)
 		return -EINVAL;
 
-	device = (struct ad713x_iio *)no_os_calloc(1, sizeof(*device));
+	device = (struct ad713x_iio *)capi_calloc(1, sizeof(*device));
 	if (!device)
 		return -1;
 
@@ -516,7 +516,7 @@ int iio_ad713x_init(struct ad713x_iio **desc,
 
 	return 0;
 dev_err:
-	no_os_free(device);
+	capi_free(device);
 
 	return ret;
 }
@@ -531,7 +531,7 @@ int iio_ad713x_remove(struct ad713x_iio *desc)
 	if (!desc)
 		return -EINVAL;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/adc/ad713x/iio_dual_ad713x.c
+++ b/drivers/adc/ad713x/iio_dual_ad713x.c
@@ -43,7 +43,7 @@
 #include "spi_engine.h"
 #include "iio_dual_ad713x.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 #define BITS_PER_SAMPLE 32
 
@@ -149,7 +149,7 @@ int32_t iio_dual_ad713x_init(struct iio_ad713x **desc,
 {
 	struct iio_ad713x *iio_ad713x;
 
-	iio_ad713x = (struct iio_ad713x *)no_os_calloc(1, sizeof(struct iio_ad713x));
+	iio_ad713x = (struct iio_ad713x *)capi_calloc(1, sizeof(struct iio_ad713x));
 	if (!iio_ad713x)
 		return -1;
 
@@ -179,7 +179,7 @@ int32_t iio_dual_ad713x_remove(struct iio_ad713x *desc)
 	if (!desc)
 		return -1;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/adc/ad717x/ad717x.c
+++ b/drivers/adc/ad717x/ad717x.c
@@ -37,7 +37,7 @@
 #include <stdlib.h>
 #include "ad717x.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /* Error codes */
 #define INVALID_VAL -1 /* Invalid argument */
@@ -786,7 +786,7 @@ int32_t AD717X_Init(ad717x_dev **device,
 	uint8_t setup_index;
 	uint8_t ch_index;
 
-	dev = (ad717x_dev *)no_os_malloc(sizeof(*dev));
+	dev = (ad717x_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -910,7 +910,7 @@ int32_t AD717X_remove(ad717x_dev *dev)
 
 	ret = no_os_spi_remove(dev->spi_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/adc/ad719x/ad719x.c
+++ b/drivers/adc/ad719x/ad719x.c
@@ -35,7 +35,7 @@
 #include "ad719x.h"    // AD719X definitions.
 #include "no_os_error.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include <string.h>
 
 /***************************************************************************//**
@@ -55,7 +55,7 @@ int ad719x_init(struct ad719x_dev **device,
 	uint32_t reg_val;
 	int ret;
 
-	dev = (struct ad719x_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad719x_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -167,7 +167,7 @@ error_miso:
 error_spi:
 	no_os_spi_remove(dev->spi_desc);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return -1;
 }
@@ -191,7 +191,7 @@ int ad719x_remove(struct ad719x_dev *dev)
 	if (ret != 0)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/adc/ad7280a/ad7280a.c
+++ b/drivers/adc/ad7280a/ad7280a.c
@@ -34,7 +34,7 @@
 
 #include <stdlib.h>
 #include "ad7280a.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 
 /******************************************************************************
@@ -55,7 +55,7 @@ int8_t ad7280a_init(struct ad7280a_dev **device,
 	int8_t status;
 	uint32_t value;
 
-	dev = (struct ad7280a_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad7280a_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -124,7 +124,7 @@ int32_t ad7280a_remove(struct ad7280a_dev *dev)
 	ret |= no_os_gpio_remove(dev->gpio_cnvst);
 	ret |= no_os_gpio_remove(dev->gpio_alert);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/adc/ad738x/ad738x.c
+++ b/drivers/adc/ad738x/ad738x.c
@@ -42,7 +42,7 @@
 #include "ad738x.h"
 #include "no_os_delay.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_pwm.h"
 /**
  * Read from device.
@@ -428,7 +428,7 @@ int32_t ad738x_init(struct ad738x_dev **device,
 	struct ad738x_dev *dev;
 	int32_t ret = 0;
 
-	dev = (struct ad738x_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ad738x_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -511,7 +511,7 @@ int32_t ad738x_remove(struct ad738x_dev *dev)
 
 	ret |= no_os_pwm_remove(dev->pwm_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/adc/ad738x/iio_ad738x.c
+++ b/drivers/adc/ad738x/iio_ad738x.c
@@ -19,7 +19,7 @@
 #include "iio_ad738x.h"
 #include "iio.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #if !defined(USE_STANDARD_SPI)
 #include "spi_engine.h"
@@ -122,7 +122,7 @@ static struct iio_channel *ad738x_iio_alloc_channels(uint8_t num_channels,
 	struct iio_channel *channels;
 	int i;
 
-	channels = no_os_calloc(num_channels, sizeof(*channels));
+	channels = capi_calloc(num_channels, sizeof(*channels));
 	if (!channels)
 		return NULL;
 
@@ -279,7 +279,7 @@ int ad738x_iio_init(struct ad738x_iio_dev **dev,
 	uint8_t storage_bits;
 	int ret;
 
-	desc = no_os_calloc(1, sizeof(*desc));
+	desc = capi_calloc(1, sizeof(*desc));
 	if (!desc)
 		return -ENOMEM;
 
@@ -301,7 +301,7 @@ int ad738x_iio_init(struct ad738x_iio_dev **dev,
 #endif
 
 	/* Allocate IIO device structure */
-	iio_dev = no_os_calloc(1, sizeof(*iio_dev));
+	iio_dev = capi_calloc(1, sizeof(*iio_dev));
 	if (!iio_dev) {
 		ret = -ENOMEM;
 		goto error_dev;
@@ -327,11 +327,11 @@ int ad738x_iio_init(struct ad738x_iio_dev **dev,
 	return 0;
 
 error_iio_dev:
-	no_os_free(iio_dev);
+	capi_free(iio_dev);
 error_dev:
 	ad738x_remove(desc->ad738x_dev);
 error_desc:
-	no_os_free(desc);
+	capi_free(desc);
 	return ret;
 }
 
@@ -342,14 +342,14 @@ int ad738x_iio_remove(struct ad738x_iio_dev *dev)
 
 	if (dev->iio_dev) {
 		if (dev->iio_dev->channels)
-			no_os_free(dev->iio_dev->channels);
-		no_os_free(dev->iio_dev);
+			capi_free(dev->iio_dev->channels);
+		capi_free(dev->iio_dev);
 	}
 
 	if (dev->ad738x_dev)
 		ad738x_remove(dev->ad738x_dev);
 
-	no_os_free(dev);
+	capi_free(dev);
 	return 0;
 }
 

--- a/drivers/adc/ad7490/ad7490.c
+++ b/drivers/adc/ad7490/ad7490.c
@@ -31,7 +31,7 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 #include "ad7490.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_delay.h"
 
@@ -431,7 +431,7 @@ int ad7490_init(struct ad7490_desc **desc,
 	uint16_t reg_val;
 	int ret;
 
-	descriptor = (struct ad7490_desc *)no_os_calloc(1, sizeof(*descriptor));
+	descriptor = (struct ad7490_desc *)capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -463,7 +463,7 @@ int ad7490_init(struct ad7490_desc **desc,
 free_spi:
 	no_os_spi_remove(descriptor->spi_desc);
 free_desc:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -478,7 +478,7 @@ int ad7490_remove(struct ad7490_desc *desc)
 	ad7490_stop_seq(desc);
 	ad7490_set_op_mode(desc, AD7490_MODE_FULLSHUTDOWN);
 	no_os_spi_remove(desc->spi_desc);
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/adc/ad7490/iio_ad7490.c
+++ b/drivers/adc/ad7490/iio_ad7490.c
@@ -32,7 +32,7 @@
 ******************************************************************************/
 #include <string.h>
 #include "iio_ad7490.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 
 #define AD7490_V_FS_2V5		2500
@@ -385,7 +385,7 @@ int ad7490_iio_init(struct ad7490_iio_desc **iio_desc,
 	struct ad7490_iio_desc *iio_descriptor;
 	int ret;
 
-	iio_descriptor = (struct ad7490_iio_desc *)no_os_calloc(1,
+	iio_descriptor = (struct ad7490_iio_desc *)capi_calloc(1,
 			 sizeof(*iio_descriptor));
 	if (!iio_descriptor)
 		return -ENOMEM;
@@ -410,7 +410,7 @@ int ad7490_iio_init(struct ad7490_iio_desc **iio_desc,
 free_ad7490:
 	ad7490_remove(iio_descriptor->ad7490_desc);
 free_desc:
-	no_os_free(iio_descriptor);
+	capi_free(iio_descriptor);
 
 	return 0;
 }
@@ -418,7 +418,7 @@ free_desc:
 int ad7490_iio_remove(struct ad7490_iio_desc *iio_desc)
 {
 	ad7490_remove(iio_desc->ad7490_desc);
-	no_os_free(iio_desc);
+	capi_free(iio_desc);
 
 	return 0;
 }

--- a/drivers/adc/ad74xx/ad74xx.c
+++ b/drivers/adc/ad74xx/ad74xx.c
@@ -33,7 +33,7 @@
 
 #include <stdlib.h>
 #include "ad74xx.h"		// AD74xx definitions.
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /***************************************************************************//**
  * @brief Initializes the communication peripheral and the initial Values for
@@ -55,7 +55,7 @@ int8_t ad74xx_init(struct ad74xx_dev **device,
 	struct ad74xx_dev *dev;
 	uint8_t status;
 
-	dev = (struct ad74xx_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad74xx_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -92,7 +92,7 @@ int32_t ad74xx_remove(struct ad74xx_dev *dev)
 
 	status = no_os_gpio_remove(dev->gpio_cs);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return status;
 }

--- a/drivers/adc/ad7606/ad7606.c
+++ b/drivers/adc/ad7606/ad7606.c
@@ -40,7 +40,7 @@
 #include "no_os_error.h"
 #include "no_os_util.h"
 #include "no_os_crc.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 #ifdef XILINX_PLATFORM
 #include "no_os_axi_io.h"
@@ -1783,7 +1783,7 @@ int32_t ad7606_init(struct ad7606_dev **device,
 	no_os_crc8_populate_msb(ad7606_crc8, 0x7);
 	no_os_crc16_populate_msb(ad7606_crc16, 0x755b);
 
-	dev = (struct ad7606_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ad7606_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -2033,7 +2033,7 @@ int32_t ad7606_remove(struct ad7606_dev *dev)
 	ad7606_axi_remove(dev);
 #endif
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/adc/ad7606/iio_ad7606.c
+++ b/drivers/adc/ad7606/iio_ad7606.c
@@ -18,7 +18,7 @@
 #include "iio_ad7606.h"
 #include "iio.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 
 #define AD7606_CH(_idx, bits) {\
@@ -98,7 +98,7 @@ static int get_raw(void *device,
 	uint32_t *res;
 	int ret;
 
-	res = no_os_calloc(num_chan, sizeof(*res));
+	res = capi_calloc(num_chan, sizeof(*res));
 	if (!res)
 		return -ENOMEM;
 
@@ -115,7 +115,7 @@ static int get_raw(void *device,
 	ret = sprintf(buf, "%ld", no_os_sign_extend32(res[channel->ch_num],
 			iio_dev->sign_bit));
 error:
-	no_os_free(res);
+	capi_free(res);
 
 	return ret;
 }
@@ -440,7 +440,7 @@ int ad7606_iio_init(struct ad7606_iio_dev **dev,
 	struct ad7606_iio_dev *desc;
 	int ret;
 
-	desc = no_os_calloc(1, sizeof(*desc));
+	desc = capi_calloc(1, sizeof(*desc));
 	if (!desc)
 		return -ENOMEM;
 
@@ -460,7 +460,7 @@ int ad7606_iio_init(struct ad7606_iio_dev **dev,
 	return 0;
 
 error_setup:
-	no_os_free(desc);
+	capi_free(desc);
 	return ret;
 }
 
@@ -471,7 +471,7 @@ int ad7606_iio_remove(struct ad7606_iio_dev *dev)
 
 	ad7606_remove(dev->ad7606_dev);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/adc/ad7616/ad7616.c
+++ b/drivers/adc/ad7616/ad7616.c
@@ -46,7 +46,7 @@
 #include "no_os_gpio.h"
 #include "no_os_error.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_util.h"
 
 #ifdef XILINX_PLATFORM
@@ -942,7 +942,7 @@ int32_t ad7616_setup(struct ad7616_dev **device,
 	uint8_t i;
 	int32_t ret = 0;
 
-	dev = (struct ad7616_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ad7616_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev) {
 		return -1;
 	}
@@ -1081,5 +1081,5 @@ void ad7616_remove(struct ad7616_dev *dev)
 	no_os_gpio_remove(dev->gpio_convst);
 	no_os_gpio_remove(dev->gpio_busy);
 
-	no_os_free(dev);
+	capi_free(dev);
 }

--- a/drivers/adc/ad7616/iio_ad7616.c
+++ b/drivers/adc/ad7616/iio_ad7616.c
@@ -19,7 +19,7 @@
 #include "iio_ad7616.h"
 #include "iio.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 
 #define AD7616_CH(_idx) {\
@@ -314,7 +314,7 @@ static int iio_ad7616_submit_buffer(struct iio_device_data *iio_dev_data)
 	uint32_t j;
 	uint32_t k;
 
-	results = no_os_calloc(dev->layers_nb * iio_dev_data->buffer->samples, sizeof(
+	results = capi_calloc(dev->layers_nb * iio_dev_data->buffer->samples, sizeof(
 				       *results));
 	if (!results)
 		return -ENOMEM;
@@ -354,7 +354,7 @@ static int iio_ad7616_submit_buffer(struct iio_device_data *iio_dev_data)
 	return 0;
 
 cleanup:
-	no_os_free(results);
+	capi_free(results);
 	return ret;
 }
 
@@ -427,7 +427,7 @@ int ad7616_iio_init(struct ad7616_iio_dev **dev,
 		{ AD7616_VA6, AD7616_VB6 },
 		{ AD7616_VA7, AD7616_VB7 },
 	};
-	struct ad7616_iio_dev *desc = no_os_calloc(1, sizeof(*desc));
+	struct ad7616_iio_dev *desc = capi_calloc(1, sizeof(*desc));
 	if (!desc)
 		return -ENOMEM;
 
@@ -444,7 +444,7 @@ int ad7616_iio_init(struct ad7616_iio_dev **dev,
 	return 0;
 
 error_setup:
-	no_os_free(desc);
+	capi_free(desc);
 	return ret;
 }
 
@@ -455,7 +455,7 @@ int ad7616_iio_remove(struct ad7616_iio_dev *dev)
 
 	ad7616_remove(dev->ad7616_dev);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/adc/ad7689/ad7689.c
+++ b/drivers/adc/ad7689/ad7689.c
@@ -36,7 +36,7 @@
 #include "no_os_error.h"
 #include "no_os_print_log.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 const char *ad7689_device_name[] = {
 	"AD7689",
@@ -147,7 +147,7 @@ int32_t ad7689_init(struct ad7689_dev **dev,
 	if (init_param->id > ID_AD7699)
 		return -EINVAL;
 
-	d = (struct ad7689_dev *)no_os_calloc(1, sizeof(*d));
+	d = (struct ad7689_dev *)capi_calloc(1, sizeof(*d));
 	if (!d)
 		return -ENOMEM;
 
@@ -173,7 +173,7 @@ int32_t ad7689_init(struct ad7689_dev **dev,
 error_init:
 	no_os_spi_remove(d->spi_desc);
 error_spi:
-	no_os_free(d);
+	capi_free(d);
 	pr_err("%s initialization failed with status %d\n", d->name,
 	       ret);
 
@@ -282,7 +282,7 @@ int32_t ad7689_remove(struct ad7689_dev *dev)
 		return -EINVAL;
 
 	no_os_spi_remove(dev->spi_desc);
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/adc/ad7768-1/ad77681.c
+++ b/drivers/adc/ad7768-1/ad77681.c
@@ -38,7 +38,7 @@
 #include "ad77681.h"
 #include "no_os_error.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * Compute CRC8 checksum.
@@ -1750,14 +1750,14 @@ int32_t ad77681_setup(struct ad77681_dev **device,
 	int32_t ret;
 	uint8_t scratchpad_check = 0xAD;
 
-	dev = (struct ad77681_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad77681_dev *)capi_malloc(sizeof(*dev));
 	if (!dev) {
 		return -1;
 	}
 
-	stat = (struct ad77681_status_registers *)no_os_malloc(sizeof(*stat));
+	stat = (struct ad77681_status_registers *)capi_malloc(sizeof(*stat));
 	if (!stat) {
-		no_os_free(dev);
+		capi_free(dev);
 		return -1;
 	}
 
@@ -1783,8 +1783,8 @@ int32_t ad77681_setup(struct ad77681_dev **device,
 
 	ret = no_os_spi_init(&dev->spi_desc, &init_param.spi_eng_dev_init);
 	if (ret < 0) {
-		no_os_free(dev);
-		no_os_free(stat);
+		capi_free(dev);
+		capi_free(stat);
 		return ret;
 	}
 
@@ -1797,8 +1797,8 @@ int32_t ad77681_setup(struct ad77681_dev **device,
 		scratchpad_check = 0xAD;/* If failure, second try */
 		ret |= (ad77681_scratchpad(dev, &scratchpad_check));
 		if (ret == -1) {
-			no_os_free(dev);
-			no_os_free(stat);
+			capi_free(dev);
+			capi_free(stat);
 			return ret;
 		}
 	}

--- a/drivers/adc/ad7768/ad7768.c
+++ b/drivers/adc/ad7768/ad7768.c
@@ -34,7 +34,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "ad7768.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
 #include "no_os_delay.h"
@@ -634,7 +634,7 @@ int32_t ad7768_setup(ad7768_dev **device,
 error:
 	no_os_spi_remove(dev->spi_desc);
 	no_os_gpio_remove(dev->gpio_reset);
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -652,7 +652,7 @@ int32_t ad7768_setup_begin(ad7768_dev **device,
 	ad7768_dev *dev;
 	int32_t ret;
 
-	dev = (ad7768_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (ad7768_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev) {
 		return -ENOMEM;
 	}
@@ -684,7 +684,7 @@ int32_t ad7768_setup_begin(ad7768_dev **device,
 error_1:
 	no_os_spi_remove(dev->spi_desc);
 error:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -928,7 +928,7 @@ int ad7768_remove(ad7768_dev *dev)
 		no_os_gpio_remove(dev->gpio_mode3);
 	}
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/adc/ad7779/ad7779.c
+++ b/drivers/adc/ad7779/ad7779.c
@@ -36,7 +36,7 @@
 #include "ad7779.h"
 #include "no_os_util.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 const uint8_t pin_mode_options[16][4] = {
 	/*GAIN_1, GAIN_2, GAIN_4, GAIN_8 */
@@ -1476,7 +1476,7 @@ int32_t ad7779_init(ad7779_dev **device,
 	uint8_t i;
 	int32_t ret;
 
-	dev = (ad7779_dev *)no_os_malloc(sizeof(*dev));
+	dev = (ad7779_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -1635,7 +1635,7 @@ int32_t ad7779_remove(ad7779_dev *dev)
 	ret |= no_os_gpio_remove(dev->gpio_sync_in);
 	ret |= no_os_gpio_remove(dev->gpio_convst_sar);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/adc/ad7780/ad7780.c
+++ b/drivers/adc/ad7780/ad7780.c
@@ -33,7 +33,7 @@
 
 #include <stdlib.h>
 #include "ad7780.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 
 /***************************************************************************//**
@@ -57,7 +57,7 @@ int8_t ad7780_init(struct ad7780_dev **device,
 	uint8_t ad7780status;
 	int8_t init_status;
 
-	dev = (struct ad7780_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad7780_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -119,7 +119,7 @@ int32_t ad7780_remove(struct ad7780_dev *dev)
 	ret |= no_os_gpio_remove(dev->gpio_filter);
 	ret |= no_os_gpio_remove(dev->gpio_gain);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/adc/ad7799/ad7799.c
+++ b/drivers/adc/ad7799/ad7799.c
@@ -36,7 +36,7 @@
 #include <string.h>
 #include "no_os_error.h"
 #include "ad7799.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 static const uint8_t ad7798_reg_size[] = {
 	[AD7799_REG_COMM] = AD7799_REG_SIZE_1B,
@@ -386,7 +386,7 @@ int32_t ad7799_init(struct ad7799_dev **device,
 	uint32_t chip_id = 0;
 
 
-	dev = (struct ad7799_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ad7799_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -404,13 +404,13 @@ int32_t ad7799_init(struct ad7799_dev **device,
 		dev->reg_size = ad7799_reg_size;
 		break;
 	default:
-		no_os_free(dev);
+		capi_free(dev);
 		return -EINVAL;
 	}
 
 	ret = no_os_spi_init(&dev->spi_desc, &init_param->spi_init);
 	if (ret) {
-		no_os_free(dev);
+		capi_free(dev);
 		return ret;
 	}
 
@@ -460,7 +460,7 @@ int32_t ad7799_init(struct ad7799_dev **device,
 
 error_spi:
 	no_os_spi_remove(dev->spi_desc);
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -477,7 +477,7 @@ int32_t ad7799_remove(struct ad7799_dev *device)
 		return -EINVAL;
 
 	ret = no_os_spi_remove(device->spi_desc);
-	no_os_free(device);
+	capi_free(device);
 
 	return ret;
 }

--- a/drivers/adc/ad796x/ad796x.c
+++ b/drivers/adc/ad796x/ad796x.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include "ad796x.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_print_log.h"
 
 #define AD796X_BYTES_PER_SAMPLE		4
@@ -151,7 +151,7 @@ int ad796x_init(struct ad796x_dev **device,
 	struct ad796x_dev *dev;
 	int ret;
 
-	dev = (struct ad796x_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ad796x_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -236,7 +236,7 @@ int ad796x_remove(struct ad796x_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/adc/ad7980/ad7980.c
+++ b/drivers/adc/ad7980/ad7980.c
@@ -33,7 +33,7 @@
 
 #include <stdlib.h>
 #include "ad7980.h"           // AD7980 definitions.
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 
 /***************************************************************************//**
@@ -53,7 +53,7 @@ int8_t ad7980_init(struct ad7980_dev **device,
 	struct ad7980_dev *dev;
 	uint8_t status;
 
-	dev = (struct ad7980_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad7980_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -89,7 +89,7 @@ int32_t ad7980_remove(struct ad7980_dev *dev)
 
 	ret |= no_os_gpio_remove(dev->gpio_cs);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/adc/ad799x/ad799x.c
+++ b/drivers/adc/ad799x/ad799x.c
@@ -33,7 +33,7 @@
 
 #include <stdlib.h>
 #include "ad799x.h"    // AD799x definitions.
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /***************************************************************************//**
  * @brief Initializes I2C.
@@ -52,7 +52,7 @@ int8_t ad799x_init(struct ad799x_dev **device,
 	struct ad799x_dev *dev;
 	int8_t status = -1;
 
-	dev = (struct ad799x_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad799x_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -90,7 +90,7 @@ int32_t ad799x_remove(struct ad799x_dev *dev)
 
 	ret = no_os_i2c_remove(dev->i2c_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/adc/ad9081/ad9081.c
+++ b/drivers/adc/ad9081/ad9081.c
@@ -37,7 +37,7 @@
 #include "adi_cms_api_common.h"
 #include "no_os_util.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "adi_ad9081_hal.h"
 #include "no_os_print_log.h"
 #include "ad9081.h"
@@ -1453,7 +1453,7 @@ int32_t ad9081_init(struct ad9081_phy **dev,
 	uint8_t api_rev[3];
 	int32_t ret;
 
-	phy = (struct ad9081_phy *)no_os_calloc(1, sizeof(*phy));
+	phy = (struct ad9081_phy *)capi_calloc(1, sizeof(*phy));
 	if (!phy)
 		return -1;
 
@@ -1618,7 +1618,7 @@ error_1:
 		no_os_gpio_remove(phy->lf_output_pin);
 	if (phy->lf_input_pin)
 		no_os_gpio_remove(phy->lf_input_pin);
-	no_os_free(phy);
+	capi_free(phy);
 
 	return ret;
 }
@@ -1634,7 +1634,7 @@ int32_t ad9081_remove(struct ad9081_phy *dev)
 
 	ret = no_os_gpio_remove(dev->gpio_reset);
 	ret += no_os_spi_remove(dev->spi_desc);
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/adc/ad9083/ad9083.c
+++ b/drivers/adc/ad9083/ad9083.c
@@ -41,7 +41,7 @@
 #include "no_os_clk.h"
 #include "uc_settings.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_print_log.h"
 
 extern int32_t adi_ad9083_jtx_startup(adi_ad9083_device_t *device,
@@ -327,7 +327,7 @@ int32_t ad9083_init(struct ad9083_phy **device,
 	uint8_t api_rev[3];
 	int32_t ret;
 
-	phy = (struct ad9083_phy *)no_os_calloc(1, sizeof(*phy));
+	phy = (struct ad9083_phy *)capi_calloc(1, sizeof(*phy));
 	if (!phy)
 		return -ENOMEM;
 
@@ -406,7 +406,7 @@ error_2:
 	no_os_gpio_remove(phy->gpio_reset);
 error_1:
 	if (phy)
-		no_os_free(phy);
+		capi_free(phy);
 
 	return ret;
 }
@@ -435,7 +435,7 @@ int32_t ad9083_remove(struct ad9083_phy *dev)
 	if (ret != 0)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/adc/ad9208/ad9208.c
+++ b/drivers/adc/ad9208/ad9208.c
@@ -37,7 +37,7 @@
 #include "ad9208.h"
 #include <inttypes.h>
 #include "api_def.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * Spi write and read compatible with ad9208 API
@@ -51,7 +51,7 @@ static int ad9208_spi_xfer(void *user_data, uint8_t *wbuf,
 			   uint8_t *rbuf, int len)
 {
 	struct no_os_spi_desc *spi = user_data;
-	uint8_t * buffer = (uint8_t *) no_os_malloc(len);
+	uint8_t * buffer = (uint8_t *) capi_malloc(len);
 	int32_t ret;
 
 	if (!buffer)
@@ -65,7 +65,7 @@ static int ad9208_spi_xfer(void *user_data, uint8_t *wbuf,
 	else
 		memcpy(rbuf, buffer, len);
 
-	no_os_free(buffer);
+	capi_free(buffer);
 
 	return ret;
 }
@@ -375,11 +375,11 @@ int32_t ad9208_initialize(ad9208_dev **device, ad9208_init_param *init_param)
 	ad9208_dev *dev;
 	int32_t i, ret;
 
-	dev = (ad9208_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (ad9208_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
-	dev->st = (struct ad9208_state *)no_os_calloc(1, sizeof(*dev->st));
+	dev->st = (struct ad9208_state *)capi_calloc(1, sizeof(*dev->st));
 	if (!dev->st) {
 		ret = -ENOMEM;
 		goto error;
@@ -402,19 +402,19 @@ int32_t ad9208_initialize(ad9208_dev **device, ad9208_init_param *init_param)
 	if (ret < 0)
 		goto error;
 
-	struct ad9208_state *st = (struct ad9208_state *)no_os_calloc(1, sizeof(*st));
+	struct ad9208_state *st = (struct ad9208_state *)capi_calloc(1, sizeof(*st));
 	if (!st) {
 		ret = -ENOMEM;
 		goto error;
 	}
 
-	st->jesd_param = (jesd_param_t *)no_os_calloc(1, sizeof(*st->jesd_param));
+	st->jesd_param = (jesd_param_t *)capi_calloc(1, sizeof(*st->jesd_param));
 	if (!st->jesd_param) {
 		ret = -ENOMEM;
 		goto error;
 	}
 
-	st->adc_h = (ad9208_handle_t *)no_os_calloc(1, sizeof(*st->adc_h));
+	st->adc_h = (ad9208_handle_t *)capi_calloc(1, sizeof(*st->adc_h));
 	if (!st->adc_h) {
 		ret = -ENOMEM;
 		goto error;
@@ -476,19 +476,19 @@ int32_t ad9208_initialize(ad9208_dev **device, ad9208_init_param *init_param)
 
 error:
 	if (st->adc_h)
-		no_os_free(st->adc_h);
+		capi_free(st->adc_h);
 	if (st->jesd_param)
-		no_os_free(st->jesd_param);
+		capi_free(st->jesd_param);
 	if (st)
-		no_os_free(st);
+		capi_free(st);
 	if (dev->gpio_powerdown)
 		no_os_gpio_remove(dev->gpio_powerdown);
 	if (dev->spi_desc)
 		no_os_spi_remove(dev->spi_desc);
 	if (dev->st)
-		no_os_free(dev->st);
+		capi_free(dev->st);
 	if (dev)
-		no_os_free(dev);
+		capi_free(dev);
 
 	return ret;
 }
@@ -501,11 +501,11 @@ int32_t ad9208_remove(ad9208_dev *device)
 	ret |= no_os_spi_remove(device->spi_desc);
 
 	if (device->st->adc_h)
-		no_os_free(device->st->adc_h);
+		capi_free(device->st->adc_h);
 	if (device->st)
-		no_os_free(device->st);
+		capi_free(device->st);
 	if (device)
-		no_os_free(device);
+		capi_free(device);
 
 	return ret;
 }

--- a/drivers/adc/ad9250/ad9250.c
+++ b/drivers/adc/ad9250/ad9250.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include "ad9250.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 const int32_t shadow_regs[SHADOW_REGISTER_COUNT] = {
 	0,
@@ -76,7 +76,7 @@ int32_t ad9250_setup(struct ad9250_dev **device,
 	struct ad9250_dev *dev;
 	int32_t ret, i;
 
-	dev = (struct ad9250_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad9250_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -178,7 +178,7 @@ int32_t ad9250_remove(struct ad9250_dev *dev)
 
 	ret = no_os_spi_remove(dev->spi_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/adc/ad9265/ad9265.c
+++ b/drivers/adc/ad9265/ad9265.c
@@ -35,7 +35,7 @@
 #include <stdlib.h>
 #include "axi_adc_core.h"
 #include "ad9265.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 #define DCO_DEBUG
 
@@ -283,7 +283,7 @@ int32_t ad9265_setup(struct ad9265_dev **device,
 	int32_t ret;
 	struct ad9265_dev *dev;
 
-	dev = (struct ad9265_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad9265_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -321,7 +321,7 @@ int32_t ad9265_remove(struct ad9265_dev *dev)
 
 	ret = no_os_spi_remove(dev->spi_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/adc/ad9434/ad9434.c
+++ b/drivers/adc/ad9434/ad9434.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "ad9434.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 
 #define DCO_DEBUG
@@ -139,7 +139,7 @@ int32_t ad9434_setup(struct ad9434_dev **device,
 	int32_t ret = 0;
 	struct ad9434_dev *dev;
 
-	dev = (struct ad9434_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad9434_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -173,7 +173,7 @@ int32_t ad9434_remove(struct ad9434_dev *dev)
 
 	ret = no_os_spi_remove(dev->spi_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/adc/ad9467/ad9467.c
+++ b/drivers/adc/ad9467/ad9467.c
@@ -33,7 +33,7 @@
 
 #include <stdlib.h>
 #include "ad9467.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 
 /***************************************************************************//**
@@ -51,7 +51,7 @@ int32_t ad9467_setup(struct ad9467_dev **device,
 	int32_t ret = 0;
 	struct ad9467_dev *dev;
 
-	dev = (struct ad9467_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad9467_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -92,7 +92,7 @@ int32_t ad9467_remove(struct ad9467_dev *dev)
 
 	ret = no_os_spi_remove(dev->spi_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/adc/ad9625/ad9625.c
+++ b/drivers/adc/ad9625/ad9625.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "ad9625.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 
 /***************************************************************************//**
@@ -91,7 +91,7 @@ int32_t ad9625_setup(struct ad9625_dev **device,
 	int32_t ret;
 	struct ad9625_dev *dev;
 
-	dev = (struct ad9625_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad9625_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -147,7 +147,7 @@ int32_t ad9625_remove(struct ad9625_dev *dev)
 
 	ret = no_os_spi_remove(dev->spi_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/adc/ad9656/ad9656.c
+++ b/drivers/adc/ad9656/ad9656.c
@@ -37,7 +37,7 @@
 #include "no_os_error.h"
 #include "ad9656.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Reads from the ad9656 that is contected to the SPI
@@ -186,7 +186,7 @@ int32_t ad9656_setup(struct ad9656_dev **device,
 	struct ad9656_dev *dev;
 	uint8_t tmp;
 
-	dev = (struct ad9656_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ad9656_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -280,7 +280,7 @@ int32_t ad9656_setup(struct ad9656_dev **device,
 error_comm:
 	no_os_spi_remove(dev->spi_desc);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -296,7 +296,7 @@ int32_t ad9656_remove(struct ad9656_dev *dev)
 	ret = no_os_spi_remove(dev->spi_desc);
 
 	if (ret == 0)
-		no_os_free(dev);
+		capi_free(dev);
 
 	return ret;
 }

--- a/drivers/adc/ad9680/ad9680.c
+++ b/drivers/adc/ad9680/ad9680.c
@@ -36,7 +36,7 @@
 #include "ad9680.h"
 #include "no_os_error.h"
 #include "no_os_print_log.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 struct ad9680_jesd204_priv {
 	struct ad9680_dev *dev;
@@ -224,7 +224,7 @@ int32_t ad9680_setup(struct ad9680_dev **device,
 
 	ret = 0;
 
-	dev = (struct ad9680_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad9680_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -299,7 +299,7 @@ int32_t ad9680_setup_jesd_fsm(struct ad9680_dev **device,
 
 	ret = 0;
 
-	dev = (struct ad9680_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad9680_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -387,7 +387,7 @@ int32_t ad9680_remove(struct ad9680_dev *dev)
 
 	ret = no_os_spi_remove(dev->spi_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/adc/adaq7980/adaq7980.c
+++ b/drivers/adc/adaq7980/adaq7980.c
@@ -36,7 +36,7 @@
 #include "adaq7980.h"
 #include "no_os_error.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Read from device.
@@ -84,7 +84,7 @@ int32_t adaq7980_setup(struct adaq7980_dev **device,
 	struct adaq7980_dev *dev;
 	int32_t ret;
 
-	dev = (struct adaq7980_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct adaq7980_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -123,7 +123,7 @@ int32_t adaq7980_setup(struct adaq7980_dev **device,
 error_spi:
 	no_os_spi_remove(dev->spi_desc);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return -1;
 }

--- a/drivers/adc/adaq8092/adaq8092.c
+++ b/drivers/adc/adaq8092/adaq8092.c
@@ -35,7 +35,7 @@
 #include <errno.h>
 #include "adaq8092.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /******************************************************************************/
 
@@ -116,7 +116,7 @@ int adaq8092_init(struct adaq8092_dev **device,
 	struct adaq8092_dev *dev;
 	int ret;
 
-	dev = (struct adaq8092_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct adaq8092_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -249,7 +249,7 @@ error_adc_pd1:
 error_spi:
 	no_os_spi_remove(dev->spi_desc);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -283,7 +283,7 @@ int adaq8092_remove(struct adaq8092_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/adc/adc_demo/adc_demo.c
+++ b/drivers/adc/adc_demo/adc_demo.c
@@ -37,7 +37,7 @@
 #include "adc_demo.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /* default sine lookup table to be used if ext_buff is not available */
 const uint16_t sine_lut[128] = {
@@ -69,7 +69,7 @@ int32_t adc_demo_init(struct adc_demo_desc **desc,
 		      struct adc_demo_init_param *param)
 {
 	struct adc_demo_desc *adesc;
-	adesc = (struct adc_demo_desc*)no_os_calloc(1, sizeof(*adesc));
+	adesc = (struct adc_demo_desc*)capi_calloc(1, sizeof(*adesc));
 
 	if (!adesc)
 		return -ENOMEM;
@@ -94,7 +94,7 @@ int32_t adc_demo_remove(struct adc_demo_desc *desc)
 	if (!desc)
 		return -EINVAL;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/adc/adm1177/adm1177.c
+++ b/drivers/adc/adm1177/adm1177.c
@@ -32,7 +32,7 @@
 ******************************************************************************/
 #include <stdlib.h>
 #include "adm1177.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 #include "no_os_error.h"
 
@@ -53,14 +53,14 @@ int adm1177_init(struct adm1177_dev **device,
 	struct adm1177_dev *dev;
 	int status;
 
-	dev = (struct adm1177_dev *)no_os_calloc(sizeof(*dev), 1);
+	dev = (struct adm1177_dev *)capi_calloc(sizeof(*dev), 1);
 	if (!dev)
 		return -ENOMEM;
 
 	/* Initialize I2C peripheral */
 	status = no_os_i2c_init(&dev->i2c_desc, &init_param->i2c_init);
 	if (status) {
-		no_os_free(dev);
+		capi_free(dev);
 		return status;
 	}
 
@@ -82,7 +82,7 @@ int adm1177_remove(struct adm1177_dev *device)
 
 	ret = no_os_i2c_remove(device->i2c_desc);
 
-	no_os_free(device);
+	capi_free(device);
 
 	return ret;
 }

--- a/drivers/adc/adm1177/iio_adm1177.c
+++ b/drivers/adc/adm1177/iio_adm1177.c
@@ -34,7 +34,7 @@
 #include "adm1177.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 static struct scan_type adm1177_iio_scan_type = {
 	.sign = 'u',
@@ -225,7 +225,7 @@ int adm1177_iio_init(struct adm1177_iio_dev **iio_dev,
 	int ret;
 	struct adm1177_iio_dev *desc;
 
-	desc = (struct adm1177_iio_dev *)no_os_calloc(1, sizeof(*desc));
+	desc = (struct adm1177_iio_dev *)capi_calloc(1, sizeof(*desc));
 	if (!desc)
 		return -ENOMEM;
 
@@ -244,7 +244,7 @@ int adm1177_iio_init(struct adm1177_iio_dev **iio_dev,
 
 	return 0;
 error_desc:
-	no_os_free(desc);
+	capi_free(desc);
 
 	return ret;
 }
@@ -257,7 +257,7 @@ int adm1177_iio_remove(struct adm1177_iio_dev *desc)
 	if (ret)
 		return ret;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/adc/ltc2312/ltc2312.c
+++ b/drivers/adc/ltc2312/ltc2312.c
@@ -47,7 +47,7 @@ ongoing work.
 #include <stdlib.h>
 #include <math.h>
 #include "ltc2312.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * Initializes the ltc2312 device handler.
@@ -64,7 +64,7 @@ int32_t ltc2312_setup(struct ltc2312_dev **device,
 	struct ltc2312_dev *dev;
 	int32_t ret;
 
-	dev = no_os_malloc(sizeof(*dev));
+	dev = capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -78,7 +78,7 @@ int32_t ltc2312_setup(struct ltc2312_dev **device,
 
 	return ret;
 error:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -101,7 +101,7 @@ int32_t ltc2312_remove(struct ltc2312_dev *dev)
 	if (ret != 0)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/adc/ltc2358/ltc2358.c
+++ b/drivers/adc/ltc2358/ltc2358.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include "ltc2358.h"
 #include "errno.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Create 24-bit configuration word for the 8 channels.
@@ -113,7 +113,7 @@ int32_t ltc2358_init(struct ltc2358_dev **device,
 	struct ltc2358_dev *dev;
 	int32_t ret;
 
-	dev = (struct ltc2358_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ltc2358_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -125,7 +125,7 @@ int32_t ltc2358_init(struct ltc2358_dev **device,
 
 	return ret;
 error:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }
@@ -146,7 +146,7 @@ int32_t ltc2358_remove(struct ltc2358_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/adc/ltc2378/iio_ltc2378.c
+++ b/drivers/adc/ltc2378/iio_ltc2378.c
@@ -33,7 +33,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
@@ -250,7 +250,7 @@ int ltc2378_iio_init(struct ltc2378_iio_desc **iio_desc,
 	if (!iio_desc || !init_param || !init_param->ltc2378_init_param)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -265,7 +265,7 @@ int ltc2378_iio_init(struct ltc2378_iio_desc **iio_desc,
 	return 0;
 
 error_free_desc:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 	return ret;
 }
 
@@ -280,7 +280,7 @@ int ltc2378_iio_remove(struct ltc2378_iio_desc *iio_desc)
 		return -EINVAL;
 
 	ltc2378_remove(iio_desc->ltc2378_dev);
-	no_os_free(iio_desc);
+	capi_free(iio_desc);
 
 	return 0;
 }

--- a/drivers/adc/ltc2378/ltc2378.c
+++ b/drivers/adc/ltc2378/ltc2378.c
@@ -33,7 +33,7 @@
 
 #include "ltc2378.h"
 #include <stdlib.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 #include "no_os_util.h"
 
@@ -52,7 +52,7 @@ int ltc2378_init(struct ltc2378_dev **device,
 	if (!device || !init_param)
 		return -EINVAL;
 
-	dev = (struct ltc2378_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ltc2378_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -91,7 +91,7 @@ error_cnv:
 error_spi:
 	no_os_spi_remove(dev->spi_desc);
 error:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -109,7 +109,7 @@ int ltc2378_remove(struct ltc2378_dev *dev)
 	no_os_gpio_remove(dev->gpio_cnv);
 	if (dev->gpio_busy)
 		no_os_gpio_remove(dev->gpio_busy);
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/adc/max11205/iio_max11205.c
+++ b/drivers/adc/max11205/iio_max11205.c
@@ -36,7 +36,7 @@
 #include "iio_max11205.h"
 #include "errno.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 #define MAX11205_BIT_SCALE		15
 #define MAX11205_NEW_DATA_TIMEOUT	12000000
@@ -248,7 +248,7 @@ int max11205_iio_init(struct max11205_iio_dev **iio_dev,
 	int ret;
 	struct max11205_iio_dev *desc;
 
-	desc = (struct max11205_iio_dev *)no_os_calloc(1, sizeof(*desc));
+	desc = (struct max11205_iio_dev *)capi_calloc(1, sizeof(*desc));
 	if (!desc)
 		return -ENOMEM;
 
@@ -267,7 +267,7 @@ int max11205_iio_init(struct max11205_iio_dev **iio_dev,
 	return 0;
 
 error_max11205_init:
-	no_os_free(desc);
+	capi_free(desc);
 	return ret;
 }
 
@@ -284,7 +284,7 @@ int max11205_iio_remove(struct max11205_iio_dev *desc)
 	if (ret)
 		return ret;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/adc/max11205/max11205.c
+++ b/drivers/adc/max11205/max11205.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include "max11205.h"
 #include "errno.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief GPIO interrupt handler for data ready.
@@ -87,7 +87,7 @@ int max11205_init(struct max11205_dev **device,
 	if (init_param.vref_mv > MAX11205_VREF_MAX_MV)
 		return -EINVAL;
 
-	dev = (struct max11205_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct max11205_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -146,7 +146,7 @@ error_gpio:
 error_spi:
 	no_os_spi_remove(dev->spi_desc);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -216,7 +216,7 @@ int max11205_remove(struct max11205_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/adc/max14001/max14001.c
+++ b/drivers/adc/max14001/max14001.c
@@ -36,7 +36,7 @@
 #include "no_os_delay.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Read from device.
@@ -188,7 +188,7 @@ int max14001_init(struct max14001_dev **device,
 
 	no_os_mdelay(100);
 
-	dev = (struct max14001_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct max14001_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -201,7 +201,7 @@ int max14001_init(struct max14001_dev **device,
 	return ret;
 
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 
@@ -669,7 +669,7 @@ int max14001_remove(struct max14001_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/adc/max9611pmb/max9611.c
+++ b/drivers/adc/max9611pmb/max9611.c
@@ -38,7 +38,7 @@
 #include "no_os_util.h"
 #include "no_os_error.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "max9611.h"
 
 /***************************************************************************//**
@@ -97,7 +97,7 @@ int max9611_init(struct max9611_dev **device,
 	int ret;
 	struct max9611_dev *dev;
 
-	dev = (struct max9611_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct max9611_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -110,7 +110,7 @@ int max9611_init(struct max9611_dev **device,
 	return 0;
 
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -125,7 +125,7 @@ int max9611_remove(struct max9611_dev *dev)
 	int ret;
 
 	ret = no_os_i2c_remove(dev->i2c_desc);
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/adc/pulsar_adc/iio_pulsar_adc.c
+++ b/drivers/adc/pulsar_adc/iio_pulsar_adc.c
@@ -38,7 +38,7 @@
 #include "iio_pulsar_adc.h"
 #include "iio.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 
 /**
@@ -182,7 +182,7 @@ int pulsar_adc_iio_init(struct pulsar_adc_iio_dev **dev,
 	struct pulsar_adc_iio_dev *desc;
 	int ret;
 
-	desc = no_os_calloc(1, sizeof(*desc));
+	desc = capi_calloc(1, sizeof(*desc));
 	if (!desc)
 		return -ENOMEM;
 
@@ -206,7 +206,7 @@ int pulsar_adc_iio_init(struct pulsar_adc_iio_dev **dev,
 	return 0;
 
 error_setup:
-	no_os_free(desc);
+	capi_free(desc);
 	return ret;
 }
 
@@ -222,6 +222,6 @@ int pulsar_adc_iio_remove(struct pulsar_adc_iio_dev *iio_dev)
 
 	pulsar_adc_remove(iio_dev->pulsar_adc_dev);
 
-	no_os_free(iio_dev);
+	capi_free(iio_dev);
 	return 0;
 }

--- a/drivers/adc/pulsar_adc/pulsar_adc.c
+++ b/drivers/adc/pulsar_adc/pulsar_adc.c
@@ -43,7 +43,7 @@
 #include "spi_engine.h"
 #endif
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_util.h"
 
 const struct pulsar_adc_dev_info pulsar_adc_devices[] = {
@@ -304,7 +304,7 @@ int32_t pulsar_adc_init(struct pulsar_adc_dev **device,
 	if (!init_param)
 		return -1;
 
-	dev = (struct pulsar_adc_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct pulsar_adc_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -405,7 +405,7 @@ int32_t pulsar_adc_remove(struct pulsar_adc_dev *dev)
 #endif
 	ret = no_os_spi_remove(dev->spi_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/afe/ad4110/ad4110.c
+++ b/drivers/afe/ad4110/ad4110.c
@@ -37,7 +37,7 @@
 #include <stdlib.h>
 #include "ad4110.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_irq.h"
 #include "no_os_print_log.h"
@@ -886,7 +886,7 @@ int32_t ad4110_setup(struct ad4110_dev **device,
 {
 	struct ad4110_dev *dev;
 	int32_t ret;
-	dev = (struct ad4110_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad4110_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -1017,7 +1017,7 @@ int32_t ad4110_setup(struct ad4110_dev **device,
 err_spi:
 	no_os_spi_remove(dev->spi_dev);
 err_dev:
-	no_os_free(dev);
+	capi_free(dev);
 	pr_err("AD4110 initialization error (%d)\n", ret);
 	return ret;
 }
@@ -1084,7 +1084,7 @@ int32_t ad4110_remove(struct ad4110_dev *dev)
 
 	ret = no_os_spi_remove(dev->spi_dev);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/afe/ad413x/ad413x.c
+++ b/drivers/afe/ad413x/ad413x.c
@@ -40,7 +40,7 @@
 #include "no_os_delay.h"
 #include "no_os_crc8.h"
 #include "no_os_spi.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 NO_OS_DECLARE_CRC8_TABLE(ad413x_crc8);
 uint32_t timeout = 0xFFFFFF;
@@ -920,7 +920,7 @@ int32_t ad413x_init(struct ad413x_dev **device,
 
 	no_os_crc8_populate_msb(ad413x_crc8, AD413X_CRC8_POLY);
 
-	dev = (struct ad413x_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad413x_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -1065,7 +1065,7 @@ err_gpio:
 err_spi:
 	no_os_spi_remove(dev->spi_dev);
 err_dev:
-	no_os_free(dev);
+	capi_free(dev);
 	pr_err("AD413X initialization error (%d)\n", ret);
 	return ret;
 }
@@ -1085,7 +1085,7 @@ int32_t ad413x_remove(struct ad413x_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/afe/ad413x/iio_ad413x.c
+++ b/drivers/afe/ad413x/iio_ad413x.c
@@ -8,7 +8,7 @@
 #include "iio.h"
 #include "iio_ad413x.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "ad413x.h"
 
 struct scan_type ad413x_iio_scan_type = {
@@ -435,7 +435,7 @@ int32_t ad413x_iio_init(struct ad413x_iio_dev **iio_dev,
 	int32_t ret;
 	struct ad413x_iio_dev *desc;
 
-	desc = (struct ad413x_iio_dev *)no_os_calloc(1, sizeof(*desc));
+	desc = (struct ad413x_iio_dev *)capi_calloc(1, sizeof(*desc));
 	if (!desc)
 		return -1;
 
@@ -449,7 +449,7 @@ int32_t ad413x_iio_init(struct ad413x_iio_dev **iio_dev,
 
 	return 0;
 error_desc:
-	no_os_free(desc);
+	capi_free(desc);
 
 	return ret;
 }
@@ -462,7 +462,7 @@ int32_t ad413x_iio_remove(struct ad413x_iio_dev *desc)
 	if (ret != 0)
 		return ret;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/afe/ad5940/ad5940.c
+++ b/drivers/afe/ad5940/ad5940.c
@@ -39,7 +39,7 @@
 #include "no_os_delay.h"
 #include "no_os_spi.h"
 #include "no_os_gpio.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "ad5940.h"
 
 static int AD5940_Initialize(struct ad5940_dev *dev);
@@ -83,7 +83,7 @@ int ad5940_init(struct ad5940_dev **device,
 	if (!device || !init_param)
 		return -EINVAL;
 
-	dev = (struct ad5940_dev *) no_os_calloc(1, sizeof(struct ad5940_dev));
+	dev = (struct ad5940_dev *) capi_calloc(1, sizeof(struct ad5940_dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -183,7 +183,7 @@ error_2:
 error_1:
 	no_os_spi_remove(dev->spi);
 error:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -195,7 +195,7 @@ int ad5940_remove(struct ad5940_dev *dev)
 	no_os_gpio_remove(dev->reset_gpio);
 	no_os_spi_remove(dev->spi);
 	dev->spi = NULL;
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }
@@ -657,7 +657,7 @@ static int AD5940_FIFORd_Fast(struct no_os_spi_desc *spi, uint32_t *pBuffer,
 	uint32_t s = 0;
 
 	if (!iobuf_alloc_sz) {
-		iobuf = no_os_malloc(iobuf_sz);
+		iobuf = capi_malloc(iobuf_sz);
 		if (!iobuf)
 			return -ENOMEM;
 	}

--- a/drivers/afe/ad5940/iio_ad5940.c
+++ b/drivers/afe/ad5940/iio_ad5940.c
@@ -37,7 +37,7 @@
 #include "no_os_error.h"
 #include "no_os_delay.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "iio.h"
 #include "iio_ad5940.h"
 #include "bia_measurement.h"
@@ -295,13 +295,13 @@ int32_t ad5940_iio_init(struct ad5940_iio_dev **iio_dev,
 	if (!iio_dev || !init_param)
 		return -EINVAL;
 
-	desc = (struct ad5940_iio_dev *)no_os_calloc(1, sizeof(*desc));
+	desc = (struct ad5940_iio_dev *)capi_calloc(1, sizeof(*desc));
 	if (!desc)
 		return -ENOMEM;
 
 	desc->iio = &ad5940_iio_device;
 
-	desc->iio->channels = (struct iio_channel *)no_os_calloc(1,
+	desc->iio->channels = (struct iio_channel *)capi_calloc(1,
 			      sizeof(struct iio_channel));
 	if (!desc->iio->channels)
 		goto error_1;
@@ -348,9 +348,9 @@ int32_t ad5940_iio_init(struct ad5940_iio_dev **iio_dev,
 
 	return 0;
 error_2:
-	no_os_free(desc->iio->channels);
+	capi_free(desc->iio->channels);
 error_1:
-	no_os_free(desc);
+	capi_free(desc);
 
 	return ret;
 }
@@ -363,8 +363,8 @@ int32_t ad5940_iio_remove(struct ad5940_iio_dev *desc)
 	if (ret != 0)
 		return ret;
 
-	no_os_free(desc->iio->channels);
-	no_os_free(desc);
+	capi_free(desc->iio->channels);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/afe/max30009/max30009.c
+++ b/drivers/afe/max30009/max30009.c
@@ -35,7 +35,7 @@
 #include <string.h>
 #include <errno.h>
 #include "max30009.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 #include "no_os_error.h"
 #include "no_os_print_log.h"
@@ -62,7 +62,7 @@ static int max30009_spi_reg_access(struct max30009_dev *device,
 	uint32_t i;
 	int ret;
 
-	buf = no_os_calloc(len + 2, sizeof(*buf));
+	buf = capi_calloc(len + 2, sizeof(*buf));
 	if (!buf)
 		return -ENOMEM;
 
@@ -81,7 +81,7 @@ static int max30009_spi_reg_access(struct max30009_dev *device,
 			data[i] = buf[2 + i]; /* Data is on 3rd byte */
 	}
 
-	no_os_free(buf);
+	capi_free(buf);
 
 	return ret;
 }
@@ -113,7 +113,7 @@ static int max30009_i2c_reg_access(struct max30009_dev *device,
 		return no_os_i2c_read(device->i2c_desc, data, len, 1);
 	}
 
-	buf = no_os_calloc(len + 1, sizeof(*buf));
+	buf = capi_calloc(len + 1, sizeof(*buf));
 	if (!buf)
 		return -ENOMEM;
 
@@ -122,7 +122,7 @@ static int max30009_i2c_reg_access(struct max30009_dev *device,
 		buf[1 + i] = data[i];
 
 	ret = no_os_i2c_write(device->i2c_desc, buf, len + 1, 1);
-	no_os_free(buf);
+	capi_free(buf);
 
 	return ret;
 }
@@ -328,11 +328,11 @@ int max30009_init(struct max30009_dev **device,
 	if (!device || !init_param)
 		return -EINVAL;
 
-	dev = (struct max30009_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct max30009_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
-	dev->fifo_read_buf = no_os_calloc(
+	dev->fifo_read_buf = capi_calloc(
 				     MAX30009_FIFO_DEPTH * MAX30009_FIFO_DATA_SIZE,
 				     sizeof(*dev->fifo_read_buf));
 	if (!dev->fifo_read_buf) {
@@ -395,8 +395,8 @@ error_csb_gpio:
 	if (dev->csb_gpio_desc)
 		no_os_gpio_remove(dev->csb_gpio_desc);
 error_alloc:
-	no_os_free(dev->fifo_read_buf);
-	no_os_free(dev);
+	capi_free(dev->fifo_read_buf);
+	capi_free(dev);
 	return ret;
 }
 
@@ -426,8 +426,8 @@ int max30009_remove(struct max30009_dev *device)
 	else if (device->i2c_desc)
 		ret |= no_os_i2c_remove(device->i2c_desc);
 
-	no_os_free(device->fifo_read_buf);
-	no_os_free(device);
+	capi_free(device->fifo_read_buf);
+	capi_free(device);
 
 	return ret;
 }

--- a/drivers/amplifiers/ada4250/ada4250.c
+++ b/drivers/amplifiers/ada4250/ada4250.c
@@ -35,7 +35,7 @@
 #include "ada4250.h"
 #include "no_os_delay.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Writes data to ada4250 over SPI.
@@ -515,7 +515,7 @@ int32_t ada4250_init(struct ada4250_dev **device,
 	uint16_t chip_id;
 	struct ada4250_dev *dev;
 
-	dev = (struct ada4250_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ada4250_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -646,7 +646,7 @@ error_slp:
 error_shtdwn:
 	no_os_gpio_remove(dev->gpio_shtdwn);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -688,7 +688,7 @@ int32_t ada4250_remove(struct ada4250_dev *dev)
 			return ret;
 	}
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/amplifiers/adhv4710/adhv4710.c
+++ b/drivers/amplifiers/adhv4710/adhv4710.c
@@ -41,7 +41,7 @@
 #include "no_os_irq.h"
 #include "no_os_delay.h"
 #include "no_os_units.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_crc16.h"
 #include "no_os_print_log.h"
 #include <stdlib.h>
@@ -71,7 +71,7 @@ int adhv4710_init(struct adhv4710_dev **device,
 	/* value read from register */
 	uint8_t reg_val;
 
-	dev = (struct adhv4710_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct adhv4710_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -110,7 +110,7 @@ int adhv4710_init(struct adhv4710_dev **device,
 error_spi:
 	no_os_spi_remove(dev->spi_desc);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -254,7 +254,7 @@ int adhv4710_remove(struct adhv4710_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/amplifiers/adhv4710/adhv4710.h
+++ b/drivers/amplifiers/adhv4710/adhv4710.h
@@ -42,7 +42,7 @@
 #include "no_os_irq.h"
 #include "no_os_delay.h"
 #include "no_os_units.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_crc16.h"
 #include "no_os_print_log.h"
 #include <stdlib.h>

--- a/drivers/amplifiers/adl8113/adl8113.c
+++ b/drivers/amplifiers/adl8113/adl8113.c
@@ -35,7 +35,7 @@
 #include <stdlib.h>
 #include "adl8113.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * Set operation mode (LNA or Bypass).
@@ -129,7 +129,7 @@ int adl8113_init(struct adl8113_dev **device,
 	if (!device || !init_param)
 		return -EINVAL;
 
-	dev = (struct adl8113_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct adl8113_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -162,7 +162,7 @@ error_config:
 error_vb:
 	no_os_gpio_remove(dev->gpio_va);
 error_va:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -180,7 +180,7 @@ int adl8113_remove(struct adl8113_dev *dev)
 	no_os_gpio_remove(dev->gpio_va);
 	no_os_gpio_remove(dev->gpio_vb);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/amplifiers/adl8113/iio_adl8113.c
+++ b/drivers/amplifiers/adl8113/iio_adl8113.c
@@ -34,7 +34,7 @@
 #include <stdio.h>
 
 #include "iio_adl8113.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
 
@@ -222,7 +222,7 @@ static int adl8113_iio_init_gain_configs(struct adl8113_iio_dev *desc,
 	if (init_param->has_external_bypass_b)
 		n++;
 
-	desc->gain_configs = no_os_calloc(n, sizeof(*desc->gain_configs));
+	desc->gain_configs = capi_calloc(n, sizeof(*desc->gain_configs));
 	if (!desc->gain_configs)
 		return -ENOMEM;
 
@@ -278,7 +278,7 @@ int adl8113_iio_init(struct adl8113_iio_dev **iio_dev,
 	if (!iio_dev || !init_param || !init_param->adl8113_init_param)
 		return -EINVAL;
 
-	desc = no_os_calloc(1, sizeof(*desc));
+	desc = capi_calloc(1, sizeof(*desc));
 	if (!desc)
 		return -ENOMEM;
 
@@ -297,9 +297,9 @@ int adl8113_iio_init(struct adl8113_iio_dev **iio_dev,
 	return 0;
 
 err_gain:
-	no_os_free(desc->gain_configs);
+	capi_free(desc->gain_configs);
 err_desc:
-	no_os_free(desc);
+	capi_free(desc);
 	return ret;
 }
 
@@ -314,8 +314,8 @@ int adl8113_iio_remove(struct adl8113_iio_dev *iio_dev)
 		return -EINVAL;
 
 	adl8113_remove(iio_dev->adl8113_dev);
-	no_os_free(iio_dev->gain_configs);
-	no_os_free(iio_dev);
+	capi_free(iio_dev->gain_configs);
+	capi_free(iio_dev);
 
 	return 0;
 }

--- a/drivers/axi_core/axi_adc_core/axi_adc_core.c
+++ b/drivers/axi_core/axi_adc_core/axi_adc_core.c
@@ -37,7 +37,7 @@
 #include "no_os_error.h"
 #include "no_os_delay.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "axi_adc_core.h"
 #include "no_os_axi_io.h"
 
@@ -586,7 +586,7 @@ int32_t axi_adc_init_begin(struct axi_adc **adc_core,
 {
 	struct axi_adc *adc;
 
-	adc = (struct axi_adc *)no_os_malloc(sizeof(*adc));
+	adc = (struct axi_adc *)capi_malloc(sizeof(*adc));
 	if (!adc)
 		return -1;
 
@@ -665,7 +665,7 @@ int32_t axi_adc_init(struct axi_adc **adc_core,
 
 	return 0;
 error:
-	no_os_free(adc);
+	capi_free(adc);
 
 	return -1;
 }
@@ -677,7 +677,7 @@ error:
  */
 int32_t axi_adc_remove(struct axi_adc *adc)
 {
-	no_os_free(adc);
+	capi_free(adc);
 
 	return 0;
 }

--- a/drivers/axi_core/axi_dac_core/axi_dac_core.c
+++ b/drivers/axi_core/axi_dac_core/axi_dac_core.c
@@ -37,7 +37,7 @@
 #include "no_os_error.h"
 #include "no_os_delay.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "axi_dac_core.h"
 #include "no_os_axi_io.h"
 
@@ -1109,7 +1109,7 @@ int32_t axi_dac_init_begin(struct axi_dac **dac_core,
 {
 	struct axi_dac *dac;
 
-	dac = (struct axi_dac *)no_os_malloc(sizeof(*dac));
+	dac = (struct axi_dac *)capi_malloc(sizeof(*dac));
 	if (!dac)
 		return -1;
 
@@ -1189,7 +1189,7 @@ int32_t axi_dac_init(struct axi_dac **dac_core,
 
 	return 0;
 error:
-	no_os_free(dac);
+	capi_free(dac);
 
 	return -1;
 }
@@ -1246,7 +1246,7 @@ int32_t axi_dac_data_setup(struct axi_dac *dac)
  */
 int32_t axi_dac_remove(struct axi_dac *dac)
 {
-	no_os_free(dac);
+	capi_free(dac);
 
 	return 0;
 }

--- a/drivers/axi_core/axi_dmac/axi_dmac.c
+++ b/drivers/axi_core/axi_dmac/axi_dmac.c
@@ -39,7 +39,7 @@
 #include "no_os_axi_io.h"
 #include "no_os_error.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "axi_dmac.h"
 
 /*******************************************************************************
@@ -328,7 +328,7 @@ int32_t axi_dmac_init(struct axi_dmac **dmac_core,
 {
 	struct axi_dmac *dmac;
 
-	dmac = (struct axi_dmac *)no_os_calloc(1, sizeof(*dmac));
+	dmac = (struct axi_dmac *)capi_calloc(1, sizeof(*dmac));
 	if (!dmac)
 		return -1;
 
@@ -345,7 +345,7 @@ int32_t axi_dmac_init(struct axi_dmac **dmac_core,
 	return 0;
 
 free:
-	no_os_free(dmac);
+	capi_free(dmac);
 	return -1;
 }
 
@@ -361,7 +361,7 @@ int32_t axi_dmac_remove(struct axi_dmac *dmac)
 	if (!dmac)
 		return -1;
 
-	no_os_free(dmac);
+	capi_free(dmac);
 
 	return 0;
 }

--- a/drivers/axi_core/axi_pwmgen/axi_pwm.c
+++ b/drivers/axi_core/axi_pwmgen/axi_pwm.c
@@ -36,7 +36,7 @@
 #include "axi_pwm_extra.h"
 #include "no_os_axi_io.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 
 #define AXI_PWMGEN_REG_CORE_VERSION	0x00
@@ -278,11 +278,11 @@ int32_t axi_pwm_init(struct no_os_pwm_desc **desc,
 
 	axi_init = param->extra;
 
-	pwm_desc = (struct no_os_pwm_desc *)no_os_calloc(1, sizeof(*pwm_desc));
+	pwm_desc = (struct no_os_pwm_desc *)capi_calloc(1, sizeof(*pwm_desc));
 	if (!pwm_desc)
 		return -1;
 
-	axi_desc = (struct axi_pwm_desc *)no_os_calloc(1, sizeof(*axi_desc));
+	axi_desc = (struct axi_pwm_desc *)capi_calloc(1, sizeof(*axi_desc));
 	if (!axi_desc)
 		goto error_desc;
 
@@ -358,9 +358,9 @@ int32_t axi_pwm_init(struct no_os_pwm_desc **desc,
 	return 0;
 
 error_xdesc:
-	no_os_free(axi_desc);
+	capi_free(axi_desc);
 error_desc:
-	no_os_free(pwm_desc);
+	capi_free(pwm_desc);
 
 	return -1;
 }
@@ -384,8 +384,8 @@ int32_t axi_pwm_remove(struct no_os_pwm_desc *desc)
 	if (ret != 0)
 		return -1;
 
-	no_os_free(axi_desc);
-	no_os_free(desc);
+	capi_free(axi_desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/axi_core/axi_sysid/axi_sysid.c
+++ b/drivers/axi_core/axi_sysid/axi_sysid.c
@@ -38,7 +38,7 @@
 #include "no_os_print_log.h"
 #include "no_os_axi_io.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "axi_sysid.h"
 
 static inline uint32_t axi_sysid_ioread(const struct axi_sysid *st,
@@ -166,7 +166,7 @@ static int axi_sysid_validate(struct axi_sysid *st)
 	struct sysid_header_v1 *header;
 	uint32_t *build_raw;
 
-	st->mem = no_os_calloc(st->size, sizeof(uint32_t));
+	st->mem = capi_calloc(st->size, sizeof(uint32_t));
 	if (!st->mem)
 		return -ENOMEM;
 
@@ -215,7 +215,7 @@ int32_t axi_sysid_init(struct axi_sysid **sysid_core,
 	struct axi_sysid *sysid;
 	int ret;
 
-	sysid = (struct axi_sysid *)no_os_calloc(1, sizeof(*sysid));
+	sysid = (struct axi_sysid *)capi_calloc(1, sizeof(*sysid));
 	if (!sysid)
 		return -ENOMEM;
 
@@ -223,7 +223,7 @@ int32_t axi_sysid_init(struct axi_sysid **sysid_core,
 	sysid->size = (1 << axi_sysid_ioread(sysid, AXI_SYSID_REG_ROM_ADDR_WIDTH)) *
 		      AXI_SYSID_WORD_SIZE;
 
-	info = (struct axi_sysid_core_info *)no_os_calloc(1, sizeof(*info));
+	info = (struct axi_sysid_core_info *)capi_calloc(1, sizeof(*info));
 	if (!info) {
 		ret = -ENOMEM;
 		goto error;
@@ -253,9 +253,9 @@ int32_t axi_sysid_init(struct axi_sysid **sysid_core,
 
 	return 0;
 error1:
-	no_os_free(info);
+	capi_free(info);
 error:
-	no_os_free(sysid);
+	capi_free(sysid);
 	return ret;
 }
 
@@ -271,7 +271,7 @@ int32_t axi_sysid_remove(struct axi_sysid *sysid)
 	if (!sysid)
 		return -1;
 
-	no_os_free(sysid);
+	capi_free(sysid);
 
 	return 0;
 }

--- a/drivers/axi_core/clk_altera_a10_fpll/clk_altera_a10_fpll.c
+++ b/drivers/axi_core/clk_altera_a10_fpll/clk_altera_a10_fpll.c
@@ -40,7 +40,7 @@
 #include "io.h"
 #include "no_os_util.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "clk_altera_a10_fpll.h"
 
 #define FPLL_REG_C_COUNTER0			0x10D
@@ -458,7 +458,7 @@ int32_t altera_a10_fpll_init(struct altera_a10_fpll **a10_fpll,
 {
 	struct altera_a10_fpll *fpll;
 
-	fpll = (struct altera_a10_fpll *)no_os_malloc(sizeof(*fpll));
+	fpll = (struct altera_a10_fpll *)capi_malloc(sizeof(*fpll));
 	if (!fpll)
 		return -1;
 
@@ -476,7 +476,7 @@ int32_t altera_a10_fpll_init(struct altera_a10_fpll **a10_fpll,
  */
 int32_t altera_a10_fpll_remove(struct altera_a10_fpll *fpll)
 {
-	no_os_free(fpll);
+	capi_free(fpll);
 
 	return 0;
 }

--- a/drivers/axi_core/clk_axi_clkgen/clk_axi_clkgen.c
+++ b/drivers/axi_core/clk_axi_clkgen/clk_axi_clkgen.c
@@ -38,7 +38,7 @@
 #include <stdlib.h>
 #include <inttypes.h>
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_delay.h"
 #include "no_os_axi_io.h"
@@ -516,7 +516,7 @@ int32_t axi_clkgen_init(struct axi_clkgen **clk,
 {
 	struct axi_clkgen *clkgen;
 
-	clkgen = (struct axi_clkgen *)no_os_malloc(sizeof(*clkgen));
+	clkgen = (struct axi_clkgen *)capi_malloc(sizeof(*clkgen));
 	if (!clkgen)
 		return -1;
 
@@ -534,7 +534,7 @@ int32_t axi_clkgen_init(struct axi_clkgen **clk,
  */
 int32_t axi_clkgen_remove(struct axi_clkgen *clkgen)
 {
-	no_os_free(clkgen);
+	capi_free(clkgen);
 
 	return 0;
 }

--- a/drivers/axi_core/iio_axi_adc/iio_axi_adc.c
+++ b/drivers/axi_core/iio_axi_adc/iio_axi_adc.c
@@ -37,7 +37,7 @@
 #include <stdio.h>
 #include <inttypes.h>
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "iio.h"
 #include "iio_axi_adc.h"
 
@@ -383,10 +383,10 @@ static int iio_axi_adc_delete_device_descriptor(
 		return -1;
 
 	if (desc->dev_descriptor.channels)
-		no_os_free(desc->dev_descriptor.channels);
+		capi_free(desc->dev_descriptor.channels);
 
 	if (desc->ch_names)
-		no_os_free(desc->ch_names);
+		capi_free(desc->ch_names);
 
 	return 0;
 }
@@ -417,12 +417,12 @@ static int32_t iio_axi_adc_create_device_descriptor(
 
 	iio_device->num_ch = desc->adc->num_channels;
 	iio_device->attributes = NULL; /* no device attribute */
-	iio_device->channels = no_os_calloc(iio_device->num_ch,
+	iio_device->channels = capi_calloc(iio_device->num_ch,
 					    sizeof(struct iio_channel));
 	if (!iio_device->channels)
 		goto error;
 
-	desc->ch_names = no_os_calloc(iio_device->num_ch, sizeof(*desc->ch_names));
+	desc->ch_names = capi_calloc(iio_device->num_ch, sizeof(*desc->ch_names));
 	if (!desc->ch_names)
 		goto error;
 
@@ -484,7 +484,7 @@ int32_t iio_axi_adc_init(struct iio_axi_adc_desc **desc,
 	if (!init->rx_adc)
 		return -1;
 
-	iio_axi_adc_inst = (struct iio_axi_adc_desc *)no_os_calloc(1,
+	iio_axi_adc_inst = (struct iio_axi_adc_desc *)capi_calloc(1,
 			   sizeof(struct iio_axi_adc_desc));
 	if (!iio_axi_adc_inst)
 		return -1;
@@ -504,7 +504,7 @@ int32_t iio_axi_adc_init(struct iio_axi_adc_desc **desc,
 	status = iio_axi_adc_create_device_descriptor(iio_axi_adc_inst,
 			&iio_axi_adc_inst->dev_descriptor);
 	if (NO_OS_IS_ERR_VALUE(status)) {
-		no_os_free(iio_axi_adc_inst);
+		capi_free(iio_axi_adc_inst);
 		return status;
 	}
 
@@ -529,7 +529,7 @@ int32_t iio_axi_adc_remove(struct iio_axi_adc_desc *desc)
 	if (status < 0)
 		return status;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/axi_core/iio_axi_dac/iio_axi_dac.c
+++ b/drivers/axi_core/iio_axi_dac/iio_axi_dac.c
@@ -38,7 +38,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "iio.h"
 #include "iio_axi_dac.h"
 
@@ -556,10 +556,10 @@ static int iio_axi_dac_delete_device_descriptor(
 		return -1;
 
 	if (desc->dev_descriptor.channels)
-		no_os_free(desc->dev_descriptor.channels);
+		capi_free(desc->dev_descriptor.channels);
 
 	if (desc->ch_names)
-		no_os_free(desc->ch_names);
+		capi_free(desc->ch_names);
 
 	return 0;
 }
@@ -609,12 +609,12 @@ static int32_t iio_axi_dac_create_device_descriptor(
 	altvoltage_ch_no = desc->dac->num_channels * 2;
 	iio_device->num_ch = voltage_ch_no + altvoltage_ch_no;
 	iio_device->attributes = NULL; /* no device attribute */
-	iio_device->channels = no_os_calloc(iio_device->num_ch,
+	iio_device->channels = capi_calloc(iio_device->num_ch,
 					    sizeof(struct iio_channel));
 	if (!iio_device->channels)
 		goto error;
 
-	desc->ch_names = no_os_calloc(iio_device->num_ch, sizeof(*desc->ch_names));
+	desc->ch_names = capi_calloc(iio_device->num_ch, sizeof(*desc->ch_names));
 	if (!desc->ch_names)
 		goto error;
 
@@ -686,7 +686,7 @@ int32_t iio_axi_dac_init(struct iio_axi_dac_desc **desc,
 	if (!init->tx_dac)
 		return -1;
 
-	iio_axi_dac_inst = (struct iio_axi_dac_desc *)no_os_calloc(1,
+	iio_axi_dac_inst = (struct iio_axi_dac_desc *)capi_calloc(1,
 			   sizeof(struct iio_axi_dac_desc));
 	if (!iio_axi_dac_inst)
 		return -1;
@@ -701,7 +701,7 @@ int32_t iio_axi_dac_init(struct iio_axi_dac_desc **desc,
 	status = iio_axi_dac_create_device_descriptor(iio_axi_dac_inst,
 			&iio_axi_dac_inst->dev_descriptor);
 	if (NO_OS_IS_ERR_VALUE(status)) {
-		no_os_free(iio_axi_dac_inst);
+		capi_free(iio_axi_dac_inst);
 		return status;
 	}
 
@@ -726,7 +726,7 @@ int32_t iio_axi_dac_remove(struct iio_axi_dac_desc *desc)
 	if (status < 0)
 		return status;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/axi_core/jesd204/altera_adxcvr.c
+++ b/drivers/axi_core/jesd204/altera_adxcvr.c
@@ -37,7 +37,7 @@
 #include "io.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "altera_a10_atx_pll.h"
 #include "altera_a10_cdr_pll.h"
 #include "altera_adxcvr.h"
@@ -432,7 +432,7 @@ int32_t adxcvr_init(struct adxcvr **ad_xcvr,
 	uint32_t synth_conf;
 	uint32_t i;
 
-	xcvr = (struct adxcvr *)no_os_malloc(sizeof(*xcvr));
+	xcvr = (struct adxcvr *)capi_malloc(sizeof(*xcvr));
 	if (!xcvr)
 		return -1;
 
@@ -468,7 +468,7 @@ int32_t adxcvr_init(struct adxcvr **ad_xcvr,
 	return 0;
 
 err:
-	no_os_free(xcvr);
+	capi_free(xcvr);
 
 	return -1;
 }
@@ -478,7 +478,7 @@ err:
  */
 int32_t adxcvr_remove(struct adxcvr *xcvr)
 {
-	no_os_free(xcvr);
+	capi_free(xcvr);
 
 	return 0;
 }

--- a/drivers/axi_core/jesd204/axi_adxcvr.c
+++ b/drivers/axi_core/jesd204/axi_adxcvr.c
@@ -36,7 +36,7 @@
 #include <inttypes.h>
 #include "no_os_axi_io.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_delay.h"
 #include "xilinx_transceiver.h"
@@ -563,7 +563,7 @@ int32_t adxcvr_init(struct adxcvr **ad_xcvr,
 	int32_t ret;
 	uint32_t i;
 
-	xcvr = (struct adxcvr *)no_os_calloc(1, sizeof(*xcvr));
+	xcvr = (struct adxcvr *)capi_calloc(1, sizeof(*xcvr));
 	if (!xcvr)
 		return -1;
 
@@ -669,7 +669,7 @@ int32_t adxcvr_init(struct adxcvr **ad_xcvr,
 	return 0;
 
 err:
-	no_os_free(xcvr);
+	capi_free(xcvr);
 
 	return -1;
 }
@@ -681,7 +681,7 @@ err:
  */
 int32_t adxcvr_remove(struct adxcvr *xcvr)
 {
-	no_os_free(xcvr);
+	capi_free(xcvr);
 
 	return 0;
 }

--- a/drivers/axi_core/jesd204/axi_jesd204_rx.c
+++ b/drivers/axi_core/jesd204/axi_jesd204_rx.c
@@ -38,7 +38,7 @@
 #include "no_os_error.h"
 #include "no_os_delay.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "axi_jesd204_rx.h"
 #include "no_os_axi_io.h"
 #include "no_os_print_log.h"
@@ -873,7 +873,7 @@ int32_t axi_jesd204_rx_init_legacy(struct axi_jesd204_rx **jesd204,
 	uint32_t status;
 	uint32_t tmp;
 
-	jesd = (struct axi_jesd204_rx *)no_os_malloc(sizeof(*jesd));
+	jesd = (struct axi_jesd204_rx *)capi_malloc(sizeof(*jesd));
 	if (!jesd)
 		return -1;
 
@@ -929,7 +929,7 @@ int32_t axi_jesd204_rx_init_legacy(struct axi_jesd204_rx **jesd204,
 	return 0;
 
 err:
-	no_os_free(jesd);
+	capi_free(jesd);
 
 	return -1;
 }
@@ -950,7 +950,7 @@ int32_t axi_jesd204_rx_init(struct axi_jesd204_rx **jesd204,
 	uint32_t tmp;
 	int ret = -ENODEV;
 
-	jesd = (struct axi_jesd204_rx *)no_os_calloc(1, sizeof(*jesd));
+	jesd = (struct axi_jesd204_rx *)capi_calloc(1, sizeof(*jesd));
 	if (!jesd)
 		return -ENOMEM;
 
@@ -1024,7 +1024,7 @@ int32_t axi_jesd204_rx_init(struct axi_jesd204_rx **jesd204,
 	return 0;
 
 err:
-	no_os_free(jesd);
+	capi_free(jesd);
 
 	return ret;
 }
@@ -1036,7 +1036,7 @@ err:
  */
 int32_t axi_jesd204_rx_remove(struct axi_jesd204_rx *jesd)
 {
-	no_os_free(jesd);
+	capi_free(jesd);
 
 	return 0;
 }

--- a/drivers/axi_core/jesd204/axi_jesd204_tx.c
+++ b/drivers/axi_core/jesd204/axi_jesd204_tx.c
@@ -37,7 +37,7 @@
 #include "no_os_clk.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "axi_jesd204_tx.h"
 #include "no_os_axi_io.h"
 #include "no_os_delay.h"
@@ -764,7 +764,7 @@ int32_t axi_jesd204_tx_init_legacy(struct axi_jesd204_tx **jesd204,
 	uint32_t status;
 	uint32_t tmp;
 
-	jesd = (struct axi_jesd204_tx *)no_os_malloc(sizeof(*jesd));
+	jesd = (struct axi_jesd204_tx *)capi_malloc(sizeof(*jesd));
 	if (!jesd)
 		return -1;
 
@@ -833,7 +833,7 @@ int32_t axi_jesd204_tx_init_legacy(struct axi_jesd204_tx **jesd204,
 	return 0;
 
 err:
-	no_os_free(jesd);
+	capi_free(jesd);
 
 	return -1;
 }
@@ -855,7 +855,7 @@ int32_t axi_jesd204_tx_init(struct axi_jesd204_tx **jesd204,
 	uint32_t tmp;
 	int ret = -ENODEV;
 
-	jesd = (struct axi_jesd204_tx *)no_os_calloc(1, sizeof(*jesd));
+	jesd = (struct axi_jesd204_tx *)capi_calloc(1, sizeof(*jesd));
 	if (!jesd)
 		return -ENOMEM;
 
@@ -942,7 +942,7 @@ int32_t axi_jesd204_tx_init(struct axi_jesd204_tx **jesd204,
 	return 0;
 
 err:
-	no_os_free(jesd);
+	capi_free(jesd);
 
 	return ret;
 }
@@ -954,7 +954,7 @@ err:
  */
 int32_t axi_jesd204_tx_remove(struct axi_jesd204_tx *jesd)
 {
-	no_os_free(jesd);
+	capi_free(jesd);
 
 	return 0;
 }

--- a/drivers/axi_core/jesd204/jesd204_clk.c
+++ b/drivers/axi_core/jesd204/jesd204_clk.c
@@ -32,7 +32,7 @@
 *******************************************************************************/
 
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_clk.h"
 #include "jesd204_clk.h"
 
@@ -130,7 +130,7 @@ static int jesd204_no_os_clk_init(struct no_os_clk_desc **desc,
 		return -EINVAL;
 	}
 
-	*desc = no_os_calloc(1, sizeof(**desc));
+	*desc = capi_calloc(1, sizeof(**desc));
 	/* Exit if memory cannot be allocated */
 	if (!*desc)
 		goto error;
@@ -143,7 +143,7 @@ static int jesd204_no_os_clk_init(struct no_os_clk_desc **desc,
 	(*desc)->name = init_param->name;
 	(*desc)->hw_ch_num = init_param->hw_ch_num;
 
-	(*desc)->dev_desc = (void *)no_os_calloc(1, sizeof(struct jesd204_clk));
+	(*desc)->dev_desc = (void *)capi_calloc(1, sizeof(struct jesd204_clk));
 
 	(*desc)->dev_desc = init_param->dev_desc;
 

--- a/drivers/axi_core/spi_engine/spi_engine.c
+++ b/drivers/axi_core/spi_engine/spi_engine.c
@@ -48,7 +48,7 @@ significant delays */
 #include "axi_dmac.h"
 #include "no_os_axi_io.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_util.h"
 #include "spi_engine.h"
 
@@ -224,7 +224,7 @@ static int32_t spi_engine_queue_new_cmd(struct spi_engine_cmd_queue **fifo,
 {
 	struct spi_engine_cmd_queue *local_fifo;
 
-	local_fifo = (spi_engine_cmd_queue*)no_os_malloc(sizeof(*local_fifo));
+	local_fifo = (spi_engine_cmd_queue*)capi_malloc(sizeof(*local_fifo));
 
 	if (!local_fifo)
 		return -1;
@@ -298,9 +298,9 @@ static int32_t spi_engine_queue_get_cmd(struct spi_engine_cmd_queue **fifo,
 	*cmd = local_fifo->cmd;
 	if ((*fifo)->next) {
 		*fifo = local_fifo->next;
-		no_os_free(local_fifo);
+		capi_free(local_fifo);
 	} else {
-		no_os_free(*fifo);
+		capi_free(*fifo);
 		*fifo = NULL;
 	}
 
@@ -318,7 +318,7 @@ static int32_t spi_engine_queue_no_os_free(struct spi_engine_cmd_queue **fifo)
 	if (*fifo && (*fifo)->next)
 		spi_engine_queue_no_os_free(&(*fifo)->next);
 	if ((*fifo) != NULL) {
-		no_os_free(*fifo);
+		capi_free(*fifo);
 		*fifo = NULL;
 	}
 
@@ -624,13 +624,13 @@ int32_t spi_engine_init(struct no_os_spi_desc **desc,
 		return -1;
 	}
 
-	*desc = no_os_malloc(sizeof(**desc));
+	*desc = capi_malloc(sizeof(**desc));
 	if (! *desc) {
-		no_os_free(*desc);
+		capi_free(*desc);
 		return -1;
 	}
 
-	eng_desc = (struct spi_engine_desc*)no_os_malloc(sizeof(*eng_desc));
+	eng_desc = (struct spi_engine_desc*)capi_malloc(sizeof(*eng_desc));
 
 	if (!eng_desc)
 		return -1;
@@ -706,12 +706,12 @@ int32_t spi_engine_write_and_read(struct no_os_spi_desc *desc,
 
 	words_number = spi_get_words_number(desc_extra, bytes_number);
 
-	msg.cmds = (spi_engine_cmd_queue*)no_os_malloc(sizeof(*msg.cmds));
+	msg.cmds = (spi_engine_cmd_queue*)capi_malloc(sizeof(*msg.cmds));
 	if (!msg.cmds)
 		return -1;
 
-	msg.tx_buf = (uint32_t*)no_os_calloc(words_number, sizeof(msg.tx_buf[0]));
-	msg.rx_buf = (uint32_t*)no_os_calloc(words_number, sizeof(msg.rx_buf[0]));
+	msg.tx_buf = (uint32_t*)capi_calloc(words_number, sizeof(msg.tx_buf[0]));
+	msg.rx_buf = (uint32_t*)capi_calloc(words_number, sizeof(msg.rx_buf[0]));
 	msg.length = words_number;
 
 	/* Get the length of transfered word */
@@ -737,8 +737,8 @@ int32_t spi_engine_write_and_read(struct no_os_spi_desc *desc,
 			   ((i) % word_len + 1) * 8);
 
 	spi_engine_queue_no_os_free(&msg.cmds);
-	no_os_free(msg.tx_buf);
-	no_os_free(msg.rx_buf);
+	capi_free(msg.tx_buf);
+	capi_free(msg.rx_buf);
 
 	desc_extra->offload_config = prev_offload_config;
 
@@ -820,7 +820,7 @@ int32_t spi_engine_offload_transfer(struct no_os_spi_desc *desc,
 	eng_desc->offload_tx_len = 0;
 	eng_desc->offload_rx_len = 0;
 
-	transfer.cmds = (spi_engine_cmd_queue*)no_os_malloc(sizeof(*transfer.cmds));
+	transfer.cmds = (spi_engine_cmd_queue*)capi_malloc(sizeof(*transfer.cmds));
 
 	if (!transfer.cmds)
 		return -1;
@@ -904,8 +904,8 @@ int32_t spi_engine_remove(struct no_os_spi_desc *desc)
 		axi_dmac_remove(eng_desc->offload_tx_dma);
 	if (eng_desc->offload_config & OFFLOAD_RX_EN)
 		axi_dmac_remove(eng_desc->offload_rx_dma);
-	no_os_free(desc->extra);
-	no_os_free(desc);
+	capi_free(desc->extra);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/cdc/ad7156/ad7156.c
+++ b/drivers/cdc/ad7156/ad7156.c
@@ -33,7 +33,7 @@
 
 #include <stdlib.h>
 #include "ad7156.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /***************************************************************************//**
  * @brief Performs a burst read of a specified number of registers.
@@ -94,7 +94,7 @@ int8_t ad7156_init(struct ad7156_dev **device,
 	int8_t status = -1;
 	uint8_t test = 0;
 
-	dev = (struct ad7156_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad7156_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -128,7 +128,7 @@ int32_t ad7156_remove(struct ad7156_dev *dev)
 
 	status = no_os_i2c_remove(dev->i2c_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return status;
 }

--- a/drivers/cdc/ad7746/ad7746.c
+++ b/drivers/cdc/ad7746/ad7746.c
@@ -35,7 +35,7 @@
 #include <string.h>
 #include "no_os_error.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "ad7746.h"
 
 /***************************************************************************//**
@@ -56,7 +56,7 @@ int32_t ad7746_init(struct ad7746_dev **device,
 	int32_t ret;
 	struct ad7746_dev *dev;
 
-	dev = (struct ad7746_dev *)no_os_calloc(1, sizeof(struct ad7746_dev));
+	dev = (struct ad7746_dev *)capi_calloc(1, sizeof(struct ad7746_dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -95,7 +95,7 @@ int32_t ad7746_init(struct ad7746_dev **device,
 error_2:
 	no_os_i2c_remove(dev->i2c_dev);
 error_1:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -185,7 +185,7 @@ int32_t ad7746_remove(struct ad7746_dev *dev)
 
 	no_os_i2c_remove(dev->i2c_dev);
 	dev->i2c_dev = NULL;
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/cdc/ad7746/iio_ad7746.c
+++ b/drivers/cdc/ad7746/iio_ad7746.c
@@ -7,7 +7,7 @@
 #include "iio.h"
 #include "iio_ad7746.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "ad7746.h"
 #include <string.h>
 
@@ -744,7 +744,7 @@ int32_t ad7746_iio_init(struct ad7746_iio_dev **iio_dev,
 	int32_t ret;
 	struct ad7746_iio_dev *desc;
 
-	desc = (struct ad7746_iio_dev *)no_os_calloc(1, sizeof(*desc));
+	desc = (struct ad7746_iio_dev *)capi_calloc(1, sizeof(*desc));
 	if (!desc)
 		return -1;
 
@@ -762,7 +762,7 @@ int32_t ad7746_iio_init(struct ad7746_iio_dev **iio_dev,
 
 	return 0;
 error_desc:
-	no_os_free(desc);
+	capi_free(desc);
 
 	return ret;
 }
@@ -775,7 +775,7 @@ int32_t ad7746_iio_remove(struct ad7746_iio_dev *desc)
 	if (ret != 0)
 		return ret;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/dac/ad3552r/ad3552r.c
+++ b/drivers/dac/ad3552r/ad3552r.c
@@ -41,7 +41,7 @@
 #include "axi_dmac.h"
 #include "clk_axi_clkgen.h"
 #endif
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 #include "no_os_error.h"
 #include "no_os_gpio.h"
@@ -1349,7 +1349,7 @@ int32_t ad3552r_init(struct ad3552r_desc **desc,
 	if (!desc || !param)
 		return -EINVAL;
 
-	ldesc = (struct ad3552r_desc*)no_os_calloc(1, sizeof(*ldesc));
+	ldesc = (struct ad3552r_desc*)capi_calloc(1, sizeof(*ldesc));
 	if (!ldesc)
 		return -ENOMEM;
 
@@ -1482,7 +1482,7 @@ err_reset:
 err_spi:
 	no_os_spi_remove(ldesc->spi);
 err:
-	no_os_free(ldesc);
+	capi_free(ldesc);
 
 	return err;
 }
@@ -1496,7 +1496,7 @@ int32_t ad3552r_remove(struct ad3552r_desc *desc)
 	if (!desc->axi)
 		no_os_spi_remove(desc->spi);
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/dac/ad3552r/iio_ad3552r.c
+++ b/drivers/dac/ad3552r/iio_ad3552r.c
@@ -38,7 +38,7 @@
 #include "ad3552r.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 #define AD3552R_ATTR(_name, _priv) {\
 	.name = _name,\
@@ -219,13 +219,13 @@ int32_t iio_ad3552r_init(struct iio_ad3552r_desc **iio_dac,
 	if (!iio_dac || !param)
 		return -EINVAL;
 
-	liio_dac = (struct iio_ad3552r_desc *)no_os_calloc(1, sizeof(*liio_dac));
+	liio_dac = (struct iio_ad3552r_desc *)capi_calloc(1, sizeof(*liio_dac));
 	if (!liio_dac)
 		return -ENOMEM;
 
 	err = ad3552r_init(&liio_dac->dac, param);
 	if (NO_OS_IS_ERR_VALUE(err)) {
-		no_os_free(liio_dac);
+		capi_free(liio_dac);
 		return err;
 	}
 
@@ -253,7 +253,7 @@ int32_t iio_ad3552r_remove(struct iio_ad3552r_desc *iio_dac)
 
 	ad3552r_remove(iio_dac->dac);
 
-	no_os_free(iio_dac);
+	capi_free(iio_dac);
 
 	return 0;
 }

--- a/drivers/dac/ad5421/ad5421.c
+++ b/drivers/dac/ad5421/ad5421.c
@@ -34,7 +34,7 @@
 
 #include <stdlib.h>
 #include "ad5421.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**************************************************************************//**
  * @brief Initialize SPI and Initial Values for AD5421 Board.
@@ -59,7 +59,7 @@ int32_t ad5421_init(struct ad5421_dev **device,
 			     !CTRL_SPI_WATCHDOG);
 	int32_t ret_value = -1;
 
-	dev = (struct ad5421_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad5421_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -116,7 +116,7 @@ int32_t ad5421_remove(struct ad5421_dev *dev)
 	ret |= no_os_gpio_remove(dev->gpio_ldac);
 	ret |= no_os_gpio_remove(dev->gpio_faultin);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/dac/ad5446/ad5446.c
+++ b/drivers/dac/ad5446/ad5446.c
@@ -35,7 +35,7 @@
 
 #include <stdlib.h>
 #include "ad5446.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 #define MAX_RESOLUTION  16      /* Maximum resolution of supported devices */
 #define DATA_MASK(x)    (0xFFFF >> (MAX_RESOLUTION - (x)))
@@ -129,7 +129,7 @@ int8_t ad5446_init(struct ad5446_dev **device,
 	struct ad5446_dev *dev;
 	int8_t status;
 
-	dev = (struct ad5446_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad5446_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -178,7 +178,7 @@ int32_t ad5446_remove(struct ad5446_dev *dev)
 	ret |= no_os_gpio_remove(dev->gpio_ladc);
 	ret |= no_os_gpio_remove(dev->gpio_clrout);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/dac/ad5449/ad5449.c
+++ b/drivers/dac/ad5449/ad5449.c
@@ -33,7 +33,7 @@
 
 #include <stdlib.h>
 #include "ad5449.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 #define MAX_RESOLUTION  12     /* Maximum resolution of the supported devices */
 #define DATA_MASK       0xFFF  /* Mask for 16 data bits */
@@ -102,7 +102,7 @@ int8_t ad5449_init(struct ad5449_dev **device,
 	struct ad5449_dev *dev;
 	int8_t status;
 
-	dev = (struct ad5449_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad5449_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -156,7 +156,7 @@ int32_t ad5449_remove(struct ad5449_dev *dev)
 	ret |= no_os_gpio_remove(dev->gpio_ldac);
 	ret |= no_os_gpio_remove(dev->gpio_clr);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/dac/ad5460/ad5460.c
+++ b/drivers/dac/ad5460/ad5460.c
@@ -36,7 +36,7 @@
 #include "no_os_delay.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 #define AD5460_CRC_POLYNOMIAL 	0x7
 #define AD5460_DIN_DEBOUNCE_LEN 	NO_OS_BIT(5)
@@ -547,7 +547,7 @@ int ad5460_init(struct ad5460_desc **desc,
 	if (!init_param)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -581,7 +581,7 @@ gpio_err:
 comm_err:
 	no_os_spi_remove(descriptor->spi_desc);
 err:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -612,7 +612,7 @@ int ad5460_remove(struct ad5460_desc *desc)
 
 	desc->spi_desc = NULL;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/dac/ad552xr/ad552xr.c
+++ b/drivers/dac/ad552xr/ad552xr.c
@@ -37,7 +37,7 @@
 #include "ad552xr.h"
 #include "no_os_delay.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_util.h"
 
 static const uint16_t ad552xr_supported_product_ids[AD552XR_NUM_TYPES][1] = {
@@ -956,7 +956,7 @@ int ad552xr_init(struct ad552xr_dev **device,
 	if (init_param->dev_addr > 3 || init_param->type >= AD552XR_NUM_TYPES)
 		return -EINVAL;
 
-	dev = (struct ad552xr_dev*)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ad552xr_dev*)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -1065,7 +1065,7 @@ err_gpio:
 err_spi:
 	no_os_spi_remove(dev->spi_desc);
 err_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -1092,7 +1092,7 @@ int ad552xr_remove(struct ad552xr_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/dac/ad5628/ad5628.c
+++ b/drivers/dac/ad5628/ad5628.c
@@ -33,7 +33,7 @@
 
 #include <stdlib.h>
 #include "ad5628.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /***************************************************************************//**
  * @brief Initializes the communication peripheral and the initial Values for
@@ -55,7 +55,7 @@ int32_t ad5628_init(struct ad5628_dev **device,
 	struct ad5628_dev *dev;
 	int32_t status;
 
-	dev = (struct ad5628_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad5628_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -90,7 +90,7 @@ int32_t ad5628_remove(struct ad5628_dev *dev)
 
 	status = no_os_spi_remove(dev->spi_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return status;
 }

--- a/drivers/dac/ad5629r/ad5629r.c
+++ b/drivers/dac/ad5629r/ad5629r.c
@@ -35,7 +35,7 @@
 
 #include <stdlib.h>
 #include "ad5629r.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 static const struct ad5629r_chip_info chip_info[] = {
 	[ID_AD5629R] = {
@@ -77,7 +77,7 @@ int8_t ad5629r_init(struct ad5629r_dev **device,
 	struct ad5629r_dev *dev;
 	int8_t status;
 
-	dev = (struct ad5629r_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad5629r_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -124,7 +124,7 @@ int32_t ad5629r_remove(struct ad5629r_dev *dev)
 	if (dev->gpio_clr)
 		ret |= no_os_gpio_remove(dev->gpio_clr);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/dac/ad5686/ad5686.c
+++ b/drivers/dac/ad5686/ad5686.c
@@ -34,7 +34,7 @@
 
 #include <stdlib.h>
 #include "ad5686.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 static const uint32_t ad5683_channel_addr [] = {
 	[AD5686_CH_0] = 0,
@@ -303,7 +303,7 @@ int32_t ad5686_init(struct ad5686_dev **device,
 	struct ad5686_dev *dev;
 	int32_t ret;
 
-	dev = (struct ad5686_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad5686_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -360,7 +360,7 @@ int32_t ad5686_remove(struct ad5686_dev *dev)
 	if (dev->gpio_gain)
 		ret |= no_os_gpio_remove(dev->gpio_gain);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/dac/ad5706r/ad5706r.c
+++ b/drivers/dac/ad5706r/ad5706r.c
@@ -40,7 +40,7 @@
 #include "no_os_delay.h"
 #include "no_os_error.h"
 #include "no_os_print_log.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_util.h"
 
 /******************************************************************************/
@@ -1702,7 +1702,7 @@ int ad5706r_init(struct ad5706r_dev **device,
 	if (!init_param)
 		return -EINVAL;
 
-	dev = (struct ad5706r_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ad5706r_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -1829,7 +1829,7 @@ error_spi:
 	no_os_spi_remove(dev->spi_desc);
 
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -1854,7 +1854,7 @@ int ad5706r_remove(struct ad5706r_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/dac/ad5754r/ad5754r.c
+++ b/drivers/dac/ad5754r/ad5754r.c
@@ -34,7 +34,7 @@
 
 #include <stdlib.h>
 #include "ad5754r.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 
 /* AD5754R gain values scaled up to avoid float computations */
@@ -747,7 +747,7 @@ int ad5754r_init(struct ad5754r_dev **device,
 	if (!device || !init_param)
 		return -EINVAL;
 
-	dev = (struct ad5754r_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad5754r_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -787,7 +787,7 @@ error_spi:
 error_gpio:
 	ad5754r_remove_gpios(dev);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -836,7 +836,7 @@ int ad5754r_remove(struct ad5754r_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/dac/ad5755/ad5755.c
+++ b/drivers/dac/ad5755/ad5755.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include "ad5755.h"         // AD5755 definitions.
 #include "ad5755_cfg.h"     // AD5755_cfg definitions.
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /***************************************************************************//**
  * @brief Initializes the device and powers-up all channels. The device is
@@ -56,7 +56,7 @@ int8_t ad5755_init(struct ad5755_dev **device,
 	uint8_t channel = 0;
 	uint16_t dac_control_buff[4] = {0, 0, 0, 0};
 
-	dev = (struct ad5755_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad5755_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -159,7 +159,7 @@ int32_t ad5755_remove(struct ad5755_dev *dev)
 	ret |= no_os_gpio_remove(dev->gpio_clr);
 	ret |= no_os_gpio_remove(dev->gpio_poc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/dac/ad5758/ad5758.c
+++ b/drivers/dac/ad5758/ad5758.c
@@ -38,7 +38,7 @@
 #include "inttypes.h"
 #include "no_os_print_log.h"
 #include "no_os_spi.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "stdbool.h"
 #include "stdio.h"
 #include "stdlib.h"
@@ -766,7 +766,7 @@ int32_t ad5758_init(struct ad5758_dev **device,
 	struct ad5758_dev *dev;
 	int32_t ret;
 
-	dev = (struct ad5758_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad5758_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -862,6 +862,6 @@ error_gpio_ldac:
 	no_os_gpio_remove(dev->reset_n);
 error_init:
 	pr_err("ad5758 could not be initialized\n");
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }

--- a/drivers/dac/ad5761r/ad5761r.c
+++ b/drivers/dac/ad5761r/ad5761r.c
@@ -35,7 +35,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "ad5761r.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * SPI write to device.
@@ -650,7 +650,7 @@ int32_t ad5761r_init(struct ad5761r_dev **device,
 	struct ad5761r_dev *dev;
 	int32_t ret = 0;
 
-	dev = (struct ad5761r_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad5761r_dev *)capi_malloc(sizeof(*dev));
 	if (!dev) {
 		return -1;
 	}
@@ -716,7 +716,7 @@ int32_t ad5761r_remove(struct ad5761r_dev *dev)
 	if (dev->gpio_ldac)
 		ret |= no_os_gpio_remove(dev->gpio_ldac);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/dac/ad5766/ad5766.c
+++ b/drivers/dac/ad5766/ad5766.c
@@ -35,7 +35,7 @@
 #include <stdlib.h>
 #include "ad5766.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * SPI command write to device.
@@ -283,7 +283,7 @@ int32_t ad5766_init(struct ad5766_dev **device,
 	struct ad5766_dev *dev;
 	int32_t ret;
 
-	dev = (struct ad5766_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad5766_dev *)capi_malloc(sizeof(*dev));
 	if (!dev) {
 		return -1;
 	}
@@ -333,7 +333,7 @@ int32_t ad5766_remove(struct ad5766_dev *dev)
 
 	ret |= no_os_gpio_remove(dev->gpio_reset);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/dac/ad5770r/ad5770r.c
+++ b/drivers/dac/ad5770r/ad5770r.c
@@ -36,7 +36,7 @@
 #include <string.h>
 #include "no_os_error.h"
 #include "ad5770r.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * Read from device.
@@ -88,19 +88,19 @@ int32_t ad5770r_spi_reg_read_multiple(struct ad5770r_dev *dev,
 	if (!dev || !reg_data)
 		return -1;
 
-	buf = (uint8_t*)no_os_calloc(count + 1, sizeof(uint8_t));
+	buf = (uint8_t*)capi_calloc(count + 1, sizeof(uint8_t));
 
 	buf[0] = AD5770R_REG_READ(reg_addr);
 
 	ret = no_os_spi_write_and_read(dev->spi_desc, buf, count + 1);
 
 	if (ret) {
-		no_os_free(buf);
+		capi_free(buf);
 		return ret;
 	}
 
 	memcpy(reg_data, buf + 1, count);
-	no_os_free(buf);
+	capi_free(buf);
 
 	return ret;
 }
@@ -146,13 +146,13 @@ int32_t ad5770r_spi_reg_write_multiple(struct ad5770r_dev *dev,
 	if (!dev | !reg_data)
 		return -1;
 
-	data = (uint8_t*)no_os_calloc(count + 1, sizeof(uint8_t));
+	data = (uint8_t*)capi_calloc(count + 1, sizeof(uint8_t));
 
 	data[0] = AD5770R_REG_WRITE(reg_addr);
 	memcpy(&data[1], reg_data, count);
 
 	ret = no_os_spi_write_and_read(dev->spi_desc, data, count + 1);
-	no_os_free(data);
+	capi_free(data);
 
 	return ret;
 }
@@ -666,7 +666,7 @@ int32_t ad5770r_init(struct ad5770r_dev **device,
 	if (!device || !init_param)
 		return -1;
 
-	dev = (struct ad5770r_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ad5770r_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -765,7 +765,7 @@ error_gpio:
 error_spi:
 	no_os_spi_remove(dev->spi_desc);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return -1;
 }
@@ -788,7 +788,7 @@ int32_t ad5770r_remove(struct ad5770r_dev *dev)
 	if (NO_OS_IS_ERR_VALUE(ret))
 		return -1;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/dac/ad5791/ad5791.c
+++ b/drivers/dac/ad5791/ad5791.c
@@ -34,7 +34,7 @@
 
 #include <stdlib.h>
 #include "ad5791.h"    // AD5791 definitions.
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 static const struct ad5791_chip_info chip_info[] = {
 	[ID_AD5760] = {
@@ -71,7 +71,7 @@ int32_t ad5791_init(struct ad5791_dev **device,
 	struct ad5791_dev *dev;
 	int32_t status;
 
-	dev = (struct ad5791_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad5791_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -114,7 +114,7 @@ int32_t ad5791_remove(struct ad5791_dev *dev)
 	ret |= no_os_gpio_remove(dev->gpio_clr);
 	ret |= no_os_gpio_remove(dev->gpio_ldac);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/dac/ad5791/iio_ad5791.c
+++ b/drivers/dac/ad5791/iio_ad5791.c
@@ -38,7 +38,7 @@
 #include <string.h>
 #include "iio_ad5791.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief IIO get method to the 'scale' attribute of the channel.
@@ -381,7 +381,7 @@ int32_t ad5791_iio_init(struct ad5791_iio_desc **iio_dev,
 	int32_t ret;
 	struct ad5791_iio_desc *desc;
 
-	desc = (struct ad5791_iio_desc *)no_os_calloc(1, sizeof(*desc));
+	desc = (struct ad5791_iio_desc *)capi_calloc(1, sizeof(*desc));
 	if (!desc)
 		return -1;
 
@@ -398,7 +398,7 @@ int32_t ad5791_iio_init(struct ad5791_iio_desc **iio_dev,
 
 	return 0;
 error_desc:
-	no_os_free(desc);
+	capi_free(desc);
 
 	return ret;
 }
@@ -416,7 +416,7 @@ int32_t ad5791_iio_remove(struct ad5791_iio_desc *desc)
 	if (ret != 0)
 		return ret;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/dac/ad7293/ad7293.c
+++ b/drivers/dac/ad7293/ad7293.c
@@ -35,7 +35,7 @@
 #include "ad7293.h"
 #include "no_os_error.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Set specific AD7293 page.
@@ -458,7 +458,7 @@ int ad7293_init(struct ad7293_dev **device,
 	uint16_t chip_id;
 	int ret;
 
-	dev = (struct ad7293_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ad7293_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -496,7 +496,7 @@ error_gpio:
 error_spi:
 	no_os_spi_remove(dev->spi_desc);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -514,7 +514,7 @@ int ad7293_remove(struct ad7293_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/dac/ad7303/ad7303.c
+++ b/drivers/dac/ad7303/ad7303.c
@@ -33,7 +33,7 @@
 
 #include <stdlib.h>
 #include "ad7303.h"           // AD7303 definitions.
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /***************************************************************************//**
  * @brief Initializes SPI communication.
@@ -52,7 +52,7 @@ int8_t ad7303_init(struct ad7303_dev **device,
 	struct ad7303_dev *dev;
 	int8_t status;
 
-	dev = (struct ad7303_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad7303_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -76,7 +76,7 @@ int32_t ad7303_remove(struct ad7303_dev *dev)
 
 	ret = no_os_spi_remove(dev->spi_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/dac/ad8460/ad8460.c
+++ b/drivers/dac/ad8460/ad8460.c
@@ -32,7 +32,7 @@
 *******************************************************************************/
 
 #include "ad8460.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 #include "no_os_error.h"
 #include "no_os_spi.h"
@@ -118,7 +118,7 @@ int ad8460_init(struct ad8460_device **dev,
 	struct ad8460_device *temp_dev;
 	int ret;
 
-	temp_dev = no_os_calloc(1, sizeof(*temp_dev));
+	temp_dev = capi_calloc(1, sizeof(*temp_dev));
 	if (!temp_dev)
 		return -ENOMEM;
 
@@ -147,7 +147,7 @@ remove_spi:
 		pr_err("Failed to remove SPI descriptor\r\n");
 
 free_dev:
-	no_os_free(temp_dev);
+	capi_free(temp_dev);
 
 	return ret;
 }
@@ -168,7 +168,7 @@ int ad8460_remove(struct ad8460_device *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/dac/ad8460/iio_ad8460.c
+++ b/drivers/dac/ad8460/iio_ad8460.c
@@ -34,7 +34,7 @@
 #include <errno.h>
 #include "iio_ad8460.h"
 #include "ad8460.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 
 #define AD8460_CHAN_EXT_INFO(_name, _what, _read, _write) {	\
@@ -427,13 +427,13 @@ int ad8460_iio_init(struct ad8460_iio_device **iio_device,
 	if (!iio_init_param || !iio_init_param->init_param)
 		return -EINVAL;
 
-	iio_device_temp = no_os_calloc(1, sizeof(*iio_device_temp));
+	iio_device_temp = capi_calloc(1, sizeof(*iio_device_temp));
 	if (!iio_device_temp)
 		return -ENOMEM;
 
 	ret = ad8460_init(&iio_device_temp->dev, iio_init_param->init_param);
 	if (ret) {
-		no_os_free(iio_device_temp);
+		capi_free(iio_device_temp);
 		return ret;
 	}
 
@@ -465,7 +465,7 @@ int ad8460_iio_remove(struct ad8460_iio_device *iio_device)
 	if (ret)
 		return ret;
 
-	no_os_free(iio_device);
+	capi_free(iio_device);
 
 	return 0;
 }

--- a/drivers/dac/ad9144/ad9144.c
+++ b/drivers/dac/ad9144/ad9144.c
@@ -36,7 +36,7 @@
 #include <stdbool.h>
 #include "ad9144.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_print_log.h"
 
 struct ad9144_jesd204_link_mode {
@@ -975,7 +975,7 @@ int32_t ad9144_setup_legacy(struct ad9144_dev **device,
 	int32_t ret;
 	struct ad9144_dev *dev;
 
-	dev = (struct ad9144_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad9144_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -1131,7 +1131,7 @@ int32_t ad9144_setup_jesd_fsm(struct ad9144_dev **device,
 	struct ad9144_dev *dev;
 	unsigned char i;
 
-	dev = (struct ad9144_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad9144_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -1229,7 +1229,7 @@ int32_t ad9144_remove(struct ad9144_dev *dev)
 
 	ret = no_os_spi_remove(dev->spi_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/dac/ad9152/ad9152.c
+++ b/drivers/dac/ad9152/ad9152.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "ad9152.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /***************************************************************************//**
  * @brief ad9152_spi_read
@@ -92,7 +92,7 @@ int32_t ad9152_setup(struct ad9152_dev **device,
 	int32_t ret;
 	struct ad9152_dev *dev;
 
-	dev = (struct ad9152_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad9152_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -201,7 +201,7 @@ int32_t ad9152_remove(struct ad9152_dev *dev)
 
 	ret = no_os_spi_remove(dev->spi_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/dac/ad917x/ad9172.c
+++ b/drivers/dac/ad917x/ad9172.c
@@ -33,7 +33,7 @@
 
 #include "no_os_print_log.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_clk.h"
 #include <inttypes.h>
 #include "jesd204.h"
@@ -334,7 +334,7 @@ static int32_t ad9172_spi_xfer(void *user_data, uint8_t *wbuf,
 {
 	int32_t ret;
 	struct no_os_spi_desc *spi = user_data;
-	uint8_t * buffer = (uint8_t *) no_os_malloc(len);
+	uint8_t * buffer = (uint8_t *) capi_malloc(len);
 
 	if (!buffer)
 		return -ENOMEM;
@@ -346,7 +346,7 @@ static int32_t ad9172_spi_xfer(void *user_data, uint8_t *wbuf,
 	} else {
 		memcpy(rbuf, buffer, len);
 	}
-	no_os_free(buffer);
+	capi_free(buffer);
 
 	return ret;
 }
@@ -515,11 +515,11 @@ int32_t ad9172_init(ad9172_dev **device, ad9172_init_param * init_param)
 	ad9172_dev *dev;
 	int32_t ret, i;
 
-	dev = (ad9172_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (ad9172_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
-	struct ad9172_state *st = (struct ad9172_state *)no_os_calloc(1, sizeof(*st));
+	struct ad9172_state *st = (struct ad9172_state *)capi_calloc(1, sizeof(*st));
 	if (!st) {
 		ret = -ENOMEM;
 		goto error_1;
@@ -605,9 +605,9 @@ int32_t ad9172_init(ad9172_dev **device, ad9172_init_param * init_param)
 error_3:
 	no_os_spi_remove(dev->spi_desc);
 error_2:
-	no_os_free(st);
+	capi_free(st);
 error_1:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -626,9 +626,9 @@ int32_t ad9172_remove(ad9172_dev *device)
 	ret += no_os_gpio_remove(device->gpio_txen0);
 	ret += no_os_gpio_remove(device->gpio_txen1);
 
-	no_os_free(device->st);
+	capi_free(device->st);
 
-	no_os_free(device);
+	capi_free(device);
 
 	return ret;
 }

--- a/drivers/dac/ad9739a/ad9739a.c
+++ b/drivers/dac/ad9739a/ad9739a.c
@@ -36,7 +36,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "ad9739a.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 #define FDATA 2500	// for 2.5 GSPS
 
@@ -272,7 +272,7 @@ int32_t ad9739a_setup(struct ad9739a_dev **device,
 	uint8_t ad9739a_reg_lvds_rec_stat9_buf;
 	struct ad9739a_dev *dev;
 
-	dev = (struct ad9739a_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad9739a_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -451,7 +451,7 @@ int32_t ad9739a_remove(struct ad9739a_dev *dev)
 
 	ret = no_os_spi_remove(dev->spi_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/dac/dac_demo/dac_demo.c
+++ b/drivers/dac/dac_demo/dac_demo.c
@@ -36,7 +36,7 @@
 #include "dac_demo.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /***************************************************************************//**
  * @brief init function for the dac demo driver
@@ -48,7 +48,7 @@ int32_t dac_demo_init(struct dac_demo_desc **desc,
 		      struct dac_demo_init_param *param)
 {
 	struct dac_demo_desc *adesc;
-	adesc = (struct dac_demo_desc*)no_os_calloc(1, sizeof(*adesc));
+	adesc = (struct dac_demo_desc*)capi_calloc(1, sizeof(*adesc));
 
 	if (!adesc)
 		return -ENOMEM;
@@ -73,7 +73,7 @@ int32_t dac_demo_remove(struct dac_demo_desc *desc)
 	if (!desc)
 		return -EINVAL;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/dac/ltc2672/ltc2672.c
+++ b/drivers/dac/ltc2672/ltc2672.c
@@ -42,7 +42,7 @@
 #include "no_os_delay.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /******************************************************************************/
 
@@ -102,7 +102,7 @@ int ltc2672_remove(struct ltc2672_dev *device)
 	if (ret)
 		return ret;
 
-	no_os_free(device);
+	capi_free(device);
 
 	return ret;
 }
@@ -836,7 +836,7 @@ int ltc2672_init(struct ltc2672_dev **device,
 	int ret;
 	struct ltc2672_dev *descriptor;
 
-	descriptor = (struct ltc2672_dev *)no_os_calloc(1, sizeof(*descriptor));
+	descriptor = (struct ltc2672_dev *)capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -902,7 +902,7 @@ error_spi:
 	no_os_spi_remove(descriptor->comm_desc);
 
 error_init:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }

--- a/drivers/dac/ltc268x/ltc268x.c
+++ b/drivers/dac/ltc268x/ltc268x.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 #include "ltc268x.h" /* LTC268X definitions. */
 
@@ -411,7 +411,7 @@ int32_t ltc268x_init(struct ltc268x_dev **device,
 	uint8_t channel = 0;
 	int ret;
 
-	dev = (struct ltc268x_dev*)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ltc268x_dev*)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -483,7 +483,7 @@ int32_t ltc268x_init(struct ltc268x_dev **device,
 
 error:
 	printf("LTC268X initialization error (%d)\n", ret);
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -501,7 +501,7 @@ int32_t ltc268x_remove(struct ltc268x_dev *dev)
 
 	ret = no_os_spi_remove(dev->spi_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/dac/max22007/max22007.c
+++ b/drivers/dac/max22007/max22007.c
@@ -32,7 +32,7 @@
 *******************************************************************************/
 #include "no_os_print_log.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 #include "no_os_crc8.h"
 #include "no_os_spi.h"
@@ -515,7 +515,7 @@ int max22007_init(struct max22007_dev **device,
 	uint8_t ch;
 	int ret;
 
-	dev = (struct max22007_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct max22007_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -591,7 +591,7 @@ int max22007_remove(struct max22007_dev *dev)
 
 	no_os_spi_remove(dev->comm_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/dac/max22017/iio_max22017.c
+++ b/drivers/dac/max22017/iio_max22017.c
@@ -36,7 +36,7 @@
 #include "no_os_error.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 #include "max22017.h"
 #include "iio_max22017.h"
@@ -753,7 +753,7 @@ int max22017_iio_init(struct max22017_iio_desc **iio_desc,
 	if (!init_param || !init_param->max22017_init_param)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -780,11 +780,11 @@ int max22017_iio_remove(struct max22017_iio_desc *iio_desc)
 		return -ENODEV;
 
 	if (iio_desc->iio_dev->channels)
-		no_os_free(iio_desc->iio_dev->channels);
+		capi_free(iio_desc->iio_dev->channels);
 	if (iio_desc->max22017_desc)
 		max22017_remove(iio_desc->max22017_desc);
 
-	no_os_free(iio_desc);
+	capi_free(iio_desc);
 
 	return 0;
 }

--- a/drivers/dac/max22017/max22017.c
+++ b/drivers/dac/max22017/max22017.c
@@ -35,7 +35,7 @@
 #include "max22017.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_crc8.h"
 
 NO_OS_DECLARE_CRC8_TABLE(table);
@@ -58,7 +58,7 @@ int32_t max22017_gpio_get(struct no_os_gpio_desc **desc,
 
 	gpio_extra = param->extra;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -79,7 +79,7 @@ int32_t max22017_gpio_get(struct no_os_gpio_desc **desc,
 	return 0;
 
 free_descriptor:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -105,7 +105,7 @@ int32_t max22017_gpio_remove(struct no_os_gpio_desc *desc)
 	if (ret)
 		return ret;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }
@@ -569,7 +569,7 @@ int max22017_init(struct max22017_desc **desc,
 	struct max22017_desc *descriptor;
 	int ret;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -666,7 +666,7 @@ int max22017_remove(struct max22017_desc *desc)
 
 	no_os_spi_remove(desc->comm_desc);
 	no_os_gpio_remove(desc->ldac_desc);
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/dac/max538x/max538x.c
+++ b/drivers/dac/max538x/max538x.c
@@ -38,7 +38,7 @@
 #include "no_os_i2c.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 const struct max538x_chip_info chip_info[] = {
 	[MAX5380L] = {
@@ -115,7 +115,7 @@ int max538x_init(struct max538x_dev **device,
 	    && init_param.active_device > MAX5381K)
 		return -EINVAL;
 
-	dev = (struct max538x_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct max538x_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -137,7 +137,7 @@ int max538x_init(struct max538x_dev **device,
 	return 0;
 
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -151,7 +151,7 @@ int max538x_remove(struct max538x_dev *dev)
 	int ret;
 
 	ret = no_os_i2c_remove(dev->i2c_desc);
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/digital-io/max14914/max14914.c
+++ b/drivers/digital-io/max14914/max14914.c
@@ -35,7 +35,7 @@
 #include "max14914.h"
 #include "no_os_util.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Set the state of the MAX14914
@@ -127,7 +127,7 @@ int max14914_init(struct max14914_desc **desc,
 	struct max14914_desc *descriptor;
 	int ret;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -191,7 +191,7 @@ pp_error:
 di_en_error:
 	no_os_gpio_remove(descriptor->di_en_gpio);
 error:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -211,7 +211,7 @@ int max14914_remove(struct max14914_desc *desc)
 	no_os_gpio_remove(desc->in_gpio);
 	no_os_gpio_remove(desc->pp_gpio);
 	no_os_gpio_remove(desc->di_en_gpio);
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/digital-io/max14919/max14919.c
+++ b/drivers/digital-io/max14919/max14919.c
@@ -31,7 +31,7 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 #include "max14919.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Set the OUT channels state
@@ -124,7 +124,7 @@ int max14919_init(struct max14919_desc **desc,
 	struct max14919_desc *descriptor;
 	int ret, i;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -197,7 +197,7 @@ int max14919_remove(struct max14919_desc *desc)
 	no_os_gpio_remove(desc->inrush_desc);
 	no_os_gpio_remove(desc->rev_desc);
 	no_os_gpio_remove(desc->fault_desc);
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/digital-io/max149x6/iio_max14906.c
+++ b/drivers/digital-io/max149x6/iio_max14906.c
@@ -33,7 +33,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
@@ -499,7 +499,7 @@ int max14906_iio_setup_channels(struct max14906_iio_desc *desc)
 		if (desc->channel_configs[i].enabled)
 			enabled_ch++;
 
-	max14906_iio_channels = no_os_calloc(enabled_ch,
+	max14906_iio_channels = capi_calloc(enabled_ch,
 					     sizeof(*max14906_iio_channels));
 	if (!max14906_iio_channels)
 		return -ENOMEM;
@@ -537,7 +537,7 @@ int max14906_iio_setup_channels(struct max14906_iio_desc *desc)
 	return 0;
 
 free_channels:
-	no_os_free(max14906_iio_channels);
+	capi_free(max14906_iio_channels);
 
 	return ret;
 }
@@ -585,7 +585,7 @@ int max14906_iio_init(struct max14906_iio_desc **iio_desc,
 	if (!init_param || !init_param->max14906_init_param)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -609,7 +609,7 @@ int max14906_iio_init(struct max14906_iio_desc **iio_desc,
 free_dev:
 	max14906_remove(descriptor->max14906_desc);
 free_desc:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -624,9 +624,9 @@ int max14906_iio_remove(struct max14906_iio_desc *iio_desc)
 	if (!iio_desc)
 		return -ENODEV;
 
-	no_os_free(iio_desc->iio_dev->channels);
+	capi_free(iio_desc->iio_dev->channels);
 	max14906_remove(iio_desc->max14906_desc);
-	no_os_free(iio_desc);
+	capi_free(iio_desc);
 
 	return 0;
 }

--- a/drivers/digital-io/max149x6/iio_max14916.c
+++ b/drivers/digital-io/max149x6/iio_max14916.c
@@ -33,7 +33,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
@@ -184,7 +184,7 @@ int max14916_iio_setup_channels(struct max14916_iio_desc *desc, bool *ch_enable)
 		if (ch_enable[i])
 			enabled_ch++;
 
-	max14916_iio_channels = no_os_calloc(enabled_ch,
+	max14916_iio_channels = capi_calloc(enabled_ch,
 					     sizeof(*max14916_iio_channels));
 	if (!max14916_iio_channels)
 		return -ENOMEM;
@@ -249,7 +249,7 @@ int max14916_iio_init(struct max14916_iio_desc **iio_desc,
 	if (!init_param || !init_param->max14916_init_param)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -270,7 +270,7 @@ int max14916_iio_init(struct max14916_iio_desc **iio_desc,
 free_dev:
 	max14916_remove(descriptor->max14916_desc);
 free_desc:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 	return ret;
 }
 
@@ -284,9 +284,9 @@ int max14916_iio_remove(struct max14916_iio_desc *iio_desc)
 	if (!iio_desc)
 		return -ENODEV;
 
-	no_os_free(iio_desc->iio_dev->channels);
+	capi_free(iio_desc->iio_dev->channels);
 	max14916_remove(iio_desc->max14916_desc);
-	no_os_free(iio_desc);
+	capi_free(iio_desc);
 
 	return 0;
 }

--- a/drivers/digital-io/max149x6/max14906.c
+++ b/drivers/digital-io/max149x6/max14906.c
@@ -35,7 +35,7 @@
 #include <string.h>
 #include "max14906.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Read the (voltage) state of a channel (works for both input or output).
@@ -173,7 +173,7 @@ int max14906_init(struct max149x6_desc **desc,
 	int ret;
 	int i;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -265,7 +265,7 @@ gpio_err:
 spi_err:
 	no_os_spi_remove(descriptor->comm_desc);
 err:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -295,7 +295,7 @@ int max14906_remove(struct max149x6_desc *desc)
 	no_os_gpio_remove(desc->ready_gpio);
 	no_os_gpio_remove(desc->synch_gpio);
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/digital-io/max149x6/max14916.c
+++ b/drivers/digital-io/max149x6/max14916.c
@@ -35,7 +35,7 @@
 #include <string.h>
 #include "max14916.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Read the high-side state of a channel's switch.
@@ -207,7 +207,7 @@ int max14916_init(struct max149x6_desc **desc,
 	uint32_t reg_val;
 	int ret, i;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -303,7 +303,7 @@ gpio_err:
 spi_err:
 	no_os_spi_remove(descriptor->comm_desc);
 err:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 	return ret;
 }
 
@@ -324,7 +324,7 @@ int max14916_remove(struct max149x6_desc *desc)
 	no_os_gpio_remove(desc->ready_gpio);
 	no_os_gpio_remove(desc->synch_gpio);
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/digital-io/max149x6/max149x6-base.c
+++ b/drivers/digital-io/max149x6/max149x6-base.c
@@ -36,7 +36,7 @@
 #include <string.h>
 #include "max149x6-base.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Compute the CRC5 value for an array of bytes when writing to MAX149X6

--- a/drivers/digital-io/max22190/iio_max22190.c
+++ b/drivers/digital-io/max22190/iio_max22190.c
@@ -33,7 +33,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
@@ -556,7 +556,7 @@ int max22190_iio_init(struct max22190_iio_desc **iio_desc,
 	if (!init_param || !init_param->max22190_init_param)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -572,7 +572,7 @@ int max22190_iio_init(struct max22190_iio_desc **iio_desc,
 	return 0;
 
 free_desc:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 	return ret;
 }
 
@@ -587,7 +587,7 @@ int max22190_iio_remove(struct max22190_iio_desc *iio_desc)
 		return -ENODEV;
 
 	max22190_remove(iio_desc->max22190_desc);
-	no_os_free(iio_desc);
+	capi_free(iio_desc);
 
 	return 0;
 }

--- a/drivers/digital-io/max22190/max22190.c
+++ b/drivers/digital-io/max22190/max22190.c
@@ -35,7 +35,7 @@
 #include <string.h>
 #include "max22190.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Compute the CRC5 value for MAX22190
@@ -430,7 +430,7 @@ int max22190_init(struct max22190_desc **desc,
 	struct max22190_desc *descriptor;
 	int ret;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -472,7 +472,7 @@ gpio_err:
 spi_err:
 	no_os_spi_remove(descriptor->comm_desc);
 err:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -498,7 +498,7 @@ int max22190_remove(struct max22190_desc *desc)
 
 	no_os_spi_remove(desc->comm_desc);
 	no_os_gpio_remove(desc->en_gpio);
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/digital-io/max22196/iio_max22196.c
+++ b/drivers/digital-io/max22196/iio_max22196.c
@@ -36,7 +36,7 @@
 #include "no_os_error.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 #include "max22196.h"
 #include "iio_max22196.h"
@@ -775,7 +775,7 @@ int max22196_iio_setup_channels(struct max22196_iio_desc *desc)
 	struct iio_channel *max22196_iio_channels;
 	int i;
 
-	max22196_iio_channels = no_os_calloc(desc->max22196_desc->max_chn_nb,
+	max22196_iio_channels = capi_calloc(desc->max22196_desc->max_chn_nb,
 					     sizeof(*max22196_iio_channels));
 
 	if (!max22196_iio_channels)
@@ -835,7 +835,7 @@ int max22196_iio_init(struct max22196_iio_desc **iio_desc,
 	if (!init_param || !init_param->max22196_init_param)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -870,8 +870,8 @@ int max22196_iio_remove(struct max22196_iio_desc *iio_desc)
 		return -ENODEV;
 
 	max22196_remove(iio_desc->max22196_desc);
-	no_os_free(iio_desc->iio_dev->channels);
-	no_os_free(iio_desc);
+	capi_free(iio_desc->iio_dev->channels);
+	capi_free(iio_desc);
 
 	return 0;
 }

--- a/drivers/digital-io/max22196/max22196.c
+++ b/drivers/digital-io/max22196/max22196.c
@@ -35,7 +35,7 @@
 #include <string.h>
 #include "max22196.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Compute the CRC5 value for an array of bytes when writing to MAX22196
@@ -505,7 +505,7 @@ int max22196_init(struct max22196_desc **desc,
 	uint32_t reg_val;
 	int ret;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -571,7 +571,7 @@ int max22196_remove(struct max22196_desc *desc)
 
 	no_os_spi_remove(desc->comm_desc);
 	no_os_gpio_remove(desc->crc_desc);
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/digital-io/max22200/iio_max22200.c
+++ b/drivers/digital-io/max22200/iio_max22200.c
@@ -33,7 +33,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
@@ -1011,7 +1011,7 @@ int max22200_iio_setup_channels(struct max22200_iio_desc *desc, bool *ch_enable)
 		if (ch_enable[i])
 			enabled_ch++;
 
-	max22200_iio_channels = no_os_calloc(enabled_ch,
+	max22200_iio_channels = capi_calloc(enabled_ch,
 					     sizeof(*max22200_iio_channels));
 
 	if (!max22200_iio_channels)
@@ -1051,7 +1051,7 @@ int max22200_iio_init(struct max22200_iio_desc **iio_desc,
 	if (!init_param || !init_param->max22200_init_param)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -1072,7 +1072,7 @@ int max22200_iio_init(struct max22200_iio_desc **iio_desc,
 free_dev:
 	max22200_remove(descriptor->max22200_desc);
 free_desc:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 	return ret;
 }
 
@@ -1086,9 +1086,9 @@ int max22200_iio_remove(struct max22200_iio_desc *iio_desc)
 	if (!iio_desc)
 		return -ENODEV;
 
-	no_os_free(iio_desc->iio_dev->channels);
+	capi_free(iio_desc->iio_dev->channels);
 	max22200_remove(iio_desc->max22200_desc);
-	no_os_free(iio_desc);
+	capi_free(iio_desc);
 
 	return 0;
 }

--- a/drivers/digital-io/max22200/max22200.c
+++ b/drivers/digital-io/max22200/max22200.c
@@ -35,7 +35,7 @@
 #include <string.h>
 #include "max22200.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 
 /**
@@ -729,7 +729,7 @@ int max22200_init(struct max22200_desc **desc,
 	uint32_t status_reg = 0;
 	int ret, i;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -854,7 +854,7 @@ cmd_err:
 spi_err:
 	no_os_spi_remove(descriptor->comm_desc);
 err:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 	return ret;
 }
 
@@ -891,7 +891,7 @@ int max22200_remove(struct max22200_desc *desc)
 	no_os_gpio_remove(desc->trig_desc);
 	no_os_gpio_remove(desc->fault_desc);
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/digital-io/max22915/max22915.c
+++ b/drivers/digital-io/max22915/max22915.c
@@ -33,7 +33,7 @@
 
 #include "max22915.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_spi.h"
 #include "no_os_print_log.h"
 #include <stdio.h>
@@ -369,7 +369,7 @@ int max22915_init(struct max22915_desc **device,
 	uint8_t i;
 	uint8_t reg_data;
 
-	dev = (struct max22915_desc *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct max22915_desc *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -435,7 +435,7 @@ err:
 	if (dev->spi_desc)
 		no_os_spi_remove(dev->spi_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -451,7 +451,7 @@ int max22915_remove(struct max22915_desc *dev)
 		return -EINVAL;
 
 	no_os_spi_remove(dev->spi_desc);
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/display/display.c
+++ b/drivers/display/display.c
@@ -35,7 +35,7 @@
 #include <stdbool.h>
 #include "display.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include <string.h>
 
 /**
@@ -55,7 +55,7 @@ int32_t display_init(struct display_dev **device,
 	if (!device || !param)
 		return -EINVAL;
 
-	dev = (struct display_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct display_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 	dev->cols_nb = param->cols_nb;
@@ -65,7 +65,7 @@ int32_t display_init(struct display_dev **device,
 
 	ret = dev->controller_ops->init(dev);
 	if (ret != 0) {
-		no_os_free(dev);
+		capi_free(dev);
 		return -1;
 	}
 
@@ -90,7 +90,7 @@ int32_t display_remove(struct display_dev *device)
 	ret = device->controller_ops->remove(device);
 	if (ret != 0)
 		return -1;
-	no_os_free(device);
+	capi_free(device);
 
 	return ret;
 }

--- a/drivers/display/nhd_c12832a1z/nhd_c12832a1z.c
+++ b/drivers/display/nhd_c12832a1z/nhd_c12832a1z.c
@@ -36,7 +36,7 @@
 #include "no_os_error.h"
 #include "no_os_spi.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include <string.h>
 
 static const uint8_t ASC16[256][8] = {
@@ -459,7 +459,7 @@ int nhd_c12832a1z_init(struct nhd_c12832a1z_dev **device,
 	struct nhd_c12832a1z_dev *dev;
 	int ret;
 
-	dev = (struct nhd_c12832a1z_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct nhd_c12832a1z_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -538,7 +538,7 @@ error_dc:
 error_spi:
 	no_os_spi_remove(dev->spi_desc);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -564,7 +564,7 @@ int nhd_c12832a1z_remove(struct nhd_c12832a1z_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/ecg/adas1000/adas1000.c
+++ b/drivers/ecg/adas1000/adas1000.c
@@ -37,7 +37,7 @@
 #include "no_os_error.h"
 #include "adas1000.h"
 #include "no_os_crc.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Preliminary function which computes the spi frequency based on the
@@ -90,7 +90,7 @@ int32_t adas1000_init(struct adas1000_dev **device,
 	int32_t ret;
 	struct adas1000_dev *dev;
 
-	dev = (struct adas1000_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct adas1000_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -100,7 +100,7 @@ int32_t adas1000_init(struct adas1000_dev **device,
 	/** Initialize the SPI controller. */
 	ret = no_os_spi_init(&dev->spi_desc, &init_param->spi_init);
 	if (ret != 0) {
-		no_os_free(dev);
+		capi_free(dev);
 		return ret;
 	}
 

--- a/drivers/eeprom/24xx32a/24xx32a.c
+++ b/drivers/eeprom/24xx32a/24xx32a.c
@@ -42,7 +42,7 @@
 #include "no_os_error.h"
 #include "no_os_delay.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief 	Initialize the 24XX32A EEPROM
@@ -61,13 +61,13 @@ int32_t eeprom_24xx32a_init(struct no_os_eeprom_desc **desc,
 	if (!desc || !param)
 		return -EINVAL;
 
-	eeprom_desc = (struct no_os_eeprom_desc*)no_os_calloc(1, sizeof(*eeprom_desc));
+	eeprom_desc = (struct no_os_eeprom_desc*)capi_calloc(1, sizeof(*eeprom_desc));
 	if (!eeprom_desc)
 		return -ENOMEM;
 
 	eeprom_desc->device_id = param->device_id;
 
-	eeprom_dev = (struct eeprom_24xx32a_dev*)no_os_calloc(1, sizeof(*eeprom_dev));
+	eeprom_dev = (struct eeprom_24xx32a_dev*)capi_calloc(1, sizeof(*eeprom_dev));
 	if (!eeprom_dev) {
 		ret = -ENOMEM;
 		goto error_eeprom_dev;
@@ -84,9 +84,9 @@ int32_t eeprom_24xx32a_init(struct no_os_eeprom_desc **desc,
 	return 0;
 
 error_eeprom_init:
-	no_os_free(eeprom_dev);
+	capi_free(eeprom_dev);
 error_eeprom_dev:
-	no_os_free(eeprom_desc);
+	capi_free(eeprom_desc);
 
 	return ret;
 }
@@ -209,8 +209,8 @@ int32_t eeprom_24xx32a_remove(struct no_os_eeprom_desc *desc)
 		return ret;
 
 	/* Free the EEPROM descriptor objects */
-	no_os_free(desc->extra);
-	no_os_free(desc);
+	capi_free(desc->extra);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/eeprom/m24512/m24512.c
+++ b/drivers/eeprom/m24512/m24512.c
@@ -34,7 +34,7 @@
 #include <string.h>
 
 #include "m24512.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 #include "no_os_gpio.h"
 #include "no_os_eeprom.h"
@@ -94,13 +94,13 @@ int32_t m24512_init(struct no_os_eeprom_desc **desc,
 	if (!desc || !param)
 		return -EINVAL;
 
-	eeprom_desc = (struct no_os_eeprom_desc *)no_os_calloc(1, sizeof(*eeprom_desc));
+	eeprom_desc = (struct no_os_eeprom_desc *)capi_calloc(1, sizeof(*eeprom_desc));
 	if (!eeprom_desc)
 		return -ENOMEM;
 
 	eeprom_desc->device_id = param->device_id;
 
-	m24512_dev = (struct m24512_dev *)no_os_calloc(1, sizeof(*m24512_dev));
+	m24512_dev = (struct m24512_dev *)capi_calloc(1, sizeof(*m24512_dev));
 	if (!m24512_dev) {
 		ret = -ENOMEM;
 		goto remove_eeprom_desc;
@@ -148,9 +148,9 @@ remove_wc_gpio_desc:
 remove_i2c_desc:
 	no_os_i2c_remove(m24512_dev->i2c_desc);
 remove_m24512_dev:
-	no_os_free(m24512_dev);
+	capi_free(m24512_dev);
 remove_eeprom_desc:
-	no_os_free(eeprom_desc);
+	capi_free(eeprom_desc);
 	return ret;
 }
 
@@ -173,8 +173,8 @@ int32_t m24512_remove(struct no_os_eeprom_desc *desc)
 	if (dev->i2c_desc)
 		no_os_i2c_remove(dev->i2c_desc);
 
-	no_os_free(dev);
-	no_os_free(desc);
+	capi_free(dev);
+	capi_free(desc);
 
 	return 0;
 }
@@ -399,7 +399,7 @@ static int m24512_write_raw(struct m24512_dev *dev, uint16_t addr,
 		return -EINVAL;
 
 	// Allocate buffer for address + data
-	write_buf = (uint8_t *)no_os_calloc(len + 2, sizeof(uint8_t));
+	write_buf = (uint8_t *)capi_calloc(len + 2, sizeof(uint8_t));
 	if (!write_buf)
 		return -ENOMEM;
 
@@ -413,7 +413,7 @@ static int m24512_write_raw(struct m24512_dev *dev, uint16_t addr,
 	// Ensure write protection is disabled right before write
 	ret = m24512_set_write_protection(dev, false);
 	if (ret) {
-		no_os_free(write_buf);
+		capi_free(write_buf);
 		return ret;
 	}
 
@@ -425,7 +425,7 @@ static int m24512_write_raw(struct m24512_dev *dev, uint16_t addr,
 		no_os_udelay(500);  // 500 microseconds delay
 	}
 
-	no_os_free(write_buf);
+	capi_free(write_buf);
 	return ret;
 }
 

--- a/drivers/filter/admv8818/admv8818.c
+++ b/drivers/filter/admv8818/admv8818.c
@@ -34,7 +34,7 @@
 #include <malloc.h>
 #include "admv8818.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_units.h"
 
 static const unsigned long long freq_range_hpf[4][2] = {
@@ -334,7 +334,7 @@ int admv8818_init(struct admv8818_dev **device,
 	struct admv8818_dev *dev;
 	int ret;
 
-	dev = (struct admv8818_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct admv8818_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -387,7 +387,7 @@ int admv8818_init(struct admv8818_dev **device,
 error_spi:
 	no_os_spi_remove(dev->spi_desc);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -405,7 +405,7 @@ int admv8818_remove(struct admv8818_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/frequency/ad9508/ad9508.c
+++ b/drivers/frequency/ad9508/ad9508.c
@@ -37,7 +37,7 @@
 #include "no_os_error.h"
 #include "ad9508.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Reads from the ad9508 that is contected to the SPI
@@ -111,7 +111,7 @@ int32_t ad9508_setup(struct ad9508_dev **device,
 	struct ad9508_dev *dev;
 	uint8_t reg_data;
 
-	dev = (struct ad9508_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad9508_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -186,7 +186,7 @@ int32_t ad9508_remove(struct ad9508_dev *dev)
 	if (ret != 0)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/frequency/ad9517/ad9517.c
+++ b/drivers/frequency/ad9517/ad9517.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "ad9517.h"
 
 /***************************************************************************//**
@@ -62,7 +62,7 @@ int32_t ad9517_setup(struct ad9517_dev **device,
 		AD9517_REG_LVPECL_OUT3
 	};
 
-	dev = (struct ad9517_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad9517_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -220,7 +220,7 @@ int32_t ad9517_remove(struct ad9517_dev *dev)
 
 	ret = no_os_spi_remove(dev->spi_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/frequency/ad9523/ad9523.c
+++ b/drivers/frequency/ad9523/ad9523.c
@@ -35,7 +35,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "ad9523.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /* Helpers to avoid excess line breaks */
 #define AD_IFE(_pde, _a, _b) ((dev->pdata->_pde) ? _a : _b)
@@ -430,7 +430,7 @@ int32_t ad9523_setup(struct ad9523_dev **device,
 	uint32_t version_id;
 	struct ad9523_dev *dev;
 
-	dev = (struct ad9523_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad9523_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -728,7 +728,7 @@ int32_t ad9523_remove(struct ad9523_dev *dev)
 
 	ret = no_os_spi_remove(dev->spi_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/frequency/ad9528/ad9528.c
+++ b/drivers/frequency/ad9528/ad9528.c
@@ -35,7 +35,7 @@
 #include <limits.h>
 #include <stdio.h>
 #include "no_os_print_log.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
 #include "no_os_clk.h"
@@ -720,21 +720,21 @@ int32_t ad9528_setup(struct ad9528_dev **device,
 		"ad9528-1_out10", "ad9528-1_out11", "ad9528-1_out12", "ad9528-1_out13"
 	};
 
-	dev = (struct ad9528_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ad9528_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -1;
 
 	if (init_param.export_no_os_clk) {
-		clocks = no_os_calloc(AD9528_NUM_CHAN, sizeof(struct no_os_clk_desc *));
+		clocks = capi_calloc(AD9528_NUM_CHAN, sizeof(struct no_os_clk_desc *));
 		if (!clocks) {
-			no_os_free(dev);
+			capi_free(dev);
 			return -1;
 		}
 		for (i = 0; i < AD9528_NUM_CHAN; i++) {
-			clocks[i] = no_os_calloc(1, sizeof(struct no_os_clk_desc));
+			clocks[i] = capi_calloc(1, sizeof(struct no_os_clk_desc));
 			if (!clocks[i]) {
 				for (j = 0; j < i; j++) {
-					no_os_free(clocks[j]);
+					capi_free(clocks[j]);
 				}
 				return -1;
 			}
@@ -747,7 +747,7 @@ int32_t ad9528_setup(struct ad9528_dev **device,
 			ret = no_os_clk_init(&clocks[i], &clk_init);
 			if (ret) {
 				for (j = 0; j < i; j++) {
-					no_os_free(clocks[j]);
+					capi_free(clocks[j]);
 				}
 				return ret;
 			}
@@ -1103,9 +1103,9 @@ pll2_bypassed:
 error:
 
 	for (i = 0; i < AD9528_NUM_CHAN; i++) {
-		no_os_free(clocks[i]);
+		capi_free(clocks[i]);
 	}
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -1143,7 +1143,7 @@ int32_t ad9528_remove(struct ad9528_dev *dev)
 	ret = no_os_spi_remove(dev->spi_desc);
 	if (ret)
 		return ret;
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/frequency/ad9545/ad9545.c
+++ b/drivers/frequency/ad9545/ad9545.c
@@ -40,7 +40,7 @@
 #include "no_os_util.h"
 #include "no_os_clk.h"
 #include "ad9545.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "sys/types.h"
 
 static const char *ad9545_aux_dpll_name = "AUX_DPLL";
@@ -1531,7 +1531,7 @@ int32_t ad9545_init(struct ad9545_dev **device,
 	struct ad9545_dev *dev;
 	int32_t ret;
 
-	dev = (struct ad9545_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad9545_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -1585,7 +1585,7 @@ int32_t ad9545_init(struct ad9545_dev **device,
 	return ret;
 error:
 	printf("ad9545 initialization error (%d)\n", ret);
-	no_os_free(dev);
+	capi_free(dev);
 	no_os_mdelay(1000);
 	return ret;
 }
@@ -1803,7 +1803,7 @@ static int ad9545_aux_ncos_setup(struct ad9545_dev *dev)
 	int ret;
 	uint8_t i;
 
-	dev->clks[AD9545_CLK_NCO] = no_os_calloc(NO_OS_ARRAY_SIZE(
+	dev->clks[AD9545_CLK_NCO] = capi_calloc(NO_OS_ARRAY_SIZE(
 					    ad9545_aux_nco_clk_names),
 				    sizeof(struct no_os_clk_desc *));
 	if (!dev->clks[AD9545_CLK_NCO])
@@ -1881,7 +1881,7 @@ static int ad9545_aux_tdcs_setup(struct ad9545_dev *dev)
 	int ret;
 	uint8_t i;
 
-	dev->clks[AD9545_CLK_AUX_TDC] = (struct no_os_clk_desc **)no_os_calloc(
+	dev->clks[AD9545_CLK_AUX_TDC] = (struct no_os_clk_desc **)capi_calloc(
 						NO_OS_ARRAY_SIZE(ad9545_aux_tdc_clk_names),
 						sizeof(*dev->clks[AD9545_CLK_AUX_TDC]));
 	if (!dev->clks[AD9545_CLK_AUX_TDC])
@@ -2122,7 +2122,7 @@ static int ad9545_plls_setup(struct ad9545_dev *dev)
 	int i;
 	int j;
 
-	dev->clks[AD9545_CLK_PLL] = (struct no_os_clk_desc **)no_os_calloc(
+	dev->clks[AD9545_CLK_PLL] = (struct no_os_clk_desc **)capi_calloc(
 					    NO_OS_ARRAY_SIZE(ad9545_pll_clk_names),
 					    sizeof(struct no_os_clk_desc *));
 	if (!dev->clks[AD9545_CLK_PLL])
@@ -2146,7 +2146,7 @@ static int ad9545_plls_setup(struct ad9545_dev *dev)
 			if (pll->profiles[j].en)
 				pll->num_parents++;
 
-		pll->parents = (struct no_os_clk_desc **)no_os_calloc(pll->num_parents,
+		pll->parents = (struct no_os_clk_desc **)capi_calloc(pll->num_parents,
 				sizeof(*pll->parents));
 		if (!pll->parents)
 			return -ENOMEM;
@@ -2265,7 +2265,7 @@ static int ad9545_outputs_setup(struct ad9545_dev *dev)
 			return ret;
 	}
 
-	dev->clks[AD9545_CLK_OUT] = no_os_calloc(NO_OS_ARRAY_SIZE(ad9545_out_clk_names),
+	dev->clks[AD9545_CLK_OUT] = capi_calloc(NO_OS_ARRAY_SIZE(ad9545_out_clk_names),
 				    sizeof(struct no_os_clk_desc *));
 	if (!dev->clks[AD9545_CLK_OUT])
 		return -ENOMEM;
@@ -2412,10 +2412,10 @@ int32_t ad9545_remove(struct ad9545_dev *dev)
 
 	for (i = 0; i < NO_OS_ARRAY_SIZE(dev->clks); i++) {
 		if (dev->clks[i])
-			no_os_free(dev->clks[i]);
+			capi_free(dev->clks[i]);
 	}
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/frequency/ad9553/ad9553.c
+++ b/drivers/frequency/ad9553/ad9553.c
@@ -37,7 +37,7 @@
 #include "no_os_error.h"
 #include "ad9553.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Reads from the ad9553 that is contected to the SPI
@@ -107,7 +107,7 @@ int32_t ad9553_setup(struct ad9553_dev **device,
 
 	struct ad9553_dev *dev;
 
-	dev = (struct ad9553_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad9553_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -232,7 +232,7 @@ int32_t ad9553_remove(struct ad9553_dev *dev)
 	if (ret != 0)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/frequency/ad9833/ad9833.c
+++ b/drivers/frequency/ad9833/ad9833.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include "ad9833.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 float phase_const = 651.8986469f;
 
@@ -75,7 +75,7 @@ int8_t ad9833_init(struct ad9833_dev **device,
 	uint16_t spi_data = 0;
 	int8_t status = -1;
 
-	dev = (struct ad9833_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad9833_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -143,7 +143,7 @@ int32_t ad9833_remove(struct ad9833_dev *dev)
 	ret |= no_os_gpio_remove(dev->gpio_reset);
 	ret |= no_os_gpio_remove(dev->gpio_sleep);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/frequency/adf4030/adf4030.c
+++ b/drivers/frequency/adf4030/adf4030.c
@@ -32,7 +32,7 @@
 *******************************************************************************/
 
 #include "adf4030.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 #include "no_os_error.h"
 #include "no_os_print_log.h"
@@ -2064,7 +2064,7 @@ int adf4030_init(struct adf4030_dev **dev,
 	struct adf4030_dev *device;
 	int ret;
 
-	device = (struct adf4030_dev *)no_os_calloc(1, sizeof(*device));
+	device = (struct adf4030_dev *)capi_calloc(1, sizeof(*device));
 	if (!device)
 		return -ENOMEM;
 
@@ -2125,7 +2125,7 @@ int adf4030_init(struct adf4030_dev **dev,
 error_spi:
 	no_os_spi_remove(device->spi_desc);
 error_dev:
-	no_os_free(device);
+	capi_free(device);
 
 	return ret;
 }
@@ -2146,7 +2146,7 @@ int adf4030_remove(struct adf4030_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/frequency/adf4030/iio_adf4030.c
+++ b/drivers/frequency/adf4030/iio_adf4030.c
@@ -37,7 +37,7 @@
 #include "no_os_util.h"
 #include "iio_adf4030.h"
 #include "adf4030.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 
 /**
@@ -791,7 +791,7 @@ int adf4030_iio_init(struct adf4030_iio_dev **iio_dev,
 	struct adf4030_iio_dev *dev;
 	int ret;
 
-	dev = (struct adf4030_iio_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct adf4030_iio_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -806,7 +806,7 @@ int adf4030_iio_init(struct adf4030_iio_dev **iio_dev,
 	return ret;
 
 error:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -823,7 +823,7 @@ int adf4030_iio_remove(struct adf4030_iio_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/frequency/adf4106/adf4106.c
+++ b/drivers/frequency/adf4106/adf4106.c
@@ -33,7 +33,7 @@
 
 #include <stdlib.h>
 #include "adf4106.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 #define DATA_MASK_MSB8      0xFF0000
 #define DATA_OFFSET_MSB8    16
@@ -82,7 +82,7 @@ int8_t adf4106_init(struct adf4106_dev **device,
 	struct adf4106_dev *dev;
 	int8_t status = -1;
 
-	dev = (struct adf4106_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct adf4106_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -153,7 +153,7 @@ int32_t adf4106_remove(struct adf4106_dev *dev)
 	ret |= no_os_gpio_remove(dev->gpio_le2);
 	ret |= no_os_gpio_remove(dev->gpio_ce2);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/frequency/adf4153/adf4153.c
+++ b/drivers/frequency/adf4153/adf4153.c
@@ -33,7 +33,7 @@
 
 #include <stdlib.h>
 #include "adf4153.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /* For round up division */
 #define CEIL(a, b) (((a) / (b)) + (((a) % (b)) > 0 ? 1 : 0))
@@ -63,7 +63,7 @@ int8_t adf4153_init(struct adf4153_dev **device,
 	struct adf4153_dev *dev;
 	int8_t status;
 
-	dev = (struct adf4153_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct adf4153_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -176,7 +176,7 @@ int32_t adf4153_remove(struct adf4153_dev *dev)
 	ret |= no_os_gpio_remove(dev->gpio_le2);
 	ret |= no_os_gpio_remove(dev->gpio_ce2);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/frequency/adf4156/adf4156.c
+++ b/drivers/frequency/adf4156/adf4156.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include "adf4156.h"
 #include "adf4156_cfg.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /***************************************************************************//**
  * @brief Initialize the SPI communication with the device.
@@ -54,7 +54,7 @@ int8_t adf4156_init(struct adf4156_dev **device,
 	uint32_t cfg_value;
 	int8_t status;
 
-	dev = (struct adf4156_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct adf4156_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -136,7 +136,7 @@ int32_t adf4156_remove(struct adf4156_dev *dev)
 	ret |= no_os_gpio_remove(dev->gpio_le);
 	ret |= no_os_gpio_remove(dev->gpio_ce);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/frequency/adf4157/adf4157.c
+++ b/drivers/frequency/adf4157/adf4157.c
@@ -33,7 +33,7 @@
 #include <stdlib.h>
 #include "adf4157.h"
 #include "adf4157_cfg.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /***************************************************************************//**
  * @brief Initialize the SPI communication with the device.
@@ -53,7 +53,7 @@ int8_t adf4157_init(struct adf4157_dev **device,
 	uint32_t cfg_value = 0;
 	int8_t status = -1;
 
-	dev = (struct adf4157_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct adf4157_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -134,7 +134,7 @@ int32_t adf4157_remove(struct adf4157_dev *dev)
 	ret |= no_os_gpio_remove(dev->gpio_le);
 	ret |= no_os_gpio_remove(dev->gpio_ce);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/frequency/adf4350/adf4350.c
+++ b/drivers/frequency/adf4350/adf4350.c
@@ -35,7 +35,7 @@
 #include <malloc.h>
 #include <stdio.h>
 #include "adf4350.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /***************************************************************************//**
  * @brief Writes 4 bytes of data to ADF4350.
@@ -273,7 +273,7 @@ int32_t adf4350_setup(adf4350_dev **device,
 	adf4350_dev *dev;
 	int32_t ret;
 
-	dev = (adf4350_dev *)no_os_malloc(sizeof(*dev));
+	dev = (adf4350_dev *)capi_malloc(sizeof(*dev));
 	if (!dev) {
 		return -1;
 	}
@@ -281,7 +281,7 @@ int32_t adf4350_setup(adf4350_dev **device,
 	/* SPI */
 	ret = no_os_spi_init(&dev->spi_desc, &init_param.spi_init);
 
-	dev->pdata = (struct adf4350_platform_data *)no_os_malloc(sizeof(*dev->pdata));
+	dev->pdata = (struct adf4350_platform_data *)capi_malloc(sizeof(*dev->pdata));
 	if (!dev->pdata)
 		return -1;
 

--- a/drivers/frequency/adf4368/adf4368.c
+++ b/drivers/frequency/adf4368/adf4368.c
@@ -32,7 +32,7 @@
 *******************************************************************************/
 
 #include "adf4368.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 #include "no_os_error.h"
 #include "no_os_print_log.h"
@@ -1901,7 +1901,7 @@ int adf4368_init(struct adf4368_dev **dev,
 	bool en = true;
 	int ret;
 
-	device = (struct adf4368_dev *)no_os_calloc(1, sizeof(*device));
+	device = (struct adf4368_dev *)capi_calloc(1, sizeof(*device));
 	if (!device)
 		return -ENOMEM;
 
@@ -1975,7 +1975,7 @@ int adf4368_init(struct adf4368_dev **dev,
 error_spi:
 	no_os_spi_remove(device->spi_desc);
 error_dev:
-	no_os_free(device);
+	capi_free(device);
 	return ret;
 }
 
@@ -1990,7 +1990,7 @@ int adf4368_remove(struct adf4368_dev *dev)
 
 	ret = no_os_spi_remove(dev->spi_desc);
 	if (ret)
-		no_os_free(dev);
+		capi_free(dev);
 
 	return 0;
 }

--- a/drivers/frequency/adf4368/iio_adf4368.c
+++ b/drivers/frequency/adf4368/iio_adf4368.c
@@ -37,7 +37,7 @@
 #include "no_os_util.h"
 #include "iio_adf4368.h"
 #include "adf4368.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 
 /**
@@ -636,7 +636,7 @@ int adf4368_iio_init(struct adf4368_iio_dev **iio_dev,
 	struct adf4368_iio_dev *dev;
 	int ret;
 
-	dev = (struct adf4368_iio_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct adf4368_iio_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -651,7 +651,7 @@ int adf4368_iio_init(struct adf4368_iio_dev **iio_dev,
 	return ret;
 
 error:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -668,7 +668,7 @@ int adf4368_iio_remove(struct adf4368_iio_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/frequency/adf4371/adf4371.c
+++ b/drivers/frequency/adf4371/adf4371.c
@@ -37,7 +37,7 @@
 #include <stdio.h>
 #include "no_os_error.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_clk.h"
 #include "adf4371.h"
 
@@ -790,7 +790,7 @@ int32_t adf4371_init(struct adf4371_dev **device,
 	int32_t ret;
 	uint32_t i;
 
-	dev = (struct adf4371_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct adf4371_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -851,7 +851,7 @@ int32_t adf4371_init(struct adf4371_dev **device,
 
 error:
 	no_os_spi_remove(dev->spi_desc);
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -868,7 +868,7 @@ int32_t adf4371_remove(struct adf4371_dev *device)
 	if (device->spi_desc)
 		ret = no_os_spi_remove(device->spi_desc);
 
-	no_os_free(device);
+	capi_free(device);
 
 	return ret;
 }

--- a/drivers/frequency/adf4377/adf4377.c
+++ b/drivers/frequency/adf4377/adf4377.c
@@ -37,7 +37,7 @@
 #include "adf4377.h"
 #include "no_os_error.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_print_log.h"
 #include "no_os_util.h"
 #include "no_os_units.h"
@@ -1354,7 +1354,7 @@ int32_t adf4377_init(struct adf4377_dev **device,
 	uint8_t chip_type;
 	struct adf4377_dev *dev;
 
-	dev = (struct adf4377_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct adf4377_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -1475,7 +1475,7 @@ error_gpio_ce:
 	no_os_gpio_remove(dev->gpio_ce);
 
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -1505,7 +1505,7 @@ int32_t adf4377_remove(struct adf4377_dev *dev)
 	if (ret < 0)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/frequency/adf4377/iio_adf4377.c
+++ b/drivers/frequency/adf4377/iio_adf4377.c
@@ -41,7 +41,7 @@
 #include "no_os_util.h"
 #include "iio_adf4377.h"
 #include "adf4377.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Supported charge pump currents for ADF4377.
@@ -724,7 +724,7 @@ int adf4377_iio_init(struct adf4377_iio_dev **iio_dev,
 	struct adf4377_iio_dev *dev;
 	int32_t ret;
 
-	dev = (struct adf4377_iio_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct adf4377_iio_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -737,7 +737,7 @@ int adf4377_iio_init(struct adf4377_iio_dev **iio_dev,
 
 	return ret;
 error:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -754,7 +754,7 @@ int adf4377_iio_remove(struct adf4377_iio_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/frequency/adf4382/adf4382.c
+++ b/drivers/frequency/adf4382/adf4382.c
@@ -33,7 +33,7 @@
 *******************************************************************************/
 
 #include "adf4382.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 #include "no_os_error.h"
 #include "no_os_print_log.h"
@@ -1998,7 +1998,7 @@ int adf4382_init(struct adf4382_dev **dev,
 	uint8_t i;
 	int ret;
 
-	device = (struct adf4382_dev *)no_os_calloc(1, sizeof(*device));
+	device = (struct adf4382_dev *)capi_calloc(1, sizeof(*device));
 	if (!device)
 		return -ENOMEM;
 
@@ -2102,7 +2102,7 @@ int adf4382_init(struct adf4382_dev **dev,
 error_spi:
 	no_os_spi_remove(device->spi_desc);
 error_dev:
-	no_os_free(device);
+	capi_free(device);
 	return ret;
 }
 
@@ -2117,7 +2117,7 @@ int adf4382_remove(struct adf4382_dev *dev)
 
 	ret = no_os_spi_remove(dev->spi_desc);
 	if (ret)
-		no_os_free(dev);
+		capi_free(dev);
 
 	return 0;
 }

--- a/drivers/frequency/adf4382/iio_adf4382.c
+++ b/drivers/frequency/adf4382/iio_adf4382.c
@@ -38,7 +38,7 @@
 #include "no_os_util.h"
 #include "iio_adf4382.h"
 #include "adf4382.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Supported charge pump currents
@@ -683,7 +683,7 @@ int adf4382_iio_init(struct adf4382_iio_dev **iio_dev,
 	struct adf4382_iio_dev *dev;
 	int ret;
 
-	dev = (struct adf4382_iio_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct adf4382_iio_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -698,7 +698,7 @@ int adf4382_iio_init(struct adf4382_iio_dev **iio_dev,
 	return ret;
 
 error:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -715,7 +715,7 @@ int adf4382_iio_remove(struct adf4382_iio_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/frequency/adf5355/adf5355.c
+++ b/drivers/frequency/adf5355/adf5355.c
@@ -37,7 +37,7 @@
 #include <malloc.h>
 #include "no_os_delay.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "adf5355.h"
 
 /**
@@ -453,7 +453,7 @@ int32_t adf5355_init(struct adf5355_dev **device,
 	int32_t ret;
 	struct adf5355_dev *dev;
 
-	dev = (struct adf5355_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct adf5355_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -520,7 +520,7 @@ int32_t adf5355_init(struct adf5355_dev **device,
 error_spi:
 	no_os_spi_remove(dev->spi_desc);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -537,7 +537,7 @@ int32_t adf5355_remove(struct adf5355_dev *device)
 	if (device->spi_desc)
 		ret = no_os_spi_remove(device->spi_desc);
 
-	no_os_free(device);
+	capi_free(device);
 
 	return ret;
 }

--- a/drivers/frequency/adf5611/adf5611.c
+++ b/drivers/frequency/adf5611/adf5611.c
@@ -32,7 +32,7 @@
 *******************************************************************************/
 
 #include "adf5611.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_print_log.h"
 #include "no_os_delay.h"
@@ -885,7 +885,7 @@ int adf5611_init(struct adf5611_dev **dev,
 	uint8_t i;
 	int ret;
 
-	device = (struct adf5611_dev *)no_os_calloc(1, sizeof(*device));
+	device = (struct adf5611_dev *)capi_calloc(1, sizeof(*device));
 	if (!device)
 		return -ENOMEM;
 
@@ -954,7 +954,7 @@ int adf5611_init(struct adf5611_dev **dev,
 error_spi:
 	no_os_spi_remove(device->spi_desc);
 error_dev:
-	no_os_free(device);
+	capi_free(device);
 	return ret;
 }
 
@@ -969,7 +969,7 @@ int adf5611_remove(struct adf5611_dev *dev)
 
 	ret = no_os_spi_remove(dev->spi_desc);
 	if (ret)
-		no_os_free(dev);
+		capi_free(dev);
 
 	return 0;
 }

--- a/drivers/frequency/adf5611/iio_adf5611.c
+++ b/drivers/frequency/adf5611/iio_adf5611.c
@@ -37,7 +37,7 @@
 #include "no_os_util.h"
 #include "iio_adf5611.h"
 #include "adf5611.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 
 /**
@@ -534,7 +534,7 @@ int adf5611_iio_init(struct adf5611_iio_dev **iio_dev,
 	struct adf5611_iio_dev *dev;
 	int ret;
 
-	dev = (struct adf5611_iio_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct adf5611_iio_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -550,7 +550,7 @@ int adf5611_iio_init(struct adf5611_iio_dev **iio_dev,
 	return ret;
 
 error:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -567,7 +567,7 @@ int adf5611_iio_remove(struct adf5611_iio_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/frequency/adf5902/adf5902.c
+++ b/drivers/frequency/adf5902/adf5902.c
@@ -36,7 +36,7 @@
 #include "no_os_error.h"
 #include "no_os_delay.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Writes 4 bytes of data to ADF5902.
@@ -472,7 +472,7 @@ int32_t adf5902_init(struct adf5902_dev **device,
 	if (ret != 0)
 		return ret;
 
-	dev = (struct adf5902_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct adf5902_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -656,7 +656,7 @@ error_gpio:
 	no_os_gpio_remove(dev->gpio_ce);
 
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -904,7 +904,7 @@ int32_t adf5902_remove(struct adf5902_dev *dev)
 
 	ret = no_os_gpio_remove(dev->gpio_ce);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/frequency/admfm2000/admfm2000.c
+++ b/drivers/frequency/admfm2000/admfm2000.c
@@ -32,7 +32,7 @@
 *******************************************************************************/
 
 #include "admfm2000.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_print_log.h"
 
@@ -134,7 +134,7 @@ int admfm2000_init(struct admfm2000_dev **device,
 	uint8_t i, j;
 	struct admfm2000_dev *dev;
 
-	dev = (struct admfm2000_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct admfm2000_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -181,7 +181,7 @@ int admfm2000_init(struct admfm2000_dev **device,
 	return 0;
 
 error:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -203,7 +203,7 @@ int admfm2000_remove(struct admfm2000_dev *dev)
 		for (j = 0; j < ADMFM2000_DSA_GPIOS; j++)
 			no_os_gpio_remove(dev->gpio_dsa[i][j]);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/frequency/admfm2000/iio_admfm2000.c
+++ b/drivers/frequency/admfm2000/iio_admfm2000.c
@@ -37,7 +37,7 @@
 #include "no_os_error.h"
 #include "no_os_util.h"
 #include "iio_admfm2000.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Get the channel gain.
@@ -169,7 +169,7 @@ int admfm2000_iio_init(struct admfm2000_iio_dev **iio_dev,
 	struct admfm2000_dev *admfm2000_dev;
 	int32_t ret;
 
-	iio_admfm2000 = (struct admfm2000_iio_dev *)no_os_calloc(1,
+	iio_admfm2000 = (struct admfm2000_iio_dev *)capi_calloc(1,
 			sizeof(*iio_admfm2000));
 	if (!iio_admfm2000)
 		return -ENOMEM;
@@ -199,8 +199,8 @@ int admfm2000_iio_remove(struct admfm2000_iio_dev *desc)
 	if (ret)
 		return ret;
 
-	no_os_free(desc->admfm2000_dev);
-	no_os_free(desc);
+	capi_free(desc->admfm2000_dev);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/frequency/admv1013/admv1013.c
+++ b/drivers/frequency/admv1013/admv1013.c
@@ -34,7 +34,7 @@
 #include <malloc.h>
 #include "admv1013.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 #define MIXER_GATE_0_TO_1_8_V(x)		((2389 * x/ 1000000 + 8100) / 100)
 #define MIXER_GATE_1_8_TO_2_6_V(x)		((2375 * x/ 1000000 + 125) / 100)
@@ -294,7 +294,7 @@ int admv1013_init(struct admv1013_dev **device,
 	uint16_t data;
 	int ret;
 
-	dev = (struct admv1013_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct admv1013_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -366,7 +366,7 @@ int admv1013_init(struct admv1013_dev **device,
 error_spi:
 	no_os_spi_remove(dev->spi_desc);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -384,7 +384,7 @@ int admv1013_remove(struct admv1013_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/frequency/admv1014/admv1014.c
+++ b/drivers/frequency/admv1014/admv1014.c
@@ -34,7 +34,7 @@
 #include <malloc.h>
 #include "admv1014.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 static const int mixer_vgate_table[] = {
 	106, 107, 108, 110, 111, 112, 113, 114,
@@ -363,7 +363,7 @@ int admv1014_init(struct admv1014_dev **device,
 	uint16_t chip_id, enable_reg, enable_reg_msk;
 	int ret;
 
-	dev = (struct admv1014_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct admv1014_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -443,7 +443,7 @@ int admv1014_init(struct admv1014_dev **device,
 error_spi:
 	no_os_spi_remove(dev->spi_desc);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -461,7 +461,7 @@ int admv1014_remove(struct admv1014_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/frequency/adrf6780/adrf6780.c
+++ b/drivers/frequency/adrf6780/adrf6780.c
@@ -35,7 +35,7 @@
 #include "adrf6780.h"
 #include "no_os_error.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Writes data to ADRF6780 over SPI.
@@ -267,7 +267,7 @@ int adrf6780_init(struct adrf6780_dev **device,
 	struct adrf6780_dev *dev;
 	int ret;
 
-	dev = (struct adrf6780_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct adrf6780_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -345,7 +345,7 @@ int adrf6780_init(struct adrf6780_dev **device,
 error_spi:
 	no_os_spi_remove(dev->spi_desc);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -363,7 +363,7 @@ int adrf6780_remove(struct adrf6780_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/frequency/hmc7044/hmc7044.c
+++ b/drivers/frequency/hmc7044/hmc7044.c
@@ -37,7 +37,7 @@
 #include "no_os_print_log.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_clk.h"
 #include "hmc7044.h"
 #include "jesd204.h"
@@ -1485,7 +1485,7 @@ int32_t hmc7044_init(struct hmc7044_dev **device,
 		"clock_10", "clock_11", "clock_12", "clock_13"
 	};
 
-	dev = (struct hmc7044_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct hmc7044_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -1494,11 +1494,11 @@ int32_t hmc7044_init(struct hmc7044_dev **device,
 		return ret;
 
 	if (init_param->export_no_os_clk) {
-		clocks = no_os_calloc(HMC7044_NUM_CHAN, sizeof(struct no_os_clk_desc *));
+		clocks = capi_calloc(HMC7044_NUM_CHAN, sizeof(struct no_os_clk_desc *));
 		if (!clocks)
 			return -1;
 		for (i = 0; i < HMC7044_NUM_CHAN; i++) {
-			clocks[i] = no_os_calloc(1, sizeof(struct no_os_clk_desc));
+			clocks[i] = capi_calloc(1, sizeof(struct no_os_clk_desc));
 			if (!clocks[i])
 				return -1;
 			/* Initialize clk component */
@@ -1587,7 +1587,7 @@ int32_t hmc7044_init(struct hmc7044_dev **device,
 
 	dev->num_channels = init_param->num_channels;
 	dev->channels = (struct hmc7044_chan_spec *)
-			no_os_malloc(sizeof(*dev->channels) * dev->num_channels);
+			capi_malloc(sizeof(*dev->channels) * dev->num_channels);
 
 	for (i = 0; i < dev->num_channels; i++) {
 		dev->channels[i].num = init_param->channels[i].num;
@@ -1639,8 +1639,8 @@ int32_t hmc7044_remove(struct hmc7044_dev *device)
 	int32_t ret;
 
 	ret = no_os_spi_remove(device->spi_desc);
-	no_os_free(device->channels);
-	no_os_free(device);
+	capi_free(device->channels);
+	capi_free(device);
 
 	return ret;
 }

--- a/drivers/frequency/ltc6953/ltc6953.c
+++ b/drivers/frequency/ltc6953/ltc6953.c
@@ -40,7 +40,7 @@
 #include "no_os_spi.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 static const uint8_t LTC6953_LUT[2][LTC6953_NUM_REGADDR] = {
 	{
@@ -73,7 +73,7 @@ int ltc6953_init(struct ltc6953_dev **device,
 	int ret;
 	struct ltc6953_dev *dev;
 
-	dev = (struct ltc6953_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ltc6953_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -93,7 +93,7 @@ int ltc6953_init(struct ltc6953_dev **device,
 error:
 	no_os_spi_remove(dev->spi_desc);
 error_init:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -190,7 +190,7 @@ int ltc6953_remove(struct ltc6953_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/gmsl/common/gmsl_reg_access.c
+++ b/drivers/gmsl/common/gmsl_reg_access.c
@@ -32,7 +32,7 @@
 ******************************************************************************/
 
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_util.h"
 #include "no_os_i2c.h"
 #include "gmsl_reg_access.h"

--- a/drivers/gmsl/deserializer/camera/max96792/max96792.c
+++ b/drivers/gmsl/deserializer/camera/max96792/max96792.c
@@ -36,7 +36,7 @@
 #include "max96792_csi.h"
 #include "gmsl_dbg.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "gmsl_cam_des.h"
 #include "max96792_diag.h"
 
@@ -128,14 +128,14 @@ int32_t max96792_init(struct gmsl_dev** device, struct no_os_i2c_desc* i2c_desc,
 			break;
 		}
 
-		dev = no_os_calloc(1, sizeof(*dev));
+		dev = capi_calloc(1, sizeof(*dev));
 		if (!dev) {
 			ret = -ENOMEM;
 			init_error = true;
 			break;
 		}
 
-		dev_cap = no_os_calloc(1, sizeof(*dev_cap));
+		dev_cap = capi_calloc(1, sizeof(*dev_cap));
 		if (dev_cap == NULL) {
 			ret = -ENOMEM;
 			error_remove_dev = true;
@@ -175,7 +175,7 @@ int32_t max96792_init(struct gmsl_dev** device, struct no_os_i2c_desc* i2c_desc,
 		else
 			strcpy(dev->dev_name, DEV_NAME);
 
-		dev->dev_state = no_os_calloc(1, MAX96792_DEV_STATE_MEM_SIZE);
+		dev->dev_state = capi_calloc(1, MAX96792_DEV_STATE_MEM_SIZE);
 		if (!dev->dev_state) {
 			ret = -ENOMEM;
 			error_remove_cap = true;
@@ -189,11 +189,11 @@ int32_t max96792_init(struct gmsl_dev** device, struct no_os_i2c_desc* i2c_desc,
 	} while (false);
 
 	if (error_remove_cap) {
-		no_os_free(dev_cap);
+		capi_free(dev_cap);
 	}
 
 	if (error_remove_cap || error_remove_dev) {
-		no_os_free(dev);
+		capi_free(dev);
 	}
 	if (error_remove_cap || error_remove_dev || init_error) {
 		GMSL_LOG_ERROR("MAX96792 Initialization failed");
@@ -221,7 +221,7 @@ int32_t max96792_remove(struct gmsl_dev* dev)
 	slave_addr = dev->i2c_desc->slave_address;
 #endif
 	if (dev->dev_state != NULL) {
-		no_os_free(dev->dev_state);
+		capi_free(dev->dev_state);
 	} else {
 		GMSL_LOG_ERROR("%s-0x%x Freeing of device state memory failed",
 			       (char *)DEV_NAME, slave_addr);
@@ -229,14 +229,14 @@ int32_t max96792_remove(struct gmsl_dev* dev)
 	}
 
 	if (dev->dev_cap != NULL) {
-		no_os_free(dev->dev_cap);
+		capi_free(dev->dev_cap);
 	} else {
 		GMSL_LOG_ERROR("%s-0x%x Freeing of device capability memory failed",
 			       (char *)DEV_NAME, slave_addr);
 		ret = -EINVAL;
 	}
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	GMSL_LOG_INFO("%s-0x%x remove passed", (char *)DEV_NAME, slave_addr);
 

--- a/drivers/gmsl/deserializer/camera/max96792/max96792.h
+++ b/drivers/gmsl/deserializer/camera/max96792/max96792.h
@@ -37,7 +37,7 @@
 #include "gmsl_common.h"
 #include "gmsl_dbg.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "gmsl_cam_des.h"
 
 #define MAX96792_DEV_STATE_MEM_SIZE         (sizeof(struct max96792_state))

--- a/drivers/gmsl/serializer/camera/max96793/max96793.c
+++ b/drivers/gmsl/serializer/camera/max96793/max96793.c
@@ -36,7 +36,7 @@
 #include "max96793_csi.h"
 #include "gmsl_dbg.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "gmsl_reg_access.h"
 
 #define MAX96793_MAX_LINKS          (1U)
@@ -121,13 +121,13 @@ int32_t max96793_init(struct gmsl_dev **device, struct no_os_i2c_desc *i2c_desc,
 		goto init_error;
 	}
 
-	dev = no_os_calloc(1, sizeof(*dev));
+	dev = capi_calloc(1, sizeof(*dev));
 	if (!dev) {
 		ret = -ENOMEM;
 		goto init_error;
 	}
 
-	dev_cap = no_os_calloc(1, sizeof(*dev_cap));
+	dev_cap = capi_calloc(1, sizeof(*dev_cap));
 	if (!dev_cap) {
 		ret = -ENOMEM;
 		goto error_remove_dev;
@@ -152,7 +152,7 @@ int32_t max96793_init(struct gmsl_dev **device, struct no_os_i2c_desc *i2c_desc,
 	else
 		strcpy(dev->dev_name, DEV_NAME);         /*!< Default device name */
 
-	dev->dev_state = no_os_calloc(1, MAX96793_DEV_STATE_MEM_SIZE);
+	dev->dev_state = capi_calloc(1, MAX96793_DEV_STATE_MEM_SIZE);
 	if (!dev->dev_state) {
 		ret = -ENOMEM;
 		goto error_remove_cap;
@@ -166,10 +166,10 @@ int32_t max96793_init(struct gmsl_dev **device, struct no_os_i2c_desc *i2c_desc,
 	goto exit;
 
 error_remove_cap:
-	no_os_free(dev_cap);
+	capi_free(dev_cap);
 
 error_remove_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 init_error:
 	GMSL_LOG_ERROR("MAX96793 Initialization failed");
@@ -199,7 +199,7 @@ int32_t max96793_remove(struct gmsl_dev *dev)
 	slave_addr = dev->i2c_desc->slave_address;
 #endif
 	if (dev->dev_state != NULL) {
-		no_os_free(dev->dev_state);
+		capi_free(dev->dev_state);
 	} else {
 		GMSL_LOG_ERROR("%s-0x%x Freeing of device state memory failed",
 			       (char *)DEV_NAME, slave_addr);
@@ -207,14 +207,14 @@ int32_t max96793_remove(struct gmsl_dev *dev)
 	}
 
 	if (dev->dev_cap != NULL) {
-		no_os_free(dev->dev_cap);
+		capi_free(dev->dev_cap);
 	} else {
 		GMSL_LOG_ERROR("%s-0x%x Freeing of device capabilities memory failed",
 			       (char *)DEV_NAME, slave_addr);
 		ret = -EINVAL;
 	}
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	GMSL_LOG_INFO("%s-0x%x remove passed", (char *)DEV_NAME, slave_addr);
 

--- a/drivers/gnss-gps/nmea_ubx/nmea_ubx.c
+++ b/drivers/gnss-gps/nmea_ubx/nmea_ubx.c
@@ -41,7 +41,7 @@
 #include "no_os_gpio.h"
 #include "no_os_irq.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_print_log.h"
 #include <stdlib.h>
 #include <errno.h>
@@ -109,7 +109,7 @@ int gnss_init(struct gnss_dev **device,
 	if (!device)
 		return -EINVAL;
 
-	dev = (struct gnss_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct gnss_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 	init_param.uart_init->baud_rate = init_param.baud_rate;
@@ -179,9 +179,9 @@ int gnss_init(struct gnss_dev **device,
 		no_os_mdelay(100);
 
 		/* flush the UART port */
-		scrap = no_os_calloc(500, sizeof(uint8_t));
+		scrap = capi_calloc(500, sizeof(uint8_t));
 		no_os_uart_read_nonblocking(dev->uart_desc, scrap, 500);
-		no_os_free(scrap);
+		capi_free(scrap);
 
 		/* Configure baudrate via UBX commands (if specified) */
 		if (init_param.baud_rate > 0) {
@@ -217,7 +217,7 @@ error_reset:
 error_uart:
 	no_os_uart_remove(dev->uart_desc);
 remove_device:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -237,7 +237,7 @@ int gnss_remove(struct gnss_dev *dev)
 	if (dev->uart_desc)
 		no_os_uart_remove(dev->uart_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }
@@ -358,7 +358,7 @@ int gnss_ubx_send_packet(struct gnss_dev *dev, uint8_t cls,
 		return -ERANGE;
 
 	/* packet header is 6 bytes and CRC is 2 bytes */
-	packet = no_os_calloc(length + 8, sizeof(uint8_t));
+	packet = capi_calloc(length + 8, sizeof(uint8_t));
 
 	/* Build packet header */
 	packet[0] = UBX_SYNCH_1;
@@ -384,11 +384,11 @@ int gnss_ubx_send_packet(struct gnss_dev *dev, uint8_t cls,
 	/* Send packet */
 	ret = gnss_write(dev, packet, packet_size);
 	if (ret < 0) {
-		no_os_free(packet);
+		capi_free(packet);
 		return ret;
 	}
 
-	no_os_free(packet);
+	capi_free(packet);
 	return 0;
 }
 
@@ -411,7 +411,7 @@ int gnss_ubx_receive_packet(struct gnss_dev *dev,
 	if (!dev || !packet)
 		return -EINVAL;
 
-	header = no_os_calloc(6, sizeof(uint8_t));
+	header = capi_calloc(6, sizeof(uint8_t));
 	/* Read 6 bytes that represent the UBX header */
 	ret = gnss_read(dev, header, 6);
 	if (ret < 0)
@@ -428,8 +428,8 @@ int gnss_ubx_receive_packet(struct gnss_dev *dev,
 	/* bytes 5-6 - length bytes (little endian) */
 	packet->length = no_os_get_unaligned_le16(&header[4]);
 	/* Prepare buffer for payload depending on the packet length + 2 bytes CRC */
-	byte = no_os_calloc(packet->length + 2, sizeof(uint8_t));
-	packet->payload = no_os_calloc(packet->length, sizeof(uint8_t));
+	byte = capi_calloc(packet->length + 2, sizeof(uint8_t));
+	packet->payload = capi_calloc(packet->length, sizeof(uint8_t));
 	/* Read payload + 2 checksum bytes */
 	ret = gnss_read(dev, byte, packet->length + 2);
 	if (ret < 0)
@@ -446,7 +446,7 @@ int gnss_ubx_receive_packet(struct gnss_dev *dev,
 	no_os_put_unaligned_le16(packet->length, &header[2]);
 
 	/* Calculate checksum over header and payload */
-	data = no_os_calloc(packet->length + 4, sizeof(uint8_t));
+	data = capi_calloc(packet->length + 4, sizeof(uint8_t));
 	memcpy(&data[0], header, 4);
 	if (packet->payload && packet->length > 0) {
 		memcpy(&data[4], packet->payload, packet->length);
@@ -473,12 +473,12 @@ int gnss_ubx_receive_packet(struct gnss_dev *dev,
 	}
 
 free_payload:
-	no_os_free(packet->payload);
+	capi_free(packet->payload);
 free_data:
-	no_os_free(data);
-	no_os_free(byte);
+	capi_free(data);
+	capi_free(byte);
 free_header:
-	no_os_free(header);
+	capi_free(header);
 
 	return ret;
 }
@@ -523,7 +523,7 @@ int gnss_ubx_wait_for_ack(struct gnss_dev *dev, uint8_t cls, uint8_t id)
 
 free_payload:
 	if (packet.payload)
-		no_os_free(packet.payload);
+		capi_free(packet.payload);
 	return ret;
 }
 
@@ -567,7 +567,7 @@ int gnss_ubx_set_val_no_ack(struct gnss_dev *dev, uint32_t key_id,
 		return -EINVAL;
 	}
 
-	payload = no_os_calloc(value_size + 8, sizeof(uint8_t));
+	payload = capi_calloc(value_size + 8, sizeof(uint8_t));
 	/* Build payload */
 	payload[0] = 0;			/* Version */
 	payload[1] = layer_val;		/* Layer */
@@ -603,7 +603,7 @@ int gnss_ubx_set_val_no_ack(struct gnss_dev *dev, uint32_t key_id,
 	ret = 0;
 
 free_payload:
-	no_os_free(payload);
+	capi_free(payload);
 	return ret;
 }
 
@@ -648,7 +648,7 @@ int gnss_ubx_set_val(struct gnss_dev *dev, uint32_t key_id,
 		return -EINVAL;
 	}
 
-	payload = no_os_calloc(value_size + 8, sizeof(uint8_t));
+	payload = capi_calloc(value_size + 8, sizeof(uint8_t));
 	/* Build payload */
 	payload[0] = 0;			/* Version */
 	payload[1] = layer_val;		/* Layer */
@@ -672,7 +672,7 @@ int gnss_ubx_set_val(struct gnss_dev *dev, uint32_t key_id,
 		no_os_put_unaligned_le64(value, &payload[8]);
 		break;
 	default:
-		no_os_free(payload);
+		capi_free(payload);
 		return -EINVAL;
 	}
 
@@ -690,7 +690,7 @@ int gnss_ubx_set_val(struct gnss_dev *dev, uint32_t key_id,
 	ret = 0;
 
 free_payload:
-	no_os_free(payload);
+	capi_free(payload);
 	return ret;
 }
 
@@ -733,7 +733,7 @@ int gnss_ubx_get_val(struct gnss_dev *dev, uint32_t key_id,
 		return -EINVAL;
 	}
 
-	payload = no_os_calloc(value_size + 8, sizeof(uint8_t));
+	payload = capi_calloc(value_size + 8, sizeof(uint8_t));
 	/* Build payload */
 	payload[0] = 0;			/* Version */
 	payload[1] = layer_val;		/* Layer */
@@ -795,9 +795,9 @@ int gnss_ubx_get_val(struct gnss_dev *dev, uint32_t key_id,
 	ret = 0;
 
 free_response:
-	no_os_free(response.payload);
+	capi_free(response.payload);
 free_payload:
-	no_os_free(payload);
+	capi_free(payload);
 
 	return ret;
 }
@@ -1062,13 +1062,13 @@ int gnss_ubx_poll_nav_pvt(struct gnss_dev *dev,
 	/* Verify response */
 	if (response.cls != UBX_CLASS_NAV || response.id != UBX_NAV_PVT) {
 		if (response.payload)
-			no_os_free(response.payload);
+			capi_free(response.payload);
 		return -EIO;
 	}
 
 	if (response.length < sizeof(struct gnss_ubx_nav_pvt)) {
 		if (response.payload)
-			no_os_free(response.payload);
+			capi_free(response.payload);
 		return -EIO;
 	}
 
@@ -1076,7 +1076,7 @@ int gnss_ubx_poll_nav_pvt(struct gnss_dev *dev,
 	memcpy(nav_data, response.payload, sizeof(struct gnss_ubx_nav_pvt));
 
 	if (response.payload)
-		no_os_free(response.payload);
+		capi_free(response.payload);
 
 	return 0;
 }
@@ -1112,13 +1112,13 @@ int gnss_ubx_poll_nav_timeutc(struct gnss_dev *dev,
 	/* Verify response */
 	if (response.cls != UBX_CLASS_NAV || response.id != UBX_NAV_TIMEUTC) {
 		if (response.payload)
-			no_os_free(response.payload);
+			capi_free(response.payload);
 		return -EIO;
 	}
 
 	if (response.length < sizeof(struct gnss_ubx_nav_timeutc)) {
 		if (response.payload)
-			no_os_free(response.payload);
+			capi_free(response.payload);
 		return -EIO;
 	}
 
@@ -1126,7 +1126,7 @@ int gnss_ubx_poll_nav_timeutc(struct gnss_dev *dev,
 	memcpy(time_data, response.payload, sizeof(struct gnss_ubx_nav_timeutc));
 
 	if (response.payload)
-		no_os_free(response.payload);
+		capi_free(response.payload);
 
 	return 0;
 }
@@ -1886,7 +1886,7 @@ int gnss_parse_gprmc_sentence(const char *sentence,
 
 	/* Create working copy for parsing */
 	len = strlen(sentence);
-	sentence_copy = no_os_calloc(len + 1, sizeof(char));
+	sentence_copy = capi_calloc(len + 1, sizeof(char));
 	if (!sentence_copy)
 		return -ENOMEM;
 	strcpy(sentence_copy, sentence);
@@ -1980,7 +1980,7 @@ int gnss_parse_gprmc_sentence(const char *sentence,
 		ret = -EINVAL;
 	}
 
-	no_os_free(sentence_copy);
+	capi_free(sentence_copy);
 	return ret;
 }
 
@@ -2313,7 +2313,7 @@ int gnss_parse_gpgga_sentence(const char *sentence,
 
 	/* Create working copy for parsing */
 	len = strlen(sentence);
-	sentence_copy = no_os_calloc(len + 1, sizeof(char));
+	sentence_copy = capi_calloc(len + 1, sizeof(char));
 	if (!sentence_copy) {
 		return -ENOMEM;
 	}
@@ -2388,7 +2388,7 @@ int gnss_parse_gpgga_sentence(const char *sentence,
 		ret = -EINVAL;
 	}
 
-	no_os_free(sentence_copy);
+	capi_free(sentence_copy);
 	return ret;
 }
 

--- a/drivers/gnss-gps/nmea_ubx/nmea_ubx.h
+++ b/drivers/gnss-gps/nmea_ubx/nmea_ubx.h
@@ -41,7 +41,7 @@
 #include "no_os_gpio.h"
 #include "no_os_irq.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_print_log.h"
 #include "no_os_error.h"
 #include <stdlib.h>

--- a/drivers/gyro/adxrs290/adxrs290.c
+++ b/drivers/gyro/adxrs290/adxrs290.c
@@ -34,7 +34,7 @@
 #include <stdint.h>
 #include <string.h>
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "adxrs290.h"
 
 /**
@@ -329,7 +329,7 @@ int32_t adxrs290_init(struct adxrs290_dev **device,
 	int32_t ret = 0;
 	uint8_t val = 0;
 
-	dev = (struct adxrs290_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct adxrs290_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -391,7 +391,7 @@ error_spi:
 	no_os_spi_remove(dev->spi_desc);
 
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -405,7 +405,7 @@ int32_t adxrs290_remove(struct adxrs290_dev *dev)
 {
 	no_os_spi_remove(dev->spi_desc);
 	no_os_gpio_remove(dev->gpio_sync);
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/gyro/adxrs453/adxrs453.c
+++ b/drivers/gyro/adxrs453/adxrs453.c
@@ -33,7 +33,7 @@
 
 #include <stdlib.h>
 #include "adxrs453.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /***************************************************************************//**
  * @brief Initializes the ADXRS453 and checks if the device is present.
@@ -54,7 +54,7 @@ int32_t adxrs453_init(struct adxrs453_dev **device,
 	int32_t status = 0;
 	uint16_t adxrs453_id = 0;
 
-	dev = (struct adxrs453_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct adxrs453_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -83,7 +83,7 @@ int32_t adxrs453_remove(struct adxrs453_dev *dev)
 
 	ret = no_os_spi_remove(dev->spi_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/impedance-analyzer/ad5933/ad5933.c
+++ b/drivers/impedance-analyzer/ad5933/ad5933.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include "ad5933.h"
 #include <math.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 const int32_t pow_2_27 = 134217728ul;      // 2 to the power of 27
 
@@ -58,7 +58,7 @@ int32_t ad5933_init(struct ad5933_dev **device,
 	struct ad5933_dev *dev;
 	int32_t status;
 
-	dev = (struct ad5933_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad5933_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -69,7 +69,7 @@ int32_t ad5933_init(struct ad5933_dev **device,
 
 	status = no_os_i2c_init(&dev->i2c_desc, &init_param.i2c_init);
 	if (status) {
-		no_os_free(dev);
+		capi_free(dev);
 		return status;
 	}
 
@@ -91,7 +91,7 @@ int32_t ad5933_remove(struct ad5933_dev *dev)
 
 	status = no_os_i2c_remove(dev->i2c_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return status;
 }

--- a/drivers/imu/adis.c
+++ b/drivers/imu/adis.c
@@ -36,7 +36,7 @@
 #include "no_os_delay.h"
 #include "no_os_gpio.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_print_log.h"
 #include <string.h>
 
@@ -92,7 +92,7 @@ int adis_init(struct adis_dev **adis, const struct adis_init_param *ip)
 	if (!ip || !ip->info)
 		return -EINVAL;
 
-	dev = (struct adis_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct adis_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -139,7 +139,7 @@ error:
 	no_os_gpio_remove(dev->gpio_reset);
 	no_os_spi_remove(dev->spi_desc);
 error_spi:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -156,7 +156,7 @@ void adis_remove(struct adis_dev *adis)
 	if (adis->spi_desc)
 		no_os_spi_remove(adis->spi_desc);
 
-	no_os_free(adis);
+	capi_free(adis);
 }
 
 /**

--- a/drivers/imu/iio_adis1646x.c
+++ b/drivers/imu/iio_adis1646x.c
@@ -32,7 +32,7 @@
  ******************************************************************************/
 
 #include "iio_adis1646x.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_units.h"
 
 static const char * const adis1646x_rang_mdl_txt[] = {
@@ -351,7 +351,7 @@ int adis1646x_iio_init(struct adis_iio_dev **iio_dev,
 	int ret;
 	struct adis_iio_dev *desc;
 
-	desc = (struct adis_iio_dev *)no_os_calloc(1, sizeof(*desc));
+	desc = (struct adis_iio_dev *)capi_calloc(1, sizeof(*desc));
 	if (!desc)
 		return -ENOMEM;
 
@@ -370,7 +370,7 @@ int adis1646x_iio_init(struct adis_iio_dev **iio_dev,
 	return 0;
 
 error_adis1646x_init:
-	no_os_free(desc);
+	capi_free(desc);
 	return ret;
 }
 
@@ -383,5 +383,5 @@ void adis1646x_iio_remove(struct adis_iio_dev *desc)
 	if (!desc)
 		return;
 	adis_remove(desc->adis_dev);
-	no_os_free(desc);
+	capi_free(desc);
 }

--- a/drivers/imu/iio_adis1647x.c
+++ b/drivers/imu/iio_adis1647x.c
@@ -32,7 +32,7 @@
  ******************************************************************************/
 
 #include "iio_adis1647x.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_units.h"
 
 static const char * const adis1647x_rang_mdl_txt[] = {
@@ -372,7 +372,7 @@ int adis1647x_iio_init(struct adis_iio_dev **iio_dev,
 	int ret;
 	struct adis_iio_dev *desc;
 
-	desc = (struct adis_iio_dev *)no_os_calloc(1, sizeof(*desc));
+	desc = (struct adis_iio_dev *)capi_calloc(1, sizeof(*desc));
 	if (!desc)
 		return -ENOMEM;
 
@@ -391,7 +391,7 @@ int adis1647x_iio_init(struct adis_iio_dev **iio_dev,
 	return 0;
 
 error_adis1647x_init:
-	no_os_free(desc);
+	capi_free(desc);
 	return ret;
 }
 
@@ -404,5 +404,5 @@ void adis1647x_iio_remove(struct adis_iio_dev *desc)
 	if (!desc)
 		return;
 	adis_remove(desc->adis_dev);
-	no_os_free(desc);
+	capi_free(desc);
 }

--- a/drivers/imu/iio_adis1650x.c
+++ b/drivers/imu/iio_adis1650x.c
@@ -32,7 +32,7 @@
  ******************************************************************************/
 
 #include "iio_adis1650x.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_units.h"
 
 static const char * const adis1650x_rang_mdl_txt[] = {
@@ -351,7 +351,7 @@ int adis1650x_iio_init(struct adis_iio_dev **iio_dev,
 	int ret;
 	struct adis_iio_dev *desc;
 
-	desc = (struct adis_iio_dev *)no_os_calloc(1, sizeof(*desc));
+	desc = (struct adis_iio_dev *)capi_calloc(1, sizeof(*desc));
 	if (!desc)
 		return -ENOMEM;
 
@@ -370,7 +370,7 @@ int adis1650x_iio_init(struct adis_iio_dev **iio_dev,
 	return 0;
 
 error_adis1650x_init:
-	no_os_free(desc);
+	capi_free(desc);
 	return ret;
 }
 
@@ -383,5 +383,5 @@ void adis1650x_iio_remove(struct adis_iio_dev *desc)
 	if (!desc)
 		return;
 	adis_remove(desc->adis_dev);
-	no_os_free(desc);
+	capi_free(desc);
 }

--- a/drivers/imu/iio_adis1654x.c
+++ b/drivers/imu/iio_adis1654x.c
@@ -32,7 +32,7 @@
  ******************************************************************************/
 
 #include "iio_adis1654x.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_units.h"
 
 static const char * const adis1654x_rang_mdl_txt[] = {
@@ -633,7 +633,7 @@ int adis1654x_iio_init(struct adis_iio_dev **iio_dev,
 	int ret;
 	struct adis_iio_dev *desc;
 
-	desc = (struct adis_iio_dev *)no_os_calloc(1, sizeof(*desc));
+	desc = (struct adis_iio_dev *)capi_calloc(1, sizeof(*desc));
 	if (!desc)
 		return -ENOMEM;
 
@@ -652,7 +652,7 @@ int adis1654x_iio_init(struct adis_iio_dev **iio_dev,
 	return 0;
 
 error_adis1654x_init:
-	no_os_free(desc);
+	capi_free(desc);
 	return ret;
 }
 
@@ -663,5 +663,5 @@ error_adis1654x_init:
 void adis1654x_iio_remove(struct adis_iio_dev *desc)
 {
 	adis_remove(desc->adis_dev);
-	no_os_free(desc);
+	capi_free(desc);
 }

--- a/drivers/imu/iio_adis1655x.c
+++ b/drivers/imu/iio_adis1655x.c
@@ -32,7 +32,7 @@
  ******************************************************************************/
 
 #include "iio_adis1655x.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_units.h"
 
 static const char * const adis1655x_rang_mdl_txt[] = {
@@ -477,7 +477,7 @@ int adis1655x_iio_init(struct adis_iio_dev **iio_dev,
 	int ret;
 	struct adis_iio_dev *desc;
 
-	desc = (struct adis_iio_dev *)no_os_calloc(1, sizeof(*desc));
+	desc = (struct adis_iio_dev *)capi_calloc(1, sizeof(*desc));
 	if (!desc)
 		return -ENOMEM;
 
@@ -495,7 +495,7 @@ int adis1655x_iio_init(struct adis_iio_dev **iio_dev,
 	return 0;
 
 error_adis1655x_init:
-	no_os_free(desc);
+	capi_free(desc);
 	return ret;
 }
 
@@ -508,5 +508,5 @@ void adis1655x_iio_remove(struct adis_iio_dev *desc)
 	if (!desc)
 		return;
 	adis_remove(desc->adis_dev);
-	no_os_free(desc);
+	capi_free(desc);
 }

--- a/drivers/imu/iio_adis1657x.c
+++ b/drivers/imu/iio_adis1657x.c
@@ -32,7 +32,7 @@
  ******************************************************************************/
 
 #include "iio_adis1657x.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_units.h"
 
 static const char * const adis1657x_rang_mdl_txt[] = {
@@ -479,7 +479,7 @@ int adis1657x_iio_init(struct adis_iio_dev **iio_dev,
 	int ret;
 	struct adis_iio_dev *desc;
 
-	desc = (struct adis_iio_dev *)no_os_calloc(1, sizeof(*desc));
+	desc = (struct adis_iio_dev *)capi_calloc(1, sizeof(*desc));
 	if (!desc)
 		return -ENOMEM;
 
@@ -500,7 +500,7 @@ int adis1657x_iio_init(struct adis_iio_dev **iio_dev,
 	return 0;
 
 error_adis1657x_init:
-	no_os_free(desc);
+	capi_free(desc);
 	return ret;
 }
 
@@ -513,5 +513,5 @@ void adis1657x_iio_remove(struct adis_iio_dev *desc)
 	if (!desc)
 		return;
 	adis_remove(desc->adis_dev);
-	no_os_free(desc);
+	capi_free(desc);
 }

--- a/drivers/io-expander/adp5589/adp5589.c
+++ b/drivers/io-expander/adp5589/adp5589.c
@@ -33,7 +33,7 @@
 
 #include <stdlib.h>
 #include "adp5589.h"			// ADP5589 definitions.
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /***************************************************************************//**
  * @brief Writes data into a register.
@@ -95,7 +95,7 @@ int8_t adp5589_init(struct adp5589_dev **device,
 	struct adp5589_dev *dev;
 	static uint8_t status;
 
-	dev = (struct adp5589_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct adp5589_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -128,7 +128,7 @@ int32_t adp5589_remove(struct adp5589_dev *dev)
 
 	ret = no_os_i2c_remove(dev->i2c_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/io-expander/demux_spi/demux_spi.c
+++ b/drivers/io-expander/demux_spi/demux_spi.c
@@ -33,7 +33,7 @@
 
 #include "demux_spi.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -64,7 +64,7 @@ int32_t demux_spi_init(struct no_os_spi_desc **desc,
 	if (!param)
 		return -1;
 
-	descriptor = (struct no_os_spi_desc *)no_os_calloc(1, sizeof(*descriptor));
+	descriptor = (struct no_os_spi_desc *)capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -1;
 
@@ -76,7 +76,7 @@ int32_t demux_spi_init(struct no_os_spi_desc **desc,
 
 	ret = no_os_spi_init(&spi_dev_desc, spi_dev_param);
 	if (ret != 0) {
-		no_os_free(descriptor);
+		capi_free(descriptor);
 		return -1;
 	}
 
@@ -100,7 +100,7 @@ int32_t demux_spi_remove(struct no_os_spi_desc *desc)
 	if (no_os_spi_remove(desc->extra))
 		return -1;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }
@@ -124,7 +124,7 @@ int32_t demux_spi_write_and_read(struct no_os_spi_desc *desc, uint8_t *data,
 	if (!desc)
 		return -1;
 
-	buff = no_os_malloc(sizeof(*buff) * (bytes_number + 1));
+	buff = capi_malloc(sizeof(*buff) * (bytes_number + 1));
 	if (!buff)
 		return -1;
 
@@ -138,7 +138,7 @@ int32_t demux_spi_write_and_read(struct no_os_spi_desc *desc, uint8_t *data,
 
 	memcpy(data, buff + 1, bytes_number);
 
-	no_os_free(buff);
+	capi_free(buff);
 
 	return ret;
 }

--- a/drivers/io-expander/ltc4306/ltc4306.c
+++ b/drivers/io-expander/ltc4306/ltc4306.c
@@ -36,7 +36,7 @@
 #include "no_os_i2c.h"
 #include "no_os_util.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "ltc4306.h"
 
 /* Pin configurable LTC4306 addresses */
@@ -90,7 +90,7 @@ int ltc4306_init(struct ltc4306_dev **device,
 	struct ltc4306_dev *dev;
 	int ret;
 
-	dev = (struct ltc4306_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ltc4306_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -103,7 +103,7 @@ int ltc4306_init(struct ltc4306_dev **device,
 	return 0;
 
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -121,7 +121,7 @@ int ltc4306_remove(struct ltc4306_dev *dev)
 
 	ret = no_os_i2c_remove(dev->i2c_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/io-expander/ltc4332/ltc4332.c
+++ b/drivers/io-expander/ltc4332/ltc4332.c
@@ -33,7 +33,7 @@
 
 #include "ltc4332.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -82,8 +82,8 @@ int32_t ltc4332_spi_remove(struct no_os_spi_desc *desc)
 	if (!desc)
 		return -EINVAL;
 
-	no_os_free(desc->extra);
-	no_os_free(desc);
+	capi_free(desc->extra);
+	capi_free(desc);
 	return 0;
 }
 
@@ -107,7 +107,7 @@ int32_t ltc4332_spi_write_and_read(struct no_os_spi_desc *desc, uint8_t *data,
 	temp_ops = desc->platform_ops;
 	desc->platform_ops = desc->parent->platform_ops;
 
-	buff = no_os_calloc(bytes_number + 1, sizeof * buff);
+	buff = capi_calloc(bytes_number + 1, sizeof * buff);
 	if (!buff)
 		return -ENOMEM;
 
@@ -118,11 +118,11 @@ int32_t ltc4332_spi_write_and_read(struct no_os_spi_desc *desc, uint8_t *data,
 
 	memcpy(data, buff + 1, bytes_number);
 	desc->platform_ops = temp_ops;
-	no_os_free(buff);
+	capi_free(buff);
 
 	return ret;
 error:
-	no_os_free(buff);
+	capi_free(buff);
 	return ret;
 }
 

--- a/drivers/io-link/max22516/max22516.c
+++ b/drivers/io-link/max22516/max22516.c
@@ -35,7 +35,7 @@
 #include "max22516.h"
 #include "no_os_delay.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Writes data to max22516 over SPI.
@@ -835,7 +835,7 @@ int max22516_init(struct max22516_dev **device,
 	int ret;
 	struct max22516_dev *dev;
 
-	dev = (struct max22516_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct max22516_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 

--- a/drivers/led/ltc3208/ltc3208.c
+++ b/drivers/led/ltc3208/ltc3208.c
@@ -42,7 +42,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "ltc3208.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_i2c.h"
 #include "no_os_util.h"
 #include "no_os_delay.h"
@@ -59,7 +59,7 @@ int ltc3208_init(struct ltc3208_dev **device,
 	struct ltc3208_dev *dev;
 	int ret;
 
-	dev = (struct ltc3208_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ltc3208_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -112,7 +112,7 @@ int ltc3208_remove(struct ltc3208_dev *device)
 		device->gpio_enrgbs_desc = NULL;
 	}
 
-	no_os_free(device);
+	capi_free(device);
 
 	return 0;
 }

--- a/drivers/led/ltc3220/ltc3220.c
+++ b/drivers/led/ltc3220/ltc3220.c
@@ -42,7 +42,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "ltc3220.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_i2c.h"
 #include "no_os_util.h"
 #include "no_os_delay.h"
@@ -59,7 +59,7 @@ int ltc3220_init(struct ltc3220_dev **device,
 	struct ltc3220_dev *dev;
 	int ret;
 
-	dev = (struct ltc3220_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ltc3220_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -110,7 +110,7 @@ int ltc3220_remove(struct ltc3220_dev *device)
 		device->gpio_rst_desc = NULL;
 	}
 
-	no_os_free(device);
+	capi_free(device);
 
 	return 0;
 }

--- a/drivers/led/max25603/max25603.c
+++ b/drivers/led/max25603/max25603.c
@@ -33,7 +33,7 @@
 #include "max25603.h"
 #include "no_os_delay.h"
 #include "no_os_units.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief MAX25603 select comparator function
@@ -238,7 +238,7 @@ int max25603_init(struct max25603_desc **desc,
 	struct max25603_desc *descriptor;
 	int ret;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -328,7 +328,7 @@ en2_err:
 en1_err:
 	no_os_pwm_remove(descriptor->en1_desc);
 err:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -351,7 +351,7 @@ int max25603_remove(struct max25603_desc *desc)
 	no_os_pwm_remove(desc->turn_desc);
 	no_os_pwm_remove(desc->en2_desc);
 	no_os_pwm_remove(desc->en1_desc);
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/mcs/mcs_gpio/mcs_gpio.c
+++ b/drivers/mcs/mcs_gpio/mcs_gpio.c
@@ -37,7 +37,7 @@
 #include "no_os_error.h"
 #include "no_os_gpio.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "mcs_gpio.h"
 #include "jesd204.h"
 
@@ -93,7 +93,7 @@ int32_t mcs_gpio_init(struct mcs_gpio_dev **device,
 	struct mcs_gpio_dev *dev;
 	int32_t ret;
 
-	dev = (struct mcs_gpio_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct mcs_gpio_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -115,7 +115,7 @@ int32_t mcs_gpio_init(struct mcs_gpio_dev **device,
 err_gpio:
 	no_os_gpio_remove(dev->gpio_req);
 error:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -129,7 +129,7 @@ int32_t mcs_gpio_remove(struct mcs_gpio_dev *device)
 	int32_t ret;
 
 	ret = no_os_gpio_remove(device->gpio_req);
-	no_os_free(device);
+	capi_free(device);
 
 	return ret;
 }

--- a/drivers/meter/ade7753/ade7753.c
+++ b/drivers/meter/ade7753/ade7753.c
@@ -41,7 +41,7 @@
 #include "no_os_irq.h"
 #include "no_os_delay.h"
 #include "no_os_units.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_crc16.h"
 #include "no_os_print_log.h"
 #include <stdlib.h>
@@ -69,7 +69,7 @@ int ade7753_init(struct ade7753_dev **device,
 	/* timeout value */
 	uint16_t timeout = 1000;
 
-	dev = (struct ade7753_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ade7753_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -124,7 +124,7 @@ int ade7753_init(struct ade7753_dev **device,
 error_spi:
 	no_os_spi_remove(dev->spi_desc);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -297,7 +297,7 @@ int ade7753_remove(struct ade7753_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/meter/ade7753/ade7753.h
+++ b/drivers/meter/ade7753/ade7753.h
@@ -42,7 +42,7 @@
 #include "no_os_irq.h"
 #include "no_os_delay.h"
 #include "no_os_units.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_crc16.h"
 #include "no_os_print_log.h"
 #include <stdlib.h>

--- a/drivers/meter/ade7754/ade7754.c
+++ b/drivers/meter/ade7754/ade7754.c
@@ -41,7 +41,7 @@
 #include "no_os_irq.h"
 #include "no_os_delay.h"
 #include "no_os_units.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_crc16.h"
 #include "no_os_print_log.h"
 #include <stdlib.h>
@@ -68,7 +68,7 @@ int ade7754_init(struct ade7754_dev **device,
 	/* timeout value */
 	uint16_t timeout = 1000;
 
-	dev = (struct ade7754_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ade7754_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -131,7 +131,7 @@ int ade7754_init(struct ade7754_dev **device,
 error_spi:
 	no_os_spi_remove(dev->spi_desc);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -369,7 +369,7 @@ int ade7754_remove(struct ade7754_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/meter/ade7754/ade7754.h
+++ b/drivers/meter/ade7754/ade7754.h
@@ -42,7 +42,7 @@
 #include "no_os_irq.h"
 #include "no_os_delay.h"
 #include "no_os_units.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_crc16.h"
 #include "no_os_print_log.h"
 #include <stdlib.h>

--- a/drivers/meter/ade7758/ade7758.c
+++ b/drivers/meter/ade7758/ade7758.c
@@ -41,7 +41,7 @@
 #include "no_os_irq.h"
 #include "no_os_delay.h"
 #include "no_os_units.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_crc16.h"
 #include "no_os_print_log.h"
 #include <stdlib.h>
@@ -71,7 +71,7 @@ int ade7758_init(struct ade7758_dev **device,
 	/* timeout value */
 	uint16_t timeout = 1000;
 
-	dev = (struct ade7758_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ade7758_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -118,7 +118,7 @@ int ade7758_init(struct ade7758_dev **device,
 error_spi:
 	no_os_spi_remove(dev->spi_desc);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -326,7 +326,7 @@ int ade7758_remove(struct ade7758_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/meter/ade7758/ade7758.h
+++ b/drivers/meter/ade7758/ade7758.h
@@ -42,7 +42,7 @@
 #include "no_os_irq.h"
 #include "no_os_delay.h"
 #include "no_os_units.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_crc16.h"
 #include "no_os_print_log.h"
 #include <stdlib.h>

--- a/drivers/meter/ade7816/ade7816.c
+++ b/drivers/meter/ade7816/ade7816.c
@@ -30,7 +30,7 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 #include "no_os_units.h"
 #include "ade7816.h"
@@ -1423,7 +1423,7 @@ int ade7816_init(struct ade7816_desc **desc,
 	uint32_t reg_val;
 	int ret;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -1644,7 +1644,7 @@ remove_irq:
 remove_irq0:
 	no_os_gpio_remove(descriptor->gpio_irq0_desc);
 remove_ade7816:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -1688,7 +1688,7 @@ int ade7816_remove(struct ade7816_desc *desc)
 	}
 	no_os_gpio_remove(desc->gpio_irq1_desc);
 	no_os_gpio_remove(desc->gpio_irq0_desc);
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/meter/ade7880/ade7880.c
+++ b/drivers/meter/ade7880/ade7880.c
@@ -36,7 +36,7 @@
 #include "ade7880.h"
 #include "no_os_delay.h"
 #include "no_os_units.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Read device register.
@@ -316,7 +316,7 @@ int ade7880_init(struct ade7880_dev **device,
 	/* chip id read value */
 	uint32_t chip_id;
 
-	dev = (struct ade7880_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ade7880_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -383,7 +383,7 @@ int ade7880_init(struct ade7880_dev **device,
 error_spi:
 	no_os_spi_remove(dev->spi_desc);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -458,7 +458,7 @@ int ade7880_remove(struct ade7880_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/meter/ade7913/ade7913.c
+++ b/drivers/meter/ade7913/ade7913.c
@@ -37,7 +37,7 @@
 #include "ade7913.h"
 #include "no_os_delay.h"
 #include "no_os_units.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_crc8.h"
 #include "no_os_crc16.h"
 #include "no_os_print_log.h"
@@ -360,7 +360,7 @@ int ade7913_init(struct ade7913_dev **device,
 		return -EINVAL;
 
 	// allocate memory for the dev strucuture
-	dev = (struct ade7913_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ade7913_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -370,17 +370,17 @@ int ade7913_init(struct ade7913_dev **device,
 	dev->burst_mode = init_param.burst_mode;
 
 	// allocate memory for the waveforms depending on the number of dev
-	i_wav = (int32_t *)no_os_calloc(dev->no_devs, sizeof(*i_wav));
+	i_wav = (int32_t *)capi_calloc(dev->no_devs, sizeof(*i_wav));
 	if (!i_wav)
 		goto err_alloc_i_wav;
-	v1_wav = (int32_t *)no_os_calloc(dev->no_devs, sizeof(*v1_wav));
+	v1_wav = (int32_t *)capi_calloc(dev->no_devs, sizeof(*v1_wav));
 	if (!v1_wav)
 		goto err_alloc_v1_wav;
-	v2_wav = (int32_t *)no_os_calloc(dev->no_devs, sizeof(*v2_wav));
+	v2_wav = (int32_t *)capi_calloc(dev->no_devs, sizeof(*v2_wav));
 	if (!v2_wav)
 		goto err_alloc_v2_wav;
 
-	v_product = (uint8_t *)no_os_calloc(dev->no_devs, sizeof(*v_product));
+	v_product = (uint8_t *)capi_calloc(dev->no_devs, sizeof(*v_product));
 	if (!v_product)
 		goto err_alloc_v_product;
 
@@ -534,15 +534,15 @@ error_spi1:
 error_spi0:
 	no_os_spi_remove(dev->spi_desc0);
 error_dev:
-	no_os_free(v_product);
+	capi_free(v_product);
 err_alloc_v_product:
-	no_os_free(v2_wav);
+	capi_free(v2_wav);
 err_alloc_v2_wav:
-	no_os_free(v1_wav);
+	capi_free(v1_wav);
 err_alloc_v1_wav:
-	no_os_free(i_wav);
+	capi_free(i_wav);
 err_alloc_i_wav:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -569,11 +569,11 @@ int ade7913_remove(struct ade7913_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev->ver_product);
-	no_os_free(dev->i_wav_m);
-	no_os_free(dev->v1_wav_m);
-	no_os_free(dev->v2_wav_m);
-	no_os_free(dev);
+	capi_free(dev->ver_product);
+	capi_free(dev->i_wav_m);
+	capi_free(dev->v1_wav_m);
+	capi_free(dev->v2_wav_m);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/meter/ade7953/ade7953.c
+++ b/drivers/meter/ade7953/ade7953.c
@@ -41,7 +41,7 @@
 #include "no_os_irq.h"
 #include "no_os_delay.h"
 #include "no_os_units.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_crc16.h"
 #include "no_os_print_log.h"
 #include <stdlib.h>
@@ -65,7 +65,7 @@ int ade7953_init(struct ade7953_dev **device,
 	/* value read from register */
 	uint32_t reg_val;
 
-	dev = (struct ade7953_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ade7953_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -113,7 +113,7 @@ int ade7953_init(struct ade7953_dev **device,
 error_spi:
 	no_os_spi_remove(dev->spi_desc);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -295,7 +295,7 @@ int ade7953_remove(struct ade7953_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/meter/ade7953/ade7953.h
+++ b/drivers/meter/ade7953/ade7953.h
@@ -42,7 +42,7 @@
 #include "no_os_irq.h"
 #include "no_os_delay.h"
 #include "no_os_units.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_crc16.h"
 #include "no_os_print_log.h"
 #include <stdlib.h>

--- a/drivers/meter/ade7978/ade7978.c
+++ b/drivers/meter/ade7978/ade7978.c
@@ -36,7 +36,7 @@
 #include "ade7978.h"
 #include "no_os_delay.h"
 #include "no_os_units.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Read device register.
@@ -306,7 +306,7 @@ int ade7978_init(struct ade7978_dev **device,
 	/* data read */
 	uint8_t data;
 
-	dev = (struct ade7978_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ade7978_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -386,7 +386,7 @@ int ade7978_init(struct ade7978_dev **device,
 error_spi:
 	no_os_spi_remove(dev->spi_desc);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -548,7 +548,7 @@ int ade7978_remove(struct ade7978_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/meter/ade9000/ade9000.c
+++ b/drivers/meter/ade9000/ade9000.c
@@ -36,7 +36,7 @@
 #include "ade9000.h"
 #include "no_os_delay.h"
 #include "no_os_units.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Read device register.
@@ -382,7 +382,7 @@ int ade9000_init(struct ade9000_dev **device,
 	/* chip id read value */
 	uint32_t chip_id;
 
-	dev = (struct ade9000_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ade9000_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -421,7 +421,7 @@ int ade9000_init(struct ade9000_dev **device,
 error_spi:
 	no_os_spi_remove(dev->spi_desc);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -504,7 +504,7 @@ int ade9000_remove(struct ade9000_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/meter/ade9078/ade9078.c
+++ b/drivers/meter/ade9078/ade9078.c
@@ -36,7 +36,7 @@
 #include "ade9078.h"
 #include "no_os_delay.h"
 #include "no_os_units.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Read device register.
@@ -381,7 +381,7 @@ int ade9078_init(struct ade9078_dev **device,
 	/* part id read value */
 	uint32_t part_id;
 
-	dev = (struct ade9078_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ade9078_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -446,7 +446,7 @@ int ade9078_init(struct ade9078_dev **device,
 error_spi:
 	no_os_spi_remove(dev->spi_desc);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -524,7 +524,7 @@ int ade9078_remove(struct ade9078_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/meter/ade9113/ade9113.c
+++ b/drivers/meter/ade9113/ade9113.c
@@ -37,7 +37,7 @@
 #include "ade9113.h"
 #include "no_os_delay.h"
 #include "no_os_units.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_crc8.h"
 #include "no_os_crc16.h"
 #include "no_os_print_log.h"
@@ -409,21 +409,21 @@ int ade9113_init(struct ade9113_dev **device,
 		if (!init_param.irq_ctrl)
 			return -EINVAL;
 
-	dev = (struct ade9113_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ade9113_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
 	dev->no_devs = init_param.no_devs;
 
-	i_wav = (int32_t *)no_os_calloc(dev->no_devs, sizeof(*i_wav));
+	i_wav = (int32_t *)capi_calloc(dev->no_devs, sizeof(*i_wav));
 	if (!i_wav)
 		goto err_alloc_i_wav;
 
-	v1_wav = (int32_t *)no_os_calloc(dev->no_devs, sizeof(*v1_wav));
+	v1_wav = (int32_t *)capi_calloc(dev->no_devs, sizeof(*v1_wav));
 	if (!v1_wav)
 		goto err_alloc_v1_wav;
 
-	v2_wav = (int32_t *)no_os_calloc(dev->no_devs, sizeof(*v2_wav));
+	v2_wav = (int32_t *)capi_calloc(dev->no_devs, sizeof(*v2_wav));
 	if (!v2_wav)
 		goto err_alloc_v2_wav;
 
@@ -595,13 +595,13 @@ error_gpio:
 error_spi:
 	no_os_spi_remove(dev->spi_desc);
 error_dev:
-	no_os_free(v2_wav);
+	capi_free(v2_wav);
 err_alloc_v2_wav:
-	no_os_free(v1_wav);
+	capi_free(v1_wav);
 err_alloc_v1_wav:
-	no_os_free(i_wav);
+	capi_free(i_wav);
 err_alloc_i_wav:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -632,7 +632,7 @@ int ade9113_remove(struct ade9113_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/meter/ade9153a/ade9153a.c
+++ b/drivers/meter/ade9153a/ade9153a.c
@@ -41,7 +41,7 @@
 #include "no_os_irq.h"
 #include "no_os_delay.h"
 #include "no_os_units.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_crc16.h"
 #include "no_os_print_log.h"
 #include <stdlib.h>
@@ -159,7 +159,7 @@ int ade9153a_init(struct ade9153a_dev **device,
 	if (!init_param.irq_ctrl)
 		return -EINVAL;
 
-	dev = (struct ade9153a_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ade9153a_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -274,7 +274,7 @@ error_irq:
 error_gpio_rdy:
 	no_os_gpio_remove(dev->gpio_rdy);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -535,7 +535,7 @@ int ade9153a_remove(struct ade9153a_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/meter/ade9153a/ade9153a.h
+++ b/drivers/meter/ade9153a/ade9153a.h
@@ -42,7 +42,7 @@
 #include "no_os_irq.h"
 #include "no_os_delay.h"
 #include "no_os_units.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_crc16.h"
 #include "no_os_print_log.h"
 #include <stdlib.h>

--- a/drivers/meter/ade9430/ade9430.c
+++ b/drivers/meter/ade9430/ade9430.c
@@ -36,7 +36,7 @@
 #include "ade9430.h"
 #include "no_os_delay.h"
 #include "no_os_units.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Read device register.
@@ -281,7 +281,7 @@ int ade9430_init(struct ade9430_dev **device,
 	uint32_t chip_id;
 	int ret;
 
-	dev = (struct ade9430_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ade9430_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -325,7 +325,7 @@ int ade9430_init(struct ade9430_dev **device,
 error_spi:
 	no_os_spi_remove(dev->spi_desc);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -343,7 +343,7 @@ int ade9430_remove(struct ade9430_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/motor/tmc5240/iio_tmc5240.c
+++ b/drivers/motor/tmc5240/iio_tmc5240.c
@@ -35,7 +35,7 @@
 #include "no_os_spi.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "iio.h"
 #include "iio_tmc5240.h"
 #include "tmc5240.h"
@@ -267,7 +267,7 @@ int tmc5240_iio_init(struct tmc5240_iio_dev **iio_dev,
 	if (!iio_dev || !init_param)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -283,7 +283,7 @@ int tmc5240_iio_init(struct tmc5240_iio_dev **iio_dev,
 	return 0;
 
 init_tmc_err:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -302,7 +302,7 @@ int tmc5240_iio_remove(struct tmc5240_iio_dev *desc)
 		return -EINVAL;
 
 	tmc5240_remove(desc->tmc5240_dev);
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/motor/tmc5240/tmc5240.c
+++ b/drivers/motor/tmc5240/tmc5240.c
@@ -31,7 +31,7 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_spi.h"
 #include "no_os_util.h"
@@ -166,7 +166,7 @@ int tmc5240_init(struct tmc5240_dev **device,
 	if (!device || !init_param)
 		return -EINVAL;
 
-	dev = (struct tmc5240_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct tmc5240_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -253,7 +253,7 @@ err_remove:
 	if (dev->spi_desc)
 		no_os_spi_remove(dev->spi_desc);
 err_free:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -280,7 +280,7 @@ int tmc5240_remove(struct tmc5240_dev *device)
 		device->spi_desc = NULL;
 	}
 
-	no_os_free(device);
+	capi_free(device);
 
 	return ret;
 }

--- a/drivers/motor/tmc7300/tmc7300.c
+++ b/drivers/motor/tmc7300/tmc7300.c
@@ -35,7 +35,7 @@
 #include <stdbool.h>
 
 #include "no_os_uart.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
 
@@ -501,7 +501,7 @@ int tmc7300_init(struct tmc7300_desc **desc,
 	if (!param || !param->comm_desc)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -538,7 +538,7 @@ int tmc7300_init(struct tmc7300_desc **desc,
 free_gpio:
 	no_os_gpio_remove(descriptor->en_gpio);
 free_desc:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -554,7 +554,7 @@ int tmc7300_remove(struct tmc7300_desc *desc)
 		return -ENODEV;
 
 	no_os_gpio_remove(desc->en_gpio);
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/mux/adg2404/adg2404.c
+++ b/drivers/mux/adg2404/adg2404.c
@@ -35,7 +35,7 @@
 #include <stdlib.h>
 #include "adg2404.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * Select the multiplexer channel.
@@ -98,7 +98,7 @@ int adg2404_init(struct adg2404_dev **device,
 	if (!device || !init_param)
 		return -EINVAL;
 
-	dev = (struct adg2404_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct adg2404_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -138,7 +138,7 @@ error_en:
 error_a1:
 	no_os_gpio_remove(dev->gpio_a0);
 error_a0:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -157,7 +157,7 @@ int adg2404_remove(struct adg2404_dev *dev)
 	no_os_gpio_remove(dev->gpio_a1);
 	no_os_gpio_remove(dev->gpio_en);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/mux/adgs1408/adgs1408.c
+++ b/drivers/mux/adgs1408/adgs1408.c
@@ -36,7 +36,7 @@
 #include <stdbool.h>
 #include "adgs1408.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * Compute CRC8 checksum.
@@ -383,7 +383,7 @@ int32_t adgs1408_init(struct adgs1408_dev **device,
 	struct adgs1408_dev *dev;
 	int32_t ret;
 
-	dev = (struct adgs1408_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct adgs1408_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -445,7 +445,7 @@ int32_t adgs1408_remove(struct adgs1408_dev *dev)
 
 	ret = no_os_spi_remove(dev->spi_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/mux/adgs5412/adgs5412.c
+++ b/drivers/mux/adgs5412/adgs5412.c
@@ -35,7 +35,7 @@
 #include <stdlib.h>
 #include "adgs5412.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * Compute CRC8 checksum.
@@ -316,7 +316,7 @@ int32_t adgs5412_init(adgs5412_dev **device,
 	adgs5412_dev *dev;
 	int32_t ret;
 
-	dev = (adgs5412_dev *)no_os_malloc(sizeof(*dev));
+	dev = (adgs5412_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -369,7 +369,7 @@ int32_t adgs5412_remove(adgs5412_dev *dev)
 
 	ret = no_os_spi_remove(dev->spi_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/net/adin1110/adin1110.c
+++ b/drivers/net/adin1110/adin1110.c
@@ -37,7 +37,7 @@
 #include <string.h>
 #include "no_os_spi.h"
 #include "adin1110.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_crc8.h"
 #include "no_os_delay.h"
 #include "no_os_util.h"
@@ -947,7 +947,7 @@ int adin1110_init(struct adin1110_desc **desc,
 	struct adin1110_desc *descriptor;
 	int ret;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -1003,7 +1003,7 @@ int adin1110_init(struct adin1110_desc **desc,
 		if (ret)
 			goto free_spi;
 	} else {
-		descriptor->data = no_os_calloc(ADIN1110_BUFF_LEN,
+		descriptor->data = capi_calloc(ADIN1110_BUFF_LEN,
 						sizeof(*descriptor->data));
 		if (!descriptor->data) {
 			ret = -ENOMEM;
@@ -1028,14 +1028,14 @@ int adin1110_init(struct adin1110_desc **desc,
 	return 0;
 
 free_oa:
-	no_os_free(descriptor->data);
+	capi_free(descriptor->data);
 	oa_tc6_remove(descriptor->oa_desc);
 free_spi:
 	no_os_spi_remove(descriptor->comm_desc);
 free_rst_gpio:
 	no_os_gpio_remove(descriptor->reset_gpio);
 free_desc:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -1062,9 +1062,9 @@ int adin1110_remove(struct adin1110_desc *desc)
 			return ret;
 	}
 
-	no_os_free(desc->data);
+	capi_free(desc->data);
 	oa_tc6_remove(desc->oa_desc);
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/net/adin1300.c
+++ b/drivers/net/adin1300.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include <errno.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 #include "no_os_gpio.h"
 #include "mdio_bitbang.h"
@@ -15,7 +15,7 @@ int adin1300_init(struct adin1300_desc **dev, struct adin1300_init_param *param)
 	if (!dev || !param)
 		return -EINVAL;
 
-	d = (struct adin1300_desc *) no_os_calloc(1, sizeof(*d));
+	d = (struct adin1300_desc *) capi_calloc(1, sizeof(*d));
 	if (!d)
 		return -ENOMEM;
 

--- a/drivers/net/adin1320/adin1320.c
+++ b/drivers/net/adin1320/adin1320.c
@@ -32,7 +32,7 @@
 *******************************************************************************/
 
 #include <errno.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 #include "no_os_gpio.h"
 #include "adin1320.h"
@@ -55,7 +55,7 @@ int adin1320_init(struct adin1320_desc **dev,
 	if (!dev || !param)
 		return -EINVAL;
 
-	d = (struct adin1320_desc *) no_os_calloc(1, sizeof(*d));
+	d = (struct adin1320_desc *) capi_calloc(1, sizeof(*d));
 	if (!d)
 		return -ENOMEM;
 
@@ -117,7 +117,7 @@ free_reset:
 free_mdio:
 	no_os_mdio_remove(d->mdio);
 free_d:
-	no_os_free(d);
+	capi_free(d);
 	return ret;
 }
 
@@ -168,7 +168,7 @@ int adin1320_remove(struct adin1320_desc *dev)
 	if (dev->reset_gpio)
 		ret_gpio = no_os_gpio_remove(dev->reset_gpio);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret_mdio ? ret_mdio : ret_gpio;
 }

--- a/drivers/net/iio_adin1300.c
+++ b/drivers/net/iio_adin1300.c
@@ -4,7 +4,7 @@
 #include "no_os_error.h"
 #include "no_os_delay.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "iio_adin1300.h"
 #include "adin1300.h"
 #include "iio.h"
@@ -152,11 +152,11 @@ int32_t adin1300_iio_init(struct adin1300_iio_desc **iiodev,
 	struct adin1300_iio_desc *d;
 	struct iio_device *d2;
 
-	d = (struct adin1300_iio_desc *)no_os_calloc(1, sizeof(*d));
+	d = (struct adin1300_iio_desc *)capi_calloc(1, sizeof(*d));
 	if (!d)
 		return -ENOMEM;
 
-	d2 = (struct iio_device *)no_os_calloc(1, sizeof(*d2));
+	d2 = (struct iio_device *)capi_calloc(1, sizeof(*d2));
 	if (!d2) {
 		ret = -ENOMEM;
 		goto end_0;
@@ -171,7 +171,7 @@ int32_t adin1300_iio_init(struct adin1300_iio_desc **iiodev,
 
 	return 0;
 end_0:
-	no_os_free(d);
+	capi_free(d);
 
 	return ret;
 }
@@ -179,9 +179,9 @@ end_0:
 int32_t adin1300_iio_remove(struct adin1300_iio_desc *iiodev)
 {
 	if (iiodev)
-		no_os_free(iiodev->iio_dev);
+		capi_free(iiodev->iio_dev);
 
-	no_os_free(iiodev);
+	capi_free(iiodev);
 
 	return 0;
 }

--- a/drivers/net/iio_max24287.c
+++ b/drivers/net/iio_max24287.c
@@ -4,7 +4,7 @@
 #include "no_os_error.h"
 #include "no_os_delay.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "iio_max24287.h"
 #include "max24287.h"
 #include "iio.h"
@@ -138,11 +138,11 @@ int32_t max24287_iio_init(struct max24287_iio_desc **iiodev,
 	struct max24287_iio_desc *d;
 	struct iio_device *d2;
 
-	d = (struct max24287_iio_desc *)no_os_calloc(1, sizeof(*d));
+	d = (struct max24287_iio_desc *)capi_calloc(1, sizeof(*d));
 	if (!d)
 		return -ENOMEM;
 
-	d2 = (struct iio_device *)no_os_calloc(1, sizeof(*d2));
+	d2 = (struct iio_device *)capi_calloc(1, sizeof(*d2));
 	if (!d2) {
 		ret = -ENOMEM;
 		goto end_0;
@@ -157,7 +157,7 @@ int32_t max24287_iio_init(struct max24287_iio_desc **iiodev,
 
 	return 0;
 end_0:
-	no_os_free(d);
+	capi_free(d);
 
 	return ret;
 }
@@ -165,9 +165,9 @@ end_0:
 int32_t max24287_iio_remove(struct max24287_iio_desc *iiodev)
 {
 	if (iiodev)
-		no_os_free(iiodev->iio_dev);
+		capi_free(iiodev->iio_dev);
 
-	no_os_free(iiodev);
+	capi_free(iiodev);
 
 	return 0;
 }

--- a/drivers/net/max24287.c
+++ b/drivers/net/max24287.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include <errno.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 #include "no_os_gpio.h"
 #include "mdio_bitbang.h"
@@ -15,7 +15,7 @@ int max24287_init(struct max24287_desc **dev, struct max24287_init_param *param)
 	if (!dev || !param)
 		return -EINVAL;
 
-	d = (struct max24287_desc *) no_os_calloc(1, sizeof(*d));
+	d = (struct max24287_desc *) capi_calloc(1, sizeof(*d));
 	if (!d)
 		return -ENOMEM;
 

--- a/drivers/net/mdio_bitbang.c
+++ b/drivers/net/mdio_bitbang.c
@@ -33,7 +33,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_gpio.h"
 #include "no_os_mdio.h"
 #include "mdio_bitbang.h"
@@ -49,11 +49,11 @@ int mdio_bitbang_init(struct no_os_mdio_desc **dev,
 	int ret;
 	struct mdio_bitbang_init_param *mbip = ip->extra;
 
-	struct mdio_bitbang_extra *mbe = no_os_calloc(1, sizeof(*mbe));
+	struct mdio_bitbang_extra *mbe = capi_calloc(1, sizeof(*mbe));
 	if (!mbe)
 		return -ENOMEM;
 
-	struct no_os_mdio_desc *d = no_os_calloc(1, sizeof(*dev));
+	struct no_os_mdio_desc *d = capi_calloc(1, sizeof(*dev));
 	if (!d)
 		goto error;
 
@@ -83,9 +83,9 @@ error_2:
 error_1:
 	no_os_gpio_remove(mbe->mdc);
 error_0:
-	no_os_free(d);
+	capi_free(d);
 error:
-	no_os_free(mbe);
+	capi_free(mbe);
 
 	return ret;
 }
@@ -179,8 +179,8 @@ int mdio_bitbang_remove(struct no_os_mdio_desc *dev)
 
 	no_os_gpio_remove(mbe->mdio);
 	no_os_gpio_remove(mbe->mdc);
-	no_os_free(mbe);
-	no_os_free(dev);
+	capi_free(mbe);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/net/mdio_spi/mdio_spi.c
+++ b/drivers/net/mdio_spi/mdio_spi.c
@@ -32,7 +32,7 @@
 *******************************************************************************/
 
 #include <errno.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "mdio_spi.h"
 
 /**
@@ -64,11 +64,11 @@ int mdio_spi_init(struct no_os_mdio_desc **dev,
 
 	msip = ip->extra;
 
-	mse = no_os_calloc(1, sizeof(*mse));
+	mse = capi_calloc(1, sizeof(*mse));
 	if (!mse)
 		return -ENOMEM;
 
-	d = no_os_calloc(1, sizeof(*d));
+	d = capi_calloc(1, sizeof(*d));
 	if (!d) {
 		ret = -ENOMEM;
 		goto error_mdio_spi_calloc;
@@ -84,9 +84,9 @@ int mdio_spi_init(struct no_os_mdio_desc **dev,
 	return 0;
 
 error_mdio_calloc:
-	no_os_free(d);
+	capi_free(d);
 error_mdio_spi_calloc:
-	no_os_free(mse);
+	capi_free(mse);
 
 	return ret;
 }
@@ -222,8 +222,8 @@ static int mdio_spi_remove(struct no_os_mdio_desc *dev)
 	mse = dev->extra;
 
 	no_os_spi_remove(mse->mdio);
-	no_os_free(mse);
-	no_os_free(dev);
+	capi_free(mse);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/net/oa_tc6/oa_tc6.c
+++ b/drivers/net/oa_tc6/oa_tc6.c
@@ -36,7 +36,7 @@
 #include <stdbool.h>
 #include <string.h>
 
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "oa_tc6.h"
 
 int oa_rx_chunk_to_frame(struct oa_tc6_desc *desc, uint8_t *chunks,
@@ -732,7 +732,7 @@ int oa_tc6_init(struct oa_tc6_desc **desc, struct oa_tc6_init_param *param)
 {
 	struct oa_tc6_desc *descriptor;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -745,7 +745,7 @@ int oa_tc6_init(struct oa_tc6_desc **desc, struct oa_tc6_init_param *param)
 				    OA_TC6_CONFIG0_ZARFE_MASK,
 				    OA_TC6_CONFIG0_ZARFE_MASK);
 	if (ret) {
-		no_os_free(descriptor);
+		capi_free(descriptor);
 
 		return ret;
 	}
@@ -766,7 +766,7 @@ int oa_tc6_remove(struct oa_tc6_desc *desc)
 	if (!desc)
 		return -ENODEV;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/net/w5500/w5500.c
+++ b/drivers/net/w5500/w5500.c
@@ -35,7 +35,7 @@
 
 #include <errno.h>
 #include <string.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 
 /***************************************************************************//**
@@ -1051,7 +1051,7 @@ int w5500_init(struct w5500_dev **device,
 	struct w5500_dev *dev;
 	int ret;
 
-	dev = (struct w5500_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct w5500_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -1088,7 +1088,7 @@ free_gpio_int:
 free_gpio_reset:
 	no_os_gpio_remove(dev->gpio_reset);
 free_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -1108,7 +1108,7 @@ int w5500_remove(struct w5500_dev *dev)
 	ret |= no_os_gpio_remove(dev->gpio_reset);
 	ret |= no_os_gpio_remove(dev->gpio_int);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/photo-electronic/adpd188/adpd188.c
+++ b/drivers/photo-electronic/adpd188/adpd188.c
@@ -35,7 +35,7 @@
 #include "adpd188.h"
 #include "no_os_error.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Initialize the ADPD188 driver.
@@ -51,7 +51,7 @@ int32_t adpd188_init(struct adpd188_dev **device,
 	struct adpd188_dev *dev;
 	uint16_t reg_data;
 
-	dev = (struct adpd188_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct adpd188_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -1;
 	dev->device = init_param->device;
@@ -114,7 +114,7 @@ error_phy:
 	else if (dev->phy_opt == ADPD188_I2C)
 		no_os_i2c_remove(dev->phy_desc);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return -1;
 }
@@ -144,7 +144,7 @@ int32_t adpd188_remove(struct adpd188_dev *dev)
 	if (ret != 0)
 		return -1;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/photo-electronic/adpd188/iio_adpd188.c
+++ b/drivers/photo-electronic/adpd188/iio_adpd188.c
@@ -37,7 +37,7 @@
 #include "iio_adpd188.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include <stdio.h>
 
 static int adpd188_iio_read_offset_chan(void *device, char *buf, uint32_t len,
@@ -459,7 +459,7 @@ int32_t adpd188_iio_init(struct adpd188_iio_desc **device,
 			 struct adpd188_iio_init_param *init_param)
 {
 	struct adpd188_iio_desc *dev =
-		(struct adpd188_iio_desc *)no_os_calloc(1, sizeof(*dev));
+		(struct adpd188_iio_desc *)capi_calloc(1, sizeof(*dev));
 	int32_t ret;
 	uint16_t reg_data;
 	struct adpd188_slot_config slota = {
@@ -535,7 +535,7 @@ int32_t adpd188_iio_init(struct adpd188_iio_desc **device,
 error_drv:
 	adpd188_remove(dev->drv_dev);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return -1;
 }
@@ -553,7 +553,7 @@ int32_t adpd188_iio_remove(struct adpd188_iio_desc *dev)
 	if (ret != 0)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/photo-electronic/adpd410x/adpd410x.c
+++ b/drivers/photo-electronic/adpd410x/adpd410x.c
@@ -35,7 +35,7 @@
 #include <string.h>
 #include "no_os_error.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "adpd410x.h"
 
 /**
@@ -79,13 +79,13 @@ int32_t adpd410x_reg_read_bytes(struct adpd410x_dev *dev, uint16_t address,
 
 	switch (dev->dev_type) {
 	case ADPD4100:
-		buff = (uint8_t *) no_os_calloc(num_bytes + 2, sizeof(*buff));
+		buff = (uint8_t *) capi_calloc(num_bytes + 2, sizeof(*buff));
 		buff[0] = no_os_field_get(ADPD410X_UPPDER_BYTE_SPI_MASK, address);
 		buff[1] = (address << 1) & ADPD410X_LOWER_BYTE_SPI_MASK;
 
 		ret = no_os_spi_write_and_read(dev->dev_ops.spi_phy_dev, buff, num_bytes + 2);
 		if (ret != 0) {
-			no_os_free(buff);
+			capi_free(buff);
 			return ret;
 		}
 		for (i = 0; i < num_bytes; i++) {
@@ -96,7 +96,7 @@ int32_t adpd410x_reg_read_bytes(struct adpd410x_dev *dev, uint16_t address,
 		// Number of bytes for an I2C read is an 8-bit number, or at most 255
 		if (num_bytes > 255)
 			return -1;
-		buff = (uint8_t *) no_os_calloc(2, sizeof(*buff));
+		buff = (uint8_t *) capi_calloc(2, sizeof(*buff));
 		buff[0] = no_os_field_get(ADPD410X_UPPDER_BYTE_I2C_MASK, address);
 		buff[0] |= 0x80;
 		buff[1] = address & ADPD410X_LOWER_BYTE_I2C_MASK;
@@ -104,19 +104,19 @@ int32_t adpd410x_reg_read_bytes(struct adpd410x_dev *dev, uint16_t address,
 		/* No stop bit */
 		ret = no_os_i2c_write(dev->dev_ops.i2c_phy_dev, buff, 2, 0);
 		if (ret != 0) {
-			no_os_free(buff);
+			capi_free(buff);
 			return ret;
 		}
 		ret = no_os_i2c_read(dev->dev_ops.i2c_phy_dev, data, (uint8_t) num_bytes, 1);
 		if (ret != 0) {
-			no_os_free(buff);
+			capi_free(buff);
 			return ret;
 		}
 		break;
 	default:
 		return -1;
 	}
-	no_os_free(buff);
+	capi_free(buff);
 	return 0;
 }
 
@@ -501,7 +501,7 @@ static int32_t adpd410x_get_data_packet(struct adpd410x_dev *dev,
 	int8_t i, got_one = 0;
 	uint8_t *slot_bytecount_tab;
 
-	slot_bytecount_tab = (uint8_t *)no_os_calloc(no_slots,
+	slot_bytecount_tab = (uint8_t *)capi_calloc(no_slots,
 			     sizeof(*slot_bytecount_tab));
 	if (!slot_bytecount_tab)
 		return -ENOMEM;
@@ -528,11 +528,11 @@ static int32_t adpd410x_get_data_packet(struct adpd410x_dev *dev,
 		}
 	} while (i < no_slots);
 
-	no_os_free(slot_bytecount_tab);
+	capi_free(slot_bytecount_tab);
 	return 0;
 
 error_slot:
-	no_os_free(slot_bytecount_tab);
+	capi_free(slot_bytecount_tab);
 
 	return ret;
 }
@@ -559,7 +559,7 @@ int32_t adpd410x_read_fifo(struct adpd410x_dev *dev, uint32_t *data,
 	if (datawidth > 4 || total_bytes > ADPD410X_FIFO_DEPTH || data == NULL)
 		return -1;
 
-	data_byte_buff = (uint8_t *) no_os_calloc(total_bytes,
+	data_byte_buff = (uint8_t *) capi_calloc(total_bytes,
 			 sizeof(*data_byte_buff));
 	if (!data_byte_buff)
 		return -ENOMEM;
@@ -605,7 +605,7 @@ int32_t adpd410x_read_fifo(struct adpd410x_dev *dev, uint32_t *data,
 	}
 
 fifo_free_return:
-	no_os_free(data_byte_buff);
+	capi_free(data_byte_buff);
 	return ret;
 }
 
@@ -654,7 +654,7 @@ int32_t adpd410x_setup(struct adpd410x_dev **device,
 	struct adpd410x_dev *dev;
 	uint16_t reg_temp;
 
-	dev = no_os_calloc(1, sizeof * dev);
+	dev = capi_calloc(1, sizeof * dev);
 	if (!dev)
 		return -ENOMEM;
 
@@ -748,7 +748,7 @@ error_phy:
 	else
 		no_os_i2c_remove(dev->dev_ops.i2c_phy_dev);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -785,7 +785,7 @@ int32_t adpd410x_remove(struct adpd410x_dev *dev)
 	if (ret != 0)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/position/admt4000/admt4000.c
+++ b/drivers/position/admt4000/admt4000.c
@@ -41,7 +41,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "admt4000.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 
 static int admt4000_set_page(struct admt4000_dev *device, uint8_t page);
@@ -195,7 +195,7 @@ int admt4000_init(struct admt4000_dev **device,
 	if (!device || !init_param)
 		return -EINVAL;
 
-	dev = (struct admt4000_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct admt4000_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -278,7 +278,7 @@ err_gpio_reset:
 	no_os_spi_remove(dev->spi_desc);
 
 err:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -318,7 +318,7 @@ int admt4000_remove(struct admt4000_dev *device)
 		device->gpio_reset_desc = NULL;
 	}
 
-	no_os_free(device);
+	capi_free(device);
 
 	return 0;
 }

--- a/drivers/position/admt4000/iio_admt4000.c
+++ b/drivers/position/admt4000/iio_admt4000.c
@@ -38,7 +38,7 @@
 #include "admt4000.h"
 #include "iio.h"
 #include "iio_trigger.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 #include "no_os_gpio.h"
 #include "no_os_util.h"
@@ -422,7 +422,7 @@ int admt4000_iio_init(struct admt4000_iio_dev **iio_dev,
 	if (!init_param)
 		return -EINVAL;
 
-	descriptor = (struct admt4000_iio_dev *)no_os_calloc(1, sizeof(*descriptor));
+	descriptor = (struct admt4000_iio_dev *)capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -437,7 +437,7 @@ int admt4000_iio_init(struct admt4000_iio_dev **iio_dev,
 
 	return 0;
 init_err:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -450,7 +450,7 @@ init_err:
 int admt4000_iio_remove(struct admt4000_iio_dev *desc)
 {
 	admt4000_remove(desc->admt4000_desc);
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/potentiometer/ad5110/ad5110.c
+++ b/drivers/potentiometer/ad5110/ad5110.c
@@ -33,7 +33,7 @@
 
 #include <stdlib.h>
 #include "ad5110.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /***************************************************************************//**
  * @brief Initializes the communication with the device.
@@ -52,7 +52,7 @@ int8_t ad5110_init(struct ad5110_dev **device,
 	struct ad5110_dev *dev;
 	int8_t status;
 
-	dev = (struct ad5110_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad5110_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -77,7 +77,7 @@ int32_t ad5110_remove(struct ad5110_dev *dev)
 
 	ret = no_os_i2c_remove(dev->i2c_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/potentiometer/ad525x/ad525x.c
+++ b/drivers/potentiometer/ad525x/ad525x.c
@@ -33,7 +33,7 @@
 
 #include <stdlib.h>
 #include "ad525x.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 #define MSB_BYTE_MASK       0xFF00
 #define LSB_BYTE_MASK       0x00FF
@@ -92,7 +92,7 @@ int8_t ad525x_init(struct ad525x_dev **device,
 	struct ad525x_dev *dev;
 	int8_t status;
 
-	dev = (struct ad525x_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct ad525x_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -155,7 +155,7 @@ int32_t ad525x_remove(struct ad525x_dev *dev)
 	if (dev->gpio_wpbf)
 		ret |= no_os_gpio_remove(dev->gpio_wpbf);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/potentiometer/ad5293/ad5293.c
+++ b/drivers/potentiometer/ad5293/ad5293.c
@@ -31,7 +31,7 @@ SOFTWARE.
 #include <string.h>
 #include <errno.h>
 #include "ad5293.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 
 /***************************************************************************//**
@@ -78,7 +78,7 @@ int32_t ad5293_init(struct ad5293_dev **device,
 	if ((! device) || (! init_param))
 		return - EINVAL;
 
-	dev = (struct ad5293_dev*)no_os_malloc(sizeof(* dev));
+	dev = (struct ad5293_dev*)capi_malloc(sizeof(* dev));
 	if (! dev)
 		return - ENOMEM;
 
@@ -104,7 +104,7 @@ int32_t ad5293_init(struct ad5293_dev **device,
 	}
 
 	dev->chip_num = init_param->chip_num;
-	chp = (struct ad5293_chip_info*)no_os_malloc(dev->chip_num * sizeof(* chp));
+	chp = (struct ad5293_chip_info*)capi_malloc(dev->chip_num * sizeof(* chp));
 	if (! chp) {
 		ret = - ENOMEM;
 		goto error;
@@ -134,8 +134,8 @@ error:
 		ret = no_os_gpio_remove(dev->gpio_reset);
 	if (dev->spi_desc)
 		ret = no_os_spi_remove(dev->gpio_reset);
-	no_os_free(chp);
-	no_os_free(dev);
+	capi_free(chp);
+	capi_free(dev);
 	return ret;
 }
 
@@ -163,8 +163,8 @@ int32_t ad5293_remove(struct ad5293_dev* dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev->chip);
-	no_os_free(dev);
+	capi_free(dev->chip);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/power/ades1754/ades1754.c
+++ b/drivers/power/ades1754/ades1754.c
@@ -31,7 +31,7 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 #include "ades1754.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_crc8.h"
 #include "no_os_delay.h"
 #include "no_os_error.h"
@@ -1186,7 +1186,7 @@ int ades1754_init(struct ades1754_desc **desc,
 	if (init_param->dev_addr > ADES1754_DEV_ADDR_MAX)
 		return -EINVAL;
 
-	descriptor = (struct ades1754_desc *)no_os_calloc(sizeof(*descriptor),
+	descriptor = (struct ades1754_desc *)capi_calloc(sizeof(*descriptor),
 			1);
 	if (!descriptor)
 		return -ENOMEM;
@@ -1216,7 +1216,7 @@ int ades1754_init(struct ades1754_desc **desc,
 free_comm:
 	no_os_uart_remove(descriptor->uart_desc);
 free_desc:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -1230,7 +1230,7 @@ int ades1754_remove(struct ades1754_desc *desc)
 {
 	no_os_mdelay(10);
 	no_os_uart_remove(desc->uart_desc);
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/power/adp1050/adp1050.c
+++ b/drivers/power/adp1050/adp1050.c
@@ -33,7 +33,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "adp1050.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 #include "no_os_error.h"
 
@@ -1249,7 +1249,7 @@ int adp1050_init(struct adp1050_desc **desc,
 	struct adp1050_desc *descriptor;
 	int ret;
 
-	descriptor = (struct adp1050_desc *)no_os_calloc(sizeof(*descriptor), 1);
+	descriptor = (struct adp1050_desc *)capi_calloc(sizeof(*descriptor), 1);
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -1349,7 +1349,7 @@ int adp1050_remove(struct adp1050_desc *desc)
 	no_os_pwm_remove(desc->syni_desc);
 	no_os_gpio_remove(desc->pg_alt_desc);
 	no_os_i2c_remove(desc->i2c_desc);
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/power/adp1050/iio_adp1050.c
+++ b/drivers/power/adp1050/iio_adp1050.c
@@ -33,7 +33,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
@@ -1293,7 +1293,7 @@ int adp1050_iio_init(struct adp1050_iio_desc **iio_desc,
 	if (!init_param || !init_param->adp1050_init_param)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -1355,9 +1355,9 @@ int adp1050_iio_remove(struct adp1050_iio_desc *iio_desc)
 	if (!iio_desc)
 		return -ENODEV;
 
-	no_os_free(iio_desc->iio_dev->channels);
+	capi_free(iio_desc->iio_dev->channels);
 	adp1050_remove(iio_desc->adp1050_desc);
-	no_os_free(iio_desc);
+	capi_free(iio_desc);
 
 	return 0;
 }

--- a/drivers/power/adp1055/adp1055.c
+++ b/drivers/power/adp1055/adp1055.c
@@ -33,7 +33,7 @@
 #include "adp1055.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 
 /**
@@ -147,7 +147,7 @@ int adp1055_init(struct adp1055_desc **desc,
 	int ret;
 	uint8_t val;
 
-	descriptor = (struct adp1055_desc *)no_os_calloc(sizeof(*descriptor), 1);
+	descriptor = (struct adp1055_desc *)capi_calloc(sizeof(*descriptor), 1);
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -252,7 +252,7 @@ int adp1055_remove(struct adp1055_desc *desc)
 	no_os_pwm_remove(desc->syni_desc);
 	no_os_gpio_remove(desc->pg_alt_desc);
 	no_os_i2c_remove(desc->i2c_desc);
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/power/adp1055/iio_adp1055.c
+++ b/drivers/power/adp1055/iio_adp1055.c
@@ -33,7 +33,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
@@ -809,7 +809,7 @@ int adp1055_iio_init(struct adp1055_iio_desc **iio_desc,
 	if (!init_param || !init_param->adp1055_init_param)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -857,7 +857,7 @@ int adp1055_iio_remove(struct adp1055_iio_desc *iio_desc)
 		return -ENODEV;
 
 	adp1055_remove(iio_desc->adp1055_desc);
-	no_os_free(iio_desc);
+	capi_free(iio_desc);
 
 	return 0;
 }

--- a/drivers/power/adp5055/adp5055.c
+++ b/drivers/power/adp5055/adp5055.c
@@ -33,7 +33,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "adp5055.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 #include "no_os_error.h"
 
@@ -472,7 +472,7 @@ int adp5055_init(struct adp5055_desc **desc,
 	struct adp5055_desc *descriptor;
 	int ret;
 
-	descriptor = (struct adp5055_desc *)no_os_calloc(sizeof(*descriptor), 1);
+	descriptor = (struct adp5055_desc *)capi_calloc(sizeof(*descriptor), 1);
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -513,7 +513,7 @@ int adp5055_remove(struct adp5055_desc *desc)
 	}
 
 	no_os_i2c_remove(desc->i2c_desc);
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/power/adp5055/iio_adp5055.c
+++ b/drivers/power/adp5055/iio_adp5055.c
@@ -33,7 +33,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
@@ -1370,7 +1370,7 @@ int adp5055_iio_init(struct adp5055_iio_desc **iio_desc,
 	if (!init_param || !init_param->adp5055_init_param)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -1401,9 +1401,9 @@ int adp5055_iio_remove(struct adp5055_iio_desc *iio_desc)
 	if (!iio_desc)
 		return -ENODEV;
 
-	no_os_free(iio_desc->iio_dev->channels);
+	capi_free(iio_desc->iio_dev->channels);
 	adp5055_remove(iio_desc->adp5055_desc);
-	no_os_free(iio_desc);
+	capi_free(iio_desc);
 
 	return 0;
 }

--- a/drivers/power/lt3074/iio_lt3074.c
+++ b/drivers/power/lt3074/iio_lt3074.c
@@ -33,7 +33,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
@@ -297,7 +297,7 @@ int lt3074_iio_init(struct lt3074_iio_desc **iio_desc,
 	if (!init_param || !init_param->lt3074_init_param)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -329,7 +329,7 @@ int lt3074_iio_remove(struct lt3074_iio_desc *iio_desc)
 		return -ENODEV;
 
 	lt3074_remove(iio_desc->lt3074_dev);
-	no_os_free(iio_desc);
+	capi_free(iio_desc);
 
 	return 0;
 }

--- a/drivers/power/lt3074/lt3074.c
+++ b/drivers/power/lt3074/lt3074.c
@@ -38,7 +38,7 @@
 #include "no_os_units.h"
 #include "no_os_util.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_i2c.h"
 #include "no_os_gpio.h"
 #include "no_os_crc8.h"
@@ -276,7 +276,7 @@ int lt3074_init(struct lt3074_dev **device,
 	uint32_t value;
 	uint8_t block[7];
 
-	dev = (struct lt3074_dev *)no_os_calloc(1, sizeof(struct lt3074_dev));
+	dev = (struct lt3074_dev *)capi_calloc(1, sizeof(struct lt3074_dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -356,7 +356,7 @@ int lt3074_init(struct lt3074_dev **device,
 dev_err:
 	no_os_i2c_remove(dev->i2c_desc);
 i2c_err:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -386,7 +386,7 @@ int lt3074_remove(struct lt3074_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/power/lt7170/iio_lt7170.c
+++ b/drivers/power/lt7170/iio_lt7170.c
@@ -39,7 +39,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
@@ -769,7 +769,7 @@ int lt7170_iio_init(struct lt7170_iio_desc **iio_desc,
 	if (!init_param || !init_param->lt7170_init_param)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -785,7 +785,7 @@ int lt7170_iio_init(struct lt7170_iio_desc **iio_desc,
 	return 0;
 
 dev_err:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -800,9 +800,9 @@ int lt7170_iio_remove(struct lt7170_iio_desc *iio_desc)
 	if (!iio_desc)
 		return -ENODEV;
 
-	no_os_free(iio_desc->iio_dev->channels);
+	capi_free(iio_desc->iio_dev->channels);
 	lt7170_remove(iio_desc->lt7170_dev);
-	no_os_free(iio_desc);
+	capi_free(iio_desc);
 
 	return 0;
 }

--- a/drivers/power/lt7170/lt7170.c
+++ b/drivers/power/lt7170/lt7170.c
@@ -45,7 +45,7 @@
 #include "no_os_units.h"
 #include "no_os_util.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_pwm.h"
 #include "no_os_i2c.h"
 #include "no_os_gpio.h"
@@ -309,7 +309,7 @@ int lt7170_init(struct lt7170_dev **device,
 	uint16_t word;
 	uint8_t block[lt7170_info[init_param->chip_id].name_size];
 
-	dev = (struct lt7170_dev *)no_os_calloc(1, sizeof(struct lt7170_dev));
+	dev = (struct lt7170_dev *)capi_calloc(1, sizeof(struct lt7170_dev));
 	if (!dev) {
 		ret = -ENOMEM;
 	}
@@ -416,7 +416,7 @@ int lt7170_init(struct lt7170_dev **device,
 dev_err:
 	no_os_i2c_remove(dev->i2c_desc);
 i2c_err:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -455,7 +455,7 @@ int lt7170_remove(struct lt7170_dev *dev)
 			return ret;
 	}
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/power/lt7182s/iio_lt7182s.c
+++ b/drivers/power/lt7182s/iio_lt7182s.c
@@ -33,7 +33,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
@@ -863,7 +863,7 @@ int lt7182s_iio_init(struct lt7182s_iio_desc **iio_desc,
 	if (!init_param || !init_param->lt7182s_init_param)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -879,7 +879,7 @@ int lt7182s_iio_init(struct lt7182s_iio_desc **iio_desc,
 	return 0;
 
 dev_err:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -894,9 +894,9 @@ int lt7182s_iio_remove(struct lt7182s_iio_desc *iio_desc)
 	if (!iio_desc)
 		return -ENODEV;
 
-	no_os_free(iio_desc->iio_dev->channels);
+	capi_free(iio_desc->iio_dev->channels);
 	lt7182s_remove(iio_desc->lt7182s_dev);
-	no_os_free(iio_desc);
+	capi_free(iio_desc);
 
 	return 0;
 }

--- a/drivers/power/lt7182s/lt7182s.c
+++ b/drivers/power/lt7182s/lt7182s.c
@@ -39,7 +39,7 @@
 #include "no_os_units.h"
 #include "no_os_util.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_pwm.h"
 #include "no_os_i2c.h"
 #include "no_os_gpio.h"
@@ -531,7 +531,7 @@ int lt7182s_init(struct lt7182s_dev **device,
 	uint16_t word;
 	uint8_t block[7];
 
-	dev = (struct lt7182s_dev *)no_os_calloc(1, sizeof(struct lt7182s_dev));
+	dev = (struct lt7182s_dev *)capi_calloc(1, sizeof(struct lt7182s_dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -706,7 +706,7 @@ dev_err:
 	no_os_gpio_remove(dev->pg0_desc);
 	no_os_i2c_remove(dev->i2c_desc);
 i2c_err:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -758,7 +758,7 @@ int lt7182s_remove(struct lt7182s_dev *dev)
 			return ret;
 	}
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/power/lt8491/iio_lt8491.c
+++ b/drivers/power/lt8491/iio_lt8491.c
@@ -34,7 +34,7 @@
 #include <errno.h>
 #include "iio_lt8491.h"
 #include "lt8491.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 
 #define LT8491_IIO_CH_ATTR_RW(_name, _priv)	\
@@ -460,7 +460,7 @@ int lt8491_iio_init(struct lt8491_iio_device **iio_device,
 	if (!iio_init_param || !iio_init_param->init_param)
 		return -EINVAL;
 
-	iio_device_temp = no_os_calloc(1, sizeof(*iio_device_temp));
+	iio_device_temp = capi_calloc(1, sizeof(*iio_device_temp));
 	if (!iio_device_temp)
 		return -ENOMEM;
 
@@ -490,7 +490,7 @@ int lt8491_iio_init(struct lt8491_iio_device **iio_device,
 remove_dev:
 	lt8491_remove(iio_device_temp->dev);
 free_dev:
-	no_os_free(iio_device_temp);
+	capi_free(iio_device_temp);
 
 	return ret;
 }
@@ -504,7 +504,7 @@ int lt8491_iio_remove(struct lt8491_iio_device *iio_device)
 {
 	lt8491_remove(iio_device->dev);
 
-	no_os_free(iio_device);
+	capi_free(iio_device);
 
 	return 0;
 }

--- a/drivers/power/lt8491/lt8491.c
+++ b/drivers/power/lt8491/lt8491.c
@@ -32,7 +32,7 @@
 *******************************************************************************/
 
 #include "lt8491.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_i2c.h"
 #include "no_os_print_log.h"
@@ -112,7 +112,7 @@ int lt8491_init(struct lt8491_desc **dev,
 	struct lt8491_desc *temp_dev;
 	int ret;
 
-	temp_dev = no_os_calloc(1, sizeof(*temp_dev));
+	temp_dev = capi_calloc(1, sizeof(*temp_dev));
 	if (!temp_dev)
 		return -ENOMEM;
 
@@ -125,7 +125,7 @@ int lt8491_init(struct lt8491_desc **dev,
 	return 0;
 
 free_dev:
-	no_os_free(temp_dev);
+	capi_free(temp_dev);
 
 	return ret;
 }
@@ -146,7 +146,7 @@ int lt8491_remove(struct lt8491_desc *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/power/lt8722/iio_lt8722.c
+++ b/drivers/power/lt8722/iio_lt8722.c
@@ -34,7 +34,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
@@ -1853,7 +1853,7 @@ int lt8722_iio_init(struct lt8722_iio_dev **iio_dev,
 	if (!iio_dev || !init_param || !init_param->lt8722_init_param)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -1884,9 +1884,9 @@ int lt8722_iio_remove(struct lt8722_iio_dev *desc)
 	if (!desc)
 		return -ENODEV;
 
-	no_os_free(desc->iio_dev->channels);
+	capi_free(desc->iio_dev->channels);
 	lt8722_remove(desc->lt8722_dev);
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/power/lt8722/lt8722.c
+++ b/drivers/power/lt8722/lt8722.c
@@ -33,7 +33,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_crc8.h"
 #include "no_os_delay.h"
 #include "no_os_error.h"
@@ -1038,7 +1038,7 @@ int lt8722_init(struct lt8722_dev **device,
 	if (!device || !init_param)
 		return -EINVAL;
 
-	dev = (struct lt8722_dev *)no_os_calloc(sizeof(*dev), 1);
+	dev = (struct lt8722_dev *)capi_calloc(sizeof(*dev), 1);
 	if (!dev)
 		return -ENOMEM;
 
@@ -1153,7 +1153,7 @@ int lt8722_remove(struct lt8722_dev *dev)
 	no_os_gpio_remove(dev->gpio_en);
 	no_os_gpio_remove(dev->gpio_swen);
 	no_os_spi_remove(dev->spi);
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/power/ltc2992/ltc2992.c
+++ b/drivers/power/ltc2992/ltc2992.c
@@ -35,7 +35,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_i2c.h"
 #include "no_os_units.h"
 
@@ -182,7 +182,7 @@ int ltc2992_init(struct ltc2992_dev **device,
 	if (!device)
 		return -EINVAL;
 
-	dev = no_os_calloc(1, sizeof(struct ltc2992_dev));
+	dev = capi_calloc(1, sizeof(struct ltc2992_dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -256,7 +256,7 @@ dev_err:
 	no_os_gpio_remove(dev->alert_gpio_desc);
 	no_os_i2c_remove(dev->i2c_desc);
 i2c_err:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -272,7 +272,7 @@ int ltc2992_remove(struct ltc2992_dev *dev)
 
 	no_os_gpio_remove(dev->alert_gpio_desc);
 	no_os_i2c_remove(dev->i2c_desc);
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/power/ltc3337/ltc3337.c
+++ b/drivers/power/ltc3337/ltc3337.c
@@ -34,7 +34,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include "ltc3337.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 
 /**
@@ -94,7 +94,7 @@ int ltc3337_init(struct ltc3337_dev** device,
 	if ((!device) || (!init_param))
 		return -EINVAL;
 
-	dev = (struct ltc3337_dev*)no_os_calloc(1, sizeof(struct ltc3337_dev));
+	dev = (struct ltc3337_dev*)capi_calloc(1, sizeof(struct ltc3337_dev));
 	if (!dev)
 		return  -ENOMEM;
 
@@ -120,7 +120,7 @@ int ltc3337_init(struct ltc3337_dev** device,
 comm_err:
 	no_os_i2c_remove(dev->i2c_desc);
 err:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -138,7 +138,7 @@ int ltc3337_remove(struct ltc3337_dev* dev)
 		return -EINVAL;
 
 	ret = no_os_i2c_remove(dev->i2c_desc);
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/power/ltc3350/ltc3350.c
+++ b/drivers/power/ltc3350/ltc3350.c
@@ -38,7 +38,7 @@
 
 #include "no_os_util.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_i2c.h"
 
 #include "ltc3350.h"
@@ -58,7 +58,7 @@ int ltc3350_init(struct ltc3350_dev **device,
 {
 	struct ltc3350_dev *dev;
 	int ret;
-	dev = (struct ltc3350_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ltc3350_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -70,7 +70,7 @@ int ltc3350_init(struct ltc3350_dev **device,
 	return 0;
 
 err:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -89,7 +89,7 @@ int ltc3350_remove(struct ltc3350_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/power/ltc4162l/iio_ltc4162l.c
+++ b/drivers/power/ltc4162l/iio_ltc4162l.c
@@ -34,7 +34,7 @@
 #include <errno.h>
 #include "iio_ltc4162l.h"
 #include "ltc4162l.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 
 #define LT8491_IIO_CH_ATTR_RW(_name, _priv)	\
@@ -490,7 +490,7 @@ int ltc4162l_iio_init(struct ltc4162l_iio_device **iio_device,
 	if (!iio_init_param || !iio_init_param->init_param)
 		return -EINVAL;
 
-	iio_device_temp = no_os_calloc(1, sizeof(*iio_device_temp));
+	iio_device_temp = capi_calloc(1, sizeof(*iio_device_temp));
 	if (!iio_device_temp)
 		return -ENOMEM;
 
@@ -505,7 +505,7 @@ int ltc4162l_iio_init(struct ltc4162l_iio_device **iio_device,
 	return 0;
 
 free_dev:
-	no_os_free(iio_device_temp);
+	capi_free(iio_device_temp);
 
 	return ret;
 }
@@ -519,7 +519,7 @@ int ltc4162l_iio_remove(struct ltc4162l_iio_device *iio_device)
 {
 	ltc4162l_remove(iio_device->dev);
 
-	no_os_free(iio_device);
+	capi_free(iio_device);
 
 	return 0;
 }

--- a/drivers/power/ltc4162l/ltc4162l.c
+++ b/drivers/power/ltc4162l/ltc4162l.c
@@ -36,7 +36,7 @@
 
 #include "no_os_util.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_i2c.h"
 
 #include "ltc4162l.h"
@@ -257,7 +257,7 @@ int ltc4162l_init(struct ltc4162l_desc **device,
 	struct ltc4162l_desc *dev;
 	int ret;
 
-	dev = no_os_calloc(1, sizeof(*dev));
+	dev = capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -275,7 +275,7 @@ int ltc4162l_init(struct ltc4162l_desc **device,
 	return 0;
 
 free_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -293,7 +293,7 @@ int ltc4162l_remove(struct ltc4162l_desc *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/power/ltc4296/ltc4296.c
+++ b/drivers/power/ltc4296/ltc4296.c
@@ -34,7 +34,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include "ltc4296.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 #include "no_os_print_log.h"
 #include "no_os_util.h"
@@ -1023,7 +1023,7 @@ int ltc4296_init(struct ltc4296_dev **device,
 	if ((!device) || (!init_param))
 		return -EINVAL;
 
-	dev = (struct ltc4296_dev*)no_os_calloc(1, sizeof(struct ltc4296_dev));
+	dev = (struct ltc4296_dev*)capi_calloc(1, sizeof(struct ltc4296_dev));
 	if (!dev)
 		return  -ENOMEM;
 
@@ -1056,7 +1056,7 @@ int ltc4296_init(struct ltc4296_dev **device,
 err_spi:
 	no_os_spi_remove(dev->spi_desc);
 err:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -1074,7 +1074,7 @@ int ltc4296_remove(struct ltc4296_dev* dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/power/ltc7841/iio_ltc7841.c
+++ b/drivers/power/ltc7841/iio_ltc7841.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
@@ -104,7 +104,7 @@ int ltc7841_iio_init(struct ltc7841_iio_desc **iio_desc,
 	if (!init_param || !init_param->ltc7841_init_param)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -121,7 +121,7 @@ int ltc7841_iio_init(struct ltc7841_iio_desc **iio_desc,
 	return 0;
 
 dev_err:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -137,7 +137,7 @@ int ltc7841_iio_remove(struct ltc7841_iio_desc *desc)
 		return -ENODEV;
 
 	ltc7841_remove(desc->ltc7841_desc);
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/power/ltc7841/ltc7841.c
+++ b/drivers/power/ltc7841/ltc7841.c
@@ -31,6 +31,7 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 #include "ltc7841.h"
+#include "capi_alloc.h"
 
 const uint8_t ltc7841_write_only_registers[WRITE_ONLY_REGISTERS_NUMBER] = {
 	LTC7841_MFR_CLEAR_PEAKS,
@@ -52,7 +53,7 @@ int ltc7841_remove(struct ltc7841_desc *desc)
 	if (ret)
 		return ret;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }
@@ -130,7 +131,7 @@ int ltc7841_init(struct ltc7841_desc **device,
 
 	return 0;
 i2c_err:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/power/ltc7841/ltc7841.h
+++ b/drivers/power/ltc7841/ltc7841.h
@@ -43,7 +43,7 @@
 #include "no_os_error.h"
 #include "no_os_util.h"
 #include "no_os_units.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /** X is set based on the pull configuration of the ADDR pin */
 #define TWO_BYTES_LENGTH                       2

--- a/drivers/power/ltc7871/iio_ltc7871.c
+++ b/drivers/power/ltc7871/iio_ltc7871.c
@@ -35,7 +35,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
@@ -1455,7 +1455,7 @@ int ltc7871_iio_init(struct ltc7871_iio_dev **iio_dev,
 	if (!iio_dev || !init_param || !init_param->ltc7871_init_param)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -1487,7 +1487,7 @@ int ltc7871_iio_remove(struct ltc7871_iio_dev *desc)
 		return -ENODEV;
 
 	ltc7871_remove(desc->ltc7871_dev);
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/power/ltc7871/ltc7871.c
+++ b/drivers/power/ltc7871/ltc7871.c
@@ -33,7 +33,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 #include "no_os_error.h"
 #include "no_os_print_log.h"
@@ -704,7 +704,7 @@ int ltc7871_init(struct ltc7871_dev **device,
 	if (!device || !init_param)
 		return -EINVAL;
 
-	dev = (struct ltc7871_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ltc7871_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -746,7 +746,7 @@ int ltc7871_remove(struct ltc7871_dev *dev)
 
 	no_os_gpio_remove(dev->gpio_pwmen);
 	no_os_spi_remove(dev->spi);
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/power/ltm3360b/ltm3360b.c
+++ b/drivers/power/ltm3360b/ltm3360b.c
@@ -38,7 +38,7 @@
 
 #include "no_os_util.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_i2c.h"
 #include "no_os_error.h"
 #include "ltm3360b.h"
@@ -251,7 +251,7 @@ int ltm3360b_init(struct ltm3360b_dev **device,
 	if (!device || !init_param || !init_param->i2c_init)
 		return -EINVAL;
 
-	dev = (struct ltm3360b_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct ltm3360b_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -283,7 +283,7 @@ int ltm3360b_init(struct ltm3360b_dev **device,
 error_i2c:
 	no_os_i2c_remove(dev->i2c_desc);
 error_free:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -302,7 +302,7 @@ int ltm3360b_remove(struct ltm3360b_dev *dev)
 
 	no_os_i2c_remove(dev->i2c_desc);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/power/ltm4686/iio_ltm4686.c
+++ b/drivers/power/ltm4686/iio_ltm4686.c
@@ -33,7 +33,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
@@ -687,7 +687,7 @@ int ltm4686_iio_init(struct ltm4686_iio_desc **iio_desc,
 	if (!init_param || !init_param->ltm4686_init_param)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -706,7 +706,7 @@ int ltm4686_iio_init(struct ltm4686_iio_desc **iio_desc,
 	return 0;
 
 dev_err:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -721,9 +721,9 @@ int ltm4686_iio_remove(struct ltm4686_iio_desc *iio_desc)
 	if (!iio_desc)
 		return -ENODEV;
 
-	no_os_free(iio_desc->iio_dev->channels);
+	capi_free(iio_desc->iio_dev->channels);
 	ltm4686_remove(iio_desc->ltm4686_dev);
-	no_os_free(iio_desc);
+	capi_free(iio_desc);
 
 	return 0;
 }

--- a/drivers/power/ltm4686/ltm4686.c
+++ b/drivers/power/ltm4686/ltm4686.c
@@ -38,7 +38,7 @@
 #include "no_os_units.h"
 #include "no_os_util.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_i2c.h"
 #include "no_os_gpio.h"
 #include "no_os_crc8.h"
@@ -464,7 +464,7 @@ int ltm4686_init(struct ltm4686_dev **device,
 	int ret, i;
 	uint8_t byte;
 
-	dev = (struct ltm4686_dev *)no_os_calloc(1, sizeof(struct ltm4686_dev));
+	dev = (struct ltm4686_dev *)capi_calloc(1, sizeof(struct ltm4686_dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -579,7 +579,7 @@ dev_err:
 		no_os_gpio_remove(dev->fault_descs[i]);
 	}
 i2c_err:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -603,7 +603,7 @@ int ltm4686_remove(struct ltm4686_dev *dev)
 		no_os_gpio_remove(dev->fault_descs[i]);
 	}
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/power/ltm4700/iio_ltm4700.c
+++ b/drivers/power/ltm4700/iio_ltm4700.c
@@ -33,7 +33,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
@@ -928,7 +928,7 @@ int ltm4700_iio_init(struct ltm4700_iio_desc **iio_desc,
 	if (!iio_desc || !init_param || !init_param->ltm4700_init_param)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -943,7 +943,7 @@ int ltm4700_iio_init(struct ltm4700_iio_desc **iio_desc,
 	return 0;
 
 error:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 	return ret;
 }
 
@@ -963,7 +963,7 @@ int ltm4700_iio_remove(struct ltm4700_iio_desc *desc)
 	if (ret)
 		return ret;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/power/ltm4700/ltm4700.c
+++ b/drivers/power/ltm4700/ltm4700.c
@@ -38,7 +38,7 @@
 #include "no_os_units.h"
 #include "no_os_util.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_i2c.h"
 #include "no_os_gpio.h"
 #include "no_os_crc8.h"
@@ -311,7 +311,7 @@ int ltm4700_init(struct ltm4700_dev **device,
 	if (!device || !init_param || !init_param->i2c_init)
 		return -EINVAL;
 
-	dev = no_os_calloc(1, sizeof(*dev));
+	dev = capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -353,7 +353,7 @@ int ltm4700_init(struct ltm4700_dev **device,
 	}
 
 	if (init_param->pgood_params) {
-		dev->pgood_descs = no_os_calloc(dev->num_channels, sizeof(*dev->pgood_descs));
+		dev->pgood_descs = capi_calloc(dev->num_channels, sizeof(*dev->pgood_descs));
 		if (!dev->pgood_descs) {
 			ret = -ENOMEM;
 			goto error_alert;
@@ -370,7 +370,7 @@ int ltm4700_init(struct ltm4700_dev **device,
 	}
 
 	if (init_param->run_params) {
-		dev->run_descs = no_os_calloc(dev->num_channels, sizeof(*dev->run_descs));
+		dev->run_descs = capi_calloc(dev->num_channels, sizeof(*dev->run_descs));
 		if (!dev->run_descs) {
 			ret = -ENOMEM;
 			goto error_pgood;
@@ -387,7 +387,7 @@ int ltm4700_init(struct ltm4700_dev **device,
 	}
 
 	if (init_param->fault_params) {
-		dev->fault_descs = no_os_calloc(dev->num_channels, sizeof(*dev->fault_descs));
+		dev->fault_descs = capi_calloc(dev->num_channels, sizeof(*dev->fault_descs));
 		if (!dev->fault_descs) {
 			ret = -ENOMEM;
 			goto error_run;
@@ -411,26 +411,26 @@ error_fault:
 	if (dev->fault_descs) {
 		for (int i = 0; i < dev->num_channels; i++)
 			no_os_gpio_remove(dev->fault_descs[i]);
-		no_os_free(dev->fault_descs);
+		capi_free(dev->fault_descs);
 	}
 error_run:
 	if (dev->run_descs) {
 		for (int i = 0; i < dev->num_channels; i++)
 			no_os_gpio_remove(dev->run_descs[i]);
-		no_os_free(dev->run_descs);
+		capi_free(dev->run_descs);
 	}
 error_pgood:
 	if (dev->pgood_descs) {
 		for (int i = 0; i < dev->num_channels; i++)
 			no_os_gpio_remove(dev->pgood_descs[i]);
-		no_os_free(dev->pgood_descs);
+		capi_free(dev->pgood_descs);
 	}
 error_alert:
 	no_os_gpio_remove(dev->alert_desc);
 error_i2c:
 	no_os_i2c_remove(dev->i2c_desc);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -452,19 +452,19 @@ int ltm4700_remove(struct ltm4700_dev *dev)
 	if (dev->fault_descs) {
 		for (int i = 0; i < dev->num_channels; i++)
 			no_os_gpio_remove(dev->fault_descs[i]);
-		no_os_free(dev->fault_descs);
+		capi_free(dev->fault_descs);
 	}
 
 	if (dev->run_descs) {
 		for (int i = 0; i < dev->num_channels; i++)
 			no_os_gpio_remove(dev->run_descs[i]);
-		no_os_free(dev->run_descs);
+		capi_free(dev->run_descs);
 	}
 
 	if (dev->pgood_descs) {
 		for (int i = 0; i < dev->num_channels; i++)
 			no_os_gpio_remove(dev->pgood_descs[i]);
-		no_os_free(dev->pgood_descs);
+		capi_free(dev->pgood_descs);
 	}
 
 	if (dev->alert_desc) {
@@ -479,7 +479,7 @@ int ltm4700_remove(struct ltm4700_dev *dev)
 			ret = tmp_ret;
 	}
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/power/ltp8800/iio_ltp8800.c
+++ b/drivers/power/ltp8800/iio_ltp8800.c
@@ -33,7 +33,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
@@ -771,7 +771,7 @@ int ltp8800_iio_init(struct ltp8800_iio_desc **iio_desc,
 	if (!init_param || !init_param->ltp8800_init_param)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -787,7 +787,7 @@ int ltp8800_iio_init(struct ltp8800_iio_desc **iio_desc,
 	return 0;
 
 dev_err:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -802,9 +802,9 @@ int ltp8800_iio_remove(struct ltp8800_iio_desc *iio_desc)
 	if (!iio_desc)
 		return -ENODEV;
 
-	no_os_free(iio_desc->iio_dev->channels);
+	capi_free(iio_desc->iio_dev->channels);
 	ltp8800_remove(iio_desc->ltp8800_dev);
-	no_os_free(iio_desc);
+	capi_free(iio_desc);
 
 	return 0;
 }

--- a/drivers/power/ltp8800/ltp8800.c
+++ b/drivers/power/ltp8800/ltp8800.c
@@ -38,7 +38,7 @@
 #include "no_os_units.h"
 #include "no_os_util.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_pwm.h"
 #include "no_os_i2c.h"
 #include "no_os_gpio.h"
@@ -295,7 +295,7 @@ int ltp8800_init(struct ltp8800_dev **device,
 	uint8_t ic_device_id[2] = LTP8800_IC_DEVICE_ID_VALUE;
 	uint8_t val;
 
-	dev = (struct ltp8800_dev *)no_os_calloc(1, sizeof(struct ltp8800_dev));
+	dev = (struct ltp8800_dev *)capi_calloc(1, sizeof(struct ltp8800_dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -391,7 +391,7 @@ dev_err:
 	no_os_gpio_remove(dev->smbalert_desc);
 	no_os_i2c_remove(dev->i2c_desc);
 i2c_err:
-	no_os_free(dev);
+	capi_free(dev);
 	return ret;
 }
 
@@ -423,7 +423,7 @@ int ltp8800_remove(struct ltp8800_dev *dev)
 			return ret;
 	}
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/power/max17616/iio_max17616.c
+++ b/drivers/power/max17616/iio_max17616.c
@@ -33,7 +33,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
@@ -822,7 +822,7 @@ int max17616_iio_init(struct max17616_iio_desc **iio_desc,
 	if (!iio_desc || !init_param || !init_param->max17616_init_param)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -838,7 +838,7 @@ int max17616_iio_init(struct max17616_iio_desc **iio_desc,
 	return 0;
 
 dev_err:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -856,7 +856,7 @@ int max17616_iio_remove(struct max17616_iio_desc *iio_desc)
 	if (iio_desc->max17616_dev)
 		max17616_remove(iio_desc->max17616_dev);
 
-	no_os_free(iio_desc);
+	capi_free(iio_desc);
 
 	return 0;
 }

--- a/drivers/power/max17616/max17616.c
+++ b/drivers/power/max17616/max17616.c
@@ -40,7 +40,7 @@
 #include "no_os_units.h"
 #include "no_os_util.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_i2c.h"
 #include "no_os_crc8.h"
 
@@ -1098,7 +1098,7 @@ int max17616_init(struct max17616_dev **device,
 	struct max17616_dev *dev;
 	int ret = -EINVAL;
 
-	dev = (struct max17616_dev *)no_os_calloc(1, sizeof(struct max17616_dev));
+	dev = (struct max17616_dev *)capi_calloc(1, sizeof(struct max17616_dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -1132,7 +1132,7 @@ int max17616_init(struct max17616_dev **device,
 dev_err:
 	no_os_i2c_remove(dev->i2c_desc);
 i2c_err:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -1145,7 +1145,7 @@ i2c_err:
 int max17616_remove(struct max17616_dev *dev)
 {
 	no_os_i2c_remove(dev->i2c_desc);
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/power/max17851/max17851.c
+++ b/drivers/power/max17851/max17851.c
@@ -31,7 +31,7 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 #include "max17851.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 
 /**
@@ -115,7 +115,7 @@ static int32_t max17851_uart_init(struct no_os_uart_desc **desc,
 	if (!param || !param->extra)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -148,7 +148,7 @@ static int32_t max17851_uart_init(struct no_os_uart_desc **desc,
 	return 0;
 
 error:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -168,7 +168,7 @@ static int32_t max17851_uart_remove(struct no_os_uart_desc *desc)
 	extra = desc->extra;
 
 	max17851_remove(extra);
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }
@@ -583,7 +583,7 @@ int max17851_init(struct max17851_desc **desc,
 	uint8_t reg_val;
 	int ret;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -715,7 +715,7 @@ free_gpio1:
 free_spi:
 	no_os_spi_remove(descriptor->spi_desc);
 free_desc:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -730,7 +730,7 @@ int max17851_remove(struct max17851_desc *desc)
 	no_os_gpio_remove(desc->gpio2_desc);
 	no_os_gpio_remove(desc->gpio1_desc);
 	no_os_spi_remove(desc->spi_desc);
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/power/max22216/max22216.h
+++ b/drivers/power/max22216/max22216.h
@@ -37,7 +37,7 @@
 #include <stdbool.h>
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_util.h"
 #include "no_os_error.h"
 

--- a/drivers/power/max42500/max42500.c
+++ b/drivers/power/max42500/max42500.c
@@ -41,7 +41,7 @@
 #include "max42500.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_crc8.h"
 
 #define CRC8_PEC        0x07      /* Implements Polynomial X^8 + X^2 + X^1 +1 */
@@ -627,7 +627,7 @@ int max42500_init(struct max42500_dev **desc,
 
 	no_os_crc8_populate_msb(max42500_crc8, CRC8_PEC);
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -780,7 +780,7 @@ free_en1:
 free_en0:
 	no_os_gpio_remove(descriptor->en0);
 free_desc:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -813,7 +813,7 @@ int max42500_remove(struct max42500_dev *desc)
 	if (ret)
 		return ret;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/resolver/ad2s1210/ad2s1210.c
+++ b/drivers/resolver/ad2s1210/ad2s1210.c
@@ -37,7 +37,7 @@
 #include "no_os_error.h"
 #include "no_os_print_log.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 static int ad2s1210_set_mode_pins(struct ad2s1210_dev *dev,
 				  enum ad2s1210_mode mode);
@@ -313,7 +313,7 @@ int ad2s1210_init(struct ad2s1210_dev **dev,
 		return -EINVAL;
 	}
 
-	d = (struct ad2s1210_dev *)no_os_calloc(1, sizeof(*d));
+	d = (struct ad2s1210_dev *)capi_calloc(1, sizeof(*d));
 	if (!d)
 		return -ENOMEM;
 
@@ -392,7 +392,7 @@ err_a1:
 err_a0:
 	no_os_gpio_remove(d->gpio_sample);
 err_sample:
-	no_os_free(d);
+	capi_free(d);
 	pr_err("%s initialization failed with status %ld\n", d->name, ret);
 
 	return ret;
@@ -533,7 +533,7 @@ int ad2s1210_remove(struct ad2s1210_dev *dev)
 			return ret;
 	}
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/rf-transceiver/ad9361/ad9361.c
+++ b/drivers/rf-transceiver/ad9361/ad9361.c
@@ -43,7 +43,7 @@
 #include "no_os_delay.h"
 #include "ad9361_util.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "app_config.h"
 
 #define diff_abs(x, y) ((x) > (y) ? (x - y) : (y - x))
@@ -695,7 +695,7 @@ int32_t ad9361_spi_readm(struct no_os_spi_desc *spi, uint32_t reg,
 		return -EINVAL;
 
 	cmd = AD_READ | AD_CNT(num) | AD_ADDR(reg);
-	rbuffer = no_os_malloc(num + 2);
+	rbuffer = capi_malloc(num + 2);
 	if (!rbuffer)
 		return -ENOMEM;
 	rbuffer[0] = cmd >> 8;
@@ -707,7 +707,7 @@ int32_t ad9361_spi_readm(struct no_os_spi_desc *spi, uint32_t reg,
 	else
 		memcpy(rbuf, &rbuffer[2], num);
 
-	no_os_free(rbuffer);
+	capi_free(rbuffer);
 #ifdef _DEBUG
 	{
 		int32_t i;
@@ -7252,7 +7252,7 @@ static struct no_os_clk *ad9361_clk_register(struct ad9361_rf_phy *phy,
 		// Unused variable - fix compiler warning
 	}
 
-	clk_priv = (struct refclk_scale *)no_os_malloc(sizeof(*clk_priv));
+	clk_priv = (struct refclk_scale *)capi_malloc(sizeof(*clk_priv));
 	if (!clk_priv) {
 		dev_err(&phy->spi->dev,
 			"ad9361_clk_register: could not allocate fixed factor clk");
@@ -7267,9 +7267,9 @@ static struct no_os_clk *ad9361_clk_register(struct ad9361_rf_phy *phy,
 
 	phy->ref_clk_scale[source] = clk_priv;
 
-	clk = (struct no_os_clk *)no_os_malloc(sizeof(*clk));
+	clk = (struct no_os_clk *)capi_malloc(sizeof(*clk));
 	if (!clk) {
-		no_os_free(clk_priv);
+		capi_free(clk_priv);
 		return (struct no_os_clk *)ERR_PTR(-ENOMEM);
 	}
 
@@ -7463,8 +7463,8 @@ int32_t ad9361_unregister_clocks(struct ad9361_rf_phy *phy)
 	int32_t i;
 
 	for (i = 0; i < NUM_AD9361_CLKS; i++) {
-		no_os_free(phy->clks[i]);
-		no_os_free(phy->ref_clk_scale[i]);
+		capi_free(phy->clks[i]);
+		capi_free(phy->ref_clk_scale[i]);
 	}
 
 	return 0;

--- a/drivers/rf-transceiver/ad9361/ad9361_api.c
+++ b/drivers/rf-transceiver/ad9361/ad9361_api.c
@@ -36,7 +36,7 @@
 #include "no_os_delay.h"
 #include "no_os_spi.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "app_config.h"
 #include <string.h>
 #ifndef AXI_ADC_NOT_PRESENT
@@ -75,41 +75,41 @@ int32_t ad9361_init(struct ad9361_rf_phy **ad9361_phy,
 	int32_t rev = 0;
 	int32_t i   = 0;
 
-	phy = (struct ad9361_rf_phy *)no_os_calloc(1, sizeof(*phy));
+	phy = (struct ad9361_rf_phy *)capi_calloc(1, sizeof(*phy));
 	if (!phy) {
 		return -ENOMEM;
 	}
 
-	phy->clk_refin = (struct no_os_clk *)no_os_calloc(1, sizeof(*phy->clk_refin));
+	phy->clk_refin = (struct no_os_clk *)capi_calloc(1, sizeof(*phy->clk_refin));
 	if (!phy->clk_refin) {
-		no_os_free(phy);
+		capi_free(phy);
 		return -ENOMEM;
 	}
 
-	phy->pdata = (struct ad9361_phy_platform_data *)no_os_calloc(1,
+	phy->pdata = (struct ad9361_phy_platform_data *)capi_calloc(1,
 			sizeof(*phy->pdata));
 	if (!phy->pdata) {
-		no_os_free(phy->clk_refin);
-		no_os_free(phy);
+		capi_free(phy->clk_refin);
+		capi_free(phy);
 		return -ENOMEM;
 	}
 #ifndef AXI_ADC_NOT_PRESENT
-	phy->adc_conv = (struct axiadc_converter *)no_os_calloc(1,
+	phy->adc_conv = (struct axiadc_converter *)capi_calloc(1,
 			sizeof(*phy->adc_conv));
 	if (!phy->adc_conv) {
-		no_os_free(phy->pdata);
-		no_os_free(phy->clk_refin);
-		no_os_free(phy);
+		capi_free(phy->pdata);
+		capi_free(phy->clk_refin);
+		capi_free(phy);
 		return -ENOMEM;
 	}
 
-	phy->adc_state = (struct axiadc_state *)no_os_calloc(1,
+	phy->adc_state = (struct axiadc_state *)capi_calloc(1,
 			 sizeof(*phy->adc_state));
 	if (!phy->adc_state) {
-		no_os_free(phy->adc_conv);
-		no_os_free(phy->pdata);
-		no_os_free(phy->clk_refin);
-		no_os_free(phy);
+		capi_free(phy->adc_conv);
+		capi_free(phy->pdata);
+		capi_free(phy->clk_refin);
+		capi_free(phy);
 		return -ENOMEM;
 	}
 	phy->adc_state->phy = phy;
@@ -571,12 +571,12 @@ out_clk:
 	ad9361_unregister_clocks(phy);
 out:
 #ifndef AXI_ADC_NOT_PRESENT
-	no_os_free(phy->adc_conv);
-	no_os_free(phy->adc_state);
+	capi_free(phy->adc_conv);
+	capi_free(phy->adc_state);
 #endif
-	no_os_free(phy->clk_refin);
-	no_os_free(phy->pdata);
-	no_os_free(phy);
+	capi_free(phy->clk_refin);
+	capi_free(phy->pdata);
+	capi_free(phy);
 	printf("%s : AD936x initialization error\n", __func__);
 
 	return -ENODEV;
@@ -596,12 +596,12 @@ int32_t ad9361_remove(struct ad9361_rf_phy *phy)
 	no_os_gpio_remove(phy->gpio_desc_cal_sw1);
 	no_os_gpio_remove(phy->gpio_desc_cal_sw2);
 #ifndef AXI_ADC_NOT_PRESENT
-	no_os_free(phy->adc_conv);
-	no_os_free(phy->adc_state);
+	capi_free(phy->adc_conv);
+	capi_free(phy->adc_state);
 #endif
-	no_os_free(phy->clk_refin);
-	no_os_free(phy->pdata);
-	no_os_free(phy);
+	capi_free(phy->clk_refin);
+	capi_free(phy->pdata);
+	capi_free(phy);
 
 	return 0;
 }

--- a/drivers/rf-transceiver/ad9361/ad9361_ext_band_ctrl.c
+++ b/drivers/rf-transceiver/ad9361/ad9361_ext_band_ctrl.c
@@ -14,7 +14,7 @@
 #include "ad9361_ext_band_ctrl.h"
 #include "no_os_gpio.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_spi.h"
 
 /**
@@ -219,7 +219,7 @@ static struct ad9361_band_setting **grow_settings_array(
 	uint32_t i;
 
 	new_arr = (struct ad9361_band_setting **)
-		  no_os_calloc(old_count + 1, sizeof(*new_arr));
+		  capi_calloc(old_count + 1, sizeof(*new_arr));
 	if (!new_arr)
 		return NULL;
 
@@ -228,7 +228,7 @@ static struct ad9361_band_setting **grow_settings_array(
 
 	new_arr[old_count] = new_elem;
 
-	no_os_free(old_arr);
+	capi_free(old_arr);
 	return new_arr;
 }
 
@@ -248,14 +248,14 @@ ad9361_band_setting_alloc(const char *name, uint64_t freq_min,
 	uint32_t i;
 
 	s = (struct ad9361_band_setting *)
-	    no_os_calloc(1, sizeof(*s));
+	    capi_calloc(1, sizeof(*s));
 	if (!s)
 		return NULL;
 
 	if (name) {
-		char *name_copy = (char *)no_os_calloc(1, strlen(name) + 1);
+		char *name_copy = (char *)capi_calloc(1, strlen(name) + 1);
 		if (!name_copy) {
-			no_os_free(s);
+			capi_free(s);
 			return NULL;
 		}
 		strcpy(name_copy, name);
@@ -269,10 +269,10 @@ ad9361_band_setting_alloc(const char *name, uint64_t freq_min,
 
 	if (ngpios > 0) {
 		s->gpio_values = (uint32_t *)
-				 no_os_calloc(ngpios, sizeof(uint32_t));
+				 capi_calloc(ngpios, sizeof(uint32_t));
 		if (!s->gpio_values) {
-			no_os_free((void *)s->name);
-			no_os_free(s);
+			capi_free((void *)s->name);
+			capi_free(s);
 			return NULL;
 		}
 		for (i = 0; i < ngpios; i++)
@@ -294,22 +294,22 @@ void ad9361_band_setting_free(struct ad9361_band_setting *s)
 	if (!s)
 		return;
 
-	no_os_free((void *)s->name);
-	no_os_free(s->gpio_values);
+	capi_free((void *)s->name);
+	capi_free(s->gpio_values);
 
 	if (s->pre_seq) {
 		for (i = 0; i < s->pre_seq_len; i++)
-			no_os_free(s->pre_seq[i].gpio_values);
-		no_os_free(s->pre_seq);
+			capi_free(s->pre_seq[i].gpio_values);
+		capi_free(s->pre_seq);
 	}
 
 	if (s->post_seq) {
 		for (i = 0; i < s->post_seq_len; i++)
-			no_os_free(s->post_seq[i].gpio_values);
-		no_os_free(s->post_seq);
+			capi_free(s->post_seq[i].gpio_values);
+		capi_free(s->post_seq);
 	}
 
-	no_os_free(s);
+	capi_free(s);
 }
 
 /**
@@ -371,7 +371,7 @@ void ad9361_band_setting_set_delay(struct ad9361_band_setting *s,
 struct ad9361_ext_band_ctl *ad9361_ext_band_ctl_alloc(void)
 {
 	return (struct ad9361_ext_band_ctl *)
-	       no_os_calloc(1, sizeof(struct ad9361_ext_band_ctl));
+	       capi_calloc(1, sizeof(struct ad9361_ext_band_ctl));
 }
 
 /**
@@ -392,9 +392,9 @@ void ad9361_ext_band_ctl_free(struct ad9361_ext_band_ctl *ctl)
 	for (i = 0; i < ctl->tx_count; i++)
 		ad9361_band_setting_free(ctl->tx_settings[i]);
 
-	no_os_free(ctl->rx_settings);
-	no_os_free(ctl->tx_settings);
-	no_os_free(ctl);
+	capi_free(ctl->rx_settings);
+	capi_free(ctl->tx_settings);
+	capi_free(ctl);
 }
 
 /**

--- a/drivers/rf-transceiver/ad9361/iio_ad9361.c
+++ b/drivers/rf-transceiver/ad9361/iio_ad9361.c
@@ -40,7 +40,7 @@
 #include "iio_ad9361.h"
 #include "ad9361_api.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #ifndef AXI_ADC_NOT_PRESENT
 #include "axi_adc_core.h"
 #endif
@@ -3125,7 +3125,7 @@ int32_t iio_ad9361_init(struct iio_ad9361_desc **desc,
 {
 	struct iio_ad9361_desc *iio_ad9361_inst;
 
-	iio_ad9361_inst = (struct iio_ad9361_desc *)no_os_calloc(1,
+	iio_ad9361_inst = (struct iio_ad9361_desc *)capi_calloc(1,
 			  sizeof(struct iio_ad9361_desc));
 	if (!iio_ad9361_inst)
 		return -1;
@@ -3153,7 +3153,7 @@ int32_t iio_ad9361_remove(struct iio_ad9361_desc *desc)
 	if (!desc)
 		return -1;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/rf-transceiver/adf7023/adf7023.c
+++ b/drivers/rf-transceiver/adf7023/adf7023.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include "adf7023_config.h"
 #include "adf7023.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 #define ADF7023_CS_ASSERT   no_os_gpio_set_value(dev->gpio_cs,  \
 			    NO_OS_GPIO_LOW)
@@ -82,7 +82,7 @@ int32_t adf7023_init(struct adf7023_dev **device,
 	uint8_t status = 0;
 	int32_t ret = 0;
 
-	dev = (struct adf7023_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct adf7023_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -1;
 
@@ -133,7 +133,7 @@ int32_t adf7023_remove(struct adf7023_dev *dev)
 	ret |= no_os_gpio_remove(dev->gpio_cs);
 	ret |= no_os_gpio_remove(dev->gpio_miso);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/rf-transceiver/hmc630x/hmc630x.c
+++ b/drivers/rf-transceiver/hmc630x/hmc630x.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include "hmc630x.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 #define HMC630X_ARRAY_ADDRESS_MASK NO_OS_GENMASK(13, 8)
 #define HMC630X_RW_MASK NO_OS_BIT(14)
@@ -82,11 +82,11 @@ static int _hmc630x_generate_vco(struct hmc630x_dev *d, uint64_t f_start,
 {
 	int ret, e;
 
-	d->vco.freqs = (uint64_t *)no_os_calloc(entries, sizeof(*d->vco.freqs));
+	d->vco.freqs = (uint64_t *)capi_calloc(entries, sizeof(*d->vco.freqs));
 	if (!d->vco.freqs)
 		return -ENOMEM;
 
-	d->vco.fbdiv = (uint8_t *)no_os_calloc(entries, sizeof(*d->vco.fbdiv));
+	d->vco.fbdiv = (uint8_t *)capi_calloc(entries, sizeof(*d->vco.fbdiv));
 	if (!d->vco.fbdiv) {
 		ret = -ENOMEM;
 		goto error;
@@ -101,7 +101,7 @@ static int _hmc630x_generate_vco(struct hmc630x_dev *d, uint64_t f_start,
 
 	return 0;
 error:
-	no_os_free(d->vco.freqs);
+	capi_free(d->vco.freqs);
 	return ret;
 }
 
@@ -115,7 +115,7 @@ int hmc630x_init(struct hmc630x_dev **dev, struct hmc630x_init_param *init)
 	if (!dev || !init)
 		return -EINVAL;
 
-	d = (struct hmc630x_dev *) no_os_calloc(1, sizeof(*d));
+	d = (struct hmc630x_dev *) capi_calloc(1, sizeof(*d));
 	if (!d)
 		return -ENOMEM;
 
@@ -243,10 +243,10 @@ error_3:
 error_2:
 	no_os_gpio_remove(d->en);
 error_1:
-	no_os_free(d->vco.freqs);
-	no_os_free(d->vco.fbdiv);
+	capi_free(d->vco.freqs);
+	capi_free(d->vco.fbdiv);
 error_0:
-	no_os_free(d);
+	capi_free(d);
 	return ret;
 }
 
@@ -255,9 +255,9 @@ int hmc630x_remove(struct hmc630x_dev *dev)
 {
 	int ret;
 
-	no_os_free(dev->vco.freqs);
+	capi_free(dev->vco.freqs);
 	dev->vco.freqs = NULL;
-	no_os_free(dev->vco.fbdiv);
+	capi_free(dev->vco.fbdiv);
 	dev->vco.fbdiv = NULL;
 
 	ret = no_os_gpio_remove(dev->en);
@@ -276,7 +276,7 @@ int hmc630x_remove(struct hmc630x_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/rf-transceiver/hmc630x/iio_hmc630x.c
+++ b/drivers/rf-transceiver/hmc630x/iio_hmc630x.c
@@ -39,7 +39,7 @@
 #include "iio.h"
 #include "iio_hmc630x.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "hmc630x.h"
 #include <string.h>
 
@@ -440,11 +440,11 @@ int32_t hmc630x_iio_init(struct hmc630x_iio_dev **iiodev,
 	struct hmc630x_iio_dev *d;
 	struct iio_device *d2;
 
-	d = (struct hmc630x_iio_dev *)no_os_calloc(1, sizeof(*d));
+	d = (struct hmc630x_iio_dev *)capi_calloc(1, sizeof(*d));
 	if (!d)
 		return -ENOMEM;
 
-	d2 = (struct iio_device *)no_os_calloc(1, sizeof(*d2));
+	d2 = (struct iio_device *)capi_calloc(1, sizeof(*d2));
 	if (!d2)
 		goto end_0;
 
@@ -465,9 +465,9 @@ int32_t hmc630x_iio_init(struct hmc630x_iio_dev **iiodev,
 
 	return 0;
 end_1:
-	no_os_free(d2);
+	capi_free(d2);
 end_0:
-	no_os_free(d);
+	capi_free(d);
 
 	return ret;
 }
@@ -483,8 +483,8 @@ int32_t hmc630x_iio_remove(struct hmc630x_iio_dev *iiodev)
 	if (ret != 0)
 		return ret;
 
-	no_os_free(iiodev->iio_dev);
-	no_os_free(iiodev);
+	capi_free(iiodev->iio_dev);
+	capi_free(iiodev);
 
 	return 0;
 }

--- a/drivers/rf-transceiver/koror/adrv904x.c
+++ b/drivers/rf-transceiver/koror/adrv904x.c
@@ -18,7 +18,7 @@
 #include "no_os_print_log.h"
 #include "no_os_error.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_util.h"
 #include "no_os_spi.h"
 #include "adrv904x.h"
@@ -1000,7 +1000,7 @@ int32_t adrv904x_init(struct adrv904x_rf_phy **dev,
 	struct adrv904x_rf_phy *phy;
 	int ret;
 
-	phy = (struct adrv904x_rf_phy *)no_os_calloc(1, sizeof(*phy));
+	phy = (struct adrv904x_rf_phy *)capi_calloc(1, sizeof(*phy));
 	if (!phy) {
 		ret = -ENOMEM;
 		goto error;
@@ -1049,7 +1049,7 @@ int32_t adrv904x_init(struct adrv904x_rf_phy **dev,
 
 	return 0;
 error_setup:
-	no_os_free(phy);
+	capi_free(phy);
 	*dev = NULL;
 error:
 	return ret;
@@ -1127,7 +1127,7 @@ int adrv904x_setup(struct adrv904x_rf_phy *phy)
 	if (ret)
 		return ret;
 
-	errPtr = (adi_common_ErrData_t *)no_os_calloc(1, sizeof(adi_common_ErrData_t));
+	errPtr = (adi_common_ErrData_t *)capi_calloc(1, sizeof(adi_common_ErrData_t));
 	if (!errPtr)
 		return -ENOMEM;
 
@@ -1140,7 +1140,7 @@ int adrv904x_setup(struct adrv904x_rf_phy *phy)
 	if (ret)
 		goto error_free_errptr;
 
-	rx_sample_clk = no_os_calloc(1, sizeof(*rx_sample_clk));
+	rx_sample_clk = capi_calloc(1, sizeof(*rx_sample_clk));
 	if (!rx_sample_clk)
 		goto rx_out_clk_error;
 
@@ -1156,7 +1156,7 @@ int adrv904x_setup(struct adrv904x_rf_phy *phy)
 
 	phy->clks[ADRV904X_RX_SAMPL_CLK] = rx_sample_clk;
 
-	tx_sample_clk = no_os_calloc(1, sizeof(*tx_sample_clk));
+	tx_sample_clk = capi_calloc(1, sizeof(*tx_sample_clk));
 	if (!tx_sample_clk)
 		goto rx_out_clk_init_error;
 
@@ -1172,7 +1172,7 @@ int adrv904x_setup(struct adrv904x_rf_phy *phy)
 
 	phy->clks[ADRV904X_TX_SAMPL_CLK] = tx_sample_clk;
 
-	orx_sample_clk = no_os_calloc(1, sizeof(*orx_sample_clk));
+	orx_sample_clk = capi_calloc(1, sizeof(*orx_sample_clk));
 	if (!orx_sample_clk)
 		goto tx_out_clk_init_error;
 
@@ -1254,14 +1254,14 @@ int adrv904x_setup(struct adrv904x_rf_phy *phy)
 	return 0;
 
 orx_out_clk_init_error:
-	no_os_free(orx_sample_clk);
+	capi_free(orx_sample_clk);
 tx_out_clk_init_error:
-	no_os_free(tx_sample_clk);
+	capi_free(tx_sample_clk);
 rx_out_clk_init_error:
-	no_os_free(rx_sample_clk);
+	capi_free(rx_sample_clk);
 rx_out_clk_error:
 error_free_errptr:
-	no_os_free(errPtr);
+	capi_free(errPtr);
 	return ret;
 }
 
@@ -1276,7 +1276,7 @@ int adrv904x_remove(struct adrv904x_rf_phy *phy)
 	if (phy->is_initialized)
 		adrv904x_shutdown(phy);
 
-	no_os_free(phy);
+	capi_free(phy);
 
 	return 0;
 }

--- a/drivers/rf-transceiver/madura/adrv9025.c
+++ b/drivers/rf-transceiver/madura/adrv9025.c
@@ -8,7 +8,7 @@
 #include "xilinx_transceiver.h"
 #include "no_os_print_log.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_util.h"
 #include "no_os_spi.h"
 #include "adrv9025.h"
@@ -1240,11 +1240,11 @@ int32_t adrv9025_init(struct adrv9025_rf_phy **dev,
 	struct adrv9025_rf_phy *phy;
 	int ret;
 
-	phy = (struct adrv9025_rf_phy *)no_os_calloc(1, sizeof(*phy));
+	phy = (struct adrv9025_rf_phy *)capi_calloc(1, sizeof(*phy));
 	if (!phy)
 		goto error;
 
-	agcConfig = no_os_calloc(1, sizeof(adi_adrv9025_AgcCfg_t));
+	agcConfig = capi_calloc(1, sizeof(adi_adrv9025_AgcCfg_t));
 	if (!agcConfig)
 		goto error_setup;
 
@@ -1285,9 +1285,9 @@ int32_t adrv9025_init(struct adrv9025_rf_phy **dev,
 
 	return 0;
 error_agc_config:
-	no_os_free(agcConfig);
+	capi_free(agcConfig);
 error_setup:
-	no_os_free(phy);
+	capi_free(phy);
 error:
 	return ret;
 }
@@ -1391,7 +1391,7 @@ int adrv9025_setup(struct adrv9025_rf_phy *phy)
 	if (ret)
 		return adrv9025_dev_err(phy);
 
-	rx_sample_clk = no_os_calloc(1, sizeof(rx_sample_clk));
+	rx_sample_clk = capi_calloc(1, sizeof(rx_sample_clk));
 	if (!rx_sample_clk)
 		goto rx_out_clk_error;
 
@@ -1407,7 +1407,7 @@ int adrv9025_setup(struct adrv9025_rf_phy *phy)
 
 	phy->clks[ADRV9025_RX_SAMPL_CLK] = rx_sample_clk;
 
-	tx_sample_clk = no_os_calloc(1, sizeof(tx_sample_clk));
+	tx_sample_clk = capi_calloc(1, sizeof(tx_sample_clk));
 	if (!tx_sample_clk)
 		goto rx_out_clk_init_error;
 
@@ -1423,7 +1423,7 @@ int adrv9025_setup(struct adrv9025_rf_phy *phy)
 
 	phy->clks[ADRV9025_TX_SAMPL_CLK] = tx_sample_clk;
 
-	orx_sample_clk = no_os_calloc(1, sizeof(orx_sample_clk));
+	orx_sample_clk = capi_calloc(1, sizeof(orx_sample_clk));
 	if (!orx_sample_clk)
 		goto tx_out_clk_init_error;
 
@@ -1448,11 +1448,11 @@ int adrv9025_setup(struct adrv9025_rf_phy *phy)
 	return 0;
 
 orx_out_clk_init_error:
-	no_os_free(orx_sample_clk);
+	capi_free(orx_sample_clk);
 tx_out_clk_init_error:
-	no_os_free(tx_sample_clk);
+	capi_free(tx_sample_clk);
 rx_out_clk_init_error:
-	no_os_free(rx_sample_clk);
+	capi_free(rx_sample_clk);
 rx_out_clk_error:
 	return ret;
 }

--- a/drivers/rf-transceiver/navassa/adrv9002.c
+++ b/drivers/rf-transceiver/navassa/adrv9002.c
@@ -34,7 +34,7 @@
 #include <string.h>
 #include "no_os_print_log.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 #include "no_os_util.h"
 #include "no_os_clk.h"

--- a/drivers/rf-transceiver/palma/adrv903x.c
+++ b/drivers/rf-transceiver/palma/adrv903x.c
@@ -46,7 +46,7 @@
 #include "adi_adrv903x_tx.h"
 #include "adi_common_error.h"
 #include "jesd204.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_clk.h"
 #include "no_os_delay.h"
 #include "no_os_error.h"
@@ -732,7 +732,7 @@ int adrv903x_init(struct adrv903x_rf_phy **phy,
 	if (!phy || !init_param)
 		return -EINVAL;
 
-	p = no_os_calloc(1, sizeof(*p));
+	p = capi_calloc(1, sizeof(*p));
 	if (!p)
 		return -ENOMEM;
 
@@ -745,7 +745,7 @@ int adrv903x_init(struct adrv903x_rf_phy **phy,
 	p->palmaDevice->common.devHalInfo = &p->hal;
 
 	/* Allocate error data block required by the API */
-	errPtr = no_os_calloc(1, sizeof(*errPtr));
+	errPtr = capi_calloc(1, sizeof(*errPtr));
 	if (!errPtr) {
 		ret = -ENOMEM;
 		goto error_free_phy;
@@ -893,9 +893,9 @@ error_disable_clk:
 	if (p->dev_clk)
 		no_os_clk_disable(p->dev_clk);
 error_free_errptr:
-	no_os_free(errPtr);
+	capi_free(errPtr);
 error_free_phy:
-	no_os_free(p);
+	capi_free(p);
 	return ret;
 }
 
@@ -919,7 +919,7 @@ int adrv903x_remove(struct adrv903x_rf_phy *phy)
 	if (phy->dev_clk)
 		no_os_clk_disable(phy->dev_clk);
 
-	no_os_free(phy->palmaDevice->common.errPtr);
-	no_os_free(phy);
+	capi_free(phy->palmaDevice->common.errPtr);
+	capi_free(phy);
 	return 0;
 }

--- a/drivers/rf-transceiver/talise/adrv9009.c
+++ b/drivers/rf-transceiver/talise/adrv9009.c
@@ -39,7 +39,7 @@
 // platform drivers
 #include "no_os_print_log.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 #include "no_os_util.h"
 
@@ -1206,7 +1206,7 @@ int32_t adrv9009_init(struct adrv9009_rf_phy **dev,
 	struct adrv9009_rf_phy *phy;
 	int ret;
 
-	phy = (struct adrv9009_rf_phy *)no_os_calloc(1, sizeof(*phy));
+	phy = (struct adrv9009_rf_phy *)capi_calloc(1, sizeof(*phy));
 	if (!phy)
 		goto error;
 
@@ -1271,7 +1271,7 @@ int32_t adrv9009_init(struct adrv9009_rf_phy **dev,
 
 	return 0;
 error_setup:
-	no_os_free(phy);
+	capi_free(phy);
 error:
 	return ret;
 }
@@ -1385,7 +1385,7 @@ int adrv9009_setup(struct adrv9009_rf_phy *phy)
 	}
 
 	/* Initialize clk components */
-	rx_sample_clk = no_os_calloc(1, sizeof(*rx_sample_clk));
+	rx_sample_clk = capi_calloc(1, sizeof(*rx_sample_clk));
 	if (!rx_sample_clk)
 		goto error;
 
@@ -1400,7 +1400,7 @@ int adrv9009_setup(struct adrv9009_rf_phy *phy)
 
 	phy->clks[RX_SAMPL_CLK] = rx_sample_clk;
 
-	orx_sample_clk = no_os_calloc(1, sizeof(*orx_sample_clk));
+	orx_sample_clk = capi_calloc(1, sizeof(*orx_sample_clk));
 	if (!orx_sample_clk)
 		goto rx_out_clk_init_error;
 
@@ -1415,7 +1415,7 @@ int adrv9009_setup(struct adrv9009_rf_phy *phy)
 
 	phy->clks[OBS_SAMPL_CLK] = orx_sample_clk;
 
-	tx_sample_clk = no_os_calloc(1, sizeof(*tx_sample_clk));
+	tx_sample_clk = capi_calloc(1, sizeof(*tx_sample_clk));
 	if (!tx_sample_clk)
 		goto orx_out_clk_init_error;
 
@@ -1448,11 +1448,11 @@ int adrv9009_setup(struct adrv9009_rf_phy *phy)
 	return 0;
 
 tx_out_clk_init_error:
-	no_os_free(tx_sample_clk);
+	capi_free(tx_sample_clk);
 orx_out_clk_init_error:
-	no_os_free(orx_sample_clk);
+	capi_free(orx_sample_clk);
 rx_out_clk_init_error:
-	no_os_free(rx_sample_clk);
+	capi_free(rx_sample_clk);
 error:
 	return ret;
 }

--- a/drivers/rtc/max31343/max31343.c
+++ b/drivers/rtc/max31343/max31343.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include "max31343.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Read device register.
@@ -110,7 +110,7 @@ int max31343_init(struct max31343_dev **device,
 	struct max31343_dev *dev;
 	int ret;
 
-	dev = (struct max31343_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct max31343_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 	*device = dev;
@@ -144,7 +144,7 @@ int max31343_init(struct max31343_dev **device,
 error:
 	no_os_i2c_remove(dev->i2c_desc);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -263,7 +263,7 @@ int max31343_remove(struct max31343_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/rtc/pcf85263/pcf85263.c
+++ b/drivers/rtc/pcf85263/pcf85263.c
@@ -35,7 +35,7 @@
 #include <errno.h>
 #include "pcf85263.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Read device register.
@@ -109,7 +109,7 @@ int pcf85263_init(struct pcf85263_dev **device,
 	struct pcf85263_dev *dev;
 	int ret;
 
-	dev = (struct pcf85263_dev *)no_os_calloc(1, sizeof(*dev));
+	dev = (struct pcf85263_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -133,7 +133,7 @@ int pcf85263_init(struct pcf85263_dev **device,
 error_i2c:
 	no_os_i2c_remove(dev->i2c_desc);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -249,7 +249,7 @@ int pcf85263_remove(struct pcf85263_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/sd-card/sd.c
+++ b/drivers/sd-card/sd.c
@@ -36,7 +36,7 @@
 #include "sd.h"
 #include "no_os_delay.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 #define BIT_CCS				(1u<<30)
 #define BIT_APPLICATION_CMD		(1u<<7)
@@ -518,7 +518,7 @@ int32_t sd_init(struct sd_desc **sd_desc, const struct sd_init_param *param)
 	if (!sd_desc || !param)
 		return -1;
 
-	local_desc = no_os_calloc(1, sizeof(*local_desc));
+	local_desc = capi_calloc(1, sizeof(*local_desc));
 	if (!local_desc)
 		return -1;
 	local_desc->spi_desc = param->spi_desc;
@@ -610,7 +610,7 @@ int32_t sd_init(struct sd_desc **sd_desc, const struct sd_init_param *param)
 
 	return 0;
 failure:
-	no_os_free(local_desc);
+	capi_free(local_desc);
 	return -1;
 }
 
@@ -624,6 +624,6 @@ int32_t sd_remove(struct sd_desc *desc)
 	if (desc == NULL)
 		return -1;
 
-	no_os_free(desc);
+	capi_free(desc);
 	return 0;
 }

--- a/drivers/switch/adg1712/adg1712.c
+++ b/drivers/switch/adg1712/adg1712.c
@@ -33,7 +33,7 @@
 
 #include <stdlib.h>
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "adg1712.h"
 
 /**
@@ -137,7 +137,7 @@ int adg1712_init(struct adg1712_dev **device,
 	if (!device || !init_param)
 		return -EINVAL;
 
-	dev = no_os_calloc(1, sizeof(*dev));
+	dev = capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -188,7 +188,7 @@ error_gpio2:
 error_gpio1:
 	no_os_gpio_remove(dev->gpio_in1);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -207,7 +207,7 @@ int adg1712_remove(struct adg1712_dev *dev)
 	no_os_gpio_remove(dev->gpio_in2);
 	no_os_gpio_remove(dev->gpio_in3);
 	no_os_gpio_remove(dev->gpio_in4);
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/switch/adg1736/adg1736.c
+++ b/drivers/switch/adg1736/adg1736.c
@@ -33,7 +33,7 @@
 
 #include <stdlib.h>
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "adg1736.h"
 
 /**
@@ -132,7 +132,7 @@ int adg1736_init(struct adg1736_dev **device,
 	    init_param->gpio_en)
 		return -EINVAL;
 
-	dev = no_os_calloc(1, sizeof(*dev));
+	dev = capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -177,7 +177,7 @@ error_gpio2:
 error_gpio1:
 	no_os_gpio_remove(dev->gpio_in1);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -196,7 +196,7 @@ int adg1736_remove(struct adg1736_dev *dev)
 	no_os_gpio_remove(dev->gpio_in2);
 	if ((dev->type == ADG1736 || dev->type == ADG2736) && dev->gpio_en)
 		no_os_gpio_remove(dev->gpio_en);
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/switch/adg2128/iio_adg2128.c
+++ b/drivers/switch/adg2128/iio_adg2128.c
@@ -8,7 +8,7 @@
 #include "iio.h"
 #include "iio_adg2128.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "iio_adg2128.h"
 
 static int _adg2128_read_register2(void *device,
@@ -55,7 +55,7 @@ static struct iio_device adg2128_iio_device = {
 int32_t adg2128_iio_init(struct adg2128_iio_dev **iio_dev,
 			 struct no_os_i2c_desc *i2c_desc)
 {
-	struct adg2128_iio_dev *desc = (struct adg2128_iio_dev *)no_os_calloc(1,
+	struct adg2128_iio_dev *desc = (struct adg2128_iio_dev *)capi_calloc(1,
 				       sizeof(*desc));
 	if (!desc)
 		return -ENOMEM;
@@ -70,7 +70,7 @@ int32_t adg2128_iio_init(struct adg2128_iio_dev **iio_dev,
 
 int32_t adg2128_iio_remove(struct adg2128_iio_dev *desc)
 {
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/switch/adgm3121/adgm3121.c
+++ b/drivers/switch/adgm3121/adgm3121.c
@@ -33,7 +33,7 @@
 
 #include <stdlib.h>
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 #include "no_os_util.h"
 #include "adgm3121.h"
@@ -441,7 +441,7 @@ int adgm3121_init(struct adgm3121_dev **device,
 	if (!device || !init_param)
 		return -EINVAL;
 
-	dev = no_os_calloc(1, sizeof(*dev));
+	dev = capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -541,7 +541,7 @@ error_gpio1:
 error_pin_spi:
 	no_os_gpio_remove(dev->gpio_pin_spi);
 error_dev:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -578,7 +578,7 @@ int adgm3121_remove(struct adgm3121_dev *dev)
 	if (dev->gpio_pin_spi)
 		no_os_gpio_remove(dev->gpio_pin_spi);
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/switch/adgs6414d/adgs6414d.c
+++ b/drivers/switch/adgs6414d/adgs6414d.c
@@ -35,7 +35,7 @@
 #include <stdlib.h>
 #include "adgs6414d.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_crc8.h"
 
 NO_OS_DECLARE_CRC8_TABLE(adgs6414d_crc8);
@@ -343,7 +343,7 @@ int adgs6414d_init(struct adgs6414d_dev **device,
 
 	no_os_crc8_populate_msb(adgs6414d_crc8, ADGS6414D_CRC8_POLYNOMIAL);
 
-	dev = (struct adgs6414d_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct adgs6414d_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -390,7 +390,7 @@ int adgs6414d_init(struct adgs6414d_dev **device,
 error_config:
 	no_os_spi_remove(dev->spi_desc);
 error_spi:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -406,7 +406,7 @@ int adgs6414d_remove(struct adgs6414d_dev *dev)
 		return -EINVAL;
 
 	no_os_spi_remove(dev->spi_desc);
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/temperature/adt7420/adt7420.c
+++ b/drivers/temperature/adt7420/adt7420.c
@@ -34,7 +34,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 #include "adt7420.h"
 
@@ -205,7 +205,7 @@ int32_t adt7420_init(struct adt7420_dev **device,
 	int32_t status;
 	uint16_t device_connected_check = 0;
 
-	dev = (struct adt7420_dev *)no_os_malloc(sizeof(*dev));
+	dev = (struct adt7420_dev *)capi_malloc(sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -268,7 +268,7 @@ int32_t adt7420_remove(struct adt7420_dev *dev)
 		ret = no_os_i2c_remove(dev->i2c_desc);
 	else
 		ret = no_os_spi_remove(dev->spi_desc);
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/drivers/temperature/adt7420/iio_adt7420.c
+++ b/drivers/temperature/adt7420/iio_adt7420.c
@@ -37,7 +37,7 @@
 #include "no_os_i2c.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "iio_adt7420.h"
 #include "adt7420.h"
 
@@ -126,7 +126,7 @@ int adt7420_iio_init(struct adt7420_iio_dev **iio_dev,
 	int ret;
 	struct adt7420_iio_dev *desc;
 
-	desc = (struct adt7420_iio_dev*)no_os_calloc(1, sizeof(*desc));
+	desc = (struct adt7420_iio_dev*)capi_calloc(1, sizeof(*desc));
 	if (!desc)
 		return -ENOMEM;
 
@@ -145,7 +145,7 @@ int adt7420_iio_init(struct adt7420_iio_dev **iio_dev,
 error_reset:
 	adt7420_remove(desc->adt7420_dev);
 error_init:
-	no_os_free(desc);
+	capi_free(desc);
 	return ret;
 }
 
@@ -164,7 +164,7 @@ int adt7420_iio_remove(struct adt7420_iio_dev *desc)
 	if (ret)
 		return ret;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/temperature/adt75/adt75.c
+++ b/drivers/temperature/adt75/adt75.c
@@ -36,7 +36,7 @@
 #include "no_os_error.h"
 #include "no_os_util.h"
 #include "no_os_units.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /******************************************************************************/
 
@@ -128,7 +128,7 @@ int adt75_init(struct adt75_desc **desc, struct adt75_init_param *init_param)
 	struct adt75_desc *descriptor;
 	int ret;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -141,7 +141,7 @@ int adt75_init(struct adt75_desc **desc, struct adt75_init_param *init_param)
 	return 0;
 
 free_desc:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -162,7 +162,7 @@ int adt75_remove(struct adt75_desc *desc)
 	if (ret)
 		return ret;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/temperature/adt75/iio_adt75.c
+++ b/drivers/temperature/adt75/iio_adt75.c
@@ -36,7 +36,7 @@
 #include "no_os_error.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "iio_adt75.h"
 #include "adt75.h"
 #include "iio.h"
@@ -191,7 +191,7 @@ int adt75_iio_init(struct adt75_iio_desc **desc,
 	struct adt75_iio_desc *descriptor;
 	int ret;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -206,7 +206,7 @@ int adt75_iio_init(struct adt75_iio_desc **desc,
 	return 0;
 
 free_desc:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -224,7 +224,7 @@ int adt75_iio_remove(struct adt75_iio_desc *desc)
 	if (ret)
 		return ret;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/temperature/lm75/iio_lm75.c
+++ b/drivers/temperature/lm75/iio_lm75.c
@@ -32,7 +32,7 @@
  ********************************************************************************/
 #include <errno.h>
 #include "iio_lm75.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_util.h"
 
 static int lm75_ch_attr_show(void *device, char *buf, uint32_t len,
@@ -243,7 +243,7 @@ int iio_lm75_init(struct iio_lm75 **iio_lm75pp,
 	if (!dev)
 		return -EINVAL;
 
-	liio_desc = no_os_calloc(1, sizeof * liio_desc);
+	liio_desc = capi_calloc(1, sizeof * liio_desc);
 	if (!liio_desc)
 		return -ENOMEM;
 
@@ -258,7 +258,7 @@ int iio_lm75_init(struct iio_lm75 **iio_lm75pp,
 	return 0;
 
 err_cleanup:
-	no_os_free(liio_desc);
+	capi_free(liio_desc);
 	return err;
 }
 
@@ -275,7 +275,7 @@ int iio_lm75_remove(struct iio_lm75 *iio_lm75)
 	if (!iio_lm75)
 		return -EINVAL;
 
-	no_os_free(iio_lm75);
+	capi_free(iio_lm75);
 
 	return 0;
 }

--- a/drivers/temperature/lm75/lm75.c
+++ b/drivers/temperature/lm75/lm75.c
@@ -31,7 +31,7 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 #include <errno.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "lm75.h"
 
 static const struct lm75_reg_permissions {
@@ -266,7 +266,7 @@ static int new_lm75(struct lm75_dev **lm75pp,
 	if (!lm75_addr_ok(ip->slave_address))
 		return -EINVAL;
 
-	lm75 = no_os_malloc(sizeof(*lm75));
+	lm75 = capi_malloc(sizeof(*lm75));
 	if (!lm75)
 		return -ENOMEM;
 
@@ -293,7 +293,7 @@ static int new_lm75(struct lm75_dev **lm75pp,
 err_iic_remove:
 	no_os_i2c_remove(iic);
 err_iic_failed:
-	no_os_free(lm75);
+	capi_free(lm75);
 	return err;
 }
 
@@ -314,7 +314,7 @@ static int delete_lm75(struct lm75_dev *lm75)
 	if (lm75->i2c)
 		err = no_os_i2c_remove(lm75->i2c);
 
-	no_os_free(lm75);
+	capi_free(lm75);
 
 	return err;
 }

--- a/drivers/temperature/ltc2983/iio_ltc2983.c
+++ b/drivers/temperature/ltc2983/iio_ltc2983.c
@@ -35,7 +35,7 @@
 #include "iio_ltc2983.h"
 #include "ltc2983.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "iio.h"
 
 #define LTC2983_CHAN(_type, _index) ({ \
@@ -145,7 +145,7 @@ int ltc2983_iio_init(struct ltc2983_iio_desc **iio_dev,
 	if (!init_param || !init_param->ltc2983_desc_init_param)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -175,7 +175,7 @@ int ltc2983_iio_init(struct ltc2983_iio_desc **iio_dev,
 			iio_chan_count++;
 	}
 
-	ltc2983_channels = no_os_calloc(iio_chan_count, sizeof(*ltc2983_channels));
+	ltc2983_channels = capi_calloc(iio_chan_count, sizeof(*ltc2983_channels));
 	if (!ltc2983_channels) {
 		ret = -ENOMEM;
 		goto free_dev;
@@ -213,7 +213,7 @@ int ltc2983_iio_init(struct ltc2983_iio_desc **iio_dev,
 free_dev:
 	ltc2983_remove(descriptor->ltc2983_dev);
 free_desc:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 	return ret;
 }
 
@@ -230,7 +230,7 @@ int ltc2983_iio_remove(struct ltc2983_iio_desc *desc)
 	if (ret)
 		return ret;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/temperature/ltc2983/ltc2983.c
+++ b/drivers/temperature/ltc2983/ltc2983.c
@@ -33,7 +33,7 @@
 
 #include <errno.h>
 #include "ltc2983.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 #include "no_os_print_log.h"
 
@@ -51,7 +51,7 @@ int ltc2983_init(struct ltc2983_desc **device,
 	int ret, i;
 	struct ltc2983_desc *descriptor;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -115,7 +115,7 @@ gpio_err:
 spi_err:
 	no_os_spi_remove(descriptor->comm_desc);
 free_err:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 	return ret;
 }
 
@@ -138,7 +138,7 @@ int ltc2983_remove(struct ltc2983_desc *device)
 	if (ret)
 		return -EINVAL;
 
-	no_os_free(device);
+	capi_free(device);
 
 	return 0;
 }

--- a/drivers/temperature/max31827/iio_max31827.c
+++ b/drivers/temperature/max31827/iio_max31827.c
@@ -34,7 +34,7 @@
 #include <errno.h>
 #include "iio_max31827.h"
 #include "max31827.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 
 #define MAX31827_IIO_CH_ATTR_RW(_name, _priv)  \
@@ -356,13 +356,13 @@ int max31827_iio_init(struct max31827_iio_device **iio_device,
 	if (!iio_init_param || !iio_init_param->init_param)
 		return -EINVAL;
 
-	iio_device_temp = no_os_calloc(1, sizeof(*iio_device_temp));
+	iio_device_temp = capi_calloc(1, sizeof(*iio_device_temp));
 	if (!iio_device_temp)
 		return -ENOMEM;
 
 	ret = max31827_init(&iio_device_temp->dev, iio_init_param->init_param);
 	if (ret) {
-		no_os_free(iio_device_temp);
+		capi_free(iio_device_temp);
 		return ret;
 	}
 
@@ -386,7 +386,7 @@ int max31827_iio_remove(struct max31827_iio_device *iio_device)
 	if (ret)
 		return ret;
 
-	no_os_free(iio_device);
+	capi_free(iio_device);
 
 	return 0;
 }

--- a/drivers/temperature/max31827/max31827.c
+++ b/drivers/temperature/max31827/max31827.c
@@ -32,7 +32,7 @@
 *******************************************************************************/
 
 #include "max31827.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 #include "no_os_error.h"
 #include "no_os_i2c.h"
@@ -150,7 +150,7 @@ int max31827_init(struct max31827_device **dev,
 	struct max31827_device *temp_dev;
 	int ret;
 
-	temp_dev = no_os_calloc(1, sizeof(*temp_dev));
+	temp_dev = capi_calloc(1, sizeof(*temp_dev));
 	if (!temp_dev)
 		return -ENOMEM;
 
@@ -176,7 +176,7 @@ remove_i2c:
 		pr_err("Failed to remove I2C descriptor\r\n");
 
 free_dev:
-	no_os_free(temp_dev);
+	capi_free(temp_dev);
 
 	return ret;
 }
@@ -197,7 +197,7 @@ int max31827_remove(struct max31827_device *dev)
 	if (ret)
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/temperature/max31855/iio_max31855.c
+++ b/drivers/temperature/max31855/iio_max31855.c
@@ -36,7 +36,7 @@
 #include "iio_max31855.h"
 #include "max31855.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "iio.h"
 
 static int max31855_iio_read_raw(void *dev, char *buf, uint32_t len,
@@ -123,7 +123,7 @@ int max31855_iio_init(struct max31855_iio_dev **iio_dev,
 	if (!init_param)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -137,7 +137,7 @@ int max31855_iio_init(struct max31855_iio_dev **iio_dev,
 
 	return 0;
 init_err:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -155,7 +155,7 @@ int max31855_iio_remove(struct max31855_iio_dev *desc)
 	if (ret)
 		return ret;
 
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/drivers/temperature/max31855/max31855.c
+++ b/drivers/temperature/max31855/max31855.c
@@ -37,7 +37,7 @@
 #include "max31855.h"
 #include "no_os_spi.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /******************************************************************************/
 
@@ -53,7 +53,7 @@ int max31855_init(struct max31855_dev **device,
 	int ret;
 	struct max31855_dev *descriptor;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -65,7 +65,7 @@ int max31855_init(struct max31855_dev **device,
 
 	return 0;
 spi_err:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -84,7 +84,7 @@ int max31855_remove(struct max31855_dev *device)
 	if (ret)
 		return -EINVAL;
 
-	no_os_free(device);
+	capi_free(device);
 
 	return 0;
 }

--- a/drivers/temperature/max31865pmb1/max31865.c
+++ b/drivers/temperature/max31865pmb1/max31865.c
@@ -39,7 +39,7 @@
 #include "max31865.h"
 #include "no_os_spi.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 
 /******************************************************************************/
@@ -59,7 +59,7 @@ int max31865_init(struct max31865_dev **device,
 	if (!init_param)
 		return -EINVAL;
 
-	descriptor = (struct max31865_dev *)no_os_calloc(1, sizeof(*descriptor));
+	descriptor = (struct max31865_dev *)capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -81,7 +81,7 @@ int max31865_init(struct max31865_dev **device,
 	return 0;
 
 err:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -102,7 +102,7 @@ int max31865_remove(struct max31865_dev *device)
 	if (ret)
 		return ret;
 
-	no_os_free(device);
+	capi_free(device);
 
 	return 0;
 }

--- a/drivers/temperature/max31875/max31875.c
+++ b/drivers/temperature/max31875/max31875.c
@@ -32,7 +32,7 @@
 *******************************************************************************/
 
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "max31875.h"
 
 /**
@@ -135,7 +135,7 @@ int32_t max31875_init(struct max31875_dev **device,
 	if (!device || !init_param)
 		return -EINVAL;
 
-	dev = no_os_calloc(1, sizeof(*dev));
+	dev = capi_calloc(1, sizeof(*dev));
 	if (!dev)
 		return -ENOMEM;
 
@@ -147,7 +147,7 @@ int32_t max31875_init(struct max31875_dev **device,
 
 	return 0;
 error:
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }
@@ -168,7 +168,7 @@ int32_t max31875_remove(struct max31875_dev *dev)
 	if (NO_OS_IS_ERR_VALUE(ret))
 		return ret;
 
-	no_os_free(dev);
+	capi_free(dev);
 
 	return 0;
 }

--- a/drivers/temperature/max31889/max31889.c
+++ b/drivers/temperature/max31889/max31889.c
@@ -32,7 +32,7 @@
 *******************************************************************************/
 
 #include "max31889.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 #include "no_os_util.h"
 
@@ -131,14 +131,14 @@ int32_t max31889_init(struct max31889_desc **desc,
 	if (!desc || !param)
 		return -EINVAL;
 
-	max31889_desc_tmp = (struct max31889_desc *)no_os_malloc(sizeof(
+	max31889_desc_tmp = (struct max31889_desc *)capi_malloc(sizeof(
 				    *max31889_desc_tmp));
 	if (!max31889_desc_tmp)
 		return -ENOMEM;
 
 	ret = no_os_i2c_init(&max31889_desc_tmp->i2c_desc, param->i2c_ip);
 	if (ret) {
-		no_os_free(max31889_desc_tmp);
+		capi_free(max31889_desc_tmp);
 		return ret;
 	}
 
@@ -153,7 +153,7 @@ int32_t max31889_remove(struct max31889_desc *desc)
 		return -EINVAL;
 	if (desc->i2c_desc)
 		no_os_i2c_remove(desc->i2c_desc);
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/projects/ad-acevsecrdset-sl/src/state_machine/state_machine.c
+++ b/projects/ad-acevsecrdset-sl/src/state_machine/state_machine.c
@@ -34,7 +34,7 @@
 #include "no_os_print_log.h"
 #include "state_machine.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "common_data.h"
 #include "no_os_error.h"
 #include "self_test.h"
@@ -143,31 +143,31 @@ int state_machine()
 #endif
 
 	/* Allocate memory for application structure */
-	stout = (struct stout *)no_os_calloc(1, sizeof(*stout));
+	stout = (struct stout *)capi_calloc(1, sizeof(*stout));
 	if (!stout)
 		return -ENOMEM;
 
 	/* Allocate memory for rms & adc values structure */
-	rms_adc_values = (struct rms_adc_values *)no_os_calloc(1,
+	rms_adc_values = (struct rms_adc_values *)capi_calloc(1,
 			 sizeof(*rms_adc_values));
 	if (!rms_adc_values) {
-		no_os_free(stout);
+		capi_free(stout);
 		return -ENOMEM;
 	}
 
 	/* Initialize I2C adt75*/
 	ret = adt75_init(&adt75_desc, &adt75_ip);
 	if (ret) {
-		no_os_free(stout);
-		no_os_free(rms_adc_values);
+		capi_free(stout);
+		capi_free(rms_adc_values);
 		return ret;
 	}
 
 	/* Initialize LEDs and buttons */
 	ret = interface_init(&stout->gpio_led[0]);
 	if (ret) {
-		no_os_free(stout);
-		no_os_free(rms_adc_values);
+		capi_free(stout);
+		capi_free(rms_adc_values);
 		adt75_remove(adt75_desc);
 		return ret;
 	}

--- a/projects/ad469x_evb/src/examples/iio/iio_example.c
+++ b/projects/ad469x_evb/src/examples/iio/iio_example.c
@@ -36,6 +36,7 @@
 #include "iio_app.h"
 #include "ad469x.h"
 #include "no_os_util.h"
+#include "capi_alloc.h"
 #include "no_os_print_log.h"
 
 /* Data channel mask */
@@ -144,7 +145,7 @@ int example_main()
 	app_init_param.uart_init_params = iio_uart_ip;
 
 	ad469x_iio_channels =
-		no_os_calloc(1, num_channels * sizeof(*ad469x_iio_channels));
+		capi_calloc(1, num_channels * sizeof(*ad469x_iio_channels));
 	if (!ad469x_iio_channels)
 		return -ENOMEM;
 
@@ -177,7 +178,7 @@ int example_main()
 
 	iio_app_remove(app);
 err:
-	no_os_free(ad469x_iio_channels);
+	capi_free(ad469x_iio_channels);
 err_remove:
 	ad469x_remove(dev);
 

--- a/projects/ad5766-sdz/src/ad5766_core.c
+++ b/projects/ad5766-sdz/src/ad5766_core.c
@@ -37,7 +37,7 @@
 #include "spi_engine_private.h"
 #include <xil_io.h>
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "ad5766_core.h"
 
 const uint16_t sine_lut[512] = {
@@ -167,7 +167,7 @@ int32_t ad5766_core_setup(struct spi_engine_desc *eng_desc,
 	uint32_t	sync_id = 0;
 	uint8_t		size = 3;
 
-	core = (ad5766_core *)no_os_malloc(sizeof(*core));
+	core = (ad5766_core *)capi_malloc(sizeof(*core));
 	if (!core)
 		return -1;
 
@@ -179,7 +179,7 @@ int32_t ad5766_core_setup(struct spi_engine_desc *eng_desc,
 
 	rate_reg = ref_clk_hz / core->rate_hz;
 	if (rate_reg > 0xFFFF) {
-		no_os_free(core);
+		capi_free(core);
 		return -1;
 	}
 

--- a/projects/ad9083/src/app_ad9083.c
+++ b/projects/ad9083/src/app_ad9083.c
@@ -43,7 +43,7 @@
 #include "no_os_util.h"
 #include "no_os_delay.h"
 #include "no_os_print_log.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Check sysref is submultiple of lmfc.
@@ -179,14 +179,14 @@ int32_t app_ad9083_init(struct app_ad9083 **app,
 		.jesd_rx_clk_desc = init_param->jesd_rx_clk_desc,
 	};
 
-	app_ad9083 = (struct app_ad9083 *)no_os_calloc(1, sizeof(*app_ad9083));
+	app_ad9083 = (struct app_ad9083 *)capi_calloc(1, sizeof(*app_ad9083));
 	if (!app_ad9083)
 		return -1;
 
 	status = ad9083_init(&app_ad9083->ad9083_phy, &ad9083_init_param);
 	if (status != 0) {
 		pr_err("error: %"PRId32" ad9083_initialize() \n", status);
-		no_os_free(app_ad9083);
+		capi_free(app_ad9083);
 
 		return -1;
 	}
@@ -206,7 +206,7 @@ int32_t app_ad9083_remove(struct app_ad9083 *app)
 	if (!app)
 		return -1;
 
-	no_os_free(app);
+	capi_free(app);
 
 	return 0;
 }

--- a/projects/ad9083/src/app_clocking.c
+++ b/projects/ad9083/src/app_clocking.c
@@ -44,7 +44,7 @@
 #include "no_os_print_log.h"
 #include "parameters.h"
 #include "uc_settings.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 #define FPGA_SYSREF_CLK	0
 #define FPGA_GLBL_CLK	1
@@ -74,7 +74,7 @@ int32_t app_clocking_init(struct app_clocking **app,
 	struct ad9528_init_param ad9528_param;
 	struct ad9528_platform_data ad9528_pdata;
 
-	app_clocking = (struct app_clocking *)no_os_calloc(1, sizeof(*app_clocking));
+	app_clocking = (struct app_clocking *)capi_calloc(1, sizeof(*app_clocking));
 	if (!app_clocking)
 		return -1;
 
@@ -233,7 +233,7 @@ int32_t app_clocking_init(struct app_clocking **app,
 error_1:
 	ad9528_remove(app_clocking->clkchip_device);
 error_0:
-	no_os_free(app_clocking);
+	capi_free(app_clocking);
 
 	return -1;
 }
@@ -254,7 +254,7 @@ int32_t app_clocking_remove(struct app_clocking *app)
 	if (ret < 0)
 		return ret;
 
-	no_os_free(app);
+	capi_free(app);
 
 	return 0;
 }

--- a/projects/ad9083/src/app_jesd.c
+++ b/projects/ad9083/src/app_jesd.c
@@ -42,7 +42,7 @@
 #include "no_os_print_log.h"
 #include "parameters.h"
 #include "uc_settings.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 /**
  * @brief Application JESD setup.
@@ -59,7 +59,7 @@ int32_t app_jesd_init(struct app_jesd **app, struct app_jesd_init *init_param)
 	adi_cms_jesd_param_t *jtx_param = &uc_settings->jtx_param[init_param->uc];
 	uint64_t *clk_hz = uc_settings->clk_hz[init_param->uc];
 
-	app_jesd = (struct app_jesd *)no_os_calloc(1, sizeof(*app_jesd));
+	app_jesd = (struct app_jesd *)capi_calloc(1, sizeof(*app_jesd));
 	if (!app_jesd)
 		return -1;
 
@@ -113,7 +113,7 @@ int32_t app_jesd_init(struct app_jesd **app, struct app_jesd_init *init_param)
 error_1:
 	axi_jesd204_rx_remove(app_jesd->rx_jesd);
 error_0:
-	no_os_free(app_jesd);
+	capi_free(app_jesd);
 
 	return -1;
 }
@@ -143,7 +143,7 @@ int32_t app_jesd_remove(struct app_jesd *app)
 	if (ret < 0)
 		return ret;
 
-	no_os_free(app);
+	capi_free(app);
 
 	return 0;
 }

--- a/projects/adin1320/src/examples/cmd/cmd.c
+++ b/projects/adin1320/src/examples/cmd/cmd.c
@@ -38,7 +38,7 @@
 #include "adin1320.h"
 #include "common_data.h"
 #include "mdio_spi.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 #include "no_os_gpio.h"
 #include "no_os_mdio.h"
@@ -253,7 +253,7 @@ int board_init(struct no_os_uart_desc **uart_desc,
 
 	no_os_uart_stdio(*uart_desc);
 
-	struct cmd_gpio *temp_cmd_gpio = (struct cmd_gpio *) no_os_calloc(1,
+	struct cmd_gpio *temp_cmd_gpio = (struct cmd_gpio *) capi_calloc(1,
 					 sizeof(*temp_cmd_gpio));
 	if (!temp_cmd_gpio) {
 		ret = -ENOMEM;
@@ -430,7 +430,7 @@ remove_cfg1:
 remove_cfg0:
 	no_os_gpio_remove(temp_cmd_gpio->gpio_uc_cfg0_desc);
 remove_calloc:
-	no_os_free(temp_cmd_gpio);
+	capi_free(temp_cmd_gpio);
 remove_uart:
 	no_os_uart_remove(*uart_desc);
 	return ret;
@@ -580,7 +580,7 @@ err_board:
 	no_os_gpio_remove(cmd_gpio->gpio_uc_cfg2_desc);
 	no_os_gpio_remove(cmd_gpio->gpio_uc_cfg1_desc);
 	no_os_gpio_remove(cmd_gpio->gpio_uc_cfg0_desc);
-	no_os_free(cmd_gpio);
+	capi_free(cmd_gpio);
 	no_os_uart_remove(uart_desc);
 	return ret;
 }

--- a/projects/admt4000/src/common/iio_admt_evb.c
+++ b/projects/admt4000/src/common/iio_admt_evb.c
@@ -36,7 +36,7 @@
 #include <string.h>
 #include "no_os_gpio.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 #include "iio.h"
 #include "iio_admt_evb.h"
@@ -83,7 +83,7 @@ int admt_evb_iio_init(struct admt_evb_iio_desc **iio_desc,
 	if (!init_param)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 
@@ -130,7 +130,7 @@ v_en_out_err:
 v_en_err:
 	no_os_gpio_remove(descriptor->gpio_shdn_n_desc);
 err:
-	no_os_free(descriptor);
+	capi_free(descriptor);
 
 	return ret;
 }
@@ -145,7 +145,7 @@ int admt_evb_iio_remove(struct admt_evb_iio_desc *desc)
 {
 	no_os_gpio_remove(desc->gpio_v_en_desc);
 	no_os_gpio_remove(desc->gpio_shdn_n_desc);
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/projects/adrv902x/src/common/hal/no_os_platform.c
+++ b/projects/adrv902x/src/common/hal/no_os_platform.c
@@ -17,7 +17,7 @@
 #include "no_os_delay.h"
 #include "common_data.h"
 #include "ADRV9025_FW.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "parameters.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
@@ -701,19 +701,19 @@ long int ftell(FILE *stream)
 
 FILE* __fopen(const char * filename, const char *mode)
 {
-	FILE *stream = no_os_calloc(1, sizeof(*stream));
+	FILE *stream = capi_calloc(1, sizeof(*stream));
 	unsigned int length;
 	char *temp;
 
 	if (!strcmp(filename, "ActiveUseCase.profile")) {
-		temp = (char *)no_os_malloc((strlen(json_profile_active_use_case) + 1) * sizeof(
+		temp = (char *)capi_malloc((strlen(json_profile_active_use_case) + 1) * sizeof(
 						    char));
 		strcpy(temp, json_profile_active_use_case);
 		profile.data = temp;
 		profile.start = profile.ptr = profile.data;
 		profile.end = profile.start + strlen(profile.data);
 	} else if (!strcmp(filename, "ActiveUtilInit.profile")) {
-		temp = (char *)no_os_malloc((strlen(json_profile_active_util_init) + 1) *
+		temp = (char *)capi_malloc((strlen(json_profile_active_util_init) + 1) *
 					    sizeof(
 						    char));
 		strcpy(temp, json_profile_active_util_init);
@@ -723,41 +723,41 @@ FILE* __fopen(const char * filename, const char *mode)
 	} else if (!strcmp(filename,
 			   ADRV9025_STREAM_IMAGE_FILE)) {
 		length = sizeof(stream_image_bin);
-		temp = (unsigned char *)no_os_calloc(length, sizeof(unsigned char));
+		temp = (unsigned char *)capi_calloc(length, sizeof(unsigned char));
 		memcpy(temp, stream_image_bin, length);
 		profile.data = temp;
 		profile.start = profile.ptr = profile.data;
 		profile.end = profile.start + length;
 	} else if (!strcmp(filename, "ADRV9025_FW.bin")) {
 		length = sizeof(ADRV9025_FW_bin);
-		temp = (unsigned char *)no_os_calloc(length, sizeof(unsigned char));
+		temp = (unsigned char *)capi_calloc(length, sizeof(unsigned char));
 		memcpy(temp, ADRV9025_FW_bin, sizeof(ADRV9025_FW_bin));
 		profile.data = temp;
 		profile.start = profile.ptr = profile.data;
 		profile.end = profile.start + length;
 	} else if (!strcmp(filename, "ADRV9025_DPDCORE_FW.bin")) {
 		length = sizeof(ADRV9025_DPDCORE_FW_bin);
-		temp = (unsigned char *)no_os_calloc(length, sizeof(unsigned char));
+		temp = (unsigned char *)capi_calloc(length, sizeof(unsigned char));
 		memcpy(temp, ADRV9025_DPDCORE_FW_bin, sizeof(ADRV9025_DPDCORE_FW_bin));
 		profile.data = temp;
 		profile.start = profile.ptr = profile.data;
 		profile.end = profile.start + length;
 	} else if (!strcmp(filename, "ADRV9025_RxGainTable.h")) {
 		length = strlen(ADRV9025_RxGainTable_text);
-		temp = (unsigned char *)no_os_calloc(length, sizeof(unsigned char));
+		temp = (unsigned char *)capi_calloc(length, sizeof(unsigned char));
 		strcpy(temp, ADRV9025_RxGainTable_text);
 		profile.data = temp;
 		profile.start = profile.ptr = profile.data;
 		profile.end = profile.start + strlen(profile.data);
 	} else if (!strcmp(filename, "ADRV9025_TxAttenTable.h")) {
 		length = strlen(ADRV9025_TxAttenTable_text);
-		temp = (unsigned char *)no_os_calloc(length, sizeof(unsigned char));
+		temp = (unsigned char *)capi_calloc(length, sizeof(unsigned char));
 		strcpy(temp, ADRV9025_TxAttenTable_text);
 		profile.data = temp;
 		profile.start = profile.ptr = profile.data;
 		profile.end = profile.start + strlen(profile.data);
 	} else {
-		no_os_free(stream);
+		capi_free(stream);
 	}
 
 	return stream;
@@ -795,7 +795,7 @@ int __fclose(FILE *stream)
 		return -ENODEV;
 
 	memset(&profile, 0, sizeof(profile));
-	no_os_free(stream);
+	capi_free(stream);
 
 	return 0;
 }

--- a/projects/adrv903x/src/common/hal/no_os_platform.c
+++ b/projects/adrv903x/src/common/hal/no_os_platform.c
@@ -19,7 +19,7 @@
 #include "no_os_mutex.h"
 #include "no_os_delay.h"
 #include "common_data.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "parameters.h"
 #include "app_config.h"
 #include "no_os_gpio.h"
@@ -542,7 +542,7 @@ FILE *fopen(const char *filename, const char *mode)
 	if (!filename)
 		return NULL;
 
-	p = no_os_calloc(1, sizeof(*p));
+	p = capi_calloc(1, sizeof(*p));
 	if (!p)
 		return NULL;
 
@@ -569,7 +569,7 @@ FILE *fopen(const char *filename, const char *mode)
 	} else {
 		pr_warning("ADRV903X HAL: fopen(\"%s\") - unknown file\n",
 			   filename);
-		no_os_free(p);
+		capi_free(p);
 		return NULL;
 	}
 
@@ -609,7 +609,7 @@ int __wrap_fclose(FILE *stream)
 {
 	if (!stream)
 		return -ENODEV;
-	no_os_free(stream);
+	capi_free(stream);
 	return 0;
 }
 

--- a/projects/adrv904x/src/common/hal/no_os_platform.c
+++ b/projects/adrv904x/src/common/hal/no_os_platform.c
@@ -17,7 +17,7 @@
 #include "no_os_mutex.h"
 #include "no_os_delay.h"
 #include "common_data.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "parameters.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
@@ -800,7 +800,7 @@ long int ftell(FILE *stream)
 
 FILE* fopen(const char * filename, const char *mode)
 {
-	FILE *stream = no_os_calloc(1, sizeof(*stream));
+	FILE *stream = capi_calloc(1, sizeof(*stream));
 	unsigned int length;
 	char *temp;
 
@@ -809,9 +809,9 @@ FILE* fopen(const char * filename, const char *mode)
 
 	if (!strcmp(filename, "DeviceProfileTest.bin")) {
 		length = sizeof(DeviceProfileTest_bin);
-		temp = (char *)no_os_calloc(length, sizeof(char));
+		temp = (char *)capi_calloc(length, sizeof(char));
 		if (!temp) {
-			no_os_free(stream);
+			capi_free(stream);
 			return NULL;
 		}
 		memcpy(temp, DeviceProfileTest_bin, length);
@@ -820,9 +820,9 @@ FILE* fopen(const char * filename, const char *mode)
 		profile.end = profile.start + length;
 	} else if (!strcmp(filename, "stream_image.bin")) {
 		length = sizeof(stream_image_bin);
-		temp = (char *)no_os_calloc(length, sizeof(char));
+		temp = (char *)capi_calloc(length, sizeof(char));
 		if (!temp) {
-			no_os_free(stream);
+			capi_free(stream);
 			return NULL;
 		}
 		memcpy(temp, stream_image_bin, length);
@@ -831,9 +831,9 @@ FILE* fopen(const char * filename, const char *mode)
 		profile.end = profile.start + length;
 	} else if (!strcmp(filename, "ADRV9040_FW.bin")) {
 		length = sizeof(ADRV9040_FW_bin);
-		temp = (char *)no_os_calloc(length, sizeof(char));
+		temp = (char *)capi_calloc(length, sizeof(char));
 		if (!temp) {
-			no_os_free(stream);
+			capi_free(stream);
 			return NULL;
 		}
 		memcpy(temp, ADRV9040_FW_bin, sizeof(ADRV9040_FW_bin));
@@ -842,9 +842,9 @@ FILE* fopen(const char * filename, const char *mode)
 		profile.end = profile.start + length;
 	} else if (!strcmp(filename, "ADRV9040_DFE_CALS_FW.bin")) {
 		length = sizeof(ADRV9040_DFE_CALS_FW_bin);
-		temp = (char *)no_os_calloc(length, sizeof(char));
+		temp = (char *)capi_calloc(length, sizeof(char));
 		if (!temp) {
-			no_os_free(stream);
+			capi_free(stream);
 			return NULL;
 		}
 		memcpy(temp, ADRV9040_DFE_CALS_FW_bin, sizeof(ADRV9040_DFE_CALS_FW_bin));
@@ -853,9 +853,9 @@ FILE* fopen(const char * filename, const char *mode)
 		profile.end = profile.start + length;
 	} else if (!strcmp(filename, "RxGainTable.csv")) {
 		length = strlen(ADRV9040_RxGainTable_text);
-		temp = (char *)no_os_calloc(length, sizeof(char));
+		temp = (char *)capi_calloc(length, sizeof(char));
 		if (!temp) {
-			no_os_free(stream);
+			capi_free(stream);
 			return NULL;
 		}
 		strcpy(temp, ADRV9040_RxGainTable_text);
@@ -863,7 +863,7 @@ FILE* fopen(const char * filename, const char *mode)
 		profile.start = profile.ptr = profile.data;
 		profile.end = profile.start + strlen(profile.data);
 	} else {
-		no_os_free(stream);
+		capi_free(stream);
 		stream = NULL;
 	}
 
@@ -903,7 +903,7 @@ int __wrap_fclose(FILE *stream)
 		return -ENODEV;
 
 	memset(&profile, 0, sizeof(profile));
-	no_os_free(stream);
+	capi_free(stream);
 
 	return 0;
 }

--- a/projects/adv7511/src/wrapper.c
+++ b/projects/adv7511/src/wrapper.c
@@ -9,7 +9,7 @@
 #include "no_os_i2c.h"
 #include "tx_lib.h"
 #include "tx_isr.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 
 CONSTANT UINT16 VicInfo[NUM_OF_VICS * 4] = {
 	/* H     V     I   Hz */
@@ -253,7 +253,7 @@ UINT32 ATV_I2CReadField32(UCHAR DevAddr, UCHAR RegAddr, UCHAR MsbMask,
 	uint32_t value = 0;
 	int8_t i;
 
-	read_data = no_os_calloc(FldSpan, sizeof * read_data);
+	read_data = capi_calloc(FldSpan, sizeof * read_data);
 	if (!read_data)
 		return 0xDEADDEAD;
 
@@ -269,11 +269,11 @@ UINT32 ATV_I2CReadField32(UCHAR DevAddr, UCHAR RegAddr, UCHAR MsbMask,
 		value |= (read_data[i] << (j++ * 8 - LsbPos));
 	}
 
-	no_os_free(read_data);
+	capi_free(read_data);
 
 	return value;
 error:
-	no_os_free(read_data);
+	capi_free(read_data);
 
 	return 0xDEADDEAD;
 }
@@ -308,7 +308,7 @@ UINT32 ATV_I2CReadField32LE(UCHAR DevAddr, UCHAR RegAddr, UCHAR MsbMask,
 	uint8_t *read_data, i;
 	uint32_t value = 0;
 
-	read_data = no_os_calloc(FldSpan, sizeof * read_data);
+	read_data = capi_calloc(FldSpan, sizeof * read_data);
 	if (!read_data)
 		return 0xDEADDEAD;
 
@@ -324,11 +324,11 @@ UINT32 ATV_I2CReadField32LE(UCHAR DevAddr, UCHAR RegAddr, UCHAR MsbMask,
 		value |= read_data[i] << (i * 8 - LsbPos);
 	}
 
-	no_os_free(read_data);
+	capi_free(read_data);
 
 	return value;
 error:
-	no_os_free(read_data);
+	capi_free(read_data);
 
 	return 0xDEADDEAD;
 }
@@ -360,7 +360,7 @@ void ATV_I2CWriteField32(UCHAR DevAddr, UCHAR RegAddr, UCHAR MsbMask,
 	uint8_t *read_data, j = 1;
 	int8_t i;
 
-	read_data = no_os_calloc(FldSpan, sizeof * read_data);
+	read_data = capi_calloc(FldSpan, sizeof * read_data);
 	if (!read_data)
 		return;
 
@@ -383,7 +383,7 @@ void ATV_I2CWriteField32(UCHAR DevAddr, UCHAR RegAddr, UCHAR MsbMask,
 
 	HAL_I2CWriteBlock(DevAddr, RegAddr, read_data, FldSpan);
 error:
-	no_os_free(read_data);
+	capi_free(read_data);
 }
 
 /*===========================================================================
@@ -456,7 +456,7 @@ void ATV_I2CWriteField32LE(UCHAR DevAddr, UCHAR RegAddr, UCHAR MsbMask,
 	uint8_t *read_data, j = 0;
 	int8_t i;
 
-	read_data = no_os_calloc(FldSpan, sizeof * read_data);
+	read_data = capi_calloc(FldSpan, sizeof * read_data);
 	if (!read_data)
 		return;
 
@@ -479,7 +479,7 @@ void ATV_I2CWriteField32LE(UCHAR DevAddr, UCHAR RegAddr, UCHAR MsbMask,
 
 	HAL_I2CWriteBlock(DevAddr, RegAddr, read_data, FldSpan);
 error:
-	no_os_free(read_data);
+	capi_free(read_data);
 }
 
 /*===========================================================================
@@ -627,7 +627,7 @@ UINT16  HAL_I2CWriteBlock(UCHAR Dev, UCHAR Reg, UCHAR *Data,
 
 	i2c_handler->slave_address = i2c_addr;
 
-	data_write = no_os_calloc((NumberBytes + 1), sizeof * data_write);
+	data_write = capi_calloc((NumberBytes + 1), sizeof * data_write);
 	if (!data_write)
 		return 0xDEAD;
 
@@ -639,11 +639,11 @@ UINT16  HAL_I2CWriteBlock(UCHAR Dev, UCHAR Reg, UCHAR *Data,
 	if (ret != 0)
 		goto error;
 
-	no_os_free(data_write);
+	capi_free(data_write);
 
 	return 0;
 error:
-	no_os_free(data_write);
+	capi_free(data_write);
 
 	return 0xDEAD;
 }

--- a/projects/eval-ade7753/src/main.c
+++ b/projects/eval-ade7753/src/main.c
@@ -32,6 +32,7 @@
 *******************************************************************************/
 #include <stdio.h>
 #include "no_os_uart.h"
+#include "capi_alloc.h"
 #include "no_os_pwm.h"
 #include "no_os_delay.h"
 #include "no_os_gpio.h"
@@ -134,7 +135,7 @@ int main(void)
 	pr_info("ADE7753 SPI example \n");
 
 	/* Init ade7753 struct */
-	ade7753_dev = (struct ade7753_dev *)no_os_calloc(1, sizeof(*ade7753_dev));
+	ade7753_dev = (struct ade7753_dev *)capi_calloc(1, sizeof(*ade7753_dev));
 	if (!ade7753_dev)
 		return -ENOMEM;
 
@@ -196,7 +197,7 @@ int main(void)
 	}
 
 free_dev:
-	no_os_free(ade7753_dev);
+	capi_free(ade7753_dev);
 remove_reset:
 	no_os_gpio_remove(reset_desc);
 remove_led:

--- a/projects/eval-ade7754/src/main.c
+++ b/projects/eval-ade7754/src/main.c
@@ -32,6 +32,7 @@
 *******************************************************************************/
 #include <stdio.h>
 #include "no_os_uart.h"
+#include "capi_alloc.h"
 #include "no_os_pwm.h"
 #include "no_os_delay.h"
 #include "no_os_gpio.h"
@@ -137,7 +138,7 @@ int main(void)
 	pr_info("ADE7754 SPI example \n");
 
 	/* Init ade7754 struct */
-	ade7754_dev = (struct ade7754_dev *)no_os_calloc(1, sizeof(*ade7754_dev));
+	ade7754_dev = (struct ade7754_dev *)capi_calloc(1, sizeof(*ade7754_dev));
 	if (!ade7754_dev)
 		return -ENOMEM;
 
@@ -203,7 +204,7 @@ int main(void)
 	}
 
 free_dev:
-	no_os_free(ade7754_dev);
+	capi_free(ade7754_dev);
 remove_reset:
 	no_os_gpio_remove(reset_desc);
 remove_led:

--- a/projects/eval-ade7758/src/main.c
+++ b/projects/eval-ade7758/src/main.c
@@ -32,6 +32,7 @@
 *******************************************************************************/
 #include <stdio.h>
 #include "no_os_uart.h"
+#include "capi_alloc.h"
 #include "no_os_pwm.h"
 #include "no_os_delay.h"
 #include "no_os_gpio.h"
@@ -119,7 +120,7 @@ int main(void)
 	pr_info("ADE7758 SPI example \n");
 
 	/* Init ade7758 struct */
-	ade7758_dev = (struct ade7758_dev *)no_os_calloc(1, sizeof(*ade7758_dev));
+	ade7758_dev = (struct ade7758_dev *)capi_calloc(1, sizeof(*ade7758_dev));
 	if (!ade7758_dev)
 		return -ENOMEM;
 
@@ -185,7 +186,7 @@ int main(void)
 	}
 
 free_dev:
-	no_os_free(ade7758_dev);
+	capi_free(ade7758_dev);
 remove_led:
 	no_os_gpio_remove(gpio_desc);
 remove_uart:

--- a/projects/eval-ade7880/src/main.c
+++ b/projects/eval-ade7880/src/main.c
@@ -40,7 +40,7 @@
 #include "no_os_units.h"
 #include "no_os_util.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "maxim_uart.h"
 #include "maxim_gpio.h"
 #include "maxim_uart_stdio.h"
@@ -139,7 +139,7 @@ int main(void)
 	pr_info("ADE7880 SPI example \n");
 
 	/* Init ade7880 struct */
-	ade7880_dev = (struct ade7880_dev *)no_os_calloc(1, sizeof(*ade7880_dev));
+	ade7880_dev = (struct ade7880_dev *)capi_calloc(1, sizeof(*ade7880_dev));
 	if (!ade7880_dev)
 		return -ENOMEM;
 
@@ -173,7 +173,7 @@ int main(void)
 	}
 
 free_dev:
-	no_os_free(ade7880_dev);
+	capi_free(ade7880_dev);
 remove_reset:
 	no_os_gpio_remove(gpio_reset_desc);
 remove_psm1:

--- a/projects/eval-ade7913/src/main.c
+++ b/projects/eval-ade7913/src/main.c
@@ -39,7 +39,7 @@
 #include "no_os_print_log.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "maxim_uart.h"
 #include "maxim_gpio.h"
@@ -126,19 +126,19 @@ int main(void)
 	}
 
 	// allocate memory depending on the number of devices
-	i_rms = (int32_t *)no_os_calloc(ade7913_ip.no_devs,
+	i_rms = (int32_t *)capi_calloc(ade7913_ip.no_devs,
 					sizeof(i_rms));
 	if (!i_rms) {
 		ret = -ENOMEM;
 		goto remove_led;
 	}
-	v1_rms = (int32_t *)no_os_calloc(ade7913_ip.no_devs,
+	v1_rms = (int32_t *)capi_calloc(ade7913_ip.no_devs,
 					 sizeof(v1_rms));
 	if (!v1_rms) {
 		ret = -ENOMEM;
 		goto remove_led;
 	}
-	v2_rms = (int32_t *)no_os_calloc(ade7913_ip.no_devs,
+	v2_rms = (int32_t *)capi_calloc(ade7913_ip.no_devs,
 					 sizeof(v2_rms));
 	if (!v2_rms) {
 		ret = -ENOMEM;
@@ -149,19 +149,19 @@ int main(void)
 	rms_values.v1_rms = v1_rms;
 	rms_values.v2_rms = v2_rms;
 
-	i_rms_adc = (int32_t *)no_os_calloc(ade7913_ip.no_devs,
+	i_rms_adc = (int32_t *)capi_calloc(ade7913_ip.no_devs,
 					    sizeof(i_rms_adc));
 	if (!i_rms_adc) {
 		ret = -ENOMEM;
 		goto remove_led;
 	}
-	v1_rms_adc = (int32_t *)no_os_calloc(ade7913_ip.no_devs,
+	v1_rms_adc = (int32_t *)capi_calloc(ade7913_ip.no_devs,
 					     sizeof(v1_rms_adc));
 	if (!v1_rms_adc) {
 		ret = -ENOMEM;
 		goto remove_led;
 	}
-	v2_rms_adc = (int32_t *)no_os_calloc(ade7913_ip.no_devs,
+	v2_rms_adc = (int32_t *)capi_calloc(ade7913_ip.no_devs,
 					     sizeof(v2_rms_adc));
 	if (!v2_rms_adc) {
 		ret = -ENOMEM;
@@ -181,7 +181,7 @@ int main(void)
 
 	/* Init ade7913 struct */
 	ade7913_dev = (struct ade7913_dev *)
-		      no_os_calloc(1, sizeof(*ade7913_dev));
+		      capi_calloc(1, sizeof(*ade7913_dev));
 	if (!ade7913_dev) {
 		ret = -ENOMEM;
 		goto remove_led;
@@ -340,7 +340,7 @@ int main(void)
 	}
 
 free_dev:
-	no_os_free(ade7913_dev);
+	capi_free(ade7913_dev);
 remove_led:
 	no_os_gpio_remove(gpio_desc);
 remove_uart:

--- a/projects/eval-ade7953/src/main.c
+++ b/projects/eval-ade7953/src/main.c
@@ -32,6 +32,7 @@
 *******************************************************************************/
 #include <stdio.h>
 #include "no_os_uart.h"
+#include "capi_alloc.h"
 #include "no_os_pwm.h"
 #include "no_os_delay.h"
 #include "no_os_gpio.h"
@@ -135,7 +136,7 @@ int main(void)
 	pr_info("ADE7953 SPI example \n");
 
 	/* Init ade7953 struct */
-	ade7953_dev = (struct ade7953_dev *)no_os_calloc(1, sizeof(*ade7953_dev));
+	ade7953_dev = (struct ade7953_dev *)capi_calloc(1, sizeof(*ade7953_dev));
 	if (!ade7953_dev)
 		return -ENOMEM;
 
@@ -193,7 +194,7 @@ int main(void)
 	}
 
 free_dev:
-	no_os_free(ade7953_dev);
+	capi_free(ade7953_dev);
 remove_reset:
 	no_os_gpio_remove(reset_desc);
 remove_led:

--- a/projects/eval-ade7978/src/main.c
+++ b/projects/eval-ade7978/src/main.c
@@ -40,7 +40,7 @@
 #include "no_os_units.h"
 #include "no_os_util.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_init.h"
 #include "maxim_uart.h"
 #include "maxim_gpio.h"
@@ -143,12 +143,12 @@ int main(void)
 	pr_info("ADE7978 SPI example \n\n");
 
 	/* Init ade7978 struct */
-	ade7978_dev = (struct ade7978_dev *)no_os_calloc(1, sizeof(*ade7978_dev));
+	ade7978_dev = (struct ade7978_dev *)capi_calloc(1, sizeof(*ade7978_dev));
 	if (!ade7978_dev)
 		return -ENOMEM;
 
 	/* Init measurements struct */
-	vals = (struct measurements *)no_os_calloc(1, sizeof(*vals));
+	vals = (struct measurements *)capi_calloc(1, sizeof(*vals));
 	if (!vals) {
 		ret = -ENOMEM;
 		goto free_dev;
@@ -216,9 +216,9 @@ int main(void)
 	}
 
 free_dev2:
-	no_os_free(vals);
+	capi_free(vals);
 free_dev:
-	no_os_free(ade7978_dev);
+	capi_free(ade7978_dev);
 remove_reset:
 	no_os_gpio_remove(gpio_reset_desc);
 remove_led:

--- a/projects/eval-ade9000/src/main.c
+++ b/projects/eval-ade9000/src/main.c
@@ -40,7 +40,7 @@
 #include "no_os_units.h"
 #include "no_os_util.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "maxim_uart.h"
 #include "maxim_gpio.h"
 #include "maxim_uart_stdio.h"
@@ -90,7 +90,7 @@ int main(void)
 	pr_info("ADE9000 SPI example \n");
 
 	/* Init ade9000 struct */
-	ade9000_dev = (struct ade9000_dev *)no_os_calloc(1, sizeof(*ade9000_dev));
+	ade9000_dev = (struct ade9000_dev *)capi_calloc(1, sizeof(*ade9000_dev));
 	if (!ade9000_dev)
 		return -ENOMEM;
 
@@ -129,7 +129,7 @@ int main(void)
 	}
 
 free_dev:
-	no_os_free(ade9000_dev);
+	capi_free(ade9000_dev);
 remove_led:
 	no_os_gpio_remove(gpio_desc);
 remove_uart:

--- a/projects/eval-ade9078/src/main.c
+++ b/projects/eval-ade9078/src/main.c
@@ -39,7 +39,7 @@
 #include "no_os_print_log.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "maxim_uart.h"
 #include "maxim_gpio.h"
@@ -139,7 +139,7 @@ int main(void)
 	uint8_t val;
 
 	/* Init ade9078 struct */
-	ade9078_dev = (struct ade9078_dev *)no_os_calloc(1, sizeof(*ade9078_dev));
+	ade9078_dev = (struct ade9078_dev *)capi_calloc(1, sizeof(*ade9078_dev));
 	if (!ade9078_dev)
 		return -ENOMEM;
 
@@ -173,7 +173,7 @@ int main(void)
 	}
 
 free_dev:
-	no_os_free(ade9078_dev);
+	capi_free(ade9078_dev);
 remove_reset:
 	no_os_gpio_remove(reset_desc);
 remove_psm1:

--- a/projects/eval-ade9153a/src/main.c
+++ b/projects/eval-ade9153a/src/main.c
@@ -32,6 +32,7 @@
 *******************************************************************************/
 #include <stdio.h>
 #include "no_os_uart.h"
+#include "capi_alloc.h"
 #include "no_os_pwm.h"
 #include "no_os_delay.h"
 #include "no_os_gpio.h"
@@ -164,7 +165,7 @@ int main(void)
 	pr_info("ADE9153A SPI example \n");
 
 	/* Init ade9153a struct */
-	ade9153a_dev = (struct ade9153a_dev *)no_os_calloc(1, sizeof(*ade9153a_dev));
+	ade9153a_dev = (struct ade9153a_dev *)capi_calloc(1, sizeof(*ade9153a_dev));
 	if (!ade9153a_dev)
 		return -ENOMEM;
 
@@ -208,7 +209,7 @@ int main(void)
 	}
 
 free_dev:
-	no_os_free(ade9153a_dev);
+	capi_free(ade9153a_dev);
 remove_reset:
 	no_os_gpio_remove(reset_desc);
 remove_sck:

--- a/projects/eval-ade9430/src/common/common_data.h
+++ b/projects/eval-ade9430/src/common/common_data.h
@@ -42,7 +42,7 @@
 #include "no_os_units.h"
 #include "no_os_util.h"
 #include "no_os_error.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "maxim_uart.h"
 #include "maxim_uart_stdio.h"
 #include "maxim_gpio.h"

--- a/projects/eval-adhv4710/src/main.c
+++ b/projects/eval-adhv4710/src/main.c
@@ -32,6 +32,7 @@
 *******************************************************************************/
 #include <stdio.h>
 #include "no_os_uart.h"
+#include "capi_alloc.h"
 #include "no_os_delay.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
@@ -116,7 +117,7 @@ int main(void)
 	pr_info("ADHV4710 SPI example \n");
 
 	/* Init adhv4710 struct */
-	adhv4710_dev = (struct adhv4710_dev *)no_os_calloc(1, sizeof(*adhv4710_dev));
+	adhv4710_dev = (struct adhv4710_dev *)capi_calloc(1, sizeof(*adhv4710_dev));
 	if (!adhv4710_dev)
 		return -ENOMEM;
 
@@ -263,7 +264,7 @@ int main(void)
 	}
 
 free_dev:
-	no_os_free(adhv4710_dev);
+	capi_free(adhv4710_dev);
 remove_reset:
 	no_os_gpio_remove(reset_desc);
 remove_led:

--- a/projects/eval-cn0391-ardz/src/common/cn0391.c
+++ b/projects/eval-cn0391-ardz/src/common/cn0391.c
@@ -35,7 +35,7 @@
 #include "cn0391.h"
 #include "no_os_thermocouple.h"
 #include "no_os_rtd.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_print_log.h"
 
@@ -92,7 +92,7 @@ int cn0391_init(struct cn0391_dev **dev,
 	struct cn0391_dev *d;
 	int ret;
 
-	d = (struct cn0391_dev *)no_os_calloc(1, sizeof(*d));
+	d = (struct cn0391_dev *)capi_calloc(1, sizeof(*d));
 	if (!d)
 		return -ENOMEM;
 
@@ -129,7 +129,7 @@ int cn0391_init(struct cn0391_dev **dev,
 error_ad7124:
 	ad7124_remove(d->ad7124_dev);
 error_free:
-	no_os_free(d);
+	capi_free(d);
 
 	return ret;
 }
@@ -142,7 +142,7 @@ int cn0391_remove(struct cn0391_dev *dev)
 		return -EINVAL;
 
 	ret = ad7124_remove(dev->ad7124_dev);
-	no_os_free(dev);
+	capi_free(dev);
 
 	return ret;
 }

--- a/projects/eval-pqmon/src/examples/basic/basic_example.c
+++ b/projects/eval-pqmon/src/examples/basic/basic_example.c
@@ -33,12 +33,13 @@
 
 #ifdef BASIC_EXAMPLE
 #include "basic_example.h"
+#include "capi_alloc.h"
 #endif
 
 int32_t pqm_init(struct pqm_desc **desc, struct pqm_init_para *param)
 {
 	struct pqm_desc *d;
-	d = (struct pqm_desc *)no_os_calloc(1, sizeof(*d));
+	d = (struct pqm_desc *)capi_calloc(1, sizeof(*d));
 
 	if (!d)
 		return -ENOMEM;
@@ -62,7 +63,7 @@ int32_t pqm_remove(struct pqm_desc *desc)
 {
 	if (!desc)
 		return -EINVAL;
-	no_os_free(desc);
+	capi_free(desc);
 
 	return 0;
 }

--- a/projects/fmcdaq2/src/app/fmcdaq2.c
+++ b/projects/fmcdaq2/src/app/fmcdaq2.c
@@ -70,7 +70,7 @@
 #endif
 
 #include "no_os_print_log.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "jesd204.h"
 #include "jesd204_clk.h"
 
@@ -1177,7 +1177,7 @@ static int fmcdaq2_setup(struct fmcdaq2_dev *dev,
 	dev->ad9144_device->link_config.sysref.mode = JESD204_SYSREF_ONESHOT;
 	dev->ad9144_device->link_config.sysref.lmfc_offset = 0;
 
-	dev->ad9144_device->link_config.lane_ids = no_os_calloc(
+	dev->ad9144_device->link_config.lane_ids = capi_calloc(
 				dev->ad9144_device->link_config.num_lanes, sizeof(uint8_t));
 	if (!dev->ad9144_device->link_config.lane_ids)
 		return -ENOMEM;

--- a/projects/ltc2378/src/examples/iio/iio_example.c
+++ b/projects/ltc2378/src/examples/iio/iio_example.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_units.h"
 #include "no_os_util.h"

--- a/projects/swiot1l/src/common/swiot.c
+++ b/projects/swiot1l/src/common/swiot.c
@@ -40,7 +40,7 @@
 #include "swiot.h"
 #include "no_os_gpio.h"
 #include "no_os_delay.h"
-#include "no_os_alloc.h"
+#include "capi_alloc.h"
 #include "iio_ad74413r.h"
 #include "iio_max14906.h"
 #include "flc.h"
@@ -648,7 +648,7 @@ int swiot_iio_init(struct swiot_iio_desc **swiot_desc,
 	if (!init_param)
 		return -EINVAL;
 
-	descriptor = no_os_calloc(1, sizeof(*descriptor));
+	descriptor = capi_calloc(1, sizeof(*descriptor));
 	if (!descriptor)
 		return -ENOMEM;
 


### PR DESCRIPTION
## Pull Request Description
Tree wide replacement of no_os_alloc with capi_alloc
For now, for platforms that don't have their drivers ported to CAPI , the build will fail.
This should maybe be merged once CAPI compatibility is ensured across all platforms supported by no-os

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
