### PR TITLE
Feature/sdgsw 1296 use capi time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,8 +328,8 @@ add_custom_command(
 include(${KCONFIG_VARS_FILE})
 
 # add capi dir into `no-os` before projects are added
-# capi_alloc_add_link_guard() is defined when a project's
-# post_build_config() calls it.
+# capi_alloc_add_link_guard() / capi_time_add_link_guard() are defined when a
+# project's post_build_config() calls them.
 add_subdirectory(capi)
 
 if(NATIVE_BUILD)

--- a/capi/CMakeLists.txt
+++ b/capi/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2026 Analog Devices, Inc.
 #
-# Generic wiring for capi_alloc
+# Generic wiring for capi_alloc and capi_time
 # Will become generic wiring for entire CAPI
 
 # 1. Header path (always on -- harmless where capi is unused).
@@ -54,4 +54,45 @@ function(capi_alloc_add_link_guard _target)
                 -P ${CAPI_ALLOC_GUARD_SCRIPT}
         VERBATIM
         COMMENT "capi_alloc: verifying strong allocation backend for ${_target}")
+endfunction()
+
+# --- capi_time (mirrors the capi_alloc wiring above) ---------------------------
+
+# Generic wrapper (always compiled).
+target_sources(no-os PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/capi_time.c)
+
+# Platform backend, only if this PLATFORM provides one.
+set(_capi_time_backend
+    ${CMAKE_CURRENT_SOURCE_DIR}/platform/${PLATFORM}/${PLATFORM}_capi_time.c)
+if(EXISTS "${_capi_time_backend}")
+    target_sources(no-os PRIVATE ${_capi_time_backend})
+    message(STATUS "capi_time: using ${PLATFORM} backend")
+else()
+    message(STATUS "capi_time: no ${PLATFORM} backend -- weak no-op defaults "
+                   "in effect (a link guard fails any project that uses capi_time)")
+endif()
+
+# Reuse the toolchain 'nm' already resolved for capi_alloc above.
+set(CAPI_TIME_NM "${_capi_nm}" CACHE INTERNAL "nm used by the capi_time link guard")
+set(CAPI_TIME_GUARD_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/capi_time_guard.cmake"
+    CACHE INTERNAL "path to the capi_time post-link guard script")
+
+# Attach the post-link weak-symbol guard to an executable target. Safe to call
+# on every project: it passes silently unless capi_wait_us_impl / capi_uptime_impl
+# is referenced but resolves to the weak no-op default (no strong backend linked).
+function(capi_time_add_link_guard _target)
+    if(NOT CAPI_TIME_NM)
+        message(WARNING "capi_time: no 'nm' found; skipping weak-symbol link "
+                        "guard for ${_target} (time backend not verified)")
+        return()
+    endif()
+    add_custom_command(
+        TARGET ${_target} POST_BUILD
+        COMMAND ${CMAKE_COMMAND}
+                -DELF=$<TARGET_FILE:${_target}>
+                -DNM=${CAPI_TIME_NM}
+                -DPLATFORM=${PLATFORM}
+                -P ${CAPI_TIME_GUARD_SCRIPT}
+        VERBATIM
+        COMMENT "capi_time: verifying strong time backend for ${_target}")
 endfunction()

--- a/capi/capi_time_guard.cmake
+++ b/capi/capi_time_guard.cmake
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026 Analog Devices, Inc.
+#
+# Post-link guard for the capi_time time/delay backend.
+#
+# Run as a POST_BUILD step on a final executable:
+#   cmake -DELF=<file> -DNM=<nm> -DPLATFORM=<plat> -P capi_time_guard.cmake
+#
+# It fails the build if a capi_time hook that has no usable weak default is
+# present in the linked executable as a WEAK symbol. Because the whole capi
+# time suite is compiled with -ffunction-sections and linked with
+# --gc-sections, a capi_*_impl symbol survives into the ELF only when it is
+# actually referenced (i.e. some code calls capi_wait_us/capi_wait_ms/
+# capi_uptime). If such a reference resolves to the weak default from
+# capi/src/capi_time.c instead of a strong platform backend, delays become
+# no-ops and capi_uptime returns -ENOSYS at runtime. This turns that silent
+# runtime failure into a loud build failure.
+#
+# Note: capi_wait_ms_impl is intentionally NOT guarded. Its weak default
+# legitimately delegates to capi_wait_us_impl, so a platform that provides only
+# the microsecond backend is still correct -- guarding capi_wait_ms_impl would
+# wrongly fail such a platform.
+#
+# Symbols that are never used are removed by the linker and never reach this
+# check, so projects that do not use capi_time are unaffected.
+# This is a temporary guard. Eventually all platform will have their drivers
+# ported to CAPI. This will become redundant.
+
+if(NOT EXISTS "${ELF}")
+    message(FATAL_ERROR "capi_time guard: executable not found: ${ELF}")
+endif()
+
+execute_process(
+    COMMAND "${NM}" "${ELF}"
+    OUTPUT_VARIABLE _nm_out
+    RESULT_VARIABLE _nm_rc
+    ERROR_VARIABLE  _nm_err
+)
+if(NOT _nm_rc EQUAL 0)
+    message(FATAL_ERROR "capi_time guard: '${NM} ${ELF}' failed: ${_nm_err}")
+endif()
+
+set(_impls capi_wait_us_impl capi_uptime_impl)
+set(_weak "")
+
+# nm line for a defined symbol: "<hexvalue> <type> <name>"
+# nm line for an undefined symbol: "<spaces> <type> <name>"
+# Weak types: V/W (defined weak), v/w (undefined weak). Any of these for a
+# capi_*_impl means no strong backend won the link.
+string(REPLACE "\n" ";" _lines "${_nm_out}")
+foreach(_line IN LISTS _lines)
+    if(_line MATCHES "^[0-9a-fA-F]* +([VWvw]) +([A-Za-z0-9_]+)$")
+        set(_type "${CMAKE_MATCH_1}")
+        set(_name "${CMAKE_MATCH_2}")
+        list(FIND _impls "${_name}" _idx)
+        if(NOT _idx EQUAL -1)
+            list(APPEND _weak "${_name} (weak '${_type}')")
+        endif()
+    endif()
+endforeach()
+
+if(_weak)
+    string(REPLACE ";" "\n    " _weak_str "${_weak}")
+    message(FATAL_ERROR
+        "capi_time: the following time hooks resolved to the WEAK "
+        "no-op default in\n  ${ELF}:\n    ${_weak_str}\n\n"
+        "capi_wait_us/capi_wait_ms/capi_uptime are used, but no strong platform "
+        "backend was linked for PLATFORM=${PLATFORM}, so delays would be no-ops "
+        "and capi_uptime would return -ENOSYS at runtime.\n"
+        "Provide capi/platform/${PLATFORM}/${PLATFORM}_capi_time.c (defining "
+        "capi_wait_us_impl and capi_uptime_impl, and optionally "
+        "capi_wait_ms_impl), or do not use capi_time on this platform yet.")
+endif()

--- a/cmake/project_utils.cmake
+++ b/cmake/project_utils.cmake
@@ -58,6 +58,12 @@ function(post_build_config PROJECT_TARGET)
                 capi_alloc_add_link_guard(${PROJECT_TARGET})
         endif()
 
+        # Same for capi_time: fail if delays/uptime resolve to the weak no-op
+        # default (no strong backend). Passes silently if capi_time is unused.
+        if(COMMAND capi_time_add_link_guard)
+                capi_time_add_link_guard(${PROJECT_TARGET})
+        endif()
+
         # IDE project file generation (replaces cmake -P vscode_config.cmake
         # and generate_stm32cubeide_project calls)
         ide_generate(${PROJECT_TARGET})

--- a/drivers/accel/adxl313/adxl313.c
+++ b/drivers/accel/adxl313/adxl313.c
@@ -37,7 +37,7 @@
 #include "adxl313.h"
 #include "no_os_print_log.h"
 #include "no_os_util.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 
 static int64_t adxl313_accel_conv(struct adxl313_dev *dev, int16_t raw_accel);
@@ -904,7 +904,7 @@ int adxl313_get_raw_fifo_data(struct adxl313_dev *dev, uint8_t *entries,
 				return ret;
 
 			//wait 5us
-			no_os_udelay(5);
+			capi_wait_us(5);
 		}
 
 		for (uint8_t idx = 0; idx < (*entries); idx++) {
@@ -2167,7 +2167,7 @@ int adxl313_self_test(struct adxl313_dev *dev)
 		return ret;
 
 	/* Output settling time, min 4 samples. 10ms per sample at 100Hz. */
-	no_os_mdelay(50);
+	capi_wait_ms(50);
 
 	/* 4. Read and store the 10 samples in the FIFO. */
 	ret = adxl313_get_raw_fifo_data(dev, &fifo_entries, x, y, z);
@@ -2200,7 +2200,7 @@ int adxl313_self_test(struct adxl313_dev *dev)
 		return ret;
 
 	/* Output settling time, min 4 samples. 10ms per sample at 100Hz. */
-	no_os_mdelay(50);
+	capi_wait_ms(50);
 
 	/* 6. Read and store samples in the FIFO. */
 	ret = adxl313_get_raw_fifo_data(dev, &fifo_entries, x, y, z);

--- a/drivers/accel/adxl355/adxl355.c
+++ b/drivers/accel/adxl355/adxl355.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include "adxl355.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 
 static uint8_t shadow_reg_val[5] = {0, 0, 0, 0, 0};
@@ -314,7 +314,7 @@ int adxl355_soft_reset(struct adxl355_dev *dev)
 		return -EAGAIN;
 
 	// Delay is needed between soft reset command and shadow registers reading
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	// Read the shadow registers
 	ret = adxl355_read_device_data(dev,

--- a/drivers/accel/adxl367/adxl367.c
+++ b/drivers/accel/adxl367/adxl367.c
@@ -33,7 +33,7 @@
 
 #include <stdlib.h>
 #include "adxl367.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
 #include "capi_alloc.h"
@@ -194,7 +194,7 @@ int adxl367_self_test(struct adxl367_dev *dev)
 	if (ret)
 		return ret;
 	// 4 / ODR delay
-	no_os_mdelay(st_delay_ms);
+	capi_wait_ms(st_delay_ms);
 	ret = adxl367_get_register_value(dev, &read_val, ADXL367_REG_XDATA_H, 1);
 	if (ret)
 		return ret;
@@ -212,7 +212,7 @@ int adxl367_self_test(struct adxl367_dev *dev)
 	if (ret)
 		return ret;
 	// 4 / ODR delay
-	no_os_mdelay(st_delay_ms);
+	capi_wait_ms(st_delay_ms);
 	ret = adxl367_get_register_value(dev, &read_val, ADXL367_REG_XDATA_H, 1);
 	if (ret)
 		return ret;
@@ -419,7 +419,7 @@ int adxl367_software_reset(struct adxl367_dev *dev)
 	dev->z_offset = 0;
 
 	//initialization delay
-	no_os_mdelay(20);
+	capi_wait_ms(20);
 
 	return 0;
 }
@@ -448,7 +448,7 @@ int adxl367_set_power_mode(struct adxl367_dev *dev,
 
 	//100 ms wait time before reading acceleration data.
 	if (mode == ADXL367_OP_MEASURE)
-		no_os_mdelay(100);
+		capi_wait_ms(100);
 
 	dev->op_mode = mode;
 

--- a/drivers/accel/adxl372/adxl372.c
+++ b/drivers/accel/adxl372/adxl372.c
@@ -38,6 +38,7 @@
 #include "adxl372.h"
 #include "capi_alloc.h"
 #include "no_os_error.h"
+#include "capi_time.h"
 
 /**
  * Wrapper used to read device registers.
@@ -456,7 +457,7 @@ int32_t adxl372_reset(struct adxl372_dev *dev)
 	if (ret < 0)
 		return ret;
 
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	return ret;
 }
@@ -829,12 +830,12 @@ int32_t adxl372_init(struct adxl372_dev **device,
 
 	*device = dev;
 	printf("adxl372 successfully initialized\n");
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 	return ret;
 
 error:
 	printf("adxl372 initialization error (%d)\n", ret);
 	capi_free(dev);
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 	return ret;
 }

--- a/drivers/accel/adxl372/adxl372.h
+++ b/drivers/accel/adxl372/adxl372.h
@@ -36,7 +36,7 @@
 
 #include <stdint.h>
 #include "no_os_util.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_i2c.h"
 #include "no_os_spi.h"

--- a/drivers/accel/adxl38x/adxl38x.c
+++ b/drivers/accel/adxl38x/adxl38x.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include "adxl38x.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 #include "no_os_util.h"
 
@@ -280,7 +280,7 @@ int adxl38x_soft_reset(struct adxl38x_dev *dev)
 		return ret;
 	// Delay is needed between soft reset and initialization (From SOFT_RESET
 	// bit description in REG_RESET)
-	no_os_udelay(500);
+	capi_wait_us(500);
 	ret = adxl38x_read_device_data(dev, ADXL38X_DEVID_AD, 1, &reg_value);
 	if (reg_value != 0xAD)
 		return -EAGAIN;
@@ -306,7 +306,7 @@ int adxl38x_set_op_mode(struct adxl38x_dev *dev, enum adxl38x_op_mode op_mode)
 	if (!ret)
 		dev->op_mode = op_mode;
 	// 2ms wait for op_mode to settle (See Operating Modes section of datasheet)
-	no_os_mdelay(2);
+	capi_wait_ms(2);
 
 	return ret;
 }
@@ -806,7 +806,7 @@ int adxl38x_selftest(struct adxl38x_dev *dev, enum adxl38x_op_mode op_mode,
 
 	/* Measure output on all three axes for at least 25 samples and compute average*/
 	for (int k = 0; k < 25; k++) {
-		no_os_mdelay(10);
+		capi_wait_ms(10);
 		ret = adxl38x_read_device_data(dev, ADXL38X_XDATA_H, 6, array_raw_data);
 
 		x_sum += (int64_t)(no_os_get_unaligned_be16(array_raw_data));
@@ -827,7 +827,7 @@ int adxl38x_selftest(struct adxl38x_dev *dev, enum adxl38x_op_mode op_mode,
 	y_sum = 0;
 	z_sum = 0;
 	for (int k = 0; k < 25; k++) {
-		no_os_mdelay(10);
+		capi_wait_ms(10);
 		ret = adxl38x_read_device_data(dev, ADXL38X_XDATA_H, 6, array_raw_data);
 
 		x_sum += (int64_t)(no_os_get_unaligned_be16(array_raw_data));

--- a/drivers/adc-dac/ad5592r/ad5592r-base.c
+++ b/drivers/adc-dac/ad5592r/ad5592r-base.c
@@ -33,6 +33,7 @@
 *******************************************************************************/
 #include "no_os_error.h"
 #include "ad5592r-base.h"
+#include "capi_time.h"
 
 /**
  * Write register.
@@ -190,7 +191,7 @@ int32_t ad5592r_software_reset(struct ad5592r_dev *dev)
 	/* Writing this magic value resets the device */
 	ret = ad5592r_base_reg_write(dev, AD5592R_REG_RESET, 0xdac);
 
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 
 	return ret;
 }

--- a/drivers/adc-dac/ad5592r/ad5592r-base.h
+++ b/drivers/adc-dac/ad5592r/ad5592r-base.h
@@ -35,7 +35,7 @@
 #define AD5592R_BASE_H_
 
 #include "stdint.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_spi.h"
 #include "no_os_i2c.h"
 #include "no_os_gpio.h"

--- a/drivers/adc-dac/ad5592r/ad5592r.c
+++ b/drivers/adc-dac/ad5592r/ad5592r.c
@@ -35,6 +35,7 @@
 #include "capi_alloc.h"
 #include "ad5592r-base.h"
 #include "ad5592r.h"
+#include "capi_time.h"
 
 const struct ad5592r_rw_ops ad5592r_rw_ops = {
 	.write_dac = ad5592r_write_dac,
@@ -163,7 +164,7 @@ int32_t ad5592r_read_adc(struct ad5592r_dev *dev, uint8_t chan,
 		track_time = AD5592R_TEMPERATURE_TRACK_TIME_UNBUFFERED;
 		if (dev->adc_buf)
 			track_time = AD5592R_TEMPERATURE_TRACK_TIME_BUFFERED;
-		no_os_udelay(track_time);
+		capi_wait_us(track_time);
 	}
 
 	/*

--- a/drivers/adc-dac/ad74413r/ad74413r.c
+++ b/drivers/adc-dac/ad74413r/ad74413r.c
@@ -33,7 +33,7 @@
 
 #include "ad74413r.h"
 #include "no_os_crc8.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
 #include "capi_alloc.h"
@@ -379,7 +379,7 @@ int ad74413r_reset(struct ad74413r_desc *desc)
 			return ret;
 
 		/* Minimum RESET signal pulse duration */
-		no_os_udelay(50);
+		capi_wait_us(50);
 		ret = no_os_gpio_set_value(desc->reset_gpio, NO_OS_GPIO_HIGH);
 		if (ret)
 			return ret;
@@ -394,7 +394,7 @@ int ad74413r_reset(struct ad74413r_desc *desc)
 	}
 
 	/* Time taken for device reset (datasheet value = 1ms) */
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	return 0;
 }
@@ -421,7 +421,7 @@ int ad74413r_set_channel_function(struct ad74413r_desc *desc,
 		return ret;
 
 	/* Each function should be selected for at least 130 us. */
-	no_os_udelay(130);
+	capi_wait_us(130);
 	ret = ad74413r_reg_update(desc, AD74413R_CH_FUNC_SETUP(ch),
 				  AD74413R_CH_FUNC_SETUP_MASK, ch_func);
 	if (ret)
@@ -433,7 +433,7 @@ int ad74413r_set_channel_function(struct ad74413r_desc *desc,
 		return ret;
 
 	/* No writes to the DACx registers may be done for 150 us after changing function */
-	no_os_udelay(150);
+	capi_wait_us(150);
 
 	desc->channel_configs[ch].function = ch_func;
 
@@ -677,7 +677,7 @@ int ad74413r_set_adc_conv_seq(struct ad74413r_desc *desc,
 	 * The write to CONV_SEQ powers up the ADC. If the ADC was powered down, the user must wait
 	 * for 100us before the ADC starts doing conversions.
 	 */
-	no_os_udelay(100);
+	capi_wait_us(100);
 
 	return 0;
 }
@@ -732,9 +732,9 @@ int ad74413r_get_adc_single(struct ad74413r_desc *desc, uint32_t ch,
 
 	/** Wait for all channels to complete the conversion. */
 	if (delay < 1000)
-		no_os_udelay(delay * nb_active_channels);
+		capi_wait_us(delay * nb_active_channels);
 	else
-		no_os_mdelay((delay * nb_active_channels) / 1000);
+		capi_wait_ms((delay * nb_active_channels) / 1000);
 
 	if (is_diag)
 		ret = ad74413r_get_diag(desc, ch, val);

--- a/drivers/adc-dac/ad74416h/ad74416h.c
+++ b/drivers/adc-dac/ad74416h/ad74416h.c
@@ -33,7 +33,7 @@
 
 #include "ad74416h.h"
 #include "no_os_crc8.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
 #include "capi_alloc.h"
@@ -473,7 +473,7 @@ int ad74416h_set_adc_conv_seq(struct ad74416h_desc *desc,
 	 * If the ADC was powered down, wait for 100us before the ADC starts
 	 * doing conversions.
 	 */
-	no_os_udelay(100);
+	capi_wait_us(100);
 
 	return 0;
 }
@@ -514,7 +514,7 @@ int ad74416h_get_adc_single(struct ad74416h_desc *desc, uint32_t ch,
 
 	delay = AD74116H_CONV_TIME_US / conv_rate_ad74416h[rate];
 
-	no_os_udelay(delay * nb_active_channels);
+	capi_wait_us(delay * nb_active_channels);
 
 	ret = ad74416h_get_raw_adc_result(desc, ch, val);
 	if (ret)
@@ -589,7 +589,7 @@ int ad74416h_set_channel_function(struct ad74416h_desc *desc,
 		return ret;
 
 	/* Datasheet delay required before transition to new desired mode */
-	no_os_udelay(200);
+	capi_wait_us(200);
 
 	ret = ad74416h_reg_update(desc, AD74416H_CH_FUNC_SETUP(ch),
 				  AD74416H_CH_FUNC_SETUP_MSK, ch_func);
@@ -599,7 +599,7 @@ int ad74416h_set_channel_function(struct ad74416h_desc *desc,
 	desc->channel_configs[ch].function = ch_func;
 
 	/* Datasheet delay required before updating the new DAC code */
-	no_os_udelay(200);
+	capi_wait_us(200);
 
 	return 0;
 }
@@ -918,7 +918,7 @@ int ad74416h_reset(struct ad74416h_desc *desc)
 			return ret;
 
 		/* Minimum RESET signal pulse duration */
-		no_os_udelay(50);
+		capi_wait_us(50);
 		ret = no_os_gpio_set_value(desc->reset_gpio, NO_OS_GPIO_HIGH);
 		if (ret)
 			return ret;
@@ -932,7 +932,7 @@ int ad74416h_reset(struct ad74416h_desc *desc)
 			return ret;
 	}
 	/* Time taken for device reset (datasheet value = 1ms) */
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	return 0;
 }

--- a/drivers/adc/ad405x/ad405x.c
+++ b/drivers/adc/ad405x/ad405x.c
@@ -37,7 +37,7 @@
 #include <errno.h>
 #include <string.h>
 #include "ad405x.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 
 static const uint8_t reset_pattern_buff[18] = {
@@ -242,7 +242,7 @@ int ad405x_soft_reset(struct ad405x_dev *dev)
 			}
 		} else {
 			/* Wait at least Tswreset time - 500us */
-			no_os_mdelay(5);
+			capi_wait_ms(5);
 		}
 	} else {
 		/* Perform soft reset */
@@ -1068,7 +1068,7 @@ int ad405x_trigger_adc_conv(struct ad405x_dev *dev)
 		return ret;
 
 	/* CNV High Time 10 ns. */
-	no_os_udelay(1);
+	capi_wait_us(1);
 
 	ret = no_os_gpio_set_value(dev->extra.spi_extra.gpio_cnv,
 				   NO_OS_GPIO_LOW);
@@ -1076,7 +1076,7 @@ int ad405x_trigger_adc_conv(struct ad405x_dev *dev)
 		return ret;
 
 	/* Conversion Time (CNV Rising Edge to Data Ready) 250ns. */
-	no_os_udelay(1);
+	capi_wait_us(1);
 
 	return ret;
 }

--- a/drivers/adc/ad4080/ad4080.c
+++ b/drivers/adc/ad4080/ad4080.c
@@ -36,7 +36,7 @@
 #include <assert.h>
 #include <errno.h>
 #include "ad4080.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 /******************************************************************************/
 

--- a/drivers/adc/ad4170/ad4170.c
+++ b/drivers/adc/ad4170/ad4170.c
@@ -37,7 +37,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_crc8.h"
 #include "ad4170.h"
 
@@ -984,7 +984,7 @@ int ad4170_reset(struct ad4170_dev *dev)
 		return ret;
 
 	/* Turn-on settling time */
-	no_os_udelay(200);
+	capi_wait_us(200);
 
 	// Reset the driver representation of the chip to a default state
 	// that matches the chip configuration right after reset.
@@ -1785,7 +1785,7 @@ int ad4170_init(struct ad4170_dev **device,
 	if (ret)
 		goto error;
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	ret = ad4170_reset(dev);
 	if (ret)

--- a/drivers/adc/ad463x/ad463x.c
+++ b/drivers/adc/ad463x/ad463x.c
@@ -35,7 +35,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_units.h"
 #include "ad463x.h"
 #include "no_os_print_log.h"
@@ -372,12 +372,12 @@ static int32_t ad463x_init_gpio(struct ad463x_dev *dev,
 	if (ret != 0)
 		goto error_gpio_reset;
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 	ret = no_os_gpio_set_value(dev->gpio_resetn, NO_OS_GPIO_HIGH);
 	if (ret != 0)
 		goto error_gpio_reset;
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	ret = no_os_gpio_get_optional(&dev->gpio_cnv, init_param->gpio_cnv);
 	if (ret != 0)

--- a/drivers/adc/ad4692/ad4692.c
+++ b/drivers/adc/ad4692/ad4692.c
@@ -35,7 +35,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "ad4692.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
 #include "capi_alloc.h"
@@ -438,7 +438,7 @@ int ad4692_get_ch(struct ad4692_desc *desc, uint8_t ch, uint32_t *val)
 	if (ret)
 		return ret;
 
-	no_os_udelay(AD4692_MAX_CONV_PERIOD_US);
+	capi_wait_us(AD4692_MAX_CONV_PERIOD_US);
 
 	ret = ad4692_sampling_enable(desc, false);
 	if (ret)
@@ -575,13 +575,13 @@ int ad4692_hardware_reset(struct ad4692_desc *desc)
 	if (ret)
 		return ret;
 
-	no_os_udelay(1);
+	capi_wait_us(1);
 
 	ret = no_os_gpio_set_value(desc->reset_desc, NO_OS_GPIO_HIGH);
 	if (ret)
 		return ret;
 
-	no_os_udelay(300);
+	capi_wait_us(300);
 
 	/* Clearing STATUS Register. */
 	ret = ad4692_reg_read(desc, AD4692_STATUS_REG, &reg_val);
@@ -600,7 +600,7 @@ int ad4692_software_reset(struct ad4692_desc *desc)
 	if (ret)
 		return ret;
 
-	no_os_udelay(300);
+	capi_wait_us(300);
 
 	return 0;
 }

--- a/drivers/adc/ad4692/iio_ad4692.c
+++ b/drivers/adc/ad4692/iio_ad4692.c
@@ -37,7 +37,7 @@
 #include "no_os_error.h"
 #include "no_os_units.h"
 #include "no_os_util.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 #include "ad4692.h"
 #include "iio_ad4692.h"
@@ -726,7 +726,7 @@ static int ad4692_iio_submit_buffer(struct iio_device_data *iio_dev_data)
 
 		while (sample_idx < buffer->samples) {
 			/* Wait for all channels to be sampled */
-			no_os_udelay(delay_us);
+			capi_wait_us(delay_us);
 
 			ad4692_sampling_enable(ad4692, false);
 

--- a/drivers/adc/ad469x/ad469x.c
+++ b/drivers/adc/ad469x/ad469x.c
@@ -38,7 +38,7 @@
 #if !defined(USE_STANDARD_SPI)
 #include "spi_engine.h"
 #endif
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
 #include "capi_alloc.h"
@@ -842,13 +842,13 @@ int32_t ad469x_reset_dev(struct ad469x_dev *dev)
 	if (ret != 0)
 		return ret;
 
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 
 	ret = no_os_gpio_set_value(dev->gpio_resetn, NO_OS_GPIO_HIGH);
 	if (ret != 0)
 		return ret;
 
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 
 	ret = ad469x_spi_reg_read(dev, AD469x_REG_STATUS, &reset_status);
 	if (ret != 0)

--- a/drivers/adc/ad4858/ad4858.c
+++ b/drivers/adc/ad4858/ad4858.c
@@ -33,7 +33,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include "ad4858.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 
 /**
@@ -845,7 +845,7 @@ int ad4858_soft_reset(struct ad4858_dev *dev)
 		return ret;
 
 	/* Reset delay */
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 
 	return 0;
 }

--- a/drivers/adc/ad6676/ad6676.c
+++ b/drivers/adc/ad6676/ad6676.c
@@ -37,6 +37,7 @@
 #include "ad6676.h"
 #include "capi_alloc.h"
 #include "no_os_error.h"
+#include "capi_time.h"
 
 /***************************************************************************//**
  * @brief SPI read from device.
@@ -391,7 +392,7 @@ static int32_t ad6676_set_clk_synth(struct ad6676_dev *dev,
 
 	tout = 4;
 	do {
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 		ad6676_spi_read(dev, AD6676_CLKSYN_STATUS, (uint8_t *)&reg_val);
 	} while (--tout && (reg_val & SYN_STAT_VCO_CAL_BUSY));
 
@@ -406,7 +407,7 @@ static int32_t ad6676_set_clk_synth(struct ad6676_dev *dev,
 
 	tout = 4;
 	do {
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 		ad6676_spi_read(dev, AD6676_CLKSYN_STATUS, (uint8_t *)&reg_val);
 		reg_val &= SYN_STAT_PLL_LCK | SYN_STAT_VCO_CAL_BUSY |
 			   SYN_STAT_CP_CAL_DONE;
@@ -534,7 +535,7 @@ static int32_t ad6676_calibrate(struct ad6676_dev *dev,
 		tout_i = 2;
 
 		do {
-			no_os_mdelay(250);
+			capi_wait_ms(250);
 			ad6676_spi_read(dev, AD6676_CAL_DONE, (uint8_t *)&done);
 			done &= CAL_DONE;
 		} while (tout_i-- && !done);
@@ -572,7 +573,7 @@ static int32_t ad6676_reset(struct ad6676_dev *dev,
 	ret = ad6676_spi_write(dev, AD6676_SPI_CONFIG,
 			       SPI_CONF_SW_RESET |
 			       (spi3wire ? 0 : SPI_CONF_SDIO_DIR));
-	no_os_mdelay(2);
+	capi_wait_ms(2);
 
 	return ret;
 }

--- a/drivers/adc/ad6676/ad6676.h
+++ b/drivers/adc/ad6676/ad6676.h
@@ -36,7 +36,7 @@
 
 #include <stdint.h>
 #include "no_os_util.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_spi.h"
 
 #define AD6676_SPI_CONFIG		0x000

--- a/drivers/adc/ad7091r5/ad7091r5.c
+++ b/drivers/adc/ad7091r5/ad7091r5.c
@@ -36,7 +36,7 @@
 #include <errno.h>
 #include "stdlib.h"
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_util.h"
 #include "capi_alloc.h"
 
@@ -145,7 +145,7 @@ int32_t ad7091r5_i2c_write_mask(struct ad7091r5_dev *dev,
 	reg_data |= data;
 
 	/* Allow time for register modification to take effect before write */
-	no_os_udelay(100);
+	capi_wait_us(100);
 
 	return ad7091r5_i2c_reg_write(dev, reg_addr, reg_data);
 }
@@ -447,7 +447,7 @@ int32_t ad7091r5_reset(struct ad7091r5_dev *dev, bool is_software)
 			return ret;
 
 		/* Reset pulse width extended to ensure proper device reset */
-		no_os_udelay(100);
+		capi_wait_us(100);
 		return no_os_gpio_set_value(dev->gpio_resetn, NO_OS_GPIO_HIGH);
 	}
 }
@@ -503,7 +503,7 @@ int32_t ad7091r5_read_one(struct ad7091r5_dev *dev,
 		return ret;
 
 	/* Wait for channel switch and conversion to complete before reading result */
-	no_os_udelay(100);
+	capi_wait_us(100);
 
 	ret = ad7091r5_i2c_reg_read(dev, AD7091R5_REG_RESULT, &val);
 	if (ret)

--- a/drivers/adc/ad7091r8/ad7091r8.c
+++ b/drivers/adc/ad7091r8/ad7091r8.c
@@ -38,7 +38,7 @@
 #include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 /**
  * Pull the CONVST line up then down to signal to the start of a read/write
@@ -360,7 +360,7 @@ int ad7091r8_reset(struct ad7091r8_dev *dev, bool is_software)
 	if (ret)
 		return ret;
 
-	no_os_udelay(1);
+	capi_wait_us(1);
 	return no_os_gpio_set_value(dev->gpio_reset, NO_OS_GPIO_HIGH);
 }
 

--- a/drivers/adc/ad7124/ad7124.c
+++ b/drivers/adc/ad7124/ad7124.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include "ad7124.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 #include "no_os_error.h"
 
@@ -272,7 +272,7 @@ int32_t ad7124_reset(struct ad7124_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(AD7124_POST_RESET_DELAY);
+	capi_wait_ms(AD7124_POST_RESET_DELAY);
 
 	return 0;
 }

--- a/drivers/adc/ad7124/ad7124.h
+++ b/drivers/adc/ad7124/ad7124.h
@@ -36,7 +36,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include "no_os_spi.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_util.h"
 
 #define	AD7124_RW 1   /* Read and Write */

--- a/drivers/adc/ad713x/ad713x.c
+++ b/drivers/adc/ad713x/ad713x.c
@@ -40,7 +40,7 @@
 
 #include <stdlib.h>
 #include "ad713x.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "capi_alloc.h"
 
@@ -459,14 +459,14 @@ static int32_t ad713x_init_gpio(struct ad713x_dev *dev,
 		ret = no_os_gpio_direction_output(dev->gpio_resetn, false);
 		if (NO_OS_IS_ERR_VALUE(ret))
 			return -1;
-		no_os_mdelay(100);
+		capi_wait_ms(100);
 		ret = no_os_gpio_set_value(dev->gpio_resetn, true);
 		if (NO_OS_IS_ERR_VALUE(ret))
 			return -1;
-		no_os_mdelay(100);
+		capi_wait_ms(100);
 	}
 
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 
 	return 0;
 }

--- a/drivers/adc/ad713x/iio_dual_ad713x.c
+++ b/drivers/adc/ad713x/iio_dual_ad713x.c
@@ -42,7 +42,7 @@
 #include "iio_types.h"
 #include "spi_engine.h"
 #include "iio_dual_ad713x.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 
 #define BITS_PER_SAMPLE 32

--- a/drivers/adc/ad719x/ad719x.c
+++ b/drivers/adc/ad719x/ad719x.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include "ad719x.h"    // AD719X definitions.
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 #include <string.h>
 
@@ -312,7 +312,7 @@ int ad719x_reset(struct ad719x_dev *dev)
 		return ret;
 
 	// user must allow a period of 500 us
-	no_os_udelay(500);
+	capi_wait_us(500);
 
 	return ret;
 }

--- a/drivers/adc/ad7280a/ad7280a.c
+++ b/drivers/adc/ad7280a/ad7280a.c
@@ -36,6 +36,7 @@
 #include "ad7280a.h"
 #include "capi_alloc.h"
 #include "no_os_error.h"
+#include "capi_time.h"
 
 /******************************************************************************
  * @brief Initializes the communication with the device.
@@ -71,7 +72,7 @@ int8_t ad7280a_init(struct ad7280a_dev **device,
 	AD7280A_ALERT_IN;
 
 	/* Wait 250us */
-	no_os_mdelay(250);
+	capi_wait_ms(250);
 
 	status |= no_os_spi_init(&dev->spi_desc, &init_param.spi_init);
 
@@ -305,14 +306,14 @@ int8_t ad7280a_convert_read_all(struct ad7280a_dev *dev)
 	ad7280a_transfer_32bits(dev,
 				value);
 	/* Wait 100us */
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 	/* Toggle CNVST pin */
 	AD7280A_CNVST_LOW;
 	/* Wait 50us */
-	no_os_mdelay(50);
+	capi_wait_ms(50);
 	AD7280A_CNVST_HIGH;
 	/* Wait 300us */
-	no_os_mdelay(300);
+	capi_wait_ms(300);
 	/* Read data from both devices */
 	for (i = 0; i < 24; i++) {
 		dev->read_data[i] = ad7280a_transfer_32bits(dev,
@@ -398,7 +399,7 @@ int16_t ad7280a_read_register(struct ad7280a_dev *dev,
 	ad7280a_transfer_32bits(dev,
 				value);
 	/* Wait 100us */
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 	/* Configure the Read register */
 	value = ad7280a_crc_write((uint32_t)(dev_addr << 31) |
 				  (AD7280A_READ << 21) |
@@ -456,7 +457,7 @@ int16_t ad7280a_read_conversion(struct ad7280a_dev *dev,
 	ad7280a_transfer_32bits(dev,
 				value);
 	/* Wait 100us */
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 	/*  */
 	value = ad7280a_crc_write((uint32_t)(dev_addr << 31) |
 				  (AD7280A_CONTROL_HB << 21) |
@@ -465,7 +466,7 @@ int16_t ad7280a_read_conversion(struct ad7280a_dev *dev,
 	ad7280a_transfer_32bits(dev,
 				value);
 	/* Wait 100us */
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 	/* Allow conversions to be initiated using CNVST pin on selected part */
 	value = ad7280a_crc_write((uint32_t)(dev_addr << 31) |
 				  (AD7280A_CNVST_N_CONTROL << 21) |
@@ -477,10 +478,10 @@ int16_t ad7280a_read_conversion(struct ad7280a_dev *dev,
 	AD7280A_CNVST_LOW;
 	/* Allow sufficient time for all conversions to be completed */
 	/* Wait 50us */
-	no_os_mdelay(50);
+	capi_wait_ms(50);
 	AD7280A_CNVST_HIGH;
 	/* Wait 300us */
-	no_os_mdelay(300);
+	capi_wait_ms(300);
 	/* Perform the read */
 	value = ad7280a_transfer_32bits(dev,
 					AD7280A_READ_TXVAL);
@@ -690,7 +691,7 @@ void ad7280a_selftest_all(struct ad7280a_dev *dev,
 	ad7280a_transfer_32bits(dev,
 				value);
 	/* Wait 100us */
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 	value = ad7280a_crc_write((uint32_t)(AD7280A_READ << 21) |
 				  (AD7280A_SELF_TEST << 15)            |
 				  (1 << 12));
@@ -705,10 +706,10 @@ void ad7280a_selftest_all(struct ad7280a_dev *dev,
 				value);
 	AD7280A_CNVST_LOW;
 	/* wait 100us */
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 	AD7280A_CNVST_HIGH;
 	/* wait 300us */
-	no_os_mdelay(300);
+	capi_wait_ms(300);
 	value = ad7280a_crc_write((uint32_t)(AD7280A_CNVST_N_CONTROL << 21) |
 				  (1 << 13)                       |
 				  (1 << 12));

--- a/drivers/adc/ad7280a/ad7280a.h
+++ b/drivers/adc/ad7280a/ad7280a.h
@@ -37,7 +37,7 @@
 
 
 #include <stdint.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 

--- a/drivers/adc/ad738x/ad738x.c
+++ b/drivers/adc/ad738x/ad738x.c
@@ -40,7 +40,7 @@
 #include "spi_engine.h"
 #endif
 #include "ad738x.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "capi_alloc.h"
 #include "no_os_pwm.h"
@@ -470,7 +470,7 @@ int32_t ad738x_init(struct ad738x_dev **device,
 	if (ret)
 		goto err;
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 	/* 1-wire or 2-wire mode */
 	ret = ad738x_set_conversion_mode(dev, dev->conv_mode);
 	if (ret)
@@ -487,7 +487,7 @@ int32_t ad738x_init(struct ad738x_dev **device,
 
 	*device = dev;
 	printf("ad738x successfully initialized\n");
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 	return 0;
 err:
 	printf("ad738x failed to initialize\n");

--- a/drivers/adc/ad7490/ad7490.c
+++ b/drivers/adc/ad7490/ad7490.c
@@ -33,7 +33,7 @@
 #include "ad7490.h"
 #include "capi_alloc.h"
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 #define AD7490_DUMMY_TRANSFER		0xFFFF
 
@@ -101,7 +101,7 @@ int ad7490_set_op_mode(struct ad7490_desc *desc, enum ad7490_op_mode op_mode)
 
 		break;
 	case AD7490_MODE_AUTOSHUTDOWN:
-		no_os_udelay(1);
+		capi_wait_us(1);
 
 		break;
 	case AD7490_MODE_FULLSHUTDOWN:

--- a/drivers/adc/ad7606/ad7606.c
+++ b/drivers/adc/ad7606/ad7606.c
@@ -44,6 +44,7 @@
 
 #ifdef XILINX_PLATFORM
 #include "no_os_axi_io.h"
+#include "capi_time.h"
 #include <unistd.h>
 #include <errno.h>
 #endif
@@ -610,7 +611,7 @@ int32_t ad7606_convst(struct ad7606_dev *dev)
 		return ret;
 
 	/* wait LP_CNV time */
-	no_os_udelay(1);
+	capi_wait_us(1);
 
 	return no_os_gpio_set_value(dev->gpio_convst, 1);
 }
@@ -924,7 +925,7 @@ int32_t ad7606_read_one_sample(struct ad7606_dev *dev, uint32_t * data)
 			if (busy == 0)
 				break;
 
-			no_os_udelay(1);
+			capi_wait_us(1);
 			timeout--;
 		}
 
@@ -932,7 +933,7 @@ int32_t ad7606_read_one_sample(struct ad7606_dev *dev, uint32_t * data)
 			return -ETIME;
 	} else {
 		/* wait CONV time */
-		no_os_udelay(tconv_max[dev->oversampling.os_ratio]);
+		capi_wait_us(tconv_max[dev->oversampling.os_ratio]);
 	}
 
 	return ad7606_spi_data_read(dev, data);
@@ -1089,7 +1090,7 @@ int32_t ad7606_reset(struct ad7606_dev *dev)
 	if (ret < 0)
 		return ret;
 
-	no_os_udelay(3);
+	capi_wait_us(3);
 
 	ret = no_os_gpio_set_value(dev->gpio_reset, 0);
 	if (ret < 0)
@@ -1843,7 +1844,7 @@ int32_t ad7606_init(struct ad7606_dev **device,
 	memcpy(dev->offset_ch, init_param->offset_ch, sizeof(dev->offset_ch));
 
 	/* wait DEVICE_SETUP time */
-	no_os_udelay(253);
+	capi_wait_us(253);
 
 	if (!dev->parallel_interface) {
 		ret = no_os_spi_init(&dev->spi_desc, &init_param->spi_init);

--- a/drivers/adc/ad7606/ad7606.h
+++ b/drivers/adc/ad7606/ad7606.h
@@ -36,7 +36,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_util.h"

--- a/drivers/adc/ad7616/ad7616.c
+++ b/drivers/adc/ad7616/ad7616.c
@@ -45,7 +45,7 @@
 #include "ad7616.h"
 #include "no_os_gpio.h"
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 #include "no_os_util.h"
 
@@ -457,10 +457,10 @@ int32_t ad7616_reset(struct ad7616_dev *dev)
 
 	ret = no_os_gpio_set_value(dev->gpio_reset, NO_OS_GPIO_LOW);
 	/* Low pulse width for a full reset should be at least 1200 ns */
-	no_os_mdelay(20);
+	capi_wait_ms(20);
 	ret |= no_os_gpio_set_value(dev->gpio_reset, NO_OS_GPIO_HIGH);
 	/* 15 ms are required to completely reconfigure the device */
-	no_os_mdelay(150);
+	capi_wait_ms(150);
 
 	return ret;
 }
@@ -706,10 +706,10 @@ int32_t ad7616_par_read(struct ad7616_dev *dev, uint8_t reg_addr,
 
 	no_os_axi_io_write(dev->core_baseaddr, AD7616_REG_UP_WRITE_DATA,
 			   0x0000 | ((reg_addr & 0x3F) << 9));
-	no_os_udelay(50);
+	capi_wait_us(50);
 	no_os_axi_io_read(dev->core_baseaddr, AD7616_REG_UP_READ_DATA, &read);
 	*reg_data = read & 0xFF;
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	return 0;
 #endif
@@ -731,7 +731,7 @@ int32_t ad7616_par_write(struct ad7616_dev *dev, uint8_t reg_addr,
 	no_os_axi_io_write(dev->core_baseaddr, AD7616_REG_UP_WRITE_DATA,
 			   0x8000 | ((reg_addr & 0x3F) << 9) |
 			   (reg_data & 0xFF));
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	return 0;
 #endif
@@ -808,14 +808,14 @@ int32_t ad7616_core_setup(struct ad7616_dev *dev)
 	uint32_t type;
 
 	no_os_axi_io_write(dev->core_baseaddr, AD7616_REG_UP_CTRL, 0x00);
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 	no_os_axi_io_write(dev->core_baseaddr, AD7616_REG_UP_CTRL, AD7616_CTRL_RESETN);
 	no_os_axi_io_write(dev->core_baseaddr, AD7616_REG_UP_CONV_RATE, 100);
 	no_os_axi_io_write(dev->core_baseaddr, AD7616_REG_UP_CTRL,
 			   AD7616_CTRL_RESETN | AD7616_CTRL_CNVST_EN);
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 	no_os_axi_io_write(dev->core_baseaddr, AD7616_REG_UP_CTRL, AD7616_CTRL_RESETN);
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 
 	no_os_axi_io_read(dev->core_baseaddr, AD7616_REG_UP_IF_TYPE, &type);
 

--- a/drivers/adc/ad7689/ad7689.c
+++ b/drivers/adc/ad7689/ad7689.c
@@ -35,7 +35,7 @@
 #include "no_os_util.h"
 #include "no_os_error.h"
 #include "no_os_print_log.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 
 const char *ad7689_device_name[] = {

--- a/drivers/adc/ad7768-1/ad77681.c
+++ b/drivers/adc/ad7768-1/ad77681.c
@@ -37,7 +37,7 @@
 #include <string.h>
 #include "ad77681.h"
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 
 /**
@@ -1210,7 +1210,7 @@ int32_t ad77681_programmable_filter(struct ad77681_dev *dev,
 			return ret;
 
 		/* Wait for Twait uSeconds*/
-		no_os_udelay(twait);
+		capi_wait_us(twait);
 
 		/* Padding of zeros before the desired coef in case the coef count in less than 56 */
 		if ((num_coeffs + i) < coeff_reg_length) {
@@ -1241,7 +1241,7 @@ int32_t ad77681_programmable_filter(struct ad77681_dev *dev,
 		/* Increment the address*/
 		address++;
 		/* Wait for Twait uSeconds*/
-		no_os_udelay(twait);
+		capi_wait_us(twait);
 	}
 
 	/* Disable coefficient write */
@@ -1254,7 +1254,7 @@ int32_t ad77681_programmable_filter(struct ad77681_dev *dev,
 	if (ret < 0)
 		return ret;
 
-	no_os_udelay(twait);
+	capi_wait_us(twait);
 
 	/* Disable coefficient access */
 	ret = ad77681_spi_write_mask(dev,
@@ -1790,7 +1790,7 @@ int32_t ad77681_setup(struct ad77681_dev **device,
 
 	ret |= ad77681_soft_reset(dev);
 
-	no_os_udelay(200);
+	capi_wait_us(200);
 
 	/* Check physical connection using scratchpad*/
 	if (ad77681_scratchpad(dev, &scratchpad_check) == -1) {

--- a/drivers/adc/ad7768/ad7768.c
+++ b/drivers/adc/ad7768/ad7768.c
@@ -37,7 +37,7 @@
 #include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 const uint8_t standard_pin_ctrl_mode_sel[3][4] = {
 //		MCLK/1,	MCLK/2,	MCLK/4,	MCLK/8
@@ -716,7 +716,7 @@ int32_t ad7768_setup_finish(ad7768_dev *dev,
 	ret |= no_os_gpio_direction_output(dev->gpio_reset, dev->gpio_reset_value);
 
 	/* Delay to ensure device is out of reset */
-	no_os_mdelay(2);
+	capi_wait_ms(2);
 
 	dev->sleep_mode = init_param.sleep_mode;
 	dev->mclk_div = init_param.mclk_div;

--- a/drivers/adc/ad7779/ad7779.c
+++ b/drivers/adc/ad7779/ad7779.c
@@ -37,6 +37,7 @@
 #include "no_os_util.h"
 #include "no_os_error.h"
 #include "capi_alloc.h"
+#include "capi_time.h"
 
 const uint8_t pin_mode_options[16][4] = {
 	/*GAIN_1, GAIN_2, GAIN_4, GAIN_8 */
@@ -403,7 +404,7 @@ int32_t ad7779_do_update_mode_pins(ad7779_dev *dev)
 	/* All the pins that define the AD7779 configuration mode are re-evaluated
 	 * every time SYNC_IN pin is pulsed. */
 	ret |= no_os_gpio_set_value(dev->gpio_sync_in, NO_OS_GPIO_LOW);
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 	ret |= no_os_gpio_set_value(dev->gpio_sync_in, NO_OS_GPIO_HIGH);
 
 	return ret;
@@ -1377,9 +1378,9 @@ int32_t ad7779_do_single_sar_conv(ad7779_dev *dev,
 	ret = ad7779_set_sar_cfg(dev, AD7779_ENABLE, mux);
 	ret |= ad7779_set_spi_op_mode(dev, AD7779_SAR_CONV);
 	ret |= no_os_gpio_set_value(dev->gpio_convst_sar, NO_OS_GPIO_LOW);
-	no_os_mdelay(10);	// Acquisition Time = min 500 ns
+	capi_wait_ms(10);	// Acquisition Time = min 500 ns
 	ret |= no_os_gpio_set_value(dev->gpio_convst_sar, NO_OS_GPIO_HIGH);
-	no_os_mdelay(10);	// Conversion Time = max 3.4 us
+	capi_wait_ms(10);	// Conversion Time = max 3.4 us
 	ad7779_spi_sar_read_code(dev, mux, sar_code);
 	ret |= ad7779_set_sar_cfg(dev, restore_sar_state, mux);
 	ret |= ad7779_set_spi_op_mode(dev, restore_spi_op_mode);
@@ -1507,9 +1508,9 @@ int32_t ad7779_init(ad7779_dev **device,
 
 	ret |= no_os_gpio_direction_output(dev->gpio_reset,
 					   NO_OS_GPIO_LOW);
-	no_os_mdelay(10);	// RESET Hold Time = min 2 x MCLK
+	capi_wait_ms(10);	// RESET Hold Time = min 2 x MCLK
 	ret |= no_os_gpio_set_value(dev->gpio_reset, NO_OS_GPIO_HIGH);
-	no_os_mdelay(10);	// RESET Rising Edge to First DRDY = min 225 us
+	capi_wait_ms(10);	// RESET Rising Edge to First DRDY = min 225 us
 	ret |= no_os_gpio_direction_output(dev->gpio_mode0,
 					   NO_OS_GPIO_LOW);
 	ret |= no_os_gpio_direction_output(dev->gpio_mode1,
@@ -1558,7 +1559,7 @@ int32_t ad7779_init(ad7779_dev **device,
 			ret |= ad7779_set_state(dev, (ad7779_ch)i, dev->state[i]);
 	}
 
-	no_os_mdelay(50);
+	capi_wait_ms(50);
 
 	for (i = AD7779_CH0; i <= AD7779_CH7; i++) {
 		dev->gain[i] = init_param.gain[i];

--- a/drivers/adc/ad7779/ad7779.h
+++ b/drivers/adc/ad7779/ad7779.h
@@ -35,7 +35,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 

--- a/drivers/adc/ad9081/ad9081.c
+++ b/drivers/adc/ad9081/ad9081.c
@@ -36,7 +36,7 @@
 #include "no_os_error.h"
 #include "adi_cms_api_common.h"
 #include "no_os_util.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 #include "adi_ad9081_hal.h"
 #include "no_os_print_log.h"
@@ -409,7 +409,7 @@ static int32_t ad9081_jesd_rx_link_status_print(struct ad9081_phy *phy,
 					lnk->link_id, ad9081_jrx_204c_states[stat & 0x7],
 					stat);
 			else
-				no_os_mdelay(20);
+				capi_wait_ms(20);
 		} else {
 			mask = (1 << lnk->num_lanes) - 1;
 
@@ -424,7 +424,7 @@ static int32_t ad9081_jesd_rx_link_status_print(struct ad9081_phy *phy,
 				pr_info("JESD TX (JRX) Link%d 0x%X lanes in DATA\n",
 					lnk->link_id, stat);
 			else
-				no_os_mdelay(20);
+				capi_wait_ms(20);
 		}
 	} while (ret && retry--);
 
@@ -473,7 +473,7 @@ int ad9081_jesd_tx_link_status_print(struct ad9081_phy *phy,
 					stat & NO_OS_BIT(6) ? "established" : "lost",
 					stat & NO_OS_BIT(7) ? "invalid" : "valid");
 			else
-				no_os_mdelay(20);
+				capi_wait_ms(20);
 		} else {
 			if ((stat & 0xFF) == 0x7D)
 				ret = 0;
@@ -488,7 +488,7 @@ int ad9081_jesd_tx_link_status_print(struct ad9081_phy *phy,
 					stat & NO_OS_BIT(6) ? "established" : "lost",
 					stat & NO_OS_BIT(7) ? "invalid" : "valid");
 			else
-				no_os_mdelay(20);
+				capi_wait_ms(20);
 		}
 	} while (ret && retry--);
 
@@ -821,7 +821,7 @@ static int ad9081_setup(struct ad9081_phy *phy)
 
 static int32_t ad9081_udelay(void *user_data, uint32_t us)
 {
-	no_os_udelay(us);
+	capi_wait_us(us);
 
 	return 0;
 }
@@ -1105,7 +1105,7 @@ static int ad9081_jesd204_clks_enable(struct jesd204_dev *jdev,
 		if (ret != 0)
 			return ret;
 
-		no_os_mdelay(4);
+		capi_wait_ms(4);
 	}
 
 	return JESD204_STATE_CHANGE_DONE;
@@ -1275,7 +1275,7 @@ static int ad9081_jesd204_setup_stage1(struct jesd204_dev *jdev,
 	if (ret != 0)
 		return ret;
 
-	no_os_mdelay(4);
+	capi_wait_ms(4);
 
 	/* JESD OneShot Sync */
 	ret = adi_ad9081_hal_bf_set(&phy->ad9081, REG_SYNC_DEBUG0_ADDR,

--- a/drivers/adc/ad9083/ad9083.c
+++ b/drivers/adc/ad9083/ad9083.c
@@ -37,7 +37,7 @@
 #include "adi_ad9083_hal.h"
 #include "no_os_error.h"
 #include <inttypes.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_clk.h"
 #include "uc_settings.h"
 #include "no_os_util.h"
@@ -188,7 +188,7 @@ int32_t ad9083_log_write(void *user_data, int32_t log_type, const char *message,
  */
 static int ad9083_udelay(void *user_data, unsigned int us)
 {
-	no_os_udelay(us);
+	capi_wait_us(us);
 
 	return 0;
 }
@@ -229,12 +229,12 @@ static int32_t ad9083_link_reset(struct ad9083_phy *device, uint8_t uc)
 	if (ret != 0)
 		return ret;
 
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 	ret = adi_ad9083_jesd_tx_link_digital_reset(&device->adi_ad9083, 0);
 	if (ret != 0)
 		return ret;
 
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	return 0;
 }

--- a/drivers/adc/ad9208/ad9208.c
+++ b/drivers/adc/ad9208/ad9208.c
@@ -38,6 +38,7 @@
 #include <inttypes.h>
 #include "api_def.h"
 #include "capi_alloc.h"
+#include "capi_time.h"
 
 /**
  * Spi write and read compatible with ad9208 API
@@ -331,7 +332,7 @@ static int32_t ad9208_setup(struct ad9208_state *st)
 	timeout = 10;
 
 	do {
-		no_os_mdelay(10);
+		capi_wait_ms(10);
 		ret = ad9208_jesd_get_pll_status(ad9208_h, &pll_stat);
 		if (ret < 0) {
 			printf("Failed to get pll status (%d)\n", ret);
@@ -358,7 +359,7 @@ error:
  */
 static int ad9208_udelay(void *user_data, unsigned int us)
 {
-	no_os_udelay(us);
+	capi_wait_us(us);
 
 	return 0;
 }

--- a/drivers/adc/ad9208/ad9208.h
+++ b/drivers/adc/ad9208/ad9208.h
@@ -40,7 +40,7 @@
 #include "ad9208_reg.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 #define AD9208_FULL_BANDWIDTH_MODE 0
 #define AD9208_1_DDC_MODE 1

--- a/drivers/adc/ad9265/ad9265.c
+++ b/drivers/adc/ad9265/ad9265.c
@@ -36,6 +36,7 @@
 #include "axi_adc_core.h"
 #include "ad9265.h"
 #include "capi_alloc.h"
+#include "capi_time.h"
 
 #define DCO_DEBUG
 
@@ -166,7 +167,7 @@ int32_t ad9265_calibrate(struct ad9265_dev *dev,
 
 			axi_adc_write(&core, AXI_ADC_REG_CHAN_STATUS(0), ~0);
 
-			no_os_mdelay(1);
+			capi_wait_ms(1);
 
 			axi_adc_read(&core, AXI_ADC_REG_CHAN_STATUS(0), &stat);
 

--- a/drivers/adc/ad9265/ad9265.h
+++ b/drivers/adc/ad9265/ad9265.h
@@ -34,7 +34,7 @@
 #define AD9265_H_
 
 #include <stdint.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_spi.h"
 
 #define AD9265_REG_CHIP_PORT_CONF	0x00

--- a/drivers/adc/ad9434/ad9434.c
+++ b/drivers/adc/ad9434/ad9434.c
@@ -36,6 +36,7 @@
 #include "ad9434.h"
 #include "capi_alloc.h"
 #include "no_os_error.h"
+#include "capi_time.h"
 
 #define DCO_DEBUG
 
@@ -107,7 +108,7 @@ int32_t ad9434_testmode_set(struct ad9434_dev *dev,
 
 	ad9434_spi_write(dev, AD9434_REG_TEST_IO, 0x10);
 	ad9434_spi_write(dev, AD9434_REG_TRANSFER, TRANSFER_SYNC);
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 	ad9434_spi_write(dev, AD9434_REG_TEST_IO, 0x0);
 	ad9434_spi_write(dev, AD9434_REG_TRANSFER, TRANSFER_SYNC);
 	ad9434_spi_write(dev, AD9434_REG_TEST_IO, mode);

--- a/drivers/adc/ad9434/ad9434.h
+++ b/drivers/adc/ad9434/ad9434.h
@@ -34,7 +34,7 @@
 #define AD9434_H_
 
 #include <stdint.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_spi.h"
 
 #define AD9434_REG_CHIP_PORT_CONF	0x00

--- a/drivers/adc/ad9625/ad9625.c
+++ b/drivers/adc/ad9625/ad9625.c
@@ -36,6 +36,7 @@
 #include "ad9625.h"
 #include "capi_alloc.h"
 #include "no_os_error.h"
+#include "capi_time.h"
 
 /***************************************************************************//**
  * @brief ad9625_spi_read
@@ -100,7 +101,7 @@ int32_t ad9625_setup(struct ad9625_dev **device,
 
 	ad9625_spi_write(dev, AD9625_REG_CHIP_PORT_CONF, 0x18);
 	ad9625_spi_write(dev, AD9625_REG_TRANSFER, 0x01);
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 
 	ad9625_spi_write(dev, AD9625_REG_POWER_MODE, 0x00);
 	ad9625_spi_write(dev, AD9625_REG_TRANSFER, 0x01);
@@ -112,7 +113,7 @@ int32_t ad9625_setup(struct ad9625_dev **device,
 	ad9625_spi_write(dev, AD9625_REG_OUTPUT_ADJUST, 0x10);
 	ad9625_spi_write(dev, AD9625_REG_JESD204B_LINK_CNTRL_1, 0x14);
 	ad9625_spi_write(dev, AD9625_REG_TRANSFER, 0x01);
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 
 	ad9625_spi_read(dev, AD9625_REG_CHIP_ID, &chip_id);
 	if (chip_id != AD9625_CHIP_ID) {

--- a/drivers/adc/ad9625/ad9625.h
+++ b/drivers/adc/ad9625/ad9625.h
@@ -34,7 +34,7 @@
 #define AD9625_H_
 
 #include <stdint.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_spi.h"
 
 #define AD9625_REG_CHIP_PORT_CONF				0x000

--- a/drivers/adc/ad9656/ad9656.c
+++ b/drivers/adc/ad9656/ad9656.c
@@ -36,7 +36,7 @@
 #include <stdio.h>
 #include "no_os_error.h"
 #include "ad9656.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 
 /**
@@ -199,7 +199,7 @@ int32_t ad9656_setup(struct ad9656_dev **device,
 	if (ret != 0)
 		goto error_comm;
 
-	no_os_mdelay(250);
+	capi_wait_ms(250);
 
 	ret = ad9656_reg_read(dev, AD9656_REG_CHIP_ID, &chip_id);
 	if (ret != 0)
@@ -261,7 +261,7 @@ int32_t ad9656_setup(struct ad9656_dev **device,
 	if (ret != 0)
 		goto error_comm;
 
-	no_os_mdelay(250);
+	capi_wait_ms(250);
 
 	ret = ad9656_reg_read(dev, AD9656_REG_JESD204B_PLL_LOCK_STATUS, &pll_stat);
 	if (ret != 0)

--- a/drivers/adc/ad9680/ad9680.c
+++ b/drivers/adc/ad9680/ad9680.c
@@ -37,6 +37,7 @@
 #include "no_os_error.h"
 #include "no_os_print_log.h"
 #include "capi_alloc.h"
+#include "capi_time.h"
 
 struct ad9680_jesd204_priv {
 	struct ad9680_dev *dev;
@@ -242,7 +243,7 @@ int32_t ad9680_setup(struct ad9680_dev **device,
 	ad9680_spi_write(dev,
 			 AD9680_REG_INTERFACE_CONF_A,
 			 0x81);	// RESET
-	no_os_mdelay(250);
+	capi_wait_ms(250);
 
 	ad9680_spi_write(dev,
 			 AD9680_REG_LINK_CONTROL,
@@ -270,7 +271,7 @@ int32_t ad9680_setup(struct ad9680_dev **device,
 	ad9680_spi_write(dev,
 			 AD9680_REG_LINK_CONTROL,
 			 0x14);	// link enable
-	no_os_mdelay(250);
+	capi_wait_ms(250);
 
 	ad9680_spi_read(dev,
 			AD9680_REG_JESD204B_PLL_LOCK_STATUS,
@@ -317,7 +318,7 @@ int32_t ad9680_setup_jesd_fsm(struct ad9680_dev **device,
 	ad9680_spi_write(dev,
 			 AD9680_REG_INTERFACE_CONF_A,
 			 0x81);	// RESET
-	no_os_mdelay(250);
+	capi_wait_ms(250);
 
 	ad9680_spi_write(dev,
 			 AD9680_REG_LINK_CONTROL,
@@ -345,7 +346,7 @@ int32_t ad9680_setup_jesd_fsm(struct ad9680_dev **device,
 	ad9680_spi_write(dev,
 			 AD9680_REG_LINK_CONTROL,
 			 0x14);	// link enable
-	no_os_mdelay(250);
+	capi_wait_ms(250);
 
 	ad9680_spi_read(dev,
 			AD9680_REG_JESD204B_PLL_LOCK_STATUS,

--- a/drivers/adc/ad9680/ad9680.h
+++ b/drivers/adc/ad9680/ad9680.h
@@ -34,7 +34,7 @@
 #define AD9680_H_
 
 #include <stdint.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_spi.h"
 #include "jesd204.h"
 #include "no_os_util.h"

--- a/drivers/adc/adaq7980/adaq7980.c
+++ b/drivers/adc/adaq7980/adaq7980.c
@@ -35,7 +35,7 @@
 #include "stdlib.h"
 #include "adaq7980.h"
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 
 /**
@@ -101,12 +101,12 @@ int32_t adaq7980_setup(struct adaq7980_dev **device,
 		if (ret != 0)
 			goto error_dev;
 
-		no_os_mdelay(10);
+		capi_wait_ms(10);
 		ret = no_os_gpio_set_value(dev->gpio_pd_ldo, NO_OS_GPIO_HIGH);
 		if (ret != 0)
 			goto error_dev;
 
-		no_os_mdelay(10);
+		capi_wait_ms(10);
 	}
 	ret = no_os_pwm_init(&dev->trigger_pwm_desc, init_param->trigger_pwm_init);
 	if (ret != 0)

--- a/drivers/adc/adaq8092/adaq8092.c
+++ b/drivers/adc/adaq8092/adaq8092.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include "adaq8092.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 
 /******************************************************************************/
@@ -159,19 +159,19 @@ int adaq8092_init(struct adaq8092_dev **device,
 	if (ret)
 		goto error_par_ser;
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	ret = no_os_gpio_set_value(dev->gpio_en_1p8, NO_OS_GPIO_HIGH);
 	if (ret)
 		goto error_par_ser;
 
-	no_os_mdelay(500);
+	capi_wait_ms(500);
 
 	ret = no_os_gpio_set_value(dev->gpio_adc_pd1, NO_OS_GPIO_HIGH);
 	if (ret)
 		goto error_par_ser;
 
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	ret = no_os_gpio_set_value(dev->gpio_adc_pd2, NO_OS_GPIO_HIGH);
 	if (ret)
@@ -183,7 +183,7 @@ int adaq8092_init(struct adaq8092_dev **device,
 	if (ret)
 		goto error_par_ser;
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	/* Device Initialization */
 	ret = adaq8092_set_pd_mode(dev, init_param.pd_mode);

--- a/drivers/adc/adm1177/adm1177.c
+++ b/drivers/adc/adm1177/adm1177.c
@@ -33,7 +33,7 @@
 #include <stdlib.h>
 #include "adm1177.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 
 /**************************************************************************//**
@@ -211,7 +211,7 @@ int adm1177_read_conv(struct adm1177_dev *device,
 	uint8_t data[3];
 
 	/* Time taken for device conversion (datasheet value = 150us) */
-	no_os_udelay(150);
+	capi_wait_us(150);
 
 	switch (device->last_command) {
 	case ADM1177_CURRENT_EN:

--- a/drivers/adc/ltc2312/ltc2312.c
+++ b/drivers/adc/ltc2312/ltc2312.c
@@ -48,6 +48,7 @@ ongoing work.
 #include <math.h>
 #include "ltc2312.h"
 #include "capi_alloc.h"
+#include "capi_time.h"
 
 /**
  * Initializes the ltc2312 device handler.
@@ -160,7 +161,7 @@ int32_t ltc2312_read(struct ltc2312_dev *dev, uint16_t *ptr_adc_code)
 
 	/* Gather values for averaging */
 	for (i = 0; i < LTC2312_READ_VALUES_NUMBER; ++i) {
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 
 		/* Read the value of the ADC */
 		ret = no_os_spi_write_and_read(dev->spi_desc, adc_array, bytes_no);

--- a/drivers/adc/ltc2312/ltc2312.h
+++ b/drivers/adc/ltc2312/ltc2312.h
@@ -60,7 +60,7 @@ ongoing work.
 #define LTC2312_READ_VALUES_NUMBER 100
 
 #include <stdint.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_spi.h"
 
 enum device_type {

--- a/drivers/adc/ltc2378/ltc2378.c
+++ b/drivers/adc/ltc2378/ltc2378.c
@@ -34,7 +34,7 @@
 #include "ltc2378.h"
 #include <stdlib.h>
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_util.h"
 
 /**
@@ -130,7 +130,7 @@ int ltc2378_start_conversion(struct ltc2378_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_udelay(LTC2378_CNV_PULSE_WIDTH_US);
+	capi_wait_us(LTC2378_CNV_PULSE_WIDTH_US);
 
 	ret = no_os_gpio_set_value(dev->gpio_cnv, 0);
 	if (ret)
@@ -165,13 +165,13 @@ int ltc2378_read_raw(struct ltc2378_dev *dev, uint32_t *data)
 			ret = no_os_gpio_get_value(dev->gpio_busy, &val);
 			if (ret)
 				return ret;
-			no_os_udelay(1);
+			capi_wait_us(1);
 		} while (val && --timeout);
 
 		if (timeout == 0)
 			return -ETIMEDOUT;
 	} else {
-		no_os_udelay(LTC2378_CONVERSION_DELAY_US);
+		capi_wait_us(LTC2378_CONVERSION_DELAY_US);
 	}
 
 	ret = no_os_spi_write_and_read(dev->spi_desc, buf, sizeof(buf));
@@ -263,6 +263,6 @@ int ltc2378_power_down(struct ltc2378_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_udelay(LTC2378_POWERDOWN_DELAY_US);
+	capi_wait_us(LTC2378_POWERDOWN_DELAY_US);
 	return 0;
 }

--- a/drivers/adc/ltc2378/ltc2378.h
+++ b/drivers/adc/ltc2378/ltc2378.h
@@ -37,7 +37,7 @@
 #include <stdint.h>
 #include "no_os_spi.h"
 #include "no_os_gpio.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 
 #define LTC2378_RESOLUTION_UNIPOLAR (1 << 20) /* 2^20 = 1048576 */

--- a/drivers/adc/max14001/max14001.c
+++ b/drivers/adc/max14001/max14001.c
@@ -33,7 +33,7 @@
 
 #include <stdlib.h>
 #include "max14001.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
 #include "capi_alloc.h"
@@ -186,7 +186,7 @@ int max14001_init(struct max14001_dev **device,
 	struct max14001_dev *dev;
 	int ret;
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	dev = (struct max14001_dev *)capi_calloc(1, sizeof(*dev));
 	if (!dev)
@@ -217,7 +217,7 @@ int max14001_init_config(struct max14001_dev *dev)
 	int i, ret;
 	uint16_t data;
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	ret = max14001_read(dev, MAX14001_FLAGS_REG, &data);
 	if (ret)

--- a/drivers/adc/max9611pmb/max9611.c
+++ b/drivers/adc/max9611pmb/max9611.c
@@ -37,7 +37,7 @@
 #include "no_os_i2c.h"
 #include "no_os_util.h"
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 #include "max9611.h"
 

--- a/drivers/adc/max9611pmb/max9611.h
+++ b/drivers/adc/max9611pmb/max9611.h
@@ -39,7 +39,7 @@
 #include "no_os_i2c.h"
 #include "no_os_util.h"
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 #define MAX9611_MUX_MASK		NO_OS_GENMASK(2, 0)
 #define MAX9611_MODE_MASK		NO_OS_GENMASK(7, 5)

--- a/drivers/afe/ad4110/ad4110.c
+++ b/drivers/afe/ad4110/ad4110.c
@@ -41,6 +41,7 @@
 #include "no_os_error.h"
 #include "no_os_irq.h"
 #include "no_os_print_log.h"
+#include "capi_time.h"
 #include <string.h>
 
 /***************************************************************************//**
@@ -913,7 +914,7 @@ int32_t ad4110_setup(struct ad4110_dev **device,
 	ret = ad4110_spi_do_soft_reset(dev);
 	if (ret)
 		goto err_spi;
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 
 	if (init_param.afe_crc_en != AD4110_AFE_CRC_DISABLE) {
 		ret = ad4110_spi_int_reg_write(dev,
@@ -1061,7 +1062,7 @@ int32_t ad4110_continuous_read(struct ad4110_dev *dev, uint32_t *buffer,
 	if (ret)
 		return ret;
 	// make sure adc is fully initialized before irq enabling
-	no_os_mdelay(2U);
+	capi_wait_ms(2U);
 	ret = no_os_irq_enable(dev->irq_desc, dev->nready_pin);
 	if (ret)
 		return ret;

--- a/drivers/afe/ad4110/ad4110.h
+++ b/drivers/afe/ad4110/ad4110.h
@@ -38,7 +38,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_irq.h"

--- a/drivers/afe/ad413x/ad413x.c
+++ b/drivers/afe/ad413x/ad413x.c
@@ -37,7 +37,7 @@
 #include "no_os_error.h"
 #include "no_os_irq.h"
 #include "no_os_print_log.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_crc8.h"
 #include "no_os_spi.h"
 #include "capi_alloc.h"
@@ -638,7 +638,7 @@ int32_t ad413x_do_soft_reset(struct ad413x_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(5); // TBD
+	capi_wait_ms(5); // TBD
 
 	return 0;
 }

--- a/drivers/afe/ad413x/ad413x.h
+++ b/drivers/afe/ad413x/ad413x.h
@@ -35,7 +35,7 @@
 #define AD413X_H_
 
 #include <stdint.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_irq.h"

--- a/drivers/afe/ad413x/iio_ad413x.c
+++ b/drivers/afe/ad413x/iio_ad413x.c
@@ -4,7 +4,7 @@
 #include <math.h>
 #include <string.h>
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "iio.h"
 #include "iio_ad413x.h"
 #include "no_os_util.h"

--- a/drivers/afe/ad5940/ad5940.c
+++ b/drivers/afe/ad5940/ad5940.c
@@ -36,7 +36,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include <errno.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_spi.h"
 #include "no_os_gpio.h"
 #include "capi_alloc.h"
@@ -2952,9 +2952,9 @@ int ad5940_HWReset(struct ad5940_dev *dev)
 	uint32_t tempreg;
 
 	no_os_gpio_set_value(dev->reset_gpio, NO_OS_GPIO_LOW);
-	no_os_udelay(10); /* Delay some time */
+	capi_wait_us(10); /* Delay some time */
 	no_os_gpio_set_value(dev->reset_gpio, NO_OS_GPIO_HIGH);
-	no_os_mdelay(1); /* AD5940 need some time to exit reset status */
+	capi_wait_ms(1); /* AD5940 need some time to exit reset status */
 
 	ret = ad5940_ReadReg(dev, REG_AFECON_ADIID, &tempreg);
 	if (ret < 0)

--- a/drivers/afe/ad5940/iio_ad5940.c
+++ b/drivers/afe/ad5940/iio_ad5940.c
@@ -35,7 +35,7 @@
 #include <inttypes.h>
 #include <math.h>
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_util.h"
 #include "capi_alloc.h"
 #include "iio.h"
@@ -79,7 +79,7 @@ static int ad5940_iio_read_chan_raw(void *device, char *buf, uint32_t len,
 		no_os_gpio_get_value(iiodev->ad5940->gp0_gpio, &gpio);
 		if (!gpio)
 			break;
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 		timeout--;
 	}
 
@@ -217,7 +217,7 @@ int ad5940_iio_set_attr(void *device, char *buf, uint32_t len,
 		ret = ad5940_WriteReg(iiodev->ad5940, REG_AGPIO_GP0OUT, 0);
 		if (ret < 0)
 			return ret;
-		no_os_udelay(10);
+		capi_wait_us(10);
 		ret = ad5940_WriteReg(iiodev->ad5940, REG_AGPIO_GP0OUT, AGPIO_Pin1);
 		if (ret < 0)
 			return ret;

--- a/drivers/afe/max30009/max30009.c
+++ b/drivers/afe/max30009/max30009.c
@@ -36,7 +36,7 @@
 #include <errno.h>
 #include "max30009.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "no_os_print_log.h"
 
@@ -260,7 +260,7 @@ int max30009_soft_reset(struct max30009_dev *device)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 	ret = max30009_reg_update(device,
 				  MAX30009_REG_SYSTEM_CONFIGURATION1,
 				  MAX30009_RESET_MSK,
@@ -268,7 +268,7 @@ int max30009_soft_reset(struct max30009_dev *device)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	return ret;
 }
@@ -350,7 +350,7 @@ int max30009_init(struct max30009_dev **device,
 		if (ret)
 			goto error_csb_gpio;
 
-		no_os_mdelay(10);
+		capi_wait_ms(10);
 
 		ret = no_os_i2c_init(&dev->i2c_desc, &init_param->i2c_init);
 	} else {
@@ -369,7 +369,7 @@ int max30009_init(struct max30009_dev **device,
 			goto error_int_gpio;
 	}
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	ret = max30009_verify_part_id(dev);
 	if (ret)
@@ -499,7 +499,7 @@ static int max30009_wait_for_lock(struct max30009_dev *device,
 		    (status & MAX30009_STATUS1_PHASE_LOCK_MSK))
 			return 0;
 
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 		elapsed++;
 	}
 
@@ -835,7 +835,7 @@ int max30009_timing_system_reset(struct max30009_dev *device)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	return 0;
 }
@@ -1136,7 +1136,7 @@ int max30009_bioz_enable(struct max30009_dev *device, bool enable)
 		return ret;
 
 	if (enable)
-		no_os_mdelay(100);
+		capi_wait_ms(100);
 
 	return 0;
 }
@@ -1193,7 +1193,7 @@ int max30009_bioz_bg_enable(struct max30009_dev *device, bool enable)
 		return ret;
 
 	if (enable)
-		no_os_mdelay(100);
+		capi_wait_ms(100);
 
 	return 0;
 }

--- a/drivers/amplifiers/ada4250/ada4250.c
+++ b/drivers/amplifiers/ada4250/ada4250.c
@@ -33,7 +33,7 @@
 
 #include <stdlib.h>
 #include "ada4250.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "capi_alloc.h"
 
@@ -482,7 +482,7 @@ int32_t ada4250_set_normal_mode(struct ada4250_dev *dev, bool reconfig)
 		return ret;
 
 	/* Wait for 200/400 us for the device to wake up from sleep/shutdown mode */
-	no_os_udelay(dev->power_mode == ADA4250_POWER_SLEEP ? 200 : 400);
+	capi_wait_us(dev->power_mode == ADA4250_POWER_SLEEP ? 200 : 400);
 
 	if (dev->power_mode == ADA4250_POWER_SHUTDOWN) {
 		if (reconfig) {
@@ -545,7 +545,7 @@ int32_t ada4250_init(struct ada4250_dev **device,
 		goto error_slp;
 
 	/* Wait for the device to wake up*/
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 	dev->power_mode = ADA4250_POWER_NORMAL;
 
 	if (dev->device_id == ADA4250) {

--- a/drivers/amplifiers/adhv4710/adhv4710.c
+++ b/drivers/amplifiers/adhv4710/adhv4710.c
@@ -39,7 +39,7 @@
 #include "no_os_spi.h"
 #include "no_os_gpio.h"
 #include "no_os_irq.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_units.h"
 #include "capi_alloc.h"
 #include "no_os_crc16.h"
@@ -289,7 +289,7 @@ int adhv4710_hw_reset(struct adhv4710_dev *dev)
 			return ret;
 	}
 	/* delay for toggeling the reset pin (minimum 10ns see datasheet) */
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	if (dev->gpio_reset) {
 		ret = no_os_gpio_set_value(dev->gpio_reset, NO_OS_GPIO_HIGH);

--- a/drivers/amplifiers/adhv4710/adhv4710.h
+++ b/drivers/amplifiers/adhv4710/adhv4710.h
@@ -40,7 +40,7 @@
 #include "no_os_spi.h"
 #include "no_os_gpio.h"
 #include "no_os_irq.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_units.h"
 #include "capi_alloc.h"
 #include "no_os_crc16.h"

--- a/drivers/axi_core/axi_adc_core/axi_adc_core.c
+++ b/drivers/axi_core/axi_adc_core/axi_adc_core.c
@@ -35,7 +35,7 @@
 #include <stdio.h>
 #include <inttypes.h>
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_util.h"
 #include "capi_alloc.h"
 #include "axi_adc_core.h"
@@ -142,12 +142,12 @@ int32_t axi_adc_pn_mon(struct axi_adc *adc,
 		axi_adc_write(adc, AXI_ADC_REG_CHAN_CNTRL(ch), reg_data);
 		axi_adc_set_pnsel(adc, ch, sel);
 	}
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	for (ch = 0; ch < adc->num_channels; ch++) {
 		axi_adc_write(adc, AXI_ADC_REG_CHAN_STATUS(ch), 0xff);
 	}
-	no_os_mdelay(delay_ms);
+	capi_wait_ms(delay_ms);
 
 	for (ch = 0; ch < adc->num_channels; ch++) {
 		axi_adc_read(adc, AXI_ADC_REG_CHAN_STATUS(ch), &reg_data);
@@ -256,7 +256,7 @@ int32_t axi_adc_delay_calibrate(struct axi_adc *adc,
 
 	for (delay = 0; delay < 32; delay++) {
 		axi_adc_delay_set(adc, no_of_lanes, delay);
-		no_os_mdelay(20);
+		capi_wait_ms(20);
 		if (axi_adc_pn_mon(adc, sel, 100) == 0) {
 			err_field[delay] = 0;
 			start_valid_delay = start_valid_delay == 32 ?
@@ -655,7 +655,7 @@ int32_t axi_adc_init(struct axi_adc **adc_core,
 			      AXI_ADC_FORMAT_SIGNEXT | AXI_ADC_FORMAT_ENABLE |
 			      AXI_ADC_ENABLE);
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	ret = axi_adc_init_finish(adc);
 	if (ret)

--- a/drivers/axi_core/axi_dac_core/axi_dac_core.c
+++ b/drivers/axi_core/axi_dac_core/axi_dac_core.c
@@ -35,7 +35,7 @@
 #include <stdio.h>
 #include <inttypes.h>
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_util.h"
 #include "capi_alloc.h"
 #include "axi_dac_core.h"
@@ -421,7 +421,7 @@ int32_t axi_dac_read_poll_timeout(struct axi_dac *dac, uint32_t reg_addr,
 		if ((reg & mask) == value)
 			return 0;
 
-		no_os_udelay(sleep_us);
+		capi_wait_us(sleep_us);
 		timeout_us -= sleep_us;
 	}
 
@@ -464,7 +464,7 @@ int32_t axi_dac_bus_write(struct axi_dac *dac, uint32_t reg_addr,
 	if (err)
 		return err;
 
-	no_os_udelay(100);
+	capi_wait_us(100);
 
 	axi_dac_update_bits(dac, AXI_DAC_REG_CUSTOM_CTRL,
 			    AXI_DAC_TRANSFER_DATA, 0);
@@ -499,7 +499,7 @@ int32_t axi_dac_bus_read(struct axi_dac *dac,
 	if (err)
 		return err;
 
-	no_os_udelay(100);
+	capi_wait_us(100);
 
 	no_os_axi_io_read(dac->base, AXI_DAC_CNTRL_DATA_RD, reg_data);
 
@@ -1176,7 +1176,7 @@ int32_t axi_dac_init(struct axi_dac **dac_core,
 
 	axi_dac_write(dac, AXI_DAC_REG_RATECNTRL, AXI_DAC_RATE(init->rate));
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	ret = axi_dac_init_finish(dac);
 	if (ret)

--- a/drivers/axi_core/axi_dmac/axi_dmac.c
+++ b/drivers/axi_core/axi_dmac/axi_dmac.c
@@ -38,7 +38,7 @@
 #include <stdint.h>
 #include "no_os_axi_io.h"
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 #include "axi_dmac.h"
 
@@ -523,7 +523,7 @@ int32_t axi_dmac_transfer_wait_completion(struct axi_dmac *dmac,
 	if (dmac->irq_option == IRQ_ENABLED) {
 		while (!dmac->transfer.transfer_done) {
 			timeout++;
-			no_os_mdelay(1);
+			capi_wait_ms(1);
 			if (timeout == timeout_ms) {
 				printf("Error transferring data using DMA.\n");
 				return -1;
@@ -533,7 +533,7 @@ int32_t axi_dmac_transfer_wait_completion(struct axi_dmac *dmac,
 		axi_dmac_read(dmac, AXI_DMAC_REG_IRQ_PENDING, &reg_val);
 		while (reg_val != (AXI_DMAC_IRQ_SOT | AXI_DMAC_IRQ_EOT)) {
 			timeout++;
-			no_os_mdelay(1);
+			capi_wait_ms(1);
 			if (timeout == timeout_ms) {
 				printf("Error transferring data using DMA.\n");
 				return -1;

--- a/drivers/axi_core/clk_altera_a10_fpll/clk_altera_a10_fpll.c
+++ b/drivers/axi_core/clk_altera_a10_fpll/clk_altera_a10_fpll.c
@@ -42,6 +42,7 @@
 #include "no_os_error.h"
 #include "capi_alloc.h"
 #include "clk_altera_a10_fpll.h"
+#include "capi_time.h"
 
 #define FPLL_REG_C_COUNTER0			0x10D
 #define FPLL_REG_C_COUNTER1			0x10E
@@ -103,7 +104,7 @@ uint32_t altera_a10_acquire_arbitration(struct altera_a10_fpll *fpll)
 		status = altera_a10_fpll_read(fpll, 0x280);
 		if ((status & NO_OS_BIT(2)) == 0)
 			return 0;
-		no_os_udelay(10);
+		capi_wait_us(10);
 	} while (timeout++ < 10000);
 
 	printf("%s: Failed to acquire arbitration\n", fpll->name);
@@ -308,7 +309,7 @@ int32_t altera_a10_fpll_pll_calibration_check(struct altera_a10_fpll *fpll)
 
 	/* Wait max 100ms for cal_busy to de-assert */
 	do {
-		no_os_udelay(200);
+		capi_wait_us(200);
 
 		/* Read FPLL calibration status from capability register */
 		val = altera_a10_fpll_read(fpll, 0x280);

--- a/drivers/axi_core/clk_axi_clkgen/clk_axi_clkgen.c
+++ b/drivers/axi_core/clk_axi_clkgen/clk_axi_clkgen.c
@@ -40,7 +40,7 @@
 #include "no_os_util.h"
 #include "capi_alloc.h"
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_axi_io.h"
 
 #define AXI_PCORE_VER(major, minor, letter)     ((major << 16) | (minor << 8) | letter)
@@ -462,7 +462,7 @@ int32_t axi_clkgen_set_rate(struct axi_clkgen *clkgen,
 
 	axi_clkgen_mmcm_enable(clkgen, 1);
 
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 
 	axi_clkgen_read(clkgen, AXI_CLKGEN_REG_STATUS, &reg_val);
 	if ((reg_val & AXI_CLKGEN_STATUS) == 0x0) {

--- a/drivers/axi_core/jesd204/altera_adxcvr.c
+++ b/drivers/axi_core/jesd204/altera_adxcvr.c
@@ -41,6 +41,7 @@
 #include "altera_a10_atx_pll.h"
 #include "altera_a10_cdr_pll.h"
 #include "altera_adxcvr.h"
+#include "capi_time.h"
 
 /* ADXCVR Registers */
 
@@ -104,7 +105,7 @@ void adxcvr_acquire_arbitration(struct adxcvr *xcvr,
 		val = IORD_32DIRECT(addr, status_reg * 4);
 		if ((val & NO_OS_BIT(2)) == 0)
 			return;
-		no_os_udelay(10);
+		capi_wait_us(10);
 	} while (timeout++ < 10000);
 
 	printf("%s: Failed to acquire arbitration\n", xcvr->name);
@@ -241,7 +242,7 @@ int32_t atx_pll_calibration_check(struct adxcvr *xcvr)
 
 	/* Wait max 100ms for cal_busy to de-assert */
 	do {
-		no_os_mdelay(10);
+		capi_wait_ms(10);
 
 		/* Read ATX PLL calibration status from capability register */
 		atx_pll_read(xcvr, XCVR_REG_CAPAB_ATX_PLL_STAT, &val);
@@ -279,7 +280,7 @@ int32_t adxcfg_calibration_check(struct adxcvr *xcvr, uint32_t lane,
 
 	/* Wait max 100ms for cal_busy to de-assert */
 	do {
-		no_os_udelay(100);
+		capi_wait_us(100);
 
 		/* Read PMA calibration status from capability register */
 		adxcfg_read(xcvr, lane, XCVR_REG_CAPAB_PMA, &val);
@@ -359,7 +360,7 @@ void adxcvr_finalize_lane_rate_change(struct adxcvr *xcvr)
 		adxcvr_read(xcvr, ADXCVR_REG_STATUS, &status);
 		if (status == ADXCVR_STATUS)
 			break;
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 		timeout--;
 	}
 

--- a/drivers/axi_core/jesd204/axi_adxcvr.c
+++ b/drivers/axi_core/jesd204/axi_adxcvr.c
@@ -38,7 +38,7 @@
 #include "no_os_util.h"
 #include "capi_alloc.h"
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "xilinx_transceiver.h"
 #include "axi_adxcvr.h"
 #include "no_os_print_log.h"
@@ -139,7 +139,7 @@ int32_t adxcvr_drp_wait_idle(struct adxcvr *xcvr,
 		if (!(val & ADXCVR_DRP_STATUS_BUSY))
 			return ADXCVR_DRP_STATUS_RDATA(val);
 
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 		timeout--;
 	}
 
@@ -431,7 +431,7 @@ int32_t adxcvr_status_error(struct adxcvr *xcvr)
 	uint32_t status;
 
 	do {
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 		adxcvr_read(xcvr, ADXCVR_REG_STATUS, &status);
 	} while ((timeout--) && !(status & ADXCVR_STATUS));
 
@@ -454,7 +454,7 @@ static int adxcvr_reset(struct adxcvr *xcvr)
 
 	do {
 		adxcvr_write(xcvr, ADXCVR_REG_RESETN, 0);
-		no_os_udelay(2);
+		capi_wait_us(2);
 		adxcvr_write(xcvr, ADXCVR_REG_RESETN, ADXCVR_RESETN);
 		pr_debug("%s: %s %s Reset\n",
 			 __func__,
@@ -487,7 +487,7 @@ int adxcvr_clk_enable(struct adxcvr *xcvr)
 		do {
 			adxcvr_write(xcvr, ADXCVR_REG_RESETN, ADXCVR_BUFSTATUS_RST | ADXCVR_RESETN);
 			adxcvr_write(xcvr, ADXCVR_REG_RESETN, ADXCVR_RESETN);
-			no_os_mdelay(1);
+			capi_wait_ms(1);
 			adxcvr_read(xcvr, ADXCVR_REG_STATUS, &status);
 			bufstatus_err = ((status & ADXCVR_BUFSTATUS_UNDERFLOW)
 					 || (status & ADXCVR_BUFSTATUS_OVERFLOW));

--- a/drivers/axi_core/jesd204/axi_jesd204_rx.c
+++ b/drivers/axi_core/jesd204/axi_jesd204_rx.c
@@ -36,7 +36,7 @@
 #include <inttypes.h>
 #include "no_os_clk.h"
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_util.h"
 #include "capi_alloc.h"
 #include "axi_jesd204_rx.h"
@@ -160,11 +160,11 @@ static int axi_jesd_ext_reset(struct no_os_gpio_desc *reset,
 		return 0;
 
 	no_os_gpio_set_value(reset, NO_OS_GPIO_HIGH);
-	no_os_udelay(20);
+	capi_wait_us(20);
 	no_os_gpio_set_value(reset, NO_OS_GPIO_LOW);
 
 	for (count = 0; count < 32; count++) {
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 		no_os_gpio_get_value(done, &val);
 		if (val)
 			return 0;
@@ -517,7 +517,7 @@ int32_t axi_jesd204_rx_watchdog(struct axi_jesd204_rx *jesd)
 
 		if (restart) {
 			axi_jesd204_rx_write(jesd, JESD204_RX_REG_LINK_DISABLE, 0x1);
-			no_os_mdelay(100);
+			capi_wait_ms(100);
 			axi_jesd204_rx_write(jesd, JESD204_RX_REG_LINK_DISABLE, 0x0);
 		}
 	}
@@ -817,7 +817,7 @@ static int axi_jesd204_rx_jesd204_link_running(struct jesd204_dev *jdev,
 
 	if (reason == JESD204_STATE_OP_REASON_INIT) {
 		do {
-			no_os_mdelay(4);
+			capi_wait_ms(4);
 			axi_jesd204_rx_read(jesd, JESD204_RX_REG_LINK_STATUS, &link_status);
 			link_status &= 0x3;
 		} while (link_status != JESD204_LINK_STATUS_DATA && retry--);

--- a/drivers/axi_core/jesd204/axi_jesd204_tx.c
+++ b/drivers/axi_core/jesd204/axi_jesd204_tx.c
@@ -40,7 +40,7 @@
 #include "capi_alloc.h"
 #include "axi_jesd204_tx.h"
 #include "no_os_axi_io.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 
 #define JESD204_TX_REG_VERSION			0x00
@@ -117,11 +117,11 @@ static int axi_jesd_ext_reset(struct no_os_gpio_desc *reset,
 		return 0;
 
 	no_os_gpio_set_value(reset, NO_OS_GPIO_HIGH);
-	no_os_udelay(20);
+	capi_wait_us(20);
 	no_os_gpio_set_value(reset, NO_OS_GPIO_LOW);
 
 	for (count = 0; count < 32; count++) {
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 		no_os_gpio_get_value(done, &val);
 		if (val)
 			return 0;
@@ -668,7 +668,7 @@ static int axi_jesd204_tx_jesd204_clks_enable(struct jesd204_dev *jdev,
 		axi_jesd_ext_reset(jesd->gt_reset_dp, jesd->gt_reset_done);
 
 	axi_jesd204_tx_write(jesd, JESD204_TX_REG_LINK_DISABLE, 0x1);
-	no_os_udelay(1);
+	capi_wait_us(1);
 	axi_jesd204_tx_write(jesd, JESD204_TX_REG_SYSREF_STATUS, 0x3);
 	axi_jesd204_tx_write(jesd, JESD204_TX_REG_LINK_DISABLE, 0x0);
 
@@ -710,7 +710,7 @@ static int axi_jesd204_tx_jesd204_link_running(struct jesd204_dev *jdev,
 
 	if (reason == JESD204_STATE_OP_REASON_INIT) {
 		do {
-			no_os_mdelay(4);
+			capi_wait_ms(4);
 			axi_jesd204_tx_read(jesd, JESD204_TX_REG_LINK_STATUS, &link_status);
 			link_status &= 0x3;
 		} while (link_status != JESD204_LINK_STATUS_DATA && retry--);

--- a/drivers/axi_core/spi_engine/spi_engine.c
+++ b/drivers/axi_core/spi_engine/spi_engine.c
@@ -42,7 +42,7 @@ significant delays */
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include <inttypes.h>
 
 #include "axi_dmac.h"
@@ -651,7 +651,7 @@ int32_t spi_engine_init(struct no_os_spi_desc **desc,
 
 	/* Perform a reset */
 	spi_engine_write(eng_desc, SPI_ENGINE_REG_RESET, 0x01);
-	no_os_udelay(1000);
+	capi_wait_us(1000);
 	spi_engine_write(eng_desc, SPI_ENGINE_REG_RESET, 0x00);
 
 	/* Get current data width */
@@ -880,7 +880,7 @@ int32_t spi_engine_offload_transfer(struct no_os_spi_desc *desc,
 			goto error;
 	}
 
-	no_os_udelay(1000);
+	capi_wait_us(1000);
 
 error:
 	spi_engine_queue_no_os_free(&transfer.cmds);

--- a/drivers/cdc/ad7746/ad7746.c
+++ b/drivers/cdc/ad7746/ad7746.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 #include "ad7746.h"
 
@@ -71,7 +71,7 @@ int32_t ad7746_init(struct ad7746_dev **device,
 		goto error_2;
 
 	// the device does not acknowledge for max: 200us after a reset
-	no_os_udelay(200);
+	capi_wait_us(200);
 
 	ret = ad7746_set_cap(dev, init_param->setup.cap);
 	if (ret < 0)
@@ -539,7 +539,7 @@ int32_t ad7746_calibrate(struct ad7746_dev *dev, enum ad7746_md md)
 	do {
 		// Wait an arbitrary time to avoid too many reg reads.
 		// This typically results in 1 read only.
-		no_os_mdelay(20);
+		capi_wait_ms(20);
 
 		ret = ad7746_reg_read(dev, AD7746_REG_CFG, &reg, 1);
 		if (ret < 0)

--- a/drivers/cdc/ad7746/iio_ad7746.c
+++ b/drivers/cdc/ad7746/iio_ad7746.c
@@ -3,7 +3,7 @@
 #include <inttypes.h>
 #include <math.h>
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "iio.h"
 #include "iio_ad7746.h"
 #include "no_os_util.h"
@@ -193,7 +193,7 @@ static int ad7746_iio_read_raw(void *device, char *buf, uint32_t len,
 			return ret;
 	}
 
-	no_os_mdelay(delay);
+	capi_wait_ms(delay);
 
 	switch (channel->type) {
 	case IIO_TEMP:

--- a/drivers/dac/ad3530r/ad3530r.c
+++ b/drivers/dac/ad3530r/ad3530r.c
@@ -32,7 +32,7 @@
 #include "ad3530r.h"
 #include <stdlib.h>
 #include <string.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "no_os_print_log.h"
 #include "no_os_gpio.h"
@@ -1018,7 +1018,7 @@ int ad3530r_hw_ldac_trigger(struct ad3530r_desc *desc)
 	if (ret)
 		return ret;
 
-	no_os_udelay(AD3530R_LDAC_PULSE_US);
+	capi_wait_us(AD3530R_LDAC_PULSE_US);
 
 	ret = no_os_gpio_set_value(desc->ldac, NO_OS_GPIO_HIGH);
 	if (ret)
@@ -1049,7 +1049,7 @@ int ad3530r_reset(struct ad3530r_desc *desc)
 		ret = no_os_gpio_set_value(desc->reset, NO_OS_GPIO_LOW);
 		if (ret)
 			return ret;
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 		ret = no_os_gpio_set_value(desc->reset, NO_OS_GPIO_HIGH);
 		if (ret)
 			return ret;
@@ -1062,7 +1062,7 @@ int ad3530r_reset(struct ad3530r_desc *desc)
 			return ret;
 	}
 
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	/* Default interface configuration after reset */
 	memset(&desc->spi_cfg, 0, sizeof(desc->spi_cfg));

--- a/drivers/dac/ad3552r/ad3552r.c
+++ b/drivers/dac/ad3552r/ad3552r.c
@@ -42,7 +42,7 @@
 #include "clk_axi_clkgen.h"
 #endif
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "no_os_gpio.h"
 #include "no_os_print_log.h"
@@ -1515,7 +1515,7 @@ int32_t ad3552r_reset(struct ad3552r_desc *desc)
 	 */
 	if (desc->reset) {
 		no_os_gpio_set_value(desc->reset, NO_OS_GPIO_LOW);
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 		no_os_gpio_set_value(desc->reset, NO_OS_GPIO_HIGH);
 	} else if (!desc->axi) {
 		err = _ad3552r_update_reg_field(desc,
@@ -1528,7 +1528,7 @@ int32_t ad3552r_reset(struct ad3552r_desc *desc)
 
 	if (desc->axi) {
 		/* Device init may take up to 100 ms */
-		no_os_mdelay(100);
+		capi_wait_ms(100);
 		return 0;
 	}
 
@@ -1572,7 +1572,7 @@ int32_t ad3552r_ldac_trigger(struct ad3552r_desc *desc, uint16_t mask,
 	if (NO_OS_IS_ERR_VALUE(err))
 		return err;
 
-	no_os_udelay(AD3552R_LDAC_PULSE_US);
+	capi_wait_us(AD3552R_LDAC_PULSE_US);
 	err = no_os_gpio_set_value(desc->ldac, NO_OS_GPIO_HIGH);
 	if (NO_OS_IS_ERR_VALUE(err))
 		return err;
@@ -1811,9 +1811,9 @@ int32_t ad3552r_axi_write_data(struct ad3552r_desc *desc, uint32_t *buf,
 	if (cyclic) {
 		if (cyclic_secs == 0)
 			while (true)
-				no_os_mdelay(1000);
+				capi_wait_ms(1000);
 		else
-			no_os_mdelay(cyclic_secs * 1000);
+			capi_wait_ms(cyclic_secs * 1000);
 	} else
 		axi_dmac_transfer_wait_completion(desc->dmac_ip, 10000);
 

--- a/drivers/dac/ad5460/ad5460.c
+++ b/drivers/dac/ad5460/ad5460.c
@@ -33,7 +33,7 @@
 
 #include "ad5460.h"
 #include "no_os_crc8.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
 #include "capi_alloc.h"
@@ -250,7 +250,7 @@ int ad5460_set_channel_function(struct ad5460_desc *desc,
 		return ret;
 
 	/* Datasheet delay required before transition to new desired mode */
-	no_os_udelay(200);
+	capi_wait_us(200);
 
 	ret = ad5460_reg_update(desc, AD5460_CH_FUNC_SETUP(ch),
 				AD5460_CH_FUNC_SETUP_MSK, ch_func);
@@ -488,7 +488,7 @@ int ad5460_reset(struct ad5460_desc *desc)
 			return ret;
 
 		/* Minimum RESET signal pulse duration */
-		no_os_udelay(50);
+		capi_wait_us(50);
 		ret = no_os_gpio_set_value(desc->reset_gpio, NO_OS_GPIO_HIGH);
 		if (ret)
 			return ret;
@@ -502,7 +502,7 @@ int ad5460_reset(struct ad5460_desc *desc)
 			return ret;
 	}
 	/* Time taken for device reset (datasheet value = 1ms) */
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	return 0;
 }

--- a/drivers/dac/ad552xr/ad552xr.c
+++ b/drivers/dac/ad552xr/ad552xr.c
@@ -35,7 +35,7 @@
 #include <string.h>
 #include <stdbool.h>
 #include "ad552xr.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "capi_alloc.h"
 #include "no_os_util.h"
@@ -141,7 +141,7 @@ static int ad552xr_check_scratch_pad(struct ad552xr_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	ret = ad552xr_spi_reg_read(dev, AD552XR_REG_SCRATCH_PAD, &val);
 	if (ret)
@@ -789,14 +789,14 @@ int ad552xr_hw_ldac_trigger(struct ad552xr_dev *dev,
 	if (ret)
 		return ret;
 
-	no_os_udelay(delay_us >> 1);
+	capi_wait_us(delay_us >> 1);
 
 	ret = no_os_gpio_set_value(dev->gpio_ldac_tgp[ldac_hw_sel], NO_OS_GPIO_HIGH);
 	if (ret)
 		return ret;
 
 	/* Provide delay to achieve 50% duty cycle */
-	no_os_udelay(delay_us >> 1);
+	capi_wait_us(delay_us >> 1);
 
 	return 0;
 }
@@ -923,7 +923,7 @@ int ad552xr_hw_reset(struct ad552xr_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	ret = no_os_gpio_set_value(dev->gpio_resetb, NO_OS_GPIO_HIGH);
 	if (ret)
@@ -1003,7 +1003,7 @@ int ad552xr_init(struct ad552xr_dev **device,
 		if (ret)
 			goto err_gpio;
 
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 
 		ret = no_os_gpio_set_value(dev->gpio_clearb, NO_OS_GPIO_HIGH);
 		if (ret)

--- a/drivers/dac/ad5706r/ad5706r.c
+++ b/drivers/dac/ad5706r/ad5706r.c
@@ -37,7 +37,7 @@
 #include <string.h>
 #include <stdbool.h>
 #include "ad5706r.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "no_os_print_log.h"
 #include "capi_alloc.h"
@@ -1335,7 +1335,7 @@ int ad5706r_hw_ldac_trigger(struct ad5706r_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_udelay(AD5706R_LDAC_PULSE_US);
+	capi_wait_us(AD5706R_LDAC_PULSE_US);
 
 	return no_os_gpio_set_value(dev->gpio_ldac_tgp, NO_OS_GPIO_LOW);
 }
@@ -1396,7 +1396,7 @@ int ad5706r_sw_ldac_trigger(struct ad5706r_dev *dev)
 static int ad5706r_cfg_reset(struct ad5706r_dev *dev, bool sw_reset)
 {
 	bool tmp = false;
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	/* For SW reset, address ascension mode is retained. */
 	if (sw_reset)
@@ -1454,7 +1454,7 @@ int ad5706r_hw_reset(struct ad5706r_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	ret = no_os_gpio_set_value(dev->gpio_reset, NO_OS_GPIO_HIGH);
 	if (ret)

--- a/drivers/dac/ad5710r/ad5710r.c
+++ b/drivers/dac/ad5710r/ad5710r.c
@@ -42,7 +42,7 @@
 #include "ad5710r.h"
 #include <stdlib.h>
 #include <string.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "no_os_print_log.h"
 #include "no_os_gpio.h"
@@ -845,7 +845,7 @@ int ad5710r_hw_ldac_trigger(struct ad5710r_desc *desc)
 	if (ret)
 		return ret;
 
-	no_os_udelay(AD5710R_LDAC_PULSE_US);
+	capi_wait_us(AD5710R_LDAC_PULSE_US);
 
 	ret = no_os_gpio_set_value(desc->ldac, NO_OS_GPIO_HIGH);
 	if (ret)
@@ -871,7 +871,7 @@ int ad5710r_reset(struct ad5710r_desc *desc)
 		ret = no_os_gpio_set_value(desc->reset, NO_OS_GPIO_LOW);
 		if (ret)
 			return ret;
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 		ret = no_os_gpio_set_value(desc->reset, NO_OS_GPIO_HIGH);
 		if (ret)
 			return ret;
@@ -884,7 +884,7 @@ int ad5710r_reset(struct ad5710r_desc *desc)
 			return ret;
 	}
 
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	/* Default interface configuration after reset */
 	memset(&desc->spi_cfg, 0, sizeof(desc->spi_cfg));

--- a/drivers/dac/ad5754r/ad5754r.c
+++ b/drivers/dac/ad5754r/ad5754r.c
@@ -35,7 +35,7 @@
 #include <stdlib.h>
 #include "ad5754r.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 /* AD5754R gain values scaled up to avoid float computations */
 const unsigned int ad5754r_gain_values_scaled[AD5754R_SPAN_M10V8_TO_10V8 + 1] =
@@ -219,7 +219,7 @@ int ad5754r_ldac_trigger(struct ad5754r_dev *dev)
 			return ret;
 
 		/* Delay must be greater than 20ns, per the datasheet. */
-		no_os_udelay(1);
+		capi_wait_us(1);
 
 		return no_os_gpio_set_value(dev->gpio_ldac, NO_OS_GPIO_HIGH);
 	}

--- a/drivers/dac/ad5755/ad5755.c
+++ b/drivers/dac/ad5755/ad5755.c
@@ -35,6 +35,7 @@
 #include "ad5755.h"         // AD5755 definitions.
 #include "ad5755_cfg.h"     // AD5755_cfg definitions.
 #include "capi_alloc.h"
+#include "capi_time.h"
 
 /***************************************************************************//**
  * @brief Initializes the device and powers-up all channels. The device is
@@ -90,7 +91,7 @@ int8_t ad5755_init(struct ad5755_dev **device,
 				     AD5755_MAIN_SHTCCTLIM(dev->p_ad5755_st->sht_cc_lim_bit));
 
 	ad5755_software_reset(dev);
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 	/* DC-to-DC configuration. */
 	ad5755_set_control_registers(dev,
 				     AD5755_CREG_DC_DC,
@@ -122,7 +123,7 @@ int8_t ad5755_init(struct ad5755_dev **device,
 					     dac_control_buff[channel]);
 	}
 	/* Allow at least 200us before enabling the channel output. */
-	no_os_mdelay(200);
+	capi_wait_ms(200);
 	/* Enable the channel output. */
 	for (channel = AD5755_DAC_A; channel <= AD5755_DAC_D; channel++) {
 		/* Write to each DAC data register*/

--- a/drivers/dac/ad5755/ad5755.h
+++ b/drivers/dac/ad5755/ad5755.h
@@ -35,7 +35,7 @@
 #define __AD5755_H__
 
 #include <stdint.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 

--- a/drivers/dac/ad5758/ad5758.c
+++ b/drivers/dac/ad5758/ad5758.c
@@ -32,7 +32,7 @@
 *******************************************************************************/
 
 #include "ad5758.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "no_os_gpio.h"
 #include "inttypes.h"
@@ -238,7 +238,7 @@ int32_t ad5758_soft_reset(struct ad5758_dev *dev)
 	if (ret < 0)
 		goto error;
 	/* Wait 100 us */
-	no_os_udelay(100);
+	capi_wait_us(100);
 
 	return 0;
 
@@ -514,7 +514,7 @@ int32_t ad5758_dac_output_en(struct ad5758_dev *dev, uint8_t enable)
 		pr_err("%s: Failed with code: %"PRIi32".\n", __func__, ret);
 		return -1;
 	}
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	return 0;
 }
@@ -852,7 +852,7 @@ int32_t ad5758_init(struct ad5758_dev **device,
 
 	*device = dev;
 	pr_info("ad5758 successfully initialized\n");
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	return 0;
 

--- a/drivers/dac/ad5766/ad5766.c
+++ b/drivers/dac/ad5766/ad5766.c
@@ -36,6 +36,7 @@
 #include "ad5766.h"
 #include "no_os_error.h"
 #include "capi_alloc.h"
+#include "capi_time.h"
 
 /**
  * SPI command write to device.
@@ -294,9 +295,9 @@ int32_t ad5766_init(struct ad5766_dev **device,
 	/* GPIO */
 	ret |= no_os_gpio_get(&dev->gpio_reset, &init_param.gpio_reset);
 	ret |= no_os_gpio_direction_output(dev->gpio_reset, NO_OS_GPIO_LOW);
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 	ret |= no_os_gpio_set_value(dev->gpio_reset, NO_OS_GPIO_HIGH);
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 
 	/* Device Settings */
 	dev->daisy_chain_en = init_param.daisy_chain_en;

--- a/drivers/dac/ad5766/ad5766.h
+++ b/drivers/dac/ad5766/ad5766.h
@@ -34,7 +34,7 @@
 #define AD5766_H_
 
 #include <stdint.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 

--- a/drivers/dac/ad5791/ad5791.c
+++ b/drivers/dac/ad5791/ad5791.c
@@ -35,6 +35,7 @@
 #include <stdlib.h>
 #include "ad5791.h"    // AD5791 definitions.
 #include "capi_alloc.h"
+#include "capi_time.h"
 
 static const struct ad5791_chip_info chip_info[] = {
 	[ID_AD5760] = {
@@ -284,7 +285,7 @@ int32_t ad5791_soft_instruction(struct ad5791_dev *dev,
 	if (status < 0) {
 		return status;
 	}
-	no_os_mdelay(1);    // Wait for the instruction to take effect.
+	capi_wait_ms(1);    // Wait for the instruction to take effect.
 
 	return status;
 }
@@ -430,7 +431,7 @@ int ad5791_ldac_trigger(struct ad5791_dev *dev)
 			return ret;
 
 		/* Delay must be greater than 14ns, per the datasheet. */
-		no_os_udelay(1);
+		capi_wait_us(1);
 
 		return no_os_gpio_set_value(dev->gpio_ldac, NO_OS_GPIO_HIGH);
 	}
@@ -458,7 +459,7 @@ int ad5791_clear_async(struct ad5791_dev *dev)
 			return ret;
 
 		/* Delay must be greater than 50ns, per the datasheet. */
-		no_os_udelay(1);
+		capi_wait_us(1);
 
 		return no_os_gpio_set_value(dev->gpio_clr, NO_OS_GPIO_HIGH);
 	}

--- a/drivers/dac/ad5791/ad5791.h
+++ b/drivers/dac/ad5791/ad5791.h
@@ -35,7 +35,7 @@
 #define __AD5791_H__
 
 #include <stdint.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_util.h"

--- a/drivers/dac/ad7293/ad7293.c
+++ b/drivers/dac/ad7293/ad7293.c
@@ -34,7 +34,7 @@
 #include <malloc.h>
 #include "ad7293.h"
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 
 /**
@@ -379,14 +379,14 @@ int ad7293_ch_read_raw(struct ad7293_dev *dev, enum ad7293_ch_type type,
 			if (ret)
 				return ret;
 
-			no_os_mdelay(9);
+			capi_wait_ms(9);
 		} else if (type == AD7293_ADC_ISENSE) {
 			ret = ad7293_spi_write(dev, AD7293_REG_ISENSE_BG_EN,
 					       NO_OS_BIT(ch));
 			if (ret)
 				return ret;
 
-			no_os_mdelay(9);
+			capi_wait_ms(9);
 		}
 
 		ret = ad7293_spi_write(dev, reg_wr, data_wr);
@@ -433,10 +433,10 @@ int ad7293_reset(struct ad7293_dev *dev)
 	if (dev->gpio_reset) {
 		no_os_gpio_direction_output(dev->gpio_reset, NO_OS_GPIO_LOW);
 		/* Datasheet: Minimum Reset pulse width: 90ns */
-		no_os_udelay(1);
+		capi_wait_us(1);
 		no_os_gpio_direction_output(dev->gpio_reset, NO_OS_GPIO_HIGH);
 		/* Datasheet: Minimum Reset pulse width: 90ns */
-		no_os_udelay(1);
+		capi_wait_us(1);
 
 		return 0;
 	}

--- a/drivers/dac/ad8460/ad8460.c
+++ b/drivers/dac/ad8460/ad8460.c
@@ -33,7 +33,7 @@
 
 #include "ad8460.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "no_os_spi.h"
 #include "no_os_print_log.h"
@@ -187,7 +187,7 @@ int ad8460_reset(struct ad8460_device *dev)
 		return ret;
 
 	/* minimum duration of 10ns */
-	no_os_udelay(1);
+	capi_wait_us(1);
 
 	ret = no_os_gpio_set_value(dev->gpio_rstn, NO_OS_GPIO_HIGH);
 	if (ret)
@@ -293,7 +293,7 @@ int ad8460_hv_reset(struct ad8460_device *dev)
 	if (ret)
 		return ret;
 
-	no_os_udelay(20);
+	capi_wait_us(20);
 
 	return ad8460_reg_update_bits(dev, 0x00, AD8460_HV_RESET_MSK, 0);
 }

--- a/drivers/dac/ad9144/ad9144.c
+++ b/drivers/dac/ad9144/ad9144.c
@@ -38,6 +38,7 @@
 #include "no_os_error.h"
 #include "capi_alloc.h"
 #include "no_os_print_log.h"
+#include "capi_time.h"
 
 struct ad9144_jesd204_link_mode {
 	uint8_t id;
@@ -135,7 +136,7 @@ int32_t ad9144_spi_check_status(struct ad9144_dev *dev,
 			return 0;
 		} else {
 			timeout++;
-			no_os_mdelay(1);
+			capi_wait_ms(1);
 		}
 	} while (timeout < 100);
 
@@ -680,7 +681,7 @@ static void ad9144_set_nco_freq(struct ad9144_dev *dev, uint32_t sample_rate,
 	if (mod_type == AD9144_MOD_TYPE_FINE)
 		ad9144_spi_write(dev, REG_NCO_FTW_UPDATE, 1);
 
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 }
 
 static void ad9144_setup_samplerate(struct ad9144_dev *dev)
@@ -725,7 +726,7 @@ static void ad9144_setup_samplerate(struct ad9144_dev *dev)
 	ad9144_spi_write(dev, REG_REF_CLK_DIVIDER_LDO, serdes_plldiv);
 
 	ad9144_spi_write(dev, REG_SYNTH_ENABLE_CNTRL, 0x01);	// enable serdes pll
-	no_os_mdelay(20);
+	capi_wait_ms(20);
 
 	ad9144_spi_read(dev, 0x281, &val);
 	if ((val & 0x01) == 0x00)
@@ -987,7 +988,7 @@ int32_t ad9144_setup_legacy(struct ad9144_dev **device,
 	// reset
 	ad9144_spi_write(dev, REG_SPI_INTFCONFA, SOFTRESET_M | SOFTRESET);
 	ad9144_spi_write(dev, REG_SPI_INTFCONFA, init_param->spi3wire ? 0x00 : 0x18);
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	ad9144_spi_read(dev, REG_SPI_PRODIDL, &chip_id);
 	if (chip_id != AD9144_CHIP_ID) {
@@ -1078,7 +1079,7 @@ int32_t ad9144_setup_legacy(struct ad9144_dev **device,
 	ad9144_spi_write(dev, REG_SYNTH_ENABLE_CNTRL, 0x01);	// enable serdes pll
 	ad9144_spi_write(dev, REG_SYNTH_ENABLE_CNTRL,
 			 0x05);	// enable serdes calibration
-	no_os_mdelay(20);
+	capi_wait_ms(20);
 
 	ret = ad9144_spi_check_status(dev, REG_PLL_STATUS, 0x01, 0x01);
 	if (ret == -1)
@@ -1143,7 +1144,7 @@ int32_t ad9144_setup_jesd_fsm(struct ad9144_dev **device,
 	// reset
 	ad9144_spi_write(dev, REG_SPI_INTFCONFA, SOFTRESET_M | SOFTRESET);
 	ad9144_spi_write(dev, REG_SPI_INTFCONFA, init_param->spi3wire ? 0x00 : 0x18);
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	ad9144_spi_read(dev, REG_SPI_PRODIDL, &chip_id);
 	if (chip_id != AD9144_CHIP_ID) {
@@ -1201,7 +1202,7 @@ int32_t ad9144_dac_calibrate(struct ad9144_dev *dev)
 	ad9144_spi_write(dev, REG_CAL_INDX, dac_mask);	// select all active DACs
 	ad9144_spi_write(dev, REG_CAL_CTRL, 0x01);	// single cal enable
 	ad9144_spi_write(dev, REG_CAL_CTRL, 0x03);	// single cal start
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 
 	for (i = 0; i < dev->num_converters; i++) {
 		ad9144_spi_write(dev, REG_CAL_INDX, NO_OS_BIT(i));	// read dac-i
@@ -1324,7 +1325,7 @@ int32_t ad9144_datapath_prbs_test(struct ad9144_dev *dev,
 
 	ad9144_spi_write(dev, REG_PRBS, ((init_param->prbs_type << 2) | 0x03));
 	ad9144_spi_write(dev, REG_PRBS, ((init_param->prbs_type << 2) | 0x01));
-	no_os_mdelay(500);
+	capi_wait_ms(500);
 
 	ad9144_spi_write(dev, REG_SPI_PAGEINDX, 0x01);
 	ad9144_spi_read(dev, REG_PRBS, &status);

--- a/drivers/dac/ad9144/ad9144.h
+++ b/drivers/dac/ad9144/ad9144.h
@@ -34,7 +34,7 @@
 #define AD9144_H_
 
 #include <stdint.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_spi.h"
 #include "no_os_util.h"
 #include "jesd204.h"

--- a/drivers/dac/ad9152/ad9152.c
+++ b/drivers/dac/ad9152/ad9152.c
@@ -35,6 +35,7 @@
 #include <stdio.h>
 #include "ad9152.h"
 #include "capi_alloc.h"
+#include "capi_time.h"
 
 /***************************************************************************//**
  * @brief ad9152_spi_read
@@ -108,12 +109,12 @@ int32_t ad9152_setup(struct ad9152_dev **device,
 	}
 
 	// power-up and dac initialization
-	no_os_mdelay(5);
+	capi_wait_ms(5);
 
 	ad9152_spi_write(dev, REG_SPI_INTFCONFA, SOFTRESET_M | SOFTRESET);	// reset
 	ad9152_spi_write(dev, REG_SPI_INTFCONFA, 0x00);	// reset
 
-	no_os_mdelay(4);
+	capi_wait_ms(4);
 
 	ad9152_spi_write(dev, REG_PWRCNTRL0, 0x00);	// dacs - power up everything
 	ad9152_spi_write(dev, REG_CLKCFG0, 0x00);	// clocks - power up everything
@@ -164,7 +165,7 @@ int32_t ad9152_setup(struct ad9152_dev **device,
 	ad9152_spi_write(dev, REG_SYNTH_ENABLE_CNTRL, 0x01);	// enable serdes pll
 	ad9152_spi_write(dev, REG_SYNTH_ENABLE_CNTRL,
 			 0x05);	// enable serdes calibration
-	no_os_mdelay(20);
+	capi_wait_ms(20);
 
 	ad9152_spi_read(dev, REG_PLL_STATUS, &pll_stat);
 	if (pll_stat == 0) {
@@ -233,7 +234,7 @@ int32_t ad9152_short_pattern_test(struct ad9152_dev *dev,
 					 ((sample << 4) | (dac << 2) | 0x03));
 			ad9152_spi_write(dev, REG_SHORT_TPL_TEST_0,
 					 ((sample << 4) | (dac << 2) | 0x01));
-			no_os_mdelay(1);
+			capi_wait_ms(1);
 
 			ad9152_spi_read(dev, REG_SHORT_TPL_TEST_3, &status);
 			if ((status & 0x1) == 0x1)
@@ -265,7 +266,7 @@ int32_t ad9152_datapath_prbs_test(struct ad9152_dev *dev,
 
 	ad9152_spi_write(dev, REG_PRBS, ((init_param.prbs_type << 2) | 0x03));
 	ad9152_spi_write(dev, REG_PRBS, ((init_param.prbs_type << 2) | 0x01));
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	ad9152_spi_read(dev, REG_PRBS, &status);
 	if ((status & 0xc0) != 0xc0) {

--- a/drivers/dac/ad9152/ad9152.h
+++ b/drivers/dac/ad9152/ad9152.h
@@ -34,7 +34,7 @@
 #define AD9152_H_
 
 #include <stdint.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_spi.h"
 
 #define REG_SPI_INTFCONFA                        0x000 /* Interface configuration A */

--- a/drivers/dac/ad917x/ad9172.c
+++ b/drivers/dac/ad917x/ad9172.c
@@ -32,7 +32,7 @@
 *******************************************************************************/
 
 #include "no_os_print_log.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 #include "no_os_clk.h"
 #include <inttypes.h>
@@ -187,7 +187,7 @@ static int32_t ad9172_setup(struct ad9172_state *st)
 		return ret;
 	}
 
-	no_os_mdelay(100); /* Wait 100 ms for PLL to lock */
+	capi_wait_ms(100); /* Wait 100 ms for PLL to lock */
 
 	ret = ad917x_get_dac_clk_status(ad917x_h,
 					&pll_lock_status, &dll_lock_stat);
@@ -252,7 +252,7 @@ static int32_t ad9172_setup(struct ad9172_state *st)
 		return ret;
 	}
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	ret = ad917x_jesd_get_pll_status(ad917x_h, &pll_lock_status);
 	if (ret != 0) {
@@ -296,7 +296,7 @@ static int32_t ad9172_setup(struct ad9172_state *st)
 		return -EIO;
 	}
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	ret = ad9172_link_status_get(st, lane_rate_kHz);
 	if (ret != 0) {
@@ -316,7 +316,7 @@ static int32_t ad9172_setup(struct ad9172_state *st)
  */
 static int32_t ad9172_delay_us(void *user_data, uint32_t us)
 {
-	no_os_udelay(us);
+	capi_wait_us(us);
 
 	return 0;
 }

--- a/drivers/dac/ad917x/ad9172.h
+++ b/drivers/dac/ad917x/ad9172.h
@@ -34,7 +34,7 @@
 #define __AD9172_H__
 
 #include "AD917x.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 

--- a/drivers/dac/ltc2672/ltc2672.c
+++ b/drivers/dac/ltc2672/ltc2672.c
@@ -39,7 +39,7 @@
 #include "ltc2672.h"
 #include "no_os_spi.h"
 #include "no_os_gpio.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
 #include "capi_alloc.h"
@@ -134,7 +134,7 @@ int ltc2672_reset(struct ltc2672_dev *device)
 	if (ret)
 		return ret;
 
-	no_os_udelay(1);
+	capi_wait_us(1);
 
 	ret = no_os_gpio_set_value(device->gpio_clear, NO_OS_GPIO_HIGH);
 	if (ret)
@@ -815,7 +815,7 @@ int ltc2672_hw_ldac_update(struct ltc2672_dev *device)
 	if (ret)
 		return ret;
 
-	no_os_udelay(1);
+	capi_wait_us(1);
 
 	ret = no_os_gpio_set_value(device->gpio_ldac, NO_OS_GPIO_HIGH);
 	if (ret)

--- a/drivers/dac/ltc268x/ltc268x.c
+++ b/drivers/dac/ltc268x/ltc268x.c
@@ -37,6 +37,7 @@
 #include "capi_alloc.h"
 
 #include "ltc268x.h" /* LTC268X definitions. */
+#include "capi_time.h"
 
 static const struct ltc268x_span_tbl ltc268x_span_tbl[] = {
 	[LTC268X_VOLTAGE_RANGE_0V_5V] = {0, 5},
@@ -425,7 +426,7 @@ int32_t ltc268x_init(struct ltc268x_dev **device,
 	if (ret < 0)
 		goto error;
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	dev->dev_id = init_param.dev_id;
 	if (init_param.dev_id == LTC2686) {

--- a/drivers/dac/ltc268x/ltc268x.h
+++ b/drivers/dac/ltc268x/ltc268x.h
@@ -35,7 +35,7 @@
 
 #include "no_os_spi.h"
 #include "no_os_util.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "errno.h"
 
 #define LTC268X_CHANNEL_SEL(x, id)			(id ? x : (x << 1))

--- a/drivers/dac/max22007/max22007.c
+++ b/drivers/dac/max22007/max22007.c
@@ -33,7 +33,7 @@
 #include "no_os_print_log.h"
 #include "no_os_error.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_crc8.h"
 #include "no_os_spi.h"
 #include "max22007.h"

--- a/drivers/digital-io/max22200/max22200.c
+++ b/drivers/digital-io/max22200/max22200.c
@@ -36,7 +36,7 @@
 #include "max22200.h"
 #include "no_os_util.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 /**
  * @brief Read data from desired register for MAX22200
@@ -738,7 +738,7 @@ int max22200_init(struct max22200_desc **desc,
 		goto err;
 
 	/* Time between enable pin set and device power-up. */
-	no_os_udelay(500);
+	capi_wait_us(500);
 
 	ret = no_os_gpio_get(&descriptor->cmd_desc,
 			     init_param->cmd_param);
@@ -829,7 +829,7 @@ int max22200_init(struct max22200_desc **desc,
 
 	/* Delay needed from setting active bit to 1 and configuring channels
 	   to normal operation. */
-	no_os_udelay(2500);
+	capi_wait_us(2500);
 
 	/* Reading from the status register again to clear faults. */
 	ret = max22200_reg_read(descriptor, MAX22200_STATUS_REG, &reg_val);

--- a/drivers/display/nhd_c12832a1z/nhd_c12832a1z.c
+++ b/drivers/display/nhd_c12832a1z/nhd_c12832a1z.c
@@ -35,7 +35,7 @@
 #include "nhd_c12832a1z.h"
 #include "no_os_error.h"
 #include "no_os_spi.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 #include <string.h>
 
@@ -485,7 +485,7 @@ int nhd_c12832a1z_init(struct nhd_c12832a1z_dev **device,
 		if (ret)
 			goto error_rst;
 
-		no_os_udelay(3U);
+		capi_wait_us(3U);
 		ret = no_os_gpio_set_value(dev->reset_pin, NHD_C12832A1Z_RST_OFF);
 		if (ret)
 			goto error_rst;

--- a/drivers/display/ssd_1306/ssd_1306.c
+++ b/drivers/display/ssd_1306/ssd_1306.c
@@ -36,7 +36,7 @@
 #include "no_os_error.h"
 #include "no_os_spi.h"
 #include "no_os_i2c.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include <string.h>
 
 /* @defines for ssd_1306 pins signal level */
@@ -152,93 +152,93 @@ int32_t ssd_1306_init(struct display_dev *device)
 
 	}
 	// Post reset delay, Treset=3us (See datasheet -> power on sequence)
-	no_os_udelay(3U);
+	capi_wait_us(3U);
 	if (extra->reset_pin) {
 		ret = no_os_gpio_set_value(extra->reset_pin, SSD1306_RST_OFF);
 		if (ret != 0)
 			return -1;
 	}
 
-	no_os_udelay(3U);
+	capi_wait_us(3U);
 	command[0] = 0xA8;
 	command[1] = 0x3F;
 	ret = ssd1306_buffer_transmit(extra, command, 2U, SSD1306_CMD);
 	if (ret != 0)
 		return -1;
 
-	no_os_udelay(3U);
+	capi_wait_us(3U);
 	command[0] = 0xD3;
 	command[1] = 0x00;
 	ret = ssd1306_buffer_transmit(extra, command, 2U, SSD1306_CMD);
 	if (ret != 0)
 		return -1;
 
-	no_os_udelay(3U);
+	capi_wait_us(3U);
 	command[0] = 0x40;
 	ret = ssd1306_buffer_transmit(extra, command, 1U, SSD1306_CMD);
 	if (ret != 0)
 		return -1;
 
-	no_os_udelay(3U);
+	capi_wait_us(3U);
 	command[0] = 0xA1;
 	ret = ssd1306_buffer_transmit(extra, command, 1U, SSD1306_CMD);
 	if (ret != 0)
 		return -1;
 
-	no_os_udelay(3U);
+	capi_wait_us(3U);
 	command[0] = 0xC8;
 	ret = ssd1306_buffer_transmit(extra, command, 1U, SSD1306_CMD);
 	if (ret != 0)
 		return -1;
 
-	no_os_udelay(3U);
+	capi_wait_us(3U);
 	command[0] = 0xDA;
 	command[1] = 0xD2;
 	ret = ssd1306_buffer_transmit(extra, command, 2U, SSD1306_CMD);
 	if (ret != 0)
 		return -1;
 
-	no_os_udelay(3U);
+	capi_wait_us(3U);
 	command[0] = 0x81;
 	command[1] = 0x7F;
 	ret = ssd1306_buffer_transmit(extra, command, 2U, SSD1306_CMD);
 	if (ret != 0)
 		return -1;
 
-	no_os_udelay(3U);
+	capi_wait_us(3U);
 	command[0] = 0xA4;
 	ret = ssd1306_buffer_transmit(extra, command, 1U, SSD1306_CMD);
 	if (ret != 0)
 		return -1;
 
-	no_os_udelay(3U);
+	capi_wait_us(3U);
 	command[0] = 0xA7;
 	ret = ssd1306_buffer_transmit(extra, command, 1U, SSD1306_CMD);
 	if (ret != 0)
 		return -1;
 
-	no_os_udelay(3U);
+	capi_wait_us(3U);
 	command[0] = 0xD5;
 	command[1] = 0x80;
 	ret = ssd1306_buffer_transmit(extra, command, 2U, SSD1306_CMD);
 	if (ret != 0)
 		return -1;
 
-	no_os_udelay(3U);
+	capi_wait_us(3U);
 	command[0] = 0x8D;
 	command[1] = 0x14;
 	ret = ssd1306_buffer_transmit(extra, command, 2U, SSD1306_CMD);
 	if (ret != 0)
 		return -1;
 
-	no_os_udelay(3U);
+	capi_wait_us(3U);
 	command[0] = 0xAF;
 	ret = ssd1306_buffer_transmit(extra, command, 1U, SSD1306_CMD);
 	if (ret != 0)
 		return -1;
 
 	// set addressing mode
-	no_os_udelay(3U);
+	capi_wait_us(3U);
 	command[0] = 0x20;
 	command[1] = 0x00;
 	return ssd1306_buffer_transmit(extra, command, 2U, SSD1306_CMD);

--- a/drivers/eeprom/24xx32a/24xx32a.c
+++ b/drivers/eeprom/24xx32a/24xx32a.c
@@ -40,7 +40,7 @@
 #include "no_os_eeprom.h"
 #include "no_os_i2c.h"
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_util.h"
 #include "capi_alloc.h"
 
@@ -166,7 +166,7 @@ int32_t eeprom_24xx32a_write(struct no_os_eeprom_desc *desc, uint32_t address,
 				return ret;
 
 			/* Write cycle time (typ 5msec as per datasheet) */
-			no_os_mdelay(5);
+			capi_wait_ms(5);
 		}
 	} else {
 		/* Perform byte by byte write */
@@ -179,7 +179,7 @@ int32_t eeprom_24xx32a_write(struct no_os_eeprom_desc *desc, uint32_t address,
 				return ret;
 
 			/* Write cycle time (typ 5msec as per datasheet) */
-			no_os_mdelay(5);
+			capi_wait_ms(5);
 
 			curr_address++;
 		}

--- a/drivers/eeprom/m24512/m24512.c
+++ b/drivers/eeprom/m24512/m24512.c
@@ -35,7 +35,7 @@
 
 #include "m24512.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_eeprom.h"
 
@@ -307,7 +307,7 @@ int m24512_wait_ready(struct m24512_dev *dev, uint32_t timeout_ms)
 			return 0;
 
 		// Wait 1ms between polling attempts
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 	}
 
 	return -ETIME;
@@ -350,7 +350,7 @@ static int m24512_set_write_protection(struct m24512_dev *dev, bool protect)
 
 	if (ret == 0) {
 		// Add small delay to ensure WC pin settles
-		no_os_udelay(10); // 10 microseconds should be sufficient
+		capi_wait_us(10); // 10 microseconds should be sufficient
 	}
 
 	return ret;
@@ -422,7 +422,7 @@ static int m24512_write_raw(struct m24512_dev *dev, uint16_t addr,
 
 	// Give EEPROM time to start internal write cycle
 	if (ret == 0) {
-		no_os_udelay(500);  // 500 microseconds delay
+		capi_wait_us(500);  // 500 microseconds delay
 	}
 
 	capi_free(write_buf);

--- a/drivers/frequency/ad9508/ad9508.c
+++ b/drivers/frequency/ad9508/ad9508.c
@@ -36,7 +36,7 @@
 #include <stdio.h>
 #include "no_os_error.h"
 #include "ad9508.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 
 /**
@@ -125,7 +125,7 @@ int32_t ad9508_setup(struct ad9508_dev **device,
 	if (ret != 0)
 		return ret;
 
-	no_os_mdelay(250);
+	capi_wait_ms(250);
 
 	/*
 	 * read family part id: 0x0C contains the least significant byte,

--- a/drivers/frequency/ad9517/ad9517.c
+++ b/drivers/frequency/ad9517/ad9517.c
@@ -33,7 +33,7 @@
 
 #include <stdlib.h>
 #include <errno.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 #include "ad9517.h"
 
@@ -199,7 +199,7 @@ int32_t ad9517_setup(struct ad9517_dev **device,
 			return ret;
 
 		/* Time to complete a VCO calibration (Table 29, datasheet). */
-		no_os_mdelay(88);
+		capi_wait_ms(88);
 	}
 
 	*device = dev;

--- a/drivers/frequency/ad9523/ad9523.c
+++ b/drivers/frequency/ad9523/ad9523.c
@@ -36,6 +36,7 @@
 #include <stdio.h>
 #include "ad9523.h"
 #include "capi_alloc.h"
+#include "capi_time.h"
 
 /* Helpers to avoid excess line breaks */
 #define AD_IFE(_pde, _a, _b) ((dev->pdata->_pde) ? _a : _b)
@@ -215,7 +216,7 @@ int32_t ad9523_calibrate(struct ad9523_dev *dev)
 
 	timeout = 0;
 	while (timeout < 100) {
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 		timeout = timeout + 1;
 		ad9523_spi_read(dev,
 				AD9523_READBACK_1,
@@ -271,7 +272,7 @@ int32_t ad9523_status(struct ad9523_dev *dev)
 
 	timeout = 0;
 	while (timeout < 100) {
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 		timeout = timeout + 1;
 		ad9523_spi_read(dev,
 				AD9523_READBACK_0,
@@ -448,7 +449,7 @@ int32_t ad9523_setup(struct ad9523_dev **device,
 				AD9523_SER_CONF_SDO_ACTIVE));
 	if (ret < 0)
 		return ret;
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	ret = ad9523_spi_write(dev,
 			       AD9523_READBACK_CTRL,

--- a/drivers/frequency/ad9523/ad9523.h
+++ b/drivers/frequency/ad9523/ad9523.h
@@ -35,7 +35,7 @@
 #define _AD9523_H_
 
 #include <stdint.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_spi.h"
 
 /* Registers */

--- a/drivers/frequency/ad9528/ad9528.c
+++ b/drivers/frequency/ad9528/ad9528.c
@@ -41,6 +41,7 @@
 #include "no_os_clk.h"
 #include "ad9528.h"
 #include "jesd204.h"
+#include "capi_time.h"
 
 struct ad9528_jesd204_priv {
 	struct ad9528_dev *device;
@@ -215,7 +216,7 @@ int32_t ad9528_poll(struct ad9528_dev *dev,
 					&reg_data);
 		if (ret < 0)
 			return ret;
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 	} while (((reg_data & mask) != data) && --timeout);
 
 	return timeout ? 0 : -1;
@@ -584,7 +585,7 @@ static int ad9528_jesd204_sysref(struct jesd204_dev *jdev)
 
 	if (dev->sysref_req_gpio && dev->pdata->sysref_req_en) {
 		no_os_gpio_direction_output(dev->sysref_req_gpio, 1);
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 		ret = no_os_gpio_direction_output(dev->sysref_req_gpio, 0);
 	} else {
 		ret = ad9528_spi_read_n(dev, AD9528_SYSREF_CTRL, &val);
@@ -1298,12 +1299,12 @@ int32_t ad9528_reset(struct ad9528_dev *dev)
 		if (s < 0)
 			return s;
 
-		no_os_mdelay(100);
+		capi_wait_ms(100);
 
 		s = no_os_gpio_direction_output(dev->gpio_resetb, 1);
 		if (s < 0)
 			return s;
-		no_os_mdelay(100);
+		capi_wait_ms(100);
 	}
 
 	s = ad9528_spi_write_n(dev,
@@ -1314,13 +1315,13 @@ int32_t ad9528_reset(struct ad9528_dev *dev)
 	if (s < 0)
 		return s;
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	s = ad9528_spi_write_n(dev, AD9528_SERIAL_PORT_CONFIG_B, 0x00);
 	if (s < 0)
 		return s;
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	return 0;
 }

--- a/drivers/frequency/ad9528/ad9528.h
+++ b/drivers/frequency/ad9528/ad9528.h
@@ -35,7 +35,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_spi.h"
 #include "no_os_gpio.h"
 

--- a/drivers/frequency/ad9545/ad9545.c
+++ b/drivers/frequency/ad9545/ad9545.c
@@ -42,6 +42,7 @@
 #include "ad9545.h"
 #include "capi_alloc.h"
 #include "sys/types.h"
+#include "capi_time.h"
 
 static const char *ad9545_aux_dpll_name = "AUX_DPLL";
 
@@ -1581,12 +1582,12 @@ int32_t ad9545_init(struct ad9545_dev **device,
 
 	*device = dev;
 	printf("ad9545 successfully initialized\n");
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 	return ret;
 error:
 	printf("ad9545 initialization error (%d)\n", ret);
 	capi_free(dev);
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 	return ret;
 }
 
@@ -1855,7 +1856,7 @@ static int ad9545_calib_system_clock(struct ad9545_dev *dev)
 		}
 
 		/* wait for sys pll to lock and become stable */
-		no_os_mdelay(50 + AD9545_SYS_CLK_STABILITY_MS);
+		capi_wait_ms(50 + AD9545_SYS_CLK_STABILITY_MS);
 
 		ret = ad9545_read_reg(dev, AD9545_PLL_STATUS, &reg);
 		if (ret)
@@ -2013,7 +2014,7 @@ static int ad9545_calib_apll(struct ad9545_dev *dev, int i)
 			return ret;
 
 		cal_count += 1;
-		no_os_mdelay(100);
+		capi_wait_ms(100);
 
 		ret = ad9545_read_reg(dev, AD9545_PLLX_STATUS(i), &reg);
 		if (ret)

--- a/drivers/frequency/ad9545/ad9545.h
+++ b/drivers/frequency/ad9545/ad9545.h
@@ -36,7 +36,7 @@
 
 #include <stdint.h>
 #include "no_os_util.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_clk.h"
 #include "no_os_gpio.h"
 #include "no_os_i2c.h"

--- a/drivers/frequency/ad9553/ad9553.c
+++ b/drivers/frequency/ad9553/ad9553.c
@@ -36,7 +36,7 @@
 #include <stdio.h>
 #include "no_os_error.h"
 #include "ad9553.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 
 /**
@@ -121,7 +121,7 @@ int32_t ad9553_setup(struct ad9553_dev **device,
 	if (ret != 0)
 		return ret;
 
-	no_os_mdelay(250);
+	capi_wait_ms(250);
 
 	// enable SPI control of charge pump
 	ret = ad9553_reg_write(dev, AD9553_PLL_CHARGE_PUMP_PFD_CTRL, 0xB0);
@@ -172,7 +172,7 @@ int32_t ad9553_setup(struct ad9553_dev **device,
 	if (ret != 0)
 		return ret;
 
-	no_os_mdelay(250);
+	capi_wait_ms(250);
 
 	// RefA = 10
 	// RefA[13:6] divider

--- a/drivers/frequency/ad9833/ad9833.c
+++ b/drivers/frequency/ad9833/ad9833.c
@@ -35,6 +35,7 @@
 #include "ad9833.h"
 #include "no_os_error.h"
 #include "capi_alloc.h"
+#include "capi_time.h"
 
 float phase_const = 651.8986469f;
 
@@ -110,7 +111,7 @@ int8_t ad9833_init(struct ad9833_dev **device,
 	spi_data |= AD9833_CTRLRESET;
 	ad9833_tx_spi(dev,
 		      spi_data);
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 	spi_data &= ~AD9833_CTRLRESET;
 	ad9833_tx_spi(dev,
 		      spi_data);
@@ -168,7 +169,7 @@ void ad9833_tx_spi(struct ad9833_dev *dev,
 		spi_data |= AD9833_CTRLRESET;
 		ad9833_tx_spi(dev,
 			      spi_data);
-		no_os_mdelay(10);
+		capi_wait_ms(10);
 		spi_data &= ~ AD9833_CTRLRESET;
 		ad9833_tx_spi(dev,
 			      spi_data);

--- a/drivers/frequency/ad9833/ad9833.h
+++ b/drivers/frequency/ad9833/ad9833.h
@@ -34,7 +34,7 @@
 #define _AD9833_H_
 
 #include <stdint.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 

--- a/drivers/frequency/adf4030/adf4030.c
+++ b/drivers/frequency/adf4030/adf4030.c
@@ -33,7 +33,7 @@
 
 #include "adf4030.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "no_os_print_log.h"
 
@@ -217,7 +217,7 @@ static int adf4030_poll(struct adf4030_dev *dev, uint32_t reg_addr,
 				       &reg_data);
 		if (ret)
 			return ret;
-		no_os_mdelay(2);
+		capi_wait_ms(2);
 	} while (((reg_data & mask) != data) && --timeout);
 
 	return timeout ? 0 : -ETIMEDOUT;
@@ -261,7 +261,7 @@ int adf4030_set_default_regs(struct adf4030_dev *dev, bool spi_4wire)
 	if (ret)
 		return ret;
 
-	no_os_udelay(ADF4030_POR_DELAY_US);
+	capi_wait_us(ADF4030_POR_DELAY_US);
 
 	ret = adf4030_spi_write(dev, 0x00,
 				ADF4030_SPI_4W_CFG(spi_4wire) |

--- a/drivers/frequency/adf4030/iio_adf4030.c
+++ b/drivers/frequency/adf4030/iio_adf4030.c
@@ -38,7 +38,7 @@
 #include "iio_adf4030.h"
 #include "adf4030.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 /**
  * @brief Wrapper for reading adf4030 register.

--- a/drivers/frequency/adf4106/adf4106.c
+++ b/drivers/frequency/adf4106/adf4106.c
@@ -34,6 +34,7 @@
 #include <stdlib.h>
 #include "adf4106.h"
 #include "capi_alloc.h"
+#include "capi_time.h"
 
 #define DATA_MASK_MSB8      0xFF0000
 #define DATA_OFFSET_MSB8    16
@@ -278,7 +279,7 @@ void adf4106_init_cepin_method(struct adf4106_dev *dev)
 	/* Bring CE high to take the device out of power-down */
 	ADF4106_CE_HIGH;
 	/* Wait for the input buffer bias to reach steady state */
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 }
 
 /**************************************************************************//**

--- a/drivers/frequency/adf4106/adf4106.h
+++ b/drivers/frequency/adf4106/adf4106.h
@@ -35,7 +35,7 @@
 #define __ADF4106_H__
 
 #include <stdint.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 

--- a/drivers/frequency/adf4368/adf4368.c
+++ b/drivers/frequency/adf4368/adf4368.c
@@ -33,7 +33,7 @@
 
 #include "adf4368.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "no_os_print_log.h"
 
@@ -1576,7 +1576,7 @@ int adf4368_set_default_regs(struct adf4368_dev *dev, bool spi_4wire)
 	if (ret)
 		return ret;
 
-	no_os_udelay(ADF4368_POR_DELAY_US);
+	capi_wait_us(ADF4368_POR_DELAY_US);
 
 	ret = adf4368_spi_write(dev, 0x00,
 				ADF4368_SPI_4W_CFG(spi_4wire) |
@@ -1876,7 +1876,7 @@ int adf4368_set_freq(struct adf4368_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(ADF4368_LKD_DELAY_MS);
+	capi_wait_ms(ADF4368_LKD_DELAY_MS);
 	ret = adf4368_spi_read(dev, 0x58, &val);
 	if (ret)
 		return ret;

--- a/drivers/frequency/adf4368/iio_adf4368.c
+++ b/drivers/frequency/adf4368/iio_adf4368.c
@@ -38,7 +38,7 @@
 #include "iio_adf4368.h"
 #include "adf4368.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 /**
  * @brief Supported charge pump currents

--- a/drivers/frequency/adf4377/adf4377.c
+++ b/drivers/frequency/adf4377/adf4377.c
@@ -36,7 +36,7 @@
 #include <stdlib.h>
 #include "adf4377.h"
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 #include "no_os_print_log.h"
 #include "no_os_util.h"
@@ -433,7 +433,7 @@ int adf4377_soft_reset(struct adf4377_dev *dev, bool spi_4wire)
 	if (ret < 0)
 		return ret;
 
-	no_os_udelay(ADF4377_POR_DELAY_US);
+	capi_wait_us(ADF4377_POR_DELAY_US);
 
 	/* SPI Configuration */
 	ret = adf4377_spi_write(dev, 0x00,
@@ -852,7 +852,7 @@ int adf4377_set_freq(struct adf4377_dev *dev)
 	if (ret < 0)
 		return ret;
 
-	no_os_udelay(ADF4377_LKD_DELAY_US);
+	capi_wait_us(ADF4377_LKD_DELAY_US);
 	ret = adf4377_spi_read(dev, 0x49, &val);
 	if (ret)
 		return ret;
@@ -1173,7 +1173,7 @@ int adf4377_set_en_sysref_monitor(struct adf4377_dev *dev, bool en)
 		if (ret)
 			return ret;
 
-		no_os_udelay(ADF4377_SR_MON_DELAY_US);
+		capi_wait_us(ADF4377_SR_MON_DELAY_US);
 
 		ret = adf4377_spi_update_bit(dev, 0x42, ADF4377_RST_SR_MON_MSK,
 					     ADF4377_RST_SR_MON(!en));

--- a/drivers/frequency/adf4382/adf4382.c
+++ b/drivers/frequency/adf4382/adf4382.c
@@ -34,7 +34,7 @@
 
 #include "adf4382.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "no_os_print_log.h"
 #include "no_os_util.h"
@@ -854,7 +854,7 @@ int adf4382_set_en_fast_calibration(struct adf4382_dev *dev, bool en_fast_cal)
 	while (fsm_busy == 1) {
 		if (timeout++ > ADF4382_FSM_BUSY_LOOP_CNT)
 			break;
-		no_os_mdelay(10);
+		capi_wait_ms(10);
 		ret = adf4382_spi_read(dev, 0x58, &val);
 		if (ret)
 			return ret;
@@ -1586,7 +1586,7 @@ int adf4382_set_freq(struct adf4382_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_udelay(ADF4382_LKD_DELAY_US);
+	capi_wait_us(ADF4382_LKD_DELAY_US);
 	ret = adf4382_spi_read(dev, 0x58, &val);
 	if (ret)
 		return ret;
@@ -2048,7 +2048,7 @@ int adf4382_init(struct adf4382_dev **dev,
 	if (ret)
 		goto error_spi;
 
-	no_os_udelay(ADF4382_POR_DELAY_US);
+	capi_wait_us(ADF4382_POR_DELAY_US);
 
 	if (device->spi_3wire_en)
 		en = false;

--- a/drivers/frequency/adf5355/adf5355.c
+++ b/drivers/frequency/adf5355/adf5355.c
@@ -35,7 +35,7 @@
 #include <stdio.h>
 #include "no_os_error.h"
 #include <malloc.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_util.h"
 #include "capi_alloc.h"
 #include "adf5355.h"
@@ -166,7 +166,7 @@ static int32_t adf5355_reg_config(struct adf5355_dev *dev, bool sync_all)
 			return ret;
 	}
 
-	no_os_udelay(dev->delay_us);
+	capi_wait_us(dev->delay_us);
 
 	return adf5355_write(dev, ADF5355_REG(0), dev->regs[0]);
 }

--- a/drivers/frequency/adf5611/adf5611.c
+++ b/drivers/frequency/adf5611/adf5611.c
@@ -35,7 +35,7 @@
 #include "capi_alloc.h"
 #include "no_os_error.h"
 #include "no_os_print_log.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 //Charge pump current values expressed in uA
 static const int adf5611_cp_ua[] = {
@@ -860,7 +860,7 @@ int adf5611_set_freq(struct adf5611_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_udelay(ADF5611_LKD_DELAY_US);
+	capi_wait_us(ADF5611_LKD_DELAY_US);
 	ret = adf5611_spi_read(dev, 0x48, &val);
 	if (ret)
 		return ret;
@@ -919,7 +919,7 @@ int adf5611_init(struct adf5611_dev **dev,
 	if (ret)
 		goto error_spi;
 
-	no_os_udelay(ADF5611_POR_DELAY_US);
+	capi_wait_us(ADF5611_POR_DELAY_US);
 
 	/* Setup SPI for 4 Wire */
 	ret = adf5611_spi_write(device, 0x00, ADF5611_SPI_4W_CFG(device->spi4wire));

--- a/drivers/frequency/adf5611/iio_adf5611.c
+++ b/drivers/frequency/adf5611/iio_adf5611.c
@@ -38,7 +38,7 @@
 #include "iio_adf5611.h"
 #include "adf5611.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 /**
  * @brief Supported charge pump currents

--- a/drivers/frequency/adf5902/adf5902.c
+++ b/drivers/frequency/adf5902/adf5902.c
@@ -34,7 +34,7 @@
 #include <malloc.h>
 #include "adf5902.h"
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_util.h"
 #include "capi_alloc.h"
 
@@ -326,7 +326,7 @@ static int32_t adf5902_vco_freq_calib(struct adf5902_dev *dev)
 		return ret;
 
 	/* Required 1200us delay */
-	no_os_udelay(1200);
+	capi_wait_us(1200);
 
 	/* Tx1 on, Tx2 off, LO on */
 	ret = adf5902_write(dev, ADF5902_REG0, ADF5902_REG0_RESERVED |
@@ -355,7 +355,7 @@ static int32_t adf5902_vco_freq_calib(struct adf5902_dev *dev)
 		return ret;
 
 	/* Required 500us delay */
-	no_os_udelay(500);
+	capi_wait_us(500);
 
 	/* Tx1 off, Tx2 on, LO on */
 	ret = adf5902_write(dev, ADF5902_REG0, ADF5902_REG0_RESERVED |
@@ -384,7 +384,7 @@ static int32_t adf5902_vco_freq_calib(struct adf5902_dev *dev)
 		return ret;
 
 	/* Required 500us delay */
-	no_os_udelay(500);
+	capi_wait_us(500);
 
 	return ret;
 }
@@ -444,7 +444,7 @@ static int32_t adf5902_vco_normal_op(struct adf5902_dev *dev)
 	if (ret != 0)
 		return ret;
 
-	no_os_udelay(100);
+	capi_wait_us(100);
 
 	/* Set Ramp Mode */
 	ret = adf5902_write(dev, ADF5902_REG11, ADF5902_REG11_RESERVED |
@@ -577,7 +577,7 @@ int32_t adf5902_init(struct adf5902_dev **device,
 		goto error_spi;
 
 	/* Required delay */
-	no_os_udelay(10);
+	capi_wait_us(10);
 
 	/* Start VCO Frequency Calibration */
 	ret = adf5902_vco_freq_calib(dev);
@@ -748,7 +748,7 @@ int32_t adf5902_read_temp(struct adf5902_dev *dev, float *temp)
 		return ret;
 
 	/* Make sure ADC conversion is finished */
-	no_os_udelay(1200);
+	capi_wait_us(1200);
 
 	/* Read ADC Data */
 	reg_data = ADF5902_REG3_IO_LVL(ADF5902_IO_LVL_3V3) |
@@ -846,7 +846,7 @@ int32_t adf5902f_compute_frequency(struct adf5902_dev *dev, uint64_t *freq)
 	}
 
 	/* Add minumum required delay */
-	no_os_udelay(delay);
+	capi_wait_us(delay);
 
 	/* Read Frequency Data 2 */
 	freq2 = ADF5902_REG3_IO_LVL(ADF5902_IO_LVL_3V3) |

--- a/drivers/frequency/adrf6780/adrf6780.c
+++ b/drivers/frequency/adrf6780/adrf6780.c
@@ -34,7 +34,7 @@
 #include <malloc.h>
 #include "adrf6780.h"
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 
 /**
@@ -216,7 +216,7 @@ int adrf6780_read_adc_raw(struct adrf6780_dev *dev, uint16_t *data)
 		return ret;
 
 	/* Recommended delay for the ADC to be ready */
-	no_os_udelay(200);
+	capi_wait_us(200);
 
 	ret = adrf6780_spi_read(dev, ADRF6780_REG_ADC_OUTPUT, data);
 	if (ret)

--- a/drivers/frequency/hmc7044/hmc7044.c
+++ b/drivers/frequency/hmc7044/hmc7044.c
@@ -41,6 +41,7 @@
 #include "no_os_clk.h"
 #include "hmc7044.h"
 #include "jesd204.h"
+#include "capi_time.h"
 
 #define HMC7044_WRITE		(0 << 15)
 #define HMC7044_READ		(1 << 15)
@@ -358,7 +359,7 @@ static int hmc7044_toggle_bit(struct hmc7044_dev *dev,
 		return ret;
 
 	if (us_delay)
-		no_os_udelay(us_delay);
+		capi_wait_us(us_delay);
 
 	return 0;
 }
@@ -488,7 +489,7 @@ static int hmc7044_info(struct hmc7044_dev *dev)
 			return ret;
 
 		if (HMC7044_PLL1_FSM_STATE(pll1_stat) != 2) { /* Lock */
-			no_os_mdelay(NO_OS_DIV_ROUND_UP(5000, dev->pll1_loop_bw));
+			capi_wait_ms(NO_OS_DIV_ROUND_UP(5000, dev->pll1_loop_bw));
 			ret = hmc7044_read(dev,
 					   HMC7044_REG_PLL1_STATUS, &pll1_stat);
 			if (ret < 0)
@@ -844,7 +845,7 @@ static int32_t hmc7044_setup(struct hmc7044_dev *dev)
 			return ret;
 	}
 
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 
 	/* Program the output channels */
 	for (i = 0; i < dev->num_channels; i++) {
@@ -891,7 +892,7 @@ static int32_t hmc7044_setup(struct hmc7044_dev *dev)
 		if (ret)
 			return ret;
 	}
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 
 	/* Do a restart to reset the system and initiate calibration */
 	ret = hmc7044_toggle_bit(dev, HMC7044_REG_REQ_MODE_0,
@@ -958,9 +959,9 @@ static int32_t hmc7043_setup(struct hmc7044_dev *dev)
 
 	/* Resets all registers to default values */
 	hmc7044_write(dev, HMC7044_REG_SOFT_RESET, HMC7044_SOFT_RESET);
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 	hmc7044_write(dev, HMC7044_REG_SOFT_RESET, 0);
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 
 	hmc7044_read_write_check(dev);
 
@@ -1039,17 +1040,17 @@ static int32_t hmc7043_setup(struct hmc7044_dev *dev)
 			       0 : HMC7044_HI_PERF_MODE) | HMC7044_SYNC_EN |
 			      HMC7044_CH_EN);
 	}
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 
 
 	/* Do a restart to reset the system and initiate calibration */
 	hmc7044_write(dev, HMC7044_REG_REQ_MODE_0,
 		      HMC7044_RESTART_DIV_FSM);
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 	hmc7044_write(dev, HMC7044_REG_REQ_MODE_0,
 		      (dev->high_performance_mode_clock_dist_en ?
 		       HMC7044_HIGH_PERF_DISTRIB_PATH : 0));
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	return 0;
 }
@@ -1249,7 +1250,7 @@ reseed:
 
 		hmc7044_write(hmc, HMC7044_REG_PULSE_GEN,
 			      HMC7044_PULSE_GEN_MODE(HMC7044_PULSE_GEN_LEVEL_SENSITIVE));
-		no_os_mdelay(10);
+		capi_wait_ms(10);
 	}
 
 	if (!hmc->sync_pin_mode) {
@@ -1287,7 +1288,7 @@ static int hmc7044_jesd204_clks_sync2(struct jesd204_dev *jdev,
 		int ret = hmc7044_jesd204_sysref(jdev);
 		if (ret)
 			return ret;
-		no_os_mdelay(2);
+		capi_wait_ms(2);
 	}
 
 	return JESD204_STATE_CHANGE_DONE;
@@ -1322,7 +1323,7 @@ static int hmc7044_jesd204_clks_sync3(struct jesd204_dev *jdev,
 
 		if (hmc->sync_pin_mode) {
 			while (HMC7044_SYSREF_SYNC_STAT(val)) {
-				no_os_mdelay(2);
+				capi_wait_ms(2);
 
 				ret = hmc7044_read(hmc, HMC7044_REG_ALARM_READBACK, &val);
 				if (ret < 0) {

--- a/drivers/frequency/hmc7044/hmc7044.h
+++ b/drivers/frequency/hmc7044/hmc7044.h
@@ -35,7 +35,7 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_spi.h"
 
 struct hmc7044_chan_spec {

--- a/drivers/gmsl/deserializer/camera/max96792/max96792_csi.c
+++ b/drivers/gmsl/deserializer/camera/max96792/max96792_csi.c
@@ -33,6 +33,7 @@
 
 #include "max96792_csi.h"
 #include "max96792_regs.h"
+#include "capi_time.h"
 /** \addtogroup ADI_GMSL_CAM_DESERIALIZER GMSL Camera Deserializers
  *  @{
  */
@@ -696,7 +697,7 @@ int max96792_csi_select_links(struct gmsl_dev *dev, unsigned int mask)
 	do {
 		REG_UPDATE_BREAK_ON_ERR(ret, dev->i2c_desc, GMSL1_COMMON_GMSL1_EN_ADDR, mask,
 					LINK_EN_A_GMSL1_COMMON_GMSL1_EN_MASK | LINK_EN_B_GMSL1_COMMON_GMSL1_EN_MASK);
-		no_os_mdelay(60);
+		capi_wait_ms(60);
 
 	} while (false);
 

--- a/drivers/gmsl/deserializer/camera/max96792/max96792_csi.h
+++ b/drivers/gmsl/deserializer/camera/max96792/max96792_csi.h
@@ -38,7 +38,7 @@
 #include "gmsl_cam_des.h"
 #include "gmsl_dbg.h"
 #include "gmsl_reg_access.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "max96792.h"
 

--- a/drivers/gmsl/deserializer/camera/max96792/max96792_diag.c
+++ b/drivers/gmsl/deserializer/camera/max96792/max96792_diag.c
@@ -38,7 +38,7 @@
 #include "gmsl_dbg.h"
 #include "gmsl_reg_access.h"
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 /** \addtogroup ADI_GMSL_CAM_DESERIALIZER GMSL Camera Deserializers
  *  @{
  */
@@ -504,7 +504,7 @@ int max96792_csi_diag_check_mipi_status(struct gmsl_dev *dev, void *mipi_status,
 				phy_pkt_cnt_sum[mipi_phy_index] +=
 					mipi_stat->phy_pkt_cnt[mipi_phy_index][pkt_index];
 
-				no_os_mdelay(10); /* Delay to read the next packet count */
+				capi_wait_ms(10); /* Delay to read the next packet count */
 			}
 			BREAK_ON_ERR(ret);
 			if (csi2_pkt_cnt_sum[csi_index] == 0u) {

--- a/drivers/gmsl/serializer/camera/max96793/max96793_csi.c
+++ b/drivers/gmsl/serializer/camera/max96793/max96793_csi.c
@@ -36,6 +36,7 @@
 #include "gmsl_reg_access.h"
 #include "no_os_error.h"
 #include "max96793_regs.h"
+#include "capi_time.h"
 /** \addtogroup ADI_GMSL_CAM_SERIALIZER GMSL Camera Serializers
  *  @{
  */
@@ -347,13 +348,13 @@ int max96793_gpio_cam_cfg(struct gmsl_dev *dev)
 	int ret = 0;
 	do {
 		REG_WRITE_BREAK_ON_ERR(ret, dev->i2c_desc, GPIO0_0_GPIO_A_ADDR, 0x90);
-		no_os_mdelay(100);
+		capi_wait_ms(100);
 		REG_WRITE_BREAK_ON_ERR(ret, dev->i2c_desc, GPIO0_0_GPIO_B_ADDR, 0X60);
-		no_os_mdelay(100);
+		capi_wait_ms(100);
 		REG_WRITE_BREAK_ON_ERR(ret, dev->i2c_desc, REF_VTG_REF_VTG1_ADDR, 0X89);
-		no_os_mdelay(100);
+		capi_wait_ms(100);
 		REG_WRITE_BREAK_ON_ERR(ret, dev->i2c_desc, MISC_PIO_SLEW_1_ADDR, 0X0C);
-		no_os_mdelay(100);
+		capi_wait_ms(100);
 	} while (false);
 	return ret;
 }

--- a/drivers/gmsl/serializer/camera/max96793/max96793_csi.h
+++ b/drivers/gmsl/serializer/camera/max96793/max96793_csi.h
@@ -36,7 +36,7 @@
 
 #include "gmsl_common.h"
 #include "gmsl_cam_ser.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 int32_t max96793_csi_change_ser_address(struct gmsl_dev *dev,
 					unsigned int new_addr);
 

--- a/drivers/gmsl/serializer/camera/max96793/max96793_diag.c
+++ b/drivers/gmsl/serializer/camera/max96793/max96793_diag.c
@@ -38,7 +38,7 @@
 #include "no_os_error.h"
 #include "max96793_regs.h"
 #include "max96793.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 /** \addtogroup ADI_GMSL_CAM_SERIALIZER GMSL Camera Serializers
  *  @{
@@ -1798,7 +1798,7 @@ int max96793_csi_diag_check_mipi_phy_pkt_cnt_status(struct gmsl_dev *dev,
 
 			phy_clk_cnt_sum += mipi_pkt_cnt_err_sts->phy_clk_cnt[index];
 
-			no_os_mdelay(
+			capi_wait_ms(
 				MAX96793_CSI_DIAG_MIPI_PKT_READ_DELAY); /* Delay to read the next packet count */
 		}
 

--- a/drivers/gnss-gps/nmea_ubx/nmea_ubx.c
+++ b/drivers/gnss-gps/nmea_ubx/nmea_ubx.c
@@ -40,7 +40,7 @@
 #include "no_os_uart.h"
 #include "no_os_gpio.h"
 #include "no_os_irq.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 #include "no_os_print_log.h"
 #include <stdlib.h>
@@ -176,7 +176,7 @@ int gnss_init(struct gnss_dev **device,
 		if (ret)
 			pr_warning("Failed to enable NMEA input protocol: %d\n", ret);
 
-		no_os_mdelay(100);
+		capi_wait_ms(100);
 
 		/* flush the UART port */
 		scrap = capi_calloc(500, sizeof(uint8_t));
@@ -263,7 +263,7 @@ int gnss_hw_reset(struct gnss_dev *dev)
 		return ret;
 
 	/* Hold reset for 100ms */
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	/* Release reset */
 	ret = no_os_gpio_set_value(dev->gpio_reset, NO_OS_GPIO_HIGH);
@@ -271,7 +271,7 @@ int gnss_hw_reset(struct gnss_dev *dev)
 		return ret;
 
 	/* Wait for device to boot */
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	return 0;
 }
@@ -294,7 +294,7 @@ int gnss_ubx_sw_reset(struct gnss_dev *dev)
 		return ret;
 
 	/* Wait for reset to complete */
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	return 0;
 }
@@ -1029,7 +1029,7 @@ int gnss_ubx_configure_baudrate(struct gnss_dev *dev,
 	}
 
 	/* Small delay to allow configuration to take effect */
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	return 0;
 }
@@ -1563,7 +1563,7 @@ int gnss_configure_baudrate_via_nmea(struct gnss_dev *dev,
 	}
 
 	/* Wait for command to take effect */
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	return 0;
 }
@@ -1619,7 +1619,7 @@ int gnss_configure_messages_via_nmea(struct gnss_dev *dev,
 					   constellation_prefixes[j], messages_to_disable[i], ret);
 			}
 
-			no_os_mdelay(50); /* Short delay between commands */
+			capi_wait_ms(50); /* Short delay between commands */
 		}
 	}
 
@@ -1640,7 +1640,7 @@ int gnss_configure_messages_via_nmea(struct gnss_dev *dev,
 				   ret);
 		}
 
-		no_os_mdelay(50); /* Short delay between commands */
+		capi_wait_ms(50); /* Short delay between commands */
 	}
 
 	/* Disable all RMC variants except the one we want to enable */
@@ -1664,7 +1664,7 @@ int gnss_configure_messages_via_nmea(struct gnss_dev *dev,
 				 rmc_variants[i], ret);
 		}
 
-		no_os_mdelay(50); /* Short delay between commands */
+		capi_wait_ms(50); /* Short delay between commands */
 	}
 
 	/* Enable the desired RMC message at specified rate */
@@ -1680,7 +1680,7 @@ int gnss_configure_messages_via_nmea(struct gnss_dev *dev,
 		return ret;
 	}
 
-	no_os_mdelay(500); /* Wait for configuration to take effect */
+	capi_wait_ms(500); /* Wait for configuration to take effect */
 
 	/* Enable GPGGA at 1Hz (will be read every 10th cycle in software) */
 	snprintf(sentence_content, sizeof(sentence_content), "MSG,%s,1", target_gga);
@@ -1694,7 +1694,7 @@ int gnss_configure_messages_via_nmea(struct gnss_dev *dev,
 		/* Non-fatal - continue without position data */
 	}
 
-	no_os_mdelay(500); /* Wait for configuration to take effect */
+	capi_wait_ms(500); /* Wait for configuration to take effect */
 
 	return 0;
 }
@@ -1745,7 +1745,7 @@ int gnss_configure_nmea_device(struct gnss_dev *dev,
 		if (ret < 0) {
 			pr_warning("Failed to send time sync command %d: %d\n", i + 1, ret);
 		}
-		no_os_mdelay(1000); /* Wait between commands */
+		capi_wait_ms(1000); /* Wait between commands */
 	}
 
 	return 0;
@@ -2016,7 +2016,7 @@ int gnss_get_nmea_timing_data(struct gnss_dev *dev,
 		}
 
 		attempts++;
-		no_os_mdelay(100);  /* Small delay between attempts */
+		capi_wait_ms(100);  /* Small delay between attempts */
 	}
 
 	pr_warning("Failed to get valid GPRMC data after %d attempts\n", max_attempts);
@@ -2055,7 +2055,7 @@ static int gnss_get_nmea_position_data_internal(struct gnss_dev *dev,
 		}
 
 		attempts++;
-		no_os_mdelay(100);  /* Small delay between attempts */
+		capi_wait_ms(100);  /* Small delay between attempts */
 	}
 
 	pr_debug("Failed to get valid GPGGA data after %d attempts\n", max_attempts);

--- a/drivers/gnss-gps/nmea_ubx/nmea_ubx.h
+++ b/drivers/gnss-gps/nmea_ubx/nmea_ubx.h
@@ -40,7 +40,7 @@
 #include "no_os_uart.h"
 #include "no_os_gpio.h"
 #include "no_os_irq.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 #include "no_os_print_log.h"
 #include "no_os_error.h"

--- a/drivers/imu/adis.c
+++ b/drivers/imu/adis.c
@@ -33,7 +33,7 @@
 
 #include "adis.h"
 #include "adis_internals.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_util.h"
 #include "capi_alloc.h"
@@ -116,7 +116,7 @@ int adis_init(struct adis_dev **adis, const struct adis_init_param *ip)
 						  NO_OS_GPIO_LOW);
 		if (ret)
 			goto error;
-		no_os_mdelay(ip->info->timeouts->reset_ms);
+		capi_wait_ms(ip->info->timeouts->reset_ms);
 	}
 
 	dev->info = ip->info;
@@ -174,7 +174,7 @@ int adis_initial_startup(struct adis_dev *adis)
 		ret = no_os_gpio_set_value(adis->gpio_reset, NO_OS_GPIO_HIGH);
 		if (ret)
 			return ret;
-		no_os_mdelay(timeouts->reset_ms);
+		capi_wait_ms(timeouts->reset_ms);
 	} else {
 		ret = adis_cmd_sw_res(adis);
 		if (ret)
@@ -1971,7 +1971,7 @@ int adis_write_filt_size_var_b(struct adis_dev *adis, uint32_t filt_size_var_b)
 	if (ret)
 		return ret;
 
-	no_os_udelay(adis->info->timeouts->filt_size_var_b_update_us);
+	capi_wait_us(adis->info->timeouts->filt_size_var_b_update_us);
 
 	return 0;
 }
@@ -2563,7 +2563,7 @@ int adis_write_dr_selection(struct adis_dev *adis, uint32_t dr_selection)
 	if (ret)
 		return ret;
 
-	no_os_udelay(adis->info->timeouts->msc_reg_update_us);
+	capi_wait_us(adis->info->timeouts->msc_reg_update_us);
 
 	return 0;
 }
@@ -2598,7 +2598,7 @@ int adis_write_dr_polarity(struct adis_dev *adis, uint32_t dr_polarity)
 	if (ret)
 		return ret;
 
-	no_os_udelay(adis->info->timeouts->msc_reg_update_us);
+	capi_wait_us(adis->info->timeouts->msc_reg_update_us);
 
 	return 0;
 }
@@ -2633,7 +2633,7 @@ int adis_write_dr_enable(struct adis_dev *adis, uint32_t dr_enable)
 	if (ret)
 		return ret;
 
-	no_os_udelay(adis->info->timeouts->msc_reg_update_us);
+	capi_wait_us(adis->info->timeouts->msc_reg_update_us);
 
 	return 0;
 }
@@ -2673,7 +2673,7 @@ int adis_write_sync_selection(struct adis_dev *adis, uint32_t sync_selection)
 	if (ret)
 		return ret;
 
-	no_os_udelay(adis->info->timeouts->msc_reg_update_us);
+	capi_wait_us(adis->info->timeouts->msc_reg_update_us);
 
 	return 0;
 }
@@ -2708,7 +2708,7 @@ int adis_write_sync_polarity(struct adis_dev *adis, uint32_t sync_polarity)
 	if (ret)
 		return ret;
 
-	no_os_udelay(adis->info->timeouts->msc_reg_update_us);
+	capi_wait_us(adis->info->timeouts->msc_reg_update_us);
 
 	return 0;
 }
@@ -2807,7 +2807,7 @@ int adis_write_alarm_selection(struct adis_dev *adis, uint32_t alarm_selection)
 	if (ret)
 		return ret;
 
-	no_os_udelay(adis->info->timeouts->msc_reg_update_us);
+	capi_wait_us(adis->info->timeouts->msc_reg_update_us);
 
 	return 0;
 }
@@ -2842,7 +2842,7 @@ int adis_write_alarm_polarity(struct adis_dev *adis, uint32_t alarm_polarity)
 	if (ret)
 		return ret;
 
-	no_os_udelay(adis->info->timeouts->msc_reg_update_us);
+	capi_wait_us(adis->info->timeouts->msc_reg_update_us);
 
 	return 0;
 }
@@ -2877,7 +2877,7 @@ int adis_write_alarm_enable(struct adis_dev *adis, uint32_t alarm_enable)
 	if (ret)
 		return ret;
 
-	no_os_udelay(adis->info->timeouts->msc_reg_update_us);
+	capi_wait_us(adis->info->timeouts->msc_reg_update_us);
 
 	return 0;
 }
@@ -3037,7 +3037,7 @@ int adis_write_sens_bw(struct adis_dev *adis, uint32_t sens_bw)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(adis->info->timeouts->sens_bw_update_ms);
+	capi_wait_ms(adis->info->timeouts->sens_bw_update_ms);
 
 	return 0;
 }
@@ -3121,7 +3121,7 @@ int adis_write_pt_of_perc_algnmt(struct adis_dev *adis,
 	if (ret)
 		return ret;
 
-	no_os_udelay(adis->info->timeouts->msc_reg_update_us);
+	capi_wait_us(adis->info->timeouts->msc_reg_update_us);
 
 	return 0;
 }
@@ -3157,7 +3157,7 @@ int adis_write_linear_accl_comp(struct adis_dev *adis,
 	if (ret)
 		return ret;
 
-	no_os_udelay(adis->info->timeouts->msc_reg_update_us);
+	capi_wait_us(adis->info->timeouts->msc_reg_update_us);
 
 	return 0;
 }
@@ -3197,7 +3197,7 @@ int adis_write_burst_sel(struct adis_dev *adis, uint32_t burst_sel)
 
 	adis->burst_sel = burst_sel;
 
-	no_os_udelay(adis->info->timeouts->msc_reg_update_us);
+	capi_wait_us(adis->info->timeouts->msc_reg_update_us);
 
 	return 0;
 }
@@ -3237,7 +3237,7 @@ int adis_write_burst32(struct adis_dev *adis, uint32_t burst32)
 
 	adis->burst32 = (burst32 == 1);
 
-	no_os_udelay(adis->info->timeouts->msc_reg_update_us);
+	capi_wait_us(adis->info->timeouts->msc_reg_update_us);
 
 	return 0;
 }
@@ -3269,7 +3269,7 @@ int adis_write_timestamp32(struct adis_dev *adis, uint32_t timestamp32)
 	if (ret)
 		return ret;
 
-	no_os_udelay(adis->info->timeouts->msc_reg_update_us);
+	capi_wait_us(adis->info->timeouts->msc_reg_update_us);
 
 	return 0;
 }
@@ -3301,7 +3301,7 @@ int adis_write_sync_4khz(struct adis_dev *adis, uint32_t sync_4khz)
 
 	adis->int_clk = sync_4khz ? 4000 : 2000;
 
-	no_os_udelay(adis->info->timeouts->msc_reg_update_us);
+	capi_wait_us(adis->info->timeouts->msc_reg_update_us);
 
 	return 0;
 }
@@ -3375,7 +3375,7 @@ int adis_write_dec_rate(struct adis_dev *adis, uint32_t dec_rate)
 	if (ret)
 		return ret;
 
-	no_os_udelay(adis->info->timeouts->dec_rate_update_us);
+	capi_wait_us(adis->info->timeouts->dec_rate_update_us);
 
 	return 0;
 }
@@ -3588,7 +3588,7 @@ int adis_cmd_fact_calib_restore(struct adis_dev *adis)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(adis->info->timeouts->fact_calib_restore_ms);
+	capi_wait_ms(adis->info->timeouts->fact_calib_restore_ms);
 
 	return 0;
 }
@@ -3607,7 +3607,7 @@ int adis_cmd_snsr_self_test(struct adis_dev *adis)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(adis->info->timeouts->self_test_ms);
+	capi_wait_ms(adis->info->timeouts->self_test_ms);
 
 	return 0;
 }
@@ -3627,7 +3627,7 @@ int adis_cmd_fls_mem_update(struct adis_dev *adis)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(adis->info->timeouts->fls_mem_update_ms);
+	capi_wait_ms(adis->info->timeouts->fls_mem_update_ms);
 
 	/* Make sure flash counter is read after each flash update */
 	return adis_read_fls_mem_wr_cntr(adis, &flash_cnt);
@@ -3647,7 +3647,7 @@ int adis_cmd_fls_mem_test(struct adis_dev *adis)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(adis->info->timeouts->fls_mem_test_ms);
+	capi_wait_ms(adis->info->timeouts->fls_mem_test_ms);
 
 	return 0;
 }
@@ -3677,7 +3677,7 @@ int adis_cmd_sw_res(struct adis_dev *adis)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(adis->info->timeouts->sw_reset_ms);
+	capi_wait_ms(adis->info->timeouts->sw_reset_ms);
 
 	adis->is_locked = false;
 

--- a/drivers/imu/adis1654x.c
+++ b/drivers/imu/adis1654x.c
@@ -37,7 +37,7 @@
 #include "no_os_units.h"
 #include <string.h>
 #include "no_os_util.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #define ADIS1654X_CRC32_SEED		0xFFFFFFFF
 
 static const struct adis_data_field_map_def adis1654x_def = {
@@ -660,7 +660,7 @@ static int adis1654x_write_lpf(struct adis_dev *adis, enum adis_chan_type chan,
 		return ret;
 
 	/* Typical delay needed to enable and select filter bank. */
-	no_os_udelay(65);
+	capi_wait_us(65);
 
 	return 0;
 }

--- a/drivers/imu/adis1655x.c
+++ b/drivers/imu/adis1655x.c
@@ -35,7 +35,7 @@
 #include "adis_internals.h"
 #include "adis1655x.h"
 #include "no_os_units.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include <string.h>
 
 #define ADIS1655X_ID_NO_OFFSET(x) 	((x) - ADIS16550)
@@ -672,7 +672,7 @@ static int adis1655x_read_burst_data(struct adis_dev *adis,
 	if (ret)
 		return ret;
 
-	no_os_udelay(ADIS1655X_STALL_PERIOD_BURST_US);
+	capi_wait_us(ADIS1655X_STALL_PERIOD_BURST_US);
 
 	/* First 4 bytes are the header, any valid command can be sent: sending a burst read command. */
 	buffer[0] = 0;

--- a/drivers/imu/iio_adis.c
+++ b/drivers/imu/iio_adis.c
@@ -32,7 +32,7 @@
  ******************************************************************************/
 
 #include "iio_adis_internals.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_units.h"
 #include <stdio.h>
 #include <string.h>
@@ -1442,7 +1442,7 @@ int adis_iio_pre_enable(void* dev, uint32_t mask)
 		if (ret)
 			return ret;
 		/* From data-sheet, wait time to finalize the fifo flush command */
-		no_os_udelay(500);
+		capi_wait_us(500);
 		ret = adis_write_fifo_overflow(adis, 1);
 		if (ret)
 			return ret;
@@ -1756,7 +1756,7 @@ int adis_iio_trigger_handler_with_fifo(struct iio_device_data *dev_data)
 		goto trig_enable;
 
 	/* From data-sheet, minimum time between reads */
-	no_os_udelay(10);
+	capi_wait_us(10);
 	if (fifo_cnt > dev_data->buffer->samples)
 		fifo_cnt = dev_data->buffer->samples;
 
@@ -1768,7 +1768,7 @@ int adis_iio_trigger_handler_with_fifo(struct iio_device_data *dev_data)
 			goto trig_enable;
 
 		/* From data-sheet, minimum time between reads */
-		no_os_udelay(10);
+		capi_wait_us(10);
 
 		for (j = 0; j < fifo_cnt - 1; j++) {
 			ret = adis_iio_trigger_push_single_sample(iio_adis,
@@ -1777,12 +1777,12 @@ int adis_iio_trigger_handler_with_fifo(struct iio_device_data *dev_data)
 				goto trig_enable;
 
 			/* From data-sheet, minimum time between reads */
-			no_os_udelay(10);
+			capi_wait_us(10);
 		}
 		ret = adis_iio_trigger_push_single_sample(iio_adis,
 				dev_data->buffer->active_mask, dev_data->buffer, false);
 		/* From data-sheet, minimum time between reads */
-		no_os_udelay(10);
+		capi_wait_us(10);
 	}
 
 trig_enable:

--- a/drivers/io-link/max22516/max22516.c
+++ b/drivers/io-link/max22516/max22516.c
@@ -33,7 +33,7 @@
 
 #include <stdlib.h>
 #include "max22516.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "capi_alloc.h"
 

--- a/drivers/led/ltc3208/ltc3208.c
+++ b/drivers/led/ltc3208/ltc3208.c
@@ -45,7 +45,7 @@
 #include "capi_alloc.h"
 #include "no_os_i2c.h"
 #include "no_os_util.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 /***************************************************************************//**
  * @brief Initializes the LTC3208 device structure.

--- a/drivers/led/ltc3220/ltc3220.c
+++ b/drivers/led/ltc3220/ltc3220.c
@@ -45,7 +45,7 @@
 #include "capi_alloc.h"
 #include "no_os_i2c.h"
 #include "no_os_util.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 /***************************************************************************//**
  * @brief Initializes the LTC3220 device structure.
@@ -128,7 +128,7 @@ int ltc3220_reset(struct ltc3220_dev *device)
 	if (ret)
 		return ret;
 
-	no_os_udelay(LTC3220_RESET_DELAY_USEC); /* at least 20ns */
+	capi_wait_us(LTC3220_RESET_DELAY_USEC); /* at least 20ns */
 
 	ret = no_os_gpio_set_value(device->gpio_rst_desc, NO_OS_GPIO_HIGH);
 	if (ret)

--- a/drivers/led/max25603/max25603.c
+++ b/drivers/led/max25603/max25603.c
@@ -31,7 +31,7 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 #include "max25603.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_units.h"
 #include "capi_alloc.h"
 

--- a/drivers/meter/ade7753/ade7753.c
+++ b/drivers/meter/ade7753/ade7753.c
@@ -39,7 +39,7 @@
 #include "no_os_spi.h"
 #include "no_os_gpio.h"
 #include "no_os_irq.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_units.h"
 #include "capi_alloc.h"
 #include "no_os_crc16.h"
@@ -317,7 +317,7 @@ int ade7753_sw_reset(struct ade7753_dev *dev)
 		return ret;
 
 	/* Wait for device to initialize */
-	no_os_mdelay(ADE7753_RESET_DEL);
+	capi_wait_ms(ADE7753_RESET_DEL);
 
 	return 0;
 }
@@ -338,7 +338,7 @@ int ade7753_hw_reset(struct ade7753_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	ret = no_os_gpio_set_value(dev->gpio_reset, NO_OS_GPIO_HIGH);
 	if (ret)

--- a/drivers/meter/ade7753/ade7753.h
+++ b/drivers/meter/ade7753/ade7753.h
@@ -40,7 +40,7 @@
 #include "no_os_spi.h"
 #include "no_os_gpio.h"
 #include "no_os_irq.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_units.h"
 #include "capi_alloc.h"
 #include "no_os_crc16.h"

--- a/drivers/meter/ade7754/ade7754.c
+++ b/drivers/meter/ade7754/ade7754.c
@@ -39,7 +39,7 @@
 #include "no_os_spi.h"
 #include "no_os_gpio.h"
 #include "no_os_irq.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_units.h"
 #include "capi_alloc.h"
 #include "no_os_crc16.h"
@@ -389,7 +389,7 @@ int ade7754_sw_reset(struct ade7754_dev *dev)
 		return ret;
 
 	/* Wait for device to initialize */
-	no_os_udelay(ADE7754_RESET_DEL);
+	capi_wait_us(ADE7754_RESET_DEL);
 
 	return 0;
 }

--- a/drivers/meter/ade7754/ade7754.h
+++ b/drivers/meter/ade7754/ade7754.h
@@ -40,7 +40,7 @@
 #include "no_os_spi.h"
 #include "no_os_gpio.h"
 #include "no_os_irq.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_units.h"
 #include "capi_alloc.h"
 #include "no_os_crc16.h"

--- a/drivers/meter/ade7758/ade7758.c
+++ b/drivers/meter/ade7758/ade7758.c
@@ -39,7 +39,7 @@
 #include "no_os_spi.h"
 #include "no_os_gpio.h"
 #include "no_os_irq.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_units.h"
 #include "capi_alloc.h"
 #include "no_os_crc16.h"
@@ -346,7 +346,7 @@ int ade7758_sw_reset(struct ade7758_dev *dev)
 		return ret;
 
 	/* Wait for device to initialize */
-	no_os_mdelay(ADE7758_RESET_DEL);
+	capi_wait_ms(ADE7758_RESET_DEL);
 
 	return 0;
 }

--- a/drivers/meter/ade7758/ade7758.h
+++ b/drivers/meter/ade7758/ade7758.h
@@ -40,7 +40,7 @@
 #include "no_os_spi.h"
 #include "no_os_gpio.h"
 #include "no_os_irq.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_units.h"
 #include "capi_alloc.h"
 #include "no_os_crc16.h"

--- a/drivers/meter/ade7816/ade7816.c
+++ b/drivers/meter/ade7816/ade7816.c
@@ -31,7 +31,7 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_units.h"
 #include "ade7816.h"
 
@@ -98,7 +98,7 @@ int ade7816_sw_reset(struct ade7816_desc *desc)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(ADE7816_INIT_DELAY);
+	capi_wait_ms(ADE7816_INIT_DELAY);
 
 	return 0;
 }
@@ -116,13 +116,13 @@ int ade7816_hw_reset(struct ade7816_desc *desc)
 	if (ret)
 		return ret;
 
-	no_os_udelay(ADE7816_HWRST_DELAY);
+	capi_wait_us(ADE7816_HWRST_DELAY);
 
 	ret = no_os_gpio_set_value(desc->reset_desc, NO_OS_GPIO_HIGH);
 	if (ret)
 		return ret;
 
-	no_os_mdelay(ADE7816_INIT_DELAY);
+	capi_wait_ms(ADE7816_INIT_DELAY);
 
 	return 0;
 }
@@ -1075,7 +1075,7 @@ int ade7816_zx_detect(struct ade7816_desc *desc, enum ade7816_channel chan)
 	/* Delay required for settling after changing channel selection for zx
 	 * detection.
 	 */
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 
 	return 0;
 }
@@ -1206,7 +1206,7 @@ int ade7816_read_period(struct ade7816_desc *desc, uint32_t *period_us)
 	int ret;
 
 	/* Delay required for internal filtering. */
-	no_os_mdelay(40);
+	capi_wait_ms(40);
 
 	ret = ade7816_read_reg(desc, ADE7816_PERIOD_REG, &reg_val);
 	if (ret)
@@ -1602,7 +1602,7 @@ int ade7816_init(struct ade7816_desc **desc,
 		goto remove_reset;
 	}
 
-	no_os_mdelay(ADE7816_INIT_DELAY);
+	capi_wait_ms(ADE7816_INIT_DELAY);
 
 	ret = ade7816_write_reg(descriptor, ADE7816_RUN_REG, 0x01);
 	if (ret)

--- a/drivers/meter/ade7880/ade7880.c
+++ b/drivers/meter/ade7880/ade7880.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include "ade7880.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_units.h"
 #include "capi_alloc.h"
 
@@ -342,7 +342,7 @@ int ade7880_init(struct ade7880_dev **device,
 	if (ret)
 		goto error_dev;
 	// delay reset
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 	ret = no_os_gpio_set_value(dev->reset_desc,
 				   NO_OS_GPIO_HIGH);
 	if (ret)
@@ -350,7 +350,7 @@ int ade7880_init(struct ade7880_dev **device,
 
 	// wait for device to initialize after hardware reset
 	// >= 100 ms see datasheet.
-	no_os_mdelay(ADE7880_RESET_RECOVER);
+	capi_wait_ms(ADE7880_RESET_RECOVER);
 
 	/* SPI Initialization */
 	ret = no_os_spi_init(&dev->spi_desc, init_param.spi_init);

--- a/drivers/meter/ade7913/ade7913.c
+++ b/drivers/meter/ade7913/ade7913.c
@@ -35,7 +35,7 @@
 #include <errno.h>
 #include <math.h>
 #include "ade7913.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_units.h"
 #include "capi_alloc.h"
 #include "no_os_crc8.h"
@@ -402,7 +402,7 @@ int ade7913_init(struct ade7913_dev **device,
 		/* Wait until devices comm is initialized*/
 		do {
 			ret = ade7913_read(dev, ADE7913_REG_STATUS0, &data);
-			no_os_mdelay(5);
+			capi_wait_ms(5);
 			timeout++;
 			if (timeout == 20) {
 				ret = -ENOTCONN;
@@ -422,7 +422,7 @@ int ade7913_init(struct ade7913_dev **device,
 		/* Wait until devices comm is initialized*/
 		do {
 			ret = ade7913_read(dev, ADE7913_REG_STATUS0, &data);
-			no_os_mdelay(5);
+			capi_wait_ms(5);
 			timeout++;
 			if (timeout == 20) {
 				ret = -ENOTCONN;
@@ -442,7 +442,7 @@ int ade7913_init(struct ade7913_dev **device,
 		/* Wait until devices comm is initialized*/
 		do {
 			ret = ade7913_read(dev, ADE7913_REG_STATUS0, &data);
-			no_os_mdelay(5);
+			capi_wait_ms(5);
 			timeout++;
 			if (timeout == 20) {
 				ret = -ENOTCONN;
@@ -464,7 +464,7 @@ int ade7913_init(struct ade7913_dev **device,
 		/* Wait until devices comm is initialized*/
 		do {
 			ret = ade7913_read(dev, ADE7913_REG_STATUS0, &data);
-			no_os_mdelay(5);
+			capi_wait_ms(5);
 			timeout++;
 			if (timeout == 20) {
 				ret = -ENOTCONN;
@@ -484,7 +484,7 @@ int ade7913_init(struct ade7913_dev **device,
 		/* Wait until devices comm is initialized*/
 		do {
 			ret = ade7913_read(dev, ADE7913_REG_STATUS0, &data);
-			no_os_mdelay(5);
+			capi_wait_ms(5);
 			timeout++;
 			if (timeout == 20) {
 				ret = -ENOTCONN;
@@ -506,7 +506,7 @@ int ade7913_init(struct ade7913_dev **device,
 		/* Wait until devices comm is initialized*/
 		do {
 			ret = ade7913_read(dev, ADE7913_REG_STATUS0, &data);
-			no_os_mdelay(5);
+			capi_wait_ms(5);
 			timeout++;
 			if (timeout == 20) {
 				ret = -ENOTCONN;

--- a/drivers/meter/ade7953/ade7953.c
+++ b/drivers/meter/ade7953/ade7953.c
@@ -39,7 +39,7 @@
 #include "no_os_spi.h"
 #include "no_os_gpio.h"
 #include "no_os_irq.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_units.h"
 #include "capi_alloc.h"
 #include "no_os_crc16.h"
@@ -315,7 +315,7 @@ int ade7953_sw_reset(struct ade7953_dev *dev)
 		return ret;
 
 	/* Wait for device to initialize */
-	no_os_mdelay(ADE7953_RESET_DEL);
+	capi_wait_ms(ADE7953_RESET_DEL);
 
 	return 0;
 }
@@ -337,7 +337,7 @@ int ade7953_hw_reset(struct ade7953_dev *dev)
 		if (ret)
 			return ret;
 	}
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	if (dev->gpio_reset)
 		ret = no_os_gpio_set_value(dev->gpio_reset, NO_OS_GPIO_HIGH);

--- a/drivers/meter/ade7953/ade7953.h
+++ b/drivers/meter/ade7953/ade7953.h
@@ -40,7 +40,7 @@
 #include "no_os_spi.h"
 #include "no_os_gpio.h"
 #include "no_os_irq.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_units.h"
 #include "capi_alloc.h"
 #include "no_os_crc16.h"

--- a/drivers/meter/ade7978/ade7978.c
+++ b/drivers/meter/ade7978/ade7978.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include "ade7978.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_units.h"
 #include "capi_alloc.h"
 
@@ -322,7 +322,7 @@ int ade7978_init(struct ade7978_dev **device,
 		goto error_dev;
 
 	/* delay reset */
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 	ret = no_os_gpio_set_value(dev->reset_desc,
 				   NO_OS_GPIO_HIGH);
 	if (ret)
@@ -330,7 +330,7 @@ int ade7978_init(struct ade7978_dev **device,
 
 	/* wait for device to initialize after hardware reset */
 	/* >= 100 ms see datasheet. */
-	no_os_mdelay(ADE7978_RESET_RECOVER);
+	capi_wait_ms(ADE7978_RESET_RECOVER);
 
 	/* SPI Initialization */
 	ret = no_os_spi_init(&dev->spi_desc, init_param.spi_init);

--- a/drivers/meter/ade9000/ade9000.c
+++ b/drivers/meter/ade9000/ade9000.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include "ade9000.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_units.h"
 #include "capi_alloc.h"
 
@@ -200,7 +200,7 @@ int ade9000_read_temp(struct ade9000_dev *dev)
 	// wait for conversion result
 	while (!(status)) {
 		ret = ade9000_get_int_status0(dev, ADE9000_MASK0_TEMP_RDY, &status);
-		no_os_mdelay(2);
+		capi_wait_ms(2);
 		timeout++;
 		if (timeout == 2000) {
 			ret = -ENODATA;
@@ -398,7 +398,7 @@ int ade9000_init(struct ade9000_dev **device,
 
 	// wait for device to initialize after software reset
 	// > 46 ms see datasheet.
-	no_os_mdelay(50);
+	capi_wait_ms(50);
 
 	/* Use a valid register with default value different from 0*/
 	ret = ade9000_read(dev, ADE9000_REG_CONFIG5, &chip_id);

--- a/drivers/meter/ade9078/ade9078.c
+++ b/drivers/meter/ade9078/ade9078.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include "ade9078.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_units.h"
 #include "capi_alloc.h"
 
@@ -412,7 +412,7 @@ int ade9078_init(struct ade9078_dev **device,
 	if (ret)
 		return ret;
 	// delay reset
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 	ret = no_os_gpio_set_value(dev->reset_desc,
 				   NO_OS_GPIO_HIGH);
 	if (ret)
@@ -420,7 +420,7 @@ int ade9078_init(struct ade9078_dev **device,
 
 	// wait for device to initialize after hardware reset
 	// >= 100 ms see datasheet.
-	no_os_mdelay(ADE9078_RESET_RECOVER);
+	capi_wait_ms(ADE9078_RESET_RECOVER);
 
 	/* Use a valid register with default value different from 0 */
 	ret = ade9078_read(dev, ADE9078_REG_CONFIG5, &chip_id);

--- a/drivers/meter/ade9113/ade9113.c
+++ b/drivers/meter/ade9113/ade9113.c
@@ -35,7 +35,7 @@
 #include <errno.h>
 #include <math.h>
 #include "ade9113.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_units.h"
 #include "capi_alloc.h"
 #include "no_os_crc8.h"
@@ -507,13 +507,13 @@ int ade9113_init(struct ade9113_dev **device,
 	if (ret)
 		goto error_gpio;
 
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 
 	ret = no_os_gpio_set_value(dev->gpio_reset, NO_OS_GPIO_HIGH);
 	if (ret)
 		goto error_gpio;
 
-	no_os_mdelay(50);
+	capi_wait_ms(50);
 
 	// Check if device 0 communication is up
 	if (dev->no_devs < 2) {
@@ -522,7 +522,7 @@ int ade9113_init(struct ade9113_dev **device,
 			if (ret)
 				goto error_gpio;
 
-			no_os_mdelay(5);
+			capi_wait_ms(5);
 			timeout++;
 			if (timeout == 20) {
 				ret = -ENOTCONN;
@@ -535,7 +535,7 @@ int ade9113_init(struct ade9113_dev **device,
 			if (ret)
 				goto error_gpio;
 
-			no_os_mdelay(5);
+			capi_wait_ms(5);
 			timeout++;
 			if (timeout == 20) {
 				ret = -ENOTCONN;
@@ -558,7 +558,7 @@ int ade9113_init(struct ade9113_dev **device,
 				if (ret)
 					goto error_gpio;
 
-				no_os_mdelay(5);
+				capi_wait_ms(5);
 				timeout++;
 				if (timeout == 20) {
 					ret = -ENOTCONN;
@@ -654,7 +654,7 @@ int ade9113_sw_reset(struct ade9113_dev *dev)
 	dev->crc_en = 1;
 
 	/* Wait for device to initialize */ // ToDo - check required timing
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	/* Read version product */
 	ret = ade9113_get_version_product(dev, &ver_product);
@@ -680,7 +680,7 @@ int ade9113_hw_reset(struct ade9113_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 
 	ret = no_os_gpio_set_value(dev->gpio_reset, NO_OS_GPIO_HIGH);
 	if (ret)
@@ -689,7 +689,7 @@ int ade9113_hw_reset(struct ade9113_dev *dev)
 	dev->crc_en = 1;
 
 	/* Wait for device to initialize */ // ToDo - check required timing
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	/* Read version product */
 	ret = ade9113_get_version_product(dev, &ver_product);

--- a/drivers/meter/ade9153a/ade9153a.c
+++ b/drivers/meter/ade9153a/ade9153a.c
@@ -39,7 +39,7 @@
 #include "no_os_spi.h"
 #include "no_os_gpio.h"
 #include "no_os_irq.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_units.h"
 #include "capi_alloc.h"
 #include "no_os_crc16.h"
@@ -242,7 +242,7 @@ int ade9153a_init(struct ade9153a_dev **device,
 			goto error_spi;
 	}
 
-	no_os_mdelay(ADE9153A_RESET_DEL);
+	capi_wait_ms(ADE9153A_RESET_DEL);
 
 	ret = ade9153a_run(dev);
 	if (ret)
@@ -558,7 +558,7 @@ int ade9153a_sw_reset(struct ade9153a_dev *dev)
 		return ret;
 
 	/* Wait for device to initialize */
-	no_os_mdelay(ADE9153A_RESET_DEL);
+	capi_wait_ms(ADE9153A_RESET_DEL);
 
 	return 0;
 }
@@ -580,7 +580,7 @@ int ade9153a_hw_reset(struct ade9153a_dev *dev)
 		if (ret)
 			return ret;
 	}
-	no_os_mdelay(ADE9153A_RESET_DEL);
+	capi_wait_ms(ADE9153A_RESET_DEL);
 
 	if (dev->gpio_reset)
 		ret = no_os_gpio_set_value(dev->gpio_reset, NO_OS_GPIO_HIGH);
@@ -588,7 +588,7 @@ int ade9153a_hw_reset(struct ade9153a_dev *dev)
 		return ret;
 
 	/* Wait for device to initialize */
-	no_os_mdelay(ADE9153A_RESET_DEL);
+	capi_wait_ms(ADE9153A_RESET_DEL);
 
 	return 0;
 }
@@ -4018,7 +4018,7 @@ int ade9153a_temp_val(struct ade9153a_dev *dev,
 	// wait for conversion result
 	while (!(status)) {
 		ret = ade9153a_get_temp_rdy(dev, &status);
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 		timeout++;
 		if (timeout == 2000) {
 			ret = -ENODATA;

--- a/drivers/meter/ade9153a/ade9153a.h
+++ b/drivers/meter/ade9153a/ade9153a.h
@@ -40,7 +40,7 @@
 #include "no_os_spi.h"
 #include "no_os_gpio.h"
 #include "no_os_irq.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_units.h"
 #include "capi_alloc.h"
 #include "no_os_crc16.h"

--- a/drivers/meter/ade9430/ade9430.c
+++ b/drivers/meter/ade9430/ade9430.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include "ade9430.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_units.h"
 #include "capi_alloc.h"
 
@@ -133,7 +133,7 @@ int ade9430_read_temp(struct ade9430_dev *dev)
 		return ret;
 
 	/* New temperature reading available after 1.25ms */
-	no_os_mdelay(2);
+	capi_wait_ms(2);
 
 	ret = ade9430_read(dev, ADE9430_REG_TEMP_RSLT, &temp_raw);
 	if (ret)
@@ -295,7 +295,7 @@ int ade9430_init(struct ade9430_dev **device,
 	if (ret)
 		goto error_spi;
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	ret = ade9430_update_bits(dev, ADE9430_REG_CONFIG1, ADE9430_SWRST,
 				  no_os_field_prep(ADE9430_SWRST, 0));

--- a/drivers/net/adin1110/adin1110.c
+++ b/drivers/net/adin1110/adin1110.c
@@ -39,7 +39,7 @@
 #include "adin1110.h"
 #include "capi_alloc.h"
 #include "no_os_crc8.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_util.h"
 
 #include "oa_tc6.h"
@@ -795,13 +795,13 @@ int adin1110_phy_reset(struct adin1110_desc *desc)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 
 	ret = no_os_gpio_set_value(desc->reset_gpio, NO_OS_GPIO_HIGH);
 	if (ret)
 		return ret;
 
-	no_os_mdelay(90);
+	capi_wait_ms(90);
 
 	ret = adin1110_reg_read(desc, ADIN1110_PHY_ID_REG, &phy_id);
 	if (ret)
@@ -964,14 +964,14 @@ int adin1110_init(struct adin1110_desc **desc,
 		 * Minimum required time for the reset GPIO to be in the low state
 		 * in order to reset the ADIN1110.
 		 */
-		no_os_mdelay(10);
+		capi_wait_ms(10);
 
 		ret = no_os_gpio_set_value(descriptor->reset_gpio, NO_OS_GPIO_HIGH);
 		if (ret)
 			goto free_rst_gpio;
 
 		/* Wait for the MAC and PHY digital interface to intialize after reset */
-		no_os_mdelay(90);
+		capi_wait_ms(90);
 	}
 
 	ret = no_os_spi_init(&descriptor->comm_desc, &param->comm_param);
@@ -992,7 +992,7 @@ int adin1110_init(struct adin1110_desc **desc,
 			goto free_spi;
 
 		/* Wait for the MAC and PHY digital interface to intialize */
-		no_os_mdelay(90);
+		capi_wait_ms(90);
 	}
 
 	descriptor->oa_tc6_spi = param->oa_tc6_spi;

--- a/drivers/net/adin1300.c
+++ b/drivers/net/adin1300.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "mdio_bitbang.h"
 #include "adin1300.h"
@@ -88,7 +88,7 @@ int adin1300_soft_reset(struct adin1300_desc *dev)
 	if (ret < 0)
 		return ret;
 
-	no_os_mdelay(20);
+	capi_wait_ms(20);
 
 	return 0;
 }
@@ -100,11 +100,11 @@ int adin1300_hard_reset(struct adin1300_desc *dev)
 	ret = no_os_gpio_direction_output(dev->reset_gpio, NO_OS_GPIO_LOW);
 	if (ret)
 		return ret;
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 	ret = no_os_gpio_direction_output(dev->reset_gpio, NO_OS_GPIO_HIGH);
 	if (ret)
 		return ret;
-	no_os_mdelay(20);
+	capi_wait_ms(20);
 
 	return 0;
 }

--- a/drivers/net/adin1320/adin1320.c
+++ b/drivers/net/adin1320/adin1320.c
@@ -33,7 +33,7 @@
 
 #include <errno.h>
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "adin1320.h"
 
@@ -138,13 +138,13 @@ int adin1320_hard_reset(struct adin1320_desc *dev)
 		return ret;
 
 	/* Minimum reset pulse length is 1 microsecond */
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 	ret = no_os_gpio_direction_output(dev->reset_gpio, NO_OS_GPIO_HIGH);
 	if (ret)
 		return ret;
 
 	/* Minimum 5ms required after reset deassertion before device can be used */
-	no_os_mdelay(20);
+	capi_wait_ms(20);
 
 	return 0;
 }

--- a/drivers/net/iio_adin1300.c
+++ b/drivers/net/iio_adin1300.c
@@ -2,7 +2,7 @@
 #include <string.h>
 #include <stdio.h>
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_util.h"
 #include "capi_alloc.h"
 #include "iio_adin1300.h"

--- a/drivers/net/iio_max24287.c
+++ b/drivers/net/iio_max24287.c
@@ -2,7 +2,7 @@
 #include <string.h>
 #include <stdio.h>
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_util.h"
 #include "capi_alloc.h"
 #include "iio_max24287.h"

--- a/drivers/net/max24287.c
+++ b/drivers/net/max24287.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "mdio_bitbang.h"
 #include "max24287.h"
@@ -47,7 +47,7 @@ int max24287_init(struct max24287_desc **dev, struct max24287_init_param *param)
 		// Rev B sequence
 		max24287_write(d, MAX24287_PTPCR1,
 			       MAX24287_PTPCR1_W_MASK | MAX24287_RX_PWDN_MASK);
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 		max24287_write(d, MAX24287_PTPCR1, MAX24287_PTPCR1_W_MASK);
 		max24287_write(d, MAX24287_BMCR, MAX24287_DP_RST_MASK);
 	}
@@ -87,7 +87,7 @@ int max24287_soft_reset(struct max24287_desc *dev)
 	if (ret < 0)
 		return ret;
 
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	return 0;
 }
@@ -99,12 +99,12 @@ int max24287_hard_reset(struct max24287_desc *dev)
 	ret = no_os_gpio_direction_output(dev->reset_gpio, NO_OS_GPIO_LOW);
 	if (ret)
 		return ret;
-	no_os_udelay(100);
+	capi_wait_us(100);
 	ret = no_os_gpio_direction_output(dev->reset_gpio, NO_OS_GPIO_HIGH);
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	return 0;
 }

--- a/drivers/net/w5500/w5500.c
+++ b/drivers/net/w5500/w5500.c
@@ -36,7 +36,7 @@
 #include <errno.h>
 #include <string.h>
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 /***************************************************************************//**
  * @brief Write data to a W5500 register
@@ -624,7 +624,7 @@ int w5500_socket_send(struct w5500_dev *dev, uint8_t sock_id, const void *buf,
 			    status != W5500_Sn_SR_MACRAW)
 				return -ECONNRESET;
 
-			no_os_mdelay(1);
+			capi_wait_ms(1);
 			continue;
 		}
 
@@ -709,7 +709,7 @@ int w5500_socket_recv(struct w5500_dev *dev, uint8_t sock_id, void *buf,
 		    status != W5500_Sn_SR_MACRAW)
 			return -ECONNRESET;
 
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 	}
 
 	if (len > rx_size)
@@ -799,7 +799,7 @@ int w5500_socket_sendto(struct w5500_dev *dev, uint8_t sock_id, const void *buf,
 		if (status != W5500_Sn_SR_UDP)
 			return -EPROTOTYPE;
 
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 	}
 
 	ret = w5500_read_16bit_reg(dev, W5500_SOCKET_REG_BLOCK(sock_id),
@@ -979,7 +979,7 @@ int w5500_reset(struct w5500_dev *dev)
 			return ret;
 
 		/* Hold reset low for at least 500us per datasheet */
-		no_os_udelay(500);
+		capi_wait_us(500);
 
 		ret = no_os_gpio_set_value(dev->gpio_reset, 1);
 		if (ret)
@@ -992,7 +992,7 @@ int w5500_reset(struct w5500_dev *dev)
 	}
 
 	/* Wait for reset to complete */
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	ret = w5500_reg_read(dev, W5500_COMMON_REG, W5500_MR, &mr, 1);
 	if (ret)

--- a/drivers/photo-electronic/adpd188/adpd188.c
+++ b/drivers/photo-electronic/adpd188/adpd188.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include "adpd188.h"
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 
 /**
@@ -538,7 +538,7 @@ int32_t adpd188_clk32mhz_cal(struct adpd188_dev *dev)
 	if (ret != 0)
 		return -1;
 
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 	ret = adpd188_reg_read(dev, ADPD188_REG_CLK_RATIO, &reg_data);
 	if (ret != 0)
 		return -1;

--- a/drivers/position/admt4000/admt4000.c
+++ b/drivers/position/admt4000/admt4000.c
@@ -42,7 +42,7 @@
 #include <stdbool.h>
 #include "admt4000.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 static int admt4000_set_page(struct admt4000_dev *device, uint8_t page);
 static int admt4000_ecc_config(struct admt4000_dev *device, bool is_en);
@@ -103,7 +103,7 @@ static int admt4000_config(struct admt4000_dev *device,
 	}
 
 	/* Delay for GPIO lines to settle before clearing faults */
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 
 	ret = admt4000_clear_all_faults(device);
 	if (ret)
@@ -164,7 +164,7 @@ int admt4000_hard_reset(struct admt4000_dev *device)
 		return ret;
 
 	/* Hold for 1ms */
-	no_os_mdelay(ADMT4000_RESET_HOLD_TIME_MS);
+	capi_wait_ms(ADMT4000_RESET_HOLD_TIME_MS);
 
 	/* Deassert reset */
 	ret = no_os_gpio_set_value(device->gpio_reset_desc, NO_OS_GPIO_HIGH);
@@ -172,7 +172,7 @@ int admt4000_hard_reset(struct admt4000_dev *device)
 		return ret;
 
 	/* Wait for device startup */
-	no_os_mdelay(ADMT4000_STARTUP_TIME_MS);
+	capi_wait_ms(ADMT4000_STARTUP_TIME_MS);
 
 	/* Invalidate page cache */
 	device->page_cache_valid = false;
@@ -710,7 +710,7 @@ int admt4000_toggle_cnv(struct admt4000_dev *device)
 		if (ret)
 			return ret;
 
-		no_os_udelay(ADMT4000_CNV_PULSE_WIDTH_US);
+		capi_wait_us(ADMT4000_CNV_PULSE_WIDTH_US);
 		ret = no_os_gpio_set_value(device->gpio_cnv_desc, NO_OS_GPIO_LOW);
 		if (ret)
 			return ret;

--- a/drivers/position/admt4000/iio_admt4000.c
+++ b/drivers/position/admt4000/iio_admt4000.c
@@ -39,7 +39,7 @@
 #include "iio.h"
 #include "iio_trigger.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_util.h"
 
@@ -1198,7 +1198,7 @@ static int admt4000_iio_read_raw(void *dev, char *buf, uint32_t len,
 			if (ret)
 				return ret;
 
-			no_os_mdelay(ADMT4000_CONVERSION_DELAY_MS);
+			capi_wait_ms(ADMT4000_CONVERSION_DELAY_MS);
 		}
 
 		ret = admt4000_get_raw_turns_and_angle(admt4000, &raw_quarter_turns, angle);
@@ -1360,7 +1360,7 @@ static int admt4000_iio_submit_buffer(struct iio_device_data *dev_data)
 			return ret;
 
 		/* Wait for conversion to complete */
-		no_os_mdelay(ADMT4000_CONVERSION_DELAY_MS);
+		capi_wait_ms(ADMT4000_CONVERSION_DELAY_MS);
 	}
 
 	/* Call trigger handler to read and push data */

--- a/drivers/potentiometer/ad514x/ad5141.c
+++ b/drivers/potentiometer/ad514x/ad5141.c
@@ -30,7 +30,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 #include "ad5141.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 #define AD5141_NVM_WRITE_DELAY 18
 
@@ -260,7 +260,7 @@ int ad5141_dpot_init(struct dpot_init_param *param, struct dpot_dev **desc)
 	ret = ad5141_dpot_reset(dev);
 	if (ret)
 		goto err_dpot_init;
-	no_os_udelay(30 * 5);
+	capi_wait_us(30 * 5);
 	/* Set operating mode */
 	ret = ad5141_dpot_set_operating_mode(dev, ad5141_params->eoperating_mode);
 	if (ret)
@@ -361,7 +361,7 @@ int ad5141_dpot_reset(struct dpot_dev *desc)
 			return ret;
 
 		/* Min reset low time as per datasheet spec is 0.1usec */
-		no_os_udelay(1);
+		capi_wait_us(1);
 
 		ret = no_os_gpio_set_value(ad5141_desc->reset_gpio_desc, NO_OS_GPIO_HIGH);
 		if (ret)
@@ -381,7 +381,7 @@ int ad5141_dpot_reset(struct dpot_dev *desc)
 	/* Reset EEPROM restore time as per datasheet spec.
 	 * This delay ensures RDAC contents are loaded into EEPROM
 	 * after device reset */
-	no_os_udelay(30);
+	capi_wait_us(30);
 
 	return 0;
 }
@@ -740,7 +740,7 @@ int ad5141_dpot_nvm_write(struct dpot_dev *desc,
 		return ret;
 
 	/* EEPROM write delay as per device specifications */
-	no_os_mdelay(AD5141_NVM_WRITE_DELAY);
+	capi_wait_ms(AD5141_NVM_WRITE_DELAY);
 
 	return 0;
 }
@@ -774,7 +774,7 @@ int ad5141_dpot_copy_rdac_to_nvm(struct dpot_dev *desc, enum dpot_chn_type chn)
 		return ret;
 
 	/* EEPROM write delay as per device specifications */
-	no_os_mdelay(18);
+	capi_wait_ms(18);
 
 	return 0;
 }

--- a/drivers/potentiometer/ad514x/ad5142.c
+++ b/drivers/potentiometer/ad514x/ad5142.c
@@ -30,7 +30,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 #include "ad5142.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 /* AD5142 dpot command address mapped to channel type */
 uint8_t ad5142_dpot_cmd_addr[] = {
@@ -207,7 +207,7 @@ int ad5142_dpot_init(struct dpot_init_param *param, struct dpot_dev **desc)
 	if (ret)
 		goto err_dpot_init;
 	/* The reset command loads the RDAC register with the contents of the EEPROM and takes approximately 30 us. */
-	no_os_udelay(30 * 5);
+	capi_wait_us(30 * 5);
 	/* Set operating mode */
 	ret = ad5142_dpot_set_operating_mode(dev, ad5142_params->eoperating_mode);
 	if (ret)
@@ -307,7 +307,7 @@ int ad5142_dpot_reset(struct dpot_dev *desc)
 			return ret;
 
 		/* Min reset low time as per datasheet spec is 0.1usec */
-		no_os_udelay(1);
+		capi_wait_us(1);
 
 		ret = no_os_gpio_set_value(ad5142_desc->reset_gpio_desc, NO_OS_GPIO_HIGH);
 		if (ret)
@@ -327,7 +327,7 @@ int ad5142_dpot_reset(struct dpot_dev *desc)
 	/* Reset EEPROM restore time as per datasheet spec.
 	 * This delay ensures RDAC contents are loaded into EEPROM
 	 * after device reset */
-	no_os_udelay(30);
+	capi_wait_us(30);
 
 	return 0;
 }
@@ -692,7 +692,7 @@ int ad5142_dpot_nvm_write(struct dpot_dev *desc,
 		return ret;
 
 	/* EEPROM write delay as per device specifications */
-	no_os_mdelay(18);
+	capi_wait_ms(18);
 
 	return 0;
 }
@@ -726,7 +726,7 @@ int ad5142_dpot_copy_rdac_to_nvm(struct dpot_dev *desc, enum dpot_chn_type chn)
 		return ret;
 
 	/* EEPROM write delay as per device specifications */
-	no_os_mdelay(18);
+	capi_wait_ms(18);
 
 	return 0;
 }

--- a/drivers/potentiometer/ad514x/ad5143.c
+++ b/drivers/potentiometer/ad514x/ad5143.c
@@ -30,7 +30,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 #include "ad5143.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 /* AD5143 dpot command address mapped to channel type */
 uint8_t ad5143_dpot_cmd_addr[] = {
@@ -196,7 +196,7 @@ int ad5143_dpot_reset(struct dpot_dev *desc)
 	/* Reset EEPROM restore time as per datasheet spec.
 	 * This delay ensures RDAC contents are loaded into EEPROM
 	 * after device reset */
-	no_os_udelay(30);
+	capi_wait_us(30);
 
 	return 0;
 }
@@ -557,7 +557,7 @@ int ad5143_dpot_nvm_write(struct dpot_dev *desc,
 		return ret;
 
 	/* EEPROM write delay as per device specifications */
-	no_os_mdelay(18);
+	capi_wait_ms(18);
 
 	return 0;
 }
@@ -591,7 +591,7 @@ int ad5143_dpot_copy_rdac_to_nvm(struct dpot_dev *desc, enum dpot_chn_type chn)
 		return ret;
 
 	/* EEPROM write delay as per device specifications */
-	no_os_mdelay(18);
+	capi_wait_ms(18);
 
 	return 0;
 }

--- a/drivers/potentiometer/ad514x/ad5144.c
+++ b/drivers/potentiometer/ad514x/ad5144.c
@@ -30,7 +30,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 #include "ad5144.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 /* AD5144 dpot command address mapped to channel type */
 uint8_t ad5144_dpot_cmd_addr[] = {
@@ -266,7 +266,7 @@ int ad5144_dpot_init(struct dpot_init_param *param, struct dpot_dev **desc)
 	if (ret)
 		goto err_dpot_init;
 	/* The reset command loads the RDAC register with the contents of the EEPROM and takes approximately 30 µs. */
-	no_os_udelay(AD5144_RESET_DELAY);
+	capi_wait_us(AD5144_RESET_DELAY);
 	/* Set operating mode */
 	ret = ad5144_dpot_set_operating_mode(dev, ad5144_params->eoperating_mode);
 	if (ret)
@@ -371,7 +371,7 @@ int ad5144_dpot_reset(struct dpot_dev *desc)
 			return ret;
 
 		/* Min reset low time as per datasheet spec is 0.1usec */
-		no_os_udelay(1);
+		capi_wait_us(1);
 
 		ret = no_os_gpio_set_value(ad5144_desc->reset_gpio_desc, NO_OS_GPIO_HIGH);
 		if (ret)
@@ -391,7 +391,7 @@ int ad5144_dpot_reset(struct dpot_dev *desc)
 	/* Reset EEPROM restore time as per datasheet spec.
 	 * This delay ensures RDAC contents are loaded into EEPROM
 	 * after device reset */
-	no_os_udelay(AD5144_RESET_DELAY);
+	capi_wait_us(AD5144_RESET_DELAY);
 
 	return 0;
 }
@@ -750,7 +750,7 @@ int ad5144_dpot_nvm_write(struct dpot_dev *desc,
 		return ret;
 
 	/* EEPROM write delay as per device specifications */
-	no_os_mdelay(18);
+	capi_wait_ms(18);
 
 	return 0;
 }
@@ -784,7 +784,7 @@ int ad5144_dpot_copy_rdac_to_nvm(struct dpot_dev *desc, enum dpot_chn_type chn)
 		return ret;
 
 	/* EEPROM write delay as per device specifications */
-	no_os_mdelay(18);
+	capi_wait_ms(18);
 
 	return 0;
 }

--- a/drivers/potentiometer/ad5161/ad5161.c
+++ b/drivers/potentiometer/ad5161/ad5161.c
@@ -30,7 +30,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 #include "ad5161.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 uint8_t ad5161_dpot_cmd_addr[] = {
 	[DPOT_CHN_RDAC1] = 0x0,
 

--- a/drivers/potentiometer/ad5165/ad5165.c
+++ b/drivers/potentiometer/ad5165/ad5165.c
@@ -30,7 +30,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 #include "ad5165.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 static int ad5165_dpot_send_cmd_write(struct dpot_dev *desc,
 				      struct dpot_command *cmd);

--- a/drivers/potentiometer/ad5171/ad5171.c
+++ b/drivers/potentiometer/ad5171/ad5171.c
@@ -30,7 +30,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 #include "ad5171.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 /**
  * @brief Initialize the ad5171 digital potentiometer.

--- a/drivers/potentiometer/ad5242/ad5242.c
+++ b/drivers/potentiometer/ad5242/ad5242.c
@@ -30,7 +30,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 #include "ad5242.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 /* Contains the address that need to be programmed while configuring the two different channels of AD5242*/
 static uint8_t ad5242_dpot_cmd_addr[] = {

--- a/drivers/potentiometer/ad5246/ad5246.c
+++ b/drivers/potentiometer/ad5246/ad5246.c
@@ -30,7 +30,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 #include "ad5246.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 /* AD5246 dpot command address mapped to channel type */
 /**

--- a/drivers/potentiometer/ad5259/ad5259.c
+++ b/drivers/potentiometer/ad5259/ad5259.c
@@ -30,7 +30,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 #include "ad5259.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 static int ad5259_dpot_send_cmd_write(struct dpot_dev *desc,
 				      struct dpot_command *cmd);
@@ -308,7 +308,7 @@ int ad5259_dpot_nvm_write(struct dpot_dev *desc,
 		return ret;
 
 	/* EEPROM write delay as per device specifications */
-	no_os_mdelay(180);
+	capi_wait_ms(180);
 	return 0;
 }
 
@@ -338,7 +338,7 @@ int ad5259_dpot_copy_rdac_to_nvm(struct dpot_dev *desc, enum dpot_chn_type chn)
 		return ret;
 
 	/* EEPROM write delay as per device specifications */
-	no_os_mdelay(18);
+	capi_wait_ms(18);
 
 	return 0;
 }

--- a/drivers/potentiometer/ad525x/ad525x.c
+++ b/drivers/potentiometer/ad525x/ad525x.c
@@ -34,6 +34,7 @@
 #include <stdlib.h>
 #include "ad525x.h"
 #include "capi_alloc.h"
+#include "capi_time.h"
 
 #define MSB_BYTE_MASK       0xFF00
 #define LSB_BYTE_MASK       0x00FF
@@ -283,7 +284,7 @@ uint16_t ad525x_read_rdac(struct ad525x_dev *dev,
 			no_os_spi_write_and_read(dev->spi_desc,
 						 data_buffer,
 						 3);
-			no_os_mdelay(50);
+			capi_wait_ms(50);
 			data_buffer[0] &= AD525X_CMD_NOP << AD525X_CMD_SPI_OFFSET;
 			no_os_spi_write_and_read(dev->spi_desc,
 						 data_buffer,
@@ -294,7 +295,7 @@ uint16_t ad525x_read_rdac(struct ad525x_dev *dev,
 			no_os_spi_write_and_read(dev->spi_desc,
 						 data_buffer,
 						 2);
-			no_os_mdelay(50);
+			capi_wait_ms(50);
 			/* Sending a dummy frame to read the result */
 			data_buffer[0] &= AD525X_CMD_NOP << AD525X_CMD_SPI_OFFSET;
 			no_os_spi_write_and_read(dev->spi_desc,
@@ -363,7 +364,7 @@ void ad525x_write_rdac(struct ad525x_dev *dev,
 				2,
 				1);
 	}
-	no_os_mdelay(25);
+	capi_wait_ms(25);
 }
 
 /**************************************************************************//**
@@ -435,5 +436,5 @@ void ad525x_write_command(struct ad525x_dev *dev,
 					1);
 		}
 	}
-	no_os_mdelay(25);
+	capi_wait_ms(25);
 }

--- a/drivers/potentiometer/ad525x/ad525x.h
+++ b/drivers/potentiometer/ad525x/ad525x.h
@@ -36,7 +36,7 @@
 #define __AD525X_H__
 
 #include <stdint.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_i2c.h"

--- a/drivers/potentiometer/ad5293/ad5293.c
+++ b/drivers/potentiometer/ad5293/ad5293.c
@@ -32,7 +32,7 @@ SOFTWARE.
 #include <errno.h>
 #include "ad5293.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 /***************************************************************************//**
  * @brief Reset ad5293 chip info
@@ -190,13 +190,13 @@ int32_t ad5293_hard_reset(struct ad5293_dev* dev)
 	if (ret)
 		return ret;
 
-	no_os_udelay(1);  // >20ns pulse width
+	capi_wait_us(1);  // >20ns pulse width
 
 	ret = no_os_gpio_set_value(dev->gpio_reset, NO_OS_GPIO_HIGH);
 	if (ret)
 		return ret;
 
-	no_os_mdelay(2); // t12: max 1.5ms reset time
+	capi_wait_ms(2); // t12: max 1.5ms reset time
 
 	ad5293_reset_chip_info(dev);
 
@@ -229,7 +229,7 @@ int32_t ad5293_soft_reset(struct ad5293_dev* dev)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(2); // t12: max 1.5ms reset time
+	capi_wait_ms(2); // t12: max 1.5ms reset time
 
 	ad5293_reset_chip_info(dev);
 
@@ -425,7 +425,7 @@ int32_t ad5293_write_wiper(struct ad5293_dev* dev)
 	if (ret)
 		return ret;
 
-	no_os_udelay(3); // performance mode, t12 > 2.4us
+	capi_wait_us(3); // performance mode, t12 > 2.4us
 
 	return ad5293_write_protect(dev, PROTECT_LOCK);
 

--- a/drivers/power/ades1754/ades1754.c
+++ b/drivers/power/ades1754/ades1754.c
@@ -33,7 +33,7 @@
 #include "ades1754.h"
 #include "capi_alloc.h"
 #include "no_os_crc8.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 
 NO_OS_DECLARE_CRC8_TABLE(crc_table);
@@ -1228,7 +1228,7 @@ free_desc:
  */
 int ades1754_remove(struct ades1754_desc *desc)
 {
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 	no_os_uart_remove(desc->uart_desc);
 	capi_free(desc);
 

--- a/drivers/power/adp1050/adp1050.c
+++ b/drivers/power/adp1050/adp1050.c
@@ -34,7 +34,7 @@
 #include <string.h>
 #include "adp1050.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 
 /**
@@ -1306,7 +1306,7 @@ int adp1050_init(struct adp1050_desc **desc,
 		goto free_desc;
 
 	/* Time needed for the ADP1050 to power-up. */
-	no_os_mdelay(52);
+	capi_wait_ms(52);
 
 	ret = adp1050_send_command(descriptor, ADP1050_CLEAR_FAULTS);
 	if (ret)

--- a/drivers/power/adp1055/adp1055.c
+++ b/drivers/power/adp1055/adp1055.c
@@ -34,7 +34,7 @@
 #include "no_os_error.h"
 #include "no_os_util.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 /**
  * @brief Send command byte/word to ADP1055
@@ -206,7 +206,7 @@ int adp1055_init(struct adp1055_desc **desc,
 		goto free_desc;
 
 	/* Time needed for the adp1055 to power-up. */
-	no_os_mdelay(52);
+	capi_wait_ms(52);
 
 	ret = adp1055_send_command(descriptor, ADP1055_CLEAR_FAULTS);
 	if (ret)

--- a/drivers/power/adp5055/adp5055.c
+++ b/drivers/power/adp5055/adp5055.c
@@ -34,7 +34,7 @@
 #include <string.h>
 #include "adp5055.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 
 /**

--- a/drivers/power/lt3074/lt3074.c
+++ b/drivers/power/lt3074/lt3074.c
@@ -37,7 +37,7 @@
 
 #include "no_os_units.h"
 #include "no_os_util.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 #include "no_os_i2c.h"
 #include "no_os_gpio.h"

--- a/drivers/power/lt7170/lt7170.c
+++ b/drivers/power/lt7170/lt7170.c
@@ -44,7 +44,7 @@
 
 #include "no_os_units.h"
 #include "no_os_util.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 #include "no_os_pwm.h"
 #include "no_os_i2c.h"

--- a/drivers/power/lt7182s/lt7182s.c
+++ b/drivers/power/lt7182s/lt7182s.c
@@ -38,7 +38,7 @@
 
 #include "no_os_units.h"
 #include "no_os_util.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 #include "no_os_pwm.h"
 #include "no_os_i2c.h"

--- a/drivers/power/lt8722/lt8722.c
+++ b/drivers/power/lt8722/lt8722.c
@@ -35,7 +35,7 @@
 #include <string.h>
 #include "capi_alloc.h"
 #include "no_os_crc8.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "no_os_print_log.h"
 #include "lt8722.h"
@@ -1098,7 +1098,7 @@ int lt8722_init(struct lt8722_dev **device,
 		if (ret)
 			goto free_desc;
 
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 
 		// 5. Ramp the output voltage control DAC from 0xFF000000 to 0x00000000
 		start_voltage = lt8722_dac_to_voltage(0xFF000000);
@@ -1112,7 +1112,7 @@ int lt8722_init(struct lt8722_dev **device,
 			if (ret)
 				goto free_desc;
 
-			no_os_mdelay(1);
+			capi_wait_ms(1);
 		}
 
 		// 6. Enable the PWM switching behavior
@@ -1124,7 +1124,7 @@ int lt8722_init(struct lt8722_dev **device,
 		if (ret)
 			goto free_desc;
 
-		no_os_udelay(160);
+		capi_wait_us(160);
 
 		// 7. Set the desired output voltage
 	}

--- a/drivers/power/ltc3350/ltc3350.c
+++ b/drivers/power/ltc3350/ltc3350.c
@@ -37,7 +37,7 @@
 #include <errno.h>
 
 #include "no_os_util.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 #include "no_os_i2c.h"
 

--- a/drivers/power/ltc4162l/ltc4162l.c
+++ b/drivers/power/ltc4162l/ltc4162l.c
@@ -35,7 +35,7 @@
 #include <errno.h>
 
 #include "no_os_util.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 #include "no_os_i2c.h"
 

--- a/drivers/power/ltc4296/ltc4296.c
+++ b/drivers/power/ltc4296/ltc4296.c
@@ -35,7 +35,7 @@
 #include <errno.h>
 #include "ltc4296.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_util.h"
 
@@ -168,7 +168,7 @@ int ltc4296_reset(struct ltc4296_dev *dev)
 		return ret;
 
 	/* Delay required after performing a software reset */
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	return 0;
 }
@@ -333,7 +333,7 @@ int ltc4296_set_gadc_vin(struct ltc4296_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(4); /* Delay of 4ms*/
+	capi_wait_ms(4); /* Delay of 4ms*/
 
 	return 0;
 }
@@ -403,7 +403,7 @@ int ltc4296_disable_gadc(struct ltc4296_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(4); /* Delay of 4ms*/
+	capi_wait_ms(4); /* Delay of 4ms*/
 
 	return 0;
 }

--- a/drivers/power/ltc7841/ltc7841.h
+++ b/drivers/power/ltc7841/ltc7841.h
@@ -39,7 +39,7 @@
 #include "no_os_i2c.h"
 #include "no_os_irq.h"
 #include "no_os_print_log.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
 #include "no_os_units.h"

--- a/drivers/power/ltc7871/ltc7871.c
+++ b/drivers/power/ltc7871/ltc7871.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "no_os_print_log.h"
 #include "ltc7871.h"

--- a/drivers/power/ltm3360b/ltm3360b.c
+++ b/drivers/power/ltm3360b/ltm3360b.c
@@ -37,7 +37,7 @@
 #include <errno.h>
 
 #include "no_os_util.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 #include "no_os_i2c.h"
 #include "no_os_error.h"
@@ -231,7 +231,7 @@ int ltm3360b_adc_read_raw(struct ltm3360b_dev *dev,
 	if (ret)
 		return ret;
 
-	no_os_mdelay(LTM3360B_ADC_CONV_TIME_MS);
+	capi_wait_ms(LTM3360B_ADC_CONV_TIME_MS);
 
 	return ltm3360b_reg_read(dev, LTM3360B_ADC_OUTPUT, result);
 }

--- a/drivers/power/ltm4686/ltm4686.c
+++ b/drivers/power/ltm4686/ltm4686.c
@@ -37,7 +37,7 @@
 
 #include "no_os_units.h"
 #include "no_os_util.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 #include "no_os_i2c.h"
 #include "no_os_gpio.h"

--- a/drivers/power/ltm4700/ltm4700.c
+++ b/drivers/power/ltm4700/ltm4700.c
@@ -37,7 +37,7 @@
 #include <errno.h>
 #include "no_os_units.h"
 #include "no_os_util.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 #include "no_os_i2c.h"
 #include "no_os_gpio.h"

--- a/drivers/power/ltp8800/ltp8800.c
+++ b/drivers/power/ltp8800/ltp8800.c
@@ -37,7 +37,7 @@
 
 #include "no_os_units.h"
 #include "no_os_util.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 #include "no_os_pwm.h"
 #include "no_os_i2c.h"

--- a/drivers/power/max17616/max17616.c
+++ b/drivers/power/max17616/max17616.c
@@ -39,7 +39,7 @@
 
 #include "no_os_units.h"
 #include "no_os_util.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 #include "no_os_i2c.h"
 #include "no_os_crc8.h"

--- a/drivers/resolver/ad2s1210/ad2s1210.c
+++ b/drivers/resolver/ad2s1210/ad2s1210.c
@@ -36,7 +36,7 @@
 #include "no_os_util.h"
 #include "no_os_error.h"
 #include "no_os_print_log.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 
 static int ad2s1210_set_mode_pins(struct ad2s1210_dev *dev,

--- a/drivers/rf-transceiver/ad9361/ad9361.c
+++ b/drivers/rf-transceiver/ad9361/ad9361.c
@@ -40,7 +40,7 @@
 #include "ad9361_ext_band_ctrl.h"
 #include "no_os_spi.h"
 #include "no_os_gpio.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "ad9361_util.h"
 #include "no_os_util.h"
 #include "capi_alloc.h"
@@ -1037,9 +1037,9 @@ int32_t ad9361_reset(struct ad9361_rf_phy *phy)
 {
 	if (phy->gpio_desc_resetb) {
 		no_os_gpio_set_value(phy->gpio_desc_resetb, 0);
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 		no_os_gpio_set_value(phy->gpio_desc_resetb, 1);
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 		dev_dbg(&phy->spi->dev, "%s: by GPIO", __func__);
 		return 0;
 	}
@@ -1306,9 +1306,9 @@ static int32_t ad9361_check_cal_done(struct ad9361_rf_phy *phy, uint32_t reg,
 			return 0;
 
 		if (reg == REG_CALIBRATION_CTRL)
-			no_os_udelay(1200);
+			capi_wait_us(1200);
 		else
-			no_os_udelay(120);
+			capi_wait_us(120);
 		timeout--;
 	}
 
@@ -2038,7 +2038,7 @@ void ad9361_ensm_force_state(struct ad9361_rf_phy *phy, uint8_t ensm_state)
 	}
 
 	while (ad9361_ensm_get_state(phy) != ensm_state && --timeout) {
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 	}
 
 	if (timeout == 0)
@@ -4451,7 +4451,7 @@ int32_t ad9361_ensm_set_state(struct ad9361_rf_phy *phy, uint8_t ensm_state,
 		ad9361_spi_write(spi, REG_CLOCK_ENABLE,
 				 DIGITAL_POWER_UP | CLOCK_ENABLE_DFLT | BBPLL_ENABLE |
 				 (phy->pdata->use_extclk ? XO_BYPASS : 0)); /* Enable Clocks */
-		no_os_udelay(20);
+		capi_wait_us(20);
 		ad9361_spi_write(spi, REG_ENSM_CONFIG_1, TO_ALERT | FORCE_ALERT_STATE);
 		ad9361_trx_vco_cal_control(phy, false, true); /* Enable VCO Cal */
 		ad9361_trx_vco_cal_control(phy, true, true);
@@ -4495,9 +4495,9 @@ int32_t ad9361_ensm_set_state(struct ad9361_rf_phy *phy, uint8_t ensm_state,
 		ad9361_spi_write(spi, REG_ENSM_CONFIG_1,
 				 phy->pdata->fdd ? FORCE_TX_ON : FORCE_RX_ON);
 		/* Delay Flush Time 384 ADC clock cycles */
-		no_os_udelay(384000000UL / clk_get_rate(phy, phy->ref_clk_scale[ADC_CLK]));
+		capi_wait_us(384000000UL / clk_get_rate(phy, phy->ref_clk_scale[ADC_CLK]));
 		ad9361_spi_write(spi, REG_ENSM_CONFIG_1, 0); /* Move to Wait*/
-		no_os_udelay(1); /* Wait for ENSM settle */
+		capi_wait_us(1); /* Wait for ENSM settle */
 		ad9361_spi_write(spi, REG_CLOCK_ENABLE,
 				 (phy->pdata->use_extclk ? XO_BYPASS : 0)); /* Turn off all clocks */
 		phy->curr_ensm_state = ensm_state;
@@ -7523,7 +7523,7 @@ int32_t ad9361_rssi_gain_step_calib(struct ad9361_rf_phy *phy)
 				 gain_step_calib_reg_val[lo_index][i + 1]);
 		ad9361_spi_write(phy->spi, REG_CONFIG,
 				 CALIB_TABLE_SELECT(0x3) | WRITE_LNA_GAIN_DIFF | START_CALIB_TABLE_CLOCK);
-		no_os_udelay(3);	//Wait for data to fully write to internal table
+		capi_wait_us(3);	//Wait for data to fully write to internal table
 	}
 
 	ad9361_spi_write(phy->spi, REG_CONFIG, START_CALIB_TABLE_CLOCK);
@@ -7593,7 +7593,7 @@ int32_t ad9361_rssi_program_lna_gain(struct ad9361_rf_phy *phy)
 		ad9361_spi_write(spi, REG_CONFIG,
 				 CALIB_TABLE_SELECT(0x3) | WRITE_LNA_GAIN_DIFF |
 				 START_CALIB_TABLE_CLOCK);
-		no_os_udelay(3);
+		capi_wait_us(3);
 	}
 
 	ad9361_spi_write(spi, REG_CONFIG, START_CALIB_TABLE_CLOCK);

--- a/drivers/rf-transceiver/ad9361/ad9361_api.c
+++ b/drivers/rf-transceiver/ad9361/ad9361_api.c
@@ -33,7 +33,7 @@
 
 #include "ad9361.h"
 #include "ad9361_api.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_spi.h"
 #include "no_os_util.h"
 #include "capi_alloc.h"
@@ -2050,7 +2050,7 @@ int32_t ad9361_do_mcs(struct ad9361_rf_phy *phy_master,
 	for (step = 0; step <= 5; step++) {
 		ad9361_mcs(phy_slave, step);
 		ad9361_mcs(phy_master, step);
-		no_os_mdelay(100);
+		capi_wait_ms(100);
 	}
 
 	ad9361_set_en_state_machine_mode(phy_master, ensm_mode);

--- a/drivers/rf-transceiver/ad9361/ad9361_conv.c
+++ b/drivers/rf-transceiver/ad9361/ad9361_conv.c
@@ -34,7 +34,7 @@
 #include <inttypes.h>
 #include <string.h>
 #include "ad9361.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "ad9361_util.h"
 #include "axi_adc_core.h"
 #include "app_config.h"
@@ -76,7 +76,7 @@ static int32_t ad9361_check_pn(struct ad9361_rf_phy *phy, bool tx,
 	for (chan = 0; chan < num_chan; chan++)
 		axi_adc_write(axi_adc, AXI_ADC_REG_CHAN_STATUS(chan),
 			      AXI_ADC_PN_ERR | AXI_ADC_PN_OOS);
-	no_os_mdelay(delay);
+	capi_wait_ms(delay);
 
 	axi_adc_read(axi_adc, AXI_ADC_REG_STATUS, &adi_reg_status);
 	if (!tx && !(adi_reg_status & AXI_ADC_STATUS))
@@ -195,7 +195,7 @@ static int32_t ad9361_dig_tune_iodelay(struct ad9361_rf_phy *phy, bool tx)
 	for (i = 0; i < 7; i++) {
 		for (j = 0; j < 32; j++) {
 			ad9361_iodelay_set(st, i, j, tx);
-			no_os_mdelay(1);
+			capi_wait_ms(1);
 			field[j] = ad9361_check_pn(phy, tx, 10);
 		}
 

--- a/drivers/rf-transceiver/ad9361/ad9361_ext_band_ctrl.c
+++ b/drivers/rf-transceiver/ad9361/ad9361_ext_band_ctrl.c
@@ -13,7 +13,7 @@
 #include "ad9361_util.h"
 #include "ad9361_ext_band_ctrl.h"
 #include "no_os_gpio.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 #include "no_os_spi.h"
 
@@ -130,7 +130,7 @@ static int apply_setting(struct ad9361_rf_phy *phy,
 			if (ret < 0)
 				return ret;
 			if (new_sett->pre_seq[i].delay_us)
-				no_os_udelay(new_sett->pre_seq[i].delay_us);
+				capi_wait_us(new_sett->pre_seq[i].delay_us);
 		}
 	}
 
@@ -193,7 +193,7 @@ static int apply_setting(struct ad9361_rf_phy *phy,
 			if (ret < 0)
 				return ret;
 			if (new_sett->post_seq[i].delay_us)
-				no_os_udelay(new_sett->post_seq[i].delay_us);
+				capi_wait_us(new_sett->post_seq[i].delay_us);
 		}
 	}
 

--- a/drivers/rf-transceiver/ad9361/ad9361_util.c
+++ b/drivers/rf-transceiver/ad9361/ad9361_util.c
@@ -33,7 +33,7 @@
 
 #include "ad9361_util.h"
 #include "string.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 #define NO_OS_BITS_PER_LONG		32
 

--- a/drivers/rf-transceiver/hmc630x/hmc630x.c
+++ b/drivers/rf-transceiver/hmc630x/hmc630x.c
@@ -33,7 +33,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include "hmc630x.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 
 #define HMC630X_ARRAY_ADDRESS_MASK NO_OS_GENMASK(13, 8)
@@ -308,9 +308,9 @@ int hmc630x_write_row(struct hmc630x_dev *dev, uint8_t row, uint8_t val)
 	no_os_gpio_set_value(dev->en, NO_OS_GPIO_LOW);
 	for (b = 0; b < HMC630X_FRAME_SIZE; b++) {
 		no_os_gpio_set_value(dev->data, send & 0x1);
-		no_os_udelay(HMC6300_BITBANG_DELAY_US);
+		capi_wait_us(HMC6300_BITBANG_DELAY_US);
 		no_os_gpio_set_value(dev->clk, NO_OS_GPIO_HIGH);
-		no_os_udelay(HMC6300_BITBANG_DELAY_US);
+		capi_wait_us(HMC6300_BITBANG_DELAY_US);
 		no_os_gpio_set_value(dev->clk, NO_OS_GPIO_LOW);
 		send >>= 1;
 	}
@@ -340,9 +340,9 @@ int hmc630x_read_row(struct hmc630x_dev *dev, uint8_t row, uint8_t *val)
 	no_os_gpio_set_value(dev->en, NO_OS_GPIO_LOW);
 	for (b = 0; b < HMC630X_FRAME_SIZE; b++) {
 		no_os_gpio_set_value(dev->data, send & 0x1);
-		no_os_udelay(HMC6300_BITBANG_DELAY_US);
+		capi_wait_us(HMC6300_BITBANG_DELAY_US);
 		no_os_gpio_set_value(dev->clk, NO_OS_GPIO_HIGH);
-		no_os_udelay(HMC6300_BITBANG_DELAY_US);
+		capi_wait_us(HMC6300_BITBANG_DELAY_US);
 		no_os_gpio_set_value(dev->clk, NO_OS_GPIO_LOW);
 		send >>= 1;
 	}
@@ -350,22 +350,22 @@ int hmc630x_read_row(struct hmc630x_dev *dev, uint8_t row, uint8_t *val)
 	no_os_gpio_set_value(dev->en, NO_OS_GPIO_HIGH);
 
 	// extra pulse while cs is high
-	no_os_udelay(HMC6300_BITBANG_DELAY_US);
+	capi_wait_us(HMC6300_BITBANG_DELAY_US);
 	no_os_gpio_set_value(dev->clk, NO_OS_GPIO_HIGH);
-	no_os_udelay(HMC6300_BITBANG_DELAY_US);
+	capi_wait_us(HMC6300_BITBANG_DELAY_US);
 	no_os_gpio_set_value(dev->clk, NO_OS_GPIO_LOW);
-	no_os_udelay(HMC6300_BITBANG_DELAY_US);
+	capi_wait_us(HMC6300_BITBANG_DELAY_US);
 
 	*val = 0;
 	no_os_gpio_set_value(dev->en, NO_OS_GPIO_LOW);
 	for (b = 0; b < 8; b++) {
 		// scanout changes on sck rising edge
 		no_os_gpio_set_value(dev->clk, NO_OS_GPIO_HIGH);
-		no_os_udelay(HMC6300_BITBANG_DELAY_US);
+		capi_wait_us(HMC6300_BITBANG_DELAY_US);
 		// sample scanout along with sck faling edge
 		no_os_gpio_set_value(dev->clk, NO_OS_GPIO_LOW);
 		no_os_gpio_get_value(dev->scanout, &recv);
-		no_os_udelay(HMC6300_BITBANG_DELAY_US);
+		capi_wait_us(HMC6300_BITBANG_DELAY_US);
 		*val |= recv << b;
 	}
 	no_os_gpio_set_value(dev->en, NO_OS_GPIO_HIGH);
@@ -773,7 +773,7 @@ int hmc630x_set_vco(struct hmc630x_dev *dev, uint64_t frequency)
 			return ret;
 
 		/* TODO: update this when it'll be specified in the datasheet. */
-		no_os_mdelay(HMC6300_SETTLING_DELAY_MS);
+		capi_wait_ms(HMC6300_SETTLING_DELAY_MS);
 
 		/* Detect range of VCO_BANDSEL for which PLL locks. */
 		ret = hmc630x_read(dev, HMC630X_LOCKDET, &lock);
@@ -797,7 +797,7 @@ int hmc630x_set_vco(struct hmc630x_dev *dev, uint64_t frequency)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(HMC6300_SETTLING_DELAY_MS);
+	capi_wait_ms(HMC6300_SETTLING_DELAY_MS);
 
 	/* Make sure it locks. */
 	ret = hmc630x_read(dev, HMC630X_LOCKDET, &lock);

--- a/drivers/rf-transceiver/hmc630x/iio_hmc630x.c
+++ b/drivers/rf-transceiver/hmc630x/iio_hmc630x.c
@@ -35,7 +35,7 @@
 #include <inttypes.h>
 #include <math.h>
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "iio.h"
 #include "iio_hmc630x.h"
 #include "no_os_util.h"

--- a/drivers/rf-transceiver/koror/adrv904x.c
+++ b/drivers/rf-transceiver/koror/adrv904x.c
@@ -17,7 +17,7 @@
 #include "xilinx_transceiver.h"
 #include "no_os_print_log.h"
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 #include "no_os_util.h"
 #include "no_os_spi.h"

--- a/drivers/rf-transceiver/madura/adrv9025_conv.c
+++ b/drivers/rf-transceiver/madura/adrv9025_conv.c
@@ -8,7 +8,7 @@
 #include "no_os_print_log.h"
 #include "axi_adc_core.h"
 #include "axi_dac_core.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
 #include "adrv9025.h"
@@ -76,7 +76,7 @@ int adrv9025_post_setup(struct adrv9025_rf_phy *phy)
 				      AXI_ADC_ENABLE | AXI_ADC_IQCOR_ENB);
 		}
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 	axi_adc_read(phy->rx_adc, 0x4054, &freq);
 	axi_adc_read(phy->rx_adc, 0x4058, &ratio);
 	clock_hz = freq * ratio;

--- a/drivers/rf-transceiver/navassa/adrv9002.c
+++ b/drivers/rf-transceiver/navassa/adrv9002.c
@@ -35,7 +35,7 @@
 #include "no_os_print_log.h"
 #include "no_os_error.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_util.h"
 #include "no_os_clk.h"
 #include "adrv9002.h"
@@ -487,7 +487,7 @@ static int adrv9002_chan_to_state_poll(const struct adrv9002_rf_phy *phy,
 
 		if (__state == state)
 			break;
-		no_os_udelay(1000);
+		capi_wait_us(1000);
 	} while (++try < n_tries);
 
 	if (try == n_tries)
@@ -817,7 +817,7 @@ static int adrv9002_mcs_run(struct adrv9002_rf_phy *phy, const char *buf)
 
 		if (radio.mcsState == ADI_ADRV9001_ARMMCSSTATES_DONE)
 			break;
-		no_os_udelay(20 * 1000);
+		capi_wait_us(20 * 1000);
 	} while (++try < 10 * 1000);
 
 

--- a/drivers/rf-transceiver/navassa/adrv9002.h
+++ b/drivers/rf-transceiver/navassa/adrv9002.h
@@ -34,7 +34,7 @@
 #define IIO_TRX_ADRV9002_H_
 
 #include "no_os_gpio.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_clk.h"
 
 #include "adi_common_log.h"
@@ -374,7 +374,7 @@ static inline void adrv9002_sync_gpio_toggle(const struct adrv9002_rf_phy *phy)
 	if (phy->rx2tx2) {
 		/* toggle ssi sync gpio */
 		no_os_gpio_set_value(phy->ssi_sync, 1);
-		no_os_udelay(5000);
+		capi_wait_us(5000);
 		no_os_gpio_set_value(phy->ssi_sync, 0);
 	}
 }

--- a/drivers/rf-transceiver/navassa/adrv9002_conv.c
+++ b/drivers/rf-transceiver/navassa/adrv9002_conv.c
@@ -35,7 +35,7 @@
 #include <string.h>
 #include "no_os_util.h"
 #include "no_os_print_log.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "parameters.h"
 #include "adrv9002.h"
 #include "axi_adc_core.h"
@@ -292,7 +292,7 @@ static int adrv9002_axi_pn_check(const struct adrv9002_rf_phy *phy,
 		axi_adc_write(phy->rx1_adc, AIM_AXI_REG(off, AXI_ADC_REG_CHAN_STATUS(c)),
 			      AXI_ADC_PN_ERR | AXI_ADC_PN_OOS);
 
-	no_os_udelay(5000);
+	capi_wait_us(5000);
 
 	/* check for errors in any channel */
 	for (c = 0; c < n_chan; c++) {

--- a/drivers/rf-transceiver/palma/adrv903x.c
+++ b/drivers/rf-transceiver/palma/adrv903x.c
@@ -48,7 +48,7 @@
 #include "jesd204.h"
 #include "capi_alloc.h"
 #include "no_os_clk.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "no_os_print_log.h"
 #include "no_os_util.h"
@@ -621,7 +621,7 @@ static int adrv903x_jesd204_post_running_stage(struct jesd204_dev *jdev,
 	 * bare-metal no-OS the commands fire back-to-back and TxAttenSet
 	 * triggers an ARM CPU exception without this settling window.
 	 */
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	/* Set TX attenuation to 6 dB (matches Linux default) */
 	txAtten[0].txChannelMask = tx_mask;

--- a/drivers/rf-transceiver/talise/adrv9009.c
+++ b/drivers/rf-transceiver/talise/adrv9009.c
@@ -40,7 +40,7 @@
 #include "no_os_print_log.h"
 #include "no_os_error.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_util.h"
 
 // talise
@@ -548,7 +548,7 @@ static int adrv9009_jesd204_setup_stage2(struct jesd204_dev *jdev,
 
 	ret = TALISE_getPllsLockStatus(phy->talDevice, &pllLockStatus);
 	if ((pllLockStatus & pllLockStatus_mask) != pllLockStatus_mask) {
-		no_os_mdelay(200);
+		capi_wait_ms(200);
 		ret = TALISE_getPllsLockStatus(phy->talDevice, &pllLockStatus);
 		if ((pllLockStatus & pllLockStatus_mask) != pllLockStatus_mask) {
 			pr_err("%s:%d RF PLL unlocked (0x%x)\n",

--- a/drivers/rf-transceiver/talise/adrv9009_conv.c
+++ b/drivers/rf-transceiver/talise/adrv9009_conv.c
@@ -8,7 +8,7 @@
 #include "no_os_print_log.h"
 #include "axi_adc_core.h"
 #include "axi_dac_core.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
 #include "adrv9009.h"
@@ -57,7 +57,7 @@ int adrv9009_post_setup(struct adrv9009_rf_phy *phy)
 			      AXI_ADC_ENABLE | AXI_ADC_IQCOR_ENB);
 	}
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 	// Read frequency and ratio from DAC
 	axi_adc_read(phy->rx_adc, 0x4054, &freq);
 	axi_adc_read(phy->rx_adc, 0x4058, &ratio);

--- a/drivers/rtc/pcf85263/pcf85263.c
+++ b/drivers/rtc/pcf85263/pcf85263.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include "pcf85263.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 
 /**

--- a/drivers/sd-card/sd.c
+++ b/drivers/sd-card/sd.c
@@ -34,7 +34,7 @@
 *******************************************************************************/
 
 #include "sd.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "capi_alloc.h"
 
@@ -95,7 +95,7 @@ static int32_t wait_for_response(struct sd_desc *sd_desc, uint8_t *data_out)
 			ret = 0;
 			break;
 		}
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 	} while (not_timeout--);
 
 	return ret;
@@ -122,7 +122,7 @@ static int32_t wait_until_not_busy(struct sd_desc *sd_desc)
 			ret = 0;
 			break;
 		}
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 	} while (not_timeout--);
 
 	return ret;

--- a/drivers/switch/adg2128/iio_adg2128.c
+++ b/drivers/switch/adg2128/iio_adg2128.c
@@ -3,7 +3,7 @@
 #include <inttypes.h>
 #include <math.h>
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_i2c.h"
 #include "iio.h"
 #include "iio_adg2128.h"

--- a/drivers/switch/adgm3121/adgm3121.c
+++ b/drivers/switch/adgm3121/adgm3121.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include "no_os_error.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_util.h"
 #include "adgm3121.h"
 
@@ -215,7 +215,7 @@ static int adgm3121_set_switch_spi(struct adgm3121_dev *dev,
 	dev->switch_states = switch_data;
 
 	/* Wait for switching time */
-	no_os_udelay(ADGM3121_SWITCHING_TIME_US);
+	capi_wait_us(ADGM3121_SWITCHING_TIME_US);
 
 	return 0;
 }
@@ -319,7 +319,7 @@ int adgm3121_set_switches(struct adgm3121_dev *dev, uint8_t switch_mask)
 		dev->switch_states = switch_mask;
 
 		/* Wait for switching time */
-		no_os_udelay(ADGM3121_SWITCHING_TIME_US);
+		capi_wait_us(ADGM3121_SWITCHING_TIME_US);
 	}
 
 	return 0;
@@ -504,9 +504,9 @@ int adgm3121_init(struct adgm3121_dev **device,
 
 	/* Wait for power-up time */
 	if (dev->type == ID_ADGM3053)
-		no_os_mdelay(ADGM3053_POWER_UP_TIME_MS);
+		capi_wait_ms(ADGM3053_POWER_UP_TIME_MS);
 	else
-		no_os_mdelay(ADGM3121_POWER_UP_TIME_MS);
+		capi_wait_ms(ADGM3121_POWER_UP_TIME_MS);
 
 	/* Reset all switches to off state */
 	ret = adgm3121_reset_switches(dev);

--- a/drivers/temperature/adt7420/adt7420.c
+++ b/drivers/temperature/adt7420/adt7420.c
@@ -35,7 +35,7 @@
 #include <stdlib.h>
 #include "no_os_error.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "adt7420.h"
 
 const struct adt7420_chip_info chip_info[] = {
@@ -353,7 +353,7 @@ int32_t adt7420_reset(struct adt7420_dev *dev)
 			return -1;
 		}
 	}
-	no_os_mdelay(ADT7420_RESET_DELAY); /* device restart */
+	capi_wait_ms(ADT7420_RESET_DELAY); /* device restart */
 	dev->resolution_setting = 0;
 	return 0;
 }

--- a/drivers/temperature/adt75/adt75.c
+++ b/drivers/temperature/adt75/adt75.c
@@ -32,7 +32,7 @@
 *******************************************************************************/
 
 #include "adt75.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
 #include "no_os_units.h"
@@ -108,7 +108,7 @@ int adt75_get_single_temp(struct adt75_desc *desc, int32_t *val)
 		return ret;
 
 	/** Wait for a new conversion to finish */
-	no_os_mdelay(ADT75_CONV_DELAY_MS);
+	capi_wait_ms(ADT75_CONV_DELAY_MS);
 
 	reg_val = no_os_field_get(ADT75_TEMP_MASK, reg_val);
 	*val = no_os_sign_extend32(reg_val, ADT75_SIGN_BIT);

--- a/drivers/temperature/ltc2983/ltc2983.c
+++ b/drivers/temperature/ltc2983/ltc2983.c
@@ -34,7 +34,7 @@
 #include <errno.h>
 #include "ltc2983.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 
 /******************************************************************************/
@@ -98,7 +98,7 @@ int ltc2983_init(struct ltc2983_desc **device,
 		goto gpio_err;
 
 	/* bring the device out of reset */
-	no_os_udelay(1200);
+	capi_wait_us(1200);
 	ret = no_os_gpio_set_value(descriptor->gpio_rstn, NO_OS_GPIO_HIGH);
 	if (ret)
 		goto gpio_err;
@@ -235,7 +235,7 @@ int ltc2983_setup(struct ltc2983_desc *device)
 		ret = ltc2983_reg_read(device, LTC2983_STATUS_REG, &status);
 		if (ret)
 			return ret;
-		no_os_udelay(25000);
+		capi_wait_us(25000);
 	} while (LTC2983_STATUS_UP(status) != 1 && --timeout);
 	if (!timeout)
 		return -EINVAL;
@@ -343,7 +343,7 @@ int ltc2983_chan_read_resistance(struct ltc2983_desc *device, const int chan,
 		return ret;
 
 	/* wait for conversion to complete */
-	no_os_mdelay(300);
+	capi_wait_ms(300);
 
 	raw_array[0] = LTC2983_SPI_READ_BYTE;
 	no_os_put_unaligned_be16(ADT7604_RES_RES_ADDR(chan), raw_array + 1);
@@ -416,7 +416,7 @@ int ltc2983_chan_read_raw(struct ltc2983_desc *device, const int chan,
 	if (ret)
 		return ret;
 
-	no_os_mdelay(300);
+	capi_wait_ms(300);
 
 	/* read the converted data */
 	raw_array[0] = LTC2983_SPI_READ_BYTE;

--- a/drivers/temperature/max31827/max31827.c
+++ b/drivers/temperature/max31827/max31827.c
@@ -33,7 +33,7 @@
 
 #include "max31827.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "no_os_i2c.h"
 #include "no_os_print_log.h"
@@ -280,7 +280,7 @@ int max31827_read_temp_input(struct max31827_device *dev, int32_t *val)
 		if (ret)
 			return ret;
 
-		no_os_udelay(max31827_conv_times[dev->resolution]);
+		capi_wait_us(max31827_conv_times[dev->resolution]);
 	}
 
 	/**
@@ -290,7 +290,7 @@ int max31827_read_temp_input(struct max31827_device *dev, int32_t *val)
 	 */
 	if (dev->resolution == MAX31827_RES_12_BIT &&
 	    dev->update_interval == max31827_conversions[MAX31827_CNV_8_HZ])
-		no_os_udelay(15000);
+		capi_wait_us(15000);
 
 	return max31827_read_temp(dev, MAX31827_T_REG, val);
 }

--- a/drivers/temperature/max31865pmb1/max31865.c
+++ b/drivers/temperature/max31865pmb1/max31865.c
@@ -40,7 +40,7 @@
 #include "no_os_spi.h"
 #include "no_os_util.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 /******************************************************************************/
 
@@ -401,9 +401,9 @@ int max31865_read_rtd(struct max31865_dev *device, uint16_t *rtd_reg)
 		return ret;
 
 	if (device->is_filt_50)
-		no_os_udelay(62500 + device->t_rc_delay);
+		capi_wait_us(62500 + device->t_rc_delay);
 	else
-		no_os_udelay(52000 + device->t_rc_delay);
+		capi_wait_us(52000 + device->t_rc_delay);
 
 	ret = max31865_read(device, MAX31865_RTDMSB_REG, &reg_data);
 	if (ret)

--- a/drivers/temperature/max31889/max31889.c
+++ b/drivers/temperature/max31889/max31889.c
@@ -33,7 +33,7 @@
 
 #include "max31889.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_util.h"
 
 int32_t max31889_write_reg(struct max31889_desc *desc, uint8_t reg_addr,
@@ -105,7 +105,7 @@ int32_t max31889_trig_and_read_temp(struct max31889_desc *desc,
 		if (ret)
 			return ret;
 		++step_counter;
-		no_os_mdelay(
+		capi_wait_ms(
 			TEMP_MEAS_WAIT_UNTIL_ERROR_MS); // Delay to allow the conversion to complete
 	} while (!(reg_tmp & NO_OS_BIT(1)) && step_counter < MAX31889_MAX_CONV_STEPS);
 

--- a/projects/ad-acevsecrdset-sl/src/interface/interface.c
+++ b/projects/ad-acevsecrdset-sl/src/interface/interface.c
@@ -33,7 +33,7 @@
 
 #include "no_os_print_log.h"
 #include "state_machine.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "common_data.h"
 #include "interface.h"
 

--- a/projects/ad-acevsecrdset-sl/src/self_test/self_test.c
+++ b/projects/ad-acevsecrdset-sl/src/self_test/self_test.c
@@ -33,7 +33,7 @@
 
 #include "no_os_print_log.h"
 #include "common_data.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "parameters.h"
 #include "no_os_util.h"
 #include "self_test.h"
@@ -107,7 +107,7 @@ int self_test_supply(struct stout *stout, struct rms_adc_values *rms_adc_values)
 		goto error1;
 	pr_debug("PASSED \n");
 	// Allow time for relay to switch
-	no_os_mdelay(DELAY_SELF_TEST_READING);
+	capi_wait_ms(DELAY_SELF_TEST_READING);
 	// Test Vin value within limits
 	// Skip SELF_TEST_SKIP_CYCLES_NO periods
 	while (!get_zero_cross_flag_state());
@@ -137,7 +137,7 @@ int self_test_supply(struct stout *stout, struct rms_adc_values *rms_adc_values)
 	ret = relay_open(stout->relay);
 	if (ret)
 		goto error1;
-	no_os_mdelay(DELAY_SELF_TEST_READING);
+	capi_wait_ms(DELAY_SELF_TEST_READING);
 	// Test Vin value within limits
 	// Skip SELF_TEST_SKIP_CYCLES_NO periods
 	while (!get_zero_cross_flag_state());
@@ -211,14 +211,14 @@ int self_test_rcd(struct stout *stout)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(60);
+	capi_wait_ms(60);
 
 	ret = no_os_gpio_set_value(stout->gpio_rcm_test, NO_OS_GPIO_HIGH);
 	if (ret)
 		return ret;
 
 	// Wait for 700 ms and sample rcddc and rcdac pins (we should have rcddc 1 and rcdac 0)
-	no_os_mdelay(700);
+	capi_wait_ms(700);
 	ret = no_os_gpio_get_value(stout->gpio_rcddc, &val_rcddc);
 	if (ret)
 		return ret;
@@ -230,7 +230,7 @@ int self_test_rcd(struct stout *stout)
 		goto error;
 
 	// wait for another 700 ms, we should have both values 1
-	no_os_mdelay(700);
+	capi_wait_ms(700);
 	ret = no_os_gpio_get_value(stout->gpio_rcddc, &val_rcddc);
 	if (ret)
 		return ret;
@@ -242,7 +242,7 @@ int self_test_rcd(struct stout *stout)
 		goto error;
 
 	// Wait for another 600 ms, we should have both values 0
-	no_os_mdelay(720);
+	capi_wait_ms(720);
 	ret = no_os_gpio_get_value(stout->gpio_rcddc, &val_rcddc);
 	if (ret)
 		return ret;
@@ -472,7 +472,7 @@ int self_test_startup(struct stout *stout,
 	// Start the CP signal, so we can test it
 	// Test only the high portion of the CP
 	pilot_pwm_timer_set_duty_cycle(stout, PWM_DC);
-	no_os_mdelay(200);
+	capi_wait_ms(200);
 	ret = self_test_rcd(stout);
 	if (ret)
 		goto error;

--- a/projects/ad-acevsecrdset-sl/src/state_machine/state_machine.c
+++ b/projects/ad-acevsecrdset-sl/src/state_machine/state_machine.c
@@ -33,7 +33,7 @@
 
 #include "no_os_print_log.h"
 #include "state_machine.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 #include "common_data.h"
 #include "no_os_error.h"
@@ -53,6 +53,24 @@
 uint16_t zcross_cnt;
 // Charging state
 uint8_t is_charging;
+
+// Monotonic time since boot, split into whole seconds and the microseconds
+// within the current second (the shape the state machine timing logic expects).
+struct sm_time {
+	uint32_t s, us;
+};
+
+static struct sm_time sm_get_time(void)
+{
+	uint64_t now_us = 0;
+
+	capi_uptime(&now_us);
+
+	return (struct sm_time) {
+		.s = (uint32_t)(now_us / 1000000ULL),
+		.us = (uint32_t)(now_us % 1000000ULL),
+	};
+}
 
 /**
  * @brief State machine main execution
@@ -82,7 +100,7 @@ int state_machine()
 	// Variable used for skipping the repeated execution of RCD test steps
 	uint8_t count_rcd_state = 0;
 	// Curent time value read from RTC
-	struct no_os_time current_time = no_os_get_time();
+	struct sm_time current_time = sm_get_time();
 	// The time interval in which the RCD test is disabled
 	uint32_t rcd_test_s = current_time.s;
 	// The time interval in which the print values is disabled
@@ -133,7 +151,7 @@ int state_machine()
 	/**************************************************************************/
 	/* Clear the screen. */
 	printf("%c%c%c%c", 27, '[', '2', 'J');
-	no_os_mdelay(5);
+	capi_wait_ms(5);
 	pr_debug("\nSTOUT app FIRMWARE VERSION: %s\n", FIRMWARE_VERSION);
 	/*Board revision*/
 #if defined(REV_A)
@@ -303,7 +321,7 @@ int state_machine()
 			// Compute PWM LOW and PWM HIGH averages
 			pilot_write_new_values(stout);
 			// Get current time since device powered
-			current_time = no_os_get_time();
+			current_time = sm_get_time();
 
 			if (current_time.us < recalc_time_us)
 				us_elapsed_since_recalc = current_time.us + 1000000 - recalc_time_us;
@@ -311,7 +329,7 @@ int state_machine()
 				us_elapsed_since_recalc = current_time.us - recalc_time_us;
 
 			if (VALUE_20MS < us_elapsed_since_recalc) {
-				current_time = no_os_get_time();
+				current_time = sm_get_time();
 				recalc_time_us = current_time.us;
 				// The CP event is determined only if the the special cases are not present
 				if ((event != S_M_CHECK_STUCK_RELAY) && (event != S_M_DIODE_ERR_CHECK)
@@ -515,7 +533,7 @@ int state_machine()
 							stout->err_status = INTF_RCD_ERROR;
 						}
 						// Reset values to disable RCD test for the time specified by RCD_TIME_REPEAT_INTERVAL
-						current_time = no_os_get_time();
+						current_time = sm_get_time();
 						rcd_test_s = current_time.s;
 						reset_count_ms();
 					} else if (S_M_RCD_TEST_TRIGGERED == event) {
@@ -898,7 +916,7 @@ error:
 		ret = interface_disp(stout);
 		if (ret)
 			return ret;
-		no_os_mdelay(50);
+		capi_wait_ms(50);
 	}
 	return ret;
 	/*****************************************ERROR latching and display END****************************************/

--- a/projects/ad3552r_fmcz/src/examples/axi_qspi/axi_qspi_example.c
+++ b/projects/ad3552r_fmcz/src/examples/axi_qspi/axi_qspi_example.c
@@ -44,7 +44,7 @@
 #include "no_os_spi.h"
 #include "no_os_gpio.h"
 #include "no_os_util.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "xilinx_spi.h"
 #include "xilinx_gpio.h"
 #include "ad3552r.h"
@@ -171,7 +171,7 @@ int32_t run_example(struct ad3552r_desc *dac)
 		return err;
 	}
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	samples[0] = 0;
 	samples[1] = 65534;
@@ -187,7 +187,7 @@ int32_t run_example(struct ad3552r_desc *dac)
 		return err;
 	}
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	pr_info("Fast cyclic dma transfer starts now, for 20 seconds ...\n");
 

--- a/projects/ad3552r_fmcz/src/examples/generic_spi/generic_spi_example.c
+++ b/projects/ad3552r_fmcz/src/examples/generic_spi/generic_spi_example.c
@@ -38,7 +38,7 @@
 #include "no_os_spi.h"
 #include "no_os_gpio.h"
 #include "no_os_util.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "xilinx_spi.h"
 #include "xilinx_gpio.h"
 #include "ad3552r.h"
@@ -157,7 +157,7 @@ int32_t run_example(struct ad3552r_desc *dac)
 		if (NO_OS_IS_ERR_VALUE(err))
 			return err;
 
-		no_os_udelay(time_between_samples_us);
+		capi_wait_us(time_between_samples_us);
 
 		i = (i + 1) % nb_samples;
 		err = ad3552r_ldac_trigger(dac, AD3552R_MASK_ALL_CH, false);

--- a/projects/ad405x/src/examples/basic_i3c_example/basic_i3c_example.c
+++ b/projects/ad405x/src/examples/basic_i3c_example/basic_i3c_example.c
@@ -38,7 +38,7 @@
 *******************************************************************************/
 
 #include "common_data.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "ad405x.h"
 
@@ -131,7 +131,7 @@ int example_main()
 		while (i < 50) {
 			ret = ad405x_get_adc(dev, &data);
 			pr_info("\rADC(%02d): %05ld", ++i, data);
-			no_os_mdelay(50); // Cosmetic delay
+			capi_wait_ms(50); // Cosmetic delay
 		}
 
 		pr_info("\nWaiting threshold event .");
@@ -147,7 +147,7 @@ int example_main()
 		while (block_non_blocking) {
 			// Other task...
 			pr_info("\b%c", loading_wheel[++i & 0x3]);
-			no_os_mdelay(100); // Cosmetic delay
+			capi_wait_ms(100); // Cosmetic delay
 		};
 		/* Left wait loop, continue execution */
 		pr_info("\rGot threshold event!     ");

--- a/projects/ad405x/src/examples/i3c_dma_example/i3c_dma_example.c
+++ b/projects/ad405x/src/examples/i3c_dma_example/i3c_dma_example.c
@@ -38,7 +38,7 @@
 *******************************************************************************/
 
 #include "common_data.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "ad405x.h"
 
@@ -126,7 +126,7 @@ int example_main()
 		data = no_os_get_unaligned_be32((uint8_t *)&data);
 
 		pr_info("\rADC(%02d): %05ld", ++i, data);
-		no_os_mdelay(50); // Cosmetic delay
+		capi_wait_ms(50); // Cosmetic delay
 	}
 
 error_dev:

--- a/projects/ad405x/src/examples/iio_example/iio_example.c
+++ b/projects/ad405x/src/examples/iio_example/iio_example.c
@@ -41,7 +41,7 @@
 #include "common_data.h"
 #include "no_os_util.h"
 #include "no_os_print_log.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "iio_ad405x.h"
 
 #define DATA_BUFFER_SIZE 1000

--- a/projects/ad5460/src/examples/basic/basic_example.c
+++ b/projects/ad5460/src/examples/basic/basic_example.c
@@ -33,7 +33,7 @@
 
 #include "common_data.h"
 #include "ad5460.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_print_log.h"
 

--- a/projects/ad5460/src/examples/channel_output_example/channel_output_example.c
+++ b/projects/ad5460/src/examples/channel_output_example/channel_output_example.c
@@ -34,7 +34,7 @@
 
 #include "common_data.h"
 #include "ad5460.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_print_log.h"
 

--- a/projects/ad5460/src/examples/current_output_example/current_output_example.c
+++ b/projects/ad5460/src/examples/current_output_example/current_output_example.c
@@ -34,7 +34,7 @@
 
 #include "common_data.h"
 #include "ad5460.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_print_log.h"
 

--- a/projects/ad5460/src/examples/voltage_output_example/voltage_output_example.c
+++ b/projects/ad5460/src/examples/voltage_output_example/voltage_output_example.c
@@ -34,7 +34,7 @@
 
 #include "common_data.h"
 #include "ad5460.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_print_log.h"
 

--- a/projects/ad6676-ebz/src/ad6676_ebz.c
+++ b/projects/ad6676-ebz/src/ad6676_ebz.c
@@ -42,7 +42,7 @@
 #include "no_os_gpio.h"
 #include "xilinx_spi.h"
 #include "xilinx_gpio.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "ad6676.h"
 #include "axi_adc_core.h"
@@ -492,7 +492,7 @@ int main(void)
 
 #ifdef IIO_SUPPORT
 	// Allow time for UART messages to be displayed
-	no_os_mdelay(200);
+	capi_wait_ms(200);
 
 	struct xil_uart_init_param platform_uart_init_par = {
 #ifdef XPAR_XUARTLITE_NUM_INSTANCES

--- a/projects/ad7091r8-sdz/src/examples/basic/basic_example.c
+++ b/projects/ad7091r8-sdz/src/examples/basic/basic_example.c
@@ -34,7 +34,7 @@
 #include "common_data.h"
 #include "ad7091r8.h"
 #include "no_os_uart.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_util.h"
 
@@ -76,7 +76,7 @@ int example_main()
 		printf("Channel %d raw ADC output: %d\n\r",
 		       no_os_field_get(AD7091R8_REG_RESULT_CH_ID_MASK, val),
 		       no_os_field_get(AD7091R8_REG_RESULT_DATA_MASK, val));
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 	}
 
 error:

--- a/projects/ad713x_fmcz/src/ad713x_fmc.c
+++ b/projects/ad713x_fmcz/src/ad713x_fmc.c
@@ -46,7 +46,7 @@
 #include "ad713x.h"
 #include "no_os_spi.h"
 #include "xilinx_spi.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "xilinx_gpio.h"
 #include "no_os_util.h"
@@ -276,12 +276,12 @@ int main()
 	if (ret != 0)
 		return -1;
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 	ad713x_init_param_2.spi_common_dev = ad713x_dev_1->spi_desc;
 	ret = ad713x_init(&ad713x_dev_2, &ad713x_init_param_2);
 	if (ret != 0)
 		return -1;
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	spi_engine_offload_init_param.rx_dma_baseaddr = AD7134_DMA_BASEADDR;
 	spi_engine_offload_init_param.offload_config = OFFLOAD_RX_EN;

--- a/projects/ad738x_fmcz/src/examples/basic_example/basic_example.c
+++ b/projects/ad738x_fmcz/src/examples/basic_example/basic_example.c
@@ -34,7 +34,7 @@
 
 #include "basic_example.h"
 #include "common_data.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 
 #ifdef NUMBER_OF_CHANNELS
@@ -89,7 +89,7 @@ int basic_example_main()
 			pr_info("\r\n");
 		}
 #endif
-		no_os_mdelay(5000);
+		capi_wait_ms(5000);
 	}
 
 	return ad738x_remove(dev);

--- a/projects/ad74413r/src/examples/dummy/dummy_example.c
+++ b/projects/ad74413r/src/examples/dummy/dummy_example.c
@@ -33,7 +33,7 @@
 
 #include "common_data.h"
 #include "ad74413r.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 
 /***************************************************************************//**
@@ -179,7 +179,7 @@ int example_main()
 		pr_info("Channel C fault: %d\n", status.status_bits.VI_ERR_C);
 		pr_info("Channel D fault: %d\n", status.status_bits.VI_ERR_D);
 
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 	}
 
 error:

--- a/projects/ad74414h/src/examples/basic/basic_example.c
+++ b/projects/ad74414h/src/examples/basic/basic_example.c
@@ -33,7 +33,7 @@
 
 #include "common_data.h"
 #include "ad74416h.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_print_log.h"
 

--- a/projects/ad74414h/src/examples/current_input_ext/current_input_ext.c
+++ b/projects/ad74414h/src/examples/current_input_ext/current_input_ext.c
@@ -33,7 +33,7 @@
 
 #include "common_data.h"
 #include "ad74416h.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "math.h"
 

--- a/projects/ad74414h/src/examples/current_input_loop/current_input_loop.c
+++ b/projects/ad74414h/src/examples/current_input_loop/current_input_loop.c
@@ -33,7 +33,7 @@
 
 #include "common_data.h"
 #include "ad74416h.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include <math.h>
 

--- a/projects/ad74414h/src/examples/current_output/current_output.c
+++ b/projects/ad74414h/src/examples/current_output/current_output.c
@@ -33,7 +33,7 @@
 
 #include "common_data.h"
 #include "ad74416h.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 
 /***************************************************************************//**

--- a/projects/ad74414h/src/examples/digital_input_logic/digital_input_logic.c
+++ b/projects/ad74414h/src/examples/digital_input_logic/digital_input_logic.c
@@ -36,7 +36,7 @@
 
 #include "common_data.h"
 #include "ad74416h.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_util.h"
 
@@ -143,7 +143,7 @@ int example_main()
 	}
 
 	while (1) {
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 		ret = ad74416h_gpio_get(ad74414h_desc, 0, &dig_input);
 		if (ret) {
 			pr_info("Error getting DIN value\r\n");

--- a/projects/ad74414h/src/examples/digital_input_loop/digital_input_loop.c
+++ b/projects/ad74414h/src/examples/digital_input_loop/digital_input_loop.c
@@ -36,7 +36,7 @@
 
 #include "common_data.h"
 #include "ad74416h.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_util.h"
 
@@ -158,7 +158,7 @@ int example_main()
 
 
 	while (1) {
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 		ret = ad74416h_gpio_get(ad74414h_desc, 0, &dig_input);
 		if (ret) {
 			pr_info("Error getting DIN value\r\n");

--- a/projects/ad74414h/src/examples/digital_output/digital_output.c
+++ b/projects/ad74414h/src/examples/digital_output/digital_output.c
@@ -33,7 +33,7 @@
 
 #include "common_data.h"
 #include "ad74416h.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_util.h"
 

--- a/projects/ad74416h/src/examples/basic/basic_example.c
+++ b/projects/ad74416h/src/examples/basic/basic_example.c
@@ -33,7 +33,7 @@
 
 #include "common_data.h"
 #include "ad74416h.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_print_log.h"
 

--- a/projects/ad74416h/src/examples/current_input_ext/current_input_ext.c
+++ b/projects/ad74416h/src/examples/current_input_ext/current_input_ext.c
@@ -34,7 +34,7 @@
 
 #include "common_data.h"
 #include "ad74416h.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "math.h"
 

--- a/projects/ad74416h/src/examples/current_input_loop/current_input_loop.c
+++ b/projects/ad74416h/src/examples/current_input_loop/current_input_loop.c
@@ -34,7 +34,7 @@
 
 #include "common_data.h"
 #include "ad74416h.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include <math.h>
 

--- a/projects/ad74416h/src/examples/current_output/current_output.c
+++ b/projects/ad74416h/src/examples/current_output/current_output.c
@@ -34,7 +34,7 @@
 
 #include "common_data.h"
 #include "ad74416h.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 
 /***************************************************************************//**

--- a/projects/ad74416h/src/examples/digital_input_logic/digital_input_logic.c
+++ b/projects/ad74416h/src/examples/digital_input_logic/digital_input_logic.c
@@ -37,7 +37,7 @@
 
 #include "common_data.h"
 #include "ad74416h.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_util.h"
 
@@ -144,7 +144,7 @@ int example_main()
 	}
 
 	while (1) {
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 		ret = ad74416h_gpio_get(ad74416h_desc, 0, &dig_input);
 		if (ret) {
 			pr_info("Error getting DIN value\r\n");

--- a/projects/ad74416h/src/examples/digital_input_loop/digital_input_loop.c
+++ b/projects/ad74416h/src/examples/digital_input_loop/digital_input_loop.c
@@ -37,7 +37,7 @@
 
 #include "common_data.h"
 #include "ad74416h.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_util.h"
 
@@ -159,7 +159,7 @@ int example_main()
 
 
 	while (1) {
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 		ret = ad74416h_gpio_get(ad74416h_desc, 0, &dig_input);
 		if (ret) {
 			pr_info("Error getting DIN value\r\n");

--- a/projects/ad74416h/src/examples/digital_output/digital_output.c
+++ b/projects/ad74416h/src/examples/digital_output/digital_output.c
@@ -34,7 +34,7 @@
 
 #include "common_data.h"
 #include "ad74416h.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_util.h"
 

--- a/projects/ad74416h/src/examples/multiple_devices/multiple_devices.c
+++ b/projects/ad74416h/src/examples/multiple_devices/multiple_devices.c
@@ -34,7 +34,7 @@
 
 #include "common_data.h"
 #include "ad74416h.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 
 /***************************************************************************//**

--- a/projects/ad74416h/src/examples/temperature_2wire_rtd/temperature_2wire_rtd.c
+++ b/projects/ad74416h/src/examples/temperature_2wire_rtd/temperature_2wire_rtd.c
@@ -34,7 +34,7 @@
 
 #include "common_data.h"
 #include "ad74416h.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_util.h"
 #include <math.h>

--- a/projects/ad74416h/src/examples/temperature_3wire_rtd/temperature_3wire_rtd.c
+++ b/projects/ad74416h/src/examples/temperature_3wire_rtd/temperature_3wire_rtd.c
@@ -34,7 +34,7 @@
 
 #include "common_data.h"
 #include "ad74416h.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_util.h"
 #include <math.h>

--- a/projects/ad74416h/src/examples/voltage_input/voltage_input.c
+++ b/projects/ad74416h/src/examples/voltage_input/voltage_input.c
@@ -34,7 +34,7 @@
 
 #include "common_data.h"
 #include "ad74416h.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include <math.h>
 

--- a/projects/ad74416h/src/examples/voltage_input_irq/voltage_input_irq.c
+++ b/projects/ad74416h/src/examples/voltage_input_irq/voltage_input_irq.c
@@ -34,7 +34,7 @@
 
 #include "common_data.h"
 #include "ad74416h.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_gpio.h"
 #include "no_os_irq.h"

--- a/projects/ad74416h/src/examples/voltage_output/voltage_output.c
+++ b/projects/ad74416h/src/examples/voltage_output/voltage_output.c
@@ -34,7 +34,7 @@
 
 #include "common_data.h"
 #include "ad74416h.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 
 /***************************************************************************//**

--- a/projects/ad7746-ebz/src/app/headless.c
+++ b/projects/ad7746-ebz/src/app/headless.c
@@ -45,7 +45,7 @@
 #include "ad7746.h"
 #include "no_os_i2c.h"
 #include "aducm3029_i2c.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_uart.h"
 #include "aducm3029_uart.h"
@@ -185,7 +185,7 @@ int main(void)
 
 		pr_info("Position: %d mm, Temperature: %d *C\n", capData, temperature);
 
-		no_os_mdelay(2000);
+		capi_wait_ms(2000);
 	}
 
 error:

--- a/projects/ad7768-1fmcz/src/ad77681evb.c
+++ b/projects/ad7768-1fmcz/src/ad77681evb.c
@@ -43,7 +43,7 @@
 #include "ad77681.h"
 #include "spi_engine.h"
 #include "parameters.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 
 uint32_t spi_msg_cmds[6] = {CS_LOW, CS_HIGH, CS_LOW, WRITE_READ(1), CS_HIGH};
@@ -135,7 +135,7 @@ int main()
 				printf("%x", adc_data[i]);
 			}
 			printf("\r\n");
-			no_os_mdelay(1000);
+			capi_wait_ms(1000);
 		}
 	} else {
 		ret = spi_engine_offload_init(adc_dev->spi_desc,
@@ -154,7 +154,7 @@ int main()
 		if (ret != 0)
 			return ret;
 
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 
 		Xil_DCacheInvalidateRange(spi_engine_offload_message.rx_addr,
 					  AD77681_EVB_SAMPLE_NO * 4);

--- a/projects/ad7768-evb/src/ad7768_evb.c
+++ b/projects/ad7768-evb/src/ad7768_evb.c
@@ -37,7 +37,7 @@
 #include "axi_dmac.h"
 #include "no_os_print_log.h"
 #include "no_os_gpio.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "xilinx_spi.h"
 #include "xilinx_gpio.h"
 #include "no_os_error.h"
@@ -134,13 +134,13 @@ int main(void)
 	if (ret)
 		goto error_1;
 	/* minimum 2 / mclck */
-	no_os_udelay(100);
+	capi_wait_us(100);
 	ret = no_os_gpio_set_value(dev->gpio_reset, NO_OS_GPIO_HIGH);
 	if (ret != 0)
 		goto error_1;
 
 	// allow at least 1.66 ms after reset, (ADC start-up time)
-	no_os_udelay(1660);
+	capi_wait_us(1660);
 
 	/* Check Rev ID */
 	ret = ad7768_spi_read(dev, AD7768_REG_REV_ID, &reg_data);
@@ -173,7 +173,7 @@ int main(void)
 			      AXI_ADC_FORMAT_SIGNEXT | AXI_ADC_FORMAT_ENABLE |
 			      AXI_ADC_ENABLE);
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	/* Finish AXI ADC initialization */
 	axi_adc_write(axi_adc_core_desc, AXI_ADC_REG_CNTRL_3, AXI_ADC_CRC_EN);

--- a/projects/ad9083/src/app_ad9083.c
+++ b/projects/ad9083/src/app_ad9083.c
@@ -41,7 +41,7 @@
 #include "xilinx_gpio.h"
 #include "no_os_error.h"
 #include "no_os_util.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "capi_alloc.h"
 
@@ -117,7 +117,7 @@ int32_t app_ad9083_status(struct app_ad9083 *app)
 				stat & NO_OS_BIT(6) ? "established" : "lost",
 				stat & NO_OS_BIT(7) ? "invalid" : "valid");
 		else
-			no_os_udelay(20000);
+			capi_wait_us(20000);
 
 	} while (ret && retry--);
 

--- a/projects/ad9208/src/main.c
+++ b/projects/ad9208/src/main.c
@@ -45,7 +45,7 @@
 #include "xil_printf.h"
 #include <xparameters.h>
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_spi.h"
 #include "xilinx_spi.h"
 #include "no_os_gpio.h"
@@ -479,7 +479,7 @@ int main(void)
 		goto error_1;
 	}
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	status = ad9208_initialize(&ad9208_1_device, &ad9208_1_param);
 	if (status != 0) {

--- a/projects/ad9361/src/main.c
+++ b/projects/ad9361/src/main.c
@@ -37,7 +37,7 @@
 #include "parameters.h"
 #include "no_os_spi.h"
 #include "no_os_gpio.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #ifdef XILINX_PLATFORM
 #include <xparameters.h>
 #include <xil_cache.h>
@@ -829,7 +829,7 @@ int main(void)
 	/* Flush cache data. */
 	Xil_DCacheInvalidateRange((uintptr_t)dac_buffer, sizeof(sine_lut_iq));
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 #endif
 #ifdef FMCOMMS5
@@ -1142,83 +1142,83 @@ int main(void)
 				return status;
 			}
 			no_os_gpio_direction_output(gpio_txnrx_pin, 0);
-			no_os_udelay(10);
+			capi_wait_us(10);
 			ad9361_get_en_state_machine_mode(ad9361_phy, &ensm_mode);
 			printf("TXNRX control - Alert: %s\n",
 			       ensm_mode == ENSM_MODE_ALERT ? "OK" : "Error");
-			no_os_mdelay(1000);
+			capi_wait_ms(1000);
 
 			if (ad9361_phy->pdata->ensm_pin_pulse_mode) {
 				while (1) {
 					no_os_gpio_set_value(gpio_txnrx_pin, 0);
-					no_os_udelay(10);
+					capi_wait_us(10);
 					no_os_gpio_set_value(gpio_enable_pin, 1);
-					no_os_udelay(10);
+					capi_wait_us(10);
 					no_os_gpio_set_value(gpio_enable_pin, 0);
 					ad9361_get_en_state_machine_mode(ad9361_phy, &ensm_mode);
 					printf("TXNRX Pulse control - RX: %s\n",
 					       ensm_mode == ENSM_MODE_RX ? "OK" : "Error");
-					no_os_mdelay(1000);
+					capi_wait_ms(1000);
 
 					no_os_gpio_set_value(gpio_enable_pin, 1);
-					no_os_udelay(10);
+					capi_wait_us(10);
 					no_os_gpio_set_value(gpio_enable_pin, 0);
 					ad9361_get_en_state_machine_mode(ad9361_phy, &ensm_mode);
 					printf("TXNRX Pulse control - Alert: %s\n",
 					       ensm_mode == ENSM_MODE_ALERT ? "OK" : "Error");
-					no_os_mdelay(1000);
+					capi_wait_ms(1000);
 
 					no_os_gpio_set_value(gpio_txnrx_pin, 1);
-					no_os_udelay(10);
+					capi_wait_us(10);
 					no_os_gpio_set_value(gpio_enable_pin, 1);
-					no_os_udelay(10);
+					capi_wait_us(10);
 					no_os_gpio_set_value(gpio_enable_pin, 0);
 					ad9361_get_en_state_machine_mode(ad9361_phy, &ensm_mode);
 					printf("TXNRX Pulse control - TX: %s\n",
 					       ensm_mode == ENSM_MODE_TX ? "OK" : "Error");
-					no_os_mdelay(1000);
+					capi_wait_ms(1000);
 
 					no_os_gpio_set_value(gpio_enable_pin, 1);
-					no_os_udelay(10);
+					capi_wait_us(10);
 					no_os_gpio_set_value(gpio_enable_pin, 0);
 					ad9361_get_en_state_machine_mode(ad9361_phy, &ensm_mode);
 					printf("TXNRX Pulse control - Alert: %s\n",
 					       ensm_mode == ENSM_MODE_ALERT ? "OK" : "Error");
-					no_os_mdelay(1000);
+					capi_wait_ms(1000);
 				}
 			} else {
 				while (1) {
 					no_os_gpio_set_value(gpio_txnrx_pin, 0);
-					no_os_udelay(10);
+					capi_wait_us(10);
 					no_os_gpio_set_value(gpio_enable_pin, 1);
-					no_os_udelay(10);
+					capi_wait_us(10);
 					ad9361_get_en_state_machine_mode(ad9361_phy, &ensm_mode);
 					printf("TXNRX control - RX: %s\n",
 					       ensm_mode == ENSM_MODE_RX ? "OK" : "Error");
-					no_os_mdelay(1000);
+					capi_wait_ms(1000);
 
 					no_os_gpio_set_value(gpio_enable_pin, 0);
-					no_os_udelay(10);
+					capi_wait_us(10);
 					ad9361_get_en_state_machine_mode(ad9361_phy, &ensm_mode);
 					printf("TXNRX control - Alert: %s\n",
 					       ensm_mode == ENSM_MODE_ALERT ? "OK" : "Error");
-					no_os_mdelay(1000);
+					capi_wait_ms(1000);
 
 					no_os_gpio_set_value(gpio_txnrx_pin, 1);
-					no_os_udelay(10);
+					capi_wait_us(10);
 					no_os_gpio_set_value(gpio_enable_pin, 1);
-					no_os_udelay(10);
+					capi_wait_us(10);
 					ad9361_get_en_state_machine_mode(ad9361_phy, &ensm_mode);
 					printf("TXNRX control - TX: %s\n",
 					       ensm_mode == ENSM_MODE_TX ? "OK" : "Error");
-					no_os_mdelay(1000);
+					capi_wait_ms(1000);
 
 					no_os_gpio_set_value(gpio_enable_pin, 0);
-					no_os_udelay(10);
+					capi_wait_us(10);
 					ad9361_get_en_state_machine_mode(ad9361_phy, &ensm_mode);
 					printf("TXNRX control - Alert: %s\n",
 					       ensm_mode == ENSM_MODE_ALERT ? "OK" : "Error");
-					no_os_mdelay(1000);
+					capi_wait_ms(1000);
 				}
 			}
 		} else {
@@ -1227,25 +1227,25 @@ int main(void)
 				ad9361_get_en_state_machine_mode(ad9361_phy, &ensm_mode);
 				printf("SPI control - RX: %s\n",
 				       ensm_mode == ENSM_MODE_RX ? "OK" : "Error");
-				no_os_mdelay(1000);
+				capi_wait_ms(1000);
 
 				ad9361_set_en_state_machine_mode(ad9361_phy, ENSM_MODE_ALERT);
 				ad9361_get_en_state_machine_mode(ad9361_phy, &ensm_mode);
 				printf("SPI control - Alert: %s\n",
 				       ensm_mode == ENSM_MODE_ALERT ? "OK" : "Error");
-				no_os_mdelay(1000);
+				capi_wait_ms(1000);
 
 				ad9361_set_en_state_machine_mode(ad9361_phy, ENSM_MODE_TX);
 				ad9361_get_en_state_machine_mode(ad9361_phy, &ensm_mode);
 				printf("SPI control - TX: %s\n",
 				       ensm_mode == ENSM_MODE_TX ? "OK" : "Error");
-				no_os_mdelay(1000);
+				capi_wait_ms(1000);
 
 				ad9361_set_en_state_machine_mode(ad9361_phy, ENSM_MODE_ALERT);
 				ad9361_get_en_state_machine_mode(ad9361_phy, &ensm_mode);
 				printf("SPI control - Alert: %s\n",
 				       ensm_mode == ENSM_MODE_ALERT ? "OK" : "Error");
-				no_os_mdelay(1000);
+				capi_wait_ms(1000);
 			}
 		}
 	}

--- a/projects/ad9371/src/app/headless.c
+++ b/projects/ad9371/src/app/headless.c
@@ -40,7 +40,7 @@
 #include "parameters.h"
 #include "no_os_util.h"
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #ifdef ALTERA_PLATFORM
 #include "clk_altera_a10_fpll.h"
 #include "altera_adxcvr.h"
@@ -496,13 +496,13 @@ int main(void)
 	/* Minimum 3 SYSREF pulses from Clock Device has to be produced for MulticChip Sync */
 
 	AD9528_requestSysref(clockAD9528_device, 1);
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 	AD9528_requestSysref(clockAD9528_device, 1);
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 	AD9528_requestSysref(clockAD9528_device, 1);
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 	AD9528_requestSysref(clockAD9528_device, 1);
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	/*************************************************************************/
 	/*****                Mykonos Verify MultiChip Sync                 *****/
@@ -569,7 +569,7 @@ int main(void)
 	}
 
 	/* Wait 200ms for PLLs to lock */
-	no_os_mdelay(200);
+	capi_wait_ms(200);
 
 	if ((mykError = MYKONOS_checkPllsLockStatus(&mykDevice,
 			&pllLockStatus)) != MYKONOS_ERR_OK) {
@@ -787,7 +787,7 @@ int main(void)
 
 	/* Request a SYSREF from the AD9528 */
 	AD9528_requestSysref(clockAD9528_device, 1);
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	/*** < Info: Mykonos is actively transmitting CGS from the RxFramer> ***/
 
@@ -812,9 +812,9 @@ int main(void)
 
 	/* Request two SYSREFs from the AD9528 */
 	AD9528_requestSysref(clockAD9528_device, 1);
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 	AD9528_requestSysref(clockAD9528_device, 1);
-	no_os_mdelay(5);
+	capi_wait_ms(5);
 
 	/*************************************************************************/
 	/*****               Check Mykonos Framer Status                     *****/
@@ -880,7 +880,7 @@ int main(void)
 	axi_jesd204_rx_watchdog(rx_jesd);
 	axi_jesd204_rx_watchdog(rx_os_jesd);
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	/* Print JESD status */
 	axi_jesd204_rx_status_read(rx_jesd);
@@ -929,7 +929,7 @@ int main(void)
 	/* Flush cache data. */
 	Xil_DCacheInvalidateRange((uintptr_t)dac_buffer, sizeof(sine_lut_iq));
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	/* Initialize the DMAC and transfer 16384 samples from ADC to MEM */
 	axi_dmac_init(&rx_dmac, &rx_dmac_init);

--- a/projects/ad9371/src/devices/adi_hal/common.c
+++ b/projects/ad9371/src/devices/adi_hal/common.c
@@ -19,7 +19,7 @@
 #include "no_os_spi.h"
 #include "xilinx_gpio.h"
 #include "no_os_gpio.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 #include "parameters.h"
 
@@ -298,14 +298,14 @@ commonErr_t CMB_flushLog(void)
 
 commonErr_t CMB_wait_ms(uint32_t time_ms)
 {
-	no_os_mdelay(time_ms);
+	capi_wait_ms(time_ms);
 
 	return (COMMONERR_OK);
 }
 
 commonErr_t CMB_wait_us(uint32_t time_us)
 {
-	no_os_udelay(time_us);
+	capi_wait_us(time_us);
 
 	return (COMMONERR_OK);
 }
@@ -330,7 +330,7 @@ commonErr_t CMB_setTimeout_us(uint32_t timeOut_us)
 
 commonErr_t CMB_hasTimeoutExpired()
 {
-	no_os_udelay(1);
+	capi_wait_us(1);
 
 	_desired_time_to_elapse_us--;
 	if (_desired_time_to_elapse_us > 0)

--- a/projects/ad9467/src/app/ad9467_fmc.c
+++ b/projects/ad9467/src/app/ad9467_fmc.c
@@ -39,7 +39,7 @@
 #include "xparameters.h"
 #include "no_os_spi.h"
 #include "xilinx_spi.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 
 #include "axi_adc_core.h"
@@ -335,7 +335,7 @@ int main()
 	if (status)
 		return status;
 
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 	if (axi_adc_delay_calibrate(ad9467_core, 8, 1)) {
 		status = ad9467_read(ad9467_device, 0x16, &ret_val);
 		if (status)
@@ -354,7 +354,7 @@ int main()
 		if (status)
 			return status;
 		printf("AD9467[0x016]: %02x\n\r", ret_val);
-		no_os_mdelay(10);
+		capi_wait_ms(10);
 		if (axi_adc_delay_calibrate(ad9467_core, 16, 1)) {
 			printf("adc_setup: can not set a zero error delay!\n\r");
 		}
@@ -545,13 +545,13 @@ void adc_test(struct axi_adc *adc,
 
 		axi_adc_set_pnsel(adc, 0,
 				  ((mode == PN_23_SEQUENCE) ? AXI_ADC_PN23A : AXI_ADC_PN9));
-		no_os_mdelay(10);
+		capi_wait_ms(10);
 		axi_adc_write(adc,
 			      CF_REG_DATA_MONITOR,
 			      CF_DATA_MONITOR_PN_ERR |
 			      CF_DATA_MONITOR_PN_SYNC |
 			      CF_DATA_MONITOR_PN_OVER_RNG); // write ones to clear bits
-		no_os_mdelay(100);
+		capi_wait_ms(100);
 		axi_adc_read(adc, CF_REG_DATA_MONITOR, &rdata);
 		if ((rdata & (CF_DATA_MONITOR_PN_ERR |
 			      CF_DATA_MONITOR_PN_SYNC |

--- a/projects/ad9545/src/examples/basic_example/basic_example.c
+++ b/projects/ad9545/src/examples/basic_example/basic_example.c
@@ -34,7 +34,7 @@
 #include "common_data.h"
 #include "ad9545.h"
 #include "no_os_clk.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_util.h"
 #include <stdbool.h>

--- a/projects/ad9545/src/platform/linux/main.c
+++ b/projects/ad9545/src/platform/linux/main.c
@@ -31,7 +31,7 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_uart.h"
 #include "no_os_error.h"
 #include "common_data.h"

--- a/projects/ad9656_fmc/src/app/ad9656_fmc.c
+++ b/projects/ad9656_fmc/src/app/ad9656_fmc.c
@@ -45,7 +45,7 @@
 #include "xilinx_spi.h"
 #include "parameters.h"
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 #ifdef IIO_SUPPORT
 #include "iio_app.h"
@@ -212,7 +212,7 @@ int main(void)
 	}
 
 	// Allow link to reach DATA
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	status = axi_jesd204_rx_status_read(ad9656_jesd);
 	if (status != 0) {
@@ -285,7 +285,7 @@ int main(void)
 
 	printf("ad9656: setup, configuration and test program is done\n");
 
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 
 #ifdef IIO_SUPPORT
 	struct xil_uart_init_param platform_uart_init_par = {

--- a/projects/adalm-lsmspg/src/examples/curvetrace_example/curvetrace_example.c
+++ b/projects/adalm-lsmspg/src/examples/curvetrace_example/curvetrace_example.c
@@ -34,7 +34,7 @@
 #include "example.h"
 #include "common_data.h"
 #include "parameters.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_uart.h"
 #include "ad5592r.h"
@@ -200,7 +200,7 @@ static int dac_test_sweep_run(struct no_os_uart_desc *uart_desc,
 		ret = cfg->write_dac(dev, 2, test_val);
 		if (ret)
 			continue;
-		no_os_mdelay(10);
+		capi_wait_ms(10);
 		ret = cfg->read_adc(dev, 2, &readback_raw);
 		if (ret == 0) {
 			readback_raw &= 0x0FFF;
@@ -294,7 +294,7 @@ static void plot_ascii_graph(struct no_os_uart_desc *uart_desc,
 	}
 
 	/* Print graph header */
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 	sprintf(buf, "\r\n\r\n === %s (%s) - %s Curve Tracer (Ic vs Vc) ===\r\n",
 		cfg->device_name, cfg->bus_label, cfg->bjt_label);
 	no_os_uart_write(uart_desc, buf, strlen(buf));
@@ -506,7 +506,7 @@ static int curve_trace_common(struct no_os_uart_desc *uart_desc,
 
 		/* Verify by reading back channel 2 (DAC+ADC mode) */
 		uint16_t readback_raw;
-		no_os_mdelay(10);
+		capi_wait_ms(10);
 		ret = cfg->read_adc(dev, 2, &readback_raw);
 		if (ret == 0) {
 			readback_raw &= 0x0FFF;
@@ -555,7 +555,7 @@ static int curve_trace_common(struct no_os_uart_desc *uart_desc,
 		}
 
 		/* Allow base current to settle */
-		no_os_mdelay(50);
+		capi_wait_ms(50);
 
 		float vb_voltage = (vbdrive_raw * mV_per_lsb) / 1000.0f;
 		ib = (vb_voltage - Vbe) / Rbase;
@@ -586,7 +586,7 @@ static int curve_trace_common(struct no_os_uart_desc *uart_desc,
 			}
 
 			/* Small delay for settling */
-			no_os_mdelay(10);
+			capi_wait_ms(10);
 
 			/* Read ADC channels */
 			ret = cfg->read_adc(dev, 1, &Vcsense_raw);
@@ -642,7 +642,7 @@ static int curve_trace_common(struct no_os_uart_desc *uart_desc,
 	/* Output CSV data */
 	output_csv_data(uart_desc, cfg, curve_vcs, curve_ics);
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 cleanup:
 	if (dev)
@@ -731,7 +731,7 @@ int lm75_example(struct no_os_uart_desc *uart_desc)
 		goto cleanup;
 	}
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 	for (int m = 0; m < 100; m++) {
 
 		ret = lm75_read_temperature(lm75, lm75_die_temperature, &temp_raw);
@@ -745,12 +745,12 @@ int lm75_example(struct no_os_uart_desc *uart_desc)
 		sprintf(temp_msg, "LM75 Temperature: %d.%d°C (raw=%u)\n\r", temp / 1000,
 			temp % 1000, temp_raw);
 		no_os_uart_write(uart_desc, temp_msg, strlen(temp_msg));
-		no_os_mdelay(100);
+		capi_wait_ms(100);
 	}
 	char csv_footer[] = "=== LM75 TEST END ===\n\r\n\r";
 	no_os_uart_write(uart_desc, csv_footer, sizeof(csv_footer) - 1);
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 cleanup:
 	if (lm75)
@@ -771,7 +771,7 @@ int curvetrace_example(void)
 	}
 
 	/* Add delay to ensure UART connection is fully established */
-	no_os_mdelay(2000);
+	capi_wait_ms(2000);
 
 	char msg_clear[] = "\e[2J\e[H";
 	no_os_uart_write(uart_desc, msg_clear, sizeof(msg_clear) - 1);
@@ -791,7 +791,7 @@ int curvetrace_example(void)
 	}
 
 	/* Add delay between tests */
-	no_os_mdelay(2000);
+	capi_wait_ms(2000);
 
 	/* Run AD5593R curve tracer (I2C) */
 	ret = ad5593r_curve_example(uart_desc);
@@ -802,7 +802,7 @@ int curvetrace_example(void)
 	}
 
 	/* Add delay between tests */
-	no_os_mdelay(2000);
+	capi_wait_ms(2000);
 
 	/* Run AD5593R curve tracer (I2C) */
 	ret = lm75_example(uart_desc);

--- a/projects/adalm-mmsc/src/examples/iio/iio_example.c
+++ b/projects/adalm-mmsc/src/examples/iio/iio_example.c
@@ -38,6 +38,7 @@
 #include "iio_example.h"
 #include "iio_ad4080.h"
 #include "iio_app.h"
+#include "capi_time.h"
 
 static struct ad4080_init_param default_ad4080_init_param = {
 	.cfg = {
@@ -214,7 +215,7 @@ int iio_example_main(void)
 	struct iio_data_buffer read_data_buffer;
 
 	/* give the mezannine time to ramp up its power rails */
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	err = iio_ad4080_init(&iio_ad4080, &iio_ad4080_init_param);
 	if (err)

--- a/projects/ade7816/src/examples/basic/basic_example.c
+++ b/projects/ade7816/src/examples/basic/basic_example.c
@@ -31,7 +31,7 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 #include "common_data.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_irq.h"
 #include "no_os_uart.h"
@@ -186,7 +186,7 @@ int example_main()
 			interrupt = true;
 		}
 
-		no_os_mdelay(500);
+		capi_wait_ms(500);
 	}
 
 remove_ade7816:

--- a/projects/ades1754/src/examples/basic/basic_example.c
+++ b/projects/ades1754/src/examples/basic/basic_example.c
@@ -31,7 +31,7 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 #include "common_data.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 
 #define ADES1754_CELL_RESOLUTION		16383.0f
@@ -92,7 +92,7 @@ int example_main()
 		if (alert)
 			pr_info("Alert detected, solve alert related failures and start again!\n");
 		else
-			no_os_mdelay(500);
+			capi_wait_ms(500);
 	}
 
 remove_ades1754:

--- a/projects/ades1754/src/examples/spi_uart_bridge/spi_uart_bridge_example.c
+++ b/projects/ades1754/src/examples/spi_uart_bridge/spi_uart_bridge_example.c
@@ -32,7 +32,7 @@
 *******************************************************************************/
 #include "common_data.h"
 #include "max17851.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 
 #define ADES1754_CELL_RESOLUTION		16383.0f
@@ -126,7 +126,7 @@ int example_main()
 		if (alert)
 			pr_info("Alert detected, solve alert related failures and start again!\n");
 		else
-			no_os_mdelay(500);
+			capi_wait_ms(500);
 	}
 
 remove_ades1754:

--- a/projects/adf4030/src/examples/basic/basic_example.c
+++ b/projects/adf4030/src/examples/basic/basic_example.c
@@ -33,7 +33,7 @@
 
 #include "common_data.h"
 #include "no_os_uart.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 
 /**

--- a/projects/adf4368/src/examples/basic/basic_example.c
+++ b/projects/adf4368/src/examples/basic/basic_example.c
@@ -33,7 +33,7 @@
 
 #include "parameters.h"
 #include "common_data.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 
 /**

--- a/projects/adf4371/src/examples/basic/basic_example.c
+++ b/projects/adf4371/src/examples/basic/basic_example.c
@@ -31,7 +31,7 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 #include "common_data.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 
 /**

--- a/projects/adf4377_sdz/src/examples/basic/basic_example.c
+++ b/projects/adf4377_sdz/src/examples/basic/basic_example.c
@@ -36,7 +36,7 @@
 #include <string.h>
 #include <ctype.h>
 #include "common_data.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "adf4377.h"
 

--- a/projects/adf4382/src/examples/basic/basic_example.c
+++ b/projects/adf4382/src/examples/basic/basic_example.c
@@ -32,7 +32,7 @@
 *******************************************************************************/
 
 #include "common_data.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 
 /**

--- a/projects/adf5611/src/examples/basic/basic_example.c
+++ b/projects/adf5611/src/examples/basic/basic_example.c
@@ -35,7 +35,7 @@
 #include <string.h>
 #include <ctype.h>
 #include "common_data.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 
 /**

--- a/projects/adin1110/src/examples/frame_rx_tx/frame_rx_tx_example.c
+++ b/projects/adin1110/src/examples/frame_rx_tx/frame_rx_tx_example.c
@@ -32,7 +32,7 @@
 *******************************************************************************/
 #include <string.h>
 #include "common_data.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 
 #include "adin1110.h"
@@ -233,7 +233,7 @@ int example_main()
 			}
 		}
 
-		no_os_mdelay(5000);
+		capi_wait_ms(5000);
 	}
 
 error:

--- a/projects/adin1320/src/examples/basic_init/basic_init.c
+++ b/projects/adin1320/src/examples/basic_init/basic_init.c
@@ -34,7 +34,7 @@
 #include "adin1320.h"
 #include "common_data.h"
 #include "mdio_spi.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_util.h"
 
@@ -205,7 +205,7 @@ int example_main(void)
 	}
 
 	/* Allow time for UART buffer to flush before cleanup */
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 err_adin:
 	adin1320_remove(adin1320_desc);

--- a/projects/adin1320/src/examples/basic_init_2devices/basic_init_2devices.c
+++ b/projects/adin1320/src/examples/basic_init_2devices/basic_init_2devices.c
@@ -34,7 +34,7 @@
 #include "adin1320.h"
 #include "common_data.h"
 #include "mdio_spi.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_util.h"
 
@@ -331,7 +331,7 @@ int example_main(void)
 	}
 
 	/* Allow time for UART buffer to flush before cleanup */
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 err_adin8:
 	adin1320_remove(adin1320_8_desc);

--- a/projects/adin1320/src/examples/cmd/cmd.c
+++ b/projects/adin1320/src/examples/cmd/cmd.c
@@ -39,7 +39,7 @@
 #include "common_data.h"
 #include "mdio_spi.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_mdio.h"
 #include "no_os_print_log.h"

--- a/projects/adin1320/src/examples/cmd/cmd_mode.c
+++ b/projects/adin1320/src/examples/cmd/cmd_mode.c
@@ -36,7 +36,7 @@
 #include "adin1320.h"
 #include "common_data.h"
 #include "mdio_spi.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_print_log.h"
 #include "no_os_util.h"
@@ -235,7 +235,7 @@ int fw_mode_sgmii_path_test(struct cmd_gpio *cmd_gpio,
 			return ret;
 	} while ((data & 0x0001) == 0); /* Wait for FG done */
 
-	no_os_mdelay(10000); /* Allow time window for frames to come back */
+	capi_wait_ms(10000); /* Allow time window for frames to come back */
 
 	/* Read frame error count to enable reading of frame counts */
 	ret = adin1320_read(dev_8, 0x0014, &data); /* RX_ERR_CNT */
@@ -402,7 +402,7 @@ int fw_mode_mdi_path_test(struct cmd_gpio *cmd_gpio,
 			return ret;
 	} while ((data & 0x0001) == 0); /* Wait for FG done */
 
-	no_os_mdelay(10000); /* Allow time window for frames to come back */
+	capi_wait_ms(10000); /* Allow time window for frames to come back */
 
 	/* Read frame error count to enable reading of frame counts */
 	ret = adin1320_read(dev_0, 0x0014, &data); /* RX_ERR_CNT */

--- a/projects/adin1320/src/examples/wake_on_lan/wake_on_lan.c
+++ b/projects/adin1320/src/examples/wake_on_lan/wake_on_lan.c
@@ -34,7 +34,7 @@
 #include "adin1320.h"
 #include "common_data.h"
 #include "mdio_spi.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 
 static struct irq_context {

--- a/projects/admt4000/src/common/iio_admt_evb.c
+++ b/projects/admt4000/src/common/iio_admt_evb.c
@@ -37,7 +37,7 @@
 #include "no_os_gpio.h"
 #include "no_os_util.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "iio.h"
 #include "iio_admt_evb.h"
 
@@ -105,7 +105,7 @@ int admt_evb_iio_init(struct admt_evb_iio_desc **iio_desc,
 					  NO_OS_GPIO_HIGH);
 	if (ret)
 		goto err;
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 
 	ret = no_os_gpio_get(&descriptor->gpio_coil_rs_desc,
 			     &init_param->gpio_coil_rs_ip);

--- a/projects/admt4000/src/examples/basic/basic_example.c
+++ b/projects/admt4000/src/examples/basic/basic_example.c
@@ -34,7 +34,7 @@
 #include "basic_example.h"
 #include "common_data.h"
 #include "admt4000.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_uart.h"
 #include <stdint.h>
@@ -78,7 +78,7 @@ int example_main()
 	if (ret)
 		goto err_gpio_ven;
 
-	no_os_mdelay(ADMT4000_STARTUP_TIME_MS);
+	capi_wait_ms(ADMT4000_STARTUP_TIME_MS);
 	/* Initialize ADMT4000 device */
 	pr_info("Initializing ADMT4000...\r\n");
 	admt4000_ip.gpio_fault_ip = gpio_fault_ip;
@@ -198,7 +198,7 @@ int example_main()
 		pr_info("-------------------------------------------\r\n");
 
 		/* Delay 500ms before next reading */
-		no_os_mdelay(500);
+		capi_wait_ms(500);
 	}
 
 exit_example:

--- a/projects/admt4000/src/examples/iio_trigger_example/iio_trigger_example.c
+++ b/projects/admt4000/src/examples/iio_trigger_example/iio_trigger_example.c
@@ -41,6 +41,7 @@
 #endif
 #include "iio_trigger.h"
 #include "iio_app.h"
+#include "capi_time.h"
 
 #define DATA_BUFFER_SIZE 400
 uint8_t iio_data_buffer[DATA_BUFFER_SIZE * 5 * sizeof(uint32_t)];
@@ -99,13 +100,13 @@ int example_main()
 #endif
 	uint32_t nb_ctx_attr;
 	bool hw_mezzanine_is_valid = false;
-	no_os_mdelay(2000);
+	capi_wait_ms(2000);
 
 	ret = no_os_eeprom_init(&eeprom_desc, &eeprom_ip);
 	if (ret)
 		return ret;
 
-	no_os_mdelay(2000);
+	capi_wait_ms(2000);
 	ret = get_iio_context_attributes_ex(&iio_ctx_attrs,
 					    &nb_ctx_attr,
 					    eeprom_desc,
@@ -117,7 +118,7 @@ int example_main()
 	if (ret)
 		return ret;
 
-	no_os_mdelay(3);
+	capi_wait_ms(3);
 
 	ret = admt_evb_iio_init(&admt_evb_desc, &admt_evb_ip);
 	if (ret)

--- a/projects/admt4000/src/platform/stm32/main.c
+++ b/projects/admt4000/src/platform/stm32/main.c
@@ -33,7 +33,7 @@
 
 #include "parameters.h"
 #include "common_data.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "admt4000.h"
 #include "no_os_print_log.h"

--- a/projects/adp1050/src/examples/basic/basic_example.c
+++ b/projects/adp1050/src/examples/basic/basic_example.c
@@ -31,7 +31,7 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 #include "common_data.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_i2c.h"
 #include "no_os_print_log.h"
 #include "no_os_util.h"

--- a/projects/adp1055/src/examples/basic/basic_example.c
+++ b/projects/adp1055/src/examples/basic/basic_example.c
@@ -31,7 +31,7 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 #include "common_data.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_i2c.h"
 #include "no_os_print_log.h"
 #include "no_os_util.h"

--- a/projects/adp5055/src/examples/basic/basic_example.c
+++ b/projects/adp5055/src/examples/basic/basic_example.c
@@ -31,7 +31,7 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 #include "common_data.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_i2c.h"
 #include "no_os_print_log.h"
 #include "no_os_util.h"

--- a/projects/adrv9001/src/app/headless.c
+++ b/projects/adrv9001/src/app/headless.c
@@ -65,6 +65,7 @@
 #include "Navassa_LVDS_profile.h"
 #else
 #include "Navassa_CMOS_profile.h"
+#include "capi_time.h"
 #endif
 
 /* ADC/DAC Buffers */
@@ -528,7 +529,7 @@ int main(void)
 #endif
 #endif /* XILINX_PLATFORM */
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	struct axi_dma_transfer read_transfer1 = {
 		// Number of bytes to write/read
@@ -591,7 +592,7 @@ int main(void)
 	       rx1_adc_init.num_channels, 8 * sizeof(adc_buffers[0][0]));
 #endif
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 #ifdef IIO_SUPPORT
 	struct iio_axi_adc_init_param iio_axi_adcs_init_par[] = {{

--- a/projects/adrv9001/src/hal/no_os_platform.c
+++ b/projects/adrv9001/src/hal/no_os_platform.c
@@ -41,7 +41,7 @@
 #include "no_os_spi.h"
 #include "xilinx_spi.h"
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "adi_common_error.h"
 #include "Navassa_EvaluationFw.h"
 #include "Navassa_Stream.h"
@@ -413,7 +413,7 @@ int32_t no_os_timer_wait_us(void *devHalCfg, uint32_t time_us)
 {
 	int32_t halError = (int32_t)ADI_COMMON_ERR_OK;
 
-	no_os_udelay(time_us);
+	capi_wait_us(time_us);
 
 	return halError;
 }

--- a/projects/adrv9009/src/app/app_clocking.c
+++ b/projects/adrv9009/src/app/app_clocking.c
@@ -48,7 +48,7 @@
 #include "no_os_spi.h"
 #include "no_os_gpio.h"
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_util.h"
 
 // platform specific

--- a/projects/adrv9009/src/app/app_talise.c
+++ b/projects/adrv9009/src/app/app_talise.c
@@ -38,7 +38,7 @@
 
 // platform drivers
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_util.h"
 
 // talise
@@ -251,7 +251,7 @@ adiHalErr_t talise_setup(taliseDevice_t * const pd, taliseInit_t * const pi)
 	}
 
 	/*** < wait 200ms for PLLs to lock - user code here > ***/
-	no_os_mdelay(200);
+	capi_wait_ms(200);
 
 	talAction = TALISE_getPllsLockStatus(pd, &pllLockStatus);
 	if ((pllLockStatus & 0x07) != 0x07) {
@@ -401,7 +401,7 @@ adiHalErr_t talise_setup(taliseDevice_t * const pd, taliseInit_t * const pi)
 
 	ADIHAL_sysrefReq(pd->devHalInfo, SYSREF_CONT_OFF);
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	/*** < Insert User JESD204B Sync Verification Code Here > ***/
 

--- a/projects/adrv9009/src/app/headless_arm.c
+++ b/projects/adrv9009/src/app/headless_arm.c
@@ -14,7 +14,7 @@
 #include "adi_hal.h"
 #include "no_os_spi.h"
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "parameters.h"
 #include "no_os_util.h"
 #include "axi_dac_core.h"
@@ -470,7 +470,7 @@ int main(void)
 	axi_dmac_transfer_start(tx_dmac, &transfer_tx);
 	Xil_DCacheInvalidateRange((uintptr_t)DAC_DDR_BASEADDR, sizeof(sine_lut_iq));
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 #endif
 
 	/* Transfer 16384 samples from ADC to MEM */
@@ -518,7 +518,7 @@ int main(void)
 
 #ifdef IIO_SUPPORT
 	// Allow time to display messages correctly
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 #ifdef ADRV9008_2
 	status = start_iiod(rx_os_dmac, tx_dmac, rx_os_adc, tx_dac);
 #else

--- a/projects/adrv9009/src/app/headless_mb.c
+++ b/projects/adrv9009/src/app/headless_mb.c
@@ -18,7 +18,7 @@
 #include "axi_dac_core.h"
 #include "axi_adc_core.h"
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "xilinx_gpio.h"
 #include "parameters.h"
 #include "no_os_util.h"
@@ -780,7 +780,7 @@ int main(void)
 	Xil_DCacheInvalidateRange((uintptr_t)dac_buffer_dma,
 				  sizeof(sine_lut_iq) * phy->tx_dac->num_channels / 2);
 
-	no_os_mdelay(50);
+	capi_wait_ms(50);
 
 	/* Transfer 16384 samples from ADC to MEM */
 	struct axi_dma_transfer transfer_rx = {
@@ -797,7 +797,7 @@ int main(void)
 		.dest_addr = (uintptr_t)(DDR_MEM_BASEADDR + 0x800000)
 	};
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	status = axi_dmac_transfer_start(rx_dmac, &transfer_rx);
 	if (status)
@@ -819,7 +819,7 @@ int main(void)
 
 #ifdef IIO_SUPPORT
 	// Allow time to display messages correctly
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 	status = start_iiod(rx_dmac, tx_dmac, phy->rx_adc, phy->tx_dac);
 	if (status)
 		printf("iiod error: %d\n", status);

--- a/projects/adrv9009/src/app/headless_zu.c
+++ b/projects/adrv9009/src/app/headless_zu.c
@@ -19,7 +19,7 @@
 #include "axi_dac_core.h"
 #include "axi_adc_core.h"
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "xilinx_gpio.h"
 #include "no_os_gpio.h"
 #include "parameters.h"
@@ -575,7 +575,7 @@ int main(void)
 	Xil_DCacheInvalidateRange((uintptr_t)dac_buffer_dma,
 				  sizeof(sine_lut_iq) * phy[TALISE_A]->tx_dac->num_channels);
 
-	no_os_mdelay(50);
+	capi_wait_ms(50);
 
 	/* Transfer 16384 samples from ADC to MEM */
 	struct axi_dma_transfer transfer_rx = {
@@ -607,7 +607,7 @@ int main(void)
 		.dest_addr = (uintptr_t)(DDR_MEM_BASEADDR + 0xC00000)
 	};
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	status = axi_dmac_transfer_start(rx_dmac, &transfer_rx);
 	if (status)
@@ -639,7 +639,7 @@ int main(void)
 	axi_dac_set_datasel(phy[TALISE_A]->tx_dac, -1, AXI_DAC_DATA_SEL_DDS);
 	axi_dac_data_setup(phy[TALISE_A]->tx_dac);
 
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 
 	status = axi_dmac_transfer_start(rx_os_dmac, &transfer_os_rx);
 	if (status)

--- a/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
+++ b/projects/adrv9009/src/devices/adi_hal/no_os_hal.c
@@ -37,7 +37,7 @@
 #include "no_os_spi.h"
 #include "no_os_gpio.h"
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #ifndef ALTERA_PLATFORM
 #include "xilinx_spi.h"
 #include "xilinx_gpio.h"
@@ -125,11 +125,11 @@ adiHalErr_t ADIHAL_resetHw(void *devHalInfo)
 	struct adi_hal *devHalData = (struct adi_hal *)devHalInfo;
 
 	no_os_gpio_direction_output(devHalData->gpio_adrv_resetb, 1);
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 	no_os_gpio_direction_output(devHalData->gpio_adrv_resetb, 0);
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 	no_os_gpio_direction_output(devHalData->gpio_adrv_resetb, 1);
-	no_os_mdelay(10);
+	capi_wait_ms(10);
 
 	return ADIHAL_OK;
 }
@@ -144,7 +144,7 @@ adiHalErr_t ADIHAL_sysrefReq(void *devHalInfo, sysrefReqMode_t mode)
 		no_os_gpio_direction_output(devHalData->gpio_adrv_sysref_req, 0);
 	else if (mode == SYSREF_PULSE) {
 		no_os_gpio_direction_output(devHalData->gpio_adrv_sysref_req, 1);
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 		no_os_gpio_direction_output(devHalData->gpio_adrv_sysref_req, 0);
 	} else
 		return ADIHAL_ERR;
@@ -254,7 +254,7 @@ adiHalErr_t ADIHAL_spiReadField(void *devHalInfo,
 
 adiHalErr_t  ADIHAL_wait_us(void *devHalInfo, uint32_t time_us)
 {
-	no_os_udelay(time_us);
+	capi_wait_us(time_us);
 
 	return ADIHAL_OK;
 }

--- a/projects/adrv902x/src/common/hal/no_os_platform.c
+++ b/projects/adrv902x/src/common/hal/no_os_platform.c
@@ -14,7 +14,7 @@
 #include "no_os_print_log.h"
 #include "no_os_platform.h"
 #include "adi_platform.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "common_data.h"
 #include "ADRV9025_FW.h"
 #include "capi_alloc.h"
@@ -437,7 +437,7 @@ int32_t no_os_TimerWait_us(void *devHalCfg, uint32_t time_us)
 {
 	int32_t halError = (int32_t)ADI_HAL_OK;
 
-	no_os_udelay(time_us);
+	capi_wait_us(time_us);
 
 	return halError;
 }
@@ -455,7 +455,7 @@ int32_t no_os_TimerWait_ms(void *devHalCfg, uint32_t time_ms)
 {
 	int32_t halError = (int32_t)ADI_HAL_OK;
 
-	no_os_mdelay(time_ms);
+	capi_wait_ms(time_ms);
 
 	return halError;
 }

--- a/projects/adrv902x/src/examples/basic_example/basic_example.c
+++ b/projects/adrv902x/src/examples/basic_example/basic_example.c
@@ -58,6 +58,7 @@
 #include "clkgen_routines.h"
 #include "adrv9025.h"
 #include "ad9528.h"
+#include "capi_time.h"
 
 /***************************************************************************//**
  * @brief Basic example main execution.
@@ -408,7 +409,7 @@ int example_main(void)
 		      AXI_ADC_MMCM_RSTN | AXI_ADC_RSTN);
 #endif
 
-	no_os_mdelay(200);
+	capi_wait_ms(200);
 
 	status = clkgen_setup(&rx_clkgen, &tx_clkgen, &orx_clkgen,
 			      phy->deviceInitStruct.dataInterface.deframer[0].enableJesd204C);

--- a/projects/adrv902x/src/examples/dma_example/dma_example.c
+++ b/projects/adrv902x/src/examples/dma_example/dma_example.c
@@ -59,6 +59,7 @@
 #include "clkgen_routines.h"
 #include "adrv9025.h"
 #include "ad9528.h"
+#include "capi_time.h"
 
 uint32_t dac_buffer_dma[DAC_BUFFER_SAMPLES] __attribute__((aligned(16)));
 uint16_t adc_buffer_dma[ADC_BUFFER_SAMPLES * ADRV9025_RX_JESD_CONVS_PER_DEVICE]
@@ -419,7 +420,7 @@ int example_main(void)
 		      AXI_ADC_MMCM_RSTN | AXI_ADC_RSTN);
 #endif
 
-	no_os_mdelay(200);
+	capi_wait_ms(200);
 
 	status = clkgen_setup(&rx_clkgen, &tx_clkgen, &orx_clkgen,
 			      phy->deviceInitStruct.dataInterface.deframer[0].enableJesd204C);
@@ -558,7 +559,7 @@ int example_main(void)
 	/* Flush cache data. */
 	Xil_DCacheInvalidateRange((uintptr_t)dac_buffer_dma, sizeof(dac_buffer_dma));
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	struct axi_dma_transfer read_transfer = {
 		// Number of bytes to write/read

--- a/projects/adrv902x/src/examples/iio_example/iio_example.c
+++ b/projects/adrv902x/src/examples/iio_example/iio_example.c
@@ -64,6 +64,7 @@
 #include "iio_axi_adc.h"
 #include "iio_axi_dac.h"
 #include "iio_app.h"
+#include "capi_time.h"
 
 
 uint32_t dac_buffer[DAC_BUFFER_SAMPLES] __attribute__((aligned(1024)));
@@ -432,7 +433,7 @@ int example_main(void)
 		      AXI_ADC_MMCM_RSTN | AXI_ADC_RSTN);
 #endif
 
-	no_os_mdelay(200);
+	capi_wait_ms(200);
 
 	status = clkgen_setup(&rx_clkgen, &tx_clkgen, &orx_clkgen,
 			      phy->deviceInitStruct.dataInterface.deframer[0].enableJesd204C);
@@ -685,7 +686,7 @@ int example_main(void)
 	app_init_param.uart_init_params = iio_uart_ip;
 
 	/* Wait to display previous messages */
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	status = iio_app_init(&app, app_init_param);
 	if (status)

--- a/projects/adrv903x/src/common/hal/no_os_platform.c
+++ b/projects/adrv903x/src/common/hal/no_os_platform.c
@@ -17,7 +17,7 @@
 #include "no_os_platform.h"
 #include "adi_platform.h"
 #include "no_os_mutex.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "common_data.h"
 #include "capi_alloc.h"
 #include "parameters.h"
@@ -281,13 +281,13 @@ int32_t no_os_TimerInit(void *devHalCfg)
 
 adi_hal_Err_e no_os_TimerWait_ms(void *devHalCfg, uint32_t time_ms)
 {
-	no_os_mdelay(time_ms);
+	capi_wait_ms(time_ms);
 	return ADI_HAL_ERR_OK;
 }
 
 adi_hal_Err_e no_os_TimerWait_us(void *devHalCfg, uint32_t time_us)
 {
-	no_os_udelay(time_us);
+	capi_wait_us(time_us);
 	return ADI_HAL_ERR_OK;
 }
 

--- a/projects/adrv903x/src/examples/dma_example/dma_example.c
+++ b/projects/adrv903x/src/examples/dma_example/dma_example.c
@@ -57,6 +57,7 @@
 #include "jesd204.h"
 #include <string.h>
 #include "no_os_axi_io.h"
+#include "capi_time.h"
 #include <xil_cache.h>
 
 /*
@@ -575,7 +576,7 @@ int example_main()
 	axi_dmac_transfer_start(tx_dmac, &tx_transfer);
 
 	/* Allow the tone to settle for 1 s before capturing RX data */
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	/*
 	 * ----------------------------------------------------------------

--- a/projects/adrv903x/src/examples/iio_example/iio_example.c
+++ b/projects/adrv903x/src/examples/iio_example/iio_example.c
@@ -57,6 +57,7 @@
 #include "iio_axi_adc.h"
 #include "iio_axi_dac.h"
 #include "iio_app.h"
+#include "capi_time.h"
 #include <string.h>
 #include <xil_cache.h>
 
@@ -632,7 +633,7 @@ int example_main()
 	app_init_param.uart_init_params = iio_uart_ip;
 
 	/* Allow previous log messages to flush before IIO takes over UART */
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	ret = iio_app_init(&app, app_init_param);
 	if (ret)

--- a/projects/adrv904x/src/common/hal/no_os_platform.c
+++ b/projects/adrv904x/src/common/hal/no_os_platform.c
@@ -15,7 +15,7 @@
 #include "adi_platform.h"
 #include "ADRV9040_FW.h"
 #include "no_os_mutex.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "common_data.h"
 #include "capi_alloc.h"
 #include "parameters.h"
@@ -485,7 +485,7 @@ adi_hal_Err_e no_os_TimerWait_ms(void *devHalCfg, uint32_t time_ms)
 {
 	int32_t halError = (int32_t)ADI_HAL_ERR_OK;
 
-	no_os_mdelay(time_ms);
+	capi_wait_ms(time_ms);
 
 	return halError;
 }
@@ -503,7 +503,7 @@ adi_hal_Err_e no_os_TimerWait_us(void *devHalCfg, uint32_t time_us)
 {
 	int32_t halError = (int32_t)ADI_HAL_ERR_OK;
 
-	no_os_udelay(time_us);
+	capi_wait_us(time_us);
 
 	return halError;
 }

--- a/projects/adrv904x/src/examples/dma_example/dma_example.c
+++ b/projects/adrv904x/src/examples/dma_example/dma_example.c
@@ -67,6 +67,7 @@
 #include "clkgen_routines.h"
 #include "adrv904x.h"
 #include "ad9528.h"
+#include "capi_time.h"
 
 uint32_t dac_buffer_dma[DAC_BUFFER_SAMPLES] __attribute__((aligned(1024)));
 uint16_t adc_buffer_dma[ADC_BUFFER_SAMPLES * ADC_CHANNELS] __attribute__((
@@ -417,7 +418,7 @@ int example_main(void)
 	/* Flush cache data. */
 	Xil_DCacheInvalidateRange((uintptr_t)dac_buffer_dma, sizeof(sine_lut_iq));
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	struct axi_dma_transfer read_transfer = {
 		// Number of bytes to write/read

--- a/projects/adrv904x/src/examples/iio_example/iio_example.c
+++ b/projects/adrv904x/src/examples/iio_example/iio_example.c
@@ -73,6 +73,7 @@
 #include "iio_axi_adc.h"
 #include "iio_axi_dac.h"
 #include "iio_app.h"
+#include "capi_time.h"
 
 uint32_t dac_buffer[DAC_BUFFER_SAMPLES] __attribute__((aligned(1024)));
 uint16_t adc_buffer[ADC_BUFFER_SAMPLES * ADC_CHANNELS] __attribute__((
@@ -504,7 +505,7 @@ int example_main(void)
 	app_init_param.uart_init_params = iio_uart_ip;
 
 	/* Wait to display previous messages */
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	status = iio_app_init(&app, app_init_param);
 	if (status)

--- a/projects/adt7420-pmdz/src/examples/dummy/dummy_example.c
+++ b/projects/adt7420-pmdz/src/examples/dummy/dummy_example.c
@@ -35,7 +35,7 @@
 
 #include "common_data.h"
 #include "adt7420.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 
 #ifdef LINUX_PLATFORM
@@ -90,7 +90,7 @@ int example_main()
 		goto error_adt7420;
 
 	/* Datasheet specified delay between conversions. */
-	no_os_mdelay(240);
+	capi_wait_ms(240);
 
 	while (1) {
 		ret = adt7420_reg_read(adt7420, ADT7420_REG_T_HIGH_MSB, &temp_msb_l);
@@ -152,7 +152,7 @@ int example_main()
 		pr_info("Temp read is %lf\r\n", temp_now);
 		pr_info("Current temp high setpoint is %d\r\n", (int) temp_c_max);
 		pr_info("Current temp low setpoint is %d\r\n", (int) temp_c_min);
-		no_os_mdelay(3000);
+		capi_wait_ms(3000);
 	}
 error_adt7420:
 	adt7420_remove(adt7420);

--- a/projects/adt75/src/examples/basic/basic_example.c
+++ b/projects/adt75/src/examples/basic/basic_example.c
@@ -33,7 +33,7 @@
 
 #include "common_data.h"
 #include "no_os_uart.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_i2c.h"
 #include "no_os_print_log.h"
 #include "no_os_util.h"
@@ -74,7 +74,7 @@ int example_main()
 			goto error;
 
 		pr_info("Temperature: %.03f C\n", (double)val / 1000);
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 	}
 
 error:

--- a/projects/aducm_blinky_example/src/examples/basic_example/basic_example.c
+++ b/projects/aducm_blinky_example/src/examples/basic_example/basic_example.c
@@ -5,7 +5,7 @@
 
 #include "common_data.h"
 #include "no_os_gpio.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 /*****************************************************************************
  * @brief Toggle a GPIO-connected LED.
@@ -49,9 +49,9 @@ int example_main()
 	while (1) {
 		toggle(blue);
 		toggle(green);
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 		toggle(green);
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 	}
 
 	return 0;

--- a/projects/cn0552/src/app/headless.c
+++ b/projects/cn0552/src/app/headless.c
@@ -45,7 +45,7 @@
 #include "no_os_i2c.h"
 #include "aducm3029_i2c.h"
 #include "aducm3029_uart.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "platform_init.h"
 #include "parameters.h"

--- a/projects/cn0561/src/cn0561.c
+++ b/projects/cn0561/src/cn0561.c
@@ -45,7 +45,7 @@
 #include "ad713x.h"
 #include "no_os_spi.h"
 #include "xilinx_spi.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "xilinx_gpio.h"
 #include "no_os_util.h"
@@ -219,7 +219,7 @@ int main()
 			return -1;
 	} /* Select SINC3 filtering, enable higher data convertion rates */
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	ret = ad713x_spi_reg_write(cn0561_dev, AD713X_REG_GPIO_DIR_CTRL, 0xE7);
 	if (ret != 0)

--- a/projects/cn0565/src/examples/eit/app.c
+++ b/projects/cn0565/src/examples/eit/app.c
@@ -36,7 +36,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include <math.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_uart.h"
 #include "no_os_spi.h"
 #include "no_os_gpio.h"
@@ -65,7 +65,7 @@ int ADG2128_SwRst(struct ad5940_dev *dev)
 	int ret = ad5940_WriteReg(dev, REG_AGPIO_GP0OUT, 0);
 	if (ret < 0)
 		return ret;
-	no_os_udelay(1);
+	capi_wait_us(1);
 	return ad5940_WriteReg(dev, REG_AGPIO_GP0OUT, AGPIO_Pin1);
 }
 
@@ -435,10 +435,10 @@ int app_main(struct no_os_i2c_desc *i2c, struct ad5940_init_param *ad5940_ip)
 						printf("%s", "!CMD Q OK\n");
 						configMeasurement(&oldMeasCfg, newMeasCfg);
 						AppBiaInit(ad5940, AppBuff, APPBUFF_SIZE);
-						no_os_udelay(10);
+						capi_wait_us(10);
 						printf("%s", "!Q ");
 						setMuxSwitch(i2c, ad5940, newElCfg, MUXBOARD_SIZE);
-						no_os_udelay(3);
+						capi_wait_us(3);
 						AppBiaCtrl(ad5940, BIACTRL_START, 0);
 						lastConfig = 'Q';
 					} else {
@@ -465,7 +465,7 @@ int app_main(struct no_os_i2c_desc *i2c, struct ad5940_init_param *ad5940_ip)
 								swComboSeq);
 						configMeasurement(&oldMeasCfg, newMeasCfg);
 						AppBiaInit(ad5940, AppBuff, APPBUFF_SIZE);
-						no_os_udelay(10);
+						capi_wait_us(10);
 						printf("%s", "!C OK\n");
 						lastConfig = 'C';
 					} else {
@@ -481,7 +481,7 @@ int app_main(struct no_os_i2c_desc *i2c, struct ad5940_init_param *ad5940_ip)
 						switchSeqNum = 0;
 						setMuxSwitch(i2c, ad5940, swComboSeq[switchSeqNum++], newEitCfg.nElectrodeCnt);
 						AppBiaInit(ad5940, AppBuff, APPBUFF_SIZE);
-						no_os_udelay(10);
+						capi_wait_us(10);
 						AppBiaCtrl(ad5940, BIACTRL_START, 0);
 						printf("%s", "!V ");
 					} else
@@ -523,7 +523,7 @@ int app_main(struct no_os_i2c_desc *i2c, struct ad5940_init_param *ad5940_ip)
 						   newMeasCfg.bMagnitudeMode);
 					putchar(',');
 					setMuxSwitch(i2c, ad5940, swComboSeq[switchSeqNum++], newEitCfg.nElectrodeCnt);
-					no_os_udelay(3);
+					capi_wait_us(3);
 					AppBiaCtrl(ad5940, BIACTRL_START, 0);
 				}
 			}

--- a/projects/cn0565/src/examples/eit/mux_board.c
+++ b/projects/cn0565/src/examples/eit/mux_board.c
@@ -32,7 +32,7 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 #include <stdbool.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "mux_board.h"
 #include "app.h"
 
@@ -112,6 +112,6 @@ void setMuxSwitch(struct no_os_i2c_desc *i2c, struct ad5940_dev *ad5940,
 				no_os_i2c_write(i2c, muxData, 2, true);
 			}
 		}
-		no_os_udelay(1);
+		capi_wait_us(1);
 	}
 }

--- a/projects/dc2703a/src/examples/basic/basic_example.c
+++ b/projects/dc2703a/src/examples/basic/basic_example.c
@@ -34,7 +34,7 @@
 #include "common_data.h"
 #include "no_os_uart.h"
 #include "lt8491.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_units.h"
 /*****************************************************************************
@@ -176,7 +176,7 @@ int example_main()
 
 		pr_info("LT8491 VIN: %d\r\n", uval);
 
-		no_os_mdelay(5000);
+		capi_wait_ms(5000);
 	}
 
 	return 0;

--- a/projects/dc2903a/src/examples/basic/basic_example.c
+++ b/projects/dc2903a/src/examples/basic/basic_example.c
@@ -34,7 +34,7 @@
 #include "ltc2672.h"
 #include "common_data.h"
 #include "no_os_print_log.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_util.h"
 #include "no_os_uart.h"
 
@@ -90,7 +90,7 @@ int example_main()
 				(double)currents_to_set[i]);
 
 			/*Lengthy delay to better visualize the change in values*/
-			no_os_mdelay(1500);
+			capi_wait_ms(1500);
 		}
 
 		/* Configure MUX pin to output the VREF measurement */
@@ -102,7 +102,7 @@ int example_main()
 		}
 
 		/*Lengthy delay to better visualize the change in values*/
-		no_os_mdelay(2000);
+		capi_wait_ms(2000);
 
 		/* Chip Power Down */
 		pr_info("Chip Power Down. All Channels and VREF should measure 0.\n");
@@ -113,7 +113,7 @@ int example_main()
 		}
 
 		/*Lengthy delay to better visualize the change in values*/
-		no_os_mdelay(2000);
+		capi_wait_ms(2000);
 
 		/* Setup and Demo toggle function on OUT3 */
 		pr_info("Toggle function on OUT3. Current toggles between %0.2f and %0.2f mA.\n",
@@ -139,7 +139,7 @@ int example_main()
 			}
 
 			/*Lengthy delay to better visualize the change in values*/
-			no_os_mdelay(2000);
+			capi_wait_ms(2000);
 		}
 
 		ret = ltc2672_enable_toggle_channel(ltc2672_desc, 0);
@@ -148,7 +148,7 @@ int example_main()
 		}
 
 		/*Lengthy delay to better visualize the change in values*/
-		no_os_mdelay(2000);
+		capi_wait_ms(2000);
 
 	}// end while
 

--- a/projects/demo_esp/src/examples/basic/basic_example.c
+++ b/projects/demo_esp/src/examples/basic/basic_example.c
@@ -33,7 +33,7 @@
 
 #include <string.h>
 #include "common_data.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "no_os_gpio.h"
 #include "no_os_timer.h"
@@ -64,7 +64,7 @@ int32_t init_and_connect_wifi(struct wifi_desc **wifi)
 			goto error_gpio;
 		}
 
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 
 		ret = no_os_gpio_set_value(wifi_rst_gpio, NO_OS_GPIO_HIGH);
 		if (ret) {
@@ -73,7 +73,7 @@ int32_t init_and_connect_wifi(struct wifi_desc **wifi)
 		}
 
 		/* Allow the wifi module to bring up after reset */
-		no_os_mdelay(3000);
+		capi_wait_ms(3000);
 	}
 
 	ret = no_os_irq_ctrl_init(&irq_ctrl, &irq_ip);

--- a/projects/display_demo/src/app/main.c
+++ b/projects/display_demo/src/app/main.c
@@ -41,7 +41,7 @@
 #include "ssd_1306.h"
 #include "display.h"
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 /***************************************************************************//**
  * @brief main

--- a/projects/eval-ad7490sdz/src/examples/basic/basic_example.c
+++ b/projects/eval-ad7490sdz/src/examples/basic/basic_example.c
@@ -32,7 +32,7 @@
  *******************************************************************************/
 #include "ad7490.h"
 #include "common_data.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 
 #define AD7490_VREF		2.5
@@ -71,7 +71,7 @@ int example_main()
 				((float)val * AD7490_VREF) / AD7490_FULLSCALE);
 		}
 
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 	}
 
 	return 0;

--- a/projects/eval-ade7753/src/common/common_data.h
+++ b/projects/eval-ade7753/src/common/common_data.h
@@ -36,7 +36,7 @@
 #include "ade7753.h"
 #include "no_os_uart.h"
 #include "no_os_pwm.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_print_log.h"

--- a/projects/eval-ade7753/src/main.c
+++ b/projects/eval-ade7753/src/main.c
@@ -34,7 +34,7 @@
 #include "no_os_uart.h"
 #include "capi_alloc.h"
 #include "no_os_pwm.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_print_log.h"

--- a/projects/eval-ade7753/src/platform/platform.h
+++ b/projects/eval-ade7753/src/platform/platform.h
@@ -36,7 +36,7 @@
 
 #include "ade7753.h"
 #include "no_os_uart.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_util.h"

--- a/projects/eval-ade7754/src/common/common_data.h
+++ b/projects/eval-ade7754/src/common/common_data.h
@@ -36,7 +36,7 @@
 #include "ade7754.h"
 #include "no_os_uart.h"
 #include "no_os_pwm.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_print_log.h"

--- a/projects/eval-ade7754/src/main.c
+++ b/projects/eval-ade7754/src/main.c
@@ -34,7 +34,7 @@
 #include "no_os_uart.h"
 #include "capi_alloc.h"
 #include "no_os_pwm.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_print_log.h"

--- a/projects/eval-ade7754/src/platform/maxim/platform.h
+++ b/projects/eval-ade7754/src/platform/maxim/platform.h
@@ -36,7 +36,7 @@
 
 #include "ade7754.h"
 #include "no_os_uart.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_util.h"

--- a/projects/eval-ade7758/src/common/common_data.h
+++ b/projects/eval-ade7758/src/common/common_data.h
@@ -36,7 +36,7 @@
 #include "ade7758.h"
 #include "no_os_uart.h"
 #include "no_os_pwm.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_print_log.h"

--- a/projects/eval-ade7758/src/main.c
+++ b/projects/eval-ade7758/src/main.c
@@ -34,7 +34,7 @@
 #include "no_os_uart.h"
 #include "capi_alloc.h"
 #include "no_os_pwm.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_print_log.h"

--- a/projects/eval-ade7758/src/platform/maxim/platform.h
+++ b/projects/eval-ade7758/src/platform/maxim/platform.h
@@ -36,7 +36,7 @@
 
 #include "ade7758.h"
 #include "no_os_uart.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_util.h"

--- a/projects/eval-ade7880/src/main.c
+++ b/projects/eval-ade7880/src/main.c
@@ -33,7 +33,7 @@
 #include <stdio.h>
 #include "no_os_uart.h"
 #include "no_os_pwm.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_print_log.h"
@@ -153,11 +153,11 @@ int main(void)
 	if (ret)
 		goto free_dev;
 
-	no_os_mdelay(RESET_TIME);
+	capi_wait_ms(RESET_TIME);
 
 	while (1) {
 		// time delay between readings
-		no_os_mdelay(READ_INTERVAL);
+		capi_wait_ms(READ_INTERVAL);
 		/* read and print the ade7880 rms measured values for PHASE A */
 		ret = ade7880_read_data_ph(ade7880_dev, ADE7880_PHASE_A);
 		if (ret)

--- a/projects/eval-ade7880/src/platform/platform.h
+++ b/projects/eval-ade7880/src/platform/platform.h
@@ -36,7 +36,7 @@
 #include "ade7880.h"
 #include "no_os_uart.h"
 #include "no_os_pwm.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_print_log.h"

--- a/projects/eval-ade7913/src/common/common_data.h
+++ b/projects/eval-ade7913/src/common/common_data.h
@@ -36,7 +36,7 @@
 #include "ade7913.h"
 #include "no_os_uart.h"
 #include "no_os_pwm.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_print_log.h"

--- a/projects/eval-ade7913/src/main.c
+++ b/projects/eval-ade7913/src/main.c
@@ -33,7 +33,7 @@
 #include <stdio.h>
 #include "no_os_uart.h"
 #include "no_os_pwm.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_print_log.h"
@@ -188,7 +188,7 @@ int main(void)
 	}
 
 	// Delay for ADE power up
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	// Disable the burst mode
 	ade7913_ip.burst_mode = DISABLE;

--- a/projects/eval-ade7913/src/platform/platform.h
+++ b/projects/eval-ade7913/src/platform/platform.h
@@ -36,7 +36,7 @@
 #include "ade7913.h"
 #include "no_os_uart.h"
 #include "no_os_pwm.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_print_log.h"

--- a/projects/eval-ade7953/src/common/common_data.h
+++ b/projects/eval-ade7953/src/common/common_data.h
@@ -36,7 +36,7 @@
 #include "ade7953.h"
 #include "no_os_uart.h"
 #include "no_os_pwm.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_print_log.h"

--- a/projects/eval-ade7953/src/main.c
+++ b/projects/eval-ade7953/src/main.c
@@ -34,7 +34,7 @@
 #include "no_os_uart.h"
 #include "capi_alloc.h"
 #include "no_os_pwm.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_print_log.h"

--- a/projects/eval-ade7953/src/platform/platform.h
+++ b/projects/eval-ade7953/src/platform/platform.h
@@ -36,7 +36,7 @@
 
 #include "ade7953.h"
 #include "no_os_uart.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_util.h"

--- a/projects/eval-ade7978/src/common/common_data.h
+++ b/projects/eval-ade7978/src/common/common_data.h
@@ -36,7 +36,7 @@
 #include "ade7978.h"
 #include "no_os_uart.h"
 #include "no_os_pwm.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_print_log.h"

--- a/projects/eval-ade7978/src/main.c
+++ b/projects/eval-ade7978/src/main.c
@@ -33,7 +33,7 @@
 #include <stdio.h>
 #include "no_os_uart.h"
 #include "no_os_pwm.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_print_log.h"

--- a/projects/eval-ade7978/src/platform/platform.h
+++ b/projects/eval-ade7978/src/platform/platform.h
@@ -36,7 +36,7 @@
 #include "ade7978.h"
 #include "no_os_uart.h"
 #include "no_os_pwm.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_print_log.h"

--- a/projects/eval-ade9000/src/main.c
+++ b/projects/eval-ade9000/src/main.c
@@ -33,7 +33,7 @@
 #include <stdio.h>
 #include "no_os_uart.h"
 #include "no_os_pwm.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_print_log.h"
@@ -104,11 +104,11 @@ int main(void)
 	if (ret)
 		goto free_dev;
 
-	no_os_mdelay(RESET_TIME);
+	capi_wait_ms(RESET_TIME);
 
 	while (1) {
 		// time delay between readings
-		no_os_mdelay(READ_INTERVAL);
+		capi_wait_ms(READ_INTERVAL);
 		/* read and print the ade9000 rms measured values for PHASE A */
 		ret = ade9000_read_data_ph(ade9000_dev, ADE9000_PHASE_A);
 		if (ret)

--- a/projects/eval-ade9000/src/platform/platform.h
+++ b/projects/eval-ade9000/src/platform/platform.h
@@ -36,7 +36,7 @@
 #include "ade9000.h"
 #include "no_os_uart.h"
 #include "no_os_pwm.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_print_log.h"

--- a/projects/eval-ade9078/src/main.c
+++ b/projects/eval-ade9078/src/main.c
@@ -33,7 +33,7 @@
 #include <stdio.h>
 #include "no_os_uart.h"
 #include "no_os_pwm.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_print_log.h"
@@ -153,11 +153,11 @@ int main(void)
 	if (ret)
 		goto free_dev;
 
-	no_os_mdelay(RESET_TIME);
+	capi_wait_ms(RESET_TIME);
 
 	while (1) {
 		// time delay between readings
-		no_os_mdelay(READ_INTERVAL);
+		capi_wait_ms(READ_INTERVAL);
 		/* read and print the ade9078 rms measured values for PHASE A */
 		ret = ade9078_read_data_ph(ade9078_dev, ADE9078_PHASE_A);
 		if (ret)

--- a/projects/eval-ade9078/src/platform/platform.h
+++ b/projects/eval-ade9078/src/platform/platform.h
@@ -36,7 +36,7 @@
 #include "ade9078.h"
 #include "no_os_uart.h"
 #include "no_os_pwm.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_print_log.h"

--- a/projects/eval-ade9153a/src/common/common_data.c
+++ b/projects/eval-ade9153a/src/common/common_data.c
@@ -32,6 +32,7 @@
 *******************************************************************************/
 
 #include "common_data.h"
+#include "capi_time.h"
 
 struct max_uart_init_param max_uart_extra_ip = {
 	.flow = MAX_UART_FLOW_DIS
@@ -363,13 +364,13 @@ int autocalibration_start(struct ade9153a_dev *dev)
 	pr_info("IA autocalibration started \n");
 
 	// wait 2s so the current autocalibration is ready
-	no_os_mdelay(20000);
+	capi_wait_ms(20000);
 
 	ret = ade9153a_write(dev, ADE9153A_REG_MS_ACAL_CFG, 0x00000000);
 	if (ret)
 		return ret;
 
-	no_os_mdelay(200);
+	capi_wait_ms(200);
 
 	ret = ade9153a_start_autocal_av(dev, NORMAL);
 	if (ret) {
@@ -380,13 +381,13 @@ int autocalibration_start(struct ade9153a_dev *dev)
 	pr_info("VA autocalibration started \n");
 
 	// wait 5s so the voltage autocalibration is ready
-	no_os_mdelay(50000);
+	capi_wait_ms(50000);
 
 	ret = ade9153a_write(dev, ADE9153A_REG_MS_ACAL_CFG, 0x00000000);
 	if (ret)
 		return ret;
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	return 0;
 }

--- a/projects/eval-ade9153a/src/common/common_data.h
+++ b/projects/eval-ade9153a/src/common/common_data.h
@@ -36,7 +36,7 @@
 #include "ade9153a.h"
 #include "no_os_uart.h"
 #include "no_os_pwm.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_print_log.h"

--- a/projects/eval-ade9153a/src/main.c
+++ b/projects/eval-ade9153a/src/main.c
@@ -34,7 +34,7 @@
 #include "no_os_uart.h"
 #include "capi_alloc.h"
 #include "no_os_pwm.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_print_log.h"
@@ -178,7 +178,7 @@ int main(void)
 	// burst disable
 	ade9153a_dev->burst_en = 0;
 
-	no_os_mdelay(RESET_TIME);
+	capi_wait_ms(RESET_TIME);
 
 	ret = ade9153a_setup(ade9153a_dev, ade9153a_ip);
 	if (ret)
@@ -198,7 +198,7 @@ int main(void)
 
 	while (1) {
 		// time delay between readings
-		no_os_mdelay(READ_INTERVAL);
+		capi_wait_ms(READ_INTERVAL);
 		/* read and print the ade9153a measured values */
 		ret = read_measurements(ade9153a_dev);
 		if (ret)

--- a/projects/eval-ade9430/src/common/common_data.h
+++ b/projects/eval-ade9430/src/common/common_data.h
@@ -37,7 +37,7 @@
 #include "no_os_uart.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_units.h"
 #include "no_os_util.h"

--- a/projects/eval-ade9430/src/examples/basic_example/basic_example.c
+++ b/projects/eval-ade9430/src/examples/basic_example/basic_example.c
@@ -33,7 +33,7 @@
 
 #include "common_data.h"
 #include "ade9430.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_print_log.h"
 
@@ -82,7 +82,7 @@ static int basic_read_temp(struct ade9430_dev *dev)
 
 		status = no_os_field_get(ADE9430_STATUS0_TEMP_RDY, status0);
 
-		no_os_mdelay(2);
+		capi_wait_ms(2);
 		timeout++;
 		if (timeout == 2000)
 			return -ENODATA;
@@ -157,19 +157,19 @@ int example_main(void)
 	if (ret)
 		goto remove_reset;
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	ret = no_os_gpio_set_value(gpio_reset_desc, NO_OS_GPIO_LOW);
 	if (ret)
 		goto remove_reset;
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	ret = no_os_gpio_set_value(gpio_reset_desc, NO_OS_GPIO_HIGH);
 	if (ret)
 		goto remove_reset;
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 #endif
 
 	ret = ade9430_init(&ade9430_device, ade9430_ip);
@@ -186,7 +186,7 @@ int example_main(void)
 	}
 
 	while (1) {
-		no_os_mdelay(READ_INTERVAL);
+		capi_wait_ms(READ_INTERVAL);
 
 		/* Read and print the RMS measured values for PHASE A */
 		ret = ade9430_read_data_ph(ade9430_device, ADE9430_PHASE_A);

--- a/projects/eval-ade9430/src/examples/iot_example/iot_example.c
+++ b/projects/eval-ade9430/src/examples/iot_example/iot_example.c
@@ -38,7 +38,7 @@
 
 #include "no_os_uart.h"
 #include "no_os_gpio.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_timer.h"
 #include "no_os_i2c.h"
 #include "mqtt_client.h"
@@ -481,7 +481,7 @@ int example_main()
 		goto error_gpio_rst;
 	}
 
-	no_os_mdelay(500);
+	capi_wait_ms(500);
 
 	ret = no_os_gpio_set_value(wifi_rst_gpio, NO_OS_GPIO_HIGH);
 	if (ret) {
@@ -490,7 +490,7 @@ int example_main()
 	}
 
 	/* Allow the wifi module to bring up after reset */
-	no_os_mdelay(3000);
+	capi_wait_ms(3000);
 
 	ret = ade9430_init(&ade9430_device, ade9430_ip);
 	if (ret) {
@@ -834,7 +834,7 @@ int example_main()
 
 		pr_info("Data sent to broker\n");
 
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 
 		/* Dispatch new mqtt mesages if any during SCAN_SENSOR_TIME */
 		ret = mqtt_yield(mqtt, SCAN_SENSOR_TIME);
@@ -874,7 +874,7 @@ error_pcf:
 			goto error_red_gpio_led;
 		}
 
-		no_os_mdelay(500);
+		capi_wait_ms(500);
 
 		ret = no_os_gpio_set_value(red_led_gpio, NO_OS_GPIO_LOW);
 		if (ret) {
@@ -882,7 +882,7 @@ error_pcf:
 			goto error_red_gpio_led;
 		}
 
-		no_os_mdelay(500);
+		capi_wait_ms(500);
 	}
 
 error_red_gpio_led:

--- a/projects/eval-adg1712/src/examples/basic/basic_example.c
+++ b/projects/eval-adg1712/src/examples/basic/basic_example.c
@@ -33,7 +33,7 @@
 
 #include "common_data.h"
 #include "adg1712.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 
 /***************************************************************************//**
@@ -84,7 +84,7 @@ int example_main()
 			}
 			pr_info("\r\n");
 
-			no_os_mdelay(1000);
+			capi_wait_ms(1000);
 
 			ret = adg1712_set_switch_state(dev, sw, false);
 			if (ret) {

--- a/projects/eval-adg1736/src/examples/basic/basic_example.c
+++ b/projects/eval-adg1736/src/examples/basic/basic_example.c
@@ -32,7 +32,7 @@
 *******************************************************************************/
 
 #include "common_data.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_gpio.h"
 #include "adg1736.h"
@@ -105,7 +105,7 @@ int example_main(void)
 		ret = adg1736_set_switch_state(dev, test_sw, target_state);
 		if (ret)
 			break;
-		no_os_mdelay(10);
+		capi_wait_ms(10);
 		ret = no_os_gpio_get_value(gpio_s, &s_val);
 		if (ret)
 			break;
@@ -114,7 +114,7 @@ int example_main(void)
 			s_val, s_val == 1 ? "[PASS]" : "[FAIL]");
 		pass = (s_val == 1);
 
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 
 		/* Test 2: Set to opposite position, S should be disconnected */
 		ret = adg1736_set_switch_state(dev, test_sw,
@@ -122,7 +122,7 @@ int example_main(void)
 					       ADG1736_CONNECT_B : ADG1736_CONNECT_A);
 		if (ret)
 			break;
-		no_os_mdelay(10);
+		capi_wait_ms(10);
 		ret = no_os_gpio_get_value(gpio_s, &s_val);
 		if (ret)
 			break;
@@ -142,7 +142,7 @@ int example_main(void)
 			pr_info("=== FAIL ===\r\n\r\n");
 		}
 
-		no_os_mdelay(2000);
+		capi_wait_ms(2000);
 	}
 
 	adg1736_remove(dev);

--- a/projects/eval-adg2404/src/examples/basic/basic_example.c
+++ b/projects/eval-adg2404/src/examples/basic/basic_example.c
@@ -33,7 +33,7 @@
 
 #include "adg2404.h"
 #include "common_data.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_uart.h"
 
@@ -67,28 +67,28 @@ int example_main(void)
 	if (ret)
 		goto error_uart;
 
-	no_os_udelay(1);
+	capi_wait_us(1);
 
 	/* Disable mux to start in a known state */
 	ret = adg2404_enable(adg2404_dev, false);
 	if (ret)
 		goto error;
 
-	no_os_udelay(1);
+	capi_wait_us(1);
 
 	/* Enable mux */
 	ret = adg2404_enable(adg2404_dev, true);
 	if (ret)
 		goto error;
 
-	no_os_udelay(1);
+	capi_wait_us(1);
 
 	/* Cycle through channels to cover truth table */
 	for (i = 0; i < 5; i++) {
 		ret = adg2404_select_channel(adg2404_dev, channels[i]);
 		if (ret)
 			goto error;
-		no_os_mdelay(3000);
+		capi_wait_ms(3000);
 	}
 
 	/* Disable mux */
@@ -96,7 +96,7 @@ int example_main(void)
 	if (ret)
 		goto error;
 
-	no_os_udelay(1);
+	capi_wait_us(1);
 
 	adg2404_remove(adg2404_dev);
 	no_os_uart_remove(uart_desc);

--- a/projects/eval-adgs6414d/src/examples/basic/basic_example.c
+++ b/projects/eval-adgs6414d/src/examples/basic/basic_example.c
@@ -33,7 +33,7 @@
 
 #include "common_data.h"
 #include "adgs6414d.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_error.h"
 #include "no_os_uart.h"
@@ -310,7 +310,7 @@ int example_main(void)
 		if (ret)
 			goto exit;
 
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 	}
 
 

--- a/projects/eval-adhv4710/src/common/common_data.h
+++ b/projects/eval-adhv4710/src/common/common_data.h
@@ -36,7 +36,7 @@
 #include "adhv4710.h"
 #include "no_os_uart.h"
 #include "no_os_pwm.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_print_log.h"

--- a/projects/eval-adhv4710/src/main.c
+++ b/projects/eval-adhv4710/src/main.c
@@ -33,7 +33,7 @@
 #include <stdio.h>
 #include "no_os_uart.h"
 #include "capi_alloc.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_print_log.h"

--- a/projects/eval-adhv4710/src/platform/platform.h
+++ b/projects/eval-adhv4710/src/platform/platform.h
@@ -36,7 +36,7 @@
 
 #include "adhv4710.h"
 #include "no_os_uart.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_spi.h"
 #include "no_os_util.h"

--- a/projects/eval-adis1646x/src/examples/basic_example/basic_example.c
+++ b/projects/eval-adis1646x/src/examples/basic_example/basic_example.c
@@ -33,7 +33,7 @@
 
 #include "common_data.h"
 #include "adis1646x.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_units.h"
 
@@ -107,7 +107,7 @@ int example_main()
 
 	while (1) {
 		pr_info("while loop \n");
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 		ret = adis_read_x_gyro(adis1646x_desc, &val[0]);
 		if (ret)
 			goto exit;

--- a/projects/eval-adis1647x/src/examples/basic_example/basic_example.c
+++ b/projects/eval-adis1647x/src/examples/basic_example/basic_example.c
@@ -33,7 +33,7 @@
 
 #include "common_data.h"
 #include "adis1647x.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_units.h"
 
@@ -107,7 +107,7 @@ int example_main()
 
 	while (1) {
 		pr_info("while loop \n");
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 		ret = adis_read_x_gyro(adis1647x_desc, &val[0]);
 		if (ret)
 			goto exit;

--- a/projects/eval-adis1650x/src/examples/basic_example/basic_example.c
+++ b/projects/eval-adis1650x/src/examples/basic_example/basic_example.c
@@ -33,7 +33,7 @@
 
 #include "common_data.h"
 #include "adis1650x.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_units.h"
 
@@ -107,7 +107,7 @@ int example_main()
 
 	while (1) {
 		pr_info("while loop \n");
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 		ret = adis_read_x_gyro(adis1650x_desc, &val[0]);
 		if (ret)
 			goto exit;

--- a/projects/eval-adis1654x/src/examples/basic_example/basic_example.c
+++ b/projects/eval-adis1654x/src/examples/basic_example/basic_example.c
@@ -33,7 +33,7 @@
 
 #include "common_data.h"
 #include "adis1654x.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_units.h"
 
@@ -107,7 +107,7 @@ int example_main()
 
 	while (1) {
 		pr_info("while loop \n");
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 		ret = adis_read_x_gyro(adis1654x_desc, &val[0]);
 		if (ret)
 			goto exit;

--- a/projects/eval-adis1655x/src/examples/basic_example/basic_example.c
+++ b/projects/eval-adis1655x/src/examples/basic_example/basic_example.c
@@ -33,7 +33,7 @@
 
 #include "common_data.h"
 #include "adis1655x.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_units.h"
 
@@ -107,7 +107,7 @@ int example_main()
 
 	while (1) {
 		pr_info("while loop \n");
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 		ret = adis_read_x_gyro(adis1655x_desc, &val[0]);
 		if (ret)
 			goto exit;

--- a/projects/eval-adis1657x/src/examples/basic_example/basic_example.c
+++ b/projects/eval-adis1657x/src/examples/basic_example/basic_example.c
@@ -33,7 +33,7 @@
 
 #include "common_data.h"
 #include "adis1657x.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_units.h"
 
@@ -107,7 +107,7 @@ int example_main()
 
 	while (1) {
 		pr_info("while loop \n");
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 		ret = adis_read_x_gyro(adis1657x_desc, &val[0]);
 		if (ret)
 			goto exit;

--- a/projects/eval-adl8113/src/examples/basic/basic_example.c
+++ b/projects/eval-adl8113/src/examples/basic/basic_example.c
@@ -34,7 +34,7 @@
 #include <stdbool.h>
 #include "adl8113.h"
 #include "common_data.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_uart.h"
 
@@ -54,7 +54,7 @@ static bool handle_button_press(struct no_os_gpio_desc *button)
 
 	if (val == 0) {
 		/* Wait for debounce */
-		no_os_mdelay(50);
+		capi_wait_ms(50);
 		ret = no_os_gpio_get_value(button, &val);
 		if (ret)
 			return false;
@@ -66,9 +66,9 @@ static bool handle_button_press(struct no_os_gpio_desc *button)
 				ret = no_os_gpio_get_value(button, &val);
 				if (ret)
 					return false;
-				no_os_mdelay(10);
+				capi_wait_ms(10);
 			}
-			no_os_mdelay(50);
+			capi_wait_ms(50);
 			return true;
 		}
 	}
@@ -278,7 +278,7 @@ int example_main(void)
 		default:
 			break;
 		}
-		no_os_mdelay(50);
+		capi_wait_ms(50);
 	}
 
 	pr_info("Exiting example.\n");

--- a/projects/eval-adxl313z/src/examples/basic/basic_example.c
+++ b/projects/eval-adxl313z/src/examples/basic/basic_example.c
@@ -34,7 +34,7 @@
 #include "common_data.h"
 #include "adxl313.h"
 #include "no_os_uart.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_error.h"
 
@@ -142,7 +142,7 @@ int example_main()
 		goto error;
 
 	/* Wait for 2 seconds. */
-	no_os_mdelay(2000);
+	capi_wait_ms(2000);
 
 	struct adxl313_frac_repr x[ADXL313_MAX_FIFO_ENTRIES] = {0};
 	struct adxl313_frac_repr y[ADXL313_MAX_FIFO_ENTRIES] = {0};
@@ -203,7 +203,7 @@ int example_main()
 		pr_info("===========================================================\n");
 
 		/* Wait for one second. */
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 	}
 
 error:

--- a/projects/eval-adxl355-pmdz/src/examples/dummy/dummy_example.c
+++ b/projects/eval-adxl355-pmdz/src/examples/dummy/dummy_example.c
@@ -33,7 +33,7 @@
 
 #include "common_data.h"
 #include "adxl355.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 
 /***************************************************************************//**
@@ -119,7 +119,7 @@ int example_main()
 		pr_info(" Temp =%d"".%09u millidegress Celsius \n", (int)temp.integer,
 			(abs)(temp.fractional));
 
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 	}
 
 error:

--- a/projects/eval-adxl38x/src/examples/basic/basic_example_main.c
+++ b/projects/eval-adxl38x/src/examples/basic/basic_example_main.c
@@ -33,7 +33,7 @@
 
 #include "common_data.h"
 #include "adxl38x.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include <errno.h>
 
@@ -83,7 +83,7 @@ int example_main()
 		pr_info(" Device Type = ADXL382\n");
 	else
 		pr_info(" Device Type = ADXL380\n");
-	no_os_mdelay(500);
+	capi_wait_ms(500);
 
 	while (1) {
 		ret = adxl38x_get_sts_reg(adxl38x_desc, &device_flags);
@@ -113,7 +113,7 @@ int example_main()
 		pr_info(" y = %lld.%07dg\n", yf.integer, abs(yf.fractional));
 		pr_info(" z = %lld.%07dg\n", zf.integer, abs(zf.fractional));
 
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 
 		ret = adxl38x_get_op_mode(adxl38x_desc, &opmode);
 		if (ret)
@@ -128,7 +128,7 @@ int example_main()
 		pr_info(" y = %d\n", (int)y);
 		pr_info(" z = %d\n", (int)z);
 		pr_info(" t = %d\n", (int)t);
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 	}
 
 error:

--- a/projects/eval-cn0391-ardz/src/examples/basic/basic_example.c
+++ b/projects/eval-cn0391-ardz/src/examples/basic/basic_example.c
@@ -33,7 +33,7 @@
 
 #include "common_data.h"
 #include "cn0391.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_uart.h"
 
@@ -72,7 +72,7 @@ int example_main(void)
 		}
 		printf("---\n");
 
-		no_os_mdelay(2000);
+		capi_wait_ms(2000);
 	}
 
 free_dev:

--- a/projects/eval-ltc4306/src/examples/basic/basic_example.c
+++ b/projects/eval-ltc4306/src/examples/basic/basic_example.c
@@ -34,7 +34,7 @@
 #include "common_data.h"
 #include "ltc4306.h"
 #include "no_os_uart.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 
 int LTC4306_USED_DOWNSTREAM_CHANNELS[] = {1, 2};
@@ -93,25 +93,25 @@ int example_main()
 		if (ret)
 			goto error_ltc4306;
 
-		no_os_mdelay(50);
+		capi_wait_ms(50);
 
 		ret = ltc4306_set_gpio_output_state(ltc4306, 1, false);
 		if (ret)
 			goto error_ltc4306;
 
-		no_os_mdelay(50);
+		capi_wait_ms(50);
 
 		ret = ltc4306_set_gpio_output_state(ltc4306, 2, true);
 		if (ret)
 			goto error_ltc4306;
 
-		no_os_mdelay(50);
+		capi_wait_ms(50);
 
 		ret = ltc4306_set_gpio_output_state(ltc4306, 1, true);
 		if (ret)
 			goto error_ltc4306;
 
-		no_os_mdelay(50);
+		capi_wait_ms(50);
 	}
 
 	/* Turn OFF LTC4306 Green GPIO LEDs */
@@ -133,7 +133,7 @@ int example_main()
 		pr_info("\n");
 	}
 
-	no_os_mdelay(50);
+	capi_wait_ms(50);
 
 	/* Multiple DAC Configuration Loop */
 	while (1) {

--- a/projects/eval-pqmon/src/common/afe_config.c
+++ b/projects/eval-pqmon/src/common/afe_config.c
@@ -32,6 +32,7 @@
  *******************************************************************************/
 
 #include "afe_config.h"
+#include "capi_time.h"
 
 struct no_os_spi_desc *hSPI;
 struct no_os_spi_msg spiMsg;
@@ -503,11 +504,11 @@ int reset_afe(void)
 	status = no_os_gpio_set_value(sw_reset_gpio_desc, 0);
 	if (status)
 		goto exit;
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 	status = no_os_gpio_set_value(sw_reset_gpio_desc, 1);
 	if (status)
 		goto exit;
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 	return status;
 
 exit:

--- a/projects/eval-ublox-gnss/src/main.c
+++ b/projects/eval-ublox-gnss/src/main.c
@@ -32,7 +32,7 @@
 *******************************************************************************/
 #include <stdio.h>
 #include "no_os_uart.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_gpio.h"
 #include "no_os_print_log.h"
 #include "no_os_util.h"

--- a/projects/fmcdaq2/src/app/fmcdaq2.c
+++ b/projects/fmcdaq2/src/app/fmcdaq2.c
@@ -49,7 +49,7 @@
 #include "no_os_gpio.h"
 #include "xilinx_spi.h"
 #include "xilinx_gpio.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "ad9144.h"
 #include "ad9523.h"
@@ -233,7 +233,7 @@ static int fmcdaq2_gpio_init(struct fmcdaq2_dev *dev)
 	if (status < 0)
 		return status;
 
-	no_os_mdelay(5);
+	capi_wait_ms(5);
 
 	status = no_os_gpio_set_value(dev->gpio_clkd_sync, NO_OS_GPIO_HIGH);
 	if (status < 0)
@@ -1321,7 +1321,7 @@ int main(void)
 		// Address of data destination
 		.dest_addr = (uintptr_t)ADC_DDR_BASEADDR
 	};
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 	status = axi_dmac_transfer_start(fmcdaq2.ad9680_dmac, &transfer_rx);
 	if (status)
 		return status;

--- a/projects/fmcdaq3/src/app/fmcdaq3.c
+++ b/projects/fmcdaq3/src/app/fmcdaq3.c
@@ -49,7 +49,7 @@
 #include "no_os_gpio.h"
 #include "xilinx_spi.h"
 #include "xilinx_gpio.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "ad9152.h"
 #include "ad9528.h"
@@ -652,7 +652,7 @@ int main(void)
 	       (uintptr_t)adc_buffer, transfer_rx.size / 2,
 	       ad9680_core->num_channels, ad9152_jesd_param.bits_per_sample);
 #ifdef IIO_SUPPORT
-	no_os_mdelay(100); // Allow time for displaying DMA transfer message
+	capi_wait_ms(100); // Allow time for displaying DMA transfer message
 
 	struct xil_uart_init_param platform_uart_init_par = {
 #ifdef XPAR_XUARTLITE_NUM_INSTANCES

--- a/projects/hello_world/src/examples/basic_example/basic_example.c
+++ b/projects/hello_world/src/examples/basic_example/basic_example.c
@@ -60,7 +60,7 @@
 #include <inttypes.h>
 #include "parameters.h"
 #include "no_os_uart.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "no_os_print_log.h"
 #include "basic_example.h"
@@ -137,11 +137,11 @@ int basic_example_main(void)
 		pr_info("Hello World #%"PRIu32"\n", count);
 
 		/*
-		 * no_os_mdelay() is the no-OS millisecond delay function.
+		 * capi_wait_ms() is the no-OS millisecond delay function.
 		 * It uses the platform timer underneath, so the exact
 		 * implementation differs per target but the API is identical.
 		 */
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 	}
 
 	/*

--- a/projects/iio_demo_freeRTOS/src/common/common_data.h
+++ b/projects/iio_demo_freeRTOS/src/common/common_data.h
@@ -50,7 +50,7 @@
 #include "wut.h"
 #include "uart.h"
 #include "lp.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #endif
 
 extern struct no_os_uart_init_param iio_demo_uart_ip;

--- a/projects/iio_demo_freeRTOS/src/platform/maxim/main.c
+++ b/projects/iio_demo_freeRTOS/src/platform/maxim/main.c
@@ -32,6 +32,7 @@
 *******************************************************************************/
 
 #include "common_data.h"
+#include "capi_time.h"
 
 extern int example_main();
 
@@ -73,14 +74,14 @@ void blinkingTask(void *arg)
 			if (ret)
 				goto error_pin;
 			led_on = true;
-			no_os_mdelay(100);
+			capi_wait_ms(100);
 		}
 		if (led_on) {
 			ret = no_os_gpio_set_value(led_pin, NO_OS_GPIO_LOW);
 			if (ret)
 				goto error_pin;
 			led_on = false;
-			no_os_mdelay(100);
+			capi_wait_ms(100);
 		}
 	}
 

--- a/projects/lt3074/src/examples/basic/basic_example.c
+++ b/projects/lt3074/src/examples/basic/basic_example.c
@@ -31,7 +31,7 @@
 * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 #include "common_data.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "lt3074.h"
 
@@ -102,7 +102,7 @@ int example_main()
 		pr_info("vin = %d mV | vout = %d mV | vbias = %d mV | iout = %d mA | temp = %d C\n",
 			vals[0], vals[1], vals[2], vals[3], vals[4] / 1000);
 
-		no_os_mdelay(500);
+		capi_wait_ms(500);
 	}
 
 exit:

--- a/projects/lt7170/src/examples/basic/basic_example.c
+++ b/projects/lt7170/src/examples/basic/basic_example.c
@@ -37,7 +37,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 #include "common_data.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_uart.h"
 #include "lt7170.h"
@@ -98,7 +98,7 @@ int example_main()
 			vals[3] / 1000);
 
 		pr_info("\n");
-		no_os_mdelay(500);
+		capi_wait_ms(500);
 	}
 
 exit:

--- a/projects/lt7182s/src/examples/basic/basic_example.c
+++ b/projects/lt7182s/src/examples/basic/basic_example.c
@@ -32,7 +32,7 @@
 *******************************************************************************/
 #include "common_data.h"
 #include "no_os_uart.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "lt7182s.h"
 
@@ -98,7 +98,7 @@ int example_main()
 		}
 
 		pr_info("\n");
-		no_os_mdelay(500);
+		capi_wait_ms(500);
 	}
 
 exit:

--- a/projects/lt8722/src/examples/basic/basic_example.c
+++ b/projects/lt8722/src/examples/basic/basic_example.c
@@ -30,7 +30,7 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_spi.h"
 #include "no_os_util.h"

--- a/projects/ltc2378/src/examples/basic/basic_example.c
+++ b/projects/ltc2378/src/examples/basic/basic_example.c
@@ -31,7 +31,7 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************/
 
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_spi.h"
 #include "no_os_util.h"
@@ -82,7 +82,7 @@ int example_main()
 
 		pr_info("Raw: %lu, Voltage: %ld uV\n", raw, voltage_uv);
 
-		no_os_mdelay(BASIC_EXAMPLE_DELAY_MS);
+		capi_wait_ms(BASIC_EXAMPLE_DELAY_MS);
 	}
 
 	ltc2378_remove(dev);

--- a/projects/ltc2983/src/examples/adt7604_basic/adt7604_basic_example.c
+++ b/projects/ltc2983/src/examples/adt7604_basic/adt7604_basic_example.c
@@ -33,7 +33,7 @@
 #include "common_data.h"
 #include "ltc2983.h"
 #include "no_os_uart.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 
 /*****************************************************************************
@@ -114,7 +114,7 @@ int example_main()
 			}
 		}
 
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 	}
 
 free_dev:

--- a/projects/ltc2983/src/examples/basic/basic_example.c
+++ b/projects/ltc2983/src/examples/basic/basic_example.c
@@ -34,7 +34,7 @@
 #include "common_data.h"
 #include "ltc2983.h"
 #include "no_os_uart.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 
 /*****************************************************************************
@@ -78,7 +78,7 @@ int example_main()
 			pr_info("Channel %d: temperature: %d mC\r\n", i + 1,
 				val);
 		}
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 	}
 
 free_dev:

--- a/projects/ltc3208/src/examples/basic_example/basic_example.c
+++ b/projects/ltc3208/src/examples/basic_example/basic_example.c
@@ -33,7 +33,7 @@
 
 #include "common_data.h"
 #include "ltc3208.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 
 /*****************************************************************************
@@ -50,13 +50,13 @@ int test_rgb(struct ltc3208_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	ret = ltc3208_set_4_bit_dac(dev, GREEN_RED_REG, 0, 8);
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	ret = ltc3208_set_4_bit_dac(dev, GREEN_RED_REG, 0, 0);
 	if (ret)
@@ -66,7 +66,7 @@ int test_rgb(struct ltc3208_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	ret = ltc3208_set_4_bit_dac(dev, GREEN_RED_REG, 8, 8);
 	if (ret)
@@ -89,37 +89,37 @@ int test_aux(struct ltc3208_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	ret = ltc3208_set_all_aux_led_dac(dev, MAIN, MAIN, MAIN, MAIN);
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	ret = ltc3208_set_all_aux_led_dac(dev, SUB, SUB, SUB, SUB);
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	ret = ltc3208_set_all_aux_led_dac(dev, CAM, CAM, CAM, CAM);
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	ret = ltc3208_set_aux_led_dac(dev, MAIN, 2);
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	ret = ltc3208_set_aux_led_dac(dev, SUB, 1);
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	ret = ltc3208_set_aux_led_dac(dev, AUX, 3);
 	if (ret)
@@ -142,19 +142,19 @@ int test_cam(struct ltc3208_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	ret = ltc3208_set_cam_high(dev, true);
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	ret = ltc3208_set_cam_high(dev, false);
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 
 	return 0;
@@ -178,13 +178,13 @@ int test_enrgbs(struct ltc3208_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	ret = no_os_gpio_set_value(dev->gpio_enrgbs_desc, NO_OS_GPIO_HIGH);
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	ret = ltc3208_set_sub_enable(dev, true);
 	if (ret)
@@ -194,13 +194,13 @@ int test_enrgbs(struct ltc3208_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	ret = no_os_gpio_set_value(dev->gpio_enrgbs_desc, NO_OS_GPIO_HIGH);
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	ret = ltc3208_set_sub_enable(dev, false);
 	if (ret)
@@ -210,13 +210,13 @@ int test_enrgbs(struct ltc3208_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	ret = no_os_gpio_set_value(dev->gpio_enrgbs_desc, NO_OS_GPIO_HIGH);
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	return 0;
 }
@@ -247,25 +247,25 @@ int test_dropout(struct ltc3208_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	ret = ltc3208_set_4_bit_dac(dev, GREEN_RED_REG, 8, 13);
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	ret = ltc3208_set_4_bit_dac(dev, GREEN_RED_REG, 8, 9);
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	ret = ltc3208_set_4_bit_dac(dev, AUX_BLUE_REG, 8, 13);
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	ret = ltc3208_set_all_aux_led_dac(dev, AUX, AUX, AUX, AUX);
 	if (ret)
@@ -275,7 +275,7 @@ int test_dropout(struct ltc3208_dev *dev)
 	if (ret)
 		return ret;
 
-	no_os_mdelay(1000);
+	capi_wait_ms(1000);
 
 	return 0;
 }
@@ -300,49 +300,49 @@ int example_main()
 		if (ret)
 			goto free_dev;
 
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 
 		ret = ltc3208_set_8_bit_dac(dev, MAIN_REG, 40);
 		if (ret)
 			goto free_dev;
 
-		no_os_mdelay(500);
+		capi_wait_ms(500);
 
 		ret = ltc3208_set_8_bit_dac(dev, SUB_REG, 20);
 		if (ret)
 			goto free_dev;
 
-		no_os_mdelay(500);
+		capi_wait_ms(500);
 
 		ret = test_cam(dev);
 		if (ret)
 			goto free_dev;
 
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 
 		ret = test_rgb(dev);
 		if (ret)
 			goto free_dev;
 
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 
 		ret = test_aux(dev);
 		if (ret)
 			goto free_dev;
 
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 
 		ret = test_enrgbs(dev);
 		if (ret)
 			goto free_dev;
 
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 
 		ret = test_dropout(dev);
 		if (ret)
 			goto free_dev;
 
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 	}
 
 free_dev:

--- a/projects/ltc3220/src/examples/basic_example/basic_example.c
+++ b/projects/ltc3220/src/examples/basic_example/basic_example.c
@@ -33,7 +33,7 @@
 
 #include "common_data.h"
 #include "ltc3220.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "basic_example.h"
 
 /***************************************************************************//**
@@ -60,7 +60,7 @@ int example_main()
 		/* regular light mode */
 		ltc3220_test_led_singles(ltc3220, LTC3220_MODE_NORMAL);
 
-		no_os_mdelay(3000);
+		capi_wait_ms(3000);
 
 		ret = ltc3220_reset(ltc3220);
 		if (ret)
@@ -71,7 +71,7 @@ int example_main()
 		ltc3220_set_blink_long(ltc3220, false);
 		ltc3220_test_led_singles(ltc3220, LTC3220_MODE_BLINK);
 
-		no_os_mdelay(3000);
+		capi_wait_ms(3000);
 
 		ret = ltc3220_reset(ltc3220);
 		if (ret)
@@ -82,7 +82,7 @@ int example_main()
 		ltc3220_set_blink_long(ltc3220, true);
 		ltc3220_test_led_singles(ltc3220, LTC3220_MODE_BLINK);
 
-		no_os_mdelay(3000);
+		capi_wait_ms(3000);
 
 		ret = ltc3220_reset(ltc3220);
 		if (ret)
@@ -97,7 +97,7 @@ int example_main()
 		ltc3220_set_grad_speed(ltc3220, LTC3220_GRAD_MAX_SPD);
 		ltc3220_test_led_singles(ltc3220, LTC3220_MODE_GRADATION);
 
-		no_os_mdelay(3000);
+		capi_wait_ms(3000);
 
 		ret = ltc3220_reset(ltc3220);
 		if (ret)
@@ -108,7 +108,7 @@ int example_main()
 		ltc3220_set_grad_speed(ltc3220, LTC3220_GRAD_MAX_SPD);
 		ltc3220_test_led_singles(ltc3220, LTC3220_MODE_GRADATION);
 
-		no_os_mdelay(3000);
+		capi_wait_ms(3000);
 
 		ret = ltc3220_reset(ltc3220);
 		if (ret)
@@ -118,7 +118,7 @@ int example_main()
 		ltc3220_set_grad_speed(ltc3220, 0);
 		ltc3220_test_led_singles(ltc3220, LTC3220_MODE_GRADATION);
 
-		no_os_mdelay(3000);
+		capi_wait_ms(3000);
 
 		ret = ltc3220_reset(ltc3220);
 		if (ret)
@@ -129,7 +129,7 @@ int example_main()
 		ltc3220_set_grad_speed(ltc3220, LTC3220_GRAD_MAX_SPD);
 		ltc3220_test_led_singles_alt_modes(ltc3220);
 
-		no_os_mdelay(3000);
+		capi_wait_ms(3000);
 
 		ret = ltc3220_reset(ltc3220);
 		if (ret)
@@ -143,7 +143,7 @@ int example_main()
 		ltc3220_set_blink_long(ltc3220, true);
 		ltc3220_test_led_quick_write_with_indiv(ltc3220, LTC3220_MODE_BLINK);
 
-		no_os_mdelay(3000);
+		capi_wait_ms(3000);
 
 		ret = ltc3220_reset(ltc3220);
 		if (ret)
@@ -156,11 +156,11 @@ int example_main()
 		ltc3220_test_led_singles_alt_modes(ltc3220);
 		ltc3220_set_shutdown(ltc3220, true);
 
-		no_os_mdelay(5000);
+		capi_wait_ms(5000);
 
 		ltc3220_set_shutdown(ltc3220, false);
 
-		no_os_mdelay(5000);
+		capi_wait_ms(5000);
 	}
 
 error_ltc3220:
@@ -193,7 +193,7 @@ int ltc3220_test_led_singles(struct ltc3220_dev *ltc3220,
 		ltc3220_set_uled_current(ltc3220, i, power * i);
 		if (ret)
 			return ret;
-		no_os_mdelay(1500);
+		capi_wait_ms(1500);
 	}
 
 	return 0;
@@ -221,7 +221,7 @@ int ltc3220_test_led_singles_alt_modes(struct ltc3220_dev *ltc3220)
 		ltc3220_set_uled_current(ltc3220, i, power * i);
 		if (ret)
 			return ret;
-		no_os_mdelay(1500);
+		capi_wait_ms(1500);
 	}
 
 	return 0;
@@ -254,7 +254,7 @@ int ltc3220_test_led_quick_write_with_indiv(struct ltc3220_dev *ltc3220,
 		if (ret)
 			return ret;
 
-		no_os_mdelay(1500);
+		capi_wait_ms(1500);
 	}
 
 	ret = ltc3220_set_uled_mode(ltc3220, 1, LTC3220_MODE_NORMAL);
@@ -262,7 +262,7 @@ int ltc3220_test_led_quick_write_with_indiv(struct ltc3220_dev *ltc3220,
 	if (ret)
 		return ret;
 
-	no_os_mdelay(3000);
+	capi_wait_ms(3000);
 
 	for (int i = LTC3220_REG_END_ULED / 2;
 	     i <= LTC3220_REG_END_ULED;
@@ -274,7 +274,7 @@ int ltc3220_test_led_quick_write_with_indiv(struct ltc3220_dev *ltc3220,
 		if (ret)
 			return ret;
 
-		no_os_mdelay(1500);
+		capi_wait_ms(1500);
 	}
 
 	ret = ltc3220_set_quick_write(ltc3220, false);
@@ -285,7 +285,7 @@ int ltc3220_test_led_quick_write_with_indiv(struct ltc3220_dev *ltc3220,
 	if (ret)
 		return ret;
 
-	no_os_mdelay(3000);
+	capi_wait_ms(3000);
 
 	return 0;
 }

--- a/projects/ltc3337/src/examples/basic/basic_example.c
+++ b/projects/ltc3337/src/examples/basic/basic_example.c
@@ -35,7 +35,7 @@
 #include "no_os_uart.h"
 #include "ltc3337.h"
 #include "no_os_print_log.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 /*****************************************************************************
  * @brief Basic example main execution.
@@ -102,7 +102,7 @@ int example_main()
 
 		pr_info("Die Temp %d C\n", temp_value);
 
-		no_os_mdelay(2000);
+		capi_wait_ms(2000);
 	}
 
 free_dev:

--- a/projects/ltc4162l/src/examples/basic/basic_example.c
+++ b/projects/ltc4162l/src/examples/basic/basic_example.c
@@ -34,7 +34,7 @@
 #include "common_data.h"
 #include "no_os_uart.h"
 #include "ltc4162l.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_units.h"
 
@@ -98,7 +98,7 @@ int example_main()
 	}
 
 	pr_info("\n");
-	no_os_mdelay(500);
+	capi_wait_ms(500);
 
 free_dev:
 	ltc4162l_remove(dev);

--- a/projects/ltc4296/src/examples/basic/basic_example.c
+++ b/projects/ltc4296/src/examples/basic/basic_example.c
@@ -32,7 +32,7 @@
 *******************************************************************************/
 #include "common_data.h"
 #include "no_os_uart.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_spi.h"
 #include "no_os_print_log.h"
 #include "no_os_util.h"
@@ -65,7 +65,7 @@ int example_main()
 	if (ret)
 		goto err;
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	ltc4296_port_prebias(ltc4296_desc, LTC_PORT1, LTC_CFG_APL_MODE);
 	if (ret)
@@ -75,7 +75,7 @@ int example_main()
 	if (ret)
 		goto err;
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	ret = ltc4296_port_prebias(ltc4296_desc, LTC_PORT2, LTC_CFG_APL_MODE);
 	if (ret)
@@ -85,7 +85,7 @@ int example_main()
 	if (ret)
 		goto err;
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	ret = ltc4296_port_prebias(ltc4296_desc, LTC_PORT3, LTC_CFG_APL_MODE);
 	if (ret)
@@ -95,7 +95,7 @@ int example_main()
 	if (ret)
 		goto err;
 
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	return 0;
 

--- a/projects/ltc7841/src/common/common_data.h
+++ b/projects/ltc7841/src/common/common_data.h
@@ -35,7 +35,7 @@
 
 #include "no_os_uart.h"
 #include "no_os_util.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "ltc7841.h"
 #include "parameters.h"
 

--- a/projects/ltc7841/src/examples/basic/basic_example.c
+++ b/projects/ltc7841/src/examples/basic/basic_example.c
@@ -31,7 +31,7 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 #include "common_data.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "ltc7841.h"
 
@@ -118,7 +118,7 @@ int example_main(void)
 		error = ltc7841_reg_read(ltc7841_desc, LTC7841_MFR_VOUT_MARGIN_LOW, value);
 		if (error)
 			goto remove_ltc7841;
-		no_os_mdelay(500);
+		capi_wait_ms(500);
 	}
 remove_ltc7841:
 	ltc7841_remove(ltc7841_desc);

--- a/projects/ltc7871/src/examples/basic/basic_example.c
+++ b/projects/ltc7871/src/examples/basic/basic_example.c
@@ -30,7 +30,7 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_spi.h"
 #include "no_os_util.h"

--- a/projects/ltm4686/src/examples/basic/basic_example.c
+++ b/projects/ltm4686/src/examples/basic/basic_example.c
@@ -32,7 +32,7 @@
 *******************************************************************************/
 #include "common_data.h"
 #include "no_os_uart.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "ltm4686.h"
 
@@ -89,7 +89,7 @@ int example_main()
 		}
 
 		pr_info("\n");
-		no_os_mdelay(500);
+		capi_wait_ms(500);
 	}
 
 exit:

--- a/projects/ltm4700/src/examples/basic/basic_example.c
+++ b/projects/ltm4700/src/examples/basic/basic_example.c
@@ -31,7 +31,7 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 #include "common_data.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "ltm4700.h"
 #include <stdlib.h>
@@ -92,7 +92,7 @@ int example_main()
 		}
 
 		pr_info("\n");
-		no_os_mdelay(TELEMETRY_DISPLAY_DELAY_MS);
+		capi_wait_ms(TELEMETRY_DISPLAY_DELAY_MS);
 	}
 
 

--- a/projects/ltp8800/src/examples/basic/basic_example.c
+++ b/projects/ltp8800/src/examples/basic/basic_example.c
@@ -32,7 +32,7 @@
 *******************************************************************************/
 #include "common_data.h"
 #include "no_os_uart.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "ltp8800.h"
 
@@ -117,7 +117,7 @@ int example_main()
 		pr_info("vin = %d mV | vout = %d mV | iout = %d mA | temp0 = %d C\n",
 			vals[0], vals[1], vals[2], vals[3] / 1000);
 
-		no_os_mdelay(500);
+		capi_wait_ms(500);
 	}
 
 exit:

--- a/projects/max11205pmb1/src/examples/basic/basic_example.c
+++ b/projects/max11205pmb1/src/examples/basic/basic_example.c
@@ -35,7 +35,7 @@
 #include "common_data.h"
 #include "no_os_uart.h"
 #include "no_os_print_log.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 /***************************************************************************//**
  * @brief basic example main execution.

--- a/projects/max14906/src/examples/basic/basic_example.c
+++ b/projects/max14906/src/examples/basic/basic_example.c
@@ -34,7 +34,7 @@
 #include "max149x6-base.h"
 #include "max14906.h"
 #include "no_os_uart.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_irq.h"
 
@@ -129,14 +129,14 @@ int example_main()
 		if (ret)
 			goto gpio_irq_unregister_callback;
 
-		no_os_mdelay(500);
+		capi_wait_ms(500);
 
 		ret = max149x6_reg_update(max14906_desc, MAX14906_SETLED_REG,
 					  MAX14906_SLED_CH(i), no_os_field_prep(MAX14906_SLED_CH(i), 0));
 		if (ret)
 			goto gpio_irq_unregister_callback;
 
-		no_os_mdelay(500);
+		capi_wait_ms(500);
 	}
 
 	/** Setting a current limit for channel 0. */

--- a/projects/max14914/src/examples/basic/basic_example.c
+++ b/projects/max14914/src/examples/basic/basic_example.c
@@ -33,7 +33,7 @@
 #include "common_data.h"
 #include "no_os_uart.h"
 #include "max14914.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 
 int example_main()

--- a/projects/max14916/src/examples/basic/basic_example.c
+++ b/projects/max14916/src/examples/basic/basic_example.c
@@ -33,7 +33,7 @@
 #include "common_data.h"
 #include "max149x6-base.h"
 #include "max14916.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_irq.h"
 
@@ -72,14 +72,14 @@ int example_main()
 			ret = max14916_sled_set(max14916_desc, i, MAX14916_SLED_ON);
 			if (ret)
 				goto remove_max14916;
-			no_os_mdelay(200);
+			capi_wait_ms(200);
 		}
 
 		for (i = 0; i < MAX14916_CHANNELS; i++) {
 			ret = max14916_sled_set(max14916_desc, i, MAX14916_SLED_OFF);
 			if (ret)
 				goto remove_max14916;
-			no_os_mdelay(200);
+			capi_wait_ms(200);
 		}
 		j++;
 	}

--- a/projects/max14919/src/examples/basic/basic_example.c
+++ b/projects/max14919/src/examples/basic/basic_example.c
@@ -33,7 +33,7 @@
 #include "common_data.h"
 #include "no_os_uart.h"
 #include "max14919.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 
 int example_main()

--- a/projects/max17616/src/examples/basic/basic_example.c
+++ b/projects/max17616/src/examples/basic/basic_example.c
@@ -31,7 +31,7 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *******************************************************************************/
 #include "common_data.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "max17616.h"
 #include <stdlib.h>
@@ -385,7 +385,7 @@ int example_main(void)
 
 		pr_info("\n\r");
 
-		no_os_mdelay(2000);
+		capi_wait_ms(2000);
 	}
 
 exit:

--- a/projects/max22007/src/examples/basic/basic_example.c
+++ b/projects/max22007/src/examples/basic/basic_example.c
@@ -38,7 +38,7 @@
 *******************************************************************************/
 
 #include "no_os_print_log.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "common_data.h"
 #include "max22007.h"
 
@@ -77,7 +77,7 @@ int example_main()
 
 	while (1) {
 		// Main loop - DAC channels are now set to test values
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 	}
 
 error:

--- a/projects/max22017/src/examples/basic/basic_example.c
+++ b/projects/max22017/src/examples/basic/basic_example.c
@@ -33,7 +33,7 @@
 #include "common_data.h"
 #include "no_os_uart.h"
 #include "max22017.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_irq.h"
 
@@ -123,7 +123,7 @@ int example_main()
 
 		data += sign * increment;
 
-		no_os_mdelay(1000 / freq);
+		capi_wait_ms(1000 / freq);
 	}
 
 remove_gpio0:

--- a/projects/max22190/src/examples/basic/basic_example.c
+++ b/projects/max22190/src/examples/basic/basic_example.c
@@ -33,7 +33,7 @@
 #include "common_data.h"
 #include "no_os_uart.h"
 #include "max22190.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_irq.h"
 
@@ -78,7 +78,7 @@ int example_main()
 	ret = max22190_filter_set(max22190_desc, 3, 0, 1, MAX22190_DELAY_50US);
 	if (ret)
 		goto remove_max22190;
-	no_os_udelay(50);
+	capi_wait_us(50);
 
 	ret = max22190_filter_get(max22190_desc, 3, &clrf, &fbp, &delay);
 	if (ret)

--- a/projects/max22196/src/examples/basic/basic_example.c
+++ b/projects/max22196/src/examples/basic/basic_example.c
@@ -33,7 +33,7 @@
 #include "common_data.h"
 #include "no_os_uart.h"
 #include "max22196.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_irq.h"
 

--- a/projects/max22200/src/examples/basic/basic_example.c
+++ b/projects/max22200/src/examples/basic/basic_example.c
@@ -33,7 +33,7 @@
 #include "common_data.h"
 #include "no_os_uart.h"
 #include "max22200.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_irq.h"
 

--- a/projects/max22915/src/examples/basic/basic_example.c
+++ b/projects/max22915/src/examples/basic/basic_example.c
@@ -32,7 +32,7 @@
 *******************************************************************************/
 
 #include "no_os_print_log.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_error.h"
 #include "common_data.h"
 #include "max22915.h"
@@ -218,7 +218,7 @@ int example_main()
 
 		pr_info("Diagnostics cycle complete\r\n");
 
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 	}
 
 error:

--- a/projects/max25603/src/examples/basic/basic_example.c
+++ b/projects/max25603/src/examples/basic/basic_example.c
@@ -33,7 +33,7 @@
 #include "common_data.h"
 #include "no_os_uart.h"
 #include "max25603.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_irq.h"
 
@@ -64,7 +64,7 @@ int example_main()
 	if (ret)
 		goto remove_max25603;
 
-	no_os_mdelay(5000);
+	capi_wait_ms(5000);
 
 	ret = max25603_set_beam(max25603_desc, MAX25603_DISABLE_BEAM, 0, 0);
 	if (ret)

--- a/projects/max30009/src/examples/basic/basic_example.c
+++ b/projects/max30009/src/examples/basic/basic_example.c
@@ -36,7 +36,7 @@
 
 #include "max30009.h"
 #include "common_data.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_irq.h"
 #include "no_os_print_log.h"
 #include "no_os_uart.h"
@@ -374,7 +374,7 @@ int example_main(void)
 next:
 			max30009_clear_status(dev);
 		}
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 		elapsed++;
 	}
 

--- a/projects/max30009/src/platform/maxim/main.c
+++ b/projects/max30009/src/platform/maxim/main.c
@@ -33,7 +33,7 @@
 
 #include "common_data.h"
 #include "no_os_irq.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "parameters.h"
 
 int example_main();
@@ -63,7 +63,7 @@ int main(void)
 	no_os_uart_stdio(uart_desc);
 
 	/* Add delay to ensure UART is fully initialized after power-on reset */
-	no_os_mdelay(100);
+	capi_wait_ms(100);
 
 	ret = example_main();
 	if (ret)

--- a/projects/max31827-evkit/src/examples/basic/basic_example.c
+++ b/projects/max31827-evkit/src/examples/basic/basic_example.c
@@ -32,7 +32,7 @@
  *******************************************************************************/
 #include "common_data.h"
 #include "max31827.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_units.h"
 /*****************************************************************************
@@ -68,7 +68,7 @@ int example_main()
 
 		pr_info("Temperature: %d mC\r\n", val);
 
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 	}
 
 free_dev:

--- a/projects/max31855/src/examples/basic/basic_example.c
+++ b/projects/max31855/src/examples/basic/basic_example.c
@@ -35,7 +35,7 @@
 #include "no_os_uart.h"
 #include "max31855.h"
 #include "no_os_print_log.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 
 /*****************************************************************************
  * @brief Basic example main execution.
@@ -75,7 +75,7 @@ int example_main()
 		pr_info("Ambient temperature %.02d.%.02d\n", ambient_temp.integer,
 			ambient_temp.decimal);
 
-		no_os_mdelay(2000);
+		capi_wait_ms(2000);
 	}
 
 free_dev:

--- a/projects/max42500/src/common/common_data.h
+++ b/projects/max42500/src/common/common_data.h
@@ -42,7 +42,7 @@
 #include "parameters.h"
 #include "no_os_uart.h"
 #include "no_os_util.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "max42500.h"
 
 extern struct no_os_uart_init_param uart_ip;

--- a/projects/pulsar-adc/src/examples/basic_example/basic_example.c
+++ b/projects/pulsar-adc/src/examples/basic_example/basic_example.c
@@ -33,7 +33,7 @@
 
 #include "basic_example.h"
 #include "common_data.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_util.h"
 #include "no_os_print_log.h"
 #include "pulsar_adc.h"

--- a/projects/ssd1306/src/common/common_data.h
+++ b/projects/ssd1306/src/common/common_data.h
@@ -37,7 +37,7 @@
 #include "no_os_util.h"
 #include "display.h"
 #include "ssd_1306.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_i2c.h"
 #include "maxim_i2c.h"
 #include "example.h"

--- a/projects/ssd1306/src/examples/example/example.c
+++ b/projects/ssd1306/src/examples/example/example.c
@@ -35,7 +35,7 @@
 #include "no_os_util.h"
 #include <stdint.h>
 #include <stdio.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_i2c.h"
 #include "display.h"
 #include "ssd_1306.h"
@@ -241,7 +241,7 @@ void startup_screen()
 	lv_display_t * disp = lv_display_get_default();
 	lv_area_t area = {0, 0, SSD1306_HOR_REZ - 1, SSD1306_VER_REZ - 1};
 	my_flush_cb(disp, &area, &display_buffer[8]);
-	no_os_mdelay(5000);
+	capi_wait_ms(5000);
 	lv_refr_now(NULL);
 }
 
@@ -278,7 +278,7 @@ int example_main(void)
 	test_draw();
 
 	while (1) {
-		no_os_mdelay(20);
+		capi_wait_ms(20);
 		lv_timer_handler();
 	}
 	return 0;

--- a/projects/swiot1l/src/common/swiot.c
+++ b/projects/swiot1l/src/common/swiot.c
@@ -39,7 +39,7 @@
 #include "iio.h"
 #include "swiot.h"
 #include "no_os_gpio.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "capi_alloc.h"
 #include "iio_ad74413r.h"
 #include "iio_max14906.h"
@@ -459,9 +459,9 @@ static int swiot_write_identify(void *dev, char *buf, uint32_t len,
 
 	for (int i = 0; i < 15; i++) {
 		no_os_gpio_set_value(desc->identify_gpio, 1);
-		no_os_mdelay(100);
+		capi_wait_ms(100);
 		no_os_gpio_set_value(desc->identify_gpio, 0);
-		no_os_mdelay(100);
+		capi_wait_ms(100);
 	}
 
 	return 0;

--- a/projects/swiot1l/src/examples/swiot1l-mqtt/swiot1l_mqtt.c
+++ b/projects/swiot1l/src/examples/swiot1l-mqtt/swiot1l_mqtt.c
@@ -39,7 +39,7 @@
 #include "common_data.h"
 #include "no_os_util.h"
 #include "no_os_gpio.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "mqtt_client.h"
 #include "mqtt_noos_support.h"
@@ -210,7 +210,7 @@ int swiot1l_mqtt()
 
 	while (connect_timeout--) {
 		no_os_lwip_step(tcp_socket->net->net, NULL);
-		no_os_mdelay(1);
+		capi_wait_ms(1);
 	}
 
 	ret = mqtt_connect(mqtt, &conn_config, NULL);
@@ -290,7 +290,7 @@ int swiot1l_mqtt()
 			goto free_mqtt;
 		}
 
-		no_os_mdelay(1000);
+		capi_wait_ms(1000);
 	}
 
 	return 0;

--- a/projects/wethlink/src/app/led.c
+++ b/projects/wethlink/src/app/led.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include "no_os_gpio.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "parameters.h"
 #include "led.h"
 
@@ -119,12 +119,12 @@ void led_blink_all(unsigned int times, unsigned int duration_ms)
 		led_rx_lock(true);
 		led_tx_det_green(true);
 		led_rx_det_green(true);
-		no_os_mdelay(duration_ms / times / 2);
+		capi_wait_ms(duration_ms / times / 2);
 		led_tx_lock(false);
 		led_rx_lock(false);
 		led_tx_det_green(false);
 		led_rx_det_green(false);
-		no_os_mdelay(duration_ms / times / 2);
+		capi_wait_ms(duration_ms / times / 2);
 	}
 }
 

--- a/projects/wethlink/src/app/main.c
+++ b/projects/wethlink/src/app/main.c
@@ -1,5 +1,5 @@
 #include <string.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_print_log.h"
 #include "no_os_util.h"
 #include "no_os_rtc.h"

--- a/projects/wethlink/src/app/mwc.c
+++ b/projects/wethlink/src/app/mwc.c
@@ -4,7 +4,7 @@
 #include <inttypes.h>
 #include <math.h>
 #include "no_os_error.h"
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_crc8.h"
 #include "iio.h"
 #include "mwc.h"
@@ -258,9 +258,9 @@ int mwc_tx_rx_reset(struct mwc_iio_dev *mwc)
 		return -EINVAL;
 
 	no_os_gpio_set_value(mwc->reset_gpio, NO_OS_GPIO_HIGH);
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 	no_os_gpio_set_value(mwc->reset_gpio, NO_OS_GPIO_LOW);
-	no_os_mdelay(1);
+	capi_wait_ms(1);
 
 	return 0;
 }

--- a/projects/wethlink/src/app/net.c
+++ b/projects/wethlink/src/app/net.c
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include "no_os_delay.h"
+#include "capi_time.h"
 #include "no_os_mdio.h"
 #include "no_os_gpio.h"
 #include "no_os_irq.h"


### PR DESCRIPTION
## Pull Request Description

Tree wide replacement of no_os_delay with capi_time
For now the build will fail, when trying to build a project that runs on a platform whose drivers are not ported to CAPI yet.
This should also be merged only when all the supported platform drivers are ported to CAPI.

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
