### PR TITLE
ci: build_projects: add per-project build timeout

### DIFF
--- a/tools/scripts/build_projects.py
+++ b/tools/scripts/build_projects.py
@@ -68,6 +68,8 @@ def parse_input():
 		args.platform, args.build_name, args.builds_dir, args.hardware, args.hdl_branch)
 
 ERR = 0
+BUILD_TIMEOUT = 120
+XILINX_BUILD_TIMEOUT = 600
 LOG_START = " -> "
 TOKEN = os.environ.get('TOKEN')
 BRANCH = os.environ.get('BRANCH')
@@ -403,8 +405,20 @@ def build_cmake_project(noos, project, _platform, _build_name, export_dir,
 				os.path.abspath(build_dir_base), jobs, fresh_flag, hardware_arg))
 		log(build_cmd)
 		sys.stdout.flush()
-		err = os.system(build_cmd + ' > %s 2>&1' % os.devnull)
-		success = err == 0
+		timeout = XILINX_BUILD_TIMEOUT if platform == 'xilinx' else BUILD_TIMEOUT
+		try:
+			result = subprocess.run(
+				build_cmd, shell=True,
+				stdout=subprocess.DEVNULL,
+				stderr=subprocess.DEVNULL,
+				timeout=timeout,
+			)
+			success = result.returncode == 0
+		except subprocess.TimeoutExpired:
+			success = False
+			log_err("TIMEOUT")
+			log("Project configuration and compilation took more than %d s, "
+			    "please check the logs: %s" % (timeout, dst_log))
 
 		os.environ.clear()
 		os.environ.update(env)


### PR DESCRIPTION
 ## Summary
 - Adds a 600 s (10 min) timeout for Xilinx and 120 s for the rest of platforms, to each per-project `no_os_build.py` invocation in `build_projects.py`
 - When a project hangs (e.g. CubeMX version-mismatch popup on STM32), the build is killed and reported as `TIMEOUT` so remaining projects still build and the shared runner is released promptly

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [ ] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [ ] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [ ] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [ ] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
