### PR TITLE
capi: Add PINT and WDT to CMake and Kconfig

### DIFF
--- a/capi/CMakeLists.txt
+++ b/capi/CMakeLists.txt
@@ -15,6 +15,8 @@ no_os_sources_ifdef(CONFIG_CAPI_SPI   ${CMAKE_CURRENT_SOURCE_DIR}/src/capi_spi.c
 no_os_sources_ifdef(CONFIG_CAPI_TIMER ${CMAKE_CURRENT_SOURCE_DIR}/src/capi_timer.c)
 no_os_sources_ifdef(CONFIG_CAPI_I2C   ${CMAKE_CURRENT_SOURCE_DIR}/src/capi_i2c.c)
 no_os_sources_ifdef(CONFIG_CAPI_DMA   ${CMAKE_CURRENT_SOURCE_DIR}/src/capi_dma.c)
+no_os_sources_ifdef(CONFIG_CAPI_WDT   ${CMAKE_CURRENT_SOURCE_DIR}/src/capi_wdt.c)
+no_os_sources_ifdef(CONFIG_CAPI_PINT  ${CMAKE_CURRENT_SOURCE_DIR}/src/capi_pint.c)
 
 target_include_directories(no-os PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/inc)
 

--- a/capi/Kconfig
+++ b/capi/Kconfig
@@ -47,4 +47,12 @@ config CAPI_DMA
 	bool "CAPI DMA"
 	default n
 
+config CAPI_WDT
+	bool "CAPI WDT"
+	default n
+
+config CAPI_PINT
+	bool "CAPI PINT"
+	default n
+
 endif # CAPI

--- a/capi/inc/capi_pint.h
+++ b/capi/inc/capi_pint.h
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief Common API for Pin Interrupt (PINT) Controller
+ */
+
+#ifndef _CAPI_PINT_H_
+#define _CAPI_PINT_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/**
+ * @brief PINT trigger types
+ */
+enum capi_pint_trigger {
+	CAPI_PINT_TRIGGER_EDGE_RISING = 0x00U,  /**< Rising edge trigger */
+	CAPI_PINT_TRIGGER_EDGE_FALLING = 0x01U, /**< Falling edge trigger */
+	CAPI_PINT_TRIGGER_LEVEL_LOW = 0x02U,    /**< Level low trigger */
+	CAPI_PINT_TRIGGER_LEVEL_HIGH = 0x03U    /**< Level high trigger */
+};
+
+/**
+ * @brief PINT callback type
+ *
+ * @param [in] pin_index Pin index that triggered the interrupt
+ * @param [in] user_data Pointer to user-specific data
+ */
+typedef void (*capi_pint_callback_t)(uint8_t pin_index, void *user_data);
+
+/**
+ * @brief PINT pin configuration structure
+ */
+struct capi_pint_pin_config {
+	enum capi_pint_trigger trigger_type; /**< Trigger type for the pin */
+	bool enabled;                        /**< Enable/disable flag */
+};
+
+/**
+ * @brief PINT port handle type
+ */
+struct capi_pint_port_handle {
+	const struct capi_pint_ops *ops; /**< Set and used by CAPI thin layer */
+	bool init_allocated;             /**< If true, the driver owns handle memory */
+	void *lock; /**< Set and used by CAPI thin layer if mutex is available */
+	void *priv; /**< Set and used by driver implementation */
+};
+
+/**
+ * @brief PINT port configuration
+ */
+struct capi_pint_port_config {
+	/** PINT port specific operations */
+	const struct capi_pint_ops *ops;
+	/** PINT port identifier (typically base address) */
+	uint64_t identifier;
+	/** Number of PINT pins */
+	uint8_t num_pins;
+	/** Reference to PINT port private information */
+	void *priv;
+};
+
+/**
+ * @brief Initialize the PINT port
+ *
+ * @param [in,out] handle If NULL, the function must allocate the required memory.
+ *                        Otherwise, init() will use the preallocated structure.
+ * @param [in] config The PINT port configuration.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int capi_pint_port_init(struct capi_pint_port_handle **handle,
+			const struct capi_pint_port_config *config);
+
+/**
+ * @brief Deinitialize the PINT port
+ *
+ * @param [in] handle The PINT port handle. If allocated by init(),
+ *                    deinit() must free the memory.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int capi_pint_port_deinit(struct capi_pint_port_handle **handle);
+
+/**
+ * @brief Configure a specific PINT pin
+ *
+ * @param [in] handle The PINT port handle.
+ * @param [in] pin_index Pin index to configure.
+ * @param [in] config Pin configuration (trigger type, enable/disable).
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int capi_pint_configure_pin(struct capi_pint_port_handle *handle,
+			    uint8_t pin_index,
+			    const struct capi_pint_pin_config *config);
+
+/**
+ * @brief Enable a specific PINT pin
+ *
+ * @param [in] handle The PINT port handle.
+ * @param [in] pin_index Pin index to enable.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int capi_pint_enable_pin(struct capi_pint_port_handle *handle,
+			 uint8_t pin_index);
+
+/**
+ * @brief Disable a specific PINT pin
+ *
+ * @param [in] handle The PINT port handle.
+ * @param [in] pin_index Pin index to disable.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int capi_pint_disable_pin(struct capi_pint_port_handle *handle,
+			  uint8_t pin_index);
+
+/**
+ * @brief Register a callback for a specific PINT pin
+ *
+ * @param [in] handle The PINT port handle.
+ * @param [in] pin_index Pin index for callback registration.
+ * @param [in] callback Callback function to be invoked on interrupt.
+ * @param [in] user_data User-specific data passed to the callback.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int capi_pint_register_callback(struct capi_pint_port_handle *handle,
+				uint8_t pin_index,
+				capi_pint_callback_t callback, void *user_data);
+
+/**
+ * @brief Unregister a callback for a specific PINT pin
+ *
+ * @param [in] handle The PINT port handle.
+ * @param [in] pin_index Pin index for callback unregistration.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int capi_pint_unregister_callback(struct capi_pint_port_handle *handle,
+				  uint8_t pin_index);
+
+/**
+ * @brief Clear pending interrupt for a specific PINT pin
+ *
+ * @param [in] handle The PINT port handle.
+ * @param [in] pin_index Pin index to clear pending interrupt.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int capi_pint_clear_pending(struct capi_pint_port_handle *handle,
+			    uint8_t pin_index);
+
+/**
+ * @brief Get pending interrupt status for a specific PINT pin
+ *
+ * @param [in] handle The PINT port handle.
+ * @param [out] pending Pointer to store pending status (bitmask of pending pins).
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int capi_pint_get_pending(struct capi_pint_port_handle *handle,
+			  uint32_t *pending);
+
+/**
+ * @brief Handle interrupt for the PINT port (should be called from ISR)
+ *
+ * @param [in] handle The PINT port handle.
+ *
+ * @return 0 in case of success, negative error code otherwise.
+ */
+int capi_pint_handle_interrupt(struct capi_pint_port_handle *handle);
+
+/**
+ * @brief Container for PINT specific operations
+ */
+struct capi_pint_ops {
+	/** See capi_pint_port_init() */
+	int (*port_init)(struct capi_pint_port_handle **handle,
+			 const struct capi_pint_port_config *config);
+	/** See capi_pint_port_deinit() */
+	int (*port_deinit)(struct capi_pint_port_handle **handle);
+	/** See capi_pint_configure_pin() */
+	int (*configure_pin)(struct capi_pint_port_handle *handle, uint8_t pin_index,
+			     const struct capi_pint_pin_config *config);
+	/** See capi_pint_enable_pin() */
+	int (*enable_pin)(struct capi_pint_port_handle *handle, uint8_t pin_index);
+	/** See capi_pint_disable_pin() */
+	int (*disable_pin)(struct capi_pint_port_handle *handle, uint8_t pin_index);
+	/** See capi_pint_register_callback() */
+	int (*register_callback)(struct capi_pint_port_handle *handle,
+				 uint8_t pin_index,
+				 capi_pint_callback_t callback, void *user_data);
+	/** See capi_pint_unregister_callback() */
+	int (*unregister_callback)(struct capi_pint_port_handle *handle,
+				   uint8_t pin_index);
+	/** See capi_pint_clear_pending() */
+	int (*clear_pending)(struct capi_pint_port_handle *handle, uint8_t pin_index);
+	/** See capi_pint_get_pending() */
+	int (*get_pending)(struct capi_pint_port_handle *handle, uint32_t *pending);
+	/** See capi_pint_handle_interrupt() */
+	int (*handle_interrupt)(struct capi_pint_port_handle *handle);
+};
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* _CAPI_PINT_H_ */

--- a/capi/inc/capi_wdt.h
+++ b/capi/inc/capi_wdt.h
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2024-2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief The Watchdog Timer API
+ */
+
+#ifndef _CAPI_WDT_H
+#define _CAPI_WDT_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* _cplusplus */
+
+/**
+ * @brief User callback. Used for interrupt mode only.
+ *
+ * @param[in] chan_id Channel identifier (for multi-channel WDT support).
+ * @param[in] arg Pointer to user specific data.
+ * @param[in] extra_flags optional, platform/driver specific extra flags
+ */
+typedef void (*capi_wdt_callback_t)(int chan_id, void *arg,
+				    uint32_t extra_flags);
+
+/**
+ * @brief WDT configuration. Common WDT config for all channels.
+ * WDT can support multiple channels (multiple reset and IRQ signals).
+ * Channel numbers starts from Zero.
+ */
+struct capi_wdt_config {
+	/** ops - optional. if NULL, API selects driver from static mapping based on
+	 * identifier */
+	const struct capi_wdt_ops *ops;
+	/** WDT controller identifier:
+	 * - Base address for internal controllers.
+	 * - Device specific address for external controllers
+	 */
+	uint64_t identifier;
+	/** Frequency of peripheral clock in Hz, if zero, driver sets to default of platform */
+	uint32_t clk_freq_hz;
+	/** User callback. Must be provided if any channel is set to irq mode */
+	capi_wdt_callback_t callback;
+	/** User specific data passed to the callback */
+	void *arg;
+	/** Optional platform specific extra configuration */
+	void *extra;
+};
+
+/**
+ * @brief WDT channel configuration.
+ * WDT can support multiple channels (multiple reset and IRQ signals).
+ * Channel numbers starts from Zero.
+ */
+struct capi_wdt_chan_config {
+	/** true : WDT raises interrupt on expiration instead of resetting system */
+	bool irq_enabled;
+	/** true : WDT reset output is enabled */
+	bool reset_enabled;
+	/** Timeout in usecs */
+	uint64_t timeout_us;
+	/** Optional platform specific extra configuration */
+	void *extra;
+};
+
+/**
+ * @brief WDT handle
+ *
+ * Drivers may need own handle type to handle internals.
+ * Driver developer shall declare this as the first field of private handle structure.
+ */
+struct capi_wdt_handle {
+	const struct capi_wdt_ops *ops; /**< set and used by capi thin layer */
+	bool init_allocated;            /**< If true, the driver is owner of handle memory. */
+	void *priv;                     /**< set and used by user optionally */
+};
+
+/**
+ * @brief Initialize an instance of the WDT.
+ * Note, init doesn't start the WDT. WDT starts with first feed.
+ *
+ * @param [in out] handle Points to a pointer of the context structure. If this
+ *                 pointer is set to NULL, then the controller will allocate
+ *	               the context structure and be the owner. If the pointer
+ *	               is not NULL, the application has allocated the structure and is
+ *	               the owner.
+ * @param [in] config Points to the configuration for the WDT.
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_wdt_init(struct capi_wdt_handle **handle,
+		  const struct capi_wdt_config *config);
+
+/**
+ * @brief Deinitialize the WDT, disable all channels, and bring to default settings.
+ *
+ * @param [in] handle Points to the WDT context.
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_wdt_deinit(struct capi_wdt_handle *handle);
+
+/**
+ * @brief Get available channels for WDT. WDT can support multiple channels (multiple reset and IRQ
+ * signals). Channel numbers starts from Zero.
+ *
+ * @param [in] handle Points to a pointer of the context structure.
+ * @param [out] channels returns number of available channels. Single channel WDT shall return 1.
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_wdt_get_chan_count(struct capi_wdt_handle *handle, int *channels);
+
+/**
+ * @brief Setup WDT channel with timing and other options
+ * Note, setup doesn't start the WDT. WDT starts with first feed.
+ *
+ * @param [in] handle Points to a pointer of the context structure.
+ * @param [in] chan_id WDT channel id for multi-channel case. Channels starts from 0.
+ * @param [in] chan_config Points to the configuration for the WDT.
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_wdt_setup_chan(struct capi_wdt_handle *handle, int chan_id,
+			const struct capi_wdt_chan_config *chan_config);
+
+/**
+ * @brief Setup single channel WDT with timing and other options
+ * Note, setup doesn't start the WDT. WDT starts with first feed.
+ *
+ * @param [in] handle Points to a pointer of the context structure.
+ * @param [in] chan_config Points to the configuration for the WDT.
+ *
+ * @return int 0 for success or error code.
+ */
+static inline int capi_wdt_setup(struct capi_wdt_handle *handle,
+				 const struct capi_wdt_chan_config *chan_config)
+{
+	return capi_wdt_setup_chan(handle, 0, chan_config);
+}
+
+/**
+ * @brief Stops the WDT for specific channel. Feed is required to restart.
+ *
+ * @param [in] handle Points to a pointer of the context structure.
+ * @param [in] chan_id WDT channel id for multi-channel case. Channels starts from 0.
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_wdt_disable_chan(struct capi_wdt_handle *handle, int chan_id);
+
+/**
+ * @brief Stops the single channel WDT. Feed is required to restart.
+ *
+ * @param [in] handle Points to a pointer of the context structure.
+ *
+ * @return int 0 for success or error code.
+ */
+static inline int capi_wdt_disable(struct capi_wdt_handle *handle)
+{
+	return capi_wdt_disable_chan(handle, 0);
+}
+
+/**
+ * @brief Feed (restart) the WDT for specific channel.
+ *
+ * @param [in] handle Points to a pointer of the context structure.
+ * @param [in] chan_id WDT channel id for multi-channel case. Channels starts from 0.
+ *
+ * @return int 0 for success or error code.
+ */
+int capi_wdt_feed_chan(struct capi_wdt_handle *handle, int chan_id);
+
+/**
+ * @brief Feed (restart) the single channel WDT.
+ *
+ * @param [in] handle Points to a pointer of the context structure.
+ *
+ * @return int 0 for success or error code.
+ */
+static inline int capi_wdt_feed(struct capi_wdt_handle *handle)
+{
+	return capi_wdt_feed_chan(handle, 0);
+}
+
+/**
+ * @brief WDT Driver Interrupt handler. If interrupt vectors are managed and implemented by user,
+ * then user shall call this function in the relevant interrupt vector function.
+ *
+ * @param [in] handle Points to the WDT context
+ */
+void capi_wdt_isr(struct capi_wdt_handle *handle);
+
+/**
+ * @brief Structure holding WDT function pointers that point to the platform
+ * specific function. See API functions for relevant descriptions.
+ */
+struct capi_wdt_ops {
+	/** See capi_wdt_init() */
+	int (*init)(struct capi_wdt_handle **handle,
+		    const struct capi_wdt_config *config);
+	/** See capi_wdt_deinit() */
+	int (*deinit)(struct capi_wdt_handle *handle);
+	/** See capi_wdt_get_chan_count() */
+	int (*get_chan_count)(struct capi_wdt_handle *handle, int *channels);
+	/** See capi_wdt_setup_chan() */
+	int (*setup_chan)(struct capi_wdt_handle *handle, int chan_id,
+			  const struct capi_wdt_chan_config *chan_config);
+	/** See capi_wdt_disable_chan() */
+	int (*disable_chan)(struct capi_wdt_handle *handle, int chan_id);
+	/** See capi_wdt_feed_chan() */
+	int (*feed_chan)(struct capi_wdt_handle *handle, int chan_id);
+	/** See capi_wdt_isr() */
+	void (*isr)(struct capi_wdt_handle *handle);
+};
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* _CAPI_WDT_H */

--- a/capi/src/capi_pint.c
+++ b/capi/src/capi_pint.c
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file
+ * @brief CAPI PINT thin layer implementation
+ */
+
+#include "capi_pint.h"
+#include <errno.h>
+
+int capi_pint_port_init(struct capi_pint_port_handle **handle,
+			const struct capi_pint_port_config *config)
+{
+	if (!handle || !config || !config->ops || !config->ops->port_init) {
+		return -EINVAL;
+	}
+
+	return config->ops->port_init(handle, config);
+}
+
+int capi_pint_port_deinit(struct capi_pint_port_handle **handle)
+{
+	if (!handle || !*handle || !(*handle)->ops || !(*handle)->ops->port_deinit) {
+		return -EINVAL;
+	}
+
+	return (*handle)->ops->port_deinit(handle);
+}
+
+int capi_pint_configure_pin(struct capi_pint_port_handle *handle,
+			    uint8_t pin_index,
+			    const struct capi_pint_pin_config *config)
+{
+	if (!handle || !handle->ops || !handle->ops->configure_pin) {
+		return -EINVAL;
+	}
+
+	return handle->ops->configure_pin(handle, pin_index, config);
+}
+
+int capi_pint_enable_pin(struct capi_pint_port_handle *handle,
+			 uint8_t pin_index)
+{
+	if (!handle || !handle->ops || !handle->ops->enable_pin) {
+		return -EINVAL;
+	}
+
+	return handle->ops->enable_pin(handle, pin_index);
+}
+
+int capi_pint_disable_pin(struct capi_pint_port_handle *handle,
+			  uint8_t pin_index)
+{
+	if (!handle || !handle->ops || !handle->ops->disable_pin) {
+		return -EINVAL;
+	}
+
+	return handle->ops->disable_pin(handle, pin_index);
+}
+
+int capi_pint_register_callback(struct capi_pint_port_handle *handle,
+				uint8_t pin_index,
+				capi_pint_callback_t callback, void *user_data)
+{
+	if (!handle || !handle->ops || !handle->ops->register_callback) {
+		return -EINVAL;
+	}
+
+	return handle->ops->register_callback(handle, pin_index, callback, user_data);
+}
+
+int capi_pint_unregister_callback(struct capi_pint_port_handle *handle,
+				  uint8_t pin_index)
+{
+	if (!handle || !handle->ops || !handle->ops->unregister_callback) {
+		return -EINVAL;
+	}
+
+	return handle->ops->unregister_callback(handle, pin_index);
+}
+
+int capi_pint_clear_pending(struct capi_pint_port_handle *handle,
+			    uint8_t pin_index)
+{
+	if (!handle || !handle->ops || !handle->ops->clear_pending) {
+		return -EINVAL;
+	}
+
+	return handle->ops->clear_pending(handle, pin_index);
+}
+
+int capi_pint_get_pending(struct capi_pint_port_handle *handle,
+			  uint32_t *pending)
+{
+	if (!handle || !handle->ops || !handle->ops->get_pending) {
+		return -EINVAL;
+	}
+
+	return handle->ops->get_pending(handle, pending);
+}
+
+int capi_pint_handle_interrupt(struct capi_pint_port_handle *handle)
+{
+	if (!handle || !handle->ops || !handle->ops->handle_interrupt) {
+		return -EINVAL;
+	}
+
+	return handle->ops->handle_interrupt(handle);
+}

--- a/capi/src/capi_wdt.c
+++ b/capi/src/capi_wdt.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2024-2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/**
+ * @file capi_wdt.c
+ * @brief This file contains a set of small wrapper functions that can be used to access
+ *        the WDT driver via its ops pointer structure. Note, it does not
+ *        implement any thread safety such as mutually excluding calls to the WDT functions.
+ *        If this is needed, it is suggested that this file and all of the other driver
+ *        wrappers be copied and enhanced in your project.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <capi_wdt.h>
+
+int capi_wdt_init(struct capi_wdt_handle **handle,
+		  const struct capi_wdt_config *config)
+{
+	if (!handle || !config || !config->ops || !config->ops->init) {
+		return -EINVAL;
+	}
+	return config->ops->init(handle, config);
+}
+
+int capi_wdt_deinit(struct capi_wdt_handle *handle)
+{
+	if (!handle || !handle->ops || !handle->ops->deinit) {
+		return -EINVAL;
+	}
+	return handle->ops->deinit(handle);
+}
+
+int capi_wdt_get_chan_count(struct capi_wdt_handle *handle, int *channels)
+{
+	if (!handle || !handle->ops || !handle->ops->get_chan_count) {
+		return -EINVAL;
+	}
+	return handle->ops->get_chan_count(handle, channels);
+}
+
+int capi_wdt_setup_chan(struct capi_wdt_handle *handle, int chan_id,
+			const struct capi_wdt_chan_config *chan_config)
+{
+	if (!handle || !handle->ops || !handle->ops->setup_chan) {
+		return -EINVAL;
+	}
+	return handle->ops->setup_chan(handle, chan_id, chan_config);
+}
+
+int capi_wdt_disable_chan(struct capi_wdt_handle *handle, int chan_id)
+{
+	if (!handle || !handle->ops || !handle->ops->disable_chan) {
+		return -EINVAL;
+	}
+	return handle->ops->disable_chan(handle, chan_id);
+}
+
+int capi_wdt_feed_chan(struct capi_wdt_handle *handle, int chan_id)
+{
+	if (!handle || !handle->ops || !handle->ops->feed_chan) {
+		return -EINVAL;
+	}
+	return handle->ops->feed_chan(handle, chan_id);
+}
+
+void capi_wdt_isr(struct capi_wdt_handle *handle)
+{
+	if (!handle || !handle->ops || !handle->ops->isr) {
+		return;
+	}
+	handle->ops->isr(handle);
+}


### PR DESCRIPTION
## Pull Request Description

This is the **1st** of 3 PRs in the stack.

Adds `CMakeLists.txt` wiring and `Kconfig` options for PINT and WDT drivers

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
