### PR TITLE
drivers: accel: register ADXL345 in CMake and Kconfig

### DIFF
--- a/drivers/accel/CMakeLists.txt
+++ b/drivers/accel/CMakeLists.txt
@@ -2,6 +2,9 @@ no_os_sources_ifdef(CONFIG_ACCEL_ADXL313 ${CMAKE_CURRENT_SOURCE_DIR}/adxl313/adx
 no_os_sources_ifdef(CONFIG_ACCEL_IIO_ADXL313 ${CMAKE_CURRENT_SOURCE_DIR}/adxl313/iio_adxl313.c)
 target_include_directories(no-os PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/adxl313)
 
+no_os_sources_ifdef(CONFIG_ACCEL_ADXL345 ${CMAKE_CURRENT_SOURCE_DIR}/adxl345/adxl345.c)
+target_include_directories(no-os PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/adxl345)
+
 no_os_sources_ifdef(CONFIG_ACCEL_ADXL355 ${CMAKE_CURRENT_SOURCE_DIR}/adxl355/adxl355.c)
 no_os_sources_ifdef(CONFIG_ACCEL_IIO_ADXL355 ${CMAKE_CURRENT_SOURCE_DIR}/adxl355/iio_adxl355.c)
 no_os_sources_ifdef(CONFIG_ACCEL_IIO_ADXL355 ${CMAKE_CURRENT_SOURCE_DIR}/adxl355/iio_adxl355_trig.c)

--- a/drivers/accel/Kconfig
+++ b/drivers/accel/Kconfig
@@ -18,6 +18,11 @@ config ACCEL_IIO_ADXL313
     bool "Enable the ADXL313 IIO driver"
     default n
 
+config ACCEL_ADXL345
+    depends on SPI
+    bool "Enable the ADXL345 driver"
+    default n
+
 config ACCEL_ADXL355
     depends on SPI
     select GPIO


### PR DESCRIPTION
## Pull Request Description

The ADXL345 driver exists in the source tree but cannot be selected through the accelerometer Kconfig/CMake integration. Add `CONFIG_ACCEL_ADXL345`, compile `adxl345.c` when selected, and export its include directory.

This allows projects such as the MAX78000 IMU examples to select the driver through their configuration.

## Dependencies and review order

Layer 3 of the MAX78000 stack. This PR targets `dev/max78000-platform` and follows #3346. Its diff contains only this layer's changes.

| Layer | PR | Scope |
| --- | --- | --- |
| 1 | #3343 | CAPI coprocessor and IPC primitives |
| 2 | #3346 | MAX78000 platform backends and board support |
| 3 | #3344 | Shared ADXL345 configuration |
| 4 | #3345 | Arm/RISC-V coprocessor build support |
| 5 | #3347 | MAX78000FTHR example project |
| 6 (top) | #3218 | MAX78000EVKIT CAPI camera project |

The branches form a linear chain on `main`. #3218 is the top PR and the entry point for the complete stack. Use GitHub's stack controls to review and land the layers in order.

## Validation

- The branch Kconfig parsed successfully during branch preparation.
- The MAX78000 IMU configurations selected their variants successfully with the combined prerequisites present.
- Firmware builds and hardware tests have not been rerun for this draft.

## PR Type

- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist

- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [x] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc), if applies
