### PR TITLE
tools: xilinx: enable boot.bin generation

### DIFF
--- a/cmake/xilinx/xilinx_boot.cmake
+++ b/cmake/xilinx/xilinx_boot.cmake
@@ -1,0 +1,67 @@
+# Boot-image description for the Xilinx CMake flow.
+#
+# Everything needed to package an SD-card BOOT.BIN is already known to CMake at
+# configure time: the arch came out of the .xsa in the toolchain file, the
+# bitstream was unzipped by extract_xsa_members(), and the ELF and FSBL paths
+# are fixed by the build layout. write_xilinx_boot_info() writes those facts to
+# <build>/bootinfo.json so the packager
+# (tools/scripts/platform/xilinx/boot_bin.py) does not have to rediscover any of
+# them -- no CMakeCache.txt grepping, no second unzip of the .xsa.
+#
+# Paths are absolute and describe where each file will be, not where it is: the
+# ELF appears at build time and the FSBL only when the packager or the 'flash'
+# target generates it. The packager checks for itself.
+#
+# Schema (version 1):
+#   version    - integer, bumped on incompatible changes
+#   project    - CMake target name; the ELF and .bif are named after it
+#   arch       - HSI cell name from the .xsa (psu_cortexa53_0, ps7_cortexa9_0,
+#                sys_mb, ...). The packager maps this to bootgen's -arch and the
+#                BIF destination_cpu.
+#   xsa        - the hardware file this build was configured against
+#   elf        - the application ELF
+#   bitstream  - PL bitstream extracted from the .xsa ("" if it ships none)
+#   fsbl       - where create_fsbl puts the boot loader
+#   fsbl_ws    - workspace/hw_path pair util.py create_fsbl expects (ws, ws/tmp)
+#   output_dir - where the packager should leave BOOT.BIN
+
+function(write_xilinx_boot_info TARGET_NAME RUN_DIR HW_PATH ELF FSBL)
+    # create_fsbl reads the arch from <hw_path>/arch.txt and the .xsa from
+    # <hw_path>. The 'flash' target stages both when it runs; stage them here
+    # too so the packager can generate an FSBL without having flashed first.
+    # (The flash target's copy_if_different then becomes a no-op.)
+    file(WRITE "${HW_PATH}/arch.txt" "${XILINX_ARCH}\n")
+    file(COPY "${HARDWARE}" DESTINATION "${HW_PATH}")
+
+    # extract_xsa_members() has already unpacked these next to the .xsa copy.
+    file(GLOB _bit "${HW_PATH}/*.bit")
+    if(NOT _bit)
+        file(GLOB _bit "${HW_PATH}/*.pdi")
+    endif()
+    list(GET _bit 0 _bitstream)
+    if(NOT _bitstream)
+        set(_bitstream "")
+    endif()
+
+    # A backslash is an escape inside a JSON string, and -DHARDWARE=C:\... on
+    # Windows reaches us unnormalized. CMake itself accepts forward slashes on
+    # every host, and so do bootgen and the Vitis Python API.
+    foreach(_var HARDWARE ELF FSBL RUN_DIR _bitstream)
+        string(REPLACE "\\" "/" ${_var} "${${_var}}")
+    endforeach()
+
+    set(_info "${CMAKE_BINARY_DIR}/bootinfo.json")
+    string(JOIN "\n" _json
+        "{"
+        "  \"version\": 1,"
+        "  \"project\": \"${TARGET_NAME}\","
+        "  \"arch\": \"${XILINX_ARCH}\","
+        "  \"xsa\": \"${HARDWARE}\","
+        "  \"elf\": \"${ELF}\","
+        "  \"bitstream\": \"${_bitstream}\","
+        "  \"fsbl\": \"${FSBL}\","
+        "  \"fsbl_ws\": \"${RUN_DIR}\","
+        "  \"output_dir\": \"${CMAKE_BINARY_DIR}/boot\""
+        "}")
+    file(WRITE "${_info}" "${_json}\n")
+endfunction()

--- a/cmake/xilinx/xilinx_flash.cmake
+++ b/cmake/xilinx/xilinx_flash.cmake
@@ -15,14 +15,6 @@
 #   JTAG_CABLE_ID  - JTAG cable id to disambiguate multiple probes; default empty.
 
 function(add_xilinx_flash_target TARGET_NAME)
-    find_program(VITIS_EXECUTABLE vitis HINTS "$ENV{XILINX_VITIS}/bin")
-    if(NOT VITIS_EXECUTABLE)
-        message(STATUS
-            "vitis not found under $ENV{XILINX_VITIS}/bin; 'flash' target "
-            "will be unavailable. Source settings64.sh from your Vitis install.")
-        return()
-    endif()
-
     set(_util_py "${NO_OS_DIR}/tools/scripts/platform/xilinx/util.py")
     set(_elf "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${TARGET_NAME}.elf")
     get_filename_component(_xsa_file "${HARDWARE}" NAME)
@@ -44,6 +36,21 @@ function(add_xilinx_flash_target TARGET_NAME)
     # time). Best-effort per architecture; see extract_xsa_members().
     include(${NO_OS_DIR}/cmake/xilinx/xilinx_hw.cmake)
     extract_xsa_members("${HARDWARE}" "${_hw_path}")
+
+    # Publish what a boot-image packager needs (see xilinx_boot.cmake). Written
+    # before the vitis check below: the .json is a description of the build, and
+    # is just as valid on a host that cannot run the 'flash' target.
+    include(${NO_OS_DIR}/cmake/xilinx/xilinx_boot.cmake)
+    write_xilinx_boot_info("${TARGET_NAME}" "${_run_dir}" "${_hw_path}"
+                           "${_elf}" "${_fsbl}")
+
+    find_program(VITIS_EXECUTABLE vitis HINTS "$ENV{XILINX_VITIS}/bin")
+    if(NOT VITIS_EXECUTABLE)
+        message(STATUS
+            "vitis not found under $ENV{XILINX_VITIS}/bin; 'flash' target "
+            "will be unavailable. Source settings64.sh from your Vitis install.")
+        return()
+    endif()
 
     # Optional JTAG selectors (empty by default, like the legacy defaults).
     if(NOT DEFINED TARGET_CPU)

--- a/tools/scripts/no_os_build.py
+++ b/tools/scripts/no_os_build.py
@@ -514,7 +514,47 @@ def append_log(log_path, section, result):
         f.write("\n")
 
 
-def run_build(repo_root, combo, build_dir_base, jobs, clean, dry_run, probe=None, flash=False, fresh=False, hardware=None):
+def load_boot_bin_module(repo_root):
+    """Import tools/scripts/platform/xilinx/boot_bin.py by path.
+
+    Loaded on demand rather than at module import: it is only needed for
+    --boot-bin, and importing by path keeps 'platform' (which shadows a stdlib
+    module) off sys.path.
+    """
+    import importlib.util
+
+    path = repo_root / "tools" / "scripts" / "platform" / "xilinx" / "boot_bin.py"
+    spec = importlib.util.spec_from_file_location("no_os_boot_bin", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def boot_bin_cmd(repo_root, combo, build_dir):
+    """Equivalent standalone command, for --dry-run output."""
+    script = repo_root / "tools" / "scripts" / "platform" / "xilinx" / "boot_bin.py"
+    return [sys.executable, str(script), "--build-dir", str(build_dir)]
+
+
+def run_boot_bin(repo_root, combo, build_dir):
+    """Package one combination's build into a BOOT.BIN. Returns (ok, message).
+
+    Everything the packager needs is in <build_dir>/bootinfo.json, written by
+    the Xilinx CMake flow at configure time.
+    """
+    if combo["platform"] != "xilinx":
+        return True, (f"--boot-bin: skipped, {combo['platform']} is not a "
+                      "Xilinx platform")
+
+    boot_bin = load_boot_bin_module(repo_root)
+    try:
+        boot_bin.make_boot_bin(build_dir)
+    except boot_bin.BootBinError as e:
+        return False, f"BOOT.BIN failed: {e}"
+    return True, ""
+
+
+def run_build(repo_root, combo, build_dir_base, jobs, clean, dry_run, probe=None, flash=False, fresh=False, hardware=None, boot_bin=False):
     """Run cmake configure + build (and optionally flash) for a single combination.
 
     Returns (combo, success, detail). On failure, detail is the error message.
@@ -569,6 +609,8 @@ def run_build(repo_root, combo, build_dir_base, jobs, clean, dry_run, probe=None
     if dry_run:
         print(f"  {quote_cmd(configure_cmd)}")
         print(f"  {quote_cmd(build_cmd)}")
+        if boot_bin:
+            print(f"  {quote_cmd(boot_bin_cmd(repo_root, combo, build_dir))}")
         if flash:
             print(f"  {quote_cmd(flash_cmd)}")
         return combo, True, ""
@@ -608,6 +650,15 @@ def run_build(repo_root, combo, build_dir_base, jobs, clean, dry_run, probe=None
             append_log(log_path, "Build", e)
             spinner.finish("FAILED")
             return combo, False, f"Build failed:\n{e.stderr[-500:]}"
+
+    # Before flashing: a JTAG run and an SD-card image are independent, but the
+    # image is the artifact worth having even if the board is not connected.
+    if boot_bin:
+        ok, msg = run_boot_bin(repo_root, combo, build_dir)
+        if not ok:
+            return combo, False, msg
+        if msg:
+            print(f"  {msg}")
 
     if flash:
         echo_cmd(flash_cmd)
@@ -770,6 +821,9 @@ def cmd_build(args, repo_root, presets):
 
             if args.dry_run:
                 lines = f"  {quote_cmd(build_cmd)}"
+                if args.boot_bin:
+                    lines += ("\n  " + quote_cmd(
+                        boot_bin_cmd(repo_root, combo, build_dir)))
                 if args.flash:
                     lines += f"\n  {quote_cmd(flash_cmd)}"
                 return combo, True, lines
@@ -789,6 +843,13 @@ def cmd_build(args, repo_root, presets):
                 return combo, False, f"Build failed:\n{e.stderr[-500:]}"
 
             artifacts_msg = f"Build artifacts: {build_dir / 'build'}"
+
+            if args.boot_bin:
+                ok, msg = run_boot_bin(repo_root, combo, build_dir)
+                if not ok:
+                    return combo, False, msg
+                if msg:
+                    artifacts_msg += f"\n  {msg}"
 
             if args.flash:
                 echo_cmd(flash_cmd)
@@ -840,7 +901,7 @@ def cmd_build(args, repo_root, presets):
             combo_result, success, msg = run_build(
                 repo_root, combo, build_dir_base, args.jobs, args.clean, args.dry_run,
                 probe=args.probe, flash=args.flash, fresh=args.fresh,
-                hardware=args.hardware,
+                hardware=args.hardware, boot_bin=args.boot_bin,
             )
 
             if args.dry_run:
@@ -935,6 +996,13 @@ def main():
         "--flash",
         action="store_true",
         help="Flash the firmware after a successful build (requires --probe)",
+    )
+    build_parser.add_argument(
+        "--boot-bin",
+        action="store_true",
+        help="Xilinx only: package FSBL + bitstream + ELF into an SD-card "
+             "BOOT.BIN after a successful build (tools/scripts/platform/"
+             "xilinx/make_boot_bin.sh)",
     )
     build_parser.add_argument(
         "--open",

--- a/tools/scripts/platform/xilinx/boot_bin.py
+++ b/tools/scripts/platform/xilinx/boot_bin.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""
+Package a built no-OS Xilinx project into an SD-card BOOT.BIN.
+
+The CMake build only emits <project>.elf. A bootable image also needs the FSBL
+and the PL bitstream; this module collects the three and runs bootgen.
+
+Everything about the build comes from <build_dir>/bootinfo.json, which the
+Xilinx CMake flow writes at configure time (cmake/xilinx/xilinx_boot.cmake):
+the arch, the .xsa, the ELF, the already-extracted bitstream and the FSBL path.
+Nothing here re-derives what CMake has already resolved. The only work left is
+generating the FSBL (a Vitis platform build, minutes) and running bootgen.
+
+Importable from no_os_build.py:
+
+    import boot_bin
+    boot_bin.make_boot_bin(build_dir)
+
+or standalone:
+
+    tools/scripts/platform/xilinx/boot_bin.py --build-dir build/adate500-iio-zcu102
+"""
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+BOOT_INFO_NAME = "bootinfo.json"
+SUPPORTED_INFO_VERSION = 1
+
+# HSI cell name (bootinfo "arch") -> bootgen -arch, BIF destination_cpu.
+ARCH_MAP = {
+    "cortexa9": ("zynq", "a9-0"),
+    "cortexa53": ("zynqmp", "a53-0"),
+    "cortexr5": ("zynqmp", "r5-0"),
+}
+
+# Architectures that boot some other way, with the reason to report.
+UNSUPPORTED_ARCH = {
+    "cortexa72": "Versal boots from a PDI built by Vivado, not from an FSBL BIF",
+    "sys_mb": "MicroBlaze has no BOOT.BIN; program the bitstream+ELF as an .mcs",
+    "microblaze": "MicroBlaze has no BOOT.BIN; program the bitstream+ELF as an .mcs",
+}
+
+
+class BootBinError(Exception):
+    """Anything that stops a BOOT.BIN from being produced."""
+
+
+def _vitis_tool(name):
+    """Absolute path to a Vitis tool, honouring PATH then XILINX_VITIS."""
+    found = shutil.which(name)
+    if found:
+        return found
+    root = os.environ.get("XILINX_VITIS")
+    if not root:
+        raise BootBinError(
+            f"{name} not found and XILINX_VITIS is not set; source settings64.sh "
+            "from your Vitis install")
+    # Vitis ships .bat wrappers on Windows; the extensionless names there are
+    # bash scripts that CreateProcess cannot run.
+    names = [name + ".bat", name + ".exe", name] if os.name == "nt" else [name]
+    for candidate in names:
+        path = Path(root) / "bin" / candidate
+        if path.is_file():
+            return str(path)
+    raise BootBinError(f"{name} not found under {root}/bin")
+
+
+def load_boot_info(build_dir):
+    """Read and validate <build_dir>/bootinfo.json."""
+    path = Path(build_dir) / BOOT_INFO_NAME
+    if not path.is_file():
+        raise BootBinError(
+            f"{path} not found. It is written when a Xilinx project is "
+            "configured; configure the build first.")
+    try:
+        info = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        raise BootBinError(f"{path} is not valid JSON: {e}") from e
+
+    version = info.get("version")
+    if version != SUPPORTED_INFO_VERSION:
+        raise BootBinError(
+            f"{path} has schema version {version}, expected "
+            f"{SUPPORTED_INFO_VERSION}; reconfigure the build.")
+    return info
+
+
+def resolve_arch(arch):
+    """Map an HSI cell name to (bootgen -arch, BIF destination_cpu)."""
+    for key, reason in UNSUPPORTED_ARCH.items():
+        if key in arch:
+            raise BootBinError(f"{arch}: {reason}")
+    for key, mapping in ARCH_MAP.items():
+        if key in arch:
+            return mapping
+    raise BootBinError(f"unsupported architecture: {arch}")
+
+
+def generate_fsbl(info, quiet=False):
+    """Build the FSBL if it is not already there. Returns its path.
+
+    create_fsbl builds a throwaway Vitis platform component just for the boot
+    loader, which takes minutes. It writes into the same workspace the 'flash'
+    target uses, so the two share one FSBL.
+    """
+    fsbl = Path(info["fsbl"])
+    if fsbl.is_file():
+        return fsbl
+
+    if not quiet:
+        print("==> Generating FSBL (this takes a few minutes)", flush=True)
+    ws = Path(info["fsbl_ws"])
+    hw_path = ws / "tmp"
+    # CMake staged arch.txt and the .xsa copy here at configure time.
+    cmd = [
+        _vitis_tool("vitis"), "-s", str(SCRIPT_DIR / "util.py"), "create_fsbl",
+        str(ws), str(hw_path), Path(info["xsa"]).name,
+        info["elf"], "0", "Empty Application(C)",
+    ]
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as e:
+        raise BootBinError(f"create_fsbl failed (exit code {e.returncode})") from e
+
+    if not fsbl.is_file():
+        raise BootBinError(f"create_fsbl reported success but {fsbl} is missing")
+    return fsbl
+
+
+def write_bif(path, fsbl, bitstream, elf, dest_cpu, pmufw=None):
+    """Write the bootgen image description. Returns the .bif path."""
+    lines = ["the_ROM_image:", "{"]
+    if pmufw:
+        lines.append(f"    [pmufw_image] {pmufw}")
+    lines.append(f"    [bootloader, destination_cpu={dest_cpu}] {fsbl}")
+    if bitstream:
+        lines.append(f"    [destination_device=pl] {bitstream}")
+    lines.append(f"    [destination_cpu={dest_cpu}] {elf}")
+    lines.append("}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
+def make_boot_bin(build_dir, output=None, pmufw=None, bitstream=None, quiet=False):
+    """Package the build in `build_dir` into a BOOT.BIN. Returns its path.
+
+    Raises BootBinError with an actionable message on any failure.
+    """
+    build_dir = Path(build_dir)
+    info = load_boot_info(build_dir)
+    boot_arch, dest_cpu = resolve_arch(info["arch"])
+    if not quiet:
+        print(f"==> {info['arch']} -> bootgen -arch {boot_arch}, "
+              f"destination_cpu={dest_cpu}", flush=True)
+
+    elf = Path(info["elf"])
+    if not elf.is_file():
+        raise BootBinError(f"application ELF not found: {elf} (build it first)")
+
+    bitstream = Path(bitstream) if bitstream else (
+        Path(info["bitstream"]) if info.get("bitstream") else None)
+    if bitstream and not bitstream.is_file():
+        raise BootBinError(f"bitstream not found: {bitstream}")
+    if not bitstream and not quiet:
+        # A PL-less design is legal; a missing .bit in a design that needs one
+        # produces an image that boots and then hangs on the first PL access.
+        print("==> No bitstream in the .xsa; packaging PS-only", flush=True)
+
+    fsbl = generate_fsbl(info, quiet=quiet)
+    if pmufw:
+        pmufw = Path(pmufw)
+        if not pmufw.is_file():
+            raise BootBinError(f"pmufw not found: {pmufw}")
+
+    out_dir = Path(output).parent if output else Path(info["output_dir"])
+    out = Path(output) if output else out_dir / "BOOT.BIN"
+    bif = write_bif(out_dir / f"{info['project']}.bif",
+                    fsbl, bitstream, elf, dest_cpu, pmufw)
+
+    if not quiet:
+        print("==> Running bootgen", flush=True)
+    cmd = [_vitis_tool("bootgen"), "-arch", boot_arch,
+           "-image", str(bif), "-o", str(out), "-w"]
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as e:
+        raise BootBinError(f"bootgen failed (exit code {e.returncode})") from e
+    # bootgen drops a profiling report in the working directory; not an artifact.
+    Path("dfx_runtime.txt").unlink(missing_ok=True)
+
+    if not quiet:
+        print(f"\nBOOT.BIN  {out}")
+        print(f"  fsbl      {fsbl}")
+        print(f"  bitstream {bitstream or '(none)'}")
+        print(f"  app       {elf}")
+        if pmufw:
+            print(f"  pmufw     {pmufw}")
+        print("\nCopy it to the FAT32 SD card root, set the board to SD boot "
+              "mode, power-cycle.")
+    return out
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__.strip().split("\n")[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "--build-dir", required=True,
+        help=f"Configured build directory (the one holding {BOOT_INFO_NAME})")
+    parser.add_argument("-o", "--output", help="Output image (default: <build>/boot/BOOT.BIN)")
+    parser.add_argument(
+        "--bitstream", help="Use this .bit instead of the one named in bootinfo.json")
+    parser.add_argument(
+        "--pmufw",
+        help="PMU firmware to embed (ZynqMP). Not included by default; the "
+             "platform export leaves one in .../export/hw0/sw/qemu/")
+    args = parser.parse_args()
+
+    try:
+        make_boot_bin(args.build_dir, output=args.output, pmufw=args.pmufw,
+                      bitstream=args.bitstream)
+    except BootBinError as e:
+        sys.exit(f"error: {e}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
During SD card booting, boot.bin is possible to be created from the cilinc projec using the added python scripts

During Xilinx platform builds, allow user to generate boot.bin by adding the fllag '--boot-bin' to the python build command

## PR Type
- [ ] Bug fix (change that fixes an issue)
- [x] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have followed the [Coding style guidelines](http://analogdevicesinc.github.io/no-OS/drivers_guide.html#coding-style)
- [x] I have complied with the [Submission Checklist](http://analogdevicesinc.github.io/no-OS/contributing.html#submission-checklist)
- [x] I have performed a self-review of the changes
- [x] I have commented my code, at least hard-to-understand parts
- [x] I have build all projects affected by the changes in this PR
- [ ] I have tested in hardware affected projects, at the relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc), if applies
