### PR TITLE
scripts: xilinx: dispose client before create_app_component

### DIFF
--- a/.github/workflows/build-xilinx-platform.yaml
+++ b/.github/workflows/build-xilinx-platform.yaml
@@ -66,7 +66,7 @@ jobs:
       RELEASES_DIR: ${{ github.workspace }}/latest_build
       LOGS_DIR: ${{ github.workspace }}/logs
       NO_OS_CACHE_DIR: ${{ github.workspace }}/deps_cache
-    runs-on: test-vitis-error
+    runs-on: noos-runner-xilinx
     timeout-minutes: 600
     steps:
       - name: Checkout code

--- a/.github/workflows/build-xilinx-platform.yaml
+++ b/.github/workflows/build-xilinx-platform.yaml
@@ -66,7 +66,7 @@ jobs:
       RELEASES_DIR: ${{ github.workspace }}/latest_build
       LOGS_DIR: ${{ github.workspace }}/logs
       NO_OS_CACHE_DIR: ${{ github.workspace }}/deps_cache
-    runs-on: noos-runner-xilinx
+    runs-on: test-vitis-error
     timeout-minutes: 600
     steps:
       - name: Checkout code

--- a/tools/scripts/platform/xilinx/util.py
+++ b/tools/scripts/platform/xilinx/util.py
@@ -510,9 +510,13 @@ def create_project(ws, hw_path, hw_file, target):
         print("INFO: Building platform (BSP + FSBL)...")
         platform.build()
 
+    # Dispose and reconnect so gRPC server registers the new xpfm.
+    vitis.dispose()
+
     # --- Step 2: App component (linker script) ---
     xpfm = os.path.join(out_dir, "hw0", "export", "hw0", "hw0.xpfm")
     print("INFO: Creating app component for linker script...")
+    client = vitis.create_client(workspace=out_dir)
     app = client.create_app_component(
         name="app", platform=xpfm, template="empty_application")
     ld = app.get_ld_script()


### PR DESCRIPTION
## Pull Request Description

Recycle the Vitis gRPC client between platform.build() and create_app_component(). The gRPC workspace cache does not register the new .xpfm until the client is disposed and reconnected.

This aligns create_project() with create_ide_workspace(), which already does dispose+reconnect between build phases.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
